### PR TITLE
Fixes SI-5593

### DIFF
--- a/src/compiler/scala/tools/nsc/doc/Settings.scala
+++ b/src/compiler/scala/tools/nsc/doc/Settings.scala
@@ -97,4 +97,7 @@ class Settings(error: String => Unit) extends scala.tools.nsc.Settings(error) {
     docformat, doctitle, docfooter, docversion, docUncompilable, docsourceurl, docgenerator
   )
   val isScaladocSpecific: String => Boolean = scaladocSpecific map (_.name)
+
+  // SI-5593: set the default classpath to "" instead of "."
+  override protected def fallbackClasspath = ""
 }

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -28,7 +28,8 @@ trait ScalaSettings extends AbsScalaSettings
    *  - Otherwise, if CLASSPATH is set, it is that
    *  - If neither of those, then "." is used.
    */
-  protected def defaultClasspath = sys.env.getOrElse("CLASSPATH", ".")
+  def fallbackClasspath = "."
+  def defaultClasspath = sys.env.getOrElse("CLASSPATH", fallbackClasspath)
 
   /** Disable a setting */
   def disable(s: Setting) = allSettings -= s

--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -194,18 +194,10 @@ class PathResolver(settings: Settings, context: JavaContext) {
     def scalaExtDirs        = cmdLineOrElse("extdirs", Defaults.scalaExtDirs)
     def sourcePath          = cmdLineOrElse("sourcepath", Defaults.scalaSourcePath)
 
-    /** Against my better judgment, giving in to martin here and allowing
-     *  CLASSPATH to be used automatically.  So for the user-specified part
-     *  of the classpath:
-     *
-     *  - If -classpath or -cp is given, it is that
-     *  - Otherwise, if CLASSPATH is set, it is that
-     *  - If neither of those, then "." is used.
-     */
     def userClassPath = (
       if (!settings.classpath.isDefault)
         settings.classpath.value
-      else sys.env.getOrElse("CLASSPATH", ".")
+      else settings.defaultClasspath
     )
 
     import context._


### PR DESCRIPTION
The problem was the classpath was sneakily set to "." whenever no
classpath was given. Paul's comment says it all:

/*\* [...]
 *
-  - If -classpath or -cp is given, it is that
-  - Otherwise, if CLASSPATH is set, it is that
-  - If neither of those, then "." is used.
  */

Fixed for Scaladoc, if the classpath is empty, it stays empty. Scalac
still has the "." fallback classpath, as before, I'm not touching that.
