### PR TITLE
Closes SI-5882

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1385,6 +1385,11 @@ trait Typers extends Modes with Adaptations with Tags {
             unit.error(clazz.pos, "value class needs to have exactly one public val parameter")
         }
       }
+      body foreach {
+        case md: ModuleDef => unit.error(md.pos, "value class may not have nested module definitions")
+        case cd: ClassDef => unit.error(cd.pos, "value class may not have nested class definitions")
+        case _ =>
+      }
       for (tparam <- clazz.typeParams)
         if (tparam hasAnnotation definitions.SpecializedClass)
           unit.error(tparam.pos, "type parameter of value class may not be specialized")
@@ -4531,7 +4536,7 @@ trait Typers extends Modes with Adaptations with Tags {
           assert(errorContainer == null, "Cannot set ambiguous error twice for identifier")
           errorContainer = tree
         }
-        
+
         val fingerPrint: Long = name.fingerPrint
 
         var defSym: Symbol = tree.symbol  // the directly found symbol

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1386,8 +1386,12 @@ trait Typers extends Modes with Adaptations with Tags {
         }
       }
       body foreach {
-        case md: ModuleDef => unit.error(md.pos, "value class may not have nested module definitions")
-        case cd: ClassDef => unit.error(cd.pos, "value class may not have nested class definitions")
+        case md: ModuleDef =>
+          unit.error(md.pos, "value class may not have nested module definitions")
+        case cd: ClassDef =>
+          unit.error(cd.pos, "value class may not have nested class definitions")
+        case md: DefDef if md.symbol.isConstructor && !md.symbol.isPrimaryConstructor =>
+          unit.error(md.pos, "value class may not have secondary constructors")
         case _ =>
       }
       for (tparam <- clazz.typeParams)

--- a/test/files/neg/t5799.check
+++ b/test/files/neg/t5799.check
@@ -1,0 +1,4 @@
+t5799.scala:2: error: value class may not have secondary constructors
+  def this(s: String) = this(s.toDouble)
+      ^
+one error found

--- a/test/files/neg/t5799.scala
+++ b/test/files/neg/t5799.scala
@@ -1,0 +1,8 @@
+class Foo(val bar: Double) extends AnyVal {
+  def this(s: String) = this(s.toDouble)
+}
+object Test {
+  def main(args: Array[String]): Unit =
+    new Foo("")
+ }
+

--- a/test/files/neg/t5882.check
+++ b/test/files/neg/t5882.check
@@ -1,0 +1,15 @@
+t5882.scala:2: warning: case classes without a parameter list have been deprecated;
+use either case objects or case classes with `()' as parameter list.
+  case class Scope
+                  ^
+t5882.scala:2: error: value class may not have nested class definitions
+  case class Scope
+             ^
+t5882.scala:3: error: value class may not have nested class definitions
+  class Foo
+        ^
+t5882.scala:4: error: value class may not have nested module definitions
+  object Bar
+         ^
+one warning found
+three errors found

--- a/test/files/neg/t5882.scala
+++ b/test/files/neg/t5882.scala
@@ -1,0 +1,5 @@
+class NodeOps(val n: Any) extends AnyVal {
+  case class Scope
+  class Foo
+  object Bar
+}


### PR DESCRIPTION
I have added a restriction that value classes may not contain inner classes or objects. This makes sense as the "outer" field of any such classes or objects would be ephemeral, with surprising results. SIP-15 has been changed accordingly.

Review by @szeiger @moors
