### PR TITLE
SI-6648 copyAttrs must preserve TypeTree#wasEmpty

### DIFF
--- a/test/files/pos/t6648.scala
+++ b/test/files/pos/t6648.scala
@@ -1,0 +1,24 @@
+abstract class Node extends NodeSeq
+trait NodeSeq extends Seq[Node]
+object NodeSeq {
+  implicit def seqToNodeSeq(ns: Seq[Node]): NodeSeq = ???
+   def foo[B, That](f: Seq[B])(implicit bf: scala.collection.generic.CanBuildFrom[Seq[Int], B, That]): That = ???
+}
+
+class Transformer {
+  def apply(nodes: Any): Any = ???
+}
+
+object transformer1 extends Transformer {
+  // Adding explicit type arguments, or making the impilcit view
+  // seqToNodeSeq explicit avoids the crash
+  NodeSeq.foo {
+    // These both avoid the crash:
+    // val t = new Transformer {}; t.apply(null)
+    // new Transformer().apply(null)
+    new Transformer {}.apply(null)
+
+    null: NodeSeq
+  }: NodeSeq
+}
+


### PR DESCRIPTION
This field tracks whether the type is an inferred
one, subject to removal in `resetAttrs`, or an explicit
type, which must remain.

In ae5ff662, `ResetAttrs` was modified to duplicate
trees, rather than mutate trees in place. But the
tree copier didn't pass `wasEmpty` on to the new tree,
which in turn meant that the subsequent typing run
on the tree would not re-infer the types. If the
type refers to a local class, e.g. the anonymous
function in the enclosed test case, the reference
to the old symbol would persist.

This commit overrides `copyAttrs` in TypeTree to
copy `wasEmpty`.

We might consider representing this as a tree
attachment, but this would need to be validated
for the performance impact.

Review by @lrytz
