### PR TITLE
SI-4976 Scaladoc: Add a source link to package objects

### DIFF
--- a/src/compiler/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/compiler/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -314,11 +314,14 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
       inform("Creating doc template for " + sym)
 
     override def toRoot: List[DocTemplateImpl] = this :: inTpl.toRoot
-    def inSource =
-      if (sym.sourceFile != null && ! sym.isSynthetic)
-        Some((sym.sourceFile, sym.pos.line))
+
+    protected def inSourceFromSymbol(symbol: Symbol) =
+      if (symbol.sourceFile != null && ! symbol.isSynthetic)
+        Some((symbol.sourceFile, symbol.pos.line))
       else
         None
+
+    def inSource = inSourceFromSymbol(sym)
 
     def sourceUrl = {
       def fixPath(s: String) = s.replaceAll("\\" + java.io.File.separator, "/")
@@ -508,11 +511,11 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
   abstract class PackageImpl(sym: Symbol, inTpl: PackageImpl) extends DocTemplateImpl(sym, inTpl) with Package {
     override def inTemplate = inTpl
     override def toRoot: List[PackageImpl] = this :: inTpl.toRoot
-    override lazy val linearization = {
-      val symbol = sym.info.members.find {
+    override lazy val (inSource, linearization) = {
+      val representive = sym.info.members.find {
         s => s.isPackageObject
       } getOrElse sym
-      linearizationFromSymbol(symbol)
+      (inSourceFromSymbol(representive), linearizationFromSymbol(representive))
     }
     def packages = members collect { case p: PackageImpl if !(droppedPackages contains p) => p }
   }

--- a/test/scaladoc/run/package-object.check
+++ b/test/scaladoc/run/package-object.check
@@ -1,3 +1,4 @@
 List(test.B, test.A, scala.AnyRef, scala.Any)
 List(B, A, AnyRef, Any)
+Some((newSource,10))
 Done.

--- a/test/scaladoc/run/package-object.scala
+++ b/test/scaladoc/run/package-object.scala
@@ -11,6 +11,7 @@ object Test extends ScaladocModelTest {
     val p = root._package("test")
     println(p.linearizationTemplates)
     println(p.linearizationTypes)
+    println(p.inSource)
   }
 }
 


### PR DESCRIPTION
If a package has a package object, the source link should point the source file of the package object.

Review by @heathermiller
