### PR TITLE
Javap for Java 7 (Fixes SI-4936)

### DIFF
--- a/src/compiler/scala/tools/ant/templates/tool-unix.tmpl
+++ b/src/compiler/scala/tools/ant/templates/tool-unix.tmpl
@@ -102,6 +102,9 @@ if [[ -n "$cygwin" ]]; then
         format=windows
     fi
     SCALA_HOME="$(cygpath --$format "$SCALA_HOME")"
+    if [[ -n "$JAVA_HOME" ]]; then
+        JAVA_HOME="$(cygpath --$format "$JAVA_HOME")"
+    fi
     TOOL_CLASSPATH="$(cygpath --path --$format "$TOOL_CLASSPATH")"
 elif [[ -n "$mingw" ]]; then
     SCALA_HOME="$(cmd //c echo "$SCALA_HOME")"

--- a/src/compiler/scala/tools/nsc/backend/jvm/BytecodeWriters.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BytecodeWriters.scala
@@ -9,7 +9,7 @@ package backend.jvm
 import java.io.{ DataOutputStream, FileOutputStream, OutputStream, File => JFile }
 import scala.tools.nsc.io._
 import scala.tools.nsc.util.ScalaClassLoader
-import scala.tools.util.JavapClass
+import scala.tools.util.{ Javap, JavapClass }
 import java.util.jar.{ JarEntry, JarOutputStream, Attributes }
 import Attributes.Name
 import scala.language.postfixOps
@@ -60,27 +60,32 @@ trait BytecodeWriters {
     override def close() = writer.close()
   }
 
