### PR TITLE
SI-6112 exposes symbol mutators in macro universe

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -78,6 +78,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def asType: Type = tpe
     def asTypeIn(site: Type): Type = site.memberType(this)
     def asTypeConstructor: Type = typeConstructor
+    def setFlags(flags: FlagSet): this.type = setInternalFlags(flags)
     def setInternalFlags(flag: Long): this.type = { setFlag(flag); this }
     def setTypeSignature(tpe: Type): this.type = { setInfo(tpe); this }
     def getAnnotations: List[AnnotationInfo] = { initialize; annotations }

--- a/src/reflect/scala/reflect/makro/Universe.scala
+++ b/src/reflect/scala/reflect/makro/Universe.scala
@@ -24,8 +24,15 @@ abstract class Universe extends scala.reflect.api.Universe {
    */
   trait SymbolContextApi extends SymbolApi with AttachableApi { this: Symbol =>
 
-    // [Eugene++ to Martin] should we also add mutability methods here (similarly to what's done below for trees)?
-    // I'm talking about `setAnnotations` and friends
+    def setFlags(flags: FlagSet): this.type
+
+    def setTypeSignature(tpe: Type): this.type
+
+    def setAnnotations(annots: AnnotationInfo*): this.type
+
+    def setName(name: Name): this.type
+
+    def setPrivateWithin(sym: Symbol): this.type
   }
 
   // Tree extensions ---------------------------------------------------------------


### PR DESCRIPTION
In makro.Universe we expose the most hardcore fragments of the compiler API
that don't make sense / can't be made use of in runtime reflection API.

makro.Universe is already refining Tree to include setters for
symbols, types and positions. Now we bring Symbol up to speed.
