### PR TITLE
hotfix for SI-6293

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2178,7 +2178,7 @@ DOCUMENTATION
       docfooter="epfl"
       docsourceurl="${scaladoc.url}€{FILE_PATH}.scala#L1"
       docUncompilable="${src.dir}/library-aux"
-      skipPackages="scala.reflect.macros"
+      skipPackages="scala.reflect.macros.internal"
       sourcepath="${src.dir}"
       classpathref="pack.classpath"
       addparams="${scalac.args.all}"


### PR DESCRIPTION
We need to hide scala.reflect.macros.internal from scaladoc,
not the entire scala.reflect.macros.
