### PR TITLE
Fix for SI-4929. Includes (previously failing) test case.

### DIFF
--- a/test/files/run/t4929.check
+++ b/test/files/run/t4929.check
@@ -1,0 +1,1 @@
+success

--- a/test/files/run/t4929.scala
+++ b/test/files/run/t4929.scala
@@ -1,0 +1,32 @@
+object Test extends App {
+  import scala.util.parsing.json._
+
+  val LIMIT = 2000
+  val count = new java.util.concurrent.atomic.AtomicInteger(0)
+
+  var error:Option[Throwable] = None
+
+  (1 to 20) foreach { i =>
+    (new Thread {
+      override def run() {
+        while (count.getAndIncrement() < LIMIT && !error.isDefined) {
+          try {
+            JSON.parseFull("""{"foo": [1,2,3,4]}""")
+          } catch {
+            case t: Throwable => error = Some(t)
+          }
+        }
+      }
+    }).start()
+
+  }
+
+  while (count.get() < LIMIT && !error.isDefined) {
+    Thread.sleep(1)
+  }
+
+  error foreach { throw(_) }
+
+  println("success")
+
+}


### PR DESCRIPTION
This uses thread-local variables, which is not ideal; however, I can't find any way to fix it otherwise that doesn't involve significant refactoring.

I've created a new pull request because I believe my old one (https://github.com/scala/scala-minor-snafu/pull/3) might have been lost in the repo snafu; a branch in the new repo was created but it since seems to have disappeared. Apologies if this was unnecessary.
