### PR TITLE
Backports/SI-5380: non-local return of try expression

### DIFF
--- a/test/files/run/si5380.scala
+++ b/test/files/run/si5380.scala
@@ -1,0 +1,6 @@
+object Test {
+  def main(args: Array[String]) {
+    val f = () => return try { 1 } catch { case _ => 0 }
+    f()
+  }
+}


### PR DESCRIPTION
This is the backport of the two commits which I submitted for master (squashed into one commit):

Fixes SI-5380: non-local return of try expression
(cherry picked from commit 02e260a8e67e2b2b6f876aafe76cd61248a89374)

Lift only _non-local_ returns of try expressions.
(cherry picked from commit edf3ae0b8c3688b5cacbe2f7e2ae826f5fbb7644)
