### PR TITLE
Test for SI-3556.

### DIFF
--- a/test/files/neg/t3556.check
+++ b/test/files/neg/t3556.check
@@ -1,0 +1,4 @@
+t3556.scala:13: error: covariant type CaseDef occurs in contravariant position in type Collects.this.PMat[U] of value pmat
+    def doMatch[U](x: C)(pmat: PMat[U]): U
+                         ^
+one error found

--- a/test/files/neg/t3556.scala
+++ b/test/files/neg/t3556.scala
@@ -1,0 +1,40 @@
+object t3556 {
+  trait CollectsCases[C, El, +U, +V] {
+    def caseDef(xs: C): U
+    def caseSeq(xs: Seq[El]): V
+  }
+
+  trait Id {
+    type Apply[U] = U
+  }
+
+  trait Collects[C, El, +CaseDef[T], +CaseSel[T]] {
+    type PMat[U] = CollectsCases[C, El, CaseDef[U], CaseSel[U]]
+    def doMatch[U](x: C)(pmat: PMat[U]): U
+  }
+
+  class CollectsDefault {
+    implicit def collectsDef[T] = new Collects[T, T, Id#Apply, Any] {
+      def doMatch[U](x: T)(pmat: PMat[U]) = pmat.caseDef(x)
+    }
+  }
+
+  object Collects extends CollectsDefault {
+    implicit def collectsSeq[C <: Seq[_], T](implicit ev: C <:< Seq[T]) = new Collects[C, T, Any, Id#Apply] {
+      def doMatch[U](x: C)(pmat: PMat[U]) = pmat.caseSeq(x)
+    }
+  }
+
+  object Test extends App {
+    def frob[C, T](xs: C)(implicit ev: Collects[C, T, Any, Any]) /*BUG: Nothing is inferred */ = {
+      val pmat = new CollectsCases[C, T, C, T]{
+        def caseDef(xs: C) = xs
+        def caseSeq(xs: Seq[T]) = xs.head
+      }
+      ev.doMatch(xs)(pmat)
+    }
+    println(frob(List(1, 2)))
+    println(frob("not a List(1, 2)"))
+  }
+}
+


### PR DESCRIPTION
Not sure if this is completely fixed, because the compiler complains much earlier,
but I guess it cannot hurt to have it in place and recognize it early when this
starts moving again.
