### PR TITLE
SI-5958 This deserves a stable type - backport to 2.9.x

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/TreeGen.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeGen.scala
@@ -124,6 +124,8 @@ abstract class TreeGen {
 
   /** Computes stable type for a tree if possible */
   def stableTypeFor(tree: Tree): Option[Type] = tree match {
+    case This(_) if tree.symbol != null && !tree.symbol.isError =>
+      Some(ThisType(tree.symbol))
     case Ident(_) if tree.symbol.isStable =>
       Some(singleType(tree.symbol.owner.thisType, tree.symbol))
     case Select(qual, _) if ((tree.symbol ne null) && (qual.tpe ne null)) && // turned assert into guard for #4064

--- a/test/files/pos/t5958.flags
+++ b/test/files/pos/t5958.flags
@@ -1,0 +1,1 @@
+-Ydependent-method-types

--- a/test/files/pos/t5958.scala
+++ b/test/files/pos/t5958.scala
@@ -1,0 +1,15 @@
+class Test {
+  def newComponent(u: Universe): u.Component = throw new Exception("not implemented")
+
+  class Universe { self =>
+    class Component
+
+    newComponent(this): this.Component // error, but should be fine since this is a stable reference
+    newComponent(self): self.Component // error, but should be fine since this is a stable reference
+    newComponent(self): this.Component // error, but should be fine since this is a stable reference
+    newComponent(this): self.Component // error, but should be fine since this is a stable reference
+
+    val u = this
+    newComponent(u): u.Component // ok
+  }
+}


### PR DESCRIPTION
`this` (or the self variable) passed as an actual argument to a method
should receive a singleton type when computing the method's resultType

this is necessary if the method's type depends on that argument

adapts the test so that it runs on 2.9.x

Note: this backport is required for the backport of SIP-14 (futures).

review by @adriaanm
