### PR TITLE
Integrate isNameInScope in Contexts.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -436,16 +436,7 @@ trait Contexts { self: Analyzer =>
       case _                => outer.isLocal()
     }
 
-    /** Fast path for some slow checks (ambiguous assignment in Refchecks, and
-     *  existence of __match for MatchTranslation in virtpatmat.) This logic probably
-     *  needs improvement.
-     */
-    def isNameInScope(name: Name) = (
-      enclosingContextChain exists (ctx =>
-           (ctx.scope.lookupEntry(name) != null)
-        || (ctx.owner.rawInfo.member(name) != NoSymbol)
-      )
-    )
+    def isNameInScope(name: Name) = lookupSymbol(name, _ => true).isSuccess
 
     // nextOuter determines which context is searched next for implicits
     // (after `this`, which contributes `newImplicits` below.) In

--- a/src/reflect/scala/reflect/internal/Scopes.scala
+++ b/src/reflect/scala/reflect/internal/Scopes.scala
@@ -10,8 +10,8 @@ trait Scopes extends api.Scopes { self: SymbolTable =>
 
   /** An ADT to represent the results of symbol name lookups.
    */
-  sealed trait NameLookup { def symbol: Symbol }
-  case class LookupSucceeded(qualifier: Tree, symbol: Symbol) extends NameLookup
+  sealed trait NameLookup { def symbol: Symbol ; def isSuccess = false }
+  case class LookupSucceeded(qualifier: Tree, symbol: Symbol) extends NameLookup { override def isSuccess = true }
   case class LookupAmbiguous(msg: String) extends NameLookup { def symbol = NoSymbol }
   case class LookupInaccessible(symbol: Symbol, msg: String) extends NameLookup
   case object LookupNotFound extends NameLookup { def symbol = NoSymbol }


### PR DESCRIPTION
This was a partial implementation of symbol lookup used for
short-circuiting some expensive tests. After rescuing lookup
from typedIdent, it should only be a wrapper around
lookupSymbol (as it now is.)
