### PR TITLE
Tolerate symbol sharing between accessor/field.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
@@ -313,6 +313,9 @@ abstract class TreeCheckers extends Analyzer {
         }
         for {
           sym <- referencedSymbols
+          // Accessors are known to steal the type of the underlying field without cloning existential symbols at the new owner.
+          // This happens in Namer#accessorTypeCompleter. We just look the other way here.
+          if !tree.symbol.isAccessor
           if (sym.isTypeParameter || sym.isLocal) && !(tree.symbol hasTransOwner sym.owner)
         } errorFn(s"The symbol, tpe or info of tree `(${tree}) : ${info}` refers to a out-of-scope symbol, ${sym.fullLocationString}. tree.symbol.ownerChain: ${tree.symbol.ownerChain.mkString(", ")}")
       }


### PR DESCRIPTION
Recently, TreeCheckers (-Ycheck) was extended to
report on references to symbols that were not in
scope, which is often a sign that some substitution
or ownership changes have been omitted.

But, accessor methods directly use the type of the
underlying field, without cloning symbols defined
in that type, such as quantified types in existentials,
at the new owner.

My attempt to change this broke pos/existentials.scala.

Instead, I'll just look the other way in TreeCheckers.

review by @paulp
