### PR TITLE
Fixed cloning a double-linked list.

### DIFF
--- a/src/library/scala/collection/mutable/DoubleLinkedList.scala
+++ b/src/library/scala/collection/mutable/DoubleLinkedList.scala
@@ -63,6 +63,13 @@ class DoubleLinkedList[A]() extends AbstractSeq[A]
   }
 
   override def companion: GenericCompanion[DoubleLinkedList] = DoubleLinkedList
+
+  // Accurately clone this collection.  See SI-6296
+  override def clone(): DoubleLinkedList[A] = {
+    val builder = newBuilder
+    builder ++= this
+    builder.result
+  }
 }
 
 /** $factoryInfo

--- a/test/files/run/t6292.scala
+++ b/test/files/run/t6292.scala
@@ -1,0 +1,18 @@
+ import scala.collection.mutable.DoubleLinkedList
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    cloneAndtest(DoubleLinkedList[Int]())
+    cloneAndtest(DoubleLinkedList[Int](1))
+    cloneAndtest(DoubleLinkedList[Int](1,2,3,4))
+  }
+
+  def cloneAndtest(l: DoubleLinkedList[Int]): Unit =
+    testSame(l, l.clone.asInstanceOf[DoubleLinkedList[Int]])
+
+  def testSame(one: DoubleLinkedList[Int], two: DoubleLinkedList[Int]): Unit = {
+    def msg = s" for ${one} and ${two} !"
+    assert(one.size == two.size, s"Cloned sizes are not the same $msg!")
+    assert(one == two, s"Cloned lists are not equal $msg")
+  }
+}


### PR DESCRIPTION
Still need to determine if this is a systemic
issue and needs to be addressed higher in the
linked list hierarchy.   For now, just
fixing the reported bug, with a note here
for other maintainers.

Review by @alex22 or @paulp.  Let me know if you think I need to bump the clone method higher in the LL hierarchy.
