### PR TITLE
SI-6052 - fix groupBy on parallel collections

### DIFF
--- a/src/library/scala/collection/parallel/immutable/ParHashMap.scala
+++ b/src/library/scala/collection/parallel/immutable/ParHashMap.scala
@@ -202,7 +202,7 @@ extends collection.parallel.BucketCombiner[(K, V), ParHashMap[K, V], (K, V), Has
   def groupByKey[Repr](cbf: () => Combiner[V, Repr]): ParHashMap[K, Repr] = {
     val bucks = buckets.filter(_ != null).map(_.headPtr)
     val root = new Array[HashMap[K, AnyRef]](bucks.length)
-
+    
     combinerTaskSupport.executeAndWaitResult(new CreateGroupedTrie(cbf, bucks, root, 0, bucks.length))
 
     var bitmap = 0
@@ -306,8 +306,7 @@ extends collection.parallel.BucketCombiner[(K, V), ParHashMap[K, V], (K, V), Has
         unrolled = unrolled.next
       }
 
-      evaluateCombiners(trie)
-      trie.asInstanceOf[HashMap[K, Repr]]
+      evaluateCombiners(trie).asInstanceOf[HashMap[K, Repr]]
     }
     private def evaluateCombiners(trie: HashMap[K, Combiner[V, Repr]]): HashMap[K, Repr] = trie match {
       case hm1: HashMap.HashMap1[_, _] =>

--- a/test/files/run/t6052.scala
+++ b/test/files/run/t6052.scala
@@ -1,0 +1,21 @@
+
+
+
+
+
+
+
+object Test extends App {
+  def seqarr(i: Int) = Array[Int]() ++ (0 until i)
+  def pararr(i: Int) = seqarr(i).par
+  
+  def check[T](i: Int, f: Int => T) {
+    val gseq = seqarr(i).toSeq.groupBy(f)
+    val gpar = pararr(i).groupBy(f)
+    assert(gseq == gpar, (gseq, gpar))
+  }
+  
+  for (i <- 0 until 20) check(i, _ > 0)
+  for (i <- 0 until 20) check(i, _ % 2)
+  for (i <- 0 until 20) check(i, _ % 4)
+}


### PR DESCRIPTION
Somehow this previously didn't make it into the 2.10.x branch.

Review by @jsuereth.
