### PR TITLE
[Backport] Fix for exponential compile time in specialization.

### DIFF
--- a/test/files/pos/exponential-spec.scala
+++ b/test/files/pos/exponential-spec.scala
@@ -1,0 +1,47 @@
+// a.scala
+// Sat Jun 30 19:51:17 PDT 2012
+
+trait Exp[T]
+
+object Test {
+  def f[T](exp: Exp[T]): Exp[T] = (
+    f[T] _ 
+      compose f[T]
+      compose f[T]
+      compose f[T]
+      compose f[T]
+      compose f[T]
+      compose f[T]
+      compose f[T]
+      compose f[T]
+      compose f[T]
+      compose f[T]      // 4s
+      compose f[T]      // 5s
+      compose f[T]      // 5s
+      compose f[T]      // 6s
+      compose f[T]      // 7s
+      compose f[T]      // 8s
+      compose f[T]      // 11s
+      compose f[T]      // 17s
+      compose f[T]      // 29s
+      compose f[T]      // 54s
+      compose f[T]
+      compose f[T]
+      compose f[T]
+      compose f[T]
+      compose f[T]
+      compose f[T]
+      compose f[T]
+      compose f[T]
+      compose f[T]
+      compose f[T]
+      compose f[T]
+      compose f[T]
+      compose f[T]
+      compose f[T]
+      compose f[T]
+      compose f[T]
+      compose f[T]
+      compose f[T]      
+    )(exp)
+}


### PR DESCRIPTION
Backport fix to 2.9.2, from commit 39f01d4f48e59c2037a3af759eb6d55d0da50e70 on paulp/scala. I ran the tests successfully and verified that the bug is not reproducible on the included testcase.

Note that the original pull request (https://github.com/scala/scala/pull/801) is not yet merged.

Review by @prokopec.
