### PR TITLE
Remove typesafe-config as dependency for library.  Akka-actors will draw...

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -280,7 +280,7 @@ INITIALISATION
   <!-- Resolve maven dependencies -->
   <target name="init.maven.jars" depends="init.maven.tasks">
     <artifact:dependencies pathId="dependency.classpath" filesetId="dependency.fileset">
-      <dependency groupId="com.typesafe" artifactId="config" version="0.4.0"/>
+      <!--<dependency groupId="com.typesafe" artifactId="config" version="0.4.0"/>-->
     </artifact:dependencies>
   </target>
 

--- a/src/build/maven/scala-library-pom.xml
+++ b/src/build/maven/scala-library-pom.xml
@@ -31,11 +31,11 @@
       <url>https://issues.scala-lang.org/</url>
    </issueManagement>
    <dependencies>
-      <dependency>
+      <!--<dependency>
          <groupId>com.typesafe</groupId>
          <artifactId>config</artifactId>
          <version>0.4.0</version>
-     </dependency>
+     </dependency>-->
    </dependencies>
    <distributionManagement>
       <repository>


### PR DESCRIPTION
... it in.

Review by @lrytz or @adriaanm.

And sorry, this holds up 2.10.0-M6
