### PR TITLE
No one define sh_highlightDocument

### DIFF
--- a/src/compiler/scala/tools/nsc/doc/html/page/Template.scala
+++ b/src/compiler/scala/tools/nsc/doc/html/page/Template.scala
@@ -70,8 +70,7 @@ class Template(universe: doc.Universe, tpl: DocTemplateEntity) extends HtmlPage 
         <p id="owner">{ templatesToHtml(tpl.inTemplate.toRoot.reverse.tail, xml.Text(".")) }</p>
     }
 
-    <body class={ if (tpl.isTrait || tpl.isClass || tpl.qualifiedName == "scala.AnyRef") "type" else "value" }
-          onload={ "sh_highlightDocument('../lib/', '.min.js');" }>
+    <body class={ if (tpl.isTrait || tpl.isClass || tpl.qualifiedName == "scala.AnyRef") "type" else "value" }>
       <div id="definition">
         {
           tpl.companion match {


### PR DESCRIPTION
This line was added on 2621ee63285808785159a3c24c9e5a5a723b8b9c but
no one define sh_highlightDocument and syntax highlighting is done
on Scala-side.
