### PR TITLE
Fixed use case signature problems in #5054

### DIFF
--- a/src/compiler/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/compiler/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -119,14 +119,18 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
         else Public()
       }
     }
-    def flags = {
-      val fgs = mutable.ListBuffer.empty[Paragraph]
-      if (sym.isImplicit) fgs += Paragraph(Text("implicit"))
-      if (sym.isSealed) fgs += Paragraph(Text("sealed"))
-      if (!sym.isTrait && (sym hasFlag Flags.ABSTRACT)) fgs += Paragraph(Text("abstract"))
-      if (!sym.isTrait && (sym hasFlag Flags.DEFERRED)) fgs += Paragraph(Text("abstract"))
-      if (!sym.isModule && (sym hasFlag Flags.FINAL)) fgs += Paragraph(Text("final"))
-      fgs.toList
+    def flags = this match { 
+      	// workaround for uninitialized flags in use cases - see SI-5054
+    		case m: NonTemplateMemberEntity if (m.useCaseOf.isDefined) =>
+    			m.useCaseOf.get.flags
+    		case _ =>
+		      val fgs = mutable.ListBuffer.empty[Paragraph]
+		      if (sym.isImplicit) fgs += Paragraph(Text("implicit"))
+		      if (sym.isSealed) fgs += Paragraph(Text("sealed"))
+		      if (!sym.isTrait && (sym hasFlag Flags.ABSTRACT)) fgs += Paragraph(Text("abstract"))
+		      if (!sym.isTrait && (sym hasFlag Flags.DEFERRED)) fgs += Paragraph(Text("abstract"))
+		      if (!sym.isModule && (sym hasFlag Flags.FINAL)) fgs += Paragraph(Text("final"))
+		      fgs.toList    	
     }
     def deprecation =
       if (sym.isDeprecated)

--- a/test/scaladoc/resources/SI_5054_q1.scala
+++ b/test/scaladoc/resources/SI_5054_q1.scala
@@ -1,0 +1,10 @@
+class SI_5054_q1 {
+	
+	/**
+	 * A simple comment
+	 * 
+	 * @param lost a lost parameter
+	 * @usecase def test(): Int
+	 */
+	def test(implicit lost: Int): Int = lost
+}

--- a/test/scaladoc/resources/SI_5054_q2.scala
+++ b/test/scaladoc/resources/SI_5054_q2.scala
@@ -1,0 +1,10 @@
+class SI_5054_q2 {
+	
+	/**
+	 * A simple comment
+	 * 
+	 * @param lost a lost parameter
+	 * @usecase def test(): Int
+	 */
+	final def test(implicit lost: Int): Int = lost
+}

--- a/test/scaladoc/resources/SI_5054_q3.scala
+++ b/test/scaladoc/resources/SI_5054_q3.scala
@@ -1,4 +1,4 @@
-class SI_5054 {
+class SI_5054_q3 {
 	
 	/**
 	 * A simple comment
@@ -6,5 +6,5 @@ class SI_5054 {
 	 * @param lost a lost parameter
 	 * @usecase def test(): Int
 	 */
-	def test(implicit lost: Int): Int = lost
+	implicit def test(implicit lost: Int): Int = lost
 }

--- a/test/scaladoc/resources/SI_5054_q4.scala
+++ b/test/scaladoc/resources/SI_5054_q4.scala
@@ -1,0 +1,10 @@
+abstract class SI_5054_q4 {
+	
+	/**
+	 * A simple comment
+	 * 
+	 * @param lost a lost parameter
+	 * @usecase def test(): Int
+	 */
+	def test(implicit lost: Int): Int
+}

--- a/test/scaladoc/resources/SI_5054_q5.scala
+++ b/test/scaladoc/resources/SI_5054_q5.scala
@@ -1,0 +1,10 @@
+trait SI_5054_q5 {
+	
+	/**
+	 * A simple comment
+	 * 
+	 * @param lost a lost parameter
+	 * @usecase def test(): Int
+	 */
+	def test(implicit lost: Int): Int = lost
+}

--- a/test/scaladoc/resources/SI_5054_q6.scala
+++ b/test/scaladoc/resources/SI_5054_q6.scala
@@ -1,0 +1,10 @@
+trait SI_5054_q6 {
+	
+	/**
+	 * A simple comment
+	 * 
+	 * @param lost a lost parameter
+	 * @usecase def test(): Int
+	 */
+	def test(implicit lost: Int): Int
+}

--- a/test/scaladoc/scala/html/HtmlFactoryTest.scala
+++ b/test/scaladoc/scala/html/HtmlFactoryTest.scala
@@ -378,11 +378,67 @@ object Test extends Properties("HtmlFactory") {
     true
   }
 
-  property("Use cases should override their original members - valid until signature is added to html") = {
-    createTemplate("SI_5054.scala") match {
+  // A piece of the signature - corresponding to the use case
+  def signature(no: Int, modifier: String) = ("""
+    <li visbl="pub" name="SI_5054_q""" + no + """#test" data-isabs="false">
+      <a id="test():Int"></a>
+      <h4 class="signature">
+      <span class="modifier_kind">
+        <span class="modifier">""" + modifier + """</span>
+        <span class="kind">def</span>
+      </span>
+      <span class="symbol">
+        <span class="name">test</span><span class="params">()</span><span class="result">: <span name="scala.Int" class="extype">Int</span></span>
+      </span>
+      </h4>
+      <p class="shortcomment cmt">[use case] A simple comment
+      </p>
+    </li>""").replaceAll("\\s+", "")
+  
+  property("Use cases should override their original members - TODO: Change when including full signature") = {
+    createTemplate("SI_5054_q1.scala") match {
       case node: scala.xml.Node =>
-        node.toString.contains("A simple comment") &&
-        ! node.toString.contains("a lost parameter")
+        node.toString.replaceAll("\\s+","").contains(signature(1, ""))
+      case _ => false
+    }
+  }
+
+  property("Use cases should keep their flags - final should not be lost") = {
+    createTemplate("SI_5054_q2.scala") match {
+      case node: scala.xml.Node =>
+        node.toString.replaceAll("\\s+","").contains(signature(2, "final"))
+      case _ => false
+    }
+  }
+  
+  property("Use cases should keep their flags - implicit should not be lost") = {
+    createTemplate("SI_5054_q3.scala") match {
+      case node: scala.xml.Node =>
+        node.toString.replaceAll("\\s+","").contains(signature(3, "implicit"))
+      case _ => false
+    }
+  }
+
+  property("Use cases should keep their flags - real abstract should not be lost") = {
+    createTemplate("SI_5054_q4.scala") match {
+      case node: scala.xml.Node =>
+        node.toString.replaceAll("\\s+","").contains(signature(4, "abstract"))
+      case _ => false
+    }
+  }
+
+  property("Use cases should keep their flags - traits should not be affected") = {
+    createTemplate("SI_5054_q5.scala") match {
+      case node: scala.xml.Node =>
+        node.toString.replaceAll("\\s+","").contains(signature(5, ""))
+      case _ => false
+    }
+  }
+
+  property("Use cases should keep their flags - traits with abstract members should display abstract") = {
+    createTemplate("SI_5054_q6.scala") match {
+      case node: scala.xml.Node =>
+        node.toString.replaceAll("\\s+","").contains(signature(6, "abstract"))
       case _ => false
     }
   }


### PR DESCRIPTION
The flags attached to symbols depend on the order of access and this
affects use cases. For a workaround, flags are copied from the full
signature, which is always correct. Closes #5054, will open another
bug for the html itself.
