### PR TITLE
Fix doc about specialized subclasses of c.i.HashMap/HashSet.

### DIFF
--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -15,8 +15,7 @@ import parallel.immutable.ParHashMap
 
 /** This class implements immutable maps using a hash trie.
  *
- *  '''Note:''' the builder of a hash map returns specialized representations EmptyMap,Map1,..., Map4
- *  for maps of size <= 4.
+ *  '''Note:''' The builder of this hash map may return specialized representations for small maps.
  *
  *  @tparam A      the type of the keys contained in this hash map.
  *  @tparam B      the type of the values associated with the keys.

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -17,8 +17,7 @@ import collection.parallel.immutable.ParHashSet
 
 /** This class implements immutable sets using a hash trie.
  *
- *  '''Note:''' the builder of a hash set returns specialized representations `EmptySet`,`Set1`,..., `Set4`
- *  for sets of `size <= 4`.
+ *  '''Note:''' The builder of this hash set may return specialized representations for small sets.
  *
  *  @tparam A      the type of the elements contained in this hash set.
  *


### PR DESCRIPTION
The documentation was wrong and judging from the “TODO: add HashMap2,
HashMap3, ...” in the source file I refrained from mentioning any
specific number, so overall it has gotten a bit less precise, but
hopefully more correct.

Review: @heathermiller
