### PR TITLE
JavaConversions: Restore source compatibility with 2.9

### DIFF
--- a/src/library/scala/collection/JavaConversions.scala
+++ b/src/library/scala/collection/JavaConversions.scala
@@ -22,7 +22,8 @@ import convert._
  *    scala.collection.mutable.Buffer <=> java.util.List
  *    scala.collection.mutable.Set <=> java.util.Set
  *    scala.collection.mutable.Map <=> java.util.{ Map, Dictionary }
- *    scala.collection.mutable.ConcurrentMap <=> java.util.concurrent.ConcurrentMap
+ *    scala.collection.mutable.ConcurrentMap (deprecated since 2.10) <=> java.util.concurrent.ConcurrentMap
+ *    scala.collection.concurrent.Map <=> java.util.concurrent.ConcurrentMap
  *}}}
  *    In all cases, converting from a source type to a target type and back
  *    again will return the original source object, eg.

--- a/src/library/scala/collection/convert/WrapAsScala.scala
+++ b/src/library/scala/collection/convert/WrapAsScala.scala
@@ -13,7 +13,27 @@ import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
 import Wrappers._
 import language.implicitConversions
 
-trait WrapAsScala {
+trait LowPriorityWrapAsScala {
+  this: WrapAsScala =>
+  /**
+   * Implicitly converts a Java ConcurrentMap to a Scala mutable ConcurrentMap.
+   * The returned Scala ConcurrentMap is backed by the provided Java
+   * ConcurrentMap and any side-effects of using it via the Scala interface will
+   * be visible via the Java interface and vice versa.
+   *
+   * If the Java ConcurrentMap was previously obtained from an implicit or
+   * explicit call of `asConcurrentMap(scala.collection.mutable.ConcurrentMap)`
+   * then the original Scala ConcurrentMap will be returned.
+   *
+   * @param m The ConcurrentMap to be converted.
+   * @return A Scala mutable ConcurrentMap view of the argument.
+   */
+  @deprecated("Use `mapAsScalaConcurrentMap` instead, and use `concurrent.Map` instead of `ConcurrentMap`.", "2.10.0")
+  implicit def mapAsScalaDeprecatedConcurrentMap[A, B](m: juc.ConcurrentMap[A, B]): mutable.ConcurrentMap[A, B] =
+    asScalaConcurrentMap(m)
+}
+
+trait WrapAsScala extends LowPriorityWrapAsScala {
   /**
    * Implicitly converts a Java `Iterator` to a Scala `Iterator`.
    *

--- a/test/files/neg/javaConversions-2.10-ambiguity.check
+++ b/test/files/neg/javaConversions-2.10-ambiguity.check
@@ -1,0 +1,6 @@
+javaConversions-2.10-ambiguity.scala:8: error: type mismatch;
+ found   : scala.collection.concurrent.Map[String,String]
+ required: scala.collection.mutable.ConcurrentMap[String,String]
+  assertType[mutable.ConcurrentMap[String, String]](a)
+                                                    ^
+one error found

--- a/test/files/neg/javaConversions-2.10-ambiguity.scala
+++ b/test/files/neg/javaConversions-2.10-ambiguity.scala
@@ -1,0 +1,10 @@
+import collection.{JavaConversions, mutable, concurrent}
+import JavaConversions._
+import java.util.concurrent.{ConcurrentHashMap => CHM}
+
+object Bar {
+  def assertType[T](t: T) = t
+  val a = new CHM[String, String]() += (("", ""))
+  assertType[mutable.ConcurrentMap[String, String]](a)
+}
+// vim: set et:

--- a/test/files/pos/javaConversions-2.10-regression.scala
+++ b/test/files/pos/javaConversions-2.10-regression.scala
@@ -1,0 +1,11 @@
+import collection.{JavaConversions, mutable}
+import JavaConversions._
+import java.util.concurrent.ConcurrentHashMap
+
+object Foo {
+  def buildCache2_9_simple[K <: AnyRef, V <: AnyRef]: mutable.ConcurrentMap[K, V] =
+    asScalaConcurrentMap(new ConcurrentHashMap())
+
+  def buildCache2_9_implicit[K <: AnyRef, V <: AnyRef]: mutable.ConcurrentMap[K, V] =
+    new ConcurrentHashMap[K, V]()
+}

--- a/test/files/pos/javaConversions-2.10-regression.scala
+++ b/test/files/pos/javaConversions-2.10-regression.scala
@@ -1,11 +1,17 @@
-import collection.{JavaConversions, mutable}
+import collection.{JavaConversions, mutable, concurrent}
 import JavaConversions._
-import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.{ConcurrentHashMap => CHM}
 
 object Foo {
   def buildCache2_9_simple[K <: AnyRef, V <: AnyRef]: mutable.ConcurrentMap[K, V] =
-    asScalaConcurrentMap(new ConcurrentHashMap())
+    asScalaConcurrentMap(new CHM())
 
   def buildCache2_9_implicit[K <: AnyRef, V <: AnyRef]: mutable.ConcurrentMap[K, V] =
-    new ConcurrentHashMap[K, V]()
+    new CHM[K, V]()
+}
+
+object Bar {
+  def assertType[T](t: T) = t
+  val a = new CHM[String, String]() += (("", ""))
+  assertType[concurrent.Map[String, String]](a)
 }


### PR DESCRIPTION
Readd an implicit conversion which was available in 2.9, the one from
`java.util.concurrent.ConcurrentMap` (`juc.ConcurrentMap`) to the (now
deprecated) type `scala.collection.mutable.ConcurrentMap`.

This implicit conversion can also be used to convert from
`juc.ConcurrentMap`
to `collection.Map` and creates an ambiguity error in
test/files/run/map_java_conversions.scala. To fix this, I have given
lower priority to the new conversion.

Moreover, update the documentation in `JavaConversions`: mark this
conversion as deprecated and mention the new conversion which replaces
it, converting to `scala.collection.concurrent.Map`.

I discussed this issue previously with Paul Phillips on scala-language:

https://groups.google.com/d/topic/scala-language/uXKRiGXb-44/discussion

Review by @axel22.
