### PR TITLE
Better fix for memory leaks in the presentation compiler (take 2)

### DIFF
--- a/src/compiler/scala/reflect/internal/SymbolTable.scala
+++ b/src/compiler/scala/reflect/internal/SymbolTable.scala
@@ -8,6 +8,7 @@ package internal
 
 import scala.collection.{ mutable, immutable }
 import util._
+import scala.tools.nsc.util.WeakHashSet
 
 abstract class SymbolTable extends api.Universe
                               with Collections
@@ -266,9 +267,10 @@ abstract class SymbolTable extends api.Universe
       }
     }
 
-    def newWeakMap[K, V]() = recordCache(mutable.WeakHashMap[K, V]())
-    def newMap[K, V]()     = recordCache(mutable.HashMap[K, V]())
-    def newSet[K]()        = recordCache(mutable.HashSet[K]())
+    def newWeakMap[K, V]()        = recordCache(mutable.WeakHashMap[K, V]())
+    def newMap[K, V]()            = recordCache(mutable.HashMap[K, V]())
+    def newSet[K]()               = recordCache(mutable.HashSet[K]())
+    def newWeakSet[K <: AnyRef]() = recordCache(new WeakHashSet[K]())
   }
 
   /** Break into repl debugger if assertion is true. */

--- a/src/compiler/scala/tools/nsc/interactive/Global.scala
+++ b/src/compiler/scala/tools/nsc/interactive/Global.scala
@@ -1052,7 +1052,6 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "")
 
   def newTyperRun() {
     currentTyperRun = new TyperRun
-    perRunCaches.clearAll()
   }
 
   class TyperResult(val tree: Tree) extends ControlThrowable

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -97,7 +97,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
   private val wasSpecializedForTypeVars = perRunCaches.newMap[Symbol, Set[Symbol]]() withDefaultValue Set()
 
   /** Concrete methods that use a specialized type, or override such methods. */
-  private val concreteSpecMethods = perRunCaches.newSet[Symbol]()
+  private val concreteSpecMethods = perRunCaches.newWeakSet[Symbol]()
 
   private def isSpecialized(sym: Symbol)          = sym hasAnnotation SpecializedClass
   private def hasSpecializedFlag(sym: Symbol)     = sym hasFlag SPECIALIZED

--- a/src/compiler/scala/tools/nsc/util/WeakHashSet.scala
+++ b/src/compiler/scala/tools/nsc/util/WeakHashSet.scala
@@ -1,0 +1,61 @@
+package scala.tools.nsc.util
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable.Builder
+import scala.collection.mutable.SetBuilder
+import scala.runtime.AbstractFunction1
+
+/** A bare-bones implementation of a mutable `Set` that uses weak references
+ *  to hold the elements.
+ *  
+ *  This implementation offers only add/remove/test operations,
+ *  therefore it does not fulfill the contract of Scala collection sets.
+ */
+class WeakHashSet[T <: AnyRef] extends AbstractFunction1[T, Boolean] {
+  private val underlying = mutable.HashSet[WeakReferenceWithEquals[T]]()
+
+  /** Add the given element to this set. */
+  def +=(elem: T): this.type = {
+    underlying += new WeakReferenceWithEquals(elem)
+    this
+  }
+
+  /** Remove the given element from this set. */
+  def -=(elem: T): this.type = {
+    underlying -= new WeakReferenceWithEquals(elem)
+    this
+  }
+
+  /** Does the given element belong to this set? */
+  def contains(elem: T): Boolean = 
+    underlying.contains(new WeakReferenceWithEquals(elem))
+
+  /** Does the given element belong to this set? */
+  def apply(elem: T): Boolean = contains(elem)
+
+  /** Return the number of elements in this set, including reclaimed elements. */
+  def size = underlying.size
+  
+  /** Remove all elements in this set. */
+  def clear() = underlying.clear()
+}
+
+/** A WeakReference implementation that implements equals and hashCode by
+ *  delegating to the referent.
+ */
+class WeakReferenceWithEquals[T <: AnyRef](ref: T) {
+  def get(): T = underlying.get()
+
+  override val hashCode = ref.hashCode
+
+  override def equals(other: Any): Boolean = other match {
+    case wf: WeakReferenceWithEquals[_] =>
+      underlying.get() == wf.get()
+    case _ =>
+      false
+  }
+
+  private val underlying = new java.lang.ref.WeakReference(ref)
+}
+


### PR DESCRIPTION
The explicit call to `perRunCaches.clearAll()` introduced subtle bugs since maps in `Namer` _are_ needed between runs of the presentation compiler. For instance, `classAndNamerOfModule` was cleared when it was still needed, leading to spurious errors in pattern matches (claiming a case class was not a case class).

I added a simple implementation of a `WeakHashMap`, and use it in SpecializedTypes. This fixes the memory leak without the explicit call to `clearAll` in the presentation compiler.

A better implementation could go to the standard library, and I  plan to do that, but it requires a bit more effort to properly integrate it in the collection library. I'll prepare another pull request if that's desirable.
