### PR TITLE
SI-7006 Eliminate NOPs and unreachable code

### DIFF
--- a/test/files/jvm/t7006/Foo_1.flags
+++ b/test/files/jvm/t7006/Foo_1.flags
@@ -1,0 +1,1 @@
+ -Ydead-code -Ydebug -Xfatal-warnings

--- a/test/files/jvm/t7006/Foo_1.scala
+++ b/test/files/jvm/t7006/Foo_1.scala
@@ -1,0 +1,9 @@
+class Foo_1 {
+  def foo {
+    try {
+      val x = 3
+    } finally {
+      print("hello")
+    }
+  }
+}

--- a/test/files/jvm/t7006/Foo_1.scala
+++ b/test/files/jvm/t7006/Foo_1.scala
@@ -1,9 +1,10 @@
 class Foo_1 {
   def foo {
     try {
-      val x = 3
+      val x = 3 // this will be optimized away, leaving a useless jump only block
     } finally {
       print("hello")
     }
+    while(true){} // ensure infinite loop doesn't break the algoirthm
   }
 }

--- a/test/files/jvm/t7006/Test.scala
+++ b/test/files/jvm/t7006/Test.scala
@@ -1,0 +1,18 @@
+import scala.tools.partest.BytecodeTest
+import scala.tools.asm
+import asm.tree.InsnList
+import scala.collection.JavaConverters._
+
+object Test extends BytecodeTest {
+  def show: Unit = {
+    val classNode = loadClassNode("Foo_1")
+    val methodNode = getMethod(classNode, "foo")
+    assert(countNops(methodNode.instructions) == 0)
+  }
+
+  def countNops(insnList: InsnList): Int = {
+    def isNop(node: asm.tree.AbstractInsnNode): Boolean =
+      (node.getOpcode == asm.Opcodes.NOP)
+    insnList.iterator.asScala.count(isNop)
+  }
+}

--- a/test/files/jvm/t7006/Test.scala
+++ b/test/files/jvm/t7006/Test.scala
@@ -7,12 +7,13 @@ object Test extends BytecodeTest {
   def show: Unit = {
     val classNode = loadClassNode("Foo_1")
     val methodNode = getMethod(classNode, "foo")
-    assert(countNops(methodNode.instructions) == 0)
+    assert(count(methodNode.instructions, asm.Opcodes.NOP) == 0)
+    assert(count(methodNode.instructions, asm.Opcodes.GOTO) == 1)
   }
 
-  def countNops(insnList: InsnList): Int = {
+  def count(insnList: InsnList, opcode: Int): Int = {
     def isNop(node: asm.tree.AbstractInsnNode): Boolean =
-      (node.getOpcode == asm.Opcodes.NOP)
+      (node.getOpcode == opcode)
     insnList.iterator.asScala.count(isNop)
   }
 }

--- a/test/files/run/t6102.flags
+++ b/test/files/run/t6102.flags
@@ -1,1 +1,1 @@
- -Ydead-code 
+ -Ydead-code -Ydebug -Xfatal-warnings


### PR DESCRIPTION
We were generating NOPs in two cases

1) If jump elision failed to eliminate a JUMP-only block that happened to JUMP to its next block then the code emitter would spit out a NOP. The answer was to fix jump elision to catch more jump-only blocks. Along the way a O(N*M) method was reduced to O(N)

2) Partly from jump elision and partly from other sources we were leaving behind unreachable code. ASM turned that into NOPs. The answer here was to get rid of the unreachable exception handler elision that would leave behind other unreachable code and replace it with full blown (and simpler) unreachable block elision.

PR is broken into several commits to make review a bit easier.
