### PR TITLE
introduces -Yignore-crashes

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1553,8 +1553,14 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
           pw.toString
         } else ex.getClass.getName
         // ex.printStackTrace(Console.out) // DEBUG for fsc, note that error stacktraces do not print in fsc
-        globalError(supplementErrorMessage("uncaught exception during compilation: " + shown))
-        throw ex
+        if (!settings.ignoreCrashes.value) {
+          globalError(supplementErrorMessage("uncaught exception during compilation: " + shown))
+          throw ex
+        } else {
+          var msg = if (ex.getMessage != null) ex.getMessage else ex.getClass.toString
+          msg = msg.lines.take(1).mkString
+          println("crash: " + msg)
+        }
       }
     }
 

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -135,6 +135,7 @@ trait ScalaSettings extends AbsScalaSettings
   val noCompletion    = BooleanSetting    ("-Yno-completion", "Disable tab-completion in the REPL.")
   val Xdce            = BooleanSetting    ("-Ydead-code", "Perform dead code elimination.")
   val debug           = BooleanSetting    ("-Ydebug", "Increase the quantity of debugging output.")
+  val ignoreCrashes   = BooleanSetting    ("-Yignore-crashes", "Don't print crash messages and stack traces")
   //val doc           = BooleanSetting    ("-Ydoc", "Generate documentation")
   val termConflict    = ChoiceSetting     ("-Yresolve-term-conflict", "strategy", "Resolve term conflicts", List("package", "object", "error"), "error")
   val inline          = BooleanSetting    ("-Yinline", "Perform inlining when possible.")


### PR DESCRIPTION
Quite useful when prototyping significant changes in the compiler
and not wanting to expose oneself to huge crash messages.
