### PR TITLE
silences optional logs in reflection

### DIFF
--- a/src/reflect/scala/reflect/runtime/JavaUniverse.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverse.scala
@@ -17,7 +17,7 @@ class JavaUniverse extends internal.SymbolTable with ReflectSetup with runtime.S
   def forInteractive = false
   def forScaladoc = false
 
-  def log(msg: => AnyRef): Unit = println(" [] "+msg)
+  def log(msg: => AnyRef): Unit = if (settings.debug.value) println(" [] "+msg)
 
   type TreeCopier = InternalTreeCopierOps
   def newStrictTreeCopier: TreeCopier = new StrictTreeCopier


### PR DESCRIPTION
Some parts of the compiler call `SymbolTable.log` to dump information
about the progress of compilation, type inference, etc.

In Global.scala, `log` checks the -Ylog configuration setting to approve
or reject incoming messages.

However in runtime reflection (scala.reflect.runtime.JavaUniverse)
`log` always prints its argument, which is annoying. Here's why
this is happening.

In runtime reflection -Ylog is inapplicable, because this is a
phase-based setting, whereas reflection does not have a notion of phases.
Moreover reflection doesn't expose `settings` to the programmers
(the corresponding `def settings` definition is declared in
scala.reflect.internal.Required).

Therefore there's no obvious solution to conditional printing in `log`
when invoked in reflective setting. The situation is tough and needs to
be addressed in a principled manner. However we're in between RC1 and RC2
at the moment, so I don't fancy significant changes right now.

Nevertheless we need to fix the annoyance right away, therefore I change
reflective `log` to use -Ydebug. This is inconsistent w.r.t how Global
works, and also there's no way to enable logging short of casting to
`scala.reflect.runtime.SymbolTable`, but it looks like a decent
temporary measure.
