### PR TITLE
SI-6064 Add method contains to Option.

### DIFF
--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -209,6 +209,15 @@ sealed abstract class Option[+A] extends Product with Serializable {
     def withFilter(q: A => Boolean): WithFilter = new WithFilter(x => p(x) && q(x))
   }
 
+  /** Tests whether the option contains a given value as an element.
+   * 
+   *  @param elem the element to test.
+   *  @return `true` if the option has an element that is equal (as
+   *  determined by `==`) to `elem`, `false` otherwise.
+   */
+  final def contains[A1 >: A](elem: A1): Boolean =
+    !isEmpty && this.get == elem
+
   /** Returns true if this option is nonempty '''and''' the predicate
    * $p returns true when applied to this $option's value.
    * Otherwise, returns false.

--- a/test/files/run/t6064.scala
+++ b/test/files/run/t6064.scala
@@ -1,0 +1,9 @@
+object Test extends App {
+  assert(Option(42) contains 42)
+  assert(Some(42) contains 42)
+  assert(Option(BigInt(42)) contains 42)
+  assert(Option(42) contains BigInt(42))
+  assert(!(None contains 42))
+  assert(Some(null) contains null)
+  assert(!(Option(null) contains null))
+}


### PR DESCRIPTION
The Option API more or less mirrors the Collection API,
but it seems that somehow this method has been forgotten.

Resubmit of #886 for Scala 2.11.

Review: @axel22
