### PR TITLE
SI-3761: Overload resolution fails on by-name parameter

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -172,6 +172,7 @@ trait ScalaSettings extends AbsScalaSettings
   val YmethodInfer    = BooleanSetting    ("-Yinfer-argument-types", "Infer types for arguments of overriden methods.")
   val etaExpandKeepsStar = BooleanSetting ("-Yeta-expand-keeps-star", "Eta-expand varargs methods to T* rather than Seq[T].  This is a temporary option to ease transition.")
   val noSelfCheck     = BooleanSetting    ("-Yno-self-type-checks", "Suppress check for self-type conformance among inherited members.")
+  val YresolveByName  = BooleanSetting    ("-Yresolve-by-name", "Favor an exact match of call-by-name parameters if overloaded.")
   val YvirtClasses    = false // too embryonic to even expose as a -Y //BooleanSetting    ("-Yvirtual-classes", "Support virtual classes")
 
   val exposeEmptyPackage = BooleanSetting("-Yexpose-empty-package", "Internal only: expose the empty package.").internalOnly()

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2812,7 +2812,7 @@ trait Typers extends Modes with Adaptations with Taggings {
           if (context.hasErrors)
             setError(tree)
           else {
-            inferMethodAlternative(fun, undetparams, argtpes.toList, pt, varArgsOnly = treeInfo.isWildcardStarArgList(args))
+            inferMethodAlternative(fun, undetparams, args, argtpes.toList, pt, varArgsOnly = treeInfo.isWildcardStarArgList(args))
             doTypedApply(tree, adapt(fun, forFunMode(mode), WildcardType), args1, mode, pt)
           }
 

--- a/test/files/neg/names-defaults-neg.check
+++ b/test/files/neg/names-defaults-neg.check
@@ -59,7 +59,7 @@ names-defaults-neg.scala:49: error: ambiguous reference to overloaded definition
 both method g in object t7 of type (a: B)String
 and  method g in object t7 of type (a: C, b: Int*)String
 match argument types (C)
-  t7.g(new C()) // ambigous reference
+  t7.g(new C()) // ambiguous reference
      ^
 names-defaults-neg.scala:53: error: parameter 'b' is already specified at parameter position 2
   test5(a = 1, b = "dkjl", b = "dkj")
@@ -74,7 +74,7 @@ names-defaults-neg.scala:61: error: ambiguous reference to overloaded definition
 both method f in object t8 of type (b: String, a: Int)String
 and  method f in object t8 of type (a: Int, b: Object)String
 match argument types (a: Int,b: String) and expected result type Any
-  println(t8.f(a = 0, b = "1")) // ambigous reference
+  println(t8.f(a = 0, b = "1")) // ambiguous reference
              ^
 names-defaults-neg.scala:69: error: wrong number of arguments for <none>: (x: Int, y: String)A1
   A1() match { case A1(_) => () }

--- a/test/files/neg/names-defaults-neg.scala
+++ b/test/files/neg/names-defaults-neg.scala
@@ -46,7 +46,7 @@ object Test extends App {
     def g(a: C, b: Int*) = "third"
     def g(a: B) = "fourth"
   }
-  t7.g(new C()) // ambigous reference
+  t7.g(new C()) // ambiguous reference
 
   // vararg
   def test5(a: Int, b: String*) = a
@@ -58,7 +58,7 @@ object Test extends App {
     def f(a: Int, b: Object) = "first"
     def f(b: String, a: Int) = "second"
   }
-  println(t8.f(a = 0, b = "1")) // ambigous reference
+  println(t8.f(a = 0, b = "1")) // ambiguous reference
 
 
   // case class copy does not exist if there's a vararg

--- a/test/files/neg/t3761-neg-overload-byname-neg.check
+++ b/test/files/neg/t3761-neg-overload-byname-neg.check
@@ -1,0 +1,7 @@
+t3761-neg-overload-byname.scala:14: error: ambiguous reference to overloaded definition,
+both method f in class WWTT of type (i: => Int, j: Int)Int
+and  method f in class WWTT of type (i: Int, j: => Int)Int
+match argument types (Int,Int)
+    sut.f(1,2)
+        ^
+one error found

--- a/test/files/neg/t3761-neg-overload-byname.scala
+++ b/test/files/neg/t3761-neg-overload-byname.scala
@@ -1,0 +1,16 @@
+
+package overloadByName
+
+// WWTT = what were they thinking
+class WWTT {
+  def f(i: Int, j: =>Int) = i+j
+  def f(i: =>Int, j: Int) = i*j
+}
+
+object Test {
+  def main(args: Array[String]) {
+    // sut =  system under test
+    val sut = new WWTT
+    sut.f(1,2)
+  }
+}

--- a/test/files/neg/t4728-lead-star.check
+++ b/test/files/neg/t4728-lead-star.check
@@ -1,0 +1,7 @@
+t4728-lead-star.scala:13: error: ambiguous reference to overloaded definition,
+both method f in object Ambiguous of type (ys: Y*)Int
+and  method f in object Ambiguous of type (x: X)Int
+match argument types (Y) and expected result type Any
+    println(Ambiguous.f(new Y))
+                      ^
+one error found

--- a/test/files/neg/t4728-lead-star.scala
+++ b/test/files/neg/t4728-lead-star.scala
@@ -1,0 +1,15 @@
+
+class X
+class Y extends X
+
+// A lead star but no diva.
+object Ambiguous {
+  def f(x: X) = 1
+  def f(ys: Y*) = 2
+}
+
+object Test {
+  def main(args: Array[String]) {
+    println(Ambiguous.f(new Y))
+  }
+}

--- a/test/files/run/t3761-overload-byname.check
+++ b/test/files/run/t3761-overload-byname.check
@@ -1,0 +1,9 @@
+hello
+hello working world
+goodnight
+goodnight moon, nobody, noises everywhere
+knock-knock!
+who's there?
+gee whiz!
+resolve this!!!!
+hello world!!!

--- a/test/files/run/t3761-overload-byname.flags
+++ b/test/files/run/t3761-overload-byname.flags
@@ -1,0 +1,1 @@
+-Yresolve-by-name

--- a/test/files/run/t3761-overload-byname.scala
+++ b/test/files/run/t3761-overload-byname.scala
@@ -1,0 +1,39 @@
+
+class OverTheTop {
+  def info0(m: String) = m
+  def info0(m: String, args: Any*) = m +" "+ args.mkString(" ")
+
+  // as reported
+  def info1(m: =>String) = m
+  def info1(m: =>String, args: Any*) = m +" "+ args.mkString(", ")
+
+  def mixed(m: String) = m + "!"
+  def mixed(m: =>String, args: Any*) = m +" "+ args.mkString(" ") + "?"
+  def mixed(m: =>String) = "gee " + m + "!"
+
+  def goForIt(m: =>String) = mixed(m)  // go for the eval param!
+}
+class Tri {
+  def choices(m: =>String,n: =>String) = m +" "+ n + "!"
+  def choices(m: =>String,n: String) = m +" "+ n + "!!"
+  def choices(m: String,n: =>String) = m +" "+ n + "!!!"
+  def choices(m: String,n: String) = m +" "+ n + "!!!!"
+
+  def disambiguate(m: String,n: =>String) = choices(m,n)
+}
+
+object Test {
+  def main(args: Array[String]) {
+    val top = new OverTheTop
+    println(top.info0("hello"))
+    println(top.info0("hello","working","world"))
+    println(top.info1("goodnight"))
+    println(top.info1("goodnight", "moon", "nobody", "noises everywhere"))
+    println(top.mixed("knock-knock"))
+    println(top.mixed("who's", "there"))
+    println(top.goForIt("whiz"))
+    val tri = new Tri
+    println(tri.choices("resolve","this"))
+    println(tri.disambiguate("hello","world"))
+  }
+}

--- a/test/files/run/t3761-overload-byvalue.check
+++ b/test/files/run/t3761-overload-byvalue.check
@@ -1,0 +1,9 @@
+hello
+hello working world
+goodnight
+goodnight moon, nobody, noises everywhere
+knock-knock!
+who's there?
+whiz!
+resolve this!!!!
+hello world!!!!

--- a/test/files/run/t3761-overload-byvalue.scala
+++ b/test/files/run/t3761-overload-byvalue.scala
@@ -1,0 +1,39 @@
+
+class OverTheTop {
+  def info0(m: String) = m
+  def info0(m: String, args: Any*) = m +" "+ args.mkString(" ")
+
+  // as reported
+  def info1(m: =>String) = m
+  def info1(m: =>String, args: Any*) = m +" "+ args.mkString(", ")
+
+  def mixed(m: String) = m + "!"
+  def mixed(m: =>String, args: Any*) = m +" "+ args.mkString(" ") + "?"
+  def mixed(m: =>String) = "gee " + m + "!"
+
+  def goForIt(m: =>String) = mixed(m)  // go for the eval param!
+}
+class Tri {
+  def choices(m: =>String,n: =>String) = m +" "+ n + "!"
+  def choices(m: =>String,n: String) = m +" "+ n + "!!"
+  def choices(m: String,n: =>String) = m +" "+ n + "!!!"
+  def choices(m: String,n: String) = m +" "+ n + "!!!!"
+
+  def disambiguate(m: String,n: =>String) = choices(m,n)
+}
+
+object Test {
+  def main(args: Array[String]) {
+    val top = new OverTheTop
+    println(top.info0("hello"))
+    println(top.info0("hello","working","world"))
+    println(top.info1("goodnight"))
+    println(top.info1("goodnight", "moon", "nobody", "noises everywhere"))
+    println(top.mixed("knock-knock"))
+    println(top.mixed("who's", "there"))
+    println(top.goForIt("whiz"))
+    val tri = new Tri
+    println(tri.choices("resolve","this"))
+    println(tri.disambiguate("hello","world"))
+  }
+}


### PR DESCRIPTION
Preamble: passes ant test and ant nightly.  Build time is not slower. Tie-break by cbn is behind a -Yoption.

Footnote: I tried retaining by-name during type inference, but that breaks a bound (in json.Parser, "null" ^^^ null becomes Parser[Nothing] instead of Parser[Null].  I don't see to the bottom there.  Continuing education.

When isAsSpecific checks if method m applies to args of types of
formal params of m1, a by-name parameter was converted to its
underlying result type for the params (of m) but not the args (of m1).
This had the useful effect of making m(A) more specific than m(=>A),
but also made m(=>A) and m(=>A, B*) ambiguous.  To handle this edge
case, the isCompatible test for A and =>A is made explicit, and
by-name params are no longer converted.

An option -Yresolve-by-name is provided for the purpose of
favoring m(=>A) over m(A) when applied to (=>A).  This only happens
for "pass-by-name", when f(x: =>A) invokes g(x).  Because overload
resolution does not normally consider the call site, this optional
behavior is not specified. (An analogous case under discussion,
which is more specified: f(x: A) and f(y: B, C*) where B <: A,
for f(b) chooses the fixed-arity method, even though f(B) is more
specific than f(A); that is, the number of actual arguments is not
an input to overload resolution.)

The mechanism for resolve-by-name is to convert cbn params to the
underlying type, which results in ties between m(A) and m(=>A),
and then pick the method which exactly matches the call site with
respect to by-namedness.

The specified workaround for selecting overloaded f(=>A) is to
put the definition in an interface (where it is not overloaded).
