### PR TITLE
Fix SI-4581.

### DIFF
--- a/test/files/neg/static-annot.check
+++ b/test/files/neg/static-annot.check
@@ -13,7 +13,10 @@ static-annot.scala:38: error: The @static annotation is only allowed on public m
 static-annot.scala:39: error: The @static annotation is not allowed on lazy members.
   @static lazy val bam = 3
                    ^
+static-annot.scala:52: error: The @static annotation is not allowed on method definitions.
+  @static def x = 42
+              ^
 static-annot.scala:14: error: Only members of top-level objects and their nested objects can be annotated with @static.
     @static val blah = 2
                 ^
-6 errors found
+7 errors found

--- a/test/files/neg/t4581/static-declaration_1.scala
+++ b/test/files/neg/t4581/static-declaration_1.scala
@@ -1,0 +1,14 @@
+
+
+
+
+
+object Constants {
+  import scala.annotation.static
+  @static val Const: Int = 0 // should generate a static final field
+  @static final val FinalConst: Int = 0 // ditto
+  @static var MutableField: Int = 0 // should not be final
+}
+
+
+

--- a/test/files/neg/t4581/static_2.java
+++ b/test/files/neg/t4581/static_2.java
@@ -1,0 +1,15 @@
+
+
+
+
+public class static_2 {
+	public static void main(String[] args) {
+		Constants.Const = 17;
+		Constants.FinalConst = 99;
+		Constants.MutableField = 199;
+	}
+}
+
+
+
+

--- a/test/files/run/static-annot-repl.check
+++ b/test/files/run/static-annot-repl.check
@@ -13,7 +13,9 @@ scala> @static val x2 = 43
 x2: Int = 43
 
 scala> @static def x3 = 44
-x3: Int
+<console>:8: error: The @static annotation is not allowed on method definitions.
+       @static def x3 = 44
+                   ^
 
 scala> x1
 res0: Int = 42
@@ -22,11 +24,15 @@ scala> x2
 res1: Int = 43
 
 scala> x3
-res2: Int = 44
+<console>:9: error: not found: value x3
+              x3
+              ^
 
 scala> class Test {
   @static def x = 42
 }
-defined class Test
+<console>:9: error: The @static annotation is not allowed on method definitions.
+         @static def x = 42
+                     ^
 
 scala> 


### PR DESCRIPTION
Specifically, the final flag on the generated static field
is no longer ommitted.

Fix 2 failing test-cases.

Empty check file `t4581.check` is there until we fix https://issues.scala-lang.org/browse/SI-6289.

Review by @paulp.
