### PR TITLE
SI-5892 Don't apply implicit class members in class type param annots

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -117,6 +117,7 @@ trait Contexts { self: Analyzer =>
     var inSelfSuperCall = false             // is this context (enclosed in) a constructor call?
     // (the call to the super or self constructor in the first line of a constructor)
     // in this context the object's fields should not be in scope
+    // This mode is also used when typing class type parameters.
 
     var diagnostic: List[String] = Nil      // these messages are printed when issuing an error
     var implicitsEnabled = false

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -540,8 +540,17 @@ trait Namers extends MethodSynthesis {
         //@M! TypeDef's type params are handled differently
         //@M e.g., in [A[x <: B], B], A and B are entered first as both are in scope in the definition of x
         //@M x is only in scope in `A[x <: B]'
-        if (!tree.symbol.isAbstractType) //@M TODO: change to isTypeMember ?
-          createNamer(tree) enterSyms tparams
+        if (!tree.symbol.isAbstractType) { //@M TODO: change to isTypeMember ?
+          val scope = tree match {
+            case ClassDef(_, _, _, _) =>
+              val scope = context.makeNewScope(tree, tree.symbol)
+              scope.inSelfSuperCall = true
+              scope
+            case _ =>
+              context.makeNewScope(tree, tree.symbol)
+          }
+          newNamer(scope) enterSyms tparams
+        }
 
         new PolyTypeCompleter(tparams, mono, tree, context) //@M
       }

--- a/test/files/neg/t5892.check
+++ b/test/files/neg/t5892.check
@@ -1,0 +1,6 @@
+t5892.scala:5: error: type mismatch;
+ found   : Boolean(false)
+ required: String
+class C[@annot(false) X] {
+               ^
+one error found

--- a/test/files/neg/t5892.scala
+++ b/test/files/neg/t5892.scala
@@ -1,0 +1,7 @@
+import language.implicitConversions
+
+class annot(a: String) extends annotation.StaticAnnotation
+
+class C[@annot(false) X] {
+  implicit def b2s(b: Boolean): String = ""
+}


### PR DESCRIPTION
- Abuse `Context#inSelfSuperCall` for this purpose.
- Inline `createNamer` into `completerOf(tree, typeParams)`, remove impossible case,
  and tweak inSelfSuperCall.

I originally tried this change in `Typers#typedClassDef`. Perhaps that also needs
to be addressed, but I couldn't motivate that with a failing test.

This problem can lead to cyclic inheritance errors, as was seen in Scalala.

Review by @lrytz
