### PR TITLE
Compile speed optimizations

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/Trees.scala
+++ b/src/compiler/scala/tools/nsc/ast/Trees.scala
@@ -50,7 +50,7 @@ trait Trees extends reflect.internal.Trees { self: Global =>
 
  /** Array selection <qualifier> . <name> only used during erasure */
   case class SelectFromArray(qualifier: Tree, name: Name, erasure: Type)
-       extends TermTree with RefTree
+       extends RefTree with TermTree
 
   /** Derived value class injection (equivalent to: new C(arg) after easure); only used during erasure
    *  The class C is stored as the symbol of the tree node.

--- a/src/compiler/scala/tools/nsc/backend/icode/BasicBlocks.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/BasicBlocks.scala
@@ -20,6 +20,12 @@ trait BasicBlocks {
   import global.{ ifDebug, settings, log, nme }
   import nme.isExceptionResultName
 
+  /** Override Array creation for efficiency (to not go through reflection). */
+  private implicit val instructionTag: scala.reflect.ClassTag[Instruction] = new scala.reflect.ClassTag[Instruction] {
+    def runtimeClass: java.lang.Class[Instruction] = classOf[Instruction]
+    final override def newArray(len: Int): Array[Instruction] = new Array[Instruction](len)
+  }
+
   object NoBasicBlock extends BasicBlock(-1, null)
 
   /** This class represents a basic block. Each

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
@@ -2371,8 +2371,6 @@ abstract class GenASM extends SubComponent with BytecodeWriters {
       def genBlock(b: BasicBlock) {
         jmethod.visitLabel(labels(b))
 
-        import asm.Opcodes;
-
         debuglog("Generating code for block: " + b)
 
         // val lastInstr = b.lastInstruction
@@ -2391,287 +2389,308 @@ abstract class GenASM extends SubComponent with BytecodeWriters {
             }
           }
 
-          (instr.category: @scala.annotation.switch) match {
-
-            case icodes.localsCat => (instr: @unchecked) match {
-                case THIS(_)            => jmethod.visitVarInsn(Opcodes.ALOAD, 0)
-                case LOAD_LOCAL(local)  => jcode.load(indexOf(local), local.kind)
-                case STORE_LOCAL(local) => jcode.store(indexOf(local), local.kind)
-                case STORE_THIS(_)      =>
-                  // this only works for impl classes because the self parameter comes first
-                  // in the method signature. If that changes, this code has to be revisited.
-                  jmethod.visitVarInsn(Opcodes.ASTORE, 0)
-
-                case SCOPE_ENTER(lv) =>
-                  // locals removed by closelim (via CopyPropagation) may have left behind SCOPE_ENTER, SCOPE_EXIT that are to be ignored
-                  val relevant = (!lv.sym.isSynthetic && m.locals.contains(lv))
-                  if(relevant) { // TODO check: does GenICode emit SCOPE_ENTER, SCOPE_EXIT for synthetic vars?
-                    // this label will have DEBUG bit set in its flags (ie ASM ignores it for dataflow purposes)
-                    // similarly, these labels aren't tracked in the `labels` map.
-                    val start = new asm.Label
-                    jmethod.visitLabel(start)
-                    scoping.pushScope(lv, start)
-                  }
-
-                case SCOPE_EXIT(lv) =>
-                  val relevant = (!lv.sym.isSynthetic && m.locals.contains(lv))
-                  if(relevant) {
-                    // this label will have DEBUG bit set in its flags (ie ASM ignores it for dataflow purposes)
-                    // similarly, these labels aren't tracked in the `labels` map.
-                    val end = new asm.Label
-                    jmethod.visitLabel(end)
-                    scoping.popScope(lv, end, instr.pos)
-                  }
-            }
-
-            case icodes.stackCat => (instr: @unchecked) match {
-
-              case LOAD_MODULE(module) =>
-                // assert(module.isModule, "Expected module: " + module)
-                debuglog("generating LOAD_MODULE for: " + module + " flags: " + Flags.flagsToString(module.flags));
-                if (clasz.symbol == module.moduleClass && jMethodName != nme.readResolve.toString) {
-                  jmethod.visitVarInsn(Opcodes.ALOAD, 0)
-                } else {
-                  jmethod.visitFieldInsn(
-                    Opcodes.GETSTATIC,
-                    javaName(module) /* + "$" */ ,
-                    strMODULE_INSTANCE_FIELD,
-                    descriptor(module)
-                  )
-                }
-
-              case DROP(kind)   => emit(if(kind.isWideType) Opcodes.POP2 else Opcodes.POP)
-
-              case DUP(kind)    => emit(if(kind.isWideType) Opcodes.DUP2 else Opcodes.DUP)
-
-              case LOAD_EXCEPTION(_) => ()
-            }
-
-            case icodes.constCat => genConstant(jmethod, instr.asInstanceOf[CONSTANT].constant)
-
-            case icodes.arilogCat => genPrimitive(instr.asInstanceOf[CALL_PRIMITIVE].primitive, instr.pos)
-
-            case icodes.castsCat => (instr: @unchecked) match {
-
-              case IS_INSTANCE(tpe) =>
-                val jtyp: asm.Type =
-                  tpe match {
-                    case REFERENCE(cls) => asm.Type.getObjectType(javaName(cls))
-                    case ARRAY(elem)    => javaArrayType(javaType(elem))
-                    case _              => abort("Unknown reference type in IS_INSTANCE: " + tpe)
-                  }
-                jmethod.visitTypeInsn(Opcodes.INSTANCEOF, jtyp.getInternalName)
-
-              case CHECK_CAST(tpe) =>
-                tpe match {
-
-                  case REFERENCE(cls) =>
-                    if (cls != ObjectClass) { // No need to checkcast for Objects
-                      jmethod.visitTypeInsn(Opcodes.CHECKCAST, javaName(cls))
-                    }
-
-                  case ARRAY(elem)    =>
-                    val iname = javaArrayType(javaType(elem)).getInternalName
-                    jmethod.visitTypeInsn(Opcodes.CHECKCAST, iname)
-
-                  case _              => abort("Unknown reference type in IS_INSTANCE: " + tpe)
-                }
-
-            }
-
-            case icodes.objsCat  => (instr: @unchecked) match {
-
-              case BOX(kind) =>
-                val MethodNameAndType(mname, mdesc) = jBoxTo(kind)
-                jcode.invokestatic(BoxesRunTime, mname, mdesc)
-
-              case UNBOX(kind) =>
-                val MethodNameAndType(mname, mdesc) = jUnboxTo(kind)
-                jcode.invokestatic(BoxesRunTime, mname, mdesc)
-
-              case NEW(REFERENCE(cls)) =>
-                val className = javaName(cls)
-                jmethod.visitTypeInsn(Opcodes.NEW, className)
-
-              case MONITOR_ENTER() => emit(Opcodes.MONITORENTER)
-              case MONITOR_EXIT()  => emit(Opcodes.MONITOREXIT)
-            }
-
-            case icodes.fldsCat  => (instr: @unchecked) match {
-
-              case lf @ LOAD_FIELD(field, isStatic) =>
-                var owner = javaName(lf.hostClass)
-                debuglog("LOAD_FIELD with owner: " + owner + " flags: " + Flags.flagsToString(field.owner.flags))
-                val fieldJName = javaName(field)
-                val fieldDescr = descriptor(field)
-                val opc = if (isStatic) Opcodes.GETSTATIC else Opcodes.GETFIELD
-                jmethod.visitFieldInsn(opc, owner, fieldJName, fieldDescr)
-
-              case STORE_FIELD(field, isStatic) =>
-                val owner = javaName(field.owner)
-                val fieldJName = javaName(field)
-                val fieldDescr = descriptor(field)
-                val opc = if (isStatic) Opcodes.PUTSTATIC else Opcodes.PUTFIELD
-                jmethod.visitFieldInsn(opc, owner, fieldJName, fieldDescr)
-
-            }
-
-            case icodes.mthdsCat => (instr: @unchecked) match {
-
-              /** Special handling to access native Array.clone() */
-              case call @ CALL_METHOD(definitions.Array_clone, Dynamic) =>
-                val target: String = javaType(call.targetTypeKind).getInternalName
-                jcode.invokevirtual(target, "clone", mdesc_arrayClone)
-
-              case call @ CALL_METHOD(method, style) => genCallMethod(call)
-
-            }
-
-            case icodes.arraysCat => (instr: @unchecked) match {
-              case LOAD_ARRAY_ITEM(kind)    => jcode.aload(kind)
-              case STORE_ARRAY_ITEM(kind)   => jcode.astore(kind)
-              case CREATE_ARRAY(elem, 1)    => jcode newarray elem
-              case CREATE_ARRAY(elem, dims) => jmethod.visitMultiANewArrayInsn(descriptor(ArrayN(elem, dims)), dims)
-            }
-
-            case icodes.jumpsCat => (instr: @unchecked) match {
-
-              case sw @ SWITCH(tagss, branches) =>
-                assert(branches.length == tagss.length + 1, sw)
-                val flatSize     = sw.flatTagsCount
-                val flatKeys     = new Array[Int](flatSize)
-                val flatBranches = new Array[asm.Label](flatSize)
-
-                var restTagss    = tagss
-                var restBranches = branches
-                var k = 0 // ranges over flatKeys and flatBranches
-                while(restTagss.nonEmpty) {
-                  val currLabel = labels(restBranches.head)
-                  for(cTag <- restTagss.head) {
-                    flatKeys(k)     = cTag;
-                    flatBranches(k) = currLabel
-                    k += 1
-                  }
-                  restTagss    = restTagss.tail
-                  restBranches = restBranches.tail
-                }
-                val defaultLabel = labels(restBranches.head)
-                assert(restBranches.tail.isEmpty)
-                debuglog("Emitting SWITCH:\ntags: " + tagss + "\nbranches: " + branches)
-                jcode.emitSWITCH(flatKeys, flatBranches, defaultLabel, MIN_SWITCH_DENSITY)
-
-              case JUMP(whereto) =>
-                if (nextBlock != whereto) {
-                  jcode goTo labels(whereto)
-                } else if(m.exh.exists(eh => eh.covers(b))) {
-                  // SI-6102: Determine whether eliding this JUMP results in an empty range being covered by some EH.
-                  // If so, emit a NOP in place of the elided JUMP, to avoid "java.lang.ClassFormatError: Illegal exception table range"
-                  val isSthgLeft = b.toList.exists {
-                    case _: LOAD_EXCEPTION => false
-                    case _: SCOPE_ENTER    => false
-                    case _: SCOPE_EXIT     => false
-                    case _: JUMP           => false
-                    case _ => true
-                  }
-                  if(!isSthgLeft) {
-                    emit(asm.Opcodes.NOP)
-                  }
-                }
-
-              case CJUMP(success, failure, cond, kind) =>
-                if(kind.isIntSizedType) { // BOOL, BYTE, CHAR, SHORT, or INT
-                  if (nextBlock == success) {
-                    jcode.emitIF_ICMP(cond.negate, labels(failure))
-                    // .. and fall through to success label
-                  } else {
-                    jcode.emitIF_ICMP(cond, labels(success))
-                    if (nextBlock != failure) { jcode goTo labels(failure) }
-                  }
-                } else if(kind.isRefOrArrayType) { // REFERENCE(_) | ARRAY(_)
-                  if (nextBlock == success) {
-                    jcode.emitIF_ACMP(cond.negate, labels(failure))
-                    // .. and fall through to success label
-                  } else {
-                    jcode.emitIF_ACMP(cond, labels(success))
-                    if (nextBlock != failure) { jcode goTo labels(failure) }
-                  }
-                } else {
-                  (kind: @unchecked) match {
-                    case LONG   => emit(Opcodes.LCMP)
-                    case FLOAT  =>
-                      if (cond == LT || cond == LE) emit(Opcodes.FCMPG)
-                      else emit(Opcodes.FCMPL)
-                    case DOUBLE =>
-                      if (cond == LT || cond == LE) emit(Opcodes.DCMPG)
-                      else emit(Opcodes.DCMPL)
-                  }
-                  if (nextBlock == success) {
-                    jcode.emitIF(cond.negate, labels(failure))
-                    // .. and fall through to success label
-                  } else {
-                    jcode.emitIF(cond, labels(success))
-                    if (nextBlock != failure) { jcode goTo labels(failure) }
-                  }
-                }
-
-              case CZJUMP(success, failure, cond, kind) =>
-                if(kind.isIntSizedType) { // BOOL, BYTE, CHAR, SHORT, or INT
-                  if (nextBlock == success) {
-                    jcode.emitIF(cond.negate, labels(failure))
-                  } else {
-                    jcode.emitIF(cond, labels(success))
-                    if (nextBlock != failure) { jcode goTo labels(failure) }
-                  }
-                } else if(kind.isRefOrArrayType) { // REFERENCE(_) | ARRAY(_)
-                  val Success = success
-                  val Failure = failure
-                  // @unchecked because references aren't compared with GT, GE, LT, LE.
-                  ((cond, nextBlock) : @unchecked) match {
-                    case (EQ, Success) => jcode emitIFNONNULL labels(failure)
-                    case (NE, Failure) => jcode emitIFNONNULL labels(success)
-                    case (EQ, Failure) => jcode emitIFNULL    labels(success)
-                    case (NE, Success) => jcode emitIFNULL    labels(failure)
-                    case (EQ, _) =>
-                      jcode emitIFNULL labels(success)
-                      jcode goTo labels(failure)
-                    case (NE, _) =>
-                      jcode emitIFNONNULL labels(success)
-                      jcode goTo labels(failure)
-                  }
-                } else {
-                  (kind: @unchecked) match {
-                    case LONG   =>
-                      emit(Opcodes.LCONST_0)
-                      emit(Opcodes.LCMP)
-                    case FLOAT  =>
-                      emit(Opcodes.FCONST_0)
-                      if (cond == LT || cond == LE) emit(Opcodes.FCMPG)
-                      else emit(Opcodes.FCMPL)
-                    case DOUBLE =>
-                      emit(Opcodes.DCONST_0)
-                      if (cond == LT || cond == LE) emit(Opcodes.DCMPG)
-                      else emit(Opcodes.DCMPL)
-                  }
-                  if (nextBlock == success) {
-                    jcode.emitIF(cond.negate, labels(failure))
-                  } else {
-                    jcode.emitIF(cond, labels(success))
-                    if (nextBlock != failure) { jcode goTo labels(failure) }
-                  }
-                }
-
-            }
-
-            case icodes.retCat   => (instr: @unchecked) match {
-              case RETURN(kind) => jcode emitRETURN kind
-              case THROW(_)     => emit(Opcodes.ATHROW)
-            }
-
-          }
+          genInstr(instr, b)
 
         }
 
