### PR TITLE
Fix memory leak related to default arguments in presentation compiler.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -684,7 +684,7 @@ trait Namers extends MethodSynthesis {
           val acc = sym.lazyAccessor
           if (acc != NoSymbol) enterIfNotThere(acc)
         }
-        defaultParametersOfMethod(sym) foreach enterIfNotThere
+        defaultParametersOfMethod(sym) foreach { symRef => enterIfNotThere(symRef()) }
       }
       this.context
     }
@@ -1161,7 +1161,7 @@ trait Namers extends MethodSynthesis {
               // if compiling the same local block several times (which can happen in interactive mode)
               // we might otherwise not find the default symbol, because the second time it the
               // method symbol will be re-entered in the scope but the default parameter will not.
-              defaultParametersOfMethod(meth) += default
+              defaultParametersOfMethod(meth) += new WeakReference(default)
             }
           } else if (baseHasDefault) {
             // the parameter does not have a default itself, but the

--- a/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
@@ -8,6 +8,7 @@ package typechecker
 
 import symtab.Flags._
 import scala.collection.mutable
+import scala.ref.WeakReference
 
 /**
  *  @author Lukas Rytz
@@ -20,7 +21,7 @@ trait NamesDefaults { self: Analyzer =>
   import NamesDefaultsErrorsGen._
 
   val defaultParametersOfMethod =
-    perRunCaches.newWeakMap[Symbol, Set[Symbol]]() withDefaultValue Set()
+    perRunCaches.newWeakMap[Symbol, Set[WeakReference[Symbol]]]() withDefaultValue Set()
 
   case class NamedApplyInfo(
     qual:       Option[Tree],

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2202,7 +2202,7 @@ trait Typers extends Modes with Adaptations with PatMatVirtualiser {
             vparams map {p => if(p.tpt.tpe == null) typedType(p.tpt).tpe else p.tpt.tpe}
         }
 
-      def mkParams(methodSym: Symbol, formals: List[Type]/* = deriveFormals*/) = {
+      def mkParams(methodSym: Symbol, formals: List[Type] = deriveFormals) = {
         selOverride match {
           case None if targs.isEmpty => MissingParameterTypeAnonMatchError(tree, pt); (Nil, EmptyTree)
           case None =>
@@ -2228,7 +2228,7 @@ trait Typers extends Modes with Adaptations with PatMatVirtualiser {
         // rig the show so we can get started typing the method body -- later we'll correct the infos...
         anonClass setInfo ClassInfoType(List(ObjectClass.tpe, pt, SerializableClass.tpe), newScope, anonClass)
         val methodSym = anonClass.newMethod(nme.apply, tree.pos, FINAL)
-        val (paramSyms, selector) = mkParams(methodSym, deriveFormals)
+        val (paramSyms, selector) = mkParams(methodSym)
 
         if (selector eq EmptyTree) EmptyTree
         else {
@@ -2292,7 +2292,7 @@ trait Typers extends Modes with Adaptations with PatMatVirtualiser {
 
       def isDefinedAtMethod = {
         val methodSym = anonClass.newMethod(nme.isDefinedAt, tree.pos, FINAL)
-        val (paramSyms, selector) = mkParams(methodSym, deriveFormals)
+        val (paramSyms, selector) = mkParams(methodSym)
         if (selector eq EmptyTree) EmptyTree
         else {
           val methodBodyTyper = newTyper(context.makeNewScope(context.tree, methodSym)) // should use the DefDef for the context's tree, but it doesn't exist yet (we need the typer we're creating to create it)


### PR DESCRIPTION
This bug exists for a long time, but was triggered / discovered only lately
by the default argument of mkParams in 118aef558f.

This reverts the workaroud commit 19b6ad5ee4.

The fix is tested by test/files/presentation/memory-leaks which runs the
presentation compiler several times on Typers.scala. I could not reproduce
the memory leak in a smaller test case.

Build: https://scala-webapps.epfl.ch/jenkins/job/scala-checkin-manual/9/console
