### PR TITLE
Clear uniques via perRunCaches.

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3822,6 +3822,7 @@ trait Types extends api.Types { self: SymbolTable =>
     Statistics.incCounter(rawTypeCount)
     if (uniqueRunId != currentRunId) {
       uniques = util.HashSet[Type]("uniques", initialUniquesCapacity)
+      perRunCaches.recordCache(uniques)
       uniqueRunId = currentRunId
     }
     (uniques findEntryOrUpdate tp).asInstanceOf[T]

--- a/src/reflect/scala/reflect/internal/util/HashSet.scala
+++ b/src/reflect/scala/reflect/internal/util/HashSet.scala
@@ -13,7 +13,7 @@ object HashSet {
     new HashSet[T](label, initialCapacity)
 }
 
-class HashSet[T >: Null <: AnyRef](val label: String, initialCapacity: Int) extends Set[T] {
+class HashSet[T >: Null <: AnyRef](val label: String, initialCapacity: Int) extends Set[T] with collection.generic.Clearable {
   private var used = 0
   private var table = new Array[AnyRef](initialCapacity)
   private def index(x: Int): Int = math.abs(x % table.length)


### PR DESCRIPTION
That lets this huge cache be cleared eagerly after a run
is over rather than lazily when another run begins.  This
arrives pre-LGTMed by Important People.
