### PR TITLE
When we strip tvars we should also recursively strip their instantiation...

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -6605,11 +6605,11 @@ trait Types extends api.Types { self: SymbolTable =>
       case ExistentialType(qs, _) => qs
       case t => List()
     }
-    def stripType(tp: Type) = tp match {
+    def stripType(tp: Type): Type = tp match {
       case ExistentialType(_, res) =>
         res
       case tv@TypeVar(_, constr) =>
-        if (tv.instValid) constr.inst
+        if (tv.instValid) stripType(constr.inst)
         else if (tv.untouchable) tv
         else abort("trying to do lub/glb of typevar "+tp)
       case t => t

--- a/test/files/pos/strip-tvars-for-lubbasetypes.scala
+++ b/test/files/pos/strip-tvars-for-lubbasetypes.scala
@@ -1,0 +1,25 @@
+object Test {
+
+  implicit final class EqualOps[T](val x: T) extends AnyVal {
+    def ===[T1, Ph >: T <: T1, Ph2 >: Ph <: T1](other: T1): Boolean = x == other
+    def !!![T1, Ph2 >: Ph <: T1, Ph >: T <: T1](other: T1): Boolean = x == other
+  }
+
+  class A
+  class B extends A
+  class C extends A
+
+  val a = new A
+  val b = new B
+  val c = new C
+
+  val x1 = a === b
+  val x2 = b === a
+  val x3 = b === c // error, infers Object{} for T1
+  val x4 = b.===[A, B, B](c)
+
+  val x5 = b !!! c // always compiled due to the order of Ph2 and Ph
+
+
+
+}


### PR DESCRIPTION
...s

as they can be tvars as well.
Otherwise our list of lub base types can be empty.
After this fix value x3 in the test case compiles.

review by @adriaanm
