### PR TITLE
Remove maven deply from epfl-publish script.

### DIFF
--- a/tools/epfl-publish
+++ b/tools/epfl-publish
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 #
 # publishes nightly build if $publish_to is set in environment.
-# alternate maven settings.xml file given in $maven_settings.
 #
 
 [[ $# -eq 1 ]] || {
@@ -20,21 +19,6 @@ version="$1"
   exit 1
 }
 
-# should not be hardcoded
-# adds -Dsettings.file= if fixed path is present 
-mavenSettingsOption () {
-  hardcoded_path="/home/linuxsoft/apps/hudson-maven-settings/settings.xml"
-  
-  # environment variable
-  if [[ -n $maven_settings ]]; then
-    echo -Dsettings.file="$maven_settings"
-  elif [[ -f $hardcoded_path ]]; then
-    echo -Dsettings.file="$hardcoded_path"
-  fi
-}
-
-mavenSettings=${maven_settings:-findMavenSettings}
-
 if [[ -z $publish_to ]]; then
   echo "Nothing to publish."
 else
@@ -45,6 +29,4 @@ else
   [[ $version == "2.8.x" ]] || rsync -az build/scaladoc/ "$publish_to/docs"
   # sbaz
   [[ -d dists/sbaz ]] && rsync -az dists/sbaz/ "$publish_to/sbaz"
-  # Deploy the maven artifacts on scala-tools.org
-  ( cd dists/maven/latest && ant deploy.snapshot $(mavenSettingsOption) )
 fi


### PR DESCRIPTION
This is done by the separate scala-nightly-maven-deploy jenkins job, doing it here fails depending on the build machine (/home/linuxsoft/... is not available everywhere).
