### PR TITLE
Closes SI-5148.

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -879,7 +879,7 @@ abstract class ClassfileParser {
         case tpnme.ScalaSignatureATTR =>
           if (!isScalaAnnot) {
             debuglog("warning: symbol " + sym.fullName + " has pickled signature in attribute")
-            unpickler.unpickle(in.buf, in.bp, clazz, staticModule, in.file.toString)
+            unpickler.unpickle(in.buf, in.bp, clazz, staticModule, in.file.name)
           }
           in.skip(attrLen)
         case tpnme.ScalaATTR =>
@@ -897,7 +897,7 @@ abstract class ClassfileParser {
                 case Some(san: AnnotationInfo) =>
                   val bytes =
                     san.assocs.find({ _._1 == nme.bytes }).get._2.asInstanceOf[ScalaSigBytes].bytes
-                  unpickler.unpickle(bytes, 0, clazz, staticModule, in.file.toString)
+                  unpickler.unpickle(bytes, 0, clazz, staticModule, in.file.name)
                 case None =>
                   throw new RuntimeException("Scala class file does not contain Scala annotation")
               }

--- a/test/files/neg/t4541.check
+++ b/test/files/neg/t4541.check
@@ -1,4 +1,4 @@
-t4541.scala:11: error: scala.reflect.internal.Types$TypeError: variable data in class Sparse cannot be accessed in Sparse[Int]
+t4541.scala:11: error: variable data in class Sparse cannot be accessed in Sparse[Int]
  Access to protected method data not permitted because
  prefix type Sparse[Int] does not conform to
  class Sparse$mcI$sp where the access take place

--- a/test/files/neg/t4541b.check
+++ b/test/files/neg/t4541b.check
@@ -1,4 +1,4 @@
-t4541b.scala:13: error: scala.reflect.internal.Types$TypeError: variable data in class SparseArray cannot be accessed in SparseArray[Int]
+t4541b.scala:13: error: variable data in class SparseArray cannot be accessed in SparseArray[Int]
  Access to protected method data not permitted because
  prefix type SparseArray[Int] does not conform to
  class SparseArray$mcI$sp where the access take place

--- a/test/files/neg/t5148.check
+++ b/test/files/neg/t5148.check
@@ -1,0 +1,2 @@
+error: bad reference while unpickling Imports.class: term memberHandlers not found in scala.tools.nsc.interpreter.IMain
+one error found

--- a/test/files/neg/t5148.scala
+++ b/test/files/neg/t5148.scala
@@ -1,0 +1,4 @@
+package scala.tools.nsc
+package interpreter
+
+class IMain extends Imports


### PR DESCRIPTION
Unfortunately we have to wrap transform to catch all
the MissingRequirementErrors exceptions (wrapped in TypeErrors).
This is because we force the info of the symbol in a couple of
places and we would have to catch all/some of them
(and remove the duplicates as well which really becomes messy).

Review by @axel22.