+  /** To be mixed-in with the BytecodeWriter that generates
+   *  the class file to be disassembled.
+   */
   trait JavapBytecodeWriter extends BytecodeWriter {
     val baseDir = Directory(settings.Ygenjavap.value).createDirectory()
+    val cl      = ScalaClassLoader.appLoader
 
-    def emitJavap(bytes: Array[Byte], javapFile: io.File) {
-      val pw    = javapFile.printWriter()
-      val javap = new JavapClass(ScalaClassLoader.appLoader, pw) {
-        override def findBytes(path: String): Array[Byte] = bytes
-      }
-
-      try javap(Seq("-verbose", "dummy")) foreach (_.show())
-      finally pw.close()
+    def emitJavap(classFile: AbstractFile, javapFile: File) {
+      val pw = javapFile.printWriter()
+      try {
+        val javap = new JavapClass(cl, pw) {
+          override def findBytes(path: String): Array[Byte] = classFile.toByteArray
+        }
+        javap(Seq("-verbose", "-protected", classFile.name)) foreach (_.show())
+      } finally pw.close()
     }
     abstract override def writeClass(label: String, jclassName: String, jclassBytes: Array[Byte], sym: Symbol) {
       super.writeClass(label, jclassName, jclassBytes, sym)
 
-      val bytes     = getFile(sym, jclassName, ".class").toByteArray
+      val classFile = getFile(sym, jclassName, ".class")
       val segments  = jclassName.split("[./]")
       val javapFile = segments.foldLeft(baseDir: Path)(_ / _) changeExtension "javap" toFile;
-
       javapFile.parent.createDirectory()
-      emitJavap(bytes, javapFile)
+
+      if (Javap.isAvailable(cl)) emitJavap(classFile, javapFile)
+      else warning("No javap on classpath, skipping javap output.")
     }
   }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
@@ -130,13 +130,18 @@ abstract class GenASM extends SubComponent with BytecodeWriters {
           new DirectToJarfileWriter(f.file)
 
         case _                               =>
+          import scala.tools.util.Javap
           if (settings.Ygenjavap.isDefault) {
             if(settings.Ydumpclasses.isDefault)
               new ClassBytecodeWriter { }
             else
               new ClassBytecodeWriter with DumpBytecodeWriter { }
           }
-          else new ClassBytecodeWriter with JavapBytecodeWriter { }
+          else if (Javap.isAvailable()) new ClassBytecodeWriter with JavapBytecodeWriter { }
+          else {
+            warning("No javap on classpath, skipping javap output.")
+            new ClassBytecodeWriter { }
+          }
 
           // TODO A ScalapBytecodeWriter could take asm.util.Textifier as starting point.
           //      Three areas where javap ouput is less than ideal (e.g. when comparing versions of the same classfile) are:

--- a/src/compiler/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/ILoop.scala
@@ -432,8 +432,8 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
   private def javapCommand(line: String): Result = {
     if (javap == null)
       ":javap unavailable, no tools.jar at %s.  Set JDK_HOME.".format(jdkHome)
-    else if (javaVersion startsWith "1.7")
-      ":javap not yet working with java 1.7"
+    //else if (javaVersion startsWith "1.7")
+    //  ":javap not yet working with java 1.7"
     else if (line == "")
       ":javap [-lcsvp] [path1 path2 ...]"
     else

--- a/src/compiler/scala/tools/util/Javap.scala
+++ b/src/compiler/scala/tools/util/Javap.scala
@@ -6,13 +6,18 @@
 package scala.tools
 package util
 
-import java.lang.reflect.{ GenericSignatureFormatError, Method, Constructor }
-import java.lang.{ ClassLoader => JavaClassLoader }
+import java.lang.{ ClassLoader => JavaClassLoader, Iterable => JIterable }
 import scala.tools.nsc.util.ScalaClassLoader
-import java.io.{ InputStream, PrintWriter, ByteArrayInputStream, FileNotFoundException }
+import java.io.{ ByteArrayInputStream, CharArrayWriter, FileNotFoundException, InputStream,
+                 PrintWriter, Writer }
+import javax.tools.{ DiagnosticListener, JavaFileManager, JavaFileObject, SimpleJavaFileObject,
+                     StandardLocation }
 import scala.tools.nsc.io.File
-import Javap._
+import scala.util.{ Properties, Try, Success, Failure }
+import scala.collection.JavaConverters
 import scala.language.reflectiveCalls
+
+import Javap._
 
 trait Javap {
   def loader: ScalaClassLoader
@@ -35,45 +40,28 @@ class JavapClass(
   val printWriter: PrintWriter = new PrintWriter(System.out, true)
 ) extends Javap {
 
-  lazy val parser = new JpOptions
+  lazy val tool = JavapTool(loader, printWriter)
 
-  val EnvClass     = loader.tryToInitializeClass[FakeEnvironment](Env).orNull
-  val PrinterClass = loader.tryToInitializeClass[FakePrinter](Printer).orNull
-  private def failed = (EnvClass eq null) || (PrinterClass eq null)
-
-  val PrinterCtr   = (
-    if (failed) null
-    else PrinterClass.getConstructor(classOf[InputStream], classOf[PrintWriter], EnvClass)
-  )
-
-  def findBytes(path: String): Array[Byte] =
-    tryFile(path) getOrElse tryClass(path)
-
+  /** Run the tool. Option args start with "-".
+   *  The default options are "-protected -verbose".
+   *  Byte data for filename args is retrieved with findBytes.
+   *  If the filename does not end with ".class", javap will
+   *  insert a banner of the form:
+   *  `Binary file dummy contains simple.Complex`.
+   */
   def apply(args: Seq[String]): List[JpResult] = {
-    if (failed) Nil
-    else args.toList filterNot (_ startsWith "-") map { path =>
-      val bytes = findBytes(path)
-      if (bytes.isEmpty) new JpError("Could not find class bytes for '%s'".format(path))
-      else new JpSuccess(newPrinter(new ByteArrayInputStream(bytes), newEnv(args)))
-    }
+    val (optional, claases) = args partition (_ startsWith "-")
+    val options = if (optional.nonEmpty) optional else JavapTool.DefaultOptions
+    tool(options)(claases map (claas => claas -> bytesFor(claas)))
   }
 
-  def newPrinter(in: InputStream, env: FakeEnvironment): FakePrinter =
-    if (failed) null
-    else PrinterCtr.newInstance(in, printWriter, env)
-
-  def newEnv(opts: Seq[String]): FakeEnvironment = {
-    lazy val env: FakeEnvironment = EnvClass.newInstance()
-
-    if (failed) null
-    else parser(opts) foreach { case (name, value) =>
-      val field = EnvClass getDeclaredField name
-      field setAccessible true
-      field.set(env, value.asInstanceOf[AnyRef])
-    }
-
-    env
+  private def bytesFor(path: String) = Try {
+    val bytes = findBytes(path)
+    if (bytes.isEmpty) throw new FileNotFoundException(s"Could not find class bytes for '${path}'")
+    else bytes
   }
+
+  def findBytes(path: String): Array[Byte] = tryFile(path) getOrElse tryClass(path)
 
   /** Assume the string is a path and try to find the classfile
    *  it represents.
@@ -89,52 +77,164 @@ class JavapClass(
   /** Assume the string is a fully qualified class name and try to
    *  find the class object it represents.
    */
-  def tryClass(path: String): Array[Byte] = {
-    val extName = (
-      if (path endsWith ".class") (path dropRight 6).replace('/', '.')
-      else path
-    )
-    loader.classBytes(extName)
+  def tryClass(path: String): Array[Byte] = loader classBytes {
+    if (path endsWith ".class") (path dropRight 6).replace('/', '.')
+    else path
   }
 }
 
-object Javap {
+abstract class JavapTool {
+  type ByteAry = Array[Byte]
+  type Input = Pair[String, Try[ByteAry]]
+  def apply(options: Seq[String])(inputs: Seq[Input]): List[JpResult]
+  // Since the tool is loaded by reflection, check for catastrophic failure.
+  protected def failed: Boolean
+  implicit protected class Failer[A](a: =>A) {
+    def orFailed[B >: A](b: =>B) = if (failed) b else a
+  }
+  protected def noToolError = new JpError(s"No javap tool available: ${getClass.getName} failed to initialize.")
+}
+
+class JavapTool6(loader: ScalaClassLoader, printWriter: PrintWriter) extends JavapTool {
+  import JavapTool._
+  val EnvClass     = loader.tryToInitializeClass[FakeEnvironment](Env).orNull
+  val PrinterClass = loader.tryToInitializeClass[FakePrinter](Printer).orNull
+  override protected def failed = (EnvClass eq null) || (PrinterClass eq null)
+
+  val PrinterCtr = PrinterClass.getConstructor(classOf[InputStream], classOf[PrintWriter], EnvClass) orFailed null
+  def newPrinter(in: InputStream, env: FakeEnvironment): FakePrinter =
+    PrinterCtr.newInstance(in, printWriter, env) orFailed null
+  def showable(fp: FakePrinter) = new Showable {
+    def show() = fp.asInstanceOf[{ def print(): Unit }].print()
+  }
+
+  lazy val parser = new JpOptions
+  def newEnv(opts: Seq[String]): FakeEnvironment = {
+    def result = {
+      val env: FakeEnvironment = EnvClass.newInstance()
+      parser(opts) foreach { case (name, value) =>
+        val field = EnvClass getDeclaredField name
+        field setAccessible true
+        field.set(env, value.asInstanceOf[AnyRef])
+      }
+      env
+    }
+    result orFailed null
+  }
+
+  override def apply(options: Seq[String])(inputs: Seq[Input]): List[JpResult] =
+    (inputs map {
+      case (_, Success(ba)) => new JpSuccess(showable(newPrinter(new ByteArrayInputStream(ba), newEnv(options))))
+      case (_, Failure(e))  => new JpError(e.toString)
+    }).toList orFailed List(noToolError)
+}
+
+class JavapTool7(loader: ScalaClassLoader, printWriter: PrintWriter) extends JavapTool {
+  import JavapTool._
+  type Task = {
+    def call(): Boolean                             // true = ok
+    //def run(args: Array[String]): Int             // all args
+    //def handleOptions(args: Array[String]): Unit  // options, then run() or call()
+  }
+  // result of Task.run
+  //object TaskResult extends Enumeration {
+  //  val Ok, Error, CmdErr, SysErr, Abnormal = Value
+  //}
+  val TaskClaas = loader.tryToInitializeClass[Task](JavapTool.Tool).orNull
+  override protected def failed = TaskClaas eq null
+
+  val TaskCtor  = TaskClaas.getConstructor(
+    classOf[Writer],
+    classOf[JavaFileManager],
+    classOf[DiagnosticListener[_]],
+    classOf[JIterable[String]],
+    classOf[JIterable[String]]
+  ) orFailed null
+
+  // manages named arrays of bytes, which might have failed to load
+  class JavapFileManager(val managed: Seq[Input]) extends SimpleJavaFileManager {
+    import JavaFileObject.Kind
+    import Kind._
+    import StandardLocation._
+    import JavaFileManager.Location
+    import java.net.URI
+    def uri(name: String): URI = new URI(name) // new URI("jfo:" + name)
+
+    def inputNamed(name: String): Try[ByteAry] = (managed find (_._1 == name)).get._2
+    def managedFile(name: String, kind: Kind) = kind match {
+      case CLASS  => fileObjectForInput(name, inputNamed(name), kind)
+      case _      => null
+    }
+    // todo: just wrap it as scala abstractfile and adapt it uniformly
+    def fileObjectForInput(name: String, bytes: Try[ByteAry], kind: Kind): JavaFileObject =
+      new SimpleJavaFileObject(uri(name), kind) {
+        override def openInputStream(): InputStream = new ByteArrayInputStream(bytes.get)
+        // if non-null, ClassWriter wrongly requires scheme non-null
+        override def toUri: URI = null
+        override def getName: String = name
+        // suppress
+        override def getLastModified: Long = -1L
+      }
+    override def getJavaFileForInput(location: Location, className: String, kind: Kind): JavaFileObject =
+      location match {
+        case CLASS_PATH => managedFile(className, kind)
+        case _          => null
+      }
+    override def hasLocation(location: Location): Boolean =
+      location match {
+        case CLASS_PATH => true
+        case _          => false
+      }
+  }
+  def fileManager(inputs: Seq[Input]) = new JavapFileManager(inputs)
+  val reporter = new JavaReporter
+  val writer = new CharArrayWriter
+  def showable(): Showable = {
+    val written = {
+      writer.flush()
+      val w = writer.toString
+      writer.reset()
+      w
+    }
+    val msgs = {
+      import Properties.lineSeparator
+      val m = reporter.messages
+      if (m.nonEmpty) m mkString ("", lineSeparator, lineSeparator)
+      else ""
+    }
+    new Showable {
+      def show() = printWriter.write(msgs + written)
+    }
+  }
+  // eventually, use the tool interface
+  def task(options: Seq[String], claases: Seq[String], inputs: Seq[Input]): Task = {
+    //ServiceLoader.load(classOf[javax.tools.DisassemblerTool]).
+    //getTask(writer, fileManager, reporter, options.asJava, claases.asJava)
+    import JavaConverters.asJavaIterableConverter
+    TaskCtor.newInstance(writer, fileManager(inputs), reporter, options.asJava, claases.asJava)
+      .orFailed (throw new IllegalStateException)
+  }
+  // a result per input
+  override def apply(options: Seq[String])(inputs: Seq[Input]): List[JpResult] = (inputs map {
+    case (claas, Success(ba)) =>
+      if (task(options, Seq(claas), inputs).call()) new JpSuccess(showable())
+      else new JpError(reporter.messages mkString ",")
+    case (_, Failure(e))      => new JpError(e.toString)
+  }).toList orFailed List(noToolError)
+}
+
+object JavapTool {
+  // >= 1.7
+  val Tool    = "com.sun.tools.javap.JavapTask"
+
+  // < 1.7
   val Env     = "sun.tools.javap.JavapEnvironment"
   val Printer = "sun.tools.javap.JavapPrinter"
-
-  def isAvailable(cl: ScalaClassLoader = ScalaClassLoader.appLoader) =
-    cl.tryToInitializeClass[AnyRef](Env).isDefined
-
   // "documentation"
   type FakeEnvironment = AnyRef
   type FakePrinter = AnyRef
 
-  def apply(path: String): Unit      = apply(Seq(path))
-  def apply(args: Seq[String]): Unit = new JavapClass() apply args foreach (_.show())
-
-  sealed trait JpResult {
-    type ResultType
-    def isError: Boolean
-    def value: ResultType
-    def show(): Unit
-    // todo
-    // def header(): String
-    // def fields(): List[String]
-    // def methods(): List[String]
-    // def signatures(): List[String]
-  }
-  class JpError(msg: String) extends JpResult {
-    type ResultType = String
-    def isError = true
-    def value = msg
-    def show() = println(msg)
-  }
-  class JpSuccess(val value: AnyRef) extends JpResult {
-    type ResultType = AnyRef
-    def isError = false
-    def show() = value.asInstanceOf[{ def print(): Unit }].print()
-  }
-
+  // support JavapEnvironment
   class JpOptions {
     private object Access {
       final val PRIVATE = 0
@@ -171,5 +271,51 @@ object Javap {
         }
       }
     }
+  }
+
+  val DefaultOptions = List("-protected", "-verbose")
+
+  def isAvailable(cl: ScalaClassLoader = ScalaClassLoader.appLoader) = Seq(Env, Tool) exists (cn => hasClass(cl, cn))
+
+  private def hasClass(cl: ScalaClassLoader, cn: String) = cl.tryToInitializeClass[AnyRef](cn).isDefined
+
+  private def isTaskable(cl: ScalaClassLoader) = hasClass(cl, Tool)
+
+  def apply(cl: ScalaClassLoader, pw: PrintWriter) =
+    if (isTaskable(cl)) new JavapTool7(cl, pw) else new JavapTool6(cl, pw)
+}
+
+object Javap {
+
+  def isAvailable(cl: ScalaClassLoader = ScalaClassLoader.appLoader) = JavapTool.isAvailable(cl)
+
+  def apply(path: String): Unit      = apply(Seq(path))
+  def apply(args: Seq[String]): Unit = new JavapClass() apply args foreach (_.show())
+
+  trait Showable {
+    def show(): Unit
+  }
+
+  sealed trait JpResult {
+    type ResultType
+    def isError: Boolean
+    def value: ResultType
+    def show(): Unit
+    // todo
+    // def header(): String
+    // def fields(): List[String]
+    // def methods(): List[String]
+    // def signatures(): List[String]
+  }
+  class JpError(msg: String) extends JpResult {
+    type ResultType = String
+    def isError = true
+    def value = msg
+    def show() = println(msg)   // makes sense for :javap, less for -Ygen-javap
+  }
+  class JpSuccess(val value: Showable) extends JpResult {
+    type ResultType = AnyRef
+    def isError = false
+    def show() = value.show()   // output to tool's PrintWriter
   }
 }

--- a/src/compiler/scala/tools/util/JavaxTools.scala
+++ b/src/compiler/scala/tools/util/JavaxTools.scala
@@ -1,0 +1,80 @@
+/* NSC -- new Scala compiler
+ * Copyright 2005-2012 LAMP/EPFL
+ * @author Paul Phillips
+ */
+
+package scala.tools
+package util
+
+import java.lang.{ ClassLoader => JavaClassLoader, Iterable => JIterable }
+import java.util.{ Iterator => JIterator, Locale, Set => JSet }
+import javax.tools.{ FileObject, JavaFileManager, JavaFileObject }
+import javax.tools.{ Diagnostic, DiagnosticCollector, DiagnosticListener }
+
+/** Degenerate implementation, by analogy to [[javax.tools.SimpleJavaFileObject]]. */
+abstract class SimpleJavaFileManager extends JavaFileManager {
+  import JavaFileObject.Kind
+  import JavaFileManager.Location
+
+  @inline private final def ??! = throw new UnsupportedOperationException
+
+  /** Does nothing. */
+  override def close() { }
+  /** Does nothing. */
+  override def flush() { }
+  /** Unsupported. */
+  override def getClassLoader(location: Location): JavaClassLoader = ??!
+  /** Unsupported. */
+  override def getFileForInput(location: Location, packageName: String, relativeName: String): FileObject = ??!
+  /** Unsupported. */
+  override def getFileForOutput(location: Location, packageName: String, relativeName: String, sibling: FileObject): FileObject = ??!
+  /** Unsupported. */
+  override def getJavaFileForInput(location: Location, className: String, kind: Kind): JavaFileObject = ??!
+  /** Unsupported. */
+  override def getJavaFileForOutput(location: Location, className: String, kind: Kind, sibling: FileObject): JavaFileObject = ??!
+  /** False. */
+  override def handleOption(current: String, remaining: JIterator[String]): Boolean = false
+  /** False. */
+  override def hasLocation(location: Location): Boolean = false
+      /*
+      location match {
+        case s: StandardLocation =>
+          s match {
+            case ANNOTATION_PROCESSOR_PATH => false
+            case CLASS_OUTPUT => false
+            case CLASS_PATH => false
+            case PLATFORM_CLASS_PATH => false
+            case SOURCE_OUTPUT => false
+            case SOURCE_PATH => false
+          }
+        case _ => false
+      }
+      */
+  /** Unsupported. */
+  override def inferBinaryName(location: Location, file: JavaFileObject): String = ??!
+  /** Unsupported. */
+  override def isSameFile(a: FileObject, b: FileObject): Boolean = ??!
+  /** Unsupported. */
+  override def list(location: Location, packageName: String, kinds: JSet[Kind], recurse: Boolean): JIterable[JavaFileObject] = ??!
+  final val NotSupported = -1
+  /** Always -1 (option not supported). */
+  override def isSupportedOption(option: String): Int = NotSupported
+}
+
+/** A rich [[javax.tools.DiagnosticCollector]]. */
+class JavaReporter extends DiagnosticListener[JavaFileObject] {
+  import Diagnostic.Kind.ERROR
+  import scala.collection.JavaConverters.iterableAsScalaIterableConverter
+  val collector = new DiagnosticCollector[JavaFileObject]
+  override def report(diagnostic: Diagnostic[_ <: JavaFileObject]) { collector report diagnostic }
+  /** All diagnostics in the collector. */
+  def diagnostics: Iterable[Diagnostic[_ <: JavaFileObject]] = collector.getDiagnostics.asScala
+  /** Locale for diagnostic messages, null by default. */
+  def locale: Locale = null
+  /** All diagnostic messages. */
+  def messages = (diagnostics map (_ getMessage locale)).toList
+  /** Count the errors. */
+  def errorCount: Int = (0 /: diagnostics)((sum, d) => sum + (if (d.getKind == ERROR) 1 else 0))
+  /** Error diagnostics in the collector. */
+  def errors = (diagnostics filter (_.getKind == ERROR)).toList
+}


### PR DESCRIPTION
Add support for reflective invocation of javap under jdk7,
using the quasi-javax.tools API.

Under -Ygen-javap, warn if you can't.

Since JAVA_HOME is used to locate tools.jar, the script is
updated to convert it for cygwin.

A par-test awaits a fix for SI-6026 and perhaps consensus on usage of tests requiring tools.jar, e.g., whether a missing tools.jar should fail the test or skip it.  Jenkins knows if java.home is set correctly.  That's why he's Jenkins.

But this will be moot after the asm textifier.
