### PR TITLE
SI-6022 model type-test-implication better -- review by @paulp

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
@@ -1616,7 +1616,16 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
 
     type Const <: AbsConst
     trait AbsConst {
+      // when we know V = C, which other equalities must hold
+      // in general, equality to some type implies equality to its supertypes
+      // (this multi-valued kind of equality is necessary for unreachability)
+      // note that we use subtyping as a model for implication between instanceof tests
+      // i.e., when S <:< T we assume x.isInstanceOf[S] implies x.isInstanceOf[T]
+      // unfortunately this is not true in general (see e.g. SI-6022)
       def implies(other: Const): Boolean
+
+      // does V = C preclude V having value `other`?  V = null is an exclusive assignment,
+      // but V = 1 does not preclude V = Int, or V = Any
       def excludes(other: Const): Boolean
     }
 
@@ -2164,11 +2173,28 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
 
       def isAny = wideTp.typeSymbol == AnyClass
 
+      // we use subtyping as a model for implication between instanceof tests
+      // i.e., when S <:< T we assume x.isInstanceOf[S] implies x.isInstanceOf[T]
+      // unfortunately this is not true in general:
+      // SI-6022 expects instanceOfTpImplies(ProductClass.tpe, AnyRefClass.tpe)
+      private def instanceOfTpImplies(tp: Type, tpImplied: Type) = {
+        val impliedSym = tpImplied.typeSymbol
+        val tpValue    = tp.typeSymbol.isPrimitiveValueClass
+
+        val tpImpliedNormalizedToAny =
+          if ((tpValue && impliedSym == AnyValClass) ||
+              (!tpValue && (impliedSym == AnyRefClass || impliedSym == ObjectClass))
+             ) AnyClass.tpe
+          else tpImplied
+
+        tp <:< tpImpliedNormalizedToAny
+      }
+
       final def implies(other: Const): Boolean = {
         val r = (this, other) match {
           case (_: ValueConst, _: ValueConst) => this == other // hashconsed
-          case (_: ValueConst, _: TypeConst)  => tp <:< other.tp
-          case (_: TypeConst,  _)             => tp <:< other.tp
+          case (_: ValueConst, _: TypeConst)  => instanceOfTpImplies(tp, other.tp)
+          case (_: TypeConst,  _)             => instanceOfTpImplies(tp, other.tp)
           case _                              => false
         }
         // if(r) patmatDebug("implies    : "+(this, other))
@@ -2185,12 +2211,12 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
           // this causes false negative for unreachability, but that's ok:
           // example: val X = 1; val Y = 1; (2: Int) match { case X => case Y => /* considered reachable */ }
           case (_: ValueConst, _: ValueConst) => this != other
-          case (_: ValueConst, _: TypeConst)  => !((tp <:< other.tp) || (other.tp <:< wideTp))
-          case (_: TypeConst,  _: ValueConst) => !((other.tp <:< tp) || (tp <:< other.wideTp))
-          case (_: TypeConst,  _: TypeConst)  => !((tp <:< other.tp) || (other.tp <:< tp))
+          case (_: ValueConst, _: TypeConst)  => !(instanceOfTpImplies(tp, other.tp) || instanceOfTpImplies(other.tp, wideTp))
+          case (_: TypeConst,  _: ValueConst) => !(instanceOfTpImplies(other.tp, tp) || instanceOfTpImplies(tp, other.wideTp))
+          case (_: TypeConst,  _: TypeConst)  => !(instanceOfTpImplies(tp, other.tp) || instanceOfTpImplies(other.tp, tp))
           case _                              => false
         }
-        // if(r) patmatDebug("excludes    : "+(this, this.tp, other, other.tp, (tp <:< other.tp), (tp <:< other.wideTp), (other.tp <:< tp), (other.tp <:< wideTp)))
+        // if(r) patmatDebug("excludes    : "+(this, this.tp, other, other.tp))
         // else  patmatDebug("NOT excludes: "+(this, other))
         r
       }
@@ -2752,7 +2778,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
         def simplify(c: Cond): Set[Cond] = c match {
           case AndCond(a, b)  => simplify(a) ++ simplify(b)
           case OrCond(_, _)   => Set(FalseCond) // TODO: make more precise
-          case NonNullCond(_) => Set(TrueCond) // not worth remembering
+          case NonNullCond(_) => Set(TrueCond)  // not worth remembering
           case _              => Set(c)
         }
         val conds = simplify(cond)
@@ -2768,7 +2794,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
               case (priorTest, deps) =>
                 ((simplify(priorTest.cond) == nonTrivial) || // our conditions are implied by priorTest if it checks the same thing directly
                  (nonTrivial subsetOf deps)                  // or if it depends on a superset of our conditions
-                ) && (deps subsetOf tested)             // the conditions we've tested when we are here in the match satisfy the prior test, and hence what it tested
+                ) && (deps subsetOf tested)                  // the conditions we've tested when we are here in the match satisfy the prior test, and hence what it tested
             } foreach {
               case (priorTest, _) =>
                 // if so, note the dependency in both tests

--- a/test/files/pos/t6022.flags
+++ b/test/files/pos/t6022.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t6022.scala
+++ b/test/files/pos/t6022.scala
@@ -1,0 +1,7 @@
+class Test {
+  (null: Any) match {
+    case x: AnyRef if false =>
+    case list: Option[_] =>
+    case product: Product => // change Product to String and it's all good
+  }
+}


### PR DESCRIPTION
we use subtyping as a model for implication between instanceof tests
i.e., when S <:< T we assume x.isInstanceOf[S] implies x.isInstanceOf[T]
unfortunately this is not true in general.

SI-6022 expects instanceOfTpImplies(ProductClass.tpe, AnyRefClass.tpe), but
ProductClass.tpe <:< AnyRefClass.tpe does not hold because Product extends Any

however, if x.isInstanceOf[Product] holds, so does x.isInstanceOf[AnyRef],
and that's all we care about when modeling type tests
