### PR TITLE
fix SI-5384

### DIFF
--- a/src/compiler/scala/reflect/internal/TreeInfo.scala
+++ b/src/compiler/scala/reflect/internal/TreeInfo.scala
@@ -221,9 +221,29 @@ abstract class TreeInfo {
     case _ => false
   }
 
+  /**
+   * Named arguments can transform a constructor call into a block, e.g.
+   *   <init>(b = foo, a = bar)
+   * is transformed to
+   *   { val x$1 = foo
+   *     val x$2 = bar
+   *     <init>(x$2, x$1)
+   *   }
+   */
+  def stripNamedApplyBlock(tree: Tree) = tree match {
+    case Block(stats, expr) if stats.forall(_.isInstanceOf[ValDef]) =>
+      expr
+    case _ =>
+      tree
+  }
+  
   /** Is tree a self or super constructor call? */
-  def isSelfOrSuperConstrCall(tree: Tree) =
-    isSelfConstrCall(tree) || isSuperConstrCall(tree)
+  def isSelfOrSuperConstrCall(tree: Tree) = {
+    // stripNamedApply for SI-3584: adaptToImplicitMethod in Typers creates a special context
+    // for implicit search in constructor calls, adaptToImplicitMethod(isSelfOrConstrCall)
+    val tree1 = stripNamedApplyBlock(tree)
+    isSelfConstrCall(tree1) || isSuperConstrCall(tree1)
+  }
 
   /** Is tree a variable pattern? */
   def isVarPattern(pat: Tree): Boolean = pat match {

--- a/test/files/pos/t5384.scala
+++ b/test/files/pos/t5384.scala
@@ -1,0 +1,7 @@
+class A(x: String, y: Int)(implicit o: String)
+class B1(implicit o: String) extends A(y = 5, x = "a")
+class B2(implicit o: String) extends A("a", 5)
+class B3(implicit o: String) extends A(y = 5, x = "a")(o)
+
+class AM[E: Manifest](val x: Unit = (), y: Unit)
+class BM[E: Manifest] extends AM[E](y = ())


### PR DESCRIPTION
make TreeInfo recognize constructor calls after named arguments transformation.

build https://scala-webapps.epfl.ch/jenkins/job/scala-checkin-manual/10/
