### PR TITLE
Fix for SI-6597, implicit case class crasher.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -414,7 +414,7 @@ trait Namers extends MethodSynthesis {
      *  a module definition or a class definition.
      */
     def enterModuleSymbol(tree : ModuleDef): Symbol = {
-      var m: Symbol = context.scope.lookup(tree.name)
+      var m: Symbol = context.scope lookupAll tree.name find (_.isModule) getOrElse NoSymbol
       val moduleFlags = tree.mods.flags | MODULE
       if (m.isModule && !m.isPackage && inCurrentScope(m) && (currentRun.canRedefine(m) || m.isSynthetic)) {
         updatePosFlags(m, tree.pos, moduleFlags)

--- a/test/files/neg/t6597.check
+++ b/test/files/neg/t6597.check
@@ -1,0 +1,4 @@
+t6597.scala:3: error: illegal combination of modifiers: implicit and case for: class Quux
+  implicit case class Quux(value: Int) extends AnyVal with T
+                      ^
+one error found

--- a/test/files/neg/t6597.scala
+++ b/test/files/neg/t6597.scala
@@ -1,0 +1,5 @@
+object Test {
+  trait T extends Any
+  implicit case class Quux(value: Int) extends AnyVal with T
+  object Quux
+}


### PR DESCRIPTION
It seems to me like every call to scope.lookup in the
compiler is a latent bug. If a symbol is overloaded, you
get one at random. (See the FIXME comment in f5c336d5660
for more on this.)
