### PR TITLE
SI-5652 Mangle names of potentially public lambda lifted methods.

### DIFF
--- a/test/files/run/t5652.check
+++ b/test/files/run/t5652.check
@@ -1,0 +1,8 @@
+public static final int T1$class.g$1(T1)
+public static int T1$class.f0(T1)
+public static void T1$class.$init$(T1)
+public final int A1.A1$$g$2()
+public int A1.f1()
+public final int A2.A2$$g$1()
+public int A2.f0()
+public int A2.f2()

--- a/test/files/run/t5652/t5652_1.scala
+++ b/test/files/run/t5652/t5652_1.scala
@@ -1,0 +1,6 @@
+trait T1 {
+  def f0 = { def g = 1 ; class A { def a = g } ; g ; new A().a }
+}
+class A1 {
+  def f1 = { def g = 1 ; class A { def a = g } ; g ; new A().a }
+}

--- a/test/files/run/t5652/t5652_2.scala
+++ b/test/files/run/t5652/t5652_2.scala
@@ -1,0 +1,9 @@
+class A2 extends A1 with T1{
+	def f2 = { def g = 5 ; class A { def a = g }; g ; new A().a }
+}
+
+object Test extends A2 {
+	def main(args: Array[String]) {
+    println(Seq(Class.forName(classOf[T1].getName + "$class"), classOf[A1], classOf[A2]).flatMap(_.getDeclaredMethods.map(_.toString).sorted).mkString("\n"))
+  }
+}

--- a/test/files/run/t5652b.check
+++ b/test/files/run/t5652b.check
@@ -1,0 +1,4 @@
+private final int A1.g$1()
+public int A1.f1()
+private final int A2.g$1()
+public int A2.f2()

--- a/test/files/run/t5652b/t5652b_1.scala
+++ b/test/files/run/t5652b/t5652b_1.scala
@@ -1,0 +1,3 @@
+class A1 {
+  def f1 = { def g = 5 ; class A { def a = 0 } ; new A; g }
+}

--- a/test/files/run/t5652b/t5652b_2.scala
+++ b/test/files/run/t5652b/t5652b_2.scala
@@ -1,0 +1,9 @@
+class A2 extends A1 {
+	def f2 = { def g = 5 ; class A { def a = 0 } ; new A; g }
+}
+
+object Test extends A2 {
+  def main(args: Array[String]) {
+    println(Seq(classOf[A1], classOf[A2]).flatMap(_.getDeclaredMethods.map(_.toString).sorted).mkString("\n"))
+  }
+}

--- a/test/files/run/t5652c.check
+++ b/test/files/run/t5652c.check
@@ -1,0 +1,6 @@
+public final int A1.A1$$g$1()
+public final int A1.A1$$g$2()
+public int A1.f1()
+public int A1.f2()
+1
+2

--- a/test/files/run/t5652c/t5652c.scala
+++ b/test/files/run/t5652c/t5652c.scala
@@ -1,0 +1,10 @@
+class A1 {
+  def f1 = { def g = 1 ; class A { def a = g } ; new A().a }
+  def f2 = { def g = 2 ; class A { def a = g } ; new A().a }
+}
+
+object Test extends App {
+  println(classOf[A1].getDeclaredMethods.map(_.toString).sorted.mkString("\n"))
+  println(new A1().f1)
+  println(new A1().f2)
+}


### PR DESCRIPTION
This can happen if they are accessed from an inner class. If a
subclass is happens to lift a public method to the same name,
a VerifyError ensues.

The enclosed tests:
- demonstrate the absense of the VerifyError
- show the names generated for the lifted methods (which are
  unchanged if not called from an inner class, or if lifted
  into a trait implementation class.)
- ensure that the callers are rewritten to call the correct
  method when multiple with the same name are lifted.

It's not ideal that this phase needs a priori knowledge of the
later phases to perform this mangling. A better fix would defer
this until the point when the methods are publicised, and leave
the unmangled private method in place and install an public,
mangled forwarder.

Resubmission of #628; review by @paulp or @odersky.
