### PR TITLE
SI-6183 don't crash on type error in outer test

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
@@ -1043,8 +1043,9 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
 
         def outerTest(testedBinder: Symbol, expectedTp: Type): Tree = {
           val expectedOuter = expectedTp.prefix match {
-            case ThisType(clazz)  => THIS(clazz)
-            case pre              => REF(pre.prefix, pre.termSymbol)
+            case ThisType(clazz)      => THIS(clazz)
+            case pre if pre != NoType => REF(pre.prefix, pre.termSymbol)
+            case _ => TRUE_typed // fallback for SI-6183
           }
 
           // ExplicitOuter replaces `Select(q, outerSym) OBJ_EQ expectedPrefix` by `Select(q, outerAccessor(outerSym.owner)) OBJ_EQ expectedPrefix`


### PR DESCRIPTION
defend against ill-typed code reaching the outer-test codegen logic
since we already drop outer tests when in trouble, this fits nicely

there's no test case because the report was hard to minimize
since it was a crash on erroneous code, a backstop against a crash should suffice

review by @hubertp
