### PR TITLE
Fixes SI-6559 - StringContext not using passed in escape function.

### DIFF
--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -120,7 +120,7 @@ case class StringContext(parts: String*) {
     val bldr = new java.lang.StringBuilder(process(pi.next()))
     while (ai.hasNext) {
       bldr append ai.next
-      bldr append treatEscapes(pi.next())
+      bldr append process(pi.next())
     }
     bldr.toString
   }

--- a/test/files/run/t6559.scala
+++ b/test/files/run/t6559.scala
@@ -1,0 +1,17 @@
+
+object Test {
+
+  def main(args: Array[String]) = {
+     val one = "1"
+     val two = "2"
+
+     val raw = raw"\n$one\n$two\n"
+     val escaped = s"\n$one\n$two\n"
+     val buggy = "\\n1\n2\n"
+     val correct = "\\n1\\n2\\n"
+
+     assert(raw != escaped, "Raw strings should not be escaped.")
+     assert(raw != buggy, "Raw strings after variables should not be escaped.")
+     assert(raw == correct, "Raw strings should stay raw.")
+  }
+}


### PR DESCRIPTION
As reported by Curtis Stanford, with indication of what to fix.  standardInterpolator was not correctly
calling the passed in process function, so raw strings were not really raw.

Review by @adriaanm
