### PR TITLE
SI-6923 Context now buffers warnings as well as errors

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -728,7 +728,15 @@ trait Typers extends Modes with Adaptations with Tags {
           if (context1.hasErrors) {
             stopStats()
             SilentTypeError(context1.errBuffer.head)
-          } else SilentResultValue(result)
+          } else {
+            // If we have a successful result, emit any warnings it created.
+            if (context1.hasWarnings) {
+              context1.flushAndReturnWarningsBuffer() foreach {
+                case (pos, msg) => unit.warning(pos, msg)
+              }
+            }
+            SilentResultValue(result)
+          }
         } else {
           assert(context.bufferErrors || isPastTyper, "silent mode is not available past typer")
           withSavedContext(context){

--- a/test/files/neg/names-defaults-neg.check
+++ b/test/files/neg/names-defaults-neg.check
@@ -134,9 +134,17 @@ names-defaults-neg.scala:144: error: variable definition needs type because 'x' 
 names-defaults-neg.scala:147: error: variable definition needs type because 'x' is used as a named argument in its body.
   object t6 { var x = t.f(x = 1) }
                   ^
+names-defaults-neg.scala:147: warning: type-checking the invocation of method f checks if the named argument expression 'x = ...' is a valid assignment
+in the current scope. The resulting type inference error (see above) can be fixed by providing an explicit type in the local definition for x.
+  object t6 { var x = t.f(x = 1) }
+                            ^
 names-defaults-neg.scala:150: error: variable definition needs type because 'x' is used as a named argument in its body.
   class t9 { var x = t.f(x = 1) }
                  ^
+names-defaults-neg.scala:150: warning: type-checking the invocation of method f checks if the named argument expression 'x = ...' is a valid assignment
+in the current scope. The resulting type inference error (see above) can be fixed by providing an explicit type in the local definition for x.
+  class t9 { var x = t.f(x = 1) }
+                           ^
 names-defaults-neg.scala:164: error: variable definition needs type because 'x' is used as a named argument in its body.
   def u3 { var x = u.f(x = 1) }
                ^
@@ -156,5 +164,5 @@ in the current scope. The resulting type inference error (see above) can be fixe
 names-defaults-neg.scala:180: error: reference to x is ambiguous; it is both a method parameter and a variable in scope.
   class u18 { var x: Int = u.f(x = 1) }
                                  ^
-two warnings found
+four warnings found
 41 errors found

--- a/test/files/neg/t4851.check
+++ b/test/files/neg/t4851.check
@@ -40,4 +40,10 @@ S.scala:10: error: Adapting argument list by inserting (): this is unlikely to b
  after adaptation: new J2((): Unit)
   val z2 = new J2()
            ^
-7 errors found
+S.scala:14: error: Adapting argument list by creating a 3-tuple: this may not be what you want.
+        signature: Test.anyId(a: Any): Any
+  given arguments: 1, 2, 3
+ after adaptation: Test.anyId((1, 2, 3): (Int, Int, Int))
+  val w1 = anyId(1, 2 ,3)
+                ^
+8 errors found

--- a/test/files/neg/t4851/S.scala
+++ b/test/files/neg/t4851/S.scala
@@ -10,6 +10,9 @@ object Test {
   val z2 = new J2()
   val z3 = new J2(())
 
+  def anyId(a: Any) = a
+  val w1 = anyId(1, 2 ,3)
+
   def main(args: Array[String]): Unit = {
     println(x1)
     println(x2)
@@ -19,5 +22,7 @@ object Test {
     println(z1)
     println(z2)
     println(z3)
+
+    println(w1)
   }
 }


### PR DESCRIPTION
First pull request!

https://issues.scala-lang.org/browse/SI-6923

I want this change in 2.10.x but what's the procedure for porting this to 2.11/master?

---

Code that was silently typed would not report warnings, even if it
returned a successful result.

This appeared in the following code which didn't show warnings even
with -Ywarn-adapted-args:

```
def foo(a: Any) = a; foo(1, 2)
```

While the following would show the expected warning:

```
def foo[A](a: Any) = a; foo(1, 2)
```
