### PR TITLE
SI-6799 Adds option to trace when a symbol from a list of ids is created...

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/AbsScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/AbsScalaSettings.scala
@@ -14,6 +14,7 @@ trait AbsScalaSettings {
   type BooleanSetting     <: Setting { type T = Boolean }
   type ChoiceSetting      <: Setting { type T = String }
   type IntSetting         <: Setting { type T = Int }
+  type MultiIntSetting    <: Setting { type T = List[Int] }
   type MultiStringSetting <: Setting { type T = List[String] }
   type PathSetting        <: Setting { type T = String }
   type PhasesSetting      <: Setting { type T = List[String] }
@@ -26,6 +27,7 @@ trait AbsScalaSettings {
   def BooleanSetting(name: String, descr: String): BooleanSetting
   def ChoiceSetting(name: String, helpArg: String, descr: String, choices: List[String], default: String): ChoiceSetting
   def IntSetting(name: String, descr: String, default: Int, range: Option[(Int, Int)], parser: String => Option[Int]): IntSetting
+  def MultiIntSetting(name: String, helpArg: String, descr: String): MultiIntSetting
   def MultiStringSetting(name: String, helpArg: String, descr: String): MultiStringSetting
   def OutputSetting(outputDirs: OutputDirs, default: String): OutputSetting
   def PathSetting(name: String, descr: String, default: String): PathSetting

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -194,6 +194,7 @@ trait ScalaSettings extends AbsScalaSettings
   val Yposdebug               = BooleanSetting("-Ypos-debug", "Trace position validation.")
   val Yreifydebug             = BooleanSetting("-Yreify-debug", "Trace reification.")
   val Yrepldebug              = BooleanSetting("-Yrepl-debug", "Trace all repl activity.") andThen (interpreter.replProps.debug setValue _)
+  val Ytraceidsdebug          = MultiIntSetting("-Ytraceids-debug", "id(s)", "Print a stack trace at the creation point of identifiers with the given unique id(s) (see also -uniqid)")
   val Ytyperdebug             = BooleanSetting("-Ytyper-debug", "Trace all type assignments.")
   val Ypatmatdebug            = BooleanSetting("-Ypatmat-debug", "Trace pattern matching translation.")
 

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -139,7 +139,11 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     rawatt = initPos
 
     val id = nextId() // identity displayed when -uniqid
-    //assert(id != 3390, initName)
+    // dump a stack trace if this id is being traced
+    if (settings.Ytraceidsdebug.value.contains(id)) {
+      println(s"Created symbol ${initName }#${id} with initial owner ${initOwner} and position ${initPos}")
+      java.lang.Thread.dumpStack();
+    }
 
     private[this] var _validTo: Period = NoPeriod
 

--- a/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
+++ b/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
@@ -14,6 +14,7 @@ abstract class MutableSettings extends AbsSettings {
   type Setting <: SettingValue
   type BooleanSetting <: Setting { type T = Boolean }
   type IntSetting <: Setting { type T = Int }
+  type MultiIntSetting <: Setting { type T = List[Int] }
   type MultiStringSetting <: Setting { type T = List[String] }
 
   // basically this is a value which remembers if it's been modified
@@ -39,6 +40,7 @@ abstract class MutableSettings extends AbsSettings {
   def explaintypes: BooleanSetting
   def verbose: BooleanSetting
   def uniqid: BooleanSetting
+  def Ytraceidsdebug: MultiIntSetting
   def Yshowsymkinds: BooleanSetting
   def Xprintpos: BooleanSetting
   def Yrecursion: IntSetting

--- a/src/reflect/scala/reflect/runtime/Settings.scala
+++ b/src/reflect/scala/reflect/runtime/Settings.scala
@@ -23,6 +23,12 @@ private[reflect] class Settings extends MutableSettings {
     override def value: Int = v
   }
 
+  class MultiIntSetting(xs: List[Int]) extends Setting {
+    type T = List[Int]
+    protected var v: List[Int] = xs
+    override def value: List[Int] = v
+  }
+
   class MultiStringSetting(xs: List[String]) extends Setting {
     type T = List[String]
     protected var v: List[String] = xs
@@ -42,6 +48,7 @@ private[reflect] class Settings extends MutableSettings {
   val overrideObjects   = new BooleanSetting(false)
   val printtypes        = new BooleanSetting(false)
   val uniqid            = new BooleanSetting(false)
+  val Ytraceidsdebug    = new MultiIntSetting(Nil)
   val verbose           = new BooleanSetting(false)
 
   val Yrecursion        = new IntSetting(0)


### PR DESCRIPTION
....

Create -Ytraceids-debug, a debugging aid to find out where
specified symbols are created by dumping  a stack trace.
This change also meant adding a settings type for multiple ints.
