### PR TITLE
SI-6549 Improve escaping in REPL codegen.

### DIFF
--- a/src/compiler/scala/tools/nsc/interpreter/MemberHandlers.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/MemberHandlers.scala
@@ -120,7 +120,7 @@ trait MemberHandlers {
           if (replProps.vids) """" + " @ " + "%%8x".format(System.identityHashCode(%s)) + " """.trim.format(req fullPath name)
           else ""
 
-        """ + "%s%s: %s = " + %s""".format(prettyName, vidString, string2code(req typeOf name), resultString)
+        """ + "%s%s: %s = " + %s""".format(string2code(prettyName), vidString, string2code(req typeOf name), resultString)
       }
     }
   }
@@ -147,8 +147,7 @@ trait MemberHandlers {
     override def resultExtractionCode(req: Request) = {
       val lhsType = string2code(req lookupTypeOf name)
       val res     = string2code(req fullPath name)
-
-      """ + "%s: %s = " + %s + "\n" """.format(lhs, lhsType, res) + "\n"
+      """ + "%s: %s = " + %s + "\n" """.format(string2code(lhs.toString), lhsType, res) + "\n"
     }
   }
 

--- a/test/files/run/t6549.check
+++ b/test/files/run/t6549.check
@@ -1,0 +1,32 @@
+Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> 
+
+scala> case class `X"`(var xxx: Any)
+defined class X$u0022
+
+scala> val m = Map(("": Any) -> `X"`("\""), ('s: Any) -> `X"`("\""))
+m: scala.collection.immutable.Map[Any,X"] = Map("" -> X"("), 's -> X"("))
+
+scala> m("")
+res0: X" = X"(")
+
+scala> m("").xxx
+res1: Any = "
+
+scala> m("").xxx = 0
+m("").xxx: Any = 0
+
+scala> m("").xxx = "\""
+m("").xxx: Any = "
+
+scala> m('s).xxx = 's
+m(scala.Symbol("s")).xxx: Any = 's
+
+scala> val `"` = 0
+": Int = 0
+
+scala> 
+
+scala> 

--- a/test/files/run/t6549.scala
+++ b/test/files/run/t6549.scala
@@ -1,0 +1,22 @@
+import scala.tools.partest.ReplTest
+
+// Check that the fragments of code generated in
+// in the REPL correctly escape values added to
+// literal strings.
+//
+// Before, we saw:
+// scala> m("").x = 77
+// <console>:10: error: ')' expected but string literal found.
+//  + "m("").x: Int = " + `$ires8` + "\n"
+object Test extends ReplTest {
+  def code = """
+    |case class `X"`(var xxx: Any)
+    |val m = Map(("": Any) -> `X"`("\""), ('s: Any) -> `X"`("\""))
+    |m("")
+    |m("").xxx
+    |m("").xxx = 0
+    |m("").xxx = "\""
+    |m('s).xxx = 's
+    |val `"` = 0
+  """.stripMargin
+}


### PR DESCRIPTION
- Escape the LHS of an assign when printing results
  - e.g. X("").foo = bar
  - Escape val names
    - e.g. val `"` = 0`

Review by @paulp
