### PR TITLE
SI-6539 Annotation for methods unfit for post-typer ASTs

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1377,8 +1377,13 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
     }
 
     private def checkCompileTimeOnly(sym: Symbol, pos: Position) = {
-      if (sym.isCompileTimeOnly)
-        unit.error(pos, s"reference to ${sym.fullLocationString} should not survive typechecking: ${sym.compileTimeOnlyMessage.get}")
+      if (sym.isCompileTimeOnly) {
+        def defaultMsg =
+          s"""|Reference to ${sym.fullLocationString} should not have survived past type checking,
+              |it should have been processed and eliminated during expansion of an enclosing macro.""".stripMargin
+        // The getOrElse part should never happen, it's just here as a backstop.
+        unit.error(pos, sym.compileTimeOnlyMessage getOrElse defaultMsg)
+      }
     }
 
     private def lessAccessible(otherSym: Symbol, memberSym: Symbol): Boolean = (

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1376,6 +1376,11 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
         )
     }
 
+    private def checkCompileTimeOnly(sym: Symbol, pos: Position) = {
+      if (sym.isCompileTimeOnly)
+        unit.error(pos, s"reference to ${sym.fullLocationString} should not survive typechecking: ${sym.compileTimeOnlyMessage.get}")
+    }
+
     private def lessAccessible(otherSym: Symbol, memberSym: Symbol): Boolean = (
          (otherSym != NoSymbol)
       && !otherSym.isProtected
@@ -1562,6 +1567,7 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
       checkDeprecated(sym, tree.pos)
       if (settings.Xmigration28.value)
         checkMigration(sym, tree.pos)
+      checkCompileTimeOnly(sym, tree.pos)
 
       if (sym eq NoSymbol) {
         unit.warning(tree.pos, "Select node has NoSymbol! " + tree + " / " + tree.tpe)

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -944,6 +944,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val BeanPropertyAttr           = requiredClass[scala.beans.BeanProperty]
     lazy val BooleanBeanPropertyAttr    = requiredClass[scala.beans.BooleanBeanProperty]
     lazy val CloneableAttr              = requiredClass[scala.annotation.cloneable]
+    lazy val CompileTimeOnlyAttr        = requiredClass[scala.reflect.macros.compileTimeOnly]
     lazy val DeprecatedAttr             = requiredClass[scala.deprecated]
     lazy val DeprecatedNameAttr         = requiredClass[scala.deprecatedName]
     lazy val DeprecatedInheritanceAttr  = requiredClass[scala.deprecatedInheritance]

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -944,7 +944,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val BeanPropertyAttr           = requiredClass[scala.beans.BeanProperty]
     lazy val BooleanBeanPropertyAttr    = requiredClass[scala.beans.BooleanBeanProperty]
     lazy val CloneableAttr              = requiredClass[scala.annotation.cloneable]
-    lazy val CompileTimeOnlyAttr        = requiredClass[scala.reflect.macros.compileTimeOnly]
+    lazy val CompileTimeOnlyAttr        = getClassIfDefined("scala.reflect.macros.compileTimeOnly")
     lazy val DeprecatedAttr             = requiredClass[scala.deprecated]
     lazy val DeprecatedNameAttr         = requiredClass[scala.deprecatedName]
     lazy val DeprecatedInheritanceAttr  = requiredClass[scala.deprecatedInheritance]

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -743,6 +743,9 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def elisionLevel        = getAnnotation(ElidableMethodClass) flatMap { _.intArg(0) }
     def implicitNotFoundMsg = getAnnotation(ImplicitNotFoundClass) flatMap { _.stringArg(0) }
 
+    def isCompileTimeOnly       = hasAnnotation(CompileTimeOnlyAttr)
+    def compileTimeOnlyMessage  = getAnnotation(CompileTimeOnlyAttr) flatMap (_ stringArg 0)
+
     /** Is this symbol an accessor method for outer? */
     final def isOuterAccessor = {
       hasFlag(STABLE | ARTIFACT) &&

--- a/src/reflect/scala/reflect/macros/compileTimeOnly.scala
+++ b/src/reflect/scala/reflect/macros/compileTimeOnly.scala
@@ -1,0 +1,16 @@
+package scala.reflect
+package macros
+
+import scala.annotation.meta._
+
+/**
+ * An annotation that designates a member should not be referred to after
+ * type checking (which includes macro expansion); it must only be used in
+ * the arguments of some other macro that will eliminate it from the AST.
+ *
+ * @param  message the error message to print during compilation if a reference remains
+ *                 after type checking
+ * @since  2.10.0
+ */
+@getter @setter @beanGetter @beanSetter
+final class compileTimeOnly(message: String = "") extends scala.annotation.StaticAnnotation

--- a/src/reflect/scala/reflect/macros/compileTimeOnly.scala
+++ b/src/reflect/scala/reflect/macros/compileTimeOnly.scala
@@ -10,7 +10,7 @@ import scala.annotation.meta._
  *
  * @param  message the error message to print during compilation if a reference remains
  *                 after type checking
- * @since  2.10.0
+ * @since  2.10.1
  */
 @getter @setter @beanGetter @beanSetter
-final class compileTimeOnly(message: String = "") extends scala.annotation.StaticAnnotation
+final class compileTimeOnly(message: String) extends scala.annotation.StaticAnnotation

--- a/test/files/neg/t6539.check
+++ b/test/files/neg/t6539.check
@@ -1,0 +1,10 @@
+Test_2.scala:2: error: reference to method cto in object M should not survive typechecking: cto may only be used as an argument to m
+	M.cto // error
+          ^
+Test_2.scala:3: error: reference to method cto in object M should not survive typechecking: cto may only be used as an argument to m
+	M.m(M.cto, ()) // error
+              ^
+Test_2.scala:5: error: reference to method cto in object M should not survive typechecking: cto may only be used as an argument to m
+	M.cto // error
+          ^
+three errors found

--- a/test/files/neg/t6539.check
+++ b/test/files/neg/t6539.check
@@ -1,10 +1,10 @@
-Test_2.scala:2: error: reference to method cto in object M should not survive typechecking: cto may only be used as an argument to m
-	M.cto // error
-          ^
-Test_2.scala:3: error: reference to method cto in object M should not survive typechecking: cto may only be used as an argument to m
-	M.m(M.cto, ()) // error
-              ^
-Test_2.scala:5: error: reference to method cto in object M should not survive typechecking: cto may only be used as an argument to m
-	M.cto // error
-          ^
+Test_2.scala:2: error: cto may only be used as an argument to m
+  M.cto // error
+    ^
+Test_2.scala:3: error: cto may only be used as an argument to m
+  M.m(M.cto, ()) // error
+        ^
+Test_2.scala:5: error: cto may only be used as an argument to m
+  M.cto // error
+    ^
 three errors found

--- a/test/files/neg/t6539/Macro_1.scala
+++ b/test/files/neg/t6539/Macro_1.scala
@@ -2,9 +2,9 @@ import language.experimental.macros
 import reflect.macros.Context
 
 object M {
-	def m(a: Any, b: Any): Any = macro mImpl
-	def mImpl(c: Context)(a: c.Expr[Any], b: c.Expr[Any]) = a
+  def m(a: Any, b: Any): Any = macro mImpl
+  def mImpl(c: Context)(a: c.Expr[Any], b: c.Expr[Any]) = a
 
-  @reflect.macros.compileTimeOnly("cto may only be used as an argument to m")
-	def cto = 0
+  @reflect.macros.compileTimeOnly("cto may only be used as an argument to " + "m")
+  def cto = 0
 }

--- a/test/files/neg/t6539/Macro_1.scala
+++ b/test/files/neg/t6539/Macro_1.scala
@@ -1,0 +1,10 @@
+import language.experimental.macros
+import reflect.macros.Context
+
+object M {
+	def m(a: Any, b: Any): Any = macro mImpl
+	def mImpl(c: Context)(a: c.Expr[Any], b: c.Expr[Any]) = a
+
+  @reflect.macros.compileTimeOnly("cto may only be used as an argument to m")
+	def cto = 0
+}

--- a/test/files/neg/t6539/Test_2.scala
+++ b/test/files/neg/t6539/Test_2.scala
@@ -1,6 +1,6 @@
 object Test {
-	M.cto // error
-	M.m(M.cto, ()) // error
-	M.m((), M.cto) // okay
-	M.cto // error
+  M.cto // error
+  M.m(M.cto, ()) // error
+  M.m((), M.cto) // okay
+  M.cto // error
 }

--- a/test/files/neg/t6539/Test_2.scala
+++ b/test/files/neg/t6539/Test_2.scala
@@ -1,0 +1,6 @@
+object Test {
+	M.cto // error
+	M.m(M.cto, ()) // error
+	M.m((), M.cto) // okay
+	M.cto // error
+}


### PR DESCRIPTION
Motivated by the `.value` method in the SBT task-syntax branch,
which should only be called within the context of the argument
to a setting initialization macro.

The facility is akin to a fatal deprecation.

Review by @xeno-by @harrah
