### PR TITLE
Use the same default scalac options in all three partest frontends

### DIFF
--- a/src/partest/scala/tools/partest/PartestTask.scala
+++ b/src/partest/scala/tools/partest/PartestTask.scala
@@ -355,7 +355,7 @@ class PartestTask extends Task with CompilationPathProperty {
 
     javacmd foreach (x => antFileManager.JAVACMD = x.getAbsolutePath)
     javaccmd foreach (x => antFileManager.JAVAC_CMD = x.getAbsolutePath)
-    scalacArgsFlat foreach (antFileManager.SCALAC_OPTS = _)
+    scalacArgsFlat foreach (antFileManager.SCALAC_OPTS ++= _)
     timeout foreach (antFileManager.timeout = _)
 
     type TFSet = (Array[File], String, String)

--- a/src/partest/scala/tools/partest/nest/SBTRunner.scala
+++ b/src/partest/scala/tools/partest/nest/SBTRunner.scala
@@ -46,7 +46,7 @@ object SBTRunner extends DirectRunner {
       case x                                        => sys.error("Unknown command line options: " + x)
     }
     val config = parseArgs(args, CommandLineOptions())
-    fileManager.SCALAC_OPTS = config.scalacOptions
+    fileManager.SCALAC_OPTS ++= config.scalacOptions
     fileManager.CLASSPATH = config.classpath getOrElse sys.error("No classpath set")
 
     def findClasspath(jar: String, name: String): Option[String] = {

--- a/test/partest
+++ b/test/partest
@@ -77,7 +77,6 @@ fi
 # last arg wins, so if JAVA_OPTS already contains -Xmx or -Xms the
 # supplied argument will be used.
 JAVA_OPTS="-Xmx1024M -Xms64M $JAVA_OPTS"
-[ -n "$SCALAC_OPTS" ] || SCALAC_OPTS="-deprecation"
 
 partestDebugStr=""
 if [ ! -z "${PARTEST_DEBUG}" ] ; then


### PR DESCRIPTION
Make ConsoleRunner, AntRunner and SBTRunner take scalac options from
"partest.scalac_opts" property.

Also remove leftover "-deprecation" option from test/partest.

The change to SBTRunner was not tested as sbt test is currently broken.
