### PR TITLE
Allow nested calls to `askForResponse` in the presentation compiler.

### DIFF
--- a/test/files/presentation/recursive-ask.check
+++ b/test/files/presentation/recursive-ask.check
@@ -1,0 +1,4 @@
+[ outer] askForResponse
+[nested] askForResponse
+passed
+done

--- a/test/files/presentation/recursive-ask/RecursiveAsk.scala
+++ b/test/files/presentation/recursive-ask/RecursiveAsk.scala
@@ -1,0 +1,20 @@
+import scala.tools.nsc.interactive.tests._
+
+object Test extends InteractiveTest {
+  override def execute(): Unit = recursiveAskForResponse()
+
+  def recursiveAskForResponse() {
+    val res0 = compiler.askForResponse( () => {
+      println("[ outer] askForResponse")
+      val res = compiler.askForResponse( () => { println("[nested] askForResponse") })
+      println (res.get(5000) match {
+        case Some(_) => "passed"
+        case None    => "timeout"
+      })
+    })
+
+    res0.get
+
+    println("done")
+  }
+}


### PR DESCRIPTION
Fix #6312.

review by @odersky,@lrytz.
