### PR TITLE
SI-6359 Deep prohibition of templates in value class

### DIFF
--- a/test/files/neg/t6359.check
+++ b/test/files/neg/t6359.check
@@ -1,0 +1,7 @@
+t6359.scala:3: error: value class may not have nested module definitions
+      object X
+             ^
+t6359.scala:4: error: value class may not have nested class definitions
+      class Y
+            ^
+two errors found

--- a/test/files/neg/t6359.scala
+++ b/test/files/neg/t6359.scala
@@ -1,0 +1,8 @@
+class M(val t: Int) extends AnyVal {
+   def lazyString = {
+      object X
+      class Y
+
+      () => {X; new Y}
+   }
+}


### PR DESCRIPTION
This seems to have been the intent of 95d532 / SI-5882.

The method local object/classes are also generated with `outer` pointers, so we should also prohibit them, at least for now.

Review by @paulp or @odersky
