### PR TITLE
Removes discrepancy between SIP 15 and compiler

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2936,7 +2936,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     }
 
     override def derivedValueClassUnbox =
-      (info.decl(nme.unbox)) orElse
+      // (info.decl(nme.unbox)) orElse      uncomment once we accept unbox methods
       (info.decls.find(_ hasAllFlags PARAMACCESSOR | METHOD) getOrElse
        NoSymbol)
 


### PR DESCRIPTION
There was a discrepancy in that the compiler alternatively accepts a val parameter or an unbox method for a value class but SIP 15 does not mention the unbox method. I commented out the line in the compiler that does it. Review by @harrah @paulp
