### PR TITLE
Fixes an oversight in recent array optimization.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -628,7 +628,7 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
         super.transform(arg)
       case Apply(appMeth, List(elem0, Apply(wrapArrayMeth, List(rest @ ArrayValue(elemtpt, _)))))
       if wrapArrayMeth.symbol == Predef_wrapArray(elemtpt.tpe) && appMeth.symbol == ArrayModule_apply(elemtpt.tpe) =>
-        super.transform(rest.copy(elems = elem0 :: rest.elems))
+        super.transform(rest.copy(elems = elem0 :: rest.elems).setType(rest.tpe))
 
       case _ =>
         super.transform(tree)


### PR DESCRIPTION
In 8265175, I forgot to set the type of the new ArrayValue
tree, and we accidentally merged without approval on the extra
commit by our feline build overlords.

This is an alternative to #1582, which fixes the problem rather than
reverting the optimization.

Review by @lrytz
