### PR TITLE
SI-5045 Regex.unapplySeq should use m.find(0) instead of m.matches

### DIFF
--- a/src/library/scala/collection/immutable/StringLike.scala
+++ b/src/library/scala/collection/immutable/StringLike.scala
@@ -12,6 +12,7 @@ package immutable
 import generic._
 import mutable.Builder
 import scala.util.matching.Regex
+import scala.util.matching.NoImplicitAnchors
 import scala.math.ScalaNumber
 
 /** A companion object for the `StringLike` containing some constants.
@@ -210,6 +211,12 @@ self =>
    *  """A\w*""".r   is the regular expression for identifiers starting with `A`.
    */
   def r: Regex = new Regex(toString)
+
+  /** You can follow a string with `.qr`, turning it into a `Regex with NoImplictAnchors`. E.g.
+   *
+   *  """A\w*""".qr   is the regular expression for extracting identifiers starting with `A`.
+   */
+  def qr: Regex with NoImplicitAnchors = new Regex(toString) with NoImplicitAnchors
 
   def toBoolean: Boolean = parseBoolean(toString)
   def toByte: Byte       = java.lang.Byte.parseByte(toString)

--- a/src/library/scala/util/matching/Regex.scala
+++ b/src/library/scala/util/matching/Regex.scala
@@ -341,6 +341,46 @@ class Regex(regex: String, groupNames: String*) extends Serializable {
   override def toString = regex
 }
 
+/** This trait turns off the implicit anchoring semantics of Regex
+ *  in match/case.
+ *
+ *  The canonical way of adding in this trait is by using the method `qr`, provided
+ *  on [[java.lang.String]] through an implicit conversion into
+ *  [[scala.collection.immutable.WrappedString]]. Using triple quotes to write these
+ *  strings avoids having to quote the backslash character (`\`).
+ *
+ *  This changes the basic behavior so the following work
+ *
+ *  {{{
+ *  val dateP1 = """(\d\d\d\d)-(\d\d)-(\d\d)""".qr
+ *
+ *  val dateP1(year, month, day) = "Date 2011-07-15"
+ *
+ *  val copyright: String = "Date of this document: 2011-07-15" match {
+ *    case dateP1(year, month, day) => "Copyright "+year
+ *    case _                        => "No copyright"
+ *  }
+ *  }}}
+ *
+ */
+trait NoImplicitAnchors {
+
+  self: scala.util.matching.Regex =>
+
+  import Regex.Match
+
+  override def unapplySeq(target: Any): Option[List[String]] = target match {
+    case s: java.lang.CharSequence =>
+      val m = pattern.matcher(s)
+      if (m.find(0)) Some((1 to m.groupCount).toList map m.group)
+      else None
+    case Match(s) =>
+      unapplySeq(s)
+    case _ =>
+      None
+  }
+}
+
 /** This object defines inner classes that describe
  *  regex matches and helper objects. The class hierarchy
  *  is as follows:

--- a/test/files/run/si5045.scala
+++ b/test/files/run/si5045.scala
@@ -1,0 +1,40 @@
+object Test {
+
+ import scala.util.matching.{Regex, NoImplicitAnchors}
+
+ val dateP1  = """(\d\d\d\d)-(\d\d)-(\d\d)""".qr
+ val dateP2 = new scala.util.matching.Regex("""(\d\d\d\d)-(\d\d)-(\d\d)""", "year", "month", "day") with NoImplicitAnchors
+
+ val yearStr = "2011"
+ val dateStr = List(yearStr,"07","15").mkString("-")
+
+  def test(msg: String)(body: => Boolean): Unit = assert(body, msg)
+
+  test("extract an exact match") {
+    val dateP1(y,m,d) = dateStr
+    List(y,m,d).mkString("-") == dateStr
+  }
+
+  test("extract from middle of string") {
+    val dateP1(y,m,d) = "Tested on "+dateStr+"."
+    List(y,m,d).mkString("-") == dateStr
+  }
+
+  def copyright(in: String): String = in match {
+    case dateP1(year, month, day) => "Copyright "+year
+    case _                        => "No copyright"
+  }
+
+  test("copyright example has date") {
+    copyright("Date of this document: "+dateStr) == "Copyright "+yearStr
+  }
+
+  test("copyright example missing date") {
+    copyright("Date of this document: unknown") == "No copyright"
+  }
+
+  test("extract from middle of string (P2)") {
+    val dateP2(y,m,d) = "Tested on "+dateStr+"."
+    List(y,m,d).mkString("-") == dateStr
+  }
+}


### PR DESCRIPTION
First pull request was lost going from svn to github however there were concerns about changing existing behavior.

This pull request adds a trait to turn off the implicit matching behavior which can be added explicitly during instantiation or through a .qr method in StringLike.  An added benefit of this approach is having the type system keep straight which style of Regex is being used.
