### PR TITLE
Fix version to be the first word.

### DIFF
--- a/tools/binary-repo-lib.sh
+++ b/tools/binary-repo-lib.sh
@@ -205,7 +205,7 @@ pullJarFile() {
   local sha1=$(cat ${jar}${desired_ext})
   local jar_dir=$(dirname $jar)
   local jar_name=${jar#$jar_dir/}
-  local version=${sha1% ?$jar_name}
+  local version=${sha1%% *}
   local remote_uri=${version}/${jar#$basedir/}
   echo "Resolving [${remote_uri}]"
   pullJarFileToCache $remote_uri $version


### PR DESCRIPTION
Current scheme doesn't work (because the files don't contain jar_name?).
