### PR TITLE
Issue/hardening compiling with newer sources

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1667,13 +1667,14 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
     /** Compile abstract file until `globalPhase`, but at least to phase "namer".
      */
     def compileLate(unit: CompilationUnit) {
-      val maxId = math.max(globalPhase.id, typerPhase.id)
       addUnit(unit)
 
-      firstPhase.iterator takeWhile (_.id < maxId) foreach (ph =>
-        atPhase(ph)(ph.asInstanceOf[GlobalPhase] applyPhase unit)
-      )
-      refreshProgress
+      if (firstPhase ne null) { // we might get here during initialization, is a source is newer than the binary
+        val maxId = math.max(globalPhase.id, typerPhase.id)
+        firstPhase.iterator takeWhile (_.id < maxId) foreach (ph =>
+          atPhase(ph)(ph.asInstanceOf[GlobalPhase] applyPhase unit))
+        refreshProgress
+      }
     }
 
     /** Reset package class to state at typer (not sure what this

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -253,7 +253,16 @@ self =>
   final val InBlock = 1
   final val InTemplate = 2
 
-  lazy val ScalaValueClassNames = tpnme.AnyVal :: definitions.ScalaValueClasses.map(_.name)
+  lazy val ScalaValueClassNames = Seq(tpnme.AnyVal, 
+      tpnme.Unit,
+      tpnme.Boolean,
+      tpnme.Byte,
+      tpnme.Short,
+      tpnme.Char,
+      tpnme.Int,
+      tpnme.Long,
+      tpnme.Float,
+      tpnme.Double)
 
   import nme.raw
 

--- a/src/compiler/scala/tools/nsc/symtab/BrowsingLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/BrowsingLoaders.scala
@@ -105,7 +105,7 @@ abstract class BrowsingLoaders extends SymbolLoaders {
    */
   override def enterToplevelsFromSource(root: Symbol, name: String, src: AbstractFile) {
     try {
-      if (root.isEffectiveRoot) // RootClass or EmptyPackageClass
+      if (root.isEffectiveRoot || !src.name.endsWith(".scala")) // RootClass or EmptyPackageClass
         super.enterToplevelsFromSource(root, name, src)
       else
         browseTopLevel(root, src)


### PR DESCRIPTION
A bunch of changes to make the compiler more robust when sources in the Scala library are newer than the corresponding classfiles.

Most changes affect the presentation compiler, but they would help in normal builds as well. I broke it down in several small self-contained commits.

review by @odersky.
