### PR TITLE
fixes the typedIdent problem for good

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4753,7 +4753,7 @@ trait Typers extends Modes with Adaptations with Tags {
               case sym      => typed1(tree setSymbol sym, mode, pt)
             }
           case LookupSucceeded(qual, sym)   =>
-            // this -> Foo.this
+            (// this -> Foo.this
             if (sym.isThisSym)
               typed1(This(sym.owner) setPos tree.pos, mode, pt)
             // Inferring classOf type parameter from expected type.  Otherwise an
@@ -4762,12 +4762,12 @@ trait Typers extends Modes with Adaptations with Tags {
               typedClassOf(tree, TypeTree(pt.typeArgs.head))
             else {
               val pre1  = if (sym.owner.isPackageClass) sym.owner.thisType else if (qual == EmptyTree) NoPrefix else qual.tpe
-              val tree1 = if (qual == EmptyTree) tree else atPos(tree.pos)(Select(atPos(tree.pos.focusStart)(qual), name) setAttachments tree.attachments)
+              val tree1 = if (qual == EmptyTree) tree else atPos(tree.pos)(Select(atPos(tree.pos.focusStart)(qual), name))
               val (tree2, pre2) = makeAccessible(tree1, sym, pre1, qual)
               // SI-5967 Important to replace param type A* with Seq[A] when seen from from a reference, to avoid
               //         inference errors in pattern matching.
               stabilize(tree2, pre2, mode, pt) modifyType dropIllegalStarTypes
-            }
+            }) setAttachments tree.attachments
         }
       }
 

--- a/test/files/pos/attachments-typed-another-ident.flags
+++ b/test/files/pos/attachments-typed-another-ident.flags
@@ -1,0 +1,1 @@
+-language:experimental.macros

--- a/test/files/pos/attachments-typed-another-ident/Impls_1.scala
+++ b/test/files/pos/attachments-typed-another-ident/Impls_1.scala
@@ -1,0 +1,17 @@
+import scala.reflect.macros.Context
+import language.experimental.macros
+
+object MyAttachment
+
+object Macros {
+  def impl(c: Context) = {
+    import c.universe._
+    val ident = Ident(newTermName("bar")) updateAttachment MyAttachment
+    assert(ident.attachments.get[MyAttachment.type].isDefined, ident.attachments)
+    val typed = c.typeCheck(ident)
+    assert(typed.attachments.get[MyAttachment.type].isDefined, typed.attachments)
+    c.Expr[Int](typed)
+  }
+
+  def foo = macro impl
+}

--- a/test/files/pos/attachments-typed-another-ident/Macros_Test_2.scala
+++ b/test/files/pos/attachments-typed-another-ident/Macros_Test_2.scala
@@ -1,0 +1,5 @@
+object Test extends App {
+  def bar = 2
+  Macros.foo
+}
+


### PR DESCRIPTION
Previous attachment retaining fix was only working for Idents which
get turned into Selects. Now it works for all transformations applied
to Idents (e.g. when an ident refers to something within a package obj).
