### PR TITLE
fix usage of Duration in Promise impl

### DIFF
--- a/src/library/scala/concurrent/Awaitable.scala
+++ b/src/library/scala/concurrent/Awaitable.scala
@@ -18,13 +18,18 @@ trait Awaitable[+T] {
   /**
    * Should throw [[scala.concurrent.TimeoutException]] if it times out
    * This method should not be called directly.
+   *
+   * @throws InterruptedException if the wait call was interrupted
    */
   @throws(classOf[TimeoutException])
+  @throws(classOf[InterruptedException])
   def ready(atMost: Duration)(implicit permit: CanAwait): this.type
   
   /**
    * Throws exceptions if it cannot produce a T within the specified time.
    * This method should not be called directly.
+   *
+   * @throws InterruptedException if the wait call was interrupted
    */
   @throws(classOf[Exception])
   def result(atMost: Duration)(implicit permit: CanAwait): T

--- a/src/library/scala/concurrent/Awaitable.scala
+++ b/src/library/scala/concurrent/Awaitable.scala
@@ -16,20 +16,34 @@ import scala.concurrent.util.Duration
 
 trait Awaitable[+T] {
   /**
-   * Should throw [[scala.concurrent.TimeoutException]] if it times out
+   * Await the "resolved" state of this Awaitable.
    * This method should not be called directly.
    *
-   * @throws InterruptedException if the wait call was interrupted
+   * @param atMost
+   *        maximum wait time, which may be negative (no waiting is done),
+   *        [[Duration.Inf]] for unbounded waiting, or a finite positive
+   *        duration
+   * @return the Awaitable itself
+   * @throws InterruptedException     if the wait call was interrupted
+   * @throws TimeoutException         if after waiting for the specified time this Awaitable is still not ready
+   * @throws IllegalArgumentException if `atMost` is [[Duration.Undefined]]
    */
   @throws(classOf[TimeoutException])
   @throws(classOf[InterruptedException])
   def ready(atMost: Duration)(implicit permit: CanAwait): this.type
   
   /**
-   * Throws exceptions if it cannot produce a T within the specified time.
+   * Await and return the result of this Awaitable, which is either of type T or a thrown exception (any Throwable).
    * This method should not be called directly.
    *
-   * @throws InterruptedException if the wait call was interrupted
+   * @param atMost
+   *        maximum wait time, which may be negative (no waiting is done),
+   *        [[Duration.Inf]] for unbounded waiting, or a finite positive
+   *        duration
+   * @return the value if the Awaitable was successful within the specific maximum wait time
+   * @throws InterruptedException     if the wait call was interrupted
+   * @throws TimeoutException         if after waiting for the specified time this Awaitable is still not ready
+   * @throws IllegalArgumentException if `atMost` is [[Duration.Undefined]]
    */
   @throws(classOf[Exception])
   def result(atMost: Duration)(implicit permit: CanAwait): T

--- a/src/library/scala/concurrent/BlockContext.scala
+++ b/src/library/scala/concurrent/BlockContext.scala
@@ -8,9 +8,6 @@
 
 package scala.concurrent
 
-import java.lang.Thread
-import scala.concurrent.util.Duration
-
 /**
  * A context to be notified by `scala.concurrent.blocking` when
  * a thread is about to block. In effect this trait provides

--- a/src/library/scala/concurrent/ExecutionContext.scala
+++ b/src/library/scala/concurrent/ExecutionContext.scala
@@ -10,7 +10,6 @@ package scala.concurrent
 
 
 import java.util.concurrent.{ ExecutorService, Executor }
-import scala.concurrent.util.Duration
 import scala.annotation.implicitNotFound
 import scala.util.Try
 

--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -16,7 +16,6 @@ import java.lang.{ Iterable => JIterable }
 import java.util.{ LinkedList => JLinkedList }
 import java.util.concurrent.atomic.{ AtomicReferenceFieldUpdater, AtomicInteger, AtomicBoolean }
 
-import scala.concurrent.util.Duration
 import scala.util.control.NonFatal
 import scala.Option
 import scala.util.{Try, Success, Failure}

--- a/src/library/scala/concurrent/impl/ExecutionContextImpl.scala
+++ b/src/library/scala/concurrent/impl/ExecutionContextImpl.scala
@@ -14,7 +14,6 @@ import java.util.concurrent.{ LinkedBlockingQueue, Callable, Executor, ExecutorS
 import java.util.Collection
 import scala.concurrent.forkjoin._
 import scala.concurrent.{ BlockContext, ExecutionContext, Awaitable, CanAwait, ExecutionContextExecutor, ExecutionContextExecutorService }
-import scala.concurrent.util.Duration
 import scala.util.control.NonFatal
 
 

--- a/src/library/scala/concurrent/package.scala
+++ b/src/library/scala/concurrent/package.scala
@@ -74,8 +74,10 @@ package concurrent {
      * @param awaitable   the `Awaitable` on which `ready` is to be called
      * @param atMost      the maximum timeout for which to wait
      * @return            the result of `awaitable.ready` which is defined to be the awaitable itself.
+     * @throws InterruptedException if the wait call was interrupted
      */
     @throws(classOf[TimeoutException])
+    @throws(classOf[InterruptedException])
     def ready[T](awaitable: Awaitable[T], atMost: Duration): awaitable.type =
       blocking(awaitable.ready(atMost)(AwaitPermission))
     
@@ -87,6 +89,7 @@ package concurrent {
      * @param awaitable   the `Awaitable` on which `result` is to be called
      * @param atMost      the maximum timeout for which to wait
      * @return            the result of `awaitable.result`
+     * @throws InterruptedException if the wait call was interrupted
      */
     @throws(classOf[Exception])
     def result[T](awaitable: Awaitable[T], atMost: Duration): T =

--- a/src/library/scala/concurrent/package.scala
+++ b/src/library/scala/concurrent/package.scala
@@ -67,14 +67,19 @@ package concurrent {
    */
   object Await {
     /**
+     * Await the "resolved" state of this Awaitable.
      * Invokes ready() on the awaitable, properly wrapped by a call to `scala.concurrent.blocking`.
-     * ready() blocks until the awaitable has completed or the timeout expires.
      *
-     * Throws a TimeoutException if the timeout expires, as that is in the contract of `Awaitable.ready`.
-     * @param awaitable   the `Awaitable` on which `ready` is to be called
-     * @param atMost      the maximum timeout for which to wait
-     * @return            the result of `awaitable.ready` which is defined to be the awaitable itself.
-     * @throws InterruptedException if the wait call was interrupted
+     * @param awaitable
+     *        the `Awaitable` on which `ready` is to be called
+     * @param atMost
+     *        maximum wait time, which may be negative (no waiting is done),
+     *        [[Duration.Inf]] for unbounded waiting, or a finite positive
+     *        duration
+     * @return the awaitable itself
+     * @throws InterruptedException     if the wait call was interrupted
+     * @throws TimeoutException         if after waiting for the specified time this Awaitable is still not ready
+     * @throws IllegalArgumentException if `atMost` is [[Duration.Undefined]]
      */
     @throws(classOf[TimeoutException])
     @throws(classOf[InterruptedException])
@@ -82,14 +87,19 @@ package concurrent {
       blocking(awaitable.ready(atMost)(AwaitPermission))
     
     /**
+     * Await and return the result of this Awaitable, which is either of type T or a thrown exception (any Throwable).
      * Invokes result() on the awaitable, properly wrapped by a call to `scala.concurrent.blocking`.
-     * result() blocks until the awaitable has completed or the timeout expires.
      *
-     * Throws a TimeoutException if the timeout expires, or any exception thrown by `Awaitable.result`.
-     * @param awaitable   the `Awaitable` on which `result` is to be called
-     * @param atMost      the maximum timeout for which to wait
-     * @return            the result of `awaitable.result`
-     * @throws InterruptedException if the wait call was interrupted
+     * @param awaitable
+     *        the `Awaitable` on which `result` is to be called
+     * @param atMost
+     *        maximum wait time, which may be negative (no waiting is done),
+     *        [[Duration.Inf]] for unbounded waiting, or a finite positive
+     *        duration
+     * @return the value if the Awaitable was successful within the specific maximum wait time
+     * @throws InterruptedException     if the wait call was interrupted
+     * @throws TimeoutException         if after waiting for the specified time this Awaitable is still not ready
+     * @throws IllegalArgumentException if `atMost` is [[Duration.Undefined]]
      */
     @throws(classOf[Exception])
     def result[T](awaitable: Awaitable[T], atMost: Duration): T =

--- a/src/partest/scala/tools/partest/TestUtil.scala
+++ b/src/partest/scala/tools/partest/TestUtil.scala
@@ -1,5 +1,7 @@
 package scala.tools.partest
 
+import reflect.{ classTag, ClassTag }
+
 trait TestUtil {
   /** Given function and block of code, evaluates code block,
    *  calls function with nanoseconds elapsed, and returns block result.
@@ -29,6 +31,14 @@ trait TestUtil {
 
     assert(mult <= acceptableMultiple, "Performance difference too great: multiple = " + mult)
   }
+
+  def intercept[T <: Exception : ClassTag](code: => Unit): Unit =
+    try {
+      code
+      assert(false, "did not throw " + classTag[T])
+    } catch {
+      case ex: Exception if classTag[T].runtimeClass isInstance ex =>
+    }
 }
 
 object TestUtil extends TestUtil {

--- a/test/files/jvm/scala-concurrent-tck.scala
+++ b/test/files/jvm/scala-concurrent-tck.scala
@@ -11,6 +11,7 @@ import scala.concurrent.{
 import scala.concurrent.{ future, promise, blocking }
 import scala.util.{ Try, Success, Failure }
 import scala.concurrent.util.Duration
+import scala.reflect.{ classTag, ClassTag }
 
 trait TestBase {
   
@@ -19,6 +20,14 @@ trait TestBase {
     body(() => sv put true)
     sv.take(2000)
   }
+
+  def intercept[T <: Exception : ClassTag](code: => Unit): Unit =
+    try {
+      code
+      assert(false, "did not throw " + classTag[T])
+    } catch {
+      case ex: Exception if classTag[T].runtimeClass isInstance ex =>
+    }
   
   // def assert(cond: => Boolean) {
   //   try {
@@ -663,6 +672,29 @@ trait FutureProjections extends TestBase {
       case nsee: NoSuchElementException => done()
     }
   }
+
+  def testAwaitPositiveDuration(): Unit = once { done =>
+    val p = Promise[Int]()
+    val f = p.future
+    future {
+      intercept[IllegalArgumentException] { Await.ready(f, Duration.Undefined) }
+      p.success(0)
+      Await.ready(f, Duration.Zero)
+      Await.ready(f, Duration(500, "ms"))
+      Await.ready(f, Duration.Inf)
+      done()
+    } onFailure { case x => throw x }
+  }
+
+  def testAwaitNegativeDuration(): Unit = once { done =>
+    val f = Promise().future
+    future {
+      intercept[TimeoutException] { Await.ready(f, Duration.Zero) }
+      intercept[TimeoutException] { Await.ready(f, Duration.MinusInf) }
+      intercept[TimeoutException] { Await.ready(f, Duration(-500, "ms")) }
+      done()
+    } onFailure { case x => throw x }
+  }
   
   testFailedFailureOnComplete()
   testFailedFailureOnSuccess()
@@ -670,6 +702,8 @@ trait FutureProjections extends TestBase {
   testFailedSuccessOnFailure()
   testFailedFailureAwait()
   testFailedSuccessAwait()
+  testAwaitPositiveDuration()
+  testAwaitNegativeDuration()
   
 }
 

--- a/test/files/jvm/scala-concurrent-tck.scala
+++ b/test/files/jvm/scala-concurrent-tck.scala
@@ -12,6 +12,7 @@ import scala.concurrent.{ future, promise, blocking }
 import scala.util.{ Try, Success, Failure }
 import scala.concurrent.util.Duration
 import scala.reflect.{ classTag, ClassTag }
+import scala.tools.partest.TestUtil.intercept
 
 trait TestBase {
   
@@ -21,14 +22,6 @@ trait TestBase {
     sv.take(2000)
   }
 
-  def intercept[T <: Exception : ClassTag](code: => Unit): Unit =
-    try {
-      code
-      assert(false, "did not throw " + classTag[T])
-    } catch {
-      case ex: Exception if classTag[T].runtimeClass isInstance ex =>
-    }
-  
   // def assert(cond: => Boolean) {
   //   try {
   //     Predef.assert(cond)


### PR DESCRIPTION
- correctly treat MinusInf and Undefined
- don't toMillis in the timeout message (could be MinusInf)
- also notice that Inf did not actually wait unbounded
- and further notice that tryAwait swallows InterruptedException instead
  of bailing out early => changed to do so and added throws annotation
- also removed some unused imports of Duration
