### PR TITLE
SI-6556 Remove unneeded workaround in erasure.

### DIFF
--- a/src/reflect/scala/reflect/internal/transform/Erasure.scala
+++ b/src/reflect/scala/reflect/internal/transform/Erasure.scala
@@ -214,9 +214,6 @@ trait Erasure {
         specialConstructorErasure(clazz, restpe)
       case ExistentialType(tparams, restpe) =>
         specialConstructorErasure(clazz, restpe)
-      case RefinedType(parents, decls) =>
-        specialConstructorErasure(
-          clazz, specialScalaErasure.mergeParents(parents))
       case mt @ MethodType(params, restpe) =>
         MethodType(
           cloneSymbolsAndModify(params, specialScalaErasure),
@@ -225,15 +222,7 @@ trait Erasure {
         typeRef(pre, clazz, List())
       case tp =>
         if (!(clazz == ArrayClass || tp.isError))
-          // See SI-6556. It seems in some cases the result constructor
-          // type of an anonymous class is a different version of the class.
-          // This has nothing to do with value classes per se.
-          // We simply used a less discriminating transform before, that
-          // did not look at the cases in detail.
-          // It seems there is a deeper problem here, which needs
-          // following up to. But we will not risk regressions
-          // in 2.10 because of it.
-          devWarning(s"unexpected constructor erasure $tp for $clazz")
+          assert(clazz == ArrayClass || tp.isError, s"!!! unexpected constructor erasure $tp for $clazz")
         specialScalaErasure(tp)
     }
   }


### PR DESCRIPTION
In fb6e687, a workaround was added, described as:

> See SI-6556. It seems in some cases the result constructor
> type of an anonymous class is a different version of the class.
> This has nothing to do with value classes per se.
> We simply used a less discriminating transform before, that
> did not look at the cases in detail.
> It seems there is a deeper problem here, which needs
> following up to. But we will not risk regressions
> in 2.10 because of it.

I was expecting an arduous investigation into this,
but happilly the underlying problem was already solved
in the fix for SI-6648 (1587a77e). (Chalk up another
win for libscala's scala-hash!)

This commit escalates the logging to an assertion.
It also reverts the other change in fb6e687,
which introduced a case for RefinedType, which are
not needed to pass pos/t6556.scala.

Reviewed by @paulp in it's previous incarnation, #1868
