### PR TITLE
Warn about more misplaced expressions.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2713,17 +2713,6 @@ trait Typers extends Modes with Adaptations with Tags {
       case Some(imp1: Import) => imp1
       case _                  => log("unhandled import: "+imp+" in "+unit); imp
     }
-    private def isWarnablePureExpression(tree: Tree) = tree match {
-      case EmptyTree | Literal(Constant(())) => false
-      case _                                 =>
-        !tree.isErrorTyped && (treeInfo isExprSafeToInline tree) && {
-          val sym = tree.symbol
-          (sym == null) || !(sym.isModule || sym.isLazy) || {
-            debuglog("'Pure' but side-effecting expression in statement position: " + tree)
-            false
-          }
-        }
-    }
 
     def typedStats(stats: List[Tree], exprOwner: Symbol): List[Tree] = {
       val inBlock = exprOwner == context.owner
@@ -2760,7 +2749,7 @@ trait Typers extends Modes with Adaptations with Tags {
                     ConstructorsOrderError(stat)
                 }
 
-                if (isWarnablePureExpression(result)) context.warning(stat.pos,
+                if (treeInfo.isPureExprForWarningPurposes(result)) context.warning(stat.pos,
                   "a pure expression does nothing in statement position; " +
                   "you may be omitting necessary parentheses"
                 )

--- a/test/files/neg/unit-returns-value.check
+++ b/test/files/neg/unit-returns-value.check
@@ -4,6 +4,12 @@ unit-returns-value.scala:4: warning: a pure expression does nothing in statement
 unit-returns-value.scala:4: warning: enclosing method f has result type Unit: return value discarded
     if (b) return 5
            ^
+unit-returns-value.scala:22: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+    i1 // warn
+    ^
+unit-returns-value.scala:23: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+    i2 // warn
+    ^
 error: No warnings can be incurred under -Xfatal-warnings.
-two warnings found
+four warnings found
 one error found

--- a/test/files/neg/unit-returns-value.scala
+++ b/test/files/neg/unit-returns-value.scala
@@ -3,9 +3,30 @@ object Test {
     var b = false
     if (b) return 5
   }
-  
+
   // no warning
   def g {
     return println("hello")
   }
 }
+
+class UnusedValues {
+  var i1 = 2
+  val i2 = 2
+  lazy val i3 = 2
+  object i4 { }
+  def i5 = 2
+  final def i6 = 2
+
+  def x = {
+    i1 // warn
+    i2 // warn
+    i3 // no warn
+    i4 // no warn
+    i5 // no warn
+    i6 // could warn someday, if i6 returned 2.type instead of Int
+
+    5
+  }
+}
+


### PR DESCRIPTION
An identifier being used in statement position is not likely
what was meant when it is a non-lazy getter.
