### PR TITLE
SI-6415 avoid early evaluation in some Stream's methods

### DIFF
--- a/src/library/scala/collection/LinearSeqOptimized.scala
+++ b/src/library/scala/collection/LinearSeqOptimized.scala
@@ -255,10 +255,9 @@ trait LinearSeqOptimized[+A, +Repr <: LinearSeqOptimized[A, Repr]] extends Linea
       var i = 0
       val it = iterator
       while (it.hasNext) {
-	if (i == len)
-	  return if (it.hasNext) 1 else 0
-	it.next()
-	i += 1
+        if (i == len) return if (it.hasNext) 1 else 0
+        it.next()
+        i += 1
       }
       i - len
     }

--- a/src/library/scala/collection/LinearSeqOptimized.scala
+++ b/src/library/scala/collection/LinearSeqOptimized.scala
@@ -247,14 +247,21 @@ trait LinearSeqOptimized[+A, +Repr <: LinearSeqOptimized[A, Repr]] extends Linea
   }
 
   override /*SeqLike*/
-  def lengthCompare(len: Int): Int =  {
-    var i = 0
-    var these = self
-    while (!these.isEmpty && i <= len) {
-      i += 1
-      these = these.tail
+  def lengthCompare(len: Int): Int = {
+    // TODO: Remove this method when incrementing a major revision
+    // This method is the same as in SeqLike, no need to redefine it
+    if (len < 0) 1
+    else {
+      var i = 0
+      val it = iterator
+      while (it.hasNext) {
+	if (i == len)
+	  return if (it.hasNext) 1 else 0
+	it.next()
+	i += 1
+      }
+      i - len
     }
-    i - len
   }
 
   override /*SeqLike*/

--- a/src/library/scala/collection/LinearSeqOptimized.scala
+++ b/src/library/scala/collection/LinearSeqOptimized.scala
@@ -12,6 +12,7 @@ import generic._
 import mutable.ListBuffer
 import immutable.List
 import scala.util.control.Breaks._
+import scala.annotation.tailrec
 
 /** A template trait for linear sequences of type `LinearSeq[A]`  which optimizes
  *  the implementation of several methods under the assumption of fast linear access.
@@ -248,19 +249,16 @@ trait LinearSeqOptimized[+A, +Repr <: LinearSeqOptimized[A, Repr]] extends Linea
 
   override /*SeqLike*/
   def lengthCompare(len: Int): Int = {
-    // TODO: Remove this method when incrementing a major revision
-    // This method is the same as in SeqLike, no need to redefine it
-    if (len < 0) 1
-    else {
-      var i = 0
-      val it = iterator
-      while (it.hasNext) {
-        if (i == len) return if (it.hasNext) 1 else 0
-        it.next()
-        i += 1
-      }
-      i - len
+    @tailrec def loop(i: Int, xs: Repr): Int = {
+      if (i == len)
+        if (xs.isEmpty) 0 else 1
+      else if (xs.isEmpty)
+        -1
+      else
+        loop(i + 1, xs.tail)
     }
+    if (len < 0) 1
+    else loop(0, this)
   }
 
   override /*SeqLike*/

--- a/src/library/scala/collection/SeqLike.scala
+++ b/src/library/scala/collection/SeqLike.scala
@@ -84,13 +84,18 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
    *  if computing `length` is cheap.
    */
   def lengthCompare(len: Int): Int = {
-    var i = 0
-    val it = iterator
-    while (it.hasNext && i <= len) {
-      it.next()
-      i += 1
+    if (len < 0) 1
+    else {
+      var i = 0
+      val it = iterator
+      while (it.hasNext) {
+	if (i == len)
+	  return if (it.hasNext) 1 else 0
+	it.next()
+	i += 1
+      }
+      i - len
     }
-    i - len
   }
 
   override /*IterableLike*/ def isEmpty: Boolean = lengthCompare(0) == 0

--- a/src/library/scala/collection/SeqLike.scala
+++ b/src/library/scala/collection/SeqLike.scala
@@ -89,10 +89,9 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
       var i = 0
       val it = iterator
       while (it.hasNext) {
-	if (i == len)
-	  return if (it.hasNext) 1 else 0
-	it.next()
-	i += 1
+        if (i == len) return if (it.hasNext) 1 else 0
+        it.next()
+        i += 1
       }
       i - len
     }

--- a/test/files/run/streams.check
+++ b/test/files/run/streams.check
@@ -1,5 +1,8 @@
 Stream()
 Stream()
+true
+true
+true
 
 Array(1)
 Stream(1, ?)
@@ -8,12 +11,21 @@ Stream()
 Stream()
 Stream(1)
 Stream()
+true
+true
+true
+true
 
 Array(1, 2)
 Stream(2)
 Stream()
 Stream(1, 2)
 Stream()
+true
+true
+true
+true
+true
 
 999
 512
@@ -23,3 +35,5 @@ Stream(100001, ?)
 true
 true
 705082704
+
+true

--- a/test/files/run/streams.scala
+++ b/test/files/run/streams.scala
@@ -2,6 +2,9 @@ object Test extends App {
   val s0: Stream[Int] = Stream.empty
   println(s0.take(1))
   println(s0.takeWhile(_ > 0))
+  println(s0.lengthCompare(-5) > 0)
+  println(s0.lengthCompare(0) == 0)
+  println(s0.lengthCompare(5) < 0)
   println
 
   val s1 = Stream.cons(1, Stream.empty)
@@ -12,6 +15,10 @@ object Test extends App {
   println(s1.drop(2))
   println(s1.drop(-1))
   println(s1.dropWhile(_ > 0))
+  println(s1.lengthCompare(-5) > 0)
+  println(s1.lengthCompare(0) > 0)
+  println(s1.lengthCompare(1) == 0)
+  println(s1.lengthCompare(5) < 0)
   println
 
   val s2 = s1.append(Stream.cons(2, Stream.empty))
@@ -20,6 +27,11 @@ object Test extends App {
   println(s2.drop(2))
   println(s2.drop(-1))
   println(s2.dropWhile(_ > 0))
+  println(s2.lengthCompare(-5) > 0)
+  println(s2.lengthCompare(0) > 0)
+  println(s2.lengthCompare(1) > 0)
+  println(s2.lengthCompare(2) == 0)
+  println(s2.lengthCompare(5) < 0)
   println
 
   val s3 = Stream.range(1, 1000) //100000 (ticket #153: Stackoverflow)
@@ -43,4 +55,12 @@ object Test extends App {
   println(Stream.from(1).take(size).foldLeft(0)(_ + _))
   val arr = new Array[Int](size)
   Stream.from(1).take(size).copyToArray(arr, 0)
+
+  println
+
+  // ticket #6415
+  lazy val x = { println("evaluated"); 1 }
+  val s4 = 0 #:: x #:: Stream.empty
+
+  println(s4.isDefinedAt(0))
 }


### PR DESCRIPTION
The lengthCompare method in LinearSeqOptimized was looking one step further
than it needed to in order to give the correct result, which was creating some
unwanted side effects related to Streams.

Add test case to expose the problem and a few test cases to ensure correctness of LinearSeq.lengthCompare() method.

https://issues.scala-lang.org/browse/SI-6415

Review by @axel22
