### PR TITLE
SI-6526 Tail call elimination should descend deeper.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/TailCalls.scala
+++ b/src/compiler/scala/tools/nsc/transform/TailCalls.scala
@@ -208,7 +208,7 @@ abstract class TailCalls extends Transform {
           debuglog("Cannot rewrite recursive call at: " + fun.pos + " because: " + reason)
 
           ctx.failReason = reason
-          treeCopy.Apply(tree, target, transformArgs)
+          treeCopy.Apply(tree, noTailTransform(target), transformArgs)
         }
         /** Position of failure is that of the tree being considered.
          */
@@ -220,7 +220,7 @@ abstract class TailCalls extends Transform {
           debuglog("Rewriting tail recursive call:  " + fun.pos.lineContent.trim)
 
           accessed += ctx.label
-          typedPos(fun.pos)(Apply(Ident(ctx.label), recv :: transformArgs))
+          typedPos(fun.pos)(Apply(Ident(ctx.label), noTailTransform(recv) :: transformArgs))
         }
 
         if (!ctx.isEligible)            fail("it is neither private nor final so can be overridden")
@@ -361,7 +361,9 @@ abstract class TailCalls extends Transform {
 
         case Alternative(_) | Star(_) | Bind(_, _) =>
           sys.error("We should've never gotten inside a pattern")
-        case EmptyTree | Super(_, _) | This(_) | Select(_, _) | Ident(_) | Literal(_) | Function(_, _) | TypeTree() =>
+        case Select(qual, name) =>
+          treeCopy.Select(tree, noTailTransform(qual), name)
+        case EmptyTree | Super(_, _) | This(_) | Ident(_) | Literal(_) | Function(_, _) | TypeTree() =>
           tree
         case _ =>
           super.transform(tree)

--- a/test/files/neg/t6526.check
+++ b/test/files/neg/t6526.check
@@ -1,0 +1,13 @@
+t6526.scala:8: error: could not optimize @tailrec annotated method inner: it contains a recursive call not in tail position
+    @tailrec def inner(i: Int): Int = 1 + inner(i)
+                                        ^
+t6526.scala:14: error: could not optimize @tailrec annotated method inner: it contains a recursive call not in tail position
+    @tailrec def inner(i: Int): Int = 1 + inner(i)
+                                        ^
+t6526.scala:20: error: could not optimize @tailrec annotated method inner: it contains a recursive call not in tail position
+    @tailrec def inner(i: Int): Int = 1 + inner(i)
+                                        ^
+t6526.scala:30: error: could not optimize @tailrec annotated method inner: it contains a recursive call not in tail position
+        @tailrec def inner(i: Int): Int = 1 + inner(i)
+                                            ^
+four errors found

--- a/test/files/neg/t6526.check
+++ b/test/files/neg/t6526.check
@@ -10,4 +10,7 @@ t6526.scala:20: error: could not optimize @tailrec annotated method inner: it co
 t6526.scala:30: error: could not optimize @tailrec annotated method inner: it contains a recursive call not in tail position
         @tailrec def inner(i: Int): Int = 1 + inner(i)
                                             ^
-four errors found
+t6526.scala:39: error: could not optimize @tailrec annotated method inner: it contains a recursive call not in tail position
+    def inner(i: Int): Int = 1 + inner(i)
+                               ^
+5 errors found

--- a/test/files/neg/t6526.scala
+++ b/test/files/neg/t6526.scala
@@ -1,0 +1,36 @@
+import scala.annotation.tailrec
+
+class TailRec {
+  def bar(f: => Any) = ""
+
+  // transform the qualifier of a Select
+  bar {
+    @tailrec def inner(i: Int): Int = 1 + inner(i)
+    inner(0)
+  }.length
+
+  // transform the body of a function
+  () => {
+    @tailrec def inner(i: Int): Int = 1 + inner(i)
+    inner(0)
+  }
+
+  // transform the qualifier of a Select
+  {
+    @tailrec def inner(i: Int): Int = 1 + inner(i)
+    inner(0)
+    ""
+  }.length
+
+  // The receiver of a tail recursive call must itself be transformed
+  object X {
+    @tailrec // okay, all other annotated methods should fail.
+    def foo: Any = {
+      {
+        @tailrec def inner(i: Int): Int = 1 + inner(i)
+        inner(0)
+        this
+      }.foo
+    }
+  }
+}

--- a/test/files/neg/t6526.scala
+++ b/test/files/neg/t6526.scala
@@ -33,4 +33,9 @@ class TailRec {
       }.foo
     }
   }
+
+  Some(new AnyRef) map { phooie =>
+    @tailrec
+    def inner(i: Int): Int = 1 + inner(i)
+  } getOrElse 42
 }


### PR DESCRIPTION
It wasn't traversing into Select nodes nor into the receiver of
a tail call.

Review by @dragos
