### PR TITLE
Remove alphanumeric characters from the major part of the Scala version ...

### DIFF
--- a/tools/get-scala-revision
+++ b/tools/get-scala-revision
@@ -37,5 +37,8 @@ suffix="${described##${tag}-}"
 counter=$(echo $suffix | cut -d - -f 1)
 hash=$(echo $suffix | cut -d - -f 2)
 
-# v2.10.0-M1-0098-g6f1c486d0b-2012-02-01
+# remove any alphabetic characters before the version number
+tag=$(echo $tag | sed "s/\([a-z_A-Z]*\)\(.*\)/\2/")
+
+# 2.10.0-M1-0098-g6f1c486d0b-2012-02-01
 printf "%s-%04d-%s-%s\n" "$tag" "$counter" "$hash" $(date "+%Y-%m-%d")


### PR DESCRIPTION
...number.

In practice, this removes the 'v' in v2.10.0-M1-0168-g99844ebc10-2012-02-08. Why is this important, you ask? 
Many tools assume the version number to be composed of 3 numbers and a string qualifier. Eclipse is one of the 
tools that validates version numbers, and this string is used to stamp Scala IDE builds against Scala nightlies.
