### PR TITLE
Yvirtpatmat switch improvements

### DIFF
--- a/lib/fjbg.jar.desired.sha1
+++ b/lib/fjbg.jar.desired.sha1
@@ -1,1 +1,1 @@
-9aa9c99b8032e454f1f85d27de31a88b3dec1045 ?fjbg.jar
+c3f9b576c91cb9761932ad936ccc4a71f33d2ef2 ?fjbg.jar

--- a/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
@@ -1072,6 +1072,15 @@ abstract class GenICode extends SubComponent  {
                 targets = tmpCtx.bb :: targets
               case Ident(nme.WILDCARD) =>
                 default = tmpCtx.bb
+              case Alternative(alts) =>
+                alts foreach {
+                  case Literal(value) =>
+                    tags = value.intValue :: tags
+                    targets = tmpCtx.bb :: targets
+                  case _ =>
+                    abort("Invalid case in alternative in switch-like pattern match: " +
+                          tree + " at: " + tree.pos)
+                }
               case _ =>
                 abort("Invalid case statement in switch-like pattern match: " +
                       tree + " at: " + (tree.pos))

--- a/src/compiler/scala/tools/nsc/typechecker/PatMatVirtualiser.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatMatVirtualiser.scala
@@ -1128,9 +1128,21 @@ defined class Foo */
     //   }
     // }
 
+    private val switchableTpes = Set(ByteClass.tpe, ShortClass.tpe, IntClass.tpe, CharClass.tpe)
+
     def emitSwitch(scrut: Tree, scrutSym: Symbol, cases: List[List[TreeMaker]], pt: Type): Option[Tree] = if (!optimizingCodeGen) None else {
       def sequence[T](xs: List[Option[T]]): Option[List[T]] =
         if (xs exists (_.isEmpty)) None else Some(xs.flatten)
+
+      def isSwitchableTpe(tpe: Type): Boolean =
+        switchableTpes contains tpe
+      def switchableConstToInt(x: Tree): Tree = {
+        val Literal(const) = x
+        const.tag match {
+          case IntTag => x
+          case ByteTag | ShortTag | CharTag => Literal(Constant(const.intValue))
+        }
+      }
 
       val caseDefs = cases map { makers =>
         removeSubstOnly(makers) match {
@@ -1139,12 +1151,12 @@ defined class Foo */
             Some(CaseDef(Ident(nme.WILDCARD), EmptyTree, btm.substitution(body)))
           // constant
           case (EqualityTestTreeMaker(_, const@SwitchablePattern(), _)) :: (btm@BodyTreeMaker(body, _)) :: Nil =>
-            Some(CaseDef(const, EmptyTree, btm.substitution(body)))
+            Some(CaseDef(switchableConstToInt(const), EmptyTree, btm.substitution(body)))
           // alternatives
           case AlternativesTreeMaker(_, altss, _) :: (btm@BodyTreeMaker(body, _)) :: Nil => // assert(currLabel.isEmpty && nextLabel.isEmpty)
             val caseConstants = altss map {
               case EqualityTestTreeMaker(_, const@SwitchablePattern(), _) :: Nil =>
-                Some(const)
+                Some(switchableConstToInt(const))
               case _ =>
                 None
             }
@@ -1158,27 +1170,35 @@ defined class Foo */
         }
       }
 
-      sequence(caseDefs) map { caseDefs =>
-        import CODE._
-        val caseDefsWithDefault = {
-          def isDefault(x: CaseDef): Boolean = x match { 
-            case CaseDef(Ident(nme.WILDCARD), EmptyTree, _) => true
-            case _ => false
+      if (!isSwitchableTpe(scrut.tpe))
+        None
+      else {
+        sequence(caseDefs) map { caseDefs =>
+          import CODE._
+          val caseDefsWithDefault = {
+            def isDefault(x: CaseDef): Boolean = x match {
+              case CaseDef(Ident(nme.WILDCARD), EmptyTree, _) => true
+              case _ => false
+            }
+            val hasDefault = caseDefs exists isDefault
+            if (hasDefault) caseDefs else {
+              val default = atPos(scrut.pos) { DEFAULT ==> MATCHERROR(REF(scrutSym)) }
+              caseDefs :+ default
+            }
           }
-          val hasDefault = caseDefs exists isDefault
-          if (hasDefault) caseDefs else {
-            val default = atPos(scrut.pos) { DEFAULT ==> MATCHERROR(REF(scrutSym)) }
-            caseDefs :+ default
-          }
+          val matcher = BLOCK(
+            if (scrut.tpe != IntClass.tpe) {
+              scrutSym setInfo IntClass.tpe
+              VAL(scrutSym) === (scrut DOT nme.toInt)
+            } else {
+              VAL(scrutSym) === scrut
+            },
+            Match(REF(scrutSym), caseDefsWithDefault) // match on scrutSym, not scrut to avoid duplicating scrut
+          )
+          // matcher filter (tree => tree.tpe == null) foreach println
+          // treeBrowser browse matcher
+          matcher // set type to avoid recursion in typedMatch
         }
-        val matcher = BLOCK(
-          VAL(scrutSym) === scrut, // TODO: type test for switchable type if patterns allow switch but the scrutinee doesn't
-          Match(REF(scrutSym), caseDefsWithDefault) // match on scrutSym, not scrut to avoid duplicating scrut
-        )
-
-        // matcher filter (tree => tree.tpe == null) foreach println
-        // treeBrowser browse matcher
-        matcher // set type to avoid recursion in typedMatch
       }
     }
 

--- a/src/compiler/scala/tools/nsc/typechecker/PatMatVirtualiser.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatMatVirtualiser.scala
@@ -1138,7 +1138,7 @@ defined class Foo */
           case (btm@BodyTreeMaker(body, _)) :: Nil =>
             Some(CaseDef(Ident(nme.WILDCARD), EmptyTree, btm.substitution(body)))
           // constant
-          case (EqualityTestTreeMaker(_, const@SwitchablePattern(), _)) :: (btm@BodyTreeMaker(body, _)) :: Nil => import CODE._
+          case (EqualityTestTreeMaker(_, const@SwitchablePattern(), _)) :: (btm@BodyTreeMaker(body, _)) :: Nil =>
             Some(CaseDef(const, EmptyTree, btm.substitution(body)))
           // alternatives
           case AlternativesTreeMaker(_, altss, _) :: (btm@BodyTreeMaker(body, _)) :: Nil => // assert(currLabel.isEmpty && nextLabel.isEmpty)

--- a/src/fjbg/ch/epfl/lamp/fjbg/JExtendedCode.java
+++ b/src/fjbg/ch/epfl/lamp/fjbg/JExtendedCode.java
@@ -596,6 +596,16 @@ public class JExtendedCode extends JCode {
                            double minDensity) {
         assert keys.length == branches.length;
 
+        //The special case for empty keys. It makes sense to allow
+        //empty keys and generate LOOKUPSWITCH with defaultBranch
+        //only. This is exactly what javac does for switch statement
+        //that has only a default case.
+        if (keys.length == 0) {
+          emitLOOKUPSWITCH(keys, branches, defaultBranch);
+          return;
+        }
+        //the rest of the code assumes that keys.length > 0
+
         // sorting the tables
         // FIXME use quicksort
         for (int i = 1; i < keys.length; i++) {

--- a/test/files/run/virtpatmat_switch.check
+++ b/test/files/run/virtpatmat_switch.check
@@ -1,0 +1,7 @@
+zero
+one
+many
+got a
+got b
+got some letter
+scala.MatchError: 5 (of class java.lang.Integer)

--- a/test/files/run/virtpatmat_switch.flags
+++ b/test/files/run/virtpatmat_switch.flags
@@ -1,0 +1,1 @@
+ -Yvirtpatmat -Xexperimental

--- a/test/files/run/virtpatmat_switch.scala
+++ b/test/files/run/virtpatmat_switch.scala
@@ -1,0 +1,32 @@
+object Test extends App {
+  def intSwitch(x: Int) = x match {
+    case 0 => "zero"
+    case 1 => "one"
+    case _ => "many"
+  }
+  
+  println(intSwitch(0))
+  println(intSwitch(1))
+  println(intSwitch(10))
+  
+  def charSwitch(x: Char) = x match {
+    case 'a' => "got a"
+    case 'b' => "got b"
+    case _ => "got some letter"
+  }
+  
+  println(charSwitch('a'))
+  println(charSwitch('b'))
+  println(charSwitch('z'))
+  
+  def implicitDefault(x: Int) = x match {
+    case 0 => 0
+  }
+  
+  try {
+    implicitDefault(5)
+  } catch {
+    case e: MatchError => println(e)
+  }
+
+}


### PR DESCRIPTION
Summary: some further improvements to how Yvirtpatmat handles patterns that can be translated to switch tables. Fixed bug in fjbg on the way.

Check out individual commits for details.
