### PR TITLE
SI-2038 make pt fully-defined when typing Typed

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4980,7 +4980,9 @@ trait Typers extends Modes with Adaptations with Tags {
           if (isPatternMode) {
             val uncheckedTypeExtractor = extractorForUncheckedType(tpt.pos, tptTyped.tpe)
             val ownType = inferTypedPattern(tptTyped, tptTyped.tpe, pt, canRemedy = uncheckedTypeExtractor.nonEmpty)
-            treeTyped setType ownType
+            // println(s"Typed($expr, ${tpt.tpe}) : $pt --> $ownType  (${isFullyDefined(ownType)}, ${makeFullyDefined(ownType)})")
+            // make fully defined to avoid bounded wildcard types that may be in pt from calling dropExistential (SI-2038)
+            treeTyped setType (if (isFullyDefined(ownType)) ownType else makeFullyDefined(ownType)) //ownType
 
             uncheckedTypeExtractor match {
               case None => treeTyped

--- a/test/files/pos/t2038.scala
+++ b/test/files/pos/t2038.scala
@@ -1,0 +1,5 @@
+class Test {
+  List(Some(classOf[java.lang.Integer]), Some(classOf[Int])).map {
+    case Some(f: Class[_]) => f.cast(???)
+  }
+}


### PR DESCRIPTION
dropExistential turns existentials in the expected type (pt) that's passed to `typed`
into `BoundedWildcardType`s, but those should not end up in trees

when typing a `Typed` node, we didn't check for the type being fully defined (`isFullyDefined`)
(and thus did not make it fully defined by turning these BWTs into existentials again using `makeFullyDefined`)
