### PR TITLE
adds Tree.nonEmpty

### DIFF
--- a/src/reflect/scala/reflect/api/Trees.scala
+++ b/src/reflect/scala/reflect/api/Trees.scala
@@ -89,6 +89,12 @@ trait Trees { self: Universe =>
      */
     def isEmpty: Boolean
 
+    /** Is this tree one of the empty trees?
+     *
+     *  @see `isEmpty`
+     */
+    def nonEmpty: Boolean
+
     /** Can this tree carry attributes (i.e. symbols, types or positions)?
      *  Typically the answer is yes, except for the `EmptyTree` null object and
      *  two special singletons: `emptyValDef` and `pendingSuperCall`.

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -39,6 +39,8 @@ trait Trees extends api.Trees { self: SymbolTable =>
     def isDef = false
 
     def isEmpty = false
+    def nonEmpty = !isEmpty
+
     def canHaveAttrs = true
 
     /** The canonical way to test if a Tree represents a term.


### PR DESCRIPTION
So that trees become consistent with isEmpty on lists and options.
