### PR TITLE
Fixes SI-3791

### DIFF
--- a/src/library/scala/Double.scala
+++ b/src/library/scala/Double.scala
@@ -29,12 +29,12 @@ final abstract class Double private extends AnyVal {
   def toDouble: Double
 
   /**
- * Returns this value, unmodified.
- */
+  * Returns this value, unmodified.
+  */
   def unary_+ : Double
   /**
- * Returns the negation of this value.
- */
+  * Returns the negation of this value.
+  */
   def unary_- : Double
 
   def +(x: String): String
@@ -370,6 +370,11 @@ object Double extends AnyValCompanion {
   final val PositiveInfinity = java.lang.Double.POSITIVE_INFINITY
   final val NegativeInfinity = java.lang.Double.NEGATIVE_INFINITY
 
+  /** Upper bound on the relative error which occurs when a real number is rounded
+   *  to its nearest Double floating-point number.
+   */
+  final val Epsilon = java.lang.Double.longBitsToDouble(0x3ca0000000000000L)
+
   /** The negative number with the greatest (finite) absolute value which is representable
    *  by a Double.  Note that it differs from [[java.lang.Double.MIN_VALUE]], which
    *  is the smallest positive value representable by a Double.  In Scala that number
@@ -379,7 +384,7 @@ object Double extends AnyValCompanion {
 
   /** The largest finite positive number representable as a Double. */
   final val MaxValue = java.lang.Double.MAX_VALUE
-
+  
   /** Transform a value type into a boxed reference type.
    *
    *  @param  x   the Double to be boxed

--- a/src/library/scala/Double.scala
+++ b/src/library/scala/Double.scala
@@ -373,7 +373,7 @@ object Double extends AnyValCompanion {
   /** Upper bound on the relative error which occurs when a real number is rounded
    *  to its nearest Double floating-point number.
    */
-  final val Epsilon = java.lang.Double.longBitsToDouble(0x3ca0000000000000L)
+  final val Epsilon = 1.1102230246251565E-16
 
   /** The negative number with the greatest (finite) absolute value which is representable
    *  by a Double.  Note that it differs from [[java.lang.Double.MIN_VALUE]], which

--- a/src/library/scala/Float.scala
+++ b/src/library/scala/Float.scala
@@ -373,7 +373,7 @@ object Float extends AnyValCompanion {
   /** Upper bound on the relative error which occurs when a real number is rounded
    *  to its nearest Float floating-point number.
    */
-  final val Epsilon = java.lang.Float.intBitsToFloat(0x33800000)
+  final val Epsilon = 5.9604644775390625E-08f
 
   /** The negative number with the greatest (finite) absolute value which is representable
    *  by a Float.  Note that it differs from [[java.lang.Float.MIN_VALUE]], which

--- a/src/library/scala/Float.scala
+++ b/src/library/scala/Float.scala
@@ -29,12 +29,12 @@ final abstract class Float private extends AnyVal {
   def toDouble: Double
 
   /**
- * Returns this value, unmodified.
- */
+  * Returns this value, unmodified.
+  */
   def unary_+ : Float
   /**
- * Returns the negation of this value.
- */
+  * Returns the negation of this value.
+  */
   def unary_- : Float
 
   def +(x: String): String
@@ -369,6 +369,11 @@ object Float extends AnyValCompanion {
   final val NaN              = java.lang.Float.NaN
   final val PositiveInfinity = java.lang.Float.POSITIVE_INFINITY
   final val NegativeInfinity = java.lang.Float.NEGATIVE_INFINITY
+
+  /** Upper bound on the relative error which occurs when a real number is rounded
+   *  to its nearest Float floating-point number.
+   */
+  final val Epsilon = java.lang.Float.intBitsToFloat(0x33800000)
 
   /** The negative number with the greatest (finite) absolute value which is representable
    *  by a Float.  Note that it differs from [[java.lang.Float.MIN_VALUE]], which

--- a/test/files/run/t3791.scala
+++ b/test/files/run/t3791.scala
@@ -1,0 +1,27 @@
+object Test extends App {
+  // checks whether Double.Epsilon == 2^(-53)
+  assert(Double.Epsilon == java.lang.Double.longBitsToDouble(0x3ca0000000000000L))
+
+  // checks whether Float.Epsilon == 2^(-24)
+  assert(Float.Epsilon == java.lang.Float.intBitsToFloat(0x33800000))
+
+  // epsd is the greatest power of 2 such that 1+epsd == 1
+  // this value should be equivalent to Double.Epsilon
+  def epsd = {
+    var e: Double = 1
+    var f = 1 + e
+    while(f > 1) { e = e / 2; f = 1+e }
+    e
+  }
+  assert(epsd == Double.Epsilon)
+
+  // epsf is the greatest power of 2 such that 1+epsf == 1
+  // this value should be equivalent to Float.Epsilon
+  def epsf = {
+    var e: Float = 1
+    var f = 1 + e
+    while(f > 1) { e = e / 2; f = 1+e }
+    e
+  }
+  assert(epsf == Float.Epsilon)
+}


### PR DESCRIPTION
review by @phaller or @retronym

After Float.Epsilon and Double.Epsilon have been deprecated for
2.9, they have been removed for 2.10. With this pull request, the
correct values for Epsilon are added for 2.11.

The definition for the machine epsilon is taken from the paper "What
Every Computer Scientist Should Know About Floating-Point Arithmetic"
by David Goldberg, published in the March, 1991 issue of the ACM
Computing Surveys.

I have also fixed the indentation of two doc comments in both sources.
