### PR TITLE
the scanner is now less eager about deprecations

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -104,6 +104,11 @@ trait Scanners extends ScannersCommon {
       cbuf.append(c)
     }
 
+    /** Determines whether this scanner should emit identifier deprecation warnings,
+     *  e.g. when seeing `macro` or `then`, which are planned to become keywords in future versions of Scala.
+     */
+    protected def emitIdentifierDeprecationWarnings = true
+
     /** Clear buffer and set name and token */
     private def finishNamed(idtoken: Int = IDENTIFIER) {
       name = newTermName(cbuf.toString)
@@ -113,7 +118,7 @@ trait Scanners extends ScannersCommon {
         val idx = name.start - kwOffset
         if (idx >= 0 && idx < kwArray.length) {
           token = kwArray(idx)
-          if (token == IDENTIFIER && allowIdent != name)
+          if (token == IDENTIFIER && allowIdent != name && emitIdentifierDeprecationWarnings)
             deprecationWarning(name+" is now a reserved word; usage as an identifier is deprecated")
         }
       }
@@ -1460,6 +1465,10 @@ trait Scanners extends ScannersCommon {
       }
       delete(bracePairs)
     }
+
+    // don't emit deprecation warnings about identifiers like `macro` or `then`
+    // when skimming through the source file trying to heal braces
+    override def emitIdentifierDeprecationWarnings = false
 
     override def error(offset: Int, msg: String) {}
   }

--- a/test/files/neg/macro-false-deprecation-warning.check
+++ b/test/files/neg/macro-false-deprecation-warning.check
@@ -1,0 +1,4 @@
+Impls_Macros_1.scala:5: error: illegal start of simple expression
+}
+^
+one error found

--- a/test/files/neg/macro-false-deprecation-warning.flags
+++ b/test/files/neg/macro-false-deprecation-warning.flags
@@ -1,0 +1,1 @@
+-language:experimental.macros

--- a/test/files/neg/macro-false-deprecation-warning.flags
+++ b/test/files/neg/macro-false-deprecation-warning.flags
@@ -1,1 +1,1 @@
--language:experimental.macros
+-language:experimental.macros -deprecation

--- a/test/files/neg/macro-false-deprecation-warning/Impls_Macros_1.scala
+++ b/test/files/neg/macro-false-deprecation-warning/Impls_Macros_1.scala
@@ -1,0 +1,15 @@
+import scala.reflect.macros.Context
+
+object Helper {
+  def unapplySeq[T](x: List[T]): Option[Seq[T]] =
+}
+
+object Macros {
+  def impl[T: c.WeakTypeTag](c: Context)(x: c.Expr[List[T]]) = {
+    c.universe.reify(Helper.unapplySeq(x.splice))
+  }
+
+  object UnapplyMacro {
+    def unapplySeq[T](x: List[T]): Option[Seq[T]] = macro impl[T]
+  }
+}


### PR DESCRIPTION
When healing braces it isn't very useful to report deprecation warnings,
especially since this process is just simple context-free skimming, which
can't know about what positions can accept what identifiers.
