### PR TITLE
Reflection tuning

### DIFF
--- a/src/library/scala/reflect/base/Symbols.scala
+++ b/src/library/scala/reflect/base/Symbols.scala
@@ -107,8 +107,8 @@ trait Symbols { self: Universe =>
 
     /** Does this symbol represent the definition of a type?
      *  Note that every symbol is either a term or a type.
-     *  So for every symbol `sym`, either `sym.isTerm` is true
-     *  or `sym.isType` is true.
+     *  So for every symbol `sym` (except for `NoSymbol`),
+     *  either `sym.isTerm` is true or `sym.isType` is true.
      */
     def isType: Boolean = false
 
@@ -118,9 +118,9 @@ trait Symbols { self: Universe =>
     def asType: TypeSymbol = throw new ScalaReflectionException(s"$this is not a type")
 
     /** Does this symbol represent the definition of a term?
-     *  Note that every symbol is either a term or a term.
-     *  So for every symbol `sym`, either `sym.isTerm` is true
-     *  or `sym.isTerm` is true.
+     *  Note that every symbol is either a term or a type.
+     *  So for every symbol `sym` (except for `NoSymbol`),
+     *  either `sym.isTerm` is true or `sym.isTerm` is true.
      */
     def isTerm: Boolean = false
 
@@ -234,10 +234,10 @@ trait Symbols { self: Universe =>
       *  `PolyType(ClassInfoType(...))` that describes type parameters, value
       *  parameters, parent types, and members of `C`.
       */
-     def toType: Type
+    def toType: Type
 
-    override def isType = true
-    override def asType = this
+    final override def isType = true
+    final override def asType = this
   }
 
   /** The base API that all term symbols support */

--- a/src/reflect/scala/reflect/api/FlagSets.scala
+++ b/src/reflect/scala/reflect/api/FlagSets.scala
@@ -3,7 +3,7 @@ package api
 
 import scala.language.implicitConversions
 
-trait FlagSets { self: Universe =>
+trait FlagSets extends base.FlagSets { self: Universe =>
 
   type FlagSet
 

--- a/src/reflect/scala/reflect/api/Mirrors.scala
+++ b/src/reflect/scala/reflect/api/Mirrors.scala
@@ -1,7 +1,7 @@
 package scala.reflect
 package api
 
-trait Mirrors { self: Universe =>
+trait Mirrors extends base.Mirrors { self: Universe =>
 
   type RuntimeClass >: Null
 

--- a/src/reflect/scala/reflect/internal/Importers.scala
+++ b/src/reflect/scala/reflect/internal/Importers.scala
@@ -3,7 +3,7 @@ package internal
 import scala.collection.mutable.WeakHashMap
 
 // SI-6241: move importers to a mirror
-trait Importers { self: SymbolTable =>
+trait Importers extends api.Importers { self: SymbolTable =>
 
   def mkImporter(from0: api.Universe): Importer { val from: from0.type } = (
     if (self eq from0) {


### PR DESCRIPTION
This pull request applies some tuning changes to the reflection library:
1) the traits scala.reflect.api.FlagSets, scala.reflect.api.Mirrors
   and scala.reflect.internal.Importers extend their corresponding
   trait in the base layer of the cake.
2) method isType and asType in trait TypeSymbolBase is declared final
3) small changes in the docs.

Review: @xeno-by
