### PR TITLE
SI-6939 Fix namespace binding (xmlns) not overriding outer binding

### DIFF
--- a/test/files/run/t6939.scala
+++ b/test/files/run/t6939.scala
@@ -1,0 +1,13 @@
+object Test extends App {
+  val foo = <x:foo xmlns:x="http://foo.com/"><x:bar xmlns:x="http://bar.com/"><x:baz/></x:bar></x:foo>
+  assert(foo.child.head.scope.toString == """ xmlns:x="http://bar.com/"""")
+
+  val fooDefault = <foo xmlns="http://foo.com/"><bar xmlns="http://bar.com/"><baz/></bar></foo>
+  assert(fooDefault.child.head.scope.toString == """ xmlns="http://bar.com/"""")
+
+  val foo2 = scala.xml.XML.loadString("""<x:foo xmlns:x="http://foo.com/"><x:bar xmlns:x="http://bar.com/"><x:baz/></x:bar></x:foo>""")
+  assert(foo2.child.head.scope.toString == """ xmlns:x="http://bar.com/"""")
+
+  val foo2Default = scala.xml.XML.loadString("""<foo xmlns="http://foo.com/"><bar xmlns="http://bar.com/"><baz/></bar></foo>""")
+  assert(foo2Default.child.head.scope.toString == """ xmlns="http://bar.com/"""")
+}


### PR DESCRIPTION
This is a fix for [SI-6939: Namespace binding (xmlns) is duplicated if a child redefines a prefix](https://issues.scala-lang.org/browse/SI-6939).

Given a nested XML literal to the compiler Elem instance is generated
with namespace binding of the inner element copying that of the outer element:

``` scala
val foo = <x:foo xmlns:x="http://foo.com/">
  <x:bar xmlns:x="http://bar.com/">
    <x:baz/>
  </x:bar>
</x:foo>
```

With the above example, `foo.child.head.scope.toString` returns

``` scala
" xmlns:x="http://bar.com/" xmlns:x="http://foo.com/""
```

This is incorrect since the outer xmls:x should be overridden
by the inner binding.

XML library also parses XML document in a similar manner:

``` scala
val foo2 = scala.xml.XML.loadString("""<x:foo xmlns:x="http://foo.com/"><x:bar xmlns:x="http://bar.com/"><x:baz/></x:bar></x:foo>""")
```

Despite this erroneous behavior, since the structure of NamespaceBinding class
is designed to be singly-linked list, the stacking of namespace bindings allows
constant-time creation with simple implementation.
Since the inner namespace binding comes before the outer one,
query methods like `getURI` method behave correctly.

Because this bug is manifested when Elem is turned back into XML string,
it could be fixed by normalizing the namespace binding right when
buildString is called.
With this change `foo.child.head.scope.toString` now returns:

``` scala
" xmlns:x="http://bar.com/""
```
