### PR TITLE
SI-3755: catch exception thrown by adaptToNewrun

### DIFF
--- a/src/compiler/scala/reflect/internal/Types.scala
+++ b/src/compiler/scala/reflect/internal/Types.scala
@@ -4832,9 +4832,14 @@ trait Types extends api.Types { self: SymbolTable =>
         if (sym.isPackage) tp
         else {
           val pre1 = this(pre)
-          val sym1 = adaptToNewRun(pre1, sym)
-          if ((pre1 eq pre) && (sym1 eq sym)) tp
-          else singleType(pre1, sym1)
+          try {
+            val sym1 = adaptToNewRun(pre1, sym)
+            if ((pre1 eq pre) && (sym1 eq sym)) tp
+            else singleType(pre1, sym1)
+          } catch {
+            case _: MissingTypeControl =>
+              tp
+          }
         }
       case TypeRef(pre, sym, args) =>
         if (sym.isPackageClass) tp


### PR DESCRIPTION
someone who knows adaptToNewRun (@lrytz ?), please review
I just added a try/catch to mimic what the other cases were doing

it would be nice to have a test for this, but you'd need to involve the repl,
as I couldn't trigger it using multiple scalac runs
