### PR TITLE
suppresses warnings introduced in a2115b2352

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -415,7 +415,7 @@ LOCAL REFERENCE BUILD (LOCKER)
       classpath="${build-locker.dir}/classes/library"
       includes="**/*.java"
       target="1.5" source="1.5">
-        <compilerarg line="${javac.args}"/>
+        <compilerarg line="${javac.args} -XDignore.symbol.file"/>
     </javac>
     <!-- NOTE: Potential problem with maximal command line length on Windows
          (32768 characters for XP, since executed with Java's "exec"). See
@@ -660,7 +660,7 @@ QUICK BUILD (QUICK)
       classpath="${build-quick.dir}/classes/library"
       includes="**/*.java"
       target="1.5" source="1.5">
-      <compilerarg line="${javac.args}"/>
+      <compilerarg line="${javac.args} -XDignore.symbol.file"/>
     </javac>
     <javac
       srcdir="${src.dir}/actors"
@@ -1217,7 +1217,7 @@ BOOTSTRAPPING BUILD (STRAP)
       classpath="${build-strap.dir}/classes/library"
       includes="**/*.java"
       target="1.5" source="1.5">
-      <compilerarg line="${javac.args}"/>
+      <compilerarg line="${javac.args} -XDignore.symbol.file"/>
     </javac>
     <javac
       srcdir="${src.dir}/actors"


### PR DESCRIPTION
locker.lib:
    [javac] Compiling 1 source file to C:\Projects\Kepler\build\locker\classes\library
    [javac] C:\Projects\Kepler\src\library\scala\concurrent\impl\Unsafe.java:17: warning: sun.misc.Unsafe is Sun proprietary API and may be removed in a future release
    [javac]     public final static sun.misc.Unsafe instance;
    [javac]                                 ^
    [javac] C:\Projects\Kepler\src\library\scala\concurrent\impl\Unsafe.java:20: warning: sun.misc.Unsafe is Sun proprietary API and may be removed in a future release
    [javac]             sun.misc.Unsafe found = null;
    [javac]                     ^
    [javac] C:\Projects\Kepler\src\library\scala\concurrent\impl\Unsafe.java:21: warning: sun.misc.Unsafe is Sun proprietary API and may be removed in a future release
    [javac]             for(Field field : sun.misc.Unsafe.class.getDeclaredFields()) {
    [javac]                                       ^
    [javac] C:\Projects\Kepler\src\library\scala\concurrent\impl\Unsafe.java:22: warning: sun.misc.Unsafe is Sun proprietary API and may be removed in a future release
    [javac]               if (field.getType() == sun.misc.Unsafe.class) {
    [javac]                                              ^
    [javac] C:\Projects\Kepler\src\library\scala\concurrent\impl\Unsafe.java:24: warning: sun.misc.Unsafe is Sun proprietary API and may be removed in a future release
    [javac]                 found = (sun.misc.Unsafe) field.get(null);
    [javac]                                  ^
    [javac] 5 warnings
[propertyfile] Updating property file: C:\Projects\Kepler\build\locker\classes\library\library.properties
[stopwatch] [locker.lib.timer: 0.908 sec]
