### PR TITLE
SI-5959 type equality now accounts for mirrors

### DIFF
--- a/test/files/run/reflection-equality.check
+++ b/test/files/run/reflection-equality.check
@@ -1,0 +1,53 @@
+Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> 
+
+scala> class X {
+   def methodIntIntInt(x: Int, y: Int) = x+y
+}
+defined class X
+
+scala> 
+
+scala> import scala.reflect.runtime.universe._
+import scala.reflect.runtime.universe._
+
+scala> import scala.reflect.runtime.{ currentMirror => cm }
+import scala.reflect.runtime.{currentMirror=>cm}
+
+scala> def im: InstanceMirror = cm.reflect(new X)
+im: reflect.runtime.universe.InstanceMirror
+
+scala> val cs: ClassSymbol = im.symbol
+cs: reflect.runtime.universe.ClassSymbol = class X
+
+scala> val ts: Type = cs.typeSignature
+ts: reflect.runtime.universe.Type = 
+java.lang.Object {
+  def <init>: <?>
+  def methodIntIntInt: <?>
+}
+
+scala> val ms: MethodSymbol = ts.declaration(newTermName("methodIntIntInt")).asMethodSymbol
+ms: reflect.runtime.universe.MethodSymbol = method methodIntIntInt
+
+scala> val MethodType( _, t1 ) = ms.typeSignature
+t1: reflect.runtime.universe.Type = scala.Int
+
+scala> val t2 = typeOf[scala.Int]
+t2: reflect.runtime.universe.Type = Int
+
+scala> t1 == t2
+res0: Boolean = true
+
+scala> t1 =:= t2
+res1: Boolean = true
+
+scala> t1 <:< t2
+res2: Boolean = true
+
+scala> t2 <:< t1
+res3: Boolean = true
+
+scala> 

--- a/test/files/run/reflection-equality.scala
+++ b/test/files/run/reflection-equality.scala
@@ -1,0 +1,22 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  def code = """
+    |class X {
+    |   def methodIntIntInt(x: Int, y: Int) = x+y
+    |}
+    |
+    |import scala.reflect.runtime.universe._
+    |import scala.reflect.runtime.{ currentMirror => cm }
+    |def im: InstanceMirror = cm.reflect(new X)
+    |val cs: ClassSymbol = im.symbol
+    |val ts: Type = cs.typeSignature
+    |val ms: MethodSymbol = ts.declaration(newTermName("methodIntIntInt")).asMethodSymbol
+    |val MethodType( _, t1 ) = ms.typeSignature
+    |val t2 = typeOf[scala.Int]
+    |t1 == t2
+    |t1 =:= t2
+    |t1 <:< t2
+    |t2 <:< t1
+    |""".stripMargin
+}


### PR DESCRIPTION
TypeRef(ThisType(<package1>), sym, args) should always be equal to
TypeRef(ThisType(<package2>), sym, args) regardless of whether
package1 and package2 actually represent the same symbols of not.

Same goes for subtyping (<:<) and type equality (=:=).

This is done to account for the fact that mirrors share normal symbols,
but never share package symbols. Therefore at times it will occur that
the same types loaded by different mirrors appear different because of
the package symbols. More details: https://issues.scala-lang.org/browse/SI-5959.
