### PR TITLE
Add a link to collections API overview into the scaladoc of collection classes

### DIFF
--- a/src/library/scala/collection/immutable/BitSet.scala
+++ b/src/library/scala/collection/immutable/BitSet.scala
@@ -17,6 +17,9 @@ import mutable.{ Builder, SetBuilder }
 
 /** A class for immutable bitsets.
  *  $bitsetinfo
+ *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_21.html "The Scala 2.8 Collections API"]]
+ *  section on `Immutable BitSets` for more information.
+ *
  *  @define Coll immutable.BitSet
  *  @define coll immutable bitset
  */

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -25,6 +25,8 @@ import parallel.immutable.ParHashMap
  *  @author  Tiark Rompf
  *  @version 2.8
  *  @since   2.3
+ *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_19.html "The Scala 2.8 Collections API"]]
+ *  section on `Hash Tries` for more information.
  *  @define Coll immutable.HashMap
  *  @define coll immutable hash map
  *  @define mayNotTerminateInf

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -57,6 +57,9 @@ import annotation.tailrec
  *  @author  Martin Odersky and others
  *  @version 2.8
  *  @since   1.0
+ *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_13.html "The Scala 2..8 Collections API"]]
+ *  section on `Lists` for more information.
+
  *
  *  @tparam  A    the type of the list's elements
  *

--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -16,6 +16,9 @@ import annotation.{tailrec, bridge}
 
 /** $factoryInfo
  *  @since 1
+ *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_22.html "The Scala 2.8 Collections API"]]
+ *  section on `List Maps` for more information.
+ *
  *  @define Coll immutable.ListMap
  *  @define coll immutable list map
  */

--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -27,6 +27,9 @@ import annotation.tailrec
  *  @author  Erik Stenman
  *  @version 1.0, 08/07/2003
  *  @since   1
+ *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_17.html "The Scala 2.8 Collections API"]]
+ *  section on `Ummutable Queues` for more information.
+ *
  *  @define Coll immutable.Queue
  *  @define coll immutable queue
  *  @define mayNotTerminateInf

--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -31,6 +31,9 @@ import annotation.bridge
  *  @author Paul Phillips
  *  @version 2.8
  *  @since   2.5
+ *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_18.html "The Scala 2.8 Collections API"]]
+ *  section on `Ranges` for more information.
+ *
  *  @define Coll Range
  *  @define coll range
  *  @define mayNotTerminateInf

--- a/src/library/scala/collection/immutable/Stack.scala
+++ b/src/library/scala/collection/immutable/Stack.scala
@@ -34,6 +34,9 @@ object Stack extends SeqFactory[Stack] {
  *  @author  Matthias Zenger
  *  @version 1.0, 10/07/2003
  *  @since   1
+ *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_16.html "The Scala 2.8 Collections API"]]
+ *  section on `Immutable stacks` for more information.
+ *
  *  @define Coll immutable.Stack
  *  @define coll immutable stack
  *  @define orderDependent

--- a/src/library/scala/collection/immutable/Stream.scala
+++ b/src/library/scala/collection/immutable/Stream.scala
@@ -172,6 +172,9 @@ import Stream.cons
  *  @author Martin Odersky, Matthias Zenger
  *  @version 1.1 08/08/03
  *  @since   2.8
+ *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_14.html "The Scala 2.8 Collections API"]]
+  *  section on `Streams` for more information.
+
  *  @define naturalsEx def naturalsFrom(i: Int): Stream[Int] = i #:: naturalsFrom(i + 1)
  *  @define Coll Stream
  *  @define coll stream

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -36,6 +36,9 @@ object TreeMap extends ImmutableSortedMapFactory[TreeMap] {
  *  @author  Matthias Zenger
  *  @version 1.1, 03/05/2004
  *  @since   1
+ *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_20.html "The Scala 2.8 Collections API"]]
+ *  section on `Red-Black Trees` for more information.
+ *
  *  @define Coll immutable.TreeMap
  *  @define coll immutable tree map
  *  @define orderDependent

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -36,6 +36,9 @@ object TreeSet extends ImmutableSortedSetFactory[TreeSet] {
  *  @author  Martin Odersky
  *  @version 2.0, 02/01/2007
  *  @since   1
+ *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_20.html "The Scala 2.8 Collections API"]]
+ *  section on `Red-Black Trees` for more information.
+ *
  *  @define Coll immutable.TreeSet
  *  @define coll immutable tree set
  *  @define orderDependent

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -35,6 +35,9 @@ object Vector extends SeqFactory[Vector] {
  *  endian bit-mapped vector trie with a branching factor of 32.  Locality is very good, but not
  *  contiguous, which is good for very large sequences.
  *
+ *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_15.html "The Scala 2.8 Collections API"]]
+ *  section on `Vectors` for more information.
+ *
  *  @tparam A the element type
  *
  *  @define Coll Vector

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -23,6 +23,9 @@ import parallel.mutable.ParArray
  *  @author  Martin Odersky
  *  @version 2.8
  *  @since   1
