### PR TITLE
Partest instrumentation fixes

### DIFF
--- a/src/partest/scala/tools/partest/instrumented/Instrumentation.scala
+++ b/src/partest/scala/tools/partest/instrumented/Instrumentation.scala
@@ -54,14 +54,20 @@ object Instrumentation {
   def startProfiling(): Unit = Profiler.startProfiling()
   def stopProfiling(): Unit = Profiler.stopProfiling()
   def resetProfiling(): Unit = Profiler.resetProfiling()
+  def isProfiling(): Boolean = Profiler.isProfiling()
 
   def getStatistics: Statistics = {
-    Profiler.stopProfiling()
+    val isProfiling = Profiler.isProfiling()
+    if (isProfiling) {
+      Profiler.stopProfiling()
+    }
     val stats = Profiler.getStatistics().asScala.toSeq.map {
       case (trace, count) => MethodCallTrace(trace.className, trace.methodName, trace.methodDescriptor) -> count.intValue
     }
     val res = Map(stats: _*)
-    Profiler.startProfiling()
+    if (isProfiling) {
+      Profiler.startProfiling()
+    }
     res
   }
 

--- a/src/partest/scala/tools/partest/instrumented/Profiler.java
+++ b/src/partest/scala/tools/partest/instrumented/Profiler.java
@@ -55,6 +55,10 @@ public class Profiler {
 		isProfiling = false;
 	}
 	
+	public static boolean isProfiling() {
+	  return isProfiling;
+	}
+
 	public static void resetProfiling() {
 	  counts = new HashMap<MethodCallTrace, Integer>();
 	}

--- a/src/partest/scala/tools/partest/javaagent/ASMTransformer.java
+++ b/src/partest/scala/tools/partest/javaagent/ASMTransformer.java
@@ -21,7 +21,9 @@ public class ASMTransformer implements ClassFileTransformer {
         // we instrument all classes from empty package
         (!className.contains("/") ||
         // we instrument all classes from scala package
-        className.startsWith("scala/"));
+        className.startsWith("scala/") ||
+        // we instrument all classes from `instrumented` package
+        className.startsWith("instrumented/"));
   }
 	
 	public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) {

--- a/test/files/instrumented/InstrumentationTest.check
+++ b/test/files/instrumented/InstrumentationTest.check
@@ -1,4 +1,8 @@
 true
 Method call statistics:
+    1  Foo1.<init>()V
+    1  Foo1.someMethod()I
+    1  instrumented/Foo2.<init>()V
+    1  instrumented/Foo2.someMethod()I
     1  scala/Predef$.println(Ljava/lang/Object;)V
     1  scala/runtime/BoxesRunTime.boxToBoolean(Z)Ljava/lang/Boolean;

--- a/test/files/instrumented/InstrumentationTest.scala
+++ b/test/files/instrumented/InstrumentationTest.scala
@@ -1,11 +1,27 @@
 import scala.tools.partest.instrumented.Instrumentation._
 
+/** We check if classes put in empty package are properly instrumented */
+class Foo1 {
+  def someMethod = 0
+}
+
+/** We check if classes put in `instrumented` package are properly instrumented */
+package instrumented {
+  class Foo2 {
+    def someMethod = 0
+  }
+}
+
 /** Tests if instrumentation itself works correctly */
 object Test {
   def main(args: Array[String]) {
     // force predef initialization before profiling
     Predef
     startProfiling()
+    val foo1 = new Foo1
+    foo1.someMethod
+    val foo2 = new instrumented.Foo2
+    foo2.someMethod
     // should box the boolean
     println(true)
     stopProfiling()


### PR DESCRIPTION
Instrument all classes in `instrumented` package.
Extend instrumenting infrastructure to instrument
classes in `instrumented` package. This is useful
because very often you need to put your classes
into non-empty package. E.g. inliner doesn't work
properly with empty package at the moment so in
order to test any behaviour we need to put classes
in some other package that is instrumented.

Added testing code for that to instrumentation
test-case.

---

Fix `Instrumentation.getStatistics` method in partest.
The previous implementation was wrong because it
would always enable profiling after call to
`Instrumenation.getStatistics` method. Now we are
checking the profiling status and enable it again
only when it was enabled before.

Review by @phaller.
