### PR TITLE
Fix example of Ordering.on in scaladoc for Ordering.

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/BrowsingLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/BrowsingLoaders.scala
@@ -69,10 +69,18 @@ abstract class BrowsingLoaders extends SymbolLoaders {
         case _ =>
           throw new MalformedInput(pkg.pos.point, "illegal tree node in package prefix: "+pkg)
       }
+
+      private def inPackagePrefix(pkg: Tree)(op: => Unit): Unit = {
+        val oldPrefix = packagePrefix
+        addPackagePrefix(pkg)
+        op
+        packagePrefix = oldPrefix
+      }
+
       override def traverse(tree: Tree): Unit = tree match {
         case PackageDef(pkg, body) =>
-          addPackagePrefix(pkg)
-          body foreach traverse
+          inPackagePrefix(pkg) { body foreach traverse }
+
         case ClassDef(_, name, _, _) =>
           if (packagePrefix == root.fullName) {
             enterClass(root, name.toString, new SourcefileLoader(src))

--- a/src/compiler/scala/tools/nsc/transform/PostErasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/PostErasure.scala
@@ -52,7 +52,7 @@ trait PostErasure extends InfoTransform with TypingTransformers {
             List(Apply(Select(New(tpt2), nme.CONSTRUCTOR), List(arg2))))
         if atPhase(currentRun.erasurePhase) {
           tpt1.tpe.typeSymbol.isDerivedValueClass &&
-          (cmp == nme.EQ || cmp == nme.NE) &&
+          (sel.symbol == Object_== || sel.symbol == Object_!=) &&
           tpt2.tpe.typeSymbol == tpt1.tpe.typeSymbol
         } =>
           val result = Apply(Select(arg1, cmp) setPos sel.pos, List(arg2)) setPos tree.pos

--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -28,7 +28,7 @@ import language.{implicitConversions, higherKinds}
   * Sorting.quickSort(pairs)(Ordering.by[(String, Int, Int), Int](_._2)
   *
   * // sort by the 3rd element, then 1st
-  * Sorting.quickSort(pairs)(Ordering[(Int, String)].on[(String, Int, Int)]((_._3, _._1))
+  * Sorting.quickSort(pairs)(Ordering[(Int, String)].on(x => (x._3, x._1)))
   * }}}
   *
   * An Ordering[T] is implemented by specifying compare(a:T, b:T), which

--- a/test/files/pos/t6089b.scala
+++ b/test/files/pos/t6089b.scala
@@ -1,0 +1,18 @@
+// this crazy code simply tries to nest pattern matches so that the last call is in a tricky-to-determine
+// tail position (my initial tightenign of tailpos detection for SI-6089 ruled this out)
+class BKTree {
+ @annotation.tailrec
+ final def -?-[AA](a: AA): Boolean = this match {
+    case BKTreeEmpty => false
+    case BKTreeNode(v) => {
+      val d = 1
+      d == 0 || ( Map(1 -> this,2  -> this,3 -> this) get d match {
+        case None => false
+        case Some(w) => w -?- a // can tail call here (since || is shortcutting)
+      })
+    }
+  }
+}
+
+object BKTreeEmpty extends BKTree
+case class BKTreeNode[A](v: A) extends BKTree

--- a/test/files/run/t6090.scala
+++ b/test/files/run/t6090.scala
@@ -1,0 +1,6 @@
+class X { def ==(other: X) = true }
+class V(val x: X) extends AnyVal
+object Test extends {
+  def main(args: Array[String]) =
+    assert((new V(new X) == new V(new X)))
+}


### PR DESCRIPTION
The current scaladoc for Ordering includes an example of using Ordering.on that does not compile; it has too few parentheses, and uses _ as a placeholder argument twice in a function that should only take one argument.  Once these issues are fixed, the explicit type parameters to on are no longer needed.

An alternative fix would be something like

  .on { case (s, _, i) => (i, s) }
