### PR TITLE
Fixes SI-6271 - Missing isEmpty override for views.

### DIFF
--- a/src/library/scala/collection/GenIterableViewLike.scala
+++ b/src/library/scala/collection/GenIterableViewLike.scala
@@ -25,6 +25,7 @@ self =>
     def iterator: Iterator[B]
     override def foreach[U](f: B => U): Unit = iterator foreach f
     override def toString = viewToString
+    override def isEmpty = !iterator.hasNext
   }
 
   trait EmptyView extends Transformed[Nothing] with super.EmptyView {

--- a/test/files/run/t6271.scala
+++ b/test/files/run/t6271.scala
@@ -1,0 +1,32 @@
+object Test extends App {
+  def filterIssue = {
+    val viewed : Iterable[Iterable[Int]] = List(List(0).view).view
+    val filtered = viewed flatMap { x => List( x filter (_ > 0) ) }
+    filtered.iterator.toIterable.flatten
+  }
+  def takenIssue = {
+    val viewed : Iterable[Iterable[Int]] = List(List(0).view).view
+    val filtered = viewed flatMap { x => List( x take 0 ) }
+    filtered.iterator.toIterable.flatten
+  }
+  def droppedIssue = {
+    val viewed : Iterable[Iterable[Int]] = List(List(0).view).view
+    val filtered = viewed flatMap { x => List( x drop 1 ) }
+    filtered.iterator.toIterable.flatten
+  }
+  def flatMappedIssue = {
+    val viewed : Iterable[Iterable[Int]] = List(List(0).view).view
+    val filtered = viewed flatMap { x => List( x flatMap (_ => List()) ) }
+    filtered.iterator.toIterable.flatten
+  }
+  def slicedIssue = {
+    val viewed : Iterable[Iterable[Int]] = List(List(0).view).view
+    val filtered = viewed flatMap { x => List( x slice (2,3) ) }
+    filtered.iterator.toIterable.flatten
+  }
+  filterIssue
+  takenIssue
+  droppedIssue
+  flatMappedIssue
+  slicedIssue
+}


### PR DESCRIPTION
GenIterableView didn't override isEmpty for filter to look at _filtered_ iterator, but was instead pulling
unfiltered iterator and causing issues.   Chalk up another bizzare bug to lack of insight/visibility into
linearization and what havoc overriding new methods can spew on our library.

Review by @alex22, @paulp or anyone who loves inheritance (not the $$ kind).
