### PR TITLE
Improve unchecked warnings a little.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1267,16 +1267,18 @@ trait Infer {
         tp match {
           case SingleType(pre, _) =>
             check(pre, bound)
+          case TypeRef(_, NothingClass | NullClass | AnyValClass, _) =>
+            TypePatternOrIsInstanceTestError(tree, tp)
           case TypeRef(pre, sym, args) =>
             if (sym.isAbstractType) {
               // we only use the extractor for top-level type tests, type arguments (see below) remain unchecked
               if (!isLocalBinding(sym) && !canRemedy) patternWarning(tp, "abstract type ")
-            } else if (sym.isAliasType) {
+            }
+            else if (sym.isAliasType) {
               check(tp.normalize, bound)
-            } else if (sym == NothingClass || sym == NullClass || sym == AnyValClass) {
-              TypePatternOrIsInstanceTestError(tree, tp)
-            } else {
-              for (arg <- args) {
+            }
+            else {
+              for ((param, arg) <- sym.typeParams zip args) {
                 if (sym == ArrayClass) check(arg, bound)
                 else if (arg.typeArgs.nonEmpty) ()              // avoid spurious warnings with higher-kinded types
                 else if (sym == NonLocalReturnControlClass) ()  // no way to suppress unchecked warnings on try/catch
@@ -1287,7 +1289,12 @@ trait Infer {
                     // Want to warn about type arguments, not type parameters. Otherwise we'll
                     // see warnings about "invisible" types, like: val List(x0) = x1 leading to "non
                     // variable type-argument A in type pattern List[A]..."
-                    if (!arg.typeSymbol.isTypeParameterOrSkolem)
+                    if (arg.typeSymbol.isTypeParameterOrSkolem)
+                      log("Suppressing unchecked warning for 'invisible' type " + arg)
+                    // case _: Seq[Any] should not warn about "Any"
+                    else if (param.isCovariant && arg.typeSymbol == AnyClass)
+                      log("Suppressing unchecked warning for 'Any' in covariant position")
+                    else
                       patternWarning(arg, "non variable type-argument ")
                 }
               }

--- a/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
@@ -389,8 +389,9 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
         **/
         // must treat Typed and Bind together -- we need to know the patBinder of the Bind pattern to get at the actual type
         case MaybeBoundTyped(subPatBinder, pt) =>
+          val next = glb(List(patBinder.info.widen, pt)).normalize
           // a typed pattern never has any subtrees
-          noFurtherSubPats(TypeTestTreeMaker(subPatBinder, patBinder, pt, glb(List(patBinder.info.widen, pt)).normalize)(pos))
+          noFurtherSubPats(TypeTestTreeMaker(subPatBinder, patBinder, pt, next)(pos))
 
         /** A pattern binder x@p consists of a pattern variable x and a pattern p.
             The type of the variable x is the static type T of the pattern p.

--- a/test/files/neg/unchecked.check
+++ b/test/files/neg/unchecked.check
@@ -1,0 +1,16 @@
+unchecked.scala:14: error: non variable type-argument String in type pattern Iterable[String] is unchecked since it is eliminated by erasure
+    case xs: Iterable[String] => xs.head // unchecked
+             ^
+unchecked.scala:18: error: non variable type-argument Any in type pattern Set[Any] is unchecked since it is eliminated by erasure
+    case xs: Set[Any]    => xs.head // unchecked
+             ^
+unchecked.scala:22: error: non variable type-argument Any in type pattern Map[Any,Any] is unchecked since it is eliminated by erasure
+    case xs: Map[Any, Any] => xs.head // unchecked
+             ^
+unchecked.scala:27: error: non variable type-argument Int in type pattern Test.Exp[Int] is unchecked since it is eliminated by erasure
+    case ArrayApply(x: Exp[Array[T]], i: Exp[Int], _) => x // okay - shouldn't warn, TODO
+                                         ^
+unchecked.scala:32: error: non variable type-argument String in type pattern Test.Exp[String] is unchecked since it is eliminated by erasure
+    case ArrayApply(x: Exp[Array[T]], _, j: Exp[String]) => x // unchecked
+                                            ^
+5 errors found

--- a/test/files/neg/unchecked.flags
+++ b/test/files/neg/unchecked.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -unchecked

--- a/test/files/neg/unchecked.scala
+++ b/test/files/neg/unchecked.scala
@@ -1,0 +1,50 @@
+object Test {
+  class Def[T]
+  class Exp[T]
+
+  case class ArrayApply[T](x: Exp[Array[T]], i: Exp[Int], j: Exp[_]) extends Def[T]
+
+  val IntArrayApply = ArrayApply[Int](new Exp[Array[Int]], new Exp[Int], new Exp[Int])
+
+  def f(x: Any) = x match {
+    case xs: Iterable[Any]    => xs.head // okay
+    case _                    => 0
+  }
+  def f2(x: Any) = x match {
+    case xs: Iterable[String] => xs.head // unchecked
+    case _                    => 0
+  }
+  def f3(x: Any) = x match {
+    case xs: Set[Any]    => xs.head // unchecked
+    case _                    => 0
+  }
+  def f4(x: Any) = x match {
+    case xs: Map[Any, Any] => xs.head // unchecked
+    case _                 => 0
+  }
+
+  def g[T](x: Def[T]) = x match {
+    case ArrayApply(x: Exp[Array[T]], i: Exp[Int], _) => x // okay - shouldn't warn, TODO
+    case _                                            => 0
+  }
+
+  def g2[T](x: Def[T]) = x match {
+    case ArrayApply(x: Exp[Array[T]], _, j: Exp[String]) => x // unchecked
+    case _                                               => 0
+  }
+
+  def g3[T](x: Any) = x match {
+    case ArrayApply(x: Exp[Array[T]], _, _) => x // unchecked
+    case _                                  => 0
+  }
+
+  def g4 = IntArrayApply match {
+    case ArrayApply(x: Exp[Array[Int]], _, _) => x // okay
+    case _                                    => ()
+  }
+  // 
+  // def g5 = IntArrayApply match {
+  //   case ArrayApply(x: Exp[Array[String]], _, _) => x // nope
+  //   case _                                       => ()
+  // }
+}


### PR DESCRIPTION
Don't warn on case _: CC[Any] if Any corresponds to a
covariant type parameter.
