### PR TITLE
SI-6122: Small changes to reflection API to make it safe for IDE use.

### DIFF
--- a/src/library/scala/reflect/base/Base.scala
+++ b/src/library/scala/reflect/base/Base.scala
@@ -96,8 +96,8 @@ class Base extends Universe { self =>
 
   // todo. write a decent toString that doesn't crash on recursive types
   class Type extends TypeBase {
-    def typeSymbol: Symbol = NoSymbol
     def termSymbol: Symbol = NoSymbol
+    def typeSymbol: Symbol = NoSymbol
   }
   implicit val TypeTagg = ClassTag[Type](classOf[Type])
 

--- a/src/library/scala/reflect/base/Types.scala
+++ b/src/library/scala/reflect/base/Types.scala
@@ -3,24 +3,13 @@ package base
 
 trait Types { self: Universe =>
 
-  /** The base API that all types support */
-  abstract class TypeBase {
-
-    /** The term symbol associated with the type, or `NoSymbol` for types
-     *  that do not refer to a term symbol.
-     */
-    def termSymbol: Symbol
-
-    /** The type symbol associated with the type, or `NoSymbol` for types
-     *  that do not refer to a type symbol.
-     */
-    def typeSymbol: Symbol
-  }
-
   /** The type of Scala types, and also Scala type signatures.
    *  (No difference is internally made between the two).
    */
   type Type >: Null <: TypeBase
+
+  /** The base API that all types support */
+  abstract class TypeBase
 
   /** A tag that preserves the identity of the `Type` abstract type from erasure.
    *  Can be used for pattern matching, instance tests, serialization and likes.

--- a/src/reflect/scala/reflect/api/Types.scala
+++ b/src/reflect/scala/reflect/api/Types.scala
@@ -8,6 +8,15 @@ trait Types extends base.Types { self: Universe =>
   /** The extended API of types
    */
   abstract class TypeApi extends TypeBase {
+    /** The term symbol associated with the type, or `NoSymbol` for types
+     *  that do not refer to a term symbol.
+     */
+    def termSymbol: Symbol
+
+    /** The type symbol associated with the type, or `NoSymbol` for types
+     *  that do not refer to a type symbol.
+     */
+    def typeSymbol: Symbol
 
     /** The defined or declared members with name `name` in this type;
      *  an OverloadedSymbol if several exist, NoSymbol if none exist.

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -469,7 +469,7 @@ trait Trees extends api.Trees { self: SymbolTable =>
     private var orig: Tree = null
     private[scala] var wasEmpty: Boolean = false
 
-    override def symbol = if (tpe == null) null else tpe.typeSymbol
+    override def symbol = typeTreeSymbol(this) // if (tpe == null) null else tpe.typeSymbol
     override def isEmpty = (tpe eq null) || tpe == NoType
 
     def original: Tree = orig
@@ -1024,6 +1024,14 @@ trait Trees extends api.Trees { self: SymbolTable =>
     }
   }
 
+    
+  /** Delegate for a TypeTree symbol. This operation is unsafe because
+   *  it may trigger type checking when forcing the type symbol of the
+   *  underlying type.
+   */
+  protected def typeTreeSymbol(tree: TypeTree): Symbol =
+    if (tree.tpe == null) null else tree.tpe.typeSymbol
+  
   // --- generic traversers and transformers
 
   override protected def itraverse(traverser: Traverser, tree: Tree): Unit = {


### PR DESCRIPTION
- Removed `typeSymbol` and `termSymbol` from `reflect.api.base`, and pushed them down to
  `reflect.api`.
- extracted `TypeTree.symbol` to a top-level method so it can be overridden in lower cake layers (this is the only method in trees that can trigger type checking and therefore is not thread safe.

review by @odersky, @xeno_by
