### PR TITLE
Booking more progress on SI-6666

### DIFF
--- a/src/compiler/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/IMain.scala
@@ -262,7 +262,9 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
   protected def newCompiler(settings: Settings, reporter: Reporter): ReplGlobal = {
     settings.outputDirs setSingleOutput virtualDirectory
     settings.exposeEmptyPackage.value = true
-    new Global(settings, reporter) with ReplGlobal
+    new Global(settings, reporter) with ReplGlobal {
+      override def toString: String = "<global>"
+    }
   }
 
   /** Parent classloader.  Overridable. */

--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -8,6 +8,7 @@ package transform
 
 import symtab._
 import Flags.{ CASE => _, _ }
+import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import matching.{ Patterns, ParallelMatching }
 
@@ -209,6 +210,8 @@ abstract class ExplicitOuter extends InfoTransform
 
     /** The first outer selection from currently transformed tree.
      *  The result is typed but not positioned.
+     *
+     * Will return `EmptyTree` if there is no outer accessor because of a premature self reference.
      */
     protected def outerValue: Tree =
       if (outerParam != NoSymbol) ID(outerParam)
@@ -218,25 +221,34 @@ abstract class ExplicitOuter extends InfoTransform
      *  The result is typed but not positioned.
      *  If the outer access is from current class and current class is final
      *  take outer field instead of accessor
+     *
+     *  Will return `EmptyTree` if there is no outer accessor because of a premature self reference.
      */
     private def outerSelect(base: Tree): Tree = {
-      val outerAcc = outerAccessor(base.tpe.typeSymbol.toInterface)
-      val currentClass = this.currentClass //todo: !!! if this line is removed, we get a build failure that protected$currentClass need an override modifier
-      // outerFld is the $outer field of the current class, if the reference can
-      // use it (i.e. reference is allowed to be of the form this.$outer),
-      // otherwise it is NoSymbol
-      val outerFld =
-        if (outerAcc.owner == currentClass &&
+      val baseSym = base.tpe.typeSymbol.toInterface
+      val outerAcc = outerAccessor(baseSym)
+      if (outerAcc == NoSymbol && baseSym.ownersIterator.exists(isUnderConstruction)) {
+         // e.g neg/t6666.scala
+         // The caller will report the error with more information.
+         EmptyTree
+      } else {
+        val currentClass = this.currentClass //todo: !!! if this line is removed, we get a build failure that protected$currentClass need an override modifier
+        // outerFld is the $outer field of the current class, if the reference can
+        // use it (i.e. reference is allowed to be of the form this.$outer),
+        // otherwise it is NoSymbol
+        val outerFld =
+          if (outerAcc.owner == currentClass &&
             base.tpe =:= currentClass.thisType &&
             outerAcc.owner.isEffectivelyFinal)
-          outerField(currentClass) suchThat (_.owner == currentClass)
-        else
-          NoSymbol
-      val path =
-        if (outerFld != NoSymbol) Select(base, outerFld)
-        else Apply(Select(base, outerAcc), Nil)
+            outerField(currentClass) suchThat (_.owner == currentClass)
+          else
+            NoSymbol
+        val path =
+          if (outerFld != NoSymbol) Select(base, outerFld)
+          else Apply(Select(base, outerAcc), Nil)
 
-      localTyper typed path
+        localTyper typed path
+      }
     }
 
     /** The path
@@ -256,6 +268,17 @@ abstract class ExplicitOuter extends InfoTransform
       else outerPath(outerSelect(base), from.outerClass, to)
     }
 
+
+    /** The stack of constructor symbols in which a call to this() or to the super
+      * constructor is active.
+      */
+    protected def isUnderConstruction(clazz: Symbol) = selfOrSuperCalls exists (_.owner == clazz)
+    protected val selfOrSuperCalls = mutable.Stack[Symbol]()
+    @inline protected def inSelfOrSuperCall[A](sym: Symbol)(a: => A) = {
+      selfOrSuperCalls push sym
+      try a finally selfOrSuperCalls.pop()
+    }
+
     override def transform(tree: Tree): Tree = {
       val savedOuterParam = outerParam
       try {
@@ -269,7 +292,10 @@ abstract class ExplicitOuter extends InfoTransform
             }
           case _ =>
         }
-        super.transform(tree)
+        if (treeInfo isSelfOrSuperConstrCall tree) // TODO also handle (and test) (treeInfo isEarlyDef tree)
+          inSelfOrSuperCall(currentOwner)(super.transform(tree))
+        else
+          super.transform(tree)
       }
       finally outerParam = savedOuterParam
     }
