### PR TITLE
Remove -deprecation from partest default options.

### DIFF
--- a/src/partest/scala/tools/partest/PartestDefaults.scala
+++ b/src/partest/scala/tools/partest/PartestDefaults.scala
@@ -21,7 +21,7 @@ object PartestDefaults {
   def javaCmd     = propOrElse("partest.javacmd", "java")
   def javacCmd    = propOrElse("partest.javac_cmd", "javac")
   def javaOpts    = propOrElse("partest.java_opts", "")
-  def scalacOpts  = propOrElse("partest.scalac_opts", "-deprecation")
+  def scalacOpts  = propOrElse("partest.scalac_opts", "")
 
   def testBuild  = propOrNone("partest.build")
   def errorCount = propOrElse("partest.errors", "0").toInt

--- a/src/partest/scala/tools/partest/nest/CompileManager.scala
+++ b/src/partest/scala/tools/partest/nest/CompileManager.scala
@@ -41,7 +41,6 @@ class ExtConsoleReporter(settings: Settings, val writer: PrintWriter) extends Co
 class TestSettings(cp: String, error: String => Unit) extends Settings(error) {
   def this(cp: String) = this(cp, _ => ())
 
-  deprecation.value = true
   nowarnings.value  = false
   encoding.value    = "UTF-8"
   classpath.value   = cp

--- a/test/files/neg/classmanifests_new_deprecations.flags
+++ b/test/files/neg/classmanifests_new_deprecations.flags
@@ -1,1 +1,1 @@
--Xfatal-warnings
+-deprecation -Xfatal-warnings

--- a/test/files/neg/for-comprehension-old.flags
+++ b/test/files/neg/for-comprehension-old.flags
@@ -1,0 +1,1 @@
+-deprecation

--- a/test/files/neg/macro-deprecate-idents.flags
+++ b/test/files/neg/macro-deprecate-idents.flags
@@ -1,1 +1,1 @@
--Xfatal-warnings
+-deprecation -Xfatal-warnings

--- a/test/files/neg/macro-invalidshape-d.flags
+++ b/test/files/neg/macro-invalidshape-d.flags
@@ -1,1 +1,1 @@
--language:experimental.macros
+-deprecation -language:experimental.macros

--- a/test/files/neg/names-defaults-neg.flags
+++ b/test/files/neg/names-defaults-neg.flags
@@ -1,0 +1,1 @@
+-deprecation

--- a/test/files/neg/t5589neg.flags
+++ b/test/files/neg/t5589neg.flags
@@ -1,0 +1,1 @@
+-deprecation

--- a/test/files/neg/t5956.flags
+++ b/test/files/neg/t5956.flags
@@ -1,0 +1,1 @@
+-deprecation


### PR DESCRIPTION
Who knows why it was ever like this; it's not like anyone
sees the deprecation warnings. In PR #1807 there is now a
test which depends on partest not making this move, so it's
a good time to finally expunge it.
