### PR TITLE
Fixes SI-5822 & SI-6305 - OSGi tests + fixes

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -22,7 +22,7 @@ END-USER TARGETS
   <target name="clean" depends="quick.clean"
     description="Removes binaries of compiler and library. Distributions are untouched."/>
 
-  <target name="test" depends="test.done"
+  <target name="test" depends="test.done, osgi.test"
     description="Runs test suite and bootstrapping test on Scala compiler and library."/>
 
   <target name="test-opt"
@@ -217,6 +217,7 @@ PROPERTIES
   <property name="build-palo.dir" value="${build.dir}/palo"/>
   <property name="build-quick.dir" value="${build.dir}/quick"/>
   <property name="build-pack.dir" value="${build.dir}/pack"/>
+  <property name="build-osgi.dir" value="${build.dir}/osgi"/>
   <property name="build-strap.dir" value="${build.dir}/strap"/>
   <property name="build-docs.dir" value="${build.dir}/scaladoc"/>
   <property name="build-libs.dir" value="${build.dir}/libs"/>
@@ -276,6 +277,28 @@ INITIALISATION
     <path id="maven-ant-tasks.classpath" path="${lib.dir}/ant/maven-ant-tasks-2.1.1.jar" />
     <typedef resource="org/apache/maven/artifact/ant/antlib.xml" uri="urn:maven-artifact-ant" classpathref="maven-ant-tasks.classpath" />
 
+    <property name="init.maven.tasks.finished" value="true" />
+  </target>
+
+  <target name="init.extra.tasks" depends="init.maven.tasks" unless="init.extra.tasks.finished">
+    <artifact:dependencies pathId="extra.tasks.classpath" filesetId="extra.tasks.fileset">
+      <dependency groupId="biz.aQute" artifactId="bnd" version="1.50.0"/>
+    </artifact:dependencies>
+    <!-- Pax runner -->
+    <property name="pax.exam.version" value="2.5.0"/>
+    <artifact:dependencies pathId="pax.exam.classpath" filesetId="pax.exam.fileset">
+      <dependency groupId="org.ops4j.pax.exam" artifactId="pax-exam-container-native" version="${pax.exam.version}"/>
+      <dependency groupId="org.ops4j.pax.exam" artifactId="pax-exam-junit4" version="${pax.exam.version}"/>
+      <dependency groupId="org.ops4j.pax.exam" artifactId="pax-exam-link-assembly" version="${pax.exam.version}"/>
+      <dependency groupId="org.ops4j.pax.url" artifactId="pax-url-aether" version="1.4.0"/>
+      <dependency groupId="org.ops4j.pax.swissbox" artifactId="pax-swissbox-framework" version="1.5.1"/>
+      <dependency groupId="ch.qos.logback" artifactId="logback-core" version="0.9.20"/>
+      <dependency groupId="ch.qos.logback" artifactId="logback-classic" version="0.9.20"/>
+      <dependency groupId="junit" artifactId="junit" version="4.10"/>
+      <dependency groupId="org.apache.felix" artifactId="org.apache.felix.framework" version="3.2.2"/>
+    </artifact:dependencies>
+    <!-- BND support -->
+    <typedef resource="aQute/bnd/ant/taskdef.properties" classpathref="extra.tasks.classpath" />
     <property name="init.maven.tasks.finished" value="true" />
   </target>
 
@@ -400,7 +423,7 @@ INITIALISATION
      </echo>
   </target>
 
-  <target name="init" depends="init.jars, init.maven.jars, init.version.done, init.fail.bad.jdk, init.warn.jdk7">
+  <target name="init" depends="init.jars, init.maven.jars, init.version.done, init.fail.bad.jdk, init.warn.jdk7, init.extra.tasks">
     <property name="scalac.args.always" value="-Yreify-copypaste" />
   <!-- scalac.args.optimise is selectively overridden in certain antcall tasks. -->
     <property name="scalac.args.optimise" value=""/>
@@ -1673,6 +1696,139 @@ PACKED QUICK BUILD (PACK)
   </target>
 
 <!-- ===========================================================================
