### PR TITLE
 SI-4829 The :load command now fais if the command ends with a space

### DIFF
--- a/src/compiler/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/ILoop.scala
@@ -248,7 +248,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
   /** Prompt to print when awaiting input */
   def prompt = currentPrompt
 
-  import LoopCommand.{ cmd, nullary }
+  import LoopCommand.{ cmd, nullary, varargs }
 
   /** Standard commands **/
   lazy val standardCommands = List(
@@ -259,7 +259,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     cmd("imports", "[name name ...]", "show import history, identifying sources of names", importsCommand),
     cmd("implicits", "[-v]", "show the implicits in scope", implicitsCommand),
     cmd("javap", "<path|class>", "disassemble a file or class name", javapCommand),
-    cmd("load", "<path>", "load and interpret a Scala file", loadCommand),
+    varargs("load", "<path>", "load and interpret a Scala file", loadCommand),
     nullary("paste", "enter paste mode: all input up to ctrl-D compiled together", pasteCommand),
     nullary("power", "enable power user mode", powerCmd),
     nullary("quit", "exit the interpreter", () => Result(false, None)),
@@ -632,19 +632,18 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     }
   }
 
-  def withFile(filename: String)(action: File => Unit) {
-    val f = File(filename)
-
-    if (f.exists) action(f)
-    else echo("That file does not exist")
-  }
-
-  def loadCommand(arg: String) = {
-    var shouldReplay: Option[String] = None
-    withFile(arg)(f => {
-      interpretAllFrom(f)
-      shouldReplay = Some(":load " + arg)
-    })
+  def loadCommand(args: List[String]) = {
+    val files = args.map(filename => File(filename))
+    val badFiles = files.filter(file => !file.exists)
+    val shouldReplay =
+    if (badFiles.isEmpty) {
+      for (file <- files) interpretAllFrom(file)
+      Some(":load " + args)
+    }
+    else {
+      for (badFile <- badFiles) echo(s"$badFile does not exist")
+      None
+    }
     Result(true, shouldReplay)
   }
 
@@ -692,9 +691,10 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     * if any. */
   def command(line: String): Result = {
     if (line startsWith ":") {
-      val cmd = line.tail takeWhile (x => !x.isWhitespace)
+      val segments = line.tail splitLeft(1, ' ')
+      val cmd = segments(0)
       uniqueCommand(cmd) match {
-        case Some(lc) => lc(line.tail stripPrefix cmd dropWhile (_.isWhitespace))
+        case Some(lc) => lc(segments.applyOrElse(1, ""))
         case _        => ambiguousError(cmd)
       }
     }

--- a/src/library/scala/PartialFunction.scala
+++ b/src/library/scala/PartialFunction.scala
@@ -117,6 +117,8 @@ trait PartialFunction[-A, +B] extends (A => B) { self =>
   def applyOrElse[A1 <: A, B1 >: B](x: A1, default: A1 => B1): B1 =
     if (isDefinedAt(x)) apply(x) else default(x)
 
+  def applyOrElse[B1 >: B](x: A, default: B1): B1 = applyOrElse(x, (y: A) => default)
+
   /** Composes this partial function with an action function which
    *  gets applied to results of this partial function.
    *  The action function is invoked only for its side effects; its result is ignored.

--- a/src/library/scala/collection/immutable/StringLike.scala
+++ b/src/library/scala/collection/immutable/StringLike.scala
@@ -206,6 +206,36 @@ self =>
     toString.split(re)
   }
 
+  def splitRight(count: Int, ch: Char): Seq[String] = {
+    val combine = (recurse: Seq[String], append: String) => recurse :+ append
+    val splitIndex = (s: String) => s.lastIndexOf(ch)
+    val order = (front: String, back: String) => (front, back)
+    split(count, splitIndex, order, combine)
+  }
+
+  def splitLeft(count: Int, ch: Char): Seq[String] = {
+    val combine = (recurse: Seq[String], append: String) => append +: recurse
+    val splitIndex = (s: String) => s.indexOf(ch)
+    val order = (front: String, back: String) => (back, front)
+    split(count, splitIndex, order, combine)
+  }
+
+  private def split(count: Int,
+                    splitIndexFunction: String => Int,
+                    order: (String, String) => (String, String),
+                    combine: (Seq[String], String) => Seq[String]): Seq[String] = {
+    if (count < 1) List(toString)
+    else {
+      val splitIndex = splitIndexFunction(toString)
+      if (splitIndex < 0) List(toString)
+      else {
+        val (first, second) = toString.splitAt(splitIndex)
+        val (recurse, append) = order(first, second.tail)
+        combine(recurse.split(count - 1, splitIndexFunction, order, combine), append)
+      }
+    }
+  }
+
   /** You can follow a string with `.r`, turning it into a `Regex`. E.g.
    *
    *  `"""A\w*""".r`   is the regular expression for identifiers starting with `A`.

--- a/test/files/run/string.check
+++ b/test/files/run/string.check
@@ -1,0 +1,4 @@
+List(Hi, there Bob)
+List(load, test.scala bogus.scala helloWorld.scala)
+List(z, c, vxbx)
+List(zxcxv, b, )

--- a/test/files/run/string.scala
+++ b/test/files/run/string.scala
@@ -1,0 +1,6 @@
+object Test extends App {
+  println("Hi there Bob".splitLeft(1, ' '))
+  println(":load test.scala bogus.scala helloWorld.scala".tail.splitLeft(1, ' '))
+  println("zxcxvxbx".splitLeft(2, 'x'))
+  println("zxcxvxbx".splitRight(2, 'x'))
+}


### PR DESCRIPTION
Modified the load command to accept a variable amount of filenames and to ignore whitespace at the end of the command.

I am aware that this pull request cannot be accepted in  it's current form. I am looking to gather feedback on what I have done up until now, as not to waste too much time going down the wrong path (i.e. writing documentation for the methods I added). I am also aware that this would need to be rebased against master if I were to actually add these methods.

Review by @paulp, @phaller, @axel22
