### PR TITLE
Makes it possible to use env(1) to run scala scripts, 

### DIFF
--- a/src/compiler/scala/tools/nsc/util/SourceFile.scala
+++ b/src/compiler/scala/tools/nsc/util/SourceFile.scala
@@ -72,7 +72,7 @@ object ScriptSourceFile {
    *  with "!#" or "::!#".
    */
   def headerLength(cs: Array[Char]): Int = {
-    val headerPattern = Pattern.compile("""^(::)?!#.*(\r|\n|\r\n)""", Pattern.MULTILINE)
+    val headerPattern = Pattern.compile("""((?m)^(::)?!#.*|^.*/env .*)(\r|\n|\r\n)""")
     val headerStarts  = List("#!", "::#!")
 
     if (headerStarts exists (cs startsWith _)) {


### PR DESCRIPTION
by dropping the requirement of a !# line when using env. This is how some other
languages, such as ruby, are run.

Typical usage:

```
#!/usr/bin/env scala
println("Hello, "+args(0)+"!")
```

Contributed by: Daniel C. Sobral
