### PR TITLE
SI-6696 removes "helper" tree factory methods

### DIFF
--- a/src/reflect/scala/reflect/api/Trees.scala
+++ b/src/reflect/scala/reflect/api/Trees.scala
@@ -1611,14 +1611,23 @@ trait Trees { self: Universe =>
    *  This node always occurs in the following context:
    *
    *    (`new` tpt).<init>[targs](args)
+   *
+   *  For example, an AST representation of:
+   *
+   *    new Example[Int](2)(3)
+   *
+   *  is the following code:
+   *
+   *    Apply(
+   *      Apply(
+   *        TypeApply(
+   *          Select(New(TypeTree(typeOf[Example])), nme.CONSTRUCTOR)
+   *          TypeTree(typeOf[Int])),
+   *        List(Literal(Constant(2)))),
+   *      List(Literal(Constant(3))))
    *  @group Extractors
    */
   abstract class NewExtractor {
-    /** A user level `new`.
-     *  One should always use this factory method to build a user level `new`.
-     *
-     *  @param tpt    a class type
-     */
     def apply(tpt: Tree): New
     def unapply(new_ : New): Option[Tree]
   }
@@ -2371,118 +2380,141 @@ trait Trees { self: Universe =>
   /** A factory method for `ClassDef` nodes.
    *  @group Factories
    */
+  @deprecated("Use the canonical ClassDef constructor to create a class and then initialize its position and symbol manually", "2.10.1")
   def ClassDef(sym: Symbol, impl: Template): ClassDef
 
   /** A factory method for `ModuleDef` nodes.
    *  @group Factories
    */
+  @deprecated("Use the canonical ModuleDef constructor to create an object and then initialize its position and symbol manually", "2.10.1")
   def ModuleDef(sym: Symbol, impl: Template): ModuleDef
 
   /** A factory method for `ValDef` nodes.
    *  @group Factories
    */
+  @deprecated("Use the canonical ValDef constructor to create a val and then initialize its position and symbol manually", "2.10.1")
   def ValDef(sym: Symbol, rhs: Tree): ValDef
 
   /** A factory method for `ValDef` nodes.
    *  @group Factories
    */
+  @deprecated("Use the canonical ValDef constructor to create a val with an empty right-hand side and then initialize its position and symbol manually", "2.10.1")
   def ValDef(sym: Symbol): ValDef
 
   /** A factory method for `ValDef` nodes.
    *  @group Factories
    */
+  @deprecated("Use the canonical DefDef constructor to create a method and then initialize its position and symbol manually", "2.10.1")
   def DefDef(sym: Symbol, mods: Modifiers, vparamss: List[List[ValDef]], rhs: Tree): DefDef
 
   /** A factory method for `ValDef` nodes.
    *  @group Factories
    */
+  @deprecated("Use the canonical DefDef constructor to create a method and then initialize its position and symbol manually", "2.10.1")
   def DefDef(sym: Symbol, vparamss: List[List[ValDef]], rhs: Tree): DefDef
 
   /** A factory method for `ValDef` nodes.
    *  @group Factories
    */
+  @deprecated("Use the canonical DefDef constructor to create a method and then initialize its position and symbol manually", "2.10.1")
   def DefDef(sym: Symbol, mods: Modifiers, rhs: Tree): DefDef
 
   /** A factory method for `ValDef` nodes.
    *  @group Factories
    */
+  @deprecated("Use the canonical DefDef constructor to create a method and then initialize its position and symbol manually", "2.10.1")
   def DefDef(sym: Symbol, rhs: Tree): DefDef
 
   /** A factory method for `ValDef` nodes.
    *  @group Factories
    */
+  @deprecated("Use the canonical DefDef constructor to create a method and then initialize its position and symbol manually", "2.10.1")
   def DefDef(sym: Symbol, rhs: List[List[Symbol]] => Tree): DefDef
 
   /** A factory method for `TypeDef` nodes.
    *  @group Factories
    */
+  @deprecated("Use the canonical TypeDef constructor to create a type alias and then initialize its position and symbol manually", "2.10.1")
   def TypeDef(sym: Symbol, rhs: Tree): TypeDef
 
   /** A factory method for `TypeDef` nodes.
    *  @group Factories
    */
+  @deprecated("Use the canonical TypeDef constructor to create an abstract type or type parameter and then initialize its position and symbol manually", "2.10.1")
   def TypeDef(sym: Symbol): TypeDef
 
   /** A factory method for `LabelDef` nodes.
    *  @group Factories
    */
+  @deprecated("Use the canonical LabelDef constructor to create a label and then initialize its position and symbol manually", "2.10.1")
   def LabelDef(sym: Symbol, params: List[Symbol], rhs: Tree): LabelDef
 
   /** A factory method for `Block` nodes.
    *  Flattens directly nested blocks.
    *  @group Factories
    */
+  @deprecated("Use the canonical Block constructor, explicitly specifying its expression if necessary. Flatten directly nested blocks manually if needed", "2.10.1")
   def Block(stats: Tree*): Block
 
   /** A factory method for `CaseDef` nodes.
    *  @group Factories
    */
+  @deprecated("Use the canonical CaseDef constructor passing EmptyTree for guard", "2.10.1")
   def CaseDef(pat: Tree, body: Tree): CaseDef
 
   /** A factory method for `Bind` nodes.
    *  @group Factories
    */
+  @deprecated("Use the canonical Bind constructor to create a bind and then initialize its symbol manually", "2.10.1")
   def Bind(sym: Symbol, body: Tree): Bind
 
   /** A factory method for `Try` nodes.
    *  @group Factories
    */
+  @deprecated("Use canonical CaseDef constructors to to create exception catching expressions and then wrap them in Try", "2.10.1")
   def Try(body: Tree, cases: (Tree, Tree)*): Try
 
   /** A factory method for `Throw` nodes.
    *  @group Factories
    */
+  @deprecated("Use the canonical New constructor to create an object instantiation expression and then wrap it in Throw", "2.10.1")
   def Throw(tpe: Type, args: Tree*): Throw
 
   /** Factory method for object creation `new tpt(args_1)...(args_n)`
    *  A `New(t, as)` is expanded to: `(new t).<init>(as)`
    *  @group Factories
    */
+  @deprecated("Use Apply(...Apply(Select(New(tpt), nme.CONSTRUCTOR), args1)...argsN) instead", "2.10.1")
   def New(tpt: Tree, argss: List[List[Tree]]): Tree
 
   /** 0-1 argument list new, based on a type.
    *  @group Factories
    */
+  @deprecated("Use New(TypeTree(tpe), args.toList) instead", "2.10.1")
   def New(tpe: Type, args: Tree*): Tree
 
   /** 0-1 argument list new, based on a symbol.
    *  @group Factories
    */
+  @deprecated("Use New(sym.toType, args) instead", "2.10.1")
   def New(sym: Symbol, args: Tree*): Tree
 
   /** A factory method for `Apply` nodes.
    *  @group Factories
    */
+  @deprecated("Use Apply(Ident(sym), args.toList) instead", "2.10.1")
   def Apply(sym: Symbol, args: Tree*): Tree
 
   /** 0-1 argument list new, based on a type tree.
    *  @group Factories
    */
+  @deprecated("Use Apply(Select(New(tpt), nme.CONSTRUCTOR), args) instead", "2.10.1")
   def ApplyConstructor(tpt: Tree, args: List[Tree]): Tree
 
   /** A factory method for `Super` nodes.
    *  @group Factories
    */
+  @deprecated("Use Super(This(sym), mix) instead", "2.10.1")
   def Super(sym: Symbol, mix: TypeName): Tree
 
   /** A factory method for `This` nodes.
@@ -2494,6 +2526,7 @@ trait Trees { self: Universe =>
    *  The string `name` argument is assumed to represent a [[scala.reflect.api.Names#TermName `TermName`]].
    *  @group Factories
    */
+  @deprecated("Use Select(tree, newTermName(name)) instead", "2.10.1")
   def Select(qualifier: Tree, name: String): Select
 
   /** A factory method for `Select` nodes.
@@ -2504,6 +2537,7 @@ trait Trees { self: Universe =>
   /** A factory method for `Ident` nodes.
    *  @group Factories
    */
+  @deprecated("Use Ident(newTermName(name)) instead", "2.10.1")
   def Ident(name: String): Ident
 
   /** A factory method for `Ident` nodes.

--- a/src/reflect/scala/reflect/api/Trees.scala
+++ b/src/reflect/scala/reflect/api/Trees.scala
@@ -1729,6 +1729,16 @@ trait Trees { self: Universe =>
    *  This AST node corresponds to the following Scala code:
    *
    *    fun[args]
+   *
+   *  Should only be used with `fun` nodes which are terms, i.e. which have `isTerm` returning `true`.
+   *  Otherwise `AppliedTypeTree` should be used instead.
+   *
+   *    def foo[T] = ???
+   *    foo[Int] // represented as TypeApply(Ident(<foo>), List(TypeTree(<Int>)))
+   *
+   *    List[Int] as in `val x: List[Int] = ???`
+   *    // represented as AppliedTypeTree(Ident(<List>), List(TypeTree(<Int>)))
+   *
    *  @group Extractors
    */
   abstract class TypeApplyExtractor {
@@ -1899,6 +1909,12 @@ trait Trees { self: Universe =>
    *  This AST node corresponds to the following Scala code:
    *
    *    qualifier.selector
+   *
+   *  Should only be used with `qualifier` nodes which are terms, i.e. which have `isTerm` returning `true`.
+   *  Otherwise `SelectFromTypeTree` should be used instead.
+   *
+   *    foo.Bar // represented as Select(Ident(<foo>), <Bar>)
+   *    Foo#Bar // represented as SelectFromTypeTree(Ident(<Foo>), <Bar>)
    *  @group Extractors
    */
   abstract class SelectExtractor {
@@ -2131,7 +2147,6 @@ trait Trees { self: Universe =>
    *  @group Trees
    *  @template
    */
-  // [Eugene++] don't see why we need it, when we have Select
   type SelectFromTypeTree >: Null <: TypTree with RefTree with SelectFromTypeTreeApi
 
   /** A tag that preserves the identity of the `SelectFromTypeTree` abstract type from erasure.
@@ -2151,6 +2166,12 @@ trait Trees { self: Universe =>
    *    qualifier # selector
    *
    *  Note: a path-dependent type p.T is expressed as p.type # T
+   *
+   *  Should only be used with `qualifier` nodes which are types, i.e. which have `isType` returning `true`.
+   *  Otherwise `Select` should be used instead.
+   *
+   *    Foo#Bar // represented as SelectFromTypeTree(Ident(<Foo>), <Bar>)
+   *    foo.Bar // represented as Select(Ident(<foo>), <Bar>)
    *  @group Extractors
    */
   abstract class SelectFromTypeTreeExtractor {
@@ -2226,6 +2247,15 @@ trait Trees { self: Universe =>
    *  This AST node corresponds to the following Scala code:
    *
    *    tpt[args]
+   *
+   *  Should only be used with `tpt` nodes which are types, i.e. which have `isType` returning `true`.
+   *  Otherwise `TypeApply` should be used instead.
+   *
+   *    List[Int] as in `val x: List[Int] = ???`
+   *    // represented as AppliedTypeTree(Ident(<List>), List(TypeTree(<Int>)))
+   *
+   *    def foo[T] = ???
+   *    foo[Int] // represented as TypeApply(Ident(<foo>), List(TypeTree(<Int>)))
    *  @group Extractors
    */
   abstract class AppliedTypeTreeExtractor {

--- a/test/files/neg/macro-invalidsig-implicit-params/Impls_Macros_1.scala
+++ b/test/files/neg/macro-invalidsig-implicit-params/Impls_Macros_1.scala
@@ -5,10 +5,10 @@ object Impls {
   def foo_targs[T, U: c.WeakTypeTag](c: Ctx)(implicit x: c.Expr[Int]) = {
     import c.{prefix => prefix}
     import c.universe._
-    val body = Block(
+    val body = Block(List(
       Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("invoking foo_targs...")))),
       Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("type of prefix is: " + prefix.staticType)))),
-      Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("U is: " + implicitly[c.WeakTypeTag[U]].tpe)))),
+      Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("U is: " + implicitly[c.WeakTypeTag[U]].tpe))))),
       Literal(Constant(())))
     c.Expr[Unit](body)
   }

