### PR TITLE
(1 line) Fixes SI-5632 (deserialization of large HashTables)

### DIFF
--- a/src/library/scala/collection/mutable/HashTable.scala
+++ b/src/library/scala/collection/mutable/HashTable.scala
@@ -366,7 +366,7 @@ private[collection] object HashTable {
 
   private[collection] final def newThreshold(_loadFactor: Int, size: Int) = ((size.toLong * _loadFactor) / loadFactorDenum).toInt
 
-  private[collection] final def sizeForThreshold(_loadFactor: Int, thr: Int) = thr * loadFactorDenum / _loadFactor
+  private[collection] final def sizeForThreshold(_loadFactor: Int, thr: Int) = ((thr.toLong * loadFactorDenum) / _loadFactor).toInt
 
   private[collection] final def capacity(expectedSize: Int) = if (expectedSize == 0) 1 else powerOfTwo(expectedSize)
 


### PR DESCRIPTION
Converts HashTable threshold to long before multiplying by a large value.

Test is very slow and requires giving partest more RAM. Rather than committing it, I'm attaching it as a gist. Whoever does the merge is more than welcome to commit it along with this patch…

Test: https://gist.github.com/2257703

Issue: https://issues.scala-lang.org/browse/SI-5632
