### PR TITLE
[backport] Fixed SI-6505. Respond to ask calls by immediate failure even after comp...

### DIFF
--- a/src/compiler/scala/tools/nsc/interactive/CompilerControl.scala
+++ b/src/compiler/scala/tools/nsc/interactive/CompilerControl.scala
@@ -12,6 +12,7 @@ import scala.tools.nsc.symtab._
 import scala.tools.nsc.ast._
 import scala.tools.nsc.util.FailedInterrupt
 import scala.tools.nsc.util.EmptyAction
+import scala.tools.nsc.util.InterruptReq
 
 /** Interface of interactive compiler to a client such as an IDE
  *  The model the presentation compiler consists of the following parts:
@@ -412,6 +413,16 @@ trait CompilerControl { self: Global =>
     override def doQuickly[A](op: () => A): A = {
       throw new FailedInterrupt(new Exception("Posted a work item to a compiler that's shutting down"))
     }
+
+    override def askDoQuickly[A](op: () => A): InterruptReq { type R = A } = {
+      val ir = new InterruptReq {
+        type R = A
+        val todo = () => throw new MissingResponse
+      }
+      ir.execute()
+      ir
+    }
+
   }
 
 }

--- a/src/compiler/scala/tools/nsc/util/InterruptReq.scala
+++ b/src/compiler/scala/tools/nsc/util/InterruptReq.scala
@@ -48,7 +48,10 @@ abstract class InterruptReq {
   }
 
   def onComplete(k: Continuation) = synchronized {
-    waiting = k :: waiting
+    if (result.isDefined)
+      k(result.get)
+    else
+      waiting = k :: waiting
   }
 }
 


### PR DESCRIPTION
...iler shutdown.

When the compiler is asked to shutdown, it may still have items on the working queue, and more can be added by clients in other thread that don't _know_ the compiler is down yet. These requests were never serviced, leading to deadlocks or timeouts.

review by @odersky, @hubertp
(cherry picked from commit 19ea47b3425f973c1ca92890cb8ee561b0ecab3d)
