### PR TITLE
renames Symbol.kind and Type.kind in the API

### DIFF
--- a/src/reflect/scala/reflect/api/Symbols.scala
+++ b/src/reflect/scala/reflect/api/Symbols.scala
@@ -201,8 +201,15 @@ trait Symbols extends base.Symbols { self: Universe =>
      */
     def suchThat(cond: Symbol => Boolean): Symbol
 
-    /** The string discriminator of this symbol; useful for debugging */
-    def kind: String
+    /** The string discriminator of this symbol.
+     *
+     *  Useful for debugging and debug printing.
+     *
+     *  Values returned by this method should not be used to tell symbols apart.
+     *  These values can changed on a whim, depending on how the underlying implementation sees fit.
+     *  Use one of the `isXXX` methods instead (e.g. isMethod or isGetter).
+     */
+    def discr: String
   }
 
   /** The API of term symbols */

--- a/src/reflect/scala/reflect/api/Types.scala
+++ b/src/reflect/scala/reflect/api/Types.scala
@@ -160,8 +160,15 @@ trait Types extends base.Types { self: Universe =>
     /** Does this type contain a reference to given symbol? */
     def contains(sym: Symbol): Boolean
 
-    /** The string discriminator of this type; useful for debugging */
-    def kind: String
+    /** The string discriminator of this type.
+     *
+     *  Useful for debugging and debug printing.
+     *
+     *  Values returned by this method should not be used to tell symbols apart.
+     *  These values can changed on a whim, depending on how the underlying implementation sees fit.
+     *  Use pattern matching against concrete subtypes instead.
+     */
+    def discr: String
   }
 
   /** .. */

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -63,7 +63,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
   abstract class SymbolContextApiImpl extends SymbolContextApi {
     this: Symbol =>
 
-    def kind: String = kindString
+    def discr: String = accurateKindString
     def isExistential: Boolean = this.isExistentiallyBound
     def isParamWithDefault: Boolean = this.hasDefault
     def isByNameParam: Boolean = this.isValueParameter && (this hasFlag BYNAMEPARAM)

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -341,6 +341,10 @@ trait Types extends api.Types { self: SymbolTable =>
     def isSpliceable = {
       this.isInstanceOf[TypeRef] && typeSymbol.isAbstractType && !typeSymbol.isExistential
     }
+
+    // `kind` seems to be a useful name as in http://en.wikipedia.org/wiki/Kind_(type_theory)
+    // don't want to tie the reflection API to it
+    def discr = kind
   }
 
   /** The base class for all types */

--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -124,7 +124,7 @@ trait JavaMirrors extends internal.SymbolTable with api.JavaUniverse { self: Sym
     private def ErrorInnerModule(wannabe: Symbol) = throw new ScalaReflectionException(s"$wannabe is an inner module, use reflectModule on an InstanceMirror to obtain its ModuleMirror")
     private def ErrorStaticClass(wannabe: Symbol) = throw new ScalaReflectionException(s"$wannabe is a static class, use reflectClass on a RuntimeMirror to obtain its ClassMirror")
     private def ErrorStaticModule(wannabe: Symbol) = throw new ScalaReflectionException(s"$wannabe is a static module, use reflectModule on a RuntimeMirror to obtain its ModuleMirror")
-    private def ErrorNotMember(wannabe: Symbol, owner: Symbol) = throw new ScalaReflectionException(s"expected a member of $owner, you provided ${wannabe.kind} ${wannabe.fullName}")
+    private def ErrorNotMember(wannabe: Symbol, owner: Symbol) = throw new ScalaReflectionException(s"expected a member of $owner, you provided ${wannabe.kindString} ${wannabe.fullName}")
     private def ErrorNotField(wannabe: Symbol) = throw new ScalaReflectionException(s"expected a field or an accessor method symbol, you provided $wannabe")
     private def ErrorNonExistentField(wannabe: Symbol) = throw new ScalaReflectionException(s"""
       |Scala field ${wannabe.name} isn't represented as a Java field, neither it has a Java accessor method

--- a/test/files/jvm/manifests-new.scala
+++ b/test/files/jvm/manifests-new.scala
@@ -106,6 +106,6 @@ trait TestUtil {
 //    val t1: TypeTag[T] = read(write(t))
     val t1: TypeTag[T] = t
     val x1 = x.toString.replaceAll("@[0-9a-z]+$", "")
-    println("x="+x1+", t="+t1+", k="+t1.tpe.kind+", s="+t1.tpe.typeSymbol.toString)
+    println("x="+x1+", t="+t1+", k="+t1.tpe.discr+", s="+t1.tpe.typeSymbol.toString)
   }
 }

--- a/test/files/run/existentials3-new.scala
+++ b/test/files/run/existentials3-new.scala
@@ -35,7 +35,7 @@ object Test {
 
   def printTpe(t: Type) = {
     val s = if (t.typeSymbol.isFreeType) t.typeSymbol.typeSignature.toString else t.typeSymbol.toString
-    println("%s, t=%s, s=%s".format(t, t.kind, s))
+    println("%s, t=%s, s=%s".format(t, t.discr, s))
   }
   def m[T: TypeTag](x: T) = printTpe(typeOf[T])
   def m2[T: AbsTypeTag](x: T) = printTpe(implicitly[AbsTypeTag[T]].tpe)


### PR DESCRIPTION
Kind as in http://en.wikipedia.org/wiki/Kind_(type_theory) seems to be
too useful of a name to bind it to a debugging facility in the API.

I also added a comment that this facility is meant for debugging only
and should not be used to discriminate symbols/types in production code.
