### PR TITLE
SI-6651 Extension methods types may depend on the typed of the wrapped value

### DIFF
--- a/test/files/pos/t6651.scala
+++ b/test/files/pos/t6651.scala
@@ -1,0 +1,26 @@
+class YouAreYourself[A <: AnyRef](val you: A) extends AnyVal {
+  def yourself: you.type = you
+}
+
+object Test {
+	val s = ""
+	val s1: s.type = new YouAreYourself[s.type](s).yourself
+}
+
+trait Path {
+  type Dep <: AnyRef
+}
+
+final class ValueClass[P <: Path](val path: P) extends AnyVal {
+  import path._
+  def apply(dep: Dep)(d2: dep.type, foo: Int): (Dep, d2.type) = (d2 ,d2)
+}
+
+object TestValueClass {
+	object P extends Path {
+		type Dep = String
+	}
+
+	val s: String = ""
+	new ValueClass(P).apply(s)(s, 0): (String, s.type)
+}


### PR DESCRIPTION
This allows for the likes of:

```
class A[X](val x: X) extends AnyVal {
  def foo(xy: x.Y) {}
}
```

We have to do this in both directions, when synthesizing
the extension method in `Extender#transform`, and later on
when Erasure tries to find the corresponding extension
methods by backing out the original signatures from
the signatures of the synthesized methods in the companion.

In the first case, we have to be careful to use a stable
reference to the `self` parameter, which can satisfy the
dependent types.

Review by @paulp
