### PR TITLE
Fix .empty and add .ofDim factory method.

### DIFF
--- a/src/library/scala/collection/mutable/FlatArray.scala
+++ b/src/library/scala/collection/mutable/FlatArray.scala
@@ -60,8 +60,15 @@ extends AbstractSeq[T]
  */
 object FlatArray {
 
-  def empty[Boxed, Unboxed](elems: Boxed*)
-      (implicit boxings: BoxingConversions[Boxed, Unboxed], elemManifest: ClassManifest[Unboxed]): FlatArray[Boxed] = apply()
+  def ofDim[Boxed, Unboxed](size:Int)
+      (implicit boxings: BoxingConversions[Boxed, Unboxed],
+       manifest: ClassManifest[Unboxed]): FlatArray[Boxed] = {
+    val elems = Array.ofDim[Unboxed](size)
+    new FlatArray.Impl(elems, boxings, manifest)
+  }
+
+  def empty[Boxed, Unboxed](implicit boxings: BoxingConversions[Boxed, Unboxed],
+                            elemManifest: ClassManifest[Unboxed]): FlatArray[Boxed] = apply()
 
   def apply[Boxed, Unboxed](elems: Boxed*)
       (implicit boxings: BoxingConversions[Boxed, Unboxed], elemManifest: ClassManifest[Unboxed]): FlatArray[Boxed] = {


### PR DESCRIPTION
This commit removes the (unused and unnecessary) elems\* parameter
from the 'empty' method. It also adds 'ofDim' which allows the
user to allocate a FlatArray of a given size without providing
actual elements.

This fixes SI-5609.
