### PR TITLE
Closes #5497.

### DIFF
--- a/test/files/neg/t5493.check
+++ b/test/files/neg/t5493.check
@@ -1,0 +1,4 @@
+t5493.scala:2: error: not found: value iDontExist
+  def meh(xs: Any): Any = xs :: iDontExist :: Nil
+                                ^
+one error found

--- a/test/files/neg/t5493.scala
+++ b/test/files/neg/t5493.scala
@@ -1,0 +1,3 @@
+object Test {
+  def meh(xs: Any): Any = xs :: iDontExist :: Nil
+}

--- a/test/files/neg/t5497.check
+++ b/test/files/neg/t5497.check
@@ -1,0 +1,4 @@
+t5497.scala:3: error: not found: value sq
+    case other => println(null.asInstanceOf[sq.Filter].tableName) 
+                                            ^
+one error found

--- a/test/files/neg/t5497.scala
+++ b/test/files/neg/t5497.scala
@@ -1,0 +1,5 @@
+object TestQueryable extends App{
+  ({
+    case other => println(null.asInstanceOf[sq.Filter].tableName) 
+  } : Any => Unit)(null)
+}


### PR DESCRIPTION
Chain contexts by sharing the error buffer, unless you explicitly create a silent context. Review by @odersky
