### PR TITLE
Avoid spurious warning for `def foo = x.foo`.

### DIFF
--- a/test/files/neg/t6276.check
+++ b/test/files/neg/t6276.check
@@ -1,13 +1,19 @@
-t6276.scala:4: error: method a does nothing other than call itself recursively
+t6276.scala:4: error: method a in class C does nothing other than call itself recursively
       def a: Any = a // warn
                    ^
-t6276.scala:5: error: value b does nothing other than call itself recursively
+t6276.scala:5: error: value b in class C does nothing other than call itself recursively
       val b: Any = b // warn
                    ^
-t6276.scala:10: error: method a does nothing other than call itself recursively
+t6276.scala:7: error: method c in class C does nothing other than call itself recursively
+      def c: Any = this.c // warn
+                        ^
+t6276.scala:8: error: method d in class C does nothing other than call itself recursively
+      def d: Any = C.this.d // warn
+                          ^
+t6276.scala:13: error: method a does nothing other than call itself recursively
       def a: Any = a // warn
                    ^
-t6276.scala:19: error: method a does nothing other than call itself recursively
+t6276.scala:22: error: method a does nothing other than call itself recursively
       def a = a // warn
               ^
-four errors found
+6 errors found

--- a/test/files/neg/t6276.scala
+++ b/test/files/neg/t6276.scala
@@ -1,8 +1,11 @@
 object Test {
   def foo(a: Int, b: Int, c: Int) {
-    new {
+    class C {
       def a: Any = a // warn
       val b: Any = b // warn
+
+      def c: Any = this.c // warn
+      def d: Any = C.this.d // warn
     }
 
     def method {
@@ -24,6 +27,18 @@ object Test {
       def a: Any = {println(""); a}
       val b: Any = {println(""); b}
       def c(i: Int): Any = c(i - 0)
+    }
+
+    class D {
+      def other: D = null
+      def foo: Any = other.foo
+    }
+
+    class E {
+      def foo: Any = 0
+      class D extends E {
+        override def foo: Any = E.this.foo
+      }
     }
   }
 }


### PR DESCRIPTION
Followup to SI-6276 (#1275)

Review by @paulp, and by checking the build logs on Jenkins to ensure the new warning isn't issued spuriously any more.
