### PR TITLE
SI-6126 Test case for varargs of tagged primitives.

### DIFF
--- a/test/files/run/t6126.scala
+++ b/test/files/run/t6126.scala
@@ -1,0 +1,8 @@
+trait LogLevelType
+object Test {
+  type LogLevel = Int with LogLevelType
+  final val ErrorLevel = 1.asInstanceOf[Int with LogLevelType]
+  def main(args: Array[String]) {
+    List(ErrorLevel, ErrorLevel)
+  }
+}


### PR DESCRIPTION
This started working after the merge fe1110f. I didn't track
down precisely which commit was responsible beyond that.

Review by @adriaanm
