### PR TITLE
virtpatmat: jump-based codegen + tail calls + (partial)fun synthesis during typer (WIP) + more skolem-packing (WIP)

### DIFF
--- a/src/compiler/scala/reflect/internal/Trees.scala
+++ b/src/compiler/scala/reflect/internal/Trees.scala
@@ -350,8 +350,9 @@ trait Trees extends api.Trees { self: SymbolTable =>
     "subst[%s, %s](%s)".format(fromStr, toStr, (from, to).zipped map (_ + " -> " + _) mkString ", ")
   }
 
-  // NOTE: if symbols in `from` occur multiple times in the `tree` passed to `transform`,
-  // the resulting Tree will be a graph, not a tree... this breaks all sorts of stuff,
+  // NOTE: calls shallowDuplicate on trees in `to` to avoid problems when symbols in `from`
+  // occur multiple times in the `tree` passed to `transform`,
+  // otherwise, the resulting Tree would be a graph, not a tree... this breaks all sorts of stuff,
   // notably concerning the mutable aspects of Trees (such as setting their .tpe)
   class TreeSubstituter(from: List[Symbol], to: List[Tree]) extends Transformer {
     override def transform(tree: Tree): Tree = tree match {

--- a/src/compiler/scala/reflect/internal/Types.scala
+++ b/src/compiler/scala/reflect/internal/Types.scala
@@ -2617,15 +2617,6 @@ trait Types extends api.Types { self: SymbolTable =>
     }
   }
 
-  // TODO: I don't really know why this happens -- maybe because
-  // the owner hierarchy changes? the other workaround (besides
-  // repackExistential) is to explicitly pass expectedTp as the type
-  // argument for the call to guard, but repacking the existential
-  // somehow feels more robust
-  //
-  // TODO: check if optimization makes a difference, try something else
-  // if necessary (cache?)
-
   /** Repack existential types, otherwise they sometimes get unpacked in the
    *  wrong location (type inference comes up with an unexpected skolem)
    */

--- a/src/compiler/scala/tools/nsc/transform/TailCalls.scala
+++ b/src/compiler/scala/tools/nsc/transform/TailCalls.scala
@@ -36,6 +36,8 @@ abstract class TailCalls extends Transform {
     }
   }
 
