### PR TITLE
Remove BoxingConversions from the scala package.

### DIFF
--- a/src/library/scala/BoxingConversions.scala
+++ b/src/library/scala/BoxingConversions.scala
@@ -1,5 +1,0 @@
-package scala
-abstract class BoxingConversions[Boxed, Unboxed] {
-  def box(x: Unboxed): Boxed
-  def unbox(x: Boxed): Unboxed
-}

--- a/test/files/run/Meter.scala
+++ b/test/files/run/Meter.scala
@@ -1,4 +1,9 @@
 package a {
+  abstract class BoxingConversions[Boxed, Unboxed] {
+    def box(x: Unboxed): Boxed
+    def unbox(x: Boxed): Unboxed
+  }
+
   class Meter(val underlying: Double) extends AnyVal with _root_.b.Printable {
     def + (other: Meter): Meter =
       new Meter(this.underlying + other.underlying)

--- a/test/files/run/MeterCaseClass.scala
+++ b/test/files/run/MeterCaseClass.scala
@@ -1,4 +1,9 @@
 package a {
+  abstract class BoxingConversions[Boxed, Unboxed] {
+    def box(x: Unboxed): Boxed
+    def unbox(x: Boxed): Unboxed
+  }
+
   case class Meter(underlying: Double) extends AnyVal with _root_.b.Printable {
     def + (other: Meter): Meter =
       new Meter(this.underlying + other.underlying)


### PR DESCRIPTION
And add it to two test cases that rely on it.

It is a remnant of the now-removed FlatArray (8cc7de74d).

Review by @odersky.
