### PR TITLE
Remove the term "pimp" from the repository in favor of "enrich"

### DIFF
--- a/src/compiler/scala/tools/nsc/doc/model/ModelFactoryImplicitSupport.scala
+++ b/src/compiler/scala/tools/nsc/doc/model/ModelFactoryImplicitSupport.scala
@@ -65,7 +65,7 @@ trait ModelFactoryImplicitSupport {
    *     class A[T]
    *     class B extends A[Int]
    *     class C extends A[String]
-   *     implicit def pimpA[T: Numeric](a: A[T]): D
+   *     implicit def enrichA[T: Numeric](a: A[T]): D
    *  }}}
    *  For B, no constraints are generated as Numeric[Int] is already in the default scope. On the other hand, for the
    *  conversion from C to D, depending on -implicits-show-all, the conversion can:
@@ -121,13 +121,13 @@ trait ModelFactoryImplicitSupport {
    * What? in details:
    *  - say we start from a class A[T1, T2, T3, T4]
    *  - we have an implicit function (view) in scope:
-   *     def pimpA[T3 <: Long, T4](a: A[Int, Foo[Bar[X]], T3, T4])(implicit ev1: TypeTag[T4], ev2: Numeric[T4]): PimpedA
-   *  - A is converted to PimpedA ONLY if a couple of constraints are satisfied:
+   *     def enrichA[T3 <: Long, T4](a: A[Int, Foo[Bar[X]], T3, T4])(implicit ev1: TypeTag[T4], ev2: Numeric[T4]): EnrichedA
+   *  - A is converted to EnrichedA ONLY if a couple of constraints are satisfied:
    *     * T1 must be equal to Int
    *     * T2 must be equal to Foo[Bar[X]]
    *     * T3 must be upper bounded by Long
    *     * there must be evidence of Numeric[T4] and a TypeTag[T4] within scope
-   *  - the final type is PimpedA and A therefore inherits a couple of members from pimpedA
+   *  - the final type is EnrichedA and A therefore inherits a couple of members from enrichA
    *
    * How?
    * some notes:
@@ -495,11 +495,11 @@ trait ModelFactoryImplicitSupport {
    * returns the simplified type of the view
    *
    * for the example view:
-   *   implicit def pimpMyClass[T](a: MyClass[T])(implicit ev: Numeric[T]): PimpedMyClass[T]
+   *   implicit def enrichMyClass[T](a: MyClass[T])(implicit ev: Numeric[T]): EnrichedMyClass[T]
    * the implicit view result type is:
-   *   (a: MyClass[T])(implicit ev: Numeric[T]): PimpedMyClass[T]
+   *   (a: MyClass[T])(implicit ev: Numeric[T]): EnrichedMyClass[T]
    * and the simplified type will be:
-   *   MyClass[T] => PimpedMyClass[T]
+   *   MyClass[T] => EnrichedMyClass[T]
    */
   def removeImplicitParameters(viewType: Type): (Type, List[Type]) = {
 

--- a/src/compiler/scala/tools/nsc/interactive/Global.scala
+++ b/src/compiler/scala/tools/nsc/interactive/Global.scala
@@ -948,7 +948,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
     for (sym <- ownerTpe.members)
       addTypeMember(sym, pre, sym.owner != ownerTpe.typeSymbol, NoSymbol)
     members.allMembers #:: {
-      //print("\nadd pimped")
+      //print("\nadd enrichment")
       val applicableViews: List[SearchResult] =
         if (ownerTpe.isErroneous) List()
         else new ImplicitSearch(

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -271,7 +271,7 @@ object Predef extends LowPriorityImplicits {
     // reduces the chances of a user's writing `foo.__leftOfArrow` and
     // being confused why they get an ambiguous implicit conversion
     // error. (`foo.x` used to produce this error since both
-    // any2Ensuring and any2ArrowAssoc enrich an `x` onto everything)
+    // any2Ensuring and any2ArrowAssoc enrich everything with an `x`)
     @deprecated("Use `__leftOfArrow` instead", "2.10.0")
     def x = __leftOfArrow
 

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -271,7 +271,7 @@ object Predef extends LowPriorityImplicits {
     // reduces the chances of a user's writing `foo.__leftOfArrow` and
     // being confused why they get an ambiguous implicit conversion
     // error. (`foo.x` used to produce this error since both
-    // any2Ensuring and any2ArrowAssoc pimped an `x` onto everything)
+    // any2Ensuring and any2ArrowAssoc enrich an `x` onto everything)
     @deprecated("Use `__leftOfArrow` instead", "2.10.0")
     def x = __leftOfArrow
 

--- a/test/files/pos/t3864/tuples_1.scala
+++ b/test/files/pos/t3864/tuples_1.scala
@@ -1,11 +1,11 @@
-trait PimpedType[X] {
+trait EnrichedType[X] {
   val value: X
 }
 
 trait Tuples {
 
-  
-trait Tuple15W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O] extends PimpedType[Tuple15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]] {
+
+trait Tuple15W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O] extends EnrichedType[Tuple15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]] {
   def fold[Z](f: => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => Z): Z = {import value._; f(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15)}
   def toIndexedSeq[Z](implicit ev: value.type <:< Tuple15[Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z]): IndexedSeq[Z] = {val zs = ev(value); import zs._; IndexedSeq(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15)}
   def mapElements[AA, BB, CC, DD, EE, FF, GG, HH, II, JJ, KK, LL, MM, NN, OO](_1: (A => AA) = identity[A] _, _2: (B => BB) = identity[B] _, _3: (C => CC) = identity[C] _, _4: (D => DD) = identity[D] _, _5: (E => EE) = identity[E] _, _6: (F => FF) = identity[F] _, _7: (G => GG) = identity[G] _, _8: (H => HH) = identity[H] _, _9: (I => II) = identity[I] _, _10: (J => JJ) = identity[J] _, _11: (K => KK) = identity[K] _, _12: (L => LL) = identity[L] _, _13: (M => MM) = identity[M] _, _14: (N => NN) = identity[N] _, _15: (O => OO) = identity[O] _): (AA, BB, CC, DD, EE, FF, GG, HH, II, JJ, KK, LL, MM, NN, OO) = (_1(value._1), _2(value._2), _3(value._3), _4(value._4), _5(value._5), _6(value._6), _7(value._7), _8(value._8), _9(value._9), _10(value._10), _11(value._11), _12(value._12), _13(value._13), _14(value._14), _15(value._15))
@@ -13,8 +13,8 @@ trait Tuple15W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O] extends PimpedType[T
 
 implicit def ToTuple15W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](t: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)): Tuple15W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O] = new { val value = t } with Tuple15W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]
 
-  
-trait Tuple16W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P] extends PimpedType[Tuple16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P]] {
+
+trait Tuple16W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P] extends EnrichedType[Tuple16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P]] {
   def fold[Z](f: => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => Z): Z = {import value._; f(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16)}
   def toIndexedSeq[Z](implicit ev: value.type <:< Tuple16[Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z]): IndexedSeq[Z] = {val zs = ev(value); import zs._; IndexedSeq(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16)}
   def mapElements[AA, BB, CC, DD, EE, FF, GG, HH, II, JJ, KK, LL, MM, NN, OO, PP](_1: (A => AA) = identity[A] _, _2: (B => BB) = identity[B] _, _3: (C => CC) = identity[C] _, _4: (D => DD) = identity[D] _, _5: (E => EE) = identity[E] _, _6: (F => FF) = identity[F] _, _7: (G => GG) = identity[G] _, _8: (H => HH) = identity[H] _, _9: (I => II) = identity[I] _, _10: (J => JJ) = identity[J] _, _11: (K => KK) = identity[K] _, _12: (L => LL) = identity[L] _, _13: (M => MM) = identity[M] _, _14: (N => NN) = identity[N] _, _15: (O => OO) = identity[O] _, _16: (P => PP) = identity[P] _): (AA, BB, CC, DD, EE, FF, GG, HH, II, JJ, KK, LL, MM, NN, OO, PP) = (_1(value._1), _2(value._2), _3(value._3), _4(value._4), _5(value._5), _6(value._6), _7(value._7), _8(value._8), _9(value._9), _10(value._10), _11(value._11), _12(value._12), _13(value._13), _14(value._14), _15(value._15), _16(value._16))
@@ -22,8 +22,8 @@ trait Tuple16W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P] extends PimpedTyp
 
 implicit def ToTuple16W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](t: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)): Tuple16W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P] = new { val value = t } with Tuple16W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P]
 
