### PR TITLE
Fix SI-6208.  mutable.Queue now returns mutable.Queue for collection met...

### DIFF
--- a/src/library/scala/collection/mutable/Queue.scala
+++ b/src/library/scala/collection/mutable/Queue.scala
@@ -32,6 +32,7 @@ import generic._
  */
 class Queue[A]
 extends MutableList[A]
+   with LinearSeqOptimized[A, Queue[A]]
    with GenericTraversableTemplate[A, Queue]
    with Cloneable[Queue[A]]
    with Serializable
@@ -165,6 +166,17 @@ extends MutableList[A]
    *  @return the first element.
    */
   def front: A = head
+
+
+  // TODO - Don't override this just for new to create appropriate type....
+  override def tail: Queue[A] = {
+    require(nonEmpty, "tail of empty list")
+    val tl = new Queue[A]
+    tl.first0 = first0.tail
+    tl.last0 = last0
+    tl.len = len - 1
+    tl
+  }
 }
 
 

--- a/test/files/pos/t6208.scala
+++ b/test/files/pos/t6208.scala
@@ -1,0 +1,4 @@
+object Test {
+  val col = collection.mutable.Queue(1,2,3)
+  val WORK: collection.mutable.Queue[Int] = col filterNot (_ % 2 == 0)
+}


### PR DESCRIPTION
...hods rather than MutableList.

Review by @alex22.  In particular, not happy about code duplication for `tail`.  Suggestions welcome, or I can refactory to add a MutableListLike if you think that's best.
