### PR TITLE
SI-6278 fixed: synthetic implicit def must sort with its associated impl...

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2739,11 +2739,17 @@ trait Typers extends Modes with Adaptations with Tags {
           // this code by associating defaults and companion objects
           // with the original tree instead of the new symbol.
           def matches(stat: Tree, synt: Tree) = (stat, synt) match {
+            // synt is default arg for stat
             case (DefDef(_, statName, _, _, _, _), DefDef(mods, syntName, _, _, _, _)) =>
               mods.hasDefaultFlag && syntName.toString.startsWith(statName.toString)
 
+            // synt is companion module
             case (ClassDef(_, className, _, _), ModuleDef(_, moduleName, _)) =>
               className.toTermName == moduleName
+
+            // synt is implicit def for implicit class (#6278)
+            case (ClassDef(cmods, cname, _, _), DefDef(dmods, dname, _, _, _, _)) =>
+              cmods.isImplicit && dmods.isImplicit && cname.toTermName == dname
 
             case _ => false
           }

--- a/test/files/pos/t6278-synth-def.scala
+++ b/test/files/pos/t6278-synth-def.scala
@@ -1,0 +1,30 @@
+
+package t6278
+
+import language.implicitConversions
+
+object test {
+  def ok() {
+    class Foo(val i: Int) {
+      def foo[A](body: =>A): A = body
+    }
+    implicit def toFoo(i: Int): Foo = new Foo(i)
+
+    val k = 1
+    k foo println("k?")
+    val j = 2
+  }
+  def nope() {
+    implicit class Foo(val i: Int) {
+      def foo[A](body: =>A): A = body
+    }
+
+    val k = 1
+    k foo println("k?")
+    //lazy
+    val j = 2
+  }
+  def main(args: Array[String]) {
+    ok(); nope()
+  }
+}


### PR DESCRIPTION
...icit class

Add a case to the ad-hoc (or add-hack) addSynthetics to keep the trees close.

This relies on naming convention, so changes in naming of the implicit def
would require an update here.

This revised PR includes local names that don't require special software to read.

Review by @paulp or @retronym
