### PR TITLE
SI-6961 maintain structural sharing in list serialization.

### DIFF
--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -343,29 +343,82 @@ case object Nil extends List[Nothing] {
  */
 @SerialVersionUID(0L - 8476791151983527571L)
 final case class ::[B](private var hd: B, private[scala] var tl: List[B]) extends List[B] {
-  override def head : B = hd
-  override def tail : List[B] = tl
+  override def head: B = hd
+  override def tail: List[B] = tl
   override def isEmpty: Boolean = false
 
   private def writeObject(out: ObjectOutputStream) {
-    out.writeObject(ListSerializeStart) // needed to differentiate with the legacy `::` serialization
-    out.writeObject(this.hd)
-    out.writeObject(this.tl)
+    List.SerializeControl.withControl { ctrl =>
+      writeObject_2_10_1(out, ctrl)
+    }
+  }
+
+  private def writeObject_2_10_1(out: ObjectOutputStream, ctrl: List.SerializeControl) {
+    if (ctrl.inLoop) {
+      ctrl.writeAsSeen(out, hd)
+    } else {
+      // needed to differentiate with the legacy `::` serialization
+      out.writeObject(ListSerializeStart_2_10_1)
+      out.writeObject(hd)
+      var current: List[B] = this
+      do {
+        current = current.tail
+        ctrl.writeInLoop(out, current)
+      } while (ctrl.seen)
+    }
   }
 
   private def readObject(in: ObjectInputStream) {
-    val obj = in.readObject()
-    if (obj == ListSerializeStart) {
+    List.SerializeControl.withControl { ctrl =>
+      readObject_2_10_1(in, ctrl)
+    }
+  }
+
+  private def readObject_2_10_1(in: ObjectInputStream, ctrl: List.SerializeControl) {
+    if (ctrl.inLoop) {
+      hd = ctrl.readAsSeen(in).asInstanceOf[B]
+    } else {
+      val obj = in.readObject
+      if (obj != ListSerializeStart_2_10_1) {
+        readObject_2_10_0(in, obj)
+      } else {
+        hd = in.readObject.asInstanceOf[B]
+        var current = this
+        do {
+          val currentTail = ctrl.readInLoop(in).asInstanceOf[List[B]]
+          current.tl = currentTail
+          current = if (ctrl.seen) currentTail.asInstanceOf[::[B]] else null
+        } while (current != null)
+      }
+    }
+  }
+
+  /** The oldReadObject method prior to SI-6961 is here for
+   *  deserialization of legacy objects.
+   */
+  private def readObject_2_10_0(in: ObjectInputStream, firstObject: AnyRef) {
+    if (firstObject == ListSerializeStart) {
       this.hd = in.readObject().asInstanceOf[B]
       this.tl = in.readObject().asInstanceOf[List[B]]
-    } else oldReadObject(in, obj)
+    } else {
+      // otherwise, we switch back to 2.9.x deserialization
+      readObject_2_9_x(in, firstObject)
+    }
+  }
+
+  /** The old version of the writeObject method, prior to SI-6961.
+   */
+  private def writeObject_2_10_0(out: ObjectOutputStream) {
+    out.writeObject(ListSerializeStart) // needed to differentiate with the legacy `::` serialization
+    out.writeObject(this.hd)
+    out.writeObject(this.tl)
   }
 
   /* The oldReadObject method exists here for compatibility reasons.
    * :: objects used to be serialized by serializing all the elements to
    * the output stream directly, but this was broken (see SI-5374).
    */
-  private def oldReadObject(in: ObjectInputStream, firstObject: AnyRef) {
+  private def readObject_2_9_x(in: ObjectInputStream, firstObject: AnyRef) {
     hd = firstObject.asInstanceOf[B]
     assert(hd != ListSerializeEnd)
     var current: ::[B] = this
@@ -379,6 +432,15 @@ final case class ::[B](private var hd: B, private[scala] var tl: List[B]) extend
         current = list
     }
   }
+
+  /** The old version of the writeObject method, prior to SI-5374.
+   */
+  private def writeObject_2_9_x(out: ObjectOutputStream) {
+    var xs: List[B] = this
+    while (!xs.isEmpty) { out.writeObject(xs.head); xs = xs.tail }
+    out.writeObject(ListSerializeEnd)
+  }
+
 }
 
 /** $factoryInfo
@@ -395,13 +457,67 @@ object List extends SeqFactory[List] {
   override def empty[A]: List[A] = Nil
 
   override def apply[A](xs: A*): List[A] = xs.toList
+
+  private[scala] object SerializeControl {
+    final val tl = new ThreadLocal[List.SerializeControl]
+
+    @inline def withControl[A](f: SerializeControl => A): A = {
+      tl.get match {
+        case null =>
+          val control = new List.SerializeControl
+          tl set control
+          try f(control) finally tl set null
+        case control => f(control)
+      }
+    }
+  }
+
+  private[scala] final class SerializeControl {
+    private var seen0: Boolean = false
+    private var inLoop0: Boolean = false
+ 
+    def seen = seen0
+ 
+    def inLoop = inLoop0
+ 
+    def writeInLoop(out: ObjectOutputStream, obj: AnyRef) {
+      seen0 = false
+      inLoop0 = true
+      try out.writeObject(obj)
+      finally inLoop0 = false
+    }
+ 
+    def writeAsSeen(out: ObjectOutputStream, obj: Any) {
+      inLoop0 = false
+      out.writeObject(obj)
+      seen0 = true
+    }
+ 
+    def readInLoop(in: ObjectInputStream): AnyRef = {
+      seen0 = false
+      inLoop0 = true
+      try in.readObject()
+      finally inLoop0 = false
+    }
+ 
+    def readAsSeen(in: ObjectInputStream): AnyRef = {
+      inLoop0 = false
+      val obj = in.readObject()
+      seen0 = true
+      obj
+    }
+  }
+
 }
 
-/** Only used for list serialization */
+/** Only used for list serialization in 2.10.0 */
 @SerialVersionUID(0L - 8287891243975527522L)
-private[scala] case object ListSerializeStart
+private case object ListSerializeStart
 
-/** Only used for list serialization */
+/** Only used for list serialization from 2.10.1 */
+@SerialVersionUID(0L - 8392743892147938211L)
+private case object ListSerializeStart_2_10_1
+
+/** Only used for list serialization. */
 @SerialVersionUID(0L - 8476791151975527571L)
-private[scala] case object ListSerializeEnd
-
+private case object ListSerializeEnd

--- a/test/files/run/t6961.scala
+++ b/test/files/run/t6961.scala
@@ -1,0 +1,99 @@
+
+
+
+import java.io._
+
+
+
+object Test {
+
+  def deepCopy[T](obj : T): T = {
+    val baos = new ByteArrayOutputStream()
+    val oos = new ObjectOutputStream(baos)
+    oos.writeObject(obj)
+    oos.flush()
+    val data = baos.toByteArray
+    val bais = new ByteArrayInputStream(data)
+    val ois = new ObjectInputStream(bais)
+    ois.readObject().asInstanceOf[T]
+  }
+ 
+  def test1() {
+    var r: List[Int] = Nil
+    var i = 0
+    while (i < 1000000) {
+      r = i :: r
+      i += 1
+    }
+    assert(Nil == deepCopy(Nil))
+    assert(r.take(1) == deepCopy(r.take(1)))
+    assert(List(1, 2, 3) == deepCopy(List(1, 2, 3)))
+    assert(r == deepCopy(r))
+    val nestedList = r :: r
+    assert(nestedList == deepCopy(nestedList))
+  }
+ 
+  def test2() {
+    val l1: List[String] = "1" :: Nil
+    val l2: List[String] = "2" :: "3" :: l1
+    val p = (l1, l2)
+    val pr = (l2, l1)
+    val a = Array(l2, p)
+    val l3: List[AnyRef] = p :: l2 :: l1 :: p :: a :: Nil
+ 
+    def verifyL1L2(l1: List[String], l2: List[String]) {
+      assert(l1 eq l2.tail.tail)
+    }
+ 
+    def verifyP(p: (List[String], List[String])) {
+      verifyL1L2(p._1, p._2)
+    }
+ 
+    def verifyPr(p: (List[String], List[String])) {
+      verifyL1L2(p._2, p._1)
+    }
+ 
+    def verifyL3(list: List[AnyRef]) {
+      val p = list.head.asInstanceOf[(List[String], List[String])]
+      val l1 = p._1
+      val l2 = p._2
+      val a = list.tail.tail.tail.tail.head.asInstanceOf[Array[AnyRef]]
+      verifyP(p)
+      assert(p eq list.tail.tail.tail.head)
+      assert(l2 eq list.tail.head)
+      assert(l1 eq list.tail.tail.head)
+      assert(a(0) eq l2)
+      assert(a(1) eq p)
+    }
+ 
+    verifyP(p)
+    val pc = deepCopy(p)
+    verifyP(pc)
+ 
+    verifyPr(pr)
+    val prc = deepCopy(pr)
+    verifyPr(prc)
+ 
+    verifyL3(l3)
+    val l3c = deepCopy(l3)
+    verifyL3(l3c)
+  }
+ 
+  def main(args: Array[String]) {
+    test1()
+    test2()
+  }
+
+}
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Applying Jan Vanek's patch that makes list serialization maintain
structural sharing, as well as avoids a stack overflow for big lists.
See a more detailed explanation in the bugtracker.

Additionally, deserialization of lists serialized with Scala 2.10.1
and 2.9.x should work.
This legacy deserialization is embodied in the methods `readObject_2_10_0`
and `readObject_2_9_x`.

Factored out setting and resetting of the SerializeControl instance
into the companion object, using @inline to eliminate the closure.

This is a PR 1923 resubmitted, squashed:
https://github.com/scala/scala/pull/1923
