### PR TITLE
SI-5330, SI-6014 deal with existential self-type

### DIFF
--- a/test/files/pos/t5330.scala
+++ b/test/files/pos/t5330.scala
@@ -1,0 +1,24 @@
+trait FM[A] {
+  def map(f: A => Any)
+}
+
+trait M[A] extends FM[A] {
+  def map(f: A => Any)
+}
+
+trait N[A] extends FM[A]
+
+object test {
+  def kaboom(xs: M[_]) = xs map (x => ()) // missing parameter type.
+
+  def okay1[A](xs: M[A]) = xs map (x => ())
+  def okay2(xs: FM[_]) = xs map (x => ())
+  def okay3(xs: N[_]) = xs map (x => ())
+}
+
+
+// does not compile
+class CC2(xs: List[_]) {
+  def f(x1: Any, x2: Any) = null
+  def g = xs map (x => f(x, x))
+}

--- a/test/files/pos/t5330b.scala
+++ b/test/files/pos/t5330b.scala
@@ -1,0 +1,6 @@
+abstract trait Base {
+  def foo: this.type
+};
+class Derived[T] extends Base {
+  def foo: Nothing = sys.error("!!!")
+}

--- a/test/files/pos/t6014.scala
+++ b/test/files/pos/t6014.scala
@@ -1,0 +1,13 @@
+object Test {
+  case class CC[T](key: T)
+  type Alias[T] = Seq[CC[T]]
+
+  def f(xs: Seq[CC[_]]) = xs map { case CC(x) => CC(x) }    // ok
+  def g(xs: Alias[_])   = xs map { case CC(x) => CC(x) }    // fails
+  // ./a.scala:11: error: missing parameter type for expanded function
+  // The argument types of an anonymous function must be fully known. (SLS 8.5)
+  // Expected type was: ?
+  //   def g(xs: Alias[_])   = xs map { case CC(x) => CC(x) }    // fails
+  //                                  ^
+  // one error found
+}


### PR DESCRIPTION
This has been broken since https://github.com/scala/scala/commit/b7b81ca2#L0L567.
The existential rash is treated in a similar manner as in fc24db4c.

Conceptually, the fix would be `def selfTypeSkolemized = widen.skolemizeExistential.narrow`,
but simply widening before narrowing achieves the same thing. Since we're in existential voodoo territory,
let's go for the minimal fix: replacing `this.narrow` by `widen.narrow`.

review by @odersky
