### PR TITLE
SI-5789 Removes assertion about implclass flag in Mixin.scala

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Mixin.scala
+++ b/src/compiler/scala/tools/nsc/transform/Mixin.scala
@@ -269,7 +269,7 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
 
     /** Mix in members of implementation class mixinClass into class clazz */
     def mixinImplClassMembers(mixinClass: Symbol, mixinInterface: Symbol) {
-      assert(mixinClass.isImplClass, "Not an impl class:" +
+      if (!mixinClass.isImplClass) debugwarn ("Impl class flag is not set " +
         ((mixinClass.debugLocationString, mixinInterface.debugLocationString)))
 
       for (member <- mixinClass.info.decls ; if isForwarded(member)) {
@@ -360,7 +360,6 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
     // first complete the superclass with mixed in members
     addMixedinMembers(clazz.superClass, unit)
 
-    //Console.println("adding members of " + clazz.info.baseClasses.tail.takeWhile(superclazz !=) + " to " + clazz);//DEBUG
     for (mc <- clazz.mixinClasses ; if mc hasFlag lateINTERFACE) {
       // @SEAN: adding trait tracking so we don't have to recompile transitive closures
       unit.depends += mc

--- a/test/files/run/t5789.check
+++ b/test/files/run/t5789.check
@@ -1,0 +1,1 @@
+completed successfully

--- a/test/files/run/t5789.check
+++ b/test/files/run/t5789.check
@@ -1,1 +1,14 @@
-completed successfully
+Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> 
+
+scala>     val n = 2
+n: Int = 2
+
+scala>     () => n
+res0: () => Int = <function0>
+
+scala> 
+
+scala> 

--- a/test/files/run/t5789.scala
+++ b/test/files/run/t5789.scala
@@ -1,0 +1,29 @@
+
+import scala.tools.nsc._
+import interpreter.ILoop
+
+object Test {
+
+  def main(args : Array[String]) {
+
+    val code = """
+  val n = 2
+  () => n
+    """
+
+    val s = new Settings()
+    s.optimise.value = false
+    s.debug.value  = true
+    s.log.value = List("all")
+    val lines = ILoop.runForTranscript(code + "\n" + code, s).lines.toList
+
+
+    if (lines exists (_ contains "Abandoning crashed session")) {
+     lines foreach println
+    	println("crashed!")
+    } else {
+      println("completed successfully")
+    }
+  }
+}
+

--- a/test/files/run/t5789.scala
+++ b/test/files/run/t5789.scala
@@ -1,27 +1,14 @@
 
 import scala.tools.nsc._
 import interpreter.ILoop
-
-object Test {
-
-  def main(args : Array[String]) {
-
-    val code = """
-  val n = 2
-  () => n
-    """
-
-    val s = new Settings()
-    s.optimise.value = true
-    val lines = ILoop.runForTranscript(code + "\n" + code, s).lines.toList
+import scala.tools.partest.ReplTest
 
 
-    if (lines exists (_ contains "Abandoning crashed session")) {
-     lines foreach println
-    	println("crashed!")
-    } else {
-      println("completed successfully")
-    }
-  }
+object Test extends ReplTest {
+  override def extraSettings = "-Yinline"
+  def code = """
+    val n = 2
+    () => n
+  """
 }
 

--- a/test/files/run/t5789.scala
+++ b/test/files/run/t5789.scala
@@ -12,9 +12,7 @@ object Test {
     """
 
     val s = new Settings()
-    s.optimise.value = false
-    s.debug.value  = true
-    s.log.value = List("all")
+    s.optimise.value = true
     val lines = ILoop.runForTranscript(code + "\n" + code, s).lines.toList
 
 


### PR DESCRIPTION
The assertion that the class being mixed from should be an implclass
seems reasonable, but the flag isn't always set. In order to stop the
bleeding this fix turns the assertion into a debug warning. Issue SI-6782
will track figuring out the root cause of the missing flag.
