### PR TITLE
don't try to create tags w/o scala-reflect.jar

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Tags.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Tags.scala
@@ -59,11 +59,14 @@ trait Tags {
      *           EmptyTree if `concrete` is true and the result contains unresolved (i.e. not spliced) type parameters and abstract type members.
      *           EmptyTree if `allowMaterialization` is false, and there is no array tag in scope.
      */
-    def resolveTypeTag(pos: Position, pre: Type, tp: Type, concrete: Boolean, allowMaterialization: Boolean = true): Tree = {
-      val tagSym = if (concrete) TypeTagClass else WeakTypeTagClass
-      val tagTp =  if (pre == NoType) TypeRef(ApiUniverseClass.toTypeConstructor, tagSym, List(tp)) else singleType(pre, pre member tagSym.name)
-      val taggedTp = appliedType(tagTp, List(tp))
-      resolveTag(pos, taggedTp, allowMaterialization)
-    }
+    def resolveTypeTag(pos: Position, pre: Type, tp: Type, concrete: Boolean, allowMaterialization: Boolean = true): Tree =
+      // if someone requests a type tag, but scala-reflect.jar isn't on the library classpath, then bail
+      if (pre == NoType && ApiUniverseClass == NoSymbol) EmptyTree
+      else {
+        val tagSym = if (concrete) TypeTagClass else WeakTypeTagClass
+        val tagTp =  if (pre == NoType) TypeRef(ApiUniverseClass.toTypeConstructor, tagSym, List(tp)) else singleType(pre, pre member tagSym.name)
+        val taggedTp = appliedType(tagTp, List(tp))
+        resolveTag(pos, taggedTp, allowMaterialization)
+      }
   }
 }

--- a/test/files/run/typetags_without_scala_reflect_manifest_lookup.scala
+++ b/test/files/run/typetags_without_scala_reflect_manifest_lookup.scala
@@ -1,0 +1,29 @@
+import scala.tools.partest._
+import scala.tools.nsc.Settings
+
+object Test extends DirectTest {
+  override def extraSettings = "-cp " + sys.props("partest.lib")
+
+  def code = """
+    object Test extends App {
+      // manifest lookup also involves type tag lookup
+      // because we support manifest <-> typetag convertability
+      //
+      // however when scala-reflect.jar (the home of type tags) is not on the classpath
+      // we need to omit the type tag lookup, because we lack the necessary symbols
+      // to do implicit search and tag materialization
+      // (such missing symbols are e.g. ApiUniverseClass and TypeTagsClass)
+      //
+      // the test case you're looking at checks exactly this
+      // we establish a classpath that only includes scala-library.jar
+      // and then force scalac to perform implicit search for a manifest
+      // if type tag lookup is not disabled, the compiler will crash
+      // if it is disabled, then the compilation will succeed
+      // http://groups.google.com/group/scala-internals/browse_thread/thread/166ce4b71b7c46bb
+      def foo[T: Manifest] = ()
+      foo[List[Int]]
+    }
+  """
+
+  def show = compile()
+}

--- a/test/files/run/typetags_without_scala_reflect_typetag_lookup.check
+++ b/test/files/run/typetags_without_scala_reflect_typetag_lookup.check
@@ -1,0 +1,3 @@
+newSource1:9: error: could not find implicit value for evidence parameter of type reflect.runtime.package.universe.TypeTag[Int]
+      Library.foo[Int]
+                 ^

