### PR TITLE
util.Random.alphanumeric method moves to util.Random class

### DIFF
--- a/src/library/scala/util/Random.scala
+++ b/src/library/scala/util/Random.scala
@@ -120,15 +120,6 @@ class Random(val self: java.util.Random) {
     bf(xs) ++= buf result
   }
 
-}
-
-/** The object `Random` offers a default implementation
- *  of scala.util.Random and random-related convenience methods.
- *
- *  @since 2.8
- */
-object Random extends Random {
-
   /** Returns a Stream of pseudorandomly chosen alphanumeric characters,
    *  equally chosen from A-Z, a-z, and 0-9.
    *
@@ -139,5 +130,16 @@ object Random extends Random {
 
     Stream continually nextPrintableChar filter isAlphaNum
   }
+
+}
+
+/** The object `Random` offers a default implementation
+ *  of scala.util.Random and random-related convenience methods.
+ *
+ *  @since 2.8
+ */
+object Random extends Random {
+
+  implicit def javaRandomToRandom(r: java.util.Random): Random = new Random(r)
 
 }


### PR DESCRIPTION
I want to use util.Random.alphanumeric method to generate a password.

``` scala
util.Random.alphanumeric.take(8).mkString
```

however, this is not secure.

so, I tried making alphanumeric possible to be called from java.security.SecureRandom.

``` scala
import util.Random._
new java.security.SecureRandom().alphanumeric.take(8).mkString
```
