### PR TITLE
Implicit vars should have non-implicit setters.

### DIFF
--- a/src/reflect/scala/reflect/internal/Flags.scala
+++ b/src/reflect/scala/reflect/internal/Flags.scala
@@ -262,7 +262,7 @@ class Flags extends ModifierFlags {
    *  Getters of immutable values also get STABLE.
    */
   final val GetterFlags = ~(PRESUPER | MUTABLE)
-  final val SetterFlags = ~(PRESUPER | MUTABLE | STABLE | CASEACCESSOR)
+  final val SetterFlags = ~(PRESUPER | MUTABLE | STABLE | CASEACCESSOR | IMPLICIT)
 
   /** When a symbol for a default getter is created, it inherits these
    *  flags from the method with the default.  Other flags applied at creation

--- a/test/files/pos/setter-not-implicit.flags
+++ b/test/files/pos/setter-not-implicit.flags
@@ -1,0 +1,1 @@
+-feature -Xfatal-warnings

--- a/test/files/pos/setter-not-implicit.scala
+++ b/test/files/pos/setter-not-implicit.scala
@@ -1,0 +1,3 @@
+object O {
+  implicit var x: Int = 0
+}


### PR DESCRIPTION
Otherwise they trigger spurious feature warnings.

```
scala> trait T { implicit var a: Any }
<console>:7: warning: implicit conversion method a_= should
be enabled by making the implicit value
language.implicitConversions visible.
```