--- a/test/files/run/macro-abort-fresh/Test_2.scala
+++ b/test/files/run/macro-abort-fresh/Test_2.scala
@@ -2,7 +2,7 @@ object Test extends App {
   import scala.reflect.runtime.universe._
   import scala.reflect.runtime.{currentMirror => cm}
   import scala.tools.reflect.ToolBox
-  val tree = Select(Ident("Macros"), newTermName("foo"))
+  val tree = Select(Ident(newTermName("Macros")), newTermName("foo"))
   try cm.mkToolBox().eval(tree)
   catch { case ex: Throwable =>  println(ex.getMessage) }
 }

--- a/test/files/run/macro-declared-in-class-class/Impls_1.scala
+++ b/test/files/run/macro-declared-in-class-class/Impls_1.scala
@@ -5,7 +5,7 @@ object Impls {
     import c.{prefix => prefix}
     import c.universe._
     val printPrefix = Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("prefix = " + prefix))))
-    val body = Block(printPrefix, Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("it works")))))
+    val body = Block(List(printPrefix), Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("it works")))))
     c.Expr[Unit](body)
   }
 }

--- a/test/files/run/macro-declared-in-class-object/Impls_1.scala
+++ b/test/files/run/macro-declared-in-class-object/Impls_1.scala
@@ -5,7 +5,7 @@ object Impls {
     import c.{prefix => prefix}
     import c.universe._
     val printPrefix = Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("prefix = " + prefix))))
