### PR TITLE
Fixes SI-6150 - backport to 2.10.x branch.

### DIFF
--- a/src/library/scala/collection/IndexedSeq.scala
+++ b/src/library/scala/collection/IndexedSeq.scala
@@ -28,8 +28,14 @@ trait IndexedSeq[+A] extends Seq[A]
  *  @define coll indexed sequence
  *  @define Coll `IndexedSeq`
  */
-object IndexedSeq extends SeqFactory[IndexedSeq] {
-  implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, IndexedSeq[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+object IndexedSeq extends IndexedSeqFactory[IndexedSeq] {
+  // A single CBF which can be checked against to identify
+  // an indexed collection type.
+  override val ReusableCBF: GenericCanBuildFrom[Nothing] = new GenericCanBuildFrom[Nothing] {
+    override def apply() = newBuilder[Nothing]
+  }
   def newBuilder[A]: Builder[A, IndexedSeq[A]] = immutable.IndexedSeq.newBuilder[A]
+  implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, IndexedSeq[A]] =
+    ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
 }
 

--- a/src/library/scala/collection/generic/GenTraversableFactory.scala
+++ b/src/library/scala/collection/generic/GenTraversableFactory.scala
@@ -36,15 +36,12 @@ import scala.language.higherKinds
  *    @see GenericCanBuildFrom
  */
 abstract class GenTraversableFactory[CC[X] <: GenTraversable[X] with GenericTraversableTemplate[X, CC]]
-  extends GenericCompanion[CC] {
+extends GenericCompanion[CC] {
 
-  // A default implementation of GenericCanBuildFrom which can be cast
-  // to whatever is desired.
-  private class ReusableCBF extends GenericCanBuildFrom[Nothing] {
+  private[this] val ReusableCBFInstance: GenericCanBuildFrom[Nothing] = new GenericCanBuildFrom[Nothing] {
     override def apply() = newBuilder[Nothing]
   }
-  // Working around SI-4789 by using a lazy val instead of an object.
-  lazy val ReusableCBF: GenericCanBuildFrom[Nothing] = new ReusableCBF
+  def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
 
   /** A generic implementation of the `CanBuildFrom` trait, which forwards
    *  all calls to `apply(from)` to the `genericBuilder` method of

--- a/src/library/scala/collection/generic/IndexedSeqFactory.scala
+++ b/src/library/scala/collection/generic/IndexedSeqFactory.scala
@@ -1,0 +1,21 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2003-2011, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala.collection
+package generic
+
+import language.higherKinds
+
+/** A template for companion objects of IndexedSeq and subclasses thereof.
+ *
+ *  @since 2.10
+ */
+abstract class IndexedSeqFactory[CC[X] <: IndexedSeq[X] with GenericTraversableTemplate[X, CC]] extends SeqFactory[CC] {
+  override def ReusableCBF: GenericCanBuildFrom[Nothing] =
+    scala.collection.IndexedSeq.ReusableCBF.asInstanceOf[GenericCanBuildFrom[Nothing]]
+}

--- a/src/library/scala/collection/immutable/IndexedSeq.scala
+++ b/src/library/scala/collection/immutable/IndexedSeq.scala
@@ -31,11 +31,12 @@ trait IndexedSeq[+A] extends Seq[A]
  *  @define coll indexed sequence
  *  @define Coll `IndexedSeq`
  */
-object IndexedSeq extends SeqFactory[IndexedSeq] {
+object IndexedSeq extends IndexedSeqFactory[IndexedSeq] {
   class Impl[A](buf: ArrayBuffer[A]) extends AbstractSeq[A] with IndexedSeq[A] with Serializable {
     def length = buf.length
     def apply(idx: Int) = buf.apply(idx)
   }
-  implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, IndexedSeq[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
   def newBuilder[A]: Builder[A, IndexedSeq[A]] = Vector.newBuilder[A]
+  implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, IndexedSeq[A]] =
+    ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
 }

--- a/test/files/run/t6150.scala
+++ b/test/files/run/t6150.scala
@@ -1,0 +1,44 @@
+
+
+
+
+object Test {
+  import collection.{ immutable, mutable, generic }
+  def TheOneTrueCBF = collection.IndexedSeq.ReusableCBF
+
+  val cbf1 = implicitly[generic.CanBuildFrom[immutable.Vector[Int], Int, collection.IndexedSeq[Int]]]
+  val cbf2 = implicitly[generic.CanBuildFrom[immutable.IndexedSeq[Int], Int, collection.IndexedSeq[Int]]]
+  val cbf3 = implicitly[generic.CanBuildFrom[collection.IndexedSeq[Int], Int, collection.IndexedSeq[Int]]]
+
+  val cbf4 = implicitly[generic.CanBuildFrom[immutable.Vector[Int], Int, immutable.IndexedSeq[Int]]]
+  val cbf5 = implicitly[generic.CanBuildFrom[immutable.Vector[Int], Int, immutable.Vector[Int]]]
+  val cbf6 = implicitly[generic.CanBuildFrom[immutable.IndexedSeq[Int], Int, immutable.IndexedSeq[Int]]]
+
+  def check[C](v: C) = {
+    assert(v == Vector(1, 2, 3, 4))
+    assert(v.isInstanceOf[Vector[_]])
+  }
+  def checkRealMccoy(x: AnyRef) = {
+    assert(x eq TheOneTrueCBF, cbf1)
+  }
+
+  val v = immutable.Vector(1, 2, 3)
+  val iiv: immutable.IndexedSeq[Int] = immutable.Vector(1, 2, 3)
+  val iv: IndexedSeq[Int] = immutable.Vector(1, 2, 3)
+
+  def main(args: Array[String]): Unit = {
+    List(cbf1, cbf2, cbf3, cbf4, cbf5, cbf6) foreach checkRealMccoy
+    check(v.:+(4)(cbf1))
+    check(v.:+(4)(cbf2))
+    check(v.:+(4)(cbf3))
+
+    check(iiv.:+(4)(cbf2))
+    check(iiv.:+(4)(cbf3))
+
+    check(iv.:+(4)(cbf3))
+  }
+}
+
+
+
+


### PR DESCRIPTION
Backporting https://github.com/scala/scala/pull/1150 to 2.10.x.

Review by @paulp and/or @jsuereth.

https://scala-webapps.epfl.ch/jenkins/job/scala-checkin-manual/669/console
