### PR TITLE
Fix a NSDNHAO in extension methods.

### DIFF
--- a/test/files/pos/value-class-override-no-spec.flags
+++ b/test/files/pos/value-class-override-no-spec.flags
@@ -1,0 +1,1 @@
+-no-specialization

--- a/test/files/pos/value-class-override-no-spec.scala
+++ b/test/files/pos/value-class-override-no-spec.scala
@@ -1,0 +1,9 @@
+// There are two versions of this tests: one with and one without specialization.
+// The bug was only exposed *without* specialization.
+trait T extends Any {
+  def x: Any
+}
+
+final class StringOps(val repr0: String) extends AnyVal with T {
+  def x = ()
+}

--- a/test/files/pos/value-class-override-spec.scala
+++ b/test/files/pos/value-class-override-spec.scala
@@ -1,0 +1,9 @@
+// There are two versions of this tests: one with and one without specialization.
+// The bug was only exposed *without* specialization.
+trait T extends Any {
+  def x: Any
+}
+
+final class StringOps(val repr0: String) extends AnyVal with T {
+  def x = ()
+}


### PR DESCRIPTION
A bridge method, created when we override a method from
a superclass and refine the return type, was appearing
as an overloaded alternative. (`erasure` doesn't create
new scopes, so the bridges it builds are visible at
earlier phases.)

The problem was masked when compiling with specialization,
which _does_ create a new scope, shielding the code in
question from the artefacts of erasure.

To fix the problem, we filter out bridge methods from
the overloaded alternatives returned by `.decl`, as would
happen internally in `.member`.

Resubmission of #632.

review by @odersky
