### PR TITLE
Shorter flattened names for nested $anons

### DIFF
--- a/test/files/run/flatten.check
+++ b/test/files/run/flatten.check
@@ -1,0 +1,91 @@
+[[syntax trees at end of                   flatten]] // newSource1
+package <empty> {
+  object O extends Object {
+    def <init>(): ... = {
+      O.super.<init>();
+      {
+        new anonymous class O$$anon$2()
+      };
+      ()
+    }
+  };
+  abstract trait T1 extends Object;
+  abstract trait T2 extends Object;
+  abstract trait T3 extends Object;
+  abstract trait T3$class extends Object with T3 {
+    def /*T3$class*/$init$(): Unit = {
+      {
+        (new anonymous class T3$$anonfun$2(T3$class.this): Function0)
+      };
+      ()
+    }
+  };
+  class O$C$D extends Object {
+    <synthetic> <paramaccessor> protected val $outer: O$C = _;
+    <synthetic> <stable> def O$C$D$$$outer(): O$C = O$C$D.this.$outer;
+    def <init>($outer: O$C): O$C$D = {
+      if ($outer.eq(null))
+        throw new NullPointerException()
+      else
+        O$C$D.this.$outer = $outer;
+      O$C$D.super.<init>();
+      ()
+    }
+  };
+  final class O$C$$anon$1 extends Object with T1 with T2 {
+    def <init>($outer: O$C): anonymous class O$C$$anon$1 = {
+      O$C$$anon$1.super.<init>();
+      ()
+    }
+  };
+  class O$C extends Object {
+    def <init>(): O$C = {
+      O$C.super.<init>();
+      {
+        new anonymous class O$C$$anon$1(O$C.this)
+      };
+      ()
+    }
+  };
+  @SerialVersionUID(0) final <synthetic> class O$$anon$2$$anonfun$1 extends scala.runtime.AbstractFunction0$mcI$sp with Serializable {
+    final def apply(): Int = O$$anon$2$$anonfun$1.this.apply$mcI$sp();
+    <specialized> def apply$mcI$sp(): Int = 0;
+    final <bridge> def apply(): Object = scala.Int.box(O$$anon$2$$anonfun$1.this.apply());
+    def <init>($outer: anonymous class O$$anon$2): anonymous class O$$anon$2$$anonfun$1 = {
+      O$$anon$2$$anonfun$1.super.<init>();
+      ()
+    }
+  };
+  final class O$$anon$2$$anon$3 extends Object {
+    def <init>($outer: anonymous class O$$anon$2): anonymous class O$$anon$2$$anon$3 = {
+      O$$anon$2$$anon$3.super.<init>();
+      ()
+    }
+  };
+  final class O$$anon$2 extends Object {
+    def <init>(): anonymous class O$$anon$2 = {
+      O$$anon$2.super.<init>();
+      {
+        (new anonymous class O$$anon$2$$anonfun$1(O$$anon$2.this): Function0)
+      };
+      {
+        new anonymous class O$$anon$2$$anon$3(O$$anon$2.this)
+      };
+      ()
+    }
+  };
+  final class T3$$anonfun$2$$anon$4 extends Object {
+    def <init>($outer: anonymous class T3$$anonfun$2): anonymous class T3$$anonfun$2$$anon$4 = {
+      T3$$anonfun$2$$anon$4.super.<init>();
+      ()
+    }
+  };
+  @SerialVersionUID(0) final <synthetic> class T3$$anonfun$2 extends scala.runtime.AbstractFunction0 with Serializable {
+    final def apply(): Object = new anonymous class T3$$anonfun$2$$anon$4(T3$$anonfun$2.this);
+    def <init>($outer: T3): anonymous class T3$$anonfun$2 = {
+      T3$$anonfun$2.super.<init>();
+      ()
+    }
+  }
+}
+

--- a/test/files/run/flatten.check
+++ b/test/files/run/flatten.check
@@ -32,9 +32,9 @@ package <empty> {
       ()
     }
   };
