### PR TITLE
SI-4842 Forbid access to outer this from constructor-local classes.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -221,9 +221,6 @@ trait ContextErrors {
       def SuperConstrReferenceError(tree: Tree) =
         NormalTypeError(tree, "super constructor cannot be passed a self reference unless parameter is declared by-name")
 
-      def SuperConstrArgsThisReferenceError(tree: Tree) =
-        NormalTypeError(tree, "super constructor arguments cannot reference unconstructed `this`")
-
       def TooManyArgumentListsForConstructor(tree: Tree) = {
         issueNormalTypeError(tree, "too many argument lists for constructor invocation")
         setError(tree)
@@ -258,6 +255,10 @@ trait ContextErrors {
 
       def AmbiguousParentClassError(tree: Tree) =
         issueNormalTypeError(tree, "ambiguous parent class qualifier")
+
+      //typedThis
+      def CannotAccessEnclosingInstanceFromConstructorInvocation(tree: Tree) =
+        issueNormalTypeError(tree, "Cannot access enclosing instance from a class local to a constructor invocation.")
 
       //typedSelect
       def NotAMemberError(sel: Tree, qual: Tree, name: Name) = {

--- a/test/files/neg/t4166.check
+++ b/test/files/neg/t4166.check
@@ -1,4 +1,4 @@
-t4166.scala:3: error: super constructor arguments cannot reference unconstructed `this`
+t4166.scala:3: error: Cannot access enclosing instance from a class local to a constructor invocation.
 class Demo extends Base(new { Demo.this.toString }) {
                               ^
 one error found

--- a/test/files/neg/t4842.check
+++ b/test/files/neg/t4842.check
@@ -1,0 +1,7 @@
+t4842.scala:6: error: Cannot access enclosing instance from a class local to a constructor invocation.
+  def this(x: Int) = this(new { println(Foo.this)}) // error
+                                        ^
+t4842.scala:10: error: Cannot access enclosing instance from a class local to a constructor invocation.
+  extends Foo(new { println(Bar.this)}) // error
+                            ^
+two errors found

--- a/test/files/neg/t4842.scala
+++ b/test/files/neg/t4842.scala
@@ -1,0 +1,16 @@
+class Foo (x: AnyRef) {
+  def this() = {
+    this(new { } ) // okay
+  }
+
+  def this(x: Int) = this(new { println(Foo.this)}) // error
+}
+
+class Bar (x: AnyRef)
+  extends Foo(new { println(Bar.this)}) // error
+
+class Blerg (x: AnyRef) {
+  def this() = {
+    this(new { class Bar { println(Bar.this); new { println(Bar.this) } }; new Bar } ) // okay
+  }
+}


### PR DESCRIPTION
In the same spirit as SI-4166. In fact, this change takes over some of its error message turf.

In this case, it's more of an implementation restriction, as the generated classes don't get an `$outer` parameter (See `Symbol#{isClassLocalToConstructor, outerClass}`).

review by @adriaanm (or another member of the Wannabe NPEs...)
- would it be more correct to add an `$outer` parameter for these? maybe the restriction was only intended for arguments to the super constructor, rather than the self constructor.
- general question: which checks go into `Typers` vs `RefChecks`?
