### PR TITLE
Fixes the backticks in use case signature crash

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/DocComments.scala
+++ b/src/compiler/scala/tools/nsc/ast/DocComments.scala
@@ -383,7 +383,7 @@ trait DocComments { self: Global =>
   }
 
   // !!! todo: inherit from Comment?
-  case class DocComment(raw: String, pos: Position = NoPosition) {
+  case class DocComment(raw: String, pos: Position = NoPosition, codePos: Position = NoPosition) {
 
     /** Returns:
      *   template: the doc comment minus all @define and @usecase sections
@@ -412,7 +412,7 @@ trait DocComments { self: Global =>
       val comment      = "/** " + raw.substring(commentStart, end) + "*/"
       val commentPos   = subPos(commentStart, end)
 
-      UseCase(DocComment(comment, commentPos), code, codePos)
+      UseCase(DocComment(comment, commentPos, codePos), code, codePos)
     }
 
     private def subPos(start: Int, end: Int) =
@@ -461,7 +461,18 @@ trait DocComments { self: Global =>
         findIn(classes ::: List(pkgs.head, definitions.RootClass))
       }
 
-      def getType(str: String): Type = {
+      def getType(_str: String, variable: String): Type = {
+        /*
+         * work around the backticks issue suggested by Simon in
+         * https://groups.google.com/forum/?hl=en&fromgroups#!topic/scala-internals/z7s1CCRCz74
+         * ideally, we'd have a removeWikiSyntax method in the CommentFactory to completely eliminate the wiki markup
+         */
+        val str =
+          if (_str.length >= 2 && _str.startsWith("`") && _str.endsWith("`"))
+            _str.substring(1, _str.length - 2)
+          else
+            _str
+
         def getParts(start: Int): List[String] = {
           val end = skipIdent(str, start)
           if (end == start) List()
@@ -471,7 +482,11 @@ trait DocComments { self: Global =>
           }
         }
         val parts = getParts(0)
-        assert(parts.nonEmpty, "parts is empty '" + str + "' in site " + site)
+        if (parts.isEmpty) {
+          reporter.error(comment.codePos, "Incorrect variable expansion for " + variable + " in use case. Does the " +
+                             "variable expand to wiki syntax when documenting " + site + "?")
+          return ErrorType
+        }
         val partnames = (parts.init map newTermName) :+ newTypeName(parts.last)
         val (start, rest) = parts match {
           case "this" :: _      => (site.thisType, partnames.tail)
@@ -490,7 +505,7 @@ trait DocComments { self: Global =>
         for (alias <- aliases) yield
           lookupVariable(alias.name.toString.substring(1), site) match {
             case Some(repl) =>
-              val tpe = getType(repl.trim)
+              val tpe = getType(repl.trim, alias.name.toString)
               if (tpe != NoType) tpe
               else {
                 val alias1 = alias.cloneSymbol(definitions.RootClass, alias.rawflags, newTypeName(repl))

--- a/test/scaladoc/run/usecase-var-expansion.check
+++ b/test/scaladoc/run/usecase-var-expansion.check
@@ -1,0 +1,4 @@
+newSource:8: error: Incorrect variable expansion for $Coll in use case. Does the variable expand to wiki syntax when documenting class Test2?
+       * @usecase def foo: $Coll[T]
+                  ^
+Done.

--- a/test/scaladoc/run/usecase-var-expansion.scala
+++ b/test/scaladoc/run/usecase-var-expansion.scala
@@ -1,0 +1,26 @@
+import scala.tools.nsc.doc.model._
+import scala.tools.partest.ScaladocModelTest
+import language._
+
+object Test extends ScaladocModelTest {
+
+  override def code = """
+    /**
+     * @define Coll `Test`
+     */
+    class Test[T] {
+      /**
+       * member $Coll
+       * @usecase def foo: $Coll[T]
+       *   usecase $Coll
+       */
+      def foo(implicit err: String): Test[T] = sys.error(err)
+    }
+
+    /** @define Coll {{{some `really` < !! >> invalid $$$ thing}}} */
+    class Test2[T] extends Test[Int]
+  """
+
+  def scaladocSettings = ""
+  def testModel(root: Package) = ()
+}


### PR DESCRIPTION
Suggested by Simon in
https://groups.google.com/forum/?hl=en&fromgroups#!topic/scala-internals/z7s1CCRCz74

Now it eliminates backticks and gracefully bails out with an error
message when it can't remove the wiki syntax.
