### PR TITLE
macro expansions are now auto-duplicated

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -691,9 +691,11 @@ trait Macros extends scala.tools.reflect.FastTrack with Traces {
 
             var expectedTpe = expandee.tpe
             if (isNullaryInvocation(expandee)) expectedTpe = expectedTpe.finalResultType
-            var typechecked = typecheck("macro def return type", expanded, expectedTpe)
-            typechecked = typecheck("expected type", typechecked, pt)
-            typechecked
+            // also see http://groups.google.com/group/scala-internals/browse_thread/thread/492560d941b315cc
+            val expanded0 = duplicateAndKeepPositions(expanded)
+            val expanded1 = typecheck("macro def return type", expanded0, expectedTpe)
+            val expanded2 = typecheck("expected type", expanded1, pt)
+            expanded2
           } finally {
             popMacroContext()
           }

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -1499,14 +1499,17 @@ trait Trees extends api.Trees { self: SymbolTable =>
     }
   }
 
-  private lazy val duplicator = new Transformer {
+  private lazy val duplicator = new Duplicator(focusPositions = true)
+  private class Duplicator(focusPositions: Boolean) extends Transformer {
     override val treeCopy = newStrictTreeCopier
     override def transform(t: Tree) = {
       val t1 = super.transform(t)
-      if ((t1 ne t) && t1.pos.isRange) t1 setPos t.pos.focus
+      if ((t1 ne t) && t1.pos.isRange && focusPositions) t1 setPos t.pos.focus
       t1
     }
   }
+
+  def duplicateAndKeepPositions(tree: Tree) = new Duplicator(focusPositions = false) transform tree
 
   // ------ copiers -------------------------------------------
 

--- a/test/files/run/macro-duplicate.flags
+++ b/test/files/run/macro-duplicate.flags
@@ -1,0 +1,1 @@
+-language:experimental.macros

--- a/test/files/run/macro-duplicate/Impls_Macros_1.scala
+++ b/test/files/run/macro-duplicate/Impls_Macros_1.scala
@@ -1,0 +1,29 @@
+import scala.reflect.macros.Context
+
+object Macros {
+  def impl(c: Context) = {
+    import c.universe._
+    val Expr(Block((cdef: ClassDef) :: Nil, _)) = reify { class C { def x = 2 } }
+    val cdef1 =
+      new Transformer {
+        override def transform(tree: Tree): Tree = tree match {
+          case Template(_, _, ctor :: defs) =>
+            val defs1 = defs collect {
+              case ddef @ DefDef(mods, name, tparams, vparamss, tpt, body) =>
+                val future = Select(Select(Select(Ident(newTermName("scala")), newTermName("concurrent")), newTermName("package")), newTermName("future"))
+                val Future = Select(Select(Ident(newTermName("scala")), newTermName("concurrent")), newTypeName("Future"))
+                val tpt1 = if (tpt.isEmpty) tpt else AppliedTypeTree(Future, List(tpt))
+                val body1 = Apply(future, List(body))
+                val name1 = newTermName("async" + name.toString.capitalize)
+                DefDef(mods, name1, tparams, vparamss, tpt1, body1)
+            }
+            Template(Nil, emptyValDef, ctor +: defs ::: defs1)
+          case _ =>
+            super.transform(tree)
+        }
+      } transform cdef
+    c.Expr[Unit](Block(cdef1 :: Nil, Literal(Constant(()))))
+  }
+
+  def foo = macro impl
+}

--- a/test/files/run/macro-duplicate/Test_2.scala
+++ b/test/files/run/macro-duplicate/Test_2.scala
@@ -1,0 +1,6 @@
+import scala.concurrent._
+import ExecutionContext.Implicits.global
+
+object Test extends App {
+  Macros.foo
+}


### PR DESCRIPTION
The fix still requires macro developers to be careful about sharing trees
by references, because attributed DefTrees will still bring trouble.

However this is an improvement, because it doesn't make matters worse
and automatically fixes situations similar to one in the test.

A much more thorough discussion with a number of open questions left:
http://groups.google.com/group/scala-internals/browse_thread/thread/492560d941b315cc
