### PR TITLE
Another reflection bomb

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2337,7 +2337,7 @@ DOCUMENTATION
       docfooter="epfl"
       docsourceurl="${scaladoc.url}€{FILE_PATH}.scala#L1"
       docUncompilable="${src.dir}/library-aux"
-      skipPackages="scala.reflect.macros.internal:scala.reflect.internal:scala.reflect.runtime:scala.reflect.io"
+      skipPackages="scala.reflect.macros.internal:scala.reflect.internal:scala.reflect.io"
       sourcepath="${src.dir}"
       classpathref="pack.classpath"
       addparams="${scalac.args.all}"

--- a/src/compiler/scala/reflect/macros/runtime/Parsers.scala
+++ b/src/compiler/scala/reflect/macros/runtime/Parsers.scala
@@ -19,6 +19,6 @@ trait Parsers {
     } catch {
       case ToolBoxError(msg, cause) =>
         // todo. provide a position
-        throw new ParseError(universe.NoPosition, msg)
+        throw new ParseException(universe.NoPosition, msg)
     }
 }

--- a/src/compiler/scala/reflect/macros/runtime/Typers.scala
+++ b/src/compiler/scala/reflect/macros/runtime/Typers.scala
@@ -25,7 +25,7 @@ trait Typers {
         result
       case error @ universe.analyzer.SilentTypeError(_) =>
         macroLogVerbose(error.err.errMsg)
-        if (!silent) throw new universe.TypeError(error.err.errPos, error.err.errMsg)
+        if (!silent) throw new TypecheckException(error.err.errPos, error.err.errMsg)
         universe.EmptyTree
     })
   }
@@ -49,17 +49,11 @@ trait Typers {
     wrapper(universe.analyzer.inferImplicit(tree, pt, reportAmbiguous = true, isView = isView, context = context, saveAmbiguousDivergent = !silent, pos = pos)) match {
       case failure if failure.tree.isEmpty =>
         macroLogVerbose("implicit search has failed. to find out the reason, turn on -Xlog-implicits")
-        if (context.hasErrors) throw new universe.TypeError(context.errBuffer.head.errPos, context.errBuffer.head.errMsg)
+        if (context.hasErrors) throw new TypecheckException(context.errBuffer.head.errPos, context.errBuffer.head.errMsg)
         universe.EmptyTree
       case success =>
         success.tree
     }
-  }
-
-  type TypeError = universe.TypeError
-
-  object TypeError extends TypeErrorExtractor {
-    def unapply(error: TypeError): Option[(Position, String)] = Some((error.pos, error.msg))
   }
 
   def resetAllAttrs(tree: Tree): Tree = universe.resetAllAttrs(tree)

--- a/src/compiler/scala/reflect/reify/Errors.scala
+++ b/src/compiler/scala/reflect/reify/Errors.scala
@@ -1,7 +1,7 @@
 package scala.reflect.reify
 
