### PR TITLE
Fix [@spec A] to correctly induce AnyRef specialization.

### DIFF
--- a/test/files/run/t3575.check
+++ b/test/files/run/t3575.check
@@ -1,5 +1,5 @@
-Two
-Two
+Two$mcLI$sp
+Two$mcIL$sp
 Two
 Two$mcII$sp
 TwoLong


### PR DESCRIPTION
While [@specialized A] already tries to include specialization,
a bug in specializedOn prevented this from happening: any empty
list could mean that the type var was unspecialized, or that it
was specialized on everything.

The fix is to have this function create the full list of symbols
in the case where the @specialized annotation doesn't explicitly
include any types.
