### PR TITLE
SI-5082 Cycle avoidance between case companions

### DIFF
--- a/test/files/pos/t5082.scala
+++ b/test/files/pos/t5082.scala
@@ -1,0 +1,14 @@
+trait Something[T]
+object Test { class A }
+case class Test() extends Something[Test.A]
+
+object User {
+  val Test() = Test()
+}
+
+object Wrap {
+  trait Something[T]
+  object Test { class A }
+  case class Test(a: Int, b: Int)(c: String) extends Something[Test.A]
+  val Test(x, y) = Test(1, 2)(""); (x + y).toString
+}


### PR DESCRIPTION
We can synthesize the case companion unapply without forcing
the info of the case class, by looking at the parameters in
the `ClassDef` tree, rather than at `sym.caseFieldAccessors`.

Review by @paulp. Perhaps you'd like to try it in combination with your `ProductN` patch.
