### PR TITLE
Refined isEffectivelyFinal logic for sealedness.

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -191,7 +191,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
 
         } else None
       }
-      
+
       // Begin Reflection Helpers
 
       // Replaces a repeated parameter type at the end of the parameter list
@@ -354,7 +354,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       val selection = select(alts, defaultFilteringOps)
 
       val knownApplicable = applicable(selection)
-      
+
       if (knownApplicable.size == 1) knownApplicable.head
       else NoSymbol
     }
@@ -1016,6 +1016,14 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
 
     def isTopLevelModule = hasFlag(MODULE) && owner.isPackageClass
 
+    /** A helper function for isEffectivelyFinal. */
+    private def isNotOverridden = (
+      owner.isClass && (
+           owner.isEffectivelyFinal
+        || owner.isSealed && owner.children.forall(c => c.isEffectivelyFinal && (overridingSymbol(c) == NoSymbol))
+      )
+    )
+
     /** Is this symbol effectively final? I.e, it cannot be overridden */
     final def isEffectivelyFinal: Boolean = (
          (this hasFlag FINAL | PACKAGE)
@@ -1023,8 +1031,8 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       || isTerm && (
              isPrivate
           || isLocal
-          || owner.isClass && owner.isEffectivelyFinal
-      )
+          || isNotOverridden
+         )
     )
 
     /** Is this symbol locally defined? I.e. not accessed from outside `this` instance */

--- a/test/files/neg/sealed-final-neg.check
+++ b/test/files/neg/sealed-final-neg.check
@@ -1,0 +1,4 @@
+sealed-final-neg.scala:41: error: expected class or object definition
+"Due to SI-6142 this emits no warnings, so we'll just break it until that's fixed."
+^
+one error found

--- a/test/files/neg/sealed-final-neg.flags
+++ b/test/files/neg/sealed-final-neg.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -Yinline-warnings -optimise

--- a/test/files/neg/sealed-final-neg.scala
+++ b/test/files/neg/sealed-final-neg.scala
@@ -1,0 +1,41 @@
+package neg1 {
+  sealed abstract class Foo {
+    @inline def bar(x: Int) = x + 1
+  }
+  object Foo {
+    def mkFoo(): Foo = new Baz2
+  }
+
+  object Baz1 extends Foo
+  final class Baz2 extends Foo
+  final class Baz3 extends Foo {
+    override def bar(x: Int) = x - 1
+  }
+
+  object Test {
+    // bar can't be inlined - it is overridden in Baz3
+    def f = Foo.mkFoo() bar 10
+  }
+}
+
+package neg2 {
+  sealed abstract class Foo {
+    @inline def bar(x: Int) = x + 1
+  }
+  object Foo {
+    def mkFoo(): Foo = new Baz2
+  }
+
+  object Baz1 extends Foo
+  final class Baz2 extends Foo
+  class Baz3 extends Foo {
+    override def bar(x: Int) = x - 1
+  }
+
+  object Test {
+    // bar can't be inlined - Baz3 is not final
+    def f = Foo.mkFoo() bar 10
+  }
+}
+
+"Due to SI-6142 this emits no warnings, so we'll just break it until that's fixed."

--- a/test/files/pos/sealed-final.flags
+++ b/test/files/pos/sealed-final.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -Yinline-warnings -optimise

--- a/test/files/pos/sealed-final.scala
+++ b/test/files/pos/sealed-final.scala
@@ -1,0 +1,14 @@
+sealed abstract class Foo {
+  @inline def bar(x: Int) = x + 1
+}
+object Foo {
+  def mkFoo(): Foo = new Baz2
+}
+
+object Baz1 extends Foo
+final class Baz2 extends Foo
+
+object Test {
+  // bar should be inlined now
+  def f = Foo.mkFoo() bar 10
+}

--- a/test/files/run/t2886.check
+++ b/test/files/run/t2886.check
@@ -1,5 +1,5 @@
 ((x: String) => {
-  val x$1 = x;
-  val x$2 = x;
+  <hidden> val x$1 = x;
+  <hidden> val x$2 = x;
   Test.this.test(x$2, x$1)
 })


### PR DESCRIPTION
If the enclosing class of a method is sealed and has only final
subclasses, then the method is effectively final in the sealed class if
none of the subclasses overrides it. This makes it possible to inline
more methods without explicitly marking them final.

Note that the test doesn't fail before this patch due to SI-6142,
a bug in the optimizer, but here's a bytecode diff to prove it:

  @@ -16,8 +16,10 @@ public final class Test$ {
       Code:
   : getstatic                      // Field Foo$.MODULE$:LFoo$;
   : invokevirtual                  // Method Foo$.mkFoo:()LFoo;
  +: pop
   : bipush
  -: invokevirtual                  // Method Foo.bar:(I)I
  +: iconst_1
  +: iadd
   : ireturn

And the test in neg, which is manually made to fail due to the absence
of inline warnings, correctly refuses to inline the methods.

Review by @dragos.
