### PR TITLE
Fixes SI-5640

### DIFF
--- a/src/library/scala/runtime/BoxesRunTime.java
+++ b/src/library/scala/runtime/BoxesRunTime.java
@@ -228,7 +228,7 @@ public final class BoxesRunTime
      *  as yet have not.
      *
      *  Note: Among primitives, Float.NaN != Float.NaN, but the boxed
-     *  verisons are equal.  This still needs reconciliation.
+     *  versions are equal.  This still needs reconciliation.
      */
     public static int hashFromLong(java.lang.Long n) {
         int iv = n.intValue();
@@ -242,6 +242,9 @@ public final class BoxesRunTime
 
         long lv = n.longValue();
         if (lv == dv) return java.lang.Long.valueOf(lv).hashCode();
+
+        float fv = n.floatValue();
+        if (fv == dv) return java.lang.Float.valueOf(fv).hashCode();
         else return n.hashCode();
     }
     public static int hashFromFloat(java.lang.Float n) {

--- a/src/library/scala/runtime/ScalaRunTime.scala
+++ b/src/library/scala/runtime/ScalaRunTime.scala
@@ -234,13 +234,10 @@ object ScalaRunTime {
   // Note that these are the implementations called by ##, so they
   // must not call ## themselves.
 
-  @inline def hash(x: Any): Int = x match {
-    case null                => 0
-    case x: Double           => hash(x)
-    case x: Float            => hash(x)
-    case x: java.lang.Number => hash(x)
-    case _                   => x.hashCode
-  }
+  @inline def hash(x: Any): Int =
+    if (x == null) 0
+    else if (x.isInstanceOf[java.lang.Number]) BoxesRunTime.hashFromNumber(x.asInstanceOf[java.lang.Number])
+    else x.hashCode
 
   @inline def hash(dv: Double): Int = {
     val iv = dv.toInt

--- a/test/files/run/hashhash.scala
+++ b/test/files/run/hashhash.scala
@@ -9,7 +9,15 @@ object Test {
 
     val x = (BigInt(1) << 64).toDouble
     val y: Any = x
+    val f: Float = x.toFloat
+    val jn: java.lang.Number = x
+    val jf: java.lang.Float = x.toFloat
+    val jd: java.lang.Double = x
 
     assert(x.## == y.##, ((x, y)))
+    assert(x.## == f.##, ((x, f)))
+    assert(x.## == jn.##, ((x, jn)))
+    assert(x.## == jf.##, ((x, jf)))
+    assert(x.## == jd.##, ((x, jd)))
   }
 }


### PR DESCRIPTION
Fixes the problem in ## computation in scala.runtime.BoxesRunTime.java.
It reverts part of the changes made in 58bb2d1bd2 (not the changes in the
test).
