### PR TITLE
SI-5858 xml.Node construction ambiguity is gone.

### DIFF
--- a/test/files/pos/t5858.scala
+++ b/test/files/pos/t5858.scala
@@ -1,0 +1,3 @@
+object Test {
+  new xml.Elem(null, null, xml.Null, xml.TopScope, Nil: _*) // was ambiguous
+}


### PR DESCRIPTION
Test case to show that the fix for SI-5859 saves the day.
