### PR TITLE
removes Type.isConcrete

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -630,7 +630,7 @@ trait Macros extends scala.tools.reflect.FastTrack with Traces {
                 macroDef.owner)
           } else
             targ.tpe
-          if (tpe.isConcrete) context.TypeTag(tpe) else context.AbsTypeTag(tpe)
+          context.AbsTypeTag(tpe)
         })
         macroTraceVerbose("tags: ")(tags)
 

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -317,25 +317,6 @@ trait Types extends api.Types { self: SymbolTable =>
     def substituteSymbols(from: List[Symbol], to: List[Symbol]): Type = substSym(from, to)
     def substituteTypes(from: List[Symbol], to: List[Type]): Type = subst(from, to)
 
-    def isConcrete = {
-      def notConcreteSym(sym: Symbol) =
-        sym.isAbstractType && !sym.isExistential
-
-      def notConcreteTpe(tpe: Type): Boolean = tpe match {
-        case ThisType(_) => false
-        case SuperType(_, _) => false
-        case SingleType(pre, sym) => notConcreteSym(sym)
-        case ConstantType(_) => false
-        case TypeRef(_, sym, args) => notConcreteSym(sym) || (args exists notConcreteTpe)
-        case RefinedType(_, _) => false
-        case ExistentialType(_, _) => false
-        case AnnotatedType(_, tp, _) => notConcreteTpe(tp)
-        case _ => true
-      }
-
-      !notConcreteTpe(this)
-    }
-
     // the only thingies that we want to splice are: 1) type parameters, 2) abstract type members
     // the thingies that we don't want to splice are: 1) concrete types (obviously), 2) existential skolems
     def isSpliceable = {

--- a/test/files/run/macro-expand-tparams-implicit.check
+++ b/test/files/run/macro-expand-tparams-implicit.check
@@ -1,2 +1,2 @@
 TypeTag[Int]
-TypeTag[String]
+AbsTypeTag[String]

--- a/test/files/run/macro-expand-tparams-prefix-a.check
+++ b/test/files/run/macro-expand-tparams-prefix-a.check
@@ -1,4 +1,4 @@
 TypeTag[Int]
 TypeTag[Int]
-TypeTag[String]
+AbsTypeTag[String]
 TypeTag[Boolean]

--- a/test/files/run/macro-expand-tparams-prefix-b.check
+++ b/test/files/run/macro-expand-tparams-prefix-b.check
@@ -1,2 +1,2 @@
 TypeTag[Boolean] TypeTag[Int]
-TypeTag[Boolean] TypeTag[String]
+TypeTag[Boolean] AbsTypeTag[String]

--- a/test/files/run/macro-expand-tparams-prefix-c1.check
+++ b/test/files/run/macro-expand-tparams-prefix-c1.check
@@ -1,3 +1,3 @@
 TypeTag[Int]
-TypeTag[String]
+AbsTypeTag[String]
 TypeTag[Boolean]

--- a/test/files/run/macro-expand-tparams-prefix-c2.check
+++ b/test/files/run/macro-expand-tparams-prefix-c2.check
@@ -1,3 +1,3 @@
 TypeTag[Int]
-TypeTag[String]
+AbsTypeTag[String]
 TypeTag[Boolean]

--- a/test/files/run/macro-undetparams-macroitself.check
+++ b/test/files/run/macro-undetparams-macroitself.check
@@ -1,2 +1,2 @@
 TypeTag[Int]
-TypeTag[String]
+AbsTypeTag[String]


### PR DESCRIPTION
This method was no longer used anywhere, except for a place where it wasn't
really necessary.

Its implementation is non-trivial, and I have doubts about it, so I propose
to remove it altogether instead of living with some dubious code necessary
for some dubious matter.
