### PR TITLE
SI-6485 stops creating extmethods for macros

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -654,7 +654,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       info.firstParent.typeSymbol == AnyValClass && !isPrimitiveValueClass
 
     final def isMethodWithExtension =
-      isMethod && owner.isDerivedValueClass && !isParamAccessor && !isConstructor && !hasFlag(SUPERACCESSOR)
+      isMethod && owner.isDerivedValueClass && !isParamAccessor && !isConstructor && !hasFlag(SUPERACCESSOR) && !isTermMacro
 
     final def isAnonymousFunction = isSynthetic && (name containsName tpnme.ANON_FUN_NAME)
     final def isDefinedInPackage  = effectiveOwner.isPackageClass

--- a/test/files/pos/t6485a/Macros_1.scala
+++ b/test/files/pos/t6485a/Macros_1.scala
@@ -1,0 +1,5 @@
+import scala.reflect.macros.Context
+
+object Macros {
+  def crash(c: Context): c.Expr[Unit] = c.universe.reify(())
+}

--- a/test/files/pos/t6485a/Test_2.scala
+++ b/test/files/pos/t6485a/Test_2.scala
@@ -1,0 +1,5 @@
+import scala.language.experimental.macros
+
+final class Ops[T](val x: T) extends AnyVal {
+  def f = macro Macros.crash
+}

--- a/test/files/pos/t6485b/Test.scala
+++ b/test/files/pos/t6485b/Test.scala
@@ -1,0 +1,10 @@
+import scala.language.experimental.macros
+import scala.reflect.macros.Context
+
+final class Ops[T](val x: T) extends AnyVal {
+  def f = macro Macros.crash
+}
+
+object Macros {
+  def crash(c: Context): c.Expr[Unit] = c.universe.reify(())
+}


### PR DESCRIPTION
Macros don't correspond to bytecode-level methods, therefore
there's no need to undergo any transformations past typer.
