### PR TITLE
Fix for SI-6595, lost modifiers in early defs.

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/Trees.scala
+++ b/src/compiler/scala/tools/nsc/ast/Trees.scala
@@ -104,7 +104,7 @@ trait Trees extends scala.reflect.internal.Trees { self: Global =>
         rhs = EmptyTree
       )
     }
-    val lvdefs = evdefs collect { case vdef: ValDef => copyValDef(vdef)(mods = Modifiers(PRESUPER)) }
+    val lvdefs = evdefs collect { case vdef: ValDef => copyValDef(vdef)(mods = vdef.mods | PRESUPER) }
 
     val constrs = {
       if (constrMods hasFlag TRAIT) {

--- a/test/files/pos/t6595.flags
+++ b/test/files/pos/t6595.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t6595.scala
+++ b/test/files/pos/t6595.scala
@@ -1,0 +1,18 @@
+import scala.annotation.switch
+
+class Foo extends {
+  final val b0 = 5
+} with AnyRef {
+  final val b1 = 10
+
+  // Using the @switch annotation as a means of testing that the
+  // type inferred for b0 is Int(5) and not Int. Only in the former
+  // case can a switch be generated.
+  def f(p: Int) = (p: @switch) match {
+    case `b0` => 1
+    case `b1` => 2
+    case 15   => 3
+    case 20   => 4
+    case _    => 5
+  }
+}


### PR DESCRIPTION
Saw this by accident; the trees created for early defs would
wholesale replace the modifiers with PRESUPER rather than
combining them. FINAL was lost that way, as would be any other
modifiers which might be valid there.
