### PR TITLE
[backport] SI-6301 / SI-6572 specialization regressions 

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -450,19 +450,31 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
            *   is a value type (int et al.) in which case it must cast to the boxed version
            *   because invoke only returns object and erasure made sure the result is
            *   expected to be an AnyRef. */
-          val t: Tree = ad.symbol.tpe match {
-            case MethodType(mparams, resType) =>
-              assert(params.length == mparams.length, mparams)
+          val t: Tree = {
+            val (mparams, resType) = ad.symbol.tpe match {
+              case MethodType(mparams, resType) =>
+                assert(params.length == mparams.length, ((params, mparams)))
+                (mparams, resType)
+              case tpe @ OverloadedType(pre, alts) =>
+                unit.warning(ad.pos, s"Overloaded type reached the backend! This is a bug in scalac.\n     Symbol: ${ad.symbol}\n  Overloads: $tpe\n  Arguments: " + ad.args.map(_.tpe))
+                alts filter (_.paramss.flatten.size == params.length) map (_.tpe) match {
+                  case mt @ MethodType(mparams, resType) :: Nil =>
+                    unit.warning(NoPosition, "Only one overload has the right arity, proceeding with overload " + mt)
+                    (mparams, resType)
+                  case _ =>
+                    unit.error(ad.pos, "Cannot resolve overload.")
+                    (Nil, NoType)
+                }
+            }
+            typedPos {
+              val sym = currentOwner.newValue(mkTerm("qual"), ad.pos) setInfo qual0.tpe
+              qual = REF(sym)
 
-              typedPos {
-                val sym = currentOwner.newValue(mkTerm("qual"), ad.pos) setInfo qual0.tpe
-                qual = REF(sym)
-
-                BLOCK(
-                  VAL(sym) === qual0,
-                  callAsReflective(mparams map (_.tpe), resType)
-                )
-              }
+              BLOCK(
+                VAL(sym) === qual0,
+                callAsReflective(mparams map (_.tpe), resType)
+              )
+            }
           }
 
           /* For testing purposes, the dynamic application's condition

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -178,6 +178,14 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
 
   case class Overload(sym: Symbol, env: TypeEnv) {
     override def toString = "specialized overload " + sym + " in " + env
+    def matchesSym(other: Symbol) = sym.tpe =:= other.tpe
+    def matchesEnv(env1: TypeEnv) = TypeEnv.includes(env, env1)
+  }
+  private def newOverload(method: Symbol, specializedMethod: Symbol, env: TypeEnv) = {
+    assert(!specializedMethod.isOverloaded, specializedMethod.defString)
+    val om = Overload(specializedMethod, env)
+    overloads(method) ::= om
+    om
   }
 
   /** Just to mark uncheckable */
@@ -288,10 +296,6 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
       case _ => tp
     }
   }
