### PR TITLE
SI-6773 Changes IndexSeqFactory to be "since 2.11"

### DIFF
--- a/src/library/scala/collection/generic/IndexedSeqFactory.scala
+++ b/src/library/scala/collection/generic/IndexedSeqFactory.scala
@@ -13,7 +13,7 @@ import language.higherKinds
 
 /** A template for companion objects of IndexedSeq and subclasses thereof.
  *
- *  @since 2.10
+ *  @since 2.11
  */
 abstract class IndexedSeqFactory[CC[X] <: IndexedSeq[X] with GenericTraversableTemplate[X, CC]] extends SeqFactory[CC] {
   override def ReusableCBF: GenericCanBuildFrom[Nothing] =


### PR DESCRIPTION
The addition of IndexSeqFactory to 2.10.x branch created a binary
incompatibility so it was removed in that branch before being released.
This commit fixes the since annotation to 2.11 on IndexSeqFactory in the
master branch.

Relates to https://github.com/scala/scala/pull/2064
