### PR TITLE
SI-6184 don't introduce dummies in checkableType

### DIFF
--- a/test/files/pos/t6184.scala
+++ b/test/files/pos/t6184.scala
@@ -1,0 +1,7 @@
+trait Foo[TroubleSome] {
+  type T <: Foo[TroubleSome]
+
+  this match {
+    case e: Foo[_]#T => ???
+  }
+}


### PR DESCRIPTION
this should fix the crash in asSeenFrom that resulted from calling
baseTypeSeq on a type that had an unbound type parameter in it

also, simplify widenToClass
