### PR TITLE
Fixing OSGi distribution.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2672,7 +2672,12 @@ DISTRIBUTION
   <target name="dist.base" depends="dist.start">
     <mkdir dir="${dist.dir}/lib"/>
     <copy toDir="${dist.dir}/lib">
-      <fileset dir="${build-pack.dir}/lib"/>
+      <fileset dir="${build-pack.dir}/lib">
+        <include name="jline.jar"/>
+        <include name="scalacheck.jar"/>
+        <include name="scala-partest.jar"/>
+        <include name="scalap.jar"/>
+      </fileset>
     </copy>
     <mkdir dir="${dist.dir}/bin"/>
     <!-- TODO - Stop being inefficient and don't copy OSGi bundles overtop other jars. -->


### PR DESCRIPTION
Apparently you have to resort to all manners of awesome in ant.  Probably better to
filter in what you awnt to copy rather than overwrite.  So far ths works.

Review by @lrytz or @adriaanm
