### PR TITLE
SI-7046 reflection now auto-initializes knownDirectSubclasses

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -86,7 +86,11 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       case n: TypeName => if (isClass) newClassSymbol(n, pos, newFlags) else newNonClassSymbol(n, pos, newFlags)
     }
 
-    def knownDirectSubclasses             = children
+    def knownDirectSubclasses = {
+      if (!isCompilerUniverse && needsInitialize(isFlagRelated = false, mask = 0)) initialize
+      children
+    }
+
     def baseClasses                       = info.baseClasses
     def module                            = sourceModule
     def thisPrefix: Type                  = thisType

--- a/test/files/run/t7046.check
+++ b/test/files/run/t7046.check
@@ -1,0 +1,2 @@
+Set(class D, class E)
+Set(class D, class E)

--- a/test/files/run/t7046.scala
+++ b/test/files/run/t7046.scala
@@ -1,0 +1,13 @@
+import scala.reflect.runtime.universe._
+import scala.reflect.runtime.{currentMirror => cm}
+
+sealed class C
+class D extends C
+class E extends C
+
+object Test extends App {
+  val c = cm.staticClass("C")
+  println(c.knownDirectSubclasses)
+  c.typeSignature
+  println(c.knownDirectSubclasses)
+}


### PR DESCRIPTION
knownDirectSubclasses joins the happy family of flags, annotations and
privateWithin, which automatically trigger initialization, when used
within runtime reflection.
