### PR TITLE
SI-1832 consistent symbols in casedef's pattern&body

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -225,38 +225,15 @@ abstract class UnCurry extends InfoTransform
     }
 
 
-    /*  Transform a function node (x_1,...,x_n) => body of type FunctionN[T_1, .., T_N, R] to
+    /**  Transform a function node (x_1,...,x_n) => body of type FunctionN[T_1, .., T_N, R] to
      *
      *    class $anon() extends AbstractFunctionN[T_1, .., T_N, R] with Serializable {
      *      def apply(x_1: T_1, ..., x_N: T_n): R = body
      *    }
      *    new $anon()
      *
-     *  transform a function node (x => body) of type PartialFunction[T, R] where
-     *    body = expr match { case P_i if G_i => E_i }_i=1..n
-     *  to:
+     * If `settings.XoldPatmat.value`, also synthesized AbstractPartialFunction subclasses (see synthPartialFunction).
      *
-     //TODO: correct code template below
-     *    class $anon() extends AbstractPartialFunction[T, R] with Serializable {
-     *      def applyOrElse[A1 <: A, B1 >: B](x: A1, default: A1 => B1): B1 = (expr: @unchecked) match {
-     *        case P_1 if G_1 => E_1
-     *        ...
-     *        case P_n if G_n => E_n
-     *        case _ => default(expr)
-     *      }
-     *      def isDefinedAt(x: T): boolean = (x: @unchecked) match {
-     *        case P_1 if G_1 => true
-     *        ...
-     *        case P_n if G_n => true
-     *        case _ => false
-     *      }
-     *    }
-     *    new $anon()
-     *
-     *  However, if one of the patterns P_i if G_i is a default pattern,
-     *  drop the last default clause in the definition of `apply` and generate for `_isDefinedAt` instead
-     *
-     *      def isDefinedAtCurrent(x: T): boolean = true
      */
     def transformFunction(fun: Function): Tree =
       deEta(fun) match {
@@ -300,6 +277,28 @@ abstract class UnCurry extends InfoTransform
 
       }
 
+    /** Transform a function node (x => body) of type PartialFunction[T, R] where
+     *    body = expr match { case P_i if G_i => E_i }_i=1..n
+     *  to (assuming none of the cases is a default case):
+     *
+     *    class $anon() extends AbstractPartialFunction[T, R] with Serializable {
+     *      def applyOrElse[A1 <: A, B1 >: B](x: A1, default: A1 => B1): B1 = (expr: @unchecked) match {
+     *        case P_1 if G_1 => E_1
+     *        ...
+     *        case P_n if G_n => E_n
+     *        case _ => default(expr)
+     *      }
+     *      def isDefinedAt(x: T): boolean = (x: @unchecked) match {
+     *        case P_1 if G_1 => true
+     *        ...
+     *        case P_n if G_n => true
+     *        case _ => false
+     *      }
+     *    }
+     *    new $anon()
+     *
+     *  If there's a default case, the original match is used for applyOrElse, and isDefinedAt returns `true`
+     */
     def synthPartialFunction(fun: Function) = {
       if (!settings.XoldPatmat.value) debugwarn("Under the new pattern matching scheme, PartialFunction should have been synthesized during typers.")
 

--- a/test/files/pos/t1832.scala
+++ b/test/files/pos/t1832.scala
@@ -1,0 +1,8 @@
+trait Cloning {
+  trait Foo
+  def fn(g: Any => Unit): Foo
+  
+  implicit def mkStar(i: Int) = new { def *(a: Foo): Foo = null }
+
+  val pool = 4 * fn { case ghostSYMBOL: Int => ghostSYMBOL * 2 }
+}


### PR DESCRIPTION
the only change to typedBind in this commit (beyond refactoring to keep my eyes from bleeding),
is explained by the added comment:

have to imperatively set the symbol for this bind to keep it in sync with the symbols used in the body of a case
when type checking a case we imperatively update the symbols in the body of the case
those symbols are bound by the symbols in the Binds in the pattern of the case,
so, if we set the symbols in the case body, but not in the patterns,
then re-type check the casedef (for a second try in typedApply for example -- SI-1832),
we are no longer in sync: the body has symbols set that do not appear in the patterns
since body1 is not necessarily equal to body, we must return a copied tree,
but we must still mutate the original bind
