### PR TITLE
SI-6033 Closed. Provides implicit conversion from BigInteger to BigInt

### DIFF
--- a/src/library/scala/math/BigInt.scala
+++ b/src/library/scala/math/BigInt.scala
@@ -87,6 +87,11 @@ object BigInt {
   def apply(x: String, radix: Int): BigInt =
     new BigInt(new BigInteger(x, radix))
 
+  /** Translates a `java.math.BigInteger` into a BigInt.
+   */
+  def apply(x: BigInteger): BigInt =
+    new BigInt(x)
+
   /** Returns a positive BigInt that is probably prime, with the specified bitLength.
    */
   def probablePrime(bitLength: Int, rnd: scala.util.Random): BigInt =
@@ -96,9 +101,13 @@ object BigInt {
    */
   implicit def int2bigInt(i: Int): BigInt = apply(i)
 
-  /** Implicit conversion from long to BigInt
+  /** Implicit conversion from `Long` to `BigInt`.
    */
   implicit def long2bigInt(l: Long): BigInt = apply(l)
+
+  /** Implicit conversion from `java.math.BigInteger` to `scala.BigInt`.
+   */
+  implicit def javaBigInteger2bigInt(x: BigInteger): BigInt = apply(x)
 }
 
 /**

--- a/test/files/pos/t6033.scala
+++ b/test/files/pos/t6033.scala
@@ -1,0 +1,5 @@
+object Test extends App {
+  val b = new java.math.BigInteger("123")
+  val big1 = BigInt(b)
+  val big2: BigInt = b
+}


### PR DESCRIPTION
Adds an implicit conversion from java.math.BigInteger to BigInt. This way, 
BigDecimal (which also provides such a conversion) and BigInt are consistent.

Review: ??? (who is responsible for the library (beyond collections, concurrent)?)
