### PR TITLE
Fix access to empty package from the repl.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3981,7 +3981,8 @@ trait Typers extends Adaptations with Tags {
 
       // Lookup in the given qualifier.  Used in last-ditch efforts by typedIdent and typedSelect.
       def lookupInRoot(name: Name): Symbol  = lookupInOwner(rootMirror.RootClass, name)
-      def lookupInEmpty(name: Name): Symbol = lookupInOwner(rootMirror.EmptyPackageClass, name)
+      def lookupInEmpty(name: Name): Symbol = rootMirror.EmptyPackageClass.info member name
+
       def lookupInQualifier(qual: Tree, name: Name): Symbol = (
         if (name == nme.ERROR || qual.tpe.widen.isErroneous)
           NoSymbol
@@ -4775,7 +4776,7 @@ trait Typers extends Adaptations with Tags {
        *                   (2) Change imported symbols to selections
        */
       def typedIdent(tree: Tree, name: Name): Tree = {
-        // setting to enable unqualified idents in empty package
+        // setting to enable unqualified idents in empty package (used by the repl)
         def inEmptyPackage = if (settings.exposeEmptyPackage.value) lookupInEmpty(name) else NoSymbol
 
         def issue(err: AbsTypeError) = {

--- a/test/files/run/repl-empty-package.check
+++ b/test/files/run/repl-empty-package.check
@@ -1,0 +1,7 @@
+Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> println(Bippy.bippy)
+bippy!
+
+scala> 

--- a/test/files/run/repl-empty-package/s_1.scala
+++ b/test/files/run/repl-empty-package/s_1.scala
@@ -1,0 +1,3 @@
+object Bippy {
+  def bippy = "bippy!"
+}

--- a/test/files/run/repl-empty-package/s_2.scala
+++ b/test/files/run/repl-empty-package/s_2.scala
@@ -1,0 +1,5 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  def code = "println(Bippy.bippy)"
+}


### PR DESCRIPTION
It seems that way back in f5c336d566 three months ago I
booched the repl's ability to get at the empty package.
I've noticed this a hundred times but strangely it has not
been reported by anyone else. Perhaps you are all religious
package users. In any case, it is back.
