### PR TITLE
typeParams now performs one more completion

### DIFF
--- a/src/compiler/scala/reflect/internal/Symbols.scala
+++ b/src/compiler/scala/reflect/internal/Symbols.scala
@@ -1097,6 +1097,10 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def typeParams: List[Symbol] =
       if (isMonomorphicType) Nil
       else {
+        // analogously to the "info" getter, here we allow for two completions:
+        //   one: sourceCompleter to LazyType, two: LazyType to completed type
+        if (validTo == NoPeriod)
+          atPhase(phaseOf(infos.validFrom))(rawInfo load this)
         if (validTo == NoPeriod)
           atPhase(phaseOf(infos.validFrom))(rawInfo load this)
 


### PR DESCRIPTION
When tracking a problem in type inference during reflective compilation,
Martin and I have discovered that under certain circumstances typeParams
does not fully load the type.

During a debugging session we found out that info first had the type of
TopLevelCompleter, and after the load it was still not completed, having
the type of UnPickler$something$LazyTypeRef.

After that discovery it became apparent that typeParams need to behave
similarly to the info getter - allow for two completions, not just one.

Review by @odersky, @adriaanm.
