### PR TITLE
Avoids cyclic reference error in AddInterfaces.

### DIFF
--- a/src/compiler/scala/reflect/internal/Symbols.scala
+++ b/src/compiler/scala/reflect/internal/Symbols.scala
@@ -693,7 +693,8 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def isClassLocalToConstructor = false
 
     final def isDerivedValueClass =
-      isClass && info.firstParent.typeSymbol == AnyValClass && !isPrimitiveValueClass
+      isClass && !hasFlag(PACKAGE | TRAIT) && 
+      info.firstParent.typeSymbol == AnyValClass && !isPrimitiveValueClass
 
     final def isMethodWithExtension =
       isMethod && owner.isDerivedValueClass && !isParamAccessor && !isConstructor && !hasFlag(SUPERACCESSOR)


### PR DESCRIPTION
Compile Global or Typers twice in resident mode yielded a CyclicReference error, in phase erasure. The error was due to a cyclic call of the isDerivedValue method. Checking I noted that isDerivedValue is called very often, and mostly unneccessarily. I tightened the condition to not force the type of the class if it is a trait or package. This made the CyclicReference go away.

2nd, corrected pull request widened criterion that enables validation of derived value classes. Previous version made two neg tests slip through.

Review by @adriaanm
