### PR TITLE
SI-4733 - fsc no longer creates a single temp directory for all users.

### DIFF
--- a/src/compiler/scala/tools/nsc/CompileSocket.scala
+++ b/src/compiler/scala/tools/nsc/CompileSocket.scala
@@ -72,7 +72,7 @@ class CompileSocket extends CompileOutputCommon {
   /** A temporary directory to use */
   val tmpDir = {
     val udir  = Option(Properties.userName) getOrElse "shared"
-    val f     = (Path(Properties.tmpDir) / "scala-devel" / udir).createDirectory()
+    val f     = (Path(Properties.tmpDir) / ("scala-devel" + udir)).createDirectory()
 
     if (f.isDirectory && f.canWrite) {
       info("[Temp directory: " + f + "]")


### PR DESCRIPTION
fsc previously created a single temporary directory called
"scala-devel". This is an issue, since the directory belongs to whoever
created the directory. Depending on the user's umask, this directory may
only be writable for the creator. This causes problems for any other
users who then try to use fsc or invoke fsc indirectly.

Other programs usually solve this issue by creating a separate directory
for each user, either by appending the username to a base directory name
or creating a new direcotory with a random name with a program like
"mktemp". This commit changes CompileSocket to use the first method.

Fixes SI-4733
backport to 2.10.x
