### PR TITLE
Closes SI-6227

### DIFF
--- a/test/files/neg/t6227.check
+++ b/test/files/neg/t6227.check
@@ -1,0 +1,4 @@
+t6227.scala:2: error: illegal combination of modifiers: implicit and case for: class IntOps
+  implicit case class IntOps( i: Int ) {
+                      ^
+one error found

--- a/test/files/neg/t6227.scala
+++ b/test/files/neg/t6227.scala
@@ -1,0 +1,6 @@
+object Test {
+  implicit case class IntOps( i: Int ) {
+    def twice = i * 2
+  }
+}
+

--- a/test/files/pos/t5667.scala
+++ b/test/files/pos/t5667.scala
@@ -1,6 +1,4 @@
 object Main {
   implicit class C(val s: String) extends AnyVal
   implicit class C2(val s: String) extends AnyRef
-
-  implicit case class Foo(i: Int)
 }


### PR DESCRIPTION
I added some general hook where one can add validation code before a name conflict involving at least one implicit symbol is reported. Review by @paulp