-    val body = Block(printPrefix, Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("it works")))))
+    val body = Block(List(printPrefix), Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("it works")))))
     c.Expr[Unit](body)
   }
 }

--- a/test/files/run/macro-declared-in-class/Impls_1.scala
+++ b/test/files/run/macro-declared-in-class/Impls_1.scala
@@ -5,7 +5,7 @@ object Impls {
     import c.{prefix => prefix}
     import c.universe._
     val printPrefix = Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("prefix = " + prefix))))
-    val body = Block(printPrefix, Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("it works")))))
+    val body = Block(List(printPrefix), Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("it works")))))
     c.Expr[Unit](body)
   }
 }

--- a/test/files/run/macro-declared-in-implicit-class/Impls_Macros_1.scala
+++ b/test/files/run/macro-declared-in-implicit-class/Impls_Macros_1.scala
@@ -5,7 +5,7 @@ object Impls {
     import c.{prefix => prefix}
     import c.universe._
     val printPrefix = Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("prefix = " + prefix))))
-    val body = Block(printPrefix, Apply(Ident(definitions.SomeModule), List(Select(Select(prefix.tree, newTermName("x")), newTermName("toInt")))))
+    val body = Block(List(printPrefix), Apply(Ident(definitions.SomeModule), List(Select(Select(prefix.tree, newTermName("x")), newTermName("toInt")))))
     c.Expr[Option[Int]](body)
   }
 }

