### PR TITLE
Fixes SI-4042, challenges with NumericRange's contains.

### DIFF
--- a/test/files/run/numeric-range.scala
+++ b/test/files/run/numeric-range.scala
@@ -1,7 +1,3 @@
-
-
-
-
 object Test {
   def main(args: Array[String]) {
     val r = 'a' to 'z'
@@ -9,5 +5,12 @@ object Test {
       assert(r.take(i) == r.toList.take(i), (i, r.take(i)))
       assert(r.drop(i) == r.toList.drop(i), (i, r.drop(i)))
     }
+    assert(1L to 10L contains 3)
+    assert(1L to 10L contains 3L)
+    assert(1L to 10L contains BigInt(3))
+    assert(1L to 10L contains 3.0d)
+    assert(1L to 10L contains (3: Short))
+    assert(1L to 10L contains BigDecimal(3))
+    assert(!(1L to 10L contains 3.00000001d))
   }
 }


### PR DESCRIPTION
Cleans up some sketchy and inadequate casting in favor of
using a dummy implicit to overload contains.  This way if
you're doing something reasonably sensible like

  1L to 10L contains 3

It will be both fast and correct.  And if you're doing
something sensible but less convenient for the implementor like

  1L to 10L contains BigInt(3)

..then it will still be correct.
