### PR TITLE
SI-6666 Restrict hidden `this` access in self/super calls.

### DIFF
--- a/test/files/neg/t6666.check
+++ b/test/files/neg/t6666.check
@@ -1,0 +1,40 @@
+t6666.scala:23: error: Implementation restriction: access of method x$2 in object O1 from anonymous class 2, would require illegal premature access to object O1
+  F.byname(x)
+           ^
+t6666.scala:30: error: Implementation restriction: access of value x$3 in object O2 from anonymous class 3, would require illegal premature access to object O2
+  F.byname(x)
+           ^
+t6666.scala:37: error: Implementation restriction: access of method x$4 in object O3 from anonymous class 4, would require illegal premature access to object O3
+  F.hof(() => x)
+              ^
+t6666.scala:50: error: Implementation restriction: access of method x$6 in class C1 from anonymous class 7, would require illegal premature access to the unconstructed `this` of class C1
+  F.byname(x)
+           ^
+t6666.scala:54: error: Implementation restriction: access of value x$7 in class C2 from anonymous class 8, would require illegal premature access to the unconstructed `this` of class C2
+  F.byname(x)
+           ^
+t6666.scala:58: error: Implementation restriction: access of method x$8 in class C3 from anonymous class 9, would require illegal premature access to the unconstructed `this` of class C3
+  F.hof(() => x)
+              ^
+t6666.scala:62: error: Implementation restriction: access of method x$9 in class C4 from object Nested$5, would require illegal premature access to the unconstructed `this` of class C4
+  object Nested { def xx = x}
+                           ^
+t6666.scala:68: error: Implementation restriction: access of method x$10 in class C5 from object Nested$6, would require illegal premature access to the unconstructed `this` of class C5
+    object Nested { def xx = x}
+                             ^
+t6666.scala:83: error: Implementation restriction: access of method x$12 in class C11 from anonymous class 12, would require illegal premature access to the unconstructed `this` of class C11
+      F.byname(x)
+               ^
+t6666.scala:102: error: Implementation restriction: access of method x$13 in class C13 from anonymous class 13, would require illegal premature access to the unconstructed `this` of class C13
+      F.hof(() => x)
+                  ^
+t6666.scala:111: error: Implementation restriction: access of method x$14 in class C14 from object Nested$7, would require illegal premature access to the unconstructed `this` of class C14
+      object Nested { def xx = x}
+                               ^
+t6666.scala:122: error: Implementation restriction: access of method x$15 in class C15 from object Nested$8, would require illegal premature access to the unconstructed `this` of class C15
+        object Nested { def xx = x}
+                                 ^
+t6666.scala:131: error: Implementation restriction: access of method foo$1 in class COuter from class CInner$1, would require illegal premature access to the unconstructed `this` of class COuter
+  class CInner extends C({foo})
+                          ^
+13 errors found

--- a/test/files/neg/t6666.scala
+++ b/test/files/neg/t6666.scala
@@ -1,0 +1,132 @@
+class C(a: Any)
+object F {
+  def byname(a: => Any) = println(a)
+  def hof(a: () => Any) = println(a())
+}
+
+class COkay extends C(0) {
+  def this(a: Any) {
+    this()
+    def x = "".toString
+    F.byname(x)
+  }
+}
+
+//
+// The thunk's apply method accesses the MODULE$
+// field before it is set.
+//
+//   0: getstatic #23; //Field O1$.MODULE$:LO1$;
+//   3: invokevirtual #26; //Method O1$.O1$$x$1:()Ljava/lang/String;
+object O1 extends C({
+  def x = "".toString
+  F.byname(x)
+})
+
+// java.lang.NullPointerException
+//   at O2$$anonfun$$init$$1.apply(<console>:11)
+object O2 extends C({
+  lazy val x = "".toString
+  F.byname(x)
+})
+
+// java.lang.NullPointerException
+//   at O3$$anonfun$$init$$1.apply(<console>:11)
+object O3 extends C({
+  def x = "".toString
+  F.hof(() => x)
+})
+
+// Okay, the nested classes don't get an outer pointer passed,
+// just an extra param for `x: String`.
+object O6 extends C({
+  val x = "".toString
+  F.byname(x); F.hof(() => x); (new { val xx = x }.xx)
+})
+
+
+class C1 extends C({
+  def x = "".toString
+  F.byname(x)
+})
+class C2 extends C({
+  lazy val x = "".toString
+  F.byname(x)
+})
+class C3 extends C({
+  def x = "".toString
+  F.hof(() => x)
+})
+class C4 extends C({
+  def x = "".toString
+  object Nested { def xx = x}
+  Nested.xx
+})
+class C5 extends C({
+  def x = "".toString
+  val y = {
+    object Nested { def xx = x}
+    Nested.xx
+  }
+})
+
+// okay, for same reason as O6
+class C6 extends C({
+  val x = "".toString
+  F.byname(x); F.hof(() => x); (new { val xx = x }.xx)
+})
+
+class C11(a: Any) {
+  def this() = {
+    this({
+     def x = "".toString
+      F.byname(x)
+    })
+  }
+}
+
+// Crashes earlier in lazyVals.
+// class C12(a: Any) {
+//   def this() = {
+//     this({
+//       lazy val x = "".toString
+//       F.byname(x)
+//     })
+//   }
+// }
+
+class C13(a: Any) {
+  def this() = {
+    this({
+      def x = "".toString
+      F.hof(() => x)
+    })
+  }
+}
+
+class C14(a: Any) {
+  def this() = {
+    this({
+      def x = "".toString
+      object Nested { def xx = x}
+      Nested.xx
+    })
+  }
+}
+
+class C15(a: Any) {
+  def this() = {
+    this({
+      def x = "".toString
+      val y = {
+        object Nested { def xx = x}
+        Nested.xx
+      }
+    })
+  }
+}
+
+class COuter extends C({
+  def foo = 0
+  class CInner extends C({foo})
+})


### PR DESCRIPTION
Detect when classes (user authored or compiler generated)
local to a self or super constructor argument would require
premature access to the in-construction instance.

The same restriction applies for classes and objects; for objects,
the premature access would result in a null via MODULE$ field.

A residual error has been lodged as SI-6997.

I'd like to remove calls to `Symbol#outerClass` (which relies on
the flaky flag INCONSTRUCTOR, see my comments in the JIRA issue
for more discussion) from `LambdaLift` and `ExplicitOuter`, and
instead use the stack of active self/super calls to know when to
skip an enclosing class. That will obviate that flag.

Review by @paulp
