### PR TITLE
Fix bug in partest-ack.

### DIFF
--- a/tools/partest-ack
+++ b/tools/partest-ack
@@ -5,7 +5,7 @@
 args="$@"
 
 pathMatches () {
-  ack --noenv --files-with-matches "$@" test/files
+  ack --noenv --text --files-with-matches "$@" test/files
 
   for p in $(find test/files/* -print); do
     [[ $p =~ $1 ]] && echo "$p"


### PR DESCRIPTION
Unfortunate bug was making it far less useful than it was
supposed to be. Now it really does look in scala/check/flags
files, here are examples of things which work:

  % tools/partest-ack "input ended while parsing XML"
  Found 6 tests matching 'ack input ended while parsing XML'

  % tools/partest-ack Xlint
  Found 11 tests matching 'ack Xlint'

  % tools/partest-ack -- -language:experimental.macros
  Found 143 tests matching 'ack -- -language:experimental.macros'

  % tools/partest-ack @unchecked
  Found 13 tests matching 'ack @unchecked'
