### PR TITLE
Fixes SI-6758: force LazyAnnnotationInfo for DefDef and TypeDef

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1929,8 +1929,7 @@ trait Typers extends Modes with Adaptations with Tags {
      */
     def typedTemplate(templ: Template, parents1: List[Tree]): Template = {
       val clazz = context.owner
-      // complete lazy annotations
-      val annots = clazz.annotations
+      clazz.annotations.map(_.completeInfo)
       if (templ.symbol == NoSymbol)
         templ setSymbol clazz.newLocalDummy(templ.pos)
       val self1 = templ.self match {
@@ -2025,8 +2024,7 @@ trait Typers extends Modes with Adaptations with Tags {
       val typer1 = constrTyperIf(sym.isParameter && sym.owner.isConstructor)
       val typedMods = typedModifiers(vdef.mods)
 
-      // complete lazy annotations
-      val annots = sym.annotations
+      sym.annotations.map(_.completeInfo)
       var tpt1 = checkNoEscaping.privates(sym, typer1.typedType(vdef.tpt))
       checkNonCyclic(vdef, tpt1)
 
@@ -2269,8 +2267,7 @@ trait Typers extends Modes with Adaptations with Tags {
       val tparams1 = ddef.tparams mapConserve typedTypeDef
       val vparamss1 = ddef.vparamss mapConserve (_ mapConserve typedValDef)
 
-      // complete lazy annotations
-      val annots = meth.annotations
+      meth.annotations.map(_.completeInfo)
 
       for (vparams1 <- vparamss1; vparam1 <- vparams1 dropRight 1)
         if (isRepeatedParamType(vparam1.symbol.tpe))
@@ -2345,8 +2342,7 @@ trait Typers extends Modes with Adaptations with Tags {
       reenterTypeParams(tdef.tparams)
       val tparams1 = tdef.tparams mapConserve typedTypeDef
       val typedMods = typedModifiers(tdef.mods)
-      // complete lazy annotations
-      val annots = tdef.symbol.annotations
+      tdef.symbol.annotations.map(_.completeInfo)
 
       // @specialized should not be pickled when compiling with -no-specialize
       if (settings.nospecialization.value && currentRun.compiles(tdef.symbol)) {
@@ -5253,8 +5249,6 @@ trait Typers extends Modes with Adaptations with Tags {
       def typedPackageDef(pdef: PackageDef) = {
         val pid1 = typedQualifier(pdef.pid).asInstanceOf[RefTree]
         assert(sym.moduleClass ne NoSymbol, sym)
-        // complete lazy annotations
-        val annots = sym.annotations
         val stats1 = newTyper(context.make(tree, sym.moduleClass, sym.info.decls))
           .typedStats(pdef.stats, NoSymbol)
         treeCopy.PackageDef(tree, pid1, stats1) setType NoType

--- a/src/reflect/scala/reflect/internal/AnnotationInfos.scala
+++ b/src/reflect/scala/reflect/internal/AnnotationInfos.scala
@@ -201,6 +201,8 @@ trait AnnotationInfos extends api.Annotations { self: SymbolTable =>
     override def toString = if (forced) forcedInfo.toString else "@<?>"
 
     override def pos: Position = if (forced) forcedInfo.pos else NoPosition
+
+    override def completeInfo(): Unit = forcedInfo
   }
 
   /** Typed information about an annotation. It can be attached to either
@@ -241,6 +243,9 @@ trait AnnotationInfos extends api.Annotations { self: SymbolTable =>
       rawpos = pos
       this
     }
+
+    // Forces LazyAnnotationInfo, no op otherwise
+    def completeInfo(): Unit = ()
 
     /** Annotations annotating annotations are confusing so I drew
      *  an example.  Given the following code:

--- a/test/files/neg/t3222.check
+++ b/test/files/neg/t3222.check
@@ -1,7 +1,13 @@
-t3222.scala:4: error: not found: type D
-  def foo(@throws(classOf[D]) x: Int) {}
-                          ^
 t3222.scala:1: error: not found: type B
 @throws(classOf[B])
                 ^
-two errors found
+t3222.scala:4: error: not found: type D
+  def foo(@throws(classOf[D]) x: Int) {}
+                          ^
+t3222.scala:3: error: not found: type C
+  @throws(classOf[C])
+                  ^
+t3222.scala:6: error: not found: type E
+  @throws(classOf[E])
+                  ^
+four errors found

--- a/test/files/neg/t6558.check
+++ b/test/files/neg/t6558.check
@@ -1,10 +1,10 @@
-t6558.scala:19: error: not found: type classs
+t6558.scala:4: error: not found: type classs
   @classs
    ^
-t6558.scala:22: error: not found: type typeparam
+t6558.scala:7: error: not found: type typeparam
   class D[@typeparam T]
            ^
-t6558.scala:25: error: not found: type valueparam
+t6558.scala:10: error: not found: type valueparam
   	@valueparam x: Any
          ^
 three errors found

--- a/test/files/neg/t6558.scala
+++ b/test/files/neg/t6558.scala
@@ -1,21 +1,6 @@
 class AnnotNotFound {
   def foo(a: Any) = ()
 
-  foo {
-    // Not yet issued in the context of this file, see SI-6758
-    // This error is issued in t6558b.scala
-    @inargument
-    def foo = 0
-    foo
-  }
-
-  () => {
-    // As per above
-    @infunction
-    def foo = 0
-    ()
-  }
-
   @classs
   class C
 

--- a/test/files/neg/t6758.check
+++ b/test/files/neg/t6758.check
@@ -1,0 +1,28 @@
+t6758.scala:5: error: not found: type inargument
+    @inargument
+     ^
+t6758.scala:11: error: not found: type infunction
+    @infunction
+     ^
+t6758.scala:18: error: not found: type nested
+      @nested
+       ^
+t6758.scala:25: error: not found: type param
+  def func(@param x: Int): Int = 0
+            ^
+t6758.scala:28: error: not found: type typealias
+    @typealias
+     ^
+t6758.scala:32: error: not found: type classs
+  @classs
+   ^
+t6758.scala:35: error: not found: type module
+  @module
+   ^
+t6758.scala:38: error: not found: type typeparam
+  class D[@typeparam T]
+           ^
+t6758.scala:41: error: not found: type valueparam
+    @valueparam x: Any
+     ^
+9 errors found

--- a/test/files/neg/t6758.scala
+++ b/test/files/neg/t6758.scala
@@ -1,0 +1,43 @@
+class AnnotNotFound {
+  def foo(a: Any) = ()
+
+  foo {
+    @inargument
+    def foo = 0
+    foo
+  }
+
+  () => {
+    @infunction
+    def foo = 0
+    ()
+  }
+
+  () => {
+    val bar: Int = {
+      @nested
+      val bar2: Int = 2
+      2
+    }
+    ()
+  }
+
+  def func(@param x: Int): Int = 0
+
+  abstract class A {
+    @typealias
+    type B = Int
+  }
+
+  @classs
+  class C
+
+  @module
+  object D
+
+  class D[@typeparam T]
+
+  class E(
+    @valueparam x: Any
+  )
+}


### PR DESCRIPTION
Looks like the change in 25ecde037f22ff no longer forced
lazy annotations for some of the cases.
Also removed forcing for PackageDef annotations as we currently
don't support them.

Review by @lrytz
