### PR TITLE
SI-6074

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4522,7 +4522,9 @@ trait Typers extends Modes with Adaptations with Tags {
                 }) setType qual.tpe setPos qual.pos,
                 name)
             case _ if accessibleError.isDefined =>
-              val qual1 = adaptToMemberWithArgs(tree, qual, name, mode, false, false)
+              // don't adapt constructor, SI-6074
+              val qual1 = if (name == nme.CONSTRUCTOR) qual
+                          else adaptToMemberWithArgs(tree, qual, name, mode, false, false)
               if (!qual1.isErrorTyped && (qual1 ne qual))
                 typed(Select(qual1, name) setPos tree.pos, mode, pt)
               else

--- a/test/files/neg/t6074.check
+++ b/test/files/neg/t6074.check
@@ -1,0 +1,4 @@
+t6074.scala:5: error: constructor A in class A cannot be accessed in object T
+  def t = new A()
+          ^
+one error found

--- a/test/files/neg/t6074.scala
+++ b/test/files/neg/t6074.scala
@@ -1,0 +1,6 @@
+class A private () { }
+class B { }
+object T {
+  implicit def a2b(a: A): B = null
+  def t = new A()
+}


### PR DESCRIPTION
When selecting a non-accessible constructor, don't infer a view to
something with an accessible constructor.

review by @adriaanm
