### PR TITLE
Adds extractors for TypeName, TermName and Modifiers

### DIFF
--- a/src/reflect/scala/reflect/api/Names.scala
+++ b/src/reflect/scala/reflect/api/Names.scala
@@ -58,7 +58,7 @@ trait Names {
    *  Can be used for pattern matching, instance tests, serialization and likes.
    *  @group Tags
    */
-implicit val TypeNameTag: ClassTag[TypeName]
+  implicit val TypeNameTag: ClassTag[TypeName]
 
   /** The abstract type of names representing types.
    *  @group Names
@@ -109,10 +109,38 @@ implicit val TypeNameTag: ClassTag[TypeName]
   /** Create a new term name.
    *  @group Names
    */
+  @deprecated("Use TermName instead", "2.10.1")
   def newTermName(s: String): TermName
 
   /** Creates a new type name.
    *  @group Names
    */
+  @deprecated("Use TypeName instead", "2.10.1")
   def newTypeName(s: String): TypeName
+
+  /** The constructor/extractor for `TermName` instances.
+   *  @group Extractors
+   */
+  val TermName: TermNameExtractor
+
+  /** An extractor class to create and pattern match with syntax `TermName(s)`.
+   *  @group Extractors
+   */
+  abstract class TermNameExtractor {
+    def apply(s: String): TermName
+    def unapply(name: TermName): Option[String]
+  }
+
+  /** The constructor/extractor for `TypeName` instances.
+   *  @group Extractors
+   */
+  val TypeName: TypeNameExtractor
+
+  /** An extractor class to create and pattern match with syntax `TypeName(s)`.
+   *  @group Extractors
+   */
+  abstract class TypeNameExtractor {
+    def apply(s: String): TypeName
+    def unapply(name: TypeName): Option[String]
+  }
 }

--- a/src/reflect/scala/reflect/api/Trees.scala
+++ b/src/reflect/scala/reflect/api/Trees.scala
@@ -2929,15 +2929,16 @@ trait Trees { self: Universe =>
   /** The constructor/extractor for `Modifiers` instances.
    *  @group Traversal
    */
-  val Modifiers: ModifiersCreator
+  val Modifiers: ModifiersExtractor
 
   /** An extractor class to create and pattern match with syntax `Modifiers(flags, privateWithin, annotations)`.
    *  Modifiers encapsulate flags, visibility annotations and Scala annotations for member definitions.
    *  @group Traversal
    */
-  abstract class ModifiersCreator {
+  abstract class ModifiersExtractor {
     def apply(): Modifiers = Modifiers(NoFlags, tpnme.EMPTY, List())
     def apply(flags: FlagSet, privateWithin: Name, annotations: List[Tree]): Modifiers
+    def unapply(mods: Modifiers): Option[(FlagSet, Name, List[Tree])]
   }
 
   /** The factory for `Modifiers` instances.

--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -510,6 +510,11 @@ trait Names extends api.Names with LowPriorityNames {
 
   implicit val TermNameTag = ClassTag[TermName](classOf[TermName])
 
+  object TermName extends TermNameExtractor {
+    def apply(s: String) = newTermName(s)
+    def unapply(name: TermName): Option[String] = Some(name.toString)
+  }
+
   sealed abstract class TypeName(index0: Int, len0: Int, hash: Int) extends Name(index0, len0) {
     type ThisNameType = TypeName
     protected[this] def thisName: TypeName = this
@@ -539,4 +544,9 @@ trait Names extends api.Names with LowPriorityNames {
   }
 
   implicit val TypeNameTag = ClassTag[TypeName](classOf[TypeName])
+
+  object TypeName extends TypeNameExtractor {
+    def apply(s: String) = newTypeName(s)
+    def unapply(name: TypeName): Option[String] = Some(name.toString)
+  }
 }

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -900,7 +900,7 @@ trait Trees extends api.Trees { self: SymbolTable =>
     override def toString = "Modifiers(%s, %s, %s)".format(flagString, annotations mkString ", ", positions)
   }
 
-  object Modifiers extends ModifiersCreator
+  object Modifiers extends ModifiersExtractor
 
   implicit val ModifiersTag = ClassTag[Modifiers](classOf[Modifiers])
 
@@ -1301,7 +1301,7 @@ trait Trees extends api.Trees { self: SymbolTable =>
 
   class ChangeOwnerTraverser(val oldowner: Symbol, val newowner: Symbol) extends Traverser {
     final def change(sym: Symbol) = {
-      if (sym != NoSymbol && sym.owner == oldowner) 
+      if (sym != NoSymbol && sym.owner == oldowner)
         sym.owner = newowner
     }
     override def traverse(tree: Tree) {

--- a/test/files/run/reflection-extractors-modifiers.scala
+++ b/test/files/run/reflection-extractors-modifiers.scala
@@ -1,0 +1,6 @@
+import scala.reflect.runtime.universe._
+
+object Test extends App {
+
+  Modifiers(Flag.IMPLICIT) match { case Modifiers(flag, _, _) => assert(flag == Flag.IMPLICIT) }
+}

--- a/test/files/run/reflection-extractors-names.scala
+++ b/test/files/run/reflection-extractors-names.scala
@@ -1,0 +1,8 @@
+import scala.reflect.runtime.universe._
+
+object Test extends App {
+
+  TermName("name") match { case TermName(name) => assert(name == "name") }
+
+  TypeName("name") match { case TypeName(name) => assert(name == "name") }
+}

--- a/test/files/scalacheck/ReflectionExtractors.scala
+++ b/test/files/scalacheck/ReflectionExtractors.scala
@@ -1,0 +1,38 @@
+import org.scalacheck._
+import Prop._
+import Gen._
+import Arbitrary._
+
+import scala.reflect.runtime.universe._
+import Flag._
+
+object Test extends Properties("reflection extractors") {
+
+  val genFlag = oneOf(
+    TRAIT, INTERFACE, MUTABLE, MACRO, DEFERRED, ABSTRACT, FINAL, SEALED,
+    IMPLICIT, LAZY, OVERRIDE, PRIVATE, PROTECTED, LOCAL, CASE, ABSOVERRIDE,
+    BYNAMEPARAM, PARAM, COVARIANT, CONTRAVARIANT, DEFAULTPARAM, PRESUPER,
+    DEFAULTINIT
+  )
+  val genModifiers = for(flag <- genFlag) yield Modifiers(flag)
+  val genTermName = for(name <- arbitrary[String]) yield TermName(name)
+  val genTypeName = for(name <- arbitrary[String]) yield TypeName(name)
+  implicit val arbTermName: Arbitrary[TermName] = Arbitrary(genTermName)
+  implicit val arbTypeName: Arbitrary[TypeName] = Arbitrary(genTypeName)
+  implicit val arbMods: Arbitrary[Modifiers] = Arbitrary(genModifiers)
+
+  property("extract termname") = forAll { (name: TermName) =>
+    val TermName(s) = name
+    s == name.toString
+  }
+
+  property("extract typename") = forAll { (name: TypeName) =>
+    val TypeName(s) = name
+    s == name.toString
+  }
+
+  property("extract modifiers") = forAll { (mods: Modifiers) =>
+    val Modifiers(flags, _, _) = mods
+    flags == mods.flags
+  }
+}


### PR DESCRIPTION
This change allows to pattern match over type names, term names and
modifiers. Otherwise it can be quite painful to match over complex trees
as each name or modifiers requires a guard.

This pull request also changes the name of default constructor for term
and type names i.e. TypeName(s) instead of newTermName(s). This is
shorter to type, more consistent with the rest of reflection api and
consistent with the way it will be pattern matched later on.
