### PR TITLE
Typesafe config 0.4.0

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -249,7 +249,7 @@ INITIALISATION
   <!-- Resolve maven dependencies -->
   <target name="init.maven.jars" depends="init.maven.tasks">
     <artifact:dependencies pathId="dependency.classpath" filesetId="dependency.fileset">
-      <dependency groupId="org.skife.com.typesafe.config" artifactId="typesafe-config" version="0.3.0"/>
+      <dependency groupId="com.typesafe" artifactId="config" version="0.4.0"/>
     </artifact:dependencies>
   </target>
 

--- a/src/build/maven/scala-library-pom.xml
+++ b/src/build/maven/scala-library-pom.xml
@@ -32,9 +32,9 @@
    </issueManagement>
    <dependencies>
       <dependency>
-         <groupId>org.skife.com.typesafe.config</groupId>
-         <artifactId>typesafe-config</artifactId>
-         <version>0.3.0</version>
+         <groupId>com.typesafe</groupId>
+         <artifactId>config</artifactId>
+         <version>0.4.0</version>
      </dependency>
    </dependencies>
    <distributionManagement>


### PR DESCRIPTION
DO NOT PULL immediately, because 0.4.0 has not synced to Maven Central yet (something is wrong with our sync).  Can check https://issues.sonatype.org/browse/OSSRH-3250 for status.

I wanted to go ahead and get this pull request in the queue so people would be aware of it, but it is blocking on the maven central sync.

I haven't tested this patch fully since the sync isn't done, but it looks simple enough, right? :-P

The release is available at https://oss.sonatype.org/content/repositories/releases/com/typesafe/config/ just not on central yet.
