### PR TITLE
SI-6135 SI-6443 Bridges for dependent method types

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -403,14 +403,14 @@ abstract class Erasure extends AddInterfaces
         override def parents              = List(root.info.firstParent)
         override def exclude(sym: Symbol) = !sym.isMethod || sym.isPrivate || super.exclude(sym)
         override def memberTypeForOverriding(self: Type, sym: Symbol) = self memberType sym map {
-          case MethodType(params, res) =>
+          case MethodType(params@(p1 :: p2 :: ps), res) => // only needed for arity-2 and higher
             // SI-6135 / SI-6443
             // We're operating with signatures that have been uncurried and can have a dependently
             // typed parameter in `params` that refers to an earlier parameter *in the same list*.
             // Such types don't match the types of the corresponding parameter in the super class,
             // preventing creation of bridge methods.
             //
-            // Ideally, we would restore the nested MethodTypes to repreprent the parameter grouping
+            // Ideally, we would restore the nested MethodTypes to represent the parameter grouping
             // before uncurry; but this would not account for methods added during specialization.
             //
             // Instead, we just take the conservative approximation that the original method was

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -402,6 +402,22 @@ abstract class Erasure extends AddInterfaces
       new overridingPairs.Cursor(root) {
         override def parents              = List(root.info.firstParent)
         override def exclude(sym: Symbol) = !sym.isMethod || sym.isPrivate || super.exclude(sym)
+        override def memberType(self: Type, sym: Symbol) = self memberType sym map {
+          case MethodType(params, res) =>
+            // SI-6135 / SI-6443
+            // We're operating with signatures that have been uncurried and can have a dependently
+            // typed parameter in `params` that refers to an earlier parameter *in the same list*.
+            // Such types don't match the types of the corresponding parameter in the super class,
+            // preventing creation of bridge methods.
+            //
+            // Ideally, we would restore the nested MethodTypes to repreprent the parameter grouping
+            // before uncurry; but this would not account for methods added during specialization.
+            //
+            // Instead, we just take the conservative approximation that the original method was
+            // fully curried.
+            params.reverse.foldLeft(res)((a, param) => MethodType(param :: Nil, a))
+          case t => t
+        }
       }
     }
 

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -402,7 +402,7 @@ abstract class Erasure extends AddInterfaces
       new overridingPairs.Cursor(root) {
         override def parents              = List(root.info.firstParent)
         override def exclude(sym: Symbol) = !sym.isMethod || sym.isPrivate || super.exclude(sym)
-        override def memberType(self: Type, sym: Symbol) = self memberType sym map {
+        override def memberTypeForOverriding(self: Type, sym: Symbol) = self memberType sym map {
           case MethodType(params, res) =>
             // SI-6135 / SI-6443
             // We're operating with signatures that have been uncurried and can have a dependently

--- a/src/compiler/scala/tools/nsc/transform/OverridingPairs.scala
+++ b/src/compiler/scala/tools/nsc/transform/OverridingPairs.scala
@@ -47,15 +47,15 @@ abstract class OverridingPairs {
      */
     protected def matches(sym1: Symbol, sym2: Symbol): Boolean = {
       def tp_s(s: Symbol) = {
-        val memType = memberType(self, s)
+        val memType = memberTypeForOverriding(self, s)
         s"${memType}/${memType.getClass}"
       }
-      val result = sym1.isType || (memberType(self, sym1) matches memberType(self, sym2))
+      val result = sym1.isType || (memberTypeForOverriding(self, sym1) matches memberTypeForOverriding(self, sym2))
       debuglog(s"overriding-pairs? ${sym1.fullLocationString} matches ${sym2.fullLocationString} (${tp_s(sym1)} vs. ${tp_s(sym2)}) == $result")
       result
     }
 
-    protected def memberType(self: Type, sym: Symbol) = self memberType sym
+    protected def memberTypeForOverriding(self: Type, sym: Symbol) = self memberType sym
 
     /** An implementation of BitSets as arrays (maybe consider collection.BitSet
      *  for that?) The main purpose of this is to implement

--- a/src/compiler/scala/tools/nsc/transform/OverridingPairs.scala
+++ b/src/compiler/scala/tools/nsc/transform/OverridingPairs.scala
@@ -46,13 +46,16 @@ abstract class OverridingPairs {
      *  relative to <base>.this do
      */
     protected def matches(sym1: Symbol, sym2: Symbol): Boolean = {
-      def tp_s(s: Symbol) = self.memberType(s) + "/" + self.memberType(s).getClass
-      val result = sym1.isType || (self.memberType(sym1) matches self.memberType(sym2))
-      debuglog("overriding-pairs? %s matches %s (%s vs. %s) == %s".format(
-        sym1.fullLocationString, sym2.fullLocationString, tp_s(sym1), tp_s(sym2), result))
-
+      def tp_s(s: Symbol) = {
+        val memType = memberType(self, s)
+        s"${memType}/${memType.getClass}"
+      }
+      val result = sym1.isType || (memberType(self, sym1) matches memberType(self, sym2))
+      debuglog(s"overriding-pairs? ${sym1.fullLocationString} matches ${sym2.fullLocationString} (${tp_s(sym1)} vs. ${tp_s(sym2)}) == $result")
       result
     }
+
+    protected def memberType(self: Type, sym: Symbol) = self memberType sym
 
     /** An implementation of BitSets as arrays (maybe consider collection.BitSet
      *  for that?) The main purpose of this is to implement

--- a/test/files/neg/t6443c.check
+++ b/test/files/neg/t6443c.check
@@ -1,0 +1,7 @@
+t6443c.scala:16: error: double definition:
+method foo:(d: B.D)(a: Any)(d2: d.type)Unit and
+method foo:(d: B.D)(a: Any, d2: d.type)Unit at line 11
+have same type after erasure: (d: B.D, a: Object, d2: B.D)Unit
+  def foo(d: D)(a: Any)(d2: d.type): Unit = ()
+      ^
+one error found

--- a/test/files/neg/t6443c.scala
+++ b/test/files/neg/t6443c.scala
@@ -1,0 +1,21 @@
+trait A {
+  type D >: Null <: C
+  def foo(d: D)(a: Any, d2: d.type): Unit
+  trait C {
+    def bar: Unit = foo(null)(null, null)
+  }
+}
+object B extends A {
+  class D extends C
+
+  def foo(d: D)(a: Any, d2: d.type): Unit = () // Bridge method required here!
+
+  // No bridge method should be added, but we'll be happy enough if
+  // the "same type after erasure" error kicks in before the duplicated
+  // bridge causes a problem.
+  def foo(d: D)(a: Any)(d2: d.type): Unit = ()
+}
+
+object Test extends App {
+  new B.D().bar
+}

--- a/test/files/run/t6135.scala
+++ b/test/files/run/t6135.scala
@@ -1,0 +1,13 @@
+object Test extends App {
+  class A { class V }
+
+  abstract class B[S] {
+    def foo(t: S, a: A)(v: a.V)
+  }
+
+  val b1 = new B[String] {
+    def foo(t: String, a: A)(v: a.V) = () // Bridge method required here!
+  }
+
+  b1.foo("", null)(null)
+}

--- a/test/files/run/t6443.scala
+++ b/test/files/run/t6443.scala
@@ -1,0 +1,14 @@
+class Base
+class Derived extends Base
+
+trait A {
+  def foo(d: AnyRef)(d2: d.type): Base
+  def bar: Unit = foo(null)(null)
+}
+object B extends A {
+  def foo(d: AnyRef)(d2: d.type): Derived = null // Bridge method required here!
+}
+
+object Test extends App {
+  B.bar
+}

--- a/test/files/run/t6443b.scala
+++ b/test/files/run/t6443b.scala
@@ -1,0 +1,16 @@
+trait A {
+  type D >: Null <: C
+  def foo(d: D)(d2: d.type): Unit
+  trait C {
+    def bar: Unit = foo(null)(null)
+  }
+}
+object B extends A {
+  class D extends C
+
+  def foo(d: D)(d2: d.type): Unit = () // Bridge method required here!
+}
+
+object Test extends App {
+  new B.D().bar
+}


### PR DESCRIPTION
Bridge building operates on unusual method signatures:
after uncurry, so parameter lists are collapsed; but before
erasure, so dependently typed parameters are still around.

Original:

```
def foo(a: T)(b: a.type, c: a.U): Unit
```

During computeBridges:

```
(a: T, b: a.type, c: a.U)Unit
```

This signature no longer appears to override the corresponding
one in a superclass, because the types of `b` and `c` are dependent
on method parameters.

This commit instead checks for overriding pairs with fully
curried signatures, such as:

```
(a: T)(b: a.type)(c: a.U)Unit
```

Existing logic in [`matchesQuantified`](https://github.com/retronym/scala/blob/8e8aa4b1d/src/reflect/scala/reflect/internal/Types.scala#L6175), a local method in
`matchesType`, then correctly substitutes the superclass signature
parameter symbol into the subclass signature.

Review by @odersky
