### PR TITLE
Fixes SI-5387: Improve Performance Of dropWhile in TraversableLike

### DIFF
--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -535,7 +535,7 @@ trait TraversableLike[+A, +Repr] extends HasNewBuilder[A, Repr]
     val b = newBuilder
     var go = false
     for (x <- this) {
-      if (!p(x)) go = true
+      if (!go && !p(x)) go = true
       if (go) b += x
     }
     b.result


### PR DESCRIPTION
The predicate was evaluated repeatedly for every element, even every non-dropped one.
