### PR TITLE
SI-6897, lubs and varargs star.

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -6801,7 +6801,10 @@ trait Types extends api.Types { self: SymbolTable =>
             else lubBase
           }
         }
-      existentialAbstraction(tparams, lubType)
+      // dropRepeatedParamType is a localized fix for SI-6897. We should probably
+      // integrate that transformation at a lower level in master, but lubs are
+      // the likely and maybe only spot they escape, so fixing here for 2.10.1.
+      existentialAbstraction(tparams, dropRepeatedParamType(lubType))
     }
     if (printLubs) {
       println(indent + "lub of " + ts + " at depth "+depth)//debug

--- a/test/files/pos/t6897.scala
+++ b/test/files/pos/t6897.scala
@@ -1,0 +1,6 @@
+class A {
+  val html = (null: Any) match {
+    case 1 => <xml:group></xml:group>
+    case 2 => <p></p>
+  }
+}


### PR DESCRIPTION
Don't allow lubs to calculate refinement types which contain
a varargs star outside of legal varargs star position.
