### PR TITLE
SI-5318 Make implicit divergence checking PolyType aware.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -346,7 +346,12 @@ trait Implicits {
         case _ => tp
       }
       def stripped(tp: Type): Type = {
-        deriveTypeWithWildcards(freeTypeParametersNoSkolems.collect(tp))(tp)
+        def isFreeTypeParamNoSkolem(sym: Symbol) = sym.isTypeParameter && sym.owner.isTerm
+        // `t.typeSymbol` returns the symbol of the normalized type. If that normalized type
+        // is a `PolyType`, the symbol of the result type is returned. This is precisely
+        // what we require for SI-5318.
+        val syms = for (t <- tp; if isFreeTypeParamNoSkolem(t.typeSymbol)) yield t.typeSymbol
+        deriveTypeWithWildcards(syms.distinct)(tp)
       }
       def sum(xs: List[Int]) = (0 /: xs)(_ + _)
       def complexity(tp: Type): Int = tp.normalize match {

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -346,11 +346,10 @@ trait Implicits {
         case _ => tp
       }
       def stripped(tp: Type): Type = {
-        def isFreeTypeParamNoSkolem(sym: Symbol) = sym.isTypeParameter && sym.owner.isTerm
         // `t.typeSymbol` returns the symbol of the normalized type. If that normalized type
-        // is a `PolyType`, the symbol of the result type is returned. This is precisely
+        // is a `PolyType`, the symbol of the result type is collected. This is precisely
         // what we require for SI-5318.
-        val syms = for (t <- tp; if isFreeTypeParamNoSkolem(t.typeSymbol)) yield t.typeSymbol
+        val syms = for (t <- tp; if t.typeSymbol.isTypeParameter) yield t.typeSymbol
         deriveTypeWithWildcards(syms.distinct)(tp)
       }
       def sum(xs: List[Int]) = (0 /: xs)(_ + _)

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1076,7 +1076,7 @@ trait Infer {
      */
     def inferConstructorInstance(tree: Tree, undetparams: List[Symbol], pt0: Type) {
       val pt       = widen(pt0)
-      val ptparams = freeTypeParamsOfTerms.collect(pt)
+      val ptparams = freeTypeParamsOfTerms(pt)
       val ctorTp   = tree.tpe
       val resTp    = ctorTp.finalResultType
 
@@ -1310,8 +1310,8 @@ trait Infer {
 
     def inferTypedPattern(tree0: Tree, pattp: Type, pt0: Type): Type = {
       val pt        = widen(pt0)
-      val ptparams  = freeTypeParamsOfTerms.collect(pt)
-      val tpparams  = freeTypeParamsOfTerms.collect(pattp)
+      val ptparams  = freeTypeParamsOfTerms(pt)
+      val tpparams  = freeTypeParamsOfTerms(pattp)
 
       def ptMatchesPattp = pt matchesPattern pattp.widen
       def pattpMatchesPt = pattp matchesPattern pt
@@ -1364,7 +1364,7 @@ trait Infer {
 
     def inferModulePattern(pat: Tree, pt: Type) =
       if (!(pat.tpe <:< pt)) {
-        val ptparams = freeTypeParamsOfTerms.collect(pt)
+        val ptparams = freeTypeParamsOfTerms(pt)
         debuglog("free type params (2) = " + ptparams)
         val ptvars = ptparams map freshVar
         val pt1 = pt.instantiateTypeParams(ptparams, ptvars)
@@ -1381,19 +1381,6 @@ trait Infer {
       }
     }
 
-    abstract class SymCollector extends TypeCollector(List[Symbol]()) {
-      protected def includeCondition(sym: Symbol): Boolean
-
-      def traverse(tp: Type) {
-        tp.normalize match {
-          case TypeRef(_, sym, _) =>
-            if (includeCondition(sym) && !result.contains(sym)) result = sym :: result
-          case _ =>
-        }
-        mapOver(tp)
-      }
-    }
-
     object approximateAbstracts extends TypeMap {
       def apply(tp: Type): Type = tp.normalize match {
         case TypeRef(pre, sym, _) if sym.isAbstractType => WildcardType
@@ -1401,31 +1388,21 @@ trait Infer {
       }
     }
 
-    /** A traverser to collect type parameters referred to in a type
+    /** Collects type parameters referred to in a type.
      */
-    object freeTypeParamsOfTerms extends SymCollector {
+    def freeTypeParamsOfTerms(tp: Type) = {
       // An inferred type which corresponds to an unknown type
       // constructor creates a file/declaration order-dependent crasher
       // situation, the behavior of which depends on the state at the
       // time the typevar is created. Until we can deal with these
       // properly, we can avoid it by ignoring type parameters which
       // have type constructors amongst their bounds. See SI-4070.
-      protected def includeCondition(sym: Symbol) = (
-           sym.isAbstractType
-        && sym.owner.isTerm
-        && !sym.info.bounds.exists(_.typeParams.nonEmpty)
-      )
-    }
-
-    /** A traverser to collect type parameters referred to in a type
-     */
-    object freeTypeParametersNoSkolems extends SymCollector {
-      protected def includeCondition(sym: Symbol): Boolean =
-        sym.isTypeParameter && sym.owner.isTerm
-    }
-
-    object typeRefs extends SymCollector {
-      protected def includeCondition(sym: Symbol): Boolean = true
+      def includeCondition(sym: Symbol) = (
+        sym.isAbstractType
+          && sym.owner.isTerm
+          && !sym.info.bounds.exists(_.typeParams.nonEmpty)
+        )
+      (for (t <- tp if includeCondition(t.typeSymbol)) yield t.typeSymbol).distinct
     }
 
     /* -- Overload Resolution ---------------------------------------------- */

--- a/test/files/neg/t5318.check
+++ b/test/files/neg/t5318.check
@@ -1,0 +1,5 @@
+t5318.scala:7: error: diverging implicit expansion for type CompilerHang.this.TC[F]
+starting with method tc in class CompilerHang
+  breakage  // type checker doesn't terminate, should report inference failure
+  ^
+one error found

--- a/test/files/neg/t5318.scala
+++ b/test/files/neg/t5318.scala
@@ -1,0 +1,8 @@
+class CompilerHang {
+  trait TC[M[_]]
+  trait S[A]
+
+  implicit def tc[M[_]](implicit M0: TC[M]): TC[S] = null
+  def breakage[F[_] : TC] = 0
+  breakage  // type checker doesn't terminate, should report inference failure
+}

--- a/test/files/neg/t5318b.check
+++ b/test/files/neg/t5318b.check
@@ -1,0 +1,5 @@
+t5318b.scala:7: error: diverging implicit expansion for type DivergingImplicitReported.this.TC[F]
+starting with method tc in class DivergingImplicitReported
+  breakage // correct: diverging implicit expansion
+  ^
+one error found

--- a/test/files/neg/t5318b.scala
+++ b/test/files/neg/t5318b.scala
@@ -1,0 +1,8 @@
+class DivergingImplicitReported {
+  trait TC[M]
+  trait S
+
+  implicit def tc[M](implicit M0: TC[M]): TC[S] = null
+  def breakage[F: TC] = 0
+  breakage // correct: diverging implicit expansion
+}

--- a/test/files/neg/t5318c.check
+++ b/test/files/neg/t5318c.check
@@ -1,0 +1,5 @@
+t5318c.scala:13: error: diverging implicit expansion for type CompilerHang.this.TC[x]
+starting with method tc in class CompilerHang
+  breakage(tc) // type checker doesn't terminate, should report inference failure
+           ^
+one error found

--- a/test/files/neg/t5318c.scala
+++ b/test/files/neg/t5318c.scala
@@ -1,0 +1,14 @@
+class CompilerHang {
+  trait TC[M[_]]
+  trait S[A]
+
+  class C[M[_]] {
+    type TCM = TC[M]
+  }
+
+  // A nefarious implicit, to motivate the removal of `&& sym.owner.isTerm` from
+  // `isFreeTypeParamNoSkolem`.
+  implicit def tc[x[_], CC[x[_]] <: C[x]](implicit M0: CC[x]#TCM): CC[x]#TCM = null
+  def breakage[F[_] : TC] = 0
+  breakage(tc) // type checker doesn't terminate, should report inference failure
+}


### PR DESCRIPTION
Replaces the two active subclasses of `SymCollector`
with direct use of `Type#foreach` and `Type#typeSymbol`.

Resubmission of #589.
