### PR TITLE
Removes @bridge methods.

### DIFF
--- a/src/library/scala/collection/GenSeqLike.scala
+++ b/src/library/scala/collection/GenSeqLike.scala
@@ -228,9 +228,6 @@ trait GenSeqLike[+A, +Repr] extends Any with GenIterableLike[A, Repr] with Equal
    */
   def startsWith[B](that: GenSeq[B]): Boolean = startsWith(that, 0)
 
-  @bridge
-  def startsWith[B](that: Seq[B]): Boolean = startsWith(that: GenSeq[B])
-
   /** Tests whether this $coll contains the given sequence at a given index.
    *
    * '''Note''': If the both the receiver object `this` and the argument
@@ -412,10 +409,6 @@ trait GenSeqLike[+A, +Repr] extends Any with GenIterableLike[A, Repr] with Equal
    *                  followed by all elements of `that`.
    */
   def union[B >: A, That](that: GenSeq[B])(implicit bf: CanBuildFrom[Repr, B, That]): That = this ++ that
-
-  @bridge
-  def union[B >: A, That](that: Seq[B])(implicit bf: CanBuildFrom[Repr, B, That]): That =
-    union(that: GenSeq[B])(bf)
 
   /** Computes the multiset difference between this $coll and another sequence.
    *

--- a/src/library/scala/collection/GenSetLike.scala
+++ b/src/library/scala/collection/GenSetLike.scala
@@ -51,9 +51,6 @@ extends GenIterableLike[A, Repr]
    */
   def intersect(that: GenSet[A]): Repr = this filter that
 
-  @bridge
-  def intersect(that: Set[A]): Repr = intersect(that: GenSet[A])
-
   /** Computes the intersection between this set and another set.
    *
    *  '''Note:'''  Same as `intersect`.
@@ -62,9 +59,6 @@ extends GenIterableLike[A, Repr]
    *  set and in the given set `that`.
    */
   def &(that: GenSet[A]): Repr = this intersect that
-
-  @bridge
-  def &(that: Set[A]): Repr = &(that: GenSet[A])
 
   /** Computes the union between of set and another set.
    *
@@ -83,9 +77,6 @@ extends GenIterableLike[A, Repr]
    */
   def | (that: GenSet[A]): Repr = this union that
 
-  @bridge
-  def | (that: Set[A]): Repr = | (that: GenSet[A])
-
   /** Computes the difference of this set and another set.
    *
    *  @param that the set of elements to exclude.
@@ -103,9 +94,6 @@ extends GenIterableLike[A, Repr]
    */
   def &~(that: GenSet[A]): Repr = this diff that
 
-  @bridge
-  def &~(that: Set[A]): Repr = &~(that: GenSet[A])
-
   /** Tests whether this set is a subset of another set.
    *
    *  @param that  the set to test.
@@ -113,9 +101,6 @@ extends GenIterableLike[A, Repr]
    *              every element of this set is also an element of `that`.
    */
   def subsetOf(that: GenSet[A]): Boolean = this forall that
-
-  @bridge
-  def subsetOf(that: Set[A]): Boolean = subsetOf(that: GenSet[A])
 
   /** Compares this set with another object for equality.
    *

--- a/src/library/scala/collection/IterableLike.scala
+++ b/src/library/scala/collection/IterableLike.scala
@@ -239,10 +239,6 @@ self =>
     b.result
   }
 
-  @bridge
-  def zip[A1 >: A, B, That](that: Iterable[B])(implicit bf: CanBuildFrom[Repr, (A1, B), That]): That =
-    zip(that: GenIterable[B])(bf)
-
   def zipAll[B, A1 >: A, That](that: GenIterable[B], thisElem: A1, thatElem: B)(implicit bf: CanBuildFrom[Repr, (A1, B), That]): That = {
     val b = bf(repr)
     val these = this.iterator
@@ -255,10 +251,6 @@ self =>
       b += ((thisElem, those.next))
     b.result
   }
-
-  @bridge
-  def zipAll[B, A1 >: A, That](that: Iterable[B], thisElem: A1, thatElem: B)(implicit bf: CanBuildFrom[Repr, (A1, B), That]): That =
-    zipAll(that: GenIterable[B], thisElem, thatElem)(bf)
 
   def zipWithIndex[A1 >: A, That](implicit bf: CanBuildFrom[Repr, (A1, Int), That]): That = {
     val b = bf(repr)
@@ -279,9 +271,6 @@ self =>
 
     !these.hasNext && !those.hasNext
   }
-
-  @bridge
-  def sameElements[B >: A](that: Iterable[B]): Boolean = sameElements(that: GenIterable[B])
 
   override /*TraversableLike*/ def toStream: Stream[A] = iterator.toStream
 