+ *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_38.html "The Scala 2.8 Collections API"]]
+ *  section on `Concrete Mutable Collection Classes` for more information.
+
  *
  *  @tparam A    the type of this arraybuffer's elements.
  *

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -21,6 +21,8 @@ import parallel.mutable.ParArray
  *  @author Martin Odersky
  *  @version 2.8
  *  @since   2.8
+ *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_31.html "The Scala 2.8 Collections API"]]
+ *  section on `Array Sequences` for more information.
  *
  *  @tparam A      type of the elements contained in this array sequence.
  *  @param length  the length of the underlying array.

--- a/src/library/scala/collection/mutable/ArrayStack.scala
+++ b/src/library/scala/collection/mutable/ArrayStack.scala
@@ -46,6 +46,8 @@ object ArrayStack extends SeqFactory[ArrayStack] {
  *
  *  @author David MacIver
  *  @since  2.7
+ *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_33.html "The Scala 2.8 Collections API"]]
+ *  section on `Array Stacks` for more information.
  *
  *  @tparam T    type of the elements contained in this array stack.
  *

--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -18,6 +18,9 @@ import BitSetLike.{LogWL, updateArray}
  *
  *  $bitsetinfo
  *
+ *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_37.html "The Scala 2.8 Collections API"]]
+ *  section on `Mutable Bitsets` for more information.
+ *
  *  @define Coll BitSet
  *  @define coll bitset
  *  @define thatinfo the class of the returned collection. In the standard library configuration,

--- a/src/library/scala/collection/mutable/ConcurrentMap.scala
+++ b/src/library/scala/collection/mutable/ConcurrentMap.scala
@@ -14,6 +14,8 @@ package mutable
  *  $concurrentmapinfo
  *
  *  @since 2.8
+ *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_36.html "The Scala 2.8 Collections API"]]
+ *  section on `Concurrent Maps` for more information.
  *
  *  @tparam A  the key type of the map
  *  @tparam B  the value type of the map

--- a/src/library/scala/collection/mutable/DoubleLinkedList.scala
+++ b/src/library/scala/collection/mutable/DoubleLinkedList.scala
@@ -20,6 +20,9 @@ import generic._
  *  @author Martin Odersky
  *  @version 2.8
  *  @since   1
+ *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_28.html "The Scala 2.8 Collections API"]]
+ *  section on `Double Linked Lists` for more information.
+
  *
  *  @tparam A     the type of the elements contained in this double linked list.
  *

--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -15,6 +15,8 @@ import scala.collection.parallel.mutable.ParHashMap
 /** This class implements mutable maps using a hashtable.
  *
  *  @since 1
+ *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_34.html "The Scala 2.8 Collections API"]]
+ *  section on `Hash Tables` for more information.
  *
  *  @tparam A    the type of the keys contained in this hash map.
  *  @tparam B    the type of the values assigned to keys in this hash map.

--- a/src/library/scala/collection/mutable/HashSet.scala
+++ b/src/library/scala/collection/mutable/HashSet.scala
@@ -22,6 +22,8 @@ import collection.parallel.mutable.ParHashSet
  *  @author  Martin Odersky
  *  @version 2.0, 31/12/2006
  *  @since   1
+ *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_34.html "The Scala 2.8 Collections API"]]
+ *  section on `Hash Tables` for more information.
  *
  *  @define Coll mutable.HashSet
  *  @define coll mutable hash set

--- a/src/library/scala/collection/mutable/LinearSeq.scala
+++ b/src/library/scala/collection/mutable/LinearSeq.scala
@@ -19,6 +19,8 @@ import generic._
  *
  *  @define Coll LinearSeq
  *  @define coll linear sequence
+ *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_29.html "The Scala 2.8 Collections API"]]
+  *  section on `Mutable Lists` for more information.
  */
 trait LinearSeq[A] extends Seq[A]
                            with scala.collection.LinearSeq[A]

