### PR TITLE
Fix SI-6294.

### DIFF
--- a/test/files/pos/t6294.scala
+++ b/test/files/pos/t6294.scala
@@ -1,0 +1,14 @@
+
+
+
+object A {
+  @annotation.static final val x = 123
+}
+
+
+object B {
+  println(A.x)
+}
+
+
+


### PR DESCRIPTION
Accomodates the fact that a `val` is inlined into a `def` if it is `final` and the right hand side is a mere literal.