+OSGi Artifacts
+============================================================================ -->
+
+  <target name="osgi.init" depends="pack.done">
+    <mkdir dir="${build-osgi.dir}"/>
+
+    <property name="osgi.test.src" value="${partest.dir}/osgi/src"/>
+    <property name="osgi.test.classes" value="${build-osgi.dir}/classes"/>
+
+    <!-- simplify fixing pom versions -->
+    <macrodef name="make-bundle">
+      <attribute name="name" />
+      <attribute name="version" />
+      <sequential>
+        <copy file="${src.dir}/build/bnd/@{name}.bnd" tofile="${build-osgi.dir}/@{name}.bnd" overwrite="true">
+          <filterset>
+            <filter token="VERSION" value="@{version}" />
+          </filterset>
+        </copy>
+        <bnd classpath="${build-pack.dir}/lib/@{name}.jar"
+             eclipse="false"
+             failok="false"
+             exceptions="true"
+             files="${build-osgi.dir}/@{name}.bnd"
+             output="${build-osgi.dir}"/>
+      </sequential>
+    </macrodef>
+    <macrodef name="make-plugin-bundle">
+      <attribute name="name" />
+      <attribute name="version" />
+      <sequential>
+        <copy file="${src.dir}/build/bnd/@{name}.bnd" tofile="${build-osgi.dir}/@{name}.bnd" overwrite="true">
+          <filterset>
+            <filter token="VERSION" value="@{version}" />
+          </filterset>
+        </copy>
+        <bnd classpath="${build-pack.dir}/misc/scala-devel/plugins/@{name}.jar"
+             eclipse="false"
+             failok="false"
+             exceptions="true"
+             files="${build-osgi.dir}/@{name}.bnd"
+             output="${build-osgi.dir}"/>
+      </sequential>
+    </macrodef>
+    <uptodate property="osgi.bundles.available" targetfile="${build-osgi.dir}/bundles.complete">
+      <srcfiles dir="${basedir}">
+        <include name="build.xml"/>
+        <include name="src/build/bnd/*.bnd"/>
+      </srcfiles>
+    </uptodate>
+  </target>
+
+  <target name="osgi.bundles" depends="osgi.init" unless="osgi.bundles.available">
+    <stopwatch name="osgi.bundle.timer"/>  
+    <make-bundle name="scala-library" version="${osgi.version.number}" />
+    <make-bundle name="scala-actors" version="${osgi.version.number}" />
+    <make-bundle name="scala-actors-migration" version="${osgi.version.number}" />
+    <make-bundle name="scala-reflect" version="${osgi.version.number}" />
+    <make-bundle name="scala-compiler" version="${osgi.version.number}" />
+    <make-plugin-bundle name="continuations" version="${osgi.version.number}" />
+    <touch file="${build-osgi.dir}/bundles.complete" verbose="no"/>
+    <stopwatch name="osgi.bundle.timer" action="total"/>   
+  </target>
+
+  <target name="osgi.bundles.swing" depends="osgi.init" if="has.java6" unless="osgi.bundles.available">
+    <!-- TODO - only if JDK6 -->
+    <make-bundle name="scala-swing" version="${osgi.version.number}"/>
+  </target>
+
+  <target name="osgi.done" depends="osgi.bundles, osgi.bundles.swing"/>
+
+  <target name="osgi.test.init" depends="osgi.done">
+    <path id="osgi.bundle.classpath">
+      <pathelement location="${build-osgi.dir}/org.scala-lang.scala-library.jar"/>
+      <pathelement location="${build-osgi.dir}/org.scala-lang.scala-reflect.jar"/>
+      <pathelement location="${build-osgi.dir}/org.scala-lang.scala-compiler.jar"/>
+      <pathelement location="${build-osgi.dir}/org.scala-lang.scala-actors.jar"/>
+      <pathelement location="${build-osgi.dir}/org.scala-lang.scala-actors-migration.jar"/>
+    </path>
+
+    <uptodate property="osgi.test.available" targetfile="${build-osgi.dir}/test-compile.complete">
+      <srcfiles dir="${osgi.test.src}">
+        <include name="**/*.scala"/>
+      </srcfiles>
+    </uptodate>
+  </target>
+
+  <target name="osgi.test.comp" depends="osgi.test.init, quick.done" unless="osgi.test.available">
+    <stopwatch name="osgi.test.comp.timer"/>
+    <mkdir dir="${osgi.test.classes}"/>
+    <scalacfork
+      destdir="${osgi.test.classes}"
+      compilerpathref="quick.classpath"
+      params="${scalac.args.quick}"
+      srcdir="${osgi.test.src}"
+      jvmargs="${scalacfork.jvmargs}">
+      <include name="**/*.scala"/>
+      <compilationpath>
+        <pathelement location="${osgi.test.classes}"/>
+        <path refid="osgi.bundle.classpath"/>
+        <path refid="pax.exam.classpath"/>
+        <path refid="forkjoin.classpath"/>
+      </compilationpath>
+    </scalacfork>
+    <touch file="${build-osgi.dir}/test-compile.complete" verbose="no"/>
+    <stopwatch name="osgi.test.comp.timer" action="total"/>   
+  </target>
+
+  <target name="osgi.test" depends="osgi.test.comp">
+    <stopwatch name="osgi.test.timer"/>
+    <mkdir dir="${osgi.test.classes}"/>
+    <junit fork="yes" haltonfailure="yes">
+      <classpath>
+        <pathelement location="${osgi.test.classes}"/>
+        <path refid="osgi.bundle.classpath"/>
+        <path refid="pax.exam.classpath"/>
+        <path refid="forkjoin.classpath"/>
+      </classpath>
+      <batchtest fork="yes" todir="${build-osgi.dir}">
+        <fileset dir="${osgi.test.classes}">
+          <include name="**/*Test.class"/>
+        </fileset>
+      </batchtest>
+      <formatter type="brief" usefile="false" />
+    </junit>
+    <stopwatch name="osgi.test.timer" action="total"/>   
+  </target>
+
+  <target name="osgi.clean">
+    <delete dir="${build-osgi.dir}" includeemptydirs="yes" quiet="yes" failonerror="no"/>
+  </target>
+
+<!-- ===========================================================================
 BOOTSTRAPPING BUILD (STRAP)
 ============================================================================ -->
 
