### PR TITLE
Fixes SI-6558: typecheck lazy annotation info using non-silent context.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1262,7 +1262,11 @@ trait Namers extends MethodSynthesis {
           case defn: MemberDef =>
             val ainfos = defn.mods.annotations filterNot (_ eq null) map { ann =>
               // need to be lazy, #1782. beforeTyper to allow inferView in annotation args, SI-5892.
-              AnnotationInfo lazily beforeTyper(typer typedAnnotation ann)
+              AnnotationInfo lazily {
+                val context1 = typer.context.make(ann)
+                context1.setReportErrors()
+                beforeTyper(newTyper(context1) typedAnnotation ann)
+              }
             }
             if (ainfos.nonEmpty) {
               annotated setAnnotations ainfos

--- a/test/files/neg/t6558.check
+++ b/test/files/neg/t6558.check
@@ -1,0 +1,4 @@
+t6558.scala:5: error: not found: type sth
+    @sth
+     ^
+one error found

--- a/test/files/neg/t6558.scala
+++ b/test/files/neg/t6558.scala
@@ -1,0 +1,9 @@
+class AnnotNotFound {
+  def foo(a: Any) = ()
+
+  foo {
+    @sth
+    def foo = 0
+    foo
+  }
+}


### PR DESCRIPTION
Make context for typing lazy annotations always non-silent. If lazy annotation info was created in local (silent) context, error could go unnoticed because later they would still use silent typer for typing the annotation.

Review by @lrytz
