### PR TITLE
A better REPL context classloader.

### DIFF
--- a/src/compiler/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/ILoop.scala
@@ -110,7 +110,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
   class ILoopInterpreter extends IMain(settings, out) {
     outer =>
 
-    private class ThreadStoppingLineManager extends Line.Manager(parentClassLoader) {
+    private class ThreadStoppingLineManager(classLoader: ClassLoader) extends Line.Manager(classLoader) {
       override def onRunaway(line: Line[_]): Unit = {
         val template = """
           |// She's gone rogue, captain! Have to take her out!
@@ -126,8 +126,8 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     override lazy val formatting = new Formatting {
       def prompt = ILoop.this.prompt
     }
-    override protected def createLineManager(): Line.Manager =
-      new ThreadStoppingLineManager
+    override protected def createLineManager(classLoader: ClassLoader): Line.Manager =
+      new ThreadStoppingLineManager(classLoader)
 
     override protected def parentClassLoader =
       settings.explicitParentLoader.getOrElse( classOf[ILoop].getClassLoader )

--- a/src/compiler/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/IMain.scala
@@ -269,7 +269,7 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
 
   /** Create a line manager.  Overridable.  */
   protected def noLineManager = ReplPropsKludge.noThreadCreation(settings)
-  protected def createLineManager(): Line.Manager = new Line.Manager(_classLoader)
+  protected def createLineManager(classLoader: ClassLoader): Line.Manager = new Line.Manager(classLoader)
 
   /** Instantiate a compiler.  Overridable. */
   protected def newCompiler(settings: Settings, reporter: Reporter) = {
@@ -304,7 +304,7 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
   final def ensureClassLoader() {
     if (_classLoader == null) {
       _classLoader = makeClassLoader()
-      _lineManager = if (noLineManager) null else createLineManager()
+      _lineManager = if (noLineManager) null else createLineManager(_classLoader)
     }
   }
   def classLoader: AbstractFileClassLoader = {

--- a/test/files/run/t5072.check
+++ b/test/files/run/t5072.check
@@ -1,0 +1,14 @@
+Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> 
+
+scala> class C
+defined class C
+
+scala> Thread.currentThread.getContextClassLoader.loadClass(classOf[C].getName)
+res0: Class[_] = class C
+
+scala> 
+
+scala> 

--- a/test/files/run/t5072.scala
+++ b/test/files/run/t5072.scala
@@ -1,0 +1,8 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  def code = """
+class C
+Thread.currentThread.getContextClassLoader.loadClass(classOf[C].getName)
+  """
+}


### PR DESCRIPTION
Previously, when using ThreadStoppingLineManager (ie, not using
-Yrepl-sync), the parent classloader was installed as the thread
context classloader. On my machine, this was null.

Now, the behaviour is consistent with the thread-free line manager,
and allows access to classes defined during the REPL session.

Closes SI-5072
