### PR TITLE
I actually managed to hit the limit of Scala signature annotation not fi...

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
@@ -993,8 +993,13 @@ abstract class GenASM extends SubComponent with BytecodeWriters {
         case sb@ScalaSigBytes(bytes) =>
           // see http://www.scala-lang.org/sid/10 (Storage of pickled Scala signatures in class files)
           // also JVMS Sec. 4.7.16.1 The element_value structure and JVMS Sec. 4.4.7 The CONSTANT_Utf8_info Structure.
-          val assocValue = (if(sb.fitsInOneString) strEncode(sb) else arrEncode(sb))
-          av.visit(name, assocValue)
+          if (sb.fitsInOneString)
+            av.visit(name, strEncode(sb))
+          else {
+            val arrAnnotV: asm.AnnotationVisitor = av.visitArray(name)
+            for(arg <- arrEncode(sb)) { arrAnnotV.visit(name, arg) }
+            arrAnnotV.visitEnd()
+          }
           // for the lazy val in ScalaSigBytes to be GC'ed, the invoker of emitAnnotations() should hold the ScalaSigBytes in a method-local var that doesn't escape.
 
         case ArrayAnnotArg(args) =>


### PR DESCRIPTION
...tting into a single string (high five everyone) and entered the undisovered region of arrEncode in GenASM.

arrEncode returns Array[String] so asm.AnnotationWriter is not going to like it.

Already discussed with @magarciaEPFL but please review again.
