### PR TITLE
Updated scalacheck sources.

### DIFF
--- a/src/scalacheck/org/scalacheck/Arbitrary.scala
+++ b/src/scalacheck/org/scalacheck/Arbitrary.scala
@@ -5,7 +5,7 @@
 **                                                                         **
 **  This software is released under the terms of the Revised BSD License.  **
 **  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*-------------------------------------------------------------------------*/
+\*------------------------------------------------------------------------ */
 
 package org.scalacheck
 
@@ -178,9 +178,10 @@ object Arbitrary {
     import java.math.MathContext._
     val mcGen = oneOf(UNLIMITED, DECIMAL32, DECIMAL64, DECIMAL128)
     val bdGen = for {
-      mc <- mcGen
-      scale <- arbInt.arbitrary
       x <- arbBigInt.arbitrary
+      mc <- mcGen
+      limit <- value(if(mc == UNLIMITED) 0 else math.max(x.abs.toString.length - mc.getPrecision, 0))
+      scale <- Gen.chooseNum(Int.MinValue + limit , Int.MaxValue)
     } yield BigDecimal(x, scale, mc)
     Arbitrary(bdGen)
   }
@@ -197,24 +198,37 @@ object Arbitrary {
   }
 
   /** Generates an arbitrary property */
-  implicit lazy val arbProp: Arbitrary[Prop] =
+  implicit lazy val arbProp: Arbitrary[Prop] = {
+    import Prop._
+    val undecidedOrPassed = forAll { b: Boolean =>
+      b ==> true
+    }
     Arbitrary(frequency(
-      (5, Prop.proved),
-      (4, Prop.falsified),
-      (2, Prop.undecided),
-      (1, Prop.exception(null))
+      (4, falsified),
+      (4, passed),
+      (3, proved),
+      (3, undecidedOrPassed),
+      (2, undecided),
+      (1, exception(null))
     ))
+  }
 
   /** Arbitrary instance of test params */
   implicit lazy val arbTestParams: Arbitrary[Test.Params] =
     Arbitrary(for {
-      minSuccTests <- choose(10,150)
-      maxDiscTests <- choose(100,500)
+      minSuccTests <- choose(10,200)
+      maxDiscardRatio <- choose(0.2f,10f)
       minSize <- choose(0,500)
       sizeDiff <- choose(0,500)
       maxSize <- choose(minSize, minSize + sizeDiff)
       ws <- choose(1,4)
-    } yield Test.Params(minSuccTests,maxDiscTests,minSize,maxSize,workers = ws))
+    } yield Test.Params(
+      minSuccessfulTests = minSuccTests,
+      maxDiscardRatio = maxDiscardRatio,
+      minSize = minSize,
+      maxSize = maxSize,
+      workers = ws
+    ))
 
   /** Arbitrary instance of gen params */
   implicit lazy val arbGenParams: Arbitrary[Gen.Params] =

--- a/src/scalacheck/org/scalacheck/Arg.scala
+++ b/src/scalacheck/org/scalacheck/Arg.scala
@@ -5,7 +5,7 @@
 **                                                                         **
 **  This software is released under the terms of the Revised BSD License.  **
 **  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*-------------------------------------------------------------------------*/
+\*------------------------------------------------------------------------ */
 
 package org.scalacheck
 

--- a/src/scalacheck/org/scalacheck/Commands.scala
+++ b/src/scalacheck/org/scalacheck/Commands.scala
@@ -5,7 +5,7 @@
 **                                                                         **
 **  This software is released under the terms of the Revised BSD License.  **
 **  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*-------------------------------------------------------------------------*/
+\*------------------------------------------------------------------------ */
 
 package org.scalacheck
 
