### PR TITLE
Add missing tests for SI-6190

### DIFF
--- a/test/files/jvm/future-spec/TryTests.scala
+++ b/test/files/jvm/future-spec/TryTests.scala
@@ -46,6 +46,12 @@ object TryTests extends MinimalScalaTest {
         val e2 = new Exception
         Failure[Int](e) map(_ => throw e2) mustEqual Failure(e)
       }
+      "when there is a fatal exception" in {
+        val e3 = new ThreadDeath
+        intercept[ThreadDeath] {
+          Success(1) map (_ => throw e3)
+        }
+      }
     }
 
     "flatMap" in {
@@ -59,6 +65,12 @@ object TryTests extends MinimalScalaTest {
 
         val e2 = new Exception
         Failure[Int](e).flatMap[Int](_ => throw e2) mustEqual Failure(e)
+      }
+      "when there is a fatal exception" in {
+        val e3 = new ThreadDeath
+        intercept[ThreadDeath] {
+          Success(1).flatMap[Int](_ => throw e3)
+        }
       }
     }
 


### PR DESCRIPTION
This was silently fixed in commit
3cb0e784a05db7d0b542cec9bf4c5fbf3772a6cf (https://github.com/scala/scala/commit/3cb0e784a05db7d0b542cec9bf4c5fbf3772a6cf#L4L209) but no test was added.

Closes SI-6190 (does this belong to the commit message?).

Review by @heathermiller (who authored this commit) or @phaller (maintainer of the std. library).
UPDATE: let's make that

Review by @heathermiller and @phaller.

to avoid the by-stander effect. This is also just a passing additional testcase.
