### PR TITLE
Closes SI-5066

### DIFF
--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -269,7 +269,7 @@ object Predef extends LowPriorityImplicits {
   def printf(text: String, xs: Any*) = Console.print(text.format(xs: _*))
 
   def readLine(): String = Console.readLine()
-  def readLine(text: String, args: Any*) = Console.readLine(text, args)
+  def readLine(text: String, args: Any*) = Console.readLine(text, args: _*)
   def readBoolean() = Console.readBoolean()
   def readByte() = Console.readByte()
   def readShort() = Console.readShort()

--- a/test/files/run/Predef.readLine.check
+++ b/test/files/run/Predef.readLine.check
@@ -1,0 +1,3 @@
+prompt
+fancy prompt
+immensely fancy prompt

--- a/test/files/run/Predef.readLine.scala
+++ b/test/files/run/Predef.readLine.scala
@@ -1,0 +1,10 @@
+import java.io.StringReader
+
+object Test extends App {
+  Console.withIn(new StringReader("")) {
+    readLine()
+    readLine("prompt\n")
+    readLine("%s prompt\n", "fancy")
+    readLine("%s %s prompt\n", "immensely", "fancy")
+  }
+}


### PR DESCRIPTION
readLine("%s", "prompt") printed "WrappedArray(prompt)"
readLine("%s%s", "pro", "mpt") threw a MissingFormatArgumentException
