### PR TITLE
Fixes SI-6268.  Improper multistring setting unparse.

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -536,7 +536,7 @@ class MutableSettings(val errorFn: String => Unit)
     }
     override def tryToSetColon(args: List[String]) = tryToSet(args)
     override def tryToSetFromPropertyValue(s: String) = tryToSet(s.trim.split(',').toList)
-    def unparse: List[String] = name :: value
+    def unparse: List[String] = value map (name + ":" + _)
 
     withHelpSyntax(name + ":<" + arg + ">")
   }

--- a/test/ant/test-basic/build.xml
+++ b/test/ant/test-basic/build.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project name="test-simple" default="compile">
+  <description>Super simple test for Scala</description>
+
+  <target name="init">
+     <!-- Define project CLASSPATH. -->
+    <property name="base.dir" value="../../.."/>
+    <property name="pack.dir" value="${base.dir}/build/pack/"/>
+    <property name="build.dir" value="classes"/>
+    <property name="src.dir" value="src"/>
+    <property name="jvmargs" value=""/>
+    <path id="scala.classpath">
+      <fileset dir="${pack.dir}/lib/"> <include name="*.jar" /> </fileset>
+    </path>
+
+    <!-- Define scala compiler, scaladoc, etc command -->
+    <taskdef resource="scala/tools/ant/antlib.xml">
+      <classpath refid="scala.classpath" />
+    </taskdef>
+  </target>
+
+  <target name="compile" depends="init">
+    <mkdir dir="${build.dir}"/>
+
+    <scalac srcdir="${src.dir}" destdir="${build.dir}"
+            classpathref="scala.classpath" fork="true" target="jvm-1.5"
+            deprecation="no" addparams="-no-specialization"
+            jvmargs="${jvmargs} -XX:+UseConcMarkSweepGC">
+      <include name="**/*.scala"/>
+    </scalac>
+  </target>
+</project>


### PR DESCRIPTION
Fixes SI-6268.   Review by @paulp and @lrytz.

This reverts a refactoring from https://github.com/scala/scala/commit/963aabbeb4

MultiString settings would not properly write an `unparse` string that could be reparsed, leading to failures when forking scalac in ant.  Specifically, if a setting was empty, it was getting added to the unparse string and causing scalac to fail.   This at least reverts to previous behavior.   Whatever we do here has to work with the @file style argument reading and can't place empty options on the command line.   

Note:  The test is not automated yet, so unfortunately, we need to improve ANT testing capabilities to prevent regressons
