### PR TITLE
SI-6335 More precise location of the implicit class synthetic method.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
@@ -369,7 +369,7 @@ trait MethodSynthesis {
     }
 
     /** A synthetic method which performs the implicit conversion implied by
-     *  the declaration of an implicit class.  Yet to be written.
+     *  the declaration of an implicit class.
      */
     case class ImplicitClassWrapper(tree: ClassDef) extends DerivedFromClassDef {
       def completer(sym: Symbol): Type = ??? // not needed
@@ -377,7 +377,7 @@ trait MethodSynthesis {
       def derivedSym: Symbol = {
         // Only methods will do! Don't want to pick up any stray
         // companion objects of the same name.
-        val result = enclClass.info decl name suchThat (_.isMethod)
+        val result = enclClass.info decl name suchThat (x => x.isMethod && x.isSynthetic)
         assert(result != NoSymbol, "not found: "+name+" in "+enclClass+" "+enclClass.info.decls)
         result
       }

--- a/test/files/neg/t6335.check
+++ b/test/files/neg/t6335.check
@@ -1,0 +1,9 @@
+t6335.scala:6: error: method Z is defined twice
+  conflicting symbols both originated in file 't6335.scala'
+  implicit class Z[A](val i: A) { def zz = i }
+                 ^
+t6335.scala:3: error: method X is defined twice
+  conflicting symbols both originated in file 't6335.scala'
+  implicit class X(val x: Int) { def xx = x }
+                 ^
+two errors found

--- a/test/files/neg/t6335.scala
+++ b/test/files/neg/t6335.scala
@@ -1,0 +1,7 @@
+object ImplicitClass {
+  def X(i: Int) {}
+  implicit class X(val x: Int) { def xx = x }
+
+  def Z[A](i: A) {}
+  implicit class Z[A](val i: A) { def zz = i }
+}

--- a/test/files/pos/t6335.scala
+++ b/test/files/pos/t6335.scala
@@ -1,0 +1,11 @@
+object E {
+  def X = 3
+  implicit class X(val i: Int) {
+    def xx = i
+  }
+}
+
+object Test {
+	import E._
+	0.xx
+}

--- a/test/files/pos/t6335.scala
+++ b/test/files/pos/t6335.scala
@@ -1,11 +1,25 @@
-object E {
+object E extends Z {
   def X = 3
   implicit class X(val i: Int) {
     def xx = i
   }
+
+  def Y(a: Any) = 0
+  object Y
+  implicit class Y(val i: String) { def yy = i }
+
+  implicit class Z(val i: Boolean) { def zz = i }
+}
+
+trait Z {
+	def Z = 0
 }
 
 object Test {
 	import E._
 	0.xx
+
+	"".yy
+
+  true.zz
 }


### PR DESCRIPTION
One approach would be to disallow an implicit class in a template
that already has a member with the same name.

But this commit doesn't do this; instead it uses `isSynthetic` to
find the synthesized implicit conversion method from the potentially
overloaded alternatives.
