### PR TITLE
SI-6860, annotations accepting dummy arguments.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -423,6 +423,9 @@ trait ContextErrors {
       def UnexpectedTreeAnnotation(tree: Tree) =
         NormalTypeError(tree, "unexpected tree in annotation: "+ tree)
 
+      def AnnotationRequiresTypeArgs(tree: Tree, unapplied: Type) =
+        NormalTypeError(tree, s"$unapplied requires explicit type arguments")
+
       def AnnotationTypeMismatchError(tree: Tree, expected: Type, found: Type) =
         NormalTypeError(tree, "expected annotation of type " + expected + ", found " + found)
 

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2915,11 +2915,18 @@ trait Types extends api.Types { self: SymbolTable =>
     else existentialAbstraction(existentialsInType(tp), tp)
   )
 
-  def containsExistential(tpe: Type) =
-    tpe exists typeIsExistentiallyBound
+  def containsDummyTypeArg(tp: Type) = tp exists isDummyTypeArg
+  def isDummyTypeArg(tp: Type) = tp.typeSymbol.isTypeParameter
+  def isDummyAppliedType(tp: Type) = tp match {
+    case TypeRef(_, _, args) if args.nonEmpty => args exists isDummyTypeArg
+    case _                                    => false
+  }
 
   def existentialsInType(tpe: Type) =
     tpe withFilter typeIsExistentiallyBound map (_.typeSymbol)
+
+  def containsExistential(tpe: Type) =
+    tpe exists typeIsExistentiallyBound
 
   /** Precondition: params.nonEmpty.  (args.nonEmpty enforced structurally.)
    */

--- a/test/files/neg/t6860.check
+++ b/test/files/neg/t6860.check
@@ -1,0 +1,7 @@
+t6860.scala:4: error: Bippy[T] requires explicit type arguments
+  def f1: Int @Bippy("hi") = 1
+               ^
+t6860.scala:7: error: throws[T] requires explicit type arguments
+  @throws("what do I throw?") def f3 = throw new RuntimeException
+   ^
+two errors found

--- a/test/files/neg/t6860.scala
+++ b/test/files/neg/t6860.scala
@@ -1,0 +1,9 @@
+class Bippy[T](val value: T) extends annotation.StaticAnnotation
+
+class A {
+  def f1: Int @Bippy("hi") = 1
+  def f2: Int @Bippy[String]("hi") = 2
+
+  @throws("what do I throw?") def f3 = throw new RuntimeException
+  @throws[RuntimeException]("that's good to know!") def f4 = throw new RuntimeException
+}


### PR DESCRIPTION
This is less than ideal:

  scala> class Bippy[T] extends annotation.StaticAnnotation
  defined class Bippy

  scala> def f: Int @Bippy = 5
  f: Int @Bippy[T]

  scala>

Now it says:

<console>:8: error: Bippy[T] requires explicit type arguments
       def f: Int @Bippy = 5
                   ^
