### PR TITLE
Made 'def clone()' consistent with parens everywhere.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/icode/Opcodes.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/Opcodes.scala
@@ -128,7 +128,7 @@ trait Opcodes { self: ICodes =>
     }
 
     /** Clone this instruction. */
-    override def clone: Instruction =
+    override def clone(): Instruction =
       super.clone.asInstanceOf[Instruction]
   }
 

--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -511,5 +511,5 @@ final class Array[T](_length: Int) extends java.io.Serializable with java.lang.C
    *
    *  @return A clone of the Array.
    */
-  override def clone: Array[T] = throw new Error()
+  override def clone(): Array[T] = throw new Error()
 }

--- a/src/library/scala/collection/mutable/Cloneable.scala
+++ b/src/library/scala/collection/mutable/Cloneable.scala
@@ -18,5 +18,5 @@ package mutable
  *  @tparam A    Type of the elements contained in the collection, covariant and with reference types as upperbound.
  */
 trait Cloneable[+A <: AnyRef] extends scala.Cloneable {
-  override def clone: A = super.clone().asInstanceOf[A]
+  override def clone(): A = super.clone().asInstanceOf[A]
 }

--- a/src/library/scala/collection/mutable/OpenHashMap.scala
+++ b/src/library/scala/collection/mutable/OpenHashMap.scala
@@ -195,7 +195,7 @@ extends AbstractMap[Key, Value]
     }
   }
 
-  override def clone = {
+  override def clone() = {
     val it = new OpenHashMap[Key, Value]
     foreachUndeletedEntry(entry => it.put(entry.key, entry.hash, entry.value.get));
     it

--- a/src/library/scala/collection/mutable/TreeSet.scala
+++ b/src/library/scala/collection/mutable/TreeSet.scala
@@ -103,7 +103,7 @@ class TreeSet[A](implicit val ordering: Ordering[A]) extends SortedSet[A] with S
    * the clone. So clone complexity in time is O(1).
    *
    */
-  override def clone: TreeSet[A] = {
+  override def clone(): TreeSet[A] = {
     val clone = new TreeSet[A](base, from, until)
     clone.avl = resolve.avl
     clone.cardinality = resolve.cardinality

--- a/src/library/scala/collection/mutable/WrappedArray.scala
+++ b/src/library/scala/collection/mutable/WrappedArray.scala
@@ -75,7 +75,7 @@ extends AbstractSeq[T]
   override def stringPrefix = "WrappedArray"
 
   /** Clones this object, including the underlying Array. */
-  override def clone: WrappedArray[T] = WrappedArray make array.clone()
+  override def clone(): WrappedArray[T] = WrappedArray make array.clone()
 
   /** Creates new builder for this collection ==> move to subclasses
    */


### PR DESCRIPTION
For the reference of others,

  ack --files-with-matches 'def clone[:\s]' src

is how you might find out who needs fixing.
