### PR TITLE
Fix Documentation Typo

### DIFF
--- a/src/library/scala/xml/transform/RewriteRule.scala
+++ b/src/library/scala/xml/transform/RewriteRule.scala
@@ -11,8 +11,8 @@
 package scala.xml
 package transform
 
-/** a RewriteRule, when applied to a term, yields either
- *  the resulting of rewriting or the term itself it the rule
+/** A RewriteRule, when applied to a term, yields either
+ *  the result of rewriting the term or the term itself if the rule
  *  is not applied.
  *
  *  @author  Burak Emir


### PR DESCRIPTION
There was a typo on the if.

I also thought it might be worth rephrasing the paragraph because it seemed a bit contrived.

It's a trivial fix, but it would allow us to close a bug in the issue tracker which seems worthwhile to me.
