### PR TITLE
Incorrect parsing of -Xplugin

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -533,7 +533,7 @@ class MutableSettings(val errorFn: String => Unit)
       Some(rest)
     }
     override def tryToSetColon(args: List[String]) = tryToSet(args)
-    override def tryToSetFromPropertyValue(s: String) = tryToSet(s.trim.split(" +").toList)
+    override def tryToSetFromPropertyValue(s: String) = tryToSet(s.trim.split(',').toList)
     def unparse: List[String] = value map { name + ":" + _ }
 
     withHelpSyntax(name + ":<" + arg + ">")


### PR DESCRIPTION
# Commit Message

-Xplugin value passed by the Eclipse IDE are incorrectly parsed when it contains whitespaces.

Assume -Xplugin is given the value (in the Eclipse IDE)

  C:\Programs Files\plugins\Aplugin.jar C:\Programs Files\plugins\Bplugin.jar

Calling `tryToSetFromPropertyValue` with the above value will always result
in a total mess, no matter what, because it will split the string at
whitespaces.

The proposed solution is to change the implementation of
`tryToSetFromPropertyValue` to use `,` (comma) as the splitting character

Further, I'm quite convinced that the current implementation of
`MultiStringSetting.tryToSetFromPropertyValue` has never worked, that is why I
did not create an overload of `tryToSetFromPropertyValue` where the splitting
character (or string) can be passed as argument.

For more information, there is also an Eclipse Scala IDE ticket associated to this issue:

  http://scala-ide-portfolio.assembla.com/spaces/scala-ide/tickets/1000917
# Note

Ideally, this should also be merged in 2.9.x (and be available in the next 2.9.2 release).
