### PR TITLE
Fixes SI-5687.

### DIFF
--- a/test/files/neg/t5687.check
+++ b/test/files/neg/t5687.check
@@ -1,0 +1,8 @@
+t5687.scala:4: error: type arguments [T] do not conform to class Template's type parameter bounds [T <: AnyRef]
+  type Repr[T]<:Template[T]
+                ^
+t5687.scala:20: error: overriding type Repr in class Template with bounds[T] <: Template[T];
+ type Repr has incompatible type
+  type Repr = CurveTemplate[T]
+       ^
+two errors found

--- a/test/files/neg/t5687.scala
+++ b/test/files/neg/t5687.scala
@@ -1,0 +1,55 @@
+abstract class Template[T <: AnyRef](private val t: T) {
+
+//  type Repr[A<:AnyRef]<:Template[T]
+  type Repr[T]<:Template[T]
+
+  def access1(timeout: Int): Repr[T] = this.asInstanceOf[Repr[T]]
+  def access2: Repr[T] = this.asInstanceOf[Repr[T]]
+  val access3: Repr[T] = this.asInstanceOf[Repr[T]]
+  def access4(v: Repr[T]): Repr[T] = this.asInstanceOf[Repr[T]]
+  def access5(x: X): Repr[T] = this.asInstanceOf[Repr[T]]
+  def access5(x: Y): Repr[T] = this.asInstanceOf[Repr[T]]
+
+  def withReadModifiers(readModifiers:Int): Repr[T] = this.asInstanceOf[Repr[T]]
+}
+
+class Curve
+
+class CurveTemplate [T <: Curve](t: T) extends Template(t) {
+//  type Repr[A<: AnyRef] = CurveTemplate[T]
+  type Repr = CurveTemplate[T]
+}
+
+class Base
+class X extends Base
+class Y extends Base
+
+
+object Example {
+ def test1() {
+   new CurveTemplate(new Curve).access1(10)
+
+   new CurveTemplate(new Curve).access2
+
+   new CurveTemplate(new Curve).access3
+
+   new CurveTemplate(new Curve).access4(null)
+
+   new CurveTemplate(new Curve).access5(new X)
+
+   ()
+
+ }
+
+ def test2() {
+   new CurveTemplate(new Curve).access1(10).withReadModifiers(1)
+
+   new CurveTemplate(new Curve).access2.withReadModifiers(1)
+
+   new CurveTemplate(new Curve).access3.withReadModifiers(1)
+
+   new CurveTemplate(new Curve).access4(null).withReadModifiers(1)
+
+   new CurveTemplate(new Curve).access5(new X).withReadModifiers(1)
+ }
+}


### PR DESCRIPTION
Recover from erroneous type alias override to report
more useful error message.

Review by @adriaanm (I couldn't come up with a scenario where normalize would loop and I don't think it can happen so I left the original commit as is). 
