### PR TITLE
Handle empty format specifiers in the formatting interpolator.

### DIFF
--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -46,10 +46,10 @@ case class StringContext(parts: String*) {
     checkLengths(args: _*)
     val pi = parts.iterator
     val ai = args.iterator
-    val bldr = new java.lang.StringBuilder(treatEscapes(pi.next))
+    val bldr = new java.lang.StringBuilder(treatEscapes(pi.next()))
     while (ai.hasNext) {
       bldr append ai.next
-      bldr append treatEscapes(pi.next)
+      bldr append treatEscapes(pi.next())
     }
     bldr.toString
   }
@@ -89,11 +89,12 @@ case class StringContext(parts: String*) {
     val bldr = new java.lang.StringBuilder
     val args1 = new ArrayBuffer[Any]
     def copyString(first: Boolean): Unit = {
-      val str = treatEscapes(pi.next)
+      val str = treatEscapes(pi.next())
+      val strIsEmpty = str.length == 0
       var start = 0
       var idx = 0
       if (!first) {
-        if ((str charAt 0) != '%')
+        if (strIsEmpty || (str charAt 0) != '%')
           bldr append "%s"
         idx = 1
       }
@@ -106,11 +107,11 @@ case class StringContext(parts: String*) {
         }
         idx += 1
       }
-      bldr append (str substring (start, idx))
+      if (!strIsEmpty) bldr append (str substring (start, idx))
     }
     copyString(first = true)
     while (pi.hasNext) {
-      args1 += ai.next
+      args1 += ai.next()
       copyString(first = false)
     }
     bldr.toString format (args1: _*)

--- a/test/files/run/interpolation.check
+++ b/test/files/run/interpolation.check
@@ -24,3 +24,9 @@ Best price: 13.345
 Best price: 13.35
 13.345% discount included
 13.35% discount included
+
+0
+00
+
+0
+00

--- a/test/files/run/interpolation.scala
+++ b/test/files/run/interpolation.scala
@@ -23,4 +23,10 @@ object Test extends App {
   test2(10.0f)
   test2(13.345f)
 
+  println(s"")
+  println(s"${0}")
+  println(s"${0}${0}")
+  println(f"")
+  println(f"${0}")
+  println(f"${0}${0}")
 }


### PR DESCRIPTION
f"${foo}" is treated like f"${foo}%s".
