### PR TITLE
Optimize findmember

### DIFF
--- a/src/compiler/scala/tools/nsc/Driver.scala
+++ b/src/compiler/scala/tools/nsc/Driver.scala
@@ -1,10 +1,12 @@
 package scala.tools.nsc
 
 import scala.tools.nsc.reporters.{Reporter, ConsoleReporter}
-import Properties.{ versionString, copyrightString }
+import Properties.{ versionString, copyrightString, residentPromptString }
 import scala.reflect.internal.util.{ BatchSourceFile, FakePos }
 
 abstract class Driver {
+  
+  val prompt = residentPromptString
 
   val versionMsg = "Scala compiler " +
     versionString + " -- " +

--- a/src/compiler/scala/tools/nsc/Main.scala
+++ b/src/compiler/scala/tools/nsc/Main.scala
@@ -12,14 +12,12 @@ import scala.tools.nsc.interactive.{ RefinedBuildManager, SimpleBuildManager }
 import scala.tools.nsc.io.AbstractFile
 import scala.tools.nsc.reporters.{Reporter, ConsoleReporter}
 import scala.reflect.internal.util.{ BatchSourceFile, FakePos } //{Position}
-import Properties.{ versionString, copyrightString, residentPromptString, msilLibPath }
+import Properties.msilLibPath
 
 /** The main class for NSC, a compiler for the programming
- *  language Scala.
+ *  language Scala. 
  */
 object Main extends Driver with EvalLoop {
-
-  val prompt = residentPromptString
 
   def resident(compiler: Global) {
     loop { line =>

--- a/src/compiler/scala/tools/nsc/MainBench.scala
+++ b/src/compiler/scala/tools/nsc/MainBench.scala
@@ -1,0 +1,48 @@
+/* NSC -- new Scala compiler
+ * Copyright 2005-2011 LAMP/EPFL
+ * @author  Martin Odersky
+ */
+
+package scala.tools.nsc
+
+import java.io.File
+import File.pathSeparator
+
+import scala.tools.nsc.interactive.{ RefinedBuildManager, SimpleBuildManager }
+import scala.tools.nsc.io.AbstractFile
+import scala.tools.nsc.reporters.{Reporter, ConsoleReporter}
+import scala.reflect.internal.util.{ BatchSourceFile, FakePos } //{Position}
+import Properties.{ versionString, copyrightString, residentPromptString, msilLibPath }
+import scala.reflect.internal.util.Statistics
+
+/** The main class for NSC, a compiler for the programming
+ *  language Scala.
+ */
+object MainBench extends Driver with EvalLoop {
+  
+  lazy val theCompiler = Global(settings, reporter)
+  
+  override def newCompiler() = theCompiler
+  
+  val NIter = 50
+  val NBest = 10
+  
+  override def main(args: Array[String]) = {
+    val times = new Array[Long](NIter)
+    var start = System.nanoTime()
+    for (i <- 0 until NIter) {
+      if (i == NIter-1) {
+        theCompiler.settings.Ystatistics.value = true
+        Statistics.enabled = true
+      }
+      process(args)
+      val end = System.nanoTime()
+      val duration = (end-start)/1000000
+      println(s"${duration}ms")
+      times(i) = duration
+      start = end
+    }
+    val avg = times.sorted.take(NBest).sum / NBest
+    println(s"avg shortest $NBest times ${avg}ms")
+  }
+}

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -119,7 +119,7 @@ abstract class RefChecks extends InfoTransform with reflect.internal.transform.R
       // those with the DEFAULTPARAM flag, and infer the methods. Looking for the methods
       // directly requires inspecting the parameter list of every one. That modification
       // shaved 95% off the time spent in this method.
-      val defaultGetters     = clazz.info.findMember(nme.ANYNAME, 0L, DEFAULTPARAM, false).alternatives
+      val defaultGetters     = clazz.info.findMembers(0L, DEFAULTPARAM)
       val defaultMethodNames = defaultGetters map (sym => nme.defaultGetterToMethod(sym.name))
 
       defaultMethodNames.distinct foreach { name =>

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4510,6 +4510,8 @@ trait Typers extends Modes with Adaptations with Tags {
           assert(errorContainer == null, "Cannot set ambiguous error twice for identifier")
           errorContainer = tree
         }
+        
+        val fingerPrint: Long = name.fingerPrint
 
         var defSym: Symbol = tree.symbol  // the directly found symbol
         var pre: Type = NoPrefix          // the prefix type of defSym, if a class member
@@ -4548,7 +4550,10 @@ trait Typers extends Modes with Adaptations with Tags {
           var cx = startingIdentContext
           while (defSym == NoSymbol && cx != NoContext && (cx.scope ne null)) { // cx.scope eq null arises during FixInvalidSyms in Duplicators
             pre = cx.enclClass.prefix
-            defEntry = cx.scope.lookupEntry(name)
+            defEntry = {
+                val scope = cx.scope
+                if ((fingerPrint & scope.fingerPrints) != 0) scope.lookupEntry(name) else null
+              }
             if ((defEntry ne null) && qualifies(defEntry.sym)) {
               // Right here is where SI-1987, overloading in package objects, can be
               // seen to go wrong. There is an overloaded symbol, but when referring

--- a/src/reflect/scala/reflect/api/StandardNames.scala
+++ b/src/reflect/scala/reflect/api/StandardNames.scala
@@ -43,7 +43,6 @@ trait StandardNames extends base.StandardNames {
     val SUPER_PREFIX_STRING: String
     val TRAIT_SETTER_SEPARATOR_STRING: String
 
-    val ANYNAME: TermName
     val FAKE_LOCAL_THIS: TermName
     val INITIALIZER: TermName
     val LAZY_LOCAL: TermName

--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -414,6 +414,9 @@ trait Names extends api.Names {
       }
       else toString
     }
+    
+    @inline
+    final def fingerPrint: Long = (1L << start)
 
     /** TODO - find some efficiency. */
     def append(ch: Char)        = newName("" + this + ch)

--- a/src/reflect/scala/reflect/internal/Scopes.scala
+++ b/src/reflect/scala/reflect/internal/Scopes.scala
@@ -41,15 +41,15 @@ trait Scopes extends api.Scopes { self: SymbolTable =>
    *  This is necessary because when run from reflection every scope needs to have a
    *  SynchronizedScope as mixin.
    */
-  class Scope protected[Scopes] (initElems: ScopeEntry = null) extends Iterable[Symbol] {
+  class Scope protected[Scopes] (initElems: ScopeEntry = null, initFingerPrints: Long = 0L) extends Iterable[Symbol] {
     
     /** A bitset containing the last 6 bits of the start value of every name 
      *  stored in this scope.
      */
-    var fingerPrints: Long = 0L
+    var fingerPrints: Long = initFingerPrints
 
     protected[Scopes] def this(base: Scope) = {
-      this(base.elems)
+      this(base.elems, base.fingerPrints)
       nestinglevel = base.nestinglevel + 1
     }
 
@@ -119,7 +119,7 @@ trait Scopes extends api.Scopes { self: SymbolTable =>
      *  @param sym ...
      */
     def enter[T <: Symbol](sym: T): T = { 
-      fingerPrints |= (1L << sym.name.start)
+      fingerPrints |= sym.name.fingerPrint
       enterEntry(newScopeEntry(sym, this)) 
       sym 
     }
@@ -156,6 +156,7 @@ trait Scopes extends api.Scopes { self: SymbolTable =>
     }
 
     def rehash(sym: Symbol, newname: Name) {
+      fingerPrints |= newname.fingerPrint
       if (hashtable ne null) {
         val index = sym.name.start & HASHMASK
         var e1 = hashtable(index)

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -294,7 +294,7 @@ trait StdNames {
     val WHILE_PREFIX                  = "while$"
 
     // Compiler internal names
-    val ANYNAME: NameType                  = "<anyname>"
+    val ANYname: NameType                  = "<any>"
     val CONSTRUCTOR: NameType              = "<init>"
     val EQEQ_LOCAL_VAR: NameType           = "eqEqTemp$"
     val FAKE_LOCAL_THIS: NameType          = "this$"

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -294,7 +294,7 @@ trait StdNames {
     val WHILE_PREFIX                  = "while$"
 
     // Compiler internal names
-    val ANYname: NameType                  = "<any>"
+    val ANYname: NameType                  = "<anyname>"
     val CONSTRUCTOR: NameType              = "<init>"
     val EQEQ_LOCAL_VAR: NameType           = "eqEqTemp$"
     val FAKE_LOCAL_THIS: NameType          = "this$"

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1045,6 +1045,7 @@ trait Types extends api.Types { self: SymbolTable =>
       var continue = true
       var self: Type = null
       var membertpe: Type = null
+      val fingerPrint: Long = (1L << name.start)
       while (continue) {
         continue = false
         val bcs0 = baseClasses
@@ -1052,7 +1053,9 @@ trait Types extends api.Types { self: SymbolTable =>
         while (!bcs.isEmpty) {
           val decls = bcs.head.info.decls
           var entry =
-            if (name == nme.ANYNAME) decls.elems else decls.lookupEntry(name)
+            if (name == nme.ANYNAME) decls.elems 
+            else if ((fingerPrint & decls.fingerPrints) == 0) null
+            else decls.lookupEntry(name)
           while (entry ne null) {
             val sym = entry.sym
             if (sym hasAllFlags requiredFlags) {

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1053,7 +1053,7 @@ trait Types extends api.Types { self: SymbolTable =>
         while (!bcs.isEmpty) {
           val decls = bcs.head.info.decls
           var entry =
-            if (name == nme.ANYNAME) decls.elems 
+            if (name eq nme.ANYNAME) decls.elems 
             else if ((fingerPrint & decls.fingerPrints) == 0) null
             else decls.lookupEntry(name)
           while (entry ne null) {
@@ -1069,12 +1069,12 @@ trait Types extends api.Types { self: SymbolTable =>
                   Statistics.popTimer(typeOpsStack, start)
                   if (suspension ne null) suspension foreach (_.suspended = false)
                   return sym
-                } else if (member == NoSymbol) {
+                } else if (member eq NoSymbol) {
                   member = sym
                 } else if (members eq null) {
-                  if (member.name != sym.name ||
-                      !(member == sym ||
-                        member.owner != sym.owner &&
+                  if ((member.name ne sym.name) ||
+                      !((member eq sym) ||
+                        (member.owner ne sym.owner) &&
                         !sym.isPrivate && {
                           if (self eq null) self = this.narrow
                           if (membertpe eq null) membertpe = self.memberType(member)
@@ -1088,8 +1088,8 @@ trait Types extends api.Types { self: SymbolTable =>
                   var prevEntry = members.lookupEntry(sym.name)
                   var symtpe: Type = null
                   while ((prevEntry ne null) &&
-                         !(prevEntry.sym == sym ||
-                           prevEntry.sym.owner != sym.owner &&
+                         !((prevEntry.sym eq sym) ||
+                           (prevEntry.sym.owner ne sym.owner) &&
                            !sym.hasFlag(PRIVATE) && {
                              if (self eq null) self = this.narrow
                              if (symtpe eq null) symtpe = self.memberType(sym)

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1110,6 +1110,7 @@ trait Types extends api.Types { self: SymbolTable =>
       var lastM: ::[Symbol] = null
       var membertpe: Type = null
       var membertpes: Array[Type] = null
+      var required = requiredFlags
       var excluded = excludedFlags | DEFERRED
       var continue = true
       var self: Type = null
@@ -1142,7 +1143,7 @@ trait Types extends api.Types { self: SymbolTable =>
             while (entry ne null) {
               val sym = entry.sym
               val flags = sym.flags
-              if ((flags & requiredFlags) == requiredFlags) {
+              if ((flags & required) == required) {
                 val excl = flags & excluded
                 if (excl == 0L &&
                     (// omit PRIVATE LOCALS unless selector class is contained in class owning the def.
@@ -1205,6 +1206,7 @@ trait Types extends api.Types { self: SymbolTable =>
           bcs = if (name == nme.CONSTRUCTOR) Nil else bcs.tail
         } // while (!bcs.isEmpty)
         excluded = excludedFlags
+        required |= DEFERRED
       } // while (continue)
       Statistics.popTimer(typeOpsStack, start)
       if (suspension ne null) suspension foreach (_.suspended = false)

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1045,7 +1045,7 @@ trait Types extends api.Types { self: SymbolTable =>
       var continue = true
       var self: Type = null
       var membertpe: Type = null
-      val fingerPrint: Long = (1L << name.start)
+      val fingerPrint: Long = name.fingerPrint
       while (continue) {
         continue = false
         val bcs0 = baseClasses
@@ -1612,8 +1612,13 @@ trait Types extends api.Types { self: SymbolTable =>
     if (period != currentPeriod) {
       tpe.baseClassesPeriod = currentPeriod
       if (!isValidForBaseClasses(period)) {
-        tpe.baseClassesCache = null
-        tpe.baseClassesCache = tpe.memo(computeBaseClasses)(tpe.typeSymbol :: _.baseClasses.tail)
+        val start = Statistics.pushTimer(typeOpsStack, baseClassesNanos)
+        try {
+          tpe.baseClassesCache = null
+          tpe.baseClassesCache = tpe.memo(computeBaseClasses)(tpe.typeSymbol :: _.baseClasses.tail)
+        } finally {
+          Statistics.popTimer(typeOpsStack, start)
+        }
       }
     }
     if (tpe.baseClassesCache eq null)
@@ -6909,6 +6914,7 @@ object TypesStats {
   val findMemberNanos     = Statistics.newStackableTimer("time spent in findmember", typerNanos)
   val asSeenFromNanos     = Statistics.newStackableTimer("time spent in asSeenFrom", typerNanos)
   val baseTypeSeqNanos    = Statistics.newStackableTimer("time spent in baseTypeSeq", typerNanos)
+  val baseClassesNanos    = Statistics.newStackableTimer("time spent in baseClasses", typerNanos)
   val compoundBaseTypeSeqCount = Statistics.newSubCounter("  of which for compound types", baseTypeSeqCount)
   val typerefBaseTypeSeqCount = Statistics.newSubCounter("  of which for typerefs", baseTypeSeqCount)
   val singletonBaseTypeSeqCount = Statistics.newSubCounter("  of which for singletons", baseTypeSeqCount)

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1105,14 +1105,32 @@ trait Types extends api.Types { self: SymbolTable =>
       val start = Statistics.pushTimer(typeOpsStack, findMemberNanos)
 
       //Console.println("find member " + name.decode + " in " + this + ":" + this.baseClasses)//DEBUG
+      var member: Symbol = NoSymbol
       var members: List[Symbol] = null
       var lastM: ::[Symbol] = null
-      var member: Symbol = NoSymbol
+      var membertpe: Type = null
+      var membertpes: Array[Type] = null
       var excluded = excludedFlags | DEFERRED
       var continue = true
       var self: Type = null
-      var membertpe: Type = null
       val fingerPrint: Long = name.fingerPrint
+
+      def getMtpe(sym: Symbol, idx: Int): Type = {
+        var result = membertpes(idx)
+        if (result eq null) { result = self memberType sym; membertpes(idx) = result }
+        result
+      }
+
+      def addMtpe(xs: Array[Type], tpe: Type, idx: Int): Array[Type] =
+        if (idx < xs.length ) {
+          xs(idx) = tpe
+          xs
+        } else {
+          val ys = new Array[Type](xs.length * 2)
+          Array.copy(xs, 0, ys, 0, xs.length)
+          addMtpe(ys, tpe, idx)
+        }
+
       while (continue) {
         continue = false
         val bcs0 = baseClasses
@@ -1138,33 +1156,42 @@ trait Types extends api.Types { self: SymbolTable =>
                   } else if (member eq NoSymbol) {
                     member = sym
                   } else if (members eq null) {
-                    if (!((member eq sym) ||
-                          (member.owner ne sym.owner) &&
-                          (flags & PRIVATE) == 0 && {
-                            if (self eq null) self = this.narrow
-                            if (membertpe eq null) membertpe = self.memberType(member)
-                            (membertpe matches self.memberType(sym))
-                          })) {
+                    var symtpe: Type = null
+                    if ((member ne sym) &&
+                        ((member.owner eq sym.owner) ||
+                         (flags & PRIVATE) != 0 || {
+                           if (self eq null) self = this.narrow
+                           if (membertpe eq null) membertpe = self.memberType(member)
+                           symtpe = self.memberType(sym)
+                           !(membertpe matches symtpe)
+                         })) {
                       lastM = new ::(sym, null)
                       members = member :: lastM
+                      membertpes = new Array[Type](8)
+                      membertpes(0) = membertpe
+                      membertpes(1) = symtpe
                     }
                   } else {
                     var others = members
+                    var idx = 0
                     var symtpe: Type = null
-                    while ((others ne null) &&
-                           !((others.head eq sym) ||
-                             (others.head.owner ne sym.owner) &&
-                             (flags & PRIVATE) == 0 && {
-                               if (self eq null) self = this.narrow
-                               if (symtpe eq null) symtpe = self.memberType(sym)
-                               self.memberType(others.head) matches symtpe
-                             })) {
+                    while ((others ne null) && {
+                             val other = others.head
+                             (other ne sym) &&
+                             ((other.owner eq sym.owner) ||
+                              (flags & PRIVATE) != 0 || {
+                                if (self eq null) self = this.narrow
+                                if (symtpe eq null) symtpe = self.memberType(sym)
+                                !(getMtpe(other, idx) matches symtpe)
+                             })}) {
                       others = others.tail
+                      idx += 1
                     }
                     if (others eq null) {
                       val lastM1 = new ::(sym, null)
                       lastM.tl = lastM1
                       lastM = lastM1
+                      membertpes = addMtpe(membertpes, symtpe, idx)
                     }
                   }
                 } else if (excl == DEFERRED) {
@@ -5132,7 +5159,7 @@ trait Types extends api.Types { self: SymbolTable =>
    */
   def needsOuterTest(patType: Type, selType: Type, currentOwner: Symbol) = {
     def createDummyClone(pre: Type): Type = {
-      val dummy = currentOwner.enclClass.newValue(nme.ANYNAME).setInfo(pre.widen)
+      val dummy = currentOwner.enclClass.newValue(nme.ANYname).setInfo(pre.widen)
       singleType(ThisType(currentOwner.enclClass), dummy)
     }
     def maybeCreateDummyClone(pre: Type, sym: Symbol): Type = pre match {

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1034,7 +1034,6 @@ trait Types extends api.Types { self: SymbolTable =>
       var excluded = excludedFlags | DEFERRED
       var continue = true
       var self: Type = null
-      var membertpe: Type = null
       while (continue) {
         continue = false
         val bcs0 = baseClasses
@@ -1044,12 +1043,13 @@ trait Types extends api.Types { self: SymbolTable =>
           var entry = decls.elems 
           while (entry ne null) {
             val sym = entry.sym
-            if (sym hasAllFlags requiredFlags) {
-              val excl = sym.getFlag(excluded)
+            val flags = sym.flags
+            if ((flags & requiredFlags) == requiredFlags) {
+              val excl = flags & excluded
               if (excl == 0L &&
                   (// omit PRIVATE LOCALS unless selector class is contained in class owning the def.
                    (bcs eq bcs0) ||
-                   !sym.isPrivateLocal ||
+                   (flags & PrivateLocal) != PrivateLocal ||
                    (bcs0.head.hasTransOwner(bcs.head)))) {
                 if (members eq null) members = newScope
                 var prevEntry = members.lookupEntry(sym.name)
@@ -1118,61 +1118,60 @@ trait Types extends api.Types { self: SymbolTable =>
         var bcs = bcs0
         while (!bcs.isEmpty) {
           val decls = bcs.head.info.decls
-          var entry =
-            if (name eq nme.ANYNAME) decls.elems 
-            else if ((fingerPrint & decls.fingerPrints) == 0) null
-            else decls.lookupEntry(name)
-          while (entry ne null) {
-            val sym = entry.sym
-            if (sym hasAllFlags requiredFlags) {
-              val excl = sym.getFlag(excluded)
-              if (excl == 0L &&
-                  (// omit PRIVATE LOCALS unless selector class is contained in class owning the def.
-                   (bcs eq bcs0) ||
-                   !sym.isPrivateLocal ||
-                   (bcs0.head.hasTransOwner(bcs.head)))) {
-                if (name.isTypeName || stableOnly && sym.isStable) {
-                  Statistics.popTimer(typeOpsStack, start)
-                  if (suspension ne null) suspension foreach (_.suspended = false)
-                  return sym
-                } else if (member eq NoSymbol) {
-                  member = sym
-                } else if (members eq null) {
-                  if ((member.name ne sym.name) ||
-                      !((member eq sym) ||
-                        (member.owner ne sym.owner) &&
-                        !sym.isPrivate && {
-                          if (self eq null) self = this.narrow
-                          if (membertpe eq null) membertpe = self.memberType(member)
-                          (membertpe matches self.memberType(sym))
-                        })) {
+          if ((fingerPrint & decls.fingerPrints) != 0) {
+            var entry = decls.lookupEntry(name)
+            while (entry ne null) {
+              val sym = entry.sym
+              val flags = sym.flags
+              if ((flags & requiredFlags) == requiredFlags) {
+                val excl = flags & excluded
+                if (excl == 0L &&
+                    (// omit PRIVATE LOCALS unless selector class is contained in class owning the def.
+                     (bcs eq bcs0) ||
+                     (flags & PrivateLocal) != PrivateLocal ||
+                     (bcs0.head.hasTransOwner(bcs.head)))) {
+                  if (name.isTypeName || stableOnly && sym.isStable) {
+                    Statistics.popTimer(typeOpsStack, start)
+                    if (suspension ne null) suspension foreach (_.suspended = false)
+                    return sym
+                  } else if (member eq NoSymbol) {
+                    member = sym
+                  } else if (members eq null) {
+                    if (!((member eq sym) ||
+                          (member.owner ne sym.owner) &&
+                          (flags & PRIVATE) == 0 && {
+                            if (self eq null) self = this.narrow
+                            if (membertpe eq null) membertpe = self.memberType(member)
+                            (membertpe matches self.memberType(sym))
+                          })) {
                     members = newScope
                     members enter member
                     members enter sym
+                    }
+                  } else {
+                    var prevEntry = members.lookupEntry(sym.name)
+                    var symtpe: Type = null
+                    while ((prevEntry ne null) &&
+                           !((prevEntry.sym eq sym) ||
+                             (prevEntry.sym.owner ne sym.owner) &&
+                             (flags & PRIVATE) == 0 && {
+                               if (self eq null) self = this.narrow
+                               if (symtpe eq null) symtpe = self.memberType(sym)
+                               self.memberType(prevEntry.sym) matches symtpe
+                             })) {
+                      prevEntry = members lookupNextEntry prevEntry
+                    }
+                    if (prevEntry eq null) {
+                      members enter sym
+                    }
                   }
-                } else {
-                  var prevEntry = members.lookupEntry(sym.name)
-                  var symtpe: Type = null
-                  while ((prevEntry ne null) &&
-                         !((prevEntry.sym eq sym) ||
-                           (prevEntry.sym.owner ne sym.owner) &&
-                           !sym.hasFlag(PRIVATE) && {
-                             if (self eq null) self = this.narrow
-                             if (symtpe eq null) symtpe = self.memberType(sym)
-                             self.memberType(prevEntry.sym) matches symtpe
-                           })) {
-                    prevEntry = members lookupNextEntry prevEntry
-                  }
-                  if (prevEntry eq null) {
-                    members enter sym
-                  }
+                } else if (excl == DEFERRED) {
+                  continue = true
                 }
-              } else if (excl == DEFERRED.toLong) {
-                continue = true
               }
-            }
-            entry = if (name == nme.ANYNAME) entry.next else decls lookupNextEntry entry
-          } // while (entry ne null)
+              entry = decls lookupNextEntry entry
+            } // while (entry ne null)
+          } // if (fingerPrint matches)
           // excluded = excluded | LOCAL
           bcs = if (name == nme.CONSTRUCTOR) Nil else bcs.tail
         } // while (!bcs.isEmpty)

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1032,21 +1032,10 @@ trait Types extends api.Types { self: SymbolTable =>
 
       //Console.println("find member " + name.decode + " in " + this + ":" + this.baseClasses)//DEBUG
       var members: Scope = null
-      var membertpes: mutable.Map[Symbol, Type] = null
       var required = requiredFlags
       var excluded = excludedFlags | DEFERRED
       var continue = true
       var self: Type = null
-
-      def getMtpe(cache: mutable.Map[Symbol, Type], sym: Symbol): Type = cache get sym match {
-        case Some(tpe) if tpe ne null =>
-          tpe
-        case _ =>
-          val result = self memberType sym
-          cache(sym) = result
-          result
-      }
-
       while (continue) {
         continue = false
         val bcs0 = baseClasses
@@ -1064,10 +1053,7 @@ trait Types extends api.Types { self: SymbolTable =>
                    (bcs eq bcs0) ||
                    (flags & PrivateLocal) != PrivateLocal ||
                    (bcs0.head.hasTransOwner(bcs.head)))) {
-                if (members eq null) {
-                  members = newScope
-                  membertpes = new mutable.HashMap
-                }
+                if (members eq null) members = newScope
                 var others: ScopeEntry = members.lookupEntry(sym.name)
                 var symtpe: Type = null
                 while ((others ne null) && {
@@ -1077,7 +1063,7 @@ trait Types extends api.Types { self: SymbolTable =>
                           (flags & PRIVATE) != 0 || {
                              if (self eq null) self = this.narrow
                              if (symtpe eq null) symtpe = self.memberType(sym)
-                             !(getMtpe(membertpes, other) matches symtpe)
+                             !(self.memberType(other) matches symtpe)
                           })}) {
                   others = members lookupNextEntry others
                 }
@@ -1092,7 +1078,7 @@ trait Types extends api.Types { self: SymbolTable =>
           bcs = bcs.tail
         } // while (!bcs.isEmpty)
         required |= DEFERRED
-        excluded = excludedFlags
+        excluded &= ~(DEFERRED.toLong)
       } // while (continue)
       Statistics.popTimer(typeOpsStack, start)
       if (suspension ne null) suspension foreach (_.suspended = false)
@@ -1125,31 +1111,11 @@ trait Types extends api.Types { self: SymbolTable =>
       var members: List[Symbol] = null
       var lastM: ::[Symbol] = null
       var membertpe: Type = null
-      var membertpes: Array[Type] = null
       var required = requiredFlags
       var excluded = excludedFlags | DEFERRED
       var continue = true
       var self: Type = null
       val fingerPrint: Long = name.fingerPrint
-
-      def getMtpe(idx: Int, sym: Symbol): Type = {
-        var result = membertpes(idx)
-        if (result eq null) {
-          result = self memberType sym
-          membertpes(idx) = result
-        }
-        result
-      }
-
-      def addMtpe(xs: Array[Type], idx: Int, tpe: Type): Array[Type] =
-        if (idx < xs.length) {
-          xs(idx) = tpe
-          xs
-        } else {
-          val ys = new Array[Type](xs.length * 2)
-          Array.copy(xs, 0, ys, 0, xs.length)
-          addMtpe(ys, idx, tpe)
-        }
 
       while (continue) {
         continue = false
@@ -1176,24 +1142,18 @@ trait Types extends api.Types { self: SymbolTable =>
                   } else if (member eq NoSymbol) {
                     member = sym
                   } else if (members eq null) {
-                    var symtpe: Type = null
                     if ((member ne sym) &&
                         ((member.owner eq sym.owner) ||
                          (flags & PRIVATE) != 0 || {
                            if (self eq null) self = this.narrow
                            if (membertpe eq null) membertpe = self.memberType(member)
-                           symtpe = self.memberType(sym)
-                           !(membertpe matches symtpe)
+                           !(membertpe matches self.memberType(sym))
                          })) {
                       lastM = new ::(sym, null)
                       members = member :: lastM
-                      membertpes = new Array[Type](8)
-                      membertpes(0) = membertpe
-                      membertpes(1) = symtpe
                     }
                   } else {
                     var others: List[Symbol] = members
-                    var idx = 0
                     var symtpe: Type = null
                     while ((others ne null) && {
                              val other = others.head
@@ -1202,16 +1162,14 @@ trait Types extends api.Types { self: SymbolTable =>
                               (flags & PRIVATE) != 0 || {
                                 if (self eq null) self = this.narrow
                                 if (symtpe eq null) symtpe = self.memberType(sym)
-                                !(getMtpe(idx, other) matches symtpe)
+                                !(self.memberType(other) matches symtpe)
                              })}) {
                       others = others.tail
-                      idx += 1
                     }
                     if (others eq null) {
                       val lastM1 = new ::(sym, null)
                       lastM.tl = lastM1
                       lastM = lastM1
-                      membertpes = addMtpe(membertpes, idx, symtpe)
                     }
                   }
                 } else if (excl == DEFERRED) {
@@ -1225,7 +1183,7 @@ trait Types extends api.Types { self: SymbolTable =>
           bcs = if (name == nme.CONSTRUCTOR) Nil else bcs.tail
         } // while (!bcs.isEmpty)
         required |= DEFERRED
-        excluded = excludedFlags
+        excluded &= ~(DEFERRED.toLong)
       } // while (continue)
       Statistics.popTimer(typeOpsStack, start)
       if (suspension ne null) suspension foreach (_.suspended = false)

--- a/src/reflect/scala/reflect/runtime/SymbolLoaders.scala
+++ b/src/reflect/scala/reflect/runtime/SymbolLoaders.scala
@@ -99,8 +99,10 @@ trait SymbolLoaders { self: SymbolTable =>
     0 < dp && dp < (name.length - 1)
   }
 
-  class PackageScope(pkgClass: Symbol) extends Scope() with SynchronizedScope {
+  class PackageScope(pkgClass: Symbol) extends Scope(initFingerPrints = -1L) // disable fingerprinting as we do not know entries beforehand
+      with SynchronizedScope {
     assert(pkgClass.isType)
+    // disable fingerprinting as we do not know entries beforehand
     private val negatives = mutable.Set[Name]() // Syncnote: Performance only, so need not be protected.
     override def lookupEntry(name: Name): ScopeEntry = {
       val e = super.lookupEntry(name)


### PR DESCRIPTION
resubmission of #905

From its description:

findMember takes about 30% of typechecking aggregate, 20% if we discount nested calls to asSeenFrom.
I have tried ten different things to make it faster. The end result is less impressive than I had hoped for. I get about 16% reduction in wall-clock time for findMember, but my timings might be off. Still, every small improvement is worth it.

I left all 10 changes as separate commits, so that we have a chance of measuring what works and what doesn't when Greg's benchmarking code is done.

review by @odersky 