--- a/test/files/run/typetags_without_scala_reflect_typetag_lookup.scala
+++ b/test/files/run/typetags_without_scala_reflect_typetag_lookup.scala
@@ -1,0 +1,45 @@
+import scala.tools.partest._
+
+object Test extends DirectTest {
+  def code = ???
+
+  def library = """
+    import scala.reflect.runtime.universe._
+
+    object Library {
+      def foo[T: TypeTag] = ()
+    }
+  """
+  def compileLibrary() = {
+    val classpath = List(sys.props("partest.lib"), sys.props("partest.reflect")) mkString sys.props("path.separator")
+    compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(library)
+  }
+
+  def app = """
+    object Test extends App {
+      // tries to materialize a type tag not having scala-reflect.jar on the classpath
+      // even though it's easy to materialize a type tag of Int, this line will fail
+      // because materialization involves classes from scala-reflect.jar
+      //
+      // in this test we make sure that the compiler doesn't crash
+      // but just displays several missing class file errors and an unavailable implicit message
+      Library.foo[Int]
+    }
+  """
+  def compileApp() = {
+    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
+    compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(app)
+  }
+
+  def show(): Unit = {
+    val prevErr = System.err
+    val baos = new java.io.ByteArrayOutputStream();
+    System.setErr(new java.io.PrintStream(baos));
+    compileLibrary();
+    compileApp();
+    // we should get bad symbolic reference errors, because we're trying to call a method that can't be unpickled
+    // but we don't know the number of these errors and their order, so I just ignore them all
+    baos.toString.split("\n") filter (!_.startsWith("error: bad symbolic reference")) foreach println
+    System.setErr(prevErr)
+  }
+}

--- a/test/files/run/typetags_without_scala_reflect_typetag_manifest_interop.check
+++ b/test/files/run/typetags_without_scala_reflect_typetag_manifest_interop.check
@@ -1,0 +1,3 @@
+newSource1:9: error: No Manifest available for App.this.T.
+      manifest[T]
+              ^

--- a/test/files/run/typetags_without_scala_reflect_typetag_manifest_interop.scala
+++ b/test/files/run/typetags_without_scala_reflect_typetag_manifest_interop.scala
@@ -1,0 +1,46 @@
+import scala.tools.partest._
+
+object Test extends DirectTest {
+  def code = ???
+
+  def library = """
+    import scala.reflect.runtime.universe._
+
+    trait Library {
+      type T
+      implicit val tt: TypeTag[T]
+    }
+  """
+  def compileLibrary() = {
+    val classpath = List(sys.props("partest.lib"), sys.props("partest.reflect")) mkString sys.props("path.separator")
+    compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(library)
+  }
+
+  def app = """
+    trait App extends Library {
+      // tries to create a manifest from a type tag without having scala-reflect.jar on the classpath
+      // even though it's possible to convert a type tag into a manifest, this will fail
+      // because conversion requires classes from scala-reflect.jar
+      //
+      // in this test we make sure that the compiler doesn't crash
+      // but just displays several missing class file errors and an unavailable implicit message
+      manifest[T]
+    }
+  """
+  def compileApp() = {
+    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
+    compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(app)
+  }
+
+  def show(): Unit = {
+    val prevErr = System.err
+    val baos = new java.io.ByteArrayOutputStream();
+    System.setErr(new java.io.PrintStream(baos));
+    compileLibrary();
+    compileApp();
+    // we should get bad symbolic reference errors, because we're trying to use an implicit that can't be unpickled
+    // but we don't know the number of these errors and their order, so I just ignore them all
+    baos.toString.split("\n") filter (!_.startsWith("error: bad symbolic reference")) foreach println
+    System.setErr(prevErr)
+  }
+}


### PR DESCRIPTION
Since recently type tags have relocated to scala-reflect.jar,
meaning that they are no longer always on library classpath.

In the compiler we do have code that generates type tags, and this code
is bound to fail if scala-reflect.jar isn't there.

I though this wouldn't be a problem, because type tag materialization
is only going to be triggered by users explicitly requesting a type tag.

That's generally true, but I overlooked a corner case. Since we provide
manifest <-> type tag compatibility, manifest lookup can sometimes trigger
tag lookup, which might result in tag synthesis, which blows up like this:
http://groups.google.com/group/scala-internals/browse_thread/thread/166ce4b71b7c46bb
