### PR TITLE
Fix for SI-6600, regression with ScalaNumber.

### DIFF
--- a/src/library/scala/math/ScalaNumericConversions.scala
+++ b/src/library/scala/math/ScalaNumericConversions.scala
@@ -10,15 +10,22 @@ package scala.math
 
 import java.{ lang => jl }
 
-/** Conversions which present a consistent conversion interface
- *  across all the numeric types.
+/** A slightly more specific conversion trait for classes which
+ *  extend ScalaNumber (which excludes value classes.)
  */
-trait ScalaNumericConversions extends Any {
+trait ScalaNumericConversions extends ScalaNumber with ScalaNumericAnyConversions {
+  def underlying(): Object
+}
+
+/** Conversions which present a consistent conversion interface
+ *  across all the numeric types, suitable for use in value classes.
+ */
+trait ScalaNumericAnyConversions extends Any {
   def isWhole(): Boolean
   def underlying(): Any
 
-  def byteValue(): Byte = intValue().toByte
-  def shortValue(): Short = intValue().toShort
+  def byteValue(): Byte
+  def shortValue(): Short
   def intValue(): Int
   def longValue(): Long
   def floatValue(): Float

--- a/src/library/scala/runtime/ScalaNumberProxy.scala
+++ b/src/library/scala/runtime/ScalaNumberProxy.scala
@@ -9,7 +9,7 @@
 package scala.runtime
 
 import scala.collection.{ mutable, immutable }
-import scala.math.ScalaNumericConversions
+import scala.math.{ ScalaNumericConversions, ScalaNumericAnyConversions }
 import immutable.NumericRange
 import Proxy.Typed
 
@@ -20,7 +20,7 @@ import Proxy.Typed
  *  @version 2.9
  *  @since   2.9
  */
-trait ScalaNumberProxy[T] extends Any with ScalaNumericConversions with Typed[T] with OrderedProxy[T] {
+trait ScalaNumberProxy[T] extends Any with ScalaNumericAnyConversions with Typed[T] with OrderedProxy[T] {
   protected implicit def num: Numeric[T]
 
   def underlying()  = self.asInstanceOf[AnyRef]
@@ -28,6 +28,8 @@ trait ScalaNumberProxy[T] extends Any with ScalaNumericConversions with Typed[T]
   def floatValue()  = num.toFloat(self)
   def longValue()   = num.toLong(self)
   def intValue()    = num.toInt(self)
+  def byteValue()   = intValue.toByte
+  def shortValue()  = intValue.toShort
 
   def min(that: T): T = num.min(self, that)
   def max(that: T): T = num.max(self, that)

--- a/test/files/pos/t6600.scala
+++ b/test/files/pos/t6600.scala
@@ -1,0 +1,8 @@
+final class Natural extends scala.math.ScalaNumber with scala.math.ScalaNumericConversions {
+  def intValue(): Int = 0
+  def longValue(): Long = 0L
+  def floatValue(): Float = 0.0F
+  def doubleValue(): Double = 0.0D
+  def isWhole(): Boolean = false
+  def underlying() = this
+}


### PR DESCRIPTION
Not much in the end; I divided ScalaNumericConversions
into two traits such that the ScalaNumericAnyConversions can
be used in value classes, and ScalaNumericConversions can
override methods in ScalaNumber (since one trait cannot do
both those things.)

The fact that ScalaNumber is privileged for equality but a) extends
java.lang.Number and therefore b) cannot be a value class is something
we will want to revisit real soon.
