### PR TITLE
SI-6407 Better defaults for text encoding

### DIFF
--- a/src/library/scala/io/Codec.scala
+++ b/src/library/scala/io/Codec.scala
@@ -82,6 +82,7 @@ trait LowPriorityCodecImplicits {
 }
 
 object Codec extends LowPriorityCodecImplicits {
+  // TODO: Replace with java.nio.charset.StandardCharsets as soon as support for Java < 7 is dropped.
   final val ISO8859: Codec = new Codec(Charset forName "ISO-8859-1")
   final val UTF8: Codec    = new Codec(Charset forName "UTF-8")
 

--- a/src/library/scala/io/Source.scala
+++ b/src/library/scala/io/Source.scala
@@ -111,6 +111,7 @@ object Source {
   /** Create a `Source` from array of bytes, assuming
    *  one byte per character (ISO-8859-1 encoding.)
    */
+  @deprecated("Use `fromBytes` and specify encoding explicitly.", "2.10.0")
   def fromRawBytes(bytes: Array[Byte]): Source =
     fromString(new String(bytes, Codec.ISO8859.name))
 

--- a/src/library/scala/xml/XML.scala
+++ b/src/library/scala/xml/XML.scala
@@ -14,6 +14,7 @@ import java.io.{ File, FileDescriptor, FileInputStream, FileOutputStream }
 import java.io.{ InputStream, Reader, StringReader, Writer }
 import java.nio.channels.Channels
 import scala.util.control.Exception.ultimately
+import scala.annotation.migration
 
 object Source {
   def fromFile(file: File)              = new InputSource(new FileInputStream(file))
@@ -61,7 +62,8 @@ object XML extends XMLLoader[Elem] {
   val preserve  = "preserve"
   val space     = "space"
   val lang      = "lang"
-  val encoding  = "ISO-8859-1"
+  @migration("Default encoding changed from ISO-8859-1 to UTF-8.", "2.10.0")
+  val encoding  = "UTF-8"
 
   /** Returns an XMLLoader whose load* methods will use the supplied SAXParser. */
   def withSAXParser(p: SAXParser): XMLLoader[Elem] =


### PR DESCRIPTION
Traditionally there were two ways of getting a “default” text encoding:
- Assume UTF-8
- Use the underlying platform's encoding

We shouldn't invent an additional, third way to do that.