-  final class O$C$$anon$1 extends Object with T1 with T2 {
-    def <init>($outer: O$C): anonymous class O$C$$anon$1 = {
-      O$C$$anon$1.super.<init>();
+  final class O$$anon$1 extends Object with T1 with T2 {
+    def <init>($outer: O$C): anonymous class O$$anon$1 = {
+      O$$anon$1.super.<init>();
       ()
     }
   };
@@ -42,23 +42,23 @@ package <empty> {
     def <init>(): O$C = {
       O$C.super.<init>();
       {
-        new anonymous class O$C$$anon$1(O$C.this)
+        new anonymous class O$$anon$1(O$C.this)
       };
       ()
     }
   };
-  @SerialVersionUID(0) final <synthetic> class O$$anon$2$$anonfun$1 extends scala.runtime.AbstractFunction0$mcI$sp with Serializable {
-    final def apply(): Int = O$$anon$2$$anonfun$1.this.apply$mcI$sp();
+  @SerialVersionUID(0) final <synthetic> class O$$anonfun$1 extends scala.runtime.AbstractFunction0$mcI$sp with Serializable {
+    final def apply(): Int = O$$anonfun$1.this.apply$mcI$sp();
     <specialized> def apply$mcI$sp(): Int = 0;
-    final <bridge> def apply(): Object = scala.Int.box(O$$anon$2$$anonfun$1.this.apply());
-    def <init>($outer: anonymous class O$$anon$2): anonymous class O$$anon$2$$anonfun$1 = {
-      O$$anon$2$$anonfun$1.super.<init>();
+    final <bridge> def apply(): Object = scala.Int.box(O$$anonfun$1.this.apply());
+    def <init>($outer: anonymous class O$$anon$2): anonymous class O$$anonfun$1 = {
+      O$$anonfun$1.super.<init>();
       ()
     }
   };
-  final class O$$anon$2$$anon$3 extends Object {
-    def <init>($outer: anonymous class O$$anon$2): anonymous class O$$anon$2$$anon$3 = {
-      O$$anon$2$$anon$3.super.<init>();
+  final class O$$anon$3 extends Object {
+    def <init>($outer: anonymous class O$$anon$2): anonymous class O$$anon$3 = {
+      O$$anon$3.super.<init>();
       ()
     }
   };
@@ -66,22 +66,22 @@ package <empty> {
     def <init>(): anonymous class O$$anon$2 = {
       O$$anon$2.super.<init>();
       {
-        (new anonymous class O$$anon$2$$anonfun$1(O$$anon$2.this): Function0)
+        (new anonymous class O$$anonfun$1(O$$anon$2.this): Function0)
       };
       {
-        new anonymous class O$$anon$2$$anon$3(O$$anon$2.this)
+        new anonymous class O$$anon$3(O$$anon$2.this)
       };
       ()
     }
   };
-  final class T3$$anonfun$2$$anon$4 extends Object {
-    def <init>($outer: anonymous class T3$$anonfun$2): anonymous class T3$$anonfun$2$$anon$4 = {
-      T3$$anonfun$2$$anon$4.super.<init>();
+  final class T3$$anon$4 extends Object {
+    def <init>($outer: anonymous class T3$$anonfun$2): anonymous class T3$$anon$4 = {
+      T3$$anon$4.super.<init>();
       ()
     }
   };
   @SerialVersionUID(0) final <synthetic> class T3$$anonfun$2 extends scala.runtime.AbstractFunction0 with Serializable {
-    final def apply(): Object = new anonymous class T3$$anonfun$2$$anon$4(T3$$anonfun$2.this);
+    final def apply(): Object = new anonymous class T3$$anon$4(T3$$anonfun$2.this);
     def <init>($outer: T3): anonymous class T3$$anonfun$2 = {
       T3$$anonfun$2.super.<init>();
       ()

--- a/test/files/run/flatten.check
+++ b/test/files/run/flatten.check
@@ -20,7 +20,32 @@ package <empty> {
       ()
     }
   };
+  final class O$$anon$4 extends Object {
+    def <init>($outer: anonymous class O$$anonfun$method$1): anonymous class O$$anon$4 = {
+      O$$anon$4.super.<init>();
+      "anon class in method".isEmpty();
+      ()
+    }
+  };
+  @SerialVersionUID(0) final <synthetic> class O$$anonfun$method$1 extends scala.runtime.AbstractFunction0 with Serializable {
+    final def apply(): Object = {
+      "anon fun in method".isEmpty();
+      {
+        new anonymous class O$$anon$4(O$$anonfun$method$1.this)
+      }
+    };
+    def <init>($outer: O$C$D): anonymous class O$$anonfun$method$1 = {
+      O$$anonfun$method$1.super.<init>();
+      ()
+    }
+  };
   class O$C$D extends Object {
+    def method(): Unit = {
+      {
+        (new anonymous class O$$anonfun$method$1(O$C$D.this): Function0)
+      };
+      ()
+    };
     <synthetic> <paramaccessor> protected val $outer: O$C = _;
     <synthetic> <stable> def O$C$D$$$outer(): O$C = O$C$D.this.$outer;
     def <init>($outer: O$C): O$C$D = {
@@ -74,14 +99,14 @@ package <empty> {
       ()
     }
   };
-  final class T3$$anon$4 extends Object {
-    def <init>($outer: anonymous class T3$$anonfun$2): anonymous class T3$$anon$4 = {
-      T3$$anon$4.super.<init>();
+  final class T3$$anon$5 extends Object {
+    def <init>($outer: anonymous class T3$$anonfun$2): anonymous class T3$$anon$5 = {
+      T3$$anon$5.super.<init>();
       ()
     }
   };
   @SerialVersionUID(0) final <synthetic> class T3$$anonfun$2 extends scala.runtime.AbstractFunction0 with Serializable {
-    final def apply(): Object = new anonymous class T3$$anon$4(T3$$anonfun$2.this);
+    final def apply(): Object = new anonymous class T3$$anon$5(T3$$anonfun$2.this);
     def <init>($outer: T3): anonymous class T3$$anonfun$2 = {
       T3$$anonfun$2.super.<init>();
       ()

--- a/test/files/run/flatten.scala
+++ b/test/files/run/flatten.scala
@@ -14,7 +14,12 @@ object Test extends DirectTest {
       |  }
       |  class C {
       |    new T1 with T2 {}
-      |    class D
+      |    class D {
+      |      def method {
+      |        () => "anon fun in method".isEmpty
+      |        new { "anon class in method".isEmpty }
+      |      }
+      |    }
       |  }
       |}
       |

--- a/test/files/run/flatten.scala
+++ b/test/files/run/flatten.scala
@@ -1,0 +1,33 @@
+import scala.tools.partest._
+
+object Test extends DirectTest {
+
+  override def extraSettings: String = "-usejavacp -Xprint:flatten -d " + testOutput.path
+
+  override def code =
+    """
+      |object O {
+      |  new {
+      |    () => 0
+      |    new {
+      |    }
+      |  }
+      |  class C {
+      |    new T1 with T2 {}
+      |    class D
+      |  }
+      |}
+      |
+      |trait T1; trait T2
+      |
+      |trait T3 {
+      |  () => { new { } }
+      |}
+    """.stripMargin
+
+  override def show(): Unit = {
+    Console.withErr(System.out) {
+      compile()
+    }
+  }
+}


### PR DESCRIPTION
[scala-internals thread](https://groups.google.com/d/topic/scala-internals/M852v50Rrik/discussion)

The effect of the change is best described by the diff of [flatten.check](https://github.com/retronym/scala/commit/968909#diff-1)

Review by @paulp, @odersky
- Can you suggest additional interesting cases for test/files/run/flatten.scala?
- Do we care that by unnesting the names we make it harder to mentally link the mangled name to its source code? (Incidentally, it would be great if we could teach YourKit to do this for us automatically, to save us either guessing / messing around with javap to figure it out).
- I've done this for `$anonFun`, `$anon`: is there anything else that could have the same treatment?
- The code to walk the `rawowner` chain was a bit fiddly to write and should be scrutinized. I didn't find an existing method on `Symbol` that did what I needed.

References SI-3623.
