### PR TITLE
Si 6261

### DIFF
--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -230,6 +230,7 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
 
   private[collection] class HashMapCollision1[A, +B](private[collection] val hash: Int, val kvs: ListMap[A, B @uV])
           extends HashMap[A, B @uV] {
+    assert(kvs.size > 1)
 
     override def size = kvs.size
 
@@ -277,6 +278,9 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
     private[collection] val elems: Array[HashMap[A, B @uV]],
     private[collection] val size0: Int
   ) extends HashMap[A, B @uV] {
+
+    assert(Integer.bitCount(bitmap) == elems.length)
+    assert(elems.length > 1 || (elems.length == 1 && elems(0).isInstanceOf[HashTrieMap[_,_]]))
 
 /*
     def this (level: Int, m1: HashMap1[A,B], m2: HashMap1[A,B]) = {

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -359,6 +359,8 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
               new HashTrieMap(bitmapNew, elemsNew, sizeNew)
           } else
             HashMap.empty[A,B]
+        } else if(elems.length == 1 && !subNew.isInstanceOf[HashTrieMap[_,_]]) {
+          subNew
         } else {
           val elemsNew = new Array[HashMap[A,B]](elems.length)
           Array.copy(elems, 0, elemsNew, 0, elems.length)

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -248,10 +248,13 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
     override def removed0(key: A, hash: Int, level: Int): HashMap[A, B] =
       if (hash == this.hash) {
         val kvs1 = kvs - key
-        if (!kvs1.isEmpty)
-          new HashMapCollision1(hash, kvs1)
-        else
+        if (kvs1.isEmpty)
           HashMap.empty[A,B]
+        else if(kvs1.tail.isEmpty) {
+          val kv = kvs1.head
+          new HashMap1[A,B](kv._1,hash,kv._2,kv)
+        } else
+          new HashMapCollision1(hash, kvs1)
       } else this
 
     override def iterator: Iterator[(A,B)] = kvs.iterator

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -230,7 +230,7 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
 
   private[collection] class HashMapCollision1[A, +B](private[collection] val hash: Int, val kvs: ListMap[A, B @uV])
           extends HashMap[A, B @uV] {
-    assert(kvs.size > 1)
+    // assert(kvs.size > 1)
 
     override def size = kvs.size
 
@@ -279,8 +279,8 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
     private[collection] val size0: Int
   ) extends HashMap[A, B @uV] {
 
-    assert(Integer.bitCount(bitmap) == elems.length)
-    assert(elems.length > 1 || (elems.length == 1 && elems(0).isInstanceOf[HashTrieMap[_,_]]))
+    // assert(Integer.bitCount(bitmap) == elems.length)
+    // assert(elems.length > 1 || (elems.length == 1 && elems(0).isInstanceOf[HashTrieMap[_,_]]))
 
 /*
     def this (level: Int, m1: HashMap1[A,B], m2: HashMap1[A,B]) = {

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -221,7 +221,7 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
     // this method may be called multiple times in a multithreaded environment, but that's ok
     private[HashMap] def ensurePair: (A,B) = if (kv ne null) kv else { kv = (key, value); kv }
     protected override def merge0[B1 >: B](that: HashMap[A, B1], level: Int, merger: Merger[A, B1]): HashMap[A, B1] = {
-      that.updated0(key, hash, level, value, kv, if (merger ne null) merger.invert else null)
+      that.updated0(key, hash, level, value, kv, merger.invert)
     }
   }
 
@@ -486,7 +486,7 @@ time { mNew.iterator.foreach( p => ()) }
         }
 
         new HashTrieMap[A, B1](this.bitmap | that.bitmap, merged, totalelems)
-      case hm: HashMapCollision1[_, _] => that.merge0(this, level, if (merger ne null) merger.invert else null)
+      case hm: HashMapCollision1[_, _] => that.merge0(this, level, merger.invert)
       case hm: HashMap[_, _] => this
       case _ => sys.error("section supposed to be unreachable.")
     }

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -350,7 +350,10 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
             Array.copy(elems, 0, elemsNew, 0, offset)
             Array.copy(elems, offset + 1, elemsNew, offset, elems.length - offset - 1)
             val sizeNew = size - sub.size
-            new HashTrieMap(bitmapNew, elemsNew, sizeNew)
+            if (elemsNew.length == 1 && !elemsNew(0).isInstanceOf[HashTrieMap[_,_]])
+              elemsNew(0)
+            else
+              new HashTrieMap(bitmapNew, elemsNew, sizeNew)
           } else
             HashMap.empty[A,B]
         } else {

--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -121,12 +121,12 @@ extends AbstractMap[A, B]
       def hasNext = !self.isEmpty
       def next(): (A,B) =
         if (!hasNext) throw new NoSuchElementException("next on empty iterator")
-        else { val res = (self.key, self.value); self = self.next; res }
+        else { val res = (self.key, self.value); self = self.tail; res }
     }.toList.reverseIterator
 
   protected def key: A = throw new NoSuchElementException("empty map")
   protected def value: B = throw new NoSuchElementException("empty map")
-  protected def next: ListMap[A, B] = throw new NoSuchElementException("empty map")
+  override def tail: ListMap[A, B] = throw new NoSuchElementException("empty map")
 
   /** This class represents an entry in the `ListMap`.
    */
@@ -140,7 +140,7 @@ extends AbstractMap[A, B]
     override def size: Int = size0(this, 0)
 
     // to allow tail recursion and prevent stack overflows
-    @tailrec private def size0(cur: ListMap[A, B1], acc: Int): Int = if (cur.isEmpty) acc else size0(cur.next, acc + 1)
+    @tailrec private def size0(cur: ListMap[A, B1], acc: Int): Int = if (cur.isEmpty) acc else size0(cur.tail, acc + 1)
 
     /** Is this an empty map?
      *
@@ -157,7 +157,7 @@ extends AbstractMap[A, B]
      */
     override def apply(k: A): B1 = apply0(this, k)
 
-    @tailrec private def apply0(cur: ListMap[A, B1], k: A): B1 = if (k == cur.key) cur.value else apply0(cur.next, k)
+    @tailrec private def apply0(cur: ListMap[A, B1], k: A): B1 = if (k == cur.key) cur.value else apply0(cur.tail, k)
 
     /** Checks if this map maps `key` to a value and return the
      *  value if it exists.
@@ -169,7 +169,7 @@ extends AbstractMap[A, B]
 
     @tailrec private def get0(cur: ListMap[A, B1], k: A): Option[B1] =
       if (k == cur.key) Some(cur.value)
-      else if (cur.next.nonEmpty) get0(cur.next, k) else None
+      else if (cur.tail.nonEmpty) get0(cur.tail, k) else None
 
     /** This method allows one to create a new map with an additional mapping
      *  from `key` to `value`. If the map contains already a mapping for `key`,
@@ -198,7 +198,7 @@ extends AbstractMap[A, B]
       var lst: List[(A, B1)] = Nil
       while (cur.nonEmpty) {
         if (k != cur.key) lst ::= ((cur.key, cur.value))
-        cur = cur.next
+        cur = cur.tail
       }
       var acc = ListMap[A, B1]()
       while (lst != Nil) {
@@ -211,6 +211,6 @@ extends AbstractMap[A, B]
     }
 
 
-    override protected def next: ListMap[A, B1] = ListMap.this
+    override def tail: ListMap[A, B1] = ListMap.this
   }
 }

--- a/test/files/run/t6261.scala
+++ b/test/files/run/t6261.scala
@@ -2,6 +2,12 @@ import scala.collection.immutable._
 
 object Test extends App {
 
+  def test0() {
+    val m=ListMap(1->2,3->4)
+    if(m.tail ne m.tail)
+      println("ListMap.tail uses a builder, so it is not O(1)")
+  }
+
   def test1() {
     // test that a HashTrieMap with one leaf element is not created!
     val x = HashMap.empty + (1->1) + (2->2)
@@ -86,6 +92,7 @@ object Test extends App {
     // StructureTests.printStructure(z)
     require(z.size == 2 && z.contains(a._1) && z.contains(c._1))
   }
+  test0()
   test1()
   test2()
   test3()

--- a/test/files/run/t6261.scala
+++ b/test/files/run/t6261.scala
@@ -1,0 +1,32 @@
+import scala.collection.immutable._
+
+object Test extends App {
+
+  def test1() {
+    // test that a HashTrieMap with one leaf element is not created!
+    val x = HashMap.empty + (1->1) + (2->2)
+    if(x.getClass.getSimpleName != "HashTrieMap")
+      println("A hash map containing two non-colliding values should be a HashTrieMap")
+
+    val y = x - 1
+    if(y.getClass.getSimpleName != "HashMap1")
+      println("A hash map containing one element should always use HashMap1")
+  }
+
+  def test2() {
+    // class that always causes hash collisions
+    case class Collision(value:Int) { override def hashCode = 0 }
+
+    // create a set that should have a collison
+    val x = HashMap.empty + (Collision(0)->0) + (Collision(1) ->0)
+    if(x.getClass.getSimpleName != "HashMapCollision1")
+      println("HashMap of size >1 with collisions should use HashMapCollision")
+
+    // remove the collision again by removing all but one element
+    val y = x - Collision(0)
+    if(y.getClass.getSimpleName != "HashMap1")
+      println("HashMap of size 1 should use HashMap1" + y.getClass)
+  }
+  test1()
+  test2()
+}

--- a/test/files/run/t6261.scala
+++ b/test/files/run/t6261.scala
@@ -27,6 +27,97 @@ object Test extends App {
     if(y.getClass.getSimpleName != "HashMap1")
       println("HashMap of size 1 should use HashMap1" + y.getClass)
   }
+  def test3() {
+    // finds an int x such that improved(x) differs in the first bit to improved(0),
+    // which is the worst case for the HashTrieSet
+    def findWorstCaseInts() {
+      // copy of improve from HashSet
+      def improve(hcode: Int) = {
+        var h: Int = hcode + ~(hcode << 9)
+        h = h ^ (h >>> 14)
+        h = h + (h << 4)
+        h ^ (h >>> 10)
+      }
+
+      // find two hashes which have a large separation
+      val x = 0
+      var y = 1
+      val ix = improve(x)
+      while(y!=0 && improve(y)!=ix+(1<<31))
+        y+=1
+      printf("%s %s %x %x\n",x,y,improve(x), improve(y))
+    }
+    // this is not done every test run since it would slow down ant test.suite too much.
+    // findWorstCaseInts()
+
+    // two numbers that are immediately adiacent when fed through HashSet.improve
+    val h0 = 0
+    val h1 = 1270889724
+
+    // h is the hashcode, i is ignored for the hashcode but relevant for equality
+    case class Collision(h:Int, i:Int) {
+      override def hashCode = h
+    }
+    val a = Collision(h0,0)->0
+    val b = Collision(h0,1)->0
+    val c = Collision(h1,0)->0
+
+    // create a HashSetCollision1
+    val x = HashMap(a) + b
+    if(x.getClass.getSimpleName != "HashMapCollision1")
+      println("x should be a HashMapCollision")
+    StructureTests.validate(x)
+    //StructureTests.printStructure(x)
+    require(x.size==2 && x.contains(a._1) && x.contains(b._1))
+
+    // go from a HashSetCollision1 to a HashTrieSet with maximum depth
+    val y = x + c
+    if(y.getClass.getSimpleName != "HashTrieMap")
+      println("y should be a HashTrieMap")
+    StructureTests.validate(y)
+    // StructureTests.printStructure(y)
+    require(y.size==3 && y.contains(a._1) && y.contains(b._1) && y.contains(c._1))
+
+    // go from a HashSet1 directly to a HashTrieSet with maximum depth
+    val z = HashMap(a) + c
+    if(y.getClass.getSimpleName != "HashTrieMap")
+      println("y should be a HashTrieMap")
+    StructureTests.validate(z)
+    // StructureTests.printStructure(z)
+    require(z.size == 2 && z.contains(a._1) && z.contains(c._1))
+  }
   test1()
   test2()
+  test3()
+}
+
+
+package scala.collection.immutable {
+  object StructureTests {
+    def printStructure(x:HashMap[_,_], prefix:String="") {
+      x match {
+        case m:HashMap.HashTrieMap[_,_] =>
+          println(prefix+m.getClass.getSimpleName + " " + m.size)
+          m.elems.foreach(child => printStructure(child, prefix + "  "))
+        case m:HashMap.HashMapCollision1[_,_] =>
+          println(prefix+m.getClass.getSimpleName + " " + m.kvs.size)
+        case m:HashMap.HashMap1[_,_] =>
+          println(prefix+m.getClass.getSimpleName + " " + m.head)
+        case _ =>
+          println(prefix+"empty")
+      }
+    }
+
+    def validate(x:HashMap[_,_]) {
+      x match {
+        case m:HashMap.HashTrieMap[_,_] =>
+          require(m.elems.size>1 || (m.elems.size==1 && m.elems(0).isInstanceOf[HashMap.HashTrieMap[_,_]]))
+          m.elems.foreach(validate _)
+        case m:HashMap.HashMapCollision1[_,_] =>
+          require(m.kvs.size>1)
+        case m:HashMap.HashMap1[_,_] =>
+        case _ =>
+      }
+    }
+  }
 }


### PR DESCRIPTION
This is basically the improvements made to HashSet in SI-6197, SI-6198, SI-6220 applied to HashMap.

The test case is the same as the test cases for SI-6197, SI-6198 and SI-6220 as well.

If you want this as a single commit, or if I should create a SI for each tiny change, let me know.

I am not sure if assertions are OK in scala collections, or if they should be commented out for test performance reasons. However just having them in there commented out is preferable to not having them at all because they show very concisely the assumptions made in the data structure.
