### PR TITLE
SI-5313 Disable dead local store optimization on ref and array types

### DIFF
--- a/test/files/run/t5313.check
+++ b/test/files/run/t5313.check
@@ -1,0 +1,46 @@
+class Foo extends Object {
+  // fields:
+  
+  // methods
+  def bar(): ref.WeakReference {
+  locals: variable obj, value result
+  startBlock: 1
+  blocks: [1]
+  
+  1: 
+    3	NEW REF(class Object)
+    3	DUP(REF(class Object))
+    3	CALL_METHOD java.lang.Object.<init> (static-instance)
+    3	STORE_LOCAL(variable obj)
+    3	SCOPE_ENTER variable obj
+    4	NEW REF(class WeakReference)
+    4	DUP(REF(class WeakReference))
+    4	LOAD_LOCAL(variable obj)
+    4	CALL_METHOD java.lang.ref.WeakReference.<init> (static-instance)
+    4	STORE_LOCAL(value result)
+    4	SCOPE_ENTER value result
+    5	CONSTANT(null)
+    5	STORE_LOCAL(variable obj)
+    7	LOAD_LOCAL(value result)
+    7	SCOPE_EXIT variable obj
+    7	SCOPE_EXIT value result
+    7	RETURN(REF(class WeakReference))
+    
+  }
+  Exception handlers: 
+    
+  def <init>(): Foo {
+  locals: 
+  startBlock: 1
+  blocks: [1]
+  
+  1: 
+    9	THIS(Foo)
+    9	CALL_METHOD java.lang.Object.<init> (super())
+    9	RETURN(UNIT)
+    
+  }
+  Exception handlers: 
+    
+  
+}

--- a/test/files/run/t5313.scala
+++ b/test/files/run/t5313.scala
@@ -1,0 +1,23 @@
+import scala.tools.partest.IcodeTest
+
+object Test extends IcodeTest {
+  override def printIcodeAfterPhase = "dce"
+
+  override def extraSettings: String = super.extraSettings + " -optimize"  
+
+  override def code =
+    """class Foo {
+      def bar = {
+        var obj = new Object
+        val result = new java.lang.ref.WeakReference(obj)
+        obj = null // we can't eliminate this assigment because result can observe
+                   // when the object has no more references. See SI-5313
+        result
+      }
+    }""".stripMargin
+
+  override def show() {
+    val lines1 = collectIcode("")
+    println(lines1 mkString "\n")
+  }
+}


### PR DESCRIPTION
Storing to local variables of reference or array type is indirectly
observable because it potentially allows gc to collect an object. So
this commit gets rid of dead store optimization on reference and array
types.

review @gkossakowski
