### PR TITLE
Promote unchecked warnings into being emitted by default.

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
@@ -43,7 +43,7 @@ trait StandardScalaSettings {
   val target =          ChoiceSetting ("-target", "target", "Target platform for object files. All JVM 1.5 targets are deprecated.",
                                        List("jvm-1.5", "jvm-1.5-fjbg", "jvm-1.5-asm", "jvm-1.6", "jvm-1.7", "msil"),
                                        "jvm-1.6")
-  val unchecked =      BooleanSetting ("-unchecked", "Enable detailed unchecked (erasure) warnings.")
+  val unchecked =      BooleanSetting ("-unchecked", "Enable additional warnings where generated code depends on assumptions.")
   val uniqid =         BooleanSetting ("-uniqid", "Uniquely tag all identifiers in debugging output.")
   val usejavacp =      BooleanSetting ("-usejavacp", "Utilize the java.class.path in classpath resolution.")
   val verbose =        BooleanSetting ("-verbose", "Output messages about what the compiler is doing.")

--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -416,7 +416,7 @@ abstract class ExplicitOuter extends InfoTransform
 
       val (checkExhaustive, requireSwitch) = nselector match {
         case Typed(nselector1, tpt) =>
-          val unchecked = treeInfo.isUncheckedAnnotation(tpt.tpe)
+          val unchecked = tpt.tpe hasAnnotation UncheckedClass
           if (unchecked)
             nselector = nselector1
 

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1366,14 +1366,16 @@ trait Infer {
             else if (param.isContravariant) >:>
             else =:=
           )
-          val TypeRef(_, sym, args) = arg
+          (arg hasAnnotation UncheckedClass) || {
+            val TypeRef(_, sym, args) = arg.withoutAnnotations
 
-          (    isLocalBinding(sym)
-            || arg.typeSymbol.isTypeParameterOrSkolem
-            || (sym.name == tpnme.WILDCARD) // avoid spurious warnings on HK types
-            || check(arg, param.tpe, conforms)
-            || warn("non-variable type argument " + arg)
-          )
+            (    isLocalBinding(sym)
+              || arg.typeSymbol.isTypeParameterOrSkolem
+              || (sym.name == tpnme.WILDCARD) // avoid spurious warnings on HK types
+              || check(arg, param.tpe, conforms)
+              || warn("non-variable type argument " + arg)
+            )
+          }
         }
 
         // Checking if pt (the expected type of the pattern, and the type
@@ -1404,8 +1406,11 @@ trait Infer {
         case _ =>
           def where = ( if (inPattern) "pattern " else "" ) + typeToTest
           if (check(typeToTest, typeEnsured, =:=)) ()
+          // Note that this is a regular warning, not an uncheckedWarning,
+          // which is now the province of such notifications as "pattern matcher
+          // exceeded its analysis budget."
           else warningMessages foreach (m =>
-            context.unit.uncheckedWarning(tree.pos, s"$m in type $where is unchecked since it is eliminated by erasure"))
+            context.unit.warning(tree.pos, s"$m in type $where is unchecked since it is eliminated by erasure"))
       }
     }
 

