### PR TITLE
Fixed error in reflection API docs about linearization order on method baseClasses

### DIFF
--- a/src/reflect/scala/reflect/api/Symbols.scala
+++ b/src/reflect/scala/reflect/api/Symbols.scala
@@ -946,7 +946,7 @@ trait Symbols { self: Universe =>
     def knownDirectSubclasses: Set[Symbol]
 
     /** The list of all base classes of this type (including its own typeSymbol)
-     *  in reverse linearization order, starting with the class itself and ending
+     *  in linearization order, starting with the class itself and ending
      *  in class Any.
      *
      *  @group Class

--- a/src/reflect/scala/reflect/api/Types.scala
+++ b/src/reflect/scala/reflect/api/Types.scala
@@ -149,7 +149,7 @@ trait Types { self: Universe =>
     def =:= (that: Type): Boolean
 
     /** The list of all base classes of this type (including its own typeSymbol)
-     *  in reverse linearization order, starting with the class itself and ending
+     *  in linearization order, starting with the class itself and ending
      *  in class Any.
      */
     def baseClasses: List[Symbol]


### PR DESCRIPTION
Doc comment for method `baseClasses` in `SymbolAPI` and `TypeAPI` incorrectly claims that the method returns a list of base classes in reverse linearization order, when the list returned is actually in linearization order (not in reverse).

For fun, the spec (ignore references to `ScalaObject`):
![](http://f.cl.ly/items/1v1l2y1v3v1A3U0B3m35/Screen%20Shot%202013-02-19%20at%2010.34.25%20PM.png)

review by @retronym, @xeno-by
