### PR TITLE
SI-6575 Type ascribe partial function literals.

### DIFF
--- a/test/files/pos/t6575a.scala
+++ b/test/files/pos/t6575a.scala
@@ -1,0 +1,15 @@
+trait X { def foo: PartialFunction[Int, Int] }
+
+trait Y extends X {
+  // Inferred type was AbstractPartialFunction[Int, Int] with Serializable
+  abstract override def foo = { case i => super.foo(i) * 2 }
+}
+trait Z extends X {
+  // ditto
+  abstract override def foo = { case i => super.foo(i) + 3 }
+}
+
+trait Comb extends Y with Z {
+  // ... which led to a type error here.
+  abstract override def foo: PartialFunction[Int, Int] = { case i => super.foo(i) - 2 }
+}

--- a/test/files/pos/t6575b.scala
+++ b/test/files/pos/t6575b.scala
@@ -1,0 +1,17 @@
+// inferred types were okay here as Function nodes aren't
+// translated into anoymous subclasses of AbstractFunctionN
+// until after the typer.
+//
+// So this test is just confirmation.
+trait X { def foo: Function1[Int, Int] }
+
+trait Y extends X {
+  abstract override def foo = { case i => super.foo(i) * 2 }
+}
+trait Z extends X {
+  abstract override def foo = { case i => super.foo(i) + 3 }
+}
+
+trait Comb extends Y with Z {
+  abstract override def foo: Function1[Int, Int] = { case i => super.foo(i) - 2 }
+}


### PR DESCRIPTION
Usually this isn't needed, as partial functions can only be
defined with an expected type. But if that expected type is
and inherited method return type, the actual type of the partial
function literal is used, and the implementation detail of
`AbstractPartialFunction[A, B] with Serializable` leaks out.

After this change, the inferred types match those from
Scala 2.9.2.

```
ticket/6575 ~/code/scala scalac29 -Xprint:typer test/files/pos/t6575a.scala | grep def > 29.txt
ticket/6575 ~/code/scala squalac -Xprint:typer test/files/pos/t6575a.scala | grep def > 210.txt
ticket/6575 ~/code/scala diff -u 29.txt 210.txt
--- 29.txt  2012-10-28 13:51:07.000000000 +0100
+++ 210.txt 2012-10-28 13:51:20.000000000 +0100
@@ -1,7 +1,16 @@
     def foo: PartialFunction[Int,Int]
     def /*Y*/$init$(): Unit = {
-    absoverride def foo: PartialFunction[Int,Int] = ((x0$1: Int) => x0$1 match {
+    absoverride def foo: PartialFunction[Int,Int] = {
+        def <init>(): anonymous class $anonfun = {
+        final override def applyOrElse[A1 >: Nothing <: Int, B1 >: Int <: Any](x$1: A1, default: A1 => B1): B1 = (x$1: A1 @unchecked) match {
+        final def isDefinedAt(x$1: Int): Boolean = (x$1: Int @unchecked) match {
     def /*Z*/$init$(): Unit = {
-    absoverride def foo: PartialFunction[Int,Int] = ((x0$2: Int) => x0$2 match {
+    absoverride def foo: PartialFunction[Int,Int] = {
+        def <init>(): anonymous class $anonfun = {
+        final override def applyOrElse[A1 >: Nothing <: Int, B1 >: Int <: Any](x$1: A1, default: A1 => B1): B1 = (x$1: A1 @unchecked) match {
+        final def isDefinedAt(x$1: Int): Boolean = (x$1: Int @unchecked) match {
     def /*Comb*/$init$(): Unit = {
-    absoverride def foo: PartialFunction[Int,Int] = ((x0$3: Int) => x0$3 match {
+    absoverride def foo: PartialFunction[Int,Int] = {
+        def <init>(): anonymous class $anonfun = {
+        final override def applyOrElse[A1 >: Nothing <: Int, B1 >: Int <: Any](x$1: A1, default: A1 => B1): B1 = (x$1: A1 @unchecked) match {
+        final def isDefinedAt(x$1: Int): Boolean = (x$1: Int @unchecked) match {
```

review by @adriaanm
