### PR TITLE
SI-7164 - Removing NotImplementedError as Fatal from s.u.c.NonFatal

### DIFF
--- a/src/library/scala/util/control/NonFatal.scala
+++ b/src/library/scala/util/control/NonFatal.scala
@@ -11,7 +11,7 @@ package scala.util.control
 /**
  * Extractor of non-fatal Throwables. Will not match fatal errors like `VirtualMachineError`
  * (for example, `OutOfMemoryError`, a subclass of `VirtualMachineError`), `ThreadDeath`,
- * `LinkageError`, `InterruptedException`, `ControlThrowable`, or `NotImplementedError`.
+ * `LinkageError`, `InterruptedException`, `ControlThrowable`.
  * However, `StackOverflowError` is matched, i.e. considered non-fatal.
  *
  * Note that [[scala.util.control.ControlThrowable]], an internal Throwable, is not matched by
@@ -35,7 +35,7 @@ object NonFatal {
    def apply(t: Throwable): Boolean = t match {
      case _: StackOverflowError => true // StackOverflowError ok even though it is a VirtualMachineError
      // VirtualMachineError includes OutOfMemoryError and other fatal errors
-     case _: VirtualMachineError | _: ThreadDeath | _: InterruptedException | _: LinkageError | _: ControlThrowable | _: NotImplementedError => false
+     case _: VirtualMachineError | _: ThreadDeath | _: InterruptedException | _: LinkageError | _: ControlThrowable => false
      case _ => true
    }
   /**

--- a/test/files/jvm/future-spec/FutureTests.scala
+++ b/test/files/jvm/future-spec/FutureTests.scala
@@ -77,7 +77,7 @@ object FutureTests extends MinimalScalaTest {
       val logThrowable: Throwable => Unit = p.trySuccess(_)
       val ec: ExecutionContext = ExecutionContext.fromExecutor(null, logThrowable)
 
-      val t = new NotImplementedError("foo")
+      val t = new InterruptedException()
       val f = Future(throw t)(ec)
       Await.result(p.future, 2.seconds) mustBe t
     }

--- a/test/files/jvm/non-fatal-tests.scala
+++ b/test/files/jvm/non-fatal-tests.scala
@@ -7,7 +7,8 @@ trait NonFatalTests {
       Seq(new StackOverflowError,
           new RuntimeException,
           new Exception,
-          new Throwable)
+          new Throwable,
+          new NotImplementedError)
     
     //Fatals
     val fatals: Seq[Throwable] =
@@ -15,8 +16,7 @@ trait NonFatalTests {
           new OutOfMemoryError,
           new LinkageError,
           new VirtualMachineError {},
-          new Throwable with scala.util.control.ControlThrowable,
-          new NotImplementedError)
+          new Throwable with scala.util.control.ControlThrowable)
 
 	def testFatalsUsingApply(): Unit = {
 	   fatals foreach { t => assert(NonFatal(t) == false) }


### PR DESCRIPTION
Fixing docs and test and making NotImplementedError NonFatal instead of Fatal, see: https://issues.scala-lang.org/browse/SI-7164
