### PR TITLE
Changes scaladoc text in trait Dynamic

### DIFF
--- a/src/library/scala/Dynamic.scala
+++ b/src/library/scala/Dynamic.scala
@@ -11,7 +11,7 @@ package scala
 /** A marker trait that enables dynamic invocations. Instances `x` of this
  *  trait allow calls `x.meth(args)` for arbitrary method names `meth` and
  *  argument lists `args`.  If a call is not natively supported by `x`, it
- *  is rewritten to `x.applyDynamic("meth", args)`.
+ *  is rewritten to `x.applyDynamic("meth")(args)`.
  *
  *  As of scala 2.9, `scalac` must receive the `-Xexperimental` option for
  *  `Dynamic` to receive this treatment.


### PR DESCRIPTION
This commit changes the text in trait dynamic which explains, how methods
invocations, which are not natively supported, are rewritten.

In the current implementation they are rewritten to `x.applyDynamic("meth")(args)`.
