### PR TITLE
Scaladoc: improved usecases, display full signature. Closes #5291

### DIFF
--- a/src/compiler/scala/tools/nsc/doc/html/page/Template.scala
+++ b/src/compiler/scala/tools/nsc/doc/html/page/Template.scala
@@ -345,6 +345,17 @@ class Template(universe: doc.Universe, tpl: DocTemplateEntity) extends HtmlPage 
       }
     }
 
+    val fullSignature: Seq[scala.xml.Node] = {
+      mbr match {
+        case nte: NonTemplateMemberEntity if nte.isUseCase =>
+          <div class="full-signature-block toggleContainer">
+            <span class="toggle">Full Signature</span>
+            <div class="hiddenContent full-signature-usecase">{ signature(nte.useCaseOf.get,true) }</div>
+          </div>
+        case _ => NodeSeq.Empty
+      }
+    }    
+
     val selfType: Seq[scala.xml.Node] = mbr match {
       case dtpl: DocTemplateEntity if (isSelf && !dtpl.selfType.isEmpty && !isReduced) =>
         <dt>Self Type</dt>
@@ -466,7 +477,7 @@ class Template(universe: doc.Universe, tpl: DocTemplateEntity) extends HtmlPage 
     }
     // end attributes block vals ---
 
-    val attributesInfo = attributes ++ definitionClasses ++ selfType ++ annotations ++ deprecation ++ migration ++ sourceLink ++ mainComment
+    val attributesInfo = attributes ++ definitionClasses ++ fullSignature ++ selfType ++ annotations ++ deprecation ++ migration ++ sourceLink ++ mainComment
     val attributesBlock =
       if (attributesInfo.isEmpty)
         NodeSeq.Empty

--- a/src/compiler/scala/tools/nsc/doc/html/resource/lib/template.css
+++ b/src/compiler/scala/tools/nsc/doc/html/resource/lib/template.css
@@ -340,6 +340,30 @@ div.members > ol > li:last-child {
   color: darkgreen;
 }
 
+.full-signature-usecase h4 span {
+  font-size: 10pt;
+}
+
+.full-signature-usecase > #signature {
+  padding-top: 0px;
+}
+
+#template .full-signature-usecase > .signature.closed {
+  background: none;
+}
+
+#template .full-signature-usecase > .signature.opened {
+  background: none;
+}
+
+.full-signature-block {
+  padding: 5px 0 0;
+  border-top: 1px solid #EBEBEB;
+  margin-top: 5px;
+  margin-bottom: 5px;
+}
+
+
 /* Comments text formating */
 
 .cmt {}


### PR DESCRIPTION
Makes the full signature of a use case member available, but still hidden under a drop-down menu.