--- a/test/files/run/macro-declared-in-method/Impls_1.scala
+++ b/test/files/run/macro-declared-in-method/Impls_1.scala
@@ -5,7 +5,7 @@ object Impls {
     import c.{prefix => prefix}
     import c.universe._
     val printPrefix = Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("prefix = " + prefix))))
-    val body = Block(printPrefix, Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("it works")))))
+    val body = Block(List(printPrefix), Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("it works")))))
     c.Expr[Unit](body)
   }
 }

--- a/test/files/run/macro-declared-in-object-class/Impls_1.scala
+++ b/test/files/run/macro-declared-in-object-class/Impls_1.scala
@@ -5,7 +5,7 @@ object Impls {
     import c.{prefix => prefix}
     import c.universe._
     val printPrefix = Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("prefix = " + prefix))))
-    val body = Block(printPrefix, Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("it works")))))
+    val body = Block(List(printPrefix), Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("it works")))))
     c.Expr[Unit](body)
   }
 }

--- a/test/files/run/macro-declared-in-object-object/Impls_1.scala
+++ b/test/files/run/macro-declared-in-object-object/Impls_1.scala
@@ -5,7 +5,7 @@ object Impls {
     import c.{prefix => prefix}
     import c.universe._
     val printPrefix = Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("prefix = " + prefix))))
-    val body = Block(printPrefix, Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("it works")))))
+    val body = Block(List(printPrefix), Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("it works")))))
     c.Expr[Unit](body)
   }
 }

--- a/test/files/run/macro-declared-in-object/Impls_1.scala
+++ b/test/files/run/macro-declared-in-object/Impls_1.scala
@@ -5,7 +5,7 @@ object Impls {
     import c.{prefix => prefix}
     import c.universe._
     val printPrefix = Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("prefix = " + prefix))))
-    val body = Block(printPrefix, Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("it works")))))
+    val body = Block(List(printPrefix), Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("it works")))))
     c.Expr[Unit](body)
   }
 }

--- a/test/files/run/macro-declared-in-package-object/Impls_1.scala
+++ b/test/files/run/macro-declared-in-package-object/Impls_1.scala
@@ -5,7 +5,7 @@ object Impls {
     import c.{prefix => prefix}
     import c.universe._
     val printPrefix = Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("prefix = " + prefix))))
