### PR TITLE
SI-6188 backport (ICodeReader wrongly ignored exception handlers)

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/icode/Members.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/Members.scala
@@ -154,6 +154,7 @@ trait Members { self: ICodes =>
     var returnType: TypeKind = _
 
     var recursive: Boolean = false
+    var bytecodeHasEHs = false // set by ICodeReader only, used by Inliner to prevent inlining (SI-6188)
 
     /** local variables and method parameters */
     var locals: List[Local] = Nil

--- a/src/compiler/scala/tools/nsc/backend/opt/Inliners.scala
+++ b/src/compiler/scala/tools/nsc/backend/opt/Inliners.scala
@@ -311,7 +311,7 @@ abstract class Inliners extends SubComponent {
       def isRecursive   = m.recursive
       def hasCode       = m.code != null
       def hasSourceFile = m.sourceFile != null
-      def hasHandlers   = handlers.nonEmpty
+      def hasHandlers   = handlers.nonEmpty || m.bytecodeHasEHs
 
       // the number of inlined calls in 'm', used by 'shouldInline'
       var inlinedCalls = 0
@@ -495,7 +495,7 @@ abstract class Inliners extends SubComponent {
       }
 
       def isStampedForInlining(stack: TypeStack) =
-        !sameSymbols && inc.hasCode && shouldInline && isSafeToInline(stack)
+        !sameSymbols && inc.hasCode && !inc.m.bytecodeHasEHs && shouldInline && isSafeToInline(stack)
 
       def logFailure(stack: TypeStack) = log(
         """|inline failed for %s:

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
@@ -618,6 +618,7 @@ abstract class ICodeReader extends ClassfileParser {
     while (pc < codeLength) parseInstruction
 
     val exceptionEntries = in.nextChar.toInt
+    code.containsEHs = (exceptionEntries != 0)
     var i = 0
     while (i < exceptionEntries) {
       // skip start end PC
@@ -669,6 +670,7 @@ abstract class ICodeReader extends ClassfileParser {
 
     var containsDUPX = false
     var containsNEW  = false
+    var containsEHs  = false
 
     def emit(i: Instruction) {
       instrs += ((pc, i))
@@ -686,6 +688,7 @@ abstract class ICodeReader extends ClassfileParser {
 
       val code = new Code(method)
       method.setCode(code)
+      method.bytecodeHasEHs = containsEHs
       var bb = code.startBlock
 
       def makeBasicBlocks: mutable.Map[Int, BasicBlock] =


### PR DESCRIPTION
A backport of https://github.com/scala/scala/commit/61cc8ff61c81a1276a921ad5288ee3bebea1c96e

The original fix (above) includes a test case that relies on scala.util.Success which as of this writing isn't there in 2.9.x. The test case requires a previously compiled classfile (where bytecode for an @inline method with exception handlers can be found). Ticket SI-6188 contains a self-contained example (not dependent on scala.util.Success) with _1 and _2 .scala files . Alternatively that test case could be used instead.

The backported fix (this commit) is safe in the sense that it prevents methods read by ICodeReader containing exception handlers from being inlined, even if marked @inline. Alternatively, the same effect can be achieved by annotating a method as @noinline.

review by @phaller 

this PR supercedes https://github.com/scala/scala/pull/1750
