### PR TITLE
Fix [@spec A] to correctly induce AnyRef specialization.

### DIFF
--- a/test/files/run/t3575.check
+++ b/test/files/run/t3575.check
@@ -1,6 +1,6 @@
 Two
-Two
-Two
+Two$mcIL$sp
+Two$mcLI$sp
 Two$mcII$sp
 TwoLong
 TwoLong$mcIL$sp
@@ -11,8 +11,8 @@ TwoCool$mcIL$sp
 TwoCool$mcLI$sp
 TwoCool$mcII$sp
 TwoShort
-TwoShort
-TwoShort
+TwoShort$mcIL$sp
+TwoShort$mcLI$sp
 TwoShort$mcII$sp
 TwoMinimal
 TwoMinimal$mcIL$sp


### PR DESCRIPTION
While [@specialized A] already tries to include specialization,
a bug in specializedOn prevented this from happening: any empty
list could mean that the type var was unspecialized, or that it
was specialized on everything.

The fix is to have this function create the full list of symbols
in the case where the @specialized annotation doesn't explicitly
include any types.

NOTE: Unlike last time, I rebuilt and ran all the tests so it should be OK.
