### PR TITLE
SI-7096 SubstSymMap copies trees before modifying their symbols

### DIFF
--- a/test/files/run/t7096.check
+++ b/test/files/run/t7096.check
@@ -1,0 +1,2 @@
+testing symbol List(method foo, class Base, package ano, package <root>), param value x, xRefs List(x)
+testing symbol List(method foo, class Sub, package ano, package <root>), param value x, xRefs List(x)

--- a/test/files/run/t7096.scala
+++ b/test/files/run/t7096.scala
@@ -1,0 +1,36 @@
+import scala.tools.partest._
+import scala.tools.nsc._
+
+object Test extends CompilerTest {
+  import global._
+  import definitions._
+
+  override def code = """
+package ano
+
+class ann(x: Any) extends annotation.TypeConstraint
+
+abstract class Base {
+  def foo(x: String): String @ann(x.trim())
+}
+
+class Sub extends Base {
+  def foo(x: String): String @ann(x.trim()) = x
+}
+  """
+
+  object syms extends SymsInPackage("ano")
+  import syms._
+
+  def check(source: String, unit: global.CompilationUnit) {
+    afterTyper {
+      terms.filter(_.name.toString == "foo").foreach(sym => {
+        val xParam = sym.tpe.paramss.flatten.head
+        val annot = sym.tpe.finalResultType.annotations.head
+        val xRefs = annot.args.head.filter(t => t.symbol == xParam)
+        println(s"testing symbol ${sym.ownerChain}, param $xParam, xRefs $xRefs")
+        assert(xRefs.length == 1, xRefs)
+      })
+    }
+  }
+}


### PR DESCRIPTION
I removed some strange code in a06d31f6a2 and replaced it by something
incorrect: SubstSymMap should never have side-effects: otherwise,
calling 'tpe1 <: tpe2' for instance would modify the symbols in
annotations of tpe2.

SubstSymMap now always creates new trees before changing them.

Comes with a fancy test! I verified that the test fails on 2.10.x before the patch.

Review by @adriaanm
