### PR TITLE
SI-6411 reflection is now aware of posterasure

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -78,6 +78,8 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
 
   def picklerPhase: Phase = if (currentRun.isDefined) currentRun.picklerPhase else NoPhase
 
+  def erasurePhase: Phase = if (currentRun.isDefined) currentRun.erasurePhase else NoPhase
+
   // platform specific elements
 
   type ThisPlatform = Platform { val global: Global.this.type }
@@ -566,7 +568,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
   } with Erasure
 
   // phaseName = "posterasure"
-  object postErasure extends {
+  override object postErasure extends {
     val global: Global.this.type = Global.this
     val runsAfter = List("erasure")
     val runsRightAfter = Some("erasure")

--- a/src/compiler/scala/tools/nsc/transform/PostErasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/PostErasure.scala
@@ -8,7 +8,7 @@ package transform
 /** This phase maps ErasedValueTypes to the underlying unboxed representation and
  *  performs peephole optimizations.
  */
-trait PostErasure extends InfoTransform with TypingTransformers {
+trait PostErasure extends InfoTransform with TypingTransformers with scala.reflect.internal.transform.PostErasure {
 
   val global: Global
   import global._
@@ -18,18 +18,6 @@ trait PostErasure extends InfoTransform with TypingTransformers {
 
   def newTransformer(unit: CompilationUnit): Transformer = new PostErasureTransformer(unit)
   override def changesBaseClasses = false
-
-  object elimErasedValueType extends TypeMap {
-    def apply(tp: Type) = tp match {
-      case ConstantType(Constant(tp: Type)) =>
-        ConstantType(Constant(apply(tp)))
-      case ErasedValueType(tref) =>
-        atPhase(currentRun.erasurePhase)(erasure.erasedValueClassArg(tref))
-      case _ => mapOver(tp)
-    }
-  }
-
-  def transformInfo(sym: Symbol, tp: Type) = elimErasedValueType(tp)
 
   class PostErasureTransformer(unit: CompilationUnit) extends TypingTransformer(unit) {
 

--- a/src/compiler/scala/tools/reflect/ReflectGlobal.scala
+++ b/src/compiler/scala/tools/reflect/ReflectGlobal.scala
@@ -12,9 +12,10 @@ class ReflectGlobal(currentSettings: Settings, reporter: Reporter, override val 
   extends Global(currentSettings, reporter) with scala.tools.reflect.ReflectSetup with scala.reflect.runtime.SymbolTable {
 
   override def transformedType(sym: Symbol) =
-    erasure.transformInfo(sym,
-      uncurry.transformInfo(sym,
-        refChecks.transformInfo(sym, sym.info)))
+    postErasure.transformInfo(sym,
+      erasure.transformInfo(sym,
+        uncurry.transformInfo(sym,
+          refChecks.transformInfo(sym, sym.info))))
 
   override def isCompilerUniverse = true
 

--- a/src/reflect/scala/reflect/internal/Required.scala
+++ b/src/reflect/scala/reflect/internal/Required.scala
@@ -7,6 +7,8 @@ trait Required { self: SymbolTable =>
 
   def picklerPhase: Phase
 
+  def erasurePhase: Phase
+
   def settings: MutableSettings
 
   def forInteractive: Boolean

--- a/src/reflect/scala/reflect/internal/transform/PostErasure.scala
+++ b/src/reflect/scala/reflect/internal/transform/PostErasure.scala
@@ -1,0 +1,22 @@
+package scala.reflect
+package internal
+package transform
+
+trait PostErasure {
+
+  val global: SymbolTable
+  import global._
+  import definitions._
+
+  object elimErasedValueType extends TypeMap {
+    def apply(tp: Type) = tp match {
+      case ConstantType(Constant(tp: Type)) =>
+        ConstantType(Constant(apply(tp)))
+      case ErasedValueType(tref) =>
+        atPhase(erasurePhase)(erasure.erasedValueClassArg(tref))
+      case _ => mapOver(tp)
+    }
+  }
+
+  def transformInfo(sym: Symbol, tp: Type) = elimErasedValueType(tp)
+}

--- a/src/reflect/scala/reflect/internal/transform/Transforms.scala
+++ b/src/reflect/scala/reflect/internal/transform/Transforms.scala
@@ -25,17 +25,20 @@ trait Transforms { self: SymbolTable =>
   private val refChecksLazy = new Lazy(new { val global: Transforms.this.type = self } with RefChecks)
   private val uncurryLazy = new Lazy(new { val global: Transforms.this.type = self } with UnCurry)
   private val erasureLazy = new Lazy(new { val global: Transforms.this.type = self } with Erasure)
+  private val postErasureLazy = new Lazy(new { val global: Transforms.this.type = self } with PostErasure)
 
   def refChecks = refChecksLazy.force
   def uncurry = uncurryLazy.force
   def erasure = erasureLazy.force
+  def postErasure = postErasureLazy.force
 
   def transformedType(sym: Symbol) =
-    erasure.transformInfo(sym,
-      uncurry.transformInfo(sym,
-        refChecks.transformInfo(sym, sym.info)))
+    postErasure.transformInfo(sym,
+      erasure.transformInfo(sym,
+        uncurry.transformInfo(sym,
+          refChecks.transformInfo(sym, sym.info))))
 
   def transformedType(tpe: Type) =
-    erasure.scalaErasure(uncurry.uncurry(tpe))
+    postErasure.elimErasedValueType(erasure.scalaErasure(uncurry.uncurry(tpe)))
 
 }

--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -325,13 +325,21 @@ private[reflect] trait JavaMirrors extends internal.SymbolTable with api.JavaUni
       bytecodelessMethodOwners(meth.owner) && !bytecodefulObjectMethods(meth)
     }
 
+    private def isByNameParam(p: Type) = isByNameParamType(p)
+    private def isValueClassParam(p: Type) = p match {
+      case TypeRef(_, RepeatedParamClass, targ :: Nil) => targ.typeSymbol.isDerivedValueClass
+      case tpe => tpe.typeSymbol.isDerivedValueClass
+    }
+
     // unlike other mirrors, method mirrors are created by a factory
     // that's because we want to have decent performance
     // therefore we move special cases into separate subclasses
     // rather than have them on a hot path them in a unified implementation of the `apply` method
     private def mkJavaMethodMirror[T: ClassTag](receiver: T, symbol: MethodSymbol): JavaMethodMirror = {
+      def existsParam(pred: Type => Boolean) = symbol.paramss.flatten.map(_.info).exists(pred)
       if (isBytecodelessMethod(symbol)) new JavaBytecodelessMethodMirror(receiver, symbol)
-      else if (symbol.paramss.flatten exists (p => isByNameParamType(p.info))) new JavaByNameMethodMirror(receiver, symbol)
+      else if (existsParam(isByNameParam)) new JavaByNameMethodMirror(receiver, symbol)
+      else if (existsParam(isValueClassParam)) new JavaValueClassParamMethodMirror(receiver, symbol)
       else new JavaVanillaMethodMirror(receiver, symbol)
     }
 
@@ -357,11 +365,50 @@ private[reflect] trait JavaMirrors extends internal.SymbolTable with api.JavaUni
       def apply(args: Any*): Any = jinvoke(jmeth, receiver, args)
     }
 
-    private class JavaByNameMethodMirror(val receiver: Any, symbol: MethodSymbol)
-            extends JavaMethodMirror(symbol) {
+    private abstract class JavaMethodMirrorWithTransform(val receiver: Any, symbol: MethodSymbol)
+                     extends JavaMethodMirror(symbol) {
+      def shouldTransform(arg: Any, param: Type, vararg: Boolean): Boolean
+      def transform(arg: Any, param: Type, vararg: Boolean): Any
+
       def apply(args: Any*): Any = {
-        val transformed = map2(args.toList, symbol.paramss.flatten)((arg, param) => if (isByNameParamType(param.info)) () => arg else arg)
+        // TODO: vararg is only supported in the last parameter list (SI-6182)
+        // so we don't need to worry about the rest for now
+        if (symbol.isVarargs && args.length + 1 < symbol.paramss.flatten.length) throw new IllegalArgumentException("argument count mismatch")
+        val params = symbol.paramss.flatten.map(_.info) match {
+          case params @ normals :+ TypeRef(_, _, varparam :: Nil) if symbol.isVarargs =>
+            normals ++ List.fill(args.length - params.length + 1)(varparam)
+          case params => params
+        }
+        var i = 0
+        val transformed = map2(args.toList, params)((arg, param) => {
+          val vararg = symbol.isVarargs && i >= symbol.paramss.flatten.length - 1
+          val arg1 = if (shouldTransform(arg, param, vararg)) transform(arg, param, vararg) else arg
+          i += 1
+          arg1
+        })
         jinvoke(jmeth, receiver, transformed)
+      }
+    }
+
+    private class JavaByNameMethodMirror(receiver: Any, symbol: MethodSymbol)
+            extends JavaMethodMirrorWithTransform(receiver, symbol) {
+      override def shouldTransform(arg: Any, param: Type, vararg: Boolean) = isByNameParam(param)
+      override def transform(arg: Any, param: Type, vararg: Boolean): Any = { assert(!vararg, symbol); () => arg }
+    }
+
+    private class JavaValueClassParamMethodMirror(receiver: Any, symbol: MethodSymbol)
+            extends JavaMethodMirrorWithTransform(receiver, symbol) {
+      override def shouldTransform(arg: Any, param: Type, vararg: Boolean) = !vararg && isValueClassParam(param)
+      override def transform(arg: Any, param: Type, vararg: Boolean): Any = {
+        if (arg == null) throw new IllegalArgumentException()
+        val expectedTpe = param.typeSymbol.asClass.toType
+        // transform is only called when shouldTransform returns true, which means that param has to be a value class
+        // therefore we don't need to use the isinstanceof check, but a simple equality test for getClass will be enough
+        if (runtimeClass(expectedTpe) != arg.getClass) throw new IllegalArgumentException("argument type mismatch")
+        val fields @ (field :: _) = expectedTpe.declarations.collect{ case ts: TermSymbol if ts.isParamAccessor && ts.isMethod => ts }.toList
+        assert(fields.length == 1, s"${param.typeSymbol}: $fields")
+        val jgetter = arg.getClass.getDeclaredMethod(field.name)
+        jgetter.invoke(arg)
       }
     }
 

--- a/src/reflect/scala/reflect/runtime/JavaUniverse.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverse.scala
@@ -13,6 +13,8 @@ class JavaUniverse extends internal.SymbolTable with ReflectSetup with runtime.S
 
   def picklerPhase = SomePhase
 
+  def erasurePhase = SomePhase
+
   lazy val settings = new Settings
   def forInteractive = false
   def forScaladoc = false

--- a/src/reflect/scala/reflect/runtime/ReflectionUtils.scala
+++ b/src/reflect/scala/reflect/runtime/ReflectionUtils.scala
@@ -10,7 +10,7 @@ import java.lang.reflect.{ Method, InvocationTargetException, UndeclaredThrowabl
 
 /** A few java-reflection oriented utility functions useful during reflection bootstrapping.
  */
-private[scala] object ReflectionUtils {
+object ReflectionUtils {
   // Unwraps some chained exceptions which arise during reflective calls.
   def unwrapThrowable(x: Throwable): Throwable = x match {
     case  _: InvocationTargetException |      // thrown by reflectively invoked method or constructor

--- a/test/files/run/t6411.check
+++ b/test/files/run/t6411.check
@@ -1,0 +1,172 @@
+meth = method yg_1
+as seen by Scala reflection: def yg_1[T <: <?>](y: Y[T]): T
+as seen by Java reflection: public java.lang.Object a$.yg_1(java.lang.Object)
+result = class java.lang.IllegalArgumentException: null
+meth = method yg_1
+as seen by Scala reflection: def yg_1[T](y: Y[T]): T
+as seen by Java reflection: public java.lang.Object a$.yg_1(java.lang.Object)
+result = 1
+meth = method yg_1
+as seen by Scala reflection: def yg_1[T](y: Y[T]): T
+as seen by Java reflection: public java.lang.Object a$.yg_1(java.lang.Object)
+result = 1
+meth = method yi_2
+as seen by Scala reflection: def yi_2(y: Y[Int]): Int
+as seen by Java reflection: public int a$.yi_2(java.lang.Integer)
+result = 2
+meth = method yi_2
+as seen by Scala reflection: def yi_2(y: Y[Int]): Int
+as seen by Java reflection: public int a$.yi_2(java.lang.Integer)
+result = class java.lang.IllegalArgumentException: argument type mismatch
+meth = method ys_3
+as seen by Scala reflection: def ys_3(y: Y[String]): String
+as seen by Java reflection: public java.lang.String a$.ys_3(java.lang.String)
+result = class java.lang.IllegalArgumentException: argument type mismatch
+meth = method ys_3
+as seen by Scala reflection: def ys_3(y: Y[String]): String
+as seen by Java reflection: public java.lang.String a$.ys_3(java.lang.String)
+result = 3
+meth = method ya_4
+as seen by Scala reflection: def ya_4(ys: Array[Y[String]]): List[String]
+as seen by Java reflection: public scala.collection.immutable.List a$.ya_4(Y[])
+result = class java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.String
+meth = method ya_4
+as seen by Scala reflection: def ya_4(ys: Array[Y[String]]): List[String]
+as seen by Java reflection: public scala.collection.immutable.List a$.ya_4(Y[])
+result = List(4)
+meth = method yl_5
+as seen by Scala reflection: def yl_5(ys: List[Y[String]]): List[String]
+as seen by Java reflection: public scala.collection.immutable.List a$.yl_5(scala.collection.immutable.List)
+result = class java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.String
+meth = method yl_5
+as seen by Scala reflection: def yl_5(ys: List[Y[String]]): List[String]
+as seen by Java reflection: public scala.collection.immutable.List a$.yl_5(scala.collection.immutable.List)
+result = List(5)
+meth = method zg_1
+as seen by Scala reflection: def zg_1[T](z: Z[T]): T
+as seen by Java reflection: public java.lang.Object a$.zg_1(Z)
+result = class java.lang.NullPointerException: null
+meth = method zg_1
+as seen by Scala reflection: def zg_1[T](z: Z[T]): T
+as seen by Java reflection: public java.lang.Object a$.zg_1(Z)
+result = 1
+meth = method zg_1
+as seen by Scala reflection: def zg_1[T](z: Z[T]): T
+as seen by Java reflection: public java.lang.Object a$.zg_1(Z)
+result = 1
+meth = method zi_2
+as seen by Scala reflection: def zi_2(z: Z[Int]): Int
+as seen by Java reflection: public int a$.zi_2(Z)
+result = 2
+meth = method zi_2
+as seen by Scala reflection: def zi_2(z: Z[Int]): Int
+as seen by Java reflection: public int a$.zi_2(Z)
+result = class java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Integer
+meth = method zs_3
+as seen by Scala reflection: def zs_3(z: Z[String]): String
+as seen by Java reflection: public java.lang.String a$.zs_3(Z)
+result = class java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.String
+meth = method zs_3
+as seen by Scala reflection: def zs_3(z: Z[String]): String
+as seen by Java reflection: public java.lang.String a$.zs_3(Z)
+result = 3
+meth = method za_4
+as seen by Scala reflection: def za_4(zs: Array[Z[String]]): List[String]
+as seen by Java reflection: public scala.collection.immutable.List a$.za_4(Z[])
+result = class java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.String
+meth = method za_4
+as seen by Scala reflection: def za_4(zs: Array[Z[String]]): List[String]
+as seen by Java reflection: public scala.collection.immutable.List a$.za_4(Z[])
+result = List(4)
+meth = method zl_5
+as seen by Scala reflection: def zl_5(zs: List[Z[String]]): List[String]
+as seen by Java reflection: public scala.collection.immutable.List a$.zl_5(scala.collection.immutable.List)
+result = class java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.String
+meth = method zl_5
+as seen by Scala reflection: def zl_5(zs: List[Z[String]]): List[String]
+as seen by Java reflection: public scala.collection.immutable.List a$.zl_5(scala.collection.immutable.List)
+result = List(5)
+meth = method yzg_1
+as seen by Scala reflection: def yzg_1[T <: <?>](y: Y[T],z: Z[T]): T
+as seen by Java reflection: public java.lang.Object a$.yzg_1(java.lang.Object,Z)
+result = class java.lang.IllegalArgumentException: null
+meth = method yzg_1
+as seen by Scala reflection: def yzg_1[T](y: Y[T],z: Z[T]): T
+as seen by Java reflection: public java.lang.Object a$.yzg_1(java.lang.Object,Z)
+result = 1
+meth = method yzg_1
+as seen by Scala reflection: def yzg_1[T](y: Y[T],z: Z[T]): T
+as seen by Java reflection: public java.lang.Object a$.yzg_1(java.lang.Object,Z)
+result = 1
+meth = method yzg_1
+as seen by Scala reflection: def yzg_1[T](y: Y[T],z: Z[T]): T
+as seen by Java reflection: public java.lang.Object a$.yzg_1(java.lang.Object,Z)
+result = 1
+meth = method yzg_1
+as seen by Scala reflection: def yzg_1[T](y: Y[T],z: Z[T]): T
+as seen by Java reflection: public java.lang.Object a$.yzg_1(java.lang.Object,Z)
+result = 1
+meth = method yzi_2
+as seen by Scala reflection: def yzi_2(y: Y[Int],z: Z[Int]): Int
+as seen by Java reflection: public int a$.yzi_2(java.lang.Integer,Z)
+result = 2
+meth = method yzi_2
+as seen by Scala reflection: def yzi_2(y: Y[Int],z: Z[Int]): Int
+as seen by Java reflection: public int a$.yzi_2(java.lang.Integer,Z)
+result = class java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Integer
+meth = method yzi_2
+as seen by Scala reflection: def yzi_2(y: Y[Int],z: Z[Int]): Int
+as seen by Java reflection: public int a$.yzi_2(java.lang.Integer,Z)
+result = class java.lang.IllegalArgumentException: argument type mismatch
+meth = method yzi_2
+as seen by Scala reflection: def yzi_2(y: Y[Int],z: Z[Int]): Int
+as seen by Java reflection: public int a$.yzi_2(java.lang.Integer,Z)
+result = class java.lang.IllegalArgumentException: argument type mismatch
+meth = method yzs_3
+as seen by Scala reflection: def yzs_3(y: Y[String],z: Z[String]): String
+as seen by Java reflection: public java.lang.String a$.yzs_3(java.lang.String,Z)
+result = class java.lang.IllegalArgumentException: argument type mismatch
+meth = method yzs_3
+as seen by Scala reflection: def yzs_3(y: Y[String],z: Z[String]): String
+as seen by Java reflection: public java.lang.String a$.yzs_3(java.lang.String,Z)
+result = class java.lang.IllegalArgumentException: argument type mismatch
+meth = method yzs_3
+as seen by Scala reflection: def yzs_3(y: Y[String],z: Z[String]): String
+as seen by Java reflection: public java.lang.String a$.yzs_3(java.lang.String,Z)
+result = class java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.String
+meth = method yzs_3
+as seen by Scala reflection: def yzs_3(y: Y[String],z: Z[String]): String
+as seen by Java reflection: public java.lang.String a$.yzs_3(java.lang.String,Z)
+result = 3
+meth = method yza_4
+as seen by Scala reflection: def yza_4(ys: Array[Y[String]],zs: Array[Z[String]]): List[String]
+as seen by Java reflection: public scala.collection.immutable.List a$.yza_4(Y[],Z[])
+result = class java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.String
+meth = method yza_4
+as seen by Scala reflection: def yza_4(ys: Array[Y[String]],zs: Array[Z[String]]): List[String]
+as seen by Java reflection: public scala.collection.immutable.List a$.yza_4(Y[],Z[])
+result = List(4)
+meth = method yza_4
+as seen by Scala reflection: def yza_4(ys: Array[Y[String]],zs: Array[Z[String]]): List[String]
+as seen by Java reflection: public scala.collection.immutable.List a$.yza_4(Y[],Z[])
+result = class java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.String
+meth = method yza_4
+as seen by Scala reflection: def yza_4(ys: Array[Y[String]],zs: Array[Z[String]]): List[String]
+as seen by Java reflection: public scala.collection.immutable.List a$.yza_4(Y[],Z[])
+result = List(4)
+meth = method yzl_5
+as seen by Scala reflection: def yzl_5(ys: List[Y[String]],zs: List[Z[String]]): List[String]
+as seen by Java reflection: public scala.collection.immutable.List a$.yzl_5(scala.collection.immutable.List,scala.collection.immutable.List)
+result = class java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.String
+meth = method yzl_5
+as seen by Scala reflection: def yzl_5(ys: List[Y[String]],zs: List[Z[String]]): List[String]
+as seen by Java reflection: public scala.collection.immutable.List a$.yzl_5(scala.collection.immutable.List,scala.collection.immutable.List)
+result = List(5)
+meth = method yzl_5
+as seen by Scala reflection: def yzl_5(ys: List[Y[String]],zs: List[Z[String]]): List[String]
+as seen by Java reflection: public scala.collection.immutable.List a$.yzl_5(scala.collection.immutable.List,scala.collection.immutable.List)
+result = class java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.String
+meth = method yzl_5
+as seen by Scala reflection: def yzl_5(ys: List[Y[String]],zs: List[Z[String]]): List[String]
+as seen by Java reflection: public scala.collection.immutable.List a$.yzl_5(scala.collection.immutable.List,scala.collection.immutable.List)
+result = List(5)

--- a/test/files/run/t6411.scala
+++ b/test/files/run/t6411.scala
@@ -1,0 +1,102 @@
+import scala.reflect.runtime.universe._
+import scala.reflect.runtime.{currentMirror => cm}
+
+class Y[T](val i: T) extends AnyVal {
+  override def toString = s"Y($i)"
+}
+class Z[T](val i: T) extends AnyRef {
+  override def toString = s"Z($i)"
+}
+
+object a {
+  def yg_1[T](y: Y[T])                                  = y.i
+  def yi_2(y: Y[Int])                                   = y.i
+  def ys_3(y: Y[String])                                = y.i
+  def ya_4(ys: Array[Y[String]])                        = ys.toList.map(_.i)
+  def yl_5(ys: List[Y[String]])                         = ys.map(_.i)
+  def yv_6(ys: Y[String]*)                              = ys.toList.map(_.i)
+
+  def zg_1[T](z: Z[T])                                  = z.i
+  def zi_2(z: Z[Int])                                   = z.i
+  def zs_3(z: Z[String])                                = z.i
+  def za_4(zs: Array[Z[String]])                        = zs.toList.map(_.i)
+  def zl_5(zs: List[Z[String]])                         = zs.map(_.i)
+  def zv_6(zs: Z[String]*)                              = zs.toList.map(_.i)
+
+  def yzg_1[T](y: Y[T], z: Z[T])                        = z.i
+  def yzi_2(y: Y[Int], z: Z[Int])                       = z.i
+  def yzs_3(y: Y[String], z: Z[String])                 = z.i
+  def yza_4(ys: Array[Y[String]], zs: Array[Z[String]]) = zs.toList.map(_.i)
+  def yzl_5(ys: List[Y[String]], zs: List[Z[String]])   = zs.map(_.i)
+}
+
+object Test extends App {
+  def test(methName: String, args: Any*) = {
+    val moduleA = cm.reflect(a)
+    val msym = moduleA.symbol.typeSignature.declaration(newTermName(methName)).asMethod
+    println(s"meth = $msym")
+    val mmirror = moduleA.reflectMethod(msym)
+    val mresult =
+      try { mmirror(args: _*) }
+      catch {
+        case ex: Exception =>
+          val ex1 = scala.reflect.runtime.ReflectionUtils.unwrapThrowable(ex)
+          s"${ex1.getClass}: ${ex1.getMessage}"
+      }
+    println(s"as seen by Scala reflection: ${msym.asInstanceOf[scala.reflect.internal.Symbols#Symbol].defString}")
+    println(s"as seen by Java reflection: ${mmirror.asInstanceOf[{val jmeth: java.lang.reflect.Method}].jmeth}")
+    println(s"result = $mresult")
+  }
+
+  test("yg_1", null)
+  test("yg_1", new Y(1))
+  test("yg_1", new Y("1"))
+  test("yi_2", new Y(2))
+  test("yi_2", new Y("2"))
+  test("ys_3", new Y(3))
+  test("ys_3", new Y("3"))
+  test("ya_4", Array(new Y(4)))
+  test("ya_4", Array(new Y("4")))
+  test("yl_5", List(new Y(5)))
+  test("yl_5", List(new Y("5")))
+  // FIXME: disabled because of SI-7056
+  // test("yv_6", new Y(6))
+  // test("yv_6", new Y("6"))
+
+  test("zg_1", null)
+  test("zg_1", new Z(1))
+  test("zg_1", new Z("1"))
+  test("zi_2", new Z(2))
+  test("zi_2", new Z("2"))
+  test("zs_3", new Z(3))
+  test("zs_3", new Z("3"))
+  test("za_4", Array(new Z(4)))
+  test("za_4", Array(new Z("4")))
+  test("zl_5", List(new Z(5)))
+  test("zl_5", List(new Z("5")))
+  // FIXME: disabled because of SI-7056
+  // test("zv_6", new Z(6))
+  // test("zv_6", new Z("6"))
+
+  test("yzg_1", null, null)
+  test("yzg_1", new Y(1), new Z(1))
+  test("yzg_1", new Y(1), new Z("1"))
+  test("yzg_1", new Y("1"), new Z(1))
+  test("yzg_1", new Y("1"), new Z("1"))
+  test("yzi_2", new Y(2), new Z(2))
+  test("yzi_2", new Y(2), new Z("2"))
+  test("yzi_2", new Y("2"), new Z(2))
+  test("yzi_2", new Y("2"), new Z("2"))
+  test("yzs_3", new Y(3), new Z(3))
+  test("yzs_3", new Y(3), new Z("3"))
+  test("yzs_3", new Y("3"), new Z(3))
+  test("yzs_3", new Y("3"), new Z("3"))
+  test("yza_4", Array(new Y(4)), Array(new Z(4)))
+  test("yza_4", Array(new Y(4)), Array(new Z("4")))
+  test("yza_4", Array(new Y("4")), Array(new Z(4)))
+  test("yza_4", Array(new Y("4")), Array(new Z("4")))
+  test("yzl_5", List(new Y(5)), List(new Z(5)))
+  test("yzl_5", List(new Y(5)), List(new Z("5")))
+  test("yzl_5", List(new Y("5")), List(new Z(5)))
+  test("yzl_5", List(new Y("5")), List(new Z("5")))
+}


### PR DESCRIPTION
The `transformedType` method, which is used to bring Scala types to Java
world, was written in pre-valueclass times. Therefore, this method only
called transforms from erasure, uncurry and refChecks.

Now runtime reflection becomes aware of posterasure and as a consequence
methods, which have value classes in their signatures, can be called
without having to wrap them in catch-a-crash clause.
