### PR TITLE
Fix SI-5909.

### DIFF
--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -473,7 +473,9 @@ extends CNodeBase[K, V] {
   private def computeSize(ct: TrieMap[K, V]): Int = {
     var i = 0
     var sz = 0
-    val offset = math.abs(util.Random.nextInt()) % array.length
+    val offset =
+      if (array.length > 0) math.abs(util.Random.nextInt()) % array.length
+      else 0
     while (i < array.length) {
       val pos = (i + offset) % array.length
       array(pos) match {

--- a/src/partest/scala/tools/partest/nest/Worker.scala
+++ b/src/partest/scala/tools/partest/nest/Worker.scala
@@ -609,7 +609,7 @@ class Worker(val fileManager: FileManager, params: TestRunParams) extends Actor 
           NestUI.verbose(file2String(logFile))
           // obviously this must be improved upon
           val lines = SFile(logFile).lines map (_.trim) filterNot (_ == "") toBuffer;
-          if (lines forall (x => !x.startsWith("!"))) {
+          if (lines forall (x => x.startsWith("+"))) {
             NestUI.verbose("test for '" + file + "' success: " + succeeded)
             true
           }

--- a/src/scalacheck/org/scalacheck/ConsoleReporter.scala
+++ b/src/scalacheck/org/scalacheck/ConsoleReporter.scala
@@ -20,11 +20,11 @@ class ConsoleReporter(val verbosity: Int) extends Test.TestCallback {
     if(verbosity > 0) {
       if(name == "") {
         val s = (if(res.passed) "+ " else "! ") + pretty(res, prettyPrms)
-        printf("\r%s\n", format(s, "", "", 75))
+        printf("\r%s\n", format(s, "", "", Int.MaxValue))
       } else {
         val s = (if(res.passed) "+ " else "! ") + name + ": " +
           pretty(res, prettyPrms)
-        printf("\r%s\n", format(s, "", "", 75))
+        printf("\r%s\n", format(s, "", "", Int.MaxValue))
       }
     }
   }


### PR DESCRIPTION
Empty trie maps no longer fail when size is called.

Also, partest scalacheck test should now correctly report
if a test failed.
Every line in the output of the scalacheck test must begin
with a `+`, and lines no longer wrap.
