### PR TITLE
first stab at serialization of exprs and tags

### DIFF
--- a/src/library/scala/reflect/base/TypeTags.scala
+++ b/src/library/scala/reflect/base/TypeTags.scala
@@ -6,6 +6,7 @@
 package scala.reflect
 package base
 
+import java.io.{ObjectInputStream, ObjectOutputStream}
 import java.lang.{ Class => jClass }
 import language.implicitConversions
 
@@ -228,10 +229,19 @@ trait TypeTags { self: Universe =>
     def unapply[T](ttag: TypeTag[T]): Option[Type] = Some(ttag.tpe)
   }
 
-  private class TypeTagImpl[T](mirror: Mirror, tpec: TypeCreator) extends AbsTypeTagImpl[T](mirror, tpec) with TypeTag[T] {
+  private class TypeTagImpl[T](var mirror: Mirror, var tpec: TypeCreator) extends AbsTypeTagImpl[T](mirror, tpec) with TypeTag[T] {
     override def in[U <: Universe with Singleton](otherMirror: MirrorOf[U]): U # TypeTag[T] = {
       val otherMirror1 = otherMirror.asInstanceOf[MirrorOf[otherMirror.universe.type]]
       otherMirror.universe.TypeTag[T](otherMirror1, tpec)
+    }
+
+    private def writeObject(out: ObjectOutputStream) {
+      out.writeObject(tpec)
+    }
+
+    private def readObject(in: ObjectInputStream) {
+      mirror = scala.reflect.basis
+      tpec = in.readObject()
     }
   }
 


### PR DESCRIPTION
Instead of serializing into nonsense that can hardly be deserialized
(which happens now), exprs and type tags will now serialize their creators
and deserialize into scala.reflect.basis.

Since creators produced by reification are not serializable right now,
serialization will crash. That's a small improvement over state of the art
functionality-wise, but it's a step forward robustness-wise.

Next step in this direction is generation of serialization code for creators.
Related issues: SI-5919 and SI-5908. Also see the discussion at scala-internals
http://groups.google.com/group/scala-internals/browse_thread/thread/ef63f8b5bd194c7c
