### PR TITLE
.ensime template for compiler development

### DIFF
--- a/src/ensime/.ensime.SAMPLE
+++ b/src/ensime/.ensime.SAMPLE
@@ -1,0 +1,17 @@
+(
+  :disable-source-load-on-startup t
+  :disable-scala-jars-on-classpath t
+  :root-dir "c:/Projects/Kepler"
+  :sources (
+    "c:/Projects/Kepler/src/library"
+    "c:/Projects/Kepler/src/reflect"
+    "c:/Projects/Kepler/src/compiler"
+  )
+  :compile-deps (
+    "c:/Projects/Kepler/build/asm/classes"
+    "c:/Projects/Kepler/build/locker/classes/library"
+    "c:/Projects/Kepler/build/locker/classes/reflect"
+    "c:/Projects/Kepler/build/locker/classes/compiler"
+  )
+  :target "c:/Projects/Kepler/build/classes"
+)

--- a/src/ensime/README.md
+++ b/src/ensime/README.md
@@ -1,0 +1,11 @@
+Ensime project files
+=====================
+
+Rename .ensime.SAMPLE to .ensime and replace sample paths with real paths to your sources and build results.
+After that you're good to go with one of the ENSIME-enabled text editors.
+
+Editors that know how to talk to ENSIME servers:
+1) Emacs via https://github.com/aemoncannon/ensime
+2) jEdit via https://github.com/djspiewak/ensime-sidekick
+3) TextMate via https://github.com/mads379/ensime.tmbundle
+4) Sublime Text 2 via https://github.com/sublimescala/sublime-ensime


### PR DESCRIPTION
Provides a template of an .ensime file to be used for compiler hacking
together with an ENSIME-enabled text editor.

Also includes a readme that outlines what editors support ENSIME.
To the best of my knowledge these are Emacs, TextMate, jEdit and Sublime Text 2
