### PR TITLE
better way to look for method bodies to inline, helps with SI-4767

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/icode/analysis/TypeFlowAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/analysis/TypeFlowAnalysis.scala
@@ -445,6 +445,8 @@ abstract class TypeFlowAnalysis {
           }
           val concreteMethod = inliner.lookupImplFor(msym, receiver)
           val isCandidate = {
+            !inliner.isIface(receiver)    &&
+            !inliner.isJDKClass(receiver) &&
             ( inliner.isClosureClass(receiver) || concreteMethod.isEffectivelyFinal || receiver.isEffectivelyFinal ) &&
             !blackballed(concreteMethod)
           }

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
@@ -725,8 +725,7 @@ abstract class ICodeReader extends ClassfileParser {
         import analysis.typeFlowLattice.IState
 
         /** Abstract interpretation for one instruction. */
-        override def interpret(in: typeFlowLattice.Elem, i: Instruction): typeFlowLattice.Elem = {
-          var out = IState(new VarBinding(in.vars), new TypeStack(in.stack))
+        override def mutatingInterpret(out: typeFlowLattice.Elem, i: Instruction): typeFlowLattice.Elem = {
           val bindings = out.vars
           val stack = out.stack
           import stack.push
@@ -734,12 +733,10 @@ abstract class ICodeReader extends ClassfileParser {
             case DUP_X1 =>
               val (one, two) = stack.pop2
               push(one); push(two); push(one);
-              out = IState(bindings, stack)
 
             case DUP_X2 =>
               val (one, two, three) = stack.pop3
               push(one); push(three); push(two); push(one);
-              out = IState(bindings, stack)
 
             case DUP2_X1 =>
               val (one, two) = stack.pop2
@@ -749,7 +746,6 @@ abstract class ICodeReader extends ClassfileParser {
                 val three = stack.pop
                 push(two); push(one); push(three); push(two); push(one);
               }
-              out = IState(bindings, stack)
 
             case DUP2_X2 =>
               val (one, two) = stack.pop2
@@ -768,10 +764,9 @@ abstract class ICodeReader extends ClassfileParser {
                   push(two); push(one); push(four); push(one); push(three); push(two); push(one);
                 }
               }
-              out = IState(bindings, stack)
 
             case _ =>
-              out = super.interpret(in, i)
+              super.mutatingInterpret(out, i)
           }
           out
         }

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
@@ -730,7 +730,7 @@ abstract class ICodeReader extends ClassfileParser {
           val stack = out.stack
           import stack.push
           i match {
-            case DUP_X1 =>
+            case DUP_X1 => // for example, scala.tools.asm.ClassWriter sports a DUP_X1 , showing it can happen for "scala" classes too.
               val (one, two) = stack.pop2
               push(one); push(two); push(one);
 
@@ -928,12 +928,12 @@ abstract class ICodeReader extends ClassfileParser {
       def checkValidIndex() {
         locals.get(idx - 1) match {
           case Some(others) if others exists (_._2.isWideType) =>
-            global.globalError("Illegal index: " + idx + " points in the middle of another local")
+            MissingRequirementError.signal("Illegal index: " + idx + " points in the middle of another local")
           case _ => ()
         }
         kind match {
           case LONG | DOUBLE if (locals.isDefinedAt(idx + 1)) =>
-            global.globalError("Illegal index: " + idx + " overlaps " + locals(idx + 1) + "\nlocals: " + locals)
+            MissingRequirementError.signal("Illegal index: " + idx + " overlaps " + locals(idx + 1) + "\nlocals: " + locals)
           case _ => ()
         }
       }


### PR DESCRIPTION
This pull request changes a core aspect of the inliner, thus please be sure to re-check.

At least one aspect definitely needs improvement: the definition of `isJDKClass()`. Ideas are specially welcome about that.

As well as comments about any material effect on performance ( @gkossakowski comes to mind ).

review by @VladUreche
review by @dragos
