### PR TITLE
SI-5627 BigInt.equals(Number) and BigDecimal.equals(Number) 

### DIFF
--- a/src/library/scala/math/BigDecimal.scala
+++ b/src/library/scala/math/BigDecimal.scala
@@ -183,7 +183,8 @@ extends ScalaNumber with ScalaNumericConversions with Serializable {
   override def equals (that: Any): Boolean = that match {
     case that: BigDecimal     => this equals that
     case that: BigInt         => this.toBigIntExact exists (that equals _)
-    case _: Float | _: Double => unifiedPrimitiveEquals(that)
+    case that: Double         => isValidDouble && toDouble == that
+    case that: Float          => isValidFloat && toFloat == that
     case _                    => isValidLong && unifiedPrimitiveEquals(that)
   }
   override def isValidByte  = noArithmeticException(toByteExact)
@@ -191,6 +192,18 @@ extends ScalaNumber with ScalaNumericConversions with Serializable {
   override def isValidChar  = isValidInt && toIntExact >= Char.MinValue && toIntExact <= Char.MaxValue
   override def isValidInt   = noArithmeticException(toIntExact)
   def isValidLong  = noArithmeticException(toLongExact)
+  /** Returns `true` iff this can be represented exactly by [[scala.Float]]; otherwise returns `false`.
+    */
+  def isValidFloat = {
+    val f = toFloat
+    !f.isInfinity && bigDecimal.compareTo(new java.math.BigDecimal(f)) == 0
+  }
+  /** Returns `true` iff this can be represented exactly by [[scala.Double]]; otherwise returns `false`.
+    */
+  def isValidDouble = {
+    val d = toDouble
+    !d.isInfinity && bigDecimal.compareTo(new java.math.BigDecimal(d)) == 0
+  }
 
   private def noArithmeticException(body: => Unit): Boolean = {
     try   { body ; true }

--- a/test/files/run/is-valid-num.scala
+++ b/test/files/run/is-valid-num.scala
@@ -1,11 +1,15 @@
 object Test {
   def x = BigInt("10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
   def y = BigDecimal("" + (Short.MaxValue + 1) + ".0")
+  def y1 = BigDecimal("0.1")
+  def y2 = BigDecimal("0.5")
   
   def l1 = Int.MaxValue.toLong + 1
   def l2 = Int.MinValue.toLong - 1
 
   def main(args: Array[String]): Unit = {
+    assert(!x.isValidDouble, x)
+    assert(!x.isValidFloat, x)
     assert(!x.isValidLong, x)
     assert(!x.isValidInt, x)
     assert(!x.isValidChar, x)
@@ -13,8 +17,81 @@ object Test {
     assert(!y.isValidShort, y)
     assert(y.isValidChar, y)
     assert(y.isValidInt, y)
+    assert(y.isValidFloat, y)
+    assert(y.isValidDouble, y)
+    assert(!y1.isValidLong, y1)
+    assert(!y1.isValidFloat, y1)
+    assert(!y1.isValidDouble, y1)
+    assert(!y2.isValidLong, y2)
+    assert(y2.isValidFloat, y2)
+    assert(y2.isValidDouble, y2)
+
+    testBigIntIsFloat()
+    testBigIntIsDouble()
 
     assert(!l1.isValidInt && (l1 - 1).isValidInt, l1)
     assert(!l2.isValidInt && (l2 + 1).isValidInt, l2)
+  }
+
+  def biExp2(e: Int) = BigInt(1) << e
+
+  def testBigIntIsFloat() {
+    val prec = 24
+    def checkFloatT(x: BigInt) = {
+      assert(x.isValidFloat, x)
+      assert((-x).isValidFloat, -x)
+    }
+    def checkFloatF(x: BigInt) = {
+      assert(!x.isValidFloat, x)
+      assert(!(-x).isValidFloat, -x)
+    } 
+    checkFloatT(biExp2(prec) - 1)
+    checkFloatT(biExp2(prec))
+    checkFloatF(biExp2(prec) + 1)
+    checkFloatT(biExp2(prec) + 2)
+    checkFloatT(biExp2(prec) - 2)
+    checkFloatF(biExp2(prec + 1) - 1)
+    checkFloatT(biExp2(prec + 1))
+    checkFloatF(biExp2(prec + 1) + 1)
+    checkFloatF(biExp2(prec + 1) + 2)
+    checkFloatF(biExp2(prec + 1) + 3)
+    checkFloatT(biExp2(prec + 1) + 4)
+    checkFloatT(biExp2(64))
+    checkFloatF(biExp2(64) + biExp2(64 - prec))
+    checkFloatT(biExp2(64) + biExp2(64 - prec + 1))
+    checkFloatT(biExp2(127))
+    checkFloatT(biExp2(128) - biExp2(128 - prec))
+    checkFloatF(biExp2(128) - biExp2(128 - prec - 1))
+    checkFloatF(biExp2(128))
+  }
+
+  def testBigIntIsDouble() {
+    val prec = 53
+    def checkDoubleT(x: BigInt) = {
+      assert(x.isValidDouble, x)
+      assert((-x).isValidDouble, -x)
+    }
+    def checkDoubleF(x: BigInt) = {
+      assert(!x.isValidDouble, x)
+      assert(!(-x).isValidDouble, -x)
+    }
+    checkDoubleT(biExp2(prec) - 1)
+    checkDoubleT(biExp2(prec))
+    checkDoubleF(biExp2(prec) + 1)
+    checkDoubleT(biExp2(prec) + 2)
+    checkDoubleT(biExp2(prec + 1) - 2)
+    checkDoubleF(biExp2(prec + 1) - 1)
+    checkDoubleT(biExp2(prec + 1))
+    checkDoubleF(biExp2(prec + 1) + 1)
+    checkDoubleF(biExp2(prec + 1) + 2)
+    checkDoubleF(biExp2(prec + 1) + 3)
+    checkDoubleT(biExp2(prec + 1) + 4)
+    checkDoubleT(biExp2(64))
+    checkDoubleF(biExp2(64) + biExp2(64 - prec))
+    checkDoubleT(biExp2(64) + biExp2(64 - prec + 1))
+    checkDoubleT(biExp2(1023))
+    checkDoubleT(biExp2(1024) - biExp2(1024 - prec))
+    checkDoubleF(biExp2(1024) - biExp2(1024 - prec - 1))
+    checkDoubleF(biExp2(1024))
   }
 }

--- a/test/files/run/numbereq.scala
+++ b/test/files/run/numbereq.scala
@@ -16,7 +16,20 @@ object Test {
     
     base ::: extras
   }
-      
+
+  def mkNumbers(x: BigInt): List[AnyRef] = {
+    List(
+      List(BigDecimal(x, java.math.MathContext.UNLIMITED)), 
+      List(x),
+      if (x.isValidDouble) List(new java.lang.Double(x.toDouble)) else Nil,
+      if (x.isValidFloat) List(new java.lang.Float(x.toFloat)) else Nil,
+      if (x.isValidLong) List(new java.lang.Long(x.toLong)) else Nil,
+      if (x.isValidInt) List(new java.lang.Integer(x.toInt)) else Nil,
+      if (x.isValidShort) List(new java.lang.Short(x.toShort)) else Nil,
+      if (x.isValidByte) List(new java.lang.Byte(x.toByte)) else Nil,
+      if (x.isValidChar) List(new java.lang.Character(x.toChar)) else Nil
+    ).flatten
+  }
   
   def main(args: Array[String]): Unit = {
     val ints    = (0 to 15).toList map (Short.MinValue >> _)
@@ -36,6 +49,24 @@ object Test {
       // println("'%s' == '%s' (%s == %s) (%s == %s)".format(x, y, x.hashCode, y.hashCode, x.##, y.##))
       assert(x == y, "%s/%s != %s/%s".format(x, x.getClass, y, y.getClass))
       assert(x.## == y.##, "%s != %s".format(x.getClass, y.getClass))
+    }
+
+    val bigInts  = (0 to 1024).toList map (BigInt(-1) << _)
+    val bigInts2 = bigInts map (x => -x)
+    val bigInts3 = bigInts map (_ + 1)
+    val bigInts4 = bigInts2 map (_ - 1)
+    
+    val setneg1b = bigInts map mkNumbers
+    val setneg2b = bigInts3 map mkNumbers
+    val setpos1b = bigInts2 map mkNumbers
+    val setpos2b = bigInts4 map mkNumbers
+
+    val sets2 = setneg1 ++ setneg1b ++ setneg2 ++ setneg2b ++ List(zero) ++ setpos1 ++ setpos1b ++ setpos2 ++ setpos2b
+    
+    for (set <- sets2 ; x <- set ; y <- set) {
+//      println("'%s' == '%s' (%s == %s) (%s == %s)".format(x, y, x.hashCode, y.hashCode, x.##, y.##))
+      assert(x == y, "%s/%s != %s/%s".format(x, x.getClass, y, y.getClass))
+//      assert(x.## == y.##, "%s != %s".format(x.getClass, y.getClass))    Disable until Double.## is fixed (SI-5640)
     }
   }
 }


### PR DESCRIPTION
This is an attempt to fix the bug
SI-5627 BigInt.equals(Number) and BigDecimal.equals(Number) should implement equality in mathematical sense.

Methods "isValidDouble" and "isValidFloat" are added to to "BigInt" and "BigDecimal" classes.
"BigInt" methods are implemented with attention to performance.
"BigDecimal" methods are implemented stupidly.

I tried to fix methods "BigInt.hashCode" and "BigDecimal.hashCode" too, but found a bug SI-5640.
So I removed "hashCode" fixes from this commit, until some discussions.
