### PR TITLE
SI-2442 sealedness for java enums non-experimental

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -613,8 +613,8 @@ abstract class ClassfileParser {
       parseAttributes(sym, info)
       getScope(jflags).enter(sym)
 
-      // sealed java enums (experimental)
-      if (isEnum && opt.experimental) {
+      // sealed java enums
+      if (isEnum) {
         val enumClass = sym.owner.linkedClassOfClass
         if (!enumClass.isSealed)
           enumClass setFlag (SEALED | ABSTRACT)

--- a/test/files/neg/t2442.flags
+++ b/test/files/neg/t2442.flags
@@ -1,1 +1,1 @@
--Xexperimental -Xfatal-warnings
+-Xfatal-warnings


### PR DESCRIPTION
consider java enums as sealed even when we're not running in experimental mode
