### PR TITLE
A little cleanup along the Any to AnyRef trail.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -106,7 +106,7 @@ trait ContextErrors {
       else
         s"$name extends Any, not AnyRef"
     )
-    if (isPrimitiveValueType(found)) "" else "\n" +
+    if (isPrimitiveValueType(found) || isTrivialTopType(tp)) "" else "\n" +
        s"""|Note that $what.
            |Such types can participate in value classes, but instances
            |cannot appear in singleton types or in reference comparisons.""".stripMargin

--- a/src/library/scala/runtime/StringAdd.scala
+++ b/src/library/scala/runtime/StringAdd.scala
@@ -10,10 +10,5 @@ package scala.runtime
 
 /** A wrapper class that adds string concatenation `+` to any value */
 final class StringAdd(val self: Any) extends AnyVal {
-  // Note: The implicit conversion from Any to StringAdd is one of two
-  // implicit conversions from Any to AnyRef in Predef. It is important to have at least
-  // two such conversions, so that silent conversions from value types to AnyRef
-  // are avoided. If StringFormat should become a value class, another
-  // implicit conversion from Any to AnyRef has to be introduced in Predef
   def +(other: String) = String.valueOf(self) + other
 }

--- a/src/library/scala/runtime/StringFormat.scala
+++ b/src/library/scala/runtime/StringFormat.scala
@@ -11,12 +11,6 @@ package scala.runtime
 /** A wrapper class that adds a `formatted` operation to any value
  */
 final class StringFormat(val self: Any) extends AnyVal {
-  // Note: The implicit conversion from Any to StringFormat is one of two
-  // implicit conversions from Any to AnyRef in Predef. It is important to have at least
-  // two such conversions, so that silent conversions from value types to AnyRef
-  // are avoided. If StringFormat should become a value class, another
-  // implicit conversion from Any to AnyRef has to be introduced in Predef
-
   /** Returns string formatted according to given `format` string.
    *  Format strings are as for `String.format`
    *  (@see java.lang.String.format).

--- a/test/files/neg/no-implicit-to-anyref.check
+++ b/test/files/neg/no-implicit-to-anyref.check
@@ -1,0 +1,28 @@
+no-implicit-to-anyref.scala:11: error: type mismatch;
+ found   : Int(1)
+ required: AnyRef
+Note: an implicit exists from scala.Int => java.lang.Integer, but
+methods inherited from Object are rendered ambiguous.  This is to avoid
+a blanket implicit which would convert any scala.Int to any AnyRef.
+You may wish to use a type ascription: `x: java.lang.Integer`.
+    1: AnyRef
+    ^
+no-implicit-to-anyref.scala:17: error: type mismatch;
+ found   : Any
+ required: AnyRef
+    (null: Any): AnyRef
+         ^
+no-implicit-to-anyref.scala:21: error: type mismatch;
+ found   : AnyVal
+ required: AnyRef
+    (0: AnyVal): AnyRef
+      ^
+no-implicit-to-anyref.scala:27: error: type mismatch;
+ found   : Test.AV
+ required: AnyRef
+Note that AV extends Any, not AnyRef.
+Such types can participate in value classes, but instances
+cannot appear in singleton types or in reference comparisons.
+    new AV(0): AnyRef
+    ^
+four errors found

--- a/test/files/neg/no-implicit-to-anyref.scala
+++ b/test/files/neg/no-implicit-to-anyref.scala
@@ -1,0 +1,29 @@
+// Checks that the state of standard implicits in Predef._ and scala._
+// doesn't allow us to unambiguously and implicitly convert AnyVal
+// and subtypes to AnyRef.
+//
+// In the days before value classes, this was precariously held be
+// the competing implicits Any => StringAdd and Any => StringFormat.
+// Since then, these have both become value classes, but seeing as
+// this happened simultaneously, we're still okay.
+object Test {
+  locally {
+    1: AnyRef
+  }
+
+  locally {
+    // before this test case was added and ContextErrors was tweaked, this
+    // emitted: "Note that Any extends Any, not AnyRef."
+    (null: Any): AnyRef
+  }
+
+  locally {
+    (0: AnyVal): AnyRef
+  }
+
+  class AV(val a: Int) extends AnyVal
+
+  locally {
+    new AV(0): AnyRef
+  }
+}


### PR DESCRIPTION
Followup to 35316be and d3f879a.
- Remove obsolete comments and replace them with a test.
- Don't emit error addendum unless we know we're dealing
  with a value class.

review by @paulp
