### PR TITLE
Attempt to fix classloader issues

### DIFF
--- a/src/compiler/scala/reflect/runtime/JavaToScala.scala
+++ b/src/compiler/scala/reflect/runtime/JavaToScala.scala
@@ -34,8 +34,10 @@ trait JavaToScala extends ConversionUtil { self: SymbolTable =>
     val global: JavaToScala.this.type = self
   }
 
-  protected def defaultReflectiveClassLoader(): JClassLoader =
-    Thread.currentThread.getContextClassLoader
+  protected def defaultReflectiveClassLoader(): JClassLoader = {
+    val cl = Thread.currentThread.getContextClassLoader
+    if (cl == null) getClass.getClassLoader else cl
+  }
 
   /** Paul: It seems the default class loader does not pick up root classes, whereas the system classloader does.
    *  Can you check with your newly acquired classloader fu whether this implementation makes sense?


### PR DESCRIPTION
@odersky writes: When doing reflect.mirror.ClassWithName("foo")
in the REPL, we get a NullPointerException. It goes away if we have
this fallback in defaultClassLoader.

Not sure it's the right fix, though.

Fixes SI-5226, review by @odersky
