### PR TITLE
Re SI-6688

### DIFF
--- a/src/compiler/scala/tools/nsc/io/Socket.scala
+++ b/src/compiler/scala/tools/nsc/io/Socket.scala
@@ -35,7 +35,7 @@ object Socket {
 
   def newIPv4Server(port: Int = 0)        = new Box(() => preferringIPv4(new ServerSocket(0)))
   def newServer(port: Int = 0)            = new Box(() => new ServerSocket(0))
-  def localhost(port: Int)                = apply(InetAddress.getLocalHost(), port)
+  def localhost(port: Int)                = apply(InetAddress.getByAddress(Array[Byte](127,0,0,1)), port)
   def apply(host: InetAddress, port: Int) = new Box(() => new Socket(new JSocket(host, port)))
   def apply(host: String, port: Int)      = new Box(() => new Socket(new JSocket(host, port)))
 }


### PR DESCRIPTION
CompileClient now connects by default to the "localhost/127.0.0.1" interface rather than the public external facing local interface.
