### PR TITLE
Close file descriptor leak in sys.process. (SI-5439)

### DIFF
--- a/src/library/scala/sys/process/BasicIO.scala
+++ b/src/library/scala/sys/process/BasicIO.scala
@@ -20,9 +20,18 @@ import scala.annotation.tailrec
   * which can be used to control the I/O of a [[scala.sys.process.Process]]
   * when a [[scala.sys.process.ProcessBuilder]] is started with the `run`
   * command.
+  *
+  * It also contains some helper methods that can be used to in the creation of
+  * `ProcessIO`.
+  *
+  * It is used by other classes in the package in the implementation of various
+  * features, but can also be used by client code.
   */
 object BasicIO {
+  /** Size of the buffer used in all the functions that copy data */
   final val BufferSize = 8192
+
+  /** Used to separate lines in the `processFully` function that takes `Appendable`. */
   final val Newline    = props("line.separator")
 
   private[process] final class Streamed[T](
@@ -53,15 +62,70 @@ object BasicIO {
     def protect(out: OutputStream): OutputStream = if ((out eq stdout) || (out eq stderr)) Uncloseable(out) else out
   }
 
+  /** Creates a `ProcessIO` from a function `String => Unit`. It can attach the
+    * process input to stdin, and it will either send the error stream to
+    * stderr, or to a `ProcessLogger`.
+    *
+    * For example, the `ProcessIO` created below will print all normal output
+    * while ignoring all error output. No input will be provided.
+    * {{{
+    * import scala.sys.process.BasicIO
+    * val errToDevNull = BasicIO(false, println(_), None)
+    * }}}
+    *
+    * @param withIn True if the process input should be attached to stdin.
+    * @param output A function that will be called with the process output.
+    * @param log    An optional `ProcessLogger` to which the output should be
+    *               sent. If `None`, output will be sent to stderr.
+    * @return A `ProcessIO` with the characteristics above.
+    */
   def apply(withIn: Boolean, output: String => Unit, log: Option[ProcessLogger]) =
     new ProcessIO(input(withIn), processFully(output), getErr(log))
 
+  /** Creates a `ProcessIO` that appends its output to a `StringBuffer`. It can
+    * attach the process input to stdin, and it will either send the error
+    * stream to stderr, or to a `ProcessLogger`.
+    *
+    * For example, the `ProcessIO` created by the function below will store the
+    * normal output on the buffer provided, and print all error on stderr. The
+    * input will be read from stdin.
+    * {{{
+    * import scala.sys.process.{BasicIO, ProcessLogger}
+    * val printer = ProcessLogger(println(_))
+    * def appendToBuffer(b: StringBuffer) = BasicIO(true, b, Some(printer))
+    * }}}
+    *
+    * @param withIn True if the process input should be attached to stdin.
+    * @param buffer A `StringBuffer` which will receive the process normal
+    *               output. 
+    * @param log    An optional `ProcessLogger` to which the output should be
+    *               sent. If `None`, output will be sent to stderr.
+    * @return A `ProcessIO` with the characteristics above.
+    */
   def apply(withIn: Boolean, buffer: StringBuffer, log: Option[ProcessLogger]) =
     new ProcessIO(input(withIn), processFully(buffer), getErr(log))
 
+  /** Creates a `ProcessIO` from a `ProcessLogger` . It can attach the
+    * process input to stdin.
+    *
+    * @param withIn True if the process input should be attached to stdin.
+    * @param log    A `ProcessLogger` to receive all output, normal and error.
+    * @return A `ProcessIO` with the characteristics above.
+    */
   def apply(withIn: Boolean, log: ProcessLogger) =
     new ProcessIO(input(withIn), processOutFully(log), processErrFully(log))
 
+  /** Returns a function `InputStream => Unit` given an optional
+    * `ProcessLogger`. If no logger is passed, the function will send the output
+    * to stderr. This function can be used to create a
+    * [[scala.sys.process.ProcessIO]].
+    *
+    * @param log An optional `ProcessLogger` to which the contents of
+    *            the `InputStream` will be sent.
+    * @return A function `InputStream => Unit` (used by
+    *          [[scala.sys.process.ProcessIO]]) which will send the data to
+    *          either the provided `ProcessLogger` or, if `None`, to stderr.
+    */
   def getErr(log: Option[ProcessLogger]) = log match {
     case Some(lg) => processErrFully(lg)
     case None     => toStdErr
@@ -70,14 +134,40 @@ object BasicIO {
   private def processErrFully(log: ProcessLogger) = processFully(log err _)
   private def processOutFully(log: ProcessLogger) = processFully(log out _)
 
+  /** Closes a `Closeable` without throwing an exception */
   def close(c: Closeable) = try c.close() catch { case _: IOException => () }
+
+  /** Returns a function `InputStream => Unit` that appends all data read to the
+    * provided `Appendable`. This function can be used to create a
+    * [[scala.sys.process.ProcessIO]]. The buffer will be appended line by line.
+    *
+    * @param buffer An `Appendable` such as `StringBuilder` or `StringBuffer`.
+    * @return A function `InputStream => Unit` (used by
+    *          [[scala.sys.process.ProcessIO]] which will append all data read
+    *          from the stream to the buffer.
+    */
   def processFully(buffer: Appendable): InputStream => Unit = processFully(appendLine(buffer))
+
+  /** Returns a function `InputStream => Unit` that will call the passed
+    * function with all data read. This function can be used to create a
+    * [[scala.sys.process.ProcessIO]]. The `processLine` function will be called
+    * with each line read, and `Newline` will be appended after each line.
+    *
+    * @param processLine A function that will be called with all data read from
+    *                    the stream.
+    * @return A function `InputStream => Unit` (used by
+    *          [[scala.sys.process.ProcessIO]] which will call `processLine`
+    *          with all data read from the stream.
+    */
   def processFully(processLine: String => Unit): InputStream => Unit = in => {
     val reader = new BufferedReader(new InputStreamReader(in))
     processLinesFully(processLine)(reader.readLine)
     reader.close()
   }
 
+  /** Calls `processLine` with the result of `readLine` until the latter returns
+    * `null`.
+    */
   def processLinesFully(processLine: String => Unit)(readLine: () => String) {
     def readFully() {
       val line = readLine()
@@ -88,17 +178,38 @@ object BasicIO {
     }
     readFully()
   }
+
+  /** Copy contents of stdin to the `OutputStream`. */
   def connectToIn(o: OutputStream): Unit = transferFully(Uncloseable protect stdin, o)
+
+  /** Returns a function `OutputStream => Unit` that either reads the content
+    * from stdin or does nothing. This function can be used by
+    * [[scala.sys.process.ProcessIO]].
+    */
   def input(connect: Boolean): OutputStream => Unit = { outputToProcess =>
     if (connect) connectToIn(outputToProcess)
     outputToProcess.close()
   }
+
+  /** Returns a `ProcessIO` connected to stdout and stderr, and, optionally, stdin. */
   def standard(connectInput: Boolean): ProcessIO = standard(input(connectInput))
+
+  /** Retruns a `ProcessIO` connected to stdout, stderr and the provided `in` */
   def standard(in: OutputStream => Unit): ProcessIO = new ProcessIO(in, toStdOut, toStdErr)
 
+  /** Send all the input from the stream to stderr, and closes the input stream
+   * afterwards.
+   */
   def toStdErr = (in: InputStream) => transferFully(in, stderr)
+
+  /** Send all the input from the stream to stdout, and closes the input stream
+   * afterwards.
+   */
   def toStdOut = (in: InputStream) => transferFully(in, stdout)
 
+  /** Copy all input from the input stream to the output stream. Closes the
+    * input stream once it's all read.
+    */
   def transferFully(in: InputStream, out: OutputStream): Unit =
     try transferFullyImpl(in, out)
     catch onInterrupt(())

--- a/src/library/scala/sys/process/Process.scala
+++ b/src/library/scala/sys/process/Process.scala
@@ -13,7 +13,7 @@ import processInternal._
 import ProcessBuilder._
 
 /** Represents a process that is running or has finished running.
- *  It may be a compound process with several underlying native processes (such as 'a #&& b`).
+ *  It may be a compound process with several underlying native processes (such as `a #&& b`).
  *
  *  This trait is often not used directly, though its companion object contains
  *  factories for [[scala.sys.process.ProcessBuilder]], the main component of this
@@ -42,28 +42,28 @@ object Process extends ProcessImpl with ProcessCreation { }
  *  found on and used through [[scala.sys.process.Process]]'s companion object.
  */
 trait ProcessCreation {
-  /** Create a [[scala.sys.process.ProcessBuilder]] from a `String`, including the
+  /** Creates a [[scala.sys.process.ProcessBuilder]] from a `String`, including the
     * parameters.
     *
     * @example {{{ apply("cat file.txt") }}}
     */
   def apply(command: String): ProcessBuilder                         = apply(command, None)
 
-  /** Create a [[scala.sys.process.ProcessBuilder]] from a sequence of `String`,
+  /** Creates a [[scala.sys.process.ProcessBuilder]] from a sequence of `String`,
     * where the head is the command and each element of the tail is a parameter.
     *
     * @example {{{ apply("cat" :: files) }}}
     */
   def apply(command: Seq[String]): ProcessBuilder                    = apply(command, None)
 
-  /** Create a [[scala.sys.process.ProcessBuilder]] from a command represented by a `String`,
+  /** Creates a [[scala.sys.process.ProcessBuilder]] from a command represented by a `String`,
     * and a sequence of `String` representing the arguments.
     *
     * @example {{{ apply("cat", files) }}}
     */
   def apply(command: String, arguments: Seq[String]): ProcessBuilder = apply(command +: arguments, None)
 
-  /** Create a [[scala.sys.process.ProcessBuilder]] with working dir set to `File` and extra
+  /** Creates a [[scala.sys.process.ProcessBuilder]] with working dir set to `File` and extra
     * environment variables.
     *
     * @example {{{ apply("java", new java.ioFile("/opt/app"), "CLASSPATH" -> "library.jar") }}}
@@ -71,7 +71,7 @@ trait ProcessCreation {
   def apply(command: String, cwd: File, extraEnv: (String, String)*): ProcessBuilder =
     apply(command, Some(cwd), extraEnv: _*)
 
-  /** Create a [[scala.sys.process.ProcessBuilder]] with working dir set to `File` and extra
+  /** Creates a [[scala.sys.process.ProcessBuilder]] with working dir set to `File` and extra
     * environment variables.
     *
     * @example {{{ apply("java" :: javaArgs, new java.ioFile("/opt/app"), "CLASSPATH" -> "library.jar") }}}
@@ -79,7 +79,7 @@ trait ProcessCreation {
   def apply(command: Seq[String], cwd: File, extraEnv: (String, String)*): ProcessBuilder =
     apply(command, Some(cwd), extraEnv: _*)
 
-  /** Create a [[scala.sys.process.ProcessBuilder]] with working dir optionally set to
+  /** Creates a [[scala.sys.process.ProcessBuilder]] with working dir optionally set to
     * `File` and extra environment variables.
     *
     * @example {{{ apply("java", params.get("cwd"), "CLASSPATH" -> "library.jar") }}}
@@ -93,7 +93,7 @@ trait ProcessCreation {
     }*/
   }
 
-  /** Create a [[scala.sys.process.ProcessBuilder]] with working dir optionally set to
+  /** Creates a [[scala.sys.process.ProcessBuilder]] with working dir optionally set to
     * `File` and extra environment variables.
     *
     * @example {{{ apply("java" :: javaArgs, params.get("cwd"), "CLASSPATH" -> "library.jar") }}}
@@ -105,7 +105,7 @@ trait ProcessCreation {
     apply(jpb)
   }
 
-  /** create a [[scala.sys.process.ProcessBuilder]] from a `java.lang.ProcessBuilder`.
+  /** Creates a [[scala.sys.process.ProcessBuilder]] from a `java.lang.ProcessBuilder`.
     *
     * @example {{{
     * apply((new java.lang.ProcessBuilder("ls", "-l")) directory new java.io.File(System.getProperty("user.home")))
@@ -113,19 +113,19 @@ trait ProcessCreation {
     */
   def apply(builder: JProcessBuilder): ProcessBuilder = new Simple(builder)
 
-  /** create a [[scala.sys.process.ProcessBuilder]] from a `java.io.File`. This
+  /** Creates a [[scala.sys.process.ProcessBuilder]] from a `java.io.File`. This
     * `ProcessBuilder` can then be used as a `Source` or a `Sink`, so one can
     * pipe things from and to it.
     */
   def apply(file: File): FileBuilder                  = new FileImpl(file)
 
-  /** Create a [[scala.sys.process.ProcessBuilder]] from a `java.net.URL`. This
+  /** Creates a [[scala.sys.process.ProcessBuilder]] from a `java.net.URL`. This
     * `ProcessBuilder` can then be used as a `Source`, so that one can pipe things
     * from it.
     */
   def apply(url: URL): URLBuilder                     = new URLImpl(url)
 
-  /** Create a [[scala.sys.process.ProcessBuilder]] from a Scala XML Element.
+  /** Creates a [[scala.sys.process.ProcessBuilder]] from a Scala XML Element.
     * This can be used as a way to template strings.
     *
     * @example {{{
@@ -134,23 +134,23 @@ trait ProcessCreation {
     */
   def apply(command: scala.xml.Elem): ProcessBuilder  = apply(command.text.trim)
 
-  /** Create a [[scala.sys.process.ProcessBuilder]] from a `Boolean`. This can be
+  /** Creates a [[scala.sys.process.ProcessBuilder]] from a `Boolean`. This can be
     * to force an exit value.
     */
   def apply(value: Boolean): ProcessBuilder           = apply(value.toString, if (value) 0 else 1)
 
-  /** Create a [[scala.sys.process.ProcessBuilder]] from a `String` name and a
+  /** Creates a [[scala.sys.process.ProcessBuilder]] from a `String` name and a
     * `Boolean`. This can be used to force an exit value, with the name being
     * used for `toString`.
     */
   def apply(name: String, exitValue: => Int): ProcessBuilder = new Dummy(name, exitValue)
 
-  /** Create a sequence of [[scala.sys.process.ProcessBuilder.Source]] from a sequence of
+  /** Creates a sequence of [[scala.sys.process.ProcessBuilder.Source]] from a sequence of
     * something else for which there's an implicit conversion to `Source`.
     */
   def applySeq[T](builders: Seq[T])(implicit convert: T => Source): Seq[Source] = builders.map(convert)
 
-  /** Create a [[scala.sys.process.ProcessBuilder]] from one or more
+  /** Creates a [[scala.sys.process.ProcessBuilder]] from one or more
     * [[scala.sys.process.ProcessBuilder.Source]], which can then be
     * piped to something else.
     *
@@ -170,7 +170,7 @@ trait ProcessCreation {
     */
   def cat(file: Source, files: Source*): ProcessBuilder = cat(file +: files)
 
-  /** Create a [[scala.sys.process.ProcessBuilder]] from a non-empty sequence
+  /** Creates a [[scala.sys.process.ProcessBuilder]] from a non-empty sequence
     * of [[scala.sys.process.ProcessBuilder.Source]], which can then be
     * piped to something else.
     *
@@ -198,18 +198,41 @@ trait ProcessImplicits {
   /** Implicitly convert a `java.lang.ProcessBuilder` into a Scala one. */
   implicit def builderToProcess(builder: JProcessBuilder): ProcessBuilder = apply(builder)
 
-  /** Implicitly convert a `java.io.File` into a [[scala.sys.process.ProcessBuilder]] */
+  /** Implicitly convert a `java.io.File` into a
+    * [[scala.sys.process.ProcessBuilder.FileBuilder]], which can be used as
+    * either input or output of a process. For example:
+    * {{{
+    * import scala.sys.process._
+    * "ls" #> new java.io.File("dirContents.txt") !
+    * }}}
+    */
   implicit def fileToProcess(file: File): FileBuilder                     = apply(file)
 
-  /** Implicitly convert a `java.net.URL` into a [[scala.sys.process.ProcessBuilder]] */
+  /** Implicitly convert a `java.net.URL` into a
+    * [[scala.sys.process.ProcessBuilder.URLBuilder]] , which can be used as
+    * input to a process. For example:
+    * {{{
+    * import scala.sys.process._
+    * Seq("xmllint", "--html", "-") #< new java.net.URL("http://www.scala-lang.org") #> new java.io.File("fixed.html") !
+    * }}}
+    */
   implicit def urlToProcess(url: URL): URLBuilder                         = apply(url)
 
-  /** Implicitly convert a [[scala.xml.Elem]] into a [[scala.sys.process.ProcessBuilder]] */
+  /** Implicitly convert a [[scala.xml.Elem]] into a
+    * [[scala.sys.process.ProcessBuilder]]. This is done by obtaining the text
+    * elements of the element, trimming spaces, and then converting the result
+    * from string to a process. Importantly, tags are completely ignored, so
+    * they cannot be used to separate parameters.
+    */
   implicit def xmlToProcess(command: scala.xml.Elem): ProcessBuilder      = apply(command)
 
-  /** Implicitly convert a `String` into a [[scala.sys.process.ProcessBuilder]] */
+  /** Implicitly convert a `String` into a [[scala.sys.process.ProcessBuilder]]. */
   implicit def stringToProcess(command: String): ProcessBuilder           = apply(command)
 
-  /** Implicitly convert a sequence of `String` into a [[scala.sys.process.ProcessBuilder]] */
+  /** Implicitly convert a sequence of `String` into a
+    * [[scala.sys.process.ProcessBuilder]]. The first argument will be taken to
+    * be the command to be executed, and the remaining will be its arguments.
+    * When using this, arguments may contain spaces.
+    */
   implicit def stringSeqToProcess(command: Seq[String]): ProcessBuilder   = apply(command)
 }

--- a/src/library/scala/sys/process/ProcessBuilder.scala
+++ b/src/library/scala/sys/process/ProcessBuilder.scala
@@ -12,133 +12,265 @@ package process
 import processInternal._
 import ProcessBuilder._
 
-/** Represents a runnable process.
+/** Represents a sequence of one or more external processes that can be
+  * executed. A `ProcessBuilder` can be a single external process, or a
+  * combination of other `ProcessBuilder`. One can control where a
+  * the output of an external process will go to, and where its input will come
+  * from, or leave that decision to whoever starts it.
   *
-  * This is the main component of this package. A `ProcessBuilder` may be composed with
-  * others, either concatenating their outputs or piping them from one to the next, and
-  * possibly with conditional execution depending on the last process exit value.
+  * One creates a `ProcessBuilder` through factories provided in
+  * [[scala.sys.process.Process]]'s companion object, or implicit conversions
+  * based on these factories made available in the package object
+  * [[scala.sys.process]]. Here are some examples:
+  * {{{
+  * import.scala.sys.process._
   *
-  * Once executed, one can retrieve the output or redirect it to a
-  * [[scala.sys.process.ProcessLogger]], or one can get the exit value, discarding or
-  * redirecting the output.
+  * // Executes "ls" and sends output to stdout
+  * "ls".!
   *
-  * One creates a `ProcessBuilder` through factories provided in [[scala.sys.process.Process]]'s
-  * companion object, or implicit conversions based on these factories made available in the
-  * package object [[scala.sys.process]].
+  * // Execute "ls" and assign a `Stream[String]` of its output to "contents".
+  * // Because [[scala.Predef]] already defines a `lines` method for `String`,
+  * // we use [[scala.sys.process.Process]]'s object companion to create it.
+  * val contents = Process("ls").lines
+  *
+  * // Here we use a `Seq` to make the parameter whitespace-safe
+  * def contentsOf(dir: String): String = Seq("ls", dir).!!
+  * }}}
+  *
+  * The methods of `ProcessBuilder` are divided in three categories: the ones that
+  * combine two `ProcessBuilder` to create a third, the ones that redirect input
+  * or output of a `ProcessBuilder`, and the ones that execute
+  * the external processes associated with it.
+  *
+  * ==Combining `ProcessBuilder`==
+  *
+  * Two existing `ProcessBuilder` can be combined in the following ways:
+  *
+  *   * They can be executed in parallel, with the output of the first being fed
+  *   as input to the second, like Unix pipes. This is achieved with the `#|`
+  *   method.
+  *   * They can be executed in sequence, with the second starting as soon as
+  *   the first ends. This is done by the `###` method.
+  *   * The execution of the second one can be conditioned by the return code
+  *   (exit status) of the first, either only when it's zero, or only when it's
+  *   not zero. The methods `#&&` and `#||` accomplish these tasks.
+  *
+  * ==Redirecting Input/Output==
+  *
+  * Though control of input and output can be done when executing the process,
+  * there's a few methods that create a new `ProcessBuilder` with a
+  * pre-configured input or output. They are `#<`, `#>` and `#>>`, and may take
+  * as input either another `ProcessBuilder` (like the pipe described above), or
+  * something else such as a `java.io.File` or a `java.lang.InputStream`.
+  * For example:
+  * {{{
+  * new URL("http://databinder.net/dispatch/About") #> "grep JSON" #>> new File("About_JSON") !
+  * }}}
+  *
+  * ==Starting Processes==
+  *
+  * To execute all external commands associated with a `ProcessBuilder`, one
+  * may use one of four groups of methods. Each of these methods have various
+  * overloads and variations to enable further control over the I/O. These
+  * methods are:
+  *
+  *   * `run`: the most general method, it returns a
+  *   [[scala.sys.process.Process]] immediately, and the external command
+  *   executes concurrently.
+  *   * `!`: blocks until all external commands exit, and returns the exit code
+  *   of the last one in the chain of execution.
+  *   * `!!`: blocks until all external commands exit, and returns a `String`
+  *   with the output generated.
+  *   * `lines`: returns immediately like `run`, and the output being generared
+  *   is provided through a `Stream[String]`. Getting the next element of that
+  *   `Stream` may block until it becomes available. This method will throw an
+  *   exception if the return code is different than zero -- if this is not
+  *   desired, use the `lines_!` method.
+  *
+  * ==Handling Input and Output==
+  *
+  * If not specified, the input of the external commands executed with `run` or
+  * `!` will not be tied to anything, and the output will be redirected to the
+  * stdout and stderr of the Scala process. For the methods `!!` and `lines`, no
+  * input will be provided, and the output will be directed according to the
+  * semantics of these methods.
+  *
+  * Some methods will cause stdin to be used as input. Output can be controlled
+  * with a [[scala.sys.process.ProcessLogger]] -- `!!` and `lines` will only
+  * redirect error output when passed a `ProcessLogger`. If one desires full
+  * control over input and output, then a [[scala.sys.process.ProcessIO]] can be
+  * used with `run`.
+  *
+  * For example, we could silence the error output from `lines_!` like this:
+  * {{{
+  * val etcFiles = "find /etc" lines_! ProcessLogger(line => ())
+  * }}}
+  *
+  * ==Extended Example==
   *
   * Let's examine in detail one example of usage:
-  *
   * {{{
   * import scala.sys.process._
   * "find src -name *.scala -exec grep null {} ;"  #|  "xargs test -z"  #&&  "echo null-free"  #||  "echo null detected"  !
   * }}}
-  *
   * Note that every `String` is implicitly converted into a `ProcessBuilder`
   * through the implicits imported from [[scala.sys.process]]. These `ProcessBuilder` are then
   * combined in three different ways.
   *
   *   1. `#|` pipes the output of the first command into the input of the second command. It
-  * mirrors a shell pipe (`|`).
-  *   2. `#&&` conditionally executes the second command if the previous one finished with
-  * exit value 0. It mirrors shell's `&&`.
-  *   3. `#||` conditionally executes the third command if the exit value of the previous
-  * command is different than zero. It mirrors shell's `&&`.
+  *      mirrors a shell pipe (`|`).
+  *   1. `#&&` conditionally executes the second command if the previous one finished with
+  *      exit value 0. It mirrors shell's `&&`.
+  *   1. `#||` conditionally executes the third command if the exit value of the previous
+  *      command is different than zero. It mirrors shell's `&&`.
   *
-  * Not shown here, the equivalent of a shell's `;` would be `###`. The reason for this name is
-  * that `;` is a reserved token in Scala.
+  * Finally, `!` at the end executes the commands, and returns the exit value.
+  * Whatever is printed will be sent to the Scala process standard output. If
+  * we wanted to caputre it, we could run that with `!!` instead.
   *
-  * Finally, `!` at the end executes the commands, and returns the exit value. If the output
-  * was desired instead, one could run that with `!!` instead.
-  *
-  * If one wishes to execute the commands in background, one can either call `run`, which
-  * returns a [[scala.sys.process.Process]] from which the exit value can be obtained, or
-  * `lines`, which returns a [scala.collection.immutable.Stream] of output lines. This throws
-  * an exception at the end of the `Stream` is the exit value is non-zero. To avoid exceptions,
-  * one can use `lines_!` instead.
-  *
-  * One can also start the commands in specific ways to further control their I/O. Using `!<` to
-  * start the commands will use the stdin from the current process for them. All methods can
-  * be used passing a [[scala.sys.process.ProcessLogger]] to capture the output, both stderr and
-  * stdout. And, when using `run`, one can pass a [[scala.sys.process.ProcessIO]] to control
-  * stdin, stdout and stderr.
-  *
-  * The stdin of a command can be redirected from a `java.io.InputStream`, a `java.io.File`, a
-  * `java.net.URL` or another `ProcessBuilder` through the method `#<`. Likewise, the stdout
-  * can be sent to a `java.io.OutputStream`, a `java.io.File` or another `ProcessBuilder` with
-  * the method `#>`. The method `#>>` can be used to append the output to a `java.io.File`.
-  * For example:
-  *
-  * {{{
-  * new URL("http://databinder.net/dispatch/About") #> "grep JSON" #>> new File("About_JSON") !
-  * }}}
+  * Note: though it is not shown above, the equivalent of a shell's `;` would be
+  * `###`. The reason for this name is that `;` is a reserved token in Scala.
   */
 trait ProcessBuilder extends Source with Sink {
-  /** Starts the process represented by this builder, blocks until it exits, and returns the output as a String.  Standard error is
-  * sent to the console.  If the exit code is non-zero, an exception is thrown.*/
+  /** Starts the process represented by this builder, blocks until it exits, and
+    * returns the output as a String.  Standard error is sent to the console.  If
+    * the exit code is non-zero, an exception is thrown.
+    */
   def !! : String
-  /** Starts the process represented by this builder, blocks until it exits, and returns the output as a String.  Standard error is
-  * sent to the provided ProcessLogger.  If the exit code is non-zero, an exception is thrown.*/
+
+  /** Starts the process represented by this builder, blocks until it exits, and
+    * returns the output as a String.  Standard error is sent to the provided
+    * ProcessLogger.  If the exit code is non-zero, an exception is thrown.
+    */
   def !!(log: ProcessLogger): String
-  /** Starts the process represented by this builder.  The output is returned as a Stream that blocks when lines are not available
-  * but the process has not completed.  Standard error is sent to the console.  If the process exits with a non-zero value,
-  * the Stream will provide all lines up to termination and then throw an exception. */
+
+  /** Starts the process represented by this builder, blocks until it exits, and
+    * returns the output as a String.  Standard error is sent to the console.  If
+    * the exit code is non-zero, an exception is thrown.  The newly started
+    * process reads from standard input of the current process.
+    */
+  def !!< : String
+
+  /** Starts the process represented by this builder, blocks until it exits, and
+    * returns the output as a String.  Standard error is sent to the provided
+    * ProcessLogger.  If the exit code is non-zero, an exception is thrown.  The
+    * newly started process reads from standard input of the current process.
+    */
+  def !!<(log: ProcessLogger): String
+
+  /** Starts the process represented by this builder.  The output is returned as
+    * a Stream that blocks when lines are not available but the process has not
+    * completed.  Standard error is sent to the console.  If the process exits
+    * with a non-zero value, the Stream will provide all lines up to termination
+    * and then throw an exception.
+    */
   def lines: Stream[String]
-  /** Starts the process represented by this builder.  The output is returned as a Stream that blocks when lines are not available
-  * but the process has not completed.  Standard error is sent to the provided ProcessLogger.  If the process exits with a non-zero value,
-  * the Stream will provide all lines up to termination but will not throw an exception. */
+
+  /** Starts the process represented by this builder.  The output is returned as
+    * a Stream that blocks when lines are not available but the process has not
+    * completed.  Standard error is sent to the provided ProcessLogger.  If the
+    * process exits with a non-zero value, the Stream will provide all lines up
+    * to termination but will not throw an exception.
+    */
   def lines(log: ProcessLogger): Stream[String]
-  /** Starts the process represented by this builder.  The output is returned as a Stream that blocks when lines are not available
-  * but the process has not completed.  Standard error is sent to the console. If the process exits with a non-zero value,
-  * the Stream will provide all lines up to termination but will not throw an exception. */
+
+  /** Starts the process represented by this builder.  The output is returned as
+    * a Stream that blocks when lines are not available but the process has not
+    * completed.  Standard error is sent to the console. If the process exits
+    * with a non-zero value, the Stream will provide all lines up to termination
+    * but will not throw an exception.
+    */
   def lines_! : Stream[String]
-  /** Starts the process represented by this builder.  The output is returned as a Stream that blocks when lines are not available
-  * but the process has not completed.  Standard error is sent to the provided ProcessLogger. If the process exits with a non-zero value,
-  * the Stream will provide all lines up to termination but will not throw an exception. */
+
+  /** Starts the process represented by this builder.  The output is returned as
+    * a Stream that blocks when lines are not available but the process has not
+    * completed.  Standard error is sent to the provided ProcessLogger. If the
+    * process exits with a non-zero value, the Stream will provide all lines up
+    * to termination but will not throw an exception.
+    */
   def lines_!(log: ProcessLogger): Stream[String]
-  /** Starts the process represented by this builder, blocks until it exits, and returns the exit code.  Standard output and error are
-  * sent to the console.*/
+
+  /** Starts the process represented by this builder, blocks until it exits, and
+    * returns the exit code.  Standard output and error are sent to the console.
+    */
   def ! : Int
-  /** Starts the process represented by this builder, blocks until it exits, and returns the exit code.  Standard output and error are
-  * sent to the given ProcessLogger.*/
+
+  /** Starts the process represented by this builder, blocks until it exits, and
+    * returns the exit code.  Standard output and error are sent to the given
+    * ProcessLogger.
+    */
   def !(log: ProcessLogger): Int
-  /** Starts the process represented by this builder, blocks until it exits, and returns the exit code.  Standard output and error are
-  * sent to the console.  The newly started process reads from standard input of the current process.*/
+
+  /** Starts the process represented by this builder, blocks until it exits, and
+    * returns the exit code.  Standard output and error are sent to the console.
+    * The newly started process reads from standard input of the current process.
+    */
   def !< : Int
-  /** Starts the process represented by this builder, blocks until it exits, and returns the exit code.  Standard output and error are
-  * sent to the given ProcessLogger.  The newly started process reads from standard input of the current process.*/
+
+  /** Starts the process represented by this builder, blocks until it exits, and
+    * returns the exit code.  Standard output and error are sent to the given
+    * ProcessLogger.  The newly started process reads from standard input of the
+    * current process.
+    */
   def !<(log: ProcessLogger): Int
-  /** Starts the process represented by this builder.  Standard output and error are sent to the console.*/
+
+  /** Starts the process represented by this builder.  Standard output and error
+   * are sent to the console.*/
   def run(): Process
-  /** Starts the process represented by this builder.  Standard output and error are sent to the given ProcessLogger.*/
+
+  /** Starts the process represented by this builder.  Standard output and error
+    * are sent to the given ProcessLogger.
+    */
   def run(log: ProcessLogger): Process
-  /** Starts the process represented by this builder.  I/O is handled by the given ProcessIO instance.*/
+
+  /** Starts the process represented by this builder.  I/O is handled by the
+    * given ProcessIO instance.
+    */
   def run(io: ProcessIO): Process
-  /** Starts the process represented by this builder.  Standard output and error are sent to the console.
-  * The newly started process reads from standard input of the current process if `connectInput` is true.*/
+
+  /** Starts the process represented by this builder.  Standard output and error
+    * are sent to the console.  The newly started process reads from standard
+    * input of the current process if `connectInput` is true.
+    */
   def run(connectInput: Boolean): Process
-  /** Starts the process represented by this builder, blocks until it exits, and returns the exit code.  Standard output and error are
-  * sent to the given ProcessLogger.
-  * The newly started process reads from standard input of the current process if `connectInput` is true.*/
+
+  /** Starts the process represented by this builder, blocks until it exits, and
+    * returns the exit code.  Standard output and error are sent to the given
+    * ProcessLogger.  The newly started process reads from standard input of the
+    * current process if `connectInput` is true.
+    */
   def run(log: ProcessLogger, connectInput: Boolean): Process
 
-  /** Constructs a command that runs this command first and then `other` if this command succeeds.*/
+  /** Constructs a command that runs this command first and then `other` if this
+    * command succeeds.
+    */
   def #&& (other: ProcessBuilder): ProcessBuilder
-  /** Constructs a command that runs this command first and then `other` if this command does not succeed.*/
+
+  /** Constructs a command that runs this command first and then `other` if this
+    * command does not succeed.
+    */
   def #|| (other: ProcessBuilder): ProcessBuilder
-  /** Constructs a command that will run this command and pipes the output to `other`.  `other` must be a simple command.*/
+
+  /** Constructs a command that will run this command and pipes the output to
+    * `other`.  `other` must be a simple command.
+    */
   def #| (other: ProcessBuilder): ProcessBuilder
-  /** Constructs a command that will run this command and then `other`.  The exit code will be the exit code of `other`.*/
+
+  /** Constructs a command that will run this command and then `other`.  The
+    * exit code will be the exit code of `other`.
+    */
   def ### (other: ProcessBuilder): ProcessBuilder
 
-  /** True if this command can be the target of a pipe.
-   */
+
+  /** True if this command can be the target of a pipe.  */
   def canPipeTo: Boolean
 
-  /** True if this command has an exit code which should be propagated to the user.
-   *  Given a pipe between A and B, if B.hasExitValue is true then the exit code will
-   *  be the one from B; if it is false, the one from A.  This exists to prevent output
-   *  redirections (implemented as pipes) from masking useful process error codes.
-   */
+  /** True if this command has an exit code which should be propagated to the
+    * user.  Given a pipe between A and B, if B.hasExitValue is true then the
+    * exit code will be the one from B; if it is false, the one from A.  This
+    * exists to prevent output redirections (implemented as pipes) from masking
+    * useful process error codes.
+    */
   def hasExitValue: Boolean
 }
 

--- a/src/library/scala/sys/process/ProcessIO.scala
+++ b/src/library/scala/sys/process/ProcessIO.scala
@@ -11,14 +11,40 @@ package process
 
 import processInternal._
 
-/** This class is used to control the I/O of every [[scala.sys.process.ProcessBuilder]].
- *  Most of the time, there is no need to interact with `ProcessIO` directly. However, if
- *  fine control over the I/O of a `ProcessBuilder` is desired, one can use the factories
- *  on [[scala.sys.process.BasicIO]] stand-alone object to create one.
- *
- *  Each method will be called in a separate thread.
- *  If daemonizeThreads is true, they will all be marked daemon threads.
- */
+/** This class is used to control the I/O of every
+  * [[scala.sys.process.Process]]. The functions used to create it will be
+  * called with the process streams once it has been started. It might not be
+  * necessary to use `ProcessIO` directly --
+  * [[scala.sys.process.ProcessBuilder]] can return the process output to the
+  * caller, or use a [[scala.sys.process.ProcessLogger]] which avoids direct
+  * interaction with a stream. One can even use the factories at `BasicIO` to
+  * create a `ProcessIO`, or use its helper methods when creating one's own
+  * `ProcessIO`.
+  *
+  * When creating a `ProcessIO`, it is important to ''close all streams'' when
+  * finished, since the JVM might use system resources to capture the process
+  * input and output, and will not release them unless the streams are
+  * explicitly closed.
+  *
+  * `ProcessBuilder` will call `writeInput`, `processOutput` and `processError`
+  * in separate threads, and if daemonizeThreads is true, they will all be
+  * marked as daemon threads.
+  *
+  * @param writeInput Function that will be called with the `OutputStream` to
+  *                   which all input to the process must be written. This will
+  *                   be called in a newly spawned thread.
+  * @param processOutput Function that will be called with the `InputStream`
+  *                      from which all normal output of the process must be
+  *                      read from. This will be called in a newly spawned
+  *                      thread.
+  * @param processError Function that will be called with the `InputStream` from
+  *                     which all error output of the process must be read from.
+  *                     This will be called in a newly spawned thread.
+  * @param daemonizeThreads Indicates whether the newly spawned threads that
+  *                         will run `processOutput`, `processError` and
+  *                         `writeInput` should be marked as daemon threads.
+  * @note Failure to close the passed streams may result in resource leakage.
+  */
 final class ProcessIO(
   val writeInput: OutputStream => Unit,
   val processOutput: InputStream => Unit,
@@ -27,8 +53,15 @@ final class ProcessIO(
 ) {
   def this(in: OutputStream => Unit, out: InputStream => Unit, err: InputStream => Unit) = this(in, out, err, false)
 
+  /** Creates a new `ProcessIO` with a different handler for the process input. */
   def withInput(write: OutputStream => Unit): ProcessIO   = new ProcessIO(write, processOutput, processError, daemonizeThreads)
+
+  /** Creates a new `ProcessIO` with a different handler for the normal output. */
   def withOutput(process: InputStream => Unit): ProcessIO = new ProcessIO(writeInput, process, processError, daemonizeThreads)
+
+  /** Creates a new `ProcessIO` with a different handler for the error output. */
   def withError(process: InputStream => Unit): ProcessIO  = new ProcessIO(writeInput, processOutput, process, daemonizeThreads)
+
+  /** Creates a new `ProcessIO`, with `daemonizeThreads` true. */
   def daemonized(): ProcessIO = new ProcessIO(writeInput, processOutput, processError, true)
 }

--- a/src/library/scala/sys/process/ProcessLogger.scala
+++ b/src/library/scala/sys/process/ProcessLogger.scala
@@ -11,12 +11,26 @@ package process
 
 import java.io._
 
-/** Encapsulates the output and error streams of a running process.
- *  Many of the methods of `ProcessBuilder` accept a `ProcessLogger` as
- *  an argument.
- *
- *  @see [[scala.sys.process.ProcessBuilder]]
- */
+/** Encapsulates the output and error streams of a running process. This is used
+  * by [[scala.sys.process.ProcessBuilder]] when starting a process, as an
+  * alternative to [[scala.sys.process.ProcessIO]], which can be more difficult
+  * to use. Note that a `ProcessLogger` will be used to create a `ProcessIO`
+  * anyway. The object `BasicIO` has some functions to do that.
+  *
+  * Here is an example that counts the number of lines in the normal and error
+  * output of a process:
+  * {{{
+  * import scala.sys.process._
+  *
+  * var normalLines = 0
+  * var errorLines = 0
+  * val countLogger = ProcessLogger(line => normalLines += 1,
+  *                                 line => errorLines += 1)
+  * "find /etc" ! countLogger
+  * }}}
+  *
+  *  @see [[scala.sys.process.ProcessBuilder]]
+  */
 trait ProcessLogger {
   /** Will be called with each line read from the process output stream.
    */


### PR DESCRIPTION
This closes most file descriptor leaks in sys.process through
the simple expedient of making sure every InputStream being read
by BasicIO is closed once there's nothing more to read.

A single file descriptor leak would remain for the OutputStream
(that is, that process stdin) of each Process, which is closed after the
InputStream being read to feed it is closed. Special care is taken
not to close the calling process stdin.

Fix an additional non-reported by where sending data to a process
that had already terminated would result in an exception being thrown.

File descriptors can still leak in some conditions that must be
handled by user code. Documentation to that effect will follow.

Closes SI-5439.
