### PR TITLE
SI-6205 make pt fully defined before inferTypedPattern

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5040,10 +5040,11 @@ trait Typers extends Modes with Adaptations with Tags {
 
           if (isPatternMode) {
             val uncheckedTypeExtractor = extractorForUncheckedType(tpt.pos, tptTyped.tpe)
-            val ownType = inferTypedPattern(tptTyped, tptTyped.tpe, pt, canRemedy = uncheckedTypeExtractor.nonEmpty)
-            // println(s"Typed($expr, ${tpt.tpe}) : $pt --> $ownType  (${isFullyDefined(ownType)}, ${makeFullyDefined(ownType)})")
+
             // make fully defined to avoid bounded wildcard types that may be in pt from calling dropExistential (SI-2038)
-            treeTyped setType (if (isFullyDefined(ownType)) ownType else makeFullyDefined(ownType)) //ownType
+            val ptDefined = if (isFullyDefined(pt)) pt else makeFullyDefined(pt)
+            val ownType   = inferTypedPattern(tptTyped, tptTyped.tpe, ptDefined, canRemedy = uncheckedTypeExtractor.nonEmpty)
+            treeTyped setType ownType
 
             uncheckedTypeExtractor match {
               case None => treeTyped

--- a/test/files/pos/t6205.scala
+++ b/test/files/pos/t6205.scala
@@ -1,0 +1,18 @@
+// original code by reporter
+class A[T]
+class Test1 {
+  def x(backing: Map[A[_], Any]) =
+    for( (k: A[kt], v) <- backing)
+      yield (k: A[kt])
+}
+
+// this tests same thing as above, but independent of library classes,
+// earlier expansions eliminated as well as variance (everything's invariant)
+case class Holder[A](a: A)
+class Mapped[A] { def map[T](f: Holder[A] => T): Iterable[T] = ??? }
+class Test2 {
+  def works(backing: Mapped[A[_]]): Iterable[A[_]]
+    = backing.map(x =>
+         x match {case Holder(k: A[kt]) => (k: A[kt])}
+      )
+}


### PR DESCRIPTION
refines my fix for SI-2038 (#981) by making pt fully defined before calling inferTypedPattern,
instead of making the result of inferTypedPattern fully defined

I finally realized my mistake by diffing the -Ytyper-debug output of compiling the variants with:

```
  x match {case Holder(k: A[kt]) => (k: A[kt])}
```

and

```
  (x: Any) match {case Holder(k: A[kt]) => (k: A[kt])}
```
