### PR TITLE
SI-6090

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/PostErasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/PostErasure.scala
@@ -52,7 +52,7 @@ trait PostErasure extends InfoTransform with TypingTransformers {
             List(Apply(Select(New(tpt2), nme.CONSTRUCTOR), List(arg2))))
         if atPhase(currentRun.erasurePhase) {
           tpt1.tpe.typeSymbol.isDerivedValueClass &&
-          (cmp == nme.EQ || cmp == nme.NE) &&
+          (sel.symbol == Object_== || sel.symbol == Object_!=) &&
           tpt2.tpe.typeSymbol == tpt1.tpe.typeSymbol
         } =>
           val result = Apply(Select(arg1, cmp) setPos sel.pos, List(arg2)) setPos tree.pos

--- a/test/files/run/t6090.scala
+++ b/test/files/run/t6090.scala
@@ -1,0 +1,6 @@
+class X { def ==(other: X) = true }
+class V(val x: X) extends AnyVal
+object Test extends {
+  def main(args: Array[String]) =
+    assert((new V(new X) == new V(new X)))
+}


### PR DESCRIPTION
Sharpens the test so that only Object_== and Object_!= methods on valueclasses may be rewritten in posterasure, whereas user-defined methods are not rewritten. Review by @retronym.
