### PR TITLE
SI-6225 Fix import of inherited package object implicits

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -644,7 +644,14 @@ trait Contexts { self: Analyzer =>
         new ImplicitInfo(sym.name, pre, sym)
 
     private def collectImplicitImports(imp: ImportInfo): List[ImplicitInfo] = {
-      val pre = imp.qual.tpe
+      val qual = imp.qual
+
+      val pre =
+        if (qual.tpe.typeSymbol.isPackageClass)
+          // SI-6225 important if the imported symbol is inherited by the the package object.
+          singleType(qual.tpe, qual.tpe member nme.PACKAGE)
+        else
+          qual.tpe
       def collect(sels: List[ImportSelector]): List[ImplicitInfo] = sels match {
         case List() =>
           List()

--- a/test/files/pos/t6225.scala
+++ b/test/files/pos/t6225.scala
@@ -1,0 +1,20 @@
+
+package library.x {
+  class X {
+    class Foo
+    implicit val foo: Foo = new Foo
+  }
+}
+package library {
+  package object y extends library.x.X
+}
+
+object ko {
+  import library.y.{Foo, foo}
+  implicitly[Foo]
+}
+
+object ko2 {
+  import library.y._
+  implicitly[Foo]
+}


### PR DESCRIPTION
The prefix in the ImplicitInfo must be com.acme.`package`.type,
rather than com.acme.

Review by @paulp. It could easily wait until 2.10.2 unless you're feeling lucky.
