### PR TITLE
Change Doc to trait to allow it to be used as a cake slice.

### DIFF
--- a/src/compiler/scala/tools/nsc/interactive/Doc.scala
+++ b/src/compiler/scala/tools/nsc/interactive/Doc.scala
@@ -1,5 +1,5 @@
 /* NSC -- new Scala compiler
- * Copyright 2007-2012 LAMP/EPFL
+ * Copyright 2007-2013 LAMP/EPFL
  * @author  Eugene Vigdorchik
  */
 
@@ -8,29 +8,27 @@ package interactive
 
 import doc.base._
 import comment._
+import scala.reflect.internal.util.SourceFile
 import scala.xml.NodeSeq
 
 sealed trait DocResult
 final case class UrlResult(url: String) extends DocResult
 final case class HtmlResult(comment: Comment) extends DocResult
 
-abstract class Doc(val settings: doc.Settings) extends MemberLookupBase with CommentFactoryBase {
+trait Doc extends MemberLookupBase with CommentFactoryBase { self: interactive.Global =>
+  override val settings: doc.Settings
 
-  override val global: interactive.Global
-  import global._
+  val global: this.type = this
  
   def chooseLink(links: List[LinkTo]): LinkTo
 
   override def internalLink(sym: Symbol, site: Symbol): Option[LinkTo] =
-    ask { () => 
-      if (sym.isClass || sym.isModule)
-        Some(LinkToTpl(sym))
-      else
-        if ((site.isClass || site.isModule) && site.info.members.toList.contains(sym))
-          Some(LinkToMember(sym, site))
-        else
-          None
-    }
+    if (sym.isClass || sym.isModule)
+      Some(LinkToTpl(sym))
+    else
+      if ((site.isClass || site.isModule) && site.info.members.toList.contains(sym))
+        Some(LinkToMember(sym, site))
+      else None
 
   override def toString(link: LinkTo) = ask { () =>
     link match {
@@ -41,19 +39,33 @@ abstract class Doc(val settings: doc.Settings) extends MemberLookupBase with Com
     }
   }
 
-  def retrieve(sym: Symbol, site: Symbol): Option[DocResult] = {
-    val sig = ask { () => externalSignature(sym) }
-    findExternalLink(sym, sig) map { link => UrlResult(link.url) } orElse {
-      val resp = new Response[Tree]
-      // Ensure docComment tree is type-checked.
-      val pos = ask { () => docCommentPos(sym) }
-      askTypeAt(pos, resp)
-      resp.get.left.toOption flatMap { _ =>
-        ask { () =>
-          val comment = parseAtSymbol(expandedDocComment(sym), rawDocComment(sym), pos, Some(site))
+ /**
+  * Gets the documentation either as a Comment object or as a URL.
+  * @param sym      The symbol whose documentation should be retrieved.
+  * @param site     The place where sym is observed.
+  * @param source   The source file to look for the symbol.
+  */
+  def retrieve(sym: Symbol, site: Symbol, source: SourceFile): Option[DocResult] = {
+    debugLog("Retrieve documentation for "+sym)
+    assert(onCompilerThread, "!onCompilerThread")
+
+    val html = withTempUnit(source){ u =>
+      val mirror = forceDocComment(sym, site, u)
+      if (mirror eq NoSymbol)
+        None
+      else {
+        val expanded = expandedDocComment(mirror, site)
+        if (!expanded.isEmpty) {
+          val comment = parseAtSymbol(expanded, rawDocComment(mirror), docCommentPos(mirror), Some(site))
           Some(HtmlResult(comment))
-        }
+        } else
+          None
       }
+    }
+
+    html orElse {
+      val sig = externalSignature(sym)
+      findExternalLink(sym, sig) map { link => UrlResult(link.url) }
     }
   }
 }

--- a/src/compiler/scala/tools/nsc/interactive/Global.scala
+++ b/src/compiler/scala/tools/nsc/interactive/Global.scala
@@ -562,7 +562,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
   }
 
   /** Parse unit and create a name index, unless this has already been done before */
-  private def parseAndEnter(unit: RichCompilationUnit): Unit =
+  private[interactive] def parseAndEnter(unit: RichCompilationUnit): Unit =
     if (unit.status == NotLoaded) {
       debugLog("parsing: "+unit)
       currentTyperRun.compileLate(unit)
@@ -727,7 +727,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
         try {
           debugLog("starting targeted type check")
           typeCheck(unit)
-          println("tree not found at "+pos)
+//          println("tree not found at "+pos)
           EmptyTree
         } catch {
           case ex: TyperResult => new Locator(pos) locateIn ex.tree
@@ -758,64 +758,101 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
     respond(response)(typedTree(source, forceReload))
   }
 
-  /** Implements CompilerControl.askLinkPos */
-  private[interactive] def getLinkPos(sym: Symbol, source: SourceFile, response: Response[Position]) {
-
-    /** Find position of symbol `sym` in unit `unit`. Pre: `unit is loaded. */
-    def findLinkPos(unit: RichCompilationUnit): Position = {
-      val originalTypeParams = sym.owner.typeParams
-      parseAndEnter(unit)
-      val pre = adaptToNewRunMap(ThisType(sym.owner))
-      val rawsym = pre.typeSymbol.info.decl(sym.name)
-      val newsym = rawsym filter { alt =>
-        sym.isType || {
-          try {
-            val tp1 = pre.memberType(alt) onTypeError NoType
-            val tp2 = adaptToNewRunMap(sym.tpe) substSym (originalTypeParams, sym.owner.typeParams)
-            matchesType(tp1, tp2, false) || {
-              debugLog(s"getLinkPos matchesType($tp1, $tp2) failed")
-              val tp3 = adaptToNewRunMap(sym.tpe) substSym (originalTypeParams, alt.owner.typeParams)
-              matchesType(tp1, tp3, false) || {
-                debugLog(s"getLinkPos fallback matchesType($tp1, $tp3) failed")
-                false
-              }
-            }
-          }
-          catch {
-            case ex: ControlThrowable => throw ex
-            case ex: Throwable =>
-              println("error in hyperlinking: " + ex)
-              ex.printStackTrace()
-              false
-          }
-        }
-      }
-      if (newsym == NoSymbol) {
-        if (rawsym.exists && !rawsym.isOverloaded) rawsym.pos
-        else {
-          debugLog("link not found " + sym + " " + source + " " + pre)
-          NoPosition
-        }
-      } else if (newsym.isOverloaded) {
-        settings.uniqid.value = true
-        debugLog("link ambiguous " + sym + " " + source + " " + pre + " " + newsym.alternatives)
-        NoPosition
-      } else {
-        debugLog("link found for " + newsym + ": " + newsym.pos)
-        newsym.pos
-      }
+  private[interactive] def withTempUnit[T](source: SourceFile)(f: RichCompilationUnit => T): T =
+    getUnit(source) match {
+      case None =>
+        reloadSources(List(source))
+        try f(getUnit(source).get)
+        finally afterRunRemoveUnitOf(source)
+      case Some(unit) =>
+        f(unit)
     }
 
+  private[interactive] def forceDocComment(sym: Symbol, site: Symbol, unit: RichCompilationUnit): Symbol = {
+    val m = findMirrorSymbol(sym, unit)
+    // Either typer has been run and we don't find DocDef,
+    // or we force the targeted typecheck here.
+    // In both cases doc comment maps should be filled for the subject symbol.
+    val docTree =
+      unit.body find { t =>
+        t match {
+          case DocDef(_, defn) if defn.symbol eq m => true
+          case _ => false
+        }
+      }
+
+    for (t <- docTree) {
+      debugLog("Found DocDef tree for "+sym)
+      // Cannot get a typed tree at position since DocDef range is transparent.
+      val prevPos = unit.targetPos
+      val prevInterruptsEnabled = interruptsEnabled
+      try {
+        unit.targetPos = t.pos
+        interruptsEnabled = true
+        typeCheck(unit)
+      } catch {
+        case _: TyperResult => // ignore since we are after the side effect.
+      } finally {
+        unit.targetPos = prevPos
+        interruptsEnabled = prevInterruptsEnabled
+      }
+    }
+    m
+  }
+
+  /** Find position of symbol `sym` in unit `unit`. Pre: `unit is loaded. */
+  private def findMirrorSymbol(sym: Symbol, unit: RichCompilationUnit): Symbol = {
+    val originalTypeParams = sym.owner.typeParams
+    parseAndEnter(unit)
+    val pre = adaptToNewRunMap(ThisType(sym.owner))
+    val rawsym = pre.typeSymbol.info.decl(sym.name)
+    val newsym = rawsym filter { alt =>
+      sym.isType || {
+        try {
+          val tp1 = pre.memberType(alt) onTypeError NoType
+          val tp2 = adaptToNewRunMap(sym.tpe) substSym (originalTypeParams, sym.owner.typeParams)
+          matchesType(tp1, tp2, false) || {
+            debugLog(s"getLinkPos matchesType($tp1, $tp2) failed")
+            val tp3 = adaptToNewRunMap(sym.tpe) substSym (originalTypeParams, alt.owner.typeParams)
+            matchesType(tp1, tp3, false) || {
+              debugLog(s"getLinkPos fallback matchesType($tp1, $tp3) failed")
+              false
+            }
+          }
+        }
+        catch {
+          case ex: ControlThrowable => throw ex
+          case ex: Throwable =>
+            println("error in hyperlinking: " + ex)
+            ex.printStackTrace()
+            false
+        }
+      }
+    }
+    if (newsym == NoSymbol) {
+      if (rawsym.exists && !rawsym.isOverloaded) rawsym
+      else {
+        debugLog("link not found " + sym + " " + unit.source + " " + pre)
+        NoSymbol
+      }
+    } else if (newsym.isOverloaded) {
+      settings.uniqid.value = true
+      debugLog("link ambiguous " + sym + " " + unit.source + " " + pre + " " + newsym.alternatives)
+      NoSymbol
+    } else {
+      debugLog("link found for " + newsym + ": " + newsym.pos)
+      newsym
+    }
+  }
+
+  /** Implements CompilerControl.askLinkPos */
+  private[interactive] def getLinkPos(sym: Symbol, source: SourceFile, response: Response[Position]) {
     informIDE("getLinkPos "+sym+" "+source)
     respond(response) {
       if (sym.owner.isClass) {
-        getUnit(source) match {
-          case None =>
-            reloadSources(List(source))
-            try findLinkPos(getUnit(source).get)
-            finally afterRunRemoveUnitOf(source)
-          case Some(unit) =>
-            findLinkPos(unit)
+        withTempUnit(source){ u =>
+          val m = findMirrorSymbol(sym, u)
+          if (m eq NoSymbol) NoPosition else m.pos
         }
       } else {
         debugLog("link not in class "+sym+" "+source+" "+sym.owner)

--- a/src/compiler/scala/tools/nsc/interactive/tests/core/PresentationCompilerInstance.scala
+++ b/src/compiler/scala/tools/nsc/interactive/tests/core/PresentationCompilerInstance.scala
@@ -8,7 +8,8 @@ import scala.reflect.internal.util.Position
 /** Trait encapsulating the creation of a presentation compiler's instance.*/
 private[tests] trait PresentationCompilerInstance extends TestSettings {
   protected val settings = new Settings
-  protected def docSettings: doc.Settings = new doc.Settings(_ => ())
+  protected val docSettings = new doc.Settings(_ => ())
+
   protected val compilerReporter: CompilerReporter = new InteractiveReporter {
     override def compiler = PresentationCompilerInstance.this.compiler
   }

--- a/test/files/presentation/doc.check
+++ b/test/files/presentation/doc.check
@@ -1,3 +1,4 @@
+reload: Test.scala
 body:Body(List(Paragraph(Chain(List(Summary(Chain(List(Text(This is a test comment), Text(.)))), Text(
 ))))))
 @example:Body(List(Paragraph(Chain(List(Summary(Monospace(Text("abb".permutations = Iterator(abb, bab, bba)))))))))

--- a/test/files/presentation/doc/doc.scala
+++ b/test/files/presentation/doc/doc.scala
@@ -28,12 +28,18 @@ object Test extends InteractiveTest {
        |trait Commented {}
        |class User(c: %sCommented)""".stripMargin.format(comment, tags take nTags mkString "\n", caret)
 
-  override def main(args: Array[String]) {
-    val documenter = new Doc(settings) {
-      val global: compiler.type = compiler
-
+  override lazy val compiler = {
+    new {
+      override val settings = {
+        prepareSettings(Test.this.settings)
+        Test.this.settings
+      }
+    } with Global(settings, compilerReporter) with Doc {
       def chooseLink(links: List[LinkTo]): LinkTo = links.head
     }
+  }
+
+  override def runDefaultTests() {
     for (i <- 1 to tags.length) {
       val markedText = text(i)
       val idx = markedText.indexOf(caret)
@@ -52,7 +58,10 @@ object Test extends InteractiveTest {
           treeResponse.get.left.toOption match {
             case Some(tree) =>
               val sym = tree.tpe.typeSymbol
-              documenter.retrieve(sym, sym.owner) match {
+              val res = compiler.ask { () =>
+                compiler.retrieve(sym, sym.owner, compiler.unitOfFile(sym.sourceFile).source)
+              }
+              res match {
                case Some(HtmlResult(comment)) =>
                  import comment._
                  val tags: List[(String, Iterable[Body])] =


### PR DESCRIPTION
Change the implementation of retrieve() method.
Rename and privatize symbols in CommentFactoryBase to avoid clashes when cooking a cake.
