### PR TITLE
Fixes binary repo push for new typesafe repo layouts.

### DIFF
--- a/tools/push.jar.desired.sha1
+++ b/tools/push.jar.desired.sha1
@@ -1,1 +1,1 @@
-de5d3eb21a732e4bce44c283ccfbd1ed94bfeaed ?push.jar
+a1883f4304d5aa65e1f6ee6aad5900c62dd81079 ?push.jar


### PR DESCRIPTION
This adds a new/fixed push.jar and adapts the binary-repo-lib script to use different URLs
for pulling than pushing.

Review by @lrytz + use by @xeno-by  / @paulp

Note to self: Cherry pick this against 2.9.x when able.
