### PR TITLE
MethodSymbol.params => MethodSymbol.paramss

### DIFF
--- a/src/reflect/scala/reflect/api/Symbols.scala
+++ b/src/reflect/scala/reflect/api/Symbols.scala
@@ -540,12 +540,13 @@ trait Symbols { self: Universe =>
     def typeParams: List[Symbol]
 
     /** All parameter lists of the method.
+     *  The name ending with "ss" indicates that the result type is a list of lists.
      *
      *  Can be used to distinguish nullary methods and methods with empty parameter lists.
      *  For a nullary method, returns the empty list (i.e. `List()`).
      *  For a method with an empty parameter list, returns a list that contains the empty list (i.e. `List(List())`).
      */
-    def params: List[List[Symbol]]
+    def paramss: List[List[Symbol]]
 
     /** Does this method support variable length argument lists?
      */

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2599,8 +2599,6 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       res
     }
 
-    override def params: List[List[Symbol]] = paramss
-
     override def isVarargs: Boolean = definitions.isVarArgsList(paramss.flatten)
 
     override def returnType: Type = {

--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -300,7 +300,7 @@ trait JavaMirrors extends internal.SymbolTable with api.JavaUniverse { thisUnive
         def showTparams(tparams: List[Symbol]) = "[" + (tparams map showTparam mkString ", ") + "]"
         sig += showTparams(symbol.typeParams)
       }
-      if (symbol.params.nonEmpty) {
+      if (symbol.paramss.nonEmpty) {
         def showParam(param: Symbol) = s"${param.name}: ${param.typeSignature}"
         def showParams(params: List[Symbol]) = {
           val s_mods = if (params.nonEmpty && params(0).hasFlag(IMPLICIT)) "implicit " else ""
@@ -308,7 +308,7 @@ trait JavaMirrors extends internal.SymbolTable with api.JavaUniverse { thisUnive
           "(" + s_mods + s_params + ")"
         }
         def showParamss(paramss: List[List[Symbol]]) = paramss map showParams mkString ""
-        sig += showParamss(symbol.params)
+        sig += showParamss(symbol.paramss)
       }
       sig += s": ${symbol.returnType}"
       sig
@@ -316,7 +316,7 @@ trait JavaMirrors extends internal.SymbolTable with api.JavaUniverse { thisUnive
 
     // the "symbol == Any_getClass || symbol == Object_getClass" test doesn't cut it
     // because both AnyVal and its primitive descendants define their own getClass methods
-    private def isGetClass(meth: MethodSymbol) = meth.name.toString == "getClass" && meth.params.flatten.isEmpty
+    private def isGetClass(meth: MethodSymbol) = meth.name.toString == "getClass" && meth.paramss.flatten.isEmpty
     private def isStringConcat(meth: MethodSymbol) = meth == String_+ || (meth.owner.isPrimitiveValueClass && meth.returnType =:= StringClass.toType)
     lazy val bytecodelessMethodOwners = Set[Symbol](AnyClass, AnyValClass, AnyRefClass, ObjectClass, ArrayClass) ++ ScalaPrimitiveValueClasses
     lazy val bytecodefulObjectMethods = Set[Symbol](Object_clone, Object_equals, Object_finalize, Object_hashCode, Object_toString,
@@ -332,7 +332,7 @@ trait JavaMirrors extends internal.SymbolTable with api.JavaUniverse { thisUnive
     // rather than have them on a hot path them in a unified implementation of the `apply` method
     private def mkJavaMethodMirror[T: ClassTag](receiver: T, symbol: MethodSymbol): JavaMethodMirror = {
       if (isBytecodelessMethod(symbol)) new JavaBytecodelessMethodMirror(receiver, symbol)
-      else if (symbol.params.flatten exists (p => isByNameParamType(p.info))) new JavaByNameMethodMirror(receiver, symbol)
+      else if (symbol.paramss.flatten exists (p => isByNameParamType(p.info))) new JavaByNameMethodMirror(receiver, symbol)
       else new JavaVanillaMethodMirror(receiver, symbol)
     }
 
@@ -361,7 +361,7 @@ trait JavaMirrors extends internal.SymbolTable with api.JavaUniverse { thisUnive
     private class JavaByNameMethodMirror(val receiver: Any, symbol: MethodSymbol)
             extends JavaMethodMirror(symbol) {
       def apply(args: Any*): Any = {
-        val transformed = map2(args.toList, symbol.params.flatten)((arg, param) => if (isByNameParamType(param.info)) () => arg else arg)
+        val transformed = map2(args.toList, symbol.paramss.flatten)((arg, param) => if (isByNameParamType(param.info)) () => arg else arg)
         jinvoke(jmeth, receiver, transformed)
       }
     }

--- a/src/reflect/scala/reflect/runtime/SynchronizedSymbols.scala
+++ b/src/reflect/scala/reflect/runtime/SynchronizedSymbols.scala
@@ -110,7 +110,7 @@ trait SynchronizedSymbols extends internal.Symbols { self: SymbolTable =>
 
   trait SynchronizedMethodSymbol extends MethodSymbol with SynchronizedTermSymbol {
     override def typeAsMemberOf(pre: Type): Type = synchronized { super.typeAsMemberOf(pre) }
-    override def params: List[List[Symbol]] = synchronized { super.params }
+    override def paramss: List[List[Symbol]] = synchronized { super.paramss }
     override def returnType: Type = synchronized { super.returnType }
   }
 

--- a/test/files/run/reflection-implicit.scala
+++ b/test/files/run/reflection-implicit.scala
@@ -9,7 +9,7 @@ class C {
 object Test extends App {
   val decls = typeOf[C].typeSymbol.typeSignature.declarations.sorted.toList.filter(sym => !sym.isTerm || (sym.isMethod && !sym.asMethod.isConstructor))
   println(decls map (_.isImplicit))
-  val param = decls.find(_.name.toString == "d").get.asMethod.params.last.head
+  val param = decls.find(_.name.toString == "d").get.asMethod.paramss.last.head
   param.typeSignature
   println(param.isImplicit)
 }

--- a/test/files/run/reflection-methodsymbol-params.scala
+++ b/test/files/run/reflection-methodsymbol-params.scala
@@ -13,12 +13,12 @@ class C {
 }
 
 object Test extends App {
-  println(typeOf[C].member(newTermName("x1")).asMethod.params)
-  println(typeOf[C].member(newTermName("x2")).asMethod.params)
-  println(typeOf[C].member(newTermName("x3")).asMethod.params)
-  println(typeOf[C].member(newTermName("x4")).asMethod.params)
-  println(typeOf[C].member(newTermName("y1")).asMethod.params)
-  println(typeOf[C].member(newTermName("y2")).asMethod.params)
-  println(typeOf[C].member(newTermName("y3")).asMethod.params)
-  println(typeOf[C].member(newTermName("y4")).asMethod.params)
+  println(typeOf[C].member(newTermName("x1")).asMethod.paramss)
+  println(typeOf[C].member(newTermName("x2")).asMethod.paramss)
+  println(typeOf[C].member(newTermName("x3")).asMethod.paramss)
+  println(typeOf[C].member(newTermName("x4")).asMethod.paramss)
+  println(typeOf[C].member(newTermName("y1")).asMethod.paramss)
+  println(typeOf[C].member(newTermName("y2")).asMethod.paramss)
+  println(typeOf[C].member(newTermName("y3")).asMethod.paramss)
+  println(typeOf[C].member(newTermName("y4")).asMethod.paramss)
 }

--- a/test/files/run/reflection-valueclasses-magic.scala
+++ b/test/files/run/reflection-valueclasses-magic.scala
@@ -7,7 +7,7 @@ object Test extends App {
   def key(sym: Symbol) = {
     sym match {
       // initialize parameter symbols
-      case meth: MethodSymbol => meth.params.flatten.map(_.typeSignature)
+      case meth: MethodSymbol => meth.paramss.flatten.map(_.typeSignature)
     }
     sym + ": " + sym.typeSignature
   }
@@ -41,8 +41,8 @@ object Test extends App {
     val meth = tpe.declaration(newTermName(method).encodedName.toTermName)
     val testees = if (meth.isMethod) List(meth.asMethod) else meth.asTerm.alternatives.map(_.asMethod)
     testees foreach (testee => {
-      val convertedArgs = args.zipWithIndex.map { case (arg, i) => convert(arg, testee.params.flatten.apply(i).typeSignature) }
-      print(s"testing ${tpe.typeSymbol.name}.$method(${testee.params.flatten.map(_.typeSignature).mkString(','.toString)}) with receiver = $receiver and args = ${convertedArgs.map(arg => arg + ' '.toString + arg.getClass).toList}: ")
+      val convertedArgs = args.zipWithIndex.map { case (arg, i) => convert(arg, testee.paramss.flatten.apply(i).typeSignature) }
+      print(s"testing ${tpe.typeSymbol.name}.$method(${testee.paramss.flatten.map(_.typeSignature).mkString(','.toString)}) with receiver = $receiver and args = ${convertedArgs.map(arg => arg + ' '.toString + arg.getClass).toList}: ")
       wrap(cm.reflect(receiver).reflectMethod(testee)(convertedArgs: _*))
     })
   }


### PR DESCRIPTION
This matter was discussed at scala-internals:
http://groups.google.com/group/scala-internals/browse_thread/thread/6414d200cf31c357

And I am convinced with Paul's argument: consistency of the convention
is very important.
