### PR TITLE
SI-6075 cleans up api.StandardNames

### DIFF
--- a/src/library/scala/reflect/base/Base.scala
+++ b/src/library/scala/reflect/base/Base.scala
@@ -52,7 +52,6 @@ class Base extends Universe { self =>
       else if (isFreeTerm) "free term"
       else if (isTerm) "value"
       else "symbol"
-    // [Eugene++ to Martin] base names should expose `decode`
     override def toString() = s"$kindString $name"
   }
   implicit val SymbolTag = ClassTag[Symbol](classOf[Symbol])
@@ -204,20 +203,22 @@ class Base extends Universe { self =>
 
   object nme extends TermNamesBase {
     type NameType = TermName
-    val EMPTY              = newTermName("")
-    val ROOT               = newTermName("<root>")
-    val EMPTY_PACKAGE_NAME = newTermName("<empty>")
-    val CONSTRUCTOR        = newTermName("<init>")
+    val WILDCARD             = newTermName("_")
+    val CONSTRUCTOR          = newTermName("<init>")
+    val ROOTPKG              = newTermName("_root_")
+    val EMPTY                = newTermName("")
+    val EMPTY_PACKAGE_NAME   = newTermName("<empty>")
+    val ROOT                 = newTermName("<root>")
     val NO_NAME            = newTermName("<none>")
-    val WILDCARD           = newTermName("_")
   }
 
   object tpnme extends TypeNamesBase {
     type NameType = TypeName
-    val EMPTY              = nme.EMPTY.toTypeName
-    val ROOT               = nme.ROOT.toTypeName
-    val EMPTY_PACKAGE_NAME = nme.EMPTY_PACKAGE_NAME.toTypeName
-    val WILDCARD           = nme.WILDCARD.toTypeName
+    val WILDCARD             = nme.WILDCARD.toTypeName
+    val EMPTY                = nme.EMPTY.toTypeName
+    val WILDCARD_STAR        = newTypeName("_*")
+    val EMPTY_PACKAGE_NAME   = nme.EMPTY_PACKAGE_NAME.toTypeName
+    val ROOT                 = nme.ROOT.toTypeName
   }
 
   type FlagSet = Long

--- a/src/library/scala/reflect/base/StandardNames.scala
+++ b/src/library/scala/reflect/base/StandardNames.scala
@@ -6,6 +6,11 @@
 package scala.reflect
 package base
 
+// Q: I have a pretty name. Where do I put it - into base.StandardNames or into api.StandardNames?
+// A: Is it necessary to construct trees (like EMPTY or WILDCARD_STAR)? If yes, then it goes to base.StandardNames.
+//    Is it necessary to perform reflection (like ERROR or LOCAL_SUFFIX_STRING)? If yes, then it goes to api.StandardNames.
+//    Otherwise it goes nowhere - reflection API should stay minimalistic.
+
 trait StandardNames {
   self: Universe =>
 
@@ -14,16 +19,16 @@ trait StandardNames {
 
   trait NamesBase {
     type NameType >: Null <: Name
-    val EMPTY: NameType
-    val ROOT: NameType
-    val EMPTY_PACKAGE_NAME: NameType
     val WILDCARD: NameType
   }
 
-  trait TypeNamesBase extends NamesBase
-
   trait TermNamesBase extends NamesBase {
     val CONSTRUCTOR: TermName
-    val NO_NAME: NameType
+    val ROOTPKG: TermName
+  }
+
+  trait TypeNamesBase extends NamesBase {
+    val EMPTY: NameType
+    val WILDCARD_STAR: NameType
   }
 }

--- a/src/reflect/scala/reflect/api/Names.scala
+++ b/src/reflect/scala/reflect/api/Names.scala
@@ -20,9 +20,6 @@ trait Names extends base.Names {
    */
   abstract class NameApi extends NameBase {
 
-    // [Eugene++] this functionality should be in base
-    // this is because stuff will be reified in mangled state, and people will need a way to figure it out
-
     /** Replaces all occurrences of \$op_names in this name by corresponding operator symbols.
      *  Example: `foo_\$plus\$eq` becomes `foo_+=`
      */

--- a/src/reflect/scala/reflect/api/StandardNames.scala
+++ b/src/reflect/scala/reflect/api/StandardNames.scala
@@ -5,6 +5,9 @@
 package scala.reflect
 package api
 
+// Q: I have a pretty name. Where do I put it - into base.StandardNames or into api.StandardNames?
+// A: <see base.StandardNames>
+
 trait StandardNames extends base.StandardNames {
   self: Universe =>
 
@@ -12,151 +15,16 @@ trait StandardNames extends base.StandardNames {
   val tpnme: TypeNamesApi
 
   trait NamesApi extends NamesBase {
-    val ANON_CLASS_NAME: NameType
-    val ANON_FUN_NAME: NameType
+    val ROOT: NameType
     val EMPTY: NameType
     val ERROR: NameType
-    val IMPORT: NameType
-    val MODULE_VAR_SUFFIX: NameType
     val PACKAGE: NameType
-    val ROOT: NameType
-    val SPECIALIZED_SUFFIX: NameType
-
-    def flattenedName(segments: Name*): NameType
   }
 
   trait TermNamesApi extends NamesApi with TermNamesBase {
-    val EXPAND_SEPARATOR_STRING: String
-    val IMPL_CLASS_SUFFIX: String
-    val INTERPRETER_IMPORT_WRAPPER: String
-    val INTERPRETER_LINE_PREFIX: String
-    val INTERPRETER_VAR_PREFIX: String
-    val INTERPRETER_WRAPPER_SUFFIX: String
-    val LOCALDUMMY_PREFIX: String
     val LOCAL_SUFFIX_STRING: String
-    val MODULE_SUFFIX_NAME: TermName
-    val NAME_JOIN_NAME: TermName
-    val PROTECTED_PREFIX: String
-    val PROTECTED_SET_PREFIX: String
-    val SETTER_SUFFIX: TermName
-    val SINGLETON_SUFFIX: String
-    val SUPER_PREFIX_STRING: String
-    val TRAIT_SETTER_SEPARATOR_STRING: String
-
-    val FAKE_LOCAL_THIS: TermName
-    val INITIALIZER: TermName
-    val LAZY_LOCAL: TermName
-    val UNIVERSE_BUILD: NameType
-    val UNIVERSE_BUILD_PREFIX: NameType
-    val UNIVERSE_PREFIX: NameType
-    val UNIVERSE_SHORT: NameType
-    val MIRROR_PREFIX: NameType
-    val MIRROR_SHORT: NameType
-    val MIRROR_UNTYPED: NameType
-    val REIFY_FREE_PREFIX: NameType
-    val REIFY_FREE_THIS_SUFFIX: NameType
-    val REIFY_FREE_VALUE_SUFFIX: NameType
-    val REIFY_SYMDEF_PREFIX: NameType
-    val MIXIN_CONSTRUCTOR: TermName
-    val MODULE_INSTANCE_FIELD: TermName
-    val OUTER: TermName
-    val OUTER_LOCAL: TermName
-    val OUTER_SYNTH: TermName
-    val SELECTOR_DUMMY: TermName
-    val SELF: TermName
-    val SPECIALIZED_INSTANCE: TermName
-    val STAR: TermName
-    val THIS: TermName
-
-    val BITMAP_NORMAL: TermName
-    val BITMAP_TRANSIENT: TermName
-    val BITMAP_CHECKINIT: TermName
-    val BITMAP_CHECKINIT_TRANSIENT: TermName
-
-    val ROOTPKG: TermName
-
-    val ADD: TermName
-    val AND: TermName
-    val ASR: TermName
-    val DIV: TermName
-    val EQ: TermName
-    val EQL: TermName
-    val GE: TermName
-    val GT: TermName
-    val HASHHASH: TermName
-    val LE: TermName
-    val LSL: TermName
-    val LSR: TermName
-    val LT: TermName
-    val MINUS: TermName
-    val MOD: TermName
-    val MUL: TermName
-    val NE: TermName
-    val OR: TermName
-    val PLUS : TermName
-    val SUB: TermName
-    val XOR: TermName
-    val ZAND: TermName
-    val ZOR: TermName
-
-    val UNARY_~ : TermName
-    val UNARY_+ : TermName
-    val UNARY_- : TermName
-    val UNARY_! : TermName
-
-    val ??? : TermName
-
-    def isConstructorName(name: Name): Boolean
-    def isExceptionResultName(name: Name): Boolean
-    def isImplClassName(name: Name): Boolean
-    def isLocalDummyName(name: Name): Boolean
-    def isLocalName(name: Name): Boolean
-    def isLoopHeaderLabel(name: Name): Boolean
-    def isModuleName(name: Name): Boolean
-    def isOpAssignmentName(name: Name): Boolean
-    def isProtectedAccessorName(name: Name): Boolean
-    def isReplWrapperName(name: Name): Boolean
-    def isSetterName(name: Name): Boolean
-    def isSingletonName(name: Name): Boolean
-    def isSuperAccessorName(name: Name): Boolean
-    def isTraitSetterName(name: Name): Boolean
-
-    def defaultGetterName(name: Name, pos: Int): TermName
-    def defaultGetterToMethod(name: Name): TermName
-    def expandedName(name: TermName, base: Symbol, separator: String): TermName
-    def expandedSetterName(name: TermName, base: Symbol): TermName
-    def getterName(name: TermName): TermName
-    def getterToLocal(name: TermName): TermName
-    def getterToSetter(name: TermName): TermName
-    def localDummyName(clazz: Symbol): TermName
-    def localToGetter(name: TermName): TermName
-    def protName(name: Name): TermName
-    def protSetterName(name: Name): TermName
-    def setterToGetter(name: TermName): TermName
-    def superName(name: Name): TermName
-
-    def dropLocalSuffix(name: Name): Name
-    def originalName(name: Name): Name
-    def stripModuleSuffix(name: Name): Name
-    def unspecializedName(name: Name): Name
-    def segments(name: String, assumeTerm: Boolean): List[Name]
-    def splitSpecializedName(name: Name): (Name, String, String)
   }
 
   trait TypeNamesApi extends NamesApi with TypeNamesBase {
-    val BYNAME_PARAM_CLASS_NAME: TypeName
-    val EQUALS_PATTERN_NAME: TypeName
-    val JAVA_REPEATED_PARAM_CLASS_NAME: TypeName
-    val LOCAL_CHILD: TypeName
-    val REFINE_CLASS_NAME: TypeName
-    val REPEATED_PARAM_CLASS_NAME: TypeName
-    val WILDCARD_STAR: TypeName
-    val REIFY_TYPECREATOR_PREFIX: NameType
-    val REIFY_TREECREATOR_PREFIX: NameType
-
-    def dropSingletonName(name: Name): TypeName
-    def implClassName(name: Name): TypeName
-    def interfaceName(implname: Name): TypeName
-    def singletonName(name: Name): TypeName
   }
 }

--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -649,19 +649,18 @@ trait Printers extends api.Printers { self: SymbolTable =>
   }
 
   def show(name: Name): String = name match {
-    // base.StandardNames
     case tpnme.EMPTY => "tpnme.EMPTY"
     case tpnme.ROOT => "tpnme.ROOT"
+    case tpnme.PACKAGE => "tpnme.PACKAGE"
     case tpnme.EMPTY_PACKAGE_NAME => "tpnme.EMPTY_PACKAGE_NAME"
     case tpnme.WILDCARD => "tpnme.WILDCARD"
-    case nme.CONSTRUCTOR => "nme.CONSTRUCTOR"
-    case nme.NO_NAME => "nme.NO_NAME"
-    // api.StandardNames
-    case tpnme.ERROR => "tpnme.ERROR"
-    case nme.ERROR => "nme.ERROR"
     case nme.EMPTY => "nme.EMPTY"
-    case tpnme.PACKAGE => "tpnme.PACKAGE"
+    case nme.ROOT => "nme.ROOT"
     case nme.PACKAGE => "nme.PACKAGE"
+    case nme.EMPTY_PACKAGE_NAME => "nme.EMPTY_PACKAGE_NAME"
+    case nme.WILDCARD => "nme.WILDCARD"
+    case nme.CONSTRUCTOR => "nme.CONSTRUCTOR"
+    case nme.ROOTPKG => "nme.ROOTPKG"
     case _ =>
       val prefix = if (name.isTermName) "newTermName(\"" else "newTypeName(\""
       prefix + name.toString + "\")"


### PR DESCRIPTION
I removed most of the stuff from api.StandardNames and reorganized all names.
In the new scheme of things (as documented in the comments to StandardNames):

1) base.StandardNames contains names necessary for building trees. For example,
tpnme.WILDCARD_STAR is necessary to build some invocations of varargs methods,
and nme.CONSTRUCTOR is necessary to build invocations of constructors.

2) api.StandardNames hosts names that are core to doing reflection. E.g.,
to get to a package object, you need to find a member named nme.PACKAGE,
to strip off the whitespace from the name of an underlying field of a val,
you need nme.LOCAL_SUFFIX_STRING.

Note that we don't need nme.MODULE_SUFFIX_STRING, because module name mangling
is encapsulated in java mirrors.
