### PR TITLE
SI-6017 Scaladoc: Fix dangling links on index.html

### DIFF
--- a/src/compiler/scala/tools/nsc/doc/html/page/Index.scala
+++ b/src/compiler/scala/tools/nsc/doc/html/page/Index.scala
@@ -48,10 +48,22 @@ class Index(universe: doc.Universe, val index: doc.Index) extends HtmlPage {
       </div>
     </body>
 
+  def letters: NodeSeq = {
+    val xs = index.firstLetterIndex.keys.toSeq
+    xs.sorted map {
+      c => <a target="template" href={ "index/index-" + c + ".html" }>{
+        if (c == '_') '#' else c.toUpper
+      }</a>
+    }
+  }
+
   def browser =
     <div id="browser" class="ui-layout-west">
       <div class="ui-west-center">
-      <div id="filter"></div>
+      <div id="filter">
+          <div id="textfilter"></div>
+          <div id="letters">{ letters }</div>
+      </div>
       <div class="pack" id="tpl">{
         def packageElem(pack: model.Package): NodeSeq = {
           <xml:group>

--- a/src/compiler/scala/tools/nsc/doc/html/page/Index.scala
+++ b/src/compiler/scala/tools/nsc/doc/html/page/Index.scala
@@ -48,14 +48,20 @@ class Index(universe: doc.Universe, val index: doc.Index) extends HtmlPage {
       </div>
     </body>
 
-  def letters: NodeSeq = {
-    val xs = index.firstLetterIndex.keys.toSeq
-    xs.sorted map {
-      c => <a target="template" href={ "index/index-" + c + ".html" }>{
-        if (c == '_') '#' else c.toUpper
-      }</a>
+  def letters: NodeSeq =
+    '_' +: ('a' to 'z') map {
+      char => {
+        val label = if (char == '_') '#' else char.toUpper
+
+        index.firstLetterIndex.get(char) match {
+          case Some(_) =>
+            <a target="template" href={ "index/index-" + char + ".html" }>{
+              label
+            }</a>
+          case None => <span>{ label }</span>
+        }
+      }
     }
-  }
 
   def browser =
     <div id="browser" class="ui-layout-west">

--- a/src/compiler/scala/tools/nsc/doc/html/resource/lib/index.css
+++ b/src/compiler/scala/tools/nsc/doc/html/resource/lib/index.css
@@ -206,13 +206,17 @@ h1 {
   border-right:0;
 }
 
-#letters > a {
+#letters > a, #letters > span {
 /*  font-family: monospace;*/
   color: #858484;
   font-weight: bold;
   font-size: 8pt;
   text-shadow: #ffffff 0 1px 0;
   padding-right: 2px;
+}
+
+#letters > span {
+  color: #bbb;
 }
   
 #tpl {

--- a/src/compiler/scala/tools/nsc/doc/html/resource/lib/index.js
+++ b/src/compiler/scala/tools/nsc/doc/html/resource/lib/index.js
@@ -335,8 +335,7 @@ function keyboardScrolldownLeftPane() {
 /* Configures the text filter  */
 function configureTextFilter() {
     scheduler.add("init", function() {
-        $("#filter").append("<div id='textfilter'><span class='pre'/><span class='input'><input id='index-input' type='text' accesskey='/'/></span><span class='post'/></div>");
-        printAlphabet();
+        $("#textfilter").append("<span class='pre'/><span class='input'><input id='index-input' type='text' accesskey='/'/></span><span class='post'/>");
         var input = $("#textfilter input");
         resizeFilterBlock();
         input.bind('keyup', function(event) {
@@ -532,19 +531,3 @@ function kindFilterSync() {
 function resizeFilterBlock() {
     $("#tpl").css("top", $("#filter").outerHeight(true));
 }
-
-function printAlphabet() {
-    var html = '<a target="template" href="index/index-_.html">#</a>';
-    var c;
-    for (c = 'a'; c <= 'z'; c = String.fromCharCode(c.charCodeAt(0) + 1)) {
-        html += [
-            '<a target="template" href="index/index-',
-            c,
-            '.html">',
-            c.toUpperCase(),
-            '</a>'
-        ].join('');
-    }
-    $("#filter").append('<div id="letters">' + html + '</div>');
-}
-

--- a/test/scaladoc/run/SI-6017.scala
+++ b/test/scaladoc/run/SI-6017.scala
@@ -18,7 +18,9 @@ object Test extends ScaladocModelTest {
         assert(index.firstLetterIndex('s').keys.toSeq.length == 2)
 
         val indexPage = new Index(universe, index)
-        assert(indexPage.letters.length == 1)
+        val letters = indexPage.letters
+        assert(letters.length > 1)
+        assert(letters(0).toString == "<span>#</span>")
       }
       case _ => assert(false)
     }

--- a/test/scaladoc/run/SI-6017.scala
+++ b/test/scaladoc/run/SI-6017.scala
@@ -16,6 +16,9 @@ object Test extends ScaladocModelTest {
         val index = IndexModelFactory.makeIndex(universe)
         // Because "STAR" and "Star" are different
         assert(index.firstLetterIndex('s').keys.toSeq.length == 2)
+
+        val indexPage = new Index(universe, index)
+        assert(indexPage.letters.length == 1)
       }
       case _ => assert(false)
     }


### PR DESCRIPTION
As @heathermiller and @VladUreche commented in #1861, I removed `<a>` and use `<span>` instead when there is no page to link to.
