### PR TITLE
Make AnyValManifest not a sealed class.

### DIFF
--- a/src/library/scala/reflect/Manifest.scala
+++ b/src/library/scala/reflect/Manifest.scala
@@ -60,7 +60,7 @@ trait Manifest[T] extends ClassManifest[T] with Equals {
   override def hashCode = this.erasure.##
 }
 
-sealed abstract class AnyValManifest[T <: AnyVal](override val toString: String) extends Manifest[T] with Equals {
+abstract class AnyValManifest[T <: AnyVal](override val toString: String) extends Manifest[T] with Equals {
   override def <:<(that: ClassManifest[_]): Boolean =
     (that eq this) || (that eq Manifest.Any) || (that eq Manifest.AnyVal)
   override def canEqual(other: Any) = other match {


### PR DESCRIPTION
Scala+GWT has a whole new hierarchy of Manifests that
does not use reflection. Every type in new hierarchy
is a subtype of a type from old hierarchy. Sealed modifier
introduced in 2e92de4cd66532404081eec6b9e82c6f85b51434
breaks this scheme. Removing it so Scala+GWT can compile again.
