### PR TITLE
Closed 6029 ...

### DIFF
--- a/test/files/pos/t6029.scala
+++ b/test/files/pos/t6029.scala
@@ -1,0 +1,3 @@
+final case class V[A](x: A) extends AnyVal {
+  def flatMap[B](f: A => V[B]) = if (true) this else f(x)
+}


### PR DESCRIPTION
... in a less nice way than I would like. Essentially, we mask type errors at later stages that arise from comparing existentials and skolems because we know that they are not tracked correctly through all tree transformations. Never mind that all these types are going erased anyway shortly afterwards. It does not smell nice. But as I write in the comment, maybe the best way out is to
avoid skolems altogether. Such a change by far exceeds the scope of this pull request however.

Review by @paulp
