### PR TITLE
showRaw can now print positions

### DIFF
--- a/src/reflect/scala/reflect/api/Printers.scala
+++ b/src/reflect/scala/reflect/api/Printers.scala
@@ -143,6 +143,7 @@ trait Printers { self: Universe =>
     protected var printIds = false
     protected var printKinds = false
     protected var printMirrors = false
+    protected var printPositions = false
     def withTypes: this.type = { printTypes = true; this }
     def withoutTypes: this.type = { printTypes = false; this }
     def withIds: this.type = { printIds = true; this }
@@ -151,6 +152,8 @@ trait Printers { self: Universe =>
     def withoutKinds: this.type = { printKinds = false; this }
     def withMirrors: this.type = { printMirrors = true; this }
     def withoutMirrors: this.type = { printMirrors = false; this }
+    def withPositions: this.type = { printPositions = true; this }
+    def withoutPositions: this.type = { printPositions = false; this }
   }
 
   /** @group Printers */
@@ -164,6 +167,12 @@ trait Printers { self: Universe =>
 
   /** @group Printers */
   protected def render(what: Any, mkPrinter: PrintWriter => TreePrinter, printTypes: BooleanFlag = None, printIds: BooleanFlag = None, printKinds: BooleanFlag = None, printMirrors: BooleanFlag = None): String = {
+    renderEx(what, mkPrinter, printTypes, printIds, printKinds, printMirrors, printPositions = None)
+  }
+
+  /** @group Printers */
+  // Should be merged into `render` in 2.11 once we're not bound by binary compatibility chains
+  protected def renderEx(what: Any, mkPrinter: PrintWriter => TreePrinter, printTypes: BooleanFlag = None, printIds: BooleanFlag = None, printKinds: BooleanFlag = None, printMirrors: BooleanFlag = None, printPositions: BooleanFlag = None): String = {
     val buffer = new StringWriter()
     val writer = new PrintWriter(buffer)
     var printer = mkPrinter(writer)
@@ -171,23 +180,33 @@ trait Printers { self: Universe =>
     printIds.value.map(printIds => if (printIds) printer.withIds else printer.withoutIds)
     printKinds.value.map(printKinds => if (printKinds) printer.withKinds else printer.withoutKinds)
     printMirrors.value.map(printMirrors => if (printMirrors) printer.withMirrors else printer.withoutMirrors)
+    printPositions.value.map(printPositions => if (printPositions) printer.withPositions else printer.withoutPositions)
     printer.print(what)
     writer.flush()
     buffer.toString
   }
 
   /** By default trees are printed with `show`
-   * @group Printers
+   *  @group Printers
    */
   override protected def treeToString(tree: Tree) = show(tree)
 
   /** Renders a representation of a reflection artifact
-   * as desugared Java code.
+   *  as desugared Scala code.
    *
-   * @group Printers
+   *  @group Printers
    */
   def show(any: Any, printTypes: BooleanFlag = None, printIds: BooleanFlag = None, printKinds: BooleanFlag = None, printMirrors: BooleanFlag = None): String =
     render(any, newTreePrinter(_), printTypes, printIds, printKinds, printMirrors)
+
+  /** Renders a representation of a reflection artifact
+   *  as desugared Scala code, including information about positions.
+   *
+   *  @group Printers
+   */
+  // Should be merged into `show` in 2.11 once we're not bound by binary compatibility chains
+  def showPos(any: Any, printTypes: BooleanFlag = None, printIds: BooleanFlag = None, printKinds: BooleanFlag = None, printMirrors: BooleanFlag = None): String =
+    renderEx(any, newTreePrinter(_), printTypes, printIds, printKinds, printMirrors, printPositions = true)
 
   /** Hook to define what `show(...)` means.
    * @group Printers
@@ -195,12 +214,21 @@ trait Printers { self: Universe =>
   protected def newTreePrinter(out: PrintWriter): TreePrinter
 
   /** Renders internal structure of a reflection artifact as the
-   * visualization of a Scala syntax tree.
+   *  visualization of a Scala syntax tree.
    *
-   * @group Printers
+   *  @group Printers
    */
   def showRaw(any: Any, printTypes: BooleanFlag = None, printIds: BooleanFlag = None, printKinds: BooleanFlag = None, printMirrors: BooleanFlag = None): String =
     render(any, newRawTreePrinter(_), printTypes, printIds, printKinds, printMirrors)
+
+  /** Renders internal structure of a reflection artifact as the
+   *  visualization of a Scala syntax tree, including information about positions.
+   *
+   *  @group Printers
+   */
+  // Should be merged into `showRaw` in 2.11 once we're not bound by binary compatibility chains
+  def showRawPos(any: Any, printTypes: BooleanFlag = None, printIds: BooleanFlag = None, printKinds: BooleanFlag = None, printMirrors: BooleanFlag = None): String =
+    renderEx(any, newRawTreePrinter(_), printTypes, printIds, printKinds, printMirrors, printPositions = true)
 
   /** Hook to define what `showRaw(...)` means.
    * @group Printers

--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -67,12 +67,12 @@ trait Printers extends api.Printers { self: SymbolTable =>
     printIds = settings.uniqid.value
     printKinds = settings.Yshowsymkinds.value
     printMirrors = false // typically there's no point to print mirrors inside the compiler, as there is only one mirror there
-    protected def doPrintPositions = settings.Xprintpos.value
+    printPositions = settings.Xprintpos.value
 
     def indent() = indentMargin += indentStep
     def undent() = indentMargin -= indentStep
 
-    def printPosition(tree: Tree) = if (doPrintPositions) print(tree.pos.show)
+    def printPosition(tree: Tree) = if (printPositions) print(tree.pos.show)
 
     def println() {
       out.println()
@@ -389,7 +389,7 @@ trait Printers extends api.Printers { self: SymbolTable =>
           print(x.escapedStringValue)
 
         case tt: TypeTree =>
-          if ((tree.tpe eq null) || (doPrintPositions && tt.original != null)) {
+          if ((tree.tpe eq null) || (printPositions && tt.original != null)) {
             if (tt.original != null) print("<type: ", tt.original, ">")
             else print("<type ?>")
           } else if ((tree.tpe.typeSymbol ne null) && tree.tpe.typeSymbol.isAnonymousClass) {
@@ -552,6 +552,7 @@ trait Printers extends api.Printers { self: SymbolTable =>
           printProduct(
             tree,
             preamble = _ => {
+              if (printPositions) print(tree.pos.show)
               print(tree.productPrefix)
               if (printTypes && tree.tpe != null) print(tree.tpe)
             },


### PR DESCRIPTION
Would be great to simply add `printPos` argument to `show` and `showRaw`,
but we're bound by binary compatibility obligations for 2.10.x.
