### PR TITLE
Fix SI-5626.

### DIFF
--- a/test/files/pos/t5626.scala
+++ b/test/files/pos/t5626.scala
@@ -1,0 +1,12 @@
+class C {
+  val blob = {
+    new { case class Foo() }
+  }
+  val blub = {
+    class Inner { case class Foo() }
+    new Inner
+  }
+
+  val foo = blob.Foo()
+  val bar = blub.Foo()
+}


### PR DESCRIPTION
By not replacing 'CaseClass.apply()' factor by 'new CaseClass()' when the class type 'CaseClass' is not accessible.
