### PR TITLE
typedIdent no longer destroys attachments

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5159,7 +5159,7 @@ trait Typers extends Modes with Adaptations with Tags {
             val tree1 = (
               if (qual == EmptyTree) tree
               // atPos necessary because qualifier might come from startContext
-              else atPos(tree.pos)(Select(qual, name))
+              else atPos(tree.pos)(Select(qual, name) setAttachments tree.attachments)
             )
             val (tree2, pre2) = makeAccessible(tree1, defSym, pre, qual)
             // assert(pre.typeArgs isEmpty) // no need to add #2416-style check here, right?

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -10,6 +10,7 @@ trait StdAttachments {
   trait Attachable {
     protected var rawatt: scala.reflect.macros.Attachments { type Pos = Position } = NoPosition
     def attachments = rawatt
+    def setAttachments(attachments: scala.reflect.macros.Attachments { type Pos = Position }): this.type = { rawatt = attachments; this }
     def updateAttachment[T: ClassTag](attachment: T): this.type = { rawatt = rawatt.update(attachment); this }
     def removeAttachment[T: ClassTag]: this.type = { rawatt = rawatt.remove[T]; this }
 

--- a/test/files/pos/attachments-typed-ident.flags
+++ b/test/files/pos/attachments-typed-ident.flags
@@ -1,0 +1,1 @@
+-language:experimental.macros

--- a/test/files/pos/attachments-typed-ident/Impls_1.scala
+++ b/test/files/pos/attachments-typed-ident/Impls_1.scala
@@ -1,0 +1,17 @@
+import scala.reflect.macros.Context
+import language.experimental.macros
+
+object MyAttachment
+
+object Macros {
+  def impl(c: Context) = {
+    import c.universe._
+    val ident = Ident(newTermName("bar")) updateAttachment MyAttachment
+    assert(ident.attachments.get[MyAttachment.type].isDefined, ident.attachments)
+    val typed = c.typeCheck(ident)
+    assert(typed.attachments.get[MyAttachment.type].isDefined, typed.attachments)
+    c.Expr[Int](typed)
+  }
+
+  def foo = macro impl
+}

--- a/test/files/pos/attachments-typed-ident/Macros_Test_2.scala
+++ b/test/files/pos/attachments-typed-ident/Macros_Test_2.scala
@@ -1,0 +1,4 @@
+object Test extends App {
+  def bar = 2
+  Macros.foo
+}


### PR DESCRIPTION
When transforming Idents to qualified Selects, typedIdent used to forget
about carrying original attachments to the resulting tree. Not anymore.
