### PR TITLE
Removed redundant containsUncheckable.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1363,51 +1363,6 @@ trait Infer extends Checkable {
       }
     }
 
-    /** Does `tp` contain any types that cannot be checked at run-time (i.e., after erasure, will isInstanceOf[erased(tp)] imply conceptualIsInstanceOf[tp]?)
-     * we should find a way to ask erasure: hey, is `tp` going to make it through you with all of its isInstanceOf resolving powers intact?
-     * TODO: at the very least, reduce duplication wrt checkCheckable
-     */
-    def containsUnchecked(tp: Type): Boolean = {
-      def check(tp: Type, bound: List[Symbol]): Boolean = {
-        def isSurroundingTypeParam(sym: Symbol) = {
-          val e = context.scope.lookupEntry(sym.name)
-            (    (e ne null)
-              && (e.sym == sym )
-              && !e.sym.isTypeParameterOrSkolem
-              && (e.owner == context.scope)
-            )
-        }
-        def isLocalBinding(sym: Symbol) = (
-          sym.isAbstractType && (
-               (bound contains sym)
-            || (sym.name == tpnme.WILDCARD)
-            || isSurroundingTypeParam(sym)
-          )
-        )
-        tp.normalize match {
-          case SingleType(pre, _) =>
-            check(pre, bound)
-          case TypeRef(_, ArrayClass, arg :: _) =>
-            check(arg, bound)
-          case tp @ TypeRef(pre, sym, args) =>
-            (  (sym.isAbstractType && !isLocalBinding(sym))
-            || (args exists (x => !isLocalBinding(x.typeSymbol)))
-            || check(pre, bound)
-            )
-          // case RefinedType(_, decls) if decls.nonEmpty =>
-          //   patternWarning(tp, "refinement ")
-          case RefinedType(parents, _) =>
-            parents exists (p => check(p, bound))
-          case ExistentialType(quantified, tp1) =>
-            check(tp1, bound ::: quantified)
-          case _ =>
-            false
-        }
-      }
-      check(tp, Nil)
-    }
-
-
     /** Type intersection of simple type tp1 with general type tp2.
      *  The result eliminates some redundancies.
      */

--- a/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
@@ -192,7 +192,6 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
 
   trait MatchTranslation extends MatchMonadInterface { self: TreeMakers with CodegenCore =>
     import typer.{typed, context, silent, reallyExists}
-    // import typer.infer.containsUnchecked
 
     // Why is it so difficult to say "here's a name and a context, give me any
     // matching symbol in scope" ? I am sure this code is wrong, but attempts to

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3362,10 +3362,10 @@ trait Typers extends Modes with Adaptations with Tags {
         // if at least one of the types in an intersection is checkable, use the checkable ones
         // this avoids problems as in run/matchonseq.scala, where the expected type is `Coll with scala.collection.SeqLike`
         // Coll is an abstract type, but SeqLike of course is not
-        case RefinedType(parents, _)  if (parents.length >= 2) && (parents.exists(tp => !infer.containsUnchecked(tp))) =>
+        case RefinedType(ps, _) if ps.length > 1 && (ps exists infer.isCheckable) =>
           None
 
-        case ptCheckable if infer.containsUnchecked(ptCheckable) =>
+        case ptCheckable if infer isUncheckable ptCheckable =>
           val classTagExtractor = resolveClassTag(pos, ptCheckable)
 
           if (classTagExtractor != EmptyTree && unapplyMember(classTagExtractor.tpe) != NoSymbol)


### PR DESCRIPTION
Like the comment said:

  "TODO: at the very least, reduce duplication wrt checkCheckable"

I went with the very most, eliminating it.
