### PR TITLE
Fix SI-5853.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -821,6 +821,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
           debuglog("%s expands to %s in %s".format(sym, specMember.name.decode, pp(env)))
           info(specMember) = NormalizedMember(sym)
           overloads(sym) ::= Overload(specMember, env)
+          owner.info.decls.enter(specMember)
           specMember
         }
       }

--- a/test/files/pos/t5853.scala
+++ b/test/files/pos/t5853.scala
@@ -1,0 +1,55 @@
+
+
+
+
+
+
+
+final class C(val x: Int) extends AnyVal {
+  def ppp[@specialized(Int) T](y: T) = ()
+}
+
+
+class Foo {
+  def f = new C(1) ppp 2
+}
+
+
+/* Original SI-5853 test-case. */
+
+object Bippy {
+  implicit final class C(val x: Int) extends AnyVal {
+    def +++[@specialized T](y: T) = ()
+  }
+  def f = 1 +++ 2
+}
+
+
+/* Few more examples. */
+
+final class C2(val x: Int) extends AnyVal {
+  def +++[@specialized(Int) T](y: T) = ()
+}
+
+
+class Foo2 {
+  def f = new C2(1) +++ 2
+}
+
+
+object Arrow {
+  implicit final class ArrowAssoc[A](val __leftOfArrow: A) extends AnyVal {
+    @inline def ->>[B](y: B): Tuple2[A, B] = Tuple2(__leftOfArrow, y)
+  }
+  
+  def foo = 1 ->> 2
+}
+
+
+object SpecArrow {
+  implicit final class ArrowAssoc[A](val __leftOfArrow: A) extends AnyVal {
+    @inline def ->> [@specialized(Int) B](y: B): Tuple2[A, B] = Tuple2(__leftOfArrow, y)
+  }
+  
+  def foo = 1 ->> 2
+}


### PR DESCRIPTION
This solves two issues.

First, up to now the newly generated symbols for normalized
members were not being added to the declaration list of the
owner during `specialize`. Now they are.

Second, during `extmethods`, the extension methods generated
get an additional curried parameter list for `$this`.
Trouble was, after that, during `uncurry` and before `specialize`,
these curried parameter lists were merged into one list.
Specialization afterwards treats extension methods just
like normal methods and generates new symbols without the
curried parameter list.
The `extensionMethod` now takes this into account by checking
if the first parameter of a potential extension method has
the name `$this`.

Review by @dragos.
Review by @odersky.
