### PR TITLE
SI-5760: Improve error message for package$Klass conflict with Klass

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -874,8 +874,12 @@ trait ContextErrors {
         val s1 = if (prevSym.isModule) "case class companion " else ""
         val s2 = if (prevSym.isSynthetic) "(compiler-generated) " + s1 else ""
         val s3 = if (prevSym.isCase) "case class " + prevSym.name else "" + prevSym
+        val where = if (currentSym.owner.isPackageClass != prevSym.owner.isPackageClass) {
+                      val inOrOut = if (prevSym.owner.isPackageClass) "outside of" else "in"
+                      " %s package object %s".format(inOrOut, ""+prevSym.effectiveOwner.name)
+                    } else ""
 
-        issueSymbolTypeError(currentSym, prevSym.name + " is already defined as " + s2 + s3)
+        issueSymbolTypeError(currentSym, prevSym.name + " is already defined as " + s2 + s3 + where)
       }
 
       def MaxParametersCaseClassError(tree: Tree) =

--- a/test/files/neg/t5760-pkgobj-warn.check
+++ b/test/files/neg/t5760-pkgobj-warn.check
@@ -1,0 +1,4 @@
+stalepkg_2.scala:6: error: Foo is already defined as class Foo in package object stalepkg
+  class Foo
+        ^
+one error found

--- a/test/files/neg/t5760-pkgobj-warn/stalepkg_1.scala
+++ b/test/files/neg/t5760-pkgobj-warn/stalepkg_1.scala
@@ -1,0 +1,11 @@
+
+package object stalepkg {
+  class Foo
+}
+
+package stalepkg {
+  object Test {
+    def main(args: Array[String]) {
+    }
+  }
+}

--- a/test/files/neg/t5760-pkgobj-warn/stalepkg_2.scala
+++ b/test/files/neg/t5760-pkgobj-warn/stalepkg_2.scala
@@ -1,0 +1,11 @@
+
+package object stalepkg {
+}
+
+package stalepkg {
+  class Foo
+  object Test {
+    def main(args: Array[String]) {
+    }
+  }
+}


### PR DESCRIPTION
Added a clarification to DoubleDefError for when the previous symbol
was in the package object but current symbol is not.

This was actually supposed to be an opportunity to hack partest to
run the two-step failing compilation, but somebody beat me to it and my
rebase failed.

The next hacking opportunity might be to add .pt script files!  The
possibilities are endless.
