### PR TITLE
Addressing warnings.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -1360,7 +1360,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
               debuglog("obtained env: " + e)
               e.keySet == env.keySet
             } catch {
-              case _ =>
+              case _: Throwable =>
                 debuglog("Could not unify.")
                 false
             }

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -730,7 +730,7 @@ trait ContextErrors {
           } catch {
             // the code above tries various tricks to detect the relevant portion of the stack trace
             // if these tricks fail, just fall back to uninformative, but better than nothing, getMessage
-            case NonFatal(ex) =>
+            case NonFatal(ex) => // currently giving a spurious warning, see SI-6994
               macroLogVerbose("got an exception when processing a macro generated exception\n" +
                               "offender = " + stackTraceString(realex) + "\n" +
                               "error = " + stackTraceString(ex))

--- a/src/library/scala/collection/mutable/HashSet.scala
+++ b/src/library/scala/collection/mutable/HashSet.scala
@@ -88,7 +88,7 @@ extends AbstractSet[A]
   }
 
   private def readObject(in: java.io.ObjectInputStream) {
-    init(in, x => x)
+    init(in, x => ())
   }
 
   /** Toggles whether a size map is used to track hash map statistics.

--- a/src/library/scala/collection/parallel/mutable/ParArray.scala
+++ b/src/library/scala/collection/parallel/mutable/ParArray.scala
@@ -469,7 +469,6 @@ self =>
           Array.copy(arr, i, targetarr, 0, until - i)
           pac.buff.size = pac.buff.size + until - i
           pac.buff.lastPtr.size = until - i
-            pac
         } otherwise {
           copy2builder_quick(cb, arr, until, i)
           i = until
@@ -531,7 +530,6 @@ self =>
         val targetarr: Array[Any] = pac.lastbuff.internalArray.asInstanceOf[Array[Any]]
         reverse2combiner_quick(targetarr, arr, 0, i, until)
         pac.lastbuff.setInternalSize(sz)
-        pac
       } otherwise {
         cb.ifIs[UnrolledParArrayCombiner[T]] {
           pac =>
@@ -542,7 +540,6 @@ self =>
           reverse2combiner_quick(targetarr, arr, 0, i, until)
           pac.buff.size = pac.buff.size + sz
           pac.buff.lastPtr.size = sz
-          pac
         } otherwise super.reverse2combiner(cb)
       }
       cb

--- a/src/library/scala/collection/parallel/mutable/ParHashSet.scala
+++ b/src/library/scala/collection/parallel/mutable/ParHashSet.scala
@@ -85,7 +85,7 @@ extends ParSet[T]
   }
 
   private def readObject(in: java.io.ObjectInputStream) {
-    init(in, x => x)
+    init(in, x => ())
   }
 
   import scala.collection.DebugUtils._


### PR DESCRIPTION
- SI-6923 uncovered a few valid warnings, these have been
  addressed.
  - A pair of "catches all throwable" warnings appeared; one
    of the is spurious and the subject of SI-6994.

Review by @JamesIry. What's your opinion on the spuriosity of the following?

```
scala> (x => x): (Any => Unit)
<console>:8: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
              (x => x): (Any => Unit)
                    ^
```