--- a/src/library/scala/collection/MapLike.scala
+++ b/src/library/scala/collection/MapLike.scala
@@ -297,9 +297,6 @@ self =>
   def ++[B1 >: B](xs: GenTraversableOnce[(A, B1)]): Map[A, B1] =
     ((repr: Map[A, B1]) /: xs.seq) (_ + _)
 
-  @bridge
-  def ++[B1 >: B](xs: TraversableOnce[(A, B1)]): Map[A, B1] = ++(xs: GenTraversableOnce[(A, B1)])
-
   /** Returns a new map with all key/value pairs for which the predicate
    *  `p` returns `true`.
    *

--- a/src/library/scala/collection/SeqLike.scala
+++ b/src/library/scala/collection/SeqLike.scala
@@ -296,9 +296,6 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
     !j.hasNext
   }
 
-  @bridge
-  def startsWith[B](that: Seq[B], offset: Int): Boolean = startsWith(that: GenSeq[B], offset)
-
   def endsWith[B](that: GenSeq[B]): Boolean = {
     val i = this.iterator.drop(length - that.length)
     val j = that.iterator
@@ -309,10 +306,6 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
     !j.hasNext
   }
 
-  @bridge
-  def endsWith[B](that: Seq[B]): Boolean = endsWith(that: GenSeq[B])
-
-
   /** Finds first index where this $coll contains a given sequence as a slice.
    *  $mayNotTerminateInf
    *  @param  that    the sequence to test
@@ -320,9 +313,6 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
    *           match the elements of sequence `that`, or `-1` of no such subsequence exists.
    */
   def indexOfSlice[B >: A](that: GenSeq[B]): Int = indexOfSlice(that, 0)
-
-  @bridge
-  def indexOfSlice[B >: A](that: Seq[B]): Int = indexOfSlice(that: GenSeq[B])
 
   /** Finds first index after or at a start index where this $coll contains a given sequence as a slice.
    *  $mayNotTerminateInf
@@ -354,9 +344,6 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
       -1
     }
 
-  @bridge
-  def indexOfSlice[B >: A](that: Seq[B], from: Int): Int = indexOfSlice(that: GenSeq[B], from)
-
   /** Finds last index where this $coll contains a given sequence as a slice.
    *  $willNotTerminateInf
    *  @param  that    the sequence to test
@@ -364,9 +351,6 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
    *           match the elements of sequence `that`, or `-1` of no such subsequence exists.
    */
   def lastIndexOfSlice[B >: A](that: GenSeq[B]): Int = lastIndexOfSlice(that, length)
-
-  @bridge
-  def lastIndexOfSlice[B >: A](that: Seq[B]): Int = lastIndexOfSlice(that: GenSeq[B])
 
   /** Finds last index before or at a given end index where this $coll contains a given sequence as a slice.
    *  @param  that    the sequence to test
@@ -385,9 +369,6 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
     else SeqLike.kmpSearch(thisCollection, 0, clippedL+tl, that.seq, 0, tl, false)
   }
 
-  @bridge
-  def lastIndexOfSlice[B >: A](that: Seq[B], end: Int): Int = lastIndexOfSlice(that: GenSeq[B], end)
-
   /** Tests whether this $coll contains a given sequence as a slice.
    *  $mayNotTerminateInf
    *  @param  that    the sequence to test
@@ -395,9 +376,6 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
    *           as `that`, otherwise `false`.
    */
   def containsSlice[B](that: GenSeq[B]): Boolean = indexOfSlice(that) != -1
