### PR TITLE
Batch files no longer swallow exit codes

### DIFF
--- a/src/compiler/scala/tools/ant/templates/tool-windows.tmpl
+++ b/src/compiler/scala/tools/ant/templates/tool-windows.tmpl
@@ -86,3 +86,4 @@ goto :eof
 
 :end
 @@endlocal
+exit /b %errorlevel%

--- a/test/files/jvm/mkLibNatives.bat
+++ b/test/files/jvm/mkLibNatives.bat
@@ -67,4 +67,4 @@ goto end
 
 :end
 if "%OS%"=="Windows_NT" @endlocal
-
+exit /b %errorlevel%

--- a/test/partest.bat
+++ b/test/partest.bat
@@ -101,3 +101,4 @@ goto end
 
 :end
 if "%OS%"=="Windows_NT" @endlocal
+exit /b %errorlevel%


### PR DESCRIPTION
Usually scripts like scala.bat and scalac.bat correctly propagate
exit codes from underlying Java invocations. However, if you run these
scripts as follows: "cmd /c scala ...", then errorlevel gets swallowed.
This simple patch fixes the aforementioned problem.

Fixes SI-5295, no review.
