### PR TITLE
ActorRef API for the scala.concurrent

### DIFF
--- a/src/actors-migration/scala/actors/Pattern.scala
+++ b/src/actors-migration/scala/actors/Pattern.scala
@@ -17,9 +17,9 @@ class AskableActorRef(val ar: ActorRef) extends ActorRef {
 
   def !(message: Any)(implicit sender: ActorRef = null): Unit = ar.!(message)(sender)
 
-  def ?(message: Any)(timeout: Timeout): Future[Any] = ar.?(message, timeout.duration)
+  def ?(message: Any)(implicit timeout: Timeout): scala.concurrent.Future[Any] = ar.?(message, timeout.duration)
 
-  private[actors] def ?(message: Any, timeout: Duration): Future[Any] = ar.?(message, timeout)
+  private[actors] def ?(message: Any, timeout: Duration): scala.concurrent.Future[Any] = ar.?(message, timeout)
 
   def forward(message: Any) = ar.forward(message)
 

--- a/src/actors-migration/scala/actors/Pattern.scala
+++ b/src/actors-migration/scala/actors/Pattern.scala
@@ -6,7 +6,7 @@ import scala.language.implicitConversions
 
 object pattern {
 
-  implicit def askSupport(ar: ActorRef): AskableActorRef =
+  implicit def ask(ar: ActorRef): AskableActorRef =
     new AskableActorRef(ar)
 }
 

--- a/src/actors/scala/actors/ActorRef.scala
+++ b/src/actors/scala/actors/ActorRef.scala
@@ -28,7 +28,7 @@ trait ActorRef {
   /**
    * Sends a message asynchronously, returning a future which may eventually hold the reply.
    */
-  private[actors] def ?(message: Any, timeout: Duration): Future[Any]
+  private[actors] def ?(message: Any, timeout: Duration): scala.concurrent.Future[Any]
 
   /**
    * Forwards the message and passes the original sender actor as the sender.
@@ -43,7 +43,7 @@ trait ActorRef {
 
 private[actors] class OutputChannelRef(val actor: OutputChannel[Any]) extends ActorRef {
 
-  override private[actors] def ?(message: Any, timeout: Duration): Future[Any] =
+  override private[actors] def ?(message: Any, timeout: Duration): scala.concurrent.Future[Any] =
     throw new UnsupportedOperationException("Output channel does not support ?")
 
   /**
@@ -88,14 +88,15 @@ private[actors] final class InternalActorRef(override val actor: InternalActor) 
   /**
    * Sends a message asynchronously, returning a future which may eventually hold the reply.
    */
-  override private[actors] def ?(message: Any, timeout: Duration): Future[Any] =
-    Futures.future {
-      val dur = if (timeout.isFinite()) timeout.toMillis else (java.lang.Long.MAX_VALUE >> 2)
-      actor !? (dur, message) match {
-        case Some(x) => x
-        case None => new AskTimeoutException("? operation timed out.")
-      }
+  override private[actors] def ?(message: Any, timeout: Duration): scala.concurrent.Future[Any] = {
+    val dur = if (timeout.isFinite()) timeout.toMillis else (java.lang.Long.MAX_VALUE >> 2)
+    val replyPromise = scala.concurrent.Promise[Any]
+    val scalaFut = actor !? (dur, message) match {
+      case Some(x) => replyPromise success x
+      case None => replyPromise failure new AskTimeoutException("? operation timed out.")
     }
+    replyPromise.future
+  }
 
   override def !(message: Any)(implicit sender: ActorRef = null): Unit =
     if (message == PoisonPill)

--- a/test/files/jvm/actmig-PinS.scala
+++ b/test/files/jvm/actmig-PinS.scala
@@ -1,3 +1,7 @@
+/**
+ * NOTE: Code snippets from this test are included in the Actor Migration Guide. In case you change
+ * code in these tests prior to the 2.10.0 release please send the notification to @vjovanov.
+ */
 import scala.actors._
 import scala.concurrent.util.duration._
 import scala.concurrent.{ Promise, Await }

--- a/test/files/jvm/actmig-PinS_1.scala
+++ b/test/files/jvm/actmig-PinS_1.scala
@@ -1,3 +1,7 @@
+/**
+ * NOTE: Code snippets from this test are included in the Actor Migration Guide. In case you change
+ * code in these tests prior to the 2.10.0 release please send the notification to @vjovanov.
+ */
 import scala.actors._
 import scala.actors.migration._
 import scala.concurrent.util.duration._

--- a/test/files/jvm/actmig-PinS_2.scala
+++ b/test/files/jvm/actmig-PinS_2.scala
@@ -1,3 +1,7 @@
+/**
+ * NOTE: Code snippets from this test are included in the Actor Migration Guide. In case you change
+ * code in these tests prior to the 2.10.0 release please send the notification to @vjovanov.
+ */
 import scala.actors._
 import scala.actors.migration._
 import scala.concurrent.util.duration._

--- a/test/files/jvm/actmig-PinS_3.scala
+++ b/test/files/jvm/actmig-PinS_3.scala
@@ -1,3 +1,7 @@
+/**
+ * NOTE: Code snippets from this test are included in the Actor Migration Guide. In case you change
+ * code in these tests prior to the 2.10.0 release please send the notification to @vjovanov.
+ */
 import scala.actors._
 import scala.actors.migration._
 import scala.concurrent.util.duration._

--- a/test/files/jvm/actmig-hierarchy.scala
+++ b/test/files/jvm/actmig-hierarchy.scala
@@ -1,0 +1,47 @@
+/**
+ * NOTE: Code snippets from this test are included in the Actor Migration Guide. In case you change
+ * code in these tests prior to the 2.10.0 release please send the notification to @vjovanov.
+ */
+import scala.actors._
+
+
+class ReactorActor extends Reactor[String] {
+   def act() {
+     var cond = true
+     loopWhile(cond) {
+       react {
+         case x if x == "hello1" => println("hello")
+         case "exit" => cond = false
+       }
+     }
+   }
+}
+
+class ReplyActor extends ReplyReactor {
+   def act() {
+     var cond = true
+     loopWhile(cond) {
+       react {
+         case "hello" => println("hello")
+         case "exit" => cond = false;
+       }
+     }
+   }
+}
+
+
+object Test {
+
+  def main(args: Array[String]) {
+    val reactorActor = new ReactorActor
+    val replyActor = new ReplyActor
+    reactorActor.start()
+    replyActor.start()
+
+    reactorActor ! "hello1"
+    replyActor ! "hello"
+
+    reactorActor ! "exit"
+    replyActor ! "exit"
+  }
+}

--- a/test/files/jvm/actmig-hierarchy_1.scala
+++ b/test/files/jvm/actmig-hierarchy_1.scala
@@ -1,0 +1,45 @@
+/**
+ * NOTE: Code snippets from this test are included in the Actor Migration Guide. In case you change
+ * code in these tests prior to the 2.10.0 release please send the notification to @vjovanov.
+ */
+import scala.actors._
+
+class ReactorActor extends Actor {
+  def act() {
+    var cond = true
+    loopWhile(cond) {
+      react {
+        case x: String if x == "hello1" => println("hello")
+        case "exit" => cond = false
+      }
+    }
+  }
+}
+
+class ReplyActor extends Actor {
+  def act() {
+    var cond = true
+    loopWhile(cond) {
+      react {
+        case "hello" => println("hello")
+        case "exit" => cond = false;
+      }
+    }
+  }
+}
+
+object Test {
+
+  def main(args: Array[String]) {
+    val reactorActor = new ReactorActor
+    val replyActor = new ReplyActor
+    reactorActor.start()
+    replyActor.start()
+
+    reactorActor ! "hello1"
+    replyActor ! "hello"
+
+    reactorActor ! "exit"
+    replyActor ! "exit"
+  }
+}

--- a/test/files/jvm/actmig-instantiation.scala
+++ b/test/files/jvm/actmig-instantiation.scala
@@ -1,0 +1,96 @@
+/**
+ * NOTE: Code snippets from this test are included in the Actor Migration Guide. In case you change
+ * code in these tests prior to the 2.10.0 release please send the notification to @vjovanov.
+ */
+import scala.actors.migration.MigrationSystem._
+import scala.actors.migration._
+import scala.actors.Actor._
+import scala.actors._
+import java.util.concurrent.{ TimeUnit, CountDownLatch }
+import scala.collection.mutable.ArrayBuffer
+
+class TestStashingActor extends StashingActor {
+
+  def receive = { case v: Int => Test.append(v); Test.latch.countDown() }
+
+}
+
+object Test {
+  val NUMBER_OF_TESTS = 5
+
+  // used for sorting non-deterministic output
+  val buff = ArrayBuffer[Int](0)
+  val latch = new CountDownLatch(NUMBER_OF_TESTS)
+  val toStop = ArrayBuffer[ActorRef]()
+
+  def append(v: Int) = synchronized {
+    buff += v
+  }
+
+  def main(args: Array[String]) = {
+    // plain scala actor
+    val a1 = actor {
+      react { case v: Int => Test.append(v); Test.latch.countDown() }
+    }
+    a1 ! 100
+
+    // simple instantiation
+    val a2 = MigrationSystem.actorOf(Props(() => new TestStashingActor, "akka.actor.default-stash-dispatcher"))
+    a2 ! 200
+    toStop += a2
+
+    // actor of with scala actor
+    val a3 = MigrationSystem.actorOf(Props(() => actor {
+      react { case v: Int => Test.append(v); Test.latch.countDown() }
+    }, "akka.actor.default-stash-dispatcher"))
+    a3 ! 300
+
+    // using the manifest
+    val a4 = MigrationSystem.actorOf(Props(() => new TestStashingActor, "akka.actor.default-stash-dispatcher"))
+    a4 ! 400
+    toStop += a4
+
+    // deterministic part of a test
+    // creation without actorOf
+    try {
+      val a3 = new TestStashingActor
+      a3 ! -1
+    } catch {
+      case e => println("OK error: " + e)
+    }
+
+    // actorOf double creation
+    try {
+      val a3 = MigrationSystem.actorOf(Props(() => {
+        new TestStashingActor
+        new TestStashingActor
+      }, "akka.actor.default-stash-dispatcher"))
+      a3 ! -1
+    } catch {
+      case e => println("OK error: " + e)
+    }
+
+    // actorOf nesting
+    try {
+      val a5 = MigrationSystem.actorOf(Props(() => {
+        val a6 = MigrationSystem.actorOf(Props(() => new TestStashingActor, "akka.actor.default-stash-dispatcher"))
+        toStop += a6
+        new TestStashingActor
+      }, "akka.actor.default-stash-dispatcher"))
+
+      a5 ! 500
+      toStop += a5
+    } catch {
+      case e => println("Should not throw an exception: " + e)
+    }
+
+    // output
+    latch.await(5, TimeUnit.SECONDS)
+    if (latch.getCount() > 0) {
+      println("Error: Tasks have not finished!!!")
+    }
+
+    buff.sorted.foreach(println)
+    toStop.foreach(_ ! PoisonPill)
+  }
+}

--- a/test/files/jvm/actmig-loop-react.scala
+++ b/test/files/jvm/actmig-loop-react.scala
@@ -1,3 +1,7 @@
+/**
+ * NOTE: Code snippets from this test are included in the Actor Migration Guide. In case you change
+ * code in these tests prior to the 2.10.0 release please send the notification to @vjovanov.
+ */
 import scala.actors.migration.MigrationSystem._
 import scala.actors.Actor._
 import scala.actors._

--- a/test/files/jvm/actmig-public-methods.check
+++ b/test/files/jvm/actmig-public-methods.check
@@ -1,6 +1,6 @@
 None
 Some(bang qmark after 1)
 bang
+bang bang in the future after 0
 bang qmark after 0
-bang qmark in future after 0
-typed bang qmark in future after 0
+typed bang bang in the future after 0

--- a/test/files/jvm/actmig-public-methods.scala
+++ b/test/files/jvm/actmig-public-methods.scala
@@ -1,0 +1,74 @@
+/**
+ * NOTE: Code snippets from this test are included in the Actor Migration Guide. In case you change
+ * code in these tests prior to the 2.10.0 release please send the notification to @vjovanov.
+ */
+import scala.collection.mutable.ArrayBuffer
+import scala.actors.Actor._
+import scala.actors._
+import scala.actors.migration.MigrationSystem
+import scala.util.continuations._
+import java.util.concurrent.{ TimeUnit, CountDownLatch }
+
+object Test {
+  val NUMBER_OF_TESTS = 6
+
+  // used for sorting non-deterministic output
+  val buff = ArrayBuffer[String]()
+  val latch = new CountDownLatch(NUMBER_OF_TESTS)
+  val toStop = ArrayBuffer[Actor]()
+
+  def append(v: String) = synchronized {
+    buff += v
+  }
+
+  def main(args: Array[String]) = {
+
+    val respActor = actor {
+      loop {
+        react {
+          case (x: String, time: Long) =>
+            Thread.sleep(time)
+            reply(x + " after " + time)
+          case str: String =>
+            append(str)
+            latch.countDown()
+          case _ => exit()
+        }
+      }
+    }
+
+    toStop += respActor
+
+    respActor ! ("bang")
+
+    val res1 = respActor !? (("bang qmark", 0L))
+    append(res1.toString)
+    latch.countDown()
+
+    val res2 = respActor !? (5000, ("bang qmark", 1L))
+    append(res2.toString)
+    latch.countDown()
+
+    // this one should timeout
+    val res21 = respActor !? (1, ("bang qmark", 5000L))
+    append(res21.toString)
+    latch.countDown()
+
+    val fut1 = respActor !! (("bang bang in the future", 0L))
+    append(fut1().toString())
+    latch.countDown()
+
+    val fut2 = respActor !! (("typed bang bang in the future", 0L), { case x: String => x })
+    append(fut2())
+    latch.countDown()
+
+    // output
+    latch.await(10, TimeUnit.SECONDS)
+    if (latch.getCount() > 0) {
+      println("Error: Tasks have not finished!!!")
+    }
+
+    buff.sorted.foreach(println)
+    toStop.foreach(_ ! 'stop)
+  }
+}

--- a/test/files/jvm/actmig-public-methods_1.check
+++ b/test/files/jvm/actmig-public-methods_1.check
@@ -1,6 +1,6 @@
 None
 Some(bang qmark after 1)
 bang
+bang bang in the future after 0
 bang qmark after 0
-bang qmark in future after 0
-typed bang qmark in future after 0
+typed bang bang in the future after 0

--- a/test/files/jvm/actmig-public-methods_1.scala
+++ b/test/files/jvm/actmig-public-methods_1.scala
@@ -1,11 +1,18 @@
+/**
+ * NOTE: Code snippets from this test are included in the Actor Migration Guide. In case you change
+ * code in these tests prior to the 2.10.0 release please send the notification to @vjovanov.
+ */
 import scala.collection.mutable.ArrayBuffer
 import scala.actors.Actor._
 import scala.actors._
 import scala.actors.migration._
 import scala.util._
+import scala.concurrent._
+import scala.concurrent.util.duration._
 import java.util.concurrent.{ TimeUnit, CountDownLatch }
 import scala.concurrent.util.Duration
 import scala.actors.migration.pattern._
+import scala.concurrent.ExecutionContext.Implicits.global
 
 object Test {
   val NUMBER_OF_TESTS = 6
@@ -40,45 +47,53 @@ object Test {
 
     respActor ! "bang"
 
-    implicit val timeout = Timeout(Duration(500, TimeUnit.MILLISECONDS))
-    val msg = ("bang qmark", 0L)
-    val res1 = respActor.?(msg)(Timeout(Duration.Inf))
-    append(res1().toString)
-    latch.countDown()
-
-    val msg1 = ("bang qmark", 1L)
-    val res2 = respActor.?(msg1)(Timeout(Duration(500, TimeUnit.MILLISECONDS)))
-    append((res2() match {
-      case x: AskTimeoutException => None
-      case v => Some(v)
-    }).toString)
-    latch.countDown()
-
-    // this one should time out
-    val msg11 = ("bang qmark", 500L)
-    val res21 = respActor.?(msg11)(Timeout(Duration(1, TimeUnit.MILLISECONDS)))
-    append((res21() match {
-      case x: AskTimeoutException => None
-      case v => Some(v)
-    }).toString)
-    latch.countDown()
-
-    val msg2 = ("bang qmark in future", 0L)
-    val fut1 = respActor.?(msg2)(Duration.Inf)
-    append(fut1().toString())
-    latch.countDown()
-
-    val handler: PartialFunction[Any, String] = {
-      case x: String => x.toString
+    {
+      val msg = ("bang qmark", 0L)
+      val res = respActor.?(msg)(Timeout(Duration.Inf))
+      append(Await.result(res, Duration.Inf).toString)
+      latch.countDown()
     }
 
-    val msg3 = ("typed bang qmark in future", 0L)
-    val fut2 = (respActor.?(msg3)(Duration.Inf))
-    append(Futures.future { handler.apply(fut2()) }().toString)
-    latch.countDown()
+    {
+      val msg = ("bang qmark", 1L)
+      val res = respActor.?(msg)(Timeout(5 seconds))
+
+      val promise = Promise[Option[Any]]()
+      res.onComplete(v => promise.success(v.toOption))
+      append(Await.result(promise.future, Duration.Inf).toString)
+
+      latch.countDown()
+    }
+
+    {
+      val msg = ("bang qmark", 5000L)
+      val res = respActor.?(msg)(Timeout(1 millisecond))
+      val promise = Promise[Option[Any]]()
+      res.onComplete(v => promise.success(v.toOption))
+      append(Await.result(promise.future, Duration.Inf).toString)
+      latch.countDown()
+    }
+
+    {
+      val msg = ("bang bang in the future", 0L)
+      val fut = respActor.?(msg)(Timeout(Duration.Inf))
+      append(Await.result(fut, Duration.Inf).toString)
+      latch.countDown()
+    }
+
+    {
+      val handler: PartialFunction[Any, String] = {
+        case x: String => x
+      }
+
+      val msg = ("typed bang bang in the future", 0L)
+      val fut = (respActor.?(msg)(Timeout(Duration.Inf)))
+      append((Await.result(fut.map(handler), Duration.Inf)).toString)
+      latch.countDown()
+    }
 
     // output
-    latch.await(200, TimeUnit.MILLISECONDS)
+    latch.await(10, TimeUnit.SECONDS)
     if (latch.getCount() > 0) {
       println("Error: Tasks have not finished!!!")
     }

--- a/test/files/jvm/actmig-react-receive.scala
+++ b/test/files/jvm/actmig-react-receive.scala
@@ -1,3 +1,7 @@
+/**
+ * NOTE: Code snippets from this test are included in the Actor Migration Guide. In case you change
+ * code in these tests prior to the 2.10.0 release please send the notification to @vjovanov.
+ */
 import scala.actors.migration.MigrationSystem._
 import scala.actors.Actor._
 import scala.actors._

--- a/test/files/jvm/actmig-react-within.scala
+++ b/test/files/jvm/actmig-react-within.scala
@@ -1,3 +1,7 @@
+/**
+ * NOTE: Code snippets from this test are included in the Actor Migration Guide. In case you change
+ * code in these tests prior to the 2.10.0 release please send the notification to @vjovanov.
+ */
 import scala.actors.migration.MigrationSystem._
 import scala.actors.Actor._
 import scala.actors._

--- a/test/files/jvm/actmig-receive.scala
+++ b/test/files/jvm/actmig-receive.scala
@@ -1,3 +1,7 @@
+/**
+ * NOTE: Code snippets from this test are included in the Actor Migration Guide. In case you change
+ * code in these tests prior to the 2.10.0 release please send the notification to @vjovanov.
+ */
 import scala.actors.migration.MigrationSystem._
 import scala.actors.Actor._
 import scala.actors._


### PR DESCRIPTION
These changes are made to address the change in Akka API for the scala.concurrent package.
Added some additional tests.
Minor cleanup.

Review by @phaller.
