### PR TITLE
Delegate to Java's implementation of signum for Long and Int.

### DIFF
--- a/src/library/scala/math/package.scala
+++ b/src/library/scala/math/package.scala
@@ -127,15 +127,9 @@ package object math {
     else if (x > 0) 1.0f
     else x    // NaN
 
-  def signum(x: Long): Long =
-    if (x == 0l) 0l
-    else if (x < 0) -1l
-    else 1l
+  def signum(x: Long): Long = java.lang.Long.signum(x)
 
-  def signum(x: Int): Int =
-    if (x == 0) 0
-    else if (x < 0) -1
-    else 1
+  def signum(x: Int): Int = java.lang.Integer.signum(x)
 
   // -----------------------------------------------------------------------
   // root functions

--- a/test/files/jvm/signum.scala
+++ b/test/files/jvm/signum.scala
@@ -1,0 +1,15 @@
+object Test {
+  def main(args: Array[String]) {
+    assert(math.signum(Long.MaxValue) == 1L)
+    assert(math.signum(1L) == 1L)
+    assert(math.signum(0L) == 0L)
+    assert(math.signum(-1L) == -1L)
+    assert(math.signum(Long.MinValue) == -1L)
+
+    assert(math.signum(Int.MaxValue) == 1)
+    assert(math.signum(1) == 1)
+    assert(math.signum(0) == 0)
+    assert(math.signum(-1) == -1)
+    assert(math.signum(Int.MinValue) == -1)
+  }
+}


### PR DESCRIPTION
The Java implementation is faster as it doesn't have branches.

java.lang.Math includes implementations of signum for Double and Float,
but I didn't change the ones in scala.math because there is a difference
on how negative zero is handled.
