### PR TITLE
SI-5675 Discard duplicate feature warnings at a position

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1193,13 +1193,13 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
 
   /** Collects for certain classes of warnings during this run. */
   class ConditionalWarning(what: String, option: Settings#BooleanSetting) {
-    val warnings = new mutable.ListBuffer[(Position, String)]
+    val warnings = mutable.LinkedHashMap[Position, String]()
     def warn(pos: Position, msg: String) =
       if (option.value) reporter.warning(pos, msg)
-      else warnings += ((pos, msg))
+      else if (!(warnings contains pos)) warnings += ((pos, msg))
     def summarize() =
       if (option.isDefault && warnings.nonEmpty)
-        reporter.warning(NoPosition, "there were %d %s warnings; re-run with %s for details".format(warnings.size, what, option.name))
+        reporter.warning(NoPosition, "there were %d %s warning(s); re-run with %s for details".format(warnings.size, what, option.name))
   }
 
   def newUnitParser(code: String)      = new syntaxAnalyzer.UnitParser(newCompilationUnit(code))

--- a/test/files/buildmanager/t2650_1/t2650_1.check
+++ b/test/files/buildmanager/t2650_1/t2650_1.check
@@ -1,6 +1,6 @@
 builder > A.scala B.scala
 compiling Set(A.scala, B.scala)
-warning: there were 1 feature warnings; re-run with -feature for details
+warning: there were 1 feature warning(s); re-run with -feature for details
 Changes: Map()
 builder > A.scala
 compiling Set(A.scala)

--- a/test/files/buildmanager/t2657/t2657.check
+++ b/test/files/buildmanager/t2657/t2657.check
@@ -1,6 +1,6 @@
 builder > A.scala B.scala
 compiling Set(A.scala, B.scala)
-warning: there were 1 feature warnings; re-run with -feature for details
+warning: there were 1 feature warning(s); re-run with -feature for details
 Changes: Map()
 builder > A.scala
 compiling Set(A.scala)

--- a/test/files/jvm/interpreter.check
+++ b/test/files/jvm/interpreter.check
@@ -97,7 +97,7 @@ scala> case class Bar(n: Int)
 defined class Bar
 
 scala> implicit def foo2bar(foo: Foo) = Bar(foo.n)
-warning: there were 1 feature warnings; re-run with -feature for details
+warning: there were 1 feature warning(s); re-run with -feature for details
 foo2bar: (foo: Foo)Bar
 
 scala> val bar: Bar = Foo(3)
@@ -271,7 +271,7 @@ scala> xs map (x => x)
 res6: Array[_] = Array(1, 2)
 
 scala> xs map (x => (x, x))
-warning: there were 1 feature warnings; re-run with -feature for details
+warning: there were 1 feature warning(s); re-run with -feature for details
 res7: Array[(_$1, _$1)] forSome { type _$1 } = Array((1,1), (2,2))
 
 scala> 

--- a/test/files/neg/t5675.check
+++ b/test/files/neg/t5675.check
@@ -1,0 +1,2 @@
+error: there were 1 feature warning(s); re-run with -feature for details
+one error found

--- a/test/files/neg/t5675.flags
+++ b/test/files/neg/t5675.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/t5675.scala
+++ b/test/files/neg/t5675.scala
@@ -1,0 +1,7 @@
+class PostFix {
+  val list = List(1, 2, 3)
+  def main(args: Array[String]) {
+    val a = list filter (2 !=)
+    val b = list filter (2 != _)
+  }
+}

--- a/test/files/run/constrained-types.check
+++ b/test/files/run/constrained-types.check
@@ -75,11 +75,11 @@ scala> var four = "four"
 four: String = four
 
 scala> val four2 = m(four) // should have an existential bound
-warning: there were 1 feature warnings; re-run with -feature for details
+warning: there were 1 feature warning(s); re-run with -feature for details
 four2: String @Annot(x) forSome { val x: String } = four
 
 scala> val four3 = four2   // should have the same type as four2
-warning: there were 1 feature warnings; re-run with -feature for details
+warning: there were 1 feature warning(s); re-run with -feature for details
 four3: String @Annot(x) forSome { val x: String } = four
 
 scala> val stuff = m("stuff") // should not crash
@@ -102,7 +102,7 @@ scala> def m = {
   val y : String @Annot(x) = x
   y
 } // x should not escape the local scope with a narrow type
-warning: there were 1 feature warnings; re-run with -feature for details
+warning: there were 1 feature warning(s); re-run with -feature for details
 m: String @Annot(x) forSome { val x: String }
 
 scala> 
@@ -116,7 +116,7 @@ scala> def n(y: String) = {
   }
   m("stuff".stripMargin)
 } // x should be existentially bound
-warning: there were 1 feature warnings; re-run with -feature for details
+warning: there were 1 feature warning(s); re-run with -feature for details
 n: (y: String)String @Annot(x) forSome { val x: String }
 
 scala> 

--- a/test/files/run/reflection-magicsymbols-repl.check
+++ b/test/files/run/reflection-magicsymbols-repl.check
@@ -23,7 +23,7 @@ scala> def test(n: Int): Unit = {
   val x = sig.asInstanceOf[MethodType].params.head
   println(x.typeSignature)
 }
