### PR TITLE
removes isLocatable from the public API

### DIFF
--- a/src/reflect/scala/reflect/api/Symbols.scala
+++ b/src/reflect/scala/reflect/api/Symbols.scala
@@ -140,18 +140,6 @@ trait Symbols extends base.Symbols { self: Universe =>
      */
     def isErroneous : Boolean
 
-    /** Can this symbol be loaded by a reflective mirror?
-     *
-     *  Scalac relies on `ScalaSignature' annotation to retain symbols across compilation runs.
-     *  Such annotations (also called "pickles") are applied on top-level classes and include information
-     *  about all symbols reachable from the annotee. However, local symbols (e.g. classes or definitions local to a block)
-     *  are typically unreachable and information about them gets lost.
-     *
-     *  This method is useful for macro writers who wish to save certain ASTs to be used at runtime.
-     *  With `isLocatable' it's possible to check whether a tree can be retained as is, or it needs special treatment.
-     */
-    def isLocatable: Boolean
-
     /** Is this symbol static (i.e. with no outer instance)?
      *  Q: When exactly is a sym marked as STATIC?
      *  A: If it's a member of a toplevel object, or of an object contained in a toplevel object, or any number of levels deep.

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -853,7 +853,16 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     final def isInitialized: Boolean =
       validTo != NoPeriod
 
-    /** Determines whether this symbol can be loaded by subsequent reflective compilation */
+    /** Can this symbol be loaded by a reflective mirror?
+     *
+     *  Scalac relies on `ScalaSignature' annotation to retain symbols across compilation runs.
+     *  Such annotations (also called "pickles") are applied on top-level classes and include information
+     *  about all symbols reachable from the annotee. However, local symbols (e.g. classes or definitions local to a block)
+     *  are typically unreachable and information about them gets lost.
+     *
+     *  This method is useful for macro writers who wish to save certain ASTs to be used at runtime.
+     *  With `isLocatable' it's possible to check whether a tree can be retained as is, or it needs special treatment.
+     */
     final def isLocatable: Boolean = {
       if (this == NoSymbol) return false
       if (isRoot || isRootPackage) return true


### PR DESCRIPTION
Hard to come up with a good name, would need extensive documentation
to justify its purpose => no go. If necessary we can always reintroduce
it later in 2.10.1.
