### PR TITLE
Fix deadlocks occurring during presentation compiler shutdown.

### DIFF
--- a/src/compiler/scala/tools/nsc/interactive/CompilerControl.scala
+++ b/src/compiler/scala/tools/nsc/interactive/CompilerControl.scala
@@ -10,6 +10,8 @@ import scala.tools.nsc.io.AbstractFile
 import scala.tools.nsc.util.{SourceFile, Position, WorkScheduler}
 import scala.tools.nsc.symtab._
 import scala.tools.nsc.ast._
+import scala.tools.nsc.util.FailedInterrupt
+import scala.tools.nsc.util.EmptyAction
 
 /** Interface of interactive compiler to a client such as an IDE
  *  The model the presentation compiler consists of the following parts:
@@ -48,7 +50,7 @@ trait CompilerControl { self: Global =>
   /** The scheduler by which client and compiler communicate
    *  Must be initialized before starting compilerRunner
    */
-  protected[interactive] val scheduler = new WorkScheduler
+  @volatile protected[interactive] var scheduler = new WorkScheduler
 
   /** Return the compilation unit attached to a source file, or None
    *  if source is not loaded.
@@ -349,6 +351,25 @@ trait CompilerControl { self: Global =>
 
     def raiseMissing() =
       response raise new MissingResponse
+  }
+
+  /** A do-nothing work scheduler that responds immediately with MissingResponse.
+   *
+   *  Used during compiler shutdown.
+   */
+  class NoWorkScheduler extends WorkScheduler {
+
+    override def postWorkItem(action: Action) = synchronized {
+      action match {
+        case w: WorkItem => w.raiseMissing()
+        case e: EmptyAction => // do nothing
+        case _ => println("don't know what to do with this " + action.getClass)
+      }
+    }
+    
+    override def doQuickly[A](op: () => A): A = {
+      throw new FailedInterrupt(new Exception("Posted a work item to a compiler that's shutting down"))
+    }
   }
 
 }

--- a/src/compiler/scala/tools/nsc/interactive/Global.scala
+++ b/src/compiler/scala/tools/nsc/interactive/Global.scala
@@ -358,6 +358,7 @@ class Global(settings: Settings, reporter: Reporter, projectName: String = "")
             checkNoResponsesOutstanding()
 
             log.flush();
+            scheduler = new NoWorkScheduler
             throw ShutdownReq
           }
 
@@ -610,6 +611,15 @@ class Global(settings: Settings, reporter: Reporter, projectName: String = "")
         }
         response raise ex
         throw ex
+
+      case ex @ ShutdownReq =>
+        if (debugIDE) {
+          println("ShutdownReq thrown during response")
+          ex.printStackTrace()
+        }
+        response raise ex
+        throw ex
+
       case ex =>
         if (debugIDE) {
           println("exception thrown during response: "+ex)


### PR DESCRIPTION
During shutdown, other threads can still post work items on the work queue. They will never be serviced,
leading to clients waiting forever.

The fix is to replace the implementation of the queue with a 'always fail' implementation during shutdown.
Review by @odersky.(cherry picked from commit 53fb61cba9f02c176f1aae80f0b270491fbbf91c)

(removed the test because there are no presentation compiler tests in 2.9.x and it depends on test infrastructure that is not in place).

Conflicts:

```
src/compiler/scala/tools/nsc/interactive/CompilerControl.scala
```
