### PR TITLE
SI-5942 toolboxes now reset front ends

### DIFF
--- a/src/compiler/scala/tools/reflect/FrontEnds.scala
+++ b/src/compiler/scala/tools/reflect/FrontEnds.scala
@@ -36,6 +36,16 @@ trait FrontEnds extends scala.reflect.api.FrontEnds {
 
     def displayPrompt(): Unit =
       frontEnd.interactive()
+
+    override def flush(): Unit = {
+      super.flush()
+      frontEnd.flush()
+    }
+
+    override def reset(): Unit = {
+      super.reset()
+      frontEnd.reset()
+    }
   }
 
   def wrapFrontEnd(frontEnd: FrontEnd): Reporter = new FrontEndToReporterProxy(frontEnd) {

--- a/test/files/run/t5942.scala
+++ b/test/files/run/t5942.scala
@@ -1,0 +1,10 @@
+import scala.reflect.runtime.universe._
+import scala.reflect.runtime.{currentMirror => cm}
+import scala.tools.reflect._
+
+object Test extends App {
+  val tb = cm.mkToolBox()
+  tb.parse("def x = {}")
+  try { tb.parse("def x = {") } catch { case _ => }
+  tb.parse("def x = {}")
+}


### PR DESCRIPTION
FrontEnd => Reporter proxy now correctly redirects
flush and reset back to the underlying front end.
