### PR TITLE
Update tools/epfl-publish

### DIFF
--- a/tools/epfl-publish
+++ b/tools/epfl-publish
@@ -24,7 +24,7 @@ if [[ -z $publish_to ]]; then
 else
   echo "Publishing nightly build to $publish_to"
   # Archive Scala nightly distribution
-  rsync -az dists/archives/ "$publish_to/distributions"
+  rsync -az --exclude scala-latest-sources.tgz dists/archives/ "$publish_to/distributions"
   # only publish scaladoc nightly for trunk
   [[ $version == "master" ]] && rsync -az build/scaladoc/ "$publish_to/docs"
   # sbaz


### PR DESCRIPTION
Currently, during each Scala nightly build, the epfl-publish script rsyncs the resulting dists/archives to the repository machine (chara).

Now, as a result of a change introduced a while back, dists/archives/ contains a symbolic link, created at the end of the build when the targets "pack-archives.latest.*" are invoked (in src/build/pack.xml). That was introduced in:

scala/scala@506bcfe71c93160ebfa0ca9b8b170b4b54e844e9
scala/scala@cb99853c8655686dae1288cbcd44a42cf1ea6609

This link, created in dists/archives/, is copied to chara with the rest. On chara, however, the link points to an invalid target (the path is absolute).

Separately, the repository directory on chara is rsync'd every 30 minutes over to the machine that serves www.scala-lang.org, via cron. Rsync finds that the link target does not exist, and generates an email with the cron log, which is then duly sent to a system mailbox. Every 30 minutes. Since March. Needless to say, the mailbox is pretty large by now.

The fix is trivial, but this needs to be included in all the branches that are tested during the nightly tests. Since RC2 has just been cut, and the code frozen, I'm not sure how this change can be included without disruption; therefore, I'll just send a pull request on 2.10.0-wip, and let Josh/Paul take the appropriate steps.
