### PR TITLE
Fix for SI-5215: scalac crash when @elidable used in trait

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
@@ -876,6 +876,11 @@ abstract class GenICode extends SubComponent  {
             val (newCtx, resKind) = genPrimitiveOp(app, ctx, expectedType)
             generatedType = resKind
             newCtx
+          } else if (sym.elisionLevel.exists (_ < settings.elidebelow.value || settings.noassertions.value)) {
+            // XXX settings.noassertions.value temporarily retained to avoid
+            // breakage until a reasonable interface is settled upon.
+            debuglog("Eliding call from " + tree.symbol.owner + " to " + sym + " based on its elision threshold of " + sym.elisionLevel.get)
+            ctx
           } else {  // normal method call
             debuglog("Gen CALL_METHOD with sym: " + sym + " isStaticSymbol: " + sym.isStaticMember);
             val invokeStyle =

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -452,19 +452,6 @@ abstract class UnCurry extends InfoTransform
       }
     }
 
-    /** For removing calls to specially designated methods.
-     */
-    def elideIntoUnit(tree: Tree): Tree = Literal(Constant()) setPos tree.pos setType UnitClass.tpe
-    def isElidable(tree: Tree) = {
-      val sym = treeInfo.methPart(tree).symbol
-      // XXX settings.noassertions.value temporarily retained to avoid
-      // breakage until a reasonable interface is settled upon.
-      sym != null && sym.elisionLevel.exists(x => x < settings.elidebelow.value || settings.noassertions.value) && {
-        log("Eliding call from " + tree.symbol.owner + " to " + sym + " based on its elision threshold of " + sym.elisionLevel.get)
-        true
-      }
-    }
-
 // ------ The tree transformers --------------------------------------------------------
 
     def mainTransform(tree: Tree): Tree = {
@@ -502,8 +489,7 @@ abstract class UnCurry extends InfoTransform
         finally this.inConstructorFlag = saved
       }
 
-      if (isElidable(tree)) elideIntoUnit(tree)
-      else tree match {
+      tree match {
         case dd @ DefDef(mods, name, tparams, vparamss, tpt, rhs) =>
           if (dd.symbol hasAnnotation VarargsClass) saveRepeatedParams(dd)
           withNeedLift(false) {

--- a/test/files/run/elidable.check
+++ b/test/files/run/elidable.check
@@ -1,1 +1,4 @@
-Good for me, I was not elided.
+Good for me, I was not elided. Test.f3
+Good for me, I was not elided. O.f3
+Good for me, I was not elided. C.f1
+Good for me, I was not elided. C.f2

--- a/test/files/run/elidable.scala
+++ b/test/files/run/elidable.scala
@@ -1,10 +1,30 @@
 import annotation._
 import elidable._
 
+trait T {
+  @elidable(FINEST) def f1()
+  @elidable(SEVERE) def f2()
+  @elidable(FINEST) def f3() = assert(false, "Should have been elided.")
+  def f4()
+}
+
+class C extends T {
+  def f1() = println("Good for me, I was not elided. C.f1")
+  def f2() = println("Good for me, I was not elided. C.f2")
+  @elidable(FINEST) def f4() = assert(false, "Should have been elided.")
+}
+
+object O {
+  @elidable(FINEST) def f1() = assert(false, "Should have been elided.")
+  @elidable(INFO) def f2() = assert(false, "Should have been elided.")
+  @elidable(SEVERE) def f3() = println("Good for me, I was not elided. O.f3")
+  @elidable(INFO) def f4 = assert(false, "Should have been elided (no parens).")
+}
+
 object Test {
   @elidable(FINEST) def f1() = assert(false, "Should have been elided.")
   @elidable(INFO) def f2() = assert(false, "Should have been elided.")
-  @elidable(SEVERE) def f3() = println("Good for me, I was not elided.")
+  @elidable(SEVERE) def f3() = println("Good for me, I was not elided. Test.f3")
   @elidable(INFO) def f4 = assert(false, "Should have been elided (no parens).")
   
   def main(args: Array[String]): Unit = {
@@ -12,5 +32,26 @@ object Test {
     f2()
     f3()
     f4
+    O.f1()
+    O.f2()
+    O.f3()
+    O.f4
+
+    val c = new C
+    c.f1()
+    c.f2()
+    c.f3()
+    c.f4()
+
+    // this one won't show up in the output because a call to f1 is elidable when accessed through T
+    (c:T).f1()
+
+    // Test whether the method definitions are still available.
+    List("Test", "Test$", "O", "O$", "C", "T") foreach { className =>
+      List("f1", "f2", "f3", "f4") foreach { methodName =>
+        Class.forName(className).getMethod(methodName)
+      }
+    }
+    Class.forName("T$class").getMethod("f3", classOf[T])
   }
 }


### PR DESCRIPTION
The elision is now done by not emitting method calls (it was done by removing the elidable methods).
