### PR TITLE
SI-6022 cleaner model of variable equality modulo <:

### DIFF
--- a/test/files/pos/t6022b.scala
+++ b/test/files/pos/t6022b.scala
@@ -1,0 +1,20 @@
+trait A
+trait B
+trait C
+trait AB extends B with A
+
+// two types are mutually exclusive if there is no equality symbol whose constant implies both
+object Test extends App {
+  def foo(x: Any) = x match {
+    case _ : C  => println("C")
+    case _ : AB => println("AB")
+    case _ : (A with B) => println("AB'")
+    case _ : B  => println("B")
+    case _ : A  => println("A")
+  }
+
+  foo(new A {})
+  foo(new B {})
+  foo(new AB{})
+  foo(new C {})
+}


### PR DESCRIPTION
centralized and improved the construction of the information needed to construct the boolean proposition that encodes the equality proposition (V = C) that models a type test pattern `_: C` or constant pattern `C`, where the type test gives rise to a TypeConst C, and the constant pattern yields a ValueConst C

for exhaustivity, we really only need implication (e.g., V = 1 implies that V = 1 /\ V = Int, if both tests occur in the match, and thus in this variable's equality symbols), but reachability also requires us to model things like V = 1 precluding V = "1"
