### PR TITLE
Small documentation fixes & small fix to Scaladoc @see formatting

### DIFF
--- a/src/actors/scala/actors/package.scala
+++ b/src/actors/scala/actors/package.scala
@@ -7,7 +7,7 @@ package scala
  * == Guide ==
  *
  * A detailed guide for the actors library is available
- * [[http://www.scala-lang.org/docu/files/actors-api/actors_api_guide.html#]].
+ * [[http://docs.scala-lang.org/overviews/core/actors.html]].
  *
  * == Getting Started ==
  *

--- a/src/compiler/scala/tools/nsc/doc/html/page/Template.scala
+++ b/src/compiler/scala/tools/nsc/doc/html/page/Template.scala
@@ -511,7 +511,7 @@ class Template(universe: doc.Universe, tpl: DocTemplateEntity) extends HtmlPage 
             <dt>See also</dt>
             <dd>{
               val seeXml:List[scala.xml.NodeSeq]=(for(see <- comment.see ) yield <span class="cmt">{bodyToHtml(see)}</span> )
-              seeXml.reduceLeft(_ ++ Text(", ") ++ _)
+              seeXml.reduceLeft(_ ++ _)
             }</dd>
           } else NodeSeq.Empty
 

--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -438,7 +438,7 @@ object Array extends FallbackArrayBuilding {
  *  Arrays make use of two common pieces of Scala syntactic sugar, shown on lines 2 and 3 of the above
  *  example code.
  *  Line 2 is translated into a call to `apply(Int)`, while line 3 is translated into a call to
- *  `update(Int, T)`. For more information on these transformations, see the
+ *  `update(Int, T)`.
  *  
  *  Two implicit conversions exist in [[scala.Predef]] that are frequently applied to arrays: a conversion
  *  to [[scala.collection.mutable.ArrayOps]] (shown on line 4 of the example above) and a conversion

--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -439,9 +439,7 @@ object Array extends FallbackArrayBuilding {
  *  example code.
  *  Line 2 is translated into a call to `apply(Int)`, while line 3 is translated into a call to
  *  `update(Int, T)`. For more information on these transformations, see the
- *  [[http://www.scala-lang.org/docu/files/ScalaReference.pdf Scala Language Specification v2.8]], Sections
- *  6.6 and 6.15 respectively.
- *
+ *  
  *  Two implicit conversions exist in [[scala.Predef]] that are frequently applied to arrays: a conversion
  *  to [[scala.collection.mutable.ArrayOps]] (shown on line 4 of the example above) and a conversion
  *  to [[scala.collection.mutable.WrappedArray]] (a subtype of [[scala.collections.Seq]]).
@@ -465,8 +463,9 @@ object Array extends FallbackArrayBuilding {
  *
  *  @author Martin Odersky
  *  @version 1.0
- *  @see [[http://www.scala-lang.org/docu/files/collections-api/collections_38.html#anchor "The Scala 2.8 Collections' API"]]
- *  section on `Array` by Martin Odersky for more information.
+ *  @see [[http://www.scala-lang.org/docu/files/ScalaReference.pdf Scala Language Specification]], for in-depth information on the transformations the Scala compiler makes on Arrays (Sections 6.6 and 6.15 respectively.)
+ *  @see [[http://docs.scala-lang.org/sips/completed/scala-2-8-arrays.html "Scala 2.8 Arrays"]] the Scala Improvement Document detailing arrays since Scala 2.8.
+ *  @see [[http://docs.scala-lang.org/overviews/collections/arrays.html "The Scala 2.8 Collections' API"]] section on `Array` by Martin Odersky for more information.
  *  @define coll array
  *  @define Coll `Array`
  *  @define orderDependent

--- a/src/library/scala/Function.scala
+++ b/src/library/scala/Function.scala
@@ -37,7 +37,7 @@ object Function {
    *  @param   f    a function `T => Option[R]`
    *  @return       a partial function defined for those inputs where
    *                f returns `Some(_)` and undefined where `f` returns `None`.
-   *  @see [[scala.PartialFunction#lift]]
+   *  @see [[scala.PartialFunction]], method `lift`.
    */
   def unlift[T, R](f: T => Option[R]): PartialFunction[T, R] = PartialFunction.unlifted(f)
 

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -451,14 +451,14 @@ object Predef extends LowPriorityImplicits {
   }
 
   /** A type for which there is always an implicit value.
-   *  @see fallbackCanBuildFrom in Array.scala
+   *  @see [[scala.Array$]], method `fallbackCanBuildFrom`
    */
   class DummyImplicit
 
   object DummyImplicit {
 
     /** An implicit value yielding a `DummyImplicit`.
-     *   @see fallbackCanBuildFrom in Array.scala
+     *   @see [[scala.Array$]], method `fallbackCanBuildFrom`
      */
     implicit def dummyImplicit: DummyImplicit = new DummyImplicit
   }

--- a/src/library/scala/collection/IterableLike.scala
+++ b/src/library/scala/collection/IterableLike.scala
@@ -148,7 +148,7 @@ self =>
   }
 
   /** Partitions elements in fixed size ${coll}s.
-   *  @see Iterator#grouped
+   *  @see [[scala.collection.Iterator]], method `grouped`
    *
    *  @param size the number of elements per group
    *  @return An iterator producing ${coll}s of size `size`, except the
@@ -163,7 +163,7 @@ self =>
 
   /** Groups elements in fixed size blocks by passing a "sliding window"
    *  over them (as opposed to partitioning them, as is done in grouped.)
-   *  @see Iterator#sliding
+   *  @see [[scala.collection.Iterator]], method `sliding`
    *
    *  @param size the number of elements per group
    *  @return An iterator producing ${coll}s of size `size`, except the
@@ -174,7 +174,7 @@ self =>
   
   /** Groups elements in fixed size blocks by passing a "sliding window"
    *  over them (as opposed to partitioning them, as is done in grouped.)
-   *  @see Iterator#sliding
+   *  @see [[scala.collection.Iterator]], method `sliding`
    *
    *  @param size the number of elements per group
    *  @param step the distance between the first elements of successive

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -824,7 +824,7 @@ trait Iterator[+A] extends TraversableOnce[A] {
 
   /** Creates a buffered iterator from this iterator.
    *
-   *  @see BufferedIterator
+   *  @see [[scala.collection.BufferedIterator]]
    *  @return  a buffered iterator producing the same values as this iterator.
    *  @note    Reuse: $consumesAndProducesIterator
    */

--- a/src/library/scala/collection/SeqLike.scala
+++ b/src/library/scala/collection/SeqLike.scala
@@ -566,7 +566,7 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
 
   /** Sorts this $Coll according to the Ordering which results from transforming
    *  an implicitly given Ordering with a transformation function.
-   *  @see scala.math.Ordering
+   *  @see [[scala.math.Ordering]]
    *  $willNotTerminateInf
    *  @param   f the transformation function mapping elements
    *           to some other domain `B`.
@@ -591,7 +591,7 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
    *  The sort is stable. That is, elements that are equal (as determined by
    *  `lt`) appear in the same order in the sorted sequence as in the original.
    *
-   *  @see scala.math.Ordering
+   *  @see [[scala.math.Ordering]]
    *
    *  @param  ord the ordering to be used to compare elements.
    *  @return     a $coll consisting of the elements of this $coll
@@ -852,7 +852,7 @@ object SeqLike {
   /** Finds a particular index at which one sequence occurs in another sequence.
    *  Like `indexOf`, but finds the latest occurrence rather than earliest.
    *
-   *  @see  SeqLike#indexOf
+   *  @see  [[scala.collection.SeqLike], method `indexOf`
    */
   def lastIndexOf[B](
     source: Seq[B], sourceOffset: Int, sourceCount: Int,

--- a/src/library/scala/collection/generic/CanBuildFrom.scala
+++ b/src/library/scala/collection/generic/CanBuildFrom.scala
@@ -20,7 +20,7 @@ import scala.annotation.implicitNotFound
  *  @tparam Elem  the element type of the collection to be created.
  *  @tparam To    the type of the collection to be created.
  *
- *  @see Builder
+ *  @see [[scala.collection.mutable.Builder]]
  *  @author Martin Odersky
  *  @author Adriaan Moors
  *  @since 2.8

--- a/src/library/scala/collection/generic/GenericCompanion.scala
+++ b/src/library/scala/collection/generic/GenericCompanion.scala
@@ -16,7 +16,7 @@ import language.higherKinds
  *  represent an unconstrained higher-kinded type. Typically
  *  such classes inherit from trait `GenericTraversableTemplate`.
  *  @tparam  CC   The type constructor representing the collection class.
- *  @see GenericTraversableTemplate
+ *  @see [[scala.collection.generic.GenericTraversableTemplate]]
  *  @author Martin Odersky
  *  @since 2.8
  *  @define coll  collection

--- a/src/library/scala/collection/package.scala
+++ b/src/library/scala/collection/package.scala
@@ -14,7 +14,7 @@ package scala
  * == Guide ==
  *
  * A detailed guide for the collections library is available
- * at [[http://www.scala-lang.org/docu/files/collections-api]].
+ * at [[http://docs.scala-lang.org/overviews/collections/introduction.html]].
  *
  * == Using Collections ==
  *
@@ -67,7 +67,7 @@ package scala
  * Also note that the collections library was carefully designed to include several implementations of
  * each of the three basic collection types. These implementations have specific performance
  * characteristics which are described
- * in [[http://www.scala-lang.org/docu/files/collections-api the guide]].
+ * in [[http://docs.scala-lang.org/overviews/collections/performance-characteristics.html the guide]].
  *
  * === Converting between Java Collections ===
  *

--- a/src/library/scala/sys/package.scala
+++ b/src/library/scala/sys/package.scala
@@ -50,7 +50,7 @@ package object sys {
   /** A bidirectional, mutable Map representing the current system Properties.
    *
    *  @return   a SystemProperties.
-   *  @see      `scala.sys.SystemProperties`
+   *  @see      [[scala.sys.SystemProperties]]
    */
   def props: SystemProperties = new SystemProperties
 

--- a/src/library/scala/util/MurmurHash3.scala
+++ b/src/library/scala/util/MurmurHash3.scala
@@ -19,7 +19,7 @@ import java.lang.Integer.{ rotateLeft => rotl }
  * to remedy some weaknesses and improve performance. This represents the
  * latest and supposedly final version of the algortihm (revision 136).
  *
- * @see http://code.google.com/p/smhasher
+ * @see [[http://code.google.com/p/smhasher]]
  */
 class MurmurHash3 {
   /** Mix in a block of data into an intermediate hash value. */

--- a/src/library/scala/util/Try.scala
+++ b/src/library/scala/util/Try.scala
@@ -92,8 +92,8 @@ sealed abstract class Try[+T] {
   def andThen[U](f: T => Try[U]): Try[U] = flatMap(f)
 
   /**
-   * Transforms a nested `Try`, i.e., a `Try` of type `Try[Try[T]]`,
-   * into an un-nested `Try`, i.e., a `Try` of type `Try[T]`.
+   * Transforms a nested `Try`, ie, a `Try` of type `Try[Try[T]]`,
+   * into an un-nested `Try`, ie, a `Try` of type `Try[T]`.
    */
   def flatten[U](implicit ev: T <:< Try[U]): Try[U]
 

--- a/src/library/scala/util/parsing/combinator/lexical/StdLexical.scala
+++ b/src/library/scala/util/parsing/combinator/lexical/StdLexical.scala
@@ -25,8 +25,8 @@ import scala.collection.mutable
  *  `delimiters` set.
  *
  *  Usually this component is used to break character-based input into
- *  bigger tokens, which are then passed to a token-parser {@see
- *  [[scala.util.parsing.combinator.syntactical.TokenParsers]]}.
+ *  bigger tokens, which are then passed to a token-parser (see
+ *  [[scala.util.parsing.combinator.syntactical.TokenParsers]].)
  *
  * @author Martin Odersky
  * @author Iulian Dragos

--- a/src/library/scala/xml/Node.scala
+++ b/src/library/scala/xml/Node.scala
@@ -162,8 +162,6 @@ abstract class Node extends NodeSeq {
 
   /**
    * Same as `toString('''false''')`.
-   *
-   * @see <code><a href="#toString">toString(Boolean)</a></code>
    */
   override def toString(): String = buildString(false)
 


### PR DESCRIPTION
- updates some old links to point to doc site
- massaging of doc comments on `Try` so as to make them actually appear (on method `flatten`)
- fixes formatting of "See also" Scaladoc tag for multi-line "See also"s
