### PR TITLE
Special treatment of emptyValDef in reify

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/LiftCode.scala
+++ b/src/compiler/scala/tools/nsc/transform/LiftCode.scala
@@ -476,6 +476,8 @@ abstract class LiftCode extends Transform with TypingTransformers {
         if (!(boundSyms exists (tt.tpe contains _))) mirrorCall("TypeTree", reifyType(tt.tpe))
         else if (tt.original != null) reify(tt.original)
         else TypeTree()
+      case global.emptyValDef =>
+        mirrorSelect("emptyValDef")
       case _ =>
         if (tree.isDef)
           boundSyms += tree.symbol

--- a/src/library/scala/reflect/api/Trees.scala
+++ b/src/library/scala/reflect/api/Trees.scala
@@ -624,6 +624,8 @@ trait Trees /*extends reflect.generic.Trees*/ { self: Universe =>
   }
 
   def TypeTree(tp: Type): TypeTree = TypeTree() setType tp
+  
+  def emptyValDef: ValDef
 
   // ------ traversers, copiers, and transformers ---------------------------------------------
 


### PR DESCRIPTION
emptyValDef has special meaning in the compiler, so reify needs to preserve it by identity and not just by structure. Review by @xeno-by
