### PR TITLE
[backport] SI-3577 BoundedWildcardType handling

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -905,13 +905,15 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
          *  the type occurs itself at variance position given by `variance`
          */
         def validateVariance(tp: Type, variance: Int): Unit = tp match {
-          case ErrorType => ;
-          case WildcardType => ;
-          case NoType => ;
-          case NoPrefix => ;
-          case ThisType(_) => ;
-          case ConstantType(_) => ;
-          // case DeBruijnIndex(_, _) => ;
+          case ErrorType =>
+          case WildcardType =>
+          case BoundedWildcardType(bounds) =>
+            validateVariance(bounds, variance)
+          case NoType =>
+          case NoPrefix =>
+          case ThisType(_) =>
+          case ConstantType(_) =>
+          // case DeBruijnIndex(_, _) =>
           case SingleType(pre, sym) =>
             validateVariance(pre, variance)
           case TypeRef(pre, sym, args) =>

--- a/src/compiler/scala/tools/nsc/typechecker/Variances.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Variances.scala
@@ -67,6 +67,8 @@ trait Variances {
   def varianceInType(tp: Type)(tparam: Symbol): Int = tp match {
     case ErrorType | WildcardType | NoType | NoPrefix | ThisType(_) | ConstantType(_) =>
       VARIANCES
+    case BoundedWildcardType(bounds) =>
+      varianceInType(bounds)(tparam)
     case SingleType(pre, sym) =>
       varianceInType(pre)(tparam)
     case TypeRef(pre, sym, args) =>

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -22,6 +22,8 @@ import util.ThreeValues._
     // internal: error
   case WildcardType =>
     // internal: unknown
+  case BoundedWildcardType(bounds) =>
+    // internal: unknown
   case NoType =>
   case NoPrefix =>
   case ThisType(sym) =>

--- a/test/files/pos/t3577.scala
+++ b/test/files/pos/t3577.scala
@@ -1,0 +1,29 @@
+case class Check[A](val value: A)
+
+case class C2(checks: Check[_]*);
+
+object C {
+  def m(x : C2): Any = (null: Any) match {
+    case C2(_, rest @ _*) => {
+      rest.map(_.value)
+    }
+  }
+}
+
+///////////////////
+
+object Container {
+  trait Exp[+T]
+  abstract class FuncExp[-S, +T]
+
+  sealed abstract class FoundNode[T, Repr] {
+    def optimize[TupleT, U, That](parentNode: FlatMap[T, Repr, U, That]): Any
+    def optimize2[TupleT, U, That](parentNode: Any): Any
+  }
+
+  class FlatMap[T, Repr, U, That]
+
+  val Seq(fn: FoundNode[t, repr]) = Seq[FoundNode[_, _]]()
+  fn.optimize(null)    // was: scala.MatchError: ? (of class BoundedWildcardType) @ Variances#varianceInType
+  fn.optimize2(null) // was: fatal error: bad type: ?(class scala.reflect.internal.Types$BoundedWildcardType) @ Pickle.putType
+}


### PR DESCRIPTION
commit 3c91b32d699a9e29d685ac20c9805f96c9f2db2c
Author: Jason Zaugg jzaugg@gmail.com
Date:   Fri Aug 24 01:16:47 2012 +0200

```
Mention BoundedWildcardType in "a standard type pattern match".
(cherry picked from commit 00e46b3dbcea2b72fd3941b7ffc2efba382871e9)
```

commit 0664be2b69b1ce013e937bc93f4e84b891676f1f
Author: Jason Zaugg jzaugg@gmail.com
Date:   Fri Aug 24 01:05:07 2012 +0200

```
Make RefChecks#validateVariance aware of BoundedWildcardType.

The only test case that I know for this will be neutered
by the imminent fix for SI-6258; so I haven't been able to
test this.

But trying this manually, you can see that this patch defers the
the SI-6258 to the erasure phase.

Original:

scala.MatchError: ? (of class scala.reflect.internal.Types$BoundedWildcardType)
    at scala.tools.nsc.typechecker.RefChecks$RefCheckTransformer$$anon$3.scala$tools$nsc$typechecker$RefChecks$RefCheckTransformer$$anon$$validateVariance$1(RefChecks.scala:894)
    at scala.tools.nsc.typechecker.RefChecks$RefCheckTransformer$$anon$3.validateVariance(RefChecks.scala:965)

Modified:

java.lang.ClassCastException: scala.reflect.internal.Types$TypeRef$$anon$6 cannot be cast to scala.reflect.internal.Types$TypeBounds
    at scala.reflect.internal.Types$TypeMap.mapOver(Types.scala:4160)
    at scala.reflect.internal.transform.Erasure$ErasureMap.apply(Erasure.scala:156)
(cherry picked from commit 2b4e7183fd24113cca5e868456668fd05c848168)
```

commit 6ad651c94faf463133c742feb2aee59ef782ea1f
Author: Jason Zaugg jzaugg@gmail.com
Date:   Fri Aug 24 00:54:59 2012 +0200

```
SI-3577 Make varianceInType aware of BoundedWildcardType.
(cherry picked from commit 21105654c40ed0c462142bcbb6c8eced77f8b07a)
```

Review by @adriaanm
