### PR TITLE
SI-6099 - Scaladoc for scala.concurrent incomplete

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2337,7 +2337,7 @@ DOCUMENTATION
       docfooter="epfl"
       docsourceurl="${scaladoc.url}€{FILE_PATH}.scala#L1"
       docUncompilable="${src.dir}/library-aux"
-      skipPackages="scala.reflect.macros.internal:scala.reflect.internal:scala.reflect.io"
+      skipPackages="scala.reflect.macros.internal:scala.reflect.internal:scala.reflect.io:scala.concurrent.impl"
       sourcepath="${src.dir}"
       classpathref="pack.classpath"
       addparams="${scalac.args.all}"

--- a/src/library/scala/concurrent/Awaitable.scala
+++ b/src/library/scala/concurrent/Awaitable.scala
@@ -14,36 +14,47 @@ import scala.concurrent.duration.Duration
 
 
 
+/**
+ * An object that may eventually be completed with a result value of type `T` which may be
+ * awaited using blocking methods.
+ * 
+ * The [[Await]] object provides methods that allow accessing the result of an `Awaitable`
+ * by blocking the current thread until the `Awaitable` has been completed or a timeout has
+ * occurred.
+ */
 trait Awaitable[+T] {
+
   /**
-   * Await the "resolved" state of this Awaitable.
-   * This method should not be called directly.
-   *
-   * @param atMost
-   *        maximum wait time, which may be negative (no waiting is done),
-   *        [[Duration.Inf]] for unbounded waiting, or a finite positive
-   *        duration
-   * @return the Awaitable itself
-   * @throws InterruptedException     if the wait call was interrupted
-   * @throws TimeoutException         if after waiting for the specified time this Awaitable is still not ready
-   * @throws IllegalArgumentException if `atMost` is [[Duration.Undefined]]
+   * Await the "completed" state of this `Awaitable`.
+   * 
+   * '''''This method should not be called directly; use [[Await.ready]] instead.'''''
+   * 
+   * @param  atMost
+   *         maximum wait time, which may be negative (no waiting is done),
+   *         [[scala.concurrent.duration.Duration.Inf Duration.Inf]] for unbounded waiting, or a finite positive
+   *         duration
+   * @return this `Awaitable`
+   * @throws InterruptedException     if the current thread is interrupted while waiting
+   * @throws TimeoutException         if after waiting for the specified time this `Awaitable` is still not ready
+   * @throws IllegalArgumentException if `atMost` is [[scala.concurrent.duration.Duration.Undefined Duration.Undefined]]
    */
   @throws(classOf[TimeoutException])
   @throws(classOf[InterruptedException])
   def ready(atMost: Duration)(implicit permit: CanAwait): this.type
   
   /**
-   * Await and return the result of this Awaitable, which is either of type T or a thrown exception (any Throwable).
-   * This method should not be called directly.
-   *
-   * @param atMost
-   *        maximum wait time, which may be negative (no waiting is done),
-   *        [[Duration.Inf]] for unbounded waiting, or a finite positive
-   *        duration
-   * @return the value if the Awaitable was successful within the specific maximum wait time
-   * @throws InterruptedException     if the wait call was interrupted
-   * @throws TimeoutException         if after waiting for the specified time this Awaitable is still not ready
-   * @throws IllegalArgumentException if `atMost` is [[Duration.Undefined]]
+   * Await and return the result (of type `T`) of this `Awaitable`.
+   * 
+   * '''''This method should not be called directly; use [[Await.result]] instead.'''''
+   * 
+   * @param  atMost
+   *         maximum wait time, which may be negative (no waiting is done),
+   *         [[scala.concurrent.duration.Duration.Inf Duration.Inf]] for unbounded waiting, or a finite positive
+   *         duration
+   * @return the result value if the `Awaitable` is completed within the specific maximum wait time
+   * @throws InterruptedException     if the current thread is interrupted while waiting
+   * @throws TimeoutException         if after waiting for the specified time this `Awaitable` is still not ready
+   * @throws IllegalArgumentException if `atMost` is [[scala.concurrent.duration.Duration.Undefined Duration.Undefined]]
    */
   @throws(classOf[Exception])
   def result(atMost: Duration)(implicit permit: CanAwait): T


### PR DESCRIPTION
This is a rebase and resubmission of @phaller's [pull](https://github.com/scala/scala/pull/1485), with the reviewers' comments additionally addressed.
