### PR TITLE
Fixing -Xlint and acting on its advice for 2.10.

### DIFF
--- a/src/actors-migration/scala/actors/migration/Props.scala
+++ b/src/actors-migration/scala/actors/migration/Props.scala
@@ -10,6 +10,5 @@ case class Props(creator: () ⇒ InternalActor, dispatcher: String) {
   /**
    * Returns a new Props with the specified creator set
    */
-  def withCreator(c: ⇒ InternalActor) = copy(creator = () ⇒ c)
-
+  final def withCreator(c: ⇒ InternalActor) = copy(creator = () ⇒ c)
 }

--- a/src/actors-migration/scala/actors/migration/StashingActor.scala
+++ b/src/actors-migration/scala/actors/migration/StashingActor.scala
@@ -18,7 +18,7 @@ trait StashingActor extends InternalActor {
   type Receive = PartialFunction[Any, Unit]
 
   // checks if StashingActor is created within the actorOf block
-  creationCheck;
+  creationCheck()
 
   private[actors] val ref = new InternalActorRef(this)
 
@@ -112,8 +112,7 @@ trait StashingActor extends InternalActor {
   /*
    * Checks that StashingActor can be created only by MigrationSystem.actorOf method.
    */
-  private[this] def creationCheck = {
-
+  private[this] def creationCheck(): Unit = {
     // creation check (see ActorRef)
     val context = MigrationSystem.contextStack.get
     if (context.isEmpty)

--- a/src/compiler/scala/reflect/macros/runtime/Infrastructure.scala
+++ b/src/compiler/scala/reflect/macros/runtime/Infrastructure.scala
@@ -23,13 +23,13 @@ trait Infrastructure {
   type Run = universe.Run
 
   object Run extends RunExtractor {
-    def unapply(run: Run): Option[(CompilationUnit, List[CompilationUnit])] = Some(run.currentUnit, run.units.toList)
+    def unapply(run: Run): Option[(CompilationUnit, List[CompilationUnit])] = Some((run.currentUnit, run.units.toList))
   }
 
   type CompilationUnit = universe.CompilationUnit
 
   object CompilationUnit extends CompilationUnitExtractor {
-    def unapply(compilationUnit: CompilationUnit): Option[(java.io.File, Array[Char], Tree)] = Some(compilationUnit.source.file.file, compilationUnit.source.content, compilationUnit.body)
+    def unapply(compilationUnit: CompilationUnit): Option[(java.io.File, Array[Char], Tree)] = Some((compilationUnit.source.file.file, compilationUnit.source.content, compilationUnit.body))
   }
 
   val currentMacro: Symbol = expandee.symbol

--- a/src/compiler/scala/reflect/reify/utils/Extractors.scala
+++ b/src/compiler/scala/reflect/reify/utils/Extractors.scala
@@ -114,7 +114,7 @@ trait Extractors {
             case Select(Select(_, tagFlavor), _) => tagFlavor
             case Select(_, tagFlavor) => tagFlavor
           }
-          Some(universe, mirror, SymbolTable(symbolTable1 ++ symbolTable2), rtree, ttpe.tpe, rtpe, tagFlavor == nme.TypeTag)
+          Some((universe, mirror, SymbolTable(symbolTable1 ++ symbolTable2), rtree, ttpe.tpe, rtpe, tagFlavor == nme.TypeTag))
       case _ =>
         None
     }
@@ -139,7 +139,7 @@ trait Extractors {
             case Select(Select(_, tagFlavor), _) => tagFlavor
             case Select(_, tagFlavor) => tagFlavor
           }
-          Some(universe, mirror, SymbolTable(symtab), ttpe.tpe, rtpe, tagFlavor == nme.TypeTag)
+          Some((universe, mirror, SymbolTable(symtab), ttpe.tpe, rtpe, tagFlavor == nme.TypeTag))
       case _ =>
         None
     }
@@ -160,9 +160,9 @@ trait Extractors {
   object FreeDef {
     def unapply(tree: Tree): Option[(Tree, TermName, Tree, Long, String)] = tree match {
       case FreeTermDef(uref, name, binding, flags, origin) =>
-        Some(uref, name, binding, flags, origin)
+        Some((uref, name, binding, flags, origin))
       case FreeTypeDef(uref, name, binding, flags, origin) =>
-        Some(uref, name, binding, flags, origin)
+        Some((uref, name, binding, flags, origin))
       case _ =>
         None
     }
@@ -207,7 +207,7 @@ trait Extractors {
     def unapply(tree: Tree): Option[(Tree, TermName)] = tree match {
       case Apply(Select(Select(uref @ Ident(_), build), ident), List(Ident(name: TermName)))
       if build == nme.build && ident == nme.Ident && name.startsWith(nme.REIFY_FREE_PREFIX) =>
-        Some(uref, name)
+        Some((uref, name))
       case _ =>
         None
     }
@@ -226,7 +226,7 @@ trait Extractors {
             Literal(Constant(isClass: Boolean)))))
       if uref1.name == nme.UNIVERSE_SHORT && build1 == nme.build && newNestedSymbol == nme.newNestedSymbol &&
          uref2.name == nme.UNIVERSE_SHORT && build2 == nme.build && flagsFromBits == nme.flagsFromBits =>
-        Some(uref1, name, flags, isClass)
+        Some((uref1, name, flags, isClass))
       case _ =>
         None
     }

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -360,7 +360,7 @@ trait Scanners extends ScannersCommon {
           if (ch == '"' && token == IDENTIFIER)
             token = INTERPOLATIONID
         case '<' => // is XMLSTART?
-          def fetchLT = {
+          def fetchLT() = {
             val last = if (charOffset >= 2) buf(charOffset - 2) else ' '
             nextChar()
             last match {
@@ -389,7 +389,7 @@ trait Scanners extends ScannersCommon {
             getOperatorRest()
           }
         case '0' =>
-          def fetchZero = {
+          def fetchZero() = {
             putChar(ch)
             nextChar()
             if (ch == 'x' || ch == 'X') {
@@ -416,7 +416,7 @@ trait Scanners extends ScannersCommon {
         case '`' =>
           getBackquotedIdent()
         case '\"' =>
-          def fetchDoubleQuote = {
+          def fetchDoubleQuote() = {
             if (token == INTERPOLATIONID) {
               nextRawChar()
               if (ch == '\"') {
@@ -452,7 +452,7 @@ trait Scanners extends ScannersCommon {
           }
           fetchDoubleQuote
         case '\'' =>
-          def fetchSingleQuote = {
+          def fetchSingleQuote() = {
             nextChar()
             if (isIdentifierStart(ch))
               charLitOr(getIdentRest)
@@ -500,7 +500,7 @@ trait Scanners extends ScannersCommon {
             nextChar()
           }
         case _ =>
-          def fetchOther = {
+          def fetchOther() = {
             if (ch == '\u21D2') {
               nextChar(); token = ARROW
             } else if (ch == '\u2190') {

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
@@ -2407,7 +2407,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters {
         (instr.category: @scala.annotation.switch) match {
 
           case icodes.localsCat =>
-          def genLocalInstr = (instr: @unchecked) match {
+          def genLocalInstr() = (instr: @unchecked) match {
             case THIS(_) => jmethod.visitVarInsn(Opcodes.ALOAD, 0)
             case LOAD_LOCAL(local) => jcode.load(indexOf(local), local.kind)
             case STORE_LOCAL(local) => jcode.store(indexOf(local), local.kind)
@@ -2440,7 +2440,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters {
           genLocalInstr
 
           case icodes.stackCat =>
-          def genStackInstr = (instr: @unchecked) match {
+          def genStackInstr() = (instr: @unchecked) match {
 
             case LOAD_MODULE(module) =>
               // assert(module.isModule, "Expected module: " + module)
@@ -2468,7 +2468,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters {
           case icodes.arilogCat => genPrimitive(instr.asInstanceOf[CALL_PRIMITIVE].primitive, instr.pos)
 
           case icodes.castsCat =>
-          def genCastInstr = (instr: @unchecked) match {
+          def genCastInstr() = (instr: @unchecked) match {
 
             case IS_INSTANCE(tpe) =>
               val jtyp: asm.Type =
@@ -2498,7 +2498,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters {
           genCastInstr
 
           case icodes.objsCat =>
-          def genObjsInstr = (instr: @unchecked) match {
+          def genObjsInstr() = (instr: @unchecked) match {
 
             case BOX(kind) =>
               val MethodNameAndType(mname, mdesc) = jBoxTo(kind)
@@ -2518,7 +2518,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters {
           genObjsInstr
 
           case icodes.fldsCat =>
-          def genFldsInstr = (instr: @unchecked) match {
+          def genFldsInstr() = (instr: @unchecked) match {
 
             case lf @ LOAD_FIELD(field, isStatic) =>
               var owner = javaName(lf.hostClass)
@@ -2539,7 +2539,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters {
           genFldsInstr
 
           case icodes.mthdsCat =>
-          def genMethodsInstr = (instr: @unchecked) match {
+          def genMethodsInstr() = (instr: @unchecked) match {
 
             /** Special handling to access native Array.clone() */
             case call @ CALL_METHOD(definitions.Array_clone, Dynamic) =>
@@ -2552,7 +2552,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters {
           genMethodsInstr
 
           case icodes.arraysCat =>
-          def genArraysInstr = (instr: @unchecked) match {
+          def genArraysInstr() = (instr: @unchecked) match {
             case LOAD_ARRAY_ITEM(kind) => jcode.aload(kind)
             case STORE_ARRAY_ITEM(kind) => jcode.astore(kind)
             case CREATE_ARRAY(elem, 1) => jcode newarray elem
@@ -2561,7 +2561,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters {
           genArraysInstr
 
           case icodes.jumpsCat =>
-          def genJumpInstr = (instr: @unchecked) match {
+          def genJumpInstr() = (instr: @unchecked) match {
 
             case sw @ SWITCH(tagss, branches) =>
               assert(branches.length == tagss.length + 1, sw)
@@ -2691,7 +2691,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters {
           genJumpInstr
 
           case icodes.retCat =>
-          def genRetInstr = (instr: @unchecked) match {
+          def genRetInstr() = (instr: @unchecked) match {
             case RETURN(kind) => jcode emitRETURN kind
             case THROW(_) => emit(Opcodes.ATHROW)
           }
@@ -2781,7 +2781,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters {
           case Negation(kind) => jcode.neg(kind)
 
           case Arithmetic(op, kind) =>
-            def genArith = {
+            def genArith() = {
             op match {
 
               case ADD => jcode.add(kind)
@@ -2811,7 +2811,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters {
           // TODO GenICode uses `toTypeKind` to define that elem, `toValueTypeKind` would be needed instead.
           // TODO How about adding some asserts to Logical and similar ones to capture the remaining constraint (UNIT not allowed).
           case Logical(op, kind) =>
-            def genLogical = op match {
+            def genLogical() = op match {
               case AND =>
                 kind match {
                   case LONG => emit(Opcodes.LAND)
@@ -2840,7 +2840,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters {
             genLogical
 
           case Shift(op, kind) =>
-            def genShift = op match {
+            def genShift() = op match {
               case LSL =>
                 kind match {
                   case LONG => emit(Opcodes.LSHL)
@@ -2869,7 +2869,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters {
             genShift
 
           case Comparison(op, kind) =>
-            def genCompare = op match {
+            def genCompare() = op match {
               case CMP =>
                 (kind: @unchecked) match {
                   case LONG =>  emit(Opcodes.LCMP)

--- a/src/compiler/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/compiler/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -403,7 +403,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
      * This is the final point in the core model creation: no DocTemplates are created after the model has finished, but
      * inherited templates and implicit members are added to the members at this point.
      */
-    def completeModel: Unit = {
+    def completeModel(): Unit = {
       // DFS completion
       // since alias types and abstract types have no own members, there's no reason for them to call completeModel
       if (!sym.isAliasType && !sym.isAbstractType)

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -18,6 +18,7 @@ trait Warnings {
   // These warnings are all so noisy as to be useless in their
   // present form, but have the potential to offer useful info.
   protected def allWarnings = lintWarnings ++ List(
+    warnDeadCode,
     warnSelectNullable,
     warnValueDiscard,
     warnNumericWiden
@@ -25,7 +26,7 @@ trait Warnings {
   // These warnings should be pretty quiet unless you're doing
   // something inadvisable.
   protected def lintWarnings = List(
-    warnDeadCode,
+    // warnDeadCode,
     warnInaccessible,
     warnNullaryOverride,
     warnNullaryUnit,

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -663,7 +663,7 @@ abstract class Erasure extends AddInterfaces
     /** Generate a synthetic cast operation from tree.tpe to pt.
      *  @pre pt eq pt.normalize
      */
-    private def cast(tree: Tree, pt: Type): Tree = {
+    private def cast(tree: Tree, pt: Type): Tree = logResult(s"cast($tree, $pt)") {
       if (pt.typeSymbol == UnitClass) {
         // See SI-4731 for one example of how this occurs.
         log("Attempted to cast to Unit: " + tree)

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -354,7 +354,7 @@ trait Macros extends scala.tools.reflect.FastTrack with Traces {
     macroTraceVerbose("tparams are: ")(tparams)
     macroTraceVerbose("vparamss are: ")(vparamss)
     macroTraceVerbose("retTpe is: ")(retTpe)
-    macroTraceVerbose("macroImplSig is: ")(paramss, implRetTpe)
+    macroTraceVerbose("macroImplSig is: ")((paramss, implRetTpe))
   }
 
   /** Verifies that the body of a macro def typechecks to a reference to a static public non-overloaded method,

--- a/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
@@ -1864,7 +1864,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
       def registerEquality(c: Const): Unit
 
       // call this to indicate null is part of the domain
-      def registerNull: Unit
+      def registerNull(): Unit
 
       // can this variable be null?
       def mayBeNull: Boolean
@@ -2279,7 +2279,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
       val staticTpCheckable: Type = checkableType(staticTp)
 
       private[this] var _mayBeNull = false
-      def registerNull: Unit = { ensureCanModify; if (NullTp <:< staticTpCheckable) _mayBeNull = true }
+      def registerNull(): Unit = { ensureCanModify; if (NullTp <:< staticTpCheckable) _mayBeNull = true }
       def mayBeNull: Boolean = _mayBeNull
 
       // case None => domain is unknown,

--- a/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
@@ -1589,7 +1589,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
     object EqualityCond {
       private val uniques = new scala.collection.mutable.HashMap[(Tree, Tree), EqualityCond]
       def apply(testedPath: Tree, rhs: Tree): EqualityCond = uniques getOrElseUpdate((testedPath, rhs), new EqualityCond(testedPath, rhs))
-      def unapply(c: EqualityCond) = Some(c.testedPath, c.rhs)
+      def unapply(c: EqualityCond) = Some((c.testedPath, c.rhs))
     }
     class EqualityCond(val testedPath: Tree, val rhs: Tree) extends Cond {
       override def toString = testedPath +" == "+ rhs +"#"+ id
@@ -1607,7 +1607,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
     object TypeCond {
       private val uniques = new scala.collection.mutable.HashMap[(Tree, Type), TypeCond]
       def apply(testedPath: Tree, pt: Type): TypeCond = uniques getOrElseUpdate((testedPath, pt), new TypeCond(testedPath, pt))
-      def unapply(c: TypeCond) = Some(c.testedPath, c.pt)
+      def unapply(c: TypeCond) = Some((c.testedPath, c.pt))
     }
     class TypeCond(val testedPath: Tree, val pt: Type) extends Cond {
       override def toString = testedPath +" : "+ pt +"#"+ id
@@ -1645,7 +1645,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
 
       def unapply(xtm: ExtractorTreeMaker): Option[(Tree, Symbol)] = xtm match {
         case ExtractorTreeMaker(extractor, None, nextBinder) if irrefutableExtractorType(extractor.tpe) =>
-          Some(extractor, nextBinder)
+          Some((extractor, nextBinder))
         case _ =>
           None
       }
@@ -2676,7 +2676,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
         case UnitClass =>
           Some(List(UnitClass.tpe))
         case BooleanClass =>
-          Some(List(ConstantType(Constant(true)), ConstantType(Constant(false))))
+          Some((List(ConstantType(Constant(true)), ConstantType(Constant(false)))))
         // TODO case _ if tp.isTupleType => // recurse into component types
         case modSym: ModuleClassSymbol =>
           Some(List(tp))

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1631,12 +1631,14 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
       case NullaryMethodType(restpe) if restpe.typeSymbol == UnitClass =>
         // this may be the implementation of e.g. a generic method being parameterized
         // on Unit, in which case we had better let it slide.
-        if (sym.isGetter || sym.allOverriddenSymbols.exists(over => !(over.tpe.resultType =:= sym.tpe.resultType))) ()
-        else unit.warning(sym.pos,
-          "side-effecting nullary methods are discouraged: suggest defining as `def %s()` instead".format(
-           sym.name.decode)
+        val isOk = (
+             sym.isGetter
+          || sym.allOverriddenSymbols.exists(over => !(over.tpe.resultType =:= sym.tpe.resultType))
+          || (sym.name containsName nme.DEFAULT_GETTER_STRING)
         )
-        case _ => ()
+        if (!isOk)
+          unit.warning(sym.pos, s"side-effecting nullary methods are discouraged: suggest defining as `def ${sym.name.decode}()` instead")
+      case _ => ()
     }
 
     // Verify classes extending AnyVal meet the requirements

--- a/src/continuations/library/scala/util/continuations/ControlContext.scala
+++ b/src/continuations/library/scala/util/continuations/ControlContext.scala
@@ -101,7 +101,7 @@ final class ControlContext[+A,-B,+C](val fun: (A => B, Exception => B) => C, val
   @noinline final def map[A1](f: A => A1): ControlContext[A1,B,C] = {
     if (fun eq null)
       try {
-        new ControlContext(null, f(x)) // TODO: only alloc if f(x) != x
+        new ControlContext[A1,B,C](null, f(x)) // TODO: only alloc if f(x) != x
       } catch {
         case ex: Exception =>
           new ControlContext((k: A1 => B, thr: Exception => B) => thr(ex).asInstanceOf[C], null.asInstanceOf[A1])

--- a/src/library/scala/collection/SeqExtractors.scala
+++ b/src/library/scala/collection/SeqExtractors.scala
@@ -11,7 +11,7 @@ object +: {
 /** An extractor used to init/last deconstruct sequences. */
 object :+ {
   /** Splits a sequence into init :+ tail.
-   * @return Some(init, tail) if sequence is non-empty. None otherwise.
+   * @return Some((init, tail)) if sequence is non-empty. None otherwise.
    */
   def unapply[T,Coll <: SeqLike[T, Coll]](
       t: Coll with SeqLike[T, Coll]): Option[(Coll, T)] =

--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -920,11 +920,11 @@ object TrieMap extends MutableMapFactory[TrieMap] {
 
 
 private[collection] class TrieMapIterator[K, V](var level: Int, private var ct: TrieMap[K, V], mustInit: Boolean = true) extends Iterator[(K, V)] {
-  var stack = new Array[Array[BasicNode]](7)
-  var stackpos = new Array[Int](7)
-  var depth = -1
-  var subiter: Iterator[(K, V)] = null
-  var current: KVNode[K, V] = null
+  private var stack = new Array[Array[BasicNode]](7)
+  private var stackpos = new Array[Int](7)
+  private var depth = -1
+  private var subiter: Iterator[(K, V)] = null
+  private var current: KVNode[K, V] = null
 
   if (mustInit) initialize()
 

--- a/src/library/scala/collection/convert/DecorateAsJava.scala
+++ b/src/library/scala/collection/convert/DecorateAsJava.scala
@@ -313,6 +313,6 @@ trait DecorateAsJava {
    * @return An object with an `asJava` method that returns a Java
    *         `ConcurrentMap` view of the argument.
    */
-  implicit def asJavaConcurrentMapConverter[A, B](m: concurrent.Map[A, B]): AsJava[juc.ConcurrentMap[A, B]] =
-    new AsJava(asJavaConcurrentMap(m))
+  implicit def mapAsJavaConcurrentMapConverter[A, B](m: concurrent.Map[A, B]): AsJava[juc.ConcurrentMap[A, B]] =
+    new AsJava(mapAsJavaConcurrentMap(m))
 }

--- a/src/library/scala/collection/convert/WrapAsJava.scala
+++ b/src/library/scala/collection/convert/WrapAsJava.scala
@@ -269,7 +269,7 @@ trait WrapAsJava {
    * @param m The Scala `concurrent.Map` to be converted.
    * @return A Java `ConcurrentMap` view of the argument.
    */
-  implicit def asJavaConcurrentMap[A, B](m: concurrent.Map[A, B]): juc.ConcurrentMap[A, B] = m match {
+  implicit def mapAsJavaConcurrentMap[A, B](m: concurrent.Map[A, B]): juc.ConcurrentMap[A, B] = m match {
     case JConcurrentMapWrapper(wrapped) => wrapped
     case _ => new ConcurrentMapWrapper(m)
   }

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -120,7 +120,7 @@ class HashMap[A, +B] extends AbstractMap[A, B]
  */
 object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
 
-  private abstract class Merger[A, B] {
+  private[collection] abstract class Merger[A, B] {
     def apply(kv1: (A, B), kv2: (A, B)): (A, B)
     def invert: Merger[A, B]
   }
@@ -197,7 +197,7 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
     //     }
     //   }
 
-    override def updated0[B1 >: B](key: A, hash: Int, level: Int, value: B1, kv: (A, B1), merger: Merger[A, B1]): HashMap[A, B1] =
+    private[collection] override def updated0[B1 >: B](key: A, hash: Int, level: Int, value: B1, kv: (A, B1), merger: Merger[A, B1]): HashMap[A, B1] =
       if (hash == this.hash && key == this.key ) {
         if (merger eq null) {
           if (this.value.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef]) this
@@ -238,7 +238,7 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
     override def get0(key: A, hash: Int, level: Int): Option[B] =
       if (hash == this.hash) kvs.get(key) else None
 
-    override def updated0[B1 >: B](key: A, hash: Int, level: Int, value: B1, kv: (A, B1), merger: Merger[A, B1]): HashMap[A, B1] =
+    private[collection] override def updated0[B1 >: B](key: A, hash: Int, level: Int, value: B1, kv: (A, B1), merger: Merger[A, B1]): HashMap[A, B1] =
       if (hash == this.hash) {
         if ((merger eq null) || !kvs.contains(key)) new HashMapCollision1(hash, kvs.updated(key, value))
         else new HashMapCollision1(hash, kvs + merger((key, kvs(key)), kv))
@@ -316,7 +316,7 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
         None
     }
 
-    override def updated0[B1 >: B](key: A, hash: Int, level: Int, value: B1, kv: (A, B1), merger: Merger[A, B1]): HashMap[A, B1] = {
+    private[collection] override def updated0[B1 >: B](key: A, hash: Int, level: Int, value: B1, kv: (A, B1), merger: Merger[A, B1]): HashMap[A, B1] = {
       val index = (hash >>> level) & 0x1f
       val mask = (1 << index)
       val offset = Integer.bitCount(bitmap & (mask-1))

--- a/src/library/scala/concurrent/impl/Promise.scala
+++ b/src/library/scala/concurrent/impl/Promise.scala
@@ -107,7 +107,7 @@ private[concurrent] object Promise {
       case _ => None
     }
 
-    override def isCompleted(): Boolean = getState match { // Cheaper than boxing result into Option due to "def value"
+    override def isCompleted: Boolean = getState match { // Cheaper than boxing result into Option due to "def value"
       case _: Try[_] => true
       case _ => false
     }
@@ -156,7 +156,7 @@ private[concurrent] object Promise {
 
     val value = Some(resolveTry(suppliedValue))
 
-    override def isCompleted(): Boolean = true
+    override def isCompleted: Boolean = true
 
     def tryComplete(value: Try[T]): Boolean = false
 

--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -98,7 +98,7 @@ trait JavaMirrors extends internal.SymbolTable with api.JavaUniverse { thisUnive
     private val fieldCache = new TwoWayCache[jField, TermSymbol]
     private val tparamCache = new TwoWayCache[jTypeVariable[_ <: GenericDeclaration], TypeSymbol]
 
-    def toScala[J: HasJavaClass, S](cache: TwoWayCache[J, S], key: J)(body: (JavaMirror, J) => S): S =
+    private[runtime] def toScala[J: HasJavaClass, S](cache: TwoWayCache[J, S], key: J)(body: (JavaMirror, J) => S): S =
       cache.toScala(key){
         val jclazz = implicitly[HasJavaClass[J]] getClazz key
         body(mirrorDefining(jclazz), key)


### PR DESCRIPTION
Some fixes -Xlint told me about.

Moved dead code out of the standard lint, as it has become super
noisy for some reason. Un-overloaded implicits (don't overload
implicits!) Eliminated non-nullary method overriding nullary method
in the Future/Promise code. Made access levels consistent in some
collections classes.
