### PR TITLE
Backport/fork join detection jdk 1.7

### DIFF
--- a/src/actors/scala/actors/scheduler/ThreadPoolConfig.scala
+++ b/src/actors/scala/actors/scheduler/ThreadPoolConfig.scala
@@ -45,7 +45,7 @@ private[actors] object ThreadPoolConfig {
 
         // on IBM J9 1.6 do not use ForkJoinPool
         // XXX this all needs to go into Properties.
-        isJavaAtLeast("1.6") && ((javaVmVendor contains "Sun") || (javaVmVendor contains "Apple"))
+        isJavaAtLeast("1.6") && ((javaVmVendor contains "Oracle") || (javaVmVendor contains "Sun") || (javaVmVendor contains "Apple"))
       })
     catch {
       case _: SecurityException => false

--- a/src/library/scala/collection/parallel/package.scala
+++ b/src/library/scala/collection/parallel/package.scala
@@ -48,7 +48,7 @@ package object parallel {
   private[parallel] def getTaskSupport: TaskSupport =
     if (util.Properties.isJavaAtLeast("1.6")) {
       val vendor = util.Properties.javaVmVendor
-      if ((vendor contains "Sun") || (vendor contains "Apple")) new ForkJoinTaskSupport
+      if ((vendor contains "Oracle") || (vendor contains "Sun") || (vendor contains "Apple")) new ForkJoinTaskSupport
       else new ThreadPoolTaskSupport
     } else new ThreadPoolTaskSupport
 


### PR DESCRIPTION
JDK 7 changed the Vendor from Sun to Oracle; this backports the change that makes the fork-join detection aware of Sun's demise.