@@ -46,13 +46,6 @@ trait Commands extends Prop {
     def run(s: State): Any
     def nextState(s: State): State
 
-    /** @deprecated Use <code>preConditions += ...</code> instead. */
-    @deprecated("Use 'preConditions += ...' instead.", "1.6")
-    def preCondition_=(f: State => Boolean) = {
-      preConditions.clear
-      preConditions += f
-    }
-
     /** Returns all preconditions merged into a single function */
     def preCondition: (State => Boolean) = s => preConditions.toList.forall(_.apply(s))
 
@@ -61,20 +54,6 @@ trait Commands extends Prop {
      *  that says if the precondition is fulfilled or not. You can add several
      *  conditions to the precondition list */
     val preConditions = new collection.mutable.ListBuffer[State => Boolean]
-
-    /** @deprecated Use <code>postConditions += ...</code> instead. */
-    @deprecated("Use 'postConditions += ...' instead.", "1.6")
-    def postCondition_=(f: (State,Any) => Prop) = {
-      postConditions.clear
-      postConditions += ((s0,s1,r) => f(s0,r))
-    }
-
-    /** @deprecated Use <code>postConditions += ...</code> instead. */
-    @deprecated("Use 'postConditions += ...' instead.", "1.6")
-    def postCondition_=(f: (State,State,Any) => Prop) = {
-      postConditions.clear
-      postConditions += f
-    }
 
     /** Returns all postconditions merged into a single function */
     def postCondition: (State,State,Any) => Prop = (s0,s1,r) => all(postConditions.map(_.apply(s0,s1,r)): _*)

--- a/src/scalacheck/org/scalacheck/ConsoleReporter.scala
+++ b/src/scalacheck/org/scalacheck/ConsoleReporter.scala
@@ -5,7 +5,7 @@
 **                                                                         **
 **  This software is released under the terms of the Revised BSD License.  **
 **  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*-------------------------------------------------------------------------*/
+\*------------------------------------------------------------------------ */
 
 package org.scalacheck
 
@@ -36,31 +36,6 @@ object ConsoleReporter {
   /** Factory method, creates a ConsoleReporter with the
    *  the given verbosity */
   def apply(verbosity: Int = 0) = new ConsoleReporter(verbosity)
-
-  @deprecated("(v1.8)", "1.8")
-  def propReport(s: Int, d: Int) = {
-    if(d == 0) printf("\rPassed %s tests\r", s)
-    else printf("\rPassed %s tests; %s discarded\r", s, d)
-    Console.flush
-  }
-
-  @deprecated("(v1.8)", "1.8")
-  def propReport(pName: String, s: Int, d: Int) = {
-    if(d == 0) printf("\r  %s: Passed %s tests\r", pName, s)
-    else printf("\r  %s: Passed %s tests; %s discarded\r", pName, s, d)
-    Console.flush
-  }
-
-  @deprecated("(v1.8)", "1.8")
-  def testReport(res: Test.Result) = {
-    print(List.fill(78)(' ').mkString)
-    val s = (if(res.passed) "+ " else "! ") + pretty(res, Params(0))
-    printf("\r%s\n", format(s, "", "", 75))
-    res
-  }
-
-  @deprecated("(v1.8)", "1.8")
-  def testStatsEx(res: Test.Result): Unit = testStatsEx("", res)
 
   def testStatsEx(msg: String, res: Test.Result) = {
     lazy val m = if(msg.length == 0) "" else msg + ": "

--- a/src/scalacheck/org/scalacheck/Gen.scala
+++ b/src/scalacheck/org/scalacheck/Gen.scala
@@ -5,7 +5,7 @@
 **                                                                         **
 **  This software is released under the terms of the Revised BSD License.  **
 **  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*-------------------------------------------------------------------------*/
+\*------------------------------------------------------------------------ */
 
 package org.scalacheck
 
@@ -58,6 +58,12 @@ object Choose {
       chooseDouble.choose(low, high).map(_.toFloat)
   }
 }
+
+case class FiniteGenRes[+T](
+  r: T
+)
+
+sealed trait FiniteGen[+T] extends Gen[FiniteGenRes[T]]
 
 
 /** Class that represents a generator. */
@@ -150,13 +156,6 @@ sealed trait Gen[+T] {
 
   /** Returns a new property that holds if and only if both this
    *  and the given generator generates the same result, or both
-   *  generators generate no result.
-   *  @deprecated Use <code>==</code> instead */
-  @deprecated("Use == instead", "1.7")
-  def ===[U](g: Gen[U]): Prop = this == g
-
-  /** Returns a new property that holds if and only if both this
-   *  and the given generator generates the same result, or both
    *  generators generate no result.  */
   def ==[U](g: Gen[U]) = Prop(prms =>
     (this(prms.genPrms), g(prms.genPrms)) match {
@@ -220,11 +219,6 @@ object Gen {
       else rng.nextDouble * (h-l) + l
     }
   }
-
-  /* Default generator parameters
-   *  @deprecated Use <code>Gen.Params()</code> instead */
-  @deprecated("Use Gen.Params() instead", "1.8")
-  val defaultParams = Params()
 
   /* Generator factory method */
   def apply[T](g: Gen.Params => Option[T]) = new Gen[T] {
@@ -310,20 +304,6 @@ object Gen {
     x <- if(i == 0) g1 else if(i == 1) g2 else gs(i-2)
   } yield x
 
-  /** Chooses one of the given values, with a weighted random distribution.
-   *  @deprecated Use <code>frequency</code> with constant generators
-   *  instead. */
-  @deprecated("Use 'frequency' with constant generators instead.", "1.6")
-  def elementsFreq[T](vs: (Int, T)*): Gen[T] =
-    frequency(vs.map { case (w,v) => (w, value(v)) } : _*)
-
-  /** A generator that returns a random element from a list
-   *  @deprecated Use <code>oneOf</code> with constant generators instead. */
-  @deprecated("Use 'oneOf' with constant generators instead.", "1.6")
-  def elements[T](xs: T*): Gen[T] = if(xs.isEmpty) fail else for {
-    i <- choose(0,xs.length-1)
-  } yield xs(i)
-
 
   //// List Generators ////
 
@@ -367,12 +347,6 @@ object Gen {
   /** Generates a list of the given length. This method is equal to calling
    *  <code>containerOfN[List,T](n,g)</code>. */
   def listOfN[T](n: Int, g: Gen[T]) = containerOfN[List,T](n,g)
-
-  /** Generates a list of the given length. This method is equal to calling
-   *  <code>containerOfN[List,T](n,g)</code>.
-   *  @deprecated Use the method <code>listOfN</code> instead. */
-  @deprecated("Use 'listOfN' instead.", "1.6")
-  def vectorOf[T](n: Int, g: Gen[T]) = containerOfN[List,T](n,g)
 
   /** A generator that picks a random number of elements from a list */
   def someOf[T](l: Iterable[T]) = choose(0,l.size) flatMap (pick(_,l))
@@ -437,16 +411,6 @@ object Gen {
   def numStr: Gen[String] = for(cs <- listOf(Gen.numChar)) yield cs.mkString
 
   //// Number Generators ////
-
-  /* Generates positive integers
-   * @deprecated Use <code>posNum[Int]code> instead */
-  @deprecated("Use posNum[Int] instead", "1.7")
-  def posInt: Gen[Int] = sized(max => choose(1, max))
-
-  /* Generates negative integers
-   * @deprecated Use <code>negNum[Int]code> instead */
-  @deprecated("Use negNum[Int] instead", "1.7")
-  def negInt: Gen[Int] = sized(max => choose(-max, -1))
 
   /** Generates positive numbers of uniform distribution, with an
    *  upper bound of the generation size parameter. */

--- a/src/scalacheck/org/scalacheck/Pretty.scala
+++ b/src/scalacheck/org/scalacheck/Pretty.scala
@@ -5,7 +5,7 @@
 **                                                                         **
 **  This software is released under the terms of the Revised BSD License.  **
 **  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*-------------------------------------------------------------------------*/
+\*------------------------------------------------------------------------ */
 
 package org.scalacheck
 
@@ -48,6 +48,8 @@ object Pretty {
     s.lines.map(l => break(lead+l+trail, "  ", width)).mkString("\n")
 
   implicit def prettyAny(t: Any) = Pretty { p => t.toString }
+
+  implicit def prettyString(t: String) = Pretty { p => "\""++t++"\"" }
 
   implicit def prettyList(l: List[Any]) = Pretty { p =>
     l.map("\""+_+"\"").mkString("List(", ", ", ")")

--- a/src/scalacheck/org/scalacheck/Prop.scala
+++ b/src/scalacheck/org/scalacheck/Prop.scala
@@ -5,12 +5,13 @@
 **                                                                         **
 **  This software is released under the terms of the Revised BSD License.  **
 **  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*-------------------------------------------------------------------------*/
+\*------------------------------------------------------------------------ */
 
 package org.scalacheck
 
 import util.{FreqMap,Buildable}
 import scala.collection._
+import scala.annotation.tailrec
 
 /** A property is a generator that generates a property result */
 trait Prop {
@@ -102,15 +103,6 @@ trait Prop {
     }
   }
 
-  /** Returns a new property that holds if and only if both this
-   *  and the given property generates a result with the exact
-   *  same status. Note that this means that if one of the properties is
-   *  proved, and the other one passed, then the resulting property
-   *  will fail.
-   *  @deprecated Use <code>==</code> instead */
-  @deprecated("Use == instead.", "1.7")
-  def ===(p: Prop): Prop = this == p
-
   override def toString = "Prop"
 
   /** Put a label on the property to make test reports clearer */
@@ -201,7 +193,7 @@ object Prop {
       case (_,Undecided) => r
 
       case (_,Proof) => merge(this, r, this.status)
-      case (Proof,_) => merge(this, r, this.status)
+      case (Proof,_) => merge(this, r, r.status)
 
       case (True,True) => merge(this, r, True)
     }
@@ -337,14 +329,11 @@ object Prop {
 
   /** A property that depends on the generator size */
   def sizedProp(f: Int => Prop): Prop = Prop { prms =>
+    // provedToTrue since if the property is proved for
+    // one size, it shouldn't be regarded as proved for
+    // all sizes.
     provedToTrue(f(prms.genPrms.size)(prms))
   }
-
-  /** Implication
-   *  @deprecated Use the implication operator of the Prop class instead
-   */
-  @deprecated("Use the implication operator of the Prop class instead", "1.7")
-  def ==>(b: => Boolean, p: => Prop): Prop = (b: Prop) ==> p
 
   /** Implication with several conditions */
   def imply[T](x: T, f: PartialFunction[T,Prop]): Prop =
@@ -758,4 +747,17 @@ object Prop {
     a8: Arbitrary[A8], s8: Shrink[A8], pp8: A8 => Pretty
   ): Prop = forAll((a: A1) => forAll(f(a, _:A2, _:A3, _:A4, _:A5, _:A6, _:A7, _:A8)))
 
+  /** Ensures that the property expression passed in completes within the given space of time. */
+  def within(maximumMs: Long)(wrappedProp: => Prop): Prop = new Prop {
+    @tailrec private def attempt(prms: Params, endTime: Long): Result = {
+      val result = wrappedProp.apply(prms)
+      if (System.currentTimeMillis > endTime) {
+        (if (result.failure) result else Result(False)).label("Timeout")
+      } else {
+        if (result.success) result
+        else attempt(prms, endTime)
+      }
+    }
+    def apply(prms: Params) = attempt(prms, System.currentTimeMillis + maximumMs)
+  }
 }

--- a/src/scalacheck/org/scalacheck/Properties.scala
+++ b/src/scalacheck/org/scalacheck/Properties.scala
@@ -5,7 +5,7 @@
 **                                                                         **
 **  This software is released under the terms of the Revised BSD License.  **
 **  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*-------------------------------------------------------------------------*/
+\*------------------------------------------------------------------------ */
 
 package org.scalacheck
 

--- a/src/scalacheck/org/scalacheck/Shrink.scala
+++ b/src/scalacheck/org/scalacheck/Shrink.scala
@@ -5,7 +5,7 @@
 **                                                                         **
 **  This software is released under the terms of the Revised BSD License.  **
 **  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*-------------------------------------------------------------------------*/
+\*------------------------------------------------------------------------ */
 
 package org.scalacheck
 

--- a/src/scalacheck/org/scalacheck/util/Buildable.scala
+++ b/src/scalacheck/org/scalacheck/util/Buildable.scala
@@ -5,7 +5,7 @@
 **                                                                         **
 **  This software is released under the terms of the Revised BSD License.  **
 **  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*-------------------------------------------------------------------------*/
+\*------------------------------------------------------------------------ */
 
 package org.scalacheck.util
 
@@ -31,7 +31,7 @@ object Buildable {
     def builder = (new mutable.ListBuffer[T]).mapResult(_.toStream)
   }
 
-  implicit def buildableArray[T](implicit t: ClassTag[T]) =
+  implicit def buildableArray[T](implicit cm: ClassTag[T]) =
     new Buildable[T,Array] {
       def builder = mutable.ArrayBuilder.make[T]
     }

--- a/src/scalacheck/org/scalacheck/util/CmdLineParser.scala
+++ b/src/scalacheck/org/scalacheck/util/CmdLineParser.scala
@@ -5,7 +5,7 @@
 **                                                                         **
 **  This software is released under the terms of the Revised BSD License.  **
 **  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*-------------------------------------------------------------------------*/
+\*------------------------------------------------------------------------ */
 
 package org.scalacheck.util
 
@@ -26,6 +26,7 @@ trait CmdLineParser extends Parsers {
   }
   trait Flag extends Opt[Unit]
   trait IntOpt extends Opt[Int]
+  trait FloatOpt extends Opt[Float]
   trait StrOpt extends Opt[String]
 
   class OptMap {
@@ -68,11 +69,17 @@ trait CmdLineParser extends Parsers {
     case s if s != null && s.length > 0 && s.forall(_.isDigit) => s.toInt
   })
 
+  private val floatVal: Parser[Float] = accept("float", {
+    case s if s != null && s.matches("[0987654321]+\\.?[0987654321]*")
+      => s.toFloat
+  })
+
   private case class OptVal[T](o: Opt[T], v: T)
 
   private val optVal: Parser[OptVal[Any]] = opt into {
     case o: Flag => success(OptVal(o, ()))
     case o: IntOpt => intVal ^^ (v => OptVal(o, v))
+    case o: FloatOpt => floatVal ^^ (v => OptVal(o, v))
     case o: StrOpt => strVal ^^ (v => OptVal(o, v))
   }
 

--- a/src/scalacheck/org/scalacheck/util/FreqMap.scala
+++ b/src/scalacheck/org/scalacheck/util/FreqMap.scala
@@ -5,7 +5,7 @@
 **                                                                         **
 **  This software is released under the terms of the Revised BSD License.  **
 **  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*-------------------------------------------------------------------------*/
+\*------------------------------------------------------------------------ */
 
 package org.scalacheck.util
 

--- a/src/scalacheck/org/scalacheck/util/StdRand.scala
+++ b/src/scalacheck/org/scalacheck/util/StdRand.scala
@@ -5,7 +5,7 @@
 **                                                                         **
 **  This software is released under the terms of the Revised BSD License.  **
 **  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*-------------------------------------------------------------------------*/
+\*------------------------------------------------------------------------ */
 
 package org.scalacheck.util
 

--- a/test/files/lib/scalacheck.jar.desired.sha1
+++ b/test/files/lib/scalacheck.jar.desired.sha1
@@ -1,1 +1,1 @@
-f8cd51e0f78e30b3ac444b741b0b2249ac8248bb ?scalacheck.jar
+b6f4dbb29f0c2ec1eba682414f60d52fea84f703 ?scalacheck.jar

--- a/test/files/scalacheck/CheckEither.scala
+++ b/test/files/scalacheck/CheckEither.scala
@@ -3,7 +3,6 @@ import org.scalacheck.Arbitrary.{arbitrary, arbThrowable}
 import org.scalacheck.Gen.oneOf
 import org.scalacheck.util.StdRand
 import org.scalacheck.Prop._
-import org.scalacheck.ConsoleReporter.{testReport, propReport}
 import org.scalacheck.Test.{Params, check}
 import org.scalacheck.ConsoleReporter.testStatsEx
 import Function.tupled


### PR DESCRIPTION
To current scalacheck head 7ffda752d8 except for this diff:

diff -rw src/scalacheck/org/scalacheck/Arbitrary.scala /s/scalacheck/src/main/scala/org/scalacheck/Arbitrary.scala
13d12
< import scala.reflect.ClassTag
281c280
## <   implicit def arbArray[T](implicit a: Arbitrary[T], c: ClassTag[T]

>   implicit def arbArray[T](implicit a: Arbitrary[T], c: ClassManifest[T]
> diff -rw src/scalacheck/org/scalacheck/Prop.scala /s/scalacheck/src/main/scala/org/scalacheck/Prop.scala
> 63c63
> ## <   def mainCallsExit = false
> 
>   def mainCallsExit = true
> Only in /s/scalacheck/src/main/scala/org/scalacheck: ScalaCheckFramework.scala
> diff -rw src/scalacheck/org/scalacheck/util/Buildable.scala /s/scalacheck/src/main/scala/org/scalacheck/util/Buildable.scala
> 13d12
> < import scala.reflect.ClassTag
> 34c33
> ## <   implicit def buildableArray[T](implicit cm: ClassTag[T]) =
> 
>   implicit def buildableArray[T](implicit cm: ClassManifest[T]) =
