### PR TITLE
Issue/6153

### DIFF
--- a/src/library/scala/math/BigDecimal.scala
+++ b/src/library/scala/math/BigDecimal.scala
@@ -175,9 +175,12 @@ extends ScalaNumber with ScalaNumericConversions with Serializable {
    *  which deems 2 == 2.00, whereas in java these are unequal
    *  with unequal hashCodes.
    */
-  override def hashCode(): Int =
-    if (isWhole) unifiedPrimitiveHashcode
-    else doubleValue.##
+  override def hashCode(): Int = (
+    if (isValidInt) toInt
+    else if (isValidLong) toLong.toInt
+    else if (isWhole) toBigInt.bigInteger.hashCode
+    else bigDecimal.hashCode
+  )
 
   /** Compares this BigDecimal with the specified value for equality.
    */

--- a/src/library/scala/math/BigInt.scala
+++ b/src/library/scala/math/BigInt.scala
@@ -17,7 +17,6 @@ import language.implicitConversions
  *  @since 2.1
  */
 object BigInt {
-
   private val minCached = -1024
   private val maxCached = 1024
   private val cache = new Array[BigInt](maxCached - minCached + 1)
@@ -115,12 +114,21 @@ object BigInt {
  *  @version 1.0, 15/07/2003
  */
 class BigInt(val bigInteger: BigInteger) extends ScalaNumber with ScalaNumericConversions with Serializable {
-  /** Returns the hash code for this BigInt. */
-  override def hashCode(): Int = (
-    if (isValidInt) toInt
-    else if (isValidLong) toLong.toInt
-    else bigInteger.hashCode
-  )
+  /** Returns the hash code for this BigInt.
+   *  Should return same value as BigDecimal(this).##
+   */
+  override def hashCode(): Int = _hashCode
+
+  private lazy val _hashCode: Int = {
+    if (isValidInt)
+      intValue
+    else if (isValidLong) 
+      longValue.##
+    else if (isValidDouble)
+      doubleValue.##
+    else
+      this.bigInteger.toString.##
+  }
 
   /** Compares this BigInt with the specified value for equality.
    */

--- a/src/library/scala/math/BigInt.scala
+++ b/src/library/scala/math/BigInt.scala
@@ -116,9 +116,11 @@ object BigInt {
  */
 class BigInt(val bigInteger: BigInteger) extends ScalaNumber with ScalaNumericConversions with Serializable {
   /** Returns the hash code for this BigInt. */
-  override def hashCode(): Int =
-    if (isValidLong) unifiedPrimitiveHashcode
-    else bigInteger.##
+  override def hashCode(): Int = (
+    if (isValidInt) toInt
+    else if (isValidLong) toLong.toInt
+    else bigInteger.hashCode
+  )
 
   /** Compares this BigInt with the specified value for equality.
    */

--- a/src/library/scala/math/ScalaNumericConversions.scala
+++ b/src/library/scala/math/ScalaNumericConversions.scala
@@ -69,12 +69,6 @@ trait ScalaNumericConversions extends ScalaNumber {
     */
   def isValidChar  = isWhole && (toInt >= Char.MinValue && toInt <= Char.MaxValue)
 
-  protected def unifiedPrimitiveHashcode() = {
-    val lv = toLong
-    if (lv >= Int.MinValue && lv <= Int.MaxValue) lv.toInt
-    else lv.##
-  }
-
   /** Should only be called after all known non-primitive
    *  types have been excluded.  This method won't dispatch
    *  anywhere else after checking against the primitives

--- a/test/files/run/t6153.check
+++ b/test/files/run/t6153.check
@@ -1,0 +1,2 @@
+smallNumbers.size = 100
+largeNumbers.size = 100

--- a/test/files/run/t6153.check
+++ b/test/files/run/t6153.check
@@ -1,2 +1,4 @@
 smallNumbers.size = 100
 largeNumbers.size = 100
+flippedBitsInt.size = 100
+flippedBitsDec.size = 100

--- a/test/files/run/t6153.scala
+++ b/test/files/run/t6153.scala
@@ -1,0 +1,19 @@
+import math.{BigDecimal,BigInt}
+
+object Test {
+  val doubleEpsilon: BigDecimal = BigDecimal(Double.MinPositiveValue)     //4.9E-324
+  val subLong: BigDecimal = BigDecimal(Long.MaxValue / 2)
+  val smallNumbers: Set[Int] = (1 to 100) map (i => (doubleEpsilon * i / 1000).##) toSet
+  val largeNumbers: Set[Int] = (1 to 100) map (i => (subLong + i + 0.1).##) toSet
+
+  def main(args: Array[String]): Unit = {
+    val i: BigInt = 1000000
+    val d: BigDecimal = 1000000
+    val i4 = i pow 4
+    val d4 = d pow 4
+    assert(i4 == d4, s"$i4 != $d4")
+    assert(i4.hashCode == d4.hashCode, s"${i4.hashCode} == ${d4.hashCode}")
+    println(s"smallNumbers.size = ${smallNumbers.size}")
+    println(s"largeNumbers.size = ${largeNumbers.size}")
+  }
+}

--- a/test/files/run/t6153.scala
+++ b/test/files/run/t6153.scala
@@ -1,19 +1,128 @@
 import math.{BigDecimal,BigInt}
+import scala.util.Random
+import java.math.MathContext
 
 object Test {
-  val doubleEpsilon: BigDecimal = BigDecimal(Double.MinPositiveValue)     //4.9E-324
-  val subLong: BigDecimal = BigDecimal(Long.MaxValue / 2)
-  val smallNumbers: Set[Int] = (1 to 100) map (i => (doubleEpsilon * i / 1000).##) toSet
-  val largeNumbers: Set[Int] = (1 to 100) map (i => (subLong + i + 0.1).##) toSet
+  val dmc = new MathContext(5000) //default math context, lots of precision
+  val r = new Random(0)
+  val numRands = 100
+
+  def checkHashCode(num: String) = {
+    val bi = BigInt(num)
+    val bd = BigDecimal(num, dmc)
+
+    assert(bi != bd || bi.## == bd.##, "BigInt.hashCode != BigDecimal.hashCode for value %s" format num)
+  }
+
+  def checkHashCode(num: Long) = {
+    val i: Int = num toInt
+    val l: Long = num
+    val bi = BigInt(l)
+    val bd = BigDecimal(l, dmc)
+    val str: String = num.toString 
+
+    assert(l != i || i.## == l.##, "Int.hashCode != Long.hashCode for value %s" format str)
+    assert(l != bi || l.## == bi.##, "Long.hashCode != BigInt.hashCode for value %s" format str)
+    assert(bi != bd || bi.## == bd.##, "BigInt.hashCode != BigDecimal.hashCode for value %s" format str)
+  }
+
+  def checkHashCode(num: Double) = {
+    val bd = BigDecimal(num, dmc)
+    val bi = bd toBigInt
+    val str: String = num toString
+
+    if (num.isValidInt && bi.isValidDouble) {
+      assert(num != bi || num.## == bi.##, "Double.hashCode != BigInt.hashCode for value %s" format str)
+      assert(bi != bd || bi.## == bd.##, "BigInt.hashCode != BigDecimal.hashCode for value %s" format str)
+    }
+
+    if (bd.isValidDouble) {
+      assert(num != bd || num.## == bd.##, "Double.hashCode != BigDecimal.hashCode for value %s" format str)
+    }
+  }
+  
+  def allSameHash(things: Any*) = { val size = (things map ((i) => i.##)).toSet.size; size == 0 || size == 1 }
 
   def main(args: Array[String]): Unit = {
-    val i: BigInt = 1000000
-    val d: BigDecimal = 1000000
-    val i4 = i pow 4
-    val d4 = d pow 4
-    assert(i4 == d4, s"$i4 != $d4")
-    assert(i4.hashCode == d4.hashCode, s"${i4.hashCode} == ${d4.hashCode}")
-    println(s"smallNumbers.size = ${smallNumbers.size}")
-    println(s"largeNumbers.size = ${largeNumbers.size}")
+
+    //Ints
+    checkHashCode(0)
+    checkHashCode(1)
+    checkHashCode(-342342)
+    checkHashCode(Int.MaxValue / 2)
+    checkHashCode(Int.MaxValue)
+    checkHashCode(Int.MinValue)
+    for (i <- 1 to numRands) { checkHashCode(r nextInt) }
+
+    //Longs
+    checkHashCode(0L)
+    checkHashCode(1L)
+    checkHashCode(-342342L)
+    checkHashCode(Int.MaxValue / 2L)
+    checkHashCode(Int.MaxValue toLong)
+    checkHashCode(Int.MinValue toLong)
+    checkHashCode(Long.MaxValue)
+    checkHashCode(Long.MinValue)
+    for (i <- 1 to numRands) { checkHashCode(r nextLong) }
+
+    //Doubles
+    checkHashCode(0D)
+    checkHashCode(1D)
+    checkHashCode(-342342D)
+    checkHashCode(math.floor(Int.MaxValue / 2D))
+    checkHashCode(Int.MaxValue.toDouble)
+    checkHashCode(Int.MinValue.toDouble)
+    checkHashCode(Long.MaxValue.toDouble)
+    checkHashCode(Long.MinValue.toDouble)
+
+    //Need to lose some precision to make valid double conversions
+    checkHashCode((Long.MaxValue >> 8).toDouble)
+    checkHashCode((Long.MinValue >> 8).toDouble)
+    checkHashCode(Double.MinPositiveValue)
+    checkHashCode(Double.MaxValue)
+    checkHashCode(Double.MinValue)
+    for (i <- 1 to numRands) { checkHashCode(r nextDouble) }
+
+    //Bigs
+    checkHashCode("0")
+    checkHashCode("239847")
+    checkHashCode("-729831027830346579")
+    checkHashCode("239847938465823964587234987")
+    checkHashCode("29384709835692847502983470236512906984")
+
+    //Same hashCode for same value for different precision
+    val a = BigDecimal(2, new MathContext(20))
+    val b = BigDecimal(2, new MathContext(50))
+    val c = BigDecimal(2.000)
+    assert(allSameHash(a, b, c), "BigDecimal generates different hashCodes for different precisions!")
+
+    val preciseDecimalStr = "73029895032016298735012347895.40198263978501236495732169"
+    val precision = preciseDecimalStr.length - 1
+    val d = BigDecimal(preciseDecimalStr, new MathContext(precision + 1))
+    val e = BigDecimal(preciseDecimalStr, new MathContext(2 * precision))
+    val f = BigDecimal(preciseDecimalStr + "0000", new MathContext(2 * precision))
+    assert(allSameHash(d, e, f), "BigDecimal generates different hashCodes for different precisions!")
+
+    val endsWith0 = "1129384720000000000000000000000000000"
+    val g = BigDecimal(endsWith0, dmc)
+    val h = BigDecimal(endsWith0 + ".0", dmc)
+    val i = BigDecimal(endsWith0 + ".00000", dmc)
+    assert(allSameHash(g, h, i), "BigDecimal generates different hashCodes for different precisions!")
+
+    //Check neighbors don't have same hashCode
+    val doubleEpsilon: BigDecimal = BigDecimal(Double.MinPositiveValue)     //4.9E-324
+    val subLong: BigDecimal = BigDecimal(Long.MaxValue / 2)
+    val hugeInt: BigInt = BigInt(2) pow 403
+    val hugeDecimal: BigDecimal = BigDecimal(hugeInt, new MathContext(5000))
+
+    val smallNumbers:    Set[Int] = (1 to 100) map (i => (doubleEpsilon * i / 1000).##) toSet
+    val largeNumbers:    Set[Int] = (1 to 100) map (i => (subLong + i + 0.1).##) toSet
+    val flippedBitsInt:  Set[Int] = (1 to 100) map (i => (hugeInt * BigInt(2) pow i).##) toSet
+    val flippedBitsDec:  Set[Int] = (1 to 100) map (i => (hugeDecimal * (BigDecimal(2) pow i) + 0.1).##) toSet
+
+    println("smallNumbers.size = %s" format smallNumbers.size)
+    println("largeNumbers.size = %s" format smallNumbers.size)
+    println("flippedBitsInt.size = %s" format flippedBitsInt.size)
+    println("flippedBitsDec.size = %s" format flippedBitsDec.size)
   }
 }


### PR DESCRIPTION
This is my patch for the BigDecimal.hashCode bug, as discussed at https://issues.scala-lang.org/browse/SI-6153 .  I'm quite new to Scala, so any suggestions for improvement are welcome.  Some things it fixes:
- BigDecimal still returns same hashCode for equivalent values (e.g. "2" and "2.00")
- BigInt and BigDecimal now return same hashCode for equivalent values
- BigDecimal returns same hashCode as for equivalent Int, Long, and
  Double values
- BigDecimal hashCodes are no longer "stratified", as discussed in the original bug report
- Although the new version is more expensive to compute than the old, the result is saved so it only has to be computed once

It's worth noting that since this changes the hashCode algorithms for BigInt and BigDecimal, it could break serialized data structures that rely on them (e.g. if someone serializes a hash table from an old version of Scala and tries to load it into a new one, it may cause problems).

--Bennet Huber

PS Thanks to Paul Phillips for initial patch skeleton
