### PR TITLE
SI-5017 Poor performance of :+ operator on Arrays

### DIFF
--- a/src/library/scala/collection/mutable/ArrayOps.scala
+++ b/src/library/scala/collection/mutable/ArrayOps.scala
@@ -52,6 +52,20 @@ trait ArrayOps[T] extends Any with ArrayLike[T, Array[T]] with CustomParalleliza
       super.toArray[U]
   }
 
+  def :+[B >: T: scala.reflect.ClassTag](elem: B): Array[B] = {
+    val result = Array.ofDim[B](repr.length + 1)
+    Array.copy(repr, 0, result, 0, repr.length)
+    result(repr.length) = elem
+    result
+  }
+
+  def +:[B >: T: scala.reflect.ClassTag](elem: B): Array[B] = {
+    val result = Array.ofDim[B](repr.length + 1)
+    result(0) = elem
+    Array.copy(repr, 0, result, 1, repr.length)
+    result
+  }
+
   override def par = ParArray.handoff(repr)
 
   /** Flattens a two-dimensional array by concatenating all its rows

--- a/test/files/run/array-addition.check
+++ b/test/files/run/array-addition.check
@@ -1,0 +1,4 @@
+Array(1, 2, 3, 4)
+Array(1, 2, 3, 4)
+Array(1)
+Array(1)

--- a/test/files/run/array-addition.scala
+++ b/test/files/run/array-addition.scala
@@ -1,0 +1,11 @@
+object Test {
+  def prettyPrintArray(x: Array[_]) = println("Array(" + x.mkString(", ") + ")")
+
+  def main(args: Array[String]): Unit = {
+    prettyPrintArray(Array(1,2,3) :+ 4)
+    prettyPrintArray(1 +: Array(2,3,4))
+    prettyPrintArray(Array() :+ 1)
+    prettyPrintArray(1 +: Array())
+  }
+}
+


### PR DESCRIPTION
Control performance of :+ and +: operator on my machine were 700-800 ms

After adding size hint on the implementation in SeqLike, it went down to 500-600 ms

But with specialixed implementation in ArrayOps, brings it down to 300-400 ms

Unfortunatly, this method will only be called when the Array object is being referenced directly as it's type, but that should be the case enough times to justify the extra method.

I ended up removing the sizeHint in SeqLike because it made the execution of the "benchmark" slower when the Array was being manipulated as a Seq.

Side note: Interestingly enough, the benchmark performed better on my virtualized Fedora 17 with JDK 7 than natively on Mac OS X with JDK 6

Review by @axel22
