### PR TITLE
Fixes typo in Throwable compiler warning

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4935,7 +4935,7 @@ trait Typers extends Modes with Adaptations with Tags {
           var catches1 = typedCases(catches, ThrowableClass.tpe, pt)
 
           for (cdef <- catches1 if cdef.guard.isEmpty) {
-            def warn(name: Name) = context.warning(cdef.pat.pos, s"This catches all Throwables. If this is really intended, use `case ${name.decoded} : Throwable` to clear this warning.")
+            def warn(name: Name) = context.warning(cdef.pat.pos, s"This catches all Throwables. If this is really intended, use `case ${name.decoded}: Throwable` to clear this warning.")
             def unbound(t: Tree) = t.symbol == null || t.symbol == NoSymbol
             cdef.pat match {
               case Bind(name, i@Ident(_)) if unbound(i) => warn(name)

--- a/test/files/neg/catch-all.check
+++ b/test/files/neg/catch-all.check
@@ -1,10 +1,10 @@
-catch-all.scala:2: error: This catches all Throwables. If this is really intended, use `case _ : Throwable` to clear this warning.
+catch-all.scala:2: error: This catches all Throwables. If this is really intended, use `case _: Throwable` to clear this warning.
   try { "warn" } catch { case _ => }
                               ^
-catch-all.scala:4: error: This catches all Throwables. If this is really intended, use `case x : Throwable` to clear this warning.
+catch-all.scala:4: error: This catches all Throwables. If this is really intended, use `case x: Throwable` to clear this warning.
   try { "warn" } catch { case x => }
                               ^
-catch-all.scala:6: error: This catches all Throwables. If this is really intended, use `case x : Throwable` to clear this warning.
+catch-all.scala:6: error: This catches all Throwables. If this is really intended, use `case x: Throwable` to clear this warning.
   try { "warn" } catch { case _: RuntimeException => ; case x => }
                                                             ^
 three errors found


### PR DESCRIPTION
See corresponding section in style guide: http://docs.scala-lang.org/style/types.html
