### PR TITLE
Fix SI-7107: scala now thinks every exception is polymorphic

### DIFF
--- a/src/reflect/scala/reflect/internal/AnnotationInfos.scala
+++ b/src/reflect/scala/reflect/internal/AnnotationInfos.scala
@@ -34,6 +34,9 @@ trait AnnotationInfos extends api.Annotations { self: SymbolTable =>
     }
 
     def addThrowsAnnotation(throwableSym: Symbol): Self = {
+      // we call initialize due to the fact that we call Symbol.isMonomorphicType below
+      // and that method requires Symbol to be forced to give the right answers, see SI-7107 for details
+      throwableSym.initialize
       val throwableTpe = if (throwableSym.isMonomorphicType) throwableSym.tpe else {
         debuglog(s"Encountered polymorphic exception `${throwableSym.fullName}` while parsing class file.")
         // in case we encounter polymorphic exception the best we can do is to convert that type to


### PR DESCRIPTION
We need to force info of the `throwableSym` in `addThrowsAnnotation`
because we call `Symbol.isMonomorphicType` that relies on a symbol
being initialized to give right answers.

In the future we should just clean up implementation of
`isMonomorphicType` method to not rely on a symbol being initialized
as there's no inherent reason for that in most cases. In cases where
there's reason for that we should just force the initialization.
