### PR TITLE
SI-4270 Disqualify in scope implicits that are shadowed.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -90,7 +90,7 @@ trait ContextErrors {
     import infer.setError
 
     object TyperErrorGen {
-      implicit val context0: Context = infer.getContext
+      implicit val contextTyperErrorGen: Context = infer.getContext
 
       def UnstableTreeError(tree: Tree) = {
         def addendum = {
@@ -637,7 +637,7 @@ trait ContextErrors {
 
     object InferErrorGen {
 
-      implicit val context0 = getContext
+      implicit val contextInferErrorGen = getContext
 
       object PolyAlternativeErrorKind extends Enumeration {
         type ErrorType = Value
@@ -823,7 +823,7 @@ trait ContextErrors {
 
     object NamerErrorGen {
 
-      implicit val context0 = context
+      implicit val contextNamerErrorGen = context
 
       object SymValidateErrors extends Enumeration {
         val ImplicitConstr, ImplicitNotTermOrClass, ImplicitAtToplevel,
@@ -858,7 +858,7 @@ trait ContextErrors {
           case CyclicReference(sym, info: TypeCompleter) =>
             issueNormalTypeError(tree, typer.cyclicReferenceMessage(sym, info.tree) getOrElse ex.getMessage())
           case _ =>
-            context0.issue(TypeErrorWithUnderlyingTree(tree, ex))
+            contextNamerErrorGen.issue(TypeErrorWithUnderlyingTree(tree, ex))
         }
       }
 

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -100,6 +100,12 @@ trait Contexts { self: Analyzer =>
     var outer: Context = _                  // The next outer context
     var enclClass: Context = _              // The next outer context whose tree is a
                                             // template or package definition
+    @inline final def savingEnclClass[A](c: Context)(a: => A): A = {
+      val saved = enclClass
+      enclClass = c
+      try a finally enclClass = saved
+    }
+
     var enclMethod: Context = _             // The next outer context whose tree is a method
     var variance: Int = _                   // Variance relative to enclosing class
     private var _undetparams: List[Symbol] = List() // Undetermined type parameters,
@@ -638,11 +644,12 @@ trait Contexts { self: Analyzer =>
           if (owner != nextOuter.owner && owner.isClass && !owner.isPackageClass && !inSelfSuperCall) {
             if (!owner.isInitialized) return nextOuter.implicitss
             // debuglog("collect member implicits " + owner + ", implicit members = " + owner.thisType.implicitMembers)//DEBUG
-            val savedEnclClass = enclClass
-            this.enclClass = this
-            val res = collectImplicits(owner.thisType.implicitMembers, owner.thisType)
-            this.enclClass = savedEnclClass
-            res
+            savingEnclClass(this) {
+              // !!! In the body of `class C(implicit a: A) { }`, `implicitss` returns `List(List(a), List(a), List(<predef..)))`
+              //     it handled correctly by implicit search, which considers the second `a` to be shadowed, but should be
+              //     remedied nonetheless.
+              collectImplicits(owner.thisType.implicitMembers, owner.thisType)
+            }
           } else if (scope != nextOuter.scope && !owner.isPackageClass) {
             debuglog("collect local implicits " + scope.toList)//DEBUG
             collectImplicits(scope.toList, NoPrefix)

--- a/test/files/neg/t4270.check
+++ b/test/files/neg/t4270.check
@@ -1,0 +1,4 @@
+t4270.scala:5: error: could not find implicit value for parameter e: Int
+  implicitly[Int]
+            ^
+one error found

--- a/test/files/neg/t4270.scala
+++ b/test/files/neg/t4270.scala
@@ -1,0 +1,6 @@
+object Test1 {
+  object A { implicit val x: Int = 1 }
+  import A.x
+  def x: Int = 0
+  implicitly[Int]
+}

--- a/test/files/neg/t5376.check
+++ b/test/files/neg/t5376.check
@@ -1,0 +1,11 @@
+t5376.scala:12: error: type mismatch;
+ found   : String("a")
+ required: Int
+    "a": Int
+    ^
+t5376.scala:22: error: type mismatch;
+ found   : String("a")
+ required: Int
+    "a": Int
+    ^
+two errors found

--- a/test/files/neg/t5376.scala
+++ b/test/files/neg/t5376.scala
@@ -1,0 +1,24 @@
+object Test {
+  object O1 { implicit def f(s: String): Int = 1 }
+  object O2 { implicit def f(s: String): Int = 2 }
+  object O3 {          def f(s: String): Int = 3 }
+
+  // Import two implicits with the same name in the same scope.
+  def m1 = {
+    import O1._
+    import O2._
+
+    // Implicit usage compiles.
+    "a": Int
+  }
+
+  // Import one implict and one non-implicit method with the
+  // same name in the same scope.
+  def m2 = {
+    import O1._
+    import O3._
+
+    // Implicit usage compiles.
+    "a": Int
+  }
+}


### PR DESCRIPTION
If an expression wouldn't type check explicitly, it shouldn't be
allowed implicitly.

Employs `typedIdent`, which already does this sort of thing rather well,
instead of continuing to reimplement it in `Implicits`.

Remove check for non-implicit synonym, which is subsumed by typing an `Ident`.

Also fixes SI-5376.

Typing the `Ident` will be a touch slower, but I don't get consistent build times for `quick.comp` on my laptop at the best of times, so I couldn't determine if is a problem.

Review by @adriaanm. 
