### PR TITLE
Don't populate the concreteSpecMethod set in presentation compiler runs.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -1719,7 +1719,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
    *        that here are not garbage collected at the end of a compiler run!
    */
   def addConcreteSpecMethod(m: Symbol) {
-    if (currentRun.compiles(m)) concreteSpecMethods += m
+    if (!forInteractive && currentRun.compiles(m)) concreteSpecMethods += m
   }
 
   private def makeArguments(fun: Symbol, vparams: List[Symbol]): List[Tree] = (


### PR DESCRIPTION
This is safe because the presentation compiler never runs the tree transformer (where this map is needed). This is a source of serious memory leaks in the IDE, but it wasn't visible before because the IDE didn't run the info transformers far enough. Interestingly, this is not a leak in batch runs: each element of the set is removed when the tree is transformed.

For a nice graph of the effect of this change, see: http://i41.tinypic.com/xe0k7o.jpg
