### PR TITLE
Fixed SI-5031. Only consider classes when looking for companion class.

### DIFF
--- a/src/compiler/scala/tools/nsc/doc/model/IndexModelFactory.scala
+++ b/src/compiler/scala/tools/nsc/doc/model/IndexModelFactory.scala
@@ -8,7 +8,6 @@ package doc
 package model
 
 import scala.collection._
-import language.reflectiveCalls
 
 object IndexModelFactory {
 

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2035,7 +2035,6 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
 
     /** Is this symbol defined in the same scope and compilation unit as `that` symbol? */
     def isCoDefinedWith(that: Symbol) = {
-      import language.reflectiveCalls
       (this.rawInfo ne NoType) &&
       (this.effectiveOwner == that.effectiveOwner) && {
         !this.effectiveOwner.isPackageClass ||
@@ -2706,7 +2705,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
 
     override def moduleClass = referenced
     override def companionClass =
-      flatOwnerInfo.decl(name.toTypeName).suchThat(_ isCoDefinedWith this)
+      flatOwnerInfo.decl(name.toTypeName).suchThat(sym => sym.isClass && (sym isCoDefinedWith this))
 
     override def owner = {
       Statistics.incCounter(ownerCount)
@@ -3071,7 +3070,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
      */
     protected final def companionModule0: Symbol =
       flatOwnerInfo.decl(name.toTermName).suchThat(
-        sym => sym.hasFlag(MODULE) && (sym isCoDefinedWith this) && !sym.isMethod)
+        sym => sym.isModule && (sym isCoDefinedWith this) && !sym.isMethod)
 
     override def companionModule    = companionModule0
     override def companionSymbol    = companionModule0
@@ -3394,7 +3393,6 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
   }
 
   case class InvalidCompanions(sym1: Symbol, sym2: Symbol) extends Throwable({
-    import language.reflectiveCalls
     "Companions '" + sym1 + "' and '" + sym2 + "' must be defined in same file:\n" +
     "  Found in " + sym1.sourceFile.canonicalPath + " and " + sym2.sourceFile.canonicalPath
   }) {

--- a/test/files/neg/t5031.check
+++ b/test/files/neg/t5031.check
@@ -1,0 +1,5 @@
+Id.scala:3: error: Companions 'class Test' and 'object Test' must be defined in same file:
+  Found in t5031/package.scala and t5031/Id.scala
+object Test
+       ^
+one error found

--- a/test/files/neg/t5031/Id.scala
+++ b/test/files/neg/t5031/Id.scala
@@ -1,0 +1,4 @@
+package t5031
+
+object Test
+

--- a/test/files/neg/t5031/package.scala
+++ b/test/files/neg/t5031/package.scala
@@ -1,0 +1,3 @@
+package object t5031 {
+  class Test
+}

--- a/test/files/pos/t5031/Id.scala
+++ b/test/files/pos/t5031/Id.scala
@@ -1,0 +1,4 @@
+package t5031
+
+object ID
+

--- a/test/files/pos/t5031/package.scala
+++ b/test/files/pos/t5031/package.scala
@@ -1,0 +1,3 @@
+package object t5031 {
+  type ID = Int
+}

--- a/test/files/pos/t5031_2.scala
+++ b/test/files/pos/t5031_2.scala
@@ -1,0 +1,7 @@
+package object t5031 {	
+  class ID
+}
+
+package t5031 {
+  object ID
+}


### PR DESCRIPTION
sym.effectiveOwner revealed this piece of inconsistency. companionModule
is fine because similar check is there already.

I removed a bunch of feature imports that were unnecessary.

Review by @paulp.
