### PR TITLE
Fixes SI-6556 by converting asserts to logging.

### DIFF
--- a/src/reflect/scala/reflect/internal/transform/Erasure.scala
+++ b/src/reflect/scala/reflect/internal/transform/Erasure.scala
@@ -214,14 +214,29 @@ trait Erasure {
         specialConstructorErasure(clazz, restpe)
       case ExistentialType(tparams, restpe) =>
         specialConstructorErasure(clazz, restpe)
+      case RefinedType(parents, decls) =>
+        specialConstructorErasure(
+          clazz, specialScalaErasure.mergeParents(parents))
       case mt @ MethodType(params, restpe) =>
         MethodType(
           cloneSymbolsAndModify(params, specialScalaErasure),
           specialConstructorErasure(clazz, restpe))
-      case TypeRef(pre, `clazz`, args) =>
+      case TypeRef(pre, clazz1, args) =>
+        if (clazz != clazz1) {
+          // See SI-6556. It seems in some cases the result constructor
+          // type of an anonymous class is a different version of the class.
+          // This has nothing to do with value classes per se.
+          // We simply used a less discriminating transform before, that
+          // did not look at the cases in detail.
+          // It seems there is a deeper problem here, which needs
+          // following up to. But we will not risk regressions
+          // in 2.10 because of it.
+          log(s"unexpected constructor erasure $clazz, is different from class $clazz1")
+        }
         typeRef(pre, clazz, List())
       case tp =>
-        assert(clazz == ArrayClass || tp.isError, s"unexpected constructor erasure $tp for $clazz")
+        if (!(clazz == ArrayClass || tp.isError))
+          log(s"unexpected constructor erasure $tp for $clazz")
         specialScalaErasure(tp)
     }
   }


### PR DESCRIPTION
Previous fix to value classes uncovered some questionable cases in the backend where result types of constructor signatures are surprising. It's not a big deal because these types will be ignored afterwards anyway. But
the method uncovered some questionable situations which we should follow up on. However, breaking 2.9 code because of this is way too harsh. That's why the asserts were converted to warnings.
