### PR TITLE
Closes SI-5969.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1612,6 +1612,9 @@ trait Infer {
         val saved = context.state
         var fallback = false
         context.setBufferErrors()
+        // Need to test first attempt with an empty buffer.
+        // Otherwise, any previous errors will get lost.
+        val errorsToRestore = context.flushAndReturnBuffer()
         try {
           context.withImplicitsDisabled(infer(false))
           if (context.hasErrors) {
@@ -1625,8 +1628,10 @@ trait Infer {
           case ex: TypeError        => // recoverable cyclic references
             context.restoreState(saved)
             if (!fallback) infer(true) else ()
+        } finally {
+          context.restoreState(saved)
+          context.updateBuffer(errorsToRestore)
         }
-        context.restoreState(saved)
       }
       else infer(true)
     }

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1612,8 +1612,12 @@ trait Infer {
         val saved = context.state
         var fallback = false
         context.setBufferErrors()
-        // Need to test first attempt with an empty buffer.
-        // Otherwise, any previous errors will get lost.
+        // We cache the current buffer because it is impossible to 
+        // distinguish errors that occurred before entering tryTwice
+        // and our first attempt in 'withImplicitsDisabled'. If the
+        // first attempt fails we try with implicits on *and* clean
+        // buffer but that would also flush any pre-tryTwice valid
+        // errors, hence some manual buffer tweaking is necessary.
         val errorsToRestore = context.flushAndReturnBuffer()
         try {
           context.withImplicitsDisabled(infer(false))

--- a/test/files/neg/t5969.check
+++ b/test/files/neg/t5969.check
@@ -1,0 +1,7 @@
+t5969.scala:9: error: overloaded method value g with alternatives:
+  (x: C2)String <and>
+  (x: C1)String
+ cannot be applied to (String)
+    if (false) List(g(x)) else List[C1]() map g
+                    ^
+one error found

--- a/test/files/neg/t5969.scala
+++ b/test/files/neg/t5969.scala
@@ -1,0 +1,11 @@
+class C1
+class C2
+class A {
+  def f(x: Any) = x
+  def g(x: C1): String = "A"
+  def g(x: C2): String = "B"
+  
+  def crash() = f(List[String]() flatMap { x =>
+    if (false) List(g(x)) else List[C1]() map g
+  })
+}

--- a/test/files/neg/t649.check
+++ b/test/files/neg/t649.check
@@ -1,4 +1,4 @@
 t649.scala:3: error: overloaded method foo needs result type
   def foo[A] = foo[A]
-      ^
+                  ^
 one error found


### PR DESCRIPTION
Assumption that we enter tryTwice when inferring
the right alternative with an empty buffer is
wrong.
In this particular bug it manifested itself on
if/then/else which share the same context and 'else'
branch was simply flushing the buffer with an
error from the 'then' branch.

Review by @retronym, please (you were on the right track judging from the comments in the bug report).
