### PR TITLE
Only create a HashTrieSet if necessary.

### DIFF
--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -236,7 +236,12 @@ object HashSet extends ImmutableSetFactory[HashSet] {
             Array.copy(elems, 0, elemsNew, 0, offset)
             Array.copy(elems, offset + 1, elemsNew, offset, elems.length - offset - 1)
             val sizeNew = size - sub.size
-            new HashTrieSet(bitmapNew, elemsNew, sizeNew)
+            // if we have only one child, which is not a HashTrieSet but a self-contained set like
+            // HashSet1 or HashSetCollision1, return the child instead
+            if (elemsNew.length == 1 && !elemsNew(0).isInstanceOf[HashTrieSet[_]])
+              elemsNew(0)
+            else
+              new HashTrieSet(bitmapNew, elemsNew, sizeNew)
           } else
             HashSet.empty[A]
         } else {

--- a/test/files/run/t6197.scala
+++ b/test/files/run/t6197.scala
@@ -1,0 +1,21 @@
+import scala.collection.immutable._
+
+object Test extends App {
+
+  // test that a HashTrieSet with one leaf element is not created!
+  val x = HashSet.empty + 1 + 2
+  if(x.getClass.getSimpleName != "HashTrieSet")
+    println("A hash set containing two non-colliding values should be a HashTrieSet")
+
+  val y = x - 1
+  if(y.getClass.getSimpleName != "HashSet1")
+    println("A hash set containing one element should always use HashSet1")
+
+  // it is pretty hard to test that the case where a HashTrieSet has one element which
+  // is itself of type HashTrieS t. That is because the improve hash function makes it very difficult
+  // to find keys that will have hashes that are close together.
+  //
+  // However, it is also not necessary. Removing the ability of a HashTrieSet to have
+  // one child of type HashTrieSet completely breaks the HashSet, so that many other
+  // tests fail
+}


### PR DESCRIPTION
If allow HashTrieSets with one element, you can get a degenerate tree that is six levels deep yet contains only one element by first building a large tree and then removing elements