-    val body = Block(printPrefix, Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("it works")))))
+    val body = Block(List(printPrefix), Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("it works")))))
     c.Expr[Unit](body)
   }
 }

--- a/test/files/run/macro-declared-in-refinement/Impls_1.scala
+++ b/test/files/run/macro-declared-in-refinement/Impls_1.scala
@@ -5,7 +5,7 @@ object Impls {
     import c.{prefix => prefix}
     import c.universe._
     val printPrefix = Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("prefix = " + prefix))))
-    val body = Block(printPrefix, Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("it works")))))
+    val body = Block(List(printPrefix), Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("it works")))))
     c.Expr[Unit](body)
   }
 }

--- a/test/files/run/macro-declared-in-trait/Impls_1.scala
+++ b/test/files/run/macro-declared-in-trait/Impls_1.scala
@@ -5,7 +5,7 @@ object Impls {
     import c.{prefix => prefix}
     import c.universe._
     val printPrefix = Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("prefix = " + prefix))))
-    val body = Block(printPrefix, Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("it works")))))
+    val body = Block(List(printPrefix), Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("it works")))))
     c.Expr[Unit](body)
   }
 }

--- a/test/files/run/macro-def-infer-return-type-b/Test_2.scala
+++ b/test/files/run/macro-def-infer-return-type-b/Test_2.scala
@@ -2,7 +2,7 @@ object Test extends App {
   import scala.reflect.runtime.universe._
   import scala.reflect.runtime.{currentMirror => cm}
   import scala.tools.reflect.ToolBox
-  val tree = Apply(Select(Ident("Macros"), newTermName("foo")), List(Literal(Constant(42))))
+  val tree = Apply(Select(Ident(newTermName("Macros")), newTermName("foo")), List(Literal(Constant(42))))
   try cm.mkToolBox().eval(tree)
   catch { case ex: Throwable =>  println(ex.getMessage) }
 }

--- a/test/files/run/macro-expand-implicit-argument/Macros_1.scala
+++ b/test/files/run/macro-expand-implicit-argument/Macros_1.scala
@@ -43,16 +43,16 @@ object Macros {
     val n = as.length
     val arr = newTermName("arr")
 
-    val create = Apply(Select(ct.tree, "newArray"), List(const(n)))
+    val create = Apply(Select(ct.tree, newTermName("newArray")), List(const(n)))
     val arrtpe = TypeTree(implicitly[c.WeakTypeTag[Array[A]]].tpe)
     val valdef = ValDef(Modifiers(), arr, arrtpe, create)
 
     val updates = (0 until n).map {
-      i => Apply(Select(Ident(arr), "update"), List(const(i), as(i).tree))
+      i => Apply(Select(Ident(arr), newTermName("update")), List(const(i), as(i).tree))
     }
 
-    val exprs = Seq(valdef) ++ updates ++ Seq(Ident(arr))
-    val block = Block(exprs:_*)
+    val exprs = (Seq(valdef) ++ updates ++ Seq(Ident(arr))).toList
+    val block = Block(exprs.init, exprs.last)
 
     c.Expr[Array[A]](block)
   }

--- a/test/files/run/macro-expand-varargs-explicit-over-nonvarargs-bad/Macros_Test_2.scala
+++ b/test/files/run/macro-expand-varargs-explicit-over-nonvarargs-bad/Macros_Test_2.scala
@@ -6,7 +6,7 @@ object Test extends App {
   import scala.reflect.runtime.universe._
   import scala.reflect.runtime.{currentMirror => cm}
   import scala.tools.reflect.ToolBox
-  val tree = Apply(Select(Ident("Macros"), newTermName("foo")), List(Typed(Apply(Ident(definitions.ListModule), List(Literal(Constant(1)), Literal(Constant(2)))), Ident(tpnme.WILDCARD_STAR))))
+  val tree = Apply(Select(Ident(newTermName("Macros")), newTermName("foo")), List(Typed(Apply(Ident(definitions.ListModule), List(Literal(Constant(1)), Literal(Constant(2)))), Ident(tpnme.WILDCARD_STAR))))
   try cm.mkToolBox().eval(tree)
   catch { case ex: Throwable =>  println(ex.getMessage) }
 }

--- a/test/files/run/macro-impl-default-params/Impls_Macros_1.scala
+++ b/test/files/run/macro-impl-default-params/Impls_Macros_1.scala
@@ -6,11 +6,11 @@ object Impls {
     import c.{prefix => prefix}
     import c.universe._
     val U = implicitly[c.WeakTypeTag[U]]
-    val body = Block(
+    val body = Block(List(
       Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("invoking foo_targs...")))),
       Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("type of prefix is: " + prefix.staticType)))),
       Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("type of prefix tree is: " + prefix.tree.tpe)))),
