### PR TITLE
SI-6766 Makes the eclipse config for the library project use "scala" as ...

### DIFF
--- a/src/eclipse/scala-library/.classpath
+++ b/src/eclipse/scala-library/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="library"/>
+	<classpathentry kind="src" path="scala"/>
 	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="output" path="build-quick-lib"/>

--- a/src/eclipse/scala-library/.project
+++ b/src/eclipse/scala-library/.project
@@ -19,10 +19,10 @@
 		<link>
 			<name>build-quick-lib</name>
 			<type>2</type>
-			<locationURI>SCALA_BASEDIR/build/quick/classes/library</locationURI>
+			<locationURI>SCALA_BASEDIR/build/quick/classes/scala</locationURI>
 		</link>
 		<link>
-			<name>library</name>
+			<name>scala</name>
 			<type>2</type>
 			<locationURI>SCALA_BASEDIR/src/library</locationURI>
 		</link>


### PR DESCRIPTION
...the source path

The .classpath and .project files need to point to the "scala" subdirectory not the non-existent "library" subdirectory.
