### PR TITLE
Regex.unapplySeq should not take Any (Fixes SI-6406)

### DIFF
--- a/test/files/neg/t6406-regextract.check
+++ b/test/files/neg/t6406-regextract.check
@@ -1,0 +1,6 @@
+t6406-regextract.scala:4: warning: method unapplySeq in class Regex is deprecated: Extracting a match result from anything but a CharSequence or Match is deprecated
+  List(1) collect { case r(i) => i }
+                         ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/t6406-regextract.flags
+++ b/test/files/neg/t6406-regextract.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/t6406-regextract.scala
+++ b/test/files/neg/t6406-regextract.scala
@@ -1,0 +1,5 @@
+
+object Test extends App {
+  val r = "(\\d+)".r
+  List(1) collect { case r(i) => i }
+}

--- a/test/files/run/t6406-regextract.check
+++ b/test/files/run/t6406-regextract.check
@@ -1,0 +1,4 @@
+List(1, 3)
+List(1, 3)
+List(1, 3)
+Some(2011) Some(2011)

--- a/test/files/run/t6406-regextract.scala
+++ b/test/files/run/t6406-regextract.scala
@@ -1,0 +1,30 @@
+
+object Test extends App {
+  import util.matching._
+  import Regex._
+
+  val r = "(\\d+)".r
+  val q = """(\d)""".r
+  val ns = List("1,2","x","3,4")
+  val u = r.unanchored
+
+  val is = ns collect { case u(x) => x } map { case r(x) => x }
+  println(is)
+  // Match from same pattern
+  val js = (ns map { u findFirstMatchIn _ }).flatten map { case r(x) => x }
+  println(js)
+  // Match not from same pattern
+  val ks = (ns map { q findFirstMatchIn _ }).flatten map { case r(x) => x }
+  println(ks)
+
+  val t = "Last modified 2011-07-15"
+  val p1 = """(\d\d\d\d)-(\d\d)-(\d\d)""".r
+  val y1: Option[String] = for {
+    p1(year, month, day) <- p1 findFirstIn t
+  } yield year
+  val y2: Option[String] = for {
+    p1(year, month, day) <- p1 findFirstMatchIn t
+  } yield year
+  println(s"$y1 $y2")
+
+}


### PR DESCRIPTION
This deprecates unapplySeq(Any) and adds overloaded
unapplySeq(CharSequence) and unapplySeq(Match), with the
putative advantage that you can't try to extract the unextractable.

Regex is massaged so that the underlying Pattern is primary,
rather than the String-valued expression.  Regex and its
unanchored companion (I almost wrote unmoored) share a
Pattern object, so that unapplySeq(Match) can easily test
whether the Match was generated by this Regex; in that case,
the match result is used immediately, instead of reapplying
the regex to the matched string.

The documentation is massaged to reflect unanchored and also to
align with the underlying terminology, e.g., "subgroup" really
just means "group."

Review by @jsuereth
