### PR TITLE
Add convenience attribute operator to NodeSeq

### DIFF
--- a/src/library/scala/xml/NodeSeq.scala
+++ b/src/library/scala/xml/NodeSeq.scala
@@ -145,6 +145,11 @@ abstract class NodeSeq extends AbstractSeq[Node] with immutable.Seq[Node] with S
     }
   }
 
+  /** Convenience method which returns string text of the named attribute. Use:
+   *   - `that \@ "foo"` to get the string text of attribute `"foo"`;
+   */
+  def \@(attributeName: String): String = (this \ ("@" + attributeName)).text
+
   override def toString(): String = theSeq.mkString
 
   def text: String = (this map (_.text)).mkString

--- a/test/files/jvm/xmlattr.scala
+++ b/test/files/jvm/xmlattr.scala
@@ -6,6 +6,7 @@ object Test {
     UnprefixedAttributeTest()
     AttributeWithOptionTest()
     AttributeOutputTest()
+    AttributeOperatorTest()
   }
   
   object UnprefixedAttributeTest {
@@ -60,4 +61,10 @@ object Test {
     }
   }
 
+  object AttributeOperatorTest {
+    def apply() {
+      val xml = <foo bar="apple" />
+      assert(xml \@ "bar" == "apple")
+    }
+  }
 }


### PR DESCRIPTION
Compared to the current method of reading the string text of an attribute:

```
(x \ "@bar").text
```

...the new operator removes the need for a pair of parenthesis and shortens the overall expression by 7 chars :

```
x \@ "bar"
```

Discussion on scala-internals:

https://groups.google.com/d/topic/scala-internals/BZ-tfbebDqE/discussion

Review by @phaller
