### PR TITLE
s/SuperCallArgs/SuperArgs/

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/StdAttachments.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/StdAttachments.scala
@@ -19,16 +19,16 @@ trait StdAttachments {
    *  by `parentTypes`. This attachment coordinates `parentTypes` and `typedTemplate` and
    *  allows them to complete the synthesis.
    */
-  case class SuperCallArgsAttachment(argss: List[List[Tree]])
+  case class SuperArgsAttachment(argss: List[List[Tree]])
 
-  /** Convenience method for `SuperCallArgsAttachment`.
+  /** Convenience method for `SuperArgsAttachment`.
    *  Compared with `MacroRuntimeAttachment` this attachment has different a usage pattern,
    *  so it really benefits from a dedicated extractor.
    */
-  def superCallArgs(tree: Tree): Option[List[List[Tree]]] =
-    tree.attachments.get[SuperCallArgsAttachment] collect { case SuperCallArgsAttachment(argss) => argss }
+  def superArgs(tree: Tree): Option[List[List[Tree]]] =
+    tree.attachments.get[SuperArgsAttachment] collect { case SuperArgsAttachment(argss) => argss }
 
-  /** Determines whether the given tree has an associated SuperCallArgsAttachment.
+  /** Determines whether the given tree has an associated SuperArgsAttachment.
    */
-  def hasSuperArgs(tree: Tree): Boolean = superCallArgs(tree).nonEmpty
+  def hasSuperArgs(tree: Tree): Boolean = superArgs(tree).nonEmpty
 }

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1511,7 +1511,7 @@ trait Typers extends Modes with Adaptations with Tags {
      *
      *  Returns a `TypeTree` representing a resolved parent type.
      *  If the typechecked parent reference implies non-nullary and non-empty argument list,
-     *  this argument list is attached to the returned value in SuperCallArgsAttachment.
+     *  this argument list is attached to the returned value in SuperArgsAttachment.
      *  The attachment is necessary for the subsequent typecheck to fixup a super constructor call
      *  in the body of the primary constructor (see `typedTemplate` for details).
      *
@@ -1577,7 +1577,7 @@ trait Typers extends Modes with Adaptations with Tags {
         // this is the place where we tell the typer what argss should be used for the super call
         // if argss are nullary or empty, then (see the docs for `typedPrimaryConstrBody`)
         // the super call dummy is already good enough, so we don't need to do anything
-        if (argssAreTrivial) supertpt else supertpt updateAttachment SuperCallArgsAttachment(argss)
+        if (argssAreTrivial) supertpt else supertpt updateAttachment SuperArgsAttachment(argss)
       }
     }
 
@@ -1977,7 +1977,7 @@ trait Typers extends Modes with Adaptations with Tags {
         val primaryCtor = treeInfo.firstConstructor(body)
         val primaryCtor1 = primaryCtor match {
           case DefDef(_, _, _, _, _, Block(earlyVals :+ global.pendingSuperCall, unit)) =>
-            val argss = superCallArgs(parents1.head) getOrElse Nil
+            val argss = superArgs(parents1.head) getOrElse Nil
             val pos = wrappingPos(parents1.head.pos, argss.flatten)
             val superCall = atPos(pos)(PrimarySuperCall(argss))
             deriveDefDef(primaryCtor)(block => Block(earlyVals :+ superCall, unit) setPos pos) setPos pos


### PR DESCRIPTION
Applies a minor renaming that I failed to thoroughly perform
in the last pull request which refactored parent types.
