### PR TITLE
Fixes SI-6279.

### DIFF
--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -190,10 +190,10 @@ trait TraversableLike[+A, +Repr] extends Any
    *    @return       a new $coll which contains all elements of this $coll
    *                  followed by all elements of `that`.
    */
-  def ++:[B >: A, That](that: TraversableOnce[B])(implicit bf: CanBuildFrom[Repr, B, That]): That = {
+  def ++:[B >: A, That](that: GenTraversableOnce[B])(implicit bf: CanBuildFrom[Repr, B, That]): That = {
     val b = bf(repr)
     if (that.isInstanceOf[IndexedSeqLike[_, _]]) b.sizeHint(this, that.size)
-    b ++= that
+    b ++= that.seq
     b ++= thisCollection
     b.result
   }

--- a/src/library/scala/collection/convert/Wrappers.scala
+++ b/src/library/scala/collection/convert/Wrappers.scala
@@ -89,7 +89,7 @@ private[collection] trait Wrappers {
     def update(i: Int, elem: A) = underlying.set(i, elem)
     def +=:(elem: A) = { underlying.subList(0, 0) add elem; this }
     def +=(elem: A): this.type = { underlying add elem; this }
-    def insertAll(i: Int, elems: Traversable[A]) = {
+    def insertAll(i: Int, elems: GenTraversable[A]) = {
       val ins = underlying.subList(0, i)
       elems.seq.foreach(ins.add(_))
     }

--- a/src/library/scala/collection/generic/GenTraversableFactory.scala
+++ b/src/library/scala/collection/generic/GenTraversableFactory.scala
@@ -69,13 +69,13 @@ abstract class GenTraversableFactory[CC[X] <: GenTraversable[X] with GenericTrav
    *  @param xss the collections that are to be concatenated.
    *  @return the concatenation of all the collections.
    */
-  def concat[A](xss: Traversable[A]*): CC[A] = {
+  def concat[A](xss: GenTraversable[A]*): CC[A] = {
     val b = newBuilder[A]
     // At present we're using IndexedSeq as a proxy for "has a cheap size method".
     if (xss forall (_.isInstanceOf[IndexedSeq[_]]))
       b.sizeHint(xss.map(_.size).sum)
 
-    for (xs <- xss.seq) b ++= xs
+    for (xs <- xss.seq) b ++= xs.seq
     b.result
   }
 

--- a/src/library/scala/collection/generic/Growable.scala
+++ b/src/library/scala/collection/generic/Growable.scala
@@ -45,7 +45,7 @@ trait Growable[-A] extends Clearable {
    *  @param xs   the TraversableOnce producing the elements to $add.
    *  @return  the $coll itself.
    */
-  def ++=(xs: TraversableOnce[A]): this.type = { xs.seq foreach += ; this }
+  def ++=(xs: GenTraversableOnce[A]): this.type = { xs.seq foreach += ; this }
 
   /** Clears the $coll's contents. After this operation, the
    *  $coll is empty.

--- a/src/library/scala/collection/generic/Shrinkable.scala
+++ b/src/library/scala/collection/generic/Shrinkable.scala
@@ -46,7 +46,7 @@ trait Shrinkable[-A] {
    *  @param xs   the iterator producing the elements to remove.
    *  @return the $coll itself
    */
-  def --=(xs: TraversableOnce[A]): this.type = { xs.seq foreach -= ; this }
+  def --=(xs: GenTraversableOnce[A]): this.type = { xs.seq foreach -= ; this }
 }
 
 

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -724,7 +724,7 @@ final class VectorBuilder[A]() extends Builder[A,Vector[A]] with VectorPointer[A
     this
   }
 
-  override def ++=(xs: TraversableOnce[A]): this.type =
+  override def ++=(xs: GenTraversableOnce[A]): this.type =
     super.++=(xs)
 
   def result: Vector[A] = {

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -92,7 +92,7 @@ class ArrayBuffer[A](override protected val initialSize: Int)
    *  @param xs    the traversable object.
    *  @return      the updated buffer.
    */
-  override def ++=(xs: TraversableOnce[A]): this.type = xs match {
+  override def ++=(xs: GenTraversableOnce[A]): this.type = xs.seq match {
     case v: collection.IndexedSeqLike[_, _] =>
       val n = v.length
       ensureSize(size0 + n)
@@ -124,7 +124,7 @@ class ArrayBuffer[A](override protected val initialSize: Int)
    *  @param xs    the traversable object.
    *  @return      the updated buffer.
    */
-  override def ++=:(xs: TraversableOnce[A]): this.type = { insertAll(0, xs.toTraversable); this }
+  override def ++=:(xs: GenTraversableOnce[A]): this.type = { insertAll(0, xs.seq.toTraversable); this }
 
   /** Inserts new elements at the index `n`. Opposed to method
    *  `update`, this method will not replace an element with a
@@ -134,9 +134,9 @@ class ArrayBuffer[A](override protected val initialSize: Int)
    *  @param seq   the traversable object providing all elements to insert.
    *  @throws Predef.IndexOutOfBoundsException if `n` is out of bounds.
    */
-  def insertAll(n: Int, seq: Traversable[A]) {
+  def insertAll(n: Int, genseq: GenTraversable[A]) {
     if (n < 0 || n > size0) throw new IndexOutOfBoundsException(n.toString)
-    val xs = seq.toList
+    val xs = genseq.toList
     val len = xs.length
     ensureSize(size0 + len)
     copy(n, n + len, size0 - n)

--- a/src/library/scala/collection/mutable/ArrayBuilder.scala
+++ b/src/library/scala/collection/mutable/ArrayBuilder.scala
@@ -90,7 +90,7 @@ object ArrayBuilder {
       this
     }
 
-    override def ++=(xs: TraversableOnce[T]): this.type = (xs.asInstanceOf[AnyRef]) match {
+    override def ++=(xs: GenTraversableOnce[T]): this.type = (xs.asInstanceOf[AnyRef]) match {
       case xs: WrappedArray.ofRef[_] =>
         ensureSize(this.size + xs.length)
         Array.copy(xs.array, 0, elems, this.size, xs.length)
@@ -154,7 +154,7 @@ object ArrayBuilder {
       this
     }
 
-    override def ++=(xs: TraversableOnce[Byte]): this.type = xs match {
+    override def ++=(xs: GenTraversableOnce[Byte]): this.type = xs match {
       case xs: WrappedArray.ofByte =>
         ensureSize(this.size + xs.length)
         Array.copy(xs.array, 0, elems, this.size, xs.length)
@@ -218,7 +218,7 @@ object ArrayBuilder {
       this
     }
 
-    override def ++=(xs: TraversableOnce[Short]): this.type = xs match {
+    override def ++=(xs: GenTraversableOnce[Short]): this.type = xs match {
       case xs: WrappedArray.ofShort =>
         ensureSize(this.size + xs.length)
         Array.copy(xs.array, 0, elems, this.size, xs.length)
@@ -282,7 +282,7 @@ object ArrayBuilder {
       this
     }
 
-    override def ++=(xs: TraversableOnce[Char]): this.type = xs match {
+    override def ++=(xs: GenTraversableOnce[Char]): this.type = xs match {
       case xs: WrappedArray.ofChar =>
         ensureSize(this.size + xs.length)
         Array.copy(xs.array, 0, elems, this.size, xs.length)
@@ -346,7 +346,7 @@ object ArrayBuilder {
       this
     }
 
-    override def ++=(xs: TraversableOnce[Int]): this.type = xs match {
+    override def ++=(xs: GenTraversableOnce[Int]): this.type = xs match {
       case xs: WrappedArray.ofInt =>
         ensureSize(this.size + xs.length)
         Array.copy(xs.array, 0, elems, this.size, xs.length)
@@ -410,7 +410,7 @@ object ArrayBuilder {
       this
     }
 
-    override def ++=(xs: TraversableOnce[Long]): this.type = xs match {
+    override def ++=(xs: GenTraversableOnce[Long]): this.type = xs match {
       case xs: WrappedArray.ofLong =>
         ensureSize(this.size + xs.length)
         Array.copy(xs.array, 0, elems, this.size, xs.length)
@@ -474,7 +474,7 @@ object ArrayBuilder {
       this
     }
 
-    override def ++=(xs: TraversableOnce[Float]): this.type = xs match {
+    override def ++=(xs: GenTraversableOnce[Float]): this.type = xs match {
       case xs: WrappedArray.ofFloat =>
         ensureSize(this.size + xs.length)
         Array.copy(xs.array, 0, elems, this.size, xs.length)
@@ -538,7 +538,7 @@ object ArrayBuilder {
       this
     }
 
-    override def ++=(xs: TraversableOnce[Double]): this.type = xs match {
+    override def ++=(xs: GenTraversableOnce[Double]): this.type = xs match {
       case xs: WrappedArray.ofDouble =>
         ensureSize(this.size + xs.length)
         Array.copy(xs.array, 0, elems, this.size, xs.length)
@@ -602,7 +602,7 @@ object ArrayBuilder {
       this
     }
 
-    override def ++=(xs: TraversableOnce[Boolean]): this.type = xs match {
+    override def ++=(xs: GenTraversableOnce[Boolean]): this.type = xs match {
       case xs: WrappedArray.ofBoolean =>
         ensureSize(this.size + xs.length)
         Array.copy(xs.array, 0, elems, this.size, xs.length)
@@ -666,7 +666,7 @@ object ArrayBuilder {
       this
     }
 
-    override def ++=(xs: TraversableOnce[Unit]): this.type = xs match {
+    override def ++=(xs: GenTraversableOnce[Unit]): this.type = xs match {
       case xs: WrappedArray.ofUnit =>
         ensureSize(this.size + xs.length)
         Array.copy(xs.array, 0, elems, this.size, xs.length)

--- a/src/library/scala/collection/mutable/ArrayOps.scala
+++ b/src/library/scala/collection/mutable/ArrayOps.scala
@@ -64,11 +64,11 @@ abstract class ArrayOps[T] extends ArrayLike[T, Array[T]] with CustomParalleliza
    *  @param asTrav    A function that converts elements of this array to rows - arrays of type `U`.
    *  @return          An array obtained by concatenating rows of this array.
    */
-  def flatten[U](implicit asTrav: T => collection.Traversable[U], m: ClassTag[U]): Array[U] = {
+  def flatten[U](implicit asTrav: T => collection.GenTraversable[U], m: ClassTag[U]): Array[U] = {
     val b = Array.newBuilder[U]
     b.sizeHint(map{case is: collection.IndexedSeq[_] => is.size case _ => 0}.sum)
     for (xs <- this)
-      b ++= asTrav(xs)
+      b ++= asTrav(xs).seq
     b.result
   }
 

--- a/src/library/scala/collection/mutable/ArrayStack.scala
+++ b/src/library/scala/collection/mutable/ArrayStack.scala
@@ -156,7 +156,7 @@ extends AbstractSeq[T]
    *  @param xs The source of elements to push.
    *  @return   A reference to this stack.
    */
-  override def ++=(xs: TraversableOnce[T]): this.type = { xs.seq foreach += ; this }
+  override def ++=(xs: GenTraversableOnce[T]): this.type = { xs.seq foreach += ; this }
 
   /** Does the same as `push`, but returns the updated stack.
    *

--- a/src/library/scala/collection/mutable/BufferLike.scala
+++ b/src/library/scala/collection/mutable/BufferLike.scala
@@ -44,7 +44,7 @@ import annotation.{migration, bridge}
  *       def clear()
  *       def +=(elem: A): this.type
  *       def +=:(elem: A): this.type
- *       def insertAll(n: Int, iter: Traversable[A])
+ *       def insertAll(n: Int, iter: GenTraversable[A])
  *       def remove(n: Int): A
  *    }}}
  *  @define coll buffer
@@ -93,7 +93,7 @@ trait BufferLike[A, +This <: BufferLike[A, This] with Buffer[A]]
    *  @throws   IndexOutOfBoundsException if the index `n` is not in the valid range
    *            `0 <= n <= length`.
    */
-  def insertAll(n: Int, elems: collection.Traversable[A])
+  def insertAll(n: Int, elems: collection.GenTraversable[A])
 
    /** Removes the element at a given index from this buffer.
     *
@@ -133,7 +133,7 @@ trait BufferLike[A, +This <: BufferLike[A, This] with Buffer[A]]
    *  @param xs  the TraversableOnce containing the elements to prepend.
    *  @return the buffer itself.
    */
-  def ++=:(xs: TraversableOnce[A]): this.type = { insertAll(0, xs.toTraversable); this }
+  def ++=:(xs: GenTraversableOnce[A]): this.type = { insertAll(0, xs.seq.toTraversable); this }
 
   /** Appends the given elements to this buffer.
    *
@@ -144,7 +144,7 @@ trait BufferLike[A, +This <: BufferLike[A, This] with Buffer[A]]
   /** Appends the elements contained in a traversable object to this buffer.
    *  @param xs  the traversable object containing the elements to append.
    */
-  def appendAll(xs: TraversableOnce[A]) { this ++= xs }
+  def appendAll(xs: GenTraversableOnce[A]) { this ++= xs.seq }
 
   /** Prepends given elements to this buffer.
    *  @param elems  the elements to prepend.
@@ -154,7 +154,7 @@ trait BufferLike[A, +This <: BufferLike[A, This] with Buffer[A]]
   /** Prepends the elements contained in a traversable object to this buffer.
    *  @param xs  the collection containing the elements to prepend.
    */
-  def prependAll(xs: TraversableOnce[A]) { xs ++=: this }
+  def prependAll(xs: GenTraversableOnce[A]) { xs.seq ++=: this }
 
   /** Inserts new elements at a given index into this buffer.
    *

--- a/src/library/scala/collection/mutable/BufferProxy.scala
+++ b/src/library/scala/collection/mutable/BufferProxy.scala
@@ -51,7 +51,7 @@ trait BufferProxy[A] extends Buffer[A] with Proxy {
    *  @param xs   the traversable object.
    *  @return     a reference to this $coll.
    */
-  override def ++=(xs: TraversableOnce[A]): this.type = { self.++=(xs); this }
+  override def ++=(xs: GenTraversableOnce[A]): this.type = { self.++=(xs); this }
 
   /** Appends a sequence of elements to this buffer.
    *
@@ -63,7 +63,7 @@ trait BufferProxy[A] extends Buffer[A] with Proxy {
    *
    *  @param xs   the traversable object.
    */
-  override def appendAll(xs: TraversableOnce[A]) { self.appendAll(xs) }
+  override def appendAll(xs: GenTraversableOnce[A]) { self.appendAll(xs) }
 
   /** Prepend a single element to this buffer and return
    *  the identity of the buffer.
@@ -73,7 +73,7 @@ trait BufferProxy[A] extends Buffer[A] with Proxy {
    */
   def +=:(elem: A): this.type = { self.+=:(elem); this }
 
-  override def ++=:(xs: TraversableOnce[A]): this.type = { self.++=:(xs); this }
+  override def ++=:(xs: GenTraversableOnce[A]): this.type = { self.++=:(xs); this }
 
   /** Prepend an element to this list.
    *
@@ -86,7 +86,7 @@ trait BufferProxy[A] extends Buffer[A] with Proxy {
    *
    *  @param xs  the traversable object.
    */
-  override def prependAll(xs: TraversableOnce[A]) { self.prependAll(xs) }
+  override def prependAll(xs: GenTraversableOnce[A]) { self.prependAll(xs) }
 
   /** Inserts new elements at the index `n`. Opposed to method
    *  `update`, this method will not replace an element with a
@@ -104,11 +104,11 @@ trait BufferProxy[A] extends Buffer[A] with Proxy {
    *  @param n     the index where a new element will be inserted.
    *  @param iter  the iterable object providing all elements to insert.
    */
-  def insertAll(n: Int, iter: scala.collection.Iterable[A]) {
+  def insertAll(n: Int, iter: scala.collection.GenIterable[A]) {
     self.insertAll(n, iter)
   }
 
-  override def insertAll(n: Int, iter: scala.collection.Traversable[A]) {
+  override def insertAll(n: Int, iter: scala.collection.GenTraversable[A]) {
     self.insertAll(n, iter)
   }
 

--- a/src/library/scala/collection/mutable/Builder.scala
+++ b/src/library/scala/collection/mutable/Builder.scala
@@ -63,7 +63,7 @@ trait Builder[-Elem, +To] extends Growable[Elem] {
    *
    *  @param coll  the collection which serves as a hint for the result's size.
    */
-  def sizeHint(coll: TraversableLike[_, _]) {
+  def sizeHint(coll: GenTraversableLike[_, _]) {
     if (coll.isInstanceOf[collection.IndexedSeqLike[_,_]]) {
       sizeHint(coll.size)
     }
@@ -82,7 +82,7 @@ trait Builder[-Elem, +To] extends Growable[Elem] {
    *  @param coll  the collection which serves as a hint for the result's size.
    *  @param delta a correction to add to the `coll.size` to produce the size hint.
    */
-  def sizeHint(coll: TraversableLike[_, _], delta: Int) {
+  def sizeHint(coll: GenTraversableLike[_, _], delta: Int) {
     if (coll.isInstanceOf[collection.IndexedSeqLike[_,_]]) {
       sizeHint(coll.size + delta)
     }
@@ -100,7 +100,7 @@ trait Builder[-Elem, +To] extends Growable[Elem] {
    *                       an IndexedSeqLike, then sizes larger
    *                       than collection's size are reduced.
    */
-  def sizeHintBounded(size: Int, boundingColl: TraversableLike[_, _]) {
+  def sizeHintBounded(size: Int, boundingColl: GenTraversableLike[_, _]) {
     if (boundingColl.isInstanceOf[collection.IndexedSeqLike[_,_]])
       sizeHint(size min boundingColl.size)
   }
@@ -117,9 +117,9 @@ trait Builder[-Elem, +To] extends Growable[Elem] {
       val self = Builder.this
       def +=(x: Elem): this.type = { self += x; this }
       def clear() = self.clear()
-      override def ++=(xs: TraversableOnce[Elem]): this.type = { self ++= xs; this }
+      override def ++=(xs: GenTraversableOnce[Elem]): this.type = { self ++= xs; this }
       override def sizeHint(size: Int) = self.sizeHint(size)
-      override def sizeHintBounded(size: Int, boundColl: TraversableLike[_, _]) = self.sizeHintBounded(size, boundColl)
+      override def sizeHintBounded(size: Int, boundColl: GenTraversableLike[_, _]) = self.sizeHintBounded(size, boundColl)
       def result: NewTo = f(self.result)
     }
 }

--- a/src/library/scala/collection/mutable/LazyBuilder.scala
+++ b/src/library/scala/collection/mutable/LazyBuilder.scala
@@ -21,7 +21,7 @@ abstract class LazyBuilder[Elem, +To] extends Builder[Elem, To] {
   /** The different segments of elements to be added to the builder, represented as iterators */
   protected var parts = new ListBuffer[TraversableOnce[Elem]]
   def +=(x: Elem): this.type = { parts += List(x); this }
-  override def ++=(xs: TraversableOnce[Elem]): this.type = { parts += xs ; this }
+  override def ++=(xs: GenTraversableOnce[Elem]): this.type = { parts += xs.seq ; this }
   def result(): To
   def clear() { parts.clear() }
 }

--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -174,10 +174,10 @@ final class ListBuffer[A]
     this
   }
 
-  override def ++=(xs: TraversableOnce[A]): this.type =
+  override def ++=(xs: GenTraversableOnce[A]): this.type =
     if (xs.asInstanceOf[AnyRef] eq this) ++= (this take size) else super.++=(xs)
 
-  override def ++=:(xs: TraversableOnce[A]): this.type =
+  override def ++=:(xs: GenTraversableOnce[A]): this.type =
     if (xs.asInstanceOf[AnyRef] eq this) ++=: (this take size) else super.++=:(xs)
 
   /** Clears the buffer contents.
@@ -211,10 +211,10 @@ final class ListBuffer[A]
    *  @param  seq   the iterable object providing all elements to insert.
    *  @throws Predef.IndexOutOfBoundsException if `n` is out of bounds.
    */
-  def insertAll(n: Int, seq: Traversable[A]) {
+  def insertAll(n: Int, xs: GenTraversable[A]) {
     try {
       if (exported) copy()
-      var elems = seq.toList.reverse
+      var elems = xs.toList.reverse
       len += elems.length
       if (n == 0) {
         while (!elems.isEmpty) {

--- a/src/library/scala/collection/mutable/ObservableBuffer.scala
+++ b/src/library/scala/collection/mutable/ObservableBuffer.scala
@@ -34,7 +34,7 @@ trait ObservableBuffer[A] extends Buffer[A] with Publisher[Message[A] with Undoa
     this
   }
 
-  abstract override def ++=(xs: TraversableOnce[A]): this.type = {
+  abstract override def ++=(xs: GenTraversableOnce[A]): this.type = {
     for (x <- xs) this += x
     this
   }
@@ -71,7 +71,7 @@ trait ObservableBuffer[A] extends Buffer[A] with Publisher[Message[A] with Undoa
     })
   }
   
-  abstract override def insertAll(n: Int, elems: collection.Traversable[A]) {
+  abstract override def insertAll(n: Int, elems: collection.GenTraversable[A]) {
     super.insertAll(n, elems)
     var curr = n - 1
     val msg = elems.foldLeft(new Script[A]() with Undoable {

--- a/src/library/scala/collection/mutable/PriorityQueueProxy.scala
+++ b/src/library/scala/collection/mutable/PriorityQueueProxy.scala
@@ -50,7 +50,7 @@ abstract class PriorityQueueProxy[A](implicit ord: Ordering[A]) extends Priority
    *
    *  @param  it        an iterator
    */
-  override def ++=(it: TraversableOnce[A]): this.type = {
+  override def ++=(it: GenTraversableOnce[A]): this.type = {
     self ++= it
     this
   }

--- a/src/library/scala/collection/mutable/QueueProxy.scala
+++ b/src/library/scala/collection/mutable/QueueProxy.scala
@@ -51,7 +51,7 @@ trait QueueProxy[A] extends Queue[A] with Proxy {
    *
    *  @param  it        an iterator
    */
-  override def ++=(it: TraversableOnce[A]): this.type = {
+  override def ++=(it: GenTraversableOnce[A]): this.type = {
     self ++= it
     this
   }

--- a/src/library/scala/collection/mutable/Stack.scala
+++ b/src/library/scala/collection/mutable/Stack.scala
@@ -118,7 +118,7 @@ extends AbstractSeq[A]
    *  @param xs the traversable object.
    *  @return the stack with the new elements on top.
    */
-  def pushAll(xs: TraversableOnce[A]): this.type = { xs.seq foreach push ; this }
+  def pushAll(xs: GenTraversableOnce[A]): this.type = { xs.seq foreach push ; this }
 
   /** Returns the top element of the stack. This method will not remove
    *  the element from the stack. An error is signaled if there is no

--- a/src/library/scala/collection/mutable/StackProxy.scala
+++ b/src/library/scala/collection/mutable/StackProxy.scala
@@ -47,7 +47,7 @@ trait StackProxy[A] extends Stack[A] with Proxy {
     this
   }
 
-  override def pushAll(xs: TraversableOnce[A]): this.type = { self pushAll xs; this }
+  override def pushAll(xs: GenTraversableOnce[A]): this.type = { self pushAll xs; this }
 
   override def push(elem1: A, elem2: A, elems: A*): this.type = {
     self.push(elem1).push(elem2).pushAll(elems)

--- a/src/library/scala/collection/mutable/StringBuilder.scala
+++ b/src/library/scala/collection/mutable/StringBuilder.scala
@@ -223,7 +223,7 @@ final class StringBuilder(private val underlying: JavaStringBuilder)
    *  @param  xs  the characters to be appended.
    *  @return     this StringBuilder.
    */
-  def appendAll(xs: TraversableOnce[Char]): StringBuilder = appendAll(xs.toArray)
+  def appendAll(xs: GenTraversableOnce[Char]): StringBuilder = appendAll(xs.toArray)
 
   /** Appends all the Chars in the given Array[Char] to this sequence.
    *

--- a/src/library/scala/collection/mutable/SynchronizedBuffer.scala
+++ b/src/library/scala/collection/mutable/SynchronizedBuffer.scala
@@ -63,7 +63,7 @@ trait SynchronizedBuffer[A] extends Buffer[A] {
    *
    *  @param xs   the iterable object.
    */
-  override def ++=(xs: TraversableOnce[A]): this.type = synchronized[this.type] {
+  override def ++=(xs: GenTraversableOnce[A]): this.type = synchronized[this.type] {
     super.++=(xs)
   }
 
@@ -80,7 +80,7 @@ trait SynchronizedBuffer[A] extends Buffer[A] {
    *
    *  @param xs the traversable object.
    */
-  override def appendAll(xs: TraversableOnce[A]): Unit = synchronized {
+  override def appendAll(xs: GenTraversableOnce[A]): Unit = synchronized {
     super.appendAll(xs)
   }
 
@@ -98,7 +98,7 @@ trait SynchronizedBuffer[A] extends Buffer[A] {
    *
    *  @param xs the traversable object.
    */
-  override def ++=:(xs: TraversableOnce[A]): this.type = synchronized[this.type] { super.++=:(xs) }
+  override def ++=:(xs: GenTraversableOnce[A]): this.type = synchronized[this.type] { super.++=:(xs) }
 
   /** Prepend an element to this list.
    *
@@ -111,7 +111,7 @@ trait SynchronizedBuffer[A] extends Buffer[A] {
    *
    *  @param xs the traversable object.
    */
-  override def prependAll(xs: TraversableOnce[A]): Unit = synchronized {
+  override def prependAll(xs: GenTraversableOnce[A]): Unit = synchronized {
     super.prependAll(xs)
   }
 
@@ -133,7 +133,7 @@ trait SynchronizedBuffer[A] extends Buffer[A] {
    *  @param n     the index where a new element will be inserted.
    *  @param xs    the traversable object providing all elements to insert.
    */
-  abstract override def insertAll(n: Int, xs: Traversable[A]): Unit = synchronized {
+  abstract override def insertAll(n: Int, xs: GenTraversable[A]): Unit = synchronized {
      super.insertAll(n, xs)
   }
 

--- a/src/library/scala/collection/mutable/SynchronizedPriorityQueue.scala
+++ b/src/library/scala/collection/mutable/SynchronizedPriorityQueue.scala
@@ -46,7 +46,7 @@ class SynchronizedPriorityQueue[A](implicit ord: Ordering[A]) extends PriorityQu
    *
    *  @param  xs        a traversable object
    */
-  override def ++=(xs: TraversableOnce[A]): this.type = {
+  override def ++=(xs: GenTraversableOnce[A]): this.type = {
     synchronized {
       super.++=(xs)
     }

--- a/src/library/scala/collection/mutable/SynchronizedQueue.scala
+++ b/src/library/scala/collection/mutable/SynchronizedQueue.scala
@@ -45,7 +45,7 @@ class SynchronizedQueue[A] extends Queue[A] {
    *
    *  @param  xs        a traversable object
    */
-  override def ++=(xs: TraversableOnce[A]): this.type = synchronized[this.type] { super.++=(xs) }
+  override def ++=(xs: GenTraversableOnce[A]): this.type = synchronized[this.type] { super.++=(xs) }
 
   /** Adds all elements to the queue.
    *

--- a/src/library/scala/collection/mutable/SynchronizedSet.scala
+++ b/src/library/scala/collection/mutable/SynchronizedSet.scala
@@ -42,7 +42,7 @@ trait SynchronizedSet[A] extends Set[A] {
     super.+=(elem)
   }
 
-  override def ++=(xs: TraversableOnce[A]): this.type = synchronized[this.type] {
+  override def ++=(xs: GenTraversableOnce[A]): this.type = synchronized[this.type] {
     super.++=(xs)
   }
 
@@ -50,7 +50,7 @@ trait SynchronizedSet[A] extends Set[A] {
     super.-=(elem)
   }
 
-  override def --=(xs: TraversableOnce[A]): this.type = synchronized[this.type] {
+  override def --=(xs: GenTraversableOnce[A]): this.type = synchronized[this.type] {
     super.--=(xs)
   }
 

--- a/src/library/scala/collection/mutable/SynchronizedStack.scala
+++ b/src/library/scala/collection/mutable/SynchronizedStack.scala
@@ -55,7 +55,7 @@ class SynchronizedStack[A] extends Stack[A] {
    *
    *  @param  xs        a traversable object
    */
-  override def pushAll(xs: TraversableOnce[A]): this.type = synchronized[this.type] { super.pushAll(elems) }
+  override def pushAll(xs: GenTraversableOnce[A]): this.type = synchronized[this.type] { super.pushAll(elems) }
 
   /** Returns the top element of the stack. This method will not remove
    *  the element from the stack. An error is signaled if there is no

--- a/src/library/scala/collection/mutable/UnrolledBuffer.scala
+++ b/src/library/scala/collection/mutable/UnrolledBuffer.scala
@@ -153,7 +153,7 @@ extends collection.mutable.AbstractBuffer[T]
     this
   }
 
-  def insertAll(idx: Int, elems: collection.Traversable[T]) =
+  def insertAll(idx: Int, elems: collection.GenTraversable[T]) =
     if (idx >= 0 && idx <= sz) {
       headptr.insertAll(idx, elems, this)
       sz += elems.size
@@ -285,7 +285,7 @@ object UnrolledBuffer extends ClassTagTraversableFactory[UnrolledBuffer] {
       if (next eq null) true else false // checks if last node was thrown out
     } else false
 
-    @tailrec final def insertAll(idx: Int, t: collection.Traversable[T], buffer: UnrolledBuffer[T]): Unit = if (idx < size) {
+    @tailrec final def insertAll(idx: Int, t: collection.GenTraversable[T], buffer: UnrolledBuffer[T]): Unit = if (idx < size) {
       // divide this node at the appropriate position and insert all into head
       // update new next
       val newnextnode = new Unrolled[T](0, new Array(array.length), null, buff)

--- a/src/swing/scala/swing/BufferWrapper.scala
+++ b/src/swing/scala/swing/BufferWrapper.scala
@@ -20,9 +20,9 @@ protected[swing] abstract class BufferWrapper[A] extends Buffer[A] { outer =>
     remove(n)
     insertAt(n, a)
   }
-  def insertAll(n: Int, elems: Traversable[A]) {
+  def insertAll(n: Int, elems: collection.GenTraversable[A]) {
     var i = n
-    for (el <- elems) {
+    for (el <- elems.seq) {
       insertAt(i, el)
       i += 1
     }

--- a/test/files/run/t2503.scala
+++ b/test/files/run/t2503.scala
@@ -4,7 +4,7 @@ trait SB[A] extends Buffer[A] {
 
   import collection.Traversable
 
-  abstract override def insertAll(n: Int, iter: Traversable[A]): Unit = synchronized {
+  abstract override def insertAll(n: Int, iter: collection.GenTraversable[A]): Unit = synchronized {
      super.insertAll(n, iter)
   }
 

--- a/test/files/run/t6279.scala
+++ b/test/files/run/t6279.scala
@@ -1,0 +1,66 @@
+
+
+
+import collection._
+
+
+
+object Test {
+
+  def main(args: Array[String]) {
+    val ppc: List[Int] = List(1, 2, 3).par ++: List(4, 5, 6)
+    assert(ppc == List(1, 2, 3, 4, 5, 6), ppc)
+
+    {
+      import JavaConversions._
+      val arraylistwrapper: mutable.Buffer[Int] = new java.util.ArrayList[Int]
+      arraylistwrapper += 0
+      arraylistwrapper += 4
+      arraylistwrapper.insertAll(1, List(1, 2, 3).par)
+      assert(arraylistwrapper == Seq(0, 1, 2, 3, 4), arraylistwrapper)
+    }
+
+    val concatlist: List[Int] = List.concat(List(1, 2, 3), Array(4, 5, 6).par)
+    assert(concatlist == List(1, 2, 3, 4, 5, 6), concatlist)
+
+    val ppe = new mutable.ArrayBuffer() ++= Seq(1, 2, 3, 4, 5, 6).par
+    assert(ppe == Seq(1, 2, 3, 4, 5, 6), ppe)
+
+    val mme = mutable.Set(1, 2, 3, 4, 5, 6) --= Set(4, 5, 6).par
+    assert(mme == Set(1, 2, 3), mme)
+
+    val ppec: mutable.ArrayBuffer[Int] = List(-4, -3, -2, -1, 0) ++=: mutable.ArrayBuffer(1, 2, 3, 4)
+    assert(ppec == Seq(-4, -3, -2, -1, 0, 1, 2, 3, 4), ppec)
+
+    val ia = mutable.ArrayBuffer(1, 6)
+    ia.insertAll(1, Array(2, 3, 4, 5).par)
+    assert(ia == Seq(1, 2, 3, 4, 5, 6), ia)
+
+    val ab = new mutable.ArrayBuilder.ofRef[String]
+    ab ++= Array("_", "?", "!")
+    ab ++= Array("a", "ab", "b", "bc", "cd", "ce").par
+    assert(ab.result.toList == Seq("_", "?", "!", "a", "ab", "b", "bc", "cd", "ce"), ab)
+
+    val fl = Array((-100 until 2).par, Seq(2, 3, 4), List(5, 6, 7, 8, 9).par)
+    val flattened = fl.flatten
+    assert(flattened.toList == (-100 until 10), flattened)
+
+    val pa = mutable.ArrayBuffer(1, 2, 3, 4, 5, 6)
+    pa.prependAll((-100 until 1).par)
+    assert(pa == (-100 until 7), pa)
+
+    val aa = mutable.ArrayBuffer(1, 2, 3, 4, 5, 6)
+    aa.appendAll((7 until 100).par)
+    assert(aa == (1 until 100), aa)
+
+    val stack = mutable.Stack(6, 5, 4, 3, 2, 1)
+    stack.pushAll((7 to 100).par)
+    assert(stack == (100 until 0 by -1), stack)
+
+    val listbuffer = mutable.ListBuffer[Int](4, 5, 6)
+    listbuffer ++= (7 until 100).par
+    (-100 until 4).par ++=: listbuffer
+    assert(listbuffer == (-100 until 100), listbuffer)
+  }
+
+}


### PR DESCRIPTION
This commit additionally changes the signatures of certain collection
methods to accept `GenTraversableOnce` instead of `TraversableOnce`.

Review by @jsuereth.
