### PR TITLE
SI-6022 model type-test-implication better

### DIFF
--- a/test/files/pos/t6022.flags
+++ b/test/files/pos/t6022.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t6022.scala
+++ b/test/files/pos/t6022.scala
@@ -1,0 +1,7 @@
+class Test {
+  (null: Any) match {
+    case x: AnyRef if false =>
+    case list: Option[_] =>
+    case product: Product => // change Product to String and it's all good
+  }
+}


### PR DESCRIPTION
we use subtyping as a model for implication between instanceof tests
i.e., when S <:< T we assume x.isInstanceOf[S] implies x.isInstanceOf[T]
unfortunately this is not true in general.

SI-6022 expects instanceOfTpImplies(ProductClass.tpe, AnyRefClass.tpe), but
ProductClass.tpe <:< AnyRefClass.tpe does not hold because Product extends Any

however, if x.isInstanceOf[Product] holds, so does x.isInstanceOf[AnyRef],
and that's all we care about when modeling type tests
