### PR TITLE
SI-6535 Step back from the precipice of a cycle

### DIFF
--- a/src/library/scala/collection/convert/WrapAsJava.scala
+++ b/src/library/scala/collection/convert/WrapAsJava.scala
@@ -10,10 +10,11 @@ package scala.collection
 package convert
 
 import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
-import Wrappers._
 import scala.language.implicitConversions
 
 trait WrapAsJava {
+  import Wrappers._
+
   /**
    * Implicitly converts a Scala Iterator to a Java Iterator.
    * The returned Java Iterator is backed by the provided Scala

--- a/src/library/scala/collection/convert/WrapAsScala.scala
+++ b/src/library/scala/collection/convert/WrapAsScala.scala
@@ -10,11 +10,13 @@ package scala.collection
 package convert
 
 import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
-import Wrappers._
 import scala.language.implicitConversions
 
 trait LowPriorityWrapAsScala {
   this: WrapAsScala =>
+
+  import Wrappers._
+
   /**
    * Implicitly converts a Java ConcurrentMap to a Scala mutable ConcurrentMap.
    * The returned Scala ConcurrentMap is backed by the provided Java
@@ -34,6 +36,7 @@ trait LowPriorityWrapAsScala {
 }
 
 trait WrapAsScala extends LowPriorityWrapAsScala {
+  import Wrappers._
   /**
    * Implicitly converts a Java `Iterator` to a Scala `Iterator`.
    *

--- a/test/files/neg/t6535.check
+++ b/test/files/neg/t6535.check
@@ -1,0 +1,6 @@
+t6535.scala:2: error: encountered unrecoverable cycle resolving import.
+Note: this is often due in part to a class depending on a definition nested within its companion.
+If applicable, you may wish to try moving some members into another object.
+  import Bs.B._
+            ^
+one error found

--- a/test/files/neg/t6535.scala
+++ b/test/files/neg/t6535.scala
@@ -1,0 +1,15 @@
+object As {
+  import Bs.B._
+
+  object A
+  extends scala.AnyRef // needed for the cycle;
+                       // replacing with a locally defined closs doesn't
+                       // hit the locked import and hence doesn't cycle.
+}
+
+object Bs {
+  import As.A._
+
+  object B
+  extends scala.AnyRef // scala.Immutable, ...
+}


### PR DESCRIPTION
Adding any non-local parent to WrapAsScala will trigger a valid
cyclic reference error. By moving the import of `Wrapper._`
inside `WrapAsScala` and `WrapAsJava`, it is not in scope when
typing the parents of those, and we avoid the cycle.

Adds a test case to show the essense of the promiscious mutual
imports that triggers this.

Review by @paulp
