### PR TITLE
Make the scalac Ant task recognise -Yrangepos

### DIFF
--- a/src/compiler/scala/tools/ant/Scalac.scala
+++ b/src/compiler/scala/tools/ant/Scalac.scala
@@ -19,6 +19,7 @@ import org.apache.tools.ant.util.facade.{FacadeTaskHelper,
                                   ImplementationSpecificArgument}
 
 import scala.tools.nsc.{Global, Settings, CompilerCommand}
+import scala.tools.nsc.interactive.RangePositions
 import scala.tools.nsc.io.{Path => SPath}
 import scala.tools.nsc.reporters.{Reporter, ConsoleReporter}
 
@@ -518,7 +519,10 @@ class Scalac extends ScalaMatchingTask with ScalacShared {
     new Settings(error)
 
   protected def newGlobal(settings: Settings, reporter: Reporter) =
-    new Global(settings, reporter)
+    if (settings.Yrangepos.value)
+      new Global(settings, reporter) with RangePositions
+    else
+      new Global(settings, reporter)
 
 /*============================================================================*\
 **                           The big execute method                           **


### PR DESCRIPTION
The scalac Ant task was not setting up the Scala compiler to produce
range positions when specifying the -Yrangepos flag in its addparams
property.
