### PR TITLE
Addresses a bug in SimpleDateFormatter

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -220,7 +220,7 @@ INITIALISATION
     <taskdef resource="net/sf/antcontrib/antlib.xml" classpath="${lib.dir}/ant/ant-contrib.jar"/>
     <!-- This is the start time for the distribution -->
     <tstamp prefix="time">
-      <format property="human" pattern="d MMMM yyyy, HH:mm:ss"/>
+      <format property="human" pattern="d MMMM yyyy, HH:mm:ss" locale="en,US"/>
       <format property="short" pattern="yyyyMMddHHmmss"/>
     </tstamp>
     <!-- Find out whether we are running on Windows -->


### PR DESCRIPTION
The point is that in Windows with non-English locale the "MMMM" part turns into gibberish. SimpleDateFormatter asks the OS for a byte array that represents month name in system locale, and then transcodes these bytes into utf-8 regardless of the system encoding. On my laptop (with Russian locale) the result looks as following:

build time: 25 ─хърсЁ№ 2011, 15:57:23

Just in case you don't know Russian, this is a meaningless set of characters =)

The solution is to get these bytes from the crazy string produced by SimpleDateFormatter and create a new string that uses correct encoding. However, even if you do this in Ant (which requires writing a custom task), the result will not be perfect:

build time: 25 Декабрь 2011, 15:57:23  

Now these characters indeed say "December" in Russian, but the grammatical case of the word "Декабрь" doesn't agree with the numeral "25", so the entire printout isn't a correct Russian phrase.
