### PR TITLE
On --grep, partest must dir.list to descend into subdirs (fixes SI-6296)

### DIFF
--- a/src/partest/scala/tools/partest/nest/ConsoleRunner.scala
+++ b/src/partest/scala/tools/partest/nest/ConsoleRunner.scala
@@ -70,10 +70,11 @@ class ConsoleRunner extends DirectRunner {
   // true if a test path matches the --grep expression.
   private def pathMatchesExpr(path: Path, expr: String) = {
     def pred(p: Path) = file2String(p.toFile) contains expr
-    def srcs = path.toDirectory.deepList() filter (_.hasExtension("scala", "java"))
+    def greppable(f: Path) = f.isFile && (f hasExtension ("scala", "java"))
+    def any(d: Path) = d.toDirectory.deepList() exists (f => greppable(f) && pred(f))
 
     (path.isFile && pred(path)) ||
-    (path.isDirectory && srcs.exists(pred)) ||
+    (path.isDirectory && any(path)) ||
     (pred(path changeExtension "check"))
   }
 
@@ -121,7 +122,7 @@ class ConsoleRunner extends DirectRunner {
     val grepOption = parsed get "--grep"
     val grepPaths = grepOption.toList flatMap { expr =>
       val subjectDirs = testSetKinds map (srcDir / _ toDirectory)
-      val testPaths   = subjectDirs flatMap (_.files filter stdFilter)
+      val testPaths   = subjectDirs flatMap (_.list filter stdFilter)
       val paths       = testPaths filter (p => pathMatchesExpr(p, expr))
 
       if (paths.isEmpty)

--- a/src/partest/scala/tools/partest/package.scala
+++ b/src/partest/scala/tools/partest/package.scala
@@ -45,7 +45,7 @@ package object partest {
 
   def path2String(path: String) = file2String(new JFile(path))
   def file2String(f: JFile) =
-    try SFile(f).slurp()
+    try SFile(f).slurp(scala.io.Codec.UTF8)
     catch { case _: FileNotFoundException => "" }
 
   def basename(name: String): String = Path(name).stripExtension

--- a/test/partest
+++ b/test/partest
@@ -70,6 +70,12 @@ if $cygwin; then
     else
         format=windows
     fi
+    if [ -n "${JAVA_HOME}" ] ; then
+        JAVA_HOME=`cygpath --$format "$JAVA_HOME"`
+    fi
+    if [ -n "${JAVACMD}" ] ; then
+        JAVACMD=`cygpath --$format "$JAVACMD"`
+    fi
     SCALA_HOME=`cygpath --$format "$SCALA_HOME"`
     EXT_CLASSPATH=`cygpath --path --$format "$EXT_CLASSPATH"`
 fi
@@ -84,7 +90,7 @@ if [ ! -z "${PARTEST_DEBUG}" ] ; then
   partestDebugStr="-Dpartest.debug=${PARTEST_DEBUG}"
 fi
 
-${JAVACMD:=java} \
+"${JAVACMD:=java}" \
   $JAVA_OPTS -cp "$EXT_CLASSPATH" \
   ${partestDebugStr} \
   -Dscala.home="${SCALA_HOME}" \


### PR DESCRIPTION
In addition, always use UTF-8 when reading test files (and not default),
since some tests exercise UTF-8.

Also, quote "$JAVACMD" and convert it (and $JAVA_HOME) for cygwin, where
$JAVACMD is likely to include a space.

Review by @paulp or @axel22
