### PR TITLE
SI-6381 Honour -Yrangepos in the REPL

### DIFF
--- a/src/compiler/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/IMain.scala
@@ -262,7 +262,10 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
   protected def newCompiler(settings: Settings, reporter: Reporter): ReplGlobal = {
     settings.outputDirs setSingleOutput virtualDirectory
     settings.exposeEmptyPackage.value = true
-    new Global(settings, reporter) with ReplGlobal
+    if (settings.Yrangepos.value)
+      new Global(settings, reporter) with ReplGlobal with interactive.RangePositions
+    else
+      new Global(settings, reporter) with ReplGlobal
   }
 
   /** Parent classloader.  Overridable. */

--- a/test/files/run/t6381.check
+++ b/test/files/run/t6381.check
@@ -1,0 +1,17 @@
+Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> import language.experimental.macros
+import language.experimental.macros
+
+scala> def pos_impl(c: reflect.macros.Context): c.Expr[String] =
+  c.literal(c.enclosingPosition.getClass.toString)
+pos_impl: (c: scala.reflect.macros.Context)c.Expr[String]
+
+scala> def pos = macro pos_impl
+pos: String
+
+scala> pos
+res0: String = class scala.reflect.internal.util.RangePosition
+
+scala> 

--- a/test/files/run/t6381.scala
+++ b/test/files/run/t6381.scala
@@ -1,0 +1,13 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  def code = """
+    |import language.experimental.macros
+    |def pos_impl(c: reflect.macros.Context): c.Expr[String] =
+    |  c.literal(c.enclosingPosition.getClass.toString)
+    |def pos = macro pos_impl
+    |pos
+    |""".stripMargin.trim
+
+  override def extraSettings: String = "-Yrangepos"
+}


### PR DESCRIPTION
The motivation for this, aside from simple consistency, is to make range positions a little more accessible for macro tinkerers.

I wasn't able to find any prior discussion about why this needs to be an option at all, ie why we can't have range positions all the time. Performance? Robustness?

This is a followup to #1307, which applied the same fix to the Ant tasks.

Review by @paulp or @hubertp
