### PR TITLE
Fixes SI-4478.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
@@ -821,7 +821,7 @@ abstract class GenICode extends SubComponent  {
               ctx2
 
             case _ =>
-              abort("Cannot instantiate " + tpt + "of kind: " + generatedType)
+              abort("Cannot instantiate " + tpt + " of kind: " + generatedType)
           }
 
         case Apply(fun @ _, List(expr)) if (definitions.isBox(fun.symbol)) =>

--- a/src/library/rootdoc.txt
+++ b/src/library/rootdoc.txt
@@ -22,6 +22,6 @@ Many other packages exist.  See the complete list on the left.
 
 Identifiers in the scala package and the [[scala.Predef]] object are always in scope by default.
 
-Some of these identifiers are type aliases provided as shortcuts to commonly used classes.  For example, List is an alias for scala.collection.immutable.[[scala.collection.immutable.List]].
+Some of these identifiers are type aliases provided as shortcuts to commonly used classes.  For example, `List` is an alias for scala.collection.immutable.[[scala.collection.immutable.List]].
 
-Other aliases refer to classes providing by the underlying platform.  For example, on the JVM, String is an alias for java.lang.String.
+Other aliases refer to classes provided by the underlying platform.  For example, on the JVM, `String` is an alias for `java.lang.String`.

