### PR TITLE
Backport `Two fixes for the worksheet instrumenter`

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1267,7 +1267,8 @@ self =>
           makeDoWhile(lname, body, cond)
         }
       case FOR =>
-        atPos(in.skipToken()) {
+        val start = in.skipToken()
+        def parseFor = atPos(start) {
           val enums =
             if (in.token == LBRACE) inBracesOrNil(enumerators())
             else inParensOrNil(enumerators())
@@ -1279,6 +1280,11 @@ self =>
             makeFor(enums, expr())
           }
         }
+        def adjustStart(tree: Tree) =
+          if (tree.pos.isRange && start < tree.pos.start)
+            tree setPos tree.pos.withStart(start)
+          else tree
+        adjustStart(parseFor)
       case RETURN =>
         atPos(in.skipToken()) {
           Return(if (isExprIntro) expr() else Literal(()))

--- a/src/compiler/scala/tools/nsc/interactive/ScratchPadMaker.scala
+++ b/src/compiler/scala/tools/nsc/interactive/ScratchPadMaker.scala
@@ -113,9 +113,11 @@ trait ScratchPadMaker { self: Global =>
         val topLevel = objectName.isEmpty
         if (topLevel) objectName = tree.symbol.fullName
         body foreach traverseStat
-        applyPendingPatches(skipped)
-        if (topLevel)
-          patches += Patch(skipped, epilogue)
+        if (skipped != 0) { // don't issue prologue and epilogue if there are no instrumented statements
+          applyPendingPatches(skipped)
+          if (topLevel)
+            patches += Patch(skipped, epilogue)
+        }
       case _ =>
     }
 


### PR DESCRIPTION
(1) Handle empty worksheets
(2) Handle for expressions

Review by @lrytz
(cherry picked from commit 20dc9cd7848863097b07d1cb84ae3f729f7e94da)(cherry picked from commit 32cb44f9136a03e762baba420c0be2f4c27f4354)

Conflicts:

```
src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
```
