### PR TITLE
SI-6188 ICodeReader notes exception handlers, Inliner takes them into account

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/icode/Members.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/Members.scala
@@ -154,6 +154,7 @@ trait Members { self: ICodes =>
     var returnType: TypeKind = _
 
     var recursive: Boolean = false
+    var bytecodeHasEHs = false // set by ICodeReader only, used by Inliner to prevent inlining (SI-6188)
 
     /** local variables and method parameters */
     var locals: List[Local] = Nil

--- a/src/compiler/scala/tools/nsc/backend/opt/Inliners.scala
+++ b/src/compiler/scala/tools/nsc/backend/opt/Inliners.scala
@@ -161,6 +161,12 @@ abstract class Inliners extends SubComponent {
               val inc   = new IMethodInfo(callee)
               val pair  = new CallerCalleeInfo(caller, inc)
 
+              if(inc.hasHandlers && (info.stack == -1)) {
+                // no inlining is done, yet don't warn about it, info.stack == -1 indicates we're trying to inlineWithoutTFA.
+                // Shortly, a TFA will be computed and an error message reported if indeed inlining not possible.
+                return false
+              }
+
               if (pair isStampedForInlining info.stack) {
                 retry = true
                 inlined = true
@@ -311,7 +317,7 @@ abstract class Inliners extends SubComponent {
       def isRecursive   = m.recursive
       def hasCode       = m.code != null
       def hasSourceFile = m.sourceFile != null
-      def hasHandlers   = handlers.nonEmpty
+      def hasHandlers   = handlers.nonEmpty || m.bytecodeHasEHs
 
       // the number of inlined calls in 'm', used by 'shouldInline'
       var inlinedCalls = 0

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
@@ -618,6 +618,7 @@ abstract class ICodeReader extends ClassfileParser {
     while (pc < codeLength) parseInstruction
 
     val exceptionEntries = in.nextChar.toInt
+    code.containsEHs = (exceptionEntries != 0)
     var i = 0
     while (i < exceptionEntries) {
       // skip start end PC
@@ -669,6 +670,7 @@ abstract class ICodeReader extends ClassfileParser {
 
     var containsDUPX = false
     var containsNEW  = false
+    var containsEHs  = false
 
     def emit(i: Instruction) {
       instrs += ((pc, i))
@@ -686,6 +688,7 @@ abstract class ICodeReader extends ClassfileParser {
 
       val code = new Code(method)
       method.setCode(code)
+      method.bytecodeHasEHs = containsEHs
       var bb = code.startBlock
 
       def makeBasicBlocks: mutable.Map[Int, BasicBlock] =

--- a/test/files/run/t6188.check
+++ b/test/files/run/t6188.check
@@ -1,0 +1,2 @@
+enter Test.map
+OK

--- a/test/files/run/t6188.flags
+++ b/test/files/run/t6188.flags
@@ -1,0 +1,1 @@
+ -optimize 

--- a/test/files/run/t6188.scala
+++ b/test/files/run/t6188.scala
@@ -1,0 +1,22 @@
+// SI-6188 Optimizer incorrectly removes method invocations containing throw expressions
+
+case class Test[T](x: T) {
+  def map[S](f: T => S): Test[S] = {
+    println("enter Test.map")
+    Test(f(x))
+  }
+}
+
+object Test {
+ def main(args: Array[String]) {
+   val e = new Exception("this is an exception")
+   try {
+     val res = Test(1).map[Int](x => throw e)
+     println(res)
+   } catch {
+     case e: Exception =>
+       println("OK")
+   }
+ }
+}
+


### PR DESCRIPTION
Backport of bugfix of SI-6188 (part of #1059) to 2.9.x.

Note: this backport is required for the backport of SIP-14 (futures) to 2.9.x (#1745).

Review by @magarciaEPFL
