### PR TITLE
make Future scaladoc examples up-to-date and compilable

### DIFF
--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -107,7 +107,7 @@ class ArrayBuffer[A](override protected val initialSize: Int)
    *  the identity of the buffer. It takes time linear in
    *  the buffer size.
    *
-   *  @param elem  the element to append.
+   *  @param elem  the element to prepend.
    *  @return      the updated buffer.
    */
   def +=:(elem: A): this.type = {

--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -299,8 +299,8 @@ trait Future[+T] extends Awaitable[T] {
    *  val f = future { 5 }
    *  val g = f filter { _ % 2 == 1 }
    *  val h = f filter { _ % 2 == 0 }
-   *  await(g, 0) // evaluates to 5
-   *  await(h, 0) // throw a NoSuchElementException
+   *  Await.result(g, Duration.Zero) // evaluates to 5
+   *  Await.result(h, Duration.Zero) // throw a NoSuchElementException
    *  }}}
    */
   def filter(pred: T => Boolean)(implicit executor: ExecutionContext): Future[T] = {
@@ -348,8 +348,8 @@ trait Future[+T] extends Awaitable[T] {
    *  val h = f collect {
    *    case x if x > 0 => x * 2
    *  }
-   *  await(g, 0) // evaluates to 5
-   *  await(h, 0) // throw a NoSuchElementException
+   *  Await.result(g, Duration.Zero) // evaluates to 5
+   *  Await.result(h, Duration.Zero) // throw a NoSuchElementException
    *  }}}
    */
   def collect[S](pf: PartialFunction[T, S])(implicit executor: ExecutionContext): Future[S] = {
@@ -454,7 +454,7 @@ trait Future[+T] extends Awaitable[T] {
    *  val f = future { sys.error("failed") }
    *  val g = future { 5 }
    *  val h = f fallbackTo g
-   *  await(h, 0) // evaluates to 5
+   *  Await.result(h, Duration.Zero) // evaluates to 5
    *  }}}
    */
   def fallbackTo[U >: T](that: Future[U]): Future[U] = {
@@ -634,7 +634,7 @@ object Future {
    *
    *  Example:
    *  {{{
-   *    val result = Await.result(Futures.reduce(futures)(_ + _), 5 seconds)
+   *    val result = Await.result(Future.reduce(futures)(_ + _), 5 seconds)
    *  }}}
    */
   def reduce[T, R >: T](futures: TraversableOnce[Future[T]])(op: (R, T) => R)(implicit executor: ExecutionContext): Future[R] = {

--- a/src/library/scala/math/BigInt.scala
+++ b/src/library/scala/math/BigInt.scala
@@ -253,7 +253,7 @@ class BigInt(val bigInteger: BigInteger) extends ScalaNumber with ScalaNumericCo
    */
   def gcd (that: BigInt): BigInt = new BigInt(this.bigInteger.gcd(that.bigInteger))
 
-  /** Returns a BigInt whose value is (this mod m).
+  /** Returns a BigInt whose value is (this mod that).
    *  This method differs from `%` in that it always returns a non-negative BigInt.
    */
   def mod (that: BigInt): BigInt = new BigInt(this.bigInteger.mod(that.bigInteger))


### PR DESCRIPTION
Hi There, 
I've stumbled upon some examples in Future's scaladoc which are obsolete and will not compile. That's definitely not a critical thing, but I think it should go to 2.10.x b/c Future is a new "feature" class in 2.10 and lots of users who are going to migrate to 2.10 can find that confusing. 
There are also two unrelated minor corrections to ArrayBuffer and BigInt scaladocs.
~
Eugene

review by @heathermiller, @axel22