@@ -2553,9 +2709,24 @@ BOOTRAPING TEST AND TEST SUITE
 DISTRIBUTION
 ============================================================================ -->
 
-  <target name="dist.start" depends="pack.done">
+  <target name="dist.start" depends="pack.done, osgi.done">
     <property name="dist.name" value="scala-${version.number}"/>
     <property name="dist.dir" value="${dists.dir}/${dist.name}"/>
+
+    <macrodef name="copy-bundle">
+      <attribute name="name" />
+      <sequential>
+        <copy file="${build-osgi.dir}/org.scala-lang.@{name}.jar" 
+          tofile="${dist.dir}/lib/@{name}.jar"/>
+      </sequential>
+    </macrodef>
+    <macrodef name="copy-plugin-bundle">
+      <attribute name="name" />
+      <sequential>
+        <copy file="${build-osgi.dir}/org.scala-lang.plugins.@{name}.jar" 
+          tofile="${dist.dir}/misc/scala-devel/plugins/@{name}.jar"/>
+      </sequential>
+    </macrodef>
   </target>
 
   <target name="dist.base" depends="dist.start">
@@ -2564,6 +2735,13 @@ DISTRIBUTION
       <fileset dir="${build-pack.dir}/lib"/>
     </copy>
     <mkdir dir="${dist.dir}/bin"/>
+    <!-- TODO - Stop being inefficient and don't copy OSGi bundles overtop other jars. -->
+    <copy-bundle name="scala-library"/>
+    <copy-bundle name="scala-reflect"/>
+    <copy-bundle name="scala-swing"/>
+    <copy-bundle name="scala-actors"/>
+    <copy-bundle name="scala-actors-migration"/>
+    <copy-bundle name="scala-compiler"/>
     <copy toDir="${dist.dir}/bin">
       <fileset dir="${build-pack.dir}/bin"/>
     </copy>
@@ -2573,9 +2751,7 @@ DISTRIBUTION
     <chmod perm="ugo+rx" file="${dist.dir}/bin/fsc"/>
     <chmod perm="ugo+rx" file="${dist.dir}/bin/scalap"/>
     <mkdir dir="${dist.dir}/misc/scala-devel/plugins"/>
-    <copy toDir="${dist.dir}/misc/scala-devel/plugins">
-      <fileset dir="${build-pack.dir}/misc/scala-devel/plugins"/>
-    </copy>
+    <copy-plugin-bundle name="continuations"/>
   </target>
 
   <target name="dist.doc" depends="dist.base, docs.done">
@@ -2663,7 +2839,7 @@ TEST AND DISTRIBUTION BUNDLE (ALL)
 
   <target name="all.done" depends="dist.done, test.done"/>
 
-  <target name="all.clean" depends="locker.clean, docs.clean, dist.clean, sbt.clean"/>
+  <target name="all.clean" depends="locker.clean, docs.clean, dist.clean, sbt.clean, osgi.clean"/>
 
 <!-- ===========================================================================
 STABLE REFERENCE (STARR)

--- a/src/build/bnd/continuations.bnd
+++ b/src/build/bnd/continuations.bnd
@@ -1,0 +1,5 @@
+Bundle-Name: Scala Continuations Plugin
+Bundle-SymbolicName: org.scala-lang.plugins.continuations
+ver: @VERSION@
+Bundle-Version: ${ver}
+Export-Package: *;version=${ver}

--- a/src/build/bnd/scala-actors-migration.bnd
+++ b/src/build/bnd/scala-actors-migration.bnd
@@ -1,0 +1,5 @@
+Bundle-Name: Scala Actors Migration
+Bundle-SymbolicName: org.scala-lang.scala-actors-migration
+ver: @VERSION@
+Bundle-Version: ${ver}
+Export-Package: *;version=${ver}

--- a/src/build/bnd/scala-actors.bnd
+++ b/src/build/bnd/scala-actors.bnd
@@ -1,0 +1,5 @@
+Bundle-Name: Scala Actors
+Bundle-SymbolicName: org.scala-lang.scala-actors
+ver: @VERSION@
+Bundle-Version: ${ver}
+Export-Package: *;version=${ver}

--- a/src/build/bnd/scala-compiler.bnd
+++ b/src/build/bnd/scala-compiler.bnd
@@ -1,0 +1,8 @@
+Bundle-Name: Scala Compiler
+Bundle-SymbolicName: org.scala-lang.scala-compiler
+ver: @VERSION@
+Bundle-Version: ${ver}
+Export-Package: *;version=${ver}
+Import-Package: scala.tools.jline.*;resolution:=optional, \
+                org.apache.tools.ant.*;resolution:=optional, \
+                *

