### PR TITLE
Remove name-mangling for almost all characters

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/SymbolicXMLBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/SymbolicXMLBuilder.scala
@@ -50,7 +50,7 @@ abstract class SymbolicXMLBuilder(p: Parsers#Parser, preserveWS: Boolean) {
     val __Text: NameType    = "Text"
     val _buf: NameType      = "$buf"
     val _md: NameType       = "$md"
-    val _plus: NameType     = "$amp$plus"
+    val _plus: NameType     = "&+"
     val _scope: NameType    = "$scope"
     val _tmpscope: NameType = "$tmpscope"
     val _xml: NameType      = "xml"

--- a/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
+++ b/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
@@ -119,7 +119,7 @@ abstract class ToolBoxFactory[U <: JavaUniverse](val u: U) { factorySelf =>
 
         // need to wrap the expr, because otherwise you won't be able to typecheck macros against something that contains free vars
         var (expr, freeTerms) = extractFreeTerms(expr0, wrapFreeTermRefs = false)
-        val dummies = freeTerms.map{ case (freeTerm, name) => ValDef(NoMods, name, TypeTree(freeTerm.info), Select(Ident(PredefModule), newTermName("$qmark$qmark$qmark"))) }.toList
+        val dummies = freeTerms.map{ case (freeTerm, name) => ValDef(NoMods, name, TypeTree(freeTerm.info), Select(Ident(PredefModule), newTermName("???"))) }.toList
         expr = Block(dummies, wrapIntoTerm(expr))
 
         // [Eugene] how can we implement that?

--- a/src/library/scala/reflect/NameTransformer.scala
+++ b/src/library/scala/reflect/NameTransformer.scala
@@ -33,24 +33,17 @@ object NameTransformer {
   }
 
   /* Note: decoding assumes opcodes are only ever lowercase. */
-  enterOp('~', "$tilde")
-  enterOp('=', "$eq")
+  enterOp('.', "$dot")
+  enterOp(',', "$comma")
+  enterOp(':', "$colon")
+  enterOp(';', "$semicolon")
+  enterOp('"', "$quot")
+  enterOp('/', "$div")
+  enterOp('\\', "$bslash")
+  enterOp('[', "$lbracket")
+  enterOp(']', "$rbracket")
   enterOp('<', "$less")
   enterOp('>', "$greater")
-  enterOp('!', "$bang")
-  enterOp('#', "$hash")
-  enterOp('%', "$percent")
-  enterOp('^', "$up")
-  enterOp('&', "$amp")
-  enterOp('|', "$bar")
-  enterOp('*', "$times")
-  enterOp('/', "$div")
-  enterOp('+', "$plus")
-  enterOp('-', "$minus")
-  enterOp(':', "$colon")
-  enterOp('\\', "$bslash")
-  enterOp('?', "$qmark")
-  enterOp('@', "$at")
 
   /** Replace operator symbols by corresponding `\$opname`.
    *
@@ -71,13 +64,13 @@ object NameTransformer {
         buf.append(op2code(c))
       /* Handle glyphs that are not valid Java/JVM identifiers */
       }
-      else if (!Character.isJavaIdentifierPart(c)) {
-        if (buf eq null) {
-          buf = new StringBuilder()
-          buf.append(name.substring(0, i))
-        }
-        buf.append("$u%04X".format(c.toInt))
-      }
+//      else if (!Character.isJavaIdentifierPart(c)) {
+//        if (buf eq null) {
+//          buf = new StringBuilder()
+//          buf.append(name.substring(0, i))
+//        }
+//        buf.append("$u%04X".format(c.toInt))
+//      }
       else if (buf ne null) {
         buf.append(c)
       }

--- a/src/scalap/scala/tools/scalap/scalax/rules/scalasig/ScalaSigPrinter.scala
+++ b/src/scalap/scala/tools/scalap/scalax/rules/scalasig/ScalaSigPrinter.scala
@@ -244,12 +244,12 @@ class ScalaSigPrinter(stream: PrintStream, printPrivates: Boolean) {
     if (underCaseClass(m) && n == CONSTRUCTOR_NAME) return
     if (n.matches(".+\\$default\\$\\d+")) return // skip default function parameters
     if (n.startsWith("super$")) return // do not print auxiliary qualified super accessors
-    if (m.isAccessor && n.endsWith("_$eq")) return
+    if (m.isAccessor && n.endsWith("_=")) return
     indent()
     printModifiers(m)
     if (m.isAccessor) {
       val indexOfSetter = m.parent.get.children.indexWhere(x => x.isInstanceOf[MethodSymbol] &&
-              x.asInstanceOf[MethodSymbol].name == n + "_$eq")
+              x.asInstanceOf[MethodSymbol].name == n + "_=")
       print(if (indexOfSetter > 0) "var " else "val ")
     } else {
       print("def ")
@@ -408,13 +408,10 @@ class ScalaSigPrinter(stream: PrintStream, printPrivates: Boolean) {
     if (params.isEmpty) ""
     else params.map(toString).mkString("[", ", ", "]")
 
-  val _syms = Map("\\$bar" -> "|", "\\$tilde" -> "~",
-    "\\$bang" -> "!", "\\$up" -> "^", "\\$plus" -> "+",
-    "\\$minus" -> "-", "\\$eq" -> "=", "\\$less" -> "<",
-    "\\$times" -> "*", "\\$div" -> "/", "\\$bslash" -> "\\\\",
-    "\\$greater" -> ">", "\\$qmark" -> "?", "\\$percent" -> "%",
-    "\\$amp" -> "&", "\\$colon" -> ":", "\\$u2192" -> "→",
-    "\\$hash" -> "#")
+  val _syms = Map(
+    "\\$dot" -> ".", "\\$comma" -> ",", "\\$colon" -> ":",
+    "\\$semicolon" -> ";", "\\$div" -> "/", "\\$bslash" -> "\\\\",
+    "\\$less" -> "<", "\\$greater" -> ">", "\\$u2192" -> "→")
   val pattern = Pattern.compile(_syms.keys.foldLeft("")((x, y) => if (x == "") y else x + "|" + y))
   val placeholderPattern = "_\\$(\\d)+"
 

--- a/test/files/buildmanager/t2792/t2792.check
+++ b/test/files/buildmanager/t2792/t2792.check
@@ -3,7 +3,7 @@ compiling Set(A1.scala, A2.scala, A3.scala)
 Changes: Map()
 builder > A1.scala
 compiling Set(A1.scala)
-Changes: Map(object A -> List(Added(Definition(A.x_$eq)), Changed(Definition(A.x))[value x changed to variable x]))
+Changes: Map(object A -> List(Added(Definition(A.x_=)), Changed(Definition(A.x))[value x changed to variable x]))
 invalidate A2.scala because it references changed definition [Changed(Definition(A.x))[value x changed to variable x]]
 compiling Set(A2.scala)
 A2.scala:2: error: stable identifier required, but A.x found.

--- a/test/files/jvm/annotations.check
+++ b/test/files/jvm/annotations.check
@@ -44,7 +44,7 @@ public Test4$Foo10(java.lang.String)
 private final java.lang.String Test4$Foo11.name
 
 @test.SourceAnnotation(mails={bill.gates@bloodsuckers.com}, value=on param 3)
-public void Test4$Foo12.name_$eq(java.lang.String)
+public void Test4$Foo12.name_=(java.lang.String)
 
 0
 99

--- a/test/files/jvm/deprecation/Test_1.scala
+++ b/test/files/jvm/deprecation/Test_1.scala
@@ -10,7 +10,7 @@ class Test {
   
   @deprecated("no longer!", "") class Inner {
     @deprecated("uncool", "") def f: Int = 1
-    @deprecated("this one as well!", "") var g = -1
+    @beans.BeanProperty @deprecated("this one as well!", "") var g = -1
   }
 }
 

--- a/test/files/jvm/deprecation/Use_2.java
+++ b/test/files/jvm/deprecation/Use_2.java
@@ -4,7 +4,7 @@ class Use_2 {
         Test.Inner a = u.new Inner();
         int i = a.f();
         int j = a.g();
-        a.g_$eq(5);
+        a.setG(5);
         return i + j;
     }
 }

--- a/test/files/pos/t602.scala
+++ b/test/files/pos/t602.scala
@@ -2,7 +2,7 @@ package com.mosol.sl
 
 case class Span[K <: Ordered[K]](low: Option[K], high: Option[K]) extends Function1[K, Boolean] {
   override def equals(x$1: Any): Boolean = x$1 match {
-    case Span((low$0 @ _), (high$0 @ _)) if low$0.equals(low).$amp$amp(high$0.equals(high)) => true
+    case Span((low$0 @ _), (high$0 @ _)) if low$0.equals(low).&&(high$0.equals(high)) => true
     case _ => false
   }
   def apply(k: K): Boolean = this match {

--- a/test/files/run/exoticnames.scala
+++ b/test/files/run/exoticnames.scala
@@ -1,7 +1,18 @@
 // this is a run-test because the compiler should emit bytecode that'll pass the JVM's verifier
+// See https://blogs.oracle.com/jrose/entry/symbolic_freedom_in_the_vm for more information
+// on dangerous characters.
 object Test extends App {
-  def `(` = error("bla")
-  def `.` = error("bla")
-  def `)` = error("bla")
-  def `,` = error("bla")
+  def `.` = ???
+  def `,` = ???
+  def `:` = ???
+  def `;` = ???
+  def `/` = ???
+  def `\\`= ???
+  def `(` = ???
+  def `)` = ???
+  def `[` = ???
+  def `]` = ???
+  def `<` = ???
+  def `>` = ???
+  def `\u0000` = ???
 }

--- a/test/files/run/macro-basic-ma-md-mi/Impls_1.scala
+++ b/test/files/run/macro-basic-ma-md-mi/Impls_1.scala
@@ -3,19 +3,19 @@ import scala.reflect.macros.{Context => Ctx}
 object Impls {
   def foo(c: Ctx)(x: c.Expr[Int]): c.Expr[Int] = {
     import c.universe._
-    val body = Apply(Select(x.tree, newTermName("$plus")), List(Literal(Constant(1))))
+    val body = Apply(Select(x.tree, newTermName("+")), List(Literal(Constant(1))))
     c.Expr[Int](body)
   }
 
   def bar(c: Ctx)(x: c.Expr[Int]): c.Expr[Int] = {
     import c.universe._
-    val body = Apply(Select(x.tree, newTermName("$plus")), List(Literal(Constant(2))))
+    val body = Apply(Select(x.tree, newTermName("+")), List(Literal(Constant(2))))
     c.Expr[Int](body)
   }
 
   def quux(c: Ctx)(x: c.Expr[Int]): c.Expr[Int] = {
     import c.universe._
-    val body = Apply(Select(x.tree, newTermName("$plus")), List(Literal(Constant(3))))
+    val body = Apply(Select(x.tree, newTermName("+")), List(Literal(Constant(3))))
     c.Expr[Int](body)
   }
 }

--- a/test/files/run/macro-basic-ma-mdmi/Impls_Macros_1.scala
+++ b/test/files/run/macro-basic-ma-mdmi/Impls_Macros_1.scala
@@ -3,19 +3,19 @@ import scala.reflect.macros.{Context => Ctx}
 object Impls {
   def foo(c: Ctx)(x: c.Expr[Int]): c.Expr[Int] = {
     import c.universe._
-    val body = Apply(Select(x.tree, newTermName("$plus")), List(Literal(Constant(1))))
+    val body = Apply(Select(x.tree, newTermName("+")), List(Literal(Constant(1))))
     c.Expr[Int](body)
   }
 
   def bar(c: Ctx)(x: c.Expr[Int]): c.Expr[Int] = {
     import c.universe._
-    val body = Apply(Select(x.tree, newTermName("$plus")), List(Literal(Constant(2))))
+    val body = Apply(Select(x.tree, newTermName("+")), List(Literal(Constant(2))))
     c.Expr[Int](body)
   }
 
   def quux(c: Ctx)(x: c.Expr[Int]): c.Expr[Int] = {
     import c.universe._
-    val body = Apply(Select(x.tree, newTermName("$plus")), List(Literal(Constant(3))))
+    val body = Apply(Select(x.tree, newTermName("+")), List(Literal(Constant(3))))
     c.Expr[Int](body)
   }
 }

--- a/test/files/run/macro-basic-mamd-mi/Impls_1.scala
+++ b/test/files/run/macro-basic-mamd-mi/Impls_1.scala
@@ -3,17 +3,17 @@ import scala.reflect.macros.{Context => Ctx}
 object Impls {
   def foo(c: Ctx)(x: c.Expr[Int]): c.Expr[Int] = {
     import c.universe._
-    c.Expr(Apply(Select(x.tree, newTermName("$plus")), List(Literal(Constant(1)))))
+    c.Expr(Apply(Select(x.tree, newTermName("+")), List(Literal(Constant(1)))))
   }
 
   def bar(c: Ctx)(x: c.Expr[Int]): c.Expr[Int] = {
     import c.universe._
-    c.Expr(Apply(Select(x.tree, newTermName("$plus")), List(Literal(Constant(2)))))
+    c.Expr(Apply(Select(x.tree, newTermName("+")), List(Literal(Constant(2)))))
   }
 
   def quux(c: Ctx)(x: c.Expr[Int]): c.Expr[Int] = {
     import c.universe._
-    val body = Apply(Select(x.tree, newTermName("$plus")), List(Literal(Constant(3))))
+    val body = Apply(Select(x.tree, newTermName("+")), List(Literal(Constant(3))))
     c.Expr[Int](body)
   }
 }

--- a/test/files/run/macro-expand-multiple-arglists/Impls_1.scala
+++ b/test/files/run/macro-expand-multiple-arglists/Impls_1.scala
@@ -3,7 +3,7 @@ import scala.reflect.macros.{Context => Ctx}
 object Impls {
   def foo(c: Ctx)(x: c.Expr[Int])(y: c.Expr[Int]) = {
     import c.universe._
-    val sum = Apply(Select(x.tree, newTermName("$minus")), List(y.tree))
+    val sum = Apply(Select(x.tree, newTermName("-")), List(y.tree))
     val body = Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(sum))
     c.Expr[Unit](body)
   }

--- a/test/files/run/macro-range/Expansion_Impossible_2.scala
+++ b/test/files/run/macro-range/Expansion_Impossible_2.scala
@@ -24,7 +24,7 @@ object Impls {
         val cond = makeBinop(iref, "$less", href)
         val body = Block(
             List(makeApply(f.tree, List(iref))),
-            Assign(iref, makeBinop(iref, "$plus", Literal(Constant(1)))))
+            Assign(iref, makeBinop(iref, "+", Literal(Constant(1)))))
         val generated =
         Block(
           List(

--- a/test/files/run/macro-reflective-ma-normal-mdmi/Impls_Macros_1.scala
+++ b/test/files/run/macro-reflective-ma-normal-mdmi/Impls_Macros_1.scala
@@ -3,7 +3,7 @@ import scala.reflect.macros.{Context => Ctx}
 object Impls {
   def foo(c: Ctx)(x: c.Expr[Int]) = {
     import c.universe._
-    val body = Apply(Select(x.tree, newTermName("$plus")), List(Literal(Constant(1))))
+    val body = Apply(Select(x.tree, newTermName("+")), List(Literal(Constant(1))))
     c.Expr[Int](body)
   }
 }

--- a/test/files/run/macro-reflective-mamd-normal-mi/Impls_1.scala
+++ b/test/files/run/macro-reflective-mamd-normal-mi/Impls_1.scala
@@ -3,7 +3,7 @@ import scala.reflect.macros.{Context => Ctx}
 object Impls {
   def foo(c: Ctx)(x: c.Expr[Int]) = {
     import c.universe._
-    val body = Apply(Select(x.tree, newTermName("$plus")), List(Literal(Constant(1))))
+    val body = Apply(Select(x.tree, newTermName("+")), List(Literal(Constant(1))))
     c.Expr[Int](body)
   }
 }

--- a/test/files/run/macro-reify-freevars/Test_2.scala
+++ b/test/files/run/macro-reify-freevars/Test_2.scala
@@ -4,7 +4,7 @@ object Test extends App {
   import scala.tools.reflect.ToolBox
   val q = New(AppliedTypeTree(Select(Select(Select(Ident(newTermName("scala")), newTermName("collection")), newTermName("slick")), newTypeName("Queryable")), List(Ident(newTermName("Int")))))
   val x = ValDef(NoMods, newTermName("x"), Ident(newTermName("Int")), EmptyTree)
-  val fn = Function(List(x), Apply(Select(Ident(newTermName("x")), newTermName("$plus")), List(Literal(Constant("5")))))
+  val fn = Function(List(x), Apply(Select(Ident(newTermName("x")), newTermName("+")), List(Literal(Constant("5")))))
   val tree = Apply(Select(q, newTermName("map")), List(fn))
   try cm.mkToolBox().eval(tree)
   catch { case ex: Throwable =>  println(ex.getMessage) }

--- a/test/files/run/macro-reify-unreify/Macros_1.scala
+++ b/test/files/run/macro-reify-unreify/Macros_1.scala
@@ -9,7 +9,7 @@ object Macros {
       import treeBuild._
 
       val world = c.reifyTree(mkRuntimeUniverseRef, EmptyTree, s.tree)
-      val greeting = c.reifyTree(mkRuntimeUniverseRef, EmptyTree, c.typeCheck(Apply(Select(Literal(Constant("hello ")), newTermName("$plus")), List(c.unreifyTree(world)))))
+      val greeting = c.reifyTree(mkRuntimeUniverseRef, EmptyTree, c.typeCheck(Apply(Select(Literal(Constant("hello ")), newTermName("+")), List(c.unreifyTree(world)))))
       val typedGreeting = c.Expr[String](greeting)
 
       c.universe.reify {

--- a/test/files/run/macro-repl-basic.check
+++ b/test/files/run/macro-repl-basic.check
@@ -14,19 +14,19 @@ scala>
 scala> object Impls {
   def foo(c: Ctx)(x: c.Expr[Int]) = {
     import c.universe._
-    val body = Apply(Select(x.tree, newTermName("$plus")), List(Literal(Constant(1))))
+    val body = Apply(Select(x.tree, newTermName("+")), List(Literal(Constant(1))))
     c.Expr[Int](body)
   }
 
   def bar(c: Ctx)(x: c.Expr[Int]) = {
     import c.universe._
-    val body = Apply(Select(x.tree, newTermName("$plus")), List(Literal(Constant(2))))
+    val body = Apply(Select(x.tree, newTermName("+")), List(Literal(Constant(2))))
     c.Expr[Int](body)
   }
 
   def quux(c: Ctx)(x: c.Expr[Int]) = {
     import c.universe._
-    val body = Apply(Select(x.tree, newTermName("$plus")), List(Literal(Constant(3))))
+    val body = Apply(Select(x.tree, newTermName("+")), List(Literal(Constant(3))))
     c.Expr[Int](body)
   }
 }

--- a/test/files/run/macro-repl-basic.scala
+++ b/test/files/run/macro-repl-basic.scala
@@ -8,19 +8,19 @@ object Test extends ReplTest {
     |object Impls {
     |  def foo(c: Ctx)(x: c.Expr[Int]) = {
     |    import c.universe._
-    |    val body = Apply(Select(x.tree, newTermName("$plus")), List(Literal(Constant(1))))
+    |    val body = Apply(Select(x.tree, newTermName("+")), List(Literal(Constant(1))))
     |    c.Expr[Int](body)
     |  }
     |
     |  def bar(c: Ctx)(x: c.Expr[Int]) = {
     |    import c.universe._
-    |    val body = Apply(Select(x.tree, newTermName("$plus")), List(Literal(Constant(2))))
+    |    val body = Apply(Select(x.tree, newTermName("+")), List(Literal(Constant(2))))
     |    c.Expr[Int](body)
     |  }
     |
     |  def quux(c: Ctx)(x: c.Expr[Int]) = {
     |    import c.universe._
-    |    val body = Apply(Select(x.tree, newTermName("$plus")), List(Literal(Constant(3))))
+    |    val body = Apply(Select(x.tree, newTermName("+")), List(Literal(Constant(3))))
     |    c.Expr[Int](body)
     |  }
     |}

--- a/test/files/run/macro-typecheck-implicitsdisabled/Impls_Macros_1.scala
+++ b/test/files/run/macro-typecheck-implicitsdisabled/Impls_Macros_1.scala
@@ -4,7 +4,7 @@ object Macros {
   def impl_with_implicits_enabled(c: Context) = {
     import c.universe._
 
-    val tree1 = Apply(Select(Literal(Constant(1)), newTermName("$minus$greater")), List(Literal(Constant(2))))
+    val tree1 = Apply(Select(Literal(Constant(1)), newTermName("-$greater")), List(Literal(Constant(2))))
     val ttree1 = c.typeCheck(tree1, withImplicitViewsDisabled = false)
     c.literal(ttree1.toString)
   }
@@ -15,7 +15,7 @@ object Macros {
     import c.universe._
 
     try {
-      val tree2 = Apply(Select(Literal(Constant(1)), newTermName("$minus$greater")), List(Literal(Constant(2))))
+      val tree2 = Apply(Select(Literal(Constant(1)), newTermName("-$greater")), List(Literal(Constant(2))))
       val ttree2 = c.typeCheck(tree2, withImplicitViewsDisabled = true)
       c.literal(ttree2.toString)
     } catch {

--- a/test/files/run/reflection-fieldmirror-accessorsareokay.scala
+++ b/test/files/run/reflection-fieldmirror-accessorsareokay.scala
@@ -25,5 +25,5 @@ object Test extends App {
   }
 
   test(cs.typeSignature.declaration(newTermName("x")).asTerm)
-  test(cs.typeSignature.declaration(newTermName("x_$eq")).asTerm)
+  test(cs.typeSignature.declaration(newTermName("x_=")).asTerm)
 }

--- a/test/files/run/reify_ann1a.check
+++ b/test/files/run/reify_ann1a.check
@@ -6,9 +6,9 @@
       ()
     };
     @new ann(immutable.this.List.apply("5a")) @new ann(immutable.this.List.apply("5b")) def f(x: Int @ann(immutable.this.List.apply("6a")) @ann(immutable.this.List.apply("6b"))) = {
-      @new ann(immutable.this.List.apply("7a")) @new ann(immutable.this.List.apply("7b")) val r = x.$plus(3): @ann(immutable.this.List.apply("8a")): @ann(immutable.this.List.apply("8b"));
+      @new ann(immutable.this.List.apply("7a")) @new ann(immutable.this.List.apply("7b")) val r = x.+(3): @ann(immutable.this.List.apply("8a")): @ann(immutable.this.List.apply("8b"));
       val s = (4: Int @ann(immutable.this.List.apply("9a")) @ann(immutable.this.List.apply("9b")));
-      r.$plus(s)
+      r.+(s)
     }
   };
   ()

--- a/test/files/run/reify_ann1b.check
+++ b/test/files/run/reify_ann1b.check
@@ -6,9 +6,9 @@
       ()
     };
     @new ann(bar = "5a") @new ann(bar = "5b") def f(x: Int @ann(bar = "6a") @ann(bar = "6b")) = {
-      @new ann(bar = "7a") @new ann(bar = "7b") val r = x.$plus(3): @ann(bar = "8a"): @ann(bar = "8b");
+      @new ann(bar = "7a") @new ann(bar = "7b") val r = x.+(3): @ann(bar = "8a"): @ann(bar = "8b");
       val s = (4: Int @ann(bar = "9a") @ann(bar = "9b"));
-      r.$plus(s)
+      r.+(s)
     }
   };
   ()

--- a/test/files/run/reify_ann2a.check
+++ b/test/files/run/reify_ann2a.check
@@ -13,9 +13,9 @@
       ()
     };
     @new ann(immutable.this.List.apply("5a")) @new ann(immutable.this.List.apply("5b")) def f(x: Int @ann(immutable.this.List.apply("6a")) @ann(immutable.this.List.apply("6b"))) = {
-      @new ann(immutable.this.List.apply("7a")) @new ann(immutable.this.List.apply("7b")) val r = x.$plus(3): @ann(immutable.this.List.apply("8a")): @ann(immutable.this.List.apply("8b"));
+      @new ann(immutable.this.List.apply("7a")) @new ann(immutable.this.List.apply("7b")) val r = x.+(3): @ann(immutable.this.List.apply("8a")): @ann(immutable.this.List.apply("8b"));
       val s = (4: Int @ann(immutable.this.List.apply("9a")) @ann(immutable.this.List.apply("9b")));
-      r.$plus(s)
+      r.+(s)
     }
   };
   ()

--- a/test/files/run/t5271_2.check
+++ b/test/files/run/t5271_2.check
@@ -8,7 +8,7 @@
     }
   };
   val c = C.apply(2, 2);
-  scala.this.Predef.println(c.foo.$times(c.bar))
+  scala.this.Predef.println(c.foo.*(c.bar))
 }
 4
 ()

--- a/test/files/run/t5271_3.check
+++ b/test/files/run/t5271_3.check
@@ -15,7 +15,7 @@
     }
   };
   val c = C.apply(2, 2);
-  scala.this.Predef.println(c.foo.$times(c.bar).$eq$eq(C.qwe))
+  scala.this.Predef.println(c.foo.*(c.bar).==(C.qwe))
 }
 true
 ()

