### PR TITLE
Changed scaladoc links in collection classes to point at re-formatted Collections overview

### DIFF
--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -465,7 +465,7 @@ object Array extends FallbackArrayBuilding {
  *
  *  @author Martin Odersky
  *  @version 1.0
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_38.html "The Scala 2.8 Collections API"]]
+ *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_38.html#anchor "The Scala 2.8 Collections' API"]]
  *  section on `Array` by Martin Odersky for more information.
  */
 final class Array[T](_length: Int) extends java.io.Serializable with java.lang.Cloneable {

--- a/src/library/scala/collection/immutable/BitSet.scala
+++ b/src/library/scala/collection/immutable/BitSet.scala
@@ -17,7 +17,7 @@ import mutable.{ Builder, SetBuilder }
 
 /** A class for immutable bitsets.
  *  $bitsetinfo
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_21.html "The Scala 2.8 Collections API"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#immutable_bitsets "Scala's Collection Library overview"]]
  *  section on `Immutable BitSets` for more information.
  *
  *  @define Coll immutable.BitSet

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -25,7 +25,7 @@ import parallel.immutable.ParHashMap
  *  @author  Tiark Rompf
  *  @version 2.8
  *  @since   2.3
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_19.html "The Scala 2.8 Collections API"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#hash_tries "Scala's Collection Library overview"]]
  *  section on `Hash Tries` for more information.
  *  @define Coll immutable.HashMap
  *  @define coll immutable hash map

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -57,13 +57,9 @@ import annotation.tailrec
  *  @author  Martin Odersky and others
  *  @version 2.8
  *  @since   1.0
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_13.html "The Scala 2..8 Collections API"]]
+ *  @see  [["http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#lists" "Scala's Collection Library overview"]]
  *  section on `Lists` for more information.
-
  *
- *  @tparam  A    the type of the list's elements
- *
- *  @define Coll List
  *  @define coll list
  *  @define thatinfo the class of the returned collection. In the standard library configuration,
  *    `That` is always `List[B]` because an implicit of type `CanBuildFrom[List, B, That]`

--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -16,7 +16,7 @@ import annotation.{tailrec, bridge}
 
 /** $factoryInfo
  *  @since 1
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_22.html "The Scala 2.8 Collections API"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#list_maps "Scala's Collection Library overview"]]
  *  section on `List Maps` for more information.
  *
  *  @define Coll immutable.ListMap

--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -27,8 +27,8 @@ import annotation.tailrec
  *  @author  Erik Stenman
  *  @version 1.0, 08/07/2003
  *  @since   1
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_17.html "The Scala 2.8 Collections API"]]
- *  section on `Ummutable Queues` for more information.
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#immutable_queues "Scala's Collection Library overview"]]
+ *  section on `Immutable Queues` for more information.
  *
  *  @define Coll immutable.Queue
  *  @define coll immutable queue

--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -31,7 +31,7 @@ import annotation.bridge
  *  @author Paul Phillips
  *  @version 2.8
  *  @since   2.5
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_18.html "The Scala 2.8 Collections API"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#ranges "Scala's Collection Library overview"]]
  *  section on `Ranges` for more information.
  *
  *  @define Coll Range

--- a/src/library/scala/collection/immutable/Stack.scala
+++ b/src/library/scala/collection/immutable/Stack.scala
@@ -34,7 +34,7 @@ object Stack extends SeqFactory[Stack] {
  *  @author  Matthias Zenger
  *  @version 1.0, 10/07/2003
  *  @since   1
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_16.html "The Scala 2.8 Collections API"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#immutable_stacks "Scala's Collection Library overview"]]
  *  section on `Immutable stacks` for more information.
  *
  *  @define Coll immutable.Stack

--- a/src/library/scala/collection/immutable/Stream.scala
+++ b/src/library/scala/collection/immutable/Stream.scala
@@ -172,8 +172,8 @@ import Stream.cons
  *  @author Martin Odersky, Matthias Zenger
  *  @version 1.1 08/08/03
  *  @since   2.8
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_14.html "The Scala 2.8 Collections API"]]
-  *  section on `Streams` for more information.
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#streams "Scala's Collection Library overview"]]
+ *  section on `Streams` for more information.
 
  *  @define naturalsEx def naturalsFrom(i: Int): Stream[Int] = i #:: naturalsFrom(i + 1)
  *  @define Coll Stream

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -36,7 +36,7 @@ object TreeMap extends ImmutableSortedMapFactory[TreeMap] {
  *  @author  Matthias Zenger
  *  @version 1.1, 03/05/2004
  *  @since   1
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_20.html "The Scala 2.8 Collections API"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#redblack_trees "Scala's Collection Library overview"]]
  *  section on `Red-Black Trees` for more information.
  *
  *  @define Coll immutable.TreeMap

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -36,7 +36,7 @@ object TreeSet extends ImmutableSortedSetFactory[TreeSet] {
  *  @author  Martin Odersky
  *  @version 2.0, 02/01/2007
  *  @since   1
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_20.html "The Scala 2.8 Collections API"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#redblack_trees "Scala's Collection Library overview"]]
  *  section on `Red-Black Trees` for more information.
  *
  *  @define Coll immutable.TreeSet

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -35,7 +35,7 @@ object Vector extends SeqFactory[Vector] {
  *  endian bit-mapped vector trie with a branching factor of 32.  Locality is very good, but not
  *  contiguous, which is good for very large sequences.
  *
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_15.html "The Scala 2.8 Collections API"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#vectors "Scala's Collection Library overview"]]
  *  section on `Vectors` for more information.
  *
  *  @tparam A the element type

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -23,8 +23,8 @@ import parallel.mutable.ParArray
  *  @author  Martin Odersky
  *  @version 2.8
  *  @since   1
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_38.html "The Scala 2.8 Collections API"]]
- *  section on `Concrete Mutable Collection Classes` for more information.
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#array_buffers "Scala's Collection Library overview"]]
+ *  section on `Array Buffers` for more information.
 
  *
  *  @tparam A    the type of this arraybuffer's elements.

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -21,7 +21,7 @@ import parallel.mutable.ParArray
  *  @author Martin Odersky
  *  @version 2.8
  *  @since   2.8
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_31.html "The Scala 2.8 Collections API"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#array_sequences "Scala's Collection Library overview"]]
  *  section on `Array Sequences` for more information.
  *
  *  @tparam A      type of the elements contained in this array sequence.

--- a/src/library/scala/collection/mutable/ArrayStack.scala
+++ b/src/library/scala/collection/mutable/ArrayStack.scala
@@ -46,7 +46,7 @@ object ArrayStack extends SeqFactory[ArrayStack] {
  *
  *  @author David MacIver
  *  @since  2.7
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_33.html "The Scala 2.8 Collections API"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#array_stacks "Scala's Collection Library overview"]]
  *  section on `Array Stacks` for more information.
  *
  *  @tparam T    type of the elements contained in this array stack.

--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -18,7 +18,7 @@ import BitSetLike.{LogWL, updateArray}
  *
  *  $bitsetinfo
  *
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_37.html "The Scala 2.8 Collections API"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#mutable_bitsets "Scala's Collection Library overview"]]
  *  section on `Mutable Bitsets` for more information.
  *
  *  @define Coll BitSet

--- a/src/library/scala/collection/mutable/ConcurrentMap.scala
+++ b/src/library/scala/collection/mutable/ConcurrentMap.scala
@@ -14,7 +14,7 @@ package mutable
  *  $concurrentmapinfo
  *
  *  @since 2.8
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_36.html "The Scala 2.8 Collections API"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#concurrent_maps "Scala's Collection Library overview"]]
  *  section on `Concurrent Maps` for more information.
  *
  *  @tparam A  the key type of the map

--- a/src/library/scala/collection/mutable/DoubleLinkedList.scala
+++ b/src/library/scala/collection/mutable/DoubleLinkedList.scala
@@ -20,7 +20,7 @@ import generic._
  *  @author Martin Odersky
  *  @version 2.8
  *  @since   1
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_28.html "The Scala 2.8 Collections API"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#double_linked_lists "Scala's Collection Library overview"]]
  *  section on `Double Linked Lists` for more information.
 
  *

--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -15,7 +15,7 @@ import scala.collection.parallel.mutable.ParHashMap
 /** This class implements mutable maps using a hashtable.
  *
  *  @since 1
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_34.html "The Scala 2.8 Collections API"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#hash_tables "Scala's Collection Library overview"]]
  *  section on `Hash Tables` for more information.
  *
  *  @tparam A    the type of the keys contained in this hash map.

--- a/src/library/scala/collection/mutable/HashSet.scala
+++ b/src/library/scala/collection/mutable/HashSet.scala
@@ -22,7 +22,7 @@ import collection.parallel.mutable.ParHashSet
  *  @author  Martin Odersky
  *  @version 2.0, 31/12/2006
  *  @since   1
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_34.html "The Scala 2.8 Collections API"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#hash_tables "Scala's Collection Library overview"]]
  *  section on `Hash Tables` for more information.
  *
  *  @define Coll mutable.HashSet

--- a/src/library/scala/collection/mutable/LinearSeq.scala
+++ b/src/library/scala/collection/mutable/LinearSeq.scala
@@ -19,8 +19,8 @@ import generic._
  *
  *  @define Coll LinearSeq
  *  @define coll linear sequence
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_29.html "The Scala 2.8 Collections API"]]
-  *  section on `Mutable Lists` for more information.
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#mutable_lists "Scala's Collection Library overview"]]
+ *  section on `Mutable Lists` for more information.
  */
 trait LinearSeq[A] extends Seq[A]
                            with scala.collection.LinearSeq[A]

--- a/src/library/scala/collection/mutable/LinkedList.scala
+++ b/src/library/scala/collection/mutable/LinkedList.scala
@@ -33,7 +33,7 @@ import generic._
   *  @author Martin Odersky
   *  @version 2.8
   *  @since   1
-  *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_27.html "The Scala 2.8 Collections API"]]
+  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#linked_lists "Scala's Collection Library overview"]]
   *  section on `Linked Lists` for more information.
   *
   *  @tparam A     the type of the elements contained in this linked list.

