### PR TITLE
SI-6484 adds Universe.typeOf[T](x: T)

### DIFF
--- a/src/reflect/scala/reflect/api/TypeTags.scala
+++ b/src/reflect/scala/reflect/api/TypeTags.scala
@@ -363,10 +363,22 @@ trait TypeTags { self: Universe =>
   def weakTypeOf[T](implicit attag: WeakTypeTag[T]): Type = attag.tpe
 
   /**
+   * Type of `x` as derived from a weak type tag.
+   * @group TypeTags
+   */
+  def weakTypeOf[T: WeakTypeTag](x: T): Type = weakTypeOf[T]
+
+  /**
    * Shortcut for `implicitly[TypeTag[T]].tpe`
    * @group TypeTags
    */
   def typeOf[T](implicit ttag: TypeTag[T]): Type = ttag.tpe
+
+  /**
+   * Type of `x` as derived from a type tag.
+   * @group TypeTags
+   */
+  def typeOf[T: TypeTag](x: T): Type = typeOf[T]
 }
 
 private[scala] class SerializedTypeTag(var tpec: TypeCreator, var concrete: Boolean) extends Serializable {

--- a/src/reflect/scala/reflect/macros/Aliases.scala
+++ b/src/reflect/scala/reflect/macros/Aliases.scala
@@ -106,7 +106,17 @@ trait Aliases {
   def weakTypeOf[T](implicit attag: WeakTypeTag[T]): Type = attag.tpe
 
   /**
+   * Type of `x` as derived from a weak type tag.
+   */
+  def weakTypeOf[T: WeakTypeTag](x: T): Type = weakTypeOf[T]
+
+  /**
    * Shortcut for `implicitly[TypeTag[T]].tpe`
    */
   def typeOf[T](implicit ttag: TypeTag[T]): Type = ttag.tpe
+
+  /**
+   * Type of `x` as derived from a type tag.
+   */
+  def typeOf[T: TypeTag](x: T): Type = typeOf[T]
 }

--- a/test/files/run/typetags_typeof_x.check
+++ b/test/files/run/typetags_typeof_x.check
@@ -1,0 +1,5 @@
+List[T]
+C
+Int
+List[Any]
+java.lang.Object{def x: Int}

--- a/test/files/run/typetags_typeof_x.scala
+++ b/test/files/run/typetags_typeof_x.scala
@@ -1,0 +1,11 @@
+import scala.reflect.runtime.universe._
+
+object Test extends App {
+  def foo[T](x: T) = weakTypeOf(List(x))
+  println(foo(2))
+  locally { class C; println(weakTypeOf(new C)) }
+
+  println(typeOf(2))
+  println(typeOf(List(1, "1")))
+  println(typeOf(new { def x = 2 }))
+}


### PR DESCRIPTION
This is a nice addition to Universe.typeOf[T], quite frequently useful
for inspecting ad-hoc types.
