### PR TITLE
Error for SI-6355, overloading of applyDynamic.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -130,6 +130,15 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
           }
         }
       }
+
+      // Check for doomed attempt to overload applyDynamic
+      if (clazz isSubClass DynamicClass) {
+        clazz.info member nme.applyDynamic match {
+          case sym if sym.isOverloaded => unit.error(sym.pos, "implementation restriction: applyDynamic cannot be overloaded")
+          case _                       =>
+        }
+      }
+
       if (settings.lint.value) {
         clazz.info.decls filter (x => x.isImplicit && x.typeParams.nonEmpty) foreach { sym =>
           val alts = clazz.info.decl(sym.name).alternatives

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3871,7 +3871,7 @@ trait Typers extends Modes with Adaptations with Tags {
        *
        */
       def mkInvoke(cxTree: Tree, tree: Tree, qual: Tree, name: Name): Option[Tree] = {
-        debuglog(s"mkInvoke($cxTree, $tree, $qual, $name)")
+        debuglog(s"dyna.mkInvoke($cxTree, $tree, $qual, $name)")
         acceptsApplyDynamicWithType(qual, name) map { tp =>
           // tp eq NoType => can call xxxDynamic, but not passing any type args (unless specified explicitly by the user)
           // in scala-virtualized, when not NoType, tp is passed as type argument (for selection on a staged Struct)

--- a/test/files/neg/t6355.check
+++ b/test/files/neg/t6355.check
@@ -1,0 +1,4 @@
+t6355.scala:12: error: implementation restriction: applyDynamic cannot be overloaded
+  def applyDynamic(name: String)(x: Int): Int = 2
+      ^
+one error found

--- a/test/files/neg/t6355.scala
+++ b/test/files/neg/t6355.scala
@@ -1,0 +1,13 @@
+package foo
+
+import scala.language.dynamics
+
+class DoesntExtendDynamic {
+  def applyDynamic(name: String)(s: String): Int = 1
+  def applyDynamic(name: String)(x: Int): Int = 2
+}
+
+class A extends Dynamic {
+  def applyDynamic(name: String)(s: String): Int = 1
+  def applyDynamic(name: String)(x: Int): Int = 2
+}


### PR DESCRIPTION
As long as it can never be called anyway, seems like we'd be
doing people a kindness to fail the compile rather than letting
it be ambiguous at every use site.

Also quieted down currently noisy -Xlint warning.
