### PR TITLE
don't error when not emitting required switch

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
@@ -1105,7 +1105,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
         }
 
         emitSwitch(scrut, scrutSym, casesNoSubstOnly, pt, matchFailGenOverride).getOrElse{
-          if (requireSwitch) typer.context.unit.error(scrut.pos, "could not emit switch for @switch annotated match")
+          if (requireSwitch) typer.context.unit.warning(scrut.pos, "could not emit switch for @switch annotated match")
 
           if (casesNoSubstOnly nonEmpty) {
             // before optimizing, check casesNoSubstOnly for presence of a default case,

--- a/test/files/neg/switch.flags
+++ b/test/files/neg/switch.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings


### PR DESCRIPTION
we don't handle switches with guards, whereas the old patmat did
to ease the transition, let's not error out and see how we can resolve this
