### PR TITLE
SI-6667 Abort after any ambiguous in-scope implicit

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1394,7 +1394,7 @@ trait Implicits {
         if (Statistics.canEnable) Statistics.stopTimer(inscopeSucceedNanos, succstart)
         if (Statistics.canEnable) Statistics.incCounter(inscopeImplicitHits)
       }
-      if (result.isFailure) {
+      if (result.isFailure && !result.isAmbiguousFailure) { // SI-6667, never search companions after an ambiguous error in in-scope implicits
         val previousErrs = context.flushAndReturnBuffer()
         val failstart = if (Statistics.canEnable) Statistics.startTimer(oftypeFailNanos) else null
         val succstart = if (Statistics.canEnable) Statistics.startTimer(oftypeSucceedNanos) else null

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -132,7 +132,7 @@ trait Typers extends Modes with Adaptations with Tags {
           val res = if (paramFailed || (paramTp.isError && {paramFailed = true; true})) SearchFailure else inferImplicit(fun, paramTp, context.reportErrors, false, context)
           argResultsBuff += res
 
-          if (res != SearchFailure) {
+          if (res.isSuccess) {
             argBuff += mkArg(res.tree, param.name)
           } else {
             mkArg = mkNamedArg // don't pass the default argument (if any) here, but start emitting named arguments for the following args
@@ -761,7 +761,7 @@ trait Typers extends Modes with Adaptations with Tags {
           featureTrait.owner.ownerChain.takeWhile(_ != languageFeatureModule.moduleClass).reverse
         val featureName = (nestedOwners map (_.name + ".")).mkString + featureTrait.name
         def action(): Boolean = {
-          def hasImport = inferImplicit(EmptyTree: Tree, featureTrait.tpe, true, false, context) != SearchFailure
+          def hasImport = inferImplicit(EmptyTree: Tree, featureTrait.tpe, true, false, context).isSuccess
           def hasOption = settings.language.value exists (s => s == featureName || s == "_")
           val OK = hasImport || hasOption
           if (!OK) {

--- a/test/files/neg/t6667.check
+++ b/test/files/neg/t6667.check
@@ -1,0 +1,13 @@
+t6667.scala:8: error: ambiguous implicit values:
+ both value inScope1 in object Test of type => C
+ and value inScope2 in object Test of type => C
+ match expected type C
+  implicitly[C]: Unit // C.companion was used; whereas the ambiguity should abort the implicit search.
+            ^
+t6667.scala:9: error: ambiguous implicit values:
+ both value inScope1 in object Test of type => C
+ and value inScope2 in object Test of type => C
+ match expected type C
+  implicitly[C]       // ambiguity reported, rather than falling back to C.companion
+            ^
+two errors found

--- a/test/files/neg/t6667.scala
+++ b/test/files/neg/t6667.scala
@@ -1,0 +1,10 @@
+class C
+object C {
+  implicit def companion = new C
+}
+
+object Test {
+  implicit val inScope1, inScope2 = new C
+  implicitly[C]: Unit // C.companion was used; whereas the ambiguity should abort the implicit search.
+  implicitly[C]       // ambiguity reported, rather than falling back to C.companion
+}

--- a/test/files/neg/t6667b.check
+++ b/test/files/neg/t6667b.check
@@ -1,0 +1,13 @@
+t6667b.scala:16: error: ambiguous implicit values:
+ both value a in object Test of type => Test.Box
+ and value b of type Test.Box
+ match expected type Test.Box
+      new Test()
+      ^
+t6667b.scala:19: error: ambiguous implicit values:
+ both value a in object Test of type => Test.Box
+ and value b of type Test.Box
+ match expected type Test.Box
+    new Test()
+    ^
+two errors found

--- a/test/files/neg/t6667b.scala
+++ b/test/files/neg/t6667b.scala
@@ -1,0 +1,25 @@
+object Test {
+  abstract class Box {
+    val value: Int
+  }
+
+  implicit val a: Box = new Box {
+    val value= 1
+  }
+
+  def main(args: Array[String]) {
+    implicit val b: Box= new Box {
+      val value= 2
+    }
+
+    new Object {
+      new Test()
+    }
+    // compare with:
+    new Test()
+  }
+}
+
+class Test()(implicit x: Test.Box) {
+  println(x.value)
+}


### PR DESCRIPTION
Rather than continuing on to a search of implicits
of the expected type, which used to happen if
the caller was running the implicit search in silent
mode.

I've discussed the change with @odersky.

Review of the implementation by @adriaanm

/cc @xeno-by: Note that tag generation is also now
uniformly suppressed after any ambiguity error.
