### PR TITLE
Use presentation compiler when scaladocing.

### DIFF
--- a/src/compiler/scala/tools/nsc/doc/DocFactory.scala
+++ b/src/compiler/scala/tools/nsc/doc/DocFactory.scala
@@ -32,25 +32,23 @@ import DocParser.Parsed
   *
   * @author Gilles Dubochet */
 class DocFactory(val reporter: Reporter, val settings: doc.Settings) { processor =>
-  /** The unique compiler instance used by this processor and constructed from its `settings`. */
-  object compiler extends Global(settings, reporter) with interactive.RangePositions {
-    override protected def computeInternalPhases() {
-      phasesSet += syntaxAnalyzer
-      phasesSet += analyzer.namerFactory
-      phasesSet += analyzer.packageObjects
-      phasesSet += analyzer.typerFactory
-      phasesSet += superAccessors
-      phasesSet += pickler
-      phasesSet += refChecks
+  def mkCompiler = 
+    new Global(settings, reporter) with interactive.RangePositions {
+      override protected def computeInternalPhases() {
+        phasesSet += syntaxAnalyzer
+        phasesSet += analyzer.namerFactory
+        phasesSet += analyzer.packageObjects
+        phasesSet += analyzer.typerFactory
+      }
+      override def forScaladoc = true
     }
-    override def forScaladoc = true
-  }
 
   /** Creates a scaladoc site for all symbols defined in this call's `source`,
     * as well as those defined in `sources` of previous calls to the same processor.
     * @param source The list of paths (relative to the compiler's source path,
-    *        or absolute) of files to document or the source code. */
-  def makeUniverse(source: Either[List[String], String]): Option[Universe] = {
+    *        or absolute) of files to document or the source code.
+    * @param compiler The compiler instance to run typer on. */
+  def makeUniverse(source: Either[List[String], String], compiler: Global = mkCompiler): Option[Universe] = {
     assert(settings.docformat.value == "html")
     source match {
       case Left(files) =>

--- a/src/compiler/scala/tools/nsc/interactive/Global.scala
+++ b/src/compiler/scala/tools/nsc/interactive/Global.scala
@@ -68,6 +68,8 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "")
     if (verboseIDE) println("[%s][%s]".format(projectName, msg))
 
   override def forInteractive = true
+  /* The same compiler is used for generating scaladoc in the IDE. */
+  override def forScaladoc = true
 
   /** A map of all loaded files to the rich compilation units that correspond to them.
    */

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -48,6 +48,7 @@ trait Typers extends Modes with Adaptations with Tags {
     resetContexts()
     resetImplicits()
     transformed.clear()
+    clearDocComments()
   }
 
   object UnTyper extends Traverser {

--- a/test/files/run/t5527.scala
+++ b/test/files/run/t5527.scala
@@ -100,7 +100,7 @@ object Test extends DirectTest {
     // we want the Scaladoc compiler here, because it keeps DocDef nodes in the tree
     val settings = new Settings(_ => ())
     val command = new ScalaDoc.Command((CommandLineParser tokenize extraSettings) ++ args.toList, settings)
-    new DocFactory(new ConsoleReporter(settings), settings).compiler
+    new DocFactory(new ConsoleReporter(settings), settings).mkCompiler
   }
 
   override def isDebug = false // so we don't get the newSettings warning


### PR DESCRIPTION
Don't run unneeded phases when generating scaladoc.
Review by @VladUreche and @dragos.
