### PR TITLE
Fixes scaladoc rangepos

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -658,7 +658,8 @@ self =>
             DocDef(doc, t) setPos {
               if (t.pos.isDefined) {
                 val pos = doc.pos.withEnd(t.pos.endOrPoint)
-                if (t.pos.isOpaqueRange) pos else pos.makeTransparent
+                // always make the position transparent
+                pos.makeTransparent
               } else {
                 t.pos
               }
@@ -2967,9 +2968,9 @@ self =>
       val annots = annotations(true)
       val pos = in.offset
       val mods = (localModifiers() | implicitMod) withAnnotations annots
-      val defs = joinComment( // for SI-5527
+      val defs =
         if (!(mods hasFlag ~(Flags.IMPLICIT | Flags.LAZY))) defOrDcl(pos, mods)
-        else List(tmplDef(pos, mods)))
+        else List(tmplDef(pos, mods))
 
       in.token match {
         case RBRACE | CASE  => defs :+ (Literal(Constant()) setPos o2p(in.offset))

--- a/test/files/run/t5527.check
+++ b/test/files/run/t5527.check
@@ -1,11 +1,12 @@
 [[syntax trees at end of parser]]// Scala source: newSource1
 package <empty> {
-  abstract trait Test extends scala.ScalaObject {
-    def $init$() = {
+  object UselessComments extends scala.ScalaObject {
+    def <init>() = {
+      super.<init>();
       ()
     };
-    def sth: scala.Unit = {
-      /** Some comment here */
+    var z = 0;
+    def test1 = {
       object Maybe extends scala.ScalaObject {
         def <init>() = {
           super.<init>();
@@ -15,6 +16,83 @@ package <empty> {
         def nothing() = ()
       };
       ()
+    };
+    def test2 = {
+      var x = 4;
+      if (true)
+        {
+          x = 5;
+          val y = 6;
+          ()
+        }
+      else
+        ()
+    };
+    def test3 = {
+      if (true)
+        z = 3
+      else
+        ();
+      val t = 4;
+      0.to(4).foreach(((i) => println(i)))
+    };
+    val test4 = 'a' match {
+      case ('0'| '1'| '2'| '3'| '4'| '5'| '6'| '7'| '8'| '9') => true
+      case _ => false
+    }
+  };
+  /** comments that we should keep */
+  object UsefulComments extends scala.ScalaObject {
+    def <init>() = {
+      super.<init>();
+      ()
+    };
+    /** class A */
+    class A extends scala.ScalaObject {
+      def <init>() = {
+        super.<init>();
+        ()
+      };
+      /** f */
+      def f(i: Int) = i;
+      /** v */
+      val v = 1;
+      /** u */
+      var u = 2
+    };
+    /** trait B */
+    abstract trait B extends scala.ScalaObject {
+      def $init$() = {
+        ()
+      };
+      /** T */
+      type T >: _root_.scala.Nothing <: _root_.scala.Any;
+      /** f */
+      def f(i: Int): scala.Unit;
+      /** v */
+      val v = 1;
+      /** u */
+      var u = 2
+    };
+    /** object C */
+    object C extends scala.ScalaObject {
+      def <init>() = {
+        super.<init>();
+        ()
+      };
+      /** f */
+      def f(i: Int) = i;
+      /** v */
+      val v = 1;
+      /** u */
+      var u = 2
+    };
+    /** class D */
+    @new deprecated("use ... instead", "2.10.0") class D extends scala.ScalaObject {
+      def <init>() = {
+        super.<init>();
+        ()
+      }
     }
   }
 }

--- a/test/files/run/t5527.scala
+++ b/test/files/run/t5527.scala
@@ -11,14 +11,80 @@ object Test extends DirectTest {
 
   override def code = """
     // SI-5527
-    trait Test {
-      def sth {
+    object UselessComments {
+
+      var z = 0
+
+      def test1 = {
         /** Some comment here */
         object Maybe {
           /** Some comment inside */
           def nothing() = ()
         }
       }
+
+      def test2 = {
+        var x = 4
+        if (true) {
+          /** Testing 123 */
+          x = 5
+          val y = 6
+        }
+      }
+
+      def test3 = {
+        if (true)
+         z = 3
+
+        /** Calculate this result. */
+        val t = 4
+        for (i <- 0 to 4)
+          println(i)
+      }
+
+      val test4 = ('a') match {
+        /** Another digit is a giveaway. */
+        case '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'  =>
+          true
+        case _ =>
+          false
+      }
+    }
+
+    /** comments that we should keep */
+    object UsefulComments {
+      /** class A */
+      class A {
+        /** f */
+        def f(i: Int) = i
+        /** v */
+        val v = 1
+        /** u */
+        var u = 2
+      }     
+      /** trait B */
+      trait B {
+        /** T */
+        type T
+        /** f */
+        def f(i: Int)
+        /** v */
+        val v = 1
+        /** u */
+        var u = 2
+      }     
+      /** object C */
+      object C {
+        /** f */
+        def f(i: Int) = i
+        /** v */
+        val v = 1
+        /** u */
+        var u = 2
+      }
+      /** class D */
+      @deprecated("use ... instead", "2.10.0")
+      class D
     }
   """.trim
 


### PR DESCRIPTION
By making the comment tree node transparent. Reverts previous change
in cfb04ef065. Will mark the bug 5527 as WONTFIX, because the effort
of fixing leaking comments is too great.