-warning: there were 1 feature warnings; re-run with -feature for details
+warning: there were 1 feature warning(s); re-run with -feature for details
 test: (n: Int)Unit
 
 scala> for (i <- 1 to 8) test(i)

--- a/test/files/run/t4172.check
+++ b/test/files/run/t4172.check
@@ -4,7 +4,7 @@ Type :help for more information.
 scala> 
 
 scala>     val c = { class C { override def toString = "C" }; ((new C, new C { def f = 2 })) }
-warning: there were 1 feature warnings; re-run with -feature for details
+warning: there were 1 feature warning(s); re-run with -feature for details
 c: (C, C{def f: Int}) forSome { type C <: AnyRef } = (C,C)
 
 scala> 

--- a/test/files/run/t4710.check
+++ b/test/files/run/t4710.check
@@ -2,7 +2,38 @@ Type in expressions to have them evaluated.
 Type :help for more information.
 
 scala> def method : String = { implicit def f(s: Symbol) = "" ; 'symbol }
-warning: there were 1 feature warnings; re-run with -feature for details
-method: String
 
-scala> 
+Failed to initialize the REPL due to an unexpected error.
+This is a bug, please, report it along with the error diagnostics printed below.
+java.lang.NoSuchMethodError: scala.tools.nsc.Global$ConditionalWarning.warnings()Lscala/collection/mutable/ListBuffer;
+	at scala.tools.nsc.interpreter.IMain$ReadEvalPrint$$anonfun$10.apply(IMain.scala:789)
+	at scala.tools.nsc.interpreter.IMain$ReadEvalPrint$$anonfun$10.apply(IMain.scala:789)
+	at scala.collection.TraversableLike$$anonfun$flatMap$1.apply(TraversableLike.scala:251)
+	at scala.collection.TraversableLike$$anonfun$flatMap$1.apply(TraversableLike.scala:251)
+	at scala.collection.immutable.List.foreach(List.scala:312)
+	at scala.collection.TraversableLike$class.flatMap(TraversableLike.scala:251)
+	at scala.collection.AbstractTraversable.flatMap(Traversable.scala:105)
+	at scala.tools.nsc.interpreter.IMain$ReadEvalPrint.updateRecentWarnings(IMain.scala:789)
+	at scala.tools.nsc.interpreter.IMain$ReadEvalPrint.compileAndSaveRun(IMain.scala:800)
+	at scala.tools.nsc.interpreter.IMain$ReadEvalPrint.compile(IMain.scala:759)
+	at scala.tools.nsc.interpreter.IMain.bind(IMain.scala:616)
+	at scala.tools.nsc.interpreter.IMain.bind(IMain.scala:659)
+	at scala.tools.nsc.interpreter.IMain$$anonfun$quietBind$1.apply(IMain.scala:658)
+	at scala.tools.nsc.interpreter.IMain$$anonfun$quietBind$1.apply(IMain.scala:658)
+	at scala.tools.nsc.interpreter.IMain.beQuietDuring(IMain.scala:232)
+	at scala.tools.nsc.interpreter.IMain.quietBind(IMain.scala:658)
+	at scala.tools.nsc.interpreter.ILoop$$anonfun$process$1$$anonfun$apply$mcZ$sp$2.apply$mcV$sp(ILoop.scala:838)
+	at scala.tools.nsc.interpreter.ILoopInit$class.runThunks(ILoopInit.scala:122)
+	at scala.tools.nsc.interpreter.ILoop.runThunks(ILoop.scala:42)
+	at scala.tools.nsc.interpreter.ILoopInit$class.postInitialization(ILoopInit.scala:95)
+	at scala.tools.nsc.interpreter.ILoop.postInitialization(ILoop.scala:42)
+	at scala.tools.nsc.interpreter.ILoopInit$$anonfun$createAsyncListener$1.apply$mcV$sp(ILoopInit.scala:63)
+	at scala.tools.nsc.interpreter.ILoopInit$$anonfun$createAsyncListener$1.apply(ILoopInit.scala:60)
+	at scala.tools.nsc.interpreter.ILoopInit$$anonfun$createAsyncListener$1.apply(ILoopInit.scala:60)
+	at scala.tools.nsc.io.package$$anon$3.call(package.scala:40)
+	at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
+	at java.util.concurrent.FutureTask.run(FutureTask.java:138)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
+	at java.lang.Thread.run(Thread.java:680)
+.

--- a/test/files/run/t6028.check
+++ b/test/files/run/t6028.check
@@ -81,4 +81,4 @@ package <empty> {
   }
 }
 
-warning: there were 1 feature warnings; re-run with -feature for details
+warning: there were 1 feature warning(s); re-run with -feature for details


### PR DESCRIPTION
When -feature has not been enabled, we were double counting
identical feature warnings that were emitted at the same position.
Normal error reporting only reports the first time a warning
appears at a position; feature warning counter incrementing
should behave the same way.

Review by @hubertp
