### PR TITLE
Refine fix for SI-5374 - make list deserialization backward-compatible.

### DIFF
--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -14,6 +14,7 @@ package immutable
 import generic._
 import mutable.{Builder, ListBuffer}
 import annotation.tailrec
+import java.io._
 
 /** A class for immutable linked lists representing ordered collections
  *  of elements of type.
@@ -315,8 +316,46 @@ final case class ::[B](private var hd: B, private[scala] var tl: List[B]) extend
   override def head : B = hd
   override def tail : List[B] = tl
   override def isEmpty: Boolean = false
-
-
+  
+  private def writeObject(out: ObjectOutputStream) {
+    out.writeObject(ListSerializeStart) // needed to differentiate with the legacy `::` serialization
+    out.writeObject(this.hd)
+    out.writeObject(this.tl)
+  }
+  
+  private def readObject(in: ObjectInputStream) {
+    val obj = in.readObject()
+    if (obj == ListSerializeStart) {
+      this.hd = in.readObject().asInstanceOf[B]
+      this.tl = in.readObject().asInstanceOf[List[B]]
+    } else oldReadObject(in, obj)
+  }
+  
+  /* The oldReadObject method exists here for compatibility reasons.
+   * :: objects used to be serialized by serializing all the elements to
+   * the output stream directly, but this was broken (see SI-5374).
+   */
+  private def oldReadObject(in: ObjectInputStream, firstObject: AnyRef) {
+    hd = firstObject.asInstanceOf[B]
+    assert(hd != ListSerializeEnd)
+    var current: ::[B] = this
+    while (true) in.readObject match {
+      case ListSerializeEnd =>
+        current.tl = Nil
+        return
+      case a : Any =>
+        val list : ::[B] = new ::(a.asInstanceOf[B], Nil)
+        current.tl = list
+        current = list
+    }
+  }
+  
+  private def oldWriteObject(out: ObjectOutputStream) {
+    var xs: List[B] = this
+    while (!xs.isEmpty) { out.writeObject(xs.head); xs = xs.tail }
+    out.writeObject(ListSerializeEnd)
+  }
+  
 }
 
 /** $factoryInfo
@@ -582,4 +621,9 @@ object List extends SeqFactory[List] {
 
 /** Only used for list serialization */
 @SerialVersionUID(0L - 8476791151975527571L)
+private[scala] case object ListSerializeStart
+
+/** Only used for list serialization */
+@SerialVersionUID(0L - 8476791151975527571L)
 private[scala] case object ListSerializeEnd
+

--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -41,7 +41,7 @@ import java.io._
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  */
-@SerialVersionUID(3419063961353022661L)
+@SerialVersionUID(3419063961353022662L)
 final class ListBuffer[A]
       extends AbstractBuffer[A]
          with Buffer[A]
