### PR TITLE
SI-6594 - Switch to sneakyThrows instead of Unsafe.throwException as per...

### DIFF
--- a/src/forkjoin/scala/concurrent/forkjoin/ForkJoinPool.java
+++ b/src/forkjoin/scala/concurrent/forkjoin/ForkJoinPool.java
@@ -1372,7 +1372,7 @@ public class ForkJoinPool extends AbstractExecutorService {
         }
 
         if (ex != null)                     // rethrow
-            U.throwException(ex);
+            ForkJoinTask.rethrow(ex);
     }
 
 

--- a/src/forkjoin/scala/concurrent/forkjoin/ForkJoinTask.java
+++ b/src/forkjoin/scala/concurrent/forkjoin/ForkJoinTask.java
@@ -595,6 +595,30 @@ public abstract class ForkJoinTask<V> implements Future<V>, Serializable {
             }
         }
     }
+    
+    /**
+     * A version of "sneaky throw" to relay exceptions
+     */
+    static void rethrow(final Throwable ex) {
+        if (ex != null) {
+            if (ex instanceof Error)
+                throw (Error)ex;
+            if (ex instanceof RuntimeException)
+                throw (RuntimeException)ex;
+            ForkJoinTask.<RuntimeException>uncheckedThrow(ex);
+        }
+    }
+
+    /**
+     * The sneaky part of sneaky throw, relying on generics
+     * limitations to evade compiler complaints about rethrowing
+     * unchecked exceptions
+     */
+    @SuppressWarnings("unchecked") static <T extends Throwable>
+        void uncheckedThrow(Throwable t) throws T {
+        if (t != null)
+            throw (T)t; // rely on vacuous cast
+    }
 
     /**
      * Throws exception, if any, associated with the given status.
@@ -604,7 +628,7 @@ public abstract class ForkJoinTask<V> implements Future<V>, Serializable {
                         (s == EXCEPTIONAL) ? getThrowableException() :
                         null);
         if (ex != null)
-            U.throwException(ex);
+            ForkJoinTask.rethrow(ex);
     }
 
     // public methods
@@ -742,7 +766,7 @@ public abstract class ForkJoinTask<V> implements Future<V>, Serializable {
             }
         }
         if (ex != null)
-            U.throwException(ex);
+            ForkJoinTask.rethrow(ex);
     }
 
     /**
@@ -799,7 +823,7 @@ public abstract class ForkJoinTask<V> implements Future<V>, Serializable {
             }
         }
         if (ex != null)
-            U.throwException(ex);
+            ForkJoinTask.rethrow(ex);
         return tasks;
     }
 


### PR DESCRIPTION
... new jsr166y to avoid issues with Android

(was previously SI-6905 but that was a duplicate)

See: https://issues.scala-lang.org/browse/SI-6594

Since code is lifted from the jsr166y repo and there is no test suite for FJ embedded in scala-lib I assume this is how we roll.

This of course also needs forwardporting. 
