### PR TITLE
SI-6591 Reify and path-dependent types

### DIFF
--- a/src/compiler/scala/reflect/reify/codegen/GenSymbols.scala
+++ b/src/compiler/scala/reflect/reify/codegen/GenSymbols.scala
@@ -100,6 +100,8 @@ trait GenSymbols {
     reifyIntoSymtab(binding.symbol) { sym =>
       if (reifyDebug) println("Free term" + (if (sym.isCapturedVariable) " (captured)" else "") + ": " + sym + "(" + sym.accurateKindString + ")")
       val name = newTermName(nme.REIFY_FREE_PREFIX + sym.name + (if (sym.isType) nme.REIFY_FREE_THIS_SUFFIX else ""))
+      // Flag <stable> is set here to make reified free value pass stability test during reflective compilation
+      if (!sym.isMutable) sym setFlag reflect.internal.Flags.STABLE
       if (sym.isCapturedVariable) {
         assert(binding.isInstanceOf[Ident], showRaw(binding))
         val capturedBinding = referenceCapturedVariable(sym)

--- a/src/compiler/scala/reflect/reify/utils/Extractors.scala
+++ b/src/compiler/scala/reflect/reify/utils/Extractors.scala
@@ -263,12 +263,12 @@ trait Extractors {
   }
 
   object BoundType {
-    def unapply(tree: Tree): Option[Tree] = tree match {
-      case Select(_, name) if name.isTypeName =>
+    def unapply(tree: Tree): Option[RefTree] = tree match {
+      case tree @ Select(_, name) if name.isTypeName =>
         Some(tree)
-      case SelectFromTypeTree(_, name) if name.isTypeName =>
+      case tree @ SelectFromTypeTree(_, _) =>
         Some(tree)
-      case Ident(name) if name.isTypeName =>
+      case tree @ Ident(name) if name.isTypeName =>
         Some(tree)
       case _ =>
         None

--- a/src/reflect/scala/reflect/internal/Flags.scala
+++ b/src/reflect/scala/reflect/internal/Flags.scala
@@ -274,7 +274,7 @@ class Flags extends ModifierFlags {
    *  from Modifiers.  Others which may be applied at creation time are:
    *  SYNTHETIC.
    */
-  final val ValueParameterFlags = BYNAMEPARAM | IMPLICIT | DEFAULTPARAM
+  final val ValueParameterFlags = BYNAMEPARAM | IMPLICIT | DEFAULTPARAM | STABLE
   final val BeanPropertyFlags   = DEFERRED | OVERRIDE | STATIC
   final val VarianceFlags       = COVARIANT | CONTRAVARIANT
 

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -606,6 +606,7 @@ trait StdNames {
     val RootPackage: NameType          = "RootPackage"
     val RootClass: NameType            = "RootClass"
     val Select: NameType               = "Select"
+    val SelectFromTypeTree: NameType   = "SelectFromTypeTree"
     val StringContext: NameType        = "StringContext"
     val This: NameType                 = "This"
     val ThisType: NameType             = "ThisType"

--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -89,6 +89,12 @@ abstract class TreeInfo {
       tree.symbol.isStable && isExprSafeToInline(qual)
     case TypeApply(fn, _) =>
       isExprSafeToInline(fn)
+    /* Special case for reified free terms. During reflective compilation,
+     * reified value recovered flag <stable> from free term and wrapped into a
+     * Function object, so it can pass stability check here to become a stable
+     * identifier.*/
+    case Apply(Select(free @ Ident(_), nme.apply), _) if free.symbol.name endsWith nme.REIFY_FREE_VALUE_SUFFIX =>
+      free.symbol.hasStableFlag && isExprSafeToInline(free)
     case Apply(fn, List()) =>
       /* Note: After uncurry, field accesses are represented as Apply(getter, Nil),
        * so an Apply can also be pure.

--- a/test/files/run/reify_newimpl_30.check
+++ b/test/files/run/reify_newimpl_30.check
@@ -1,1 +1,2 @@
-List(2)
+reflective toolbox has failed:
+unresolved free type variables (namely: C defined by <local Test> in reify_newimpl_30.scala:7:11). have you forgot to use TypeTag annotations for type parameters external to a reifee? if you have troubles tracking free type variables, consider using -Xlog-free-types

--- a/test/files/run/reify_newimpl_30.scala
+++ b/test/files/run/reify_newimpl_30.scala
@@ -1,5 +1,5 @@
 import scala.reflect.runtime.universe._
-import scala.tools.reflect.ToolBox
+import scala.tools.reflect.{ ToolBox, ToolBoxError }
 import scala.tools.reflect.Eval
 
 object Test extends App {
@@ -9,7 +9,8 @@ object Test extends App {
       val code = reify {
         List[C#T](2)
       }
-      println(code.eval)
+      try { println(code.eval) }
+      catch { case e: ToolBoxError => println(e.getMessage) }
     }
 
     new C

--- a/test/files/run/t6591_1.check
+++ b/test/files/run/t6591_1.check
@@ -1,0 +1,1 @@
+Block(List(ValDef(Modifiers(), newTermName("v"), Select(Ident(A), newTypeName("I")), Select(Ident(A), newTermName("impl")))), Ident(newTermName("v")))

--- a/test/files/run/t6591_1.scala
+++ b/test/files/run/t6591_1.scala
@@ -1,0 +1,19 @@
+import scala.reflect.runtime.universe._
+import scala.tools.reflect.ToolBox
+import scala.tools.reflect.Eval
+
+trait O { trait I }
+
+object A extends O {
+  val impl = new I {}
+}
+
+object Test extends App {
+  val code = reify {
+    val v: A.I = A.impl
+    v
+  }
+  println(showRaw(code.tree))
+
+  val v: A.I = code.eval
+}

--- a/test/files/run/t6591_2.check
+++ b/test/files/run/t6591_2.check
@@ -1,0 +1,1 @@
+Block(List(ValDef(Modifiers(), newTermName("v"), SelectFromTypeTree(Ident(A), newTypeName("I")), Select(Apply(Select(New(Ident(A)), nme.CONSTRUCTOR), List()), newTermName("impl")))), Ident(newTermName("v")))

--- a/test/files/run/t6591_2.scala
+++ b/test/files/run/t6591_2.scala
@@ -1,0 +1,19 @@
+import scala.reflect.runtime.universe._
+import scala.tools.reflect.ToolBox
+import scala.tools.reflect.Eval
+
+trait O { trait I }
+
+class A extends O {
+  val impl = new I {}
+}
+
+object Test extends App {
+  val code = reify {
+    val v: A#I = (new A).impl
+    v
+  }
+  println(showRaw(code.tree))
+
+  val v: A#I = code.eval
+}

--- a/test/files/run/t6591_3.check
+++ b/test/files/run/t6591_3.check
@@ -1,0 +1,1 @@
+Block(List(ValDef(Modifiers(), newTermName("v"), Select(This(newTypeName("A")), newTypeName("I")), Apply(Select(New(Select(This(newTypeName("A")), newTypeName("I"))), nme.CONSTRUCTOR), List()))), Ident(newTermName("v")))

--- a/test/files/run/t6591_3.scala
+++ b/test/files/run/t6591_3.scala
@@ -1,0 +1,17 @@
+import scala.reflect.runtime.universe._
+import scala.tools.reflect.ToolBox
+import scala.tools.reflect.Eval
+
+class O { class I }
+
+object A extends O {
+  val code = reify {
+    val v: I = new I
+    v
+  }
+  println(showRaw(code.tree))
+}
+
+object Test extends App {
+  val v: A.I = A.code.eval
+}

--- a/test/files/run/t6591_5.check
+++ b/test/files/run/t6591_5.check
@@ -1,0 +1,1 @@
+Expr(Block(List(ValDef(Modifiers(), newTermName("v"), Select(Select(This(newTypeName("A")), newTermName("x")), newTypeName("I")), Select(Select(This(newTypeName("scala")), newTermName("Predef")), newTermName("$qmark$qmark$qmark")))), Ident(newTermName("v"))))

--- a/test/files/run/t6591_5.scala
+++ b/test/files/run/t6591_5.scala
@@ -1,0 +1,23 @@
+import scala.reflect.runtime.universe._
+import scala.tools.reflect.ToolBox
+import scala.tools.reflect.Eval
+import java.lang.reflect.InvocationTargetException
+
+class O { class I }
+
+object A extends O {
+  val x = new O
+  val code = reify {
+    val v: x.I = ???
+    v
+  }
+  println(showRaw(code))
+}
+
+object Test extends App {
+  try {
+    val v: A.x.I = A.code.eval
+  } catch {
+    case ex: InvocationTargetException if ex.getCause.isInstanceOf[NotImplementedError] =>
+  }
+}

--- a/test/files/run/t6591_6.check
+++ b/test/files/run/t6591_6.check
@@ -1,0 +1,1 @@
+Expr(Block(List(ValDef(Modifiers(), newTermName("v"), Select(Select(Ident(newTermName("A")), newTermName("x")), newTypeName("I")), Select(Select(This(newTypeName("scala")), newTermName("Predef")), newTermName("$qmark$qmark$qmark")))), Ident(newTermName("v"))))

--- a/test/files/run/t6591_6.scala
+++ b/test/files/run/t6591_6.scala
@@ -1,0 +1,24 @@
+import scala.language.existentials
+import scala.reflect.runtime.universe._
+import scala.tools.reflect.ToolBox
+import scala.tools.reflect.Eval
+import java.lang.reflect.InvocationTargetException
+
+class O { class I }
+
+class A extends O {
+  val x = new O
+  val code = reify {
+    val v: x.I = ???
+    v
+  }
+  println(showRaw(code))
+}
+
+object Test extends App {
+  try {
+    val v = (new A).code.eval
+  } catch {
+    case ex: InvocationTargetException if ex.getCause.isInstanceOf[NotImplementedError] =>
+  }
+}

--- a/test/pending/run/t6591_4.check
+++ b/test/pending/run/t6591_4.check
@@ -1,0 +1,1 @@
+Expr(Block(List(ValDef(Modifiers(), newTermName("v"), Select(Ident(newTermName("A")), newTypeName("I")), Apply(Select(New(Select(Ident(newTermName("A")), newTypeName("I"))), nme.CONSTRUCTOR), List()))), Ident(newTermName("v"))))

--- a/test/pending/run/t6591_4.scala
+++ b/test/pending/run/t6591_4.scala
@@ -1,0 +1,17 @@
+import scala.reflect.runtime.universe._
+import scala.tools.reflect.ToolBox
+import scala.tools.reflect.Eval
+
+class O { class I }
+
+class A extends O {
+  val code = reify {
+    val v: I = new I
+    v
+  }
+  println(showRaw(code))
+}
+
+object Test extends App {
+  val v: A#I = (new A).code.eval
+}


### PR DESCRIPTION
Reification scheme changed. Now Select an SelectFromTypeTree trees
reified appropriately, as Select and SelectFromTypeTree accordingly.
Packages and Predef object was excluded in order not to break the
existing reification scheme and not to break tests which rely on it.

Reified free terms can contain flag <stable> to make reified values
become stable identifiers. For example in the case of
reify_newimpl_15.scala

```
class C {
  type T
  reify { val v: List[T] = List(2) }
}
```

class C reified as free term C$value, and List[C.T] becomes
List[C$value().T], so C$value.apply() need to pass stability test
isExprSafeToInline at scala.reflect.internal.TreeInfo. For this purpose
special case for reified free terms was added to isExprSafeToInline
function.

test `reify_newimpl_30.scala` disabled due to [SI-7082](https://issues.scala-lang.org/browse/SI-7082)
test `t6591_4.scala` moved to pending due to [SI-7083](https://issues.scala-lang.org/browse/SI-7083)

review by: @xeno-by
