### PR TITLE
updating resolveDups() to use MethodTFA.mutatingInterpret()

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
@@ -725,8 +725,7 @@ abstract class ICodeReader extends ClassfileParser {
         import analysis.typeFlowLattice.IState
 
         /** Abstract interpretation for one instruction. */
-        override def interpret(in: typeFlowLattice.Elem, i: Instruction): typeFlowLattice.Elem = {
-          var out = IState(new VarBinding(in.vars), new TypeStack(in.stack))
+        override def mutatingInterpret(out: typeFlowLattice.Elem, i: Instruction): typeFlowLattice.Elem = {
           val bindings = out.vars
           val stack = out.stack
           import stack.push
@@ -734,12 +733,10 @@ abstract class ICodeReader extends ClassfileParser {
             case DUP_X1 =>
               val (one, two) = stack.pop2
               push(one); push(two); push(one);
-              out = IState(bindings, stack)
 
             case DUP_X2 =>
               val (one, two, three) = stack.pop3
               push(one); push(three); push(two); push(one);
-              out = IState(bindings, stack)
 
             case DUP2_X1 =>
               val (one, two) = stack.pop2
@@ -749,7 +746,6 @@ abstract class ICodeReader extends ClassfileParser {
                 val three = stack.pop
                 push(two); push(one); push(three); push(two); push(one);
               }
-              out = IState(bindings, stack)
 
             case DUP2_X2 =>
               val (one, two) = stack.pop2
@@ -768,10 +764,9 @@ abstract class ICodeReader extends ClassfileParser {
                   push(two); push(one); push(four); push(one); push(three); push(two); push(one);
                 }
               }
-              out = IState(bindings, stack)
 
             case _ =>
-              out = super.interpret(in, i)
+              super.mutatingInterpret(out, i)
           }
           out
         }


### PR DESCRIPTION
Without this patch ICodeReader doesn't load bytecode for some Java-compiled class files (those containing DUP_X-style instructions).

review by @VladUreche or @dragos
