### PR TITLE
SI-5894 Don't emit static forwarders for macros.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
@@ -21,7 +21,7 @@ import asm.Label
  *
  * Documentation at http://lamp.epfl.ch/~magarcia/ScalaCompilerCornerReloaded/2012Q2/GenASM.pdf
  */
-abstract class GenASM extends SubComponent with BytecodeWriters {
+abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
   import global._
   import icodes._
   import icodes.opcodes._
@@ -32,20 +32,6 @@ abstract class GenASM extends SubComponent with BytecodeWriters {
   /** Create a new phase */
   override def newPhase(p: Phase): Phase = new AsmPhase(p)
 
-  private def outputDirectory(sym: Symbol): AbstractFile =
-    settings.outputDirs outputDirFor beforeFlatten(sym.sourceFile)
-
-  private def getFile(base: AbstractFile, clsName: String, suffix: String): AbstractFile = {
-    var dir = base
-    val pathParts = clsName.split("[./]").toList
-    for (part <- pathParts.init) {
-      dir = dir.subdirectoryNamed(part)
-    }
-    dir.fileNamed(pathParts.last + suffix)
-  }
-  private def getFile(sym: Symbol, clsName: String, suffix: String): AbstractFile =
-    getFile(outputDirectory(sym), clsName, suffix)
-
   /** JVM code generation phase
    */
   class AsmPhase(prev: Phase) extends ICodePhase(prev) {
@@ -54,62 +40,6 @@ abstract class GenASM extends SubComponent with BytecodeWriters {
     def apply(cls: IClass) = sys.error("no implementation")
 
     val BeanInfoAttr = rootMirror.getRequiredClass("scala.beans.BeanInfo")
-
-    def isJavaEntryPoint(icls: IClass) = {
-      val sym = icls.symbol
-      def fail(msg: String, pos: Position = sym.pos) = {
-        icls.cunit.warning(sym.pos,
-          sym.name + " has a main method with parameter type Array[String], but " + sym.fullName('.') + " will not be a runnable program.\n" +
-          "  Reason: " + msg
-          // TODO: make this next claim true, if possible
-          //   by generating valid main methods as static in module classes
-          //   not sure what the jvm allows here
-          // + "  You can still run the program by calling it as " + sym.javaSimpleName + " instead."
-        )
-        false
-      }
-      def failNoForwarder(msg: String) = {
-        fail(msg + ", which means no static forwarder can be generated.\n")
-      }
-      val possibles = if (sym.hasModuleFlag) (sym.tpe nonPrivateMember nme.main).alternatives else Nil
-      val hasApproximate = possibles exists { m =>
-        m.info match {
-          case MethodType(p :: Nil, _) => p.tpe.typeSymbol == ArrayClass
-          case _                       => false
-        }
-      }
-      // At this point it's a module with a main-looking method, so either succeed or warn that it isn't.
-      hasApproximate && {
-        // Before erasure so we can identify generic mains.
-        beforeErasure {
-          val companion     = sym.linkedClassOfClass
-          val companionMain = companion.tpe.member(nme.main)
-
-          if (hasJavaMainMethod(companion))
-            failNoForwarder("companion contains its own main method")
-          else if (companion.tpe.member(nme.main) != NoSymbol)
-            // this is only because forwarders aren't smart enough yet
-            failNoForwarder("companion contains its own main method (implementation restriction: no main is allowed, regardless of signature)")
-          else if (companion.isTrait)
-            failNoForwarder("companion is a trait")
-          // Now either succeeed, or issue some additional warnings for things which look like
-          // attempts to be java main methods.
-          else possibles exists { m =>
-            m.info match {
-              case PolyType(_, _) =>
-                fail("main methods cannot be generic.")
-              case MethodType(params, res) =>
-                if (res.typeSymbol :: params exists (_.isAbstractType))
-                  fail("main methods cannot refer to type parameters or abstract types.", m.pos)
-                else
-                  isJavaMainMethod(m) || fail("main method must have exact signature (Array[String])Unit", m.pos)
-              case tp =>
-                fail("don't know what this is: " + tp, m.pos)
-            }
-          }
-        }
-      }
-    }
 
     private def initBytecodeWriter(entryPoints: List[IClass]): BytecodeWriter = {
       settings.outputDirs.getSingleOutput match {
@@ -1089,12 +1019,6 @@ abstract class GenASM extends SubComponent with BytecodeWriters {
     // Static forwarders (related to mirror classes but also present in
     // a plain class lacking companion module, for details see `isCandidateForForwarders`).
     // -----------------------------------------------------------------------------------------
-
-    val ExcludedForwarderFlags = {
-      import Flags._
-      // Should include DEFERRED but this breaks findMember.
-      ( CASE | SPECIALIZED | LIFTED | PROTECTED | STATIC | EXPANDEDNAME | BridgeAndPrivateFlags )
-    }
 
     /** Add a forwarder for method m. Used only from addForwarders(). */
     private def addForwarder(isRemoteClass: Boolean, jclass: asm.ClassVisitor, module: Symbol, m: Symbol) {

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenJVM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenJVM.scala
@@ -26,7 +26,7 @@ import scala.language.postfixOps
  *  @version 1.0
  *
  */
-abstract class GenJVM extends SubComponent with GenJVMUtil with GenAndroid with BytecodeWriters {
+abstract class GenJVM extends SubComponent with GenJVMUtil with GenAndroid with BytecodeWriters with GenJVMASM {
   import global._
   import icodes._
   import icodes.opcodes._
@@ -37,83 +37,12 @@ abstract class GenJVM extends SubComponent with GenJVMUtil with GenAndroid with 
   /** Create a new phase */
   override def newPhase(p: Phase): Phase = new JvmPhase(p)
 
-  private def outputDirectory(sym: Symbol): AbstractFile =
-    settings.outputDirs outputDirFor beforeFlatten(sym.sourceFile)
-
-  private def getFile(base: AbstractFile, clsName: String, suffix: String): AbstractFile = {
-    var dir = base
-    val pathParts = clsName.split("[./]").toList
-    for (part <- pathParts.init) {
-      dir = dir.subdirectoryNamed(part)
-    }
-    dir.fileNamed(pathParts.last + suffix)
-  }
-  private def getFile(sym: Symbol, clsName: String, suffix: String): AbstractFile =
-    getFile(outputDirectory(sym), clsName, suffix)
-
   /** JVM code generation phase
    */
   class JvmPhase(prev: Phase) extends ICodePhase(prev) {
     def name = phaseName
     override def erasedTypes = true
     def apply(cls: IClass) = sys.error("no implementation")
-
-    def isJavaEntryPoint(clasz: IClass) = {
-      val sym = clasz.symbol
-      def fail(msg: String, pos: Position = sym.pos) = {
-        clasz.cunit.warning(sym.pos,
-          sym.name + " has a main method with parameter type Array[String], but " + sym.fullName('.') + " will not be a runnable program.\n" +
-          "  Reason: " + msg
-          // TODO: make this next claim true, if possible
-          //   by generating valid main methods as static in module classes
-          //   not sure what the jvm allows here
-          // + "  You can still run the program by calling it as " + sym.javaSimpleName + " instead."
-        )
-        false
-      }
-      def failNoForwarder(msg: String) = {
-        fail(msg + ", which means no static forwarder can be generated.\n")
-      }
-      val possibles = if (sym.hasModuleFlag) (sym.tpe nonPrivateMember nme.main).alternatives else Nil
-      val hasApproximate = possibles exists { m =>
-        m.info match {
-          case MethodType(p :: Nil, _) => p.tpe.typeSymbol == ArrayClass
-          case _                       => false
-        }
-      }
-      // At this point it's a module with a main-looking method, so either
-      // succeed or warn that it isn't.
-      hasApproximate && {
-        // Before erasure so we can identify generic mains.
-        beforeErasure {
-          val companion     = sym.linkedClassOfClass
-          val companionMain = companion.tpe.member(nme.main)
-
-          if (hasJavaMainMethod(companion))
-            failNoForwarder("companion contains its own main method")
-          else if (companion.tpe.member(nme.main) != NoSymbol)
-            // this is only because forwarders aren't smart enough yet
-            failNoForwarder("companion contains its own main method (implementation restriction: no main is allowed, regardless of signature)")
-          else if (companion.isTrait)
-            failNoForwarder("companion is a trait")
-          // Now either succeeed, or issue some additional warnings for things which look like
-          // attempts to be java main methods.
-          else possibles exists { m =>
-            m.info match {
-              case PolyType(_, _) =>
-                fail("main methods cannot be generic.")
-              case MethodType(params, res) =>
-                if (res.typeSymbol :: params exists (_.isAbstractType))
-                  fail("main methods cannot refer to type parameters or abstract types.", m.pos)
-                else
-                  isJavaMainMethod(m) || fail("main method must have exact signature (Array[String])Unit", m.pos)
-              case tp =>
-                fail("don't know what this is: " + tp, m.pos)
-            }
-          }
-        }
-      }
-    }
 
     override def run() {
       // we reinstantiate the bytecode generator at each run, to allow the GC
@@ -209,12 +138,6 @@ abstract class GenJVM extends SubComponent with GenJVMUtil with GenAndroid with 
     val BeanInfoSkipAttr    = rootMirror.getRequiredClass("scala.beans.BeanInfoSkip")
     val BeanDisplayNameAttr = rootMirror.getRequiredClass("scala.beans.BeanDisplayName")
     val BeanDescriptionAttr = rootMirror.getRequiredClass("scala.beans.BeanDescription")
-
-    final val ExcludedForwarderFlags = {
-      import Flags._
-      // Should include DEFERRED but this breaks findMember.
-      ( CASE | SPECIALIZED | LIFTED | PROTECTED | STATIC | EXPANDEDNAME | BridgeAndPrivateFlags )
-    }
 
     // Additional interface parents based on annotations and other cues
     def newParentForAttr(attr: Symbol): Option[Symbol] = attr match {

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenJVMASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenJVMASM.scala
@@ -36,7 +36,7 @@ trait GenJVMASM {
   protected val ExcludedForwarderFlags = {
     import Flags._
     // Should include DEFERRED but this breaks findMember.
-    ( CASE | SPECIALIZED | LIFTED | PROTECTED | STATIC | EXPANDEDNAME | BridgeAndPrivateFlags )
+    ( CASE | SPECIALIZED | LIFTED | PROTECTED | STATIC | EXPANDEDNAME | BridgeAndPrivateFlags | MACRO )
   }
 
   protected def isJavaEntryPoint(icls: IClass) = {

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenJVMASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenJVMASM.scala
@@ -1,0 +1,97 @@
+/* NSC -- new Scala compiler
+ * Copyright 2005-2013 LAMP/EPFL
+ * @author  Jason Zaugg
+ */
+
+package scala.tools.nsc
+package backend.jvm
+import scala.tools.nsc.io.AbstractFile
+import scala.tools.nsc.symtab._
+
+/** Code shared between the legagy backend [[scala.tools.nsc.backend.jvm.GenJVM]]
+  * and the new backend [[scala.tools.nsc.backend.jvm.GenASM]]. There should be
+  * more here, but for now I'm starting with the refactorings that are either
+  * straightforward to review or necessary for maintenance.
+  */
+trait GenJVMASM {
+  val global: Global
+  import global._
+  import icodes._
+  import definitions._
+
+  protected def outputDirectory(sym: Symbol): AbstractFile =
+    settings.outputDirs outputDirFor beforeFlatten(sym.sourceFile)
+
+  protected def getFile(base: AbstractFile, clsName: String, suffix: String): AbstractFile = {
+    var dir = base
+    val pathParts = clsName.split("[./]").toList
+    for (part <- pathParts.init) {
+      dir = dir.subdirectoryNamed(part)
+    }
+    dir.fileNamed(pathParts.last + suffix)
+  }
+  protected def getFile(sym: Symbol, clsName: String, suffix: String): AbstractFile =
+    getFile(outputDirectory(sym), clsName, suffix)
+
+  protected val ExcludedForwarderFlags = {
+    import Flags._
+    // Should include DEFERRED but this breaks findMember.
+    ( CASE | SPECIALIZED | LIFTED | PROTECTED | STATIC | EXPANDEDNAME | BridgeAndPrivateFlags )
+  }
+
+  protected def isJavaEntryPoint(icls: IClass) = {
+    val sym = icls.symbol
+    def fail(msg: String, pos: Position = sym.pos) = {
+      icls.cunit.warning(sym.pos,
+        sym.name + " has a main method with parameter type Array[String], but " + sym.fullName('.') + " will not be a runnable program.\n" +
+          "  Reason: " + msg
+        // TODO: make this next claim true, if possible
+        //   by generating valid main methods as static in module classes
+        //   not sure what the jvm allows here
+        // + "  You can still run the program by calling it as " + sym.javaSimpleName + " instead."
+      )
+      false
+    }
+    def failNoForwarder(msg: String) = {
+      fail(msg + ", which means no static forwarder can be generated.\n")
+    }
+    val possibles = if (sym.hasModuleFlag) (sym.tpe nonPrivateMember nme.main).alternatives else Nil
+    val hasApproximate = possibles exists { m =>
+      m.info match {
+        case MethodType(p :: Nil, _) => p.tpe.typeSymbol == ArrayClass
+        case _                       => false
+      }
+    }
+    // At this point it's a module with a main-looking method, so either succeed or warn that it isn't.
+    hasApproximate && {
+      // Before erasure so we can identify generic mains.
+      beforeErasure {
+        val companion     = sym.linkedClassOfClass
+        val companionMain = companion.tpe.member(nme.main)
+
+        if (hasJavaMainMethod(companion))
+          failNoForwarder("companion contains its own main method")
+        else if (companion.tpe.member(nme.main) != NoSymbol)
+          // this is only because forwarders aren't smart enough yet
+          failNoForwarder("companion contains its own main method (implementation restriction: no main is allowed, regardless of signature)")
+        else if (companion.isTrait)
+          failNoForwarder("companion is a trait")
+        // Now either succeeed, or issue some additional warnings for things which look like
+        // attempts to be java main methods.
+        else possibles exists { m =>
+          m.info match {
+            case PolyType(_, _) =>
+              fail("main methods cannot be generic.")
+            case MethodType(params, res) =>
+              if (res.typeSymbol :: params exists (_.isAbstractType))
+                fail("main methods cannot refer to type parameters or abstract types.", m.pos)
+              else
+                isJavaMainMethod(m) || fail("main method must have exact signature (Array[String])Unit", m.pos)
+            case tp =>
+              fail("don't know what this is: " + tp, m.pos)
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/files/run/t5894.scala
+++ b/test/files/run/t5894.scala
@@ -1,0 +1,17 @@
+import language.experimental.macros
+
+class Test
+
+object Test {
+  def foo = macro fooImpl
+  def fooImpl(c: reflect.macros.Context) = c.literalUnit
+
+  def main(args: Array[String]) {
+    try {
+      val method = classOf[Test].getMethod("foo")
+      sys.error("Static forwarder generated for macro: " + method)
+    } catch {
+      case _: NoSuchMethodException => // okay
+    }
+  }
+}


### PR DESCRIPTION
With a little opportunistic `Gen{AS, JV}M` duplication avoidance en-route.

Review by @magarcia, /cc @paulp, @xeno-by