--- a/test/files/run/t5603.check
+++ b/test/files/run/t5603.check
@@ -5,7 +5,7 @@
       [15]()
     };
     [23:39]val name: [33:39]String;
-    [46:76]val msg = [56:76][56:72][56:71]"How are you, ".$plus([72:76]name)
+    [46:76]val msg = [56:76][56:72][56:71]"How are you, ".+([72:76]name)
   };
   [87:209]class C extends [94:209][151:159]Greeting {
     [119:139]val nameElse = _;

--- a/test/files/run/t6178.scala
+++ b/test/files/run/t6178.scala
@@ -2,6 +2,6 @@ import scala.reflect.runtime.universe._
 import scala.reflect.runtime.{currentMirror => cm}
 
 object Test extends App {
-  val plus = typeOf[java.lang.String].member(newTermName("$plus")).asMethod
+  val plus = typeOf[java.lang.String].member(newTermName("+")).asMethod
   println(cm.reflect("").reflectMethod(plus).apply("2"))
 }

--- a/test/files/run/t6549.check
+++ b/test/files/run/t6549.check
@@ -4,7 +4,7 @@ Type :help for more information.
 scala> 
 
 scala> case class `X"`(var xxx: Any)
-defined class X$u0022
+defined class X$quot
 
 scala> val m = Map(("": Any) -> `X"`("\""), ('s: Any) -> `X"`("\""))
 m: scala.collection.immutable.Map[Any,X"] = Map("" -> X"("), 's -> X"("))

--- a/test/files/run/toolbox_typecheck_implicitsdisabled.scala
+++ b/test/files/run/toolbox_typecheck_implicitsdisabled.scala
@@ -8,7 +8,7 @@ object Test extends App {
 
   val tree1 = Block(List(
     Import(Select(Ident(newTermName("scala")), newTermName("Predef")), List(ImportSelector(nme.WILDCARD, -1, null, -1)))),
-    Apply(Select(Literal(Constant(1)), newTermName("$minus$greater")), List(Literal(Constant(2))))
+    Apply(Select(Literal(Constant(1)), newTermName("-$greater")), List(Literal(Constant(2))))
   )
   val ttree1 = toolbox.typeCheck(tree1, withImplicitViewsDisabled = false)
   println(ttree1)
@@ -16,7 +16,7 @@ object Test extends App {
   try {
     val tree2 = Block(List(
       Import(Select(Ident(newTermName("scala")), newTermName("Predef")), List(ImportSelector(nme.WILDCARD, -1, null, -1)))),
-      Apply(Select(Literal(Constant(1)), newTermName("$minus$greater")), List(Literal(Constant(2))))
+      Apply(Select(Literal(Constant(1)), newTermName("-$greater")), List(Literal(Constant(2))))
     )
     val ttree2 = toolbox.typeCheck(tree2, withImplicitViewsDisabled = true)
     println(ttree2)


### PR DESCRIPTION
While the list of exceptions hasn't changed much in size,
non-dangerous method names like + and ??? as well as 99% of the
character plane which were formerly name-mangled with $uXXXX appear
now as-is in stacktraces, other places and tools not specificially
written with Scala's name-mangling in mind.

The changes are mostly in line with the recommendations for the JVM
(look for "symbolic freedom"), except for the list of exceptions
which currently keep using the $-style mangling instead of the suggested
backslash-style (example: / is currently encoded as $slash, the
guidelines recommend |) due to readability concerns.

The improvements to readability are impressive, imho.
Another benefit is that people have to deal with a lot less mangled
names when working with macros.
