### PR TITLE
Fixes SI-6500 by making erasure more regular.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -469,7 +469,7 @@ abstract class Erasure extends AddInterfaces
     }
 
     def checkPair(member: Symbol, other: Symbol) {
-      val otpe = erasure(root)(other.tpe)
+      val otpe = specialErasure(root)(other.tpe)
       val bridgeNeeded = afterErasure (
         !(other.tpe =:= member.tpe) &&
         !(deconstMap(other.tpe) =:= deconstMap(member.tpe)) &&
@@ -488,7 +488,7 @@ abstract class Erasure extends AddInterfaces
       debuglog("generating bridge from %s (%s): %s to %s: %s".format(
         other, flagsToString(newFlags),
         otpe + other.locationString, member,
-        erasure(root)(member.tpe) + member.locationString)
+        specialErasure(root)(member.tpe) + member.locationString)
       )
 
       // the parameter symbols need to have the new owner
@@ -1118,6 +1118,8 @@ abstract class Erasure extends AddInterfaces
               } else {
                 // store exact array erasure in map to be retrieved later when we might
                 // need to do the cast in adaptMember
+                // Note: No specialErasure needed here because we simply cast, on
+                // elimination of SelectFromArray, no boxing or unboxing is done there.
                 treeCopy.Apply(
                   tree,
                   SelectFromArray(qual, name, erasure(tree.symbol)(qual.tpe)).copyAttrs(fn),

--- a/test/files/run/t6500.scala
+++ b/test/files/run/t6500.scala
@@ -1,0 +1,13 @@
+object Test extends App {
+  class Box(val value: Int) extends AnyVal
+
+  trait Foo {
+    def append(box: Box): Foo
+  }
+
+  class Bar extends Foo {
+    override def append(box: Box): Bar = this // produces bad forwarder
+  }
+
+  ((new Bar): Foo).append(new Box(0))
+}


### PR DESCRIPTION
With the introduction of value classes, erasure uses specialErasure where a value class C with underlying type T is unboxed to an ErasedValueType. ErasedValue types are eliminated one phase later, in post-erasure. This was done everywhere, except in the parameter types of bridge methods. That was a mistake, because that way  bridge methods could not do the boxing/unboxing logic triggered by ErasedValueTypes.

Note: there is one remaining use of erasure (not specialErasure) in Erasure.scala. I put in a comment why that is OK.

Review by @paulp @adriaanm
