### PR TITLE
Fix SI-6294.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
@@ -121,10 +121,13 @@ abstract class GenICode extends SubComponent  {
         m.native = m.symbol.hasAnnotation(definitions.NativeAttr)
 
         if (!m.isAbstractMethod && !m.native) {
-          if (m.symbol.isAccessor && m.symbol.accessed.hasStaticAnnotation) {
+          val staticfield = if (m.symbol.isAccessor && m.symbol.accessed.hasStaticAnnotation) {
+            val compClass = m.symbol.owner.companionClass
+            compClass.info.findMember(m.symbol.accessed.name, NoFlags, NoFlags, false)
+          } else NoSymbol
+          if (staticfield != NoSymbol) {
             // in companion object accessors to @static fields, we access the static field directly
             val hostClass = m.symbol.owner.companionClass
-            val staticfield = hostClass.info.findMember(m.symbol.accessed.name, NoFlags, NoFlags, false)
             
             if (m.symbol.isGetter) {
               ctx1.bb.emit(LOAD_FIELD(staticfield, true) setHostClass hostClass, tree.pos)

--- a/test/files/pos/t6294.scala
+++ b/test/files/pos/t6294.scala
@@ -1,0 +1,14 @@
+
+
+
+object A {
+  @annotation.static final val x = 123
+}
+
+
+object B {
+  println(A.x)
+}
+
+
+


### PR DESCRIPTION
Accomodates the fact that a `val` is inlined into a `def` if it is final and the right hand side is a constant.

Review by @paulp.
