### PR TITLE
Made inliner work for @inline methods that access private variables.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/opt/Inliners.scala
+++ b/src/compiler/scala/tools/nsc/backend/opt/Inliners.scala
@@ -661,13 +661,15 @@ abstract class Inliners extends SubComponent {
          *
          * TODO handle more robustly the case of a trait var changed at the source-level from public to private[this]
          *      (eg by having ICodeReader use unpickler, see SI-5442).
-         * */
+         
+         DISABLED
+         
         def potentiallyPublicized(f: Symbol): Boolean = {
           (m.sourceFile eq NoSourceFile) && f.name.containsChar('$')
         }
+        */
 
-        def checkField(f: Symbol)   = check(f, potentiallyPublicized(f) ||
-                                               (f.isPrivate && !canMakePublic(f)))
+        def checkField(f: Symbol)   = check(f, f.isPrivate && !canMakePublic(f))
         def checkSuper(n: Symbol)   = check(n, n.isPrivate || !n.isClassConstructor)
         def checkMethod(n: Symbol)  = check(n, n.isPrivate)
 


### PR DESCRIPTION
We need to disable the previous "potentiallyPublished" logic because that one disables inlining as long as the inlined method has a reference to a field with a $. But making fields public in @inline method will generate fields with $. 

We still need to complement this patch with reverting the previous publication logic completely. I leave that to Vlad or Miguel. 

Review by @VladUreche, @magarciaEPFL, @gkossakowski, @moors
