### PR TITLE
Made "mode" into a value class.

### DIFF
--- a/src/compiler/scala/reflect/macros/runtime/Typers.scala
+++ b/src/compiler/scala/reflect/macros/runtime/Typers.scala
@@ -1,6 +1,8 @@
 package scala.reflect.macros
 package runtime
 
+import scala.reflect.internal.Mode
+
 trait Typers {
   self: Context =>
 
@@ -22,7 +24,7 @@ trait Typers {
     // typechecking uses silent anyways (e.g. in typedSelect), so you'll only waste your time
     // I'd advise fixing the root cause: finding why the context is not set to report errors
     // (also see reflect.runtime.ToolBoxes.typeCheckExpr for a workaround that might work for you)
-    wrapper(callsiteTyper.silent(_.typed(tree, universe.analyzer.EXPRmode, pt)) match {
+    wrapper(callsiteTyper.silent(_.typed(tree, Mode.EXPRmode, pt)) match {
       case universe.analyzer.SilentResultValue(result) =>
         macroLogVerbose(result)
         result

--- a/src/compiler/scala/tools/nsc/doc/model/ModelFactoryImplicitSupport.scala
+++ b/src/compiler/scala/tools/nsc/doc/model/ModelFactoryImplicitSupport.scala
@@ -170,7 +170,7 @@ trait ModelFactoryImplicitSupport {
         val newContext = context.makeImplicit(context.ambiguousErrors)
         newContext.macrosEnabled = false
         val newTyper = global.analyzer.newTyper(newContext)
-          newTyper.silent(_.typed(appliedTree, global.analyzer.EXPRmode, WildcardType), false) match {
+          newTyper.silent(_.typed(appliedTree, EXPRmode, WildcardType), false) match {
 
           case global.analyzer.SilentResultValue(t: Tree) => t
           case global.analyzer.SilentTypeError(err) =>

--- a/src/compiler/scala/tools/nsc/interpreter/ReplGlobal.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/ReplGlobal.scala
@@ -24,7 +24,7 @@ trait ReplGlobal extends Global {
     val global: ReplGlobal.this.type = ReplGlobal.this
   } with Analyzer {
     override def newTyper(context: Context): Typer = new Typer(context) {
-      override def typed(tree: Tree, mode: Int, pt: Type): Tree = {
+      override def typed(tree: Tree, mode: Mode, pt: Type): Tree = {
         val res = super.typed(tree, mode, pt)
         tree match {
           case Ident(name) if !tree.symbol.hasPackageFlag && !name.toString.startsWith("$") =>

--- a/src/compiler/scala/tools/nsc/package.scala
+++ b/src/compiler/scala/tools/nsc/package.scala
@@ -6,6 +6,15 @@
 package scala.tools
 
 package object nsc {
+  type Mode = scala.reflect.internal.Mode
+  val Mode = scala.reflect.internal.Mode
+
+  def EXPRmode = Mode.EXPRmode
+  def BYVALmode = Mode.BYVALmode
+  def POLYmode = Mode.POLYmode
+  def TAPPmode = Mode.TAPPmode
+  def FUNmode = Mode.FUNmode
+
   type Phase = scala.reflect.internal.Phase
   val NoPhase = scala.reflect.internal.NoPhase
 

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -10,6 +10,7 @@ import scala.reflect.internal.ClassfileConstants._
 import scala.collection.{ mutable, immutable }
 import symtab._
 import Flags._
+import scala.reflect.internal.Mode._
 
 abstract class Erasure extends AddInterfaces
                           with scala.reflect.internal.transform.Erasure
@@ -801,12 +802,12 @@ abstract class Erasure extends AddInterfaces
 
     /** A replacement for the standard typer's adapt method.
      */
-    override protected def adapt(tree: Tree, mode: Int, pt: Type, original: Tree = EmptyTree): Tree =
+    override protected def adapt(tree: Tree, mode: Mode, pt: Type, original: Tree = EmptyTree): Tree =
       adaptToType(tree, pt)
 
     /** A replacement for the standard typer's `typed1` method.
      */
-    override def typed1(tree: Tree, mode: Int, pt: Type): Tree = {
+    override def typed1(tree: Tree, mode: Mode, pt: Type): Tree = {
       val tree1 = try {
         tree match {
           case InjectDerivedValue(arg) =>

--- a/src/compiler/scala/tools/nsc/typechecker/Duplicators.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Duplicators.scala
@@ -197,7 +197,7 @@ abstract class Duplicators extends Analyzer {
      *  their symbols are recreated ad-hoc and their types are fixed inline, instead of letting the
      *  namer/typer handle them, or Idents that refer to them.
      */
-    override def typed(tree: Tree, mode: Int, pt: Type): Tree = {
+    override def typed(tree: Tree, mode: Mode, pt: Type): Tree = {
       debuglog("typing " + tree + ": " + tree.tpe + ", " + tree.getClass)
       val origtreesym = tree.symbol
       if (tree.hasSymbolField && tree.symbol != NoSymbol

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -676,7 +676,7 @@ trait Macros extends scala.tools.reflect.FastTrack with Traces {
    *    the expandee with an error marker set   if the expansion has been cancelled due malformed arguments or implementation
    *    the expandee with an error marker set   if there has been an error
    */
-  def macroExpand(typer: Typer, expandee: Tree, mode: Int = EXPRmode, pt: Type = WildcardType): Tree = {
+  def macroExpand(typer: Typer, expandee: Tree, mode: Mode = EXPRmode, pt: Type = WildcardType): Tree = {
     val start = if (Statistics.canEnable) Statistics.startTimer(macroExpandNanos) else null
     if (Statistics.canEnable) Statistics.incCounter(macroExpandCount)
     try {

--- a/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
@@ -104,7 +104,7 @@ trait NamesDefaults { self: Analyzer =>
    *  @return the transformed application (a Block) together with the NamedApplyInfo.
    *     if isNamedApplyBlock(tree), returns the existing context.namedApplyBlockInfo
    */
-  def transformNamedApplication(typer: Typer, mode: Int, pt: Type)
+  def transformNamedApplication(typer: Typer, mode: Mode, pt: Type)
                                (tree: Tree, argPos: Int => Int): Tree = {
     import typer._
     import typer.infer._

--- a/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
@@ -189,7 +189,7 @@ abstract class TreeCheckers extends Analyzer {
       if (t.symbol == NoSymbol)
         errorFn(t.pos, "no symbol: " + treestr(t))
 
-    override def typed(tree: Tree, mode: Int, pt: Type): Tree = returning(tree) {
+    override def typed(tree: Tree, mode: Mode, pt: Type): Tree = returning(tree) {
       case EmptyTree | TypeTree() => ()
       case _ if tree.tpe != null  =>
         tpeOfTree.getOrElseUpdate(tree, try tree.tpe finally tree.clearType())

--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -552,7 +552,7 @@ trait TypeDiagnostics {
       }
 
       // The checkDead call from typedArg is more selective.
-      def inMode(mode: Int, tree: Tree): Tree = {
+      def inMode(mode: Mode, tree: Tree): Tree = {
         val modeOK = (mode & (EXPRmode | BYVALmode | POLYmode)) == (EXPRmode | BYVALmode)
         if (modeOK) apply(tree)
         else tree

--- a/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
+++ b/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
@@ -1,6 +1,7 @@
 package scala.tools
 package reflect
 
+import scala.tools.nsc.EXPRmode
 import scala.tools.nsc.reporters._
 import scala.tools.nsc.CompilerCommand
 import scala.tools.nsc.io.VirtualDirectory
@@ -163,7 +164,7 @@ abstract class ToolBoxFactory[U <: JavaUniverse](val u: U) { factorySelf =>
         transformDuringTyper(expr, withImplicitViewsDisabled = withImplicitViewsDisabled, withMacrosDisabled = withMacrosDisabled)(
           (currentTyper, expr) => {
             trace("typing (implicit views = %s, macros = %s): ".format(!withImplicitViewsDisabled, !withMacrosDisabled))(showAttributed(expr, true, true, settings.Yshowsymkinds.value))
-            currentTyper.silent(_.typed(expr, analyzer.EXPRmode, pt)) match {
+            currentTyper.silent(_.typed(expr, EXPRmode, pt)) match {
               case analyzer.SilentResultValue(result) =>
                 trace("success: ")(showAttributed(result, true, true, settings.Yshowsymkinds.value))
                 result

--- a/src/reflect/scala/reflect/internal/AnnotationCheckers.scala
+++ b/src/reflect/scala/reflect/internal/AnnotationCheckers.scala
@@ -39,14 +39,14 @@ trait AnnotationCheckers {
     /** Decide whether this annotation checker can adapt a tree
      *  that has an annotated type to the given type tp, taking
      *  into account the given mode (see method adapt in trait Typers).*/
-    def canAdaptAnnotations(tree: Tree, mode: Int, pt: Type): Boolean = false
+    def canAdaptAnnotations(tree: Tree, mode: Mode, pt: Type): Boolean = false
 
     /** Adapt a tree that has an annotated type to the given type tp,
      *  taking into account the given mode (see method adapt in trait Typers).
      *  An implementation cannot rely on canAdaptAnnotations being called
      *  before. If the implementing class cannot do the adaptiong, it
      *  should return the tree unchanged.*/
-    def adaptAnnotations(tree: Tree, mode: Int, pt: Type): Tree = tree
+    def adaptAnnotations(tree: Tree, mode: Mode, pt: Type): Tree = tree
 
     /** Adapt the type of a return expression. The decision of an annotation checker
      *  whether the type should be adapted is based on the type of the expression
@@ -113,7 +113,7 @@ trait AnnotationCheckers {
 
   /** Find out whether any annotation checker can adapt a tree
    *  to a given type. Called by Typers.adapt. */
-  def canAdaptAnnotations(tree: Tree, mode: Int, pt: Type): Boolean = {
+  def canAdaptAnnotations(tree: Tree, mode: Mode, pt: Type): Boolean = {
     annotationCheckers.exists(_.canAdaptAnnotations(tree, mode, pt))
   }
 
@@ -121,7 +121,7 @@ trait AnnotationCheckers {
    *  to a given type (called by Typers.adapt). Annotation checkers
    *  that cannot do the adaption should pass the tree through
    *  unchanged. */
-  def adaptAnnotations(tree: Tree, mode: Int, pt: Type): Tree = {
+  def adaptAnnotations(tree: Tree, mode: Mode, pt: Type): Tree = {
     annotationCheckers.foldLeft(tree)((tree, checker) =>
       checker.adaptAnnotations(tree, mode, pt))
   }
@@ -129,7 +129,7 @@ trait AnnotationCheckers {
   /** Let a registered annotation checker adapt the type of a return expression.
    *  Annotation checkers that cannot do the adaptation should simply return
    *  the `default` argument.
-   *  
+   *
    *  Note that the result is undefined if more than one annotation checker
    *  returns an adapted type which is not a subtype of `default`.
    */

--- a/test/files/pos/CustomGlobal.scala
+++ b/test/files/pos/CustomGlobal.scala
@@ -22,7 +22,7 @@ class CustomGlobal(currentSettings: Settings, reporter: Reporter) extends Global
     override def newTyper(context: Context): Typer = new CustomTyper(context)
 
     class CustomTyper(context : Context) extends Typer(context) {
-      override def typed(tree: Tree, mode: Int, pt: Type): Tree = {
+      override def typed(tree: Tree, mode: Mode, pt: Type): Tree = {
         if (tree.summaryString contains "Bippy")
           println("I'm typing a Bippy! It's a " + tree.shortClass + ".")
 


### PR DESCRIPTION
This is an obvious place to apply value class goodness and
collect some safety/sanity in typing modes. It does show off
a challenge in introducing value classes without disruption:
there's no way to deprecate the old signature of 'typed',
'adapt', etc. because they erase the same.

```
  class Bippy(val x: Int) extends AnyVal
  class A {
    @deprecated("Use a bippy") def f(x: Int): Int = 5
    def f(x: Bippy): Int = x.x
  }

  ./a.scala:5: error: double definition:
  method f:(x: Bippy)Int and
  method f:(x: Int)Int at line 4
  have same type after erasure: (x: Int)Int
```

An Int => Mode implicit handles most uses, but nothing can
be done to avoid breaking anything which e.g. extends Typer
and overrides typed.
