### PR TITLE
read build.number for maven.deploy (version.* properties)

### DIFF
--- a/src/build/pack.xml
+++ b/src/build/pack.xml
@@ -284,6 +284,9 @@ MAIN DISTRIBUTION SBAZ
           file="${lib-ant.dir}/maven-ant-tasks-2.1.1.jar"/>
     <copy tofile="${dists.dir}/maven/${version.number}/build.xml"
           file="${src.dir}/build/maven/maven-deploy.xml"/>
+    <!-- read version number from build.number file; TODO: parse git.describe output from build.xml -->
+    <property file="${basedir}/build.number"/>
+
     <!-- export properties for use when deploying -->
     <property name="maven.snapshot.version.number"
               value="${version.major}.${version.minor}.${version.patch}-SNAPSHOT"/>


### PR DESCRIPTION
the nightly deployment of maven snapshots was broken by fbd5efe4
(and not fixed by 58ab20ba)

this gets us a dx away from the previous local minimum,
but a proper fix should parse the output of git.describe and put it in
version.major, version.minor, version.patch and ...
... version.suffix (though this property is ignored by the build script)

with this commit, these properties are again read from build.number,
which thus needs to be kept in sync with the git tag
