### PR TITLE
Si 6198

### DIFF
--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -151,10 +151,12 @@ object HashSet extends ImmutableSetFactory[HashSet] {
     override def removed0(key: A, hash: Int, level: Int): HashSet[A] =
       if (hash == this.hash) {
         val ks1 = ks - key
-        if (!ks1.isEmpty)
-          new HashSetCollision1(hash, ks1)
-        else
+        if(ks1.isEmpty)
           HashSet.empty[A]
+        else if(ks1.tail.isEmpty)
+          new HashSet1(ks1.head, hash)
+        else
+          new HashSetCollision1(hash, ks1)
       } else this
 
     override def iterator: Iterator[A] = ks.iterator

--- a/src/library/scala/collection/immutable/ListSet.scala
+++ b/src/library/scala/collection/immutable/ListSet.scala
@@ -116,8 +116,8 @@ class ListSet[A] extends AbstractSet[A]
     def hasNext = that.nonEmpty
     def next: A =
       if (hasNext) {
-        val res = that.elem
-        that = that.next
+        val res = that.head
+        that = that.tail
         res
       }
       else Iterator.empty.next
@@ -126,18 +126,18 @@ class ListSet[A] extends AbstractSet[A]
   /**
    *  @throws Predef.NoSuchElementException
    */
-  protected def elem: A = throw new NoSuchElementException("Set has no elements");
+  override def head: A = throw new NoSuchElementException("Set has no elements");
 
   /**
    *  @throws Predef.NoSuchElementException
    */
-  protected def next: ListSet[A] = throw new NoSuchElementException("Next of an empty set");
+  override def tail: ListSet[A] = throw new NoSuchElementException("Next of an empty set");
 
   override def stringPrefix = "ListSet"
 
   /** Represents an entry in the `ListSet`.
    */
-  protected class Node(override protected val elem: A) extends ListSet[A] with Serializable {
+  protected class Node(override val head: A) extends ListSet[A] with Serializable {
     override private[ListSet] def unchecked_outer = self
 
     /** Returns the number of elements in this set.
@@ -162,7 +162,7 @@ class ListSet[A] extends AbstractSet[A]
      */
     override def contains(e: A) = containsInternal(this, e)
     @tailrec private def containsInternal(n: ListSet[A], e: A): Boolean =
-      !n.isEmpty && (n.elem == e || containsInternal(n.unchecked_outer, e))
+      !n.isEmpty && (n.head == e || containsInternal(n.unchecked_outer, e))
 
     /** This method creates a new set with an additional element.
      */
@@ -170,10 +170,10 @@ class ListSet[A] extends AbstractSet[A]
 
     /** `-` can be used to remove a single element from a set.
      */
-    override def -(e: A): ListSet[A] = if (e == elem) self else {
-      val tail = self - e; new tail.Node(elem)
+    override def -(e: A): ListSet[A] = if (e == head) self else {
+      val tail = self - e; new tail.Node(head)
     }
 
-    override protected def next: ListSet[A] = self
+    override def tail: ListSet[A] = self
   }
 }

--- a/test/files/run/t6198.scala
+++ b/test/files/run/t6198.scala
@@ -1,0 +1,24 @@
+import scala.collection.immutable._
+
+object Test extends App {
+  // test that ListSet.tail does not use a builder
+  // we can't test for O(1) behavior, so the best we can do is to
+  // check that ls.tail always returns the same instance
+  val ls = ListSet.empty[Int] + 1 + 2
+
+  if(ls.tail ne ls.tail)
+    println("ListSet.tail should not use a builder!")
+
+  // class that always causes hash collisions
+  case class Collision(value:Int) { override def hashCode = 0 }
+
+  // create a set that should have a collison
+  val x = HashSet.empty + Collision(0) + Collision(1)
+  if(x.getClass.getSimpleName != "HashSetCollision1")
+    println("HashSet of size >1 with collisions should use HashSetCollision")
+
+  // remove the collision again by removing all but one element
+  val y = x - Collision(0)
+  if(y.getClass.getSimpleName != "HashSet1")
+    println("HashSet of size 1 should use HashSet1" + y.getClass)
+}


### PR DESCRIPTION
Create a HashSet1 instead of a HashSetCollision1 if the list of colliding keys has only one entry.

To do this efficiently it was necessary to change ListSet so that head and tail are both O(1) with low overhead.

Based on 2.10.x this time.
