### PR TITLE
Add an implicit parameter to `par` in collections.

### DIFF
--- a/src/library/scala/collection/CustomParallelizable.scala
+++ b/src/library/scala/collection/CustomParallelizable.scala
@@ -9,9 +9,10 @@
 package scala.collection
 
 import parallel.Combiner
+import parallel.TaskSupport
 
 trait CustomParallelizable[+A, +ParRepr <: Parallel] extends Parallelizable[A, ParRepr] {
-  override def par: ParRepr
+  override def par(implicit ts: TaskSupport): ParRepr
   override protected[this] def parCombiner: Combiner[A, ParRepr] = throw new UnsupportedOperationException("")
 }
 

--- a/src/library/scala/collection/Parallelizable.scala
+++ b/src/library/scala/collection/Parallelizable.scala
@@ -9,6 +9,8 @@
 package scala.collection
 
 import parallel.Combiner
+import parallel.TaskSupport
+import parallel.setTaskSupport
 
 /** This trait describes collections which can be turned into parallel collections
  *  by invoking the method `par`. Parallelizable collections may be parametrized with
@@ -36,10 +38,10 @@ trait Parallelizable[+A, +ParRepr <: Parallel] extends Any {
    *
    *  @return  a parallel implementation of this collection
    */
-  def par: ParRepr = {
+  def par(implicit tasksupport: TaskSupport): ParRepr = {
     val cb = parCombiner
     for (x <- seq) cb += x
-    cb.result
+    setTaskSupport(cb.result, tasksupport)
   }
 
   /** The default `par` implementation uses the combiner provided by this method

--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -13,6 +13,8 @@ package concurrent
 
 import java.util.concurrent.atomic._
 import collection.immutable.{ ListMap => ImmutableListMap }
+import collection.parallel.TaskSupport
+import collection.parallel.setTaskSupport
 import collection.parallel.mutable.ParTrieMap
 import util.hashing.Hashing
 import generic._
@@ -780,7 +782,7 @@ extends scala.collection.concurrent.Map[K, V]
 
   override def seq = this
 
-  override def par = new ParTrieMap(this)
+  override def par(implicit ts: TaskSupport) = setTaskSupport(new ParTrieMap(this), ts)
 
   override def empty: TrieMap[K, V] = new TrieMap[K, V]
 

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -11,6 +11,8 @@ package immutable
 
 import generic._
 import annotation.unchecked.{ uncheckedVariance=> uV }
+import parallel.TaskSupport
+import parallel.setTaskSupport
 import parallel.immutable.ParHashMap
 
 /** This class implements immutable maps using a hash trie.
@@ -117,7 +119,7 @@ class HashMap[A, +B] extends AbstractMap[A, B]
   
   protected def merge0[B1 >: B](that: HashMap[A, B1], level: Int, merger: Merger[A, B1]): HashMap[A, B1] = that
 
-  override def par = ParHashMap.fromTrie(this)
+  override def par(implicit ts: TaskSupport) = setTaskSupport(ParHashMap.fromTrie(this), ts)
 
 }
 

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -14,6 +14,8 @@ package immutable
 import annotation.unchecked.{ uncheckedVariance => uV }
 import generic._
 import collection.parallel.immutable.ParHashSet
+import collection.parallel.TaskSupport
+import collection.parallel.setTaskSupport
 
 /** This class implements immutable sets using a hash trie.
  *
@@ -40,7 +42,7 @@ class HashSet[A] extends AbstractSet[A]
 
   //class HashSet[A] extends Set[A] with SetLike[A, HashSet[A]] {
 
-  override def par = ParHashSet.fromTrie(this)
+  override def par(implicit ts: TaskSupport) = setTaskSupport(ParHashSet.fromTrie(this), ts)
 
   override def size: Int = 0
 

--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -10,6 +10,8 @@
 package scala.collection.immutable
 
 import scala.collection.parallel.immutable.ParRange
+import scala.collection.parallel.TaskSupport
+import scala.collection.parallel.setTaskSupport
 
 /** The `Range` class represents integer values in range
  *  ''[start;end)'' with non-zero step value `step`.
@@ -48,7 +50,7 @@ extends collection.AbstractSeq[Int]
    with collection.CustomParallelizable[Int, ParRange]
    with Serializable
 {
-  override def par = new ParRange(this)
+  override def par(implicit ts: TaskSupport) = setTaskSupport(new ParRange(this), ts)
 
   private def gap           = end.toLong - start.toLong
   private def isExact       = gap % step == 0

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -14,6 +14,8 @@ import compat.Platform
 import scala.collection.generic._
 import scala.collection.mutable.Builder
 import scala.collection.parallel.immutable.ParVector
+import scala.collection.parallel.TaskSupport
+import scala.collection.parallel.setTaskSupport
 
 /** Companion object to the Vector class
  */
@@ -75,7 +77,7 @@ override def companion: GenericCompanion[Vector] = Vector
 
   def length = endIndex - startIndex
 
-  override def par = new ParVector(this)
+  override def par(implicit ts: TaskSupport) = setTaskSupport(new ParVector(this), ts)
 
   override def toVector: Vector[A] = this
 

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -13,6 +13,8 @@ package mutable
 
 import generic._
 import parallel.mutable.ParArray
+import parallel.TaskSupport
+import parallel.setTaskSupport
 
 /** An implementation of the `Buffer` class using an array to
  *  represent the assembled sequence internally. Append, update and random
@@ -71,7 +73,7 @@ class ArrayBuffer[A](override protected val initialSize: Int)
     }
   }
 
-  override def par = ParArray.handoff[A](array.asInstanceOf[Array[A]], size)
+  override def par(implicit ts: TaskSupport) = setTaskSupport(ParArray.handoff[A](array.asInstanceOf[Array[A]], size), ts)
 
   /** Appends a single element to this buffer and returns
    *  the identity of the buffer. It takes constant amortized time.

--- a/src/library/scala/collection/mutable/ArrayOps.scala
+++ b/src/library/scala/collection/mutable/ArrayOps.scala
@@ -16,6 +16,8 @@ import scala.reflect.ClassTag
 import scala.runtime.ScalaRunTime._
 
 import parallel.mutable.ParArray
+import parallel.TaskSupport
+import parallel.setTaskSupport
 
 
 /** This class serves as a wrapper for `Array`s with all the operations found in
@@ -55,7 +57,7 @@ abstract class ArrayOps[T] extends ArrayLike[T, Array[T]] with CustomParalleliza
       super.toArray[U]
   }
 
-  override def par = ParArray.handoff(repr)
+  override def par(implicit ts: TaskSupport) = setTaskSupport(ParArray.handoff(repr), ts)
 
   /** Flattens a two-dimensional array by concatenating all its rows
    *  into a single array.

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -13,6 +13,8 @@ package mutable
 
 import generic._
 import parallel.mutable.ParArray
+import parallel.TaskSupport
+import parallel.setTaskSupport
 
 /** A class for polymorphic arrays of elements that's represented
  *  internally by an array of objects. This means that elements of
@@ -55,7 +57,7 @@ extends AbstractSeq[A]
 
   val array: Array[AnyRef] = new Array[AnyRef](length)
 
-  override def par = ParArray.handoff(array.asInstanceOf[Array[A]], length)
+  override def par(implicit ts: TaskSupport) = setTaskSupport(ParArray.handoff(array.asInstanceOf[Array[A]], length), ts)
 
   def apply(idx: Int): A = {
     if (idx >= length) throw new IndexOutOfBoundsException(idx.toString)

--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -11,6 +11,8 @@ package mutable
 
 import generic._
 import scala.collection.parallel.mutable.ParHashMap
+import scala.collection.parallel.TaskSupport
+import scala.collection.parallel.setTaskSupport
 
 /** This class implements mutable maps using a hashtable.
  *
@@ -54,7 +56,7 @@ extends AbstractMap[A, B]
 
   def this() = this(null)
 
-  override def par = new ParHashMap[A, B](hashTableContents)
+  override def par(implicit ts: TaskSupport) = setTaskSupport(new ParHashMap[A, B](hashTableContents), ts)
 
   // contains and apply overridden to avoid option allocations.
   override def contains(key: A) = findEntry(key) != null

--- a/src/library/scala/collection/mutable/HashSet.scala
+++ b/src/library/scala/collection/mutable/HashSet.scala
@@ -13,6 +13,8 @@ package mutable
 
 import generic._
 import collection.parallel.mutable.ParHashSet
+import collection.parallel.TaskSupport
+import collection.parallel.setTaskSupport
 
 /** This class implements mutable sets using a hashtable.
  *
@@ -61,7 +63,7 @@ extends AbstractSet[A]
 
   def -= (elem: A): this.type = { removeEntry(elem); this }
 
-  override def par = new ParHashSet(hashTableContents)
+  override def par(implicit ts: TaskSupport) = setTaskSupport(new ParHashSet(hashTableContents), ts)
 
   override def add(elem: A): Boolean = addEntry(elem)
 

--- a/src/library/scala/collection/mutable/WrappedArray.scala
+++ b/src/library/scala/collection/mutable/WrappedArray.scala
@@ -15,6 +15,8 @@ import scala.reflect.ClassTag
 import scala.runtime.ScalaRunTime._
 import scala.collection.generic._
 import scala.collection.parallel.mutable.ParArray
+import scala.collection.parallel.TaskSupport
+import scala.collection.parallel.setTaskSupport
 
 /**
  *  A class representing `Array[T]`.
@@ -59,7 +61,7 @@ extends AbstractSeq[T]
   /** The underlying array */
   def array: Array[T]
 
-  override def par = ParArray.handoff(array)
+  override def par(implicit ts: TaskSupport) = setTaskSupport(ParArray.handoff(array), ts)
 
   private def elementClass: Class[_] =
     arrayElementClass(repr.getClass)

--- a/src/library/scala/collection/parallel/Combiner.scala
+++ b/src/library/scala/collection/parallel/Combiner.scala
@@ -36,7 +36,7 @@ trait Combiner[-Elem, +To] extends Builder[Elem, To] with Sizing with Parallel {
   
   @transient
   @volatile
-  var _combinerTaskSupport = defaultTaskSupport
+  private[parallel] var _combinerTaskSupport = defaultTaskSupport
   
   def combinerTaskSupport = {
     val cts = _combinerTaskSupport
@@ -46,7 +46,7 @@ trait Combiner[-Elem, +To] extends Builder[Elem, To] with Sizing with Parallel {
     } else cts
   }
   
-  def combinerTaskSupport_=(cts: TaskSupport) = _combinerTaskSupport = cts
+  private[parallel] def combinerTaskSupport_=(cts: TaskSupport) = _combinerTaskSupport = cts
   
   /** Combines the contents of the receiver builder and the `other` builder,
    *  producing a new builder containing both their elements.

--- a/src/library/scala/collection/parallel/ParIterableLike.scala
+++ b/src/library/scala/collection/parallel/ParIterableLike.scala
@@ -129,6 +129,19 @@ import language.implicitConversions
  *  Method `size` is implemented as a constant time operation for parallel collections, and parallel collection
  *  operations rely on this assumption.
  *
+ *  A task support object can be set to a parallel collection when it is created.
+ *  Here is a way to change the task support of a parallel collection:
+ *  
+ *  {{{
+ *  import scala.collection.parallel._
+ *  implicit val myTaskSupport = new ForkJoinTaskSupport(
+ *    new scala.concurrent.forkjoin.ForkJoinPool(2))
+ *  val pc = Array(1, 2, 3).par
+ *  }}}
+ *
+ *  Clients should import `scala.collection.parallel.Implicits.defaultTaskSupport` to
+ *  use the default task support with `par`.
+ *  
  *  @author Aleksandar Prokopec
  *  @since 2.9
  *
@@ -185,22 +198,12 @@ self: ParIterableLike[T, Repr, Sequential] =>
   /** Changes the task support object which is responsible for scheduling and
    *  load-balancing tasks to processors.
    *
-   *  A task support object can be changed in a parallel collection after it
-   *  has been created, but only during a quiescent period, i.e. while there
-   *  are no concurrent invocations to parallel collection methods.
-   *                                                                              
-   *  Here is a way to change the task support of a parallel collection:          
-   *                                                                              
-   *  {{{                                                                         
-   *  import scala.collection.parallel._                                          
-   *  val pc = mutable.ParArray(1, 2, 3)                                          
-   *  pc.tasksupport = new ForkJoinTaskSupport(                                   
-   *    new scala.concurrent.forkjoin.ForkJoinPool(2))                            
-   *  }}}                                                                         
-   *
+   *  This method is used internally by the framework. Clients should specify
+   *  the task support when creating the parallel collection with a `par` method.
+   *  
    *  @see [[scala.collection.parallel.TaskSupport]]
    */     
-  def tasksupport_=(ts: TaskSupport) = _tasksupport = ts
+  private[parallel] def tasksupport_=(ts: TaskSupport) = _tasksupport = ts
 
   def seq: Sequential
 
@@ -246,7 +249,7 @@ self: ParIterableLike[T, Repr, Sequential] =>
    */
   def iterator: Splitter[T] = splitter
 
-  override def par: Repr = repr
+  override def par(implicit ts: TaskSupport): Repr = if (ts eq tasksupport) repr else seq.par(ts).asInstanceOf[Repr]
 
   /** Denotes whether this parallel collection has strict splitters.
    *
@@ -339,11 +342,11 @@ self: ParIterableLike[T, Repr, Sequential] =>
   }
 
   protected[this] def bf2seq[S, That](bf: CanBuildFrom[Repr, S, That]) = new CanBuildFrom[Sequential, S, That] {
-    def apply(from: Sequential) = bf.apply(from.par.asInstanceOf[Repr]) // !!! we only use this on `this.seq`, and know that `this.seq.par.getClass == this.getClass`
+    def apply(from: Sequential) = bf.apply(from.par(tasksupport).asInstanceOf[Repr]) // !!! we only use this on `this.seq`, and know that `this.seq.par.getClass == this.getClass`
     def apply() = bf.apply()
   }
 
-  protected[this] def sequentially[S, That <: Parallel](b: Sequential => Parallelizable[S, That]) = b(seq).par.asInstanceOf[Repr]
+  protected[this] def sequentially[S, That <: Parallel](b: Sequential => Parallelizable[S, That]) = b(seq).par(tasksupport).asInstanceOf[Repr]
 
   def mkString(start: String, sep: String, end: String): String = seq.mkString(start, sep, end)
 
@@ -497,23 +500,14 @@ self: ParIterableLike[T, Repr, Sequential] =>
   def map[S, That](f: T => S)(implicit bf: CanBuildFrom[Repr, S, That]): That = if (bf(repr).isCombiner) {
     tasksupport.executeAndWaitResult(new Map[S, That](f, combinerFactory(() => bf(repr).asCombiner), splitter) mapResult { _.resultWithTaskSupport })
   } else setTaskSupport(seq.map(f)(bf2seq(bf)), tasksupport)
-  /*bf ifParallel { pbf =>
-    tasksupport.executeAndWaitResult(new Map[S, That](f, pbf, splitter) mapResult { _.result })
-  } otherwise seq.map(f)(bf2seq(bf))*/
 
   def collect[S, That](pf: PartialFunction[T, S])(implicit bf: CanBuildFrom[Repr, S, That]): That = if (bf(repr).isCombiner) {
     tasksupport.executeAndWaitResult(new Collect[S, That](pf, combinerFactory(() => bf(repr).asCombiner), splitter) mapResult { _.resultWithTaskSupport })
   } else setTaskSupport(seq.collect(pf)(bf2seq(bf)), tasksupport)
-  /*bf ifParallel { pbf =>
-    tasksupport.executeAndWaitResult(new Collect[S, That](pf, pbf, splitter) mapResult { _.result })
-  } otherwise seq.collect(pf)(bf2seq(bf))*/
 
   def flatMap[S, That](f: T => GenTraversableOnce[S])(implicit bf: CanBuildFrom[Repr, S, That]): That = if (bf(repr).isCombiner) {
     tasksupport.executeAndWaitResult(new FlatMap[S, That](f, combinerFactory(() => bf(repr).asCombiner), splitter) mapResult { _.resultWithTaskSupport })
   } else setTaskSupport(seq.flatMap(f)(bf2seq(bf)), tasksupport)
-  /*bf ifParallel { pbf =>
-    tasksupport.executeAndWaitResult(new FlatMap[S, That](f, pbf, splitter) mapResult { _.result })
-  } otherwise seq.flatMap(f)(bf2seq(bf))*/
 
   /** Tests whether a predicate holds for all elements of this $coll.
    *
@@ -565,26 +559,26 @@ self: ParIterableLike[T, Repr, Sequential] =>
    */
   protected[this] def combinerFactory = {
     val combiner = newCombiner
-    combiner.combinerTaskSupport = tasksupport
     if (combiner.canBeShared) new CombinerFactory[T, Repr] {
-      val shared = combiner
+      val shared = setTaskSupport(combiner, tasksupport)
       def apply() = shared
       def doesShareCombiners = true
     } else new CombinerFactory[T, Repr] {
-      def apply() = newCombiner
+      def apply() = setTaskSupport(newCombiner, tasksupport)
       def doesShareCombiners = false
     }
   }
 
   protected[this] def combinerFactory[S, That](cbf: () => Combiner[S, That]) = {
     val combiner = cbf()
-    combiner.combinerTaskSupport = tasksupport
     if (combiner.canBeShared) new CombinerFactory[S, That] {
-      val shared = combiner
+      val shared = setTaskSupport(combiner, tasksupport)
       def apply() = shared
       def doesShareCombiners = true
     } else new CombinerFactory[S, That] {
-      def apply() = cbf()
+      def apply() = {
+        setTaskSupport(cbf(), tasksupport)
+      }
       def doesShareCombiners = false
     }
   }

--- a/src/library/scala/collection/parallel/TaskSupport.scala
+++ b/src/library/scala/collection/parallel/TaskSupport.scala
@@ -55,7 +55,8 @@ import scala.annotation.implicitNotFound
  *  @see [[http://docs.scala-lang.org/overviews/parallel-collections/configuration.html Configuring Parallel Collections]] section
  *    on the parallel collection's guide for more information.
  */
-@implicitNotFound(msg = "Cannot construct a parallel collection without a task support implementation in scope.")
+@implicitNotFound(msg = "Cannot construct a parallel collection without a task support implementation in scope. " +
+                  "To use the default, `import collection.parallel.Implicits.defaultTaskSupport`.")
 trait TaskSupport extends Tasks
 
 

--- a/src/library/scala/collection/parallel/TaskSupport.scala
+++ b/src/library/scala/collection/parallel/TaskSupport.scala
@@ -14,6 +14,7 @@ package scala.collection.parallel
 import java.util.concurrent.ThreadPoolExecutor
 import scala.concurrent.forkjoin.ForkJoinPool
 import scala.concurrent.ExecutionContext
+import scala.annotation.implicitNotFound
 
 
 
@@ -54,6 +55,7 @@ import scala.concurrent.ExecutionContext
  *  @see [[http://docs.scala-lang.org/overviews/parallel-collections/configuration.html Configuring Parallel Collections]] section
  *    on the parallel collection's guide for more information.
  */
+@implicitNotFound(msg = "Cannot construct a parallel collection without a task support implementation in scope.")
 trait TaskSupport extends Tasks
 
 

--- a/src/library/scala/collection/parallel/mutable/ParArray.scala
+++ b/src/library/scala/collection/parallel/mutable/ParArray.scala
@@ -23,6 +23,7 @@ import scala.collection.parallel.SeqSplitter
 import scala.collection.parallel.ParSeqLike
 import scala.collection.parallel.Task
 import scala.collection.parallel.CHECK_RATE
+import scala.collection.parallel.setTaskSupport
 import scala.collection.mutable.ArraySeq
 import scala.collection.mutable.Builder
 import scala.collection.GenTraversableOnce
@@ -591,7 +592,7 @@ self =>
     tasksupport.executeAndWaitResult(new Map[S](f, targetarr, 0, length))
 
     // wrap it into a parallel array
-    (new ParArray[S](targarrseq)).asInstanceOf[That]
+    setTaskSupport((new ParArray[S](targarrseq)).asInstanceOf[That], tasksupport)
   } else super.map(f)(bf)
 
   override def scan[U >: T, That](z: U)(op: (U, U) => U)(implicit cbf: CanBuildFrom[ParArray[T], U, That]): That =
@@ -607,7 +608,7 @@ self =>
       })
 
       // wrap the array into a parallel array
-      (new ParArray[U](targarrseq)).asInstanceOf[That]
+      setTaskSupport((new ParArray[U](targarrseq)).asInstanceOf[That], tasksupport)
     } else super.scan(z)(op)(cbf)
 
   /* tasks */

--- a/src/library/scala/collection/parallel/package.scala
+++ b/src/library/scala/collection/parallel/package.scala
@@ -49,9 +49,14 @@ package object parallel {
 
   val defaultTaskSupport: TaskSupport = getTaskSupport
   
+  object Implicits {
+    implicit def defaultTaskSupport = collection.parallel.defaultTaskSupport
+  }
+  
   def setTaskSupport[Coll](c: Coll, t: TaskSupport): Coll = {
     c match {
       case pc: ParIterableLike[_, _, _] => pc.tasksupport = t
+      case cb: Combiner[_, _] => cb.combinerTaskSupport = t
       case _ => // do nothing
     }
     c

--- a/test/files/run/ctries-new/concmap.scala
+++ b/test/files/run/ctries-new/concmap.scala
@@ -2,6 +2,7 @@
 
 
 import collection.concurrent.TrieMap
+import collection.parallel.Implicits.defaultTaskSupport
 
 
 object ConcurrentMapSpec extends Spec {

--- a/test/files/run/ctries-old/concmap.scala
+++ b/test/files/run/ctries-old/concmap.scala
@@ -2,6 +2,7 @@
 
 
 import collection.concurrent.TrieMap
+import collection.parallel.Implicits.defaultTaskSupport
 
 
 object ConcurrentMapSpec extends Spec {

--- a/test/files/run/parmap-ops.scala
+++ b/test/files/run/parmap-ops.scala
@@ -1,4 +1,8 @@
+
+
 import collection._
+import collection.parallel.Implicits.defaultTaskSupport
+
 
 object Test {
   

--- a/test/files/run/pc-conversions.scala
+++ b/test/files/run/pc-conversions.scala
@@ -1,6 +1,7 @@
 
 
 import collection._
+import collection.parallel.Implicits.defaultTaskSupport
 
 
 // test conversions between collections

--- a/test/files/run/t4459.scala
+++ b/test/files/run/t4459.scala
@@ -1,4 +1,6 @@
 import collection._
+import collection.parallel.Implicits.defaultTaskSupport
+
 
 object Test {
   def main(args: Array[String]) {

--- a/test/files/run/t4608.scala
+++ b/test/files/run/t4608.scala
@@ -1,3 +1,9 @@
+
+
+
+import collection.parallel.Implicits.defaultTaskSupport
+
+
 // #4608
 object Test {
   

--- a/test/files/run/t4761.scala
+++ b/test/files/run/t4761.scala
@@ -1,3 +1,9 @@
+
+
+
+import collection.parallel.Implicits.defaultTaskSupport
+
+
 object Test {
   def main(args: Array[String]) {
     val gs = for (x <- (1 to 5)) yield { if (x % 2 == 0) List(1).seq else List(1).par }

--- a/test/files/run/t4895.scala
+++ b/test/files/run/t4895.scala
@@ -1,3 +1,8 @@
+
+
+import collection.parallel.Implicits.defaultTaskSupport
+
+
 object Test {
   
   def checkPar(sz: Int) {

--- a/test/files/run/t5375.scala
+++ b/test/files/run/t5375.scala
@@ -2,6 +2,7 @@
 
 
 import collection.parallel.CompositeThrowable
+import collection.parallel.Implicits.defaultTaskSupport
 
 
 

--- a/test/files/run/t6052.scala
+++ b/test/files/run/t6052.scala
@@ -1,7 +1,7 @@
 
 
 
-
+import collection.parallel.Implicits.defaultTaskSupport
 
 
 

--- a/test/files/run/tasksupport.scala
+++ b/test/files/run/tasksupport.scala
@@ -1,0 +1,28 @@
+
+
+
+
+
+
+object Test extends App {
+  
+  def default() {
+    import collection.parallel.Implicits.defaultTaskSupport
+    val pc = Array(1, 2, 3).par
+    val mapped = pc.map(_ + 1)
+    assert(pc.tasksupport eq collection.parallel.Implicits.defaultTaskSupport, "default task support not resolved")
+    assert(mapped.tasksupport eq collection.parallel.Implicits.defaultTaskSupport, "default task support not resolved")
+  }
+  
+  def custom() {
+    implicit val customTaskSupport = new collection.parallel.ForkJoinTaskSupport(new scala.concurrent.forkjoin.ForkJoinPool(2))
+    val pc = Array(1, 2, 3).par
+    val mapped = pc.map(_ + 1)
+    assert(pc.tasksupport eq customTaskSupport, "custom task support not resolved")
+    assert(mapped.tasksupport eq customTaskSupport, "custom task support not resolved")
+   }
+  
+  default()
+  custom()
+  
+}


### PR DESCRIPTION
This implicit parameter is a the task support the parallel collection
will be created with.
This way the task support may be set only once, upon the collection
creation. If the clients what to change the task support, they have
to call `par` again.

Checking manual:

https://scala-webapps.epfl.ch/jenkins/job/scala-checkin-manual/230/console

review by @jsuereth, @phaller
