### PR TITLE
fixes the test for SI-7112

### DIFF
--- a/test/files/run/reflection-java-annotations/JavaSimpleEnumeration_1.java
+++ b/test/files/run/reflection-java-annotations/JavaSimpleEnumeration_1.java
@@ -1,4 +1,4 @@
-enum JavaSimpleEnumeration_1 {
+public enum JavaSimpleEnumeration_1 {
   FOO,
   BAR
 }


### PR DESCRIPTION
Freshly released Java 1.6.0_41 for OSX fails with "IllegalAccessError:
tried to access class JavaSimpleEnumeration_1 from class sun.proxy.$Proxy6",
and rightfully so, because that class isn't public.

I think I will avoid the usual "how could this even work before" in this
commit message.
