### PR TITLE
SI-6082 Conditionally expand @ann(x) to @ann(value = x)

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3637,15 +3637,18 @@ trait Typers extends Modes with Adaptations with Tags {
           } else if (argss.length > 1) {
             reportAnnotationError(MultipleArgumentListForAnnotationError(ann))
           } else {
-            val args =
-              if (argss.head.length == 1 && !isNamed(argss.head.head))
-                List(new AssignOrNamedArg(Ident(nme.value), argss.head.head))
-              else argss.head
             val annScope = annType.decls
                 .filter(sym => sym.isMethod && !sym.isConstructor && sym.isJavaDefined)
             val names = new scala.collection.mutable.HashSet[Symbol]
+            def hasValue = names exists (_.name == nme.value)
             names ++= (if (isJava) annScope.iterator
                        else typedFun.tpe.params.iterator)
+            val args = argss match {
+              case List(List(arg)) if !isNamed(arg) && hasValue =>
+                List(new AssignOrNamedArg(Ident(nme.value), arg))
+              case as :: _ => as
+            }
+
             val nvPairs = args map {
               case arg @ AssignOrNamedArg(Ident(name), rhs) =>
                 val sym = if (isJava) annScope.lookup(name)

--- a/test/files/neg/t6082.check
+++ b/test/files/neg/t6082.check
@@ -1,0 +1,13 @@
+t6082.scala:1: warning: Implementation restriction: subclassing Classfile does not
+make your annotation visible at runtime.  If that is what
+you want, you must write the annotation class in Java.
+class annot(notValue: String) extends annotation.ClassfileAnnotation
+      ^
+t6082.scala:2: error: classfile annotation arguments have to be supplied as named arguments
+@annot("") class C
+       ^
+t6082.scala:2: error: annotation annot is missing argument notValue
+@annot("") class C
+ ^
+one warning found
+two errors found

--- a/test/files/neg/t6082.scala
+++ b/test/files/neg/t6082.scala
@@ -1,0 +1,2 @@
+class annot(notValue: String) extends annotation.ClassfileAnnotation
+@annot("") class C


### PR DESCRIPTION
... if the annotation has an argument with the name `value`.

Doing so unconditionally obscures error messages.

We still require that arguments to ClassFileAnnotations
are named, other than for this special case.

Review by @lrytz
