### PR TITLE
Fixes SI-6214.

### DIFF
--- a/test/files/neg/t6214.check
+++ b/test/files/neg/t6214.check
@@ -1,0 +1,4 @@
+t6214.scala:5: error: missing parameter type
+  	m { s => case class Foo() }
+            ^
+one error found

--- a/test/files/neg/t6214.scala
+++ b/test/files/neg/t6214.scala
@@ -1,0 +1,7 @@
+object Test {
+  def m(f: String => Unit) = 0
+  def m(f: Int => Unit) = 0
+  def foo {
+  	m { s => case class Foo() }
+  }
+}


### PR DESCRIPTION
addSynthetics was calling typedStat that caused flushing error buffer. Typically that would result in errors being re-added but addSynthetics was the last thing to run in typedStats.
Instead of adding yet another check I used this as an opportunity to cleanup the once necessary workaround for typing stats. Since we are now chaining buffers of contexts manual handling is no longer necessary.

Review by @odersky (I recall that you were planning to cleanup that part at some point).
