### PR TITLE
SI-6146 More accurate prefixes for sealed subtypes.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternMatching.scala
@@ -2720,17 +2720,18 @@ trait PatternMatching extends Transform with TypingTransformers with ast.TreeDSL
           val tpApprox = typer.infer.approximateAbstracts(tp)
           val pre = tpApprox.prefix
           // valid subtypes are turned into checkable types, as we are entering the realm of the dynamic
-          val validSubTypes = (subclasses flatMap {sym =>
-              // have to filter out children which cannot match: see ticket #3683 for an example
-              // compare to the fully known type `tp` (modulo abstract types),
-              // so that we can rule out stuff like: sealed trait X[T]; class XInt extends X[Int] --> XInt not valid when enumerating X[String]
-              // however, must approximate abstract types in
-              val subTp       = appliedType(pre.memberType(sym), sym.typeParams.map(_ => WildcardType))
-              val subTpApprox = typer.infer.approximateAbstracts(subTp) // TODO: needed?
-              // patmatDebug("subtp"+(subTpApprox <:< tpApprox, subTpApprox, tpApprox))
-              if (subTpApprox <:< tpApprox) Some(checkableType(subTp))
-              else None
-            })
+          val validSubTypes = (subclasses flatMap { sym =>
+            // have to filter out children which cannot match: see ticket #3683 for an example
+            // compare to the fully known type `tp` (modulo abstract types),
+            // so that we can rule out stuff like: sealed trait X[T]; class XInt extends X[Int] --> XInt not valid when enumerating X[String]
+            // however, must approximate abstract types in
+
+            val subTp = appliedType(deepMemberType(pre, sym), sym.typeParams.map(_ => WildcardType))
+            val subTpApprox = typer.infer.approximateAbstracts(subTp) // TODO: needed?
+            // patmatDebug("subtp"+(subTpApprox <:< tpApprox, subTpApprox, tpApprox))
+            if (subTpApprox <:< tpApprox) Some(checkableType(subTp))
+            else None
+          })
           patmatDebug("enum sealed "+ (tp, tpApprox) + " as "+ validSubTypes)
           Some(validSubTypes)
       }

--- a/test/files/pos/t6146.flags
+++ b/test/files/pos/t6146.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t6146.scala
+++ b/test/files/pos/t6146.scala
@@ -1,0 +1,41 @@
+trait AxisCompanion {
+   sealed trait Format
+   object Format {
+      case object Decimal extends Format
+      case object Integer extends Format
+      // Gives an unrelated warning:  The outer reference in this type test cannot be checked at run time.
+      //final case class Time( hours: Boolean = false, millis: Boolean = true ) extends Format
+   }
+}
+object Axis extends AxisCompanion
+class Axis {
+   import Axis._
+   def test( f: Format ) = f match {
+      case Format.Integer => "Int"
+      // case Format.Time( hours, millis ) => "Time"
+      case Format.Decimal => "Dec"
+   }
+}
+
+
+trait T1[X] {
+  trait T2[Y] {
+    sealed trait Format
+    object Format {
+      case object Decimal extends Format
+      case object Integer extends Format
+    }
+  }
+}
+object O1 extends T1[Any] {
+  object O2 extends T2[Any] {
+
+  }
+}
+class Test1 {
+   import O1.O2._
+   def test( f: Format ) = f match {
+      case Format.Integer => "Int"
+      case Format.Decimal => "Dec"
+   }
+}

--- a/test/files/run/t6146b.check
+++ b/test/files/run/t6146b.check
@@ -1,0 +1,32 @@
+Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> :power
+** Power User mode enabled - BEEP WHIR GYVE **
+** :phase has been set to 'typer'.          **
+** scala.tools.nsc._ has been imported      **
+** global._, definitions._ also imported    **
+** Try  :help, :vals, power.<tab>           **
+
+scala>  val u = rootMirror.universe
+u: $r.intp.global.type = scala.tools.nsc.interpreter.IMain$$anon$1@38a133ff
+
+scala>  import u._, language._
+import u._
+import language._
+
+scala>  class C { object O { class E }}; object D extends C
+defined class C
+defined module D
+
+scala>  deepMemberType(typeOf[D.type], typeOf[c.O.E forSome { val c: C }].typeSymbol)
+res0: u.Type = D.O.E
+
+scala>  class C { class C1 { class E }}; object D extends C
+defined class C
+defined module D
+
+scala>  deepMemberType(typeOf[D.type], typeOf[c1.E forSome { val c1: C#C1 }].typeSymbol)
+res1: u.Type = D.C1#E
+
+scala> 

--- a/test/files/run/t6146b.scala
+++ b/test/files/run/t6146b.scala
@@ -1,0 +1,13 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  override def code = """
+  | :power
+  | val u = rootMirror.universe
+  | import u._, language._
+  | class C { object O { class E }}; object D extends C
+  | deepMemberType(typeOf[D.type], typeOf[c.O.E forSome { val c: C }].typeSymbol)
+  | class C { class C1 { class E }}; object D extends C
+  | deepMemberType(typeOf[D.type], typeOf[c1.E forSome { val c1: C#C1 }].typeSymbol)
+  """.stripMargin.trim
+}


### PR DESCRIPTION
When analysing exhaustivity/reachability of type tests
and equality tests, the pattern matcher must construct
a set of sealed subtypes based on the prefix of the
static type of and the set of sealed descendent symbols
of that type.

Previously, it was using `memberType` for this purpose.
In simple cases, this is sufficient:

```
scala> class C { class Inner }; object D extends C
defined class C
defined module D

scala> typeOf[D.type] memberType typeOf[C#Inner].typeSymbol
res0: u.Type = D.Inner
```

But, as reported in this bug, it fails when there is an
additional level of nesting:

```
scala> typeOf[D.type] memberType typeOf[c.O.Inner forSome { val c: C }].typeSymbol
res5: u.Type = C.O.Inner

scala> typeOf[Any] memberType typeOf[c.O.Inner forSome { val c: C }].typeSymbol
res6: u.Type = C.O.Inner
```

This commit introduces `deepMemberType`, which uses `memberType`
recursively over the prefix chain.

```
scala> deepMemberType(typeOf[D.type], typeOf[c.O.Inner forSome { val c: C }].typeSymbol)
res3: u.Type = D.O.Inner
```

Review by @adriaanm && @paulp
- I'm not sure how to join the dots on the connection to `dealiasWiden`
- `memberTypeDeep` is something of a straw-man, better suggestions?
- is this something we might expect `AsSeenFrom` to handle automatically?
