### PR TITLE
hardens DirectTest against missing -d settings

### DIFF
--- a/src/partest/scala/tools/partest/DirectTest.scala
+++ b/src/partest/scala/tools/partest/DirectTest.scala
@@ -37,7 +37,7 @@ abstract class DirectTest extends App {
   }
   // new compiler
   def newCompiler(args: String*): Global = {
-    val settings = newSettings((CommandLineParser tokenize extraSettings) ++ args.toList)
+    val settings = newSettings((CommandLineParser tokenize ("-d \"" + testOutput.path + "\" " + extraSettings)) ++ args.toList)
     if (settings.Yrangepos.value) new Global(settings) with interactive.RangePositions
     else new Global(settings)
   }

--- a/test/files/run/typetags_without_scala_reflect_manifest_lookup.scala
+++ b/test/files/run/typetags_without_scala_reflect_manifest_lookup.scala
@@ -2,7 +2,7 @@ import scala.tools.partest._
 import scala.tools.nsc.Settings
 
 object Test extends DirectTest {
-  override def extraSettings = "-cp " + sys.props("partest.lib")
+  override def extraSettings = "-cp " + sys.props("partest.lib") + " -d \"" + testOutput.path + "\""
 
   def code = """
     object Test extends App {


### PR DESCRIPTION
And also explicitly specifies -d in a test where I forgot to do that.
Double checking never hurts.
