### PR TITLE
fix compiler crash on BoundedWildcardType variance check

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Variances.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Variances.scala
@@ -65,7 +65,7 @@ trait Variances {
 
   /** Compute variance of type parameter <code>tparam</code> in type <code>tp</code>. */
   def varianceInType(tp: Type)(tparam: Symbol): Int = tp match {
-    case ErrorType | WildcardType | NoType | NoPrefix | ThisType(_) | ConstantType(_) =>
+    case ErrorType | WildcardType | BoundedWildcardType(_) | NoType | NoPrefix | ThisType(_) | ConstantType(_) =>
       VARIANCES
     case SingleType(pre, sym) =>
       varianceInType(pre)(tparam)


### PR DESCRIPTION
This was missing, causing compiler crashes in various examples whenever
a BoundedWildcardType got here.

An example of code that would crash the compiler before now is this:

```
abstract class Foo[T] extends Seq[T] {
  def f[T2](a : T => T2) : T2
}

abstract class Bar[T] (collections : Iterable[Foo[_ <: T]] ) {
  val lol = {
    collections.zipWithIndex.foreach {
      case (foo: Foo[_], i: Int) => {
        foo.f((t:T) => Unit)
      }
    }
  }
}
```
