### PR TITLE
SI-5932 Tone down non-sensible == warning with refinements.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1150,7 +1150,7 @@ abstract class RefChecks extends InfoTransform with reflect.internal.transform.R
             nonSensiblyNew()
           else if (isNew(args.head) && (receiver.isEffectivelyFinal || isReferenceOp))   // object X ; X == new Y
             nonSensiblyNew()
-          else if (receiver.isEffectivelyFinal && !(receiver isSubClass actual)) {  // object X, Y; X == Y
+          else if (receiver.isEffectivelyFinal && !(receiver isSubClass actual) && !actual.isRefinementClass) {  // object X, Y; X == Y
             if (isEitherNullable)
               nonSensible("non-null ", false)
             else

--- a/test/files/pos/t5932.flags
+++ b/test/files/pos/t5932.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t5932.scala
+++ b/test/files/pos/t5932.scala
@@ -1,0 +1,15 @@
+class A
+
+case object B extends A
+
+object Test {
+  val x1 = (B: A)
+
+  println(x1 == B) // no warning
+  println(B == x1) // no warning
+
+  val x2 = (B: A with Product)
+
+  println(x2 == B) // no warning
+  println(B == x2) // spurious warning: "always returns false"
+}


### PR DESCRIPTION
Errs on the side of avoiding false positives.

Review by @paulp
