### PR TITLE
Statistics improvements and bug fixes.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1125,7 +1125,7 @@ trait Implicits {
      *  such that some part of `tp` has C as one of its superclasses.
      */
     private def implicitsOfExpectedType: Infoss = {
-      Statistics.incCounter(implicitCacheHits)
+      Statistics.incCounter(implicitCacheAccs)
       implicitsCache get pt match {
         case Some(implicitInfoss) =>
           Statistics.incCounter(implicitCacheHits)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4025,7 +4025,7 @@ trait Typers extends Modes with Adaptations with Tags {
           } else {
             context.enclMethod.returnsSeen = true
             val expr1: Tree = typed(expr, EXPRmode | BYVALmode | RETmode, restpt.tpe)
-            
+
             // Warn about returning a value if no value can be returned.
             if (restpt.tpe.typeSymbol == UnitClass) {
               // The typing in expr1 says expr is Unit (it has already been coerced if
@@ -5131,7 +5131,7 @@ trait Typers extends Modes with Adaptations with Tags {
       indentTyping()
 
       var alreadyTyped = false
-      val startByType = Statistics.pushTimerClass(byTypeNanos, tree.getClass)
+      val startByType = Statistics.pushTimer(byTypeStack, byTypeNanos(tree.getClass))
       Statistics.incCounter(visitsByType, tree.getClass)
       try {
         if (context.retyping &&
@@ -5187,7 +5187,7 @@ trait Typers extends Modes with Adaptations with Tags {
       }
       finally {
         deindentTyping()
-        Statistics.popTimerClass(byTypeNanos, startByType)
+        Statistics.popTimer(byTypeStack, startByType)
       }
     }
 
@@ -5375,10 +5375,11 @@ object TypersStats {
   val compoundBaseTypeSeqCount = Statistics.newSubCounter("  of which for compound types", baseTypeSeqCount)
   val typerefBaseTypeSeqCount = Statistics.newSubCounter("  of which for typerefs", baseTypeSeqCount)
   val singletonBaseTypeSeqCount = Statistics.newSubCounter("  of which for singletons", baseTypeSeqCount)
-  val failedSilentNanos   = Statistics.newSubTimer  ("time spent in failed", typerNanos)
-  val failedApplyNanos    = Statistics.newSubTimer  ("  failed apply", typerNanos)
-  val failedOpEqNanos     = Statistics.newSubTimer  ("  failed op=", typerNanos)
-  val isReferencedNanos   = Statistics.newSubTimer  ("time spent ref scanning", typerNanos)
-  val visitsByType        = Statistics.newByClass   ("#visits by tree node", "typer")(Statistics.newCounter(""))
-  val byTypeNanos         = Statistics.newByClassTimerStack("time spent by tree node", typerNanos)
+  val failedSilentNanos   = Statistics.newSubTimer("time spent in failed", typerNanos)
+  val failedApplyNanos    = Statistics.newSubTimer("  failed apply", typerNanos)
+  val failedOpEqNanos     = Statistics.newSubTimer("  failed op=", typerNanos)
+  val isReferencedNanos   = Statistics.newSubTimer("time spent ref scanning", typerNanos)
+  val visitsByType        = Statistics.newByClass("#visits by tree node", "typer")(Statistics.newCounter(""))
+  val byTypeNanos         = Statistics.newByClass("time spent by tree node", "typer")(Statistics.newStackableTimer("", typerNanos))
+  val byTypeStack         = Statistics.newTimerStack()
 }

--- a/src/msil/ch/epfl/lamp/compiler/msil/emit/ILGenerator.scala
+++ b/src/msil/ch/epfl/lamp/compiler/msil/emit/ILGenerator.scala
@@ -336,7 +336,6 @@ import ILGenerator._
         emitSpecialLabel(Label.Try)
         val endExc: Label = new Label.NormalLabel() // new Label(lastLabel) ???
         excStack.push(Label.Try, endExc)
-	return endExc
     }
 
     /** Begins a catch block. */

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -129,11 +129,15 @@ abstract class SymbolTable extends makro.Universe
 
   // sigh, this has to be public or atPhase doesn't inline.
   var phStack: List[Phase] = Nil
-  private var ph: Phase = NoPhase
-  private var per = NoPeriod
+  private[this] var ph: Phase = NoPhase
+  private[this] var per = NoPeriod
 
   final def atPhaseStack: List[Phase] = phStack
-  final def phase: Phase = ph
+  final def phase: Phase = {
+    if (Statistics.hotEnabled)
+      Statistics.incCounter(SymbolTableStats.phaseCounter)
+    ph
+  }
 
   def atPhaseStackMessage = atPhaseStack match {
     case Nil    => ""
@@ -329,4 +333,8 @@ abstract class SymbolTable extends makro.Universe
   /** Is this symbol table a part of a compiler universe?
    */
   def isCompilerUniverse = false
+}
+
+object SymbolTableStats {
+  val phaseCounter = Statistics.newCounter("#phase calls")
 }


### PR DESCRIPTION
Added compile-time option hotEnabled to Statistics that can be used to count very high frequency methods with 0 overhead for the disabled case. Fixed problem with weak maps that caused some timers to be discarded prematurely before they could be printed. Fixed problem with accounting for stacked timers.
