### PR TITLE
SI-6167 Faster Vector#isEmpty (and head, tail, last, init)

### DIFF
--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -197,6 +197,8 @@ override def companion: GenericCompanion[Vector] = Vector
       Vector.empty
   }
 
+  override /*IterableLike*/ def isEmpty: Boolean = length == 0
+
   override /*IterableLike*/ def head: A = {
     if (isEmpty) throw new UnsupportedOperationException("empty.head")
     apply(0)


### PR DESCRIPTION
Avoid building a VectorIterator just to check if iterator.hasNext
is false.
