### PR TITLE
fixing test suite on java7

### DIFF
--- a/src/partest/scala/tools/partest/javaagent/ASMTransformer.java
+++ b/src/partest/scala/tools/partest/javaagent/ASMTransformer.java
@@ -28,33 +28,33 @@ public class ASMTransformer implements ClassFileTransformer {
 	
 	public byte[] transform(final ClassLoader classLoader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) {
 	  if (shouldTransform(className)) {
-  		ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS) {
-                        // this is copied verbatim from the superclass,
-                        // except that we use the outer class loader
-                        @Override protected String getCommonSuperClass(final String type1, final String type2) {
-                            Class<?> c, d;
-                            try {
-                                c = Class.forName(type1.replace('/', '.'), false, classLoader);
-                                d = Class.forName(type2.replace('/', '.'), false, classLoader);
-                            } catch (Exception e) {
-                                throw new RuntimeException(e.toString());
-                            }
-                            if (c.isAssignableFrom(d)) {
-                                return type1;
-                            }
-                            if (d.isAssignableFrom(c)) {
-                                return type2;
-                            }
-                            if (c.isInterface() || d.isInterface()) {
-                                return "java/lang/Object";
-                            } else {
-                                do {
-                                    c = c.getSuperclass();
-                                } while (!c.isAssignableFrom(d));
-                                return c.getName().replace('.', '/');
-                            }
-                        }
-                    };
+	    ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS) {
+	      // this is copied verbatim from the superclass,
+	      // except that we use the outer class loader
+	      @Override protected String getCommonSuperClass(final String type1, final String type2) {
+	        Class<?> c, d;
+	        try {
+	          c = Class.forName(type1.replace('/', '.'), false, classLoader);
+	          d = Class.forName(type2.replace('/', '.'), false, classLoader);
+	        } catch (Exception e) {
+	          throw new RuntimeException(e.toString());
+	        }
+	        if (c.isAssignableFrom(d)) {
+	          return type1;
+	        }
+	        if (d.isAssignableFrom(c)) {
+	          return type2;
+	        }
+	        if (c.isInterface() || d.isInterface()) {
+	          return "java/lang/Object";
+	        } else {
+	          do {
+	            c = c.getSuperclass();
+	          } while (!c.isAssignableFrom(d));
+	          return c.getName().replace('.', '/');
+	        }
+	      }
+	    };
   		ProfilerVisitor visitor = new ProfilerVisitor(writer);
   		ClassReader reader = new ClassReader(classfileBuffer);
   		reader.accept(visitor, 0);

--- a/src/partest/scala/tools/partest/javaagent/ProfilerVisitor.java
+++ b/src/partest/scala/tools/partest/javaagent/ProfilerVisitor.java
@@ -33,6 +33,19 @@ public class ProfilerVisitor extends ClassVisitor implements Opcodes {
       // only instrument non-abstract methods
       if((access & ACC_ABSTRACT) == 0) {
         assert(className != null);
+        /* The following instructions do not modify compressed stack frame map so
+         * we don't need to worry about recalculating stack frame map. Specifically,
+         * let's quote "ASM 4.0, A Java bytecode engineering library" guide (p. 40):
+         *
+         *   In order to save space, a compiled method does not contain one frame per
+         *   instruction: in fact it contains only the frames for the instructions
+         *   that correspond to jump targets or exception handlers, or that follow
+         *   unconditional jump instructions. Indeed the other frames can be easily
+         *   and quickly inferred from these ones.
+         *
+         * Instructions below are just loading constants and calling a method so according
+         * to definition above they do not contribute to compressed stack frame map.
+         */
         mv.visitLdcInsn(className);
         mv.visitLdcInsn(name);
         mv.visitLdcInsn(desc);

--- a/src/partest/scala/tools/partest/javaagent/ProfilingAgent.java
+++ b/src/partest/scala/tools/partest/javaagent/ProfilingAgent.java
@@ -20,6 +20,6 @@ public class ProfilingAgent {
 	  // and the test-case itself won't be loaded yet. We rely here on the fact that ASMTransformer does
 	  // not depend on Scala library. In case our assumptions are wrong we can always insert call to
 	  // inst.retransformClasses.
-		inst.addTransformer(new ASMTransformer(), true);
+	  inst.addTransformer(new ASMTransformer(), false);
 	}
 }


### PR DESCRIPTION
Something must have been lost in the translation when I attempted to get the isntrumentation tests fixed. If I had wanted a side branch where the tests pass under java7, I would have made a side branch and deleted these tests. The goal was and is to see the tests pass under java7 on master. So I discovered these patches languishing in the java7 branch, and after a cursory look they seem to work on java 6 and 7, so I don't know why they're there and not here.
