### PR TITLE
Adding JDK7 friendly build with new partialdist(-opt) tasks.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -55,6 +55,18 @@ END-USER TARGETS
     </antcall>
   </target>
 
+
+  <target name="partialdist" depends="dist.partial"
+    description="Makes a new distribution without documentation, so just for testing."/>
+
+  <target name="partialdist-opt"
+    description="Makes a new optimised distribution without testing it or removing partially build elements.">
+    <antcall target="partialdist">
+      <param name="scalac.args.optimise" value="-optimise"/>
+    </antcall>
+  </target>
+
+
   <target name="fastdist" depends="dist.done"
     description="Makes a new distribution without testing it or removing partially build elements."/>
 
@@ -334,16 +346,31 @@ INITIALISATION
   <target name="init.version.done" depends="init.version.release, init.version.snapshot"/>
 
   <target name="init.testjava6">
-    <fail message="This build requires JDK 1.6">
-      <condition>
-        <not>
+      <condition property="has.java6">
           <equals arg1="${ant.java.version}" arg2="1.6"/>
-        </not>
       </condition>
-    </fail>
+      <condition property="has.java7">
+          <equals arg1="${ant.java.version}" arg2="1.7"/>
+      </condition>
+      <condition property="has.unsupported.jdk">
+         <not><or>
+           <isset property="has.java7" />
+           <isset property="has.java6" />
+         </or></not>
+      </condition>
   </target>
 
-  <target name="init" depends="init.jars, init.maven.jars, init.version.done">
+  <target name="init.fail.bad.jdk" depends="init.testjava6">
+    <fail if="has.unsupported.jdk"
+          message="JDK ${ant.java.version} is not supported by this build!"/>
+  </target>
+  <target name="init.warn.jdk7" depends="init.testjava6" if="has.java7">
+     <echo level="warning"> You are using JDK7 for this build.  While this will be able to build most of Scala, it will
+       not build the Swing project.   You will be unable to create a distribution.
+     </echo>
+  </target>
+
+  <target name="init" depends="init.jars, init.maven.jars, init.version.done, init.fail.bad.jdk, init.warn.jdk7">
     <property name="scalac.args.always" value="" />
   <!-- scalac.args.optimise is selectively overridden in certain antcall tasks. -->
     <property name="scalac.args.optimise" value=""/>
@@ -467,7 +494,7 @@ LOCAL DEPENDENCY (Adapted ASM)
 <!-- ===========================================================================
 LOCAL DEPENDENCY (FORKJOIN)
 ============================================================================ -->
-  <target name="forkjoin.start" depends="init, init.testjava6">
+  <target name="forkjoin.start" depends="init">
     <uptodate property="forkjoin.available" targetfile="${build-libs.dir}/forkjoin.complete">
       <srcfiles dir="${src.dir}/forkjoin">
         <include name="**/*.java"/>
@@ -978,15 +1005,6 @@ QUICK BUILD (QUICK)
       <include name="**/*.scala"/>
       <compilationpath refid="quick.compilation.path"/>
     </scalacfork>
-    <scalacfork
-      destdir="${build-quick.dir}/classes/library"
-      compilerpathref="locker.classpath"
-      params="${scalac.args.quick}"
-      srcdir="${src.dir}/swing"
-      jvmargs="${scalacfork.jvmargs}">
-      <include name="**/*.scala"/>
-      <compilationpath refid="quick.compilation.path"/>
-    </scalacfork>
     <propertyfile file="${build-quick.dir}/classes/library/library.properties">
       <entry key="version.number" value="${version.number}"/>
       <entry key="maven.version.number" value="${maven.version.number}"/>
@@ -1001,12 +1019,26 @@ QUICK BUILD (QUICK)
         <include name="**/*.css"/>
       </fileset>
     </copy>
-    <touch file="${build-quick.dir}/library.complete" verbose="no"/>
-    <stopwatch name="quick.lib.timer" action="total"/>
   </target>
 
+  <target name="quick.swing" depends="quick.lib" if="has.java6" unless="quick.lib.available">
+    <scalacfork
+      destdir="${build-quick.dir}/classes/library"
+      compilerpathref="locker.classpath"
+      params="${scalac.args.quick}"
+      srcdir="${src.dir}/swing"
+      jvmargs="${scalacfork.jvmargs}">
+      <include name="**/*.scala"/>
+      <compilationpath refid="quick.compilation.path"/>
+    </scalacfork>
+  </target>
 
-  <target name="quick.pre-reflect" depends="quick.lib">
+  <target name="quick.lib.done" depends="quick.swing, quick.lib">
+    <stopwatch name="quick.lib.timer" action="total"/>
+    <touch file="${build-quick.dir}/library.complete" verbose="no"/>
+  </target>
+
+  <target name="quick.pre-reflect" depends="quick.lib.done">
     <uptodate property="quick.reflect.available" targetfile="${build-quick.dir}/reflect.complete">
       <srcfiles dir="${src.dir}">
         <include name="reflect/**"/>
@@ -1412,11 +1444,6 @@ PACKED QUICK BUILD (PACK)
       </fileset>
       <fileset dir="${build-libs.dir}/classes/forkjoin"/>
     </jar>
