### PR TITLE
Fix for SI-6283, no abstract value classes.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1618,6 +1618,8 @@ abstract class RefChecks extends InfoTransform with reflect.internal.transform.R
       if ((clazz isSubClass AnyValClass) && !isPrimitiveValueClass(clazz)) {
         if (clazz.isTrait)
           unit.error(clazz.pos, "Only classes (not traits) are allowed to extend AnyVal")
+        else if ((clazz != AnyValClass) && clazz.hasFlag(ABSTRACT))
+          unit.error(clazz.pos, "`abstract' modifier cannot be used with value classes")
       }
     }
 

--- a/test/files/neg/t6283.check
+++ b/test/files/neg/t6283.check
@@ -1,0 +1,4 @@
+t6283.scala:1: error: `abstract' modifier cannot be used with value classes
+abstract class Funky(val i: Int) extends AnyVal
+               ^
+one error found

--- a/test/files/neg/t6283.scala
+++ b/test/files/neg/t6283.scala
@@ -1,0 +1,1 @@
+abstract class Funky(val i: Int) extends AnyVal


### PR DESCRIPTION
The needless abstraction penalty was in full flower in Namers.
I managed to find somewhere else to issue this error, where I
can still just write an error message without tracking down an
enumeration in a separate file and inventing an intermediate
name for the enum member.
