### PR TITLE
SI-6089 pt2: _ is tailpos in `_ || _` and `_ && _`

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/TailCalls.scala
+++ b/src/compiler/scala/tools/nsc/transform/TailCalls.scala
@@ -397,6 +397,9 @@ abstract class TailCalls extends Transform {
       case Apply(fun, arg :: Nil) if hasSynthCaseSymbol(fun) && tailLabels(fun.symbol) =>
         traverse(arg)
 
+      case Apply(fun, args) if (fun.symbol == Boolean_or || fun.symbol == Boolean_and) =>
+        traverseTrees(args)
+
       // a translated casedef
       case LabelDef(_, _, body) if hasSynthCaseSymbol(tree) =>
         traverse(body)


### PR DESCRIPTION
pull #939 made tail position detection for matches more strict to fix SI-6089,
but became too strict: need to include the tail positions `_` in `_ || _` and `_ && _`.

review by @jsuereth
