### PR TITLE
Deprecate all JVM 1.5 targets and make 1.6 default.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -499,7 +499,7 @@ LOCAL DEPENDENCY (Adapted ASM)
       destdir="${build-asm.dir}/classes"
       classpath="${build-asm.dir}/classes"
       includes="**/*.java"
-      target="1.5" source="1.5">
+      target="1.6" source="1.5">
         <compilerarg line="${javac.args} -XDignore.symbol.file"/>
     </javac>
     <touch file="${build-asm.dir}/asm.complete" verbose="no"/>
@@ -540,7 +540,7 @@ LOCAL DEPENDENCY (FORKJOIN)
       classpath="${build-libs.dir}/classes/forkjoin"
       includes="**/*.java"
       debug="true"
-      target="1.5" source="1.5">
+      target="1.6" source="1.5">
         <compilerarg line="${javac.args} -XDignore.symbol.file"/>
     </javac>
     <touch file="${build-libs.dir}/forkjoin.complete" verbose="no"/>
@@ -587,7 +587,7 @@ LOCAL DEPENDENCY (FJBG)
       classpath="${build-libs.dir}/classes/fjbg"
       includes="**/*.java"
       debug="true"
-      target="1.5" source="1.4">
+      target="1.6" source="1.4">
         <compilerarg line="${javac.args} -XDignore.symbol.file"/>
     </javac>
     <touch file="${build-libs.dir}/fjbg.complete" verbose="no"/>
@@ -635,7 +635,7 @@ LOCAL REFERENCE BUILD (LOCKER)
       srcdir="${src.dir}/library"
       destdir="${build-locker.dir}/classes/library"
       includes="**/*.java"
-      target="1.5" source="1.5">
+      target="1.6" source="1.5">
         <compilerarg line="${javac.args} -XDignore.symbol.file"/>
         <classpath>
           <path refid="forkjoin.classpath"/>
@@ -749,7 +749,7 @@ LOCAL REFERENCE BUILD (LOCKER)
           includes="**/*.java"
           excludes="**/tests/**"
           debug="true"
-          target="1.5" source="1.4">
+          target="1.6" source="1.4">
             <compilerarg line="${javac.args}"/>
         </javac>
         <scalacfork
@@ -1009,7 +1009,7 @@ QUICK BUILD (QUICK)
       srcdir="${src.dir}/library"
       destdir="${build-quick.dir}/classes/library"
       includes="**/*.java"
-      target="1.5" source="1.5">
+      target="1.6" source="1.5">
       <compilerarg line="${javac.args} -XDignore.symbol.file"/>
       <classpath>
         <path refid="forkjoin.classpath"/>
@@ -1020,7 +1020,7 @@ QUICK BUILD (QUICK)
       srcdir="${src.dir}/actors"
       destdir="${build-quick.dir}/classes/library"
       includes="**/*.java"
-      target="1.5" source="1.5">
+      target="1.6" source="1.5">
       <compilerarg line="${javac.args}"/>
       <classpath>
         <path refid="forkjoin.classpath"/>
@@ -1145,7 +1145,7 @@ QUICK BUILD (QUICK)
       includes="**/*.java"
       excludes="**/tests/**"
       debug="true"
-      target="1.5" source="1.4">
+      target="1.6" source="1.4">
         <compilerarg line="${javac.args}"/>
     </javac>
     <scalacfork
@@ -1349,7 +1349,7 @@ QUICK BUILD (QUICK)
     <javac
       srcdir="${src.dir}/partest"
       destdir="${build-quick.dir}/classes/partest"
-      target="1.5" source="1.5">
+      target="1.6" source="1.5">
       <classpath>
         <pathelement location="${build-quick.dir}/classes/library"/>
         <pathelement location="${build-quick.dir}/classes/reflect"/>
@@ -1691,7 +1691,7 @@ BOOTSTRAPPING BUILD (STRAP)
       srcdir="${src.dir}/library"
       destdir="${build-strap.dir}/classes/library"
       includes="**/*.java"
-      target="1.5" source="1.5">
+      target="1.6" source="1.5">
       <compilerarg line="${javac.args} -XDignore.symbol.file"/>
       <classpath>
         <path refid="forkjoin.classpath"/>
@@ -1702,7 +1702,7 @@ BOOTSTRAPPING BUILD (STRAP)
       srcdir="${src.dir}/actors"
       destdir="${build-strap.dir}/classes/library"
       includes="**/*.java"
-      target="1.5" source="1.5">
+      target="1.6" source="1.5">
       <compilerarg line="${javac.args}"/>
       <classpath>
         <path refid="forkjoin.classpath"/>
@@ -1826,7 +1826,7 @@ BOOTSTRAPPING BUILD (STRAP)
       includes="**/*.java"
       excludes="**/tests/**"
       debug="true"
