### PR TITLE
SI 4881 fixed.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -575,8 +575,18 @@ trait Infer {
             "argument expression's type is not compatible with formal parameter type" + foundReqMsg(tp1, pt1))
         }
       }
+      
+      /** Determine which variance to assume for the type paraneter. We first chose the variance
+       *  that minimizes any formal parameters. If that is still undetermined, because the type parameter
+       *  does not appear as a formal parameter type, then we pick the variance so that it minimizes the
+       *  method's result type instead.
+       */
+      def inferVariance(tparam: Symbol): Int = {
+        val v = varianceInTypes(formals)(tparam)
+        if (v != VarianceFlags) v else varianceInType(restpe)(tparam)
+      }
       val targs = solvedTypes(
-        tvars, tparams, tparams map varianceInTypes(formals),
+        tvars, tparams, tparams map inferVariance,
         false, lubDepth(formals) max lubDepth(argtpes)
       )
       adjustTypeArgs(tparams, tvars, targs, restpe)

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -445,7 +445,7 @@ trait Infer {
       val tvars = tparams map freshVar
       if (isConservativelyCompatible(restpe.instantiateTypeParams(tparams, tvars), pt))
         map2(tparams, tvars)((tparam, tvar) =>
-          instantiateToBound(tvar, varianceInTypes(formals)(tparam)))
+          instantiateToBound(tvar, inferVariance(formals, restpe)(tparam)))
       else
         tvars map (tvar => WildcardType)
     }
@@ -576,20 +576,21 @@ trait Infer {
         }
       }
       
-      /** Determine which variance to assume for the type paraneter. We first chose the variance
-       *  that minimizes any formal parameters. If that is still undetermined, because the type parameter
-       *  does not appear as a formal parameter type, then we pick the variance so that it minimizes the
-       *  method's result type instead.
-       */
-      def inferVariance(tparam: Symbol): Int = {
-        val v = varianceInTypes(formals)(tparam)
-        if (v != VarianceFlags) v else varianceInType(restpe)(tparam)
-      }
       val targs = solvedTypes(
-        tvars, tparams, tparams map inferVariance,
+        tvars, tparams, tparams map inferVariance(formals, restpe),
         false, lubDepth(formals) max lubDepth(argtpes)
       )
       adjustTypeArgs(tparams, tvars, targs, restpe)
+    }
+
+    /** Determine which variance to assume for the type paraneter. We first chose the variance
+     *  that minimizes any formal parameters. If that is still undetermined, because the type parameter
+     *  does not appear as a formal parameter type, then we pick the variance so that it minimizes the
+     *  method's result type instead.
+     */
+    private def inferVariance(formals: List[Type], restpe: Type)(tparam: Symbol): Int = {
+      val v = varianceInTypes(formals)(tparam)
+      if (v != VarianceFlags) v else varianceInType(restpe)(tparam)
     }
 
     private[typechecker] def followApply(tp: Type): Type = tp match {

--- a/test/files/neg/t5845.check
+++ b/test/files/neg/t5845.check
@@ -1,7 +1,4 @@
-t5845.scala:9: error: value +++ is not a member of Int
-  println(5 +++ 5)
-            ^
 t5845.scala:15: error: value +++ is not a member of Int
   println(5 +++ 5)
             ^
-two errors found
+one error found

--- a/test/files/pos/t4881.scala
+++ b/test/files/pos/t4881.scala
@@ -1,0 +1,13 @@
+class Contra[-T]
+trait A
+trait B extends A
+trait C extends B
+
+object Test {
+  def contraLBUB[a >: C <: A](): Contra[a] = null
+  def contraLB[a >: C](): Contra[a] = null
+  val x = contraLBUB() //inferred Contra[C] instead of Contra[A]
+  val x1: Contra[A] = x
+  val y = contraLB() //inferred Contra[C] instead of Contra[Any]
+  val y1: Contra[Any] = y
+}


### PR DESCRIPTION
Changed behavior so that when determining the target variance of a method parameter, the variance in formals comes first, but if variance is still undecided by that, the variance in the result type is used as a secondary criterion.
