### PR TITLE
Add the first iteration of the `util.hashing` package.

### DIFF
--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -825,7 +825,7 @@ extends scala.collection.concurrent.Map[K, V]
   }
   
   @inline
-  def computeHash(k: K) = hashingobj.hashOf(k)
+  def computeHash(k: K) = hashingobj.hash(k)
   
   final def lookup(k: K): V = {
     val hc = computeHash(k)
@@ -915,7 +915,7 @@ object TrieMap extends MutableMapFactory[TrieMap] {
   def empty[K, V]: TrieMap[K, V] = new TrieMap[K, V]
   
   class MangledHashing[K] extends Hashing[K] {
-    def hashOf(k: K) = util.hashing.byteswap32(k.##)
+    def hash(k: K) = util.hashing.byteswap32(k.##)
   }
   
 }

--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -825,7 +825,7 @@ extends scala.collection.concurrent.Map[K, V]
   }
   
   @inline
-  def computeHash(k: K) = hashingobj.hashCode(k)
+  def computeHash(k: K) = hashingobj.hashOf(k)
   
   final def lookup(k: K): V = {
     val hc = computeHash(k)
@@ -915,11 +915,7 @@ object TrieMap extends MutableMapFactory[TrieMap] {
   def empty[K, V]: TrieMap[K, V] = new TrieMap[K, V]
   
   class MangledHashing[K] extends Hashing[K] {
-    def hashCode(k: K) = {
-      var hcode = k.## * 0x9e3775cd
-      hcode = java.lang.Integer.reverseBytes(hcode)
-      hcode * 0x9e3775cd
-    }
+    def hashOf(k: K) = util.hashing.byteswap32(k.##)
   }
   
 }

--- a/src/library/scala/collection/convert/Wrappers.scala
+++ b/src/library/scala/collection/convert/Wrappers.scala
@@ -172,20 +172,15 @@ private[collection] trait Wrappers {
 
         def hasNext = ui.hasNext
         
-        def improve(hc: Int) = {
-          var i = hc * 0x9e3775cd
-          i = java.lang.Integer.reverseBytes(i)
-          i * 0x9e3775c
-        }
-        
         def next() = {
           val (k, v) = ui.next
           prev = Some(k)
           new ju.Map.Entry[A, B] {
+            import util.hashing.byteswap32
             def getKey = k
             def getValue = v
             def setValue(v1 : B) = self.put(k, v1)
-            override def hashCode = improve(k.hashCode) + (improve(v.hashCode) << 16)
+            override def hashCode = byteswap32(k.hashCode) + (byteswap32(v.hashCode) << 16)
             override def equals(other: Any) = other match {
               case e: ju.Map.Entry[_, _] => k == e.getKey && v == e.getValue
               case _ => false

--- a/src/library/scala/collection/mutable/FlatHashTable.scala
+++ b/src/library/scala/collection/mutable/FlatHashTable.scala
@@ -397,9 +397,7 @@ private[collection] object FlatHashTable {
       //h = h + (h << 4)
       //h ^ (h >>> 10)
 
-      var i = hcode * 0x9e3775cd
-      i = java.lang.Integer.reverseBytes(i)
-      val improved = i * 0x9e3775cd
+      val improved = util.hashing.byteswap32(hcode)
 
       // for the remainder, see SI-5293
       // to ensure that different bits are used for different hash tables, we have to rotate based on the seed

--- a/src/library/scala/collection/mutable/HashTable.scala
+++ b/src/library/scala/collection/mutable/HashTable.scala
@@ -401,12 +401,7 @@ private[collection] object HashTable {
        *
        * For performance reasons, we avoid this improvement.
        * */
-      var i = hcode * 0x9e3775cd
-      i = java.lang.Integer.reverseBytes(i)
-      i = i * 0x9e3775cd
-      // a slower alternative for byte reversal:
-      // i = (i << 16) | (i >> 16)
-      // i = ((i >> 8) & 0x00ff00ff) | ((i << 8) & 0xff00ff00)
+      val i = util.hashing.byteswap32(hcode)
 
       /* Jenkins hash
        * for range 0-10000, output has the msb set to zero */

--- a/src/library/scala/util/hashing/ByteswapHashing.scala
+++ b/src/library/scala/util/hashing/ByteswapHashing.scala
@@ -13,8 +13,23 @@ package scala.util.hashing
 
 
 
+/** A fast multiplicative hash by Phil Bagwell.
+ */
 final class ByteswapHashing[T] extends Hashing[T] {
   
-  def hashOf(v: T) = byteswap32(v.##)
+  def hash(v: T) = byteswap32(v.##)
+  
+}
+
+
+object ByteswapHashing {
+  
+  private class Chained[T](h: Hashing[T]) extends Hashing[T] {
+    def hash(v: T) = byteswap32(h.hash(v))
+  }
+  
+  /** Composes another `Hashing` with the Byteswap hash.
+   */
+  def chain[T](h: Hashing[T]): Hashing[T] = new Chained(h)
   
 }

--- a/src/library/scala/util/hashing/ByteswapHashing.scala
+++ b/src/library/scala/util/hashing/ByteswapHashing.scala
@@ -1,0 +1,20 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2006-2011, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://www.scala-lang.org/           **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala.util.hashing
+
+
+
+
+
+
+final class ByteswapHashing[T] extends Hashing[T] {
+  
+  def hashOf(v: T) = byteswap32(v.##)
+  
+}

--- a/src/library/scala/util/hashing/Hashing.scala
+++ b/src/library/scala/util/hashing/Hashing.scala
@@ -22,7 +22,7 @@ package scala.util.hashing
 @annotation.implicitNotFound(msg = "No implicit Hashing defined for ${T}.")
 trait Hashing[T] extends Serializable {
   
-  def hashOf(x: T): Int
+  def hash(x: T): Int
   
 }
 
@@ -30,13 +30,13 @@ trait Hashing[T] extends Serializable {
 object Hashing {
   
   final class Default[T] extends Hashing[T] {
-    def hashOf(x: T) = x.##
+    def hash(x: T) = x.##
   }
   
   implicit def default[T] = new Default[T]
   
   def fromFunction[T](f: T => Int) = new Hashing[T] {
-    def hashOf(x: T) = f(x)
+    def hash(x: T) = f(x)
   }
   
 }

--- a/src/library/scala/util/hashing/Hashing.scala
+++ b/src/library/scala/util/hashing/Hashing.scala
@@ -22,7 +22,7 @@ package scala.util.hashing
 @annotation.implicitNotFound(msg = "No implicit Hashing defined for ${T}.")
 trait Hashing[T] extends Serializable {
   
-  def hashCode(x: T): Int
+  def hashOf(x: T): Int
   
 }
 
@@ -30,13 +30,13 @@ trait Hashing[T] extends Serializable {
 object Hashing {
   
   final class Default[T] extends Hashing[T] {
-    def hashCode(x: T) = x.##
+    def hashOf(x: T) = x.##
   }
   
   implicit def default[T] = new Default[T]
   
   def fromFunction[T](f: T => Int) = new Hashing[T] {
-    def hashCode(x: T) = f(x)
+    def hashOf(x: T) = f(x)
   }
   
 }

--- a/src/library/scala/util/hashing/package.scala
+++ b/src/library/scala/util/hashing/package.scala
@@ -1,0 +1,35 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2006-2011, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://www.scala-lang.org/           **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala.util
+
+
+
+
+
+
+package object hashing {
+  
+  /** Fast multiplicative hash with a nice distribution.
+   */
+  def byteswap32(v: Int): Int = {
+    var hc = v * 0x9e3775cd
+    hc = java.lang.Integer.reverseBytes(hc)
+    hc * 0x9e3775cd
+  }
+  
+  /** Fast multiplicative hash with a nice distribution
+   *  for 64-bit values.
+   */
+  def byteswap64(v: Long): Long = {
+    var hc = v * 0x9e3775cd9e3775cdL
+    hc = java.lang.Long.reverseBytes(hc)
+    hc * 0x9e3775cd9e3775cdL
+  }
+  
+}


### PR DESCRIPTION
Next step is to move `MurmurHash3` to `util.hashing`,
make the `class` private and retain a public companion
`object`, and put the `MurmurHash3.Hashing` implementations
for various types in the companion.

Review by @jsuereth.
