### PR TITLE
SI-5918 fixes ConstantType ugliness

### DIFF
--- a/test/files/run/constant-type.check
+++ b/test/files/run/constant-type.check
@@ -1,0 +1,24 @@
+Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> 
+
+scala> :power
+** Power User mode enabled - BEEP WHIR GYVE **
+** :phase has been set to 'typer'.          **
+** scala.tools.nsc._ has been imported      **
+** global._, definitions._ also imported    **
+** Try  :help, :vals, power.<tab>           **
+
+scala> val s = transformedType(StringClass.toType).asInstanceOf[Type]
+s: $r.intp.global.Type = String
+
+scala> { println(afterPhase(currentRun.erasurePhase)(ConstantType(Constant(s)))); }
+Class(classOf[java.lang.String])
+
+scala> { ConstantType(Constant(s)); println(afterPhase(currentRun.erasurePhase)(ConstantType(Constant(s)))); }
+Class(classOf[java.lang.String])
+
+scala> 
+
+scala> 

--- a/test/files/run/constant-type.scala
+++ b/test/files/run/constant-type.scala
@@ -1,0 +1,10 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  def code = """
+:power
+val s = transformedType(StringClass.toType).asInstanceOf[Type]
+{ println(afterPhase(currentRun.erasurePhase)(ConstantType(Constant(s)))); }
+{ ConstantType(Constant(s)); println(afterPhase(currentRun.erasurePhase)(ConstantType(Constant(s)))); }
+  """
+}


### PR DESCRIPTION
The problem that made me erect this ugly workaround has fixed itself.
The test attached failed to compile back then without a workaround, but
now it succeeds. Therefore I'm just reverting ConstantType.
