### PR TITLE
SI-5692 better error message

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
@@ -69,7 +69,11 @@ abstract class Pickler extends SubComponent {
         }
 
         if (!t.isDef && t.hasSymbol && t.symbol.isTermMacro) {
-          unit.error(t.pos, "macro has not been expanded")
+          unit.error(t.pos, t.symbol.typeParams.length match {
+            case 0 => "macro has not been expanded"
+            case 1 => "type parameter not specified"
+            case _ => "type parameters not specified"
+          })
           return
         }
       }

--- a/test/files/neg/t5692a.check
+++ b/test/files/neg/t5692a.check
@@ -1,0 +1,4 @@
+Test_2.scala:2: error: type parameter not specified
+  def x = Macros.foo
+                 ^
+one error found

--- a/test/files/neg/t5692a.flags
+++ b/test/files/neg/t5692a.flags
@@ -1,0 +1,1 @@
+-language:experimental.macros

--- a/test/files/neg/t5692a/Macros_1.scala
+++ b/test/files/neg/t5692a/Macros_1.scala
@@ -1,0 +1,6 @@
+import scala.reflect.macros.Context
+
+object Macros {
+  def impl[T](c: Context) = c.literalUnit
+  def foo[T] = macro impl[T]
+}

--- a/test/files/neg/t5692a/Test_2.scala
+++ b/test/files/neg/t5692a/Test_2.scala
@@ -1,0 +1,3 @@
+class Test {
+  def x = Macros.foo
+}

--- a/test/files/neg/t5692b.check
+++ b/test/files/neg/t5692b.check
@@ -1,0 +1,4 @@
+Test_2.scala:2: error: type parameters not specified
+  def x = Macros.foo
+                 ^
+one error found

--- a/test/files/neg/t5692b.flags
+++ b/test/files/neg/t5692b.flags
@@ -1,0 +1,1 @@
+-language:experimental.macros

--- a/test/files/neg/t5692b/Macros_1.scala
+++ b/test/files/neg/t5692b/Macros_1.scala
@@ -1,0 +1,6 @@
+import scala.reflect.macros.Context
+
+object Macros {
+  def impl[T, U](c: Context) = c.literalUnit
+  def foo[T, U] = macro impl[T, U]
+}

--- a/test/files/neg/t5692b/Test_2.scala
+++ b/test/files/neg/t5692b/Test_2.scala
@@ -1,0 +1,3 @@
+class Test {
+  def x = Macros.foo
+}


### PR DESCRIPTION
Doesn't fix the underlying issue with macros and type inference,
but at least now the error message says exactly what needs to be done
to make the error go away.
