### PR TITLE
SI-7091 Don't try to put a protected accessor in a package.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
@@ -291,6 +291,7 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
                      currentClass.isTrait
                   && sym.isProtected
                   && sym.enclClass != currentClass
+                  && !sym.owner.isPackageClass // SI-7091 no accessor needed package owned (ie, top level) symbols
                   && !sym.owner.isTrait
                   && (sym.owner.enclosingPackageClass != currentClass.enclosingPackageClass)
                   && (qual.symbol.info.member(sym.name) ne NoSymbol)

--- a/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
@@ -67,7 +67,10 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
           case t                                  => t
         }
         acc setInfoAndEnter (tpe cloneInfo acc)
-        storeAccessorDefinition(clazz, DefDef(acc, EmptyTree))
+        // Diagnostic for SI-7091
+        if (!accDefs.contains(clazz))
+          reporter.error(sel.pos, s"Internal error: unable to store accessor definition in ${clazz}. clazz.isPackage=${clazz.isPackage}. Accessor required for ${sel} (${showRaw(sel)})")
+        else storeAccessorDefinition(clazz, DefDef(acc, EmptyTree))
         acc
       }
 

--- a/test/files/pos/t7091.scala
+++ b/test/files/pos/t7091.scala
@@ -1,0 +1,7 @@
+package p1.p2
+
+protected[p2] class C(var x: Int = 0)
+
+protected[p2] trait T {
+  new C()
+}


### PR DESCRIPTION
This shows up when a protected[pack] class has a constructor
with a default argument.

Regressed in f708b87 / SI-2296.

Review by @adriaanm
- Added commentary
- Wished I'd hit the merge button on your hastily retracted lgtm on #2110 (you tease!)
