### PR TITLE
SI-6863 Fix verify error in captured var created from try/catch

### DIFF
--- a/test/files/run/t6863.scala
+++ b/test/files/run/t6863.scala
@@ -1,0 +1,14 @@
+object Test {
+
+  def main(args: Array[String]) {
+
+    var coll = {
+      val key = 4
+      try   { null }
+      catch { case _ => null }
+    }
+
+    { () => coll } // the purpose of this is making `coll` an ObjectRef
+
+  }
+}


### PR DESCRIPTION
If a var is assigned from a try/catch and it's captured into a ref
then we were generating invalid byte code. The fix basically
undoes commit b2f3fb271342d7862cc045f5ee5cff6815ac9722
and adds a test to make sure this case doesn't regress again.

review @magarciaEPFL, @paulp
