### PR TITLE
SI-6846, regression in type constructor inference.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1060,15 +1060,17 @@ trait Infer extends Checkable {
      */
     def inferExprInstance(tree: Tree, tparams: List[Symbol], pt: Type = WildcardType, treeTp0: Type = null, keepNothings: Boolean = true, useWeaklyCompatible: Boolean = false): List[Symbol] = {
       val treeTp = if(treeTp0 eq null) tree.tpe else treeTp0 // can't refer to tree in default for treeTp0
+      val (targs, tvars) = exprTypeArgs(tparams, treeTp, pt, useWeaklyCompatible)
       printInference(
         ptBlock("inferExprInstance",
           "tree"    -> tree,
           "tree.tpe"-> tree.tpe,
           "tparams" -> tparams,
-          "pt"      -> pt
+          "pt"      -> pt,
+          "targs"   -> targs,
+          "tvars"   -> tvars
         )
       )
-      val (targs, tvars) = exprTypeArgs(tparams, treeTp, pt, useWeaklyCompatible)
 
       if (keepNothings || (targs eq null)) { //@M: adjustTypeArgs fails if targs==null, neg/t0226
         substExpr(tree, tparams, targs, pt)

--- a/test/files/pos/t6846.scala
+++ b/test/files/pos/t6846.scala
@@ -1,0 +1,28 @@
+object Test {
+  class Arb[_]
+  implicit def foo[M[_], A]: Arb[M[A]] = null
+  foo: Arb[List[Int]]
+  type ListInt = List[Int]
+  foo: Arb[ListInt]
+}
+
+object Test2 {
+  import scala.collection.immutable.List
+
+  class Carb[_]
+  implicit def narrow[N, M[_], A](x: Carb[M[A]])(implicit ev: N <:< M[A]): Carb[N] = null
+  implicit def bar[M[_], A]: Carb[M[A]] = null
+
+  type ListInt = List[Int]
+
+  val x: List[Int] = List(1)
+  val y: ListInt = List(1)
+
+  type ListSingletonX = x.type
+  type ListSingletonY = y.type
+
+  bar: Carb[List[Int]]
+  bar: Carb[ListInt]
+  bar: Carb[ListSingletonX]
+  bar: Carb[ListSingletonY]
+}


### PR DESCRIPTION
In 658ba1b4e6 some inference was gained and some was lost.
In this commit we regain what was lost and gain even more.
Dealiasing and widening should be fully handled now, as
illustrated by the test case.