--- a/src/build/bnd/scala-library.bnd
+++ b/src/build/bnd/scala-library.bnd
@@ -1,0 +1,6 @@
+Bundle-Name: Scala Standard Library
+Bundle-SymbolicName: org.scala-lang.scala-library
+ver: @VERSION@
+Bundle-Version: ${ver}
+Export-Package: *;version=${ver}
+Import-Package: sun.misc;resolution:=optional, *

--- a/src/build/bnd/scala-reflect.bnd
+++ b/src/build/bnd/scala-reflect.bnd
@@ -1,0 +1,6 @@
+Bundle-Name: Scala Reflect
+Bundle-SymbolicName: org.scala-lang.scala-reflect
+ver: @VERSION@
+Bundle-Version: ${ver}
+Export-Package: *;version=${ver}
+Import-Package: scala.tools.nsc;resolution:=optional, *

--- a/src/build/bnd/scala-swing.bnd
+++ b/src/build/bnd/scala-swing.bnd
@@ -1,0 +1,5 @@
+Bundle-Name: Scala Swing
+Bundle-SymbolicName: org.scala-lang.scala-swing
+ver: @VERSION@
+Bundle-Version: ${ver}
+Export-Package: *;version=${ver}

--- a/src/compiler/scala/tools/nsc/io/package.scala
+++ b/src/compiler/scala/tools/nsc/io/package.scala
@@ -11,6 +11,23 @@ import java.util.jar.{ Attributes }
 import scala.language.implicitConversions
 
 package object io {
+  // Forwarders from scala.reflect.io
+  type AbstractFile = scala.reflect.io.AbstractFile
+  val AbstractFile = scala.reflect.io.AbstractFile
+  type Directory = scala.reflect.io.Directory
+  val Directory = scala.reflect.io.Directory
+  type File = scala.reflect.io.File
+  val File = scala.reflect.io.File
+  type Path = scala.reflect.io.Path
+  val Path = scala.reflect.io.Path
+  type PlainFile = scala.reflect.io.PlainFile
+  val PlainFile = scala.reflect.io.PlainFile
+  val Streamable = scala.reflect.io.Streamable
+  type VirtualDirectory = scala.reflect.io.VirtualDirectory
+  type VirtualFile = scala.reflect.io.VirtualFile
+  val ZipArchive = scala.reflect.io.ZipArchive
+  type ZipArchive = scala.reflect.io.ZipArchive
+  
   implicit def postfixOps = scala.language.postfixOps // make all postfix ops in this package compile without warning
 
   type JManifest = java.util.jar.Manifest

--- a/src/reflect/scala/reflect/api/Symbols.scala
+++ b/src/reflect/scala/reflect/api/Symbols.scala
@@ -18,7 +18,7 @@ trait Symbols extends base.Symbols { self: Universe =>
     /** Source file if this symbol is created during this compilation run,
      *  or a class file if this symbol is loaded from a *.class or *.jar.
      */
-    def associatedFile: scala.tools.nsc.io.AbstractFile
+    def associatedFile: scala.reflect.io.AbstractFile
 
     /** A list of annotations attached to this Symbol.
      */

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -12,7 +12,7 @@ import util.Statistics
 import Flags._
 import base.Attachments
 import scala.annotation.tailrec
-import scala.tools.nsc.io.AbstractFile
+import scala.reflect.io.AbstractFile
 
 trait Symbols extends api.Symbols { self: SymbolTable =>
   import definitions._

--- a/src/reflect/scala/reflect/internal/util/SourceFile.scala
+++ b/src/reflect/scala/reflect/internal/util/SourceFile.scala
@@ -6,7 +6,7 @@
 
 package scala.reflect.internal.util
 
-import scala.tools.nsc.io.{ AbstractFile, VirtualFile }
+import scala.reflect.io.{ AbstractFile, VirtualFile }
 import scala.collection.mutable.ArrayBuffer
 import scala.annotation.tailrec
 import java.util.regex.Pattern

--- a/src/reflect/scala/reflect/io/AbstractFile.scala
+++ b/src/reflect/scala/reflect/io/AbstractFile.scala
@@ -4,7 +4,7 @@
  */
 
 
-package scala.tools.nsc
+package scala.reflect
 package io
 
 import java.io.{ FileOutputStream, IOException, InputStream, OutputStream, BufferedOutputStream }
@@ -13,6 +13,10 @@ import java.net.URL
 import scala.collection.mutable.ArrayBuffer
 
 /**
+ * An abstraction over files for use in the reflection/compiler libraries.
+ * 
+ * ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''
+ *  
  * @author Philippe Altherr
  * @version 1.0, 23/03/2004
  */
@@ -81,6 +85,8 @@ object AbstractFile {
  *   all other cases, the class <code>SourceFile</code> is used, which honors
  *   <code>global.settings.encoding.value</code>.
  * </p>
+ * 
+ * ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''
  */
 abstract class AbstractFile extends Iterable[AbstractFile] {
 

--- a/src/reflect/scala/reflect/io/Directory.scala
+++ b/src/reflect/scala/reflect/io/Directory.scala
@@ -6,11 +6,13 @@
 **                          |/                                          **
 \*                                                                      */
 
-package scala.tools.nsc
+package scala.reflect
 package io
 
 import java.io.{ File => JFile }
-
+/**
+ * ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''
+ */
 object Directory {
   import scala.util.Properties.{ tmpDir, userHome, userDir }
 
@@ -34,6 +36,8 @@ import Path._
  *
  *  @author  Paul Phillips
  *  @since   2.8
+ *  
+ *  ''Note:  This is library is considered experimental and should not be used unless you know what you are doing.''
  */
 class Directory(jfile: JFile) extends Path(jfile) {
   override def toAbsolute: Directory = if (isAbsolute) this else super.toAbsolute.toDirectory

--- a/src/reflect/scala/reflect/io/File.scala
+++ b/src/reflect/scala/reflect/io/File.scala
@@ -7,7 +7,7 @@
 \*                                                                      */
 
 
-package scala.tools.nsc
+package scala.reflect
 package io
 
 import java.io.{
@@ -17,7 +17,9 @@ import java.io.{ File => JFile }
 import java.nio.channels.{ Channel, FileChannel }
 import scala.io.Codec
 import scala.language.{reflectiveCalls, implicitConversions}
-
+/**
+ * ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''
+ */
 object File {
   def pathSeparator = java.io.File.pathSeparator
   def separator = java.io.File.separator
@@ -74,6 +76,8 @@ import Path._
  *
  *  @author  Paul Phillips
  *  @since   2.8
+ *  
+ *  ''Note:  This is library is considered experimental and should not be used unless you know what you are doing.''
  */
 class File(jfile: JFile)(implicit constructorCodec: Codec) extends Path(jfile) with Streamable.Chars {
   override val creationCodec = constructorCodec

--- a/src/reflect/scala/reflect/io/FileOperationException.scala
+++ b/src/reflect/scala/reflect/io/FileOperationException.scala
@@ -7,7 +7,7 @@
 \*                                                                      */
 
 
-package scala.tools.nsc
+package scala.reflect
 package io
-
+/** ''Note:  This library is considered experimental and should not be used unless you know what you are doing.'' */
 case class FileOperationException(msg: String) extends RuntimeException(msg)

--- a/src/reflect/scala/reflect/io/NoAbstractFile.scala
+++ b/src/reflect/scala/reflect/io/NoAbstractFile.scala
@@ -3,7 +3,7 @@
  * @author  Paul Phillips
  */
 
-package scala.tools.nsc
+package scala.reflect
 package io
 
 import java.io.InputStream
@@ -11,6 +11,8 @@ import java.io.{ File => JFile }
 
 /** A distinguished object so you can avoid both null
  *  and Option.
+ *  
+ *  ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''
  */
 object NoAbstractFile extends AbstractFile {
   def absolute: AbstractFile = this

--- a/src/reflect/scala/reflect/io/Path.scala
+++ b/src/reflect/scala/reflect/io/Path.scala
@@ -3,7 +3,7 @@
  * @author Paul Phillips
  */
 
-package scala.tools.nsc
+package scala.reflect
 package io
 
 import java.io.{
@@ -27,8 +27,9 @@ import scala.language.implicitConversions
  *
  *  @author  Paul Phillips
  *  @since   2.8
+ *  
+ *  ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''
  */
-
 object Path {
   def isExtensionJarOrZip(jfile: JFile): Boolean = isExtensionJarOrZip(jfile.getName)
   def isExtensionJarOrZip(name: String): Boolean = {
@@ -83,6 +84,8 @@ import Path._
 
 /** The Path constructor is private so we can enforce some
  *  semantics regarding how a Path might relate to the world.
+ *  
+ *  ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''
  */
 class Path private[io] (val jfile: JFile) {
   val separator = java.io.File.separatorChar

--- a/src/reflect/scala/reflect/io/PlainFile.scala
+++ b/src/reflect/scala/reflect/io/PlainFile.scala
@@ -4,12 +4,12 @@
  */
 
 
-package scala.tools.nsc
+package scala.reflect
 package io
 
 import java.io.{ FileInputStream, FileOutputStream, IOException }
 import PartialFunction._
-
+/** ''Note:  This library is considered experimental and should not be used unless you know what you are doing.'' */
 object PlainFile {
   /**
    * If the specified File exists, returns an abstract file backed
@@ -20,7 +20,7 @@ object PlainFile {
     else if (file.isFile) new PlainFile(file)
     else null
 }
-
+/** ''Note:  This library is considered experimental and should not be used unless you know what you are doing.'' */
 class PlainDirectory(givenPath: Directory) extends PlainFile(givenPath) {
   override def isDirectory = true
   override def iterator = givenPath.list filter (_.exists) map (x => new PlainFile(x))
@@ -28,6 +28,8 @@ class PlainDirectory(givenPath: Directory) extends PlainFile(givenPath) {
 }
 
 /** This class implements an abstract file backed by a File.
+ * 
+ * ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''
  */
 class PlainFile(val givenPath: Path) extends AbstractFile {
   assert(path ne null)

--- a/src/reflect/scala/reflect/io/Streamable.scala
+++ b/src/reflect/scala/reflect/io/Streamable.scala
@@ -3,7 +3,7 @@
  * @author Paul Phillips
  */
 
-package scala.tools.nsc
+package scala.reflect
 package io
 
 import java.net.{ URI, URL }
@@ -17,12 +17,15 @@ import Path.fail
  *
  *  @author Paul Phillips
  *  @since  2.8
+ *  
+ *  ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''
  */
-
 object Streamable {
   /** Traits which can be viewed as a sequence of bytes.  Source types
    *  which know their length should override def length: Long for more
    *  efficient method implementations.
+   *  
+   *  ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''
    */
   trait Bytes {
     def inputStream(): InputStream
@@ -66,6 +69,8 @@ object Streamable {
   }
 
   /** For objects which can be viewed as Chars.
+   * 
+   * ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''
    */
   trait Chars extends Bytes {
     /** Calls to methods requiring byte<->char transformations should be offered

--- a/src/reflect/scala/reflect/io/VirtualDirectory.scala
+++ b/src/reflect/scala/reflect/io/VirtualDirectory.scala
@@ -2,7 +2,7 @@
  * Copyright 2005-2012 LAMP/EPFL
  */
 
-package scala.tools.nsc
+package scala.reflect
 package io
 
 import scala.collection.mutable
@@ -11,6 +11,8 @@ import scala.collection.mutable
  * An in-memory directory.
  *
  * @author Lex Spoon
+ * 
+ * ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''
  */
 class VirtualDirectory(val name: String, maybeContainer: Option[VirtualDirectory])
 extends AbstractFile {

--- a/src/reflect/scala/reflect/io/VirtualFile.scala
+++ b/src/reflect/scala/reflect/io/VirtualFile.scala
@@ -4,7 +4,7 @@
  */
 
 
-package scala.tools.nsc
+package scala.reflect
 package io
 
 import java.io.{ ByteArrayInputStream, ByteArrayOutputStream, InputStream, OutputStream }
@@ -14,6 +14,8 @@ import java.io.{ File => JFile }
  *
  *  @author  Philippe Altherr
  *  @version 1.0, 23/03/2004
+ *  
+ *  ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''
  */
 class VirtualFile(val name: String, override val path: String) extends AbstractFile {
   /**

--- a/src/reflect/scala/reflect/io/ZipArchive.scala
+++ b/src/reflect/scala/reflect/io/ZipArchive.scala
@@ -3,7 +3,7 @@
  * @author  Paul Phillips
  */
 
-package scala.tools.nsc
+package scala.reflect
 package io
 
 import java.net.URL
@@ -20,6 +20,8 @@ import scala.annotation.tailrec
  *  @author  Philippe Altherr (original version)
  *  @author  Paul Phillips (this one)
  *  @version 2.0,
+ *  
+ *  ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''
  */
 object ZipArchive {
   def fromPath(path: String): FileZipArchive = fromFile(new JFile(path))
@@ -57,7 +59,7 @@ object ZipArchive {
   }
 }
 import ZipArchive._
-
+/** ''Note:  This library is considered experimental and should not be used unless you know what you are doing.'' */
 abstract class ZipArchive(override val file: JFile) extends AbstractFile with Equals {
   self =>
 
@@ -78,13 +80,14 @@ abstract class ZipArchive(override val file: JFile) extends AbstractFile with Eq
     }
   }
   def deepIterator = walkIterator(iterator)
-
+  /** ''Note:  This library is considered experimental and should not be used unless you know what you are doing.'' */
   sealed abstract class Entry(path: String) extends VirtualFile(baseName(path), path) {
     // have to keep this name for compat with sbt's compiler-interface
     def getArchive: ZipFile = null
     override def underlyingSource = Some(self)
     override def toString = self.path + "(" + path + ")"
   }
+  /** ''Note:  This library is considered experimental and should not be used unless you know what you are doing.'' */
   class DirEntry(path: String) extends Entry(path) {
     val entries = mutable.HashMap[String, Entry]()
 
@@ -120,7 +123,7 @@ abstract class ZipArchive(override val file: JFile) extends AbstractFile with Eq
     else ensureDir(dirs, dirName(entry.getName), null)
   }
 }
-
+/** ''Note:  This library is considered experimental and should not be used unless you know what you are doing.'' */
 final class FileZipArchive(file: JFile) extends ZipArchive(file) {
   def iterator: Iterator[Entry] = {
     val zipFile = new ZipFile(file)
@@ -161,7 +164,7 @@ final class FileZipArchive(file: JFile) extends ZipArchive(file) {
     case _                 => false
   }
 }
-
+/** ''Note:  This library is considered experimental and should not be used unless you know what you are doing.'' */
 final class URLZipArchive(val url: URL) extends ZipArchive(null) {
   def iterator: Iterator[Entry] = {
     val root     = new DirEntry("/")

--- a/src/reflect/scala/reflect/runtime/ReflectionUtils.scala
+++ b/src/reflect/scala/reflect/runtime/ReflectionUtils.scala
@@ -49,7 +49,7 @@ object ReflectionUtils {
       case cl: java.net.URLClassLoader =>
         (cl.getURLs mkString ",")
       case cl if cl != null && isAbstractFileClassLoader(cl.getClass) =>
-        cl.asInstanceOf[{val root: scala.tools.nsc.io.AbstractFile}].root.canonicalPath
+        cl.asInstanceOf[{val root: scala.reflect.io.AbstractFile}].root.canonicalPath
       case null =>
         inferBootClasspath
       case _ =>

--- a/src/reflect/scala/reflect/runtime/SynchronizedSymbols.scala
+++ b/src/reflect/scala/reflect/runtime/SynchronizedSymbols.scala
@@ -1,7 +1,7 @@
 package scala.reflect
 package runtime
 
-import scala.tools.nsc.io.AbstractFile
+import scala.reflect.io.AbstractFile
 
 trait SynchronizedSymbols extends internal.Symbols { self: SymbolTable =>
 

--- a/test/osgi/src/BasicLibrary.scala
+++ b/test/osgi/src/BasicLibrary.scala
@@ -1,4 +1,5 @@
 package tools.test.osgi
+package libonly
  
 import org.junit.Assert._
 import org.ops4j.pax.exam.CoreOptions._
@@ -17,17 +18,20 @@ import org.osgi.framework.BundleContext
 
 
 
-
-
 @RunWith(classOf[JUnit4TestRunner])
 @ExamReactorStrategy(Array(classOf[AllConfinedStagedReactorFactory]))
-class BasicTest extends ScalaOsgiHelper {
+class BasicLibraryTest extends ScalaOsgiHelper {
   @Configuration
-  def config(): Array[exam.Option] = {
-    // TODO - Find scala bundles.
-    standardOptions
-  }
+  def config(): Array[exam.Option] =
+    justCoreLibraryOptions
  
   @Test
-  def everythingLoads(): Unit = ()
+  def everythingLoads(): Unit = {
+     // Note - This tests sun.misc usage.
+     import scala.concurrent._
+     import scala.concurrent.util.Duration.Inf
+     import ExecutionContext.Implicits._
+     val x = Future(2) map (_ + 1)
+     assertEquals(3, Await.result(x, Inf))
+  }
 }

--- a/test/osgi/src/BasicReflection.scala
+++ b/test/osgi/src/BasicReflection.scala
@@ -1,0 +1,66 @@
+package tools.test.osgi
+package reflection
+package allmirrors
+ 
+import org.junit.Assert._
+import org.ops4j.pax.exam.CoreOptions._
+ 
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.ops4j.pax.exam
+import org.ops4j.pax.exam.junit.{
+  Configuration,
+  ExamReactorStrategy,
+  JUnit4TestRunner
+}
+import org.ops4j.pax.exam.spi.reactors.AllConfinedStagedReactorFactory
+import org.ops4j.pax.swissbox.framework.ServiceLookup
+import org.osgi.framework.BundleContext
+
+
+class C {
+  val f1 = 2
+  var f2 = 3
+
+  def m1 = 4
+  def m2() = 5
+  def m3[T >: String <: Int]: T = ???
+  def m4[A[_], B <: A[Int]](x: A[B])(implicit y: Int) = ???
+  def m5(x: => Int, y: Int*): String = ???
+
+  class C
+  object M
+
+  override def toString = "an instance of C"
+}
+object M
+
+
+@RunWith(classOf[JUnit4TestRunner])
+@ExamReactorStrategy(Array(classOf[AllConfinedStagedReactorFactory]))
+class BasicReflectionTest extends ScalaOsgiHelper {
+
+  @Configuration
+  def config(): Array[exam.Option] = 
+    scalaBundles
+
+  // Ensure Pax-exam requires C/M in our module
+  def dummy = {
+    new C
+    M.toString   
+  }
+ 
+  @Test
+  def basicMirrorThroughOsgi(): Unit = {
+    // Note for now just assert that we can do this stuff.
+    import scala.reflect.runtime.universe._
+    val cm = runtimeMirror(classOf[C].getClassLoader)
+    val im = cm.reflect(new C)
+    assertEquals("Unable to reflect field name!",
+                 "value f1", 
+                 im.reflectField(typeOf[C].member(newTermName("f1")).asTerm).symbol.toString)
+    assertEquals("Unable to reflect value!",
+                 2, 
+                 im.reflectField(typeOf[C].member(newTermName("f1")).asTerm).get)
+ }
+}

--- a/test/osgi/src/BasicReflection.scala
+++ b/test/osgi/src/BasicReflection.scala
@@ -1,6 +1,6 @@
 package tools.test.osgi
 package reflection
-package allmirrors
+package basic
  
 import org.junit.Assert._
 import org.ops4j.pax.exam.CoreOptions._
@@ -42,7 +42,7 @@ class BasicReflectionTest extends ScalaOsgiHelper {
 
   @Configuration
   def config(): Array[exam.Option] = 
-    scalaBundles
+    justReflectionOptions
 
   // Ensure Pax-exam requires C/M in our module
   def dummy = {

--- a/test/osgi/src/BasicTest.scala
+++ b/test/osgi/src/BasicTest.scala
@@ -1,0 +1,33 @@
+package tools.test.osgi
+ 
+import org.junit.Assert._
+import org.ops4j.pax.exam.CoreOptions._
+ 
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.ops4j.pax.exam
+import org.ops4j.pax.exam.junit.{
+  Configuration,
+  ExamReactorStrategy,
+  JUnit4TestRunner
+}
+import org.ops4j.pax.exam.spi.reactors.AllConfinedStagedReactorFactory
+import org.ops4j.pax.swissbox.framework.ServiceLookup
+import org.osgi.framework.BundleContext
+
+
+
+
+
+@RunWith(classOf[JUnit4TestRunner])
+@ExamReactorStrategy(Array(classOf[AllConfinedStagedReactorFactory]))
+class BasicTest extends ScalaOsgiHelper {
+  @Configuration
+  def config(): Array[exam.Option] = {
+    // TODO - Find scala bundles.
+    scalaBundles
+  }
+ 
+  @Test
+  def everythingLoads(): Unit = ()
+}

--- a/test/osgi/src/ReflectionToolboxTest.scala
+++ b/test/osgi/src/ReflectionToolboxTest.scala
@@ -1,0 +1,49 @@
+package tools.test.osgi
+package reflection
+package toolbox
+ 
+import org.junit.Assert._
+import org.ops4j.pax.exam.CoreOptions._
+ 
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.ops4j.pax.exam
+import org.ops4j.pax.exam.junit.{
+  Configuration,
+  ExamReactorStrategy,
+  JUnit4TestRunner
+}
+import org.ops4j.pax.exam.spi.reactors.AllConfinedStagedReactorFactory
+import org.ops4j.pax.swissbox.framework.ServiceLookup
+import org.osgi.framework.BundleContext
+
+
+class C {
+  val f1 = 2
+}
+
+@RunWith(classOf[JUnit4TestRunner])
+@ExamReactorStrategy(Array(classOf[AllConfinedStagedReactorFactory]))
+class ReflectionToolBoxTest extends ScalaOsgiHelper {
+
+  @Configuration
+  def config(): Array[exam.Option] = 
+    standardOptions
+
+ 
+  @Test
+  def basicMirrorThroughOsgi(): Unit = {
+    // Note - this tries to make sure when pulling a toolbox, we get the compiler.
+    import scala.reflect.runtime.universe._
+    import scala.tools.reflect.ToolBox
+    val cm = runtimeMirror(classOf[C].getClassLoader)
+    val tb = cm.mkToolBox()
+    val im = cm.reflect(new C)
+    val tree = tb.parse("1 to 3 map (_+1)")
+    val eval = tb.eval(tree)
+    assertEquals(Vector(2, 3, 4), eval)
+    assertEquals("Evaluate expression using local class.", 
+      2,
+      tb.eval(tb.parse("(new tools.test.osgi.reflection.toolbox.C).f1")))
+ }
+}

--- a/test/osgi/src/ScalaOsgiHelper.scala
+++ b/test/osgi/src/ScalaOsgiHelper.scala
@@ -1,0 +1,18 @@
+package tools.test.osgi
+ 
+import org.ops4j.pax.exam.CoreOptions._
+import org.ops4j.pax.exam
+import java.io.File
+
+trait ScalaOsgiHelper {
+  def scalaBundles: Array[exam.Option]  = {
+    def bundleLocation = new File(sys.props.getOrElse("scala.bundle.dir", "build/osgi"))
+    def bundleFiles = bundleLocation.listFiles filter (_.getName endsWith ".jar")
+    def makeBundle(file: File): exam.Option =
+      bundle(file.toURI.toASCIIString)
+    val bundles = (bundleFiles map makeBundle)
+    System.out.println(bundles)
+    bundles ++ Array[exam.Option](felix(), equinox(), junitBundles())
+  }
+ 
+}


### PR DESCRIPTION
This pull requests brings:
- OSGi manfiest generation (via BND) into the ant build.  
- Felix/equinox tests against the defined bundles.  The "basic" test is enough to ensure that our packages resolve correctly.  
- A very simplistic reflection test.   Tests basic mirror usage.  Any more and we start breaking (which I'll be reporting as bugs as soon as the ability to write tests for them is in the 2.10.x branch).
- Refactoring scala.tools.nsc.io split package so that it's OSGi friendly.

Note: These changes should _not_ affect normal dev.  Only running ant test or dist.done will cause the extra bundle creation.   I'll have to look into ways to speed it up more in the future.

Review by @xeno-by and @paulp

Special thanks to @jamie-allen and @martiell for help on this.
