### PR TITLE
Fix t6114 - ++ on JList wrapper modifies underlying collection.

### DIFF
--- a/src/library/scala/collection/convert/Wrappers.scala
+++ b/src/library/scala/collection/convert/Wrappers.scala
@@ -96,6 +96,9 @@ private[collection] trait Wrappers {
     def remove(i: Int) = underlying.remove(i)
     def clear() = underlying.clear()
     def result = this
+    // Note: Clone cannot just call underlying.clone because in Java, only specific collections
+    // expose clone methods.  Generically, they're protected.
+    override def clone(): JListWrapper[A] = JListWrapper(new ju.ArrayList[A](underlying))
   }
 
   class SetWrapper[A](underlying: Set[A]) extends ju.AbstractSet[A] {
@@ -149,6 +152,10 @@ private[collection] trait Wrappers {
     override def clear() = underlying.clear()
 
     override def empty = JSetWrapper(new ju.HashSet[A])
+    // Note: Clone cannot just call underlying.clone because in Java, only specific collections
+    // expose clone methods.  Generically, they're protected.
+    override def clone() =
+      new JSetWrapper[A](new ju.LinkedHashSet[A](underlying))
   }
 
   class MapWrapper[A, B](underlying: Map[A, B]) extends ju.AbstractMap[A, B] { self =>

--- a/test/files/run/t6114.scala
+++ b/test/files/run/t6114.scala
@@ -1,0 +1,61 @@
+object Test extends App {
+  def testList = {
+    val list = new java.util.ArrayList[Int]
+    list.add(1)
+    list.add(2)
+    list.add(3)
+    import scala.collection.JavaConverters._
+    val next = list.asScala ++ List(4,5,6)
+    assert(next != list.asScala)
+
+    val raw = list.asScala
+    val cloned = raw.clone
+    list.add(1)
+    assert(raw != cloned)
+  }
+  def testSet = {
+    val set = new java.util.HashSet[Int]
+    set.add(1)
+    set.add(2)
+    set.add(3)
+    import scala.collection.JavaConverters._
+    val next = set.asScala ++ Set(4,5,6)
+    assert(next != set.asScala)
+
+    val raw = set.asScala
+    val cloned = raw.clone
+    set.add(4)
+    assert(raw != cloned)
+  }
+  def testMap = {
+    val map = new java.util.HashMap[Int,Int]
+    map.put(1,1)
+    map.put(2,2)
+    map.put(3,3)
+    import scala.collection.JavaConverters._
+    val next = map.asScala ++ Map(4->4,5->5,6->6)
+    assert(next != map.asScala)
+
+    val raw = map.asScala
+    val cloned = raw.clone
+    map.put(4,4)
+    assert(raw != cloned)
+  }
+
+  def testCollection = {
+    val list: java.util.Collection[Int] = new java.util.ArrayDeque[Int]
+    list.add(1)
+    list.add(2)
+    list.add(3)
+    import scala.collection.JavaConverters._
+    val next = list.asScala ++ List(4,5,6)
+    assert(next != list.asScala)
+
+    // Note: Clone is hidden at this level, so no overriden cloning.
+  }
+
+  testList
+  testSet
+  testMap
+  testCollection
+}


### PR DESCRIPTION
We solve this by overriding clone for JListWrapper to actually do a full clone.

Note: This fix may need to be included other places, _but_ we're not sure we've cloned the collection sensibly.  I.e.  is ArrayList a good default?

Reveiw by @alex22 or @paulp
