### PR TITLE
better unreachability for selections

### DIFF
--- a/test/files/neg/virtpatmat_unreach_select.check
+++ b/test/files/neg/virtpatmat_unreach_select.check
@@ -1,0 +1,4 @@
+virtpatmat_unreach_select.scala:10: error: unreachable code
+    case WARNING.id => // unreachable
+                    ^
+one error found

--- a/test/files/neg/virtpatmat_unreach_select.flags
+++ b/test/files/neg/virtpatmat_unreach_select.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/virtpatmat_unreach_select.scala
+++ b/test/files/neg/virtpatmat_unreach_select.scala
@@ -1,0 +1,12 @@
+class Test {
+  object severity extends Enumeration
+  class Severity(val id: Int) extends severity.Value
+  val INFO    = new Severity(0)
+  val WARNING = new Severity(1)
+
+  (0: Int) match {
+    case WARNING.id =>
+    case INFO.id => // reachable
+    case WARNING.id => // unreachable
+  }
+}


### PR DESCRIPTION
Consts are hashconsed modulo static-approximation-for-dynamic-value-equality
thus, two value-equality tests in patterns should reuse the same ValueConst
if and only if the tested values are guaranteed to be equal in all possible executions

the implementation uses unique types to track unique consts
for an Ident with a stable symbol, we simply use the corresponding singleton type
for a Select, we have to indirect some more: we store all the unique trees we've encountered and a unique type for each of them; this unique type is then used to find the unique const that approximates the run-time value

this may seem roundabout, but we need to standardize on types for representing "value" tests,
since a type test against a singleton type must give rise to the same ValueConst
as a value test using a tree that refers to the same symbol as the singleton type test
(also, it's easier to go from values to types than vice versa)
