### PR TITLE
SI-6528 Avoid loop in getClassParts.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -982,9 +982,15 @@ trait Implicits {
        *                  in order to cache them in infoMapCache
        */
       def getParts(tp: Type)(implicit infoMap: InfoMap, seen: mutable.Set[Type], pending: Set[Symbol]) {
-        if (seen(tp))
+        // SI-6528 Avoid following an endless stream of types that differ only in
+        //         abstract types
+        val seenType = tp.map {
+          case tp @ TypeRef(_, sym, args) if sym.isAbstractType => tp.bounds.hi
+          case t => t
+        }
+        if (seen(seenType))
           return
-        seen += tp
+        seen += seenType
         tp match {
           case TypeRef(pre, sym, args) =>
             if (sym.isClass) {

--- a/test/files/neg/t6528.check
+++ b/test/files/neg/t6528.check
@@ -1,0 +1,4 @@
+t6528.scala:6: error: could not find implicit value for parameter e: CoSet[U,Any]
+  implicitly[CoSet[U, Any]]
+            ^
+one error found

--- a/test/files/neg/t6528.scala
+++ b/test/files/neg/t6528.scala
@@ -1,0 +1,13 @@
+trait CoSet[U, +A <: U]
+  extends CoSetLike[U, A, ({type S[A1 <: U] = CoSet[U, A1]})#S]
+
+trait CoSetLike[U, +A <: U, +This[X] <: CoSetLike[U, A, This] with CoSet[U, A]] {
+
+  implicitly[CoSet[U, Any]]
+  // should report "implicit not found"
+  // was triggering a StackOverflow as getClassParts looped over
+  // the steam of types:
+  // CoSet#6940[U#6966,A1#22868]
+  // CoSet#6940[U#6966,A1#22876]
+  // CoSet#6940[U#6966,A1#...]
+}


### PR DESCRIPTION
Carefully crafted types can lead to an endless stream of
distinct parts, differing only in different instantiations
of an abstract type.

This commit substitutes abstract types with their upper bounds
before determining if a type has already been seen.

Review for correctness, completeness, and performance by @adriaanm.
