### PR TITLE
SI-5940 impls are no longer in macro def pickles

### DIFF
--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -236,7 +236,7 @@ abstract class TreeInfo {
     case _ =>
       tree
   }
-  
+
   /** Is tree a self or super constructor call? */
   def isSelfOrSuperConstrCall(tree: Tree) = {
     // stripNamedApply for SI-3584: adaptToImplicitMethod in Typers creates a special context
@@ -370,6 +370,13 @@ abstract class TreeInfo {
     case Apply(fn, _)            => firstTypeArg(fn)
     case TypeApply(_, targ :: _) => targ
     case _                       => EmptyTree
+  }
+
+  /** If this tree represents a type application the type arguments. Otherwise Nil.
+   */
+  def typeArguments(tree: Tree): List[Tree] = tree match {
+    case TypeApply(_, targs) => targs
+    case _                   => Nil
   }
 
   /** If this tree has type parameters, those.  Otherwise Nil.

--- a/test/files/run/t5940.scala
+++ b/test/files/run/t5940.scala
@@ -1,0 +1,41 @@
+import scala.tools.partest._
+
+object Test extends DirectTest {
+  def code = ???
+
+  def macros_1 = """
+    import scala.reflect.macros.Context
+
+    object Impls {
+      def impl(c: Context) = c.literalUnit
+    }
+
+    object Macros {
+      //import Impls._
+      def impl(c: Context) = c.literalUnit
+      def foo = macro impl
+    }
+  """
+  def compileMacros() = {
+    val classpath = List(sys.props("partest.lib"), sys.props("partest.reflect")) mkString sys.props("path.separator")
+    compileString(newCompiler("-language:experimental.macros", "-cp", classpath, "-d", testOutput.path))(macros_1)
+  }
+
+  def test_2 = """
+    object Test extends App {
+      println(Macros.foo)
+    }
+  """
+  def compileTest() = {
+    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
+    compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(test_2)
+  }
+
+  def show(): Unit = {
+    log("Compiling Macros_1...")
+    if (compileMacros()) {
+      log("Compiling Test_2...")
+      if (compileTest()) log("Success!") else log("Failed...")
+    }
+  }
+}


### PR DESCRIPTION
The first officially released version of macros persisted
macro def -> impl bindings across compilation runs using a neat trick.

The right-hand side of macro definition (which contains a reference to an impl)
was typechecked and then put verbatim into an annotation on macro definition.

This solution is very simple, but unfortunately it's also lacking. If we use it
then signatures of macro defs become transitively dependent on scala-reflect.jar
(because they refer to macro impls, and macro impls refer to
scala.reflect.macros.Context defined in scala-reflect.jar).
More details can be found in https://issues.scala-lang.org/browse/SI-5940.

Therefore we have to avoid putting macro impls into binding pickles and
come up with our own serialization format. Situation is further complicated
by the fact that it's not enough to just pickle impl's class and method names,
because macro expansion needs knowledge about the shape of impl's signature
(which we can't pickle). Hence we precompute necessary stuff (e.g. the layout
of type parameters) when compiling macro defs.
