### PR TITLE
SI-6754 Position ClassTag based unapply

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3338,13 +3338,15 @@ trait Typers extends Modes with Adaptations with Tags {
 
           val itype = glb(List(pt1, arg.tpe))
           arg.tpe = pt1    // restore type (arg is a dummy tree, just needs to pass typechecking)
-          val unapply = UnApply(fun1, args1) setPos tree.pos setType itype
 
           // if the type that the unapply method expects for its argument is uncheckable, wrap in classtag extractor
           // skip if the unapply's type is not a method type with (at least, but really it should be exactly) one argument
           // also skip if we already wrapped a classtag extractor (so we don't keep doing that forever)
-          if (uncheckedTypeExtractor.isEmpty || fun1.symbol.owner.isNonBottomSubClass(ClassTagClass)) unapply
-          else wrapClassTagUnapply(unapply, uncheckedTypeExtractor.get, unappType.paramTypes.head)
+          atPos(tree.pos) {
+            val unapply = UnApply(fun1, args1) setType itype
+            if (uncheckedTypeExtractor.isEmpty || fun1.symbol.owner.isNonBottomSubClass(ClassTagClass)) unapply
+            else wrapClassTagUnapply(unapply, uncheckedTypeExtractor.get, unappType.paramTypes.head)
+          }
         }
       }
     }
@@ -3367,7 +3369,7 @@ trait Typers extends Modes with Adaptations with Tags {
       // this breaks down when the classTagExtractor (which defineds the unapply member) is not a simple reference to an object,
       // but an arbitrary tree as is the case here
       doTypedUnapply(Apply(classTagExtractor, args), classTagExtractor, classTagExtractor, args, PATTERNmode, pt)
-      }
+    }
 
     // if there's a ClassTag that allows us to turn the unchecked type test for `pt` into a checked type test
     // return the corresponding extractor (an instance of ClassTag[`pt`])

--- a/test/files/pos/t6754.flags
+++ b/test/files/pos/t6754.flags
@@ -1,0 +1,1 @@
+-Yrangepos

--- a/test/files/pos/t6754.scala
+++ b/test/files/pos/t6754.scala
@@ -1,0 +1,20 @@
+import scala.reflect.ClassTag
+
+trait ru {
+	type Type
+	type TypeRef <: Type
+	object TypeRef {
+		def unapply(t: TypeRef) = Some((0, 0, 0))
+	}
+	implicit def TypeRefTag: ClassTag[TypeRef] = implicitly
+}
+
+object ru extends ru
+
+class C {
+  def typeArguments(t: ru.Type)  {
+    import ru._ // otherwise the pattern match will be unchecked
+                // because TypeRef is an abstract type
+    t match { case ru.TypeRef(_, _, _) => ; case _ => }
+  }
+}


### PR DESCRIPTION
Range Positions didn't take kindly to it.

======= Position error
Unpositioned tree #483
   unpositioned [L  -1 P#  484] #483    [NoPosition]    UnApply    // UnApply
      enclosing [L   7        ] #484    [261:291]       CaseDef    // ru.TypeRef(_, _, args) => args;
        sibling [L  -1 P#  484] #483    [NoPosition]    UnApply    // UnApply
        sibling [L   7 P#  484] #79     [287:291]       Ident      // args;

Review by @adriaanm. I've targetted this at 2.10.x. What is the impact of range pos errors on the IDE for 2.10.0?
