### PR TITLE
Fix for SI-5374.

### DIFF
--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -316,28 +316,7 @@ final case class ::[B](private var hd: B, private[scala] var tl: List[B]) extend
   override def tail : List[B] = tl
   override def isEmpty: Boolean = false
 
-  import java.io._
 
-  private def writeObject(out: ObjectOutputStream) {
-    var xs: List[B] = this
-    while (!xs.isEmpty) { out.writeObject(xs.head); xs = xs.tail }
-    out.writeObject(ListSerializeEnd)
-  }
-
-  private def readObject(in: ObjectInputStream) {
-    hd = in.readObject.asInstanceOf[B]
-    assert(hd != ListSerializeEnd)
-    var current: ::[B] = this
-    while (true) in.readObject match {
-      case ListSerializeEnd =>
-        current.tl = Nil
-        return
-      case a : Any =>
-        val list : ::[B] = new ::(a.asInstanceOf[B], Nil)
-        current.tl = list
-        current = list
-    }
-  }
 }
 
 /** $factoryInfo

--- a/test/files/run/si5374.check
+++ b/test/files/run/si5374.check
@@ -1,0 +1,3 @@
+ListBuffer(1, 2, 3, 1)
+ListBuffer(1, 2, 3, 1)
+ListBuffer()

--- a/test/files/run/si5374.scala
+++ b/test/files/run/si5374.scala
@@ -1,0 +1,42 @@
+
+
+
+import collection.mutable.ListBuffer
+import java.io._
+
+
+
+object Test {
+  
+  def main(args: Array[String]) {
+    ticketExample()
+    emptyListBuffer()
+  }
+  
+  def ticketExample() {
+    val baos = new ByteArrayOutputStream
+    val oos = new ObjectOutputStream(baos)
+    oos.writeObject( ListBuffer(1,2,3) )
+    val bais = new ByteArrayInputStream( baos.toByteArray )
+    val ois = new ObjectInputStream(bais)
+    val lb = ois.readObject.asInstanceOf[ListBuffer[Int]]
+    val lb2 = ListBuffer[Int]() ++= lb
+    
+    lb2 ++= List(1)
+    lb ++= List(1)
+    println(lb)
+    println(lb2)
+  }
+  
+  def emptyListBuffer() {
+    val baos = new ByteArrayOutputStream
+    val oos = new ObjectOutputStream(baos)
+    oos.writeObject( ListBuffer() )
+    val bais = new ByteArrayInputStream( baos.toByteArray )
+    val ois = new ObjectInputStream(bais)
+    val lb = ois.readObject.asInstanceOf[ListBuffer[Int]]
+    
+    println(lb)
+  }
+  
+}


### PR DESCRIPTION
Lists are now serialized so that the entire list structure is serialized, including list nodes.
This is different from the previous behaviour where only the elements were serialized.
List buffers are now optimized so that only the elements of the list are serialized, and
not the nodes of the internally maintained list.
