### PR TITLE
Removes AnyRef specialization from library

### DIFF
--- a/src/build/genprod.scala
+++ b/src/build/genprod.scala
@@ -6,6 +6,8 @@
 **                          |/                                          **
 \*                                                                      */
 
+import language.postfixOps
+
 /** This program generates the ProductN, TupleN, FunctionN,
  *  and AbstractFunctionN, where 0 <= N <= MAX_ARITY.
  *
@@ -75,7 +77,7 @@ package %s
 
   if (args.length != 1) {
     println("please give path of output directory")
-    exit(-1)
+    sys.exit(-1)
   }
   val out = args(0)
   def writeFile(node: scala.xml.Node) {
@@ -96,7 +98,7 @@ zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz */
 
 object FunctionZero extends Function(0) {
   override def genprodString  = "\n// genprod generated these sources at: " + new java.util.Date()
-  override def covariantSpecs = "@specialized "
+  override def covariantSpecs = "@specialized(Specializable.Primitives) "
   override def descriptiveComment = "  " + functionNTemplate.format("javaVersion", "anonfun0",
 """
  *    val javaVersion = () => sys.props("java.version")
@@ -111,8 +113,8 @@ object FunctionZero extends Function(0) {
 
 object FunctionOne extends Function(1) {
   override def classAnnotation    = "@annotation.implicitNotFound(msg = \"No implicit view available from ${T1} => ${R}.\")\n"
-  override def contravariantSpecs = "@specialized(scala.Int, scala.Long, scala.Float, scala.Double, scala.AnyRef) "
-  override def covariantSpecs     = "@specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double, scala.AnyRef) "
+  override def contravariantSpecs = "@specialized(scala.Int, scala.Long, scala.Float, scala.Double/*, scala.AnyRef*/) "
+  override def covariantSpecs     = "@specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double/*, scala.AnyRef*/) "
 
   override def descriptiveComment = "  " + functionNTemplate.format("succ", "anonfun1",
 """
@@ -169,7 +171,7 @@ object Function {
 
 class Function(val i: Int) extends Group("Function") with Arity {
   def descriptiveComment  = ""
-  def functionNTemplate = 
+  def functionNTemplate =
 """
  *  In the following example, the definition of %s is a
  *  shorthand for the anonymous class definition %s:
@@ -226,7 +228,7 @@ class Function(val i: Int) extends Group("Function") with Arity {
   }
 
   def tupleMethod = {
-    def comment = 
+    def comment =
 """  /** Creates a tupled version of this function: instead of %d arguments,
    *  it accepts a single [[scala.Tuple%d]] argument.
    *
@@ -275,7 +277,7 @@ object TupleOne extends Tuple(1)
 object TupleTwo extends Tuple(2)
 {
   override def imports = Tuple.zipImports
-  override def covariantSpecs = "@specialized(Int, Long, Double, Char, Boolean, AnyRef) "
+  override def covariantSpecs = "@specialized(Int, Long, Double, Char, Boolean/*, AnyRef*/) "
   override def moreMethods = """
   /** Swaps the elements of this `Tuple`.
    * @return a new Tuple where the first element is the second element of this Tuple and the

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -69,7 +69,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
   import definitions.{
     BooleanClass, UnitClass, ArrayClass,
     ScalaValueClasses, isPrimitiveValueClass, isPrimitiveValueType,
-    SpecializedClass, UnspecializedClass, AnyRefClass, ObjectClass, AnyRefModule,
+    SpecializedClass, UnspecializedClass, AnyRefClass, ObjectClass,
     GroupOfSpecializable, uncheckedVarianceClass, ScalaInlineClass
   }
   import rootMirror.RootClass
@@ -326,7 +326,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
     }
   }
 
-  lazy val specializableTypes = (ScalaValueClasses :+ AnyRefClass) map (_.tpe) sorted
+  lazy val specializableTypes = ScalaValueClasses map (_.tpe) sorted
 
   /** If the symbol is the companion of a value class, the value class.
    *  Otherwise, AnyRef.

--- a/src/library/scala/Function0.scala
+++ b/src/library/scala/Function0.scala
@@ -6,7 +6,7 @@
 **                          |/                                          **
 \*                                                                      */
 // GENERATED CODE: DO NOT EDIT.
-// genprod generated these sources at: Mon Apr 30 07:46:11 PDT 2012
+// genprod generated these sources at: Tue Aug 07 11:54:44 CEST 2012
 
 package scala
 
@@ -33,7 +33,7 @@ package scala
  *  latter can specify inputs which it will not handle.
 
  */
-trait Function0[@specialized +R] extends AnyRef { self =>
+trait Function0[@specialized(Specializable.Primitives) +R] extends AnyRef { self =>
   /** Apply the body of this function to the arguments.
    *  @return   the result of function application.
    */

--- a/src/library/scala/Function1.scala
+++ b/src/library/scala/Function1.scala
@@ -32,7 +32,7 @@ package scala
 
  */
 @annotation.implicitNotFound(msg = "No implicit view available from ${T1} => ${R}.")
-trait Function1[@specialized(scala.Int, scala.Long, scala.Float, scala.Double, scala.AnyRef) -T1, @specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double, scala.AnyRef) +R] extends AnyRef { self =>
+trait Function1[@specialized(scala.Int, scala.Long, scala.Float, scala.Double/*, scala.AnyRef*/) -T1, @specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double/*, scala.AnyRef*/) +R] extends AnyRef { self =>
   /** Apply the body of this function to the argument.
    *  @return   the result of function application.
    */

--- a/src/library/scala/Tuple2.scala
+++ b/src/library/scala/Tuple2.scala
@@ -16,7 +16,7 @@ package scala
  *  @param  _1   Element 1 of this Tuple2
  *  @param  _2   Element 2 of this Tuple2
  */
-case class Tuple2[@specialized(Int, Long, Double, Char, Boolean, AnyRef) +T1, @specialized(Int, Long, Double, Char, Boolean, AnyRef) +T2](_1: T1, _2: T2)
+case class Tuple2[@specialized(Int, Long, Double, Char, Boolean/*, AnyRef*/) +T1, @specialized(Int, Long, Double, Char, Boolean/*, AnyRef*/) +T2](_1: T1, _2: T2)
   extends Product2[T1, T2]
 {
   override def toString() = "(" + _1 + "," + _2 + ")"

--- a/src/library/scala/runtime/AbstractFunction0.scala
+++ b/src/library/scala/runtime/AbstractFunction0.scala
@@ -9,6 +9,6 @@
 
 package scala.runtime
 
-abstract class AbstractFunction0[@specialized +R] extends Function0[R] {
+abstract class AbstractFunction0[@specialized(Specializable.Primitives) +R] extends Function0[R] {
 
 }

--- a/src/library/scala/runtime/AbstractFunction1.scala
+++ b/src/library/scala/runtime/AbstractFunction1.scala
@@ -9,6 +9,6 @@
 
 package scala.runtime
 
-abstract class AbstractFunction1[@specialized(scala.Int, scala.Long, scala.Float, scala.Double, scala.AnyRef) -T1, @specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double, scala.AnyRef) +R] extends Function1[T1, R] {
+abstract class AbstractFunction1[@specialized(scala.Int, scala.Long, scala.Float, scala.Double/*, scala.AnyRef*/) -T1, @specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double/*, scala.AnyRef*/) +R] extends Function1[T1, R] {
 
 }

--- a/src/library/scala/specialized.scala
+++ b/src/library/scala/specialized.scala
@@ -28,5 +28,5 @@ import Specializable._
 
 class specialized(group: SpecializedGroup) extends annotation.StaticAnnotation {
   def this(types: Specializable*) = this(new Group(types.toList))
-  def this() = this(Everything)
+  def this() = this(Primitives)
 }

--- a/test/files/run/t3575.scala
+++ b/test/files/run/t3575.scala
@@ -1,8 +1,8 @@
 // This is here to tell me if the behavior changes, not because
 // the output is endorsed.
 case class Two[
-  @specialized A,
-  @specialized B
+  @specialized(Specializable.Everything) A,
+  @specialized(Specializable.Everything) B
 ](v: A, w: B)
 
 case class TwoLong[
@@ -16,8 +16,8 @@ case class TwoCool[
 ](v: A, w: B)
 
 case class TwoShort[
-  @specialized() A,
-  @specialized() B
+  @specialized(Specializable.Everything) A,
+  @specialized(Specializable.Everything) B
 ](v: A, w: B)
 
 case class TwoMinimal[

--- a/test/files/speclib/instrumented.jar.desired.sha1
+++ b/test/files/speclib/instrumented.jar.desired.sha1
@@ -1,1 +1,1 @@
-474d8c20ab31438d5d4a2ba6bc07ebdcdb530b50 *instrumented.jar
+1b11ac773055c1e942c6b5eb4aabdf02292a7194 ?instrumented.jar


### PR DESCRIPTION
As discussed in #999, #1025 and
https://groups.google.com/forum/?hl=en&fromgroups#!topic/scala-internals/5P5TS9ZWe_w

instrumented.jar is generated from the current source, there's no need
for a bootstrap commit.

Review by @paulp.
