### PR TITLE
Change apply method to use getOrElse

### DIFF
--- a/src/library/scala/collection/MapLike.scala
+++ b/src/library/scala/collection/MapLike.scala
@@ -137,10 +137,7 @@ self =>
    *  @return     the value associated with the given key, or the result of the
    *              map's `default` method, if none exists.
    */
-  def apply(key: A): B = get(key) match {
-    case None => default(key)
-    case Some(value) => value
-  }
+  def apply(key: A): B = get(key).getOrElse(default(key))
 
   /** Tests whether this map contains a binding for a key.
    *


### PR DESCRIPTION
There's pattern matching on Options throughout the source code.  If this change makes sense, such changes could be implemented throughout the source.
