### PR TITLE
SI-7110 Warn about naked try without catch/finally

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5336,6 +5336,13 @@ trait Typers extends Modes with Adaptations with Tags {
       }
 
       def typedTry(tree: Try) = {
+        tree match {
+          case Try(_, Nil, EmptyTree) =>
+            if (!isPastTyper) context.warning(tree.pos,
+              "A `try` without `catch` or `finally` has no effect.")
+          case _ =>
+        }
+
         var block1 = typed(tree.block, pt)
         var catches1 = typedCases(tree.catches, ThrowableClass.tpe, pt)
 

--- a/test/files/neg/t7110.check
+++ b/test/files/neg/t7110.check
@@ -1,0 +1,4 @@
+t7110.scala:2: error: A `try` without `catch` or `finally` has no effect.
+  try { ??? } // warn
+  ^
+one error found

--- a/test/files/neg/t7110.flags
+++ b/test/files/neg/t7110.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/t7110.scala
+++ b/test/files/neg/t7110.scala
@@ -1,0 +1,6 @@
+object Test {
+  try { ??? } // warn
+
+  try { ??? } finally ??? // no warn
+  try { ??? } catch { case _: Throwable => } // no warn
+}


### PR DESCRIPTION
Before, this was allowed:

```
scala> try ( 1 / 0 )
java.lang.ArithmeticException: / by zero
```

But since the advent of util.Try, the subtle difference to the
following seems dangerous:

```
scala> import util.Try
import util.Try

scala> Try ( 1 / 0 )
res4: scala.util.Try[Int] = Failure(java.lang.ArithmeticException: / by zero)
```

Discussion: https://groups.google.com/d/topic/scala-language/fy2vXD_3fF8/discussion

Review by @JamesIry
