### PR TITLE
SI-6186 TypeTags no longer supported in macros

### DIFF
--- a/src/compiler/scala/tools/reflect/FastTrack.scala
+++ b/src/compiler/scala/tools/reflect/FastTrack.scala
@@ -28,7 +28,7 @@ trait FastTrack {
     def run(args: List[Any]): Any = {
       val c = args(0).asInstanceOf[MacroContext]
       val result = expander((c, c.expandee))
-      c.Expr[Nothing](result)(c.TypeTag.Nothing)
+      c.Expr[Nothing](result)(c.AbsTypeTag.Nothing)
     }
   }
 

--- a/src/library/scala/reflect/base/Universe.scala
+++ b/src/library/scala/reflect/base/Universe.scala
@@ -46,8 +46,8 @@ abstract class Universe extends Symbols
    *    def macroImpl[T](c: Context) = {
    *      ...
    *      // T here is just a type parameter, so the tree produced by reify won't be of much use in a macro expansion
-   *      // however, if T were annotated with c.TypeTag (which would declare an implicit parameter for macroImpl)
-   *      // then reification would subtitute T with the TypeTree that was used in a TypeApply of this particular macro invocation
+   *      // however, if T were annotated with c.AbsTypeTag (which would declare an implicit parameter for macroImpl)
+   *      // then reification would substitute T with the TypeTree that was used in a TypeApply of this particular macro invocation
    *      val factory = c.reify{ new Queryable[T] }
    *      ...
    *    }

--- a/src/reflect/scala/reflect/macros/Infrastructure.scala
+++ b/src/reflect/scala/reflect/macros/Infrastructure.scala
@@ -35,7 +35,7 @@ trait Infrastructure {
    *
    *    def staticEval[T](x: T) = macro staticEval[T]
    *
-   *    def staticEval[T: c.TypeTag](c: Context)(x: c.Expr[T]) = {
+   *    def staticEval[T](c: Context)(x: c.Expr[T]) = {
    *      import scala.reflect.runtime.{universe => ru}
    *      val mirror = ru.runtimeMirror(c.libraryClassLoader)
    *      import scala.tools.reflect.ToolBox

--- a/src/reflect/scala/reflect/runtime/package.scala
+++ b/src/reflect/scala/reflect/runtime/package.scala
@@ -19,7 +19,7 @@ package runtime {
       if (runtimeClass.isEmpty) c.abort(c.enclosingPosition, "call site does not have an enclosing class")
       val runtimeUniverse = Select(Select(Select(Ident(newTermName("scala")), newTermName("reflect")), newTermName("runtime")), newTermName("universe"))
       val currentMirror = Apply(Select(runtimeUniverse, newTermName("runtimeMirror")), List(Select(runtimeClass, newTermName("getClassLoader"))))
-      c.Expr[Nothing](currentMirror)(c.TypeTag.Nothing)
+      c.Expr[Nothing](currentMirror)(c.AbsTypeTag.Nothing)
     }
   }
 }

--- a/test/files/neg/macro-invalidsig-context-bounds.check
+++ b/test/files/neg/macro-invalidsig-context-bounds.check
@@ -1,4 +1,4 @@
-Impls_1.scala:5: error: macro implementations cannot have implicit parameters other than TypeTag evidences
-  def foo[U: c.TypeTag: Numeric](c: Ctx) = {
+Impls_1.scala:5: error: macro implementations cannot have implicit parameters other than AbsTypeTag evidences
+  def foo[U: c.AbsTypeTag: Numeric](c: Ctx) = {
       ^
 one error found

--- a/test/files/neg/macro-invalidsig-context-bounds/Impls_1.scala
+++ b/test/files/neg/macro-invalidsig-context-bounds/Impls_1.scala
@@ -2,7 +2,7 @@ import scala.reflect.runtime.universe._
 import scala.reflect.macros.{Context => Ctx}
 
 object Impls {
-  def foo[U: c.TypeTag: Numeric](c: Ctx) = {
+  def foo[U: c.AbsTypeTag: Numeric](c: Ctx) = {
     import c.universe._
     Literal(Constant(42))
   }

--- a/test/files/neg/macro-invalidsig-implicit-params.check
+++ b/test/files/neg/macro-invalidsig-implicit-params.check
@@ -1,4 +1,4 @@
-Impls_Macros_1.scala:5: error: macro implementations cannot have implicit parameters other than TypeTag evidences
-  def foo_targs[T, U: c.TypeTag](c: Ctx)(implicit x: c.Expr[Int]) = {
-                                                  ^
+Impls_Macros_1.scala:5: error: macro implementations cannot have implicit parameters other than AbsTypeTag evidences
+  def foo_targs[T, U: c.AbsTypeTag](c: Ctx)(implicit x: c.Expr[Int]) = {
+                                                     ^
 one error found

--- a/test/files/neg/macro-invalidsig-implicit-params/Impls_Macros_1.scala
+++ b/test/files/neg/macro-invalidsig-implicit-params/Impls_Macros_1.scala
@@ -2,13 +2,13 @@ import scala.reflect.runtime.universe._
 import scala.reflect.macros.{Context => Ctx}
 
 object Impls {
-  def foo_targs[T, U: c.TypeTag](c: Ctx)(implicit x: c.Expr[Int]) = {
+  def foo_targs[T, U: c.AbsTypeTag](c: Ctx)(implicit x: c.Expr[Int]) = {
     import c.{prefix => prefix}
     import c.universe._
     val body = Block(
       Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("invoking foo_targs...")))),
       Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("type of prefix is: " + prefix.staticType)))),
-      Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("U is: " + implicitly[c.TypeTag[U]].tpe)))),
+      Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("U is: " + implicitly[c.AbsTypeTag[U]].tpe)))),
       Literal(Constant(())))
     c.Expr[Unit](body)
   }

