### PR TITLE
Moved inline logic before pickler.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -497,16 +497,7 @@ abstract class ExplicitOuter extends InfoTransform
           else atPos(tree.pos)(outerPath(outerValue, currentClass.outerClass, sym)) // (5)
 
         case Select(qual, name) =>
-          /** return closest enclosing method, unless shadowed by an enclosing class;
-           *  no use of closures here in the interest of speed.
-           */
-          def closestEnclMethod(from: Symbol): Symbol =
-            if (from.isSourceMethod) from
-            else if (from.isClass) NoSymbol
-            else closestEnclMethod(from.owner)
-
-          if (currentClass != sym.owner ||
-              (closestEnclMethod(currentOwner) hasAnnotation ScalaInlineClass))
+          if (currentClass != sym.owner)
             sym.makeNotPrivate(sym.owner)
 
           val qsym = qual.tpe.widen.typeSymbol

--- a/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
@@ -28,9 +28,6 @@ abstract class ExtensionMethods extends Transform with TypingTransformers {
   /** the following two members override abstract members in Transform */
   val phaseName: String = "extmethods"
 
-  /** The following flags may be set by this phase: */
-  override def phaseNewFlags: Long = notPRIVATE
-
   def newTransformer(unit: CompilationUnit): Transformer =
     new Extender(unit)
 

--- a/test/files/pos/inline-access-levels.flags
+++ b/test/files/pos/inline-access-levels.flags
@@ -1,0 +1,1 @@
+-optimise -Xfatal-warnings -Yinline-warnings

--- a/test/files/pos/inline-access-levels/A_1.scala
+++ b/test/files/pos/inline-access-levels/A_1.scala
@@ -1,0 +1,10 @@
+package test
+
+object A {
+
+  private var x: Int = 0
+
+  @inline def actOnX(f: Int => Int) = {
+    x = f(x)
+  }
+}

--- a/test/files/pos/inline-access-levels/Test_2.scala
+++ b/test/files/pos/inline-access-levels/Test_2.scala
@@ -1,0 +1,11 @@
+package test
+
+object Test {
+
+  def main(args: Array[String]) {
+
+    A.actOnX(_ + 1)
+
+  }
+
+}


### PR DESCRIPTION
The test case failed due to separate compilation. The problem was
that we don't pickle the fact that the field was made public.

Original patch by @odersky. Cleaned up by me. Changes I made:
- removed stale test-case
- reduced whitespace changes

Supersedes #1089.

Review by @odersky and @adriaanm.
