### PR TITLE
Revert "SI-6422: add missing Fractional and Integral alias in scala package"

### DIFF
--- a/src/library/scala/package.scala
+++ b/src/library/scala/package.scala
@@ -95,10 +95,7 @@ package object scala {
   val Equiv = scala.math.Equiv
 
   type Fractional[T] = scala.math.Fractional[T]
-  val Fractional = scala.math.Fractional
-
   type Integral[T] = scala.math.Integral[T]
-  val Integral = scala.math.Integral
 
   type Numeric[T] = scala.math.Numeric[T]
   val Numeric = scala.math.Numeric


### PR DESCRIPTION
This reverts commit c6866a28faf67cd2e455f9a0a829859a73e38819 because it adds two
members to the API and so breaks forward binary compatibility.

Attention: this is only intended for 2.10.x, not for 2.11.

Thanks to Paul Phillips for the report:
https://groups.google.com/d/topic/scala-internals/WQ0LKC8Re6A/discussion
