### PR TITLE
Merge ??? from trunk

### DIFF
--- a/src/library/scala/NotImplementedError.scala
+++ b/src/library/scala/NotImplementedError.scala
@@ -1,0 +1,19 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2002-2011, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+
+
+package scala
+
+/** Throwing this exception can be a temporary replacement for a method
+ *  body that remains to be implemented. For instance, the exception is thrown by
+ *  `Predef.???`.
+ */
+final class NotImplementedError(msg: String) extends Error(msg) {
+  def this() = this("an implementation is missing")
+}

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -165,6 +165,11 @@ object Predef extends LowPriorityImplicits {
   }
   implicit def any2Ensuring[A](x: A): Ensuring[A] = new Ensuring(x)
 
+  /** `???` can be used for marking methods that remain to be implemented.
+   *  @throws  A `NotImplementedError`
+   */
+  def ??? : Nothing = throw new NotImplementedError
+
   // tupling ------------------------------------------------------------
 
   type Pair[+A, +B] = Tuple2[A, B]


### PR DESCRIPTION
Added ??? and NotImplementedError because this seemed to be the
opinion of the majority on the "Adding ??? to Predef?" thread on
scala-internals. No review.

This change is pretty harmless, and if it's good enough for 2.10.0, it ought to be good enough for 2.9.2.
