### PR TITLE
SI-6194, repl crash.

### DIFF
--- a/src/compiler/scala/tools/nsc/util/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/util/ClassPath.scala
@@ -15,6 +15,7 @@ import scala.reflect.ClassTag
 import Jar.isJarOrZip
 import File.pathSeparator
 import java.net.MalformedURLException
+import java.util.regex.PatternSyntaxException
 
 /** <p>
  *    This module provides star expansion of '-classpath' option arguments, behaves the same as
@@ -39,8 +40,11 @@ object ClassPath {
     if (pattern == "*") lsDir(Directory("."))
     else if (pattern endsWith wildSuffix) lsDir(Directory(pattern dropRight 2))
     else if (pattern contains '*') {
-      val regexp = ("^%s$" format pattern.replaceAll("""\*""", """.*""")).r
-      lsDir(Directory(pattern).parent, regexp findFirstIn _ isDefined)
+      try {
+        val regexp = ("^" + pattern.replaceAllLiterally("""\*""", """.*""") + "$").r
+        lsDir(Directory(pattern).parent, regexp findFirstIn _ isDefined)
+      }
+      catch { case _: PatternSyntaxException => List(pattern) }
     }
     else List(pattern)
   }

--- a/test/files/run/t6194.check
+++ b/test/files/run/t6194.check
@@ -1,0 +1,1 @@
+C:\FooBar\Java\includes\*.jar

--- a/test/files/run/t6194.scala
+++ b/test/files/run/t6194.scala
@@ -1,0 +1,8 @@
+import scala.tools.nsc.util._
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val cp = ClassPath.expandPath("""C:\FooBar\Java\includes\*.jar""") mkString java.io.File.pathSeparator
+    println(cp)
+  }
+}


### PR DESCRIPTION
Always a bad idea to use replaceAll on unknown strings,
as we saw here when windows classpaths arrived containing
escape-requiring backslashes.
