### PR TITLE
fix SI-1247: don't create a thunk for a by-name argument if the argument expression is a Function0 application itself

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -473,7 +473,15 @@ abstract class UnCurry extends InfoTransform
             arg.pos.source.path + ":" + arg.pos.line, fun.fullName,
             if (fun.isPrivate) "private" else "")
           )
-          newFunction0(arg)
+
+          arg match {
+            // don't add a thunk for by-name argument if argument already is an application of
+            // a Function0. We can then remove the application and use the existing Function0.
+            case Apply(Select(recv, nme.apply), Nil) if recv.tpe.typeSymbol isSubClass FunctionClass(0) =>
+              recv
+            case _ =>
+              newFunction0(arg)
+          }
         }
       }
     }

--- a/test/files/run/t1247.check
+++ b/test/files/run/t1247.check
@@ -1,0 +1,1 @@
+Is same closure class: true is same closure: true

--- a/test/files/run/t1247.scala
+++ b/test/files/run/t1247.scala
@@ -1,0 +1,11 @@
+object Test extends App {
+  val f = () => 5
+  def test(g: => Int) {
+    val gFunc = g _
+    val isSameClosureClass = gFunc.getClass == f.getClass
+    val isSame = gFunc eq f
+    println("Is same closure class: "+isSameClosureClass+" is same closure: "+isSame)
+  }
+
+  test(f())
+}


### PR DESCRIPTION
Ok, another try, had not expected those few lines to have changed in the last 5 days.