-  
-trait Tuple17W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q] extends PimpedType[Tuple17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q]] {
+
+trait Tuple17W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q] extends EnrichedType[Tuple17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q]] {
   def fold[Z](f: => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => Z): Z = {import value._; f(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17)}
   def toIndexedSeq[Z](implicit ev: value.type <:< Tuple17[Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z]): IndexedSeq[Z] = {val zs = ev(value); import zs._; IndexedSeq(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17)}
   def mapElements[AA, BB, CC, DD, EE, FF, GG, HH, II, JJ, KK, LL, MM, NN, OO, PP, QQ](_1: (A => AA) = identity[A] _, _2: (B => BB) = identity[B] _, _3: (C => CC) = identity[C] _, _4: (D => DD) = identity[D] _, _5: (E => EE) = identity[E] _, _6: (F => FF) = identity[F] _, _7: (G => GG) = identity[G] _, _8: (H => HH) = identity[H] _, _9: (I => II) = identity[I] _, _10: (J => JJ) = identity[J] _, _11: (K => KK) = identity[K] _, _12: (L => LL) = identity[L] _, _13: (M => MM) = identity[M] _, _14: (N => NN) = identity[N] _, _15: (O => OO) = identity[O] _, _16: (P => PP) = identity[P] _, _17: (Q => QQ) = identity[Q] _): (AA, BB, CC, DD, EE, FF, GG, HH, II, JJ, KK, LL, MM, NN, OO, PP, QQ) = (_1(value._1), _2(value._2), _3(value._3), _4(value._4), _5(value._5), _6(value._6), _7(value._7), _8(value._8), _9(value._9), _10(value._10), _11(value._11), _12(value._12), _13(value._13), _14(value._14), _15(value._15), _16(value._16), _17(value._17))
@@ -31,8 +31,8 @@ trait Tuple17W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q] extends Pimped
 
 implicit def ToTuple17W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](t: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)): Tuple17W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q] = new { val value = t } with Tuple17W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q]
 
-  
-trait Tuple18W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R] extends PimpedType[Tuple18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R]] {
+
+trait Tuple18W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R] extends EnrichedType[Tuple18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R]] {
   def fold[Z](f: => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => Z): Z = {import value._; f(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18)}
   def toIndexedSeq[Z](implicit ev: value.type <:< Tuple18[Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z]): IndexedSeq[Z] = {val zs = ev(value); import zs._; IndexedSeq(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18)}
   def mapElements[AA, BB, CC, DD, EE, FF, GG, HH, II, JJ, KK, LL, MM, NN, OO, PP, QQ, RR](_1: (A => AA) = identity[A] _, _2: (B => BB) = identity[B] _, _3: (C => CC) = identity[C] _, _4: (D => DD) = identity[D] _, _5: (E => EE) = identity[E] _, _6: (F => FF) = identity[F] _, _7: (G => GG) = identity[G] _, _8: (H => HH) = identity[H] _, _9: (I => II) = identity[I] _, _10: (J => JJ) = identity[J] _, _11: (K => KK) = identity[K] _, _12: (L => LL) = identity[L] _, _13: (M => MM) = identity[M] _, _14: (N => NN) = identity[N] _, _15: (O => OO) = identity[O] _, _16: (P => PP) = identity[P] _, _17: (Q => QQ) = identity[Q] _, _18: (R => RR) = identity[R] _): (AA, BB, CC, DD, EE, FF, GG, HH, II, JJ, KK, LL, MM, NN, OO, PP, QQ, RR) = (_1(value._1), _2(value._2), _3(value._3), _4(value._4), _5(value._5), _6(value._6), _7(value._7), _8(value._8), _9(value._9), _10(value._10), _11(value._11), _12(value._12), _13(value._13), _14(value._14), _15(value._15), _16(value._16), _17(value._17), _18(value._18))
@@ -40,8 +40,8 @@ trait Tuple18W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R] extends Pim
 
 implicit def ToTuple18W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](t: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)): Tuple18W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R] = new { val value = t } with Tuple18W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R]
 
