### PR TITLE
Fix to Scaladoc keyboard shortcuts for Firefox

### DIFF
--- a/src/compiler/scala/tools/nsc/doc/html/page/Index.scala
+++ b/src/compiler/scala/tools/nsc/doc/html/page/Index.scala
@@ -44,7 +44,7 @@ class Index(universe: doc.Universe, index: doc.Index) extends HtmlPage {
       </div>
       { browser }
       <div id="content" class="ui-layout-center">
-        <iframe id="template" src={ relativeLinkTo{List("package.html")} }/>
+        <iframe id="template" name="template" src={ relativeLinkTo{List("package.html")} }/>
       </div>
     </body>
 


### PR DESCRIPTION
Trivial patch should fix bug in Firefox. 

Preview URL, working in Firefox, Chrome, and Safari: http://lampwww.epfl.ch/~hmiller/scaladoc/library

Anyone with IE, please now test the above URL and let me know if you have any issues.
