### PR TITLE
Fixes SI-6551.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1118,6 +1118,7 @@ trait Typers extends Modes with Adaptations with Tags {
           else if (inAllModes(mode, EXPRmode | FUNmode) &&
             !tree.tpe.isInstanceOf[MethodType] &&
             !tree.tpe.isInstanceOf[OverloadedType] &&
+            !tree.tpe.isInstanceOf[PolyType] &&
             applyPossible)
             insertApply()
           else if (!context.undetparams.isEmpty && !inPolyMode(mode)) { // (9)

--- a/test/files/pos/t6551.scala
+++ b/test/files/pos/t6551.scala
@@ -1,0 +1,13 @@
+import language.dynamics
+
+object Test {
+  def main(args: Array[String]) {
+    class Lenser[T] extends Dynamic {
+      def selectDynamic(propName: String) = ???
+    }
+
+    def lens[T] = new Lenser[T]
+
+    val qq = lens[String]
+  }
+}


### PR DESCRIPTION
Don't rewrite an explicit apply method to dynamic polytypes.

Review by @retronym and @jsuereth.
