### PR TITLE
More robust findScalaHome in bash scripts

### DIFF
--- a/src/compiler/scala/tools/ant/templates/tool-unix.tmpl
+++ b/src/compiler/scala/tools/ant/templates/tool-unix.tmpl
@@ -9,19 +9,14 @@
 ##############################################################################
 
 findScalaHome () {
-  # see SI-2092
-  local SOURCE="${BASH_SOURCE[0]}"
-  while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
-  local bindir="$( dirname "$SOURCE" )"
-  if [[ -d "$bindir"/.. ]]; then
-    ( cd -P "$bindir"/.. && pwd )
-  else
-    # See SI-5792
-    local dir=$(dirname "${BASH_SOURCE[0]}")
-    local link=$(dirname "$(readlink "${BASH_SOURCE[0]}")")
-    local path="$dir/$link/.."
-    ( cd "$path" && pwd )
-  fi
+  # see SI-2092 and SI-5792
+  local source="${BASH_SOURCE[0]}"
+  while [ -h "$source" ] ; do
+    local linked="$(readlink "$source")"
+    local dir="$( cd -P $(dirname "$source") && cd -P $(dirname "$linked") && pwd )"
+    source="$dir/$(basename "$linked")"
+  done
+  ( cd -P "$(dirname "$source")/.." && pwd )
 }
 execCommand () {
   [[ -n $SCALA_RUNNER_DEBUG ]] && echo "" && for arg in "$@@"; do echo "$arg"; done && echo "";


### PR DESCRIPTION
While looking for the latest solution for resolving script locations, for a start script for the incremental compiler, I saw SI-5792 and the problem with relative symlinks.

Thinking about this problem, multiple relative symlinks also wouldn't work with the current fix. For example:

```
relative/scala -> ../bin/scala
relative/again/scala -> ../scala
```

Here's a more general solution for resolving symlinks, whether they're relative or absolute. It resolves by jumping through the directories on the way.

Review by @paulp.
