### PR TITLE
SI-6745 Skip refinements in the search for <init>

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4883,7 +4883,8 @@ trait Typers extends Modes with Adaptations with Tags {
             }
             else {
               cx = cx.enclClass
-              val foundSym = pre.member(name) filter qualifies
+              val pre1 = if (name == nme.CONSTRUCTOR) pre.baseType(context.enclClass.owner) else pre // SI-6745, SI-4460
+              val foundSym = pre1.member(name) filter qualifies
               defSym = foundSym filter (context.isAccessible(_, pre, false))
               if (defSym == NoSymbol) {
                 if ((foundSym ne NoSymbol) && (inaccessibleSym eq NoSymbol)) {

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1145,6 +1145,7 @@ trait Types extends api.Types { self: SymbolTable =>
       var excluded = excludedFlags | DEFERRED
       var continue = true
       var self: Type = null
+      val isConstructor = name == nme.CONSTRUCTOR
 
       while (continue) {
         continue = false
@@ -1207,7 +1208,7 @@ trait Types extends api.Types { self: SymbolTable =>
             entry = decls lookupNextEntry entry
           } // while (entry ne null)
           // excluded = excluded | LOCAL
-          bcs = if (name == nme.CONSTRUCTOR) Nil else bcs.tail
+          bcs = if (isConstructor) Nil else bcs.tail // constructors aren't inherited
         } // while (!bcs.isEmpty)
         required |= DEFERRED
         excluded &= ~(DEFERRED.toLong)

--- a/test/files/neg/t4460a.check
+++ b/test/files/neg/t4460a.check
@@ -1,0 +1,4 @@
+t4460a.scala:6: error: called constructor's definition must precede calling constructor's definition
+  def this() = this() // was binding to Predef.<init> !!
+               ^
+one error found

--- a/test/files/neg/t4460a.scala
+++ b/test/files/neg/t4460a.scala
@@ -1,0 +1,7 @@
+trait A
+
+class B(val x: Int) {
+  self: A =>
+
+  def this() = this() // was binding to Predef.<init> !!
+}

--- a/test/files/neg/t4460b.check
+++ b/test/files/neg/t4460b.check
@@ -1,0 +1,4 @@
+t4460b.scala:7: error: called constructor's definition must precede calling constructor's definition
+	  def this() = this() // was binding to Predef.<init> !!
+                       ^
+one error found

--- a/test/files/neg/t4460b.scala
+++ b/test/files/neg/t4460b.scala
@@ -1,0 +1,9 @@
+trait A
+
+class Outer() {
+	class B(val x: Int) {
+	  self: A =>
+
+	  def this() = this() // was binding to Predef.<init> !!
+	}
+}

--- a/test/files/neg/t4460c.check
+++ b/test/files/neg/t4460c.check
@@ -1,0 +1,7 @@
+t4460c.scala:4: error: overloaded method constructor B with alternatives:
+  (a: String)B <and>
+  (x: Int)B
+ cannot be applied to ()
+  def this(a: String) = this()
+                        ^
+one error found

--- a/test/files/neg/t4460c.scala
+++ b/test/files/neg/t4460c.scala
@@ -1,0 +1,7 @@
+class B(val x: Int) {
+  self: A =>
+
+  def this(a: String) = this()
+}
+
+class A()

--- a/test/files/pos/t6745.scala
+++ b/test/files/pos/t6745.scala
@@ -1,0 +1,6 @@
+class Bar(i: Any) {
+  self: Any =>
+  def this() = this(0) // fail, remove `: Any` from self type to make it work.
+
+  new Bar(0) // okay
+}


### PR DESCRIPTION
These arise in the base class sequence when a self type
is annotated. This prevented an auxillary constructor from
calling the primary constructor.
