### PR TITLE
Fix for SI-5953, extension methods crasher.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
@@ -107,7 +107,7 @@ abstract class ExtensionMethods extends Transform with TypingTransformers {
 
     def extensionMethInfo(extensionMeth: Symbol, origInfo: Type, clazz: Symbol): Type = {
       var newTypeParams = cloneSymbolsAtOwner(clazz.typeParams, extensionMeth)
-      val thisParamType = appliedType(clazz.typeConstructor, newTypeParams map (_.tpe))
+      val thisParamType = appliedType(clazz.typeConstructor, newTypeParams map (_.tpeHK))
       val thisParam     = extensionMeth.newValueParameter(nme.SELF, extensionMeth.pos) setInfo thisParamType
       def transform(clonedType: Type): Type = clonedType match {
         case MethodType(params, restpe) =>
@@ -159,7 +159,7 @@ abstract class ExtensionMethods extends Transform with TypingTransformers {
               .changeOwner((origMeth, extensionMeth))
           extensionDefs(companion) += atPos(tree.pos) { DefDef(extensionMeth, extensionBody) }
           val extensionCallPrefix = Apply(
-              gen.mkTypeApply(gen.mkAttributedRef(companion), extensionMeth, origTpeParams map (_.tpe)),
+              gen.mkTypeApply(gen.mkAttributedRef(companion), extensionMeth, origTpeParams map (_.tpeHK)),
               List(This(currentOwner)))
           val extensionCall = atOwner(origMeth) {
             localTyper.typedPos(rhs.pos) {

--- a/test/files/pos/t5953.scala
+++ b/test/files/pos/t5953.scala
@@ -1,0 +1,16 @@
+import scala.collection.{ mutable, immutable, generic, GenTraversableOnce }
+
+package object foo {
+  @inline implicit class TravOps[A, CC[A] <: GenTraversableOnce[A]](val coll: CC[A]) extends AnyVal {
+    def build[CC2[X]](implicit cbf: generic.CanBuildFrom[Nothing, A, CC2[A]]): CC2[A] = {
+      cbf() ++= coll.toIterator result
+    }
+  }
+}
+
+package foo {
+  object Test {
+    def f1[T](xs: Traversable[T]) = xs.convertTo[immutable.Vector]
+    def f2[T](xs: Traversable[T]) = xs.build[immutable.Vector]
+  }
+}


### PR DESCRIPTION
As usual, .tpe -> .tpeHK. As a side note following an old theme,
if symbols of type parameters knew that they were symbols of type
parameters, they could call tpeHK themselves rather than every call
site having to do it. It's the operation which injects dummies which
should require explicit programmer action, not the operation which
faithfully reproduces the unapplied type. Were it that way, errors could
be caught much more quickly via ill-kindedness.

Seems like an improvement over lurking compiler crashes at every call
to tparam.tpe.

Review by @adriaanm
