### PR TITLE
Remove dead code from `Global`.

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -779,7 +779,6 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
   /* The set of phase objects that is the basis for the compiler phase chain */
   protected lazy val phasesSet     = new mutable.HashSet[SubComponent]
   protected lazy val phasesDescMap = new mutable.HashMap[SubComponent, String] withDefaultValue ""
-  private lazy val phaseTimings = new Phases.TimingModel   // tracking phase stats
 
   protected def addToPhasesSet(sub: SubComponent, descr: String) {
     phasesSet += sub
@@ -1584,7 +1583,6 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
 
         // progress update
         informTime(globalPhase.description, startTime)
-        phaseTimings(globalPhase) = currentTime - startTime
 
         if (opt.writeICodeAtICode || (opt.printPhase && runIsAtOptimiz)) {
           // Write *.icode files when -Xprint-icode or -Xprint:<some-optimiz-phase> was given.

--- a/src/compiler/scala/tools/nsc/Phases.scala
+++ b/src/compiler/scala/tools/nsc/Phases.scala
@@ -9,6 +9,7 @@ import symtab.Flags
 import scala.reflect.internal.util.TableDef
 import scala.language.postfixOps
 
+@deprecated("Scheduled for removal as being a dead-code in the compiler.", "2.10.1")
 object Phases {
   val MaxPhases = 64
 


### PR DESCRIPTION
This is clearly dead-code (`phaseTimings` is not referred
anywhere else in `Global.scala`) and it's safe to remove it since
`phaseTimings` is private.

This dead-code is leftover from 317a1056.

Review by @paulp.
