### PR TITLE
nested closures are flattened by calling supplementErrorMessage() directly

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -228,13 +228,15 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
   // of assert and require (but for now I've reproduced them here,
   // because there are a million to fix.)
   @inline final def assert(assertion: Boolean, message: => Any) {
-    Predef.assert(assertion, supplementErrorMessage("" + message))
+    if (!assertion)
+      throw new java.lang.AssertionError("assertion failed: "+ supplementErrorMessage("" + message))
   }
   @inline final def assert(assertion: Boolean) {
     assert(assertion, "")
   }
   @inline final def require(requirement: Boolean, message: => Any) {
-    Predef.require(requirement, supplementErrorMessage("" + message))
+    if (!requirement)
+      throw new IllegalArgumentException("requirement failed: "+ supplementErrorMessage("" + message))
   }
   @inline final def require(requirement: Boolean) {
     require(requirement, "")

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -228,6 +228,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
   // of assert and require (but for now I've reproduced them here,
   // because there are a million to fix.)
   @inline final def assert(assertion: Boolean, message: => Any) {
+    // calling Predef.assert would send a freshly allocated closure wrapping the one received as argument.
     if (!assertion)
       throw new java.lang.AssertionError("assertion failed: "+ supplementErrorMessage("" + message))
   }
@@ -235,6 +236,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
     assert(assertion, "")
   }
   @inline final def require(requirement: Boolean, message: => Any) {
+    // calling Predef.require would send a freshly allocated closure wrapping the one received as argument.
     if (!requirement)
       throw new IllegalArgumentException("requirement failed: "+ supplementErrorMessage("" + message))
   }


### PR DESCRIPTION
A closure C that becomes an argument to the constructor of another closure makes both closures harder to eliminate (either by scalac-optimizer or JIT-compiler) than is the case when C is the argument to an @ inline method.

In the same vein as https://github.com/scala/scala/pull/1823

review by @JamesIry or @paulp
