### PR TITLE
SI-6370 changed ListMap apply0 method to produce correct error message

### DIFF
--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -156,8 +156,12 @@ extends AbstractMap[A, B]
      *  @return     the value associated with the given key.
      */
     override def apply(k: A): B1 = apply0(this, k)
-
-    @tailrec private def apply0(cur: ListMap[A, B1], k: A): B1 = if (k == cur.key) cur.value else apply0(cur.tail, k)
+ 
+    
+    @tailrec private def apply0(cur: ListMap[A, B1], k: A): B1 = 
+      if (cur.isEmpty) throw new NoSuchElementException("key not found: "+k)
+      else if (k == cur.key) cur.value
+      else apply0(cur.tail, k)  
 
     /** Checks if this map maps `key` to a value and return the
      *  value if it exists.

--- a/test/files/run/t6370.scala
+++ b/test/files/run/t6370.scala
@@ -1,0 +1,12 @@
+object Test {
+
+  def main(args: Array[String]): Unit = {
+      val m = collection.immutable.ListMap( "x" -> 1 )
+      try {
+         m("y")
+      } catch {
+         case e : NoSuchElementException => assert(e.getMessage() == "key not found: y")
+      }
+
+  }
+}


### PR DESCRIPTION
Current implementation of apply0 relies on tail method to iterate over all keys.
When the list gets to its end, tail produces an 'empty map' message in its exception, which is thrown by ListMap. This change checks if the collection is empty before calling tail and provides a more appropriate key not found message.

Implementation already discussed on PR: https://github.com/scala/scala/pull/2009
review by @phaller
