### PR TITLE
Warn when Any or AnyVal is inferred.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/icode/ICodeCheckers.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/ICodeCheckers.scala
@@ -381,10 +381,9 @@ abstract class ICodeCheckers {
       for (instr <- b) {
         this.instruction = instr
 
-        def checkLocal(local: Local): Unit = {
-          method lookupLocal local.sym.name getOrElse {
-            icodeError(" " + local + " is not defined in method " + method)
-          }
+        def checkLocal(local: Local) {
+          if ((method lookupLocal local.sym.name).isEmpty)
+            icodeError(s" $local is not defined in method $method")
         }
         def checkField(obj: TypeKind, field: Symbol): Unit = obj match {
           case REFERENCE(sym) =>

--- a/src/compiler/scala/tools/nsc/interpreter/ISettings.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/ISettings.scala
@@ -44,7 +44,7 @@ class ISettings(intp: IMain) {
   }
   def deprecation: Boolean = intp.settings.deprecation.value
 
-  def allSettings = Map(
+  def allSettings = Map[String, Any](
     "maxPrintString" -> maxPrintString,
     "maxAutoprintCompletion" -> maxAutoprintCompletion,
     "unwrapStrings" -> unwrapStrings,

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -29,7 +29,8 @@ trait Warnings {
     warnInaccessible,
     warnNullaryOverride,
     warnNullaryUnit,
-    warnAdaptedArgs
+    warnAdaptedArgs,
+    warnInferAny
   )
 
   // Warning groups.
@@ -52,6 +53,7 @@ trait Warnings {
   val warnInaccessible     = BooleanSetting   ("-Ywarn-inaccessible", "Warn about inaccessible types in method signatures.")
   val warnNullaryOverride  = BooleanSetting   ("-Ywarn-nullary-override",
     "Warn when non-nullary overrides nullary, e.g. `def foo()` over `def foo`.")
+  val warnInferAny         = BooleanSetting   ("-Ywarn-infer-any", "Warn when a type argument is inferred to be `Any`.")
 
   // Backward compatibility.
   def Xwarnfatal    = fatalWarnings

--- a/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
@@ -278,7 +278,7 @@ abstract class TreeCheckers extends Analyzer {
               def cond(s: Symbol) = !s.isTerm || s.isMethod || s == sym.owner
 
               if (sym.owner != currentOwner) {
-                val expected = currentOwner.ownerChain find (x => cond(x)) getOrElse fail("DefTree can't find owner: ")
+                val expected = currentOwner.ownerChain find (x => cond(x)) getOrElse { fail("DefTree can't find owner: ") ; NoSymbol }
                 if (sym.owner != expected)
                   fail("""|
                           | currentOwner chain: %s

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3111,9 +3111,8 @@ trait Typers extends Modes with Adaptations with Tags {
                 // define the undetparams which have been fixed by this param list, replace the corresponding symbols in "fun"
                 // returns those undetparams which have not been instantiated.
                 val undetparams = inferMethodInstance(fun, tparams, args1, pt)
-                val result = doTypedApply(tree, fun, args1, mode, pt)
-                context.undetparams = undetparams
-                result
+                try doTypedApply(tree, fun, args1, mode, pt)
+                finally context.undetparams = undetparams
               }
             }
           }
@@ -4555,7 +4554,7 @@ trait Typers extends Modes with Adaptations with Tags {
           assert(errorContainer == null, "Cannot set ambiguous error twice for identifier")
           errorContainer = tree
         }
-        
+
         val fingerPrint: Long = name.fingerPrint
 
         var defSym: Symbol = tree.symbol  // the directly found symbol

--- a/src/continuations/library/scala/util/continuations/package.scala
+++ b/src/continuations/library/scala/util/continuations/package.scala
@@ -167,7 +167,7 @@ package object continuations {
   }
 
   def shiftUnitR[A,B](x: A): ControlContext[A,B,B] = {
-    new ControlContext(null, x)
+    new ControlContext[A, B, B](null, x)
   }
 
   /**

--- a/src/library/scala/collection/SeqLike.scala
+++ b/src/library/scala/collection/SeqLike.scala
@@ -383,7 +383,7 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
    *  @return     `true` if this $coll has an element that is equal (as
    *              determined by `==`) to `elem`, `false` otherwise.
    */
-  def contains(elem: Any): Boolean = exists (_ == elem)
+  def contains[A1 >: A](elem: A1): Boolean = exists (_ == elem)
 
   /** Produces a new sequence which contains all elements of this $coll and also all elements of
    *  a given sequence. `xs union ys`  is equivalent to `xs ++ ys`.

--- a/src/library/scala/collection/SeqProxyLike.scala
+++ b/src/library/scala/collection/SeqProxyLike.scala
@@ -50,7 +50,7 @@ trait SeqProxyLike[+A, +Repr <: SeqLike[A, Repr] with Seq[A]] extends SeqLike[A,
   override def lastIndexOfSlice[B >: A](that: GenSeq[B]): Int = self.lastIndexOfSlice(that)
   override def lastIndexOfSlice[B >: A](that: GenSeq[B], end: Int): Int = self.lastIndexOfSlice(that, end)
   override def containsSlice[B](that: GenSeq[B]): Boolean = self.indexOfSlice(that) != -1
-  override def contains(elem: Any): Boolean = self.contains(elem)
+  override def contains[A1 >: A](elem: A1): Boolean = self.contains(elem)
   override def union[B >: A, That](that: GenSeq[B])(implicit bf: CanBuildFrom[Repr, B, That]): That = self.union(that)(bf)
   override def diff[B >: A](that: GenSeq[B]): Repr = self.diff(that)
   override def intersect[B >: A](that: GenSeq[B]): Repr = self.intersect(that)

--- a/src/library/scala/collection/generic/SeqForwarder.scala
+++ b/src/library/scala/collection/generic/SeqForwarder.scala
@@ -50,7 +50,7 @@ trait SeqForwarder[+A] extends Seq[A] with IterableForwarder[A] {
   override def lastIndexOfSlice[B >: A](that: GenSeq[B]): Int = underlying lastIndexOfSlice that
   override def lastIndexOfSlice[B >: A](that: GenSeq[B], end: Int): Int = underlying.lastIndexOfSlice(that, end)
   override def containsSlice[B](that: GenSeq[B]): Boolean = underlying containsSlice that
-  override def contains(elem: Any): Boolean = underlying contains elem
+  override def contains[A1 >: A](elem: A1): Boolean = underlying contains elem
   override def corresponds[B](that: GenSeq[B])(p: (A,B) => Boolean): Boolean = underlying.corresponds(that)(p)
   override def indices: Range = underlying.indices
 }

--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -182,7 +182,7 @@ extends AbstractSeq[T] with IndexedSeq[T] with Serializable {
   def containsTyped(x: T): Boolean =
     isWithinBoundaries(x) && (((x - start) % step) == zero)
 
-  override def contains(x: Any): Boolean =
+  override def contains[A1 >: T](x: A1): Boolean =
     try containsTyped(x.asInstanceOf[T])
     catch { case _: ClassCastException => false }
 

--- a/src/library/scala/collection/parallel/ParIterableLike.scala
+++ b/src/library/scala/collection/parallel/ParIterableLike.scala
@@ -171,9 +171,9 @@ self: ParIterableLike[T, Repr, Sequential] =>
 
   /** The task support object which is responsible for scheduling and
    *  load-balancing tasks to processors.
-   *                                                                              
+   *
    *  @see [[scala.collection.parallel.TaskSupport]]
-   */     
+   */
   def tasksupport = {
     val ts = _tasksupport
     if (ts eq null) {
@@ -188,18 +188,18 @@ self: ParIterableLike[T, Repr, Sequential] =>
    *  A task support object can be changed in a parallel collection after it
    *  has been created, but only during a quiescent period, i.e. while there
    *  are no concurrent invocations to parallel collection methods.
-   *                                                                              
-   *  Here is a way to change the task support of a parallel collection:          
-   *                                                                              
-   *  {{{                                                                         
-   *  import scala.collection.parallel._                                          
-   *  val pc = mutable.ParArray(1, 2, 3)                                          
-   *  pc.tasksupport = new ForkJoinTaskSupport(                                   
-   *    new scala.concurrent.forkjoin.ForkJoinPool(2))                            
-   *  }}}                                                                         
+   *
+   *  Here is a way to change the task support of a parallel collection:
+   *
+   *  {{{
+   *  import scala.collection.parallel._
+   *  val pc = mutable.ParArray(1, 2, 3)
+   *  pc.tasksupport = new ForkJoinTaskSupport(
+   *    new scala.concurrent.forkjoin.ForkJoinPool(2))
+   *  }}}
    *
    *  @see [[scala.collection.parallel.TaskSupport]]
-   */     
+   */
   def tasksupport_=(ts: TaskSupport) = _tasksupport = ts
 
   def seq: Sequential
@@ -877,13 +877,13 @@ self: ParIterableLike[T, Repr, Sequential] =>
   override def toSet[U >: T]: immutable.ParSet[U] = toParCollection[U, immutable.ParSet[U]](() => immutable.ParSet.newCombiner[U])
 
   override def toMap[K, V](implicit ev: T <:< (K, V)): immutable.ParMap[K, V] = toParMap[K, V, immutable.ParMap[K, V]](() => immutable.ParMap.newCombiner[K, V])
-  
+
   override def toVector: Vector[T] = to[Vector]
 
   override def to[Col[_]](implicit cbf: CanBuildFrom[Nothing, T, Col[T @uncheckedVariance]]): Col[T @uncheckedVariance] = if (cbf().isCombiner) {
     toParCollection[T, Col[T]](() => cbf().asCombiner)
   } else seq.to(cbf)
-  
+
   /* tasks */
 
   protected trait StrictSplitterCheckTask[R, Tp] extends Task[R, Tp] {
@@ -935,8 +935,8 @@ self: ParIterableLike[T, Repr, Sequential] =>
   (f: First, s: Second)
   extends Composite[FR, SR, R, First, Second](f, s) {
     def leaf(prevr: Option[R]) = {
-      tasksupport.executeAndWaitResult(ft)
-      tasksupport.executeAndWaitResult(st)
+      tasksupport.executeAndWaitResult(ft) : Any
+      tasksupport.executeAndWaitResult(st) : Any
       mergeSubtasks
     }
   }
@@ -946,8 +946,8 @@ self: ParIterableLike[T, Repr, Sequential] =>
   (f: First, s: Second)
   extends Composite[FR, SR, R, First, Second](f, s) {
     def leaf(prevr: Option[R]) = {
-      val ftfuture = tasksupport.execute(ft)
-      tasksupport.executeAndWaitResult(st)
+      val ftfuture: () => Any = tasksupport.execute(ft)
+      tasksupport.executeAndWaitResult(st) : Any
       ftfuture()
       mergeSubtasks
     }
@@ -1504,31 +1504,3 @@ self: ParIterableLike[T, Repr, Sequential] =>
   })
 
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/library/scala/util/parsing/combinator/lexical/StdLexical.scala
+++ b/src/library/scala/util/parsing/combinator/lexical/StdLexical.scala
@@ -50,7 +50,7 @@ class StdLexical extends Lexical with StdTokens {
   def identChar = letter | elem('_')
 
   // see `whitespace in `Scanners`
-  def whitespace: Parser[Any] = rep(
+  def whitespace: Parser[Any] = rep[Any](
       whitespaceChar
     | '/' ~ '*' ~ comment
     | '/' ~ '/' ~ rep( chrExcept(EofCh, '\n') )

--- a/src/scalap/scala/tools/scalap/scalax/rules/Rule.scala
+++ b/src/scalap/scala/tools/scalap/scalax/rules/Rule.scala
@@ -50,7 +50,7 @@ trait Rule[-In, +Out, +A, +X] extends (In => Result[Out, A, X]) {
     lazy val choices = Rule.this :: other :: Nil
   }
 
-  def orError[In2 <: In] = this orElse(error[In2])
+  def orError[In2 <: In] = this orElse error[Any]
 
   def |[In2 <: In, Out2 >: Out, A2 >: A, X2 >: X](other : => Rule[In2, Out2, A2, X2]) = orElse(other)
 

--- a/src/scalap/scala/tools/scalap/scalax/rules/scalasig/ScalaSig.scala
+++ b/src/scalap/scala/tools/scalap/scalax/rules/scalasig/ScalaSig.scala
@@ -167,7 +167,7 @@ object ScalaSigEntryParsers extends RulesWithState with MemoisableRules {
 
   val symbolInfo = nameRef ~ symbolRef ~ nat ~ (symbolRef?) ~ ref ~ get ^~~~~~^ SymbolInfo
 
-  def symHeader(key: Int) = (key -~ none | (key + 64) -~ nat)
+  def symHeader(key: Int): EntryParser[Any] = (key -~ none | (key + 64) -~ nat)
 
   def symbolEntry(key : Int) = symHeader(key) -~ symbolInfo
 
@@ -263,7 +263,7 @@ object ScalaSigEntryParsers extends RulesWithState with MemoisableRules {
       47 -~ typeLevel ~ typeIndex ^~^ DeBruijnIndexType,
       48 -~ typeRef ~ (symbolRef*) ^~^ ExistentialType) as "type"
 
-  lazy val literal = oneOf(
+  lazy val literal: EntryParser[Any] = oneOf(
       24 -^ (()),
       25 -~ longValue ^^ (_ != 0L),
       26 -~ longValue ^^ (_.toByte),

--- a/src/swing/scala/swing/ComboBox.scala
+++ b/src/swing/scala/swing/ComboBox.scala
@@ -182,7 +182,7 @@ class ComboBox[A](items: Seq[A]) extends Component with Publisher {
    * of the component to its own defaults _after_ the renderer has been
    * configured. That's Swing's principle of most suprise.
    */
-  def renderer: ListView.Renderer[A] = ListView.Renderer.wrap(peer.getRenderer)
+  def renderer: ListView.Renderer[A] = ListView.Renderer.wrap[A](peer.getRenderer)
   def renderer_=(r: ListView.Renderer[A]) { peer.setRenderer(r.peer) }
 
   /* XXX: currently not safe to expose:

--- a/src/swing/scala/swing/ListView.scala
+++ b/src/swing/scala/swing/ListView.scala
@@ -216,7 +216,7 @@ class ListView[A] extends Component {
     def adjusting = peer.getSelectionModel.getValueIsAdjusting
   }
 
-  def renderer: ListView.Renderer[A] = ListView.Renderer.wrap(peer.getCellRenderer)
+  def renderer: ListView.Renderer[A] = ListView.Renderer.wrap[A](peer.getCellRenderer)
   def renderer_=(r: ListView.Renderer[A]) { peer.setCellRenderer(r.peer) }
 
   def fixedCellWidth = peer.getFixedCellWidth

--- a/test/files/neg/warn-inferred-any.check
+++ b/test/files/neg/warn-inferred-any.check
@@ -1,0 +1,10 @@
+warn-inferred-any.scala:8: error: a type was inferred to be `Any`; this may indicate a programming error.
+  { List(1, 2, 3) contains "a" }  // only this warns
+                  ^
+warn-inferred-any.scala:16: error: a type was inferred to be `AnyVal`; this may indicate a programming error.
+  { 1l to 5l contains 5 }
+             ^
+warn-inferred-any.scala:17: error: a type was inferred to be `AnyVal`; this may indicate a programming error.
+  { 1l to 5l contains 5d }
+             ^
+three errors found

--- a/test/files/neg/warn-inferred-any.flags
+++ b/test/files/neg/warn-inferred-any.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -Ywarn-infer-any

--- a/test/files/neg/warn-inferred-any.scala
+++ b/test/files/neg/warn-inferred-any.scala
@@ -1,0 +1,19 @@
+trait Foo[-A <: AnyRef, +B <: AnyRef] {
+  def run[U](x: A)(action: B => U): Boolean = ???
+
+  { run(_: A)(_: B => String) }
+}
+
+trait Xs[+A] {
+  { List(1, 2, 3) contains "a" }  // only this warns
+  { List(1, 2, 3) contains 1 }
+  { identity(List(1, 2, 3) contains 1) }
+  { List("a") foreach println }
+}
+
+trait Ys[+A] {
+  { 1 to 5 contains 5l }
+  { 1l to 5l contains 5 }
+  { 1l to 5l contains 5d }
+  { 1l to 5l contains 5l }
+}


### PR DESCRIPTION
For the very small price of annotating types as Any/AnyVal in those
cases where we wish to use them, we can obtain useful warnings.
I made trunk clean against this warning and found several bugs
or at least suboptimalities in the process.

I put the warning behind -Xlint for the moment, but I think this
belongs on by default, even for this alone:

  scala> List(1, 2, 3) contains "a"
  <console>:8: warning: a type was inferred to be `Any`; this may indicate a programming error.
                List(1, 2, 3) contains "a"
                                       ^
  res0: Boolean = false

Or this punishment meted out by SI-4042:

  scala> 1l to 5l contains 5
  <console>:8: warning: a type was inferred to be `AnyVal`; this may indicate a programming error.
                1l to 5l contains 5
                                  ^
  res0: Boolean = false

A different situation where this arises, which I have seen variations
of many times:

  scala> class A[T](default: T) {
    def get(x: => Option[T]) = x getOrElse Some(default)
  }
  <console>:7: warning: a type was inferred to be `Any`; this may indicate a programming error.
         class A[T](default: T) { def get(x: => Option[T]) = x getOrElse Some(default) }
                                                                             ^
  // Oops, this was what I meant
  scala> class A[T](default: T) {
    def get(x: => Option[T]) = x getOrElse default
  }
  defined class A

Harder to avoid spurious warnings when "Object" is inferred.
