### PR TITLE
Wip fix 2.9 stability

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1118,7 +1118,8 @@ BOOTSTRAPPING BUILD (STRAP)
         <include name="**/*.properties"/>
         <include name="**/*.swf"/>
         <include name="**/*.png"/>
-        <include name="**/*.gif"/>        
+        <include name="**/*.gif"/>   
+        <include name="**/*.txt"/>     
        </fileset>
     </copy>
     <touch file="${build-strap.dir}/compiler.complete" verbose="no"/>


### PR DESCRIPTION
Fixes the stability testing issues with 2.9.x.  One line was not copied correctly into STRAPP's build.

Review by @paulp, @dcsobral
