### PR TITLE
SI-4771 Scala eats exit code when piping stdin

### DIFF
--- a/src/compiler/scala/tools/ant/templates/tool-unix.tmpl
+++ b/src/compiler/scala/tools/ant/templates/tool-unix.tmpl
@@ -25,8 +25,8 @@ function restoreSttySettings() {
 function onExit() {
   if [[ "$saved_stty" != "" ]]; then
     restoreSttySettings
-    exit $scala_exit_status
   fi
+  exit $scala_exit_status
 }
 
 # to reenable echo if we are interrupted before completing.


### PR DESCRIPTION
Fix for SI-4771 Scala eats exit code when piping stdin
