### PR TITLE
Add filter/withFilter method to Parser

### DIFF
--- a/test/files/run/parserFilter.check
+++ b/test/files/run/parserFilter.check
@@ -1,0 +1,9 @@
+[1.3] failure: Input doesn't match filter: false
+
+if false
+  ^
+[1.1] failure: Input doesn't match filter: not
+
+not true
+^
+[1.8] parsed: (if~true)

--- a/test/files/run/parserFilter.scala
+++ b/test/files/run/parserFilter.scala
@@ -1,0 +1,15 @@
+object Test extends scala.util.parsing.combinator.RegexParsers {
+    val keywords = Set("if", "false")
+    def word: Parser[String] = "\\w+".r
+
+    def keyword: Parser[String] = word filter (keywords.contains)
+    def ident: Parser[String] = word filter(!keywords.contains(_))
+
+    def test = keyword ~ ident
+
+    def main(args: Array[String]) {
+      println(parseAll(test, "if false"))
+      println(parseAll(test, "not true"))
+      println(parseAll(test, "if true"))
+    }
+}

--- a/test/files/run/parserForFilter.check
+++ b/test/files/run/parserForFilter.check
@@ -1,0 +1,1 @@
+[1.13] parsed: (second,first)

--- a/test/files/run/parserForFilter.scala
+++ b/test/files/run/parserForFilter.scala
@@ -1,0 +1,12 @@
+object Test extends scala.util.parsing.combinator.RegexParsers {
+  def word: Parser[String] = "\\w+".r
+
+  def twoWords = for {
+    (a ~ b) <- word ~ word
+  } yield (b, a)
+
+  def main(args: Array[String]) {
+    println(parseAll(twoWords, "first second"))
+  }
+}
+


### PR DESCRIPTION
Complements map and flatMap in for comprehensions. This is required when pattern matching is used on the
result of the generators.

It is implemented through a new filterWithError method on ParseResult.

Contributed by: Daniel C. Sobral