-
-  @bridge
-  def containsSlice[B](that: Seq[B]): Boolean = containsSlice(that: GenSeq[B])
 
   /** Tests whether this $coll contains a given value as an element.
    *  $mayNotTerminateInf
@@ -463,9 +441,6 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
     b.result
   }
 
-  @bridge
-  def diff[B >: A](that: Seq[B]): Repr = diff(that: GenSeq[B])
-
   /** Computes the multiset intersection between this $coll and another sequence.
    *
    *  @param that   the sequence of elements to intersect with.
@@ -499,9 +474,6 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
     b.result
   }
 
-  @bridge
-  def intersect[B >: A](that: Seq[B]): Repr = intersect(that: GenSeq[B])
-
   private def occCounts[B](sq: Seq[B]): mutable.Map[B, Int] = {
     val occ = new mutable.HashMap[B, Int] { override def default(k: B) = 0 }
     for (y <- sq.seq) occ(y) += 1
@@ -533,10 +505,6 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
     b ++= toCollection(rest).view drop replaced
     b.result
   }
-
-  @bridge
-  def patch[B >: A, That](from: Int, patch: Seq[B], replaced: Int)(implicit bf: CanBuildFrom[Repr, B, That]): That =
-    this.patch(from, patch: GenSeq[B], replaced)(bf)
 
   def updated[B >: A, That](index: Int, elem: B)(implicit bf: CanBuildFrom[Repr, B, That]): That = {
     val b = bf(repr)
@@ -582,10 +550,6 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
 
     !i.hasNext && !j.hasNext
   }
-
-  @bridge
-  def corresponds[B](that: Seq[B])(p: (A,B) => Boolean): Boolean =
-    corresponds(that: GenSeq[B])(p)
 
   /** Sorts this $coll according to a comparison function.
    *  $willNotTerminateInf

--- a/src/library/scala/collection/SeqViewLike.scala
+++ b/src/library/scala/collection/SeqViewLike.scala
@@ -132,12 +132,8 @@ trait SeqViewLike[+A,
   override def diff[B >: A](that: GenSeq[B]): This =
     newForced(thisSeq diff that).asInstanceOf[This]
 
-  @bridge def diff[B >: A](that: Seq[B]): This = diff(that: GenSeq[B])
-
   override def intersect[B >: A](that: GenSeq[B]): This =
     newForced(thisSeq intersect that).asInstanceOf[This]
-
-  @bridge def intersect[B >: A](that: Seq[B]): This = intersect(that: GenSeq[B])
 
   override def sorted[B >: A](implicit ord: Ordering[B]): This =
     newForced(thisSeq sorted ord).asInstanceOf[This]

--- a/src/library/scala/collection/SetLike.scala
+++ b/src/library/scala/collection/SetLike.scala
@@ -127,9 +127,6 @@ self =>
    */
   def ++ (elems: GenTraversableOnce[A]): This = (repr /: elems.seq)(_ + _)
 
-  @bridge
-  def ++ (elems: TraversableOnce[A]): This = ++ (elems: GenTraversableOnce[A])
-
   /** Creates a new set with a given element removed from this set.
    *
    *  @param elem the element to be removed
@@ -152,9 +149,6 @@ self =>
    */
   def union(that: GenSet[A]): This = this ++ that
 
-  @bridge
-  def union(that: Set[A]): This = union(that: GenSet[A])
-
   /** Computes the difference of this set and another set.
    *
    *  @param that the set of elements to exclude.
@@ -162,9 +156,6 @@ self =>
    *              set that are not also contained in the given set `that`.
    */
   def diff(that: GenSet[A]): This = this -- that
