### PR TITLE
Fix race condition in scala-concurrent-tck test

### DIFF
--- a/test/files/jvm/scala-concurrent-tck.scala
+++ b/test/files/jvm/scala-concurrent-tck.scala
@@ -321,7 +321,7 @@ trait FutureProjections extends TestBase {
     done =>
     val f = future { 0 }
     try {
-      blocking(f.failed, Duration(0, "ms"))
+      blocking(f.failed, Duration(500, "ms"))
       assert(false)
     } catch {
       case nsee: NoSuchElementException => done()


### PR DESCRIPTION
This fixes a race condition in one of the future tests where a TimeoutException would be thrown non-deterministically.
