### PR TITLE
SI-6516, macros comparing types with == instead of =:=.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -452,7 +452,7 @@ trait Macros extends scala.tools.reflect.FastTrack with Traces {
         if (aparam.name != rparam.name && !rparam.isSynthetic) MacroImplParamNameMismatchError(aparam, rparam)
         if (isRepeated(aparam) ^ isRepeated(rparam)) MacroImplVarargMismatchError(aparam, rparam)
         val aparamtpe = aparam.tpe.dealias match {
-          case RefinedType(List(tpe), Scope(sym)) if tpe == MacroContextClass.tpe && sym.allOverriddenSymbols.contains(MacroContextPrefixType) => tpe
+          case RefinedType(List(tpe), Scope(sym)) if tpe =:= MacroContextClass.tpe && sym.allOverriddenSymbols.contains(MacroContextPrefixType) => tpe
           case tpe => tpe
         }
         checkMacroImplParamTypeMismatch(atpeToRtpe(aparamtpe), rparam)

--- a/test/files/pos/t6516.scala
+++ b/test/files/pos/t6516.scala
@@ -1,0 +1,19 @@
+import scala.language.experimental.macros
+import scala.reflect.macros.Context
+import scala.collection.TraversableLike
+
+// This one compiles
+object Test {
+  type Alias[T, CC[_]] = Context { type PrefixType = TraversableLike[T, CC[T]] }
+  def f() = macro f_impl
+  def f_impl(c: Alias[Int, List])() = ???
+}
+
+// This one doesn't
+object Test2 {
+  type Ctx = scala.reflect.macros.Context
+  type Alias[T, CC[_]] = Ctx { type PrefixType = TraversableLike[T, CC[T]] }
+
+  def f() = macro f_impl
+  def f_impl(c: Alias[Int, List])() = ???
+}


### PR DESCRIPTION
I gift-wrapped this ticket four months ago:

  'I think it will be enough to say "tpe =:= MacroContextClass.tpe"
   rather than == .'

Indeed. Had to open my own gift. Thanks, paulp!
