### PR TITLE
SI-5361 Avoid cyclic type with malformed refinement

### DIFF
--- a/test/files/neg/t3614.check
+++ b/test/files/neg/t3614.check
@@ -1,4 +1,4 @@
-t3614.scala:2: error: class type required but AnyRef{def a: Int} found
+t3614.scala:2: error: only declarations allowed here
   def v = new ({ def a=0 })
-               ^
+                     ^
 one error found

--- a/test/files/neg/t5361.check
+++ b/test/files/neg/t5361.check
@@ -1,0 +1,4 @@
+t5361.scala:2: error: only declarations allowed here
+  val x : { val self = this } = new { self => }
+                ^
+one error found

--- a/test/files/neg/t5361.scala
+++ b/test/files/neg/t5361.scala
@@ -1,0 +1,3 @@
+class A {
+  val x : { val self = this } = new { self => }
+}


### PR DESCRIPTION
The statement `val x = this` in the refinment type:

```
(new {}): {val x = this}
```

is lazily typechecked, in order to, according to the comment
in `typedRefinment, "avoid cyclic reference errors".

But the approximate type used ends up with:

```
Refinment@1(
  parents = [...]
  decls = { val x: Refinement@1 })
```

This commit eagerly checks that there is no term definitions
in type refinments, rather than delaying this.

This changes the error message for SI-3614.

Review by @adriaanm
