### PR TITLE
fix SI-1247: don't create a thunk for a by-name argument if the argument expression is a Function0 application

### DIFF
--- a/test/files/run/t1247.check
+++ b/test/files/run/t1247.check
@@ -1,0 +1,1 @@
+Is same closure class: true is same closure: true

--- a/test/files/run/t1247.scala
+++ b/test/files/run/t1247.scala
@@ -1,0 +1,11 @@
+object Test extends App {
+  val f = () => 5
+  def test(g: => Int) {
+    val gFunc = g _
+    val isSameClosureClass = gFunc.getClass == f.getClass
+    val isSame = gFunc eq f
+    println("Is same closure class: "+isSameClosureClass+" is same closure: "+isSame)
+  }
+
+  test(f())
+}


### PR DESCRIPTION
In my quest to come up with a fix for SI-302 this is a by-product which seems useful independently of SI-302.
