### PR TITLE
typo in doc

### DIFF
--- a/src/library/scala/Either.scala
+++ b/src/library/scala/Either.scala
@@ -261,7 +261,7 @@ object Either {
    *     case ex => Left(ex)
    *   }
    *
-   * // this will only be executed if interactWithDB returns a Some
+   * // this will only be executed if interactWithDB returns a Right
    * val report =
    *   for (r <- interactWithDB(someQuery).right) yield generateReport(r)
    * if (report.isRight)


### PR DESCRIPTION
Small typo in a part that compare Either mechanism to Option one. It suppose it might be disturbing.
