### PR TITLE
SI-6258 Reject partial funs with undefined param types

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2394,7 +2394,7 @@ trait Typers extends Modes with Adaptations with Tags {
         else targs.init
 
       def mkParams(methodSym: Symbol, formals: List[Type] = deriveFormals) =
-        if (formals.isEmpty) { MissingParameterTypeAnonMatchError(tree, pt); Nil }
+        if (formals.isEmpty || !formals.forall(isFullyDefined)) { MissingParameterTypeAnonMatchError(tree, pt); Nil }
         else methodSym newSyntheticValueParams formals
 
       def mkSel(params: List[Symbol]) =

--- a/test/files/neg/t6258.check
+++ b/test/files/neg/t6258.check
@@ -1,0 +1,16 @@
+t6258.scala:2: error: missing parameter type for expanded function
+The argument types of an anonymous function must be fully known. (SLS 8.5)
+Expected type was: PartialFunction[?, Int]
+	val f : PartialFunction[_, Int] = { case a : Int => a } // undefined param
+                                          ^
+t6258.scala:5: error: missing parameter type for expanded function
+The argument types of an anonymous function must be fully known. (SLS 8.5)
+Expected type was: PartialFunction[?,Int]
+	foo { case a : Int => a } // undefined param
+            ^
+t6258.scala:22: error: missing parameter type for expanded function
+The argument types of an anonymous function must be fully known. (SLS 8.5)
+Expected type was: PartialFunction[?,Any]
+  bar[M[Any]] (foo { // undefined param
+                   ^
+three errors found

--- a/test/files/neg/t6258.scala
+++ b/test/files/neg/t6258.scala
@@ -1,0 +1,25 @@
+object Test {
+	val f : PartialFunction[_, Int] = { case a : Int => a } // undefined param
+
+	def foo[A](pf: PartialFunction[A, Int]) {};
+	foo { case a : Int => a } // undefined param
+
+	val g : PartialFunction[Int, _] = { case a : Int => a } // okay
+}
+
+
+// Another variation, seen in the wild with Specs2.
+class X {
+  trait Matcher[-T]
+
+  def bar[T](m: Matcher[T]) = null
+  def bar[T](i: Int) = null
+
+  def foo[T](p: PartialFunction[T, Any]): Matcher[T] = null
+
+  case class M[X](a: X)
+
+  bar[M[Any]] (foo { // undefined param
+    case M(_) => null
+  })
+}


### PR DESCRIPTION
This regressed with virtpatmat.

With -Xoldpatmat, pattern matching anonymous functions with
an expected type of PartialFunction[A, B] are translated to
a Function tree, and typed by typedFunction, which issues an
error of the parameter types are not fully defined.

This commit adds the same check to MatchFunTyper.

It doesn't plug the hole in RefChecks#validateVariance (which is
reminiscent of SI-3577.) Seems to me that in general one should handle:
  a) both BoundedWildcardType and WildcardType
     when in a place that can be called during inference, or
  b) neither otherwise

I'm submitting to 2.10.x seeing as it's a regression and the fix is trivial.

Review by @paulp