@@ -335,7 +361,8 @@ abstract class ExplicitOuter extends InfoTransform
 
     /** The definition tree of the outer accessor of current class
      */
-    def outerFieldDef: Tree = VAL(outerField(currentClass)) === EmptyTree
+    def outerFieldDef: Tree =
+      VAL(outerField(currentClass)) === EmptyTree
 
     /** The definition tree of the outer accessor of current class
      */
@@ -483,6 +510,9 @@ abstract class ExplicitOuter extends InfoTransform
                 val clazz = sym.owner
                 val vparamss1 =
                   if (isInner(clazz)) { // (4)
+                    if (isUnderConstruction(clazz.outerClass)) {
+                      reporter.error(tree.pos, s"Implementation restriction: ${clazz.fullLocationString} requires premature access to ${clazz.outerClass}.")
+                    }
                     val outerParam =
                       sym.newValueParameter(nme.OUTER, sym.pos) setInfo clazz.outerClass.thisType
                     ((ValDef(outerParam) setType NoType) :: vparamss.head) :: vparamss.tail

--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -269,10 +269,10 @@ abstract class ExplicitOuter extends InfoTransform
     }
 
 
-    /** The stack of constructor symbols in which a call to this() or to the super
-      * constructor is active.
+    /** The stack of class symbols in which a call to this() or to the super
+      * constructor, or early definition is active
       */
-    protected def isUnderConstruction(clazz: Symbol) = selfOrSuperCalls exists (_.owner == clazz)
+    protected def isUnderConstruction(clazz: Symbol) = selfOrSuperCalls contains clazz
     protected val selfOrSuperCalls = mutable.Stack[Symbol]()
     @inline protected def inSelfOrSuperCall[A](sym: Symbol)(a: => A) = {
       selfOrSuperCalls push sym
@@ -292,8 +292,8 @@ abstract class ExplicitOuter extends InfoTransform
             }
           case _ =>
         }
-        if (treeInfo isSelfOrSuperConstrCall tree) // TODO also handle (and test) (treeInfo isEarlyDef tree)
-          inSelfOrSuperCall(currentOwner)(super.transform(tree))
+        if ((treeInfo isSelfOrSuperConstrCall tree) || (treeInfo isEarlyDef tree))
+          inSelfOrSuperCall(currentOwner.owner)(super.transform(tree))
         else
           super.transform(tree)
       }

--- a/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
+++ b/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
@@ -317,7 +317,7 @@ abstract class LambdaLift extends InfoTransform {
       else searchIn(currentOwner)
     }
 
