### PR TITLE
SI-5571: adds @volatile to field Enumeration.vsetDefined

### DIFF
--- a/src/library/scala/Enumeration.scala
+++ b/src/library/scala/Enumeration.scala
@@ -81,7 +81,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
 
   /** The cache listing all values of this enumeration. */
   @transient private var vset: ValueSet = null
-  @transient private var vsetDefined = false
+  @transient @volatile private var vsetDefined = false
 
   /** The mapping from the integer used to identify values to their
     * names. */


### PR DESCRIPTION
In order to guarantee visibility of changes on field vset the field vsetDefined has to
be marked as volatile.
