### PR TITLE
SI-5703: normalize refined types more

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -774,8 +774,12 @@ abstract class ClassfileParser {
           // make unbounded Array[T] where T is a type variable into Array[T with Object]
           // (this is necessary because such arrays have a representation which is incompatible
           // with arrays of primitive types.
-          if (elemtp.typeSymbol.isAbstractType && !(elemtp <:< definitions.ObjectClass.tpe))
+          // NOTE that the comparison to Object only works for abstract types bounded by classes that are strict subclasses of Object
+          // if the bound is exactly Object, it will have been converted to Any, and the comparison will fail
+          // see also RestrictJavaArraysMap (when compiling java sources directly)
+          if (elemtp.typeSymbol.isAbstractType && !(elemtp <:< definitions.ObjectClass.tpe)) {
             elemtp = intersectionType(List(elemtp, definitions.ObjectClass.tpe))
+          }
 
           definitions.arrayType(elemtp)
         case '(' =>

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1347,6 +1347,11 @@ trait Namers extends MethodSynthesis {
     /** Convert Java generic array type T[] to (T with Object)[]
      *  (this is necessary because such arrays have a representation which is incompatible
      *   with arrays of primitive types.)
+     *
+     *  @note the comparison to Object only works for abstract types bounded by classes that are strict subclasses of Object
+     *  if the bound is exactly Object, it will have been converted to Any, and the comparison will fail
+     *
+     *  see also sigToType
      */
     private object RestrictJavaArraysMap extends TypeMap {
       def apply(tp: Type): Type = tp match {

--- a/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
@@ -931,7 +931,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
     // implements the run-time aspects of (§8.2) (typedPattern has already done the necessary type transformations)
     // TODO: normalize construction, which yields a combination of a EqualityTestTreeMaker (when necessary) and a TypeTestTreeMaker
     case class TypeAndEqualityTestTreeMaker(prevBinder: Symbol, patBinder: Symbol, pt: Type, pos: Position) extends CondTreeMaker {
-      val nextBinderTp = glb(List(patBinder.info.widen, pt))
+      val nextBinderTp = glb(List(patBinder.info.widen, pt)).normalize
 
       /** Type patterns consist of types, type variables, and wildcards. A type pattern T is of one of the following forms:
           - A reference to a class C, p.C, or T#C.

--- a/test/files/neg/override.check
+++ b/test/files/neg/override.check
@@ -1,5 +1,5 @@
 override.scala:9: error: overriding type T in trait A with bounds >: Int <: Int;
  type T in trait B with bounds >: String <: String has incompatible type
   lazy val x : A with B = x
-           ^
+               ^
 one error found

--- a/test/files/pos/t5703/Base.java
+++ b/test/files/pos/t5703/Base.java
@@ -1,0 +1,3 @@
+public abstract class Base<Params> {
+	public abstract void func(Params[] params);
+}

--- a/test/files/pos/t5703/Impl.scala
+++ b/test/files/pos/t5703/Impl.scala
@@ -1,0 +1,3 @@
+class Implementation extends Base[Object] {
+  def func(params: Array[Object]): Unit = {}
+}

--- a/test/files/run/existentials3-old.check
+++ b/test/files/run/existentials3-old.check
@@ -5,7 +5,7 @@ Object with Test$ToS
 Object with Test$ToS
 scala.Function0[Object with Test$ToS]
 scala.Function0[Object with Test$ToS]
-_ <: Object with _ <: Object with Object with Test$ToS
+_ <: Object with _ <: Object with Test$ToS
 _ <: Object with _ <: Object with _ <: Object with Test$ToS
 scala.collection.immutable.List[Object with scala.collection.Seq[Int]]
 scala.collection.immutable.List[Object with scala.collection.Seq[_ <: Int]]
@@ -16,7 +16,7 @@ Object with Test$ToS
 Object with Test$ToS
 scala.Function0[Object with Test$ToS]
 scala.Function0[Object with Test$ToS]
-_ <: Object with _ <: Object with Object with Test$ToS
+_ <: Object with _ <: Object with Test$ToS
 _ <: Object with _ <: Object with _ <: Object with Test$ToS
 scala.collection.immutable.List[Object with scala.collection.Seq[Int]]
 scala.collection.immutable.List[Object with scala.collection.Seq[_ <: Int]]

--- a/test/files/run/t5688.check
+++ b/test/files/run/t5688.check
@@ -1,0 +1,1 @@
+Vector(ta, tb, tab)

--- a/test/files/run/t5688.scala
+++ b/test/files/run/t5688.scala
@@ -1,0 +1,23 @@
+object Test extends App {
+  trait T
+
+  trait TA
+  trait TB
+
+  class A extends T with TA
+  class B extends T with TB
+  class AB extends T with TA with TB
+  // Matching on _: TA with TB
+
+  val li: Vector[T] = Vector(new A, new B, new AB)
+
+  val matched = (for (l <- li) yield {
+    l match {
+      case _: TA with TB => "tab"
+      case _: TA => "ta"
+      case _: TB => "tb"
+    }
+  })
+
+  println(matched)
+}


### PR DESCRIPTION
to improve Array[T] java-interop with T[],
normalize Object with Object{} to Object

similarly, fix #SI-5688 by flattening refined types in parents

updated check files to reflect flattening of refined types and updated position for refined types
