### PR TITLE
SI-6979 Small optimization in lub

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -6437,6 +6437,7 @@ trait Types extends api.Types { self: SymbolTable =>
             || sym.isConstructor
             || !sym.isPublic
             || isGetClass(sym)
+            || sym.isFinal
             || narrowts.exists(t => !refines(t, sym))
           )
           def lubsym(proto: Symbol): Symbol = {


### PR DESCRIPTION
If a member of `lubBase` is final, it cannot be
refined in the types we're lubbing.

Review by @adriaanm.
