### PR TITLE
SI-5779: Wrong warning message (comparing Number)

### DIFF
--- a/src/compiler/scala/reflect/internal/Definitions.scala
+++ b/src/compiler/scala/reflect/internal/Definitions.scala
@@ -404,6 +404,7 @@ trait Definitions extends reflect.api.StandardDefinitions {
     lazy val JavaSerializableClass = requiredClass[java.io.Serializable] modifyInfo fixupAsAnyTrait
     lazy val ComparableClass       = requiredClass[java.lang.Comparable[_]] modifyInfo fixupAsAnyTrait
     lazy val JavaCloneableClass    = requiredClass[java.lang.Cloneable]
+    lazy val JavaNumberClass       = requiredClass[java.lang.Number]
     lazy val RemoteInterfaceClass  = requiredClass[java.rmi.Remote]
     lazy val RemoteExceptionClass  = requiredClass[java.rmi.RemoteException]
 

--- a/test/files/pos/t5779-numeq-warn.scala
+++ b/test/files/pos/t5779-numeq-warn.scala
@@ -1,0 +1,13 @@
+
+object Test {
+  def main(args: Array[String]) {
+    val d: Double = (BigInt(1) << 64).toDouble
+    val f: Float = d.toFloat
+    val n: java.lang.Number = d.toFloat
+    assert (d == f)   // ok
+    assert (d == n)   // was: comparing values of types Double and Number using `==' will always yield false
+    assert (n == d)   // was: Number and Double are unrelated: they will most likely never compare equal
+    assert (f == n)
+    assert (n == f)
+  }
+}


### PR DESCRIPTION
Probably this bug won't exist in some future version of Scala.  

It's hardly a bug; more like a gnat.

BoxesRuntime knows how to compare java.lang.Number, so we must not warn.
