### PR TITLE
SI-6669 Add . to the default scalap classpath

### DIFF
--- a/src/scalap/scala/tools/scalap/Main.scala
+++ b/src/scalap/scala/tools/scalap/Main.scala
@@ -184,7 +184,7 @@ object Main extends Main {
     val cparg = List("-classpath", "-cp") map (arguments getArgument _) reduceLeft (_ orElse _)
     val path = cparg match {
       case Some(cp) => new JavaClassPath(DefaultJavaContext.classesInExpandedPath(cp), DefaultJavaContext)
-      case _        => PathResolver.fromPathString("")
+      case _        => PathResolver.fromPathString(".") // include '.' in the default classpath SI-6669
     }
     // print the classpath if output is verbose
     if (verbose)

--- a/test/files/run/t6669.scala
+++ b/test/files/run/t6669.scala
@@ -1,0 +1,26 @@
+import java.io.{ByteArrayOutputStream, PrintStream}
+
+object Test extends App {
+  val baos = new ByteArrayOutputStream()
+  val ps = new PrintStream(baos) 
+
+  // first test with the default classpath
+  (scala.Console withOut ps) {
+    scala.tools.scalap.Main.main(Array("-verbose", "java.lang.Object"))
+  }
+
+  // now make sure we saw the '.' in the classpath
+  val msg1 = baos.toString()
+  assert(msg1 contains "directory classpath: .", s"Did not see '.' in the default class path. Full results were:\n$msg1")
+
+  // then test again with a user specified classpath
+  baos.reset
+
+  (scala.Console withOut ps) {
+    scala.tools.scalap.Main.main(Array("-verbose", "-cp", "whatever", "java.lang.Object"))
+  }
+
+  // now make sure we did not see the '.' in the classpath
+  val msg2 = baos.toString()
+  assert(!(msg2 contains "directory classpath: ."), s"Did saw '.' in the user specified class path. Full results were:\n$msg2")
+}


### PR DESCRIPTION
The default classpath for scalap did not include '.' which made it
behave differently from javap in an annoying way. This commit adds
it to the default. Also included is a test to make sure it's in
the default but does not corrupt a user specified classpath.

review @retronym (by random roll of the dice)
