### PR TITLE
Added better warning message if you've forgotten to run pull-binary-libs...

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -202,6 +202,8 @@ INITIALISATION
 ============================================================================ -->
 
   <target name="init">
+    <available file="${lib.dir}/scala-library.jar" property="starr.present"/>
+    <fail unless="starr.present" message="Could not find STARR.  Have your run the pull-binary-libs.sh script?"/>
   <!-- scalac.args.optimise is selectively overridden in certain antcall tasks. -->
     <property name="scalac.args.optimise" value=""/>
   <!-- scalac.args.quickonly are added to quick.* targets but not others (particularly, locker.)


### PR DESCRIPTION
Fixes the issue where someone checks out the scala repository fresh and ANT just issues a big old ugly error message rather than _telling_ you that you have to run the pull-binary-deps.sh script.

Review by @soundrabbit or @paulp
