### PR TITLE
Fix for SI-6264, crash in checkCheckable.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1373,14 +1373,17 @@ trait Infer {
             else =:=
           )
           (arg hasAnnotation UncheckedClass) || {
-            val TypeRef(_, sym, args) = arg.withoutAnnotations
-
-            (    isLocalBinding(sym)
-              || arg.typeSymbol.isTypeParameterOrSkolem
-              || (sym.name == tpnme.WILDCARD) // avoid spurious warnings on HK types
-              || check(arg, param.tpeHK, conforms)
-              || warn("non-variable type argument " + arg)
-            )
+            arg.withoutAnnotations match {
+              case TypeRef(_, sym, args) =>
+                (    isLocalBinding(sym)
+                  || arg.typeSymbol.isTypeParameterOrSkolem
+                  || (sym.name == tpnme.WILDCARD) // avoid spurious warnings on HK types
+                  || check(arg, param.tpeHK, conforms)
+                  || warn("non-variable type argument " + arg)
+                )
+              case _ =>
+                warn("non-variable type argument " + arg)
+            }
           }
         }
 

--- a/test/files/neg/t6264.check
+++ b/test/files/neg/t6264.check
@@ -1,0 +1,4 @@
+t6264.scala:3: error: non-variable type argument Tuple1[_] in type Tuple2[_, Tuple1[_]] is unchecked since it is eliminated by erasure
+    x.isInstanceOf[Tuple2[_, Tuple1[_]]]
+                  ^
+one error found

--- a/test/files/neg/t6264.flags
+++ b/test/files/neg/t6264.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/t6264.scala
+++ b/test/files/neg/t6264.scala
@@ -1,0 +1,6 @@
+class Foo {
+  def foo(x: AnyRef): Unit = {
+    x.isInstanceOf[Tuple2[_, Tuple1[_]]]
+    ()
+  }
+}


### PR DESCRIPTION
The classic fail of assuming you will only receive a
specific subclass of Type.
