### PR TITLE
Fix few typos in the doc

### DIFF
--- a/project/Packaging.scala
+++ b/project/Packaging.scala
@@ -24,7 +24,7 @@ trait Packaging { self: ScalaBuild.type =>
     genBinQuick <<= genBinTask(genBinRunner, binDir in genBinQuick, fullClasspath in Runtime in genBinQuick, true),
     runManmakerMan <<= runManmakerTask(fullClasspath in Runtime in manmaker, runner in manmaker, "scala.tools.docutil.EmitManPage", "man1", ".1"),
     runManmakerHtml <<= runManmakerTask(fullClasspath in Runtime in manmaker, runner in manmaker, "scala.tools.docutil.EmitHtml", "doc", ".html"),
-    // TODO - We could *really* clean this up in many ways.   Let's look into making a a Seq of "direct jars" (scalaLibrary, scalaCompiler, jline, scalap)
+    // TODO - We could *really* clean this up in many ways.   Let's look into making a Seq of "direct jars" (scalaLibrary, scalaCompiler, jline, scalap)
     // a seq of "plugin jars" (continuationsPlugin) and "binaries" (genBin) and "documentation" mappings (genBin) that this can aggregate.
     // really need to figure out a better way to pull jline + jansi.
     makeDistMappings <<= (genBin, 

--- a/src/compiler/scala/tools/nsc/ast/DocComments.scala
+++ b/src/compiler/scala/tools/nsc/ast/DocComments.scala
@@ -320,7 +320,7 @@ trait DocComments { self: Global =>
   }
 
   /** Expand variable occurrences in string `str`, until a fix point is reached or
-   *  a expandLimit is exceeded.
+   *  an expandLimit is exceeded.
    *
    *  @param str   The string to be expanded
    *  @param sym   The symbol for which doc comments are generated

--- a/src/compiler/scala/tools/nsc/backend/icode/ICodeCheckers.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/ICodeCheckers.scala
@@ -464,7 +464,7 @@ abstract class ICodeCheckers {
                 subtypeTest(elem, kind)
                 pushStack(elem)
               case (a, b) =>
-                icodeError(" expected and INT and a array reference, but " +
+                icodeError(" expected an INT and an array reference, but " +
                     a + ", " + b + " found");
             }
 

--- a/src/compiler/scala/tools/nsc/doc/html/page/Template.scala
+++ b/src/compiler/scala/tools/nsc/doc/html/page/Template.scala
@@ -760,7 +760,7 @@ class Template(universe: doc.Universe, generator: DiagramGenerator, tpl: DocTemp
           if (isReduced) NodeSeq.Empty else {
             def paramsToHtml(vlsss: List[List[ValueParam]]): NodeSeq = {
               def param0(vl: ValueParam): NodeSeq =
-                // notice the }{ in the next lines, they are necessary to avoid a undesired withspace in output
+                // notice the }{ in the next lines, they are necessary to avoid an undesired withspace in output
                 <span name={ vl.name }>{
                   Text(vl.name)
                 }{ Text(": ") ++ typeToHtml(vl.resultType, hasLinks) }{

--- a/src/compiler/scala/tools/nsc/io/Lexer.scala
+++ b/src/compiler/scala/tools/nsc/io/Lexer.scala
@@ -7,8 +7,8 @@ import java.io.Reader
  */
 object Lexer {
 
-  /** An exception raised if a if input does not correspond to what's expected
-   *  @param   rdr   the lexer form which the bad input is read
+  /** An exception raised if an input does not correspond to what's expected
+   *  @param   rdr   the lexer from which the bad input is read
    *  @param   msg   the error message
    */
   class MalformedInput(val rdr: Lexer, val msg: String) extends Exception("Malformed JSON input at "+rdr.tokenPos+": "+msg)

--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -104,7 +104,7 @@ abstract class ExplicitOuter extends InfoTransform
    *  <ol>
    *    <li>
    *      Add an outer parameter to the formal parameters of a constructor
-   *      in a inner non-trait class;
+   *      in an inner non-trait class;
    *    </li>
    *    <li>
    *      Add a protected $outer field to an inner class which is

--- a/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
+++ b/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
@@ -245,7 +245,7 @@ abstract class LambdaLift extends InfoTransform {
           freshen(sym.name + nme.NAME_JOIN_STRING + sym.owner.name + nme.NAME_JOIN_STRING)
         } else {
           // SI-5652 If the lifted symbol is accessed from an inner class, it will be made public. (where?)
-          //         Generating a a unique name, mangled with the enclosing class name, avoids a VerifyError
+          //         Generating a unique name, mangled with the enclosing class name, avoids a VerifyError
           //         in the case that a sub-class happens to lifts out a method with the *same* name.
           val name = freshen("" + sym.name + nme.NAME_JOIN_STRING)
           if (originalName.isTermName && !sym.enclClass.isImplClass && calledFromInner(sym)) nme.expandedName(name.toTermName, sym.enclClass)

--- a/src/library/scala/collection/GenTraversableLike.scala
+++ b/src/library/scala/collection/GenTraversableLike.scala
@@ -238,7 +238,7 @@ trait GenTraversableLike[+A, +Repr] extends Any with GenTraversableOnce[A] with 
    *      // lettersOf will return a Set[Char], not a Seq
    *      def lettersOf(words: Seq[String]) = words.toSet flatMap (word => word.toSeq)
    *
-   *      // xs will be a an Iterable[Int]
+   *      // xs will be an Iterable[Int]
    *      val xs = Map("a" -> List(11,111), "b" -> List(22,222)).flatMap(_._2)
    *
    *      // ys will be a Map[Int, Int]

--- a/src/library/scala/collection/parallel/ParIterableLike.scala
+++ b/src/library/scala/collection/parallel/ParIterableLike.scala
@@ -454,7 +454,7 @@ self: ParIterableLike[T, Repr, Sequential] =>
 
   def reduceRightOption[U >: T](op: (T, U) => U): Option[U] = seq.reduceRightOption(op)
 
-  /** Applies a function `f` to all the elements of $coll in a undefined order.
+  /** Applies a function `f` to all the elements of $coll in an undefined order.
    *
    *  @tparam U    the result type of the function applied to each element, which is always discarded
    *  @param f     function applied to each element

--- a/src/library/scala/math/BigInt.scala
+++ b/src/library/scala/math/BigInt.scala
@@ -358,7 +358,7 @@ class BigInt(val bigInteger: BigInteger) extends ScalaNumber with ScalaNumericCo
   def charValue   = intValue.toChar
 
   /** Converts this BigInt to an <tt>int</tt>.
-   *  If the BigInt is too big to fit in a int, only the low-order 32 bits
+   *  If the BigInt is too big to fit in an int, only the low-order 32 bits
    *  are returned. Note that this conversion can lose information about the
    *  overall magnitude of the BigInt value as well as return a result with
    *  the opposite sign.

--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -33,7 +33,7 @@ import scala.language.{implicitConversions, higherKinds}
   * }}}
   *
   * An Ordering[T] is implemented by specifying compare(a:T, b:T), which
-  * decides how to order to instances a and b. Instances of Ordering[T] can be
+  * decides how to order two instances a and b. Instances of Ordering[T] can be
   * used by things like scala.util.Sorting to sort collections like Array[T].
   *
   * For example:

--- a/src/library/scala/util/automata/NondetWordAutom.scala
+++ b/src/library/scala/util/automata/NondetWordAutom.scala
@@ -37,10 +37,10 @@ abstract class NondetWordAutom[T <: AnyRef] {
   /** @return true if there are no accepting states */
   final def isEmpty = (0 until nstates) forall (x => !isFinal(x))
 
-  /** @return a immutable.BitSet with the next states for given state and label */
+  /** @return an immutable.BitSet with the next states for given state and label */
   def next(q: Int, a: T): immutable.BitSet = delta(q).getOrElse(a, default(q))
 
-  /** @return a immutable.BitSet with the next states for given state and label */
+  /** @return an immutable.BitSet with the next states for given state and label */
   def next(Q: immutable.BitSet, a: T): immutable.BitSet = next(Q, next(_, a))
   def nextDefault(Q: immutable.BitSet): immutable.BitSet = next(Q, default)
 

--- a/src/reflect/scala/reflect/api/Names.scala
+++ b/src/reflect/scala/reflect/api/Names.scala
@@ -75,10 +75,10 @@ trait Names {
    *  @group API
    */
   abstract class NameApi {
-    /** Checks wether the name is a a term name */
+    /** Checks wether the name is a term name */
     def isTermName: Boolean
 
-    /** Checks wether the name is a a type name */
+    /** Checks wether the name is a type name */
     def isTypeName: Boolean
 
     /** Returns a term name that wraps the same string as `this` */

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -153,7 +153,7 @@ trait Types extends api.Types { self: SymbolTable =>
     }
 
     /** No sync necessary, because record should only
-     *  be called from within a undo or undoUnless block,
+     *  be called from within an undo or undoUnless block,
      *  which is already synchronized.
      */
     private[reflect] def record(tv: TypeVar) = {

--- a/src/reflect/scala/reflect/macros/Context.scala
+++ b/src/reflect/scala/reflect/macros/Context.scala
@@ -52,7 +52,7 @@ trait Context extends Aliases
 
   /** The prefix tree from which the macro is selected.
    *
-   *  For a example, for a macro `filter` defined as an instance method on a collection `Coll`,
+   *  For example, for a macro `filter` defined as an instance method on a collection `Coll`,
    *  `prefix` represents an equivalent of `this` for normal instance methods:
    *
    *  {{{

--- a/test/disabled/presentation/akka/src/akka/dispatch/Dispatchers.scala
+++ b/test/disabled/presentation/akka/src/akka/dispatch/Dispatchers.scala
@@ -89,7 +89,7 @@ object Dispatchers {
     new ThreadBasedDispatcher(actor, mailboxCapacity, pushTimeOut)
 
   /**
-   * Creates a executor-based event-driven dispatcher serving multiple (millions) of actors through a thread pool.
+   * Creates an executor-based event-driven dispatcher serving multiple (millions) of actors through a thread pool.
    * <p/>
    * Has a fluent builder interface for configuring its semantics.
    */
@@ -97,7 +97,7 @@ object Dispatchers {
     ThreadPoolConfigDispatcherBuilder(config => new ExecutorBasedEventDrivenDispatcher(name, config), ThreadPoolConfig())
 
   /**
-   * Creates a executor-based event-driven dispatcher serving multiple (millions) of actors through a thread pool.
+   * Creates an executor-based event-driven dispatcher serving multiple (millions) of actors through a thread pool.
    * <p/>
    * Has a fluent builder interface for configuring its semantics.
    */
@@ -106,7 +106,7 @@ object Dispatchers {
       new ExecutorBasedEventDrivenDispatcher(name, throughput, THROUGHPUT_DEADLINE_TIME_MILLIS, mailboxType, config), ThreadPoolConfig())
 
   /**
-   * Creates a executor-based event-driven dispatcher serving multiple (millions) of actors through a thread pool.
+   * Creates an executor-based event-driven dispatcher serving multiple (millions) of actors through a thread pool.
    * <p/>
    * Has a fluent builder interface for configuring its semantics.
    */
@@ -115,7 +115,7 @@ object Dispatchers {
       new ExecutorBasedEventDrivenDispatcher(name, throughput, throughputDeadlineMs, mailboxType, config), ThreadPoolConfig())
 
   /**
-   * Creates a executor-based event-driven dispatcher, with work-stealing, serving multiple (millions) of actors through a thread pool.
+   * Creates an executor-based event-driven dispatcher, with work-stealing, serving multiple (millions) of actors through a thread pool.
    * <p/>
    * Has a fluent builder interface for configuring its semantics.
    */
@@ -123,7 +123,7 @@ object Dispatchers {
     ThreadPoolConfigDispatcherBuilder(config => new ExecutorBasedEventDrivenWorkStealingDispatcher(name, config), ThreadPoolConfig())
 
   /**
-   * Creates a executor-based event-driven dispatcher, with work-stealing, serving multiple (millions) of actors through a thread pool.
+   * Creates an executor-based event-driven dispatcher, with work-stealing, serving multiple (millions) of actors through a thread pool.
    * <p/>
    * Has a fluent builder interface for configuring its semantics.
    */
@@ -132,7 +132,7 @@ object Dispatchers {
       new ExecutorBasedEventDrivenWorkStealingDispatcher(name, throughput, THROUGHPUT_DEADLINE_TIME_MILLIS, MAILBOX_TYPE, config), ThreadPoolConfig())
 
   /**
-   * Creates a executor-based event-driven dispatcher, with work-stealing, serving multiple (millions) of actors through a thread pool.
+   * Creates an executor-based event-driven dispatcher, with work-stealing, serving multiple (millions) of actors through a thread pool.
    * <p/>
    * Has a fluent builder interface for configuring its semantics.
    */
@@ -141,7 +141,7 @@ object Dispatchers {
       new ExecutorBasedEventDrivenWorkStealingDispatcher(name, throughput, THROUGHPUT_DEADLINE_TIME_MILLIS, mailboxType, config), ThreadPoolConfig())
 
   /**
-   * Creates a executor-based event-driven dispatcher, with work-stealing, serving multiple (millions) of actors through a thread pool.
+   * Creates an executor-based event-driven dispatcher, with work-stealing, serving multiple (millions) of actors through a thread pool.
    * <p/>
    * Has a fluent builder interface for configuring its semantics.
    */

--- a/test/files/pos/t2421b_pos.scala
+++ b/test/files/pos/t2421b_pos.scala
@@ -11,7 +11,7 @@ object Test {
 
   f
 }
-/* bug: 
+/* bug:
 error: ambiguous implicit values:
  both method b in object Test1 of type [X <: Test1.B]Test1.F[X]
  and method a in object Test1 of type => Test1.F[Test1.A]

--- a/test/files/run/ctries-new/iterator.scala
+++ b/test/files/run/ctries-new/iterator.scala
@@ -1,144 +1,134 @@
-
-
-
-
 import collection._
 import collection.concurrent.TrieMap
 
-
-
 object IteratorSpec extends Spec {
-  
+
   def test() {
     "work for an empty trie" in {
       val ct = new TrieMap
       val it = ct.iterator
-      
+
       it.hasNext shouldEqual (false)
       evaluating { it.next() }.shouldProduce [NoSuchElementException]
     }
-    
+
     def nonEmptyIteratorCheck(sz: Int) {
       val ct = new TrieMap[Wrap, Int]
       for (i <- 0 until sz) ct.put(new Wrap(i), i)
-      
+
       val it = ct.iterator
       val tracker = mutable.Map[Wrap, Int]()
       for (i <- 0 until sz) {
         assert(it.hasNext == true)
         tracker += it.next
       }
-      
+
       it.hasNext shouldEqual (false)
       evaluating { it.next() }.shouldProduce [NoSuchElementException]
       tracker.size shouldEqual (sz)
       tracker shouldEqual (ct)
     }
-    
+
     "work for a 1 element trie" in {
       nonEmptyIteratorCheck(1)
     }
-    
+
     "work for a 2 element trie" in {
       nonEmptyIteratorCheck(2)
     }
-    
+
     "work for a 3 element trie" in {
       nonEmptyIteratorCheck(3)
     }
-    
+
     "work for a 5 element trie" in {
       nonEmptyIteratorCheck(5)
     }
-    
+
     "work for a 10 element trie" in {
       nonEmptyIteratorCheck(10)
     }
-    
+
     "work for a 20 element trie" in {
       nonEmptyIteratorCheck(20)
     }
-    
+
     "work for a 50 element trie" in {
       nonEmptyIteratorCheck(50)
     }
-     
+
     "work for a 100 element trie" in {
       nonEmptyIteratorCheck(100)
     }
-    
+
     "work for a 1k element trie" in {
       nonEmptyIteratorCheck(1000)
     }
-    
+
     "work for a 5k element trie" in {
       nonEmptyIteratorCheck(5000)
     }
-    
+
     "work for a 75k element trie" in {
       nonEmptyIteratorCheck(75000)
     }
-    
+
     "work for a 250k element trie" in {
       nonEmptyIteratorCheck(500000)
     }
-    
+
     def nonEmptyCollideCheck(sz: Int) {
       val ct = new TrieMap[DumbHash, Int]
       for (i <- 0 until sz) ct.put(new DumbHash(i), i)
-      
+
       val it = ct.iterator
       val tracker = mutable.Map[DumbHash, Int]()
       for (i <- 0 until sz) {
         assert(it.hasNext == true)
         tracker += it.next
       }
-      
+
       it.hasNext shouldEqual (false)
       evaluating { it.next() }.shouldProduce [NoSuchElementException]
       tracker.size shouldEqual (sz)
       tracker shouldEqual (ct)
     }
-    
+
     "work for colliding hashcodes, 2 element trie" in {
       nonEmptyCollideCheck(2)
     }
-    
+
     "work for colliding hashcodes, 3 element trie" in {
       nonEmptyCollideCheck(3)
     }
-    
+
     "work for colliding hashcodes, 5 element trie" in {
       nonEmptyCollideCheck(5)
     }
-    
+
     "work for colliding hashcodes, 10 element trie" in {
       nonEmptyCollideCheck(10)
     }
-    
+
     "work for colliding hashcodes, 100 element trie" in {
       nonEmptyCollideCheck(100)
     }
-    
+
     "work for colliding hashcodes, 500 element trie" in {
       nonEmptyCollideCheck(500)
     }
-    
+
     "work for colliding hashcodes, 5k element trie" in {
       nonEmptyCollideCheck(5000)
     }
-    
+
     def assertEqual(a: Map[Wrap, Int], b: Map[Wrap, Int]) {
       if (a != b) {
         println(a.size + " vs " + b.size)
-        // println(a)
-        // println(b)
-        // println(a.toSeq.sortBy((x: (Wrap, Int)) => x._1.i))
-        // println(b.toSeq.sortBy((x: (Wrap, Int)) => x._1.i))
       }
       assert(a == b)
     }
-    
+
     "be consistent when taken with concurrent modifications" in {
       val sz = 25000
       val W = 15
@@ -146,40 +136,40 @@ object IteratorSpec extends Spec {
       val checks = 5
       val ct = new TrieMap[Wrap, Int]
       for (i <- 0 until sz) ct.put(new Wrap(i), i)
-      
+
       class Modifier extends Thread {
         override def run() {
           for (i <- 0 until sz) ct.putIfAbsent(new Wrap(i), i) match {
             case Some(_) => ct.remove(new Wrap(i))
-            case None => 
+            case None =>
           }
         }
       }
-      
+
       def consistentIteration(ct: TrieMap[Wrap, Int], checks: Int) {
         class Iter extends Thread {
           override def run() {
             val snap = ct.readOnlySnapshot()
             val initial = mutable.Map[Wrap, Int]()
             for (kv <- snap) initial += kv
-            
+
             for (i <- 0 until checks) {
               assertEqual(snap.iterator.toMap, initial)
             }
           }
         }
-        
+
         val iter = new Iter
         iter.start()
         iter.join()
       }
-      
+
       val threads = for (_ <- 0 until W) yield new Modifier
       threads.foreach(_.start())
       for (_ <- 0 until S) consistentIteration(ct, checks)
       threads.foreach(_.join())
     }
-    
+
     "be consistent with a concurrent removal with a well defined order" in {
       val sz = 150000
       val sgroupsize = 10
@@ -187,17 +177,16 @@ object IteratorSpec extends Spec {
       val removerslowdown = 50
       val ct = new TrieMap[Wrap, Int]
       for (i <- 0 until sz) ct.put(new Wrap(i), i)
-      
+
       class Remover extends Thread {
         override def run() {
           for (i <- 0 until sz) {
             assert(ct.remove(new Wrap(i)) == Some(i))
             for (i <- 0 until removerslowdown) ct.get(new Wrap(i)) // slow down, mate
           }
-          //println("done removing")
         }
       }
-      
+
       def consistentIteration(it: Iterator[(Wrap, Int)]) = {
         class Iter extends Thread {
           override def run() {
@@ -210,7 +199,7 @@ object IteratorSpec extends Spec {
         }
         new Iter
       }
-      
+
       val remover = new Remover
       remover.start()
       for (_ <- 0 until sgroupnum) {
@@ -218,27 +207,25 @@ object IteratorSpec extends Spec {
         iters.foreach(_.start())
         iters.foreach(_.join())
       }
-      //println("done with iterators")
       remover.join()
     }
-    
+
     "be consistent with a concurrent insertion with a well defined order" in {
       val sz = 150000
       val sgroupsize = 10
       val sgroupnum = 10
       val inserterslowdown = 50
       val ct = new TrieMap[Wrap, Int]
-      
+
       class Inserter extends Thread {
         override def run() {
           for (i <- 0 until sz) {
             assert(ct.put(new Wrap(i), i) == None)
             for (i <- 0 until inserterslowdown) ct.get(new Wrap(i)) // slow down, mate
           }
-          //println("done inserting")
         }
       }
-      
+
       def consistentIteration(it: Iterator[(Wrap, Int)]) = {
         class Iter extends Thread {
           override def run() {
@@ -251,7 +238,7 @@ object IteratorSpec extends Spec {
         }
         new Iter
       }
-      
+
       val inserter = new Inserter
       inserter.start()
       for (_ <- 0 until sgroupnum) {
@@ -259,31 +246,30 @@ object IteratorSpec extends Spec {
         iters.foreach(_.start())
         iters.foreach(_.join())
       }
-      //println("done with iterators")
       inserter.join()
     }
-    
+
     "work on a yet unevaluated snapshot" in {
       val sz = 50000
       val ct = new TrieMap[Wrap, Int]
       for (i <- 0 until sz) ct.update(new Wrap(i), i)
-      
+
       val snap = ct.snapshot()
       val it = snap.iterator
-      
+
       while (it.hasNext) it.next()
     }
-    
+
     "be duplicated" in {
       val sz = 50
       val ct = collection.parallel.mutable.ParTrieMap((0 until sz) zip (0 until sz): _*)
       val it = ct.splitter
       for (_ <- 0 until (sz / 2)) it.next()
       val dupit = it.dup
-      
+
       it.toList shouldEqual dupit.toList
     }
-    
+
   }
-  
+
 }

--- a/test/files/run/lazy-locals.scala
+++ b/test/files/run/lazy-locals.scala
@@ -120,7 +120,7 @@ object Test extends App {
       t
   }
 
-  /** test recursive method with lazy vals and a all vals forced */
+  /** test recursive method with lazy vals and all vals forced */
   def testLazyRecMany(n: Int): Int = {
     lazy val t = { println("forced lazy val t at n = " + n); 42 }
     if (n > 0) {

--- a/test/files/run/t4729/S_2.scala
+++ b/test/files/run/t4729/S_2.scala
@@ -20,7 +20,7 @@ object Test {
     (new ScalaVarArgs).method("1", "2")
     (new ScalaVarArgs: J_1).method("1", "2")
 
-    //[4] Not Ok -- error when assigning anonymous class to a explictly typed val
+    //[4] Not Ok -- error when assigning anonymous class to an explictly typed val
     // Compiler error:  object creation impossible, since method method in trait VarArgs of type (s: <repeated...>[java.lang.String])Unit is not defined
     val tagged: J_1 = new J_1 {
       def method(s: String*) { println(s) }

--- a/test/files/run/test-cpp.scala
+++ b/test/files/run/test-cpp.scala
@@ -3,7 +3,7 @@
  * in the copy-propagation performed before ClosureElimination.
  *
  * In the general case, the local variable 'l' is connected through
- * a alias chain with other local variables and at the end of the 
+ * an alias chain with other local variables and at the end of the 
  * alias chain there may be a Value, call it 'v'.
  *
  * If 'v' is cheaper to access (it is a Deref(This) or Const(_)), then


### PR DESCRIPTION
Fixes mostly **a int**, **a a thing** kind of typos.
Also removes trailing whitespaces, useless empty lines and commented
`println()` from "test/files/run/ctries-new/iterator.scala". 
