### PR TITLE
SI-6644 Account for varargs in extmethod forwarder

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
@@ -173,9 +173,7 @@ abstract class ExtensionMethods extends Transform with TypingTransformers {
               List(This(currentOwner)))
           val extensionCall = atOwner(origMeth) {
             localTyper.typedPos(rhs.pos) {
-              (extensionCallPrefix /: vparamss) {
-                case (fn, params) => Apply(fn, params map (param => Ident(param.symbol)))
-              }
+              gen.mkForwarder(extensionCallPrefix, mmap(vparamss)(_.symbol))
             }
           }
           deriveDefDef(tree)(_ => extensionCall)

--- a/test/files/run/t6644.scala
+++ b/test/files/run/t6644.scala
@@ -1,0 +1,8 @@
+class Testable(val c: String) extends AnyVal {
+  def matching(cases: Boolean*) = cases contains true
+}
+
+object Test extends App {
+  assert(new Testable("").matching(true, false))
+}
+


### PR DESCRIPTION
Which sounded difficult, so instead I offshored the work
to the friendly republic of `TreeGen`.

Review by @paulp for content, @jsuereth for merge target.

It doesn't seem different from the multitude of prior "value classes + X
are broken" bugs that blocked earlier RCs.
