### PR TITLE
SI-5930 SI-5897 reduce redundant warnings in matches, fix flags usage

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/TreeGen.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeGen.scala
@@ -72,8 +72,6 @@ abstract class TreeGen extends reflect.internal.TreeGen with TreeDSL {
     Annotated(Ident(nme.synthSwitch), expr)
   }
 
-  def hasSynthCaseSymbol(t: Tree) = (t.symbol ne null) && (t.symbol hasFlag (CASE | SYNTHETIC))
-
   // TODO: would be so much nicer if we would know during match-translation (i.e., type checking)
   // whether we should emit missingCase-style apply (and isDefinedAt), instead of transforming trees post-factum
   class MatchMatcher {
@@ -94,13 +92,13 @@ abstract class TreeGen extends reflect.internal.TreeGen with TreeDSL {
       case Apply(Apply(TypeApply(Select(tgt, nme.runOrElse), targs), List(scrut)), List(matcher)) if opt.virtPatmat => // println("virt match: "+ (tgt, targs, scrut, matcher) + "for:\n"+ matchExpr )
         caseVirtualizedMatch(matchExpr, tgt, targs, scrut, matcher)
       // optimized version of virtpatmat
-      case Block(stats, matchEndDef) if opt.virtPatmat && (stats forall hasSynthCaseSymbol) =>
+      case Block(stats, matchEndDef) if opt.virtPatmat && (stats forall treeInfo.hasSynthCaseSymbol) =>
         // the assumption is once we encounter a case, the remainder of the block will consist of cases
         // the prologue may be empty, usually it is the valdef that stores the scrut
         val (prologue, cases) = stats span (s => !s.isInstanceOf[LabelDef])
         caseVirtualizedMatchOpt(matchExpr, prologue, cases, matchEndDef, identity)
       // optimized version of virtpatmat
-      case Block(outerStats, orig@Block(stats, matchEndDef)) if opt.virtPatmat && (stats forall hasSynthCaseSymbol) =>
+      case Block(outerStats, orig@Block(stats, matchEndDef)) if opt.virtPatmat && (stats forall treeInfo.hasSynthCaseSymbol) =>
         val (prologue, cases) = stats span (s => !s.isInstanceOf[LabelDef])
         caseVirtualizedMatchOpt(matchExpr, prologue, cases, matchEndDef, m => copyBlock(matchExpr, outerStats, m))
       case other =>

--- a/src/compiler/scala/tools/nsc/transform/TailCalls.scala
+++ b/src/compiler/scala/tools/nsc/transform/TailCalls.scala
@@ -36,7 +36,7 @@ abstract class TailCalls extends Transform {
     }
   }
 
-  import gen.hasSynthCaseSymbol
+  import treeInfo.hasSynthCaseSymbol
 
   /**
    * A Tail Call Transformer

--- a/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
@@ -113,7 +113,6 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
   import definitions._
   import analyzer._ //Typer
 
-  val SYNTH_CASE = Flags.CASE | SYNTHETIC
 
   case class DefaultOverrideMatchAttachment(default: Tree)
 
@@ -241,7 +240,8 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
       // append the default to the list of cases and suppress the unreachable case error that may arise (once we detect that...)
       val matchFailGenOverride = match_.attachments.get[DefaultOverrideMatchAttachment].map{case DefaultOverrideMatchAttachment(default) => ((scrut: Tree) => default)}
 
-      val selectorSym  = freshSym(selector.pos, pureType(selectorTp)) setFlag SYNTH_CASE
+      val selectorSym  = freshSym(selector.pos, pureType(selectorTp)) setFlag treeInfo.SYNTH_CASE_FLAGS
+
       // pt = Any* occurs when compiling test/files/pos/annotDepMethType.scala  with -Xexperimental
       val combined = combineCases(selector, selectorSym, cases map translateCase(selectorSym, pt), pt, matchOwner, matchFailGenOverride)
 
@@ -1316,6 +1316,9 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
     def freshSym(pos: Position, tp: Type = NoType, prefix: String = "x") =
       NoSymbol.newTermSymbol(freshName(prefix), pos) setInfo tp
 
+    def newSynthCaseLabel(name: String) =
+      NoSymbol.newLabel(freshName(name), NoPosition) setFlag treeInfo.SYNTH_CASE_FLAGS
+
     // codegen relevant to the structure of the translation (how extractors are combined)
     trait AbsCodegen {
       def matcher(scrut: Tree, scrutSym: Symbol, restpe: Type)(cases: List[Casegen => Tree], matchFailGen: Option[Tree => Tree]): Tree
@@ -1486,7 +1489,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
     case object FalseCond extends Cond {override def toString = "F"}
 
     case class AndCond(a: Cond, b: Cond) extends Cond {override def toString = a +"/\\"+ b}
-    case class OrCond(a: Cond, b: Cond) extends Cond  {override def toString = "("+a+") \\/ ("+ b +")"}
+    case class OrCond(a: Cond, b: Cond)  extends Cond {override def toString = "("+a+") \\/ ("+ b +")"}
 
     object EqualityCond {
       private val uniques = new collection.mutable.HashMap[(Tree, Tree), EqualityCond]
@@ -3108,7 +3111,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
           }
       }
 
-      private val defaultLabel: Symbol =  NoSymbol.newLabel(freshName("default"), NoPosition) setFlag SYNTH_CASE
+      private val defaultLabel: Symbol =  newSynthCaseLabel("default")
 
       /** Collapse guarded cases that switch on the same constant (the last case may be unguarded).
        *
@@ -3476,11 +3479,11 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
        * if keepGoing is false, the result Some(x) of the naive translation is encoded as matchRes == x
        */
       def matcher(scrut: Tree, scrutSym: Symbol, restpe: Type)(cases: List[Casegen => Tree], matchFailGen: Option[Tree => Tree]): Tree = {
-        val matchEnd = NoSymbol.newLabel(freshName("matchEnd"), NoPosition) setFlag SYNTH_CASE
+        val matchEnd = newSynthCaseLabel("matchEnd")
         val matchRes = NoSymbol.newValueParameter(newTermName("x"), NoPosition, SYNTHETIC) setInfo restpe.withoutAnnotations //
         matchEnd setInfo MethodType(List(matchRes), restpe)
 
-        def newCaseSym = NoSymbol.newLabel(freshName("case"), NoPosition) setInfo MethodType(Nil, restpe) setFlag SYNTH_CASE
+        def newCaseSym = newSynthCaseLabel("case") setInfo MethodType(Nil, restpe)
         var _currCase = newCaseSym
 
         val caseDefs = cases map { (mkCase: Casegen => Tree) =>

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1718,7 +1718,7 @@ abstract class RefChecks extends InfoTransform with reflect.internal.transform.R
             val pat1 = transform(pat)
             inPattern = false
             treeCopy.CaseDef(tree, pat1, transform(guard), transform(body))
-          case LabelDef(_, _, _) if gen.hasSynthCaseSymbol(result) =>
+          case LabelDef(_, _, _) if treeInfo.hasSynthCaseSymbol(result) =>
             val old = inPattern
             inPattern = true
             val res = deriveLabelDef(result)(transform)

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1541,7 +1541,8 @@ abstract class RefChecks extends InfoTransform with reflect.internal.transform.R
           transform(qual)
 
       case Apply(fn, args) =>
-        checkSensible(tree.pos, fn, args)
+        // sensicality should be subsumed by the unreachability/exhaustivity/irrefutability analyses in the pattern matcher
+        if (!inPattern) checkSensible(tree.pos, fn, args)
         currentApplication = tree
         tree
     }

--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -401,7 +401,11 @@ trait TypeDiagnostics {
 
     object checkDead {
       private var expr: Symbol = NoSymbol
-      private def exprOK = expr != Object_synchronized
+
+      private def exprOK =
+        (expr != Object_synchronized) &&
+        !(expr.isLabel && treeInfo.isSynthCaseSymbol(expr)) // it's okay to jump to matchEnd (or another case) with an argument of type nothing
+
       private def treeOK(tree: Tree) = tree.tpe != null && tree.tpe.typeSymbol == NothingClass
 
       def updateExpr(fn: Tree) = {

--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -464,6 +464,16 @@ abstract class TreeInfo {
     case _        => false
   }
 
+
+  // used in the symbols for labeldefs and valdefs emitted by the pattern matcher
+  // tailcalls, cps,... use this flag combination to detect translated matches
+  // TODO: move to Flags
+  final val SYNTH_CASE_FLAGS  = CASE | SYNTHETIC
+
+  def isSynthCaseSymbol(sym: Symbol) = sym hasAllFlags SYNTH_CASE_FLAGS
+  def hasSynthCaseSymbol(t: Tree)    = t.symbol != null && isSynthCaseSymbol(t.symbol)
+
+
   /** The method part of an application node
    */
   def methPart(tree: Tree): Tree = tree match {

--- a/test/files/pos/t5897.flags
+++ b/test/files/pos/t5897.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t5897.scala
+++ b/test/files/pos/t5897.scala
@@ -1,0 +1,6 @@
+// no warning here
+// (strangely, if there's an unreachable code warning *anywhere in this compilation unit*,
+//  the non-sensical warning goes away under -Xfatal-warnings)
+class Test {
+  () match { case () => }
+}

--- a/test/files/pos/t5930.flags
+++ b/test/files/pos/t5930.flags
@@ -1,0 +1,1 @@
+-Ywarn-dead-code -Xfatal-warnings

--- a/test/files/pos/t5930.scala
+++ b/test/files/pos/t5930.scala
@@ -1,0 +1,4 @@
+// should not warn about dead code (`matchEnd(throw new MatchError)`)
+ class Test {
+  0 match { case x: Int => }
+}


### PR DESCRIPTION
- SI-5930 don't warn about dead code in jump to case
  the jump to matchEnd with a throw new MatchError in the argument position caused spurious dead code warnings, so ignoring those (yes, the jump is dead code, but this is how it has to be)
- SI-5897 don't check sensicality in match
  the pattern matcher analyses (unreachability/exhaustivity) should cover more than the sensical comparison analysis, so skipping the latter in matches
- the fix for SI-5930 required factoring out some flag checking code, so moved the magic flag combo to treeInfo
  should go to Flags, I feel, but opinions on dealing with composite flags differ
  as a compromise I kept the hasAllFlags check and the definition of the flag combo val together

review of the compromise and fixes by @paulp
