### PR TITLE
Fixes SI-6285 - ParIterableLike no longer says sequential foreach.

### DIFF
--- a/src/library/scala/collection/parallel/ParIterableLike.scala
+++ b/src/library/scala/collection/parallel/ParIterableLike.scala
@@ -453,7 +453,7 @@ self: ParIterableLike[T, Repr, Sequential] =>
 
   def reduceRightOption[U >: T](op: (T, U) => U): Option[U] = seq.reduceRightOption(op)
 
-  /** Applies a function `f` to all the elements of $coll in a sequential order.
+  /** Applies a function `f` to all the elements of $coll in a undefined order.
    *
    *  @tparam U    the result type of the function applied to each element, which is always discarded
    *  @param f     function applied to each element


### PR DESCRIPTION
Review by @alex22, @phaller or anyone into documentation + collections.
