### PR TITLE
Fix for SI-5654.

### DIFF
--- a/test/files/pos/t5654.scala
+++ b/test/files/pos/t5654.scala
@@ -1,0 +1,13 @@
+class T(val a: Array[_])
+
+class U {
+  val a = Array(Array(1, 2), Array("a","b"))
+}
+
+class T1 { val a: Array[_] = Array(1) }
+
+case class Bomb(a: Array[_])
+case class Bomb2(a: Array[T] forSome { type T })
+class Okay1(a: Array[_])
+case class Okay2(s: Seq[_])
+


### PR DESCRIPTION
More details as code comment and in the bug database.

Build passed https://scala-webapps.epfl.ch/jenkins/job/scala-checkin-manual/1/
