### PR TITLE
sbt-git-plugin has moved.

### DIFF
--- a/project/project/Build.scala
+++ b/project/project/Build.scala
@@ -3,5 +3,5 @@ object PluginDef extends Build {
   override def projects = Seq(root)
   lazy val root = Project("plugins", file(".")) dependsOn(proguard, git)
   lazy val proguard = uri("git://github.com/jsuereth/xsbt-proguard-plugin.git#sbt-0.12")
-  lazy val git = uri("git://github.com/sbt/sbt-git-plugin.git#scala-build")
+  lazy val git = uri("git://github.com/sbt/sbt-git.git#scala-build")
 }


### PR DESCRIPTION
We need to eliminate these sort of shifting sands to make
the SBT build a viable option.

Review by @jsuereth. Should we switch to dependencies on binary releases of these plugins?
