### PR TITLE
SI-6451: Rename classes in `unchecked-abstract.scala` test.

### DIFF
--- a/test/files/neg/unchecked-abstract.check
+++ b/test/files/neg/unchecked-abstract.check
@@ -1,25 +1,25 @@
-unchecked-abstract.scala:16: error: abstract type H in type Con[M.this.H] is unchecked since it is eliminated by erasure
-    /*   warn */ println(x.isInstanceOf[Con[H]])
+unchecked-abstract.scala:16: error: abstract type H in type Contravariant[M.this.H] is unchecked since it is eliminated by erasure
+    /*   warn */ println(x.isInstanceOf[Contravariant[H]])
                                        ^
-unchecked-abstract.scala:21: error: abstract type H in type Con[M.this.H] is unchecked since it is eliminated by erasure
-    /*   warn */ println(x.isInstanceOf[Con[H]])
+unchecked-abstract.scala:21: error: abstract type H in type Contravariant[M.this.H] is unchecked since it is eliminated by erasure
+    /*   warn */ println(x.isInstanceOf[Contravariant[H]])
                                        ^
-unchecked-abstract.scala:27: error: abstract type T in type Inv[M.this.T] is unchecked since it is eliminated by erasure
-    /*   warn */ println(x.isInstanceOf[Inv[T]])
+unchecked-abstract.scala:27: error: abstract type T in type Invariant[M.this.T] is unchecked since it is eliminated by erasure
+    /*   warn */ println(x.isInstanceOf[Invariant[T]])
                                        ^
-unchecked-abstract.scala:28: error: abstract type L in type Inv[M.this.L] is unchecked since it is eliminated by erasure
-    /*   warn */ println(x.isInstanceOf[Inv[L]])
+unchecked-abstract.scala:28: error: abstract type L in type Invariant[M.this.L] is unchecked since it is eliminated by erasure
+    /*   warn */ println(x.isInstanceOf[Invariant[L]])
                                        ^
-unchecked-abstract.scala:31: error: abstract type H in type Inv[M.this.H] is unchecked since it is eliminated by erasure
-    /*   warn */ println(x.isInstanceOf[Inv[H]])
+unchecked-abstract.scala:31: error: abstract type H in type Invariant[M.this.H] is unchecked since it is eliminated by erasure
+    /*   warn */ println(x.isInstanceOf[Invariant[H]])
                                        ^
-unchecked-abstract.scala:33: error: abstract type L in type Inv[M.this.L] is unchecked since it is eliminated by erasure
-    /*   warn */ println(x.isInstanceOf[Inv[L]])
+unchecked-abstract.scala:33: error: abstract type L in type Invariant[M.this.L] is unchecked since it is eliminated by erasure
+    /*   warn */ println(x.isInstanceOf[Invariant[L]])
                                        ^
-unchecked-abstract.scala:36: error: abstract type H in type Inv[M.this.H] is unchecked since it is eliminated by erasure
-    /*   warn */ println(x.isInstanceOf[Inv[H]])
+unchecked-abstract.scala:36: error: abstract type H in type Invariant[M.this.H] is unchecked since it is eliminated by erasure
+    /*   warn */ println(x.isInstanceOf[Invariant[H]])
                                        ^
-unchecked-abstract.scala:37: error: abstract type T in type Inv[M.this.T] is unchecked since it is eliminated by erasure
-    /*   warn */ println(x.isInstanceOf[Inv[T]])
+unchecked-abstract.scala:37: error: abstract type T in type Invariant[M.this.T] is unchecked since it is eliminated by erasure
+    /*   warn */ println(x.isInstanceOf[Invariant[T]])
                                        ^
 8 errors found

