### PR TITLE
Fixes SI-6259.  Unable to use typeOf in super call of top-level object.

### DIFF
--- a/src/compiler/scala/reflect/reify/package.scala
+++ b/src/compiler/scala/reflect/reify/package.scala
@@ -26,7 +26,14 @@ package object reify {
   private[reify] def mkDefaultMirrorRef(global: Global)(universe: global.Tree, typer0: global.analyzer.Typer): global.Tree = {
     import global._
     import definitions._
-    val enclosingErasure = reifyEnclosingRuntimeClass(global)(typer0)
+    val enclosingErasure = {
+      val rClassTree = reifyEnclosingRuntimeClass(global)(typer0)
+      // HACK around SI-6259
+      // If we're in the constructor of an object or others don't have easy access to `this`, we have no good way to grab
+      // the class of that object.  Instead, we construct an anonymous class and grab his class file, assuming
+      // this is enough to get the correct class loadeer for the class we *want* a mirror for, the object itself.
+      rClassTree orElse Apply(Select(treeBuilder.makeAnonymousNew(Nil), sn.GetClass), Nil)
+    }
     // JavaUniverse is defined in scala-reflect.jar, so we must be very careful in case someone reifies stuff having only scala-library.jar on the classpath
     val isJavaUniverse = JavaUniverseClass != NoSymbol && universe.tpe <:< JavaUniverseClass.toTypeConstructor
     if (isJavaUniverse && !enclosingErasure.isEmpty) Apply(Select(universe, nme.runtimeMirror), List(Select(enclosingErasure, sn.GetClassLoader)))
@@ -61,6 +68,8 @@ package object reify {
     }
   }
 
+  // Note: If  current context is inside the constructor of an object or otherwise not inside
+  // a class/object body, this will return an EmptyTree.
   def reifyEnclosingRuntimeClass(global: Global)(typer0: global.analyzer.Typer): global.Tree = {
     import global._
     import definitions._
@@ -68,8 +77,15 @@ package object reify {
     if (isThisInScope) {
       val enclosingClasses = typer0.context.enclosingContextChain map (_.tree) collect { case classDef: ClassDef => classDef }
       val classInScope = enclosingClasses.headOption getOrElse EmptyTree
+      def isUnsafeToUseThis = {
+        val isInsideConstructorSuper = typer0.context.enclosingContextChain exists (_.inSelfSuperCall)
+        // Note: It's ok to check for any object here, because if we were in an enclosing class, we'd already have returned its classOf
+        val isInsideObject = typer0.context.enclosingContextChain map (_.tree) exists {	case _: ModuleDef => true; case _ => false }
+        isInsideConstructorSuper && isInsideObject
+      }
       if (!classInScope.isEmpty) reifyRuntimeClass(global)(typer0, classInScope.symbol.toTypeConstructor, concrete = true)
-      else Select(This(tpnme.EMPTY), sn.GetClass)
+      else if(!isUnsafeToUseThis) Select(This(tpnme.EMPTY), sn.GetClass)
+      else EmptyTree
     } else EmptyTree
   }
 }

--- a/test/files/pos/t6259.scala
+++ b/test/files/pos/t6259.scala
@@ -1,0 +1,47 @@
+package t6259
+
+import scala.reflect.runtime.universe._
+
+class A[X](implicit val tt: TypeTag[X]) {}
+object B extends A[String]
+
+object C {
+  object D extends A[String]
+}
+
+trait E {
+  object F extends A[String]
+}
+
+class G {
+  object H extends A[String]
+}
+
+object Test {
+  val x = {
+    object InVal extends A[String]
+    5
+  }
+
+}
+
+// Note: Both of these fail right now.
+
+trait NeedsEarly {
+ val x: AnyRef
+}
+
+object Early extends {
+  // Drops to this.getClass and is not ok...
+  val x = { object EarlyOk extends A[String]; EarlyOk }
+} with NeedsEarly
+
+
+class DoubleTrouble[X](x: AnyRef)(implicit override val tt: TypeTag[X]) extends A[X]
+
+object DoubleOk extends DoubleTrouble[String]({
+  // Drops to this.getClass and is an issue 
+  object InnerTrouble extends A[String]; 
+  InnerTrouble 
+})
+

--- a/test/files/run/toolbox_typecheck_macrosdisabled.check
+++ b/test/files/run/toolbox_typecheck_macrosdisabled.check
@@ -1,6 +1,15 @@
 {
   val $u: ru.type = ru;
-  val $m: $u.Mirror = ru.rootMirror;
+  val $m: $u.Mirror = ru.runtimeMirror({
+  final class $anon extends scala.AnyRef {
+    def <init>(): anonymous class $anon = {
+      $anon.super.<init>();
+      ()
+    };
+    ()
+  };
+  new $anon()
+}.getClass().getClassLoader());
   $u.Expr.apply[Int(2)]($m, {
     final class $treecreator1 extends TreeCreator {
       def <init>(): $treecreator1 = {

--- a/test/files/run/toolbox_typecheck_macrosdisabled.scala
+++ b/test/files/run/toolbox_typecheck_macrosdisabled.scala
@@ -3,6 +3,10 @@ import scala.reflect.runtime.{universe => ru}
 import scala.reflect.runtime.{currentMirror => cm}
 import scala.tools.reflect.ToolBox
 
+// Note: If you're looking at this test and you don't know why, you may
+// have accidentally changed the way type tags reify.  If so, validate
+// that your changes are accurate and update the check file.
+
 object Test extends App {
   val toolbox = cm.mkToolBox()
   val rupkg = cm.staticModule("scala.reflect.runtime.package")

--- a/test/files/run/toolbox_typecheck_macrosdisabled2.check
+++ b/test/files/run/toolbox_typecheck_macrosdisabled2.check
@@ -1,6 +1,15 @@
 {
   val $u: ru.type = ru;
-  val $m: $u.Mirror = ru.rootMirror;
+  val $m: $u.Mirror = ru.runtimeMirror({
+  final class $anon extends scala.AnyRef {
+    def <init>(): anonymous class $anon = {
+      $anon.super.<init>();
+      ()
+    };
+    ()
+  };
+  new $anon()
+}.getClass().getClassLoader());
   $u.Expr.apply[Array[Int]]($m, {
     final class $treecreator1 extends TreeCreator {
       def <init>(): $treecreator1 = {

--- a/test/files/run/toolbox_typecheck_macrosdisabled2.scala
+++ b/test/files/run/toolbox_typecheck_macrosdisabled2.scala
@@ -3,6 +3,10 @@ import scala.reflect.runtime.{universe => ru}
 import scala.reflect.runtime.{currentMirror => cm}
 import scala.tools.reflect.ToolBox
 
+// Note: If you're looking at this test and you don't know why, you may
+// have accidentally changed the way type tags reify.  If so, validate
+// that your changes are accurate and update the check file.
+
 object Test extends App {
   val toolbox = cm.mkToolBox()
   val rupkg = cm.staticModule("scala.reflect.runtime.package")


### PR DESCRIPTION
This works around the issue of the inability to use classOf for top-level object classes by inventing a new
anonymous class and instantiating it just to grab its class.  Since the class is a nested type of the
top-level object it'll be in the same classloader unless some kind of evil behavior is afoot.

This patch should be undone if ever SI-2453 ever gets fixed, or we wind up with a direct way to grab
the class of an object.

Review by @xeno-by and @paulp
