### PR TITLE
Fix SI-4541.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Duplicators.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Duplicators.scala
@@ -360,7 +360,7 @@ abstract class Duplicators extends Analyzer {
           tree
 
         case _ =>
-          debuglog("Duplicators default case: " + tree.summaryString)
+          // log("Duplicators default case: " + tree.summaryString + " -> " + tree)
           if (tree.hasSymbol && tree.symbol != NoSymbol && (tree.symbol.owner == definitions.AnyClass)) {
             tree.symbol = NoSymbol // maybe we can find a more specific member in a subclass of Any (see AnyVal members, like ==)
           }

--- a/test/files/neg/t4541.check
+++ b/test/files/neg/t4541.check
@@ -1,0 +1,7 @@
+t4541.scala:11: error: scala.reflect.internal.Types$TypeError: variable data in class Sparse cannot be accessed in Sparse[Int]
+ Access to protected method data not permitted because
+ prefix type Sparse[Int] does not conform to
+ class Sparse$mcI$sp where the access take place
+    that.data
+         ^
+one error found

--- a/test/files/neg/t4541.scala
+++ b/test/files/neg/t4541.scala
@@ -1,0 +1,16 @@
+
+
+
+
+
+
+@SerialVersionUID(1L)
+final class Sparse[@specialized(Int) T](d: Array[T]) extends Serializable {
+  protected var data: Array[T] = d
+  def set(that: Sparse[T]) = {
+    that.data
+  }
+}
+
+
+

--- a/test/files/neg/t4541b.check
+++ b/test/files/neg/t4541b.check
@@ -1,0 +1,7 @@
+t4541b.scala:13: error: scala.reflect.internal.Types$TypeError: variable data in class SparseArray cannot be accessed in SparseArray[Int]
+ Access to protected method data not permitted because
+ prefix type SparseArray[Int] does not conform to
+ class SparseArray$mcI$sp where the access take place
+    use(that.data.clone)
+             ^
+one error found

--- a/test/files/neg/t4541b.scala
+++ b/test/files/neg/t4541b.scala
@@ -1,0 +1,16 @@
+
+
+
+
+
+@SerialVersionUID(1L)
+final class SparseArray[@specialized(Int) T](private var data: Array[T]) extends Serializable {
+  def use(inData: Array[T]) = {
+    data = inData;
+  }
+  
+  def set(that: SparseArray[T]) = {
+    use(that.data.clone)
+  }
+}
+


### PR DESCRIPTION
Catch type errors when duplicating trees.
In this case, to access a protected member from a specialized
class is an error, so we would have to make the member public
anyway.
Better it is then to report an error and have the user make the
field public explicitly.

Review by @dragos.
