### PR TITLE
[backport] SI-2968 Fix brace healing for `^case (class|object) {`

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -283,10 +283,16 @@ trait Scanners extends ScannersCommon {
         prev copyFrom this
         val nextLastOffset = charOffset - 1
         fetchToken()
+        def resetOffset() {
+          offset = prev.offset
+          lastOffset = prev.lastOffset
+        }
         if (token == CLASS) {
           token = CASECLASS
+          resetOffset()
         } else if (token == OBJECT) {
           token = CASEOBJECT
+          resetOffset()
         } else {
           lastOffset = nextLastOffset
           next copyFrom this

--- a/test/files/neg/t2968.check
+++ b/test/files/neg/t2968.check
@@ -1,0 +1,10 @@
+t2968.scala:8: error: Missing closing brace `}' assumed here
+} // missing brace
+^
+t2968.scala:17: error: Missing closing brace `}' assumed here
+} // missing brace
+^
+t2968.scala:26: error: Missing closing brace `}' assumed here
+} // missing brace
+^
+three errors found

--- a/test/files/neg/t2968.scala
+++ b/test/files/neg/t2968.scala
@@ -1,0 +1,26 @@
+object t1 {
+	case object Const {
+	}
+
+	class Var
+	{
+
+} // missing brace
+
+object t2 {
+	case class Const() {
+	}
+
+	class Var
+	{
+
+} // missing brace
+
+object t3 {
+	final case class Const() {
+	}
+
+	class Var
+	{
+
+} // missing brace

--- a/test/files/neg/t2968b.check
+++ b/test/files/neg/t2968b.check
@@ -1,0 +1,4 @@
+t2968b.scala:7: error: '}' expected but eof found.
+// missing brace
+                ^
+one error found

--- a/test/files/neg/t2968b.scala
+++ b/test/files/neg/t2968b.scala
@@ -1,0 +1,7 @@
+case class Const()
+{
+}
+
+class Var
+{
+// missing brace


### PR DESCRIPTION
Squashed commit of the following:

commit 24828531f62ce05402c96c04d7096e82d5f4e3bf
Author: Jason Zaugg jzaugg@gmail.com
Date:   Sun Oct 21 23:34:35 2012 +0200

```
SI-2968 Fix brace healing for `^case (class|object) {`

The scanner coalesces the pair of tokens into CASEOBJECT or
CASECLASS, but fails to set `offset` back to the start of `case`.
Brace healing is then unable to correctly guess the location of
the missing brace.

This commit resets `offset` and `lastOffset`, as though
caseobject were a single keyword. Only the former was neccessary
to fix this bug; I haven't found a test that shows the need for
the latter.
(cherry picked from commit cbad218dba47d49a39897b86d467c384538fdd53)
```

Review by @adriaanm
