### PR TITLE
Renaming phase time-travel methods.

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -168,7 +168,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
         if (lastPrintedSource == source)
           println(": tree is unchanged since " + lastPrintedPhase)
         else {
-          lastPrintedPhase = phase.prev // since we're running inside "afterPhase"
+          lastPrintedPhase = phase.prev // since we're running inside "exitingPhase"
           lastPrintedSource = source
           println("")
           println(source)
@@ -782,7 +782,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
    */
   def afterEachPhase[T](op: => T): List[(Phase, T)] = {
     phaseDescriptors.map(_.ownPhase).filterNot(_ eq NoPhase).foldLeft(List[(Phase, T)]()) { (res, ph) =>
-      val value = afterPhase(ph)(op)
+      val value = exitingPhase(ph)(op)
       if (res.nonEmpty && res.head._2 == value) res
       else ((ph, value)) :: res
     } reverse
@@ -1051,26 +1051,26 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
   def currentSource: SourceFile    = if (currentUnit.exists) currentUnit.source else lastSeenSourceFile
 
   // TODO - trim these to the absolute minimum.
-  @inline final def afterErasure[T](op: => T): T        = afterPhase(currentRun.erasurePhase)(op)
-  @inline final def afterExplicitOuter[T](op: => T): T  = afterPhase(currentRun.explicitouterPhase)(op)
-  @inline final def afterFlatten[T](op: => T): T        = afterPhase(currentRun.flattenPhase)(op)
-  @inline final def afterIcode[T](op: => T): T          = afterPhase(currentRun.icodePhase)(op)
-  @inline final def afterMixin[T](op: => T): T          = afterPhase(currentRun.mixinPhase)(op)
-  @inline final def afterPickler[T](op: => T): T        = afterPhase(currentRun.picklerPhase)(op)
-  @inline final def afterRefchecks[T](op: => T): T      = afterPhase(currentRun.refchecksPhase)(op)
-  @inline final def afterSpecialize[T](op: => T): T     = afterPhase(currentRun.specializePhase)(op)
-  @inline final def afterTyper[T](op: => T): T          = afterPhase(currentRun.typerPhase)(op)
-  @inline final def afterUncurry[T](op: => T): T        = afterPhase(currentRun.uncurryPhase)(op)
-  @inline final def beforeErasure[T](op: => T): T       = beforePhase(currentRun.erasurePhase)(op)
-  @inline final def beforeExplicitOuter[T](op: => T): T = beforePhase(currentRun.explicitouterPhase)(op)
-  @inline final def beforeFlatten[T](op: => T): T       = beforePhase(currentRun.flattenPhase)(op)
-  @inline final def beforeIcode[T](op: => T): T         = beforePhase(currentRun.icodePhase)(op)
-  @inline final def beforeMixin[T](op: => T): T         = beforePhase(currentRun.mixinPhase)(op)
-  @inline final def beforePickler[T](op: => T): T       = beforePhase(currentRun.picklerPhase)(op)
-  @inline final def beforeRefchecks[T](op: => T): T     = beforePhase(currentRun.refchecksPhase)(op)
-  @inline final def beforeSpecialize[T](op: => T): T    = beforePhase(currentRun.specializePhase)(op)
-  @inline final def beforeTyper[T](op: => T): T         = beforePhase(currentRun.typerPhase)(op)
-  @inline final def beforeUncurry[T](op: => T): T       = beforePhase(currentRun.uncurryPhase)(op)
+  @inline final def exitingErasure[T](op: => T): T        = exitingPhase(currentRun.erasurePhase)(op)
+  @inline final def exitingExplicitOuter[T](op: => T): T  = exitingPhase(currentRun.explicitouterPhase)(op)
+  @inline final def exitingFlatten[T](op: => T): T        = exitingPhase(currentRun.flattenPhase)(op)
+  @inline final def exitingIcode[T](op: => T): T          = exitingPhase(currentRun.icodePhase)(op)
+  @inline final def exitingMixin[T](op: => T): T          = exitingPhase(currentRun.mixinPhase)(op)
+  @inline final def exitingPickler[T](op: => T): T        = exitingPhase(currentRun.picklerPhase)(op)
+  @inline final def exitingRefchecks[T](op: => T): T      = exitingPhase(currentRun.refchecksPhase)(op)
+  @inline final def exitingSpecialize[T](op: => T): T     = exitingPhase(currentRun.specializePhase)(op)
+  @inline final def exitingTyper[T](op: => T): T          = exitingPhase(currentRun.typerPhase)(op)
+  @inline final def exitingUncurry[T](op: => T): T        = exitingPhase(currentRun.uncurryPhase)(op)
+  @inline final def enteringErasure[T](op: => T): T       = enteringPhase(currentRun.erasurePhase)(op)
+  @inline final def enteringExplicitOuter[T](op: => T): T = enteringPhase(currentRun.explicitouterPhase)(op)
+  @inline final def enteringFlatten[T](op: => T): T       = enteringPhase(currentRun.flattenPhase)(op)
+  @inline final def enteringIcode[T](op: => T): T         = enteringPhase(currentRun.icodePhase)(op)
+  @inline final def enteringMixin[T](op: => T): T         = enteringPhase(currentRun.mixinPhase)(op)
+  @inline final def enteringPickler[T](op: => T): T       = enteringPhase(currentRun.picklerPhase)(op)
+  @inline final def enteringRefchecks[T](op: => T): T     = enteringPhase(currentRun.refchecksPhase)(op)
+  @inline final def enteringSpecialize[T](op: => T): T    = enteringPhase(currentRun.specializePhase)(op)
+  @inline final def enteringTyper[T](op: => T): T         = enteringPhase(currentRun.typerPhase)(op)
+  @inline final def enteringUncurry[T](op: => T): T       = enteringPhase(currentRun.uncurryPhase)(op)
 
   def explainContext(c: analyzer.Context): String = (
     if (c == null) "" else (
@@ -1109,7 +1109,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
 
     val info1 = formatExplain(
       "while compiling"    -> currentSource.path,
-      "during phase"       -> ( if (globalPhase eq phase) phase else "global=%s, atPhase=%s".format(globalPhase, phase) ),
+      "during phase"       -> ( if (globalPhase eq phase) phase else "global=%s, enteringPhase=%s".format(globalPhase, phase) ),
       "library version"    -> scala.util.Properties.versionString,
       "compiler version"   -> Properties.versionString,
       "reconstructed args" -> settings.recreateArgs.mkString(" ")
@@ -1469,7 +1469,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
       lazy val trackers = currentRun.units.toList map (x => SymbolTracker(x))
       def snapshot() = {
         inform("\n[[symbol layout at end of " + phase + "]]")
-        afterPhase(phase) {
+        exitingPhase(phase) {
           trackers foreach { t =>
             t.snapshot()
             inform(t.show("Heading from " + phase.prev.name + " to " + phase.name))
@@ -1605,7 +1605,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
 
       // Reset project
       if (!stopPhase("namer")) {
-        atPhase(namerPhase) {
+        enteringPhase(namerPhase) {
           resetProjectClasses(RootClass)
         }
       }
@@ -1645,7 +1645,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
       if (firstPhase ne null) { // we might get here during initialization, is a source is newer than the binary
         val maxId = math.max(globalPhase.id, typerPhase.id)
         firstPhase.iterator takeWhile (_.id < maxId) foreach (ph =>
-          atPhase(ph)(ph.asInstanceOf[GlobalPhase] applyPhase unit))
+          enteringPhase(ph)(ph.asInstanceOf[GlobalPhase] applyPhase unit))
         refreshProgress
       }
     }
@@ -1654,8 +1654,8 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
      *  is needed for?)
      */
     private def resetPackageClass(pclazz: Symbol) {
-      atPhase(firstPhase) {
-        pclazz.setInfo(atPhase(typerPhase)(pclazz.info))
+      enteringPhase(firstPhase) {
+        pclazz.setInfo(enteringPhase(typerPhase)(pclazz.info))
       }
       if (!pclazz.isRoot) resetPackageClass(pclazz.owner)
     }
@@ -1703,7 +1703,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
 
   def printAllUnits() {
     print("[[syntax trees at end of %25s]]".format(phase))
-    afterPhase(phase)(currentRun.units foreach { unit =>
+    exitingPhase(phase)(currentRun.units foreach { unit =>
       nodePrinters showUnit unit
     })
   }
@@ -1712,7 +1712,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
    */
   def showDef(fullName: Name, declsOnly: Boolean, ph: Phase) = {
     val boringOwners = Set[Symbol](definitions.AnyClass, definitions.AnyRefClass, definitions.ObjectClass)
-    def phased[T](body: => T): T = afterPhase(ph)(body)
+    def phased[T](body: => T): T = exitingPhase(ph)(body)
     def boringMember(sym: Symbol) = boringOwners(sym.owner)
     def symString(sym: Symbol) = if (sym.isTerm) sym.defString else sym.toString
 

--- a/src/compiler/scala/tools/nsc/SubComponent.scala
+++ b/src/compiler/scala/tools/nsc/SubComponent.scala
@@ -47,8 +47,8 @@ abstract class SubComponent {
   private var ownPhaseCache: WeakReference[Phase] = new WeakReference(null)
   private var ownPhaseRunId = global.NoRunId
 
-  @inline final def beforeOwnPhase[T](op: => T) = global.beforePhase(ownPhase)(op)
-  @inline final def afterOwnPhase[T](op: => T)  = global.afterPhase(ownPhase)(op)
+  @inline final def beforeOwnPhase[T](op: => T) = global.enteringPhase(ownPhase)(op)
+  @inline final def afterOwnPhase[T](op: => T)  = global.exitingPhase(ownPhase)(op)
 
   /** The phase corresponding to this subcomponent in the current compiler run */
   def ownPhase: Phase = {

--- a/src/compiler/scala/tools/nsc/backend/ScalaPrimitives.scala
+++ b/src/compiler/scala/tools/nsc/backend/ScalaPrimitives.scala
@@ -565,7 +565,7 @@ abstract class ScalaPrimitives {
     import definitions._
     val code = getPrimitive(fun)
 
-    def elementType = beforeTyper {
+    def elementType = enteringTyper {
       val arrayParent = tpe :: tpe.parents collectFirst {
         case TypeRef(_, ArrayClass, elem :: Nil) => elem
       }

--- a/src/compiler/scala/tools/nsc/backend/icode/TypeKinds.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/TypeKinds.scala
@@ -139,7 +139,7 @@ trait TypeKinds { self: ICodes =>
      *  Here we make the adjustment by rewinding to a pre-erasure state and
      *  sifting through the parents for a class type.
      */
-    def lub0(tk1: TypeKind, tk2: TypeKind): Type = beforeUncurry {
+    def lub0(tk1: TypeKind, tk2: TypeKind): Type = enteringUncurry {
       import definitions._
       val tp = global.lub(List(tk1.toType, tk2.toType))
       val (front, rest) = tp.parents span (_.typeSymbol.isTrait)

--- a/src/compiler/scala/tools/nsc/backend/jvm/BytecodeWriters.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BytecodeWriters.scala
@@ -23,7 +23,7 @@ trait BytecodeWriters {
   import global._
 
   private def outputDirectory(sym: Symbol): AbstractFile = (
-    settings.outputDirs.outputDirFor(beforeFlatten(sym.sourceFile))
+    settings.outputDirs.outputDirFor(enteringFlatten(sym.sourceFile))
   )
   private def getFile(base: AbstractFile, /*cls.getName()*/ clsName: String, suffix: String): AbstractFile = {
     var dir = base

--- a/src/compiler/scala/tools/nsc/backend/msil/GenMSIL.scala
+++ b/src/compiler/scala/tools/nsc/backend/msil/GenMSIL.scala
@@ -1126,7 +1126,7 @@ abstract class GenMSIL extends SubComponent {
               }
 
               // method: implicit view(FunctionX[PType0, PType1, ...,PTypeN, ResType]):DelegateType
-              val (isDelegateView, paramType, resType) = beforeTyper {
+              val (isDelegateView, paramType, resType) = enteringTyper {
                 msym.tpe match {
                   case MethodType(params, resultType)
                   if (params.length == 1 && msym.name == nme.view_) =>
@@ -1955,7 +1955,7 @@ abstract class GenMSIL extends SubComponent {
     } // createClassMembers0
 
     private def isTopLevelModule(sym: Symbol): Boolean =
-      beforeRefchecks {
+      enteringRefchecks {
         sym.isModuleClass && !sym.isImplClass && !sym.isNestedClass
       }
 

--- a/src/compiler/scala/tools/nsc/backend/opt/Inliners.scala
+++ b/src/compiler/scala/tools/nsc/backend/opt/Inliners.scala
@@ -547,7 +547,7 @@ abstract class Inliners extends SubComponent {
 
     private def isHigherOrderMethod(sym: Symbol) = (
          sym.isMethod
-      && beforeExplicitOuter(sym.info.paramTypes exists isFunctionType) // was "at erasurePhase.prev"
+      && enteringExplicitOuter(sym.info.paramTypes exists isFunctionType) // was "at erasurePhase.prev"
     )
 
     /** Should method 'sym' being called in 'receiver' be loaded from disk? */

--- a/src/compiler/scala/tools/nsc/dependencies/DependencyAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/dependencies/DependencyAnalysis.scala
@@ -145,7 +145,7 @@ trait DependencyAnalysis extends SubComponent with Files {
           val name = d.toString
           d.symbol match {
             case s : ModuleClassSymbol =>
-              val isTopLevelModule = afterPickler { !s.isImplClass && !s.isNestedClass }
+              val isTopLevelModule = exitingPickler { !s.isImplClass && !s.isNestedClass }
 
               if (isTopLevelModule && (s.companionModule != NoSymbol)) {
                 dependencies.emits(source, nameToFile(unit.source.file, name))
@@ -183,7 +183,7 @@ trait DependencyAnalysis extends SubComponent with Files {
             // was "at uncurryPhase.prev", which is actually non-deterministic
             // because the continuations plugin may or may not supply uncurry's
             // immediately preceding phase.
-            beforeRefchecks(checkType(tree.symbol.tpe))
+            enteringRefchecks(checkType(tree.symbol.tpe))
           }
 
           tree match {
@@ -191,7 +191,7 @@ trait DependencyAnalysis extends SubComponent with Files {
                                    !cdef.symbol.isAnonymousFunction =>
               if (cdef.symbol != NoSymbol) buf += cdef.symbol
               // was "at erasurePhase.prev"
-              beforeExplicitOuter {
+              enteringExplicitOuter {
                 for (s <- cdef.symbol.info.decls)
                   s match {
                     case ts: TypeSymbol if !ts.isClass =>
@@ -203,7 +203,7 @@ trait DependencyAnalysis extends SubComponent with Files {
 
             case ddef: DefDef =>
               // was "at typer.prev"
-              beforeTyper { checkType(ddef.symbol.tpe) }
+              enteringTyper { checkType(ddef.symbol.tpe) }
               super.traverse(tree)
             case a @ Select(q, n) if ((a.symbol != NoSymbol) && (q.symbol != null)) => // #2556
               if (!a.symbol.isConstructor &&

--- a/src/compiler/scala/tools/nsc/interactive/Global.scala
+++ b/src/compiler/scala/tools/nsc/interactive/Global.scala
@@ -1066,7 +1066,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "")
      *  @return true iff typechecked correctly
      */
     private def applyPhase(phase: Phase, unit: CompilationUnit) {
-      atPhase(phase) { phase.asInstanceOf[GlobalPhase] applyPhase unit }
+      enteringPhase(phase) { phase.asInstanceOf[GlobalPhase] applyPhase unit }
     }
   }
 

--- a/src/compiler/scala/tools/nsc/interactive/RefinedBuildManager.scala
+++ b/src/compiler/scala/tools/nsc/interactive/RefinedBuildManager.scala
@@ -49,7 +49,7 @@ class RefinedBuildManager(val settings: Settings) extends Changes with BuildMana
   protected def newCompiler(settings: Settings) = new BuilderGlobal(settings)
 
   val compiler = newCompiler(settings)
-  import compiler.{ Symbol, Type, beforeErasure }
+  import compiler.{ Symbol, Type, enteringErasure }
   import compiler.dependencyAnalysis.Inherited
 
   private case class SymWithHistory(sym: Symbol, befErasure: Type)
@@ -161,7 +161,7 @@ class RefinedBuildManager(val settings: Settings) extends Changes with BuildMana
                     isCorrespondingSym(s.sym, sym)) match {
               case Some(SymWithHistory(oldSym, info)) =>
                 val changes = changeSet(oldSym.info, sym)
-                val changesErasure = beforeErasure(changeSet(info, sym))
+                val changesErasure = enteringErasure(changeSet(info, sym))
 
                 changesOf(oldSym) = (changes ++ changesErasure).distinct
               case _ =>
@@ -332,7 +332,7 @@ class RefinedBuildManager(val settings: Settings) extends Changes with BuildMana
     for (src <- files; localDefs = compiler.dependencyAnalysis.definitions(src)) {
       definitions(src) = (localDefs map (s => {
         this.classes += s.fullName -> src
-        SymWithHistory(s.cloneSymbol, beforeErasure(s.info.cloneInfo(s)))
+        SymWithHistory(s.cloneSymbol, enteringErasure(s.info.cloneInfo(s)))
       }))
     }
     this.references = compiler.dependencyAnalysis.references

--- a/src/compiler/scala/tools/nsc/interpreter/ExprTyper.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/ExprTyper.scala
@@ -63,7 +63,7 @@ trait ExprTyper {
         case IR.Success =>
           val sym0 = symbolOfTerm(name)
           // drop NullaryMethodType
-          val sym = sym0.cloneSymbol setInfo afterTyper(sym0.info.finalResultType)
+          val sym = sym0.cloneSymbol setInfo exitingTyper(sym0.info.finalResultType)
           if (sym.info.typeSymbol eq UnitClass) NoSymbol
           else sym
         case _          => NoSymbol

--- a/src/compiler/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/ILoop.scala
@@ -65,7 +65,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     import global._
 
     def printAfterTyper(msg: => String) =
-      intp.reporter printUntruncatedMessage afterTyper(msg)
+      intp.reporter printUntruncatedMessage exitingTyper(msg)
 
     /** Strip NullaryMethodType artifacts. */
     private def replInfo(sym: Symbol) = {
@@ -342,7 +342,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
 
         // This groups the members by where the symbol is defined
         val byOwner = syms groupBy (_.owner)
-        val sortedOwners = byOwner.toList sortBy { case (owner, _) => afterTyper(source.info.baseClasses indexOf owner) }
+        val sortedOwners = byOwner.toList sortBy { case (owner, _) => exitingTyper(source.info.baseClasses indexOf owner) }
 
         sortedOwners foreach {
           case (owner, members) =>

--- a/src/compiler/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/IMain.scala
@@ -770,7 +770,7 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
       val readRoot  = getRequiredModule(readPath)   // the outermost wrapper
       (accessPath split '.').foldLeft(readRoot: Symbol) {
         case (sym, "")    => sym
-        case (sym, name)  => afterTyper(termMember(sym, name))
+        case (sym, name)  => exitingTyper(termMember(sym, name))
       }
     }
     /** We get a bunch of repeated warnings for reasons I haven't
@@ -962,7 +962,7 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
     }
 
     lazy val resultSymbol = lineRep.resolvePathToSymbol(accessPath)
-    def applyToResultMember[T](name: Name, f: Symbol => T) = afterTyper(f(resultSymbol.info.nonPrivateDecl(name)))
+    def applyToResultMember[T](name: Name, f: Symbol => T) = exitingTyper(f(resultSymbol.info.nonPrivateDecl(name)))
 
     /* typeOf lookup with encoding */
     def lookupTypeOf(name: Name) = typeOf.getOrElse(name, typeOf(global.encode(name.toString)))
@@ -974,10 +974,10 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
     /** Types of variables defined by this request. */
     lazy val compilerTypeOf = typeMap[Type](x => x) withDefaultValue NoType
     /** String representations of same. */
-    lazy val typeOf         = typeMap[String](tp => afterTyper(tp.toString))
+    lazy val typeOf         = typeMap[String](tp => exitingTyper(tp.toString))
 
     // lazy val definedTypes: Map[Name, Type] = {
-    //   typeNames map (x => x -> afterTyper(resultSymbol.info.nonPrivateDecl(x).tpe)) toMap
+    //   typeNames map (x => x -> exitingTyper(resultSymbol.info.nonPrivateDecl(x).tpe)) toMap
     // }
     lazy val definedSymbols = (
       termNames.map(x => x -> applyToResultMember(x, x => x)) ++
@@ -1074,7 +1074,7 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
       else NoType
     }
   }
-  def cleanMemberDecl(owner: Symbol, member: Name): Type = afterTyper {
+  def cleanMemberDecl(owner: Symbol, member: Name): Type = exitingTyper {
     normalizeNonPublic {
       owner.info.nonPrivateDecl(member).tpe match {
         case NullaryMethodType(tp) => tp
@@ -1163,7 +1163,7 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
 
   def symbolDefString(sym: Symbol) = {
     TypeStrings.quieter(
-      afterTyper(sym.defString),
+      exitingTyper(sym.defString),
       sym.owner.name + ".this.",
       sym.owner.fullName + "."
     )

--- a/src/compiler/scala/tools/nsc/interpreter/Imports.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/Imports.scala
@@ -191,5 +191,5 @@ trait Imports {
     prevRequestList flatMap (req => req.handlers map (req -> _))
 
   private def membersAtPickler(sym: Symbol): List[Symbol] =
-    beforePickler(sym.info.nonPrivateMembers)
+    enteringPickler(sym.info.nonPrivateMembers)
 }

--- a/src/compiler/scala/tools/nsc/interpreter/JLineCompletion.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/JLineCompletion.scala
@@ -47,12 +47,12 @@ class JLineCompletion(val intp: IMain) extends Completion with CompletionOutput 
     def anyRefMethodsToShow = Set("isInstanceOf", "asInstanceOf", "toString")
 
     def tos(sym: Symbol): String = sym.decodedName
-    def memberNamed(s: String) = afterTyper(effectiveTp member newTermName(s))
+    def memberNamed(s: String) = exitingTyper(effectiveTp member newTermName(s))
     def hasMethod(s: String) = memberNamed(s).isMethod
 
     // XXX we'd like to say "filterNot (_.isDeprecated)" but this causes the
     // compiler to crash for reasons not yet known.
-    def members     = afterTyper((effectiveTp.nonPrivateMembers ++ anyMembers) filter (_.isPublic))
+    def members     = exitingTyper((effectiveTp.nonPrivateMembers ++ anyMembers) filter (_.isPublic))
     def methods     = members filter (_.isMethod)
     def packages    = members filter (_.isPackage)
     def aliases     = members filter (_.isAliasType)
@@ -111,7 +111,7 @@ class JLineCompletion(val intp: IMain) extends Completion with CompletionOutput 
     def excludeNames: List[String] = (anyref.methodNames filterNot anyRefMethodsToShow) :+ "_root_"
 
     def methodSignatureString(sym: Symbol) = {
-      IMain stripString afterTyper(new MethodSymbolOutput(sym).methodString())
+      IMain stripString exitingTyper(new MethodSymbolOutput(sym).methodString())
     }
 
     def exclude(name: String): Boolean = (

--- a/src/compiler/scala/tools/nsc/interpreter/MemberHandlers.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/MemberHandlers.scala
@@ -208,10 +208,10 @@ trait MemberHandlers {
     def importedSymbols = individualSymbols ++ wildcardSymbols
 
     lazy val individualSymbols: List[Symbol] =
-      beforePickler(individualNames map (targetType nonPrivateMember _))
+      enteringPickler(individualNames map (targetType nonPrivateMember _))
 
     lazy val wildcardSymbols: List[Symbol] =
-      if (importsWildcard) beforePickler(targetType.nonPrivateMembers)
+      if (importsWildcard) enteringPickler(targetType.nonPrivateMembers)
       else Nil
 
     /** Complete list of names imported by a wildcard */

--- a/src/compiler/scala/tools/nsc/interpreter/Phased.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/Phased.scala
@@ -68,7 +68,7 @@ trait Phased {
 
   def apply[T](body: => T) = immutable.SortedMap[PhaseName, T](atMap(PhaseName.all)(body): _*)
 
-  def atCurrent[T](body: => T): T = atPhase(get)(body)
+  def atCurrent[T](body: => T): T = enteringPhase(get)(body)
   def multi[T](body: => T): Seq[T] = multi map (ph => at(ph)(body))
   def all[T](body: => T): Seq[T] = atMulti(PhaseName.all)(body)
   def show[T](body: => T): Seq[T] = {
@@ -121,7 +121,7 @@ trait Phased {
     def isEmpty   = this eq NoPhaseName
 
     // Execute some code during this phase.
-    def apply[T](body: => T): T = atPhase(phase)(body)
+    def apply[T](body: => T): T = enteringPhase(phase)(body)
   }
 
   case object Parser extends PhaseName

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -420,9 +420,9 @@ abstract class ClassfileParser {
     var sym: Symbol = rootMirror.RootClass
 
     // was "at flatten.prev"
-    beforeFlatten {
+    enteringFlatten {
       for (part0 <- parts; if !(part0 == ""); part = newTermName(part0)) {
-        val sym1 = beforeIcode {
+        val sym1 = enteringIcode {
           sym.linkedClassOfClass.info
           sym.info.decl(part.encode)
         }//.suchThat(module == _.isModule)
@@ -1203,7 +1203,7 @@ abstract class ClassfileParser {
               // if loading during initialization of `definitions` typerPhase is not yet set.
               // in that case we simply load the member at the current phase
               if (currentRun.typerPhase != null)
-                beforeTyper(getMember(sym, innerName.toTypeName))
+                enteringTyper(getMember(sym, innerName.toTypeName))
               else
                 getMember(sym, innerName.toTypeName)
 

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
@@ -179,7 +179,7 @@ abstract class ICodeReader extends ClassfileParser {
     }
     else {
       forceMangledName(name, false)
-      afterFlatten(rootMirror.getClassByName(name.toTypeName))
+      exitingFlatten(rootMirror.getClassByName(name.toTypeName))
     }
     if (sym.isModule)
       sym.moduleClass

--- a/src/compiler/scala/tools/nsc/transform/AddInterfaces.scala
+++ b/src/compiler/scala/tools/nsc/transform/AddInterfaces.scala
@@ -112,7 +112,7 @@ abstract class AddInterfaces extends InfoTransform { self: Erasure =>
   def implClass(iface: Symbol): Symbol = {
     iface.info
 
-    implClassMap.getOrElse(iface, atPhase(implClassPhase) {
+    implClassMap.getOrElse(iface, enteringPhase(implClassPhase) {
       log("Creating implClass for " + iface)
       if (iface.implClass ne NoSymbol)
         log("%s.implClass already exists: %s".format(iface, iface.implClass))
@@ -196,7 +196,7 @@ abstract class AddInterfaces extends InfoTransform { self: Erasure =>
         case PolyType(_, restpe) =>
           implType(restpe)
       }
-      implSym setInfo implType(beforeErasure(iface.info))
+      implSym setInfo implType(enteringErasure(iface.info))
     }
 
     override def load(clazz: Symbol) { complete(clazz) }
@@ -353,7 +353,7 @@ abstract class AddInterfaces extends InfoTransform { self: Erasure =>
           val mix1 = mix
             if (mix == tpnme.EMPTY) mix
             else {
-              val ps = beforeErasure {
+              val ps = enteringErasure {
                 sym.info.parents dropWhile (p => p.symbol.name != mix)
               }
               assert(!ps.isEmpty, tree);

--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -170,7 +170,7 @@ abstract class ExplicitOuter extends InfoTransform
       }
       if (!clazz.isTrait && !parents.isEmpty) {
         for (mc <- clazz.mixinClasses) {
-          val mixinOuterAcc: Symbol = afterExplicitOuter(outerAccessor(mc))
+          val mixinOuterAcc: Symbol = exitingExplicitOuter(outerAccessor(mc))
           if (mixinOuterAcc != NoSymbol) {
             if (decls1 eq decls) decls1 = decls.cloneScope
             val newAcc = mixinOuterAcc.cloneSymbol(clazz, mixinOuterAcc.flags & ~DEFERRED)
@@ -558,7 +558,7 @@ abstract class ExplicitOuter extends InfoTransform
 
     /** The transformation method for whole compilation units */
     override def transformUnit(unit: CompilationUnit) {
-      afterExplicitOuter(super.transformUnit(unit))
+      exitingExplicitOuter(super.transformUnit(unit))
     }
   }
 

--- a/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
@@ -69,7 +69,7 @@ abstract class ExtensionMethods extends Transform with TypingTransformers {
 
   /** Return the extension method that corresponds to given instance method `meth`.
    */
-  def extensionMethod(imeth: Symbol): Symbol = atPhase(currentRun.refchecksPhase) {
+  def extensionMethod(imeth: Symbol): Symbol = enteringPhase(currentRun.refchecksPhase) {
     val companionInfo = imeth.owner.companionModule.info
     val candidates = extensionNames(imeth) map (companionInfo.decl(_))
     val matching = candidates filter (alt => normalize(alt.tpe, imeth.owner) matches imeth.tpe)

--- a/src/compiler/scala/tools/nsc/transform/Flatten.scala
+++ b/src/compiler/scala/tools/nsc/transform/Flatten.scala
@@ -20,7 +20,7 @@ abstract class Flatten extends InfoTransform {
 
   /** Updates the owning scope with the given symbol; returns the old symbol.
    */
-  private def replaceSymbolInCurrentScope(sym: Symbol): Symbol = afterFlatten {
+  private def replaceSymbolInCurrentScope(sym: Symbol): Symbol = exitingFlatten {
     val scope = sym.owner.info.decls
     val old   = scope lookup sym.name
     if (old ne NoSymbol)
@@ -53,7 +53,7 @@ abstract class Flatten extends InfoTransform {
     clazz.isClass && !clazz.isPackageClass && {
       // Cannot flatten here: class A[T] { object B }
       // was "at erasurePhase.prev"
-      beforeErasure(clazz.typeParams.isEmpty)
+      enteringErasure(clazz.typeParams.isEmpty)
     }
   }
 
@@ -67,11 +67,11 @@ abstract class Flatten extends InfoTransform {
         val decls1 = scopeTransform(clazz) {
           val decls1 = newScope
           if (clazz.isPackageClass) {
-            afterFlatten { decls foreach (decls1 enter _) }
+            exitingFlatten { decls foreach (decls1 enter _) }
           }
           else {
             val oldowner = clazz.owner
-            afterFlatten { oldowner.info }
+            exitingFlatten { oldowner.info }
             parents1 = parents mapConserve (this)
 
             for (sym <- decls) {
@@ -123,7 +123,7 @@ abstract class Flatten extends InfoTransform {
           liftedDefs(sym.enclosingTopLevelClass.owner) += tree
           EmptyTree
         case Select(qual, name) if (sym.isStaticModule && !sym.owner.isPackageClass) =>
-          afterFlatten(atPos(tree.pos)(gen.mkAttributedRef(sym)))
+          exitingFlatten(atPos(tree.pos)(gen.mkAttributedRef(sym)))
         case _ =>
           tree
       }

--- a/src/compiler/scala/tools/nsc/transform/InfoTransform.scala
+++ b/src/compiler/scala/tools/nsc/transform/InfoTransform.scala
@@ -10,11 +10,11 @@ package transform
  * An InfoTransform contains a compiler phase that transforms trees and symbol infos -- making sure they stay consistent.
  * The symbol info is transformed assuming it is consistent right before this phase.
  * The info transformation is triggered by Symbol::rawInfo, which caches the results in the symbol's type history.
- * This way sym.info (during an atPhase(p)) can look up what the symbol's info should look like at the beginning of phase p.
+ * This way sym.info (during an enteringPhase(p)) can look up what the symbol's info should look like at the beginning of phase p.
  * (If the transformed info had not been stored yet, rawInfo will compute the info by composing the info-transformers
  *  of the most recent phase before p, up to the transformer of the phase right before p.)
  *
- * Concretely, atPhase(p) { sym.info } yields the info *before* phase p has transformed it. Imagine you're a phase and it all makes sense.
+ * Concretely, enteringPhase(p) { sym.info } yields the info *before* phase p has transformed it. Imagine you're a phase and it all makes sense.
  */
 trait InfoTransform extends Transform {
   import global.{Symbol, Type, InfoTransformer, infoTransformers}

--- a/src/compiler/scala/tools/nsc/transform/LazyVals.scala
+++ b/src/compiler/scala/tools/nsc/transform/LazyVals.scala
@@ -275,7 +275,7 @@ abstract class LazyVals extends Transform with TypingTransformers with ast.TreeD
         bmps(n)
       else {
         val sym = meth.newVariable(nme.newBitmapName(nme.BITMAP_NORMAL, n), meth.pos).setInfo(ByteClass.tpe)
-        beforeTyper {
+        enteringTyper {
           sym addAnnotation VolatileAttr
         }
 

--- a/src/compiler/scala/tools/nsc/transform/PostErasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/PostErasure.scala
@@ -24,7 +24,7 @@ trait PostErasure extends InfoTransform with TypingTransformers {
       case ConstantType(Constant(tp: Type)) =>
         ConstantType(Constant(apply(tp)))
       case ErasedValueType(tref) =>
-        atPhase(currentRun.erasurePhase)(erasure.erasedValueClassArg(tref))
+        enteringPhase(currentRun.erasurePhase)(erasure.erasedValueClassArg(tref))
       case _ => mapOver(tp)
     }
   }
@@ -39,7 +39,7 @@ trait PostErasure extends InfoTransform with TypingTransformers {
           Apply(sel @ Select(
             Apply(Select(New(tpt), nme.CONSTRUCTOR), List(arg)),
             acc), List())
-        if atPhase(currentRun.erasurePhase) {
+        if enteringPhase(currentRun.erasurePhase) {
           tpt.tpe.typeSymbol.isDerivedValueClass &&
           sel.symbol == tpt.tpe.typeSymbol.derivedValueClassUnbox
         } =>
@@ -50,7 +50,7 @@ trait PostErasure extends InfoTransform with TypingTransformers {
             Apply(Select(New(tpt1), nme.CONSTRUCTOR), List(arg1)),
             cmp),
             List(Apply(Select(New(tpt2), nme.CONSTRUCTOR), List(arg2))))
-        if atPhase(currentRun.erasurePhase) {
+        if enteringPhase(currentRun.erasurePhase) {
           tpt1.tpe.typeSymbol.isDerivedValueClass &&
           (cmp == nme.EQ || cmp == nme.NE) &&
           tpt2.tpe.typeSymbol == tpt1.tpe.typeSymbol

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -402,7 +402,7 @@ abstract class UnCurry extends InfoTransform
 
         // when calling into scala varargs, make sure it's a sequence.
         def arrayToSequence(tree: Tree, elemtp: Type) = {
-          afterUncurry {
+          exitingUncurry {
             localTyper.typedPos(pos) {
               val pt = arrayType(elemtp)
               val adaptedTree = // might need to cast to Array[elemtp], as arrays are not covariant
@@ -432,7 +432,7 @@ abstract class UnCurry extends InfoTransform
               case _          => EmptyTree
             }
           }
-          afterUncurry {
+          exitingUncurry {
             localTyper.typedPos(pos) {
               gen.mkMethodCall(tree, toArraySym, Nil, List(traversableClassTag(tree.tpe)))
             }
@@ -456,7 +456,7 @@ abstract class UnCurry extends InfoTransform
             else arrayToSequence(mkArray, varargsElemType)
           }
 
-        afterUncurry {
+        exitingUncurry {
           if (isJava && !isReferenceArray(suffix.tpe) && isArrayOfSymbol(fun.tpe.params.last.tpe, ObjectClass)) {
             // The array isn't statically known to be a reference array, so call ScalaRuntime.toObjectArray.
             suffix = localTyper.typedPos(pos) {
@@ -664,7 +664,7 @@ abstract class UnCurry extends InfoTransform
       result setType uncurryTreeType(result.tpe)
     }
 
-    def postTransform(tree: Tree): Tree = afterUncurry {
+    def postTransform(tree: Tree): Tree = exitingUncurry {
       def applyUnary(): Tree = {
         // TODO_NMT: verify that the inner tree of a type-apply also gets parens if the
         // whole tree is a polymorphic nullary method application

--- a/src/compiler/scala/tools/nsc/typechecker/Tags.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Tags.scala
@@ -10,7 +10,7 @@ trait Tags {
   trait Tag {
     self: Typer =>
 
-    private def resolveTag(pos: Position, taggedTp: Type, allowMaterialization: Boolean) = beforeTyper {
+    private def resolveTag(pos: Position, taggedTp: Type, allowMaterialization: Boolean) = enteringTyper {
       def wrapper (tree: => Tree): Tree = if (allowMaterialization) (context.withMacrosEnabled[Tree](tree)) else (context.withMacrosDisabled[Tree](tree))
       wrapper(inferImplicit(
         EmptyTree,

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -1615,7 +1615,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
      */
     def unsafeTypeParams: List[Symbol] =
       if (isMonomorphicType) Nil
-      else atPhase(unsafeTypeParamPhase)(rawInfo.typeParams)
+      else enteringPhase(unsafeTypeParamPhase)(rawInfo.typeParams)
 
     /** The type parameters of this symbol.
      *  assumption: if a type starts out as monomorphic, it will not acquire
@@ -1627,9 +1627,9 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
         // analogously to the "info" getter, here we allow for two completions:
         //   one: sourceCompleter to LazyType, two: LazyType to completed type
         if (validTo == NoPeriod)
-          atPhase(phaseOf(infos.validFrom))(rawInfo load this)
+          enteringPhase(phaseOf(infos.validFrom))(rawInfo load this)
         if (validTo == NoPeriod)
-          atPhase(phaseOf(infos.validFrom))(rawInfo load this)
+          enteringPhase(phaseOf(infos.validFrom))(rawInfo load this)
 
         rawInfo.typeParams
       }

--- a/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
+++ b/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
@@ -838,7 +838,7 @@ abstract class UnPickler /*extends reflect.generic.UnPickler*/ {
       private val p = phase
       override def complete(sym: Symbol) : Unit = try {
         val tp = at(i, () => readType(sym.isTerm)) // after NMT_TRANSITION, revert `() => readType(sym.isTerm)` to `readType`
-        atPhase(p) (sym setInfo tp)
+        enteringPhase(p) (sym setInfo tp)
         if (currentRunId != definedAtRunId)
           sym.setInfo(adaptToNewRunMap(tp))
       }
@@ -856,7 +856,7 @@ abstract class UnPickler /*extends reflect.generic.UnPickler*/ {
         super.complete(sym)
         var alias = at(j, readSymbol)
         if (alias.isOverloaded)
-          alias = atPhase(picklerPhase)((alias suchThat (alt => sym.tpe =:= sym.owner.thisType.memberType(alt))))
+          alias = enteringPhase(picklerPhase)((alias suchThat (alt => sym.tpe =:= sym.owner.thisType.memberType(alt))))
 
         sym.asInstanceOf[TermSymbol].setAlias(alias)
       }

--- a/src/reflect/scala/reflect/internal/util/TraceSymbolActivity.scala
+++ b/src/reflect/scala/reflect/internal/util/TraceSymbolActivity.scala
@@ -125,7 +125,7 @@ trait TraceSymbolActivity {
     }
     ph
   }
-  private def runBeforeErasure[T](body: => T): T = atPhase(findErasurePhase)(body)
+  private def runBeforeErasure[T](body: => T): T = enteringPhase(findErasurePhase)(body)
 
   def showAllSymbols() {
     if (!traceSymbolActivity) return

--- a/src/reflect/scala/reflect/runtime/SymbolLoaders.scala
+++ b/src/reflect/scala/reflect/runtime/SymbolLoaders.scala
@@ -28,7 +28,7 @@ trait SymbolLoaders { self: SymbolTable =>
       debugInfo("completing "+sym+"/"+clazz.fullName)
       assert(sym == clazz || sym == module || sym == module.moduleClass)
 //      try {
-      atPhaseNotLaterThan(picklerPhase) {
+      enteringPhaseNotLaterThan(picklerPhase) {
         val loadingMirror = mirrorThatLoaded(sym)
         val javaClass = loadingMirror.javaClass(clazz.javaClassName)
         loadingMirror.unpickleClass(clazz, module, javaClass)

--- a/test/files/run/compiler-asSeenFrom.scala
+++ b/test/files/run/compiler-asSeenFrom.scala
@@ -107,7 +107,7 @@ package ll {
   def check(source: String, unit: global.CompilationUnit) = {
     import syms._
 
-    afterTyper {
+    exitingTyper {
       val typeArgs = List[Type](IntClass.tpe, ListClass[Int]) ++ tparams.map(_.tpe)
       permute(typeArgs) foreach println
     }

--- a/test/files/run/existentials-in-compiler.scala
+++ b/test/files/run/existentials-in-compiler.scala
@@ -73,7 +73,7 @@ package extest {
 
   def check(source: String, unit: global.CompilationUnit) = {
     getRequiredModule("extest").moduleClass.info.decls.toList.filter(_.isType).map(_.initialize).sortBy(_.name.toString) foreach { clazz =>
-      afterTyper {
+      exitingTyper {
         clazz.info
         println(clazz.defString)
         println("    " + classExistentialType(clazz) + "\n")


### PR DESCRIPTION
enteringPhase and exitingPhase are our unambiguously named
phase time travel methods.  atPhase is deprecated.  Other methods
and uses have all been brought into line with that.

Review by @lrytz.
