### PR TITLE
Fix for SI-6245, protected/super accessor issue.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
@@ -287,16 +287,19 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
                 // FIXME - this should be unified with needsProtectedAccessor, but some
                 // subtlety which presently eludes me is foiling my attempts.
                 val shouldEnsureAccessor = (
-                  currentClass.isTrait
+                     currentClass.isTrait
                   && sym.isProtected
                   && sym.enclClass != currentClass
                   && !sym.owner.isTrait
                   && (sym.owner.enclosingPackageClass != currentClass.enclosingPackageClass)
-                  && (qual.symbol.info.member(sym.name) ne NoSymbol))
+                  && (qual.symbol.info.member(sym.name) ne NoSymbol)
+                  && !needsProtectedAccessor(sym, tree.pos)
+                )
                 if (shouldEnsureAccessor) {
                   log("Ensuring accessor for call to protected " + sym.fullLocationString + " from " + currentClass)
                   ensureAccessor(sel)
-                } else
+                }
+                else
                   mayNeedProtectedAccessor(sel, EmptyTree.asList, false)
               }
 

--- a/test/files/pos/t6245/Base.java
+++ b/test/files/pos/t6245/Base.java
@@ -1,0 +1,5 @@
+package t1;
+
+public class Base {
+  protected Vis inner;
+}

--- a/test/files/pos/t6245/Foo.scala
+++ b/test/files/pos/t6245/Foo.scala
@@ -1,0 +1,9 @@
+import t1.Vis
+
+abstract class Foo extends t1.Base {
+  trait Nested {
+    def crash() {
+      inner
+    }
+  }
+}

--- a/test/files/pos/t6245/Vis.java
+++ b/test/files/pos/t6245/Vis.java
@@ -1,0 +1,3 @@
+package t1;
+
+public class Vis { }


### PR DESCRIPTION
Don't subvert the creation of the standard protected
accessor with the java interop accessor.
