### PR TITLE
A band-aid solution for SI-5803.

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/Trees.scala
+++ b/src/compiler/scala/tools/nsc/ast/Trees.scala
@@ -362,7 +362,8 @@ trait Trees extends reflect.internal.Trees { self: Global =>
       }
 
       val x1 = new Transformer().transform(x)
-      assert(x.getClass isInstance x1, x1.getClass)
+      // The loose invariant is a temporary workaround for SI-5803
+      assert(x.getClass.isInstance(x1) || (x.isInstanceOf[ApplyConstructor] && x1.isInstanceOf[Apply]), (x.getClass, x1.getClass))
       x1.asInstanceOf[T]
     }
   }

--- a/test/files/neg/t5803.check
+++ b/test/files/neg/t5803.check
@@ -1,0 +1,4 @@
+t5803.scala:3: error: could not find implicit value for parameter ev: Nothing
+  new Foo(): String
+  ^
+one error found

--- a/test/files/neg/t5803.scala
+++ b/test/files/neg/t5803.scala
@@ -1,0 +1,4 @@
+object Test {
+  class Foo()(implicit ev: Nothing)
+  new Foo(): String
+}


### PR DESCRIPTION
Since ae5ff662, resetAttrs duplicates trees, which doesn't preserve ApplyConstructor.
My attempt to modify TreeCopier to do so proved trickier than expected.

In any case, ApplyConstructor is not long for this world, and is only used in tree printing
to distinguish `new X` from regular Apply trees, so this should suffice pending full surgery.
