### PR TITLE
SI-6987 Fixes fsc compile server verbose output

### DIFF
--- a/src/compiler/scala/tools/nsc/CompileServer.scala
+++ b/src/compiler/scala/tools/nsc/CompileServer.scala
@@ -174,11 +174,22 @@ object CompileServer extends StandardCompileServer {
   /** A directory holding redirected output */
   private lazy val redirectDir = (compileSocket.tmpDir / "output-redirects").createDirectory()
 
-  private def redirect(setter: PrintStream => Unit, filename: String) {
-    setter(new PrintStream((redirectDir / filename).createFile().bufferedOutput()))
-  }
+  private def createRedirect(filename: String) =
+    new PrintStream((redirectDir / filename).createFile().bufferedOutput())
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]) = 
+    execute(() => (), args)
+  
+  /**
+   * Used for internal testing. The callback is called upon
+   * server start, notifying the caller that the server is
+   * ready to run. WARNING: the callback runs in the
+   * server's thread, blocking the server from doing any work
+   * until the callback is finished. Callbacks should be kept
+   * simple and clients should not try to interact with the
+   * server while the callback is processing.
+   */
+  def execute(startupCallback : () => Unit, args: Array[String]) {
     val debug = args contains "-v"
 
     if (debug) {
@@ -186,14 +197,16 @@ object CompileServer extends StandardCompileServer {
       echo("Redirect dir is " + redirectDir)
     }
 
-    redirect(System.setOut, "scala-compile-server-out.log")
-    redirect(System.setErr, "scala-compile-server-err.log")
-    System.err.println("...starting server on socket "+port+"...")
-    System.err.flush()
-    compileSocket setPort port
-    run()
-
-    compileSocket deletePort port
-    sys exit 0
+    Console.withErr(createRedirect("scala-compile-server-err.log")) {
+      Console.withOut(createRedirect("scala-compile-server-out.log")) {
+        Console.err.println("...starting server on socket "+port+"...")
+        Console.err.flush()
+        compileSocket setPort port
+        startupCallback()
+        run()
+    
+        compileSocket deletePort port
+      }
+    }
   }
 }

--- a/src/compiler/scala/tools/nsc/CompileServer.scala
+++ b/src/compiler/scala/tools/nsc/CompileServer.scala
@@ -92,10 +92,11 @@ class StandardCompileServer extends SocketServer {
 
     val args        = input.split("\0", -1).toList
     val newSettings = new FscSettings(fscError)
-    this.verbose    = newSettings.verbose.value
     val command     = newOfflineCompilerCommand(args, newSettings)
+    this.verbose    = newSettings.verbose.value
 
     info("Settings after normalizing paths: " + newSettings)
+    if (!command.files.isEmpty) info("Input files after normalizing paths: " + (command.files mkString ","))
     printMemoryStats()
 
     // Update the idle timeout if given

--- a/src/compiler/scala/tools/util/SocketServer.scala
+++ b/src/compiler/scala/tools/util/SocketServer.scala
@@ -16,7 +16,7 @@ trait CompileOutputCommon {
   def verbose: Boolean
 
   def info(msg: String)  = if (verbose) echo(msg)
-  def echo(msg: String)  = Console println msg
+  def echo(msg: String)  = {Console println msg; Console.flush}
   def warn(msg: String)  = System.err println msg
   def fatal(msg: String) = { warn(msg) ; sys.exit(1) }
 }

--- a/src/compiler/scala/tools/util/SocketServer.scala
+++ b/src/compiler/scala/tools/util/SocketServer.scala
@@ -17,7 +17,7 @@ trait CompileOutputCommon {
 
   def info(msg: String)  = if (verbose) echo(msg)
   def echo(msg: String)  = {Console println msg; Console.flush}
-  def warn(msg: String)  = System.err println msg
+  def warn(msg: String)  = {Console.err println msg; Console.flush}
   def fatal(msg: String) = { warn(msg) ; sys.exit(1) }
 }
 

--- a/test/files/run/t6987.check
+++ b/test/files/run/t6987.check
@@ -1,0 +1,1 @@
+got successful verbose results!

--- a/test/files/run/t6987.scala
+++ b/test/files/run/t6987.scala
@@ -1,0 +1,43 @@
+import java.io._
+import tools.nsc.{CompileClient, CompileServer}
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
+object Test extends App {
+  val startupLatch = new CountDownLatch(1)
+  // we have to explicitly launch our server because when the client launches a server it uses 
+  // the "scala" shell command meaning whatever version of scala (and whatever version of libraries)
+  // happens to be in the path gets used
+  val t = new Thread(new Runnable {
+    def run() = {
+      CompileServer.execute(() => startupLatch.countDown(), Array[String]())
+    }
+  })
+  t setDaemon true
+  t.start()
+  if (!startupLatch.await(2, TimeUnit.MINUTES))
+    sys error "Timeout waiting for server to start"
+
+  val baos = new ByteArrayOutputStream()
+  val ps = new PrintStream(baos) 
+
+  val success = (scala.Console withOut ps) {
+    // shut down the server via the client using the verbose flag
+    CompileClient.process(Array("-shutdown", "-verbose"))
+  }
+
+  // now make sure we got success and a verbose result
+  val msg = baos.toString()
+
+  if (success) {
+    if (msg contains "Settings after normalizing paths") {
+     println("got successful verbose results!")
+    } else {
+     println("did not get the string expected, full results were:")
+     println(msg)
+    }
+  } else {
+    println("got a failure. Full results were:")
+    println(msg)
+  }
+  scala.Console.flush
+}


### PR DESCRIPTION
Internally the fsc server code was setting a "verbose" flag, but it was
always false. Fixing that gives server's verbose output, but because the
output was buffered and not flushed the server's output wasn't seen
until the compile run was complete. This commit fixes the verbose flag
and flushes the server side output.

No reviewer requested until the build kitteh can verify the test works reliably.
