### PR TITLE
SI-4989 Reject super.x if an intermediate class declares x abstract.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
@@ -124,7 +124,15 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
             !(member.isAbstractOverride && member.isIncompleteIn(clazz)))
           unit.error(sel.pos, ""+sym.fullLocationString+" is accessed from super. It may not be abstract "+
                                "unless it is overridden by a member declared `abstract' and `override'");
+      } else if (mix == tpnme.EMPTY){
+        // SI-4989 Check if an intermediary between clazz and sym.owner redeclares the method as abstract.
+        val intermediateClasses = clazz.info.baseClasses.tail.takeWhile(_ != sym.owner)
+        intermediateClasses.map(sym.overridingSymbol).find(s => s.isDeferred && !s.isAbstractOverride).foreach {
+          absSym =>
+            unit.error(sel.pos, s"${sym.fullLocationString} cannot be directly accessed from ${clazz} because ${absSym.owner} redeclares it as abstract")
+        }
       }
+
       if (name.isTermName && mix == tpnme.EMPTY && (clazz.isTrait || clazz != currentClass || !validCurrentOwner))
         ensureAccessor(sel)
       else sel

--- a/test/files/neg/t4989.check
+++ b/test/files/neg/t4989.check
@@ -1,0 +1,4 @@
+t4989.scala:14: error: method print in class A cannot be directly accessed from class C because class B redeclares it as abstract
+  override def print(): String = super.print() // should be an error
+                                       ^
+one error found

--- a/test/files/neg/t4989.scala
+++ b/test/files/neg/t4989.scala
@@ -1,0 +1,19 @@
+class A0 {
+  def print(): String
+}
+
+class A extends A0 {
+  def print(): String = "A"
+}
+
+abstract class B extends A {
+  def print() : String
+}
+
+class C extends B {
+  override def print(): String = super.print() // should be an error
+}
+
+class D extends A {
+  override def print(): String = super.print() // okay
+}


### PR DESCRIPTION
This is in line with Java's treatment. Without this, an AbstractMethodError
is thrown at runtime.

Review by @hubertp

Discussion: https://groups.google.com/d/topic/scala-internals/1D9HEe-CIe0/discussion
