### PR TITLE
SI-4540 Fix [RichDouble|RichFloat|RichLong].isValid[Byte|Short|Char|Int]...

### DIFF
--- a/src/library/scala/runtime/RichDouble.scala
+++ b/src/library/scala/runtime/RichDouble.scala
@@ -35,4 +35,16 @@ final class RichDouble(val self: Double) extends FractionalProxy[Double] {
   def isInfinity: Boolean = java.lang.Double.isInfinite(self)
   def isPosInfinity: Boolean = isInfinity && self > 0.0
   def isNegInfinity: Boolean = isInfinity && self < 0.0
+
+  override def isValidByte = self.toByte.toDouble == self
+  override def isValidShort = self.toShort.toDouble == self
+  override def isValidChar = self.toChar.toDouble == self
+  override def isValidInt = self.toInt.toDouble == self
+  // override def isValidLong = { val l = self.toLong; l.toDouble == self && l != Long.MaxValue }
+  // override def isValidFloat = self.toFloat.toDouble == self
+  // override def isValidDouble = !java.lang.Double.isNaN(self)
+  override def isWhole = {
+    val l = self.toLong
+    l.toDouble == self || l == Long.MaxValue && self < Double.PositiveInfinity || l == Long.MinValue && self > Double.NegativeInfinity
+  }
 }

--- a/src/library/scala/runtime/RichFloat.scala
+++ b/src/library/scala/runtime/RichFloat.scala
@@ -36,4 +36,16 @@ final class RichFloat(val self: Float) extends FractionalProxy[Float] {
   def isInfinity: Boolean = java.lang.Float.isInfinite(self)
   def isPosInfinity: Boolean = isInfinity && self > 0.0f
   def isNegInfinity: Boolean = isInfinity && self < 0.0f
+
+  override def isValidByte = self.toByte.toFloat == self
+  override def isValidShort = self.toShort.toFloat == self
+  override def isValidChar = self.toChar.toFloat == self
+  override def isValidInt = { val i = self.toInt; i.toFloat == self && i != Int.MaxValue }
+  // override def isValidLong = { val l = self.toLong; l.toFloat == self && l != Long.MaxValue }
+  // override def isValidFloat = !java.lang.Float.isNaN(self)
+  // override def isValidDouble = !java.lang.Float.isNaN(self)
+  override def isWhole = {
+    val l = self.toLong
+    l.toFloat == self || l == Long.MaxValue && self < Float.PositiveInfinity || l == Long.MinValue && self > Float.NegativeInfinity
+  }
 }

--- a/src/library/scala/runtime/RichLong.scala
+++ b/src/library/scala/runtime/RichLong.scala
@@ -12,4 +12,12 @@ final class RichLong(val self: Long) extends IntegralProxy[Long] {
   def toBinaryString: String = java.lang.Long.toBinaryString(self)
   def toHexString: String = java.lang.Long.toHexString(self)
   def toOctalString: String = java.lang.Long.toOctalString(self)
+
+  override def isValidByte = self.toByte.toLong == self
+  override def isValidShort = self.toShort.toLong == self
+  override def isValidChar = self.toChar.toLong == self
+  override def isValidInt = self.toInt.toLong == self
+  // override def isValidLong = true
+  // override def isValidFloat = self.toFloat.toLong == self && self != Long.MaxValue
+  // override def isValidDouble = self.toDouble.toLong == self && self != Long.MaxValue
 }

