### PR TITLE
SI-1672 Catches are in tail position without finally.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/TailCalls.scala
+++ b/src/compiler/scala/tools/nsc/transform/TailCalls.scala
@@ -327,8 +327,16 @@ abstract class TailCalls extends Transform {
             transformTrees(cases).asInstanceOf[List[CaseDef]]
           )
 
+        case Try(block, catches, finalizer @ EmptyTree) =>
+          // SI-1672 Catches are in tail position when there is no finalizer
+          treeCopy.Try(tree,
+            noTailTransform(block),
+            transformTrees(catches).asInstanceOf[List[CaseDef]],
+            EmptyTree
+          )
+
         case Try(block, catches, finalizer) =>
-           // no calls inside a try are in tail position, but keep recursing for nested functions
+           // no calls inside a try are in tail position if there is a finalizer, but keep recursing for nested functions
           treeCopy.Try(tree,
             noTailTransform(block),
             noTailTransforms(catches).asInstanceOf[List[CaseDef]],

--- a/test/files/neg/t1672b.check
+++ b/test/files/neg/t1672b.check
@@ -1,0 +1,13 @@
+t1672b.scala:3: error: could not optimize @tailrec annotated method bar: it contains a recursive call not in tail position
+  def bar : Nothing = {
+      ^
+t1672b.scala:14: error: could not optimize @tailrec annotated method baz: it contains a recursive call not in tail position
+  def baz : Nothing = {
+      ^
+t1672b.scala:29: error: could not optimize @tailrec annotated method boz: it contains a recursive call not in tail position
+      case _: Throwable => boz; ???
+                                ^
+t1672b.scala:34: error: could not optimize @tailrec annotated method bez: it contains a recursive call not in tail position
+  def bez : Nothing = {
+      ^
+four errors found

--- a/test/files/neg/t1672b.check
+++ b/test/files/neg/t1672b.check
@@ -10,4 +10,7 @@ t1672b.scala:29: error: could not optimize @tailrec annotated method boz: it con
 t1672b.scala:34: error: could not optimize @tailrec annotated method bez: it contains a recursive call not in tail position
   def bez : Nothing = {
       ^
-four errors found
+t1672b.scala:46: error: could not optimize @tailrec annotated method bar: it contains a recursive call not in tail position
+    else 1 + (try {
+           ^
+5 errors found

--- a/test/files/neg/t1672b.scala
+++ b/test/files/neg/t1672b.scala
@@ -1,0 +1,41 @@
+object Test {
+  @annotation.tailrec
+  def bar : Nothing = {
+    try {
+      throw new RuntimeException
+    } catch {
+      case _: Throwable => bar
+    } finally {
+      bar
+    }
+  }
+
+  @annotation.tailrec
+  def baz : Nothing = {
+    try {
+      throw new RuntimeException
+    } catch {
+      case _: Throwable => baz
+    } finally {
+      ???
+    }
+  }
+
+  @annotation.tailrec
+  def boz : Nothing = {
+    try {
+      throw new RuntimeException
+    } catch {
+      case _: Throwable => boz; ???
+    }
+  }
+
+  @annotation.tailrec
+  def bez : Nothing = {
+    try {
+      bez
+    } finally {
+      ???
+    }
+  }
+}

--- a/test/files/neg/t1672b.scala
+++ b/test/files/neg/t1672b.scala
@@ -38,4 +38,15 @@ object Test {
       ???
     }
   }
+
+  // the `liftedTree` local method will prevent a tail call here.
+  @annotation.tailrec
+  def bar(i : Int) : Int = {
+    if (i == 0) 0
+    else 1 + (try {
+      throw new RuntimeException
+    } catch {
+      case _: Throwable => bar(i - 1)
+    })
+  }
 }

--- a/test/files/pos/t1672.scala
+++ b/test/files/pos/t1672.scala
@@ -1,0 +1,10 @@
+object Test {
+  @annotation.tailrec
+  def bar : Nothing = {
+    try {
+      throw new RuntimeException
+    } catch {
+      case _: Throwable => bar
+    }
+  }
+}

--- a/test/files/run/t1672.scala
+++ b/test/files/run/t1672.scala
@@ -1,0 +1,28 @@
+object Test {
+  @annotation.tailrec
+  def bar(i : Int) : Int = {
+    if (i == 0) 0
+    else try {
+      throw new RuntimeException
+    } catch {
+      case _: Throwable => bar(i - 1)
+    }
+  }
+
+  @annotation.tailrec
+  def nestedTry1(i : Int) : Int = {
+    if (i == 0) 0
+    else try {
+      throw new RuntimeException
+    } catch {
+      case _: Throwable =>
+        try { ??? } catch { case _: Throwable => nestedTry1(i - 1) }
+    }
+  }
+
+  def main(args: Array[String]) {
+    assert(bar(2) == 0)
+
+    assert(nestedTry1(2) == 0)
+  }
+}


### PR DESCRIPTION
So we can eliminate tail calls within.

Review by @dragos, who once opined "I think this is safe as long as there is no `finally`".
