### PR TITLE
Made -Ystop-after:parser work correctly

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1201,8 +1201,10 @@ class Global(var currentSettings: Settings, var reporter: Reporter) extends Symb
       perRunCaches.clearAll()
 
       // Reset project
-      atPhase(namerPhase) {
-        resetProjectClasses(definitions.RootClass)
+      if (!stopPhase("namer")) {
+        atPhase(namerPhase) {
+          resetProjectClasses(definitions.RootClass)
+        }
       }
     }
 


### PR DESCRIPTION
Without this fix running a compiler with the aforementioned option
leads to a crash (because namerPhase gets resolved to a NoPhase).
