### PR TITLE
prevents spurious kind bound errors

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1008,12 +1008,18 @@ trait Infer extends Checkable {
       //@M TODO: better place to check this?
       //@M TODO: errors for getters & setters are reported separately
       val kindErrors = checkKindBounds(tparams, targs, pre, owner)
+      def alreadyHasErrors = (targs exists (_.isErroneous)) || (tparams exists (_.isErroneous))
 
       if(!kindErrors.isEmpty) {
         if (targs contains WildcardType) true
-        else { KindBoundErrors(tree, prefix, targs, tparams, kindErrors); false }
+        else {
+          if (!alreadyHasErrors) {
+            KindBoundErrors(tree, prefix, targs, tparams, kindErrors)
+            false
+          } else true
+        }
       } else if (!isWithinBounds(pre, owner, tparams, targs)) {
-        if (!(targs exists (_.isErroneous)) && !(tparams exists (_.isErroneous))) {
+        if (!alreadyHasErrors) {
           NotWithinBounds(tree, prefix, targs, tparams, kindErrors)
           false
         } else true

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1003,28 +1003,22 @@ trait Infer extends Checkable {
 */
     /** error if arguments not within bounds. */
     def checkBounds(tree: Tree, pre: Type, owner: Symbol,
-                    tparams: List[Symbol], targs: List[Type], prefix: String): Boolean = {
-      //@M validate variances & bounds of targs wrt variances & bounds of tparams
-      //@M TODO: better place to check this?
-      //@M TODO: errors for getters & setters are reported separately
-      val kindErrors = checkKindBounds(tparams, targs, pre, owner)
-      def alreadyHasErrors = (targs exists (_.isErroneous)) || (tparams exists (_.isErroneous))
-
-      if(!kindErrors.isEmpty) {
-        if (targs contains WildcardType) true
-        else {
-          if (!alreadyHasErrors) {
-            KindBoundErrors(tree, prefix, targs, tparams, kindErrors)
-            false
-          } else true
+                    tparams: List[Symbol], targs: List[Type], prefix: String): Boolean =
+      if ((targs exists (_.isErroneous)) || (tparams exists (_.isErroneous))) true
+      else {
+        //@M validate variances & bounds of targs wrt variances & bounds of tparams
+        //@M TODO: better place to check this?
+        //@M TODO: errors for getters & setters are reported separately
+        val kindErrors = checkKindBounds(tparams, targs, pre, owner)
+        kindErrors match {
+          case Nil =>
+            def notWithinBounds() = NotWithinBounds(tree, prefix, targs, tparams, Nil)
+            isWithinBounds(pre, owner, tparams, targs) || {notWithinBounds(); false}
+          case errors =>
+            def kindBoundErrors() = KindBoundErrors(tree, prefix, targs, tparams, errors)
+            (targs contains WildcardType) || {kindBoundErrors(); false}
         }
-      } else if (!isWithinBounds(pre, owner, tparams, targs)) {
-        if (!alreadyHasErrors) {
-          NotWithinBounds(tree, prefix, targs, tparams, kindErrors)
-          false
-        } else true
-      } else true
-    }
+      }
 
     def checkKindBounds(tparams: List[Symbol], targs: List[Type], pre: Type, owner: Symbol): List[String] = {
       checkKindBounds0(tparams, targs, pre, owner, true) map {

--- a/test/files/neg/t4044.check
+++ b/test/files/neg/t4044.check
@@ -1,11 +1,6 @@
 t4044.scala:9: error: AnyRef takes no type parameters, expected: one
   M[AnyRef] // error, (AnyRef :: *) not kind-conformant to (N :: * -> * -> *)
     ^
-t4044.scala:9: error: kinds of the type arguments (<error>) do not conform to the expected kinds of the type parameters (type N).
-<error>'s type parameters do not match type N's expected parameters:
-<none> has no type parameters, but type N has one
-  M[AnyRef] // error, (AnyRef :: *) not kind-conformant to (N :: * -> * -> *)
-   ^
 t4044.scala:11: error: kinds of the type arguments (Test.A) do not conform to the expected kinds of the type parameters (type N).
 Test.A's type parameters do not match type N's expected parameters:
 type _ has no type parameters, but type O has one
@@ -16,4 +11,4 @@ Test.C's type parameters do not match type N's expected parameters:
 type _ has one type parameter, but type _ has none
   M[C] // error, (C :: (* -> * -> * -> *) not kind-conformant to (N :: * -> * -> *)
    ^
-four errors found
+three errors found


### PR DESCRIPTION
The patch adds a check which makes sure that the trees we're about to
report aren't already erroneous.
