### PR TITLE
SI-6167 Override SeqLike#isEmpty for better performance

### DIFF
--- a/src/library/scala/collection/SeqLike.scala
+++ b/src/library/scala/collection/SeqLike.scala
@@ -92,6 +92,8 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
     i - len
   }
 
+  override /*IterableLike*/ def isEmpty: Boolean = lengthCompare(0) == 0
+
   /** The size of this $coll, equivalent to `length`.
    *
    *  $willNotTerminateInf


### PR DESCRIPTION
This results in a faster Vector#isEmpty (and head, tail, last, init)
because it avoids building a VectorIterator just to check if
iterator.hasNext is false.
Other classes which have not overridden the implementation of SeqLike
also benefit from it.
