### PR TITLE
fixes a bug in a weak cache in runtime reflection

### DIFF
--- a/src/reflect/scala/reflect/runtime/SynchronizedTypes.scala
+++ b/src/reflect/scala/reflect/runtime/SynchronizedTypes.scala
@@ -24,7 +24,8 @@ trait SynchronizedTypes extends internal.Types { self: SymbolTable =>
     // i.e. they have their caches cleaned up automatically on per-run basis,
     // therefore they should use vanilla uniques, which are faster
     if (!isCompilerUniverse) {
-      val result = if (uniques contains tp) uniques(tp).get else null
+      val inCache = uniques get tp
+      val result = if (inCache.isDefined) inCache.get.get else null
       if (result ne null) result.asInstanceOf[T]
       else {
         uniques(tp) = new WeakReference(tp)


### PR DESCRIPTION
Entries in SynchronizedTypes.uniques could previously be garbage collected
in-between a successful call to contains and an actual cache lookup.

The patch could be a one-liner, but I don't want to use HOFs
in this function, whose prototype is a hotspot in the compiler.

Also the fix doesn't touch scalac in any way. It only applies to
reflective universes that provide runtime reflection functionality.
