### PR TITLE
move pattern match expansion to its own phase

### DIFF
--- a/src/compiler/scala/reflect/internal/Definitions.scala
+++ b/src/compiler/scala/reflect/internal/Definitions.scala
@@ -412,8 +412,6 @@ trait Definitions extends reflect.api.StandardDefinitions {
     lazy val JavaRepeatedParamClass = specialPolyClass(tpnme.JAVA_REPEATED_PARAM_CLASS_NAME, COVARIANT)(tparam => arrayType(tparam.tpe))
     lazy val RepeatedParamClass     = specialPolyClass(tpnme.REPEATED_PARAM_CLASS_NAME, COVARIANT)(tparam => seqType(tparam.tpe))
 
-    lazy val MarkerCPSTypes = getClassIfDefined("scala.util.continuations.cpsParam")
-
     def isByNameParamType(tp: Type)        = tp.typeSymbol == ByNameParamClass
     def isScalaRepeatedParamType(tp: Type) = tp.typeSymbol == RepeatedParamClass
     def isJavaRepeatedParamType(tp: Type)  = tp.typeSymbol == JavaRepeatedParamClass

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -462,6 +462,13 @@ class Global(var currentSettings: Settings, var reporter: Reporter) extends Symb
     val global: Global.this.type = Global.this
   } with Analyzer
 
+  // phaseName = "patmat"
+  object patmat extends {
+    val global: Global.this.type = Global.this
+    val runsAfter = List("typer")
+    val runsRightAfter = Some("typer")
+  } with PatternMatching
+
   // phaseName = "superaccessors"
   object superAccessors extends {
     val global: Global.this.type = Global.this
@@ -682,6 +689,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter) extends Symb
       analyzer.namerFactory   -> "resolve names, attach symbols to named trees",
       analyzer.packageObjects -> "load package objects",
       analyzer.typerFactory   -> "the meat and potatoes: type the trees",
+      patmat                  -> "translate match expressions",
       superAccessors          -> "add super accessors in traits and nested classes",
       extensionMethods        -> "add extension methods for inline classes",
       pickler                 -> "serialize symbol tables",

--- a/src/compiler/scala/tools/nsc/ast/Trees.scala
+++ b/src/compiler/scala/tools/nsc/ast/Trees.scala
@@ -234,6 +234,11 @@ trait Trees extends reflect.internal.Trees { self: Global =>
     }
   }
 
