### PR TITLE
Presentation Compiler test for hyperlinking inside patterns

### DIFF
--- a/src/compiler/scala/tools/nsc/interactive/tests/core/CoreTestDefs.scala
+++ b/src/compiler/scala/tools/nsc/interactive/tests/core/CoreTestDefs.scala
@@ -90,8 +90,9 @@ private[tests] trait CoreTestDefs
               compiler.askLinkPos(tree.symbol, source, r)
               r.get match {
                 case Left(pos) =>
+                  val resolvedPos = if (tree.symbol.pos.isDefined) tree.symbol.pos else pos
                   withResponseDelimiter {
-                    reporter.println("[response] found askHyperlinkPos for `" + tree.symbol.name + "` at " + format(pos) + " " + tree.symbol.sourceFile.name)
+                    reporter.println("[response] found askHyperlinkPos for `" + tree.symbol.name + "` at " + format(resolvedPos) + " " + tree.symbol.sourceFile.name)
                   }
                 case Right(ex) =>
                   ex.printStackTrace()

--- a/test/files/presentation/patmat.check
+++ b/test/files/presentation/patmat.check
@@ -1,0 +1,36 @@
+reload: PatMatTests.scala
+
+askHyperlinkPos for `CaseOne` at (12,18) PatMatTests.scala
+================================================================================
+[response] found askHyperlinkPos for `CaseOne` at (5,12) PatMatTests.scala
+================================================================================
+
+askHyperlinkPos for `first` at (14,21) PatMatTests.scala
+================================================================================
+[response] found askHyperlinkPos for `first` at (12,29) PatMatTests.scala
+================================================================================
+
+askHyperlinkPos for `tmp` at (15,19) PatMatTests.scala
+================================================================================
+[response] found askHyperlinkPos for `tmp` at (13,13) PatMatTests.scala
+================================================================================
+
+askHyperlinkPos for `CaseTwo` at (17,18) PatMatTests.scala
+================================================================================
+[response] found askHyperlinkPos for `CaseTwo` at (6,12) PatMatTests.scala
+================================================================================
+
+askHyperlinkPos for `mystring` at (18,24) PatMatTests.scala
+================================================================================
+[response] found askHyperlinkPos for `mystring` at (17,25) PatMatTests.scala
+================================================================================
+
+askHyperlinkPos for `x` at (25,13) PatMatTests.scala
+================================================================================
+[response] found askHyperlinkPos for `x` at (23,10) PatMatTests.scala
+================================================================================
+
+askHyperlinkPos for `y` at (25,21) PatMatTests.scala
+================================================================================
+[response] found askHyperlinkPos for `y` at (23,13) PatMatTests.scala
+================================================================================

--- a/test/files/presentation/patmat.flags
+++ b/test/files/presentation/patmat.flags
@@ -1,0 +1,3 @@
+# This test will fail in the new pattern matcher because 
+# it generates trees whose positions are not transparent
+-Xoldpatmat

--- a/test/files/presentation/patmat/Runner.scala
+++ b/test/files/presentation/patmat/Runner.scala
@@ -1,0 +1,11 @@
+import scala.tools.nsc.interactive.tests.InteractiveTest
+
+object Test extends InteractiveTest {
+  override def runTests() {
+    // make sure typer is done.. the virtual pattern matcher might translate
+    // some trees and mess up positions. But we'll catch it red handed!
+    sourceFiles foreach (src => askLoadedTyped(src).get)
+    super.runTests()
+  }
+  
+}

--- a/test/files/presentation/patmat/src/PatMatTests.scala
+++ b/test/files/presentation/patmat/src/PatMatTests.scala
@@ -1,0 +1,28 @@
+package patmat
+
+abstract class BaseType
+
+case class CaseOne(x: Int, y: List[Int]) extends BaseType
+case class CaseTwo(str: String) extends BaseType
+
+class PatMatTests {
+  
+  def foo(x: BaseType) {
+    x match {
+      case CaseOne/*#*/(10, first :: second :: Nil) =>
+        val tmp = 23
+        println(first/*#*/)
+        println(tmp/*#*/)
+        
+      case CaseTwo/*#*/(mystring) =>
+        println(mystring/*#*/)
+    }
+  }
+  
+  def multipleAssign() {
+    val (x, y) = ("abc", "def")
+    
+    println(x/*#*/, y/*#*/)
+  }
+
+}


### PR DESCRIPTION
This test ensures hyperlinking works inside and around pattern matching. The new virtual pattern matcher
synthesizes trees that are not properly nested, and whose positions make it impossible to retrieve the correct
tree/symbol for a given position. Therefore, the current test is using the old pattern matcher. However,
once the virtual pattern matcher is fixed, remove the corresponding line from patmat.flags to re-enable virtpatmat.
