### PR TITLE
Reflective compiler now crashes properly

### DIFF
--- a/src/compiler/scala/reflect/runtime/ToolBoxes.scala
+++ b/src/compiler/scala/reflect/runtime/ToolBoxes.scala
@@ -88,7 +88,13 @@ trait ToolBoxes extends { self: Universe =>
       def runExpr(expr: Tree): Any = {
         val etpe = expr.tpe
         val fvs = (expr filter isFree map (_.symbol)).distinct
+        
+        reporter.reset()
         val className = compileExpr(expr, fvs)
+        if (reporter.hasErrors) {
+          throw new Error("reflective compilation has failed")
+        }
+        
         if (settings.debug.value) println("generated: "+className)
         val jclazz = jClass.forName(moduleFileName(className), true, classLoader)
         val jmeth = jclazz.getDeclaredMethods.find(_.getName == wrapperMethodName).get


### PR DESCRIPTION
Adjust toolbox to escalate errors reported during reflective compilation.

Without this functionality, errors get swallowed and lead to weirdness
like https://issues.scala-lang.org/browse/SI-5274. The only meaningful
part of the output in the bug report linked above is the first line.
Subsequent stack trace is at best useless and at worst misleading.
Now the error report is much more sane: https://gist.github.com/1443232

Review by @odersky.
