### PR TITLE
Introduce getAnnotations that triggers symbol completion

### DIFF
--- a/src/compiler/scala/reflect/internal/Symbols.scala
+++ b/src/compiler/scala/reflect/internal/Symbols.scala
@@ -1272,6 +1272,16 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
      *  the annotations attached to member a definition (class, method, type, field).
      */
     def annotations: List[AnnotationInfo] = _annotations
+
+    /** This getter is necessary for reflection, see https://issues.scala-lang.org/browse/SI-5423
+     *  We could auto-inject completion into `annotations' and `setAnnotations', but I'm not sure about that
+     *  @odersky writes: I fear we can't do the forcing for all compiler symbols as that could introduce cycles
+     */
+    def getAnnotations: List[AnnotationInfo] = {
+      initialize
+      _annotations
+    }
+
     def setAnnotations(annots: List[AnnotationInfo]): this.type = {
       _annotations = annots
       this

--- a/src/library/scala/reflect/api/Symbols.scala
+++ b/src/library/scala/reflect/api/Symbols.scala
@@ -79,7 +79,7 @@ trait Symbols { self: Universe =>
 
     /** A list of annotations attached to this Symbol.
      */
-    def annotations: List[self.AnnotationInfo]
+    def getAnnotations: List[self.AnnotationInfo]
 
     /** For a class: the module or case class factory with the same name in the same package.
      *  For all others: NoSymbol

--- a/test/files/run/t5423.check
+++ b/test/files/run/t5423.check
@@ -1,0 +1,1 @@
+List(table)

--- a/test/files/run/t5423.scala
+++ b/test/files/run/t5423.scala
@@ -1,0 +1,12 @@
+import java.lang.Class
+import scala.reflect.mirror._
+import scala.reflect.runtime.Mirror.ToolBox
+import scala.reflect.Code
+
+final class table extends StaticAnnotation
+@table class A
+
+object Test extends App{
+  val s = classToSymbol(classOf[A])
+  println(s.getAnnotations)
+}


### PR DESCRIPTION
Default getter for annotations doesn't perform initialization, hence
we've faced the following bug: https://issues.scala-lang.org/browse/SI-5423.

One of the approaches to fixing it would be to auto-complete on getter,
but according to Martin we'd better not do that because of cycles.

That's why I'm just introducing a new, eager, variation of `annotations'
and redirecting public API to it.
