### PR TITLE
SI-6976 Fix value class separate compilation crasher.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
@@ -64,14 +64,18 @@ abstract class ExtensionMethods extends Transform with TypingTransformers {
     }
   }
 
-  /** Return the extension method that corresponds to given instance method `meth`.
-   */
+  private def companionModuleForce(sym: Symbol) = {
+    sym.andAlso(_.owner.initialize) // See SI-6976. `companionModule` only calls `rawInfo`. (Why?)
+    sym.companionModule
+  }
+
+  /** Return the extension method that corresponds to given instance method `meth`. */
   def extensionMethod(imeth: Symbol): Symbol = atPhase(currentRun.refchecksPhase) {
-    val companionInfo = imeth.owner.companionModule.info
+    val companionInfo = companionModuleForce(imeth.owner).info
     val candidates = extensionNames(imeth) map (companionInfo.decl(_)) filter (_.exists)
     val matching = candidates filter (alt => normalize(alt.tpe, imeth.owner) matches imeth.tpe)
     assert(matching.nonEmpty,
-      s"no extension method found for $imeth:${imeth.tpe} among ${candidates map (c => c.name+":"+c.tpe)} / ${extensionNames(imeth)}")
+      s"no extension method found for $imeth:${imeth.tpe} among ${candidates.map(c => c.name+":"+c.tpe).toList} / ${extensionNames(imeth).toList}")
     matching.head
   }
 

--- a/test/files/pos/t6976/Exts_1.scala
+++ b/test/files/pos/t6976/Exts_1.scala
@@ -1,0 +1,10 @@
+object Exts {
+  implicit class AnyExts[T](val o: T) extends AnyVal {
+    def moo = "moo!"
+  }
+}
+
+trait Exts {
+  import language.implicitConversions
+  implicit def AnyExts[T](o: T) = Exts.AnyExts(o)
+}

--- a/test/files/pos/t6976/ImplicitBug_1.scala
+++ b/test/files/pos/t6976/ImplicitBug_1.scala
@@ -1,0 +1,27 @@
+// This one is weird and nasty. Not sure if this is scalac or sbt 
+// (tried with 0.12 & 0.12.2-RC2) bug.
+//
+// A level of indirection is required to trigger this bug.
+// Exts seems to need to be defined in separate file.
+//
+// Steps to reproduce:
+// 1. sbt clean
+// 2. sbt run (it works)
+// 3. Comment A & uncomment B.
+// 4. sbt run (it fails)
+// 5. Switch it back & sbt run. It still fails.
+//
+// In this project sbt clean helps. However in a large project where this 
+// bug was found compiler crashed even after doing sbt clean. The only
+// way to work around this was to reference Exts object explicitly (C) in 
+// the source file using its implicit classes.
+
+// Lets suppose this is a mega-trait combining all sorts of helper 
+// functionality.
+trait Support extends Exts
+
+object ImplicitsBug extends App with Support { // A
+// object ImplicitsBug extends App with Exts { // B
+  //Exts // C) this reference helped in the large project.
+  println(3.moo)
+}

--- a/test/files/pos/t6976/ImplicitBug_2.scala
+++ b/test/files/pos/t6976/ImplicitBug_2.scala
@@ -1,0 +1,7 @@
+trait Support extends Exts
+
+// object ImplicitsBug extends App with Support { // A
+object ImplicitsBug extends App with Exts { // B
+  //Exts // C) this reference helped in the large project.
+  println(3.moo)
+}


### PR DESCRIPTION
We can't guarantee that the owner of the value class
is initialized, and if it isn't, the search for the
companion module will turn up bubkis.

This is a localized fix, but I'd be suprised if there
weren't other places that suffered from the same problem.

Wouldn't it be nicer to have something like:

```
// doesn't force info
sym.raw.info
sym.raw.companionModule

// forces info
sym.info
sym.companionModule
```

Review by @paulp. 

/cc @JamesIry for consideration of SI-5954
