### PR TITLE
Ensure sha files don't go to production

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1688,7 +1688,9 @@ DISTRIBUTION
     </copy>
     <mkdir dir="${dist.dir}/doc/scala-devel-docs/examples"/>
     <copy toDir="${dist.dir}/doc/scala-devel-docs/examples">
-      <fileset dir="${docs.dir}/examples"/>
+      <fileset dir="${docs.dir}/examples">
+        <exclude name="**/*.desired.sha1"/>
+      </fileset>
     </copy>
     <mkdir dir="${dist.dir}/doc/scala-devel-docs/tools"/>
     <copy toDir="${dist.dir}/doc/scala-devel-docs/tools">


### PR DESCRIPTION
This commit filters out the sha files that have been going into the
docs area of a distribution.  Really, I think examples might
belong in a separate project moreso than in the distro, but
for now just preventing the build information from leaking
into the distro is helpful.

Review by: @lrytz
