### PR TITLE
Partial redesign of incremental compiler invalidation.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/JavaPlatform.scala
+++ b/src/compiler/scala/tools/nsc/backend/JavaPlatform.scala
@@ -23,10 +23,10 @@ trait JavaPlatform extends Platform {
     if (currentClassPath.isEmpty) currentClassPath = Some(new PathResolver(settings).result)
     currentClassPath.get
   }
-    
+
   /** Update classpath with a substituted subentry */
-  def updateClassPath(oldEntry: ClassPath[BinaryRepr], newEntry: ClassPath[BinaryRepr]) = 
-    currentClassPath = Some(new DeltaClassPath(currentClassPath.get, oldEntry, newEntry))
+  def updateClassPath(subst: Map[ClassPath[BinaryRepr], ClassPath[BinaryRepr]]) =
+    currentClassPath = Some(new DeltaClassPath(currentClassPath.get, subst))
 
   def rootLoader = new loaders.PackageLoader(classPath.asInstanceOf[ClassPath[platform.BinaryRepr]])
     // [Martin] Why do we need a cast here?

--- a/src/compiler/scala/tools/nsc/backend/MSILPlatform.scala
+++ b/src/compiler/scala/tools/nsc/backend/MSILPlatform.scala
@@ -30,11 +30,11 @@ trait MSILPlatform extends Platform {
   lazy val classPath = MsilClassPath.fromSettings(settings)
   def rootLoader = new loaders.PackageLoader(classPath.asInstanceOf[ClassPath[platform.BinaryRepr]])
     // See discussion in JavaPlatForm for why we need a cast here.
-  
+
   /** Update classpath with a substituted subentry */
-  def updateClassPath(oldEntry: ClassPath[BinaryRepr], newEntry: ClassPath[BinaryRepr]) = 
+  def updateClassPath(subst: Map[ClassPath[BinaryRepr], ClassPath[BinaryRepr]]) =
     throw new UnsupportedOperationException("classpath invalidations not supported on MSIL")
-  
+
   def platformPhases = List(
     genMSIL   // generate .msil files
   )

--- a/src/compiler/scala/tools/nsc/backend/Platform.scala
+++ b/src/compiler/scala/tools/nsc/backend/Platform.scala
@@ -23,9 +23,9 @@ trait Platform {
 
   /** The root symbol loader. */
   def rootLoader: LazyType
-  
-  /** Update classpath with a substituted subentry */
-  def updateClassPath(oldEntry: ClassPath[BinaryRepr], newEntry: ClassPath[BinaryRepr])
+
+  /** Update classpath with a substitution that maps entries to entries */
+  def updateClassPath(subst: Map[ClassPath[BinaryRepr], ClassPath[BinaryRepr]])
 
   /** Any platform-specific phases. */
   def platformPhases: List[SubComponent]

--- a/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
@@ -51,6 +51,46 @@ abstract class SymbolLoaders {
     enterIfNew(owner, module, completer)
   }
 
+  /** Enter package with given `name` into scope of `root`
+   *  and give them `completer` as type.
+   */
+  def enterPackage(root: Symbol, name: String, completer: SymbolLoader): Symbol = {
+    val pname = newTermName(name)
+    val preExisting = root.info.decls lookup pname
+    if (preExisting != NoSymbol) {
+      // Some jars (often, obfuscated ones) include a package and
+      // object with the same name. Rather than render them unusable,
+      // offer a setting to resolve the conflict one way or the other.
+      // This was motivated by the desire to use YourKit probes, which
+      // require yjp.jar at runtime. See SI-2089.
+      if (settings.termConflict.isDefault)
+        throw new TypeError(
+          root+" contains object and package with same name: "+
+          name+"\none of them needs to be removed from classpath"
+        )
+      else if (settings.termConflict.value == "package") {
+        global.warning(
+          "Resolving package/object name conflict in favor of package " +
+          preExisting.fullName + ".  The object will be inaccessible."
+        )
+        root.info.decls.unlink(preExisting)
+      }
+      else {
+        global.warning(
+          "Resolving package/object name conflict in favor of object " +
+          preExisting.fullName + ".  The package will be inaccessible."
+        )
+        return NoSymbol
+      }
+    }
+    // todo: find out initialization sequence for pkg/pkg.moduleClass is different from enterModule
+    val pkg = root.newPackage(pname)
+    pkg.moduleClass setInfo completer
+    pkg setInfo pkg.moduleClass.tpe
+    root.info.decls enter pkg
+    pkg
+  }
+
   /** Enter class and module with given `name` into scope of `root`
    *  and give them `completer` as type.
    */
@@ -170,40 +210,6 @@ abstract class SymbolLoaders {
    */
   class PackageLoader(classpath: ClassPath[platform.BinaryRepr]) extends SymbolLoader {
     protected def description = "package loader "+ classpath.name
-
-    def enterPackage(root: Symbol, name: String, completer: SymbolLoader) {
-      val preExisting = root.info.decls.lookup(newTermName(name))
-      if (preExisting != NoSymbol) {
-        // Some jars (often, obfuscated ones) include a package and
-        // object with the same name. Rather than render them unusable,
-        // offer a setting to resolve the conflict one way or the other.
-        // This was motivated by the desire to use YourKit probes, which
-        // require yjp.jar at runtime. See SI-2089.
-        if (settings.termConflict.isDefault)
-          throw new TypeError(
-            root+" contains object and package with same name: "+
-            name+"\none of them needs to be removed from classpath"
-          )
-        else if (settings.termConflict.value == "package") {
-          global.warning(
-            "Resolving package/object name conflict in favor of package " +
-            preExisting.fullName + ".  The object will be inaccessible."
-          )
-          root.info.decls.unlink(preExisting)
-        }
-        else {
-          global.warning(
-            "Resolving package/object name conflict in favor of object " +
-            preExisting.fullName + ".  The package will be inaccessible."
-          )
-          return
-        }
-      }
-      val pkg = root.newPackage(newTermName(name))
-      pkg.moduleClass.setInfo(completer)
-      pkg.setInfo(pkg.moduleClass.tpe)
-      root.info.decls.enter(pkg)
-    }
 
     protected def doComplete(root: Symbol) {
       assert(root.isPackageClass, root)

--- a/src/compiler/scala/tools/nsc/util/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/util/ClassPath.scala
@@ -312,9 +312,11 @@ class DirectoryClassPath(val dir: AbstractFile, val context: ClassPathContext[Ab
   override def toString() = "directory classpath: "+ origin.getOrElse("?")
 }
 
-class DeltaClassPath[T](original: MergedClassPath[T], oldEntry: ClassPath[T], newEntry: ClassPath[T]) 
-extends MergedClassPath[T](original.entries map (e => if (e == oldEntry) newEntry else e), original.context) {
-  require(original.entries contains oldEntry)
+class DeltaClassPath[T](original: MergedClassPath[T], subst: Map[ClassPath[T], ClassPath[T]])
+extends MergedClassPath[T](original.entries map (e => subst getOrElse (e, e)), original.context) {
+  // not sure we should require that here. Commented out for now.
+  // require(subst.keySet subsetOf original.entries.toSet)
+  // We might add specialized operations for computing classes packages here. Not sure it's worth it.
 }
 
 /**


### PR DESCRIPTION
We now do the right thing when packages are either newly created or deleted. Previously there was a problem when a new package was created inside a system package (and, unofrtunately, root is a system package). That's fixed now. We also approximate more tightly now when packages are newly created (iei the newly created symbol gets rescanned, instead of its owner).

Incremental class invalidation: dealing with empty package.

The compiler can now also invalidate the empty package. Previously, no invalidation was done because empty was identified with root, which is considered a system package.

(1) Fixed NPE when creating a new toplevel package in invalidation. (2) generalized interface to deal with multiple entries at a time.

Review by @harrah, @pvlugter, @adriaanm
