### PR TITLE
Add a link to "z" in Scaladoc

### DIFF
--- a/src/compiler/scala/tools/nsc/doc/html/resource/lib/index.js
+++ b/src/compiler/scala/tools/nsc/doc/html/resource/lib/index.js
@@ -454,7 +454,7 @@ function resizeFilterBlock() {
 function printAlphabet() {
     var html = '<a target="template" href="index/index-_.html">#</a>';
     var c;
-    for (c = 'a'; c < 'z'; c = String.fromCharCode(c.charCodeAt(0) + 1)) {
+    for (c = 'a'; c <= 'z'; c = String.fromCharCode(c.charCodeAt(0) + 1)) {
         html += [
             '<a target="template" href="index/index-',
             c,


### PR DESCRIPTION
We have index/index-z.html but there is no link in HTML.

// Sorry, it's my bug (00da8a8f07b9ba21ee93a007dbf7c2961c355fd6).
