### PR TITLE
SI-7035 Centralize case field accessor sorting.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
@@ -746,26 +746,8 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
 
       // reference the (i-1)th case accessor if it exists, otherwise the (i-1)th tuple component
       override protected def tupleSel(binder: Symbol)(i: Int): Tree = { import CODE._
-        // caseFieldAccessors is messed up after typers (reversed, names mangled for non-public fields)
-        // TODO: figure out why...
         val accessors = binder.caseFieldAccessors
-        // luckily, the constrParamAccessors are still sorted properly, so sort the field-accessors using them
-        // (need to undo name-mangling, including the sneaky trailing whitespace)
-        val constrParamAccessors = binder.constrParamAccessors
-
-        def indexInCPA(acc: Symbol) =
-          constrParamAccessors indexWhere { orig =>
-            // patmatDebug("compare: "+ (orig, acc, orig.name, acc.name, (acc.name == orig.name), (acc.name startsWith (orig.name append "$"))))
-            val origName  = orig.name.toString.trim
-            val accName = acc.name.toString.trim
-            (accName == origName) || (accName startsWith (origName + "$"))
-          }
-
-        // patmatDebug("caseFieldAccessors: "+ (accessors, binder.caseFieldAccessors map indexInCPA))
-        // patmatDebug("constrParamAccessors: "+ constrParamAccessors)
-
-        val accessorsSorted = accessors sortBy indexInCPA
-        if (accessorsSorted isDefinedAt (i-1)) REF(binder) DOT accessorsSorted(i-1)
+        if (accessors isDefinedAt (i-1)) REF(binder) DOT accessors(i-1)
         else codegen.tupleSel(binder)(i) // this won't type check for case classes, as they do not inherit ProductN
       }
 

--- a/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
@@ -78,14 +78,7 @@ trait SyntheticMethods extends ast.TreeDSL {
       else templ
     }
 
-    val originalAccessors = clazz.caseFieldAccessors
-    // private ones will have been renamed -- make sure they are entered
-    // in the original order.
-    def accessors = clazz.caseFieldAccessors sortBy { acc =>
-      originalAccessors indexWhere { orig =>
-        (acc.name == orig.name) || (acc.name startsWith (orig.name append "$"))
-      }
-    }
+    def accessors = clazz.caseFieldAccessors
     val arity = accessors.size
     // If this is ProductN[T1, T2, ...], accessorLub is the lub of T1, T2, ..., .
     // !!! Hidden behind -Xexperimental due to bummer type inference bugs.

--- a/test/files/pos/t7035.scala
+++ b/test/files/pos/t7035.scala
@@ -1,0 +1,15 @@
+case class Y(final var x: Int, final private var y: String, final val z1: Boolean, final private val z2: Any) {
+
+  import Test.{y => someY}
+  List(someY.x: Int, someY.y: String, someY.z1: Boolean, someY.z2: Any)
+  someY.y = ""
+}
+
+object Test {
+  val y = Y(0, "", true, new {})
+  val unapp: Option[(Int, String, Boolean, Any)] = // was (Int, Boolean, String, Any) !!
+    Y.unapply(y)
+
+  val Y(a, b, c, d) = y
+  List(a: Int, b: String, c: Boolean, d: Any)
+}


### PR DESCRIPTION
It is both burdensome and dangerous to expect callers
to reorder these. This was seen in the field permutation
in the unapply method; a regression in 2.10.0.

Review by @paulp
