### PR TITLE
Separating Scala Actors from the Scala Library.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -614,9 +614,9 @@ QUICK BUILD (QUICK)
       <srcfiles dir="${src.dir}">
         <include name="library/**"/>
         <include name="dbc/**"/>
-        <include name="actors/**"/>
         <include name="continuations/**"/>
         <include name="swing/**"/>
+        <include name="actors/**"/>
       </srcfiles>
     </uptodate>
   </target>
@@ -995,6 +995,7 @@ PACKED QUICK BUILD (PACK)
       <fileset dir="${build-quick.dir}/classes/library">
         <exclude name="scala/dbc/**"/>
         <exclude name="scala/swing/**"/>
+        <exclude name="scala/actors/**"/>
       </fileset>
       <zipfileset dirmode="755" filemode="644" src="${forkjoin.jar}"/>
     </jar>
@@ -1008,6 +1009,11 @@ PACKED QUICK BUILD (PACK)
         <include name="scala/swing/**"/>
       </fileset>
     </jar>
+  <jar destfile="${build-pack.dir}/lib/scala-actors.jar">
+      <fileset dir="${build-quick.dir}/classes/library">
+        <include name="scala/actors/**"/>
+      </fileset>
+  </jar>
   </target>
   
   <target name="pack.pre-comp" depends="pack.lib">
@@ -1137,6 +1143,7 @@ PACKED QUICK BUILD (PACK)
       <pathelement location="${build-pack.dir}/lib/scala-compiler.jar"/>
       <pathelement location="${build-pack.dir}/lib/scala-partest.jar"/>
       <pathelement location="${build-pack.dir}/lib/scalap.jar"/>
+      <pathelement location="${build-pack.dir}/lib/scala-actors.jar"/>
       <pathelement location="${ant.jar}"/>
       <pathelement location="${jline.jar}"/>
       <path refid="lib.extra"/>
@@ -1160,8 +1167,8 @@ BOOTSTRAPPING BUILD (STRAP)
       <srcfiles dir="${src.dir}">
         <include name="library/**"/>
         <include name="dbc/**"/>
-        <include name="actors/**"/>
         <include name="swing/**"/>
+        <include name="actors/**"/>
       </srcfiles>
     </uptodate>
   </target>
@@ -1589,8 +1596,8 @@ DOCUMENTATION
       <source-includes>
         <include name="library/**"/>
         <include name="dbc/**"/>
-        <include name="actors/**"/>
         <include name="swing/**"/>
+        <include name="actors/**"/>
       </source-includes>
     </doc-uptodate-check>
   </target>
@@ -1608,7 +1615,7 @@ DOCUMENTATION
       sourcepath="${src.dir}"
       classpathref="pack.classpath"
       addparams="${scalac.args.all}"
-      docRootContent="${src.dir}/library/rootdoc.txt"> 
+      docRootContent="${src.dir}/library/rootdoc.txt">
       <src>
         <files includes="${src.dir}/actors"/>
         <files includes="${src.dir}/library/scala"/>
@@ -1967,7 +1974,6 @@ DISTRIBUTION
     <mkdir dir="${dist.dir}/src"/>
     <jar destfile="${dist.dir}/src/scala-library-src.jar">
       <fileset dir="${src.dir}/library"/>
-      <fileset dir="${src.dir}/actors"/>
       <fileset dir="${src.dir}/continuations/library"/>
     </jar>
     <jar destfile="${dist.dir}/src/scala-dbc-src.jar">
@@ -1978,6 +1984,9 @@ DISTRIBUTION
     </jar>
     <jar destfile="${dist.dir}/src/scala-compiler-src.jar">
       <fileset dir="${src.dir}/compiler"/>
+    </jar>
+    <jar destfile="${dist.dir}/src/scala-actors-src.jar">
+      <fileset dir="${src.dir}/actors"/>
     </jar>
     <jar destfile="${dist.dir}/src/scalap-src.jar">
       <fileset dir="${src.dir}/scalap"/>