-      Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("U is: " + U.tpe)))),
+      Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("U is: " + U.tpe))))),
       Literal(Constant(())))
     c.Expr[Unit](body)
   }

--- a/test/files/run/macro-impl-rename-context/Impls_Macros_1.scala
+++ b/test/files/run/macro-impl-rename-context/Impls_Macros_1.scala
@@ -3,8 +3,8 @@ import scala.reflect.macros.{Context => Ctx}
 object Impls {
   def foo(unconventionalName: Ctx)(x: unconventionalName.Expr[Int]) = {
     import unconventionalName.universe._
-    val body = Block(
-      Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("invoking foo...")))),
+    val body = Block(List(
+      Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Literal(Constant("invoking foo..."))))),
       Literal(Constant(())))
     unconventionalName.Expr[Unit](body)
   }

--- a/test/files/run/macro-invalidret-doesnt-conform-to-def-rettype/Test_2.scala
+++ b/test/files/run/macro-invalidret-doesnt-conform-to-def-rettype/Test_2.scala
@@ -2,7 +2,7 @@ object Test extends App {
   import scala.reflect.runtime.universe._
   import scala.reflect.runtime.{currentMirror => cm}
   import scala.tools.reflect.ToolBox
-  val tree = Select(Ident("Macros"), newTermName("foo"))
+  val tree = Select(Ident(newTermName("Macros")), newTermName("foo"))
   try cm.mkToolBox().eval(tree)
   catch { case ex: Throwable =>  println(ex.getMessage) }
 }

--- a/test/files/run/macro-invalidret-nontypeable/Impls_Macros_1.scala
+++ b/test/files/run/macro-invalidret-nontypeable/Impls_Macros_1.scala
@@ -3,7 +3,7 @@ import scala.reflect.macros.{Context => Ctx}
 object Impls {
   def foo(c: Ctx) = {
     import c.universe._
-    val body = Ident("IDoNotExist")
+    val body = Ident(newTermName("IDoNotExist"))
     c.Expr[Int](body)
   }
 }

