### PR TITLE
Don't call `updateInfo` during typing.

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -1469,7 +1469,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def makeSerializable() {
       info match {
         case ci @ ClassInfoType(_, _, _) =>
-          updateInfo(ci.copy(parents = ci.parents :+ SerializableClass.tpe))
+          setInfo(ci.copy(parents = ci.parents :+ SerializableClass.tpe))
         case i =>
           abort("Only ClassInfoTypes can be made serializable: "+ i)
       }


### PR DESCRIPTION
We resort to `setInfo`, basically removing the previous info. This "fixes" a possible race condition
in typing ModuleDefs by making the typer always 'win'. See the assertion stack trace in SI-6429.

review by @odersky, @gkossakowski 
