### PR TITLE
Fixed windows bat file exit code and command chaining (finally)

### DIFF
--- a/src/compiler/scala/tools/ant/templates/tool-windows.tmpl
+++ b/src/compiler/scala/tools/ant/templates/tool-windows.tmpl
@@ -86,4 +86,6 @@ goto :eof
 
 :end
 @@endlocal
-exit /b %errorlevel%
+
+REM exit code fix, see http://stackoverflow.com/questions/4632891/exiting-batch-with-exit-b-x-where-x-1-acts-as-if-command-completed-successfu
+@@%COMSPEC% /C exit %errorlevel% >nul


### PR DESCRIPTION
The problem was, that executing the following command in the windows
shell, always executed scala.bat regardless of the outcome of scalac.bat:

  scalac.bat somefile.scala && scala.bat Test

Apparently exit codes are broken for windows bat files.

Implementing the workaround suggested at
http://stackoverflow.com/questions/4632891/exiting-batch-with-exit-b-x-where-x-1-acts-as-if-command-completed-successfu
fixed the problem. Tested manually in Windows 7 64.
