### PR TITLE
SI-5045 - allow for using Regex without implicit anchors

### DIFF
--- a/src/library/scala/collection/immutable/StringLike.scala
+++ b/src/library/scala/collection/immutable/StringLike.scala
@@ -12,6 +12,7 @@ package immutable
 import generic._
 import mutable.Builder
 import scala.util.matching.Regex
+import scala.util.matching.NoImplicitAnchors
 import scala.math.ScalaNumber
 
 /** A companion object for the `StringLike` containing some constants.
@@ -221,6 +222,14 @@ self =>
    *  @param groupNames The names of the groups in the pattern, in the order they appear.
    */
   def r(groupNames: String*): Regex = new Regex(toString, groupNames: _*)
+
+  /** You can follow a string with `.qr`, turning it into a `Regex with NoImplictAnchors`. E.g.
+   *
+   *  """A\w*""".qr   is the regular expression for extracting identifiers starting with `A`.
+   */
+  def qr: Regex with NoImplicitAnchors = qr()
+
+  def qr(groupNames: String*): Regex with NoImplicitAnchors = new Regex(toString, groupNames: _*) with NoImplicitAnchors
 
   def toBoolean: Boolean = parseBoolean(toString)
   def toByte: Byte       = java.lang.Byte.parseByte(toString)

--- a/test/files/run/si5045.scala
+++ b/test/files/run/si5045.scala
@@ -1,0 +1,46 @@
+object Test extends App {
+
+ import scala.util.matching.{Regex, NoImplicitAnchors}
+
+ val dateP1 = """(\d\d\d\d)-(\d\d)-(\d\d)""".qr
+ val dateP2 = """(\d\d\d\d)-(\d\d)-(\d\d)""" qr ("year", "month", "day")
+ val dateP3 =  new Regex("""(\d\d\d\d)-(\d\d)-(\d\d)""", "year", "month", "day") with NoImplicitAnchors
+
+ val yearStr = "2011"
+ val dateStr = List(yearStr,"07","15").mkString("-")
+
+  def test(msg: String)(body: => Boolean): Unit = assert(body, msg)
+
+  test("extract an exact match") {
+    val dateP1(y,m,d) = dateStr
+    List(y,m,d).mkString("-") == dateStr
+  }
+
+  test("extract from middle of string") {
+    val dateP1(y,m,d) = "Tested on "+dateStr+"."
+    List(y,m,d).mkString("-") == dateStr
+  }
+
+  test("extract from middle of string (P2)") {
+    val dateP2(y,m,d) = "Tested on "+dateStr+"."
+    List(y,m,d).mkString("-") == dateStr
+  }
+
+  test("extract from middle of string (P3)") {
+    val dateP2(y,m,d) = "Tested on "+dateStr+"."
+    List(y,m,d).mkString("-") == dateStr
+  }
+
+  def copyright(in: String): String = in match {
+    case dateP1(year, month, day) => "Copyright "+year
+    case _                        => "No copyright"
+  }
+
+  test("copyright example has date") {
+    copyright("Date of this document: "+dateStr) == "Copyright "+yearStr
+  }
+
+  test("copyright example missing date") {
+    copyright("Date of this document: unknown") == "No copyright"
+  }
+}


### PR DESCRIPTION
Code changes to address SI-5045 (https://issues.scala-lang.org/browse/SI-5045)
- Add trait NoImplictAnchors to override Regex.unapplySeq
- Add .qr method to StringLike to create a Regex with NoImplicitAnchors
- Add tests of above

Have discussed in jira, scala-debate, and plan to raise the suggested change on scala-language.
