### PR TITLE
Small documentation fixes & small fix to Scaladoc @see formatting

### DIFF
--- a/src/actors/scala/actors/package.scala
+++ b/src/actors/scala/actors/package.scala
@@ -7,7 +7,7 @@ package scala
  * == Guide ==
  *
  * A detailed guide for the actors library is available
- * [[http://www.scala-lang.org/docu/files/actors-api/actors_api_guide.html#]].
+ * [[http://docs.scala-lang.org/overviews/core/actors.html]].
  *
  * == Getting Started ==
  *

--- a/src/compiler/scala/tools/nsc/doc/html/page/Template.scala
+++ b/src/compiler/scala/tools/nsc/doc/html/page/Template.scala
@@ -511,7 +511,7 @@ class Template(universe: doc.Universe, tpl: DocTemplateEntity) extends HtmlPage 
             <dt>See also</dt>
             <dd>{
               val seeXml:List[scala.xml.NodeSeq]=(for(see <- comment.see ) yield <span class="cmt">{bodyToHtml(see)}</span> )
-              seeXml.reduceLeft(_ ++ Text(", ") ++ _)
+              seeXml.reduceLeft(_ ++ _)
             }</dd>
           } else NodeSeq.Empty
 

--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -439,9 +439,7 @@ object Array extends FallbackArrayBuilding {
  *  example code.
  *  Line 2 is translated into a call to `apply(Int)`, while line 3 is translated into a call to
  *  `update(Int, T)`. For more information on these transformations, see the
- *  [[http://www.scala-lang.org/docu/files/ScalaReference.pdf Scala Language Specification v2.8]], Sections
- *  6.6 and 6.15 respectively.
- *
+ *  
  *  Two implicit conversions exist in [[scala.Predef]] that are frequently applied to arrays: a conversion
  *  to [[scala.collection.mutable.ArrayOps]] (shown on line 4 of the example above) and a conversion
  *  to [[scala.collection.mutable.WrappedArray]] (a subtype of [[scala.collections.Seq]]).
@@ -465,8 +463,9 @@ object Array extends FallbackArrayBuilding {
  *
  *  @author Martin Odersky
  *  @version 1.0
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_38.html#anchor "The Scala 2.8 Collections' API"]]
- *  section on `Array` by Martin Odersky for more information.
+ *  @see [[http://www.scala-lang.org/docu/files/ScalaReference.pdf Scala Language Specification]], for in-depth information on the transformations the Scala compiler makes on Arrays (Sections 6.6 and 6.15 respectively.)
+ *  @see [[http://docs.scala-lang.org/sips/completed/scala-2-8-arrays.html "Scala 2.8 Arrays"]] the Scala Improvement Document detailing arrays since Scala 2.8.
+ *  @see [[http://docs.scala-lang.org/overviews/collections/arrays.html "The Scala 2.8 Collections' API"]] section on `Array` by Martin Odersky for more information.
  *  @define coll array
  *  @define Coll `Array`
  *  @define orderDependent

--- a/src/library/scala/collection/package.scala
+++ b/src/library/scala/collection/package.scala
@@ -14,7 +14,7 @@ package scala
  * == Guide ==
  *
  * A detailed guide for the collections library is available
- * at [[http://www.scala-lang.org/docu/files/collections-api]].
+ * at [[http://docs.scala-lang.org/overviews/collections/introduction.html]].
  *
  * == Using Collections ==
  *
@@ -67,7 +67,7 @@ package scala
  * Also note that the collections library was carefully designed to include several implementations of
  * each of the three basic collection types. These implementations have specific performance
  * characteristics which are described
- * in [[http://www.scala-lang.org/docu/files/collections-api the guide]].
+ * in [[http://docs.scala-lang.org/overviews/collections/performance-characteristics.html the guide]].
  *
  * === Converting between Java Collections ===
  *

--- a/src/library/scala/util/Try.scala
+++ b/src/library/scala/util/Try.scala
@@ -92,8 +92,8 @@ sealed abstract class Try[+T] {
   def andThen[U](f: T => Try[U]): Try[U] = flatMap(f)
 
   /**
-   * Transforms a nested `Try`, i.e., a `Try` of type `Try[Try[T]]`,
-   * into an un-nested `Try`, i.e., a `Try` of type `Try[T]`.
+   * Transforms a nested `Try`, ie, a `Try` of type `Try[Try[T]]`,
+   * into an un-nested `Try`, ie, a `Try` of type `Try[T]`.
    */
   def flatten[U](implicit ev: T <:< Try[U]): Try[U]
 


### PR DESCRIPTION
- updates some some old links to point to doc site
- massaging of doc comments on `Try` so as to make them actually appear (on method `flatten`)
- fixes formatting of "See also" Scaladoc tag for multi-line "See also"s
