### PR TITLE
fix IsTraversableLike example code

### DIFF
--- a/src/library/scala/collection/generic/IsTraversableLike.scala
+++ b/src/library/scala/collection/generic/IsTraversableLike.scala
@@ -22,7 +22,7 @@ package generic
  *      final def filterMap[B, That](f: A => Option[B])(implicit cbf: CanBuildFrom[Repr, B, That]): That =
  *        r.flatMap(f(_).toSeq)
  *    }
- *    implicit def filterMap[Repr, A](r: Repr)(implicit fr: IsTraversableOnce[Repr]): FilterMapImpl[fr.A,Repr] =
+ *    implicit def filterMap[Repr, A](r: Repr)(implicit fr: IsTraversableLike[Repr]): FilterMapImpl[fr.A,Repr] =
  *      new FilterMapImpl(fr.conversion(r))
  *
  *    val l = List(1, 2, 3, 4, 5)


### PR DESCRIPTION
Can't compile current example code. Maybe copy/paste mistakes form `IsTraversableOnce`

https://github.com/scala/scala/blob/v2.10.0/src/library/scala/collection/generic/IsTraversableLike.scala#L21-L30

``` scala
$ scala
Welcome to Scala version 2.10.0 (Java HotSpot(TM) 64-Bit Server VM, Java 1.7.0_09).
Type in expressions to have them evaluated.
Type :help for more information.

scala> import scala.collection._
import scala.collection._

scala> import scala.collection.generic._
import scala.collection.generic._

scala> class FilterMapImpl[A, Repr](val r: GenTraversableLike[A, Repr]) {
     |   final def filterMap[B, That](f: A => Option[B])(implicit cbf: CanBuildFrom[Repr, B, That]): That =
     |     r.flatMap(f(_).toSeq)
     | }
defined class FilterMapImpl

scala> implicit def filterMap[Repr, A](r: Repr)(implicit fr: IsTraversableOnce[Repr]): FilterMapImpl[fr.A,Repr] =
     |   new FilterMapImpl(fr.conversion(r))
<console>:15: error: type mismatch;
 found   : scala.collection.GenTraversableOnce[fr.A]
 required: scala.collection.GenTraversableLike[fr.A,Repr]
         new FilterMapImpl(fr.conversion(r))
                                        ^
```

https://github.com/scala/scala/blob/v2.10.0/test/files/run/enrich-gentraversable.scala#L7-L12
