### PR TITLE
Cache consistency checks for starr binary repo.

### DIFF
--- a/tools/binary-repo-lib.sh
+++ b/tools/binary-repo-lib.sh
@@ -88,12 +88,22 @@ pushJarFile() {
   # rm $jar
 }
 
+getJarSha() {
+  local jar=$1
+  if [[ ! -f "$jar" ]]; then
+    echo ""
+  else
+    shastring=$(sha1sum "$jar")
+    echo "${shastring:0:$(expr index "$shastring" " ")-1}"
+  fi
+}
+
 # Tests whether or not the .desired.sha1 hash matches a given file.
 # Arugment 1 - The jar file to test validity.
 # Returns: Empty string on failure, "OK" on success.
 isJarFileValid() {
   local jar=$1
-  if [[ ! -f $jar ]]; then
+  if [[ ! -f "$jar" ]]; then
     echo ""
   else
     local jar_dir=$(dirname $jar)
@@ -131,6 +141,27 @@ pushJarFiles() {
   fi
 } 
 
+
+checkJarSha() {
+  local jar=$1
+  local sha=$2
+  local testsha=$(getJarSha "$jar")
+  if test "$sha" == "$testsha"; then
+    echo "OK"
+  fi
+}
+
+makeCacheLocation() {
+  local uri=$1
+  local sha=$2
+  local cache_loc="$cache_dir/$uri"
+  local cdir=$(dirname $cache_loc)
+  if [[ ! -d "$cdir" ]]; then
+    mkdir -p "$cdir"
+  fi
+  echo "$cache_loc"
+}
+
 # Pulls a single binary artifact from a remote repository.
 # Argument 1 - The uri to the file that should be downloaded.
 # Argument 2 - SHA of the file...
@@ -138,16 +169,19 @@ pushJarFiles() {
 pullJarFileToCache() {
   local uri=$1
   local sha=$2
-  local cache_loc=$cache_dir/$uri
-  local cdir=$(dirname $cache_loc)
-  if [[ ! -d $cdir ]]; then
-    mkdir -p $cdir
-  fi
+  local cache_loc="$(makeCacheLocation $uri)"
   # TODO - Check SHA of local cache is accurate.
-  if [[ ! -f $cache_loc ]]; then
-    curlDownload $cache_loc ${remote_urlbase}/${uri}
+  if test -f "$cache_loc" && test "$(checkJarSha "$cache_loc" "$sha")" != "OK"; then
+    echo "Found bad cached file: $cache_loc"
+    rm -f "$cache_loc"
   fi
-  echo "$cache_loc"
+  if [[ ! -f "$cache_loc" ]]; then
+    curlDownload $cache_loc ${remote_urlbase}/${uri}
+    if test "$(checkJarSha "$cache_loc" "$sha")" != "OK"; then
+      echo "Trouble downloading $uri.  Please try pull-binary-libs again when your internet connection is stable."
+      exit 2
+    fi
+  fi
 }
 
 # Pulls a single binary artifact from a remote repository.
@@ -162,7 +196,8 @@ pullJarFile() {
   local version=${sha1% ?$jar_name}
   local remote_uri=${version}/${jar#$basedir/}
   echo "Resolving [${remote_uri}]"
-  local cached_file=$(pullJarFileToCache $remote_uri $version)
+  pullJarFileToCache $remote_uri $version
+  local cached_file=$(makeCacheLocation $remote_uri)
   cp $cached_file $jar
 }
 


### PR DESCRIPTION
- invalid jar files in cache are now corrected
- downloading an invalid jar file causes the script to exit with an error
- Ant will still continue in the event of one of these errors.