+  private def hasSynthCaseSymbol(t: Tree) = (t.symbol ne null) && (t.symbol hasFlag (Flags.CASE | Flags.SYNTHETIC))
+
   /**
    * A Tail Call Transformer
    *
@@ -87,9 +89,21 @@ abstract class TailCalls extends Transform {
   class TailCallElimination(unit: CompilationUnit) extends Transformer {
     private val defaultReason = "it contains a recursive call not in tail position"
 
+    /** Has the label been accessed? Then its symbol is in this set. */
+    private val accessed = new collection.mutable.HashSet[Symbol]()
+    // `accessed` was stored as boolean in the current context -- this is no longer tenable
+    // with jumps to labels in tailpositions now considered in tailposition,
+    // a downstream context may access the label, and the upstream one will be none the wiser
+    // this is necessary because tail-calls may occur in places where syntactically they seem impossible
+    // (since we now consider jumps to labels that are in tailposition, such as matchEnd(x) {x})
+
+
     class Context() {
       /** The current method */
       var method: Symbol = NoSymbol
+
+      // symbols of label defs in this method that are in tail position
+      var tailLabels: Set[Symbol] = Set()
 
       /** The current tail-call label */
       var label: Symbol = NoSymbol
@@ -104,24 +118,20 @@ abstract class TailCalls extends Transform {
       var failReason = defaultReason
       var failPos    = method.pos
 
-      /** Has the label been accessed? */
-      var accessed = false
-
       def this(that: Context) = {
         this()
         this.method   = that.method
         this.tparams  = that.tparams
         this.tailPos  = that.tailPos
-        this.accessed = that.accessed
         this.failPos  = that.failPos
         this.label    = that.label
+        this.tailLabels = that.tailLabels
       }
       def this(dd: DefDef) {
         this()
         this.method   = dd.symbol
         this.tparams  = dd.tparams map (_.symbol)
         this.tailPos  = true
-        this.accessed = false
         this.failPos  = dd.pos
 
         /** Create a new method symbol for the current method and store it in
@@ -141,14 +151,14 @@ abstract class TailCalls extends Transform {
       def isEligible       = method.isEffectivelyFinal
       // @tailrec annotation indicates mandatory transformation
       def isMandatory      = method.hasAnnotation(TailrecClass) && !forMSIL
-      def isTransformed    = isEligible && accessed
+      def isTransformed    = isEligible && accessed(label)
       def tailrecFailure() = unit.error(failPos, "could not optimize @tailrec annotated " + method + ": " + failReason)
 
       def newThis(pos: Position) = method.newValue(nme.THIS, pos, SYNTHETIC) setInfo currentClass.typeOfThis
 
       override def toString(): String = (
         "" + method.name + " tparams: " + tparams + " tailPos: " + tailPos +
-        " accessed: " + accessed + "\nLabel: " + label + "\nLabel type: " + label.info
+        " Label: " + label + " Label type: " + label.info
       )
     }
 
@@ -206,7 +216,7 @@ abstract class TailCalls extends Transform {
         def rewriteTailCall(recv: Tree): Tree = {
           debuglog("Rewriting tail recursive call:  " + fun.pos.lineContent.trim)
 
-          ctx.accessed = true
+          accessed += ctx.label
           typedPos(fun.pos)(Apply(Ident(ctx.label), recv :: transformArgs))
         }
 
@@ -242,10 +252,16 @@ abstract class TailCalls extends Transform {
               unit.error(tree.pos, "@tailrec annotated method contains no recursive calls")
             }
           }
-          debuglog("Considering " + dd.name + " for tailcalls")
+
+          // labels are local to a method, so only traverse the rhs of a defdef
+          val collectTailPosLabels = new TailPosLabelsTraverser
+          collectTailPosLabels traverse rhs0
+          newCtx.tailLabels = collectTailPosLabels.tailLabels.toSet
+
+          debuglog("Considering " + dd.name + " for tailcalls, with labels in tailpos: "+ newCtx.tailLabels)
           val newRHS = transform(rhs0, newCtx)
 
-          deriveDefDef(tree)(rhs =>
+          deriveDefDef(tree){rhs =>
             if (newCtx.isTransformed) {
               /** We have rewritten the tree, but there may be nested recursive calls remaining.
                *  If @tailrec is given we need to fail those now.
@@ -270,7 +286,21 @@ abstract class TailCalls extends Transform {
 
               newRHS
             }
+          }
+
+        // a translated match
+        case Block(stats, expr) if stats forall hasSynthCaseSymbol =>
+          // the assumption is once we encounter a case, the remainder of the block will consist of cases
+          // the prologue may be empty, usually it is the valdef that stores the scrut
+          val (prologue, cases) = stats span (s => !s.isInstanceOf[LabelDef])
+          treeCopy.Block(tree,
+            noTailTransforms(prologue) ++ transformTrees(cases),
+            transform(expr)
           )
+
+        // a translated casedef
+        case LabelDef(_, _, body) if hasSynthCaseSymbol(tree) =>
+          deriveLabelDef(tree)(transform)
 
         case Block(stats, expr) =>
           treeCopy.Block(tree,
@@ -308,8 +338,18 @@ abstract class TailCalls extends Transform {
         case Apply(fun, args) =>
           if (fun.symbol == Boolean_or || fun.symbol == Boolean_and)
             treeCopy.Apply(tree, fun, transformTrees(args))
-          else
-            rewriteApply(fun, fun, Nil, args)
+          else if (fun.symbol.isLabel && args.nonEmpty && args.tail.isEmpty && ctx.tailLabels(fun.symbol)) {
+            // this is to detect tailcalls in translated matches
+            // it's a one-argument call to a label that is in a tailposition and that looks like label(x) {x}
+            // thus, the argument to the call is in tailposition and we don't need to jump to the label, tail jump instead
+            val saved = ctx.tailPos
+            ctx.tailPos = true
+            debuglog("in tailpos label: "+ args.head)
+            val res = transform(args.head)
+            ctx.tailPos = saved
+            if (res ne args.head) res // we tail-called -- TODO: shield from false-positives where we rewrite but don't tail-call
+            else rewriteApply(fun, fun, Nil, args)
+          } else rewriteApply(fun, fun, Nil, args)
 
         case Alternative(_) | Star(_) | Bind(_, _) =>
           sys.error("We should've never gotten inside a pattern")
@@ -318,6 +358,68 @@ abstract class TailCalls extends Transform {
         case _ =>
           super.transform(tree)
       }
+    }
+  }
+
+  // collect the LabelDefs (generated by the pattern matcher) in a DefDef that are in tail position
+  // the labels all look like: matchEnd(x) {x}
+  // then, in a forward jump `matchEnd(expr)`, `expr` is considered in tail position (and the matchEnd jump is replaced by the jump generated by expr)
+  class TailPosLabelsTraverser extends Traverser {
+    val tailLabels = new collection.mutable.ListBuffer[Symbol]()
+
+    private var maybeTail: Boolean = true // since we start in the rhs of a DefDef
+
+    def traverse(tree: Tree, maybeTailNew: Boolean): Unit = {
+      val saved = maybeTail
+      maybeTail = maybeTailNew
+      try traverse(tree)
+      finally maybeTail = saved
+    }
+
+    def traverseNoTail(tree: Tree) = traverse(tree, false)
+    def traverseTreesNoTail(trees: List[Tree]) = trees foreach traverseNoTail
+
+    override def traverse(tree: Tree) = tree match {
+      case LabelDef(_, List(arg), body@Ident(_)) if arg.symbol == body.symbol => // we're looking for label(x){x} in tail position, since that means `a` is in tail position in a call `label(a)`
+        if (maybeTail) tailLabels += tree.symbol
+
+      // a translated casedef
+      case LabelDef(_, _, body) if hasSynthCaseSymbol(tree) =>
+        traverse(body)
+
+      // a translated match
+      case Block(stats, expr) if stats forall hasSynthCaseSymbol =>
+        // the assumption is once we encounter a case, the remainder of the block will consist of cases
+        // the prologue may be empty, usually it is the valdef that stores the scrut
+        val (prologue, cases) = stats span (s => !s.isInstanceOf[LabelDef])
+        traverseTreesNoTail(prologue) // selector (may be absent)
+        traverseTrees(cases)
+        traverse(expr)
+
+      case CaseDef(pat, guard, body) =>
+        traverse(body)
+
+      case Match(selector, cases) =>
+        traverseNoTail(selector)
+        traverseTrees(cases)
+
+      case dd @ DefDef(_, _, _, _, _, _) => // we are run per-method
+
+      case Block(stats, expr) =>
+        traverseTreesNoTail(stats)
+        traverse(expr)
+
+      case If(cond, thenp, elsep) =>
+        traverse(thenp)
+        traverse(elsep)
+
+      case Try(block, catches, finalizer) =>
+        traverseNoTail(block)
+        traverseTreesNoTail(catches)
+        traverseNoTail(finalizer)
+
+      case EmptyTree | Super(_, _) | This(_) | Select(_, _) | Ident(_) | Literal(_) | Function(_, _) | TypeTree() =>
+      case _ => super.traverse(tree)
     }
   }
 }

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -237,8 +237,10 @@ abstract class UnCurry extends InfoTransform
       def targs = fun.tpe.typeArgs
       def isPartial = fun.tpe.typeSymbol == PartialFunctionClass
 
+      // if the function was eta-expanded, it's not a match without a selector
       if (fun1 ne fun) fun1
       else {
+        assert(!(opt.virtPatmat && isPartial)) // empty-selector matches have already been translated into instantiations of anonymous (partial) functions
         val (formals, restpe) = (targs.init, targs.last)
         val anonClass = owner.newAnonymousFunctionClass(fun.pos, inConstructorFlag)
         def parents =
@@ -286,52 +288,54 @@ abstract class UnCurry extends InfoTransform
 
               def defaultCase = CaseDef(Ident(nme.WILDCARD), EmptyTree, Literal(Constant(false)))
 
-              val casesNoSynthCatchAll = dropSyntheticCatchAll(cases)
+//              val casesNoSynthCatchAll = dropSyntheticCatchAll(cases)
 
               gen.mkUncheckedMatch(
-                if (casesNoSynthCatchAll exists treeInfo.isDefaultCase) Literal(Constant(true))
-                else substTree(wrap(Match(selector, (casesNoSynthCatchAll map transformCase) :+ defaultCase)).duplicate)
+                if (cases exists treeInfo.isDefaultCase) Literal(Constant(true))
+                else substTree(wrap(Match(selector, (cases map transformCase) :+ defaultCase)).duplicate)
               )
             }
 
-            override def caseVirtualizedMatch(orig: Tree, _match: Tree, targs: List[Tree], scrut: Tree, matcher: Tree): Tree = {
-              object noOne extends Transformer {
-                override val treeCopy = newStrictTreeCopier // must duplicate everything
-                val one = _match.tpe member newTermName("one")
-                override def transform(tree: Tree): Tree = tree match {
-                  case Apply(fun, List(a)) if fun.symbol == one =>
-                    // blow one's argument away since all we want to know is whether the match succeeds or not
-                    // (the alternative, making `one` CBN, would entail moving away from Option)
-                    Apply(fun.duplicate, List(gen.mkZeroContravariantAfterTyper(a.tpe)))
-                  case _ =>
-                    super.transform(tree)
-                }
-              }
-              substTree(Apply(Apply(TypeApply(Select(_match.duplicate, _match.tpe.member(newTermName("isSuccess"))), targs map (_.duplicate)), List(scrut.duplicate)), List(noOne.transform(matcher))))
-            }
+            override def caseVirtualizedMatch(orig: Tree, _match: Tree, targs: List[Tree], scrut: Tree, matcher: Tree): Tree = {assert(false); orig}
+            // {
+            //   object noOne extends Transformer {
+            //     override val treeCopy = newStrictTreeCopier // must duplicate everything
+            //     val one = _match.tpe member newTermName("one")
+            //     override def transform(tree: Tree): Tree = tree match {
+            //       case Apply(fun, List(a)) if fun.symbol == one =>
+            //         // blow one's argument away since all we want to know is whether the match succeeds or not
+            //         // (the alternative, making `one` CBN, would entail moving away from Option)
+            //         Apply(fun.duplicate, List(gen.mkZeroContravariantAfterTyper(a.tpe)))
+            //       case _ =>
+            //         super.transform(tree)
+            //     }
+            //   }
+            //   substTree(Apply(Apply(TypeApply(Select(_match.duplicate, _match.tpe.member(newTermName("isSuccess"))), targs map (_.duplicate)), List(scrut.duplicate)), List(noOne.transform(matcher))))
+            // }
 
-            override def caseVirtualizedMatchOpt(orig: Tree, zero: ValDef, x: ValDef, matchRes: ValDef, keepGoing: ValDef, stats: List[Tree], epilogue: Tree, wrap: Tree => Tree) = {
-              object dropMatchResAssign extends Transformer {
-                // override val treeCopy = newStrictTreeCopier // will duplicate below
-                override def transform(tree: Tree): Tree = tree match {
-                  // don't compute the result of the match -- remove the block for the RHS (emitted by pmgen.one), except for the assignment to keepGoing
-                  case gen.VirtualCaseDef(assignKeepGoing, matchRes, zero) if assignKeepGoing.lhs.symbol eq keepGoing.symbol =>
-                    Block(List(assignKeepGoing), zero)
-                  case _ =>
-                    super.transform(tree)
-                }
-              }
-              val statsNoMatchRes: List[Tree] = stats map (dropMatchResAssign.transform) toList
-              val idaBlock = wrap(Block(
-                zero ::
-                x ::
-                /* drop matchRes def */
-                keepGoing ::
-                statsNoMatchRes,
-                NOT(REF(keepGoing.symbol)) // replace `if (keepGoing) throw new MatchError(...) else matchRes` epilogue by `!keepGoing`
-              ))
-              substTree(idaBlock.duplicate) // duplicate on block as a whole to ensure valdefs are properly cloned and substed
-            }
+            override def caseVirtualizedMatchOpt(orig: Tree, zero: ValDef, x: ValDef, matchRes: ValDef, keepGoing: ValDef, stats: List[Tree], epilogue: Tree, wrap: Tree => Tree) = {assert(false); orig}
+            // {
+            //   object dropMatchResAssign extends Transformer {
+            //     // override val treeCopy = newStrictTreeCopier // will duplicate below
+            //     override def transform(tree: Tree): Tree = tree match {
+            //       // don't compute the result of the match -- remove the block for the RHS (emitted by pmgen.one), except for the assignment to keepGoing
+            //       case gen.VirtualCaseDef(assignKeepGoing, matchRes, zero) if assignKeepGoing.lhs.symbol eq keepGoing.symbol =>
+            //         Block(List(assignKeepGoing), zero)
+            //       case _ =>
+            //         super.transform(tree)
+            //     }
+            //   }
+            //   val statsNoMatchRes: List[Tree] = stats map (dropMatchResAssign.transform) toList
+            //   val idaBlock = wrap(Block(
+            //     zero ::
+            //     x ::
+            //     /* drop matchRes def */
+            //     keepGoing ::
+            //     statsNoMatchRes,
+            //     NOT(REF(keepGoing.symbol)) // replace `if (keepGoing) throw new MatchError(...) else matchRes` epilogue by `!keepGoing`
+            //   ))
+            //   substTree(idaBlock.duplicate) // duplicate on block as a whole to ensure valdefs are properly cloned and substed
+            // }
           }
 
           DefDef(m, isDefinedAtTransformer(fun.body))

