### PR TITLE
fixes a typo in macro classloaders

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -26,7 +26,7 @@ import java.lang.reflect.{Array => jArray, Method => jMethod}
  *    def fooBar[T: c.TypeTag]
  *           (c: scala.reflect.makro.Context)
  *           (xs: c.Expr[List[T]])
- *           : c.Tree = {
+ *           : c.Expr[T] = {
  *      ...
  *    }
  *
@@ -601,7 +601,7 @@ trait Macros extends scala.tools.reflect.FastTrack with Traces {
 
     if (settings.XmacroPrimaryClasspath.value != "") {
       macroLogVerbose("primary macro classloader: initializing from -Xmacro-primary-classpath: %s".format(settings.XmacroPrimaryClasspath.value))
-      val classpath = toURLs(settings.XmacroFallbackClasspath.value)
+      val classpath = toURLs(settings.XmacroPrimaryClasspath.value)
       ScalaClassLoader.fromURLs(classpath, self.getClass.getClassLoader)
     } else {
       macroLogVerbose("primary macro classloader: initializing from -cp: %s".format(global.classPath.asURLs))


### PR DESCRIPTION
Primary should be here, because a test a few lines up checks whether
primary != "". Hence usage of fallback here is just a typo.

Primary and fallback classpaths were designed for situations when library
classpath are not enough (e.g. for bootstrapping libraries that don't get
onto tool classpaths). Originally I planned to use them to bootstrap
scala-library, however, there's always a starr/locker on a tool classpath,
so we don't need special treatment of this case. After I realized that, I
decided to keep advanced classpath switches, because others might not be as
lucky as we are.
