### PR TITLE
More fix for invalid companions.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -914,10 +914,13 @@ trait Infer {
     /** Is sym1 (or its companion class in case it is a module) a subclass of
      *  sym2 (or its companion class in case it is a module)?
      */
-    def isProperSubClassOrObject(sym1: Symbol, sym2: Symbol): Boolean =
-      sym1 != sym2 && sym1 != NoSymbol && (sym1 isSubClass sym2) ||
-      sym1.isModuleClass && isProperSubClassOrObject(sym1.linkedClassOfClass, sym2) ||
-      sym2.isModuleClass && isProperSubClassOrObject(sym1, sym2.linkedClassOfClass)
+    def isProperSubClassOrObject(sym1: Symbol, sym2: Symbol): Boolean = (
+      (sym1 != sym2) && (sym1 != NoSymbol) && (
+           (sym1 isSubClass sym2)
+        || (sym1.isModuleClass && isProperSubClassOrObject(sym1.linkedClassOfClass, sym2))
+        || (sym2.isModuleClass && isProperSubClassOrObject(sym1, sym2.linkedClassOfClass))
+      )
+    )
 
     /** is symbol `sym1` defined in a proper subclass of symbol `sym2`?
      */

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -347,10 +347,39 @@ trait Namers extends MethodSynthesis {
       }
     }
 
+    /** Given a ClassDef or ModuleDef, verifies there isn't a companion which
+     *  has been defined in a separate file.
+     */
+    private def validateCompanionDefs(tree: ImplDef) {
+      val sym = tree.symbol
+      if (sym eq NoSymbol) return
+
+      val ctx    = if (context.owner.isPackageObjectClass) context.outer else context
+      val module = if (sym.isModule) sym else ctx.scope lookup tree.name.toTermName
+      val clazz  = if (sym.isClass) sym else ctx.scope lookup tree.name.toTypeName
+      val fails  = (
+           module.isModule
+        && clazz.isClass
+        && !module.isSynthetic
+        && !clazz.isSynthetic
+        && (clazz.sourceFile ne null)
+        && (module.sourceFile ne null)
+        && !(module isCoDefinedWith clazz)
+      )
+      if (fails) {
+        context.unit.error(tree.pos, (
+            s"Companions '$clazz' and '$module' must be defined in same file:\n"
+          + s"  Found in ${clazz.sourceFile.canonicalPath} and ${module.sourceFile.canonicalPath}")
+        )
+      }
+    }
+
     def enterModuleDef(tree: ModuleDef) = {
       val sym = enterModuleSymbol(tree)
       sym.moduleClass setInfo namerOf(sym).moduleClassTypeCompleter(tree)
       sym setInfo completerOf(tree)
+      validateCompanionDefs(tree)
+      sym
     }
 
     /** Enter a module symbol. The tree parameter can be either
@@ -623,6 +652,7 @@ trait Namers extends MethodSynthesis {
         }
         else context.unit.error(tree.pos, "implicit classes must accept exactly one primary constructor parameter")
       }
+      validateCompanionDefs(tree)
     }
 
     // this logic is needed in case typer was interrupted half
@@ -687,7 +717,7 @@ trait Namers extends MethodSynthesis {
       // }
     }
 
-    def moduleClassTypeCompleter(tree: Tree) = {
+    def moduleClassTypeCompleter(tree: ModuleDef) = {
       mkTypeCompleter(tree) { sym =>
         val moduleSymbol = tree.symbol
         assert(moduleSymbol.moduleClass == sym, moduleSymbol.moduleClass)
@@ -1532,18 +1562,11 @@ trait Namers extends MethodSynthesis {
    *  call this method?
    */
   def companionSymbolOf(original: Symbol, ctx: Context): Symbol = {
-    try {
-      original.companionSymbol orElse {
-        ctx.lookup(original.name.companionName, original.owner).suchThat(sym =>
-          (original.isTerm || sym.hasModuleFlag) &&
-          (sym isCoDefinedWith original)
-        )
-      }
-    }
-    catch {
-      case e: InvalidCompanions =>
-        ctx.unit.error(original.pos, e.getMessage)
-        NoSymbol
+    original.companionSymbol orElse {
+      ctx.lookup(original.name.companionName, original.owner).suchThat(sym =>
+        (original.isTerm || sym.hasModuleFlag) &&
+        (sym isCoDefinedWith original)
+      )
     }
   }
 }

--- a/test/files/neg/t5031.check
+++ b/test/files/neg/t5031.check
@@ -1,5 +1,5 @@
-Id.scala:3: error: Companions 'class Test' and 'object Test' must be defined in same file:
+package.scala:2: error: Companions 'class Test' and 'object Test' must be defined in same file:
   Found in t5031/package.scala and t5031/Id.scala
-object Test
-       ^
+  class Test
+        ^
 one error found

--- a/test/files/neg/t5031b.check
+++ b/test/files/neg/t5031b.check
@@ -1,0 +1,5 @@
+b.scala:3: error: Companions 'class Bippy' and 'object Bippy' must be defined in same file:
+  Found in t5031b/a.scala and t5031b/b.scala
+object Bippy
+       ^
+one error found

--- a/test/files/neg/t5031b/a.scala
+++ b/test/files/neg/t5031b/a.scala
@@ -1,0 +1,3 @@
+package foo
+
+class Bippy

--- a/test/files/neg/t5031b/b.scala
+++ b/test/files/neg/t5031b/b.scala
@@ -1,0 +1,3 @@
+package foo
+
+object Bippy


### PR DESCRIPTION
Eliminated InvalidCompanions exception entirely.  Anyone's
guess why we unholstered this exception every time someone
calls "isCodefinedWith" rather than when symbols are created.
I moved the check into Namers, where it can be done once and
with sufficient finesse not to crash so much.

With this patch in place, "playbench" can be built with java7.
