### PR TITLE
SI-6675 -Xlint arity enforcement for extractors

### DIFF
--- a/src/compiler/scala/tools/nsc/matching/Patterns.scala
+++ b/src/compiler/scala/tools/nsc/matching/Patterns.scala
@@ -402,7 +402,7 @@ trait Patterns extends ast.TreeDSL {
       case _                                => toPats(args)
     }
 
-    def resTypes = analyzer.unapplyTypeList(unfn.symbol, unfn.tpe, args.length)
+    def resTypes = analyzer.unapplyTypeList(unfn.pos, unfn.symbol, unfn.tpe, args.length)
     def resTypesString = resTypes match {
       case Nil  => "Boolean"
       case xs   => xs.mkString(", ")

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -613,7 +613,7 @@ abstract class UnCurry extends InfoTransform
             val fn1 = withInPattern(false)(transform(fn))
             val args1 = transformTrees(fn.symbol.name match {
               case nme.unapply    => args
-              case nme.unapplySeq => transformArgs(tree.pos, fn.symbol, args, analyzer.unapplyTypeList(fn.symbol, fn.tpe, args.length))
+              case nme.unapplySeq => transformArgs(tree.pos, fn.symbol, args, analyzer.unapplyTypeList(fn.pos, fn.symbol, fn.tpe, args.length))
               case _              => sys.error("internal error: UnApply node has wrong symbol")
             })
             treeCopy.UnApply(tree, fn1, args1)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3465,7 +3465,7 @@ trait Typers extends Modes with Adaptations with Tags {
         val resTp     = fun1.tpe.finalResultType.normalize
         val nbSubPats = args.length
 
-        val (formals, formalsExpanded) = extractorFormalTypes(resTp, nbSubPats, fun1.symbol)
+        val (formals, formalsExpanded) = extractorFormalTypes(fun0.pos, resTp, nbSubPats, fun1.symbol)
         if (formals == null) duplErrorTree(WrongNumberOfArgsError(tree, fun))
         else {
           val args1 = typedArgs(args, mode, formals, formalsExpanded)
@@ -5311,7 +5311,7 @@ trait Typers extends Modes with Adaptations with Tags {
 
       def typedUnApply(tree: UnApply) = {
         val fun1 = typed(tree.fun)
-        val tpes = formalTypes(unapplyTypeList(tree.fun.symbol, fun1.tpe, tree.args.length), tree.args.length)
+        val tpes = formalTypes(unapplyTypeList(tree.fun.pos, tree.fun.symbol, fun1.tpe, tree.args.length), tree.args.length)
         val args1 = map2(tree.args, tpes)(typedPattern)
         treeCopy.UnApply(tree, fun1, args1) setType pt
       }

--- a/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
@@ -34,12 +34,12 @@ trait Unapplies extends ast.TreeDSL
   /** returns type list for return type of the extraction
    * @see extractorFormalTypes
    */
-  def unapplyTypeList(ufn: Symbol, ufntpe: Type, nbSubPats: Int) = {
+  def unapplyTypeList(pos: Position, ufn: Symbol, ufntpe: Type, nbSubPats: Int) = {
     assert(ufn.isMethod, ufn)
     //Console.println("utl "+ufntpe+" "+ufntpe.typeSymbol)
     ufn.name match {
       case nme.unapply | nme.unapplySeq =>
-        val (formals, _) = extractorFormalTypes(unapplyUnwrap(ufntpe), nbSubPats, ufn)
+        val (formals, _) = extractorFormalTypes(pos, unapplyUnwrap(ufntpe), nbSubPats, ufn)
         if (formals == null) throw new TypeError(s"$ufn of type $ufntpe cannot extract $nbSubPats sub-patterns")
         else formals
       case _ => throw new TypeError(ufn+" is not an unapply or unapplySeq")

--- a/test/files/neg/t6675-old-patmat.check
+++ b/test/files/neg/t6675-old-patmat.check
@@ -1,0 +1,4 @@
+t6675-old-patmat.scala:10: error: extractor pattern binds a single value to a Product3 of type (Int, Int, Int)
+  "" match { case X(b) => b } // should warn under -Xlint. Not an error because of SI-6111
+                  ^
+one error found

--- a/test/files/neg/t6675-old-patmat.flags
+++ b/test/files/neg/t6675-old-patmat.flags
@@ -1,0 +1,1 @@
+-Xlint -Xfatal-warnings -Xoldpatmat

--- a/test/files/neg/t6675-old-patmat.scala
+++ b/test/files/neg/t6675-old-patmat.scala
@@ -1,0 +1,13 @@
+object X {
+  def unapply(s: String): Option[(Int,Int,Int)] = Some((1,2,3))
+}
+
+object Y {
+  def unapplySeq(s: String): Option[Seq[(Int,Int,Int)]] = Some(Seq((1,2,3)))
+}
+
+object Test {
+  "" match { case X(b) => b } // should warn under -Xlint. Not an error because of SI-6111
+
+  "" match { case Y(b) => b } // no warning
+}

--- a/test/files/neg/t6675.check
+++ b/test/files/neg/t6675.check
@@ -1,0 +1,4 @@
+t6675.scala:10: error: extractor pattern binds a single value to a Product3 of type (Int, Int, Int)
+  "" match { case X(b) => b } // should warn under -Xlint. Not an error because of SI-6111
+                  ^
+one error found

--- a/test/files/neg/t6675.flags
+++ b/test/files/neg/t6675.flags
@@ -1,0 +1,1 @@
+-Xlint -Xfatal-warnings

--- a/test/files/neg/t6675.scala
+++ b/test/files/neg/t6675.scala
@@ -1,0 +1,13 @@
+object X {
+  def unapply(s: String): Option[(Int,Int,Int)] = Some((1,2,3))
+}
+
+object Y {
+  def unapplySeq(s: String): Option[Seq[(Int,Int,Int)]] = Some(Seq((1,2,3)))
+}
+
+object Test {
+  "" match { case X(b) => b } // should warn under -Xlint. Not an error because of SI-6111
+
+  "" match { case Y(b) => b } // no warning
+}


### PR DESCRIPTION
Extractor Patterns changed in 2.10.0 to implement
the letter of the spec, which allows a single binding
to capture an entire TupleN. But this can hide arity
mismatches, especially if the case body uses the
bound value as an `Any`.

This change warns when this happens under -Xlint.

Review by @adriaanm, @paulp.

In particular, I'm after suggestions about how to issue a positioned warning from `Infer` in a less clunky way.
