### PR TITLE
SI-6935 Added readResolve in BoxedUnit

### DIFF
--- a/src/library/scala/runtime/BoxedUnit.java
+++ b/src/library/scala/runtime/BoxedUnit.java
@@ -17,6 +17,8 @@ public final class BoxedUnit implements java.io.Serializable {
     public final static BoxedUnit UNIT = new BoxedUnit();
 
     public final static Class<Void> TYPE = java.lang.Void.TYPE;
+    
+    private Object readResolve() { return UNIT; }
 
     private BoxedUnit() { }
 

--- a/test/files/run/t6935.scala
+++ b/test/files/run/t6935.scala
@@ -1,0 +1,14 @@
+object Test {
+
+  def main(args: Array[String]): Unit = {
+		  import java.io._
+		  val bytes = new ByteArrayOutputStream()
+		  val out = new ObjectOutputStream(bytes)
+		  out.writeObject(())
+		  out.close()
+		  val buf = bytes.toByteArray
+		  val in = new ObjectInputStream(new ByteArrayInputStream(buf))
+		  val unit = in.readObject()
+		  assert(unit == ())
+  }
+}


### PR DESCRIPTION
When deserializing Unit, it would return an instance of Object, but not a Scala Unit.
By adding readResolve, the deserialization of Unit will work.

review by @phaller 
