### PR TITLE
Extractors for value class trees.

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/TreeInfo.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeInfo.scala
@@ -14,6 +14,65 @@ package ast
 abstract class TreeInfo extends scala.reflect.internal.TreeInfo {
   val global: Global
   import global._
+  import definitions._
+
+  // arg1.op(arg2) returns (arg1, op.symbol, arg2)
+  object BinaryOp {
+    def unapply(t: Tree): Option[(Tree, Symbol, Tree)] = t match {
+      case Apply(sel @ Select(arg1, _), arg2 :: Nil) => Some((arg1, sel.symbol, arg2))
+      case _                                         => None
+    }
+  }
+  // recv.op[T1, ...] returns (recv, op.symbol, type argument types)
+  object TypeApplyOp {
+    def unapply(t: Tree): Option[(Tree, Symbol, List[Type])] = t match {
+      case Apply(TypeApply(sel @ Select(Apply(recv, Nil), _), targs), Nil) => Some((recv, sel.symbol, targs map (_.tpe)))
+      case _                                                               => None
+    }
+  }
+  // x.asInstanceOf[T] returns (x, typeOf[T])
+  object AsInstanceOf {
+    def unapply(t: Tree): Option[(Tree, Type)] = t match {
+      case TypeApplyOp(recv, Object_asInstanceOf, tpe :: Nil) => Some((recv, tpe))
+      case _                                                  => None
+    }
+  }
+
+  // Extractors for value classes.
+  object ValueClass {
+    def isValueClass(tpt: Tree)                = enteringErasure(tpt.tpe.typeSymbol.isDerivedValueClass)
+    def valueUnbox(tpe: Type)                  = tpe.typeSymbol.derivedValueClassUnbox
+    def isValueClassOp(tpt1: Tree, tpt2: Tree) = enteringErasure(isValueClass(tpt1) && tpt2.tpe.typeSymbol == tpt1.tpe.typeSymbol)
+
+    // arg1.op(arg2) where arg1 and arg2 are the same boxed value class. Returns unboxed values.
+    object BinaryOp {
+      def unapply(t: Tree): Option[(Tree, Symbol, Tree)] = t match {
+        case Apply(sel @ Select(Box(t1, arg1), _), Box(t2, arg2) :: Nil) if isValueClassOp(t1, t2) => Some((arg1, sel.symbol, arg2))
+        case _                                                                                     => None
+      }
+    }
+    // x.underlying() where x is a value class and underlying is its field.
+    object Underlying {
+      def unapply(t: Tree): Option[Tree] = t match {
+        case Apply(sel @ Select(Box(tpt, arg), _), Nil) if sel.symbol == valueUnbox(tpt.tpe) => Some(arg)
+        case _                                                                               => None
+      }
+    }
+    // new Boxed(underlying).  Returns "Boxed" and underlying.
+    object Box {
+      def unapply(t: Tree): Option[(Tree, Tree)] = t match {
+        case Apply(Select(New(tpt), nme.CONSTRUCTOR), arg :: Nil) => Some((tpt, arg))
+        case _                                                    => None
+      }
+    }
+    // x.asInstanceOf[T] where x is a call to a value class's unbox method.  Returns the underlying value of the receiving instance.
+    object Cast {
+      def unapply(t: Tree): Option[Tree] = t match {
+        case AsInstanceOf(sel @ Select(arg, _), tpe) if sel.symbol == valueUnbox(tpe) => Some(arg)
+        case _                                                                        => None
+      }
+    }
+  }
 
   /** Is tree legal as a member definition of an interface?
    */

--- a/test/files/run/t6028.check
+++ b/test/files/run/t6028.check
@@ -48,7 +48,7 @@ package <empty> {
       };
       <synthetic> <paramaccessor> <artifact> private[this] val $outer: T = _;
       <synthetic> <stable> <artifact> def T$MethodLocalObject$$$outer(): T = MethodLocalObject$2.this.$outer;
-      <synthetic> <stable> <artifact> def T$MethodLocalTrait$$$outer(): T = MethodLocalObject$2.this.$outer
+      <synthetic> <stable> <artifact> def T$MethodLocalTrait$$$outer(): T = MethodLocalObject$2.this.$outer.$asInstanceOf[T]()
     };
     final <stable> private[this] def MethodLocalObject$1(barParam$1: Int, MethodLocalObject$module$1: runtime.VolatileObjectRef): T#MethodLocalObject$2.type = {
       MethodLocalObject$module$1.elem = new T#MethodLocalObject$2.type(T.this, barParam$1);


### PR DESCRIPTION
Salvaged from work six months ago on value class bugs. Seemed like
a shame to lose it (look at the "after" in posterasure.) There may
be some modest overlap with some other tree extractors; I suggest
that tree extractors are not amenable to one-size-fits-all-ness,
and modest overlap should be tolerated, maybe even embraced.

I admit ignorance as to what happend with t6028.check.
