### PR TITLE
[backport] Allow nested calls to `askForResponse` in the presentation compiler.

### DIFF
--- a/src/compiler/scala/tools/nsc/interactive/CompilerControl.scala
+++ b/src/compiler/scala/tools/nsc/interactive/CompilerControl.scala
@@ -256,12 +256,18 @@ trait CompilerControl { self: Global =>
    */
   def askForResponse[A](op: () => A): Response[A] = {
     val r = new Response[A]
-    val ir = scheduler askDoQuickly op
-    ir onComplete {
-      case Left(result) => r set result
-      case Right(exc) => r raise exc
+    if (self.onCompilerThread) {
+      try   { r set op() }
+      catch { case exc: Throwable => r raise exc }
+      r
+    } else {
+      val ir = scheduler askDoQuickly op
+      ir onComplete {
+        case Left(result) => r set result
+        case Right(exc)   => r raise exc
+      }
+      r
     }
-    r
   }
 
   def onCompilerThread = Thread.currentThread == compileRunner

--- a/test/files/presentation/recursive-ask.check
+++ b/test/files/presentation/recursive-ask.check
@@ -1,0 +1,4 @@
+[ outer] askForResponse
+[nested] askForResponse
+passed
+done

--- a/test/files/presentation/recursive-ask/RecursiveAsk.scala
+++ b/test/files/presentation/recursive-ask/RecursiveAsk.scala
@@ -1,0 +1,20 @@
+import scala.tools.nsc.interactive.tests._
+
+object Test extends InteractiveTest {
+
+  override def main(args: Array[String]): Unit = {
+    val res0 = compiler.askForResponse( () => {
+      println("[ outer] askForResponse")
+      val res = compiler.askForResponse( () => { println("[nested] askForResponse") })
+      println (res.get(5000) match {
+        case Some(_) => "passed"
+        case None    => "timeout"
+      })
+    })
+
+    res0.get(5000)
+
+    println("done")
+    compiler.askShutdown()
+  }
+}


### PR DESCRIPTION
Fix #6312.

review by @odersky,@lrytz.

(cherry picked from commit 4f932df552fd2a9e1af31bc3b5fbbfeeaa15feed)
