### PR TITLE
Fixes SI-6421 - Manifest is no longer deprecated.

### DIFF
--- a/src/library/scala/reflect/Manifest.scala
+++ b/src/library/scala/reflect/Manifest.scala
@@ -39,7 +39,6 @@ import scala.collection.mutable.{ ArrayBuilder, WrappedArray }
  *
  */
 @scala.annotation.implicitNotFound(msg = "No Manifest available for ${T}.")
-@deprecated("Use scala.reflect.ClassTag (to capture erasures) or scala.reflect.runtime.universe.TypeTag (to capture types) or both instead", "2.10.0")
 trait Manifest[T] extends ClassManifest[T] with Equals {
   override def typeArguments: List[Manifest[_]] = Nil
 
@@ -60,7 +59,6 @@ trait Manifest[T] extends ClassManifest[T] with Equals {
   override def hashCode = this.erasure.##
 }
 
-@deprecated("Use type tags and manually check the corresponding class or type instead", "2.10.0")
 abstract class AnyValManifest[T <: AnyVal](override val toString: String) extends Manifest[T] with Equals {
   override def <:<(that: ClassManifest[_]): Boolean =
     (that eq this) || (that eq Manifest.Any) || (that eq Manifest.AnyVal)

--- a/src/library/scala/reflect/NoManifest.scala
+++ b/src/library/scala/reflect/NoManifest.scala
@@ -10,7 +10,6 @@ package scala.reflect
 
 /** One of the branches of an [[scala.reflect.OptManifest]].
   */
-@deprecated("This notion doesn't have a corresponding concept in 2.10, because scala.reflect.runtime.universe.TypeTag can capture arbitrary types. Use type tags instead of manifests, and there will be no need in opt manifests.", "2.10.0")
 object NoManifest extends OptManifest[Nothing] with Serializable {
   override def toString = "<?>"
 }

--- a/src/library/scala/reflect/OptManifest.scala
+++ b/src/library/scala/reflect/OptManifest.scala
@@ -14,5 +14,4 @@ package scala.reflect
  *
  *  @author Martin Odersky
  */
-@deprecated("This notion doesn't have a corresponding concept in 2.10, because scala.reflect.runtime.universe.TypeTag can capture arbitrary types. Use type tags instead of manifests, and there will be no need in opt manifests.", "2.10.0")
 trait OptManifest[+T] extends Serializable


### PR DESCRIPTION
However, all the methods on Manfiest that are approximations, or not core methods
of ClassTag are still deprecated.   This only allows people to use Manifest without
deprecation warnings for informational purposes, in lieu of non-experimental
TypeTags.

Note: This is only for 2.10.0.

Review by @xeno-by
