### PR TITLE
SI-5744 evidence params are now SYNTHETIC

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
@@ -595,7 +595,7 @@ abstract class TreeBuilder {
     if (contextBounds.isEmpty) vparamss
     else {
       val mods = Modifiers(if (owner.isTypeName) PARAMACCESSOR | LOCAL | PRIVATE else PARAM)
-      def makeEvidenceParam(tpt: Tree) = ValDef(mods | IMPLICIT, freshTermName(nme.EVIDENCE_PARAM_PREFIX), tpt, EmptyTree)
+      def makeEvidenceParam(tpt: Tree) = ValDef(mods | IMPLICIT | SYNTHETIC, freshTermName(nme.EVIDENCE_PARAM_PREFIX), tpt, EmptyTree)
       val evidenceParams = contextBounds map makeEvidenceParam
 
       val vparamssLast = if(vparamss.nonEmpty) vparamss.last else Nil

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -333,9 +333,9 @@ trait Macros extends scala.tools.reflect.FastTrack with Traces {
       def param(tree: Tree): Symbol =
         paramCache.getOrElseUpdate(tree.symbol, {
           val sym = tree.symbol
-          val sigParam = makeParam(sym.name, sym.pos, implType(sym.isType, sym.tpe))
-          if (sym.isSynthetic) sigParam.flags |= SYNTHETIC
-          sigParam
+          val ValDef(mods, _, _, _) = tree
+          val flags = sym.flags | (mods.flags & SYNTHETIC)
+          makeParam(sym.name, sym.pos, implType(sym.isType, sym.tpe), flags)
         })
 
       val paramss = List(ctxParam) :: mmap(vparamss)(param)

--- a/test/files/pos/t5744/Macros_1.scala
+++ b/test/files/pos/t5744/Macros_1.scala
@@ -1,0 +1,13 @@
+import scala.language.experimental.macros
+import scala.reflect.macros.Context
+
+object Macros {
+  def foo[U: Numeric](x: U) = macro foo_impl[U]
+
+  def foo_impl[U](c: Context)(x: c.Expr[U])(evidence: c.Expr[Numeric[U]]) = {
+    import c.universe._
+    val plusOne = Apply(Select(evidence.tree, newTermName("plus")), List(x.tree, Literal(Constant(1))))
+    val body = Apply(Select(Ident(definitions.PredefModule), newTermName("println")), List(plusOne))
+    c.Expr[Unit](body)
+  }
+}

--- a/test/files/pos/t5744/Test_2.scala
+++ b/test/files/pos/t5744/Test_2.scala
@@ -1,0 +1,4 @@
+object Test extends App {
+  import Macros._
+  foo(42)
+}


### PR DESCRIPTION
The macro def <-> macro impl correspondence check compares names of the
corresponding parameters in def and impl and reports an error if they
don't match. This was originally designed to avoid confusion w.r.t named
arguments (which ended up being never implemented as described in SI-5920).

Sometimes parameter names are generated by the compiler, which puts the
user in a tough position. Luckily, there's an escape hatch built it, which
omits the name correspondence check if one of the parameters are SYNTHETIC.
Everything went well until we realized that evidences generated by
context bounds aren't SYNTHETIC, which led to the bug at hand.

Marking auto-generated evidence parameters SYNTHETIC was only the first
step, as the correspondence checker uses parameter symbols, not parameter
trees. Why's that a problem? Because SYNTHETIC doesn't get propagated from def
trees to their underlying symbols (see ValueParameterFlags).

Unfortunately one cannot just change ValueParameterFlags, because that
would break printouts generated in TypeDiagnostics, which is designed to not
print synthetic symbols.

Therefore now we not only check paramSym.flags, but also paramDef.mods.flags
when doing corresponce sweeps. This fixes the problem and doesn't mess up
error messages and debug printouts.
