### PR TITLE
SI-5678 Bad return type for [Use Case] docs in Range

### DIFF
--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -33,7 +33,6 @@ import scala.collection.parallel.immutable.ParRange
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#ranges "Scala's Collection Library overview"]]
  *  section on `Ranges` for more information.
  *
- *  @define Coll Range
  *  @define coll range
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf


### PR DESCRIPTION
Many [Use Case] doc tags in Range such as the one associated to the union method document that the method returns a Range which is just plain false.

Example:

val ran1 = Range(1,3)
val ran2 = Range(54, 57)
val result = ran1.union(ran2) // This is a perfectly valid use case yet obviously cannot be represented as a Range

Review by @axel22