--- a/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
@@ -1228,7 +1228,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
           if (settings.XnoPatmatAnalysis.value) (true, false)
           else scrut match {
             case Typed(_, tpt) =>
-              (treeInfo.isUncheckedAnnotation(tpt.tpe),
+              (tpt.tpe hasAnnotation UncheckedClass,
                // matches with two or fewer cases need not apply for switchiness (if-then-else will do)
                treeInfo.isSwitchAnnotation(tpt.tpe) && casesNoSubstOnly.lengthCompare(2) > 0)
             case _ =>

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3211,7 +3211,7 @@ trait Typers extends Modes with Adaptations with Tags {
       // we don't create a new Context for a Match, so find the CaseDef, then go out one level and navigate back to the match that has this case
       // val thisCase = context.nextEnclosing(_.tree.isInstanceOf[CaseDef])
       // val unchecked = thisCase.outer.tree.collect{case Match(selector, cases) if cases contains thisCase => selector} match {
-      //   case List(Typed(_, tpt)) if treeInfo.isUncheckedAnnotation(tpt.tpe) => true
+      //   case List(Typed(_, tpt)) if tpt.tpe hasAnnotation UncheckedClass => true
       //   case t => println("outer tree: "+ (t, thisCase, thisCase.outer.tree)); false
       // }
       // println("wrapClassTagUnapply"+ (!isPastTyper && infer.containsUnchecked(pt), pt, uncheckedPattern))

--- a/src/library/scala/unchecked.scala
+++ b/src/library/scala/unchecked.scala
@@ -6,32 +6,30 @@
 **                          |/                                          **
 \*                                                                      */
 
-
-
 package scala
 
-/** An annotation that gets applied to a selector in a match expression.
- *  If it is present, exhaustiveness warnings for that expression will be
- *  suppressed.
- *  For example, compiling the code:
+/** An annotation to designate that the annotated entity
+ *  should not be considered for additional compiler checks.
+ *  Specific applications include annotating the subject of
+ *  a match expression to suppress exhaustiveness warnings, and
+ *  annotating a type argument in a match case to suppress
+ *  unchecked warnings.
+ *
+ *  Such suppression should be used with caution, without which
+ *  one may encounter [[scala.MatchError]] or [[java.lang.ClassCastException]]
+ *  at runtime.  In most cases one can and should address the
+ *  warning instead of suppressing it.
+ *
  *  {{{
- *    object test extends App {
- *      def f(x: Option[Int]) = x match {
- *        case Some(y) => y
- *      }
- *      f(None)
+ *    object Test extends App {
+ *      // This would normally warn "match is not exhaustive"
+ *      // because `None` is not covered.
+ *      def f(x: Option[String]) = (x: @unchecked) match { case Some(y) => y }
+ *      // This would normally warn "type pattern is unchecked"
+ *      // but here will blindly cast the head element to String.
+ *      def g(xs: Any) = xs match { case x: List[String @unchecked] => x.head }
  *    }
- *  }}}
- *  will display the following warning:
- *  {{{
- *    test.scala:2: warning: does not cover case {object None}
- *      def f(x: Option[int]) = x match {
- *                              ^
- *    one warning found
- *  }}}
- *  The above message may be suppressed by substituting the expression `x`
- *  with `(x: @unchecked)`. Then the modified code will compile silently,
- *  but, in any case, a [[scala.MatchError]] will be raised at runtime.
+ * }}}
  *
  *  @since 2.4
  */

--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -326,9 +326,6 @@ abstract class TreeInfo {
     case _ => false
   }
 
-  /** a Match(Typed(_, tpt), _) is unchecked if isUncheckedAnnotation(tpt.tpe) */
-  def isUncheckedAnnotation(tpe: Type) = tpe hasAnnotation definitions.UncheckedClass
-
   /** a Match(Typed(_, tpt), _) must be translated into a switch if isSwitchAnnotation(tpt.tpe) */
   def isSwitchAnnotation(tpe: Type) = tpe hasAnnotation definitions.SwitchClass
 

--- a/test/files/neg/t3692-new.check
+++ b/test/files/neg/t3692-new.check
@@ -1,4 +1,14 @@
+t3692-new.scala:14: warning: non-variable type argument Int in type pattern Map[Int,Int] is unchecked since it is eliminated by erasure
+      case m0: Map[Int, Int] => new java.util.HashMap[Integer, Integer]
+               ^
+t3692-new.scala:15: warning: non-variable type argument Int in type pattern Map[Int,V] is unchecked since it is eliminated by erasure
+      case m1: Map[Int, V] => new java.util.HashMap[Integer, V]
+               ^
+t3692-new.scala:16: warning: non-variable type argument Int in type pattern Map[T,Int] is unchecked since it is eliminated by erasure
+      case m2: Map[T, Int] => new java.util.HashMap[T, Integer]
+               ^
 t3692-new.scala:16: error: unreachable code
       case m2: Map[T, Int] => new java.util.HashMap[T, Integer]
                               ^
+three warnings found
 one error found

--- a/test/files/neg/t3692-old.check
+++ b/test/files/neg/t3692-old.check
@@ -1,3 +1,12 @@
+t3692-old.scala:13: warning: non-variable type argument Int in type pattern Map[Int,Int] is unchecked since it is eliminated by erasure
+      case m0: Map[Int, Int] => new java.util.HashMap[Integer, Integer]
+               ^
+t3692-old.scala:14: warning: non-variable type argument Int in type pattern Map[Int,V] is unchecked since it is eliminated by erasure
+      case m1: Map[Int, V] => new java.util.HashMap[Integer, V]
+               ^
+t3692-old.scala:15: warning: non-variable type argument Int in type pattern Map[T,Int] is unchecked since it is eliminated by erasure
+      case m2: Map[T, Int] => new java.util.HashMap[T, Integer]
+               ^
 t3692-old.scala:11: warning: type Manifest in object Predef is deprecated: Use scala.reflect.ClassTag (to capture erasures) or scala.reflect.runtime.universe.TypeTag (to capture types) or both instead
   private final def toJavaMap[T, V](map: Map[T, V])(implicit m1: Manifest[T], m2: Manifest[V]): java.util.Map[_, _] = {
                                                                  ^
@@ -7,5 +16,5 @@ t3692-old.scala:11: warning: type Manifest in object Predef is deprecated: Use s
 t3692-old.scala:15: error: unreachable code
       case m2: Map[T, Int] => new java.util.HashMap[T, Integer]
                               ^
-two warnings found
+5 warnings found
 one error found

--- a/test/files/neg/unchecked-suppress.check
+++ b/test/files/neg/unchecked-suppress.check
@@ -1,0 +1,10 @@
+unchecked-suppress.scala:4: error: non-variable type argument Int in type pattern Set[Int] is unchecked since it is eliminated by erasure
+    case xs: Set[Int]                              => xs.head   // unchecked
+             ^
+unchecked-suppress.scala:5: error: non-variable type argument String in type pattern Map[String @unchecked,String] is unchecked since it is eliminated by erasure
+    case xs: Map[String @unchecked, String]        => xs.head   // one unchecked, one okay
+             ^
+unchecked-suppress.scala:7: error: non-variable type argument Int in type pattern (Int, Int) => Int is unchecked since it is eliminated by erasure
+    case f: ((Int, Int) => Int)                    =>           // unchecked
+                        ^
+three errors found

--- a/test/files/neg/unchecked-suppress.flags
+++ b/test/files/neg/unchecked-suppress.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/unchecked-suppress.scala
+++ b/test/files/neg/unchecked-suppress.scala
@@ -1,0 +1,10 @@
+class A {
+  def f(x: Any) = x match {
+    case xs: List[String @unchecked]               => xs.head   // okay
+    case xs: Set[Int]                              => xs.head   // unchecked
+    case xs: Map[String @unchecked, String]        => xs.head   // one unchecked, one okay
+    case f: ((Int @unchecked) => (Int @unchecked)) => f(5)      // okay
+    case f: ((Int, Int) => Int)                    =>           // unchecked
+    case _                                         => ""
+  }
+}


### PR DESCRIPTION
To make that viable, suppression of unchecked warnings is now available
on a per-type-argument basis. The @unchecked annotation has hereby been
generalized beyond exhaustiveness to mean context-dependent "disable further
compiler checking on this entity." Example of new usage:

  def f(x: Any) = x match {
    case xs: List[String @unchecked] => xs.head   // no warning
    case xs: List[Int]               => xs.head   // unchecked warning
  }

It turns out -unchecked has been put to other noisy uses such as
the pattern matcher complaining about its budget like a careworn spouse.
This actually simplified the path forward: I left -unchecked in place
for that and general compatibility, so those warnings can be enabled
as before with -unchecked. The erasure warnings I turned into regular
warnings, subject to suppression by @unchecked.

Review by @odersky.
