### PR TITLE
Don't admit primitive arrays as a generic Java varargs param.

### DIFF
--- a/src/compiler/scala/reflect/internal/Definitions.scala
+++ b/src/compiler/scala/reflect/internal/Definitions.scala
@@ -434,6 +434,10 @@ trait Definitions extends reflect.api.StandardDefinitions {
       case TypeRef(_, ArrayClass, arg :: Nil) => isPrimitiveValueClass(arg.typeSymbol)
       case _                                  => false
     }
+    def isReferenceArray(tp: Type) = tp match {
+      case TypeRef(_, ArrayClass, arg :: Nil) => arg.typeSymbol.info <:< AnyRefClass.tpe
+      case _                                  => false
+    }
     def isArrayOfSymbol(tp: Type, elem: Symbol) = tp match {
       case TypeRef(_, ArrayClass, arg :: Nil) => arg.typeSymbol == elem
       case _                                  => false

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -449,7 +449,8 @@ abstract class UnCurry extends InfoTransform
           }
 
         afterUncurry {
-          if (isJava && isPrimitiveArray(suffix.tpe) && isArrayOfSymbol(fun.tpe.params.last.tpe, ObjectClass)) {
+          if (isJava && !isReferenceArray(suffix.tpe) && isArrayOfSymbol(fun.tpe.params.last.tpe, ObjectClass)) {
+            // The array isn't statically known to be a reference array, so call ScalaRuntime.toObjectArray.
             suffix = localTyper.typedPos(pos) {
               gen.mkRuntimeCall(nme.toObjectArray, List(suffix))
             }

--- a/src/library/scala/runtime/ScalaRunTime.scala
+++ b/src/library/scala/runtime/ScalaRunTime.scala
@@ -130,16 +130,18 @@ object ScalaRunTime {
     case null => throw new NullPointerException
   }
 
-  /** Convert a numeric value array to an object array.
+  /** Convert an array to an object array.
    *  Needed to deal with vararg arguments of primitive types that are passed
    *  to a generic Java vararg parameter T ...
    */
-  def toObjectArray(src: AnyRef): Array[Object] = {
-    val length = array_length(src)
-    val dest = new Array[Object](length)
-    for (i <- 0 until length)
-      array_update(dest, i, array_apply(src, i))
-    dest
+  def toObjectArray(src: AnyRef): Array[Object] = src match {
+    case x: Array[AnyRef] => x
+    case _ =>
+      val length = array_length(src)
+      val dest = new Array[Object](length)
+      for (i <- 0 until length)
+        array_update(dest, i, array_apply(src, i))
+      dest
   }
 
   def toArray[T](xs: collection.Seq[T]) = {

--- a/test/files/run/t4216.check
+++ b/test/files/run/t4216.check
@@ -1,0 +1,34 @@
+Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> def f[A: ArrayTag](a: A) = java.util.Arrays.asList(Array(a): _*)
+f: [A](a: A)(implicit evidence$1: ArrayTag[A])java.util.List[A]
+
+scala> f(".")
+res0: java.util.List[String] = [.]
+
+scala> f(0)
+res1: java.util.List[Int] = [0]
+
+scala> def i(a: Int) = java.util.Arrays.asList(Array(a): _*)
+i: (a: Int)java.util.List[Int]
+
+scala> i(0)
+res2: java.util.List[Int] = [0]
+
+scala> def o(a: Any) = java.util.Arrays.asList(Array(a): _*)
+o: (a: Any)java.util.List[Any]
+
+scala> o(".")
+res3: java.util.List[Any] = [.]
+
+scala> class V(val a: Int) extends AnyVal
+defined class V
+
+scala> f(new V(0))
+res4: java.util.List[V] = [V@0]
+
+scala> o(new V(0))
+res5: java.util.List[Any] = [V@0]
+
+scala> 

--- a/test/files/run/t4216.scala
+++ b/test/files/run/t4216.scala
@@ -1,0 +1,18 @@
+import scala.tools.partest.ReplTest
+
+// t4216
+object Test extends ReplTest {
+  def code =
+    """
+      |def f[A: ArrayTag](a: A) = java.util.Arrays.asList(Array(a): _*)
+      |f(".")
+      |f(0)
+      |def i(a: Int) = java.util.Arrays.asList(Array(a): _*)
+      |i(0)
+      |def o(a: Any) = java.util.Arrays.asList(Array(a): _*)
+      |o(".")
+      |class V(val a: Int) extends AnyVal
+      |f(new V(0))
+      |o(new V(0))
+      |""".stripMargin.trim
+}


### PR DESCRIPTION
They were sneaking through as polymorphic Arrays and avoiding boxing.

Closes SI-4216
