### PR TITLE
Added utility function shortClass.

### DIFF
--- a/src/compiler/scala/tools/nsc/interpreter/JLineCompletion.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/JLineCompletion.scala
@@ -10,6 +10,7 @@ import scala.tools.jline._
 import scala.tools.jline.console.completer._
 import Completion._
 import scala.collection.mutable.ListBuffer
+import scala.reflect.internal.util.StringOps.longestCommonPrefix
 
 // REPL completor - queries supplied interpreter for valid
 // completions based on current contents of buffer.
@@ -301,16 +302,6 @@ class JLineCompletion(val intp: IMain) extends Completion with CompletionOutput 
     def isConsecutiveTabs(buf: String, cursor: Int) =
       cursor == lastCursor && buf == lastBuf
 
-    // Longest common prefix
-    def commonPrefix(xs: List[String]): String = {
-      if (xs.isEmpty || xs.contains("")) ""
-      else xs.head.head match {
-        case ch =>
-          if (xs.tail forall (_.head == ch)) "" + ch + commonPrefix(xs map (_.tail))
-          else ""
-      }
-    }
-
     // This is jline's entry point for completion.
     override def complete(buf: String, cursor: Int): Candidates = {
       verbosity = if (isConsecutiveTabs(buf, cursor)) verbosity + 1 else 0
@@ -324,7 +315,7 @@ class JLineCompletion(val intp: IMain) extends Completion with CompletionOutput 
         val newCursor =
           if (winners contains "") p.cursor
           else {
-            val advance = commonPrefix(winners)
+            val advance = longestCommonPrefix(winners)
             lastCursor = p.position + advance.length
             lastBuf = (buf take p.position) + advance
             repldbg("tryCompletion(%s, _) lastBuf = %s, lastCursor = %s, p.position = %s".format(

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -8,7 +8,7 @@ package internal
 
 import scala.collection.{ mutable, immutable }
 import scala.collection.mutable.ListBuffer
-import util.Statistics
+import util.{ Statistics, shortClassOfInstance }
 import Flags._
 import scala.annotation.tailrec
 import scala.reflect.io.AbstractFile
@@ -182,7 +182,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       if (isGADTSkolem) " (this is a GADT skolem)"
       else ""
 
-    def shortSymbolClass = getClass.getName.split('.').last.stripPrefix("Symbols$")
+    def shortSymbolClass = shortClassOfInstance(this)
     def symbolCreationString: String = (
       "%s%25s | %-40s | %s".format(
         if (settings.uniqid.value) "%06d | ".format(id) else "",

--- a/src/reflect/scala/reflect/internal/util/StringOps.scala
+++ b/src/reflect/scala/reflect/internal/util/StringOps.scala
@@ -34,6 +34,14 @@ trait StringOps {
       s.substring(0, idx + 1)
     }
   }
+  def longestCommonPrefix(xs: List[String]): String = {
+    if (xs.isEmpty || xs.contains("")) ""
+    else xs.head.head match {
+      case ch =>
+        if (xs.tail forall (_.head == ch)) "" + ch + longestCommonPrefix(xs map (_.tail))
+        else ""
+    }
+  }
 
   def decompose(str: String, sep: Char): List[String] = {
     def ws(start: Int): List[String] =

--- a/src/reflect/scala/reflect/internal/util/package.scala
+++ b/src/reflect/scala/reflect/internal/util/package.scala
@@ -1,0 +1,34 @@
+package scala
+package reflect
+package internal
+
+package object util {
+  import StringOps.longestCommonPrefix
+
+  // Shorten a name like Symbols$FooSymbol to FooSymbol.
+  private def shortenName(name: String): String = {
+    if (name == "") return ""
+    val segments = (name split '$').toList
+    val last     = segments.last
+
+    if (last.length == 0)
+      segments takeRight 2 mkString "$"
+    else
+      last
+  }
+
+  def shortClassOfInstance(x: AnyRef): String = shortClass(x.getClass)
+  def shortClass(clazz: Class[_]): String = {
+    val name: String = (clazz.getName split '.').last
+    def isModule     = name endsWith "$"                        // object
+    def isAnon       = (name split '$').last forall (_.isDigit) // anonymous class
+
+    if (isModule)
+      (name split '$' filterNot (_ == "")).last + "$"
+    else if (isAnon) {
+      val parents = clazz.getSuperclass :: clazz.getInterfaces.toList
+      parents map (c => shortClass(c)) mkString " with "
+    }
+    else shortenName(name)
+  }
+}

--- a/test/files/run/shortClass.check
+++ b/test/files/run/shortClass.check
@@ -1,0 +1,10 @@
+bippity.bop.Foo
+bippity.bop.Foo$Bar
+bippity.bop.Foo$Bar$
+Test$$anon$1
+Test$$anon$2
+Foo
+Bar
+Bar$
+Foo with DingDongBippy
+Bar with DingDongBippy

--- a/test/files/run/shortClass.scala
+++ b/test/files/run/shortClass.scala
@@ -1,0 +1,24 @@
+import scala.reflect.internal.util._
+
+package bippity {
+  trait DingDongBippy
+
+  package bop {
+    class Foo {
+      class Bar
+      object Bar
+    }
+  }
+}
+
+object Test {
+  import bippity._
+  import bop._
+
+  def main(args: Array[String]): Unit = {
+    val f = new Foo
+    val instances = List(f, new f.Bar, f.Bar, new Foo with DingDongBippy, new f.Bar with DingDongBippy)
+    instances map (_.getClass.getName) foreach println
+    instances map shortClassOfInstance foreach println
+  }
+}


### PR DESCRIPTION
Pretty sick of names like

  scala> typeOf[List[Int]].getClass.getName
  res0: String = scala.reflect.internal.Types$TypeRef$$anon$1

I wrote this so I can see what the class of some arbitrary
thing is in a way which my little brain can understand.  For
the example above we get

  scala> shortClassOfInstance(typeOf[List[Int]])
  res0: String = ArgsTypeRef with AliasTypeRef

Let's pimp a "shortClassName" onto AnyRef and be happy.
