### PR TITLE
[backport] the scanner is now less eager about deprecations

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -113,6 +113,11 @@ trait Scanners extends ScannersCommon {
       cbuf.append(c)
     }
 
+    /** Determines whether this scanner should emit identifier deprecation warnings,
+     *  e.g. when seeing `macro` or `then`, which are planned to become keywords in future versions of Scala.
+     */
+    protected def emitIdentifierDeprecationWarnings = true
+
     /** Clear buffer and set name and token */
     private def finishNamed(idtoken: Int = IDENTIFIER) {
       name = newTermName(cbuf.toString)
@@ -122,7 +127,7 @@ trait Scanners extends ScannersCommon {
         val idx = name.start - kwOffset
         if (idx >= 0 && idx < kwArray.length) {
           token = kwArray(idx)
-          if (token == IDENTIFIER && allowIdent != name)
+          if (token == IDENTIFIER && allowIdent != name && emitIdentifierDeprecationWarnings)
             deprecationWarning(name+" is now a reserved word; usage as an identifier is deprecated")
         }
       }
@@ -1487,6 +1492,10 @@ trait Scanners extends ScannersCommon {
 
     def improves(patches1: List[BracePatch]): Boolean =
       imbalanceMeasure > new ParensAnalyzer(unit, patches1).imbalanceMeasure
+
+    // don't emit deprecation warnings about identifiers like `macro` or `then`
+    // when skimming through the source file trying to heal braces
+    override def emitIdentifierDeprecationWarnings = false
 
     override def error(offset: Int, msg: String) {}
   }

--- a/test/files/neg/macro-false-deprecation-warning.check
+++ b/test/files/neg/macro-false-deprecation-warning.check
@@ -1,0 +1,4 @@
+Impls_Macros_1.scala:5: error: illegal start of simple expression
+}
+^
+one error found

--- a/test/files/neg/macro-false-deprecation-warning.flags
+++ b/test/files/neg/macro-false-deprecation-warning.flags
@@ -1,0 +1,1 @@
+-language:experimental.macros

--- a/test/files/neg/macro-false-deprecation-warning.flags
+++ b/test/files/neg/macro-false-deprecation-warning.flags
@@ -1,1 +1,1 @@
--language:experimental.macros
+-language:experimental.macros -deprecation

--- a/test/files/neg/macro-false-deprecation-warning/Impls_Macros_1.scala
+++ b/test/files/neg/macro-false-deprecation-warning/Impls_Macros_1.scala
@@ -1,0 +1,15 @@
+import scala.reflect.macros.Context
+
+object Helper {
+  def unapplySeq[T](x: List[T]): Option[Seq[T]] =
+}
+
+object Macros {
+  def impl[T: c.WeakTypeTag](c: Context)(x: c.Expr[List[T]]) = {
+    c.universe.reify(Helper.unapplySeq(x.splice))
+  }
+
+  object UnapplyMacro {
+    def unapplySeq[T](x: List[T]): Option[Seq[T]] = macro impl[T]
+  }
+}


### PR DESCRIPTION
Backport of https://github.com/scala/scala/pull/1807
