### PR TITLE
patmat tweaks: compiler performance, better error on unsupported pattern

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/Printers.scala
+++ b/src/compiler/scala/tools/nsc/ast/Printers.scala
@@ -278,6 +278,7 @@ trait Printers extends reflect.internal.Printers { this: Global =>
 
   def asString(t: Tree): String = render(t, newStandardTreePrinter, settings.printtypes.value, settings.uniqid.value, settings.Yshowsymkinds.value)
   def asCompactString(t: Tree): String = render(t, newCompactTreePrinter, settings.printtypes.value, settings.uniqid.value, settings.Yshowsymkinds.value)
+  def asCompactDebugString(t: Tree): String = render(t, newCompactTreePrinter, true, true, true)
 
   def newStandardTreePrinter(writer: PrintWriter): TreePrinter = new TreePrinter(writer)
   def newStandardTreePrinter(stream: OutputStream): TreePrinter = newStandardTreePrinter(new PrintWriter(stream))

--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -497,7 +497,10 @@ abstract class ExplicitOuter extends InfoTransform
           else atPos(tree.pos)(outerPath(outerValue, currentClass.outerClass, sym)) // (5)
 
         case Select(qual, name) =>
-          if (currentClass != sym.owner)
+          // make not private symbol acessed from inner classes, as well as
+          // symbols accessed from @inline methods
+          if (currentClass != sym.owner ||
+              (sym.owner.enclMethod hasAnnotation ScalaInlineClass))
             sym.makeNotPrivate(sym.owner)
 
           val qsym = qual.tpe.widen.typeSymbol

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -652,11 +652,10 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
 
               info(specMember)    = Implementation(original)
               typeEnv(specMember) = env ++ typeEnv(m)
-            }
-            else debuglog({
+            } else {
               val om = forwardToOverload(m)
-              "normalizedMember " + m + " om: " + om + " " + pp(typeEnv(om))
-            })
+              debuglog("normalizedMember " + m + " om: " + om + " " + pp(typeEnv(om)))
+            }
           }
           else
             debuglog("conflicting env for " + m + " env: " + env)

--- a/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
@@ -521,7 +521,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
         // case Star(_) | ArrayValue  => error("stone age pattern relics encountered!")
 
         case _                       =>
-          error("unsupported pattern: "+ patTree +"(a "+ patTree.getClass +")")
+          typer.context.unit.error(patTree.pos, s"unsupported pattern: $patTree (a ${patTree.getClass}).\n This is a scalac bug. Tree diagnostics: ${asCompactDebugString(patTree)}.")
           noFurtherSubPats()
       }
 

--- a/test/files/pos/t6022b.scala
+++ b/test/files/pos/t6022b.scala
@@ -1,0 +1,20 @@
+trait A
+trait B
+trait C
+trait AB extends B with A
+
+// two types are mutually exclusive if there is no equality symbol whose constant implies both
+object Test extends App {
+  def foo(x: Any) = x match {
+    case _ : C  => println("C")
+    case _ : AB => println("AB")
+    case _ : (A with B) => println("AB'")
+    case _ : B  => println("B")
+    case _ : A  => println("A")
+  }
+
+  foo(new A {})
+  foo(new B {})
+  foo(new AB{})
+  foo(new C {})
+}

--- a/test/files/run/t6223.check
+++ b/test/files/run/t6223.check
@@ -1,0 +1,4 @@
+bar
+bar$mcI$sp
+bar$mIc$sp
+bar$mIcI$sp

--- a/test/files/run/t6223.scala
+++ b/test/files/run/t6223.scala
@@ -1,0 +1,11 @@
+class Foo[@specialized(Int) A](a:A) {
+  def bar[@specialized(Int) B](f:A => B) = new Foo(f(a))
+}
+
+object Test {
+  def main(args:Array[String]) {
+    val f = new Foo(333)
+    val ms = f.getClass().getDeclaredMethods()
+    ms.foreach(m => println(m.getName))
+  }
+}


### PR DESCRIPTION
- move a catch of a StackOverflowError up the call stack since @gkossakowski diagnosed it to be killing compiler performance
- Roland reported hitting the unsupported pattern branch in translatePattern in akka code, so providing some diagnostics and a nicer error message to figure out what's going on

review by @gkossakowski (/cc @paulp)
