### PR TITLE
Address doc comment rot in the standard library.

### DIFF
--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -362,8 +362,8 @@ object Array extends FallbackArrayBuilding {
 
   /** Returns an array containing a sequence of increasing integers in a range.
    *
-   *  @param from the start value of the array
-   *  @param end the end value of the array, exclusive (in other words, this is the first value '''not''' returned)
+   *  @param start  the start value of the array
+   *  @param end    the end value of the array, exclusive (in other words, this is the first value '''not''' returned)
    *  @return  the array with values in range `start, start + 1, ..., end - 1`
    *  up to, but excluding, `end`.
    */

--- a/src/library/scala/Console.scala
+++ b/src/library/scala/Console.scala
@@ -186,7 +186,6 @@ object Console {
    *  }
    *  }}}
    *
-   *  @param in the new input stream.
    *  @param thunk the code to execute with
    *               the new input stream active
    *

--- a/src/library/scala/Either.scala
+++ b/src/library/scala/Either.scala
@@ -297,7 +297,7 @@ object Either {
      * Left(12).left.foreach(x => println(x))  // prints "12"
      * Right(12).left.foreach(x => println(x)) // doesn't print
      * }}}
-     * @param e The side-effecting function to execute.
+     * @param f The side-effecting function to execute.
      */
     def foreach[U](f: A => U) = e match {
       case Left(a) => f(a)
@@ -358,7 +358,7 @@ object Either {
      * Left(12).left.flatMap(x => Left("scala")) // Left("scala")
      * Right(12).left.flatMap(x => Left("scala") // Right(12)
      * }}}
-     * @param The function to bind across `Left`.
+     * @param f The function to bind across `Left`.
      */
     def flatMap[BB >: B, X](f: A => Either[X, BB]) = e match {
       case Left(a) => f(a)
@@ -462,7 +462,7 @@ object Either {
      * Right(12).right.foreach(x => println(x)) // prints "12"
      * Left(12).right.foreach(x => println(x))  // doesn't print
      * }}}