-
-  @bridge
-  def diff(that: Set[A]): This = diff(that: GenSet[A])
 
   /** An iterator over all subsets of this set of the given size.
    *  If the requested size is impossible, an empty iterator is returned.

--- a/src/library/scala/collection/Traversable.scala
+++ b/src/library/scala/collection/Traversable.scala
@@ -28,12 +28,6 @@ trait Traversable[+A] extends TraversableLike[A, Traversable[A]]
 
   override def seq: Traversable[A] = this
 
-  @bridge
-  def flatten[B](implicit asTraversable: A => /*<:<!!!*/ GenTraversableOnce[B]): Traversable[B] = super.flatten(asTraversable)
-
-  @bridge
-  def transpose[B](implicit asTraversable: A => /*<:<!!!*/ GenTraversableOnce[B]): Traversable[Traversable[B]] = super.transpose(asTraversable)
-
   /* The following methods are inherited from TraversableLike
    *
   override def isEmpty: Boolean

--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -155,10 +155,6 @@ trait TraversableLike[+A, +Repr] extends Any
     b.result
   }
 
-  @bridge
-  def ++[B >: A, That](that: TraversableOnce[B])(implicit bf: CanBuildFrom[Repr, B, That]): That =
-    ++(that: GenTraversableOnce[B])(bf)
-
   /** As with `++`, returns a new collection containing the elements from the left operand followed by the
    *  elements from the right operand.
    *

--- a/src/library/scala/collection/generic/GenSeqFactory.scala
+++ b/src/library/scala/collection/generic/GenSeqFactory.scala
@@ -19,9 +19,4 @@ import language.higherKinds
  *  @since 2.8
  */
 abstract class GenSeqFactory[CC[X] <: GenSeq[X] with GenericTraversableTemplate[X, CC]]
-extends GenTraversableFactory[CC] {
-
-  @bridge
-  def unapplySeq[A](x: GenSeq[A]): Some[GenSeq[A]] = Some(x)
-
-}
+extends GenTraversableFactory[CC]

--- a/src/library/scala/collection/generic/GenericSeqCompanion.scala
+++ b/src/library/scala/collection/generic/GenericSeqCompanion.scala
@@ -14,12 +14,4 @@ import annotation.bridge
 import language.higherKinds
 
 trait GenericSeqCompanion[CC[X] <: Traversable[X]]
-  extends GenericCompanion[CC] {
-
-  @bridge
-  override def empty[A]: CC[A] = super.empty[A]
-
-  @bridge
-  override def apply[A](elems: A*): CC[A] = super.apply(elems: _*)
-
-}
+  extends GenericCompanion[CC]

--- a/src/library/scala/collection/generic/GenericTraversableTemplate.scala
+++ b/src/library/scala/collection/generic/GenericTraversableTemplate.scala
@@ -147,11 +147,6 @@ trait GenericTraversableTemplate[+A, +CC[X] <: GenTraversable[X]] extends HasNew
     b.result
   }
 
-  // cannot have a bridge, because it would have the same signature as the target method after erasure
-  // @bridge
-  // def flatten[B](implicit asTraversable: A => /*<:<!!!*/ TraversableOnce[B]): CC[B] =
-  //   flatten[B](asTraversable: A => GenTraversableOnce[B])
-
   /** Transposes this $coll of traversable collections into
    *  a $coll of ${coll}s.
    *

--- a/src/library/scala/collection/generic/MapFactory.scala
+++ b/src/library/scala/collection/generic/MapFactory.scala
@@ -36,6 +36,4 @@ abstract class MapFactory[CC[A, B] <: Map[A, B] with MapLike[A, B, CC[A, B]]] ex
 
   def empty[A, B]: CC[A, B]
 
-  @bridge
-  override def apply[A, B](elems: (A, B)*): CC[A, B] = super.apply(elems: _*)
 }

--- a/src/library/scala/collection/generic/SetFactory.scala
+++ b/src/library/scala/collection/generic/SetFactory.scala
@@ -16,11 +16,4 @@ import annotation.bridge
 import language.higherKinds
 
 abstract class SetFactory[CC[X] <: Set[X] with SetLike[X, CC[X]]]
-  extends GenSetFactory[CC] with GenericSeqCompanion[CC] {
-
-  @bridge
-  override def empty[A]: CC[A] = super.empty[A]
-
-  @bridge
-  override def apply[A](elems: A*): CC[A] = super.apply(elems: _*)
-}
+  extends GenSetFactory[CC] with GenericSeqCompanion[CC]

--- a/src/library/scala/collection/generic/Subtractable.scala
+++ b/src/library/scala/collection/generic/Subtractable.scala
@@ -58,7 +58,4 @@ trait Subtractable[A, +Repr <: Subtractable[A, Repr]] { self =>
    *  except one less occurrence of each of the elements of `elems`.
    */
   def --(xs: GenTraversableOnce[A]): Repr = (repr /: xs.seq) (_ - _)
-
-  @bridge
-  def --(xs: TraversableOnce[A]): Repr = --(xs: GenTraversableOnce[A])
 }