-  
-trait Tuple19W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S] extends PimpedType[Tuple19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S]] {
+
+trait Tuple19W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S] extends EnrichedType[Tuple19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S]] {
   def fold[Z](f: => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => Z): Z = {import value._; f(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19)}
   def toIndexedSeq[Z](implicit ev: value.type <:< Tuple19[Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z]): IndexedSeq[Z] = {val zs = ev(value); import zs._; IndexedSeq(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19)}
   def mapElements[AA, BB, CC, DD, EE, FF, GG, HH, II, JJ, KK, LL, MM, NN, OO, PP, QQ, RR, SS](_1: (A => AA) = identity[A] _, _2: (B => BB) = identity[B] _, _3: (C => CC) = identity[C] _, _4: (D => DD) = identity[D] _, _5: (E => EE) = identity[E] _, _6: (F => FF) = identity[F] _, _7: (G => GG) = identity[G] _, _8: (H => HH) = identity[H] _, _9: (I => II) = identity[I] _, _10: (J => JJ) = identity[J] _, _11: (K => KK) = identity[K] _, _12: (L => LL) = identity[L] _, _13: (M => MM) = identity[M] _, _14: (N => NN) = identity[N] _, _15: (O => OO) = identity[O] _, _16: (P => PP) = identity[P] _, _17: (Q => QQ) = identity[Q] _, _18: (R => RR) = identity[R] _, _19: (S => SS) = identity[S] _): (AA, BB, CC, DD, EE, FF, GG, HH, II, JJ, KK, LL, MM, NN, OO, PP, QQ, RR, SS) = (_1(value._1), _2(value._2), _3(value._3), _4(value._4), _5(value._5), _6(value._6), _7(value._7), _8(value._8), _9(value._9), _10(value._10), _11(value._11), _12(value._12), _13(value._13), _14(value._14), _15(value._15), _16(value._16), _17(value._17), _18(value._18), _19(value._19))
@@ -49,8 +49,8 @@ trait Tuple19W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S] extends 
 
 implicit def ToTuple19W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](t: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)): Tuple19W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S] = new { val value = t } with Tuple19W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S]
 
-  
-trait Tuple20W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T] extends PimpedType[Tuple20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T]] {
+
+trait Tuple20W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T] extends EnrichedType[Tuple20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T]] {
   def fold[Z](f: => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => Z): Z = {import value._; f(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20)}
   def toIndexedSeq[Z](implicit ev: value.type <:< Tuple20[Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z]): IndexedSeq[Z] = {val zs = ev(value); import zs._; IndexedSeq(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20)}
   def mapElements[AA, BB, CC, DD, EE, FF, GG, HH, II, JJ, KK, LL, MM, NN, OO, PP, QQ, RR, SS, TT](_1: (A => AA) = identity[A] _, _2: (B => BB) = identity[B] _, _3: (C => CC) = identity[C] _, _4: (D => DD) = identity[D] _, _5: (E => EE) = identity[E] _, _6: (F => FF) = identity[F] _, _7: (G => GG) = identity[G] _, _8: (H => HH) = identity[H] _, _9: (I => II) = identity[I] _, _10: (J => JJ) = identity[J] _, _11: (K => KK) = identity[K] _, _12: (L => LL) = identity[L] _, _13: (M => MM) = identity[M] _, _14: (N => NN) = identity[N] _, _15: (O => OO) = identity[O] _, _16: (P => PP) = identity[P] _, _17: (Q => QQ) = identity[Q] _, _18: (R => RR) = identity[R] _, _19: (S => SS) = identity[S] _, _20: (T => TT) = identity[T] _): (AA, BB, CC, DD, EE, FF, GG, HH, II, JJ, KK, LL, MM, NN, OO, PP, QQ, RR, SS, TT) = (_1(value._1), _2(value._2), _3(value._3), _4(value._4), _5(value._5), _6(value._6), _7(value._7), _8(value._8), _9(value._9), _10(value._10), _11(value._11), _12(value._12), _13(value._13), _14(value._14), _15(value._15), _16(value._16), _17(value._17), _18(value._18), _19(value._19), _20(value._20))
@@ -58,8 +58,8 @@ trait Tuple20W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T] exten
 
 implicit def ToTuple20W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](t: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)): Tuple20W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T] = new { val value = t } with Tuple20W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T]
 
-  
-trait Tuple21W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U] extends PimpedType[Tuple21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U]] {
+
+trait Tuple21W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U] extends EnrichedType[Tuple21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U]] {
   def fold[Z](f: => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => Z): Z = {import value._; f(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21)}
   def toIndexedSeq[Z](implicit ev: value.type <:< Tuple21[Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z]): IndexedSeq[Z] = {val zs = ev(value); import zs._; IndexedSeq(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21)}
   def mapElements[AA, BB, CC, DD, EE, FF, GG, HH, II, JJ, KK, LL, MM, NN, OO, PP, QQ, RR, SS, TT, UU](_1: (A => AA) = identity[A] _, _2: (B => BB) = identity[B] _, _3: (C => CC) = identity[C] _, _4: (D => DD) = identity[D] _, _5: (E => EE) = identity[E] _, _6: (F => FF) = identity[F] _, _7: (G => GG) = identity[G] _, _8: (H => HH) = identity[H] _, _9: (I => II) = identity[I] _, _10: (J => JJ) = identity[J] _, _11: (K => KK) = identity[K] _, _12: (L => LL) = identity[L] _, _13: (M => MM) = identity[M] _, _14: (N => NN) = identity[N] _, _15: (O => OO) = identity[O] _, _16: (P => PP) = identity[P] _, _17: (Q => QQ) = identity[Q] _, _18: (R => RR) = identity[R] _, _19: (S => SS) = identity[S] _, _20: (T => TT) = identity[T] _, _21: (U => UU) = identity[U] _): (AA, BB, CC, DD, EE, FF, GG, HH, II, JJ, KK, LL, MM, NN, OO, PP, QQ, RR, SS, TT, UU) = (_1(value._1), _2(value._2), _3(value._3), _4(value._4), _5(value._5), _6(value._6), _7(value._7), _8(value._8), _9(value._9), _10(value._10), _11(value._11), _12(value._12), _13(value._13), _14(value._14), _15(value._15), _16(value._16), _17(value._17), _18(value._18), _19(value._19), _20(value._20), _21(value._21))
@@ -67,8 +67,8 @@ trait Tuple21W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U] ex
 
 implicit def ToTuple21W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](t: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)): Tuple21W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U] = new { val value = t } with Tuple21W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U]
 
