### PR TITLE
Scaladoc knows the package structure of the libraries,

### DIFF
--- a/src/compiler/scala/tools/nsc/doc/Settings.scala
+++ b/src/compiler/scala/tools/nsc/doc/Settings.scala
@@ -7,6 +7,7 @@ package scala.tools.nsc
 package doc
 
 import java.io.File
+import java.net.URI
 import java.lang.System
 import scala.language.postfixOps
 
@@ -194,10 +195,10 @@ class Settings(error: String => Unit, val printMsg: String => Unit = println(_))
     "Expand all type aliases and abstract types into full template pages. (locally this can be done with the @template annotation)"
   )
 
-  val docExternalUrls = MultiStringSetting (
-    "-external-urls",
-    "externalUrl(s)",
-    "comma-separated list of package_names=doc_URL for external dependencies, where package names are ':'-separated"
+  val docExternalUris = MultiStringSetting (
+    "-external-uris",
+    "externalUri(s)",
+    "comma-separated list of file://classpath_entry_path#doc_URL URIs for external dependencies"
   )
 
   val docGroups = BooleanSetting (
@@ -244,21 +245,10 @@ class Settings(error: String => Unit, val printMsg: String => Unit = println(_))
     }
   }
 
-  // TODO: Enable scaladoc to scoop up the package list from another scaladoc site, just as javadoc does
-  //   -external-urls 'http://www.scala-lang.org/archives/downloads/distrib/files/nightly/docs/library'
-  // should trigger scaldoc to fetch the package-list file. The steps necessary:
-  // 1 - list all packages generated in scaladoc in the package-list file, exactly as javadoc:
-  //     see http://docs.oracle.com/javase/6/docs/api/package-list for http://docs.oracle.com/javase/6/docs/api
-  // 2 - download the file and add the packages to the list
-  lazy val extUrlMapping: Map[String, String] = (Map.empty[String, String] /: docExternalUrls.value) {
-    case (map, binding) =>
-      val idx = binding indexOf "="
-      val pkgs = binding substring (0, idx) split ":"
-      var url = binding substring (idx + 1)
-      val index = "/index.html"
-      url = if (url.endsWith(index)) url else url + index
-      map ++ (pkgs map (_ -> url))
-  }
+  lazy val extUrlMapping: Map[String, String] = docExternalUris.value map { s =>
+    val uri = new URI(s)
+    uri.getSchemeSpecificPart -> uri.getFragment
+  } toMap
 
   /**
    *  This is the hardcoded area of Scaladoc. This is where "undesirable" stuff gets eliminated. I know it's not pretty,

--- a/src/compiler/scala/tools/nsc/doc/model/MemberLookup.scala
+++ b/src/compiler/scala/tools/nsc/doc/model/MemberLookup.scala
@@ -48,9 +48,9 @@ trait MemberLookup {
           }
 
           if (sym.isClass || sym.isModule || sym.isTrait || sym.isPackage)
-            findExternalLink(linkName(sym))
+            findExternalLink(sym, linkName(sym))
           else if (owner.isClass || owner.isModule || owner.isTrait || owner.isPackage)
-            findExternalLink(linkName(owner) + "@" + externalSignature(sym))
+            findExternalLink(sym, linkName(owner) + "@" + externalSignature(sym))
           else
             None
         }
@@ -173,7 +173,7 @@ trait MemberLookup {
     // and removing NoType classes
     def cleanupBogusClasses(syms: List[Symbol]) = { syms.filter(_.info != NoType) }
 
-    def syms(name: Name) = container.info.nonPrivateMember(name).alternatives
+    def syms(name: Name) = container.info.nonPrivateMember(name.encodedName).alternatives
     def termSyms = cleanupBogusClasses(syms(newTermName(name)))
     def typeSyms = cleanupBogusClasses(syms(newTypeName(name)))
 

--- a/src/compiler/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/compiler/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -28,7 +28,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
                with MemberLookup =>
 
   import global._
-  import definitions.{ ObjectClass, NothingClass, AnyClass, AnyValClass, AnyRefClass }
+  import definitions.{ ObjectClass, NothingClass, AnyClass, AnyValClass, AnyRefClass, ListClass }
   import rootMirror.{ RootPackage, RootClass, EmptyPackage }
 
   def templatesCount = docTemplatesCache.count(_._2.isDocTemplate) - droppedPackages.size
@@ -1060,12 +1060,20 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
     { val rawComment = global.expandedDocComment(bSym, inTpl.sym)
       rawComment.contains("@template") || rawComment.contains("@documentable") }
 
-  def findExternalLink(name: String): Option[LinkTo] =
-    settings.extUrlMapping find {
-      case (pkg, _) => name startsWith pkg
-    } map {
-      case (_, url) => LinkToExternal(name, url + "#" + name)
+  def findExternalLink(sym: Symbol, name: String): Option[LinkTo] = {
+    val sym1 =
+      if (sym == AnyClass || sym == AnyRefClass || sym == AnyValClass || sym == NothingClass) ListClass
+      else if (sym.isPackage) 
+        /* Get package object which has associatedFile ne null */
+        sym.info.member(newTermName("package"))
+      else sym
+    Option(sym1.associatedFile) flatMap (_.underlyingSource) flatMap { src =>
+      val path = src.path
+      settings.extUrlMapping get path map { url =>
+        LinkToExternal(name, url + "/index.html#" + name)
+      }
     }
+  }
 
   def externalSignature(sym: Symbol) = {
     sym.info // force it, otherwise we see lazy types

--- a/src/compiler/scala/tools/nsc/doc/model/ModelFactoryTypeSupport.scala
+++ b/src/compiler/scala/tools/nsc/doc/model/ModelFactoryTypeSupport.scala
@@ -104,7 +104,7 @@ trait ModelFactoryTypeSupport {
                     if (!bSym.owner.isPackage)
                       Tooltip(name)
                     else
-                      findExternalLink(name).getOrElse (
+                      findExternalLink(bSym, name).getOrElse (
                         // (3) if we couldn't find neither the owner nor external URL to link to, show a tooltip with the qualified name
                         Tooltip(name)
                       )


### PR DESCRIPTION
so don't include them in -external-urls setting. Review by @VladUreche.
