### PR TITLE
Prevent creation of one element HashSetCollision1

### DIFF
--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -151,10 +151,11 @@ object HashSet extends ImmutableSetFactory[HashSet] {
     override def removed0(key: A, hash: Int, level: Int): HashSet[A] =
       if (hash == this.hash) {
         val ks1 = ks - key
-        if (!ks1.isEmpty)
-          new HashSetCollision1(hash, ks1)
-        else
-          HashSet.empty[A]
+        ks1.size match {
+          case 0 => HashSet.empty[A]
+          case 1 => new HashSet1(ks1.head, hash)
+          case _ => new HashSetCollision1(hash, ks1)
+        }
       } else this
 
     override def iterator: Iterator[A] = ks.iterator


### PR DESCRIPTION
if there is one element, there is no collision!

A problem with this might be that size for ListSet is O(N), and there is no other way to figure out if a ListSet contains exactly one element. Also, head might not be efficient for ListSet. 

But clearly having a HashSetCollision1 with one element is undesirable. 
