### PR TITLE
SI-6692 pickle one more flag bit: EXISTENTIAL

### DIFF
--- a/src/library/scala/reflect/generic/Flags.scala
+++ b/src/library/scala/reflect/generic/Flags.scala
@@ -100,7 +100,8 @@ object ModifierFlags extends ModifierFlags
 
   private final val PKL_MASK       = 0x00000FFF
 
-  final val PickledFlags: Long  = 0xFFFFFFFFL
+  // must pickle EXISTENTIAL for SI-6692
+  final val PickledFlags: Long     = 0x8FFFFFFFFL
 
   private def rawPickledCorrespondence = Array(
     (IMPLICIT, IMPLICIT_PKL),

--- a/src/library/scala/reflect/generic/UnPickler.scala
+++ b/src/library/scala/reflect/generic/UnPickler.scala
@@ -396,10 +396,7 @@ abstract class UnPickler {
             NullaryMethodType(restpe)
         case EXISTENTIALtpe =>
           val restpe = readTypeRef()
-          val tparams = until(end, readSymbolRef)
-          // binary compatibility: in 2.9.x, Symbol doesn't have setFlag
-          tparams foreach (x => x.asInstanceOf[{ def setFlag(mask: Long): this.type }] setFlag EXISTENTIAL)
-          ExistentialType(tparams, restpe)
+          ExistentialType(until(end, readSymbolRef), restpe)
         case ANNOTATEDtpe =>
           var typeRef = readNat()
           val selfsym = if (isSymbolRef(typeRef)) {


### PR DESCRIPTION
before, PickledFlags & EXISTENTIAL == 0, so that an existential symbol would
lose the EXISTENTIAL bit when pickled, causing spurious incremental recompiles,
as pickled information and type-checking-from-source-based information differed

pickling this additional bit should be a compatible change, as older versions (pre-2.9.3)
will simply mask out the extra flag bits pickled as of now (2.9.3) so that their behavior
is not affected -- newer versions will see more flags, which might cause regressions,
but it's also the only way to fix SI-6692

this obviates the need to set the existential flag when unpickling an existential type's params

this is the smallest backport of a9b85dbaad and 3e2c31fbeb that I could think of

as 2.9 is in maintenance mode, I don't want to invest in testing infrastructure to test the pickler,
however, the fix is tested by the incremental compiler test 'inc-pickled-existential' in sbt

review by @paulp, still taking feasible testing-suggestions
