### PR TITLE
Fix 2.9.2 scaladoc replacing nightlies in jenkins

### DIFF
--- a/tools/epfl-publish
+++ b/tools/epfl-publish
@@ -25,8 +25,8 @@ else
   echo "Publishing nightly build to $publish_to"
   # Archive Scala nightly distribution
   rsync -az dists/archives/ "$publish_to/distributions"
-  # don't publish docs in 2.8.x
-  [[ $version == "2.8.x" ]] || rsync -az build/scaladoc/ "$publish_to/docs"
+  # only publish scaladoc nightly for trunk
+  [[ $version == "master" ]] && rsync -az build/scaladoc/ "$publish_to/docs"
   # sbaz
   [[ -d dists/sbaz ]] && rsync -az dists/sbaz/ "$publish_to/sbaz"
 fi


### PR DESCRIPTION
This fixes the problem raised by Simon and Daniel in https://groups.google.com/group/scala-internals/browse_thread/thread/c2df2234943cba27 by only publishing the nightly docs if the version given in jenkins equals "master" (the trunk build)
