### PR TITLE
SI-4859 Don't rewrite CC().CC2() to new CC2

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1464,7 +1464,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
     def compiles(sym: Symbol): Boolean =
       if (sym == NoSymbol) false
       else if (symSource.isDefinedAt(sym)) true
-      else if (!sym.owner.isPackageClass) compiles(sym.enclosingTopLevelClass)
+      else if (!sym.isTopLevel) compiles(sym.enclosingTopLevelClass)
       else if (sym.isModuleClass) compiles(sym.sourceModule)
       else false
 

--- a/src/compiler/scala/tools/nsc/backend/opt/DeadCodeElimination.scala
+++ b/src/compiler/scala/tools/nsc/backend/opt/DeadCodeElimination.scala
@@ -145,6 +145,8 @@ abstract class DeadCodeElimination extends SubComponent {
                 }
               }
               if (necessary) worklist += ((bb, idx))
+            case LOAD_MODULE(sym) if isLoadNeeded(sym) && !settings.YdceModuleLoad.value =>
+              worklist += ((bb, idx)) // SI-4859 Module initialization might side-effect.
             case _ => ()
           }
           rd = rdef.interpret(bb, idx, rd)

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -134,6 +134,7 @@ trait ScalaSettings extends AbsScalaSettings
   val Ycompacttrees   = BooleanSetting    ("-Ycompact-trees", "Use compact tree printer when displaying trees.")
   val noCompletion    = BooleanSetting    ("-Yno-completion", "Disable tab-completion in the REPL.")
   val Xdce            = BooleanSetting    ("-Ydead-code", "Perform dead code elimination.")
+  val YdceModuleLoad  = BooleanSetting    ("-Ydead-code-module-load", "Dead code elimination, if enabled, may eliminate initialization of outer modules. (For compatibility with Scala 2.10.0)")
   val debug           = BooleanSetting    ("-Ydebug", "Increase the quantity of debugging output.")
   //val doc           = BooleanSetting    ("-Ydoc", "Generate documentation")
   val termConflict    = ChoiceSetting     ("-Yresolve-term-conflict", "strategy", "Resolve term conflicts", List("package", "object", "error"), "error")

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -49,7 +49,7 @@ abstract class Erasure extends AddInterfaces
             if (sym == ArrayClass) args foreach traverse
             else if (sym.isTypeParameterOrSkolem || sym.isExistentiallyBound || !args.isEmpty) result = true
             else if (sym.isClass) traverse(rebindInnerClass(pre, sym)) // #2585
-            else if (!sym.owner.isPackageClass) traverse(pre)
+            else if (!sym.isTopLevel) traverse(pre)
           case PolyType(_, _) | ExistentialType(_, _) =>
             result = true
           case RefinedType(parents, _) =>

