### PR TITLE
SI-6436 Handle ambiguous string processors

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4578,7 +4578,7 @@ trait Typers extends Modes with Adaptations with Tags {
           // xml member to StringContext, which in turn has an unapply[Seq] method)
           if (name != nme.CONSTRUCTOR && inExprModeOr(mode, PATTERNmode)) {
             val qual1 = adaptToMemberWithArgs(tree, qual, name, mode, true, true)
-            if (qual1 ne qual)
+            if ((qual1 ne qual) && !qual1.isErrorTyped)
               return typed(treeCopy.Select(tree, qual1, name), mode, pt)
           }
           NoSymbol

--- a/test/files/neg/t6436.check
+++ b/test/files/neg/t6436.check
@@ -1,0 +1,10 @@
+t6436.scala:8: error: type mismatch;
+ found   : StringContext
+ required: ?{def q: ?}
+Note that implicit conversions are not applicable because they are ambiguous:
+ both method foo1 in object quasiquotes of type (ctx: StringContext)Object{def q: Nothing}
+ and method foo2 in object quasiquotes of type (ctx: StringContext)Object{def q: Nothing}
+ are possible conversion functions from StringContext to ?{def q: ?}
+  println(q"a")
+          ^
+one error found

--- a/test/files/neg/t6436.scala
+++ b/test/files/neg/t6436.scala
@@ -1,0 +1,9 @@
+object quasiquotes {
+  implicit def foo1(ctx: StringContext) = new { def q = ??? }
+  implicit def foo2(ctx: StringContext) = new { def q = ??? }
+}
+
+object Test extends App {
+  import quasiquotes._
+  println(q"a")
+}

--- a/test/files/neg/t6436b.check
+++ b/test/files/neg/t6436b.check
@@ -1,0 +1,10 @@
+t6436b.scala:8: error: type mismatch;
+ found   : StringContext
+ required: ?{def q: ?}
+Note that implicit conversions are not applicable because they are ambiguous:
+ both method foo1 in object quasiquotes of type (ctx: StringContext)Object{def q: Nothing}
+ and method foo2 in object quasiquotes of type (ctx: StringContext)Object{def q: Nothing}
+ are possible conversion functions from StringContext to ?{def q: ?}
+  println(StringContext("a").q())
+                       ^
+one error found

--- a/test/files/neg/t6436b.scala
+++ b/test/files/neg/t6436b.scala
@@ -1,0 +1,9 @@
+object quasiquotes {
+  implicit def foo1(ctx: StringContext) = new { def q = ??? }
+  implicit def foo2(ctx: StringContext) = new { def q = ??? }
+}
+
+object Test extends App {
+  import quasiquotes._
+  println(StringContext("a").q())
+}


### PR DESCRIPTION
Before, we got in an inifinite loop by chasing
the error typed result of adaptToMemberWithArgs.

One point of befuddlement remains: why did t6436 and t6436b
behave differently before this change?

Review by @hubertp
