### PR TITLE
SI-6751 macroContext factory is now public

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -550,7 +550,17 @@ trait Macros extends scala.tools.reflect.FastTrack with Traces {
     }
   }
 
-  private def macroContext(typer: Typer, prefixTree: Tree, expandeeTree: Tree): MacroContext =
+  /** Creates macro contexts to serve macro expansions.
+   *
+   *  `typer` is the typer at the callsite of a macro, `prefixTree` is the prefix of the macro application
+   *  (see the documentation for Context.prefix for more info), `expandeeTree` is the macro application itself.
+   *
+   *  This method is designed to be overridable, e.g. from an IDE, which would redirect
+   *  methods like c.echo or c.info to a custom GUI. To override this method, extend `Global` and provide
+   *  an overriden `analyzer` val with an overriden `newTyper` method, which produces a typer with an overriden
+   *  `macroContext` method.
+   */
+  def macroContext(typer: Typer, prefixTree: Tree, expandeeTree: Tree): MacroContext =
     new {
       val universe: self.global.type = self.global
       val callsiteTyper: universe.analyzer.Typer = typer.asInstanceOf[global.analyzer.Typer]


### PR DESCRIPTION
In order to make macro contexts customizable by the embedding environment
such as an IDE.

The motivation for this commit was a request to expose an IDE-friendly
debug log API for macros. With macroContext being overridable (see the
instructions in the comments), we can recommend people to use c.info
and then the IDE could override it and present it conveniently.