--- a/src/compiler/scala/tools/nsc/transform/Flatten.scala
+++ b/src/compiler/scala/tools/nsc/transform/Flatten.scala
@@ -122,7 +122,7 @@ abstract class Flatten extends InfoTransform {
         case ClassDef(_, _, _, _) if sym.isNestedClass =>
           liftedDefs(sym.enclosingTopLevelClass.owner) += tree
           EmptyTree
-        case Select(qual, name) if (sym.isStaticModule && !sym.owner.isPackageClass) =>
+        case Select(qual, name) if sym.isStaticModule && !sym.isTopLevel =>
           afterFlatten(atPos(tree.pos)(gen.mkAttributedRef(sym)))
         case _ =>
           tree

--- a/src/compiler/scala/tools/nsc/transform/Flatten.scala
+++ b/src/compiler/scala/tools/nsc/transform/Flatten.scala
@@ -14,6 +14,7 @@ import scala.collection.mutable.ListBuffer
 abstract class Flatten extends InfoTransform {
   import global._
   import definitions._
+  import treeInfo.isExprSafeToInline
 
   /** the following two members override abstract members in Transform */
   val phaseName: String = "flatten"
@@ -122,7 +123,7 @@ abstract class Flatten extends InfoTransform {
         case ClassDef(_, _, _, _) if sym.isNestedClass =>
           liftedDefs(sym.enclosingTopLevelClass.owner) += tree
           EmptyTree
-        case Select(qual, name) if sym.isStaticModule && !sym.isTopLevel =>
+        case Select(qual, name) if isExprSafeToInline(qual) && sym.isStaticModule && !sym.isTopLevel =>
           afterFlatten(atPos(tree.pos)(gen.mkAttributedRef(sym)))
         case _ =>
           tree

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -173,7 +173,7 @@ trait Namers extends MethodSynthesis {
     )
 
     private def allowsOverload(sym: Symbol) = (
-      sym.isSourceMethod && sym.owner.isClass && !sym.owner.isPackageClass
+      sym.isSourceMethod && sym.owner.isClass && !sym.isTopLevel
     )
 
     private def inCurrentScope(m: Symbol): Boolean = {

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1525,9 +1525,12 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
         case TypeApply(fun, targs) =>
           isClassTypeAccessible(fun)
         case Select(module, apply) =>
-          // Fixes SI-5626. Classes in refinement types cannot be constructed with `new`. In this case,
-          // the companion class is actually not a ClassSymbol, but a reference to an abstract type.
-          module.symbol.companionClass.isClass
+          ( // SI-4859 `CaseClass1().InnerCaseClass2()` must not be rewritten to `new InnerCaseClass2()`
+            treeInfo.isExprSafeToInline(module) &&
+            // SI-5626 Classes in refinement types cannot be constructed with `new`. In this case,
+            // the companion class is actually not a ClassSymbol, but a reference to an abstract type.
+            module.symbol.companionClass.isClass
+          )
       }
 
       val doTransform =

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1525,7 +1525,8 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
         case TypeApply(fun, targs) =>
           isClassTypeAccessible(fun)
         case Select(module, apply) =>
-          ( // SI-4859 `CaseClass1().InnerCaseClass2()` must not be rewritten to `new InnerCaseClass2()`
+          ( // SI-4859 `CaseClass1().InnerCaseClass2()` must not be rewritten to `new InnerCaseClass2()`;
+            //          {expr; Outer}.Inner() must not be rewritten to `new Outer.Inner()`.
             treeInfo.isExprSafeToInline(module) &&
             // SI-5626 Classes in refinement types cannot be constructed with `new`. In this case,
             // the companion class is actually not a ClassSymbol, but a reference to an abstract type.

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -822,6 +822,9 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       )
     )
 
+    /** Is this symbol owned by a package? */
+    final def isTopLevel = owner.isPackageClass
+
     /** Is this symbol locally defined? I.e. not accessed from outside `this` instance */
     final def isLocal: Boolean = owner.isTerm
 
@@ -2880,7 +2883,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     override def isAnonymousClass        = name containsName tpnme.ANON_CLASS_NAME
     override def isConcreteClass         = !(this hasFlag ABSTRACT | TRAIT)
     override def isJavaInterface         = hasAllFlags(JAVA | TRAIT)
-    override def isNestedClass           = !owner.isPackageClass
+    override def isNestedClass           = !isTopLevel
     override def isNumericValueClass     = definitions.isNumericValueClass(this)
     override def isNumeric               = isNumericValueClass
     override def isPackageObjectClass    = isModuleClass && (name == tpnme.PACKAGE)

--- a/test/files/pos/t4859.scala
+++ b/test/files/pos/t4859.scala
@@ -1,0 +1,17 @@
+object O {
+  // error: C is not a legal prefix for a constructor
+  C().CC()
+  // but this works.
+  D().DD()
+}
+
+case class C() {
+  case class CC()
+}
+
+case class D() {
+  class DD()
+  object DD {
+    def apply() = new DD()
+  }
+}

--- a/test/files/run/t4859.check
+++ b/test/files/run/t4859.check
@@ -1,0 +1,8 @@
+Inner
+Inner.i
+About to reference Inner.i
+Outer
+Inner.i
+About to reference O.N
+About to reference O.N
+About to reference O.N.apply()

--- a/test/files/run/t4859.scala
+++ b/test/files/run/t4859.scala
@@ -1,0 +1,29 @@
+object O {
+  case class N()
+  object P
+}
+
+object Outer {
+  println("Outer")
+  object Inner {
+    println("Inner")
+    def i {
+      println("Inner.i")
+    }
+  }
+}
+
+object Test {
+  def main(args: Array[String]) {
+    Outer.Inner.i // we still don't initiialize Outer here (but should we?)
+
+    {println("About to reference Inner.i"); Outer}.Inner.i // Outer will be initialized.
+
+    {println("About to reference O.N"        ); O}.N
+
+    {println("About to reference O.N"        ); O}.N
+
+    {println("About to reference O.N.apply()"); O}.N.apply()
+  }
+}
+

--- a/test/files/run/t4859b.check
+++ b/test/files/run/t4859b.check
@@ -1,0 +1,4 @@
+Inner
+Inner.i
+About to reference Inner.i
+Inner.i

--- a/test/files/run/t4859b.flags
+++ b/test/files/run/t4859b.flags
@@ -1,0 +1,1 @@
+-Ydead-code -Ydead-code-module-load

--- a/test/files/run/t4859b.scala
+++ b/test/files/run/t4859b.scala
@@ -1,0 +1,21 @@
+object Outer {
+  println("Outer")
+  object Inner {
+    println("Inner")
+    def i {
+      println("Inner.i")
+    }
+  }
+}
+
+object Test {
+  def main(args: Array[String]) {
+    Outer.Inner.i // we still don't initiialize Outer here (but should we?)
+
+    // Outer still not initialized under Scala 2.10.0-
+    // or with the backwards compatilibity option -Ydead-code-module-load
+    //
+    // Contrast with run/t4859.scala.
+    {println("About to reference Inner.i"); Outer}.Inner.i
+  }
+}


### PR DESCRIPTION
Where CC and CC2 are case classes. Attempting to do so leads to
a "no legal prefix" error.

Now, we restrict this optimization (living in RefChecks ?!) to
case class applies with a "safe to inline" qualifier.

Review by @paulp
- is `isExprSafeToInline` the right check here? I wasn't sure about that.
- I didn't go as far as adding a test to show that some rewriting still works. But via manual inspection: here's how the enclosed test case looks after `refchecks`.

``` scala
  object O extends scala.AnyRef {
    def <init>(): O.type = {
      O.super.<init>();
      ()
    };
    new C().CC.apply();
    new D().DD.apply()
  };
```

_Update_

I also had to modify `Flatten` and `GenICode` to make sure we throw in:

``` scala
{???; Predef}.DummyImplicit.dummyImplicit
```

and `DeadCodeElimination` to initialize object `Outer` in `Outer.Inner.foo`.
