### PR TITLE
silences t6323a

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1132,7 +1132,7 @@ trait Implicits {
       )
       // todo. migrate hardcoded materialization in Implicits to corresponding implicit macros
       var materializer = atPos(pos.focus)(gen.mkMethodCall(TagMaterializers(tagClass), List(tp), if (prefix != EmptyTree) List(prefix) else List()))
-      if (settings.XlogImplicits.value) println("materializing requested %s.%s[%s] using %s".format(pre, tagClass.name, tp, materializer))
+      if (settings.XlogImplicits.value) reporter.echo(pos, "materializing requested %s.%s[%s] using %s".format(pre, tagClass.name, tp, materializer))
       if (context.macrosEnabled) success(materializer)
       // don't call `failure` here. if macros are disabled, we just fail silently
       // otherwise -Xlog-implicits will spam the long with zillions of "macros are disabled"

--- a/test/files/neg/t6323a.check
+++ b/test/files/neg/t6323a.check
@@ -1,3 +1,9 @@
+t6323a.scala:10: materializing requested scala.reflect.type.ClassTag[Test] using `package`.this.materializeClassTag[Test]()
+      val lookAtMe = m.reflect(Test("a",List(5)))
+                              ^
+t6323a.scala:11: materializing requested reflect.runtime.universe.type.TypeTag[Test] using `package`.this.materializeTypeTag[Test](scala.reflect.runtime.`package`.universe)
+      val value = u.typeOf[Test]
+                          ^
 t6323a.scala:11: `package`.this.materializeTypeTag[Test](scala.reflect.runtime.`package`.universe) is not a valid implicit value for reflect.runtime.universe.TypeTag[Test] because:
 failed to typecheck the materialized tag: 
 cannot create a TypeTag referring to local class Test.Test: use WeakTypeTag instead


### PR DESCRIPTION
Tag materialization notices enabled with -Xlog-implicits are now warnings
not printlns. Therefore, they go into stderr, not stdout, getting logged
by partest and not spamming stdout of partest.
