### PR TITLE
Inliner may make public only an outer field of anon-closure-class

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/opt/Inliners.scala
+++ b/src/compiler/scala/tools/nsc/backend/opt/Inliners.scala
@@ -645,29 +645,15 @@ abstract class Inliners extends SubComponent {
           else if (sym.isProtected) Protected
           else Public
 
+        /* The only private fields turned public are outer fields of anon-closure-classes.
+         * Pretty much all non-trivial anon-closures-classes couldn't be eliminated otherwise
+         * (once inlined, the code still has to reach out to environ values via the outer field).
+         * This shouldn't pose a problem with separate compilation, because anon-closure-classes arent' Scala-visible to other jars.
+         */
         def canMakePublic(f: Symbol): Boolean =
-          (m.sourceFile ne NoSourceFile) &&
-          (f.isSynthetic || f.isParamAccessor) &&
+          (m.sourceFile ne NoSourceFile) && (m.sourceFile ne null) && // "compiled in this compiler run" ie not grabbed from external library
+          (f.isOuterField && isClosureClass(f.owner)) && // actually the above condition is implied by the one on this line. But one never knows.
           { toBecomePublic = f :: toBecomePublic; true }
-
-        /* A safety check to consider as private, for the purposes of inlining, a public field that:
-         *   (1) is defined in an external library, and
-         *   (2) can be presumed synthetic (due to a dollar sign in its name).
-         * Such field was made public by `doMakePublic()` and we don't want to rely on that,
-         * because under other compilation conditions (ie no -optimize) that won't be the case anymore.
-         *
-         * This allows aggressive intra-library inlining (making public if needed)
-         * that does not break inter-library scenarios (see comment for `Inliners`).
-         *
-         * TODO handle more robustly the case of a trait var changed at the source-level from public to private[this]
-         *      (eg by having ICodeReader use unpickler, see SI-5442).
-         
-         DISABLED
-         
-        def potentiallyPublicized(f: Symbol): Boolean = {
-          (m.sourceFile eq NoSourceFile) && f.name.containsChar('$')
-        }
-        */
 
         def checkField(f: Symbol)   = check(f, f.isPrivate && !canMakePublic(f))
         def checkSuper(n: Symbol)   = check(n, n.isPrivate || !n.isClassConstructor)


### PR DESCRIPTION
As discussed in https://groups.google.com/d/topic/scala-internals/iPkMCygzws4/discussion

Stats informing us about anon-closures-classes not being eliminated because of this commit are welcome!

review by @gkossakowski 
