### PR TITLE
Fixes SI-6521, overrides Range#head to be faster

### DIFF
--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -77,6 +77,7 @@ extends scala.collection.AbstractSeq[Int]
   final val terminalElement = start + numRangeElements * step
 
   override def last = if (isEmpty) Nil.last else lastElement
+  override def head = if (isEmpty) Nil.head else start
 
   override def min[A1 >: Int](implicit ord: Ordering[A1]): Int =
     if (ord eq Ordering.Int) {


### PR DESCRIPTION
Backport of 63ba3d64a7002ef67f7f13083a18fe1042a3adba
