### PR TITLE
SI-5958 This deserves a stable type

### DIFF
--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -143,6 +143,8 @@ abstract class TreeGen extends makro.TreeBuilder {
 
   /** Computes stable type for a tree if possible */
   def stableTypeFor(tree: Tree): Option[Type] = tree match {
+    case This(_) if tree.symbol != null && !tree.symbol.isError =>
+      Some(ThisType(tree.symbol))
     case Ident(_) if tree.symbol.isStable =>
       Some(singleType(tree.symbol.owner.thisType, tree.symbol))
     case Select(qual, _) if ((tree.symbol ne null) && (qual.tpe ne null)) && // turned assert into guard for #4064

--- a/test/files/pos/t5958.scala
+++ b/test/files/pos/t5958.scala
@@ -1,0 +1,15 @@
+class Test {
+  def newComponent(u: Universe): u.Component = ???
+
+  class Universe { self =>
+    class Component
+
+    newComponent(this): this.Component // error, but should be fine since this is a stable reference
+    newComponent(self): self.Component // error, but should be fine since this is a stable reference
+    newComponent(self): this.Component // error, but should be fine since this is a stable reference
+    newComponent(this): self.Component // error, but should be fine since this is a stable reference
+
+    val u = this
+    newComponent(u): u.Component // ok
+  }
+}


### PR DESCRIPTION
`this` (or the self variable) passed as an actual argument to a method
should receive a singleton type when computing the method's resultType

this is necessary if the method's type depends on that argument
