### PR TITLE
SI-5330, SI-6014 deal with existential self-type

### DIFF
--- a/test/files/pos/t5330.scala
+++ b/test/files/pos/t5330.scala
@@ -1,0 +1,22 @@
+trait FM[A] {
+  def map(f: A => Any)
+}
+
+trait M[A] extends FM[A] {
+  def map(f: A => Any)
+}
+
+trait N[A] extends FM[A]
+
+object test {
+  def kaboom(xs: M[_]) = xs map (x => ()) // missing parameter type.
+
+  def okay1[A](xs: M[A]) = xs map (x => ())
+  def okay2(xs: FM[_]) = xs map (x => ())
+  def okay3(xs: N[_]) = xs map (x => ())
+}
+
+class CC2(xs: List[_]) {
+  def f(x1: Any, x2: Any) = null
+  def g = xs map (x => f(x, x))
+}

--- a/test/files/pos/t5330b.scala
+++ b/test/files/pos/t5330b.scala
@@ -1,0 +1,6 @@
+abstract trait Base {
+  def foo: this.type
+};
+class Derived[T] extends Base {
+  def foo: Nothing = sys.error("!!!")
+}

--- a/test/files/pos/t5330c.scala
+++ b/test/files/pos/t5330c.scala
@@ -1,0 +1,5 @@
+object t5330c {
+  val s: Set[_ >: Char] = Set('A')
+  s forall ("ABC" contains _)
+  s.forall( c => "ABC".toSeq.contains( c ))
+}

--- a/test/files/pos/t6014.scala
+++ b/test/files/pos/t6014.scala
@@ -1,0 +1,13 @@
+object Test {
+  case class CC[T](key: T)
+  type Alias[T] = Seq[CC[T]]
+
+  def f(xs: Seq[CC[_]]) = xs map { case CC(x) => CC(x) }    // ok
+  def g(xs: Alias[_])   = xs map { case CC(x) => CC(x) }    // fails
+  // ./a.scala:11: error: missing parameter type for expanded function
+  // The argument types of an anonymous function must be fully known. (SLS 8.5)
+  // Expected type was: ?
+  //   def g(xs: Alias[_])   = xs map { case CC(x) => CC(x) }    // fails
+  //                                  ^
+  // one error found
+}


### PR DESCRIPTION
[backport to 2.10.x of #1622]

This has been broken since https://github.com/scala/scala/commit/b7b81ca2#L0L567.
The existential rash is treated in a similar manner as in fc24db4c.

Conceptually, the fix would be `def selfTypeSkolemized =
widen.skolemizeExistential.narrow`, but simply widening before
narrowing achieves the same thing. Since we're in existential voodoo
territory, let's go for the minimal fix: replacing `this.narrow` by
`widen.narrow`.
## 

Original patch by @retronym in #1074, refined by @paulp to
only perform widen.narrow incantation if there are
existentials present in the widened type, as
narrowing is expensive when the type is not a singleton.

The result is that compiling the entirety of quick, that
code path is hit only 143 times.  All the other calls hit
.narrow directly as before.  It looks like the definition
of negligible in the diff of -Ystatistics when compiling
src/library/scala/collection:

```
< #symbols                      : 306315

---
> #symbols                      : 306320
12c13
< #unique types                 : 293859

---
> #unique types                 : 293865
```

I'm assuming based on the 2/1000ths of a percent increase
in symbol and type creation that wall clock is manageable,
but I didn't measure it.
