### PR TITLE
Fix/try catch libs

### DIFF
--- a/test/files/run/try-catch-unify.check
+++ b/test/files/run/try-catch-unify.check
@@ -1,0 +1,3 @@
+Failure(java.lang.NumberFormatException: For input string: "Hi")
+Success(5.0)
+O NOES

--- a/test/files/run/try-catch-unify.scala
+++ b/test/files/run/try-catch-unify.scala
@@ -1,0 +1,15 @@
+import util._
+
+import control.Exception._
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    println(catching(classOf[NumberFormatException]) withTry ("Hi".toDouble))
+    println(catching(classOf[NumberFormatException]) withTry ("5".toDouble))
+    try {
+      catching(classOf[NumberFormatException]) withTry (sys.error("O NOES"))
+    } catch {
+       case t => println(t.getMessage)
+    }
+  }
+}


### PR DESCRIPTION
This unifies the difference between `scala.util.Try` and `scala.util.control.Exception`.  They both serve useful purposes, and this patch can unify them.   See the test for an example of how.

Review by @heathermiller
