### PR TITLE
Fix for rangepos crasher.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3362,12 +3362,13 @@ trait Typers extends Modes with Adaptations with Tags {
       // println(util.Position.formatMessage(uncheckedPattern.pos, "made unchecked type test into a checked one", true))
 
       val args = List(uncheckedPattern)
+      val app  = atPos(uncheckedPattern.pos)(Apply(classTagExtractor, args))
       // must call doTypedUnapply directly, as otherwise we get undesirable rewrites
       // and re-typechecks of the target of the unapply call in PATTERNmode,
       // this breaks down when the classTagExtractor (which defineds the unapply member) is not a simple reference to an object,
       // but an arbitrary tree as is the case here
-      doTypedUnapply(Apply(classTagExtractor, args), classTagExtractor, classTagExtractor, args, PATTERNmode, pt)
-      }
+      doTypedUnapply(app, classTagExtractor, classTagExtractor, args, PATTERNmode, pt)
+    }
 
     // if there's a ClassTag that allows us to turn the unchecked type test for `pt` into a checked type test
     // return the corresponding extractor (an instance of ClassTag[`pt`])

--- a/test/files/pos/classtag-pos.flags
+++ b/test/files/pos/classtag-pos.flags
@@ -1,0 +1,1 @@
+-Yrangepos

--- a/test/files/pos/classtag-pos.scala
+++ b/test/files/pos/classtag-pos.scala
@@ -1,0 +1,5 @@
+import scala.reflect.runtime.universe._
+
+class A {
+  def f[T: TypeTag] = typeOf[T] match { case TypeRef(_, _, args) => args }
+}


### PR DESCRIPTION
wrapClassTagUnapply was generating an unpositioned tree
which would crash under -Yrangepos.  See SI-6338 / SI-6754

Review by @adriaanm (I've bumped this to a 2.10.0 blocker
after the reports or problems in the IDE with Akka.)

Cherry-pick from #1447.
