### PR TITLE
Leave final modifier on specialized methods (fixes SI-5005)

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -819,7 +819,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
           log("-->d SETTING PRIVATE WITHIN TO " + sym.enclosingPackage + " for " + sym)
         }
 
-        sym.resetFlag(FINAL)
+        //sym.resetFlag(FINAL)
         val specMember = subst(outerEnv)(specializedOverload(owner, sym, spec))
         typeEnv(specMember) = typeEnv(sym) ++ outerEnv ++ spec
         wasSpecializedForTypeVars(specMember) ++= spec collect { case (s, tp) if s.tpe == tp => s }


### PR DESCRIPTION
The "specialize" compiler phase currently removes the "final" modifier from methods which it creates specialized overrides from. This interferes with the correct functioning of the @inline annotation, as mentioned in SI-5005.

It turns out that leaving the final modifier on those methods doesn't (seem to) cause any problems with compilation. It also preserves the original author's intention (that no subclasses should be allowed to override the method). Currently you can override final methods in specialized classes, which is not a major bug, but it would be nice to "fix" this.

There may be reasons why leaving "final" on the parent class' methods is a bad idea. If so, I can rework the patch.
