### PR TITLE
SI-6042 Improve type selection from volatile type error

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -562,7 +562,9 @@ trait ContextErrors {
 
       // SelectFromTypeTree
       def TypeSelectionFromVolatileTypeError(tree: Tree, qual: Tree) = {
-        issueNormalTypeError(tree, "illegal type selection from volatile type "+qual.tpe)
+        val hiBound = qual.tpe.bounds.hi
+        val addendum = if (hiBound =:= qual.tpe) "" else s" (with upper bound ${hiBound})"
+        issueNormalTypeError(tree, s"illegal type selection from volatile type ${qual.tpe}${addendum}")
         setError(tree)
       }
 

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5114,7 +5114,7 @@ trait Typers extends Modes with Adaptations with Tags {
 
         case SelectFromTypeTree(qual, selector) =>
           val qual1 = typedType(qual, mode)
-          if (qual1.tpe.isVolatile) TypeSelectionFromVolatileTypeError(tree, qual)
+          if (qual1.tpe.isVolatile) TypeSelectionFromVolatileTypeError(tree, qual1)
           else typedSelect(qual1, selector)
 
         case CompoundTypeTree(templ) =>

--- a/test/files/neg/t6042.check
+++ b/test/files/neg/t6042.check
@@ -1,0 +1,4 @@
+t6042.scala:7: error: illegal type selection from volatile type a.OpSemExp (with upper bound LazyExp[a.OpSemExp] with _$1)
+  def foo[AA <: LazyExp[_]](a: AA): a.OpSemExp#Val = ??? // a.OpSemExp is volatile, because of `with This`
+                                               ^
+one error found

--- a/test/files/neg/t6042.scala
+++ b/test/files/neg/t6042.scala
@@ -1,0 +1,8 @@
+trait LazyExp[+This <: LazyExp[This]] { this: This =>
+  type OpSemExp <: LazyExp[OpSemExp] with This
+  type Val
+}
+
+object Test {
+  def foo[AA <: LazyExp[_]](a: AA): a.OpSemExp#Val = ??? // a.OpSemExp is volatile, because of `with This`
+}


### PR DESCRIPTION
- Display the type of the typed qualifier (qual1), to avoid the
  message "Illegal type selection from volatile type null".
  - Show the upper bound, which is used to calculate the volatility.

Review by @adriaanm
