### PR TITLE
Execute pending interrupt requests on pres. compiler shutdown

### DIFF
--- a/src/compiler/scala/tools/nsc/interactive/Global.scala
+++ b/src/compiler/scala/tools/nsc/interactive/Global.scala
@@ -352,6 +352,10 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "")
               case item: WorkItem => Some(item.raiseMissing())
               case _ => Some(())
             }
+
+            // don't forget to service interrupt requests
+            val iqs = scheduler.dequeueAllInterrupts(_.execute())
+
             debugLog("ShutdownReq: cleaning work queue (%d items)".format(units.size))
             debugLog("Cleanup up responses (%d loadedType pending, %d parsedEntered pending)"
                 .format(waitLoadedTypeResponses.size, getParsedEnteredResponses.size))

--- a/src/compiler/scala/tools/nsc/util/WorkScheduler.scala
+++ b/src/compiler/scala/tools/nsc/util/WorkScheduler.scala
@@ -30,6 +30,10 @@ class WorkScheduler {
     todo.dequeueAll(a => f(a).isDefined).map(a => f(a).get)
   }
 
+  def dequeueAllInterrupts(f: InterruptReq => Unit): Unit = synchronized {
+    interruptReqs.dequeueAll { iq => f(iq); true }
+  }
+
   /** Called from server: return optional exception posted by client
    *  Reset to no exception.
    */


### PR DESCRIPTION
Don't forget to execute pending interrupt requests when shutting down the presentation compiler.
