### PR TITLE
Test that primitive arrays aren't accepted as a Java generic array.

### DIFF
--- a/test/files/neg/t750.check
+++ b/test/files/neg/t750.check
@@ -1,0 +1,15 @@
+Test_2.scala:4: error: type mismatch;
+ found   : Array[Int]
+ required: Array[? with Object]
+Note: Int >: ? with Object, but class Array is invariant in type T.
+You may wish to investigate a wildcard type such as `_ >: ? with Object`. (SLS 3.2.10)
+  AO_1.f(a)
+         ^
+Test_2.scala:5: error: type mismatch;
+ found   : Array[Int]
+ required: Array[Int]
+Note: Int >: Int, but class Array is invariant in type T.
+You may wish to investigate a wildcard type such as `_ >: Int`. (SLS 3.2.10)
+  AO_1.f[Int](a)
+              ^
+two errors found

--- a/test/files/neg/t750/AO_1.java
+++ b/test/files/neg/t750/AO_1.java
@@ -1,0 +1,5 @@
+public class AO_1 {
+    public static <T> void f(T[] ar0) {
+        System.out.println(ar0);
+    }
+}

--- a/test/files/neg/t750/Test_2.scala
+++ b/test/files/neg/t750/Test_2.scala
@@ -1,0 +1,6 @@
+// t750
+object Test extends App {
+  val a = Array(1, 2, 3)
+  AO_1.f(a)
+  AO_1.f[Int](a)
+}

--- a/test/files/neg/t750b.check
+++ b/test/files/neg/t750b.check
@@ -1,0 +1,15 @@
+Test.scala:4: error: type mismatch;
+ found   : Array[Int]
+ required: Array[? with Object]
+Note: Int >: ? with Object, but class Array is invariant in type T.
+You may wish to investigate a wildcard type such as `_ >: ? with Object`. (SLS 3.2.10)
+  AO.f(a)
+       ^
+Test.scala:5: error: type mismatch;
+ found   : Array[Int]
+ required: Array[Int]
+Note: Int >: Int, but class Array is invariant in type T.
+You may wish to investigate a wildcard type such as `_ >: Int`. (SLS 3.2.10)
+  AO.f[Int](a)
+            ^
+two errors found

--- a/test/files/neg/t750b/AO.java
+++ b/test/files/neg/t750b/AO.java
@@ -1,0 +1,5 @@
+public class AO {
+    public static <T> void f(T[] ar0) {
+        System.out.println(ar0);
+    }
+}

--- a/test/files/neg/t750b/Test.scala
+++ b/test/files/neg/t750b/Test.scala
@@ -1,0 +1,6 @@
+// t750
+object Test extends App {
+  val a = Array(1, 2, 3)
+  AO.f(a)
+  AO.f[Int](a)
+}


### PR DESCRIPTION
They exercise both joint and separate compilation.

This resolves SI-750 (which was somewhat unfairly merged with another ticket).

The error message itself could do with refinement: in particular instance of the much beloved: found X, required X.
