### PR TITLE
Proposed fix for SI-6490.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -377,6 +377,8 @@ trait Namers extends MethodSynthesis {
         && (clazz.sourceFile ne null)
         && (module.sourceFile ne null)
         && !(module isCoDefinedWith clazz)
+        && module.exists
+        && clazz.exists
       )
       if (fails) {
         context.unit.error(tree.pos, (


### PR DESCRIPTION
Issues a "companions must be in same file" error only if both class and module exist. This can certainly do no harm. I believe it should adress SI-6490, but, lacking a test case, I don't have evidence for that.

Review by @paulp @dragos
