### PR TITLE
SI-6766 Create a continuations project in eclipse

### DIFF
--- a/src/eclipse/README.md
+++ b/src/eclipse/README.md
@@ -20,7 +20,9 @@ JDK. The Scala library uses such APIs, so you'd see this error:
 You can *fix* it by allowing calls to restricted APIs in `Java=>Compiler=>Errors/Warnings=>Deprecated and Restricted API` 
 settings.
 
-3. The IDE guesses the Scala library version by looking for `library.properties` inside 
+3. We need to build the continuations library for some dependencies and that library requires the continuations plugin to be enabled. In preferences go to Scala=>Compiler and add "continuations:enable" to the P parameter. 
+
+4. The IDE guesses the Scala library version by looking for `library.properties` inside 
 the library jar. The `scala-library` project does not have such a file, so you will see
 an error about incompatible libraries. You can work around it by adding a `library.properties`
 inside `src/library` with the following contents:
@@ -31,7 +33,7 @@ inside `src/library` with the following contents:
         osgi.version.number=2.10.0.v20120603-141530-b34313db72
         copyright.string=Copyright 2002-2012 LAMP/EPFL
 
-4. Project files are tracked by Git, so adding them to `.gitignore` won't prevent them
+5. Project files are tracked by Git, so adding them to `.gitignore` won't prevent them
 from being shown as dirty in `git status`. You can still ignore them by telling Git to
 consider them unchanged:
 

--- a/src/eclipse/README.md
+++ b/src/eclipse/README.md
@@ -20,9 +20,7 @@ JDK. The Scala library uses such APIs, so you'd see this error:
 You can *fix* it by allowing calls to restricted APIs in `Java=>Compiler=>Errors/Warnings=>Deprecated and Restricted API` 
 settings.
 
-3. We need to build the continuations library for some dependencies and that library requires the continuations plugin to be enabled. In preferences go to Scala=>Compiler and add "continuations:enable" to the P parameter. 
-
-4. The IDE guesses the Scala library version by looking for `library.properties` inside 
+3. The IDE guesses the Scala library version by looking for `library.properties` inside 
 the library jar. The `scala-library` project does not have such a file, so you will see
 an error about incompatible libraries. You can work around it by adding a `library.properties`
 inside `src/library` with the following contents:
@@ -33,7 +31,7 @@ inside `src/library` with the following contents:
         osgi.version.number=2.10.0.v20120603-141530-b34313db72
         copyright.string=Copyright 2002-2012 LAMP/EPFL
 
-5. Project files are tracked by Git, so adding them to `.gitignore` won't prevent them
+4. Project files are tracked by Git, so adding them to `.gitignore` won't prevent them
 from being shown as dirty in `git status`. You can still ignore them by telling Git to
 consider them unchanged:
 

--- a/src/eclipse/continuations-library/.classpath
+++ b/src/eclipse/continuations-library/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="library"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/scala-library"/>
+	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="output" path="build-quick-continuations-library"/>
+</classpath>

--- a/src/eclipse/continuations-library/.project
+++ b/src/eclipse/continuations-library/.project
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>continuations-library</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.scala-ide.sdt.core.scalabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.scala-ide.sdt.core.scalanature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+	<linkedResources>
+		<link>
+			<name>build-quick-continuations-library</name>
+			<type>2</type>
+			<locationURI>SCALA_BASEDIR/build/quick/classes/continuations/library</locationURI>
+		</link>
+		<link>
+			<name>library</name>
+			<type>2</type>
+			<locationURI>SCALA_BASEDIR/src/continuations/library</locationURI>
+		</link>
+	</linkedResources>
+</projectDescription>

--- a/src/eclipse/continuations-library/.settings/org.scala-ide.sdt.core.prefs
+++ b/src/eclipse/continuations-library/.settings/org.scala-ide.sdt.core.prefs
@@ -1,0 +1,2 @@
+P=continuations\:enable
+scala.compiler.useProjectSettings=true

--- a/src/eclipse/partest/.classpath
+++ b/src/eclipse/partest/.classpath
@@ -10,5 +10,6 @@
 	<classpathentry kind="lib" path="lib/jline.jar"/>
 	<classpathentry kind="lib" path="lib/msil.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/asm"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/continuations-library"/>
 	<classpathentry kind="output" path="build-quick-partest"/>
 </classpath>

--- a/src/eclipse/reflect/.classpath
+++ b/src/eclipse/reflect/.classpath
@@ -3,5 +3,6 @@
 	<classpathentry kind="src" path="reflect"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scala-library"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/continuations-library"/>
 	<classpathentry kind="output" path="build-quick-reflect"/>
 </classpath>

--- a/src/eclipse/scala-compiler/.classpath
+++ b/src/eclipse/scala-compiler/.classpath
@@ -9,5 +9,6 @@
 	<classpathentry kind="lib" path="lib/ant/ant.jar"/>
 	<classpathentry kind="lib" path="lib/jline.jar"/>
 	<classpathentry kind="lib" path="lib/msil.jar"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/continuations-library"/>
 	<classpathentry kind="output" path="build-quick-compiler"/>
 </classpath>

--- a/src/eclipse/scalap/.classpath
+++ b/src/eclipse/scalap/.classpath
@@ -8,5 +8,6 @@
 	<classpathentry kind="lib" path="lib/ant/ant.jar"/>
 	<classpathentry kind="lib" path="lib/jline.jar"/>
 	<classpathentry kind="lib" path="lib/msil.jar"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/continuations-library"/>
 	<classpathentry kind="output" path="build-quick-scalap"/>
 </classpath>


### PR DESCRIPTION
We're missing a continuations dependency when we try to build reflect
in eclipse which causes things to die horribly. This commit adds an
eclipse project for the library portion of continuations, makes
projects that depend on the scala-library also depend on
continuations-library, and adds another bullet to the eclipse readme to
turn on the continuations plugin.

This is a resubmit of https://github.com/scala/scala/pull/1715 to the 2.10.x branch