-    <jar destfile="${build-pack.dir}/lib/scala-swing.jar">
-      <fileset dir="${build-quick.dir}/classes/library">
-        <include name="scala/swing/**"/>
-      </fileset>
-    </jar>
   <jar destfile="${build-pack.dir}/lib/scala-actors.jar">
       <fileset dir="${build-quick.dir}/classes/library">
         <include name="scala/actors/**"/>
@@ -1427,7 +1454,15 @@ PACKED QUICK BUILD (PACK)
   </jar>
   </target>
 
-  <target name="pack.pre-reflect" depends="pack.lib">
+  <target name="pack.swing" depends="pack.lib" if="has.java6">
+    <jar destfile="${build-pack.dir}/lib/scala-swing.jar">
+      <fileset dir="${build-quick.dir}/classes/library">
+        <include name="scala/swing/**"/>
+      </fileset>
+    </jar>
+  </target>
+
+  <target name="pack.pre-reflect" depends="pack.lib, pack.swing">
     <uptodate
       property="pack.reflect.available"
       targetfile="${build-pack.dir}/lib/scala-reflect.jar"
@@ -1643,15 +1678,6 @@ BOOTSTRAPPING BUILD (STRAP)
       <include name="**/*.scala"/>
       <compilationpath refid="strap.compilation.path"/>
     </scalacfork>
-    <scalacfork
-      destdir="${build-strap.dir}/classes/library"
-      compilerpathref="pack.classpath"
-      params="${scalac.args.quick}"
-      srcdir="${src.dir}/swing"
-      jvmargs="${scalacfork.jvmargs}">
-      <include name="**/*.scala"/>
-      <compilationpath refid="strap.compilation.path"/>
-    </scalacfork>
     <propertyfile file="${build-strap.dir}/classes/library/library.properties">
       <entry key="version.number" value="${version.number}"/>
       <entry key="maven.version.number" value="${maven.version.number}"/>
@@ -1666,11 +1692,26 @@ BOOTSTRAPPING BUILD (STRAP)
         <include name="**/*.css"/>
       </fileset>
     </copy>
+  </target>
+
+  <target name="strap.swing" if="has.java6" unless="strap.lib.available" depends="strap.lib">
+    <scalacfork
+      destdir="${build-strap.dir}/classes/library"
+      compilerpathref="pack.classpath"
+      params="${scalac.args.quick}"
+      srcdir="${src.dir}/swing"
+      jvmargs="${scalacfork.jvmargs}">
+      <include name="**/*.scala"/>
+      <compilationpath refid="strap.compilation.path"/>
+    </scalacfork>
+  </target>
+
+  <target name="strap.lib.done" depends="strap.swing, strap.lib">
     <touch file="${build-strap.dir}/library.complete" verbose="no"/>
     <stopwatch name="strap.lib.timer" action="total"/>
   </target>
 
-  <target name="strap.pre-reflect" depends="strap.lib">
+  <target name="strap.pre-reflect" depends="strap.lib.done">
     <uptodate property="strap.reflect.available" targetfile="${build-strap.dir}/reflect.complete">
       <srcfiles dir="${src.dir}/reflect"/>
     </uptodate>
@@ -2348,7 +2389,7 @@ BOOTRAPING TEST AND TEST SUITE
 DISTRIBUTION
 ============================================================================ -->
 
-  <target name="dist.start" depends="docs.done, pack.done">
+  <target name="dist.start" depends="pack.done">
     <property name="dist.name" value="scala-${version.number}"/>
     <property name="dist.dir" value="${dists.dir}/${dist.name}"/>
   </target>
@@ -2373,7 +2414,7 @@ DISTRIBUTION
     </copy>
   </target>
 
-  <target name="dist.doc" depends="dist.base">
+  <target name="dist.doc" depends="dist.base, docs.done">
     <mkdir dir="${dist.dir}/doc/scala-devel-docs"/>
     <copy file="${docs.dir}/LICENSE" toDir="${dist.dir}/doc"/>
     <copy file="${docs.dir}/README" toDir="${dist.dir}/doc"/>
@@ -2432,11 +2473,11 @@ DISTRIBUTION
     </jar>
   </target>
 
-  <target name="dist.latest.unix" depends="dist.src" unless="os.win">
+  <target name="dist.latest.unix" depends="dist.base" unless="os.win">
     <symlink link="${dists.dir}/latest" resource="${dist.name}" overwrite="yes"/>
   </target>
 
-  <target name="dist.latest.win" depends="dist.src" if="os.win">
+  <target name="dist.latest.win" depends="dist.base" if="os.win">
     <copy todir="${dists.dir}/latest">
       <fileset dir="${dist.dir}"/>
     </copy>
@@ -2444,7 +2485,9 @@ DISTRIBUTION
 
   <target name="dist.latest" depends="dist.latest.unix,dist.latest.win"/>
 
-  <target name="dist.done" depends="dist.latest"/>
+  <target name="dist.partial" depends="dist.base, dist.latest"/>
+
+  <target name="dist.done" depends="dist.latest, dist.src"/>
 
   <target name="dist.clean">
     <delete dir="${dists.dir}" includeemptydirs="yes" quiet="yes" failonerror="no"/>


### PR DESCRIPTION
- When running in JDK 7 issues a warning.
- New partialdist, partialdist-opt tasks allow creating a distribution with no source/docs.

review/use by @paulp,  THIS TIME FOR REALZ.  
