### PR TITLE
Bases futures on Try instead of Either

### DIFF
--- a/src/library/scala/concurrent/ExecutionContext.scala
+++ b/src/library/scala/concurrent/ExecutionContext.scala
@@ -29,7 +29,8 @@ trait ExecutionContext {
   def reportFailure(t: Throwable): Unit
   
   /** Prepares for the execution of a task. Returns the prepared
-   *  execution context.
+   *  execution context. A valid implementation of `prepare` is one
+   *  that simply returns `this`.
    */
   def prepare(): ExecutionContext = this
 

--- a/src/library/scala/concurrent/ExecutionContext.scala
+++ b/src/library/scala/concurrent/ExecutionContext.scala
@@ -12,6 +12,7 @@ package scala.concurrent
 import java.util.concurrent.{ ExecutorService, Executor }
 import scala.concurrent.util.Duration
 import scala.annotation.implicitNotFound
+import scala.util.Try
 
 /**
  * An `ExecutionContext` is an abstraction over an entity that can execute program logic.
@@ -27,6 +28,13 @@ trait ExecutionContext {
    */
   def reportFailure(t: Throwable): Unit
   
+  /** Prepares for the execution of callback `f`. Returns the prepared
+   *  execution context which should be used to schedule the execution
+   *  of the task associated with `f`.
+   */
+  def prepare[T, U](f: Try[T] => U): ExecutionContext =
+    this
+
 }
 
 /**

--- a/src/library/scala/concurrent/ExecutionContext.scala
+++ b/src/library/scala/concurrent/ExecutionContext.scala
@@ -28,12 +28,10 @@ trait ExecutionContext {
    */
   def reportFailure(t: Throwable): Unit
   
-  /** Prepares for the execution of callback `f`. Returns the prepared
-   *  execution context which should be used to schedule the execution
-   *  of the task associated with `f`.
+  /** Prepares for the execution of a task. Returns the prepared
+   *  execution context.
    */
-  def prepare[T, U](f: Try[T] => U): ExecutionContext =
-    this
+  def prepare(): ExecutionContext = this
 
 }
 

