### PR TITLE
SI-6274 Fix owners when eta-expanding function with byName param

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/EtaExpansion.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/EtaExpansion.scala
@@ -47,7 +47,7 @@ trait EtaExpansion { self: Analyzer =>
    *    tree is already attributed
    *  </p>
    */
-  def etaExpand(unit : CompilationUnit, tree: Tree): Tree = {
+  def etaExpand(unit : CompilationUnit, tree: Tree, typer: Typer): Tree = {
     val tpe = tree.tpe
     var cnt = 0 // for NoPosition
     def freshName() = {
@@ -69,7 +69,11 @@ trait EtaExpansion { self: Analyzer =>
           val vname: Name = freshName()
           // Problem with ticket #2351 here
           defs += atPos(tree.pos) {
-            val rhs = if (byName) Function(List(), tree) else tree
+            val rhs = if (byName) {
+              val res = typer.typed(Function(List(), tree))
+              new ChangeOwnerTraverser(typer.context.owner, res.symbol) traverse tree // SI-6274
+              res
+            } else tree
             ValDef(Modifiers(SYNTHETIC), vname.toTermName, TypeTree(), rhs)
           }
           atPos(tree.pos.focus) {

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -886,7 +886,7 @@ trait Typers extends Modes with Adaptations with Tags {
         if (!meth.isConstructor && !meth.isTermMacro && isFunctionType(pt)) { // (4.2)
           debuglog("eta-expanding " + tree + ":" + tree.tpe + " to " + pt)
           checkParamsConvertible(tree, tree.tpe)
-          val tree0 = etaExpand(context.unit, tree)
+          val tree0 = etaExpand(context.unit, tree, this)
           // println("eta "+tree+" ---> "+tree0+":"+tree0.tpe+" undet: "+context.undetparams+ " mode: "+Integer.toHexString(mode))
 
           if (context.undetparams.nonEmpty) {

--- a/test/files/pos/t6274.scala
+++ b/test/files/pos/t6274.scala
@@ -1,0 +1,13 @@
+trait Crash {
+
+    def foo(i: => Int) (j: Int): Int
+
+    def t = {
+        // var count = 0
+        foo {
+            var count = 0
+            count
+        } _
+    }
+
+}


### PR DESCRIPTION
When eta-expanding a function that takes a by-name param the local definition
for the corresponding argument is a function-0

  val eta$1 = () => { argument-to-by-name }

If there are any definitinos in the `argument-to-by-name`, the symbol
owner needs to be changed to the anonymous function's symbol.

To know the function symbol in eta expand, we need to type-check the
function, and therefore pass the `Typer` instance to `etaExpand`.
