### PR TITLE
SI-6434 updates test reify_magicsymbols to use the new (=> A) => B

### DIFF
--- a/test/files/run/reify_magicsymbols.check
+++ b/test/files/run/reify_magicsymbols.check
@@ -10,4 +10,4 @@ List[Null]
 List[Nothing]
 AnyRef{def foo(x: Int): Int}
 Int* => Unit
-=> Int => Unit
+(=> Int) => Unit


### PR DESCRIPTION
The change to use (=> A) => B caught an innocent bystander test. This
commit makes the trivial change to the test's .check file to make it
recognize the new output.

review @paulp or @adriaanm whichever gets it first and expedite as all 2.10.x builds will be failing until this is merged.
