### PR TITLE
Fixed maddening "..." lately in printed types.

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2078,7 +2078,8 @@ trait Types extends api.Types { self: SymbolTable =>
     override protected def finishPrefix(rest: String) = objectPrefix + rest
     override def directObjectString = super.safeToString
     override def toLongString = toString
-    override def safeToString = narrow.toString
+    override def safeToString = prefixString + "type"
+    override def prefixString = if (sym.isOmittablePrefix) "" else prefix.prefixString + sym.nameString + "."
   }
   class PackageTypeRef(pre0: Type, sym0: Symbol) extends ModuleTypeRef(pre0, sym0) {
     require(sym.isPackageClass, sym)
@@ -6950,8 +6951,13 @@ trait Types extends api.Types { self: SymbolTable =>
   private var tostringRecursions = 0
 
   protected def typeToString(tpe: Type): String =
-    if (tostringRecursions >= maxTostringRecursions)
+    if (tostringRecursions >= maxTostringRecursions) {
+      debugwarn("Exceeded recursion depth attempting to print type.")
+      if (settings.debug.value)
+        (new Throwable).printStackTrace
+
       "..."
+    }
     else
       try {
         tostringRecursions += 1

--- a/test/files/run/t6028.check
+++ b/test/files/run/t6028.check
@@ -15,16 +15,16 @@ package <empty> {
       }
     };
     def bar(barParam: Int): Object = {
-      @volatile var MethodLocalObject$module: scala.runtime.VolatileObjectRef = new scala.runtime.VolatileObjectRef(<empty>);
+      @volatile var MethodLocalObject$module: runtime.VolatileObjectRef = new runtime.VolatileObjectRef(<empty>);
       T.this.MethodLocalObject$1(barParam, MethodLocalObject$module)
     };
     def tryy(tryyParam: Int): Function0 = {
-      var tryyLocal: scala.runtime.IntRef = new scala.runtime.IntRef(0);
+      var tryyLocal: runtime.IntRef = new runtime.IntRef(0);
       {
         (new anonymous class $anonfun$tryy$1(T.this, tryyParam, tryyLocal): Function0)
       }
     };
-    @SerialVersionUID(0) final <synthetic> class $anonfun$foo$1 extends scala.runtime.AbstractFunction0$mcI$sp with Serializable {
+    @SerialVersionUID(0) final <synthetic> class $anonfun$foo$1 extends runtime.AbstractFunction0$mcI$sp with Serializable {
       def <init>($outer: T, methodParam$1: Int, methodLocal$1: Int): anonymous class $anonfun$foo$1 = {
         $anonfun$foo$1.super.<init>();
         ()
@@ -41,7 +41,7 @@ package <empty> {
       <synthetic> <stable> def T$MethodLocalTrait$$$outer(): T
     };
     object MethodLocalObject$2 extends Object with T#MethodLocalTrait$1 {
-      def <init>($outer: T, barParam$1: Int): ... = {
+      def <init>($outer: T, barParam$1: Int): T#MethodLocalObject$2.type = {
         MethodLocalObject$2.super.<init>();
         MethodLocalObject$2.this.$asInstanceOf[T#MethodLocalTrait$1$class]()./*MethodLocalTrait$1$class*/$init$(barParam$1);
         ()
@@ -50,9 +50,9 @@ package <empty> {
       <synthetic> <stable> def T$MethodLocalObject$$$outer(): T = MethodLocalObject$2.this.$outer;
       <synthetic> <stable> def T$MethodLocalTrait$$$outer(): T = MethodLocalObject$2.this.$outer
     };
-    final <stable> private[this] def MethodLocalObject$1(barParam$1: Int, MethodLocalObject$module$1: scala.runtime.VolatileObjectRef): ... = {
-      MethodLocalObject$module$1.elem = new ...(T.this, barParam$1);
-      MethodLocalObject$module$1.elem.$asInstanceOf[...]()
+    final <stable> private[this] def MethodLocalObject$1(barParam$1: Int, MethodLocalObject$module$1: runtime.VolatileObjectRef): T#MethodLocalObject$2.type = {
+      MethodLocalObject$module$1.elem = new T#MethodLocalObject$2.type(T.this, barParam$1);
+      MethodLocalObject$module$1.elem.$asInstanceOf[T#MethodLocalObject$2.type]()
     };
     abstract trait MethodLocalTrait$1$class extends Object with T#MethodLocalTrait$1 {
       def /*MethodLocalTrait$1$class*/$init$(barParam$1: Int): Unit = {
@@ -60,8 +60,8 @@ package <empty> {
       };
       scala.this.Predef.print(scala.Int.box(barParam$1))
     };
-    @SerialVersionUID(0) final <synthetic> class $anonfun$tryy$1 extends scala.runtime.AbstractFunction0$mcV$sp with Serializable {
-      def <init>($outer: T, tryyParam$1: Int, tryyLocal$1: scala.runtime.IntRef): anonymous class $anonfun$tryy$1 = {
+    @SerialVersionUID(0) final <synthetic> class $anonfun$tryy$1 extends runtime.AbstractFunction0$mcV$sp with Serializable {
+      def <init>($outer: T, tryyParam$1: Int, tryyLocal$1: runtime.IntRef): anonymous class $anonfun$tryy$1 = {
         $anonfun$tryy$1.super.<init>();
         ()
       };
@@ -76,7 +76,7 @@ package <empty> {
         scala.runtime.BoxedUnit.UNIT
       };
       <synthetic> <paramaccessor> private[this] val tryyParam$1: Int = _;
-      <synthetic> <paramaccessor> private[this] val tryyLocal$1: scala.runtime.IntRef = _
+      <synthetic> <paramaccessor> private[this] val tryyLocal$1: runtime.IntRef = _
     }
   }
 }


### PR DESCRIPTION
This must have been me when I eliminated some of the
remaining distinction between TypeRef(_, moduleClass, Nil) and
SingleType(_, moduleClass).  Sorry I didn't track it down sooner.
Review by anyone who is around because this is overdue.
