### PR TITLE
Improvement in specialization

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -1275,7 +1275,10 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
                 .format(tree, symbol.tpe, tree.tpe, env, specializedName(symbol, env)))
         if (!env.isEmpty) {  // a method?
           val specCandidates = qual.tpe.member(specializedName(symbol, env))
-          val specMember = specCandidates suchThat (s => doesConform(symbol, tree.tpe, s.tpe, env))
+          val specMember = specCandidates suchThat { s =>
+            doesConform(symbol, tree.tpe, qual.tpe.memberType(s), env)
+          }
+          
           log("[specSym] found: " + specCandidates.tpe + ", instantiated as: " + tree.tpe)
           log("[specSym] found specMember: " + specMember)
           if (specMember ne NoSymbol)

--- a/test/files/specialized/spec-hlists.check
+++ b/test/files/specialized/spec-hlists.check
@@ -1,0 +1,2 @@
+class HCons$mcI$sp
+class HCons$mcI$sp

--- a/test/files/specialized/spec-hlists.scala
+++ b/test/files/specialized/spec-hlists.scala
@@ -1,0 +1,29 @@
+/** Test contributed by Stefan Zeiger showing that HLists can be
+ *  specialized.
+ */
+
+sealed trait HList {
+  type Self <: HList
+  
+  type |: [E] = HCons[E, Self]
+
+  final def |: [@specialized E](elem: E): |: [E] = new HCons[E, Self](elem, this.asInstanceOf[Self])
+
+  def m[@specialized E, T <: AnyRef](x: E): T = null.asInstanceOf[T]
+}
+
+final class HCons[@specialized H, T <: HList](val head: H, val tail: T) extends HList {
+  type Self = HCons[H, T]
+}
+
+final object HNil extends HList {
+  type Self = HNil.type
+}
+
+object Test extends App {
+  val l1 = new HCons(42, "foo" |: HNil)
+  println(l1.getClass)
+  
+  val l2 = 42 |: "abc" |: HNil
+  println(l2.getClass)
+}


### PR DESCRIPTION
Make specialization pick up opportunities when the specialized
 method has additional (non-specialized) type parameters.

This fix comes from Stefan's desire to specialize HLists (see 
corresponding test). review by @prokopec
