### PR TITLE
Added make not private logic for @inline accesses back to ExplicitOuter.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -497,7 +497,10 @@ abstract class ExplicitOuter extends InfoTransform
           else atPos(tree.pos)(outerPath(outerValue, currentClass.outerClass, sym)) // (5)
 
         case Select(qual, name) =>
-          if (currentClass != sym.owner)
+          // make not private symbol acessed from inner classes, as well as
+          // symbols accessed from @inline methods
+          if (currentClass != sym.owner ||
+              (sym.owner.enclMethod hasAnnotation ScalaInlineClass))
             sym.makeNotPrivate(sym.owner)
 
           val qsym = qual.tpe.widen.typeSymbol


### PR DESCRIPTION
As discussed in https://mail.google.com/mail/u/0/?hl=en&tab=Tm#search/inlining+changes+needed/1390c955960d7cb5, we need to move access widenings back to ExplicitOuter, so that outer fields are correctly widened. The previous logiv in SuperAccessors can go once the inliner is adapted to the new scheme. I leave SuperAccessors for the moment as is, in order not to slide back even further with inlining. Review by @magarciaEPFL, @gkossakowski
