### PR TITLE
`ScriptSourceFile` should not hard-code `OffsetPosition`.

### DIFF
--- a/src/reflect/scala/reflect/internal/util/SourceFile.scala
+++ b/src/reflect/scala/reflect/internal/util/SourceFile.scala
@@ -98,7 +98,7 @@ class ScriptSourceFile(underlying: BatchSourceFile, content: Array[Char], overri
 
   override def positionInUltimateSource(pos: Position) =
     if (!pos.isDefined) super.positionInUltimateSource(pos)
-    else new OffsetPosition(underlying, pos.point + start)
+    else pos.withSource(underlying, start)
 }
 
 /** a file whose contents do not change over time */


### PR DESCRIPTION
The presentation compiler should support script source files as well, but it needs range positions. This commit fixes an oversight when `RangePosition` was introduced.

review by @odersky, @hubertp