--- a/test/files/neg/macro-invalidsig-tparams-notparams-a/Impls_1.scala
+++ b/test/files/neg/macro-invalidsig-tparams-notparams-a/Impls_1.scala
@@ -2,5 +2,5 @@ import scala.reflect.runtime.universe._
 import scala.reflect.macros.{Context => Ctx}
 
 object Impls {
-  def foo[U: c.TypeTag](c: Ctx) = ???
+  def foo[U: c.AbsTypeTag](c: Ctx) = ???
 }

--- a/test/files/neg/macro-invalidsig-tparams-notparams-b/Impls_1.scala
+++ b/test/files/neg/macro-invalidsig-tparams-notparams-b/Impls_1.scala
@@ -2,9 +2,9 @@ import scala.reflect.runtime.universe._
 import scala.reflect.macros.{Context => Ctx}
 
 object Impls {
-  def foo[T: c.TypeTag, U: c.TypeTag, V](c: Ctx)(implicit V: c.TypeTag[V]): c.Expr[Unit] = {
-    println(implicitly[c.TypeTag[T]])
-    println(implicitly[c.TypeTag[U]])
+  def foo[T: c.AbsTypeTag, U: c.AbsTypeTag, V](c: Ctx)(implicit V: c.AbsTypeTag[V]): c.Expr[Unit] = {
+    println(implicitly[c.AbsTypeTag[T]])
+    println(implicitly[c.AbsTypeTag[U]])
     println(V)
     c.literalUnit
   }

--- a/test/files/neg/macro-invalidsig-tparams-notparams-c.check
+++ b/test/files/neg/macro-invalidsig-tparams-notparams-c.check
@@ -1,4 +1,4 @@
-Macros_Test_2.scala:3: error: wrong number of type parameters for method foo: [T, U, V](c: scala.reflect.macros.Context)(implicit evidence$1: c.TypeTag[T], implicit evidence$2: c.TypeTag[U], implicit V: c.TypeTag[V])c.Expr[Unit]
+Macros_Test_2.scala:3: error: wrong number of type parameters for method foo: [T, U, V](c: scala.reflect.macros.Context)(implicit evidence$1: c.AbsTypeTag[T], implicit evidence$2: c.AbsTypeTag[U], implicit V: c.AbsTypeTag[V])c.Expr[Unit]
     def foo[V] = macro Impls.foo[V]
                                 ^
 one error found

--- a/test/files/neg/macro-invalidsig-tparams-notparams-c/Impls_1.scala
+++ b/test/files/neg/macro-invalidsig-tparams-notparams-c/Impls_1.scala
@@ -2,10 +2,10 @@ import scala.reflect.runtime.universe._
 import scala.reflect.macros.{Context => Ctx}
 
 object Impls {
-  def foo[T: c.TypeTag, U: c.TypeTag, V](c: Ctx)(implicit V: c.TypeTag[V]): c.Expr[Unit] = {
+  def foo[T: c.AbsTypeTag, U: c.AbsTypeTag, V](c: Ctx)(implicit V: c.AbsTypeTag[V]): c.Expr[Unit] = {
     import c.universe._
-    println(implicitly[c.TypeTag[T]])
-    println(implicitly[c.TypeTag[U]])
+    println(implicitly[c.AbsTypeTag[T]])
+    println(implicitly[c.AbsTypeTag[U]])
     println(V)
     c.literalUnit
   }

--- a/test/files/pos/t6047.scala
+++ b/test/files/pos/t6047.scala
@@ -4,7 +4,7 @@ import java.io.InputStream
 object Macros {
    def unpack[A](input: InputStream): A = macro unpack_impl[A]
 
-   def unpack_impl[A: c.TypeTag](c: Context)(input: c.Expr[InputStream]): c.Expr[A] = {
+   def unpack_impl[A: c.AbsTypeTag](c: Context)(input: c.Expr[InputStream]): c.Expr[A] = {
      import c.universe._
 
      def unpackcode(tpe: c.Type): c.Expr[_] = {
@@ -14,7 +14,7 @@ object Macros {
        ???
      }
 
-     unpackcode(c.typeOf[A])
+     unpackcode(implicitly[c.AbsTypeTag[A]].tpe)
      ???
    }
  }

--- a/test/files/run/macro-def-path-dependent-d/Impls_Macros_1.scala
+++ b/test/files/run/macro-def-path-dependent-d/Impls_Macros_1.scala
@@ -5,5 +5,5 @@ import scala.reflect.api.Universe
 object Test {
   def materializeTypeTag[T](u: Universe)(e: T) = macro materializeTypeTag_impl[T]
 
-  def materializeTypeTag_impl[T: c.TypeTag](c: Context)(u: c.Expr[Universe])(e: c.Expr[T]): c.Expr[u.value.TypeTag[T]] = ???
+  def materializeTypeTag_impl[T: c.AbsTypeTag](c: Context)(u: c.Expr[Universe])(e: c.Expr[T]): c.Expr[u.value.TypeTag[T]] = ???
 }

--- a/test/files/run/macro-expand-nullary-generic/Impls_1.scala
+++ b/test/files/run/macro-expand-nullary-generic/Impls_1.scala
@@ -2,14 +2,14 @@ import scala.reflect.runtime.universe._
 import scala.reflect.macros.{Context => Ctx}
 
 object Impls {
-  def impl[T: c.TypeTag](c: Ctx) = {
+  def impl[T: c.AbsTypeTag](c: Ctx) = {
     import c.universe._
-    val body = Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("it works " + implicitly[c.TypeTag[T]]))))
+    val body = Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("it works " + implicitly[c.AbsTypeTag[T]]))))
     c.Expr[Unit](body)
   }
 
-  def fooNullary[T: c.TypeTag](c: Ctx) = impl[T](c)
-  def fooEmpty[T: c.TypeTag](c: Ctx)() = impl[T](c)
-  def barNullary[T: c.TypeTag](c: Ctx)(x: c.Expr[Int]) = impl[T](c)
-  def barEmpty[T: c.TypeTag](c: Ctx)(x: c.Expr[Int])() = impl[T](c)
+  def fooNullary[T: c.AbsTypeTag](c: Ctx) = impl[T](c)
+  def fooEmpty[T: c.AbsTypeTag](c: Ctx)() = impl[T](c)
+  def barNullary[T: c.AbsTypeTag](c: Ctx)(x: c.Expr[Int]) = impl[T](c)
+  def barEmpty[T: c.AbsTypeTag](c: Ctx)(x: c.Expr[Int])() = impl[T](c)
 }

--- a/test/files/run/macro-expand-tparams-explicit/Impls_1.scala
+++ b/test/files/run/macro-expand-tparams-explicit/Impls_1.scala
@@ -2,9 +2,9 @@ import scala.reflect.runtime.universe._
 import scala.reflect.macros.{Context => Ctx}
 
 object Impls {
-  def foo[U: c.TypeTag](c: Ctx) = {
+  def foo[U: c.AbsTypeTag](c: Ctx) = {
     import c.universe._
-    val U = implicitly[c.TypeTag[U]]
+    val U = implicitly[c.AbsTypeTag[U]]
     val body = Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant(U.toString))))
     c.Expr[Unit](body)
   }

