### PR TITLE
Test for SI-5316

### DIFF
--- a/test/files/neg/implicits.check
+++ b/test/files/neg/implicits.check
@@ -8,4 +8,7 @@ implicits.scala:46: error: type mismatch;
  required: List[Mxml]
         children.toList.flatMap ( e => {
                                 ^
-two errors found
+implicits.scala:66: error: could not find implicit value for parameter x: Nothing
+  foo {
+      ^
+three errors found

--- a/test/files/neg/implicits.scala
+++ b/test/files/neg/implicits.scala
@@ -56,3 +56,19 @@ class Mxml {
     }
 
 } 
+
+// SI-5316
+class Test3 {
+  def foo(p: => Any)(implicit x: Nothing): Unit = ()
+
+  object X
+
+  foo {
+    val a = 0
+
+    {
+      import X._
+      a
+    }
+  }
+}


### PR DESCRIPTION
Compiler NPE on 2.9.1 when implicit parameter not found
