### PR TITLE
SI-7070 Turn restriction on companions in pkg objs into warning

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -175,7 +175,6 @@ trait ScalaSettings extends AbsScalaSettings
   val etaExpandKeepsStar = BooleanSetting ("-Yeta-expand-keeps-star", "Eta-expand varargs methods to T* rather than Seq[T].  This is a temporary option to ease transition.")
   val Yinvalidate     = StringSetting     ("-Yinvalidate", "classpath-entry", "Invalidate classpath entry before run", "")
   val noSelfCheck     = BooleanSetting    ("-Yno-self-type-checks", "Suppress check for self-type conformance among inherited members.")
-  val companionsInPkgObjs = BooleanSetting("-Ycompanions-in-pkg-objs", "Allow companion objects and case classes in package objects. See issue SI-5954.")
   val YvirtClasses    = false // too embryonic to even expose as a -Y //BooleanSetting    ("-Yvirtual-classes", "Support virtual classes")
 
   val exposeEmptyPackage = BooleanSetting("-Yexpose-empty-package", "Internal only: expose the empty package.").internalOnly()

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1914,29 +1914,29 @@ trait Typers extends Modes with Adaptations with Tags {
 
       // SI-5954. On second compile of a companion class contained in a package object we end up
       // with some confusion of names which leads to having two symbols with the same name in the
-      // same owner. Until that can be straightened out we can't allow companion objects in package
+      // same owner. Until that can be straightened out we will warn on companion objects in package
       // objects. But this code also tries to be friendly by distinguishing between case classes and
       // user written companion pairs
-      def restrictPackageObjectMembers(mdef : ModuleDef) = for (m <- mdef.symbol.info.members) {
+      def warnPackageObjectMembers(mdef : ModuleDef) = for (m <- mdef.symbol.info.members) {
         // ignore synthetic objects, because the "companion" object to a case class is synthetic and
         // we only want one error per case class
         if (!m.isSynthetic) {
           // can't handle case classes in package objects
-          if (m.isCaseClass) pkgObjectRestriction(m, mdef, "case")
+          if (m.isCaseClass) pkgObjectWarning(m, mdef, "case")
           // can't handle companion class/object pairs in package objects
           else if ((m.isClass && m.companionModule != NoSymbol && !m.companionModule.isSynthetic) ||
                    (m.isModule && m.companionClass != NoSymbol && !m.companionClass.isSynthetic))
-                     pkgObjectRestriction(m, mdef, "companion")
+                     pkgObjectWarning(m, mdef, "companion")
         }
 
-        def pkgObjectRestriction(m : Symbol, mdef : ModuleDef, restricted : String) = {
+        def pkgObjectWarning(m : Symbol, mdef : ModuleDef, restricted : String) = {
           val pkgName = mdef.symbol.ownerChain find (_.isPackage) map (_.decodedName) getOrElse mdef.symbol.toString
-          context.error(if (m.pos.isDefined) m.pos else mdef.pos, s"implementation restriction: package object ${pkgName} cannot contain ${restricted} ${m}. Instead, ${m} should be placed directly in package ${pkgName}.")
+          context.warning(if (m.pos.isDefined) m.pos else mdef.pos, s"${m} should be placed directly in package ${pkgName} instead of package object ${pkgName}. Under some circumstances companion objects and case classes in package objects can fail to recompile. See https://issues.scala-lang.org/browse/SI-5954.")
         }
       }
 
-      if (!settings.companionsInPkgObjs.value && mdef.symbol.isPackageObject)
-        restrictPackageObjectMembers(mdef)
+      if (mdef.symbol.isPackageObject)
+        warnPackageObjectMembers(mdef)
 
       treeCopy.ModuleDef(mdef, typedMods, mdef.name, impl2) setType NoType
     }

--- a/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
+++ b/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
@@ -47,6 +47,4 @@ abstract class MutableSettings extends AbsSettings {
   def XoldPatmat: BooleanSetting
   def XnoPatmatAnalysis: BooleanSetting
   def XfullLubs: BooleanSetting
-  def companionsInPkgObjs: BooleanSetting
-  
 }

--- a/src/reflect/scala/reflect/runtime/Settings.scala
+++ b/src/reflect/scala/reflect/runtime/Settings.scala
@@ -43,7 +43,6 @@ private[reflect] class Settings extends MutableSettings {
   val printtypes        = new BooleanSetting(false)
   val uniqid            = new BooleanSetting(false)
   val verbose           = new BooleanSetting(false)
-  val companionsInPkgObjs = new BooleanSetting(false)
 
   val Yrecursion        = new IntSetting(0)
   val maxClassfileName  = new IntSetting(255)

--- a/test/files/neg/t5954.check
+++ b/test/files/neg/t5954.check
@@ -1,16 +1,16 @@
-t5954.scala:36: error: implementation restriction: package object A cannot contain case class D. Instead, class D should be placed directly in package A.
+t5954.scala:36: error: class D should be placed directly in package A instead of package object A. Under some circumstances companion objects and case classes in package objects can fail to recompile. See https://issues.scala-lang.org/browse/SI-5954.
   case class D()
              ^
-t5954.scala:35: error: implementation restriction: package object A cannot contain companion object C. Instead, object C should be placed directly in package A.
+t5954.scala:35: error: object C should be placed directly in package A instead of package object A. Under some circumstances companion objects and case classes in package objects can fail to recompile. See https://issues.scala-lang.org/browse/SI-5954.
   object C
          ^
-t5954.scala:34: error: implementation restriction: package object A cannot contain companion trait C. Instead, trait C should be placed directly in package A.
+t5954.scala:34: error: trait C should be placed directly in package A instead of package object A. Under some circumstances companion objects and case classes in package objects can fail to recompile. See https://issues.scala-lang.org/browse/SI-5954.
   trait C
         ^
-t5954.scala:33: error: implementation restriction: package object A cannot contain companion object B. Instead, object B should be placed directly in package A.
+t5954.scala:33: error: object B should be placed directly in package A instead of package object A. Under some circumstances companion objects and case classes in package objects can fail to recompile. See https://issues.scala-lang.org/browse/SI-5954.
   object B
          ^
-t5954.scala:32: error: implementation restriction: package object A cannot contain companion class B. Instead, class B should be placed directly in package A.
+t5954.scala:32: error: class B should be placed directly in package A instead of package object A. Under some circumstances companion objects and case classes in package objects can fail to recompile. See https://issues.scala-lang.org/browse/SI-5954.
   class B
         ^
 5 errors found

--- a/test/files/neg/t5954.flags
+++ b/test/files/neg/t5954.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/t5954.scala
+++ b/test/files/neg/t5954.scala
@@ -1,4 +1,4 @@
-// if you ever think you've fixed the underlying reason for the implementation restrictions
+// if you ever think you've fixed the underlying reason for the warning
 // imposed by SI-5954, then here's a test that should pass with two "succes"es
 //
 //import scala.tools.partest._

--- a/test/files/pos/package-case.flags
+++ b/test/files/pos/package-case.flags
@@ -1,1 +1,0 @@
--Ycompanions-in-pkg-objs

--- a/test/files/pos/t2130-1.flags
+++ b/test/files/pos/t2130-1.flags
@@ -1,1 +1,0 @@
--Ycompanions-in-pkg-objs

--- a/test/files/pos/t2130-2.flags
+++ b/test/files/pos/t2130-2.flags
@@ -1,1 +1,0 @@
--Ycompanions-in-pkg-objs

--- a/test/files/pos/t3999b.flags
+++ b/test/files/pos/t3999b.flags
@@ -1,1 +1,0 @@
--Ycompanions-in-pkg-objs

--- a/test/files/pos/t4052.flags
+++ b/test/files/pos/t4052.flags
@@ -1,1 +1,0 @@
--Ycompanions-in-pkg-objs


### PR DESCRIPTION
The implementation restriction created from SI-5954 in
3ef487ecb6733bfe3c13d89780ebcfc81f9a5ea0 has two problems.

1) The problematic code works fine if compile with sbt. That means the
restriction is breaking some people needlessly.

2) It's not binary compatible.

To fix all that this commit changes the error into a warning and removes
the setting used to get around the restriction.
