### PR TITLE
SI-6145 lax typing of args to synthetic case-labels

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3041,7 +3041,19 @@ trait Typers extends Modes with Adaptations with Tags {
               // target of a call.  Since this information is no longer available from
               // typedArg, it is recorded here.
               checkDead.updateExpr(fun)
-              val args1 = typedArgs(args, forArgMode(fun, mode), paramTypes, formals)
+
+              val args1 =
+                // no expected type when jumping to a match label -- anything goes (this is ok since we're typing the translation of well-typed code)
+                // ... except during erasure: we must take the expected type into account as it drives the insertion of casts!
+                // I've exhausted all other semi-clean approaches I could think of in balancing GADT magic, SI-6145, CPS type-driven transforms and other existential trickiness
+                // (the right thing to do -- packing existential types -- runs into limitations in subtyping existential types,
+                //  casting breaks SI-6145,
+                //  not casting breaks GADT typing as it requires sneaking ill-typed trees past typer)
+                if (!phase.erasedTypes && fun.symbol.isLabel && treeInfo.isSynthCaseSymbol(fun.symbol))
+                  typedArgs(args, forArgMode(fun, mode))
+                else
+                  typedArgs(args, forArgMode(fun, mode), paramTypes, formals)
+
               // instantiate dependent method types, must preserve singleton types where possible (stableTypeFor) -- example use case:
               // val foo = "foo"; def precise(x: String)(y: x.type): x.type = {...}; val bar : foo.type = precise(foo)(foo)
               // precise(foo) : foo.type => foo.type

--- a/test/files/pos/t6145.scala
+++ b/test/files/pos/t6145.scala
@@ -1,0 +1,11 @@
+object Test {
+  // the existential causes a cast and the cast makes searchClass not be in tail position
+  // can we get rid of the useless cast?
+  @annotation.tailrec
+  final def searchClass: Class[_] = {
+    "packageName" match {
+      case _ =>
+        searchClass
+    }
+  }
+}


### PR DESCRIPTION
Use wildcard for the expected type of the arguments of a jump to a label
synthesized by the pattern matcher... except during erasure: we must take the
expected type into account as it drives the insertion of casts!

It's ok since we're typing the translation of well-typed code. The only "type
errors" we catch are skolem mismatches. (after erasure the existential types that
before caused problems have disappeared.)

It's necessary to balance GADT magic, SI-6145, CPS type-driven transforms and
other existential trickiness. I've exhausted all other semi-clean approaches
I could think of:
- the right thing to do -- packing existential types -- runs into limitations
  in subtyping existential types,
- casting breaks SI-6145 (and it's an unnecessary cast at run time),
- not casting breaks GADT typing as it requires sneaking ill-typed trees
  past typer

review by @odersky
