### PR TITLE
Deprecate unmaintained/old classes for removal in 2.11

### DIFF
--- a/src/library/scala/io/BytePickle.scala
+++ b/src/library/scala/io/BytePickle.scala
@@ -19,6 +19,7 @@ import scala.collection.mutable
  * @author  Philipp Haller
  * @version 1.1
  */
+@deprecated("This class will be removed.", "2.10.0")
 object BytePickle {
   abstract class SPU[T] {
     def appP(a: T, state: PicklerState): PicklerState

--- a/src/library/scala/io/Position.scala
+++ b/src/library/scala/io/Position.scala
@@ -32,6 +32,7 @@ package scala.io
  *  }}}
  *  @author Burak Emir (translated from work by Matthias Zenger and others)
  */
+@deprecated("This class will be removed.", "2.10.0")
 abstract class Position {
   /** Definable behavior for overflow conditions.
    */

--- a/src/library/scala/io/UTF8Codec.scala
+++ b/src/library/scala/io/UTF8Codec.scala
@@ -13,6 +13,7 @@ package scala.io
  *  @author  Martin Odersky
  *  @version 1.0, 04/10/2004
  */
+@deprecated("This class will be removed.", "2.10.0")
 object UTF8Codec {
   final val UNI_REPLACEMENT_CHAR: Int = 0x0000FFFD
   final val UNI_REPLACEMENT_BYTES = Array[Byte](-17, -65, -67)

--- a/src/library/scala/testing/Benchmark.scala
+++ b/src/library/scala/testing/Benchmark.scala
@@ -33,6 +33,7 @@ import compat.Platform
  *
  *  @author Iulian Dragos, Burak Emir
  */
+@deprecated("This class will be removed.", "2.10.0")
 trait Benchmark {
 
   /** this method should be implemented by the concrete benchmark.

--- a/src/library/scala/testing/Show.scala
+++ b/src/library/scala/testing/Show.scala
@@ -25,6 +25,7 @@ package scala.testing
  *  where `&lt;result&gt;` is the result of evaluating the call.
  *
  */
+@deprecated("This class will be removed.", "2.10.0")
 trait Show {
 
   /** An implicit definition that adds an apply method to Symbol which forwards to `test`. 

--- a/src/library/scala/util/logging/ConsoleLogger.scala
+++ b/src/library/scala/util/logging/ConsoleLogger.scala
@@ -17,6 +17,7 @@ package scala.util.logging
  *  @author  Burak Emir
  *  @version 1.0
  */
+@deprecated("This class will be removed.", "2.10.0")
 trait ConsoleLogger extends Logged {
 
   /** logs argument to Console using [[scala.Console.println]]

--- a/src/library/scala/util/logging/Logged.scala
+++ b/src/library/scala/util/logging/Logged.scala
@@ -22,6 +22,7 @@ package scala.util.logging
   * }}}
   * and the logging is sent to the [[scala.util.logging.ConsoleLogger]] object.
   */
+@deprecated("This class will be removed.", "2.10.0")
 trait Logged {
   /** This method should log the message given as argument somewhere
    *  as a side-effect.


### PR DESCRIPTION
Deprecate unmaintained/undocumented/unused code.   Part 1 of 3.

review by @alex22
