### PR TITLE
SI-5830 switches: support guards, unreachability  -- review by @dragos

### DIFF
--- a/test/files/neg/switch.check
+++ b/test/files/neg/switch.check
@@ -1,10 +1,7 @@
-switch.scala:28: error: could not emit switch for @switch annotated match
-  def fail1(c: Char) = (c: @switch) match {
-                            ^
 switch.scala:38: error: could not emit switch for @switch annotated match
   def fail2(c: Char) = (c: @switch @unchecked) match {
                                     ^
 switch.scala:45: error: could not emit switch for @switch annotated match
   def fail3(c: Char) = (c: @unchecked @switch) match {
                                        ^
-three errors found
+two errors found

--- a/test/files/neg/switch.scala
+++ b/test/files/neg/switch.scala
@@ -24,8 +24,8 @@ object Main {
     case _                => false
   }
   
-  // has a guard
-  def fail1(c: Char) = (c: @switch) match {
+  // has a guard, but since SI-5830 that's ok
+  def succ_guard(c: Char) = (c: @switch) match {
     case 'A' | 'B' | 'C'  => true
     case x if x == 'A'    => true
     case _                => false

--- a/test/files/neg/t5830.check
+++ b/test/files/neg/t5830.check
@@ -1,0 +1,4 @@
+t5830.scala:6: error: unreachable code
+    case 'a' => println("b") // unreachable
+                       ^
+one error found

--- a/test/files/neg/t5830.flags
+++ b/test/files/neg/t5830.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/t5830.scala
+++ b/test/files/neg/t5830.scala
@@ -1,0 +1,9 @@
+import scala.annotation.switch
+
+class Test {
+  def unreachable(ch: Char) = (ch: @switch) match {
+    case 'a' => println("b") // ok
+    case 'a' => println("b") // unreachable
+    case 'c' =>
+  }
+}

--- a/test/files/run/inline-ex-handlers.check
+++ b/test/files/run/inline-ex-handlers.check
@@ -20,14 +20,14 @@
 409c408,417
 <     103	THROW(MyException)
 ---
->     ?	STORE_LOCAL(value ex5)
+>     ?	STORE_LOCAL(value ex6)
 >     ?	JUMP 17
 >     
 >   17: 
->     101	LOAD_LOCAL(value ex5)
->     101	STORE_LOCAL(value x3)
->     101	SCOPE_ENTER value x3
->     106	LOAD_LOCAL(value x3)
+>     101	LOAD_LOCAL(value ex6)
+>     101	STORE_LOCAL(value x4)
+>     101	SCOPE_ENTER value x4
+>     106	LOAD_LOCAL(value x4)
 >     106	IS_INSTANCE REF(class MyException)
 >     106	CZJUMP (BOOL)NE ? 5 : 11
 422,424d429
@@ -125,29 +125,29 @@
 737c786,793
 <     172	THROW(MyException)
 ---
->     ?	STORE_LOCAL(value ex5)
+>     ?	STORE_LOCAL(value ex6)
 >     ?	JUMP 32
 >     
 >   32: 
->     170	LOAD_LOCAL(value ex5)
->     170	STORE_LOCAL(value x3)
->     170	SCOPE_ENTER value x3
+>     170	LOAD_LOCAL(value ex6)
+>     170	STORE_LOCAL(value x4)
+>     170	SCOPE_ENTER value x4
 >     170	JUMP 18
 793c849,850
 <     177	THROW(MyException)
 ---
->     ?	STORE_LOCAL(value ex5)
+>     ?	STORE_LOCAL(value ex6)
 >     ?	JUMP 33
 797c854,861
 <     170	THROW(Throwable)
 ---
->     ?	STORE_LOCAL(value ex5)
+>     ?	STORE_LOCAL(value ex6)
 >     ?	JUMP 33
 >     
 >   33: 
->     169	LOAD_LOCAL(value ex5)
->     169	STORE_LOCAL(value x3)
->     169	SCOPE_ENTER value x3
+>     169	LOAD_LOCAL(value ex6)
+>     169	STORE_LOCAL(value x4)
+>     169	SCOPE_ENTER value x4
 >     169	JUMP 5
 830c894,895
 <     182	THROW(MyException)
@@ -188,13 +188,13 @@
 909c988,995
 <     124	THROW(MyException)
 ---
->     ?	STORE_LOCAL(value ex5)
+>     ?	STORE_LOCAL(value ex6)
 >     ?	JUMP 20
 >     
 >   20: 
->     122	LOAD_LOCAL(value ex5)
->     122	STORE_LOCAL(value x3)
->     122	SCOPE_ENTER value x3
+>     122	LOAD_LOCAL(value ex6)
+>     122	STORE_LOCAL(value x4)
+>     122	SCOPE_ENTER value x4
 >     122	JUMP 7
 969c1055
 <     catch (IllegalArgumentException) in ArrayBuffer(6, 7, 8, 11, 14, 16, 17, 19) starting at: 3
@@ -207,14 +207,14 @@
 1019c1105,1114
 <     148	THROW(MyException)
 ---
->     ?	STORE_LOCAL(value ex5)
+>     ?	STORE_LOCAL(value ex6)
 >     ?	JUMP 20
 >     
 >   20: 
->     145	LOAD_LOCAL(value ex5)
->     145	STORE_LOCAL(value x3)
->     145	SCOPE_ENTER value x3
->     154	LOAD_LOCAL(value x3)
+>     145	LOAD_LOCAL(value ex6)
+>     145	STORE_LOCAL(value x4)
+>     145	SCOPE_ENTER value x4
+>     154	LOAD_LOCAL(value x4)
 >     154	IS_INSTANCE REF(class MyException)
 >     154	CZJUMP (BOOL)NE ? 5 : 11
 1040,1042d1134
@@ -243,19 +243,19 @@
 1372c1471,1472
 <     203	THROW(MyException)
 ---
->     ?	STORE_LOCAL(value ex5)
+>     ?	STORE_LOCAL(value ex6)
 >     ?	JUMP 20
 1392c1492,1501
 <     209	THROW(MyException)
 ---
->     ?	STORE_LOCAL(value ex5)
+>     ?	STORE_LOCAL(value ex6)
 >     ?	JUMP 20
 >     
 >   20: 
->     200	LOAD_LOCAL(value ex5)
->     200	STORE_LOCAL(value x3)
->     200	SCOPE_ENTER value x3
->     212	LOAD_LOCAL(value x3)
+>     200	LOAD_LOCAL(value ex6)
+>     200	STORE_LOCAL(value x4)
+>     200	SCOPE_ENTER value x4
+>     212	LOAD_LOCAL(value x4)
 >     212	IS_INSTANCE REF(class MyException)
 >     212	CZJUMP (BOOL)NE ? 5 : 11
 1405,1407d1513

--- a/test/files/run/t5830.check
+++ b/test/files/run/t5830.check
@@ -1,0 +1,6 @@
+a with oef
+a with oef
+a
+def with oef
+def
+default

--- a/test/files/run/t5830.flags
+++ b/test/files/run/t5830.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/run/t5830.scala
+++ b/test/files/run/t5830.scala
@@ -1,0 +1,56 @@
+import scala.annotation.switch
+
+object Test extends App {
+  // TODO: should not emit a switch
+  // def noSwitch(ch: Char, eof: Boolean) = (ch: @switch) match {
+  //   case 'a' if eof => println("a with oef") // then branch
+  // }
+
+  def onlyThen(ch: Char, eof: Boolean) = (ch: @switch) match {
+    case 'a' if eof => println("a with oef") // then branch
+    case 'c' =>
+  }
+
+  def ifThenElse(ch: Char, eof: Boolean) = (ch: @switch) match {
+    case 'a' if eof => println("a with oef") // then branch
+    case 'a' if eof => println("a with oef2") // unreachable, but the analysis is not that sophisticated
+    case 'a' => println("a") // else-branch
+    case 'c' =>
+  }
+
+  def defaultUnguarded(ch: Char, eof: Boolean) = (ch: @switch) match {
+    case ' ' if eof => println("spacey oef")
+    case _ => println("default")
+  }
+
+  def defaults(ch: Char, eof: Boolean) = (ch: @switch) match {
+    case _ if eof => println("def with oef") // then branch
+    case _ if eof => println("def with oef2") // unreachable, but the analysis is not that sophisticated
+    case _ => println("def") // else-branch
+  }
+
+  // test binders in collapsed cases (no need to run, it's "enough" to know it doesn't crash the compiler)
+  def guard(x: Any): Boolean = true
+  def testBinders =
+    try { println("") } // work around SI-6015
+    catch {
+      case _ if guard(null) =>
+      case x if guard(x) => throw x
+    }
+
+  // def unreachable(ch: Char) = (ch: @switch) match {
+  //   case 'a' => println("b") // ok
+  //   case 'a' => println("b") // unreachable
+  //   case 'c' =>
+  // }
+
+  // noSwitch('a', true)
+  onlyThen('a', true)       // 'a with oef'
+  ifThenElse('a', true)     // 'a with oef'
+  ifThenElse('a', false)    // 'a'
+  defaults('a', true)       // 'def with oef'
+  defaults('a', false)      // 'def'
+
+  // test that it jumps to default case, no match error
+  defaultUnguarded(' ', false) // default
+}


### PR DESCRIPTION
turn switches with guards into guard-free switches by collecting all cases
that are (possibly) guarded by different guards but that switch on the same constant,
and pushing the implied if-then-else into the collapsed case body

```
case C if G1 => B1
case C if Gi => Bi
case C if GN => BN
```

becomes

```
case C => if (G1) B1
     else if (Gi) Bi
     else if (GN) BN
     else default() // not necessary if GN == EmptyTree
```

default() is a jump to the default case; to enable this, we wrap a default() { } labeldef
around the last case's body (the user-defined default or the synthetic case that throws the matcherror)
so we can jump to the default case after the last guard is checked
(assuming unreachability is checked, once we ended up in a non-default case,
one of the guards either matches or we go to the default case)

the unreachability analysis is minimal -- we simply check (after rewriting to guard-free form)
that:
- there are no duplicate cases
- the default case comes last

misc notes:
- can't jump in exception handlers (TODO: a more fine-grained analysis on when we need to jump)
- work around SI-6015 (test file run/t5830.scala crashed the inliner)
- propagate type of case body to label def of default case
  (needed for existentials, see e.g., t2683)
- the default(){} LabelDef breaks SelectiveANFTransform -- workaround: don't write guarded switches in CPS code
  (do the above transformation manually)
