### PR TITLE
Backport of SI-6846.

### DIFF
--- a/src/compiler/scala/tools/nsc/interpreter/CompletionOutput.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/CompletionOutput.scala
@@ -37,8 +37,8 @@ trait CompletionOutput {
     val pkg       = method.ownerChain find (_.isPackageClass) map (_.fullName) getOrElse ""
 
     def relativize(str: String): String = quietString(str stripPrefix (pkg + "."))
-    def relativize(tp: Type): String    = relativize(tp.normalize.toString)
-    def relativize(sym: Symbol): String = relativize(sym.info)
+    def relativize(tp: Type): String    = relativize(tp.dealiasWiden.toString)
+    def relativize(sym: Symbol): String = relativize(sym.info)    
 
     def braceList(tparams: List[String]) = if (tparams.isEmpty) "" else (tparams map relativize).mkString("[", ", ", "]")
     def parenList(params: List[Any])  = params.mkString("(", ", ", ")")
@@ -56,8 +56,8 @@ trait CompletionOutput {
       }
     )
 
-    def tupleString(tp: Type) = parenList(tp.normalize.typeArgs map relativize)
-    def functionString(tp: Type) = tp.normalize.typeArgs match {
+    def tupleString(tp: Type) = parenList(tp.dealiasWiden.typeArgs map relativize)
+    def functionString(tp: Type) = tp.dealiasWiden.typeArgs match {
       case List(t, r) => t + " => " + r
       case xs         => parenList(xs.init) + " => " + xs.last
     }
@@ -65,7 +65,7 @@ trait CompletionOutput {
     def tparamsString(tparams: List[Symbol])  = braceList(tparams map (_.defString))
     def paramsString(params: List[Symbol])    = {
       def paramNameString(sym: Symbol)  = if (sym.isSynthetic) "" else sym.nameString + ": "
-      def paramString(sym: Symbol)      = paramNameString(sym) + typeToString(sym.info.normalize)
+      def paramString(sym: Symbol)      = paramNameString(sym) + typeToString(sym.info.dealiasWiden)
 
       val isImplicit = params.nonEmpty && params.head.isImplicit
       val strs = (params map paramString) match {

--- a/src/compiler/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/IMain.scala
@@ -550,7 +550,7 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
 
   // normalize non-public types so we don't see protected aliases like Self
   def normalizeNonPublic(tp: Type) = tp match {
-    case TypeRef(_, sym, _) if sym.isAliasType && !sym.isPublic => tp.normalize
+    case TypeRef(_, sym, _) if sym.isAliasType && !sym.isPublic => tp.dealias
     case _                                                      => tp
   }
 

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -443,8 +443,8 @@ trait Implicits {
       val start = if (Statistics.canEnable) Statistics.startTimer(matchesPtNanos) else null
       val result = normSubType(tp, pt) || isView && {
         pt match {
-          case TypeRef(_, Function1.Sym, args) =>
-            matchesPtView(tp, args.head, args.tail.head, undet)
+          case TypeRef(_, Function1.Sym, arg1 :: arg2 :: Nil) =>
+            matchesPtView(tp, arg1, arg2, undet)
           case _ =>
             false
         }
@@ -488,7 +488,7 @@ trait Implicits {
             loop(restpe, pt)
           else pt match {
             case tr @ TypeRef(pre, sym, args) =>
-              if (sym.isAliasType) loop(tp, pt.normalize)
+              if (sym.isAliasType) loop(tp, pt.dealias)
               else if (sym.isAbstractType) loop(tp, pt.bounds.lo)
               else {
                 val len = args.length - 1
@@ -532,18 +532,15 @@ trait Implicits {
      *  to a final true or false.
      */
     private def isPlausiblySubType(tp1: Type, tp2: Type) = !isImpossibleSubType(tp1, tp2)
-    private def isImpossibleSubType(tp1: Type, tp2: Type) = tp1.normalize.widen match {
-      case tr1 @ TypeRef(_, sym1, _) =>
-        // We can only rule out a subtype relationship if the left hand
-        // side is a class, else we may not know enough.
-        sym1.isClass && (tp2.normalize.widen match {
-          case TypeRef(_, sym2, _) =>
-             sym2.isClass && !(sym1 isWeakSubClass sym2)
-          case RefinedType(parents, decls) =>
-            decls.nonEmpty &&
-            tr1.member(decls.head.name) == NoSymbol
-          case _ => false
-        })
+    private def isImpossibleSubType(tp1: Type, tp2: Type) = tp1.dealiasWiden match {
+      // We can only rule out a subtype relationship if the left hand
+      // side is a class, else we may not know enough.
+      case tr1 @ TypeRef(_, sym1, _) if sym1.isClass =>
+        tp2.dealiasWiden match {
+          case TypeRef(_, sym2, _)         => sym2.isClass && !(sym1 isWeakSubClass sym2)
+          case RefinedType(parents, decls) => decls.nonEmpty && tr1.member(decls.head.name) == NoSymbol
+          case _                           => false
+        }
       case _ => false
     }
 
@@ -1018,7 +1015,7 @@ trait Implicits {
                 args foreach (getParts(_))
               }
             } else if (sym.isAliasType) {
-              getParts(tp.normalize)
+              getParts(tp.dealias)
             } else if (sym.isAbstractType) {
               getParts(tp.bounds.hi)
             }
@@ -1048,88 +1045,6 @@ trait Implicits {
       )
       infoMap
     }
-
-    /** The parts of a type is the smallest set of types that contains
-     *    - the type itself
-     *    - the parts of its immediate components (prefix and argument)
-     *    - the parts of its base types
-     *    - for alias types and abstract types, we take instead the parts
-     *    - of their upper bounds.
-     *  @return For those parts that refer to classes with companion objects that
-     *  can be accessed with unambiguous stable prefixes, the implicits infos
-     *  which are members of these companion objects.
-
-    private def companionImplicits(tp: Type): Infoss = {
-      val partMap = new LinkedHashMap[Symbol, Type]
-      val seen = mutable.HashSet[Type]()  // cycle detection
-
-      /** Enter all parts of `tp` into `parts` set.
-       *  This method is performance critical: about 2-4% of all type checking is spent here
-       */
-      def getParts(tp: Type) {
-        if (seen(tp))
-          return
-        seen += tp
-        tp match {
-          case TypeRef(pre, sym, args) =>
-            if (sym.isClass) {
-              if (!((sym.name == tpnme.REFINE_CLASS_NAME) ||
-                    (sym.name startsWith tpnme.ANON_CLASS_NAME) ||
-                    (sym.name == tpnme.ROOT)))
-                partMap get sym match {
-                  case Some(pre1) =>
-                    if (!(pre =:= pre1)) partMap(sym) = NoType // ambiguous prefix - ignore implicit members
-                  case None =>
-                    if (pre.isStable) partMap(sym) = pre
-                    val bts = tp.baseTypeSeq
-                    var i = 1
-                    while (i < bts.length) {
-                      getParts(bts(i))
-                      i += 1
-                    }
-                    getParts(pre)
-                    args foreach getParts
-                }
-            } else if (sym.isAliasType) {
-              getParts(tp.normalize)
-            } else if (sym.isAbstractType) {
-              getParts(tp.bounds.hi)
-            }
-          case ThisType(_) =>
-            getParts(tp.widen)
-          case _: SingletonType =>
-            getParts(tp.widen)
-          case RefinedType(ps, _) =>
-            for (p <- ps) getParts(p)
-          case AnnotatedType(_, t, _) =>
-            getParts(t)
-          case ExistentialType(_, t) =>
-            getParts(t)
-          case PolyType(_, t) =>
-            getParts(t)
-          case _ =>
-        }
-      }
-
-      getParts(tp)
-
-      val buf = new ListBuffer[Infos]
-      for ((clazz, pre) <- partMap) {
-        if (pre != NoType) {
-          val companion = clazz.companionModule
-          companion.moduleClass match {
-            case mc: ModuleClassSymbol =>
-              buf += (mc.implicitMembers map (im =>
-                new ImplicitInfo(im.name, singleType(pre, companion), im)))
-            case _ =>
-          }
-        }
-      }
-      //println("companion implicits of "+tp+" = "+buf.toList) // DEBUG
-      buf.toList
-    }
-
-*/
 
     /** The implicits made available by type `pt`.
      *  These are all implicits found in companion objects of classes C
@@ -1258,7 +1173,7 @@ trait Implicits {
         implicit def wrapResult(tree: Tree): SearchResult =
           if (tree == EmptyTree) SearchFailure else new SearchResult(tree, if (from.isEmpty) EmptyTreeTypeSubstituter else new TreeTypeSubstituter(from, to))
 
-        val tp1 = tp0.normalize
+        val tp1 = tp0.dealias
         tp1 match {
           case ThisType(_) | SingleType(_, _) =>
             // can't generate a reference to a value that's abstracted over by an existential

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -44,7 +44,7 @@ trait Infer extends Checkable {
       case formal => formal
     } else formals
     if (isVarArgTypes(formals1) && (removeRepeated || formals.length != nargs)) {
-      val ft = formals1.last.normalize.typeArgs.head
+      val ft = formals1.last.dealiasWiden.typeArgs.head
       formals1.init ::: (for (i <- List.range(formals1.length - 1, nargs)) yield ft)
     } else formals1
   }
@@ -1060,15 +1060,17 @@ trait Infer extends Checkable {
      */
     def inferExprInstance(tree: Tree, tparams: List[Symbol], pt: Type = WildcardType, treeTp0: Type = null, keepNothings: Boolean = true, useWeaklyCompatible: Boolean = false): List[Symbol] = {
       val treeTp = if(treeTp0 eq null) tree.tpe else treeTp0 // can't refer to tree in default for treeTp0
+      val (targs, tvars) = exprTypeArgs(tparams, treeTp, pt, useWeaklyCompatible)
       printInference(
         ptBlock("inferExprInstance",
           "tree"    -> tree,
           "tree.tpe"-> tree.tpe,
           "tparams" -> tparams,
-          "pt"      -> pt
+          "pt"      -> pt,
+          "targs"   -> targs,
+          "tvars"   -> tvars
         )
       )
-      val (targs, tvars) = exprTypeArgs(tparams, treeTp, pt, useWeaklyCompatible)
 
       if (keepNothings || (targs eq null)) { //@M: adjustTypeArgs fails if targs==null, neg/t0226
         substExpr(tree, tparams, targs, pt)
@@ -1422,9 +1424,9 @@ trait Infer extends Checkable {
     }
 
     object approximateAbstracts extends TypeMap {
-      def apply(tp: Type): Type = tp.normalize match {
+      def apply(tp: Type): Type = tp.dealiasWiden match {
         case TypeRef(pre, sym, _) if sym.isAbstractType => WildcardType
-        case _ => mapOver(tp)
+        case _                                          => mapOver(tp)
       }
     }
 

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -224,7 +224,7 @@ trait Typers extends Modes with Adaptations with Tags {
       case ExistentialType(tparams, tpe) =>
         new SubstWildcardMap(tparams).apply(tp)
       case TypeRef(_, sym, _) if sym.isAliasType =>
-        val tp0 = tp.normalize
+        val tp0 = tp.dealias
         val tp1 = dropExistential(tp0)
         if (tp1 eq tp0) tp else tp1
       case _ => tp
@@ -439,7 +439,7 @@ trait Typers extends Modes with Adaptations with Tags {
               if (!hiddenSymbols.isEmpty && hiddenSymbols.head == sym &&
                   sym.isAliasType && sameLength(sym.typeParams, args)) {
                 hiddenSymbols = hiddenSymbols.tail
-                t.normalize
+                t.dealias
               } else t
             case SingleType(_, sym) =>
               checkNoEscape(sym)
@@ -1075,9 +1075,9 @@ trait Typers extends Modes with Adaptations with Tags {
           adapt(tree setType restpe, mode, pt, original)
         case TypeRef(_, ByNameParamClass, List(arg)) if ((mode & EXPRmode) != 0) => // (2)
           adapt(tree setType arg, mode, pt, original)
-        case tr @ TypeRef(_, sym, _) if sym.isAliasType && tr.normalize.isInstanceOf[ExistentialType] &&
+        case tr @ TypeRef(_, sym, _) if sym.isAliasType && tr.dealias.isInstanceOf[ExistentialType] &&
           ((mode & (EXPRmode | LHSmode)) == EXPRmode) =>
-          adapt(tree setType tr.normalize.skolemizeExistential(context.owner, tree), mode, pt, original)
+          adapt(tree setType tr.dealias.skolemizeExistential(context.owner, tree), mode, pt, original)
         case et @ ExistentialType(_, _) if ((mode & (EXPRmode | LHSmode)) == EXPRmode) =>
           adapt(tree setType et.skolemizeExistential(context.owner, tree), mode, pt, original)
         case PolyType(tparams, restpe) if inNoModes(mode, TAPPmode | PATTERNmode | HKmode) => // (3)
@@ -1147,7 +1147,7 @@ trait Typers extends Modes with Adaptations with Tags {
               if (tree1.tpe <:< pt) adapt(tree1, mode, pt, original)
               else {
                 if (inExprModeButNot(mode, FUNmode)) {
-                  pt.normalize match {
+                  pt.dealias match {
                     case TypeRef(_, sym, _) =>
                       // note: was if (pt.typeSymbol == UnitClass) but this leads to a potentially
                       // infinite expansion if pt is constant type ()
@@ -1302,7 +1302,7 @@ trait Typers extends Modes with Adaptations with Tags {
 
     def adaptToMember(qual: Tree, searchTemplate: Type, reportAmbiguous: Boolean = true, saveErrors: Boolean = true): Tree = {
       if (isAdaptableWithView(qual)) {
-        qual.tpe.widen.normalize match {
+        qual.tpe.dealiasWiden match {
           case et: ExistentialType =>
             qual setType et.skolemizeExistential(context.owner, qual) // open the existential
           case _ =>
@@ -1840,7 +1840,7 @@ trait Typers extends Modes with Adaptations with Tags {
         _.typedTemplate(cdef.impl, parentTypes(cdef.impl))
       }
       val impl2 = finishMethodSynthesis(impl1, clazz, context)
-      if (clazz.isTrait && clazz.info.parents.nonEmpty && clazz.info.firstParent.normalize.typeSymbol == AnyClass)
+      if (clazz.isTrait && clazz.info.parents.nonEmpty && clazz.info.firstParent.typeSymbol == AnyClass)
         checkEphemeral(clazz, impl2.body)
       if ((clazz != ClassfileAnnotationClass) &&
           (clazz isNonBottomSubClass ClassfileAnnotationClass))
@@ -3865,7 +3865,7 @@ trait Typers extends Modes with Adaptations with Tags {
       val normalizeLocals = new TypeMap {
         def apply(tp: Type): Type = tp match {
           case TypeRef(pre, sym, args) =>
-            if (sym.isAliasType && containsLocal(tp)) apply(tp.normalize)
+            if (sym.isAliasType && containsLocal(tp)) apply(tp.dealias)
             else {
               if (pre.isVolatile)
                 InferTypeWithVolatileTypeSelectionError(tree, pre)
@@ -4393,7 +4393,13 @@ trait Typers extends Modes with Adaptations with Tags {
       def typedNew(tree: New) = {
         val tpt = tree.tpt
         val tpt1 = {
-          val tpt0 = typedTypeConstructor(tpt)
+          // This way typedNew always returns a dealiased type. This used to happen by accident
+          // for instantiations without type arguments due to ad hoc code in typedTypeConstructor,
+          // and annotations depended on it (to the extent that they worked, which they did
+          // not when given a parameterized type alias which dealiased to an annotation.)
+          // typedTypeConstructor dealiases nothing now, but it makes sense for a "new" to always be
+          // given a dealiased type.
+          val tpt0 = typedTypeConstructor(tpt) modifyType (_.dealias)
           if (checkStablePrefixClassType(tpt0))
             if (tpt0.hasSymbol && !tpt0.symbol.typeParams.isEmpty) {
               context.undetparams = cloneSymbols(tpt0.symbol.typeParams)
@@ -5733,29 +5739,18 @@ trait Typers extends Modes with Adaptations with Tags {
     def typedTypeConstructor(tree: Tree, mode: Int): Tree = {
       val result = typed(tree, forTypeMode(mode) | FUNmode, WildcardType)
 
-      val restpe = result.tpe.normalize // normalize to get rid of type aliases for the following check (#1241)
-      if (!phase.erasedTypes && restpe.isInstanceOf[TypeRef] && !restpe.prefix.isStable && !context.unit.isJava) {
-        // The isJava exception if OK only because the only type constructors scalac gets
-        // to see are those in the signatures. These do not need a unique object as a prefix.
-        // The situation is different for new's and super's, but scalac does not look deep
-        // enough to see those. See #3938
-        ConstructorPrefixError(tree, restpe)
-      } else {
-        //@M fix for #2208
-        // if there are no type arguments, normalization does not bypass any checks, so perform it to get rid of AnyRef
-        if (result.tpe.typeArgs.isEmpty) {
-          // minimal check: if(result.tpe.typeSymbolDirect eq AnyRefClass) {
-          // must expand the fake AnyRef type alias, because bootstrapping (init in Definitions) is not
-          // designed to deal with the cycles in the scala package (ScalaObject extends
-          // AnyRef, but the AnyRef type alias is entered after the scala package is
-          // loaded and completed, so that ScalaObject is unpickled while AnyRef is not
-          // yet defined )
-          // !!! TODO - revisit now that ScalaObject is gone.
-          result setType(restpe)
-        } else { // must not normalize: type application must be (bounds-)checked (during RefChecks), see #2208
+      // get rid of type aliases for the following check (#1241)
+      result.tpe.dealias match {
+        case restpe @ TypeRef(pre, _, _) if !phase.erasedTypes && !pre.isStable && !context.unit.isJava =>
+          // The isJava exception if OK only because the only type constructors scalac gets
+          // to see are those in the signatures. These do not need a unique object as a prefix.
+          // The situation is different for new's and super's, but scalac does not look deep
+          // enough to see those. See #3938
+          ConstructorPrefixError(tree, restpe)
+        case _ =>
+          // must not normalize: type application must be (bounds-)checked (during RefChecks), see #2208
           // during uncurry (after refchecks), all types are normalized
           result
-        }
       }
     }
 

--- a/test/files/continuations-neg/function2.check
+++ b/test/files/continuations-neg/function2.check
@@ -1,6 +1,6 @@
 function2.scala:11: error: type mismatch;
  found   : () => Int
- required: () => Int @util.continuations.cps[Int]
+ required: () => Int @scala.util.continuations.cpsParam[Int,Int]
     val g: () => Int @cps[Int] = f
                                  ^
 one error found

--- a/test/files/continuations-neg/t5314-type-error.check
+++ b/test/files/continuations-neg/t5314-type-error.check
@@ -1,6 +1,6 @@
 t5314-type-error.scala:7: error: type mismatch;
- found   : Int @util.continuations.cps[Int]
- required: Int @util.continuations.cps[String]
+ found   : Int @scala.util.continuations.cpsParam[Int,Int]
+ required: Int @scala.util.continuations.cpsParam[String,String]
   def bar(x:Int): Int @cps[String] = return foo(x)
                                                ^
 one error found

--- a/test/files/jvm/annotations.check
+++ b/test/files/jvm/annotations.check
@@ -29,7 +29,19 @@ public Test4$Foo8(int)
 private int Test4$Foo9.z
 
 @test.SourceAnnotation(mails={bill.gates@bloodsuckers.com}, value=http://eppli.com)
+private int Test4$Foo9.z2
+
+@test.SourceAnnotation(mails={bill.gates@bloodsuckers.com}, value=http://eppli.com)
+private int Test4$Foo9.z3
+
+@test.SourceAnnotation(mails={bill.gates@bloodsuckers.com}, value=http://eppli.com)
 public int Test4$Foo9.getZ()
+
+@test.SourceAnnotation(mails={bill.gates@bloodsuckers.com}, value=http://eppli.com)
+public int Test4$Foo9.getZ2()
+
+@test.SourceAnnotation(mails={bill.gates@bloodsuckers.com}, value=http://eppli.com)
+public int Test4$Foo9.getZ3()
 
 @test.SourceAnnotation(mails={bill.gates@bloodsuckers.com}, value=http://apple.com)
 public int Test4$Foo9.x()

--- a/test/files/jvm/annotations.scala
+++ b/test/files/jvm/annotations.scala
@@ -101,6 +101,12 @@ object Test4 {
 
     type myAnn = SourceAnnotation @beanGetter @field
     @BeanProperty @myAnn("http://eppli.com") var z = 0
+
+    type myAnn2[T] = SourceAnnotation @beanGetter @field
+    @BeanProperty @myAnn2[String]("http://eppli.com") var z2 = 0
+
+    type myAnn3[CC[_]] = SourceAnnotation @beanGetter @field
+    @BeanProperty @myAnn3[List]("http://eppli.com") var z3 = 0
   }
   class Foo10(@SourceAnnotation("on param 1") val name: String)
   class Foo11(@(SourceAnnotation @scala.annotation.meta.field)("on param 2") val name: String)

--- a/test/files/neg/override-object-no.check
+++ b/test/files/neg/override-object-no.check
@@ -6,8 +6,8 @@ an overriding object must conform to the overridden object's class bound;
                     ^
 override-object-no.scala:21: error: overriding object Bar in trait Quux1 with object Bar in trait Quux2:
 an overriding object must conform to the overridden object's class bound;
- found   : Object{def g: String}
- required: Object{def g: Int}
+ found   : AnyRef{def g: String}
+ required: AnyRef{def g: Int}
   trait Quux2 extends Quux1 { override object Bar { def g = "abc" } } // err
                                               ^
 override-object-no.scala:25: error: overriding object Bar in trait Quux3;

--- a/test/files/neg/t2078.check
+++ b/test/files/neg/t2078.check
@@ -1,4 +1,4 @@
-t2078.scala:2: error: contravariant type S occurs in covariant position in type => Object{val x: S} of value f
+t2078.scala:2: error: contravariant type S occurs in covariant position in type => AnyRef{val x: S} of value f
   val f  = new { val x = y }
       ^
 one error found

--- a/test/files/neg/t2336.check
+++ b/test/files/neg/t2336.check
@@ -1,4 +1,4 @@
-t2336.scala:6: error: type Foo[Int] is not a stable prefix
+t2336.scala:6: error: Foo[Int] is not a legal prefix for a constructor
   new Foo[Int]#Bar(0)
                ^
 one error found

--- a/test/files/neg/t3691.check
+++ b/test/files/neg/t3691.check
@@ -9,7 +9,7 @@ t3691.scala:5: error: type mismatch;
  val c = (new A[String]{}): { type A } // not ok
           ^
 t3691.scala:7: error: type mismatch;
- found   : Object{type A = String}
+ found   : AnyRef{type A = String}
  required: AnyRef{type A[X]}
  val x = (new { type A = String }): { type A[X] } // not ok
           ^

--- a/test/files/neg/t4877.check
+++ b/test/files/neg/t4877.check
@@ -1,10 +1,10 @@
 t4877.scala:4: error: type mismatch;
- found   : Object{def bar: Int}
+ found   : AnyRef{def bar: Int}
  required: AnyRef{def bar: String}
   def foo: AnyRef { def bar: String } = new AnyRef { def bar = 42 }
                                         ^
 t4877.scala:6: error: type mismatch;
- found   : Object{def bar(x: Int): String}
+ found   : AnyRef{def bar(x: Int): String}
  required: AnyRef{def bar(x: Int): Int}
   def foo3: AnyRef { def bar(x: Int): Int } = new AnyRef { def bar(x: Int) = "abc" }
                                               ^
@@ -14,7 +14,7 @@ t4877.scala:7: error: type mismatch;
   def foo4: C { def bar(x: Int): Int ; def quux(x: Int): Int } = new C { def bar(x: Int) = 5 }
                                                                  ^
 t4877.scala:17: error: type mismatch;
- found   : Object{type Mom = String; def bar(x: Int): Int; def bippy(): List[Int]}
+ found   : AnyRef{type Mom = String; def bar(x: Int): Int; def bippy(): List[Int]}
  required: B.this.Bippy
     (which expands to)  AnyRef{type Mom; def bar(x: Int): this.Mom; def bippy(): List[this.Mom]}
   val x: Bippy = new AnyRef {

--- a/test/files/neg/t5060.check
+++ b/test/files/neg/t5060.check
@@ -1,7 +1,7 @@
-t5060.scala:2: error: covariant type T occurs in contravariant position in type => Object{def contains(x: T): Unit} of value foo0
+t5060.scala:2: error: covariant type T occurs in contravariant position in type => AnyRef{def contains(x: T): Unit} of value foo0
   val foo0 = {
       ^
-t5060.scala:6: error: covariant type T occurs in contravariant position in type => Object{def contains(x: T): Unit} of method foo1
+t5060.scala:6: error: covariant type T occurs in contravariant position in type => AnyRef{def contains(x: T): Unit} of method foo1
   def foo1 = {
       ^
 two errors found

--- a/test/files/neg/t5063.check
+++ b/test/files/neg/t5063.check
@@ -1,4 +1,4 @@
-t5063.scala:2: error: value + is not a member of Object
+t5063.scala:2: error: value + is not a member of AnyRef
   super.+("")
         ^
 one error found

--- a/test/files/neg/t6436.check
+++ b/test/files/neg/t6436.check
@@ -2,8 +2,8 @@ t6436.scala:8: error: type mismatch;
  found   : StringContext
  required: ?{def q: ?}
 Note that implicit conversions are not applicable because they are ambiguous:
- both method foo1 in object quasiquotes of type (ctx: StringContext)Object{def q: Nothing}
- and method foo2 in object quasiquotes of type (ctx: StringContext)Object{def q: Nothing}
+ both method foo1 in object quasiquotes of type (ctx: StringContext)AnyRef{def q: Nothing}
+ and method foo2 in object quasiquotes of type (ctx: StringContext)AnyRef{def q: Nothing}
  are possible conversion functions from StringContext to ?{def q: ?}
   println(q"a")
           ^

--- a/test/files/neg/t6436b.check
+++ b/test/files/neg/t6436b.check
@@ -2,8 +2,8 @@ t6436b.scala:8: error: type mismatch;
  found   : StringContext
  required: ?{def q: ?}
 Note that implicit conversions are not applicable because they are ambiguous:
- both method foo1 in object quasiquotes of type (ctx: StringContext)Object{def q: Nothing}
- and method foo2 in object quasiquotes of type (ctx: StringContext)Object{def q: Nothing}
+ both method foo1 in object quasiquotes of type (ctx: StringContext)AnyRef{def q: Nothing}
+ and method foo2 in object quasiquotes of type (ctx: StringContext)AnyRef{def q: Nothing}
  are possible conversion functions from StringContext to ?{def q: ?}
   println(StringContext("a").q())
                        ^

--- a/test/files/neg/t963.check
+++ b/test/files/neg/t963.check
@@ -5,7 +5,7 @@ t963.scala:17: error: stable identifier required, but Test.this.y4.x found.
   val w4 : y4.x.type = y4.x
               ^
 t963.scala:10: error: type mismatch;
- found   : Object{def x: Integer}
+ found   : AnyRef{def x: Integer}
  required: AnyRef{val x: Integer}
   val y2 : { val x : java.lang.Integer  } = new { def x = new java.lang.Integer(r.nextInt) }
                                             ^

--- a/test/files/pos/t6846.scala
+++ b/test/files/pos/t6846.scala
@@ -1,0 +1,28 @@
+object Test {
+  class Arb[_]
+  implicit def foo[M[_], A]: Arb[M[A]] = null
+  foo: Arb[List[Int]]
+  type ListInt = List[Int]
+  foo: Arb[ListInt]
+}
+
+object Test2 {
+  import scala.collection.immutable.List
+
+  class Carb[_]
+  implicit def narrow[N, M[_], A](x: Carb[M[A]])(implicit ev: N <:< M[A]): Carb[N] = null
+  implicit def bar[M[_], A]: Carb[M[A]] = null
+
+  type ListInt = List[Int]
+
+  val x: List[Int] = List(1)
+  val y: ListInt = List(1)
+
+  type ListSingletonX = x.type
+  type ListSingletonY = y.type
+
+  bar: Carb[List[Int]]
+  bar: Carb[ListInt]
+  bar: Carb[ListSingletonX]
+  bar: Carb[ListSingletonY]
+}

--- a/test/files/run/existentials-in-compiler.check
+++ b/test/files/run/existentials-in-compiler.check
@@ -1,156 +1,156 @@
-abstract trait Bippy[A <: AnyRef, B] extends Object
+abstract trait Bippy[A <: AnyRef, B] extends AnyRef
     extest.Bippy[_ <: AnyRef, _]
 
-abstract trait BippyBud[A <: AnyRef, B, C <: List[A]] extends Object
+abstract trait BippyBud[A <: AnyRef, B, C <: List[A]] extends AnyRef
     extest.BippyBud[A,B,C] forSome { A <: AnyRef; B; C <: List[A] }
 
-abstract trait BippyLike[A <: AnyRef, B <: List[A], This <: extest.BippyLike[A,B,This] with extest.Bippy[A,B]] extends Object
+abstract trait BippyLike[A <: AnyRef, B <: List[A], This <: extest.BippyLike[A,B,This] with extest.Bippy[A,B]] extends AnyRef
     extest.BippyLike[A,B,This] forSome { A <: AnyRef; B <: List[A]; This <: extest.BippyLike[A,B,This] with extest.Bippy[A,B] }
 
-abstract trait Contra[-A >: AnyRef, -B] extends Object
+abstract trait Contra[-A >: AnyRef, -B] extends AnyRef
     extest.Contra[_ >: AnyRef, _]
 
-abstract trait ContraLike[-A >: AnyRef, -B >: List[A]] extends Object
+abstract trait ContraLike[-A >: AnyRef, -B >: List[A]] extends AnyRef
     extest.ContraLike[A,B] forSome { -A >: AnyRef; -B >: List[A] }
 
-abstract trait Cov01[+A <: AnyRef, +B] extends Object
+abstract trait Cov01[+A <: AnyRef, +B] extends AnyRef
     extest.Cov01[_ <: AnyRef, _]
 
-abstract trait Cov02[+A <: AnyRef, B] extends Object
+abstract trait Cov02[+A <: AnyRef, B] extends AnyRef
     extest.Cov02[_ <: AnyRef, _]
 
-abstract trait Cov03[+A <: AnyRef, -B] extends Object
+abstract trait Cov03[+A <: AnyRef, -B] extends AnyRef
     extest.Cov03[_ <: AnyRef, _]
 
-abstract trait Cov04[A <: AnyRef, +B] extends Object
+abstract trait Cov04[A <: AnyRef, +B] extends AnyRef
     extest.Cov04[_ <: AnyRef, _]
 
-abstract trait Cov05[A <: AnyRef, B] extends Object
+abstract trait Cov05[A <: AnyRef, B] extends AnyRef
     extest.Cov05[_ <: AnyRef, _]
 
-abstract trait Cov06[A <: AnyRef, -B] extends Object
+abstract trait Cov06[A <: AnyRef, -B] extends AnyRef
     extest.Cov06[_ <: AnyRef, _]
 
-abstract trait Cov07[-A <: AnyRef, +B] extends Object
+abstract trait Cov07[-A <: AnyRef, +B] extends AnyRef
     extest.Cov07[_ <: AnyRef, _]
 
-abstract trait Cov08[-A <: AnyRef, B] extends Object
+abstract trait Cov08[-A <: AnyRef, B] extends AnyRef
     extest.Cov08[_ <: AnyRef, _]
 
-abstract trait Cov09[-A <: AnyRef, -B] extends Object
+abstract trait Cov09[-A <: AnyRef, -B] extends AnyRef
     extest.Cov09[_ <: AnyRef, _]
 
-abstract trait Cov11[+A <: AnyRef, +B <: List[_]] extends Object
+abstract trait Cov11[+A <: AnyRef, +B <: List[_]] extends AnyRef
     extest.Cov11[_ <: AnyRef, _ <: List[_]]
 
-abstract trait Cov12[+A <: AnyRef, B <: List[_]] extends Object
+abstract trait Cov12[+A <: AnyRef, B <: List[_]] extends AnyRef
     extest.Cov12[_ <: AnyRef, _ <: List[_]]
 
-abstract trait Cov13[+A <: AnyRef, -B <: List[_]] extends Object
+abstract trait Cov13[+A <: AnyRef, -B <: List[_]] extends AnyRef
     extest.Cov13[_ <: AnyRef, _ <: List[_]]
 
-abstract trait Cov14[A <: AnyRef, +B <: List[_]] extends Object
+abstract trait Cov14[A <: AnyRef, +B <: List[_]] extends AnyRef
     extest.Cov14[_ <: AnyRef, _ <: List[_]]
 
-abstract trait Cov15[A <: AnyRef, B <: List[_]] extends Object
+abstract trait Cov15[A <: AnyRef, B <: List[_]] extends AnyRef
     extest.Cov15[_ <: AnyRef, _ <: List[_]]
 
-abstract trait Cov16[A <: AnyRef, -B <: List[_]] extends Object
+abstract trait Cov16[A <: AnyRef, -B <: List[_]] extends AnyRef
     extest.Cov16[_ <: AnyRef, _ <: List[_]]
 
-abstract trait Cov17[-A <: AnyRef, +B <: List[_]] extends Object
+abstract trait Cov17[-A <: AnyRef, +B <: List[_]] extends AnyRef
     extest.Cov17[_ <: AnyRef, _ <: List[_]]
 
-abstract trait Cov18[-A <: AnyRef, B <: List[_]] extends Object
+abstract trait Cov18[-A <: AnyRef, B <: List[_]] extends AnyRef
     extest.Cov18[_ <: AnyRef, _ <: List[_]]
 
-abstract trait Cov19[-A <: AnyRef, -B <: List[_]] extends Object
+abstract trait Cov19[-A <: AnyRef, -B <: List[_]] extends AnyRef
     extest.Cov19[_ <: AnyRef, _ <: List[_]]
 
-abstract trait Cov21[+A, +B] extends Object
+abstract trait Cov21[+A, +B] extends AnyRef
     extest.Cov21[_, _]
 
-abstract trait Cov22[+A, B] extends Object
+abstract trait Cov22[+A, B] extends AnyRef
     extest.Cov22[_, _]
 
-abstract trait Cov23[+A, -B] extends Object
+abstract trait Cov23[+A, -B] extends AnyRef
     extest.Cov23[_, _]
 
-abstract trait Cov24[A, +B] extends Object
+abstract trait Cov24[A, +B] extends AnyRef
     extest.Cov24[_, _]
 
-abstract trait Cov25[A, B] extends Object
+abstract trait Cov25[A, B] extends AnyRef
     extest.Cov25[_, _]
 
-abstract trait Cov26[A, -B] extends Object
+abstract trait Cov26[A, -B] extends AnyRef
     extest.Cov26[_, _]
 
-abstract trait Cov27[-A, +B] extends Object
+abstract trait Cov27[-A, +B] extends AnyRef
     extest.Cov27[_, _]
 
-abstract trait Cov28[-A, B] extends Object
+abstract trait Cov28[-A, B] extends AnyRef
     extest.Cov28[_, _]
 
-abstract trait Cov29[-A, -B] extends Object
+abstract trait Cov29[-A, -B] extends AnyRef
     extest.Cov29[_, _]
 
-abstract trait Cov31[+A, +B, C <: (A, B)] extends Object
+abstract trait Cov31[+A, +B, C <: (A, B)] extends AnyRef
     extest.Cov31[A,B,C] forSome { +A; +B; C <: (A, B) }
 
-abstract trait Cov32[+A, B, C <: (A, B)] extends Object
+abstract trait Cov32[+A, B, C <: (A, B)] extends AnyRef
     extest.Cov32[A,B,C] forSome { +A; B; C <: (A, B) }
 
-abstract trait Cov33[+A, -B, C <: Tuple2[A, _]] extends Object
+abstract trait Cov33[+A, -B, C <: Tuple2[A, _]] extends AnyRef
     extest.Cov33[A,B,C] forSome { +A; -B; C <: Tuple2[A, _] }
 
-abstract trait Cov34[A, +B, C <: (A, B)] extends Object
+abstract trait Cov34[A, +B, C <: (A, B)] extends AnyRef
     extest.Cov34[A,B,C] forSome { A; +B; C <: (A, B) }
 
-abstract trait Cov35[A, B, C <: (A, B)] extends Object
+abstract trait Cov35[A, B, C <: (A, B)] extends AnyRef
     extest.Cov35[A,B,C] forSome { A; B; C <: (A, B) }
 
-abstract trait Cov36[A, -B, C <: Tuple2[A, _]] extends Object
+abstract trait Cov36[A, -B, C <: Tuple2[A, _]] extends AnyRef
     extest.Cov36[A,B,C] forSome { A; -B; C <: Tuple2[A, _] }
 
-abstract trait Cov37[-A, +B, C <: Tuple2[_, B]] extends Object
+abstract trait Cov37[-A, +B, C <: Tuple2[_, B]] extends AnyRef
     extest.Cov37[A,B,C] forSome { -A; +B; C <: Tuple2[_, B] }
 
-abstract trait Cov38[-A, B, C <: Tuple2[_, B]] extends Object
+abstract trait Cov38[-A, B, C <: Tuple2[_, B]] extends AnyRef
     extest.Cov38[A,B,C] forSome { -A; B; C <: Tuple2[_, B] }
 
-abstract trait Cov39[-A, -B, C <: Tuple2[_, _]] extends Object
+abstract trait Cov39[-A, -B, C <: Tuple2[_, _]] extends AnyRef
     extest.Cov39[_, _, _ <: Tuple2[_, _]]
 
-abstract trait Cov41[+A >: Null, +B] extends Object
+abstract trait Cov41[+A >: Null, +B] extends AnyRef
     extest.Cov41[_ >: Null, _]
 
-abstract trait Cov42[+A >: Null, B] extends Object
+abstract trait Cov42[+A >: Null, B] extends AnyRef
     extest.Cov42[_ >: Null, _]
 
-abstract trait Cov43[+A >: Null, -B] extends Object
+abstract trait Cov43[+A >: Null, -B] extends AnyRef
     extest.Cov43[_ >: Null, _]
 
-abstract trait Cov44[A >: Null, +B] extends Object
+abstract trait Cov44[A >: Null, +B] extends AnyRef
     extest.Cov44[_ >: Null, _]
 
-abstract trait Cov45[A >: Null, B] extends Object
+abstract trait Cov45[A >: Null, B] extends AnyRef
     extest.Cov45[_ >: Null, _]
 
-abstract trait Cov46[A >: Null, -B] extends Object
+abstract trait Cov46[A >: Null, -B] extends AnyRef
     extest.Cov46[_ >: Null, _]
 
-abstract trait Cov47[-A >: Null, +B] extends Object
+abstract trait Cov47[-A >: Null, +B] extends AnyRef
     extest.Cov47[_ >: Null, _]
 
-abstract trait Cov48[-A >: Null, B] extends Object
+abstract trait Cov48[-A >: Null, B] extends AnyRef
     extest.Cov48[_ >: Null, _]
 
-abstract trait Cov49[-A >: Null, -B] extends Object
+abstract trait Cov49[-A >: Null, -B] extends AnyRef
     extest.Cov49[_ >: Null, _]
 
-abstract trait Covariant[+A <: AnyRef, +B] extends Object
+abstract trait Covariant[+A <: AnyRef, +B] extends AnyRef
     extest.Covariant[_ <: AnyRef, _]
 
-abstract trait CovariantLike[+A <: AnyRef, +B <: List[A], +This <: extest.CovariantLike[A,B,This] with extest.Covariant[A,B]] extends Object
+abstract trait CovariantLike[+A <: AnyRef, +B <: List[A], +This <: extest.CovariantLike[A,B,This] with extest.Covariant[A,B]] extends AnyRef
     extest.CovariantLike[A,B,This] forSome { +A <: AnyRef; +B <: List[A]; +This <: extest.CovariantLike[A,B,This] with extest.Covariant[A,B] }
 

--- a/test/files/run/existentials3-new.check
+++ b/test/files/run/existentials3-new.check
@@ -7,7 +7,7 @@ Test.ToS, t=RefinedType, s=f5
 () => Test.ToS, t=TypeRef, s=trait Function0
 $anon, t=TypeRef, s=type $anon
 $anon, t=TypeRef, s=type $anon
-List[java.lang.Object{type T1}#T1], t=TypeRef, s=class List
+List[AnyRef{type T1}#T1], t=TypeRef, s=class List
 List[Seq[Int]], t=TypeRef, s=class List
 List[Seq[U forSome { type U <: Int }]], t=TypeRef, s=class List
 Bar.type, t=TypeRef, s=type Bar.type
@@ -19,6 +19,6 @@ Test.ToS, t=RefinedType, s=g5
 () => Test.ToS, t=TypeRef, s=trait Function0
 $anon, t=TypeRef, s=type $anon
 $anon, t=TypeRef, s=type $anon
-List[java.lang.Object{type T1}#T1], t=TypeRef, s=class List
+List[AnyRef{type T1}#T1], t=TypeRef, s=class List
 List[Seq[Int]], t=TypeRef, s=class List
 List[Seq[U forSome { type U <: Int }]], t=TypeRef, s=class List

--- a/test/files/run/existentials3-old.check
+++ b/test/files/run/existentials3-old.check
@@ -5,7 +5,7 @@ Object with Test$ToS
 Object with Test$ToS
 scala.Function0[Object with Test$ToS]
 scala.Function0[Object with Test$ToS]
-_ <: Object with _ <: Object with Test$ToS
+_ <: Object with _ <: Object with Object with Test$ToS
 _ <: Object with _ <: Object with _ <: Object with Test$ToS
 scala.collection.immutable.List[Object with scala.collection.Seq[Int]]
 scala.collection.immutable.List[Object with scala.collection.Seq[_ <: Int]]
@@ -16,7 +16,7 @@ Object with Test$ToS
 Object with Test$ToS
 scala.Function0[Object with Test$ToS]
 scala.Function0[Object with Test$ToS]
-_ <: Object with _ <: Object with Test$ToS
+_ <: Object with _ <: Object with Object with Test$ToS
 _ <: Object with _ <: Object with _ <: Object with Test$ToS
 scala.collection.immutable.List[Object with scala.collection.Seq[Int]]
 scala.collection.immutable.List[Object with scala.collection.Seq[_ <: Int]]

--- a/test/files/run/macro-declared-in-trait.check
+++ b/test/files/run/macro-declared-in-trait.check
@@ -1,5 +1,5 @@
 prefix = Expr[Nothing]({
-  final class $anon extends Object with Base {
+  final class $anon extends AnyRef with Base {
     def <init>(): anonymous class $anon = {
       $anon.super.<init>();
       ()

--- a/test/files/run/reflection-equality.check
+++ b/test/files/run/reflection-equality.check
@@ -24,7 +24,7 @@ cs: reflect.runtime.universe.ClassSymbol = class X
 
 scala> val ts: Type = cs.typeSignature
 ts: reflect.runtime.universe.Type = 
-java.lang.Object {
+scala.AnyRef {
   def <init>(): X
   def methodIntIntInt(x: scala.Int,y: scala.Int): scala.Int
 }

--- a/test/files/run/repl-colon-type.check
+++ b/test/files/run/repl-colon-type.check
@@ -77,10 +77,10 @@ scala> :type -v List(1,2,3) filter _
 
 // Internal Type structure
 TypeRef(
-  TypeSymbol(abstract trait Function1[-T1, +R] extends Object)
+  TypeSymbol(abstract trait Function1[-T1, +R] extends AnyRef)
   args = List(
     TypeRef(
-      TypeSymbol(abstract trait Function1[-T1, +R] extends Object)
+      TypeSymbol(abstract trait Function1[-T1, +R] extends AnyRef)
       args = List(
         TypeRef(TypeSymbol(final abstract class Int extends AnyVal))
         TypeRef(
@@ -147,7 +147,7 @@ Int => Iterator[List[Nothing]]
 
 // Internal Type structure
 TypeRef(
-  TypeSymbol(abstract trait Function1[-T1, +R] extends Object)
+  TypeSymbol(abstract trait Function1[-T1, +R] extends AnyRef)
   args = List(
     TypeRef(TypeSymbol(final abstract class Int extends AnyVal))
     TypeRef(
@@ -180,7 +180,7 @@ PolyType(
   typeParams = List(TypeParam(T <: AnyVal))
   resultType = NullaryMethodType(
     TypeRef(
-      TypeSymbol(abstract trait Function1[-T1, +R] extends Object)
+      TypeSymbol(abstract trait Function1[-T1, +R] extends AnyRef)
       args = List(
         TypeRef(TypeSymbol(final abstract class Int extends AnyVal))
         TypeRef(

--- a/test/files/run/repl-parens.check
+++ b/test/files/run/repl-parens.check
@@ -66,7 +66,7 @@ scala> 55 ; () => 5
 res13: () => Int = <function0>
 
 scala> () => { class X ; new X }
-res14: () => Object = <function0>
+res14: () => AnyRef = <function0>
 
 scala> 
 

--- a/test/files/run/t4172.check
+++ b/test/files/run/t4172.check
@@ -5,7 +5,7 @@ scala>
 
 scala>     val c = { class C { override def toString = "C" }; ((new C, new C { def f = 2 })) }
 warning: there were 1 feature warnings; re-run with -feature for details
-c: (C, C{def f: Int}) forSome { type C <: Object } = (C,C)
+c: (C, C{def f: Int}) forSome { type C <: AnyRef } = (C,C)
 
 scala> 
 

--- a/test/files/run/t5256a.check
+++ b/test/files/run/t5256a.check
@@ -1,6 +1,6 @@
 class A
 A
-Object {
+AnyRef {
   def <init>(): A
   def foo: Nothing
 }

--- a/test/files/run/t5256b.check
+++ b/test/files/run/t5256b.check
@@ -1,6 +1,6 @@
 class A
 Test.A
-Object {
+AnyRef {
   def <init>(): Test.A
   def foo: Nothing
 }

--- a/test/files/run/t5256d.check
+++ b/test/files/run/t5256d.check
@@ -22,7 +22,7 @@ scala> println(c.fullName)
 $line8.$read.$iw.$iw.$iw.$iw.A
 
 scala> println(c.typeSignature)
-java.lang.Object {
+scala.AnyRef {
   def <init>(): A
   def foo: scala.Nothing
 }

--- a/test/files/run/t5256e.check
+++ b/test/files/run/t5256e.check
@@ -1,6 +1,6 @@
 class A
 Test.C.A
-Object {
+AnyRef {
   def <init>(): C.this.A
   def foo: Nothing
 }

--- a/test/files/run/t5256f.check
+++ b/test/files/run/t5256f.check
@@ -1,12 +1,12 @@
 class A1
 Test.A1
-Object {
+AnyRef {
   def <init>(): Test.A1
   def foo: Nothing
 }
 class A2
 Test.A2
-Object {
+AnyRef {
   def <init>(): Test.this.A2
   def foo: Nothing
 }

--- a/test/files/scalap/abstractClass/result.test
+++ b/test/files/scalap/abstractClass/result.test
@@ -1,4 +1,4 @@
-abstract class AbstractClass extends java.lang.Object {
+abstract class AbstractClass extends scala.AnyRef {
   def this() = { /* compiled code */ }
   def foo : scala.Predef.String
 }

--- a/test/files/scalap/abstractMethod/result.test
+++ b/test/files/scalap/abstractMethod/result.test
@@ -1,4 +1,4 @@
-trait AbstractMethod extends java.lang.Object {
+trait AbstractMethod extends scala.AnyRef {
   def $init$() : scala.Unit = { /* compiled code */ }
   def arity : scala.Int
   def isCool : scala.Boolean = { /* compiled code */ }

--- a/test/files/scalap/cbnParam/result.test
+++ b/test/files/scalap/cbnParam/result.test
@@ -1,3 +1,3 @@
-class CbnParam extends java.lang.Object {
+class CbnParam extends scala.AnyRef {
   def this(s : => scala.Predef.String) = { /* compiled code */ }
 }

--- a/test/files/scalap/classPrivate/result.test
+++ b/test/files/scalap/classPrivate/result.test
@@ -1,7 +1,7 @@
-class ClassPrivate extends java.lang.Object {
+class ClassPrivate extends scala.AnyRef {
   def this() = { /* compiled code */ }
   def baz : scala.Int = { /* compiled code */ }
-  class Outer extends java.lang.Object {
+  class Outer extends scala.AnyRef {
     def this() = { /* compiled code */ }
     private[ClassPrivate] def qux : scala.Int = { /* compiled code */ }
   }

--- a/test/files/scalap/classWithExistential/result.test
+++ b/test/files/scalap/classWithExistential/result.test
@@ -1,4 +1,4 @@
-class ClassWithExistential extends java.lang.Object {
+class ClassWithExistential extends scala.AnyRef {
   def this() = { /* compiled code */ }
   def foo[A, B] : scala.Function1[A, B forSome {type A <: scala.Seq[scala.Int]; type B >: scala.Predef.String}] = { /* compiled code */ }
 }

--- a/test/files/scalap/classWithSelfAnnotation/result.test
+++ b/test/files/scalap/classWithSelfAnnotation/result.test
@@ -1,4 +1,4 @@
-class ClassWithSelfAnnotation extends java.lang.Object {
+class ClassWithSelfAnnotation extends scala.AnyRef {
  this : ClassWithSelfAnnotation with java.lang.CharSequence =>
   def this() = { /* compiled code */ }
   def foo : scala.Int = { /* compiled code */ }

--- a/test/files/scalap/covariantParam/result.test
+++ b/test/files/scalap/covariantParam/result.test
@@ -1,4 +1,4 @@
-class CovariantParam[+A] extends java.lang.Object {
+class CovariantParam[+A] extends scala.AnyRef {
   def this() = { /* compiled code */ }
   def foo[A](a : A) : scala.Int = { /* compiled code */ }
 }

--- a/test/files/scalap/defaultParameter/result.test
+++ b/test/files/scalap/defaultParameter/result.test
@@ -1,3 +1,3 @@
-trait DefaultParameter extends java.lang.Object {
+trait DefaultParameter extends scala.AnyRef {
   def foo(s : scala.Predef.String) : scala.Unit
 }

--- a/test/files/scalap/implicitParam/result.test
+++ b/test/files/scalap/implicitParam/result.test
@@ -1,4 +1,4 @@
-class ImplicitParam extends java.lang.Object {
+class ImplicitParam extends scala.AnyRef {
   def this() = { /* compiled code */ }
   def foo(i : scala.Int)(implicit f : scala.Float, d : scala.Double) : scala.Int = { /* compiled code */ }
 }

--- a/test/files/scalap/packageObject/result.test
+++ b/test/files/scalap/packageObject/result.test
@@ -1,4 +1,4 @@
-package object PackageObject extends java.lang.Object {
+package object PackageObject extends scala.AnyRef {
   def this() = { /* compiled code */ }
   type A = scala.Predef.String
   def foo(i : scala.Int) : scala.Int = { /* compiled code */ }

--- a/test/files/scalap/paramClauses/result.test
+++ b/test/files/scalap/paramClauses/result.test
@@ -1,4 +1,4 @@
-class ParamClauses extends java.lang.Object {
+class ParamClauses extends scala.AnyRef {
   def this() = { /* compiled code */ }
   def foo(i : scala.Int)(s : scala.Predef.String)(t : scala.Double) : scala.Int = { /* compiled code */ }
 }

--- a/test/files/scalap/paramNames/result.test
+++ b/test/files/scalap/paramNames/result.test
@@ -1,4 +1,4 @@
-class ParamNames extends java.lang.Object {
+class ParamNames extends scala.AnyRef {
   def this() = { /* compiled code */ }
   def foo(s : => scala.Seq[scala.Int], s2 : => scala.Seq[scala.Any]) : scala.Unit = { /* compiled code */ }
 }

--- a/test/files/scalap/sequenceParam/result.test
+++ b/test/files/scalap/sequenceParam/result.test
@@ -1,3 +1,3 @@
-class SequenceParam extends java.lang.Object {
+class SequenceParam extends scala.AnyRef {
   def this(s : scala.Predef.String, i : scala.Int*) = { /* compiled code */ }
 }

--- a/test/files/scalap/simpleClass/result.test
+++ b/test/files/scalap/simpleClass/result.test
@@ -1,4 +1,4 @@
-class SimpleClass extends java.lang.Object {
+class SimpleClass extends scala.AnyRef {
   def this() = { /* compiled code */ }
   def foo : scala.Int = { /* compiled code */ }
 }

--- a/test/files/scalap/traitObject/result.test
+++ b/test/files/scalap/traitObject/result.test
@@ -1,8 +1,8 @@
-trait TraitObject extends java.lang.Object {
+trait TraitObject extends scala.AnyRef {
   def $init$() : scala.Unit = { /* compiled code */ }
   def foo : scala.Int = { /* compiled code */ }
 }
-object TraitObject extends java.lang.Object {
+object TraitObject extends scala.AnyRef {
   def this() = { /* compiled code */ }
   def bar : scala.Int = { /* compiled code */ }
 }

--- a/test/files/scalap/typeAnnotations/result.test
+++ b/test/files/scalap/typeAnnotations/result.test
@@ -1,4 +1,4 @@
-abstract class TypeAnnotations[@scala.specialized R] extends java.lang.Object {
+abstract class TypeAnnotations[@scala.specialized R] extends scala.AnyRef {
   def this() = { /* compiled code */ }
   @scala.specialized
   val x : scala.Int = { /* compiled code */ }

--- a/test/files/scalap/valAndVar/result.test
+++ b/test/files/scalap/valAndVar/result.test
@@ -1,4 +1,4 @@
-class ValAndVar extends java.lang.Object {
+class ValAndVar extends scala.AnyRef {
   def this() = { /* compiled code */ }
   val foo : java.lang.String = { /* compiled code */ }
   var bar : scala.Int = { /* compiled code */ }

--- a/test/files/scalap/wildcardType/result.test
+++ b/test/files/scalap/wildcardType/result.test
@@ -1,3 +1,3 @@
-class WildcardType extends java.lang.Object {
+class WildcardType extends scala.AnyRef {
   def this(f : scala.Function1[scala.Int, _]) = { /* compiled code */ }
 }


### PR DESCRIPTION
Squashed commit of the following:

commit 55806cc0e6177820c12a35a18b4f2a12dc07bb39
Author: Paul Phillips paulp@improving.org
Date:   Wed Dec 19 07:32:19 2012 -0800

```
SI-6846, regression in type constructor inference.

In 658ba1b4e6 some inference was gained and some was lost.
In this commit we regain what was lost and gain even more.
Dealiasing and widening should be fully handled now, as
illustrated by the test case.
(cherry picked from commit dbebcd509e4013ce02655a2687b27d0967b3650e)
```

commit e6ef58447d0f4ef6de956fcc03ee283bb9028c02
Author: Paul Phillips paulp@improving.org
Date:   Fri Dec 21 15:11:29 2012 -0800

```
Cleaning up type alias usage.

I determined that many if not most of the calls to .normalize
have no intent beyond dealiasing the type. In light of this I
went call site to call site knocking on doors and asking why
exactly they were calling any of

  .normalize
  .widen.normalize
  .normalize.widen

and if I didn't like their answers they found themselves
introduced to 'dropAliasesAndSingleTypes', the recursive widener
and dealiaser which I concluded is necessary after all.

Discovered that the object called 'deAlias' actually depends
upon calling 'normalize', not 'dealias'. Decided this was
sufficient cause to rename it to 'normalizeAliases'.

Created dealiasWiden and dealiasWidenChain.

Dropped dropAliasesAndSingleTypes in favor of methods
on Type alongside dealias and widen (Type#dealiasWiden).
These should reduce the number of "hey, the type alias doesn't work" bugs.

(cherry picked from commit 3bf51189f979eb0dd41744ca844fd12dfdaa0dee)

Conflicts:
    src/compiler/scala/tools/nsc/interpreter/CompletionOutput.scala
```

commit c1d8803cea1523f458730103386d8e14324a9446
Author: Paul Phillips paulp@improving.org
Date:   Sat Dec 22 08:13:48 2012 -0800

```
Shored up a hidden dealiasing dependency.

Like the comment says:

// This way typedNew always returns a dealiased type. This
// used to happen by accident for instantiations without type
// arguments due to ad hoc code in typedTypeConstructor, and
// annotations depended on it (to the extent that they worked,
// which they did not when given a parameterized type alias
// which dealiased to an annotation.) typedTypeConstructor
// dealiases nothing now, but it makes sense for a "new" to
// always be given a dealiased type.

PS:
Simply running the test suite is becoming more difficult all
the time. Running "ant test" includes time consuming activities
of niche interest such as all the osgi tests, but test.suite
manages to miss the continuations tests.
(cherry picked from commit 422f461578ae0547181afe6d2c0c52ea1071d37b)
```

commit da4748502792b260161baa10939554564c488051
Author: Paul Phillips paulp@improving.org
Date:   Fri Dec 21 12:39:02 2012 -0800

```
Fix and simplify typedTypeConstructor.

Investigating the useful output of devWarning (-Xdev people,
it's good for you) led back to this comment:

  "normalize to get rid of type aliases"

You may know that this is not all the normalizing does.
Normalizing also turns TypeRefs with unapplied arguments
(type constructors) into PolyTypes. That means that when
typedParentType would call typedTypeConstructor it would
find its parent had morphed into a PolyType. Not that it
noticed; it would blithely continue and unwittingly discard
the type arguments by way of appliedType (which smoothly
logged the incident, thank you appliedType.)

The simplification of typedTypeConstructor:

There was a whole complicated special treatment of AnyRef
here which appears to have become unnecessary. Removed special
treatment and lit a candle for regularity.

Updated lots of tests regarding newly not-so-special AnyRef.
(cherry picked from commit 394cc426c1ff1da53146679b4e2995ece52a133e)
```

commit 1f3c77bacb2fbb3ba9e4ad0a8a733e0f9263b234
Author: Paul Phillips paulp@improving.org
Date:   Fri Dec 21 15:06:10 2012 -0800

```
Removed dead implementation.

Another "attractive nuisance" burning off time until I
realized it was commented out.
(cherry picked from commit ed40f5cbdf35d09b02898e9c0950b9bd34c1f858)
```

Review by @paulp
