### PR TITLE
SI-7011 Fix finding constructor type in captured var definitions

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
+++ b/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
@@ -430,10 +430,10 @@ abstract class LambdaLift extends InfoTransform {
             /* Creating a constructor argument if one isn't present. */
             val constructorArg = rhs match {
               case EmptyTree =>
-                sym.primaryConstructor.info.paramTypes match {
+                sym.tpe.typeSymbol.primaryConstructor.info.paramTypes match {
                   case List(tp) => gen.mkZero(tp)
                   case _        =>
-                    log("Couldn't determine how to properly construct " + sym)
+                    debugwarn("Couldn't determine how to properly construct " + sym)
                     rhs
                 }
               case arg => arg

--- a/test/files/pos/t7011.flags
+++ b/test/files/pos/t7011.flags
@@ -1,0 +1,1 @@
+-Ydebug -Xfatal-warnings

--- a/test/files/pos/t7011.scala
+++ b/test/files/pos/t7011.scala
@@ -1,0 +1,7 @@
+object bar {
+	def foo {
+    lazy val x = 42
+
+    {()=>x}
+  }
+}


### PR DESCRIPTION
If a captured var was initialized with an empty tree then finding
the type of the empty tree was being handled improperly. The fix is
to look for primary constructors on the tree's type symbol rather than
the tree's symbol.

A test is included. In order to make the problem more testable the debug
logging of the issue is changed to a debug warn.

review @retronym
