### PR TITLE
SI-6336 Disallows value types in structuralal refinements

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1984,18 +1984,21 @@ trait Typers extends Modes with Adaptations with Tags {
         case PolyType(_, restpe)       => restpe
         case _                         => NoType
       }
-
+      def failStruct(what: String) =
+        fail(s"Parameter type in structural refinement may not refer to $what")
       for (paramType <- tp.paramTypes) {
         val sym = paramType.typeSymbol
 
         if (sym.isAbstractType) {
           if (!sym.hasTransOwner(meth.owner))
-            fail("Parameter type in structural refinement may not refer to an abstract type defined outside that refinement")
+            failStruct("an abstract type defined outside that refinement")
           else if (!sym.hasTransOwner(meth))
-            fail("Parameter type in structural refinement may not refer to a type member of that refinement")
+            failStruct("a type member of that refinement")
         }
+        if (sym.isDerivedValueClass)
+          failStruct("a user-defined value class")
         if (paramType.isInstanceOf[ThisType] && sym == meth.owner)
-          fail("Parameter type in structural refinement may not refer to the type of that refinement (self type)")
+          failStruct("the type of that refinement (self type)")
       }
     }
     def typedUseCase(useCase: UseCase) {

--- a/test/files/neg/t6336.check
+++ b/test/files/neg/t6336.check
@@ -1,0 +1,4 @@
+t6336.scala:3: error: Parameter type in structural refinement may not refer to a user-defined value class
+    val a = new { def y[T](x: X[T]) = x.i }
+                      ^
+one error found

--- a/test/files/neg/t6336.scala
+++ b/test/files/neg/t6336.scala
@@ -1,0 +1,11 @@
+object D {
+  def main(args: Array[String]) {
+    val a = new { def y[T](x: X[T]) = x.i }
+    val x = new X(3)
+    val t = a.y(x)
+    println(t)
+  }
+}
+
+class X[T](val i: Int) extends AnyVal
+


### PR DESCRIPTION
Structural refinements already have a number of restrictions, e.g. cannot refer to
type parameters of enclosing classes. We need to disallow value classes as well. Review by @harrah @paulp
