### PR TITLE
SI-6601 Publicise derived value contstructor after pickler

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
@@ -140,7 +140,6 @@ abstract class ExtensionMethods extends Transform with TypingTransformers {
              wrap over other value classes anyway.
             checkNonCyclic(currentOwner.pos, Set(), currentOwner) */
             extensionDefs(currentOwner.companionModule) = new mutable.ListBuffer[Tree]
-            currentOwner.primaryConstructor.makeNotPrivate(NoSymbol)
             super.transform(tree)
           } else if (currentOwner.isStaticOwner) {
             super.transform(tree)

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1677,6 +1677,8 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
             val bridges = addVarargBridges(currentOwner)
             checkAllOverrides(currentOwner)
             checkAnyValSubclass(currentOwner)
+            if (currentOwner.isDerivedValueClass)
+              currentOwner.primaryConstructor makeNotPrivate NoSymbol // SI-6601, must be done *after* pickler!
             if (bridges.nonEmpty) deriveTemplate(tree)(_ ::: bridges) else tree
 
           case dc@TypeTreeWithDeferredRefCheck() => abort("adapt should have turned dc: TypeTreeWithDeferredRefCheck into tpt: TypeTree, with tpt.original == dc")

--- a/test/files/neg/t6601.check
+++ b/test/files/neg/t6601.check
@@ -1,0 +1,4 @@
+AccessPrivateConstructor_2.scala:2: error: constructor PrivateConstructor in class PrivateConstructor cannot be accessed in class AccessPrivateConstructor
+  new PrivateConstructor("") // Scalac should forbid accessing to the private constructor!
+  ^
+one error found

--- a/test/files/neg/t6601/AccessPrivateConstructor_2.scala
+++ b/test/files/neg/t6601/AccessPrivateConstructor_2.scala
@@ -1,0 +1,3 @@
+class AccessPrivateConstructor {
+  new PrivateConstructor("") // Scalac should forbid accessing to the private constructor!
+}

--- a/test/files/neg/t6601/PrivateConstructor_1.scala
+++ b/test/files/neg/t6601/PrivateConstructor_1.scala
@@ -1,0 +1,1 @@
+class PrivateConstructor private(val s: String) extends AnyVal


### PR DESCRIPTION
Otherwise the access restrictions are not enforced under
separate compilation.

See also SI-6608.

Review by @gkossakowski

We don't ship any value classes with private constructors in the standard library, so perhaps we can ship this fix in 2.10.x.
