### PR TITLE
SI-5856 enables use of $this in string interpolation

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1169,7 +1169,12 @@ self =>
           if (inPattern) dropAnyBraces(pattern())
           else {
             if (in.token == IDENTIFIER) atPos(in.offset)(Ident(ident()))
-            else expr()
+            else if(in.token == LBRACE) expr()
+            else if(in.token == THIS) { in.nextToken(); atPos(in.offset)(This(tpnme.EMPTY)) }
+            else {
+               syntaxErrorOrIncomplete("error in interpolated string: identifier or block expected", true)
+               EmptyTree
+            }
           }
         }
       }

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -734,7 +734,7 @@ trait Scanners extends ScannersCommon {
             next.token = kwArray(idx)
           }
         } else {
-          syntaxError("invalid string interpolation: $$, $ident or $block expected")
+          syntaxError("invalid string interpolation: `$$', `$'ident or `$'BlockExpr expected")
         }
       } else {
         val isUnclosedLiteral = !isUnicodeEscape && (ch == SU || (!multiLine && (ch == CR || ch == LF)))

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -729,8 +729,12 @@ trait Scanners extends ScannersCommon {
           next.token = IDENTIFIER
           next.name = newTermName(cbuf.toString)
           cbuf.clear()
+          val idx = next.name.start - kwOffset
+          if (idx >= 0 && idx < kwArray.length) {
+            next.token = kwArray(idx)
+          }
         } else {
-          syntaxError("invalid string interpolation")
+          syntaxError("invalid string interpolation: $$, $ident or $block expected")
         }
       } else {
         val isUnclosedLiteral = !isUnicodeEscape && (ch == SU || (!multiLine && (ch == CR || ch == LF)))

--- a/test/files/neg/t5856.check
+++ b/test/files/neg/t5856.check
@@ -1,4 +1,4 @@
-t5856.scala:10: error: invalid string interpolation: $$, $ident or $block expected
+t5856.scala:10: error: invalid string interpolation: `$$', `$'ident or `$'BlockExpr expected
   val s9 = s"$"
             ^
 t5856.scala:10: error: unclosed string literal

--- a/test/files/neg/t5856.check
+++ b/test/files/neg/t5856.check
@@ -1,0 +1,31 @@
+t5856.scala:10: error: invalid string interpolation: $$, $ident or $block expected
+  val s9 = s"$"
+            ^
+t5856.scala:10: error: unclosed string literal
+  val s9 = s"$"
+              ^
+t5856.scala:2: error: error in interpolated string: identifier or block expected
+  val s1 = s"$null"
+              ^
+t5856.scala:3: error: error in interpolated string: identifier or block expected
+  val s2 = s"$false"
+              ^
+t5856.scala:4: error: error in interpolated string: identifier or block expected
+  val s3 = s"$true"
+              ^
+t5856.scala:5: error: error in interpolated string: identifier or block expected
+  val s4 = s"$yield"
+              ^
+t5856.scala:6: error: error in interpolated string: identifier or block expected
+  val s5 = s"$return"
+              ^
+t5856.scala:7: error: error in interpolated string: identifier or block expected
+  val s6 = s"$new"
+              ^
+t5856.scala:8: error: error in interpolated string: identifier or block expected
+  val s7 = s"$s1 $null $super"
+                  ^
+t5856.scala:9: error: error in interpolated string: identifier or block expected
+  val s8 = s"$super"
+              ^
+10 errors found

--- a/test/files/neg/t5856.scala
+++ b/test/files/neg/t5856.scala
@@ -1,0 +1,11 @@
+object Test {
+  val s1 = s"$null"
+  val s2 = s"$false"
+  val s3 = s"$true"
+  val s4 = s"$yield"
+  val s5 = s"$return"
+  val s6 = s"$new"
+  val s7 = s"$s1 $null $super"
+  val s8 = s"$super"
+  val s9 = s"$"
+}

--- a/test/files/run/t5856.scala
+++ b/test/files/run/t5856.scala
@@ -1,0 +1,10 @@
+object Test extends App {
+  override def toString = "Test"
+
+  assert(s"$this" == "Test")
+  assert(s"$this$this" == "TestTest")
+  assert(s"$this$$" == "Test$")
+  assert(s"$this.##" == "Test.##")
+  assert(s"$this.toString" == "Test.toString")
+  assert(s"$this=THIS" == "Test=THIS")
+}


### PR DESCRIPTION
Review: @xeno-by and @cvogt

This pull request fixes SI-5856. The scanner has been modified
to return the correct token if keywords appear in $-expressions.
The parser has been modified to issue an error and to only accept
$<identifier>, $this and $block.
