### PR TITLE
SI-6434 Pretty print function types with by name arg as (=> A) => B

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2481,8 +2481,10 @@ trait Types extends api.Types { self: SymbolTable =>
           // from (T1, T2) => R.
           targs match {
             case in :: out :: Nil if !isTupleType(in) =>
-              // A => B => C should be (A => B) => C or A => (B => C)
-              val in_s  = if (isFunctionType(in)) "(" + in + ")" else "" + in
+              // A => B => C should be (A => B) => C or A => (B => C).
+              // Also if A is byname, then we want (=> A) => B because => is right associative and => A => B
+              // would mean => (A => B) which is a different type
+              val in_s  = if (isFunctionType(in) || isByNameParamType(in)) "(" + in + ")" else "" + in
               val out_s = if (isFunctionType(out)) "(" + out + ")" else "" + out
               in_s + " => " + out_s
             case xs =>

--- a/test/files/run/t6434.check
+++ b/test/files/run/t6434.check
@@ -1,0 +1,10 @@
+Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> def f(x: => Int): Int = x
+f: (x: => Int)Int
+
+scala> f _
+res0: (=> Int) => Int = <function1>
+
+scala> 

--- a/test/files/run/t6434.scala
+++ b/test/files/run/t6434.scala
@@ -1,0 +1,8 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  def code =
+"""def f(x: => Int): Int = x
+f _
+"""
+}


### PR DESCRIPTION
We were pretty printing a function type with one by name arg as
=> A => B, but because => is right associative that's formally
equivalent to => (A => B) and that's entirely a different thing. This
commit changes the pretty printer in Typers.scala to check for a
byname argument on a function type and wrap it in parens. A REPL test
is included.

review @paulp
