### PR TITLE
Fixes SI-5031 for separate compilation scenario.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
@@ -558,7 +558,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters {
     def innerClassSymbolFor(s: Symbol): Symbol =
       if (s.isClass) s else if (s.isModule) s.moduleClass else NoSymbol
 
-    /** Return the a name of this symbol that can be used on the Java platform.  It removes spaces from names.
+    /** Return the name of this symbol that can be used on the Java platform.  It removes spaces from names.
      *
      *  Special handling:
      *    scala.Nothing erases to scala.runtime.Nothing$
@@ -607,7 +607,8 @@ abstract class GenASM extends SubComponent with BytecodeWriters {
           case None         =>
             reverseJavaName.put(internalName, trackedSym)
           case Some(oldsym) =>
-            assert((oldsym == trackedSym) || (oldsym == RuntimeNothingClass) || (oldsym == RuntimeNullClass), // In contrast, neither NothingClass nor NullClass show up bytecode-level.
+            assert((oldsym == trackedSym) || (oldsym == RuntimeNothingClass) || (oldsym == RuntimeNullClass) ||
+                    (oldsym.isModuleClass && (oldsym.sourceModule == trackedSym.sourceModule)), // In contrast, neither NothingClass nor NullClass show up bytecode-level.
                    "how can getCommonSuperclass() do its job if different class symbols get the same bytecode-level internal name: " + internalName)
         }
       }

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -94,7 +94,10 @@ abstract class ClassfileParser {
     pushBusy(root) {
       this.in           = new AbstractFileReader(file)
       this.clazz        = if (root.isModule) root.companionClass else root
-      this.staticModule = clazz.companionModule
+      // WARNING! do no use clazz.companionModule to find staticModule.
+      // In a situation where root can be defined, but its companionClass not,
+      // this would give incorrect results (see SI-5031 in separate compilation scenario)
+      this.staticModule = if (root.isModule) root else root.companionModule
       this.isScala      = false
 
       parseHeader

--- a/test/files/pos/t5031_3/Foo_1.scala
+++ b/test/files/pos/t5031_3/Foo_1.scala
@@ -1,0 +1,5 @@
+package foo.bar
+
+object Foo {
+  def bar = 42
+}

--- a/test/files/pos/t5031_3/Main_2.scala
+++ b/test/files/pos/t5031_3/Main_2.scala
@@ -1,0 +1,6 @@
+package org.example
+
+object Main extends App {
+   println(foo.bar.Foo.bar)
+}
+

--- a/test/files/pos/t5031_3/package.scala
+++ b/test/files/pos/t5031_3/package.scala
@@ -1,0 +1,6 @@
+package foo
+
+package object bar {
+  type Foo = Int => String
+}
+


### PR DESCRIPTION
When you have a conflicting member in package object and normal package that share the same namespace we remove the latter ClassSymbol from the scope. Now, this has an unpleasant consequence that companionClass/companionModule/companionSymbol no longer work correctly as they rely on finding the correspondent symbol using decls of the owner.
This fixes the problem of SI-5031 for separate compilation. Why the above change matters for finding foo.bar.Foo? Because when parsing the class we needed information about the static module (and we have the correct module symbol when completing the info). It's just that 043ce6d0565c9d5d960 relied on no longer valid assumptions. So we were getting NoSymbol and sym.exist was failing.

Obviously a more complete solution would be better if we didn't rely on the scope but that's too big to change for 2.10.0.

Already discussed with @odersky, but it would be great to get a quick lgtm.
