### PR TITLE
SI-6023 reify abstract vals

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
@@ -373,6 +373,7 @@ trait MethodSynthesis {
         // spot that brand of them. In other words it's an artifact of the implementation.
         val tpt = derivedSym.tpe.finalResultType match {
           case ExistentialType(_, _)  => TypeTree()
+          case _ if mods.isDeferred   => TypeTree()
           case tp                     => TypeTree(tp)
         }
         tpt setPos derivedSym.pos.focus

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5001,8 +5001,14 @@ trait Typers extends Modes with Adaptations with Tags {
       }
 
       def typedTypeTree(tree: TypeTree) = {
-        if (tree.original != null)
-          tree setType typedType(tree.original, mode).tpe
+        if (tree.original != null) {
+          val newTpt = typedType(tree.original, mode)
+          tree setType newTpt.tpe
+          newTpt match {
+            case tt @ TypeTree() => tree setOriginal tt.original
+            case _ => tree
+          }
+        } 
         else
           // we should get here only when something before failed
           // and we try again (@see tryTypedApply). In that case we can assign

--- a/test/files/run/t6023.check
+++ b/test/files/run/t6023.check
@@ -1,0 +1,12 @@
+{
+  abstract trait Foo extends AnyRef {
+    <stable> <accessor> def a: Int
+  };
+  ()
+}
+{
+  abstract trait Foo extends AnyRef {
+    <stable> <accessor> def a: Int
+  };
+  ()
+}

--- a/test/files/run/t6023.scala
+++ b/test/files/run/t6023.scala
@@ -1,0 +1,17 @@
+import scala.reflect.runtime.universe._
+import scala.reflect.runtime.{currentMirror => cm}
+import scala.tools.reflect.ToolBox
+
+object Test extends App {
+  // test 1: reify
+  val tree = reify{ trait Foo { val a: Int } }.tree
+  println(tree.toString)
+
+  // test 2: import and typecheck
+  val toolbox = cm.mkToolBox()
+  val ttree = toolbox.typeCheck(tree)
+  println(ttree.toString)
+
+  // test 3: import and compile
+  toolbox.eval(tree)
+}


### PR DESCRIPTION
 SI-6023 reify abstract vals

Type trees created by MethodSynthesis for abstract val getters carry symless originals,
which are unusable for reification purposes
(or the result of reification will be unhygienic).

To combat this, type trees for such getters are now created empty,
i.e. without any `tpe` set, just having an original assigned.
Subsequent `typedTypeTree` invocations fill in the `tpe` and
update the original to be symful.
