### PR TITLE
Fix for SI-5385.

### DIFF
--- a/src/partest/scala/tools/partest/DirectTest.scala
+++ b/src/partest/scala/tools/partest/DirectTest.scala
@@ -38,7 +38,8 @@ abstract class DirectTest extends App {
   // new compiler
   def newCompiler(args: String*): Global = {
     val settings = newSettings((CommandLineParser tokenize extraSettings) ++ args.toList)
-    new Global(settings)
+    if (settings.Yrangepos.value) new Global(settings) with interactive.RangePositions
+    else new Global(settings)
   }
   def newSources(sourceCodes: String*) = sourceCodes.toList.zipWithIndex map {
     case (src, idx) => new BatchSourceFile("newSource" + (idx + 1), src)
@@ -69,7 +70,7 @@ abstract class DirectTest extends App {
 
   /**  Constructor/main body  **/
   try show()
-  catch { case t => println(t) ; t.printStackTrace ; sys.exit(1) }
+  catch { case t => println(t.getMessage) ; t.printStackTrace ; sys.exit(1) }
 
   /** Debugger interest only below this line **/
   protected def isDebug       = (sys.props contains "partest.debug") || (sys.env contains "PARTEST_DEBUG")

--- a/src/reflect/scala/tools/nsc/io/VirtualFile.scala
+++ b/src/reflect/scala/tools/nsc/io/VirtualFile.scala
@@ -55,7 +55,7 @@ class VirtualFile(val name: String, override val path: String) extends AbstractF
     }
   }
 
-  def container: AbstractFile =  unsupported
+  def container: AbstractFile = NoAbstractFile
 
   /** Is this abstract file a directory? */
   def isDirectory: Boolean = false

--- a/test/files/neg/t4069.check
+++ b/test/files/neg/t4069.check
@@ -12,5 +12,5 @@ t4069.scala:4: error:  I encountered a '}' where I didn't expect one, maybe this
              ^
 t4069.scala:10: error: '}' expected but eof found.
 }
-^
+ ^
 5 errors found

--- a/test/files/neg/t4584.check
+++ b/test/files/neg/t4584.check
@@ -1,4 +1,7 @@
-t4584.scala:1: error: incomplete unicode escape
+t4584.scala:1: error: error in unicode escape
+class A { val /u2
+                 ^
+t4584.scala:1: error: illegal character '/uffff'
 class A { val /u2
                 ^
-one error found
+two errors found

--- a/test/files/neg/unicode-unterminated-quote.check
+++ b/test/files/neg/unicode-unterminated-quote.check
@@ -1,4 +1,7 @@
 unicode-unterminated-quote.scala:2: error: unclosed string literal
   val x = /u0022
                ^
-one error found
+unicode-unterminated-quote.scala:2: error: '}' expected but eof found.
+  val x = /u0022
+                ^
+two errors found

--- a/test/files/run/t5385.check
+++ b/test/files/run/t5385.check
@@ -1,0 +1,8 @@
+[0:9]           class Azz
+[0:9]           class Bzz
+[0:9]           class Czz
+[0:9]           class Dzz
+[0:11]          class Ezz
+[0:11]          class Fzz
+[0:13]          class Gzz
+[0:13]          class Hzz

--- a/test/files/run/t5385.scala
+++ b/test/files/run/t5385.scala
@@ -1,0 +1,16 @@
+import scala.tools.partest._
+
+object Test extends CompilerTest {
+  import global._
+  override def extraSettings = super.extraSettings + " -Yrangepos"
+  override def sources = List(
+    "class Azz", "class Bzz ", "class Czz              ", "class Dzz\n",
+    "class Ezz{}", "class Fzz{} ", "class Gzz { }", "class Hzz { }            "
+  )
+  def check(source: String, unit: CompilationUnit) {
+    unit.body foreach {
+      case cdef: ClassDef => println("%-15s class %s".format(cdef.pos.show, cdef.name))
+      case _              =>
+    }
+  }
+}


### PR DESCRIPTION
Nodes which hit EOF with no whitespace afterward had
wrong position.

Stole commit from @paulp and adapted it to the current state of master. Needed to fix DirectTest as the original commit assumed that we only produce range positions.

Review by @paulp and @dotta.
