### PR TITLE
SI-5340 Change println to log

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -956,7 +956,7 @@ trait Implicits {
           infoMap get sym match {
             case Some(infos1) =>
               if (infos1.nonEmpty && !(pre =:= infos1.head.pre.prefix)) {
-                println("amb prefix: "+pre+"#"+sym+" "+infos1.head.pre.prefix+"#"+sym)
+                log(s"Ignoring implicit members of $pre#$sym as it is also visible via another prefix: ${infos1.head.pre.prefix}")
                 infoMap(sym) = List() // ambiguous prefix - ignore implicit members
               }
             case None =>

--- a/test/files/neg/t5340.check
+++ b/test/files/neg/t5340.check
@@ -1,0 +1,6 @@
+t5340.scala:17: error: type mismatch;
+ found   : MyApp.r.E
+ required: MyApp.s.E
+  println(b: s.E)
+          ^
+one error found

--- a/test/files/neg/t5340.scala
+++ b/test/files/neg/t5340.scala
@@ -1,0 +1,29 @@
+class Poly {
+  class E
+  object E {
+    implicit def conv(value: Any): E = sys.error("")
+  }
+}
+
+object MyApp {
+  val r: Poly = sys.error("")
+  val s: Poly = sys.error("")
+  val b: r.E = sys.error("")
+
+  // okay
+  s.E.conv(b): s.E
+
+  // compilation fails with error below
+  println(b: s.E)
+
+  // amb prefix: MyApp.s.type#class E MyApp.r.type#class E
+  // amb prefix: MyApp.s.type#class E MyApp.r.type#class E
+  // ../test/pending/run/t5310.scala:17: error: type mismatch;
+  //  found   : MyApp.r.E
+  //  required: MyApp.s.E
+  //   println(b: s.E)
+  //           ^
+
+  // The type error is as expected, but the `amb prefix` should be logged,
+  // rather than printed to standard out.
+}


### PR DESCRIPTION
An esoteric implicit search could trigger an "amb prefix ..."
message to standard out. Now the message has been improved
and sent to the logger.

Review by @JamesIry
