### PR TITLE
Implemented specialized filter for scala.collection.immutable.HashSet

### DIFF
--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -166,6 +166,7 @@ object HashSet extends ImmutableSetFactory[HashSet] {
 
     protected override def filter0(p: A => Boolean) : HashSet[A] = {
       val ks1 = ks.filter(p)
+	  // call to ListSet.size is O(N), and ks1.head might also be inefficient. 
       ks1.size match {
         case 0 => HashSet.empty[A]
         case 1 => new HashSet1(ks1.head, hash)

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -130,7 +130,7 @@ object HashSet extends ImmutableSetFactory[HashSet] {
     override def removed0(key: A, hash: Int, level: Int): HashSet[A] =
       if (hash == this.hash && key == this.key) HashSet.empty[A] else this
 
-    override def filter0(p: A => Boolean) : HashSet[A] =
+    protected override def filter0(p: A => Boolean) : HashSet[A] =
       if(!p(key)) HashSet.empty[A] else this
 
     override def iterator: Iterator[A] = Iterator(key)
@@ -164,7 +164,7 @@ object HashSet extends ImmutableSetFactory[HashSet] {
           HashSet.empty[A]
       } else this
 
-    override def filter0(p: A => Boolean) : HashSet[A] = {
+    protected override def filter0(p: A => Boolean) : HashSet[A] = {
       val ks1 = ks.filter(p)
       ks1.size match {
         case 0 => HashSet.empty[A]
@@ -263,7 +263,7 @@ object HashSet extends ImmutableSetFactory[HashSet] {
       }
     }
 
-    override def filter0(p: A => Boolean): HashSet[A] = {
+    protected override def filter0(p: A => Boolean): HashSet[A] = {
       var index = 0
       var offset = 0
       var tgtOffset = 0

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -269,6 +269,7 @@ object HashSet extends ImmutableSetFactory[HashSet] {
       var tgtOffset = 0
       var bitmapNew = 0
       var elemsNew: Array[HashSet[A]] = null
+	  var sizeNew = 0
       // iterate over all 32 indices even though just a few of them might be occupied.
       while (index < 32) {
         val mask = (1 << index)
@@ -286,6 +287,7 @@ object HashSet extends ImmutableSetFactory[HashSet] {
               }
               elemsNew(tgtOffset) = subNew
             }
+			sizeNew += subNew.size
             bitmapNew |= mask
             tgtOffset += 1
           }
@@ -304,14 +306,14 @@ object HashSet extends ImmutableSetFactory[HashSet] {
       else if (tgtOffset == 1)
       // we don't need a HashTrieSet with one element
         elemsNew(0)
-      else if (tgtOffset == size0)
+      else if (tgtOffset == offset)
       // use elemsNew as is
-        if(elemsNew eq elems) this else new HashTrieSet[A](bitmapNew, elemsNew, tgtOffset)
+        if(elemsNew eq elems) this else new HashTrieSet[A](bitmapNew, elemsNew, sizeNew)
       else {
         // resize elemsNew
         val elemsNew2 = new Array[HashSet[A]](tgtOffset)
         Array.copy(elemsNew, 0, elemsNew2, 0, tgtOffset)
-        new HashTrieSet[A](bitmapNew, elemsNew2, tgtOffset)
+        new HashTrieSet[A](bitmapNew, elemsNew2, sizeNew)
       }
     }
 


### PR DESCRIPTION
This is a filter method for HashSet that does not use the builder infrastructure and thus does not create unneeded temporary copies. 
