### PR TITLE
Associate correct names to e-mails, correct or not

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,7 @@
+Aleksandar Prokopec <aleksandar@aleksandar-Latitude-E6500.(none)>
+Aleksandar Prokopec <aleksandar@htpc.(none)>
+Aleksandar Prokopec <aleksandar@htpc-axel22.(none)>
+Aleksandar Prokopec <aleksandar@lampmac14.epfl.ch>
+Aleksandar Prokopec <aleksandar.prokopec@epfl.ch>
+Daniel C. Sobral <dcs@dcs-132-CK-NF79.(none)>
+Pavel Pavlov <pavel.e.pavlov@gmail.com>


### PR DESCRIPTION
This is used by git log to produce names with certain formats, and
is used by the release notes tool as well. Helpful if you have commits
with Author not set correctly, as did I.

I'm also including Aleksandar Prokopec and his friend Aleksandar Pokopec,
as well as Pavel Pavlov, both of whom have commits appearing under more
than one name.

I'm not including others who have not set a full name, but don't have
commits appearing under more than one name.
