### PR TITLE
Fixes SI-6551.

### DIFF
--- a/test/files/pos/t6551.scala
+++ b/test/files/pos/t6551.scala
@@ -1,0 +1,13 @@
+import language.dynamics
+
+object Test {
+  def main(args: Array[String]) {
+    class Lenser[T] extends Dynamic {
+      def selectDynamic(propName: String) = ???
+    }
+
+    def lens[T] = new Lenser[T]
+
+    val qq = lens[String]
+  }
+}


### PR DESCRIPTION
Don't rewrite an explicit apply method to dynamic polytypes.
