### PR TITLE
Corection of Range comments - SI-5678

### DIFF
--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -33,7 +33,6 @@ import scala.collection.parallel.immutable.ParRange
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#ranges "Scala's Collection Library overview"]]
  *  section on `Ranges` for more information.
  *
- *  @define Coll Range
  *  @define coll range
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf

--- a/src/library/scala/collection/parallel/immutable/ParRange.scala
+++ b/src/library/scala/collection/parallel/immutable/ParRange.scala
@@ -28,7 +28,6 @@ import scala.collection.Iterator
  *  @see  [[http://docs.scala-lang.org/overviews/parallel-collections/concrete-parallel-collections.html#parallel_range Scala's Parallel Collections Library overview]]
  *  section on `ParRange` for more information.
  *
- *  @define Coll `immutable.ParRange`
  *  @define coll immutable parallel range
  */
 @SerialVersionUID(1L)

--- a/src/library/scala/collection/parallel/immutable/ParSeq.scala
+++ b/src/library/scala/collection/parallel/immutable/ParSeq.scala
@@ -24,8 +24,8 @@ import scala.collection.GenSeq
 
 /** An immutable variant of `ParSeq`.
  *
- *  @define Coll `mutable.ParSeq`
- *  @define coll mutable parallel sequence
+ *  @define Coll `immutable.ParSeq`
+ *  @define coll immutable parallel sequence
  */
 trait ParSeq[+T]
 extends scala.collection/*.immutable*/.GenSeq[T]


### PR DESCRIPTION
Remove $Coll comment in Range and ParRange. Correct immutable in comment of ParSeq.
