### PR TITLE
SI-6558: typecheck lazy annotation info using non-silent context

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1260,7 +1260,11 @@ trait Namers extends MethodSynthesis {
           case defn: MemberDef =>
             val ainfos = defn.mods.annotations filterNot (_ eq null) map { ann =>
               // need to be lazy, #1782. beforeTyper to allow inferView in annotation args, SI-5892.
-              AnnotationInfo lazily beforeTyper(typer typedAnnotation ann)
+              AnnotationInfo lazily {
+                val context1 = typer.context.make(ann)
+                context1.setReportErrors()
+                beforeTyper(newTyper(context1) typedAnnotation ann)
+              }
             }
             if (ainfos.nonEmpty) {
               annotated setAnnotations ainfos

--- a/test/files/neg/t6558.check
+++ b/test/files/neg/t6558.check
@@ -1,10 +1,10 @@
-t6558.scala:16: error: not found: type classs
+t6558.scala:19: error: not found: type classs
   @classs
    ^
-t6558.scala:19: error: not found: type typeparam
+t6558.scala:22: error: not found: type typeparam
   class D[@typeparam T]
            ^
-t6558.scala:22: error: not found: type valueparam
+t6558.scala:25: error: not found: type valueparam
   	@valueparam x: Any
          ^
 three errors found

--- a/test/files/neg/t6558.check
+++ b/test/files/neg/t6558.check
@@ -1,4 +1,10 @@
-t6558.scala:5: error: not found: type sth
-    @sth
-     ^
-one error found
+t6558.scala:16: error: not found: type classs
+  @classs
+   ^
+t6558.scala:19: error: not found: type typeparam
+  class D[@typeparam T]
+           ^
+t6558.scala:22: error: not found: type valueparam
+  	@valueparam x: Any
+         ^
+three errors found

--- a/test/files/neg/t6558.check
+++ b/test/files/neg/t6558.check
@@ -1,0 +1,4 @@
+t6558.scala:5: error: not found: type sth
+    @sth
+     ^
+one error found

--- a/test/files/neg/t6558.scala
+++ b/test/files/neg/t6558.scala
@@ -1,0 +1,9 @@
+class AnnotNotFound {
+  def foo(a: Any) = ()
+
+  foo {
+    @sth
+    def foo = 0
+    foo
+  }
+}

--- a/test/files/neg/t6558.scala
+++ b/test/files/neg/t6558.scala
@@ -2,12 +2,15 @@ class AnnotNotFound {
   def foo(a: Any) = ()
 
   foo {
+    // Not yet issued in the context of this file, see SI-6758
+    // This error is issued in t6558b.scala
     @inargument
     def foo = 0
     foo
   }
 
   () => {
+    // As per above
     @infunction
     def foo = 0
     ()

--- a/test/files/neg/t6558.scala
+++ b/test/files/neg/t6558.scala
@@ -2,8 +2,23 @@ class AnnotNotFound {
   def foo(a: Any) = ()
 
   foo {
-    @sth
+    @inargument
     def foo = 0
     foo
   }
+
+  () => {
+    @infunction
+    def foo = 0
+    ()
+  }
+
+  @classs
+  class C
+
+  class D[@typeparam T]
+
+  class E(
+  	@valueparam x: Any
+  )
 }

--- a/test/files/neg/t6558b.check
+++ b/test/files/neg/t6558b.check
@@ -1,0 +1,7 @@
+t6558b.scala:5: error: not found: type inargument
+    @inargument
+     ^
+t6558b.scala:11: error: not found: type infunction
+    @infunction
+     ^
+two errors found

--- a/test/files/neg/t6558b.scala
+++ b/test/files/neg/t6558b.scala
@@ -1,0 +1,15 @@
+class AnnotNotFound {
+  def foo(a: Any) = ()
+
+  foo {
+    @inargument
+    def foo = 0
+    foo
+  }
+
+  () => {
+    @infunction
+    def foo = 0
+    ()
+  }
+}


### PR DESCRIPTION
Resubmitting #1531 to `2.10.x`.

Patch by @hubertp, LGTM, with the extra test cases I added to the PR.

Review by @lrtyz
