### PR TITLE
Fixes https://issues.scala-lang.org/browse/SI-5453

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -20,14 +20,11 @@ trait Macros { self: Analyzer =>
       macroArgs(fn) :+ args
     case TypeApply(fn, args) =>
       macroArgs(fn) :+ args
-    case Select(qual, name) if !isStaticMacro(tree.symbol) =>
+    case Select(qual, name) =>
       List(List(qual))
     case _ =>
       List(List())
   }
-
-  private def isStaticMacro(mac: Symbol): Boolean =
-    mac.owner.isModuleClass
 
   /**
    *  The definition of the method implementing a macro. Example:
@@ -46,7 +43,6 @@ trait Macros { self: Analyzer =>
    *      expr
    *    }
    *
-   *  If `foo` is declared in an object, the second parameter list is () instead of (_this: _context.Tree).
    *  If macro has no type arguments, the third parameter list is omitted (it's not empty, but omitted altogether).
    *
    *  To find out the desugared representation of your particular macro, compile it with -Ydebug.
@@ -58,7 +54,7 @@ trait Macros { self: Analyzer =>
     def globSelect(name: Name) = Select(Ident(nme.context), name)
     def globTree = globSelect(newTypeName("Tree"))
     def globType = globSelect(newTypeName("Type"))
-    val thisParamSec = if (isStaticMacro(mdef.symbol)) List() else List(paramDef(newTermName("_this"), globTree))
+    val thisParamSec = List(paramDef(newTermName("_this"), globTree))
     def tparamInMacro(tdef: TypeDef) = paramDef(tdef.name.toTermName, globType)
     def vparamInMacro(vdef: ValDef): ValDef = paramDef(vdef.name, vdef.tpt match {
       case tpt @ AppliedTypeTree(hk, _) if treeInfo.isRepeatedParamType(tpt) => AppliedTypeTree(hk, List(globTree))

--- a/test/files/codelib/code.jar.desired.sha1
+++ b/test/files/codelib/code.jar.desired.sha1
@@ -1,1 +1,1 @@
-5880dd44ee9fedec44fed3f223842e42d8a63959 ?code.jar
+e25f1daf9010b9dc6038ae7069fc9d0f7d48a53b ?code.jar


### PR DESCRIPTION
Originally we thought that macros declared inside objects should not
provide _this to their bodies.

However, it: 1) contradicts vanilla Scala rules, according to which
both class and object methods can use this, 2) imposes unnecessary
burden on macro developers without providing any conveniences to us.

Review by @odersky.
