### PR TITLE
Repl javap decodes various synthetic names for us (fixing SI-6894)

### DIFF
--- a/src/compiler/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/IMain.scala
@@ -953,7 +953,7 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
    */
   def tryTwice(op: => Symbol): Symbol = exitingTyper(op) orElse exitingFlatten(op)
 
-  def symbolOfIdent(id: String): Symbol  = symbolOfTerm(id) orElse symbolOfType(id)
+  def symbolOfIdent(id: String): Symbol  = symbolOfType(id) orElse symbolOfTerm(id)
   def symbolOfType(id: String): Symbol   = tryTwice(replScope lookup (id: TypeName))
   def symbolOfTerm(id: String): Symbol   = tryTwice(replScope lookup (id: TermName))
   def symbolOfName(id: Name): Symbol     = replScope lookup id

--- a/src/partest/scala/tools/partest/JavapTest.scala
+++ b/src/partest/scala/tools/partest/JavapTest.scala
@@ -1,0 +1,26 @@
+
+package scala.tools.partest
+
+import scala.util.{Try,Success,Failure}
+import java.lang.System.{out => sysout}
+
+/** A trait for testing repl's javap command
+ *  or possibly examining its output.
+ */
+abstract class JavapTest extends ReplTest {
+
+  /** Your Assertion Here, whatever you want to bejahen.
+   *  Assertions must be satisfied by all flavors of javap
+   *  and should not be fragile with respect to compiler output.
+   */
+  def yah(res: Seq[String]): Boolean
+
+  def baddies = List(":javap unavailable", ":javap not yet working")
+
+  // give it a pass if javap is broken
+  override def show() = try {
+    val res = eval().toSeq
+    val unsupported = res exists (s => baddies exists (s contains _))
+    assert ((unsupported || yah(res)), res.mkString("","\n","\n"))
+  } catch { case ae: AssertionError => ae.printStackTrace(sysout) }
+}

--- a/test/files/run/repl-javap-def.scala
+++ b/test/files/run/repl-javap-def.scala
@@ -1,0 +1,17 @@
+import scala.tools.partest.JavapTest
+
+object Test extends JavapTest {
+  def code = """
+    |def f = 7
+    |:javap -public -raw f
+  """.stripMargin
+
+  // it should find f wrapped in repl skins. replstiltskin.
+  override def yah(res: Seq[String]) = {
+    // replstiltskin: what be my name?
+    val keywords = List("public", "class", "line")
+    def isLineClass(s: String) = keywords forall (s contains _)
+    def filtered = res filter isLineClass
+    1 == filtered.size
+  }
+}

--- a/test/files/run/repl-javap-fun.scala
+++ b/test/files/run/repl-javap-fun.scala
@@ -1,0 +1,16 @@
+import scala.tools.partest.JavapTest
+
+object Test extends JavapTest {
+  def code = """
+    |object Betty {
+    | List(1,2,3) filter (_ % 2 != 0) map (_ * 2)
+    |}
+    |:javap -fun Betty
+  """.stripMargin
+
+  // two anonfuns of Betty
+  override def yah(res: Seq[String]) = {
+    def filtered = res filter (_ contains "public final class Betty")
+    2 == filtered.size
+  }
+}

--- a/test/files/run/repl-javap-mem.scala
+++ b/test/files/run/repl-javap-mem.scala
@@ -1,0 +1,19 @@
+import scala.tools.partest.JavapTest
+
+object Test extends JavapTest {
+  def code = """
+    |object Betty {
+    |  val ds = List(1,2,3) filter (_ % 2 == 0) map (_ * 3)
+    |  def m(vs: List[Int]) = vs filter (_ % 2 != 0) map (_ * 2)
+    |}
+    |:javap Betty#m
+  """.stripMargin
+
+  // filter for requested method member
+  override def yah(res: Seq[String]) = {
+    // cheaply, methods end in arg list
+    val p = """.*m\(.*\);""".r
+    def filtered = res filter (_ match { case p() => true case _ => false })
+    1 == filtered.size
+  }
+}

