### PR TITLE
Cleanup after "Fixed equality and string representation of xml attribute...

### DIFF
--- a/src/library/scala/xml/PrefixedAttribute.scala
+++ b/src/library/scala/xml/PrefixedAttribute.scala
@@ -13,22 +13,25 @@ package scala.xml
  *
  *  @param pre   ...
  *  @param key   ...
- *  @param value the attribute value, which may not be null
+ *  @param value the attribute value
  *  @param next  ...
  */
 class PrefixedAttribute(
   val pre: String,
   val key: String,
   val value: Seq[Node],
-  val next: MetaData)
+  val next1: MetaData)
 extends Attribute
 {
-  if (value eq null)
-    throw new UnsupportedOperationException("value is null")
+  val next = if (value ne null) next1 else next1.remove(key)
 
-  /** same as this(key, Utility.parseAttributeValue(value), next) */
+  /** same as this(pre, key, Text(value), next), or no attribute if value is null */
   def this(pre: String, key: String, value: String, next: MetaData) =
-    this(pre, key, Text(value), next)
+    this(pre, key, if (value ne null) Text(value) else null: NodeSeq, next)
+
+  /** same as this(pre, key, value.get, next), or no attribute if value is None */
+  def this(pre: String, key: String, value: Option[Seq[Node]], next: MetaData) =
+    this(pre, key, value.orNull, next)
 
   /** Returns a copy of this unprefixed attribute with the given
    *  next field.

--- a/test/files/run/xml-attribute.scala
+++ b/test/files/run/xml-attribute.scala
@@ -5,10 +5,29 @@ object Test {
     val noAttr = <t/>
     val attrNull = <t a={ null: String }/>
     val attrNone = <t a={ None: Option[Seq[Node]] }/>
+    val preAttrNull = <t p:a={ null: String }/>
+    val preAttrNone = <t p:a={ None: Option[Seq[Node]] }/>
     assert(noAttr == attrNull)
     assert(noAttr == attrNone)
-    assert(noAttr.toString() == "<t></t>")
-    assert(attrNull.toString() == "<t></t>")
-    assert(attrNone.toString() == "<t></t>")
+    assert(noAttr == preAttrNull)
+    assert(noAttr == preAttrNone)
+
+    val noAttrStr = "<t></t>"
+    assert(noAttr.toString() == noAttrStr)
+    assert(attrNull.toString() == noAttrStr)
+    assert(attrNone.toString() == noAttrStr)
+    assert(preAttrNull.toString() == noAttrStr)
+    assert(preAttrNone.toString() == noAttrStr)
+
+    val xml1 = <t b="1" d="2"/>
+    val xml2 = <t a={ null: String } p:a={ null: String } b="1" c={ null: String } d="2"/>
+    val xml3 = <t b="1" c={ null: String } d="2" a={ null: String } p:a={ null: String }/>
+    assert(xml1 == xml2)
+    assert(xml1 == xml3)
+
+    val xml1Str = "<t d=\"2\" b=\"1\"></t>"
+    assert(xml1.toString() == xml1Str)
+    assert(xml2.toString() == xml1Str)
+    assert(xml3.toString() == xml1Str)
   }
 }

--- a/test/scaladoc/scala/html/HtmlFactoryTest.scala
+++ b/test/scaladoc/scala/html/HtmlFactoryTest.scala
@@ -185,18 +185,18 @@ object Test extends Properties("HtmlFactory") {
   property("Trac #4180") = {
     createTemplate("Trac4180.scala") != None
   }
-  // 
-  // property("Trac #4372") = {
-  //   createTemplate("Trac4372.scala") match {
-  //     case node: scala.xml.Node => {
-  //       val html = node.toString
-  //       html.contains("<span class=\"name\" title=\"gt4s: $plus$colon\">+:</span>") &&
-  //         html.contains("<span class=\"name\" title=\"gt4s: $minus$colon\">-:</span>") &&
-  //           html.contains("""<span class="params">(<span name="n">n: <span name="scala.Int" class="extype">Int</span></span>)</span><span class="result">: <span name="scala.Int" class="extype">Int</span></span>""")
-  //     }
-  //     case _ => false
-  //   }
-  // }
+
+  property("Trac #4372") = {
+    createTemplate("Trac4372.scala") match {
+      case node: scala.xml.Node => {
+        val html = node.toString
+        html.contains("<span title=\"gt4s: $plus$colon\" class=\"name\">+:</span>") &&
+          html.contains("<span title=\"gt4s: $minus$colon\" class=\"name\">-:</span>") &&
+            html.contains("""<span class="params">(<span name="n">n: <span name="scala.Int" class="extype">Int</span></span>)</span><span class="result">: <span name="scala.Int" class="extype">Int</span></span>""")
+      }
+      case _ => false
+    }
+  }
 
   property("Trac #4374 - public") = {
     val files = createTemplates("Trac4374.scala")
@@ -426,11 +426,11 @@ object Test extends Properties("HtmlFactory") {
     createTemplate("SI_4898.scala")
     true
   }
-  // 
-  // property("Use cases should override their original members") =
-  //    checkText1("SI_5054_q1.scala", """def test(): Int""") &&
-  //    !checkText1("SI_5054_q1.scala", """def test(implicit lost: Int): Int""")
-  // 
+  
+  property("Use cases should override their original members") =
+     checkText1("SI_5054_q1.scala", """def test(): Int""") &&
+     !checkText1("SI_5054_q1.scala", """def test(implicit lost: Int): Int""")
+  
 
   property("Use cases should keep their flags - final should not be lost") = 
     checkText1("SI_5054_q2.scala", """final def test(): Int""")


### PR DESCRIPTION
...s with null value"

This commit reverts the following two commits:
5f2568e36b87d183fd4e4442d5c304db628846c4 - "Revert "Accept prefixed xml attributes with null value"
b00002f9049c034510438881b4a4449d73fe2f54 - "Disabling some scaladoc tests."
and fixes a scaladoc test broken by:
4787f883604d1344257c0b40c15790c3dde477f2 - "Fixed equality and string representation of xml attributes with null value"
