### PR TITLE
Adding copyInto and toVector methods to collections.

### DIFF
--- a/src/library/scala/collection/GenTraversableOnce.scala
+++ b/src/library/scala/collection/GenTraversableOnce.scala
@@ -562,13 +562,13 @@ trait GenTraversableOnce[+A] extends Any {
   def toVector: Vector[A]
 
   /** Converts this $coll into another by copying all elemnents.
-   *  $willNotTerminateInf
+   *  @tparam Col  The collection type to build.
    *  @return a new collection containing all elements of this $coll.
    *  
-   *  @usecase def copyInto[Col[_]]: Col[A]
+   *  @usecase def copyTo[Col[_]]: Col[A]
    *    @inheritdoc
    *    $willNotTerminateInf
-   *    @return a new collection containing all elemnts of this $coll.
+   *    @return a new collection containing all elements of this $coll.
    */
-  def copyInto[Col[_]](implicit cbf: CanBuildFrom[Nothing, A, Col[A @uV]]): Col[A @uV]
+  def copyTo[Col[_]](implicit cbf: CanBuildFrom[Nothing, A, Col[A @uV]]): Col[A @uV]
 }

--- a/src/library/scala/collection/GenTraversableOnce.scala
+++ b/src/library/scala/collection/GenTraversableOnce.scala
@@ -9,6 +9,8 @@
 package scala.collection
 
 import scala.reflect.ClassTag
+import scala.collection.generic.CanBuildFrom
+import scala.annotation.unchecked.{ uncheckedVariance => uV }
 
 /** A template trait for all traversable-once objects which may be
  *  traversed in parallel.
@@ -552,4 +554,21 @@ trait GenTraversableOnce[+A] extends Any {
    *               containing all key/value pairs of type `(T, U)` of this $coll.
    */
   def toMap[K, V](implicit ev: A <:< (K, V)): GenMap[K, V]
+
+  /** Converts this $coll to a Vector.
+   *  $willNotTerminateInf
+   *  @return a vector containing all elements of this $coll.
+   */
+  def toVector: Vector[A]
+
+  /** Converts this $coll into another by copying all elemnents.
+   *  $willNotTerminateInf
+   *  @return a new collection containing all elements of this $coll.
+   *  
+   *  @usecase def copyInto[Col[_]]: Col[A]
+   *    @inheritdoc
+   *    $willNotTerminateInf
+   *    @return a new collection containing all elemnts of this $coll.
+   */
+  def copyInto[Col[_]](implicit cbf: CanBuildFrom[Nothing, A, Col[A @uV]]): Col[A @uV]
 }

--- a/src/library/scala/collection/GenTraversableOnce.scala
+++ b/src/library/scala/collection/GenTraversableOnce.scala
@@ -565,10 +565,10 @@ trait GenTraversableOnce[+A] extends Any {
    *  @tparam Col  The collection type to build.
    *  @return a new collection containing all elements of this $coll.
    *  
-   *  @usecase def copyTo[Col[_]]: Col[A]
+   *  @usecase def build[Col[_]]: Col[A]
    *    @inheritdoc
    *    $willNotTerminateInf
    *    @return a new collection containing all elements of this $coll.
    */
-  def copyTo[Col[_]](implicit cbf: CanBuildFrom[Nothing, A, Col[A @uV]]): Col[A @uV]
+  def build[Col[_]](implicit cbf: CanBuildFrom[Nothing, A, Col[A @uV]]): Col[A @uV]
 }