-      } // end of genCode()'s genBlock()
+      }
+
+      def genInstr(instr: Instruction, b: BasicBlock) {
+        import asm.Opcodes
+        (instr.category: @scala.annotation.switch) match {
+
+          case icodes.localsCat => 
+          def genLocalInstr = (instr: @unchecked) match {
+            case THIS(_) => jmethod.visitVarInsn(Opcodes.ALOAD, 0)
+            case LOAD_LOCAL(local) => jcode.load(indexOf(local), local.kind)
+            case STORE_LOCAL(local) => jcode.store(indexOf(local), local.kind)
+            case STORE_THIS(_) =>
+              // this only works for impl classes because the self parameter comes first
+              // in the method signature. If that changes, this code has to be revisited.
+              jmethod.visitVarInsn(Opcodes.ASTORE, 0)
+
+            case SCOPE_ENTER(lv) =>
+              // locals removed by closelim (via CopyPropagation) may have left behind SCOPE_ENTER, SCOPE_EXIT that are to be ignored
+              val relevant = (!lv.sym.isSynthetic && m.locals.contains(lv))
+              if (relevant) { // TODO check: does GenICode emit SCOPE_ENTER, SCOPE_EXIT for synthetic vars?
+                // this label will have DEBUG bit set in its flags (ie ASM ignores it for dataflow purposes)
+                // similarly, these labels aren't tracked in the `labels` map.
+                val start = new asm.Label
+                jmethod.visitLabel(start)
+                scoping.pushScope(lv, start)
+              }
+
+            case SCOPE_EXIT(lv) =>
+              val relevant = (!lv.sym.isSynthetic && m.locals.contains(lv))
+              if (relevant) {
+                // this label will have DEBUG bit set in its flags (ie ASM ignores it for dataflow purposes)
+                // similarly, these labels aren't tracked in the `labels` map.
+                val end = new asm.Label
+                jmethod.visitLabel(end)
+                scoping.popScope(lv, end, instr.pos)
+              }
+          }
+          genLocalInstr
+
+          case icodes.stackCat => 
+          def genStackInstr = (instr: @unchecked) match {
+
+            case LOAD_MODULE(module) =>
+              // assert(module.isModule, "Expected module: " + module)
+              debuglog("generating LOAD_MODULE for: " + module + " flags: " + Flags.flagsToString(module.flags));
+              if (clasz.symbol == module.moduleClass && jMethodName != nme.readResolve.toString) {
+                jmethod.visitVarInsn(Opcodes.ALOAD, 0)
+              } else {
+                jmethod.visitFieldInsn(
+                  Opcodes.GETSTATIC,
+                  javaName(module) /* + "$" */ ,
+                  strMODULE_INSTANCE_FIELD,
+                  descriptor(module))
+              }
+
+            case DROP(kind) => emit(if (kind.isWideType) Opcodes.POP2 else Opcodes.POP)
+
+            case DUP(kind) => emit(if (kind.isWideType) Opcodes.DUP2 else Opcodes.DUP)
+
+            case LOAD_EXCEPTION(_) => ()
+          }
+          genStackInstr
+
+          case icodes.constCat => genConstant(jmethod, instr.asInstanceOf[CONSTANT].constant)
+
+          case icodes.arilogCat => genPrimitive(instr.asInstanceOf[CALL_PRIMITIVE].primitive, instr.pos)
+
+          case icodes.castsCat => 
+          def genCastInstr = (instr: @unchecked) match {
+
+            case IS_INSTANCE(tpe) =>
+              val jtyp: asm.Type =
+                tpe match {
+                  case REFERENCE(cls) => asm.Type.getObjectType(javaName(cls))
+                  case ARRAY(elem) => javaArrayType(javaType(elem))
+                  case _ => abort("Unknown reference type in IS_INSTANCE: " + tpe)
+                }
+              jmethod.visitTypeInsn(Opcodes.INSTANCEOF, jtyp.getInternalName)
+
+            case CHECK_CAST(tpe) =>
+              tpe match {
+
+                case REFERENCE(cls) =>
+                  if (cls != ObjectClass) { // No need to checkcast for Objects
+                    jmethod.visitTypeInsn(Opcodes.CHECKCAST, javaName(cls))
+                  }
+
+                case ARRAY(elem) =>
+                  val iname = javaArrayType(javaType(elem)).getInternalName
+                  jmethod.visitTypeInsn(Opcodes.CHECKCAST, iname)
+
+                case _ => abort("Unknown reference type in IS_INSTANCE: " + tpe)
+              }
+
+          }
+          genCastInstr
+
+          case icodes.objsCat => 
+          def genObjsInstr = (instr: @unchecked) match {
+
+            case BOX(kind) =>
+              val MethodNameAndType(mname, mdesc) = jBoxTo(kind)
+              jcode.invokestatic(BoxesRunTime, mname, mdesc)
+
+            case UNBOX(kind) =>
+              val MethodNameAndType(mname, mdesc) = jUnboxTo(kind)
+              jcode.invokestatic(BoxesRunTime, mname, mdesc)
+
+            case NEW(REFERENCE(cls)) =>
+              val className = javaName(cls)
+              jmethod.visitTypeInsn(Opcodes.NEW, className)
+
+            case MONITOR_ENTER() => emit(Opcodes.MONITORENTER)
+            case MONITOR_EXIT() => emit(Opcodes.MONITOREXIT)
+          }
+          genObjsInstr
+
+          case icodes.fldsCat => 
+          def genFldsInstr = (instr: @unchecked) match {
+
+            case lf @ LOAD_FIELD(field, isStatic) =>
+              var owner = javaName(lf.hostClass)
+              debuglog("LOAD_FIELD with owner: " + owner + " flags: " + Flags.flagsToString(field.owner.flags))
+              val fieldJName = javaName(field)
+              val fieldDescr = descriptor(field)
+              val opc = if (isStatic) Opcodes.GETSTATIC else Opcodes.GETFIELD
+              jmethod.visitFieldInsn(opc, owner, fieldJName, fieldDescr)
+
+            case STORE_FIELD(field, isStatic) =>
+              val owner = javaName(field.owner)
+              val fieldJName = javaName(field)
+              val fieldDescr = descriptor(field)
+              val opc = if (isStatic) Opcodes.PUTSTATIC else Opcodes.PUTFIELD
+              jmethod.visitFieldInsn(opc, owner, fieldJName, fieldDescr)
+
+          }
+          genFldsInstr
+
+          case icodes.mthdsCat => 
+          def genMethodsInstr = (instr: @unchecked) match {
+
+            /** Special handling to access native Array.clone() */
+            case call @ CALL_METHOD(definitions.Array_clone, Dynamic) =>
+              val target: String = javaType(call.targetTypeKind).getInternalName
+              jcode.invokevirtual(target, "clone", mdesc_arrayClone)
+
+            case call @ CALL_METHOD(method, style) => genCallMethod(call)
+
+          }
+          genMethodsInstr
+
+          case icodes.arraysCat => 
+          def genArraysInstr = (instr: @unchecked) match {
+            case LOAD_ARRAY_ITEM(kind) => jcode.aload(kind)
+            case STORE_ARRAY_ITEM(kind) => jcode.astore(kind)
+            case CREATE_ARRAY(elem, 1) => jcode newarray elem
+            case CREATE_ARRAY(elem, dims) => jmethod.visitMultiANewArrayInsn(descriptor(ArrayN(elem, dims)), dims)
+          }
+          genArraysInstr
+
+          case icodes.jumpsCat => 
+          def genJumpInstr = (instr: @unchecked) match {
+
+            case sw @ SWITCH(tagss, branches) =>
+              assert(branches.length == tagss.length + 1, sw)
+              val flatSize = sw.flatTagsCount
+              val flatKeys = new Array[Int](flatSize)
+              val flatBranches = new Array[asm.Label](flatSize)
+
+              var restTagss = tagss
+              var restBranches = branches
+              var k = 0 // ranges over flatKeys and flatBranches
+              while (restTagss.nonEmpty) {
+                val currLabel = labels(restBranches.head)
+                for (cTag <- restTagss.head) {
+                  flatKeys(k) = cTag;
+                  flatBranches(k) = currLabel
+                  k += 1
+                }
+                restTagss = restTagss.tail
+                restBranches = restBranches.tail
+              }
+              val defaultLabel = labels(restBranches.head)
+              assert(restBranches.tail.isEmpty)
+              debuglog("Emitting SWITCH:\ntags: " + tagss + "\nbranches: " + branches)
+              jcode.emitSWITCH(flatKeys, flatBranches, defaultLabel, MIN_SWITCH_DENSITY)
+
+            case JUMP(whereto) =>
+              if (nextBlock != whereto) {
+                jcode goTo labels(whereto)
+              } else if (m.exh.exists(eh => eh.covers(b))) {
+                // SI-6102: Determine whether eliding this JUMP results in an empty range being covered by some EH.
+                // If so, emit a NOP in place of the elided JUMP, to avoid "java.lang.ClassFormatError: Illegal exception table range"
+                val isSthgLeft = b.toList.exists {
+                  case _: LOAD_EXCEPTION => false
+                  case _: SCOPE_ENTER => false
+                  case _: SCOPE_EXIT => false
+                  case _: JUMP => false
+                  case _ => true
+                }
+                if (!isSthgLeft) {
+                  emit(asm.Opcodes.NOP)
+                }
+              }
+
+            case CJUMP(success, failure, cond, kind) =>
+              if (kind.isIntSizedType) { // BOOL, BYTE, CHAR, SHORT, or INT
+                if (nextBlock == success) {
+                  jcode.emitIF_ICMP(cond.negate, labels(failure))
+                  // .. and fall through to success label
+                } else {
+                  jcode.emitIF_ICMP(cond, labels(success))
+                  if (nextBlock != failure) { jcode goTo labels(failure) }
+                }
+              } else if (kind.isRefOrArrayType) { // REFERENCE(_) | ARRAY(_)
+                if (nextBlock == success) {
+                  jcode.emitIF_ACMP(cond.negate, labels(failure))
+                  // .. and fall through to success label
+                } else {
+                  jcode.emitIF_ACMP(cond, labels(success))
+                  if (nextBlock != failure) { jcode goTo labels(failure) }
+                }
+              } else {
+                (kind: @unchecked) match {
+                  case LONG => emit(Opcodes.LCMP)
+                  case FLOAT =>
+                    if (cond == LT || cond == LE) emit(Opcodes.FCMPG)
+                    else emit(Opcodes.FCMPL)
+                  case DOUBLE =>
+                    if (cond == LT || cond == LE) emit(Opcodes.DCMPG)
+                    else emit(Opcodes.DCMPL)
+                }
+                if (nextBlock == success) {
+                  jcode.emitIF(cond.negate, labels(failure))
+                  // .. and fall through to success label
+                } else {
+                  jcode.emitIF(cond, labels(success))
+                  if (nextBlock != failure) { jcode goTo labels(failure) }
+                }
+              }
+
+            case CZJUMP(success, failure, cond, kind) =>
+              if (kind.isIntSizedType) { // BOOL, BYTE, CHAR, SHORT, or INT
+                if (nextBlock == success) {
+                  jcode.emitIF(cond.negate, labels(failure))
+                } else {
+                  jcode.emitIF(cond, labels(success))
+                  if (nextBlock != failure) { jcode goTo labels(failure) }
+                }
+              } else if (kind.isRefOrArrayType) { // REFERENCE(_) | ARRAY(_)
+                val Success = success
+                val Failure = failure
+                // @unchecked because references aren't compared with GT, GE, LT, LE.
+                ((cond, nextBlock): @unchecked) match {
+                  case (EQ, Success) => jcode emitIFNONNULL labels(failure)
+                  case (NE, Failure) => jcode emitIFNONNULL labels(success)
+                  case (EQ, Failure) => jcode emitIFNULL labels(success)
+                  case (NE, Success) => jcode emitIFNULL labels(failure)
+                  case (EQ, _) =>
+                    jcode emitIFNULL labels(success)
+                    jcode goTo labels(failure)
+                  case (NE, _) =>
+                    jcode emitIFNONNULL labels(success)
+                    jcode goTo labels(failure)
+                }
+              } else {
+                (kind: @unchecked) match {
+                  case LONG =>
+                    emit(Opcodes.LCONST_0)
+                    emit(Opcodes.LCMP)
+                  case FLOAT =>
+                    emit(Opcodes.FCONST_0)
+                    if (cond == LT || cond == LE) emit(Opcodes.FCMPG)
+                    else emit(Opcodes.FCMPL)
+                  case DOUBLE =>
+                    emit(Opcodes.DCONST_0)
+                    if (cond == LT || cond == LE) emit(Opcodes.DCMPG)
+                    else emit(Opcodes.DCMPL)
+                }
+                if (nextBlock == success) {
+                  jcode.emitIF(cond.negate, labels(failure))
+                } else {
+                  jcode.emitIF(cond, labels(success))
+                  if (nextBlock != failure) { jcode goTo labels(failure) }
+                }
+              }
+
+          }
+          genJumpInstr
+
+          case icodes.retCat => 
+          def genRetInstr = (instr: @unchecked) match {
+            case RETURN(kind) => jcode emitRETURN kind
+            case THROW(_) => emit(Opcodes.ATHROW)
+          }
+          genRetInstr
+        }
+      }
 
       /**
        * Emits one or more conversion instructions based on the types given as arguments.

--- a/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
@@ -250,7 +250,7 @@ abstract class SymbolLoaders {
     protected def description = "class file "+ classfile.toString
 
     protected def doComplete(root: Symbol) {
-      val start = Statistics.startTimer(classReadNanos)
+      val start = if (Statistics.canEnable) Statistics.startTimer(classReadNanos) else null
       classfileParser.parse(classfile, root)
       if (root.associatedFile eq null) {
         root match {
@@ -262,7 +262,7 @@ abstract class SymbolLoaders {
             debuglog("Not setting associatedFile to %s because %s is a %s".format(classfile, root.name, root.shortSymbolClass))
         }
       }
-      Statistics.stopTimer(classReadNanos, start)
+      if (Statistics.canEnable) Statistics.stopTimer(classReadNanos, start)
     }
     override def sourcefile: Option[AbstractFile] = classfileParser.srcfile
   }

--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -482,7 +482,7 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
 
                 BLOCK(
                   VAL(sym) === qual0,
-                  callAsReflective(mparams map (_.tpe), resType)
+                  callAsReflective(mparams map tpeOfSymbol, resType)
                 )
               }
           }

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -271,8 +271,11 @@ abstract class Erasure extends AddInterfaces
           poly + jsig(restpe)
 
         case MethodType(params, restpe) =>
-          "("+(params map (_.tpe) map (jsig(_))).mkString+")"+
-          (if (restpe.typeSymbol == UnitClass || sym0.isConstructor) VOID_TAG.toString else jsig(restpe))
+          val buf = new StringBuffer("(")
+          params foreach (p => buf append jsig(p.tpe))
+          buf append ")"
+          buf append (if (restpe.typeSymbol == UnitClass || sym0.isConstructor) VOID_TAG.toString else jsig(restpe))
+          buf.toString
 
         case RefinedType(parent :: _, decls) =>
           boxedSig(parent)

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -488,7 +488,7 @@ abstract class Erasure extends AddInterfaces
     private def isPrimitiveValueMember(sym: Symbol) =
       sym != NoSymbol && isPrimitiveValueClass(sym.owner)
 
-    private def box(tree: Tree, target: => String): Tree = {
+    @inline private def box(tree: Tree, target: => String): Tree = {
       val result = box1(tree)
       log("boxing "+tree+":"+tree.tpe+" to "+target+" = "+result+":"+result.tpe)
       result

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -931,151 +931,174 @@ abstract class Erasure extends AddInterfaces
      *   - Reset all other type attributes to null, thus enforcing a retyping.
      */
     private val preTransformer = new TypingTransformer(unit) {
-      def preErase(tree: Tree): Tree = tree match {
-        case ClassDef(_,_,_,_) =>
-          debuglog("defs of " + tree.symbol + " = " + tree.symbol.info.decls)
-          copyClassDef(tree)(tparams = Nil)
-        case DefDef(_,_,_,_,_,_) =>
-          copyDefDef(tree)(tparams = Nil)
-        case TypeDef(_, _, _, _) =>
-          EmptyTree
-        case Apply(instanceOf @ TypeApply(fun @ Select(qual, name), args @ List(arg)), List()) // !!! todo: simplify by having GenericArray also extract trees
-              if ((fun.symbol == Any_isInstanceOf || fun.symbol == Object_isInstanceOf) &&
-                  unboundedGenericArrayLevel(arg.tpe) > 0) =>
-          val level = unboundedGenericArrayLevel(arg.tpe)
-          def isArrayTest(arg: Tree) =
-            gen.mkRuntimeCall(nme.isArray, List(arg, Literal(Constant(level))))
 
-          global.typer.typedPos(tree.pos) {
-            if (level == 1) isArrayTest(qual)
-            else gen.evalOnce(qual, currentOwner, unit) { qual1 =>
-              gen.mkAnd(
-                gen.mkMethodCall(
-                  qual1(),
-                  fun.symbol,
-                  List(specialErasure(fun.symbol)(arg.tpe)),
-                  Nil
-                ),
-                isArrayTest(qual1())
-              )
-            }
+      private def preEraseNormalApply(tree: Apply) = {
+        val fn = tree.fun
+        val args = tree.args
+
+        def qualifier = fn match {
+          case Select(qual, _) => qual
+          case TypeApply(Select(qual, _), _) => qual
+        }
+
+        def preEraseAsInstanceOf = {
+          (fn: @unchecked) match {
+            case TypeApply(Select(qual, _), List(targ)) =>
+              if (qual.tpe <:< targ.tpe)
+                atPos(tree.pos) { Typed(qual, TypeTree(targ.tpe)) }
+              else if (isNumericValueClass(qual.tpe.typeSymbol) && isNumericValueClass(targ.tpe.typeSymbol))
+                atPos(tree.pos)(numericConversion(qual, targ.tpe.typeSymbol))
+              else
+                tree
           }
+          // todo: also handle the case where the singleton type is buried in a compound
+        }
+
+        def preEraseIsInstanceOf = {
+          fn match {
+            case TypeApply(sel @ Select(qual, name), List(targ)) =>
+              if (qual.tpe != null && isPrimitiveValueClass(qual.tpe.typeSymbol) && targ.tpe != null && targ.tpe <:< AnyRefClass.tpe)
+                unit.error(sel.pos, "isInstanceOf cannot test if value types are references.")
+              
+              def mkIsInstanceOf(q: () => Tree)(tp: Type): Tree =
+                Apply(
+                  TypeApply(
+                    Select(q(), Object_isInstanceOf) setPos sel.pos,
+                    List(TypeTree(tp) setPos targ.pos)) setPos fn.pos,
+                  List()) setPos tree.pos
+              targ.tpe match {
+                case SingleType(_, _) | ThisType(_) | SuperType(_, _) =>
+                  val cmpOp = if (targ.tpe <:< AnyValClass.tpe) Any_equals else Object_eq
+                  atPos(tree.pos) {
+                    Apply(Select(qual, cmpOp), List(gen.mkAttributedQualifier(targ.tpe)))
+                  }
+                case RefinedType(parents, decls) if (parents.length >= 2) =>
+                  // Optimization: don't generate isInstanceOf tests if the static type
+                  // conforms, because it always succeeds.  (Or at least it had better.)
+                  // At this writing the pattern matcher generates some instance tests
+                  // involving intersections where at least one parent is statically known true.
+                  // That needs fixing, but filtering the parents here adds an additional
+                  // level of robustness (in addition to the short term fix.)
+                  val parentTests = parents filterNot (qual.tpe <:< _)
+
+                  if (parentTests.isEmpty) Literal(Constant(true))
+                  else gen.evalOnce(qual, currentOwner, unit) { q =>
+                    atPos(tree.pos) {
+                      parentTests map mkIsInstanceOf(q) reduceRight gen.mkAnd
+                    }
+                  }
+                case _ =>
+                  tree
+              }
+            case _ => tree
+          }
+        }
+
+        if (fn.symbol == Any_asInstanceOf) {
+          preEraseAsInstanceOf
+        } else if (fn.symbol == Any_isInstanceOf) {
+          preEraseIsInstanceOf
+        } else if (fn.symbol.owner.isRefinementClass && !fn.symbol.isOverridingSymbol) {
+          ApplyDynamic(qualifier, args) setSymbol fn.symbol setPos tree.pos
+        } else if (fn.symbol.isMethodWithExtension) {
+          Apply(gen.mkAttributedRef(extensionMethods.extensionMethod(fn.symbol)), qualifier :: args)
+        } else {
+          tree
+        }
+      }
+
+      private def preEraseApply(tree: Apply) = {
+        tree.fun match {
+          case TypeApply(fun @ Select(qual, name), args @ List(arg))
+          if ((fun.symbol == Any_isInstanceOf || fun.symbol == Object_isInstanceOf) &&
+              unboundedGenericArrayLevel(arg.tpe) > 0) => // !!! todo: simplify by having GenericArray also extract trees
+            val level = unboundedGenericArrayLevel(arg.tpe)
+            def isArrayTest(arg: Tree) =
+              gen.mkRuntimeCall(nme.isArray, List(arg, Literal(Constant(level))))
+
+            global.typer.typedPos(tree.pos) {
+              if (level == 1) isArrayTest(qual)
+              else gen.evalOnce(qual, currentOwner, unit) { qual1 =>
+                gen.mkAnd(
+                  gen.mkMethodCall(
+                    qual1(),
+                    fun.symbol,
+                    List(specialErasure(fun.symbol)(arg.tpe)),
+                    Nil
+                  ),
+                  isArrayTest(qual1())
+                )
+              }
+            }
+          case fn @ Select(qual, name) =>
+            val args = tree.args
+            if (fn.symbol.owner == ArrayClass) {
+              // Have to also catch calls to abstract types which are bounded by Array.
+              if (unboundedGenericArrayLevel(qual.tpe.widen) == 1 || qual.tpe.typeSymbol.isAbstractType) {
+                // convert calls to apply/update/length on generic arrays to
+                // calls of ScalaRunTime.array_xxx method calls
+                global.typer.typedPos(tree.pos) {
+                  val arrayMethodName = name match {
+                    case nme.apply  => nme.array_apply
+                    case nme.length => nme.array_length
+                    case nme.update => nme.array_update
+                    case nme.clone_ => nme.array_clone
+                    case _          => unit.error(tree.pos, "Unexpected array member, no translation exists.") ; nme.NO_NAME
+                  }
+                  gen.mkRuntimeCall(arrayMethodName, qual :: args)
+                }
+              } else {
+                // store exact array erasure in map to be retrieved later when we might
+                // need to do the cast in adaptMember
+                treeCopy.Apply(
+                  tree,
+                  SelectFromArray(qual, name, erasure(tree.symbol)(qual.tpe)).copyAttrs(fn),
+                  args)
+              }
+            } else if (args.isEmpty && interceptedMethods(fn.symbol)) {
+              if (fn.symbol == Any_## || fn.symbol == Object_##) {
+                // This is unattractive, but without it we crash here on ().## because after
+                // erasure the ScalaRunTime.hash overload goes from Unit => Int to BoxedUnit => Int.
+                // This must be because some earlier transformation is being skipped on ##, but so
+                // far I don't know what.  For null we now define null.## == 0.
+                qual.tpe.typeSymbol match {
+                  case UnitClass | NullClass                    => LIT(0)
+                  case IntClass                                 => qual
+                  case s @ (ShortClass | ByteClass | CharClass) => numericConversion(qual, s)
+                  case BooleanClass                             => If(qual, LIT(true.##), LIT(false.##))
+                  case _                                        =>
+                    global.typer.typed(gen.mkRuntimeCall(nme.hash_, List(qual)))
+                }
+              } else if (isPrimitiveValueClass(qual.tpe.typeSymbol)) { 
+                // Rewrite 5.getClass to ScalaRunTime.anyValClass(5)
+                global.typer.typed(gen.mkRuntimeCall(nme.anyValClass, List(qual, typer.resolveClassTag(tree.pos, qual.tpe.widen))))
+              } else {
+                tree
+              }
+            } else qual match {
+              case New(tpt) if name == nme.CONSTRUCTOR && tpt.tpe.typeSymbol.isDerivedValueClass =>
+                // println("inject derived: "+arg+" "+tpt.tpe)
+                val List(arg) = args
+                InjectDerivedValue(arg) addAttachment //@@@ setSymbol tpt.tpe.typeSymbol
+                  new TypeRefAttachment(tree.tpe.asInstanceOf[TypeRef])
+              case _ =>
+                preEraseNormalApply(tree)
+            }
+
+          case _ =>
+            preEraseNormalApply(tree)
+        }
+      }
+
+      def preErase(tree: Tree): Tree = tree match {
+        case tree: Apply =>
+          preEraseApply(tree)
+
         case TypeApply(fun, args) if (fun.symbol.owner != AnyClass &&
                                       fun.symbol != Object_asInstanceOf &&
                                       fun.symbol != Object_isInstanceOf) =>
           // leave all other type tests/type casts, remove all other type applications
           preErase(fun)
-        case Apply(fn @ Select(qual, name), args) if fn.symbol.owner == ArrayClass =>
-          // Have to also catch calls to abstract types which are bounded by Array.
-          if (unboundedGenericArrayLevel(qual.tpe.widen) == 1 || qual.tpe.typeSymbol.isAbstractType) {
-            // convert calls to apply/update/length on generic arrays to
-            // calls of ScalaRunTime.array_xxx method calls
-            global.typer.typedPos(tree.pos)({
-              val arrayMethodName = name match {
-                case nme.apply  => nme.array_apply
-                case nme.length => nme.array_length
-                case nme.update => nme.array_update
-                case nme.clone_ => nme.array_clone
-                case _          => unit.error(tree.pos, "Unexpected array member, no translation exists.") ; nme.NO_NAME
-              }
-              gen.mkRuntimeCall(arrayMethodName, qual :: args)
-            })
-          }
-          else {
-            // store exact array erasure in map to be retrieved later when we might
-            // need to do the cast in adaptMember
-            treeCopy.Apply(
-              tree,
-              SelectFromArray(qual, name, erasure(tree.symbol)(qual.tpe)).copyAttrs(fn),
-              args)
-          }
-        case Apply(fn @ Select(qual, _), Nil) if interceptedMethods(fn.symbol) =>
-          if (fn.symbol == Any_## || fn.symbol == Object_##) {
-            // This is unattractive, but without it we crash here on ().## because after
-            // erasure the ScalaRunTime.hash overload goes from Unit => Int to BoxedUnit => Int.
-            // This must be because some earlier transformation is being skipped on ##, but so
-            // far I don't know what.  For null we now define null.## == 0.
-            qual.tpe.typeSymbol match {
-              case UnitClass | NullClass                    => LIT(0)
-              case IntClass                                 => qual
-              case s @ (ShortClass | ByteClass | CharClass) => numericConversion(qual, s)
-              case BooleanClass                             => If(qual, LIT(true.##), LIT(false.##))
-              case _                                        =>
-                global.typer.typed(gen.mkRuntimeCall(nme.hash_, List(qual)))
-            }
-          }
-          // Rewrite 5.getClass to ScalaRunTime.anyValClass(5)
-          else if (isPrimitiveValueClass(qual.tpe.typeSymbol))
-            global.typer.typed(gen.mkRuntimeCall(nme.anyValClass, List(qual, typer.resolveClassTag(tree.pos, qual.tpe.widen))))
-          else
-            tree
-
-
-        case Apply(Select(New(tpt), nme.CONSTRUCTOR), List(arg)) if (tpt.tpe.typeSymbol.isDerivedValueClass) =>
-//          println("inject derived: "+arg+" "+tpt.tpe)
-          InjectDerivedValue(arg) addAttachment //@@@ setSymbol tpt.tpe.typeSymbol
-            new TypeRefAttachment(tree.tpe.asInstanceOf[TypeRef])
-        case Apply(fn, args) =>
-          def qualifier = fn match {
-            case Select(qual, _) => qual
-            case TypeApply(Select(qual, _), _) => qual
-          }
-          if (fn.symbol == Any_asInstanceOf)
-            (fn: @unchecked) match {
-              case TypeApply(Select(qual, _), List(targ)) =>
-                if (qual.tpe <:< targ.tpe)
-                  atPos(tree.pos) { Typed(qual, TypeTree(targ.tpe)) }
-                else if (isNumericValueClass(qual.tpe.typeSymbol) && isNumericValueClass(targ.tpe.typeSymbol))
-                  atPos(tree.pos)(numericConversion(qual, targ.tpe.typeSymbol))
-                else
-                  tree
-            }
-            // todo: also handle the case where the singleton type is buried in a compound
-          else if (fn.symbol == Any_isInstanceOf) {
-            fn match {
-              case TypeApply(sel @ Select(qual, name), List(targ)) =>
-                if (qual.tpe != null && isPrimitiveValueClass(qual.tpe.typeSymbol) && targ.tpe != null && targ.tpe <:< AnyRefClass.tpe)
-                  unit.error(sel.pos, "isInstanceOf cannot test if value types are references.")
-
-                def mkIsInstanceOf(q: () => Tree)(tp: Type): Tree =
-                  Apply(
-                    TypeApply(
-                      Select(q(), Object_isInstanceOf) setPos sel.pos,
-                      List(TypeTree(tp) setPos targ.pos)) setPos fn.pos,
-                    List()) setPos tree.pos
-                targ.tpe match {
-                  case SingleType(_, _) | ThisType(_) | SuperType(_, _) =>
-                    val cmpOp = if (targ.tpe <:< AnyValClass.tpe) Any_equals else Object_eq
-                    atPos(tree.pos) {
-                      Apply(Select(qual, cmpOp), List(gen.mkAttributedQualifier(targ.tpe)))
-                    }
-                  case RefinedType(parents, decls) if (parents.length >= 2) =>
-                    // Optimization: don't generate isInstanceOf tests if the static type
-                    // conforms, because it always succeeds.  (Or at least it had better.)
-                    // At this writing the pattern matcher generates some instance tests
-                    // involving intersections where at least one parent is statically known true.
-                    // That needs fixing, but filtering the parents here adds an additional
-                    // level of robustness (in addition to the short term fix.)
-                    val parentTests = parents filterNot (qual.tpe <:< _)
-
-                    if (parentTests.isEmpty) Literal(Constant(true))
-                    else gen.evalOnce(qual, currentOwner, unit) { q =>
-                      atPos(tree.pos) {
-                        parentTests map mkIsInstanceOf(q) reduceRight gen.mkAnd
-                      }
-                    }
-                  case _ =>
-                    tree
-                }
-              case _ => tree
-            }
-          } else if (fn.symbol.owner.isRefinementClass && !fn.symbol.isOverridingSymbol) {
-            ApplyDynamic(qualifier, args) setSymbol fn.symbol setPos tree.pos
-          } else if (fn.symbol.isMethodWithExtension) {
-            Apply(gen.mkAttributedRef(extensionMethods.extensionMethod(fn.symbol)), qualifier :: args)
-          } else {
-                tree
-            }
 
         case Select(qual, name) =>
           val owner = tree.symbol.owner
@@ -1122,6 +1145,14 @@ abstract class Erasure extends AddInterfaces
             case tpe => specialScalaErasure(tpe)
           }
           treeCopy.Literal(tree, Constant(erased))
+
+        case ClassDef(_,_,_,_) =>
+          debuglog("defs of " + tree.symbol + " = " + tree.symbol.info.decls)
+          copyClassDef(tree)(tparams = Nil)
+        case DefDef(_,_,_,_,_,_) =>
+          copyDefDef(tree)(tparams = Nil)
+        case TypeDef(_, _, _, _) =>
+          EmptyTree
 
         case _ =>
           tree

--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -385,7 +385,7 @@ abstract class ExplicitOuter extends InfoTransform
       def makeGuardDef(vs: List[Symbol], guard: Tree) = {
         val gdname = unit.freshTermName("gd")
         val method = currentOwner.newMethod(gdname, tree.pos, SYNTHETIC)
-        val params = method newSyntheticValueParams vs.map(_.tpe)
+        val params = method newSyntheticValueParams vs.map(tpeOfSymbol)
         method setInfo new MethodType(params, BooleanClass.tpe)
 
         localTyper typed {

--- a/src/compiler/scala/tools/nsc/transform/TypingTransformers.scala
+++ b/src/compiler/scala/tools/nsc/transform/TypingTransformers.scala
@@ -25,19 +25,14 @@ trait TypingTransformers {
     protected var curTree: Tree = _
     protected def typedPos(pos: Position)(tree: Tree) = localTyper typed { atPos(pos)(tree) }
 
-    /** a typer for each enclosing class */
-    val typers: mutable.Map[Symbol, analyzer.Typer] = new mutable.HashMap
-
-    override def atOwner[A](owner: Symbol)(trans: => A): A = atOwner(curTree, owner)(trans)
+    override final def atOwner[A](owner: Symbol)(trans: => A): A = atOwner(curTree, owner)(trans)
 
     def atOwner[A](tree: Tree, owner: Symbol)(trans: => A): A = {
       val savedLocalTyper = localTyper
 //      println("transformer atOwner: " + owner + " isPackage? " + owner.isPackage)
       localTyper = localTyper.atOwner(tree, if (owner.isModule) owner.moduleClass else owner)
-      typers += Pair(owner, localTyper)
       val result = super.atOwner(owner)(trans)
       localTyper = savedLocalTyper
-      typers -= owner
       result
     }
 

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -693,6 +693,46 @@ abstract class UnCurry extends InfoTransform
         else
           tree
       }
+      
+      def isThrowable(pat: Tree): Boolean = pat match {
+        case Typed(Ident(nme.WILDCARD), tpt) => 
+          tpt.tpe =:= ThrowableClass.tpe
+        case Bind(_, pat) => 
+          isThrowable(pat)
+        case _ =>
+          false
+      }
+      
+      def isDefaultCatch(cdef: CaseDef) = isThrowable(cdef.pat) && cdef.guard.isEmpty
+
+      def postTransformTry(tree: Try) = {
+        val body = tree.block
+        val catches = tree.catches
+        val finalizer = tree.finalizer
+        if (opt.virtPatmat) {
+          if (catches exists (cd => !treeInfo.isCatchCase(cd)))
+            debugwarn("VPM BUG! illegal try/catch " + catches)
+          tree
+        } else if (catches forall treeInfo.isCatchCase) {
+          tree
+        } else {
+          val exname = unit.freshTermName("ex$")
+          val cases =
+            if ((catches exists treeInfo.isDefaultCase) || isDefaultCatch(catches.last)) catches
+            else catches :+ CaseDef(Ident(nme.WILDCARD), EmptyTree, Throw(Ident(exname)))
+          val catchall =
+            atPos(tree.pos) {
+              CaseDef(
+                Bind(exname, Ident(nme.WILDCARD)),
+                EmptyTree,
+                Match(Ident(exname), cases))
+            }
+          debuglog("rewrote try: " + catches + " ==> " + catchall);
+          val catches1 = localTyper.typedCases(
+            List(catchall), ThrowableClass.tpe, WildcardType)
+          treeCopy.Try(tree, body, catches1, finalizer)
+        }
+      }
 
       tree match {
         /* Some uncurry post transformations add members to templates.
@@ -724,35 +764,12 @@ abstract class UnCurry extends InfoTransform
           )
           addJavaVarargsForwarders(dd, flatdd)
 
-        case Try(body, catches, finalizer) =>
-          if (opt.virtPatmat) { if(catches exists (cd => !treeInfo.isCatchCase(cd))) debugwarn("VPM BUG! illegal try/catch "+ catches); tree }
-          else if (catches forall treeInfo.isCatchCase) tree
-          else {
-            val exname = unit.freshTermName("ex$")
-            val cases =
-              if ((catches exists treeInfo.isDefaultCase) || (catches.last match {  // bq: handle try { } catch { ... case ex:Throwable => ...}
-                    case CaseDef(Typed(Ident(nme.WILDCARD), tpt), EmptyTree, _) if (tpt.tpe =:= ThrowableClass.tpe) =>
-                      true
-                    case CaseDef(Bind(_, Typed(Ident(nme.WILDCARD), tpt)), EmptyTree, _) if (tpt.tpe =:= ThrowableClass.tpe) =>
-                      true
-                    case _ =>
-                      false
-                  })) catches
-              else catches :+ CaseDef(Ident(nme.WILDCARD), EmptyTree, Throw(Ident(exname)))
-            val catchall =
-              atPos(tree.pos) {
-                CaseDef(
-                  Bind(exname, Ident(nme.WILDCARD)),
-                  EmptyTree,
-                  Match(Ident(exname), cases))
-              }
-            debuglog("rewrote try: " + catches + " ==> " + catchall);
-            val catches1 = localTyper.typedCases(
-              List(catchall), ThrowableClass.tpe, WildcardType)
-            treeCopy.Try(tree, body, catches1, finalizer)
-          }
+        case tree: Try =>
+          postTransformTry(tree)
+          
         case Apply(Apply(fn, args), args1) =>
           treeCopy.Apply(tree, fn, args ::: args1)
+          
         case Ident(name) =>
           assert(name != tpnme.WILDCARD_STAR, tree)
           applyUnary()

--- a/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
@@ -85,13 +85,13 @@ trait Analyzer extends AnyRef
       // compiler run). This is good enough for the resident compiler, which was the most affected.
       undoLog.clear()
       override def run() {
-        val start = Statistics.startTimer(typerNanos)
+        val start = if (Statistics.canEnable) Statistics.startTimer(typerNanos) else null
         global.echoPhaseSummary(this)
         currentRun.units foreach applyPhase
         undoLog.clear()
         // need to clear it after as well or 10K+ accumulated entries are
         // uncollectable the rest of the way.
-        Statistics.stopTimer(typerNanos, start)
+        if (Statistics.canEnable) Statistics.stopTimer(typerNanos, start)
       }
       def apply(unit: CompilationUnit) {
         try {

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -181,8 +181,8 @@ trait Implicits {
         containsError(restpe)
       case NullaryMethodType(restpe) =>
         containsError(restpe)
-      case MethodType(params, restpe) =>
-        params.exists(_.tpe.isError) || containsError(restpe)
+      case mt @ MethodType(_, restpe) =>
+        (mt.paramTypes exists typeIsError) || containsError(restpe)
       case _ =>
         tp.isError
     }

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -72,10 +72,10 @@ trait Implicits {
     )
     indentTyping()
 
-    val rawTypeStart    = Statistics.startCounter(rawTypeImpl)
-    val findMemberStart = Statistics.startCounter(findMemberImpl)
-    val subtypeStart    = Statistics.startCounter(subtypeImpl)
-    val start           = Statistics.startTimer(implicitNanos)
+    val rawTypeStart    = if (Statistics.canEnable) Statistics.startCounter(rawTypeImpl) else null
+    val findMemberStart = if (Statistics.canEnable) Statistics.startCounter(findMemberImpl) else null
+    val subtypeStart    = if (Statistics.canEnable) Statistics.startCounter(subtypeImpl) else null
+    val start           = if (Statistics.canEnable) Statistics.startTimer(implicitNanos) else null
     if (printInfers && !tree.isEmpty && !context.undetparams.isEmpty)
       printTyping("typing implicit: %s %s".format(tree, context.undetparamsString))
     val implicitSearchContext = context.makeImplicit(reportAmbiguous)
@@ -87,10 +87,10 @@ trait Implicits {
     printInference("[infer implicit] inferred " + result)
     context.undetparams = context.undetparams filterNot result.subst.from.contains
 
-    Statistics.stopTimer(implicitNanos, start)
-    Statistics.stopCounter(rawTypeImpl, rawTypeStart)
-    Statistics.stopCounter(findMemberImpl, findMemberStart)
-    Statistics.stopCounter(subtypeImpl, subtypeStart)
+    if (Statistics.canEnable) Statistics.stopTimer(implicitNanos, start)
+    if (Statistics.canEnable) Statistics.stopCounter(rawTypeImpl, rawTypeStart)
+    if (Statistics.canEnable) Statistics.stopCounter(findMemberImpl, findMemberStart)
+    if (Statistics.canEnable) Statistics.stopCounter(subtypeImpl, subtypeStart)
     deindentTyping()
     printTyping("Implicit search yielded: "+ result)
     result
@@ -308,12 +308,12 @@ trait Implicits {
     /** Is implicit info `info1` better than implicit info `info2`?
      */
     def improves(info1: ImplicitInfo, info2: ImplicitInfo) = {
-      Statistics.incCounter(improvesCount)
+      if (Statistics.canEnable) Statistics.incCounter(improvesCount)
       (info2 == NoImplicitInfo) ||
       (info1 != NoImplicitInfo) && {
         if (info1.sym.isStatic && info2.sym.isStatic) {
           improvesCache get (info1, info2) match {
-            case Some(b) => Statistics.incCounter(improvesCachedCount); b
+            case Some(b) => if (Statistics.canEnable) Statistics.incCounter(improvesCachedCount); b
             case None =>
               val result = isStrictlyMoreSpecific(info1.tpe, info2.tpe, info1.sym, info2.sym)
               improvesCache((info1, info2)) = result
@@ -377,7 +377,7 @@ trait Implicits {
       overlaps(dtor1, dted1) && (dtor1 =:= dted1 || complexity(dtor1) > complexity(dted1))
     }
 
-    Statistics.incCounter(implicitSearchCount)
+    if (Statistics.canEnable) Statistics.incCounter(implicitSearchCount)
 
     /** The type parameters to instantiate */
     val undetParams = if (isView) List() else context.outer.undetparams
@@ -429,7 +429,7 @@ trait Implicits {
      *  This method is performance critical: 5-8% of typechecking time.
      */
     private def matchesPt(tp: Type, pt: Type, undet: List[Symbol]): Boolean = {
-      val start = Statistics.startTimer(matchesPtNanos)
+      val start = if (Statistics.canEnable) Statistics.startTimer(matchesPtNanos) else null
       val result = normSubType(tp, pt) || isView && {
         pt match {
           case TypeRef(_, Function1.Sym, args) =>
@@ -438,7 +438,7 @@ trait Implicits {
             false
         }
       }
-      Statistics.stopTimer(matchesPtNanos, start)
+      if (Statistics.canEnable) Statistics.stopTimer(matchesPtNanos, start)
       result
     }
     private def matchesPt(info: ImplicitInfo): Boolean = (
@@ -537,7 +537,7 @@ trait Implicits {
     }
 
     private def typedImplicit0(info: ImplicitInfo, ptChecked: Boolean, isLocal: Boolean): SearchResult = {
-      Statistics.incCounter(plausiblyCompatibleImplicits)
+      if (Statistics.canEnable) Statistics.incCounter(plausiblyCompatibleImplicits)
       printTyping (
         ptBlock("typedImplicit0",
           "info.name" -> info.name,
@@ -557,7 +557,7 @@ trait Implicits {
     }
 
     private def typedImplicit1(info: ImplicitInfo, isLocal: Boolean): SearchResult = {
-      Statistics.incCounter(matchingImplicits)
+      if (Statistics.canEnable) Statistics.incCounter(matchingImplicits)
 
       val itree = atPos(pos.focus) {
         // workaround for deficient context provided by ModelFactoryImplicitSupport#makeImplicitConstraints
@@ -595,7 +595,7 @@ trait Implicits {
         if (context.hasErrors)
           return fail("typed implicit %s has errors".format(info.sym.fullLocationString))
 
-        Statistics.incCounter(typedImplicits)
+        if (Statistics.canEnable) Statistics.incCounter(typedImplicits)
 
         printTyping("typed implicit %s:%s, pt=%s".format(itree1, itree1.tpe, wildPt))
         val itree2 = if (isView) (itree1: @unchecked) match { case Apply(fun, _) => fun }
@@ -678,7 +678,7 @@ trait Implicits {
               fail("typing TypeApply reported errors for the implicit tree")
             else {
               val result = new SearchResult(itree2, subst)
-              Statistics.incCounter(foundImplicits)
+              if (Statistics.canEnable) Statistics.incCounter(foundImplicits)
               printInference("[success] found %s for pt %s".format(result, ptInstantiated))
               result
             }
@@ -905,11 +905,11 @@ trait Implicits {
      *  @return               map from infos to search results
      */
     def applicableInfos(iss: Infoss, isLocal: Boolean): Map[ImplicitInfo, SearchResult] = {
-      val start       = Statistics.startCounter(subtypeAppInfos)
+      val start       = if (Statistics.canEnable) Statistics.startCounter(subtypeAppInfos) else null
       val computation = new ImplicitComputation(iss, isLocal) { }
       val applicable  = computation.findAll()
 
-      Statistics.stopCounter(subtypeAppInfos, start)
+      if (Statistics.canEnable) Statistics.stopCounter(subtypeAppInfos, start)
       applicable
     }
 
@@ -1125,13 +1125,13 @@ trait Implicits {
      *  such that some part of `tp` has C as one of its superclasses.
      */
     private def implicitsOfExpectedType: Infoss = {
-      Statistics.incCounter(implicitCacheAccs)
+      if (Statistics.canEnable) Statistics.incCounter(implicitCacheAccs)
       implicitsCache get pt match {
         case Some(implicitInfoss) =>
-          Statistics.incCounter(implicitCacheHits)
+          if (Statistics.canEnable) Statistics.incCounter(implicitCacheHits)
           implicitInfoss
         case None =>
-          val start = Statistics.startTimer(subtypeETNanos)
+          val start = if (Statistics.canEnable) Statistics.startTimer(subtypeETNanos) else null
           //        val implicitInfoss = companionImplicits(pt)
           val implicitInfoss1 = companionImplicitMap(pt).valuesIterator.toList
           //        val is1 = implicitInfoss.flatten.toSet
@@ -1140,7 +1140,7 @@ trait Implicits {
           //          if (!(is2 contains i)) println("!!! implicit infos of "+pt+" differ, new does not contain "+i+",\nold: "+implicitInfoss+",\nnew: "+implicitInfoss1)
           //        for (i <- is2)
           //          if (!(is1 contains i)) println("!!! implicit infos of "+pt+" differ, old does not contain "+i+",\nold: "+implicitInfoss+",\nnew: "+implicitInfoss1)
-          Statistics.stopTimer(subtypeETNanos, start)
+          if (Statistics.canEnable) Statistics.stopTimer(subtypeETNanos, start)
           implicitsCache(pt) = implicitInfoss1
           if (implicitsCache.size >= sizeLimit)
             implicitsCache -= implicitsCache.keysIterator.next
@@ -1372,21 +1372,21 @@ trait Implicits {
      *  If all fails return SearchFailure
      */
     def bestImplicit: SearchResult = {
-      val failstart = Statistics.startTimer(inscopeFailNanos)
-      val succstart = Statistics.startTimer(inscopeSucceedNanos)
+      val failstart = if (Statistics.canEnable) Statistics.startTimer(inscopeFailNanos) else null
+      val succstart = if (Statistics.canEnable) Statistics.startTimer(inscopeSucceedNanos) else null
 
       var result = searchImplicit(context.implicitss, true)
 
       if (result == SearchFailure) {
-        Statistics.stopTimer(inscopeFailNanos, failstart)
+        if (Statistics.canEnable) Statistics.stopTimer(inscopeFailNanos, failstart)
       } else {
-        Statistics.stopTimer(inscopeSucceedNanos, succstart)
-        Statistics.incCounter(inscopeImplicitHits)
+        if (Statistics.canEnable) Statistics.stopTimer(inscopeSucceedNanos, succstart)
+        if (Statistics.canEnable) Statistics.incCounter(inscopeImplicitHits)
       }
       if (result == SearchFailure) {
         val previousErrs = context.flushAndReturnBuffer()
-        val failstart = Statistics.startTimer(oftypeFailNanos)
-        val succstart = Statistics.startTimer(oftypeSucceedNanos)
+        val failstart = if (Statistics.canEnable) Statistics.startTimer(oftypeFailNanos) else null
+        val succstart = if (Statistics.canEnable) Statistics.startTimer(oftypeSucceedNanos) else null
 
         result = materializeImplicit(pt)
 
@@ -1396,10 +1396,10 @@ trait Implicits {
 
         if (result == SearchFailure) {
           context.updateBuffer(previousErrs)
-          Statistics.stopTimer(oftypeFailNanos, failstart)
+          if (Statistics.canEnable) Statistics.stopTimer(oftypeFailNanos, failstart)
         } else {
-          Statistics.stopTimer(oftypeSucceedNanos, succstart)
-          Statistics.incCounter(oftypeImplicitHits)
+          if (Statistics.canEnable) Statistics.stopTimer(oftypeSucceedNanos, succstart)
+          if (Statistics.canEnable) Statistics.incCounter(oftypeImplicitHits)
         }
       }
 

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -661,7 +661,13 @@ trait Infer {
         val restp1 = followApply(restp)
         if (restp1 eq restp) tp else restp1
       case _ =>
-        val appmeth = tp.nonPrivateMember(nme.apply) filter (_.isPublic)
+        val appmeth = {
+          //OPT cut down on #closures by special casing non-overloaded case
+          // was: tp.nonPrivateMember(nme.apply) filter (_.isPublic)
+          val result = tp.nonPrivateMember(nme.apply) 
+          if ((result eq NoSymbol) || !result.isOverloaded && result.isPublic) result
+          else result filter (_.isPublic)
+        }
         if (appmeth == NoSymbol) tp
         else OverloadedType(tp, appmeth.alternatives)
     }

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -240,7 +240,7 @@ trait Infer {
   def normalize(tp: Type): Type = tp match {
     case mt @ MethodType(params, restpe) if mt.isImplicit =>
       normalize(restpe)
-    case mt @ MethodType(params, restpe) if !restpe.isDependent =>
+    case mt @ MethodType(params, restpe) if !mt.isDependentMethodType =>
       functionType(params map (_.tpe), normalize(restpe))
     case NullaryMethodType(restpe) =>
       normalize(restpe)

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -240,8 +240,8 @@ trait Infer {
   def normalize(tp: Type): Type = tp match {
     case mt @ MethodType(params, restpe) if mt.isImplicit =>
       normalize(restpe)
-    case mt @ MethodType(params, restpe) if !mt.isDependentMethodType =>
-      functionType(params map (_.tpe), normalize(restpe))
+    case mt @ MethodType(_, restpe) if !mt.isDependentMethodType =>
+      functionType(mt.paramTypes, normalize(restpe))
     case NullaryMethodType(restpe) =>
       normalize(restpe)
     case ExistentialType(tparams, qtpe) =>
@@ -747,8 +747,8 @@ trait Infer {
           alts exists (alt => isApplicable(undetparams, pre.memberType(alt), argtpes0, pt))
         case ExistentialType(tparams, qtpe) =>
           isApplicable(undetparams, qtpe, argtpes0, pt)
-        case MethodType(params, _) =>
-          val formals = formalTypes(params map { _.tpe }, argtpes0.length, removeByName = false)
+        case mt @ MethodType(params, _) =>
+          val formals = formalTypes(mt.paramTypes, argtpes0.length, removeByName = false)
 
           def tryTupleApply: Boolean = {
             // if 1 formal, 1 argtpe (a tuple), otherwise unmodified argtpes0
@@ -854,8 +854,8 @@ trait Infer {
         isAsSpecific(res, ftpe2)
       case mt: MethodType if mt.isImplicit =>
         isAsSpecific(ftpe1.resultType, ftpe2)
-      case MethodType(params, _) if params.nonEmpty =>
-        var argtpes = params map (_.tpe)
+      case mt @ MethodType(params, _) if params.nonEmpty =>
+        var argtpes = mt.paramTypes
         if (isVarArgsList(params) && isVarArgsList(ftpe2.params))
           argtpes = argtpes map (argtpe =>
             if (isRepeatedParamType(argtpe)) argtpe.typeArgs.head else argtpe)
@@ -864,8 +864,8 @@ trait Infer {
         isAsSpecific(PolyType(tparams, res), ftpe2)
       case PolyType(tparams, mt: MethodType) if mt.isImplicit =>
         isAsSpecific(PolyType(tparams, mt.resultType), ftpe2)
-      case PolyType(_, MethodType(params, _)) if params.nonEmpty =>
-        isApplicable(List(), ftpe2, params map (_.tpe), WildcardType)
+      case PolyType(_, (mt @ MethodType(params, _))) if params.nonEmpty =>
+        isApplicable(List(), ftpe2, mt.paramTypes, WildcardType)
       // case NullaryMethodType(res) =>
       //   isAsSpecific(res, ftpe2)
       case ErrorType =>
@@ -1111,10 +1111,10 @@ trait Infer {
      */
     def inferMethodInstance(fn: Tree, undetparams: List[Symbol],
                             args: List[Tree], pt0: Type): List[Symbol] = fn.tpe match {
-      case MethodType(params0, _) =>
+      case mt @ MethodType(params0, _) =>
         try {
           val pt      = if (pt0.typeSymbol == UnitClass) WildcardType else pt0
-          val formals = formalTypes(params0 map (_.tpe), args.length)
+          val formals = formalTypes(mt.paramTypes, args.length)
           val argtpes = actualTypes(args map (x => elimAnonymousClass(x.tpe.deconst)), formals.length)
           val restpe  = fn.tpe.resultType(argtpes)
 
@@ -1640,7 +1640,7 @@ trait Infer {
       else eligible filter { alt =>
         // for functional values, the `apply` method might be overloaded
         val mtypes = followApply(alt.tpe) match {
-          case OverloadedType(_, alts) => alts map (_.tpe)
+          case OverloadedType(_, alts) => alts map tpeOfSymbol
           case t                       => t :: Nil
         }
         // Drop those that use a default; keep those that use vararg/tupling conversion.
@@ -1777,7 +1777,7 @@ trait Infer {
           else if (sym.isOverloaded) {
             val xs      = sym.alternatives
             val tparams = new AsSeenFromMap(pre, xs.head.owner) mapOver xs.head.typeParams
-            val bounds  = tparams map (_.tpeHK) // see e.g., #1236
+            val bounds  = tparams map tpeHKOfSymbol // see e.g., #1236
             val tpe     = PolyType(tparams, OverloadedType(AntiPolyType(pre, bounds), xs))
 
             (sym setInfo tpe, tpe)

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -697,8 +697,8 @@ trait Macros extends scala.tools.reflect.FastTrack with Traces {
       this.fail(typer, tree, err.errPos, "failed to %s: %s".format(what, err.errMsg))
       return expandee
     }
-    val start = Statistics.startTimer(macroExpandNanos)
-    Statistics.incCounter(macroExpandCount)
+    val start = if (Statistics.canEnable) Statistics.startTimer(macroExpandNanos) else null
+    if (Statistics.canEnable) Statistics.incCounter(macroExpandCount)
     try {
       macroExpand1(typer, expandee) match {
         case Success(expanded0) =>
@@ -744,7 +744,7 @@ trait Macros extends scala.tools.reflect.FastTrack with Traces {
           result
       }
     } finally {
-      Statistics.stopTimer(macroExpandNanos, start)
+      if (Statistics.canEnable) Statistics.stopTimer(macroExpandNanos, start)
     }
   }
 

--- a/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
@@ -41,7 +41,7 @@ trait MethodSynthesis {
       require(container.owner.isPackageClass, "Container must be a top-level class in a package: " + container)
       require(tparams.size == args.size, "Arguments must match type constructor arity: " + tparams + ", " + args)
 
-      appliedType(container, args map (_.tpe): _*)
+      appliedType(container, args map tpeOfSymbol: _*)
     }
 
     def companionType[T](implicit ct: CT[T]) =

--- a/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
@@ -277,7 +277,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
       if(phase.id >= currentRun.uncurryPhase.id) debugwarn("running translateMatch at "+ phase +" on "+ selector +" match "+ cases)
       patmatDebug("translating "+ cases.mkString("{", "\n", "}"))
 
-      val start = Statistics.startTimer(patmatNanos)
+      val start = if (Statistics.canEnable) Statistics.startTimer(patmatNanos) else null
 
       val selectorTp = repeatedToSeq(elimAnonymousClass(selector.tpe.widen.withoutAnnotations))
 
@@ -305,7 +305,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
       // pt = Any* occurs when compiling test/files/pos/annotDepMethType.scala  with -Xexperimental
       val combined = combineCases(selector, selectorSym, cases map translateCase(selectorSym, pt), pt, matchOwner, matchFailGenOverride)
 
-      Statistics.stopTimer(patmatNanos, start)
+      if (Statistics.canEnable) Statistics.stopTimer(patmatNanos, start)
       combined
     }
 
@@ -1954,7 +1954,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
     // TODO: for V1 representing x1 and V2 standing for x1.head, encode that
     //       V1 = Nil implies -(V2 = Ci) for all Ci in V2's domain (i.e., it is unassignable)
     def removeVarEq(props: List[Prop], modelNull: Boolean = false): (Prop, List[Prop]) = {
-      val start = Statistics.startTimer(patmatAnaVarEq)
+      val start = if (Statistics.canEnable) Statistics.startTimer(patmatAnaVarEq) else null
 
       val vars = new collection.mutable.HashSet[Var]
 
@@ -2009,7 +2009,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
       patmatDebug("eqAxioms:\n"+ cnfString(eqFreePropToSolvable(eqAxioms)))
       patmatDebug("pure:"+ pure.map(p => cnfString(eqFreePropToSolvable(p))).mkString("\n"))
 
-      Statistics.stopTimer(patmatAnaVarEq, start)
+      if (Statistics.canEnable) Statistics.stopTimer(patmatAnaVarEq, start)
 
       (eqAxioms, pure)
     }
@@ -2121,13 +2121,13 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
         }
       }
 
-      val start = Statistics.startTimer(patmatCNF)
+      val start = if (Statistics.canEnable) Statistics.startTimer(patmatCNF) else null
       val res   = conjunctiveNormalForm(negationNormalForm(p))
 
-      Statistics.stopTimer(patmatCNF, start)
+      if (Statistics.canEnable) Statistics.stopTimer(patmatCNF, start)
 
       //
-      if (Statistics.enabled) patmatCNFSizes(res.size).value += 1
+      if (Statistics.canEnable) patmatCNFSizes(res.size).value += 1
 
 //      patmatDebug("cnf for\n"+ p +"\nis:\n"+cnfString(res))
       res
@@ -2204,7 +2204,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
 
       patmatDebug("DPLL\n"+ cnfString(f))
 
-      val start = Statistics.startTimer(patmatAnaDPLL)
+      val start = if (Statistics.canEnable) Statistics.startTimer(patmatAnaDPLL) else null
 
       val satisfiableWithModel: Model =
         if (f isEmpty) EmptyModel
@@ -2242,7 +2242,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
             }
         }
 
-        Statistics.stopTimer(patmatAnaDPLL, start)
+        if (Statistics.canEnable) Statistics.stopTimer(patmatAnaDPLL, start)
 
         satisfiableWithModel
     }
@@ -2603,7 +2603,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
     // thus, the case is unreachable if there is no model for -(-P /\ C),
     // or, equivalently, P \/ -C, or C => P
     def unreachableCase(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type): Option[Int] = {
-      val start = Statistics.startTimer(patmatAnaReach)
+      val start = if (Statistics.canEnable) Statistics.startTimer(patmatAnaReach) else null
 
       // use the same approximator so we share variables,
       // but need different conditions depending on whether we're conservatively looking for failure or success
@@ -2657,7 +2657,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
           }
         }
 
-        Statistics.stopTimer(patmatAnaReach, start)
+        if (Statistics.canEnable) Statistics.stopTimer(patmatAnaReach, start)
 
         if (reachable) None else Some(caseIndex)
       } catch {
@@ -2750,7 +2750,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
       // - back off (to avoid crying exhaustive too often) when:
       //    - there are guards -->
       //    - there are extractor calls (that we can't secretly/soundly) rewrite
-      val start = Statistics.startTimer(patmatAnaExhaust)
+      val start = if (Statistics.canEnable) Statistics.startTimer(patmatAnaExhaust) else null
       var backoff = false
 
       val approx = new TreeMakersToConds(prevBinder)
@@ -2802,7 +2802,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
 
           val pruned = CounterExample.prune(counterExamples).map(_.toString).sorted
 
-          Statistics.stopTimer(patmatAnaExhaust, start)
+          if (Statistics.canEnable) Statistics.stopTimer(patmatAnaExhaust, start)
           pruned
         } catch {
           case ex : AnalysisBudget.Exception =>

--- a/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
@@ -3294,7 +3294,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
               // TODO: I don't think the binder's types can actually be different (due to checks in caseEquals)
               // if they do somehow manage to diverge, the lub might not be precise enough and we could get a type error
               // TODO: reuse name exactly if there's only one binder in binders
-              val binder = freshSym(binders.head.pos, lub(binders.map(_.tpe)), binders.head.name.toString)
+              val binder = freshSym(binders.head.pos, lub(binders.map(tpeOfSymbol)), binders.head.name.toString)
 
               // the patterns in same are equal (according to caseEquals)
               // we can thus safely pick the first one arbitrarily, provided we correct binding

--- a/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
@@ -2040,6 +2040,11 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
   trait CNF extends Logic {
     // CNF: a formula is a conjunction of clauses
     type Formula = Array[Clause]
+    /** Override Array creation for efficiency (to not go through reflection). */
+    private implicit val formulaTag: scala.reflect.ClassTag[Formula] = new scala.reflect.ClassTag[Formula] {
+      def runtimeClass: java.lang.Class[Formula] = classOf[Formula]
+      final override def newArray(len: Int): Array[Formula] = new Array[Formula](len)
+    }
     def formula(c: Clause*): Formula = c.toArray
     def andFormula(a: Formula, b: Formula): Formula = a ++ b
 

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -941,9 +941,9 @@ abstract class RefChecks extends InfoTransform with reflect.internal.transform.R
           case TypeBounds(lo, hi) =>
             validateVariance(lo, -variance)
             validateVariance(hi, variance)
-          case MethodType(formals, result) =>
+          case mt @ MethodType(formals, result) =>
             if (inRefinement)
-              validateVariances(formals map (_.tpe), -variance)
+              validateVariances(mt.paramTypes, -variance)
             validateVariance(result, variance)
           case NullaryMethodType(result) =>
             validateVariance(result, variance)
@@ -1677,7 +1677,7 @@ abstract class RefChecks extends InfoTransform with reflect.internal.transform.R
             tree
 
           case TypeApply(fn, args) =>
-            checkBounds(tree, NoPrefix, NoSymbol, fn.tpe.typeParams, args map (_.tpe))
+            checkBounds(tree, NoPrefix, NoSymbol, fn.tpe.typeParams, args map tpeOfTree)
             transformCaseApply(tree, ())
 
           case x @ Apply(_, _)  =>

--- a/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
@@ -393,7 +393,7 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
         val code = DefDef(newAcc, {
           val (receiver :: _) :: tail = newAcc.paramss
           val base: Tree              = Select(Ident(receiver), sym)
-          val allParamTypes           = mapParamss(sym)(_.tpe)
+          val allParamTypes           = mapParamss(sym)(tpeOfSymbol)
           val args = map2(tail, allParamTypes)((params, tpes) => map2(params, tpes)(makeArg(_, receiver, _)))
           args.foldLeft(base)(Apply(_, _))
         })

--- a/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
@@ -357,9 +357,22 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
       }
     }
 
-    override def atOwner[A](owner: Symbol)(trans: => A): A = {
+    /** a typer for each enclosing class */
+    private var typers = immutable.Map[Symbol, analyzer.Typer]()
+
+    /** Specialized here for performance; the previous blanked
+     *  introduction of typers in TypingTransformer caused a >5%
+     *  performance hit for the compiler as a whole.
+     */
+    override def atOwner[A](tree: Tree, owner: Symbol)(trans: => A): A = {
       if (owner.isClass) validCurrentOwner = true
-      super.atOwner(owner)(trans)
+      val savedLocalTyper = localTyper
+      localTyper = localTyper.atOwner(tree, if (owner.isModule) owner.moduleClass else owner)
+      typers = typers updated (owner, localTyper)
+      val result = super.atOwner(tree, owner)(trans)
+      localTyper = savedLocalTyper
+      typers -= owner
+      result
     }
 
     private def withInvalidOwner[A](trans: => A): A = {

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -352,7 +352,7 @@ trait Typers extends Modes with Adaptations with Tags {
             if (formals exists (isRepeatedParamType(_)))
               error(pos, "methods with `*`-parameters cannot be converted to function values");
             */
-            if (restpe.isDependent)
+            if (tpe.isDependentMethodType)
               DependentMethodTpeConversionToFunctionError(tree, tpe)
             checkParamsConvertible(tree, restpe)
           case _ =>

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4679,8 +4679,6 @@ trait Typers extends Modes with Adaptations with Tags {
           errorContainer = tree
         }
 
-        val fingerPrint: Long = name.fingerPrint
-
         var defSym: Symbol = tree.symbol  // the directly found symbol
         var pre: Type = NoPrefix          // the prefix type of defSym, if a class member
         var qual: Tree = EmptyTree        // the qualifier tree if transformed tree is a select
@@ -4718,10 +4716,7 @@ trait Typers extends Modes with Adaptations with Tags {
           var cx = startingIdentContext
           while (defSym == NoSymbol && cx != NoContext && (cx.scope ne null)) { // cx.scope eq null arises during FixInvalidSyms in Duplicators
             pre = cx.enclClass.prefix
-            defEntry = {
-                val scope = cx.scope
-                if ((fingerPrint & scope.fingerPrints) != 0) scope.lookupEntry(name) else null
-              }
+            defEntry = cx.scope.lookupEntry(name)
             if ((defEntry ne null) && qualifies(defEntry.sym)) {
               // Right here is where SI-1987, overloading in package objects, can be
               // seen to go wrong. There is an overloaded symbol, but when referring
@@ -5069,7 +5064,7 @@ trait Typers extends Modes with Adaptations with Tags {
 
         treeCopy.Try(tree, block1, catches1, finalizer1) setType owntype
       }
-      
+
       def typedThrow(tree: Throw) = {
         val expr1 = typed(tree.expr, EXPRmode | BYVALmode, ThrowableClass.tpe)
         treeCopy.Throw(tree, expr1) setType NothingClass.tpe
@@ -5112,7 +5107,7 @@ trait Typers extends Modes with Adaptations with Tags {
               case _ =>
                 setError(tree)
             }
-            
+
           case _ =>
             val tptTyped = typedType(tpt, mode)
             val exprTyped = typed(expr, onlyStickyModes(mode), tptTyped.tpe.deconst)
@@ -5134,7 +5129,7 @@ trait Typers extends Modes with Adaptations with Tags {
               treeTyped setType tptTyped.tpe
         }
       }
-      
+
       def typedTypeApply(tree: TypeApply) = {
         val fun = tree.fun
         val args = tree.args
@@ -5206,11 +5201,11 @@ trait Typers extends Modes with Adaptations with Tags {
       }
 
       def typedSelectFromTypeTree(tree: SelectFromTypeTree) = {
-        val qual1 = typedType(tree.qualifier, mode) 
-        if (qual1.tpe.isVolatile) TypeSelectionFromVolatileTypeError(tree, qual1) 
+        val qual1 = typedType(tree.qualifier, mode)
+        if (qual1.tpe.isVolatile) TypeSelectionFromVolatileTypeError(tree, qual1)
         else typedSelect(tree, qual1, tree.name)
       }
-      
+
       def typedTypeBoundsTree(tree: TypeBoundsTree) = {
         val lo1 = typedType(tree.lo, mode)
         val hi1 = typedType(tree.hi, mode)
@@ -5250,7 +5245,7 @@ trait Typers extends Modes with Adaptations with Tags {
 
         case tree: TypeTree =>
           typedTypeTree(tree)
-         
+
         case tree: Literal =>
           typedLiteral(tree)
 
@@ -5292,7 +5287,7 @@ trait Typers extends Modes with Adaptations with Tags {
 
         case tree: New =>
           typedNew(tree)
-          
+
         case Assign(lhs, rhs) =>
           typedAssign(lhs, rhs)
 
@@ -5368,7 +5363,7 @@ trait Typers extends Modes with Adaptations with Tags {
         case tree: ReferenceToBoxed =>
           typedReferenceToBoxed(tree)
 
-        case tree: TypeTreeWithDeferredRefCheck => 
+        case tree: TypeTreeWithDeferredRefCheck =>
           tree // TODO: should we re-type the wrapped tree? then we need to change TypeTreeWithDeferredRefCheck's representation to include the wrapped tree explicitly (instead of in its closure)
 
         case tree: Import =>

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4130,7 +4130,8 @@ trait Typers extends Modes with Adaptations with Tags {
         }
       }
 
-      def typedNew(tpt: Tree) = {
+      def typedNew(tree: New) = {
+        val tpt = tree.tpt
         val tpt1 = {
           val tpt0 = typedTypeConstructor(tpt)
           if (checkStablePrefixClassType(tpt0))
@@ -4297,7 +4298,7 @@ trait Typers extends Modes with Adaptations with Tags {
         }
       }
 
-      def typedApply(fun: Tree, args: List[Tree]) = {
+      def normalTypedApply(tree: Tree, fun: Tree, args: List[Tree]) = {
         val stableApplication = (fun.symbol ne null) && fun.symbol.isMethod && fun.symbol.isStable
         if (stableApplication && isPatternMode) {
           // treat stable function applications f() as expressions.
@@ -4368,6 +4369,38 @@ trait Typers extends Modes with Adaptations with Tags {
         }
       }
 
+      def typedApply(tree: Apply) = {
+        val fun = tree.fun
+        val args = tree.args
+        fun match {
+          case Block(stats, expr) =>
+            typed1(atPos(tree.pos)(Block(stats, Apply(expr, args) setPos tree.pos.makeTransparent)), mode, pt)
+          case _ =>
+            normalTypedApply(tree, fun, args) match {
+              case Apply(Select(New(tpt), name), args)
+              if (tpt.tpe != null &&
+                tpt.tpe.typeSymbol == ArrayClass &&
+                args.length == 1 &&
+                erasure.GenericArray.unapply(tpt.tpe).isDefined) => // !!! todo simplify by using extractor
+                // convert new Array[T](len) to evidence[ClassTag[T]].newArray(len)
+                // convert new Array^N[T](len) for N > 1 to evidence[ClassTag[Array[...Array[T]...]]].newArray(len), where Array HK gets applied (N-1) times
+                // [Eugene] no more MaxArrayDims. ClassTags are flexible enough to allow creation of arrays of arbitrary dimensionality (w.r.t JVM restrictions)
+                val Some((level, componentType)) = erasure.GenericArray.unapply(tpt.tpe)
+                val tagType = List.iterate(componentType, level)(tpe => appliedType(ArrayClass.toTypeConstructor, List(tpe))).last
+                val newArrayApp = atPos(tree.pos) {
+                  val tag = resolveClassTag(tree.pos, tagType)
+                  if (tag.isEmpty) MissingClassTagError(tree, tagType)
+                  else new ApplyToImplicitArgs(Select(tag, nme.newArray), args)
+                }
+                typed(newArrayApp, mode, pt)
+              case Apply(Select(fun, nme.apply), _) if treeInfo.isSuperConstrCall(fun) => //SI-5696
+                TooManyArgumentListsForConstructor(tree)
+              case tree1 =>
+                tree1
+            }
+        }
+      }
+
       def convertToAssignment(fun: Tree, qual: Tree, name: Name, args: List[Tree]): Tree = {
         val prefix = name.toTermName stripSuffix nme.EQL
         def mkAssign(vble: Tree): Tree =
@@ -4413,8 +4446,9 @@ trait Typers extends Modes with Adaptations with Tags {
         typed1(tree1, mode, pt)
       }
 
-      def typedSuper(qual: Tree, mix: TypeName) = {
-        val qual1 = typed(qual)
+      def typedSuper(tree: Super) = {
+        val mix = tree.mix
+        val qual1 = typed(tree.qual)
 
         val clazz = qual1 match {
           case This(_) => qual1.symbol
@@ -4457,12 +4491,13 @@ trait Typers extends Modes with Adaptations with Tags {
         treeCopy.Super(tree, qual1, mix) setType SuperType(clazz.thisType, owntype)
       }
 
-      def typedThis(qual: Name) = tree.symbol orElse qualifyingClass(tree, qual, packageOK = false) match {
-        case NoSymbol => tree
-        case clazz    =>
-          tree setSymbol clazz setType clazz.thisType.underlying
-          if (isStableContext(tree, mode, pt)) tree setType clazz.thisType else tree
-      }
+      def typedThis(tree: This) =
+        tree.symbol orElse qualifyingClass(tree, tree.qual, packageOK = false) match {
+          case NoSymbol => tree
+          case clazz    =>
+            tree setSymbol clazz setType clazz.thisType.underlying
+            if (isStableContext(tree, mode, pt)) tree setType clazz.thisType else tree
+        }
 
       /** Attribute a selection where <code>tree</code> is <code>qual.name</code>.
        *  <code>qual</code> is already attributed.
@@ -4471,7 +4506,7 @@ trait Typers extends Modes with Adaptations with Tags {
        *  @param name ...
        *  @return     ...
        */
-      def typedSelect(qual: Tree, name: Name): Tree = {
+      def typedSelect(tree: Tree, qual: Tree, name: Name): Tree = {
         def asDynamicCall = dyna.mkInvoke(context.tree, tree, qual, name) map (typed1(_, mode, pt))
 
         val sym = tree.symbol orElse member(qual, name) orElse {
@@ -4581,6 +4616,49 @@ trait Typers extends Modes with Adaptations with Tags {
         }
       }
 
+      def typedSelectOrSuperCall(tree: Select) = {
+        val qual = tree.qualifier
+        val name = tree.name
+        qual match {
+          case _: Super if name == nme.CONSTRUCTOR =>
+            val qual1 =
+              typed(qual, EXPRmode | QUALmode | POLYmode | SUPERCONSTRmode, WildcardType)
+              // the qualifier type of a supercall constructor is its first parent class
+            typedSelect(tree, qual1, nme.CONSTRUCTOR)
+          case _ =>
+            Statistics.incCounter(typedSelectCount)
+            var qual1 = checkDead(typedQualifier(qual, mode))
+            if (name.isTypeName) qual1 = checkStable(qual1)
+
+            val tree1 = // temporarily use `filter` and an alternative for `withFilter`
+              if (name == nme.withFilter)
+                silent(_ => typedSelect(tree, qual1, name)) match {
+                  case SilentResultValue(result) =>
+                    result
+                  case _ =>
+                    silent(_ => typed1(Select(qual1, nme.filter) setPos tree.pos, mode, pt)) match {
+                      case SilentResultValue(result2) =>
+                        unit.deprecationWarning(
+                          tree.pos, "`withFilter' method does not yet exist on " + qual1.tpe.widen +
+                            ", using `filter' method instead")
+                        result2
+                      case SilentTypeError(err) =>
+                        WithFilterError(tree, err)
+                    }
+                }
+              else
+                typedSelect(tree, qual1, name)
+
+            if (tree.isInstanceOf[PostfixSelect])
+              checkFeature(tree.pos, PostfixOpsFeature, name.decode)
+            if (tree1.symbol != null && tree1.symbol.isOnlyRefinementMember)
+              checkFeature(tree1.pos, ReflectiveCallsFeature, tree1.symbol.toString)
+
+            if (qual1.hasSymbolWhich(_.isRootPackage)) treeCopy.Ident(tree1, name)
+            else tree1
+        }
+      }
+
       /** Attribute an identifier consisting of a simple name or an outer reference.
        *
        *  @param tree      The tree representing the identifier.
@@ -4588,7 +4666,7 @@ trait Typers extends Modes with Adaptations with Tags {
        *  Transformations: (1) Prefix class members with this.
        *                   (2) Change imported symbols to selections
        */
-      def typedIdent(name: Name): Tree = {
+      def typedIdent(tree: Tree, name: Name): Tree = {
         var errorContainer: AbsTypeError = null
         @inline
         def ambiguousError(msg: String) = {
@@ -4831,7 +4909,18 @@ trait Typers extends Modes with Adaptations with Tags {
         }
       }
 
-      def typedCompoundTypeTree(templ: Template) = {
+      def typedIdentOrWildcard(tree: Ident) = {
+        val name = tree.name
+        Statistics.incCounter(typedIdentCount)
+        if ((name == nme.WILDCARD && (mode & (PATTERNmode | FUNmode)) == PATTERNmode) ||
+            (name == tpnme.WILDCARD && (mode & TYPEmode) != 0))
+          tree setType makeFullyDefined(pt)
+        else
+          typedIdent(tree, name)
+      }
+
+      def typedCompoundTypeTree(tree: CompoundTypeTree) = {
+        val templ = tree.templ
         val parents1 = templ.parents mapConserve (typedType(_, mode))
         if (parents1 exists (_.isErrorTyped)) tree setType ErrorType
         else {
@@ -4844,7 +4933,9 @@ trait Typers extends Modes with Adaptations with Tags {
         }
       }
 
-      def typedAppliedTypeTree(tpt: Tree, args: List[Tree]) = {
+      def typedAppliedTypeTree(tree: AppliedTypeTree) = {
+        val tpt = tree.tpt
+        val args = tree.args
         val tpt1 = typed1(tpt, mode | FUNmode | TAPPmode, WildcardType)
         if (tpt1.isErrorTyped) {
           tpt1
@@ -4978,109 +5069,32 @@ trait Typers extends Modes with Adaptations with Tags {
 
         treeCopy.Try(tree, block1, catches1, finalizer1) setType owntype
       }
+      
+      def typedThrow(tree: Throw) = {
+        val expr1 = typed(tree.expr, EXPRmode | BYVALmode, ThrowableClass.tpe)
+        treeCopy.Throw(tree, expr1) setType NothingClass.tpe
+      }
 
-      // begin typed1
-      //if (settings.debug.value && tree.isDef) log("typing definition of "+sym);//DEBUG
-      tree match {
-        case tree: PackageDef =>
-          typedPackageDef(tree)
-
-        case tree: ClassDef =>
-          newTyper(context.makeNewScope(tree, sym)).typedClassDef(tree)
-
-        case tree: ModuleDef =>
-          newTyper(context.makeNewScope(tree, sym.moduleClass)).typedModuleDef(tree)
-
-        case tree: ValDef =>
-          typedValDef(tree)
-
-        case tree: DefDef =>
-          // flag default getters for constructors. An actual flag would be nice. See SI-5543.
-          //val flag = ddef.mods.hasDefaultFlag && ddef.mods.hasFlag(PRESUPER)
-          defDefTyper(tree).typedDefDef(tree)
-
-        case tree: TypeDef =>
-          typedTypeDef(tree)
-
-        case tree: LabelDef =>
-          labelTyper(tree).typedLabelDef(tree)
-
-        case tree: DocDef =>
-         typedDocDef(tree)
-
-        case tree: Annotated =>
-          typedAnnotated(tree)
-
-        case tree: Block =>
-          typerWithLocalContext(context.makeNewScope(tree, context.owner)){
-            _.typedBlock(tree, mode, pt)
-          }
-
-        case tree: Alternative =>
-          typedAlternative(tree)
-
-        case tree: Star =>
-          typedStar(tree)
-
-        case tree: Bind =>
-          typedBind(tree)
-
-        case tree: UnApply =>
-          typedUnApply(tree)
-
-        case tree: ArrayValue =>
-          typedArrayValue(tree)
-
-        case tree: Function =>
-          if (tree.symbol == NoSymbol)
-            tree.symbol = context.owner.newAnonymousFunctionValue(tree.pos)
-          typerWithLocalContext(context.makeNewScope(tree, tree.symbol))(_.typedFunction(tree, mode, pt))
-
-        case Assign(lhs, rhs) =>
-          typedAssign(lhs, rhs)
-
-        case AssignOrNamedArg(lhs, rhs) => // called by NamesDefaults in silent typecheck
-          typedAssign(lhs, rhs)
-
-        case tree: If =>
-          typedIf(tree)
-
-        case tree: Match =>
-          typedVirtualizedMatch(tree)
-
-        case tree: Return =>
-          typedReturn(tree)
-
-        case tree: Try =>
-          typedTry(tree)
-
-        case Throw(expr) =>
-          val expr1 = typed(expr, EXPRmode | BYVALmode, ThrowableClass.tpe)
-          treeCopy.Throw(tree, expr1) setType NothingClass.tpe
-
-        case New(tpt: Tree) =>
-          typedNew(tpt)
-
-        case Typed(expr, Function(List(), EmptyTree)) =>
-          def typedEta0 = {
+      def typedTyped(tree: Typed) = {
+        val expr = tree.expr
+        val tpt = tree.tpt
+        tpt match {
+          case Function(List(), EmptyTree) =>
             // find out whether the programmer is trying to eta-expand a macro def
             // to do that we need to typecheck the tree first (we need a symbol of the eta-expandee)
             // that typecheck must not trigger macro expansions, so we explicitly prohibit them
             // Q: "but, " - you may ask - ", `typed1` doesn't call adapt, which does macro expansion, so why explicit check?"
             // A: solely for robustness reasons. this mechanism might change in the future, which might break unprotected code
-            val expr1 = context.withMacrosDisabled(typed1(expr, mode, pt))
-            expr1 match {
+            val exprTyped = context.withMacrosDisabled(typed1(expr, mode, pt))
+            exprTyped match {
               case macroDef if macroDef.symbol != null && macroDef.symbol.isTermMacro && !macroDef.symbol.isErroneous =>
-                MacroEtaError(expr1)
+                MacroEtaError(exprTyped)
               case _ =>
-                typedEta(checkDead(expr1))
+                typedEta(checkDead(exprTyped))
             }
-          }
-          typedEta0
 
-        case Typed(expr0, tpt @ Ident(tpnme.WILDCARD_STAR)) =>
-          def typedVarArg = {
-            val expr = typed(expr0, onlyStickyModes(mode), WildcardType)
+          case Ident(tpnme.WILDCARD_STAR) =>
+            val exprTyped = typed(expr, onlyStickyModes(mode), WildcardType)
             def subArrayType(pt: Type) =
               if (isPrimitiveValueClass(pt.typeSymbol) || !isFullyDefined(pt)) arrayType(pt)
               else {
@@ -5088,21 +5102,18 @@ trait Typers extends Modes with Adaptations with Tags {
                 newExistentialType(List(tparam), arrayType(tparam.tpe))
               }
 
-            val (expr1, baseClass) = expr.tpe.typeSymbol match {
-              case ArrayClass => (adapt(expr, onlyStickyModes(mode), subArrayType(pt)), ArrayClass)
-              case _ => (adapt(expr, onlyStickyModes(mode), seqType(pt)), SeqClass)
+            val (exprAdapted, baseClass) = exprTyped.tpe.typeSymbol match {
+              case ArrayClass => (adapt(exprTyped, onlyStickyModes(mode), subArrayType(pt)), ArrayClass)
+              case _ => (adapt(exprTyped, onlyStickyModes(mode), seqType(pt)), SeqClass)
             }
-            expr1.tpe.baseType(baseClass) match {
+            exprAdapted.tpe.baseType(baseClass) match {
               case TypeRef(_, _, List(elemtp)) =>
-                treeCopy.Typed(tree, expr1, tpt setType elemtp) setType elemtp
+                treeCopy.Typed(tree, exprAdapted, tpt setType elemtp) setType elemtp
               case _ =>
                 setError(tree)
             }
-          }
-          typedVarArg
-
-        case Typed(expr, tpt) =>
-          def typedTyped0 = {
+            
+          case _ =>
             val tptTyped = typedType(tpt, mode)
             val exprTyped = typed(expr, onlyStickyModes(mode), tptTyped.tpe.deconst)
             val treeTyped = treeCopy.Typed(tree, exprTyped, tptTyped)
@@ -5121,190 +5132,249 @@ trait Typers extends Modes with Adaptations with Tags {
               }
             } else
               treeTyped setType tptTyped.tpe
+        }
+      }
+      
+      def typedTypeApply(tree: TypeApply) = {
+        val fun = tree.fun
+        val args = tree.args
+        // @M: kind-arity checking is done here and in adapt, full kind-checking is in checkKindBounds (in Infer)
+        //@M! we must type fun in order to type the args, as that requires the kinds of fun's type parameters.
+        // However, args should apparently be done first, to save context.undetparams. Unfortunately, the args
+        // *really* have to be typed *after* fun. We escape from this classic Catch-22 by simply saving&restoring undetparams.
+
+        // @M TODO: the compiler still bootstraps&all tests pass when this is commented out..
+        //val undets = context.undetparams
+
+        // @M: fun is typed in TAPPmode because it is being applied to its actual type parameters
+        val fun1 = typed(fun, forFunMode(mode) | TAPPmode, WildcardType)
+        val tparams = fun1.symbol.typeParams
+
+        //@M TODO: val undets_fun = context.undetparams  ?
+        // "do args first" (by restoring the context.undetparams) in order to maintain context.undetparams on the function side.
+
+        // @M TODO: the compiler still bootstraps when this is commented out.. TODO: run tests
+        //context.undetparams = undets
+
+        // @M maybe the well-kindedness check should be done when checking the type arguments conform to the type parameters' bounds?
+        val args1 = if (sameLength(args, tparams)) map2Conserve(args, tparams) {
+          //@M! the polytype denotes the expected kind
+          (arg, tparam) => typedHigherKindedType(arg, mode, GenPolyType(tparam.typeParams, AnyClass.tpe))
+        }
+        else {
+          //@M  this branch is correctly hit for an overloaded polymorphic type. It also has to handle erroneous cases.
+          // Until the right alternative for an overloaded method is known, be very liberal,
+          // typedTypeApply will find the right alternative and then do the same check as
+          // in the then-branch above. (see pos/tcpoly_overloaded.scala)
+          // this assert is too strict: be tolerant for errors like trait A { def foo[m[x], g]=error(""); def x[g] = foo[g/*ERR: missing argument type*/] }
+          //assert(fun1.symbol.info.isInstanceOf[OverloadedType] || fun1.symbol.isError) //, (fun1.symbol,fun1.symbol.info,fun1.symbol.info.getClass,args,tparams))
+          args mapConserve (typedHigherKindedType(_, mode))
+        }
+
+        //@M TODO: context.undetparams = undets_fun ?
+        Typer.this.typedTypeApply(tree, mode, fun1, args1)
+      }
+
+      def typedApplyDynamic(tree: ApplyDynamic) = {
+        assert(phase.erasedTypes)
+        val reflectiveCalls = !(settings.refinementMethodDispatch.value == "invoke-dynamic")
+        val qual1 = typed(tree.qual, AnyRefClass.tpe)
+        val args1 = tree.args mapConserve (arg => if (reflectiveCalls) typed(arg, AnyRefClass.tpe) else typed(arg))
+        treeCopy.ApplyDynamic(tree, qual1, args1) setType (if (reflectiveCalls) AnyRefClass.tpe else tree.symbol.info.resultType)
+      }
+
+      def typedReferenceToBoxed(tree: ReferenceToBoxed) = {
+        val id = tree.ident
+        val id1 = typed1(id, mode, pt) match { case id: Ident => id }
+        // [Eugene] am I doing it right?
+        val erasedTypes = phaseId(currentPeriod) >= currentRun.erasurePhase.id
+        val tpe = capturedVariableType(id.symbol, erasedTypes = erasedTypes)
+        treeCopy.ReferenceToBoxed(tree, id1) setType tpe
+      }
+
+      def typedLiteral(tree: Literal) = {
+        val value = tree.value
+        tree setType (
+          if (value.tag == UnitTag) UnitClass.tpe
+          else ConstantType(value))
+      }
+
+      def typedSingletonTypeTree(tree: SingletonTypeTree) = {
+        val ref1 = checkStable(
+          typed(tree.ref, EXPRmode | QUALmode | (mode & TYPEPATmode), AnyRefClass.tpe))
+        tree setType ref1.tpe.resultType
+      }
+
+      def typedSelectFromTypeTree(tree: SelectFromTypeTree) = {
+        val qual1 = typedType(tree.qualifier, mode) 
+        if (qual1.tpe.isVolatile) TypeSelectionFromVolatileTypeError(tree, qual1) 
+        else typedSelect(tree, qual1, tree.name)
+      }
+      
+      def typedTypeBoundsTree(tree: TypeBoundsTree) = {
+        val lo1 = typedType(tree.lo, mode)
+        val hi1 = typedType(tree.hi, mode)
+        treeCopy.TypeBoundsTree(tree, lo1, hi1) setType TypeBounds(lo1.tpe, hi1.tpe)
+      }
+
+      def typedExistentialTypeTree(tree: ExistentialTypeTree) = {
+        val tree1 = typerWithLocalContext(context.makeNewScope(tree, context.owner)){
+          _.typedExistentialTypeTree(tree, mode)
+        }
+        checkExistentialsFeature(tree1.pos, tree1.tpe, "the existential type")
+        tree1
+      }
+
+      def typedTypeTree(tree: TypeTree) = {
+        if (tree.original != null)
+          tree setType typedType(tree.original, mode).tpe
+        else
+          // we should get here only when something before failed
+          // and we try again (@see tryTypedApply). In that case we can assign
+          // whatever type to tree; we just have to survive until a real error message is issued.
+          tree setType AnyClass.tpe
+      }
+
+      // begin typed1
+      //if (settings.debug.value && tree.isDef) log("typing definition of "+sym);//DEBUG
+
+      tree match {
+        case tree: Ident =>
+          typedIdentOrWildcard(tree)
+
+        case tree: Select =>
+          typedSelectOrSuperCall(tree)
+
+        case tree: Apply =>
+          typedApply(tree)
+
+        case tree: TypeTree =>
+          typedTypeTree(tree)
+         
+        case tree: Literal =>
+          typedLiteral(tree)
+
+        case tree: This =>
+          typedThis(tree)
+
+        case tree: ValDef =>
+          typedValDef(tree)
+
+        case tree: DefDef =>
+          // flag default getters for constructors. An actual flag would be nice. See SI-5543.
+          //val flag = ddef.mods.hasDefaultFlag && ddef.mods.hasFlag(PRESUPER)
+          defDefTyper(tree).typedDefDef(tree)
+
+        case tree: Block =>
+          typerWithLocalContext(context.makeNewScope(tree, context.owner)){
+            _.typedBlock(tree, mode, pt)
           }
-          typedTyped0
 
-        case TypeApply(fun, args) =>
-          def typedTypeApply0 = {
-            // @M: kind-arity checking is done here and in adapt, full kind-checking is in checkKindBounds (in Infer)
-            //@M! we must type fun in order to type the args, as that requires the kinds of fun's type parameters.
-            // However, args should apparently be done first, to save context.undetparams. Unfortunately, the args
-            // *really* have to be typed *after* fun. We escape from this classic Catch-22 by simply saving&restoring undetparams.
+        case tree: If =>
+          typedIf(tree)
 
-            // @M TODO: the compiler still bootstraps&all tests pass when this is commented out..
-            //val undets = context.undetparams
+        case tree: TypeApply =>
+          typedTypeApply(tree)
 
-            // @M: fun is typed in TAPPmode because it is being applied to its actual type parameters
-            val fun1 = typed(fun, forFunMode(mode) | TAPPmode, WildcardType)
-            val tparams = fun1.symbol.typeParams
+        case tree: AppliedTypeTree =>
+          typedAppliedTypeTree(tree)
 
-            //@M TODO: val undets_fun = context.undetparams  ?
-            // "do args first" (by restoring the context.undetparams) in order to maintain context.undetparams on the function side.
+        case tree: Bind =>
+          typedBind(tree)
 
-            // @M TODO: the compiler still bootstraps when this is commented out.. TODO: run tests
-            //context.undetparams = undets
+        case tree: Function =>
+          if (tree.symbol == NoSymbol)
+            tree.symbol = context.owner.newAnonymousFunctionValue(tree.pos)
+          typerWithLocalContext(context.makeNewScope(tree, tree.symbol))(_.typedFunction(tree, mode, pt))
 
-            // @M maybe the well-kindedness check should be done when checking the type arguments conform to the type parameters' bounds?
-            val args1 = if (sameLength(args, tparams)) map2Conserve(args, tparams) {
-              //@M! the polytype denotes the expected kind
-              (arg, tparam) => typedHigherKindedType(arg, mode, GenPolyType(tparam.typeParams, AnyClass.tpe))
-            }
-            else {
-              //@M  this branch is correctly hit for an overloaded polymorphic type. It also has to handle erroneous cases.
-              // Until the right alternative for an overloaded method is known, be very liberal,
-              // typedTypeApply will find the right alternative and then do the same check as
-              // in the then-branch above. (see pos/tcpoly_overloaded.scala)
-              // this assert is too strict: be tolerant for errors like trait A { def foo[m[x], g]=error(""); def x[g] = foo[g/*ERR: missing argument type*/] }
-              //assert(fun1.symbol.info.isInstanceOf[OverloadedType] || fun1.symbol.isError) //, (fun1.symbol,fun1.symbol.info,fun1.symbol.info.getClass,args,tparams))
-              args mapConserve (typedHigherKindedType(_, mode))
-            }
+        case tree: Match =>
+          typedVirtualizedMatch(tree)
 
-            //@M TODO: context.undetparams = undets_fun ?
-            typedTypeApply(tree, mode, fun1, args1)
-          }
-          typedTypeApply0
+        case tree: New =>
+          typedNew(tree)
+          
+        case Assign(lhs, rhs) =>
+          typedAssign(lhs, rhs)
 
-        case Apply(Block(stats, expr), args) =>
-          typed1(atPos(tree.pos)(Block(stats, Apply(expr, args) setPos tree.pos.makeTransparent)), mode, pt)
+        case AssignOrNamedArg(lhs, rhs) => // called by NamesDefaults in silent typecheck
+          typedAssign(lhs, rhs)
 
-        case Apply(fun, args) =>
-          def typedApply0 = {
-            typedApply(fun, args) match {
-              case Apply(Select(New(tpt), name), args)
-              if (tpt.tpe != null &&
-                tpt.tpe.typeSymbol == ArrayClass &&
-                args.length == 1 &&
-                erasure.GenericArray.unapply(tpt.tpe).isDefined) => // !!! todo simplify by using extractor
-              // convert new Array[T](len) to evidence[ClassTag[T]].newArray(len)
-              // convert new Array^N[T](len) for N > 1 to evidence[ClassTag[Array[...Array[T]...]]].newArray(len), where Array HK gets applied (N-1) times
-              // no more MaxArrayDims. ClassTags are flexible enough to allow creation of arrays of arbitrary dimensionality (w.r.t JVM restrictions)
-              val Some((level, componentType)) = erasure.GenericArray.unapply(tpt.tpe)
-              val tagType = List.iterate(componentType, level)(tpe => appliedType(ArrayClass.toTypeConstructor, List(tpe))).last
-              val newArrayApp = atPos(tree.pos) {
-                val tag = resolveClassTag(tree.pos, tagType)
-                if (tag.isEmpty) MissingClassTagError(tree, tagType)
-                else new ApplyToImplicitArgs(Select(tag, nme.newArray), args)
-              }
-              typed(newArrayApp, mode, pt)
-            case Apply(Select(fun, nme.apply), _) if treeInfo.isSuperConstrCall(fun) => //SI-5696
-              TooManyArgumentListsForConstructor(tree)
-            case tree1 =>
-              tree1
-          }
-          typedApply0
+        case tree: Super =>
+          typedSuper(tree)
 
-        case ApplyDynamic(qual, args) =>
-          assert(phase.erasedTypes)
-          val reflectiveCalls = !(settings.refinementMethodDispatch.value == "invoke-dynamic")
-          val qual1 = typed(qual, AnyRefClass.tpe)
-          val args1 = args mapConserve (arg => if (reflectiveCalls) typed(arg, AnyRefClass.tpe) else typed(arg))
-          treeCopy.ApplyDynamic(tree, qual1, args1) setType (if (reflectiveCalls) AnyRefClass.tpe else tree.symbol.info.resultType)
+        case tree: TypeBoundsTree =>
+          typedTypeBoundsTree(tree)
 
-        case Super(qual, mix) =>
-          typedSuper(qual, mix)
+        case tree: Typed =>
+          typedTyped(tree)
 
-        case This(qual) =>
-          typedThis(qual)
+        case tree: ClassDef =>
+          newTyper(context.makeNewScope(tree, sym)).typedClassDef(tree)
 
-        case Select(qual @ Super(_, _), nme.CONSTRUCTOR) =>
-          val qual1 =
-            typed(qual, EXPRmode | QUALmode | POLYmode | SUPERCONSTRmode, WildcardType)
-          // the qualifier type of a supercall constructor is its first parent class
-          typedSelect(qual1, nme.CONSTRUCTOR)
+        case tree: ModuleDef =>
+          newTyper(context.makeNewScope(tree, sym.moduleClass)).typedModuleDef(tree)
 
-        case Select(qual, name) =>
-          def typedSelect0 = {
-            Statistics.incCounter(typedSelectCount)
-            var qual1 = checkDead(typedQualifier(qual, mode))
-            if (name.isTypeName) qual1 = checkStable(qual1)
+        case tree: TypeDef =>
+          typedTypeDef(tree)
 
-            val tree1 = // temporarily use `filter` and an alternative for `withFilter`
-              if (name == nme.withFilter)
-                silent(_ => typedSelect(qual1, name)) match {
-                  case SilentResultValue(result) =>
-                    result
-                  case _ =>
-                    silent(_ => typed1(Select(qual1, nme.filter) setPos tree.pos, mode, pt)) match {
-                      case SilentResultValue(result2) =>
-                        unit.deprecationWarning(
-                          tree.pos, "`withFilter' method does not yet exist on " + qual1.tpe.widen +
-                            ", using `filter' method instead")
-                        result2
-                      case SilentTypeError(err) =>
-                        WithFilterError(tree, err)
-                    }
-                }
-              else
-                typedSelect(qual1, name)
+        case tree: LabelDef =>
+          labelTyper(tree).typedLabelDef(tree)
 
-            if (tree.isInstanceOf[PostfixSelect])
-              checkFeature(tree.pos, PostfixOpsFeature, name.decode)
-            if (tree1.symbol != null && tree1.symbol.isOnlyRefinementMember)
-              checkFeature(tree1.pos, ReflectiveCallsFeature, tree1.symbol.toString)
+        case tree: PackageDef =>
+          typedPackageDef(tree)
 
-            if (qual1.hasSymbolWhich(_.isRootPackage)) treeCopy.Ident(tree1, name)
-            else tree1
-          }
-          typedSelect0
+        case tree: DocDef =>
+         typedDocDef(tree)
 
-        case Ident(name) =>
-          Statistics.incCounter(typedIdentCount)
-          if ((name == nme.WILDCARD && (mode & (PATTERNmode | FUNmode)) == PATTERNmode) ||
-            (name == tpnme.WILDCARD && (mode & TYPEmode) != 0))
-            tree setType makeFullyDefined(pt)
-          else
-            typedIdent(name)
+        case tree: Annotated =>
+          typedAnnotated(tree)
 
-        case ReferenceToBoxed(idt @ Ident(_)) =>
-          val id1 = typed1(idt, mode, pt) match { case id: Ident => id }
-          val tpe = capturedVariableType(idt.symbol, erasedTypes = phase.erasedTypes)
-          treeCopy.ReferenceToBoxed(tree, id1) setType tpe
+        case tree: SingletonTypeTree =>
+          typedSingletonTypeTree(tree)
 
-        case Literal(value) =>
-          tree setType (
-            if (value.tag == UnitTag) UnitClass.tpe
-            else ConstantType(value))
+        case tree: SelectFromTypeTree =>
+          typedSelectFromTypeTree(tree)
 
-        case SingletonTypeTree(ref) =>
-          val ref1 = checkStable(
-            typed(ref, EXPRmode | QUALmode | (mode & TYPEPATmode), AnyRefClass.tpe))
-          tree setType ref1.tpe.resultType
+        case tree: CompoundTypeTree =>
+          typedCompoundTypeTree(tree)
 
-        case SelectFromTypeTree(qual, selector) =>
-          val qual1 = typedType(qual, mode)
-          if (qual1.tpe.isVolatile) TypeSelectionFromVolatileTypeError(tree, qual1)
-          else typedSelect(qual1, selector)
+        case tree: ExistentialTypeTree =>
+          typedExistentialTypeTree(tree)
 
-        case CompoundTypeTree(templ) =>
-          typedCompoundTypeTree(templ)
+        case tree: Return =>
+          typedReturn(tree)
 
-        case AppliedTypeTree(tpt, args) =>
-          typedAppliedTypeTree(tpt, args)
+        case tree: Try =>
+          typedTry(tree)
 
-        case TypeBoundsTree(lo, hi) =>
-          val lo1 = typedType(lo, mode)
-          val hi1 = typedType(hi, mode)
-          treeCopy.TypeBoundsTree(tree, lo1, hi1) setType TypeBounds(lo1.tpe, hi1.tpe)
+        case tree: Throw =>
+          typedThrow(tree)
 
-        case etpt @ ExistentialTypeTree(_, _) =>
-          val tree1 = typerWithLocalContext(context.makeNewScope(tree, context.owner)){
-            _.typedExistentialTypeTree(etpt, mode)
-          }
-          checkExistentialsFeature(tree1.pos, tree1.tpe, "the existential type")
-          tree1
+        case tree: Alternative =>
+          typedAlternative(tree)
 
-        case dc@TypeTreeWithDeferredRefCheck() => dc // TODO: should we re-type the wrapped tree? then we need to change TypeTreeWithDeferredRefCheck's representation to include the wrapped tree explicitly (instead of in its closure)
-        case tpt @ TypeTree() =>
-          if (tpt.original != null)
-            tree setType typedType(tpt.original, mode).tpe
-          else
-            // we should get here only when something before failed
-            // and we try again (@see tryTypedApply). In that case we can assign
-            // whatever type to tree; we just have to survive until a real error message is issued.
-            tree setType AnyClass.tpe
-        case Import(expr, selectors) =>
+        case tree: Star =>
+          typedStar(tree)
+
+        case tree: UnApply =>
+          typedUnApply(tree)
+
+        case tree: ArrayValue =>
+          typedArrayValue(tree)
+
+        case tree: ApplyDynamic =>
+          typedApplyDynamic(tree)
+
+        case tree: ReferenceToBoxed =>
+          typedReferenceToBoxed(tree)
+
+        case tree: TypeTreeWithDeferredRefCheck => 
+          tree // TODO: should we re-type the wrapped tree? then we need to change TypeTreeWithDeferredRefCheck's representation to include the wrapped tree explicitly (instead of in its closure)
+
+        case tree: Import =>
           assert(forInteractive, "!forInteractive") // should not happen in normal circumstances.
           tree setType tree.symbol.tpe
+
         case _ =>
           abort("unexpected tree: " + tree.getClass + "\n" + tree)//debug
       }

--- a/src/library/scala/collection/LinearSeqOptimized.scala
+++ b/src/library/scala/collection/LinearSeqOptimized.scala
@@ -82,17 +82,6 @@ trait LinearSeqOptimized[+A, +Repr <: LinearSeqOptimized[A, Repr]] extends Linea
     false
   }
 
-  override /*TraversableLike*/
-  def count(p: A => Boolean): Int = {
-    var these = this
-    var cnt = 0
-    while (!these.isEmpty) {
-      if (p(these.head)) cnt += 1
-      these = these.tail
-    }
-    cnt
-  }
-
   override /*SeqLike*/
   def contains(elem: Any): Boolean = {
     var these = this
@@ -123,53 +112,6 @@ trait LinearSeqOptimized[+A, +Repr <: LinearSeqOptimized[A, Repr]] extends Linea
     }
     acc
   }
-  
-  override /*TraversableLike*/
-  def map[B, That](f: A => B)(implicit bf: CanBuildFrom[Repr, B, That]): That = {
-    val b = bf(repr)
-    b.sizeHint(this)
-    var these = this
-    while (!these.isEmpty) {
-      b += f(these.head)
-      these = these.tail
-    }
-    b.result
-  }
-  
-  override /*TraversableLike*/
-  def flatMap[B, That](f: A => GenTraversableOnce[B])(implicit bf: CanBuildFrom[Repr, B, That]): That = {
-    val b = bf(repr)
-    var these = this
-    while (!these.isEmpty) {
-      b ++= f(these.head).seq
-      these = these.tail
-    }
-    b.result
-  }
-  
-  override /*TraversableLike*/
-  def filter(p: A => Boolean): Repr = {
-    val b = newBuilder
-    var these = this
-    while (!these.isEmpty) {
-      val x = these.head
-      if (p(x)) b += x
-      these = these.tail
-    }
-    b.result
-  }  
-  
-  override /*TraversableLike*/
-  def filterNot(p: A => Boolean): Repr = {
-    val b = newBuilder
-    var these = this
-    while (!these.isEmpty) {
-      val x = these.head
-      if (!p(x)) b += x
-      these = these.tail
-    }
-    b.result
-  }  
   
   override /*IterableLike*/
   def foldRight[B](z: B)(f: (A, B) => B): B =

--- a/src/library/scala/collection/LinearSeqOptimized.scala
+++ b/src/library/scala/collection/LinearSeqOptimized.scala
@@ -93,6 +93,16 @@ trait LinearSeqOptimized[+A, +Repr <: LinearSeqOptimized[A, Repr]] extends Linea
     cnt
   }
 
+  override /*SeqLike*/
+  def contains(elem: Any): Boolean = {
+    var these = this
+    while (!these.isEmpty) {
+      if (these.head == elem) return true
+      these = these.tail
+    }
+    false
+  }
+  
   override /*IterableLike*/
   def find(p: A => Boolean): Option[A] = {
     var these = this
@@ -113,7 +123,54 @@ trait LinearSeqOptimized[+A, +Repr <: LinearSeqOptimized[A, Repr]] extends Linea
     }
     acc
   }
-
+  
+  override /*TraversableLike*/
+  def map[B, That](f: A => B)(implicit bf: CanBuildFrom[Repr, B, That]): That = {
+    val b = bf(repr)
+    b.sizeHint(this)
+    var these = this
+    while (!these.isEmpty) {
+      b += f(these.head)
+      these = these.tail
+    }
+    b.result
+  }
+  
+  override /*TraversableLike*/
+  def flatMap[B, That](f: A => GenTraversableOnce[B])(implicit bf: CanBuildFrom[Repr, B, That]): That = {
+    val b = bf(repr)
+    var these = this
+    while (!these.isEmpty) {
+      b ++= f(these.head).seq
+      these = these.tail
+    }
+    b.result
+  }
+  
+  override /*TraversableLike*/
+  def filter(p: A => Boolean): Repr = {
+    val b = newBuilder
+    var these = this
+    while (!these.isEmpty) {
+      val x = these.head
+      if (p(x)) b += x
+      these = these.tail
+    }
+    b.result
+  }  
+  
+  override /*TraversableLike*/
+  def filterNot(p: A => Boolean): Repr = {
+    val b = newBuilder
+    var these = this
+    while (!these.isEmpty) {
+      val x = these.head
+      if (!p(x)) b += x
+      these = these.tail
+    }
+    b.result
+  }  
+  
   override /*IterableLike*/
   def foldRight[B](z: B)(f: (A, B) => B): B =
     if (this.isEmpty) z

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -302,6 +302,15 @@ sealed abstract class List[+A] extends AbstractSeq[A]
     if (isEmpty) Stream.Empty
     else new Stream.Cons(head, tail.toStream)
 
+  @inline override final
+  def foreach[B](f: A => B) {
+    var these = this
+    while (!these.isEmpty) {
+      f(these.head)
+      these = these.tail
+    }
+  }
+
   @deprecated("use `distinct` instead", "2.8.0")
   def removeDuplicates: List[A] = distinct
 }
@@ -378,7 +387,6 @@ final case class ::[B](private var hd: B, private[scala] var tl: List[B]) extend
     while (!xs.isEmpty) { out.writeObject(xs.head); xs = xs.tail }
     out.writeObject(ListSerializeEnd)
   }
-
 }
 
 /** $factoryInfo

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -310,6 +310,62 @@ sealed abstract class List[+A] extends AbstractSeq[A]
       these = these.tail
     }
   }
+  
+  @inline override /*TraversableLike*/
+  def map[B, That](f: A => B)(implicit bf: CanBuildFrom[List[A], B, That]): That = {
+    val b = bf(repr)
+    var these = this
+    while (!these.isEmpty) {
+      b += f(these.head)
+      these = these.tail
+    }
+    b.result
+  }
+  
+  @inline override /*TraversableLike*/
+  def flatMap[B, That](f: A => GenTraversableOnce[B])(implicit bf: CanBuildFrom[List[A], B, That]): That = {
+    val b = bf(repr)
+    var these = this
+    while (!these.isEmpty) {
+      b ++= f(these.head).seq
+      these = these.tail
+    }
+    b.result
+  }
+  
+  @inline override /*TraversableLike*/
+  def filter(p: A => Boolean): List[A] = {
+    val b = newBuilder
+    var these = this
+    while (!these.isEmpty) {
+      val x = these.head
+      if (p(x)) b += x
+      these = these.tail
+    }
+    b.result
+  }  
+  
+  @inline override /*TraversableLike*/
+  def filterNot(p: A => Boolean): List[A] = {
+    val b = newBuilder
+    var these = this
+    while (!these.isEmpty) {
+      val x = these.head
+      if (!p(x)) b += x
+      these = these.tail
+    }
+    b.result
+  }  
+
+  @inline override /*SeqLike*/
+  def contains(elem: Any): Boolean = {
+    var these = this
+    while (!these.isEmpty) {
+      if (these.head == elem) return true
+      these = these.tail
+    }
+    false
+  }
 
   @deprecated("use `distinct` instead", "2.8.0")
   def removeDuplicates: List[A] = distinct

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -310,62 +310,6 @@ sealed abstract class List[+A] extends AbstractSeq[A]
       these = these.tail
     }
   }
-  
-  @inline override /*TraversableLike*/
-  def map[B, That](f: A => B)(implicit bf: CanBuildFrom[List[A], B, That]): That = {
-    val b = bf(repr)
-    var these = this
-    while (!these.isEmpty) {
-      b += f(these.head)
-      these = these.tail
-    }
-    b.result
-  }
-  
-  @inline override /*TraversableLike*/
-  def flatMap[B, That](f: A => GenTraversableOnce[B])(implicit bf: CanBuildFrom[List[A], B, That]): That = {
-    val b = bf(repr)
-    var these = this
-    while (!these.isEmpty) {
-      b ++= f(these.head).seq
-      these = these.tail
-    }
-    b.result
-  }
-  
-  @inline override /*TraversableLike*/
-  def filter(p: A => Boolean): List[A] = {
-    val b = newBuilder
-    var these = this
-    while (!these.isEmpty) {
-      val x = these.head
-      if (p(x)) b += x
-      these = these.tail
-    }
-    b.result
-  }  
-  
-  @inline override /*TraversableLike*/
-  def filterNot(p: A => Boolean): List[A] = {
-    val b = newBuilder
-    var these = this
-    while (!these.isEmpty) {
-      val x = these.head
-      if (!p(x)) b += x
-      these = these.tail
-    }
-    b.result
-  }  
-
-  @inline override /*SeqLike*/
-  def contains(elem: Any): Boolean = {
-    var these = this
-    while (!these.isEmpty) {
-      if (these.head == elem) return true
-      these = these.tail
-    }
-    false
-  }
 
   @deprecated("use `distinct` instead", "2.8.0")
   def removeDuplicates: List[A] = distinct

--- a/src/library/scala/util/hashing/MurmurHash3.scala
+++ b/src/library/scala/util/hashing/MurmurHash3.scala
@@ -157,6 +157,20 @@ private[hashing] class MurmurHash3 {
     // Finalization
     finalizeHash(h, data.length)
   }
+
+  final def listHash(xs: collection.immutable.List[_], seed: Int): Int = {
+    var n = 0
+    var h = seed
+    var elems = xs
+    while (!elems.isEmpty) {
+      val head = elems.head
+      val tail = elems.tail
+      h = mix(h, head.##)
+      n += 1
+      elems = tail
+    }
+    finalizeHash(h, n)
+  }
 }
 
 /**
@@ -199,7 +213,11 @@ object MurmurHash3 extends MurmurHash3 {
 
   /** To offer some potential for optimization.
    */
-  def seqHash(xs: collection.Seq[_]): Int    = orderedHash(xs, seqSeed)
+  def seqHash(xs: collection.Seq[_]): Int    = xs match {
+    case xs: List[_] => listHash(xs, seqSeed)
+    case xs => orderedHash(xs, seqSeed)
+  }
+
   def mapHash(xs: collection.Map[_, _]): Int = unorderedHash(xs, mapSeed)
   def setHash(xs: collection.Set[_]): Int    = unorderedHash(xs, setSeed)
 

--- a/src/reflect/scala/reflect/internal/AnnotationInfos.scala
+++ b/src/reflect/scala/reflect/internal/AnnotationInfos.scala
@@ -8,6 +8,7 @@ package internal
 
 import util._
 import pickling.ByteCodecs
+import scala.annotation.tailrec
 
 /** AnnotationInfo and its helpers */
 trait AnnotationInfos extends api.AnnotationInfos { self: SymbolTable =>
@@ -31,11 +32,27 @@ trait AnnotationInfos extends api.AnnotationInfos { self: SymbolTable =>
       case AnnotationInfo(tp, Literal(Constant(tpe: Type)) :: Nil, _) if tp.typeSymbol == ThrowsClass => tpe.typeSymbol
     }
 
-    /** Test for, get, or remove an annotation */
-    def hasAnnotation(cls: Symbol) = annotations exists (_ matches cls)
-    def getAnnotation(cls: Symbol) = annotations find (_ matches cls)
+    /** Tests for, get, or remove an annotation */    
+    def hasAnnotation(cls: Symbol): Boolean =
+      //OPT inlined from exists to save on #closures; was:  annotations exists (_ matches cls)
+      dropOtherAnnotations(annotations, cls).nonEmpty
+
+    def getAnnotation(cls: Symbol): Option[AnnotationInfo] =
+      //OPT inlined from exists to save on #closures; was:  annotations find (_ matches cls)
+      dropOtherAnnotations(annotations, cls) match {
+        case ann :: _ => Some(ann)
+        case _ => None
+      }
+    
     def removeAnnotation(cls: Symbol): Self = filterAnnotations(ann => !(ann matches cls))
+    
     final def withAnnotation(annot: AnnotationInfo): Self = withAnnotations(List(annot))
+
+    @tailrec private 
+    def dropOtherAnnotations(anns: List[AnnotationInfo], cls: Symbol): List[AnnotationInfo] = anns match {
+      case ann :: rest => if (ann matches cls) anns else dropOtherAnnotations(rest, cls)
+      case Nil => Nil
+    }
   }
 
   /** Arguments to classfile annotations (which are written to

--- a/src/reflect/scala/reflect/internal/BaseTypeSeqs.scala
+++ b/src/reflect/scala/reflect/internal/BaseTypeSeqs.scala
@@ -39,8 +39,8 @@ trait BaseTypeSeqs {
    */
   class BaseTypeSeq protected[BaseTypeSeqs] (private[BaseTypeSeqs] val parents: List[Type], private[BaseTypeSeqs] val elems: Array[Type]) {
   self =>
-    Statistics.incCounter(baseTypeSeqCount)
-    Statistics.incCounter(baseTypeSeqLenTotal, elems.length)
+    if (Statistics.canEnable) Statistics.incCounter(baseTypeSeqCount)
+    if (Statistics.canEnable) Statistics.incCounter(baseTypeSeqLenTotal, elems.length)
 
     /** The number of types in the sequence */
     def length: Int = elems.length

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -759,7 +759,7 @@ trait Definitions extends api.StandardDefinitions {
     // java.lang.Object.  Java also special cases the return type.
     lazy val Any_getClass     = enterNewMethod(AnyClass, nme.getClass_, Nil, getMemberMethod(ObjectClass, nme.getClass_).tpe.resultType, DEFERRED)
     lazy val Any_isInstanceOf = newT1NullaryMethod(AnyClass, nme.isInstanceOf_, FINAL)(_ => booltype)
-    lazy val Any_asInstanceOf = newT1NullaryMethod(AnyClass, nme.asInstanceOf_, FINAL)(_.typeConstructor)
+    lazy val Any_asInstanceOf = newT1NullaryMethod(AnyClass, nme.asInstanceOf_, FINAL)(typeConstructorOfSymbol)
 
   // A type function from T => Class[U], used to determine the return
     // type of getClass calls.  The returned type is:
@@ -851,7 +851,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val Object_eq = enterNewMethod(ObjectClass, nme.eq, anyrefparam, booltype, FINAL)
     lazy val Object_ne = enterNewMethod(ObjectClass, nme.ne, anyrefparam, booltype, FINAL)
     lazy val Object_isInstanceOf = newT1NoParamsMethod(ObjectClass, nme.isInstanceOf_Ob, FINAL | SYNTHETIC)(_ => booltype)
-    lazy val Object_asInstanceOf = newT1NoParamsMethod(ObjectClass, nme.asInstanceOf_Ob, FINAL | SYNTHETIC)(_.typeConstructor)
+    lazy val Object_asInstanceOf = newT1NoParamsMethod(ObjectClass, nme.asInstanceOf_Ob, FINAL | SYNTHETIC)(typeConstructorOfSymbol)
     lazy val Object_synchronized = newPolyMethod(1, ObjectClass, nme.synchronized_, FINAL)(tps =>
       (Some(List(tps.head.typeConstructor)), tps.head.typeConstructor)
     )

--- a/src/reflect/scala/reflect/internal/Importers.scala
+++ b/src/reflect/scala/reflect/internal/Importers.scala
@@ -238,7 +238,7 @@ trait Importers { self: SymbolTable =>
         case from.AntiPolyType(pre, targs) =>
           AntiPolyType(importType(pre), targs map importType)
         case x: from.TypeVar =>
-          TypeVar(importType(x.origin), importTypeConstraint(x.constr0), x.typeArgs map importType, x.params map importSymbol)
+          TypeVar(importType(x.origin), importTypeConstraint(x.constr), x.typeArgs map importType, x.params map importSymbol)
         case from.NotNullType(tpe) =>
           NotNullType(importType(tpe))
         case from.AnnotatedType(annots, tpe, selfsym) =>

--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -415,9 +415,6 @@ trait Names extends api.Names with LowPriorityNames {
       }
       else toString
     }
-    
-    @inline
-    final def fingerPrint: Long = (1L << start)
 
     /** TODO - find some efficiency. */
     def append(ch: Char)        = newName("" + this + ch)

--- a/src/reflect/scala/reflect/internal/Scopes.scala
+++ b/src/reflect/scala/reflect/internal/Scopes.scala
@@ -43,13 +43,8 @@ trait Scopes extends api.Scopes { self: SymbolTable =>
    */
   class Scope protected[Scopes] (initElems: ScopeEntry = null, initFingerPrints: Long = 0L) extends ScopeBase with MemberScopeBase {
 
-    /** A bitset containing the last 6 bits of the start value of every name
-     *  stored in this scope.
-     */
-    var fingerPrints: Long = initFingerPrints
-
     protected[Scopes] def this(base: Scope) = {
-      this(base.elems, base.fingerPrints)
+      this(base.elems)
       nestinglevel = base.nestinglevel + 1
     }
 
@@ -119,7 +114,6 @@ trait Scopes extends api.Scopes { self: SymbolTable =>
      *  @param sym ...
      */
     def enter[T <: Symbol](sym: T): T = {
-      fingerPrints |= sym.name.fingerPrint
       enterEntry(newScopeEntry(sym, this))
       sym
     }
@@ -156,7 +150,6 @@ trait Scopes extends api.Scopes { self: SymbolTable =>
     }
 
     def rehash(sym: Symbol, newname: Name) {
-      fingerPrints |= newname.fingerPrint
       if (hashtable ne null) {
         val index = sym.name.start & HASHMASK
         var e1 = hashtable(index)

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -72,11 +72,13 @@ abstract class SymbolTable extends macros.Universe
     Console.err.println(msg + ": " + result)
     result
   }
-  private[scala] def logResult[T](msg: String)(result: T): T = {
+  @inline
+  final private[scala] def logResult[T](msg: => String)(result: T): T = {
     log(msg + ": " + result)
     result
   }
-  private[scala] def logResultIf[T](msg: String, cond: T => Boolean)(result: T): T = {
+  @inline
+  final private[scala] def logResultIf[T](msg: => String, cond: T => Boolean)(result: T): T = {
     if (cond(result))
       log(msg + ": " + result)
 

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -3219,6 +3219,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
   private[scala] final val symbolIsNonVariant = (sym: Symbol) => sym.variance == 0
   private[scala] final val typeConstructorOfSymbol = (sym: Symbol) => sym.typeConstructor
   private[scala] final val tpeOfSymbol = (sym: Symbol) => sym.tpe
+  private[scala] final val infoOfSymbol = (sym: Symbol) => sym.info
   private[scala] final val tpeHKOfSymbol = (sym: Symbol) => sym.tpeHK
 
   @tailrec private[scala] final

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2884,7 +2884,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     }
 
     override def name: TypeName = {
-      Statistics.incCounter(nameCount)
+      if (Statistics.canEnable) Statistics.incCounter(nameCount)
       if (needsFlatClasses) {
         if (flatname eq null)
           flatname = nme.flattenedName(rawowner.name, rawname).toTypeName

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -1378,8 +1378,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     /** The value parameter sections of this symbol.
      */
     def paramss: List[List[Symbol]] = info.paramss
-    def hasParamWhich(cond: Symbol => Boolean) = mexists(paramss)(cond)
-
+    
     /** The least proper supertype of a class; includes all parent types
      *  and refinement where needed. You need to compute that in a situation like this:
      *  {

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -19,7 +19,7 @@ trait Trees extends api.Trees { self: SymbolTable =>
     val id = nodeCount // TODO: add to attachment?
     nodeCount += 1
 
-    Statistics.incCounter(TreesStats.nodeByType, getClass)
+    if (Statistics.canEnable) Statistics.incCounter(TreesStats.nodeByType, getClass)
 
     @inline final override def pos: Position = rawatt.pos
 

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -1540,6 +1540,12 @@ trait Trees extends api.Trees { self: SymbolTable =>
       sys.error("Not a LabelDef: " + t + "/" + t.getClass)
   }
 
+// ----- Hoisted closures and convenience methods, for compile time reductions -------
+
+  private[scala] final val tpeOfTree = (tree: Tree) => tree.tpe
+
+// -------------- Classtags --------------------------------------------------------
+
   implicit val TreeTag = ClassTag[Tree](classOf[Tree])
   implicit val TermTreeTag = ClassTag[TermTree](classOf[TermTree])
   implicit val TypTreeTag = ClassTag[TypTree](classOf[TypTree])

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -29,7 +29,7 @@ trait Trees extends api.Trees { self: SymbolTable =>
     def setType(tp: Type): this.type = { rawtpe = tp; this }
     def defineType(tp: Type): this.type = setType(tp)
 
-    def symbol: Symbol = null
+    def symbol: Symbol = null //!!!OPT!!! symbol is about 3% of hot compile times -- megamorphic dispatch?
     def symbol_=(sym: Symbol) { throw new UnsupportedOperationException("symbol_= inapplicable for " + this) }
     def setSymbol(sym: Symbol): this.type = { symbol = sym; this }
     def hasSymbol = false

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1240,7 +1240,7 @@ trait Types extends api.Types { self: SymbolTable =>
 // Subclasses ------------------------------------------------------------
 
   trait UniqueType extends Product {
-    final override val hashCode = scala.runtime.ScalaRunTime._hashCode(this)
+    final override val hashCode = super.hashCode // scala.runtime.ScalaRunTime._hashCode(this)
   }
 
  /** A base class for types that defer some operations

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -363,7 +363,7 @@ trait Types extends api.Types { self: SymbolTable =>
      *  and all type parameters (if any) are invariant.
      */
     def isFinalType =
-      typeSymbol.isFinal && (typeSymbol.typeParams forall (_.variance == 0))
+      typeSymbol.isFinal && (typeSymbol.typeParams forall symbolIsNonVariant)
 
     /** Is this type completed (i.e. not a lazy type)? */
     def isComplete: Boolean = true
@@ -484,7 +484,7 @@ trait Types extends api.Types { self: SymbolTable =>
     /** A list of placeholder types derived from the type parameters.
      *  Used by RefinedType and TypeRef.
      */
-    protected def dummyArgs: List[Type] = typeParams map (_.typeConstructor)
+    protected def dummyArgs: List[Type] = typeParams map typeConstructorOfSymbol
 
     /** For a (nullary) method or poly type, its direct result type,
      *  the type itself for all other types. */
@@ -835,7 +835,7 @@ trait Types extends api.Types { self: SymbolTable =>
         case (TypeRef(_, ArrayClass, List(arg1)), TypeRef(_, ArrayClass, List(arg2))) if arg2.typeSymbol.typeParams.nonEmpty =>
           arg1 matchesPattern arg2
         case (_, TypeRef(_, _, args)) =>
-          val newtp = existentialAbstraction(args map (_.typeSymbol), that)
+          val newtp = existentialAbstraction(args map typeSymbolOfType, that)
           !(that =:= newtp) && (this <:< newtp)
         case _ =>
           false
@@ -1495,8 +1495,8 @@ trait Types extends api.Types { self: SymbolTable =>
     }
     private def lowerString = if (emptyLowerBound) "" else " >: " + lo
     private def upperString = if (emptyUpperBound) "" else " <: " + hi
-    private def emptyLowerBound = lo.typeSymbolDirect eq NothingClass
-    private def emptyUpperBound = hi.typeSymbolDirect eq AnyClass
+    private def emptyLowerBound = typeIsNothing(lo)
+    private def emptyUpperBound = typeIsAny(hi)
     def isEmptyBounds = emptyLowerBound && emptyUpperBound
 
     // override def isNullable: Boolean = NullClass.tpe <:< lo;
@@ -1706,7 +1706,7 @@ trait Types extends api.Types { self: SymbolTable =>
 
     override def isHigherKinded = (
       parents.nonEmpty &&
-      (parents forall (_.isHigherKinded)) &&
+      (parents forall typeIsHigherKinded) &&
       !phase.erasedTypes
     )
 
@@ -1716,7 +1716,7 @@ trait Types extends api.Types { self: SymbolTable =>
 
     //@M may result in an invalid type (references to higher-order args become dangling )
     override def typeConstructor =
-      copyRefinedType(this, parents map (_.typeConstructor), decls)
+      copyRefinedType(this, parents map typeConstructorOfType, decls)
 
     final override def normalize: Type =
       if (phase.erasedTypes) normalizeImpl
@@ -2540,7 +2540,7 @@ trait Types extends api.Types { self: SymbolTable =>
 
     override def paramss: List[List[Symbol]] = params :: resultType.paramss
 
-    override lazy val paramTypes = params map (_.tpe)
+    override lazy val paramTypes = params map tpeOfSymbol
 
     override def boundSyms = resultType.boundSyms ++ params
 
@@ -3240,7 +3240,7 @@ trait Types extends api.Types { self: SymbolTable =>
       if (constr.instValid) constr.inst
       // get here when checking higher-order subtyping of the typevar by itself
       // TODO: check whether this ever happens?
-      else if (isHigherKinded) typeFun(params, applyArgs(params map (_.typeConstructor)))
+      else if (isHigherKinded) typeFun(params, applyArgs(params map typeConstructorOfSymbol))
       else super.normalize
     )
     override def typeSymbol = origin.typeSymbol
@@ -3625,7 +3625,7 @@ trait Types extends api.Types { self: SymbolTable =>
         val bounds   = args map (TypeBounds upper _)
         foreach2(eparams, bounds)(_ setInfo _)
 
-        newExistentialType(eparams, typeRef(pre, sym, eparams map (_.tpe)))
+        newExistentialType(eparams, typeRef(pre, sym, eparams map tpeOfSymbol))
       case _ =>
         appliedType(tycon, args)
     }
@@ -3862,8 +3862,8 @@ trait Types extends api.Types { self: SymbolTable =>
      *  guarding addLoBound/addHiBound somehow broke raw types so it
      *  only guards against being created with them.]
      */
-    private var lobounds = lo0 filterNot (_.typeSymbolDirect eq NothingClass)
-    private var hibounds = hi0 filterNot (_.typeSymbolDirect eq AnyClass)
+    private var lobounds = lo0 filterNot typeIsNothing
+    private var hibounds = hi0 filterNot typeIsAny
     private var numlo = numlo0
     private var numhi = numhi0
     private var avoidWidening = avoidWidening0
@@ -3919,8 +3919,8 @@ trait Types extends api.Types { self: SymbolTable =>
 
     override def toString = {
       val boundsStr = {
-        val lo    = loBounds filterNot (_.typeSymbolDirect eq NothingClass)
-        val hi    = hiBounds filterNot (_.typeSymbolDirect eq AnyClass)
+        val lo    = loBounds filterNot typeIsNothing
+        val hi    = hiBounds filterNot typeIsAny
         val lostr = if (lo.isEmpty) Nil else List(lo.mkString(" >: (", ", ", ")"))
         val histr = if (hi.isEmpty) Nil else List(hi.mkString(" <: (", ", ", ")"))
 
@@ -4281,7 +4281,7 @@ trait Types extends api.Types { self: SymbolTable =>
         else try {
           expanded += sym
           val eparams = mapOver(typeParamsToExistentials(sym))
-          existentialAbstraction(eparams, typeRef(apply(pre), sym, eparams map (_.tpe)))
+          existentialAbstraction(eparams, typeRef(apply(pre), sym, eparams map tpeOfSymbol))
         } finally {
           expanded -= sym
         }
@@ -5904,7 +5904,8 @@ trait Types extends api.Types { self: SymbolTable =>
       def specializedBy(membr: Symbol): Boolean =
         membr == sym || specializesSym(tp.narrow, membr, sym.owner.thisType, sym, depth)
       val member = tp.nonPrivateMember(sym.name)
-      if (member.isOverloaded) member.alternatives exists specializedBy
+      if (member eq NoSymbol) false
+      else if (member.isOverloaded) member.alternatives exists specializedBy
       else specializedBy(member)
       // was
       // (tp.nonPrivateMember(sym.name).alternatives exists
@@ -6224,8 +6225,8 @@ trait Types extends api.Types { self: SymbolTable =>
    */
   private def lubList(ts: List[Type], depth: Int): List[Type] = {
     // Matching the type params of one of the initial types means dummies.
-    val initialTypeParams = ts map (_.typeParams)
-    def isHotForTs(xs: List[Type]) = initialTypeParams contains xs.map(_.typeSymbol)
+    val initialTypeParams = ts map typeParamsOfType
+    def isHotForTs(xs: List[Type]) = initialTypeParams contains (xs map typeSymbolOfType)
 
     def elimHigherOrderTypeParam(tp: Type) = tp match {
       case TypeRef(pre, sym, args) if args.nonEmpty && isHotForTs(args) => tp.typeConstructor
@@ -6458,8 +6459,8 @@ trait Types extends api.Types { self: SymbolTable =>
         val tparams1 = map2(tparams, matchingBounds(ts, tparams).transpose)((tparam, bounds) =>
           tparam.cloneSymbol.setInfo(glb(bounds, depth)))
         PolyType(tparams1, lub0(matchingInstTypes(ts, tparams1)))
-      case ts @ MethodType(params, _) :: rest =>
-        MethodType(params, lub0(matchingRestypes(ts, params map (_.tpe))))
+      case ts @ (mt @ MethodType(params, _)) :: rest =>
+        MethodType(params, lub0(matchingRestypes(ts, mt.paramTypes)))
       case ts @ NullaryMethodType(_) :: rest =>
         NullaryMethodType(lub0(matchingRestypes(ts, Nil)))
       case ts @ TypeBounds(_, _) :: rest =>
@@ -6613,8 +6614,8 @@ trait Types extends api.Types { self: SymbolTable =>
         val tparams1 = map2(tparams, matchingBounds(ts, tparams).transpose)((tparam, bounds) =>
           tparam.cloneSymbol.setInfo(lub(bounds, depth)))
         PolyType(tparams1, glbNorm(matchingInstTypes(ts, tparams1), depth))
-      case ts @ MethodType(params, _) :: rest =>
-        MethodType(params, glbNorm(matchingRestypes(ts, params map (_.tpe)), depth))
+      case ts @ (mt @ MethodType(params, _)) :: rest =>
+        MethodType(params, glbNorm(matchingRestypes(ts, mt.paramTypes), depth))
       case ts @ NullaryMethodType(_) :: rest =>
         NullaryMethodType(glbNorm(matchingRestypes(ts, Nil), depth))
       case ts @ TypeBounds(_, _) :: rest =>
@@ -6877,7 +6878,7 @@ trait Types extends api.Types { self: SymbolTable =>
    */
   private def matchingRestypes(tps: List[Type], pts: List[Type]): List[Type] =
     tps map {
-      case MethodType(params1, res) if (isSameTypes(params1 map (_.tpe), pts)) =>
+      case mt @ MethodType(params1, res) if isSameTypes(mt.paramTypes, pts) =>
         res
       case NullaryMethodType(res) if pts.isEmpty =>
         res
@@ -6991,27 +6992,28 @@ trait Types extends api.Types { self: SymbolTable =>
 
 // ----- Hoisted closures and convenience methods, for compile time reductions -------
 
-  private val typeIsNotNull = (tp: Type) => tp.isNotNull
-  private val symbolIsPossibleInRefinement = (sym: Symbol) => sym.isPossibleInRefinement
-  private val isTypeVar = (tp: Type) => tp.isInstanceOf[TypeVar]
-  private val typeContainsTypeVar = (tp: Type) => tp exists isTypeVar
-  private val typeIsNonClassType = (tp: Type) => tp.typeSymbolDirect.isNonClassType
-  private val typeIsExistentiallyBound = (tp: Type) => tp.typeSymbol.isExistentiallyBound
-  private val typeSymbolOfType = (tp: Type) => tp.typeSymbol
-  private val typeIsErroneous = (tp: Type) => tp.isErroneous
-  private val typeHasAnnotations = (tp: Type) => tp.annotations.nonEmpty
-  private val boundsContainType = (bounds: TypeBounds, tp: Type) => bounds containsType tp
-  private val typeListIsEmpty = (ts: List[Type]) => ts.isEmpty
-  private val typeIsSubTypeOfSerializable = (tp: Type) => tp <:< SerializableClass.tpe
+  private[scala] val typeIsNotNull = (tp: Type) => tp.isNotNull
+  private[scala] val isTypeVar = (tp: Type) => tp.isInstanceOf[TypeVar]
+  private[scala] val typeContainsTypeVar = (tp: Type) => tp exists isTypeVar
+  private[scala] val typeIsNonClassType = (tp: Type) => tp.typeSymbolDirect.isNonClassType
+  private[scala] val typeIsExistentiallyBound = (tp: Type) => tp.typeSymbol.isExistentiallyBound
+  private[scala] val typeIsErroneous = (tp: Type) => tp.isErroneous
+  private[scala] val typeIsError = (tp: Type) => tp.isError
+  private[scala] val typeHasAnnotations = (tp: Type) => tp.annotations.nonEmpty
+  private[scala] val boundsContainType = (bounds: TypeBounds, tp: Type) => bounds containsType tp
+  private[scala] val typeListIsEmpty = (ts: List[Type]) => ts.isEmpty
+  private[scala] val typeIsSubTypeOfSerializable = (tp: Type) => tp <:< SerializableClass.tpe
+  private[scala] val typeIsNothing = (tp: Type) => tp.typeSymbolDirect eq NothingClass
+  private[scala] val typeIsAny = (tp: Type) => tp.typeSymbolDirect eq AnyClass
+  private[scala] val typeIsHigherKinded = (tp: Type) => tp.isHigherKinded
+
+  private[scala] val typeSymbolOfType = (tp: Type) => tp.typeSymbol
+  private[scala] val typeParamsOfType = (tp: Type) => tp.typeParams
+  private[scala] val typeConstructorOfType = (tp: Type) => tp.typeConstructor
 
   @tailrec private def typesContain(tps: List[Type], sym: Symbol): Boolean = tps match {
     case tp :: rest => (tp contains sym) || typesContain(rest, sym)
     case _ => false
-  }
-
-  @tailrec private def allSymbolsHaveOwner(syms: List[Symbol], owner: Symbol): Boolean = syms match {
-    case sym :: rest => sym.owner == owner && allSymbolsHaveOwner(rest, owner)
-    case _ => true
   }
 
 // -------------- Classtags --------------------------------------------------------

--- a/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
+++ b/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
@@ -769,8 +769,21 @@ abstract class UnPickler /*extends reflect.generic.UnPickler*/ {
     }
 
     /* Read a reference to a pickled item */
+    protected def readSymbolRef(): Symbol             = {//OPT inlined from: at(readNat(), readSymbol) to save on closure creation
+      val i = readNat()
+      var r = entries(i)
+      if (r eq null) {
+        val savedIndex = readIndex
+        readIndex = index(i)
+        r = readSymbol()
+        assert(entries(i) eq null, entries(i))
+        entries(i) = r
+        readIndex = savedIndex
+      }
+      r.asInstanceOf[Symbol]
+    }
+    
     protected def readNameRef(): Name                 = at(readNat(), readName)
-    protected def readSymbolRef(): Symbol             = at(readNat(), readSymbol)
     protected def readTypeRef(): Type                 = at(readNat(), () => readType()) // after the NMT_TRANSITION period, we can leave off the () => ... ()
     protected def readConstantRef(): Constant         = at(readNat(), readConstant)
     protected def readAnnotationRef(): AnnotationInfo = at(readNat(), readAnnotation)

--- a/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
+++ b/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
@@ -677,7 +677,7 @@ abstract class UnPickler /*extends reflect.generic.UnPickler*/ {
           val args = until(end, readTreeRef)
           if (fun.symbol.isOverloaded) {
             fun.setType(fun.symbol.info)
-            inferMethodAlternative(fun, args map (_.tpe), tpe)
+            inferMethodAlternative(fun, args map tpeOfTree, tpe)
           }
           Apply(fun, args)
 

--- a/src/reflect/scala/reflect/internal/transform/Erasure.scala
+++ b/src/reflect/scala/reflect/internal/transform/Erasure.scala
@@ -141,7 +141,7 @@ trait Erasure {
           if (restpe.typeSymbol == UnitClass) erasedTypeRef(UnitClass)
           // this replaces each typeref that refers to an argument
           // by the type `p.tpe` of the actual argument p (p in params)
-          else apply(mt.resultType(params map (_.tpe))))
+          else apply(mt.resultType(mt.paramTypes)))
       case RefinedType(parents, decls) =>
         apply(mergeParents(parents))
       case AnnotatedType(_, atp, _) =>
@@ -220,7 +220,7 @@ trait Erasure {
         MethodType(
           cloneSymbolsAndModify(params, specialErasureAvoiding(clazz, _)),
           if (restpe.typeSymbol == UnitClass) erasedTypeRef(UnitClass)
-          else specialErasureAvoiding(clazz, (mt.resultType(params map (_.tpe)))))
+          else specialErasureAvoiding(clazz, (mt.resultType(mt.paramTypes))))
       case TypeRef(pre, `clazz`, args) =>
         typeRef(pre, clazz, List())
       case _ =>

--- a/src/reflect/scala/reflect/internal/util/Statistics.scala
+++ b/src/reflect/scala/reflect/internal/util/Statistics.scala
@@ -236,6 +236,23 @@ quant)
 
   private var _enabled = false
   private val qs = new mutable.HashMap[String, Quantity]
+ 
+  /** replace with 
+   * 
+   *    final val canEnable = true
+   *    
+   *  and rebuild, to allow for statistics to be enabled
+   */  
+  final val canEnable = false 
+  
+  /** replace with 
+   * 
+   *   final def hotEnabled = _enabled
+   *   
+   * and rebuild, to also count tiny but super-hot methods
+   * such as phase, flags, owner, name.
+   */
+  final val hotEnabled = false
 
   def enabled = _enabled
   def enabled_=(cond: Boolean) = {
@@ -253,9 +270,4 @@ quant)
       _enabled = true
     }
   }
-
-  /** replace rhs with enabled and rebuild to also count tiny but super-hot methods
-   * such as phase, flags, owner, name.
-   */
-  final val hotEnabled = false
 }

--- a/src/reflect/scala/reflect/internal/util/ThreeValues.scala
+++ b/src/reflect/scala/reflect/internal/util/ThreeValues.scala
@@ -1,0 +1,14 @@
+package scala.reflect.internal.util
+
+/** A simple three value type for booleans with an unknown value */
+object ThreeValues {
+
+  type ThreeValue = Byte
+
+  final val YES = 1
+  final val NO = -1
+  final val UNKNOWN = 0
+
+  @inline def fromBoolean(b: Boolean): ThreeValue = if (b) YES else NO
+  @inline def toBoolean(x: ThreeValue): Boolean = x == YES
+}

--- a/src/reflect/scala/reflect/runtime/SynchronizedTypes.scala
+++ b/src/reflect/scala/reflect/runtime/SynchronizedTypes.scala
@@ -14,15 +14,10 @@ trait SynchronizedTypes extends internal.Types { self: SymbolTable =>
   override def unique[T <: Type](tp: T): T = uniqueLock.synchronized { super.unique(tp) }
 
   class SynchronizedUndoLog extends UndoLog {
+    private val actualLock = new java.util.concurrent.locks.ReentrantLock
 
-    override def clear() =
-      synchronized { super.clear() }
-
-    override def undo[T](block: => T): T =
-      synchronized { super.undo(block) }
-
-    override def undoUnless(block: => Boolean): Boolean =
-      synchronized { super.undoUnless(block) }
+    final override protected def lock(): Unit = actualLock.lock()
+    final override protected def unlock(): Unit = actualLock.unlock()
   }
 
   override protected def newUndoLog = new SynchronizedUndoLog

--- a/src/reflect/scala/reflect/runtime/SynchronizedTypes.scala
+++ b/src/reflect/scala/reflect/runtime/SynchronizedTypes.scala
@@ -16,8 +16,8 @@ trait SynchronizedTypes extends internal.Types { self: SymbolTable =>
   class SynchronizedUndoLog extends UndoLog {
     private val actualLock = new java.util.concurrent.locks.ReentrantLock
 
-    final override protected def lock(): Unit = actualLock.lock()
-    final override protected def unlock(): Unit = actualLock.unlock()
+    final override def lock(): Unit = actualLock.lock()
+    final override def unlock(): Unit = actualLock.unlock()
   }
 
   override protected def newUndoLog = new SynchronizedUndoLog


### PR DESCRIPTION
Here's the combined effort of Greg and myself this week to make the compiler faster. Overall we seem to be getting between 10 and 15%. We still need to do analysis to find out what optimizations were most beneficial. 

Some optimizations are beneficial for cold compilers and compilers warming up (this is what we see in the Scala build for instance). In particular method splitting seems to help. Other optimizations seem to mostly help in stable state when the compiler is fully jitted. These are harder to predict and often not intuitive at all. For instance method specialization might actually slow down the speed because it makes callsites polymorphic.

Review by @paulp @gkossakowski
