### PR TITLE
Avoid calling apply twice on Range.foreach.

### DIFF
--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -74,12 +74,11 @@ extends collection.AbstractSeq[Int]
   @inline final override def foreach[@specialized(Unit) U](f: Int => U) {
     if (length > 0) {
       val last = this.last
-      var i = start
-      while (i != last) {
-        f(i)
+      var i = start - step
+      do {
         i += step
-      }
-      f(i)
+        f(i)
+      } while (i != last)
     }
   }
 


### PR DESCRIPTION
On micro-benchmarks, this resulted in slightly slower foreach loops
for small ranges (10-sized loops), but some gains for bigger loops
(100-sized+). Small loops with Range are extremely slow compared to
while loops anyway.

More importantly, it reduces the size of inlined code with -optimise,
which increases the chance of inlining happening and of JVM further
improving upon it.

```
Fixes SI-5286
```
