### PR TITLE
SI-6951 Refine ClassTag based unapply after inference.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
@@ -2501,7 +2501,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
     // (At least conceptually: `true` is an instance of class `Boolean`)
     private def widenToClass(tp: Type): Type =
       if (tp.typeSymbol.isClass) tp
-      else tp.baseType(tp.baseClasses.head)
+      else tp.baseType(tp.baseClasses.headOption.getOrElse(AnyClass)) // Checkable type might be type ID[X] = X
 
     object TypeConst extends TypeConstExtractor {
       def apply(tp: Type) = {

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3437,12 +3437,13 @@ trait Typers extends Modes with Adaptations with Tags {
       val argDummy  = context.owner.newValue(nme.SELECTOR_DUMMY, fun.pos, SYNTHETIC) setInfo pt
       val arg       = Ident(argDummy) setType pt
 
-      val uncheckedTypeExtractor =
-        if (unappType.paramTypes.nonEmpty)
-          extractorForUncheckedType(tree.pos, unappType.paramTypes.head)
-        else None
 
       if (!isApplicableSafe(Nil, unappType, List(pt), WildcardType)) {
+        val uncheckedTypeExtractor =
+          if (unappType.paramTypes.nonEmpty)
+            extractorForUncheckedType(tree.pos, unappType.paramTypes.head)
+          else None
+
         //Console.println("UNAPP: need to typetest, arg.tpe = "+arg.tpe+", unappType = "+unappType)
         val (freeVars, unappFormal) = freshArgType(unappType.skolemizeExistential(context.owner, tree))
         val unapplyContext = context.makeNewScope(context.tree, context.owner)
@@ -3478,11 +3479,26 @@ trait Typers extends Modes with Adaptations with Tags {
           arg.tpe = pt1    // restore type (arg is a dummy tree, just needs to pass typechecking)
           val unapply = UnApply(fun1, args1) setPos tree.pos setType itype
 
+          // SI-6951 Use the inferred type arguments of unapply to recheck and recreate
+          //         the class tag based extractor wrapper; we might have inferred a
+          //         checkable type. If we don't do this, we can lose track of singleton types.
+          val uncheckedTypeExtractor = {
+            val inferredScrutineeType: Option[Type] = unappType.paramTypes.headOption.map { tp =>
+              val applied = treeInfo.dissectApplied(fun1)
+              val unapplyFunTpe = applied.core.tpe
+              unapplyFunTpe.paramTypes.head.subst(unapplyFunTpe.typeParams, applied.targs.map(_.tpe))
+            }
+            inferredScrutineeType flatMap (extractorForUncheckedType(tree.pos, _))
+          }
+
           // if the type that the unapply method expects for its argument is uncheckable, wrap in classtag extractor
           // skip if the unapply's type is not a method type with (at least, but really it should be exactly) one argument
           // also skip if we already wrapped a classtag extractor (so we don't keep doing that forever)
-          if (uncheckedTypeExtractor.isEmpty || fun1.symbol.owner.isNonBottomSubClass(ClassTagClass)) unapply
-          else wrapClassTagUnapply(unapply, uncheckedTypeExtractor.get, unappType.paramTypes.head)
+          val isClassTagMember = fun1.symbol.owner isNonBottomSubClass ClassTagClass
+          uncheckedTypeExtractor match {
+            case Some(extractor) if !isClassTagMember => wrapClassTagUnapply(unapply, extractor, unappType.paramTypes.head)
+            case _                                    => unapply
+          }
         }
       }
     }
@@ -3520,14 +3536,20 @@ trait Typers extends Modes with Adaptations with Tags {
           None
 
         case ptCheckable if infer.containsUnchecked(ptCheckable) =>
-          val classTagExtractor = resolveClassTag(pos, ptCheckable)
+          // We disallow materialization to prevent summoning ClassTag[Outer#Inner]
+          // to satify the ClassTag[T#Inner] in:
+          //
+          // class Outer { class Inner }
+          // object Extractor { def unapply[T <: Outer](t: T#Inner) = ...
+          //
+          val classTagExtractor = resolveClassTag(pos, ptCheckable, allowMaterialization = false)
 
           if (classTagExtractor != EmptyTree && unapplyMember(classTagExtractor.tpe) != NoSymbol)
             Some(classTagExtractor)
           else None
 
         case _ => None
-    }
+      }
     }
 
     /**

--- a/test/files/pos/t6951.scala
+++ b/test/files/pos/t6951.scala
@@ -32,3 +32,11 @@ object CallerWithTag extends App {
     case Matcher(branch) => branch // <-- type mismatch; found: T#Branch; required: Oak.Branch
   }
 }
+
+
+object TypeConstructor {
+  object E { def unapply[M[_] <: Array[_], T](mt: M[T]) = Some(mt) }
+  Array(1) match { case E(x) => x }
+
+  type ID[X] = X
+}

--- a/test/files/pos/t6951.scala
+++ b/test/files/pos/t6951.scala
@@ -1,0 +1,34 @@
+abstract class Tree {
+  type FinalBranch <: Branch
+
+  trait Branch {
+    this: FinalBranch =>
+    def myself: FinalBranch = this
+  }
+}
+
+object Matcher {
+  def unapply[T <: Tree](branch: T#Branch) = Some(branch.myself)
+}
+
+object Oak extends Tree {
+  type FinalBranch = Branch
+  class Branch extends super.Branch {
+    this: FinalBranch =>
+  }
+}
+
+object Caller extends App {
+  val oakBranch = new Oak.Branch
+  val matched = oakBranch match {
+    case Matcher(branch) => branch // <-- type mismatch; found: T#Branch; required: Oak.Branch
+  }
+}
+
+object CallerWithTag extends App {
+  implicit def tag[T]: scala.reflect.ClassTag[T] = ???
+  val oakBranch = new Oak.Branch
+  val matched = oakBranch match {
+    case Matcher(branch) => branch // <-- type mismatch; found: T#Branch; required: Oak.Branch
+  }
+}

--- a/test/files/run/t6951c.scala
+++ b/test/files/run/t6951c.scala
@@ -1,0 +1,35 @@
+import scala.tools.partest._
+
+object Test extends ReplTest {
+
+  override def code = """
+abstract class Tree {
+  type FinalBranch <: Branch
+  trait Branch {
+    this: FinalBranch =>
+    def myself: FinalBranch = this
+  }
+}
+object Oak extends Tree {
+  type FinalBranch = Branch
+  class Branch extends super.Branch {
+    this: FinalBranch =>
+  }
+}
+object TypeConstructor {
+  type ID[X] = X
+  object Matcher {
+    def unapply[M[X] <: ID[X], T <: Tree](branch: M[T#Branch]) = Some(branch.myself)
+  }
+  val oakBranch = new Oak.Branch
+  val matched = oakBranch match {
+    // Triggered Nil.head in `tp.baseType(tp.baseClasses.head)` in `widenToClass`
+    // after correctly issueing an unchecked warning)
+    case Matcher(branch) => branch
+  }
+}
+"""
+}
+
+
+


### PR DESCRIPTION
Before, we were getting:

```
typed ClassTag.apply[T#Branch](classOf[Tree$Branch]).unapply(<unapply-selector>) <unapply> (Matcher.unapply[Oak.type](<unapply-selector>) <unapply> ((branch @ _))): T#Branch
```

This is problematic for two reasons:
- We don't actually need to use a class tag in
  pattern matching, because after inference the
  substituted formal type of the unapply method
  is a concrete type, Oak.Branch.
- The class tag check delivers a T#Branch, which
  doesn't line up with the required Oak.Branch
  required by unapply.

Now, we use the inferred type argument `Oak.type` to
double check whether the type is in fact uncheckable,
and retain the inferred type.

In addition, we only consider class tags available
through normal implcits, we disable materialization.
See the code comments for an example of an uncheckable
type that for which a classtag can be materialized.

Review by @adriaanm
