### PR TITLE
Closes SI-5821.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1306,14 +1306,18 @@ trait Namers extends MethodSynthesis {
           if (expr1.symbol != null && expr1.symbol.isRootPackage)
             RootImportError(tree)
 
-          val newImport = treeCopy.Import(tree, expr1, selectors).asInstanceOf[Import]
-          checkSelectors(newImport)
-          transformed(tree) = newImport
-          // copy symbol and type attributes back into old expression
-          // so that the structure builder will find it.
-          expr.symbol = expr1.symbol
-          expr.tpe = expr1.tpe
-          ImportType(expr1)
+          if (expr1.isErrorTyped)
+            ErrorType
+          else {
+            val newImport = treeCopy.Import(tree, expr1, selectors).asInstanceOf[Import]
+            checkSelectors(newImport)
+            transformed(tree) = newImport
+            // copy symbol and type attributes back into old expression
+            // so that the structure builder will find it.
+            expr.symbol = expr1.symbol
+            expr.tpe = expr1.tpe
+            ImportType(expr1)
+          }
       }
 
       val result =

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2552,9 +2552,11 @@ trait Typers extends Modes with Adaptations with Taggings {
         else
           stat match {
             case imp @ Import(_, _) =>
-              context = context.makeNewImport(imp)
               imp.symbol.initialize
-              typedImport(imp)
+              if (!imp.symbol.isError) {
+                context = context.makeNewImport(imp)
+                typedImport(imp)
+              } else EmptyTree
             case _ =>
               if (localTarget && !includesTargetPos(stat)) {
                 // skip typechecking of statements in a sequence where some other statement includes

--- a/test/files/buildmanager/t2792/t2792.check
+++ b/test/files/buildmanager/t2792/t2792.check
@@ -9,3 +9,6 @@ compiling Set(A2.scala)
 A2.scala:2: error: stable identifier required, but A.x found.
   import A.x.y
            ^
+A2.scala:3: error: not found: value y
+  val z = y
+          ^

--- a/test/files/neg/t5821.check
+++ b/test/files/neg/t5821.check
@@ -1,0 +1,4 @@
+t5821.scala:1: error: not found: object SthImportant
+import SthImportant._
+       ^
+one error found

--- a/test/files/neg/t5821.scala
+++ b/test/files/neg/t5821.scala
@@ -1,0 +1,8 @@
+import SthImportant._
+
+class Bar
+
+class Foo2 {
+  type Sth = Array[Bar]
+  def foo(xs: Sth): Bar = if ((xs eq null) || (xs.length == 0)) null else xs(0)
+}

--- a/test/files/neg/t639.check
+++ b/test/files/neg/t639.check
@@ -1,4 +1,7 @@
 t639.scala:3: error: not found: object a
 import a._
        ^
-one error found
+t639.scala:5: error: not found: type B
+@B
+ ^
+two errors found


### PR DESCRIPTION
This was an interesting one. Basically an erroneous
import was creating an erroneous symbol for Array (similary
for other symbols that were 'found' in this import) which was
leading to all sorts of inconsistencies and spurious errors.

This wasn't a bug in ContextErrors but rather something that
existed for ages and was hidden from the general audience.

Review by @paulp.