@@ -2055,8 +2064,8 @@ STABLE REFERENCE (STARR)
   <target name="starr.src" depends="starr.comp">
     <jar destfile="${basedir}/lib/scala-library-src.jar">
       <fileset dir="${basedir}/src/library"/>
-      <fileset dir="${basedir}/src/actors"/>
       <fileset dir="${basedir}/src/swing"/>
+      <fileset dir="${basedir}/src/actors"/>
       <fileset dir="${basedir}/src/dbc"/>
     </jar>
   </target>

--- a/src/build/maven/maven-deploy.xml
+++ b/src/build/maven/maven-deploy.xml
@@ -111,11 +111,12 @@
         <deploy-local name="scala-library" version="@{version}" repository="@{repository}" />
         <deploy-local name="scala-compiler" version="@{version}" repository="@{repository}" />
         <deploy-local-plugin name="continuations" version="@{version}" repository="@{repository}"/>
+        <deploy-local name="scala-actors" version="@{version}" repository="@{repository}" />
         <deploy-local name="scala-dbc" version="@{version}" repository="@{repository}" />
         <deploy-local name="scala-swing" version="@{version}" repository="@{repository}"/>
-      	<deploy-local name="scalap" version="@{version}" repository="@{repository}"/>
-      	<deploy-local name="scala-partest" version="@{version}" repository="@{repository}"/>
-      	<deploy-local name="jline" version="@{version}" repository="@{repository}"/>
+        <deploy-local name="scalap" version="@{version}" repository="@{repository}"/>
+        <deploy-local name="scala-partest" version="@{version}" repository="@{repository}"/>
+        <deploy-local name="jline" version="@{version}" repository="@{repository}"/>
       </sequential>
     </macrodef>
   </target>
@@ -168,12 +169,13 @@
             <artifact:attach type="jar" file="scala-library/scala-library-docs.jar" classifier="javadoc" />
           </extra-attachments>
         </deploy-remote>
-      	<deploy-remote name="jline" version="@{version}" repository="@{repository}"/>
+        <deploy-remote name="jline" version="@{version}" repository="@{repository}"/>
         <deploy-remote name="scala-compiler" version="@{version}" repository="@{repository}" />
         <deploy-remote name="scala-dbc" version="@{version}" repository="@{repository}" />
         <deploy-remote name="scala-swing" version="@{version}" repository="@{repository}"/>
-      	<deploy-remote name="scalap" version="@{version}" repository="@{repository}"/>
-      	<deploy-remote name="scala-partest" version="@{version}" repository="@{repository}"/>
+        <deploy-remote name="scala-actors" version="@{version}" repository="@{repository}"/>
+        <deploy-remote name="scalap" version="@{version}" repository="@{repository}"/>
+        <deploy-remote name="scala-partest" version="@{version}" repository="@{repository}"/>
         <deploy-remote-plugin name="continuations" version="@{version}" repository="@{repository}"/> 
       </sequential>
     </macrodef>
@@ -234,13 +236,14 @@
       <attribute name="version" />
       <sequential>
         <deploy-remote-plugin-signed name="continuations" version="@{version}" repository="@{repository}"/> 
-      	<deploy-remote-signed name="scala-library" version="@{version}" repository="@{repository}"/>
-      	<deploy-remote-signed name="jline" version="@{version}" repository="@{repository}"/>
+        <deploy-remote-signed name="scala-library" version="@{version}" repository="@{repository}"/>
+        <deploy-remote-signed name="jline" version="@{version}" repository="@{repository}"/>
         <deploy-remote-signed name="scala-compiler" version="@{version}" repository="@{repository}" />
         <deploy-remote-signed name="scala-dbc" version="@{version}" repository="@{repository}" />
         <deploy-remote-signed name="scala-swing" version="@{version}" repository="@{repository}"/>
-      	<deploy-remote-signed name="scalap" version="@{version}" repository="@{repository}"/>
-      	<deploy-remote-signed name="scala-partest" version="@{version}" repository="@{repository}"/>
+        <deploy-remote-signed name="scala-actors" version="@{version}" repository="@{repository}"/>
+        <deploy-remote-signed name="scalap" version="@{version}" repository="@{repository}"/>
+        <deploy-remote-signed name="scala-partest" version="@{version}" repository="@{repository}"/>
       </sequential>
     </macrodef>
   </target>

