### PR TITLE
A REPL pattern matching crasher that crashes no more.

### DIFF
--- a/test/files/run/t4025.check
+++ b/test/files/run/t4025.check
@@ -1,0 +1,19 @@
+Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> 
+
+scala> class Color(val red: Int)
+defined class Color
+
+scala> 
+
+scala> case class Red(r:Int) extends Color(r)
+defined class Red
+
+scala> 
+
+scala> def f(c: Any) = c match { case Red(_) => () }
+f: (c: Any)Unit
+
+scala> 

--- a/test/files/run/t4025.scala
+++ b/test/files/run/t4025.scala
@@ -1,0 +1,12 @@
+import scala.tools.nsc.Settings
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  def code = """
+class Color(val red: Int)
+
+case class Red(r:Int) extends Color(r)
+
+def f(c: Any) = c match { case Red(_) => () }
+"""
+}


### PR DESCRIPTION
Not due to virtpatmat, mind you; it passes with -Xoldpatmat.

Closes SI-4025.
