### PR TITLE
Bump the default memory setting in ANT_OPTS to 2G.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -236,7 +236,7 @@ PROPERTIES
 
   <!-- if ANT_OPTS is already set by the environment, it will be unaltered,
        but if it is unset it will take this default value. -->
-  <property name="env.ANT_OPTS" value="-Xms1536M -Xmx1536M -Xss1M -XX:MaxPermSize=192M -XX:+UseParallelGC" />
+  <property name="env.ANT_OPTS" value="-Xms2G -Xmx2G -Xss1M -XX:MaxPermSize=192M -XX:+UseParallelGC" />
 
   <property
       name="scalacfork.jvmargs"


### PR DESCRIPTION
The reason is that `ant dist` fails with our current default (1.5G)
because Scaladoc needs more memory. This is being discovered by
newcomers every few weeks and they just go and adjust their own
environment variable `ANT_OPTS`. Let's save that trouble and fix
the default.
