### PR TITLE
SI-6370 changed ListMap apply method to produce correct error message

### DIFF
--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -13,6 +13,7 @@ package immutable
 
 import generic._
 import scala.annotation.{tailrec, bridge}
+import scala.NoSuchElementException
 
 /** $factoryInfo
  *  @since 1
@@ -155,7 +156,12 @@ extends AbstractMap[A, B]
      *  @param  k   the key
      *  @return     the value associated with the given key.
      */
-    override def apply(k: A): B1 = apply0(this, k)
+    override def apply(k: A): B1 =
+      try {
+        apply0(this, k)
+      } catch {
+        case e :NoSuchElementException => throw new NoSuchElementException("key not found: "+k)
+      }
 
     @tailrec private def apply0(cur: ListMap[A, B1], k: A): B1 = if (k == cur.key) cur.value else apply0(cur.tail, k)
 

--- a/test/files/run/t6370.scala
+++ b/test/files/run/t6370.scala
@@ -1,0 +1,12 @@
+object Test {
+
+  def main(args: Array[String]): Unit = {
+      val m = collection.immutable.ListMap( "x" -> 1 )
+      try {
+         m("y")
+      } catch {
+         case e : NoSuchElementException => assert(e.getMessage() == "key not found: y")
+      }
+
+  }
+}


### PR DESCRIPTION
Current implementation of apply uses tail recursive apply0 to get a value from a key. apply0 relies on tail method to iterate over all keys.When the list gets to its end, tail produces an 'empty map' message in its exception, which is thrown by ListMap. This change catches this exception in the apply method and change the exception message to a more appropriate 'key not found' message

review by @phaller
