### PR TITLE
Removes annoying this "would catch all throwables" warnings

### DIFF
--- a/src/compiler/scala/tools/ant/FastScalac.scala
+++ b/src/compiler/scala/tools/ant/FastScalac.scala
@@ -159,7 +159,7 @@ class FastScalac extends Scalac {
       val url = ScalaClassLoader.originOfClass(classOf[FastScalac]).get
       File(url.getFile).jfile.getParentFile.getParentFile.getAbsolutePath
     } catch {
-      case _ =>
+      case _: Throwable =>
         buildError("Compilation failed because of an internal compiler error;"+
                    " couldn't determine value for -Dscala.home=<value>")
     }

--- a/src/compiler/scala/tools/ant/Scaladoc.scala
+++ b/src/compiler/scala/tools/ant/Scaladoc.scala
@@ -658,14 +658,10 @@ class Scaladoc extends ScalaMatchingTask {
           "; see the documenter output for details.")
       reporter.printSummary()
     } catch {
-      case exception: Throwable if exception.getMessage ne null =>
+      case exception: Throwable =>
         exception.printStackTrace()
-        safeBuildError("Document failed because of an internal documenter error (" +
-          exception.getMessage + "); see the error output for details.")
-      case exception =>
-        exception.printStackTrace()
-        safeBuildError("Document failed because of an internal documenter error " +
-          "(no error message provided); see the error output for details.")
+        val msg = Option(exception.getMessage) getOrElse "no error message provided"
+        safeBuildError(s"Document failed because of an internal documenter error ($msg); see the error output for details.")
     }
   }
 

