### PR TITLE
[Backport] Fix for SI-6426, importable _.

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -980,11 +980,8 @@ self =>
 
     /** Assumed (provisionally) to be TermNames. */
     def ident(skipIt: Boolean): Name =
-      if (isIdent) {
-        val name = in.name.encode
-        in.nextToken()
-        name
-      } else {
+      if (isIdent) rawIdent().encode
+      else {
         syntaxErrorOrIncomplete(expectedMsg(IDENTIFIER), skipIt)
         nme.ERROR
       }

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -607,7 +607,10 @@ trait Scanners extends ScannersCommon {
       if (ch == '`') {
         nextChar()
         finishNamed(BACKQUOTED_IDENT)
-        if (name.length == 0) syntaxError("empty quoted identifier")
+        if (name.length == 0)
+          syntaxError("empty quoted identifier")
+        else if (name == nme.WILDCARD)
+          syntaxError("wildcard invalid as backquoted identifier")
       }
       else syntaxError("unclosed quoted identifier")
     }

--- a/test/files/neg/t6426.check
+++ b/test/files/neg/t6426.check
@@ -1,0 +1,7 @@
+t6426.scala:4: error: wildcard invalid as backquoted identifier
+  println(`_`.Buffer(0))
+          ^
+t6426.scala:5: error: ')' expected but '}' found.
+}
+^
+two errors found

--- a/test/files/neg/t6426.scala
+++ b/test/files/neg/t6426.scala
@@ -1,0 +1,5 @@
+class A {
+  import collection.{mutable => _, _}
+
+  println(`_`.Buffer(0))
+}


### PR DESCRIPTION
backports 357f45c1152728a5e461312f462aa7ab63e2adec

Prohibit `_` as an identifier, it can only bring badness.