-  
-trait Tuple22W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V] extends PimpedType[Tuple22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V]] {
+
+trait Tuple22W[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V] extends EnrichedType[Tuple22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V]] {
   def fold[Z](f: => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => Z): Z = {import value._; f(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22)}
   def toIndexedSeq[Z](implicit ev: value.type <:< Tuple22[Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z]): IndexedSeq[Z] = {val zs = ev(value); import zs._; IndexedSeq(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22)}
   def mapElements[AA, BB, CC, DD, EE, FF, GG, HH, II, JJ, KK, LL, MM, NN, OO, PP, QQ, RR, SS, TT, UU, VV](_1: (A => AA) = identity[A] _, _2: (B => BB) = identity[B] _, _3: (C => CC) = identity[C] _, _4: (D => DD) = identity[D] _, _5: (E => EE) = identity[E] _, _6: (F => FF) = identity[F] _, _7: (G => GG) = identity[G] _, _8: (H => HH) = identity[H] _, _9: (I => II) = identity[I] _, _10: (J => JJ) = identity[J] _, _11: (K => KK) = identity[K] _, _12: (L => LL) = identity[L] _, _13: (M => MM) = identity[M] _, _14: (N => NN) = identity[N] _, _15: (O => OO) = identity[O] _, _16: (P => PP) = identity[P] _, _17: (Q => QQ) = identity[Q] _, _18: (R => RR) = identity[R] _, _19: (S => SS) = identity[S] _, _20: (T => TT) = identity[T] _, _21: (U => UU) = identity[U] _, _22: (V => VV) = identity[V] _): (AA, BB, CC, DD, EE, FF, GG, HH, II, JJ, KK, LL, MM, NN, OO, PP, QQ, RR, SS, TT, UU, VV) = (_1(value._1), _2(value._2), _3(value._3), _4(value._4), _5(value._5), _6(value._6), _7(value._7), _8(value._8), _9(value._9), _10(value._10), _11(value._11), _12(value._12), _13(value._13), _14(value._14), _15(value._15), _16(value._16), _17(value._17), _18(value._18), _19(value._19), _20(value._20), _21(value._21), _22(value._22))

--- a/test/files/pos/t5809.scala
+++ b/test/files/pos/t5809.scala
@@ -1,5 +1,5 @@
 package object foo {
-  implicit class PimpedInt(foo: Int) {
+  implicit class EnrichedInt(foo: Int) {
     def bar = ???
     def bippy = foo
   }

--- a/test/files/pos/t5877.scala
+++ b/test/files/pos/t5877.scala
@@ -7,8 +7,8 @@ package foo {
 }
 
 package object foo {
-  // Crasher: No synthetics for method PimpedFoo2: synthetics contains
-  implicit class PimpedFoo2(value: Foo) {
+  // Crasher: No synthetics for method EnrichedFoo2: synthetics contains
+  implicit class EnrichedFoo2(value: Foo) {
     def huzzah = ""
   }
 }

--- a/test/files/pos/t5877b.scala
+++ b/test/files/pos/t5877b.scala
@@ -7,7 +7,7 @@ object Test {
 }
 
 object `package` {
-  implicit class PimpedFoo2(value: Foo) {
+  implicit class EnrichedFoo2(value: Foo) {
     def huzzah = ""
   }
 }

--- a/test/scaladoc/resources/implicits-base-res.scala
+++ b/test/scaladoc/resources/implicits-base-res.scala
@@ -11,21 +11,21 @@ trait MyNumeric[R]
  *  - tests the complete type inference
  *  - the following inherited methods should appear:
  * {{{
- * def convToGtColonDoubleA(x: Double)    // pimpA3: with a constraint that T <: Double
- * def convToIntA(x: Int)                 // pimpA2: with a constraint that T = Int
- * def convToManifestA(x: T)              // pimpA7: with 2 constraints: T: Manifest and T <: Double
- * def convToMyNumericA(x: T)             // pimpA6: with a constraint that there is x: MyNumeric[T] implicit in scope
- * def convToNumericA(x: T)               // pimpA1: with a constraint that there is x: Numeric[T] implicit in scope
- * def convToPimpedA(x: Bar[Foo[T]])      // pimpA5: no constraints, SHADOWED
- * def convToPimpedA(x: S)                // pimpA4: with 3 constraints: T = Foo[Bar[S]], S: Foo and S: Bar, SHADOWED
- * def convToPimpedA(x: T)                // pimpA0: with no constraints, SHADOWED
- * def convToTraversableOps(x: T)         // pimpA7: with 2 constraints: T: Manifest and T <: Double
+ * def convToGtColonDoubleA(x: Double)    // enrichA3: with a constraint that T <: Double
+ * def convToIntA(x: Int)                 // enrichA2: with a constraint that T = Int
+ * def convToManifestA(x: T)              // enrichA7: with 2 constraints: T: Manifest and T <: Double
+ * def convToMyNumericA(x: T)             // enrichA6: with a constraint that there is x: MyNumeric[T] implicit in scope
+ * def convToNumericA(x: T)               // enrichA1: with a constraint that there is x: Numeric[T] implicit in scope
+ * def convToEnrichedA(x: Bar[Foo[T]])    // enrichA5: no constraints, SHADOWED
+ * def convToEnrichedA(x: S)              // enrichA4: with 3 constraints: T = Foo[Bar[S]], S: Foo and S: Bar, SHADOWED
+ * def convToEnrichedA(x: T)              // enrichA0: with no constraints, SHADOWED
+ * def convToTraversableOps(x: T)         // enrichA7: with 2 constraints: T: Manifest and T <: Double
  *                                        // should not be abstract!
  * }}}
  */
 class A[T] {
-  /** This should prevent the implicitly inherited `def convToPimpedA: T` from `pimpA0` from showing up */
-  def convToPimpedA(x: T): T = sys.error("Let's check it out!")
+  /** This should prevent the implicitly inherited `def convToEnrichedA: T` from `enrichA0` from showing up */
+  def convToEnrichedA(x: T): T = sys.error("Let's check it out!")
   /** This should check implicit member elimination in the case of subtyping */
   def foo(a: T, b: AnyRef): T
 }
@@ -33,15 +33,15 @@ class A[T] {
 object A {
   import language.implicitConversions // according to SIP18
 
-  implicit def pimpA0[V](a: A[V]) = new PimpedA(a)
-  implicit def pimpA1[ZBUR: Numeric](a: A[ZBUR]) = new NumericA[ZBUR](a)
-  implicit def pimpA2(a: A[Int]) = new IntA(a)
-  implicit def pimpA3(a: A[T] forSome { type T <: Double }) = new GtColonDoubleA(a)
-  implicit def pimpA4[S](a: A[Foo[Bar[S]]])(implicit foo: Foo[S], bar: Bar[S]): PimpedA[S] = sys.error("not implemented")
-  implicit def pimpA5[Z](a: A[Z]): PimpedA[Bar[Foo[Z]]] = sys.error("not implemented")
-  implicit def pimpA6[Z: MyNumeric](a: A[Z]) = new MyNumericA[Z](a)
+  implicit def enrichA0[V](a: A[V]) = new EnrichedA(a)
+  implicit def enrichA1[ZBUR: Numeric](a: A[ZBUR]) = new NumericA[ZBUR](a)
+  implicit def enrichA2(a: A[Int]) = new IntA(a)
+  implicit def enrichA3(a: A[T] forSome { type T <: Double }) = new GtColonDoubleA(a)
+  implicit def enrichA4[S](a: A[Foo[Bar[S]]])(implicit foo: Foo[S], bar: Bar[S]): EnrichedA[S] = sys.error("not implemented")
+  implicit def enrichA5[Z](a: A[Z]): EnrichedA[Bar[Foo[Z]]] = sys.error("not implemented")
+  implicit def enrichA6[Z: MyNumeric](a: A[Z]) = new MyNumericA[Z](a)
   // TODO: Add H <: Double and see why it crashes for C and D -- context bounds, need to check!
-  implicit def pimpA7[H <: Double : Manifest](a: A[H]) = new ManifestA[H](a) with MyTraversableOps[H] { def convToTraversableOps(x: H): H = sys.error("no") }
+  implicit def enrichA7[H <: Double : Manifest](a: A[H]) = new ManifestA[H](a) with MyTraversableOps[H] { def convToTraversableOps(x: H): H = sys.error("no") }
 }
 
 
@@ -49,14 +49,14 @@ object A {
  *  - tests the existential type solving
  *  - the following inherited methods should appear:
  * {{{
- * def convToGtColonDoubleA(x: Double)    // pimpA3: no constraints
- * def convToManifestA(x: Double)         // pimpA7: no constraints
- * def convToMyNumericA(x: Double)        // pimpA6: (if showAll is set) with a constraint that there is x: MyNumeric[Double] implicit in scope
- * def convToNumericA(x: Double)          // pimpA1: no constraintsd
- * def convToPimpedA(x: Bar[Foo[Double]]) // pimpA5: no constraints, SHADOWED
- * def convToPimpedA(x: Double)           // pimpA0: no constraints, SHADOWED
- * def convToTraversableOps(x: Double)    // pimpA7: no constraints
- *                                        // should not be abstract!
+ * def convToGtColonDoubleA(x: Double)      // enrichA3: no constraints
+ * def convToManifestA(x: Double)           // enrichA7: no constraints
+ * def convToMyNumericA(x: Double)          // enrichA6: (if showAll is set) with a constraint that there is x: MyNumeric[Double] implicit in scope
+ * def convToNumericA(x: Double)            // enrichA1: no constraintsd
+ * def convToEnrichedA(x: Bar[Foo[Double]]) // enrichA5: no constraints, SHADOWED
+ * def convToEnrichedA(x: Double)           // enrichA0: no constraints, SHADOWED
+ * def convToTraversableOps(x: Double)      // enrichA7: no constraints
+ *                                          // should not be abstract!
  * }}}
  */
 class B extends A[Double]
@@ -67,11 +67,11 @@ object B extends A
  *  - tests asSeenFrom
  *  - the following inherited methods should appear:
  * {{{
- * def convToIntA(x: Int)                 // pimpA2: no constraints
- * def convToMyNumericA(x: Int)           // pimpA6: (if showAll is set) with a constraint that there is x: MyNumeric[Int] implicit in scope
- * def convToNumericA(x: Int)             // pimpA1: no constraints
- * def convToPimpedA(x: Int)              // pimpA0: no constraints, SHADOWED
- * def convToPimpedA(x: Bar[Foo[Int]])    // pimpA5: no constraints, SHADOWED
+ * def convToIntA(x: Int)                 // enrichA2: no constraints
+ * def convToMyNumericA(x: Int)           // enrichA6: (if showAll is set) with a constraint that there is x: MyNumeric[Int] implicit in scope
+ * def convToNumericA(x: Int)             // enrichA1: no constraints
+ * def convToEnrichedA(x: Int)            // enrichA0: no constraints, SHADOWED
+ * def convToEnrichedA(x: Bar[Foo[Int]])  // enrichA5: no constraints, SHADOWED
  * }}}
  */
 class C extends A[Int]
@@ -82,10 +82,10 @@ object C extends A
  *  - tests implicit elimination
  *  - the following inherited methods should appear:
  * {{{
- * def convToMyNumericA(x: String)        // pimpA6: (if showAll is set) with a constraint that there is x: MyNumeric[String] implicit in scope
- * def convToNumericA(x: String)          // pimpA1: (if showAll is set) with a constraint that there is x: Numeric[String] implicit in scope
- * def convToPimpedA(x: Bar[Foo[String]]) // pimpA5: no constraints, SHADOWED
- * def convToPimpedA(x: String)           // pimpA0: no constraints, SHADOWED
+ * def convToMyNumericA(x: String)        // enrichA6: (if showAll is set) with a constraint that there is x: MyNumeric[String] implicit in scope
+ * def convToNumericA(x: String)          // enrichA1: (if showAll is set) with a constraint that there is x: Numeric[String] implicit in scope
+ * def convToEnrichedA(x: Bar[Foo[String]]) // enrichA5: no constraints, SHADOWED
+ * def convToEnrichedA(x: String)           // enrichA0: no constraints, SHADOWED
  * }}}
  */
 class D extends A[String]
@@ -93,12 +93,12 @@ class D extends A[String]
 object D extends A
 
 
-/** PimpedA class <br/>
+/** EnrichedA class <br/>
  *  - tests simple inheritance and asSeenFrom
  *  - A, B and C should be implicitly converted to this */
-class PimpedA[V](a: A[V]) {
-  /** The convToPimpedA: V documentation... */
-  def convToPimpedA(x: V): V = sys.error("Not implemented")
+class EnrichedA[V](a: A[V]) {
+  /** The convToEnrichedA: V documentation... */
+  def convToEnrichedA(x: V): V = sys.error("Not implemented")
 }
 
 /** NumericA class <br/>

--- a/test/scaladoc/run/implicits-base.scala
+++ b/test/scaladoc/run/implicits-base.scala
@@ -25,54 +25,54 @@ object Test extends ScaladocModelTest {
 
     val A = base._class("A")
 
-    // def convToPimpedA(x: T)                // pimpA0: with no constraints, SHADOWED
-    conv = A._conversion(A.qualifiedName + ".pimpA0")
+    // def convToEnrichedA(x: T)                // enrichA0: with no constraints, SHADOWED
+    conv = A._conversion(A.qualifiedName + ".enrichA0")
     assert(conv.members.length == 1)
     assert(conv.constraints.length == 0)
-    assert(isShadowed(conv._member("convToPimpedA")))
-    assert(conv._member("convToPimpedA").resultType.name == "T")
+    assert(isShadowed(conv._member("convToEnrichedA")))
+    assert(conv._member("convToEnrichedA").resultType.name == "T")
 
-    // def convToNumericA: T               // pimpA1: with a constraint that there is x: Numeric[T] implicit in scope
-    conv = A._conversion(A.qualifiedName + ".pimpA1")
+    // def convToNumericA: T               // enrichA1: with a constraint that there is x: Numeric[T] implicit in scope
+    conv = A._conversion(A.qualifiedName + ".enrichA1")
     assert(conv.members.length == 1)
     assert(conv.constraints.length == 1)
     assert(conv._member("convToNumericA").resultType.name == "T")
 
-    // def convToIntA: Int                 // pimpA2: with a constraint that T = Int
-    conv = A._conversion(A.qualifiedName + ".pimpA2")
+    // def convToIntA: Int                 // enrichA2: with a constraint that T = Int
+    conv = A._conversion(A.qualifiedName + ".enrichA2")
     assert(conv.members.length == 1)
     assert(conv.constraints.length == 1)
     assert(conv._member("convToIntA").resultType.name == "Int")
 
-    // def convToGtColonDoubleA: Double    // pimpA3: with a constraint that T <: Double
-    conv = A._conversion(A.qualifiedName + ".pimpA3")
+    // def convToGtColonDoubleA: Double    // enrichA3: with a constraint that T <: Double
+    conv = A._conversion(A.qualifiedName + ".enrichA3")
     assert(conv.members.length == 1)
     assert(conv.constraints.length == 1)
     assert(conv._member("convToGtColonDoubleA").resultType.name == "Double")
 
-    // def convToPimpedA: S                // pimpA4: with 3 constraints: T = Foo[Bar[S]], S: Foo and S: Bar
-    conv = A._conversion(A.qualifiedName + ".pimpA4")
+    // def convToEnrichedA: S                // enrichA4: with 3 constraints: T = Foo[Bar[S]], S: Foo and S: Bar
+    conv = A._conversion(A.qualifiedName + ".enrichA4")
     assert(conv.members.length == 1)
     assert(conv.constraints.length == 3)
-    assert(conv._member("convToPimpedA").resultType.name == "S")
+    assert(conv._member("convToEnrichedA").resultType.name == "S")
 
-    // def convToPimpedA: Bar[Foo[T]]      // pimpA5: no constraints
-    conv = A._conversion(A.qualifiedName + ".pimpA5")
+    // def convToEnrichedA: Bar[Foo[T]]      // enrichA5: no constraints
+    conv = A._conversion(A.qualifiedName + ".enrichA5")
     assert(conv.members.length == 1)
     assert(conv.constraints.length == 0)
-    assert(isShadowed(conv._member("convToPimpedA")))
-    assert(conv._member("convToPimpedA").resultType.name == "Bar[Foo[T]]")
+    assert(isShadowed(conv._member("convToEnrichedA")))
+    assert(conv._member("convToEnrichedA").resultType.name == "Bar[Foo[T]]")
 
-    // def convToMyNumericA: T             // pimpA6: with a constraint that there is x: MyNumeric[T] implicit in scope
-    conv = A._conversion(A.qualifiedName + ".pimpA6")
+    // def convToMyNumericA: T             // enrichA6: with a constraint that there is x: MyNumeric[T] implicit in scope
+    conv = A._conversion(A.qualifiedName + ".enrichA6")
     assert(conv.members.length == 1)
     assert(conv.constraints.length == 1)
     assert(conv._member("convToMyNumericA").resultType.name == "T")
 
-    // def convToManifestA: T              // pimpA7: with 2 constraints: T: Manifest and T <: Double
-    // def convToTraversableOps: T         // pimpA7: with 2 constraints: T: Manifest and T <: Double
+    // def convToManifestA: T              // enrichA7: with 2 constraints: T: Manifest and T <: Double
+    // def convToTraversableOps: T         // enrichA7: with 2 constraints: T: Manifest and T <: Double
                                            // should not be abstract!
-    conv = A._conversion(A.qualifiedName + ".pimpA7")
+    conv = A._conversion(A.qualifiedName + ".enrichA7")
     assert(conv.members.length == 2)
     assert(conv.constraints.length == 2)
     assert(conv._member("convToManifestA").resultType.name == "T")
@@ -84,45 +84,45 @@ object Test extends ScaladocModelTest {
     val B = base._class("B")
 
     // these conversions should not affect B
-    assert(B._conversions(A.qualifiedName + ".pimpA2").isEmpty)
-    assert(B._conversions(A.qualifiedName + ".pimpA4").isEmpty)
+    assert(B._conversions(A.qualifiedName + ".enrichA2").isEmpty)
+    assert(B._conversions(A.qualifiedName + ".enrichA4").isEmpty)
 
-    // def convToPimpedA(x: Double)           // pimpA0: no constraints, SHADOWED
-    conv = B._conversion(A.qualifiedName + ".pimpA0")
+    // def convToEnrichedA(x: Double)           // enrichA0: no constraints, SHADOWED
+    conv = B._conversion(A.qualifiedName + ".enrichA0")
     assert(conv.members.length == 1)
     assert(conv.constraints.length == 0)
-    assert(isShadowed(conv._member("convToPimpedA")))
-    assert(conv._member("convToPimpedA").resultType.name == "Double")
+    assert(isShadowed(conv._member("convToEnrichedA")))
+    assert(conv._member("convToEnrichedA").resultType.name == "Double")
 
-    // def convToNumericA: Double          // pimpA1: no constraintsd
-    conv = B._conversion(A.qualifiedName + ".pimpA1")
+    // def convToNumericA: Double          // enrichA1: no constraintsd
+    conv = B._conversion(A.qualifiedName + ".enrichA1")
     assert(conv.members.length == 1)
     assert(conv.constraints.length == 0)
     assert(conv._member("convToNumericA").resultType.name == "Double")
 
-    // def convToGtColonDoubleA: Double    // pimpA3: no constraints
-    conv = B._conversion(A.qualifiedName + ".pimpA3")
+    // def convToGtColonDoubleA: Double    // enrichA3: no constraints
+    conv = B._conversion(A.qualifiedName + ".enrichA3")
     assert(conv.members.length == 1)
     assert(conv.constraints.length == 0)
     assert(conv._member("convToGtColonDoubleA").resultType.name == "Double")
 
-    // def convToPimpedA: Bar[Foo[Double]] // pimpA5: no constraints
-    conv = B._conversion(A.qualifiedName + ".pimpA5")
+    // def convToEnrichedA: Bar[Foo[Double]] // enrichA5: no constraints
+    conv = B._conversion(A.qualifiedName + ".enrichA5")
     assert(conv.members.length == 1)
     assert(conv.constraints.length == 0)
-    assert(isShadowed(conv._member("convToPimpedA")))
-    assert(conv._member("convToPimpedA").resultType.name == "Bar[Foo[Double]]")
+    assert(isShadowed(conv._member("convToEnrichedA")))
+    assert(conv._member("convToEnrichedA").resultType.name == "Bar[Foo[Double]]")
 
-    // def convToMyNumericA: Double        // pimpA6: (if showAll is set) with a constraint that there is x: MyNumeric[Double] implicit in scope
-    conv = B._conversion(A.qualifiedName + ".pimpA6")
+    // def convToMyNumericA: Double        // enrichA6: (if showAll is set) with a constraint that there is x: MyNumeric[Double] implicit in scope
+    conv = B._conversion(A.qualifiedName + ".enrichA6")
     assert(conv.members.length == 1)
     assert(conv.constraints.length == 1)
     assert(conv._member("convToMyNumericA").resultType.name == "Double")
 
-    // def convToManifestA: Double         // pimpA7: no constraints
-    // def convToTraversableOps: Double    // pimpA7: no constraints
+    // def convToManifestA: Double         // enrichA7: no constraints
+    // def convToTraversableOps: Double    // enrichA7: no constraints
     //                                     // should not be abstract!
-    conv = B._conversion(A.qualifiedName + ".pimpA7")
+    conv = B._conversion(A.qualifiedName + ".enrichA7")
     assert(conv.members.length == 2)
     assert(conv.constraints.length == 0)
     assert(conv._member("convToManifestA").resultType.name == "Double")
@@ -134,38 +134,38 @@ object Test extends ScaladocModelTest {
     val C = base._class("C")
 
     // these conversions should not affect C
-    assert(C._conversions(A.qualifiedName + ".pimpA3").isEmpty)
-    assert(C._conversions(A.qualifiedName + ".pimpA4").isEmpty)
-    assert(C._conversions(A.qualifiedName + ".pimpA7").isEmpty)
+    assert(C._conversions(A.qualifiedName + ".enrichA3").isEmpty)
+    assert(C._conversions(A.qualifiedName + ".enrichA4").isEmpty)
+    assert(C._conversions(A.qualifiedName + ".enrichA7").isEmpty)
 
-    // def convToPimpedA(x: Int)           // pimpA0: no constraints, SHADOWED
-    conv = C._conversion(A.qualifiedName + ".pimpA0")
+    // def convToEnrichedA(x: Int)           // enrichA0: no constraints, SHADOWED
+    conv = C._conversion(A.qualifiedName + ".enrichA0")
     assert(conv.members.length == 1)
     assert(conv.constraints.length == 0)
-    assert(isShadowed(conv._member("convToPimpedA")))
-    assert(conv._member("convToPimpedA").resultType.name == "Int")
+    assert(isShadowed(conv._member("convToEnrichedA")))
+    assert(conv._member("convToEnrichedA").resultType.name == "Int")
 
-    // def convToNumericA: Int             // pimpA1: no constraints
-    conv = C._conversion(A.qualifiedName + ".pimpA1")
+    // def convToNumericA: Int             // enrichA1: no constraints
+    conv = C._conversion(A.qualifiedName + ".enrichA1")
     assert(conv.members.length == 1)
     assert(conv.constraints.length == 0)
     assert(conv._member("convToNumericA").resultType.name == "Int")
 
-    // def convToIntA: Int                 // pimpA2: no constraints
-    conv = C._conversion(A.qualifiedName + ".pimpA2")
+    // def convToIntA: Int                 // enrichA2: no constraints
+    conv = C._conversion(A.qualifiedName + ".enrichA2")
     assert(conv.members.length == 1)
     assert(conv.constraints.length == 0)
     assert(conv._member("convToIntA").resultType.name == "Int")
 
-    // def convToPimpedA: Bar[Foo[Int]]    // pimpA5: no constraints
-    conv = C._conversion(A.qualifiedName + ".pimpA5")
+    // def convToEnrichedA: Bar[Foo[Int]]    // enrichA5: no constraints
+    conv = C._conversion(A.qualifiedName + ".enrichA5")
     assert(conv.members.length == 1)
     assert(conv.constraints.length == 0)
-    assert(isShadowed(conv._member("convToPimpedA")))
-    assert(conv._member("convToPimpedA").resultType.name == "Bar[Foo[Int]]")
+    assert(isShadowed(conv._member("convToEnrichedA")))
+    assert(conv._member("convToEnrichedA").resultType.name == "Bar[Foo[Int]]")
 
-    // def convToMyNumericA: Int           // pimpA6: (if showAll is set) with a constraint that there is x: MyNumeric[Int] implicit in scope
-    conv = C._conversion(A.qualifiedName + ".pimpA6")
+    // def convToMyNumericA: Int           // enrichA6: (if showAll is set) with a constraint that there is x: MyNumeric[Int] implicit in scope
+    conv = C._conversion(A.qualifiedName + ".enrichA6")
     assert(conv.members.length == 1)
     assert(conv.constraints.length == 1)
     assert(conv._member("convToMyNumericA").resultType.name == "Int")
@@ -175,33 +175,33 @@ object Test extends ScaladocModelTest {
     val D = base._class("D")
 
     // these conversions should not affect D
-    assert(D._conversions(A.qualifiedName + ".pimpA2").isEmpty)
-    assert(D._conversions(A.qualifiedName + ".pimpA3").isEmpty)
-    assert(D._conversions(A.qualifiedName + ".pimpA4").isEmpty)
-    assert(D._conversions(A.qualifiedName + ".pimpA7").isEmpty)
+    assert(D._conversions(A.qualifiedName + ".enrichA2").isEmpty)
+    assert(D._conversions(A.qualifiedName + ".enrichA3").isEmpty)
+    assert(D._conversions(A.qualifiedName + ".enrichA4").isEmpty)
+    assert(D._conversions(A.qualifiedName + ".enrichA7").isEmpty)
 
-    // def convToPimpedA(x: String)        // pimpA0: no constraints, SHADOWED
-    conv = D._conversion(A.qualifiedName + ".pimpA0")
+    // def convToEnrichedA(x: String)        // enrichA0: no constraints, SHADOWED
+    conv = D._conversion(A.qualifiedName + ".enrichA0")
     assert(conv.members.length == 1)
     assert(conv.constraints.length == 0)
-    assert(isShadowed(conv._member("convToPimpedA")))
-    assert(conv._member("convToPimpedA").resultType.name == "String")
+    assert(isShadowed(conv._member("convToEnrichedA")))
+    assert(conv._member("convToEnrichedA").resultType.name == "String")
 
-    // def convToNumericA: String          // pimpA1: (if showAll is set) with a constraint that there is x: Numeric[String] implicit in scope
-    conv = D._conversion(A.qualifiedName + ".pimpA1")
+    // def convToNumericA: String          // enrichA1: (if showAll is set) with a constraint that there is x: Numeric[String] implicit in scope
+    conv = D._conversion(A.qualifiedName + ".enrichA1")
     assert(conv.members.length == 1)
     assert(conv.constraints.length == 1)
     assert(conv._member("convToNumericA").resultType.name == "String")
 
-    // def convToPimpedA: Bar[Foo[String]] // pimpA5: no constraints
-    conv = D._conversion(A.qualifiedName + ".pimpA5")
+    // def convToEnrichedA: Bar[Foo[String]] // enrichA5: no constraints
+    conv = D._conversion(A.qualifiedName + ".enrichA5")
     assert(conv.members.length == 1)
     assert(conv.constraints.length == 0)
-    assert(isShadowed(conv._member("convToPimpedA")))
-    assert(conv._member("convToPimpedA").resultType.name == "Bar[Foo[String]]")
+    assert(isShadowed(conv._member("convToEnrichedA")))
+    assert(conv._member("convToEnrichedA").resultType.name == "Bar[Foo[String]]")
 
-    // def convToMyNumericA: String        // pimpA6: (if showAll is set) with a constraint that there is x: MyNumeric[String] implicit in scope
-    conv = D._conversion(A.qualifiedName + ".pimpA6")
+    // def convToMyNumericA: String        // enrichA6: (if showAll is set) with a constraint that there is x: MyNumeric[String] implicit in scope
+    conv = D._conversion(A.qualifiedName + ".enrichA6")
     assert(conv.members.length == 1)
     assert(conv.constraints.length == 1)
     assert(conv._member("convToMyNumericA").resultType.name == "String")


### PR DESCRIPTION
Small terminology change aimed at improving inclusion.

Discussion on scala-internal: https://groups.google.com/forum/?fromgroups=#!topic/scala-internals/kVWg7HKldjs

I signed the CLA and sent it to the email address in the PDF.
