### PR TITLE
SI-6677 Insert required cast in `new qual.foo.T`

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -788,6 +788,7 @@ abstract class Erasure extends AddInterfaces
             else if (qual1.tpe.isInstanceOf[MethodType] && qual1.tpe.params.isEmpty) {
               assert(qual1.symbol.isStable, qual1.symbol);
               qual1 = Apply(qual1, List()) setPos qual1.pos setType qual1.tpe.resultType
+              return adaptMember(treeCopy.Select(tree, qual1, name))
             } else if (!(qual1.isInstanceOf[Super] || (qual1.tpe.typeSymbol isSubClass tree.symbol.owner))) {
               assert(tree.symbol.owner != ArrayClass)
               qual1 = cast(qual1, tree.symbol.owner.tpe)

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -693,7 +693,7 @@ abstract class Erasure extends AddInterfaces
         adaptToType(unbox(tree, pt), pt)
       else if (isPrimitiveValueType(tree.tpe) && !isPrimitiveValueType(pt)) {
         adaptToType(box(tree, pt.toString), pt)
-      } else if (tree.tpe.isInstanceOf[MethodType] && tree.tpe.params.isEmpty) {
+      } else if (isMethodTypeWithEmptyParams(tree.tpe)) {
         // [H] this assert fails when trying to typecheck tree !(SomeClass.this.bitmap) for single lazy val
         //assert(tree.symbol.isStable, "adapt "+tree+":"+tree.tpe+" to "+pt)
         adaptToType(Apply(tree, List()) setPos tree.pos setType tree.tpe.resultType, pt)
@@ -783,17 +783,21 @@ abstract class Erasure extends AddInterfaces
             else if (!isPrimitiveValueType(qual1.tpe) && isPrimitiveValueMember(tree.symbol))
               qual1 = unbox(qual1, tree.symbol.owner.tpe)
 
-            if (isPrimitiveValueMember(tree.symbol) && !isPrimitiveValueType(qual1.tpe))
+            def selectFrom(qual: Tree) = treeCopy.Select(tree, qual, name)
+
+            if (isPrimitiveValueMember(tree.symbol) && !isPrimitiveValueType(qual1.tpe)) {
               tree.symbol = NoSymbol
-            else if (qual1.tpe.isInstanceOf[MethodType] && qual1.tpe.params.isEmpty) {
+              selectFrom(qual1)
+            } else if (isMethodTypeWithEmptyParams(qual1.tpe)) {
               assert(qual1.symbol.isStable, qual1.symbol);
-              qual1 = Apply(qual1, List()) setPos qual1.pos setType qual1.tpe.resultType
-              return adaptMember(treeCopy.Select(tree, qual1, name))
+              val applied = Apply(qual1, List()) setPos qual1.pos setType qual1.tpe.resultType
+              adaptMember(selectFrom(applied))
             } else if (!(qual1.isInstanceOf[Super] || (qual1.tpe.typeSymbol isSubClass tree.symbol.owner))) {
               assert(tree.symbol.owner != ArrayClass)
-              qual1 = cast(qual1, tree.symbol.owner.tpe)
+              selectFrom(cast(qual1, tree.symbol.owner.tpe))
+            } else {
+              selectFrom(qual1)
             }
-            treeCopy.Select(tree, qual1, name)
           }
         case SelectFromArray(qual, name, erasure) =>
           var qual1 = typedQualifier(qual)
@@ -870,6 +874,11 @@ abstract class Erasure extends AddInterfaces
         case _ =>
           tree1
       }
+    }
+
+    private def isMethodTypeWithEmptyParams(tpe: Type) = tpe match {
+      case MethodType(Nil, _) => true
+      case _                  => false
     }
   }
 

--- a/test/files/run/t6677.scala
+++ b/test/files/run/t6677.scala
@@ -1,0 +1,28 @@
+
+class Test {
+  val cm: reflect.runtime.universe.Mirror = reflect.runtime.currentMirror
+  def error {
+    new cm.universe.Traverser // java.lang.VerifyError: (class: Test, method: error signature: ()V) Incompatible object argument for function call
+
+  }
+
+  def okay1 {
+    val cm: reflect.runtime.universe.Mirror = reflect.runtime.currentMirror
+
+    new cm.universe.Traverser
+  }
+
+  def okay2 {
+    val cm: reflect.runtime.universe.Mirror = reflect.runtime.currentMirror
+    val u: reflect.runtime.universe.type = cm.universe
+    new u.Traverser
+  }
+}
+
+object Test {
+  def main(args: Array[String]) {
+    new Test().error
+    new Test().okay1
+    new Test().okay2
+  }
+}

--- a/test/files/run/t6677b.scala
+++ b/test/files/run/t6677b.scala
@@ -1,0 +1,33 @@
+trait U {
+	trait U1 {
+		class X
+	}
+	type U11 <: U1
+  val u : U11 = null.asInstanceOf[U11]
+}
+trait A extends U
+
+trait B extends U {
+  def foo = ""
+  class U11 extends U1 { class X extends super.X { foo } } // refer to foo to add $outer pointer
+  override val u = new U11
+}
+class C {
+  val ab: A with B = new A with B // `B with A` works.
+
+  def foo {
+    // fails
+    new ab.u.X
+
+    // works:
+    val u = ab.u
+    new u.X
+  }
+}
+object Test {
+	def main(args: Array[String]) {
+    // java.lang.NoSuchMethodError: A.u()LB$U11;
+    // at C.foo(t6677b.scala:23)
+		new C().foo
+	}
+}


### PR DESCRIPTION
Short version: we sometimes need to rewrite this as:

```
new T(qual.asInstanceOf[OwnerOfFoo].foo)
```

Long version:

`adaptMember` in Erasure performs a few tasks, among them:
1. adding an empty argument list qualifiers in `new qual.T`
   for which `qual` is a val template member that has
   (post uncurry) a MethodType with an empty parameter list.
   
   The same rewriting was already applied in uncurry for such
   qualifiers appearing in other context, e.g. `qual.foo` was
   already rewritten to `qual().foo`.
2. casting, if necessary, the qualifier in `Select(qual, name)`
   to the type of owner of the symbol that this selection
   references.
   
   This can be neccesary with compound types:
   - some val class member has type `A with B`;
   - we instantiate `new ab.valMemberOfB.T`
   - we must pass `ab.valMemberOfB` to the constructor of `T`
     as the `$outer` pointer
   - we must cast `ab` to `B` before calling `valMemberOfB`.
   
   Failure to insert this cast can lead to a LinkageError or
   a VerifyError.

However, if 1) was performed, 2) was not.

The error is pretty easy to trigger with the new reflection
API:

```
class Test {
  val cm: reflect.runtime.universe.Mirror
      = reflect.runtime.currentMirror
  def error {
    new cm.universe.Traverser // java.lang.VerifyError
  }

  def okay1 {
    val cm: reflect.runtime.universe.Mirror = reflect.runtime.currentMirror
    new cm.universe.Traverser
  }
}
```

The fix applied here to `adaptMember` mirrors the existing
implementation of `adaptType`.

Review by @odersky
