### PR TITLE
Fix 4560

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -65,14 +65,14 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
      *  the enclosing implementation class instead.
      */
     def safeREF(sym: Symbol) = {
-      def fix(tree: Tree): Unit = tree match {
-        case Select(qual @ This(_), name) if qual.symbol != currentClass =>
-          qual.setSymbol(currentClass).setType(currentClass.tpe)
-        case _ =>
+      def fix(tree: Tree): Tree = tree match {
+        case Select(qual, name) => treeCopy.Select(tree, fix(qual), name)
+        case This(_) if tree.symbol.isInterface && tree.symbol.name + "$class" == currentClass.name.toString =>
+          tree.setSymbol(currentClass).setType(currentClass.tpe)
+        case _ => tree
       }
       val tree = REF(sym)
-      if (currentClass.isImplClass && sym.owner == currentClass) fix(tree)
-      tree
+      if (currentClass.isImplClass) fix(tree) else tree
     }
 
     //private val classConstantMeth = new HashMap[String, Symbol]

--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -58,23 +58,6 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
     }
     private def mkTerm(prefix: String): TermName = unit.freshTermName(prefix)
     
-    /** Kludge to provide a safe fix for #4560:
-     *  If we generate a reference in an implementation class, we
-     *  watch out for embedded This(..) nodes that point to the interface.
-     *  These must be wrong. We fix them by setting symbol and type to
-     *  the enclosing implementation class instead.
-     */
-    def safeREF(sym: Symbol) = {
-      def fix(tree: Tree): Tree = tree match {
-        case Select(qual, name) => treeCopy.Select(tree, fix(qual), name)
-        case This(_) if tree.symbol.isInterface && tree.symbol.name + "$class" == currentClass.name.toString =>
-          tree.setSymbol(currentClass).setType(currentClass.tpe)
-        case _ => tree
-      }
-      val tree = REF(sym)
-      if (currentClass.isImplClass) fix(tree) else tree
-    }
-
     //private val classConstantMeth = new HashMap[String, Symbol]
     //private val symbolStaticFields = new HashMap[String, (Symbol, Tree, Tree)]
 
@@ -164,7 +147,7 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
           val varDef = typedPos( VAL(varSym) === forInit )
           newStaticMembers append transform(varDef)
 
-          val varInit = typedPos( safeREF(varSym) === forInit )
+          val varInit = typedPos( REF(varSym) === forInit )
           newStaticInits append transform(varInit)
 
           varSym
@@ -200,7 +183,7 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
                 addStaticVariableToClass(nme.reflParamsCacheName, arrayType(ClassClass.tpe), fromTypesToClassArrayLiteral(paramTypes), true)
 
               addStaticMethodToClass((_, forReceiverSym) =>
-                gen.mkMethodCall(REF(forReceiverSym), Class_getMethod, Nil, List(LIT(method), safeREF(reflParamsCacheSym)))
+                gen.mkMethodCall(REF(forReceiverSym), Class_getMethod, Nil, List(LIT(method), REF(reflParamsCacheSym)))
               )
 
             case MONO_CACHE =>
@@ -239,11 +222,11 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
               addStaticMethodToClass((_, forReceiverSym) =>
                 BLOCK(
                   IF (isCacheEmpty(forReceiverSym)) THEN BLOCK(
-                    safeREF(reflMethodCacheSym) === ((REF(forReceiverSym) DOT Class_getMethod)(LIT(method), safeREF(reflParamsCacheSym))) ,
-                    safeREF(reflClassCacheSym) === gen.mkSoftRef(REF(forReceiverSym)),
+                    REF(reflMethodCacheSym) === ((REF(forReceiverSym) DOT Class_getMethod)(LIT(method), REF(reflParamsCacheSym))) ,
+                    REF(reflClassCacheSym) === gen.mkSoftRef(REF(forReceiverSym)),
                     UNIT
                   ) ENDIF,
-                  safeREF(reflMethodCacheSym)
+                  REF(reflMethodCacheSym)
                 )
               )
 
@@ -277,22 +260,22 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
               val reflPolyCacheSym: Symbol = (
                 addStaticVariableToClass(nme.reflPolyCacheName, SoftReferenceClass.tpe, mkNewPolyCache, false)
               )