@@ -399,7 +399,7 @@ final class ListBuffer[A]
   private def copy() {
     var cursor = start
     val limit = last0.tail
-    clear
+    clear()
     while (cursor ne limit) {
       this += cursor.head
       cursor = cursor.tail

--- a/test/files/run/si5374.check
+++ b/test/files/run/si5374.check
@@ -1,3 +1,6 @@
 ListBuffer(1, 2, 3, 1)
 ListBuffer(1, 2, 3, 1)
 ListBuffer()
+List(1, 2, 3, 4, 5)
+List(1, 2, 3)
+ok

--- a/test/files/run/si5374.scala
+++ b/test/files/run/si5374.scala
@@ -11,15 +11,22 @@ object Test {
   def main(args: Array[String]) {
     ticketExample()
     emptyListBuffer()
+    list()
+    legacyList()
+    objectWithMultipleLists()
+  }
+  
+  def inAndOut[T <: AnyRef](obj: T): T = {
+    val baos = new ByteArrayOutputStream
+    val oos = new ObjectOutputStream(baos)
+    oos.writeObject( obj )
+    val bais = new ByteArrayInputStream( baos.toByteArray )
+    val ois = new ObjectInputStream(bais)
+    ois.readObject.asInstanceOf[T]
   }
   
   def ticketExample() {
-    val baos = new ByteArrayOutputStream
-    val oos = new ObjectOutputStream(baos)
-    oos.writeObject( ListBuffer(1,2,3) )
-    val bais = new ByteArrayInputStream( baos.toByteArray )
-    val ois = new ObjectInputStream(bais)
-    val lb = ois.readObject.asInstanceOf[ListBuffer[Int]]
+    val lb = inAndOut(ListBuffer(1, 2, 3))
     val lb2 = ListBuffer[Int]() ++= lb
     
     lb2 ++= List(1)
@@ -29,14 +36,41 @@ object Test {
   }
   
   def emptyListBuffer() {
-    val baos = new ByteArrayOutputStream
-    val oos = new ObjectOutputStream(baos)
-    oos.writeObject( ListBuffer() )
-    val bais = new ByteArrayInputStream( baos.toByteArray )
-    val ois = new ObjectInputStream(bais)
-    val lb = ois.readObject.asInstanceOf[ListBuffer[Int]]
+    val lb = inAndOut(ListBuffer[Int]())
     
     println(lb)
+  }
+  
+  def list() {
+    val l = inAndOut(List(1, 2, 3, 4, 5))
+    
+    println(l)
+  }
+  
+  // this byte array corresponds to what List(1, 2, 3) used to be serialized to prior to this fix
+  val listBytes = Array[Byte](-84, -19, 0, 5, 115, 114, 0, 39, 115, 99, 97, 108, 97, 46, 99, 111, 108, 108, 101, 99, 116, 105, 111, 110, 46, 105, 109, 109, 117, 116, 97, 98, 108, 101, 46, 36, 99, 111, 108, 111, 110, 36, 99, 111, 108, 111, 110, -118, 92, 99, 91, -10, -40, -7, 109, 3, 0, 2, 76, 0, 43, 115, 99, 97, 108, 97, 36, 99, 111, 108, 108, 101, 99, 116, 105, 111, 110, 36, 105, 109, 109, 117, 116, 97, 98, 108, 101, 36, 36, 99, 111, 108, 111, 110, 36, 99, 111, 108, 111, 110, 36, 36, 104, 100, 116, 0, 18, 76, 106, 97, 118, 97, 47, 108, 97, 110, 103, 47, 79, 98, 106, 101, 99, 116, 59, 76, 0, 2, 116, 108, 116, 0, 33, 76, 115, 99, 97, 108, 97, 47, 99, 111, 108, 108, 101, 99, 116, 105, 111, 110, 47, 105, 109, 109, 117, 116, 97, 98, 108, 101, 47, 76, 105, 115, 116, 59, 120, 112, 115, 114, 0, 17, 106, 97, 118, 97, 46, 108, 97, 110, 103, 46, 73, 110, 116, 101, 103, 101, 114, 18, -30, -96, -92, -9, -127, -121, 56, 2, 0, 1, 73, 0, 5, 118, 97, 108, 117, 101, 120, 114, 0, 16, 106, 97, 118, 97, 46, 108, 97, 110, 103, 46, 78, 117, 109, 98, 101, 114, -122, -84, -107, 29, 11, -108, -32, -117, 2, 0, 0, 120, 112, 0, 0, 0, 1, 115, 113, 0, 126, 0, 4, 0, 0, 0, 2, 115, 113, 0, 126, 0, 4, 0, 0, 0, 3, 115, 114, 0, 44, 115, 99, 97, 108, 97, 46, 99, 111, 108, 108, 101, 99, 116, 105, 111, 110, 46, 105, 109, 109, 117, 116, 97, 98, 108, 101, 46, 76, 105, 115, 116, 83, 101, 114, 105, 97, 108, 105, 122, 101, 69, 110, 100, 36, -118, 92, 99, 91, -9, 83, 11, 109, 2, 0, 0, 120, 112, 120)
+  
+  def legacyList() {
+    val bais = new ByteArrayInputStream(listBytes)
+    val ois = new ObjectInputStream(bais)
+    val l = ois.readObject()
+    
+    println(l)
+  }
+  
+  class Foo extends Serializable {
+    val head = List(1, 2, 3)
+    val last = head.tail.tail
+    def structuralSharing: Boolean = head.tail.tail eq last
+    
+    assert(structuralSharing)
+  }
+  
+  def objectWithMultipleLists() {
+    val foo = inAndOut(new Foo)
+    
+    if (foo.structuralSharing) println("ok")
+    else println("no structural sharing")
   }
   
 }


### PR DESCRIPTION
This is done by structurally serializing list nodes, but prepending a special
`ListSerializationStart` symbol ahead of the list. If this symbol is not
in the object input stream, the deserialization reverts to the old mode.

Note there is not much to be done for list buffers - their serialization was
broken before, so legacy serialized list buffers are no longer deserializable.
However, their serialVersionUID was changed to reflect this, so deserializing
a legacy list buffer should fail fast.
