### PR TITLE
SI-6547: elide box unbox pair only when primitives match

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/opt/ClosureElimination.scala
+++ b/src/compiler/scala/tools/nsc/backend/opt/ClosureElimination.scala
@@ -147,18 +147,18 @@ abstract class ClosureElimination extends SubComponent {
                 case _ =>
               }
 
-            case UNBOX(_) =>
+            case UNBOX(boxType) =>
               info.stack match {
                 case Deref(LocalVar(loc1)) :: _ if info.bindings isDefinedAt LocalVar(loc1) =>
                   val value = info.getBinding(loc1)
                   value match {
-                    case Boxed(LocalVar(loc2)) =>
+                    case Boxed(LocalVar(loc2)) if loc2.kind == boxType =>
                       bb.replaceInstruction(i, DROP(icodes.ObjectReference) :: valueToInstruction(info.getBinding(loc2)) :: Nil)
                       debuglog("replaced " + i + " with " + info.getBinding(loc2))
                     case _ =>
                       ()
                   }
-                case Boxed(LocalVar(loc1)) :: _ =>
+                case Boxed(LocalVar(loc1)) :: _ if loc1.kind == boxType =>
                   val loc2 = info.getAlias(loc1)
                   bb.replaceInstruction(i, DROP(icodes.ObjectReference) :: valueToInstruction(Deref(LocalVar(loc2))) :: Nil)
                   debuglog("replaced " + i + " with " + LocalVar(loc2))

--- a/test/files/pos/t6547.flags
+++ b/test/files/pos/t6547.flags
@@ -1,0 +1,1 @@
+-optimise

--- a/test/files/pos/t6547.scala
+++ b/test/files/pos/t6547.scala
@@ -1,0 +1,6 @@
+trait ConfigurableDefault[@specialized V] {
+  def fillArray(arr: Array[V], v: V) = (arr: Any) match {
+    case x: Array[Int]  => null
+    case x: Array[Long] => v.asInstanceOf[Long]
+  }
+}


### PR DESCRIPTION
This is a retargeted submission of #1533; re-review by @VladUreche.
