### PR TITLE
Force .info before creating new synthetic syms

### DIFF
--- a/test/files/run/t5545.scala
+++ b/test/files/run/t5545.scala
@@ -1,0 +1,27 @@
+import scala.tools.partest._
+import java.io._
+
+object Test extends DirectTest {
+
+  override def extraSettings: String = "-usejavacp -d " + testOutput.path + " -cp " + testOutput.path
+
+  override def code = """
+    // SI-5545
+    trait F[@specialized(Int) T1, R] {
+      def f(v1: T1): R
+      def g = v1 => f(v1)
+    }
+  """.trim
+
+  override def show(): Unit = {
+    // redirect err to out, for logging
+    val prevErr = System.err
+    System.setErr(System.out)
+    compile()
+    // the bug manifests at the second compilation, when the bytecode is already there
+    compile()
+    System.setErr(prevErr)
+  }
+
+  override def isDebug = false // so we don't get the newSettings warning
+}


### PR DESCRIPTION
Closes SI-5545. In the long run this should be generalized, as other
phases might suffer from the same problem. Full explanation here:
https://issues.scala-lang.org/browse/SI-5545
