### PR TITLE
Scalac fork no longer dumps stacktraces on compilation errors

### DIFF
--- a/src/compiler/scala/tools/ant/sabbus/ScalacFork.scala
+++ b/src/compiler/scala/tools/ant/sabbus/ScalacFork.scala
@@ -13,6 +13,7 @@ import java.io.{ File, FileWriter }
 import org.apache.tools.ant.Project
 import org.apache.tools.ant.taskdefs.Java
 import org.apache.tools.ant.util.{ GlobPatternMapper, SourceFileScanner }
+import org.apache.tools.ant.BuildException
 import scala.tools.nsc.io
 import scala.tools.nsc.util.ScalaClassLoader
 
@@ -150,7 +151,7 @@ class ScalacFork extends ScalaMatchingTask with ScalacShared with TaskArgs {
     val res = execWithArgFiles(java, paths)
 
     if (failOnError && res != 0)
-      sys.error("Compilation failed because of an internal compiler error;"+
+      throw new BuildException("Compilation failed because of an internal compiler error;"+
             " see the error output for details.")
   }
 }


### PR DESCRIPTION
Current behavior of scalacfork task is to fail the build when there are
compilation errors reported by scalac fork. So far, so good.

However, this functionality is implemented by throwing sys.error, which
makes ant dump the entire stacktrace. This is annoying, since it almost
certainly scrolls the screen away of the error (hello, dear 1366x768)
and buries it under a meaningless stacktrace.

Surprisingly, there is a very simple fix that remedies the situation.
Credit goes to @bakoyaro from SO: http://bit.ly/xdR306
