### PR TITLE
Better fix for memory leaks in the presentation compiler. 

### DIFF
--- a/src/compiler/scala/tools/nsc/interactive/Global.scala
+++ b/src/compiler/scala/tools/nsc/interactive/Global.scala
@@ -1052,6 +1052,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "")
 
   def newTyperRun() {
     currentTyperRun = new TyperRun
+    perRunCaches.clearAll()
   }
 
   class TyperResult(val tree: Tree) extends ControlThrowable

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -1709,7 +1709,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
    *        that here are not garbage collected at the end of a compiler run!
    */
   def addConcreteSpecMethod(m: Symbol) {
-    if (!forInteractive && currentRun.compiles(m)) concreteSpecMethods += m
+    if (currentRun.compiles(m)) concreteSpecMethods += m
   }
 
   private def makeArguments(fun: Symbol, vparams: List[Symbol]): List[Tree] = (


### PR DESCRIPTION
Switched to perRunCaches and call clearAll from the presentation compiler.

This should go in 2.9.2 (but depends on Paul's commit 455129b32d8634856917f9ecf67987567fb46723
