### PR TITLE
Fixes SI-5593

### DIFF
--- a/src/compiler/scala/tools/nsc/doc/Settings.scala
+++ b/src/compiler/scala/tools/nsc/doc/Settings.scala
@@ -97,4 +97,6 @@ class Settings(error: String => Unit) extends scala.tools.nsc.Settings(error) {
     docformat, doctitle, docfooter, docversion, docUncompilable, docsourceurl, docgenerator
   )
   val isScaladocSpecific: String => Boolean = scaladocSpecific map (_.name)
+
+  override def isScaladoc = true
 }

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -204,4 +204,7 @@ trait ScalaSettings extends AbsScalaSettings
    */
   val pluginOptions = MultiStringSetting("-P", "plugin:opt", "Pass an option to a plugin") .
                         withHelpSyntax("-P:<plugin>:<opt>")
+
+  /** Test whether this is scaladoc we're looking at */
+  def isScaladoc = false
 }

--- a/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
@@ -126,9 +126,13 @@ abstract class SymbolLoaders {
         ok = false
         if (settings.debug.value) ex.printStackTrace()
         val msg = ex.getMessage()
-        globalError(
-          if (msg eq null) "i/o error while loading " + root.name
-          else "error while loading " + root.name + ", " + msg);
+        // SI-5593 Scaladoc's current strategy is to visit all packages in search of user code that can be documented
+        // therefore, it will rummage through the classpath triggering errors whenever it encounters package objects
+        // that are not in their correct place (see bug for details)
+        if (!settings.isScaladoc)
+          globalError(
+            if (msg eq null) "i/o error while loading " + root.name
+            else "error while loading " + root.name + ", " + msg);
       }
       try {
         val start = currentTime

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -446,7 +446,11 @@ abstract class ClassfileParser {
   def classNameToSymbol(name: Name): Symbol = {
     def loadClassSymbol(name: Name): Symbol = {
       val file = global.classPath findSourceFile ("" +name) getOrElse {
-        warning("Class " + name + " not found - continuing with a stub.")
+        // SI-5593 Scaladoc's current strategy is to visit all packages in search of user code that can be documented
+        // therefore, it will rummage through the classpath triggering errors whenever it encounters package objects
+        // that are not in their correct place (see bug for details)
+        if (!settings.isScaladoc)
+          warning("Class " + name + " not found - continuing with a stub.")
         return NoSymbol.newClass(name.toTypeName)
       }
       val completer     = new global.loaders.ClassfileLoader(file)


### PR DESCRIPTION
After hours of debugging and understanding all the root causes why
scaladoc is rummaging through the current directory for classes, I
decided to treat the symptoms rather than the cause. I'll document
the decision here in case anyone is interested:
- in order to find documentable entities, scaladoc exhaustively
  looks at all the symbols starting from the root package and going
  all the way to the leaves, visiting all classes in the classpath
- if the classpath is empty, scaladoc and scalac add "." as the
  default classpath. This leads to scaladoc going on a class hunting
  spree in the current directory. If it happens that the current
  directory contains package objects and they're not in the expected
  path (like scala.tools.nsc in build/quick/classes/.../nsc) errors
  start to pop up
- scalac is also affected by this, but to a more limited scope,
  since it will lazily expand packages whenever necessary. To show
  this, run the repl in the root directory of the scala source code,
  after compiling scala:

scala> import build.quick.classes.compiler.scala.tools.nsc._
error: error while loading package, class file './build/quick/classes/
compiler/scala/tools/nsc/package.class' contains wrong package package

The cleanest solution I can see now is to look at the tree resulting
from compilation and use it for guidance -- I will look into this.
