### PR TITLE
Fix for SI-6706, Symbol breakage under GC.

### DIFF
--- a/src/library/scala/Symbol.scala
+++ b/src/library/scala/Symbol.scala
@@ -69,6 +69,11 @@ private[scala] abstract class UniquenessCache[K, V >: Null]
         val res = cached()
         if (res != null) res
         else {
+          // If we don't remove the old String key from the map, we can
+          // wind up with one String as the key and a different String as
+          // as the name field in the Symbol, which can lead to surprising
+          // GC behavior and duplicate Symbols. See SI-6706.
+          map remove name
           val sym = valueFromKey(name)
           map.put(name, new WeakReference(sym))
           sym

--- a/test/files/run/t6706.scala
+++ b/test/files/run/t6706.scala
@@ -1,0 +1,14 @@
+object Test {
+  var name = "foo" + 1
+  var s1 = Symbol(name)
+  s1 = null
+  System.gc
+  val s2 = Symbol("foo1")
+  name = null
+  System.gc
+  val s3 = Symbol("foo1")
+
+  def main(args: Array[String]): Unit = {
+    assert(s2 eq s3, ((s2, System.identityHashCode(s2), s3, System.identityHashCode(s3))))
+  }
+}


### PR DESCRIPTION
Ensure the map key and the String in the Symbol are the
same reference by removing the old key before updating the
map with the new key -> symbol relation.
