### PR TITLE
SI-5833 Fixes tail-of-Nil problem in RefinedType#normalizeImpl

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1800,7 +1800,7 @@ trait Types extends api.Types { self: SymbolTable =>
       // TODO see comments around def intersectionType and def merge
       def flatten(tps: List[Type]): List[Type] = tps flatMap { case RefinedType(parents, ds) if ds.isEmpty => flatten(parents) case tp => List(tp) }
       val flattened = flatten(parents).distinct
-      if (decls.isEmpty && flattened.tail.isEmpty) {
+      if (decls.isEmpty && hasLength(flattened, 1)) {
         flattened.head
       } else if (flattened != parents) {
         refinedType(flattened, if (typeSymbol eq NoSymbol) NoSymbol else typeSymbol.owner, decls, NoPosition)
@@ -3542,7 +3542,7 @@ trait Types extends api.Types { self: SymbolTable =>
     if (phase.erasedTypes)
       if (parents.isEmpty) ObjectClass.tpe else parents.head
     else {
-      val clazz = owner.newRefinementClass(pos) // TODO: why were we passing in NoPosition instead of pos?
+      val clazz = owner.newRefinementClass(pos)
       val result = RefinedType(parents, decls, clazz)
       clazz.setInfo(result)
       result


### PR DESCRIPTION
RefinedType#normalizeImpl was checking to see if the flattened list of
parents had an empty tail then pulling the head if so. But if the list
was empty then boom. This fix makes it check if the whole list has
length 1 instead. Empty lists will flow through to the rest the logic
which has no problems with Nil.

review @adriaanm or @hubertp

Questions for reviewer to contemplate:
I had no luck finding a reproducing test case. Can you?
Should a refinement type with no parents and no decls normalize to AnyRef instead of falling through to the rest of the logic?