--- a/src/build/maven/scala-actors-pom.xml
+++ b/src/build/maven/scala-actors-pom.xml
@@ -1,0 +1,62 @@
+<project
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.scala-lang</groupId>
+	<artifactId>scala-actors</artifactId>
+	<packaging>jar</packaging>
+	<version>@VERSION@</version>
+  <name>Scala Actors library</name>
+  <description>Deprecated Actors Library for Scala</description>
+  <url>http://www.scala-lang.org/</url>  
+  <inceptionYear>2006</inceptionYear>
+  <organization>
+      <name>LAMP/EPFL</name>
+      <url>http://lamp.epfl.ch/</url>
+   </organization>
+   <licenses>
+      <license>
+         <name>BSD-like</name>
+         <url>http://www.scala-lang.org/downloads/license.html
+         </url>
+         <distribution>repo</distribution>
+      </license>
+   </licenses>
+   <scm>
+      <connection>scm:svn:http://lampsvn.epfl.ch/svn-repos/scala/scala/trunk</connection>
+      <url>https://lampsvn.epfl.ch/trac/scala/browser/scala/trunk</url>
+   </scm>
+   <issueManagement>
+      <system>trac</system>
+      <url>http://lampsvn.epfl.ch/trac/scala
+      </url>
+   </issueManagement>	
+	<dependencies>
+		<dependency>
+			<groupId>org.scala-lang</groupId>
+			<artifactId>scala-library</artifactId>
+			<version>@VERSION@</version>
+		</dependency>
+	</dependencies>
+	<distributionManagement>
+		<repository>
+			<id>scala-tools.org</id>
+			<url>@RELEASE_REPOSITORY@</url>
+		</repository>
+		<snapshotRepository>
+			<id>scala-tools.org</id>
+			<url>@SNAPSHOT_REPOSITORY@</url>
+			<uniqueVersion>false</uniqueVersion>
+		</snapshotRepository>
+	</distributionManagement>
+  <developers>
+    <developer>
+      <id>lamp</id>
+      <name>EPFL LAMP</name>
+    </developer>
+    <developer>
+      <id>Typesafe</id>
+      <name>Typesafe, Inc.</name>
+    </developer>
+  </developers>
+</project>

--- a/src/build/pack.xml
+++ b/src/build/pack.xml
@@ -114,8 +114,8 @@ MAIN DISTRIBUTION SBAZ
       version="${version.number}"
       desc="The Scala library. This is the minimal requirement to run any Scala program."
       link="${sbaz.universe}/scala-library-${version.number}.sbp">
-      <libset dir="${dist.dir}/lib" includes="scala-library.jar,scala-dbc.jar,scala-swing.jar"/>
-      <srcset dir="${dist.dir}/src" includes="scala-library-src.jar,scala-dbc-src.jar,scala-swing-src.jar"/>
+      <libset dir="${dist.dir}/lib" includes="scala-library.jar,scala-dbc.jar,scala-swing.jar,scala-actors.jar"/>
+      <srcset dir="${dist.dir}/src" includes="scala-library-src.jar,scala-dbc-src.jar,scala-swing-src.jar,scala-actors-src.jar"/>
       <looseset destination="doc">
         <fileset dir="${dist.dir}/doc" includes="LICENSE,README"/>
       </looseset>
@@ -228,6 +228,7 @@ MAIN DISTRIBUTION SBAZ
     <mvn-copy-lib mvn.artifact.name="scala-compiler"/>
     <mvn-copy-lib mvn.artifact.name="scala-dbc"/>
     <mvn-copy-lib mvn.artifact.name="scala-swing"/>
+    <mvn-copy-lib mvn.artifact.name="scala-actors"/>
     <mvn-copy-lib mvn.artifact.name="scala-partest"/>
     <mvn-copy-lib mvn.artifact.name="scalap"/>
   </target>