--- a/test/files/run/macro-expand-tparams-implicit/Impls_1.scala
+++ b/test/files/run/macro-expand-tparams-implicit/Impls_1.scala
@@ -2,9 +2,9 @@ import scala.reflect.runtime.universe._
 import scala.reflect.macros.{Context => Ctx}
 
 object Impls {
-  def foo[U: c.TypeTag](c: Ctx)(x: c.Expr[U]) = {
+  def foo[U: c.AbsTypeTag](c: Ctx)(x: c.Expr[U]) = {
     import c.universe._
-    val U = implicitly[c.TypeTag[U]]
+    val U = implicitly[c.AbsTypeTag[U]]
     val body = Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant(U.toString))))
     c.Expr[Unit](body)
   }

--- a/test/files/run/macro-expand-tparams-prefix-a/Impls_1.scala
+++ b/test/files/run/macro-expand-tparams-prefix-a/Impls_1.scala
@@ -2,9 +2,9 @@ import scala.reflect.runtime.universe._
 import scala.reflect.macros.{Context => Ctx}
 
 object Impls {
-  def foo[U: c.TypeTag](c: Ctx)(x: c.Expr[U]) = {
+  def foo[U: c.AbsTypeTag](c: Ctx)(x: c.Expr[U]) = {
     import c.universe._
-    val U = implicitly[c.TypeTag[U]]
+    val U = implicitly[c.AbsTypeTag[U]]
     val body = Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant(U.toString))))
     c.Expr[Unit](body)
   }

