### PR TITLE
Hunting down eliminable :: allocations.

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/TreeDSL.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeDSL.scala
@@ -95,7 +95,7 @@ trait TreeDSL {
       def INT_>=  (other: Tree)     = fn(target, getMember(IntClass, nme.GE), other)
       def INT_==  (other: Tree)     = fn(target, getMember(IntClass, nme.EQ), other)
       def INT_!=  (other: Tree)     = fn(target, getMember(IntClass, nme.NE), other)
-      
+
       // generic operations on ByteClass, IntClass, LongClass
       def GEN_|   (other: Tree, kind: ClassSymbol)  = fn(target, getMember(kind, nme.OR), other)
       def GEN_&   (other: Tree, kind: ClassSymbol)  = fn(target, getMember(kind, nme.AND), other)
@@ -234,7 +234,7 @@ trait TreeDSL {
     }
     class DefTreeStart(val name: Name) extends TreeVODDStart with DefCreator {
       def tparams: List[TypeDef] = Nil
-      def vparamss: List[List[ValDef]] = List(Nil)
+      def vparamss: List[List[ValDef]] = ListOfNil
     }
 
     class IfStart(cond: Tree, thenp: Tree) {

--- a/src/compiler/scala/tools/nsc/ast/TreeGen.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeGen.scala
@@ -44,7 +44,7 @@ abstract class TreeGen extends reflect.internal.TreeGen with TreeDSL {
           setInfo analyzer.ImportType(qual)
     )
     val importTree = (
-      Import(qual, List(ImportSelector(nme.WILDCARD, -1, null, -1)))
+      Import(qual, ImportSelector.wildList)
         setSymbol importSym
           setType NoType
     )
@@ -58,7 +58,7 @@ abstract class TreeGen extends reflect.internal.TreeGen with TreeDSL {
   def mkUnchecked(expr: Tree): Tree = atPos(expr.pos) {
     // This can't be "Annotated(New(UncheckedClass), expr)" because annotations
     // are very picky about things and it crashes the compiler with "unexpected new".
-    Annotated(New(scalaDot(UncheckedClass.name), List(Nil)), expr)
+    Annotated(New(scalaDot(UncheckedClass.name), ListOfNil), expr)
   }
   // if it's a Match, mark the selector unchecked; otherwise nothing.
   def mkUncheckedMatch(tree: Tree) = tree match {
@@ -357,8 +357,8 @@ abstract class TreeGen extends reflect.internal.TreeGen with TreeDSL {
    */
   def mkSynchronizedCheck(clazz: Symbol, cond: Tree, syncBody: List[Tree], stats: List[Tree]): Tree =
     mkSynchronizedCheck(mkAttributedThis(clazz), cond, syncBody, stats)
-    
-  def mkSynchronizedCheck(attrThis: Tree, cond: Tree, syncBody: List[Tree], stats: List[Tree]): Tree = 
+
+  def mkSynchronizedCheck(attrThis: Tree, cond: Tree, syncBody: List[Tree], stats: List[Tree]): Tree =
     Block(mkSynchronized(
       attrThis,
       If(cond, Block(syncBody: _*), EmptyTree)) ::

--- a/src/compiler/scala/tools/nsc/ast/Trees.scala
+++ b/src/compiler/scala/tools/nsc/ast/Trees.scala
@@ -111,7 +111,7 @@ trait Trees extends reflect.internal.Trees { self: Global =>
         if (body forall treeInfo.isInterfaceMember) List()
         else List(
           atPos(wrappingPos(superPos, lvdefs)) (
-            DefDef(NoMods, nme.MIXIN_CONSTRUCTOR, List(), List(List()), TypeTree(), Block(lvdefs, Literal(Constant())))))
+            DefDef(NoMods, nme.MIXIN_CONSTRUCTOR, List(), ListOfNil, TypeTree(), Block(lvdefs, Literal(Constant())))))
       } else {
         // convert (implicit ... ) to ()(implicit ... ) if its the only parameter section
         if (vparamss1.isEmpty || !vparamss1.head.isEmpty && vparamss1.head.head.mods.isImplicit)

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -192,7 +192,7 @@ self =>
 
     override def blockExpr(): Tree = skipBraces(EmptyTree)
 
-    override def templateBody(isPre: Boolean) = skipBraces((emptyValDef, List(EmptyTree)))
+    override def templateBody(isPre: Boolean) = skipBraces((emptyValDef, EmptyTree.asList))
   }
 
   class UnitParser(val unit: global.CompilationUnit, patches: List[BracePatch]) extends SourceFileParser(unit.source) {
@@ -395,7 +395,7 @@ self =>
         NoMods,
         nme.CONSTRUCTOR,
         Nil,
-        List(Nil),
+        ListOfNil,
         TypeTree(),
         Block(List(Apply(gen.mkSuperSelect, Nil)), Literal(Constant(())))
       )
@@ -404,7 +404,7 @@ self =>
       def mainParamType = AppliedTypeTree(Ident(tpnme.Array), List(Ident(tpnme.String)))
       def mainParameter = List(ValDef(Modifiers(Flags.PARAM), nme.argv, mainParamType, EmptyTree))
       def mainSetArgv   = List(ValDef(NoMods, nme.args, TypeTree(), Ident(nme.argv)))
-      def mainNew       = makeNew(Nil, emptyValDef, stmts, List(Nil), NoPosition, NoPosition)
+      def mainNew       = makeNew(Nil, emptyValDef, stmts, ListOfNil, NoPosition, NoPosition)
       def mainDef       = DefDef(NoMods, nme.main, Nil, List(mainParameter), scalaDot(tpnme.Unit), Block(mainSetArgv, mainNew))
 
       // object Main
@@ -2093,7 +2093,7 @@ self =>
     def annotationExpr(): Tree = atPos(in.offset) {
       val t = exprSimpleType()
       if (in.token == LPAREN) New(t, multipleArgumentExprs())
-      else New(t, List(Nil))
+      else New(t, ListOfNil)
     }
 
 /* -------- PARAMETERS ------------------------------------------- */
@@ -2732,10 +2732,10 @@ self =>
     def templateParents(isTrait: Boolean): (List[Tree], List[List[Tree]]) = {
       val parents = new ListBuffer[Tree] += startAnnotType()
       val argss = (
-        // TODO: the insertion of List(Nil) here is where "new Foo" becomes
+        // TODO: the insertion of ListOfNil here is where "new Foo" becomes
         // indistinguishable from "new Foo()".
         if (in.token == LPAREN && !isTrait) multipleArgumentExprs()
-        else List(Nil)
+        else ListOfNil
       )
 
       while (in.token == WITH) {
@@ -2773,7 +2773,7 @@ self =>
           val (self1, body1) = templateBodyOpt(traitParentSeen = isTrait)
           (parents, argss, self1, earlyDefs ::: body1)
         } else {
-          (List(), List(List()), self, body)
+          (List(), ListOfNil, self, body)
         }
       } else {
         val (parents, argss) = templateParents(isTrait = isTrait)
@@ -2800,7 +2800,7 @@ self =>
         else {
           newLineOptWhenFollowedBy(LBRACE)
           val (self, body) = templateBodyOpt(traitParentSeen = false)
-          (List(), List(List()), self, body)
+          (List(), ListOfNil, self, body)
         }
       )
       def anyrefParents() = {
@@ -2813,7 +2813,7 @@ self =>
       def anyvalConstructor() = (
         // Not a well-formed constructor, has to be finished later - see note
         // regarding AnyVal constructor in AddInterfaces.
-        DefDef(NoMods, nme.CONSTRUCTOR, Nil, List(Nil), TypeTree(), Block(Nil, Literal(Constant())))
+        DefDef(NoMods, nme.CONSTRUCTOR, Nil, ListOfNil, TypeTree(), Block(Nil, Literal(Constant())))
       )
       val tstart0 = if (body.isEmpty && in.lastOffset < tstart) in.lastOffset else tstart
 
@@ -2834,7 +2834,7 @@ self =>
      * @param isPre specifies whether in early initializer (true) or not (false)
      */
     def templateBody(isPre: Boolean) = inBraces(templateStatSeq(isPre = isPre)) match {
-      case (self, Nil)  => (self, List(EmptyTree))
+      case (self, Nil)  => (self, EmptyTree.asList)
       case result       => result
     }
     def templateBodyOpt(traitParentSeen: Boolean): (ValDef, List[Tree]) = {
@@ -2938,7 +2938,7 @@ self =>
     /** Informal - for the repl and other direct parser accessors.
      */
     def templateStats(): List[Tree] = templateStatSeq(isPre = false)._2 match {
-      case Nil    => List(EmptyTree)
+      case Nil    => EmptyTree.asList
       case stats  => stats
     }
 

--- a/src/compiler/scala/tools/nsc/ast/parser/SymbolicXMLBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/SymbolicXMLBuilder.scala
@@ -162,7 +162,7 @@ abstract class SymbolicXMLBuilder(p: Parsers#Parser, preserveWS: Boolean) {
 
   /** could optimize if args.length == 0, args.length == 1 AND args(0) is <: Node. */
   def makeXMLseq(pos: Position, args: Seq[Tree]) = {
-    val buffer = ValDef(NoMods, _buf, TypeTree(), New(_scala_xml_NodeBuffer, List(Nil)))
+    val buffer = ValDef(NoMods, _buf, TypeTree(), New(_scala_xml_NodeBuffer, ListOfNil))
     val applies = args filterNot isEmptyText map (t => Apply(Select(Ident(_buf), _plus), List(t)))
 
     atPos(pos)( Block(buffer :: applies.toList, Ident(_buf)) )

--- a/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
@@ -217,12 +217,12 @@ abstract class TreeBuilder {
             atPos(cpos) {
               ClassDef(
                 Modifiers(FINAL), x, Nil,
-                Template(parents, self, NoMods, List(Nil), argss, stats, cpos.focus))
+                Template(parents, self, NoMods, ListOfNil, argss, stats, cpos.focus))
             }),
           atPos(npos) {
             New(
               Ident(x) setPos npos.focus,
-              List(Nil))
+              ListOfNil)
           }
         )
       }

--- a/src/compiler/scala/tools/nsc/backend/icode/ICodes.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/ICodes.scala
@@ -2,11 +2,6 @@
  * Copyright 2005-2012 LAMP/EPFL
  * @author  Martin Odersky
  */
-/* NSC -- new scala compiler
- * Copyright 2005-2012 LAMP/EPFL
- * @author  Martin Odersky
- */
-
 
 package scala.tools.nsc
 package backend

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
@@ -2217,15 +2217,11 @@ abstract class GenASM extends SubComponent with BytecodeWriters {
           def getMerged(): collection.Map[Local, List[Interval]] = {
             // TODO should but isn't: unbalanced start(s) of scope(s)
             val shouldBeEmpty = pending filter { p => val Pair(k, st) = p; st.nonEmpty };
-
-            val merged = mutable.Map.empty[Local, List[Interval]]
-
-              def addToMerged(lv: Local, start: Label, end: Label) {
-                val ranges = merged.getOrElseUpdate(lv, Nil)
-                val coalesced = fuse(ranges, Interval(start, end))
-                merged.update(lv, coalesced)
-              }
-
+            val merged = mutable.Map[Local, List[Interval]]()
+            def addToMerged(lv: Local, start: Label, end: Label) {
+              val intv   = Interval(start, end)
+              merged(lv) = if (merged contains lv) fuse(merged(lv), intv) else intv :: Nil
+            }
             for(LocVarEntry(lv, start, end) <- seen) { addToMerged(lv, start, end) }
 
             /* for each var with unbalanced start(s) of scope(s):

--- a/src/compiler/scala/tools/nsc/interpreter/Imports.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/Imports.scala
@@ -23,7 +23,7 @@ trait Imports {
     val hd :: tl = sym.fullName.split('.').toList map newTermName
     val tree = Import(
       tl.foldLeft(Ident(hd): Tree)((x, y) => Select(x, y)),
-      List(ImportSelector(nme.WILDCARD, -1, null, -1))
+      ImportSelector.wildList
     )
     tree setSymbol sym
     new ImportHandler(tree)

--- a/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
@@ -551,7 +551,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
               if (parentToken == AT && in.token == DEFAULT) {
                 val annot =
                   atPos(pos) {
-                    New(Select(scalaDot(nme.runtime), tpnme.AnnotationDefaultATTR), List(List()))
+                    New(Select(scalaDot(nme.runtime), tpnme.AnnotationDefaultATTR), ListOfNil)
                   }
                 mods1 = mods1 withAnnotations List(annot)
                 skipTo(SEMI)
@@ -640,7 +640,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
 
     def importCompanionObject(cdef: ClassDef): Tree =
       atPos(cdef.pos) {
-        Import(Ident(cdef.name.toTermName), List(ImportSelector(nme.WILDCARD, -1, null, -1)))
+        Import(Ident(cdef.name.toTermName), ImportSelector.wildList)
       }
 
     // Importing the companion object members cannot be done uncritically: see
@@ -841,7 +841,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
       val predefs = List(
         DefDef(
           Modifiers(Flags.JAVA | Flags.STATIC), nme.values, List(),
-          List(List()),
+          ListOfNil,
           arrayOf(enumType),
           blankExpr),
         DefDef(

--- a/src/compiler/scala/tools/nsc/package.scala
+++ b/src/compiler/scala/tools/nsc/package.scala
@@ -14,4 +14,6 @@ package object nsc {
 
   type MissingRequirementError = scala.reflect.internal.MissingRequirementError
   val MissingRequirementError = scala.reflect.internal.MissingRequirementError
+
+  val ListOfNil = List(Nil)
 }

--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -50,14 +50,14 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
     private def transformTemplate(tree: Tree) = {
       val t @ Template(parents, self, body) = tree
       clearStatics()
-      
+
       val newBody = transformTrees(body)
       val templ   = deriveTemplate(tree)(_ => transformTrees(newStaticMembers.toList) ::: newBody)
       try addStaticInits(templ) // postprocess to include static ctors
       finally clearStatics()
     }
     private def mkTerm(prefix: String): TermName = unit.freshTermName(prefix)
-    
+
     //private val classConstantMeth = new HashMap[String, Symbol]
     //private val symbolStaticFields = new HashMap[String, (Symbol, Tree, Tree)]
 
@@ -542,12 +542,12 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
 
           else tree
         }
-      
+
       case ValDef(mods, name, tpt, rhs) if tree.symbol.hasStaticAnnotation =>
         log("moving @static valdef field: " + name + ", in: " + tree.symbol.owner)
         val sym = tree.symbol
         val owner = sym.owner
-        
+
         val staticBeforeLifting = atPhase(currentRun.erasurePhase) { owner.isStatic }
         val isPrivate = atPhase(currentRun.typerPhase) { sym.getter(owner).hasFlag(PRIVATE) }
         val isProtected = atPhase(currentRun.typerPhase) { sym.getter(owner).hasFlag(PROTECTED) }
@@ -574,19 +574,19 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
               val compclass = enclosing.newClass(newTypeName(owner.name.toString))
               compclass setInfo ClassInfoType(List(ObjectClass.tpe), newScope, compclass)
               enclosing.info.decls enter compclass
-              
-              val compclstree = ClassDef(compclass, NoMods, List(List()), List(List()), List(), tree.pos)
-              
+
+              val compclstree = ClassDef(compclass, NoMods, ListOfNil, ListOfNil, List(), tree.pos)
+
               syntheticClasses.getOrElseUpdate(enclosing, mutable.Set()) += compclstree
-              
+
               compclass
             case comp => comp
           }
-          
+
           // create a static field in the companion class for this @static field
           val stfieldSym = linkedClass.newVariable(newTermName(name), tree.pos, STATIC | SYNTHETIC | FINAL) setInfo sym.tpe
           stfieldSym.addAnnotation(StaticClass)
-          
+
           val names = classNames.getOrElseUpdate(linkedClass, linkedClass.info.decls.collect {
             case sym if sym.name.isTermName => sym.name
           } toSet)
@@ -597,9 +597,9 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
             )
           } else {
             linkedClass.info.decls enter stfieldSym
-            
+
             val initializerBody = rhs
-            
+
             // static field was previously initialized in the companion object itself, like this:
             //   staticBodies((linkedClass, stfieldSym)) = Select(This(owner), sym.getter(owner))
             // instead, we move the initializer to the static ctor of the companion class
@@ -608,7 +608,7 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
           }
         }
         super.transform(tree)
-        
+
       /* MSIL requires that the stack is empty at the end of a try-block.
        * Hence, we here rewrite all try blocks with a result != {Unit, All} such that they
        * store their result in a local variable. The catch blocks are adjusted as well.
@@ -722,7 +722,7 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
           case Block(stats, expr) => stats :+ expr
           case t => List(t)
         }
-        
+
         val newCtor = findStaticCtor(template) match {
           // in case there already were static ctors - augment existing ones
           // currently, however, static ctors aren't being generated anywhere else
@@ -746,7 +746,7 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
         deriveTemplate(template)(newCtor :: _)
       }
     }
-    
+
     private def addStaticDeclarations(tree: Template, clazz: Symbol) {
       // add static field initializer statements for each static field in clazz
       if (!clazz.isModuleClass) for {
@@ -757,22 +757,22 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
           val valdef = staticBodies((clazz, stfieldSym))
           val ValDef(_, _, _, rhs) = valdef
           val fixedrhs = rhs.changeOwner((valdef.symbol, clazz.info.decl(nme.CONSTRUCTOR)))
-          
+
           val stfieldDef  = localTyper.typedPos(tree.pos)(VAL(stfieldSym) === EmptyTree)
           val flattenedInit = fixedrhs match {
             case Block(stats, expr) => Block(stats, REF(stfieldSym) === expr)
             case rhs => REF(stfieldSym) === rhs
           }
           val stfieldInit = localTyper.typedPos(tree.pos)(flattenedInit)
-          
+
           // add field definition to new defs
           newStaticMembers append stfieldDef
           newStaticInits append stfieldInit
       }
     }
-    
-    
-    
+
+
+
     override def transformStats(stats: List[Tree], exprOwner: Symbol): List[Tree] = {
       super.transformStats(stats, exprOwner) ++ {
         // flush pending synthetic classes created in this owner
@@ -785,22 +785,22 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
         case clsdef @ ClassDef(mods, name, tparams, t @ Template(parent, self, body)) =>
           // process all classes in the package again to add static initializers
           clearStatics()
-          
+
           addStaticDeclarations(t, clsdef.symbol)
-          
+
           val templ  = deriveTemplate(t)(_ => transformTrees(newStaticMembers.toList) ::: body)
           val ntempl =
             try addStaticInits(templ)
             finally clearStatics()
-          
+
           val derived = deriveClassDef(clsdef)(_ => ntempl)
           classNames.remove(clsdef.symbol)
           derived
-          
+
         case stat => stat
       }
     }
-    
+
   } // CleanUpTransformer
 
 }

--- a/src/compiler/scala/tools/nsc/transform/Constructors.scala
+++ b/src/compiler/scala/tools/nsc/transform/Constructors.scala
@@ -506,14 +506,14 @@ abstract class Constructors extends Transform with ast.TreeDSL {
 
             val applyMethodDef = DefDef(
               sym = applyMethod,
-              vparamss = List(List()),
+              vparamss = ListOfNil,
               rhs = Block(applyMethodStats, gen.mkAttributedRef(BoxedUnit_UNIT)))
 
             ClassDef(
               sym = closureClass,
               constrMods = Modifiers(0),
               vparamss = List(List(outerFieldDef)),
-              argss = List(List()),
+              argss = ListOfNil,
               body = List(applyMethodDef),
               superPos = impl.pos)
           }

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -111,7 +111,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
             case TypeRef(_, GroupOfSpecializable, arg :: Nil) =>
               arg.typeArgs map (_.typeSymbol)
             case _ =>
-              List(tp.typeSymbol)
+              tp.typeSymbol :: Nil
           }
         }
       }
@@ -362,7 +362,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
     // creating each permutation of concrete types
     def loop(ctypes: List[List[Type]]): List[List[Type]] = ctypes match {
       case Nil         => Nil
-      case set :: Nil  => set map (x => List(x))
+      case set :: Nil  => set map (_ :: Nil)
       case set :: sets => for (x <- set ; xs <- loop(sets)) yield x :: xs
     }
     // zip the keys with each permutation to create a TypeEnv.
@@ -424,7 +424,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
     case MethodType(argSyms, resTpe) => specializedTypeVars(resTpe :: argSyms.map(_.tpe))
     case ExistentialType(_, res)     => specializedTypeVars(res)
     case AnnotatedType(_, tp, _)     => specializedTypeVars(tp)
-    case TypeBounds(lo, hi)          => specializedTypeVars(List(lo, hi))
+    case TypeBounds(lo, hi)          => specializedTypeVars(lo :: hi :: Nil)
     case RefinedType(parents, _)     => parents flatMap specializedTypeVars toSet
     case _                           => Set()
   }

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -27,6 +27,13 @@ trait Contexts { self: Analyzer =>
     override def implicitss: List[List[ImplicitInfo]] = Nil
     override def toString = "NoContext"
   }
+  private object RootImports {
+    import definitions._
+    // Possible lists of root imports
+    val javaList         = JavaLangPackage :: Nil
+    val javaAndScalaList = JavaLangPackage :: ScalaPackage :: Nil
+    val completeList     = JavaLangPackage :: ScalaPackage :: PredefModule :: Nil
+  }
 
   private val startContext = {
     NoContext.make(
@@ -46,13 +53,12 @@ trait Contexts { self: Analyzer =>
    *    among its leading imports, or if the tree is [[scala.Predef]], `Predef` is not imported.
    */
   protected def rootImports(unit: CompilationUnit): List[Symbol] = {
-    import definitions._
-    assert(isDefinitionsInitialized, "definitions uninitialized")
+    assert(definitions.isDefinitionsInitialized, "definitions uninitialized")
 
     if (settings.noimports.value) Nil
-    else if (unit.isJava) List(JavaLangPackage)
-    else if (settings.nopredef.value || treeInfo.noPredefImportForUnit(unit.body)) List(JavaLangPackage, ScalaPackage)
-    else List(JavaLangPackage, ScalaPackage, PredefModule)
+    else if (unit.isJava) RootImports.javaList
+    else if (settings.nopredef.value || treeInfo.noPredefImportForUnit(unit.body)) RootImports.javaAndScalaList
+    else RootImports.completeList
   }
 
   def rootContext(unit: CompilationUnit): Context             = rootContext(unit, EmptyTree, false)

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1641,7 +1641,7 @@ trait Infer {
         // for functional values, the `apply` method might be overloaded
         val mtypes = followApply(alt.tpe) match {
           case OverloadedType(_, alts) => alts map (_.tpe)
-          case t                       => List(t)
+          case t                       => t :: Nil
         }
         // Drop those that use a default; keep those that use vararg/tupling conversion.
         mtypes exists (t =>

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -797,7 +797,7 @@ trait Macros extends scala.tools.reflect.FastTrack with Traces {
     collectMacroArgs(expandee)
 
     val argcDoesntMatch = macroDef.paramss.length != exprArgs.length
-    val nullaryArgsEmptyParams = exprArgs.isEmpty && macroDef.paramss == List(List())
+    val nullaryArgsEmptyParams = exprArgs.isEmpty && macroDef.paramss == ListOfNil
     if (argcDoesntMatch && !nullaryArgsEmptyParams) { typer.TyperErrorGen.MacroPartialApplicationError(expandee); return None }
 
     var argss: List[List[Any]] = List(context) :: exprArgs.toList

--- a/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
@@ -242,7 +242,7 @@ trait MethodSynthesis {
             abort("No synthetics for " + meth + ": synthetics contains " + context.unit.synthetics.keys.mkString(", "))
         }
       case _ =>
-        List(stat)
+        stat :: Nil
       }
 
     def standardAccessors(vd: ValDef): List[DerivedFromValDef] = (
@@ -491,7 +491,7 @@ trait MethodSynthesis {
       // Derives a tree without attempting to use the original tree's symbol.
       override def derivedTree = {
         atPos(tree.pos.focus) {
-          DefDef(derivedMods, name, Nil, List(Nil), tree.tpt.duplicate,
+          DefDef(derivedMods, name, Nil, ListOfNil, tree.tpt.duplicate,
             if (isDeferred) EmptyTree else Select(This(owner), tree.name)
           )
         }

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -973,7 +973,7 @@ trait Namers extends MethodSynthesis {
       // Add a () parameter section if this overrides some method with () parameters.
       if (clazz.isClass && vparamss.isEmpty && overriddenSymbol.alternatives.exists(
         _.info.isInstanceOf[MethodType])) {
-        vparamSymss = List(List())
+        vparamSymss = ListOfNil
       }
       mforeach(vparamss) { vparam =>
         if (vparam.tpt.isEmpty) {
@@ -1032,7 +1032,7 @@ trait Namers extends MethodSynthesis {
       var baseParamss = (vparamss, overridden.tpe.paramss) match {
         // match empty and missing parameter list
         case (Nil, List(Nil)) => Nil
-        case (List(Nil), Nil) => List(Nil)
+        case (List(Nil), Nil) => ListOfNil
         case (_, paramss)     => paramss
       }
       assert(

--- a/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
@@ -70,7 +70,7 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
         storeAccessorDefinition(clazz, DefDef(acc, EmptyTree))
         acc
       }
-      
+
       atPos(sel.pos)(Select(gen.mkAttributedThis(clazz), superAcc) setType sel.tpe)
     }
 
@@ -290,7 +290,7 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
                   log("Ensuring accessor for call to protected " + sym.fullLocationString + " from " + currentClass)
                   ensureAccessor(sel)
                 } else
-                  mayNeedProtectedAccessor(sel, List(EmptyTree), false)
+                  mayNeedProtectedAccessor(sel, EmptyTree.asList, false)
               }
 
             case Super(_, mix) =>
@@ -303,7 +303,7 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
               transformSuperSelect(sel)
 
             case _ =>
-              mayNeedProtectedAccessor(sel, List(EmptyTree), true)
+              mayNeedProtectedAccessor(sel, EmptyTree.asList, true)
           }
 
         case DefDef(mods, name, tparams, vparamss, tpt, rhs) if tree.symbol.isMethodWithExtension =>
@@ -500,7 +500,7 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
           )
         true
       }
-      isCandidate && !host.isPackageClass && !isSelfType 
+      isCandidate && !host.isPackageClass && !isSelfType
     }
 
     /** Return the innermost enclosing class C of referencingClass for which either

--- a/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
@@ -115,7 +115,7 @@ trait Unapplies extends ast.TreeDSL
       Modifiers(OVERRIDE | FINAL),
       nme.toString_,
       Nil,
-      List(Nil),
+      ListOfNil,
       TypeTree(),
       Literal(Constant(cdef.name.decode)))
 
@@ -126,7 +126,7 @@ trait Unapplies extends ast.TreeDSL
     ModuleDef(
       Modifiers(cdef.mods.flags & AccessFlags | SYNTHETIC, cdef.mods.privateWithin),
       cdef.name.toTermName,
-      Template(parents, emptyValDef, NoMods, Nil, List(Nil), body, cdef.impl.pos.focus))
+      Template(parents, emptyValDef, NoMods, Nil, ListOfNil, body, cdef.impl.pos.focus))
   }
 
   private val caseMods = Modifiers(SYNTHETIC | CASE)

--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -266,7 +266,7 @@ sealed abstract class Option[+A] extends Product with Serializable {
    * if it is nonempty, or the empty list if the $option is empty.
    */
   def toList: List[A] =
-    if (isEmpty) List() else List(this.get)
+    if (isEmpty) List() else new ::(this.get, Nil)
 
   /** Returns a [[scala.util.Left]] containing the given
    * argument `left` if this $option is empty, or

--- a/src/library/scala/collection/GenTraversableLike.scala
+++ b/src/library/scala/collection/GenTraversableLike.scala
@@ -65,14 +65,14 @@ trait GenTraversableLike[+A, +Repr] extends Any with GenTraversableOnce[A] with 
    *  @throws `NoSuchElementException` if the $coll is empty.
    */
   def head: A
-  
+
   /** Optionally selects the first element.
    *  $orderDependent
    *  @return  the first element of this $coll if it is nonempty,
    *           `None` if it is empty.
    */
   def headOption: Option[A]
-  
+
   /** Tests whether this $coll can be repeatedly traversed.
    *  @return   `true`
    */
@@ -92,14 +92,14 @@ trait GenTraversableLike[+A, +Repr] extends Any with GenTraversableOnce[A] with 
     * @throws NoSuchElementException If the $coll is empty.
     */
   def last: A
-  
+
   /** Optionally selects the last element.
    *  $orderDependent
    *  @return  the last element of this $coll$ if it is nonempty,
    *           `None` if it is empty.
    */
   def lastOption: Option[A]
-  
+
   /** Selects all elements except the last.
    *  $orderDependent
    *  @return  a $coll consisting of all elements of this $coll
@@ -107,7 +107,7 @@ trait GenTraversableLike[+A, +Repr] extends Any with GenTraversableOnce[A] with 
    *  @throws `UnsupportedOperationException` if the $coll is empty.
    */
   def init: Repr
-  
+
   /** Computes a prefix scan of the elements of the collection.
    *
    *  Note: The neutral element `z` may be applied more than once.
@@ -210,7 +210,7 @@ trait GenTraversableLike[+A, +Repr] extends Any with GenTraversableOnce[A] with 
   def collect[B, That](pf: PartialFunction[A, B])(implicit bf: CanBuildFrom[Repr, B, That]): That
 
   /** Builds a new collection by applying a function to all elements of this $coll
-   *  and using the elements of the resulting collections. 
+   *  and using the elements of the resulting collections.
    *
    *  @param f      the function to apply to each element.
    *  @tparam B     the element type of the returned collection.

--- a/src/library/scala/reflect/base/Base.scala
+++ b/src/library/scala/reflect/base/Base.scala
@@ -487,6 +487,7 @@ class Base extends Universe { self =>
   }
 
   case object EmptyTree extends TermTree {
+    val asList = List(this)
     override def isEmpty = true
   }
 

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -137,9 +137,8 @@ trait Definitions extends api.StandardDefinitions {
     lazy val BooleanTpe = BooleanClass.toTypeConstructor
 
     lazy val ScalaNumericValueClasses = ScalaValueClasses filterNot Set[Symbol](UnitClass, BooleanClass)
-
-    def ScalaValueClassesNoUnit = ScalaValueClasses filterNot (_ eq UnitClass)
-    def ScalaValueClasses: List[ClassSymbol] = List(
+    lazy val ScalaValueClassesNoUnit  = ScalaValueClasses filterNot (_ eq UnitClass)
+    lazy val ScalaValueClasses: List[ClassSymbol] = List(
       UnitClass,
       BooleanClass,
       ByteClass,

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -194,7 +194,7 @@ abstract class TreeGen extends macros.TreeBuilder {
     mkTypeApply(mkAttributedSelect(target, method), targs map TypeTree)
 
   private def mkSingleTypeApply(value: Tree, tpe: Type, what: Symbol, wrapInApply: Boolean) = {
-    val tapp = mkAttributedTypeApply(value, what, List(tpe.normalize))
+    val tapp = mkAttributedTypeApply(value, what, tpe.normalize :: Nil)
     if (wrapInApply) Apply(tapp, Nil) else tapp
   }
   private def typeTestSymbol(any: Boolean) = if (any) Any_isInstanceOf else Object_isInstanceOf

--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -521,20 +521,18 @@ abstract class TreeInfo {
    */
   def noPredefImportForUnit(body: Tree) = {
     // Top-level definition whose leading imports include Predef.
-    def containsLeadingPredefImport(defs: List[Tree]): Boolean = defs match {
-      case PackageDef(_, defs1) :: _ => containsLeadingPredefImport(defs1)
-      case Import(expr, _) :: rest   => isReferenceToPredef(expr) || containsLeadingPredefImport(rest)
-      case _                         => false
+    def isLeadingPredefImport(defn: Tree): Boolean = defn match {
+      case PackageDef(_, defs1) => defs1 exists isLeadingPredefImport
+      case Import(expr, _)      => isReferenceToPredef(expr)
+      case _                    => false
     }
-
     // Compilation unit is class or object 'name' in package 'scala'
     def isUnitInScala(tree: Tree, name: Name) = tree match {
       case PackageDef(Ident(nme.scala_), defs) => firstDefinesClassOrObject(defs, name)
       case _                                   => false
     }
 
-    (  isUnitInScala(body, nme.Predef)
-    || containsLeadingPredefImport(List(body)))
+    isUnitInScala(body, nme.Predef) || isLeadingPredefImport(body)
   }
 
   def isAbsTypeDef(tree: Tree) = tree match {

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -230,6 +230,7 @@ trait Trees extends api.Trees { self: SymbolTable =>
   }
 
   case object EmptyTree extends TermTree {
+    val asList = List(this)
     super.tpe_=(NoType)
     override def tpe_=(t: Type) =
       if (t != NoType) throw new UnsupportedOperationException("tpe_=("+t+") inapplicable for <empty>")
@@ -290,7 +291,10 @@ trait Trees extends api.Trees { self: SymbolTable =>
   object LabelDef extends LabelDefExtractor
 
   case class ImportSelector(name: Name, namePos: Int, rename: Name, renamePos: Int) extends ImportSelectorApi
-  object ImportSelector extends ImportSelectorExtractor
+  object ImportSelector extends ImportSelectorExtractor {
+    val wild     = ImportSelector(nme.WILDCARD, -1, null, -1)
+    val wildList = List(wild)
+  }
 
   case class Import(expr: Tree, selectors: List[ImportSelector])
        extends SymTree with ImportApi

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -442,7 +442,7 @@ trait Types extends api.Types { self: SymbolTable =>
       if (phase.erasedTypes) this
       else {
         val cowner = commonOwner(this)
-        refinedType(List(this), cowner, EmptyScope, cowner.pos).narrow
+        refinedType(this :: Nil, cowner, EmptyScope, cowner.pos).narrow
       }
 
     /** For a TypeBounds type, itself;
@@ -1007,7 +1007,7 @@ trait Types extends api.Types { self: SymbolTable =>
         if (!e.sym.hasFlag(excludedFlags)) {
           if (sym == NoSymbol) sym = e.sym
           else {
-            if (alts.isEmpty) alts = List(sym)
+            if (alts.isEmpty) alts = sym :: Nil
             alts = e.sym :: alts
           }
         }

--- a/src/reflect/scala/reflect/internal/util/Collections.scala
+++ b/src/reflect/scala/reflect/internal/util/Collections.scala
@@ -69,7 +69,7 @@ trait Collections {
     }
     lb.toList
   }
-  
+
   final def flatCollect[A, B](elems: List[A])(pf: PartialFunction[A, Traversable[B]]): List[B] = {
     val lb = new ListBuffer[B]
     for (x <- elems ; if pf isDefinedAt x)
@@ -104,7 +104,7 @@ trait Collections {
       index += 1
     }
   }
-  
+
   // @inline
   final def findOrElse[A](xs: TraversableOnce[A])(p: A => Boolean)(orElse: => A): A = {
     xs find p getOrElse orElse


### PR DESCRIPTION
With this commit, the number of :: allocations logged in total
after individually compiling each scala file in src/compiler
drops from 190,766,642 to 170,679,925.  Twenty million fewer
colon-colons in the world, it's a start.

For some heavily used lists like List(List()) I made vals so
we can reuse the same one every time, e.g.

  val ListOfNil = List(Nil)

The modifications in this patch were informed by logging call
frequency to List.apply and examining the heaviest users.

> > Origins tag 'listApply' logged 3041128 calls from 318 distinguished sources.

1497759   scala.reflect.internal.Definitions$ValueClassDefinitions$class.ScalaValueClasses(Definitions.scala:149)
 173737   scala.reflect.internal.Symbols$Symbol.alternatives(Symbols.scala:1525)
 148642   scala.tools.nsc.typechecker.SuperAccessors$SuperAccTransformer.transform(SuperAccessors.scala:306)
 141676   scala.tools.nsc.transform.SpecializeTypes$$anonfun$scala$tools$nsc$transform$SpecializeTypes$$specializedOn$3.apply(SpecializeTypes.scala:114)
  69049   scala.tools.nsc.transform.LazyVals$LazyValues$$anonfun$1.apply(LazyVals.scala:79)
  62854   scala.tools.nsc.transform.SpecializeTypes.specializedTypeVars(SpecializeTypes.scala:427)
  54781   scala.tools.nsc.typechecker.SuperAccessors$SuperAccTransformer.transform(SuperAccessors.scala:293)
  54486   scala.reflect.internal.Symbols$Symbol.newSyntheticValueParams(Symbols.scala:334)
  53843   scala.tools.nsc.backend.icode.Opcodes$opcodes$CZJUMP.<init>(Opcodes.scala:562)
  ...     etc.
