### PR TITLE
reifyTree shouldn't emit plain TypeTree()'s, but rather their reified versions

### DIFF
--- a/src/compiler/scala/reflect/internal/Importers.scala
+++ b/src/compiler/scala/reflect/internal/Importers.scala
@@ -231,6 +231,8 @@ trait Importers { self: SymbolTable =>
           new PackageDef(importRefTree(pid), stats map importTree)
         case from.ModuleDef(mods, name, impl) =>
           new ModuleDef(importModifiers(mods), importName(name).toTermName, importTemplate(impl))
+        case from.emptyValDef =>
+          emptyValDef
         case from.ValDef(mods, name, tpt, rhs) =>
           new ValDef(importModifiers(mods), importName(name).toTermName, importTree(tpt), importTree(rhs))
         case from.DefDef(mods, name, tparams, vparamss, tpt, rhs) =>

--- a/src/compiler/scala/reflect/internal/Types.scala
+++ b/src/compiler/scala/reflect/internal/Types.scala
@@ -4177,8 +4177,9 @@ A type's typeSymbol should never be inspected directly.
       if (phase.flatClasses) {
         sym
       } else if (sym.isModuleClass) {
-        val result = adaptToNewRun(pre, sym.sourceModule).moduleClass
-        assert(result != NoSymbol, sym+" "+sym.sourceModule)
+        val sourceModule1 = adaptToNewRun(pre, sym.sourceModule)
+        val result = sourceModule1.moduleClass
+        assert(result != NoSymbol, sym+" "+sym.sourceModule+" "+sourceModule1)
         result
       } else if ((pre eq NoPrefix) || (pre eq NoType) || sym.isPackageClass) {
         sym

--- a/src/compiler/scala/reflect/internal/Types.scala
+++ b/src/compiler/scala/reflect/internal/Types.scala
@@ -4175,7 +4175,9 @@ A type's typeSymbol should never be inspected directly.
       if (phase.flatClasses) {
         sym
       } else if (sym.isModuleClass) {
-        adaptToNewRun(pre, sym.sourceModule).moduleClass
+        val result = adaptToNewRun(pre, sym.sourceModule).moduleClass
+        assert(result != NoSymbol, sym+" "+sym.sourceModule)
+        result
       } else if ((pre eq NoPrefix) || (pre eq NoType) || sym.isPackageClass) {
         sym
       } else {

--- a/src/compiler/scala/reflect/internal/Types.scala
+++ b/src/compiler/scala/reflect/internal/Types.scala
@@ -1163,7 +1163,9 @@ trait Types extends api.Types { self: SymbolTable =>
   /** A class for this-types of the form <sym>.this.type
    */
   abstract case class ThisType(sym: Symbol) extends SingletonType {
-    assert(sym.isClass)
+    if (!sym.isClass) {
+      assert(sym.isClass, sym.getClass)
+    }
     //assert(sym.isClass && !sym.isModuleClass || sym.isRoot, sym)
     override def isTrivial: Boolean = sym.isPackageClass
     override def isNotNull = true

--- a/src/compiler/scala/reflect/internal/Types.scala
+++ b/src/compiler/scala/reflect/internal/Types.scala
@@ -1731,6 +1731,9 @@ trait Types extends api.Types { self: SymbolTable =>
 //    assert(!(sym hasFlag (PARAM | EXISTENTIAL)) || pre == NoPrefix, this)
 //    assert(args.isEmpty || !sym.info.typeParams.isEmpty, this)
 //    assert(args.isEmpty || ((sym ne AnyClass) && (sym ne NothingClass))
+    if (sym.name.toString == "C" && pre.typeSymbol.isRoot) {
+      assert(false)
+    }
 
     private var parentsCache: List[Type] = _
     private var parentsPeriod = NoPeriod
@@ -4176,10 +4179,22 @@ A type's typeSymbol should never be inspected directly.
     private def adaptToNewRun(pre: Type, sym: Symbol): Symbol = {
       if (phase.flatClasses) {
         sym
+      } else if (sym == definitions.RootClass) {
+        definitions.RootClass
+      } else if (sym == definitions.RootPackage) {
+        definitions.RootPackage
       } else if (sym.isModuleClass) {
+        if (sym.sourceModule.moduleClass == NoSymbol) {
+          val rootClass = definitions.RootClass
+          val rootPackage = definitions.RootPackage
+          println(rootPackage.moduleClass)
+          println("going to blow up!")
+        }
+        
         val sourceModule1 = adaptToNewRun(pre, sym.sourceModule)
         val result = sourceModule1.moduleClass
-        assert(result != NoSymbol, sym+" "+sym.sourceModule+" "+sourceModule1)
+        assert(result != NoSymbol, "sym = %s, sourceModule = %s, sourceModule.moduleClass = %s =====> sourceModule1 = %s, sourceModule1.moduleClass = %s".format( 
+            sym, sym.sourceModule, sym.sourceModule.moduleClass, sourceModule1, sourceModule1.moduleClass))
         result
       } else if ((pre eq NoPrefix) || (pre eq NoType) || sym.isPackageClass) {
         sym

--- a/src/compiler/scala/tools/nsc/transform/LiftCode.scala
+++ b/src/compiler/scala/tools/nsc/transform/LiftCode.scala
@@ -475,7 +475,7 @@ abstract class LiftCode extends Transform with TypingTransformers {
       case tt: TypeTree if (tt.tpe != null) =>
         if (!(boundSyms exists (tt.tpe contains _))) mirrorCall("TypeTree", reifyType(tt.tpe))
         else if (tt.original != null) reify(tt.original)
-        else TypeTree()
+        else mirrorCall("TypeTree")
       case global.emptyValDef =>
         mirrorSelect("emptyValDef")
       case _ =>

--- a/test/pending/run/t5230.scala
+++ b/test/pending/run/t5230.scala
@@ -11,7 +11,11 @@ object Test extends App {
     println(new C().x)
   };
 
-  val reporter = new ConsoleReporter(new Settings)
+  val settings = new Settings
+  settings.Yreifydebug.value = true
+  settings.debug.value = true
+
+  val reporter = new ConsoleReporter(settings)
   val toolbox = new ToolBox(reporter)
   val ttree = toolbox.typeCheck(code.tree)
   val evaluated = toolbox.runExpr(ttree)

--- a/test/pending/run/t5230.scala
+++ b/test/pending/run/t5230.scala
@@ -14,6 +14,7 @@ object Test extends App {
   val settings = new Settings
   settings.Yreifydebug.value = true
   settings.debug.value = true
+  settings.nospecialization.value = true
 
   val reporter = new ConsoleReporter(settings)
   val toolbox = new ToolBox(reporter)

--- a/test/pending/run/t5230_nolift.scala
+++ b/test/pending/run/t5230_nolift.scala
@@ -1,0 +1,9 @@
+object Test extends App {
+  {
+    class C {
+      val x = 2
+    }
+
+    println(new C().x)
+  };
+}


### PR DESCRIPTION
Related to SI-5230, review by @odersky.
