### PR TITLE
[nomerge] SI-6667 Demote a new ambiguity error to a lint warning.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1319,12 +1319,17 @@ trait Implicits {
 
         // `materializeImplicit` does some preprocessing for `pt`
         // is it only meant for manifests/tags or we need to do the same for `implicitsOfExpectedType`?
-        if (result.isFailure && !wasAmbigious) result = searchImplicit(implicitsOfExpectedType, false)
+        if (result.isFailure) result = searchImplicit(implicitsOfExpectedType, false)
 
         if (result.isFailure) {
           context.updateBuffer(previousErrs)
           if (Statistics.canEnable) Statistics.stopTimer(oftypeFailNanos, failstart)
         } else {
+          if (wasAmbigious && settings.lint.value)
+            reporter.warning(tree.pos,
+              "Search of in-scope implicits was ambiguous, and the implicit scope was searched. In Scala 2.11.0, this code will not compile. See SI-6667. \n" +
+                previousErrs.map(_.errMsg).mkString("\n"))
+
           if (Statistics.canEnable) Statistics.stopTimer(oftypeSucceedNanos, succstart)
           if (Statistics.canEnable) Statistics.incCounter(oftypeImplicitHits)
         }

--- a/test/files/neg/t6667.check
+++ b/test/files/neg/t6667.check
@@ -1,4 +1,5 @@
-t6667.scala:8: error: ambiguous implicit values:
+t6667.scala:8: error: Search of in-scope implicits was ambiguous, and the implicit scope was searched. In Scala 2.11.0, this code will not compile. See SI-6667. 
+ambiguous implicit values:
  both value inScope1 in object Test of type => C
  and value inScope2 in object Test of type => C
  match expected type C

--- a/test/files/neg/t6667.flags
+++ b/test/files/neg/t6667.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -Xlint

--- a/test/files/neg/t6667b.check
+++ b/test/files/neg/t6667b.check
@@ -4,7 +4,8 @@ t6667b.scala:16: error: ambiguous implicit values:
  match expected type Test.Box
       new Test()
       ^
-t6667b.scala:19: error: ambiguous implicit values:
+t6667b.scala:19: error: Search of in-scope implicits was ambiguous, and the implicit scope was searched. In Scala 2.11.0, this code will not compile. See SI-6667. 
+ambiguous implicit values:
  both value a in object Test of type => Test.Box
  and value b of type Test.Box
  match expected type Test.Box

--- a/test/files/neg/t6667b.flags
+++ b/test/files/neg/t6667b.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -Xlint


### PR DESCRIPTION
In the interests of not breaking source compability.
A few projects are relying on this bug.

Should not be merged to master.

Review by @paulp
