### PR TITLE
Fix SI-4581.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -592,7 +592,8 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
           }
 
           // create a static field in the companion class for this @static field
-          val stfieldSym = linkedClass.newVariable(newTermName(name), tree.pos, STATIC | SYNTHETIC | FINAL) setInfo sym.tpe
+          val stfieldSym = linkedClass.newValue(newTermName(name), tree.pos, STATIC | SYNTHETIC | FINAL) setInfo sym.tpe
+          if (sym.isMutable) stfieldSym.setFlag(MUTABLE)
           stfieldSym.addAnnotation(StaticClass)
 
           val names = classNames.getOrElseUpdate(linkedClass, linkedClass.info.decls.collect {
@@ -768,7 +769,7 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
         staticSym <- clazz.info.decls
         if staticSym.hasStaticAnnotation
       } staticSym match {
-        case stfieldSym if stfieldSym.isVariable =>
+        case stfieldSym if stfieldSym.isValue || stfieldSym.isVariable =>
           val valdef = staticBodies((clazz, stfieldSym))
           val ValDef(_, _, _, rhs) = valdef
           val fixedrhs = rhs.changeOwner((valdef.symbol, clazz.info.decl(nme.CONSTRUCTOR)))

--- a/test/files/neg/t4581/static-declaration_1.scala
+++ b/test/files/neg/t4581/static-declaration_1.scala
@@ -1,0 +1,14 @@
+
+
+
+
+
+object Constants {
+  import scala.annotation.static
+  @static val Const: Int = 0 // should generate a static final field
+  @static final val FinalConst: Int = 0 // ditto
+  @static var MutableField: Int = 0 // should not be final
+}
+
+
+

--- a/test/files/neg/t4581/static_2.java
+++ b/test/files/neg/t4581/static_2.java
@@ -1,0 +1,15 @@
+
+
+
+
+public class static_2 {
+	public static void main(String[] args) {
+		Constants.Const = 17;
+		Constants.FinalConst = 99;
+		Constants.MutableField = 199;
+	}
+}
+
+
+
+


### PR DESCRIPTION
Specifically, the final flag on the generated `static` field
is no longer ommitted.

Review by @paulp.

The empty check file is there until we get https://issues.scala-lang.org/browse/SI-6289 fixed.
