### PR TITLE
PluginComponent contributes description to -Xshow-phases. (Fixes SI-6446)

### DIFF
--- a/src/compiler/scala/tools/nsc/plugins/PluginComponent.scala
+++ b/src/compiler/scala/tools/nsc/plugins/PluginComponent.scala
@@ -22,4 +22,7 @@ abstract class PluginComponent extends SubComponent {
    * but can override it */
   val runsRightAfter: Option[String] = None
 
+  /** Useful for -Xshow-phases. */
+  def description: String = ""
+
 }

--- a/src/compiler/scala/tools/nsc/plugins/Plugins.scala
+++ b/src/compiler/scala/tools/nsc/plugins/Plugins.scala
@@ -106,7 +106,7 @@ trait Plugins {
    * @see phasesSet
    */
   protected def computePluginPhases(): Unit =
-    phasesSet ++= (plugins flatMap (_.components))
+    for (p <- plugins; c <- p.components) addToPhasesSet(c, c.description)
 
   /** Summary of the options for all loaded plugins */
   def pluginOptionsHelp: String =


### PR DESCRIPTION
In Global, SubComponent is called a phase descriptor, but it doesn't
actually have a description.  (Phase itself does.)  This fix adds
a description to PluginComponent so that plugins can describe what
they do in -Xshow-phases.
