### PR TITLE
Fix check for number of arguments

### DIFF
--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -43,7 +43,7 @@ case class StringContext(parts: String*) {
    *          that does not start a valid escape sequence.
    */
   def s(args: Any*) = {
-    checkLengths(args)
+    checkLengths(args: _*)
     val pi = parts.iterator
     val ai = args.iterator
     val bldr = new java.lang.StringBuilder(treatEscapes(pi.next))
@@ -83,7 +83,7 @@ case class StringContext(parts: String*) {
    *      format specifier `%s` and adding a corresponding argument string `"%"`.
    */
   def f(args: Any*) = {
-    checkLengths(args)
+    checkLengths(args: _*)
     val pi = parts.iterator
     val ai = args.iterator
     val bldr = new java.lang.StringBuilder

--- a/test/files/run/interpolation.check
+++ b/test/files/run/interpolation.check
@@ -2,14 +2,20 @@ Bob is 1 years old
 Bob is  1 years old
 Bob will be 2 years old
 Bob will be  2 years old
+1+1 = 2
+1+1 = 2
 Bob is 12 years old
 Bob is 12 years old
 Bob will be 13 years old
 Bob will be 13 years old
+12+1 = 13
+12+1 = 13
 Bob is 123 years old
 Bob is 123 years old
 Bob will be 124 years old
 Bob will be 124 years old
+123+1 = 124
+123+1 = 124
 Best price: 10.0
 Best price: 10.00
 10.0% discount included

--- a/test/files/run/interpolation.scala
+++ b/test/files/run/interpolation.scala
@@ -5,6 +5,8 @@ object Test extends App {
     println(f"Bob is $n%2d years old")
     println(s"Bob will be ${n+1} years old")
     println(f"Bob will be ${n+1}%2d years old")
+    println(s"$n+1 = ${n+1}")
+    println(f"$n%d+1 = ${n+1}%d")
   }
 
   def test2(f: Float) = {

--- a/test/files/run/interpolationArgs.check
+++ b/test/files/run/interpolationArgs.check
@@ -1,0 +1,2 @@
+java.lang.IllegalArgumentException: wrong number of arguments for interpolated string
+java.lang.IllegalArgumentException: wrong number of arguments for interpolated string

--- a/test/files/run/interpolationArgs.flags
+++ b/test/files/run/interpolationArgs.flags
@@ -1,0 +1,1 @@
+-Xexperimental

--- a/test/files/run/interpolationArgs.scala
+++ b/test/files/run/interpolationArgs.scala
@@ -1,0 +1,5 @@
+object Test extends App {
+  try { scala.StringContext("p1", "p2", "p3").s("e1") } catch { case ex => println(ex) }
+  try { scala.StringContext("p1").s("e1") } catch { case ex => println(ex) }
+}
+


### PR DESCRIPTION
Fix the test for number of arguments by passing all arguments instead
of passing the argument list as a single argument.

Add positive and negative tests for it.
