### PR TITLE
Fix for integer types' bitwise right shift docs

### DIFF
--- a/src/library/scala/Byte.scala
+++ b/src/library/scala/Byte.scala
@@ -83,8 +83,8 @@ final abstract class Byte private extends AnyVal {
   */
   def >>>(x: Long): Int
   /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the right bits with the same value as the left-most bit of this.
+  * Returns this value bit-shifted right by the specified number of bits,
+  *         filling in the left bits with the same value as the left-most bit of this.
   *         The effect of this is to retain the sign of the value.
   * @example {{{
   * -21 >> 3 == -3
@@ -94,8 +94,8 @@ final abstract class Byte private extends AnyVal {
   */
   def >>(x: Int): Int
   /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the right bits with the same value as the left-most bit of this.
+  * Returns this value bit-shifted right by the specified number of bits,
+  *         filling in the left bits with the same value as the left-most bit of this.
   *         The effect of this is to retain the sign of the value.
   * @example {{{
   * -21 >> 3 == -3

--- a/src/library/scala/Char.scala
+++ b/src/library/scala/Char.scala
@@ -83,8 +83,8 @@ final abstract class Char private extends AnyVal {
   */
   def >>>(x: Long): Int
   /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the right bits with the same value as the left-most bit of this.
+  * Returns this value bit-shifted right by the specified number of bits,
+  *         filling in the left bits with the same value as the left-most bit of this.
   *         The effect of this is to retain the sign of the value.
   * @example {{{
   * -21 >> 3 == -3
@@ -94,8 +94,8 @@ final abstract class Char private extends AnyVal {
   */
   def >>(x: Int): Int
   /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the right bits with the same value as the left-most bit of this.
+  * Returns this value bit-shifted right by the specified number of bits,
+  *         filling in the left bits with the same value as the left-most bit of this.
   *         The effect of this is to retain the sign of the value.
   * @example {{{
   * -21 >> 3 == -3

--- a/src/library/scala/Int.scala
+++ b/src/library/scala/Int.scala
@@ -83,8 +83,8 @@ final abstract class Int private extends AnyVal {
   */
   def >>>(x: Long): Int
   /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the right bits with the same value as the left-most bit of this.
+  * Returns this value bit-shifted right by the specified number of bits,
+  *         filling in the left bits with the same value as the left-most bit of this.
   *         The effect of this is to retain the sign of the value.
   * @example {{{
   * -21 >> 3 == -3
@@ -94,8 +94,8 @@ final abstract class Int private extends AnyVal {
   */
   def >>(x: Int): Int
   /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the right bits with the same value as the left-most bit of this.
+  * Returns this value bit-shifted right by the specified number of bits,
+  *         filling in the left bits with the same value as the left-most bit of this.
   *         The effect of this is to retain the sign of the value.
   * @example {{{
   * -21 >> 3 == -3

--- a/src/library/scala/Long.scala
+++ b/src/library/scala/Long.scala
@@ -83,8 +83,8 @@ final abstract class Long private extends AnyVal {
   */
   def >>>(x: Long): Long
   /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the right bits with the same value as the left-most bit of this.
+  * Returns this value bit-shifted right by the specified number of bits,
+  *         filling in the left bits with the same value as the left-most bit of this.
   *         The effect of this is to retain the sign of the value.
   * @example {{{
   * -21 >> 3 == -3
@@ -94,8 +94,8 @@ final abstract class Long private extends AnyVal {
   */
   def >>(x: Int): Long
   /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the right bits with the same value as the left-most bit of this.
+  * Returns this value bit-shifted right by the specified number of bits,
+  *         filling in the left bits with the same value as the left-most bit of this.
   *         The effect of this is to retain the sign of the value.
   * @example {{{
   * -21 >> 3 == -3

--- a/src/library/scala/Short.scala
+++ b/src/library/scala/Short.scala
@@ -83,8 +83,8 @@ final abstract class Short private extends AnyVal {
   */
   def >>>(x: Long): Int
   /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the right bits with the same value as the left-most bit of this.
+  * Returns this value bit-shifted right by the specified number of bits,
+  *         filling in the left bits with the same value as the left-most bit of this.
   *         The effect of this is to retain the sign of the value.
   * @example {{{
   * -21 >> 3 == -3
@@ -94,8 +94,8 @@ final abstract class Short private extends AnyVal {
   */
   def >>(x: Int): Int
   /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the right bits with the same value as the left-most bit of this.
+  * Returns this value bit-shifted right by the specified number of bits,
+  *         filling in the left bits with the same value as the left-most bit of this.
   *         The effect of this is to retain the sign of the value.
   * @example {{{
   * -21 >> 3 == -3


### PR DESCRIPTION
Currently in 2.10, all integer Types (Byte, Char, Short, Int and Long) have the same small mistake in the docs in the part about the `>>` operator:
### Current:

Returns this value bit-shifted **left** by the specified number of bits,
filling in the **right** bits with the same value as the left-most bit of this.
### Should be:

Returns this value bit-shifted **right** by the specified number of bits,
filling in the **left** bits with the same value as the left-most bit of this.

No tests were written, since this commit changes only comments.
