### PR TITLE
SI-7045 reflection now auto-initializes thisSym

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -3019,7 +3019,10 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     }
 
     /** A symbol carrying the self type of the class as its type */
-    override def thisSym: Symbol = thissym
+    override def thisSym: Symbol = {
+      if (!isCompilerUniverse && needsInitialize(isFlagRelated = false, mask = 0)) initialize
+      thissym
+    }
 
     /** Sets the self type of the class */
     override def typeOfThis_=(tp: Type) {

--- a/test/files/run/t7045.check
+++ b/test/files/run/t7045.check
@@ -1,0 +1,2 @@
+D with C
+D with C

--- a/test/files/run/t7045.scala
+++ b/test/files/run/t7045.scala
@@ -1,0 +1,12 @@
+import scala.reflect.runtime.universe._
+import scala.reflect.runtime.{currentMirror => cm}
+
+class C
+class D { self: C => }
+
+object Test extends App {
+  val d = cm.staticClass("D")
+  println(d.selfType)
+  d.typeSignature
+  println(d.selfType)
+}


### PR DESCRIPTION
thisSym joins the happy family of flags, annotations and privateWithin,
which automatically trigger initialization, when used within runtime
reflection.
