### PR TITLE
Fix SI-5259

### DIFF
--- a/test/files/pos/t5259.scala
+++ b/test/files/pos/t5259.scala
@@ -1,0 +1,21 @@
+class A[T]
+class B {
+  def m(a: A[this.type] = new A[this.type]) { }
+}
+
+class C {
+  def foo(a: Int, b: Int = 0) = 0
+  def foo() = 0
+}
+
+object Test {
+  def newB = new B
+  newB.m()
+
+  val stableB = new B
+  stableB.m()
+
+  def f {
+    println((new C).foo(0))
+  }
+}


### PR DESCRIPTION
Calling the type checker on an Ident tree instead of using gen.mkAttributedRef assigns a SingleType to the tree.

build: https://scala-webapps.epfl.ch/jenkins/job/scala-checkin-manual/13/