--- a/src/compiler/scala/tools/nsc/CompileServer.scala
+++ b/src/compiler/scala/tools/nsc/CompileServer.scala
@@ -154,7 +154,7 @@ class StandardCompileServer extends SocketServer {
         case ex @ FatalError(msg) =>
           reporter.error(null, "fatal error: " + msg)
           clearCompiler()
-        case ex =>
+        case ex: Throwable =>
           warn("Compile server encountered fatal condition: " + ex)
           shutdown = true
           throw ex

--- a/src/compiler/scala/tools/nsc/Driver.scala
+++ b/src/compiler/scala/tools/nsc/Driver.scala
@@ -53,7 +53,7 @@ abstract class Driver {
         else
           doCompile(compiler)
       } catch {
-        case ex =>
+        case ex: Throwable =>
           compiler.logThrowable(ex)
           ex match {
             case FatalError(msg)  => reporter.error(null, "fatal error: " + msg)

--- a/src/compiler/scala/tools/nsc/ObjectRunner.scala
+++ b/src/compiler/scala/tools/nsc/ObjectRunner.scala
@@ -33,7 +33,7 @@ trait CommonRunner {
    */
   def runAndCatch(urls: List[URL], objectName: String, arguments: Seq[String]): Either[Throwable, Boolean] = {
     try   { run(urls, objectName, arguments) ; Right(true) }
-    catch { case e => Left(unwrap(e)) }
+    catch { case e: Throwable => Left(unwrap(e)) }
   }
 }
 

--- a/src/compiler/scala/tools/nsc/ScriptRunner.scala
+++ b/src/compiler/scala/tools/nsc/ScriptRunner.scala
@@ -199,7 +199,7 @@ class ScriptRunner extends HasCompileSocket {
     scriptArgs: List[String]): Either[Throwable, Boolean] =
   {
     try Right(runScript(settings, scriptFile, scriptArgs))
-    catch { case e => Left(unwrap(e)) }
+    catch { case e: Throwable => Left(unwrap(e)) }
   }
 
   /** Run a command

--- a/src/compiler/scala/tools/nsc/ast/TreeBrowsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeBrowsers.scala
@@ -140,7 +140,7 @@ abstract class TreeBrowsers {
       UIManager.setLookAndFeel("com.sun.java.swing.plaf.nimbus.NimbusLookAndFeel")
     }
     catch {
-      case _ => UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName())
+      case _: Throwable => UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName())
     }
 
     val frame = new JFrame("Scala AST after " + phaseName + " phase")

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
@@ -877,7 +877,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters {
 
           def wrap(op: => Unit) = {
             try   { op; true }
-            catch { case _ => false }
+            catch { case _: Throwable => false }
           }
 
       if (settings.Xverify.value) {

--- a/src/compiler/scala/tools/nsc/doc/html/page/diagram/DotRunner.scala
+++ b/src/compiler/scala/tools/nsc/doc/html/page/diagram/DotRunner.scala
@@ -106,7 +106,7 @@ class DotProcess(settings: doc.Settings) {
       result
 
     } catch {
-      case exc =>
+      case exc: Throwable =>
         errorBuffer.append("  Main thread in " + templateName + ": " +
           (if (exc.isInstanceOf[NoSuchElementException]) "Timeout" else "Exception: " + exc))
         error = true
@@ -173,7 +173,7 @@ class DotProcess(settings: doc.Settings) {
       }
       stdin.close()
     } catch {
-      case exc =>
+      case exc: Throwable =>
         error = true
         stdin.close()
         errorBuffer.append("  Input thread in " + templateName + ": Exception: " + exc + "\n")
@@ -199,7 +199,7 @@ class DotProcess(settings: doc.Settings) {
       outputString.put(buffer.toString)
       stdOut.close()
     } catch {
-      case exc =>
+      case exc: Throwable =>
         error = true
         stdOut.close()
         errorBuffer.append("  Output thread in " + templateName + ": Exception: " + exc + "\n")
@@ -218,7 +218,7 @@ class DotProcess(settings: doc.Settings) {
       }
       stdErr.close()
     } catch {
-      case exc =>
+      case exc: Throwable =>
         error = true
         stdErr.close()
         errorBuffer.append("  Error thread in " + templateName + ": Exception: " + exc + "\n")

--- a/src/compiler/scala/tools/nsc/doc/model/ModelFactoryImplicitSupport.scala
+++ b/src/compiler/scala/tools/nsc/doc/model/ModelFactoryImplicitSupport.scala
@@ -242,7 +242,7 @@ trait ModelFactoryImplicitSupport {
 
           available = Some(search.tree != EmptyTree)
         } catch {
-          case _ =>
+          case _ => // !!! [Martin]: One should never silently catch all Throwables. Please sharpen the exception type.
         }
       }
 

--- a/src/compiler/scala/tools/nsc/interactive/Global.scala
+++ b/src/compiler/scala/tools/nsc/interactive/Global.scala
@@ -627,7 +627,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "")
         response raise ex
         throw ex
 
-      case ex =>
+      case ex: Throwable =>
         if (debugIDE) {
           println("exception thrown during response: "+ex)
           ex.printStackTrace()

--- a/src/compiler/scala/tools/nsc/interactive/PresentationCompilerThread.scala
+++ b/src/compiler/scala/tools/nsc/interactive/PresentationCompilerThread.scala
@@ -36,7 +36,7 @@ final class PresentationCompilerThread(var compiler: Global, name: String = "")
 
         // make sure we don't keep around stale instances
         compiler = null
-      case ex =>
+      case ex: Throwable =>
         compiler.log.flush()
 
         ex match {

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -1140,7 +1140,7 @@ trait Macros extends scala.tools.reflect.FastTrack with Traces {
     }
 
     try macroExpandInternal
-    catch { case ex => handleMacroExpansionException(typer, expandee, ex) }
+    catch { case ex: Throwable => handleMacroExpansionException(typer, expandee, ex) }
   }
 
   private def macroExpandWithoutRuntime(typer: Typer, expandee: Tree): MacroExpansionResult = {

--- a/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
@@ -129,7 +129,7 @@ abstract class TreeCheckers extends Analyzer {
 
   private def wrap[T](msg: => Any)(body: => Unit) {
     try body
-    catch { case x =>
+    catch { case x: Throwable =>
       Console.println("Caught " + x)
       Console.println(msg)
       x.printStackTrace

--- a/src/compiler/scala/tools/nsc/util/InterruptReq.scala
+++ b/src/compiler/scala/tools/nsc/util/InterruptReq.scala
@@ -19,7 +19,7 @@ abstract class InterruptReq {
     try {
       result = Some(Left(todo()))
     } catch {
-      case t => result = Some(Right(t))
+      case t: Throwable => result = Some(Right(t))
     }
     notify()
   }

--- a/src/compiler/scala/tools/util/VerifyClass.scala
+++ b/src/compiler/scala/tools/util/VerifyClass.scala
@@ -13,7 +13,7 @@ object VerifyClass {
       Class.forName(name, true, cl)
       (name, None)
     } catch {
-      case x => (name, Some(x.toString))
+      case x: Throwable => (name, Some(x.toString))
     }
   }
 


### PR DESCRIPTION
Silenced all "this would catch all throwables" messages in tools build except one. The one that still warns needs to be fixed by tightening the caught exception to be something different from Throwable. Review by @VladUreche.
