### PR TITLE
Don't return unimportables from importedSymbol.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -996,7 +996,14 @@ trait Contexts { self: Analyzer =>
       if (settings.lint.value && selectors.nonEmpty && result != NoSymbol && pos != NoPosition)
         recordUsage(current, result)
 
-      result
+      // Harden against the fallout from bugs like SI-6745
+      //
+      // [JZ] I considered issuing a devWarning and moving the
+      //      check inside the above loop, as I believe that
+      //      this always represents a mistake on the part of
+      //      the caller.
+      if (definitions isImportable result) result
+      else NoSymbol
     }
     private def selectorString(s: ImportSelector): String = {
       if (s.name == nme.WILDCARD && s.rename == null) "_"

--- a/test/files/run/t6745-2.scala
+++ b/test/files/run/t6745-2.scala
@@ -1,0 +1,22 @@
+import scala.tools.nsc._
+import scala.tools.partest.CompilerTest
+import scala.collection.{ mutable, immutable, generic }
+
+object Test extends CompilerTest {
+  import global._
+  import rootMirror._
+  import definitions._
+  import global.analyzer.{Context, ImportInfo}
+
+  override def code = """
+package context {
+}
+  """
+
+  def check(source: String, unit: global.CompilationUnit) = {
+    val context: Context = global.analyzer.rootContext(unit)
+    val importInfo: ImportInfo = context.imports.head // Predef._
+    val importedSym = importInfo.importedSymbol(nme.CONSTRUCTOR)
+    assert(importedSym == NoSymbol, importedSym) // was "constructor Predef"
+  }
+}


### PR DESCRIPTION
Hardening against the symptom of SI-6745, which yielded:

```
wat.scala:4: error: too many arguments for constructor Predef: ()object Predef
  def this() = this(0)
           ^
```

The fix for the underlying problem in that bug
has been targetted at branch 2.10.x.

Review by @paulp.

I was tempted to add a `devWarning` for this one, but before I did that I would need to check if we hit that code path under non-warnable circumstances.