--- a/test/files/run/macro-expand-tparams-prefix-b/Impls_1.scala
+++ b/test/files/run/macro-expand-tparams-prefix-b/Impls_1.scala
@@ -2,10 +2,10 @@ import scala.reflect.runtime.universe._
 import scala.reflect.macros.{Context => Ctx}
 
 object Impls {
-  def foo[T: c.TypeTag, U: c.TypeTag](c: Ctx)(x: c.Expr[U]) = {
+  def foo[T: c.AbsTypeTag, U: c.AbsTypeTag](c: Ctx)(x: c.Expr[U]) = {
     import c.universe._
-    val T = implicitly[c.TypeTag[T]]
-    val U = implicitly[c.TypeTag[U]]
+    val T = implicitly[c.AbsTypeTag[T]]
+    val U = implicitly[c.AbsTypeTag[U]]
     val body = Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant(T.toString + " " + U.toString))))
     c.Expr[Unit](body)
   }

--- a/test/files/run/macro-expand-tparams-prefix-c1/Impls_1.scala
+++ b/test/files/run/macro-expand-tparams-prefix-c1/Impls_1.scala
@@ -2,11 +2,11 @@ import scala.reflect.runtime.universe._
 import scala.reflect.macros.{Context => Ctx}
 
 object Impls {
-  def foo[T, U: c.TypeTag, V](c: Ctx)(implicit T: c.TypeTag[T], V: c.TypeTag[V]): c.Expr[Unit] = {
+  def foo[T, U: c.AbsTypeTag, V](c: Ctx)(implicit T: c.AbsTypeTag[T], V: c.AbsTypeTag[V]): c.Expr[Unit] = {
     import c.universe._
     c.Expr(Block(List(
       Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant(T.toString)))),
-      Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant(implicitly[c.TypeTag[U]].toString)))),
+      Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant(implicitly[c.AbsTypeTag[U]].toString)))),
       Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant(V.toString))))),
       Literal(Constant(()))))
   }

