### PR TITLE
More resilience to missing classes.

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -223,8 +223,8 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
   def error(msg: String)       = globalError(msg)
   def globalError(msg: String) = reporter.error(NoPosition, msg)
   def inform(msg: String)      = reporter.echo(msg)
-  def warning(msg: String)     =
-    if (opt.fatalWarnings) globalError(msg)
+  override def warning(msg: String) =
+    if (settings.fatalWarnings.value) globalError(msg)
     else reporter.warning(NoPosition, msg)
 
   // Getting in front of Predef's asserts to supplement with more info.

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -43,6 +43,7 @@ abstract class SymbolTable extends macros.Universe
   lazy val treeBuild = gen
 
   def log(msg: => AnyRef): Unit
+  def warning(msg: String): Unit = Console.err.println(msg)
   def abort(msg: String): Nothing = throw new FatalError(supplementErrorMessage(msg))
 
   @deprecated("Give us a reason", "2.10.0")

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -3005,10 +3005,6 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     )
   }
   trait StubSymbol extends Symbol {
-    locally {
-      this setInfo NoType
-      this.associatedFile = owner.associatedFile
-    }
     protected def stubWarning = {
       def in = if (owner == NoSymbol) "" else " in " + owner
       def from = if (associatedFile == null) "" else s" - referenced from ${associatedFile.canonicalPath}"
@@ -3016,6 +3012,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     }
     private def fail(): Nothing = MissingRequirementError.signal(s"bad symbolic reference to " + stubWarning)
 
+    override def associatedFile   = owner.associatedFile
     override def tpe              = fail()
     override def rawInfo          = fail()
     override def companionSymbol  = fail()

--- a/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
+++ b/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
@@ -230,9 +230,11 @@ abstract class UnPickler /*extends reflect.generic.UnPickler*/ {
           fromName(nme.expandedName(name.toTermName, owner)) orElse {
             // (3) Try as a nested object symbol.
             nestedObjectSymbol orElse {
-              // (4) Otherwise, fail.
-              //System.err.println("missing "+name+" in "+owner+"/"+owner.id+" "+owner.info.decls)
-              adjust(errorMissingRequirement(name, owner))
+              // (4) Call the mirror's "missing" hook.
+              adjust(mirrorThatLoaded(owner).missingHook(owner, name)) orElse {
+                // (5) Create a stub symbol to defer hard failure a little longer.
+                owner.newStubSymbol(name)
+              }
             }
           }
         }


### PR DESCRIPTION
The situation (I don't know how to make partest test this) is

  package s
  class A ; class S { def f(): A = ??? }

If one compiles this and removes A.class, should references to
class S cause the compiler to explode eagerly and fail to load S,
or explode lazily if and when it needs to know something about A?
This patch takes us from the former strategy to the latter.

Review by @xeno-by.
