### PR TITLE
SI-6483 Prohibit super[T] references in value classes.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1420,6 +1420,9 @@ trait Typers extends Modes with Adaptations with Tags {
             case x: ValDef if x.mods.isLazy =>
               //see https://issues.scala-lang.org/browse/SI-6358
               implRestriction(tree, "lazy val")
+            case Select(sup @ Super(qual, mix), selector) if selector != nme.CONSTRUCTOR && qual.symbol == clazz && mix != tpnme.EMPTY =>
+              //see https://issues.scala-lang.org/browse/SI-6483
+              implRestriction(sup, "qualified super reference")
             case _ =>
           }
           super.traverse(tree)

--- a/test/files/neg/t6483.check
+++ b/test/files/neg/t6483.check
@@ -1,0 +1,9 @@
+t6483.scala:7: error: implementation restriction: qualified super reference is not allowed in value class
+This restriction is planned to be removed in subsequent releases.
+  override def foo = super[T].foo // error
+                     ^
+t6483.scala:20: error: implementation restriction: nested class is not allowed in value class
+This restriction is planned to be removed in subsequent releases.
+    class Inner extends T {
+          ^
+two errors found

--- a/test/files/neg/t6483.scala
+++ b/test/files/neg/t6483.scala
@@ -1,0 +1,24 @@
+trait T extends Any {
+  def foo = 1
+  type X
+}
+
+class C1(val a: Any) extends AnyVal with T {
+  override def foo = super[T].foo // error
+}
+
+class C2(val a: Int) extends AnyVal with T {
+  override def foo = super.foo + a // okay
+}
+
+class C3(val a: Int) extends AnyVal with T {
+  override def foo = C3.super.foo + a // okay
+}
+
+class C4(val a: Int) extends AnyVal with T {
+  def foo {
+    class Inner extends T {
+      override def foo = super[T].foo + a // no (direct) error, other than that a nested class is currently illegal.
+    }
+  }
+}


### PR DESCRIPTION
This seems the safest course of action for 2.10.0.

Without this, `typedSuper` fails during erasure.

Review by @odersky
- Is "this restriction is planned to be removed in subsequent releases" ?
