### PR TITLE
Fix and optimization in overriding logic.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -573,8 +573,7 @@ trait Contexts { self: Analyzer =>
              (  superAccess
              || pre.isInstanceOf[ThisType]
              || phase.erasedTypes
-             || isProtectedAccessOK(sym)
-             || (sym.allOverriddenSymbols exists isProtectedAccessOK)
+             || (sym.overrideChain exists isProtectedAccessOK)
                 // that last condition makes protected access via self types work.
              )
         )

--- a/test/files/run/all-overridden.check
+++ b/test/files/run/all-overridden.check
@@ -1,0 +1,1 @@
+method g

--- a/test/files/run/all-overridden.scala
+++ b/test/files/run/all-overridden.scala
@@ -1,0 +1,11 @@
+import scala.reflect.runtime.universe._
+
+object Test {
+  trait Foo { def f: Int = 5 ; def g: Int }
+  trait Bar extends Foo { def f: Int ; def g: Int = 5 }
+
+  def main(args: Array[String]): Unit = {
+    // We should see g, but not f or $init$.
+    typeOf[Bar].declarations.toList.flatMap(_.allOverriddenSymbols) foreach println
+  }
+}


### PR DESCRIPTION
Given:

  trait Foo { def f: Int = 5 }
  trait Bar extends Foo { def f: Int }

I noticed allOverriddenSymbols for the abstract f defined in Bar
was returning the method from Foo, even though an abstract method
cannot override a concrete one. There were other bits of code
which accidentally depended on this outcome. Now allOverriddenSymbols
for Bar is empty.

The optimization is that whether or not a symbol overrides
any other symbols is known at creation time and does not change.
We now spend a lot less time looking for overridden symbols in
base classes by storing that value, "isOverridingSymbol".
