### PR TITLE
Fix SI-5929 - Verify error with finally and pattern match

### DIFF
--- a/test/files/run/patmat-finally.scala
+++ b/test/files/run/patmat-finally.scala
@@ -1,0 +1,25 @@
+/** Test pattern matching and finally, see SI-5929. */
+object Test extends App {
+  def bar(s1: Object, s2: Object) {
+    s1 match {
+      case _ =>
+    }
+
+    try {
+      ()
+    } finally {
+      s2 match {
+        case _ =>
+      }
+    }
+  }
+
+  def x = {
+    null match { case _ => }
+
+    try { 1 } finally { while(false) { } }
+  }
+
+  bar(null, null)
+  x  
+}


### PR DESCRIPTION
Don't enter all labels in a method when emitting a forward jump, since some
labels will be duplicated (if defined inside finally blocks). For each forward
jump, enter only the label that is needed for that jump.

review by @magarciaEPFL, @paulp.