--- a/src/library/scala/collection/mutable/LinkedList.scala
+++ b/src/library/scala/collection/mutable/LinkedList.scala
@@ -33,6 +33,8 @@ import generic._
   *  @author Martin Odersky
   *  @version 2.8
   *  @since   1
+  *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_27.html "The Scala 2.8 Collections API"]]
+  *  section on `Linked Lists` for more information.
   *
   *  @tparam A     the type of the elements contained in this linked list.
   *

--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -21,6 +21,8 @@ import immutable.{List, Nil, ::}
  *  @author  Martin Odersky
  *  @version 2.8
  *  @since   1
+ *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_25.html "The Scala 2.8 Collections API"]]
+ *  section on `List Buffers` for more information.
  *
  *  @tparam A    the type of this list buffer's elements.
  *

--- a/src/library/scala/collection/mutable/MutableList.scala
+++ b/src/library/scala/collection/mutable/MutableList.scala
@@ -23,6 +23,8 @@ import immutable.{List, Nil}
  *  @author  Martin Odersky
  *  @version 2.8
  *  @since   1
+ *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_29.html "The Scala 2.8 Collections API"]]
+ *  section on `Mutable Lists` for more information.
  */
 @SerialVersionUID(5938451523372603072L)
 class MutableList[A]

--- a/src/library/scala/collection/mutable/Queue.scala
+++ b/src/library/scala/collection/mutable/Queue.scala
@@ -20,6 +20,8 @@ import generic._
  *  @author  Martin Odersky
  *  @version 2.8
  *  @since   1
+ *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_30.html "The Scala 2.8 Collections API"]]
+ *  section on `Queues` for more information.
  *
  *  @define Coll mutable.Queue
  *  @define coll mutable queue

--- a/src/library/scala/collection/mutable/Stack.scala
+++ b/src/library/scala/collection/mutable/Stack.scala
@@ -44,6 +44,8 @@ object Stack extends SeqFactory[Stack] {
  *  @author  Martin Odersky
  *  @version 2.8
  *  @since   1
+ *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_32.html "The Scala 2.8 Collections API"]]
+ *  section on `Array Sequences` for more information.
  *  @define Coll Stack
  *  @define coll stack
  *  @define orderDependent

--- a/src/library/scala/collection/mutable/StringBuilder.scala
+++ b/src/library/scala/collection/mutable/StringBuilder.scala
@@ -21,6 +21,8 @@ import immutable.StringLike
  *  @author Martin Odersky
  *  @version 2.8
  *  @since   2.7
+ *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_26.html "The Scala 2.8 Collections API"]]
+ *  section on `StringBuilders` for more information.
  */
 @SerialVersionUID(0 - 8525408645367278351L)
 final class StringBuilder(private val underlying: JavaStringBuilder)

--- a/src/library/scala/collection/mutable/WeakHashMap.scala
+++ b/src/library/scala/collection/mutable/WeakHashMap.scala
@@ -23,6 +23,9 @@ import generic._
  *  @tparam B      type of values associated with the keys
  *
  *  @since 2.8
+ *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_34.html "The Scala 2.8 Collections API"]]
+ *  section on `Hash Tables` for more information.
+ *
  *  @define Coll WeakHashMap
  *  @define coll weak hash map
  *  @define thatinfo the class of the returned collection. In the standard library configuration,


### PR DESCRIPTION
Recently, on scala-debate, Martin Odersky wrote: "I think two of the things we need to do on the docs side is hide implementation details better in the ScalaDoc and put a link to the collections API overview

http://www.scala-lang.org/docu/files/collections-api/collections.html

into the scaladoc of each collection class."

I've implemented the second suggestion. For the classes that have their own pages in the collections API overview, I've added @see ("See also") links to their specific pages in the collections API overview. I used the existing @see from Array.scala as a model.