--- a/test/files/run/macro-expand-tparams-prefix-c2/Impls_Macros_1.scala
+++ b/test/files/run/macro-expand-tparams-prefix-c2/Impls_Macros_1.scala
@@ -2,11 +2,11 @@ import scala.reflect.runtime.universe._
 import scala.reflect.macros.{Context => Ctx}
 
 object Impls {
-  def foo[T, U: c.TypeTag, V](c: Ctx)(implicit T: c.TypeTag[T], V: c.TypeTag[V]): c.Expr[Unit] = {
+  def foo[T, U: c.AbsTypeTag, V](c: Ctx)(implicit T: c.AbsTypeTag[T], V: c.AbsTypeTag[V]): c.Expr[Unit] = {
     import c.universe._
     c.Expr(Block(List(
       Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant(T.toString)))),
-      Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant(implicitly[c.TypeTag[U]].toString)))),
+      Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant(implicitly[c.AbsTypeTag[U]].toString)))),
       Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant(V.toString))))),
       Literal(Constant(()))))
   }

--- a/test/files/run/macro-impl-default-params/Impls_Macros_1.scala
+++ b/test/files/run/macro-impl-default-params/Impls_Macros_1.scala
@@ -2,10 +2,10 @@ import scala.reflect.runtime.universe._
 import scala.reflect.macros.{Context => Ctx}
 
 object Impls {
-  def foo_targs[T, U: c.TypeTag](c: Ctx = null)(x: c.Expr[Int] = null) = {
+  def foo_targs[T, U: c.AbsTypeTag](c: Ctx = null)(x: c.Expr[Int] = null) = {
     import c.{prefix => prefix}
     import c.universe._
-    val U = implicitly[c.TypeTag[U]]
+    val U = implicitly[c.AbsTypeTag[U]]
     val body = Block(
       Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("invoking foo_targs...")))),
       Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("type of prefix is: " + prefix.staticType)))),

--- a/test/files/run/macro-invalidusage-partialapplication-with-tparams/Impls_Macros_1.scala
+++ b/test/files/run/macro-invalidusage-partialapplication-with-tparams/Impls_Macros_1.scala
@@ -1,7 +1,7 @@
 import scala.reflect.macros.{Context => Ctx}
 
 object Impls {
-  def foo[T: c.TypeTag](c: Ctx)(x: c.Expr[T]) = {
+  def foo[T: c.AbsTypeTag](c: Ctx)(x: c.Expr[T]) = {
     import c.universe._
     val body = Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant(x.tree.toString))))
     c.Expr[Unit](body)

