### PR TITLE
Move side-effecting call out of debuglog(). Fixes SI-6223.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -652,11 +652,10 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
 
               info(specMember)    = Implementation(original)
               typeEnv(specMember) = env ++ typeEnv(m)
-            }
-            else debuglog({
+            } else {
               val om = forwardToOverload(m)
-              "normalizedMember " + m + " om: " + om + " " + pp(typeEnv(om))
-            })
+              debuglog("normalizedMember " + m + " om: " + om + " " + pp(typeEnv(om)))
+            }
           }
           else
             debuglog("conflicting env for " + m + " env: " + env)

--- a/test/files/run/t6223.check
+++ b/test/files/run/t6223.check
@@ -1,0 +1,4 @@
+bar
+bar$mcI$sp
+bar$mIc$sp
+bar$mIcI$sp

--- a/test/files/run/t6223.scala
+++ b/test/files/run/t6223.scala
@@ -1,0 +1,11 @@
+class Foo[@specialized(Int) A](a:A) {
+  def bar[@specialized(Int) B](f:A => B) = new Foo(f(a))
+}
+
+object Test {
+  def main(args:Array[String]) {
+    val f = new Foo(333)
+    val ms = f.getClass().getDeclaredMethods()
+    ms.foreach(m => println(m.getName))
+  }
+}


### PR DESCRIPTION
This change fixes a situation in which method calls aren't being properly
specialized. All the existing tests pass; in addition, it likely fixes other
specialization bugs (and improves performance of specialized code).

Review by @VladUreche or @paulp.

P.S. As I said on list, this is a very small change and it would be great
to backport to 2.10! I can send another pull request if this seems like a good idea.
