### PR TITLE
SI-6807 Deprecating the Actors library.

### DIFF
--- a/src/actors/scala/actors/AbstractActor.scala
+++ b/src/actors/scala/actors/AbstractActor.scala
@@ -15,6 +15,7 @@ import scala.language.higherKinds
  *
  * @define actor actor
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 trait AbstractActor extends OutputChannel[Any] with CanReply[Any, Any] {
 
   type Future[+R] <: scala.actors.Future[R]

--- a/src/actors/scala/actors/Actor.scala
+++ b/src/actors/scala/actors/Actor.scala
@@ -18,6 +18,7 @@ import scala.language.implicitConversions
  *
  * @author Philipp Haller
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 object Actor extends Combinators {
 
   /** State of an actor.
@@ -398,6 +399,7 @@ object Actor extends Combinators {
  *  @define channel actor's mailbox
  */
 @SerialVersionUID(-781154067877019505L)
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 trait Actor extends InternalActor with ReplyReactor {
 
   override def start(): Actor = synchronized {

--- a/src/actors/scala/actors/ActorRef.scala
+++ b/src/actors/scala/actors/ActorRef.scala
@@ -45,8 +45,9 @@ trait ActorRef {
  * This is what is used to complete a Future that is returned from an ask/? call,
  * when it times out.
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 class AskTimeoutException(message: String, cause: Throwable) extends TimeoutException {
   def this(message: String) = this(message, null: Throwable)
 }
-
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 object PoisonPill

--- a/src/actors/scala/actors/CanReply.scala
+++ b/src/actors/scala/actors/CanReply.scala
@@ -17,6 +17,7 @@ import scala.language.higherKinds
  *
  * @define actor `CanReply`
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 trait CanReply[-T, +R] {
 
   type Future[+P] <: () => P

--- a/src/actors/scala/actors/Channel.scala
+++ b/src/actors/scala/actors/Channel.scala
@@ -23,6 +23,7 @@ import scala.concurrent.SyncVar
  *
  * @author Philipp Haller
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 case class ! [a](ch: Channel[a], msg: a)
 
 /**
@@ -34,6 +35,7 @@ case class ! [a](ch: Channel[a], msg: a)
  * @define actor channel
  * @define channel channel
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 class Channel[Msg](val receiver: InternalActor) extends InputChannel[Msg] with OutputChannel[Msg] with CanReply[Msg, Any] {
 
   type Future[+P] = scala.actors.Future[P]

--- a/src/actors/scala/actors/DaemonActor.scala
+++ b/src/actors/scala/actors/DaemonActor.scala
@@ -18,6 +18,7 @@ import scheduler.DaemonScheduler
  *
  * @author Erik Engbrecht
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 trait DaemonActor extends Actor {
   override def scheduler: IScheduler = DaemonScheduler
 }

--- a/src/actors/scala/actors/Debug.scala
+++ b/src/actors/scala/actors/Debug.scala
@@ -14,6 +14,7 @@ package scala.actors
  *
  * @author Philipp Haller
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 object Debug extends Logger("") {}
 
 private[actors] class Logger(tag: String) {

--- a/src/actors/scala/actors/Future.scala
+++ b/src/actors/scala/actors/Future.scala
@@ -21,6 +21,7 @@ import scala.concurrent.SyncVar
  *
  *  @author Philipp Haller
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 abstract class Future[+T] extends Responder[T] with Function0[T] {
 
   @volatile
@@ -107,6 +108,7 @@ private class FutureActor[T](fun: SyncVar[T] => Unit, channel: Channel[T]) exten
  *
  *  @author Philipp Haller
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 object Futures {
 
   /** Arranges for the asynchronous execution of `body`,

--- a/src/actors/scala/actors/IScheduler.scala
+++ b/src/actors/scala/actors/IScheduler.scala
@@ -17,6 +17,7 @@ package scala.actors
  *
  * @author Philipp Haller
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 trait IScheduler {
 
   /** Submits a closure for execution.

--- a/src/actors/scala/actors/InputChannel.scala
+++ b/src/actors/scala/actors/InputChannel.scala
@@ -16,6 +16,7 @@ package scala.actors
  *
  * @define channel `InputChannel`
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 trait InputChannel[+Msg] {
 
   /**

--- a/src/actors/scala/actors/InternalActor.scala
+++ b/src/actors/scala/actors/InternalActor.scala
@@ -524,6 +524,7 @@ private[actors] trait InternalActor extends AbstractActor with InternalReplyReac
  *
  *  @author Philipp Haller
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 case object TIMEOUT
 
 /**
@@ -534,6 +535,7 @@ case object TIMEOUT
  *  @param from   the actor that terminated
  *  @param reason the reason that caused the actor to terminate
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 case class Exit(from: AbstractActor, reason: AnyRef)
 
 /**

--- a/src/actors/scala/actors/InternalReplyReactor.scala
+++ b/src/actors/scala/actors/InternalReplyReactor.scala
@@ -12,6 +12,7 @@ import java.util.{TimerTask}
  *
  *  @define actor `ReplyReactor`
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 trait InternalReplyReactor extends Reactor[Any] with ReactorCanReply {
 
   /* A list of the current senders. The head of the list is

--- a/src/actors/scala/actors/OutputChannel.scala
+++ b/src/actors/scala/actors/OutputChannel.scala
@@ -15,6 +15,7 @@ package scala.actors
  *
  * @define actor `OutputChannel`
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 trait OutputChannel[-Msg] {
 
   /**

--- a/src/actors/scala/actors/Reactor.scala
+++ b/src/actors/scala/actors/Reactor.scala
@@ -52,6 +52,7 @@ private[actors] object Reactor {
  *
  * @define actor reactor
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 trait Reactor[Msg >: Null] extends OutputChannel[Msg] with Combinators {
 
   /* The $actor's mailbox. */

--- a/src/actors/scala/actors/ReplyReactor.scala
+++ b/src/actors/scala/actors/ReplyReactor.scala
@@ -7,7 +7,7 @@
 \*                                                                      */
 package scala.actors
 
-@deprecated("Scala Actors are being removed from the standard library. Please refer to the migration guide.", "2.10")
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 trait ReplyReactor extends InternalReplyReactor {
   protected[actors] def sender: OutputChannel[Any] = super.internalSender
 }

--- a/src/actors/scala/actors/Scheduler.scala
+++ b/src/actors/scala/actors/Scheduler.scala
@@ -18,6 +18,7 @@ import scheduler.{DelegatingScheduler, ForkJoinScheduler, ResizableThreadPoolSch
  *
  * @author Philipp Haller
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 object Scheduler extends DelegatingScheduler {
 
   Debug.info("initializing "+this+"...")

--- a/src/actors/scala/actors/SchedulerAdapter.scala
+++ b/src/actors/scala/actors/SchedulerAdapter.scala
@@ -18,6 +18,7 @@ package scala.actors
  *
  *  @author Philipp Haller
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 trait SchedulerAdapter extends IScheduler {
 
   /** Submits a <code>Runnable</code> for execution.

--- a/src/actors/scala/actors/UncaughtException.scala
+++ b/src/actors/scala/actors/UncaughtException.scala
@@ -20,6 +20,7 @@ package scala.actors
  * @author Philipp Haller
  * @author Erik Engbrecht
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 case class UncaughtException(actor: InternalActor,
                              message: Option[Any],
                              sender: Option[OutputChannel[Any]],

--- a/src/actors/scala/actors/package.scala
+++ b/src/actors/scala/actors/package.scala
@@ -14,6 +14,7 @@ package scala
  * A starting point for using the actors library would be [[scala.actors.Reactor]],
  * [[scala.actors.ReplyReactor]], or [[scala.actors.Actor]] or their companion objects.
  *
+ * @note As of release 2.10.1, replaced by <code>akka.actor</code> package. For migration of existing actors refer to the Actors Migration Guide.
  */
 package object actors {
 

--- a/src/actors/scala/actors/remote/JavaSerializer.scala
+++ b/src/actors/scala/actors/remote/JavaSerializer.scala
@@ -39,6 +39,7 @@ extends ObjectInputStream(in) {
 /**
  *  @author Philipp Haller
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 class JavaSerializer(serv: Service, cl: ClassLoader) extends Serializer(serv) {
   def serialize(o: AnyRef): Array[Byte] = {
     val bos = new ByteArrayOutputStream()

--- a/src/actors/scala/actors/remote/RemoteActor.scala
+++ b/src/actors/scala/actors/remote/RemoteActor.scala
@@ -38,6 +38,7 @@ package remote
  *
  * @author Philipp Haller
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 object RemoteActor {
 
   private val kernels = new scala.collection.mutable.HashMap[InternalActor, NetKernel]
@@ -127,4 +128,5 @@ object RemoteActor {
  *
  * @author Philipp Haller
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 case class Node(address: String, port: Int)

--- a/src/actors/scala/actors/remote/Serializer.scala
+++ b/src/actors/scala/actors/remote/Serializer.scala
@@ -16,6 +16,7 @@ import java.lang.ClassNotFoundException
 
 import java.io.{DataInputStream, DataOutputStream, EOFException, IOException}
 
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 abstract class Serializer(val service: Service) {
   def serialize(o: AnyRef): Array[Byte]
   def deserialize(a: Array[Byte]): AnyRef

--- a/src/actors/scala/actors/remote/Service.scala
+++ b/src/actors/scala/actors/remote/Service.scala
@@ -14,6 +14,7 @@ package remote
  * @version 0.9.10
  * @author Philipp Haller
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 trait Service {
   val kernel = new NetKernel(this)
   val serializer: Serializer

--- a/src/actors/scala/actors/remote/TcpService.scala
+++ b/src/actors/scala/actors/remote/TcpService.scala
@@ -24,6 +24,7 @@ import scala.util.Random
  * @version 0.9.9
  * @author Philipp Haller
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 object TcpService {
   private val random = new Random
   private val ports = new mutable.HashMap[Int, TcpService]
@@ -67,6 +68,7 @@ object TcpService {
  * @version 0.9.10
  * @author Philipp Haller
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 class TcpService(port: Int, cl: ClassLoader) extends Thread with Service {
   val serializer: JavaSerializer = new JavaSerializer(this, cl)
 

--- a/src/actors/scala/actors/scheduler/ActorGC.scala
+++ b/src/actors/scala/actors/scheduler/ActorGC.scala
@@ -23,6 +23,7 @@ import scala.collection.mutable
  * (e.g. act method finishes, exit explicitly called, an exception is thrown),
  * the ActorGC is informed via the `terminated` method.
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 trait ActorGC extends TerminationMonitor {
   self: IScheduler =>
 

--- a/src/actors/scala/actors/scheduler/DaemonScheduler.scala
+++ b/src/actors/scala/actors/scheduler/DaemonScheduler.scala
@@ -14,6 +14,7 @@ package scheduler
  *
  * @author Erik Engbrecht
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 object DaemonScheduler extends DelegatingScheduler {
 
   protected def makeNewScheduler(): IScheduler = {

--- a/src/actors/scala/actors/scheduler/ExecutorScheduler.scala
+++ b/src/actors/scala/actors/scheduler/ExecutorScheduler.scala
@@ -19,6 +19,7 @@ import scala.concurrent.ThreadPoolRunner
  *
  * @author Philipp Haller
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 object ExecutorScheduler {
 
   private def start(sched: ExecutorScheduler): ExecutorScheduler = {
@@ -58,6 +59,7 @@ object ExecutorScheduler {
  *
  * @author Philipp Haller
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 trait ExecutorScheduler extends Thread
                         with IScheduler with TerminationService
                         with ThreadPoolRunner {

--- a/src/actors/scala/actors/scheduler/ForkJoinScheduler.scala
+++ b/src/actors/scala/actors/scheduler/ForkJoinScheduler.scala
@@ -9,6 +9,7 @@ import scala.concurrent.forkjoin._
  *
  * @author Philipp Haller
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 class ForkJoinScheduler(val initCoreSize: Int, val maxSize: Int, daemon: Boolean, fair: Boolean)
       extends Runnable with IScheduler with TerminationMonitor {
 

--- a/src/actors/scala/actors/scheduler/ResizableThreadPoolScheduler.scala
+++ b/src/actors/scala/actors/scheduler/ResizableThreadPoolScheduler.scala
@@ -22,6 +22,7 @@ import scala.concurrent.ManagedBlocker
  *
  * @author Philipp Haller
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 class ResizableThreadPoolScheduler(protected val terminate: Boolean,
                                    protected val daemon: Boolean)
   extends Thread with IScheduler with TerminationMonitor {

--- a/src/actors/scala/actors/scheduler/SingleThreadedScheduler.scala
+++ b/src/actors/scala/actors/scheduler/SingleThreadedScheduler.scala
@@ -17,6 +17,7 @@ import scala.collection.mutable
  *
  * @author Philipp Haller
  */
+@deprecated("Use the akka.actor package instead. For migration from the scala.actors package refer to the Actors Migration Guide.", "2.10.1")
 class SingleThreadedScheduler extends IScheduler {
 
   private val tasks = new mutable.Queue[Runnable]


### PR DESCRIPTION
All public classes, traits and objects marked as deprecated.
Added deprecation note on the package object.
Embedded external libraries (ThreadPool etc.) are not deprecated as they are intended for internal use only.

Retargetting #1903 to master

Review by: @phaller 
