### PR TITLE
Hiding AnyRef specialization under a flag

### DIFF
--- a/src/build/genprod.scala
+++ b/src/build/genprod.scala
@@ -15,6 +15,7 @@
  *  @author  Burak Emir, Stephane Micheloud, Geoffrey Washburn, Paul Phillips
  *  @version 1.1
  */
+import language.postfixOps
 object genprod extends App {
   val MAX_ARITY = 22
   def arities = (1 to MAX_ARITY).toList
@@ -75,7 +76,7 @@ package %s
 
   if (args.length != 1) {
     println("please give path of output directory")
-    exit(-1)
+    sys.exit(-1)
   }
   val out = args(0)
   def writeFile(node: scala.xml.Node) {
@@ -111,8 +112,8 @@ object FunctionZero extends Function(0) {
 
 object FunctionOne extends Function(1) {
   override def classAnnotation    = "@annotation.implicitNotFound(msg = \"No implicit view available from ${T1} => ${R}.\")\n"
-  override def contravariantSpecs = "@specialized(scala.Int, scala.Long, scala.Float, scala.Double, scala.AnyRef) "
-  override def covariantSpecs     = "@specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double, scala.AnyRef) "
+  override def contravariantSpecs = "@specialized(scala.Int, scala.Long, scala.Float, scala.Double/*, scala.AnyRef*/) "
+  override def covariantSpecs     = "@specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double/*, scala.AnyRef*/) "
 
   override def descriptiveComment = "  " + functionNTemplate.format("succ", "anonfun1",
 """
@@ -275,7 +276,7 @@ object TupleOne extends Tuple(1)
 object TupleTwo extends Tuple(2)
 {
   override def imports = Tuple.zipImports
-  override def covariantSpecs = "@specialized(Int, Long, Double, Char, Boolean, AnyRef) "
+  override def covariantSpecs = "@specialized(Int, Long, Double, Char, Boolean/*, AnyRef*/) "
   override def moreMethods = """
   /** Swaps the elements of this `Tuple`.
    * @return a new Tuple where the first element is the second element of this Tuple and the

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -110,6 +110,7 @@ trait ScalaSettings extends AbsScalaSettings
   val XoldPatmat    = BooleanSetting    ("-Xoldpatmat", "Use the pre-2.10 pattern matcher. Otherwise, the 'virtualizing' pattern matcher is used in 2.10.")
   val XnoPatmatAnalysis = BooleanSetting ("-Xno-patmat-analysis", "Don't perform exhaustivity/unreachability analysis. Also, ignore @switch annotation.")
   val XfullLubs     = BooleanSetting    ("-Xfull-lubs", "Retains pre 2.10 behavior of less aggressive truncation of least upper bounds.")
+  val XanyrefSpec   = BooleanSetting    ("-Xanyref-specialization", "Allow partial specialization (aka specialization on AnyRef)")
 
   /** Compatibility stubs for options whose value name did
    *  not previously match the option name.

--- a/src/library/scala/Function0.scala
+++ b/src/library/scala/Function0.scala
@@ -6,7 +6,7 @@
 **                          |/                                          **
 \*                                                                      */
 // GENERATED CODE: DO NOT EDIT.
-// genprod generated these sources at: Mon Apr 30 07:46:11 PDT 2012
+// genprod generated these sources at: Thu Jul 26 15:08:15 CEST 2012
 
 package scala
 

--- a/src/library/scala/Function1.scala
+++ b/src/library/scala/Function1.scala
@@ -32,7 +32,7 @@ package scala
 
  */
 @annotation.implicitNotFound(msg = "No implicit view available from ${T1} => ${R}.")
-trait Function1[@specialized(scala.Int, scala.Long, scala.Float, scala.Double, scala.AnyRef) -T1, @specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double, scala.AnyRef) +R] extends AnyRef { self =>
+trait Function1[@specialized(scala.Int, scala.Long, scala.Float, scala.Double/*, scala.AnyRef*/) -T1, @specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double/*, scala.AnyRef*/) +R] extends AnyRef { self =>
   /** Apply the body of this function to the argument.
    *  @return   the result of function application.
    */

--- a/src/library/scala/Tuple2.scala
+++ b/src/library/scala/Tuple2.scala
@@ -16,7 +16,7 @@ package scala
  *  @param  _1   Element 1 of this Tuple2
  *  @param  _2   Element 2 of this Tuple2
  */
-case class Tuple2[@specialized(Int, Long, Double, Char, Boolean, AnyRef) +T1, @specialized(Int, Long, Double, Char, Boolean, AnyRef) +T2](_1: T1, _2: T2)
+case class Tuple2[@specialized(Int, Long, Double, Char, Boolean/*, AnyRef*/) +T1, @specialized(Int, Long, Double, Char, Boolean/*, AnyRef*/) +T2](_1: T1, _2: T2)
   extends Product2[T1, T2]
 {
   override def toString() = "(" + _1 + "," + _2 + ")"

--- a/src/library/scala/package.scala
+++ b/src/library/scala/package.scala
@@ -29,8 +29,12 @@ package object scala {
   type AbstractMethodError             = java.lang.AbstractMethodError
   type InterruptedException            = java.lang.InterruptedException
 
-  // A dummy used by the specialization annotation.
-  val AnyRef = new Specializable {
+  // Normally it's bad juju to place objects inside package objects,
+  // but there's no choice here as we'd have to be AnyRef's companion
+  // and defined in the same file - except there is no such file.
+  // @Vlad: this was previously transformed into a val by Paul, but in Definitions
+  // we expose AnyRefModule, which crashes unless we have this as an object
+  object AnyRef extends Specializable {
     override def toString = "object AnyRef"
   }
 

--- a/src/library/scala/runtime/AbstractFunction1.scala
+++ b/src/library/scala/runtime/AbstractFunction1.scala
@@ -9,6 +9,6 @@
 
 package scala.runtime
 
-abstract class AbstractFunction1[@specialized(scala.Int, scala.Long, scala.Float, scala.Double, scala.AnyRef) -T1, @specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double, scala.AnyRef) +R] extends Function1[T1, R] {
+abstract class AbstractFunction1[@specialized(scala.Int, scala.Long, scala.Float, scala.Double/*, scala.AnyRef*/) -T1, @specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double/*, scala.AnyRef*/) +R] extends Function1[T1, R] {
 
 }

--- a/test/files/run/t3575.flags
+++ b/test/files/run/t3575.flags
@@ -1,0 +1,1 @@
+-Xanyref-specialization

--- a/test/files/run/t3575.scala
+++ b/test/files/run/t3575.scala
@@ -1,8 +1,8 @@
 // This is here to tell me if the behavior changes, not because
 // the output is endorsed.
 case class Two[
-  @specialized A,
-  @specialized B
+  @specialized(Specializable.Everything) A,
+  @specialized(Specializable.Everything) B
 ](v: A, w: B)
 
 case class TwoLong[
@@ -16,8 +16,8 @@ case class TwoCool[
 ](v: A, w: B)
 
 case class TwoShort[
-  @specialized() A,
-  @specialized() B
+  @specialized(Specializable.Everything) A,
+  @specialized(Specializable.Everything) B
 ](v: A, w: B)
 
 case class TwoMinimal[

--- a/test/files/run/t5488-fn.flags
+++ b/test/files/run/t5488-fn.flags
@@ -1,0 +1,1 @@
+-Xanyref-specialization

--- a/test/files/run/t5488.flags
+++ b/test/files/run/t5488.flags
@@ -1,0 +1,1 @@
+-Xanyref-specialization

--- a/test/files/run/t5500.flags
+++ b/test/files/run/t5500.flags
@@ -1,0 +1,1 @@
+-Xanyref-specialization

--- a/test/files/run/t5500b.flags
+++ b/test/files/run/t5500b.flags
@@ -1,0 +1,1 @@
+-Xanyref-specialization


### PR DESCRIPTION
As discussed on SI-6103: https://issues.scala-lang.org/browse/SI-6103

The reasoning is the following: the current implementation is fragile,
so we'll let the users choose whether to use it or not via the
-Xanyref-specialization flag. Source can be compiled against previously
AnyRef-specialized code without the flag, and will use the AnyRef-specd
classes, but will not be AnyRef-specialized itself.

Since the specialization information is pickled into the classfile,
we need to filter AnyRef out of the specialized annotation before we
pickle it. This is exactly what this patch does -- it expands the
specialized types in superaccessors, warns if it notices AnyRef, and
replaces the modified annotation.

THIS PATCH BREAKS BACKWARD COMPATIBILITY AT BYTECODE LEVEL:
- previously un-expanded specializations won't work anymore
- since Function_, Tuple_ and Option were previously specialized
  on AnyRef but are no more, older code that uses the specialized classes
  won't work anymore

Another less intrusive solution suggested by Lukas is to add an
anti-annotation @noAnyRefspecialization that we can add in
superaccessors and read in specialization to remove AnyRef from
the specialized list. WDYT?

Review by @paulp and @dragos pls. KTHXBYE
