### PR TITLE
Improvement to API docs: GenTraversableLike and List. Fixes SI-5522.

### DIFF
--- a/src/library/scala/collection/GenTraversableLike.scala
+++ b/src/library/scala/collection/GenTraversableLike.scala
@@ -318,7 +318,7 @@ trait GenTraversableLike[+A, +Repr] extends GenTraversableOnce[A] with Paralleli
    *  $orderDependent
    *
    *  @param from   the lowest index to include from this $coll.
-   *  @param until  the highest index to EXCLUDE from this $coll.
+   *  @param until  the lowest index to EXCLUDE from this $coll.
    *  @return  a $coll containing the elements greater than or equal to
    *           index `from` extending up to (but not including) index `until`
    *           of this $coll.

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -205,6 +205,16 @@ sealed abstract class List[+A] extends AbstractSeq[A]
     these
   }
 
+  /**
+   *  @example {{{
+   *  // Given a list
+   *  val letters = List('a','b','c','d','e')
+   *
+   *  // `slice` returns all elements beginning at index `from` and afterwards,
+   *  // up until index `until` (excluding index `until`.)
+   *  letters.slice(1,3) // Returns List('b','c')
+   *  }}}
+   */
   override def slice(from: Int, until: Int): List[A] = {
     val lo = math.max(from, 0)
     if (until <= lo || isEmpty) Nil


### PR DESCRIPTION
Tiny adjustment of wording in `slice` method on `GenTraversableLike` API docs. Additionally added example to `List` API docs.

Closes [SI-5522](https://issues.scala-lang.org/browse/SI-5522)
