### PR TITLE
SI-6295: Make DocType take optional ExternalID, as documented.

### DIFF
--- a/src/library/scala/xml/dtd/DocType.scala
+++ b/src/library/scala/xml/dtd/DocType.scala
@@ -15,7 +15,7 @@ package dtd
  *  @author Burak Emir
  *
  *  @param  name   name of this DOCTYPE
- *  @param  extID  None, or Some(external ID of this doctype)
+ *  @param  extID  NoExternalID or the external ID of this doctype
  *  @param  intSubset sequence of internal subset declarations
  */
 case class DocType(name: String, extID: ExternalID, intSubset: Seq[dtd.Decl])
@@ -31,4 +31,10 @@ case class DocType(name: String, extID: ExternalID, intSubset: Seq[dtd.Decl])
 
     """<!DOCTYPE %s %s%s>""".format(name, extID.toString, intString)
   }
+}
+
+object DocType
+{
+  /** Creates a doctype with no external id, nor internal subset declarations. */
+  def apply(name: String): DocType = apply(name, NoExternalID, Nil)
 }

--- a/src/library/scala/xml/dtd/ExternalID.scala
+++ b/src/library/scala/xml/dtd/ExternalID.scala
@@ -73,3 +73,14 @@ case class PublicID(publicId: String, systemId: String) extends ExternalID {
   /** always empty */
   def child = Nil
 }
+
+/** A marker used when a `DocType` contains no external id.
+ *
+ *  @author Michael Bayne
+ */
+object NoExternalID extends ExternalID {
+  val publicId = null
+  val systemId = null
+
+  override def toString = ""
+}


### PR DESCRIPTION
Deprecates non-optional constructor and adds additional apply method. The
latter allows one to construct DocType("html"), which suffices if one intends
only to support modern web browsers.

Adds a note regarding the incorrect extractor. No mechanism exists to deprecate
or otherwise warn users of the upcoming change which will render use of the
current extractor silently non-functional.
