### PR TITLE
compatibility stub for SBT 0.12.0

### DIFF
--- a/src/reflect/scala/reflect/internal/Scopes.scala
+++ b/src/reflect/scala/reflect/internal/Scopes.scala
@@ -324,6 +324,9 @@ trait Scopes extends api.Scopes { self: SymbolTable =>
     override def filter(p: Symbol => Boolean): Scope =
       if (!(toList forall p)) newScopeWith(toList filter p: _*) else this
 
+    @deprecated("Use `toList.reverse` instead", "2.10.0")
+    def reverse: List[Symbol] = toList.reverse
+
     override def mkString(start: String, sep: String, end: String) =
       toList.map(_.defString).mkString(start, sep, end)
 


### PR DESCRIPTION
As discussed in http://groups.google.com/group/scala-internals/browse_thread/thread/9ee8df2ae9d43169,
recent change of return type for Type.members (from List[Symbol] to Scope)
broke compiler-interface for SBT 0.12.0-final.

This stub (courtesy of Jason Zaugg) keeps reflection API untouched and
also fixes SBT. Win-win.
