### PR TITLE
Iterator.++ memory leak 

### DIFF
--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -327,14 +327,16 @@ trait Iterator[+A] extends TraversableOnce[A] {
   def ++[B >: A](that: => GenTraversableOnce[B]): Iterator[B] = new AbstractIterator[B] {
     // optimize a little bit to prevent n log n behavior.
     private var cur : Iterator[B] = self
+    private var selfExhausted : Boolean = false
     // since that is by-name, make sure it's only referenced once -
     // if "val it = that" is inside the block, then hasNext on an empty
     // iterator will continually reevaluate it.  (ticket #3269)
     lazy val it = that.toIterator
     // the eq check is to avoid an infinite loop on "x ++ x"
-    def hasNext = cur.hasNext || ((cur eq self) && {
+    def hasNext = cur.hasNext || (!selfExhausted && {
       it.hasNext && {
         cur = it
+        selfExhausted = true
         true
       }
     })


### PR DESCRIPTION
When Iterator.++() concatenates an iterator with the result of a call-by-name function argument, the resulting compound iterator holds the 'self' reference to the original iterator indefinitely.  Chaining many iterators together then causes every individual iterator to remain in memory even after all of its elements have been consumed.

This can be unpleasant if you are using this functionality to construct a compound iterator over individual functions that, for example, materialize data from disk.

This contrived snippet causes a heap OutOfMemoryError for me, but is fixed by modifying Iterator to use a boolean flag instead of an "eq self" check in order to determine whether the elements of the original iterator have already been exhausted.

``` scala
object IteratorOOM {
    def main(args: Array[String]) {

      var ctr = 0
      iterExample.foreach{junkStringList =>
        ctr += 1
        if(ctr == 100) {
          System.exit(0)
        }
        println("ctr = %d".format(ctr))}
    }

  def iterExample(): Iterator[List[String]] = {
    val myList =
      List.fill(2)(List.fill(1000000)("abcdefghijklmnopqrstuvwxyz"))
    myList.iterator ++ iterExample
  }
}
```

The patched version passes scala tests and handles "x ++ x", although it still suffers from the infinite recursion described in SI-3759.  Is there some other tricky corner case that requires doing the "eq self" instead of using a boolean flag?
