### PR TITLE
bind + argc specialization = 20x perf boost

### DIFF
--- a/src/library/scala/collection/mutable/WrappedArray.scala
+++ b/src/library/scala/collection/mutable/WrappedArray.scala
@@ -62,7 +62,7 @@ extends AbstractSeq[T]
   override def par = ParArray.handoff(array)
 
   private def elementClass: Class[_] =
-    arrayElementClass(repr.getClass)
+    arrayElementClass(array.getClass)
 
   override def toArray[U >: T : ClassTag]: Array[U] = {
     val thatElementClass = arrayElementClass(implicitly[ClassTag[U]])

--- a/src/library/scala/reflect/Manifest.scala
+++ b/src/library/scala/reflect/Manifest.scala
@@ -162,11 +162,13 @@ object ManifestFactory {
   private val NullTYPE = classOf[scala.runtime.Null$]
 
   val Any: Manifest[scala.Any] = new PhantomManifest[scala.Any](ObjectTYPE, "Any") {
+    override def newArray(len: Int) = new Array[scala.Any](len)
     override def <:<(that: ClassManifest[_]): Boolean = (that eq this)
     private def readResolve(): Any = Manifest.Any
   }
 
   val Object: Manifest[java.lang.Object] = new PhantomManifest[java.lang.Object](ObjectTYPE, "Object") {
+    override def newArray(len: Int) = new Array[java.lang.Object](len)
     override def <:<(that: ClassManifest[_]): Boolean = (that eq this) || (that eq Any)
     private def readResolve(): Any = Manifest.Object
   }
@@ -174,17 +176,20 @@ object ManifestFactory {
   val AnyRef: Manifest[scala.AnyRef] = Object.asInstanceOf[Manifest[scala.AnyRef]]
 
   val AnyVal: Manifest[scala.AnyVal] = new PhantomManifest[scala.AnyVal](ObjectTYPE, "AnyVal") {
+    override def newArray(len: Int) = new Array[scala.AnyVal](len)
     override def <:<(that: ClassManifest[_]): Boolean = (that eq this) || (that eq Any)
     private def readResolve(): Any = Manifest.AnyVal
   }
 
   val Null: Manifest[scala.Null] = new PhantomManifest[scala.Null](NullTYPE, "Null") {
+    override def newArray(len: Int) = new Array[scala.Null](len)
     override def <:<(that: ClassManifest[_]): Boolean =
       (that ne null) && (that ne Nothing) && !(that <:< AnyVal)
     private def readResolve(): Any = Manifest.Null
   }
 
   val Nothing: Manifest[scala.Nothing] = new PhantomManifest[scala.Nothing](NothingTYPE, "Nothing") {
+    override def newArray(len: Int) = new Array[scala.Nothing](len)
     override def <:<(that: ClassManifest[_]): Boolean = (that ne null)
     private def readResolve(): Any = Manifest.Nothing
   }

--- a/src/reflect/scala/reflect/api/Mirrors.scala
+++ b/src/reflect/scala/reflect/api/Mirrors.scala
@@ -352,6 +352,11 @@ trait Mirrors { self: Universe =>
      *  the value of the base field. To achieve overriding behavior, use reflectMethod on an accessor.
      */
     def set(value: Any): Unit
+
+    /** Creates a new mirror which uses the same symbol, but is bound to a different receiver.
+     *  This is significantly faster than recreating the mirror from scratch.
+     */
+    def bind(newReceiver: Any): FieldMirror
   }
 
   /** A mirror that reflects a method.
@@ -373,6 +378,11 @@ trait Mirrors { self: Universe =>
      *  with invoking the corresponding method or constructor.
      */
     def apply(args: Any*): Any
+
+    /** Creates a new mirror which uses the same symbol, but is bound to a different receiver.
+     *  This is significantly faster than recreating the mirror from scratch.
+     */
+    def bind(newReceiver: Any): MethodMirror
   }
 
   /** A mirror that reflects the instance or static parts of a runtime class.


### PR DESCRIPTION
Default logic of mirror construction, which gets triggered via
reflectField/reflectMethod/reflectConstructor, validates a lot of facts
about its arguments.

This takes quite a bit of time, which significantly degrades performance
of reflection-heavy applications. Proposed two changes provide an order
of magnitude performance boost to a simple app, which repeatedly invokes
the same method for different receiver instances.