-              def getPolyCache = gen.mkCast(fn(safeREF(reflPolyCacheSym), nme.get), MethodCacheClass.tpe)
+              def getPolyCache = gen.mkCast(fn(REF(reflPolyCacheSym), nme.get), MethodCacheClass.tpe)
 
               addStaticMethodToClass((reflMethodSym, forReceiverSym) => {
                 val methodSym = reflMethodSym.newVariable(mkTerm("method"), ad.pos) setInfo MethodClass.tpe
 
                 BLOCK(
-                  IF (getPolyCache OBJ_EQ NULL) THEN (safeREF(reflPolyCacheSym) === mkNewPolyCache) ENDIF,
+                  IF (getPolyCache OBJ_EQ NULL) THEN (REF(reflPolyCacheSym) === mkNewPolyCache) ENDIF,
                   VAL(methodSym) === ((getPolyCache DOT methodCache_find)(REF(forReceiverSym))) ,
                   IF (REF(methodSym) OBJ_!= NULL) .
                     THEN (Return(REF(methodSym)))
                   ELSE {
-                    def methodSymRHS  = ((REF(forReceiverSym) DOT Class_getMethod)(LIT(method), safeREF(reflParamsCacheSym)))
+                    def methodSymRHS  = ((REF(forReceiverSym) DOT Class_getMethod)(LIT(method), REF(reflParamsCacheSym)))
                     def cacheRHS      = ((getPolyCache DOT methodCache_add)(REF(forReceiverSym), REF(methodSym)))
                     BLOCK(
                       REF(methodSym)        === (REF(ensureAccessibleMethod) APPLY (methodSymRHS)),
-                      safeREF(reflPolyCacheSym) === gen.mkSoftRef(cacheRHS),
+                      REF(reflPolyCacheSym) === gen.mkSoftRef(cacheRHS),
                       Return(REF(methodSym))
                     )
                   }
@@ -400,7 +383,7 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
             def genDefaultCall = {
               // reflective method call machinery
               val invokeName  = MethodClass.tpe member nme.invoke_                                  // reflect.Method.invoke(...)
-              def cache       = safeREF(reflectiveMethodCache(ad.symbol.name.toString, paramTypes)) // cache Symbol
+              def cache       = REF(reflectiveMethodCache(ad.symbol.name.toString, paramTypes)) // cache Symbol
               def lookup      = Apply(cache, List(qual1() GETCLASS))                                // get Method object from cache
               def invokeArgs  = ArrayValue(TypeTree(ObjectClass.tpe), params)                       // args for invocation
               def invocation  = (lookup DOT invokeName)(qual1(), invokeArgs)                        // .invoke(qual1, ...)
@@ -495,7 +478,7 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
 
               typedPos {
                 val sym = currentOwner.newValue(mkTerm("qual"), ad.pos) setInfo qual0.tpe
-                qual = safeREF(sym)
+                qual = REF(sym)
 
                 BLOCK(
                   VAL(sym) === qual0,
@@ -678,7 +661,7 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
         val rhs = gen.mkMethodCall(Symbol_apply, arg :: Nil)
         val staticFieldSym = getSymbolStaticField(tree.pos, symname, rhs, tree)
         // create a reference to a static field
-        val ntree = typedWithPos(tree.pos)(safeREF(staticFieldSym))
+        val ntree = typedWithPos(tree.pos)(REF(staticFieldSym))
         super.transform(ntree)
 
       // This transform replaces Array(Predef.wrapArray(Array(...)), <tag>)
@@ -711,7 +694,7 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
 
         // create field definition and initialization
         val stfieldDef  = theTyper.typedPos(pos)(VAL(stfieldSym) === rhs)
-        val stfieldInit = theTyper.typedPos(pos)(safeREF(stfieldSym) === rhs)
+        val stfieldInit = theTyper.typedPos(pos)(REF(stfieldSym) === rhs)
 
         // add field definition to new defs
         newStaticMembers append stfieldDef
@@ -777,8 +760,8 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
           
           val stfieldDef  = localTyper.typedPos(tree.pos)(VAL(stfieldSym) === EmptyTree)
           val flattenedInit = fixedrhs match {
-            case Block(stats, expr) => Block(stats, safeREF(stfieldSym) === expr)
-            case rhs => safeREF(stfieldSym) === rhs
+            case Block(stats, expr) => Block(stats, REF(stfieldSym) === expr)
+            case rhs => REF(stfieldSym) === rhs
           }
           val stfieldInit = localTyper.typedPos(tree.pos)(flattenedInit)
           

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -552,7 +552,6 @@ trait Contexts { self: Analyzer =>
         (  (ab.isTerm || ab == rootMirror.RootClass)
         || (accessWithin(ab) || accessWithinLinked(ab)) &&
              (  !sym.hasLocalFlag
-             || sym.owner.isImplClass // allow private local accesses to impl classes
              || sym.isProtected && isSubThisType(pre, sym.owner)
              || pre =:= sym.owner.thisType
              )

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1392,11 +1392,9 @@ trait Types extends api.Types { self: SymbolTable =>
   final class UniqueThisType(sym: Symbol) extends ThisType(sym) with UniqueType { }
 
   object ThisType extends ThisTypeExtractor {
-    def apply(sym: Symbol): Type = {
-      if (!phase.erasedTypes) unique(new UniqueThisType(sym))
-      else if (sym.isImplClass) sym.typeOfThis
-      else sym.tpe
-    }
+    def apply(sym: Symbol): Type =
+      if (phase.erasedTypes) sym.tpe
+      else unique(new UniqueThisType(sym))
   }
 
   /** A class for singleton types of the form `<prefix>.<sym.name>.type`.

--- a/test/files/run/t4560.check
+++ b/test/files/run/t4560.check
@@ -1,2 +1,6 @@
-5
-5
+'Test
+Success 1
+'Test
+Success 2
+'Test
+Success 3

--- a/test/files/run/t4560.scala
+++ b/test/files/run/t4560.scala
@@ -1,39 +1,66 @@
-object Pimper {
- implicit def pimp(i: Int) = new {
-    def test: String = i.toString
-  }
-}
+// SI-4560 (and SI-4601): Reflection caches are expected in the wrong classfiles
+// with various differing constellations of self-types. This leads to runtime exceptions
+// when the reflection caches are accessed. This tests both reflection cache accesses
+// for structural type method invocations (`y.f()`) (SI-4560) and accesses to symbols which are
+// handled similarly (SI-4601)
 
-trait A
+// TEST 1
+// self-type is other trait
+
+trait Aa
+trait Ab
 
 trait B {
-  self: A =>
+  self: Aa with Ab =>
 
-  def test {
-    import Pimper.pimp
-
-    println(5.test)
+  def y = new { def f() = println("Success 1") }
+  def fail() = {
+    println('Test)
+    y.f()
   }
 }
+
+object Test1 extends Aa with Ab with B
+
+// TEST 2
+// self-type is class
 
 class A2
 
 trait B2 {
   self: A2 =>
 
-  def test {
-    import Pimper.pimp
-
-    println(5.test)
+  def y = new { def f() = println("Success 2") }
+  def fail() = {
+    println('Test)
+    y.f()
   }
 }
 
-object Test extends A with B {
+object Test2 extends A2 with B2
+
+// TEST 3
+// self-type is singleton type
+
+trait B3 {
+  this: Test3.type =>
+
+  def y = new { def f() = println("Success 3") }
+  def fail() = {
+    println('Test)
+    y.f()
+  }
+}
+
+object Test3 extends B3 {
+  def test { fail() }
+}
+
+object Test {
   def main(args: Array[String]) {
-    test
-    Test2.test
+    Test1.fail()
+    Test2.fail()
+    Test3.fail()
   }
 }
-
-object Test2 extends A2 with B2 
 

--- a/test/pending/run/t4560.scala
+++ b/test/pending/run/t4560.scala
@@ -1,9 +1,0 @@
-trait B {
-  this: Test.type =>
-
-  def y = new { def f() = () }
-  def fail() = y.f()
-}
-object Test extends B {
-  def main(args: Array[String]): Unit = fail()
-}


### PR DESCRIPTION
Here's a proposal to fix 4560 [as suggested](https://issues.scala-lang.org/browse/SI-4560) by @odersky:

I reverted both the original bugfixes/workarounds, 7127d8293775905acd0d04e21d9e045b5c029261 and 124cf3f9cbdc582a432c13edd229ba9b8726b99f and then reverted the commit which supposedly introduced the bug in the first place, cb4fd65825f3c88908103e48d0d7e89d70d26c22. I included the pending parts of the test and cleaned it up altogether.

Do we want to have all those revert commits in the history or should I produce a squashed commit of all the changes? Should this still go into the 2.10.x branch since the bug priority recently was lowered from 'critical' to 'major'?
