### PR TITLE
Fix SI-5341: PhaseAssembly.removeDanglingNodes removes elements from mutable.Map during iteration.

### DIFF
--- a/src/compiler/scala/tools/nsc/PhaseAssembly.scala
+++ b/src/compiler/scala/tools/nsc/PhaseAssembly.scala
@@ -185,7 +185,7 @@ trait PhaseAssembly {
      *  dependency on something that is dropped.
      */
     def removeDanglingNodes() {
-      for (node <- nodes.valuesIterator filter (_.phaseobj.isEmpty)) {
+      for (node <- nodes.values filter (_.phaseobj.isEmpty)) {
         val msg = "dropping dependency on node with no phase object: "+node.phasename
         informProgress(msg)
         nodes -= node.phasename


### PR DESCRIPTION
This has no performance impact. See the following for more information:

https://issues.scala-lang.org/browse/SI-5341
