### PR TITLE
Fixes SI-6337 by siallowing nested value classes.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
@@ -135,7 +135,8 @@ abstract class ExtensionMethods extends Transform with TypingTransformers {
       tree match {
         case Template(_, _, _) =>
           if (currentOwner.isDerivedValueClass) {
-            checkNonCyclic(currentOwner.pos, Set(), currentOwner)
+          /* This is currently redundant since value classes may not
+            checkNonCyclic(currentOwner.pos, Set(), currentOwner) */
             extensionDefs(currentOwner.companionModule) = new mutable.ListBuffer[Tree]
             currentOwner.primaryConstructor.makeNotPrivate(NoSymbol)
             super.transform(tree)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1393,8 +1393,10 @@ trait Typers extends Modes with Adaptations with Tags {
           case List(acc) =>
             def isUnderlyingAcc(sym: Symbol) =
               sym == acc || acc.hasAccessorFlag && sym == acc.accessed
-          if (acc.accessBoundary(clazz) != rootMirror.RootClass)
+            if (acc.accessBoundary(clazz) != rootMirror.RootClass)
               unit.error(acc.pos, "value class needs to have a publicly accessible val parameter")
+            else if (acc.tpe.typeSymbol.isDerivedValueClass)
+              unit.error(acc.pos, "value class may not wrap another user-defined value class")
             for (stat <- body)
               if (!treeInfo.isAllowedInUniversalTrait(stat) && !isUnderlyingAcc(stat.symbol))
                 unit.error(stat.pos,

--- a/test/files/neg/t5878.check
+++ b/test/files/neg/t5878.check
@@ -1,13 +1,13 @@
-t5878.scala:1: error: value class may not unbox to itself
+t5878.scala:1: error: value class may not wrap another user-defined value class
 case class Foo(x: Bar) extends AnyVal
-           ^
-t5878.scala:2: error: value class may not unbox to itself
+               ^
+t5878.scala:2: error: value class may not wrap another user-defined value class
 case class Bar(x: Foo) extends AnyVal
-           ^
-t5878.scala:4: error: value class may not unbox to itself
+               ^
+t5878.scala:4: error: value class may not wrap another user-defined value class
 class Foo1(val x: Bar1) extends AnyVal
-      ^
-t5878.scala:5: error: value class may not unbox to itself
+               ^
+t5878.scala:5: error: value class may not wrap another user-defined value class
 class Bar1(val x: Foo1) extends AnyVal
-      ^
+               ^
 four errors found

--- a/test/files/neg/t6337.check
+++ b/test/files/neg/t6337.check
@@ -1,0 +1,7 @@
+t6337.scala:10: error: value class may not wrap another user-defined value class
+class X[T](val i: XX[T]) extends AnyVal
+               ^
+t6337.scala:20: error: value class may not wrap another user-defined value class
+class X1[T](val i: XX1[T]) extends AnyVal
+                ^
+two errors found

--- a/test/files/neg/t6337.scala
+++ b/test/files/neg/t6337.scala
@@ -1,0 +1,21 @@
+object C {
+
+  def main(args: Array[String]) = {
+    val x = new X(new XX(3))
+    println(x.i.x + 9)
+  }
+
+}
+
+class X[T](val i: XX[T]) extends AnyVal
+class XX[T](val x: T) extends AnyVal
+
+object C1 {
+  def main(args: Array[String]) {
+    val x = new X1(new XX1(Some(3)))
+    println(x.i.x.get + 9)
+  }
+}
+
+class X1[T](val i: XX1[T]) extends AnyVal
+class XX1[T](val x: Option[T]) extends AnyVal


### PR DESCRIPTION
It seems for the moment too hard to allow this, and the functionality to have value classes wrap other value classes does not seem essential. Review by @paulp @harrah
