### PR TITLE
Fixes SI-6354: improved error messages for Dynamic signature mismatches.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -515,8 +515,15 @@ trait ContextErrors {
       def ApplyWithoutArgsError(tree: Tree, fun: Tree) =
         NormalTypeError(tree, fun.tpe+" does not take parameters")
 
+      // Dynamic
       def DynamicVarArgUnsupported(tree: Tree, name: String) =
         issueNormalTypeError(tree, name+ " does not support passing a vararg parameter")
+
+      def DynamicRewriteError(tree: Tree, err: AbsTypeError) = {
+        issueTypeError(PosAndMsgTypeError(err.errPos, err.errMsg +
+            s"\nerror after rewriting to $tree\npossible cause: maybe a wrong Dynamic method signature?"))
+        setError(tree)
+      }
 
       //checkClassType
       def TypeNotAStablePrefixError(tpt: Tree, pre: Type) = {

--- a/test/files/neg/applydynamic_sip.check
+++ b/test/files/neg/applydynamic_sip.check
@@ -7,4 +7,52 @@ applydynamic_sip.scala:8: error: applyDynamicNamed does not support passing a va
 applydynamic_sip.scala:9: error: applyDynamicNamed does not support passing a vararg parameter
   qual.sel(arg, arg2 = "a2", a2: _*)
        ^
-three errors found
+applydynamic_sip.scala:18: error: type mismatch;
+ found   : String("sel")
+ required: Int
+error after rewriting to Test.this.bad1.selectDynamic("sel")
+possible cause: maybe a wrong Dynamic method signature?
+  bad1.sel
+  ^
+applydynamic_sip.scala:19: error: type mismatch;
+ found   : String("sel")
+ required: Int
+error after rewriting to Test.this.bad1.applyDynamic("sel")
+possible cause: maybe a wrong Dynamic method signature?
+  bad1.sel(1)
+  ^
+applydynamic_sip.scala:20: error: type mismatch;
+ found   : String("sel")
+ required: Int
+error after rewriting to Test.this.bad1.applyDynamicNamed("sel")
+possible cause: maybe a wrong Dynamic method signature?
+  bad1.sel(a = 1)
+  ^
+applydynamic_sip.scala:21: error: type mismatch;
+ found   : String("sel")
+ required: Int
+error after rewriting to Test.this.bad1.updateDynamic("sel")
+possible cause: maybe a wrong Dynamic method signature?
+  bad1.sel = 1
+  ^
+applydynamic_sip.scala:29: error: Int does not take parameters
+error after rewriting to Test.this.bad2.selectDynamic("sel")
+possible cause: maybe a wrong Dynamic method signature?
+  bad2.sel
+  ^
+applydynamic_sip.scala:30: error: Int does not take parameters
+error after rewriting to Test.this.bad2.applyDynamic("sel")
+possible cause: maybe a wrong Dynamic method signature?
+  bad2.sel(1)
+  ^
+applydynamic_sip.scala:31: error: Int does not take parameters
+error after rewriting to Test.this.bad2.applyDynamicNamed("sel")
+possible cause: maybe a wrong Dynamic method signature?
+  bad2.sel(a = 1)
+  ^
+applydynamic_sip.scala:32: error: Int does not take parameters
+error after rewriting to Test.this.bad2.updateDynamic("sel")
+possible cause: maybe a wrong Dynamic method signature?
+  bad2.sel = 1
+  ^
+11 errors found

--- a/test/files/neg/applydynamic_sip.flags
+++ b/test/files/neg/applydynamic_sip.flags
@@ -1,0 +1,1 @@
+-language:dynamics

--- a/test/files/neg/applydynamic_sip.scala
+++ b/test/files/neg/applydynamic_sip.scala
@@ -7,4 +7,27 @@ object Test extends App {
   qual.sel(a, a2: _*)
   qual.sel(arg = a, a2: _*)
   qual.sel(arg, arg2 = "a2", a2: _*)
+
+  val bad1 = new Dynamic {
+    def selectDynamic(n: Int) = n
+    def applyDynamic(n: Int) = n
+    def applyDynamicNamed(n: Int) = n
+    def updateDynamic(n: Int) = n
+
+  }
+  bad1.sel
+  bad1.sel(1)
+  bad1.sel(a = 1)
+  bad1.sel = 1
+
+  val bad2 = new Dynamic {
+    def selectDynamic = 1
+    def applyDynamic = 1
+    def applyDynamicNamed = 1
+    def updateDynamic = 1
+  }
+  bad2.sel
+  bad2.sel(1)
+  bad2.sel(a = 1)
+  bad2.sel = 1
 }


### PR DESCRIPTION
If an error occurs afer a Dynamic rewriting, augment the error message
with the rewritten tree and a hint to check the Dynamic method
signature.

Review by @hubertp.
