### PR TITLE
Added comments to local definitions. Closes 5527

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2967,10 +2967,10 @@ self =>
       val annots = annotations(true)
       val pos = in.offset
       val mods = (localModifiers() | implicitMod) withAnnotations annots
-      val defs =
+      val defs = joinComment( // for SI-5527
         if (!(mods hasFlag ~(Flags.IMPLICIT | Flags.LAZY))) defOrDcl(pos, mods)
-        else List(tmplDef(pos, mods))
-
+        else List(tmplDef(pos, mods)))
+        
       in.token match {
         case RBRACE | CASE  => defs :+ (Literal(Constant()) setPos o2p(in.offset))
         case _              => defs

--- a/test/files/run/t5527.check
+++ b/test/files/run/t5527.check
@@ -1,0 +1,21 @@
+[[syntax trees at end of parser]]// Scala source: newSource1
+package <empty> {
+  abstract trait Test extends scala.ScalaObject {
+    def $init$() = {
+      ()
+    };
+    def sth: scala.Unit = {
+      /** Some comment here */
+      object Maybe extends scala.ScalaObject {
+        def <init>() = {
+          super.<init>();
+          ()
+        };
+        /** Some comment inside */
+        def nothing() = ()
+      };
+      ()
+    }
+  }
+}
+

--- a/test/files/run/t5527.scala
+++ b/test/files/run/t5527.scala
@@ -1,0 +1,43 @@
+import scala.tools.partest._
+import java.io._
+import scala.tools.nsc._
+import scala.tools.nsc.util.CommandLineParser
+import scala.tools.nsc.doc.{Settings, DocFactory}
+import scala.tools.nsc.reporters.ConsoleReporter
+
+object Test extends DirectTest {
+
+  override def extraSettings: String = "-usejavacp -Xprint:parser -Yrangepos -Ystop-after:parser -d " + testOutput.path
+
+  override def code = """
+    // SI-5527
+    trait Test {
+      def sth {
+        /** Some comment here */
+        object Maybe {
+          /** Some comment inside */
+          def nothing() = ()
+        }
+      }
+    }
+  """
+
+  override def show(): Unit = {
+    // redirect err to out, for logging
+    val prevErr = System.err
+    System.setErr(System.out)
+    compile()
+    System.setErr(prevErr)
+  }
+
+  override def newCompiler(args: String*): Global = {
+    // we want the Scaladoc compiler here, because it keeps DocDef nodes in the tree
+    val settings = new Settings(_ => ()) 
+    val command = new ScalaDoc.Command((CommandLineParser tokenize extraSettings) ++ args.toList, settings)
+    new DocFactory(new ConsoleReporter(settings), settings).compiler
+  }
+
+  override def isDebug = false // so we don't get the newSettings warning
+}
+
+


### PR DESCRIPTION
Reproducing the problem programatically was a bit tricky, as it only occurs with scaladoc -- so please excuse the longer testcase.
Review by @odersky
