### PR TITLE
Update src/library/scala/sys/process/package.scala

### DIFF
--- a/src/library/scala/sys/process/package.scala
+++ b/src/library/scala/sys/process/package.scala
@@ -25,7 +25,7 @@ package scala.sys {
     *
     * {{{
     * import scala.sys.process._
-    * "ls" #| "grep .scala" #&& "scalac *.scala" #|| "echo nothing found" lines
+    * "ls" #| "grep .scala" #&& Seq("sh", "-c", "scalac *.scala") #|| "echo nothing found" lines
     * }}}
     *
     * We describe below the general concepts and architecture of the package,


### PR DESCRIPTION
Fix broken wildcard expansion in the `sys.process` docs. (Using `"sh -c 'scalac *.scala'"` did not work.)