--- a/src/library/scala/collection/generic/TraversableFactory.scala
+++ b/src/library/scala/collection/generic/TraversableFactory.scala
@@ -37,48 +37,5 @@ import language.higherKinds
  *    @see GenericCanBuildFrom
  */
 trait TraversableFactory[CC[X] <: Traversable[X] with GenericTraversableTemplate[X, CC]]
-  extends GenTraversableFactory[CC] with GenericSeqCompanion[CC] {
-
-  @bridge
-  override def concat[A](xss: Traversable[A]*): CC[A] = super.concat(xss: _*)
-
-  @bridge
-  override def fill[A](n: Int)(elem: => A): CC[A] = super.fill(n)(elem)
-
-  @bridge
-  override def fill[A](n1: Int, n2: Int)(elem: => A): CC[CC[A]] = super.fill(n1, n2)(elem)
-
-  @bridge
-  override def fill[A](n1: Int, n2: Int, n3: Int)(elem: => A): CC[CC[CC[A]]] = super.fill(n1, n2, n3)(elem)
-
-  @bridge
-  override def fill[A](n1: Int, n2: Int, n3: Int, n4: Int)(elem: => A): CC[CC[CC[CC[A]]]] = super.fill(n1, n2, n3, n4)(elem)
-
-  @bridge
-  override def fill[A](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(elem: => A): CC[CC[CC[CC[CC[A]]]]] = super.fill(n1, n2, n3, n4, n5)(elem)
-
-  @bridge
-  override def tabulate[A](n: Int)(f: Int => A): CC[A] = super.tabulate(n)(f)
-
-  @bridge
-  override def tabulate[A](n1: Int, n2: Int)(f: (Int, Int) => A): CC[CC[A]] = super.tabulate(n1, n2)(f)
-
-  @bridge
-  override def tabulate[A](n1: Int, n2: Int, n3: Int)(f: (Int, Int, Int) => A): CC[CC[CC[A]]] = super.tabulate(n1, n2, n3)(f)
-
-  @bridge
-  override def tabulate[A](n1: Int, n2: Int, n3: Int, n4: Int)(f: (Int, Int, Int, Int) => A): CC[CC[CC[CC[A]]]] = super.tabulate(n1, n2, n3, n4)(f)
-
-  @bridge
-  override def tabulate[A](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(f: (Int, Int, Int, Int, Int) => A): CC[CC[CC[CC[CC[A]]]]] = super.tabulate(n1, n2, n3, n4, n5)(f)
-
-  @bridge
-  override def range[T: Integral](start: T, end: T): CC[T] = super.range(start, end)
-
-  @bridge
-  override def range[T: Integral](start: T, end: T, step: T): CC[T] = super.range(start, end, step)
-
-  @bridge
-  override def iterate[A](start: A, len: Int)(f: A => A): CC[A] = super.iterate(start, len)(f)
-}
+  extends GenTraversableFactory[CC] with GenericSeqCompanion[CC]
 

--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -105,9 +105,6 @@ extends AbstractMap[A, B]
   override def ++[B1 >: B](xs: GenTraversableOnce[(A, B1)]): ListMap[A, B1] =
     ((repr: ListMap[A, B1]) /: xs.seq) (_ + _)
 
-  @bridge def ++[B1 >: B](xs: TraversableOnce[(A, B1)]): ListMap[A, B1] =
-    ++(xs: GenTraversableOnce[(A, B1)])
-
   /** This creates a new mapping without the given `key`.
    *  If the map does not contain a mapping for the given key, the
    *  method returns the same map.

--- a/src/library/scala/collection/immutable/ListSet.scala
+++ b/src/library/scala/collection/immutable/ListSet.scala
@@ -102,8 +102,6 @@ class ListSet[A] extends AbstractSet[A]
     if (xs.isEmpty) this
     else (new ListSet.ListSetBuilder(this) ++= xs.seq).result
 
-  @bridge def ++(xs: TraversableOnce[A]): ListSet[A] = ++(xs: GenTraversableOnce[A]): ListSet[A]
-
   private[ListSet] def unchecked_+(e: A): ListSet[A] = new Node(e)
   private[ListSet] def unchecked_outer: ListSet[A] =
     throw new NoSuchElementException("Empty ListSet has no outer pointer")

--- a/src/library/scala/collection/immutable/MapLike.scala
+++ b/src/library/scala/collection/immutable/MapLike.scala
@@ -86,8 +86,6 @@ trait MapLike[A, +B, +This <: MapLike[A, B, This] with Map[A, B]]
   override def ++[B1 >: B](xs: GenTraversableOnce[(A, B1)]): immutable.Map[A, B1] =
     ((repr: immutable.Map[A, B1]) /: xs.seq) (_ + _)
 
-  @bridge def ++[B1 >: B](xs: TraversableOnce[(A, B1)]): immutable.Map[A, B1] = ++(xs: GenTraversableOnce[(A, B1)])
-
   /** Filters this map by retaining only keys satisfying a predicate.
    *  @param  p   the predicate used to test keys
    *  @return an immutable map consisting only of those key value pairs of this map where the key satisfies

--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -400,8 +400,5 @@ object Range {
   }
 
   @deprecated("use Range instead", "2.9.0")
-  trait ByOne extends Range {
-//    @bridge override def foreach[@specialized(Unit) U](f: Int => U) =
-//      super.foreach(f)
-  }
+  trait ByOne extends Range
 }

--- a/src/library/scala/collection/immutable/SortedMap.scala
+++ b/src/library/scala/collection/immutable/SortedMap.scala
@@ -77,8 +77,6 @@ trait SortedMap[A, +B] extends Map[A, B]
    */
   override def ++[B1 >: B](xs: GenTraversableOnce[(A, B1)]): SortedMap[A, B1] =
     ((repr: SortedMap[A, B1]) /: xs.seq) (_ + _)
-
-  @bridge def ++[B1 >: B](xs: TraversableOnce[(A, B1)]): SortedMap[A, B1] = ++(xs: GenTraversableOnce[(A, B1)])
 }
 
 /** $factoryInfo

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -162,8 +162,6 @@ class TreeMap[A, +B] private (tree: RB.Tree[A, B])(implicit val ordering: Orderi
   override def ++[B1 >: B] (xs: GenTraversableOnce[(A, B1)]): TreeMap[A, B1] =
     ((repr: TreeMap[A, B1]) /: xs.seq) (_ + _)
 
-  @bridge def ++[B1 >: B] (xs: TraversableOnce[(A, B1)]): TreeMap[A, B1] = ++(xs: GenTraversableOnce[(A, B1)])
-
   /** A new TreeMap with the entry added is returned,
    *  assuming that key is <em>not</em> in the TreeMap.
    *

--- a/src/library/scala/collection/mutable/BufferLike.scala
+++ b/src/library/scala/collection/mutable/BufferLike.scala
@@ -223,9 +223,6 @@ trait BufferLike[A, +This <: BufferLike[A, This] with Buffer[A]]
   @migration("`++` creates a new buffer. Use `++=` to add an element from this buffer and return that buffer itself.", "2.8.0")
   def ++(xs: GenTraversableOnce[A]): This = clone() ++= xs.seq
 
-  @bridge
-  def ++(xs: TraversableOnce[A]): This = ++(xs: GenTraversableOnce[A])
-
   /** Creates a new collection with all the elements of this collection except `elem`.
    *
    *  @param elem  the element to remove.
@@ -255,6 +252,4 @@ trait BufferLike[A, +This <: BufferLike[A, This] with Buffer[A]]
    */
   @migration("`--` creates a new buffer. Use `--=` to remove an element from this buffer and return that buffer itself.", "2.8.0")
   override def --(xs: GenTraversableOnce[A]): This = clone() --= xs.seq
-
-  @bridge def --(xs: TraversableOnce[A]): This = --(xs: GenTraversableOnce[A])
 }

