### PR TITLE
Fix SI-7130: Memory leaked caused by Statistics

### DIFF
--- a/src/reflect/scala/reflect/internal/util/Statistics.scala
+++ b/src/reflect/scala/reflect/internal/util/Statistics.scala
@@ -109,7 +109,7 @@ quant)
    *  Quantities with non-empty prefix are printed in the statistics info.
    */
   trait Quantity {
-    if (prefix.nonEmpty) {
+    if (enabled && prefix.nonEmpty) {
       val key = s"${if (underlying != this) underlying.prefix else ""}/$prefix"
       qs(key) = this
     }


### PR DESCRIPTION
As described in the ticket, we were leaking memory by holding reference
to Global through by-name argument that was captured by an instance of
a class stored in global HashMap `qs`.

The fix is simple: do not register quantities in HashMap unless statistics
is enabled. This way, if Statistics is disabled we do not store any
references.

We still leak memory in case of statistics being enabled.
