### PR TITLE
[nomaster] nightly tests binary compat and osgi

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -22,7 +22,7 @@ END-USER TARGETS
   <target name="clean" depends="quick.clean"
     description="Removes binaries of compiler and library. Distributions are untouched."/>
 
-  <target name="test" depends="test.done, osgi.test, bc.run"
+  <target name="test" depends="test.done"
     description="Runs test suite and bootstrapping test on Scala compiler and library."/>
 
   <target name="test-opt"
@@ -92,6 +92,7 @@ END-USER TARGETS
     <antcall target="starr.done"/>
     <antcall target="locker.clean"/>
     <antcall target="test.done"/>
+
   </target>
 
   <target name="replacestarr-opt"
@@ -2643,7 +2644,7 @@ BOOTRAPING TEST AND TEST SUITE
     </partest>
   </target>
 
-  <target name="test.done" depends="test.suite, test.continuations.suite, test.scaladoc, test.stability, test.sbt"/>
+  <target name="test.done" depends="test.suite, test.continuations.suite, test.scaladoc, bc.run, osgi.test, test.stability, test.sbt"/>
 
 
 <!-- ===========================================================================

--- a/build.xml
+++ b/build.xml
@@ -2657,7 +2657,7 @@ Binary compatibility testing
     <mkdir dir="${bc-build.dir}"/>
     <!-- Pull down MIMA -->
     <artifact:dependencies pathId="mima.classpath">
-      <dependency groupId="com.typesafe" artifactId="mima-reporter_2.9.2" version="0.1.5-SNAPSHOT"/>
+      <dependency groupId="com.typesafe" artifactId="mima-reporter_2.9.2" version="0.1.5"/>
     </artifact:dependencies>
     <artifact:dependencies pathId="old.bc.classpath">
       <dependency groupId="org.scala-lang" artifactId="scala-swing" version="2.10.0"/>


### PR DESCRIPTION
Together with af0da51e1b, this reenables testing binary compatibility
as part of PR validation, on check-in of every commit, and during the nightly.

NOTE: depends on https://github.com/typesafehub/migration-manager/pull/30 and a new migration manager release
