### PR TITLE
SI-2807 Resurrect and refine the promiscuous catch warning.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4825,6 +4825,16 @@ trait Typers extends Modes with Adaptations with Tags {
         case Try(block, catches, finalizer) =>
           var block1 = typed(block, pt)
           var catches1 = typedCases(catches, ThrowableClass.tpe, pt)
+
+          for (cdef <- catches1 if cdef.guard.isEmpty) {
+            def warn(name: Name) = context.warning(cdef.pat.pos, s"This catches all Throwables. If this is really intended, use `case ${name.decoded} : Throwable` to clear this warning.")
+            cdef.pat match {
+              case Bind(name, Ident(_)) => warn(name)
+              case Ident(name)          => warn(name)
+              case _ =>
+            }
+          }
+
           val finalizer1 = if (finalizer.isEmpty) finalizer
                            else typed(finalizer, UnitClass.tpe)
           val (owntype, needAdapt) = ptOrLub(block1.tpe :: (catches1 map (_.tpe)), pt)

--- a/test/files/continuations-neg/trycatch2.scala
+++ b/test/files/continuations-neg/trycatch2.scala
@@ -12,7 +12,7 @@ object Test {
     fatal[Int]
     cpsIntStringInt
   } catch {
-    case ex =>
+    case ex: Throwable =>
       cpsIntStringInt
   }
 
@@ -20,7 +20,7 @@ object Test {
     fatal[Int]
     cpsIntStringInt
   } catch {
-    case ex =>
+    case ex: Throwable =>
       cpsIntStringInt
   }
 

--- a/test/files/neg/catch-all.check
+++ b/test/files/neg/catch-all.check
@@ -1,0 +1,10 @@
+catch-all.scala:2: error: This catches all Throwables. If this is really intended, use `case _ : Throwable` to clear this warning.
+	try { "warn" } catch { case _ => }
+                                    ^
+catch-all.scala:4: error: This catches all Throwables. If this is really intended, use `case x : Throwable` to clear this warning.
+	try { "warn" } catch { case x => }
+                                    ^
+catch-all.scala:6: error: This catches all Throwables. If this is really intended, use `case x : Throwable` to clear this warning.
+	try { "warn" } catch { case _: RuntimeException => ; case x => }
+                                                                  ^
+three errors found

--- a/test/files/neg/catch-all.flags
+++ b/test/files/neg/catch-all.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/catch-all.scala
+++ b/test/files/neg/catch-all.scala
@@ -1,0 +1,19 @@
+object CatchAll {
+	try { "warn" } catch { case _ => }
+
+	try { "warn" } catch { case x => }
+
+	try { "warn" } catch { case _: RuntimeException => ; case x => }
+
+	try { "okay" } catch { case _: Throwable => }
+
+	try { "okay" } catch { case _: Exception => }
+
+	try { "okay" } catch { case okay: Throwable => }
+
+	try { "okay" } catch { case okay: Exception => }
+
+	try { "okay" } catch { case _ if "".isEmpty => }
+
+	"okay" match { case _ => "" }
+}


### PR DESCRIPTION
The previous incarnation didn't survive 4fb3473.

This version can be cleared by using a typed pattern: `catch { case _: Throwable => }`.

This is motivated by the recent appearance of such a catch in `util.Try`, and by battle
scars left by one too many processes bravely but stupidly catching and logging OutOfMemoryErrors.

-Y status has been skipped: this warning is enabled by default and can only be silenced
with use of a typed pattern.

A third-time's-the-charm submission, that follows #730 and #745.

Seal of approval needed by @odersky, "I agree this would be a good idea." doesn't convince the would be mergers.