@@ -290,10 +291,12 @@ MAIN DISTRIBUTION SBAZ
          basedir="${build-docs.dir}/continuations-plugin">
       <include name="**/*"/>
     </jar>
-    <!-- TODO - Scala swing, dbc should maybe have thier own jar, but creating it is SLOW. -->
+    <!-- TODO - Scala swing, dbc and actors should maybe have thier own jar, but creating it is SLOW. -->
     <copy tofile="${dists.dir}/maven/${version.number}/scala-swing/scala-swing-docs.jar"
           file="${dists.dir}/maven/${version.number}/scala-library/scala-library-docs.jar"/>
     <copy tofile="${dists.dir}/maven/${version.number}/scala-dbc/scala-dbc-docs.jar"
+          file="${dists.dir}/maven/${version.number}/scala-library/scala-library-docs.jar"/>
+    <copy tofile="${dists.dir}/maven/${version.number}/scala-actors/scala-actors-docs.jar"
           file="${dists.dir}/maven/${version.number}/scala-library/scala-library-docs.jar"/>
   </target>
 

--- a/src/partest/scala/tools/partest/PartestTask.scala
+++ b/src/partest/scala/tools/partest/PartestTask.scala
@@ -299,6 +299,16 @@ class PartestTask extends Task with CompilationPathProperty {
       }
     } getOrElse sys.error("Provided classpath does not contain a Scala partest.")
 
