### PR TITLE
Absolutize tools.nsc => scala.tools.nsc.

### DIFF
--- a/src/compiler/scala/reflect/macros/runtime/FrontEnds.scala
+++ b/src/compiler/scala/reflect/macros/runtime/FrontEnds.scala
@@ -41,7 +41,7 @@ trait FrontEnds extends scala.tools.reflect.FrontEnds {
   }
 
   def interactive(): Unit = universe.reporter match {
-    case reporter: tools.nsc.reporters.AbstractReporter => reporter.displayPrompt()
+    case reporter: scala.tools.nsc.reporters.AbstractReporter => reporter.displayPrompt()
     case _ => ()
   }
 }

--- a/src/compiler/scala/reflect/macros/runtime/Settings.scala
+++ b/src/compiler/scala/reflect/macros/runtime/Settings.scala
@@ -17,7 +17,7 @@ trait Settings {
     setCompilerSettings(options.split(" ").toList)
 
   def setCompilerSettings(options: List[String]): this.type = {
-    val settings = new tools.nsc.Settings(_ => ())
+    val settings = new scala.tools.nsc.Settings(_ => ())
     settings.copyInto(universe.settings)
     this
   }

--- a/src/compiler/scala/reflect/macros/util/Traces.scala
+++ b/src/compiler/scala/reflect/macros/util/Traces.scala
@@ -2,7 +2,7 @@ package scala.reflect.macros
 package util
 
 trait Traces {
-  def globalSettings: tools.nsc.Settings
+  def globalSettings: scala.tools.nsc.Settings
 
   val macroDebugLite = globalSettings.YmacrodebugLite.value
   val macroDebugVerbose = globalSettings.YmacrodebugVerbose.value

--- a/src/scalap/scala/tools/scalap/Main.scala
+++ b/src/scalap/scala/tools/scalap/Main.scala
@@ -10,10 +10,10 @@ package scala.tools.scalap
 import java.io.{ PrintStream, OutputStreamWriter, ByteArrayOutputStream }
 import scala.reflect.NameTransformer
 import scalax.rules.scalasig._
-import tools.nsc.util.{ ClassPath, JavaClassPath }
-import tools.util.PathResolver
+import scala.tools.nsc.util.{ ClassPath, JavaClassPath }
+import scala.tools.util.PathResolver
 import ClassPath.DefaultJavaContext
-import tools.nsc.io.{ PlainFile, AbstractFile }
+import scala.tools.nsc.io.{ PlainFile, AbstractFile }
 
 /**The main object used to execute scalap on the command-line.
  *


### PR DESCRIPTION
Relative references to scala.tools which omit the "scala"
are uncompilable by themselves if you happen to have a directory
called "tools" which shadows scala/tools.  As we do in trunk.
