### PR TITLE
SI-7039 if unapplySeq returns an option of a product `nbSubPats` is not ...

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -105,7 +105,7 @@ trait Infer extends Checkable {
       else resTp.baseType(OptionClass).typeArgs match {
         case optionTArg :: Nil =>
           def productArgs = getProductArgs(optionTArg)
-          if (nbSubPats == 1) {
+          if ((nbSubPats == 1 && !isUnapplySeq) || productArgs.size == 1) {
             if (isUnapplySeq) List(seqToRepeatedChecked(optionTArg))
             else {
               val productArity = productArgs.size

--- a/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
@@ -814,7 +814,7 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
 
       protected lazy val rawSubPatTypes =
         if (resultInMonad.typeSymbol eq UnitClass) Nil
-        else if(nbSubPats == 1)                    List(resultInMonad)
+        else if((nbSubPats == 1 && !isSeq) || hasLength(getProductArgs(resultInMonad), 1)) List(resultInMonad)
         else getProductArgs(resultInMonad) match {
           case Nil => List(resultInMonad)
           case x   => x

--- a/test/files/run/t7039.check
+++ b/test/files/run/t7039.check
@@ -1,0 +1,1 @@
+Matched!

--- a/test/files/run/t7039.scala
+++ b/test/files/run/t7039.scala
@@ -1,0 +1,10 @@
+object Test extends App {
+
+  object UnapplySeqTest {
+    def unapplySeq(any: Any): Option[(Int, Seq[Int])] = Some((5, Nil))
+  }
+
+  null match {
+    case UnapplySeqTest(5) => println("Matched!")
+  }
+}


### PR DESCRIPTION
...enough to check because this will miss a pattern with one product element and an empty repeated argument list.

The proposed solution is to check the number of elements in the expected product as well before concluding that an extractor is _no_ unapplySeq.

This seems to fix it but I suppose there are better ways to achieve the same effect.
