### PR TITLE
Made partest fully support locker-based distribs

### DIFF
--- a/src/partest/scala/tools/partest/nest/AntRunner.scala
+++ b/src/partest/scala/tools/partest/nest/AntRunner.scala
@@ -20,6 +20,8 @@ class AntRunner extends DirectRunner {
     var JAVAC_CMD: String = "javac"
     var CLASSPATH: String = _
     var LATEST_LIB: String = _
+    var LATEST_COMP: String = _
+    var LATEST_PARTEST: String = _
     val testRootPath: String = "test"
     val testRootDir: Directory = Directory(testRootPath)
   }

--- a/src/partest/scala/tools/partest/nest/CompileManager.scala
+++ b/src/partest/scala/tools/partest/nest/CompileManager.scala
@@ -111,6 +111,7 @@ class DirectCompiler(val fileManager: FileManager) extends SimpleCompiler {
 
     try {
       NestUI.verbose("compiling "+toCompile)
+      NestUI.verbose("with classpath: "+global.classPath.toString)
       try new global.Run compile toCompile
       catch {
         case FatalError(msg) =>

--- a/src/partest/scala/tools/partest/nest/ConsoleFileManager.scala
+++ b/src/partest/scala/tools/partest/nest/ConsoleFileManager.scala
@@ -157,9 +157,13 @@ class ConsoleFileManager extends FileManager {
     }
 
     LATEST_LIB = latestLibFile.getAbsolutePath
+    LATEST_COMP = latestCompFile.getAbsolutePath
+    LATEST_PARTEST = latestPartestFile.getAbsolutePath
   }
 
   var LATEST_LIB: String = ""
+  var LATEST_COMP: String = ""
+  var LATEST_PARTEST: String = ""
 
   var latestFile: File = _
   var latestLibFile: File = _

--- a/src/partest/scala/tools/partest/nest/DirectRunner.scala
+++ b/src/partest/scala/tools/partest/nest/DirectRunner.scala
@@ -52,8 +52,15 @@ trait DirectRunner {
     val kindFiles = onlyValidTestPaths(_kindFiles)
     val groupSize = (kindFiles.length / numActors) + 1
 
-    val consFM = new ConsoleFileManager
-    import consFM.{ latestCompFile, latestLibFile, latestPartestFile }
+    // @partest maintainer: we cannot create a fresh file manager here
+    // since the FM must respect --buildpath and --classpath from the command line
+    // for example, see how it's done in ReflectiveRunner
+    //val consFM = new ConsoleFileManager
+    //import consFM.{ latestCompFile, latestLibFile, latestPartestFile }
+    val latestCompFile = new File(fileManager.LATEST_COMP);
+    val latestLibFile = new File(fileManager.LATEST_LIB);
+    val latestPartestFile = new File(fileManager.LATEST_PARTEST);
+
     val scalacheckURL = PathSettings.scalaCheck.toURL
     val scalaCheckParentClassLoader = ScalaClassLoader.fromURLs(
       List(scalacheckURL, latestCompFile.toURI.toURL, latestLibFile.toURI.toURL, latestPartestFile.toURI.toURL)

--- a/src/partest/scala/tools/partest/nest/FileManager.scala
+++ b/src/partest/scala/tools/partest/nest/FileManager.scala
@@ -60,6 +60,8 @@ trait FileManager extends FileUtil {
 
   var CLASSPATH: String
   var LATEST_LIB: String
+  var LATEST_COMP: String
+  var LATEST_PARTEST: String
 
   var showDiff = false
   var updateCheck = false

--- a/src/partest/scala/tools/partest/nest/SBTRunner.scala
+++ b/src/partest/scala/tools/partest/nest/SBTRunner.scala
@@ -7,16 +7,18 @@ import scala.util.Properties.setProp
 
 
 object SBTRunner extends DirectRunner {
-  
+
   val fileManager = new FileManager {
     var JAVACMD: String        = "java"
     var JAVAC_CMD: String      = "javac"
     var CLASSPATH: String      = _
     var LATEST_LIB: String     = _
+    var LATEST_COMP: String     = _
+    var LATEST_PARTEST: String     = _
     val testRootPath: String   = "test"
     val testRootDir: Directory = Directory(testRootPath)
   }
-  
+
   def reflectiveRunTestsForFiles(kindFiles: Array[File], kind: String):java.util.HashMap[String,Int] = {
     def convert(scalaM:scala.collection.immutable.Map[String,Int]):java.util.HashMap[String,Int] = {
       val javaM = new java.util.HashMap[String,Int]()
@@ -25,9 +27,9 @@ object SBTRunner extends DirectRunner {
     }
 
     def failedOnlyIfRequired(files:List[File]):List[File]={
-      if (fileManager.failed) files filter (x => fileManager.logFileExists(x, kind)) else files 
+      if (fileManager.failed) files filter (x => fileManager.logFileExists(x, kind)) else files
     }
-    convert(runTestsForFiles(failedOnlyIfRequired(kindFiles.toList), kind))    
+    convert(runTestsForFiles(failedOnlyIfRequired(kindFiles.toList), kind))
   }
 
   case class CommandLineOptions(classpath: Option[String] = None,
@@ -38,7 +40,7 @@ object SBTRunner extends DirectRunner {
   def mainReflect(args: Array[String]): java.util.Map[String,Int] = {
     setProp("partest.debug", "true")
     setProperties()
-    
+
     val Argument = new scala.util.matching.Regex("-(.*)")
     def parseArgs(args: Seq[String], data: CommandLineOptions): CommandLineOptions = args match {
       case Seq("--failed", rest @ _*)               => parseArgs(rest, data.copy(justFailedTests = true))
@@ -50,10 +52,14 @@ object SBTRunner extends DirectRunner {
     }
     val config = parseArgs(args, CommandLineOptions())
     fileManager.SCALAC_OPTS = config.scalacOptions
-    fileManager.CLASSPATH = config.classpath getOrElse error("No classpath set")
+    fileManager.CLASSPATH = config.classpath getOrElse sys.error("No classpath set")
     // Find scala library jar file...
     val lib: Option[String] = (fileManager.CLASSPATH split File.pathSeparator filter (_ matches ".*scala-library.*\\.jar")).headOption
-    fileManager.LATEST_LIB = lib getOrElse error("No scala-library found! Classpath = " + fileManager.CLASSPATH)
+    fileManager.LATEST_LIB = lib getOrElse sys.error("No scala-library found! Classpath = " + fileManager.CLASSPATH)
+    val comp: Option[String] = (fileManager.CLASSPATH split File.pathSeparator filter (_ matches ".*scala-compiler.*\\.jar")).headOption
+    fileManager.LATEST_COMP = comp getOrElse sys.error("No scala-compiler found! Classpath = " + fileManager.CLASSPATH)
+    val partest: Option[String] = (fileManager.CLASSPATH split File.pathSeparator filter (_ matches ".*scala-partest.*\\.jar")).headOption
+    fileManager.LATEST_PARTEST = partest getOrElse sys.error("No scala-partest found! Classpath = " + fileManager.CLASSPATH)
     // TODO - Do something useful here!!!
     fileManager.JAVAC_CMD = "javac"
     fileManager.failed      = config.justFailedTests
@@ -63,7 +69,7 @@ object SBTRunner extends DirectRunner {
     val runs = config.tests.filterNot(_._2.isEmpty)
     // This next bit uses java maps...
     import collection.JavaConverters._
-    (for { 
+    (for {
      (testType, files) <- runs
      (path, result) <- reflectiveRunTestsForFiles(files,testType).asScala
     } yield (path, result)).seq asJava
@@ -80,4 +86,3 @@ object SBTRunner extends DirectRunner {
     if(!failures.isEmpty) sys.exit(1)
   }
 }
-

--- a/src/partest/scala/tools/partest/nest/TestFile.scala
+++ b/src/partest/scala/tools/partest/nest/TestFile.scala
@@ -12,6 +12,7 @@ import java.io.{ File => JFile }
 import scala.tools.nsc.Settings
 import scala.tools.nsc.util.ClassPath
 import scala.tools.nsc.io._
+import scala.util.Properties.{ propIsSet, propOrElse, setProp }
 
 trait TestFileCommon {
   def file: JFile
@@ -61,6 +62,10 @@ case class SpecializedTestFile(file: JFile, fileManager: FileManager) extends Te
     super.defineSettings(settings, setOutDir) && {
       // add the instrumented library version to classpath
       settings.classpath prepend PathSettings.srcSpecLib.toString
+      // @partest maintainer: if we use a custom Scala build (specified via --classpath)
+      // then the classes provided by it will come earlier than instrumented.jar in the resulting classpath
+      // this entire classpath business needs a thorough solution
+      if (propIsSet("java.class.path")) setProp("java.class.path", PathSettings.srcSpecLib.toString + ";" + propOrElse("java.class.path", ""))
       true
     }
   }

--- a/src/partest/scala/tools/partest/nest/Worker.scala
+++ b/src/partest/scala/tools/partest/nest/Worker.scala
@@ -53,6 +53,8 @@ class ScalaCheckFileManager(val origmanager: FileManager) extends FileManager {
 
   var CLASSPATH: String = join(origmanager.CLASSPATH, PathSettings.scalaCheck.path)
   var LATEST_LIB: String = origmanager.LATEST_LIB
+  var LATEST_COMP: String = origmanager.LATEST_COMP
+  var LATEST_PARTEST: String = origmanager.LATEST_PARTEST
 }
 
 object Output {


### PR DESCRIPTION
This patch brings support for specialized and scalacheck tests,
and finally makes it possible to run partest for locker.

To do that, you need to write your own partest script: http://bit.ly/wl9HaH,
and keep another clone of your repository that would provide the classes
for running partest. That clone should then be build normally (ant build),
and be used to transplant the stuff that isn't built by locker, namely:
partest, actors, scalacheck, forkjoin, fjbg, msil and jline.
For more information take a look at my scavenger: http://bit.ly/AjMiud.