--- a/test/files/run/repl-javap-memfun.scala
+++ b/test/files/run/repl-javap-memfun.scala
@@ -1,0 +1,18 @@
+import scala.tools.partest.JavapTest
+
+object Test extends JavapTest {
+  def code = """
+    |object Betty {
+    | List(1,2,3) count (_ % 2 != 0)
+    | def f = List(1,2,3) filter (_ % 2 != 0) map (_ * 2)
+    | def g = List(1,2,3) filter (_ % 2 == 0) map (_ * 3) map (_ + 1)
+    |}
+    |:javap -fun Betty#g
+  """.stripMargin
+
+  // three anonfuns of Betty#g
+  override def yah(res: Seq[String]) = {
+    def filtered = res filter (_ contains "public final class Betty")
+    3 == filtered.size
+  }
+}

--- a/test/files/run/repl-javap-more-fun.scala
+++ b/test/files/run/repl-javap-more-fun.scala
@@ -1,0 +1,17 @@
+import scala.tools.partest.JavapTest
+
+object Test extends JavapTest {
+  def code = """
+    |object Betty {
+    |  val ds = List(1,2,3) filter (_ % 2 == 0) map (_ * 3)
+    |  def m(vs: List[Int]) = vs filter (_ % 2 != 0) map (_ * 2)
+    |}
+    |:javap -fun Betty
+  """.stripMargin
+
+  // two anonfuns of Betty
+  override def yah(res: Seq[String]) = {
+    def filtered = res filter (_ contains "public final class Betty")
+    4 == filtered.size
+  }
+}

--- a/test/files/run/repl-javap-outdir/foo_1.scala
+++ b/test/files/run/repl-javap-outdir/foo_1.scala
@@ -1,0 +1,6 @@
+
+package disktest
+
+class Foo {
+  def m(vs: List[Int]) = vs map (_ + 1)
+}

--- a/test/files/run/repl-javap-outdir/run-repl_7.scala
+++ b/test/files/run/repl-javap-outdir/run-repl_7.scala
@@ -1,0 +1,12 @@
+import scala.tools.partest.JavapTest
+
+object Test extends JavapTest {
+  def code = """
+    |:javap disktest/Foo.class
+  """.stripMargin
+
+  override def yah(res: Seq[String]) = {
+    def filtered = res filter (_ contains "public class disktest.Foo")
+    1 == filtered.size
+  }
+}

--- a/test/files/run/repl-javap.scala
+++ b/test/files/run/repl-javap.scala
@@ -1,0 +1,13 @@
+import scala.tools.partest.JavapTest
+
+object Test extends JavapTest {
+  def code = """
+    |case class Betty(i: Int) { def next = Betty(i+1) }
+    |:javap Betty
+  """.stripMargin
+
+  override def yah(res: Seq[String]) = {
+    def filtered = res filter (_ contains "public class Betty")
+    1 == filtered.size
+  }
+}


### PR DESCRIPTION
Preface: this needs more tests.

Also, Foo#m filtering is easy to do; since -fun Foo#m is handled by this commit, maybe the less specific feature can get squashed in here, too.

Feedback on feature and impl will be gratefully incorporated.

I need this commit to work on implicits in for exprs, what a hassle to javap the anonfuns.

---

For instance, javap -app Test is equivalent to javap Test$delayedInit$App
with the correct line and iw prepended.  This works by taking Test as a
name in scope, translating that, and then supplying the suffix.

Then javap -fun Test shows Test$$anonfun_, and for def m,
javap -fun m shows Test$$anonfun$$m_.

E.g., javap -fun scala.Enumeration obviates knowing or guessing
scala/Enumeration$$anonfun$scala$Enumeration$$populateNameMap$1.class.

Also, scala> :javap -fun scala.Array#concat
but still to do is using imported syms.

Both files and replout are supported for searching for artifacts.

The trigger is detecting the synthetic name (has an interior dollar).

Still to do, filter the output on Test#m to show only m.

Need a way to explore the list of artifacts; ideally, related symbols
would be available reflectively.

Prefer companion class to object, otherwise it's not showable;
for object, require dollar when both exist.

Review and invaluable feedback by @paulp
