### PR TITLE
SI-6809 Forbids deprecated case class definitions without parameter list

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2153,8 +2153,8 @@ self =>
       val start = in.offset
       newLineOptWhenFollowedBy(LPAREN)
       if (ofCaseClass && in.token != LPAREN)
-        deprecationWarning(in.lastOffset, "case classes without a parameter list have been deprecated;\n"+
-                           "use either case objects or case classes with `()' as parameter list.")
+        syntaxError(in.lastOffset, "case classes without a parameter list are not allowed;\n"+
+                                   "use either case objects or case classes with an explicit `()' as a parameter list.")
       while (implicitmod == 0 && in.token == LPAREN) {
         in.nextToken()
         vds += paramClause()

--- a/test/files/neg/t5956.check
+++ b/test/files/neg/t5956.check
@@ -1,20 +1,7 @@
-t5956.scala:1: warning: case classes without a parameter list have been deprecated;
-use either case objects or case classes with `()' as parameter list.
-object O { case class C[T]; class C }
-                          ^
-t5956.scala:2: warning: case classes without a parameter list have been deprecated;
-use either case objects or case classes with `()' as parameter list.
-object T { case class C[T]; case class C }
-                          ^
-t5956.scala:2: warning: case classes without a parameter list have been deprecated;
-use either case objects or case classes with `()' as parameter list.
-object T { case class C[T]; case class C }
-                                        ^
 t5956.scala:1: error: C is already defined as case class C
-object O { case class C[T]; class C }
-                                  ^
+object O { case class C[T](); class C() }
+                                    ^
 t5956.scala:2: error: C is already defined as case class C
-object T { case class C[T]; case class C }
-                                       ^
-three warnings found
+object T { case class C[T](); case class C() }
+                                         ^
 two errors found

--- a/test/files/neg/t5956.scala
+++ b/test/files/neg/t5956.scala
@@ -1,2 +1,2 @@
-object O { case class C[T]; class C }
-object T { case class C[T]; case class C }
+object O { case class C[T](); class C() }
+object T { case class C[T](); case class C() }

--- a/test/files/pos/depmet_implicit_oopsla_session_simpler.scala
+++ b/test/files/pos/depmet_implicit_oopsla_session_simpler.scala
@@ -5,7 +5,7 @@ object Sessions {
     def run(dp: Dual): Unit
   }
 
-  sealed case class Stop extends Session {
+  sealed case class Stop() extends Session {
     type Dual = Stop
 
     def run(dp: Dual): Unit = {}

--- a/test/files/pos/infer2-pos.scala
+++ b/test/files/pos/infer2-pos.scala
@@ -1,7 +1,7 @@
 package test
 class Lst[T]
 case class cons[T](x: T, xs: Lst[T]) extends Lst[T]
-case class nil[T] extends Lst[T]
+case class nil[T]() extends Lst[T]
 object test {
   Console.println(cons(1, nil()))
 }

--- a/test/files/pos/t0301.scala
+++ b/test/files/pos/t0301.scala
@@ -1,7 +1,7 @@
 package fos
 
 abstract class Expr
-case class Var extends Expr
+case class Var() extends Expr
 
 object Analyzer {
   def substitution(expr: Expr, cls: (Var,Var)): Expr =

--- a/test/files/pos/t344.scala
+++ b/test/files/pos/t344.scala
@@ -1,7 +1,7 @@
 object Bug {
   class A;
-  case class A1 extends A;
-  case class A2 extends A;
+  case class A1() extends A;
+  case class A2() extends A;
   def f: A =
     if (true)
       A1()

--- a/test/files/pos/t911.scala
+++ b/test/files/pos/t911.scala
@@ -1,6 +1,6 @@
 object Test {
-def foo : Any = {
-  case class Foo {}
-  Foo;
-}
+  def foo: Any = {
+    case class Foo() {}
+    Foo;
+  }
 }

--- a/test/files/run/caseclasses.scala
+++ b/test/files/run/caseclasses.scala
@@ -1,6 +1,6 @@
 case class Foo(x: Int)(y: Int)
 
-case class Bar
+case class Bar()
 
 abstract class Base
 abstract case class Abs(x: Int) extends Base

--- a/test/files/run/structural.scala
+++ b/test/files/run/structural.scala
@@ -152,7 +152,7 @@ object test2 {
 
 object test3 {
 
-  case class Exc extends Exception
+  case class Exc() extends Exception
   
   object Rec {
     def f = throw Exc()

--- a/test/files/run/t4415.scala
+++ b/test/files/run/t4415.scala
@@ -39,7 +39,7 @@ class SecondProperty extends TopProperty
 class SubclassSecondProperty extends StandardProperty
 
 trait MyProp[T]
-case class MyPropImpl[T] extends MyProp[T]
+case class MyPropImpl[T]() extends MyProp[T]
 
 object SubclassMatch {
 

--- a/test/scaladoc/resources/Trac4325.scala
+++ b/test/scaladoc/resources/Trac4325.scala
@@ -1,5 +1,5 @@
-case class WithSynthetic
+case class WithSynthetic()
 
-case class WithObject
+case class WithObject()
 object WithObject
 


### PR DESCRIPTION
This has been deprecated since at least 2.7.7, so it should be good to go.
