### PR TITLE
SI-5966 Fix eta expansion for repeated parameters with zero arguments.

### DIFF
--- a/test/files/run/t5966.check
+++ b/test/files/run/t5966.check
@@ -1,0 +1,3 @@
+(o()_)("") = List()
+(o("a1")_)("") = WrappedArray(a1)
+(o("a1", "a2")_)("") = WrappedArray(a1, a2)

--- a/test/files/run/t5966.scala
+++ b/test/files/run/t5966.scala
@@ -1,0 +1,9 @@
+object o { def apply(i: AnyRef*)(j: String) = i }
+
+object Test {
+  def main(args: Array[String]) {
+    println("(o()_)(\"\") = " + (o()_)(""))
+    println("(o(\"a1\")_)(\"\") = " + (o("a1")_)(""))
+    println("(o(\"a1\", \"a2\")_)(\"\") = " + (o("a1", "a2")_)(""))
+  }
+}


### PR DESCRIPTION
Reworks part of e33901 / SI-5610, which was inserting an <empty> tree
as an argument in this case, which turns into a null in icode.

Review by @lrytz
