### PR TITLE
Wip sensible deprecation msgs √

### DIFF
--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -320,30 +320,30 @@ object Predef extends LowPriorityImplicits {
 
   // Primitive Widenings --------------------------------------------------------------
 
-  @deprecated("Use .toShort", "2.10.0") def byte2short(x: Byte): Short = x.toShort
-  @deprecated("Use .toInt", "2.10.0") def byte2int(x: Byte): Int = x.toInt
-  @deprecated("Use .toLong", "2.10.0") def byte2long(x: Byte): Long = x.toLong
-  @deprecated("Use .toFloat", "2.10.0") def byte2float(x: Byte): Float = x.toFloat
-  @deprecated("Use .toDouble", "2.10.0") def byte2double(x: Byte): Double = x.toDouble
+  @deprecated("Use .toShort for explicit conversion and Byte.byte2short for implicit conversion", "2.10.0") def byte2short(x: Byte): Short = x.toShort
+  @deprecated("Use .toInt for explicit conversion and Byte.byte2int for implicit conversion", "2.10.0") def byte2int(x: Byte): Int = x.toInt
+  @deprecated("Use .toLong for explicit conversion and Byte.byte2long for implicit conversion", "2.10.0") def byte2long(x: Byte): Long = x.toLong
+  @deprecated("Use .toFloat for explicit conversion and Byte.byte2float for implicit conversion", "2.10.0") def byte2float(x: Byte): Float = x.toFloat
+  @deprecated("Use .toDouble for explicit conversion and Byte.byte2double for implicit conversion", "2.10.0") def byte2double(x: Byte): Double = x.toDouble
 
-  @deprecated("Use .toInt", "2.10.0") def short2int(x: Short): Int = x.toInt
-  @deprecated("Use .toLong", "2.10.0") def short2long(x: Short): Long = x.toLong
-  @deprecated("Use .toFloat", "2.10.0") def short2float(x: Short): Float = x.toFloat
-  @deprecated("Use .toDouble", "2.10.0") def short2double(x: Short): Double = x.toDouble
+  @deprecated("Use .toInt for explicit conversion and Short.short2int for implicit conversion", "2.10.0") def short2int(x: Short): Int = x.toInt
+  @deprecated("Use .toLong for explicit conversion and Short.short2long for implicit conversion", "2.10.0") def short2long(x: Short): Long = x.toLong
+  @deprecated("Use .toFloat for explicit conversion and Short.short2float for implicit conversion", "2.10.0") def short2float(x: Short): Float = x.toFloat
+  @deprecated("Use .toDouble for explicit conversion and Short.short2double for implicit conversion", "2.10.0") def short2double(x: Short): Double = x.toDouble
 
-  @deprecated("Use .toInt", "2.10.0") def char2int(x: Char): Int = x.toInt
-  @deprecated("Use .toLong", "2.10.0") def char2long(x: Char): Long = x.toLong
-  @deprecated("Use .toFloat", "2.10.0") def char2float(x: Char): Float = x.toFloat
-  @deprecated("Use .toDouble", "2.10.0") def char2double(x: Char): Double = x.toDouble
+  @deprecated("Use .toInt for explicit conversion and Char.char2int for implicit conversion", "2.10.0") def char2int(x: Char): Int = x.toInt
+  @deprecated("Use .toLong for explicit conversion and Char.char2long for implicit conversion", "2.10.0") def char2long(x: Char): Long = x.toLong
+  @deprecated("Use .toFloat for explicit conversion and Char.char2float for implicit conversion", "2.10.0") def char2float(x: Char): Float = x.toFloat
+  @deprecated("Use .toDouble for explicit conversion and Char.char2double for implicit conversion", "2.10.0") def char2double(x: Char): Double = x.toDouble
 
-  @deprecated("Use .toLong", "2.10.0") def int2long(x: Int): Long = x.toLong
-  @deprecated("Use .toFloat", "2.10.0") def int2float(x: Int): Float = x.toFloat
-  @deprecated("Use .toDouble", "2.10.0") def int2double(x: Int): Double = x.toDouble
+  @deprecated("Use .toLong for explicit conversion and Int.int2long for implicit conversion", "2.10.0") def int2long(x: Int): Long = x.toLong
+  @deprecated("Use .toFloat for explicit conversion and Int.int2float for implicit conversion", "2.10.0") def int2float(x: Int): Float = x.toFloat
+  @deprecated("Use .toDouble for explicit conversion and Int.int2double for implicit conversion", "2.10.0") def int2double(x: Int): Double = x.toDouble
 
-  @deprecated("Use .toFloat", "2.10.0") def long2float(x: Long): Float = x.toFloat
-  @deprecated("Use .toDouble", "2.10.0") def long2double(x: Long): Double = x.toDouble
+  @deprecated("Use .toFloat for explicit conversion and Long.long2float for implicit conversion", "2.10.0") def long2float(x: Long): Float = x.toFloat
+  @deprecated("Use .toDouble for explicit conversion and Long.long2double for implicit conversion", "2.10.0") def long2double(x: Long): Double = x.toDouble
 
-  @deprecated("Use .toDouble", "2.10.0") def float2double(x: Float): Double = x.toDouble
+  @deprecated("Use .toDouble for explicit conversion and Float.float2double for implicit conversion", "2.10.0") def float2double(x: Float): Double = x.toDouble
 
   // "Autoboxing" and "Autounboxing" ---------------------------------------------------
 

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -320,30 +320,30 @@ object Predef extends LowPriorityImplicits {
 
   // Primitive Widenings --------------------------------------------------------------
 
-  @deprecated("Use a method in an AnyVal's companion object", "2.10.0") def byte2short(x: Byte): Short = x.toShort
-  @deprecated("Use a method in an AnyVal's companion object", "2.10.0") def byte2int(x: Byte): Int = x.toInt
-  @deprecated("Use a method in an AnyVal's companion object", "2.10.0") def byte2long(x: Byte): Long = x.toLong
-  @deprecated("Use a method in an AnyVal's companion object", "2.10.0") def byte2float(x: Byte): Float = x.toFloat
-  @deprecated("Use a method in an AnyVal's companion object", "2.10.0") def byte2double(x: Byte): Double = x.toDouble
+  @deprecated("Use .toShort", "2.10.0") def byte2short(x: Byte): Short = x.toShort
+  @deprecated("Use .toInt", "2.10.0") def byte2int(x: Byte): Int = x.toInt
+  @deprecated("Use .toLong", "2.10.0") def byte2long(x: Byte): Long = x.toLong
+  @deprecated("Use .toFloat", "2.10.0") def byte2float(x: Byte): Float = x.toFloat
+  @deprecated("Use .toDouble", "2.10.0") def byte2double(x: Byte): Double = x.toDouble
 
-  @deprecated("Use a method in an AnyVal's companion object", "2.10.0") def short2int(x: Short): Int = x.toInt
-  @deprecated("Use a method in an AnyVal's companion object", "2.10.0") def short2long(x: Short): Long = x.toLong
-  @deprecated("Use a method in an AnyVal's companion object", "2.10.0") def short2float(x: Short): Float = x.toFloat
-  @deprecated("Use a method in an AnyVal's companion object", "2.10.0") def short2double(x: Short): Double = x.toDouble
+  @deprecated("Use .toInt", "2.10.0") def short2int(x: Short): Int = x.toInt
+  @deprecated("Use .toLong", "2.10.0") def short2long(x: Short): Long = x.toLong
+  @deprecated("Use .toFloat", "2.10.0") def short2float(x: Short): Float = x.toFloat
+  @deprecated("Use .toDouble", "2.10.0") def short2double(x: Short): Double = x.toDouble
 
-  @deprecated("Use a method in an AnyVal's companion object", "2.10.0") def char2int(x: Char): Int = x.toInt
-  @deprecated("Use a method in an AnyVal's companion object", "2.10.0") def char2long(x: Char): Long = x.toLong
-  @deprecated("Use a method in an AnyVal's companion object", "2.10.0") def char2float(x: Char): Float = x.toFloat
-  @deprecated("Use a method in an AnyVal's companion object", "2.10.0") def char2double(x: Char): Double = x.toDouble
+  @deprecated("Use .toInt", "2.10.0") def char2int(x: Char): Int = x.toInt
+  @deprecated("Use .toLong", "2.10.0") def char2long(x: Char): Long = x.toLong
+  @deprecated("Use .toFloat", "2.10.0") def char2float(x: Char): Float = x.toFloat
+  @deprecated("Use .toDouble", "2.10.0") def char2double(x: Char): Double = x.toDouble
 
-  @deprecated("Use a method in an AnyVal's companion object", "2.10.0") def int2long(x: Int): Long = x.toLong
-  @deprecated("Use a method in an AnyVal's companion object", "2.10.0") def int2float(x: Int): Float = x.toFloat
-  @deprecated("Use a method in an AnyVal's companion object", "2.10.0") def int2double(x: Int): Double = x.toDouble
+  @deprecated("Use .toLong", "2.10.0") def int2long(x: Int): Long = x.toLong
+  @deprecated("Use .toFloat", "2.10.0") def int2float(x: Int): Float = x.toFloat
+  @deprecated("Use .toDouble", "2.10.0") def int2double(x: Int): Double = x.toDouble
 
-  @deprecated("Use a method in an AnyVal's companion object", "2.10.0") def long2float(x: Long): Float = x.toFloat
-  @deprecated("Use a method in an AnyVal's companion object", "2.10.0") def long2double(x: Long): Double = x.toDouble
+  @deprecated("Use .toFloat", "2.10.0") def long2float(x: Long): Float = x.toFloat
+  @deprecated("Use .toDouble", "2.10.0") def long2double(x: Long): Double = x.toDouble
 
-  @deprecated("Use a method in an AnyVal's companion object", "2.10.0") def float2double(x: Float): Double = x.toDouble
+  @deprecated("Use .toDouble", "2.10.0") def float2double(x: Float): Double = x.toDouble
 
   // "Autoboxing" and "Autounboxing" ---------------------------------------------------
 

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -412,7 +412,7 @@ object Predef extends LowPriorityImplicits {
    *
    * In part contributed by Jason Zaugg.
    */
-  @implicitNotFound(msg = "Cannot prove that `${From} <:< ${To}`.")
+  @implicitNotFound(msg = "Cannot prove that ${From} <:< ${To}.")
   sealed abstract class <:<[-From, +To] extends (From => To) with Serializable
   private[this] final val singleton_<:< = new <:<[Any,Any] { def apply(x: Any): Any = x }
   // not in the <:< companion object because it is also
@@ -423,7 +423,7 @@ object Predef extends LowPriorityImplicits {
    *
    * @see `<:<` for expressing subtyping constraints
    */
-  @implicitNotFound(msg = "Cannot prove that `${From} =:= ${To}`.")
+  @implicitNotFound(msg = "Cannot prove that ${From} =:= ${To}.")
   sealed abstract class =:=[From, To] extends (From => To) with Serializable
   private[this] final val singleton_=:= = new =:=[Any,Any] { def apply(x: Any): Any = x }
   object =:= {

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -121,16 +121,16 @@ object Predef extends LowPriorityImplicits {
 
   // Deprecated
 
-  @deprecated("Use sys.error(message) instead", "2.9.0")
+  @deprecated("Use `sys.error(message)` instead", "2.9.0")
   def error(message: String): Nothing = sys.error(message)
 
-  @deprecated("Use sys.exit() instead", "2.9.0")
+  @deprecated("Use `sys.exit()` instead", "2.9.0")
   def exit(): Nothing = sys.exit()
 
-  @deprecated("Use sys.exit(status) instead", "2.9.0")
+  @deprecated("Use `sys.exit(status)` instead", "2.9.0")
   def exit(status: Int): Nothing = sys.exit(status)
 
-  @deprecated("Use formatString.format(args: _*) or arg.formatted(formatString) instead", "2.9.0")
+  @deprecated("Use `formatString.format(args: _*)` or `arg.formatted(formatString)` instead", "2.9.0")
   def format(text: String, xs: Any*) = augmentString(text).format(xs: _*)
 
   // errors and asserts -------------------------------------------------
@@ -219,7 +219,7 @@ object Predef extends LowPriorityImplicits {
   final class Ensuring[A](val __resultOfEnsuring: A) extends AnyVal {
     // `__resultOfEnsuring` must be a public val to allow inlining.
     // See comments in ArrowAssoc for more.
-    @deprecated("Use __resultOfEnsuring instead", "2.10.0")
+    @deprecated("Use `__resultOfEnsuring` instead", "2.10.0")
     def x = __resultOfEnsuring
 
     def ensuring(cond: Boolean): A = { assert(cond); __resultOfEnsuring }
@@ -255,7 +255,7 @@ object Predef extends LowPriorityImplicits {
     // being confused why they get an ambiguous implicit conversion
     // error. (`foo.x` used to produce this error since both
     // any2Ensuring and any2ArrowAssoc pimped an `x` onto everything)
-    @deprecated("Use __leftOfArrow instead", "2.10.0")
+    @deprecated("Use `__leftOfArrow` instead", "2.10.0")
     def x = __leftOfArrow
 
     @inline def -> [B](y: B): Tuple2[A, B] = Tuple2(__leftOfArrow, y)
@@ -320,30 +320,30 @@ object Predef extends LowPriorityImplicits {
 
   // Primitive Widenings --------------------------------------------------------------
 
-  @deprecated("Use .toShort for explicit conversion and Byte.byte2short for implicit conversion", "2.10.0") def byte2short(x: Byte): Short = x.toShort
-  @deprecated("Use .toInt for explicit conversion and Byte.byte2int for implicit conversion", "2.10.0") def byte2int(x: Byte): Int = x.toInt
-  @deprecated("Use .toLong for explicit conversion and Byte.byte2long for implicit conversion", "2.10.0") def byte2long(x: Byte): Long = x.toLong
-  @deprecated("Use .toFloat for explicit conversion and Byte.byte2float for implicit conversion", "2.10.0") def byte2float(x: Byte): Float = x.toFloat
-  @deprecated("Use .toDouble for explicit conversion and Byte.byte2double for implicit conversion", "2.10.0") def byte2double(x: Byte): Double = x.toDouble
+  @deprecated("Use `.toShort` for explicit conversion and `Byte.byte2short` for implicit conversion", "2.10.0") def byte2short(x: Byte): Short = x.toShort
+  @deprecated("Use `.toInt` for explicit conversion and `Byte.byte2int` for implicit conversion", "2.10.0") def byte2int(x: Byte): Int = x.toInt
+  @deprecated("Use `.toLong` for explicit conversion and `Byte.byte2long for implicit conversion", "2.10.0") def byte2long(x: Byte): Long = x.toLong
+  @deprecated("Use `.toFloat` for explicit conversion and `Byte.byte2float` for implicit conversion", "2.10.0") def byte2float(x: Byte): Float = x.toFloat
+  @deprecated("Use `.toDouble` for explicit conversion and `Byte.byte2double` for implicit conversion", "2.10.0") def byte2double(x: Byte): Double = x.toDouble
 
-  @deprecated("Use .toInt for explicit conversion and Short.short2int for implicit conversion", "2.10.0") def short2int(x: Short): Int = x.toInt
-  @deprecated("Use .toLong for explicit conversion and Short.short2long for implicit conversion", "2.10.0") def short2long(x: Short): Long = x.toLong
-  @deprecated("Use .toFloat for explicit conversion and Short.short2float for implicit conversion", "2.10.0") def short2float(x: Short): Float = x.toFloat
-  @deprecated("Use .toDouble for explicit conversion and Short.short2double for implicit conversion", "2.10.0") def short2double(x: Short): Double = x.toDouble
+  @deprecated("Use `.toInt` for explicit conversion and `Short.short2int` for implicit conversion", "2.10.0") def short2int(x: Short): Int = x.toInt
+  @deprecated("Use `.toLong` for explicit conversion and `Short.short2long` for implicit conversion", "2.10.0") def short2long(x: Short): Long = x.toLong
+  @deprecated("Use `.toFloat` for explicit conversion and `Short.short2float` for implicit conversion", "2.10.0") def short2float(x: Short): Float = x.toFloat
+  @deprecated("Use `.toDouble` for explicit conversion and `Short.short2double` for implicit conversion", "2.10.0") def short2double(x: Short): Double = x.toDouble
 
-  @deprecated("Use .toInt for explicit conversion and Char.char2int for implicit conversion", "2.10.0") def char2int(x: Char): Int = x.toInt
-  @deprecated("Use .toLong for explicit conversion and Char.char2long for implicit conversion", "2.10.0") def char2long(x: Char): Long = x.toLong
-  @deprecated("Use .toFloat for explicit conversion and Char.char2float for implicit conversion", "2.10.0") def char2float(x: Char): Float = x.toFloat
-  @deprecated("Use .toDouble for explicit conversion and Char.char2double for implicit conversion", "2.10.0") def char2double(x: Char): Double = x.toDouble
+  @deprecated("Use `.toInt` for explicit conversion and `Char.char2int` for implicit conversion", "2.10.0") def char2int(x: Char): Int = x.toInt
+  @deprecated("Use `.toLong` for explicit conversion and `Char.char2long` for implicit conversion", "2.10.0") def char2long(x: Char): Long = x.toLong
+  @deprecated("Use `.toFloat` for explicit conversion and `Char.char2float` for implicit conversion", "2.10.0") def char2float(x: Char): Float = x.toFloat
+  @deprecated("Use `.toDouble` for explicit conversion and `Char.char2double` for implicit conversion", "2.10.0") def char2double(x: Char): Double = x.toDouble
 
-  @deprecated("Use .toLong for explicit conversion and Int.int2long for implicit conversion", "2.10.0") def int2long(x: Int): Long = x.toLong
-  @deprecated("Use .toFloat for explicit conversion and Int.int2float for implicit conversion", "2.10.0") def int2float(x: Int): Float = x.toFloat
-  @deprecated("Use .toDouble for explicit conversion and Int.int2double for implicit conversion", "2.10.0") def int2double(x: Int): Double = x.toDouble
+  @deprecated("Use `.toLong` for explicit conversion and `Int.int2long` for implicit conversion", "2.10.0") def int2long(x: Int): Long = x.toLong
+  @deprecated("Use `.toFloat` for explicit conversion and `Int.int2float` for implicit conversion", "2.10.0") def int2float(x: Int): Float = x.toFloat
+  @deprecated("Use `.toDouble` for explicit conversion and `Int.int2double` for implicit conversion", "2.10.0") def int2double(x: Int): Double = x.toDouble
 
-  @deprecated("Use .toFloat for explicit conversion and Long.long2float for implicit conversion", "2.10.0") def long2float(x: Long): Float = x.toFloat
-  @deprecated("Use .toDouble for explicit conversion and Long.long2double for implicit conversion", "2.10.0") def long2double(x: Long): Double = x.toDouble
+  @deprecated("Use `.toFloat` for explicit conversion and `Long.long2float` for implicit conversion", "2.10.0") def long2float(x: Long): Float = x.toFloat
+  @deprecated("Use `.toDouble` for explicit conversion and `Long.long2double` for implicit conversion", "2.10.0") def long2double(x: Long): Double = x.toDouble
 
-  @deprecated("Use .toDouble for explicit conversion and Float.float2double for implicit conversion", "2.10.0") def float2double(x: Float): Double = x.toDouble
+  @deprecated("Use `.toDouble` for explicit conversion and `Float.float2double` for implicit conversion", "2.10.0") def float2double(x: Float): Double = x.toDouble
 
   // "Autoboxing" and "Autounboxing" ---------------------------------------------------
 
@@ -385,7 +385,7 @@ object Predef extends LowPriorityImplicits {
   implicit def any2stringadd(x: Any) = new runtime.StringAdd(x)
   implicit def unaugmentString(x: StringOps): String = x.repr
 
-  @deprecated("Use StringCanBuildFrom", "2.10.0")
+  @deprecated("Use `StringCanBuildFrom`", "2.10.0")
   def stringCanBuildFrom: CanBuildFrom[String, Char, String] = StringCanBuildFrom
 
   implicit val StringCanBuildFrom: CanBuildFrom[String, Char, String] = new CanBuildFrom[String, Char, String] {
@@ -412,7 +412,7 @@ object Predef extends LowPriorityImplicits {
    *
    * In part contributed by Jason Zaugg.
    */
-  @implicitNotFound(msg = "Cannot prove that ${From} <:< ${To}.")
+  @implicitNotFound(msg = "Cannot prove that `${From} <:< ${To}`.")
   sealed abstract class <:<[-From, +To] extends (From => To) with Serializable
   private[this] final val singleton_<:< = new <:<[Any,Any] { def apply(x: Any): Any = x }
   // not in the <:< companion object because it is also
@@ -423,7 +423,7 @@ object Predef extends LowPriorityImplicits {
    *
    * @see `<:<` for expressing subtyping constraints
    */
-  @implicitNotFound(msg = "Cannot prove that ${From} =:= ${To}.")
+  @implicitNotFound(msg = "Cannot prove that `${From} =:= ${To}`.")
   sealed abstract class =:=[From, To] extends (From => To) with Serializable
   private[this] final val singleton_=:= = new =:=[Any,Any] { def apply(x: Any): Any = x }
   object =:= {


### PR DESCRIPTION
This is the new, improved one. Found overzealous backticking to be the cause earlier, although with a less than stellar failure message.