--- a/src/library/scala/collection/mutable/MapLike.scala
+++ b/src/library/scala/collection/mutable/MapLike.scala
@@ -119,8 +119,6 @@ trait MapLike[A, B, +This <: MapLike[A, B, This] with Map[A, B]]
   override def ++[B1 >: B](xs: GenTraversableOnce[(A, B1)]): Map[A, B1] =
     clone().asInstanceOf[Map[A, B1]] ++= xs.seq
 
-  @bridge def ++[B1 >: B](xs: TraversableOnce[(A, B1)]): Map[A, B1] = ++(xs: GenTraversableOnce[(A, B1)])
-
   /** Removes a key from this map, returning the value associated previously
    *  with that key as an option.
    *  @param    key the key to be removed
@@ -224,6 +222,4 @@ trait MapLike[A, B, +This <: MapLike[A, B, This] with Map[A, B]]
    */
   @migration("`--` creates a new map. Use `--=` to remove an element from this map and return that map itself.", "2.8.0")
   override def --(xs: GenTraversableOnce[A]): This = clone() --= xs.seq
-
-  @bridge def --(xs: TraversableOnce[A]): This =  --(xs: GenTraversableOnce[A])
 }

--- a/src/library/scala/collection/mutable/PriorityQueue.scala
+++ b/src/library/scala/collection/mutable/PriorityQueue.scala
@@ -113,9 +113,6 @@ class PriorityQueue[A](implicit val ord: Ordering[A])
    */
   def ++(xs: GenTraversableOnce[A]): PriorityQueue[A] = { this.clone() ++= xs.seq }
 