--- a/test/files/run/macro-invalidret-nontypeable/Test_2.scala
+++ b/test/files/run/macro-invalidret-nontypeable/Test_2.scala
@@ -1,8 +1,8 @@
-object Test extends App {
+  object Test extends App {
   import scala.reflect.runtime.universe._
   import scala.reflect.runtime.{currentMirror => cm}
   import scala.tools.reflect.ToolBox
-  val tree = Select(Ident("Macros"), newTermName("foo"))
+  val tree = Select(Ident(newTermName("Macros")), newTermName("foo"))
   try cm.mkToolBox().eval(tree)
   catch { case ex: Throwable =>  println(ex.getMessage) }
 }

--- a/test/files/run/macro-invalidusage-badret/Test_2.scala
+++ b/test/files/run/macro-invalidusage-badret/Test_2.scala
@@ -2,7 +2,7 @@ object Test extends App {
   import scala.reflect.runtime.universe._
   import scala.reflect.runtime.{currentMirror => cm}
   import scala.tools.reflect.ToolBox
-  val tree = Typed(Apply(Select(Ident("Macros"), newTermName("foo")), List(Literal(Constant(42)))), Ident(newTypeName("String")))
+  val tree = Typed(Apply(Select(Ident(newTermName("Macros")), newTermName("foo")), List(Literal(Constant(42)))), Ident(newTypeName("String")))
   try cm.mkToolBox().eval(tree)
   catch { case ex: Throwable =>  println(ex.getMessage) }
 }

--- a/test/files/run/macro-invalidusage-partialapplication-with-tparams/Test_2.scala
+++ b/test/files/run/macro-invalidusage-partialapplication-with-tparams/Test_2.scala
@@ -2,7 +2,7 @@ object Test extends App {
   import scala.reflect.runtime.universe._
   import scala.reflect.runtime.{currentMirror => cm}
   import scala.tools.reflect.ToolBox
-  val tree = Select(Ident("Macros"), newTermName("foo"))
+  val tree = Select(Ident(newTermName("Macros")), newTermName("foo"))
   try cm.mkToolBox().eval(tree)
   catch { case ex: Throwable =>  println(ex.getMessage) }
 }

--- a/test/files/run/macro-invalidusage-partialapplication/Test_2.scala
+++ b/test/files/run/macro-invalidusage-partialapplication/Test_2.scala
@@ -2,7 +2,7 @@ object Test extends App {
   import scala.reflect.runtime.universe._
   import scala.reflect.runtime.{currentMirror => cm}
   import scala.tools.reflect.ToolBox
-  val tree = Apply(Select(Ident("Macros"), newTermName("foo")), List(Literal(Constant(40))))
+  val tree = Apply(Select(Ident(newTermName("Macros")), newTermName("foo")), List(Literal(Constant(40))))
   try cm.mkToolBox().eval(tree)
   catch { case ex: Throwable =>  println(ex.getMessage) }
 }

--- a/test/files/run/macro-reflective-ma-normal-mdmi/Test_2.scala
+++ b/test/files/run/macro-reflective-ma-normal-mdmi/Test_2.scala
@@ -2,6 +2,6 @@ object Test extends App {
   import scala.reflect.runtime.universe._
   import scala.reflect.runtime.{currentMirror => cm}
   import scala.tools.reflect.ToolBox
-  val tree = Apply(Select(Ident("Macros"), newTermName("foo")), List(Literal(Constant(42))))
+  val tree = Apply(Select(Ident(newTermName("Macros")), newTermName("foo")), List(Literal(Constant(42))))
   println(cm.mkToolBox().eval(tree))
 }

--- a/test/files/run/macro-reflective-mamd-normal-mi/Macros_Test_2.scala
+++ b/test/files/run/macro-reflective-mamd-normal-mi/Macros_Test_2.scala
@@ -11,10 +11,10 @@ object Test extends App {
   val macrobody = Select(Ident(newTermName("Impls")), newTermName("foo"))
   val macroparam = ValDef(NoMods, newTermName("x"), TypeTree(definitions.IntClass.toType), EmptyTree)
   val macrodef = DefDef(Modifiers(MACRO), newTermName("foo"), Nil, List(List(macroparam)), TypeTree(), macrobody)
-  val modulector = DefDef(NoMods, nme.CONSTRUCTOR, Nil, List(List()), TypeTree(), Block(Apply(Select(Super(This(tpnme.EMPTY), tpnme.EMPTY), nme.CONSTRUCTOR), List())))
+  val modulector = DefDef(NoMods, nme.CONSTRUCTOR, Nil, List(List()), TypeTree(), Block(List(Apply(Select(Super(This(tpnme.EMPTY), tpnme.EMPTY), nme.CONSTRUCTOR), List())), Literal(Constant(()))))
   val module = ModuleDef(NoMods, newTermName("Macros"), Template(Nil, emptyValDef, List(modulector, macrodef)))
-  val macroapp = Apply(Select(Ident("Macros"), newTermName("foo")), List(Literal(Constant(42))))
-  val tree = Block(macrodef, module, macroapp)
+  val macroapp = Apply(Select(Ident(newTermName("Macros")), newTermName("foo")), List(Literal(Constant(42))))
+  val tree = Block(List(macrodef, module), macroapp)
   val toolbox = cm.mkToolBox(options = "-language:experimental.macros")
   println(toolbox.eval(tree))
 }

--- a/test/files/run/macro-reify-freevars/Test_2.scala
+++ b/test/files/run/macro-reify-freevars/Test_2.scala
@@ -2,8 +2,8 @@ object Test extends App {
   import scala.reflect.runtime.universe._
   import scala.reflect.runtime.{currentMirror => cm}
   import scala.tools.reflect.ToolBox
-  val q = New(AppliedTypeTree(Select(Select(Select(Ident("scala"), newTermName("collection")), newTermName("slick")), newTypeName("Queryable")), List(Ident("Int"))))
-  val x = ValDef(NoMods, newTermName("x"), Ident("Int"), EmptyTree)
+  val q = New(AppliedTypeTree(Select(Select(Select(Ident(newTermName("scala")), newTermName("collection")), newTermName("slick")), newTypeName("Queryable")), List(Ident(newTermName("Int")))))
+  val x = ValDef(NoMods, newTermName("x"), Ident(newTermName("Int")), EmptyTree)
   val fn = Function(List(x), Apply(Select(Ident(newTermName("x")), newTermName("$plus")), List(Literal(Constant("5")))))
   val tree = Apply(Select(q, newTermName("map")), List(fn))
   try cm.mkToolBox().eval(tree)

--- a/test/files/run/macro-reify-splice-outside-reify/Test_2.scala
+++ b/test/files/run/macro-reify-splice-outside-reify/Test_2.scala
@@ -2,7 +2,7 @@ object Test extends App {
   import scala.reflect.runtime.universe._
   import scala.reflect.runtime.{currentMirror => cm}
   import scala.tools.reflect.ToolBox
-  val tree = Apply(Select(Ident("Macros"), newTermName("foo")), List(Literal(Constant(42))))
+  val tree = Apply(Select(Ident(newTermName("Macros")), newTermName("foo")), List(Literal(Constant(42))))
   try println(cm.mkToolBox().eval(tree))
   catch { case ex: Throwable =>  println(ex.getMessage) }
 }

--- a/test/files/run/macro-reify-tagless-a/Test_2.scala
+++ b/test/files/run/macro-reify-tagless-a/Test_2.scala
@@ -6,9 +6,9 @@ object Test extends App {
   import scala.reflect.runtime.{currentMirror => cm}
   import scala.tools.reflect.ToolBox
   val tpt = AppliedTypeTree(Ident(definitions.ListClass), List(Ident(definitions.StringClass)))
-  val rhs = Apply(Select(Ident("Macros"), newTermName("foo")), List(Literal(Constant("hello world"))))
+  val rhs = Apply(Select(Ident(newTermName("Macros")), newTermName("foo")), List(Literal(Constant("hello world"))))
   val list = ValDef(NoMods, newTermName("list"), tpt, rhs)
-  val tree = Block(list, Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Ident(list.name))))
+  val tree = Block(List(list), Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Ident(list.name))))
   try cm.mkToolBox().eval(tree)
   catch { case ex: Throwable =>  println(ex.getMessage) }
 }

