### PR TITLE
Fixed typo in ProcessBuilder scaladoc.

### DIFF
--- a/src/library/scala/sys/process/ProcessBuilder.scala
+++ b/src/library/scala/sys/process/ProcessBuilder.scala
@@ -23,7 +23,7 @@ import ProcessBuilder._
   * based on these factories made available in the package object
   * [[scala.sys.process]]. Here are some examples:
   * {{{
-  * import.scala.sys.process._
+  * import scala.sys.process._
   *
   * // Executes "ls" and sends output to stdout
   * "ls".!


### PR DESCRIPTION
ProcessBuilder creation sample code did not complie due to an error
in import statement.
