### PR TITLE
SI-5390 Detect forward reference of case class apply

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1534,8 +1534,14 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
         sym.name == nme.apply &&
         isClassTypeAccessible(tree)
 
-      if (doTransform)
+      if (doTransform) {
+        tree foreach {
+          case i@Ident(_) =>
+            enterReference(i.pos, i.symbol) // SI-5390 need to `enterReference` for `a` in `a.B()`
+          case _ =>
+        }
         toConstructor(tree.pos, tree.tpe)
+      }
       else {
         ifNot
         tree

--- a/test/files/neg/t5390.check
+++ b/test/files/neg/t5390.check
@@ -1,0 +1,4 @@
+t5390.scala:7: error: forward reference extends over definition of value b
+    val b = a.B("")
+            ^
+one error found

--- a/test/files/neg/t5390.scala
+++ b/test/files/neg/t5390.scala
@@ -1,0 +1,10 @@
+class A {
+  object B { def apply(s: String) = 0}
+}
+
+object X {
+  def foo {
+    val b = a.B("")
+    val a = new A
+  }
+}

--- a/test/files/neg/t5390b.check
+++ b/test/files/neg/t5390b.check
@@ -1,0 +1,4 @@
+t5390b.scala:7: error: forward reference extends over definition of value b
+    val b = a.B("")
+            ^
+one error found

--- a/test/files/neg/t5390b.scala
+++ b/test/files/neg/t5390b.scala
@@ -1,0 +1,10 @@
+class A {
+  case class B(s: String)
+}
+
+object X {
+  def foo {
+    val b = a.B("")
+    val a = new A
+  }
+}

--- a/test/files/neg/t5390c.check
+++ b/test/files/neg/t5390c.check
@@ -1,0 +1,4 @@
+t5390c.scala:7: error: forward reference extends over definition of value b
+    val b = new a.B("")
+                ^
+one error found

--- a/test/files/neg/t5390c.scala
+++ b/test/files/neg/t5390c.scala
@@ -1,0 +1,10 @@
+class A {
+  case class B(s: String)
+}
+
+object X {
+  def foo {
+    val b = new a.B("")
+    val a = new A
+  }
+}

--- a/test/files/neg/t5390d.check
+++ b/test/files/neg/t5390d.check
@@ -1,0 +1,4 @@
+t5390d.scala:7: error: forward reference extends over definition of value b
+    val b = a.B.toString
+            ^
+one error found

--- a/test/files/neg/t5390d.scala
+++ b/test/files/neg/t5390d.scala
@@ -1,0 +1,10 @@
+class A {
+  case class B(s: String)
+}
+
+object X {
+  def foo {
+    val b = a.B.toString
+    val a = new A
+  }
+}

--- a/test/files/pos/t5390.scala
+++ b/test/files/pos/t5390.scala
@@ -1,0 +1,11 @@
+class A {
+  case class B[A](s: String)
+}
+
+object X {
+  def foo {
+    val a = new A
+    val b = new a.B[c.type]("") // not a forward reference
+    val c = ""
+  }
+}


### PR DESCRIPTION
Refchecks performs (among others) two tasks at once:
- detecting forward references
- translating `qual.Case(...)` to `new qual.Case(...)`

As is often the case with such multi-tasking tree traversals,
completion of one task precluded the other.

Review by @adriaanm

One question: should this also be a forward reference?

``` scala
class A {
  case class B[A](s: String)
}

object X {
  def foo {
    val a = new A
    val b = new a.B[c.type]("")
    val c = ""
  }
}
```