--- a/test/files/run/toolbox_typecheck_implicitsdisabled.scala
+++ b/test/files/run/toolbox_typecheck_implicitsdisabled.scala
@@ -6,16 +6,16 @@ import scala.tools.reflect.ToolBox
 object Test extends App {
   val toolbox = cm.mkToolBox()
 
-  val tree1 = Block(
-    Import(Select(Ident(newTermName("scala")), newTermName("Predef")), List(ImportSelector(nme.WILDCARD, -1, null, -1))),
+  val tree1 = Block(List(
+    Import(Select(Ident(newTermName("scala")), newTermName("Predef")), List(ImportSelector(nme.WILDCARD, -1, null, -1)))),
     Apply(Select(Literal(Constant(1)), newTermName("$minus$greater")), List(Literal(Constant(2))))
   )
   val ttree1 = toolbox.typeCheck(tree1, withImplicitViewsDisabled = false)
   println(ttree1)
 
   try {
-    val tree2 = Block(
-      Import(Select(Ident(newTermName("scala")), newTermName("Predef")), List(ImportSelector(nme.WILDCARD, -1, null, -1))),
+    val tree2 = Block(List(
+      Import(Select(Ident(newTermName("scala")), newTermName("Predef")), List(ImportSelector(nme.WILDCARD, -1, null, -1)))),
       Apply(Select(Literal(Constant(1)), newTermName("$minus$greater")), List(Literal(Constant(2))))
     )
     val ttree2 = toolbox.typeCheck(tree2, withImplicitViewsDisabled = true)

--- a/test/pending/run/macro-reify-tagless-b/Test_2.scala
+++ b/test/pending/run/macro-reify-tagless-b/Test_2.scala
@@ -6,7 +6,7 @@ object Test extends App {
   import scala.reflect.runtime.{currentMirror => cm}
   import scala.tools.reflect.ToolBox
   val tpt = AppliedTypeTree(Ident(definitions.ListClass), List(Ident(definitions.StringClass)))
-  val rhs = Apply(Select(Ident("Macros"), newTermName("foo")), List(Literal(Constant("hello world"))))
+  val rhs = Apply(Select(Ident(newTermName("Macros")), newTermName("foo")), List(Literal(Constant("hello world"))))
   val list = ValDef(NoMods, newTermName("list"), tpt, rhs)
   val tree = Block(list, Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(Ident(list.name))))
   println(cm.mkToolBox().eval(tree))


### PR DESCRIPTION
As experience shows, these methods can easily be a source of confusion
for the newcomers: https://issues.scala-lang.org/browse/SI-6696.

I'm only leaving the `TypeTree(tp)` factory, since the facility to
set underlying types for type trees is not exposed in the public API,
as it's inherently mutable.
