### PR TITLE
Fixes SI-6556 by converting asserts to logging.

### DIFF
--- a/src/reflect/scala/reflect/internal/transform/Erasure.scala
+++ b/src/reflect/scala/reflect/internal/transform/Erasure.scala
@@ -214,6 +214,9 @@ trait Erasure {
         specialConstructorErasure(clazz, restpe)
       case ExistentialType(tparams, restpe) =>
         specialConstructorErasure(clazz, restpe)
+      case RefinedType(parents, decls) =>
+        specialConstructorErasure(
+          clazz, specialScalaErasure.mergeParents(parents))
       case mt @ MethodType(params, restpe) =>
         MethodType(
           cloneSymbolsAndModify(params, specialScalaErasure),
@@ -221,7 +224,16 @@ trait Erasure {
       case TypeRef(pre, `clazz`, args) =>
         typeRef(pre, clazz, List())
       case tp =>
-        assert(clazz == ArrayClass || tp.isError, s"unexpected constructor erasure $tp for $clazz")
+        if (!(clazz == ArrayClass || tp.isError))
+          // See SI-6556. It seems in some cases the result constructor
+          // type of an anonymous class is a different version of the class.
+          // This has nothing to do with value classes per se.
+          // We simply used a less discriminating transform before, that
+          // did not look at the cases in detail.
+          // It seems there is a deeper problem here, which needs
+          // following up to. But we will not risk regressions
+          // in 2.10 because of it.
+          log(s"unexpected constructor erasure $tp for $clazz")
         specialScalaErasure(tp)
     }
   }

--- a/src/reflect/scala/reflect/internal/transform/Erasure.scala
+++ b/src/reflect/scala/reflect/internal/transform/Erasure.scala
@@ -233,7 +233,7 @@ trait Erasure {
           // It seems there is a deeper problem here, which needs
           // following up to. But we will not risk regressions
           // in 2.10 because of it.
-          log(s"unexpected constructor erasure $tp for $clazz")
+          log(s"!!! unexpected constructor erasure $tp for $clazz")
         specialScalaErasure(tp)
     }
   }

--- a/test/files/pos/t6556.scala
+++ b/test/files/pos/t6556.scala
@@ -1,0 +1,32 @@
+package nl.ndervorst.commons.scalapimps
+
+trait Adapter[X] {self =>
+  type This = self.type
+  val adaptee: X
+  val adapt: This = self
+}
+
+object Adapter {
+  implicit def adaptee[Adaptee](adapter: Adapter[Adaptee]) = adapter.adaptee
+}
+
+
+
+object IterableW {
+  def zipMerge[E](it1: Iterable[E], it2: Iterable[E])(implicit o: Ordering[E]): Iterable[(Option[E], Option[E])] = null
+}
+
+
+class Series[X: Ordering, Y](val adaptee: Iterable[(X, Y)]) extends Adapter[Iterable[(X, Y)]] {
+  val order = implicitly[Ordering[X]]
+  def zipMerge(other: Series[X, Y]): Series[X, (Option[Y], Option[Y])] = IterableW.zipMerge(this, other)(new Ordering[(X, Y)] {
+    def compare(xy1: (X, Y), xy2: (X, Y)) = order.compare(xy1._1, xy2._1)
+  }).map {
+    case _ => null
+  }
+}
+
+
+object Series {
+  implicit def wrap[X: Ordering, Y](itble: Iterable[(X, Y)]): Series[X, Y] = new Series(itble)
+}


### PR DESCRIPTION
Previous fix to value classes uncovered some questionable cases in the backend where result types of constructor signatures are surprising. It's not a big deal because these types will be ignored afterwards anyway. But the method uncovered some questionable situations which we should follow up on. However, breaking 2.9 code because of this is way too harsh. That's why the asserts were converted to warnings.

review by @paulp, @adriaanm
