### PR TITLE
Disallow eliding when Nothing is expected

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
@@ -885,6 +885,7 @@ abstract class GenICode extends SubComponent  {
               ctx.bb.emit(CONSTANT(global.gen.mkConstantZero(expectedType.toType)), tree.pos)
               generatedType = expectedType
             }
+            else if (expectedType.isNothingType) unit.error(tree.pos, "Cannot elide where Nothing is required.")
             else {
               ctx.bb.emit(CONSTANT(Constant(null)), tree.pos)
               generatedType = NullReference

--- a/test/files/neg/elide-to-nothing.check
+++ b/test/files/neg/elide-to-nothing.check
@@ -1,0 +1,4 @@
+elide-to-nothing.scala:14: error: Cannot elide where Nothing is required.
+  val b: Nothing = unimplemented()
+                                ^
+one error found

--- a/test/files/neg/elide-to-nothing.flags
+++ b/test/files/neg/elide-to-nothing.flags
@@ -1,0 +1,1 @@
+-Xelide-below 500

--- a/test/files/neg/elide-to-nothing.scala
+++ b/test/files/neg/elide-to-nothing.scala
@@ -1,0 +1,31 @@
+
+/** Test which should fail compilation */
+class ElysianFailed {
+
+  import ElysianField._
+
+  // fine
+  val a: Int = myInt
+
+  // fine
+  unimplemented()
+
+  // not fine
+  val b: Nothing = unimplemented()
+  
+}
+
+object ElysianField {
+
+  import annotation.elidable
+
+  @elidable(100) def unimplemented(): Nothing = throw new UnsupportedOperationException
+
+  @elidable(100) def myInt: Int = 17
+
+}
+
+
+
+
+


### PR DESCRIPTION
This is a one-line tweak of Paul's edit to GenICode:
https://issues.scala-lang.org/browse/SI-5215

The intention of the tweak is to disallow eliding the method call if the expected type is Nothing:
val junk: Nothing = elided()

There may be more interesting expressions in which Nothing is expected or inferred.

I added a "neg" test, "elide-to-nothing", following the conventions, I hope.

Running "ant test" completes successfully (and runs the new test) on Cygwin.

I hope this helps, even if no one uses elidable this way.  It was a useful exercise to learn github.
