### PR TITLE
SI-6123: -explaintypes should not explain errors which won't be reported

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -173,8 +173,7 @@ trait ContextErrors {
         assert(!foundType.isErroneous && !req.isErroneous, (foundType, req))
 
         issueNormalTypeError(tree, withAddendum(tree.pos)(typeErrorMsg(foundType, req, infer.isPossiblyMissingArgs(foundType, req))) )
-        if (settings.explaintypes.value)
-          explainTypes(foundType, req)
+        infer.explainTypes(foundType, req)
       }
 
       def WithFilterError(tree: Tree, ex: AbsTypeError) = {
@@ -1270,11 +1269,12 @@ trait ContextErrors {
     // not exactly an error generator, but very related
     // and I dearly wanted to push it away from Macros.scala
     private def checkSubType(slot: String, rtpe: Type, atpe: Type) = {
-      val ok = if (macroDebugVerbose || settings.explaintypes.value) {
-        if (rtpe eq atpe) println(rtpe + " <: " + atpe + "?" + EOL + "true")
+      val ok = if (macroDebugVerbose) {
         withTypesExplained(rtpe <:< atpe)
       } else rtpe <:< atpe
       if (!ok) {
+        if (!macroDebugVerbose)
+          explainTypes(rtpe, atpe)
         compatibilityError("type mismatch for %s: %s does not conform to %s".format(slot, abbreviateCoreAliases(rtpe.toString), abbreviateCoreAliases(atpe.toString)))
       }
     }

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -297,8 +297,10 @@ trait Infer extends Checkable {
       */
     )
 
-    def explainTypes(tp1: Type, tp2: Type) =
-      withDisambiguation(List(), tp1, tp2)(global.explainTypes(tp1, tp2))
+    def explainTypes(tp1: Type, tp2: Type) = {
+      if (context.reportErrors)
+        withDisambiguation(List(), tp1, tp2)(global.explainTypes(tp1, tp2))
+    }
 
     /* -- Tests & Checks---------------------------------------------------- */
 


### PR DESCRIPTION
-explainTypes means that only type tests which _fail_ should be reported in more
detail by using explainTypes. Hence, callers of explainTypes should check if
type errors are being ignored, by checking context.reportErrors. Hence, this
check is added to Inferencer, and another call site is redirected to that
method.

Note that this patch does not fix all occurrences, but only the ones which
showed up during debugging. The other ones never cause problems, maybe because
they occur when contextErrors is in fact guaranteed to be true. We might want to
fix those ones anyway.

New tests are missing, I'll add them ASAP.

Review by @hubertp.
Refs #6123
backport to _2.10.x_
