### PR TITLE
Change Doc to trait to allow it to be used as a cake slice.

### DIFF
--- a/src/compiler/scala/tools/nsc/interactive/Global.scala
+++ b/src/compiler/scala/tools/nsc/interactive/Global.scala
@@ -462,6 +462,9 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
     compileRunner
   }
 
+  private def checkUpToDate(unit: RichCompilationUnit) =
+    if (!unit.isUpToDate && unit.status != JustParsed) reset(unit) // reparse previously typechecked units.
+
   /** Compile all loaded source files in the order given by `allSources`.
    */
   private[interactive] final def backgroundCompile() {
@@ -474,7 +477,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
     // ensure all loaded units are parsed
     for (s <- allSources; unit <- getUnit(s)) {
       // checkForMoreWork(NoPosition)  // disabled, as any work done here would be in an inconsistent state
-      if (!unit.isUpToDate && unit.status != JustParsed) reset(unit) // reparse previously typechecked units.
+      checkUpToDate(unit)
       parseAndEnter(unit)
       serviceParsedEntered()
     }
@@ -727,7 +730,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
         try {
           debugLog("starting targeted type check")
           typeCheck(unit)
-          println("tree not found at "+pos)
+//          println("tree not found at "+pos)
           EmptyTree
         } catch {
           case ex: TyperResult => new Locator(pos) locateIn ex.tree
@@ -758,64 +761,100 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
     respond(response)(typedTree(source, forceReload))
   }
 
-  /** Implements CompilerControl.askLinkPos */
-  private[interactive] def getLinkPos(sym: Symbol, source: SourceFile, response: Response[Position]) {
-
-    /** Find position of symbol `sym` in unit `unit`. Pre: `unit is loaded. */
-    def findLinkPos(unit: RichCompilationUnit): Position = {
-      val originalTypeParams = sym.owner.typeParams
-      parseAndEnter(unit)
-      val pre = adaptToNewRunMap(ThisType(sym.owner))
-      val rawsym = pre.typeSymbol.info.decl(sym.name)
-      val newsym = rawsym filter { alt =>
-        sym.isType || {
-          try {
-            val tp1 = pre.memberType(alt) onTypeError NoType
-            val tp2 = adaptToNewRunMap(sym.tpe) substSym (originalTypeParams, sym.owner.typeParams)
-            matchesType(tp1, tp2, false) || {
-              debugLog(s"getLinkPos matchesType($tp1, $tp2) failed")
-              val tp3 = adaptToNewRunMap(sym.tpe) substSym (originalTypeParams, alt.owner.typeParams)
-              matchesType(tp1, tp3, false) || {
-                debugLog(s"getLinkPos fallback matchesType($tp1, $tp3) failed")
-                false
-              }
-            }
-          }
-          catch {
-            case ex: ControlThrowable => throw ex
-            case ex: Throwable =>
-              println("error in hyperlinking: " + ex)
-              ex.printStackTrace()
-              false
-          }
-        }
-      }
-      if (newsym == NoSymbol) {
-        if (rawsym.exists && !rawsym.isOverloaded) rawsym.pos
-        else {
-          debugLog("link not found " + sym + " " + source + " " + pre)
-          NoPosition
-        }
-      } else if (newsym.isOverloaded) {
-        settings.uniqid.value = true
-        debugLog("link ambiguous " + sym + " " + source + " " + pre + " " + newsym.alternatives)
-        NoPosition
-      } else {
-        debugLog("link found for " + newsym + ": " + newsym.pos)
-        newsym.pos
-      }
+  private[interactive] def withTempUnit[T](source: SourceFile)(f: RichCompilationUnit => T): T =
+    getUnit(source) match {
+      case None =>
+        reloadSources(List(source))
+        try f(getUnit(source).get)
+        finally afterRunRemoveUnitOf(source)
+      case Some(unit) =>
+        f(unit)
     }
 
+  private[interactive] def forceDocComment(sym: Symbol, unit: RichCompilationUnit) {
+    // Either typer has been run and we don't find DocDef,
+    // or we force the targeted typecheck here.
+    // In both cases doc comment maps should be filled for the subject symbol.
+    val docTree =
+      unit.body find { t =>
+        t match {
+          case DocDef(_, defn) if defn.symbol eq sym => true
+          case _ => false
+        }
+      }
+
+    for (t <- docTree) {
+      debugLog("Found DocDef tree for "+sym)
+      // Cannot get a typed tree at position since DocDef range is transparent.
+      val prevPos = unit.targetPos
+      val prevInterruptsEnabled = interruptsEnabled
+      try {
+        unit.targetPos = t.pos
+        interruptsEnabled = true
+        typeCheck(unit)
+      } catch {
+        case _: TyperResult => // ignore since we are after the side effect.
+      } finally {
+        unit.targetPos = prevPos
+        interruptsEnabled = prevInterruptsEnabled
+      }
+    }
+  }
+
+  /** Find a 'mirror' of symbol `sym` in unit `unit`. Pre: `unit is loaded. */
+  private[interactive] def findMirrorSymbol(sym: Symbol, unit: RichCompilationUnit): Symbol = {
+    val originalTypeParams = sym.owner.typeParams
+    checkUpToDate(unit)
+    parseAndEnter(unit)
+    val pre = adaptToNewRunMap(ThisType(sym.owner))
+    val rawsym = pre.typeSymbol.info.decl(sym.name)
+    val newsym = rawsym filter { alt =>
+      sym.isType || {
+        try {
+          val tp1 = pre.memberType(alt) onTypeError NoType
+          val tp2 = adaptToNewRunMap(sym.tpe) substSym (originalTypeParams, sym.owner.typeParams)
+          matchesType(tp1, tp2, false) || {
+            debugLog(s"findMirrorSymbol matchesType($tp1, $tp2) failed")
+            val tp3 = adaptToNewRunMap(sym.tpe) substSym (originalTypeParams, alt.owner.typeParams)
+            matchesType(tp1, tp3, false) || {
+              debugLog(s"findMirrorSymbol fallback matchesType($tp1, $tp3) failed")
+              false
+            }
+          }
+        }
+        catch {
+          case ex: ControlThrowable => throw ex
+          case ex: Throwable =>
+            println("error in findMirrorSymbol: " + ex)
+            ex.printStackTrace()
+            false
+        }
+      }
+    }
+    if (newsym == NoSymbol) {
+      if (rawsym.exists && !rawsym.isOverloaded) rawsym
+      else {
+        debugLog("mirror not found " + sym + " " + unit.source + " " + pre)
+        NoSymbol
+      }
+    } else if (newsym.isOverloaded) {
+      settings.uniqid.value = true
+      debugLog("mirror ambiguous " + sym + " " + unit.source + " " + pre + " " + newsym.alternatives)
+      NoSymbol
+    } else {
+      debugLog("mirror found for " + newsym + ": " + newsym.pos)
+      newsym
+    }
+  }
+
+  /** Implements CompilerControl.askLinkPos */
+  private[interactive] def getLinkPos(sym: Symbol, source: SourceFile, response: Response[Position]) {
     informIDE("getLinkPos "+sym+" "+source)
     respond(response) {
       if (sym.owner.isClass) {
-        getUnit(source) match {
-          case None =>
-            reloadSources(List(source))
-            try findLinkPos(getUnit(source).get)
-            finally afterRunRemoveUnitOf(source)
-          case Some(unit) =>
-            findLinkPos(unit)
+        withTempUnit(source){ u =>
+          val m = findMirrorSymbol(sym, u)
+          if (m eq NoSymbol) NoPosition else m.pos
         }
       } else {
         debugLog("link not in class "+sym+" "+source+" "+sym.owner)

--- a/src/compiler/scala/tools/nsc/interactive/tests/core/PresentationCompilerInstance.scala
+++ b/src/compiler/scala/tools/nsc/interactive/tests/core/PresentationCompilerInstance.scala
@@ -8,7 +8,8 @@ import scala.reflect.internal.util.Position
 /** Trait encapsulating the creation of a presentation compiler's instance.*/
 private[tests] trait PresentationCompilerInstance extends TestSettings {
   protected val settings = new Settings
-  protected def docSettings: doc.Settings = new doc.Settings(_ => ())
+  protected val docSettings = new doc.Settings(_ => ())
+
   protected val compilerReporter: CompilerReporter = new InteractiveReporter {
     override def compiler = PresentationCompilerInstance.this.compiler
   }

--- a/test/files/presentation/doc.check
+++ b/test/files/presentation/doc.check
@@ -1,3 +1,4 @@
+reload: Test.scala
 body:Body(List(Paragraph(Chain(List(Summary(Chain(List(Text(This is a test comment), Text(.)))), Text(
 ))))))
 @example:Body(List(Paragraph(Chain(List(Summary(Monospace(Text("abb".permutations = Iterator(abb, bab, bba)))))))))


### PR DESCRIPTION
Change the implementation of retrieve() method.
Rename and privatize symbols in CommentFactoryBase to avoid clashes when cooking a cake.
