### PR TITLE
Fixes https://issues.scala-lang.org/browse/SI-5451

### DIFF
--- a/src/compiler/scala/reflect/internal/StdNames.scala
+++ b/src/compiler/scala/reflect/internal/StdNames.scala
@@ -153,6 +153,9 @@ trait StdNames extends NameManglers { self: SymbolTable =>
     final val ClassfileAnnotation: NameType = "ClassfileAnnotation"
     final val Enum: NameType                = "Enum"
 
+    final val Tree: NameType             = "Tree"
+    final val TypeTree: NameType         = "TypeTree"
+
     // Annotation simple names, used in Namer
     final val BeanPropertyAnnot: NameType = "BeanProperty"
     final val BooleanBeanPropertyAnnot: NameType = "BooleanBeanProperty"
@@ -304,8 +307,6 @@ trait StdNames extends NameManglers { self: SymbolTable =>
     val classOf: NameType              = "classOf"
     val clone_ : NameType              = if (forMSIL) "MemberwiseClone" else "clone" // sn.OClone causes checkinit failure
     val conforms: NameType             = "conforms"
-    val context : NameType             = "_context"
-    val contextImplicit : NameType     = "$context"
     val copy: NameType                 = "copy"
     val delayedInit: NameType          = "delayedInit"
     val delayedInitArg: NameType       = "delayedInit$body"
@@ -346,6 +347,8 @@ trait StdNames extends NameManglers { self: SymbolTable =>
     val lengthCompare: NameType        = "lengthCompare"
     val lift_ : NameType               = "lift"
     val macro_ : NameType              = "macro"
+    val macroThis : NameType           = "_this"
+    val macroContext : NameType        = "_context"
     val main: NameType                 = "main"
     val map: NameType                  = "map"
     val mirror : NameType              = "mirror"
@@ -373,7 +376,6 @@ trait StdNames extends NameManglers { self: SymbolTable =>
     val setSymbol: NameType            = "setSymbol"
     val setType: NameType              = "setType"
     val setTypeSignature: NameType     = "setTypeSignature"
-
     val synchronized_ : NameType       = "synchronized"
     val tail: NameType                 = "tail"
     val thisModuleType: NameType       = "thisModuleType"

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -40,7 +40,7 @@ trait Macros { self: Analyzer =>
    *    def defmacro$foo
    *           (_context: scala.reflect.macro.Context)
    *           (_this: _context.Tree)
-   *           (T: _context.Type)
+   *           (T: _context.TypeTree)
    *           (xs: _context.Tree): _context.Tree = {
    *      import _context._  // this means that all methods of Context can be used unqualified in macro's body
    *      expr
@@ -54,20 +54,20 @@ trait Macros { self: Analyzer =>
   def macroMethDef(mdef: DefDef): Tree = {
     def paramDef(name: Name, tpt: Tree) = ValDef(Modifiers(PARAM), name, tpt, EmptyTree)
     val contextType = TypeTree(ReflectMacroContext.tpe)
-    val globParamSec = List(paramDef(nme.context, contextType))
-    def globSelect(name: Name) = Select(Ident(nme.context), name)
-    def globTree = globSelect(newTypeName("Tree"))
-    def globType = globSelect(newTypeName("Type"))
-    val thisParamSec = if (isStaticMacro(mdef.symbol)) List() else List(paramDef(newTermName("_this"), globTree))
-    def tparamInMacro(tdef: TypeDef) = paramDef(tdef.name.toTermName, globType)
+    val globParamSec = List(paramDef(nme.macroContext, contextType))
+    def globSelect(name: Name) = Select(Ident(nme.macroContext), name)
+    def globTree = globSelect(tpnme.Tree)
+    def globTypeTree = globSelect(tpnme.TypeTree)
+    val thisParamSec = if (isStaticMacro(mdef.symbol)) List() else List(paramDef(nme.macroThis, globTree))
+    def tparamInMacro(tdef: TypeDef) = paramDef(tdef.name.toTermName, globTypeTree)
     def vparamInMacro(vdef: ValDef): ValDef = paramDef(vdef.name, vdef.tpt match {
       case tpt @ AppliedTypeTree(hk, _) if treeInfo.isRepeatedParamType(tpt) => AppliedTypeTree(hk, List(globTree))
       case _ => globTree
     })
     def wrapImplicit(tree: Tree) = atPos(tree.pos) {
       // implicit hasn't proven useful so far, so I'm disabling it
-      //val implicitDecl = ValDef(Modifiers(IMPLICIT), nme.contextImplicit, SingletonTypeTree(Ident(nme.context)), Ident(nme.context))
-      val importGlob = Import(Ident(nme.context), List(ImportSelector(nme.WILDCARD, -1, null, -1)))
+      //val implicitDecl = ValDef(Modifiers(IMPLICIT), nme.macroContextImplicit, SingletonTypeTree(Ident(nme.macroContext)), Ident(nme.macroContext))
+      val importGlob = Import(Ident(nme.macroContext), List(ImportSelector(nme.WILDCARD, -1, null, -1)))
       Block(List(importGlob), tree)
     }
     var formals = (mdef.vparamss map (_ map vparamInMacro))


### PR DESCRIPTION
Macro implementations now get type arguments as TypeTrees, not Types.

Keeping the situation with AnnotationInfos in mind, I decided to
go for the most future-proof solution. Another argument for this decision
is that we will most likely have to support untyped macros.

Review by @odersky.
