### PR TITLE
reverts changes to ClassTag.Nothing

### DIFF
--- a/src/library/scala/reflect/ClassTag.scala
+++ b/src/library/scala/reflect/ClassTag.scala
@@ -64,6 +64,7 @@ trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serial
 }
 
 object ClassTag {
+  private val NothingTYPE = classOf[scala.runtime.Nothing$]
   private val NullTYPE = classOf[scala.runtime.Null$]
   private val ObjectTYPE = classOf[java.lang.Object]
 
@@ -80,13 +81,7 @@ object ClassTag {
   val Object  : ClassTag[java.lang.Object] = new ClassTag[java.lang.Object]{ def runtimeClass = ObjectTYPE; private def readResolve() = ClassTag.Object }
   val AnyVal  : ClassTag[scala.AnyVal]     = ClassTag.Object.asInstanceOf[ClassTag[scala.AnyVal]]
   val AnyRef  : ClassTag[scala.AnyRef]     = ClassTag.Object.asInstanceOf[ClassTag[scala.AnyRef]]
-  val Nothing : ClassTag[scala.Nothing]    = new ClassTag[scala.Nothing]{
-    def runtimeClass = throw new Exception("Nothing is a bottom type, therefore its erasure does not return a value")
-    private def readResolve() = ClassTag.Nothing
-    override def equals(x: Any) = x.isInstanceOf[ClassTag[_]] && (x.asInstanceOf[AnyRef] eq ClassTag.Nothing)
-    override def hashCode = System.identityHashCode(this)
-    override def toString = "ClassTag[Nothing]"
-  }
+  val Nothing : ClassTag[scala.Nothing]    = new ClassTag[scala.Nothing]{ def runtimeClass = NothingTYPE; private def readResolve() = ClassTag.Nothing }
   val Null    : ClassTag[scala.Null]       = new ClassTag[scala.Null]{ def runtimeClass = NullTYPE; private def readResolve() = ClassTag.Null }
 
   def apply[T](runtimeClass1: jClass[_]): ClassTag[T] =

--- a/test/files/run/classtags_core.check
+++ b/test/files/run/classtags_core.check
@@ -27,4 +27,4 @@ ClassTag[class java.lang.Object]
 true
 ClassTag[class scala.runtime.Null$]
 true
-ClassTag[Nothing]
+ClassTag[class scala.runtime.Nothing$]


### PR DESCRIPTION
It seemed to be a good idea to have ClassTag.Nothing crash
in agreement with its incalculable nature.

However this breaks CanBuildFrom for the situations when Nothing is inferred
or provided explicitly. Hence the rollback.
