### PR TITLE
Fix for SI-6687, wrong isVar logic.

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -79,7 +79,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def isImplementationArtifact: Boolean = (this hasFlag BRIDGE) || (this hasFlag VBRIDGE) || (this hasFlag ARTIFACT)
     def isJava: Boolean = isJavaDefined
     def isVal: Boolean = isTerm && !isModule && !isMethod && !isMutable
-    def isVar: Boolean = isTerm && !isModule && !isMethod && isMutable
+    def isVar: Boolean = isTerm && !isModule && !isMethod && !isLazy && isMutable
 
     def newNestedSymbol(name: Name, pos: Position, newFlags: Long, isClass: Boolean): Symbol = name match {
       case n: TermName => newTermSymbol(n, pos, newFlags)

--- a/test/files/run/t6687.scala
+++ b/test/files/run/t6687.scala
@@ -1,0 +1,10 @@
+import scala.reflect.runtime.universe._
+
+class A { lazy val x = 1 }
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val vars = typeOf[A].members.toList filter (x => x.isTerm && x.asTerm.isVar)
+    assert(vars.isEmpty, vars)
+  }
+}


### PR DESCRIPTION
Fields which back lazy vals need to be excluded via !isLazy
lest isVar return true.
