### PR TITLE
SI-6581 fixed by inlining `Actor.self`.

### DIFF
--- a/src/actors/scala/actors/remote/NetKernel.scala
+++ b/src/actors/scala/actors/remote/NetKernel.scala
@@ -60,7 +60,7 @@ private[remote] class NetKernel(service: Service) {
     send(node, name, msg, 'nosession)
 
   def send(node: Node, name: Symbol, msg: AnyRef, session: Symbol) {
-    val senderLoc = Locator(service.node, getOrCreateName(Actor.self))
+    val senderLoc = Locator(service.node, getOrCreateName(Actor.self(Scheduler)))
     val receiverLoc = Locator(node, name)
     namedSend(senderLoc, receiverLoc, msg, session)
   }

--- a/src/actors/scala/actors/remote/RemoteActor.scala
+++ b/src/actors/scala/actors/remote/RemoteActor.scala
@@ -40,7 +40,7 @@ package remote
  */
 object RemoteActor {
 
-  private val kernels = new scala.collection.mutable.HashMap[Actor, NetKernel]
+  private val kernels = new scala.collection.mutable.HashMap[InternalActor, NetKernel]
 
   /* If set to <code>null</code> (default), the default class loader
    * of <code>java.io.ObjectInputStream</code> is used for deserializing
@@ -62,7 +62,7 @@ object RemoteActor {
   private def createNetKernelOnPort(port: Int): NetKernel = {
     val serv = TcpService(port, cl)
     val kern = serv.kernel
-    val s = Actor.self
+    val s = Actor.self(Scheduler)
     kernels += Pair(s, kern)
 
     s.onTerminate {
@@ -86,10 +86,10 @@ object RemoteActor {
    * node.
    */
   def register(name: Symbol, a: Actor): Unit = synchronized {
-    val kernel = kernels.get(Actor.self) match {
+    val kernel = kernels.get(Actor.self(Scheduler)) match {
       case None =>
         val serv = TcpService(TcpService.generatePort, cl)
-        kernels += Pair(Actor.self, serv.kernel)
+        kernels += Pair(Actor.self(Scheduler), serv.kernel)
         serv.kernel
       case Some(k) =>
         k
@@ -97,7 +97,7 @@ object RemoteActor {
     kernel.register(name, a)
   }
 
-  private def selfKernel = kernels.get(Actor.self) match {
+  private def selfKernel = kernels.get(Actor.self(Scheduler)) match {
     case None =>
       // establish remotely accessible
       // return path (sender)

--- a/test/files/jvm/actmig-remote-actor-self.check
+++ b/test/files/jvm/actmig-remote-actor-self.check
@@ -1,0 +1,1 @@
+registered

--- a/test/files/jvm/actmig-remote-actor-self.scala
+++ b/test/files/jvm/actmig-remote-actor-self.scala
@@ -1,0 +1,34 @@
+/**
+ * NOTE: Code snippets from this test are included in the Actor Migration Guide. In case you change
+ * code in these tests prior to the 2.10.0 release please send the notification to @vjovanov.
+ */
+import scala.actors._
+import scala.actors.migration._
+import scala.actors.remote._
+import scala.actors.remote.RemoteActor._
+import scala.concurrent._
+import scala.concurrent.duration._
+
+object Test {
+  val finished = Promise[Boolean]
+
+  def main(args: Array[String]): Unit = {
+
+    // can fail with class cast exception in alive
+    val myAkkaActor = ActorDSL.actor(new StashingActor {
+      override def preStart() = {
+        alive(42013)
+        println("registered")
+        finished success true
+        context.stop(self)
+      }
+
+      def receive = {
+        case x: Int =>
+      }
+    })
+
+    Await.result(finished.future, Duration.Inf).toString
+  }
+
+}


### PR DESCRIPTION
This avoids the necessary type cast that was preventing leakage of internal migration classes.

Review by @phaller
