### PR TITLE
An option for real repl output.

### DIFF
--- a/src/compiler/scala/tools/nsc/interpreter/ReplDir.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/ReplDir.scala
@@ -1,0 +1,48 @@
+/* NSC -- new Scala compiler
+ * Copyright 2005-2012 LAMP/EPFL
+ * @author  Paul Phillips
+ */
+
+package scala.tools.nsc
+package interpreter
+
+import io.VirtualDirectory
+import settings.MutableSettings
+import scala.reflect.io.{ AbstractFile, PlainDirectory, Directory }
+import scala.collection.generic.Clearable
+
+/** Directory to save .class files to. */
+trait ReplDir extends AbstractFile with Clearable { }
+
+private class ReplVirtualDir() extends VirtualDirectory("(memory)", None) with ReplDir { }
+private class ReplRealDir(dir: Directory) extends PlainDirectory(dir) with ReplDir {
+  def clear() = {
+    dir.deleteRecursively()
+    dir.createDirectory()
+  }
+}
+
+class ReplOutput(val dirSetting: MutableSettings#StringSetting) {
+  // outdir for generated classfiles - may be in-memory (the default),
+  // a generated temporary directory, or a specified outdir.
+  val dir: ReplDir = (
+    if (dirSetting.isDefault)
+      new ReplVirtualDir()
+    else if (dirSetting.value == "")
+      new ReplRealDir(Directory.makeTemp("repl"))
+    else
+      new ReplRealDir(Directory(dirSetting.value))
+  )
+
+  // print the contents hierarchically
+  def show(out: JPrintWriter) = {
+    def pp(root: AbstractFile, indentLevel: Int) {
+      val label = root.name
+      val spaces = "    " * indentLevel
+      out.println(spaces + label)
+      if (root.isDirectory)
+        root.toList sortBy (_.name) foreach (x => pp(x, indentLevel + 1))
+    }
+    pp(dir, 0)
+  }
+}

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -170,6 +170,7 @@ trait ScalaSettings extends AbsScalaSettings
   val Ybuilderdebug   = ChoiceSetting     ("-Ybuilder-debug", "manager", "Compile using the specified build manager.", List("none", "refined", "simple"), "none")
   val Yreifycopypaste = BooleanSetting    ("-Yreify-copypaste", "Dump the reified trees in copypasteable representation.")
   val Yreplsync       = BooleanSetting    ("-Yrepl-sync", "Do not use asynchronous code for repl startup")
+  val Yreploutdir     = StringSetting     ("-Yrepl-outdir", "path", "Write repl-generated classfiles to given output directory (use \"\" to generate a temporary dir)" , "")
   val Ynotnull        = BooleanSetting    ("-Ynotnull", "Enable (experimental and incomplete) scala.NotNull.")
   val YmethodInfer    = BooleanSetting    ("-Yinfer-argument-types", "Infer types for arguments of overriden methods.")
   val etaExpandKeepsStar = BooleanSetting ("-Yeta-expand-keeps-star", "Eta-expand varargs methods to T* rather than Seq[T].  This is a temporary option to ease transition.")

--- a/test/files/run/repl-out-dir.check
+++ b/test/files/run/repl-out-dir.check
@@ -1,0 +1,53 @@
+Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> 
+
+scala> case class Bippy(x: Int)
+defined class Bippy
+
+scala> val x = Bippy(1)
+x: Bippy = Bippy(1)
+
+scala> $intp.showDirectory
+repl-out-dir-run.obj
+    $line1
+        $eval$.class
+        $eval.class
+    $line2
+        $eval$.class
+        $eval.class
+        $read$$iw$$iw$.class
+        $read$$iw$.class
+        $read$.class
+        $read.class
+    $line3
+        $eval$.class
+        $eval.class
+        $read$$iw$$iw$.class
+        $read$$iw$$iw$Bippy$.class
+        $read$$iw$$iw$Bippy.class
+        $read$$iw$.class
+        $read$.class
+        $read.class
+    $line4
+        $eval$.class
+        $eval.class
+        $read$$iw$$iw$.class
+        $read$$iw$.class
+        $read$.class
+        $read.class
+    $line5
+        $eval$.class
+        $eval.class
+        $read$$iw$$iw$.class
+        $read$$iw$.class
+        $read$.class
+        $read.class
+    $repl_$init.class
+    Test$.class
+    Test.class
+
+scala> 
+
+scala> 

--- a/test/files/run/repl-out-dir.scala
+++ b/test/files/run/repl-out-dir.scala
@@ -1,0 +1,13 @@
+import scala.tools.partest.ReplTest
+import scala.tools.nsc.Settings
+
+object Test extends ReplTest {
+  override def extraSettings = s"-Yrepl-outdir ${testOutput.path}"
+
+  def code = s"""
+case class Bippy(x: Int)
+val x = Bippy(1)
+$$intp.showDirectory
+  """
+
+}

--- a/test/files/run/t6223.check
+++ b/test/files/run/t6223.check
@@ -1,4 +1,4 @@
 bar
-bar$mcI$sp
 bar$mIc$sp
 bar$mIcI$sp
+bar$mcI$sp

--- a/test/files/run/t6223.scala
+++ b/test/files/run/t6223.scala
@@ -5,7 +5,7 @@ class Foo[@specialized(Int) A](a:A) {
 object Test {
   def main(args:Array[String]) {
     val f = new Foo(333)
-    val ms = f.getClass().getDeclaredMethods()
+    val ms = f.getClass().getDeclaredMethods().sortBy(_.getName)
     ms.foreach(m => println(m.getName))
   }
 }


### PR DESCRIPTION
There have been many requests to expose the products of
the repl in some way outside in-memory. This does that.

  scala                        # usual in-memory behavior
  scala -Yrepl-outdir ""       # make up a temp dir
  scala -Yrepl-outdir /foo/bar # use /foo/bar
