### PR TITLE
SI-6162 Adds @deprecatedInheritance to dissuade from inheriting a class

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -426,6 +426,7 @@ abstract class RefChecks extends InfoTransform with reflect.internal.transform.R
             overrideError("cannot override a macro")
           } else {
             checkOverrideTypes()
+            checkOverrideDeprecated()
             if (settings.warnNullaryOverride.value) {
               if (other.paramss.isEmpty && !member.paramss.isEmpty) {
                 unit.warning(member.pos, "non-nullary method overrides nullary method")
@@ -502,6 +503,16 @@ abstract class RefChecks extends InfoTransform with reflect.internal.transform.R
                 case _ =>
               }
             }
+          }
+        }
+        
+        def checkOverrideDeprecated() {
+          if (other.hasDeprecatedOverridingAnnotation) {
+            val msg = 
+              member.toString + member.locationString + " overrides " + other.toString + other.locationString + 
+              ", but overriding this member is deprecated" + 
+              other.deprecatedOverridingMessage.map(": " + _).getOrElse(".")
+            unit.deprecationWarning(member.pos, msg)
           }
         }
       }

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1558,6 +1558,15 @@ trait Typers extends Modes with Adaptations with Tags {
           if (psym.isFinal)
             pending += ParentFinalInheritanceError(parent, psym)
 
+          if (psym.hasDeprecatedInheritanceAnnotation) {
+            val sym = selfType.typeSymbol
+            val msg = 
+              sym.toString + sym.locationString + " inherits from " + psym.toString + psym.locationString + 
+              ", but inheriting from that class is deprecated" + 
+              psym.deprecatedInheritanceMessage.map(": " + _).getOrElse(".")
+            unit.deprecationWarning(sym.pos, msg)
+          }
+
           if (psym.isSealed && !phase.erasedTypes)
             if (context.unit.source.file == psym.sourceFile)
               psym addChild context.owner

--- a/src/library/scala/deprecatedInheritance.scala
+++ b/src/library/scala/deprecatedInheritance.scala
@@ -1,0 +1,20 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2012, LAMP/EPFL                  **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala
+
+/** An annotation that designates that inheriting from a class is deprecated.
+ *
+ *  This is usually done to warn about a non-final class being made final in a future version.
+ *  Sub-classing such a class then generates a warning.
+ *
+ *  @param  message the message to print during compilation if the class was sub-classed
+ *  @param  since   a string identifying the first version in which inheritance was deprecated
+ *  @since  2.10
+ */
+class deprecatedInheritance(message: String = "", since: String = "") extends annotation.StaticAnnotation

--- a/src/library/scala/deprecatedOverriding.scala
+++ b/src/library/scala/deprecatedOverriding.scala
@@ -1,0 +1,19 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2012, LAMP/EPFL                  **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala
+
+/** An annotation that designates that overriding a member is deprecated.
+ *
+ *  Overriding such a member in  a sub-class then generates a warning.
+ *
+ *  @param  message the message to print during compilation if the member was overridden
+ *  @param  since   a string identifying the first version in which overriding was deprecated
+ *  @since  2.10
+ */
+class deprecatedOverriding(message: String = "", since: String = "") extends annotation.StaticAnnotation

--- a/src/library/scala/math/BigDecimal.scala
+++ b/src/library/scala/math/BigDecimal.scala
@@ -159,6 +159,7 @@ object BigDecimal {
  *  @author  Stephane Micheloud
  *  @version 1.0
  */
+@deprecatedInheritance("This class will me made final.", "2.10.0")
 class BigDecimal(
   val bigDecimal: BigDec,
   val mc: MathContext)

--- a/src/library/scala/math/BigInt.scala
+++ b/src/library/scala/math/BigInt.scala
@@ -114,6 +114,7 @@ object BigInt {
  *  @author  Martin Odersky
  *  @version 1.0, 15/07/2003
  */
+@deprecatedInheritance("This class will me made final.", "2.10.0")
 class BigInt(val bigInteger: BigInteger) extends ScalaNumber with ScalaNumericConversions with Serializable {
   /** Returns the hash code for this BigInt. */
   override def hashCode(): Int =

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -917,6 +917,8 @@ trait Definitions extends api.StandardDefinitions {
     lazy val CloneableAttr              = requiredClass[scala.annotation.cloneable]
     lazy val DeprecatedAttr             = requiredClass[scala.deprecated]
     lazy val DeprecatedNameAttr         = requiredClass[scala.deprecatedName]
+    lazy val DeprecatedInheritanceAttr  = requiredClass[scala.deprecatedInheritance]
+    lazy val DeprecatedOverridingAttr   = requiredClass[scala.deprecatedOverriding]
     lazy val NativeAttr                 = requiredClass[scala.native]
     lazy val RemoteAttr                 = requiredClass[scala.remote]
     lazy val ScalaInlineClass           = requiredClass[scala.inline]

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -664,6 +664,18 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def deprecationMessage  = getAnnotation(DeprecatedAttr) flatMap (_ stringArg 0)
     def deprecationVersion  = getAnnotation(DeprecatedAttr) flatMap (_ stringArg 1)
     def deprecatedParamName = getAnnotation(DeprecatedNameAttr) flatMap (_ symbolArg 0)
+    def hasDeprecatedInheritanceAnnotation
+                            = hasAnnotation(DeprecatedInheritanceAttr)
+    def deprecatedInheritanceMessage
+                            = getAnnotation(DeprecatedInheritanceAttr) flatMap (_ stringArg 0)
+    def deprecatedInheritanceVersion
+                            = getAnnotation(DeprecatedInheritanceAttr) flatMap (_ stringArg 1)
+    def hasDeprecatedOverridingAnnotation
+                            = hasAnnotation(DeprecatedOverridingAttr)
+    def deprecatedOverridingMessage
+                            = getAnnotation(DeprecatedOverridingAttr) flatMap (_ stringArg 0)
+    def deprecatedOverridingVersion
+                            = getAnnotation(DeprecatedOverridingAttr) flatMap (_ stringArg 1)
 
     // !!! when annotation arguments are not literal strings, but any sort of
     // assembly of strings, there is a fair chance they will turn up here not as

--- a/test/files/neg/t6162-inheritance.check
+++ b/test/files/neg/t6162-inheritance.check
@@ -1,0 +1,4 @@
+t6162-inheritance.scala:4: error: class SubFoo inherits from class Foo, but inheriting from that class is deprecated: `Foo` will be made final in a future version.
+class SubFoo extends Foo
+      ^
+one error found

--- a/test/files/neg/t6162-inheritance.flags
+++ b/test/files/neg/t6162-inheritance.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -deprecation

--- a/test/files/neg/t6162-inheritance.scala
+++ b/test/files/neg/t6162-inheritance.scala
@@ -1,0 +1,4 @@
+@deprecatedInheritance("`Foo` will be made final in a future version.", "2.10.0")
+class Foo
+
+class SubFoo extends Foo

--- a/test/files/neg/t6162-overriding.check
+++ b/test/files/neg/t6162-overriding.check
@@ -1,0 +1,4 @@
+t6162-overriding.scala:7: error: method bar in class SubBar overrides method bar in class Bar, but overriding this member is deprecated: `bar` will be made private in a future version.
+  override def bar = 43
+               ^
+one error found

--- a/test/files/neg/t6162-overriding.flags
+++ b/test/files/neg/t6162-overriding.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -deprecation

--- a/test/files/neg/t6162-overriding.scala
+++ b/test/files/neg/t6162-overriding.scala
@@ -1,0 +1,8 @@
+class Bar {
+  @deprecatedOverriding("`bar` will be made private in a future version.", "2.10.0")
+  def bar = 42
+}
+
+class SubBar extends Bar {
+  override def bar = 43
+}


### PR DESCRIPTION
!!!WIP!!!

I added some preliminary implementation of deprecatedInheritance.

One issue with the current code is that I get 2 warnings (this issue gets hidden in the test due to -Xfatal-warnings). I tried `psym != selfType.typeSymbol && psym.hasDeprecatedInheritanceAnnotation` and similar stuff to catch the duplicate warning, but didn't figure it out yet.

I think if we want something like deprecatedOverride, it should be an additional annotation, so that the meaning and behaviour of each is clearly defined.

Review: @retronym @paulp
