### PR TITLE
Fix for SI-6664, cycle in case classes.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -909,11 +909,10 @@ trait Namers extends MethodSynthesis {
         val modClass = companionSymbolOf(clazz, context).moduleClass
         modClass.attachments.get[ClassForCaseCompanionAttachment] foreach { cma =>
           val cdef = cma.caseClass
-          def hasCopy(decls: Scope) = (decls lookup nme.copy) != NoSymbol
+          def hasCopy = (decls containsName nme.copy) || parents.exists(_ member nme.copy exists)
+
           // SI-5956 needs (cdef.symbol == clazz): there can be multiple class symbols with the same name
-          if (cdef.symbol == clazz && !hasCopy(decls) &&
-                  !parents.exists(p => hasCopy(p.typeSymbol.info.decls)) &&
-                  !parents.flatMap(_.baseClasses).distinct.exists(bc => hasCopy(bc.info.decls)))
+          if (cdef.symbol == clazz && !hasCopy)
             addCopyMethod(cdef, templateNamer)
         }
       }

--- a/src/reflect/scala/reflect/internal/Scopes.scala
+++ b/src/reflect/scala/reflect/internal/Scopes.scala
@@ -242,7 +242,8 @@ trait Scopes extends api.Scopes { self: SymbolTable =>
         // than a non-deterministic bizarre one (see any bug involving overloads
         // in package objects.)
         val alts = lookupAll(name).toList
-        log("!!! scope lookup of $name found multiple symbols: $alts")
+        def alts_s = alts map (s => s.defString) mkString " <and> "
+        log(s"!!! scope lookup of $name found multiple symbols: $alts_s")
         // FIXME - how is one supposed to create an overloaded symbol without
         // knowing the correct owner? Using the symbol owner is not correct;
         // say for instance this is List's scope and the symbols are its three
@@ -254,8 +255,9 @@ trait Scopes extends api.Scopes { self: SymbolTable =>
         // FIXME - a similar question for prefix, although there are more
         // clues from the symbols on that one, as implemented here. In general
         // the distinct list is one type and lub becomes the identity.
-        val prefix = lub(alts map (_.info.prefix) distinct)
-        NoSymbol.newOverloaded(prefix, alts)
+        // val prefix = lub(alts map (_.info.prefix) distinct)
+        // Now using NoSymbol and NoPrefix always to avoid forcing info (SI-6664)
+        NoSymbol.newOverloaded(NoPrefix, alts)
       }
     }
 

--- a/test/files/pos/t6664.scala
+++ b/test/files/pos/t6664.scala
@@ -1,0 +1,4 @@
+final case class A(i: Int, s: String) {
+    protected def copy(s2: String): A = A(i, s2)
+    protected def copy(i2: Int): A = A(i2, s)
+}

--- a/test/files/pos/t6664b.scala
+++ b/test/files/pos/t6664b.scala
@@ -1,0 +1,5 @@
+object T {
+  def A(s: String): A = new A(3, s)
+  def A(i: Int): A = A(i, "abc")
+  case class A(i: Int, s: String)
+}


### PR DESCRIPTION
Scope lookup of an overloaded symbol was accidentally
forcing some lazy info. Since as usual the caller didn't
even have any interest in the symbol, but only in whether
the name existed at all, I changed it call the method I
made for this exact purpose, containsName. Also I much
reduced the number of checks being made in the quest for
an inherited copy method.
