### PR TITLE
Enumeration#maxId: fix documentation to reflect reality

### DIFF
--- a/src/library/scala/Enumeration.scala
+++ b/src/library/scala/Enumeration.scala
@@ -113,8 +113,8 @@ abstract class Enumeration (initial: Int) extends Serializable {
     * enumeration, but no higher than 0. */
   private var bottomId = if(initial < 0) initial else 0
 
-  /** The highest integer amongst those used to identify values in this
-    * enumeration. */
+  /** The one higher than the highest integer amongst those used to identify
+    *  values in this enumeration. */
   final def maxId = topId
 
   /** The value of this enumeration with given id `x`


### PR DESCRIPTION
maxId is not really the "maximum id", but rather one past the max:

scala> object Foo extends Enumeration {
     |   val x = Value
     |   val y = Value
     | }
defined module Foo

scala> Foo.maxId
res0: Int = 2

scala> Foo(2)
java.util.NoSuchElementException: key not found: 2
    at scala.collection.MapLike$class.default(MapLike.scala:225)
        ...

scala> Foo(1)
res2: Foo.Value = y
