### PR TITLE
SI-5956 trigger copy generation with correct namer

### DIFF
--- a/test/files/neg/t1286.check
+++ b/test/files/neg/t1286.check
@@ -1,9 +1,5 @@
-a.scala:1: error: Companions 'object Foo' and 'trait Foo' must be defined in same file:
-  Found in t1286/b.scala and t1286/a.scala
-trait Foo {
-      ^
 b.scala:1: error: Companions 'trait Foo' and 'object Foo' must be defined in same file:
   Found in t1286/a.scala and t1286/b.scala
 object Foo extends Foo {
        ^
-two errors found
+one error found

--- a/test/files/neg/t5956.check
+++ b/test/files/neg/t5956.check
@@ -1,0 +1,20 @@
+t5956.scala:1: warning: case classes without a parameter list have been deprecated;
+use either case objects or case classes with `()' as parameter list.
+object O { case class C[T]; class C }
+                          ^
+t5956.scala:2: warning: case classes without a parameter list have been deprecated;
+use either case objects or case classes with `()' as parameter list.
+object T { case class C[T]; case class C }
+                          ^
+t5956.scala:2: warning: case classes without a parameter list have been deprecated;
+use either case objects or case classes with `()' as parameter list.
+object T { case class C[T]; case class C }
+                                        ^
+t5956.scala:1: error: C is already defined as case class C
+object O { case class C[T]; class C }
+                                  ^
+t5956.scala:2: error: C is already defined as case class C
+object T { case class C[T]; case class C }
+                                       ^
+three warnings found
+two errors found

--- a/test/files/neg/t5956.scala
+++ b/test/files/neg/t5956.scala
@@ -1,0 +1,2 @@
+object O { case class C[T]; class C }
+object T { case class C[T]; case class C }


### PR DESCRIPTION
the call to `addCopyMethod` passes `templateNamer`, which is supposed to be the
namer of the case class template. with two classes of the same name, `addCopyMethod`
was triggered in the wrong template.

review by @hubertp
