### PR TITLE
the very last condition in `isStampedForInlining()` should side-effect

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/opt/Inliners.scala
+++ b/src/compiler/scala/tools/nsc/backend/opt/Inliners.scala
@@ -707,7 +707,8 @@ abstract class Inliners extends SubComponent {
       }
 
       def isStampedForInlining(stackLength: Int) =
-        !sameSymbols && inc.m.hasCode && shouldInline && isSafeToInline(stackLength) && !inc.m.symbol.hasFlag(Flags.SYNCHRONIZED)
+        !sameSymbols && inc.m.hasCode && shouldInline &&
+        isSafeToInline(stackLength) // `isSafeToInline()` must be invoked last in this AND expr bc it mutates the `knownSafe` and `knownUnsafe` maps for good.
 
       def logFailure(stackLength: Int) = log(
         """|inline failed for %s:
@@ -764,8 +765,8 @@ abstract class Inliners extends SubComponent {
             true
           }
 
-        if (!inc.m.hasCode || inc.isRecursive)
-          return false
+        if (!inc.m.hasCode || inc.isRecursive)        { return false }
+        if (inc.m.symbol.hasFlag(Flags.SYNCHRONIZED)) { return false }
 
         val accessNeeded = usesNonPublics.getOrElseUpdate(inc.m, {
           // Avoiding crashing the compiler if there are open blocks.


### PR DESCRIPTION
That's the way it was working before scala/scala@fc2866efee1bcf17aee18d427ed41e172f440f62 , and that behavior is brought back with this commit. The commit adds a comment in `isStampedForInlining()` making this explicit to simplify maintenance.
