### PR TITLE
Adds `Type.resultType` to reflection API

### DIFF
--- a/src/reflect/scala/reflect/api/Types.scala
+++ b/src/reflect/scala/reflect/api/Types.scala
@@ -62,6 +62,10 @@ trait Types extends base.Types { self: Universe =>
      *  the empty list for all other types */
     def typeParams: List[Symbol]
 
+    /** For a (nullary) method or poly type, its direct result type,
+     *  the type itself for all other types. */
+    def resultType: Type
+
     /** Is this type a type constructor that is missing its type arguments?
      */
     def isHigherKinded: Boolean   // !!! This should be called "isTypeConstructor", no?


### PR DESCRIPTION
Seems to be quite an essential piece of functionality.

Got requests for it from Paul back then, and now Daniel
in his latest blog post has to painfully pattern match
his way to resultType.
