### PR TITLE
SI-7018 Fix memory leak in Attachments.

### DIFF
--- a/test/files/run/t6028.check
+++ b/test/files/run/t6028.check
@@ -15,7 +15,7 @@ package <empty> {
       }
     };
     def bar(barParam: Int): Object = {
-      @volatile var MethodLocalObject$module: runtime.VolatileObjectRef = new runtime.VolatileObjectRef(<empty>);
+      @volatile var MethodLocalObject$module: runtime.VolatileObjectRef = new runtime.VolatileObjectRef(null);
       T.this.MethodLocalObject$1(barParam, MethodLocalObject$module)
     };
     def tryy(tryyParam: Int): Function0 = {


### PR DESCRIPTION
Makes NonEmptyAttachments a top level class so that
it doesn't accidentally accumulate history via the
$outer field.

No test is included because I think the fix is
self evident.

Review by @dragos
