### PR TITLE
SI-6567 Warning for Option(implicitView(foo))

### DIFF
--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -540,10 +540,12 @@ trait Definitions extends api.StandardDefinitions {
     lazy val ScalaLongSignatureAnnotation = requiredClass[scala.reflect.ScalaLongSignature]
 
     // Option classes
-    lazy val OptionClass: ClassSymbol = requiredClass[Option[_]]
-    lazy val SomeClass: ClassSymbol   = requiredClass[Some[_]]
-    lazy val NoneModule: ModuleSymbol = requiredModule[scala.None.type]
-    lazy val SomeModule: ModuleSymbol = requiredModule[scala.Some.type]
+    lazy val OptionClass: ClassSymbol   = requiredClass[Option[_]]
+    lazy val OptionModule: ModuleSymbol = requiredModule[scala.Option.type]
+      lazy val Option_apply             = getMemberMethod(OptionModule, nme.apply)
+    lazy val SomeClass: ClassSymbol     = requiredClass[Some[_]]
+    lazy val NoneModule: ModuleSymbol   = requiredModule[scala.None.type]
+    lazy val SomeModule: ModuleSymbol   = requiredModule[scala.Some.type]
 
     def compilerTypeFromTag(tt: ApiUniverse # WeakTypeTag[_]): Type = tt.in(rootMirror).tpe
     def compilerSymbolFromTag(tt: ApiUniverse # WeakTypeTag[_]): Symbol = tt.in(rootMirror).tpe.typeSymbol

--- a/test/files/neg/t6567.check
+++ b/test/files/neg/t6567.check
@@ -1,0 +1,9 @@
+t6567.scala:8: warning: Suspicious application of an implicit view (Test.this.a2b) in the argument to Option.apply.
+  Option[B](a)
+           ^
+t6567.scala:10: warning: Suspicious application of an implicit view (Test.this.a2b) in the argument to Option.apply.
+  val b: Option[B] = Option(a)
+                           ^
+error: No warnings can be incurred under -Xfatal-warnings.
+two warnings found
+one error found

--- a/test/files/neg/t6567.flags
+++ b/test/files/neg/t6567.flags
@@ -1,0 +1,1 @@
+-Xlint -Xfatal-warnings

--- a/test/files/neg/t6567.scala
+++ b/test/files/neg/t6567.scala
@@ -1,0 +1,11 @@
+class A
+class B
+
+object Test {
+  val a: A = null
+  implicit def a2b(a: A) = new B
+
+  Option[B](a)
+
+  val b: Option[B] = Option(a)
+}


### PR DESCRIPTION
I've seen the reported problem before in the wild. It seems
worthy of a special warning, so long as we advocate `Option.apply`
as an alternative to `if (x == null) Some(x) else None`.

It is behind `-Xlint` at the moment, an option that could do with
some promotion.

Review by @paulp (is it time for Lint.scala?)
