### PR TITLE
Fix to nightly build.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2053,7 +2053,7 @@ FORWARDED TARGETS FOR NIGHTLY BUILDS
     </antcall>
   </target>
 
-  <target name="nightly-nopt" depends="all.done">
+  <target name="nightly-nopt" depends="all.done, docs.all">
     <!-- cannot antcall all.done, the properties defined in there (dist.dir) are not returned. need depends. -->
     <ant antfile="${src.dir}/build/pack.xml" target="pack-all.done" inheritall="yes" inheritrefs="yes"/>
   </target>


### PR DESCRIPTION
You see shelling to other ant builds doesn't let us declare dependencies
on the primary build, so to ensure all tasks are run when needed,
and that we don't slow everyone down with javadocs, we wind up
with a bit of spaghetti.