--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -117,7 +117,7 @@ trait Future[+T] extends Awaitable[T] {
    *  $callbackInContext
    */
   def onSuccess[U](pf: PartialFunction[T, U])(implicit executor: ExecutionContext): Unit = onComplete {
-    case Right(v) if pf isDefinedAt v => pf(v)
+    case Success(v) if pf isDefinedAt v => pf(v)
     case _ =>
   }(executor)
 
@@ -135,7 +135,7 @@ trait Future[+T] extends Awaitable[T] {
    *  $callbackInContext
    */
   def onFailure[U](callback: PartialFunction[Throwable, U])(implicit executor: ExecutionContext): Unit = onComplete {
-    case Left(t) if NonFatal(t) && callback.isDefinedAt(t) => callback(t)
+    case Failure(t) if NonFatal(t) && callback.isDefinedAt(t) => callback(t)
     case _ =>
   }(executor)
 
@@ -148,7 +148,7 @@ trait Future[+T] extends Awaitable[T] {
    *  $multipleCallbacks
    *  $callbackInContext
    */
-  def onComplete[U](func: Either[Throwable, T] => U)(implicit executor: ExecutionContext): Unit
+  def onComplete[U](func: Try[T] => U)(implicit executor: ExecutionContext): Unit
 
 
   /* Miscellaneous */
@@ -169,7 +169,7 @@ trait Future[+T] extends Awaitable[T] {
    *  if it contains a valid result, or `Some(Failure(error))` if it contains
    *  an exception.
    */
-  def value: Option[Either[Throwable, T]]
+  def value: Option[Try[T]]
 
 
   /* Projections */
@@ -190,8 +190,8 @@ trait Future[+T] extends Awaitable[T] {
     val p = Promise[Throwable]()
 
     onComplete {
-      case Left(t) => p success t
-      case Right(v) => p failure (new NoSuchElementException("Future.failed not completed with a throwable."))
+      case Failure(t) => p success t
+      case Success(v) => p failure (new NoSuchElementException("Future.failed not completed with a throwable."))
     }
 
     p.future
@@ -205,7 +205,7 @@ trait Future[+T] extends Awaitable[T] {
    *  Will not be called if the future fails.
    */
   def foreach[U](f: T => U)(implicit executor: ExecutionContext): Unit = onComplete {
-    case Right(r) => f(r)
+    case Success(r) => f(r)
     case _  => // do nothing
   }(executor)
 
@@ -227,8 +227,8 @@ trait Future[+T] extends Awaitable[T] {
       case result =>
         try {
           result match {
-            case Left(t)  => p failure f(t)
-            case Right(r) => p success s(r)
+            case Failure(t)  => p failure f(t)
+            case Success(r) => p success s(r)
           }
         } catch {
           case NonFatal(t) => p failure t
@@ -251,8 +251,8 @@ trait Future[+T] extends Awaitable[T] {
       case result =>
         try {
           result match {
-            case Right(r) => p success f(r)
-            case l: Left[_, _] => p complete l.asInstanceOf[Left[Throwable, S]]
+            case Success(r) => p success f(r)
+            case f: Failure[_] => p complete f.asInstanceOf[Failure[S]]
           }
         } catch {
           case NonFatal(t) => p failure t
@@ -273,12 +273,12 @@ trait Future[+T] extends Awaitable[T] {
     val p = Promise[S]()
 
     onComplete {
-      case l: Left[_, _] => p complete l.asInstanceOf[Left[Throwable, S]]
-      case Right(v) =>
+      case f: Failure[_] => p complete f.asInstanceOf[Failure[S]]
+      case Success(v) =>
         try {
           f(v).onComplete({
-            case l: Left[_, _] => p complete l.asInstanceOf[Left[Throwable, S]]
-            case Right(v) => p success v
+            case f: Failure[_] => p complete f.asInstanceOf[Failure[S]]
+            case Success(v) => p success v
           })(internalExecutor)
         } catch {
           case NonFatal(t) => p failure t
@@ -308,8 +308,8 @@ trait Future[+T] extends Awaitable[T] {
     val p = Promise[T]()
 
     onComplete {
-      case l: Left[_, _] => p complete l.asInstanceOf[Left[Throwable, T]]
-      case Right(v) =>
+      case f: Failure[_] => p complete f.asInstanceOf[Failure[T]]
+      case Success(v) =>
         try {
           if (pred(v)) p success v
           else p failure new NoSuchElementException("Future.filter predicate is not satisfied by: " + v)
@@ -357,8 +357,8 @@ trait Future[+T] extends Awaitable[T] {
     val p = Promise[S]()
 
     onComplete {
-      case l: Left[_, _] => p complete l.asInstanceOf[Left[Throwable, S]]
-      case Right(v) =>
+      case f: Failure[_] => p complete f.asInstanceOf[Failure[S]]
+      case Success(v) =>
         try {
           if (pf.isDefinedAt(v)) p success pf(v)
           else p failure new NoSuchElementException("Future.collect partial function is not defined at: " + v)
@@ -377,22 +377,15 @@ trait Future[+T] extends Awaitable[T] {
    *  Example:
    *
    *  {{{
-   *  future (6 / 0) recover { case e: ArithmeticException ⇒ 0 } // result: 0
-   *  future (6 / 0) recover { case e: NotFoundException   ⇒ 0 } // result: exception
-   *  future (6 / 2) recover { case e: ArithmeticException ⇒ 0 } // result: 3
+   *  future (6 / 0) recover { case e: ArithmeticException => 0 } // result: 0
+   *  future (6 / 0) recover { case e: NotFoundException   => 0 } // result: exception
+   *  future (6 / 2) recover { case e: ArithmeticException => 0 } // result: 3
    *  }}}
    */
   def recover[U >: T](pf: PartialFunction[Throwable, U])(implicit executor: ExecutionContext): Future[U] = {
     val p = Promise[U]()
 
-    onComplete {
-      case Left(t) if pf isDefinedAt t =>
-        try { p success pf(t) }
-        catch {
-          case NonFatal(t) => p failure t
-        }
-      case otherwise => p complete otherwise
-    }(executor)
+    onComplete { case tr => p.complete(tr recover pf) }(executor)
 
     p.future
   }
@@ -414,7 +407,7 @@ trait Future[+T] extends Awaitable[T] {
     val p = Promise[U]()
 
     onComplete {
-      case Left(t) if pf isDefinedAt t =>
+      case Failure(t) if pf isDefinedAt t =>
         try {
           p completeWith pf(t)
         } catch {
@@ -438,8 +431,8 @@ trait Future[+T] extends Awaitable[T] {
     val p = Promise[(T, U)]()
     
     this onComplete {
-      case l: Left[_, _] => p complete l.asInstanceOf[Left[Throwable, (T, U)]]
-      case Right(r) =>
+      case f: Failure[_] => p complete f.asInstanceOf[Failure[(T, U)]]
+      case Success(r) =>
         that onSuccess {
           case r2 => p success ((r, r2))
         }
@@ -468,8 +461,8 @@ trait Future[+T] extends Awaitable[T] {
   def fallbackTo[U >: T](that: Future[U]): Future[U] = {
     val p = Promise[U]()
     onComplete {
-      case r @ Right(_) ⇒ p complete r
-      case _            ⇒ p completeWith that
+      case s @ Success(_) => p complete s
+      case _ => p completeWith that
     }
     p.future
   }
@@ -485,12 +478,12 @@ trait Future[+T] extends Awaitable[T] {
     val p = Promise[S]()
 
     onComplete {
-      case l: Left[_, _] => p complete l.asInstanceOf[Left[Throwable, S]]
-      case Right(t) =>
+      case f: Failure[_] => p complete f.asInstanceOf[Failure[S]]
+      case Success(t) =>
         p complete (try {
-          Right(boxedType(tag.runtimeClass).cast(t).asInstanceOf[S])
+          Success(boxedType(tag.runtimeClass).cast(t).asInstanceOf[S])
         } catch {
-          case e: ClassCastException => Left(e)
+          case e: ClassCastException => Failure(e)
         })
     }
 
@@ -520,7 +513,7 @@ trait Future[+T] extends Awaitable[T] {
    *  }
    *  }}}
    */
-  def andThen[U](pf: PartialFunction[Either[Throwable, T], U])(implicit executor: ExecutionContext): Future[T] = {
+  def andThen[U](pf: PartialFunction[Try[T], U])(implicit executor: ExecutionContext): Future[T] = {
     val p = Promise[T]()
 
     onComplete {
@@ -545,7 +538,7 @@ trait Future[+T] extends Awaitable[T] {
    */
   def either[U >: T](that: Future[U]): Future[U] = {
     val p = Promise[U]()
-    val completePromise: PartialFunction[Either[Throwable, U], _] = { case result => p tryComplete result }
+    val completePromise: PartialFunction[Try[U], _] = { case result => p tryComplete result }
 
     this onComplete completePromise
     that onComplete completePromise
@@ -615,7 +608,7 @@ object Future {
   def firstCompletedOf[T](futures: TraversableOnce[Future[T]])(implicit executor: ExecutionContext): Future[T] = {
     val p = Promise[T]()
 
-    val completeFirst: Either[Throwable, T] => Unit = p tryComplete _
+    val completeFirst: Try[T] => Unit = p tryComplete _
     futures.foreach(_ onComplete completeFirst)
 
     p.future
@@ -629,14 +622,14 @@ object Future {
     else {
       val result = Promise[Option[T]]()
       val ref = new AtomicInteger(futures.size)
-      val search: Either[Throwable, T] => Unit = v => try {
+      val search: Try[T] => Unit = v => try {
         v match {
-          case Right(r) => if (predicate(r)) result tryComplete Right(Some(r))
-          case _        =>
+          case Success(r) => if (predicate(r)) result tryComplete Success(Some(r))
+          case _ =>
         }
       } finally {
         if (ref.decrementAndGet == 0) {
-          result tryComplete Right(None)
+          result tryComplete Success(None)
         }
       }
 

--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -312,7 +312,7 @@ trait Future[+T] extends Awaitable[T] {
       case Success(v) =>
         try {
           if (pred(v)) p success v
-          else p failure new NoSuchElementException("Future.filter predicate is not satisfied by: " + v)
+          else p failure new NoSuchElementException("Future.filter predicate is not satisfied")
         } catch {
           case NonFatal(t) => p failure t
         }

--- a/src/library/scala/concurrent/Promise.scala
+++ b/src/library/scala/concurrent/Promise.scala
@@ -8,6 +8,8 @@
 
 package scala.concurrent
 
+import scala.util.{ Try, Success, Failure }
+
 /** Promise is an object which can be completed with a value or failed
  *  with an exception.
  *
@@ -49,7 +51,7 @@ trait Promise[T] {
    *
    *  $promiseCompletion
    */
-  def complete(result: Either[Throwable, T]): this.type =
+  def complete(result: Try[T]): this.type =
     if (tryComplete(result)) this else throw new IllegalStateException("Promise already completed.")
 
   /** Tries to complete the promise with either a value or the exception.
@@ -58,7 +60,7 @@ trait Promise[T] {
    *
    *  @return    If the promise has already been completed returns `false`, or `true` otherwise.
    */
-  def tryComplete(result: Either[Throwable, T]): Boolean
+  def tryComplete(result: Try[T]): Boolean
 
   /** Completes this promise with the specified future, once that future is completed.
    *
@@ -84,7 +86,7 @@ trait Promise[T] {
    *
    *  $promiseCompletion
    */
-  def success(v: T): this.type = complete(Right(v))
+  def success(v: T): this.type = complete(Success(v))
 
   /** Tries to complete the promise with a value.
    *
@@ -92,7 +94,7 @@ trait Promise[T] {
    *
    *  @return    If the promise has already been completed returns `false`, or `true` otherwise.
    */
-  def trySuccess(value: T): Boolean = tryComplete(Right(value))
+  def trySuccess(value: T): Boolean = tryComplete(Success(value))
 
   /** Completes the promise with an exception.
    *
@@ -102,7 +104,7 @@ trait Promise[T] {
    *
    *  $promiseCompletion
    */
-  def failure(t: Throwable): this.type = complete(Left(t))
+  def failure(t: Throwable): this.type = complete(Failure(t))
 
   /** Tries to complete the promise with an exception.
    *
@@ -110,7 +112,7 @@ trait Promise[T] {
    *
    *  @return    If the promise has already been completed returns `false`, or `true` otherwise.
    */
-  def tryFailure(t: Throwable): Boolean = tryComplete(Left(t))
+  def tryFailure(t: Throwable): Boolean = tryComplete(Failure(t))
 }
 
 
@@ -129,14 +131,14 @@ object Promise {
    *  @tparam T       the type of the value in the promise
    *  @return         the newly created `Promise` object
    */
-  def failed[T](exception: Throwable): Promise[T] = new impl.Promise.KeptPromise[T](Left(exception))
+  def failed[T](exception: Throwable): Promise[T] = new impl.Promise.KeptPromise[T](Failure(exception))
 
   /** Creates an already completed Promise with the specified result.
    *  
    *  @tparam T       the type of the value in the promise
    *  @return         the newly created `Promise` object
    */
-  def successful[T](result: T): Promise[T] = new impl.Promise.KeptPromise[T](Right(result))
+  def successful[T](result: T): Promise[T] = new impl.Promise.KeptPromise[T](Success(result))
   
 }
 

--- a/src/library/scala/concurrent/impl/Future.scala
+++ b/src/library/scala/concurrent/impl/Future.scala
@@ -12,7 +12,7 @@ package scala.concurrent.impl
 
 import scala.concurrent.ExecutionContext
 import scala.util.control.NonFatal
-
+import scala.util.{Try, Success, Failure}
 
 
 private[concurrent] object Future {
@@ -21,7 +21,7 @@ private[concurrent] object Future {
 
     override def run() = {
       promise complete {
-        try Right(body) catch { case NonFatal(e) => Left(e) }
+        try Success(body) catch { case NonFatal(e) => Failure(e) }
       }
     }
   }

--- a/src/library/scala/concurrent/impl/Promise.scala
+++ b/src/library/scala/concurrent/impl/Promise.scala
@@ -129,7 +129,7 @@ private[concurrent] object Promise {
     }
 
     def onComplete[U](func: Try[T] => U)(implicit executor: ExecutionContext): Unit = {
-      val preparedEC = executor.prepare(func)
+      val preparedEC = executor.prepare
       val runnable = new CallbackRunnable[T](preparedEC, func)
 
       @tailrec //Tries to add the callback, if already completed, it dispatches the callback to be executed
@@ -156,16 +156,13 @@ private[concurrent] object Promise {
 
     def onComplete[U](func: Try[T] => U)(implicit executor: ExecutionContext): Unit = {
       val completedAs = value.get
-      val preparedEC = executor.prepare(func)
+      val preparedEC = executor.prepare
       (new CallbackRunnable(preparedEC, func)).executeWithValue(completedAs)
     }
 
     def ready(atMost: Duration)(implicit permit: CanAwait): this.type = this
 
-    def result(atMost: Duration)(implicit permit: CanAwait): T = value.get match {
-      case Failure(e)  => throw e
-      case Success(r) => r
-    }
+    def result(atMost: Duration)(implicit permit: CanAwait): T = value.get.get
   }
 
 }

--- a/src/library/scala/concurrent/impl/Promise.scala
+++ b/src/library/scala/concurrent/impl/Promise.scala
@@ -15,23 +15,23 @@ import scala.concurrent.{ ExecutionContext, CanAwait, OnCompleteRunnable, Timeou
 import scala.concurrent.util.Duration
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
-
+import scala.util.{ Try, Success, Failure }
 
 
 private[concurrent] trait Promise[T] extends scala.concurrent.Promise[T] with scala.concurrent.Future[T] {
   def future: this.type = this
 }
 
-private class CallbackRunnable[T](val executor: ExecutionContext, val onComplete: (Either[Throwable, T]) => Any) extends Runnable with OnCompleteRunnable {
+private class CallbackRunnable[T](val executor: ExecutionContext, val onComplete: (Try[T]) => Any) extends Runnable with OnCompleteRunnable {
   // must be filled in before running it
-  var value: Either[Throwable, T] = null
+  var value: Try[T] = null
 
   override def run() = {
     require(value ne null) // must set value to non-null before running!
     try onComplete(value) catch { case NonFatal(e) => executor reportFailure e }
   }
 
-  def executeWithValue(v: Either[Throwable, T]): Unit = {
+  def executeWithValue(v: Try[T]): Unit = {
     require(value eq null) // can't complete it twice
     value = v
     executor.execute(this)
@@ -40,17 +40,17 @@ private class CallbackRunnable[T](val executor: ExecutionContext, val onComplete
 
 private[concurrent] object Promise {
 
-  private def resolveEither[T](source: Either[Throwable, T]): Either[Throwable, T] = source match {
-    case Left(t) => resolver(t)
-    case _       => source
+  private def resolveTry[T](source: Try[T]): Try[T] = source match {
+    case Failure(t) => resolver(t)
+    case _          => source
   }
   
-  private def resolver[T](throwable: Throwable): Either[Throwable, T] = throwable match {
-    case t: scala.runtime.NonLocalReturnControl[_] => Right(t.value.asInstanceOf[T])
-    case t: scala.util.control.ControlThrowable    => Left(new ExecutionException("Boxed ControlThrowable", t))
-    case t: InterruptedException                   => Left(new ExecutionException("Boxed InterruptedException", t))
-    case e: Error                                  => Left(new ExecutionException("Boxed Error", e))
-    case t                                         => Left(t)
+  private def resolver[T](throwable: Throwable): Try[T] = throwable match {
+    case t: scala.runtime.NonLocalReturnControl[_] => Success(t.value.asInstanceOf[T])
+    case t: scala.util.control.ControlThrowable    => Failure(new ExecutionException("Boxed ControlThrowable", t))
+    case t: InterruptedException                   => Failure(new ExecutionException("Boxed InterruptedException", t))
+    case e: Error                                  => Failure(new ExecutionException("Boxed Error", e))
+    case t                                         => Failure(t)
   }
   
   /** Default promise implementation.
@@ -88,25 +88,25 @@ private[concurrent] object Promise {
     @throws(classOf[Exception])
     def result(atMost: Duration)(implicit permit: CanAwait): T =
       ready(atMost).value.get match {
-        case Left(e)  => throw e
-        case Right(r) => r
+        case Failure(e)  => throw e
+        case Success(r) => r
       }
 
-    def value: Option[Either[Throwable, T]] = getState match {
-      case c: Either[_, _] => Some(c.asInstanceOf[Either[Throwable, T]])
-      case _               => None
+    def value: Option[Try[T]] = getState match {
+      case c: Try[_] => Some(c.asInstanceOf[Try[T]])
+      case _ => None
     }
 
     override def isCompleted(): Boolean = getState match { // Cheaper than boxing result into Option due to "def value"
-      case _: Either[_, _] => true
-      case _               => false
+      case _: Try[_] => true
+      case _ => false
     }
 
-    def tryComplete(value: Either[Throwable, T]): Boolean = {
-      val resolved = resolveEither(value)
+    def tryComplete(value: Try[T]): Boolean = {
+      val resolved = resolveTry(value)
       (try {
         @tailrec
-        def tryComplete(v: Either[Throwable, T]): List[CallbackRunnable[T]] = {
+        def tryComplete(v: Try[T]): List[CallbackRunnable[T]] = {
           getState match {
             case raw: List[_] =>
               val cur = raw.asInstanceOf[List[CallbackRunnable[T]]]
@@ -124,13 +124,13 @@ private[concurrent] object Promise {
       }
     }
 
-    def onComplete[U](func: Either[Throwable, T] => U)(implicit executor: ExecutionContext): Unit = {
+    def onComplete[U](func: Try[T] => U)(implicit executor: ExecutionContext): Unit = {
       val runnable = new CallbackRunnable[T](executor, func)
 
       @tailrec //Tries to add the callback, if already completed, it dispatches the callback to be executed
       def dispatchOrAddCallback(): Unit =
         getState match {
-          case r: Either[_, _]    => runnable.executeWithValue(r.asInstanceOf[Either[Throwable, T]])
+          case r: Try[_]          => runnable.executeWithValue(r.asInstanceOf[Try[T]])
           case listeners: List[_] => if (updateState(listeners, runnable :: listeners)) () else dispatchOrAddCallback()
         }
       dispatchOrAddCallback()
@@ -141,15 +141,15 @@ private[concurrent] object Promise {
    *
    *  Useful in Future-composition when a value to contribute is already available.
    */
-  final class KeptPromise[T](suppliedValue: Either[Throwable, T]) extends Promise[T] {
+  final class KeptPromise[T](suppliedValue: Try[T]) extends Promise[T] {
 
-    val value = Some(resolveEither(suppliedValue))
+    val value = Some(resolveTry(suppliedValue))
 
     override def isCompleted(): Boolean = true
 
-    def tryComplete(value: Either[Throwable, T]): Boolean = false
+    def tryComplete(value: Try[T]): Boolean = false
 
-    def onComplete[U](func: Either[Throwable, T] => U)(implicit executor: ExecutionContext): Unit = {
+    def onComplete[U](func: Try[T] => U)(implicit executor: ExecutionContext): Unit = {
       val completedAs = value.get
       (new CallbackRunnable(executor, func)).executeWithValue(completedAs)
     }
@@ -157,8 +157,8 @@ private[concurrent] object Promise {
     def ready(atMost: Duration)(implicit permit: CanAwait): this.type = this
 
     def result(atMost: Duration)(implicit permit: CanAwait): T = value.get match {
-      case Left(e)  => throw e
-      case Right(r) => r
+      case Failure(e)  => throw e
+      case Success(r) => r
     }
   }
 

--- a/src/library/scala/util/Try.scala
+++ b/src/library/scala/util/Try.scala
@@ -142,7 +142,7 @@ sealed abstract class Try[+T] {
   /** Completes this `Try` by applying the function `f` to this if this is of type `Failure`, or conversely, by applying
    *  `s` if this is a `Success`.
    */
-  def transform[U](f: Throwable => Try[U], s: T => Try[U]): Try[U] = this match {
+  def transform[U](s: T => Try[U], f: Throwable => Try[U]): Try[U] = this match {
     case Success(v) => s(v)
     case Failure(e) => f(e)
   }

--- a/src/library/scala/util/Try.scala
+++ b/src/library/scala/util/Try.scala
@@ -54,6 +54,7 @@ import language.implicitConversions
  *
  * `Try` comes to the Scala standard library after years of use as an integral part of Twitter's stack.
  *
+ * @author based on Marius Eriksen's original implementation in com.twitter.util.
  * @since 2.10
  */
 sealed abstract class Try[+T] {
@@ -102,7 +103,7 @@ sealed abstract class Try[+T] {
    * Applies the given function `f` if this is a `Failure`, otherwise returns this if this is a `Success`.
    * This is like `flatMap` for the exception.
    */
-  def rescue[U >: T](f: PartialFunction[Throwable, Try[U]]): Try[U]
+  def recoverWith[U >: T](f: PartialFunction[Throwable, Try[U]]): Try[U]
 
   /**
    * Applies the given function `f` if this is a `Failure`, otherwise returns this if this is a `Success`.
@@ -150,20 +151,6 @@ sealed abstract class Try[+T] {
 
 object Try {
 
-  implicit def try2either[T](tr: Try[T]): Either[Throwable, T] = {
-    tr match {
-      case Success(v) => Right(v)
-      case Failure(t) => Left(t)
-    }
-  }
-
-  implicit def either2try[T](ei: Either[Throwable, T]): Try[T] = {
-    ei match {
-      case Right(v) => Success(v)
-      case Left(t) => Failure(t)
-    }
-  }
-
   def apply[T](r: => T): Try[T] = {
     try { Success(r) } catch {
       case NonFatal(e) => Failure(e)
@@ -175,7 +162,7 @@ object Try {
 final case class Failure[+T](val exception: Throwable) extends Try[T] {
   def isFailure: Boolean = true
   def isSuccess: Boolean = false
-  def rescue[U >: T](f: PartialFunction[Throwable, Try[U]]): Try[U] =
+  def recoverWith[U >: T](f: PartialFunction[Throwable, Try[U]]): Try[U] =
     if (f.isDefinedAt(exception)) f(exception) else this
   def get: T = throw exception
   def flatMap[U](f: T => Try[U]): Try[U] = Failure[U](exception)
@@ -201,12 +188,12 @@ final case class Failure[+T](val exception: Throwable) extends Try[T] {
 final case class Success[+T](value: T) extends Try[T] {
   def isFailure: Boolean = false
   def isSuccess: Boolean = true
-  def rescue[U >: T](f: PartialFunction[Throwable, Try[U]]): Try[U] = Success(value)
+  def recoverWith[U >: T](f: PartialFunction[Throwable, Try[U]]): Try[U] = Success(value)
   def get = value
   def flatMap[U](f: T => Try[U]): Try[U] =
     try f(value)
     catch {
-      case e: Throwable => Failure(e)
+      case NonFatal(e) => Failure(e)
     }
   def flatten[U](implicit ev: T <:< Try[U]): Try[U] = value
   def foreach[U](f: T => U): Unit = f(value)

--- a/src/library/scala/util/Try.scala
+++ b/src/library/scala/util/Try.scala
@@ -54,7 +54,7 @@ import language.implicitConversions
  *
  * `Try` comes to the Scala standard library after years of use as an integral part of Twitter's stack.
  *
- * @author based on Marius Eriksen's original implementation in com.twitter.util.
+ * @author based on Twitter's original implementation in com.twitter.util.
  * @since 2.10
  */
 sealed abstract class Try[+T] {
@@ -115,17 +115,6 @@ sealed abstract class Try[+T] {
    * Returns `None` if this is a `Failure` or a `Some` containing the value if this is a `Success`.
    */
   def toOption = if (isSuccess) Some(get) else None
-
-  /**
-   * Returns an empty `Seq` (usually a `List`) if this is a `Failure` or a `Seq` containing the value if this is a `Success`.
-   */
-  def toSeq = if (isSuccess) Seq(get) else Seq()
-
-  /**
-   * Returns the given function applied to the value from this `Success` or returns this if this is a `Failure`.
-   * Alias for `flatMap`.
-   */
-  def andThen[U](f: T => Try[U]): Try[U] = flatMap(f)
 
   /**
    * Transforms a nested `Try`, ie, a `Try` of type `Try[Try[T]]`,

--- a/test/files/jvm/future-spec/FutureTests.scala
+++ b/test/files/jvm/future-spec/FutureTests.scala
@@ -6,6 +6,7 @@ import scala.concurrent.util.duration._
 import scala.concurrent.util.Duration.Inf
 import scala.collection._
 import scala.runtime.NonLocalReturnControl
+import scala.util.{Try,Success,Failure}
 
 
 
@@ -197,7 +198,7 @@ object FutureTests extends MinimalScalaTest {
         } andThen {
           case _ => q.add(2)
         } andThen {
-          case Right(0) => q.add(Int.MaxValue)
+          case Success(0) => q.add(Int.MaxValue)
         } andThen {
           case _ => q.add(3);
         }
@@ -260,13 +261,13 @@ object FutureTests extends MinimalScalaTest {
       }
       
       val futures = (0 to 9) map {
-        idx => async(idx, idx * 200)
+        idx => async(idx, idx * 20)
       }
       val folded = Future.fold(futures)(0)(_ + _)
       Await.result(folded, timeout) mustBe (45)
       
       val futuresit = (0 to 9) map {
-        idx => async(idx, idx * 200)
+        idx => async(idx, idx * 20)
       }
       val foldedit = Future.fold(futures)(0)(_ + _)
       Await.result(foldedit, timeout) mustBe (45)
@@ -279,7 +280,7 @@ object FutureTests extends MinimalScalaTest {
         add
       }
       def futures = (0 to 9) map { 
-        idx => async(idx, idx * 200)
+        idx => async(idx, idx * 20)
       }
       val folded = futures.foldLeft(Future(0)) {
         case (fr, fa) => for (r <- fr; a <- fa) yield (r + a)
@@ -295,7 +296,7 @@ object FutureTests extends MinimalScalaTest {
         add
       }
       def futures = (0 to 9) map {
-        idx => async(idx, idx * 100)
+        idx => async(idx, idx * 10)
       }
       val folded = Future.fold(futures)(0)(_ + _)
       intercept[IllegalArgumentException] {
@@ -326,7 +327,7 @@ object FutureTests extends MinimalScalaTest {
     
     "shouldReduceResults" in {
       def async(idx: Int) = future {
-        Thread.sleep(idx * 200)
+        Thread.sleep(idx * 20)
         idx
       }
       val timeout = 10000 millis
@@ -348,7 +349,7 @@ object FutureTests extends MinimalScalaTest {
       }
       val timeout = 10000 millis
       def futures = (1 to 10) map {
-        idx => async(idx, idx * 100)
+        idx => async(idx, idx * 10)
       }
       val failed = Future.reduce(futures)(_ + _)
       intercept[IllegalArgumentException] {
@@ -472,7 +473,7 @@ object FutureTests extends MinimalScalaTest {
       p1.future.isCompleted mustBe (false)
       f4.isCompleted mustBe (false)
       
-      p1 complete Right("Hello")
+      p1 complete Success("Hello")
       
       Await.ready(latch(7), TestLatch.DefaultTimeout)
       
@@ -509,7 +510,7 @@ object FutureTests extends MinimalScalaTest {
     }
 
     "should not throw when Await.ready" in {
-      val expected = try Right(5 / 0) catch { case a: ArithmeticException => Left(a) }
+      val expected = try Success(5 / 0) catch { case a: ArithmeticException => Failure(a) }
       val f = future(5).map(_ / 0)
       Await.ready(f, defaultTimeout).value.get.toString mustBe expected.toString
     }

--- a/test/files/jvm/future-spec/PromiseTests.scala
+++ b/test/files/jvm/future-spec/PromiseTests.scala
@@ -6,7 +6,7 @@ import scala.concurrent.util.duration._
 import scala.concurrent.util.Duration.Inf
 import scala.collection._
 import scala.runtime.NonLocalReturnControl
-
+import scala.util.{Try,Success,Failure}
 
 
 object PromiseTests extends MinimalScalaTest {
@@ -48,27 +48,27 @@ object PromiseTests extends MinimalScalaTest {
   
   "A successful Promise" should {
     val result = "test value"
-    val promise = Promise[String]().complete(Right(result))
+    val promise = Promise[String]().complete(Success(result))
     promise.isCompleted mustBe (true)
     futureWithResult(_(promise.future, result))
   }
   
   "A failed Promise" should {
     val message = "Expected Exception"
-    val promise = Promise[String]().complete(Left(new RuntimeException(message)))
+    val promise = Promise[String]().complete(Failure(new RuntimeException(message)))
     promise.isCompleted mustBe (true)
     futureWithException[RuntimeException](_(promise.future, message))
   }
   
   "An interrupted Promise" should {
     val message = "Boxed InterruptedException"
-    val future = Promise[String]().complete(Left(new InterruptedException(message))).future
+    val future = Promise[String]().complete(Failure(new InterruptedException(message))).future
     futureWithException[ExecutionException](_(future, message))
   }
   
   "A NonLocalReturnControl failed Promise" should {
     val result = "test value"
-    val future = Promise[String]().complete(Left(new NonLocalReturnControl[String]("test", result))).future
+    val future = Promise[String]().complete(Failure(new NonLocalReturnControl[String]("test", result))).future
     futureWithResult(_(future, result))
   }
   
@@ -76,7 +76,7 @@ object PromiseTests extends MinimalScalaTest {
     
     "be completed" in { f((future, _) => future.isCompleted mustBe (true)) }
     
-    "contain a value" in { f((future, result) => future.value mustBe (Some(Right(result)))) }
+    "contain a value" in { f((future, result) => future.value mustBe (Some(Success(result)))) }
     
     "return when ready with 'Await.ready'" in { f((future, result) => Await.ready(future, defaultTimeout).isCompleted mustBe (true)) }
     
@@ -159,7 +159,7 @@ object PromiseTests extends MinimalScalaTest {
     
     "contain a value" in {
       f((future, message) => {
-        future.value.get.left.get.getMessage mustBe (message)
+        future.value.get.failed.get.getMessage mustBe (message)
       })
     }
     

--- a/test/files/jvm/future-spec/TryTests.scala
+++ b/test/files/jvm/future-spec/TryTests.scala
@@ -55,12 +55,12 @@ object TryTests extends MinimalScalaTest {
         Failure[Int](e) flatMap(x => Success(1 + x)) mustEqual Failure(e)
       }
 
-      "when there is an exception" in {
-        Success(1).flatMap[Int](_ => throw e) mustEqual Failure(e)
+      // "when there is an exception" in {
+      //   Success(1).flatMap[Int](_ => throw e) mustEqual Failure(e)
 
-        val e2 = new Exception
-        Failure[Int](e).flatMap[Int](_ => throw e2) mustEqual Failure(e)
-      }
+      //   val e2 = new Exception
+      //   Failure[Int](e).flatMap[Int](_ => throw e2) mustEqual Failure(e)
+      // }
     }
 
     "flatten" in {

--- a/test/files/jvm/future-spec/TryTests.scala
+++ b/test/files/jvm/future-spec/TryTests.scala
@@ -1,4 +1,3 @@
-x
 // This is a port of the com.twitter.util Try spec.
 // --
 // It lives in the future-spec directory simply because it requires a specs-like

--- a/test/files/jvm/future-spec/TryTests.scala
+++ b/test/files/jvm/future-spec/TryTests.scala
@@ -1,0 +1,119 @@
+
+// This is a port of the com.twitter.util Try spec.
+// --
+// It lives in the future-spec directory simply because it requires a specs-like
+// DSL which has already been minimally implemented for the future spec tests.
+
+import scala.util.{Try,Success,Failure}
+
+object TryTests extends MinimalScalaTest {
+  class MyException extends Exception
+  val e = new Exception("this is an exception")
+
+  "Try()" should {
+    "catch exceptions and lift into the Try type" in {
+      Try[Int](1) mustEqual Success(1)
+      Try[Int] { throw e } mustEqual Failure(e)
+    }
+  }
+
+  "Try" should {
+    "recoverWith" in {
+      val myException = new MyException
+      Success(1) recoverWith { case _ => Success(2) } mustEqual Success(1)
+      Failure(e) recoverWith { case _ => Success(2) } mustEqual Success(2)
+      Failure(e) recoverWith { case _ => Failure(e) } mustEqual Failure(e)
+    }
+
+    "getOrElse" in {
+      Success(1) getOrElse 2 mustEqual 1
+      Failure(e) getOrElse 2 mustEqual 2
+    }
+
+    "orElse" in {
+      Success(1) orElse Success(2) mustEqual Success(1)
+      Failure(e) orElse Success(2) mustEqual Success(2)
+    }
+
+    "map" in {
+      "when there is no exception" in {
+        Success(1) map(1+) mustEqual Success(2)
+        Failure[Int](e) map(1+) mustEqual Failure(e)
+      }
+
+      "when there is an exception" in {
+        Success(1) map(_ => throw e) mustEqual Failure(e)
+
+        val e2 = new Exception
+        Failure[Int](e) map(_ => throw e2) mustEqual Failure(e)
+      }
+    }
+
+    "flatMap" in {
+      "when there is no exception" in {
+        Success(1) flatMap(x => Success(1 + x)) mustEqual Success(2)
+        Failure[Int](e) flatMap(x => Success(1 + x)) mustEqual Failure(e)
+      }
+
+      "when there is an exception" in {
+        Success(1).flatMap[Int](_ => throw e) mustEqual Failure(e)
+
+        val e2 = new Exception
+        Failure[Int](e).flatMap[Int](_ => throw e2) mustEqual Failure(e)
+      }
+    }
+
+    "flatten" in {
+      "is a Success(Success)" in {
+        Success(Success(1)).flatten mustEqual Success(1)
+      }
+
+      "is a Success(Failure)" in {
+        val e = new Exception
+        Success(Failure(e)).flatten mustEqual Failure(e)
+      }
+
+      "is a Throw" in {
+        val e = new Exception
+        Failure[Try[Int]](e).flatten mustEqual Failure(e)
+      }
+    }
+
+    "for" in {
+      "with no Failure values" in {
+        val result = for {
+          i <- Success(1)
+          j <- Success(1)
+        } yield (i + j)
+        result mustEqual Success(2)
+      }
+
+      "with Failure values" in {
+        "throws before" in {
+          val result = for {
+            i <- Failure[Int](e)
+            j <- Success(1)
+          } yield (i + j)
+          result mustEqual Failure(e)
+        }
+
+        "throws after" in {
+          val result = for {
+            i <- Success(1)
+            j <- Failure[Int](e)
+          } yield (i + j)
+          result mustEqual Failure(e)
+        }
+
+        "returns the FIRST Failure" in {
+          val e2 = new Exception
+          val result = for {
+            i <- Failure[Int](e)
+            j <- Failure[Int](e2)
+          } yield (i + j)
+          result mustEqual Failure(e)
+        }
+      }
+    }
+  }
+}

--- a/test/files/jvm/future-spec/TryTests.scala
+++ b/test/files/jvm/future-spec/TryTests.scala
@@ -1,4 +1,4 @@
-
+x
 // This is a port of the com.twitter.util Try spec.
 // --
 // It lives in the future-spec directory simply because it requires a specs-like
@@ -55,12 +55,12 @@ object TryTests extends MinimalScalaTest {
         Failure[Int](e) flatMap(x => Success(1 + x)) mustEqual Failure(e)
       }
 
-      // "when there is an exception" in {
-      //   Success(1).flatMap[Int](_ => throw e) mustEqual Failure(e)
+      "when there is an exception" in {
+        Success(1).flatMap[Int](_ => throw e) mustEqual Failure(e)
 
-      //   val e2 = new Exception
-      //   Failure[Int](e).flatMap[Int](_ => throw e2) mustEqual Failure(e)
-      // }
+        val e2 = new Exception
+        Failure[Int](e).flatMap[Int](_ => throw e2) mustEqual Failure(e)
+      }
     }
 
     "flatten" in {

--- a/test/files/jvm/future-spec/main.scala
+++ b/test/files/jvm/future-spec/main.scala
@@ -12,6 +12,7 @@ object Test {
   def main(args: Array[String]) {
     FutureTests.check()
     PromiseTests.check()
+    TryTests.check()
   }
   
 }
@@ -47,7 +48,7 @@ trait MinimalScalaTest extends Output {
         snippet
         bufferPrintln("[OK] Test passed.")
       } catch {
-        case e =>
+        case e: Throwable =>
           bufferPrintln("[FAILED] " + e)
           bufferPrintln(e.getStackTrace().mkString("\n"))
           throwables += e
@@ -59,6 +60,7 @@ trait MinimalScalaTest extends Output {
   implicit def objectops(obj: Any) = new {
     
     def mustBe(other: Any) = assert(obj == other, obj + " is not " + other)
+    def mustEqual(other: Any) = mustBe(other)
     
   }
   

--- a/test/files/jvm/scala-concurrent-tck.scala
+++ b/test/files/jvm/scala-concurrent-tck.scala
@@ -601,10 +601,10 @@ trait FutureProjections extends TestBase {
       throw cause
     }
     f.failed onComplete {
-      case Right(t) =>
+      case Success(t) =>
         assert(t == cause)
         done()
-      case Left(t) =>
+      case Failure(t) =>
         assert(false)
     }
   }
@@ -626,9 +626,9 @@ trait FutureProjections extends TestBase {
     done =>
     val f = future { 0 }
     f.failed onComplete {
-      case Right(t) =>
+      case Success(t) =>
         assert(false)
-      case Left(t) =>
+      case Failure(t) =>
         assert(t.isInstanceOf[NoSuchElementException])
         done()
     }
@@ -803,81 +803,6 @@ trait Exceptions extends TestBase {
 
 }
 
-// trait TryEitherExtractor extends TestBase {
-
-//   import scala.util.{Try, Success, Failure}
-
-//   def testSuccessMatch(): Unit = once {
-//     done =>
-//     val thisIsASuccess = Success(42)
-//     thisIsASuccess match {
-//       case Success(v) =>
-//         done()
-//         assert(v == 42)
-//       case Failure(e) =>
-//         done()
-//         assert(false)
-//       case other =>
-//         done()
-//         assert(false)
-//     }
-//   }
-
-//   def testRightMatch(): Unit = once {
-//     done =>
-//     val thisIsNotASuccess: Right[Throwable, Int] = Right(43)
-//     thisIsNotASuccess match {
-//       case Success(v) =>
-//         done()
-//         assert(v == 43)
-//       case Failure(e) =>
-//         done()
-//         assert(false)
-//       case other =>
-//         done()
-//         assert(false)
-//     }
-//   }
-
-//   def testFailureMatch(): Unit = once {
-//     done =>
-//     val thisIsAFailure = Failure(new Exception("I'm an exception"))
-//     thisIsAFailure match {
-//       case Success(v) =>
-//         done()
-//         assert(false)
-//       case Failure(e) =>
-//         done()
-//         assert(e.getMessage == "I'm an exception")
-//       case other =>
-//         done()
-//         assert(false)
-//     }
-//   }
-
-//   def testLeftMatch(): Unit = once {
-//     done =>
-//     val thisIsNotAFailure: Left[Throwable, Int] = Left(new Exception("I'm an exception"))
-//     thisIsNotAFailure match {
-//       case Success(v) =>
-//         done()
-//         assert(false)
-//       case Failure(e) =>
-//         done()
-//         assert(e.getMessage == "I'm an exception")
-//       case other =>
-//         done()
-//         assert(false)
-//     }
-    
-//   }
-
-//   testSuccessMatch()
-//   testRightMatch()
-//   testFailureMatch()
-//   testLeftMatch()
-// }
-
 trait CustomExecutionContext extends TestBase {
   import scala.concurrent.{ ExecutionContext, Awaitable }
 
@@ -975,13 +900,13 @@ trait CustomExecutionContext extends TestBase {
            } flatMap { x =>
              Promise.successful(x + 1).future.map(addOne).map(addOne)
            } onComplete {
-            case Left(t) =>
+            case Failure(t) =>
               try {
                 throw new AssertionError("error in test: " + t.getMessage, t)
               } finally {
                 done()
               }
-            case Right(x) =>
+            case Success(x) =>
               assertEC()
               assert(x == 14)
               done()
@@ -1009,12 +934,8 @@ with FutureProjections
 with Promises
 with BlockContexts
 with Exceptions
-// with TryEitherExtractor
 with CustomExecutionContext
 {
   System.exit(0)
 }
-
-
-
 

--- a/test/files/jvm/scala-concurrent-tck.scala
+++ b/test/files/jvm/scala-concurrent-tck.scala
@@ -937,7 +937,7 @@ trait ExecutionContextPrepare extends TestBase {
     override def execute(runnable: Runnable): Unit =
       delegate.execute(runnable)
     
-    override def prepare[T, U](f: Try[T] => U): ExecutionContext = {
+    override def prepare(): ExecutionContext = {
       // save object stored in ThreadLocal storage
       val localData = theLocal.get
       new PreparingExecutionContext {

--- a/test/files/jvm/try-type-tests.scala
+++ b/test/files/jvm/try-type-tests.scala
@@ -59,12 +59,12 @@ trait TryStandard {
 
 	def testRescueSuccess(): Unit = {
 		val t = Success(1)
-		t.rescue{ case x => assert(false); Try() }
+		t.recoverWith{ case x => assert(false); Try() }
 	}
 
 	def testRescueFailure(): Unit = {
 		val t = Failure(new Exception("foo"))
-		val n = t.rescue{ case x => Try(1) }
+		val n = t.recoverWith{ case x => Try(1) }
 		assert(n.get == 1)
 	}
 
@@ -121,130 +121,8 @@ trait TryStandard {
 	testFailedFailure()
 }
 
-// tests that implicit conversions from Try to Either behave as expected
-trait TryImplicitConversionTry2Either {
-
-	def testTry2RightMap(): Unit = {
-		val t = Success(1)
-		val n = t.right.map(x => x * 100)
-		assert(n == Right(100))
-	}
-
-	def testTry2LeftMap(): Unit = {
-		val e = new Exception("foo")
-		val t = Failure(e)
-		val n = t.left.map(x => x)
-		assert(n == Left(e))
-	}
-
-	def testTry2FoldSuccess(): Unit = {
-		val t = Success(1)
-		val n = t.fold(x => assert(false), y => y * 200)
-		assert(n == 200)
-	}
-
-	def testTry2FoldFailure(): Unit = {
-		val e = new Exception("foo")
-		val t = Failure(e)
-		val n = t.fold(x => x, y => assert(false))
-		assert(n == e)
-	}
-
-	def testTry2SwapSuccess(): Unit = {
-		val t = Success(1)
-		val n = t.swap
-		assert(n == Left(1))
-	}
-
-	def testTry2SwapFailure(): Unit = {
-		val e = new Exception("foo")
-		val t = Failure(e)
-		val n = t.swap
-		assert(n == Right(e))
-	}
-
-	// def testTry2MergeSucccess(): Unit = {
-	// 	val t: Try[Int] = Success(1)
-	// 	val n = (t: Either[Any, Any]).t.merge // connecting two implicit conversions
-	// 	assert(n == 1)
-	// }
-
-	// def testTry2MergeFailure(): Unit = {
-	// 	val e = new Exception("foo")
-	// 	val t = Failure(e)
-	// 	val n = (t: Either[Any, Any]).merge // connecting two implicit conversions
-	// 	assert(n == e)
-	// }
-
-	testTry2RightMap()
-	testTry2LeftMap()
-	testTry2FoldSuccess()
-	testTry2FoldFailure()
-	testTry2SwapSuccess()
-	testTry2SwapFailure()
-	// testTry2MergeSucccess()
-	// testTry2MergeFailure()
-}
-
-// tests that implicit conversions from Either to Try behave as expected
-trait TryImplicitConversionEither2Try {
-
-	def testRight2FilterSuccessTrue(): Unit = {
-	  def expectsTry[U <% Try[Int]](rght: U): Try[Int] = {
-			val n = rght.filter(x => x > 0) // this should be converted to a Try
-			n
-	  }
-		val r = Right(1)
-    val n = expectsTry(r)
-		assert(n == Success(1))
-	}
-
-	def testRight2FilterSuccessFalse(): Unit = {
-	  def expectsTry[U <% Try[Int]](rght: U): Try[Int] = {
-			val n = rght.filter(x => x < 0) // this should be converted to a Try
-			n
-	  }
-		val r = Right(1)
-    val n = expectsTry(r)
-    n match {
-	case Failure(e: NoSuchElementException) => assert(true)
-	case _ => assert(false)
-    }
-	}
-
-	def testLeft2FilterFailure(): Unit = {
-	  def expectsTry[U <% Try[Int]](rght: U): Try[Int] = {
-			val n = rght.filter(x => x > 0) // this should be converted to a Try
-			n
-	  }
-		val r = Left(new Exception("foo"))
-    val n = expectsTry(r)
-    n match {
-	case Failure(e: Exception) => assert(true)
-	case _ => assert(false)
-    }
-	}
-
-	def testRight2GetSuccess(): Unit = {
-	  def expectsTry[U <% Try[Int]](rght: U): Int = {
-			val n = rght.get // this should be converted to a Try
-			n
-	  }
-		val r = Right(1)
-    val n = expectsTry(r)
-    assert(n == 1)
-	}
-
-	testRight2FilterSuccessTrue()
-	testRight2FilterSuccessFalse()
-	testLeft2FilterFailure()
-	testRight2GetSuccess()
-}
-
 object Test
 extends App
-with TryStandard
-with TryImplicitConversionTry2Either
-with TryImplicitConversionEither2Try {
+with TryStandard {
   System.exit(0)
 }

--- a/test/files/jvm/try-type-tests.scala
+++ b/test/files/jvm/try-type-tests.scala
@@ -107,7 +107,7 @@ trait TryStandard {
 		val s = Success(1)
 		val succ = (x: Int) => Success(x * 10)
 		val fail = (x: Throwable) => Success(0)
-		assert(s.transform(succ, fail).get == s.get)
+		assert(s.transform(succ, fail).get == 10)
 	}
 
 	def testFailureTransform(): Unit = {
@@ -133,6 +133,8 @@ trait TryStandard {
 	testFlattenSuccess()
 	testFailedSuccess()
 	testFailedFailure()
+	testSuccessTransform()
+	testFailureTransform()
 }
 
 object Test

--- a/test/files/jvm/try-type-tests.scala
+++ b/test/files/jvm/try-type-tests.scala
@@ -103,6 +103,20 @@ trait TryStandard {
 		}
 	}
 
+	def testSuccessTransform(): Unit = {
+		val s = Success(1)
+		val succ = (x: Int) => Success(x * 10)
+		val fail = (x: Throwable) => Success(0)
+		assert(s.transform(succ, fail).get == s.get)
+	}
+
+	def testFailureTransform(): Unit = {
+		val f = Failure(new Exception("foo"))
+		val succ = (x: Int) => Success(x * 10)
+		val fail = (x: Throwable) => Success(0)
+		assert(f.transform(succ, fail).get == 0)
+	}
+
 	testForeachSuccess()
 	testForeachFailure()
 	testFlatMapSuccess()


### PR DESCRIPTION
This pull request is a result of meetings between the Scala team, the Akka team and Twitter Engineering to move toward a consolidated future implementation.

Its main contribution is the replacement of the use of `Either` with `scala.util.Try` in methods `Future.onComplete`, `Future.value`, `Future.andThen`, `Promise.complete`, and `Promise.tryComplete`.

`Try` is an abstraction adopted from the `com.twitter.util` package [[1](https://github.com/twitter/util/)]. Unlike `Either`, `Try` is projection-less, which makes it more composable and more semantically similar to futures. Furthermore, as compared to `Either`, `Try` is better suited to handling exceptions, including execption-specific combinators such as `recover` and `recoverWith` (called `rescue` in `com.twitter.util.Try`). Moreover, both fatal and non-fatal exceptions are handled consistently across combinators such as `map` and `flatMap`. 

Changes compared to Twitter's original implementation of `Try`:
- Use `scala.util.control.NonFatal` (adopted from Akka [[2](http://akka.io/)] for SIP-14) to avoid catching fatal exceptions.
- Rename `Return/Throw` (in package `com.twitter.util`) to `Success`/`Failure` (in package `scala.util`); this makes the use of `Try` in combination with `Future` more regular.
- Rename `handle` (in package `com.twitter.util`) to `recover` (in package `scala.util`).
- Rename `rescue` (in package `com.twitter.util`) to `recoverWith` (in package `scala.util`), after `scala.concurrent.Future`'s semantically-similar `recoverWith` method.
- Add `foreach` method.
- Add `orElse` method.
- Add `failed` projection.

This pull request additionally contains some small fixes (`flatMap` in `Try` now goes through the `NonFatal` extractor), clean ups, and added tests on `Try`.

@phaller has also included a `prepare` method on `ExecutionContext`s which enables abstractions to be built on top of execution contexts, such as Twitter's `Local` for handling data local to a chain of future callbacks, as previously discussed.

Review by @viktorklang, and if available @mariusaeriksen 
