### PR TITLE
Changed implementation comments from /** */ to /* */ for ScalaDoc

### DIFF
--- a/src/library/scala/collection/IndexedSeqLike.scala
+++ b/src/library/scala/collection/IndexedSeqLike.scala
@@ -90,7 +90,7 @@ trait IndexedSeqLike[+A, +Repr] extends Any with SeqLike[A, Repr] {
   override /*IterableLike*/
   def iterator: Iterator[A] = new Elements(0, length)
 
-  /** Overridden for efficiency */
+  /* Overridden for efficiency */
   override def toBuffer[A1 >: A]: mutable.Buffer[A1] = {
     val result = new mutable.ArrayBuffer[A1](size)
     copyToBuffer(result)

--- a/src/library/scala/collection/MapLike.scala
+++ b/src/library/scala/collection/MapLike.scala
@@ -319,7 +319,7 @@ self =>
     res
   }
 
-  /** Overridden for efficiency. */
+  /* Overridden for efficiency. */
   override def toSeq: Seq[(A, B)] = toBuffer[(A, B)]
   override def toBuffer[C >: (A, B)]: mutable.Buffer[C] = {
     val result = new mutable.ArrayBuffer[C](size)

--- a/src/library/scala/collection/SetLike.scala
+++ b/src/library/scala/collection/SetLike.scala
@@ -78,7 +78,7 @@ self =>
 
   protected[this] override def parCombiner = ParSet.newCombiner[A]
 
-  /** Overridden for efficiency. */
+  /* Overridden for efficiency. */
   override def toSeq: Seq[A] = toBuffer[A]
   override def toBuffer[A1 >: A]: mutable.Buffer[A1] = {
     val result = new mutable.ArrayBuffer[A1](size)

--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -391,7 +391,7 @@ trait Names extends api.Names with LowPriorityNames {
       newTermName(cs, 0, len)
     }
 
-    /** TODO - reconcile/fix that encode returns a Name but
+    /* TODO - reconcile/fix that encode returns a Name but
      *  decode returns a String.
      */
 


### PR DESCRIPTION
There were some comments saying "overridden for efficiency" in /*\* */ brackets
which then were shown in ScalaDoc as documentation for the function.

I changed them to /\* */