+    val scalaActors = {
+      (classpath.list map { fs => new File(fs) }) find { f =>
+        f.getName match {
+          case "scala-actors.jar" => true
+          case "actors" if (f.getParentFile.getName == "classes") => true
+          case _ => false
+        }
+      }
+    } getOrElse sys.error("Provided classpath does not contain a Scala actors.")
+
     def scalacArgsFlat: Option[Seq[String]] = scalacArgs map (_ flatMap { a =>
       val parts = a.getParts
       if(parts eq null) Seq[String]() else parts.toSeq
@@ -324,6 +334,7 @@ class PartestTask extends Task with CompilationPathProperty {
     antFileManager.LATEST_LIB = scalaLibrary.getAbsolutePath
     antFileManager.LATEST_COMP = scalaCompiler.getAbsolutePath
     antFileManager.LATEST_PARTEST = scalaPartest.getAbsolutePath
+    antFileManager.LATEST_ACTORS = scalaActors.getAbsolutePath
 
     javacmd foreach (x => antFileManager.JAVACMD = x.getAbsolutePath)
     javaccmd foreach (x => antFileManager.JAVAC_CMD = x.getAbsolutePath)

--- a/src/partest/scala/tools/partest/nest/AntRunner.scala
+++ b/src/partest/scala/tools/partest/nest/AntRunner.scala
@@ -22,6 +22,7 @@ class AntRunner extends DirectRunner {
     var LATEST_LIB: String = _
     var LATEST_COMP: String = _
     var LATEST_PARTEST: String = _
+    var LATEST_ACTORS: String = _
     val testRootPath: String = "test"
     val testRootDir: Directory = Directory(testRootPath)
   }

--- a/src/partest/scala/tools/partest/nest/ConsoleFileManager.scala
+++ b/src/partest/scala/tools/partest/nest/ConsoleFileManager.scala
@@ -83,6 +83,7 @@ class ConsoleFileManager extends FileManager {
 
       latestFile        = testClassesDir.parent / "bin"
       latestLibFile     = testClassesDir / "library"
+      latestActorsFile  = testClassesDir / "library" / "actors"
       latestCompFile    = testClassesDir / "compiler"
       latestPartestFile = testClassesDir / "partest"
       latestFjbgFile    = testParent / "lib" / "fjbg.jar"
@@ -92,6 +93,7 @@ class ConsoleFileManager extends FileManager {
       NestUI.verbose("Running on "+dir)
       latestFile        = dir / "bin"
       latestLibFile     = dir / "lib/scala-library.jar"
+      latestActorsFile  = dir / "lib/scala-actors.jar"
       latestCompFile    = dir / "lib/scala-compiler.jar"
       latestPartestFile = dir / "lib/scala-partest.jar"
     }
@@ -100,6 +102,7 @@ class ConsoleFileManager extends FileManager {
         NestUI.verbose("Running build/quick")
         latestFile        = prefixFile("build/quick/bin")
         latestLibFile     = prefixFile("build/quick/classes/library")
+        latestActorsFile  = prefixFile("build/quick/classes/library/actors")
         latestCompFile    = prefixFile("build/quick/classes/compiler")
         latestPartestFile = prefixFile("build/quick/classes/partest")
       }
@@ -109,6 +112,7 @@ class ConsoleFileManager extends FileManager {
         val p = testParent.getParentFile
         latestFile        = prefixFileWith(p, "bin")
         latestLibFile     = prefixFileWith(p, "lib/scala-library.jar")
+        latestActorsFile  = prefixFileWith(p, "lib/scala-actors.jar")
         latestCompFile    = prefixFileWith(p, "lib/scala-compiler.jar")
         latestPartestFile = prefixFileWith(p, "lib/scala-partest.jar")
       }
@@ -117,6 +121,7 @@ class ConsoleFileManager extends FileManager {
         NestUI.verbose("Running dists/latest")
         latestFile        = prefixFile("dists/latest/bin")
         latestLibFile     = prefixFile("dists/latest/lib/scala-library.jar")
+        latestActorsFile  = prefixFile("dists/latest/lib/scala-actors.jar")
         latestCompFile    = prefixFile("dists/latest/lib/scala-compiler.jar")
         latestPartestFile = prefixFile("dists/latest/lib/scala-partest.jar")
       }
@@ -125,6 +130,7 @@ class ConsoleFileManager extends FileManager {
         NestUI.verbose("Running build/pack")
         latestFile        = prefixFile("build/pack/bin")
         latestLibFile     = prefixFile("build/pack/lib/scala-library.jar")
+        latestActorsFile  = prefixFile("build/pack/lib/scala-actors.jar")
         latestCompFile    = prefixFile("build/pack/lib/scala-compiler.jar")
         latestPartestFile = prefixFile("build/pack/lib/scala-partest.jar")
       }
@@ -159,14 +165,17 @@ class ConsoleFileManager extends FileManager {
     LATEST_LIB = latestLibFile.getAbsolutePath
     LATEST_COMP = latestCompFile.getAbsolutePath
     LATEST_PARTEST = latestPartestFile.getAbsolutePath
+    LATEST_ACTORS = latestActorsFile.getAbsolutePath
   }
 
   var LATEST_LIB: String = ""
   var LATEST_COMP: String = ""
   var LATEST_PARTEST: String = ""
+  var LATEST_ACTORS: String = ""
 
   var latestFile: File = _
   var latestLibFile: File = _
+  var latestActorsFile: File = _
   var latestCompFile: File = _
   var latestPartestFile: File = _
   var latestFjbgFile: File = _

--- a/src/partest/scala/tools/partest/nest/DirectRunner.scala
+++ b/src/partest/scala/tools/partest/nest/DirectRunner.scala
@@ -57,13 +57,14 @@ trait DirectRunner {
     // for example, see how it's done in ReflectiveRunner
     //val consFM = new ConsoleFileManager
     //import consFM.{ latestCompFile, latestLibFile, latestPartestFile }
-    val latestCompFile = new File(fileManager.LATEST_COMP);
-    val latestLibFile = new File(fileManager.LATEST_LIB);
-    val latestPartestFile = new File(fileManager.LATEST_PARTEST);
+    val latestCompFile = new File(fileManager.LATEST_COMP)
+    val latestLibFile = new File(fileManager.LATEST_LIB)
+    val latestPartestFile = new File(fileManager.LATEST_PARTEST)
+    val latestActorsFile = new File(fileManager.LATEST_ACTORS)
 
     val scalacheckURL = PathSettings.scalaCheck.toURL
     val scalaCheckParentClassLoader = ScalaClassLoader.fromURLs(
-      List(scalacheckURL, latestCompFile.toURI.toURL, latestLibFile.toURI.toURL, latestPartestFile.toURI.toURL)
+      scalacheckURL :: (List(latestCompFile, latestLibFile, latestActorsFile, latestPartestFile).map(_.toURI.toURL))
     )
     Output.init()
 

--- a/src/partest/scala/tools/partest/nest/FileManager.scala
+++ b/src/partest/scala/tools/partest/nest/FileManager.scala
@@ -62,6 +62,7 @@ trait FileManager extends FileUtil {
   var LATEST_LIB: String
   var LATEST_COMP: String
   var LATEST_PARTEST: String
+  var LATEST_ACTORS: String
 
   var showDiff = false
   var updateCheck = false

--- a/src/partest/scala/tools/partest/nest/ReflectiveRunner.scala
+++ b/src/partest/scala/tools/partest/nest/ReflectiveRunner.scala
@@ -48,9 +48,9 @@ class ReflectiveRunner {
         new ConsoleFileManager
 
     import fileManager.
-      { latestCompFile, latestLibFile, latestPartestFile, latestFjbgFile, latestScalapFile }
+      { latestCompFile, latestLibFile, latestPartestFile, latestFjbgFile, latestScalapFile, latestActorsFile }
     val files =
-      Array(latestCompFile, latestLibFile, latestPartestFile, latestFjbgFile, latestScalapFile) map (x => io.File(x))
+      Array(latestCompFile, latestLibFile, latestPartestFile, latestFjbgFile, latestScalapFile, latestActorsFile) map (x => io.File(x))
 
     val sepUrls   = files map (_.toURL)
     var sepLoader = new URLClassLoader(sepUrls, null)

--- a/src/partest/scala/tools/partest/nest/SBTRunner.scala
+++ b/src/partest/scala/tools/partest/nest/SBTRunner.scala
@@ -15,6 +15,7 @@ object SBTRunner extends DirectRunner {
     var LATEST_LIB: String     = _
     var LATEST_COMP: String     = _
     var LATEST_PARTEST: String     = _
+    var LATEST_ACTORS: String     = _
     val testRootPath: String   = "test"
     val testRootDir: Directory = Directory(testRootPath)
   }
@@ -60,6 +61,9 @@ object SBTRunner extends DirectRunner {
     fileManager.LATEST_COMP = comp getOrElse sys.error("No scala-compiler found! Classpath = " + fileManager.CLASSPATH)
     val partest: Option[String] = (fileManager.CLASSPATH split File.pathSeparator filter (_ matches ".*scala-partest.*\\.jar")).headOption
     fileManager.LATEST_PARTEST = partest getOrElse sys.error("No scala-partest found! Classpath = " + fileManager.CLASSPATH)
+    val actors: Option[String] = (fileManager.CLASSPATH split File.pathSeparator filter (_ matches ".*scala-actors.*\\.jar")).headOption
+    fileManager.LATEST_ACTORS = actors getOrElse sys.error("No scala-actors found! Classpath = " + fileManager.CLASSPATH)
+
     // TODO - Do something useful here!!!
     fileManager.JAVAC_CMD = "javac"
     fileManager.failed      = config.justFailedTests

--- a/src/partest/scala/tools/partest/nest/Worker.scala
+++ b/src/partest/scala/tools/partest/nest/Worker.scala
@@ -55,6 +55,7 @@ class ScalaCheckFileManager(val origmanager: FileManager) extends FileManager {
   var LATEST_LIB: String = origmanager.LATEST_LIB
   var LATEST_COMP: String = origmanager.LATEST_COMP
   var LATEST_PARTEST: String = origmanager.LATEST_PARTEST
+  var LATEST_ACTORS: String = origmanager.LATEST_ACTORS
 }
 
 object Output {


### PR DESCRIPTION
Scala actors are now in scala-actors.jar. Changes that were done are:
- Fixed partest to include actors library for various test usages
- Created the entry for the new jar in build.xml
- Added maven entries for scala actors

Review by: @jsuereth
