### PR TITLE
Fixed broken links in sources of scala/annotation

### DIFF
--- a/src/library/scala/annotation/ClassfileAnnotation.scala
+++ b/src/library/scala/annotation/ClassfileAnnotation.scala
@@ -9,7 +9,7 @@
 package scala.annotation
 
 /** A base class for classfile annotations. These are stored as
- *  [[http://java.sun.com/j2se/1.5.0/docs/guide/language/annotations.html#_top Java annotations]]]
+ *  [[http://docs.oracle.com/javase/7/docs/technotes/guides/language/annotations.html#_top Java annotations]]]
  *  in classfiles.
  *
  *  @author  Martin Odersky

--- a/src/library/scala/annotation/switch.scala
+++ b/src/library/scala/annotation/switch.scala
@@ -9,8 +9,8 @@ package scala.annotation
 
 /** An annotation to be applied to a match expression.  If present,
  *  the compiler will verify that the match has been compiled to a
- *  [[http://java.sun.com/docs/books/jvms/second_edition/html/Instructions2.doc14.html tableswitch]]
- *  or [[http://java.sun.com/docs/books/jvms/second_edition/html/Instructions2.doc8.html#lookupswitch lookupswitch]]
+ *  [[http://docs.oracle.com/javase/specs/jvms/se5.0/html/Instructions2.doc14.html tableswitch]]
+ *  or [[http://docs.oracle.com/javase/specs/jvms/se5.0/html/Instructions2.doc8.html#lookupswitch lookupswitch]]
  *  and issue an error if it instead compiles into a series of conditional expressions.
  *  Example usage:
 {{{


### PR DESCRIPTION
The links 
http://java.sun.com/docs/books/jvms/second_edition/html/Instructions2.doc14.html
http://java.sun.com/docs/books/jvms/second_edition/html/Instructions2.doc8.html#lookupswitch
in the scaladoc section of switch.scala are no longer valid. 

I replaced all those links in package scala.annotation by links on the docs.oracle.com site.
