### PR TITLE
SI-6908 Makes FlatHashTable as well as derived classes support nulls

### DIFF
--- a/src/library/scala/collection/mutable/FlatHashTable.scala
+++ b/src/library/scala/collection/mutable/FlatHashTable.scala
@@ -87,9 +87,9 @@ trait FlatHashTable[A] extends FlatHashTable.HashUtils[A] {
 
     var index = 0
     while (index < size) {
-      val elem = in.readObject().asInstanceOf[A]
+      val elem = entryToElem(in.readObject())
       f(elem)
-      addEntry(elem)
+      addElem(elem)
       index += 1
     }
   }
@@ -110,60 +110,72 @@ trait FlatHashTable[A] extends FlatHashTable.HashUtils[A] {
 
   /** Finds an entry in the hash table if such an element exists. */
   protected def findEntry(elem: A): Option[A] = {
-    val entry = findEntryImpl(elem)
-    if (null == entry) None else Some(entry.asInstanceOf[A])
+    val entry = findElemImpl(elem)
+    if (null == entry) None else Some(entryToElem(entry))
   }
 
   /** Checks whether an element is contained in the hash table. */
-  protected def containsEntry(elem: A): Boolean = {
-    null != findEntryImpl(elem)
+  protected def containsElem(elem: A): Boolean = {
+    null != findElemImpl(elem)
   }
 
-  private def findEntryImpl(elem: A): AnyRef = {
-    var h = index(elemHashCode(elem))
-    var entry = table(h)
-    while (null != entry && entry != elem) {
+  private def findElemImpl(elem: A): AnyRef = {
+    var searchEntry = elemToEntry(elem)
+    var h = index(searchEntry.hashCode)
+    var curEntry = table(h)
+    while (null != curEntry && curEntry != searchEntry) {
       h = (h + 1) % table.length
-      entry = table(h)
+      curEntry = table(h)
     }
-    entry
+    curEntry
   }
 
-  /** Add entry if not yet in table.
-   *  @return Returns `true` if a new entry was added, `false` otherwise.
+  /** Add elem if not yet in table.
+   *  @return Returns `true` if a new elem was added, `false` otherwise.
    */
-  protected def addEntry(elem: A) : Boolean = {
-    var h = index(elemHashCode(elem))
-    var entry = table(h)
-    while (null != entry) {
-      if (entry == elem) return false
+  protected def addElem(elem: A) : Boolean = {
+    addEntry(elemToEntry(elem))
+  }
+  
+  /**
+   * Add an entry (an elem converted to an entry via elemToEntry) if not yet in
+   * table. 
+   *  @return Returns `true` if a new elem was added, `false` otherwise.
+   */
+  protected def addEntry(newEntry : AnyRef) : Boolean = {
+    var h = index(newEntry.hashCode)
+    var curEntry = table(h)
+    while (null != curEntry) {
+      if (curEntry == newEntry) return false
       h = (h + 1) % table.length
-      entry = table(h)
+      curEntry = table(h)
       //Statistics.collisions += 1
     }
-    table(h) = elem.asInstanceOf[AnyRef]
+    table(h) = newEntry
     tableSize = tableSize + 1
     nnSizeMapAdd(h)
     if (tableSize >= threshold) growTable()
     true
+    
   }
 
-  /** Removes an entry from the hash table, returning an option value with the element, or `None` if it didn't exist. */
-  protected def removeEntry(elem: A) : Option[A] = {
+  /** Removes an elem from the hash table, returning an option value with the element, or `None` if it didn't exist. */
+  protected def removeElem(elem: A) : Option[A] = {
     if (tableDebug) checkConsistent()
     def precedes(i: Int, j: Int) = {
       val d = table.length >> 1
       if (i <= j) j - i < d
       else i - j > d
     }
-    var h = index(elemHashCode(elem))
-    var entry = table(h)
-    while (null != entry) {
-      if (entry == elem) {
+    val removalEntry = elemToEntry(elem)
+    var h = index(removalEntry.hashCode)
+    var curEntry = table(h)
+    while (null != curEntry) {
+      if (curEntry == removalEntry) {
         var h0 = h
         var h1 = (h0 + 1) % table.length
         while (null != table(h1)) {
-          val h2 = index(elemHashCode(table(h1).asInstanceOf[A]))
+          val h2 = index(table(h1).hashCode)
           //Console.println("shift at "+h1+":"+table(h1)+" with h2 = "+h2+"? "+(h2 != h1)+precedes(h2, h0)+table.length)
           if (h2 != h1 && precedes(h2, h0)) {
             //Console.println("shift "+h1+" to "+h0+"!")
@@ -176,10 +188,10 @@ trait FlatHashTable[A] extends FlatHashTable.HashUtils[A] {
         tableSize -= 1
         nnSizeMapRemove(h0)
         if (tableDebug) checkConsistent()
-        return Some(entry.asInstanceOf[A])
+        return Some(entryToElem(curEntry))
       }
       h = (h + 1) % table.length
-      entry = table(h)
+      curEntry = table(h)
     }
     None
   }
@@ -191,7 +203,7 @@ trait FlatHashTable[A] extends FlatHashTable.HashUtils[A] {
       i < table.length
     }
     def next(): A =
-      if (hasNext) { i += 1; table(i - 1).asInstanceOf[A] }
+      if (hasNext) { i += 1; entryToElem(table(i - 1)) }
       else Iterator.empty.next
   }
 
@@ -205,7 +217,7 @@ trait FlatHashTable[A] extends FlatHashTable.HashUtils[A] {
     var i = 0
     while (i < oldtable.length) {
       val entry = oldtable(i)
-      if (null != entry) addEntry(entry.asInstanceOf[A])
+      if (null != entry) addEntry(entry)
       i += 1
     }
     if (tableDebug) checkConsistent()
@@ -213,9 +225,10 @@ trait FlatHashTable[A] extends FlatHashTable.HashUtils[A] {
 
   private def checkConsistent() {
     for (i <- 0 until table.length)
-      if (table(i) != null && !containsEntry(table(i).asInstanceOf[A]))
+      if (table(i) != null && !containsElem(entryToElem(table(i))))
         assert(false, i+" "+table(i)+" "+table.mkString)
   }
+ 
 
   /* Size map handling code */
 
@@ -358,6 +371,10 @@ private[collection] object FlatHashTable {
   final def seedGenerator = new ThreadLocal[scala.util.Random] {
     override def initialValue = new scala.util.Random
   }
+  
+  val NullSentinel = new AnyRef {
+    override def hashCode = 0
+  }
 
   /** The load factor for the hash table; must be < 500 (0.5)
    */
@@ -386,10 +403,6 @@ private[collection] object FlatHashTable {
     // so that:
     protected final def sizeMapBucketSize = 1 << sizeMapBucketBitSize
 
-    protected def elemHashCode(elem: A) =
-      if (elem == null) throw new IllegalArgumentException("Flat hash tables cannot contain null elements.")
-      else elem.hashCode()
-
     protected final def improve(hcode: Int, seed: Int) = {
       //var h: Int = hcode + ~(hcode << 9)
       //h = h ^ (h >>> 14)
@@ -404,6 +417,19 @@ private[collection] object FlatHashTable {
       val rotated = (improved >>> rotation) | (improved << (32 - rotation))
       rotated
     }
+         
+    /**
+     * Elems have type A, but we store AnyRef in the table. Plus we need to deal with
+     * null elems, which need to be stored as NullSentinel
+     */
+    protected final def elemToEntry(elem : A) : AnyRef = 
+      if (null == elem) NullSentinel else elem.asInstanceOf[AnyRef]
+    
+    /**
+     * Does the inverse translation of elemToEntry
+     */
+    protected final def entryToElem(entry : AnyRef) : A = 
+      (if (NullSentinel eq entry) null else entry).asInstanceOf[A]
   }
 
 }

--- a/src/library/scala/collection/mutable/FlatHashTable.scala
+++ b/src/library/scala/collection/mutable/FlatHashTable.scala
@@ -17,7 +17,6 @@ package mutable
  *  hash table as an implementation.
  *
  *  @define coll flat hash table
- *  @define cannotStoreNull '''Note''': A $coll cannot store `null` elements.
  *  @since 2.3
  *  @tparam A   the type of the elements contained in the $coll.
  */

--- a/src/library/scala/collection/mutable/FlatHashTable.scala
+++ b/src/library/scala/collection/mutable/FlatHashTable.scala
@@ -108,10 +108,12 @@ trait FlatHashTable[A] extends FlatHashTable.HashUtils[A] {
   }
 
   /** Finds an entry in the hash table if such an element exists. */
-  protected def findEntry(elem: A): Option[A] = {
-    val entry = findElemImpl(elem)
-    if (null == entry) None else Some(entryToElem(entry))
-  }
+  protected def findEntry(elem: A): Option[A] = 
+    findElemImpl(elem) match {
+      case null => None
+      case entry => Some(entryToElem(entry))
+    }
+
 
   /** Checks whether an element is contained in the hash table. */
   protected def containsElem(elem: A): Boolean = {
@@ -119,7 +121,7 @@ trait FlatHashTable[A] extends FlatHashTable.HashUtils[A] {
   }
 
   private def findElemImpl(elem: A): AnyRef = {
-    var searchEntry = elemToEntry(elem)
+    val searchEntry = elemToEntry(elem)
     var h = index(searchEntry.hashCode)
     var curEntry = table(h)
     while (null != curEntry && curEntry != searchEntry) {
@@ -371,8 +373,9 @@ private[collection] object FlatHashTable {
     override def initialValue = new scala.util.Random
   }
   
-  val NullSentinel = new AnyRef {
+  private object NullSentinel {
     override def hashCode = 0
+    override def toString = "NullSentinel"
   }
 
   /** The load factor for the hash table; must be < 500 (0.5)
@@ -428,7 +431,7 @@ private[collection] object FlatHashTable {
      * Does the inverse translation of elemToEntry
      */
     protected final def entryToElem(entry : AnyRef) : A = 
-      (if (NullSentinel eq entry) null else entry).asInstanceOf[A]
+      (if (entry.isInstanceOf[NullSentinel.type]) null else entry).asInstanceOf[A]
   }
 
 }

--- a/src/library/scala/collection/mutable/HashSet.scala
+++ b/src/library/scala/collection/mutable/HashSet.scala
@@ -16,8 +16,6 @@ import scala.collection.parallel.mutable.ParHashSet
 
 /** This class implements mutable sets using a hashtable.
  *
- *  $cannotStoreNull
- *
  *  @author  Matthias Zenger
  *  @author  Martin Odersky
  *  @version 2.0, 31/12/2006

--- a/src/library/scala/collection/mutable/HashSet.scala
+++ b/src/library/scala/collection/mutable/HashSet.scala
@@ -55,17 +55,17 @@ extends AbstractSet[A]
 
   override def size: Int = tableSize
 
-  def contains(elem: A): Boolean = containsEntry(elem)
+  def contains(elem: A): Boolean = containsElem(elem)
 
-  def += (elem: A): this.type = { addEntry(elem); this }
+  def += (elem: A): this.type = { addElem(elem); this }
 
-  def -= (elem: A): this.type = { removeEntry(elem); this }
+  def -= (elem: A): this.type = { removeElem(elem); this }
 
   override def par = new ParHashSet(hashTableContents)
 
-  override def add(elem: A): Boolean = addEntry(elem)
+  override def add(elem: A): Boolean = addElem(elem)
 
-  override def remove(elem: A): Boolean = removeEntry(elem).isDefined
+  override def remove(elem: A): Boolean = removeElem(elem).isDefined
 
   override def clear() { clearTable() }
 
@@ -75,8 +75,8 @@ extends AbstractSet[A]
     var i = 0
     val len = table.length
     while (i < len) {
-      val elem = table(i)
-      if (elem ne null) f(elem.asInstanceOf[A])
+      val curEntry = table(i)
+      if (curEntry ne null) f(entryToElem(curEntry))
       i += 1
     }
   }

--- a/test/files/run/hashset.check
+++ b/test/files/run/hashset.check
@@ -1,0 +1,26 @@
+*** HashSet primitives
+0 true,1 true,10 true,11 true,12 true,13 true,14 true,15 true,16 true,17 true,18 true,19 true,2 true,3 true,4 true,5 true,6 true,7 true,8 true,9 true
+20 false,21 false,22 false,23 false,24 false,25 false,26 false,27 false,28 false,29 false,30 false,31 false,32 false,33 false,34 false,35 false,36 false,37 false,38 false,39 false
+0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19
+
+*** HashSet Strings with null
+null true
+0 true,1 true,10 true,11 true,12 true,13 true,14 true,15 true,16 true,17 true,18 true,19 true,2 true,3 true,4 true,5 true,6 true,7 true,8 true,9 true
+20 false,21 false,22 false,23 false,24 false,25 false,26 false,27 false,28 false,29 false,30 false,31 false,32 false,33 false,34 false,35 false,36 false,37 false,38 false,39 false
+0,1,10,11,12,13,14,15,16,17,18,19,2,3,4,5,6,7,8,9,null
+null false
+0 false,1 true,10 true,11 true,12 true,13 true,14 true,15 true,16 true,17 true,18 true,19 true,2 true,3 true,4 true,5 true,6 true,7 true,8 true,9 true
+
+*** ParHashSet primitives
+0 true,1 true,10 true,11 true,12 true,13 true,14 true,15 true,16 true,17 true,18 true,19 true,2 true,3 true,4 true,5 true,6 true,7 true,8 true,9 true
+20 false,21 false,22 false,23 false,24 false,25 false,26 false,27 false,28 false,29 false,30 false,31 false,32 false,33 false,34 false,35 false,36 false,37 false,38 false,39 false
+0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19
+
+*** ParHashSet Strings with null
+null true
+0 true,1 true,10 true,11 true,12 true,13 true,14 true,15 true,16 true,17 true,18 true,19 true,2 true,3 true,4 true,5 true,6 true,7 true,8 true,9 true
+20 false,21 false,22 false,23 false,24 false,25 false,26 false,27 false,28 false,29 false,30 false,31 false,32 false,33 false,34 false,35 false,36 false,37 false,38 false,39 false
+0,1,10,11,12,13,14,15,16,17,18,19,2,3,4,5,6,7,8,9,null
+null false
+0 false,1 true,10 true,11 true,12 true,13 true,14 true,15 true,16 true,17 true,18 true,19 true,2 true,3 true,4 true,5 true,6 true,7 true,8 true,9 true
+

--- a/test/files/run/hashset.scala
+++ b/test/files/run/hashset.scala
@@ -1,0 +1,48 @@
+import scala.collection.generic.{Growable, Shrinkable}
+import scala.collection.GenSet
+import scala.collection.mutable.FlatHashTable
+import scala.collection.mutable.HashSet
+import scala.collection.parallel.mutable.ParHashSet
+
+object Test extends App {
+  test(new Creator{
+    def create[A] = new HashSet[A]
+    def hashSetType = "HashSet"
+  })
+
+  test(new Creator{
+    def create[A] = new ParHashSet[A]
+    def hashSetType = "ParHashSet"
+  })
+
+
+  def test(creator : Creator) {
+    println("*** " + creator.hashSetType + " primitives")
+    val h1 = creator.create[Int]
+    for (i <- 0 until 20) h1 += i
+    println((for (i <- 0 until 20) yield i + " " + (h1 contains i)).toList.sorted mkString(","))
+    println((for (i <- 20 until 40) yield i + " " + (h1 contains i)).toList.sorted mkString(","))
+    println(h1.toList.sorted mkString ",")
+    println
+
+    println("*** " + creator.hashSetType + " Strings with null")
+    val h2 = creator.create[String]
+    h2 += null
+    for (i <- 0 until 20) h2 +=  "" + i
+    println("null " + (h2 contains null))
+    println((for (i <- 0 until 20) yield i + " " + (h2 contains ("" + i))).toList.sorted mkString(","))
+    println((for (i <- 20 until 40) yield i + " " + (h2 contains ("" + i))).toList.sorted mkString(","))
+    println((h2.toList map {x => "" + x}).sorted mkString ",")
+
+    h2 -= null
+    h2 -= "" + 0
+    println("null " + (h2 contains null))
+    println((for (i <- 0 until 20) yield i + " " + (h2 contains ("" + i))).toList.sorted mkString(","))
+    println
+  }
+ 
+   trait Creator {
+     def create[A] : GenSet[A] with Cloneable with FlatHashTable[A] with Growable[A] with Shrinkable[A] 
+     def hashSetType : String
+  }
+}


### PR DESCRIPTION
This change adds a null sentinel object which is used to indicate that a null
value has been inserted in FlatHashTable. It also makes a strong distinction
between logical elements of the Set vs entries in the hash table. Changes
are made to mutable.HashSet and ParHashSet accordingly.

review by @adriaanm
