### PR TITLE
avoid single-arg assert where harmful in duration-tck

### DIFF
--- a/test/files/jvm/duration-tck.scala
+++ b/test/files/jvm/duration-tck.scala
@@ -170,11 +170,14 @@ object Test extends App {
   // test Deadline
   val dead = 2.seconds.fromNow
   val dead2 = 2 seconds fromNow
-  assert(dead.timeLeft > 1.second)
-  assert(dead2.timeLeft > 1.second)
+
+  { val l = dead.timeLeft; assert(l > 1.second, s"$l <= 1.second") }
+  { val l = dead2.timeLeft; assert(l > 1.second, s"$l <= 1.second") }
+
   Thread.sleep(1.second.toMillis)
-  assert(dead.timeLeft < 1.second)
-  assert(dead2.timeLeft < 1.second)
+
+  { val l = dead.timeLeft; assert(l <= 1.second, s"$l > 1.second") }
+  { val l = dead2.timeLeft; assert(l <= 1.second, s"$l > 1.second") }
 
 
   // test integer mul/div


### PR DESCRIPTION
after mailing list discussion: https://groups.google.com/d/msg/scala-internals/7j6ph0cQBW8/U3Lr7QrA41EJ

not sure whether 2.10.0-wip is the appropriate branch, should be easily relocatable wherever needed.

review by: @paulp
