### PR TITLE
SI-6201 minor fixes in key points

### DIFF
--- a/src/reflect/scala/reflect/internal/Mirrors.scala
+++ b/src/reflect/scala/reflect/internal/Mirrors.scala
@@ -247,7 +247,7 @@ trait Mirrors extends api.Mirrors {
     // is very beneficial for a handful of bootstrap symbols to have
     // first class identities
     sealed trait WellKnownSymbol extends Symbol {
-      this initFlags TopLevelCreationFlags
+      this initFlags (TopLevelCreationFlags | STATIC)
     }
     // Features common to RootClass and RootPackage, the roots of all
     // type and term symbols respectively.
@@ -276,7 +276,6 @@ trait Mirrors extends api.Mirrors {
 
       override def isRoot            = true
       override def isEffectiveRoot   = true
-      override def isStatic          = true
       override def isNestedClass     = false
     }
     // The empty package, which holds all top level types without given packages.

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -160,7 +160,7 @@ trait Trees extends api.Trees { self: SymbolTable =>
       new ThisSubstituter(clazz, to) transform this
 
     def hasSymbolWhich(f: Symbol => Boolean) =
-      hasSymbol && symbol != null && f(symbol)
+      (symbol ne null) && (symbol ne NoSymbol) && f(symbol)
 
     def isErroneous = (tpe ne null) && tpe.isErroneous
     def isTyped     = (tpe ne null) && !tpe.isErroneous

--- a/test/files/pos/t6201.scala
+++ b/test/files/pos/t6201.scala
@@ -1,0 +1,13 @@
+class Test {
+  class Foo1 {
+    def must(x: scala.xml.Elem) = ()
+  }
+
+  class Foo2 {
+    def must(x: Int) = ()
+  }
+  implicit def toFoo1(s: scala.xml.Elem) = new Foo1()
+  implicit def toFoo2(s: scala.xml.Elem) = new Foo2()
+
+  def is: Unit = { (<a>{"a"}</a>).must(<a>{"b"}</a>) }
+}


### PR DESCRIPTION
Fixes several oversights that led to 6201. RootPackage should have been static,
refactored implementation of hasSymbolWhich shouldn't have checked hasSymbol.

Full discussion is here:
http://groups.google.com/group/scala-internals/browse_thread/thread/9500348f273a8aa.
