### PR TITLE
Closes SI-5687.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4480,6 +4480,13 @@ trait Typers extends Modes with Adaptations with Tags {
                   issue(accessibleError.get)
                   setError(tree)
                 }
+            case t if t.tpe.isErroneous && !qual.tpe.isErroneous =>
+              // Either error has been reported or we are dealing with 'invalid bounds' errors.
+              // The latter might be caused by forcing the info yet the real error reporting
+              // will be done in refchecks, so we delay it until then.
+              // qual.tpe check is done to avoid throwing spurious errors
+              // (see t692.scala for one example)
+              t setType sym.tpe.normalize
             case _ =>
               result
           }

--- a/test/files/neg/t5687.check
+++ b/test/files/neg/t5687.check
@@ -1,0 +1,8 @@
+t5687.scala:3: error: type arguments [T] do not conform to class Template's type parameter bounds [T <: AnyRef]
+  type Repr[T]<:Template[T]
+                ^
+t5687.scala:12: error: overriding type Repr in class Template with bounds[T] <: Template[T];
+ type Repr has incompatible type
+  type Repr = CurveTemplate[T]
+       ^
+two errors found

--- a/test/files/neg/t5687.scala
+++ b/test/files/neg/t5687.scala
@@ -1,0 +1,18 @@
+abstract class Template[T <: AnyRef](private val t: T) {
+
+  type Repr[T]<:Template[T]
+
+  def withTimeout(timeout:Long): Repr[T] = this.asInstanceOf[Repr[T]]
+  def withReadModifiers(readModifiers:Int): Repr[T] = this.asInstanceOf[Repr[T]]
+}
+
+class Curve
+
+class CurveTemplate [T <: Curve](t: T) extends Template(t) {
+  type Repr = CurveTemplate[T]
+}
+
+
+object Example {
+ new CurveTemplate(new Curve).withTimeout(2000L).withReadModifiers(0)
+}


### PR DESCRIPTION
Recover from early ErrorType assignment and
delay error reporting until refchecks,
where it belongs. Review by @adriaanm.
