### PR TITLE
Warn when generated classfiles differ only in case.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
@@ -160,7 +160,14 @@ abstract class GenASM extends SubComponent with BytecodeWriters {
         }
 
       // For predictably ordered error messages.
-      var sortedClasses = classes.values.toList sortBy ("" + _.symbol.fullName)
+      var sortedClasses = classes.values.toList sortBy (_.symbol.fullName)
+
+      // Warn when classes will overwrite one another on case-insensitive systems.
+      for ((_, v1 :: v2 :: _) <- sortedClasses groupBy (_.symbol.javaClassName.toString.toLowerCase)) {
+        v1.cunit.warning(v1.symbol.pos,
+          s"Class ${v1.symbol.javaClassName} differs only in case from ${v2.symbol.javaClassName}. " +
+          "Such classes will overwrite one another on case-insensitive filesystems.")
+      }
 
       debuglog("Created new bytecode generator for " + classes.size + " classes.")
       val bytecodeWriter  = initBytecodeWriter(sortedClasses filter isJavaEntryPoint)

--- a/test/files/neg/case-collision.check
+++ b/test/files/neg/case-collision.check
@@ -1,0 +1,10 @@
+case-collision.scala:5: error: Class foo.BIPPY differs only in case from foo.Bippy. Such classes will overwrite one another on case-insensitive filesystems.
+class BIPPY
+      ^
+case-collision.scala:11: error: Class foo.HyRaX$ differs only in case from foo.Hyrax$. Such classes will overwrite one another on case-insensitive filesystems.
+object HyRaX
+       ^
+case-collision.scala:8: error: Class foo.DINGO$ differs only in case from foo.Dingo$. Such classes will overwrite one another on case-insensitive filesystems.
+object DINGO
+       ^
+three errors found

--- a/test/files/neg/case-collision.flags
+++ b/test/files/neg/case-collision.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/case-collision.scala
+++ b/test/files/neg/case-collision.scala
@@ -1,0 +1,11 @@
+package foo
+
+class Bippy
+
+class BIPPY
+
+object Dingo
+object DINGO
+
+case class Hyrax()
+object HyRaX


### PR DESCRIPTION
We should most likely prohibit it completely, but warning
is a start.
