### PR TITLE
Prevent extaneous output in SI-5005

### DIFF
--- a/test/files/specialized/SI-5005.scala
+++ b/test/files/specialized/SI-5005.scala
@@ -17,7 +17,11 @@ object Test extends DirectTest {
 
   override def show(): Unit = {
     // redirect err to out, for inliner log
-    System.setErr(new PrintStream(System.out));
+    val prevErr = System.err
+    System.setErr(System.out)
     compile()
+    System.setErr(prevErr)
   }
+
+  override def isDebug = false // so we don't get the newSettings warning
 }


### PR DESCRIPTION
In case partest debug is on, the testcase SI-5005 outputs some extraneous new settings output and the check fails, fixed. Also cleaning up after redirecting err to out, to be a good test suite citizen.
