### PR TITLE
SI-6555 Scaladoc's class filter shouldn't drop the last character

### DIFF
--- a/src/compiler/scala/tools/nsc/doc/html/resource/lib/index.js
+++ b/src/compiler/scala/tools/nsc/doc/html/resource/lib/index.js
@@ -339,7 +339,7 @@ function configureTextFilter() {
         printAlphabet();
         var input = $("#textfilter input");
         resizeFilterBlock();
-        input.bind("keydown", function(event) {
+        input.bind('keyup', function(event) {
             if (event.keyCode == 27) { // escape
                 input.attr("value", "");
             }


### PR DESCRIPTION
The event handler have to wait "keyup", not "keydown".
