### PR TITLE
Backport method askForResponse

### DIFF
--- a/src/compiler/scala/tools/nsc/interactive/CompilerControl.scala
+++ b/src/compiler/scala/tools/nsc/interactive/CompilerControl.scala
@@ -251,6 +251,19 @@ trait CompilerControl { self: Global =>
   /** Asks for a computation to be done quickly on the presentation compiler thread */
   def ask[A](op: () => A): A = if (self.onCompilerThread) op() else scheduler doQuickly op
 
+  /** Asks for a computation to be done on presentation compiler thread, returning
+   *  a response with the result or an exception
+   */
+  def askForResponse[A](op: () => A): Response[A] = {
+    val r = new Response[A]
+    val ir = scheduler askDoQuickly op
+    ir onComplete {
+      case Left(result) => r set result
+      case Right(exc) => r raise exc
+    }
+    r
+  }
+
   def onCompilerThread = Thread.currentThread == compileRunner
 
   /** Info given for every member found by completion
@@ -389,7 +402,7 @@ trait CompilerControl { self: Global =>
         case _ => println("don't know what to do with this " + action.getClass)
       }
     }
-    
+
     override def doQuickly[A](op: () => A): A = {
       throw new FailedInterrupt(new Exception("Posted a work item to a compiler that's shutting down"))
     }

--- a/src/compiler/scala/tools/nsc/util/WorkScheduler.scala
+++ b/src/compiler/scala/tools/nsc/util/WorkScheduler.scala
@@ -54,6 +54,11 @@ class WorkScheduler {
 
   /** Called from client: have interrupt executed by server and return result */
   def doQuickly[A](op: () => A): A = {
+    val ir = askDoQuickly(op)
+    ir.getResult()
+  }
+
+  def askDoQuickly[A](op: () => A): InterruptReq { type R = A } = {
     val ir = new InterruptReq {
       type R = A
       val todo = op
@@ -62,7 +67,7 @@ class WorkScheduler {
       interruptReqs enqueue ir
       notify()
     }
-    ir.getResult()
+    ir
   }
 
   /** Called from client: have action executed by server */


### PR DESCRIPTION
Review by @jsuereth.

Adds method askForResponse

Adds method askForResponse which returns a response immediately instead of waiting for a result. That way, one can wait for an ask's result using a timeout.
(cherry picked from commit e896c0ab2d36740207f91086262e9feb4fc1c32d)

Conflicts:

```
src/compiler/scala/tools/nsc/util/InterruptReq.scala
```
