### PR TITLE
SI-5189 detect unsoundness when inferring type of match

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2433,11 +2433,7 @@ trait Typers extends Adaptations with Tags {
       }
 
 //    body1 = checkNoEscaping.locals(context.scope, pt, body1)
-      val treeWithSkolems = treeCopy.CaseDef(cdef, pat1, guard1, body1) setType body1.tpe
-
-      new TypeMapTreeSubstituter(deskolemizeGADTSkolems).traverse(treeWithSkolems)
-
-      treeWithSkolems // now without skolems, actually
+      treeCopy.CaseDef(cdef, pat1, guard1, body1) setType body1.tpe
     }
 
     // undo adaptConstrPattern's evil deeds, as they confuse the old pattern matcher
@@ -2470,7 +2466,10 @@ trait Typers extends Adaptations with Tags {
 
       val casesAdapted = if (!needAdapt) casesTyped else casesTyped map (adaptCase(_, mode, resTp))
 
-      treeCopy.Match(tree, selector1, casesAdapted) setType resTp
+      val matchTyped = treeCopy.Match(tree, selector1, casesAdapted) setType resTp
+      if (!newPatternMatching) // TODO: remove this in 2.11 -- only needed for old pattern matcher
+        new TypeMapTreeSubstituter(deskolemizeGADTSkolems).traverse(matchTyped)
+      matchTyped
     }
 
     // match has been typed -- virtualize it during type checking so the full context is available

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2436,16 +2436,6 @@ trait Typers extends Adaptations with Tags {
       treeCopy.CaseDef(cdef, pat1, guard1, body1) setType body1.tpe
     }
 
-    // undo adaptConstrPattern's evil deeds, as they confuse the old pattern matcher
-    // the flags are used to avoid accidentally deskolemizing unrelated skolems of skolems
-    object deskolemizeGADTSkolems extends TypeMap {
-      def apply(tp: Type): Type = mapOver(tp) match {
-        case TypeRef(pre, sym, args) if sym.isGADTSkolem =>
-          typeRef(NoPrefix, sym.deSkolemize, args)
-        case tp1 => tp1
-      }
-    }
-
     def typedCases(cases: List[CaseDef], pattp: Type, pt: Type): List[CaseDef] =
       cases mapConserve { cdef =>
         newTyper(context.makeNewScope(cdef, context.owner)).typedCase(cdef, pattp, pt)
@@ -2466,10 +2456,7 @@ trait Typers extends Adaptations with Tags {
 
       val casesAdapted = if (!needAdapt) casesTyped else casesTyped map (adaptCase(_, mode, resTp))
 
-      val matchTyped = treeCopy.Match(tree, selector1, casesAdapted) setType resTp
-      if (!newPatternMatching) // TODO: remove this in 2.11 -- only needed for old pattern matcher
-        new TypeMapTreeSubstituter(deskolemizeGADTSkolems).traverse(matchTyped)
-      matchTyped
+      treeCopy.Match(tree, selector1, casesAdapted) setType resTp
     }
 
     // match has been typed -- virtualize it during type checking so the full context is available
@@ -2491,12 +2478,11 @@ trait Typers extends Adaptations with Tags {
     // Match(EmptyTree, cases) ==> new PartialFunction { def apply<OrElse>(params) = `translateMatch('`(param1,...,paramN)` match { cases }')` }
     // for fresh params, the selector of the match we'll translated simply gathers those in a tuple
     // NOTE: restricted to PartialFunction -- leave Function trees if the expected type does not demand a partial function
-    class MatchFunTyper(tree: Tree, cases: List[CaseDef], mode: Mode, pt0: Type)  {
+    class MatchFunTyper(tree: Tree, cases: List[CaseDef], mode: Mode, pt: Type)  {
       // TODO: remove FunctionN support -- this is currently designed so that it can emit FunctionN and PartialFunction subclasses
       // however, we should leave Function nodes until Uncurry so phases after typer can still detect normal Function trees
       // we need to synthesize PartialFunction impls, though, to avoid nastiness in Uncurry in transforming&duplicating generated pattern matcher trees
       // TODO: remove PartialFunction support from UnCurry
-      private val pt    = deskolemizeGADTSkolems(pt0)
       private val targs = pt.normalize.typeArgs
       private val arity = if (isFunctionType(pt)) targs.length - 1 else 1 // TODO pt should always be a (Partial)Function, right?
       private val ptRes = if (targs.isEmpty) WildcardType else targs.last // may not be fully defined

--- a/test/files/neg/t5189_inferred.check
+++ b/test/files/neg/t5189_inferred.check
@@ -1,0 +1,6 @@
+t5189_inferred.scala:7: error: type mismatch;
+ found   : scala.collection.immutable.Nil.type
+ required: ?A1 where type ?A1
+  f(Invariant(arr): Covariant[Any])(0) = Nil
+                                         ^
+one error found

--- a/test/files/neg/t5189_inferred.scala
+++ b/test/files/neg/t5189_inferred.scala
@@ -1,0 +1,8 @@
+trait Covariant[+A]
+case class Invariant[A](xs: Array[A]) extends Covariant[A]
+
+class Test {
+  val arr = Array("abc")
+  def f[A](v: Covariant[A]) /*inferred!*/ = v match { case Invariant(xs) => xs }
+  f(Invariant(arr): Covariant[Any])(0) = Nil
+}


### PR DESCRIPTION
GADT skolems encode type slack that results from pattern matching on variant type constructors. I thought they would not longer be relevant after cases have been typed,
and since they caused weird issues with the old pattern matcher, I deskolemized in typedCase

however, when we don't have an expected type for the match, we need to keep the skolems around until the skolemized type makes it out of the match and it becomes the result of type inference for that match when you do have an expected type, it will propagate to the case-level and the confrontation will thus already take place when typing individual cases

[foward port of #1876]
