### PR TITLE
-Yshow-trees-compact respects other options

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/NodePrinters.scala
+++ b/src/compiler/scala/tools/nsc/ast/NodePrinters.scala
@@ -102,7 +102,7 @@ abstract class NodePrinters {
       buf.clear()
       if (settings.XshowtreesStringified.value) buf.append(tree.toString + EOL)
       if (settings.XshowtreesCompact.value) {
-        buf.append(showRaw(tree))
+        buf.append(showRaw(tree, printIds = settings.uniqid.value, printTypes = settings.printtypes.value))
       } else {
         level = 0
         traverse(tree)


### PR DESCRIPTION
The aforementioned tree printer now respects other tree printing
options such as -uniqid and -Xprint-types.

This helps debugging reify, which uses `nodePrinters`, not `showRaw`
to print its trees, because back then `showRaw` didn't exist yet.