--- a/test/files/run/is-valid-num.scala
+++ b/test/files/run/is-valid-num.scala
@@ -3,95 +3,310 @@ object Test {
   def y = BigDecimal("" + (Short.MaxValue + 1) + ".0")
   def y1 = BigDecimal("0.1")
   def y2 = BigDecimal("0.5")
-  
+
   def l1 = Int.MaxValue.toLong + 1
   def l2 = Int.MinValue.toLong - 1
 
   def main(args: Array[String]): Unit = {
+//    assert(x.isWhole, x)
     assert(!x.isValidDouble, x)
     assert(!x.isValidFloat, x)
     assert(!x.isValidLong, x)
     assert(!x.isValidInt, x)
     assert(!x.isValidChar, x)
+    assert(!x.isValidShort, x)
     assert(!x.isValidByte, x)
+//    assert(y.isWhole, y)
     assert(!y.isValidShort, y)
     assert(y.isValidChar, y)
     assert(y.isValidInt, y)
     assert(y.isValidFloat, y)
     assert(y.isValidDouble, y)
+    assert(y.isValidLong, y)
+    assert(!y.isValidByte, y)
+//    assert(!y1.isWhole)
     assert(!y1.isValidLong, y1)
     assert(!y1.isValidFloat, y1)
     assert(!y1.isValidDouble, y1)
+    assert(!y1.isValidInt, y1)
+    assert(!y1.isValidChar, y1)
+    assert(!y1.isValidShort, y1)
+    assert(!y1.isValidByte, y1)
     assert(!y2.isValidLong, y2)
     assert(y2.isValidFloat, y2)
     assert(y2.isValidDouble, y2)
 
-    testBigIntIsFloat()
-    testBigIntIsDouble()
-
     assert(!l1.isValidInt && (l1 - 1).isValidInt, l1)
     assert(!l2.isValidInt && (l2 + 1).isValidInt, l2)
+
+    testBigInts()
+    testNonWholeDoubles()
+    testNaNs()
   }
 
-  def biExp2(e: Int) = BigInt(1) << e
+  def testBigInts() {
+    def biExp2(e: Int) = BigInt(1) << e
+    def checkBigInt2(bi: BigInt) { checkBigInt(-bi); checkBigInt(bi) }
 
-  def testBigIntIsFloat() {
-    val prec = 24
-    def checkFloatT(x: BigInt) = {
-      assert(x.isValidFloat, x)
-      assert((-x).isValidFloat, -x)
-    }
-    def checkFloatF(x: BigInt) = {
-      assert(!x.isValidFloat, x)
-      assert(!(-x).isValidFloat, -x)
-    } 
-    checkFloatT(biExp2(prec) - 1)
-    checkFloatT(biExp2(prec))
-    checkFloatF(biExp2(prec) + 1)
-    checkFloatT(biExp2(prec) + 2)
-    checkFloatT(biExp2(prec) - 2)
-    checkFloatF(biExp2(prec + 1) - 1)
-    checkFloatT(biExp2(prec + 1))
-    checkFloatF(biExp2(prec + 1) + 1)
-    checkFloatF(biExp2(prec + 1) + 2)
-    checkFloatF(biExp2(prec + 1) + 3)
-    checkFloatT(biExp2(prec + 1) + 4)
-    checkFloatT(biExp2(64))
-    checkFloatF(biExp2(64) + biExp2(64 - prec))
-    checkFloatT(biExp2(64) + biExp2(64 - prec + 1))
-    checkFloatT(biExp2(127))
-    checkFloatT(biExp2(128) - biExp2(128 - prec))
-    checkFloatF(biExp2(128) - biExp2(128 - prec - 1))
-    checkFloatF(biExp2(128))
+    val pf = 24
+    val pd = 53
+
+    checkBigInt(BigInt(0))
+    checkBigInt2(biExp2(0))
+
+    checkBigInt2(biExp2(7) - 1)
+    checkBigInt2(biExp2(7))
+    checkBigInt2(biExp2(7) + 1)
+
+    checkBigInt2(biExp2(8) - 1)
+    checkBigInt2(biExp2(8))
+    checkBigInt2(biExp2(8) + 1)
+
+    checkBigInt2(biExp2(15) - 1)
+    checkBigInt2(biExp2(15))
+    checkBigInt2(biExp2(15) + 1)
+
+    checkBigInt2(biExp2(16) - 1)
+    checkBigInt2(biExp2(16))
+    checkBigInt2(biExp2(16) + 1)
+
+    checkBigInt2(biExp2(pf) - 1)
+    checkBigInt2(biExp2(pf))
+    checkBigInt2(biExp2(pf) + 1)
+    checkBigInt2(biExp2(pf) + 2)
+    checkBigInt2(biExp2(pf) - 2)
+    checkBigInt2(biExp2(pf + 1) - 1)
+    checkBigInt2(biExp2(pf + 1))
+    checkBigInt2(biExp2(pf + 1) + 1)
+    checkBigInt2(biExp2(pf + 1) + 2)
+    checkBigInt2(biExp2(pf + 1) + 3)
+    checkBigInt2(biExp2(pf + 1) + 4)
+
+    checkBigInt2(biExp2(31) - 1)
+    checkBigInt2(biExp2(31))
+    checkBigInt2(biExp2(31) + 1)
+
+    checkBigInt2(biExp2(32) - 1)
+    checkBigInt2(biExp2(32))
+    checkBigInt2(biExp2(32) + 1)
+    checkBigInt2(biExp2(32) + biExp2(64 - pf))
+    checkBigInt2(biExp2(32) + biExp2(64 - pf + 1))
+
+    checkBigInt2(biExp2(pd) - 1)
+    checkBigInt2(biExp2(pd))
+    checkBigInt2(biExp2(pd) + 1)
+    checkBigInt2(biExp2(pd) + 2)
+    checkBigInt2(biExp2(pd + 1) - 2)
+    checkBigInt2(biExp2(pd + 1) - 1)
+    checkBigInt2(biExp2(pd + 1))
+    checkBigInt2(biExp2(pd + 1) + 1)
+    checkBigInt2(biExp2(pd + 1) + 2)
+    checkBigInt2(biExp2(pd + 1) + 3)
+    checkBigInt2(biExp2(pd + 1) + 4)
+
+    checkBigInt2(biExp2(63) - 1)
+    checkBigInt2(biExp2(63))
+    checkBigInt2(biExp2(63) + 1)
+    checkBigInt2(biExp2(63) + biExp2(63 - pd))
+    checkBigInt2(biExp2(63) + biExp2(63 - pd + 1))
+    checkBigInt2(biExp2(63) + biExp2(63 - pf))
+    checkBigInt2(biExp2(63) + biExp2(63 - pf + 1))
+
+    checkBigInt2(biExp2(64) - 1)
+    checkBigInt2(biExp2(64))
+    checkBigInt2(biExp2(64) + 1)
+    checkBigInt2(biExp2(64) + biExp2(64 - pd))
+    checkBigInt2(biExp2(64) + biExp2(64 - pd + 1))
+    checkBigInt2(biExp2(64) + biExp2(64 - pf))
+    checkBigInt2(biExp2(64) + biExp2(64 - pf + 1))
+
+    checkBigInt2(biExp2(127))
+    checkBigInt2(biExp2(128) - biExp2(128 - pf))
+    checkBigInt2(biExp2(128) - biExp2(128 - pf - 1))
+    checkBigInt2(biExp2(128))
+    
+    checkBigInt2(biExp2(1023))
+    checkBigInt2(biExp2(1024) - biExp2(1024 - pd))
+    checkBigInt2(biExp2(1024) - biExp2(1024 - pd - 1))
+    checkBigInt2(biExp2(1024))
   }
 
-  def testBigIntIsDouble() {
-    val prec = 53
-    def checkDoubleT(x: BigInt) = {
-      assert(x.isValidDouble, x)
-      assert((-x).isValidDouble, -x)
+  def testNonWholeDoubles() {
+    checkNonWholeDouble(0.5)
+    checkNonWholeDouble(-math.E)
+    checkNonWholeDouble((1L << 51).toDouble + 0.5)
+    checkNonWholeDouble((1L << 23).toDouble + 0.5)
+    checkNonWholeDouble(Double.PositiveInfinity)
+    checkNonWholeDouble(Double.NegativeInfinity)
+  }
+
+  def testNaNs() {
+    assert(!Double.NaN.isWhole, Double.NaN)
+//    assert(!Double.NaN.isValidDouble, Double.NaN)
+//    assert(!Double.NaN.isValidFloat, Double.NaN)
+//    assert(!Double.NaN.isValidLong, Double.NaN)
+    assert(!Double.NaN.isValidInt, Double.NaN)
+    assert(!Double.NaN.isValidChar, Double.NaN)
+    assert(!Double.NaN.isValidShort, Double.NaN)
+    assert(!Double.NaN.isValidByte, Double.NaN)
+
+    assert(!Float.NaN.isWhole, Float.NaN)
+//    assert(!Float.NaN.isValidDouble, Float.NaN)
+//    assert(!Float.NaN.isValidFloat, Float.NaN)
+//    assert(!Float.NaN.isValidLong, Float.NaN)
+    assert(!Float.NaN.isValidInt, Float.NaN)
+    assert(!Float.NaN.isValidChar, Float.NaN)
+    assert(!Float.NaN.isValidShort, Float.NaN)
+    assert(!Float.NaN.isValidByte, Float.NaN)
+  }
+
+  def checkNonWholeDouble(d: Double) {
+    val f = d.toFloat
+    val isFloat = f == d
+
+    if (!d.isInfinity) {
+      val bd = BigDecimal(new java.math.BigDecimal(d))
+//      assert(!bd.isWhole, bd)
+      assert(bd.isValidDouble, bd)
+      assert(bd.isValidFloat == isFloat, bd)
+      assert(!bd.isValidLong, bd)
+      assert(!bd.isValidInt, bd)
+      assert(!bd.isValidChar, bd)
+      assert(!bd.isValidShort, bd)
+      assert(!bd.isValidByte, bd)
     }
-    def checkDoubleF(x: BigInt) = {
-      assert(!x.isValidDouble, x)
-      assert(!(-x).isValidDouble, -x)
+
+    assert(!d.isWhole, d)
+//    assert(d.isValidDouble, d)
+//    assert(d.isValidFloat == isFloat, d)
+//    assert(!d.isValidLong, d)
+    assert(!d.isValidInt, d)
+    assert(!d.isValidChar, d)
+    assert(!d.isValidShort, d)
+    assert(!d.isValidByte, d)
+
+    if (isFloat) {
+      assert(!f.isWhole, f)
+//      assert(f.isValidDouble, f)
+//      assert(f.isValidFloat == isFloat, f)
+//      assert(!f.isValidLong, f)
+      assert(!f.isValidInt, f)
+      assert(!f.isValidChar, f)
+      assert(!f.isValidShort, f)
+      assert(!f.isValidByte, f)
     }
-    checkDoubleT(biExp2(prec) - 1)
-    checkDoubleT(biExp2(prec))
-    checkDoubleF(biExp2(prec) + 1)
-    checkDoubleT(biExp2(prec) + 2)
-    checkDoubleT(biExp2(prec + 1) - 2)
-    checkDoubleF(biExp2(prec + 1) - 1)
-    checkDoubleT(biExp2(prec + 1))
-    checkDoubleF(biExp2(prec + 1) + 1)
-    checkDoubleF(biExp2(prec + 1) + 2)
-    checkDoubleF(biExp2(prec + 1) + 3)
-    checkDoubleT(biExp2(prec + 1) + 4)
-    checkDoubleT(biExp2(64))
-    checkDoubleF(biExp2(64) + biExp2(64 - prec))
-    checkDoubleT(biExp2(64) + biExp2(64 - prec + 1))
-    checkDoubleT(biExp2(1023))
-    checkDoubleT(biExp2(1024) - biExp2(1024 - prec))
-    checkDoubleF(biExp2(1024) - biExp2(1024 - prec - 1))
-    checkDoubleF(biExp2(1024))
+  }
+
+  def checkBigInt(bi: BigInt) {
+    val bd = BigDecimal(bi, java.math.MathContext.UNLIMITED)
+    val isByte = bi >= Byte.MinValue && bi <= Byte.MaxValue
+    val isShort = bi >= Short.MinValue && bi <= Short.MaxValue
+    val isChar = bi >= Char.MinValue && bi <= Char.MaxValue
+    val isInt = bi >= Int.MinValue && bi <= Int.MaxValue
+    val isLong = bi >= Long.MinValue && bi <= Long.MaxValue
+    val isFloat = !bi.toFloat.isInfinity && bd.compare(BigDecimal(new java.math.BigDecimal(bi.toFloat))) == 0
+    val isDouble = !bi.toDouble.isInfinity && bd.compare(BigDecimal(new java.math.BigDecimal(bi.toDouble))) == 0
+
+//    assert(bd.isWhole, bd)
+    assert(bd.isValidDouble == isDouble, bd)
+    assert(bd.isValidFloat == isFloat, bd)
+    assert(bd.isValidLong == isLong, bd)
+    assert(bd.isValidInt == isInt, bd)
+    assert(bd.isValidChar == isChar, bd)
+    assert(bd.isValidShort == isShort, bd)
+    assert(bd.isValidByte == isByte, bd)
+
+//    assert(bi.isWhole, bi)
+    assert(bi.isValidDouble == isDouble, bi)
+    assert(bi.isValidFloat == isFloat, bi)
+    assert(bi.isValidLong == isLong, bi)
+    assert(bi.isValidInt == isInt, bi)
+    assert(bi.isValidChar == isChar, bi)
+    assert(bi.isValidShort == isShort, bi)
+    assert(bi.isValidByte == isByte, bi)
+
+    if (isDouble) {
+      val d = bi.toDouble
+      assert(d.isWhole, d)
+//      assert(d.isValidDouble == isDouble, d)
+//      assert(d.isValidFloat == isFloat, d)
+//      assert(d.isValidLong == isLong, d)
+      assert(d.isValidInt == isInt, d)
+      assert(d.isValidChar == isChar, d)
+      assert(d.isValidShort == isShort, d)
+      assert(d.isValidByte == isByte, d)
+    }
+
+    if (isFloat) {
+      val f = bi.toFloat
+      assert(f.isWhole, f)
+//      assert(f.isValidDouble == isDouble, f)
+//      assert(f.isValidFloat == isFloat, f)
+//      assert(f.isValidLong == isLong, f)
+      assert(f.isValidInt == isInt, f)
+      assert(f.isValidChar == isChar, f)
+      assert(f.isValidShort == isShort, f)
+      assert(f.isValidByte == isByte, f)
+    }
+
+    if (isLong) {
+      val l = bi.toLong
+      assert(l.isWhole, l)
+//      assert(l.isValidDouble == isDouble, l)
+//      assert(l.isValidFloat == isFloat, l)
+//      assert(l.isValidLong == isLong, l)
+      assert(l.isValidInt == isInt, l)
+      assert(l.isValidChar == isChar, l)
+      assert(l.isValidShort == isShort, l)
+      assert(l.isValidByte == isByte, l)
+    }
+
+    if (isInt) {
+      val i = bi.toInt
+      assert(i.isWhole, i)
+//      assert(i.isValidDouble == isDouble, i)
+//      assert(i.isValidFloat == isFloat, i)
+//      assert(i.isValidLong == isLong, i)
+      assert(i.isValidInt == isInt, i)
+      assert(i.isValidChar == isChar, i)
+      assert(i.isValidShort == isShort, i)
+      assert(i.isValidByte == isByte, i)
+    }
+
+    if (isChar) {
+      val c = bi.toChar
+      assert(c.isWhole, c)
+//      assert(c.isValidDouble == isDouble, c)
+//      assert(c.isValidFloat == isFloat, c)
+//      assert(c.isValidLong == isLong, c)
+      assert(c.isValidInt == isInt, c)
+      assert(c.isValidChar == isChar, c)
+      assert(c.isValidShort == isShort, c)
+      assert(c.isValidByte == isByte, c)
+    }
+
+    if (isShort) {
+      val s = bi.toShort
+      assert(s.isWhole, s)
+//      assert(s.isValidDouble == isDouble, s)
+//      assert(s.isValidFloat == isFloat, s)
+//      assert(s.isValidLong == isLong, s)
+      assert(s.isValidInt == isInt, s)
+      assert(s.isValidChar == isChar, s)
+      assert(s.isValidShort == isShort, s)
+      assert(s.isValidByte == isByte, s)
+    }
+
+    if (isByte) {
+      val b = bi.toByte
+      assert(b.isWhole, b)
+//      assert(b.isValidDouble == isDouble, b)
+//      assert(b.isValidFloat == isFloat, b)
+//      assert(b.isValidLong == isLong, b)
+      assert(b.isValidInt == isInt, b)
+      assert(b.isValidChar == isChar, b)
+      assert(b.isValidShort == isShort, b)
+      assert(b.isValidByte == isByte, b)
+    }
   }
 }


### PR DESCRIPTION
....

This commit fixes test cases mentioned in comment 03/Apr/12 to SI-4540.
Methods are fixed in leaf classes RichDouble|RichFloat|RichLong.
Their superclasses are not modified.

File "is-valid-num.scala" contains commented tests of
isValidLong|isValidFloat|isValidLong,
but they are not added anywhere now.
