### PR TITLE
SI-6158 Restore compile error output under partest --show-log

### DIFF
--- a/src/partest/scala/tools/partest/nest/RunnerManager.scala
+++ b/src/partest/scala/tools/partest/nest/RunnerManager.scala
@@ -817,7 +817,7 @@ class RunnerManager(kind: String, val fileManager: FileManager, params: TestRunP
         if (passed exists (x => !x)) {
           if (fileManager.showDiff || isPartestDebug)
             NestUI.normal(testDiff)
-          else if (fileManager.showLog)
+          if (fileManager.showLog)
             showLog(logFile)
         }
       }


### PR DESCRIPTION
Seems like the ifs and elses didn't quite survive e830a7ce9.

Before:

```
./test/partest --show-log test/files/run/foo.scala
Testing individual files
testing: [...]/files/run/foo.scala                                    [FAILED]
```

Now:

```
./test/partest --show-log test/files/run/foo.scala
Testing individual files
testing: [...]/files/run/foo.scala                                    [FAILED]
foo.scala:1: error: expected class or object definition
askdfjskl
^
one error found
1 of 1 tests failed (elapsed time: 00:00:01)
```

Review by @VladUreche

The part I'm not 100% sure about is the duplicated output below: we show both a diff and the full output. I could also silence the full output if the diff is non empty; suggestions here are welcome.

```
./test/partest --show-log  test/files/run/foo.scala

Testing individual files
testing: [...]/files/run/foo.scala                                    [FAILED]
1c1
< 11

---
> 1
11
```
