### PR TITLE
Fix SI-7107: scala now thinks every exception is polymorphic

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -1044,6 +1044,9 @@ abstract class ClassfileParser {
       for (n <- 0 until nClasses) {
         // FIXME: this performs an equivalent of getExceptionTypes instead of getGenericExceptionTypes (SI-7065)
         val cls = pool.getClassSymbol(in.nextChar.toInt)
+        // we call initialize due to the fact that we call Symbol.isMonomorphicType in addThrowsAnnotation
+        // and that method requires Symbol to be forced to give the right answers, see SI-7107 for details
+        cls.initialize
         sym.addThrowsAnnotation(cls)
       }
     }


### PR DESCRIPTION
We need to force info of the `throwableSym` in `addThrowsAnnotation`
because we call `Symbol.isMonomorphicType` that relies on a symbol
being initialized to give right answers.

In the future we should just clean up implementation of
`isMonomorphicType` method to not rely on a symbol being initialized
as there's no inherent reason for that in most cases. In cases where
there's reason for that we should just force the initialization.
