### PR TITLE
SI-4881 infer variance from formals, then result

### DIFF
--- a/test/files/neg/t5845.check
+++ b/test/files/neg/t5845.check
@@ -1,7 +1,4 @@
-t5845.scala:9: error: value +++ is not a member of Int
-  println(5 +++ 5)
-            ^
 t5845.scala:15: error: value +++ is not a member of Int
   println(5 +++ 5)
             ^
-two errors found
+one error found

--- a/test/files/pos/t4881.scala
+++ b/test/files/pos/t4881.scala
@@ -1,0 +1,31 @@
+class Contra[-T]
+trait A
+trait B extends A
+trait C extends B
+
+// test improved variance inference: first try formals to see in which variance positions the type param appears;
+// only when that fails to determine variance, look at result type
+object Test {
+  def contraLBUB[a >: C <: A](): Contra[a] = null
+  def contraLB[a >: C](): Contra[a] = null
+
+{
+  val x = contraLBUB() //inferred Contra[C] instead of Contra[A]
+  val x1: Contra[A] = x
+}
+
+{
+  val x = contraLB() //inferred Contra[C] instead of Contra[Any]
+  val x1: Contra[Any] = x
+}
+
+{
+  val x = contraLBUB // make sure it does the same thing as its ()-less counterpart
+  val x1: Contra[A] = x
+}
+
+{
+  val x = contraLB
+  val x1: Contra[Any] = x
+}
+}


### PR DESCRIPTION
resubmission of #959 (added @retronym's variations to the test case)

Changed behavior so that when determining the target variance of a method parameter,
the variance in formals comes first. If variance is still undecided by that,
the variance in the result type is used as a secondary criterion.

(This is also done when determining prototype type params.)
