### PR TITLE
Fixes SI-5387: Improve Performance Of dropWhile in TraversableLike (now with test)

### DIFF
--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -535,7 +535,7 @@ trait TraversableLike[+A, +Repr] extends HasNewBuilder[A, Repr]
     val b = newBuilder
     var go = false
     for (x <- this) {
-      if (!p(x)) go = true
+      if (!go && !p(x)) go = true
       if (go) b += x
     }
     b.result

--- a/test/files/run/t5387.scala
+++ b/test/files/run/t5387.scala
@@ -1,0 +1,15 @@
+/*
+ * This tests that the predicate of dropWhile is only evaluated as often as needed, see https://issues.scala-lang.org/browse/SI-5387
+ */
+import scala.collection.immutable.ListMap
+object Test extends App{
+  val subject = ListMap(1->1,2->2,3->3,4->4,5->5)
+  val result  = ListMap(3->3,4->4,5->5)
+  assert( result == subject.dropWhile{
+       case (key, value) => {
+         assert( key <= 3, "predicate evaluated more often than needed, key "+key )
+         key < 3
+       }
+    }
+  )
+}


### PR DESCRIPTION
The predicate was evaluated repeatedly for every element, even every non-dropped one.

now with test.
