### PR TITLE
Added -Xdev setting... you know, for devs

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -253,11 +253,15 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
     if (settings.debug.value)
       body
   }
-  // Warnings issued only under -Ydebug.  For messages which should reach
-  // developer ears, but are not adequately actionable by users.
-  @inline final override def debugwarn(msg: => String) {
-    if (settings.debug.value)
-      warning(msg)
+  /** This is for WARNINGS which should reach the ears of scala developers
+   *  whenever they occur, but are not useful for normal users. They should
+   *  be precise, explanatory, and infrequent. Please don't use this as a
+   *  logging mechanism. !!! is prefixed to all messages issued via this route
+   *  to make them visually distinct.
+   */
+  @inline final override def devWarning(msg: => String) {
+    if (settings.developer.value || settings.debug.value)
+      warning("!!! " + msg)
   }
 
   private def elapsedMessage(msg: String, start: Long) =

--- a/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
@@ -1251,8 +1251,11 @@ abstract class GenICode extends SubComponent  {
       val sym = (
         if (!tree.symbol.isPackageClass) tree.symbol
         else tree.symbol.info.member(nme.PACKAGE) match {
-          case NoSymbol => assert(false, "Cannot use package as value: " + tree) ; NoSymbol
-          case s        => debugwarn("Bug: found package class where package object expected.  Converting.") ; s.moduleClass
+          case NoSymbol =>
+            abort("Cannot use package as value: " + tree)
+          case s        =>
+            devWarning(s"Found ${tree.symbol} where a package object is required. Converting to ${s.moduleClass}")
+            s.moduleClass
         }
       )
       debuglog("LOAD_MODULE from %s: %s".format(tree.shortClass, sym))

--- a/src/compiler/scala/tools/nsc/backend/icode/ICodes.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/ICodes.scala
@@ -28,7 +28,7 @@ abstract class ICodes extends AnyRef
                                  with Repository
 {
   val global: Global
-  import global.{ log, definitions, settings, perRunCaches }
+  import global.{ log, definitions, settings, perRunCaches, devWarning }
 
   /** The ICode representation of classes */
   val classes = perRunCaches.newMap[global.Symbol, IClass]()
@@ -82,7 +82,7 @@ abstract class ICodes extends AnyRef
         // Something is leaving open/empty blocks around (see SI-4840) so
         // let's not kill the deal unless it's nonempty.
         if (b.isEmpty) {
-          log("!!! Found open but empty block while inlining " + m + ": removing from block list.")
+          devWarning(s"Found open but empty block while inlining $m: removing from block list.")
           m.code removeBlock b
         }
         else dumpMethodAndAbort(m, b)

--- a/src/compiler/scala/tools/nsc/backend/icode/analysis/ReachingDefinitions.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/analysis/ReachingDefinitions.scala
@@ -52,7 +52,7 @@ abstract class ReachingDefinitions {
           // it makes it harder to spot the real problems.
           val result = (a.stack, b.stack).zipped map (_ ++ _)
           if (settings.debug.value && (a.stack.length != b.stack.length))
-            debugwarn("Mismatched stacks in ReachingDefinitions#lub2: " + a.stack + ", " + b.stack + ", returning " + result)
+            devWarning(s"Mismatched stacks in ReachingDefinitions#lub2: ${a.stack}, ${b.stack}, returning $result")
           result
         }
       )

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -74,6 +74,7 @@ trait ScalaSettings extends AbsScalaSettings
   val assemextdirs  = StringSetting     ("-Xassem-extdirs", "dirs", "(Requires -target:msil) List of directories containing assemblies.  default:lib", Defaults.scalaLibDir.path).dependsOn(target, "msil")
   val sourcedir     = StringSetting     ("-Xsourcedir", "directory", "(Requires -target:msil) Mirror source folder structure in output directory.", ".").dependsOn(target, "msil")
   val checkInit     = BooleanSetting    ("-Xcheckinit", "Wrap field accessors to throw an exception on uninitialized access.")
+  val developer     = BooleanSetting    ("-Xdev", "Indicates user is a developer - issue warnings about anything which seems amiss")
   val noassertions  = BooleanSetting    ("-Xdisable-assertions", "Generate no assertions or assumptions.")
   val elidebelow    = IntSetting        ("-Xelide-below", "Calls to @elidable methods are omitted if method priority is lower than argument",
                                                 elidable.MINIMUM, None, elidable.byName get _)

--- a/src/compiler/scala/tools/nsc/transform/Mixin.scala
+++ b/src/compiler/scala/tools/nsc/transform/Mixin.scala
@@ -289,7 +289,7 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
       for (mixinMember <- mixinClass.info.decls) {
         if (isConcreteAccessor(mixinMember)) {
           if (isOverriddenAccessor(mixinMember, clazz.info.baseClasses))
-            debugwarn("!!! is overridden val: "+mixinMember.fullLocationString)
+            devWarning(s"Overridden concrete accessor: ${mixinMember.fullLocationString}")
           else {
             // mixin field accessors
             val mixedInAccessor = cloneAndAddMixinMember(mixinClass, mixinMember)

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -1482,7 +1482,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
               }
               // See SI-5583.  Don't know why it happens now if it didn't before.
               if (specMember.info.typeParams.isEmpty && residualTargs.nonEmpty) {
-                log("!!! Type args to be applied, but symbol says no parameters: " + ((specMember.defString, residualTargs)))
+                devWarning("Type args to be applied, but symbol says no parameters: " + ((specMember.defString, residualTargs)))
                 localTyper.typed(sel)
               }
               else {

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -297,7 +297,8 @@ abstract class UnCurry extends InfoTransform
      *  If there's a default case, the original match is used for applyOrElse, and isDefinedAt returns `true`
      */
     def synthPartialFunction(fun: Function) = {
-      if (!settings.XoldPatmat.value) debugwarn("Under the new pattern matching scheme, PartialFunction should have been synthesized during typers.")
+      if (!settings.XoldPatmat.value)
+        devWarning("Under the new pattern matching scheme, PartialFunction should have been synthesized during typers.")
 
       val targs             = fun.tpe.typeArgs
       val (formals, restpe) = (targs.init, targs.last)
@@ -704,7 +705,7 @@ abstract class UnCurry extends InfoTransform
         val finalizer = tree.finalizer
         if (!settings.XoldPatmat.value) {
           if (catches exists (cd => !treeInfo.isCatchCase(cd)))
-            debugwarn("VPM BUG! illegal try/catch " + catches)
+            devWarning("VPM BUG - illegal try/catch " + catches)
           tree
         } else if (catches forall treeInfo.isCatchCase) {
           tree

--- a/src/compiler/scala/tools/nsc/typechecker/Checkable.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Checkable.scala
@@ -130,7 +130,7 @@ trait Checkable {
       else if (P3) RuntimeCheckable
       else if (uncheckableType == NoType) {
         // Avoid warning (except ourselves) if we can't pinpoint the uncheckable type
-        debugwarn("Checkability checker says 'Uncheckable', but uncheckable type cannot be found:\n" + summaryString)
+        debuglog("Checkability checker says 'Uncheckable', but uncheckable type cannot be found:\n" + summaryString)
         CheckabilityError
       }
       else Uncheckable

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -398,8 +398,10 @@ trait Contexts { self: Analyzer =>
       unit.error(pos, if (checking) "\n**** ERROR DURING INTERNAL CHECKING ****\n" + msg else msg)
 
     @inline private def issueCommon(err: AbsTypeError)(pf: PartialFunction[AbsTypeError, Unit]) {
-      debugwarn("issue error: " + err.errMsg)
-      if (settings.Yissuedebug.value) (new Exception).printStackTrace()
+      if (settings.Yissuedebug.value) {
+        log("issue error: " + err.errMsg)
+        (new Exception).printStackTrace()
+      }
       if (pf isDefinedAt err) pf(err)
       else if (bufferErrors) { buffer += err }
       else throw new TypeError(err.errPos, err.errMsg)

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -82,7 +82,7 @@ trait Implicits {
     val result = new ImplicitSearch(tree, pt, isView, implicitSearchContext, pos).bestImplicit
     if (saveAmbiguousDivergent && implicitSearchContext.hasErrors) {
       context.updateBuffer(implicitSearchContext.errBuffer.filter(err => err.kind == ErrorKinds.Ambiguous || err.kind == ErrorKinds.Divergent))
-      debugwarn("update buffer: " + implicitSearchContext.errBuffer)
+      debuglog("update buffer: " + implicitSearchContext.errBuffer)
     }
     printInference("[infer implicit] inferred " + result)
     context.undetparams = context.undetparams filterNot result.subst.from.contains

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1319,7 +1319,8 @@ trait Infer extends Checkable {
           new TreeTypeSubstituter(undetparams, targs).traverse(tree)
           notifyUndetparamsInferred(undetparams, targs)
         case _ =>
-          debugwarn("failed inferConstructorInstance for "+ tree  +" : "+ tree.tpe +" under "+ undetparams +" pt = "+ pt +(if(isFullyDefined(pt)) " (fully defined)" else " (not fully defined)"))
+          def full = if (isFullyDefined(pt)) "(fully defined)" else "(not fully defined)"
+          devWarning(s"failed inferConstructorInstance for $tree: ${tree.tpe} undet=$undetparams, pt=$pt $full")
           // if (settings.explaintypes.value) explainTypes(resTp.instantiateTypeParams(undetparams, tvars), pt)
           ConstrInstantiationError(tree, resTp, pt)
       }

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -336,7 +336,7 @@ trait Namers extends MethodSynthesis {
 
     private def enterClassSymbol(tree: ClassDef, clazz: ClassSymbol): Symbol = {
       if (clazz.sourceFile != null && clazz.sourceFile != contextFile)
-        debugwarn("!!! Source mismatch in " + clazz + ": " + clazz.sourceFile + " vs. " + contextFile)
+        devWarning(s"Source file mismatch in $clazz: ${clazz.sourceFile} vs. $contextFile")
 
       clazz.associatedFile = contextFile
       if (clazz.sourceFile != null) {

--- a/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
@@ -271,7 +271,9 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
       // we don't transform after uncurry
       // (that would require more sophistication when generating trees,
       //  and the only place that emits Matches after typers is for exception handling anyway)
-      if(phase.id >= currentRun.uncurryPhase.id) debugwarn("running translateMatch at "+ phase +" on "+ selector +" match "+ cases)
+      if (phase.id >= currentRun.uncurryPhase.id)
+        devWarning(s"running translateMatch past uncurry (at $phase) on $selector match $cases")
+
       patmatDebug("translating "+ cases.mkString("{", "\n", "}"))
 
       val start = if (Statistics.canEnable) Statistics.startTimer(patmatNanos) else null

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -130,7 +130,8 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
           }
         }
       }
-      if (settings.lint.value) {
+      // This has become noisy with implicit classes.
+      if (settings.lint.value && settings.developer.value) {
         clazz.info.decls filter (x => x.isImplicit && x.typeParams.nonEmpty) foreach { sym =>
           val alts = clazz.info.decl(sym.name).alternatives
           if (alts.size > 1)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1545,7 +1545,7 @@ trait Typers extends Modes with Adaptations with Tags {
 
             val preSuperVals = treeInfo.preSuperFields(templ.body)
             if (preSuperVals.isEmpty && preSuperStats.nonEmpty)
-              debugwarn("Wanted to zip empty presuper val list with " + preSuperStats)
+              devWarning("Wanted to zip empty presuper val list with " + preSuperStats)
             else
               map2(preSuperStats, preSuperVals)((ldef, gdef) => gdef.tpt.tpe = ldef.symbol.tpe)
 

--- a/src/reflect/scala/reflect/internal/Scopes.scala
+++ b/src/reflect/scala/reflect/internal/Scopes.scala
@@ -242,7 +242,7 @@ trait Scopes extends api.Scopes { self: SymbolTable =>
         // than a non-deterministic bizarre one (see any bug involving overloads
         // in package objects.)
         val alts = lookupAll(name).toList
-        log("!!! scope lookup of $name found multiple symbols: $alts")
+        devWarning(s"scope lookup of $name found multiple symbols: $alts")
         // FIXME - how is one supposed to create an overloaded symbol without
         // knowing the correct owner? Using the symbol owner is not correct;
         // say for instance this is List's scope and the symbols are its three

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -53,13 +53,16 @@ abstract class SymbolTable extends macros.Universe
   @deprecated("Give us a reason", "2.10.0")
   def abort(): Nothing = abort("unknown error")
 
+  @deprecated("Use devWarning if this is really a warning; otherwise use log", "2.11.0")
+  def debugwarn(msg: => String): Unit = devWarning(msg)
+
   /** Override with final implementation for inlining. */
   def debuglog(msg:  => String): Unit = if (settings.debug.value) log(msg)
-  def debugwarn(msg: => String): Unit = if (settings.debug.value) Console.err.println(msg)
+  def devWarning(msg: => String): Unit = if (settings.debug.value) Console.err.println(msg)
   def throwableAsString(t: Throwable): String = "" + t
 
   /** Prints a stack trace if -Ydebug or equivalent was given, otherwise does nothing. */
-  def debugStack(t: Throwable): Unit  = debugwarn(throwableAsString(t))
+  def debugStack(t: Throwable): Unit  = devWarning(throwableAsString(t))
 
   /** Overridden when we know more about what was happening during a failure. */
   def supplementErrorMessage(msg: String): String = msg

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -1268,13 +1268,13 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
         cnt += 1
         // allow for two completions:
         //   one: sourceCompleter to LazyType, two: LazyType to completed type
-        if (cnt == 3) abort("no progress in completing " + this + ":" + tp)
+        if (cnt == 3) abort(s"no progress in completing $this: $tp")
       }
       rawInfo
     }
     catch {
       case ex: CyclicReference =>
-        debugwarn("... hit cycle trying to complete " + this.fullLocationString)
+        devWarning("... hit cycle trying to complete " + this.fullLocationString)
         throw ex
     }
 
@@ -3152,7 +3152,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     override def companionSymbol = fail(NoSymbol)
 
     locally {
-      debugwarn("creating stub symbol for " + stubWarning)
+      devWarning("creating stub symbol for " + stubWarning)
     }
   }
   class StubClassSymbol(owner0: Symbol, name0: TypeName) extends ClassSymbol(owner0, owner0.pos, name0) with StubSymbol

--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -147,11 +147,10 @@ abstract class TreeInfo {
     val plen   = params.length
     val alen   = args.length
     def fail() = {
-      global.debugwarn(
-        "Mismatch trying to zip method parameters and argument list:\n" +
-        "  params = " + params + "\n" +
-        "    args = " + args + "\n"
-      )
+      global.devWarning(
+        s"""|Mismatch trying to zip method parameters and argument list:
+            |  params = $params
+            |    args = $args""".stripMargin)
       false
     }
 

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1956,7 +1956,7 @@ trait Types extends api.Types { self: SymbolTable =>
           case tr @ TypeRef(_, sym, args) if args.nonEmpty =>
             val tparams = tr.initializedTypeParams
             if (settings.debug.value && !sameLength(tparams, args))
-              debugwarn("Mismatched zip in computeRefs(): " + sym.info.typeParams + ", " + args)
+              devWarning(s"Mismatched zip in computeRefs(): ${sym.info.typeParams}, $args")
 
             foreach2(tparams, args) { (tparam1, arg) =>
               if (arg contains tparam) {
@@ -2089,7 +2089,7 @@ trait Types extends api.Types { self: SymbolTable =>
       // it later turns out not to have kind *. See SI-4070.  Only
       // logging it for now.
       if (sym.typeParams.size != args.size)
-        log("!!! %s.transform(%s), but tparams.isEmpty and args=".format(this, tp, args))
+        devWarning(s"$this.transform($tp), but tparams.isEmpty and args=$args")
 
       asSeenFromOwner(tp).instantiateTypeParams(sym.typeParams, args)
     }
@@ -3678,7 +3678,7 @@ trait Types extends api.Types { self: SymbolTable =>
     tycon match {
       case TypeRef(pre, sym @ (NothingClass|AnyClass), _) => copyTypeRef(tycon, pre, sym, Nil)   //@M drop type args to Any/Nothing
       case TypeRef(pre, sym, Nil)                         => copyTypeRef(tycon, pre, sym, args)
-      case TypeRef(pre, sym, bogons)                      => debugwarn(s"Dropping $bogons from $tycon in appliedType.") ; copyTypeRef(tycon, pre, sym, args)
+      case TypeRef(pre, sym, bogons)                      => devWarning(s"Dropping $bogons from $tycon in appliedType.") ; copyTypeRef(tycon, pre, sym, args)
       case PolyType(tparams, restpe)                      => restpe.instantiateTypeParams(tparams, args)
       case ExistentialType(tparams, restpe)               => newExistentialType(tparams, appliedType(restpe, args))
       case st: SingletonType                              => appliedType(st.widen, args) // @M TODO: what to do? see bug1
@@ -5023,7 +5023,7 @@ trait Types extends api.Types { self: SymbolTable =>
       else {
         var rebind0 = pre.findMember(sym.name, BRIDGE, 0, true) orElse {
           if (sym.isAliasType) throw missingAliasException
-          debugwarn(pre+"."+sym+" does no longer exist, phase = "+phase)
+          devWarning(s"$pre.$sym no longer exist at phase $phase")
           throw new MissingTypeControl // For build manager and presentation compiler purposes
         }
         /** The two symbols have the same fully qualified name */
@@ -5081,7 +5081,7 @@ trait Types extends api.Types { self: SymbolTable =>
             if ((pre1 eq pre) && (sym1 eq sym) && (args1 eq args)/* && sym.isExternal*/) {
               tp
             } else if (sym1 == NoSymbol) {
-              debugwarn("adapt fail: "+pre+" "+pre1+" "+sym)
+              devWarning(s"adapt to new run failed: pre=$pre pre1=$pre1 sym=$sym")
               tp
             } else {
               copyTypeRef(tp, pre1, sym1, args1)
@@ -7270,7 +7270,7 @@ trait Types extends api.Types { self: SymbolTable =>
 
   protected def typeToString(tpe: Type): String =
     if (tostringRecursions >= maxTostringRecursions) {
-      debugwarn("Exceeded recursion depth attempting to print type.")
+      devWarning("Exceeded recursion depth attempting to print " + util.shortClassOfInstance(tpe))
       if (settings.debug.value)
         (new Throwable).printStackTrace
 

--- a/src/reflect/scala/reflect/internal/transform/Erasure.scala
+++ b/src/reflect/scala/reflect/internal/transform/Erasure.scala
@@ -233,7 +233,7 @@ trait Erasure {
           // It seems there is a deeper problem here, which needs
           // following up to. But we will not risk regressions
           // in 2.10 because of it.
-          log(s"!!! unexpected constructor erasure $tp for $clazz")
+          devWarning(s"unexpected constructor erasure $tp for $clazz")
         specialScalaErasure(tp)
     }
   }

--- a/test/files/neg/overloaded-implicit.flags
+++ b/test/files/neg/overloaded-implicit.flags
@@ -1,1 +1,1 @@
--Xlint -Xfatal-warnings
+-Xlint -Xfatal-warnings -Xdev


### PR DESCRIPTION
A setting we developers can give all the time and expect to
hear useful things without being buried in debugging output.
As the comment says:

  This is for WARNINGS which should reach the ears of scala
  developers whenever they occur, but are not useful for normal
  users. They should be precise, explanatory, and infrequent. Please
  don't use this as a logging mechanism. !!! is prefixed to all
  messages issued via this route to make them visually distinct.

This is what I always intended for "debugwarn", the method
I have deprecated in favor of the more accurate:

  def devWarning(msg: => String): Unit

In this VERY SAME COMMIT, I performed the CLOSELY RELATED
task of quieting down an -Xlint warning which had become too
noisy thanks to implicit classes tickling it. I tightened that
warn condition to include both -Xlint and -Xdev.