+  // used when a phase is disabled
+  object noopTransformer extends Transformer {
+    override def transformUnit(unit: CompilationUnit): Unit = {}
+  }
+
   override protected def xtransform(transformer: super.Transformer, tree: Tree): Tree = tree match {
     case DocDef(comment, definition) =>
       transformer.treeCopy.DocDef(tree, comment, transformer.transform(definition))

--- a/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
@@ -1,5 +1,6 @@
 /* NSC -- new Scala compiler
- * Copyright 2005-2011 LAMP/EPFL
+ *
+ * Copyright 2012 LAMP/EPFL
  * @author Adriaan Moors
  */
 
@@ -9,33 +10,84 @@ package typechecker
 import symtab._
 import Flags.{MUTABLE, METHOD, LABEL, SYNTHETIC}
 import language.postfixOps
+import scala.tools.nsc.transform.TypingTransformers
+import scala.tools.nsc.transform.Transform
 
-/** Translate pattern matching into method calls (these methods form a zero-plus monad), similar in spirit to how for-comprehensions are compiled.
+/** Translate pattern matching.
+  *
+  * Either into optimized if/then/else's,
+  * or virtualized as method calls (these methods form a zero-plus monad), similar in spirit to how for-comprehensions are compiled.
   *
   * For each case, express all patterns as extractor calls, guards as 0-ary extractors, and sequence them using `flatMap`
   * (lifting the body of the case into the monad using `one`).
   *
   * Cases are combined into a pattern match using the `orElse` combinator (the implicit failure case is expressed using the monad's `zero`).
-
+  *
   * TODO:
-  *  - interaction with CPS
+  *  - exhaustivity
+  *  - DCE (unreachability/refutability/optimization)
+  *  - use TypeTags for type testing
   *  - Array patterns
   *  - implement spec more closely (see TODO's)
-  *  - DCE
-  *  - use TypeTags for type testing
   *
   * (longer-term) TODO:
   *  - user-defined unapplyProd
   *  - recover GADT typing by locally inserting implicit witnesses to type equalities derived from the current case, and considering these witnesses during subtyping (?)
   *  - recover exhaustivity and unreachability checking using a variation on the type-safe builder pattern
   */
-trait PatMatVirtualiser extends ast.TreeDSL { self: Analyzer =>
-  import global._
+trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL {   // self: Analyzer =>
+  val global: Global               // need to repeat here because otherwise last mixin defines global as
+                                   // SymbolTable. If we had DOT this would not be an issue
+  import global._                  // the global environment
+  import definitions._             // standard classes and methods
+  import CODE._
+
+  val phaseName: String = "patmat"
+
+  def newTransformer(unit: CompilationUnit): Transformer =
+    if (opt.virtPatmat) new MatchTransformer(unit)
+    else noopTransformer
+
+  // duplicated from CPSUtils (avoid dependency from compiler -> cps plugin...)
+  private lazy val MarkerCPSAdaptPlus  = definitions.getClassIfDefined("scala.util.continuations.cpsPlus")
+  private lazy val MarkerCPSAdaptMinus = definitions.getClassIfDefined("scala.util.continuations.cpsMinus")
+  private lazy val MarkerCPSSynth      = definitions.getClassIfDefined("scala.util.continuations.cpsSynth")
+  private lazy val stripTriggerCPSAnns = List(MarkerCPSSynth, MarkerCPSAdaptMinus, MarkerCPSAdaptPlus)
+  private lazy val MarkerCPSTypes      = definitions.getClassIfDefined("scala.util.continuations.cpsParam")
+  private lazy val strippedCPSAnns     = MarkerCPSTypes :: stripTriggerCPSAnns
+  private def removeCPSAdaptAnnotations(tp: Type) = tp filterAnnotations (ann => !(strippedCPSAnns exists (ann matches _)))
+
+  class MatchTransformer(unit: CompilationUnit) extends TypingTransformer(unit) {
+    override def transform(tree: Tree): Tree = tree match {
+      case Match(sel, cases) =>
+        val selX   = transform(sel)
+        val casesX = transformTrees(cases).asInstanceOf[List[CaseDef]]
+
+        val origTp = tree.tpe
+        val matchX = treeCopy.Match(tree, selX, casesX)
+
+        // when one of the internal cps-type-state annotations is present, strip all CPS annotations
+        // a cps-type-state-annotated type makes no sense as an expected type (matchX.tpe is used as pt in translateMatch)
+        // (only test availability of MarkerCPSAdaptPlus assuming they are either all available or none of them are)
+        if (MarkerCPSAdaptPlus != NoSymbol && (stripTriggerCPSAnns exists tree.tpe.hasAnnotation))
+          matchX modifyType removeCPSAdaptAnnotations
+
+        localTyper.typed(translator.translateMatch(matchX)) setType origTp
+      case Try(block, catches, finalizer) =>
+        treeCopy.Try(tree, transform(block), translator.translateTry(transformTrees(catches).asInstanceOf[List[CaseDef]], tree.tpe, tree.pos), transform(finalizer))
+      case _ => super.transform(tree)
+    }
+
+    def translator: MatchTranslation with CodegenCore = {
+      new OptimizingMatchTranslator(localTyper)
+    }
+  }
+
   import definitions._
+  import analyzer._ //Typer
 
   val SYNTH_CASE = Flags.CASE | SYNTHETIC
 
-  object TranslatedMatchAttachment
   case class DefaultOverrideMatchAttachment(default: Tree)
 
   object vpmName {
@@ -52,22 +104,6 @@ trait PatMatVirtualiser extends ast.TreeDSL { self: Analyzer =>
     val _match    = newTermName("__match") // don't call the val __match, since that will trigger virtual pattern matching...
 
     def counted(str: String, i: Int) = newTermName(str+i)
-  }
-
-  object MatchTranslator {
-    def apply(typer: Typer): MatchTranslation with CodegenCore = {
-      import typer._
-      // typing `_match` to decide which MatchTranslator to create adds 4% to quick.comp.timer
-      val matchStrategy: Tree = (
-        if (!context.isNameInScope(vpmName._match)) null    // fast path, avoiding the next line if there's no __match to be seen
-        else newTyper(context.makeImplicit(reportAmbiguousErrors = false)).silent(_.typed(Ident(vpmName._match), EXPRmode, WildcardType), reportAmbiguousErrors = false) match {
-          case SilentResultValue(ms) => ms
-          case _                     => null
-        }
-      )
-      if (matchStrategy eq null) new OptimizingMatchTranslator(typer)
-      else new PureMatchTranslator(typer, matchStrategy)
-    }
   }
 
   class PureMatchTranslator(val typer: Typer, val matchStrategy: Tree) extends MatchTranslation with TreeMakers with PureCodegen
@@ -255,7 +291,7 @@ trait PatMatVirtualiser extends ast.TreeDSL { self: Analyzer =>
       val pos = patTree.pos
 
       def translateExtractorPattern(extractor: ExtractorCall): TranslationStep = {
-        if (!extractor.isTyped) throw new TypeError(pos, "Could not typecheck extractor call: "+ extractor)
+        if (!extractor.isTyped) ErrorUtils.issueNormalTypeError(patTree, "Could not typecheck extractor call: "+ extractor)(context)
         // if (extractor.resultInMonad == ErrorType) throw new TypeError(pos, "Unsupported extractor type: "+ extractor.tpe)
 
         // must use type `tp`, which is provided by extractor's result, not the type expected by binder,
@@ -320,7 +356,7 @@ trait PatMatVirtualiser extends ast.TreeDSL { self: Analyzer =>
         **/
         case Apply(fun, args)     =>
           ExtractorCall.fromCaseClass(fun, args) map translateExtractorPattern getOrElse {
-            error("cannot find unapply member for "+ fun +" with args "+ args)
+            ErrorUtils.issueNormalTypeError(patTree, "Could not find unapply member for "+ fun +" with args "+ args)(context)
             noFurtherSubPats()
           }
 
@@ -576,18 +612,29 @@ trait PatMatVirtualiser extends ast.TreeDSL { self: Analyzer =>
         ProductExtractorTreeMaker(binder, lengthGuard(binder), Substitution(subPatBinders, subPatRefs(binder)))
       }
 
-/* TODO: remove special case when the following bug is fixed
-class Foo(x: Other) { x._1 } // BUG: can't refer to _1 if its defining class has not been type checked yet
-case class Other(y: String)
--- this is ok:
-case class Other(y: String)
-class Foo(x: Other) { x._1 } // no error in this order
-*/
+      // reference the (i-1)th case accessor if it exists, otherwise the (i-1)th tuple component
       override protected def tupleSel(binder: Symbol)(i: Int): Tree = { import CODE._
-        // reference the (i-1)th case accessor if it exists, otherwise the (i-1)th tuple component
-        val caseAccs = binder.info.typeSymbol.caseFieldAccessors
-        if (caseAccs isDefinedAt (i-1)) REF(binder) DOT caseAccs(i-1)
-        else codegen.tupleSel(binder)(i)
+        // caseFieldAccessors is messed up after typers (reversed, names mangled for non-public fields)
+        // TODO: figure out why...
+        val accessors = binder.caseFieldAccessors
+        // luckily, the constrParamAccessors are still sorted properly, so sort the field-accessors using them
+        // (need to undo name-mangling, including the sneaky trailing whitespace)
+        val constrParamAccessors = binder.constrParamAccessors
+
+        def indexInCPA(acc: Symbol) =
+          constrParamAccessors indexWhere { orig =>
+            // println("compare: "+ (orig, acc, orig.name, acc.name, (acc.name == orig.name), (acc.name startsWith (orig.name append "$"))))
+            val origName  = orig.name.toString.trim
+            val accName = acc.name.toString.trim
+            (accName == origName) || (accName startsWith (origName + "$"))
+          }
+
+        // println("caseFieldAccessors: "+ (accessors, binder.caseFieldAccessors map indexInCPA))
+        // println("constrParamAccessors: "+ constrParamAccessors)
+
+        val accessorsSorted = accessors sortBy indexInCPA
+        if (accessorsSorted isDefinedAt (i-1)) REF(binder) DOT accessorsSorted(i-1)
+        else codegen.tupleSel(binder)(i) // this won't type check for case classes, as they do not inherit ProductN
       }
 
       override def toString(): String = "case class "+ (if (constructorTp eq null) fun else paramType.typeSymbol) +" with arguments "+ args
@@ -1610,7 +1657,7 @@ class Foo(x: Other) { x._1 } // no error in this order
             else (REF(scrutSym) DOT (nme.toInt))
           Some(BLOCK(
             VAL(scrutSym) === scrut,
-            Match(scrutToInt, caseDefsWithDefault) withAttachment TranslatedMatchAttachment // add switch annotation
+            Match(scrutToInt, caseDefsWithDefault) // a switch
           ))
         }
       } else None

--- a/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
@@ -299,6 +299,7 @@ trait SyntheticMethods extends ast.TreeDSL {
           newAcc resetFlag (ACCESSOR | PARAMACCESSOR)
           ddef.rhs.duplicate
         }
+        // TODO: shouldn't the next line be: `original resetFlag CASEACCESSOR`?
         ddef.symbol resetFlag CASEACCESSOR
         lb += logResult("case accessor new")(newAcc)
       }

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2209,7 +2209,8 @@ trait Typers extends Modes with Adaptations with Taggings with PatMatVirtualiser
     def adaptCase(cdef: CaseDef, mode: Int, tpe: Type): CaseDef = deriveCaseDef(cdef)(adapt(_, mode, tpe))
 
     // takes untyped sub-trees of a match and type checks them
-    def typedMatch(selector0: Tree, cases: List[CaseDef], mode: Int, resTp: Type) = {
+    def typedMatch(selector0: Tree, cases: List[CaseDef], mode: Int, resTp: Type): Match = {
+      // strip off the annotation as it won't type check
       val (selector, doTranslation) = selector0 match {
         case Annotated(Ident(nme.synthSwitch), selector) => (selector, false)
         case s => (s, true)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2320,7 +2320,7 @@ trait Typers extends Modes with Adaptations with Taggings {
           anonClass setInfo ClassInfoType(parents, newScope, anonClass)
           methodSym setInfoAndEnter MethodType(paramSyms, resTp)
 
-          DefDef(methodSym, methodBodyTyper.virtualizedMatch(match_, mode, pt))
+          DefDef(methodSym, methodBodyTyper.virtualizedMatch(match_, mode, resTp))
         }
       }
 
@@ -2359,7 +2359,7 @@ trait Typers extends Modes with Adaptations with Taggings {
           match_ setType B1.tpe
 
           // the default uses applyOrElse's first parameter since the scrut's type has been widened
-          val body = methodBodyTyper.virtualizedMatch(match_ withAttachment DefaultOverrideMatchAttachment(REF(default) APPLY (REF(x))), mode, pt)
+          val body = methodBodyTyper.virtualizedMatch(match_ withAttachment DefaultOverrideMatchAttachment(REF(default) APPLY (REF(x))), mode, B1.tpe)
 
           DefDef(methodSym, body)
         }
@@ -2377,7 +2377,7 @@ trait Typers extends Modes with Adaptations with Taggings {
           methodSym setInfoAndEnter MethodType(paramSyms, BooleanClass.tpe)
 
           val match_ = methodBodyTyper.typedMatch(selector, casesTrue, mode, BooleanClass.tpe)
-          val body   = methodBodyTyper.virtualizedMatch(match_ withAttachment DefaultOverrideMatchAttachment(FALSE_typed), mode, pt)
+          val body   = methodBodyTyper.virtualizedMatch(match_ withAttachment DefaultOverrideMatchAttachment(FALSE_typed), mode, BooleanClass.tpe)
 
           DefDef(methodSym, body)
         }

--- a/src/continuations/plugin/scala/tools/selectivecps/SelectiveCPSTransform.scala
+++ b/src/continuations/plugin/scala/tools/selectivecps/SelectiveCPSTransform.scala
@@ -65,6 +65,7 @@ abstract class SelectiveCPSTransform extends PluginComponent with
 
 
   class CPSTransformer(unit: CompilationUnit) extends TypingTransformer(unit) {
+    private val patmatTransformer = patmat.newTransformer(unit)
 
     override def transform(tree: Tree): Tree = {
       if (!cpsEnabled) return tree
@@ -212,7 +213,7 @@ abstract class SelectiveCPSTransform extends PluginComponent with
           val catch2 = localTyper.typedCases(List(catchIfDefined), ThrowableClass.tpe, targettp)
           //typedCases(tree, catches, ThrowableClass.tpe, pt)
 
-          localTyper.typed(Block(List(funDef), treeCopy.Try(tree, treeCopy.Block(block1, stms, expr2), catch2, finalizer1)))
+          patmatTransformer.transform(localTyper.typed(Block(List(funDef), treeCopy.Try(tree, treeCopy.Block(block1, stms, expr2), catch2, finalizer1))))
 
 
 /*

--- a/test/files/neg/gadts1.check
+++ b/test/files/neg/gadts1.check
@@ -11,7 +11,4 @@ gadts1.scala:20: error: type mismatch;
  required: a
     case Cell[a](x: Int) => c.x = 5
                                   ^
-gadts1.scala:20: error: Could not typecheck extractor call: case class <none> with arguments List((x @ (_: Int)))
-    case Cell[a](x: Int) => c.x = 5
-                ^
-four errors found
+three errors found

--- a/test/files/neg/patmat-type-check.check
+++ b/test/files/neg/patmat-type-check.check
@@ -3,31 +3,19 @@ patmat-type-check.scala:22: error: scrutinee is incompatible with pattern type;
  required: String
   def f1 = "bob".reverse match { case Seq('b', 'o', 'b') => true } // fail
                                          ^
-patmat-type-check.scala:22: error: value _1 is not a member of object Seq
-  def f1 = "bob".reverse match { case Seq('b', 'o', 'b') => true } // fail
-                 ^
 patmat-type-check.scala:23: error: scrutinee is incompatible with pattern type;
  found   : Seq[A]
  required: Array[Char]
   def f2 = "bob".toArray match { case Seq('b', 'o', 'b') => true } // fail
                                          ^
-patmat-type-check.scala:23: error: value _1 is not a member of object Seq
-  def f2 = "bob".toArray match { case Seq('b', 'o', 'b') => true } // fail
-                 ^
 patmat-type-check.scala:27: error: scrutinee is incompatible with pattern type;
  found   : Seq[A]
  required: Test.Bop2
   def f3(x: Bop2) = x match { case Seq('b', 'o', 'b') => true } // fail
                                       ^
-patmat-type-check.scala:27: error: value _1 is not a member of object Seq
-  def f3(x: Bop2) = x match { case Seq('b', 'o', 'b') => true } // fail
-                    ^
 patmat-type-check.scala:30: error: scrutinee is incompatible with pattern type;
  found   : Seq[A]
  required: Test.Bop3[Char]
   def f4[T](x: Bop3[Char]) = x match { case Seq('b', 'o', 'b') => true } // fail
                                                ^
-patmat-type-check.scala:30: error: value _1 is not a member of object Seq
-  def f4[T](x: Bop3[Char]) = x match { case Seq('b', 'o', 'b') => true } // fail
-                             ^
-8 errors found
+four errors found

--- a/test/files/neg/t0418.check
+++ b/test/files/neg/t0418.check
@@ -4,7 +4,4 @@ t0418.scala:2: error: not found: value Foo12340771
 t0418.scala:2: error: not found: value x
   null match { case Foo12340771.Bar(x) => x }
                                           ^
-t0418.scala:2: error: Could not typecheck extractor call: case class <none> with arguments List((x @ _))
-  null match { case Foo12340771.Bar(x) => x }
-                                   ^
-three errors found
+two errors found

--- a/test/files/neg/t112706A.check
+++ b/test/files/neg/t112706A.check
@@ -3,7 +3,4 @@ t112706A.scala:5: error: constructor cannot be instantiated to expected type;
  required: String
     case Tuple2(node,_) =>   
          ^
-t112706A.scala:5: error: Could not typecheck extractor call: case class Tuple2 with arguments List((node @ _), _)
-    case Tuple2(node,_) =>   
-               ^
-two errors found
+one error found

--- a/test/files/neg/t3392.check
+++ b/test/files/neg/t3392.check
@@ -1,7 +1,4 @@
 t3392.scala:9: error: not found: value x
     case x@A(x/*<-- refers to the pattern that includes this comment*/.Ex(42)) =>
              ^
-t3392.scala:9: error: Could not typecheck extractor call: case class <none> with arguments List(42)
-    case x@A(x/*<-- refers to the pattern that includes this comment*/.Ex(42)) =>
-                                                                         ^
-two errors found
+one error found

--- a/test/files/neg/t418.check
+++ b/test/files/neg/t418.check
@@ -4,7 +4,4 @@ t418.scala:2: error: not found: value Foo12340771
 t418.scala:2: error: not found: value x
   null match { case Foo12340771.Bar(x) => x }
                                           ^
-t418.scala:2: error: Could not typecheck extractor call: case class <none> with arguments List((x @ _))
-  null match { case Foo12340771.Bar(x) => x }
-                                   ^
-three errors found
+two errors found

--- a/test/files/neg/t4515.check
+++ b/test/files/neg/t4515.check
@@ -1,6 +1,6 @@
 t4515.scala:37: error: type mismatch;
- found   : _0(in method apply) where type _0(in method apply)
- required: (some other)_0(in method apply)
+ found   : _0(in value $anonfun) where type _0(in value $anonfun)
+ required: (some other)_0(in value $anonfun)
         handler.onEvent(target, ctx.getEvent, node, ctx)
                                     ^
 one error found

--- a/test/files/neg/t5589neg.check
+++ b/test/files/neg/t5589neg.check
@@ -22,9 +22,6 @@ t5589neg.scala:4: error: constructor cannot be instantiated to expected type;
 t5589neg.scala:4: error: not found: value y2
   def f7(x: Either[Int, (String, Int)]) = for (y1 @ Tuple1(y2) <- x.right) yield ((y1, y2))
                                                                                        ^
-t5589neg.scala:4: error: Could not typecheck extractor call: case class Tuple1 with arguments List((y2 @ _))
-  def f7(x: Either[Int, (String, Int)]) = for (y1 @ Tuple1(y2) <- x.right) yield ((y1, y2))
-                                                          ^
 t5589neg.scala:5: error: constructor cannot be instantiated to expected type;
  found   : (T1, T2, T3)
  required: (String, Int)
@@ -37,4 +34,4 @@ t5589neg.scala:5: error: not found: value y2
   def f8(x: Either[Int, (String, Int)]) = for ((y1, y2, y3) <- x.right) yield ((y1, y2))
                                                                                     ^
 two warnings found
-8 errors found
+7 errors found

--- a/test/files/pos/t5542.flags
+++ b/test/files/pos/t5542.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -unchecked

--- a/test/files/pos/t5542.scala
+++ b/test/files/pos/t5542.scala
@@ -1,0 +1,3 @@
+class Test {
+  Option(3) match { case Some(n) => n; case None => 0 }
+}

--- a/test/files/presentation/patmat.flags
+++ b/test/files/presentation/patmat.flags
@@ -1,3 +1,2 @@
 # This test will fail in the new pattern matcher because 
 # it generates trees whose positions are not transparent
--Xoldpatmat

--- a/test/files/run/inner-parse.check
+++ b/test/files/run/inner-parse.check
@@ -5,6 +5,7 @@ class Test$$anonfun$main$1 extends scala.runtime.AbstractFunction1$mcVL$sp
   descriptor                             <clinit>  ()V
   descriptor                                apply  (Lscala/Tuple2;)V
   descriptor                                apply  (Ljava/lang/Object;)Ljava/lang/Object;
+  descriptor                                apply  (Ljava/lang/Object;)V
   descriptor                                cwd$1  Ljava/lang/String;
   descriptor                     serialVersionUID  J
   descriptor                               <init>  (Ljava/lang/String;)V

--- a/test/files/run/programmatic-main.check
+++ b/test/files/run/programmatic-main.check
@@ -4,27 +4,28 @@
                   namer   2  resolve names, attach symbols to named trees
          packageobjects   3  load package objects
                   typer   4  the meat and potatoes: type the trees
-         superaccessors   5  add super accessors in traits and nested classes
-             extmethods   6  add extension methods for inline classes
-                pickler   7  serialize symbol tables
-              refchecks   8  reference/override checking, translate nested objects
-                uncurry   9  uncurry, translate function values to anonymous classes
-              tailcalls  10  replace tail calls by jumps
-             specialize  11  @specialized-driven class and method specialization
-          explicitouter  12  this refs to outer pointers, translate patterns
-                erasure  13  erase types, add interfaces for traits
-            posterasure  14  clean up erased inline classes
-               lazyvals  15  allocate bitmaps, translate lazy vals into lazified defs
-             lambdalift  16  move nested functions to top level
-           constructors  17  move field definitions into constructors
-                flatten  18  eliminate inner classes
-                  mixin  19  mixin composition
-                cleanup  20  platform-specific cleanups, generate reflective calls
-                  icode  21  generate portable intermediate code
-                inliner  22  optimization: do inlining
-inlineExceptionHandlers  23  optimization: inline exception handlers
-               closelim  24  optimization: eliminate uncalled closures
-                    dce  25  optimization: eliminate dead code
-                    jvm  26  generate JVM bytecode
-               terminal  27  The last phase in the compiler chain
+                 patmat   5  translate match expressions
+         superaccessors   6  add super accessors in traits and nested classes
+             extmethods   7  add extension methods for inline classes
+                pickler   8  serialize symbol tables
+              refchecks   9  reference/override checking, translate nested objects
+                uncurry  10  uncurry, translate function values to anonymous classes
+              tailcalls  11  replace tail calls by jumps
+             specialize  12  @specialized-driven class and method specialization
+          explicitouter  13  this refs to outer pointers, translate patterns
+                erasure  14  erase types, add interfaces for traits
+            posterasure  15  clean up erased inline classes
+               lazyvals  16  allocate bitmaps, translate lazy vals into lazified defs
+             lambdalift  17  move nested functions to top level
+           constructors  18  move field definitions into constructors
+                flatten  19  eliminate inner classes
+                  mixin  20  mixin composition
+                cleanup  21  platform-specific cleanups, generate reflective calls
+                  icode  22  generate portable intermediate code
+                inliner  23  optimization: do inlining
+inlineExceptionHandlers  24  optimization: inline exception handlers
+               closelim  25  optimization: eliminate uncalled closures
+                    dce  26  optimization: eliminate dead code
+                    jvm  27  generate JVM bytecode
+               terminal  28  The last phase in the compiler chain
 

--- a/test/files/run/reify_fors.flags
+++ b/test/files/run/reify_fors.flags
@@ -1,1 +1,0 @@
--Xoldpatmat

--- a/test/files/run/reify_maps.flags
+++ b/test/files/run/reify_maps.flags
@@ -1,1 +1,0 @@
--Xoldpatmat

--- a/test/files/run/repl-suppressed-warnings.scala
+++ b/test/files/run/repl-suppressed-warnings.scala
@@ -1,7 +1,7 @@
 import scala.tools.partest.ReplTest
 
 object Test extends ReplTest {
-  override def extraSettings = "-Xoldpatmat"
+  override def extraSettings = ""
   def code = """
 
 // "Is this thing on?" Not working on first couple

--- a/test/files/run/t5272_1.flags
+++ b/test/files/run/t5272_1.flags
@@ -1,1 +1,0 @@
--Xoldpatmat

--- a/test/files/run/t5272_2.flags
+++ b/test/files/run/t5272_2.flags
@@ -1,1 +1,0 @@
--Xoldpatmat

--- a/test/files/run/t5273_1.flags
+++ b/test/files/run/t5273_1.flags
@@ -1,1 +1,0 @@
--Xoldpatmat

--- a/test/files/run/t5273_2a.flags
+++ b/test/files/run/t5273_2a.flags
@@ -1,1 +1,0 @@
--Xoldpatmat

--- a/test/files/run/t5273_2b.flags
+++ b/test/files/run/t5273_2b.flags
@@ -1,1 +1,0 @@
--Xoldpatmat

--- a/test/files/run/virtpatmat_staging.flags
+++ b/test/files/run/virtpatmat_staging.flags
@@ -1,1 +1,1 @@
-  -Xexperimental
+-Xexperimental


### PR DESCRIPTION
this should fix existing issues with the presentation compiler, scaladoc, rangepos, reify,...
the only tricky thing was, you guessed it, cps

"it's time for you to move out of typers, patmat"

https://raw.github.com/gist/2235522/9df576db2d.buildlog
