### PR TITLE
SI-6548 reflection now correctly enters jinners

### DIFF
--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -574,7 +574,7 @@ private[reflect] trait JavaMirrors extends internal.SymbolTable with api.JavaUni
               case None =>
                 // class does not have a Scala signature; it's a Java class
                 info("translating reflection info for Java " + jclazz) //debug
-                initClassModule(clazz, module, new FromJavaClassCompleter(clazz, module, jclazz))
+                initClassAndModule(clazz, module, new FromJavaClassCompleter(clazz, module, jclazz))
             }
         }
       } catch {
@@ -1043,7 +1043,7 @@ private[reflect] trait JavaMirrors extends internal.SymbolTable with api.JavaUni
       val owner = sOwner(jclazz)
       val name = scalaSimpleName(jclazz)
       val completer = (clazz: Symbol, module: Symbol) => new FromJavaClassCompleter(clazz, module, jclazz)
-      createClassModule(owner, name, completer) match { case (clazz, module) => clazz }
+      initAndEnterClassAndModule(owner, name, completer)._1
     }
 
     /**

--- a/src/reflect/scala/reflect/runtime/SymbolLoaders.scala
+++ b/src/reflect/scala/reflect/runtime/SymbolLoaders.scala
@@ -57,7 +57,7 @@ private[reflect] trait SymbolLoaders { self: SymbolTable =>
    *  @param name    The simple name of the newly created class
    *  @param completer  The completer to be used to set the info of the class and the module
    */
-  protected def createClassModule(owner: Symbol, name: TypeName, completer: (Symbol, Symbol) => LazyType) = {
+  protected def initAndEnterClassAndModule(owner: Symbol, name: TypeName, completer: (Symbol, Symbol) => LazyType) = {
     assert(!(name.toString endsWith "[]"), name)
     val clazz = owner.newClass(name)
     val module = owner.newModule(name.toTermName)
@@ -67,7 +67,7 @@ private[reflect] trait SymbolLoaders { self: SymbolTable =>
       owner.info.decls enter clazz
       owner.info.decls enter module
     }
-    initClassModule(clazz, module, completer(clazz, module))
+    initClassAndModule(clazz, module, completer(clazz, module))
     (clazz, module)
   }
 
@@ -75,7 +75,7 @@ private[reflect] trait SymbolLoaders { self: SymbolTable =>
     List(clazz, module, module.moduleClass) foreach (_ setInfo info)
   }
 
-  protected def initClassModule(clazz: Symbol, module: Symbol, completer: LazyType) =
+  protected def initClassAndModule(clazz: Symbol, module: Symbol, completer: LazyType) =
     setAllInfos(clazz, module, completer)
 
   /** The type completer for packages.
@@ -118,7 +118,7 @@ private[reflect] trait SymbolLoaders { self: SymbolTable =>
             val loadingMirror = currentMirror.mirrorDefining(cls)
             val (clazz, module) =
               if (loadingMirror eq currentMirror) {
-                createClassModule(pkgClass, name.toTypeName, new TopClassCompleter(_, _))
+                initAndEnterClassAndModule(pkgClass, name.toTypeName, new TopClassCompleter(_, _))
               } else {
                 val origOwner = loadingMirror.packageNameToScala(pkgClass.fullName)
                 val clazz = origOwner.info decl name.toTypeName

--- a/test/files/lib/javac-artifacts.jar.desired.sha1
+++ b/test/files/lib/javac-artifacts.jar.desired.sha1
@@ -1,1 +1,1 @@
-c5788c5e518eb267445c5a995fd98b2210f90a58 ?javac-artifacts.jar
+61931a51bb1a2d308d214b96d06e9a8808515dcf ?javac-artifacts.jar

--- a/test/files/run/t6548.check
+++ b/test/files/run/t6548.check
@@ -1,0 +1,2 @@
+false
+List(JavaAnnotationWithNestedEnum(value = VALUE))

--- a/test/files/run/t6548.scala
+++ b/test/files/run/t6548.scala
@@ -1,0 +1,12 @@
+import scala.reflect.runtime.universe._
+import scala.reflect.runtime.{currentMirror => cm}
+
+class Bean {
+  @JavaAnnotationWithNestedEnum(JavaAnnotationWithNestedEnum.Value.VALUE)
+  def value = 1
+}
+
+object Test extends App {
+  println(cm.staticClass("Bean").isCaseClass)
+  println(typeOf[Bean].declaration(newTermName("value")).annotations)
+}


### PR DESCRIPTION
When completing Java classes, runtime reflection enumerates their
fields, methods, constructors and inner classes, loads them and
enters them into either the instance part (ClassSymbol) or the
static part (ModuleSymbol).

However unlike fields, methods and constructors, inner classes don't
need to be entered explicitly - they are entered implicitly when
being loaded.

This patch fixes the double-enter problem, make sure that enter-on-load
uses the correct owner, and also hardens jclassAsScala against double
enters that can occur in a different scenario.
