### PR TITLE
SI-6555 Better parameter name retention

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -965,6 +965,11 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
         case (NoSymbol, _)     => None
         case (overridden, env) =>
           val om = specializedOverload(clazz, overridden, env)
+          foreachWithIndex(om.paramss) { (params, i) =>
+            foreachWithIndex(params) { (param, j) =>
+              param.name = overriding.paramss(i)(j).name // SI-6555 Retain the parameter names from the subclass.
+            }
+          }
           debuglog("specialized overload %s for %s in %s: %s".format(om, overriding.name.decode, pp(env), om.info))
           typeEnv(om) = env
           addConcreteSpecMethod(overriding)

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -251,7 +251,10 @@ abstract class UnCurry extends InfoTransform
 
           val applyMethodDef = {
             val methSym = anonClass.newMethod(nme.apply, fun.pos, FINAL)
-            methSym setInfoAndEnter MethodType(methSym newSyntheticValueParams formals, restpe)
+            val paramSyms = map2(formals, fun.vparams) {
+              (tp, param) => methSym.newSyntheticValueParam(tp, param.name)
+            }
+            methSym setInfoAndEnter MethodType(paramSyms, restpe)
 
             fun.vparams foreach  (_.symbol.owner =  methSym)
             fun.body changeOwner (fun.symbol     -> methSym)

--- a/test/files/neg/t6260.check
+++ b/test/files/neg/t6260.check
@@ -1,10 +1,10 @@
-t6260.scala:3: error: bridge generated for member method apply: (x$1: Box[X])Box[Y] in anonymous class $anonfun
+t6260.scala:3: error: bridge generated for member method apply: (bx: Box[X])Box[Y] in anonymous class $anonfun
 which overrides method apply: (v1: T1)R in trait Function1
 clashes with definition of the member itself;
 both have erased type (v1: Object)Object
     ((bx: Box[X]) => new Box(f(bx.x)))(this)
                   ^
-t6260.scala:8: error: bridge generated for member method apply: (x$1: Box[X])Box[Y] in anonymous class $anonfun
+t6260.scala:8: error: bridge generated for member method apply: (bx: Box[X])Box[Y] in anonymous class $anonfun
 which overrides method apply: (v1: T1)R in trait Function1
 clashes with definition of the member itself;
 both have erased type (v1: Object)Object

--- a/test/files/run/t6555.check
+++ b/test/files/run/t6555.check
@@ -1,0 +1,22 @@
+[[syntax trees at end of                specialize]] // newSource1
+package <empty> {
+  class Foo extends Object {
+    def <init>(): Foo = {
+      Foo.super.<init>();
+      ()
+    };
+    private[this] val f: Int => Int = {
+      @SerialVersionUID(0) final <synthetic> class $anonfun extends scala.runtime.AbstractFunction1$mcII$sp with Serializable {
+        def <init>(): anonymous class $anonfun = {
+          $anonfun.super.<init>();
+          ()
+        };
+        final def apply(param: Int): Int = $anonfun.this.apply$mcII$sp(param);
+        <specialized> def apply$mcII$sp(param: Int): Int = param
+      };
+      (new anonymous class $anonfun(): Int => Int)
+    };
+    <stable> <accessor> def f(): Int => Int = Foo.this.f
+  }
+}
+

--- a/test/files/run/t6555.scala
+++ b/test/files/run/t6555.scala
@@ -1,0 +1,15 @@
+import scala.tools.partest._
+import java.io.{Console => _, _}
+
+object Test extends DirectTest {
+
+  override def extraSettings: String = "-usejavacp -Xprint:specialize -d " + testOutput.path
+
+  override def code = "class Foo { val f = (param: Int) => param } "
+
+  override def show(): Unit = {
+    Console.withErr(System.out) {
+      compile()
+    }
+  }
+}


### PR DESCRIPTION
We were losing track of parameter names in two places:
1. Uncurry was using fresh names for the apply method
    parameters during Function expansion. (The parameter names
    in the tree were actually correct, they just had synthetic
    symbols with "x$1" etc.)
2. When adding specialized overrides, the parameter names
    of the overriden method were used, rather than the parameter
    names from the overriding method in the class to which we are
    adding methods.

The upshot of this is that when you're stopped in the debugger in
the body of, say, `(i: Int) => i * i`, you see `v1` rather than `i`.

This commit changes Uncurry and SpecializeTypes to remedy this.

Review by @dragos
