### PR TITLE
SI-5845 Advances the example from a crasher to an inference failure.

### DIFF
--- a/src/compiler/scala/reflect/internal/Types.scala
+++ b/src/compiler/scala/reflect/internal/Types.scala
@@ -4318,7 +4318,7 @@ trait Types extends api.Types { self: SymbolTable =>
               def throwError = abort("" + tp + sym.locationString + " cannot be instantiated from " + pre.widen)
 
               val symclazz = sym.owner
-              if (symclazz == clazz && !pre.isInstanceOf[TypeVar] && (pre.widen.typeSymbol isNonBottomSubClass symclazz)) {
+              if (symclazz == clazz && !pre.widen.isInstanceOf[TypeVar] && (pre.widen.typeSymbol isNonBottomSubClass symclazz)) {
                 // have to deconst because it may be a Class[T].
                 pre.baseType(symclazz).deconst match {
                   case TypeRef(_, basesym, baseargs) =>

--- a/test/files/neg/t5845.check
+++ b/test/files/neg/t5845.check
@@ -1,0 +1,7 @@
+t5845.scala:9: error: value +++ is not a member of Int
+  println(5 +++ 5)
+            ^
+t5845.scala:15: error: value +++ is not a member of Int
+  println(5 +++ 5)
+            ^
+two errors found

--- a/test/files/neg/t5845.scala
+++ b/test/files/neg/t5845.scala
@@ -1,0 +1,16 @@
+class Num[T] {
+  def mkOps = new Ops
+  class Ops { def +++(rhs: T) = () }
+}
+
+class A {
+  implicit def infixOps[T, CC[X] <: Num[X]](lhs: T)(implicit num: CC[T]) = num.mkOps
+  implicit val n1 = new Num[Int] { }
+  println(5 +++ 5)
+}
+
+class B {
+  implicit def infixOps[T, CC[X] <: Num[X]](lhs: T)(implicit num: CC[T]) : CC[T]#Ops = num.mkOps
+  implicit val n1 = new Num[Int] {}
+  println(5 +++ 5)
+}


### PR DESCRIPTION
The inference failure itself seems like an instance of of SI-3346.

But dependent method types (which triggered the crash), can be employed
to avoid inferring the type constructor CC.

```
class Num[T] {
  def mkOps = new Ops
  class Ops { def +++(rhs: T) = () }
}

class A {
  implicit def infixOps[T](lhs: T)(implicit num: Num[T]): num.Ops = num.mkOps
  implicit val n1: Num[Int] = new Num[Int] { }
  5 +++ 5
}
```

review by @adriaanm
