### PR TITLE
SI-6467: Zero element in aggregate now by-name

### DIFF
--- a/src/library/scala/collection/GenTraversableOnce.scala
+++ b/src/library/scala/collection/GenTraversableOnce.scala
@@ -261,11 +261,12 @@ trait GenTraversableOnce[+A] extends Any {
    *  @tparam B        the type of accumulated results
    *  @param z         the initial value for the accumulated result of the partition - this
    *                   will typically be the neutral element for the `seqop` operator (e.g.
-   *                   `Nil` for list concatenation or `0` for summation)
+   *                   `Nil` for list concatenation or `0` for summation) and may be evaluated
+   *                   more than once
    *  @param seqop     an operator used to accumulate results within a partition
    *  @param combop    an associative operator used to combine results from different partitions
    */
-  def aggregate[B](z: B)(seqop: (B, A) => B, combop: (B, B) => B): B
+  def aggregate[B](z: =>B)(seqop: (B, A) => B, combop: (B, B) => B): B
 
   /** Applies a binary operator to all elements of this $coll, going right to left.
    *  $willNotTerminateInf

--- a/src/library/scala/collection/TraversableOnce.scala
+++ b/src/library/scala/collection/TraversableOnce.scala
@@ -184,7 +184,7 @@ trait TraversableOnce[+A] extends Any with GenTraversableOnce[A] {
 
   def fold[A1 >: A](z: A1)(op: (A1, A1) => A1): A1 = foldLeft(z)(op)
 
-  def aggregate[B](z: B)(seqop: (B, A) => B, combop: (B, B) => B): B = foldLeft(z)(seqop)
+  def aggregate[B](z: =>B)(seqop: (B, A) => B, combop: (B, B) => B): B = foldLeft(z)(seqop)
 
   def sum[B >: A](implicit num: Numeric[B]): B = foldLeft(num.zero)(num.plus)
 

--- a/src/library/scala/collection/parallel/mutable/ParArray.scala
+++ b/src/library/scala/collection/parallel/mutable/ParArray.scala
@@ -181,7 +181,7 @@ self =>
 
     override def fold[U >: T](z: U)(op: (U, U) => U): U = foldLeft[U](z)(op)
 
-    override def aggregate[S](z: S)(seqop: (S, T) => S, combop: (S, S) => S): S = foldLeft[S](z)(seqop)
+    override def aggregate[S](z: =>S)(seqop: (S, T) => S, combop: (S, S) => S): S = foldLeft[S](z)(seqop)
 
     override def sum[U >: T](implicit num: Numeric[U]): U = {
       var s = sum_quick(num, arr, until, i, num.zero)

--- a/test/files/presentation/ide-bug-1000531.check
+++ b/test/files/presentation/ide-bug-1000531.check
@@ -19,7 +19,7 @@ retrieved 126 members
 [accessible:  true] `method addString(b: StringBuilder)StringBuilder`
 [accessible:  true] `method addString(b: StringBuilder, sep: String)StringBuilder`
 [accessible:  true] `method addString(b: StringBuilder, start: String, sep: String, end: String)StringBuilder`
-[accessible:  true] `method aggregate[B](z: B)(seqop: (B, B) => B, combop: (B, B) => B)B`
+[accessible:  true] `method aggregate[B](z: => B)(seqop: (B, B) => B, combop: (B, B) => B)B`
 [accessible:  true] `method asInstanceOf[T0]=> T0`
 [accessible:  true] `method buffered=> scala.collection.BufferedIterator[B]`
 [accessible:  true] `method collectFirst[B](pf: PartialFunction[B,B])Option[B]`

--- a/test/files/run/t6467.scala
+++ b/test/files/run/t6467.scala
@@ -1,0 +1,20 @@
+
+
+
+
+import collection._
+
+
+
+object Test extends App {
+
+  def compare(s1: String, s2: String) {
+    assert(s1 == s2, s1 + "\nvs.\n" + s2)
+  }
+
+  compare(List(1, 2, 3, 4).aggregate(new java.lang.StringBuffer)(_ append _, _ append _).toString, "1234")
+  compare(List(1, 2, 3, 4).par.aggregate(new java.lang.StringBuffer)(_ append _, _ append _).toString, "1234")
+  compare(Seq(0 until 100: _*).aggregate(new java.lang.StringBuffer)(_ append _, _ append _).toString, (0 until 100).mkString)
+  compare(Seq(0 until 100: _*).par.aggregate(new java.lang.StringBuffer)(_ append _, _ append _).toString, (0 until 100).mkString)
+
+}


### PR DESCRIPTION
Change zero element `z` in `aggregate` signature to be by-name.

Review by @jsuereth.
