### PR TITLE
SI-6728 Fixes crash in parser on incomplete for expression

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
@@ -258,7 +258,7 @@ abstract class TreeBuilder {
 
   /** Create tree representing a while loop */
   def makeWhile(lname: TermName, cond: Tree, body: Tree): Tree = {
-    val continu = atPos(o2p(body.pos.endOrPoint)) { Apply(Ident(lname), Nil) }
+    val continu = atPos(o2p(body.pos pointOrElse wrappingPos(List(cond, body)).pos.endOrPoint)) { Apply(Ident(lname), Nil) }
     val rhs = If(cond, Block(List(body), continu), Literal(Constant()))
     LabelDef(lname, Nil, rhs)
   }

--- a/src/reflect/scala/reflect/internal/util/Position.scala
+++ b/src/reflect/scala/reflect/internal/util/Position.scala
@@ -91,7 +91,7 @@ abstract class Position extends scala.reflect.api.Position { self =>
   /** An optional value containing the source file referred to by this position, or
    *  None if not defined.
    */
-  def source: SourceFile = throw new UnsupportedOperationException("Position.source")
+  def source: SourceFile = throw new UnsupportedOperationException(s"Position.source on ${this.getClass}")
 
   /** Is this position neither a NoPosition nor a FakePosition?
    *  If isDefined is true, offset and source are both defined.
@@ -111,19 +111,19 @@ abstract class Position extends scala.reflect.api.Position { self =>
   def makeTransparent: Position = this
 
   /** The start of the position's range, error if not a range position */
-  def start: Int = throw new UnsupportedOperationException("Position.start")
+  def start: Int = throw new UnsupportedOperationException(s"Position.start on ${this.getClass}")
 
   /** The start of the position's range, or point if not a range position */
   def startOrPoint: Int = point
 
   /**  The point (where the ^ is) of the position */
-  def point: Int = throw new UnsupportedOperationException("Position.point")
+  def point: Int = throw new UnsupportedOperationException(s"Position.point on ${this.getClass}")
 
   /**  The point (where the ^ is) of the position, or else `default` if undefined */
   def pointOrElse(default: Int): Int = default
 
   /** The end of the position's range, error if not a range position */
-  def end: Int = throw new UnsupportedOperationException("Position.end")
+  def end: Int = throw new UnsupportedOperationException(s"Position.end on ${this.getClass}")
 
   /** The end of the position's range, or point if not a range position */
   def endOrPoint: Int = point

--- a/test/files/neg/t6728.check
+++ b/test/files/neg/t6728.check
@@ -1,0 +1,4 @@
+t6728.scala:4: error: '(' expected but '}' found.
+  }
+  ^
+one error found

--- a/test/files/neg/t6728.scala
+++ b/test/files/neg/t6728.scala
@@ -1,0 +1,5 @@
+object X {
+  while(true) {
+    for
+  }
+}


### PR DESCRIPTION
The parser was trying to take the position of an empty expression
which would crash. Son on the empty expression case in TreeBuilder#
makeWhile it tries to do that and, if that failed, gets a position
that wraps both the condition and the body.

I also made a slight improvement to the UnsupportedOperationEx
messages in Position.

review @paulp
