### PR TITLE
SI-7009: `@throws` annotation synthesized incorrectly

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
@@ -1018,7 +1018,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
       if (needsAnnotation) {
         val c   = Constant(RemoteExceptionClass.tpe)
         val arg = Literal(c) setType c.tpe
-        meth.addAnnotation(ThrowsClass, arg)
+        meth.addAnnotation(appliedType(ThrowsClass, c.tpe), arg)
       }
     }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenJVM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenJVM.scala
@@ -888,7 +888,7 @@ abstract class GenJVM extends SubComponent with GenJVMUtil with GenAndroid with 
       if (needsAnnotation) {
         val c   = Constant(RemoteExceptionClass.tpe)
         val arg = Literal(c) setType c.tpe
-        meth.addAnnotation(ThrowsClass, arg)
+        meth.addAnnotation(appliedType(ThrowsClass, c.tpe), arg)
       }
     }
 

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -1583,8 +1583,21 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       setAnnotations(annot :: annotations)
 
     // Convenience for the overwhelmingly common case
-    def addAnnotation(sym: Symbol, args: Tree*): this.type =
+    def addAnnotation(sym: Symbol, args: Tree*): this.type = {
+      // The assertion below is meant to prevent from issues like SI-7009 but it's disabled
+      // due to problems with cycles while compiling Scala library. It's rather shocking that
+      // just checking if sym is monomorphic type introduces nasty cycles. We are definitively
+      // forcing too much because monomorphism is a local property of a type that can be checked
+      // syntactically
+      // assert(sym.initialize.isMonomorphicType, sym)
       addAnnotation(AnnotationInfo(sym.tpe, args.toList, Nil))
+    }
+
+    /** Use that variant if you want to pass (for example) an applied type */
+    def addAnnotation(tp: Type, args: Tree*): this.type = {
+      assert(tp.typeParams.isEmpty, tp)
+      addAnnotation(AnnotationInfo(tp, args.toList, Nil))
+    }
 
 // ------ comparisons ----------------------------------------------------------------
 

--- a/test/files/jvm/throws-annot-from-java.check
+++ b/test/files/jvm/throws-annot-from-java.check
@@ -1,0 +1,47 @@
+Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> :power
+** Power User mode enabled - BEEP WHIR GYVE **
+** :phase has been set to 'typer'.          **
+** scala.tools.nsc._ has been imported      **
+** global._, definitions._ also imported    **
+** Try  :help, :vals, power.<tab>           **
+
+scala> :paste
+// Entering paste mode (ctrl-D to finish)
+
+{
+  val clazz = rootMirror.getClassByName(newTermName("test.ThrowsDeclaration_2"));
+  {
+  	val method = clazz.info.member(newTermName("foo"))
+  	val throwsAnn = method.annotations.head
+  	val atp = throwsAnn.atp
+  	println("foo")
+  	println("atp.typeParams.isEmpty: " + atp.typeParams.isEmpty)
+  	println(throwsAnn)
+  }
+  println
+
+  {
+  	val method = clazz.info.member(newTermName("bar"))
+  	val throwsAnn = method.annotations.head
+  	val Literal(const) = throwsAnn.args.head
+  	val tp = const.typeValue
+  	println("bar")
+  	println("tp.typeParams.isEmpty: " + tp.typeParams.isEmpty)
+  	println(throwsAnn)
+  }
+}
+
+// Exiting paste mode, now interpreting.
+
+foo
+atp.typeParams.isEmpty: false
+throws(classOf[java.lang.IllegalStateException])
+
+bar
+tp.typeParams.isEmpty: false
+throws(classOf[test.PolymorphicException])
+
+scala> 

--- a/test/files/jvm/throws-annot-from-java.check
+++ b/test/files/jvm/throws-annot-from-java.check
@@ -37,11 +37,11 @@ scala> :paste
 // Exiting paste mode, now interpreting.
 
 foo
-atp.typeParams.isEmpty: false
-throws(classOf[java.lang.IllegalStateException])
+atp.typeParams.isEmpty: true
+throws[IllegalStateException](classOf[java.lang.IllegalStateException])
 
 bar
-tp.typeParams.isEmpty: false
-throws(classOf[test.PolymorphicException])
+tp.typeParams.isEmpty: true
+throws[test.PolymorphicException[_]](classOf[test.PolymorphicException])
 
 scala> 

--- a/test/files/jvm/throws-annot-from-java/PolymorphicException_1.scala
+++ b/test/files/jvm/throws-annot-from-java/PolymorphicException_1.scala
@@ -1,0 +1,3 @@
+package test
+
+class PolymorphicException[T] extends Exception

--- a/test/files/jvm/throws-annot-from-java/Test_3.scala
+++ b/test/files/jvm/throws-annot-from-java/Test_3.scala
@@ -1,0 +1,29 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+	def code = """:power
+:paste
+{
+  val clazz = rootMirror.getClassByName(newTermName("test.ThrowsDeclaration_2"));
+  {
+  	val method = clazz.info.member(newTermName("foo"))
+  	val throwsAnn = method.annotations.head
+  	val atp = throwsAnn.atp
+  	println("foo")
+  	println("atp.typeParams.isEmpty: " + atp.typeParams.isEmpty)
+  	println(throwsAnn)
+  }
+  println
+
+  {
+  	val method = clazz.info.member(newTermName("bar"))
+  	val throwsAnn = method.annotations.head
+  	val Literal(const) = throwsAnn.args.head
+  	val tp = const.typeValue
+  	println("bar")
+  	println("tp.typeParams.isEmpty: " + tp.typeParams.isEmpty)
+  	println(throwsAnn)
+  }
+}
+"""
+}

--- a/test/files/jvm/throws-annot-from-java/ThrowsDeclaration_2.java
+++ b/test/files/jvm/throws-annot-from-java/ThrowsDeclaration_2.java
@@ -1,0 +1,6 @@
+package test;
+
+public class ThrowsDeclaration_2 {
+	public void foo() throws IllegalStateException {};
+	public void bar() throws PolymorphicException {};
+}


### PR DESCRIPTION
The 990b3c7 made `scala.throws` annotation polymorphic but forgot to
adapt compiler code that synthesizes it, e.g. when parsing class files.

The consequence was that we would get non-deterministically either
`scala.throws` or `scala.throws[T]` as a type for synthesized annotation.
The reason is that `Symbol.addAnnotation` would call `tpe` method which
does not initialization of symbol so type parameters list would not be
determined correctly. Only if info of that symbol was forced for other
reason we would get `scala.throws[T]`. That non-deterministic behavior
was observed in sbt's incremental compiler.

Another problem we have is that Scala allows polymorphic exceptions
so in ClassfileParser we could synthesize `@throws` annotation with
wrong (polymorphic) type applied. In such case the best we can do
is to convert such type to monomorphic one by introducing existentials.

Here's list of changes this commit introduces:
- The `Symbol.addAnnotation` that takes symbol as argument asserts
  that the type represented by that symbol is monomorphic (disabled
  due to cycles; see comments in the code)
- Introduce `Symbol.addAnnotation` overload that allows us to pass
  an applied type
- Change all places where polymorphic annotations are synthesized
  to pass an applied type
- Handle polymorphic exception types in
  `ClassfileParser.parseExceptions`

Fixes SI-7009.
