### PR TITLE
Renamed hasSymbol to hasSymbolField.

### DIFF
--- a/src/compiler/scala/reflect/reify/codegen/GenTrees.scala
+++ b/src/compiler/scala/reflect/reify/codegen/GenTrees.scala
@@ -64,7 +64,7 @@ trait GenTrees {
 
     // usually we don't reify symbols/types, because they can be re-inferred during subsequent reflective compilation
     // however, reification of AnnotatedTypes is special. see ``reifyType'' to find out why.
-    if (reifyTreeSymbols && tree.hasSymbol) {
+    if (reifyTreeSymbols && tree.hasSymbolField) {
       if (reifyDebug) println("reifying symbol %s for tree %s".format(tree.symbol, tree))
       rtree = mirrorBuildCall(nme.setSymbol, rtree, reify(tree.symbol))
     }
@@ -86,8 +86,8 @@ trait GenTrees {
 
         // see ``Metalevels'' for more info about metalevel breaches
         // and about how we deal with splices that contain them
-        val isMetalevelBreach = splicee exists (sub => sub.hasSymbol && sub.symbol != NoSymbol && sub.symbol.metalevel > 0)
-        val isRuntimeEval = splicee exists (sub => sub.hasSymbol && sub.symbol == ExprSplice)
+        val isMetalevelBreach = splicee exists (sub => sub.hasSymbolField && sub.symbol != NoSymbol && sub.symbol.metalevel > 0)
+        val isRuntimeEval = splicee exists (sub => sub.hasSymbolField && sub.symbol == ExprSplice)
         if (isMetalevelBreach || isRuntimeEval) {
           // we used to convert dynamic splices into runtime evals transparently, but we no longer do that
           // why? see comments in ``Metalevels''

--- a/src/compiler/scala/reflect/reify/phases/Metalevels.scala
+++ b/src/compiler/scala/reflect/reify/phases/Metalevels.scala
@@ -124,7 +124,7 @@ trait Metalevels {
         withinSplice { super.transform(TreeSplice(ReifiedTree(universe, mirror, symtab1, rtree, tpe, rtpe, concrete))) }
       case TreeSplice(splicee) =>
         if (reifyDebug) println("entering splice: " + splicee)
-        val breaches = splicee filter (sub => sub.hasSymbol && sub.symbol != NoSymbol && sub.symbol.metalevel > 0)
+        val breaches = splicee filter (sub => sub.hasSymbolField && sub.symbol != NoSymbol && sub.symbol.metalevel > 0)
         if (!insideSplice && breaches.nonEmpty) {
           // we used to convert dynamic splices into runtime evals transparently, but we no longer do that
           // why? see comments above

--- a/src/compiler/scala/tools/nsc/ast/TreeBrowsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeBrowsers.scala
@@ -509,7 +509,7 @@ abstract class TreeBrowsers {
     /** Return a textual representation of this t's symbol */
     def symbolText(t: Tree): String = {
       val prefix =
-        if (t.hasSymbol)  "[has] "
+        if (t.hasSymbolField)  "[has] "
         else if (t.isDef) "[defines] "
         else ""
 

--- a/src/compiler/scala/tools/nsc/ast/TreeGen.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeGen.scala
@@ -22,7 +22,7 @@ abstract class TreeGen extends scala.reflect.internal.TreeGen with TreeDSL {
 
   def mkCheckInit(tree: Tree): Tree = {
     val tpe =
-      if (tree.tpe != null || !tree.hasSymbol) tree.tpe
+      if (tree.tpe != null || !tree.hasSymbolField) tree.tpe
       else tree.symbol.tpe
 
     if (!global.phase.erasedTypes && settings.warnSelectNullable.value &&

--- a/src/compiler/scala/tools/nsc/ast/Trees.scala
+++ b/src/compiler/scala/tools/nsc/ast/Trees.scala
@@ -341,7 +341,7 @@ trait Trees extends scala.reflect.internal.Trees { self: Global =>
                 tree
               case _ =>
                 val dupl = tree.duplicate
-                if (tree.hasSymbol && (!localOnly || (locals contains tree.symbol)) && !(keepLabels && tree.symbol.isLabel))
+                if (tree.hasSymbolField && (!localOnly || (locals contains tree.symbol)) && !(keepLabels && tree.symbol.isLabel))
                   dupl.symbol = NoSymbol
                 dupl.tpe = null
                 dupl

--- a/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
@@ -68,7 +68,7 @@ abstract class Pickler extends SubComponent {
           return
         }
 
-        if (!t.isDef && t.hasSymbol && t.symbol.isTermMacro) {
+        if (!t.isDef && t.hasSymbolField && t.symbol.isTermMacro) {
           unit.error(t.pos, t.symbol.typeParams.length match {
             case 0 => "macro has not been expanded"
             case 1 => "this type parameter must be specified"
@@ -235,7 +235,7 @@ abstract class Pickler extends SubComponent {
     private def putTree(tree: Tree): Unit = if (putEntry(tree)) {
       if (tree != EmptyTree)
         putType(tree.tpe)
-      if (tree.hasSymbol)
+      if (tree.hasSymbolField)
         putSymbol(tree.symbol)
 
       tree match {

--- a/src/compiler/scala/tools/nsc/transform/AddInterfaces.scala
+++ b/src/compiler/scala/tools/nsc/transform/AddInterfaces.scala
@@ -321,7 +321,7 @@ abstract class AddInterfaces extends InfoTransform { self: Erasure =>
         Block(List(Apply(gen.mkSuperInitCall, Nil)), expr)
 
       case Block(stats, expr) =>
-        // needs `hasSymbol` check because `supercall` could be a block (named / default args)
+        // needs `hasSymbolField` check because `supercall` could be a block (named / default args)
         val (presuper, supercall :: rest) = stats span (t => t.hasSymbolWhich(_ hasFlag PRESUPER))
         treeCopy.Block(tree, presuper ::: (supercall :: mixinConstructorCalls ::: rest), expr)
     }

--- a/src/compiler/scala/tools/nsc/transform/Mixin.scala
+++ b/src/compiler/scala/tools/nsc/transform/Mixin.scala
@@ -438,7 +438,7 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
         tree match {
           case Assign(lhs, rhs) => traverse(rhs) // assignments don't count
           case _ =>
-            if (tree.hasSymbol && tree.symbol != NoSymbol) {
+            if (tree.hasSymbolField && tree.symbol != NoSymbol) {
               val sym = tree.symbol
               if ((sym.hasAccessorFlag || (sym.isTerm && !sym.isMethod))
                   && sym.isPrivate
@@ -804,7 +804,7 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
 	   */
 	  class TreeSymSubstituterWithCopying(from: List[Symbol], to: List[Symbol]) extends TreeSymSubstituter(from, to) {
 	    override def transform(tree: Tree): Tree =
-	      if (tree.hasSymbol && from.contains(tree.symbol))
+	      if (tree.hasSymbolField && from.contains(tree.symbol))
 	        super.transform(tree.duplicate)
 	      else super.transform(tree.duplicate)
 

--- a/src/compiler/scala/tools/nsc/typechecker/Duplicators.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Duplicators.scala
@@ -233,7 +233,7 @@ abstract class Duplicators extends Analyzer {
     override def typed(tree: Tree, mode: Int, pt: Type): Tree = {
       debuglog("typing " + tree + ": " + tree.tpe + ", " + tree.getClass)
       val origtreesym = tree.symbol
-      if (tree.hasSymbol && tree.symbol != NoSymbol
+      if (tree.hasSymbolField && tree.symbol != NoSymbol
           && !tree.symbol.isLabel  // labels cannot be retyped by the type checker as LabelDef has no ValDef/return type trees
           && invalidSyms.isDefinedAt(tree.symbol)) {
         debuglog("removed symbol " + tree.symbol)
@@ -403,7 +403,7 @@ abstract class Duplicators extends Analyzer {
         case _ =>
           debuglog("Duplicators default case: " + tree.summaryString)
           debuglog(" ---> " + tree)
-          if (tree.hasSymbol && tree.symbol != NoSymbol && (tree.symbol.owner == definitions.AnyClass)) {
+          if (tree.hasSymbolField && tree.symbol != NoSymbol && (tree.symbol.owner == definitions.AnyClass)) {
             tree.symbol = NoSymbol // maybe we can find a more specific member in a subclass of Any (see AnyVal members, like ==)
           }
           val ntree = castType(tree, pt)

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -269,7 +269,7 @@ trait Infer extends Checkable {
       def errorValue  = if (context.reportErrors) context.owner.newErrorValue(name) else stdErrorValue
       def errorSym    = if (tree.isType) errorClass else errorValue
 
-      if (tree.hasSymbol)
+      if (tree.hasSymbolField)
         tree setSymbol errorSym
 
       tree setType ErrorType

--- a/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
@@ -2547,7 +2547,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
             }
 
           val toString =
-            if (p.hasSymbol && p.symbol.isStable) p.symbol.name.toString // tp.toString
+            if (p.hasSymbolField && p.symbol.isStable) p.symbol.name.toString // tp.toString
             else p.toString //+"#"+ id
 
           Const.unique(narrowTp, new ValueConst(narrowTp, checkableType(wideTp), toString)) // must make wide type checkable so that it is comparable to types from TypeConst

--- a/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
+++ b/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
@@ -102,7 +102,7 @@ abstract class ToolBoxFactory[U <: JavaUniverse](val u: U) { factorySelf =>
         })
         var expr = new Transformer {
           override def transform(tree: Tree): Tree =
-            if (tree.hasSymbol && tree.symbol.isFreeTerm) {
+            if (tree.hasSymbolField && tree.symbol.isFreeTerm) {
               tree match {
                 case Ident(_) =>
                   val freeTermRef = Ident(freeTermNames(tree.symbol.asFreeTerm))

--- a/src/reflect/scala/reflect/api/Trees.scala
+++ b/src/reflect/scala/reflect/api/Trees.scala
@@ -100,7 +100,7 @@ trait Trees { self: Universe =>
     def symbol: Symbol
 
     /** ... */
-    def hasSymbol: Boolean
+    def hasSymbolField: Boolean
 
     /** Provides an alternate if tree is empty
      *  @param  alt  The alternate tree

--- a/src/reflect/scala/reflect/internal/Importers.scala
+++ b/src/reflect/scala/reflect/internal/Importers.scala
@@ -427,17 +427,17 @@ trait Importers extends api.Importers { self: SymbolTable =>
       }
       addFixup({
         if (mytree != null) {
-          val mysym = if (tree.hasSymbol) importSymbol(tree.symbol) else NoSymbol
+          val mysym = if (tree.hasSymbolField) importSymbol(tree.symbol) else NoSymbol
           val mytpe = importType(tree.tpe)
 
           mytree match {
             case mytt: TypeTree =>
               val tt = tree.asInstanceOf[from.TypeTree]
-              if (mytree.hasSymbol) mytt.symbol = mysym
+              if (mytree.hasSymbolField) mytt.symbol = mysym
               if (tt.wasEmpty) mytt.defineType(mytpe) else mytt.setType(mytpe)
               if (tt.original != null) mytt.setOriginal(importTree(tt.original))
             case _ =>
-              if (mytree.hasSymbol) mytree.symbol = importSymbol(tree.symbol)
+              if (mytree.hasSymbolField) mytree.symbol = importSymbol(tree.symbol)
               mytree.tpe = importType(tree.tpe)
           }
         }

--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -546,8 +546,8 @@ trait Printers extends api.Printers { self: SymbolTable =>
             case _ => print(value.toString)
           }
         case tree: Tree =>
-          val hasSymbol = tree.hasSymbol && tree.symbol != NoSymbol
-          val isError = hasSymbol && tree.symbol.name.toString == nme.ERROR.toString
+          val hasSymbolField = tree.hasSymbolField && tree.symbol != NoSymbol
+          val isError = hasSymbolField && tree.symbol.name.toString == nme.ERROR.toString
           printProduct(
             tree,
             preamble = _ => {
@@ -560,7 +560,7 @@ trait Printers extends api.Printers { self: SymbolTable =>
                   if (isError) print("<")
                   print(name)
                   if (isError) print(": error>")
-                } else if (hasSymbol) {
+                } else if (hasSymbolField) {
                   tree match {
                     case _: Ident | _: Select | _: SelectFromTypeTree => print(tree.symbol)
                     case _ => print(tree.symbol.name)

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -31,7 +31,8 @@ trait Trees extends api.Trees { self: SymbolTable =>
     def symbol: Symbol = null //!!!OPT!!! symbol is about 3% of hot compile times -- megamorphic dispatch?
     def symbol_=(sym: Symbol) { throw new UnsupportedOperationException("symbol_= inapplicable for " + this) }
     def setSymbol(sym: Symbol): this.type = { symbol = sym; this }
-    def hasSymbol = false
+    def hasSymbolField = false
+    @deprecated("Use hasSymbolField", "2.11.0") def hasSymbol = hasSymbolField
 
     def isDef = false
 
@@ -62,7 +63,7 @@ trait Trees extends api.Trees { self: SymbolTable =>
     private[scala] def copyAttrs(tree: Tree): this.type = {
       rawatt = tree.rawatt
       tpe = tree.tpe
-      if (hasSymbol) symbol = tree.symbol
+      if (hasSymbolField) symbol = tree.symbol
       this
     }
 
@@ -210,7 +211,7 @@ trait Trees extends api.Trees { self: SymbolTable =>
   trait TypTree extends Tree with TypTreeApi
 
   abstract class SymTree extends Tree with SymTreeContextApi {
-    override def hasSymbol = true
+    override def hasSymbolField = true
     override var symbol: Symbol = NoSymbol
   }
 
@@ -1412,7 +1413,7 @@ trait Trees extends api.Trees { self: SymbolTable =>
       }
 
       if (tree.tpe ne null) tree.tpe = symSubst(tree.tpe)
-      if (tree.hasSymbol) {
+      if (tree.hasSymbolField) {
         subst(from, to)
         tree match {
           case Ident(name0) if tree.symbol != NoSymbol =>


### PR DESCRIPTION
Suggestion by retronym that the obvious implementation of
"hasSymbol" be called "hasSymbol" reminded me we have a method
called "hasSymbol" which does not have that implementation, and
which has burned us already with subtle bugginess. I think that
"hasSymbolField" is self-documenting.
