### PR TITLE
undeprecates manifests for 2.10.0

### DIFF
--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -103,23 +103,29 @@ object Predef extends LowPriorityImplicits {
   @annotation.implicitNotFound(msg = "No ClassManifest available for ${T}.")
   @deprecated("Use scala.reflect.ClassTag instead", "2.10.0")
   type ClassManifest[T] = scala.reflect.ClassManifest[T]
-  @deprecated("This notion doesn't have a corresponding concept in 2.10, because scala.reflect.runtime.universe.TypeTag can capture arbitrary types. Use type tags instead of manifests, and there will be no need in opt manifests.", "2.10.0")
+  // TODO undeprecated until Scala reflection becomes non-experimental
+  // @deprecated("This notion doesn't have a corresponding concept in 2.10, because scala.reflect.runtime.universe.TypeTag can capture arbitrary types. Use type tags instead of manifests, and there will be no need in opt manifests.", "2.10.0")
   type OptManifest[T]   = scala.reflect.OptManifest[T]
   @annotation.implicitNotFound(msg = "No Manifest available for ${T}.")
-  @deprecated("Use scala.reflect.ClassTag (to capture erasures) or scala.reflect.runtime.universe.TypeTag (to capture types) or both instead", "2.10.0")
+  // TODO undeprecated until Scala reflection becomes non-experimental
+  // @deprecated("Use scala.reflect.ClassTag (to capture erasures) or scala.reflect.runtime.universe.TypeTag (to capture types) or both instead", "2.10.0")
   type Manifest[T]      = scala.reflect.Manifest[T]
   @deprecated("Use scala.reflect.ClassTag instead", "2.10.0")
   val ClassManifest     = scala.reflect.ClassManifest
-  @deprecated("Use scala.reflect.ClassTag (to capture erasures) or scala.reflect.runtime.universe.TypeTag (to capture types) or both instead", "2.10.0")
+  // TODO undeprecated until Scala reflection becomes non-experimental
+  // @deprecated("Use scala.reflect.ClassTag (to capture erasures) or scala.reflect.runtime.universe.TypeTag (to capture types) or both instead", "2.10.0")
   val Manifest          = scala.reflect.Manifest
-  @deprecated("This notion doesn't have a corresponding concept in 2.10, because scala.reflect.runtime.universe.TypeTag can capture arbitrary types. Use type tags instead of manifests, and there will be no need in opt manifests.", "2.10.0")
+  // TODO undeprecated until Scala reflection becomes non-experimental
+  // @deprecated("This notion doesn't have a corresponding concept in 2.10, because scala.reflect.runtime.universe.TypeTag can capture arbitrary types. Use type tags instead of manifests, and there will be no need in opt manifests.", "2.10.0")
   val NoManifest        = scala.reflect.NoManifest
 
-  @deprecated("Use scala.reflect.classTag[T] and scala.reflect.runtime.universe.typeTag[T] instead", "2.10.0")
+  // TODO undeprecated until Scala reflection becomes non-experimental
+  // @deprecated("Use scala.reflect.classTag[T] and scala.reflect.runtime.universe.typeTag[T] instead", "2.10.0")
   def manifest[T](implicit m: Manifest[T])           = m
   @deprecated("Use scala.reflect.classTag[T] instead", "2.10.0")
   def classManifest[T](implicit m: ClassManifest[T]) = m
-  @deprecated("This notion doesn't have a corresponding concept in 2.10, because scala.reflect.runtime.universe.TypeTag can capture arbitrary types. Use type tags instead of manifests, and there will be no need in opt manifests.", "2.10.0")
+  // TODO undeprecated until Scala reflection becomes non-experimental
+  // @deprecated("This notion doesn't have a corresponding concept in 2.10, because scala.reflect.runtime.universe.TypeTag can capture arbitrary types. Use type tags instead of manifests, and there will be no need in opt manifests.", "2.10.0")
   def optManifest[T](implicit m: OptManifest[T])     = m
 
   // Minor variations on identity functions

--- a/src/library/scala/reflect/Manifest.scala
+++ b/src/library/scala/reflect/Manifest.scala
@@ -39,7 +39,8 @@ import scala.collection.mutable.{ ArrayBuilder, WrappedArray }
  *
  */
 @scala.annotation.implicitNotFound(msg = "No Manifest available for ${T}.")
-@deprecated("Use scala.reflect.ClassTag (to capture erasures) or scala.reflect.runtime.universe.TypeTag (to capture types) or both instead", "2.10.0")
+// TODO undeprecated until Scala reflection becomes non-experimental
+// @deprecated("Use scala.reflect.ClassTag (to capture erasures) or scala.reflect.runtime.universe.TypeTag (to capture types) or both instead", "2.10.0")
 trait Manifest[T] extends ClassManifest[T] with Equals {
   override def typeArguments: List[Manifest[_]] = Nil
 
@@ -60,7 +61,8 @@ trait Manifest[T] extends ClassManifest[T] with Equals {
   override def hashCode = this.erasure.##
 }
 
-@deprecated("Use type tags and manually check the corresponding class or type instead", "2.10.0")
+// TODO undeprecated until Scala reflection becomes non-experimental
+// @deprecated("Use type tags and manually check the corresponding class or type instead", "2.10.0")
 abstract class AnyValManifest[T <: AnyVal](override val toString: String) extends Manifest[T] with Equals {
   override def <:<(that: ClassManifest[_]): Boolean =
     (that eq this) || (that eq Manifest.Any) || (that eq Manifest.AnyVal)

--- a/src/library/scala/reflect/NoManifest.scala
+++ b/src/library/scala/reflect/NoManifest.scala
@@ -10,7 +10,8 @@ package scala.reflect
 
 /** One of the branches of an [[scala.reflect.OptManifest]].
   */
-@deprecated("This notion doesn't have a corresponding concept in 2.10, because scala.reflect.runtime.universe.TypeTag can capture arbitrary types. Use type tags instead of manifests, and there will be no need in opt manifests.", "2.10.0")
+// TODO undeprecated until Scala reflection becomes non-experimental
+// @deprecated("This notion doesn't have a corresponding concept in 2.10, because scala.reflect.runtime.universe.TypeTag can capture arbitrary types. Use type tags instead of manifests, and there will be no need in opt manifests.", "2.10.0")
 object NoManifest extends OptManifest[Nothing] with Serializable {
   override def toString = "<?>"
 }

--- a/src/library/scala/reflect/OptManifest.scala
+++ b/src/library/scala/reflect/OptManifest.scala
@@ -14,5 +14,6 @@ package scala.reflect
  *
  *  @author Martin Odersky
  */
-@deprecated("This notion doesn't have a corresponding concept in 2.10, because scala.reflect.runtime.universe.TypeTag can capture arbitrary types. Use type tags instead of manifests, and there will be no need in opt manifests.", "2.10.0")
+// TODO undeprecated until Scala reflection becomes non-experimental
+// @deprecated("This notion doesn't have a corresponding concept in 2.10, because scala.reflect.runtime.universe.TypeTag can capture arbitrary types. Use type tags instead of manifests, and there will be no need in opt manifests.", "2.10.0")
 trait OptManifest[+T] extends Serializable

--- a/src/library/scala/reflect/package.scala
+++ b/src/library/scala/reflect/package.scala
@@ -36,7 +36,8 @@ package object reflect {
   /** The object `Manifest` defines factory methods for manifests.
    *  It is intended for use by the compiler and should not be used in client code.
    */
-  @deprecated("Use scala.reflect.ClassTag (to capture erasures), scala.reflect.runtime.universe.TypeTag (to capture types) or both instead", "2.10.0")
+  // TODO undeprecated until Scala reflection becomes non-experimental
+  // @deprecated("Use scala.reflect.ClassTag (to capture erasures), scala.reflect.runtime.universe.TypeTag (to capture types) or both instead", "2.10.0")
   val Manifest = ManifestFactory
 
   def classTag[T](implicit ctag: ClassTag[T]) = ctag

--- a/test/files/neg/classmanifests_new_deprecations.check
+++ b/test/files/neg/classmanifests_new_deprecations.check
@@ -28,34 +28,4 @@ classmanifests_new_deprecations.scala:10: error: type ClassManifest in object Pr
 classmanifests_new_deprecations.scala:15: error: type ClassManifest in package reflect is deprecated: Use scala.reflect.ClassTag instead
   type RCM[T] = scala.reflect.ClassManifest[T]
                               ^
-classmanifests_new_deprecations.scala:20: error: type Manifest in object Predef is deprecated: Use scala.reflect.ClassTag (to capture erasures) or scala.reflect.runtime.universe.TypeTag (to capture types) or both instead
-  def m1[T: Manifest] = ???
-          ^
-classmanifests_new_deprecations.scala:21: error: type Manifest in object Predef is deprecated: Use scala.reflect.ClassTag (to capture erasures) or scala.reflect.runtime.universe.TypeTag (to capture types) or both instead
-  def m2[T](implicit evidence$1: Manifest[T]) = ???
-                                 ^
-classmanifests_new_deprecations.scala:22: error: type Manifest in object Predef is deprecated: Use scala.reflect.ClassTag (to capture erasures) or scala.reflect.runtime.universe.TypeTag (to capture types) or both instead
-  val m3: Manifest[Int] = null
-          ^
-classmanifests_new_deprecations.scala:22: error: type Manifest in object Predef is deprecated: Use scala.reflect.ClassTag (to capture erasures) or scala.reflect.runtime.universe.TypeTag (to capture types) or both instead
-  val m3: Manifest[Int] = null
-      ^
-classmanifests_new_deprecations.scala:24: error: trait Manifest in package reflect is deprecated: Use scala.reflect.ClassTag (to capture erasures) or scala.reflect.runtime.universe.TypeTag (to capture types) or both instead
-  def rm1[T: scala.reflect.Manifest] = ???
-           ^
-classmanifests_new_deprecations.scala:25: error: trait Manifest in package reflect is deprecated: Use scala.reflect.ClassTag (to capture erasures) or scala.reflect.runtime.universe.TypeTag (to capture types) or both instead
-  def rm2[T](implicit evidence$1: scala.reflect.Manifest[T]) = ???
-                                                ^
-classmanifests_new_deprecations.scala:26: error: trait Manifest in package reflect is deprecated: Use scala.reflect.ClassTag (to capture erasures) or scala.reflect.runtime.universe.TypeTag (to capture types) or both instead
-  val rm3: scala.reflect.Manifest[Int] = null
-                         ^
-classmanifests_new_deprecations.scala:26: error: trait Manifest in package reflect is deprecated: Use scala.reflect.ClassTag (to capture erasures) or scala.reflect.runtime.universe.TypeTag (to capture types) or both instead
-  val rm3: scala.reflect.Manifest[Int] = null
-      ^
-classmanifests_new_deprecations.scala:28: error: type Manifest in object Predef is deprecated: Use scala.reflect.ClassTag (to capture erasures) or scala.reflect.runtime.universe.TypeTag (to capture types) or both instead
-  type M[T] = Manifest[T]
-              ^
-classmanifests_new_deprecations.scala:33: error: trait Manifest in package reflect is deprecated: Use scala.reflect.ClassTag (to capture erasures) or scala.reflect.runtime.universe.TypeTag (to capture types) or both instead
-  type RM[T] = scala.reflect.Manifest[T]
-                             ^
-20 errors found
+10 errors found

--- a/test/files/neg/t3692-old.check
+++ b/test/files/neg/t3692-old.check
@@ -7,14 +7,8 @@ t3692-old.scala:14: warning: non-variable type argument Int in type pattern Map[
 t3692-old.scala:15: warning: non-variable type argument Int in type pattern Map[T,Int] is unchecked since it is eliminated by erasure
       case m2: Map[T, Int] => new java.util.HashMap[T, Integer]
                ^
-t3692-old.scala:11: warning: type Manifest in object Predef is deprecated: Use scala.reflect.ClassTag (to capture erasures) or scala.reflect.runtime.universe.TypeTag (to capture types) or both instead
-  private final def toJavaMap[T, V](map: Map[T, V])(implicit m1: Manifest[T], m2: Manifest[V]): java.util.Map[_, _] = {
-                                                                 ^
-t3692-old.scala:11: warning: type Manifest in object Predef is deprecated: Use scala.reflect.ClassTag (to capture erasures) or scala.reflect.runtime.universe.TypeTag (to capture types) or both instead
-  private final def toJavaMap[T, V](map: Map[T, V])(implicit m1: Manifest[T], m2: Manifest[V]): java.util.Map[_, _] = {
-                                                                                  ^
 t3692-old.scala:15: error: unreachable code
       case m2: Map[T, Int] => new java.util.HashMap[T, Integer]
                               ^
-5 warnings found
+three warnings found
 one error found

--- a/test/files/run/manifests-undeprecated-in-2.10.0.flags
+++ b/test/files/run/manifests-undeprecated-in-2.10.0.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/run/manifests-undeprecated-in-2.10.0.scala
+++ b/test/files/run/manifests-undeprecated-in-2.10.0.scala
@@ -1,0 +1,15 @@
+object Test extends App {
+  def m1a: scala.reflect.Manifest[Int] = scala.reflect.Manifest.Int
+  def m2a: scala.reflect.OptManifest[Int] = ???
+  def m3a = scala.reflect.NoManifest
+
+  def m1b: Manifest[Int] = Manifest.Int
+  def m2b: OptManifest[Int] = ???
+  def m3b = NoManifest
+
+  val m4a = manifest[Int]
+  val m5a = optManifest[Int]
+
+  val m4b = implicitly[Manifest[Int]]
+  val m5b = implicitly[OptManifest[Int]]
+}


### PR DESCRIPTION
Since scala-reflect.jar is going to be declared experimental for 2.10.0,
it doesn't make sense to deprecate manifests in favor of type tags.

Class manifests, however, ARE deprecated for class tags, because class tags
don't require scala-reflect.jar and are generated independently of type tags.
