### PR TITLE
SI-5968 Eliminate spurious exhaustiveness warning with singleton types.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
@@ -2362,6 +2362,8 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
           // patmatDebug("enum bool "+ tp)
           Some(List(ConstantType(Constant(true)), ConstantType(Constant(false))))
         // TODO case _ if tp.isTupleType => // recurse into component types
+        case modSym: ModuleClassSymbol =>
+          Some(List(tp))
         case sym if !sym.isSealed || isPrimitiveValueClass(sym) =>
           // patmatDebug("enum unsealed "+ (tp, sym, sym.isSealed, isPrimitiveValueClass(sym)))
           None

--- a/test/files/pos/t5968.flags
+++ b/test/files/pos/t5968.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t5968.scala
+++ b/test/files/pos/t5968.scala
@@ -1,0 +1,8 @@
+object X {
+  def f(e: Either[Int, X.type]) = e match {
+    case Left(i) => i
+    case Right(X) => 0
+    // SI-5986 spurious exhaustivity warning here
+  }
+}
+


### PR DESCRIPTION
A singleton type is a type ripe for enumeration.

Review by @adriaanm