-import scala.reflect.macros.ReificationError
-import scala.reflect.macros.UnexpectedReificationError
+import scala.reflect.macros.ReificationException
+import scala.reflect.macros.UnexpectedReificationException
 
 trait Errors {
   self: Reifier =>
@@ -19,17 +19,17 @@ trait Errors {
 
   def CannotReifyType(tpe: Type) = {
     val msg = "implementation restriction: cannot reify type %s (%s)".format(tpe, tpe.kind)
-    throw new ReificationError(defaultErrorPosition, msg)
+    throw new ReificationException(defaultErrorPosition, msg)
   }
 
   def CannotReifySymbol(sym: Symbol) = {
     val msg = "implementation restriction: cannot reify symbol %s (%s)".format(sym, sym.accurateKindString)
-    throw new ReificationError(defaultErrorPosition, msg)
+    throw new ReificationException(defaultErrorPosition, msg)
   }
 
   def CannotReifyWeakType(details: Any) = {
     val msg = "cannot create a TypeTag" + details
-    throw new ReificationError(defaultErrorPosition, msg)
+    throw new ReificationException(defaultErrorPosition, msg)
   }
 
   def CannotConvertManifestToTagWithoutScalaReflect(tpe: Type, manifestInScope: Tree) = {
@@ -37,7 +37,7 @@ trait Errors {
       |to create a type tag here, it is necessary to interoperate with the manifest `$manifestInScope` in scope.
       |however manifest -> typetag conversion requires Scala reflection, which is not present on the classpath.
       |to proceed put scala-reflect.jar on your compilation classpath and recompile.""".trim.stripMargin
-    throw new ReificationError(defaultErrorPosition, msg)
+    throw new ReificationException(defaultErrorPosition, msg)
   }
 
   def CannotReifyRuntimeSplice(tree: Tree) = {
@@ -46,7 +46,7 @@ trait Errors {
       |cross-stage evaluations need to be invoked explicitly, so we're showing you this error.
       |if you're sure this is not an oversight, add scala-compiler.jar to the classpath,
       |import `scala.tools.reflect.Eval` and call `<your expr>.eval` instead.""".trim.stripMargin
-    throw new ReificationError(tree.pos, msg)
+    throw new ReificationException(tree.pos, msg)
   }
 
   // unexpected errors: these can never happen under normal conditions unless there's a bug in the compiler (or in a compiler plugin or in a macro)
@@ -54,21 +54,21 @@ trait Errors {
 
   def CannotReifyUntypedPrefix(prefix: Tree) = {
     val msg = "internal error: untyped prefixes are not supported, consider typechecking the prefix before passing it to the reifier"
-    throw new UnexpectedReificationError(defaultErrorPosition, msg)
+    throw new UnexpectedReificationException(defaultErrorPosition, msg)
   }
 
   def CannotReifyUntypedReifee(reifee: Any) = {
     val msg = "internal error: untyped trees are not supported, consider typechecking the reifee before passing it to the reifier"
-    throw new UnexpectedReificationError(defaultErrorPosition, msg)
+    throw new UnexpectedReificationException(defaultErrorPosition, msg)
   }
 
   def CannotReifyErroneousPrefix(prefix: Tree) = {
     val msg = "internal error: erroneous prefixes are not supported, make sure that your prefix has typechecked successfully before passing it to the reifier"
-    throw new UnexpectedReificationError(defaultErrorPosition, msg)
+    throw new UnexpectedReificationException(defaultErrorPosition, msg)
   }
 
   def CannotReifyErroneousReifee(reifee: Any) = {
     val msg = "internal error: erroneous reifees are not supported, make sure that your reifee has typechecked successfully before passing it to the reifier"
-    throw new UnexpectedReificationError(defaultErrorPosition, msg)
+    throw new UnexpectedReificationException(defaultErrorPosition, msg)
   }
 }

--- a/src/compiler/scala/reflect/reify/Reifier.scala
+++ b/src/compiler/scala/reflect/reify/Reifier.scala
@@ -1,8 +1,8 @@
 package scala.reflect.reify
 
 import scala.tools.nsc.Global
-import scala.reflect.macros.ReificationError
-import scala.reflect.macros.UnexpectedReificationError
+import scala.reflect.macros.ReificationException
+import scala.reflect.macros.UnexpectedReificationException
 import scala.reflect.reify.utils.Utils
 
 /** Given a tree or a type, generate a tree that when executed at runtime produces the original tree or type.
@@ -132,12 +132,12 @@ abstract class Reifier extends States
 
       untyped
     } catch {
-      case ex: ReificationError =>
+      case ex: ReificationException =>
         throw ex
-      case ex: UnexpectedReificationError =>
+      case ex: UnexpectedReificationException =>
         throw ex
       case ex: Throwable =>
-        throw new UnexpectedReificationError(defaultErrorPosition, "reification crashed", ex)
+        throw new UnexpectedReificationException(defaultErrorPosition, "reification crashed", ex)
     }
   }
 }

--- a/src/compiler/scala/reflect/reify/Taggers.scala
+++ b/src/compiler/scala/reflect/reify/Taggers.scala
@@ -1,6 +1,6 @@
 package scala.reflect.reify
 
-import scala.reflect.macros.{ReificationError, UnexpectedReificationError}
+import scala.reflect.macros.{ReificationError, UnexpectedReificationError, TypecheckException}
 import scala.reflect.macros.runtime.Context
 
 abstract class Taggers {
@@ -65,13 +65,13 @@ abstract class Taggers {
           translatingReificationErrors(materializer)
       }
     try c.typeCheck(result)
-    catch { case terr @ c.TypeError(pos, msg) => failTag(result, terr) }
+    catch { case terr @ TypecheckException(pos, msg) => failTag(result, terr) }
   }
 
   def materializeExpr(universe: Tree, mirror: Tree, expr: Tree): Tree = {
     val result = translatingReificationErrors(c.reifyTree(universe, mirror, expr))
     try c.typeCheck(result)
-    catch { case terr @ c.TypeError(pos, msg) => failExpr(result, terr) }
+    catch { case terr @ TypecheckException(pos, msg) => failExpr(result, terr) }
   }
 
   private def translatingReificationErrors(materializer: => Tree): Tree = {

--- a/src/compiler/scala/reflect/reify/Taggers.scala
+++ b/src/compiler/scala/reflect/reify/Taggers.scala
@@ -1,6 +1,6 @@
 package scala.reflect.reify
 
-import scala.reflect.macros.{ReificationError, UnexpectedReificationError, TypecheckException}
+import scala.reflect.macros.{ReificationException, UnexpectedReificationException, TypecheckException}
 import scala.reflect.macros.runtime.Context
 
 abstract class Taggers {
@@ -77,10 +77,10 @@ abstract class Taggers {
   private def translatingReificationErrors(materializer: => Tree): Tree = {
     try materializer
     catch {
-      case ReificationError(pos, msg) =>
+      case ReificationException(pos, msg) =>
         c.error(pos.asInstanceOf[c.Position], msg) // this cast is a very small price for the sanity of exception handling
         EmptyTree
-      case UnexpectedReificationError(pos, err, cause) if cause != null =>
+      case UnexpectedReificationException(pos, err, cause) if cause != null =>
         throw cause
     }
   }

--- a/src/compiler/scala/reflect/reify/package.scala
+++ b/src/compiler/scala/reflect/reify/package.scala
@@ -1,7 +1,7 @@
 package scala.reflect
 
 import scala.language.implicitConversions
-import scala.reflect.macros.{Context, ReificationError, UnexpectedReificationError}
+import scala.reflect.macros.{Context, ReificationException, UnexpectedReificationException}
 import scala.tools.nsc.Global
 
 package object reify {
@@ -53,7 +53,7 @@ package object reify {
     if (tpe.isSpliceable) {
       val classTagInScope = typer0.resolveClassTag(enclosingMacroPosition, tpe, allowMaterialization = false)
       if (!classTagInScope.isEmpty) return Select(classTagInScope, nme.runtimeClass)
-      if (concrete) throw new ReificationError(enclosingMacroPosition, "tpe %s is an unresolved spliceable type".format(tpe))
+      if (concrete) throw new ReificationException(enclosingMacroPosition, "tpe %s is an unresolved spliceable type".format(tpe))
     }
 
     tpe.normalize match {

--- a/src/compiler/scala/reflect/reify/utils/SymbolTables.scala
+++ b/src/compiler/scala/reflect/reify/utils/SymbolTables.scala
@@ -28,7 +28,7 @@ trait SymbolTables {
       symtab.get(sym) match {
         case Some(FreeDef(_, name, _, _, _)) => name
         case Some(SymDef(_, name, _, _)) => name
-        case None => EmptyTermName
+        case None => nme.EMPTY
       }
 
     def symAliases(sym: Symbol): List[TermName] =

--- a/src/compiler/scala/tools/reflect/MacroImplementations.scala
+++ b/src/compiler/scala/tools/reflect/MacroImplementations.scala
@@ -1,6 +1,6 @@
 package scala.tools.reflect
 
-import scala.reflect.macros.{ReificationError, UnexpectedReificationError}
+import scala.reflect.macros.{ReificationException, UnexpectedReificationException}
 import scala.reflect.macros.runtime.Context
 import scala.collection.mutable.ListBuffer
 import scala.collection.mutable.Stack

--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -195,7 +195,7 @@ class PathResolver(settings: Settings, context: JavaContext) {
     def scalaExtDirs        = cmdLineOrElse("extdirs", Defaults.scalaExtDirs)
     /** Scaladoc doesn't need any bootstrapping, otherwise will create errors such as:
      * [scaladoc] ../scala-trunk/src/reflect/scala/reflect/macros/Reifiers.scala:89: error: object api is not a member of package reflect
-     * [scaladoc] case class ReificationError(val pos: reflect.api.PositionApi, val msg: String) extends Throwable(msg)
+     * [scaladoc] case class ReificationException(val pos: reflect.api.PositionApi, val msg: String) extends Throwable(msg)
      * [scaladoc]                                              ^
      * because the bootstrapping will look at the sourcepath and create package "reflect" in "<root>"
      * and then when typing relative names, instead of picking <root>.scala.relect, typedIdentifier will pick up the

--- a/src/reflect/scala/reflect/api/Constants.scala
+++ b/src/reflect/scala/reflect/api/Constants.scala
@@ -37,17 +37,5 @@ trait Constants {
   abstract class ConstantApi {
     val value: Any
     def tpe: Type
-
-    def booleanValue: Boolean
-    def byteValue: Byte
-    def shortValue: Short
-    def charValue: Char
-    def intValue: Int
-    def longValue: Long
-    def floatValue: Float
-    def doubleValue: Double
-    def stringValue: String
-    def typeValue: Type
-    def symbolValue: Symbol
   }
 }

--- a/src/reflect/scala/reflect/api/Constants.scala
+++ b/src/reflect/scala/reflect/api/Constants.scala
@@ -37,7 +37,6 @@ trait Constants {
   abstract class ConstantApi {
     val value: Any
     def tpe: Type
-    def isNaN: Boolean
 
     def booleanValue: Boolean
     def byteValue: Byte
@@ -50,7 +49,5 @@ trait Constants {
     def stringValue: String
     def typeValue: Type
     def symbolValue: Symbol
-
-    def convertTo(pt: Type): Constant
   }
 }

--- a/src/reflect/scala/reflect/api/FlagSets.scala
+++ b/src/reflect/scala/reflect/api/FlagSets.scala
@@ -21,14 +21,12 @@ trait FlagSets { self: Universe =>
 
   val Flag: FlagValues
 
-  type FlagValues >: Null <: FlagValuesApi
-
   // Q: I have a pretty flag. Can I put it here?
   // A: Only if there's a tree that cannot be built without it.
   //    If you want to put a flag here so that it can be tested against,
   //    introduce an `isXXX` method in one of the `api.Symbols` classes instead.
 
-  trait FlagValuesApi {
+  trait FlagValues {
 
     /** Flag indicating that tree represents a trait */
     val TRAIT: FlagSet

--- a/src/reflect/scala/reflect/api/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/api/JavaMirrors.scala
@@ -1,0 +1,16 @@
+package scala.reflect
+package api
+
+trait JavaMirrors { self: JavaUniverse =>
+
+  type RuntimeClass = java.lang.Class[_]
+
+  override type Mirror >: Null <: JavaMirror
+
+  trait JavaMirror extends scala.reflect.api.Mirror[self.type] with RuntimeMirror {
+    val classLoader: ClassLoader
+    override def toString = s"JavaMirror with ${runtime.ReflectionUtils.show(classLoader)}"
+  }
+
+  def runtimeMirror(cl: ClassLoader): Mirror
+}

--- a/src/reflect/scala/reflect/api/JavaUniverse.scala
+++ b/src/reflect/scala/reflect/api/JavaUniverse.scala
@@ -1,18 +1,7 @@
 package scala.reflect
 package api
 
-trait JavaUniverse extends Universe with Mirrors { self =>
-
-  type RuntimeClass = java.lang.Class[_]
-
-  override type Mirror >: Null <: JavaMirror
-
-  trait JavaMirror extends scala.reflect.api.Mirror[self.type] with RuntimeMirror {
-    val classLoader: ClassLoader
-    override def toString = s"JavaMirror with ${runtime.ReflectionUtils.show(classLoader)}"
-  }
-
-  def runtimeMirror(cl: ClassLoader): Mirror
+trait JavaUniverse extends Universe with JavaMirrors { self =>
 
   override def typeTagToManifest[T: ClassTag](mirror0: Any, tag: Universe # TypeTag[T]): Manifest[T] = {
     // SI-6239: make this conversion more precise

--- a/src/reflect/scala/reflect/api/Mirrors.scala
+++ b/src/reflect/scala/reflect/api/Mirrors.scala
@@ -166,9 +166,6 @@ trait Mirrors { self: Universe =>
   /** A mirror that reflects the instance or static parts of a runtime class */
   trait TemplateMirror {
 
-    /** The runtime class reflected by this mirror */
-    def runtimeClass: RuntimeClass
-
     /** True if the mirror represents the static part
      *  of a runtime class or the companion object of a Scala class.
      *  One has:
@@ -180,18 +177,6 @@ trait Mirrors { self: Universe =>
 
     /** The Scala symbol corresponding to the reflected runtime class or object */
     def symbol: Symbol
-
-    /** Optionally, the mirror of the companion reflected by this mirror.
-     *  If this mirror reflects a Scala object, the mirror for the companion class, or None
-     *  if the mirror represents a Scala object that comes without a class.
-     *  Otherwise, if the mirror represents the static part of a runtime class, the
-     *  mirror representing the instance part of the same class.
-     *  Otherwise, if the mirror represents a Scala instance class, the mirror for the companion
-     *  object of that class, or None if no such object exists.
-     *  Otherwise, if the mirror represents a runtime instance class, a mirror representing the static
-     *  part of the same class.
-     */
-    def companion: Option[TemplateMirror]
   }
 
   /** A mirror that reflects a Scala object definition or the static parts of a runtime class */
@@ -205,14 +190,6 @@ trait Mirrors { self: Universe =>
      *  If this mirror reflects the static part of a runtime class, returns `null`.
      */
     def instance: Any
-
-    /** Optionally, the mirror of the companion class if the object reflected by this mirror.
-     *  If this mirror reflects a Scala object, the mirror for the companion class, or None
-     *  if the mirror represents a Scala object that comes without a class.
-     *  Otherwise, if the mirror represents the static part of a runtime class, the
-     *  mirror representing the instance part of the same class.
-     */
-    override def companion: Option[ClassMirror]
   }
 
   /** A mirror that reflects the instance parts of a runtime class */
@@ -232,14 +209,6 @@ trait Mirrors { self: Universe =>
      *  It must be a member (declared or inherited) of the class underlying this mirror.
      */
     def reflectConstructor(constructor: MethodSymbol): MethodMirror
-
-    /** Optionally, the mirror of the companion object of the class reflected by this mirror.
-     *  If this mirror represents a Scala instance class, the mirror for the companion
-     *  object of that class, or None if no such object exists.
-     *  Otherwise, if the mirror represents a runtime instance class, a mirror representing the static
-     *  part of the same class.
-     */
-    override def companion: Option[ModuleMirror]
   }
 
   /** A mirror that reflects instances and static classes */

--- a/src/reflect/scala/reflect/api/Names.scala
+++ b/src/reflect/scala/reflect/api/Names.scala
@@ -75,12 +75,4 @@ trait Names {
   /** Creates a new type name.
    */
   def newTypeName(s: String): TypeName
-
-  /** Wraps the empty string. Can be used as the null object for term name.
-   */
-  def EmptyTermName: TermName = newTermName("")
-
-  /** Wraps the empty string. Can be used as the null object for type name.
-   */
-  def EmptyTypeName: TypeName = EmptyTermName.toTypeName
 }

--- a/src/reflect/scala/reflect/api/Position.scala
+++ b/src/reflect/scala/reflect/api/Position.scala
@@ -1,6 +1,8 @@
 package scala.reflect
 package api
 
+import scala.reflect.macros.Attachments
+
 /** The Position class and its subclasses represent positions of ASTs and symbols.
  *  Except for NoPosition and FakePos, every position refers to a SourceFile
  *  and to an offset in the sourcefile (its `point`). For batch compilation,

--- a/src/reflect/scala/reflect/api/Printers.scala
+++ b/src/reflect/scala/reflect/api/Printers.scala
@@ -5,7 +5,7 @@ import java.io.{ PrintWriter, StringWriter }
 
 trait Printers { self: Universe =>
 
-  trait TreePrinter {
+  protected trait TreePrinter {
     def print(args: Any*)
     protected var printTypes = false
     protected var printIds = false
@@ -52,7 +52,7 @@ trait Printers { self: Universe =>
 
   /** Hook to define what `show(...)` means.
    */
-  def newTreePrinter(out: PrintWriter): TreePrinter
+  protected def newTreePrinter(out: PrintWriter): TreePrinter
 
   /** Renders internal structure of a reflection artifact.
    */
@@ -61,7 +61,7 @@ trait Printers { self: Universe =>
 
   /** Hook to define what `showRaw(...)` means.
    */
-  def newRawTreePrinter(out: PrintWriter): TreePrinter
+  protected def newRawTreePrinter(out: PrintWriter): TreePrinter
 
   /** Renders a prettified representation of a name.
    */

--- a/src/reflect/scala/reflect/api/Scopes.scala
+++ b/src/reflect/scala/reflect/api/Scopes.scala
@@ -21,6 +21,9 @@ trait Scopes { self: Universe =>
    */
   implicit val ScopeTag: ClassTag[Scope]
 
+  /** Create a new scope with the given initial elements. */
+  def newScopeWith(elems: Symbol*): Scope
+
   /** The type of member scopes, as in class definitions, for example. */
   type MemberScope >: Null <: Scope with MemberScopeApi
 
@@ -28,7 +31,7 @@ trait Scopes { self: Universe =>
   trait MemberScopeApi extends ScopeApi {
     /** Sorts the symbols included in this scope so that:
      *    1) Symbols appear in the linearization order of their owners.
-     *    2) Symbols with the same owner appear in reverse order of their declarations.
+     *    2) Symbols with the same owner appear in same order of their declarations.
      *    3) Synthetic members (e.g. getters/setters for vals/vars) might appear in arbitrary order.
      */
     def sorted: List[Symbol]
@@ -38,13 +41,4 @@ trait Scopes { self: Universe =>
    *  Can be used for pattern matching, instance tests, serialization and likes.
    */
   implicit val MemberScopeTag: ClassTag[MemberScope]
-
-  /** Create a new scope. */
-  def newScope: Scope
-
-  /** Create a new scope nested in another one with which it shares its elements. */
-  def newNestedScope(outer: Scope): Scope
-
-  /** Create a new scope with the given initial elements. */
-  def newScopeWith(elems: Symbol*): Scope
 }

--- a/src/reflect/scala/reflect/api/StandardDefinitions.scala
+++ b/src/reflect/scala/reflect/api/StandardDefinitions.scala
@@ -67,12 +67,7 @@ trait StandardDefinitions {
     def Array_length: TermSymbol // todo. fix the bug in Definitions.getMemberMethod
     def Array_update: TermSymbol // todo. fix the bug in Definitions.getMemberMethod
     def ByNameParamClass: ClassSymbol
-    def ConsClass: ClassSymbol
     def FunctionClass : Array[ClassSymbol]
-    def IterableClass: ClassSymbol
-    def IteratorClass: ClassSymbol
-    def IteratorModule: ModuleSymbol
-    def Iterator_apply: TermSymbol // todo. fix the bug in Definitions.getMemberMethod
     def JavaRepeatedParamClass: ClassSymbol
     def ListModule: ModuleSymbol
     def List_apply: TermSymbol // todo. fix the bug in Definitions.getMemberMethod
@@ -81,13 +76,7 @@ trait StandardDefinitions {
     def OptionClass: ClassSymbol
     def ProductClass  : Array[ClassSymbol]
     def RepeatedParamClass: ClassSymbol
-    def SeqClass: ClassSymbol
-    def SeqModule: ModuleSymbol
-    def SomeClass: ClassSymbol
     def SomeModule: ModuleSymbol
-    def StringBuilderClass: ClassSymbol
-    def SymbolClass : ClassSymbol
-    def TraversableClass: ClassSymbol
     def TupleClass: Array[Symbol] // cannot make it Array[ClassSymbol], because TupleClass(0) is supposed to be NoSymbol. weird
     def ScalaPrimitiveValueClasses: List[ClassSymbol]
     def ScalaNumericValueClasses: List[ClassSymbol]

--- a/src/reflect/scala/reflect/api/StandardNames.scala
+++ b/src/reflect/scala/reflect/api/StandardNames.scala
@@ -23,7 +23,6 @@ trait StandardNames {
   trait NamesApi {
     type NameType >: Null <: Name
     val WILDCARD: NameType
-    val ROOT: NameType
     val EMPTY: NameType
     val ERROR: NameType
     val PACKAGE: NameType
@@ -38,7 +37,6 @@ trait StandardNames {
 
   trait TypeNamesApi extends NamesApi {
     type NameType = TypeName
-    val EMPTY: NameType
     val WILDCARD_STAR: NameType
   }
 }

--- a/src/reflect/scala/reflect/api/Trees.scala
+++ b/src/reflect/scala/reflect/api/Trees.scala
@@ -1967,12 +1967,12 @@ trait Trees { self: Universe =>
   val Modifiers: ModifiersCreator
 
   abstract class ModifiersCreator {
-    def apply(): Modifiers = Modifiers(NoFlags, EmptyTypeName, List())
+    def apply(): Modifiers = Modifiers(NoFlags, tpnme.EMPTY, List())
     def apply(flags: FlagSet, privateWithin: Name, annotations: List[Tree]): Modifiers
   }
 
   def Modifiers(flags: FlagSet, privateWithin: Name): Modifiers = Modifiers(flags, privateWithin, List())
-  def Modifiers(flags: FlagSet): Modifiers = Modifiers(flags, EmptyTypeName)
+  def Modifiers(flags: FlagSet): Modifiers = Modifiers(flags, tpnme.EMPTY)
 
   /** ... */
   lazy val NoMods = Modifiers()

--- a/src/reflect/scala/reflect/api/Trees.scala
+++ b/src/reflect/scala/reflect/api/Trees.scala
@@ -99,9 +99,6 @@ trait Trees { self: Universe =>
      */
     def symbol: Symbol
 
-    /** ... */
-    def hasSymbol: Boolean
-
     /** Provides an alternate if tree is empty
      *  @param  alt  The alternate tree
      *  @return If this tree is non empty, this tree, otherwise `alt`.

--- a/src/reflect/scala/reflect/internal/FlagSets.scala
+++ b/src/reflect/scala/reflect/internal/FlagSets.scala
@@ -17,8 +17,6 @@ trait FlagSets extends api.FlagSets { self: SymbolTable =>
 
   val NoFlags: FlagSet = 0L
 
-  trait FlagValues extends FlagValuesApi
-
   object Flag extends FlagValues {
     val TRAIT         : FlagSet = Flags.TRAIT
     val INTERFACE     : FlagSet = Flags.INTERFACE

--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -534,17 +534,16 @@ trait Printers extends api.Printers { self: SymbolTable =>
 
       depth += 1
       args foreach {
+        case expr: Expr[_] =>
+          print("Expr")
+          if (printTypes) print(expr.staticType)
+          print("(")
+          print(expr.tree)
+          print(")")
         case EmptyTree =>
           print("EmptyTree")
         case emptyValDef: AnyRef if emptyValDef eq self.emptyValDef =>
           print("emptyValDef")
-        case Literal(Constant(value)) =>
-          def print(s: String) = this.print("Literal(Constant(" + s + "))")
-          value match {
-            case s: String => print("\"" + s + "\"")
-            case null => print(null)
-            case _ => print(value.toString)
-          }
         case tree: Tree =>
           val hasSymbol = tree.hasSymbol && tree.symbol != NoSymbol
           val isError = hasSymbol && tree.symbol.name.toString == nme.ERROR.toString
@@ -568,6 +567,12 @@ trait Printers extends api.Printers { self: SymbolTable =>
                 } else {
                   print(name)
                 }
+              case Constant(s: String) =>
+                print("Constant(\"" + s + "\")")
+              case Constant(null) =>
+                print("Constant(null)")
+              case Constant(value) =>
+                print("Constant(" + value + ")")
               case arg =>
                 print(arg)
             },
@@ -582,14 +587,18 @@ trait Printers extends api.Printers { self: SymbolTable =>
           if (printIds) print("#", sym.id)
           if (printKinds) print("#", sym.abbreviatedKindString)
           if (printMirrors) print("%M", footnotes.put[scala.reflect.api.Mirror[_]](mirrorThatLoaded(sym)))
-        case NoType =>
-          print("NoType")
-        case NoPrefix =>
-          print("NoPrefix")
+        case tag: TypeTag[_] =>
+          print("TypeTag(", tag.tpe, ")")
+        case tag: WeakTypeTag[_] =>
+          print("WeakTypeTag(", tag.tpe, ")")
         case tpe: Type =>
           val defer = printTypesInFootnotes && !printingFootnotes
           if (defer) print("[", footnotes.put(tpe), "]")
-          else printProduct(tpe.asInstanceOf[Product])
+          else tpe match {
+            case NoType => print("NoType")
+            case NoPrefix => print("NoPrefix")
+            case _ => printProduct(tpe.asInstanceOf[Product])
+          }
         case mods: Modifiers =>
           print("Modifiers(")
           if (mods.flags != NoFlags || mods.privateWithin != tpnme.EMPTY || mods.annotations.nonEmpty) print(show(mods.flags))
@@ -598,6 +607,9 @@ trait Printers extends api.Printers { self: SymbolTable =>
           print(")")
         case name: Name =>
           print(show(name))
+        case scope: Scope =>
+          print("Scope")
+          printIterable(scope.toList)
         case list: List[_] =>
           print("List")
           printIterable(list)
@@ -645,16 +657,15 @@ trait Printers extends api.Printers { self: SymbolTable =>
   }
 
   def show(name: Name): String = name match {
-    case tpnme.EMPTY => "tpnme.EMPTY"
-    case tpnme.ROOT => "tpnme.ROOT"
-    case tpnme.PACKAGE => "tpnme.PACKAGE"
-    case tpnme.EMPTY_PACKAGE_NAME => "tpnme.EMPTY_PACKAGE_NAME"
     case tpnme.WILDCARD => "tpnme.WILDCARD"
-    case nme.EMPTY => "nme.EMPTY"
-    case nme.ROOT => "nme.ROOT"
-    case nme.PACKAGE => "nme.PACKAGE"
-    case nme.EMPTY_PACKAGE_NAME => "nme.EMPTY_PACKAGE_NAME"
+    case tpnme.EMPTY => "tpnme.EMPTY"
+    case tpnme.ERROR => "tpnme.ERROR"
+    case tpnme.PACKAGE => "tpnme.PACKAGE"
+    case tpnme.WILDCARD_STAR => "tpnme.WILDCARD_STAR"
     case nme.WILDCARD => "nme.WILDCARD"
+    case nme.EMPTY => "nme.EMPTY"
+    case nme.ERROR => "tpnme.ERROR"
+    case nme.PACKAGE => "nme.PACKAGE"
     case nme.CONSTRUCTOR => "nme.CONSTRUCTOR"
     case nme.ROOTPKG => "nme.ROOTPKG"
     case _ =>

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -8,7 +8,7 @@ trait StdAttachments {
    * Common code between reflect-internal Symbol and Tree related to Attachments.
    */
   trait Attachable {
-    protected var rawatt: scala.reflect.api.Attachments { type Pos = Position } = NoPosition
+    protected var rawatt: scala.reflect.macros.Attachments { type Pos = Position } = NoPosition
     def attachments = rawatt
     def updateAttachment[T: ClassTag](attachment: T): this.type = { rawatt = rawatt.update(attachment); this }
     def removeAttachment[T: ClassTag]: this.type = { rawatt = rawatt.remove[T]; this }

--- a/src/reflect/scala/reflect/internal/util/Position.scala
+++ b/src/reflect/scala/reflect/internal/util/Position.scala
@@ -7,7 +7,7 @@
 package scala.reflect.internal.util
 
 import scala.reflect.ClassTag
-import scala.reflect.api.Attachments
+import scala.reflect.macros.Attachments
 
 object Position {
   val tabInc = 8

--- a/src/reflect/scala/reflect/macros/Attachments.scala
+++ b/src/reflect/scala/reflect/macros/Attachments.scala
@@ -1,12 +1,20 @@
 package scala.reflect
-package api
+package macros
 
-/** Attachments is a generalization of Position. Typically it stores a Position of a tree, but this can be extended to
+/** Attachments provide a way to associate custom metadata with symbols and trees.
+ *
+ *  Along with `symbol` and `tpe`, which represent core metadata of trees, each tree
+ *  carries the `attachments` field that can store other metadata: compiler-defined (e.g. positions) or user-defined.
+ *  Same story is true for symbols, which also have extensible metadata by the virtue
+ *  of the same `attachments` field.
+ *
+ *  Typically attachments just store a [[scala.reflect.api.Position]], but they can be extended to
  *  encompass arbitrary payloads. Payloads are stored in type-indexed slots, which can be read with `get[T]` and written
  *  with `update[T]` and `remove[T]`.
  *
- *  Attachments always carry positions because we don't want to introduce an additional field for attachments in `Tree`
- *  imposing an unnecessary memory tax because of something that will not be used in most cases.
+ *  This API doesn't have much use in the runtime reflection API (the [[scala.reflect.api]] package), but it might be of help
+ *  for macro writers, providing a way to coordinate multiple macros operating on the same code. Therefore the `attachments`
+ *  field is only declared in trees and symbols belonging to [[scala.reflect.macros.Universe]].
  */
 abstract class Attachments { self =>
 
@@ -30,8 +38,7 @@ abstract class Attachments { self =>
     (all filter matchesTag[T]).headOption.asInstanceOf[Option[T]]
 
   /** Creates a copy of this attachment with the payload slot of T added/updated with the provided value.
-   *
-   * Replaces an existing payload of the same type, if exists.
+   *  Replaces an existing payload of the same type, if exists.
    */
   def update[T: ClassTag](attachment: T): Attachments { type Pos = self.Pos } =
     new NonemptyAttachments(this.pos, remove[T].all + attachment)

--- a/src/reflect/scala/reflect/macros/Parsers.scala
+++ b/src/reflect/scala/reflect/macros/Parsers.scala
@@ -10,5 +10,6 @@ trait Parsers {
   def parse(code: String): Tree
 }
 
-// should be path-dependent, otherwise exception handling becomes a mess
-case class ParseError(val pos: scala.reflect.api.Position, val msg: String) extends Throwable(msg)
+/** Indicates an error during [[scala.reflect.macros.Parsers#Parse]].
+ */
+case class ParseException(val pos: scala.reflect.api.Position, val msg: String) extends Exception(msg)

--- a/src/reflect/scala/reflect/macros/Reifiers.scala
+++ b/src/reflect/scala/reflect/macros/Reifiers.scala
@@ -76,6 +76,14 @@ trait Reifiers {
 
 // made these guys non path-dependent, otherwise exception handling quickly becomes a mess
 
-case class ReificationError(val pos: scala.reflect.api.Position, val msg: String) extends Throwable(msg)
+/** Indicates an expected error during one of the `reifyXXX` methods in [[scala.reflect.macros.Reifiers]].
+ *  Such errors represent one of the standard ways for reification to go wrong, e.g.
+ *  an attempt to create a `TypeTag` from a weak type.
+ */
+case class ReificationException(val pos: scala.reflect.api.Position, val msg: String) extends Exception(msg)
 
-case class UnexpectedReificationError(val pos: scala.reflect.api.Position, val msg: String, val cause: Throwable = null) extends Throwable(msg, cause)
+/** Indicates an unexpected expected error during one of the `reifyXXX` methods in [[scala.reflect.macros.Reifiers]].
+ *  Such errors wrap random crashes in reification logic and are distinguished from expected [[scala.reflect.macros.ReificationException]]s
+ *  so that the latter can be reported as compilation errors, while the former manifest themselves as compiler crashes.
+ */
+case class UnexpectedReificationException(val pos: scala.reflect.api.Position, val msg: String, val cause: Throwable = null) extends Exception(msg, cause)

--- a/src/reflect/scala/reflect/macros/Typers.scala
+++ b/src/reflect/scala/reflect/macros/Typers.scala
@@ -24,11 +24,11 @@ trait Typers {
    *  Unlike `enclosingImplicits`, this is a def, which means that it gets recalculated on every invocation,
    *  so it might change depending on what is going on during macro expansion.
    */
- def openImplicits: List[(Type, Tree)]
+  def openImplicits: List[(Type, Tree)]
 
   /** Typechecks the provided tree against the expected type `pt` in the macro callsite context.
    *
-   *  If `silent` is false, `TypeError` will be thrown in case of a typecheck error.
+   *  If `silent` is false, `TypecheckException` will be thrown in case of a typecheck error.
    *  If `silent` is true, the typecheck is silent and will return `EmptyTree` if an error occurs.
    *  Such errors don't vanish and can be inspected by turning on -Ymacro-debug-verbose.
    *  Unlike in `inferImplicitValue` and `inferImplicitView`, `silent` is false by default.
@@ -36,26 +36,32 @@ trait Typers {
    *  Typechecking can be steered with the following optional parameters:
    *    `withImplicitViewsDisabled` recursively prohibits implicit views (though, implicit vals will still be looked up and filled in), default value is false
    *    `withMacrosDisabled` recursively prohibits macro expansions and macro-based implicits, default value is false
+   *
+   *  @throws [[scala.reflect.macros.TypecheckException]]
    */
   def typeCheck(tree: Tree, pt: Type = WildcardType, silent: Boolean = false, withImplicitViewsDisabled: Boolean = false, withMacrosDisabled: Boolean = false): Tree
 
   /** Infers an implicit value of the expected type `pt` in the macro callsite context.
    *  Optional `pos` parameter provides a position that will be associated with the implicit search.
    *
-   *  If `silent` is false, `TypeError` will be thrown in case of an inference error.
+   *  If `silent` is false, `TypecheckException` will be thrown in case of an inference error.
    *  If `silent` is true, the typecheck is silent and will return `EmptyTree` if an error occurs.
    *  Such errors don't vanish and can be inspected by turning on -Xlog-implicits.
    *  Unlike in `typeCheck`, `silent` is true by default.
+   *
+   *  @throws [[scala.reflect.macros.TypecheckException]]
    */
   def inferImplicitValue(pt: Type, silent: Boolean = true, withMacrosDisabled: Boolean = false, pos: Position = enclosingPosition): Tree
 
   /** Infers an implicit view from the provided tree `tree` of the type `from` to the type `to` in the macro callsite context.
    *  Optional `pos` parameter provides a position that will be associated with the implicit search.
    *
-   *  If `silent` is false, `TypeError` will be thrown in case of an inference error.
+   *  If `silent` is false, `TypecheckException` will be thrown in case of an inference error.
    *  If `silent` is true, the typecheck is silent and will return `EmptyTree` if an error occurs.
    *  Such errors don't vanish and can be inspected by turning on -Xlog-implicits.
    *  Unlike in `typeCheck`, `silent` is true by default.
+   *
+   *  @throws [[scala.reflect.macros.TypecheckException]]
    */
   def inferImplicitView(tree: Tree, from: Type, to: Type, silent: Boolean = true, withMacrosDisabled: Boolean = false, pos: Position = enclosingPosition): Tree
 
@@ -72,12 +78,8 @@ trait Typers {
    *  For more info, read up https://issues.scala-lang.org/browse/SI-5464.
    */
   def resetLocalAttrs(tree: Tree): Tree
-
-  /** Represents an error during typechecking
-   */
-  type TypeError <: Throwable
-  val TypeError: TypeErrorExtractor
-  abstract class TypeErrorExtractor {
-    def unapply(error: TypeError): Option[(Position, String)]
-  }
 }
+
+/** Indicates an error during one of the methods in [[scala.reflect.macros.Typers]].
+ */
+case class TypecheckException(val pos: scala.reflect.api.Position, val msg: String) extends Exception(msg)

--- a/src/reflect/scala/reflect/macros/Universe.scala
+++ b/src/reflect/scala/reflect/macros/Universe.scala
@@ -7,7 +7,7 @@ abstract class Universe extends scala.reflect.api.Universe {
 
   trait AttachableApi {
     /** ... */
-    def attachments: scala.reflect.api.Attachments { type Pos = Position }
+    def attachments: Attachments { type Pos = Position }
 
     /** ... */
     def updateAttachment[T: ClassTag](attachment: T): AttachableApi.this.type

--- a/src/reflect/scala/reflect/macros/package.scala
+++ b/src/reflect/scala/reflect/macros/package.scala
@@ -1,0 +1,4 @@
+package scala.reflect
+
+package object macros {
+}

--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -24,7 +24,7 @@ import scala.language.existentials
 import scala.runtime.{ScalaRunTime, BoxesRunTime}
 import scala.reflect.internal.util.Collections._
 
-trait JavaMirrors extends internal.SymbolTable with api.JavaUniverse { thisUniverse: SymbolTable =>
+private[reflect] trait JavaMirrors extends internal.SymbolTable with api.JavaUniverse { thisUniverse: SymbolTable =>
 
   private lazy val mirrors = new WeakHashMap[ClassLoader, WeakReference[JavaMirror]]()
 
@@ -1279,6 +1279,6 @@ trait JavaMirrors extends internal.SymbolTable with api.JavaUniverse { thisUnive
   }
 }
 
-class ReflectError(msg: String) extends java.lang.Error(msg)
+private[reflect] class ReflectError(msg: String) extends java.lang.Error(msg)
 
-class HasJavaClass[J](val getClazz: J => java.lang.Class[_])
+private[reflect] class HasJavaClass[J](val getClazz: J => java.lang.Class[_])

--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -446,8 +446,7 @@ private[reflect] trait JavaMirrors extends internal.SymbolTable with api.JavaUni
             extends TemplateMirror {
       def outer: AnyRef
       def erasure: ClassSymbol
-      lazy val runtimeClass = classToJava(erasure)
-      lazy val signature = typeToScala(runtimeClass)
+      lazy val signature = typeToScala(classToJava(erasure))
     }
 
     private class JavaClassMirror(val outer: AnyRef, val symbol: ClassSymbol)
@@ -457,10 +456,6 @@ private[reflect] trait JavaMirrors extends internal.SymbolTable with api.JavaUni
       def reflectConstructor(constructor: MethodSymbol) = {
         checkConstructorOf(constructor, symbol)
         new JavaConstructorMirror(outer, constructor)
-      }
-      def companion: Option[ModuleMirror] = symbol.companionModule match {
-       case module: ModuleSymbol => Some(new JavaModuleMirror(outer, module))
-       case _ => None
       }
       override def toString = s"class mirror for ${symbol.fullName} (bound to $outer)"
     }
@@ -475,10 +470,6 @@ private[reflect] trait JavaMirrors extends internal.SymbolTable with api.JavaUni
         else
           if (outer == null) staticSingletonInstance(classToJava(symbol.moduleClass.asClass))
           else innerSingletonInstance(outer, symbol.name)
-      }
-      def companion: Option[ClassMirror] = symbol.companionClass match {
-        case cls: ClassSymbol => Some(new JavaClassMirror(outer, cls))
-        case _ => None
       }
       override def toString = s"module mirror for ${symbol.fullName} (bound to $outer)"
     }

--- a/src/reflect/scala/reflect/runtime/ReflectionUtils.scala
+++ b/src/reflect/scala/reflect/runtime/ReflectionUtils.scala
@@ -10,7 +10,7 @@ import java.lang.reflect.{ Method, InvocationTargetException, UndeclaredThrowabl
 
 /** A few java-reflection oriented utility functions useful during reflection bootstrapping.
  */
-object ReflectionUtils {
+private[scala] object ReflectionUtils {
   // Unwraps some chained exceptions which arise during reflective calls.
   def unwrapThrowable(x: Throwable): Throwable = x match {
     case  _: InvocationTargetException |      // thrown by reflectively invoked method or constructor

--- a/src/reflect/scala/reflect/runtime/Settings.scala
+++ b/src/reflect/scala/reflect/runtime/Settings.scala
@@ -7,7 +7,7 @@ import scala.reflect.internal.settings.MutableSettings
  *  This should be refined, so that settings are settable via command
  *  line options or properties.
  */
-class Settings extends MutableSettings {
+private[reflect] class Settings extends MutableSettings {
 
   trait Setting extends SettingValue { }
 

--- a/src/reflect/scala/reflect/runtime/SymbolLoaders.scala
+++ b/src/reflect/scala/reflect/runtime/SymbolLoaders.scala
@@ -5,7 +5,7 @@ import internal.Flags
 import java.lang.{Class => jClass, Package => jPackage}
 import scala.collection.mutable
 
-trait SymbolLoaders { self: SymbolTable =>
+private[reflect] trait SymbolLoaders { self: SymbolTable =>
 
   /** The standard completer for top-level classes
    *  @param clazz   The top-level class

--- a/src/reflect/scala/reflect/runtime/SymbolTable.scala
+++ b/src/reflect/scala/reflect/runtime/SymbolTable.scala
@@ -8,7 +8,7 @@ import scala.reflect.internal.Flags._
  *  It can be used either from a reflexive universe (class scala.reflect.runtime.JavaUniverse), or else from
  *  a runtime compiler that uses reflection to get a class information (class scala.tools.reflect.ReflectGlobal)
  */
-trait SymbolTable extends internal.SymbolTable with JavaMirrors with SymbolLoaders with SynchronizedOps {
+private[scala] trait SymbolTable extends internal.SymbolTable with JavaMirrors with SymbolLoaders with SynchronizedOps {
 
   def info(msg: => String) =
     if (settings.verbose.value) println("[reflect-compiler] "+msg)

--- a/src/reflect/scala/reflect/runtime/SynchronizedOps.scala
+++ b/src/reflect/scala/reflect/runtime/SynchronizedOps.scala
@@ -2,7 +2,7 @@ package scala.reflect
 package runtime
 
 // SI-6240: test thread-safety, make trees synchronized as well
-trait SynchronizedOps extends internal.SymbolTable
+private[reflect] trait SynchronizedOps extends internal.SymbolTable
                          with SynchronizedSymbols
                          with SynchronizedTypes { self: SymbolTable =>
 

--- a/src/reflect/scala/reflect/runtime/SynchronizedSymbols.scala
+++ b/src/reflect/scala/reflect/runtime/SynchronizedSymbols.scala
@@ -3,7 +3,7 @@ package runtime
 
 import scala.reflect.io.AbstractFile
 
-trait SynchronizedSymbols extends internal.Symbols { self: SymbolTable =>
+private[reflect] trait SynchronizedSymbols extends internal.Symbols { self: SymbolTable =>
 
   override protected def nextId() = synchronized { super.nextId() }
 

--- a/src/reflect/scala/reflect/runtime/SynchronizedTypes.scala
+++ b/src/reflect/scala/reflect/runtime/SynchronizedTypes.scala
@@ -7,7 +7,7 @@ import java.lang.ref.WeakReference
 /** This trait overrides methods in reflect.internal, bracketing
  *  them in synchronized { ... } to make them thread-safe
  */
-trait SynchronizedTypes extends internal.Types { self: SymbolTable =>
+private[reflect] trait SynchronizedTypes extends internal.Types { self: SymbolTable =>
 
   // No sharing of map objects:
   override protected def commonOwnerMap = new CommonOwnerMap

--- a/src/reflect/scala/reflect/runtime/package.scala
+++ b/src/reflect/scala/reflect/runtime/package.scala
@@ -11,7 +11,7 @@ package object runtime {
 }
 
 package runtime {
-  object Macros {
+  private[scala] object Macros {
     def currentMirror(c: scala.reflect.macros.Context): c.Expr[universe.Mirror] = {
       import c.universe._
       val runtimeClass = c.reifyEnclosingRuntimeClass

--- a/test/files/run/macro-reflective-mamd-normal-mi/Macros_Test_2.scala
+++ b/test/files/run/macro-reflective-mamd-normal-mi/Macros_Test_2.scala
@@ -11,7 +11,7 @@ object Test extends App {
   val macrobody = Select(Ident(newTermName("Impls")), newTermName("foo"))
   val macroparam = ValDef(NoMods, newTermName("x"), TypeTree(definitions.IntClass.toType), EmptyTree)
   val macrodef = DefDef(Modifiers(MACRO), newTermName("foo"), Nil, List(List(macroparam)), TypeTree(), macrobody)
-  val modulector = DefDef(NoMods, nme.CONSTRUCTOR, Nil, List(List()), TypeTree(), Block(Apply(Select(Super(This(EmptyTypeName), EmptyTypeName), nme.CONSTRUCTOR), List())))
+  val modulector = DefDef(NoMods, nme.CONSTRUCTOR, Nil, List(List()), TypeTree(), Block(Apply(Select(Super(This(tpnme.EMPTY), tpnme.EMPTY), nme.CONSTRUCTOR), List())))
   val module = ModuleDef(NoMods, newTermName("Macros"), Template(Nil, emptyValDef, List(modulector, macrodef)))
   val macroapp = Apply(Select(Ident("Macros"), newTermName("foo")), List(Literal(Constant(42))))
   val tree = Block(macrodef, module, macroapp)

--- a/test/files/run/macro-typecheck-implicitsdisabled.check
+++ b/test/files/run/macro-typecheck-implicitsdisabled.check
@@ -1,2 +1,2 @@
 scala.this.Predef.any2ArrowAssoc[Int](1).->[Int](2)
-scala.reflect.internal.Types$TypeError: value -> is not a member of Int
+scala.reflect.macros.TypecheckException: value -> is not a member of Int

--- a/test/files/run/reflection-magicsymbols-invoke.scala
+++ b/test/files/run/reflection-magicsymbols-invoke.scala
@@ -2,6 +2,12 @@ import scala.reflect.runtime.universe._
 import scala.reflect.runtime.universe.definitions._
 import scala.reflect.runtime.{currentMirror => cm}
 
+package scala {
+  object ExceptionUtils {
+    def unwrapThrowable(ex: Throwable): Throwable = scala.reflect.runtime.ReflectionUtils.unwrapThrowable(ex)
+  }
+}
+
 object Test extends App {
   def key(sym: Symbol) = sym + ": " + sym.typeSignature
   def test(tpe: Type, receiver: Any, method: String, args: Any*) {
@@ -13,7 +19,7 @@ object Test extends App {
         println(result)
       } catch {
         case ex: Throwable =>
-          val realex = scala.reflect.runtime.ReflectionUtils.unwrapThrowable(ex)
+          val realex = scala.ExceptionUtils.unwrapThrowable(ex)
           println(realex.getClass + ": " + realex.getMessage)
       }
     print(s"testing ${tpe.typeSymbol.name}.$method: ")

--- a/test/files/run/reflection-valueclasses-magic.scala
+++ b/test/files/run/reflection-valueclasses-magic.scala
@@ -3,6 +3,12 @@ import scala.reflect.runtime.universe.definitions._
 import scala.reflect.runtime.{currentMirror => cm}
 import scala.reflect.ClassTag
 
+package scala {
+  object ExceptionUtils {
+    def unwrapThrowable(ex: Throwable): Throwable = scala.reflect.runtime.ReflectionUtils.unwrapThrowable(ex)
+  }
+}
+
 object Test extends App {
   def key(sym: Symbol) = {
     sym match {
@@ -35,7 +41,7 @@ object Test extends App {
         println(s"[${result.getClass}] =======> $result")
       } catch {
         case ex: Throwable =>
-          val realex = scala.reflect.runtime.ReflectionUtils.unwrapThrowable(ex)
+          val realex = scala.ExceptionUtils.unwrapThrowable(ex)
           println(realex.getClass + ": " + realex.getMessage)
       }
     val meth = tpe.declaration(newTermName(method).encodedName.toTermName)


### PR DESCRIPTION
Reflection is the gift that keeps on giving.

Writing the docs for reflection and macros produced another 17 shiny commits that clean up the public API and even touch the prettyprinters. 

The previous reflection pull request caused significant controversy, but I would like to convince you, our release managers, once again. 

More than a half of the PR is removal of useless methods that somehow sneaked into the public API. Another half of the remaining half is renaming of `XXXError` exceptions wrongfully called errors. Two more commits are mandatory for Scaladoc working correctly. Another two commits are not mandatory, but they help the docs to be more comprehensible.

And the last commit upgrades prettyprinting of reflection trees, accumulating the fixes I made when prepping examples for the documentation. If you insist I'm okay with letting this one go into 2.10.1.

review @gkossakowski @jsuereth