--- a/src/library/scala/collection/GenTraversableOnce.scala
+++ b/src/library/scala/collection/GenTraversableOnce.scala
@@ -561,7 +561,7 @@ trait GenTraversableOnce[+A] extends Any {
    */
   def toVector: Vector[A]
 
-  /** Converts this $coll into another by copying all elemnents.
+  /** Converts this $coll into another by copying all elements.
    *  @tparam Col  The collection type to build.
    *  @return a new collection containing all elements of this $coll.
    *  

--- a/src/library/scala/collection/GenTraversableOnce.scala
+++ b/src/library/scala/collection/GenTraversableOnce.scala
@@ -565,10 +565,10 @@ trait GenTraversableOnce[+A] extends Any {
    *  @tparam Col  The collection type to build.
    *  @return a new collection containing all elements of this $coll.
    *  
-   *  @usecase def build[Col[_]]: Col[A]
+   *  @usecase def convertTo[Col[_]]: Col[A]
    *    @inheritdoc
    *    $willNotTerminateInf
    *    @return a new collection containing all elements of this $coll.
    */
-  def build[Col[_]](implicit cbf: CanBuildFrom[Nothing, A, Col[A @uV]]): Col[A @uV]
+  def convertTo[Col[_]](implicit cbf: CanBuildFrom[Nothing, A, Col[A @uV]]): Col[A @uV]
 }

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -1140,13 +1140,6 @@ trait Iterator[+A] extends TraversableOnce[A] {
   def toStream: Stream[A] =
     if (self.hasNext) Stream.cons(self.next, self.toStream)
     else Stream.empty[A]
-
-  def toVector: Vector[A] = build[Vector]
-  def build[Col[_]](implicit cbf: CanBuildFrom[Nothing, A, Col[A @uV]]): Col[A @uV] = {
-    val b = cbf()
-    while(hasNext) b += next
-    b.result
-  }
   
 
   /** Converts this iterator to a string.

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -11,6 +11,8 @@ package scala.collection
 import mutable.ArrayBuffer
 import annotation.migration
 import immutable.Stream
+import scala.collection.generic.CanBuildFrom
+import scala.annotation.unchecked.{ uncheckedVariance => uV }
 
 /** The `Iterator` object provides various functions for creating specialized iterators.
  *
@@ -1138,6 +1140,14 @@ trait Iterator[+A] extends TraversableOnce[A] {
   def toStream: Stream[A] =
     if (self.hasNext) Stream.cons(self.next, self.toStream)
     else Stream.empty[A]
+
+  def toVector: Vector[A] = copyInto[Vector]
+  def copyInto[Col[_]](implicit cbf: CanBuildFrom[Nothing, A, Col[A @uV]]): Col[A @uV] = {
+    val b = cbf()
+    while(hasNext) b += next
+    b.result
+  }
+  
 
   /** Converts this iterator to a string.
    *

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -1141,8 +1141,8 @@ trait Iterator[+A] extends TraversableOnce[A] {
     if (self.hasNext) Stream.cons(self.next, self.toStream)
     else Stream.empty[A]
 
-  def toVector: Vector[A] = copyTo[Vector]
-  def copyTo[Col[_]](implicit cbf: CanBuildFrom[Nothing, A, Col[A @uV]]): Col[A @uV] = {
+  def toVector: Vector[A] = build[Vector]
+  def build[Col[_]](implicit cbf: CanBuildFrom[Nothing, A, Col[A @uV]]): Col[A @uV] = {
     val b = cbf()
     while(hasNext) b += next
     b.result

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -1141,8 +1141,8 @@ trait Iterator[+A] extends TraversableOnce[A] {
     if (self.hasNext) Stream.cons(self.next, self.toStream)
     else Stream.empty[A]
 
-  def toVector: Vector[A] = copyInto[Vector]
-  def copyInto[Col[_]](implicit cbf: CanBuildFrom[Nothing, A, Col[A @uV]]): Col[A @uV] = {
+  def toVector: Vector[A] = copyTo[Vector]
+  def copyTo[Col[_]](implicit cbf: CanBuildFrom[Nothing, A, Col[A @uV]]): Col[A @uV] = {
     val b = cbf()
     while(hasNext) b += next
     b.result

--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -616,8 +616,8 @@ trait TraversableLike[+A, +Repr] extends Any
   def toTraversable: Traversable[A] = thisCollection
   def toIterator: Iterator[A] = toStream.iterator
   def toStream: Stream[A] = toBuffer.toStream
-  def toVector: Vector[A] = copyInto[Vector]
-  def copyInto[Col[_]](implicit cbf: CanBuildFrom[Nothing, A, Col[A @uV]]): Col[A @uV] = {
+  def toVector: Vector[A] = copyTo[Vector]
+  def copyTo[Col[_]](implicit cbf: CanBuildFrom[Nothing, A, Col[A @uV]]): Col[A @uV] = {
     val b = cbf()
     b.sizeHint(this)
     b ++= thisCollection

--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -616,8 +616,8 @@ trait TraversableLike[+A, +Repr] extends Any
   def toTraversable: Traversable[A] = thisCollection
   def toIterator: Iterator[A] = toStream.iterator
   def toStream: Stream[A] = toBuffer.toStream
-  def toVector: Vector[A] = build[Vector]
-  def build[Col[_]](implicit cbf: CanBuildFrom[Nothing, A, Col[A @uV]]): Col[A @uV] = {
+  // Override to provide size hint.
+  override def convertTo[Col[_]](implicit cbf: CanBuildFrom[Nothing, A, Col[A @uV]]): Col[A @uV] = {
     val b = cbf()
     b.sizeHint(this)
     b ++= thisCollection

--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -616,6 +616,13 @@ trait TraversableLike[+A, +Repr] extends Any
   def toTraversable: Traversable[A] = thisCollection
   def toIterator: Iterator[A] = toStream.iterator
   def toStream: Stream[A] = toBuffer.toStream
+  def toVector: Vector[A] = copyInto[Vector]
+  def copyInto[Col[_]](implicit cbf: CanBuildFrom[Nothing, A, Col[A @uV]]): Col[A @uV] = {
+    val b = cbf()
+    b.sizeHint(this)
+    b ++= thisCollection
+    b.result
+  }
 
   /** Converts this $coll to a string.
    *

--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -616,8 +616,8 @@ trait TraversableLike[+A, +Repr] extends Any
   def toTraversable: Traversable[A] = thisCollection
   def toIterator: Iterator[A] = toStream.iterator
   def toStream: Stream[A] = toBuffer.toStream
-  def toVector: Vector[A] = copyTo[Vector]
-  def copyTo[Col[_]](implicit cbf: CanBuildFrom[Nothing, A, Col[A @uV]]): Col[A @uV] = {
+  def toVector: Vector[A] = build[Vector]
+  def build[Col[_]](implicit cbf: CanBuildFrom[Nothing, A, Col[A @uV]]): Col[A @uV] = {
     val b = cbf()
     b.sizeHint(this)
     b ++= thisCollection

--- a/src/library/scala/collection/TraversableOnce.scala
+++ b/src/library/scala/collection/TraversableOnce.scala
@@ -9,6 +9,7 @@
 package scala.collection
 
 import mutable.{ Buffer, Builder, ListBuffer, ArrayBuffer }
+import generic.CanBuildFrom
 import annotation.unchecked.{ uncheckedVariance => uV }
 import language.{implicitConversions, higherKinds}
 import reflect.ClassTag
@@ -239,17 +240,25 @@ trait TraversableOnce[+A] extends Any with GenTraversableOnce[A] {
 
   def toTraversable: Traversable[A]
 
-  def toList: List[A] = (new ListBuffer[A] ++= seq).toList
+  def toList: List[A] = convertTo[List]
 
   def toIterable: Iterable[A] = toStream
 
   def toSeq: Seq[A] = toStream
 
-  def toIndexedSeq: immutable.IndexedSeq[A] = immutable.IndexedSeq() ++ seq
+  def toIndexedSeq: immutable.IndexedSeq[A] = convertTo[immutable.IndexedSeq]
 
-  def toBuffer[B >: A]: mutable.Buffer[B] = new ArrayBuffer[B] ++= seq
+  def toBuffer[B >: A]: mutable.Buffer[B] = convertTo[ArrayBuffer].asInstanceOf[mutable.Buffer[B]]
 
-  def toSet[B >: A]: immutable.Set[B] = immutable.Set() ++ seq
+  def toSet[B >: A]: immutable.Set[B] = convertTo[immutable.Set].asInstanceOf[immutable.Set[B]]
+
+  def toVector: Vector[A] = convertTo[Vector]
+
+  def convertTo[Col[_]](implicit cbf: CanBuildFrom[Nothing, A, Col[A @uV]]): Col[A @uV] = {
+    val b = cbf()
+    b ++= seq
+    b.result
+  }
 
   def toMap[T, U](implicit ev: A <:< (T, U)): immutable.Map[T, U] = {
     val b = immutable.Map.newBuilder[T, U]

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -77,6 +77,8 @@ override def companion: GenericCompanion[Vector] = Vector
 
   override def par = new ParVector(this)
 
+  override def toVector: Vector[A] = this
+
   override def lengthCompare(len: Int): Int = length - len
 
   private[collection] final def initIterator[B >: A](s: VectorIterator[B]) {

--- a/src/library/scala/collection/parallel/ParIterableLike.scala
+++ b/src/library/scala/collection/parallel/ParIterableLike.scala
@@ -853,7 +853,7 @@ self: ParIterableLike[T, Repr, Sequential] =>
 
   override def toVector: Vector[T] = seq.toVector
 
-  override def copyInto[Col[_]](implicit cbf: CanBuildFrom[Nothing, T, Col[T @uncheckedVariance]]): Col[T @uncheckedVariance] = seq.copyInto[Col]
+  override def copyTo[Col[_]](implicit cbf: CanBuildFrom[Nothing, T, Col[T @uncheckedVariance]]): Col[T @uncheckedVariance] = seq.copyTo[Col]
   
 
   /* tasks */

--- a/src/library/scala/collection/parallel/ParIterableLike.scala
+++ b/src/library/scala/collection/parallel/ParIterableLike.scala
@@ -851,9 +851,10 @@ self: ParIterableLike[T, Repr, Sequential] =>
 
   override def toMap[K, V](implicit ev: T <:< (K, V)): immutable.ParMap[K, V] = toParMap[K, V, immutable.ParMap[K, V]](() => immutable.ParMap.newCombiner[K, V])
 
+  // TODO(@alex22): make these better
   override def toVector: Vector[T] = seq.toVector
 
-  override def build[Col[_]](implicit cbf: CanBuildFrom[Nothing, T, Col[T @uncheckedVariance]]): Col[T @uncheckedVariance] = seq.build[Col]
+  override def convertTo[Col[_]](implicit cbf: CanBuildFrom[Nothing, T, Col[T @uncheckedVariance]]): Col[T @uncheckedVariance] = seq.convertTo[Col]
   
 
   /* tasks */

--- a/src/library/scala/collection/parallel/ParIterableLike.scala
+++ b/src/library/scala/collection/parallel/ParIterableLike.scala
@@ -851,6 +851,11 @@ self: ParIterableLike[T, Repr, Sequential] =>
 
   override def toMap[K, V](implicit ev: T <:< (K, V)): immutable.ParMap[K, V] = toParMap[K, V, immutable.ParMap[K, V]](() => immutable.ParMap.newCombiner[K, V])
 
+  override def toVector: Vector[T] = seq.toVector
+
+  override def copyInto[Col[_]](implicit cbf: CanBuildFrom[Nothing, T, Col[T @uncheckedVariance]]): Col[T @uncheckedVariance] = seq.copyInto[Col]
+  
+
   /* tasks */
 
   protected trait StrictSplitterCheckTask[R, Tp] extends Task[R, Tp] {

--- a/src/library/scala/collection/parallel/ParIterableLike.scala
+++ b/src/library/scala/collection/parallel/ParIterableLike.scala
@@ -853,7 +853,7 @@ self: ParIterableLike[T, Repr, Sequential] =>
 
   override def toVector: Vector[T] = seq.toVector
 
-  override def copyTo[Col[_]](implicit cbf: CanBuildFrom[Nothing, T, Col[T @uncheckedVariance]]): Col[T @uncheckedVariance] = seq.copyTo[Col]
+  override def build[Col[_]](implicit cbf: CanBuildFrom[Nothing, T, Col[T @uncheckedVariance]]): Col[T @uncheckedVariance] = seq.build[Col]
   
 
   /* tasks */

--- a/src/library/scala/collection/parallel/immutable/ParVector.scala
+++ b/src/library/scala/collection/parallel/immutable/ParVector.scala
@@ -62,6 +62,8 @@ extends ParSeq[T]
 
   override def seq: Vector[T] = vector
 
+  override def toVector: Vector[T] = vector
+
   class ParVectorIterator(_start: Int, _end: Int) extends VectorIterator[T](_start, _end) with SeqSplitter[T] {
     def remaining: Int = remainingElementCount
     def dup: SeqSplitter[T] = (new ParVector(remainingVector)).splitter

--- a/test/files/presentation/ide-bug-1000531.check
+++ b/test/files/presentation/ide-bug-1000531.check
@@ -3,7 +3,7 @@ reload: CrashOnLoad.scala
 askTypeCompletion at CrashOnLoad.scala(6,12)
 ================================================================================
 [response] aksTypeCompletion at (6,12)
-retrieved 124 members
+retrieved 126 members
 [accessible:  true] `class GroupedIteratorIterator[B]#GroupedIterator`
 [accessible:  true] `method !=(x$1: Any)Boolean`
 [accessible:  true] `method !=(x$1: AnyRef)Boolean`
@@ -25,6 +25,7 @@ retrieved 124 members
 [accessible:  true] `method collectFirst[B](pf: PartialFunction[B,B])Option[B]`
 [accessible:  true] `method collect[B](pf: PartialFunction[B,B])Iterator[B]`
 [accessible:  true] `method contains(elem: Any)Boolean`
+[accessible:  true] `method convertTo[Col[_]](implicit cbf: scala.collection.generic.CanBuildFrom[Nothing,B,Col[B]])Col[B]`
 [accessible:  true] `method copyToArray[B >: B](xs: Array[B])Unit`
 [accessible:  true] `method copyToArray[B >: B](xs: Array[B], start: Int)Unit`
 [accessible:  true] `method copyToArray[B >: B](xs: Array[B], start: Int, len: Int)Unit`
@@ -109,6 +110,7 @@ retrieved 124 members
 [accessible:  true] `method toStream=> scala.collection.immutable.Stream[B]`
 [accessible:  true] `method toString()String`
 [accessible:  true] `method toTraversable=> Traversable[B]`
+[accessible:  true] `method toVector=> Vector[B]`
 [accessible:  true] `method wait()Unit`
 [accessible:  true] `method wait(x$1: Long)Unit`
 [accessible:  true] `method wait(x$1: Long, x$2: Int)Unit`

--- a/test/files/run/collection-conversions.check
+++ b/test/files/run/collection-conversions.check
@@ -1,0 +1,104 @@
+-- Testing iterator ---
+  :[Direct] Vector   : OK
+  :[Copy]   Vector   : OK
+  :[Direct] Buffer   : OK
+  :[Copy]   Buffer   : OK
+  :[Direct] GenSeq   : OK
+  :[Copy]   GenSeq   : OK
+  :[Copy]   Seq      : OK
+  :[Direct] Stream   : OK
+  :[Copy]   Stream   : OK
+  :[Direct] Array    : OK
+  :[Copy]   Array    : OK
+  :[Copy]   ParVector: OK
+-- Testing Vector ---
+  :[Direct] Vector   : OK
+  :[Copy]   Vector   : OK
+  :[Direct] Buffer   : OK
+  :[Copy]   Buffer   : OK
+  :[Direct] GenSeq   : OK
+  :[Copy]   GenSeq   : OK
+  :[Copy]   Seq      : OK
+  :[Direct] Stream   : OK
+  :[Copy]   Stream   : OK
+  :[Direct] Array    : OK
+  :[Copy]   Array    : OK
+  :[Copy]   ParVector: OK
+-- Testing List ---
+  :[Direct] Vector   : OK
+  :[Copy]   Vector   : OK
+  :[Direct] Buffer   : OK
+  :[Copy]   Buffer   : OK
+  :[Direct] GenSeq   : OK
+  :[Copy]   GenSeq   : OK
+  :[Copy]   Seq      : OK
+  :[Direct] Stream   : OK
+  :[Copy]   Stream   : OK
+  :[Direct] Array    : OK
+  :[Copy]   Array    : OK
+  :[Copy]   ParVector: OK
+-- Testing Buffer ---
+  :[Direct] Vector   : OK
+  :[Copy]   Vector   : OK
+  :[Direct] Buffer   : OK
+  :[Copy]   Buffer   : OK
+  :[Direct] GenSeq   : OK
+  :[Copy]   GenSeq   : OK
+  :[Copy]   Seq      : OK
+  :[Direct] Stream   : OK
+  :[Copy]   Stream   : OK
+  :[Direct] Array    : OK
+  :[Copy]   Array    : OK
+  :[Copy]   ParVector: OK
+-- Testing ParVector ---
+  :[Direct] Vector   : OK
+  :[Copy]   Vector   : OK
+  :[Direct] Buffer   : OK
+  :[Copy]   Buffer   : OK
+  :[Direct] GenSeq   : OK
+  :[Copy]   GenSeq   : OK
+  :[Copy]   Seq      : OK
+  :[Direct] Stream   : OK
+  :[Copy]   Stream   : OK
+  :[Direct] Array    : OK
+  :[Copy]   Array    : OK
+  :[Copy]   ParVector: OK
+-- Testing Set ---
+  :[Direct] Vector   : OK
+  :[Copy]   Vector   : OK
+  :[Direct] Buffer   : OK
+  :[Copy]   Buffer   : OK
+  :[Direct] GenSeq   : OK
+  :[Copy]   GenSeq   : OK
+  :[Copy]   Seq      : OK
+  :[Direct] Stream   : OK
+  :[Copy]   Stream   : OK
+  :[Direct] Array    : OK
+  :[Copy]   Array    : OK
+  :[Copy]   ParVector: OK
+-- Testing SetView ---
+  :[Direct] Vector   : OK
+  :[Copy]   Vector   : OK
+  :[Direct] Buffer   : OK
+  :[Copy]   Buffer   : OK
+  :[Direct] GenSeq   : OK
+  :[Copy]   GenSeq   : OK
+  :[Copy]   Seq      : OK
+  :[Direct] Stream   : OK
+  :[Copy]   Stream   : OK
+  :[Direct] Array    : OK
+  :[Copy]   Array    : OK
+  :[Copy]   ParVector: OK
+-- Testing BufferView ---
+  :[Direct] Vector   : OK
+  :[Copy]   Vector   : OK
+  :[Direct] Buffer   : OK
+  :[Copy]   Buffer   : OK
+  :[Direct] GenSeq   : OK
+  :[Copy]   GenSeq   : OK
+  :[Copy]   Seq      : OK
+  :[Direct] Stream   : OK
+  :[Copy]   Stream   : OK
+  :[Direct] Array    : OK
+  :[Copy]   Array    : OK
+  :[Copy]   ParVector: OK

--- a/test/files/run/collection-conversions.scala
+++ b/test/files/run/collection-conversions.scala
@@ -1,0 +1,60 @@
+import collection._
+import mutable.Buffer
+import parallel.immutable.ParVector
+import reflect.ClassTag
+
+object Test {
+
+  def printResult[A,B](msg: String, obj: A, expected: B)(implicit tag: ClassTag[A], tag2: ClassTag[B]) = {
+    print("  :" + msg +": ")
+    val isArray = obj match { 
+      case x: Array[Int] => true 
+      case _ => false
+    }
+    val expectedEquals = 
+      if(isArray) obj.asInstanceOf[Array[Int]].toSeq == expected.asInstanceOf[Array[Int]].toSeq
+      else obj == expected
+    val tagEquals = tag == tag2
+    if(expectedEquals && tagEquals) print("OK")
+    else print("FAILED")
+    if(!expectedEquals) print(", " + obj + " != " + expected)
+    if(!tagEquals)     print(", " + tag + " != " + tag2)
+    println("")
+  }
+
+  val testVector = Vector(1,2,3)
+  val testBuffer = Buffer(1,2,3)
+  val testGenSeq = GenSeq(1,2,3)
+  val testSeq = Seq(1,2,3)
+  val testStream = Stream(1,2,3)
+  val testArray = Array(1,2,3)
+  val testParVector = ParVector(1,2,3)
+
+  def testConversion[A: ClassTag](name: String, col: => GenTraversableOnce[A]): Unit = {
+    val tmp = col
+    println("-- Testing " + name + " ---")
+    printResult("[Direct] Vector   ", col.toVector, testVector)
+    printResult("[Copy]   Vector   ", col.copyInto[Vector], testVector)
+    printResult("[Direct] Buffer   ", col.toBuffer, testBuffer)
+    printResult("[Copy]   Buffer   ", col.copyInto[Buffer], testBuffer)
+    printResult("[Direct] GenSeq   ", col.toSeq, testGenSeq)
+    printResult("[Copy]   GenSeq   ", col.copyInto[GenSeq], testGenSeq)
+    printResult("[Copy]   Seq      ", col.copyInto[Seq], testSeq)
+    printResult("[Direct] Stream   ", col.toStream, testStream)
+    printResult("[Copy]   Stream   ", col.copyInto[Stream], testStream)
+    printResult("[Direct] Array    ", col.toArray, testArray)
+    printResult("[Copy]   Array    ", col.copyInto[Array], testArray)
+    printResult("[Copy]   ParVector", col.copyInto[ParVector], testParVector)
+  }
+  
+  def main(args: Array[String]): Unit = {
+	  testConversion("iterator", (1 to 3).iterator)
+    testConversion("Vector", Vector(1,2,3))
+    testConversion("List", List(1,2,3))
+    testConversion("Buffer", Buffer(1,2,3))
+    testConversion("ParVector", ParVector(1,2,3))
+    testConversion("Set", Set(1,2,3))
+    testConversion("SetView", Set(1,2,3).view)
+    testConversion("BufferView", Buffer(1,2,3).view)
+  }
+}

--- a/test/files/run/collection-conversions.scala
+++ b/test/files/run/collection-conversions.scala
@@ -34,17 +34,17 @@ object Test {
     val tmp = col
     println("-- Testing " + name + " ---")
     printResult("[Direct] Vector   ", col.toVector, testVector)
-    printResult("[Copy]   Vector   ", col.copyInto[Vector], testVector)
+    printResult("[Copy]   Vector   ", col.copyTo[Vector], testVector)
     printResult("[Direct] Buffer   ", col.toBuffer, testBuffer)
-    printResult("[Copy]   Buffer   ", col.copyInto[Buffer], testBuffer)
+    printResult("[Copy]   Buffer   ", col.copyTo[Buffer], testBuffer)
     printResult("[Direct] GenSeq   ", col.toSeq, testGenSeq)
-    printResult("[Copy]   GenSeq   ", col.copyInto[GenSeq], testGenSeq)
-    printResult("[Copy]   Seq      ", col.copyInto[Seq], testSeq)
+    printResult("[Copy]   GenSeq   ", col.copyTo[GenSeq], testGenSeq)
+    printResult("[Copy]   Seq      ", col.copyTo[Seq], testSeq)
     printResult("[Direct] Stream   ", col.toStream, testStream)
-    printResult("[Copy]   Stream   ", col.copyInto[Stream], testStream)
+    printResult("[Copy]   Stream   ", col.copyTo[Stream], testStream)
     printResult("[Direct] Array    ", col.toArray, testArray)
-    printResult("[Copy]   Array    ", col.copyInto[Array], testArray)
-    printResult("[Copy]   ParVector", col.copyInto[ParVector], testParVector)
+    printResult("[Copy]   Array    ", col.copyTo[Array], testArray)
+    printResult("[Copy]   ParVector", col.copyTo[ParVector], testParVector)
   }
   
   def main(args: Array[String]): Unit = {

--- a/test/files/run/collection-conversions.scala
+++ b/test/files/run/collection-conversions.scala
@@ -34,17 +34,17 @@ object Test {
     val tmp = col
     println("-- Testing " + name + " ---")
     printResult("[Direct] Vector   ", col.toVector, testVector)
-    printResult("[Copy]   Vector   ", col.copyTo[Vector], testVector)
+    printResult("[Copy]   Vector   ", col.build[Vector], testVector)
     printResult("[Direct] Buffer   ", col.toBuffer, testBuffer)
-    printResult("[Copy]   Buffer   ", col.copyTo[Buffer], testBuffer)
+    printResult("[Copy]   Buffer   ", col.build[Buffer], testBuffer)
     printResult("[Direct] GenSeq   ", col.toSeq, testGenSeq)
-    printResult("[Copy]   GenSeq   ", col.copyTo[GenSeq], testGenSeq)
-    printResult("[Copy]   Seq      ", col.copyTo[Seq], testSeq)
+    printResult("[Copy]   GenSeq   ", col.build[GenSeq], testGenSeq)
+    printResult("[Copy]   Seq      ", col.build[Seq], testSeq)
     printResult("[Direct] Stream   ", col.toStream, testStream)
-    printResult("[Copy]   Stream   ", col.copyTo[Stream], testStream)
+    printResult("[Copy]   Stream   ", col.build[Stream], testStream)
     printResult("[Direct] Array    ", col.toArray, testArray)
-    printResult("[Copy]   Array    ", col.copyTo[Array], testArray)
-    printResult("[Copy]   ParVector", col.copyTo[ParVector], testParVector)
+    printResult("[Copy]   Array    ", col.build[Array], testArray)
+    printResult("[Copy]   ParVector", col.build[ParVector], testParVector)
   }
   
   def main(args: Array[String]): Unit = {

--- a/test/files/run/collection-conversions.scala
+++ b/test/files/run/collection-conversions.scala
@@ -34,17 +34,17 @@ object Test {
     val tmp = col
     println("-- Testing " + name + " ---")
     printResult("[Direct] Vector   ", col.toVector, testVector)
-    printResult("[Copy]   Vector   ", col.build[Vector], testVector)
+    printResult("[Copy]   Vector   ", col.convertTo[Vector], testVector)
     printResult("[Direct] Buffer   ", col.toBuffer, testBuffer)
-    printResult("[Copy]   Buffer   ", col.build[Buffer], testBuffer)
+    printResult("[Copy]   Buffer   ", col.convertTo[Buffer], testBuffer)
     printResult("[Direct] GenSeq   ", col.toSeq, testGenSeq)
-    printResult("[Copy]   GenSeq   ", col.build[GenSeq], testGenSeq)
-    printResult("[Copy]   Seq      ", col.build[Seq], testSeq)
+    printResult("[Copy]   GenSeq   ", col.convertTo[GenSeq], testGenSeq)
+    printResult("[Copy]   Seq      ", col.convertTo[Seq], testSeq)
     printResult("[Direct] Stream   ", col.toStream, testStream)
-    printResult("[Copy]   Stream   ", col.build[Stream], testStream)
+    printResult("[Copy]   Stream   ", col.convertTo[Stream], testStream)
     printResult("[Direct] Array    ", col.toArray, testArray)
-    printResult("[Copy]   Array    ", col.build[Array], testArray)
-    printResult("[Copy]   ParVector", col.build[ParVector], testParVector)
+    printResult("[Copy]   Array    ", col.convertTo[Array], testArray)
+    printResult("[Copy]   ParVector", col.convertTo[ParVector], testParVector)
   }
   
   def main(args: Array[String]): Unit = {


### PR DESCRIPTION
- Added generic copyInto method for collections.  For any collection with a CanBuildFrom, can convert a generic collection into it using the builder.
- Added specifici toVector method for collections.   This is more efficient than copyInto if the collection is a Vector.

Review by @axel22
