### PR TITLE
 fixed trivial error with printing of exception stack trace in verbose m...

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -12,7 +12,7 @@ import scala.tools.util.PathResolver
 import scala.collection.{ mutable, immutable }
 import io.{ SourceReader, AbstractFile, Path }
 import reporters.{ Reporter, ConsoleReporter }
-import util.{ Exceptional, ClassPath, MergedClassPath, StatisticsInfo, ScalaClassLoader, returning }
+import util.{ Exceptional, ClassPath, MergedClassPath, StatisticsInfo, ScalaClassLoader, returning, stackTraceString }
 import scala.reflect.internal.util.{ NoPosition, OffsetPosition, SourceFile, NoSourceFile, BatchSourceFile, ScriptSourceFile }
 import scala.reflect.internal.pickling.{ PickleBuffer, PickleFormat }
 import symtab.{ Flags, SymbolTable, SymbolLoaders, SymbolTrackers }
@@ -1519,13 +1519,10 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
     def compileUnits(units: List[CompilationUnit], fromPhase: Phase) {
       try compileUnitsInternal(units, fromPhase)
       catch { case ex: Throwable =>
-        val shown = if (settings.verbose.value) {
-          val sw = new java.io.StringWriter()
-          val pw = new java.io.PrintWriter(sw)
-          ex.printStackTrace(pw)
-          pw.flush()
-          sw.toString
-        } else ex.getClass.getName
+        val shown = if (settings.verbose.value) 
+           stackTraceString(ex)
+         else 
+           ex.getClass.getName
         // ex.printStackTrace(Console.out) // DEBUG for fsc, note that error stacktraces do not print in fsc
         globalError(supplementErrorMessage("uncaught exception during compilation: " + shown))
         throw ex

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1520,9 +1520,11 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
       try compileUnitsInternal(units, fromPhase)
       catch { case ex: Throwable =>
         val shown = if (settings.verbose.value) {
-          val pw = new java.io.PrintWriter(new java.io.StringWriter)
+          val sw = new java.io.StringWriter()
+          val pw = new java.io.PrintWriter(sw)
           ex.printStackTrace(pw)
-          pw.toString
+          pw.flush()
+          sw.toString
         } else ex.getClass.getName
         // ex.printStackTrace(Console.out) // DEBUG for fsc, note that error stacktraces do not print in fsc
         globalError(supplementErrorMessage("uncaught exception during compilation: " + shown))


### PR DESCRIPTION
Fixed trivial error with printing internal compiler exception stacktrace in verbose mode: in original variant  pw.toString  show us something like PrintWriter@hashCode 
