### PR TITLE
SI-4859 Step back from mis-optimizations in qualifiers

### DIFF
--- a/src/compiler/scala/reflect/reify/Taggers.scala
+++ b/src/compiler/scala/reflect/reify/Taggers.scala
@@ -58,7 +58,7 @@ abstract class Taggers {
     val result =
       tpe match {
         case coreTpe if coreTags contains coreTpe =>
-          val ref = if (tagModule.owner.isPackageClass) Ident(tagModule) else Select(prefix, tagModule.name)
+          val ref = if (tagModule.isTopLevel) Ident(tagModule) else Select(prefix, tagModule.name)
           Select(ref, coreTags(coreTpe))
         case _ =>
           translatingReificationErrors(materializer)

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1378,7 +1378,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
     def compiles(sym: Symbol): Boolean =
       if (sym == NoSymbol) false
       else if (symSource.isDefinedAt(sym)) true
-      else if (!sym.owner.isPackageClass) compiles(sym.enclosingTopLevelClass)
+      else if (!sym.isTopLevel) compiles(sym.enclosingTopLevelClass)
       else if (sym.isModuleClass) compiles(sym.sourceModule)
       else false
 

--- a/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
@@ -835,16 +835,16 @@ abstract class GenICode extends SubComponent  {
             generatedType = toTypeKind(sym.info)
             val hostClass = findHostClass(qualifier.tpe, sym)
             log(s"Host class of $sym with qual $qualifier (${qualifier.tpe}) is $hostClass")
-            val qualSafeToInline = treeInfo isExprSafeToInline qualifier
+            val qualSafeToElide = treeInfo isQualifierSafeToElide qualifier
 
-            def genLoadQualUnlessInlinable: Context =
-              if (qualSafeToInline) ctx else genLoadQualifier(tree, ctx)
+            def genLoadQualUnlessElidable: Context =
+              if (qualSafeToElide) ctx else genLoadQualifier(tree, ctx)
 
             if (sym.isModule) {
-              genLoadModule(genLoadQualUnlessInlinable, tree)
+              genLoadModule(genLoadQualUnlessElidable, tree)
             }
             else if (sym.isStaticMember) {
-              val ctx1 = genLoadQualUnlessInlinable
+              val ctx1 = genLoadQualUnlessElidable
               ctx1.bb.emit(LOAD_FIELD(sym, true) setHostClass hostClass, tree.pos)
               ctx1
             } else {

--- a/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
@@ -835,13 +835,18 @@ abstract class GenICode extends SubComponent  {
             generatedType = toTypeKind(sym.info)
             val hostClass = findHostClass(qualifier.tpe, sym)
             log(s"Host class of $sym with qual $qualifier (${qualifier.tpe}) is $hostClass")
+            val qualSafeToInline = treeInfo isExprSafeToInline qualifier
+
+            def genLoadQualUnlessInlinable: Context =
+              if (qualSafeToInline) ctx else genLoadQualifier(tree, ctx)
 
             if (sym.isModule) {
-              genLoadModule(ctx, tree)
+              genLoadModule(genLoadQualUnlessInlinable, tree)
             }
             else if (sym.isStaticMember) {
-              ctx.bb.emit(LOAD_FIELD(sym, true) setHostClass hostClass, tree.pos)
-              ctx
+              val ctx1 = genLoadQualUnlessInlinable
+              ctx1.bb.emit(LOAD_FIELD(sym, true) setHostClass hostClass, tree.pos)
+              ctx1
             } else {
               val ctx1 = genLoadQualifier(tree, ctx)
               ctx1.bb.emit(LOAD_FIELD(sym, false) setHostClass hostClass, tree.pos)

--- a/src/compiler/scala/tools/nsc/backend/opt/DeadCodeElimination.scala
+++ b/src/compiler/scala/tools/nsc/backend/opt/DeadCodeElimination.scala
@@ -144,6 +144,8 @@ abstract class DeadCodeElimination extends SubComponent {
                 }
               }
               if (necessary) worklist += ((bb, idx))
+            case LOAD_MODULE(sym) if isLoadNeeded(sym) =>
+              worklist += ((bb, idx)) // SI-4859 Module initialization might side-effect.
             case _ => ()
           }
           rd = rdef.interpret(bb, idx, rd)

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -50,7 +50,7 @@ abstract class Erasure extends AddInterfaces
             if (sym == ArrayClass) args foreach traverse
             else if (sym.isTypeParameterOrSkolem || sym.isExistentiallyBound || !args.isEmpty) result = true
             else if (sym.isClass) traverse(rebindInnerClass(pre, sym)) // #2585
-            else if (!sym.owner.isPackageClass) traverse(pre)
+            else if (!sym.isTopLevel) traverse(pre)
           case PolyType(_, _) | ExistentialType(_, _) =>
             result = true
           case RefinedType(parents, _) =>

--- a/src/compiler/scala/tools/nsc/transform/Flatten.scala
+++ b/src/compiler/scala/tools/nsc/transform/Flatten.scala
@@ -12,7 +12,7 @@ import scala.collection.mutable.ListBuffer
 
 abstract class Flatten extends InfoTransform {
   import global._
-  import treeInfo.isExprSafeToInline
+  import treeInfo.isQualifierSafeToElide
 
   /** the following two members override abstract members in Transform */
   val phaseName: String = "flatten"
@@ -121,7 +121,7 @@ abstract class Flatten extends InfoTransform {
           exitingFlatten {
             atPos(tree.pos) {
               val ref = gen.mkAttributedRef(sym)
-              if (isExprSafeToInline(qual)) ref
+              if (isQualifierSafeToElide(qual)) ref
               else Block(List(qual), ref).setType(tree.tpe) // need to execute the qualifier but refer directly to the lifted module.
             }
           }

--- a/src/compiler/scala/tools/nsc/transform/Flatten.scala
+++ b/src/compiler/scala/tools/nsc/transform/Flatten.scala
@@ -116,7 +116,7 @@ abstract class Flatten extends InfoTransform {
         case ClassDef(_, _, _, _) if sym.isNestedClass =>
           liftedDefs(sym.enclosingTopLevelClass.owner) += tree
           EmptyTree
-        case Select(qual, name) if (sym.isStaticModule && !sym.owner.isPackageClass) =>
+        case Select(qual, name) if sym.isStaticModule && !sym.isTopLevel =>
           exitingFlatten(atPos(tree.pos)(gen.mkAttributedRef(sym)))
         case _ =>
           tree

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -1048,8 +1048,8 @@ trait ContextErrors {
         val s1 = if (prevSym.isModule) "case class companion " else ""
         val s2 = if (prevSym.isSynthetic) "(compiler-generated) " + s1 else ""
         val s3 = if (prevSym.isCase) "case class " + prevSym.name else "" + prevSym
-        val where = if (currentSym.owner.isPackageClass != prevSym.owner.isPackageClass) {
-                      val inOrOut = if (prevSym.owner.isPackageClass) "outside of" else "in"
+        val where = if (currentSym.isTopLevel != prevSym.isTopLevel) {
+                      val inOrOut = if (prevSym.isTopLevel) "outside of" else "in"
                       " %s package object %s".format(inOrOut, ""+prevSym.effectiveOwner.name)
                     } else ""
 

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -124,7 +124,7 @@ trait Macros extends scala.tools.reflect.FastTrack with Traces {
       // todo. refactor when fixing SI-5498
       def className: String = {
         def loop(sym: Symbol): String = sym match {
-          case sym if sym.owner.isPackageClass =>
+          case sym if sym.isTopLevel =>
             val suffix = if (sym.isModuleClass) "$" else ""
             sym.fullName + suffix
           case sym =>

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -134,7 +134,7 @@ trait Namers extends MethodSynthesis {
       sym reset NoType setFlag newFlags setPos pos
       sym.moduleClass andAlso (updatePosFlags(_, pos, moduleClassFlags(flags)))
 
-      if (sym.owner.isPackageClass) {
+      if (sym.isTopLevel) {
         companionSymbolOf(sym, context) andAlso { companion =>
           val assignNoType = companion.rawInfo match {
             case _: SymLoader => true
@@ -163,7 +163,7 @@ trait Namers extends MethodSynthesis {
     protected def conflict(newS: Symbol, oldS: Symbol) = (
        (   !oldS.isSourceMethod
         || nme.isSetterName(newS.name)
-        || newS.owner.isPackageClass
+        || newS.isTopLevel
        ) &&
       !(   // @M: allow repeated use of `_` for higher-order type params
            (newS.owner.isTypeParameter || newS.owner.isAbstractType)
@@ -174,7 +174,7 @@ trait Namers extends MethodSynthesis {
     )
 
     private def allowsOverload(sym: Symbol) = (
-      sym.isSourceMethod && sym.owner.isClass && !sym.owner.isPackageClass
+      sym.isSourceMethod && sym.owner.isClass && !sym.isTopLevel
     )
 
     private def inCurrentScope(m: Symbol): Boolean = {
@@ -352,7 +352,7 @@ trait Namers extends MethodSynthesis {
       val existing = context.scope.lookup(tree.name)
       val isRedefinition = (
            existing.isType
-        && existing.owner.isPackageClass
+        && existing.isTopLevel
         && context.scope == existing.owner.info.decls
         && currentRun.canRedefine(existing)
       )
@@ -365,8 +365,8 @@ trait Namers extends MethodSynthesis {
         else assignAndEnterSymbol(tree) setFlag inConstructorFlag
       }
       clazz match {
-        case csym: ClassSymbol if csym.owner.isPackageClass => enterClassSymbol(tree, csym)
-        case _                                              => clazz
+        case csym: ClassSymbol if csym.isTopLevel => enterClassSymbol(tree, csym)
+        case _                                    => clazz
       }
     }
 
@@ -425,7 +425,7 @@ trait Namers extends MethodSynthesis {
         m.moduleClass setFlag moduleClassFlags(moduleFlags)
         setPrivateWithin(tree, m.moduleClass)
       }
-      if (m.owner.isPackageClass && !m.isPackage) {
+      if (m.isTopLevel && !m.isPackage) {
         m.moduleClass.associatedFile = contextFile
         currentRun.symSource(m) = m.moduleClass.sourceFile
         registerTopLevelSym(m)
@@ -1446,7 +1446,7 @@ trait Namers extends MethodSynthesis {
           fail(ImplicitConstr)
         if (!(sym.isTerm || (sym.isClass && !sym.isTrait)))
           fail(ImplicitNotTermOrClass)
-        if (sym.owner.isPackageClass)
+        if (sym.isTopLevel)
           fail(ImplicitAtToplevel)
       }
       if (sym.isClass) {

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1391,7 +1391,7 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
         case Select(module, apply) =>
           ( // SI-4859 `CaseClass1().InnerCaseClass2()` must not be rewritten to `new InnerCaseClass2()`;
             //          {expr; Outer}.Inner() must not be rewritten to `new Outer.Inner()`.
-            treeInfo.isExprSafeToInline(module) &&
+            treeInfo.isQualifierSafeToElide(module) &&
             // SI-5626 Classes in refinement types cannot be constructed with `new`. In this case,
             // the companion class is actually not a ClassSymbol, but a reference to an abstract type.
             module.symbol.companionClass.isClass

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1389,9 +1389,12 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
         case TypeApply(fun, targs) =>
           isClassTypeAccessible(fun)
         case Select(module, apply) =>
-          // Fixes SI-5626. Classes in refinement types cannot be constructed with `new`. In this case,
-          // the companion class is actually not a ClassSymbol, but a reference to an abstract type.
-          module.symbol.companionClass.isClass
+          ( // SI-4859 `CaseClass1().InnerCaseClass2()` must not be rewritten to `new InnerCaseClass2()`
+            treeInfo.isExprSafeToInline(module) &&
+            // SI-5626 Classes in refinement types cannot be constructed with `new`. In this case,
+            // the companion class is actually not a ClassSymbol, but a reference to an abstract type.
+            module.symbol.companionClass.isClass
+          )
       }
 
       val doTransform =

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1620,7 +1620,7 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
         result match {
           case ClassDef(_, _, _, _)
              | TypeDef(_, _, _, _) =>
-            if (result.symbol.isLocal || result.symbol.owner.isPackageClass)
+            if (result.symbol.isLocal || result.symbol.isTopLevel)
               varianceValidator.traverse(result)
           case _ =>
         }

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1389,7 +1389,8 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
         case TypeApply(fun, targs) =>
           isClassTypeAccessible(fun)
         case Select(module, apply) =>
-          ( // SI-4859 `CaseClass1().InnerCaseClass2()` must not be rewritten to `new InnerCaseClass2()`
+          ( // SI-4859 `CaseClass1().InnerCaseClass2()` must not be rewritten to `new InnerCaseClass2()`;
+            //          {expr; Outer}.Inner() must not be rewritten to `new Outer.Inner()`.
             treeInfo.isExprSafeToInline(module) &&
             // SI-5626 Classes in refinement types cannot be constructed with `new`. In this case,
             // the companion class is actually not a ClassSymbol, but a reference to an abstract type.

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1919,7 +1919,7 @@ trait Typers extends Adaptations with Tags {
       if (clazz.isTrait && hasSuperArgs(parents1.head))
         ConstrArgsInParentOfTraitError(parents1.head, clazz)
 
-      if ((clazz isSubClass ClassfileAnnotationClass) && !clazz.owner.isPackageClass)
+      if ((clazz isSubClass ClassfileAnnotationClass) && !clazz.isTopLevel)
         unit.error(clazz.pos, "inner classes cannot be classfile annotations")
 
       if (!phase.erasedTypes && !clazz.info.resultType.isError) // @S: prevent crash for duplicated type members
@@ -4788,7 +4788,7 @@ trait Typers extends Adaptations with Tags {
             else if (isPredefMemberNamed(sym, nme.classOf) && pt.typeSymbol == ClassClass && pt.typeArgs.nonEmpty)
             typedClassOf(tree, TypeTree(pt.typeArgs.head))
           else {
-              val pre1  = if (sym.owner.isPackageClass) sym.owner.thisType else if (qual == EmptyTree) NoPrefix else qual.tpe
+              val pre1  = if (sym.isTopLevel) sym.owner.thisType else if (qual == EmptyTree) NoPrefix else qual.tpe
               val tree1 = if (qual == EmptyTree) tree else atPos(tree.pos)(Select(atPos(tree.pos.focusStart)(qual), name))
               val (tree2, pre2) = makeAccessible(tree1, sym, pre1, qual)
             // SI-5967 Important to replace param type A* with Seq[A] when seen from from a reference, to avoid

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1139,7 +1139,7 @@ trait Definitions extends api.StandardDefinitions {
       }
       def flatNameString(sym: Symbol, separator: Char): String =
         if (sym == NoSymbol) ""   // be more resistant to error conditions, e.g. neg/t3222.scala
-        else if (sym.owner.isPackageClass) sym.javaClassName
+        else if (sym.isTopLevel) sym.javaClassName
         else flatNameString(sym.owner, separator) + nme.NAME_JOIN_STRING + sym.simpleName
       def signature1(etp: Type): String = {
         if (etp.typeSymbol == ArrayClass) "[" + signature1(erasure(etp.normalize.typeArgs.head))

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -591,7 +591,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     /** Does this symbol denote a wrapper created by the repl? */
     final def isInterpreterWrapper = (
          (this hasFlag MODULE)
-      && owner.isPackageClass
+      && isTopLevel
       && nme.isReplWrapperName(name)
     )
     final def getFlag(mask: Long): Long = {
@@ -813,7 +813,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     /** Is this symbol effectively final? I.e, it cannot be overridden */
     final def isEffectivelyFinal: Boolean = (
          (this hasFlag FINAL | PACKAGE)
-      || isModuleOrModuleClass && (owner.isPackageClass || !settings.overrideObjects.value)
+      || isModuleOrModuleClass && (isTopLevel || !settings.overrideObjects.value)
       || isTerm && (
              isPrivate
           || isLocal
@@ -873,7 +873,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
 
     // Does not always work if the rawInfo is a SourcefileLoader, see comment
     // in "def coreClassesFirst" in Global.
-    def exists = !owner.isPackageClass || { rawInfo.load(this); rawInfo != NoType }
+    def exists = !isTopLevel || { rawInfo.load(this); rawInfo != NoType }
 
     final def isInitialized: Boolean =
       validTo != NoPeriod
@@ -1919,7 +1919,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
 
     /** The top-level class containing this symbol. */
     def enclosingTopLevelClass: Symbol =
-      if (owner.isPackageClass) {
+      if (isTopLevel) {
         if (isClass) this else moduleClass
       } else owner.enclosingTopLevelClass
 
@@ -2892,7 +2892,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     override def isAnonymousClass        = name containsName tpnme.ANON_CLASS_NAME
     override def isConcreteClass         = !(this hasFlag ABSTRACT | TRAIT)
     override def isJavaInterface         = hasAllFlags(JAVA | TRAIT)
-    override def isNestedClass           = !owner.isPackageClass
+    override def isNestedClass           = !isTopLevel
     override def isNumericValueClass     = definitions.isNumericValueClass(this)
     override def isNumeric               = isNumericValueClass
     override def isPackageObjectClass    = isModuleClass && (name == tpnme.PACKAGE)
@@ -2918,7 +2918,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     override def isLocalClass = (
          isAnonOrRefinementClass
       || isLocal
-      || !owner.isPackageClass && owner.isLocalClass
+      || !isTopLevel && owner.isLocalClass
     )
 
     override def enclClassChain = this :: owner.enclClassChain
@@ -2947,7 +2947,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     }
 
     override def associatedFile = (
-      if (!owner.isPackageClass) super.associatedFile
+      if (!isTopLevel) super.associatedFile
       else if (_associatedFile eq null) NoAbstractFile // guarantee not null, but save cost of initializing the var
       else _associatedFile
     )

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -821,6 +821,9 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
          )
     )
 
+    /** Is this symbol owned by a package? */
+    final def isTopLevel = owner.isPackageClass
+
     /** Is this symbol locally defined? I.e. not accessed from outside `this` instance */
     final def isLocal: Boolean = owner.isTerm
 

--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -467,7 +467,7 @@ abstract class TreeInfo {
 
       tp match {
         case TypeRef(pre, sym, args) =>
-          args.isEmpty && (sym.owner.isPackageClass || isSimple(pre))
+          args.isEmpty && (sym.isTopLevel || isSimple(pre))
         case NoPrefix =>
           true
         case _ =>

--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -65,6 +65,9 @@ abstract class TreeInfo {
       false
   }
 
+  // TODO SI-5304 tighten this up so we don't elide side effect in module loads
+  def isQualifierSafeToElide(tree: Tree): Boolean = isExprSafeToInline(tree)
+
   /** Is tree an expression which can be inlined without affecting program semantics?
    *
    *  Note that this is not called "isExprPure" since purity (lack of side-effects)

--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -507,7 +507,7 @@ private[reflect] trait JavaMirrors extends internal.SymbolTable with api.JavaUni
       def erasure = symbol.moduleClass.asClass
       def isStatic = true
       def instance = {
-        if (symbol.owner.isPackageClass)
+        if (symbol.isTopLevel)
           staticSingletonInstance(classLoader, symbol.fullName)
         else
           if (outer == null) staticSingletonInstance(classToJava(symbol.moduleClass.asClass))
@@ -1156,11 +1156,11 @@ private[reflect] trait JavaMirrors extends internal.SymbolTable with api.JavaUni
         valueClassToJavaType(clazz)
       else if (clazz == ArrayClass)
         noClass
-      else if (clazz.owner.isPackageClass)
+      else if (clazz.isTopLevel)
         javaClass(clazz.javaClassName)
       else if (clazz.owner.isClass) {
         val childOfClass = !clazz.owner.isModuleClass
-        val childOfTopLevel = clazz.owner.owner.isPackageClass
+        val childOfTopLevel = clazz.owner.isTopLevel
         val childOfTopLevelObject = clazz.owner.isModuleClass && childOfTopLevel
 
         // suggested in https://issues.scala-lang.org/browse/SI-4023?focusedCommentId=54759#comment-54759

--- a/test/files/pos/t4859.scala
+++ b/test/files/pos/t4859.scala
@@ -1,5 +1,7 @@
 object O {
+  // error: C is not a legal prefix for a constructor
   C().CC()
+  // but this works.
   D().DD()
 }
 

--- a/test/files/run/t4859.check
+++ b/test/files/run/t4859.check
@@ -1,0 +1,8 @@
+Inner
+Inner.i
+About to reference Inner.i
+Outer
+Inner.i
+About to reference O.N
+About to reference O.N
+About to reference O.N.apply()

--- a/test/files/run/t4859.scala
+++ b/test/files/run/t4859.scala
@@ -1,0 +1,29 @@
+object O {
+  case class N()
+  object P
+}
+
+object Outer {
+  println("Outer")
+  object Inner {
+    println("Inner")
+    def i {
+      println("Inner.i")
+    }
+  }
+}
+
+object Test {
+  def main(args: Array[String]) {
+    Outer.Inner.i // we still don't initiialize Outer here (but should we?)
+
+    {println("About to reference Inner.i"); Outer}.Inner.i // Outer will be initialized.
+
+    {println("About to reference O.N"        ); O}.N
+
+    {println("About to reference O.N"        ); O}.N
+
+    {println("About to reference O.N.apply()"); O}.N.apply()
+  }
+}
+

--- a/test/files/run/t4859.scala
+++ b/test/files/run/t4859.scala
@@ -15,7 +15,7 @@ object Outer {
 
 object Test {
   def main(args: Array[String]) {
-    Outer.Inner.i // we still don't initiialize Outer here (but should we?)
+    Outer.Inner.i // we still don't initialize Outer here (but should we?)
 
     {println("About to reference Inner.i"); Outer}.Inner.i // Outer will be initialized.
 


### PR DESCRIPTION
Retargetting #1710 to master.

Widespread, invalid qualifier discarding in the apparent name of performance led to a variety of problems:

The compiler would crash in case of:

```
OuterCaseClass().InnerCaseClass()
```

And the side effect would be elided in:

```
{ println("!!"); Outer}.Inner
```

This change fixes these problems but stops short of fixing the last problem:

```
Outer.Inner.foo // module load of Outer is still elided.
```

This could be fixed use a stronger condition than `isExprSafeToInline` throughout this patch. (It would be `isExprSafeToElide` or `isPure`.)

Thoughts? Should that change be tackled in this ticket or separately?

Last time, @paulp [opined](https://github.com/scala/scala/pull/1710#discussion_r2458429):

> I don't see how we can fail to initialize Outer here if we wish to have at all predictable semantics.

Review by @paulp @magarcia
