### PR TITLE
SI-4714 Initialize history while initializing the REPL's reader

### DIFF
--- a/src/compiler/scala/tools/nsc/interpreter/JLineReader.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/JLineReader.scala
@@ -37,6 +37,9 @@ class JLineReader(_completion: => Completion) extends InteractiveReader {
   }
 
   class JLineConsoleReader extends ConsoleReader with ConsoleReaderHelper {
+    if ((history: History) ne NoHistory)
+      this setHistory history
+
     // working around protected/trait/java insufficiencies.
     def goBack(num: Int): Unit = back(num)
     def readOneKey(prompt: String) = {
@@ -51,8 +54,6 @@ class JLineReader(_completion: => Completion) extends InteractiveReader {
     // A hook for running code after the repl is done initializing.
     lazy val postInit: Unit = {
       this setBellEnabled false
-      if ((history: History) ne NoHistory)
-        this setHistory history
 
       if (completion ne NoCompletion) {
         val argCompletor: ArgumentCompleter =


### PR DESCRIPTION
It was possible to get a command into the REPL before the history
recording object was set and so the command would be lost in the sands
of time. This fix just moves the initialization of the history object
into the JLineReader constructor, out of the post-init hook.

@paulp how is this going to break things? Also, I don't have a clue how to automate the testing of this.
