### PR TITLE
SI-6966 Fix regression in implicit resolution

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -668,7 +668,11 @@ trait Implicits {
             // duplicating the code here, but this is probably a
             // hotspot (and you can't just call typed, need to force
             // re-typecheck)
-            val checked = itree2 match {
+            //
+            // This is just called for the side effect of error detection,
+            // see SI-6966 to see what goes wrong if we use the result of this
+            // as the SearchResult.
+            itree2 match {
               case TypeApply(fun, args)           => typedTypeApply(itree2, EXPRmode, fun, args)
               case Apply(TypeApply(fun, args), _) => typedTypeApply(itree2, EXPRmode, fun, args) // t2421c
               case t                              => t
@@ -677,7 +681,7 @@ trait Implicits {
             if (context.hasErrors)
               fail("typing TypeApply reported errors for the implicit tree: " + context.errBuffer.head.errMsg)
             else {
-              val result = new SearchResult(checked, subst)
+              val result = new SearchResult(itree2, subst)
               if (Statistics.canEnable) Statistics.incCounter(foundImplicits)
               printInference("[success] found %s for pt %s".format(result, ptInstantiated))
               result

--- a/test/files/pos/t6966.scala
+++ b/test/files/pos/t6966.scala
@@ -1,0 +1,17 @@
+import Ordering.{Byte, comparatorToOrdering}
+trait Format[T]
+trait InputCache[T]
+object CacheIvy {
+	implicit def basicInputCache[I](implicit fmt: Format[I], eqv: Equiv[I]): InputCache[I] = null
+	implicit def arrEquiv[T](implicit t: Equiv[T]): Equiv[Array[T]] = null
+	implicit def hNilCache: InputCache[HNil] = null
+	implicit def ByteArrayFormat: Format[Array[Byte]] = null
+	type :+:[H, T <: HList] = HCons[H,T]
+	implicit def hConsCache[H, T <: HList](implicit head: InputCache[H], tail: InputCache[T]): InputCache[H :+: T] = null
+	hConsCache[Array[Byte], HNil]
+}
+
+sealed trait HList
+sealed trait HNil extends HList
+object HNil extends HNil
+final class HCons[H, T <: HList](head : H, tail : T) extends HList


### PR DESCRIPTION
Reverts this line: 9c09c17#L50L671. That value was
apparantly discarded intentionally.

review by @paulp
