### PR TITLE
SI-6915 Updates copyright properties to 2002-2013

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -226,7 +226,7 @@ PROPERTIES
 
   <property name="dists.dir" value="${basedir}/dists"/>
 
-  <property name="copyright.string" value="Copyright 2002-2012, LAMP/EPFL"/>
+  <property name="copyright.string" value="Copyright 2002-2013, LAMP/EPFL"/>
   <property name="partest.version.number" value="0.9.2"/>
 
   <!-- These are NOT the flags used to run SuperSabbus, but the ones written

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -67,7 +67,7 @@ object Versions {
     IO.write(f, "version.number = "+versions.canonical+"\n"+
                 "osgi.number = "+versions.osgi+"\n"+
                 "maven.number = "+versions.maven+"\n"+
-                "copyright.string = Copyright 2002-2012, LAMP/EPFL")
+                "copyright.string = Copyright 2002-2013, LAMP/EPFL")
 
   def makeCanonicalVersion(isRelease: Boolean, mvnVersion: String, base: BaseBuildNumber, gitDate: String, gitSha: String): String =
     if(isRelease) mvnVersion

--- a/src/library/scala/util/Properties.scala
+++ b/src/library/scala/util/Properties.scala
@@ -102,7 +102,7 @@ private[scala] trait PropertiesTrait {
    *  or "version (unknown)" if it cannot be determined.
    */
   val versionString         = "version " + scalaPropOrElse("version.number", "(unknown)")
-  val copyrightString       = scalaPropOrElse("copyright.string", "(c) 2002-2011 LAMP/EPFL")
+  val copyrightString       = scalaPropOrElse("copyright.string", "Copyright 2002-2013, LAMP/EPFL")
 
   /** This is the encoding to use reading in source files, overridden with -encoding
    *  Note that it uses "prop" i.e. looks in the scala jar, not the system properties.


### PR DESCRIPTION
The .scala header files had the right copyright dates
but properties used to generate the information in
e.g. "scala -version" hadn't been updated.

review @adriaanm
