### PR TITLE
SI-6488: Fix for race with open I/O fds

### DIFF
--- a/src/library/scala/sys/process/ProcessImpl.scala
+++ b/src/library/scala/sys/process/ProcessImpl.scala
@@ -222,7 +222,10 @@ private[process] trait ProcessImpl {
       p.exitValue()
     }
     override def destroy() = {
-      try p.destroy()
+      try{
+        outputThreads foreach (_.stop())
+        p.destroy()
+      }
       finally inputThread.interrupt()
     }
   }

--- a/test/files/run/t6488.check
+++ b/test/files/run/t6488.check
@@ -1,0 +1,1 @@
+Success

--- a/test/files/run/t6488.scala
+++ b/test/files/run/t6488.scala
@@ -1,0 +1,11 @@
+import sys.process._
+object Test {
+  // Program that prints "Success" if the command was successfully run then destroyed
+  // It will silently pass if the command "/bin/ls" does not exist
+  // It will fail due to the uncatchable exception in t6488 race condition
+  def main(args: Array[String]) {
+    try Process("/bin/ls").run(ProcessLogger { _ => () }).destroy
+    catch { case _ => () }
+    println("Success")
+  }
+}


### PR DESCRIPTION
Unless the I/O threads for error and output are closed prior to Process.destroy() there is a potential race condition that ends in the I/O threads raising an IOException.

Added test case and resubmitted against 2.10.x

CLA also signed and confirmed.

Supersedes https://github.com/scala/scala/pull/1484 which may now be closed.