--- a/test/files/neg/unchecked-abstract.scala
+++ b/test/files/neg/unchecked-abstract.scala
@@ -1,56 +1,56 @@
-trait Con[-X]
-trait Inv[X]
-trait Cov[+X]
+trait Contravariant[-X]
+trait Invariant[X]
+trait Covariant[+X]
 
 abstract class M {
   type H
   type L <: H
   type T >: L <: H
 
-  def h1(x: Con[H]) = {
-    /* nowarn */ println(x.isInstanceOf[Con[H]])
-    /* nowarn */ println(x.isInstanceOf[Con[T]])
-    /* nowarn */ println(x.isInstanceOf[Con[L]])
+  def h1(x: Contravariant[H]) = {
+    /* nowarn */ println(x.isInstanceOf[Contravariant[H]])
+    /* nowarn */ println(x.isInstanceOf[Contravariant[T]])
+    /* nowarn */ println(x.isInstanceOf[Contravariant[L]])
   }
-  def h2(x: Con[T]) = {
-    /*   warn */ println(x.isInstanceOf[Con[H]])
-    /* nowarn */ println(x.isInstanceOf[Con[T]])
-    /* nowarn */ println(x.isInstanceOf[Con[L]])
+  def h2(x: Contravariant[T]) = {
+    /*   warn */ println(x.isInstanceOf[Contravariant[H]])
+    /* nowarn */ println(x.isInstanceOf[Contravariant[T]])
+    /* nowarn */ println(x.isInstanceOf[Contravariant[L]])
   }
-  def h3(x: Con[L]) = {
-    /*   warn */ println(x.isInstanceOf[Con[H]])
-    /*   warn */ println(x.isInstanceOf[Con[T]])
-    /* nowarn */ println(x.isInstanceOf[Con[L]])
+  def h3(x: Contravariant[L]) = {
+    /*   warn */ println(x.isInstanceOf[Contravariant[H]])
+    /*   warn */ println(x.isInstanceOf[Contravariant[T]])
+    /* nowarn */ println(x.isInstanceOf[Contravariant[L]])
   }
-  def h4(x: Inv[H]) = {
-    /* nowarn */ println(x.isInstanceOf[Inv[H]])
-    /*   warn */ println(x.isInstanceOf[Inv[T]])
-    /*   warn */ println(x.isInstanceOf[Inv[L]])
+  def h4(x: Invariant[H]) = {
+    /* nowarn */ println(x.isInstanceOf[Invariant[H]])
+    /*   warn */ println(x.isInstanceOf[Invariant[T]])
+    /*   warn */ println(x.isInstanceOf[Invariant[L]])
   }
-  def h5(x: Inv[T]) = {
-    /*   warn */ println(x.isInstanceOf[Inv[H]])
-    /* nowarn */ println(x.isInstanceOf[Inv[T]])
-    /*   warn */ println(x.isInstanceOf[Inv[L]])
+  def h5(x: Invariant[T]) = {
+    /*   warn */ println(x.isInstanceOf[Invariant[H]])
+    /* nowarn */ println(x.isInstanceOf[Invariant[T]])
+    /*   warn */ println(x.isInstanceOf[Invariant[L]])
   }
-  def h6(x: Inv[L]) = {
-    /*   warn */ println(x.isInstanceOf[Inv[H]])
-    /*   warn */ println(x.isInstanceOf[Inv[T]])
-    /* nowarn */ println(x.isInstanceOf[Inv[L]])
+  def h6(x: Invariant[L]) = {
+    /*   warn */ println(x.isInstanceOf[Invariant[H]])
+    /*   warn */ println(x.isInstanceOf[Invariant[T]])
+    /* nowarn */ println(x.isInstanceOf[Invariant[L]])
   }
-  def h7(x: Cov[H]) = {
-    /* nowarn */ println(x.isInstanceOf[Cov[H]])
-    /*   warn */ println(x.isInstanceOf[Cov[T]])
-    /*   warn */ println(x.isInstanceOf[Cov[L]])
+  def h7(x: Covariant[H]) = {
+    /* nowarn */ println(x.isInstanceOf[Covariant[H]])
+    /*   warn */ println(x.isInstanceOf[Covariant[T]])
+    /*   warn */ println(x.isInstanceOf[Covariant[L]])
   }
-  def h8(x: Cov[T]) = {
-    /* nowarn */ println(x.isInstanceOf[Cov[H]])
-    /* nowarn */ println(x.isInstanceOf[Cov[T]])
-    /*   warn */ println(x.isInstanceOf[Cov[L]])
+  def h8(x: Covariant[T]) = {
+    /* nowarn */ println(x.isInstanceOf[Covariant[H]])
+    /* nowarn */ println(x.isInstanceOf[Covariant[T]])
+    /*   warn */ println(x.isInstanceOf[Covariant[L]])
   }
-  def h9(x: Cov[L]) = {
-    /* nowarn */ println(x.isInstanceOf[Cov[H]])
-    /* nowarn */ println(x.isInstanceOf[Cov[T]])
-    /* nowarn */ println(x.isInstanceOf[Cov[L]])
+  def h9(x: Covariant[L]) = {
+    /* nowarn */ println(x.isInstanceOf[Covariant[H]])
+    /* nowarn */ println(x.isInstanceOf[Covariant[T]])
+    /* nowarn */ println(x.isInstanceOf[Covariant[L]])
   }
 }
 
@@ -59,17 +59,17 @@ object Test extends M {
   type T = Int
   type L = Nothing
 
-  val conh = new Con[H] { }
-  val cont = new Con[T] { }
-  val conl = new Con[L] { }
+  val conh = new Contravariant[H] { }
+  val cont = new Contravariant[T] { }
+  val conl = new Contravariant[L] { }
 
-  val invh = new Inv[H] { }
-  val invt = new Inv[T] { }
-  val invl = new Inv[L] { }
+  val invh = new Invariant[H] { }
+  val invt = new Invariant[T] { }
+  val invl = new Invariant[L] { }
 
-  val covh = new Cov[H] { }
-  val covt = new Cov[T] { }
-  val covl = new Cov[L] { }
+  val covh = new Covariant[H] { }
+  val covt = new Covariant[T] { }
+  val covl = new Covariant[L] { }
 
   def main(args: Array[String]): Unit = {
     h1(conh)


### PR DESCRIPTION
As reported Miguel, `Con` is problematic name of a class on Windows
and makes this test to fail. Renamed classes to something else which
hopefully make Windows build happy again.

Closes SI-6451.

Review by @magarciaEPFL or @paulp.
