### PR TITLE
removes Symbol.kind and Type.kind

### DIFF
--- a/src/reflect/scala/reflect/api/Symbols.scala
+++ b/src/reflect/scala/reflect/api/Symbols.scala
@@ -200,9 +200,6 @@ trait Symbols extends base.Symbols { self: Universe =>
     /** ...
      */
     def suchThat(cond: Symbol => Boolean): Symbol
-
-    /** The string discriminator of this symbol; useful for debugging */
-    def kind: String
   }
 
   /** The API of term symbols */

--- a/src/reflect/scala/reflect/api/Types.scala
+++ b/src/reflect/scala/reflect/api/Types.scala
@@ -159,9 +159,6 @@ trait Types extends base.Types { self: Universe =>
 
     /** Does this type contain a reference to given symbol? */
     def contains(sym: Symbol): Boolean
-
-    /** The string discriminator of this type; useful for debugging */
-    def kind: String
   }
 
   /** .. */

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -63,7 +63,6 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
   abstract class SymbolContextApiImpl extends SymbolContextApi {
     this: Symbol =>
 
-    def kind: String = kindString
     def isExistential: Boolean = this.isExistentiallyBound
     def isParamWithDefault: Boolean = this.hasDefault
     def isByNameParam: Boolean = this.isValueParameter && (this hasFlag BYNAMEPARAM)

--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -124,7 +124,7 @@ trait JavaMirrors extends internal.SymbolTable with api.JavaUniverse { self: Sym
     private def ErrorInnerModule(wannabe: Symbol) = throw new ScalaReflectionException(s"$wannabe is an inner module, use reflectModule on an InstanceMirror to obtain its ModuleMirror")
     private def ErrorStaticClass(wannabe: Symbol) = throw new ScalaReflectionException(s"$wannabe is a static class, use reflectClass on a RuntimeMirror to obtain its ClassMirror")
     private def ErrorStaticModule(wannabe: Symbol) = throw new ScalaReflectionException(s"$wannabe is a static module, use reflectModule on a RuntimeMirror to obtain its ModuleMirror")
-    private def ErrorNotMember(wannabe: Symbol, owner: Symbol) = throw new ScalaReflectionException(s"expected a member of $owner, you provided ${wannabe.kind} ${wannabe.fullName}")
+    private def ErrorNotMember(wannabe: Symbol, owner: Symbol) = throw new ScalaReflectionException(s"expected a member of $owner, you provided ${wannabe.kindString} ${wannabe.fullName}")
     private def ErrorNotField(wannabe: Symbol) = throw new ScalaReflectionException(s"expected a field or an accessor method symbol, you provided $wannabe")
     private def ErrorNonExistentField(wannabe: Symbol) = throw new ScalaReflectionException(s"""
       |Scala field ${wannabe.name} isn't represented as a Java field, neither it has a Java accessor method

--- a/test/files/jvm/manifests-new.scala
+++ b/test/files/jvm/manifests-new.scala
@@ -106,6 +106,6 @@ trait TestUtil {
 //    val t1: TypeTag[T] = read(write(t))
     val t1: TypeTag[T] = t
     val x1 = x.toString.replaceAll("@[0-9a-z]+$", "")
-    println("x="+x1+", t="+t1+", k="+t1.tpe.kind+", s="+t1.tpe.typeSymbol.toString)
+    println("x="+x1+", t="+t1+", k="+t1.tpe.asInstanceOf[Product].productPrefix+", s="+t1.tpe.typeSymbol.toString)
   }
 }

--- a/test/files/run/existentials3-new.check
+++ b/test/files/run/existentials3-new.check
@@ -1,24 +1,24 @@
-Bar.type, t=AbstractTypeRef, s= <: scala.runtime.AbstractFunction0[Bar] with Serializable{case def unapply(x$0: Bar): Boolean} with Singleton
-Bar, t=AbstractTypeRef, s= <: Test.ToS with Product with Serializable{def copy(): Bar}
+Bar.type, t=TypeRef, s= <: scala.runtime.AbstractFunction0[Bar] with Serializable{case def unapply(x$0: Bar): Boolean} with Singleton
+Bar, t=TypeRef, s= <: Test.ToS with Product with Serializable{def copy(): Bar}
 Test.ToS, t=RefinedType, s=f3
 Test.ToS, t=RefinedType, s=f4
 Test.ToS, t=RefinedType, s=f5
 () => Test.ToS, t=TypeRef, s=class Function0
 () => Test.ToS, t=TypeRef, s=class Function0
-$anon, t=AbstractTypeRef, s= <: B with Test.ToS
-$anon, t=AbstractTypeRef, s= <: B with A with Test.ToS
+$anon, t=TypeRef, s= <: B with Test.ToS
+$anon, t=TypeRef, s= <: B with A with Test.ToS
 List[java.lang.Object{type T1}#T1], t=TypeRef, s=class List
 List[Seq[Int]], t=TypeRef, s=class List
 List[Seq[U forSome { type U <: Int }]], t=TypeRef, s=class List
-Bar.type, t=AbstractTypeRef, s= <: scala.runtime.AbstractFunction0[Bar] with Serializable{case def unapply(x$0: Bar): Boolean} with Singleton
-Bar, t=AbstractTypeRef, s= <: Test.ToS with Product with Serializable{def copy(): Bar}
+Bar.type, t=TypeRef, s= <: scala.runtime.AbstractFunction0[Bar] with Serializable{case def unapply(x$0: Bar): Boolean} with Singleton
+Bar, t=TypeRef, s= <: Test.ToS with Product with Serializable{def copy(): Bar}
 Test.ToS, t=RefinedType, s=g3
 Test.ToS, t=RefinedType, s=g4
 Test.ToS, t=RefinedType, s=g5
 () => Test.ToS, t=TypeRef, s=class Function0
 () => Test.ToS, t=TypeRef, s=class Function0
-$anon, t=AbstractTypeRef, s= <: B with Test.ToS
-$anon, t=AbstractTypeRef, s= <: B with A with Test.ToS
+$anon, t=TypeRef, s= <: B with Test.ToS
+$anon, t=TypeRef, s= <: B with A with Test.ToS
 List[java.lang.Object{type T1}#T1], t=TypeRef, s=class List
 List[Seq[Int]], t=TypeRef, s=class List
 List[Seq[U forSome { type U <: Int }]], t=TypeRef, s=class List

--- a/test/files/run/existentials3-new.scala
+++ b/test/files/run/existentials3-new.scala
@@ -35,7 +35,7 @@ object Test {
 
   def printTpe(t: Type) = {
     val s = if (t.typeSymbol.isFreeType) t.typeSymbol.typeSignature.toString else t.typeSymbol.toString
-    println("%s, t=%s, s=%s".format(t, t.kind, s))
+    println("%s, t=%s, s=%s".format(t, t.asInstanceOf[Product].productPrefix, s))
   }
   def m[T: TypeTag](x: T) = printTpe(typeOf[T])
   def m2[T: AbsTypeTag](x: T) = printTpe(implicitly[AbsTypeTag[T]].tpe)


### PR DESCRIPTION
use Universe.showRaw instead:

scala> import scala.reflect.runtime.{universe => ru}
import scala.reflect.runtime.{universe=>ru}

scala> ru.showRaw(typeOf[Int])
res0: String = TypeRef(ThisType(scala), scala.Int, List())

scala> ru.showRaw(typeOf[Int].typeSymbol, printKinds = true)
res1: String = scala.Int#CLS
