### PR TITLE
SI-6336 Now also catches return types

### DIFF
--- a/test/files/neg/t6336.check
+++ b/test/files/neg/t6336.check
@@ -1,4 +1,7 @@
 t6336.scala:3: error: Parameter type in structural refinement may not refer to a user-defined value class
     val a = new { def y[T](x: X[T]) = x.i }
                       ^
-one error found
+t6336.scala:4: error: Result type in structural refinement may not refer to a user-defined value class
+    val b = new { def y[T](x: T): X[T] = new X(2) }
+                      ^
+two errors found

--- a/test/files/neg/t6336.scala
+++ b/test/files/neg/t6336.scala
@@ -1,6 +1,7 @@
 object D {
   def main(args: Array[String]) {
     val a = new { def y[T](x: X[T]) = x.i }
+    val b = new { def y[T](x: T): X[T] = new X(2) }
     val x = new X(3)
     val t = a.y(x)
     println(t)


### PR DESCRIPTION
As Mark's comments on SI-6336 shows, we also need to disallow value classes
as return types of structural types. Review by @paulp @harrah
