### PR TITLE
Revert "#653 -- no lub for statement exprs' types"

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Modes.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Modes.scala
@@ -86,17 +86,6 @@ trait Modes {
    */
   final val TYPEPATmode   = 0x10000
 
-  /** STATmode is set when typing statements inside a block.
-   *
-   *  This is useful only for skipping lub computations in 
-   *  such positions, when the expected type is known to be Unit. This
-   *  saves time in pathological cases where lubs can take many seconds 
-   *  but in the end is discarded.
-   *
-   *  TODO: Remove when lubs become types in their own right. 
-   */
-  final val STATmode      = 0x20000
-
   final private val StickyModes   = EXPRmode | PATTERNmode | TYPEmode | ALTmode
 
   final def onlyStickyModes(mode: Int) =
@@ -139,8 +128,7 @@ trait Modes {
     (1 << 13) -> "ALTmode",
     (1 << 14) -> "HKmode",
     (1 << 15) -> "BYVALmode",
-    (1 << 16) -> "TYPEPATmode",
-    (1 << 17) -> "STATmode"
+    (1 << 16) -> "TYPEPATmode"
   )
   def modeString(mode: Int): String =
     if (mode == 0) "NOmode"

--- a/test/files/neg/checksensible.check
+++ b/test/files/neg/checksensible.check
@@ -77,8 +77,8 @@ checksensible.scala:63: error: comparing a fresh object using `!=' will always y
   new Exception() != new Exception()
                   ^
 checksensible.scala:66: error: comparing values of types Int and Null using `==' will always yield false
-  val dummy = if (foo.length == null) "plante" else "plante pas"
-                             ^
+  if (foo.length == null) "plante" else "plante pas"
+                 ^
 checksensible.scala:71: error: comparing values of types Bip and Bop using `==' will always yield false
   (x1 == x2)
       ^

--- a/test/files/neg/checksensible.scala
+++ b/test/files/neg/checksensible.scala
@@ -63,7 +63,7 @@ class EqEqRefTest {
   new Exception() != new Exception()
 
   val foo: Array[String] = Array("1","2","3")
-  val dummy = if (foo.length == null) "plante" else "plante pas"
+  if (foo.length == null) "plante" else "plante pas"
 
   // final classes with default equals
   val x1 = new Bip


### PR DESCRIPTION
I should not have merged this pull request yet.
I didn't notice we didn't have a full successful run of the test suite.
It looks like it breaks test/files/continuations-neg/lazy.scala and
given the pending amount of changes, I prefer to have a stable master.

This reverts commit 037d3dcbc5896864aec0f9121eeda23fcc4cd610.
