### PR TITLE
NSDNHAO need not tell us in which version it resides.

### DIFF
--- a/src/compiler/scala/reflect/internal/Symbols.scala
+++ b/src/compiler/scala/reflect/internal/Symbols.scala
@@ -3054,7 +3054,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     override def originalEnclosingMethod = this
 
     override def owner: Symbol =
-      abort("no-symbol does not have an owner (this is a bug: scala " + scala.util.Properties.versionString + ")")
+      abort("no-symbol does not have an owner")
     override def typeConstructor: Type =
       abort("no-symbol does not have a type constructor (this may indicate scalac cannot find fundamental classes)")
   }


### PR DESCRIPTION
This is done for all crashers now. Furthermore, that error report
makes it pretty clear that it's a compiler bug, not user error, so
"this is a bug" seem like needless words.

Resisted the nostalgic temptation to remove the "an".