--- a/test/files/run/macro-reify-freevars/Macros_1.scala
+++ b/test/files/run/macro-reify-freevars/Macros_1.scala
@@ -1,7 +1,7 @@
 package scala.collection.slick
 
 object QueryableMacros{
-  def map[T:c.TypeTag, S:c.TypeTag]
+  def map[T:c.AbsTypeTag, S:c.AbsTypeTag]
          (c: scala.reflect.macros.Context)
          (projection: c.Expr[T => S])
          : c.Expr[scala.collection.slick.Queryable[S]] = {

--- a/test/files/run/macro-reify-nested-a/Impls_Macros_1.scala
+++ b/test/files/run/macro-reify-nested-a/Impls_Macros_1.scala
@@ -21,9 +21,9 @@ case class Utils[C <: Context]( c:C ) {
   }
 }
 object QueryableMacros{
-  def _helper[C <: Context,S:c.TypeTag]( c:C )( name:String, projection:c.Expr[_] ) = {
+  def _helper[C <: Context,S:c.AbsTypeTag]( c:C )( name:String, projection:c.Expr[_] ) = {
     import c.universe._
-    val element_type = c.typeOf[S]
+    val element_type = implicitly[c.AbsTypeTag[S]].tpe
     val foo = c.Expr[ru.Expr[Queryable[S]]](
     c.reifyTree( c.runtimeUniverse, EmptyTree, c.typeCheck(
       Utils[c.type](c).removeDoubleReify(
@@ -32,7 +32,7 @@ object QueryableMacros{
       )))
     c.universe.reify{ Queryable.factory[S]( foo.splice )}
   }
-  def map[T:c.TypeTag, S:c.TypeTag]
+  def map[T:c.AbsTypeTag, S:c.AbsTypeTag]
                (c: scala.reflect.macros.Context)
                (projection: c.Expr[T => S]): c.Expr[Queryable[S]] = _helper[c.type,S]( c )( "_map", projection )
 }

--- a/test/files/run/macro-reify-nested-b/Impls_Macros_1.scala
+++ b/test/files/run/macro-reify-nested-b/Impls_Macros_1.scala
@@ -21,9 +21,9 @@ case class Utils[C <: Context]( c:C ) {
   }
 }
 object QueryableMacros{
-  def _helper[C <: Context,S:c.TypeTag]( c:C )( name:String, projection:c.Expr[_] ) = {
+  def _helper[C <: Context,S:c.AbsTypeTag]( c:C )( name:String, projection:c.Expr[_] ) = {
     import c.universe._
-    val element_type = c.typeOf[S]
+    val element_type = implicitly[c.AbsTypeTag[S]].tpe
     val foo = c.Expr[ru.Expr[Queryable[S]]](
     c.reifyTree( c.runtimeUniverse, EmptyTree, c.typeCheck(
       Utils[c.type](c).removeDoubleReify(
@@ -32,7 +32,7 @@ object QueryableMacros{
       )))
     c.universe.reify{ Queryable.factory[S]( foo.splice )}
   }
-  def map[T:c.TypeTag, S:c.TypeTag]
+  def map[T:c.AbsTypeTag, S:c.AbsTypeTag]
                (c: scala.reflect.macros.Context)
                (projection: c.Expr[T => S]): c.Expr[Queryable[S]] = _helper[c.type,S]( c )( "_map", projection )
 }

--- a/test/files/run/macro-reify-tagful-a/Macros_1.scala
+++ b/test/files/run/macro-reify-tagful-a/Macros_1.scala
@@ -5,7 +5,7 @@ object Macros {
   def foo[T](s: T) = macro Impls.foo[T]
 
   object Impls {
-    def foo[T: c.TypeTag](c: Ctx)(s: c.Expr[T]) = c.universe.reify {
+    def foo[T: c.AbsTypeTag](c: Ctx)(s: c.Expr[T]) = c.universe.reify {
       List(s.splice)
     }
   }

--- a/test/files/run/macro-reify-tagless-a.check
+++ b/test/files/run/macro-reify-tagless-a.check
@@ -1,3 +1,3 @@
 reflective compilation has failed: 
 
-Macro expansion contains free type variable T defined by foo in Impls_Macros_1.scala:7:13. Have you forgotten to use c.TypeTag annotation for this type parameter? If you have troubles tracking free type variables, consider using -Xlog-free-types
+Macro expansion contains free type variable T defined by foo in Impls_Macros_1.scala:7:13. Have you forgotten to use c.AbsTypeTag annotation for this type parameter? If you have troubles tracking free type variables, consider using -Xlog-free-types

--- a/test/files/run/macro-undetparams-macroitself/Impls_Macros_1.scala
+++ b/test/files/run/macro-undetparams-macroitself/Impls_Macros_1.scala
@@ -2,7 +2,7 @@ import scala.reflect.runtime.universe._
 import scala.reflect.macros.Context
 
 object Macros {
-  def impl[T: c.TypeTag](c: Context)(foo: c.Expr[T]): c.Expr[Unit] = c.universe.reify { println(c.literal(implicitly[c.TypeTag[T]].toString).splice) }
+  def impl[T: c.AbsTypeTag](c: Context)(foo: c.Expr[T]): c.Expr[Unit] = c.universe.reify { println(c.literal(implicitly[c.AbsTypeTag[T]].toString).splice) }
 
   def foo[T](foo: T) = macro impl[T]
 }

--- a/test/pending/run/macro-expand-implicit-macro-defeats-type-inference/Impls_1.scala
+++ b/test/pending/run/macro-expand-implicit-macro-defeats-type-inference/Impls_1.scala
@@ -1,7 +1,7 @@
 import scala.reflect.macros.Context
 
 object Impls {
-  def foo[T: c.TypeTag](c: Context): c.Expr[List[T]] = c.universe.reify {
+  def foo[T: c.AbsTypeTag](c: Context): c.Expr[List[T]] = c.universe.reify {
     println("openImplicits are: " + c.literal(c.openImplicits.toString).splice)
     println("enclosingImplicits are: " + c.literal(c.enclosingImplicits.toString).splice)
     println("typetag is: " + c.literal(c.tag[T].toString).splice)

--- a/test/pending/run/macro-expand-tparams-prefix-e1/Impls_1.scala
+++ b/test/pending/run/macro-expand-tparams-prefix-e1/Impls_1.scala
@@ -1,11 +1,11 @@
 import scala.reflect.macros.{Context => Ctx}
 
 object Impls {
-  def foo[T, U: c.TypeTag, V](c: Ctx)(implicit T: c.TypeTag[T], V: c.TypeTag[V]): c.Expr[Unit] = {
+  def foo[T, U: c.AbsTypeTag, V](c: Ctx)(implicit T: c.AbsTypeTag[T], V: c.AbsTypeTag[V]): c.Expr[Unit] = {
     import c.universe._
     Block(List(
       Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant(T.toString)))),
-      Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant(implicitly[c.TypeTag[U]].toString)))),
+      Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant(implicitly[c.AbsTypeTag[U]].toString)))),
       Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant(V.toString))))),
       Literal(Constant(())))
   }

--- a/test/pending/run/macro-expand-tparams-prefix-f1/Impls_1.scala
+++ b/test/pending/run/macro-expand-tparams-prefix-f1/Impls_1.scala
@@ -1,11 +1,11 @@
 import scala.reflect.macros.{Context => Ctx}
 
 object Impls {
-  def foo[T, U: c.TypeTag, V](c: Ctx)(implicit T: c.TypeTag[T], V: c.TypeTag[V]): c.Expr[Unit] = {
+  def foo[T, U: c.AbsTypeTag, V](c: Ctx)(implicit T: c.AbsTypeTag[T], V: c.AbsTypeTag[V]): c.Expr[Unit] = {
     import c.universe._
     Block(List(
       Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant(T.toString)))),
-      Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant(implicitly[c.TypeTag[U]].toString)))),
+      Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant(implicitly[c.AbsTypeTag[U]].toString)))),
       Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant(V.toString))))),
       Literal(Constant(())))
   }

