### PR TITLE
Fix SI-5937.

### DIFF
--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -18,8 +18,14 @@ import scala.collection.parallel.immutable.ParVector
 /** Companion object to the Vector class
  */
 object Vector extends SeqFactory[Vector] {
+  private[collection] class VectorReusableCBF extends GenericCanBuildFrom[Nothing] {
+    override def apply() = newBuilder[Nothing]
+  }
+  
+  lazy val VectorReusableCBF: GenericCanBuildFrom[Nothing] = new VectorReusableCBF
+  
   @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Vector[A]] =
-    ReusableCBF.asInstanceOf[CanBuildFrom[Coll, A, Vector[A]]]
+    VectorReusableCBF.asInstanceOf[CanBuildFrom[Coll, A, Vector[A]]]
   def newBuilder[A]: Builder[A, Vector[A]] = new VectorBuilder[A]
   private[immutable] val NIL = new Vector[Nothing](0, 0, 0)
   @inline override def empty[A]: Vector[A] = NIL
@@ -140,19 +146,19 @@ override def companion: GenericCompanion[Vector] = Vector
 
   // SeqLike api
 
-  @inline override def updated[B >: A, That](index: Int, elem: B)(implicit bf: CanBuildFrom[Vector[A], B, That]): That = {
-    // just ignore bf
-    updateAt(index, elem).asInstanceOf[That]
+  @inline override def updated[B >: A, That](index: Int, elem: B)(implicit bf: CanBuildFrom[Vector[A], B, That]): That = bf match {
+    case _: Vector.VectorReusableCBF => updateAt(index, elem).asInstanceOf[That] // just ignore bf
+    case _ => super.updated(index, elem)(bf)
   }
 
-  @inline override def +:[B >: A, That](elem: B)(implicit bf: CanBuildFrom[Vector[A], B, That]): That = {
-    // just ignore bf
-    appendFront(elem).asInstanceOf[That]
+  @inline override def +:[B >: A, That](elem: B)(implicit bf: CanBuildFrom[Vector[A], B, That]): That = bf match {
+    case _: Vector.VectorReusableCBF => appendFront(elem).asInstanceOf[That] // just ignore bf
+    case _ => super.+:(elem)(bf)
   }
 
-  @inline override def :+[B >: A, That](elem: B)(implicit bf: CanBuildFrom[Vector[A], B, That]): That = {
-    // just ignore bf
-    appendBack(elem).asInstanceOf[That]
+  @inline override def :+[B >: A, That](elem: B)(implicit bf: CanBuildFrom[Vector[A], B, That]): That = bf match {
+    case _: Vector.VectorReusableCBF => appendBack(elem).asInstanceOf[That] // just ignore bf
+    case _ => super.:+(elem)(bf)
   }
 
   override def take(n: Int): Vector[A] = {

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -22,7 +22,7 @@ object Vector extends SeqFactory[Vector] {
     override def apply() = newBuilder[Nothing]
   }
   
-  lazy val VectorReusableCBF: GenericCanBuildFrom[Nothing] = new VectorReusableCBF
+  private val VectorReusableCBF: GenericCanBuildFrom[Nothing] = new VectorReusableCBF
   
   @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Vector[A]] =
     VectorReusableCBF.asInstanceOf[CanBuildFrom[Coll, A, Vector[A]]]

--- a/test/files/run/t5937.scala
+++ b/test/files/run/t5937.scala
@@ -1,0 +1,12 @@
+
+
+
+import collection._
+
+
+
+object Test extends App {
+  
+  val list: List[Int] = (immutable.Vector(1, 2, 3) :+ 4)(breakOut)
+  
+}


### PR DESCRIPTION
Fixes SI-5937 by checking the type of the builder factory and delegating to a special implementation in the case that the builder factory is constructing vectors.
