### PR TITLE
SI-6013 Disallow deferred members from intermediate java parents.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -536,7 +536,7 @@ abstract class RefChecks extends InfoTransform with reflect.internal.transform.R
 
         def javaErasedOverridingSym(sym: Symbol): Symbol =
           clazz.tpe.nonPrivateMemberAdmitting(sym.name, BRIDGE).filter(other =>
-            !other.isDeferred && other.isJavaDefined && {
+            !other.isDeferred && other.isJavaDefined && !sym.enclClass.isSubClass(other.enclClass) && {
               // #3622: erasure operates on uncurried types --
               // note on passing sym in both cases: only sym.isType is relevant for uncurry.transformInfo
               // !!! erasure.erasure(sym, uncurry.transformInfo(sym, tp)) gives erreneous of inaccessible type - check whether that's still the case!

--- a/test/files/neg/t6013.check
+++ b/test/files/neg/t6013.check
@@ -1,0 +1,7 @@
+DerivedScala.scala:4: error: class C needs to be abstract, since there is a deferred declaration of method foo in class B of type => Int which is not implemented in a subclass
+class C extends B
+      ^
+DerivedScala.scala:7: error: class DerivedScala needs to be abstract, since there is a deferred declaration of method foo in class Abstract of type ()Boolean which is not implemented in a subclass
+class DerivedScala extends Abstract
+      ^
+two errors found

--- a/test/files/neg/t6013/Abstract.java
+++ b/test/files/neg/t6013/Abstract.java
@@ -1,0 +1,7 @@
+public abstract class Abstract extends Base {
+  // overrides Base#bar under the erasure model
+  public void bar(java.util.List<java.lang.Integer> foo) { return; }
+
+  // must force re-implementation in derived classes
+  public abstract boolean foo();
+}

--- a/test/files/neg/t6013/Base.java
+++ b/test/files/neg/t6013/Base.java
@@ -1,0 +1,10 @@
+abstract public class Base {
+  // This must considered to be overridden by Abstract#foo based
+  // on the erased signatures. This special case is handled by
+  // `javaErasedOverridingSym` in `RefChecks`.
+  public abstract void bar(java.util.List<java.lang.String> foo) { return; }
+
+  // But, a concrete method in a Java superclass must not excuse
+  // a deferred method in the Java subclass!
+  public boolean foo() { return true; }
+}

--- a/test/files/neg/t6013/DerivedScala.scala
+++ b/test/files/neg/t6013/DerivedScala.scala
@@ -1,0 +1,7 @@
+// Scala extending Scala (this case was working fine before this bug.)
+class A { def foo: Int = 0 }
+abstract class B extends A { def foo: Int }
+class C extends B
+
+// Scala extending Java
+class DerivedScala extends Abstract


### PR DESCRIPTION
76c76b28f allowed for the fact that a Java method can override
a super class method without matching its type in a Scala sense;
it need only match its type after erasure. However that change
went too far, and considered a concrete method in a base class
to override a deferred method in a subclass.

Review by @odersky, to double check the intent of 76c76b28f.
