### PR TITLE
exposes absTypeTag and absTypeOf

### DIFF
--- a/src/compiler/scala/reflect/macros/runtime/Aliases.scala
+++ b/src/compiler/scala/reflect/macros/runtime/Aliases.scala
@@ -21,6 +21,8 @@ trait Aliases {
   override type TypeTag[T] = universe.TypeTag[T]
   override val AbsTypeTag = universe.AbsTypeTag
   override val TypeTag = universe.TypeTag
+  override def absTypeTag[T](implicit attag: AbsTypeTag[T]) = attag
   override def typeTag[T](implicit ttag: TypeTag[T]) = ttag
+  override def absTypeOf[T](implicit attag: AbsTypeTag[T]): Type = attag.tpe
   override def typeOf[T](implicit ttag: TypeTag[T]): Type = ttag.tpe
 }

--- a/src/library/scala/reflect/base/TypeTags.scala
+++ b/src/library/scala/reflect/base/TypeTags.scala
@@ -250,9 +250,11 @@ trait TypeTags { self: Universe =>
   }
 
   // incantations
+  def absTypeTag[T](implicit attag: AbsTypeTag[T]) = attag
   def typeTag[T](implicit ttag: TypeTag[T]) = ttag
 
   // big thanks to Viktor Klang for this brilliant idea!
+  def absTypeOf[T](implicit attag: AbsTypeTag[T]): Type = attag.tpe
   def typeOf[T](implicit ttag: TypeTag[T]): Type = ttag.tpe
 }
 

--- a/src/reflect/scala/reflect/macros/Aliases.scala
+++ b/src/reflect/scala/reflect/macros/Aliases.scala
@@ -21,6 +21,8 @@ trait Aliases {
   type TypeTag[T] = universe.TypeTag[T]
   val AbsTypeTag = universe.AbsTypeTag
   val TypeTag = universe.TypeTag
+  def absTypeTag[T](implicit attag: AbsTypeTag[T]) = attag
   def typeTag[T](implicit ttag: TypeTag[T]) = ttag
+  def absTypeOf[T](implicit attag: AbsTypeTag[T]): Type = attag.tpe
   def typeOf[T](implicit ttag: TypeTag[T]): Type = ttag.tpe
 }


### PR DESCRIPTION
to be symmetric with typeTag and typeOf.

this is especially important for macro development,
since only c.AbsTypeTag context bounds can be used on macro implementations
