### PR TITLE
fusion of loops in Range.foreach() and Range.validateRangeBoundaries()

### DIFF
--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -112,6 +112,7 @@ extends scala.collection.AbstractSeq[Int]
       fail()
   }
 
+  @deprecated("Range.foreach() is now self-contained, making this auxiliary method redundant.", "2.10.1")
   def validateRangeBoundaries(f: Int => Any): Boolean = {
     validateMaxLength()
 
@@ -134,14 +135,19 @@ extends scala.collection.AbstractSeq[Int]
   }
 
   @inline final override def foreach[@specialized(Unit) U](f: Int => U) {
-    if (validateRangeBoundaries(f)) {
-      var i = start
-      val terminal = terminalElement
-      val step = this.step
-      while (i != terminal) {
-        f(i)
-        i += step
-      }
+    validateMaxLength()
+    val isCommonCase = (start != Int.MinValue || end != Int.MinValue)
+    var i = start
+    var count = 0
+    val terminal = terminalElement
+    val step = this.step
+    while(
+      if(isCommonCase) { i != terminal }
+      else             { count < numRangeElements }
+    ) {
+      f(i)
+      count += 1
+      i += step
     }
   }
 


### PR DESCRIPTION
This commit allows closure elimination in more cases. The non-inlined case also benefits from saving a Range.validateRangeBoundaries() invocation.

Before this commit, the closure argument to Range.foreach() escaped to Range.validateRangeBoundaries(). As a consequence, closure elimination required inlining both of them. Given that the current optimizer duplicates a closure body whenever that closure's apply() is invoked, the resulting code size taxed the JIT compiler. In particular when apply() delegates to a specialized version, or when a bridge apply() stands in the way.

review by @paulp

Does the performance gain warrant merging into 2.10.x ?
