### PR TITLE
Deprecated instrumentation API

### DIFF
--- a/src/compiler/scala/tools/nsc/interactive/CompilerControl.scala
+++ b/src/compiler/scala/tools/nsc/interactive/CompilerControl.scala
@@ -221,6 +221,7 @@ trait CompilerControl { self: Global =>
    *                      everything is brought up to date in a regular type checker run.
    *  @param response     The response.
    */
+  @deprecated("SI-6458: Instrumentation logic will be moved out of the compiler.","2.10.0")
   def askInstrumented(source: SourceFile, line: Int, response: Response[(String, Array[Char])]) =
     postWorkItem(new AskInstrumentedItem(source, line, response))
 
@@ -388,6 +389,7 @@ trait CompilerControl { self: Global =>
       response raise new MissingResponse
   }
 
+  @deprecated("SI-6458: Instrumentation logic will be moved out of the compiler.","2.10.0")
   case class AskInstrumentedItem(val source: SourceFile, line: Int, response: Response[(String, Array[Char])]) extends WorkItem {
     def apply() = self.getInstrumented(source, line, response)
     override def toString = "getInstrumented "+source

--- a/src/compiler/scala/tools/nsc/interactive/Global.scala
+++ b/src/compiler/scala/tools/nsc/interactive/Global.scala
@@ -205,7 +205,7 @@ class Global(settings: Settings, reporter: Reporter, projectName: String = "")
 
   protected[interactive] var minRunId = 1
 
-  private var interruptsEnabled = true
+  private[interactive] var interruptsEnabled = true
 
   private val NoResponse: Response[_] = new Response[Any]
 
@@ -1039,6 +1039,7 @@ class Global(settings: Settings, reporter: Reporter, projectName: String = "")
     }
   }
 
+  @deprecated("SI-6458: Instrumentation logic will be moved out of the compiler.","2.10.0")
   def getInstrumented(source: SourceFile, line: Int, response: Response[(String, Array[Char])]) =
     try {
       interruptsEnabled = false

--- a/src/compiler/scala/tools/nsc/interactive/REPL.scala
+++ b/src/compiler/scala/tools/nsc/interactive/REPL.scala
@@ -92,6 +92,7 @@ object REPL {
     val completeResult = new Response[List[comp.Member]]
     val typedResult = new Response[comp.Tree]
     val structureResult = new Response[comp.Tree]
+    @deprecated("SI-6458: Instrumentation logic will be moved out of the compiler.","2.10.0")
     val instrumentedResult = new Response[(String, Array[Char])]
 
     def makePos(file: String, off1: String, off2: String) = {
@@ -120,6 +121,7 @@ object REPL {
      *  @param iContents  An Array[Char] containing the instrumented source
      *  @return The name of the instrumented source file
      */
+    @deprecated("SI-6458: Instrumentation logic will be moved out of the compiler.","2.10.0")
     def writeInstrumented(iFullName: String, suffix: String, iContents: Array[Char]): String = {
       val iSimpleName = iFullName drop ((iFullName lastIndexOf '.') + 1)
       val iSourceName = iSimpleName + suffix
@@ -138,6 +140,7 @@ object REPL {
      *                    and outputs in the right column, or None if the presentation compiler
      *                    does not respond to askInstrumented.
      */
+    @deprecated("SI-6458: Instrumentation logic will be moved out of the compiler.","2.10.0")
     def instrument(arguments: List[String], line: Int): Option[(String, String)] = {
       val source = toSourceFile(arguments.head)
       // strip right hand side comment column and any trailing spaces from all lines

--- a/src/compiler/scala/tools/nsc/interactive/ScratchPadMaker.scala
+++ b/src/compiler/scala/tools/nsc/interactive/ScratchPadMaker.scala
@@ -6,6 +6,7 @@ import collection.mutable.ArrayBuffer
 import util.Chars.{isLineBreakChar, isWhitespace}
 import ast.parser.Tokens._
 
+@deprecated("SI-6458: Instrumentation logic will be moved out of the compiler.","2.10.0")
 trait ScratchPadMaker { self: Global =>
 
   import definitions._

--- a/src/compiler/scala/tools/nsc/scratchpad/Mixer.scala
+++ b/src/compiler/scala/tools/nsc/scratchpad/Mixer.scala
@@ -6,6 +6,7 @@ import scala.runtime.ScalaRunTime.stringOf
 import java.lang.reflect.InvocationTargetException
 import collection.mutable.ArrayBuffer
 
+@deprecated("SI-6458: Instrumentation logic will be moved out of the compiler.","2.10.0")
 class Mixer {
 
   protected val stdSeparator = "//> "

--- a/src/compiler/scala/tools/nsc/scratchpad/SourceInserter.scala
+++ b/src/compiler/scala/tools/nsc/scratchpad/SourceInserter.scala
@@ -6,6 +6,7 @@ import util.SourceFile
 
 import util.Chars._
 
+@deprecated("SI-6458: Instrumentation logic will be moved out of the compiler.","2.10.0")
 object SourceInserter {
   def stripRight(cs: Array[Char]): Array[Char] = {
     val lines =

--- a/src/library/scala/runtime/WorksheetSupport.scala
+++ b/src/library/scala/runtime/WorksheetSupport.scala
@@ -4,6 +4,7 @@ import scala.runtime.ScalaRunTime.stringOf
 
 /** A utility object that's needed by the code that executes a worksheet.
  */
+@deprecated("SI-6458: Instrumentation logic will be moved out of the compiler.","2.10.0")
 object WorksheetSupport {
 
   /** The offset in the source which should be printed */


### PR DESCRIPTION
review by @jsuereth, @odersky

The instrumentation logic needed by the Scala IDE Worksheet is currently part
of the Scala project, but it doesn't need to be.  I already have a PR ready for
completely removing the instrumentation logic, but I considered it too risky at
this point for 2.10.0 release (an oversight can lead to the impossibility of
running the worksheet with Scala 2.10.0).

For the moment, I believe it's better to deprecate the whole instrumentation
API in 2.10.0, and the PR for removing the instrumentation logic will target
2.10.1 or 2.11.0.

Besides deprecating the instrumentation API, this commit also raised visibility
of `interruptsEnabled` member in `Global`.  This change alone is sufficient for
moving the instrumentation logic outside of the compiler, and it is needed
because the Presentation Compiler thread should never be interrupted while
instrumenting a source.

This commit is related to SI-6458
(cherry picked from commit 4c7127d9acb1e0bae6f14a6b40019a535d057112)