--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -468,7 +468,7 @@ object Array extends FallbackArrayBuilding {
  *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_38.html#anchor "The Scala 2.8 Collections' API"]]
  *  section on `Array` by Martin Odersky for more information.
  *  @define coll array
- *  @define Coll Array
+ *  @define Coll `Array`
  *  @define orderDependent
  *  @define orderDependentFold
  *  @define mayNotTerminateInf

--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -83,7 +83,7 @@ object Option {
  *  @define p `p`
  *  @define f `f`
  *  @define coll option
- *  @define Coll Option
+ *  @define Coll `Option`
  *  @define orderDependent
  *  @define orderDependentFold
  *  @define mayNotTerminateInf

--- a/src/library/scala/collection/BitSet.scala
+++ b/src/library/scala/collection/BitSet.scala
@@ -22,7 +22,7 @@ trait BitSet extends SortedSet[Int]
 
 /** $factoryInfo
  *  @define coll bitset
- *  @define Coll BitSet
+ *  @define Coll `BitSet`
  */
 object BitSet extends BitSetFactory[BitSet] {
   val empty: BitSet = immutable.BitSet.empty

--- a/src/library/scala/collection/BitSetLike.scala
+++ b/src/library/scala/collection/BitSetLike.scala
@@ -30,7 +30,7 @@ import mutable.StringBuilder
  *  @version 2.8
  *  @since 2.8
  *  @define coll bitset
- *  @define Coll BitSet
+ *  @define Coll `BitSet`
  */
 trait BitSetLike[+This <: BitSetLike[This] with SortedSet[Int]] extends SortedSetLike[Int, This] { self =>
 

--- a/src/library/scala/collection/GenIterableLike.scala
+++ b/src/library/scala/collection/GenIterableLike.scala
@@ -16,7 +16,7 @@ import generic.{ CanBuildFrom => CBF, _ }
  *  This trait contains abstract methods and methods that can be implemented
  *  directly in terms of other methods.
  *
- *  @define Coll GenIterable
+ *  @define Coll `GenIterable`
  *  @define coll general iterable collection
  *
  *  @author Martin Odersky

--- a/src/library/scala/collection/GenMapLike.scala
+++ b/src/library/scala/collection/GenMapLike.scala
@@ -11,7 +11,7 @@ package scala.collection
 /** A trait for all maps upon which operations may be
  *  implemented in parallel.
  *
- *  @define Coll GenMap
+ *  @define Coll `GenMap`
  *  @define coll general map
  *  @author Martin Odersky
  *  @author Aleksandar Prokopec

--- a/src/library/scala/collection/GenTraversableLike.scala
+++ b/src/library/scala/collection/GenTraversableLike.scala
@@ -43,7 +43,7 @@ import annotation.migration
  *  @define traversableInfo
  *  This is a base trait of all kinds of Scala collections.
  *
- *  @define Coll GenTraversable
+ *  @define Coll `GenTraversable`
  *  @define coll general collection
  *  @define collectExample
  *  @tparam A    the collection element type.

--- a/src/library/scala/collection/GenTraversableOnce.scala
+++ b/src/library/scala/collection/GenTraversableOnce.scala
@@ -14,7 +14,7 @@ package scala.collection
  *  Methods in this trait are either abstract or can be implemented in terms
  *  of other methods.
  *
- *  @define Coll GenTraversableOnce
+ *  @define Coll `GenTraversableOnce`
  *  @define coll collection or iterator
  *  @define possiblyparinfo
  *  This trait may possibly have operations implemented in parallel.

--- a/src/library/scala/collection/IndexedSeq.scala
+++ b/src/library/scala/collection/IndexedSeq.scala
@@ -26,7 +26,7 @@ trait IndexedSeq[+A] extends Seq[A]
 /** $factoryInfo
  *  The current default implementation of a $Coll is a `Vector`.
  *  @define coll indexed sequence
- *  @define Coll IndexedSeq
+ *  @define Coll `IndexedSeq`
  */
 object IndexedSeq extends SeqFactory[IndexedSeq] {
   implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, IndexedSeq[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]

--- a/src/library/scala/collection/IndexedSeqLike.scala
+++ b/src/library/scala/collection/IndexedSeqLike.scala
@@ -26,7 +26,7 @@ import scala.annotation.tailrec
  *  access and length computation. They are defined in terms of abstract methods
  *  `apply` for indexing and `length`.
  *
- *  Indexed sequences do not add any new methods wrt `Seq`, but promise
+ *  Indexed sequences do not add any new methods to `Seq`, but promise
  *  efficient implementations of random access patterns.
  *
  *  @tparam A    the element type of the $coll

--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -40,7 +40,7 @@ trait Iterable[+A] extends Traversable[A]
 /** $factoryInfo
  *  The current default implementation of a $Coll is a `Vector`.
  *  @define coll iterable collection
- *  @define Coll Iterable
+ *  @define Coll `Iterable`
  */
 object Iterable extends TraversableFactory[Iterable] {
 

--- a/src/library/scala/collection/LinearSeq.scala
+++ b/src/library/scala/collection/LinearSeq.scala
@@ -26,7 +26,7 @@ trait LinearSeq[+A] extends Seq[A]
 /** $factoryInfo
  *  The current default implementation of a $Coll is a `Vector`.
  *  @define coll linear sequence
- *  @define Coll LinearSeq
+ *  @define Coll `LinearSeq`
  */
 object LinearSeq extends SeqFactory[LinearSeq] {
   implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, LinearSeq[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]

--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -33,7 +33,7 @@ trait Map[A, +B] extends Iterable[(A, B)] with GenMap[A, B] with MapLike[A, B, M
 }
 
 /** $factoryInfo
- *  @define Coll Map
+ *  @define Coll `Map`
  *  @define coll map
  */
 object Map extends MapFactory[Map] {

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -27,7 +27,7 @@ trait Seq[+A] extends PartialFunction[Int, A]
 /** $factoryInfo
  *  The current default implementation of a $Coll is a `List`.
  *  @define coll sequence
- *  @define Coll Seq
+ *  @define Coll `Seq`
  */
 object Seq extends SeqFactory[Seq] {
   /** $genericCanBuildFromInfo */

--- a/src/library/scala/collection/SeqLike.scala
+++ b/src/library/scala/collection/SeqLike.scala
@@ -45,7 +45,7 @@ import scala.math.Ordering
  *  @version 1.0, 16/07/2003
  *  @since   2.8
  *
- *  @define Coll Seq
+ *  @define Coll `Seq`
  *  @define coll sequence
  *  @define thatinfo the class of the returned collection. Where possible, `That` is
  *    the same class as the current collection class `Repr`, but this
@@ -380,8 +380,8 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
    *  $mayNotTerminateInf
    *
    *  @param elem  the element to test.
-   *  @return     `true` if this $coll has an element that is
-   *               is equal (wrt `==`) to `elem`, `false` otherwise.
+   *  @return     `true` if this $coll has an element that is equal (as
+   *              determined by `==`) to `elem`, `false` otherwise.
    */
   def contains(elem: Any): Boolean = exists (_ == elem)
 
@@ -553,8 +553,8 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
   /** Sorts this $coll according to a comparison function.
    *  $willNotTerminateInf
    *
-   *  The sort is stable. That is, elements that are equal wrt `lt` appear in the
-   *  same order in the sorted sequence as in the original.
+   *  The sort is stable. That is, elements that are equal (as determined by
+   *  `lt`) appear in the same order in the sorted sequence as in the original.
    *
    *  @param  lt  the comparison function which tests whether
    *              its first argument precedes its second argument in
@@ -592,8 +592,8 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
 
   /** Sorts this $coll according to an Ordering.
    *
-   *  The sort is stable. That is, elements that are equal wrt `lt` appear in the
-   *  same order in the sorted sequence as in the original.
+   *  The sort is stable. That is, elements that are equal (as determined by
+   *  `lt`) appear in the same order in the sorted sequence as in the original.
    *
    *  @see scala.math.Ordering
    *

--- a/src/library/scala/collection/Set.scala
+++ b/src/library/scala/collection/Set.scala
@@ -35,7 +35,7 @@ trait Set[A] extends (A => Boolean)
  *  The current default implementation of a $Coll is one of `EmptySet`, `Set1`, `Set2`, `Set3`, `Set4` in
  *  class `immutable.Set` for sets of sizes up to 4, and a `immutable.HashSet` for sets of larger sizes.
  *  @define coll set
- *  @define Coll Set
+ *  @define Coll `Set`
  */
 object Set extends SetFactory[Set] {
   def newBuilder[A] = immutable.Set.newBuilder[A]

--- a/src/library/scala/collection/concurrent/Map.scala
+++ b/src/library/scala/collection/concurrent/Map.scala
@@ -19,7 +19,7 @@ package scala.collection.concurrent
  *  @tparam A  the key type of the map
  *  @tparam B  the value type of the map
  *
- *  @define Coll ConcurrentMap
+ *  @define Coll `ConcurrentMap`
  *  @define coll concurrent map
  *  @define concurrentmapinfo
  *  This is a base trait for all Scala concurrent map implementations. It

--- a/src/library/scala/collection/generic/ArrayTagTraversableFactory.scala
+++ b/src/library/scala/collection/generic/ArrayTagTraversableFactory.scala
@@ -15,7 +15,7 @@ import language.higherKinds
  *  subclasses thereof.
  *
  *  @define coll collection
- *  @define Coll Traversable
+ *  @define Coll `Traversable`
  *  @define genericCanBuildFromInfo
  *    The standard `CanBuildFrom` instance for $Coll objects.
  *    @author Aleksandar Prokopec

--- a/src/library/scala/collection/generic/BitSetFactory.scala
+++ b/src/library/scala/collection/generic/BitSetFactory.scala
@@ -15,7 +15,7 @@ import scala.collection._
 import mutable.Builder
 
 /** @define coll collection
- *  @define Coll Traversable
+ *  @define Coll `Traversable`
  *  @define factoryInfo
  *    This object provides a set of operations to create `$Coll` values.
  *    @author Martin Odersky

--- a/src/library/scala/collection/generic/GenMapFactory.scala
+++ b/src/library/scala/collection/generic/GenMapFactory.scala
@@ -15,7 +15,7 @@ import language.higherKinds
 /** A template for companion objects of `Map` and subclasses thereof.
  *
  *  @define coll map
- *  @define Coll Map
+ *  @define Coll `Map`
  *  @define factoryInfo
  *    This object provides a set of operations needed to create `$Coll` values.
  *    @author Martin Odersky

--- a/src/library/scala/collection/generic/GenSetFactory.scala
+++ b/src/library/scala/collection/generic/GenSetFactory.scala
@@ -17,7 +17,7 @@ import language.higherKinds
 /** A template for companion objects of `Set` and subclasses thereof.
  *
  *  @define coll set
- *  @define Coll Set
+ *  @define Coll `Set`
  *  @define factoryInfo
  *    This object provides a set of operations needed to create `$Coll` values.
  *    @author Martin Odersky

--- a/src/library/scala/collection/generic/GenTraversableFactory.scala
+++ b/src/library/scala/collection/generic/GenTraversableFactory.scala
@@ -19,7 +19,7 @@ import language.higherKinds
  *  @since 2.8
  *
  *  @define coll collection
- *  @define Coll Traversable
+ *  @define Coll `Traversable`
  *  @define factoryInfo
  *    This object provides a set of operations to create `$Coll` values.
  *    @author Martin Odersky

--- a/src/library/scala/collection/generic/GenericCompanion.scala
+++ b/src/library/scala/collection/generic/GenericCompanion.scala
@@ -20,7 +20,7 @@ import language.higherKinds
  *  @author Martin Odersky
  *  @since 2.8
  *  @define coll  collection
- *  @define Coll  CC
+ *  @define Coll  `CC`
  */
 abstract class GenericCompanion[+CC[X] <: GenTraversable[X]] {
   /** The underlying collection type with unknown element type */

--- a/src/library/scala/collection/generic/GenericParCompanion.scala
+++ b/src/library/scala/collection/generic/GenericParCompanion.scala
@@ -16,7 +16,7 @@ import language.higherKinds
 /** A template class for companion objects of parallel collection classes.
  *  They should be mixed in together with `GenericCompanion` type.
  *
- *  @define Coll ParIterable
+ *  @define Coll `ParIterable`
  *  @tparam CC   the type constructor representing the collection class
  *  @since 2.8
  */

--- a/src/library/scala/collection/generic/Growable.scala
+++ b/src/library/scala/collection/generic/Growable.scala
@@ -18,7 +18,7 @@ package generic
  *  @version 2.8
  *  @since   2.8
  *  @define coll growable collection
- *  @define Coll Growable
+ *  @define Coll `Growable`
  *  @define add  add
  *  @define Add  add
  */

--- a/src/library/scala/collection/generic/ImmutableSortedMapFactory.scala
+++ b/src/library/scala/collection/generic/ImmutableSortedMapFactory.scala
@@ -16,7 +16,7 @@ import language.higherKinds
 /** A template for companion objects of `SortedMap` and subclasses thereof.
  *
  *  @since 2.8
- *  @define Coll SortedMap
+ *  @define Coll `SortedMap`
  *  @define coll sorted map
  *  @define factoryInfo
  *    This object provides a set of operations needed to create sorted maps of type `$Coll`.

--- a/src/library/scala/collection/generic/ImmutableSortedSetFactory.scala
+++ b/src/library/scala/collection/generic/ImmutableSortedSetFactory.scala
@@ -16,8 +16,8 @@ import language.higherKinds
 /** A template for companion objects of `SortedSet` and subclasses thereof.
  *
  *  @since 2.8
- *  @define Coll immutable.SortedSet
- *  @define coll immutable sorted
+ *  @define Coll `immutable.SortedSet`
+ *  @define coll immutable sorted set
  *  @define factoryInfo
  *    This object provides a set of operations needed to create sorted sets of type `$Coll`.
  *    @author Martin Odersky

--- a/src/library/scala/collection/generic/MutableSortedSetFactory.scala
+++ b/src/library/scala/collection/generic/MutableSortedSetFactory.scala
@@ -13,8 +13,8 @@ import scala.collection.mutable.{ Builder, GrowingBuilder }
 import language.higherKinds
 
 /**
- * @define Coll mutable.SortedSet
- * @define coll mutable sorted
+ * @define Coll `mutable.SortedSet`
+ * @define coll mutable sorted set
  *
  * @author Lucien Pereira
  *

--- a/src/library/scala/collection/generic/ParFactory.scala
+++ b/src/library/scala/collection/generic/ParFactory.scala
@@ -17,7 +17,7 @@ import language.higherKinds
  *  operations to create `$Coll` objects.
  *
  *  @define coll parallel collection
- *  @define Coll ParIterable
+ *  @define Coll `ParIterable`
  *  @since 2.8
  */
 abstract class ParFactory[CC[X] <: ParIterable[X] with GenericParTemplate[X, CC]]

--- a/src/library/scala/collection/generic/ParMapFactory.scala
+++ b/src/library/scala/collection/generic/ParMapFactory.scala
@@ -19,7 +19,7 @@ import language.higherKinds
  *  to create `$Coll` objects.
  *
  *  @define coll parallel map
- *  @define Coll ParMap
+ *  @define Coll `ParMap`
  *  @author Aleksandar Prokopec
  *  @since 2.8
  */

--- a/src/library/scala/collection/generic/Shrinkable.scala
+++ b/src/library/scala/collection/generic/Shrinkable.scala
@@ -17,7 +17,7 @@ package generic
  *  @version 2.8
  *  @since   2.8
  *  @define coll shrinkable collection
- *  @define Coll Shrinkable
+ *  @define Coll `Shrinkable`
  */
 trait Shrinkable[-A] {
 

--- a/src/library/scala/collection/immutable/BitSet.scala
+++ b/src/library/scala/collection/immutable/BitSet.scala
@@ -20,7 +20,7 @@ import mutable.{ Builder, SetBuilder }
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#immutable_bitsets "Scala's Collection Library overview"]]
  *  section on `Immutable BitSets` for more information.
  *
- *  @define Coll immutable.BitSet
+ *  @define Coll `immutable.BitSet`
  *  @define coll immutable bitset
  */
 @SerialVersionUID(1611436763290191562L)
@@ -63,7 +63,7 @@ abstract class BitSet extends scala.collection.AbstractSet[Int]
 }
 
 /** $factoryInfo
- *  @define Coll immutable.BitSet
+ *  @define Coll `immutable.BitSet`
  *  @define coll immutable bitset
  */
 object BitSet extends BitSetFactory[BitSet] {

--- a/src/library/scala/collection/immutable/GenSeq.scala.disabled
+++ b/src/library/scala/collection/immutable/GenSeq.scala.disabled
@@ -25,7 +25,7 @@ import mutable.Builder
  * 
  *  The class adds an `update` method to `collection.Seq`.
  *  
- *  @define Coll mutable.Seq
+ *  @define Coll `mutable.Seq`
  *  @define coll mutable sequence
  */
 trait GenSeq[+A] extends GenIterable[A] 

--- a/src/library/scala/collection/immutable/GenSet.scala.disabled
+++ b/src/library/scala/collection/immutable/GenSet.scala.disabled
@@ -24,7 +24,7 @@ import mutable.Builder
  *
  *  @since 1.0
  *  @author Matthias Zenger
- *  @define Coll mutable.Set
+ *  @define Coll `mutable.Set`
  *  @define coll mutable set
  */
 trait GenSet[A] extends GenIterable[A]

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -27,7 +27,7 @@ import parallel.immutable.ParHashMap
  *  @since   2.3
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#hash_tries "Scala's Collection Library overview"]]
  *  section on `Hash Tries` for more information.
- *  @define Coll immutable.HashMap
+ *  @define Coll `immutable.HashMap`
  *  @define coll immutable hash map
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
@@ -96,7 +96,7 @@ class HashMap[A, +B] extends AbstractMap[A, B]
 }
 
 /** $factoryInfo
- *  @define Coll immutable.HashMap
+ *  @define Coll `immutable.HashMap`
  *  @define coll immutable hash map
  *
  *  @author  Tiark Rompf

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -26,7 +26,7 @@ import collection.parallel.immutable.ParHashSet
  *  @author  Tiark Rompf
  *  @version 2.8
  *  @since   2.3
- *  @define Coll immutable.HashSet
+ *  @define Coll `immutable.HashSet`
  *  @define coll immutable hash set
  */
 @SerialVersionUID(2L)
@@ -85,12 +85,12 @@ class HashSet[A] extends AbstractSet[A]
 }
 
 /** $factoryInfo
- *  @define Coll immutable.HashSet
+ *  @define Coll `immutable.HashSet`
  *  @define coll immutable hash set
  *
  *  @author  Tiark Rompf
  *  @since   2.3
- *  @define Coll immutable.HashSet
+ *  @define Coll `immutable.HashSet`
  *  @define coll immutable hash set
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf

--- a/src/library/scala/collection/immutable/IndexedSeq.scala
+++ b/src/library/scala/collection/immutable/IndexedSeq.scala
@@ -29,7 +29,7 @@ trait IndexedSeq[+A] extends Seq[A]
 /** $factoryInfo
  *  The current default implementation of a $Coll is a `Vector`.
  *  @define coll indexed sequence
- *  @define Coll IndexedSeq
+ *  @define Coll `IndexedSeq`
  */
 object IndexedSeq extends SeqFactory[IndexedSeq] {
   class Impl[A](buf: ArrayBuffer[A]) extends AbstractSeq[A] with IndexedSeq[A] with Serializable {

--- a/src/library/scala/collection/immutable/IntMap.scala
+++ b/src/library/scala/collection/immutable/IntMap.scala
@@ -36,7 +36,7 @@ import IntMapUtils._
 
 /** A companion object for integer maps.
  *
- *  @define Coll  IntMap
+ *  @define Coll  `IntMap`
  *  @define mapCanBuildFromInfo
  *    The standard `CanBuildFrom` instance for `$Coll` objects.
  *    The created value is an instance of class `MapCanBuildFrom`.
@@ -150,7 +150,7 @@ import IntMap._
  *  @tparam T    type of the values associated with integer keys.
  *
  *  @since 2.7
- *  @define Coll immutable.IntMap
+ *  @define Coll `immutable.IntMap`
  *  @define coll immutable integer map
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf

--- a/src/library/scala/collection/immutable/Iterable.scala
+++ b/src/library/scala/collection/immutable/Iterable.scala
@@ -18,7 +18,7 @@ import parallel.immutable.ParIterable
 /** A base trait for iterable collections that are guaranteed immutable.
  *  $iterableInfo
  *
- *  @define Coll immutable.Iterable
+ *  @define Coll `immutable.Iterable`
  *  @define coll immutable iterable collection
  */
 trait Iterable[+A] extends Traversable[A]
@@ -34,7 +34,7 @@ trait Iterable[+A] extends Traversable[A]
 }
 
 /** $factoryInfo
- *  @define Coll immutable.Iterable
+ *  @define Coll `immutable.Iterable`
  *  @define coll immutable iterable collection
  */
 object Iterable extends TraversableFactory[Iterable] {

--- a/src/library/scala/collection/immutable/LinearSeq.scala
+++ b/src/library/scala/collection/immutable/LinearSeq.scala
@@ -29,7 +29,7 @@ trait LinearSeq[+A] extends Seq[A]
 /** $factoryInfo
  *  The current default implementation of a $Coll is a `List`.
  *  @define coll immutable linear sequence
- *  @define Coll immutable.LinearSeq
+ *  @define Coll `immutable.LinearSeq`
  */
 object LinearSeq extends SeqFactory[LinearSeq] {
   implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, LinearSeq[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -141,7 +141,7 @@ sealed abstract class List[+A] extends AbstractSeq[A]
 
   /** Builds a new list by applying a function to all elements of this list.
    *  Like `xs map f`, but returns `xs` unchanged if function
-   *  `f` maps all elements to themselves (wrt eq).
+   *  `f` maps all elements to themselves (as determined by `eq`).
    *
    *  @param f      the function to apply to each element.
    *  @tparam B     the element type of the returned collection.
@@ -382,7 +382,7 @@ final case class ::[B](private var hd: B, private[scala] var tl: List[B]) extend
 
 /** $factoryInfo
  *  @define coll list
- *  @define Coll List
+ *  @define Coll `List`
  */
 object List extends SeqFactory[List] {
 

--- a/src/library/scala/collection/immutable/LongMap.scala
+++ b/src/library/scala/collection/immutable/LongMap.scala
@@ -36,7 +36,7 @@ import LongMapUtils._
 
 /** A companion object for long maps.
  *
- *  @define Coll  LongMap
+ *  @define Coll  `LongMap`
  *  @define mapCanBuildFromInfo
  *    The standard `CanBuildFrom` instance for `$Coll` objects.
  *    The created value is an instance of class `MapCanBuildFrom`.
@@ -147,7 +147,7 @@ import LongMap._;
  *  @tparam T      type of the values associated with the long keys.
  *
  *  @since 2.7
- *  @define Coll immutable.LongMap
+ *  @define Coll `immutable.LongMap`
  *  @define coll immutable long integer map
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -66,7 +66,7 @@ trait Map[A, +B] extends Iterable[(A, B)]
 }
 
 /** $factoryInfo
- *  @define Coll immutable.Map
+ *  @define Coll `immutable.Map`
  *  @define coll immutable map
  */
 object Map extends ImmutableMapFactory[Map] {

--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -34,7 +34,7 @@ import generic._
  *
  *  @author  Paul Phillips
  *  @version 2.8
- *  @define Coll NumericRange
+ *  @define Coll `NumericRange`
  *  @define coll numeric range
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf

--- a/src/library/scala/collection/immutable/PagedSeq.scala
+++ b/src/library/scala/collection/immutable/PagedSeq.scala
@@ -119,7 +119,7 @@ import PagedSeq._
  *
  *  @author Martin Odersky
  *  @since  2.7
- *  @define Coll PagedSeq
+ *  @define Coll `PagedSeq`
  *  @define coll paged sequence
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf

--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -30,7 +30,7 @@ import annotation.tailrec
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#immutable_queues "Scala's Collection Library overview"]]
  *  section on `Immutable Queues` for more information.
  *
- *  @define Coll immutable.Queue
+ *  @define Coll `immutable.Queue`
  *  @define coll immutable queue
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
@@ -131,7 +131,7 @@ class Queue[+A] protected(protected val in: List[A], protected val out: List[A])
 }
 
 /** $factoryInfo
- *  @define Coll immutable.Queue
+ *  @define Coll `immutable.Queue`
  *  @define coll immutable queue
  */
 object Queue extends SeqFactory[Queue] {

--- a/src/library/scala/collection/immutable/Seq.scala
+++ b/src/library/scala/collection/immutable/Seq.scala
@@ -19,7 +19,7 @@ import parallel.immutable.ParSeq
  *  that are guaranteed immutable.
  *
  *  $seqInfo
- *  @define Coll immutable.Seq
+ *  @define Coll `immutable.Seq`
  *  @define coll immutable sequence
  */
 trait Seq[+A] extends Iterable[A]
@@ -36,7 +36,7 @@ trait Seq[+A] extends Iterable[A]
 }
 
 /** $factoryInfo
- *  @define Coll immutable.Seq
+ *  @define Coll `immutable.Seq`
  *  @define coll immutable sequence
  */
 object Seq extends SeqFactory[Seq] {

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -21,7 +21,7 @@ import parallel.immutable.ParSet
  *  @since 1.0
  *  @author Matthias Zenger
  *  @author Martin Odersky
- *  @define Coll immutable.Set
+ *  @define Coll `immutable.Set`
  *  @define coll immutable set
  */
 trait Set[A] extends Iterable[A]
@@ -38,7 +38,7 @@ trait Set[A] extends Iterable[A]
 }
 
 /** $factoryInfo
- *  @define Coll immutable.Set
+ *  @define Coll `immutable.Set`
  *  @define coll immutable set
  */
 object Set extends ImmutableSetFactory[Set] {

--- a/src/library/scala/collection/immutable/SortedSet.scala
+++ b/src/library/scala/collection/immutable/SortedSet.scala
@@ -21,7 +21,7 @@ import mutable.Builder
  *  @author Martin Odersky
  *  @version 2.8
  *  @since   2.4
- *  @define Coll immutable.SortedSet
+ *  @define Coll `immutable.SortedSet`
  *  @define coll immutable sorted set
  */
 trait SortedSet[A] extends Set[A] with scala.collection.SortedSet[A] with SortedSetLike[A, SortedSet[A]] {
@@ -30,7 +30,7 @@ trait SortedSet[A] extends Set[A] with scala.collection.SortedSet[A] with Sorted
 }
 
 /** $factoryInfo
- *  @define Coll immutable.SortedSet
+ *  @define Coll `immutable.SortedSet`
  *  @define coll immutable sorted set
  */
 object SortedSet extends ImmutableSortedSetFactory[SortedSet] {

--- a/src/library/scala/collection/immutable/Stack.scala
+++ b/src/library/scala/collection/immutable/Stack.scala
@@ -13,7 +13,7 @@ import generic._
 import mutable.{ ArrayBuffer, Builder }
 
 /** $factoryInfo
- *  @define Coll immutable.Stack
+ *  @define Coll `immutable.Stack`
  *  @define coll immutable stack
  */
 object Stack extends SeqFactory[Stack] {
@@ -37,7 +37,7 @@ object Stack extends SeqFactory[Stack] {
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#immutable_stacks "Scala's Collection Library overview"]]
  *  section on `Immutable stacks` for more information.
  *
- *  @define Coll immutable.Stack
+ *  @define Coll `immutable.Stack`
  *  @define coll immutable stack
  *  @define orderDependent
  *  @define orderDependentFold

--- a/src/library/scala/collection/immutable/Stream.scala
+++ b/src/library/scala/collection/immutable/Stream.scala
@@ -177,7 +177,7 @@ import language.implicitConversions
  *  section on `Streams` for more information.
 
  *  @define naturalsEx def naturalsFrom(i: Int): Stream[Int] = i #:: naturalsFrom(i + 1)
- *  @define Coll Stream
+ *  @define Coll `Stream`
  *  @define coll stream
  *  @define orderDependent
  *  @define orderDependentFold
@@ -805,9 +805,9 @@ self =>
     these
   }
 
-  /** Builds a new stream from this stream in which any duplicates (wrt to ==)
-   * have been removed.  Among duplicate elements, only the first one is
-   * retained in the resulting `Stream`.
+  /** Builds a new stream from this stream in which any duplicates (as
+   * determined by `==`) have been removed. Among duplicate elements, only the
+   * first one is retained in the resulting `Stream`.
    *
    * @return A new `Stream` representing the result of applying distinctness to
    * the original `Stream`.

--- a/src/library/scala/collection/immutable/StringLike.scala
+++ b/src/library/scala/collection/immutable/StringLike.scala
@@ -33,7 +33,7 @@ import StringLike._
  *  @tparam Repr   The type of the actual collection inheriting `StringLike`.
  *
  *  @since 2.8
- *  @define Coll String
+ *  @define Coll `String`
  *  @define coll string
  *  @define orderDependent
  *  @define orderDependentFold

--- a/src/library/scala/collection/immutable/StringOps.scala
+++ b/src/library/scala/collection/immutable/StringOps.scala
@@ -25,7 +25,7 @@ import mutable.StringBuilder
  *  @param repr     the actual representation of this string operations object.
  *
  *  @since 2.8
- *  @define Coll StringOps
+ *  @define Coll `StringOps`
  *  @define coll string
  */
 final class StringOps(override val repr: String) extends AnyVal with StringLike[String] {

--- a/src/library/scala/collection/immutable/Traversable.scala
+++ b/src/library/scala/collection/immutable/Traversable.scala
@@ -30,7 +30,7 @@ trait Traversable[+A] extends scala.collection.Traversable[A]
 /** $factoryInfo
  *  The current default implementation of a $Coll is a `Vector`.
  *  @define coll immutable traversable collection
- *  @define Coll immutable.Traversable
+ *  @define Coll `immutable.Traversable`
  */
 object Traversable extends TraversableFactory[Traversable] {
   implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Traversable[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -16,7 +16,7 @@ import immutable.{RedBlackTree => RB}
 import mutable.{ Builder, SetBuilder }
 
 /** $factoryInfo
- *  @define Coll immutable.TreeSet
+ *  @define Coll `immutable.TreeSet`
  *  @define coll immutable tree set
  */
 object TreeSet extends ImmutableSortedSetFactory[TreeSet] {
@@ -40,7 +40,7 @@ object TreeSet extends ImmutableSortedSetFactory[TreeSet] {
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#redblack_trees "Scala's Collection Library overview"]]
  *  section on `Red-Black Trees` for more information.
  *
- *  @define Coll immutable.TreeSet
+ *  @define Coll `immutable.TreeSet`
  *  @define coll immutable tree set
  *  @define orderDependent
  *  @define orderDependentFold

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -40,7 +40,7 @@ object Vector extends SeqFactory[Vector] {
  *
  *  @tparam A the element type
  *
- *  @define Coll Vector
+ *  @define Coll `Vector`
  *  @define coll vector
  *  @define thatinfo the class of the returned collection. In the standard library configuration,
  *    `That` is always `Vector[B]` because an implicit of type `CanBuildFrom[Vector, B, That]`

--- a/src/library/scala/collection/immutable/WrappedString.scala
+++ b/src/library/scala/collection/immutable/WrappedString.scala
@@ -25,7 +25,7 @@ import mutable.{Builder, StringBuilder}
  *  @param self    a string contained within this wrapped string
  *
  *  @since 2.8
- *  @define Coll WrappedString
+ *  @define Coll `WrappedString`
  *  @define coll wrapped string
  */
 class WrappedString(val self: String) extends AbstractSeq[Char] with IndexedSeq[Char] with StringLike[WrappedString] {

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -29,7 +29,7 @@ import parallel.mutable.ParArray
  *
  *  @tparam A    the type of this arraybuffer's elements.
  *
- *  @define Coll ArrayBuffer
+ *  @define Coll `ArrayBuffer`
  *  @define coll arraybuffer
  *  @define thatinfo the class of the returned collection. In the standard library configuration,
  *    `That` is always `ArrayBuffer[B]` because an implicit of type `CanBuildFrom[ArrayBuffer, B, ArrayBuffer[B]]`
@@ -187,7 +187,7 @@ class ArrayBuffer[A](override protected val initialSize: Int)
  *
  *  $factoryInfo
  *  @define coll array buffer
- *  @define Coll ArrayBuffer
+ *  @define Coll `ArrayBuffer`
  */
 object ArrayBuffer extends SeqFactory[ArrayBuffer] {
   /** $genericCanBuildFromInfo */

--- a/src/library/scala/collection/mutable/ArrayLike.scala
+++ b/src/library/scala/collection/mutable/ArrayLike.scala
@@ -18,7 +18,7 @@ import generic._
  *  @tparam A     type of the elements contained in the array like object.
  *  @tparam Repr  the type of the actual collection containing the elements.
  *
- *  @define Coll ArrayLike
+ *  @define Coll `ArrayLike`
  *  @version 2.8
  *  @since   2.8
  */

--- a/src/library/scala/collection/mutable/ArrayOps.scala
+++ b/src/library/scala/collection/mutable/ArrayOps.scala
@@ -30,7 +30,7 @@ import parallel.mutable.ParArray
  *
  *  @tparam T   type of the elements contained in this array.
  *
- *  @define Coll ArrayOps
+ *  @define Coll `ArrayOps`
  *  @define orderDependent
  *  @define orderDependentFold
  *  @define mayNotTerminateInf

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -27,7 +27,7 @@ import parallel.mutable.ParArray
  *  @tparam A      type of the elements contained in this array sequence.
  *  @param length  the length of the underlying array.
  *
- *  @define Coll ArraySeq
+ *  @define Coll `ArraySeq`
  *  @define coll array sequence
  *  @define thatinfo the class of the returned collection. In the standard library configuration,
  *    `That` is always `ArraySeq[B]` because an implicit of type `CanBuildFrom[ArraySeq, B, ArraySeq[B]]`
@@ -93,7 +93,7 @@ extends AbstractSeq[A]
 
 /** $factoryInfo
  *  @define coll array sequence
- *  @define Coll ArraySeq
+ *  @define Coll `ArraySeq`
  */
 object ArraySeq extends SeqFactory[ArraySeq] {
   /** $genericCanBuildFromInfo */

--- a/src/library/scala/collection/mutable/ArrayStack.scala
+++ b/src/library/scala/collection/mutable/ArrayStack.scala
@@ -15,7 +15,7 @@ import generic._
  *
  *  $factoryInfo
  *  @define coll array stack
- *  @define Coll ArrayStack
+ *  @define Coll `ArrayStack`
  */
 object ArrayStack extends SeqFactory[ArrayStack] {
   implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, ArrayStack[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
@@ -51,7 +51,7 @@ object ArrayStack extends SeqFactory[ArrayStack] {
  *
  *  @tparam T    type of the elements contained in this array stack.
  *
- *  @define Coll ArrayStack
+ *  @define Coll `ArrayStack`
  *  @define coll array stack
  *  @define orderDependent
  *  @define orderDependentFold

--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -21,7 +21,7 @@ import BitSetLike.{LogWL, updateArray}
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#mutable_bitsets "Scala's Collection Library overview"]]
  *  section on `Mutable Bitsets` for more information.
  *
- *  @define Coll BitSet
+ *  @define Coll `BitSet`
  *  @define coll bitset
  *  @define thatinfo the class of the returned collection. In the standard library configuration,
  *    `That` is always `BitSet[B]` because an implicit of type `CanBuildFrom[BitSet, B, BitSet]`
@@ -114,7 +114,7 @@ class BitSet(protected var elems: Array[Long]) extends AbstractSet[Int]
 
 /** $factoryInfo
  *  @define coll bitset
- *  @define Coll BitSet
+ *  @define Coll `BitSet`
  */
 object BitSet extends BitSetFactory[BitSet] {
   def empty: BitSet = new BitSet

--- a/src/library/scala/collection/mutable/Buffer.scala
+++ b/src/library/scala/collection/mutable/Buffer.scala
@@ -25,7 +25,7 @@ import generic._
  *
  *  @tparam A    type of the elements contained in this buffer.
  *
- *  @define Coll Buffer
+ *  @define Coll `Buffer`
  *  @define coll buffer
  */
 @cloneable
@@ -37,7 +37,7 @@ trait Buffer[A] extends Seq[A]
 
 /** $factoryInfo
  *  @define coll buffer
- *  @define Coll Buffer
+ *  @define Coll `Buffer`
  */
 object Buffer extends SeqFactory[Buffer] {
   implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Buffer[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]

--- a/src/library/scala/collection/mutable/BufferProxy.scala
+++ b/src/library/scala/collection/mutable/BufferProxy.scala
@@ -25,7 +25,7 @@ import script._
  *
  *  @tparam A     type of the elements the buffer proxy contains.
  *
- *  @define Coll BufferProxy
+ *  @define Coll `BufferProxy`
  *  @define coll buffer proxy
  */
 trait BufferProxy[A] extends Buffer[A] with Proxy {

--- a/src/library/scala/collection/mutable/ConcurrentMap.scala
+++ b/src/library/scala/collection/mutable/ConcurrentMap.scala
@@ -20,7 +20,7 @@ package mutable
  *  @tparam A  the key type of the map
  *  @tparam B  the value type of the map
  *
- *  @define Coll ConcurrentMap
+ *  @define Coll `ConcurrentMap`
  *  @define coll concurrent map
  *  @define concurrentmapinfo
  *  This is a base trait for all Scala concurrent map implementations. It

--- a/src/library/scala/collection/mutable/DoubleLinkedList.scala
+++ b/src/library/scala/collection/mutable/DoubleLinkedList.scala
@@ -26,7 +26,7 @@ import generic._
  *
  *  @tparam A     the type of the elements contained in this double linked list.
  *
- *  @define Coll DoubleLinkedList
+ *  @define Coll `DoubleLinkedList`
  *  @define coll double linked list
  *  @define thatinfo the class of the returned collection. In the standard library configuration,
  *    `That` is always `DoubleLinkedList[B]` because an implicit of type `CanBuildFrom[DoubleLinkedList, B, DoubleLinkedList[B]]`
@@ -67,7 +67,7 @@ class DoubleLinkedList[A]() extends AbstractSeq[A]
 
 /** $factoryInfo
  *  @define coll double linked list
- *  @define Coll DoubleLinkedList
+ *  @define Coll `DoubleLinkedList`
  */
 object DoubleLinkedList extends SeqFactory[DoubleLinkedList] {
   /** $genericCanBuildFromInfo */

--- a/src/library/scala/collection/mutable/DoubleLinkedListLike.scala
+++ b/src/library/scala/collection/mutable/DoubleLinkedListLike.scala
@@ -52,7 +52,7 @@ import annotation.migration
  *  @tparam A    type of the elements contained in the double linked list
  *  @tparam This the type of the actual linked list holding the elements
  *
- *  @define Coll DoubleLinkedList
+ *  @define Coll `DoubleLinkedList`
  *  @define coll double linked list
  */
 trait DoubleLinkedListLike[A, This <: Seq[A] with DoubleLinkedListLike[A, This]] extends SeqLike[A, This] with LinkedListLike[A, This] { self =>

--- a/src/library/scala/collection/mutable/GenSeq.scala.disabled
+++ b/src/library/scala/collection/mutable/GenSeq.scala.disabled
@@ -24,7 +24,7 @@ import generic._
  * 
  *  The class adds an `update` method to `collection.Seq`.
  *  
- *  @define Coll mutable.Seq
+ *  @define Coll `mutable.Seq`
  *  @define coll mutable sequence
  */
 trait GenSeq[A] extends GenIterable[A] 

--- a/src/library/scala/collection/mutable/GenSet.scala.disabled
+++ b/src/library/scala/collection/mutable/GenSet.scala.disabled
@@ -24,7 +24,7 @@ import generic._
  *
  *  @since 1.0
  *  @author Matthias Zenger
- *  @define Coll mutable.Set
+ *  @define Coll `mutable.Set`
  *  @define coll mutable set
  */
 trait GenSet[A] extends GenIterable[A]

--- a/src/library/scala/collection/mutable/GrowingBuilder.scala
+++ b/src/library/scala/collection/mutable/GrowingBuilder.scala
@@ -18,7 +18,7 @@ import generic._
  *  @version 2.8
  *  @since 2.8
  *
- *  @define Coll GrowingBuilder
+ *  @define Coll `GrowingBuilder`
  *  @define coll growing builder
  */
 class GrowingBuilder[Elem, To <: Growable[Elem]](empty: To) extends Builder[Elem, To] {

--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -21,7 +21,7 @@ import scala.collection.parallel.mutable.ParHashMap
  *  @tparam A    the type of the keys contained in this hash map.
  *  @tparam B    the type of the values assigned to keys in this hash map.
  *
- *  @define Coll mutable.HashMap
+ *  @define Coll `mutable.HashMap`
  *  @define coll mutable hash map
  *  @define thatinfo the class of the returned collection. In the standard library configuration,
  *    `That` is always `HashMap[A, B]` if the elements contained in the resulting collection are
@@ -138,7 +138,7 @@ extends AbstractMap[A, B]
 }
 
 /** $factoryInfo
- *  @define Coll mutable.HashMap
+ *  @define Coll `mutable.HashMap`
  *  @define coll mutable hash map
  */
 object HashMap extends MutableMapFactory[HashMap] {

--- a/src/library/scala/collection/mutable/HashSet.scala
+++ b/src/library/scala/collection/mutable/HashSet.scala
@@ -25,7 +25,7 @@ import collection.parallel.mutable.ParHashSet
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#hash_tables "Scala's Collection Library overview"]]
  *  section on `Hash Tables` for more information.
  *
- *  @define Coll mutable.HashSet
+ *  @define Coll `mutable.HashSet`
  *  @define coll mutable hash set
  *  @define thatinfo the class of the returned collection. In the standard library configuration,
  *    `That` is always `HashSet[B]` because an implicit of type `CanBuildFrom[HashSet, B, HashSet[B]]`
@@ -98,7 +98,7 @@ extends AbstractSet[A]
 }
 
 /** $factoryInfo
- *  @define Coll mutable.HashSet
+ *  @define Coll `mutable.HashSet`
  *  @define coll mutable hash set
  */
 object HashSet extends MutableSetFactory[HashSet] {

--- a/src/library/scala/collection/mutable/IndexedSeq.scala
+++ b/src/library/scala/collection/mutable/IndexedSeq.scala
@@ -29,7 +29,7 @@ trait IndexedSeq[A] extends Seq[A]
 /** $factoryInfo
  *  The current default implementation of a $Coll is an `ArrayBuffer`.
  *  @define coll mutable indexed sequence
- *  @define Coll mutable.IndexedSeq
+ *  @define Coll `mutable.IndexedSeq`
  */
 object IndexedSeq extends SeqFactory[IndexedSeq] {
   implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, IndexedSeq[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]

--- a/src/library/scala/collection/mutable/IndexedSeqLike.scala
+++ b/src/library/scala/collection/mutable/IndexedSeqLike.scala
@@ -27,7 +27,7 @@ import generic._
  *  @tparam A    the element type of the $coll
  *  @tparam Repr the type of the actual $coll containing the elements.
  *
- *  @define Coll IndexedSeq
+ *  @define Coll `IndexedSeq`
  *  @define coll mutable indexed sequence
  *  @define indexedSeqInfo
  *  @author Martin Odersky

--- a/src/library/scala/collection/mutable/Iterable.scala
+++ b/src/library/scala/collection/mutable/Iterable.scala
@@ -29,7 +29,7 @@ trait Iterable[A] extends Traversable[A]
 /** $factoryInfo
  *  The current default implementation of a $Coll is an `ArrayBuffer`.
  *  @define coll mutable iterable collection
- *  @define Coll mutable.Iterable
+ *  @define Coll `mutable.Iterable`
  */
 object Iterable extends TraversableFactory[Iterable] {
   implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Iterable[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]

--- a/src/library/scala/collection/mutable/LinearSeq.scala
+++ b/src/library/scala/collection/mutable/LinearSeq.scala
@@ -17,7 +17,7 @@ import generic._
  *  that can be mutated.
  *  $linearSeqInfo
  *
- *  @define Coll LinearSeq
+ *  @define Coll `LinearSeq`
  *  @define coll linear sequence
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#mutable_lists "Scala's Collection Library overview"]]
  *  section on `Mutable Lists` for more information.
@@ -33,7 +33,7 @@ trait LinearSeq[A] extends Seq[A]
 /** $factoryInfo
  *  The current default implementation of a $Coll is a `MutableList`.
  *  @define coll mutable linear sequence
- *  @define Coll mutable.LinearSeq
+ *  @define Coll `mutable.LinearSeq`
  */
 object LinearSeq extends SeqFactory[LinearSeq] {
   implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, LinearSeq[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]

--- a/src/library/scala/collection/mutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/mutable/LinkedHashMap.scala
@@ -14,7 +14,7 @@ package mutable
 import generic._
 
 /** $factoryInfo
- *  @define Coll LinkedHashMap
+ *  @define Coll `LinkedHashMap`
  *  @define coll linked hash map
  */
 object LinkedHashMap extends MutableMapFactory[LinkedHashMap] {
@@ -28,7 +28,7 @@ object LinkedHashMap extends MutableMapFactory[LinkedHashMap] {
  *  @tparam A    the type of the keys contained in this hash map.
  *  @tparam B    the type of the values assigned to keys in this hash map.
  *
- *  @define Coll LinkedHashMap
+ *  @define Coll `LinkedHashMap`
  *  @define coll linked hash map
  *  @define thatinfo the class of the returned collection. In the standard library configuration,
  *    `That` is always `LinkedHashMap[A, B]` if the elements contained in the resulting collection are

--- a/src/library/scala/collection/mutable/LinkedHashSet.scala
+++ b/src/library/scala/collection/mutable/LinkedHashSet.scala
@@ -24,7 +24,7 @@ import generic._
  *
  *  @tparam A     the type of the elements contained in this set.
  *
- *  @define Coll LinkedHashSet
+ *  @define Coll `LinkedHashSet`
  *  @define coll linked hash set
  *  @define thatinfo the class of the returned collection. In the standard library configuration,
  *    `That` is always `LinkedHashSet[B]` because an implicit of type `CanBuildFrom[LinkedHashSet, B, LinkedHashSet[B]]`
@@ -87,7 +87,7 @@ class LinkedHashSet[A] extends AbstractSet[A]
 }
 
 /** $factoryInfo
- *  @define Coll LinkedHashSet
+ *  @define Coll `LinkedHashSet`
  *  @define coll linked hash set
  */
 object LinkedHashSet extends MutableSetFactory[LinkedHashSet] {

--- a/src/library/scala/collection/mutable/LinkedList.scala
+++ b/src/library/scala/collection/mutable/LinkedList.scala
@@ -40,7 +40,7 @@ import generic._
   *
   *  @constructor Creates an "empty" list, defined as a single node with no data element and next pointing to itself.
 
-  *  @define Coll LinkedList
+  *  @define Coll `LinkedList`
   *  @define coll linked list
   *  @define thatinfo the class of the returned collection. In the standard library configuration,
   *    `That` is always `LinkedList[B]` because an implicit of type `CanBuildFrom[LinkedList, B, LinkedList[B]]`
@@ -109,7 +109,7 @@ class LinkedList[A]() extends AbstractSeq[A]
 }
 
 /** $factoryInfo
- *  @define Coll LinkedList
+ *  @define Coll `LinkedList`
  *  @define coll linked list
  */
 object LinkedList extends SeqFactory[LinkedList] {

--- a/src/library/scala/collection/mutable/LinkedListLike.scala
+++ b/src/library/scala/collection/mutable/LinkedListLike.scala
@@ -29,7 +29,7 @@ import annotation.tailrec
  *  @tparam A    type of the elements contained in the linked list
  *  @tparam This the type of the actual linked list holding the elements
  *
- *  @define Coll LinkedList
+ *  @define Coll `LinkedList`
  *  @define coll linked list
  *
  *  @define singleLinkedListExample

--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -27,7 +27,7 @@ import java.io._
  *
  *  @tparam A    the type of this list buffer's elements.
  *
- *  @define Coll ListBuffer
+ *  @define Coll `ListBuffer`
  *  @define coll list buffer
  *  @define thatinfo the class of the returned collection. In the standard library configuration,
  *    `That` is always `ListBuffer[B]` because an implicit of type `CanBuildFrom[ListBuffer, B, ListBuffer[B]]`
@@ -425,7 +425,7 @@ final class ListBuffer[A]
 }
 
 /** $factoryInfo
- *  @define Coll ListBuffer
+ *  @define Coll `ListBuffer`
  *  @define coll list buffer
  */
 object ListBuffer extends SeqFactory[ListBuffer] {

--- a/src/library/scala/collection/mutable/ListMap.scala
+++ b/src/library/scala/collection/mutable/ListMap.scala
@@ -18,7 +18,7 @@ import generic._
  *  @tparam A    the type of the keys contained in this list map.
  *  @tparam B    the type of the values assigned to keys in this list map.
  *
- *  @define Coll mutable.ListMap
+ *  @define Coll `mutable.ListMap`
  *  @define coll mutable list map
  *  @define thatinfo the class of the returned collection. In the standard library configuration,
  *    `That` is always `ListMap[A, B]` if the elements contained in the resulting collection are
@@ -60,7 +60,7 @@ extends AbstractMap[A, B]
 }
 
 /** $factoryInfo
- *  @define Coll mutable.ListMap
+ *  @define Coll `mutable.ListMap`
  *  @define coll mutable list map
  */
 object ListMap extends MutableMapFactory[ListMap] {

--- a/src/library/scala/collection/mutable/Map.scala
+++ b/src/library/scala/collection/mutable/Map.scala
@@ -63,7 +63,7 @@ trait Map[A, B]
 /** $factoryInfo
  *  The current default implementation of a $Coll is a `HashMap`.
  *  @define coll mutable map
- *  @define Coll mutable.Map
+ *  @define Coll `mutable.Map`
  */
 object Map extends MutableMapFactory[Map] {
   /** $canBuildFromInfo */

--- a/src/library/scala/collection/mutable/MultiMap.scala
+++ b/src/library/scala/collection/mutable/MultiMap.scala
@@ -19,7 +19,7 @@ package mutable
  *  `B` objects.
  *
  *  @define coll multimap
- *  @define Coll MultiMap
+ *  @define Coll `MultiMap`
  *  @author  Matthias Zenger
  *  @author  Martin Odersky
  *  @version 2.8

--- a/src/library/scala/collection/mutable/OpenHashMap.scala
+++ b/src/library/scala/collection/mutable/OpenHashMap.scala
@@ -10,7 +10,7 @@ package scala.collection
 package mutable
 
 /**
- *  @define Coll OpenHashMap
+ *  @define Coll `OpenHashMap`
  *  @define coll open hash map
  *
  *  @since 2.7
@@ -42,7 +42,7 @@ object OpenHashMap {
  *  @author David MacIver
  *  @since  2.7
  *
- *  @define Coll OpenHashMap
+ *  @define Coll `OpenHashMap`
  *  @define coll open hash map
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf

--- a/src/library/scala/collection/mutable/Queue.scala
+++ b/src/library/scala/collection/mutable/Queue.scala
@@ -23,7 +23,7 @@ import generic._
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#mutable_queues "Scala's Collection Library overview"]]
  *  section on `Queues` for more information.
  *
- *  @define Coll mutable.Queue
+ *  @define Coll `mutable.Queue`
  *  @define coll mutable queue
  *  @define orderDependent
  *  @define orderDependentFold

--- a/src/library/scala/collection/mutable/Seq.scala
+++ b/src/library/scala/collection/mutable/Seq.scala
@@ -21,7 +21,7 @@ import generic._
  *
  *  The class adds an `update` method to `collection.Seq`.
  *
- *  @define Coll mutable.Seq
+ *  @define Coll `mutable.Seq`
  *  @define coll mutable sequence
  */
 trait Seq[A] extends Iterable[A]
@@ -36,7 +36,7 @@ trait Seq[A] extends Iterable[A]
 /** $factoryInfo
  *  The current default implementation of a $Coll is an `ArrayBuffer`.
  *  @define coll mutable sequence
- *  @define Coll mutable.Seq
+ *  @define Coll `mutable.Seq`
  */
 object Seq extends SeqFactory[Seq] {
   implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Seq[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]

--- a/src/library/scala/collection/mutable/Set.scala
+++ b/src/library/scala/collection/mutable/Set.scala
@@ -19,7 +19,7 @@ import generic._
  *
  *  @since 1.0
  *  @author Matthias Zenger
- *  @define Coll mutable.Set
+ *  @define Coll `mutable.Set`
  *  @define coll mutable set
  */
 trait Set[A] extends Iterable[A]
@@ -34,7 +34,7 @@ trait Set[A] extends Iterable[A]
 /** $factoryInfo
  *  The current default implementation of a $Coll is a `HashSet`.
  *  @define coll mutable set
- *  @define Coll mutable.Set
+ *  @define Coll `mutable.Set`
  */
 object Set extends MutableSetFactory[Set] {
   implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Set[A]] = setCanBuildFrom[A]

--- a/src/library/scala/collection/mutable/SortedSet.scala
+++ b/src/library/scala/collection/mutable/SortedSet.scala
@@ -14,7 +14,7 @@ import generic._
 /**
  * Base trait for mutable sorted set.
  *
- * @define Coll mutable.SortedSet
+ * @define Coll `mutable.SortedSet`
  * @define coll mutable sorted set
  *
  * @author Lucien Pereira
@@ -31,7 +31,7 @@ trait SortedSet[A] extends collection.SortedSet[A] with collection.SortedSetLike
 /**
  * A template for mutable sorted set companion objects.
  *
- * @define Coll mutable.SortedSet
+ * @define Coll `mutable.SortedSet`
  * @define coll mutable sorted set
  * @define factoryInfo
  *   This object provides a set of operations needed to create sorted sets of type mutable.SortedSet.

--- a/src/library/scala/collection/mutable/Stack.scala
+++ b/src/library/scala/collection/mutable/Stack.scala
@@ -20,7 +20,7 @@ import annotation.migration
  *
  *  $factoryInfo
  *  @define coll mutable stack
- *  @define Coll mutable.Stack
+ *  @define Coll `mutable.Stack`
  */
 object Stack extends SeqFactory[Stack] {
   class StackBuilder[A] extends Builder[A, Stack[A]] {
@@ -46,7 +46,7 @@ object Stack extends SeqFactory[Stack] {
  *  @since   1
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#stacks "Scala's Collection Library overview"]]
  *  section on `Stacks` for more information.
- *  @define Coll Stack
+ *  @define Coll `Stack`
  *  @define coll stack
  *  @define orderDependent
  *  @define orderDependentFold

--- a/src/library/scala/collection/mutable/SynchronizedBuffer.scala
+++ b/src/library/scala/collection/mutable/SynchronizedBuffer.scala
@@ -21,7 +21,7 @@ import script._
  *  @author  Matthias Zenger
  *  @version 1.0, 08/07/2003
  *  @since   1
- *  @define Coll SynchronizedBuffer
+ *  @define Coll `SynchronizedBuffer`
  *  @define coll synchronized buffer
  */
 trait SynchronizedBuffer[A] extends Buffer[A] {

--- a/src/library/scala/collection/mutable/SynchronizedMap.scala
+++ b/src/library/scala/collection/mutable/SynchronizedMap.scala
@@ -22,7 +22,7 @@ import annotation.migration
  *  @author  Matthias Zenger, Martin Odersky
  *  @version 2.0, 31/12/2006
  *  @since   1
- *  @define Coll SynchronizedMap
+ *  @define Coll `SynchronizedMap`
  *  @define coll synchronized map
  */
 trait SynchronizedMap[A, B] extends Map[A, B] {

--- a/src/library/scala/collection/mutable/SynchronizedPriorityQueue.scala
+++ b/src/library/scala/collection/mutable/SynchronizedPriorityQueue.scala
@@ -20,7 +20,7 @@ package mutable
  *  @author  Matthias Zenger
  *  @version 1.0, 03/05/2004
  *  @since   1
- *  @define Coll SynchronizedPriorityQueue
+ *  @define Coll `SynchronizedPriorityQueue`
  *  @define coll synchronized priority queue
  */
 class SynchronizedPriorityQueue[A](implicit ord: Ordering[A]) extends PriorityQueue[A] {

--- a/src/library/scala/collection/mutable/SynchronizedQueue.scala
+++ b/src/library/scala/collection/mutable/SynchronizedQueue.scala
@@ -21,7 +21,7 @@ package mutable
  *  @author  Matthias Zenger
  *  @version 1.0, 03/05/2004
  *  @since   1
- *  @define Coll SynchronizedQueue
+ *  @define Coll `SynchronizedQueue`
  *  @define coll synchronized queue
  */
 class SynchronizedQueue[A] extends Queue[A] {

--- a/src/library/scala/collection/mutable/SynchronizedSet.scala
+++ b/src/library/scala/collection/mutable/SynchronizedSet.scala
@@ -20,7 +20,7 @@ import script._
  *  @author  Matthias Zenger
  *  @version 1.0, 08/07/2003
  *  @since   1
- *  @define Coll SynchronizedSet
+ *  @define Coll `SynchronizedSet`
  *  @define coll synchronized set
  */
 trait SynchronizedSet[A] extends Set[A] {

--- a/src/library/scala/collection/mutable/SynchronizedStack.scala
+++ b/src/library/scala/collection/mutable/SynchronizedStack.scala
@@ -21,7 +21,7 @@ package mutable
  *  @author  Matthias Zenger
  *  @version 1.0, 03/05/2004
  *  @since   1
- *  @define Coll SynchronizedStack
+ *  @define Coll `SynchronizedStack`
  *  @define coll synchronized stack
  */
 class SynchronizedStack[A] extends Stack[A] {

--- a/src/library/scala/collection/mutable/Traversable.scala
+++ b/src/library/scala/collection/mutable/Traversable.scala
@@ -29,7 +29,7 @@ trait Traversable[A] extends scala.collection.Traversable[A]
 /** $factoryInfo
  *  The current default implementation of a $Coll is an `ArrayBuffer`.
  *  @define coll mutable traversable collection
- *  @define Coll mutable.Traversable
+ *  @define Coll `mutable.Traversable`
  */
 object Traversable extends TraversableFactory[Traversable] {
   implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Traversable[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]

--- a/src/library/scala/collection/mutable/TreeSet.scala
+++ b/src/library/scala/collection/mutable/TreeSet.scala
@@ -12,7 +12,7 @@ package mutable
 import generic._
 
 /**
- * @define Coll mutable.TreeSet
+ * @define Coll `mutable.TreeSet`
  * @define coll mutable tree set
  * @factoryInfo
  *   Companion object of TreeSet providing factory related utilities.

--- a/src/library/scala/collection/mutable/UnrolledBuffer.scala
+++ b/src/library/scala/collection/mutable/UnrolledBuffer.scala
@@ -36,7 +36,7 @@ import annotation.tailrec
  *  should still be avoided for such a purpose.
  *
  *  @define coll unrolled buffer
- *  @define Coll UnrolledBuffer
+ *  @define Coll `UnrolledBuffer`
  *  @author Aleksandar Prokopec
  *
  */

--- a/src/library/scala/collection/mutable/WeakHashMap.scala
+++ b/src/library/scala/collection/mutable/WeakHashMap.scala
@@ -23,7 +23,7 @@ import convert.Wrappers._
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#weak_hash_maps "Scala's Collection Library overview"]]
  *  section on `Weak Hash Maps` for more information.
  *
- *  @define Coll WeakHashMap
+ *  @define Coll `WeakHashMap`
  *  @define coll weak hash map
  *  @define thatinfo the class of the returned collection. In the standard library configuration,
  *    `That` is always `WeakHashMap[A, B]` if the elements contained in the resulting collection are
@@ -43,7 +43,7 @@ class WeakHashMap[A, B] extends JMapWrapper[A, B](new java.util.WeakHashMap)
 }
 
 /** $factoryInfo
- *  @define Coll WeakHashMap
+ *  @define Coll `WeakHashMap`
  *  @define coll weak hash map
  */
 object WeakHashMap extends MutableMapFactory[WeakHashMap] {

--- a/src/library/scala/collection/mutable/WrappedArray.scala
+++ b/src/library/scala/collection/mutable/WrappedArray.scala
@@ -24,7 +24,7 @@ import scala.collection.parallel.mutable.ParArray
  *  @author  Martin Odersky, Stephane Micheloud
  *  @version 1.0
  *  @since 2.8
- *  @define Coll WrappedArray
+ *  @define Coll `WrappedArray`
  *  @define coll wrapped array
  *  @define orderDependent
  *  @define orderDependentFold

--- a/src/library/scala/collection/parallel/ParIterable.scala
+++ b/src/library/scala/collection/parallel/ParIterable.scala
@@ -24,7 +24,7 @@ import scala.collection.parallel.mutable.ParArray
  *  @author Aleksandar Prokopec
  *  @since 2.9
  *
- *  @define Coll ParIterable
+ *  @define Coll `ParIterable`
  *  @define coll parallel iterable
  */
 trait ParIterable[+T]

--- a/src/library/scala/collection/parallel/immutable/ParHashMap.scala
+++ b/src/library/scala/collection/parallel/immutable/ParHashMap.scala
@@ -39,7 +39,7 @@ import collection.parallel.Task
  *  @see  [[http://docs.scala-lang.org/overviews/parallel-collections/concrete-parallel-collections.html#parallel_hash_tries Scala's Parallel Collections Library overview]]
  *  section on Parallel Hash Tries for more information.
   *
- *  @define Coll immutable.ParHashMap
+ *  @define Coll `immutable.ParHashMap`
  *  @define coll immutable parallel hash map
  */
 @SerialVersionUID(1L)
@@ -140,7 +140,7 @@ self =>
 
 
 /** $factoryInfo
- *  @define Coll immutable.ParHashMap
+ *  @define Coll `immutable.ParHashMap`
  *  @define coll immutable parallel hash map
  */
 object ParHashMap extends ParMapFactory[ParHashMap] {

--- a/src/library/scala/collection/parallel/immutable/ParHashSet.scala
+++ b/src/library/scala/collection/parallel/immutable/ParHashSet.scala
@@ -38,7 +38,7 @@ import collection.parallel.Task
  *  @see  [[http://docs.scala-lang.org/overviews/parallel-collections/concrete-parallel-collections.html#parallel_hash_tries Scala's Parallel Collections Library overview]]
  *  section on Parallel Hash Tries for more information.
  *
- *  @define Coll immutable.ParHashSet
+ *  @define Coll `immutable.ParHashSet`
  *  @define coll immutable parallel hash set
  */
 @SerialVersionUID(1L)
@@ -118,7 +118,7 @@ self =>
 
 
 /** $factoryInfo
- *  @define Coll immutable.ParHashSet
+ *  @define Coll `immutable.ParHashSet`
  *  @define coll immutable parallel hash set
  */
 object ParHashSet extends ParSetFactory[ParHashSet] {

--- a/src/library/scala/collection/parallel/immutable/ParNumericRange.scala.disabled
+++ b/src/library/scala/collection/parallel/immutable/ParNumericRange.scala.disabled
@@ -29,7 +29,7 @@ import scala.collection.parallel.ParIterableIterator
  *  @author Aleksandar Prokopec
  *  @since 2.9
  *  
- *  @define Coll immutable.ParRange
+ *  @define Coll `immutable.ParRange`
  *  @define coll immutable parallel range
  */
 @SerialVersionUID(1L)

--- a/src/library/scala/collection/parallel/immutable/ParRange.scala
+++ b/src/library/scala/collection/parallel/immutable/ParRange.scala
@@ -28,7 +28,7 @@ import scala.collection.Iterator
  *  @see  [[http://docs.scala-lang.org/overviews/parallel-collections/concrete-parallel-collections.html#parallel_range Scala's Parallel Collections Library overview]]
  *  section on `ParRange` for more information.
  *
- *  @define Coll immutable.ParRange
+ *  @define Coll `immutable.ParRange`
  *  @define coll immutable parallel range
  */
 @SerialVersionUID(1L)

--- a/src/library/scala/collection/parallel/immutable/ParSeq.scala
+++ b/src/library/scala/collection/parallel/immutable/ParSeq.scala
@@ -24,7 +24,7 @@ import scala.collection.GenSeq
 
 /** An immutable variant of `ParSeq`.
  *
- *  @define Coll mutable.ParSeq
+ *  @define Coll `mutable.ParSeq`
  *  @define coll mutable parallel sequence
  */
 trait ParSeq[+T]
@@ -40,7 +40,7 @@ extends collection/*.immutable*/.GenSeq[T]
 
 
 /** $factoryInfo
- *  @define Coll mutable.ParSeq
+ *  @define Coll `mutable.ParSeq`
  *  @define coll mutable parallel sequence
  */
 object ParSeq extends ParFactory[ParSeq] {

--- a/src/library/scala/collection/parallel/immutable/ParSet.scala
+++ b/src/library/scala/collection/parallel/immutable/ParSet.scala
@@ -16,7 +16,7 @@ import scala.collection.parallel.Combiner
 
 /** An immutable variant of `ParSet`.
  *
- *  @define Coll mutable.ParSet
+ *  @define Coll `mutable.ParSet`
  *  @define coll mutable parallel set
  */
 trait ParSet[T]
@@ -38,7 +38,7 @@ self =>
 }
 
 /** $factoryInfo
- *  @define Coll mutable.ParSet
+ *  @define Coll `mutable.ParSet`
  *  @define coll mutable parallel set
  */
 object ParSet extends ParSetFactory[ParSet] {

--- a/src/library/scala/collection/parallel/immutable/ParVector.scala
+++ b/src/library/scala/collection/parallel/immutable/ParVector.scala
@@ -37,7 +37,7 @@ import immutable.VectorIterator
  *  @see  [[http://docs.scala-lang.org/overviews/parallel-collections/concrete-parallel-collections.html#parallel_vector Scala's Parallel Collections Library overview]]
  *  section on `ParVector` for more information.
  *
- *  @define Coll immutable.ParVector
+ *  @define Coll `immutable.ParVector`
  *  @define coll immutable parallel vector
  */
 class ParVector[+T](private[this] val vector: Vector[T])
@@ -86,7 +86,7 @@ extends ParSeq[T]
 
 
 /** $factoryInfo
- *  @define Coll immutable.ParVector
+ *  @define Coll `immutable.ParVector`
  *  @define coll immutable parallel vector
  */
 object ParVector extends ParFactory[ParVector] {

--- a/src/library/scala/collection/parallel/mutable/ParArray.scala
+++ b/src/library/scala/collection/parallel/mutable/ParArray.scala
@@ -49,7 +49,7 @@ import scala.collection.GenTraversableOnce
  *  @see  [[http://docs.scala-lang.org/overviews/parallel-collections/concrete-parallel-collections.html#parallel_array Scala's Parallel Collections Library overview]]
  *  section on `ParArray` for more information.
  *
- *  @define Coll ParArray
+ *  @define Coll `ParArray`
  *  @define coll parallel array
  *
  */
@@ -685,7 +685,7 @@ self =>
 
 
 /** $factoryInfo
- *  @define Coll mutable.ParArray
+ *  @define Coll `mutable.ParArray`
  *  @define coll parallel array
  */
 object ParArray extends ParFactory[ParArray] {

--- a/src/library/scala/collection/parallel/mutable/ParFlatHashTable.scala
+++ b/src/library/scala/collection/parallel/mutable/ParFlatHashTable.scala
@@ -15,7 +15,7 @@ import collection.parallel.IterableSplitter
  *
  *  @tparam T      type of the elements in the $coll.
  *  @define coll   table
- *  @define Coll   flat hash table
+ *  @define Coll   `ParFlatHashTable`
  *
  *  @author Aleksandar Prokopec
  */

--- a/src/library/scala/collection/parallel/mutable/ParHashMap.scala
+++ b/src/library/scala/collection/parallel/mutable/ParHashMap.scala
@@ -28,7 +28,7 @@ import collection.parallel.Task
  *
  *  @tparam T        type of the elements in the parallel hash map
  *
- *  @define Coll ParHashMap
+ *  @define Coll `ParHashMap`
  *  @define coll parallel hash map
  *
  *  @author Aleksandar Prokopec
@@ -141,7 +141,7 @@ self =>
 
 
 /** $factoryInfo
- *  @define Coll mutable.ParHashMap
+ *  @define Coll `mutable.ParHashMap`
  *  @define coll parallel hash map
  */
 object ParHashMap extends ParMapFactory[ParHashMap] {

--- a/src/library/scala/collection/parallel/mutable/ParHashSet.scala
+++ b/src/library/scala/collection/parallel/mutable/ParHashSet.scala
@@ -25,7 +25,7 @@ import collection.parallel.Task
  *
  *  @tparam T        type of the elements in the $coll.
  *
- *  @define Coll ParHashSet
+ *  @define Coll `ParHashSet`
  *  @define coll parallel hash set
  *
  *  @author Aleksandar Prokopec
@@ -104,7 +104,7 @@ extends ParSet[T]
 
 
 /** $factoryInfo
- *  @define Coll mutable.ParHashSet
+ *  @define Coll `mutable.ParHashSet`
  *  @define coll parallel hash set
  */
 object ParHashSet extends ParSetFactory[ParHashSet] {

--- a/src/library/scala/collection/parallel/mutable/ParSeq.scala
+++ b/src/library/scala/collection/parallel/mutable/ParSeq.scala
@@ -26,7 +26,7 @@ import scala.collection.GenSeq
 
 /** A mutable variant of `ParSeq`.
  *
- *  @define Coll mutable.ParSeq
+ *  @define Coll `mutable.ParSeq`
  *  @define coll mutable parallel sequence
  */
 trait ParSeq[T] extends collection/*.mutable*/.GenSeq[T] // was: collection.mutable.Seq[T]
@@ -47,7 +47,7 @@ self =>
 
 
 /** $factoryInfo
- *  @define Coll mutable.ParSeq
+ *  @define Coll `mutable.ParSeq`
  *  @define coll mutable parallel sequence
  */
 object ParSeq extends ParFactory[ParSeq] {

--- a/src/library/scala/collection/parallel/mutable/ParSet.scala
+++ b/src/library/scala/collection/parallel/mutable/ParSet.scala
@@ -21,7 +21,7 @@ import scala.collection.GenSet
 
 /** A mutable variant of `ParSet`.
  *
- *  @define Coll mutable.ParSet
+ *  @define Coll `mutable.ParSet`
  *  @define coll mutable parallel set
  *
  *  @author Aleksandar Prokopec
@@ -41,7 +41,7 @@ self =>
 
 
 /** $factoryInfo
- *  @define Coll mutable.ParSet
+ *  @define Coll `mutable.ParSet`
  *  @define coll mutable parallel set
  */
 object ParSet extends ParSetFactory[ParSet] {

--- a/src/library/scala/reflect/api/Types.scala
+++ b/src/library/scala/reflect/api/Types.scala
@@ -464,10 +464,10 @@ trait Types { self: Universe =>
     def unapply(tpe: AnnotatedType): Option[(List[AnnotationInfo], Type, Symbol)]
   }
 
-  /** The least upper bound wrt <:< of a list of types */
+  /** The least upper bound of a list of types, as determined by `<:<`.  */
   def lub(xs: List[Type]): Type
 
-    /** The greatest lower bound wrt <:< of a list of types */
+    /** The greatest lower bound of a list of types, as determined by `<:<`. */
   def glb(ts: List[Type]): Type
 
   // Creators ---------------------------------------------------------------
@@ -515,15 +515,17 @@ trait Types { self: Universe =>
 
   /** A creator for existential types. This generates:
    *
-   *  tpe1 where { tparams }
+   *  {{{
+   *    tpe1 where { tparams }
+   *  }}}
    *
-   *  where `tpe1` is the result of extrapolating `tpe` wrt to `tparams`.
+   *  where `tpe1` is the result of extrapolating `tpe` with regard to `tparams`.
    *  Extrapolating means that type variables in `tparams` occurring
    *  in covariant positions are replaced by upper bounds, (minus any
    *  SingletonClass markers), type variables in `tparams` occurring in
    *  contravariant positions are replaced by upper bounds, provided the
-   *  resulting type is legal wrt to stability, and does not contain any type
-   *  variable in `tparams`.
+   *  resulting type is legal with regard to stability, and does not contain
+   *  any type variable in `tparams`.
    *
    *  The abstraction drops all type parameters that are not directly or
    *  indirectly referenced by type `tpe1`. If there are no remaining type


### PR DESCRIPTION
- Replaced/simplified usages of "wrt".
- Added backticks to $Coll definitions, so stuff like "immutable.Stack"
  hopefully stops being interpreted as the end of a sentence and shown
  like that in the summary line of ScalaDoc's method description.
  See collection.immutable.Stack's sortBy.
  Additionally, it looks nicer this way.
- Fixes the typo mentioned in SI-5666.
