### PR TITLE
Fix problem with names encoding in scalap.

### DIFF
--- a/src/scalap/scala/tools/scalap/Main.scala
+++ b/src/scalap/scala/tools/scalap/Main.scala
@@ -97,9 +97,14 @@ class Main {
    */
   def process(args: Arguments, path: ClassPath[AbstractFile])(classname: String): Unit = {
     // find the classfile
-    val encName = NameTransformer.encode(
-      if (classname == "scala.AnyRef") "java.lang.Object"
-      else classname)
+    val encName = classname match {
+      case "scala.AnyRef" => "java.lang.Object"
+      case _ =>
+        // we have to encode every fragment of a name separately, otherwise the NameTransformer
+        // will encode using unicode escaping dot separators as well
+        // we can afford allocations because this is not a performance critical code
+        classname.split('.').map(NameTransformer.encode).mkString(".")
+    }
     val cls = path.findClass(encName)
     if (cls.isDefined && cls.get.binary.isDefined) {
       val cfile = cls.get.binary.get


### PR DESCRIPTION
The refactoring performed in 020053c321 made use of naming encoding
more consisted but introduced a regression in scalap. The problem
is that the old encoder that scalap had didn't escape any characters
that were not included in its opcode list.

`NameTransformer` performs full encoding so it also encodes dots
that are being used as separators for packages. Therefore, in order
to retain the old behaviour we need to split the name by dots before
feeding each fragment to `NameTransformer`.

Review by @paulp.
