### PR TITLE
Don't hop to the first enclosing, non-silent context typing refinements

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2498,10 +2498,7 @@ trait Typers extends Modes with Adaptations with Taggings {
       namer.enterSyms(stats)
       // need to delay rest of typedRefinement to avoid cyclic reference errors
       unit.toCheck += { () =>
-        // go to next outer context which is not silent, see #3614
-        var c = context
-        while (c.bufferErrors) c = c.outer
-        val stats1 = newTyper(c).typedStats(stats, NoSymbol)
+        val stats1 = typedStats(stats, NoSymbol)
         for (stat <- stats1 if stat.isDef) {
           val member = stat.symbol
           if (!(context.owner.ancestors forall

--- a/test/files/neg/t3614.check
+++ b/test/files/neg/t3614.check
@@ -1,0 +1,4 @@
+t3614.scala:2: error: class type required but AnyRef{def a: <?>} found
+  def v = new ({ def a=0 })
+               ^
+one error found

--- a/test/files/neg/t3614.scala
+++ b/test/files/neg/t3614.scala
@@ -1,0 +1,3 @@
+object t3614 {
+  def v = new ({ def a=0 })
+}

--- a/test/files/pos/t3856.scala
+++ b/test/files/pos/t3856.scala
@@ -2,6 +2,7 @@ case class C[T](x: T)
 
 case class CS(xs: C[_]*)
 
+// t3856
 object Test {
   val x = CS(C(5), C("abc")) match { case CS(C(5), xs @ _*) => xs }
   println(x)

--- a/test/files/pos/t5305.scala
+++ b/test/files/pos/t5305.scala
@@ -1,0 +1,13 @@
+object t5305 {
+  def in(a: Any) = {}
+
+  object O {
+    type F = Int
+    val v = ""
+  }
+
+  in {
+  	import O.{F, v}
+    type x = {type l = (F, v.type)} // not found: type F
+  }
+}


### PR DESCRIPTION
Closes SI-5305.

This reverts a few lines of e5cfe47a19, which was a remedy for SI-3614 and SI-3856*. I added a test case for the former, the
latter was already tested. Both tests pass after this change, and they do so with the old and new pattern matcher.

But does this change still "avoid trees with null types in presentation compiler"? What was the intent of the context hopping in the first place?
- Based on this comment: https://issues.scala-lang.org/browse/SI-3614?focusedCommentId=50477&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-50477, which elaborates further than the commit comment of e5cfe47a19.