--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -21,7 +21,7 @@ import immutable.{List, Nil, ::}
  *  @author  Martin Odersky
  *  @version 2.8
  *  @since   1
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_25.html "The Scala 2.8 Collections API"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#list_buffers "Scala's Collection Library overview"]]
  *  section on `List Buffers` for more information.
  *
  *  @tparam A    the type of this list buffer's elements.

--- a/src/library/scala/collection/mutable/MutableList.scala
+++ b/src/library/scala/collection/mutable/MutableList.scala
@@ -23,7 +23,7 @@ import immutable.{List, Nil}
  *  @author  Martin Odersky
  *  @version 2.8
  *  @since   1
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_29.html "The Scala 2.8 Collections API"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#mutable_lists "Scala's Collection Library overview"]]
  *  section on `Mutable Lists` for more information.
  */
 @SerialVersionUID(5938451523372603072L)

--- a/src/library/scala/collection/mutable/Queue.scala
+++ b/src/library/scala/collection/mutable/Queue.scala
@@ -20,7 +20,7 @@ import generic._
  *  @author  Martin Odersky
  *  @version 2.8
  *  @since   1
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_30.html "The Scala 2.8 Collections API"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#mutable_queues "Scala's Collection Library overview"]]
  *  section on `Queues` for more information.
  *
  *  @define Coll mutable.Queue

