### PR TITLE
Si 6987 2.10.x

### DIFF
--- a/src/compiler/scala/tools/nsc/CompileServer.scala
+++ b/src/compiler/scala/tools/nsc/CompileServer.scala
@@ -92,10 +92,11 @@ class StandardCompileServer extends SocketServer {
 
     val args        = input.split("\0", -1).toList
     val newSettings = new FscSettings(fscError)
-    this.verbose    = newSettings.verbose.value
     val command     = newOfflineCompilerCommand(args, newSettings)
+    this.verbose    = newSettings.verbose.value
 
     info("Settings after normalizing paths: " + newSettings)
+    if (!command.files.isEmpty) info("Input files after normalizing paths: " + (command.files mkString ","))
     printMemoryStats()
 
     // Update the idle timeout if given

--- a/src/compiler/scala/tools/nsc/CompileServer.scala
+++ b/src/compiler/scala/tools/nsc/CompileServer.scala
@@ -194,6 +194,5 @@ object CompileServer extends StandardCompileServer {
     run()
 
     compileSocket deletePort port
-    sys exit 0
   }
 }

--- a/src/compiler/scala/tools/nsc/CompileServer.scala
+++ b/src/compiler/scala/tools/nsc/CompileServer.scala
@@ -178,7 +178,19 @@ object CompileServer extends StandardCompileServer {
     setter(new PrintStream((redirectDir / filename).createFile().bufferedOutput()))
   }
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]) = 
+    execute(() => (), args)
+  
+  /**
+   * Used for internal testing. The callback is called upon
+   * server start, notifying the caller that the server is
+   * ready to run. WARNING: the callback runs in the
+   * server's thread, blocking the server from doing any work
+   * until the callback is finished. Callbacks should be kept
+   * simple and clients should not try to interact with the
+   * server while the callback is processing.
+   */
+  def execute(startupCallback : () => Unit, args: Array[String]) {
     val debug = args contains "-v"
 
     if (debug) {
@@ -191,6 +203,7 @@ object CompileServer extends StandardCompileServer {
     System.err.println("...starting server on socket "+port+"...")
     System.err.flush()
     compileSocket setPort port
+    startupCallback()
     run()
 
     compileSocket deletePort port

--- a/src/compiler/scala/tools/util/SocketServer.scala
+++ b/src/compiler/scala/tools/util/SocketServer.scala
@@ -16,7 +16,7 @@ trait CompileOutputCommon {
   def verbose: Boolean
 
   def info(msg: String)  = if (verbose) echo(msg)
-  def echo(msg: String)  = Console println msg
+  def echo(msg: String)  = {Console println msg; Console.flush}
   def warn(msg: String)  = System.err println msg
   def fatal(msg: String) = { warn(msg) ; sys.exit(1) }
 }

--- a/test/files/run/t6987.check
+++ b/test/files/run/t6987.check
@@ -1,0 +1,1 @@
+got successful verbose results!

--- a/test/files/run/t6987.scala
+++ b/test/files/run/t6987.scala
@@ -1,17 +1,22 @@
 import java.io._
 import tools.nsc.{CompileClient, CompileServer}
+import java.util.concurrent.{CountDownLatch, TimeUnit}
 
 object Test extends App {
+  val startupLatch = new CountDownLatch(1)
   // we have to explicitly launch our server because when the client launches a server it uses 
   // the "scala" shell command meaning whatever version of scala (and whatever version of libraries)
   // happens to be in the path gets used
   val t = new Thread(new Runnable {
     def run() = {
-      CompileServer.main(Array[String]())
+      CompileServer.execute(() => startupLatch.countDown(), Array[String]())
     }
   })
   t setDaemon true
   t.start()
+  if (!startupLatch.await(2, TimeUnit.MINUTES)) {
+    sys error "Timeout waiting for server to start"
+  }
 
   val baos = new ByteArrayOutputStream()
   val ps = new PrintStream(baos)
@@ -37,9 +42,6 @@ object Test extends App {
       oldOut println "got a failure. Full results were:"
       oldOut println msg
     }
-  } catch {
-     case e : Throwable => 
-         oldOut println e
   } finally {
     System setOut oldOut
   }

--- a/test/files/run/t6987.scala
+++ b/test/files/run/t6987.scala
@@ -1,0 +1,46 @@
+import java.io._
+import tools.nsc.{CompileClient, CompileServer}
+
+object Test extends App {
+  // we have to explicitly launch our server because when the client launches a server it uses 
+  // the "scala" shell command meaning whatever version of scala (and whatever version of libraries)
+  // happens to be in the path gets used
+  val t = new Thread(new Runnable {
+    def run() = {
+      CompileServer.main(Array[String]())
+    }
+  })
+  t setDaemon true
+  t.start()
+
+  val baos = new ByteArrayOutputStream()
+  val ps = new PrintStream(baos)
+
+  val oldOut = System.out
+ 
+  System.setOut(ps)
+
+  try {
+    // shut down the server via the client using the verbose flag
+    val success = CompileClient.process(Array("-shutdown", "-verbose"))
+
+    // now make sure we got success and a verbose result
+    val msg = baos.toString()
+    if (success) {
+      if (msg contains "Settings after normalizing paths") {
+        oldOut println "got successful verbose results!"
+      } else {
+        oldOut println "did not get the string expected, full results were:"
+        oldOut println msg
+      }
+    } else {
+      oldOut println "got a failure. Full results were:"
+      oldOut println msg
+    }
+  } catch {
+     case e : Throwable => 
+         oldOut println e
+  } finally {
+    System setOut oldOut
+  }
+}


### PR DESCRIPTION
SI-6987 Fixes fsc compile server verbose output

Internally the fsc server code was setting a "verbose" flag, but it was
always false. Fixing that gives server's verbose output, but because the
output was buffered and not flushed the server's output wasn't seen
until the compile run was complete. This pull request fixes the verbose flag
and flushes the server side output.

Includes a test

review @adriaanm
