### PR TITLE
Enable inlining in constructors.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/opt/Inliners.scala
+++ b/src/compiler/scala/tools/nsc/backend/opt/Inliners.scala
@@ -247,7 +247,7 @@ abstract class Inliners extends SubComponent {
         debuglog("Analyzing " + cls)
 
         this.currentIClazz = cls
-        val ms = cls.methods filterNot { _.symbol.isConstructor } sorted imethodOrdering
+        val ms = cls.methods sorted imethodOrdering
         ms foreach { im =>
           if(hasInline(im.symbol)) {
             log("Not inlining into " + im.symbol.originalName.decode + " because it is marked @inline.")

--- a/test/files/instrumented/inline-in-constructors.check
+++ b/test/files/instrumented/inline-in-constructors.check
@@ -1,0 +1,3 @@
+Method call statistics:
+    1  instrumented/Bar.<init>(Z)V
+    1  instrumented/Foo.<init>(I)V

--- a/test/files/instrumented/inline-in-constructors.flags
+++ b/test/files/instrumented/inline-in-constructors.flags
@@ -1,0 +1,1 @@
+-optimise

--- a/test/files/instrumented/inline-in-constructors/assert_1.scala
+++ b/test/files/instrumented/inline-in-constructors/assert_1.scala
@@ -1,0 +1,13 @@
+package instrumented
+
+object MyPredef {
+  @inline
+  final def assert(assertion: Boolean, message: => Any) {
+    if (!assertion)
+      throw new java.lang.AssertionError("assertion failed: " + message)
+  }
+}
+
+class Foo(x: Int) {
+  MyPredef.assert(x > 0, "not positive: " + x)
+}

--- a/test/files/instrumented/inline-in-constructors/bar_2.scala
+++ b/test/files/instrumented/inline-in-constructors/bar_2.scala
@@ -1,0 +1,7 @@
+package instrumented
+
+/** Class that uses assert compiled in previous compiler run so we check if
+    inlining in constructors works across different compilation runs */
+class Bar(x: Boolean) {
+  MyPredef.assert(x, "not true: " + x)
+}

--- a/test/files/instrumented/inline-in-constructors/test_3.scala
+++ b/test/files/instrumented/inline-in-constructors/test_3.scala
@@ -1,0 +1,15 @@
+import scala.tools.partest.instrumented.Instrumentation._
+import instrumented._
+
+object Test {
+  def main(args: Array[String]) {
+    // force predef initialization before profiling
+    Predef
+    MyPredef
+    startProfiling()
+    val a = new Foo(2)
+    val b = new Bar(true)
+    stopProfiling()
+    printStatistics()
+  }
+}


### PR DESCRIPTION
Inlining in constructors has been disabled a long
time ago due to some VerifyErrors. Unfortunately,
@dragos cannot recall what exactly was the problem.
I tried to enable inlining in constructors and I
didn't see any problem.

`Predef.assert` calls in class constructors are one
of the biggest contributors to closure allocation
in a compiler so we better off get rid of it.

Added a test-case that checks if inlining in
constructors works properly.

Review by @magarciaEPFL and @paulp.
