### PR TITLE
Another bug bites virtpatmat's dust.

### DIFF
--- a/test/files/pos/t5029.flags
+++ b/test/files/pos/t5029.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t5029.scala
+++ b/test/files/pos/t5029.scala
@@ -1,0 +1,3 @@
+object Test {
+	(Vector(): Seq[_]) match { case List() => true; case Nil => false }
+}


### PR DESCRIPTION
Test case closes SI-5029.

In 2.9, one saw:

``` scala
test/files/pos/t5029.scala:2: error: unreachable code
        (Vector(): Seq[_]) match { case List() => true; case Nil => false }
                                                                    ^

[[syntax trees at end of explicitouter]]// Scala source: t5029.scala
package <empty> {
  final object Test extends java.lang.Object with ScalaObject {
    def this(): object Test = {
      Test.super.this();
      ()
    };
    {
      <synthetic> val temp1: Seq[_$1] = (scala.`package`.Vector().apply[Nothing](immutable.this.Nil): Seq[Any]);
      if (temp1.isInstanceOf[List[A]]().&&(temp1.asInstanceOf[List[A]]().isInstanceOf[object Nil]()))
        {
          true
        }
      else
        throw new MatchError(temp1)
    }
  }
}
```
