### PR TITLE
Remove special casing of sourcepath when settings.isScaladoc.

### DIFF
--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -193,15 +193,7 @@ class PathResolver(settings: Settings, context: JavaContext) {
     def javaUserClassPath   = if (useJavaClassPath) Defaults.javaUserClassPath else ""
     def scalaBootClassPath  = cmdLineOrElse("bootclasspath", Defaults.scalaBootClassPath)
     def scalaExtDirs        = cmdLineOrElse("extdirs", Defaults.scalaExtDirs)
-    /** Scaladoc doesn't need any bootstrapping, otherwise will create errors such as:
-     * [scaladoc] ../scala-trunk/src/reflect/scala/reflect/macros/Reifiers.scala:89: error: object api is not a member of package reflect
-     * [scaladoc] case class ReificationException(val pos: reflect.api.PositionApi, val msg: String) extends Throwable(msg)
-     * [scaladoc]                                              ^
-     * because the bootstrapping will look at the sourcepath and create package "reflect" in "<root>"
-     * and then when typing relative names, instead of picking <root>.scala.relect, typedIdentifier will pick up the
-     * <root>.reflect package created by the bootstrapping. Thus, no bootstrapping for scaladoc!
-     * TODO: we should refactor this as a separate -bootstrap option to have a clean implementation, no? */
-    def sourcePath          = if (!settings.isScaladoc) cmdLineOrElse("sourcepath", Defaults.scalaSourcePath) else ""
+    def sourcePath          = cmdLineOrElse("sourcepath", Defaults.scalaSourcePath)
 
     /** Against my better judgment, giving in to martin here and allowing
      *  CLASSPATH to be used automatically.  So for the user-specified part


### PR DESCRIPTION
It's a poor coincidence that scaladoc uses sourcepath for its purposes, that has
to be fixed in 2.11, but for 2.10 it makes sense to simply remove that code. [nomerge]
