### PR TITLE
Fixed SI-6092. Fixed leaky annotations

### DIFF
--- a/src/reflect/scala/reflect/internal/AnnotationInfos.scala
+++ b/src/reflect/scala/reflect/internal/AnnotationInfos.scala
@@ -160,12 +160,7 @@ trait AnnotationInfos extends api.AnnotationInfos { self: SymbolTable =>
    */
   final class LazyAnnotationInfo(lazyInfo: => AnnotationInfo) extends AnnotationInfo {
     private var forced = false
-    private lazy val forcedInfo =
-      try {
-        val result = lazyInfo
-        if (result.pos == NoPosition) result setPos pos
-        result
-      } finally forced = true
+    private lazy val forcedInfo = try lazyInfo finally forced = true
 
     def atp: Type                               = forcedInfo.atp
     def args: List[Tree]                        = forcedInfo.args

--- a/test/files/run/nullable-lazyvals.check
+++ b/test/files/run/nullable-lazyvals.check
@@ -1,0 +1,3 @@
+
+param1: null
+param2: null

--- a/test/files/run/nullable-lazyvals.scala
+++ b/test/files/run/nullable-lazyvals.scala
@@ -1,0 +1,36 @@
+
+/** Test that call-by-name parameters are set to null if
+ *  they are used only to initialize a lazy value, after the
+ *  value has been initialized.
+ */
+
+class Foo(param1: => Object, param2: => String) {
+	lazy val field1 = param1
+	lazy val field2 = try param2 finally println("")
+}
+
+object Test extends App {
+	val foo = new Foo(new Object, "abc")
+
+	foo.field1
+	foo.field2
+
+	for (f <- foo.getClass.getDeclaredFields) {
+		f.setAccessible(true)
+		if (f.getName.startsWith("param")) {
+			println("%s: %s".format(f.getName, f.get(foo)))
+		}
+	}
+
+	// test that try-finally does not generated a liftedTry
+	// helper. This would already fail the first part of the test,
+	// but this check will help diganose it (if the single access to a
+	// private field does not happen directly in the lazy val, it won't
+	// be nulled).
+	for (f <- foo.getClass.getDeclaredMethods) {
+		f.setAccessible(true)
+		if (f.getName.startsWith("lifted")) {
+			println("not expected: %s".format(f))
+		}
+	}
+}


### PR DESCRIPTION
and relaxed the conditions under which a try-catch is lifted out to an inner method.

Less known fact: lazy values null-out their dependent values is they're accessed only from
their initializer. The analysis is not context-dependent (meaning the owner where a reference
happens needs to be exactly that lazy value).
- Removed no-op code around positions in `LazyAnnotationInfo`
- Don't lift expressions that have no `catch` clause

The two changes combined fix a memory leak that's been plaguing the IDE: an annotation
(even when forced) would hang on to a namer, through the outer field of its call-by-name
parameter.

The memory leak test is in the IDE project (couldn't find a simple way to reproduce it outside
the IDE). I added a test to make sure the field is nulled after the lazy val is initialized.
