### PR TITLE
Fix for SI-6699

### DIFF
--- a/src/library/scala/math/BigDecimal.scala
+++ b/src/library/scala/math/BigDecimal.scala
@@ -198,7 +198,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable {
     */
   def isValidDouble = {
     val d = toDouble
-    !d.isInfinity && bigDecimal.compareTo(new java.math.BigDecimal(d)) == 0
+    !d.isInfinity && bigDecimal.compareTo(new java.math.BigDecimal(jl.Double.toString(d), mc))) == 0
   }
 
   private def noArithmeticException(body: => Unit): Boolean = {

--- a/src/library/scala/math/BigDecimal.scala
+++ b/src/library/scala/math/BigDecimal.scala
@@ -198,7 +198,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable {
     */
   def isValidDouble = {
     val d = toDouble
-    !d.isInfinity && bigDecimal.compareTo(new java.math.BigDecimal(jl.Double.toString(d), mc))) == 0
+    !d.isInfinity && bigDecimal.compareTo(new java.math.BigDecimal(jl.Double.toString(d), mc)) == 0
   }
 
   private def noArithmeticException(body: => Unit): Boolean = {

--- a/test/files/run/bigDecimalTest.scala
+++ b/test/files/run/bigDecimalTest.scala
@@ -28,6 +28,10 @@ object Test {
 
     // SI-4547: implicit conversion
     assert(5 + BigDecimal(3) == BigDecimal(8))
+
+    // SI-6699: BigDecimal.isValidDouble behaves unexpectedly
+    assert(BigDecimal("10.1").isValidDouble)
+    assert(!BigDecimal("10.000000000000001").isValidDouble)
     
     // meaningless sanity check
     List[BigDecimal](a, b, c, d, e, f) map (_.scale) foreach println


### PR DESCRIPTION
BigDecimal.isValidDouble was changed and two tests have been added to test/files/run/bigDecimalTest.scala
