### PR TITLE
Made the binary push script a bit friendlier for humans

### DIFF
--- a/push-binary-libs.sh
+++ b/push-binary-libs.sh
@@ -4,5 +4,10 @@
 
 . $(dirname $0)/tools/binary-repo-lib.sh
 
+if test $# -lt 2; then
+  echo "Usage: $0 <username> <password>"
+  exit 1
+fi
+
 # TODO - Argument parsing for username/password.
 pushJarFiles $(pwd) $1 $2


### PR DESCRIPTION
push script now outputs nice error messages.

pull script now pulls from the `tools/` directory.

Review/use by @paulp
