### PR TITLE
Backport "Make Stream.withFilter.{map,flatMap} run in constant stack space" against 2.9.x

### DIFF
--- a/src/library/scala/collection/immutable/Stream.scala
+++ b/src/library/scala/collection/immutable/Stream.scala
@@ -493,15 +493,6 @@ self =>
         throw new RuntimeException()
       }
 
-      /*
-      def tailMap = asStream[B](tail withFilter p map f)
-      if (isStreamBuilder(bf)) asThat(
-        if (isEmpty) Stream.Empty
-        else if (p(head)) cons(f(head), tailMap)
-        else tailMap
-        //XXX Alternative: what about having a Stream.step constructor?
-      )
-      */
       if (isStreamBuilder(bf)) asThat(tailMap(Stream.this))
       else super.map(f)(bf)
     }
@@ -521,14 +512,6 @@ self =>
         throw new RuntimeException()
       }
 
-      /*
-      def tailFlatMap = asStream[B](tail withFilter p flatMap f)
-      if (isStreamBuilder(bf)) asThat(
-        if (isEmpty) Stream.Empty
-        else if (p(head)) f(head).toStream append tailFlatMap
-        else tailFlatMap
-      )
-      */
       if (isStreamBuilder(bf)) asThat(tailFlatMap(Stream.this))
       else super.flatMap(f)(bf)
     }

--- a/test/files/run/stream-stack-overflow-filter-map.check
+++ b/test/files/run/stream-stack-overflow-filter-map.check
@@ -1,2 +1,0 @@
-Stream()
-Stream()

--- a/test/files/run/stream-stack-overflow-filter-map.check
+++ b/test/files/run/stream-stack-overflow-filter-map.check
@@ -1,0 +1,2 @@
+Stream()
+Stream()

--- a/test/files/run/stream-stack-overflow-filter-map.scala
+++ b/test/files/run/stream-stack-overflow-filter-map.scala
@@ -1,12 +1,10 @@
 object Test extends App {
-  //This runs fine.
   val resFMap1 = (1 to 10000).toStream filter (_ => false) flatMap (Seq(_))
   val resMap1 = (1 to 10000).toStream filter (_ => false) map (_ + 1)
   assert(resMap1.isEmpty)
   assert(resFMap1.isEmpty)
-  println(resMap1)
-  println(resFMap1)
-  //This will cause a stack overflow 
+
+  //This risks causing a stack overflow 
   val resFMap2 = (1 to 10000).toStream withFilter (_ => false) flatMap (Seq(_))
   val resMap2 = (1 to 10000).toStream withFilter (_ => false) map (_ + 1)
   assert(resMap1 == resMap2)

--- a/test/files/run/stream-stack-overflow-filter-map.scala
+++ b/test/files/run/stream-stack-overflow-filter-map.scala
@@ -1,12 +1,42 @@
-object Test extends App {
-  val resFMap1 = (1 to 10000).toStream filter (_ => false) flatMap (Seq(_))
-  val resMap1 = (1 to 10000).toStream filter (_ => false) map (_ + 1)
-  assert(resMap1.isEmpty)
-  assert(resFMap1.isEmpty)
+import collection.generic.{FilterMonadic, CanBuildFrom}
 
-  //This risks causing a stack overflow 
-  val resFMap2 = (1 to 10000).toStream withFilter (_ => false) flatMap (Seq(_))
-  val resMap2 = (1 to 10000).toStream withFilter (_ => false) map (_ + 1)
-  assert(resMap1 == resMap2)
-  assert(resFMap1 == resFMap2)
+object Test extends App {
+  def mapSucc[Repr, That](s: FilterMonadic[Int, Repr])(implicit cbf: CanBuildFrom[Repr, Int, That]) = s map (_ + 1)
+  def flatMapId[T, Repr, That](s: FilterMonadic[T, Repr])(implicit cbf: CanBuildFrom[Repr, T, That]) = s flatMap (Seq(_))
+
+  def testStreamPred(s: Stream[Int])(p: Int => Boolean) {
+    val res1 = s withFilter p
+    val res2 = s filter p
+
+    val expected = s.toSeq filter p
+
+    val fMapped1 = flatMapId(res1)
+    val fMapped2 = flatMapId(res2)
+    assert(fMapped1 == fMapped2)
+    assert(fMapped1.toSeq == expected)
+
+    val mapped1 = mapSucc(res1)
+    val mapped2 = mapSucc(res2)
+    assert(mapped1 == mapped2)
+    assert(mapped1.toSeq == (expected map (_ + 1)))
+
+    assert((res1 map identity).toSeq == res2.toSeq)
+  }
+
+  def testStream(s: Stream[Int]) {
+    testStreamPred(s)(_ => false)
+    testStreamPred(s)(_ => true)
+    testStreamPred(s)(_ % 2 == 0)
+    testStreamPred(s)(_ % 3 == 0)
+  }
+
+  //Reduced version of the test case - either invocation used to cause a stack
+  //overflow before commit 80b3f433e5536d086806fa108ccdfacf10719cc2.
+  val resFMap = (1 to 10000).toStream withFilter (_ => false) flatMap (Seq(_))
+  val resMap = (1 to 10000).toStream withFilter (_ => false) map (_ + 1)
+
+  //Complete test case for withFilter + map/flatMap, as requested by @axel22.
+  for (j <- (0 to 3) :+ 10000) {
+    testStream((1 to j).toStream)
+  }
 }

--- a/test/files/run/stream-stack-overflow-filter-map.scala
+++ b/test/files/run/stream-stack-overflow-filter-map.scala
@@ -37,6 +37,8 @@ object Test extends App {
 
   //Complete test case for withFilter + map/flatMap, as requested by @axel22.
   for (j <- (0 to 3) :+ 10000) {
-    testStream((1 to j).toStream)
+    val stream = (1 to j).toStream
+    assert(stream.toSeq == (1 to j).toSeq)
+    testStream(stream)
   }
 }

--- a/test/files/run/stream-stack-overflow-filter-map.scala
+++ b/test/files/run/stream-stack-overflow-filter-map.scala
@@ -1,0 +1,14 @@
+object Test extends App {
+  //This runs fine.
+  val resFMap1 = (1 to 10000).toStream filter (_ => false) flatMap (Seq(_))
+  val resMap1 = (1 to 10000).toStream filter (_ => false) map (_ + 1)
+  assert(resMap1.isEmpty)
+  assert(resFMap1.isEmpty)
+  println(resMap1)
+  println(resFMap1)
+  //This will cause a stack overflow 
+  val resFMap2 = (1 to 10000).toStream withFilter (_ => false) flatMap (Seq(_))
+  val resMap2 = (1 to 10000).toStream withFilter (_ => false) map (_ + 1)
+  assert(resMap1 == resMap2)
+  assert(resFMap1 == resFMap2)
+}


### PR DESCRIPTION
This is a backport of https://github.com/scala/scala/pull/1167. I produced the backport using `git cherry-pick` and got no conflict; I could reproduce the failure with `2.9.x` current HEAD, and no failure after applying this fix.

Review by @axel22