--- a/test/pending/run/macro-reify-array/Macros_1.scala
+++ b/test/pending/run/macro-reify-array/Macros_1.scala
@@ -4,7 +4,7 @@ object Macros {
   def foo[T](s: String) = macro Impls.foo[T]
 
   object Impls {
-    def foo[T: c.TypeTag](c: Ctx)(s: c.Expr[T]) = c.universe.reify {
+    def foo[T: c.AbsTypeTag](c: Ctx)(s: c.Expr[T]) = c.universe.reify {
       Array(s.splice)
     }
   }

--- a/test/pending/run/macro-reify-tagful-b/Macros_1.scala
+++ b/test/pending/run/macro-reify-tagful-b/Macros_1.scala
@@ -4,7 +4,7 @@ object Macros {
   def foo[T](s: T) = macro Impls.foo[List[T]]
 
   object Impls {
-    def foo[T: c.TypeTag](c: Ctx)(s: c.Expr[T]) = c.universe.reify {
+    def foo[T: c.AbsTypeTag](c: Ctx)(s: c.Expr[T]) = c.universe.reify {
       List(s.splice)
     }
   }


### PR DESCRIPTION
The original idea was to support both both TypeTags and ConcreteTypeTags as
context bounds on macro implementations.

Back then TypeTags were the implied default flavor of type tags. Basically
because "TypeTag" is shorter than "ConcreteTypeTag" everyone jumped onto
them and used them everywhere.

That led to problems, because at that time TypeTags could reify unresolved type
parameters ("unresolved" = not having TypeTag annotations for them). This
led to a series of creepy errors, when one forgets to add a context bound
in the middle of a chain of methods that all pass a type tag around, and then
suddenly all the tags turn into pumpkins (because that unlucky method just
reifies TypeRef(NoPrefix, <type parameter symbol>, Nil and passes it down
the chain).

Hence we decided to rename ConcreteTypeTag => TypeTag & TypeTag => AbsTypeTag,
which makes a lot of sense from a reflection point of view.

Unfortunately this broke macros (in a sense), because now everyone writes
TypeTag context bounds on macro implementations, which breaks in trivial
situations like: "def foo[T](x: T) = identity_macro(x)" (the type of x
is not concrete, so macro expansion will emit an error when trying to
materialize the corresponding TypeTag).

Now we restore the broken balance by banning TypeTag from macro impls.
This forces anyone to use AbsTypeTags, and if someone wants to check the input
for presence of abstract types, it's possible to do that manually.
