### PR TITLE
Revert "SI-6601 Publicise derived value contstructor after pickler"

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
@@ -144,6 +144,7 @@ abstract class ExtensionMethods extends Transform with TypingTransformers {
              wrap over other value classes anyway.
             checkNonCyclic(currentOwner.pos, Set(), currentOwner) */
             extensionDefs(currentOwner.companionModule) = new mutable.ListBuffer[Tree]
+            currentOwner.primaryConstructor.makeNotPrivate(NoSymbol)
             super.transform(tree)
           } else if (currentOwner.isStaticOwner) {
             super.transform(tree)

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1686,8 +1686,6 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
             val bridges = addVarargBridges(currentOwner)
             checkAllOverrides(currentOwner)
             checkAnyValSubclass(currentOwner)
-            if (currentOwner.isDerivedValueClass)
-              currentOwner.primaryConstructor makeNotPrivate NoSymbol // SI-6601, must be done *after* pickler!
             if (bridges.nonEmpty) deriveTemplate(tree)(_ ::: bridges) else tree
 
           case dc@TypeTreeWithDeferredRefCheck() => abort("adapt should have turned dc: TypeTreeWithDeferredRefCheck into tpt: TypeTree, with tpt.original == dc")

--- a/test/files/neg/t6601.check
+++ b/test/files/neg/t6601.check
@@ -1,4 +1,0 @@
-AccessPrivateConstructor_2.scala:2: error: constructor PrivateConstructor in class PrivateConstructor cannot be accessed in class AccessPrivateConstructor
-  new PrivateConstructor("") // Scalac should forbid accessing to the private constructor!
-  ^
-one error found

--- a/test/files/neg/t6601/AccessPrivateConstructor_2.scala
+++ b/test/files/neg/t6601/AccessPrivateConstructor_2.scala
@@ -1,3 +1,0 @@
-class AccessPrivateConstructor {
-  new PrivateConstructor("") // Scalac should forbid accessing to the private constructor!
-}

--- a/test/files/neg/t6601/PrivateConstructor_1.scala
+++ b/test/files/neg/t6601/PrivateConstructor_1.scala
@@ -1,1 +1,0 @@
-class PrivateConstructor private(val s: String) extends AnyVal

--- a/test/files/pos/t6601/PrivateValueClass_1.scala
+++ b/test/files/pos/t6601/PrivateValueClass_1.scala
@@ -1,0 +1,1 @@
+class V private (val a: Any) extends AnyVal

--- a/test/files/pos/t6601/UsePrivateValueClass_2.scala
+++ b/test/files/pos/t6601/UsePrivateValueClass_2.scala
@@ -1,0 +1,10 @@
+object Test {
+	// After the first attempt to make seprately compiled value
+	// classes respect the privacy of constructors, we got:
+	//
+	//   exception when typing v.a().==(v.a())/class scala.reflect.internal.Trees$Apply
+  //   constructor V in class V cannot be accessed in object Test in file test/files/pos/t6601/UsePrivateValueClass_2.scala
+  //   scala.reflect.internal.Types$TypeError: constructor V in class V cannot be accessed in object Test
+  def foo(v: V) = v.a == v.a
+  def bar(v: V) = v == v
+}


### PR DESCRIPTION
This reverts commit b07228aebe7aa620af45a681ef60d945ffc65665.

The remedy was far worse than the disease:

```
% cat sandbox/test.scala
class V private (val a: Any) extends AnyVal

% RUNNER=scalac scala-hash b07228aebe sandbox/test.scala
[info] b07228aebe => /Users/jason/usr/scala-v2.10.0-256-gb07228a

% scala-hash b07228aebe
[info] b07228aebe => /Users/jason/usr/scala-v2.10.0-256-gb07228a
Welcome to Scala version 2.10.1-20130116-230935-b07228aebe (Java HotSpot(TM) 64-Bit Server VM, Java 1.6.0_27).
Type in expressions to have them evaluated.
Type :help for more information.

scala> def foo(v: V) = v.a == v.a
exception when typing v.a().==(v.a())/class scala.reflect.internal.Trees$Apply
constructor V in class V cannot be accessed in object $iw in file <console>
scala.reflect.internal.Types$TypeError: constructor V in class V cannot be accessed in object $iw
```

Review by @paulp
