### PR TITLE
Apply the fix for si-5293 to hash maps.

### DIFF
--- a/test/files/jvm/serialization.check
+++ b/test/files/jvm/serialization.check
@@ -156,8 +156,8 @@ x = BitSet(0, 8, 9)
 y = BitSet(0, 8, 9)
 x equals y: true, y equals x: true
 
-x = Map(C -> 3, B -> 2, A -> 1)
-y = Map(C -> 3, A -> 1, B -> 2)
+x = Map(A -> 1, C -> 3, B -> 2)
+y = Map(A -> 1, C -> 3, B -> 2)
 x equals y: true, y equals x: true
 
 x = Set(buffers, title, layers)
@@ -283,8 +283,8 @@ x = ParArray(abc, def, etc)
 y = ParArray(abc, def, etc)
 x equals y: true, y equals x: true
 
-x = ParHashMap(1 -> 2, 2 -> 4)
-y = ParHashMap(1 -> 2, 2 -> 4)
+x = ParHashMap(2 -> 4, 1 -> 2)
+y = ParHashMap(2 -> 4, 1 -> 2)
 x equals y: true, y equals x: true
 
 x = ParCtrie(1 -> 2, 2 -> 4)

--- a/test/files/run/t5293-map.scala
+++ b/test/files/run/t5293-map.scala
@@ -1,0 +1,88 @@
+
+
+
+import scala.collection.JavaConverters._
+
+
+
+object Test extends App {
+  
+  def bench(label: String)(body: => Unit): Long = {
+    val start = System.nanoTime
+
+    0.until(10).foreach(_ => body)
+
+    val end = System.nanoTime
+
+    //println("%s: %s ms".format(label, (end - start) / 1000.0 / 1000.0))
+    
+    end - start
+  }
+  
+  def benchJava(values: java.util.Map[Int, Int]) = {
+    bench("Java Map") {
+      val m = new java.util.HashMap[Int, Int]
+      
+      m.putAll(values)
+    }
+  }
+
+  def benchScala(values: Iterable[(Int, Int)]) = {
+    bench("Scala Map") {
+      val m = new scala.collection.mutable.HashMap[Int, Int]
+      
+      m ++= values
+    }
+  }
+  
+  def benchScalaSorted(values: Iterable[(Int, Int)]) = {
+    bench("Scala Map sorted") {
+      val m = new scala.collection.mutable.HashMap[Int, Int]
+      
+      m ++= values.toArray.sorted
+    }
+  }
+  
+  def benchScalaPar(values: Iterable[(Int, Int)]) = {
+    bench("Scala ParMap") {
+      val m = new scala.collection.parallel.mutable.ParHashMap[Int, Int] map { x => x }
+      
+      m ++= values
+    }
+  }
+  
+  val total = 50000
+  val values = (0 until total) zip (0 until total)
+  val map = scala.collection.mutable.HashMap.empty[Int, Int]
+  
+  map ++= values
+  
+  // warmup
+  for (x <- 0 until 5) {
+    benchJava(map.asJava)
+    benchScala(map)
+    benchScalaPar(map)
+    benchJava(map.asJava)
+    benchScala(map)
+    benchScalaPar(map)
+  }
+  
+  val javamap = benchJava(map.asJava)
+  val scalamap = benchScala(map)
+  val scalaparmap = benchScalaPar(map)
+  
+  // println(javamap)
+  // println(scalamap)
+  // println(scalaparmap)
+  
+  assert(scalamap < (javamap * 4))
+  assert(scalaparmap < (javamap * 4))
+}
+
+
+
+
+
+
+
+


### PR DESCRIPTION
This fix was previously only applied to hash sets.