-  @bridge
-  def ++(xs: TraversableOnce[A]): PriorityQueue[A] = ++ (xs: GenTraversableOnce[A])
-
   /** Adds all elements to the queue.
    *
    *  @param  elems       the elements to add.

--- a/src/library/scala/collection/mutable/SetLike.scala
+++ b/src/library/scala/collection/mutable/SetLike.scala
@@ -170,8 +170,6 @@ trait SetLike[A, +This <: SetLike[A, This] with Set[A]]
   @migration("`++` creates a new set. Use `++=` to add elements to this set and return that set itself.", "2.8.0")
   override def ++(xs: GenTraversableOnce[A]): This = clone() ++= xs.seq
 
-  @bridge def ++(xs: TraversableOnce[A]): This = ++(xs: GenTraversableOnce[A])
-
   /** Creates a new set consisting of all the elements of this set except `elem`.
    *
    *  @param elem  the element to remove.
@@ -202,8 +200,6 @@ trait SetLike[A, +This <: SetLike[A, This] with Set[A]]
    */
   @migration("`--` creates a new set. Use `--=` to remove elements from this set and return that set itself.", "2.8.0")
   override def --(xs: GenTraversableOnce[A]): This = clone() --= xs.seq
-
-  @bridge def --(xs: TraversableOnce[A]): This = --(xs: GenTraversableOnce[A])
 
   /** Send a message to this scriptable object.
    *

--- a/src/library/scala/package.scala
+++ b/src/library/scala/package.scala
@@ -84,11 +84,6 @@ package object scala {
   @deprecated("Use Thread.currentThread instead", "2.9.0")
   def currentThread = java.lang.Thread.currentThread()
 
-  // Moved back into Predef to avoid unnecessary indirection by
-  // way of the scala package object within the standard library,
-  // but bridged for compatibility.
-  @bridge def $scope = scala.xml.TopScope
-
   // Numeric types which were moved into scala.math.*
 
   type BigDecimal = scala.math.BigDecimal

--- a/src/library/scala/runtime/RichInt.scala
+++ b/src/library/scala/runtime/RichInt.scala
@@ -37,9 +37,6 @@ final class RichInt(val self: Int) extends ScalaNumberProxy[Int] with RangedProx
     */
   def until(end: Int, step: Int): Range = Range(self, end, step)
 
-//  @bridge
-//  def until(end: Int): Range with Range.ByOne = new Range(self, end, 1) with Range.ByOne
-
   /** like `until`, but includes the last index */
   /**
     * @param end The final bound of the range to make.
@@ -55,9 +52,6 @@ final class RichInt(val self: Int) extends ScalaNumberProxy[Int] with RangedProx
     *         and including `end`.
     */
   def to(end: Int, step: Int): Range.Inclusive = Range.inclusive(self, end, step)
-
-//  @bridge
-//  def to(end: Int): Range with Range.ByOne = new Range.Inclusive(self, end, 1) with Range.ByOne
 
   /**
     * @return `'''this'''` if `'''this''' < that` or `that` otherwise


### PR DESCRIPTION
See https://groups.google.com/forum/#!topic/scala-internals/kHNbXKoUj28

Would be nice if someone could check if the now empty traits/classes are required anymore.
