### PR TITLE
Fix for overly eager package object search.

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2463,6 +2463,14 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     override def isMethod           = this hasFlag METHOD
     override def isModule           = this hasFlag MODULE
     override def isOverloaded       = this hasFlag OVERLOADED
+    /*** !!! TODO: shouldn't we do something like the following:
+    override def isOverloaded       = (
+      if (this.isInitialized)
+        this hasFlag OVERLOADED
+      else
+        (infos ne null) && infos.info.isInstanceOf[OverloadedType]
+    )
+    ***/
     override def isPackage          = this hasFlag PACKAGE
     override def isValueParameter   = this hasFlag PARAM
 


### PR DESCRIPTION
A subtle change in the order in which symbol attributes were
inspected (now you know why I avoid vals in the compiler) led to a
cycle during initialization for slick. I'm afraid I don't know how
to reproduce the issue outside of slick and sbt, so I added some
logging instead.
