### PR TITLE
SI-4989 Reject super.x if an intermediate class declares x abstract.

### DIFF
--- a/test/files/neg/t4989.check
+++ b/test/files/neg/t4989.check
@@ -1,0 +1,7 @@
+t4989.scala:14: error: method print in class A cannot be directly accessed from class C because class B redeclares it as abstract
+  override def print(): String = super.print() // should be an error
+                                       ^
+t4989.scala:18: error: method print in class A cannot be directly accessed from trait T because class B redeclares it as abstract
+  override def print(): String = super.print() // should be an error
+                                       ^
+two errors found

--- a/test/files/neg/t4989.scala
+++ b/test/files/neg/t4989.scala
@@ -1,0 +1,68 @@
+abstract class A0 {
+  def print(): String
+}
+
+class A extends A0 {
+  def print(): String = "A"
+}
+
+abstract class B extends A {
+  def print() : String
+}
+
+class C extends B {
+  override def print(): String = super.print() // should be an error
+}
+
+trait T extends B {
+  override def print(): String = super.print() // should be an error
+}
+
+class D extends A {
+  override def print(): String = super.print() // okay
+}
+
+
+// it's okay do this when trait are in the mix, as the
+// suitable super accessor methods are used.
+object ConcreteMethodAndIntermediaryAreTraits {
+  trait T1 {
+    def print(): String = ""
+  }
+
+  trait T2 extends T1 {
+    def print(): String
+  }
+
+  class C3 extends T2 {
+    def print(): String = super.print() // okay
+  }
+}
+
+object IntermediaryIsTrait {
+  class T1 {
+    def print(): String = ""
+  }
+
+  trait T2 extends T1 {
+    def print(): String
+  }
+
+  class C3 extends T2 {
+    override def print(): String = super.print() // okay
+  }
+}
+
+object ConcreteMethodIsTrait {
+  trait T1 {
+    def print(): String = ""
+  }
+
+  abstract class T2 extends T1 {
+    def print(): String
+  }
+
+  class C3 extends T2 {
+    override def print(): String = super.print() // okay
+  }
+}


### PR DESCRIPTION
This is in line with Java's treatment. Without this, an AbstractMethodError
is thrown at runtime.

Review by @hubertp

Discussion: https://groups.google.com/d/topic/scala-internals/1D9HEe-CIe0/discussion

Resubmission of #732 that excludes traits from the check.
