### PR TITLE
Modifies "maybeRewrap" to focus more on the maybe.

### DIFF
--- a/test/files/run/t6329_repl.check
+++ b/test/files/run/t6329_repl.check
@@ -3,11 +3,37 @@ Type :help for more information.
 
 scala> 
 
-scala> classManifest[List[_]]
-warning: there were 1 deprecation warnings; re-run with -deprecation for details
-res0: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List[Any]
+scala> import scala.reflect.classTag
+import scala.reflect.classTag
 
-scala> scala.reflect.classTag[List[_]]
+scala> classManifest[scala.List[_]]
+warning: there were 1 deprecation warnings; re-run with -deprecation for details
+res0: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List[<?>]
+
+scala> classTag[scala.List[_]]
 res1: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List
+
+scala> classManifest[scala.collection.immutable.List[_]]
+warning: there were 1 deprecation warnings; re-run with -deprecation for details
+res2: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List[<?>]
+
+scala> classTag[scala.collection.immutable.List[_]]
+res3: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List
+
+scala> classManifest[Predef.Set[_]]
+warning: there were 1 deprecation warnings; re-run with -deprecation for details
+res4: scala.reflect.ClassTag[scala.collection.immutable.Set[_]] = scala.collection.immutable.Set[<?>]
+
+scala> classTag[Predef.Set[_]]
+res5: scala.reflect.ClassTag[scala.collection.immutable.Set[_]] = scala.collection.immutable.Set
+
+scala> classManifest[scala.collection.immutable.Set[_]]
+warning: there were 1 deprecation warnings; re-run with -deprecation for details
+res6: scala.reflect.ClassTag[scala.collection.immutable.Set[_]] = scala.collection.immutable.Set[<?>]
+
+scala> classTag[scala.collection.immutable.Set[_]]
+res7: scala.reflect.ClassTag[scala.collection.immutable.Set[_]] = scala.collection.immutable.Set
+
+scala> 
 
 scala> 

--- a/test/files/run/t6329_repl.scala
+++ b/test/files/run/t6329_repl.scala
@@ -2,7 +2,14 @@ import scala.tools.partest.ReplTest
 
 object Test extends ReplTest {
   def code = """
-    |classManifest[List[_]]
-    |scala.reflect.classTag[List[_]]
-    |""".stripMargin
+    |import scala.reflect.classTag
+    |classManifest[scala.List[_]]
+    |classTag[scala.List[_]]
+    |classManifest[scala.collection.immutable.List[_]]
+    |classTag[scala.collection.immutable.List[_]]
+    |classManifest[Predef.Set[_]]
+    |classTag[Predef.Set[_]]
+    |classManifest[scala.collection.immutable.Set[_]]
+    |classTag[scala.collection.immutable.Set[_]]
+  """.stripMargin
 }

--- a/test/files/run/t6329_vanilla.check
+++ b/test/files/run/t6329_vanilla.check
@@ -1,2 +1,8 @@
-scala.collection.immutable.List[Any]
+scala.collection.immutable.List[<?>]
 scala.collection.immutable.List
+scala.collection.immutable.List[<?>]
+scala.collection.immutable.List
+scala.collection.immutable.Set[<?>]
+scala.collection.immutable.Set
+scala.collection.immutable.Set[<?>]
+scala.collection.immutable.Set

--- a/test/files/run/t6329_vanilla.scala
+++ b/test/files/run/t6329_vanilla.scala
@@ -1,4 +1,12 @@
+import scala.reflect.classTag
+
 object Test extends App {
-  println(classManifest[List[_]])
-  println(scala.reflect.classTag[List[_]])
+  println(classManifest[scala.List[_]])
+  println(classTag[scala.List[_]])
+  println(classManifest[scala.collection.immutable.List[_]])
+  println(classTag[scala.collection.immutable.List[_]])
+  println(classManifest[Predef.Set[_]])
+  println(classTag[Predef.Set[_]])
+  println(classManifest[scala.collection.immutable.Set[_]])
+  println(classTag[scala.collection.immutable.Set[_]])
 }


### PR DESCRIPTION
Existential types are rewrapped under a bunch of conditions
unless the operation performed on the underlying type returns
the same type by reference equality. That depends on a
foundation of predictability which doesn't exist. The upshot is
that existential types were rewrapped with abandon, even when
the type were identical.

This had both performance and correctness implications.
Note where the test case output changes like so:

  -scala.collection.immutable.List[Any]
  +scala.collection.immutable.List[<?>]

That's correctness.
