### PR TITLE
Added Regex.matches(s:String)

### DIFF
--- a/src/library/scala/util/matching/Regex.scala
+++ b/src/library/scala/util/matching/Regex.scala
@@ -189,6 +189,13 @@ class Regex(regex: String, groupNames: String*) extends Serializable {
   }
   protected def runMatcher(m: Matcher) = m.matches()
 
+  /** Tries to match target (whole match) and returns, if this was successful.
+   *
+   *  @param s The string to match
+   *  @return  True, if the given string matches the pattern. False otherwise.
+   */
+  def matches(s: String) = runMatcher(pattern matcher s)
+
   /** Return all matches of this regexp in given character sequence as a [[scala.util.matching.Regex.MatchIterator]],
    *  which is a special [[scala.collection.Iterator]] that returns the
    *  matched strings, but can also be converted into a normal iterator


### PR DESCRIPTION
I missed a function to directly check if a string complies to a regex.
- String.matches() only allows Strings as parameters (not Regex'es)
- The scala Regex class didn't offer a direct way.

The user had to write

```
val myRegex="some_regex".r
myRegex.pattern.matcher(string).matches
```

which I found to be too complicated. So I implemented a shortcut function in the scala Regex class.
