### PR TITLE
Fix for SI-5717, crash in GenASM.

### DIFF
--- a/test/files/run/t5717.scala
+++ b/test/files/run/t5717.scala
@@ -1,0 +1,16 @@
+import scala.tools.partest._
+import java.io.File
+
+object Test extends StoreReporterDirectTest {
+  def code = ???
+
+  def compileCode(code: String) = {
+    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
+    compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(code)
+  }
+  def show(): Unit = {
+    // Don't crash when we find a file 'a' where package 'a' should go.
+    scala.reflect.io.File(testOutput.path + "/a").writeAll("a")
+    compileCode("package a { class B }")
+  }
+}


### PR DESCRIPTION
If there is a file in the way when generating classfiles,
remove it and proceed. If you had wanted to keep it, you
wouldn't have left it lying around in an output directory
with a name which stands between you and the filesystem.

This is too difficult to write a test for under partest.
