### PR TITLE
SI-6280 Scaladoc: Reloading preserves anchors

### DIFF
--- a/src/compiler/scala/tools/nsc/doc/html/page/Template.scala
+++ b/src/compiler/scala/tools/nsc/doc/html/page/Template.scala
@@ -49,7 +49,11 @@ class Template(universe: doc.Universe, generator: DiagramGenerator, tpl: DocTemp
          if(top === self) {{
             var url = '{ val p = templateToPath(tpl); "../" * (p.size - 1) + "index.html" }';
             var hash = '{ val p = templateToPath(tpl); (p.tail.reverse ::: List(p.head.replace(".html", ""))).mkString(".") }';
-            window.location.href = url + '#' + hash;
+            var anchor = window.location.hash;
+            var anchor_opt = '';
+            if (anchor.length { scala.xml.Unparsed(">=") /* unless we use Unparsed, it gets escaped and crashes the script */ } 1) 
+              anchor_opt = '@' + anchor.substring(1);
+            window.location.href = url + '#' + hash + anchor_opt;
          }}
    	  </script>
     </xml:group>


### PR DESCRIPTION
Scaladoc redirects from */package.html pages to index.html with the
qualified package name as the anchor. This is done to pop up the left
navigation panel whenever someone links directly to the page. (so
users may navigate the rest of the scaladoc pages)

When linking members directly, one can use _/package.html#<signature>,
which translates to index.html#_.package@<signature>. The problem was
that the redirection javascript did not take the <signature> into
account, so it would redirect to the top of the package page instead
of scrolling to the member.

Note: this is a layout change, so there's no test for it.