--- a/src/compiler/scala/tools/nsc/typechecker/Duplicators.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Duplicators.scala
@@ -256,8 +256,16 @@ abstract class Duplicators extends Analyzer {
         case ldef @ LabelDef(name, params, rhs) =>
           // log("label def: " + ldef)
           ldef.tpe = null
-          val params1 = params map (p => Ident(updateSym(p.symbol)))
-          super.typed(treeCopy.LabelDef(tree, name, params1, rhs), mode, pt)
+          // since typer does not create the symbols for a LabelDef's params,
+          // we do that manually here -- we should really refactor LabelDef to be a subclass of DefDef
+          def newParam(p: Tree): Ident = {
+            val newsym = p.symbol.cloneSymbol //(context.owner) // TODO owner?
+            Ident(newsym.setInfo(fixType(p.symbol.info)))
+          }
+          val params1 = params map newParam
+          val rhs1 = (new TreeSubstituter(params map (_.symbol), params1) transform rhs) // TODO: duplicate?
+          rhs1.tpe = null
+          super.typed(treeCopy.LabelDef(tree, name, params1, rhs1), mode, pt)
 
         case Bind(name, _) =>
           // log("bind: " + tree)

--- a/src/compiler/scala/tools/nsc/typechecker/PatMatVirtualiser.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatMatVirtualiser.scala
@@ -1037,7 +1037,7 @@ class Foo(x: Other) { x._1 } // no error in this order
 
     // assert(owner ne null); assert(owner ne NoSymbol)
     def freshSym(pos: Position, tp: Type = NoType, prefix: String = "x") =
-      NoSymbol.newTermSymbol(freshName(prefix), pos) setInfo repackExistential(tp)
+      NoSymbol.newTermSymbol(freshName(prefix), pos) setInfo /*repackExistential*/(tp)
 
     // codegen relevant to the structure of the translation (how extractors are combined)
     trait AbsCodegen {
@@ -1079,18 +1079,18 @@ class Foo(x: Other) { x._1 } // no error in this order
       def and(a: Tree, b: Tree): Tree                  = a AND b
 
       // the force is needed mainly to deal with the GADT typing hack (we can't detect it otherwise as tp nor pt need contain an abstract type, we're just casting wildly)
-      def _asInstanceOf(t: Tree, tp: Type, force: Boolean = false): Tree      = { val tpX = repackExistential(tp)
+      def _asInstanceOf(t: Tree, tp: Type, force: Boolean = false): Tree      = { val tpX = /*repackExistential*/(tp)
         if (!force && (t.tpe ne NoType) && t.isTyped && typesConform(t.tpe, tpX))  t //{ println("warning: emitted redundant asInstanceOf: "+(t, t.tpe, tp)); t } //.setType(tpX)
         else gen.mkAsInstanceOf(t, tpX, true, false)
       }
 
-      def _isInstanceOf(b: Symbol, tp: Type): Tree    = gen.mkIsInstanceOf(REF(b), repackExistential(tp), true, false)
-      // { val tpX = repackExistential(tp)
+      def _isInstanceOf(b: Symbol, tp: Type): Tree    = gen.mkIsInstanceOf(REF(b), /*repackExistential*/(tp), true, false)
+      // { val tpX = /*repackExistential*/(tp)
       //   if (typesConform(b.info, tpX)) { println("warning: emitted spurious isInstanceOf: "+(b, tp)); TRUE }
       //   else gen.mkIsInstanceOf(REF(b), tpX, true, false)
       // }
 
-      def _asInstanceOf(b: Symbol, tp: Type): Tree    = { val tpX = repackExistential(tp)
+      def _asInstanceOf(b: Symbol, tp: Type): Tree    = { val tpX = /*repackExistential*/(tp)
         if (typesConform(b.info, tpX)) REF(b) //{ println("warning: emitted redundant asInstanceOf: "+(b, b.info, tp)); REF(b) } //.setType(tpX)
         else gen.mkAsInstanceOf(REF(b), tpX, true, false)
       }

--- a/src/compiler/scala/tools/nsc/typechecker/PatMatVirtualiser.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatMatVirtualiser.scala
@@ -1651,6 +1651,11 @@ class Foo(x: Other) { x._1 } // no error in this order
           LabelDef(nextCase, Nil, catchAllGen(casegen)(scrutRef))
         } toList
 
+        // the generated block is taken apart in TailCalls under the following assumptions
+          // the assumption is once we encounter a case, the remainder of the block will consist of cases
+          // the prologue may be empty, usually it is the valdef that stores the scrut
+          // val (prologue, cases) = stats span (s => !s.isInstanceOf[LabelDef])
+
         val prologue = if(scrutSym ne NoSymbol) List(VAL(scrutSym)  === scrut) else Nil
         Block(
           prologue ++ (cases map caseDef) ++ catchAll,

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2140,7 +2140,11 @@ trait Typers extends Modes with Adaptations with PatMatVirtualiser {
 
     def typedCases(cases: List[CaseDef], pattp: Type, pt: Type): List[CaseDef] =
       cases mapConserve { cdef =>
-        newTyper(context.makeNewScope(cdef, context.owner)).typedCase(cdef, pattp, pt)
+        val caseTyped = newTyper(context.makeNewScope(cdef, context.owner)).typedCase(cdef, pattp, pt)
+        if (opt.virtPatmat) {
+          val tpPacked  = packedType(caseTyped, context.owner)
+          caseTyped setType tpPacked
+        } else caseTyped
       }
 
     def adaptCase(cdef: CaseDef, mode: Int, tpe: Type): CaseDef = deriveCaseDef(cdef)(adapt(_, mode, tpe))

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2143,6 +2143,137 @@ trait Typers extends Modes with Adaptations with PatMatVirtualiser {
         newTyper(context.makeNewScope(cdef, context.owner)).typedCase(cdef, pattp, pt)
       }
 
+    def adaptCase(cdef: CaseDef, mode: Int, tpe: Type): CaseDef = deriveCaseDef(cdef)(adapt(_, mode, tpe))
+
+    def translateMatch(selector: Tree, cases: List[CaseDef], mode: Int, resTp: Type, scrutTp: Type = NoType, matchFailGen: Option[Tree => Tree] = None) = {
+      val selector1            = if(scrutTp eq NoType) checkDead(typed(selector, EXPRmode | BYVALmode, WildcardType)) else selector
+      val selectorTp           = if(scrutTp eq NoType) packCaptured(selector1.tpe.widen) else scrutTp
+      val casesTyped           = typedCases(cases, selectorTp, resTp)
+      val (ownType, needAdapt) = if (isFullyDefined(resTp)) (resTp, false) else weakLub(casesTyped map (_.tpe.deconst))
+      val casesAdapted         = if (!needAdapt) casesTyped else casesTyped map (adaptCase(_, mode, ownType))
+      // val (owntype0, needAdapt) = ptOrLub(casesTyped map (x => repackExistential(x.tpe)))
+      // val owntype               = elimAnonymousClass(owntype0)
+
+      def repeatedToSeq(tp: Type): Type = (tp baseType RepeatedParamClass) match {
+        case TypeRef(_, RepeatedParamClass, args) => appliedType(SeqClass.typeConstructor, args)
+        case _ => tp
+      }
+
+      def isSynthSelector(selector: Tree): Boolean = selector match {
+        case Ident(_) if selector.symbol.hasFlag(SYNTHETIC | CASE) => true
+        case Select(sel, nme.toInt) => isSynthSelector(sel) // switch may need to convert to int first
+        case _ => false
+      }
+
+      if (isSynthSelector(selector1)) { // a switch
+        (Match(selector1, casesAdapted) setType ownType, ownType) // setType of the Match to avoid recursing endlessly
+      } else {
+        val scrutType = repeatedToSeq(elimAnonymousClass(selectorTp))
+        (MatchTranslator(this).translateMatch(selector1, casesAdapted, repeatedToSeq(ownType), scrutType, matchFailGen), ownType)
+      }
+    }
+
+    // TODO: use this to synthesize (partial)function implementation for matches from the get-go,
+    // instead of the dirty post-factum hacks in uncurry -- typedMatchAnonFun is currently not used due to mindboggling failures (see virtpatmat_anonfun_for.scala)
+    def typedMatchAnonFun(tree: Tree, cases: List[CaseDef], mode: Int, pt0: Type, selOverride: Option[(List[Symbol], Tree)] = None) = {
+      val pt         = deskolemizeGADTSkolems(pt0)
+      val targs      = pt.normalize.typeArgs
+      val arity      = if (isFunctionType(pt)) targs.length - 1 else 1
+      val scrutTp0   = if (arity == 1) targs.head else /* arity > 1 */ tupleType(targs.init)
+      val scrutTp    = packCaptured(scrutTp0)
+      val ptRes      = targs.last // may not be fully defined
+      val isPartial  = pt.typeSymbol == PartialFunctionClass
+      val cname      = tpnme.ANON_FUN_NAME
+      val funThis    = This(cname)
+      // used to create a new context for pattern matching translation so that
+      // we can easily rejig the owner structure when we have the actual symbols for these methods
+      // (after type checking them, but type checking requires translation -- this seems like the easiest way to end this vicious cycle)
+      val applySentinel = NoSymbol.newMethod(nme.apply)
+      val idaSentinel   = NoSymbol.newMethod(nme._isDefinedAt)
+
+      def mkParams = {
+        val params =
+          for (i <- List.range(0, arity)) yield atPos(tree.pos.focusStart) {
+            ValDef(Modifiers(SYNTHETIC | PARAM), unit.freshTermName("x" + i + "$"), TypeTree(), EmptyTree)
+          }
+        val ids = params map (p => Ident(p.name))
+
+        val paramsRef = selOverride match {
+          case None => atPos(tree.pos.focusStart) { if (arity == 1) ids.head else gen.mkTuple(ids) }
+          case Some((_, sel)) => sel.duplicate // we'll replace the symbols that refer to the function's original syms by the ones introduced by the DefDef once the method's been type checked (until then, we don't know them)
+        }
+
+        (params, paramsRef) // paramsRef can't be typed until after match has been translated, thus supply explicit scrutTp to translate below
+      }
+
+      import CODE._
+
+      // need to duplicate the cases before typing them to generate the apply method, or the symbols will be all messed up
+      val casesTrue = if (isPartial) cases map (c => deriveCaseDef(c)(x => TRUE).duplicate) else Nil
+
+      val (applyMethod, parents) = {
+        val (params, paramsRef) = mkParams
+        val (body, resTp) = newTyper(context.make(context.tree, applySentinel)).translateMatch(paramsRef, cases, mode, ptRes, scrutTp, if (isPartial) Some(scrut => (funThis DOT nme.missingCase) (scrut)) else None)
+
+        def abstractFunctionType = {
+          val sym = AbstractFunctionClass(arity)
+          typeRef(sym.typeConstructor.prefix, sym, targs.init :+ resTp)
+        }
+
+        val parents =
+          if (isFunctionType(pt)) List(abstractFunctionType, SerializableClass.tpe)
+          else if (isPartial) List(appliedType(AbstractPartialFunctionClass.typeConstructor, List(scrutTp, resTp)), SerializableClass.tpe)
+          else List(ObjectClass.tpe, pt, SerializableClass.tpe)
+
+        (atPos(tree.pos.focus)(DefDef(Modifiers(FINAL), nme.apply, Nil, List(params), TypeTree() setType resTp, body)), parents)
+      }
+
+      def isDefinedAtMethod = {
+        val (params, paramsRef) = mkParams
+        val (body, _) = newTyper(context.make(context.tree, idaSentinel)).translateMatch(paramsRef, casesTrue, mode, BooleanClass.tpe, scrutTp, Some(scrutinee => FALSE))
+        atPos(tree.pos.focus)(
+          DefDef(Modifiers(FINAL), nme._isDefinedAt, Nil, List(params), TypeTree() setType BooleanClass.tpe, body)
+        )
+      }
+
+      val members = if (!isPartial) List(applyMethod) else List(applyMethod, isDefinedAtMethod)
+
+      val cmods = Modifiers(FINAL | SYNTHETIC /*TODO: when do we need INCONSTRUCTOR ?*/) withAnnotations (
+                       List(NEW(SerialVersionUIDAttr, LIT(0))))
+      val cdef =
+        ClassDef(cmods, cname, Nil,
+          Template(parents map (TypeTree() setType _), emptyValDef, Modifiers(0), Nil, List(Nil), members, tree.pos)
+        )
+      val funInst = (Block(List(cdef), Apply(Select(New(Ident(cname)), nme.CONSTRUCTOR), Nil)))
+
+      val res = typed(funInst, mode, pt)
+
+      // now that we have the symbols corresponding to the apply/isDefinedAt methods,
+      // we can fix up the result of fixerUpper... URGH
+      // fixerUpper nests the top-level definitions generated in the match under context.owner, but they should be owner by the apply/isDefinedAt method
+      res foreach {
+        case d: DefDef if (d.symbol.name == nme.apply) =>
+          d.rhs.changeOwner(applySentinel -> d.symbol)
+        case d: DefDef if (d.symbol.name == nme._isDefinedAt) =>
+          d.rhs.changeOwner(idaSentinel -> d.symbol)
+        case _ =>
+      }
+
+      selOverride match {
+        case None => res
+        case Some((paramSyms, sel)) =>
+          object substParamSyms extends Transformer {
+            override def transform(t: Tree): Tree = t match {
+              case d: DefDef if (d.symbol.name == nme.apply) || (d.symbol.name == nme._isDefinedAt) && (d.symbol.owner == res.tpe.typeSymbol) =>
+                deriveDefDef(d)(rhs => rhs.substTreeSyms(paramSyms, d.vparamss.head.map(_.symbol)))
+              case _ =>
+                super.transform(t)
+            }
+          }
+          substParamSyms.transform(res)
+      }
+    }
+
     /**
      *  @param fun  ...
      *  @param mode ...
@@ -2155,14 +2286,10 @@ trait Typers extends Modes with Adaptations with PatMatVirtualiser {
         return MaxFunctionArityError(fun)
 
       def decompose(pt: Type): (Symbol, List[Type], Type) =
-        if ((isFunctionType(pt)
-             ||
-             pt.typeSymbol == PartialFunctionClass &&
-             numVparams == 1 && fun.body.isInstanceOf[Match])
-             && // see bug901 for a reason why next conditions are needed
-            (pt.normalize.typeArgs.length - 1 == numVparams
-             ||
-             fun.vparams.exists(_.tpt.isEmpty)))
+        if ((isFunctionType(pt) || (pt.typeSymbol == PartialFunctionClass && numVparams == 1 && fun.body.isInstanceOf[Match])) && // see bug901 for a reason why next conditions are needed
+            (  pt.normalize.typeArgs.length - 1 == numVparams
+            || fun.vparams.exists(_.tpt.isEmpty)
+            ))
           (pt.typeSymbol, pt.normalize.typeArgs.init, pt.normalize.typeArgs.last)
         else
           (FunctionClass(numVparams), fun.vparams map (x => NoType), WildcardType)
@@ -2204,13 +2331,27 @@ trait Typers extends Modes with Adaptations with PatMatVirtualiser {
 //        for (vparam <- vparams) {
 //          checkNoEscaping.locals(context.scope, WildcardType, vparam.tpt); ()
 //        }
-        val body1 = typed(fun.body, respt)
-        val formals = vparamSyms map (_.tpe)
-        val restpe = packedType(body1, fun.symbol).deconst.resultType
-        val funtpe = typeRef(clazz.tpe.prefix, clazz, formals :+ restpe)
-//        body = checkNoEscaping.locals(context.scope, restpe, body)
-        treeCopy.Function(fun, vparams, body1).setType(funtpe)
-    }
+
+        def recompose(from: Type, to: Type) =
+          if(clazz == PartialFunctionClass) appliedType(PartialFunctionClass.typeConstructor, List(from, to))
+          else functionType(List(from), to)
+
+        fun.body match {
+          case Match(sel, cases) if opt.virtPatmat =>
+            val typedSel = typed(sel, EXPRmode | BYVALmode, WildcardType)
+            // go to outer context -- must discard the context that was created for the Function since we're discarding the function
+            // thus, its symbol, which serves as the current context.owner, is not the right owner
+            // you won't know you're using the wrong owner until lambda lift crashes (unless you know better than to use the wrong owner)
+            newTyper(context.outer).typedMatchAnonFun(fun, cases, mode, recompose(typedSel.tpe, respt), Some((vparamSyms, typedSel)))
+          case _ =>
+            val body1 = typed(fun.body, respt)
+            val formals = vparamSyms map (_.tpe)
+            val restpe = packedType(body1, fun.symbol).deconst.resultType
+            val funtpe = typeRef(clazz.tpe.prefix, clazz, formals :+ restpe)
+    //        body = checkNoEscaping.locals(context.scope, restpe, body)
+            treeCopy.Function(fun, vparams, body1).setType(funtpe)
+        }
+      }
     }
 
     def typedRefinement(stats: List[Tree]) {
@@ -3431,7 +3572,10 @@ trait Typers extends Modes with Adaptations with PatMatVirtualiser {
       }
 
       def typedMatch(tree: Tree, selector: Tree, cases: List[CaseDef]): Tree = {
-        if (selector == EmptyTree) {
+        if (opt.virtPatmat && !isPastTyper) {
+          if (selector ne EmptyTree) typed(translateMatch(selector, cases, mode, pt)._1, mode, pt)
+          else typedMatchAnonFun(tree, cases, mode, pt)
+        } else if (selector == EmptyTree) {
           val arity = if (isFunctionType(pt)) pt.normalize.typeArgs.length - 1 else 1
           val params = for (i <- List.range(0, arity)) yield
             atPos(tree.pos.focusStart) {
@@ -3445,32 +3589,11 @@ trait Typers extends Modes with Adaptations with PatMatVirtualiser {
         } else {
           val selector1 = checkDead(typed(selector, EXPRmode | BYVALmode, WildcardType))
           var cases1 = typedCases(cases, packCaptured(selector1.tpe.widen), pt)
-
-          if (isPastTyper || !opt.virtPatmat) {
-            val (owntype, needAdapt) = ptOrLub(cases1 map (_.tpe))
-            if (needAdapt) {
-              cases1 = cases1 map (adaptCase(_, owntype))
-            }
-            treeCopy.Match(tree, selector1, cases1) setType owntype
-          } else { // don't run translator after typers (see comments in PatMatVirtualiser)
-            val (owntype0, needAdapt) = ptOrLub(cases1 map (x => repackExistential(x.tpe)))
-            val owntype = elimAnonymousClass(owntype0)
-            if (needAdapt) cases1 = cases1 map (adaptCase(_, owntype))
-
-            (MatchTranslator(this)).translateMatch(selector1, cases1, owntype) match {
-              case Block(vd :: Nil, tree@Match(selector, cases)) =>
-                val selector1 = checkDead(typed(selector, EXPRmode | BYVALmode, WildcardType))
-                var cases1 = typedCases(cases, packCaptured(selector1.tpe.widen), pt)
-                val (owntype, needAdapt) = ptOrLub(cases1 map (_.tpe))
-                if (needAdapt)
-                  cases1 = cases1 map (adaptCase(_, owntype))
-                typed(Block(vd :: Nil, treeCopy.Match(tree, selector1, cases1) setType owntype))
-              case translated =>
-                // TODO: get rid of setType owntype -- it should all typecheck
-                // must call typed, not typed1, or we overflow the stack when emitting switches
-                typed(translated, mode, WildcardType) setType owntype
-            }
+          val (owntype, needAdapt) = ptOrLub(cases1 map (_.tpe))
+          if (needAdapt) {
+            cases1 = cases1 map (adaptCase(_, mode, owntype))
           }
+          treeCopy.Match(tree, selector1, cases1) setType owntype
         }
       }
 
@@ -4240,9 +4363,6 @@ trait Typers extends Modes with Adaptations with PatMatVirtualiser {
         }
       }
 
-      def adaptCase(cdef: CaseDef, tpe: Type): CaseDef =
-        deriveCaseDef(cdef)(adapt(_, mode, tpe))
-
       // begin typed1
       val sym: Symbol = tree.symbol
       if ((sym ne null) && (sym ne NoSymbol)) sym.initialize
@@ -4351,7 +4471,7 @@ trait Typers extends Modes with Adaptations with PatMatVirtualiser {
           val (owntype, needAdapt) = ptOrLub(block1.tpe :: (catches1 map (_.tpe)))
           if (needAdapt) {
             block1 = adapt(block1, mode, owntype)
-            catches1 = catches1 map (adaptCase(_, owntype))
+            catches1 = catches1 map (adaptCase(_, mode, owntype))
           }
 
           if(!isPastTyper && opt.virtPatmat) {

--- a/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
@@ -45,6 +45,11 @@ trait Unapplies extends ast.TreeDSL
       case BooleanClass             => Nil
       case OptionClass | SomeClass  =>
         val prod  = tp.typeArgs.head
+// the spec doesn't allow just any subtype of Product, it *must* be TupleN[...] -- see run/virtpatmat_extends_product.scala
+// this breaks plenty of stuff, though...
+//        val targs =
+//          if (isTupleType(prod)) getProductArgs(prod)
+//          else List(prod)
         val targs = getProductArgs(prod)
 
         if (targs.isEmpty || targs.tail.isEmpty) List(prod) // special n == 0 ||  n == 1

--- a/test/files/pos/virtpatmat_anonfun_for.flags
+++ b/test/files/pos/virtpatmat_anonfun_for.flags
@@ -1,0 +1,1 @@
+-Yvirtpatmat

--- a/test/files/pos/virtpatmat_anonfun_for.scala
+++ b/test/files/pos/virtpatmat_anonfun_for.scala
@@ -1,0 +1,8 @@
+trait Foo {
+  def bla = {
+    val tvs = "tvs"
+    Nil.foreach(x => x match {
+      case _ => println(tvs)
+    })
+  }
+}

--- a/test/files/pos/virtpatmat_exist4.scala
+++ b/test/files/pos/virtpatmat_exist4.scala
@@ -1,0 +1,35 @@
+trait Global {
+  trait Tree
+  trait Symbol { def foo: Boolean }
+}
+
+trait IMain { self:  MemberHandlers =>
+  val global: Global
+  def handlers: List[MemberHandler]
+}
+
+trait MemberHandlers {
+  val intp: IMain
+  import intp.global._
+  sealed abstract class MemberHandler(val member: Tree) {
+    def importedSymbols: List[Symbol]
+  }
+}
+
+object Test {
+  var intp: IMain with MemberHandlers = null
+
+  val handlers = intp.handlers
+  handlers.filterNot(_.importedSymbols.isEmpty).zipWithIndex foreach {
+    case (handler, idx) =>
+      val (types, terms) = handler.importedSymbols partition (_.foo)
+  }
+}
+
+object Test2 {
+  type JClass = java.lang.Class[_]
+
+  def tvarString(bounds: List[AnyRef]) = {
+    bounds collect { case x: JClass => x }
+  }
+}

--- a/test/files/pos/virtpatmat_instof_valuetype.flags
+++ b/test/files/pos/virtpatmat_instof_valuetype.flags
@@ -1,0 +1,1 @@
+ -Yvirtpatmat -Xexperimental

--- a/test/files/pos/virtpatmat_instof_valuetype.scala
+++ b/test/files/pos/virtpatmat_instof_valuetype.scala
@@ -1,0 +1,8 @@
+case class Data(private val t: Option[String] = None, only: Boolean = false) {
+  def add(other: Data) = {
+    other match {
+      case Data(None, b)    => ()
+      case Data(Some(_), b) => ()
+    }
+  }
+}

--- a/test/files/run/virtpatmat_extends_product.check
+++ b/test/files/run/virtpatmat_extends_product.check
@@ -1,0 +1,1 @@
+AnnotationInfo(a,1)

--- a/test/files/run/virtpatmat_extends_product.flags
+++ b/test/files/run/virtpatmat_extends_product.flags
@@ -1,0 +1,1 @@
+-Yvirtpatmat

--- a/test/files/run/virtpatmat_extends_product.scala
+++ b/test/files/run/virtpatmat_extends_product.scala
@@ -1,0 +1,11 @@
+object Test extends App {
+  case class AnnotationInfo(a: String, b: Int) extends Product2[String, Int]
+
+  // if we're not careful in unapplyTypeListFromReturnType, the generated unapply is
+  // thought to return two components instead of one, since AnnotationInfo (the result of the unapply) is a Product2
+  case class NestedAnnotArg(ai: AnnotationInfo)
+
+  NestedAnnotArg(AnnotationInfo("a", 1)) match {
+    case NestedAnnotArg(x) => println(x)
+  }
+}

--- a/test/files/run/virtpatmat_partial.check
+++ b/test/files/run/virtpatmat_partial.check
@@ -1,4 +1,17 @@
 Map(a -> Some(1), b -> None)
-79
-undefined
 Map(a -> 1)
+a
+undefined
+a
+undefined
+a
+undefined
+a
+undefined
+hai!
+hai!
+2
+hai!
+undefined
+1
+undefined

--- a/test/files/run/virtpatmat_partial.scala
+++ b/test/files/run/virtpatmat_partial.scala
@@ -2,95 +2,180 @@ object Test extends App {
   val a = Map("a" -> Some(1), "b" -> None)
   println(a)
 
+// inferred type should be Map[String, Int]
   val res = a collect {case (p, Some(a)) => (p, a)}
 
-  final val GT = 79
-  final val GTGT = 93
-  final val GTGTGT = 94
-  final val GTEQ = 81
-  final val GTGTEQ = 113
-  final val GTGTGTEQ = 114
-  final val ASSIGN = 75
+// variations: const target -> switch, non-const -> normal match, char target --> scrut needs toInt,
+// eta-expanded --> work is done by typedFunction, non-eta-expanded --> typedMatch
 
-  def acceptClosingAngle(in: Int) {
-    val closers: PartialFunction[Int, Int] = {
-      case GTGTGTEQ => GTGTEQ
-      case GTGTGT   => GTGT
-      case GTGTEQ   => GTEQ
-      case GTGT     => GT
-      case GTEQ     => ASSIGN
+  object nonConstCharEta {
+    final val GT      : Char = 'a'
+    final val GTGT    : Char = 'b'
+    final val GTGTGT  : Char = 'c'
+    final val GTEQ    : Char = 'd'
+    final val GTGTEQ  : Char = 'e'
+    final val GTGTGTEQ: Char = 'f'
+    final val ASSIGN  : Char = 'g'
+
+    def acceptClosingAngle(in: Char) {
+      val closers: PartialFunction[Char, Char] = {
+        case GTGTGTEQ => GTGTEQ
+        case GTGTGT   => GTGT
+        case GTGTEQ   => GTEQ
+        case GTGT     => GT
+        case GTEQ     => ASSIGN
+      }
+      if (closers isDefinedAt in) println(closers(in))
+      else println("undefined")
     }
-    if (closers isDefinedAt in) println(closers(in))
-    else println("undefined")
+
+    def test() = {
+      acceptClosingAngle(GTGT)
+      acceptClosingAngle(ASSIGN)
+    }
   }
 
-  acceptClosingAngle(GTGT)
-  acceptClosingAngle(ASSIGN)
+  object nonConstChar {
+    final val GT      : Char = 'a'
+    final val GTGT    : Char = 'b'
+    final val GTGTGT  : Char = 'c'
+    final val GTEQ    : Char = 'd'
+    final val GTGTEQ  : Char = 'e'
+    final val GTGTGTEQ: Char = 'f'
+    final val ASSIGN  : Char = 'g'
 
-  // should uncurry to:
-  // val res: Map[String,Int] = a.collect[(String, Int), Map[String,Int]](
-  //   new PartialFunction[(String, Option[Int]),(String, Int)]  {
-  //     def apply(x0_1: (String, Option[Int])): (String, Int) = MatchingStrategy.OptionMatchingStrategy.runOrElse[(String, Option[Int]), (String, Int)](x0_1)(
-  //       (x1: (String, Option[Int])) => {
-  //           val o9: Option[(String, Int)] = ({
-  //             val o8: Option[(String, Option[Int])] = Tuple2.unapply[String, Option[Int]](x1);
-  //             if (o8.isEmpty)
-  //               MatchingStrategy.OptionMatchingStrategy.zero
-  //             else
-  //               {
-  //                 val o7: Option[Some[Int]] = if (o8.get._2.isInstanceOf[Some[Int]])
-  //                   MatchingStrategy.OptionMatchingStrategy.one[Some[Int]](o8.get._2.asInstanceOf[Some[Int]])
-  //                 else
-  //                   MatchingStrategy.OptionMatchingStrategy.zero;
-  //                 if (o7.isEmpty)
-  //                   MatchingStrategy.OptionMatchingStrategy.zero
-  //                 else
-  //                   {
-  //                     val o6: Option[Int] = Some.unapply[Int](o7.get);
-  //                     if (o6.isEmpty)
-  //                       MatchingStrategy.OptionMatchingStrategy.zero
-  //                     else
-  //                       MatchingStrategy.OptionMatchingStrategy.one[(String, Int)]((o8.get._1, o6.get).asInstanceOf[(String, Int)])
-  //                   }
-  //               }
-  //           }: Option[(String, Int)]);
-  //           if (o9.isEmpty)
-  //             (MatchingStrategy.OptionMatchingStrategy.zero: Option[(String, Int)])
-  //           else
-  //             o9
-  //         })
-  //     
-  //       def isDefinedAt(x_1: (String, Option[Int])): Boolean = MatchingStrategy.OptionMatchingStrategy.isSuccess[(String, Option[Int]), (String, Int)](x_1)(
-  //         (x1: (String, Option[Int])) => {
-  //           val o9: Option[(String, Int)] = ({
-  //             val o8: Option[(String, Option[Int])] = scala.Tuple2.unapply[String, Option[Int]](x1);
-  //             if (o8.isEmpty)
-  //               MatchingStrategy.OptionMatchingStrategy.zero
-  //             else
-  //               {
-  //                 val o7: Option[Some[Int]] = if (o8.get._2.isInstanceOf[Some[Int]])
-  //                   MatchingStrategy.OptionMatchingStrategy.one[Some[Int]](o8.get._2.asInstanceOf[Some[Int]]) // XXX
-  //                 else
-  //                   MatchingStrategy.OptionMatchingStrategy.zero;
-  //                 if (o7.isEmpty)
-  //                   MatchingStrategy.OptionMatchingStrategy.zero
-  //                 else
-  //                   {
-  //                     val o6: Option[Int] = scala.Some.unapply[Int](o7.get);
-  //                     if (o6.isEmpty)
-  //                       MatchingStrategy.OptionMatchingStrategy.zero
-  //                     else
-  //                       MatchingStrategy.OptionMatchingStrategy.one[(String, Int)](null.asInstanceOf[(String, Int)])
-  //                   }
-  //               }
-  //           }: Option[(String, Int)]);
-  //           if (o9.isEmpty)
-  //             (MatchingStrategy.OptionMatchingStrategy.zero: Option[(String, Int)])
-  //           else
-  //             o9
-  //     })
-  //   }
-  // )
+    def acceptClosingAngle(in: Char) {
+      val closers: PartialFunction[Char, Char] = x => x match {
+        case GTGTGTEQ => GTGTEQ
+        case GTGTGT   => GTGT
+        case GTGTEQ   => GTEQ
+        case GTGT     => GT
+        case GTEQ     => ASSIGN
+      }
+      if (closers isDefinedAt in) println(closers(in))
+      else println("undefined")
+    }
 
-  println(res)
+    def test() = {
+      acceptClosingAngle(GTGT)
+      acceptClosingAngle(ASSIGN)
+    }
+  }
+
+  object constCharEta {
+    final val GT      = 'a'
+    final val GTGT    = 'b'
+    final val GTGTGT  = 'c'
+    final val GTEQ    = 'd'
+    final val GTGTEQ  = 'e'
+    final val GTGTGTEQ= 'f'
+    final val ASSIGN  = 'g'
+
+    def acceptClosingAngle(in: Char) {
+      val closers: PartialFunction[Char, Char] = x => x match {
+        case GTGTGTEQ => GTGTEQ
+        case GTGTGT   => GTGT
+        case GTGTEQ   => GTEQ
+        case GTGT     => GT
+        case GTEQ     => ASSIGN
+      }
+      if (closers isDefinedAt in) println(closers(in))
+      else println("undefined")
+    }
+
+    def test() = {
+      acceptClosingAngle(GTGT)
+      acceptClosingAngle(ASSIGN)
+    }
+  }
+
+  object constChar {
+    final val GT      = 'a'
+    final val GTGT    = 'b'
+    final val GTGTGT  = 'c'
+    final val GTEQ    = 'd'
+    final val GTGTEQ  = 'e'
+    final val GTGTGTEQ= 'f'
+    final val ASSIGN  = 'g'
+
+    def acceptClosingAngle(in: Char) {
+      val closers: PartialFunction[Char, Char] = {
+        case GTGTGTEQ => GTGTEQ
+        case GTGTGT   => GTGT
+        case GTGTEQ   => GTEQ
+        case GTGT     => GT
+        case GTEQ     => ASSIGN
+      }
+      if (closers isDefinedAt in) println(closers(in))
+      else println("undefined")
+    }
+
+    def test() = {
+      acceptClosingAngle(GTGT)
+      acceptClosingAngle(ASSIGN)
+    }
+  }
+
+  object constIntEta {
+    final val GT       = 1
+    final val GTGT     = 2
+    final val GTGTGT   = 3
+    final val GTEQ     = 4
+    final val GTGTEQ   = 5
+    final val GTGTGTEQ = 6
+    final val ASSIGN   = 7
+
+    def acceptClosingAngle(in: Int) {
+      val closers: PartialFunction[Int, Int] = x => {println("hai!"); (x + 1)} match {
+        case GTGTGTEQ => GTGTEQ
+        case GTGTGT   => GTGT
+        case GTGTEQ   => GTEQ
+        case GTGT     => GT
+        case GTEQ     => ASSIGN
+      }
+      if (closers isDefinedAt in) println(closers(in))
+      else println("undefined")
+    }
+
+    def test() = {
+      acceptClosingAngle(GTGT)
+      acceptClosingAngle(ASSIGN)
+    }
+  }
+
+  object constInt {
+    final val GT       = 1
+    final val GTGT     = 2
+    final val GTGTGT   = 3
+    final val GTEQ     = 4
+    final val GTGTEQ   = 5
+    final val GTGTGTEQ = 6
+    final val ASSIGN   = 7
+
+    def acceptClosingAngle(in: Int) {
+      val closers: PartialFunction[Int, Int] = {
+        case GTGTGTEQ => GTGTEQ
+        case GTGTGT   => GTGT
+        case GTGTEQ   => GTEQ
+        case GTGT     => GT
+        case GTEQ     => ASSIGN
+      }
+      if (closers isDefinedAt in) println(closers(in))
+      else println("undefined")
+    }
+
+    def test() = {
+      acceptClosingAngle(GTGT)
+      acceptClosingAngle(ASSIGN)
+    }
+  }
+
+  println(res) // prints "Map(a -> 1)"
+
+  nonConstCharEta.test()
+  nonConstChar.test()
+  constCharEta.test()
+  constChar.test()
+  constIntEta.test()
+  constInt.test()
 }

--- a/test/pending/run/virtpatmat_anonfun_underscore.flags
+++ b/test/pending/run/virtpatmat_anonfun_underscore.flags
@@ -1,0 +1,1 @@
+-Yvirtpatmat

--- a/test/pending/run/virtpatmat_anonfun_underscore.scala
+++ b/test/pending/run/virtpatmat_anonfun_underscore.scala
@@ -1,0 +1,4 @@
+object Test extends App {
+  List(1,2,3) map (_ match { case x => x + 1} ) // `_ match` is redundant but shouldn't crash the compiler
+  List((1,2)) map (_ match { case (x, z) => x + z})
+}


### PR DESCRIPTION
- this introduces a new translation scheme as discussed on scala-internals
- tail call support
- instead of mangling trees during uncurry, synth a (partial)function subclass during typer when a function with match-body is encountered (this is work in progress)
- pack skolems in branches of if/case before lubbing their types (otherwise we try to lub independently skolemized types) -- this is only enabled for virtpatmat, but is generally useful I believe (also, work in progress)

there are a couple of known problems with this version of virtpatmat, but I opted to ship it for this milestone so that people can try out the new codegen -- I should have fixes for the bugs I know of in a nightly later this week

none of the known problems arise unless -Yvirtpatmat, of course
