### PR TITLE
Use faster download URL now that artifactory is fixed.

### DIFF
--- a/tools/binary-repo-lib.sh
+++ b/tools/binary-repo-lib.sh
@@ -191,7 +191,7 @@ pullJarFileToCache() {
   if [[ ! -f "$cache_loc" ]]; then
     # Note: After we follow up with JFrog, we should check the more stable raw file server first
     # before hitting the more flaky artifactory.
-    curlDownload $cache_loc ${remote_urlpush}/${uri}
+    curlDownload $cache_loc ${remote_urlget}/${uri}
     if test "$(checkJarSha "$cache_loc" "$sha")" != "OK"; then
       echo "Trouble downloading $uri.  Please try pull-binary-libs again when your internet connection is stable."
       exit 2


### PR DESCRIPTION
Bump artifactory repo version for faster/more stable access (we're promised).   Will backport to 2.9.x if the build succeeds.

No Review
