### PR TITLE
Added toString to Codec class (uses Codec.name).

### DIFF
--- a/src/library/scala/io/Codec.scala
+++ b/src/library/scala/io/Codec.scala
@@ -38,6 +38,9 @@ class Codec(val charSet: Charset) {
   private[this] var _decodingReplacement: String      = null
   private[this] var _onCodingException: Handler       = e => throw e
 
+  /** The name of the Codec. */
+  override def toString = name
+
   // these methods can be chained to configure the variables above
   def onMalformedInput(newAction: Action): this.type = { _onMalformedInput = newAction ; this }
   def onUnmappableCharacter(newAction: Action): this.type = { _onUnmappableCharacter = newAction ; this }


### PR DESCRIPTION
After running "Implicitly[Codec]" I had to look up Codec in the scaladocs to see what field would describe the implicit Codec.  This pull request simply adds Codec.toString.
