### PR TITLE
SI-5729: TypeVar experimentals iff -Xexperimental

### DIFF
--- a/src/compiler/scala/reflect/internal/Types.scala
+++ b/src/compiler/scala/reflect/internal/Types.scala
@@ -97,7 +97,7 @@ trait Types extends api.Types { self: SymbolTable =>
    */
   private final val propagateParameterBoundsToTypeVars = sys.props contains "scalac.debug.prop-constraints"
 
-  protected val enableTypeVarExperimentals = settings.Xexperimental.value || !settings.XoldPatmat.value
+  protected val enableTypeVarExperimentals = settings.Xexperimental.value
 
   /** Empty immutable maps to avoid allocations. */
   private val emptySymMap   = immutable.Map[Symbol, Symbol]()
@@ -2898,6 +2898,7 @@ trait Types extends api.Types { self: SymbolTable =>
     // existential.
     // were we compared to skolems at a higher skolemizationLevel?
     // EXPERIMENTAL: value will not be considered unless enableTypeVarExperimentals is true
+    // see SI-5729 for why this is still experimental
     private var encounteredHigherLevel = false
     private def shouldRepackType = enableTypeVarExperimentals && encounteredHigherLevel
 

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -354,9 +354,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter) extends Symb
   // where I need it, and then an override in Global with the setting.
   override protected val etaExpandKeepsStar = settings.etaExpandKeepsStar.value
   // Here comes another one...
-  override protected val enableTypeVarExperimentals = (
-    settings.Xexperimental.value || !settings.XoldPatmat.value
-  )
+  override protected val enableTypeVarExperimentals = settings.Xexperimental.value
 
   // True if -Xscript has been set, indicating a script run.
   def isScriptRun = opt.script.isDefined

--- a/src/library/scala/concurrent/package.scala
+++ b/src/library/scala/concurrent/package.scala
@@ -26,7 +26,7 @@ package concurrent {
   object Await {
     private[concurrent] implicit val canAwaitEvidence = new CanAwait {}
     
-    def ready[T <: Awaitable[_]](awaitable: T, atMost: Duration): T = {
+    def ready[T](awaitable: Awaitable[T], atMost: Duration): awaitable.type = {
       blocking(awaitable, atMost)
       awaitable
     }

--- a/test/files/pos/t5729.scala
+++ b/test/files/pos/t5729.scala
@@ -1,0 +1,6 @@
+trait T[X]
+object Test {
+  def join(in: Seq[T[_]]): Int = ???
+  def join[S](in: Seq[T[S]]): String = ???
+  join(null: Seq[T[_]])
+}


### PR DESCRIPTION
it used to also be enabled by -Yvirtpatmat, which is now on by default,
but this type hackery is no longer necessary to bootstrap under the new pattern matching scheme,
so let's only turn it on when people are feeling -Xexperimental
