### PR TITLE
SI-6422: add missing Fractional and Integral alias in scala package

### DIFF
--- a/src/library/scala/package.scala
+++ b/src/library/scala/package.scala
@@ -95,7 +95,10 @@ package object scala {
   val Equiv = scala.math.Equiv
 
   type Fractional[T] = scala.math.Fractional[T]
+  val Fractional = scala.math.Fractional
+
   type Integral[T] = scala.math.Integral[T]
+  val Integral = scala.math.Integral
 
   type Numeric[T] = scala.math.Numeric[T]
   val Numeric = scala.math.Numeric


### PR DESCRIPTION
In scala/package.scala we see:

``` scala
type Fractional[T] = scala.math.Fractional[T]
type Integral[T] = scala.math.Integral[T]

type Numeric[T] = scala.math.Numeric[T]
val Numeric = scala.math.Numeric
```

But Fractional and Integral have an associated object as well, and they should be aliased as well for consistency.
