### PR TITLE
refines api.FlagSets

### DIFF
--- a/src/library/scala/reflect/base/Base.scala
+++ b/src/library/scala/reflect/base/Base.scala
@@ -233,9 +233,7 @@ class Base extends Universe { self =>
 
   class Modifiers(override val flags: FlagSet,
                   override val privateWithin: Name,
-                  override val annotations: List[Tree]) extends ModifiersBase {
-    def hasFlag(flags: FlagSet) = (this.flags & flags) != 0
-  }
+                  override val annotations: List[Tree]) extends ModifiersBase
 
   implicit val ModifiersTag = ClassTag[Modifiers](classOf[Modifiers])
 

--- a/src/library/scala/reflect/base/FlagSets.scala
+++ b/src/library/scala/reflect/base/FlagSets.scala
@@ -17,7 +17,6 @@ trait FlagSets { self: Universe =>
   /** The base API all flag bearers support */
   trait HasFlagsBase {
     def flags: FlagSet
-    def hasFlag(flags: FlagSet): Boolean
   }
 }
 

--- a/src/reflect/scala/reflect/api/FlagSets.scala
+++ b/src/reflect/scala/reflect/api/FlagSets.scala
@@ -9,7 +9,6 @@ trait FlagSets { self: Universe =>
 
   trait FlagOps extends Any {
     def | (right: FlagSet): FlagSet
-    def hasFlag(flags: FlagSet): Boolean
   }
 
   implicit def addFlagOps(left: FlagSet): FlagOps
@@ -18,84 +17,86 @@ trait FlagSets { self: Universe =>
 
   type FlagValues >: Null <: FlagValuesApi
 
+  // Q: I have a pretty flag. Can I put it here?
+  // A: Only if there's a tree that cannot be built without it.
+  //    If you want to put a flag here so that it can be tested against,
+  //    introduce an `isXXX` method in one of the `api.Symbols` classes instead.
+
   trait FlagValuesApi {
 
-    /** Flag indicating that symbol or tree represents a trait */
+    /** Flag indicating that tree represents a trait */
     val TRAIT: FlagSet
 
-    /** Flag indicating that symbol or tree represents a module or its internal module class */
-    val MODULE: FlagSet
+    /** Flag indicating that a tree is an interface (i.e. a trait which defines only abstract methods) */
+    val INTERFACE: FlagSet
 
-    /** Flag indicating that symbol or tree represents a mutable variable */
+    /** Flag indicating that tree represents a mutable variable */
     val MUTABLE: FlagSet
 
-    /** Flag indicating that symbol or tree represents a package or its internal package class */
-    val PACKAGE: FlagSet
-
-    /** Flag indicating that symbol or tree represents a method */
-    val METHOD: FlagSet
-
-    /** Flag indicating that symbol or tree represents a macro definition. */
+    /** Flag indicating that tree represents a macro definition. */
     val MACRO: FlagSet
 
-    /** Flag indicating that symbol or tree represents an abstract type, method, or value */
+    /** Flag indicating that tree represents an abstract type, method, or value */
     val DEFERRED: FlagSet
 
-    /** Flag indicating that symbol or tree represents an abstract class */
+    /** Flag indicating that tree represents an abstract class */
     val ABSTRACT: FlagSet
 
-    /** Flag indicating that symbol or tree has `final` modifier set */
+    /** Flag indicating that tree has `final` modifier set */
     val FINAL: FlagSet
 
-    /** Flag indicating that symbol or tree has `sealed` modifier set */
+    /** Flag indicating that tree has `sealed` modifier set */
     val SEALED: FlagSet
 
-    /** Flag indicating that symbol or tree has `implicit` modifier set */
+    /** Flag indicating that tree has `implicit` modifier set */
     val IMPLICIT: FlagSet
 
-    /** Flag indicating that symbol or tree has `lazy` modifier set */
+    /** Flag indicating that tree has `lazy` modifier set */
     val LAZY: FlagSet
 
-    /** Flag indicating that symbol or tree has `override` modifier set */
+    /** Flag indicating that tree has `override` modifier set */
     val OVERRIDE: FlagSet
 
-    /** Flag indicating that symbol or tree has `private` modifier set */
+    /** Flag indicating that tree has `private` modifier set */
     val PRIVATE: FlagSet
 
-    /** Flag indicating that symbol or tree has `protected` modifier set */
+    /** Flag indicating that tree has `protected` modifier set */
     val PROTECTED: FlagSet
 
-    /** Flag indicating that symbol or tree has `case` modifier set */
+    /** Flag indicating that tree represents a member local to current class
+     *  (i.e. private[this] or protected[this].
+     *  This requires having either PRIVATE or PROTECTED set as well.
+     */
+    val LOCAL: FlagSet
+
+    /** Flag indicating that tree has `case` modifier set */
     val CASE: FlagSet
 
-    /** Flag indicating that symbol or tree has `abstract` and `override` modifiers set */
+    /** Flag indicating that tree has `abstract` and `override` modifiers set */
     val ABSOVERRIDE: FlagSet
 
-    /** Flag indicating that symbol or tree represents a by-name parameter */
+    /** Flag indicating that tree represents a by-name parameter */
     val BYNAMEPARAM: FlagSet
 
-    /** Flag indicating that symbol or tree represents a class or parameter.
+    /** Flag indicating that tree represents a class or parameter.
      *  Both type and value parameters carry the flag. */
     val PARAM: FlagSet
 
-    /** Flag indicating that symbol or tree represents a field of a class
-     *  that was generated from a parameter of that class */
-    val PARAMACCESSOR: FlagSet
-
-    /** Flag indicating that symbol or tree represents a field of a case class
-     *  that corresponds to a parameter in the first parameter list of the
-     *  primary constructor of that class */
-    val CASEACCESSOR: FlagSet
-
-    /** Flag indicating that symbol or tree represents a contravariant
+    /** Flag indicating that tree represents a covariant
      *  type parameter (marked with `+`). */
     val COVARIANT: FlagSet
 
-    /** Flag indicating that symbol or tree represents a contravariant
+    /** Flag indicating that tree represents a contravariant
      *  type parameter (marked with `-`). */
     val CONTRAVARIANT: FlagSet
 
-    /** Flag indicating that parameter has a default value */
+    /** Flag indicating that tree represents a parameter that has a default value */
     val DEFAULTPARAM: FlagSet
+
+    /** Flag indicating that tree represents an early definition */
+    val PRESUPER: FlagSet
+
+    /** Flag indicating that tree represents a variable or a member initialized to the default value */
+    val DEFAULTINIT: FlagSet
   }
 }

--- a/src/reflect/scala/reflect/api/Symbols.scala
+++ b/src/reflect/scala/reflect/api/Symbols.scala
@@ -110,10 +110,10 @@ trait Symbols extends base.Symbols { self: Universe =>
      *
      *  The java access levels translate as follows:
      *
-     *  java private:     hasFlag(PRIVATE)                && (privateWithin == NoSymbol)
-     *  java package:     !hasFlag(PRIVATE | PROTECTED)   && (privateWithin == enclosingPackage)
-     *  java protected:   hasFlag(PROTECTED)              && (privateWithin == enclosingPackage)
-     *  java public:      !hasFlag(PRIVATE | PROTECTED)   && (privateWithin == NoSymbol)
+     *  java private:     isPrivate                  && (privateWithin == NoSymbol)
+     *  java package:     !isPrivate && !isProtected && (privateWithin == enclosingPackage)
+     *  java protected:   isProtected                && (privateWithin == enclosingPackage)
+     *  java public:      !isPrivate && !isProtected && (privateWithin == NoSymbol)
      */
     def privateWithin: Symbol
 

--- a/src/reflect/scala/reflect/internal/FlagSets.scala
+++ b/src/reflect/scala/reflect/internal/FlagSets.scala
@@ -13,7 +13,6 @@ trait FlagSets extends api.FlagSets { self: SymbolTable =>
 
   private class FlagOpsImpl(left: Long) extends FlagOps {
     def | (right: Long): Long = left | right
-    def hasFlag(right: Long): Boolean = (left & right) != 0
   }
 
   val NoFlags: FlagSet = 0L
@@ -22,10 +21,8 @@ trait FlagSets extends api.FlagSets { self: SymbolTable =>
 
   object Flag extends FlagValues {
     val TRAIT         : FlagSet = Flags.TRAIT
-    val MODULE        : FlagSet = Flags.MODULE
+    val INTERFACE     : FlagSet = Flags.INTERFACE
     val MUTABLE       : FlagSet = Flags.MUTABLE
-    val PACKAGE       : FlagSet = Flags.PACKAGE
-    val METHOD        : FlagSet = Flags.METHOD
     val MACRO         : FlagSet = Flags.MACRO
     val DEFERRED      : FlagSet = Flags.DEFERRED
     val ABSTRACT      : FlagSet = Flags.ABSTRACT
@@ -36,15 +33,15 @@ trait FlagSets extends api.FlagSets { self: SymbolTable =>
     val OVERRIDE      : FlagSet = Flags.OVERRIDE
     val PRIVATE       : FlagSet = Flags.PRIVATE
     val PROTECTED     : FlagSet = Flags.PROTECTED
+    val LOCAL         : FlagSet = Flags.LOCAL
     val CASE          : FlagSet = Flags.CASE
     val ABSOVERRIDE   : FlagSet = Flags.ABSOVERRIDE
     val BYNAMEPARAM   : FlagSet = Flags.BYNAMEPARAM
     val PARAM         : FlagSet = Flags.PARAM
-    val PARAMACCESSOR : FlagSet = Flags.PARAMACCESSOR
-    val CASEACCESSOR  : FlagSet = Flags.CASEACCESSOR
     val COVARIANT     : FlagSet = Flags.COVARIANT
     val CONTRAVARIANT : FlagSet = Flags.CONTRAVARIANT
     val DEFAULTPARAM  : FlagSet = Flags.DEFAULTPARAM
-    val INTERFACE     : FlagSet = Flags.INTERFACE
+    val PRESUPER      : FlagSet = Flags.PRESUPER
+    val DEFAULTINIT   : FlagSet = Flags.DEFAULTINIT
   }
 }

--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -670,7 +670,8 @@ trait Printers extends api.Printers { self: SymbolTable =>
     if (flags == NoFlags) nme.NoFlags.toString
     else {
       val s_flags = new collection.mutable.ListBuffer[String]
-      for (i <- 0 to 63 if (flags hasFlag (1L << i)))
+      def hasFlag(left: Long, right: Long): Boolean = (left & right) != 0
+      for (i <- 0 to 63 if hasFlag(flags, 1L << i))
         s_flags += flagToString(1L << i).replace("<", "").replace(">", "").toUpperCase
       s_flags mkString " | "
     }


### PR DESCRIPTION
In the current vision of flags, they should only be used to construct trees,
because tests are subsumed by the numerous isXXX methods that we have.

Hence we need to remove `hasFlag` and the flags that don't make sense being
added to tree modifiers manually.

A good example of that is MODULE. There's an isModule check, so hasFlag MODULE
is redundant. On the other hand, you don't need MODULE to construct a ModuleDef
so it's redundant in this department as well.
