### PR TITLE
SI-5683 Fail gracefully when transposing a ragged type arg matrix.

### DIFF
--- a/src/compiler/scala/reflect/internal/util/Collections.scala
+++ b/src/compiler/scala/reflect/internal/util/Collections.scala
@@ -201,6 +201,12 @@ trait Collections {
     }
     true
   }
+
+  final def transposeSafe[A](ass: List[List[A]]): Option[List[List[A]]] = try {
+    Some(ass.transpose)
+  } catch {
+    case _: IllegalArgumentException => None
+  }
 }
 
 object Collections extends Collections { }

--- a/test/files/neg/t5683.check
+++ b/test/files/neg/t5683.check
@@ -1,0 +1,16 @@
+t5683.scala:12: error: inferred kinds of the type arguments (Object,Int) do not conform to the expected kinds of the type parameters (type M,type B).
+Object's type parameters do not match type M's expected parameters:
+class Object has no type parameters, but type M has one
+  val crash: K[StringW,Int,Int] = k{ (y: Int) => null: W[String, Int] }
+                                  ^
+t5683.scala:12: error: type mismatch;
+ found   : Int => Test.W[String,Int]
+ required: Int => M[B]
+  val crash: K[StringW,Int,Int] = k{ (y: Int) => null: W[String, Int] }
+                                              ^
+t5683.scala:12: error: type mismatch;
+ found   : Test.K[M,Int,B]
+ required: Test.K[Test.StringW,Int,Int]
+  val crash: K[StringW,Int,Int] = k{ (y: Int) => null: W[String, Int] }
+                                   ^
+three errors found

--- a/test/files/neg/t5683.scala
+++ b/test/files/neg/t5683.scala
@@ -1,0 +1,23 @@
+object Test {
+  trait NT[X]
+  trait W[W, A] extends NT[Int]
+  type StringW[T] = W[String, T]
+  trait K[M[_], A, B]
+
+  def k[M[_], B](f: Int => M[B]): K[M, Int, B] = null
+
+  val okay1: K[StringW,Int,Int] = k{ (y: Int) => null: StringW[Int] }
+  val okay2 = k[StringW,Int]{ (y: Int) => null: W[String, Int] }
+
+  val crash: K[StringW,Int,Int] = k{ (y: Int) => null: W[String, Int] }
+
+  // remove `extends NT[Int]`, and the last line gives an inference error
+  // rather than a crash.
+  //   test/files/pos/t5683.scala:12: error: no type parameters for method k: (f: Int => M[B])Test.K[M,Int,B] exist so that it can be applied to arguments (Int => Test.W[String,Int])
+  //  --- because ---
+  // argument expression's type is not compatible with formal parameter type;
+  //  found   : Int => Test.W[String,Int]
+  //  required: Int => ?M[?B]
+  //   val crash: K[StringW,Int,Int] = k{ (y: Int) => null: W[String, Int] }
+  //                                   ^
+}


### PR DESCRIPTION
The code used to do this, until `transpose` starting throwing IAE
rather than AIOOBE.

Symptomatic treatment only: The reported crasher now infers ill-kinded
type args and reports an error.

review by @adriaanm (who applied the band-aid that fell off 68aeeae)
