### PR TITLE
SI-6916 makes FlatHashTable#remove a Boolean not Option[A]

### DIFF
--- a/src/library/scala/collection/mutable/FlatHashTable.scala
+++ b/src/library/scala/collection/mutable/FlatHashTable.scala
@@ -160,8 +160,11 @@ trait FlatHashTable[A] extends FlatHashTable.HashUtils[A] {
     
   }
 
-  /** Removes an elem from the hash table, returning an option value with the element, or `None` if it didn't exist. */
-  protected def removeElem(elem: A) : Option[A] = {
+  /** 
+   * Removes an elem from the hash table returning true if the element was found (and thus removed)
+   * or false if it didn't exist.
+   */
+  protected def removeElem(elem: A) : Boolean = {
     if (tableDebug) checkConsistent()
     def precedes(i: Int, j: Int) = {
       val d = table.length >> 1
@@ -189,12 +192,12 @@ trait FlatHashTable[A] extends FlatHashTable.HashUtils[A] {
         tableSize -= 1
         nnSizeMapRemove(h0)
         if (tableDebug) checkConsistent()
-        return Some(entryToElem(curEntry))
+        return true
       }
       h = (h + 1) % table.length
       curEntry = table(h)
     }
-    None
+    false
   }
 
   protected def iterator: Iterator[A] = new AbstractIterator[A] {

--- a/src/library/scala/collection/mutable/HashSet.scala
+++ b/src/library/scala/collection/mutable/HashSet.scala
@@ -63,7 +63,7 @@ extends AbstractSet[A]
 
   override def add(elem: A): Boolean = addElem(elem)
 
-  override def remove(elem: A): Boolean = removeElem(elem).isDefined
+  override def remove(elem: A): Boolean = removeElem(elem)
 
   override def clear() { clearTable() }
 

--- a/test/files/run/hashsetremove.check
+++ b/test/files/run/hashsetremove.check
@@ -1,0 +1,6 @@
+remove 0 should be false, was false
+contains 1 should be true, was true
+remove 1 should be true, was true
+contains 1 should be false, was false
+remove 1 should be false, was false
+contains 1 should be false, was false

--- a/test/files/run/hashsetremove.scala
+++ b/test/files/run/hashsetremove.scala
@@ -1,0 +1,13 @@
+import scala.collection.mutable.HashSet
+
+
+object Test extends App {
+  val h = new HashSet[Int]
+  h += 1
+  println(s"remove 0 should be false, was ${h remove 0}")
+  println(s"contains 1 should be true, was ${h contains 1}")
+  println(s"remove 1 should be true, was ${h remove 1}")
+  println(s"contains 1 should be false, was ${h contains 1}")
+  println(s"remove 1 should be false, was ${h remove 1}")
+  println(s"contains 1 should be false, was ${h contains 1}")
+ }


### PR DESCRIPTION
Makes FlatHashTable#remove return a boolean instead of Option[A].
Updates HashSet accordingly. Adds a test to make sure remove
works as advertised.

review by @paulp
