### PR TITLE
Fix SI-6552, regression with self types.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -558,6 +558,7 @@ trait Contexts { self: Analyzer =>
         (  (ab.isTerm || ab == rootMirror.RootClass)
         || (accessWithin(ab) || accessWithinLinked(ab)) &&
              (  !sym.hasLocalFlag
+             || sym.owner.isImplClass // allow private local accesses to impl classes
              || sym.isProtected && isSubThisType(pre, sym.owner)
              || pre =:= sym.owner.thisType
              )

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1409,9 +1409,11 @@ trait Types extends api.Types { self: SymbolTable =>
   final class UniqueThisType(sym: Symbol) extends ThisType(sym) { }
 
   object ThisType extends ThisTypeExtractor {
-    def apply(sym: Symbol): Type =
-      if (phase.erasedTypes) sym.tpe
-      else unique(new UniqueThisType(sym))
+    def apply(sym: Symbol): Type = (
+      if (!phase.erasedTypes) unique(new UniqueThisType(sym))
+      else if (sym.isImplClass) sym.typeOfThis
+      else sym.tpe
+    )
   }
 
   /** A class for singleton types of the form `<prefix>.<sym.name>.type`.

--- a/test/files/pos/t6552.scala
+++ b/test/files/pos/t6552.scala
@@ -1,0 +1,8 @@
+object Repros {
+  class Bar {}
+  class Baz(val myFoo: Foo) { }
+  trait Foo {
+    this: Bar =>
+    val thing = new Baz(this)
+  }
+}


### PR DESCRIPTION
In 6eb55d4b7a we put in a remedy for an old issue SI-4560 which
had accumulated a number of sketchy partial remedies which carried
no tests to illustrate their necessity. Looks like at least one of
those was doing something useful. Here's to reversion-reversion.

This reverts commit c8bdf199, which itself reverted cb4fd6582.
