### PR TITLE
Fix SI-3836 not-really-ambiguous import detection.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4632,10 +4632,14 @@ trait Typers extends Modes with Adaptations with Tags {
                 // the prefix from which they came.
                 def t1 = imports.head.qual.tpe memberType impSym
                 def t2 = imports1.head.qual.tpe memberType impSym1
-                // Monomorphism restriction is because type aliases could have the
-                // same target type but attach different variance to the parameters.
+                // Monomorphism restriction on types is because type aliases could have
+                // the same target type but attach different variance to the parameters.
                 // Maybe it can be relaxed, but doesn't seem worth it at present.
-                if (impSym.isMonomorphicType && impSym1.isMonomorphicType && (t1 =:= t2))
+                def symbolsMatch = (
+                     (impSym == impSym1)                                      // values - exact same symbol
+                  || (impSym.isMonomorphicType && impSym1.isMonomorphicType)  // types - any monomorphic will do
+                )
+                if (symbolsMatch && (t1 =:= t2))
                   log(s"Suppressing ambiguous import: $impSym and $impSym1 refer to the same type")
                 else {
                   log(s"Import is genuinely ambiguous: !($t1 =:= $t2)")

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4620,10 +4620,27 @@ trait Typers extends Modes with Adaptations with Tags {
             if (impSym.exists) {
               var impSym1: Symbol = NoSymbol
               var imports1 = imports.tail
+
+              /** It's possible that seemingly conflicting identifiers are
+               *  identifiably the same after type normalization.  In such cases,
+               *  allow compilation to proceed.  A typical example is:
+               *    package object foo { type InputStream = java.io.InputStream }
+               *    import foo._, java.io._
+               */
               def ambiguousImport() = {
-                if (!(imports.head.qual.tpe =:= imports1.head.qual.tpe && impSym == impSym1))
-                  ambiguousError(
-                    "it is imported twice in the same scope by\n"+imports.head +  "\nand "+imports1.head)
+                // Comparing types of imported symbols, seen as members of
+                // the prefix from which they came.
+                def t1 = imports.head.qual.tpe memberType impSym
+                def t2 = imports1.head.qual.tpe memberType impSym1
+                // Monomorphism restriction is because type aliases could have the
+                // same target type but attach different variance to the parameters.
+                // Maybe it can be relaxed, but doesn't seem worth it at present.
+                if (impSym.isMonomorphicType && impSym1.isMonomorphicType && (t1 =:= t2))
+                  log(s"Suppressing ambiguous import: $impSym and $impSym1 refer to the same type")
+                else {
+                  log(s"Import is genuinely ambiguous: !($t1 =:= $t2)")
+                  ambiguousError(s"it is imported twice in the same scope by\n${imports.head}\nand ${imports1.head}")
+                }
               }
               while (errorContainer == null && !imports1.isEmpty &&
                      (!imports.head.isExplicitImport(name) ||

--- a/test/files/neg/t3836.check
+++ b/test/files/neg/t3836.check
@@ -1,0 +1,13 @@
+t3836.scala:17: error: reference to IOException is ambiguous;
+it is imported twice in the same scope by
+import foo.bar._
+and import java.io._
+    def f = new IOException // genuinely different
+                ^
+t3836.scala:26: error: reference to Bippy is ambiguous;
+it is imported twice in the same scope by
+import baz._
+and import bar._
+    def f: Bippy[Int] = ???
+           ^
+two errors found

--- a/test/files/neg/t3836.scala
+++ b/test/files/neg/t3836.scala
@@ -1,0 +1,28 @@
+package foo
+
+package object bar {
+  type IOException = java.io.InputStream
+  type Bippy[T] = List[T]
+}
+
+package object baz {
+  type Bippy[+T] = List[T]
+}
+
+package baz {
+  import java.io._
+  import foo.bar._
+
+  object Test {
+    def f = new IOException // genuinely different
+  }
+}
+
+package baz2 {
+  import bar._
+  import baz._
+
+  object Test2 {
+    def f: Bippy[Int] = ???
+  }
+}

--- a/test/files/pos/t3836.scala
+++ b/test/files/pos/t3836.scala
@@ -1,0 +1,14 @@
+package foo
+
+package object bar {
+  type IOException = java.io.IOException
+}
+
+package baz {
+  import java.io._
+  import foo.bar._
+
+  object Test {
+    def f = new IOException
+  }
+}


### PR DESCRIPTION
Normalize types before declaring that two imports are ambiguous,
because they might be the same thing.  Review by @moors.
