### PR TITLE
SI-2796 Warn if early definitions are used with a trait.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1753,6 +1753,12 @@ trait Typers extends Modes with Adaptations with Tags {
       if (clazz.info.firstParent.typeSymbol == AnyValClass)
         validateDerivedValueClass(clazz, body1)
 
+      if (clazz.isTrait) {
+        for (decl <- clazz.info.decls if decl.isTerm && decl.isEarlyInitialized) {
+          unit.warning(decl.pos, "Implementation restriction: early definitions in traits are not initialized before the super class is initialized.")
+        }
+      }
+
       treeCopy.Template(templ, parents1, self1, body1) setType clazz.tpe
     }
 

--- a/test/files/neg/t2796.check
+++ b/test/files/neg/t2796.check
@@ -1,0 +1,4 @@
+t2796.scala:7: error: Implementation restriction: early definitions in traits are not initialized before the super class is initialized.
+  val abstractVal = "T1.abstractVal" // warn
+      ^
+one error found

--- a/test/files/neg/t2796.flags
+++ b/test/files/neg/t2796.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/t2796.scala
+++ b/test/files/neg/t2796.scala
@@ -1,0 +1,28 @@
+trait Base {
+  val abstractVal: String
+  final val useAbstractVal = abstractVal
+}
+
+trait T1 extends {
+  val abstractVal = "T1.abstractVal" // warn
+} with Base
+
+trait T2 extends {
+  type X = Int                       // okay
+} with Base
+
+
+class C1 extends {
+  val abstractVal = "C1.abstractVal" // okay
+} with Base
+
+object Test {
+  def main(args: Array[String]) {
+    assert(new C1 ().useAbstractVal == "C1.abstractVal")
+    // This currently fails. a more ambitious approach to this ticket would add $earlyinit$
+    // to traits and call it from the right places in the right order.
+    //
+    // For now, we'll just issue a warning.
+    assert(new T1 {}.useAbstractVal == "T1.abstractVal")
+  }
+}


### PR DESCRIPTION
For which they (currently) have no special meaning.

Review by @hubertp (who once uttered "Yes, the early definition doesn't work for traits initialization ATM and I guess we should provide it.")
