### PR TITLE
run patmat after typer, but not *right* after

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -464,13 +464,15 @@ class Global(var currentSettings: Settings, var reporter: Reporter) extends Symb
   object patmat extends {
     val global: Global.this.type = Global.this
     val runsAfter = List("typer")
-    val runsRightAfter = Some("typer")
+    // patmat doesn't need to be right after typer, as long as we run before supperaccesors
+    // (sbt does need to run right after typer, so don't conflict)
+    val runsRightAfter = None
   } with PatternMatching
 
   // phaseName = "superaccessors"
   object superAccessors extends {
     val global: Global.this.type = Global.this
-    val runsAfter = List("typer")
+    val runsAfter = List("patmat")
     val runsRightAfter = None
   } with SuperAccessors
 


### PR DESCRIPTION
sbt needs that spot right after type for its phase xsbt-api

https://scala-webapps.epfl.ch/jenkins/job/scala-checkin-manual/65/console
