### PR TITLE
Optimization in List.

### DIFF
--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -152,7 +152,7 @@ sealed abstract class List[+A] extends AbstractSeq[A]
    *  @usecase def mapConserve(f: A => A): List[A]
    *    @inheritdoc
    */
-  def mapConserve[B >: A <: AnyRef](f: A => B): List[B] = {
+  @inline final def mapConserve[B >: A <: AnyRef](f: A => B): List[B] = {
     @tailrec
     def loop(mapped: ListBuffer[B], unchanged: List[A], pending: List[A]): List[B] =
       if (pending.isEmpty) {
@@ -257,7 +257,7 @@ sealed abstract class List[+A] extends AbstractSeq[A]
     (b.toList, these)
   }
 
-  override def takeWhile(p: A => Boolean): List[A] = {
+  @inline final override def takeWhile(p: A => Boolean): List[A] = {
     val b = new ListBuffer[A]
     var these = this
     while (!these.isEmpty && p(these.head)) {
@@ -267,7 +267,7 @@ sealed abstract class List[+A] extends AbstractSeq[A]
     b.toList
   }
 
-  override def dropWhile(p: A => Boolean): List[A] = {
+  @inline final override def dropWhile(p: A => Boolean): List[A] = {
     @tailrec
     def loop(xs: List[A]): List[A] =
       if (xs.isEmpty || !p(xs.head)) xs
@@ -276,7 +276,7 @@ sealed abstract class List[+A] extends AbstractSeq[A]
     loop(this)
   }
 
-  override def span(p: A => Boolean): (List[A], List[A]) = {
+  @inline final override def span(p: A => Boolean): (List[A], List[A]) = {
     val b = new ListBuffer[A]
     var these = this
     while (!these.isEmpty && p(these.head)) {
@@ -284,6 +284,16 @@ sealed abstract class List[+A] extends AbstractSeq[A]
       these = these.tail
     }
     (b.toList, these)
+  }
+
+  // Overridden with an implementation identical to the inherited one (at this time)
+  // solely so it can be finalized and thus inlinable.
+  @inline final override def foreach[U](f: A => U) {
+    var these = this
+    while (!these.isEmpty) {
+      f(these.head)
+      these = these.tail
+    }
   }
 
   override def reverse: List[A] = {


### PR DESCRIPTION
Mark all the closure-accepting methods which have implementations
within List as @inline final so the closures can be eliminated.
(All the methods are effectively final anyway, as Nil and :: are
the only possible subclasses.) And compromise with respect to
the inlining of inherited methods by overriding foreach (responsible
for over 300 closures) with an inlinable implementation.

Review by @gkossakowski.
