### PR TITLE
SI-6994 Avoid spurious promiscuous catch warning

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5367,7 +5367,7 @@ trait Typers extends Modes with Adaptations with Tags {
         var block1 = typed(tree.block, pt)
         var catches1 = typedCases(tree.catches, ThrowableClass.tpe, pt)
 
-        for (cdef <- catches1 if cdef.guard.isEmpty) {
+        for (cdef <- catches1 if !isPastTyper && cdef.guard.isEmpty) {
           def warn(name: Name) = context.warning(cdef.pat.pos, s"This catches all Throwables. If this is really intended, use `case ${name.decoded} : Throwable` to clear this warning.")
           def unbound(t: Tree) = t.symbol == null || t.symbol == NoSymbol
           cdef.pat match {

--- a/test/files/pos/t6994.flags
+++ b/test/files/pos/t6994.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t6994.scala
+++ b/test/files/pos/t6994.scala
@@ -1,0 +1,8 @@
+object Test {
+  object NF {
+    def unapply(t: Throwable): Option[Throwable] = None
+  }
+  val x = (try { None } catch { case NF(ex) => None }) getOrElse 0
+  // Was emitting a spurious warning post typer:
+  // "This catches all Throwables. If this is really intended, use `case ex6 : Throwable` to clear this warning."
+}


### PR DESCRIPTION
It was being issued upon re-typechecking of a transformed
tree. Now we disable the warning post-typer.

review by @JamesIry
