### PR TITLE
SI-7033 Be symful when creating factory methods.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
@@ -389,7 +389,7 @@ trait MethodSynthesis {
         result
       }
       def derivedTree: DefDef          =
-        factoryMeth(mods & flagsMask | flagsExtra, name, tree, symbolic = false)
+        factoryMeth(mods & flagsMask | flagsExtra, name, tree)
       def flagsExtra: Long             = METHOD | IMPLICIT | SYNTHETIC
       def flagsMask: Long              = AccessFlags
       def name: TermName               = tree.name.toTermName

--- a/test/files/pos/t7033.scala
+++ b/test/files/pos/t7033.scala
@@ -1,0 +1,15 @@
+import language.higherKinds
+object Wrap {
+  implicit class X[X](val a: X)
+
+  X[Int](0)
+}
+
+class Wrap {
+  implicit class Y[Y](val a: Y)
+  Y[Int](0)
+  implicit class Z[Z[_]](val a: Z[Wrap.this.Z[Z]])
+  Z[List](List(new Z[List](null)))
+}
+
+case class X[X](val a: X)


### PR DESCRIPTION
Implicit class factory methods were synthesizing the
reference to the class as `Ident(classDef.name)`, which
was unhygienic in case of `implicit class X[X]`.

To use symbols without causing a cycle, I switched from
`REF(symbol)` to `Ident(symbol)`. The former calls into:

```
at scala.reflect.internal.TreeGen.mkAttributedSelect(TreeGen.scala:184)
at scala.reflect.internal.TreeGen.mkAttributedRef(TreeGen.scala:124)
at scala.reflect.internal.TreeGen.mkAttributedRef(TreeGen.scala:130)
at scala.tools.nsc.ast.TreeDSL$CODE$.REF(TreeDSL.scala:307)
```

which seems to force the enclosing module and blow up.

Review by @paulp
- have I lost something by using `Ident(classSym)` here.
- in general, when would one choose `REF(_)` over `Ident(_)`?
