### PR TITLE
Removes Float.Epsilon and Double.Epsilon

### DIFF
--- a/src/library/scala/Double.scala
+++ b/src/library/scala/Double.scala
@@ -370,9 +370,6 @@ object Double extends AnyValCompanion {
   final val PositiveInfinity = java.lang.Double.POSITIVE_INFINITY
   final val NegativeInfinity = java.lang.Double.NEGATIVE_INFINITY
 
-  @deprecated("use Double.MinPositiveValue instead", "2.9.0")
-  final val Epsilon  = MinPositiveValue
-
   /** The negative number with the greatest (finite) absolute value which is representable
    *  by a Double.  Note that it differs from [[java.lang.Double.MIN_VALUE]], which
    *  is the smallest positive value representable by a Double.  In Scala that number

--- a/src/library/scala/Float.scala
+++ b/src/library/scala/Float.scala
@@ -370,9 +370,6 @@ object Float extends AnyValCompanion {
   final val PositiveInfinity = java.lang.Float.POSITIVE_INFINITY
   final val NegativeInfinity = java.lang.Float.NEGATIVE_INFINITY
 
-  @deprecated("use Float.MinPositiveValue instead", "2.9.0")
-  final val Epsilon  = MinPositiveValue
-
   /** The negative number with the greatest (finite) absolute value which is representable
    *  by a Float.  Note that it differs from [[java.lang.Float.MIN_VALUE]], which
    *  is the smallest positive value representable by a Float.  In Scala that number


### PR DESCRIPTION
Float.Epsilon and Double.Epsilon contain the wrong value. Epsilon
should be an upper bound on the relative error due to rounding
errors in floating point arithmetic, i.e. it is 1/2 ULP (unit in
the last position) which is 2^(-24) for Float and 2^(-53) for Double.

This was discussed in detail in https://issues.scala-lang.org/browse/SI-3791
and it was decided to deprecate Epsilon for 2.9 and to remove it for 2.10
and to reintroduce it with the correct value for 2.11.

See also the discussion (and comments from Martin) on
https://groups.google.com/forum/?fromgroups#!topic/scala-internals/m763WjBdfyo

Review by @lrytz
