### PR TITLE
Suppress non-local return unchecked warnings.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1276,7 +1276,8 @@ trait Infer {
             } else {
               for (arg <- args) {
                 if (sym == ArrayClass) check(arg, bound)
-                else if (arg.typeArgs.nonEmpty) ()   // avoid spurious warnings with higher-kinded types
+                else if (arg.typeArgs.nonEmpty) ()              // avoid spurious warnings with higher-kinded types
+                else if (sym == NonLocalReturnControlClass) ()  // no way to suppress unchecked warnings on try/catch
                 else arg match {
                   case TypeRef(_, sym, _) if isLocalBinding(sym) =>
                     ;

--- a/test/files/pos/nonlocal-unchecked.flags
+++ b/test/files/pos/nonlocal-unchecked.flags
@@ -1,0 +1,1 @@
+-unchecked -Xfatal-warnings

--- a/test/files/pos/nonlocal-unchecked.scala
+++ b/test/files/pos/nonlocal-unchecked.scala
@@ -1,0 +1,6 @@
+class A {
+  def f: Boolean = {
+    val xs = Nil map (_ => return false)
+    true
+  }
+}


### PR DESCRIPTION
There doesn't seem to be any way to do that by adding
a synthetic annotation.