-     * @param e The side-effecting function to execute.
+     * @param f The side-effecting function to execute.
      */
     def foreach[U](f: B => U) = e match {
       case Left(_) => {}
@@ -516,7 +516,7 @@ object Either {
     /**
      * Binds the given function across `Right`.
      *
-     * @param The function to bind across `Right`.
+     * @param f The function to bind across `Right`.
      */
     def flatMap[AA >: A, Y](f: B => Either[AA, Y]) = e match {
       case Left(a) => Left(a)

--- a/src/library/scala/Function.scala
+++ b/src/library/scala/Function.scala
@@ -20,7 +20,6 @@ object Function {
    *  function `f,,1,, andThen ... andThen f,,n,,`.
    *
    *  @param fs The given sequence of functions
-   *  @return   ...
    */
   def chain[a](fs: Seq[a => a]): a => a = { x => (x /: fs) ((x, f) => f(x)) }
 
@@ -72,9 +71,6 @@ object Function {
    *
    *  @note  These functions are slotted for deprecation, but it is on
    *  hold pending superior type inference for tupling anonymous functions.
-   *
-   *  @param f  ...
-   *  @return   ...
    */
   // @deprecated("Use `f.tupled` instead")
   def tupled[a1, a2, b](f: (a1, a2) => b): Tuple2[a1, a2] => b = {

--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -146,7 +146,7 @@ sealed abstract class Option[+A] extends Product with Serializable {
 
   /** Returns the result of applying $f to this $option's
    *  value if the $option is nonempty.  Otherwise, evaluates
-   *  expression $ifEmpty.
+   *  expression `ifEmpty`.
    *
    *  @note This is equivalent to `$option map f getOrElse ifEmpty`.
    *

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -160,7 +160,7 @@ object Predef extends LowPriorityImplicits {
    *  is at least `ASSERTION`.
    *
    *  @see elidable
-   *  @param p   the expression to test
+   *  @param assertion   the expression to test
    */
   @elidable(ASSERTION)
   def assert(assertion: Boolean) {
@@ -173,8 +173,8 @@ object Predef extends LowPriorityImplicits {
    *  is at least `ASSERTION`.
    *
    *  @see elidable
-   *  @param p   the expression to test
-   *  @param msg a String to include in the failure message
+   *  @param assertion   the expression to test
+   *  @param message     a String to include in the failure message
    */
   @elidable(ASSERTION) @inline
   final def assert(assertion: Boolean, message: => Any) {
@@ -189,7 +189,7 @@ object Predef extends LowPriorityImplicits {
    *  will not be generated if `-Xelide-below` is at least `ASSERTION`.
    *
    *  @see elidable
-   *  @param p   the expression to test
+   *  @param assumption   the expression to test
    */
   @elidable(ASSERTION)
   def assume(assumption: Boolean) {
@@ -204,8 +204,8 @@ object Predef extends LowPriorityImplicits {
    *  will not be generated if `-Xelide-below` is at least `ASSERTION`.
    *
    *  @see elidable
-   *  @param p   the expression to test
-   *  @param msg a String to include in the failure message
+   *  @param assumption   the expression to test
+   *  @param message      a String to include in the failure message
    */
   @elidable(ASSERTION) @inline
   final def assume(assumption: Boolean, message: => Any) {
@@ -217,7 +217,7 @@ object Predef extends LowPriorityImplicits {
    *  This method is similar to `assert`, but blames the caller of the method
    *  for violating the condition.
    *
-   *  @param p   the expression to test
+   *  @param requirement   the expression to test
    */
   def require(requirement: Boolean) {
     if (!requirement)
@@ -228,8 +228,8 @@ object Predef extends LowPriorityImplicits {
    *  This method is similar to `assert`, but blames the caller of the method
    *  for violating the condition.
    *
-   *  @param p   the expression to test
-   *  @param msg a String to include in the failure message
+   *  @param requirement   the expression to test
+   *  @param message       a String to include in the failure message
    */
   @inline final def require(requirement: Boolean, message: => Any) {
     if (!requirement)

--- a/src/library/scala/Product.scala
+++ b/src/library/scala/Product.scala
@@ -19,7 +19,7 @@ package scala
  */
 trait Product extends Any with Equals {
   /** The n^th^ element of this product, 0-based.  In other words, for a
-   *  product `A(x,,1,,, ..., x,,k,,)`, returns `x,,(n+1),, where `0 < n < k`.
+   *  product `A(x,,1,,, ..., x,,k,,)`, returns `x,,(n+1),,` where `0 < n < k`.
    *
    *  @param    n   the index of the element to return
    *  @throws       `IndexOutOfBoundsException`

--- a/src/library/scala/Responder.scala
+++ b/src/library/scala/Responder.scala
@@ -21,9 +21,6 @@ package scala
 object Responder {
 
   /** Creates a responder that answer continuations with the constant `a`.
-   *
-   *  @param x ...
-   *  @return ...
    */
   def constant[A](x: A) = new Responder[A] {
     def respond(k: A => Unit) = k(x)
@@ -31,9 +28,6 @@ object Responder {
 
   /** Executes `x` and returns `'''true'''`, useful as syntactic
    *  convenience in for comprehensions.
-   *
-   *  @param x ...
-   *  @return ...
    */
   def exec[A](x: => Unit): Boolean = { x; true }
 

--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -132,7 +132,7 @@ object StringContext {
    *   escape:  `\\`, `\"`, `\'`
    *   octal:   `\d` `\dd` `\ddd` where `d` is an octal digit between `0` and `7`.
    *
-   *  @param  A string that may contain escape sequences
+   *  @param  str  A string that may contain escape sequences
    *  @return The string with all escape sequences expanded.
    */
   def treatEscapes(str: String): String = {

--- a/src/library/scala/annotation/elidable.scala
+++ b/src/library/scala/annotation/elidable.scala
@@ -18,18 +18,22 @@ import java.util.logging.Level
  *  be omitted from generated code if the priority given the annotation
  *  is lower than that given on the command line.
  *
+ *  {{{
  *     @elidable(123)           // annotation priority
  *     scalac -Xelide-below 456 // command line priority
- *
+ *  }}}
+ *  
  *  The method call will be replaced with an expression which depends on
  *  the type of the elided expression.  In decreasing order of precedence:
  *
+ *  {{{
  *    Unit            ()
  *    Boolean         false
  *    T <: AnyVal     0
  *    T >: Null       null
  *    T >: Nothing    Predef.???
- *
+ *  }}}
+ *  
  *  Complete example:
  {{{
    import annotation._, elidable._

--- a/src/library/scala/collection/BitSetLike.scala
+++ b/src/library/scala/collection/BitSetLike.scala
@@ -137,7 +137,7 @@ trait BitSetLike[+This <: BitSetLike[This] with SortedSet[Int]] extends SortedSe
 
   /** Computes the intersection between this bitset and another bitset by performing
    *  a bitwise "and".
-   *  @param   that  the bitset to intersect with.
+   *  @param   other  the bitset to intersect with.
    *  @return  a new bitset consisting of all elements that are both in this
    *  bitset and in the given bitset `other`.
    */
@@ -152,7 +152,7 @@ trait BitSetLike[+This <: BitSetLike[This] with SortedSet[Int]] extends SortedSe
   /** Computes the difference of this bitset and another bitset by performing
    *  a bitwise "and-not".
    *
-   *  @param that the set of bits to exclude.
+   *  @param other the set of bits to exclude.
    *  @return     a bitset containing those bits of this
    *              bitset that are not also contained in the given bitset `other`.
    */
@@ -167,7 +167,7 @@ trait BitSetLike[+This <: BitSetLike[This] with SortedSet[Int]] extends SortedSe
   /** Computes the symmetric difference of this bitset and another bitset by performing
    *  a bitwise "exclusive-or".
    *
-   *  @param that the other bitset to take part in the symmetric difference.
+   *  @param other the other bitset to take part in the symmetric difference.
    *  @return     a bitset containing those bits of this
    *              bitset or the other bitset that are not contained in both bitsets.
    */
@@ -184,7 +184,7 @@ trait BitSetLike[+This <: BitSetLike[This] with SortedSet[Int]] extends SortedSe
 
   /** Tests whether this bitset is a subset of another bitset.
    *
-   *  @param that  the bitset to test.
+   *  @param other  the bitset to test.
    *  @return     `true` if this bitset is a subset of `other`, i.e. if
    *              every bit of this set is also an element in `other`.
    */

--- a/src/library/scala/collection/GenIterableLike.scala
+++ b/src/library/scala/collection/GenIterableLike.scala
@@ -41,7 +41,7 @@ trait GenIterableLike[+A, +Repr] extends Any with GenTraversableLike[A, Repr] {
   /** Checks if the other iterable collection contains the same elements in the same order as this $coll.
    *
    *  @param that  the collection to compare with.
-   *  @tparam B    the type of the elements of collection `that`.
+   *  @tparam A1   the type of the elements of collection `that`.
    *  @return `true`, if both collections contain the same elements in the same order, `false` otherwise.
    *
    *  @usecase  def sameElements(that: GenIterable[A]): Boolean
@@ -87,13 +87,13 @@ trait GenIterableLike[+A, +Repr] extends Any with GenTraversableLike[A, Repr] {
    *  @tparam  A1    the type of the first half of the returned pairs (this is always a supertype
    *                 of the collection's element type `A`).
    *  @tparam  That  the class of the returned collection. Where possible, `That` is
-   *    the same class as the current collection class `Repr`, but this
-   *    depends on the element type `(A1, Int)` being admissible for that class,
-   *    which means that an implicit instance of type `CanBuildFrom[Repr, (A1, Int), That]`.
-   *    is found.
-   *  @tparam  bf    an implicit value of class `CanBuildFrom` which determines the
-   *    result class `That` from the current representation type `Repr`
-   *    and the new element type `(A1, Int)`.
+   *                 the same class as the current collection class `Repr`, but this
+   *                 depends on the element type `(A1, Int)` being admissible for that class,
+   *                 which means that an implicit instance of type `CanBuildFrom[Repr, (A1, Int), That]`.
+   *                 is found.
+   *  @param  bf     an implicit value of class `CanBuildFrom` which determines the
+   *                 result class `That` from the current representation type `Repr`
+   *                 and the new element type `(A1, Int)`.
    *  @return        A new collection of type `That` containing pairs consisting of all elements of this
    *                 $coll paired with their index. Indices start at `0`.
    *

--- a/src/library/scala/collection/GenMapLike.scala
+++ b/src/library/scala/collection/GenMapLike.scala
@@ -42,7 +42,6 @@ trait GenMapLike[A, +B, +Repr] extends GenIterableLike[(A, B), Repr] with Equals
    *            otherwise the result of the `default` computation.
    *   @usecase def getOrElse(key: A, default: => B): B
    *     @inheritdoc
-   *     @tparam  B        the result type of the default computation.
    */
   def getOrElse[B1 >: B](key: A, default: => B1): B1
 

--- a/src/library/scala/collection/GenSeqLike.scala
+++ b/src/library/scala/collection/GenSeqLike.scala
@@ -413,8 +413,6 @@ trait GenSeqLike[+A, +Repr] extends Any with GenIterableLike[A, Repr] with Equal
    *
    *  @param that   the sequence of elements to remove
    *  @tparam B     the element type of the returned $coll.
-   *  @tparam That  $thatinfo
-   *  @param bf     $bfinfo
    *  @return       a new collection of type `That` which contains all elements of this $coll
    *                except some of occurrences of elements that also appear in `that`.
    *                If an element value `x` appears
@@ -438,8 +436,6 @@ trait GenSeqLike[+A, +Repr] extends Any with GenIterableLike[A, Repr] with Equal
    *
    *  @param that   the sequence of elements to intersect with.
    *  @tparam B     the element type of the returned $coll.
-   *  @tparam That  $thatinfo
-   *  @param bf     $bfinfo
    *  @return       a new collection of type `That` which contains all elements of this $coll
    *                which also appear in `that`.
    *                If an element value `x` appears

--- a/src/library/scala/collection/GenTraversableLike.scala
+++ b/src/library/scala/collection/GenTraversableLike.scala
@@ -289,7 +289,7 @@ trait GenTraversableLike[+A, +Repr] extends Any with GenTraversableOnce[A] with 
 
   /** Selects all elements of this $coll which satisfy a predicate.
    *
-   *  @param p     the predicate used to test elements.
+   *  @param pred  the predicate used to test elements.
    *  @return      a new $coll consisting of all elements of this $coll that satisfy the given
    *               predicate `p`. Their order may not be preserved.
    */
@@ -297,7 +297,7 @@ trait GenTraversableLike[+A, +Repr] extends Any with GenTraversableOnce[A] with 
 
   /** Selects all elements of this $coll which do not satisfy a predicate.
    *
-   *  @param p     the predicate used to test elements.
+   *  @param pred  the predicate used to test elements.
    *  @return      a new $coll consisting of all elements of this $coll that do not satisfy the given
    *               predicate `p`. Their order may not be preserved.
    */
@@ -305,11 +305,11 @@ trait GenTraversableLike[+A, +Repr] extends Any with GenTraversableOnce[A] with 
 
   /** Partitions this $coll in two ${coll}s according to a predicate.
    *
-   *  @param p the predicate on which to partition.
-   *  @return  a pair of ${coll}s: the first $coll consists of all elements that
-   *           satisfy the predicate `p` and the second $coll consists of all elements
-   *           that don't. The relative order of the elements in the resulting ${coll}s
-   *           may not be preserved.
+   *  @param pred the predicate on which to partition.
+   *  @return     a pair of ${coll}s: the first $coll consists of all elements that
+   *              satisfy the predicate `p` and the second $coll consists of all elements
+   *              that don't. The relative order of the elements in the resulting ${coll}s
+   *              may not be preserved.
    */
   def partition(pred: A => Boolean): (Repr, Repr)
 
@@ -354,8 +354,8 @@ trait GenTraversableLike[+A, +Repr] extends Any with GenTraversableOnce[A] with 
    *  }}}
    *  $orderDependent
    *
-   *  @param from   the lowest index to include from this $coll.
-   *  @param until  the lowest index to EXCLUDE from this $coll.
+   *  @param unc_from   the lowest index to include from this $coll.
+   *  @param unc_until  the lowest index to EXCLUDE from this $coll.
    *  @return  a $coll containing the elements greater than or equal to
    *           index `from` extending up to (but not including) index `until`
    *           of this $coll.
@@ -375,7 +375,7 @@ trait GenTraversableLike[+A, +Repr] extends Any with GenTraversableOnce[A] with 
 
   /** Takes longest prefix of elements that satisfy a predicate.
    *  $orderDependent
-   *  @param   p  The predicate used to test elements.
+   *  @param   pred  The predicate used to test elements.
    *  @return  the longest prefix of this $coll whose elements all satisfy
    *           the predicate `p`.
    */
@@ -388,7 +388,7 @@ trait GenTraversableLike[+A, +Repr] extends Any with GenTraversableOnce[A] with 
    *  predicate `p` does not cause any side-effects.
    *  $orderDependent
    *
-   *  @param p the test predicate
+   *  @param pred the test predicate
    *  @return  a pair consisting of the longest prefix of this $coll whose
    *           elements all satisfy `p`, and the rest of this $coll.
    */
@@ -396,7 +396,7 @@ trait GenTraversableLike[+A, +Repr] extends Any with GenTraversableOnce[A] with 
 
   /** Drops longest prefix of elements that satisfy a predicate.
    *  $orderDependent
-   *  @param   p  The predicate used to test elements.
+   *  @param   pred  The predicate used to test elements.
    *  @return  the longest suffix of this $coll whose first element
    *           does not satisfy the predicate `p`.
    */

--- a/src/library/scala/collection/GenTraversableOnce.scala
+++ b/src/library/scala/collection/GenTraversableOnce.scala
@@ -312,7 +312,7 @@ trait GenTraversableOnce[+A] extends Any {
    *
    *   @param   num  an implicit parameter defining a set of numeric operations
    *                 which includes the `+` operator to be used in forming the sum.
-   *   @tparam  B    the result type of the `+` operator.
+   *   @tparam  A1   the result type of the `+` operator.
    *   @return       the sum of all elements of this $coll with respect to the `+` operator in `num`.
    *
    *   @usecase def sum: A
@@ -330,7 +330,7 @@ trait GenTraversableOnce[+A] extends Any {
    *
    *   @param   num  an implicit parameter defining a set of numeric operations
    *                 which includes the `*` operator to be used in forming the product.
-   *   @tparam  B    the result type of the `*` operator.
+   *   @tparam  A1   the result type of the `*` operator.
    *   @return       the product of all elements of this $coll with respect to the `*` operator in `num`.
    *
    *   @usecase def product: A
@@ -345,8 +345,8 @@ trait GenTraversableOnce[+A] extends Any {
 
   /** Finds the smallest element.
    *
-   *  @param    cmp   An ordering to be used for comparing elements.
-   *  @tparam   B     The type over which the ordering is defined.
+   *  @param    ord   An ordering to be used for comparing elements.
+   *  @tparam   A1    The type over which the ordering is defined.
    *  @return   the smallest element of this $coll with respect to the ordering `cmp`.
    *
    *  @usecase def min: A
@@ -358,8 +358,8 @@ trait GenTraversableOnce[+A] extends Any {
 
   /** Finds the largest element.
    *
-   *  @param    cmp   An ordering to be used for comparing elements.
-   *  @tparam   B     The type over which the ordering is defined.
+   *  @param    ord   An ordering to be used for comparing elements.
+   *  @tparam   A1    The type over which the ordering is defined.
    *  @return   the largest element of this $coll with respect to the ordering `cmp`.
    *
    *  @usecase def max: A
@@ -382,9 +382,9 @@ trait GenTraversableOnce[+A] extends Any {
    *  $mayNotTerminateInf
    *  $orderDependent
    *
-   *  @param p    the predicate used to test elements.
-   *  @return     an option value containing the first element in the $coll
-   *              that satisfies `p`, or `None` if none exists.
+   *  @param pred    the predicate used to test elements.
+   *  @return        an option value containing the first element in the $coll
+   *                 that satisfies `p`, or `None` if none exists.
    */
   def find(pred: A => Boolean): Option[A]
 
@@ -459,9 +459,9 @@ trait GenTraversableOnce[+A] extends Any {
 
   /** Converts this $coll to an array.
    *
-   *  @tparam B the type of the elements of the array. An `ArrayTag` for
-   *            this type must be available.
-   *  @return   an array containing all elements of this $coll.
+   *  @tparam A1 the type of the elements of the array. An `ArrayTag` for
+   *             this type must be available.
+   *  @return    an array containing all elements of this $coll.
    *
    *  @usecase def toArray: Array[A]
    *    @inheritdoc

--- a/src/library/scala/collection/IterableLike.scala
+++ b/src/library/scala/collection/IterableLike.scala
@@ -166,13 +166,23 @@ self =>
    *  @see Iterator#sliding
    *
    *  @param size the number of elements per group
+   *  @return An iterator producing ${coll}s of size `size`, except the
+   *          last and the only element will be truncated if there are
+   *          fewer elements than size.
+   */
+  def sliding(size: Int): Iterator[Repr] = sliding(size, 1)
+  
+  /** Groups elements in fixed size blocks by passing a "sliding window"
+   *  over them (as opposed to partitioning them, as is done in grouped.)
+   *  @see Iterator#sliding
+   *
+   *  @param size the number of elements per group
    *  @param step the distance between the first elements of successive
    *         groups (defaults to 1)
    *  @return An iterator producing ${coll}s of size `size`, except the
    *          last and the only element will be truncated if there are
    *          fewer elements than size.
    */
-  def sliding(size: Int): Iterator[Repr] = sliding(size, 1)
   def sliding(size: Int, step: Int): Iterator[Repr] =
     for (xs <- iterator.sliding(size, step)) yield {
       val b = newBuilder

--- a/src/library/scala/collection/MapLike.scala
+++ b/src/library/scala/collection/MapLike.scala
@@ -280,14 +280,14 @@ self =>
    *
    *  @usecase  def + (kvs: (A, B)*): Map[A, B]
    *    @inheritdoc
-   *    @param    the key/value pairs
+   *    @param    kvs the key/value pairs
    */
   def + [B1 >: B] (kv1: (A, B1), kv2: (A, B1), kvs: (A, B1) *): Map[A, B1] =
     this + kv1 + kv2 ++ kvs
 
   /** Adds all key/value pairs in a traversable collection to this map, returning a new map.
    *
-   *  @param    kvs the collection containing the added key/value pairs
+   *  @param    xs  the collection containing the added key/value pairs
    *  @tparam   B1  the type of the added values
    *  @return   a new map with the given bindings added to this map
    *

--- a/src/library/scala/collection/SeqLike.scala
+++ b/src/library/scala/collection/SeqLike.scala
@@ -413,8 +413,6 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
    *
    *  @param that   the sequence of elements to remove
    *  @tparam B     the element type of the returned $coll.
-   *  @tparam That  $thatinfo
-   *  @param bf     $bfinfo
    *  @return       a new collection of type `That` which contains all elements of this $coll
    *                except some of occurrences of elements that also appear in `that`.
    *                If an element value `x` appears
@@ -444,8 +442,6 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
    *
    *  @param that   the sequence of elements to intersect with.
    *  @tparam B     the element type of the returned $coll.
-   *  @tparam That  $thatinfo
-   *  @param bf     $bfinfo
    *  @return       a new collection of type `That` which contains all elements of this $coll
    *                which also appear in `that`.
    *                If an element value `x` appears

--- a/src/library/scala/collection/TraversableOnce.scala
+++ b/src/library/scala/collection/TraversableOnce.scala
@@ -16,8 +16,6 @@ import language.{implicitConversions, higherKinds}
  *  or one or more times.
  *  $traversableonceinfo
  *
- *  @tparam A    the element type of the collection
- *
  *  @author Martin Odersky
  *  @author Paul Phillips
  *  @version 2.8

--- a/src/library/scala/collection/convert/DecorateAsScala.scala
+++ b/src/library/scala/collection/convert/DecorateAsScala.scala
@@ -186,9 +186,9 @@ trait DecorateAsScala {
    * any side-effects of using it via the Scala interface will be visible via
    * the Java interface and vice versa.
    *
-   * @param m The `Dictionary` to be converted.
-   * @return An object with an `asScala` method that returns a Scala mutable
-   *         `Map[String, String]` view of the argument.
+   * @param p The `Dictionary` to be converted.
+   * @return  An object with an `asScala` method that returns a Scala mutable
+   *          `Map[String, String]` view of the argument.
    */
   implicit def dictionaryAsScalaMapConverter[A, B](p: ju.Dictionary[A, B]): AsScala[mutable.Map[A, B]] =
     new AsScala(dictionaryAsScalaMap(p))
@@ -200,9 +200,9 @@ trait DecorateAsScala {
    * any side-effects of using it via the Scala interface will be visible via
    * the Java interface and vice versa.
    *
-   * @param m The `Properties` to be converted.
-   * @return An object with an `asScala` method that returns a Scala mutable
-   *         `Map[String, String]` view of the argument.
+   * @param p The `Properties` to be converted.
+   * @return  An object with an `asScala` method that returns a Scala mutable
+   *          `Map[String, String]` view of the argument.
    */
   implicit def propertiesAsScalaMapConverter(p: ju.Properties): AsScala[mutable.Map[String, String]] =
     new AsScala(propertiesAsScalaMap(p))

--- a/src/library/scala/collection/convert/WrapAsJava.scala
+++ b/src/library/scala/collection/convert/WrapAsJava.scala
@@ -24,8 +24,8 @@ trait WrapAsJava {
    * explicit call of `asIterator(java.util.Iterator)` then the original
    * Java Iterator will be returned.
    *
-   * @param i The Iterator to be converted.
-   * @return A Java Iterator view of the argument.
+   * @param  it The Iterator to be converted.
+   * @return    A Java Iterator view of the argument.
    */
   implicit def asJavaIterator[A](it: Iterator[A]): ju.Iterator[A] = it match {
     case JIteratorWrapper(wrapped) => wrapped.asInstanceOf[ju.Iterator[A]]
@@ -42,8 +42,8 @@ trait WrapAsJava {
    * explicit call of `asIterator(java.util.Enumeration)` then the
    * original Java Enumeration will be returned.
    *
-   * @param i The Iterator to be converted.
-   * @return A Java Enumeration view of the argument.
+   * @param it The Iterator to be converted.
+   * @return   A Java Enumeration view of the argument.
    */
   implicit def asJavaEnumeration[A](it: Iterator[A]): ju.Enumeration[A] = it match {
     case JEnumerationWrapper(wrapped) => wrapped.asInstanceOf[ju.Enumeration[A]]
@@ -76,8 +76,8 @@ trait WrapAsJava {
    * explicit call of `asSizedIterable(java.util.Collection)` then the original
    * Java Collection will be returned.
    *
-   * @param i The SizedIterable to be converted.
-   * @return A Java Collection view of the argument.
+   * @param it The SizedIterable to be converted.
+   * @return   A Java Collection view of the argument.
    */
   implicit def asJavaCollection[A](it: Iterable[A]): ju.Collection[A] = it match {
     case JCollectionWrapper(wrapped) => wrapped.asInstanceOf[ju.Collection[A]]
@@ -112,8 +112,8 @@ trait WrapAsJava {
    * explicit call of `asSeq(java.util.List)` then the original
    * Java List will be returned.
    *
-   * @param b The Seq to be converted.
-   * @return A Java List view of the argument.
+   * @param seq The Seq to be converted.
+   * @return    A Java List view of the argument.
    */
   implicit def mutableSeqAsJavaList[A](seq: mutable.Seq[A]): ju.List[A] = seq match {
     case JListWrapper(wrapped) => wrapped
@@ -130,8 +130,8 @@ trait WrapAsJava {
    * explicit call of `asSeq(java.util.List)` then the original
    * Java List will be returned.
    *
-   * @param b The Seq to be converted.
-   * @return A Java List view of the argument.
+   * @param seq The Seq to be converted.
+   * @return    A Java List view of the argument.
    */
   implicit def seqAsJavaList[A](seq: Seq[A]): ju.List[A] = seq match {
     case JListWrapper(wrapped) => wrapped.asInstanceOf[ju.List[A]]

--- a/src/library/scala/collection/convert/WrapAsScala.scala
+++ b/src/library/scala/collection/convert/WrapAsScala.scala
@@ -25,8 +25,8 @@ trait WrapAsScala {
    * explicit call of `asIterator(scala.collection.Iterator)` then the
    * original Scala `Iterator` will be returned.
    *
-   * @param i The `Iterator` to be converted.
-   * @return A Scala `Iterator` view of the argument.
+   * @param it The `Iterator` to be converted.
+   * @return   A Scala `Iterator` view of the argument.
    */
   implicit def asScalaIterator[A](it: ju.Iterator[A]): Iterator[A] = it match {
     case IteratorWrapper(wrapped) => wrapped
@@ -187,8 +187,8 @@ trait WrapAsScala {
    * `Dictionary` and any side-effects of using it via the Scala interface
    * will be visible via the Java interface and vice versa.
    *
-   * @param m The Dictionary to be converted.
-   * @return A Scala mutable Map[String, String] view of the argument.
+   * @param p The Dictionary to be converted.
+   * @return  A Scala mutable Map[String, String] view of the argument.
    */
   implicit def dictionaryAsScalaMap[A, B](p: ju.Dictionary[A, B]): mutable.Map[A, B] = p match {
     case DictionaryWrapper(wrapped) => wrapped
@@ -202,8 +202,8 @@ trait WrapAsScala {
    * `Properties` and any side-effects of using it via the Scala interface
    * will be visible via the Java interface and vice versa.
    *
-   * @param m The Properties to be converted.
-   * @return A Scala mutable Map[String, String] view of the argument.
+   * @param p The Properties to be converted.
+   * @return  A Scala mutable Map[String, String] view of the argument.
    */
   implicit def propertiesAsScalaMap(p: ju.Properties): mutable.Map[String, String] = p match {
     case _ => new JPropertiesWrapper(p)

--- a/src/library/scala/collection/generic/GenTraversableFactory.scala
+++ b/src/library/scala/collection/generic/GenTraversableFactory.scala
@@ -201,8 +201,8 @@ abstract class GenTraversableFactory[CC[X] <: GenTraversable[X] with GenericTrav
 
   /** Produces a $coll containing a sequence of increasing of integers.
    *
-   *  @param from the first element of the $coll
-   *  @param end the end value of the $coll (the first value NOT contained)
+   *  @param start the first element of the $coll
+   *  @param end   the end value of the $coll (the first value NOT contained)
    *  @return  a $coll with values `start, start + 1, ..., end - 1`
    */
   def range[T: Integral](start: T, end: T): CC[T] = range(start, end, implicitly[Integral[T]].one)

--- a/src/library/scala/collection/generic/GenericTraversableTemplate.scala
+++ b/src/library/scala/collection/generic/GenericTraversableTemplate.scala
@@ -73,8 +73,8 @@ trait GenericTraversableTemplate[+A, +CC[X] <: GenTraversable[X]] extends HasNew
   /** Converts this $coll of pairs into two collections of the first and second
    *  half of each pair.
    *
-   *  @param A1     the type of the first half of the element pairs
-   *  @param A2     the type of the second half of the element pairs
+   *  @tparam A1    the type of the first half of the element pairs
+   *  @tparam A2    the type of the second half of the element pairs
    *  @param asPair an implicit conversion which asserts that the element type
    *                of this $coll is a pair.
    *  @return       a pair ${coll}s, containing the first, respectively second
@@ -94,9 +94,9 @@ trait GenericTraversableTemplate[+A, +CC[X] <: GenTraversable[X]] extends HasNew
   /** Converts this $coll of triples into three collections of the first, second,
    *  and third element of each triple.
    *
-   *  @param A1        the type of the first member of the element triples
-   *  @param A2        the type of the second member of the element triples
-   *  @param A3        the type of the third member of the element triples
+   *  @tparam A1       the type of the first member of the element triples
+   *  @tparam A2       the type of the second member of the element triples
+   *  @tparam A3       the type of the third member of the element triples
    *  @param asTriple  an implicit conversion which asserts that the element type
    *                   of this $coll is a triple.
    *  @return          a triple ${coll}s, containing the first, second, respectively

--- a/src/library/scala/collection/generic/Growable.scala
+++ b/src/library/scala/collection/generic/Growable.scala
@@ -42,7 +42,7 @@ trait Growable[-A] extends Clearable {
 
   /** ${Add}s all elements produced by a TraversableOnce to this $coll.
    *
-   *  @param iter  the TraversableOnce producing the elements to $add.
+   *  @param xs   the TraversableOnce producing the elements to $add.
    *  @return  the $coll itself.
    */
   def ++=(xs: TraversableOnce[A]): this.type = { xs.seq foreach += ; this }

--- a/src/library/scala/collection/generic/Shrinkable.scala
+++ b/src/library/scala/collection/generic/Shrinkable.scala
@@ -43,7 +43,7 @@ trait Shrinkable[-A] {
 
   /** Removes all elements produced by an iterator from this $coll.
    *
-   *  @param iter  the iterator producing the elements to remove.
+   *  @param xs   the iterator producing the elements to remove.
    *  @return the $coll itself
    */
   def --=(xs: TraversableOnce[A]): this.type = { xs.seq foreach -= ; this }

--- a/src/library/scala/collection/generic/Sorted.scala
+++ b/src/library/scala/collection/generic/Sorted.scala
@@ -62,8 +62,6 @@ trait Sorted[K, +This <: Sorted[K, This]] {
    *  and an upper-bound.
    *
    *  @param from  The upper-bound (exclusive) of the ranged projection.
-   *  @param until ...
-   *  @return      ...
    */
   def range(from: K, until: K): This = rangeImpl(Some(from), Some(until))
 

--- a/src/library/scala/collection/generic/Subtractable.scala
+++ b/src/library/scala/collection/generic/Subtractable.scala
@@ -52,7 +52,7 @@ trait Subtractable[A, +Repr <: Subtractable[A, Repr]] { self =>
   /** Creates a new $coll from this $coll by removing all elements of another
    *  collection.
    *
-   *  @param elems     the collection containing the removed elements.
+   *  @param xs     the collection containing the removed elements.
    *  @return a new $coll that contains all elements of the current $coll
    *  except one less occurrence of each of the elements of `elems`.
    */

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -511,7 +511,7 @@ object List extends SeqFactory[List] {
 
   /** Transforms an Iterable of Eithers into a pair of lists.
    *
-   *  @param xs the iterable of Eithers to separate
+   *  @param es the iterable of Eithers to separate
    *  @return a pair of lists.
    */
   @deprecated("use `(for (Left(x) <- es) yield x, for (Right(x) <- es) yield x)` instead", "2.8.0")
@@ -582,7 +582,7 @@ object List extends SeqFactory[List] {
   /** Tests whether the given predicate `p` holds
    *  for all corresponding elements of the argument lists.
    *
-   *  @param p function to apply to each pair of elements.
+   *  @param f function to apply to each pair of elements.
    *  @return  `(p(a<sub>0</sub>,b<sub>0</sub>) &amp;&amp;
    *           ... &amp;&amp; p(a<sub>n</sub>,b<sub>n</sub>))]`
    *           if the lists are `[a<sub>0</sub>, ..., a<sub>k</sub>]`;
@@ -604,7 +604,7 @@ object List extends SeqFactory[List] {
   /** Tests whether the given predicate `p` holds
    *  for some corresponding elements of the argument lists.
    *
-   *  @param p function to apply to each pair of elements.
+   *  @param f function to apply to each pair of elements.
    *  @return  `n != 0 &amp;&amp; (p(a<sub>0</sub>,b<sub>0</sub>) ||
    *           ... || p(a<sub>n</sub>,b<sub>n</sub>))]` if the lists are
    *           `[a<sub>0</sub>, ..., a<sub>k</sub>]`,

--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -152,7 +152,7 @@ extends AbstractMap[A, B]
      *  method throws an exception if there is no mapping from the given
      *  key to a value.
      *
-     *  @param  key the key
+     *  @param  k   the key
      *  @return     the value associated with the given key.
      */
     override def apply(k: A): B1 = apply0(this, k)
@@ -162,7 +162,7 @@ extends AbstractMap[A, B]
     /** Checks if this map maps `key` to a value and return the
      *  value if it exists.
      *
-     *  @param  key the key of the mapping of interest
+     *  @param  k   the key of the mapping of interest
      *  @return     the value of the mapping, if it exists
      */
     override def get(k: A): Option[B1] = get0(this, k)
@@ -174,9 +174,6 @@ extends AbstractMap[A, B]
     /** This method allows one to create a new map with an additional mapping
      *  from `key` to `value`. If the map contains already a mapping for `key`,
      *  it will be overridden by this function.
-     *
-     *  @param k ...
-     *  @param v ...
      */
     override def updated [B2 >: B1](k: A, v: B2): ListMap[A, B2] = {
       val m = if (contains(k)) this - k else this
@@ -186,9 +183,6 @@ extends AbstractMap[A, B]
     /** Creates a new mapping without the given `key`.
      *  If the map does not contain a mapping for the given key, the
      *  method returns the same map.
-     *
-     *  @param k ...
-     *  @return  ...
      */
     override def - (k: A): ListMap[A, B1] = {
       // This definition used to result in stack overflows

--- a/src/library/scala/collection/immutable/ListSet.scala
+++ b/src/library/scala/collection/immutable/ListSet.scala
@@ -157,7 +157,7 @@ class ListSet[A] extends AbstractSet[A]
 
     /** Checks if this set contains element `elem`.
      *
-     *  @param  elem    the element to check for membership.
+     *  @param  e       the element to check for membership.
      *  @return `'''true'''`, iff `elem` is contained in this set.
      */
     override def contains(e: A) = containsInternal(this, e)

--- a/src/library/scala/collection/immutable/MapLike.scala
+++ b/src/library/scala/collection/immutable/MapLike.scala
@@ -35,9 +35,9 @@ import parallel.immutable.ParMap
  *  It is also good idea to override methods `foreach` and
  *  `size` for efficiency.
  *
- *  @param A     the type of the keys contained in this collection.
- *  @param B     the type of the values associated with the keys.
- *  @param This  The type of the actual map implementation.
+ *  @tparam A     the type of the keys contained in this collection.
+ *  @tparam B     the type of the values associated with the keys.
+ *  @tparam This  The type of the actual map implementation.
  *
  *  @author  Martin Odersky
  *  @version 2.8

--- a/src/library/scala/collection/immutable/Stack.scala
+++ b/src/library/scala/collection/immutable/Stack.scala
@@ -84,7 +84,7 @@ class Stack[+A] protected (protected val elems: List[A])
    *  the stack. The last element returned by the traversable object
    *  will be on top of the new stack.
    *
-   *  @param   elems      the iterator object.
+   *  @param   xs      the iterator object.
    *  @return the stack with the new elements on top.
    */
   def pushAll[B >: A](xs: TraversableOnce[B]): Stack[B] =

--- a/src/library/scala/collection/immutable/Stream.scala
+++ b/src/library/scala/collection/immutable/Stream.scala
@@ -716,8 +716,8 @@ self =>
   /** A substream starting at index `from` and extending up to (but not including)
    *  index `until`.  This returns a `Stream` that is lazily evaluated.
    *
-   * @param start   The index of the first element of the returned subsequence
-   * @param end     The index of the element following the returned subsequence
+   * @param from    The index of the first element of the returned subsequence
+   * @param until   The index of the element following the returned subsequence
    * @return A new string containing the elements requested from `start` until
    * `end`.
    *

--- a/src/library/scala/collection/immutable/StringLike.scala
+++ b/src/library/scala/collection/immutable/StringLike.scala
@@ -274,7 +274,7 @@ self =>
    *    `scala.BigDecimal`) are unwrapped to pass a type which `Formatter`
    *    understands.
    *
-   *  @param locale an instance of `java.util.Locale`
+   *  @param l    an instance of `java.util.Locale`
    *  @param args the arguments used to instantiating the pattern.
    *  @throws `java.lang.IllegalArgumentException`
    */

--- a/src/library/scala/collection/mutable/ArrayOps.scala
+++ b/src/library/scala/collection/mutable/ArrayOps.scala
@@ -61,7 +61,7 @@ abstract class ArrayOps[T] extends ArrayLike[T, Array[T]] with CustomParalleliza
    *  into a single array.
    *
    *  @tparam U        Type of row elements.
-   *  @param asArray   A function that converts elements of this array to rows - arrays of type `U`.
+   *  @param asTrav    A function that converts elements of this array to rows - arrays of type `U`.
    *  @return          An array obtained by concatenating rows of this array.
    */
   def flatten[U, To](implicit asTrav: T => collection.Traversable[U], m: ArrayTag[U]): Array[U] = {

--- a/src/library/scala/collection/mutable/ArrayStack.scala
+++ b/src/library/scala/collection/mutable/ArrayStack.scala
@@ -152,7 +152,7 @@ extends AbstractSeq[T]
 
   /** Pushes all the provided elements in the traversable object onto the stack.
    *
-   *  @param x  The source of elements to push.
+   *  @param xs The source of elements to push.
    *  @return   A reference to this stack.
    */
   override def ++=(xs: TraversableOnce[T]): this.type = { xs.seq foreach += ; this }

--- a/src/library/scala/collection/mutable/BufferProxy.scala
+++ b/src/library/scala/collection/mutable/BufferProxy.scala
@@ -77,7 +77,7 @@ trait BufferProxy[A] extends Buffer[A] with Proxy {
 
   /** Prepend an element to this list.
    *
-   *  @param elem  the element to prepend.
+   *  @param elems  the elements to prepend.
    */
   override def prepend(elems: A*) { self.prependAll(elems) }
 

--- a/src/library/scala/collection/mutable/IndexedSeqLike.scala
+++ b/src/library/scala/collection/mutable/IndexedSeqLike.scala
@@ -43,7 +43,7 @@ trait IndexedSeqLike[A, +Repr] extends scala.collection.IndexedSeqLike[A, Repr] 
 
   /** Replaces element at given index with a new value.
    *
-   *  @param n       the index of the element to replace.
+   *  @param idx     the index of the element to replace.
    *  @param elem    the new value.
    *  @throws   IndexOutOfBoundsException if the index is not valid.
    */

--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -208,7 +208,7 @@ final class ListBuffer[A]
    *  one. Instead, it will insert a new element at index `n`.
    *
    *  @param  n     the index where a new element will be inserted.
-   *  @param  iter  the iterable object providing all elements to insert.
+   *  @param  seq   the iterable object providing all elements to insert.
    *  @throws Predef.IndexOutOfBoundsException if `n` is out of bounds.
    */
   def insertAll(n: Int, seq: Traversable[A]) {
@@ -338,8 +338,8 @@ final class ListBuffer[A]
   /** Remove a single element from this buffer. May take time linear in the
    *  buffer size.
    *
-   *  @param x  the element to remove.
-   *  @return   this $coll.
+   *  @param elem  the element to remove.
+   *  @return      this $coll.
    */
   override def -= (elem: A): this.type = {
     if (exported) copy()

--- a/src/library/scala/collection/mutable/QueueProxy.scala
+++ b/src/library/scala/collection/mutable/QueueProxy.scala
@@ -49,7 +49,7 @@ trait QueueProxy[A] extends Queue[A] with Proxy {
   /** Adds all elements provided by an iterator at the end of the queue. The
    *  elements are prepended in the order they are given out by the iterator.
    *
-   *  @param  iter        an iterator
+   *  @param  it        an iterator
    */
   override def ++=(it: TraversableOnce[A]): this.type = {
     self ++= it

--- a/src/library/scala/collection/mutable/SeqLike.scala
+++ b/src/library/scala/collection/mutable/SeqLike.scala
@@ -28,8 +28,8 @@ trait SeqLike[A, +This <: SeqLike[A, This] with Seq[A]]
 
   /** Replaces element at given index with a new value.
    *
-   *  @param n       the index of the element to replace.
-   *  @param lem     the new value.
+   *  @param idx      the index of the element to replace.
+   *  @param elem     the new value.
    *  @throws   IndexOutOfBoundsException if the index is not valid.
    */
   def update(idx: Int, elem: A)

--- a/src/library/scala/collection/mutable/SynchronizedBuffer.scala
+++ b/src/library/scala/collection/mutable/SynchronizedBuffer.scala
@@ -61,7 +61,7 @@ trait SynchronizedBuffer[A] extends Buffer[A] {
   /** Appends a number of elements provided by a traversable object
    *  via its `foreach` method.
    *
-   *  @param iter  the iterable object.
+   *  @param xs   the iterable object.
    */
   override def ++=(xs: TraversableOnce[A]): this.type = synchronized[this.type] {
     super.++=(xs)
@@ -102,7 +102,7 @@ trait SynchronizedBuffer[A] extends Buffer[A] {
 
   /** Prepend an element to this list.
    *
-   *  @param elem  the element to prepend.
+   *  @param elems  the elements to prepend.
    */
   override def prepend(elems: A*): Unit = prependAll(elems)
 

--- a/src/library/scala/collection/parallel/ParIterableLike.scala
+++ b/src/library/scala/collection/parallel/ParIterableLike.scala
@@ -491,8 +491,8 @@ self: ParIterableLike[T, Repr, Sequential] =>
    *
    *  $abortsignalling
    *
-   *  @param p    a predicate used to test elements
-   *  @return     true if `p` holds for all elements, false otherwise
+   *  @param pred    a predicate used to test elements
+   *  @return        true if `p` holds for all elements, false otherwise
    */
   def forall(pred: T => Boolean): Boolean = {
     tasksupport.executeAndWaitResult(new Forall(pred, splitter assign new DefaultSignalling with VolatileAbort))
@@ -502,8 +502,8 @@ self: ParIterableLike[T, Repr, Sequential] =>
    *
    *  $abortsignalling
    *
-   *  @param p    a predicate used to test elements
-   *  @return     true if `p` holds for some element, false otherwise
+   *  @param pred    a predicate used to test elements
+   *  @return        true if `p` holds for some element, false otherwise
    */
   def exists(pred: T => Boolean): Boolean = {
     tasksupport.executeAndWaitResult(new Exists(pred, splitter assign new DefaultSignalling with VolatileAbort))
@@ -517,8 +517,8 @@ self: ParIterableLike[T, Repr, Sequential] =>
    *
    *  $abortsignalling
    *
-   *  @param p     predicate used to test the elements
-   *  @return      an option value with the element if such an element exists, or `None` otherwise
+   *  @param pred     predicate used to test the elements
+   *  @return         an option value with the element if such an element exists, or `None` otherwise
    */
   def find(pred: T => Boolean): Option[T] = {
     tasksupport.executeAndWaitResult(new Find(pred, splitter assign new DefaultSignalling with VolatileAbort))
@@ -685,7 +685,7 @@ self: ParIterableLike[T, Repr, Sequential] =>
    *  @tparam That      type of the resulting collection
    *  @param z          neutral element for the operator `op`
    *  @param op         the associative operator for the scan
-   *  @param cbf        combiner factory which provides a combiner
+   *  @param bf         $bfinfo
    *  @return           a collection containing the prefix scan of the elements in the original collection
    *
    *  @usecase def scan(z: T)(op: (T, T) => T): $Coll[T]

--- a/src/library/scala/collection/parallel/ParSeqLike.scala
+++ b/src/library/scala/collection/parallel/ParSeqLike.scala
@@ -162,7 +162,7 @@ self =>
    *
    *  $abortsignalling
    *
-   *  @tparam U      the element type of `that` parallel sequence
+   *  @tparam S      the element type of `that` parallel sequence
    *  @param that    the parallel sequence this sequence is being searched for
    *  @param offset  the starting offset for the search
    *  @return        `true` if there is a sequence `that` starting at `offset` in this sequence, `false` otherwise
@@ -287,9 +287,7 @@ self =>
   /** Computes the multiset intersection between this $coll and another sequence.
    *
    *  @param that   the sequence of elements to intersect with.
-   *  @tparam B     the element type of the returned $coll.
-   *  @tparam That  $thatinfo
-   *  @param bf     $bfinfo
+   *  @tparam U     the element type of `that` parallel sequence
    *  @return       a new collection of type `That` which contains all elements of this $coll
    *                which also appear in `that`.
    *                If an element value `x` appears

--- a/src/library/scala/collection/parallel/RemainsIterator.scala
+++ b/src/library/scala/collection/parallel/RemainsIterator.scala
@@ -39,8 +39,7 @@ private[collection] trait RemainsIterator[+T] extends Iterator[T] {
 /** Augments iterators with additional methods, mostly transformers,
  *  assuming they iterate an iterable collection.
  *
- *  @param T          type of the elements iterated.
- *  @param IterRepr   iterator type.
+ *  @tparam T         type of the elements iterated.
  */
 private[collection] trait AugmentedIterableIterator[+T] extends RemainsIterator[T] {
 
@@ -377,7 +376,7 @@ private[collection] trait AugmentedSeqIterator[+T] extends AugmentedIterableIter
 /** Parallel iterators allow splitting and provide a `remaining` method to
  *  obtain the number of elements remaining in the iterator.
  *
- *  @param T          type of the elements iterated.
+ *  @tparam T          type of the elements iterated.
  */
 trait IterableSplitter[+T]
 extends AugmentedIterableIterator[T]
@@ -537,7 +536,7 @@ self =>
 
 /** Parallel sequence iterators allow splitting into arbitrary subsets.
  *
- *  @param T          type of the elements iterated.
+ *  @tparam T          type of the elements iterated.
  */
 trait SeqSplitter[+T]
 extends IterableSplitter[T]

--- a/src/library/scala/collection/parallel/mutable/ParHashMap.scala
+++ b/src/library/scala/collection/parallel/mutable/ParHashMap.scala
@@ -26,7 +26,8 @@ import collection.parallel.Task
  *  `ParHashMap` is a parallel map which internally keeps elements within a hash table.
  *  It uses chaining to resolve collisions.
  *
- *  @tparam T        type of the elements in the parallel hash map
+ *  @tparam K        type of the keys in the parallel hash map
+ *  @tparam V        type of the values in the parallel hash map
  *
  *  @define Coll `ParHashMap`
  *  @define coll parallel hash map

--- a/src/library/scala/concurrent/Channel.scala
+++ b/src/library/scala/concurrent/Channel.scala
@@ -25,7 +25,6 @@ class Channel[A] {
   private var nreaders = 0
 
   /**
-   *  @param x ...
    */
   def write(x: A) = synchronized {
     lastWritten.elem = x

--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -191,7 +191,7 @@ trait Future[+T] extends Awaitable[T] {
    *  this future. If this future is completed with an exception then the new
    *  future will also contain this exception.
    *
-   *  $forComprehensionExample
+   *  $forComprehensionExamples
    */
   def map[S](f: T => S): Future[S] = {
     val p = Promise[S]()
@@ -213,7 +213,7 @@ trait Future[+T] extends Awaitable[T] {
    *  If this future is completed with an exception then the new future will
    *  also contain this exception.
    *
-   *  $forComprehensionExample
+   *  $forComprehensionExamples
    */
   def flatMap[S](f: T => Future[S]): Future[S] = {
     val p = Promise[S]()

--- a/src/library/scala/concurrent/Promise.scala
+++ b/src/library/scala/concurrent/Promise.scala
@@ -66,7 +66,7 @@ trait Promise[T] {
 
   /** Completes the promise with a value.
    *
-   *  @param value    The value to complete the promise with.
+   *  @param v    The value to complete the promise with.
    *
    *  $promiseCompletion
    */
@@ -106,7 +106,7 @@ object Promise {
   /** Creates a promise object which can be completed with a value.
    *  
    *  @tparam T       the type of the value in the promise
-   *  @param execctx  the execution context on which the promise is created on
+   *  @param executor the execution context on which the promise is created on
    *  @return         the newly created `Promise` object
    */
   def apply[T]()(implicit executor: ExecutionContext): Promise[T] = new impl.Promise.DefaultPromise[T]()
@@ -114,7 +114,7 @@ object Promise {
   /** Creates an already completed Promise with the specified exception.
    *  
    *  @tparam T       the type of the value in the promise
-   *  @param execctx  the execution context on which the promise is created on
+   *  @param executor the execution context on which the promise is created on
    *  @return         the newly created `Promise` object
    */
   def failed[T](exception: Throwable)(implicit executor: ExecutionContext): Promise[T] = new impl.Promise.KeptPromise[T](Left(exception))
@@ -122,7 +122,7 @@ object Promise {
   /** Creates an already completed Promise with the specified result.
    *  
    *  @tparam T       the type of the value in the promise
-   *  @param execctx  the execution context on which the promise is created on
+   *  @param executor the execution context on which the promise is created on
    *  @return         the newly created `Promise` object
    */
   def successful[T](result: T)(implicit executor: ExecutionContext): Promise[T] = new impl.Promise.KeptPromise[T](Right(result))

--- a/src/library/scala/concurrent/Scheduler.scala
+++ b/src/library/scala/concurrent/Scheduler.scala
@@ -35,7 +35,7 @@ trait Scheduler {
   /** Schedules a thunk for execution after a given delay.
    *
    *  @param delay  the duration after which the thunk should be executed
-   *  @param thunk  the thunk that is scheduled for execution
+   *  @param task   the thunk that is scheduled for execution
    *  @return       a `Cancellable` that may be used to cancel the execution
    *                of the thunk
    */

--- a/src/library/scala/io/Source.scala
+++ b/src/library/scala/io/Source.scala
@@ -100,8 +100,6 @@ object Source {
   /** Create a `Source` from array of bytes, decoding
    *  the bytes according to codec.
    *
-   *  @param bytes ...
-   *  @param enc   ...
    *  @return      the created `Source` instance.
    */
   def fromBytes(bytes: Array[Byte])(implicit codec: Codec): Source =

--- a/src/library/scala/math/BigInt.scala
+++ b/src/library/scala/math/BigInt.scala
@@ -71,11 +71,7 @@ object BigInt {
     new BigInt(new BigInteger(bitlength, certainty, rnd.self))
 
   /** Constructs a randomly generated BigInt, uniformly distributed over the
-   *  range 0 to (2 ^ numBits - 1), inclusive.
-   *
-   *  @param numbits ...
-   *  @param rnd     ...
-   *  @return        ...
+   *  range `0` to `(2 ^ numBits - 1)`, inclusive.
    */
   def apply(numbits: Int, rnd: scala.util.Random): BigInt =
     new BigInt(new BigInteger(numbits, rnd.self))
@@ -87,10 +83,6 @@ object BigInt {
 
   /** Translates the string representation of a `BigInt` in the
    *  specified `radix` into a BigInt.
-   *
-   *  @param x     ...
-   *  @param radix ...
-   *  @return      ...
    */
   def apply(x: String, radix: Int): BigInt =
     new BigInt(new BigInteger(x, radix))

--- a/src/library/scala/parallel/Future.scala
+++ b/src/library/scala/parallel/Future.scala
@@ -12,6 +12,8 @@ package scala.parallel
 
 /** A future is a function without parameters that will block the caller if
  *  the parallel computation associated with the function is not completed.
+ *  
+ *  @tparam R   the type of the result
  *
  *  @since 2.9
  */
@@ -23,7 +25,6 @@ trait Future[@specialized +R] extends (() => R) {
    *  '''Note:''' creating a circular dependency between futures by calling
    *  this method will result in a deadlock.
    *
-   *  @tparam R   the type of the result
    *  @return     the result
    *  @throws     the exception that was thrown during a parallel computation
    */

--- a/src/library/scala/reflect/api/Trees.scala
+++ b/src/library/scala/reflect/api/Trees.scala
@@ -727,7 +727,7 @@ trait Trees { self: Universe =>
   def Ident(sym: Symbol): Ident
 
   /** Marks underlying reference to id as boxed.
-   *  @pre: id must refer to a captured variable
+   *  @pre id must refer to a captured variable
    *  A reference such marked will refer to the boxed entity, no dereferencing
    *  with `.elem` is done on it.
    *  This tree node can be emitted by macros such as reify that call referenceCapturedVariable.

--- a/src/library/scala/reflect/api/Types.scala
+++ b/src/library/scala/reflect/api/Types.scala
@@ -111,10 +111,12 @@ trait Types { self: Universe =>
      *  Proceed analogously for thistypes referring to outer classes.
      *
      *  Example:
+     *  {{{
      *    class D[T] { def m: T }
      *    class C extends p.D[Int]
      *    T.asSeenFrom(ThisType(C), D)  (where D is owner of m)
      *      = Int
+     *  }}} 
      */
     def asSeenFrom(pre: Type, clazz: Symbol): Type
 
@@ -481,10 +483,6 @@ trait Types { self: Universe =>
   def refinedType(parents: List[Type], owner: Symbol, decls: Scope, pos: Position): Type
 
   /** The canonical creator for a refined type with an initially empty scope.
-   *
-   *  @param parents ...
-   *  @param owner   ...
-   *  @return        ...
    */
   def refinedType(parents: List[Type], owner: Symbol): Type
 

--- a/src/library/scala/reflect/api/Universe.scala
+++ b/src/library/scala/reflect/api/Universe.scala
@@ -28,18 +28,23 @@ abstract class Universe extends Symbols
    *
    *  For instance, given the abstract syntax tree representation of the <[ x + 1 ]> expression:
    *
+   *  {{{
    *    Apply(Select(Ident("x"), "+"), List(Literal(Constant(1))))
+   *  }}}
    *
    *  The reifier transforms it to the following expression:
-   *
+   *   
+   *  {{{
    *    <[
    *      val $mr: scala.reflect.api.Universe = <reference to the Universe that calls the reify>
    *      $mr.Expr[Int]($mr.Apply($mr.Select($mr.Ident($mr.newFreeVar("x", <Int>, x), "+"), List($mr.Literal($mr.Constant(1))))))
    *    ]>
+   *  }}}
    *
    *  Reification performs expression splicing (when processing Expr.eval and Expr.value)
    *  and type splicing (for every type T that has a TypeTag[T] implicit in scope):
    *
+   *  {{{
    *    val two = mirror.reify(2)                       // Literal(Constant(2))
    *    val four = mirror.reify(two.eval + two.eval)    // Apply(Select(two.tree, newTermName("$plus")), List(two.tree))
    *
@@ -51,6 +56,7 @@ abstract class Universe extends Symbols
    *      val factory = c.reify{ new Queryable[T] }
    *      ...
    *    }
+   *  }}}
    *
    *  The transformation looks mostly straightforward, but it has its tricky parts:
    *    * Reifier retains symbols and types defined outside the reified tree, however

--- a/src/library/scala/runtime/RichDouble.scala
+++ b/src/library/scala/runtime/RichDouble.scala
@@ -18,14 +18,12 @@ final class RichDouble(val self: Double) extends FractionalProxy[Double] {
   /** Converts an angle measured in degrees to an approximately equivalent
    *  angle measured in radians.
    *
-   *  @param  x an angle, in degrees
    *  @return the measurement of the angle x in radians.
    */
   def toRadians: Double = math.toRadians(self)
 
   /** Converts an angle measured in radians to an approximately equivalent
    *  angle measured in degrees.
-   *  @param  x angle, in radians
    *  @return the measurement of the angle x in degrees.
    */
   def toDegrees: Double = math.toDegrees(self)

--- a/src/library/scala/runtime/RichFloat.scala
+++ b/src/library/scala/runtime/RichFloat.scala
@@ -18,7 +18,6 @@ final class RichFloat(val self: Float) extends FractionalProxy[Float] {
   /** Converts an angle measured in degrees to an approximately equivalent
    *  angle measured in radians.
    *
-   *  @param  x an angle, in degrees
    *  @return the measurement of the angle `x` in radians.
    */
   def toRadians: Float = math.toRadians(self).toFloat
@@ -26,7 +25,6 @@ final class RichFloat(val self: Float) extends FractionalProxy[Float] {
   /** Converts an angle measured in radians to an approximately equivalent
    *  angle measured in degrees.
    *
-   *  @param  x angle, in radians
    *  @return the measurement of the angle `x` in degrees.
    */
   def toDegrees: Float = math.toDegrees(self).toFloat

--- a/src/library/scala/sys/Prop.scala
+++ b/src/library/scala/sys/Prop.scala
@@ -38,7 +38,7 @@ trait Prop[+T] {
 
   /** Sets the property.
    *
-   *  @param    the new string value
+   *  @param    newValue  the new string value
    *  @return   the old value, or null if it was unset.
    */
   def set(newValue: String): String

--- a/src/library/scala/sys/package.scala
+++ b/src/library/scala/sys/package.scala
@@ -69,8 +69,8 @@ package object sys {
    *
    *  Note that shutdown hooks are NOT guaranteed to be run.
    *
-   *  @param    the body of code to run at shutdown
-   *  @return   the Thread which will run the shutdown hook.
+   *  @param    body  the body of code to run at shutdown
+   *  @return   the   Thread which will run the shutdown hook.
    */
   def addShutdownHook(body: => Unit): ShutdownHookThread = ShutdownHookThread(body)
 

--- a/src/library/scala/testing/Benchmark.scala
+++ b/src/library/scala/testing/Benchmark.scala
@@ -49,9 +49,6 @@ trait Benchmark {
 
   /** Run the benchmark the specified number of times and return a list with
    *  the execution times in milliseconds in reverse order of the execution.
-   *
-   *  @param noTimes ...
-   *  @return        ...
    */
   def runBenchmark(noTimes: Int): List[Long] =
     for (i <- List.range(1, noTimes + 1)) yield {

--- a/src/library/scala/text/Document.scala
+++ b/src/library/scala/text/Document.scala
@@ -33,9 +33,6 @@ abstract class Document {
   /**
    * Format this document on `writer` and try to set line
    * breaks so that the result fits in `width` columns.
-   *
-   * @param width  ...
-   * @param writer ...
    */
   def format(width: Int, writer: Writer) {
     type FmtState = (Int, Boolean, Document)

--- a/src/library/scala/util/Random.scala
+++ b/src/library/scala/util/Random.scala
@@ -101,8 +101,7 @@ class Random(val self: java.util.Random) {
 
   /** Returns a new collection of the same type in a randomly chosen order.
    *
-   *  @param  coll    the [[scala.collection.TraversableOnce]] to shuffle
-   *  @return         the shuffled [[scala.collection.TraversableOnce]]
+   *  @return         the shuffled collection
    */
   def shuffle[T, CC[X] <: TraversableOnce[X]](xs: CC[T])(implicit bf: CanBuildFrom[CC[T], T, CC[T]]): CC[T] = {
     val buf = new ArrayBuffer[T] ++= xs

--- a/src/library/scala/util/automata/BaseBerrySethi.scala
+++ b/src/library/scala/util/automata/BaseBerrySethi.scala
@@ -55,9 +55,6 @@ abstract class BaseBerrySethi {
   /** Starts from the right-to-left
    *  precondition: pos is final
    *               pats are successor patterns of a Sequence node
-   *
-   *  @param r ...
-   *  @return  ...
    */
   protected def compFollow(rs: Seq[RegExp]): Set[Int] = {
     follow(0) =
@@ -73,10 +70,6 @@ abstract class BaseBerrySethi {
   }
 
   /** Returns the first set of an expression, setting the follow set along the way.
-   *
-   *  @param fol1 ...
-   *  @param r    ...
-   *  @return     ...
    */
   protected def compFollow1(fol1: Set[Int], r: RegExp): Set[Int] = r match {
     case x: Alt     => Set((x.rs reverseMap (compFollow1(fol1, _))).flatten: _*)
@@ -93,8 +86,6 @@ abstract class BaseBerrySethi {
   }
 
   /** Returns the "Sethi-length" of a pattern, creating the set of position along the way.
-   *
-   *  @param r ...
    */
   protected def traverse(r: RegExp): Unit = r match {
     // (is tree automaton stuff, more than Berry-Sethi)

--- a/src/library/scala/util/automata/Inclusion.scala
+++ b/src/library/scala/util/automata/Inclusion.scala
@@ -23,9 +23,6 @@ trait Inclusion[A <: AnyRef] {
   val labels: Seq[A]
 
   /** Returns true if `dfa1` is included in `dfa2`.
-   *
-   *  @param dfa1 ...
-   *  @param dfa2 ...
    */
   def inclusion(dfa1: DetWordAutom[A], dfa2: DetWordAutom[A]) = {
 

--- a/src/library/scala/util/automata/WordBerrySethi.scala
+++ b/src/library/scala/util/automata/WordBerrySethi.scala
@@ -53,7 +53,6 @@ abstract class WordBerrySethi extends BaseBerrySethi {
   /** Returns the first set of an expression, setting the follow set along
    *  the way.
    *
-   *  @param fol1 ...
    *  @param r    the regular expression
    *  @return     the computed set
    */

--- a/src/library/scala/util/parsing/ast/Binders.scala
+++ b/src/library/scala/util/parsing/ast/Binders.scala
@@ -326,11 +326,11 @@ trait Binders extends AbstractSyntax with Mappable {
   // TODO: move this to some utility object higher in the scala hierarchy?
   /** Returns a given result, but executes the supplied closure before returning.
    *  (The effect of this closure does not influence the returned value.)
-   *
-   *  @param result the result to be returned
-   *  @param block  code to be executed, purely for its side-effects
    */
   trait ReturnAndDo[T]{
+    /**
+     *  @param block  code to be executed, purely for its side-effects
+     */
     def andDo(block: => Unit): T
   }
 

--- a/src/library/scala/util/parsing/input/CharArrayReader.scala
+++ b/src/library/scala/util/parsing/input/CharArrayReader.scala
@@ -21,10 +21,8 @@ object CharArrayReader {
 /** A character array reader reads a stream of characters (keeping track of their positions)
  * from an array.
  *
- * @param source an array of characters
+ * @param chars  an array of characters
  * @param index  starting offset into the array; the first element returned will be `source(index)`
- * @param line   the line number of the first element (counting from index `0` of `source`)
- * @param column the column number of the first element (counting from index `0` of `source`)
  *
  * @author Martin Odersky
  * @author Adriaan Moors

--- a/src/library/scala/util/parsing/input/OffsetPosition.scala
+++ b/src/library/scala/util/parsing/input/OffsetPosition.scala
@@ -45,10 +45,9 @@ case class OffsetPosition(source: java.lang.CharSequence, offset: Int) extends P
   /** The column number referred to by the position; column numbers start at 1. */
   def column: Int = offset - index(line - 1) + 1
 
-  /** The contents of the line numbered `lnum` (must not contain a new-line character).
+  /** The contents of the line numbered at the current offset.
    *
-   * @param lnum a 1-based integer index into the `document`
-   * @return the line at `lnum` (not including a newline)
+   * @return the line at `offset` (not including a newline)
    */
   def lineContents: String =
     source.subSequence(index(line - 1), index(line)).toString
@@ -59,7 +58,7 @@ case class OffsetPosition(source: java.lang.CharSequence, offset: Int) extends P
   /** Compare this position to another, by first comparing their line numbers,
    * and then -- if necessary -- using the columns to break a tie.
    *
-   * @param `that` a `Position` to compare to this `Position`
+   * @param  that a `Position` to compare to this `Position`
    * @return true if this position's line number or (in case of equal line numbers)
    *         column is smaller than the corresponding components of `that`
    */

--- a/src/library/scala/util/parsing/input/PagedSeqReader.scala
+++ b/src/library/scala/util/parsing/input/PagedSeqReader.scala
@@ -23,7 +23,7 @@ object PagedSeqReader {
 /** A character array reader reads a stream of characters (keeping track of their positions)
  * from an array.
  *
- * @param source the source sequence
+ * @param seq     the source sequence
  * @param offset  starting offset.
  *
  * @author Martin Odersky

--- a/src/library/scala/util/parsing/input/Position.scala
+++ b/src/library/scala/util/parsing/input/Position.scala
@@ -27,10 +27,7 @@ trait Position {
   /** The column number referred to by the position; column numbers start at 1. */
   def column: Int
 
-  /** The contents of the line numbered `lnum` (must not contain a new-line character).
-   *
-   * @param lnum a 1-based integer index into the `document`
-   * @return the line at `lnum` (not including a newline)
+  /** The contents of the line at this position. (must not contain a new-line character).
    */
   protected def lineContents: String
 

--- a/src/library/scala/util/parsing/input/StreamReader.scala
+++ b/src/library/scala/util/parsing/input/StreamReader.scala
@@ -13,14 +13,16 @@ import scala.collection.immutable.PagedSeq
 
 /** An object to create a `StreamReader` from a `java.io.Reader`.
  *
- * @param in the `java.io.Reader` that provides the underlying
- *           stream of characters for this Reader.
- *
  * @author Miles Sabin
  */
 object StreamReader {
   final val EofCh = '\032'
 
+  /** Create a `StreamReader` from a `java.io.Reader`.
+   *
+   * @param in the `java.io.Reader` that provides the underlying
+   *           stream of characters for this Reader.
+   */  
   def apply(in: java.io.Reader): StreamReader = {
     new StreamReader(PagedSeq.fromReader(in), 0, 1)
   }

--- a/src/library/scala/xml/Atom.scala
+++ b/src/library/scala/xml/Atom.scala
@@ -37,9 +37,6 @@ class Atom[+A](val data: A) extends SpecialNode with Serializable {
 
   /** Returns text, with some characters escaped according to the XML
    *  specification.
-   *
-   *  @param  sb ...
-   *  @return ...
    */
   def buildString(sb: StringBuilder): StringBuilder =
     Utility.escape(data.toString, sb)

--- a/src/library/scala/xml/Comment.scala
+++ b/src/library/scala/xml/Comment.scala
@@ -11,7 +11,7 @@ package scala.xml
 /** The class `Comment` implements an XML node for comments.
  *
  * @author Burak Emir
- * @param text the text contained in this node, may not contain "--"
+ * @param commentText the text contained in this node, may not contain "--"
  */
 case class Comment(commentText: String) extends SpecialNode {
 

--- a/src/library/scala/xml/EntityRef.scala
+++ b/src/library/scala/xml/EntityRef.scala
@@ -12,7 +12,7 @@ package scala.xml
  *
  * @author  Burak Emir
  * @version 1.0
- * @param   text the text contained in this node.
+ * @param   entityName the name of the entity reference, for example `amp`.
  */
 case class EntityRef(entityName: String) extends SpecialNode {
   final override def doCollectNamespaces = false

--- a/src/library/scala/xml/MetaData.scala
+++ b/src/library/scala/xml/MetaData.scala
@@ -102,7 +102,6 @@ extends AbstractIterable[MetaData]
    *  @param namespace_uri namespace uri of key
    *  @param owner the element owning this attribute list
    *  @param key   the attribute key
-   *  @return          ...
    */
   final def apply(namespace_uri: String, owner: Node, key: String): Seq[Node] =
     apply(namespace_uri, owner.scope, key)
@@ -112,15 +111,12 @@ extends AbstractIterable[MetaData]
    *
    * @param  namespace_uri namespace uri of key
    * @param  scp a namespace scp (usually of the element owning this attribute list)
-   * @param  key to be looked fore
+   * @param  k   to be looked for
    * @return value as Seq[Node] if key is found, null otherwise
    */
-  def apply(namespace_uri:String, scp:NamespaceBinding, k:String): Seq[Node]
+  def apply(namespace_uri: String, scp: NamespaceBinding, k: String): Seq[Node]
 
   /** returns a copy of this MetaData item with next field set to argument.
-   *
-   *  @param next ...
-   *  @return     ...
    */
   def copy(next: MetaData): MetaData
 
@@ -208,31 +204,13 @@ extends AbstractIterable[MetaData]
   }
 
   /**
-   *  @param scope ...
-   *  @return      `'''true'''` iff ...
    */
   def wellformed(scope: NamespaceBinding): Boolean
 
-  /**
-   *  @param key ...
-   *  @return    ...
-   */
   def remove(key: String): MetaData
 
-  /**
-   *  @param namespace ...
-   *  @param scope     ...
-   *  @param key       ...
-   *  @return          ...
-   */
   def remove(namespace: String, scope: NamespaceBinding, key: String): MetaData
 
-  /**
-   *  @param namespace ...
-   *  @param owner     ...
-   *  @param key       ...
-   *  @return          ...
-   */
   final def remove(namespace: String, owner: Node, key: String): MetaData =
     remove(namespace, owner.scope, key)
 }

--- a/src/library/scala/xml/Node.scala
+++ b/src/library/scala/xml/Node.scala
@@ -155,8 +155,7 @@ abstract class Node extends NodeSeq {
   /**
    * String representation of this node
    *
-   * @param stripComment if true, strips comment nodes from result
-   * @return ...
+   * @param stripComments if true, strips comment nodes from result
    */
   def buildString(stripComments: Boolean): String =
     Utility.serialize(this, stripComments = stripComments).toString
@@ -170,9 +169,6 @@ abstract class Node extends NodeSeq {
 
   /**
    * Appends qualified name of this node to `StringBuilder`.
-   *
-   * @param sb ...
-   * @return   ...
    */
   def nameToString(sb: StringBuilder): StringBuilder = {
     if (null != prefix) {

--- a/src/library/scala/xml/NodeSeq.scala
+++ b/src/library/scala/xml/NodeSeq.scala
@@ -88,9 +88,6 @@ abstract class NodeSeq extends AbstractSeq[Node] with immutable.Seq[Node] with S
    *  There is no support for searching a prefixed attribute by its literal prefix.
    *
    *  The document order is preserved.
-   *
-   *  @param that ...
-   *  @return     ...
    */
   def \(that: String): NodeSeq = {
     def fail = throw new IllegalArgumentException(that)
@@ -138,9 +135,6 @@ abstract class NodeSeq extends AbstractSeq[Node] with immutable.Seq[Node] with S
    *  There is no support for searching a prefixed attribute by its literal prefix.
    *
    *  The document order is preserved.
-   *
-   *  @param that ...
-   *  @return     ...
    */
   def \\ (that: String): NodeSeq = {
     def filt(cond: (Node) => Boolean) = this flatMap (_.descendant_or_self) filter cond

--- a/src/library/scala/xml/PrefixedAttribute.scala
+++ b/src/library/scala/xml/PrefixedAttribute.scala
@@ -11,10 +11,10 @@ package scala.xml
 
 /** prefixed attributes always have a non-null namespace.
  *
- *  @param pre   ...
- *  @param key   ...
+ *  @param pre   
+ *  @param key   
  *  @param value the attribute value
- *  @param next  ...
+ *  @param next1
  */
 class PrefixedAttribute(
   val pre: String,

--- a/src/library/scala/xml/PrettyPrinter.scala
+++ b/src/library/scala/xml/PrettyPrinter.scala
@@ -42,10 +42,6 @@ class PrettyPrinter(width: Int, step: Int) {
   }
 
   /** Try to cut at whitespace.
-   *
-   *  @param s   ...
-   *  @param ind ...
-   *  @return    ...
    */
   protected def cut(s: String, ind: Int): List[Item] = {
     val tmp = width - cur
@@ -74,10 +70,6 @@ class PrettyPrinter(width: Int, step: Int) {
   }
 
   /** Try to make indented box, if possible, else para.
-   *
-   *  @param ind ...
-   *  @param s   ...
-   *  @return    ...
    */
   protected def makeBox(ind: Int, s: String) =
     if (cur + s.length > width) {            // fits in this line
@@ -99,10 +91,6 @@ class PrettyPrinter(width: Int, step: Int) {
     cur = 0
   }
 
-  /**
-   *  @param n ...
-   *  @return  ...
-   */
   protected def leafTag(n: Node) = {
     def mkLeaf(sb: StringBuilder) {
       sb append '<'
@@ -149,7 +137,6 @@ class PrettyPrinter(width: Int, step: Int) {
   private def doPreserve(node: Node) =
     node.attribute(XML.namespace, XML.space).map(_.toString == XML.preserve) getOrElse false
 
-  /** @param tail: what we'd like to sqeeze in */
   protected def traverse(node: Node, pscope: NamespaceBinding, ind: Int): Unit =  node match {
 
       case Text(s) if s.trim() == "" =>
@@ -210,7 +197,6 @@ class PrettyPrinter(width: Int, step: Int) {
    *  given namespace to prefix mapping to the given string buffer.
    *
    * @param n    the node to be serialized
-   * @param pmap the namespace to prefix mapping
    * @param sb   the stringbuffer to append to
    */
   def format(n: Node, sb: StringBuilder) { // entry point
@@ -250,9 +236,9 @@ class PrettyPrinter(width: Int, step: Int) {
   /** Returns a formatted string containing well-formed XML with
    *  given namespace to prefix mapping.
    *
-   *  @param n    the node to be serialized
-   *  @param pmap the namespace to prefix mapping
-   *  @return     ...
+   *  @param n      the node to be serialized
+   *  @param pscope the namespace to prefix mapping
+   *  @return      the formatted string
    */
   def format(n: Node, pscope: NamespaceBinding = null): String =
     sbToString(format(n, pscope, _))

--- a/src/library/scala/xml/ProcInstr.scala
+++ b/src/library/scala/xml/ProcInstr.scala
@@ -12,8 +12,8 @@ package scala.xml
 /** an XML node for processing instructions (PI)
  *
  * @author Burak Emir
- * @param  target target name of this PI
- * @param  text   text contained in this node, may not contain "?>"
+ * @param  target     target name of this PI
+ * @param  proctext   text contained in this node, may not contain "?>"
  */
 case class ProcInstr(target: String, proctext: String) extends SpecialNode
 {

--- a/src/library/scala/xml/TextBuffer.scala
+++ b/src/library/scala/xml/TextBuffer.scala
@@ -25,9 +25,6 @@ class TextBuffer
   val sb = new StringBuilder()
 
   /** Appends this string to the text buffer, trimming whitespaces as needed.
-   *
-   *  @param  cs ...
-   *  @return ...
    */
   def append(cs: Seq[Char]): this.type = {
     cs foreach { c =>

--- a/src/library/scala/xml/Utility.scala
+++ b/src/library/scala/xml/Utility.scala
@@ -77,9 +77,6 @@ object Utility extends AnyRef with parsing.TokenTests {
 
   /**
    * Escapes the characters &lt; &gt; &amp; and &quot; from string.
-   *
-   * @param text ...
-   * @return     ...
    */
   final def escape(text: String): String = sbToString(escape(text, _))
 
@@ -102,10 +99,6 @@ object Utility extends AnyRef with parsing.TokenTests {
 
   /**
    * Appends escaped string to `s`.
-   *
-   * @param text ...
-   * @param s    ...
-   * @return     ...
    */
   final def escape(text: String, s: StringBuilder): StringBuilder = {
     // Implemented per XML spec:
@@ -135,8 +128,6 @@ object Utility extends AnyRef with parsing.TokenTests {
    * Appends unescaped string to `s`, `amp` becomes `&amp;`,
    * `lt` becomes `&lt;` etc..
    *
-   * @param ref ...
-   * @param s   ...
    * @return    `'''null'''` if `ref` was not a predefined entity.
    */
   final def unescape(ref: String, s: StringBuilder): StringBuilder =
@@ -145,18 +136,12 @@ object Utility extends AnyRef with parsing.TokenTests {
   /**
    * Returns a set of all namespaces used in a sequence of nodes
    * and all their descendants, including the empty namespaces.
-   *
-   * @param nodes ...
-   * @return      ...
    */
   def collectNamespaces(nodes: Seq[Node]): mutable.Set[String] =
     nodes.foldLeft(new mutable.HashSet[String]) { (set, x) => collectNamespaces(x, set) ; set }
 
   /**
    * Adds all namespaces in node to set.
-   *
-   * @param n   ...
-   * @param set ...
    */
   def collectNamespaces(n: Node, set: mutable.Set[String]) {
     if (n.doCollectNamespaces) {
@@ -273,9 +258,6 @@ object Utility extends AnyRef with parsing.TokenTests {
 
   /**
    * Returns prefix of qualified name if any.
-   *
-   * @param name ...
-   * @return     ...
    */
   final def prefix(name: String): Option[String] = (name indexOf ':') match {
     case -1   => None
@@ -284,11 +266,6 @@ object Utility extends AnyRef with parsing.TokenTests {
 
   /**
    * Returns a hashcode for the given constituents of a node
-   *
-   * @param uri
-   * @param label
-   * @param attribHashCode
-   * @param children
    */
   def hashCode(pre: String, label: String, attribHashCode: Int, scpeHash: Int, children: Seq[Node]) =
     scala.util.MurmurHash3.orderedHash(label +: attribHashCode +: scpeHash +: children, pre.##)
@@ -298,10 +275,6 @@ object Utility extends AnyRef with parsing.TokenTests {
   /**
    * Appends &quot;s&quot; if string `s` does not contain &quot;,
    * &apos;s&apos; otherwise.
-   *
-   * @param s  ...
-   * @param sb ...
-   * @return   ...
    */
   def appendQuoted(s: String, sb: StringBuilder) = {
     val ch = if (s contains '"') '\'' else '"'
@@ -310,10 +283,6 @@ object Utility extends AnyRef with parsing.TokenTests {
 
   /**
    * Appends &quot;s&quot; and escapes and &quot; i s with \&quot;
-   *
-   * @param s  ...
-   * @param sb ...
-   * @return   ...
    */
   def appendEscapedQuoted(s: String, sb: StringBuilder): StringBuilder = {
     sb.append('"')
@@ -324,11 +293,6 @@ object Utility extends AnyRef with parsing.TokenTests {
     sb.append('"')
   }
 
-  /**
-   * @param s     ...
-   * @param index ...
-   * @return      ...
-   */
   def getName(s: String, index: Int): String = {
     if (index >= s.length) null
     else {
@@ -341,9 +305,6 @@ object Utility extends AnyRef with parsing.TokenTests {
   /**
    * Returns `'''null'''` if the value is a correct attribute value,
    * error message if it isn't.
-   *
-   * @param value ...
-   * @return      ...
    */
   def checkAttributeValue(value: String): String = {
     var i = 0
@@ -365,12 +326,6 @@ object Utility extends AnyRef with parsing.TokenTests {
     null
   }
 
-  /**
-   * new
-   *
-   * @param value ...
-   * @return      ...
-   */
   def parseAttributeValue(value: String): Seq[Node] = {
     val sb  = new StringBuilder
     var rfb: StringBuilder = null
@@ -426,11 +381,6 @@ object Utility extends AnyRef with parsing.TokenTests {
    *             | "&amp;#x" '0'..'9'|'A'..'F'|'a'..'f' { hexdigit } ";"
    * }}}
    * See [66]
-   *
-   * @param ch                ...
-   * @param nextch            ...
-   * @param reportSyntaxError ...
-   * @return                  ...
    */
   def parseCharRef(ch: () => Char, nextch: () => Unit, reportSyntaxError: String => Unit, reportTruncatedError: String => Unit): String = {
     val hex  = (ch() == 'x') && { nextch(); true }

--- a/src/library/scala/xml/dtd/DocType.scala
+++ b/src/library/scala/xml/dtd/DocType.scala
@@ -14,7 +14,7 @@ package dtd
  *
  *  @author Burak Emir
  *
- *  @param  target name of this DOCTYPE
+ *  @param  name   name of this DOCTYPE
  *  @param  extID  None, or Some(external ID of this doctype)
  *  @param  intSubset sequence of internal subset declarations
  */

--- a/src/library/scala/xml/dtd/ExternalID.scala
+++ b/src/library/scala/xml/dtd/ExternalID.scala
@@ -41,7 +41,7 @@ abstract class ExternalID extends parsing.TokenTests
 /** a system identifier
  *
  *  @author Burak Emir
- *  @param  systemLiteral the system identifier literal
+ *  @param  systemId the system identifier literal
  */
 case class SystemID(systemId: String) extends ExternalID {
   val publicId = null
@@ -54,8 +54,8 @@ case class SystemID(systemId: String) extends ExternalID {
 /** a public identifier (see http://www.w3.org/QA/2002/04/valid-dtd-list.html).
  *
  *  @author Burak Emir
- *  @param  publicLiteral the public identifier literal
- *  @param  systemLiteral (can be null for notation pubIDs) the system identifier literal
+ *  @param  publicId the public identifier literal
+ *  @param  systemId (can be null for notation pubIDs) the system identifier literal
  */
 case class PublicID(publicId: String, systemId: String) extends ExternalID {
   if (!checkPubID(publicId))

--- a/src/library/scala/xml/include/sax/XIncludeFilter.scala
+++ b/src/library/scala/xml/include/sax/XIncludeFilter.scala
@@ -249,7 +249,7 @@ class XIncludeFilter extends XMLFilterImpl {
     * calls to `characters()`. It's used to include files with `parse="text"`.
     *
     * @param  url          URL of the document that will be read
-    * @param  encoding     Encoding of the document; e.g. UTF-8,
+    * @param  encoding1    Encoding of the document; e.g. UTF-8,
     *                      ISO-8859-1, etc.
     * @return void
     * @throws SAXException if the requested document cannot

--- a/src/library/scala/xml/parsing/ExternalSources.scala
+++ b/src/library/scala/xml/parsing/ExternalSources.scala
@@ -23,11 +23,6 @@ import scala.io.Source
 trait ExternalSources {
   self: ExternalSources with MarkupParser with MarkupHandler =>
 
-  /** ...
-   *
-   *  @param systemId ...
-   *  @return         ...
-   */
   def externalSource(systemId: String): Source = {
     if (systemId startsWith "http:")
       return Source fromURL new URL(systemId)

--- a/src/library/scala/xml/parsing/FactoryAdapter.scala
+++ b/src/library/scala/xml/parsing/FactoryAdapter.scala
@@ -158,7 +158,7 @@ abstract class FactoryAdapter extends DefaultHandler with factory.XMLLoader[Node
 
   /** End element.
    * @param uri
-   * @param localName
+   * @param _localName
    * @param qname
    * @throws org.xml.sax.SAXException if ..
    */

--- a/src/library/scala/xml/parsing/MarkupHandler.scala
+++ b/src/library/scala/xml/parsing/MarkupHandler.scala
@@ -64,7 +64,6 @@ abstract class MarkupHandler extends Logged
    *  @param pos      the position in the source file
    *  @param pre      the prefix
    *  @param label    the local name
-   *  @param attrs    the attributes (metadata)
    */
   def elemEnd(pos: Int, pre: String, label: String): Unit = ()
 
@@ -77,7 +76,6 @@ abstract class MarkupHandler extends Logged
    *  @param attrs    the attributes (metadata)
    *  @param empty    `true` if the element was previously empty; `false` otherwise.
    *  @param args     the children of this element
-   *  @return         ...
    */
   def elem(pos: Int, pre: String, label: String, attrs: MetaData, scope: NamespaceBinding, empty: Boolean, args: NodeSeq): NodeSeq
 

--- a/src/library/scala/xml/parsing/MarkupParserCommon.scala
+++ b/src/library/scala/xml/parsing/MarkupParserCommon.scala
@@ -54,8 +54,8 @@ private[scala] trait MarkupParserCommon extends TokenTests {
     xTakeUntil(mkProcInstr(_, n, _), () => tmppos, "?>")
   }
 
-  /** attribute value, terminated by either ' or ". value may not contain <.
-   *  @param endch either ' or "
+  /** attribute value, terminated by either `'` or `"`. value may not contain `<`.
+   @param endCh either `'` or `"`
    */
   def xAttributeValue(endCh: Char): String = {
     val buf = new StringBuilder

--- a/src/library/scala/xml/pull/XMLEvent.scala
+++ b/src/library/scala/xml/pull/XMLEvent.scala
@@ -38,7 +38,7 @@ case class EvElemEnd(pre: String, label: String) extends XMLEvent
 case class EvText(text: String) extends XMLEvent
 
 /** An entity reference was encountered.
- * @param the name of the entity, e.g. `gt` when encountering the entity `&gt;`
+ * @param entity the name of the entity, e.g. `gt` when encountering the entity `&gt;`
  */
 case class EvEntityRef(entity: String) extends XMLEvent
 

--- a/src/library/scala/xml/transform/BasicTransformer.scala
+++ b/src/library/scala/xml/transform/BasicTransformer.scala
@@ -18,11 +18,6 @@ package transform
  */
 abstract class BasicTransformer extends Function1[Node,Node]
 {
-  /**
-   *  @param n  ...
-   *  @param ns ...
-   *  @return   ...
-   */
   protected def unchanged(n: Node, ns: Seq[Node]) =
     ns.length == 1 && (ns.head == n)
 


### PR DESCRIPTION
- Match @param/@tparam names to the actual parameter name
- Use @tparam for type parameters
- Whitespace is required between `*` and `@`
- Fix incorrect references to @define macros.
- Use of monospace `` and {{{}}} (much more needed)
- Remove `@param p1 ...` stubs, which appear in the generated docss.
  - But, retainsed `@param p1` stubs, assuming they will be filtered from
    the generated docs by SI-5795.
- Avoid use of the shorthand `@param   doc for the solitary param`
  (which works, but isn't recognized by the code inspection in IntelliJ
  I used to sweep through the problems)

The remaining warnings from `ant docs` are spurious; 
an unintended consequence of documenting extension methods.

  [scaladoc] /Users/jason/code/scala/src/library/scala/collection/TraversableOnce.scala:181: warning: Variable coll undefined in comment for method reduceOption in class Tuple2Zipped
  [scaladoc]   def reduceOption[A1 >: A](op: %28A1, A1%29 => A1): Option[A1] = reduceLeftOption(op)
  [scaladoc]       ^
