### PR TITLE
Fix for si-5018.

### DIFF
--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -45,7 +45,7 @@ object Map extends MapFactory[Map] {
   /** An abstract shell used by { mutable, immutable }.Map but not by collection.Map
    *  because of variance issues.
    */
-  abstract class WithDefault[A, +B](underlying: Map[A, B], d: A => B) extends AbstractMap[A, B] with Map[A, B] {
+  abstract class WithDefault[A, +B](underlying: Map[A, B], d: A => B) extends AbstractMap[A, B] with Map[A, B] with Serializable {
     override def size               = underlying.size
     def get(key: A)                 = underlying.get(key) // removed in 2.9: orElse Some(default(key))
     def iterator                    = underlying.iterator

--- a/src/library/scala/collection/MapLike.scala
+++ b/src/library/scala/collection/MapLike.scala
@@ -165,7 +165,7 @@ self =>
 
   /** The implementation class of the set returned by `keySet`.
    */
-  protected class DefaultKeySet extends AbstractSet[A] with Set[A] {
+  protected class DefaultKeySet extends AbstractSet[A] with Set[A] with Serializable {
     def contains(key : A) = self.contains(key)
     def iterator = keysIterator
     def + (elem: A): Set[A] = (Set[A]() ++ this + elem).asInstanceOf[Set[A]] // !!! concrete overrides abstract problem
@@ -200,7 +200,7 @@ self =>
 
   /** The implementation class of the iterable returned by `values`.
    */
-  protected class DefaultValuesIterable extends AbstractIterable[B] with Iterable[B] {
+  protected class DefaultValuesIterable extends AbstractIterable[B] with Iterable[B] with Serializable {
     def iterator = valuesIterator
     override def size = self.size
     override def foreach[C](f: B => C) = self.valuesIterator foreach f

--- a/test/files/run/t5018.scala
+++ b/test/files/run/t5018.scala
@@ -18,7 +18,7 @@ object Test {
   
   def main(args: Array[String]) {
     val values = mutable.Map(1 -> 1).values
-    assert(serializeDeserialize(values) == values)
+    assert(serializeDeserialize(values).toList == values.toList)
     
     val keyset = mutable.Map(1 -> 1).keySet
     assert(serializeDeserialize(keyset) == keyset)
@@ -28,6 +28,9 @@ object Test {
     
     val defaultmap = immutable.Map(1 -> 1).withDefaultValue(1)
     assert(serializeDeserialize(defaultmap) == defaultmap)
+    
+    val minusmap = mutable.Map(1 -> 1).withDefault(x => -x)
+    assert(serializeDeserialize(minusmap) == minusmap)
   }
   
 }


### PR DESCRIPTION
Methods keySet, values and withDefault now return serializable collections.
