### PR TITLE
Closes SI-6072, crasher with overloaded eq.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Mixin.scala
+++ b/src/compiler/scala/tools/nsc/transform/Mixin.scala
@@ -868,7 +868,7 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
         rhs match {
           case Block(List(assign), returnTree) =>
             val Assign(moduleVarRef, _) = assign
-            val cond                    = Apply(Select(moduleVarRef, nme.eq), List(NULL))
+            val cond                    = Apply(Select(moduleVarRef, Object_eq), List(NULL))
             mkFastPathBody(clazz, moduleSym, cond, List(assign), List(NULL), returnTree, attrThis, args)
           case _ =>
             assert(false, "Invalid getter " + rhs + " for module in class " + clazz)

--- a/test/files/pos/t6072.scala
+++ b/test/files/pos/t6072.scala
@@ -1,0 +1,3 @@
+class A {
+  object B { def eq(lvl: Int) = ??? }
+}


### PR DESCRIPTION
You don't want to do name-based selections in later phases
if you can help it, because there is nobody left to resolve
your overloads.  If as in this example you're calling a
known method, use the symbol.  Review by @hubertp.
