### PR TITLE
Consider method-scoped companions in the implicit scope.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -929,7 +929,7 @@ trait Implicits {
               }
             case None =>
               if (pre.isStable) {
-                val companion = sym.companionModule
+                val companion = companionSymbolOf(sym, context)
                 companion.moduleClass match {
                   case mc: ModuleClassSymbol =>
                     val infos =

--- a/test/files/pos/t4975.scala
+++ b/test/files/pos/t4975.scala
@@ -1,0 +1,12 @@
+object ImplicitScope {
+  class A[T]
+
+  def foo {
+    trait B
+    object B {
+      implicit def ab = new A[B]
+    }
+
+    implicitly[A[B]]  // Error
+  }
+}


### PR DESCRIPTION
Fixes SI-4975.

I'll reproduce a relevant snippet of dialogue from Namers#companionSymbolOf:

``` scala
/** The companion class or companion module of `original`.
   *  Calling .companionModule does not work for classes defined inside methods.
   *
   *  !!! Then why don't we fix companionModule? Does the presence of these
   *  methods imply all the places in the compiler calling sym.companionModule are
   *  bugs waiting to be reported? If not, why not? When exactly do we need to
   *  call this method?
   */
  def companionSymbolOf(original: Symbol, ctx: Context): Symbol = {
```

This was one such bug.

Hasn't been through a full build; delegating that to build-bot.

Review by @adriaanm / @paulp
- performance ?