--- a/src/library/scala/collection/mutable/Stack.scala
+++ b/src/library/scala/collection/mutable/Stack.scala
@@ -44,8 +44,8 @@ object Stack extends SeqFactory[Stack] {
  *  @author  Martin Odersky
  *  @version 2.8
  *  @since   1
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_32.html "The Scala 2.8 Collections API"]]
- *  section on `Array Sequences` for more information.
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#stacks"Scala's Collection Library overview"]]
+ *  section on `Stacks` for more information.
  *  @define Coll Stack
  *  @define coll stack
  *  @define orderDependent

--- a/src/library/scala/collection/mutable/StringBuilder.scala
+++ b/src/library/scala/collection/mutable/StringBuilder.scala
@@ -21,7 +21,7 @@ import immutable.StringLike
  *  @author Martin Odersky
  *  @version 2.8
  *  @since   2.7
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_26.html "The Scala 2.8 Collections API"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html# "Scala's Collection Library overview"]]
  *  section on `StringBuilders` for more information.
  */
 @SerialVersionUID(0 - 8525408645367278351L)

--- a/src/library/scala/collection/mutable/WeakHashMap.scala
+++ b/src/library/scala/collection/mutable/WeakHashMap.scala
@@ -23,8 +23,8 @@ import generic._
  *  @tparam B      type of values associated with the keys
  *
  *  @since 2.8
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_34.html "The Scala 2.8 Collections API"]]
- *  section on `Hash Tables` for more information.
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#weak_hash_maps "Scala's Collection Library overview"]]
+ *  section on `Weak Hash Maps` for more information.
  *
  *  @define Coll WeakHashMap
  *  @define coll weak hash map


### PR DESCRIPTION
As per the suggestion from retronym, I updated the scaladoc links in the collection classes to point at the newly fancified Collections overview at docs.scala-lang.org (http://docs.scala-lang.org/overviews/collections/introduction.html).  Each link points to the relevant anchor in the overview.  
I also fixed a typo: s/Ummutable/Immutable/.
