### PR TITLE
Test case closes SI-4818

### DIFF
--- a/test/files/neg/t4818.check
+++ b/test/files/neg/t4818.check
@@ -1,0 +1,6 @@
+t4818.scala:4: error: type mismatch;
+ found   : Int(5)
+ required: Nothing
+	def f(x: Any) = x match { case Fn(f) => f(5) }
+                                                  ^
+one error found

--- a/test/files/neg/t4818.scala
+++ b/test/files/neg/t4818.scala
@@ -1,0 +1,7 @@
+object Test {
+	case class Fn[A, B](f: A => B)
+
+	def f(x: Any) = x match { case Fn(f) => f(5) }
+
+	Fn((x: String) => x)
+}


### PR DESCRIPTION
Fixed between 2.10.0 M2 and M3, with both the old and new pattern matcher.
