### PR TITLE
SI-6514 Avoid spurious dead code warnings

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -427,17 +427,24 @@ trait TypeDiagnostics {
       contextWarning(pos, "imported `%s' is permanently hidden by definition of %s".format(hidden, defn.fullLocationString))
 
     object checkDead {
-      private var expr: Symbol = NoSymbol
+      private val exprStack: mutable.Stack[Symbol] = mutable.Stack(NoSymbol)
+      // The method being applied to `tree` when `apply` is called.
+      private def expr = exprStack.top
 
       private def exprOK =
         (expr != Object_synchronized) &&
         !(expr.isLabel && treeInfo.isSynthCaseSymbol(expr)) // it's okay to jump to matchEnd (or another case) with an argument of type nothing
 
-      private def treeOK(tree: Tree) = tree.tpe != null && tree.tpe.typeSymbol == NothingClass
+      private def treeOK(tree: Tree) = {
+        val isLabelDef = tree match { case _: LabelDef => true; case _ => false}
+        tree.tpe != null && tree.tpe.typeSymbol == NothingClass && !isLabelDef
+      }
 
-      def updateExpr(fn: Tree) = {
-        if (fn.symbol != null && fn.symbol.isMethod && !fn.symbol.isConstructor)
-          checkDead.expr = fn.symbol
+      @inline def updateExpr[A](fn: Tree)(f: => A) = {
+        if (fn.symbol != null && fn.symbol.isMethod && !fn.symbol.isConstructor) {
+          exprStack push fn.symbol
+          try f finally exprStack.pop()
+        } else f
       }
       def apply(tree: Tree): Tree = {
         // Error suppression will squash some of these warnings unless we circumvent it.

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3305,8 +3305,6 @@ trait Typers extends Modes with Adaptations with Tags {
                 // but behaves as if it were (=> T) => T) we need to know what is the actual
                 // target of a call.  Since this information is no longer available from
                 // typedArg, it is recorded here.
-                checkDead.updateExpr(fun)
-
                 val args1 =
                   // no expected type when jumping to a match label -- anything goes (this is ok since we're typing the translation of well-typed code)
                   // ... except during erasure: we must take the expected type into account as it drives the insertion of casts!
@@ -3361,7 +3359,9 @@ trait Typers extends Modes with Adaptations with Tags {
                 else
                   constfold(treeCopy.Apply(tree, fun, args1) setType ifPatternSkipFormals(restpe))
               }
-              handleMonomorphicCall
+              checkDead.updateExpr(fun) {
+                handleMonomorphicCall
+              }
             } else if (needsInstantiation(tparams, formals, args)) {
               //println("needs inst "+fun+" "+tparams+"/"+(tparams map (_.info)))
               inferExprInstance(fun, tparams)

--- a/test/files/pos/t6514.scala
+++ b/test/files/pos/t6514.scala
@@ -1,0 +1,11 @@
+object Test {
+  def e(msg: String) = new Exception(msg)
+
+  // this code ain't dead.
+  def a(b: Boolean) = {
+    b match {
+      case true => throw e("true")
+      case false => throw e("false")
+    }
+  }
+}


### PR DESCRIPTION
`deadCode.expr` stores the method symbol most recently encountered
in `handleMonomorphicCall`, and uses this to avoid warnings
for arguments to label jumps and `Object#synchronized` (which
sneakily acts by-name without advertising the fact in its type.)

But this scheme was insufficient if the argument itself contains
another method call, such as `matchEnd(throw e(""))`.

This commit changes the single slot to a stack, and also
grants exemption to `LabelDef` trees. They were incorrectly
flagged in the enclosed test case after I made the the first change.

Review by @paulp
