### PR TITLE
Rename ConcurrentTrieMap to concurrent.TrieMap.

### DIFF
--- a/src/library/scala/collection/concurrent/BasicNode.java
+++ b/src/library/scala/collection/concurrent/BasicNode.java
@@ -6,7 +6,7 @@
 **                          |/                                          **
 \*                                                                      */
 
-package scala.collection.mutable;
+package scala.collection.concurrent;
 
 
 

--- a/src/library/scala/collection/concurrent/CNodeBase.java
+++ b/src/library/scala/collection/concurrent/CNodeBase.java
@@ -6,30 +6,30 @@
 **                          |/                                          **
 \*                                                                      */
 
-package scala.collection.mutable;
+package scala.collection.concurrent;
 
 
 
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 
 
-abstract class INodeBase<K, V> extends BasicNode {
+abstract class CNodeBase<K, V> extends MainNode<K, V> {
     
-    public static final AtomicReferenceFieldUpdater<INodeBase, MainNode> updater = AtomicReferenceFieldUpdater.newUpdater(INodeBase.class, MainNode.class, "mainnode");
+    public static final AtomicIntegerFieldUpdater<CNodeBase> updater = AtomicIntegerFieldUpdater.newUpdater(CNodeBase.class, "csize");
     
-    public static final Object RESTART = new Object();
+    public volatile int csize = -1;
     
-    public volatile MainNode<K, V> mainnode = null;
-    
-    public final Gen gen;
-    
-    public INodeBase(Gen generation) {
-	gen = generation;
+    public boolean CAS_SIZE(int oldval, int nval) {
+	return updater.compareAndSet(this, oldval, nval);
     }
     
-    public BasicNode prev() {
-	return null;
+    public void WRITE_SIZE(int nval) {
+	updater.set(this, nval);
+    }
+    
+    public int READ_SIZE() {
+	return updater.get(this);
     }
     
 }

--- a/src/library/scala/collection/concurrent/Gen.java
+++ b/src/library/scala/collection/concurrent/Gen.java
@@ -6,7 +6,7 @@
 **                          |/                                          **
 \*                                                                      */
 
-package scala.collection.mutable;
+package scala.collection.concurrent;
 
 
 

--- a/src/library/scala/collection/concurrent/INodeBase.java
+++ b/src/library/scala/collection/concurrent/INodeBase.java
@@ -6,30 +6,30 @@
 **                          |/                                          **
 \*                                                                      */
 
-package scala.collection.mutable;
+package scala.collection.concurrent;
 
 
 
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 
 
-abstract class CNodeBase<K, V> extends MainNode<K, V> {
+abstract class INodeBase<K, V> extends BasicNode {
     
-    public static final AtomicIntegerFieldUpdater<CNodeBase> updater = AtomicIntegerFieldUpdater.newUpdater(CNodeBase.class, "csize");
+    public static final AtomicReferenceFieldUpdater<INodeBase, MainNode> updater = AtomicReferenceFieldUpdater.newUpdater(INodeBase.class, MainNode.class, "mainnode");
     
-    public volatile int csize = -1;
+    public static final Object RESTART = new Object();
     
-    public boolean CAS_SIZE(int oldval, int nval) {
-	return updater.compareAndSet(this, oldval, nval);
+    public volatile MainNode<K, V> mainnode = null;
+    
+    public final Gen gen;
+    
+    public INodeBase(Gen generation) {
+	gen = generation;
     }
     
-    public void WRITE_SIZE(int nval) {
-	updater.set(this, nval);
-    }
-    
-    public int READ_SIZE() {
-	return updater.get(this);
+    public BasicNode prev() {
+	return null;
     }
     
 }

--- a/src/library/scala/collection/concurrent/MainNode.java
+++ b/src/library/scala/collection/concurrent/MainNode.java
@@ -6,7 +6,7 @@
 **                          |/                                          **
 \*                                                                      */
 
-package scala.collection.mutable;
+package scala.collection.concurrent;
 
 
 

--- a/src/library/scala/collection/concurrent/Map.scala
+++ b/src/library/scala/collection/concurrent/Map.scala
@@ -6,8 +6,7 @@
 **                          |/                                          **
 \*                                                                      */
 
-package scala.collection
-package mutable
+package scala.collection.concurrent
 
 /** A template trait for mutable maps that allow concurrent access.
  *
@@ -32,8 +31,7 @@ package mutable
  *  @define atomicop
  *  This is an atomic operation.
  */
-@deprecated("Use `scala.collection.concurrent.Map` instead.", "2.10.0")
-trait ConcurrentMap[A, B] extends Map[A, B] {
+trait Map[A, B] extends scala.collection.mutable.Map[A, B] {
 
   /**
    * Associates the given key with a given value, unless the key was already

--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -7,13 +7,13 @@
 \*                                                                      */
 
 package scala.collection
-package mutable
+package concurrent
 
 
 
 import java.util.concurrent.atomic._
 import collection.immutable.{ ListMap => ImmutableListMap }
-import collection.parallel.mutable.ParConcurrentTrieMap
+import collection.parallel.mutable.ParTrieMap
 import generic._
 import annotation.tailrec
 import annotation.switch
@@ -31,16 +31,16 @@ private[collection] final class INode[K, V](bn: MainNode[K, V], g: Gen) extends 
 
   @inline final def CAS(old: MainNode[K, V], n: MainNode[K, V]) = INodeBase.updater.compareAndSet(this, old, n)
 
-  final def gcasRead(ct: ConcurrentTrieMap[K, V]): MainNode[K, V] = GCAS_READ(ct)
+  final def gcasRead(ct: TrieMap[K, V]): MainNode[K, V] = GCAS_READ(ct)
 
-  @inline final def GCAS_READ(ct: ConcurrentTrieMap[K, V]): MainNode[K, V] = {
+  @inline final def GCAS_READ(ct: TrieMap[K, V]): MainNode[K, V] = {
     val m = /*READ*/mainnode
     val prevval = /*READ*/m.prev
     if (prevval eq null) m
     else GCAS_Complete(m, ct)
   }
 
-  @tailrec private def GCAS_Complete(m: MainNode[K, V], ct: ConcurrentTrieMap[K, V]): MainNode[K, V] = if (m eq null) null else {
+  @tailrec private def GCAS_Complete(m: MainNode[K, V], ct: TrieMap[K, V]): MainNode[K, V] = if (m eq null) null else {
     // complete the GCAS
     val prev = /*READ*/m.prev
     val ctr = ct.readRoot(true)
@@ -72,7 +72,7 @@ private[collection] final class INode[K, V](bn: MainNode[K, V], g: Gen) extends 
     }
   }
 
-  @inline final def GCAS(old: MainNode[K, V], n: MainNode[K, V], ct: ConcurrentTrieMap[K, V]): Boolean = {
+  @inline final def GCAS(old: MainNode[K, V], n: MainNode[K, V], ct: TrieMap[K, V]): Boolean = {
     n.WRITE_PREV(old)
     if (CAS(old, n)) {
       GCAS_Complete(n, ct)
@@ -86,7 +86,7 @@ private[collection] final class INode[K, V](bn: MainNode[K, V], g: Gen) extends 
     nin
   }
 
-  final def copyToGen(ngen: Gen, ct: ConcurrentTrieMap[K, V]) = {
+  final def copyToGen(ngen: Gen, ct: TrieMap[K, V]) = {
     val nin = new INode[K, V](ngen)
     val main = GCAS_READ(ct)
     nin.WRITE(main)
@@ -97,7 +97,7 @@ private[collection] final class INode[K, V](bn: MainNode[K, V], g: Gen) extends 
    *
    *  @return        true if successful, false otherwise
    */
-  @tailrec final def rec_insert(k: K, v: V, hc: Int, lev: Int, parent: INode[K, V], startgen: Gen, ct: ConcurrentTrieMap[K, V]): Boolean = {
+  @tailrec final def rec_insert(k: K, v: V, hc: Int, lev: Int, parent: INode[K, V], startgen: Gen, ct: TrieMap[K, V]): Boolean = {
     val m = GCAS_READ(ct) // use -Yinline!
 
     m match {
@@ -143,7 +143,7 @@ private[collection] final class INode[K, V](bn: MainNode[K, V], g: Gen) extends 
    *  @param cond        null - don't care if the key was there; KEY_ABSENT - key wasn't there; KEY_PRESENT - key was there; other value `v` - key must be bound to `v`
    *  @return            null if unsuccessful, Option[V] otherwise (indicating previous value bound to the key)
    */
-  @tailrec final def rec_insertif(k: K, v: V, hc: Int, cond: AnyRef, lev: Int, parent: INode[K, V], startgen: Gen, ct: ConcurrentTrieMap[K, V]): Option[V] = {
+  @tailrec final def rec_insertif(k: K, v: V, hc: Int, cond: AnyRef, lev: Int, parent: INode[K, V], startgen: Gen, ct: TrieMap[K, V]): Option[V] = {
     val m = GCAS_READ(ct)  // use -Yinline!
 
     m match {
@@ -233,7 +233,7 @@ private[collection] final class INode[K, V](bn: MainNode[K, V], g: Gen) extends 
    *
    *  @return          null if no value has been found, RESTART if the operation wasn't successful, or any other value otherwise
    */
-  @tailrec final def rec_lookup(k: K, hc: Int, lev: Int, parent: INode[K, V], startgen: Gen, ct: ConcurrentTrieMap[K, V]): AnyRef = {
+  @tailrec final def rec_lookup(k: K, hc: Int, lev: Int, parent: INode[K, V], startgen: Gen, ct: TrieMap[K, V]): AnyRef = {
     val m = GCAS_READ(ct) // use -Yinline!
 
     m match {
@@ -276,7 +276,7 @@ private[collection] final class INode[K, V](bn: MainNode[K, V], g: Gen) extends 
    *  @param v         if null, will remove the key irregardless of the value; otherwise removes only if binding contains that exact key and value
    *  @return          null if not successful, an Option[V] indicating the previous value otherwise
    */
-  final def rec_remove(k: K, v: V, hc: Int, lev: Int, parent: INode[K, V], startgen: Gen, ct: ConcurrentTrieMap[K, V]): Option[V] = {
+  final def rec_remove(k: K, v: V, hc: Int, lev: Int, parent: INode[K, V], startgen: Gen, ct: TrieMap[K, V]): Option[V] = {
     val m = GCAS_READ(ct) // use -Yinline!
 
     m match {
@@ -352,7 +352,7 @@ private[collection] final class INode[K, V](bn: MainNode[K, V], g: Gen) extends 
     }
   }
 
-  private def clean(nd: INode[K, V], ct: ConcurrentTrieMap[K, V], lev: Int) {
+  private def clean(nd: INode[K, V], ct: TrieMap[K, V], lev: Int) {
     val m = nd.GCAS_READ(ct)
     m match {
       case cn: CNode[K, V] => nd.GCAS(cn, cn.toCompressed(ct, lev, gen), ct)
@@ -360,9 +360,9 @@ private[collection] final class INode[K, V](bn: MainNode[K, V], g: Gen) extends 
     }
   }
 
-  final def isNullInode(ct: ConcurrentTrieMap[K, V]) = GCAS_READ(ct) eq null
+  final def isNullInode(ct: TrieMap[K, V]) = GCAS_READ(ct) eq null
 
-  final def cachedSize(ct: ConcurrentTrieMap[K, V]): Int = {
+  final def cachedSize(ct: TrieMap[K, V]): Int = {
     val m = GCAS_READ(ct)
     m.cachedSize(ct)
   }
@@ -379,7 +379,7 @@ private[collection] final class INode[K, V](bn: MainNode[K, V], g: Gen) extends 
 }
 
 
-private[mutable] object INode {
+private[concurrent] object INode {
   val KEY_PRESENT = new AnyRef
   val KEY_ABSENT = new AnyRef
 
@@ -391,7 +391,7 @@ private[mutable] object INode {
 }
 
 
-private[mutable] final class FailedNode[K, V](p: MainNode[K, V]) extends MainNode[K, V] {
+private[concurrent] final class FailedNode[K, V](p: MainNode[K, V]) extends MainNode[K, V] {
   WRITE_PREV(p)
 
   def string(lev: Int) = throw new UnsupportedOperationException
@@ -402,7 +402,7 @@ private[mutable] final class FailedNode[K, V](p: MainNode[K, V]) extends MainNod
 }
 
 
-private[mutable] trait KVNode[K, V] {
+private[concurrent] trait KVNode[K, V] {
   def kvPair: (K, V)
 }
 
@@ -438,7 +438,7 @@ extends MainNode[K, V] {
     if (updmap.size > 1) new LNode(updmap)
     else {
       val (k, v) = updmap.iterator.next
-      new TNode(k, v, ConcurrentTrieMap.computeHash(k)) // create it tombed so that it gets compressed on subsequent accesses
+      new TNode(k, v, TrieMap.computeHash(k)) // create it tombed so that it gets compressed on subsequent accesses
     }
   }
   def get(k: K) = listmap.get(k)
@@ -455,7 +455,7 @@ extends CNodeBase[K, V] {
     val currsz = READ_SIZE()
     if (currsz != -1) currsz
     else {
-      val sz = computeSize(ct.asInstanceOf[ConcurrentTrieMap[K, V]])
+      val sz = computeSize(ct.asInstanceOf[TrieMap[K, V]])
       while (READ_SIZE() == -1) CAS_SIZE(-1, sz)
       READ_SIZE()
     }
@@ -466,7 +466,7 @@ extends CNodeBase[K, V] {
   // => if there are concurrent size computations, they start
   //    at different positions, so they are more likely to
   //    to be independent
-  private def computeSize(ct: ConcurrentTrieMap[K, V]): Int = {
+  private def computeSize(ct: TrieMap[K, V]): Int = {
     var i = 0
     var sz = 0
     val offset = math.abs(util.Random.nextInt()) % array.length
@@ -511,7 +511,7 @@ extends CNodeBase[K, V] {
   /** Returns a copy of this cnode such that all the i-nodes below it are copied
    *  to the specified generation `ngen`.
    */
-  final def renewed(ngen: Gen, ct: ConcurrentTrieMap[K, V]) = {
+  final def renewed(ngen: Gen, ct: TrieMap[K, V]) = {
     var i = 0
     val arr = array
     val len = arr.length
@@ -542,7 +542,7 @@ extends CNodeBase[K, V] {
   //   returns the version of this node with at least some null-inodes
   //   removed (those existing when the op began)
   // - if there are only null-i-nodes below, returns null
-  final def toCompressed(ct: ConcurrentTrieMap[K, V], lev: Int, gen: Gen) = {
+  final def toCompressed(ct: TrieMap[K, V], lev: Int, gen: Gen) = {
     var bmp = bitmap
     var i = 0
     val arr = array
@@ -563,7 +563,7 @@ extends CNodeBase[K, V] {
     new CNode[K, V](bmp, tmparray, gen).toContracted(lev)
   }
 
-  private[mutable] def string(lev: Int): String = "CNode %x\n%s".format(bitmap, array.map(_.string(lev + 1)).mkString("\n"))
+  private[concurrent] def string(lev: Int): String = "CNode %x\n%s".format(bitmap, array.map(_.string(lev + 1)).mkString("\n"))
 
   /* quiescently consistent - don't call concurrently to anything involving a GCAS!! */
   protected def collectElems: Seq[(K, V)] = array flatMap {
@@ -587,14 +587,14 @@ extends CNodeBase[K, V] {
 }
 
 
-private[mutable] object CNode {
+private[concurrent] object CNode {
 
   def dual[K, V](x: SNode[K, V], xhc: Int, y: SNode[K, V], yhc: Int, lev: Int, gen: Gen): MainNode[K, V] = if (lev < 35) {
     val xidx = (xhc >>> lev) & 0x1f
     val yidx = (yhc >>> lev) & 0x1f
     val bmp = (1 << xidx) | (1 << yidx)
     if (xidx == yidx) {
-      val subinode = new INode[K, V](gen)//(ConcurrentTrieMap.inodeupdater)
+      val subinode = new INode[K, V](gen)//(TrieMap.inodeupdater)
       subinode.mainnode = dual(x, xhc, y, yhc, lev + 5, gen)
       new CNode(bmp, Array(subinode), gen)
     } else {
@@ -608,12 +608,12 @@ private[mutable] object CNode {
 }
 
 
-private[mutable] case class RDCSS_Descriptor[K, V](old: INode[K, V], expectedmain: MainNode[K, V], nv: INode[K, V]) {
+private[concurrent] case class RDCSS_Descriptor[K, V](old: INode[K, V], expectedmain: MainNode[K, V], nv: INode[K, V]) {
   @volatile var committed = false
 }
 
 
-/** A concurrent hash-trie or ConcurrentTrieMap is a concurrent thread-safe lock-free
+/** A concurrent hash-trie or TrieMap is a concurrent thread-safe lock-free
  *  implementation of a hash array mapped trie. It is used to implement the
  *  concurrent map abstraction. It has particularly scalable concurrent insert
  *  and remove operations and is memory-efficient. It supports O(1), atomic,
@@ -627,20 +627,20 @@ private[mutable] case class RDCSS_Descriptor[K, V](old: INode[K, V], expectedmai
  *  @since 2.10
  */
 @SerialVersionUID(0L - 6402774413839597105L)
-final class ConcurrentTrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater[ConcurrentTrieMap[K, V], AnyRef])
-extends ConcurrentMap[K, V]
-   with MapLike[K, V, ConcurrentTrieMap[K, V]]
-   with CustomParallelizable[(K, V), ParConcurrentTrieMap[K, V]]
+final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater[TrieMap[K, V], AnyRef])
+extends scala.collection.concurrent.Map[K, V]
+   with scala.collection.mutable.MapLike[K, V, TrieMap[K, V]]
+   with CustomParallelizable[(K, V), ParTrieMap[K, V]]
    with Serializable
 {
-  import ConcurrentTrieMap.computeHash
+  import TrieMap.computeHash
 
   private var rootupdater = rtupd
   @volatile var root = r
 
   def this() = this(
     INode.newRootNode,
-    AtomicReferenceFieldUpdater.newUpdater(classOf[ConcurrentTrieMap[K, V]], classOf[AnyRef], "root")
+    AtomicReferenceFieldUpdater.newUpdater(classOf[TrieMap[K, V]], classOf[AnyRef], "root")
   )
 
   /* internal methods */
@@ -652,22 +652,22 @@ extends ConcurrentMap[K, V]
       out.writeObject(k)
       out.writeObject(v)
     }
-    out.writeObject(ConcurrentTrieMapSerializationEnd)
+    out.writeObject(TrieMapSerializationEnd)
   }
 
   private def readObject(in: java.io.ObjectInputStream) {
     root = INode.newRootNode
-    rootupdater = AtomicReferenceFieldUpdater.newUpdater(classOf[ConcurrentTrieMap[K, V]], classOf[AnyRef], "root")
+    rootupdater = AtomicReferenceFieldUpdater.newUpdater(classOf[TrieMap[K, V]], classOf[AnyRef], "root")
 
     var obj: AnyRef = null
     do {
       obj = in.readObject()
-      if (obj != ConcurrentTrieMapSerializationEnd) {
+      if (obj != TrieMapSerializationEnd) {
         val k = obj.asInstanceOf[K]
         val v = in.readObject().asInstanceOf[V]
         update(k, v)
       }
-    } while (obj != ConcurrentTrieMapSerializationEnd)
+    } while (obj != TrieMapSerializationEnd)
   }
 
   @inline final def CAS_ROOT(ov: AnyRef, nv: AnyRef) = rootupdater.compareAndSet(this, ov, nv)
@@ -760,37 +760,37 @@ extends ConcurrentMap[K, V]
 
   override def seq = this
 
-  override def par = new ParConcurrentTrieMap(this)
+  override def par = new ParTrieMap(this)
 
-  override def empty: ConcurrentTrieMap[K, V] = new ConcurrentTrieMap[K, V]
+  override def empty: TrieMap[K, V] = new TrieMap[K, V]
 
   final def isReadOnly = rootupdater eq null
 
   final def nonReadOnly = rootupdater ne null
 
-  /** Returns a snapshot of this ConcurrentTrieMap.
+  /** Returns a snapshot of this TrieMap.
    *  This operation is lock-free and linearizable.
    *
    *  The snapshot is lazily updated - the first time some branch
-   *  in the snapshot or this ConcurrentTrieMap are accessed, they are rewritten.
+   *  in the snapshot or this TrieMap are accessed, they are rewritten.
    *  This means that the work of rebuilding both the snapshot and this
-   *  ConcurrentTrieMap is distributed across all the threads doing updates or accesses
+   *  TrieMap is distributed across all the threads doing updates or accesses
    *  subsequent to the snapshot creation.
    */
-  @tailrec final def snapshot(): ConcurrentTrieMap[K, V] = {
+  @tailrec final def snapshot(): TrieMap[K, V] = {
     val r = RDCSS_READ_ROOT()
     val expmain = r.gcasRead(this)
-    if (RDCSS_ROOT(r, expmain, r.copyToGen(new Gen, this))) new ConcurrentTrieMap(r.copyToGen(new Gen, this), rootupdater)
+    if (RDCSS_ROOT(r, expmain, r.copyToGen(new Gen, this))) new TrieMap(r.copyToGen(new Gen, this), rootupdater)
     else snapshot()
   }
 
-  /** Returns a read-only snapshot of this ConcurrentTrieMap.
+  /** Returns a read-only snapshot of this TrieMap.
    *  This operation is lock-free and linearizable.
    *
    *  The snapshot is lazily updated - the first time some branch
-   *  of this ConcurrentTrieMap are accessed, it is rewritten. The work of creating
+   *  of this TrieMap are accessed, it is rewritten. The work of creating
    *  the snapshot is thus distributed across subsequent updates
-   *  and accesses on this ConcurrentTrieMap by all threads.
+   *  and accesses on this TrieMap by all threads.
    *  Note that the snapshot itself is never rewritten unlike when calling
    *  the `snapshot` method, but the obtained snapshot cannot be modified.
    *
@@ -799,7 +799,7 @@ extends ConcurrentMap[K, V]
   @tailrec final def readOnlySnapshot(): collection.Map[K, V] = {
     val r = RDCSS_READ_ROOT()
     val expmain = r.gcasRead(this)
-    if (RDCSS_ROOT(r, expmain, r.copyToGen(new Gen, this))) new ConcurrentTrieMap(r, null)
+    if (RDCSS_ROOT(r, expmain, r.copyToGen(new Gen, this))) new TrieMap(r, null)
     else readOnlySnapshot()
   }
 
@@ -872,7 +872,7 @@ extends ConcurrentMap[K, V]
 
   def iterator: Iterator[(K, V)] =
     if (nonReadOnly) readOnlySnapshot().iterator
-    else new ConcurrentTrieMapIterator(0, this)
+    else new TrieMapIterator(0, this)
 
   private def cachedSize() = {
     val r = RDCSS_READ_ROOT()
@@ -883,17 +883,17 @@ extends ConcurrentMap[K, V]
     if (nonReadOnly) readOnlySnapshot().size
     else cachedSize()
 
-  override def stringPrefix = "ConcurrentTrieMap"
+  override def stringPrefix = "TrieMap"
 
 }
 
 
-object ConcurrentTrieMap extends MutableMapFactory[ConcurrentTrieMap] {
+object TrieMap extends MutableMapFactory[TrieMap] {
   val inodeupdater = AtomicReferenceFieldUpdater.newUpdater(classOf[INodeBase[_, _]], classOf[MainNode[_, _]], "mainnode")
 
-  implicit def canBuildFrom[K, V]: CanBuildFrom[Coll, (K, V), ConcurrentTrieMap[K, V]] = new MapCanBuildFrom[K, V]
+  implicit def canBuildFrom[K, V]: CanBuildFrom[Coll, (K, V), TrieMap[K, V]] = new MapCanBuildFrom[K, V]
 
-  def empty[K, V]: ConcurrentTrieMap[K, V] = new ConcurrentTrieMap[K, V]
+  def empty[K, V]: TrieMap[K, V] = new TrieMap[K, V]
 
   @inline final def computeHash[K](k: K): Int = {
     var hcode = k.hashCode
@@ -905,7 +905,7 @@ object ConcurrentTrieMap extends MutableMapFactory[ConcurrentTrieMap] {
 }
 
 
-private[collection] class ConcurrentTrieMapIterator[K, V](var level: Int, private var ct: ConcurrentTrieMap[K, V], mustInit: Boolean = true) extends Iterator[(K, V)] {
+private[collection] class TrieMapIterator[K, V](var level: Int, private var ct: TrieMap[K, V], mustInit: Boolean = true) extends Iterator[(K, V)] {
   var stack = new Array[Array[BasicNode]](7)
   var stackpos = new Array[Int](7)
   var depth = -1
@@ -971,9 +971,9 @@ private[collection] class ConcurrentTrieMapIterator[K, V](var level: Int, privat
     }
   } else current = null
 
-  protected def newIterator(_lev: Int, _ct: ConcurrentTrieMap[K, V], _mustInit: Boolean) = new ConcurrentTrieMapIterator[K, V](_lev, _ct, _mustInit)
+  protected def newIterator(_lev: Int, _ct: TrieMap[K, V], _mustInit: Boolean) = new TrieMapIterator[K, V](_lev, _ct, _mustInit)
 
-  protected def dupTo(it: ConcurrentTrieMapIterator[K, V]) = {
+  protected def dupTo(it: TrieMapIterator[K, V]) = {
     it.level = this.level
     it.ct = this.ct
     it.depth = this.depth
@@ -993,7 +993,7 @@ private[collection] class ConcurrentTrieMapIterator[K, V](var level: Int, privat
   }
 
   /** Returns a sequence of iterators over subsets of this iterator.
-   *  It's used to ease the implementation of splitters for a parallel version of the ConcurrentTrieMap.
+   *  It's used to ease the implementation of splitters for a parallel version of the TrieMap.
    */
   protected def subdivide(): Seq[Iterator[(K, V)]] = if (subiter ne null) {
     // the case where an LNode is being iterated
@@ -1038,15 +1038,15 @@ private[collection] class ConcurrentTrieMapIterator[K, V](var level: Int, privat
 }
 
 
-private[mutable] object RestartException extends util.control.ControlThrowable
+private[concurrent] object RestartException extends util.control.ControlThrowable
 
 
 /** Only used for ctrie serialization. */
 @SerialVersionUID(0L - 7237891413820527142L)
-private[mutable] case object ConcurrentTrieMapSerializationEnd
+private[concurrent] case object TrieMapSerializationEnd
 
 
-private[mutable] object Debug {
+private[concurrent] object Debug {
   import collection._
 
   lazy val logbuffer = new java.util.concurrent.ConcurrentLinkedQueue[AnyRef]

--- a/test/files/jvm/serialization.check
+++ b/test/files/jvm/serialization.check
@@ -192,8 +192,8 @@ x = TreeSet(1, 2, 3)
 y = TreeSet(1, 2, 3)
 x equals y: true, y equals x: true
 
-x = ConcurrentTrieMap(1 -> one, 2 -> two, 3 -> three)
-y = ConcurrentTrieMap(1 -> one, 2 -> two, 3 -> three)
+x = TrieMap(1 -> one, 2 -> two, 3 -> three)
+y = TrieMap(1 -> one, 2 -> two, 3 -> three)
 x equals y: true, y equals x: true
 
 x =  xml:src="hello"
@@ -287,8 +287,8 @@ x = ParHashMap(2 -> 4, 1 -> 2)
 y = ParHashMap(2 -> 4, 1 -> 2)
 x equals y: true, y equals x: true
 
-x = ParConcurrentTrieMap(1 -> 2, 2 -> 4)
-y = ParConcurrentTrieMap(1 -> 2, 2 -> 4)
+x = ParTrieMap(1 -> 2, 2 -> 4)
+y = ParTrieMap(1 -> 2, 2 -> 4)
 x equals y: true, y equals x: true
 
 x = ParHashSet(1, 2, 3)

--- a/test/files/jvm/serialization.scala
+++ b/test/files/jvm/serialization.scala
@@ -286,7 +286,8 @@ object Test3_mutable {
   import scala.collection.mutable.{
     ArrayBuffer, ArrayBuilder, ArraySeq, ArrayStack, BitSet, DoubleLinkedList,
     HashMap, HashSet, History, LinkedList, ListBuffer, Publisher, Queue,
-    Stack, StringBuilder, WrappedArray, TreeSet, ConcurrentTrieMap}
+    Stack, StringBuilder, WrappedArray, TreeSet}
+  import scala.collection.concurrent.TrieMap
 
   // in alphabetic order
   try {
@@ -386,9 +387,9 @@ object Test3_mutable {
     val _ts1: TreeSet[Int] = read(write(ts1))
     check(ts1, _ts1)
     
-    // ConcurrentTrieMap
-    val ct1 = ConcurrentTrieMap[Int, String]() ++= Array(1 -> "one", 2 -> "two", 3 -> "three")
-    val _ct1: ConcurrentTrieMap[Int, String] = read(write(ct1))
+    // concurrent.TrieMap
+    val ct1 = TrieMap[Int, String]() ++= Array(1 -> "one", 2 -> "two", 3 -> "three")
+    val _ct1: TrieMap[Int, String] = read(write(ct1))
     check(ct1, _ct1)
   }
   catch {
@@ -613,9 +614,9 @@ object Test9_parallel {
     val _mpm: mutable.ParHashMap[Int, Int] = read(write(mpm))
     check(mpm, _mpm)
     
-    // mutable.ParConcurrentTrieMap
-    val mpc = mutable.ParConcurrentTrieMap(1 -> 2, 2 -> 4)
-    val _mpc: mutable.ParConcurrentTrieMap[Int, Int] = read(write(mpc))
+    // mutable.ParTrieMap
+    val mpc = mutable.ParTrieMap(1 -> 2, 2 -> 4)
+    val _mpc: mutable.ParTrieMap[Int, Int] = read(write(mpc))
     check(mpc, _mpc)
     
     // mutable.ParHashSet

--- a/test/files/run/ctries/concmap.scala
+++ b/test/files/run/ctries/concmap.scala
@@ -1,7 +1,7 @@
 
 
 
-import collection.mutable.ConcurrentTrieMap
+import collection.concurrent.TrieMap
 
 
 object ConcurrentMapSpec extends Spec {
@@ -11,13 +11,13 @@ object ConcurrentMapSpec extends Spec {
   
   def test() {
     "support put" in {
-      val ct = new ConcurrentTrieMap[Wrap, Int]
+      val ct = new TrieMap[Wrap, Int]
       for (i <- 0 until initsz) assert(ct.put(new Wrap(i), i) == None)
       for (i <- 0 until initsz) assert(ct.put(new Wrap(i), -i) == Some(i))
     }
     
     "support put if absent" in {
-      val ct = new ConcurrentTrieMap[Wrap, Int]
+      val ct = new TrieMap[Wrap, Int]
       for (i <- 0 until initsz) ct.update(new Wrap(i), i)
       for (i <- 0 until initsz) assert(ct.putIfAbsent(new Wrap(i), -i) == Some(i))
       for (i <- 0 until initsz) assert(ct.putIfAbsent(new Wrap(i), -i) == Some(i))
@@ -26,7 +26,7 @@ object ConcurrentMapSpec extends Spec {
     }
     
     "support remove if mapped to a specific value" in {
-      val ct = new ConcurrentTrieMap[Wrap, Int]
+      val ct = new TrieMap[Wrap, Int]
       for (i <- 0 until initsz) ct.update(new Wrap(i), i)
       for (i <- 0 until initsz) assert(ct.remove(new Wrap(i), -i - 1) == false)
       for (i <- 0 until initsz) assert(ct.remove(new Wrap(i), i) == true)
@@ -34,7 +34,7 @@ object ConcurrentMapSpec extends Spec {
     }
     
     "support replace if mapped to a specific value" in {
-      val ct = new ConcurrentTrieMap[Wrap, Int]
+      val ct = new TrieMap[Wrap, Int]
       for (i <- 0 until initsz) ct.update(new Wrap(i), i)
       for (i <- 0 until initsz) assert(ct.replace(new Wrap(i), -i - 1, -i - 2) == false)
       for (i <- 0 until initsz) assert(ct.replace(new Wrap(i), i, -i - 2) == true)
@@ -43,7 +43,7 @@ object ConcurrentMapSpec extends Spec {
     }
     
     "support replace if present" in {
-      val ct = new ConcurrentTrieMap[Wrap, Int]
+      val ct = new TrieMap[Wrap, Int]
       for (i <- 0 until initsz) ct.update(new Wrap(i), i)
       for (i <- 0 until initsz) assert(ct.replace(new Wrap(i), -i) == Some(i))
       for (i <- 0 until initsz) assert(ct.replace(new Wrap(i), i) == Some(-i))
@@ -56,7 +56,7 @@ object ConcurrentMapSpec extends Spec {
     }
     
     "support replace if mapped to a specific value, using several threads" in {
-      val ct = new ConcurrentTrieMap[Wrap, Int]
+      val ct = new TrieMap[Wrap, Int]
       val sz = 55000
       for (i <- 0 until sz) ct.update(new Wrap(i), i)
       
@@ -89,7 +89,7 @@ object ConcurrentMapSpec extends Spec {
     }
     
     "support put if absent, several threads" in {
-      val ct = new ConcurrentTrieMap[Wrap, Int]
+      val ct = new TrieMap[Wrap, Int]
       val sz = 110000
       
       class Updater(offs: Int) extends Thread {
@@ -110,7 +110,7 @@ object ConcurrentMapSpec extends Spec {
     }
     
     "support remove if mapped to a specific value, several threads" in {
-      val ct = new ConcurrentTrieMap[Wrap, Int]
+      val ct = new TrieMap[Wrap, Int]
       val sz = 55000
       for (i <- 0 until sz) ct.update(new Wrap(i), i)
       
@@ -132,7 +132,7 @@ object ConcurrentMapSpec extends Spec {
     }
     
     "have all or none of the elements depending on the oddity" in {
-      val ct = new ConcurrentTrieMap[Wrap, Int]
+      val ct = new TrieMap[Wrap, Int]
       val sz = 65000
       for (i <- 0 until sz) ct(new Wrap(i)) = i
       
@@ -165,7 +165,7 @@ object ConcurrentMapSpec extends Spec {
     }
     
     "compute size correctly" in {
-      val ct = new ConcurrentTrieMap[Wrap, Int]
+      val ct = new TrieMap[Wrap, Int]
       val sz = 36450
       for (i <- 0 until sz) ct(new Wrap(i)) = i
       
@@ -174,7 +174,7 @@ object ConcurrentMapSpec extends Spec {
     }
     
     "compute size correctly in parallel" in {
-      val ct = new ConcurrentTrieMap[Wrap, Int]
+      val ct = new TrieMap[Wrap, Int]
       val sz = 36450
       for (i <- 0 until sz) ct(new Wrap(i)) = i
       val pct = ct.par

--- a/test/files/run/ctries/iterator.scala
+++ b/test/files/run/ctries/iterator.scala
@@ -3,7 +3,7 @@
 
 
 import collection._
-import collection.mutable.ConcurrentTrieMap
+import collection.concurrent.TrieMap
 
 
 
@@ -11,7 +11,7 @@ object IteratorSpec extends Spec {
   
   def test() {
     "work for an empty trie" in {
-      val ct = new ConcurrentTrieMap
+      val ct = new TrieMap
       val it = ct.iterator
       
       it.hasNext shouldEqual (false)
@@ -19,7 +19,7 @@ object IteratorSpec extends Spec {
     }
     
     def nonEmptyIteratorCheck(sz: Int) {
-      val ct = new ConcurrentTrieMap[Wrap, Int]
+      val ct = new TrieMap[Wrap, Int]
       for (i <- 0 until sz) ct.put(new Wrap(i), i)
       
       val it = ct.iterator
@@ -84,7 +84,7 @@ object IteratorSpec extends Spec {
     }
     
     def nonEmptyCollideCheck(sz: Int) {
-      val ct = new ConcurrentTrieMap[DumbHash, Int]
+      val ct = new TrieMap[DumbHash, Int]
       for (i <- 0 until sz) ct.put(new DumbHash(i), i)
       
       val it = ct.iterator
@@ -144,7 +144,7 @@ object IteratorSpec extends Spec {
       val W = 15
       val S = 5
       val checks = 5
-      val ct = new ConcurrentTrieMap[Wrap, Int]
+      val ct = new TrieMap[Wrap, Int]
       for (i <- 0 until sz) ct.put(new Wrap(i), i)
       
       class Modifier extends Thread {
@@ -156,7 +156,7 @@ object IteratorSpec extends Spec {
         }
       }
       
-      def consistentIteration(ct: ConcurrentTrieMap[Wrap, Int], checks: Int) {
+      def consistentIteration(ct: TrieMap[Wrap, Int], checks: Int) {
         class Iter extends Thread {
           override def run() {
             val snap = ct.readOnlySnapshot()
@@ -185,7 +185,7 @@ object IteratorSpec extends Spec {
       val sgroupsize = 10
       val sgroupnum = 5
       val removerslowdown = 50
-      val ct = new ConcurrentTrieMap[Wrap, Int]
+      val ct = new TrieMap[Wrap, Int]
       for (i <- 0 until sz) ct.put(new Wrap(i), i)
       
       class Remover extends Thread {
@@ -227,7 +227,7 @@ object IteratorSpec extends Spec {
       val sgroupsize = 10
       val sgroupnum = 10
       val inserterslowdown = 50
-      val ct = new ConcurrentTrieMap[Wrap, Int]
+      val ct = new TrieMap[Wrap, Int]
       
       class Inserter extends Thread {
         override def run() {
@@ -265,7 +265,7 @@ object IteratorSpec extends Spec {
     
     "work on a yet unevaluated snapshot" in {
       val sz = 50000
-      val ct = new ConcurrentTrieMap[Wrap, Int]
+      val ct = new TrieMap[Wrap, Int]
       for (i <- 0 until sz) ct.update(new Wrap(i), i)
       
       val snap = ct.snapshot()
@@ -276,7 +276,7 @@ object IteratorSpec extends Spec {
     
     "be duplicated" in {
       val sz = 50
-      val ct = collection.parallel.mutable.ParConcurrentTrieMap((0 until sz) zip (0 until sz): _*)
+      val ct = collection.parallel.mutable.ParTrieMap((0 until sz) zip (0 until sz): _*)
       val it = ct.splitter
       for (_ <- 0 until (sz / 2)) it.next()
       val dupit = it.dup

--- a/test/files/run/ctries/lnode.scala
+++ b/test/files/run/ctries/lnode.scala
@@ -1,7 +1,7 @@
 
 
 
-import collection.mutable.ConcurrentTrieMap
+import collection.concurrent.TrieMap
 
 
 object LNodeSpec extends Spec {
@@ -11,19 +11,19 @@ object LNodeSpec extends Spec {
   
   def test() {
     "accept elements with the same hash codes" in {
-      val ct = new ConcurrentTrieMap[DumbHash, Int]
+      val ct = new TrieMap[DumbHash, Int]
       for (i <- 0 until initsz) ct.update(new DumbHash(i), i)
     }
     
     "lookup elements with the same hash codes" in {
-      val ct = new ConcurrentTrieMap[DumbHash, Int]
+      val ct = new TrieMap[DumbHash, Int]
       for (i <- 0 until initsz) ct.update(new DumbHash(i), i)
       for (i <- 0 until initsz) assert(ct.get(new DumbHash(i)) == Some(i))
       for (i <- initsz until secondsz) assert(ct.get(new DumbHash(i)) == None)
     }
     
     "remove elements with the same hash codes" in {
-      val ct = new ConcurrentTrieMap[DumbHash, Int]
+      val ct = new TrieMap[DumbHash, Int]
       for (i <- 0 until initsz) ct.update(new DumbHash(i), i)
       for (i <- 0 until initsz) {
         val remelem = ct.remove(new DumbHash(i))
@@ -33,7 +33,7 @@ object LNodeSpec extends Spec {
     }
     
     "put elements with the same hash codes if absent" in {
-      val ct = new ConcurrentTrieMap[DumbHash, Int]
+      val ct = new TrieMap[DumbHash, Int]
       for (i <- 0 until initsz) ct.put(new DumbHash(i), i)
       for (i <- 0 until initsz) assert(ct.lookup(new DumbHash(i)) == i)
       for (i <- 0 until initsz) assert(ct.putIfAbsent(new DumbHash(i), i) == Some(i))
@@ -42,7 +42,7 @@ object LNodeSpec extends Spec {
     }
     
     "replace elements with the same hash codes" in {
-      val ct = new ConcurrentTrieMap[DumbHash, Int]
+      val ct = new TrieMap[DumbHash, Int]
       for (i <- 0 until initsz) assert(ct.put(new DumbHash(i), i) == None)
       for (i <- 0 until initsz) assert(ct.lookup(new DumbHash(i)) == i)
       for (i <- 0 until initsz) assert(ct.replace(new DumbHash(i), -i) == Some(i))
@@ -51,7 +51,7 @@ object LNodeSpec extends Spec {
     }
     
     "remove elements with the same hash codes if mapped to a specific value" in {
-      val ct = new ConcurrentTrieMap[DumbHash, Int]
+      val ct = new TrieMap[DumbHash, Int]
       for (i <- 0 until initsz) assert(ct.put(new DumbHash(i), i) == None)
       for (i <- 0 until initsz) assert(ct.remove(new DumbHash(i), i) == true)
     }

--- a/test/files/run/ctries/snapshot.scala
+++ b/test/files/run/ctries/snapshot.scala
@@ -3,7 +3,7 @@
 
 
 import collection._
-import collection.mutable.ConcurrentTrieMap
+import collection.concurrent.TrieMap
 
 
 
@@ -11,11 +11,11 @@ object SnapshotSpec extends Spec {
   
   def test() {
     "support snapshots" in {
-      val ctn = new ConcurrentTrieMap
+      val ctn = new TrieMap
       ctn.snapshot()
       ctn.readOnlySnapshot()
       
-      val ct = new ConcurrentTrieMap[Int, Int]
+      val ct = new TrieMap[Int, Int]
       for (i <- 0 until 100) ct.put(i, i)
       ct.snapshot()
       ct.readOnlySnapshot()
@@ -24,7 +24,7 @@ object SnapshotSpec extends Spec {
     "empty 2 quiescent snapshots in isolation" in {
       val sz = 4000
       
-      class Worker(trie: ConcurrentTrieMap[Wrap, Int]) extends Thread {
+      class Worker(trie: TrieMap[Wrap, Int]) extends Thread {
         override def run() {
           for (i <- 0 until sz) {
             assert(trie.remove(new Wrap(i)) == Some(i))
@@ -35,7 +35,7 @@ object SnapshotSpec extends Spec {
         }
       }
       
-      val ct = new ConcurrentTrieMap[Wrap, Int]
+      val ct = new TrieMap[Wrap, Int]
       for (i <- 0 until sz) ct.put(new Wrap(i), i)
       val snapt = ct.snapshot()
       
@@ -96,7 +96,7 @@ object SnapshotSpec extends Spec {
     }
     
     // traverses the trie `rep` times and modifies each entry
-    class Modifier(trie: ConcurrentTrieMap[Wrap, Int], index: Int, rep: Int, sz: Int) extends Thread {
+    class Modifier(trie: TrieMap[Wrap, Int], index: Int, rep: Int, sz: Int) extends Thread {
       setName("Modifier %d".format(index))
       
       override def run() {
@@ -110,7 +110,7 @@ object SnapshotSpec extends Spec {
     }
     
     // removes all the elements from the trie
-    class Remover(trie: ConcurrentTrieMap[Wrap, Int], index: Int, totremovers: Int, sz: Int) extends Thread {
+    class Remover(trie: TrieMap[Wrap, Int], index: Int, totremovers: Int, sz: Int) extends Thread {
       setName("Remover %d".format(index))
       
       override def run() {
@@ -123,7 +123,7 @@ object SnapshotSpec extends Spec {
       val N = 100
       val W = 10
       
-      val ct = new ConcurrentTrieMap[Wrap, Int]
+      val ct = new TrieMap[Wrap, Int]
       for (i <- 0 until sz) ct(new Wrap(i)) = i
       val readonly = ct.readOnlySnapshot()
       val threads = for (i <- 0 until W) yield new Modifier(ct, i, N, sz)
@@ -141,7 +141,7 @@ object SnapshotSpec extends Spec {
       val W = 100
       val S = 5000
       
-      val ct = new ConcurrentTrieMap[Wrap, Int]
+      val ct = new TrieMap[Wrap, Int]
       for (i <- 0 until sz) ct(new Wrap(i)) = i
       val threads = for (i <- 0 until W) yield new Remover(ct, i, W, sz)
       
@@ -156,7 +156,7 @@ object SnapshotSpec extends Spec {
       val W = 10
       val S = 7000
       
-      val ct = new ConcurrentTrieMap[Wrap, Int]
+      val ct = new TrieMap[Wrap, Int]
       for (i <- 0 until sz) ct(new Wrap(i)) = i
       val threads = for (i <- 0 until W) yield new Modifier(ct, i, N, sz)
       
@@ -165,7 +165,7 @@ object SnapshotSpec extends Spec {
       threads.foreach(_.join())
     }
     
-    def consistentNonReadOnly(name: String, trie: ConcurrentTrieMap[Wrap, Int], sz: Int, N: Int) {
+    def consistentNonReadOnly(name: String, trie: TrieMap[Wrap, Int], sz: Int, N: Int) {
       @volatile var e: Exception = null
       
       // reads possible entries once and stores them
@@ -223,7 +223,7 @@ object SnapshotSpec extends Spec {
       val W = 10
       val S = 400
       
-      val ct = new ConcurrentTrieMap[Wrap, Int]
+      val ct = new TrieMap[Wrap, Int]
       for (i <- 0 until sz) ct(new Wrap(i)) = i
       val threads = for (i <- 0 until W) yield new Modifier(ct, i, N, sz)
       
@@ -241,7 +241,7 @@ object SnapshotSpec extends Spec {
       val S = 10
       val modifytimes = 1200
       val snaptimes = 600
-      val ct = new ConcurrentTrieMap[Wrap, Int]
+      val ct = new TrieMap[Wrap, Int]
       for (i <- 0 until sz) ct(new Wrap(i)) = i
       
       class Snapshooter extends Thread {

--- a/test/files/scalacheck/Ctrie.scala
+++ b/test/files/scalacheck/Ctrie.scala
@@ -5,7 +5,7 @@ import org.scalacheck._
 import Prop._
 import org.scalacheck.Gen._
 import collection._
-import collection.mutable.ConcurrentTrieMap
+import collection.concurrent.TrieMap
 
 
 
@@ -16,7 +16,7 @@ case class Wrap(i: Int) {
 
 /** A check mainly oriented towards checking snapshot correctness.
  */
-object Test extends Properties("ConcurrentTrieMap") {
+object Test extends Properties("concurrent.TrieMap") {
   
   /* generators */
   
@@ -102,7 +102,7 @@ object Test extends Properties("ConcurrentTrieMap") {
     (numThreads, numElems) =>
     val p = 3 //numThreads
     val sz = 102 //numElems
-    val ct = new ConcurrentTrieMap[Wrap, Int]
+    val ct = new TrieMap[Wrap, Int]
     
     // checker
     val checker = spawn {
@@ -134,7 +134,7 @@ object Test extends Properties("ConcurrentTrieMap") {
   
   property("update") = forAll(sizes) {
     (n: Int) =>
-    val ct = new ConcurrentTrieMap[Int, Int]
+    val ct = new TrieMap[Int, Int]
     for (i <- 0 until n) ct(i) = i
     (0 until n) forall {
       case i => ct(i) == i
@@ -143,7 +143,7 @@ object Test extends Properties("ConcurrentTrieMap") {
   
   property("concurrent update") = forAll(threadCountsAndSizes) {
     case (p, sz) =>
-      val ct = new ConcurrentTrieMap[Wrap, Int]
+      val ct = new TrieMap[Wrap, Int]
       
       inParallel(p) {
         idx =>
@@ -158,7 +158,7 @@ object Test extends Properties("ConcurrentTrieMap") {
   
   property("concurrent remove") = forAll(threadCounts, sizes) {
     (p, sz) =>
-    val ct = new ConcurrentTrieMap[Wrap, Int]
+    val ct = new TrieMap[Wrap, Int]
     for (i <- 0 until sz) ct(Wrap(i)) = i
     
     inParallel(p) {
@@ -174,7 +174,7 @@ object Test extends Properties("ConcurrentTrieMap") {
   
   property("concurrent putIfAbsent") = forAll(threadCounts, sizes) {
     (p, sz) =>
-    val ct = new ConcurrentTrieMap[Wrap, Int]
+    val ct = new TrieMap[Wrap, Int]
     
     val results = inParallel(p) {
       idx =>

--- a/test/files/scalacheck/parallel-collections/ParallelCtrieCheck.scala
+++ b/test/files/scalacheck/parallel-collections/ParallelCtrieCheck.scala
@@ -19,21 +19,21 @@ abstract class ParallelConcurrentTrieMapCheck[K, V](tp: String) extends Parallel
   // ForkJoinTasks.defaultForkJoinPool.setMaximumPoolSize(Runtime.getRuntime.availableProcessors * 2)
   // ForkJoinTasks.defaultForkJoinPool.setParallelism(Runtime.getRuntime.availableProcessors * 2)
   
-  type CollType = ParConcurrentTrieMap[K, V]
+  type CollType = ParTrieMap[K, V]
   
   def isCheckingViews = false
   
   def hasStrictOrder = false
 
   def ofSize(vals: Seq[Gen[(K, V)]], sz: Int) = {  
-    val ct = new mutable.ConcurrentTrieMap[K, V]
+    val ct = new concurrent.TrieMap[K, V]
     val gen = vals(rnd.nextInt(vals.size))
     for (i <- 0 until sz) ct += sample(gen)
     ct
   }
   
   def fromTraversable(t: Traversable[(K, V)]) = {
-    val pct = new ParConcurrentTrieMap[K, V]
+    val pct = new ParTrieMap[K, V]
     var i = 0
     for (kv <- t.toList) {
       pct += kv
@@ -58,7 +58,7 @@ with PairValues[Int, Int]
   def koperators = intoperators
   
   override def printDataStructureDebugInfo(ds: AnyRef) = ds match {
-    case pm: ParConcurrentTrieMap[k, v] =>
+    case pm: ParTrieMap[k, v] =>
       println("Mutable parallel ctrie")
     case _ =>
       println("could not match data structure type: " + ds.getClass)


### PR DESCRIPTION
Introduced the collection.concurrent package and introduced the
concurrent.Map trait there. Deprecated the mutable.ConcurrentMap trait.

Pending work - introduce the appropriate changes to JavaConversions
and JavaConverters.
