### PR TITLE
SI-6925 use concrete type in applyOrElse's match's selector

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2683,7 +2683,9 @@ trait Typers extends Modes with Adaptations with Tags {
           val methodBodyTyper = newTyper(context.makeNewScope(context.tree, methodSym)) // should use the DefDef for the context's tree, but it doesn't exist yet (we need the typer we're creating to create it)
           paramSyms foreach (methodBodyTyper.context.scope enter _)
 
-          val match_ = methodBodyTyper.typedMatch(gen.mkUnchecked(selector), cases, mode, ptRes)
+          // SI-6925: subsume type of the selector to `argTp`
+          // we don't want/need the match to see the `A1` type that we must use for variance reasons in the method signature 
+          val match_ = methodBodyTyper.typedMatch(gen.mkUnchecked(Typed(selector, TypeTree(argTp))), cases, mode, ptRes)
           val resTp = match_.tpe
 
           anonClass setInfo ClassInfoType(parentsPartial(List(argTp, resTp)), newScope, anonClass)

--- a/test/files/pos/t6925.scala
+++ b/test/files/pos/t6925.scala
@@ -1,0 +1,9 @@
+class Test {
+  def f[T](xs: Set[T]) /* no expected type to trigger inference */ = 
+    xs collect { case x => x }
+
+  def g[T](xs: Set[T]): Set[T] = f[T](xs) // check that f's inferred type is Set[T]
+
+  // check that this type checks:
+  List(1).flatMap(n => Set(1).collect { case w => w })
+}


### PR DESCRIPTION
Fix a regression introduced in 28483739c3:

PartialFunction synthesis was broken so that we'd get:

```
scala> def f[T](xs: Set[T]) = xs collect { case x => x }
f: [T](xs: Set[T])scala.collection.immutable.Set[_ <: T]
```

rather than

```
scala> def f[T](xs: Set[T]) = xs collect { case x => x }
f: [T](xs: Set[T])scala.collection.immutable.Set[T]
```

review by @paulp
