### PR TITLE
Fix type of the custom `ClassTag` in `PatternMatching.scala`

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
@@ -2037,9 +2037,9 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
     // CNF: a formula is a conjunction of clauses
     type Formula = Array[Clause]
     /** Override Array creation for efficiency (to not go through reflection). */
-    private implicit val formulaTag: scala.reflect.ClassTag[Formula] = new scala.reflect.ClassTag[Formula] {
-      def runtimeClass: java.lang.Class[Formula] = classOf[Formula]
-      final override def newArray(len: Int): Array[Formula] = new Array[Formula](len)
+    private implicit val clauseTag: scala.reflect.ClassTag[Clause] = new scala.reflect.ClassTag[Clause] {
+      def runtimeClass: java.lang.Class[Clause] = classOf[Clause]
+      final override def newArray(len: Int): Array[Clause] = new Array[Clause](len)
     }
     def formula(c: Clause*): Formula = c.toArray
     def andFormula(a: Formula, b: Formula): Formula = a ++ b


### PR DESCRIPTION
In fb315772 custom ClassTags were introduced to optimize array
creation in hot places. The idea was that if `Array[T]` is allocated
through `ClassTag[T]` (which is essentially a factory for Array[T])
we would introduce a custom class implementing `ClassTag[T]` interface
and would have specialized array allocation instruction instead of
having reflective call as it's being done with default (compiler
synthesized) implementation of `ClassTag[T]`.

In case of `PatternMatching.scala` I made a mistake of providing
`ClassTag[Array[Clause]]` instead of `ClassTag[Clause]` so that value
would never be used and compiler still would resolve implicit through
default mechanism. This has been discovered thanks to @paulp's work
on unused value detection.

Review by @paulp.
