### PR TITLE
Add more permgen space for test/partest

### DIFF
--- a/test/partest
+++ b/test/partest
@@ -76,7 +76,7 @@ fi
 
 # last arg wins, so if JAVA_OPTS already contains -Xmx or -Xms the
 # supplied argument will be used.
-JAVA_OPTS="-Xmx1024M -Xms64M -XX:MaxPermSize=128M $JAVA_OPTS"
+JAVA_OPTS="-Xmx1024M -Xms64M -XX:PermSize=128M -XX:MaxPermSize=128M $JAVA_OPTS"
 [ -n "$SCALAC_OPTS" ] || SCALAC_OPTS="-deprecation"
 
 partestDebugStr=""

--- a/test/partest
+++ b/test/partest
@@ -76,7 +76,7 @@ fi
 
 # last arg wins, so if JAVA_OPTS already contains -Xmx or -Xms the
 # supplied argument will be used.
-JAVA_OPTS="-Xmx1024M -Xms64M $JAVA_OPTS"
+JAVA_OPTS="-Xmx1024M -Xms64M -XX:MaxPermSize=128M $JAVA_OPTS"
 [ -n "$SCALAC_OPTS" ] || SCALAC_OPTS="-deprecation"
 
 partestDebugStr=""


### PR DESCRIPTION
Running "test/partest --all" needs about 108MB permgen space, but the
default is less than that (85MB for me on Oracle Java 6 with no extra
options).

This commit bumps it to 128MB.
