### PR TITLE
SI-5510: string interpolation: parser no longer hangs on unclosed string

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -231,6 +231,12 @@ trait Scanners extends ScannersCommon {
           lastOffset -= 1
         }
         if (inStringInterpolation) fetchStringPart() else fetchToken()
+        if(token == ERROR) {
+          if (inMultiLineInterpolation)
+            sepRegions = sepRegions.tail.tail
+          else if (inStringInterpolation)
+            sepRegions = sepRegions.tail
+        }
       } else {
         this copyFrom next
         next.token = EMPTY
@@ -328,7 +334,7 @@ trait Scanners extends ScannersCommon {
           putChar(ch)
           nextChar()
           getIdentRest()
-          if (ch == '"' && token == IDENTIFIER && settings.Xexperimental.value)
+          if (ch == '"' && token == IDENTIFIER)
             token = INTERPOLATIONID
         case '<' => // is XMLSTART?
           val last = if (charOffset >= 2) buf(charOffset - 2) else ' '
@@ -697,7 +703,7 @@ trait Scanners extends ScannersCommon {
           do {
             putChar(ch)
             nextRawChar()
-          } while (Character.isUnicodeIdentifierPart(ch))
+          } while (ch != SU && Character.isUnicodeIdentifierPart(ch))
           next.token = IDENTIFIER
           next.name = newTermName(cbuf.toString)
           cbuf.clear()

--- a/test/files/neg/t5510.check
+++ b/test/files/neg/t5510.check
@@ -1,0 +1,19 @@
+t5510.scala:2: error: unclosed string literal
+  val s1 = s"xxx
+            ^
+t5510.scala:3: error: unclosed string literal
+  val s2 = s"xxx $x
+                   ^
+t5510.scala:4: error: unclosed string literal
+  val s3 = s"xxx $$
+            ^
+t5510.scala:5: error: unclosed string literal
+  val s4 = ""s"
+              ^
+t5510.scala:6: error: unclosed multi-line string literal
+  val s5 = ""s""" $s1 $s2 s"
+                         ^
+t5510.scala:7: error: Missing closing brace `}' assumed here
+}
+  ^
+6 errors found

--- a/test/files/neg/t5510.scala
+++ b/test/files/neg/t5510.scala
@@ -1,0 +1,7 @@
+object Test {
+  val s1 = s"xxx
+  val s2 = s"xxx $x
+  val s3 = s"xxx $$
+  val s4 = ""s"
+  val s5 = ""s""" $s1 $s2 s"
+}


### PR DESCRIPTION
This commit fixes bug 5510. After the invocation of either fetchToken or
fetchStringPart it is checked now whether an ERROR token was read. 
If so, added markers are popped from sepRegions.

Moreover, an infinite loop occurring in the REPL was fixed. Could happen
as the SU=\u001A character is considered to be isUnicodeIdentifierPart 
by class Character.

A neg-test has also been defined.

Have taken away the -Xexperimental flag for string interpolation as 
SIP 11 has been accepted.