-      target="1.5" source="1.4">
+      target="1.6" source="1.4">
         <compilerarg line="${javac.args}"/>
     </javac>
     <scalacfork
@@ -1994,7 +1994,7 @@ BOOTSTRAPPING BUILD (STRAP)
     <javac
       srcdir="${src.dir}/partest"
       destdir="${build-strap.dir}/classes/partest"
-      target="1.5" source="1.5">
+      target="1.6" source="1.5">
       <classpath>
         <pathelement location="${build-strap.dir}/classes/library"/>
         <pathelement location="${build-strap.dir}/classes/reflect"/>

--- a/src/compiler/scala/tools/ant/Scalac.scala
+++ b/src/compiler/scala/tools/ant/Scalac.scala
@@ -99,7 +99,7 @@ class Scalac extends ScalaMatchingTask with ScalacShared {
 
   /** Defines valid values for the `target` property. */
   object Target extends PermissibleValue {
-    val values = List("jvm-1.5", "jvm-1.6", "jvm-1.7", "msil")
+    val values = List("jvm-1.5", "jvm-1.5-fjbg", "jvm-1.5-asm", "jvm-1.6", "jvm-1.7", "msil")
   }
 
   /** Defines valid values for the `deprecation` and `unchecked` properties. */

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1447,6 +1447,8 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
       settings.userSetSettings filter (_.isDeprecated) foreach { s =>
         unit.deprecationWarning(NoPosition, s.name + " is deprecated: " + s.deprecationMessage.get)
       }
+      if (settings.target.value.contains("jvm-1.5"))
+        unit.deprecationWarning(NoPosition, settings.target.name + ":" + settings.target.value + " is deprecated: use target for Java 1.6 or above.")
     }
 
     /* An iterator returning all the units being compiled in this run */

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
@@ -598,7 +598,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters {
             reverseJavaName.put(internalName, trackedSym)
           case Some(oldsym) =>
             assert((oldsym == trackedSym) || (oldsym == RuntimeNothingClass) || (oldsym == RuntimeNullClass), // In contrast, neither NothingClass nor NullClass show up bytecode-level.
-                   "how can getCommonSuperclass() do its job if different class symbols get the same bytecode-level internal name.")
+                   "how can getCommonSuperclass() do its job if different class symbols get the same bytecode-level internal name: " + internalName)
         }
       }
 

--- a/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
@@ -40,9 +40,9 @@ trait StandardScalaSettings {
   val nowarn =         BooleanSetting ("-nowarn", "Generate no warnings.")
   val optimise:        BooleanSetting // depends on post hook which mutates other settings
   val print =          BooleanSetting ("-print", "Print program with Scala-specific features removed.")
-  val target =          ChoiceSetting ("-target", "target", "Target platform for object files.",
+  val target =          ChoiceSetting ("-target", "target", "Target platform for object files. All JVM 1.5 targets are deprecated.",
                                        List("jvm-1.5", "jvm-1.5-fjbg", "jvm-1.5-asm", "jvm-1.6", "jvm-1.7", "msil"),
-                                       "jvm-1.5-asm")
+                                       "jvm-1.6")
   val unchecked =      BooleanSetting ("-unchecked", "Enable detailed unchecked (erasure) warnings.")
   val uniqid =         BooleanSetting ("-uniqid", "Uniquely tag all identifiers in debugging output.")
   val usejavacp =      BooleanSetting ("-usejavacp", "Utilize the java.class.path in classpath resolution.")

--- a/test/files/pos/t5957/T_1.scala
+++ b/test/files/pos/t5957/T_1.scala
@@ -1,6 +1,8 @@
 abstract class T {
-  def t1: Test$Bar
+  // see: SI-6109
+  // def t1: Test$Bar
   def t2: Test#Bar
-  def t3: Test$Baz
+  // see: SI-6109
+  // def t3: Test$Baz
   def t4: Test.Baz
 }


### PR DESCRIPTION
Add a check if deprecated target is being used. I put
that check into `checkDeprecatedSettings`. I tried to
invent some general mechanism for deprecating choices
in ChoiceSetting but I gave up eventually. It wasn't
worth it the complexity. Also, with current approach
I'm able to provide nice, customized deprecation
warning.

Make `jvm-1.6` a default backend.

Altered test for SI-5957 because it crashes the backend.
However, the problem is not with backend but with symbol
creation. We get two different symbols with the same
internal name and both are used in trees that reach
GenASM. See SI-6109 for details.

Also, I went through `build.xml` and I updated all `javac`
invocations so they target 1.6 byte-code as well.

Review by @magarciaEPFL, @paulp and @jsuereth.