-
-  /** Return the specialized overload of sym in the given env, if any. */
-  def overload(sym: Symbol, env: TypeEnv) =
-    overloads(sym).find(ov => TypeEnv.includes(ov.env, env))
 
   /** Return the specialized name of 'sym' in the given environment. It
    *  guarantees the same result regardless of the map order by sorting
@@ -628,7 +632,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
         info(om)         = if (original.isDeferred) Forward(original) else Implementation(original)
         typeEnv(om)      = env ++ typeEnv(m) // add the environment for any method tparams
 
-        overloads(specMember) ::= Overload(om, typeEnv(om))
+        newOverload(specMember, om, typeEnv(om))
         enterMember(om)
       }
 
@@ -835,7 +839,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
 
           debuglog("%s expands to %s in %s".format(sym, specMember.name.decode, pp(env)))
           info(specMember) = NormalizedMember(sym)
-          overloads(sym) ::= Overload(specMember, env)
+          newOverload(sym, specMember, env)
           owner.info.decls.enter(specMember)
           specMember
         }
@@ -877,9 +881,8 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
       if (wasSpec.nonEmpty)
         debuglog("specialized overload for %s in %s".format(specMember, pp(typeEnv(specMember))))
 
-      overloads(sym) ::= Overload(specMember, spec)
+      newOverload(sym, specMember, spec)
       info(specMember) = SpecialOverload(sym, typeEnv(specMember))
-
       specMember
     }
 
@@ -994,7 +997,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
               SpecialOverride(impl)
             }
           )
-          overloads(overriding) ::= Overload(om, env)
+          newOverload(overriding, om, env)
           ifDebug(afterSpecialize(assert(
             overridden.owner.info.decl(om.name) != NoSymbol,
             "Could not find " + om.name + " in " + overridden.owner.info.decls))
@@ -1476,54 +1479,41 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
           }
           transformTypeApply
 
-        case Select(qual, name) =>
-          def transformSelect = {
-            qual match {
-              case _: Super if illegalSpecializedInheritance(currentClass) =>
-                val pos = tree.pos
-                debuglog(pos.source.file.name+":"+pos.line+": not specializing call to super inside illegal specialized inheritance class.")
-                debuglog(pos.lineContent)
-                tree
-              case _ =>
+        case Select(Super(_, _), _) if illegalSpecializedInheritance(currentClass) =>
+          val pos = tree.pos
+          debuglog(pos.source.file.name+":"+pos.line+": not specializing call to super inside illegal specialized inheritance class.\n" + pos.lineContent)
+          tree
 
+        case Select(qual, name) if name != nme.CONSTRUCTOR && specializedTypeVars(symbol.info).nonEmpty =>
           debuglog("specializing Select %s [tree.tpe: %s]".format(symbol.defString, tree.tpe))
-
-          //log("!!! select " + tree + " -> " + symbol.info + " specTypeVars: " + specializedTypeVars(symbol.info))
-          if (specializedTypeVars(symbol.info).nonEmpty && name != nme.CONSTRUCTOR) {
-            // log("!!! unifying " + (symbol, symbol.tpe) + " and " + (tree, tree.tpe))
-            val env = unify(symbol.tpe, tree.tpe, emptyEnv, false)
-            // log("!!! found env: " + env + "; overloads: " + overloads(symbol))
-            if (!env.isEmpty) {
-              // debuglog("checking for rerouting: " + tree + " with sym.tpe: " + symbol.tpe + " tree.tpe: " + tree.tpe + " env: " + env)
-              val specMember = overload(symbol, env)
-              if (specMember.isDefined) {
-                localTyper.typedOperator(atPos(tree.pos)(Select(transform(qual), specMember.get.sym.name)))
-              }
-              else {
-                val qual1 = transform(qual)
+          val env = unify(symbol.tpe, tree.tpe, emptyEnv, false)
+          if (env.isEmpty) super.transform(tree)
+          else {
+            val qual1 = transform(qual)
+            def reselect(member: Symbol) = {
+              val newSelect = atPos(tree.pos)(Select(qual1, member))
+              if (member.isMethod) localTyper typedOperator newSelect
+              else localTyper typed newSelect
+            }
+            overloads(symbol) find (_ matchesEnv env) match {
+              case Some(Overload(member, _)) => reselect(member)
+              case _                         =>
                 val specMember = qual1.tpe.member(specializedName(symbol, env)).suchThat(_.tpe matches subst(env, symbol.tpe))
-                if (specMember ne NoSymbol) {
-                  val tree1 = atPos(tree.pos)(Select(qual1, specMember))
-                  if (specMember.isMethod)
-                    localTyper.typedOperator(tree1)
-                  else
-                    localTyper.typed(tree1)
-                } else
+                if (specMember ne NoSymbol)
+                  reselect(specMember)
+                else
                   treeCopy.Select(tree, qual1, name)
-              }
-            } else
+            }
+          }
+        case Select(qual, _) =>
+          overloads(symbol) find (_ matchesSym symbol) match {
+            case Some(Overload(member, _)) =>
+              val newTree = Select(transform(qual), member)
+              debuglog(s"** routing $tree to ${member.fullName} tree: $newTree")
+              localTyper.typedOperator(atPos(tree.pos)(newTree))
+            case None =>
               super.transform(tree)
-          } else overloads(symbol).find(_.sym.info =:= symbol.info) match {
-              case Some(specMember) =>
-                val qual1 = transform(qual)
-                debuglog("** routing " + tree + " to " + specMember.sym.fullName + " tree: " + Select(qual1, specMember.sym))
-                localTyper.typedOperator(atPos(tree.pos)(Select(qual1, specMember.sym)))
-              case None =>
-                super.transform(tree)
           }
-          }
-          }
-          transformSelect
 
         case PackageDef(pid, stats) =>
           tree.symbol.info // make sure specializations have been performed

--- a/src/compiler/scala/tools/nsc/typechecker/Duplicators.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Duplicators.scala
@@ -317,15 +317,33 @@ abstract class Duplicators extends Analyzer {
           super.typed(tree, mode, pt)
 
         case Select(th @ This(_), sel) if (oldClassOwner ne null) && (th.symbol == oldClassOwner) =>
-          // log("selection on this, no type ascription required")
-          // we use the symbol name instead of the tree name because the symbol may have been
-          // name mangled, rendering the tree name obsolete
-          // log(tree)
-          val t = super.typedPos(tree.pos, mode, pt) {
-            Select(This(newClassOwner), tree.symbol.name)
-          }
-          // log("typed to: " + t + "; tpe = " + t.tpe + "; " + inspectTpe(t.tpe))
-          t
+          // We use the symbol name instead of the tree name because the symbol
+          // may have been name mangled, rendering the tree name obsolete.
+          // ...but you can't just do a Select on a name because if the symbol is
+          // overloaded, you will crash in the backend.
+          val memberByName  = newClassOwner.thisType.member(tree.symbol.name)
+          def nameSelection = Select(This(newClassOwner), tree.symbol.name)
+          val newTree = (
+            if (memberByName.isOverloaded) {
+              // Find the types of the overload alternatives as seen in the new class,
+              // and filter the list down to those which match the old type (after
+              // fixing the old type so it is seen as if from the new class.)
+              val typeInNewClass = fixType(oldClassOwner.info memberType tree.symbol)
+              val alts           = memberByName.alternatives
+              val memberTypes    = alts map (newClassOwner.info memberType _)
+              val memberString   = memberByName.defString
+              alts zip memberTypes filter (_._2 =:= typeInNewClass) match {
+                case ((alt, tpe)) :: Nil =>
+                  log(s"Arrested overloaded type in Duplicators, narrowing to ${alt.defStringSeenAs(tpe)}\n  Overload was: $memberString")
+                  Select(This(newClassOwner), alt)
+                case _ =>
+                  log(s"Could not disambiguate $memberString in Duplicators. Attempting name-based selection, but this may not end well...")
+                  nameSelection
+              }
+            }
+            else nameSelection
+          )
+          super.typed(atPos(tree.pos)(newTree), mode, pt)
 
         case This(_) if (oldClassOwner ne null) && (tree.symbol == oldClassOwner) =>
 //          val tree1 = Typed(This(newClassOwner), TypeTree(fixType(tree.tpe.widen)))

--- a/test/files/run/t6572/bar_1.scala
+++ b/test/files/run/t6572/bar_1.scala
@@ -1,0 +1,19 @@
+package bar
+
+abstract class IntBase[V] extends Base[Int, V]
+
+class DefaultIntBase[V <: IntProvider] extends IntBase[V] {
+  override protected def hashCode(key: Int) = key
+}
+
+trait IntProvider {
+  def int: Int
+}
+
+abstract class Base[@specialized K, V] {
+
+  protected def hashCode(key: K) = key.hashCode
+
+  def get(key: K): V = throw new RuntimeException
+
+}

--- a/test/files/run/t6572/foo_2.scala
+++ b/test/files/run/t6572/foo_2.scala
@@ -1,0 +1,17 @@
+//package foo
+
+import bar._
+
+class FooProvider extends IntProvider {
+  def int = 3
+}
+
+class Wrapper(users: DefaultIntBase[FooProvider]) {
+  final def user(userId: Int) = users.get(userId)
+}
+
+object Test {
+  def main(args: Array[String]) {
+    new Wrapper(new DefaultIntBase)
+  }
+}


### PR DESCRIPTION
- Backports parts of #1226
- omits the warnings for overloaded symbols after typer
  - to get rid of those, we would need a few library changes
- Adds the test case from SI-6572 provided by @ijuma after the original bug was fixed.

Review by @paulp
