### PR TITLE
Fix for SI-6273, repl string interpolation.

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -754,8 +754,12 @@ trait Scanners extends ScannersCommon {
       } else {
         val isUnclosedLiteral = !isUnicodeEscape && (ch == SU || (!multiLine && (ch == CR || ch == LF)))
         if (isUnclosedLiteral) {
-          syntaxError(if (!multiLine) "unclosed string literal" else "unclosed multi-line string literal")
-        } else {
+          if (multiLine)
+            incompleteInputError("unclosed multi-line string literal")
+          else
+            syntaxError("unclosed string literal")
+        }
+        else {
           putChar(ch)
           nextRawChar()
           getStringPart(multiLine)

--- a/src/compiler/scala/tools/nsc/interpreter/ExprTyper.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/ExprTyper.scala
@@ -37,7 +37,7 @@ trait ExprTyper {
   }
 
   /** Parse a line into a sequence of trees. Returns None if the input is incomplete. */
-  def parse(line: String): Option[List[Tree]] = {
+  def parse(line: String): Option[List[Tree]] = debugging(s"""parse("$line")""")  {
     var isIncomplete = false
     reporter.withIncompleteHandler((_, _) => isIncomplete = true) {
       val trees = codeParser.stmts(line)

--- a/test/files/neg/t5510.check
+++ b/test/files/neg/t5510.check
@@ -13,7 +13,7 @@ t5510.scala:5: error: unclosed string literal
 t5510.scala:6: error: unclosed multi-line string literal
   val s5 = ""s""" $s1 $s2 s"
                          ^
-t5510.scala:7: error: '}' expected but eof found.
+t5510.scala:7: error: unclosed multi-line string literal
 }
  ^
 6 errors found

--- a/test/files/run/t6273.check
+++ b/test/files/run/t6273.check
@@ -1,0 +1,19 @@
+Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> 
+
+scala> val y = 55
+y: Int = 55
+
+scala> val x = s"""
+  y = $y
+"""
+x: String = 
+"
+  y = 55
+"
+
+scala> 
+
+scala> 

--- a/test/files/run/t6273.scala
+++ b/test/files/run/t6273.scala
@@ -1,0 +1,11 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  def tq = "\"\"\""
+  def code = s"""
+val y = 55
+val x = s$tq
+  y = $$y
+$tq
+  """
+}


### PR DESCRIPTION
As usual the hard part is tracing through all the
needless abstraction.  Begone, 25 layers of parsing error
issuing methods!