-    private def memberRef(sym: Symbol) = {
+    private def memberRef(sym: Symbol): Tree = {
       val clazz = sym.owner.enclClass
       //Console.println("memberRef from "+currentClass+" to "+sym+" in "+clazz)
       def prematureSelfReference() {
@@ -331,12 +331,17 @@ abstract class LambdaLift extends InfoTransform {
         if (clazz == currentClass) gen.mkAttributedThis(clazz)
         else {
           sym resetFlag (LOCAL | PRIVATE)
-          if (selfOrSuperCalls exists (_.owner == clazz)) {
+          if (isUnderConstruction(clazz)) {
             prematureSelfReference()
             EmptyTree
           }
           else if (clazz.isStaticOwner) gen.mkAttributedQualifier(clazz.thisType)
-          else outerPath(outerValue, currentClass.outerClass, clazz)
+          else {
+            outerValue match {
+              case EmptyTree => prematureSelfReference(); return EmptyTree
+              case o         => outerPath(o, currentClass.outerClass, clazz)
+            }
+          }
         }
       Select(qual, sym) setType sym.tpe
     }
@@ -507,25 +512,13 @@ abstract class LambdaLift extends InfoTransform {
 
     private def preTransform(tree: Tree) = super.transform(tree) setType lifted(tree.tpe)
 
-    /** The stack of constructor symbols in which a call to this() or to the super
-      * constructor is active.
-      */
-    private val selfOrSuperCalls = mutable.Stack[Symbol]()
-    @inline private def inSelfOrSuperCall[A](sym: Symbol)(a: => A) = try {
-      selfOrSuperCalls push sym
-      a
-    } finally selfOrSuperCalls.pop()
-
     override def transform(tree: Tree): Tree = tree match {
       case Select(ReferenceToBoxed(idt), elem) if elem == nme.elem =>
         postTransform(preTransform(idt), isBoxedRef = false)
       case ReferenceToBoxed(idt) =>
         postTransform(preTransform(idt), isBoxedRef = true)
       case _ =>
-        def transformTree = postTransform(preTransform(tree))
-        if (treeInfo isSelfOrSuperConstrCall tree)
-          inSelfOrSuperCall(currentOwner)(transformTree)
-        else transformTree
+        postTransform(preTransform(tree))
     }
 
     /** Transform statements and add lifted definitions to them. */

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -123,9 +123,12 @@ trait Namers extends MethodSynthesis {
     def setPrivateWithin(tree: MemberDef, sym: Symbol): Symbol =
       setPrivateWithin(tree, sym, tree.mods)
 
-    def inConstructorFlag: Long =
-      if (owner.isConstructor && !context.inConstructorSuffix || owner.isEarlyInitialized) INCONSTRUCTOR
-      else 0l
+    def inConstructorFlag: Long = {
+      val termOwnedContexts: List[Context] = context.enclosingContextChain.takeWhile(_.owner.isTerm)
+      val constructorNonSuffix = termOwnedContexts exists (c => c.owner.isConstructor && !c.inConstructorSuffix)
+      val earlyInit            = termOwnedContexts exists (_.owner.isEarlyInitialized)
+      if (constructorNonSuffix || earlyInit) INCONSTRUCTOR else 0L
+    }
 
     def moduleClassFlags(moduleFlags: Long) =
       (moduleFlags & ModuleToClassFlags) | inConstructorFlag

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2867,6 +2867,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     final override def isNonClassType = false
     final override def isAbstractType = false
     final override def isAliasType = false
+    final override def isContravariant = false
 
     override def isAbstractClass           = this hasFlag ABSTRACT
     override def isCaseClass               = this hasFlag CASE

--- a/test/files/neg/t6666.check
+++ b/test/files/neg/t6666.check
@@ -16,25 +16,19 @@ t6666.scala:54: error: Implementation restriction: access of value x$7 in class 
 t6666.scala:58: error: Implementation restriction: access of method x$8 in class C3 from anonymous class 9, would require illegal premature access to the unconstructed `this` of class C3
   F.hof(() => x)
               ^
-t6666.scala:62: error: Implementation restriction: access of method x$9 in class C4 from object Nested$5, would require illegal premature access to the unconstructed `this` of class C4
+t6666.scala:62: error: Implementation restriction: access of method x$9 in class C4 from object Nested$3, would require illegal premature access to the unconstructed `this` of class C4
   object Nested { def xx = x}
                            ^
-t6666.scala:68: error: Implementation restriction: access of method x$10 in class C5 from object Nested$6, would require illegal premature access to the unconstructed `this` of class C5
-    object Nested { def xx = x}
-                             ^
-t6666.scala:83: error: Implementation restriction: access of method x$12 in class C11 from anonymous class 12, would require illegal premature access to the unconstructed `this` of class C11
+t6666.scala:76: error: Implementation restriction: access of method x$11 in class C11 from anonymous class 12, would require illegal premature access to the unconstructed `this` of class C11
       F.byname(x)
                ^
-t6666.scala:102: error: Implementation restriction: access of method x$13 in class C13 from anonymous class 13, would require illegal premature access to the unconstructed `this` of class C13
+t6666.scala:95: error: Implementation restriction: access of method x$12 in class C13 from anonymous class 13, would require illegal premature access to the unconstructed `this` of class C13
       F.hof(() => x)
                   ^
-t6666.scala:111: error: Implementation restriction: access of method x$14 in class C14 from object Nested$7, would require illegal premature access to the unconstructed `this` of class C14
+t6666.scala:104: error: Implementation restriction: access of method x$13 in class C14 from object Nested$4, would require illegal premature access to the unconstructed `this` of class C14
       object Nested { def xx = x}
                                ^
-t6666.scala:122: error: Implementation restriction: access of method x$15 in class C15 from object Nested$8, would require illegal premature access to the unconstructed `this` of class C15
-        object Nested { def xx = x}
-                                 ^
-t6666.scala:131: error: Implementation restriction: access of method foo$1 in class COuter from class CInner$1, would require illegal premature access to the unconstructed `this` of class COuter
+t6666.scala:112: error: Implementation restriction: access of method foo$1 in class COuter from class CInner$1, would require illegal premature access to the unconstructed `this` of class COuter
   class CInner extends C({foo})
                           ^
-13 errors found
+11 errors found

--- a/test/files/neg/t6666.check
+++ b/test/files/neg/t6666.check
@@ -16,7 +16,7 @@ t6666.scala:54: error: Implementation restriction: access of value x$7 in class 
 t6666.scala:58: error: Implementation restriction: access of method x$8 in class C3 from anonymous class 9, would require illegal premature access to the unconstructed `this` of class C3
   F.hof(() => x)
               ^
-t6666.scala:62: error: Implementation restriction: access of method x$9 in class C4 from object Nested$3, would require illegal premature access to the unconstructed `this` of class C4
+t6666.scala:62: error: Implementation restriction: access of method x$9 in class C4 from object Nested$4, would require illegal premature access to the unconstructed `this` of class C4
   object Nested { def xx = x}
                            ^
 t6666.scala:76: error: Implementation restriction: access of method x$11 in class C11 from anonymous class 12, would require illegal premature access to the unconstructed `this` of class C11
@@ -25,10 +25,13 @@ t6666.scala:76: error: Implementation restriction: access of method x$11 in clas
 t6666.scala:95: error: Implementation restriction: access of method x$12 in class C13 from anonymous class 13, would require illegal premature access to the unconstructed `this` of class C13
       F.hof(() => x)
                   ^
-t6666.scala:104: error: Implementation restriction: access of method x$13 in class C14 from object Nested$4, would require illegal premature access to the unconstructed `this` of class C14
+t6666.scala:104: error: Implementation restriction: access of method x$13 in class C14 from object Nested$5, would require illegal premature access to the unconstructed `this` of class C14
       object Nested { def xx = x}
                                ^
 t6666.scala:112: error: Implementation restriction: access of method foo$1 in class COuter from class CInner$1, would require illegal premature access to the unconstructed `this` of class COuter
   class CInner extends C({foo})
                           ^
-11 errors found
+t6666.scala:118: error: Implementation restriction: access of method x$14 in class CEarly from object Nested$6, would require illegal premature access to the unconstructed `this` of class CEarly
+    object Nested { def xx = x}
+                             ^
+12 errors found

--- a/test/files/neg/t6666.scala
+++ b/test/files/neg/t6666.scala
@@ -62,13 +62,6 @@ class C4 extends C({
   object Nested { def xx = x}
   Nested.xx
 })
-class C5 extends C({
-  def x = "".toString
-  val y = {
-    object Nested { def xx = x}
-    Nested.xx
-  }
-})
 
 // okay, for same reason as O6
 class C6 extends C({
@@ -110,18 +103,6 @@ class C14(a: Any) {
       def x = "".toString
       object Nested { def xx = x}
       Nested.xx
-    })
-  }
-}
-
-class C15(a: Any) {
-  def this() = {
-    this({
-      def x = "".toString
-      val y = {
-        object Nested { def xx = x}
-        Nested.xx
-      }
     })
   }
 }

--- a/test/files/neg/t6666.scala
+++ b/test/files/neg/t6666.scala
@@ -111,3 +111,11 @@ class COuter extends C({
   def foo = 0
   class CInner extends C({foo})
 })
+
+
+class CEarly(a: Any) extends {
+  val early = {def x = "".toString
+    object Nested { def xx = x}
+    Nested.xx
+  }
+} with AnyRef 

--- a/test/files/neg/t6666b.check
+++ b/test/files/neg/t6666b.check
@@ -1,0 +1,4 @@
+t6666b.scala:6: error: Implementation restriction: access of object TreeOrd$1 from object TreeOrd$2, would require illegal premature access to the unconstructed `this` of class Test
+    implicit object TreeOrd extends Ordering[K](){
+                    ^
+one error found

--- a/test/files/neg/t6666b.check
+++ b/test/files/neg/t6666b.check
@@ -1,4 +1,7 @@
-t6666b.scala:6: error: Implementation restriction: access of object TreeOrd$1 from object TreeOrd$2, would require illegal premature access to the unconstructed `this` of class Test
-    implicit object TreeOrd extends Ordering[K](){
-                    ^
-one error found
+t6666b.scala:11: error: Implementation restriction: access of method x$1 in class C5 from object Nested$3, would require illegal premature access to the unconstructed `this` of class C5
+    object Nested { def xx = x}
+                             ^
+t6666b.scala:22: error: Implementation restriction: access of method x$2 in class C15 from object Nested$4, would require illegal premature access to the unconstructed `this` of class C15
+        object Nested { def xx = x}
+                                 ^
+two errors found

--- a/test/files/neg/t6666b.scala
+++ b/test/files/neg/t6666b.scala
@@ -1,0 +1,17 @@
+import scala.collection.immutable.TreeMap
+import scala.math.Ordering
+
+class Test[K](param:TreeMap[K,Int]){
+  def this() = this({
+    implicit object TreeOrd extends Ordering[K](){
+      def compare(a: K, b: K) = {
+        -1
+      }
+    }
+    new TreeMap[K, Int]()
+  })
+}
+
+object Test extends App {
+  new Test()
+}

--- a/test/files/neg/t6666b.scala
+++ b/test/files/neg/t6666b.scala
@@ -1,17 +1,27 @@
-import scala.collection.immutable.TreeMap
-import scala.math.Ordering
-
-class Test[K](param:TreeMap[K,Int]){
-  def this() = this({
-    implicit object TreeOrd extends Ordering[K](){
-      def compare(a: K, b: K) = {
-        -1
-      }
-    }
-    new TreeMap[K, Int]()
-  })
+class C(a: Any)
+object F {
+  def byname(a: => Any) = println(a)
+  def hof(a: () => Any) = println(a())
 }
 
-object Test extends App {
-  new Test()
+
+class C5 extends C({
+  def x = "".toString
+  val y = {
+    object Nested { def xx = x}
+    Nested.xx
+  }
+})
+
+
+class C15(a: Any) {
+  def this() = {
+    this({
+      def x = "".toString
+      val y = {
+        object Nested { def xx = x}
+        Nested.xx
+      }
+    })
+  }
 }

--- a/test/files/neg/t6666c.check
+++ b/test/files/neg/t6666c.check
@@ -1,0 +1,10 @@
+t6666c.scala:2: error: Implementation restriction: access of method x$1 in class D from object X$4, would require illegal premature access to the unconstructed `this` of class D
+class D extends C({def x = 0; object X { x }})
+                                         ^
+t6666c.scala:5: error: Implementation restriction: access of method x$2 in class D1 from object X$5, would require illegal premature access to the unconstructed `this` of class D1
+class D1 extends C1({def x = 0; () => {object X { x }}})
+                                                  ^
+t6666c.scala:8: error: Implementation restriction: access of method x$3 from object X$6, would require illegal premature access to the unconstructed `this` of anonymous class 2
+class D2 extends C2({def x = 0; object X { x }})
+                                           ^
+three errors found

--- a/test/files/neg/t6666c.scala
+++ b/test/files/neg/t6666c.scala
@@ -1,0 +1,8 @@
+class C(a: Any)
+class D extends C({def x = 0; object X { x }})
+
+class C1(a: () => Any)
+class D1 extends C1({def x = 0; () => {object X { x }}})
+
+class C2(a: => Any)
+class D2 extends C2({def x = 0; object X { x }})

--- a/test/files/neg/t6666d.check
+++ b/test/files/neg/t6666d.check
@@ -1,0 +1,4 @@
+t6666d.scala:7: error: Implementation restriction: access of object TreeOrd$1 from object TreeOrd$2, would require illegal premature access to the unconstructed `this` of class Test
+    implicit object TreeOrd extends Ordering[K](){
+                    ^
+one error found

--- a/test/files/neg/t6666d.scala
+++ b/test/files/neg/t6666d.scala
@@ -1,0 +1,18 @@
+
+import scala.collection.immutable.TreeMap
+import scala.math.Ordering
+
+class Test[K](param:TreeMap[K,Int]){
+  def this() = this({
+    implicit object TreeOrd extends Ordering[K](){
+      def compare(a: K, b: K) = {
+        -1
+      }
+    }
+    new TreeMap[K, Int]()
+  })
+}
+
+object Test extends App {
+  new Test()
+}

--- a/test/files/neg/t6666e.check
+++ b/test/files/neg/t6666e.check
@@ -1,0 +1,4 @@
+t6666e.scala:8: error: Implementation restriction: anonymous class $anonfun requires premature access to class Crash.
+    this(Nil.collect{case x =>})
+                    ^
+one error found

--- a/test/files/neg/t6666e.scala
+++ b/test/files/neg/t6666e.scala
@@ -1,0 +1,9 @@
+
+import scala.collection.immutable.TreeMap
+import scala.math.Ordering
+
+
+class Crash(a: Any) {
+  def this() =
+    this(Nil.collect{case x =>})
+}

--- a/test/files/run/class-symbol-contravariant.check
+++ b/test/files/run/class-symbol-contravariant.check
@@ -1,0 +1,36 @@
+Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> :power
+** Power User mode enabled - BEEP WHIR GYVE **
+** :phase has been set to 'typer'.          **
+** scala.tools.nsc._ has been imported      **
+** global._, definitions._ also imported    **
+** Try  :help, :vals, power.<tab>           **
+
+scala> val u = rootMirror.universe
+u: $r.intp.global.type = <global>
+
+scala> import u._, scala.reflect.internal.Flags
+import u._
+import scala.reflect.internal.Flags
+
+scala> class C
+defined class C
+
+scala> val sym = u.typeOf[C].typeSymbol
+sym: u.Symbol = class C
+
+scala> sym.isContravariant
+res0: Boolean = false
+
+scala> sym setFlag Flags.INCONSTRUCTOR
+res1: sym.type = class C
+
+scala> sym.isClassLocalToConstructor
+res2: Boolean = true
+
+scala> sym.isContravariant // was true
+res3: Boolean = false
+
+scala> 

--- a/test/files/run/class-symbol-contravariant.scala
+++ b/test/files/run/class-symbol-contravariant.scala
@@ -1,0 +1,15 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  override def code = """
+  |:power
+  |val u = rootMirror.universe
+  |import u._, scala.reflect.internal.Flags
+  |class C
+  |val sym = u.typeOf[C].typeSymbol
+  |sym.isContravariant
+  |sym setFlag Flags.INCONSTRUCTOR
+  |sym.isClassLocalToConstructor
+  |sym.isContravariant // was true
+  |""".stripMargin.trim
+}

--- a/test/files/run/t6259.scala
+++ b/test/files/run/t6259.scala
@@ -1,5 +1,3 @@
-package t6259
-
 import scala.reflect.runtime.universe._
 
 class A[X](implicit val tt: TypeTag[X]) {}
@@ -17,15 +15,14 @@ class G {
   object H extends A[String]
 }
 
-object Test {
+object HasX {
   val x = {
     object InVal extends A[String]
+    InVal
     5
   }
 
 }
-
-// Note: Both of these fail right now.
 
 trait NeedsEarly {
  val x: AnyRef
@@ -44,4 +41,16 @@ object DoubleOk extends DoubleTrouble[String]({
   object InnerTrouble extends A[String]; 
   InnerTrouble 
 })
+
+object Test extends App {
+  B
+  C.D
+  val e = new E {}; e.F
+  val g = new G; g.H
+
+  //locally(HasX.x)   TODO sort out VerifyError in HasX$InVal$2$.<init> by accounting for nesting in Namer#inConstructorFlag
+  // locally(Early.x) TODO sort out VerifyError in Early$.<init>
+  // DoubleOk         TODO sort out VerifyError in DoubleOk$.<init>
+}
+
 

--- a/test/files/run/t6259.scala
+++ b/test/files/run/t6259.scala
@@ -48,7 +48,7 @@ object Test extends App {
   val e = new E {}; e.F
   val g = new G; g.H
 
-  //locally(HasX.x)   TODO sort out VerifyError in HasX$InVal$2$.<init> by accounting for nesting in Namer#inConstructorFlag
+  locally(HasX.x)
   // locally(Early.x) TODO sort out VerifyError in Early$.<init>
   // DoubleOk         TODO sort out VerifyError in DoubleOk$.<init>
 }

--- a/test/files/run/t6506.scala
+++ b/test/files/run/t6506.scala
@@ -1,0 +1,8 @@
+object Test {
+  def main(args: Array[String]) {
+    new WL(new {} #:: S) with T
+  }
+  object S { def #::(a: Any): Any = () }
+  trait T
+  class WL(a: Any)
+}

--- a/test/files/run/t6666a.scala
+++ b/test/files/run/t6666a.scala
@@ -1,0 +1,16 @@
+class A(a: Any)
+
+object Test {
+  def main(args: Array[String]): Unit = {
+  }
+
+  val x: Unit = {
+    object InVal extends A({
+      new {}           // okay
+      val o = {new {}} // nesting triggers a VerifyError.
+      null
+    });
+    InVal;
+    ()
+  };
+}

--- a/test/files/run/t6957.scala
+++ b/test/files/run/t6957.scala
@@ -1,0 +1,8 @@
+object Test {
+  def main(args: Array[String]) {
+    class Foo
+    class Parent(f:Foo)
+    class Child extends Parent({val x=new Foo{}; x})
+    new Child
+  }
+}


### PR DESCRIPTION
- Avoids unneeded outer pointers for classes nested indirectly in self/super calls
- Expands implementation restriction to prevent verify errors in early initializers

Closes SI-6259 and SI-6506; a bit more work is needed on SI-6666/SI-6957.

Review by @paulp / @JamesIry.

I'll warn you up front that there is some less than beautiful code in `ExplicitOuter` to communicate these errors as implementation restrictions, rather than crashes.
