### PR TITLE
Name boolean arguments

### DIFF
--- a/src/compiler/scala/tools/nsc/CompileSocket.scala
+++ b/src/compiler/scala/tools/nsc/CompileSocket.scala
@@ -186,7 +186,7 @@ class CompileSocket extends CompileOutputCommon {
     catch { case _: NumberFormatException => None }
 
   def getSocket(serverAdr: String): Socket = (
-    for ((name, portStr) <- splitWhere(serverAdr, _ == ':', true) ; port <- parseInt(portStr)) yield
+    for ((name, portStr) <- splitWhere(serverAdr, _ == ':', doDropIndex = true) ; port <- parseInt(portStr)) yield
       getSocket(name, port)
   ) getOrElse fatal("Malformed server address: %s; exiting" format serverAdr)
 

--- a/src/compiler/scala/tools/nsc/CompilerCommand.scala
+++ b/src/compiler/scala/tools/nsc/CompilerCommand.scala
@@ -76,9 +76,9 @@ class CompilerCommand(arguments: List[String], val settings: Settings) {
   }
 
   /** Messages explaining usage and options */
-  def usageMsg    = createUsageMsg("where possible standard", false, _.isStandard)
-  def xusageMsg   = createUsageMsg("Possible advanced", true, _.isAdvanced)
-  def yusageMsg   = createUsageMsg("Possible private", true, _.isPrivate)
+  def usageMsg    = createUsageMsg("where possible standard", shouldExplain = false, _.isStandard)
+  def xusageMsg   = createUsageMsg("Possible advanced", shouldExplain = true, _.isAdvanced)
+  def yusageMsg   = createUsageMsg("Possible private", shouldExplain = true, _.isPrivate)
 
   // If any of these settings is set, the compiler shouldn't start;
   // an informative message of some sort should be printed instead.
@@ -122,6 +122,6 @@ class CompilerCommand(arguments: List[String], val settings: Settings) {
       case x                      => List(x)
     }
 
-    settings.processArguments(expandedArguments, true)
+    settings.processArguments(expandedArguments, processAll = true)
   }
 }

--- a/src/compiler/scala/tools/nsc/GenericRunnerCommand.scala
+++ b/src/compiler/scala/tools/nsc/GenericRunnerCommand.scala
@@ -26,7 +26,7 @@ extends CompilerCommand(args, settings) {
   // change CompilerCommand behavior
   override def shouldProcessArguments: Boolean = false
 
-  private lazy val (_ok, targetAndArguments) = settings.processArguments(args, false)
+  private lazy val (_ok, targetAndArguments) = settings.processArguments(args, processAll = false)
   override def ok = _ok
   private def guessHowToRun(target: String): GenericRunnerCommand.HowToRun = {
     if (!ok) Error

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1418,10 +1418,10 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
         }
       }
       if (settings.Xshowcls.isSetByUser)
-        showDef(splitClassAndPhase(settings.Xshowcls.value, false), false, globalPhase)
+        showDef(splitClassAndPhase(settings.Xshowcls.value, term = false), declsOnly = false, globalPhase)
 
       if (settings.Xshowobj.isSetByUser)
-        showDef(splitClassAndPhase(settings.Xshowobj.value, true), false, globalPhase)
+        showDef(splitClassAndPhase(settings.Xshowobj.value, term = true), declsOnly = false, globalPhase)
     }
 
     // Similarly, this will only be created under -Yshow-syms.

--- a/src/compiler/scala/tools/nsc/OfflineCompilerCommand.scala
+++ b/src/compiler/scala/tools/nsc/OfflineCompilerCommand.scala
@@ -39,7 +39,7 @@ class OfflineCompilerCommand(arguments: List[String], settings: FscSettings) ext
 
   override def cmdName = "fsc"
   override def usageMsg = (
-    createUsageMsg("where possible fsc", false, x => x.isStandard && settings.isFscSpecific(x.name)) +
+    createUsageMsg("where possible fsc", shouldExplain = false, x => x.isStandard && settings.isFscSpecific(x.name)) +
     "\n\nStandard scalac options also available:" +
     createUsageMsg(x => x.isStandard && !settings.isFscSpecific(x.name))
   )

--- a/src/compiler/scala/tools/nsc/ScalaDoc.scala
+++ b/src/compiler/scala/tools/nsc/ScalaDoc.scala
@@ -60,7 +60,7 @@ object ScalaDoc extends ScalaDoc {
   class Command(arguments: List[String], settings: doc.Settings) extends CompilerCommand(arguments, settings) {
     override def cmdName = "scaladoc"
     override def usageMsg = (
-      createUsageMsg("where possible scaladoc", false, x => x.isStandard && settings.isScaladocSpecific(x.name)) +
+      createUsageMsg("where possible scaladoc", shouldExplain = false, x => x.isStandard && settings.isScaladocSpecific(x.name)) +
       "\n\nStandard scalac options also available:" +
       createUsageMsg(x => x.isStandard && !settings.isScaladocSpecific(x.name))
     )

--- a/src/compiler/scala/tools/nsc/ast/DocComments.scala
+++ b/src/compiler/scala/tools/nsc/ast/DocComments.scala
@@ -265,7 +265,7 @@ trait DocComments { self: Global =>
               cleanupSectionText(parent.substring(sectionTextBounds._1, sectionTextBounds._2))
             case None =>
               reporter.info(sym.pos, "The \"" + getSectionHeader + "\" annotation of the " + sym +
-                  " comment contains @inheritdoc, but the corresponding section in the parent is not defined.", true)
+                  " comment contains @inheritdoc, but the corresponding section in the parent is not defined.", force = true)
               "<invalid inheritdoc annotation>"
           }
 

--- a/src/compiler/scala/tools/nsc/ast/Printers.scala
+++ b/src/compiler/scala/tools/nsc/ast/Printers.scala
@@ -128,7 +128,7 @@ trait Printers extends scala.reflect.internal.Printers { this: Global =>
         case Select(qualifier, name) =>
           printTree(qualifier)
           print(".")
-          print(quotedName(name, true))
+          print(quotedName(name, decode = true))
 
         // target.toString() ==> target.toString
         case Apply(fn, Nil)   => printTree(fn)

--- a/src/compiler/scala/tools/nsc/ast/TreeBrowsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeBrowsers.scala
@@ -169,8 +169,8 @@ abstract class TreeBrowsers {
       _setExpansionState(root, new TreePath(root.getModel.getRoot))
     }
 
-    def expandAll(subtree: JTree) = setExpansionState(subtree, true)
-    def collapseAll(subtree: JTree) = setExpansionState(subtree, false)
+    def expandAll(subtree: JTree) = setExpansionState(subtree, expand = true)
+    def collapseAll(subtree: JTree) = setExpansionState(subtree, expand = false)
 
 
     /** Create a frame that displays the AST.

--- a/src/compiler/scala/tools/nsc/ast/TreeDSL.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeDSL.scala
@@ -116,8 +116,8 @@ trait TreeDSL {
        *  See ticket #2168 for one illustration of AS vs. AS_ANY.
        */
       def AS(tpe: Type)       = gen.mkAsInstanceOf(target, tpe, any = true, wrapInApply = false)
-      def IS(tpe: Type)       = gen.mkIsInstanceOf(target, tpe, true)
-      def IS_OBJ(tpe: Type)   = gen.mkIsInstanceOf(target, tpe, false)
+      def IS(tpe: Type)       = gen.mkIsInstanceOf(target, tpe, any = true)
+      def IS_OBJ(tpe: Type)   = gen.mkIsInstanceOf(target, tpe, any = false)
 
       def TOSTRING()          = fn(target, nme.toString_)
       def GETCLASS()          = fn(target, Object_getClass)
@@ -251,7 +251,7 @@ trait TreeDSL {
     def TRY(tree: Tree)   = new TryStart(tree, Nil, EmptyTree)
     def BLOCK(xs: Tree*)  = Block(xs.init.toList, xs.last)
     def NOT(tree: Tree)   = Select(tree, Boolean_not)
-    def SOME(xs: Tree*)   = Apply(SomeClass.companionSymbol, makeTupleTerm(xs.toList, true))
+    def SOME(xs: Tree*)   = Apply(SomeClass.companionSymbol, makeTupleTerm(xs.toList, flattenUnary = true))
 
     /** Typed trees from symbols. */
     def THIS(sym: Symbol)             = gen.mkAttributedThis(sym)

--- a/src/compiler/scala/tools/nsc/ast/parser/MarkupParsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/MarkupParsers.scala
@@ -256,7 +256,7 @@ trait MarkupParsers {
       val (qname, attrMap) = xTag(())
       if (ch == '/') { // empty element
         xToken("/>")
-        handle.element(r2p(start, start, curOffset), qname, attrMap, true, new ListBuffer[Tree])
+        handle.element(r2p(start, start, curOffset), qname, attrMap, empty = true, new ListBuffer[Tree])
       }
       else { // handle content
         xToken('>')
@@ -270,7 +270,7 @@ trait MarkupParsers {
         val pos = r2p(start, start, curOffset)
         qname match {
           case "xml:group" => handle.group(pos, ts)
-          case _ => handle.element(pos, qname, attrMap, false, ts)
+          case _ => handle.element(pos, qname, attrMap, empty = false, ts)
         }
       }
     }

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -915,7 +915,7 @@ trait Scanners extends ScannersCommon {
       }
     }
 
-    def intVal: Long = intVal(false)
+    def intVal: Long = intVal(negated = false)
 
     /** Convert current strVal, base to double value
     */
@@ -947,7 +947,7 @@ trait Scanners extends ScannersCommon {
       }
     }
 
-    def floatVal: Double = floatVal(false)
+    def floatVal: Double = floatVal(negated = false)
 
     def checkNoLetter() {
       if (isIdentifierPart(ch) && ch >= ' ')
@@ -1431,7 +1431,7 @@ trait Scanners extends ScannersCommon {
               while (lin < lineStart.length && column(lineStart(lin)) > lindent)
                 lin += 1
               if (lin < lineStart.length) {
-                val patches1 = insertPatch(patches, BracePatch(lineStart(lin), true))
+                val patches1 = insertPatch(patches, BracePatch(lineStart(lin), inserted = true))
                 //println("patch for "+bp+"/"+imbalanceMeasure+"/"+new ParensAnalyzer(unit, patches1).imbalanceMeasure)
                 /*if (improves(patches1))*/
                 patches1
@@ -1452,7 +1452,7 @@ trait Scanners extends ScannersCommon {
           else {
             val patches1 = delete(nested)
             if (patches1 ne patches) patches1
-            else insertPatch(patches, BracePatch(roff, false))
+            else insertPatch(patches, BracePatch(roff, inserted = false))
           }
       }
       delete(bracePairs)

--- a/src/compiler/scala/tools/nsc/ast/parser/SymbolicXMLBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/SymbolicXMLBuilder.scala
@@ -132,7 +132,7 @@ abstract class SymbolicXMLBuilder(p: Parsers#Parser, preserveWS: Boolean) {
       case (Some(pre), rest)  => (const(pre), const(rest))
       case _                  => (wild, const(n))
     }
-    mkXML(pos, true, prepat, labpat, null, null, false, args)
+    mkXML(pos, isPattern = true, prepat, labpat, null, null, empty = false, args)
   }
 
   protected def convertToTextPat(t: Tree): Tree = t match {
@@ -168,7 +168,7 @@ abstract class SymbolicXMLBuilder(p: Parsers#Parser, preserveWS: Boolean) {
   }
 
   /** Returns (Some(prefix) | None, rest) based on position of ':' */
-  def splitPrefix(name: String): (Option[String], String) = splitWhere(name, _ == ':', true) match {
+  def splitPrefix(name: String): (Option[String], String) = splitWhere(name, _ == ':', doDropIndex = true) match {
     case Some((pre, rest))  => (Some(pre), rest)
     case _                  => (None, name)
   }
@@ -246,7 +246,7 @@ abstract class SymbolicXMLBuilder(p: Parsers#Parser, preserveWS: Boolean) {
 
     val body = mkXML(
       pos.makeTransparent,
-      false,
+      isPattern = false,
       const(pre),
       const(newlabel),
       makeSymbolicAttrs,

--- a/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
@@ -688,7 +688,7 @@ abstract class GenICode extends SubComponent  {
                 ctx.bb.emit(DUP(generatedType))
                 val ctx1 = genLoadArguments(args, ctor.info.paramTypes, ctx)
 
-                val init = CALL_METHOD(ctor, Static(true))
+                val init = CALL_METHOD(ctor, Static(onInstance = true))
                 nw.init = init
                 ctx1.bb.emit(init, tree.pos)
                 ctx1
@@ -760,9 +760,9 @@ abstract class GenICode extends SubComponent  {
               debuglog("Gen CALL_METHOD with sym: " + sym + " isStaticSymbol: " + sym.isStaticMember);
               val invokeStyle =
                 if (sym.isStaticMember)
-                  Static(false)
+                  Static(onInstance = false)
                 else if (sym.isPrivate || sym.isClassConstructor)
-                  Static(true)
+                  Static(onInstance = true)
                 else
                   Dynamic
 
@@ -1265,7 +1265,7 @@ abstract class GenICode extends SubComponent  {
         case List(Literal(Constant("")), arg) =>
           debuglog("Rewriting \"\" + x as String.valueOf(x) for: " + arg)
           val ctx1 = genLoad(arg, ctx, ObjectReference)
-          ctx1.bb.emit(CALL_METHOD(String_valueOf, Static(false)), arg.pos)
+          ctx1.bb.emit(CALL_METHOD(String_valueOf, Static(onInstance = false)), arg.pos)
           ctx1
         case concatenations =>
           debuglog("Lifted string concatenations for " + tree + "\n to: " + concatenations)
@@ -1290,7 +1290,7 @@ abstract class GenICode extends SubComponent  {
       }
 
       val ctx1 = genLoad(tree, ctx, ObjectReference)
-      ctx1.bb.emit(CALL_METHOD(hashMethod, Static(false)))
+      ctx1.bb.emit(CALL_METHOD(hashMethod, Static(onInstance = false)))
       ctx1
     }
 
@@ -1481,7 +1481,7 @@ abstract class GenICode extends SubComponent  {
         val ctx1 = genLoad(l, ctx, ObjectReference)
         val ctx2 = genLoad(r, ctx1, ObjectReference)
         ctx2.bb.emitOnly(
-          CALL_METHOD(equalsMethod, if (settings.optimise.value) Dynamic else Static(false)),
+          CALL_METHOD(equalsMethod, if (settings.optimise.value) Dynamic else Static(onInstance = false)),
           CZJUMP(thenCtx.bb, elseCtx.bb, NE, BOOL)
         )
       }

--- a/src/compiler/scala/tools/nsc/backend/icode/ICodeCheckers.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/ICodeCheckers.scala
@@ -119,11 +119,11 @@ abstract class ICodeCheckers {
       clasz = cls
 
       for (f1 <- cls.fields ; f2 <- cls.fields ; if f1 < f2)
-        if (isConfict(f1, f2, false))
+        if (isConfict(f1, f2, canOverload = false))
           icodeError("Repetitive field name: " + f1.symbol.fullName)
 
       for (m1 <- cls.methods ; m2 <- cls.methods ; if m1 < m2)
-        if (isConfict(m1, m2, true))
+        if (isConfict(m1, m2, canOverload = true))
           icodeError("Repetitive method: " + m1.symbol.fullName)
 
       clasz.methods foreach check
@@ -321,14 +321,14 @@ abstract class ICodeCheckers {
       def popStackN(num: Int, instrFn: () => String = defaultInstrPrinter) = {
         List.range(0, num) map { _ =>
           val res = _popStack
-          printStackString(false, res, instrFn())
+          printStackString(isPush = false, res, instrFn())
           res
         }
       }
       def pushStackN(xs: Seq[TypeKind], instrFn: () => String) = {
         xs foreach { x =>
           stack push x
-          printStackString(true, x, instrFn())
+          printStackString(isPush = true, x, instrFn())
         }
       }
 
@@ -594,7 +594,7 @@ abstract class ICodeCheckers {
              case x if style.hasInstance  => x + 1
              case x                       => x
            }
-           if (style == Static(true))
+           if (style == Static(onInstance = true))
              checkBool(method.isPrivate || method.isConstructor, "Static call to non-private method.")
 
           checkStack(paramCount)

--- a/src/compiler/scala/tools/nsc/backend/icode/analysis/CopyPropagation.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/analysis/CopyPropagation.scala
@@ -308,7 +308,7 @@ abstract class CopyPropagation {
 
         case CALL_METHOD(method, style) => style match {
           case Dynamic =>
-            out = simulateCall(in, method, false)
+            out = simulateCall(in, method, static = false)
 
           case Static(onInstance) =>
             if (onInstance) {
@@ -326,12 +326,12 @@ abstract class CopyPropagation {
                 // put the Record back on the stack and remove the 'returned' value
                 out.stack = out.stack.drop(1 + method.info.paramTypes.length)
               } else
-                out = simulateCall(in, method, false)
+                out = simulateCall(in, method, static = false)
             } else
-              out = simulateCall(in, method, true)
+              out = simulateCall(in, method, static = true)
 
           case SuperCall(_) =>
-            out = simulateCall(in, method, false)
+            out = simulateCall(in, method, static = false)
         }
 
         case BOX(tpe) =>

--- a/src/compiler/scala/tools/nsc/backend/icode/analysis/DataFlowAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/analysis/DataFlowAnalysis.scala
@@ -79,7 +79,7 @@ trait DataFlowAnalysis[L <: SemiLattice] {
       val point = worklist.head
       worklist -= point
 
-      out(point) = lattice.lub(point.successors map in.apply, false) // TODO check for exception handlers
+      out(point) = lattice.lub(point.successors map in.apply, exceptional = false) // TODO check for exception handlers
       val input = f(point, out(point))
 
       if ((lattice.bottom == in(point)) || input != in(point)) {

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
@@ -1154,8 +1154,8 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
       )
       val methodSymbol = definitions.getMember(clasz.symbol.companionModule, androidFieldName)
       clasz addField new IField(fieldSymbol)
-      block emit CALL_METHOD(methodSymbol, Static(false))
-      block emit STORE_FIELD(fieldSymbol, true)
+      block emit CALL_METHOD(methodSymbol, Static(onInstance = false))
+      block emit STORE_FIELD(fieldSymbol, isStatic = true)
     }
 
     def legacyAddCreatorCode(clinit: asm.MethodVisitor) {
@@ -1612,7 +1612,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
           if (isStaticModule(clasz.symbol)) {
             // call object's private ctor from static ctor
             lastBlock emit NEW(REFERENCE(m.symbol.enclClass))
-            lastBlock emit CALL_METHOD(m.symbol.enclClass.primaryConstructor, Static(true))
+            lastBlock emit CALL_METHOD(m.symbol.enclClass.primaryConstructor, Static(onInstance = true))
           }
 
           if (isParcelableClass) { addCreatorCode(lastBlock) }
@@ -1620,11 +1620,11 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
           lastBlock emit RETURN(UNIT)
           lastBlock.close
 
-       	  method = m
+          method = m
        	  jmethod = clinitMethod
           jMethodName = CLASS_CONSTRUCTOR_NAME
           jmethod.visitCode()
-       	  genCode(m, false, true)
+          genCode(m, emitVars = false, isStatic = true)
           jmethod.visitMaxs(0, 0) // just to follow protocol, dummy arguments
           jmethod.visitEnd()
 

--- a/src/compiler/scala/tools/nsc/backend/opt/DeadCodeElimination.scala
+++ b/src/compiler/scala/tools/nsc/backend/opt/DeadCodeElimination.scala
@@ -114,7 +114,7 @@ abstract class DeadCodeElimination extends SubComponent {
         for (Pair(i, idx) <- bb.toList.zipWithIndex) {
 
           // utility for adding to worklist
-          def moveToWorkList() = moveToWorkListIf(true)
+          def moveToWorkList() = moveToWorkListIf(cond = true)
 
           // utility for (conditionally) adding to worklist
           def moveToWorkListIf(cond: Boolean) =
@@ -130,7 +130,7 @@ abstract class DeadCodeElimination extends SubComponent {
 
             case LOAD_LOCAL(_) =>
               defs = defs + Pair(((bb, idx)), rd.vars)
-              moveToWorkListIf(false)
+              moveToWorkListIf(cond = false)
 
             case STORE_LOCAL(l) =>
               /* SI-4935 Check whether a module is stack top, if so mark the instruction that loaded it
@@ -184,7 +184,7 @@ abstract class DeadCodeElimination extends SubComponent {
             case LOAD_MODULE(sym) if isLoadNeeded(sym) =>
               moveToWorkList() // SI-4859 Module initialization might side-effect.
             case _ => ()
-              moveToWorkListIf(false)
+              moveToWorkListIf(cond = false)
           }
           rd = rdef.interpret(bb, idx, rd)
         }

--- a/src/compiler/scala/tools/nsc/backend/opt/Inliners.scala
+++ b/src/compiler/scala/tools/nsc/backend/opt/Inliners.scala
@@ -480,8 +480,8 @@ abstract class Inliners extends SubComponent {
        * so that the first TFA that is run afterwards is able to gain more information as compared to a cold-start.
        */
       /*val totalPreInlines = */ { // Val name commented out to emphasize it is never used
-        val firstRound = preInline(true)
-        if(firstRound == 0) 0 else (firstRound + preInline(false))
+        val firstRound = preInline(isFirstRound = true)
+        if(firstRound == 0) 0 else (firstRound + preInline(isFirstRound = false))
       }
       staleOut.clear()
       splicedBlocks.clear()
@@ -869,7 +869,7 @@ abstract class Inliners extends SubComponent {
               r
 
             case CALL_METHOD(meth, Static(true)) if meth.isClassConstructor =>
-              CALL_METHOD(meth, Static(true))
+              CALL_METHOD(meth, Static(onInstance = true))
 
             case _ => i.clone()
           }

--- a/src/compiler/scala/tools/nsc/dependencies/Changes.scala
+++ b/src/compiler/scala/tools/nsc/dependencies/Changes.scala
@@ -52,7 +52,7 @@ abstract class Changes {
   private val changedTypeParams = new mutable.HashSet[String]
 
   private def sameParameterSymbolNames(sym1: Symbol, sym2: Symbol): Boolean =
-  	sameSymbol(sym1, sym2, true) || sym2.encodedName.startsWith(sym1.encodedName + nme.NAME_JOIN_STRING) // see #3140
+  	sameSymbol(sym1, sym2, simple = true) || sym2.encodedName.startsWith(sym1.encodedName + nme.NAME_JOIN_STRING) // see #3140
   private def sameSymbol(sym1: Symbol, sym2: Symbol, simple: Boolean = false): Boolean =
     if (simple) sym1.encodedName == sym2.encodedName else sym1.fullName == sym2.fullName
   private def sameFlags(sym1: Symbol, sym2: Symbol): Boolean =
@@ -121,7 +121,7 @@ abstract class Changes {
     case (NullaryMethodType(res1), NullaryMethodType(res2)) =>
       sameType(res1, res2)
     case (ExistentialType(tparams1, res1), ExistentialType(tparams2, res2)) =>
-      sameTypeParams(tparams1, tparams2)(false) && sameType(res1, res2)(false)
+      sameTypeParams(tparams1, tparams2)(strict = false) && sameType(res1, res2)(strict = false)
     case (TypeBounds(lo1, hi1), TypeBounds(lo2, hi2)) =>
       sameType(lo1, lo2) && sameType(hi1, hi2)
     case (BoundedWildcardType(bounds), _) =>
@@ -174,7 +174,7 @@ abstract class Changes {
 
     if ((from.parents zip to.parents) exists { case (t1, t2) => !sameType(t1, t2) })
       cs += Changed(toEntity(toSym))(from.parents.zip(to.parents).toString)
-    if (!sameTypeParams(from.typeParams, to.typeParams)(false))
+    if (!sameTypeParams(from.typeParams, to.typeParams)(strict = false))
       cs += Changed(toEntity(toSym))(" tparams: " + from.typeParams.zip(to.typeParams))
 
     // new members not yet visited

--- a/src/compiler/scala/tools/nsc/doc/DocFactory.scala
+++ b/src/compiler/scala/tools/nsc/doc/DocFactory.scala
@@ -94,7 +94,7 @@ class DocFactory(val reporter: Reporter, val settings: doc.Settings) { processor
 
   val documentError: PartialFunction[Throwable, Unit] = {
     case NoCompilerRunException =>
-      reporter.info(null, "No documentation generated with unsucessful compiler run", false)
+      reporter.info(null, "No documentation generated with unsucessful compiler run", force = false)
     case _: ClassNotFoundException =>
       ()
   }

--- a/src/compiler/scala/tools/nsc/doc/base/CommentFactoryBase.scala
+++ b/src/compiler/scala/tools/nsc/doc/base/CommentFactoryBase.scala
@@ -230,11 +230,11 @@ trait CommentFactoryBase { this: MemberLookupBase =>
 
       case CodeBlockStartRegex(before, marker, after) :: ls if (!inCodeBlock) =>
         if (!before.trim.isEmpty && !after.trim.isEmpty)
-          parse0(docBody, tags, lastTagKey, before :: marker :: after :: ls, false)
+          parse0(docBody, tags, lastTagKey, before :: marker :: after :: ls, inCodeBlock = false)
         else if (!before.trim.isEmpty)
-          parse0(docBody, tags, lastTagKey, before :: marker :: ls, false)
+          parse0(docBody, tags, lastTagKey, before :: marker :: ls, inCodeBlock = false)
         else if (!after.trim.isEmpty)
-          parse0(docBody, tags, lastTagKey, marker :: after :: ls, true)
+          parse0(docBody, tags, lastTagKey, marker :: after :: ls, inCodeBlock = true)
         else lastTagKey match {
           case Some(key) =>
             val value =
@@ -242,18 +242,18 @@ trait CommentFactoryBase { this: MemberLookupBase =>
                 case Some(b :: bs) => (b + endOfLine + marker) :: bs
                 case None => oops("lastTagKey set when no tag exists for key")
               }
-            parse0(docBody, tags + (key -> value), lastTagKey, ls, true)
+            parse0(docBody, tags + (key -> value), lastTagKey, ls, inCodeBlock = true)
           case None =>
-            parse0(docBody append endOfLine append marker, tags, lastTagKey, ls, true)
+            parse0(docBody append endOfLine append marker, tags, lastTagKey, ls, inCodeBlock = true)
         }
 
       case CodeBlockEndRegex(before, marker, after) :: ls =>
         if (!before.trim.isEmpty && !after.trim.isEmpty)
-          parse0(docBody, tags, lastTagKey, before :: marker :: after :: ls, true)
+          parse0(docBody, tags, lastTagKey, before :: marker :: after :: ls, inCodeBlock = true)
         if (!before.trim.isEmpty)
-          parse0(docBody, tags, lastTagKey, before :: marker :: ls, true)
+          parse0(docBody, tags, lastTagKey, before :: marker :: ls, inCodeBlock = true)
         else if (!after.trim.isEmpty)
-          parse0(docBody, tags, lastTagKey, marker :: after :: ls, false)
+          parse0(docBody, tags, lastTagKey, marker :: after :: ls, inCodeBlock = false)
         else lastTagKey match {
           case Some(key) =>
             val value =
@@ -261,9 +261,9 @@ trait CommentFactoryBase { this: MemberLookupBase =>
                 case Some(b :: bs) => (b + endOfLine + marker) :: bs
                 case None => oops("lastTagKey set when no tag exists for key")
               }
-            parse0(docBody, tags + (key -> value), lastTagKey, ls, false)
+            parse0(docBody, tags + (key -> value), lastTagKey, ls, inCodeBlock = false)
           case None =>
-            parse0(docBody append endOfLine append marker, tags, lastTagKey, ls, false)
+            parse0(docBody append endOfLine append marker, tags, lastTagKey, ls, inCodeBlock = false)
         }
 
       case SymbolTagRegex(name, sym, body) :: ls if (!inCodeBlock) =>
@@ -377,7 +377,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
 
     }
 
-    parse0(new StringBuilder(comment.size), Map.empty, None, clean(comment), false)
+    parse0(new StringBuilder(comment.size), Map.empty, None, clean(comment), inCodeBlock = false)
 
   }
 
@@ -453,7 +453,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
         else {
           jumpWhitespace()
           jump(style)
-          val p = Paragraph(inline(false))
+          val p = Paragraph(inline(isInlineEnd = false))
           blockEnded("end of list line ")
           Some(p)
         }
@@ -512,11 +512,11 @@ trait CommentFactoryBase { this: MemberLookupBase =>
     def para(): Block = {
       val p =
         if (summaryParsed)
-          Paragraph(inline(false))
+          Paragraph(inline(isInlineEnd = false))
         else {
           val s = summary()
           val r =
-            if (checkParaEnded) List(s) else List(s, inline(false))
+            if (checkParaEnded) List(s) else List(s, inline(isInlineEnd = false))
           summaryParsed = true
           Paragraph(Chain(r))
         }

--- a/src/compiler/scala/tools/nsc/doc/html/HtmlPage.scala
+++ b/src/compiler/scala/tools/nsc/doc/html/HtmlPage.scala
@@ -123,7 +123,7 @@ abstract class HtmlPage extends Page { thisPage =>
     case Text(text) => scala.xml.Text(text)
     case Summary(in) => inlineToHtml(in)
     case HtmlTag(tag) => scala.xml.Unparsed(tag)
-    case EntityLink(target, link) => linkToHtml(target, link, true)
+    case EntityLink(target, link) => linkToHtml(target, link, hasLinks = true)
   }
 
   def linkToHtml(text: Inline, link: LinkTo, hasLinks: Boolean) = link match {

--- a/src/compiler/scala/tools/nsc/doc/html/SyntaxHigh.scala
+++ b/src/compiler/scala/tools/nsc/doc/html/SyntaxHigh.scala
@@ -107,14 +107,14 @@ private[html] object SyntaxHigh {
           case '/' =>
             if (star) {
               if (level > 0) level -= 1
-              if (level == 0) i else multiline(i+1, true)
+              if (level == 0) i else multiline(i+1, star = true)
             } else
-              multiline(i+1, false)
+              multiline(i+1, star = false)
           case _ =>
-            multiline(i+1, false)
+            multiline(i+1, star = false)
         }
       }
-      if (buf(i) == '/') line(i) else multiline(i, true)
+      if (buf(i) == '/') line(i) else multiline(i, star = true)
       out.toString
     }
 
@@ -129,16 +129,16 @@ private[html] object SyntaxHigh {
           out append ch
           ch match {
             case '\\' =>
-              charlit0(i+1, true)
+              charlit0(i+1, bslash = true)
             case '\'' if !bslash =>
               i
             case _ =>
-              if (bslash && '0' <= ch && ch <= '9') charlit0(i+1, true)
-              else charlit0(i+1, false)
+              if (bslash && '0' <= ch && ch <= '9') charlit0(i+1, bslash = true)
+              else charlit0(i+1, bslash = false)
           }
         }
       }
-      charlit0(j, false)
+      charlit0(j, bslash = false)
       out.toString
     }
 
@@ -150,14 +150,14 @@ private[html] object SyntaxHigh {
         out append ch
         ch match {
           case '\\' =>
-            strlit0(i+1, true)
+            strlit0(i+1, bslash = true)
           case '"' if !bslash =>
             i
           case _ =>
-            strlit0(i+1, false)
+            strlit0(i+1, bslash = false)
         }
       }
-      strlit0(i, false)
+      strlit0(i, bslash = false)
       out.toString
     }
 
@@ -183,7 +183,7 @@ private[html] object SyntaxHigh {
         ch match {
           case 'e' | 'E' =>
             out append ch
-            expo(i+1, false)
+            expo(i+1, signed = false)
           case _ =>
             if (Character.isDigit(ch)) {
               out append ch
@@ -197,7 +197,7 @@ private[html] object SyntaxHigh {
         ch match {
           case '+' | '-' if !signed =>
             out append ch
-            expo(i+1, true)
+            expo(i+1, signed = true)
           case _ =>
             if (Character.isDigit(ch)) {
               out append ch

--- a/src/compiler/scala/tools/nsc/doc/html/page/diagram/DotDiagramGenerator.scala
+++ b/src/compiler/scala/tools/nsc/doc/html/page/diagram/DotDiagramGenerator.scala
@@ -321,7 +321,7 @@ class DotDiagramGenerator(settings: doc.Settings) extends DiagramGenerator {
     val result = if (dotOutput != null) {
       val src = scala.io.Source.fromString(dotOutput);
       try {
-        val cpa = scala.xml.parsing.ConstructingParser.fromSource(src, false)
+        val cpa = scala.xml.parsing.ConstructingParser.fromSource(src, preserveWS = false)
         val doc = cpa.document()
         if (doc != null)
           transform(doc.docElem)

--- a/src/compiler/scala/tools/nsc/doc/model/ModelFactoryImplicitSupport.scala
+++ b/src/compiler/scala/tools/nsc/doc/model/ModelFactoryImplicitSupport.scala
@@ -170,7 +170,7 @@ trait ModelFactoryImplicitSupport {
         val newContext = context.makeImplicit(context.ambiguousErrors)
         newContext.macrosEnabled = false
         val newTyper = global.analyzer.newTyper(newContext)
-          newTyper.silent(_.typed(appliedTree, EXPRmode, WildcardType), false) match {
+          newTyper.silent(_.typed(appliedTree, EXPRmode, WildcardType), reportAmbiguousErrors = false) match {
 
           case global.analyzer.SilentResultValue(t: Tree) => t
           case global.analyzer.SilentTypeError(err) =>

--- a/src/compiler/scala/tools/nsc/doc/model/diagram/DiagramDirectiveParser.scala
+++ b/src/compiler/scala/tools/nsc/doc/model/diagram/DiagramDirectiveParser.scala
@@ -63,7 +63,7 @@ trait DiagramDirectiveParser {
         NoDiagramAtAll
 
     if (template.comment.isDefined)
-      makeDiagramFilter(template, template.comment.get.inheritDiagram, defaultFilter, true)
+      makeDiagramFilter(template, template.comment.get.inheritDiagram, defaultFilter, isInheritanceDiagram = true)
     else
       defaultFilter
   }
@@ -72,7 +72,7 @@ trait DiagramDirectiveParser {
   def makeContentDiagramFilter(template: DocTemplateImpl): DiagramFilter = {
     val defaultFilter = if (template.isPackage || template.isObject) FullDiagram else NoDiagramAtAll
     if (template.comment.isDefined)
-      makeDiagramFilter(template, template.comment.get.contentDiagram, defaultFilter, false)
+      makeDiagramFilter(template, template.comment.get.contentDiagram, defaultFilter, isInheritanceDiagram = false)
     else
       defaultFilter
   }

--- a/src/compiler/scala/tools/nsc/interactive/Global.scala
+++ b/src/compiler/scala/tools/nsc/interactive/Global.scala
@@ -746,10 +746,10 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
         try {
           val tp1 = pre.memberType(alt) onTypeError NoType
           val tp2 = adaptToNewRunMap(sym.tpe) substSym (originalTypeParams, sym.owner.typeParams)
-          matchesType(tp1, tp2, false) || {
+          matchesType(tp1, tp2, alwaysMatchSimple = false) || {
             debugLog(s"findMirrorSymbol matchesType($tp1, $tp2) failed")
             val tp3 = adaptToNewRunMap(sym.tpe) substSym (originalTypeParams, alt.owner.typeParams)
-            matchesType(tp1, tp3, false) || {
+            matchesType(tp1, tp3, alwaysMatchSimple = false) || {
               debugLog(s"findMirrorSymbol fallback matchesType($tp1, $tp3) failed")
               false
             }
@@ -909,8 +909,8 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
     val locals = new Members[ScopeMember]
     val enclosing = new Members[ScopeMember]
     def addScopeMember(sym: Symbol, pre: Type, viaImport: Tree) =
-      locals.add(sym, pre, false) { (s, st) =>
-        new ScopeMember(s, st, context.isAccessible(s, pre, false), viaImport)
+      locals.add(sym, pre, implicitlyAdded = false) { (s, st) =>
+        new ScopeMember(s, st, context.isAccessible(s, pre, superAccess = false), viaImport)
       }
     def localsToEnclosing() = {
       enclosing.addNonShadowed(locals)
@@ -1012,7 +1012,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
         val vtree = viewApply(view)
         val vpre = stabilizedType(vtree)
         for (sym <- vtree.tpe.members) {
-          addTypeMember(sym, vpre, false, view.tree.symbol)
+          addTypeMember(sym, vpre, inherited = false, view.tree.symbol)
         }
       }
       //println()

--- a/src/compiler/scala/tools/nsc/interactive/REPL.scala
+++ b/src/compiler/scala/tools/nsc/interactive/REPL.scala
@@ -107,7 +107,7 @@ object REPL {
     }
 
     def doStructure(file: String) {
-      comp.askParsedEntered(toSourceFile(file), false, structureResult)
+      comp.askParsedEntered(toSourceFile(file), keepLoaded = false, structureResult)
       show(structureResult)
     }
 

--- a/src/compiler/scala/tools/nsc/interactive/ScratchPadMaker.scala
+++ b/src/compiler/scala/tools/nsc/interactive/ScratchPadMaker.scala
@@ -191,7 +191,7 @@ trait ScratchPadMaker { self: Global =>
    *                    prints its output and all defined values in a comment column.
    */
   protected def instrument(source: SourceFile, line: Int): (String, Array[Char]) = {
-    val tree = typedTree(source, true)
+    val tree = typedTree(source, forceReload = true)
     val endOffset = if (line < 0) source.length else source.lineToOffset(line + 1)
     val patcher = new Patcher(source.content, new LexicalStructure(source), endOffset)
     patcher.traverse(tree)

--- a/src/compiler/scala/tools/nsc/interactive/tests/Tester.scala
+++ b/src/compiler/scala/tools/nsc/interactive/tests/Tester.scala
@@ -199,7 +199,7 @@ class Tester(ntests: Int, inputs: Array[SourceFile], settings: Settings) {
 object Tester {
   def main(args: Array[String]) {
     val settings = new Settings()
-    val (_, filenames) = settings.processArguments(args.toList.tail, true)
+    val (_, filenames) = settings.processArguments(args.toList.tail, processAll = true)
     println("filenames = "+filenames)
     val files = filenames.toArray map (str => new BatchSourceFile(AbstractFile.getFile(str)): SourceFile)
     new Tester(args(0).toInt, files, settings).run()

--- a/src/compiler/scala/tools/nsc/interpreter/AbstractFileClassLoader.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/AbstractFileClassLoader.scala
@@ -28,12 +28,12 @@ class AbstractFileClassLoader(val root: AbstractFile, parent: ClassLoader)
     val pathParts          = name split '/'
 
     for (dirPart <- pathParts.init) {
-      file = file.lookupName(dirPart, true)
+      file = file.lookupName(dirPart, directory = true)
       if (file == null)
         return null
     }
 
-    file.lookupName(pathParts.last, false) match {
+    file.lookupName(pathParts.last, directory = false) match {
       case null   => null
       case file   => file
     }
@@ -47,7 +47,7 @@ class AbstractFileClassLoader(val root: AbstractFile, parent: ClassLoader)
     val pathParts          = dirNameToPath(name) split '/'
 
     for (dirPart <- pathParts) {
-      file = file.lookupName(dirPart, true)
+      file = file.lookupName(dirPart, directory = true)
       if (file == null)
         return null
     }

--- a/src/compiler/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/IMain.scala
@@ -535,8 +535,8 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
    *  The return value is whether the line was interpreter successfully,
    *  e.g. that there were no parse errors.
    */
-  def interpret(line: String): IR.Result = interpret(line, false)
-  def interpretSynthetic(line: String): IR.Result = interpret(line, true)
+  def interpret(line: String): IR.Result = interpret(line, synthetic = false)
+  def interpretSynthetic(line: String): IR.Result = interpret(line, synthetic = true)
   def interpret(line: String, synthetic: Boolean): IR.Result = {
     def loadAndRunReq(req: Request) = {
       classLoader.setAsContext()

--- a/src/compiler/scala/tools/nsc/interpreter/LoopCommands.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/LoopCommands.scala
@@ -39,7 +39,7 @@ trait LoopCommands {
     // called if no args are given
     def showUsage(): Result = {
       "usage is " + usageMsg
-      Result(true, None)
+      Result(keepRunning = true, None)
     }
   }
   object LoopCommand {
@@ -72,7 +72,7 @@ trait LoopCommands {
 
   object Result {
     // the default result means "keep running, and don't record that line"
-    val default = Result(true, None)
+    val default = Result(keepRunning = true, None)
 
     // most commands do not want to micromanage the Result, but they might want
     // to print something to the console, so we accomodate Unit and String returns.

--- a/src/compiler/scala/tools/nsc/interpreter/TypeStrings.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/TypeStrings.scala
@@ -30,10 +30,10 @@ trait StructuredTypeStrings extends DestructureTypes {
       else elems.mkString(ldelim, mdelim, rdelim)
     )
   }
-  val NoGrouping      = Grouping("", "", "", false)
-  val ListGrouping    = Grouping("(", ", ", ")", false)
-  val ProductGrouping = Grouping("(", ", ", ")", true)
-  val BlockGrouping   = Grouping(" { ", "; ", "}", false)
+  val NoGrouping      = Grouping("", "", "", labels = false)
+  val ListGrouping    = Grouping("(", ", ", ")", labels = false)
+  val ProductGrouping = Grouping("(", ", ", ")", labels = true)
+  val BlockGrouping   = Grouping(" { ", "; ", "}", labels = false)
 
   private def str(level: Int)(body: => String): String = "  " * level + body
   private def block(level: Int, grouping: Grouping)(name: String, nodes: List[TypeNode]): String = {
@@ -66,7 +66,7 @@ trait StructuredTypeStrings extends DestructureTypes {
     def nodes: List[TypeNode]
 
     def show(indent: Int, showLabel: Boolean): String = maybeBlock(indent, grouping)(mkPrefix(showLabel), nodes)
-    def show(indent: Int): String = show(indent, true)
+    def show(indent: Int): String = show(indent, showLabel = true)
     def show(): String = show(0)
 
     def withLabel(l: String): this.type = modifyNameInfo(_.copy(label = l))

--- a/src/compiler/scala/tools/nsc/io/Jar.scala
+++ b/src/compiler/scala/tools/nsc/io/Jar.scala
@@ -159,7 +159,7 @@ object Jar {
   private val ZipMagicNumber = List[Byte](80, 75, 3, 4)
   private def magicNumberIsZip(f: Path) = f.isFile && (f.toFile.bytes().take(4).toList == ZipMagicNumber)
 
-  def isJarOrZip(f: Path): Boolean = isJarOrZip(f, true)
+  def isJarOrZip(f: Path): Boolean = isJarOrZip(f, examineFile = true)
   def isJarOrZip(f: Path, examineFile: Boolean): Boolean =
     f.hasExtension("zip", "jar") || (examineFile && magicNumberIsZip(f))
 

--- a/src/compiler/scala/tools/nsc/io/SourceReader.scala
+++ b/src/compiler/scala/tools/nsc/io/SourceReader.scala
@@ -74,7 +74,7 @@ class SourceReader(decoder: CharsetDecoder, reporter: Reporter) {
   protected def read(bytes: ByteBuffer): Array[Char] = {
     val decoder: CharsetDecoder = this.decoder.reset()
     val chars: CharBuffer = this.chars; chars.clear()
-    terminate(flush(decoder, decode(decoder, bytes, chars, true)))
+    terminate(flush(decoder, decode(decoder, bytes, chars, endOfInput = true)))
   }
 
   //########################################################################

--- a/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
@@ -178,7 +178,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
           JavaScannerConfiguration.token2string(token) + " expected but " +
             JavaScannerConfiguration.token2string(in.token) + " found."
 
-        syntaxError(posToReport, msg, true)
+        syntaxError(posToReport, msg, skipIt = true)
       }
       if (in.token == token) in.nextToken
       pos
@@ -224,7 +224,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
         case AppliedTypeTree(_, _) | ExistentialTypeTree(_, _) | SelectFromTypeTree(_, _) =>
           tree
         case _ =>
-          syntaxError(tree.pos, "identifier expected", false)
+          syntaxError(tree.pos, "identifier expected", skipIt = false)
           errorTypeTree
       }
     }
@@ -259,7 +259,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
           case FLOAT => in.nextToken; TypeTree(FloatClass.tpe)
           case DOUBLE => in.nextToken; TypeTree(DoubleClass.tpe)
           case BOOLEAN => in.nextToken; TypeTree(BooleanClass.tpe)
-          case _ => syntaxError("illegal start of type", true); errorTypeTree
+          case _ => syntaxError("illegal start of type", skipIt = true); errorTypeTree
         }
       }
 
@@ -644,7 +644,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
       accept(SEMI)
       val names = buf.toList
       if (names.length < 2) {
-        syntaxError(pos, "illegal import", false)
+        syntaxError(pos, "illegal import", skipIt = false)
         List()
       } else {
         val qual = ((Ident(names.head): Tree) /: names.tail.init) (Select(_, _))
@@ -839,7 +839,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
       case INTERFACE => interfaceDecl(mods)
       case AT        => annotationDecl(mods)
       case CLASS     => classDecl(mods)
-      case _         => in.nextToken; syntaxError("illegal start of type declaration", true); List(errorTypeTree)
+      case _         => in.nextToken; syntaxError("illegal start of type declaration", skipIt = true); List(errorTypeTree)
     }
 
     /** CompilationUnit ::= [package QualId semi] TopStatSeq
@@ -867,7 +867,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
       while (in.token != EOF && in.token != RBRACE) {
         while (in.token == SEMI) in.nextToken
         if (in.token != EOF)
-          buf ++= typeDecl(modifiers(false))
+          buf ++= typeDecl(modifiers(inInterface = false))
       }
       accept(EOF)
       atPos(pos) {

--- a/src/compiler/scala/tools/nsc/javac/JavaScanners.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaScanners.scala
@@ -63,8 +63,8 @@ trait JavaScanners extends ast.parser.ScannersCommon {
     def next: AbstractJavaTokenData
     def intVal(negated: Boolean): Long
     def floatVal(negated: Boolean): Double
-    def intVal: Long = intVal(false)
-    def floatVal: Double = floatVal(false)
+    def intVal: Long = intVal(negated = false)
+    def floatVal: Double = floatVal(negated = false)
     def currentPos: Position
   }
 

--- a/src/compiler/scala/tools/nsc/reporters/Reporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/Reporter.scala
@@ -58,15 +58,15 @@ abstract class Reporter {
   /** For sending a message which should not be labeled as a warning/error,
    *  but also shouldn't require -verbose to be visible.
    */
-  def echo(msg: String): Unit                                = info(NoPosition, msg, true)
-  def echo(pos: Position, msg: String): Unit                 = info(pos, msg, true)
+  def echo(msg: String): Unit                                = info(NoPosition, msg, force = true)
+  def echo(pos: Position, msg: String): Unit                 = info(pos, msg, force = true)
 
   /** Informational messages, suppressed unless -verbose or force=true. */
   def info(pos: Position, msg: String, force: Boolean): Unit = info0(pos, msg, INFO, force)
 
   /** Warnings and errors. */
-  def warning(pos: Position, msg: String): Unit              = withoutTruncating(info0(pos, msg, WARNING, false))
-  def error(pos: Position, msg: String): Unit                = withoutTruncating(info0(pos, msg, ERROR, false))
+  def warning(pos: Position, msg: String): Unit              = withoutTruncating(info0(pos, msg, WARNING, force = false))
+  def error(pos: Position, msg: String): Unit                = withoutTruncating(info0(pos, msg, ERROR, force = false))
   def incompleteInputError(pos: Position, msg: String): Unit = {
     if (incompleteHandled) incompleteHandler(pos, msg)
     else error(pos, msg)

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
@@ -71,7 +71,7 @@ abstract class ICodeReader extends ClassfileParser {
   }
 
   override def parseField() {
-    val (jflags, sym) = parseMember(true)
+    val (jflags, sym) = parseMember(field = true)
     getCode(jflags) addField new IField(sym)
     skipAttributes()
   }
@@ -90,9 +90,9 @@ abstract class ICodeReader extends ClassfileParser {
         (jflags, NoSymbol)
       else {
         val owner = getOwner(jflags)
-        var sym = owner.info.findMember(name, 0, 0, false).suchThat(old => sameType(old.tpe, tpe))
+        var sym = owner.info.findMember(name, 0, 0, stableOnly = false).suchThat(old => sameType(old.tpe, tpe))
         if (sym == NoSymbol)
-          sym = owner.info.findMember(newTermName(name + nme.LOCAL_SUFFIX_STRING), 0, 0, false).suchThat(_.tpe =:= tpe)
+          sym = owner.info.findMember(newTermName(name + nme.LOCAL_SUFFIX_STRING), 0, 0, stableOnly = false).suchThat(_.tpe =:= tpe)
         if (sym == NoSymbol) {
           sym = if (field) owner.newValue(name.toTermName, owner.pos, toScalaFieldFlags(jflags)) else dummySym
           sym setInfoAndEnter tpe
@@ -119,7 +119,7 @@ abstract class ICodeReader extends ClassfileParser {
   }
 
   override def parseMethod() {
-    val (jflags, sym) = parseMember(false)
+    val (jflags, sym) = parseMember(field = false)
     val beginning = in.bp
     try {
       if (sym != NoSymbol) {
@@ -165,10 +165,10 @@ abstract class ICodeReader extends ClassfileParser {
     }
     else if (nme.isModuleName(name)) {
       val strippedName = nme.stripModuleSuffix(name)
-      forceMangledName(newTermName(strippedName.decode), true) orElse rootMirror.getModuleByName(strippedName)
+      forceMangledName(newTermName(strippedName.decode), module = true) orElse rootMirror.getModuleByName(strippedName)
     }
     else {
-      forceMangledName(name, false)
+      forceMangledName(name, module = false)
       exitingFlatten(rootMirror.getClassByName(name.toTypeName))
     }
     if (sym.isModule)
@@ -466,41 +466,41 @@ abstract class ICodeReader extends ClassfileParser {
         case JVM.return_     => code.emit(RETURN(UNIT))
 
         case JVM.getstatic    =>
-          val field = pool.getMemberSymbol(in.nextChar, true); size += 2
+          val field = pool.getMemberSymbol(in.nextChar, static = true); size += 2
           if (field.hasModuleFlag)
             code emit LOAD_MODULE(field)
           else
-            code emit LOAD_FIELD(field, true)
+            code emit LOAD_FIELD(field, isStatic = true)
         case JVM.putstatic   =>
-          val field = pool.getMemberSymbol(in.nextChar, true); size += 2
-          code.emit(STORE_FIELD(field, true))
+          val field = pool.getMemberSymbol(in.nextChar, static = true); size += 2
+          code.emit(STORE_FIELD(field, isStatic = true))
         case JVM.getfield    =>
-          val field = pool.getMemberSymbol(in.nextChar, false); size += 2
-          code.emit(LOAD_FIELD(field, false))
+          val field = pool.getMemberSymbol(in.nextChar, static = false); size += 2
+          code.emit(LOAD_FIELD(field, isStatic = false))
         case JVM.putfield    =>
-          val field = pool.getMemberSymbol(in.nextChar, false); size += 2
-          code.emit(STORE_FIELD(field, false))
+          val field = pool.getMemberSymbol(in.nextChar, static = false); size += 2
+          code.emit(STORE_FIELD(field, isStatic = false))
 
         case JVM.invokevirtual =>
-          val m = pool.getMemberSymbol(in.nextChar, false); size += 2
+          val m = pool.getMemberSymbol(in.nextChar, static = false); size += 2
           code.emit(CALL_METHOD(m, Dynamic))
         case JVM.invokeinterface  =>
-          val m = pool.getMemberSymbol(in.nextChar, false); size += 4
+          val m = pool.getMemberSymbol(in.nextChar, static = false); size += 4
           in.skip(2)
           code.emit(CALL_METHOD(m, Dynamic))
         case JVM.invokespecial   =>
-          val m = pool.getMemberSymbol(in.nextChar, false); size += 2
-          val style = if (m.name == nme.CONSTRUCTOR || m.isPrivate) Static(true)
+          val m = pool.getMemberSymbol(in.nextChar, static = false); size += 2
+          val style = if (m.name == nme.CONSTRUCTOR || m.isPrivate) Static(onInstance = true)
                       else SuperCall(m.owner.name);
           code.emit(CALL_METHOD(m, style))
         case JVM.invokestatic    =>
-          val m = pool.getMemberSymbol(in.nextChar, true); size += 2
+          val m = pool.getMemberSymbol(in.nextChar, static = true); size += 2
           if (isBox(m))
             code.emit(BOX(toTypeKind(m.info.paramTypes.head)))
           else if (isUnbox(m))
             code.emit(UNBOX(toTypeKind(m.info.resultType)))
           else
-            code.emit(CALL_METHOD(m, Static(false)))
+            code.emit(CALL_METHOD(m, Static(onInstance = false)))
 
         case JVM.new_          =>
           code.emit(NEW(REFERENCE(pool.getClassSymbol(in.nextChar))))
@@ -942,7 +942,7 @@ abstract class ICodeReader extends ClassfileParser {
           }
         case None =>
           checkValidIndex
-          val l = freshLocal(idx, kind, false)
+          val l = freshLocal(idx, kind, isArg = false)
           debuglog("Added new local for idx " + idx + ": " + kind)
           locals += (idx -> List((l, kind)))
           l
@@ -966,7 +966,7 @@ abstract class ICodeReader extends ClassfileParser {
      *  the original method. */
     def freshLocal(kind: TypeKind): Local = {
       count += 1
-      freshLocal(maxLocals + count, kind, false)
+      freshLocal(maxLocals + count, kind, isArg = false)
     }
 
     /** add a method param with the given index. */

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -1254,7 +1254,7 @@ abstract class Erasure extends AddInterfaces
         val tree2 = mixinTransformer.transform(tree1)
         // debuglog("tree after addinterfaces: \n" + tree2)
 
-        newTyper(rootContext(unit, tree, true)).typed(tree2)
+        newTyper(rootContext(unit, tree, erasedTypes = true)).typed(tree2)
       }
     }
   }

--- a/src/compiler/scala/tools/nsc/transform/Mixin.scala
+++ b/src/compiler/scala/tools/nsc/transform/Mixin.scala
@@ -148,7 +148,7 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
         sym =>
           isConcreteAccessor(sym) &&
           !sym.hasFlag(MIXEDIN) &&
-          matchesType(sym.tpe, member.tpe, true))
+          matchesType(sym.tpe, member.tpe, alwaysMatchSimple = true))
     }
     (    bcs.head != member.owner
       && (hasOverridingAccessor(bcs.head) || isOverriddenAccessor(member, bcs.tail))
@@ -273,7 +273,7 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
         val imember = member overriddenSymbol mixinInterface
         imember overridingSymbol clazz match {
           case NoSymbol =>
-            if (clazz.info.findMember(member.name, 0, lateDEFERRED, false).alternatives contains imember)
+            if (clazz.info.findMember(member.name, 0, lateDEFERRED, stableOnly = false).alternatives contains imember)
               cloneAndAddMixinMember(mixinInterface, imember).asInstanceOf[TermSymbol] setAlias member
           case _        =>
         }
@@ -855,7 +855,7 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
         val bitmapSym = bitmapFor(clazz, offset, lzyVal)
         val kind      = bitmapKind(lzyVal)
         val mask      = maskForOffset(offset, lzyVal, kind)
-        def cond      = mkTest(clazz, mask, bitmapSym, true, kind)
+        def cond      = mkTest(clazz, mask, bitmapSym, equalToZero = true, kind)
         val nulls     = lazyValNullables(lzyVal).toList sortBy (_.id) map nullify
         def syncBody  = init ::: List(mkSetFlag(clazz, offset, lzyVal, kind), UNIT)
 
@@ -882,7 +882,7 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
         val mask      = maskForOffset(offset, sym, kind)
         val msg       = s"Uninitialized field: ${unit.source}: ${pos.line}"
         val result    =
-          IF (mkTest(clazz, mask, bitmapSym, false, kind)) .
+          IF (mkTest(clazz, mask, bitmapSym, equalToZero = false, kind)) .
             THEN (retVal) .
             ELSE (Throw(NewFromConstructor(UninitializedFieldConstructor, LIT(msg))))
 

--- a/src/compiler/scala/tools/nsc/transform/TailCalls.scala
+++ b/src/compiler/scala/tools/nsc/transform/TailCalls.scala
@@ -392,7 +392,7 @@ abstract class TailCalls extends Transform {
       finally maybeTail = saved
     }
 
-    def traverseNoTail(tree: Tree) = traverse(tree, false)
+    def traverseNoTail(tree: Tree) = traverse(tree, maybeTailNew = false)
     def traverseTreesNoTail(trees: List[Tree]) = trees foreach traverseNoTail
 
     override def traverse(tree: Tree) = tree match {

--- a/src/compiler/scala/tools/nsc/transform/TypingTransformers.scala
+++ b/src/compiler/scala/tools/nsc/transform/TypingTransformers.scala
@@ -17,7 +17,7 @@ trait TypingTransformers {
   abstract class TypingTransformer(unit: CompilationUnit) extends Transformer {
     var localTyper: analyzer.Typer =
       if (phase.erasedTypes)
-        erasure.newTyper(erasure.rootContext(unit, EmptyTree, true)).asInstanceOf[analyzer.Typer]
+        erasure.newTyper(erasure.rootContext(unit, EmptyTree, erasedTypes = true)).asInstanceOf[analyzer.Typer]
       else
         analyzer.newTyper(analyzer.rootContext(unit, EmptyTree, true))
     protected var curTree: Tree = _

--- a/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
@@ -347,7 +347,7 @@ trait Logic extends Debugging  {
       val TrueF          = formula()
       val FalseF         = formula(clause())
       def lit(s: Sym)    = formula(clause(Lit(s)))
-      def negLit(s: Sym) = formula(clause(Lit(s, false)))
+      def negLit(s: Sym) = formula(clause(Lit(s, pos = false)))
 
       def conjunctiveNormalForm(p: Prop, budget: Int = AnalysisBudget.max): Formula = {
         def distribute(a: Formula, b: Formula, budget: Int): Formula =
@@ -439,7 +439,7 @@ trait Logic extends Debugging  {
               else Nil
             }
             val forced = unassigned flatMap { s =>
-              force(Lit(s, true)) ++ force(Lit(s, false))
+              force(Lit(s, pos = true)) ++ force(Lit(s, pos = false))
             }
             debug.patmat("forced "+ forced)
             val negated = negateModel(model)

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -658,7 +658,7 @@ trait MatchAnalysis extends TreeAndTypeAnalysis { self: PatternMatching =>
 
                 cls match {
                   case ConsClass               => ListExample(args())
-                  case _ if isTupleSymbol(cls) => TupleExample(args(true))
+                  case _ if isTupleSymbol(cls) => TupleExample(args(brevity = true))
                   case _ => ConstructorExample(cls, args())
                 }
 

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchCodeGen.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchCodeGen.scala
@@ -74,7 +74,7 @@ trait MatchCodeGen { self: PatternMatching =>
 
       // the force is needed mainly to deal with the GADT typing hack (we can't detect it otherwise as tp nor pt need contain an abstract type, we're just casting wildly)
       def _asInstanceOf(b: Symbol, tp: Type): Tree = if (b.info <:< tp) REF(b) else gen.mkCastPreservingAnnotations(REF(b), tp)
-      def _isInstanceOf(b: Symbol, tp: Type): Tree = gen.mkIsInstanceOf(REF(b), tp.withoutAnnotations, true, false)
+      def _isInstanceOf(b: Symbol, tp: Type): Tree = gen.mkIsInstanceOf(REF(b), tp.withoutAnnotations, any = true, wrapInApply = false)
 
       // duplicated out of frustration with cast generation
       def mkZero(tp: Type): Tree = {

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -87,8 +87,8 @@ trait Contexts { self: Analyzer =>
     else RootImports.completeList
   }
 
-  def rootContext(unit: CompilationUnit): Context             = rootContext(unit, EmptyTree, false)
-  def rootContext(unit: CompilationUnit, tree: Tree): Context = rootContext(unit, tree, false)
+  def rootContext(unit: CompilationUnit): Context             = rootContext(unit, EmptyTree, erasedTypes = false)
+  def rootContext(unit: CompilationUnit, tree: Tree): Context = rootContext(unit, tree, erasedTypes = false)
   def rootContext(unit: CompilationUnit, tree: Tree, erasedTypes: Boolean): Context = {
     var sc = startContext
     for (sym <- rootImports(unit)) {
@@ -444,7 +444,7 @@ trait Contexts { self: Analyzer =>
       else throw new TypeError(pos, msg1)
     }
 
-    def warning(pos: Position, msg: String): Unit = warning(pos, msg, false)
+    def warning(pos: Position, msg: String): Unit = warning(pos, msg, force = false)
     def warning(pos: Position, msg: String, force: Boolean) {
       if (reportErrors || force) unit.warning(pos, msg)
       else if (bufferErrors) warningsBuffer += ((pos, msg))

--- a/src/compiler/scala/tools/nsc/typechecker/EtaExpansion.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/EtaExpansion.scala
@@ -98,7 +98,7 @@ trait EtaExpansion { self: Analyzer =>
         case TypeApply(fn, args) =>
           treeCopy.TypeApply(tree, liftoutPrefix(fn), args).clearType()
         case Select(qual, name) =>
-          treeCopy.Select(tree, liftout(qual, false), name).clearType() setSymbol NoSymbol
+          treeCopy.Select(tree, liftout(qual, byName = false), name).clearType() setSymbol NoSymbol
         case Ident(name) =>
           tree
       }

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -34,7 +34,7 @@ trait Implicits {
   import global.typer.{ printTyping, deindentTyping, indentTyping, printInference }
 
   def inferImplicit(tree: Tree, pt: Type, reportAmbiguous: Boolean, isView: Boolean, context: Context): SearchResult =
-    inferImplicit(tree, pt, reportAmbiguous, isView, context, true, tree.pos)
+    inferImplicit(tree, pt, reportAmbiguous, isView, context, saveAmbiguousDivergent = true, tree.pos)
 
   def inferImplicit(tree: Tree, pt: Type, reportAmbiguous: Boolean, isView: Boolean, context: Context, saveAmbiguousDivergent: Boolean): SearchResult =
     inferImplicit(tree, pt, reportAmbiguous, isView, context, saveAmbiguousDivergent, tree.pos)
@@ -112,7 +112,7 @@ trait Implicits {
     val tvars = tpars map (TypeVar untouchable _)
     val tpSubsted = tp.subst(tpars, tvars)
 
-    val search = new ImplicitSearch(EmptyTree, functionType(List(tpSubsted), AnyClass.tpe), true, context.makeImplicit(false))
+    val search = new ImplicitSearch(EmptyTree, functionType(List(tpSubsted), AnyClass.tpe), true, context.makeImplicit(reportAmbiguousErrors = false))
 
     search.allImplicitsPoly(tvars)
   }
@@ -638,7 +638,7 @@ trait Implicits {
               printTyping(ptLine("" + info.sym, "tvars" -> tvars, "tvars.constr" -> tvars.map(_.constr)))
 
             val targs = solvedTypes(tvars, undetParams, undetParams map varianceInType(pt),
-                                    false, lubDepth(List(itree2.tpe, pt)))
+                                    upper = false, lubDepth(List(itree2.tpe, pt)))
 
             // #2421: check that we correctly instantiated type parameters outside of the implicit tree:
             checkBounds(itree2, NoPrefix, NoSymbol, undetParams, targs, "inferred ")
@@ -1162,7 +1162,7 @@ trait Implicits {
 
       /** Re-wraps a type in a manifest before calling inferImplicit on the result */
       def findManifest(tp: Type, manifestClass: Symbol = if (full) FullManifestClass else PartialManifestClass) =
-        inferImplicit(tree, appliedType(manifestClass, tp), true, false, context).tree
+        inferImplicit(tree, appliedType(manifestClass, tp), reportAmbiguous = true, isView = false, context).tree
 
       def findSubManifest(tp: Type) = findManifest(tp, if (full) FullManifestClass else OptManifestClass)
       def mot(tp0: Type, from: List[Symbol], to: List[Type]): SearchResult = {
@@ -1297,7 +1297,7 @@ trait Implicits {
       val failstart = if (Statistics.canEnable) Statistics.startTimer(inscopeFailNanos) else null
       val succstart = if (Statistics.canEnable) Statistics.startTimer(inscopeSucceedNanos) else null
 
-      var result = searchImplicit(context.implicitss, true)
+      var result = searchImplicit(context.implicitss, isLocal = true)
 
       if (result.isFailure) {
         if (Statistics.canEnable) Statistics.stopTimer(inscopeFailNanos, failstart)
@@ -1315,7 +1315,7 @@ trait Implicits {
 
         // `materializeImplicit` does some preprocessing for `pt`
         // is it only meant for manifests/tags or we need to do the same for `implicitsOfExpectedType`?
-        if (result.isFailure && !wasAmbigious) result = searchImplicit(implicitsOfExpectedType, false)
+        if (result.isFailure && !wasAmbigious) result = searchImplicit(implicitsOfExpectedType, isLocal = false)
 
         if (result.isFailure) {
           context.updateBuffer(previousErrs)
@@ -1334,7 +1334,7 @@ trait Implicits {
 
     def allImplicits: List[SearchResult] = {
       def search(iss: Infoss, isLocal: Boolean) = applicableInfos(iss, isLocal).values
-      (search(context.implicitss, true) ++ search(implicitsOfExpectedType, false)).toList.filter(_.tree ne EmptyTree)
+      (search(context.implicitss, isLocal = true) ++ search(implicitsOfExpectedType, isLocal = false)).toList.filter(_.tree ne EmptyTree)
     }
 
     // find all implicits for some type that contains type variables

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -491,7 +491,7 @@ trait Infer extends Checkable {
           }
           //println("try to solve "+tvars+" "+tparams)
           (solvedTypes(tvars, tparams, tparams map varianceInType(varianceType),
-                      false, lubDepth(List(restpe, pt))), tvars)
+                      upper = false, lubDepth(List(restpe, pt))), tvars)
         } catch {
           case ex: NoInstance => (null, null)
         }
@@ -667,7 +667,7 @@ trait Infer extends Checkable {
       }
       val targs = solvedTypes(
         tvars, tparams, tparams map varianceInTypes(formals),
-        false, lubDepth(formals) max lubDepth(argtpes)
+        upper = false, lubDepth(formals) max lubDepth(argtpes)
       )
       // Can warn about inferring Any/AnyVal as long as they don't appear
       // explicitly anywhere amongst the formal, argument, result, or expected type.
@@ -917,7 +917,7 @@ trait Infer extends Checkable {
      */
     private[typechecker] def isApplicableSafe(undetparams: List[Symbol], ftpe: Type,
                                               argtpes0: List[Type], pt: Type): Boolean = {
-      val silentContext = context.makeSilent(false)
+      val silentContext = context.makeSilent(reportAmbiguousErrors = false)
       val typer0 = newTyper(silentContext)
       val res1 = typer0.infer.isApplicable(undetparams, ftpe, argtpes0, pt)
       if (pt != WildcardType && silentContext.hasErrors) {
@@ -1104,7 +1104,7 @@ trait Infer extends Checkable {
       }
 
     def checkKindBounds(tparams: List[Symbol], targs: List[Type], pre: Type, owner: Symbol): List[String] = {
-      checkKindBounds0(tparams, targs, pre, owner, true) map {
+      checkKindBounds0(tparams, targs, pre, owner, explainErrors = true) map {
         case (targ, tparam, kindErrors) =>
           kindErrors.errorMessage(targ, tparam)
       }
@@ -1266,7 +1266,7 @@ trait Infer extends Checkable {
             val variances  =
               if (ctorTp.paramTypes.isEmpty) undetparams map varianceInType(ctorTp)
               else undetparams map varianceInTypes(ctorTp.paramTypes)
-            val targs      = solvedTypes(tvars, undetparams, variances, true, lubDepth(List(resTp, pt)))
+            val targs      = solvedTypes(tvars, undetparams, variances, upper = true, lubDepth(List(resTp, pt)))
             // checkBounds(tree, NoPrefix, NoSymbol, undetparams, targs, "inferred ")
             // no checkBounds here. If we enable it, test bug602 fails.
             // TODO: reinstate checkBounds, return params that fail to meet their bounds to undetparams
@@ -1335,7 +1335,7 @@ trait Infer extends Checkable {
       val tvars1 = tvars map (_.cloneInternal)
       // Note: right now it's not clear that solving is complete, or how it can be made complete!
       // So we should come back to this and investigate.
-      solve(tvars1, tvars1 map (_.origin.typeSymbol), tvars1 map (_ => Variance.Covariant), false)
+      solve(tvars1, tvars1 map (_.origin.typeSymbol), tvars1 map (_ => Variance.Covariant), upper = false)
     }
 
     // this is quite nasty: it destructively changes the info of the syms of e.g., method type params (see #3692, where the type param T's bounds were set to >: T <: T, so that parts looped)

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -502,7 +502,7 @@ trait Namers extends MethodSynthesis {
             typer.permanentlyHiddenWarning(pos, to0, e.sym)
           else if (context ne context.enclClass) {
             val defSym = context.prefix.member(to) filter (
-              sym => sym.exists && context.isAccessible(sym, context.prefix, false))
+              sym => sym.exists && context.isAccessible(sym, context.prefix, superAccess = false))
 
             defSym andAlso (typer.permanentlyHiddenWarning(pos, to0, _))
           }

--- a/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
@@ -224,7 +224,7 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
           transformTemplate
 
         case TypeApply(sel @ Select(This(_), name), args) =>
-          mayNeedProtectedAccessor(sel, args, false)
+          mayNeedProtectedAccessor(sel, args, goToSuper = false)
 
         // set a flag for all type parameters with `@specialized` annotation so it can be pickled
         case typeDef: TypeDef if typeDef.symbol.deSkolemize.hasAnnotation(definitions.SpecializedClass) =>
@@ -274,7 +274,7 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
                   Select(Super(qual, tpnme.EMPTY) setPos qual.pos, sym.alias)
                 }).asInstanceOf[Select]
                 debuglog("alias replacement: " + tree + " ==> " + result); //debug
-                localTyper.typed(gen.maybeMkAsInstanceOf(transformSuperSelect(result), sym.tpe, sym.alias.tpe, true))
+                localTyper.typed(gen.maybeMkAsInstanceOf(transformSuperSelect(result), sym.tpe, sym.alias.tpe, beforeRefChecks = true))
               } else {
                 /**
                  * A trait which extends a class and accesses a protected member
@@ -302,7 +302,7 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
                   ensureAccessor(sel)
                 }
                 else
-                  mayNeedProtectedAccessor(sel, EmptyTree.asList, false)
+                  mayNeedProtectedAccessor(sel, EmptyTree.asList, goToSuper = false)
               }
 
             case Super(_, mix) =>
@@ -315,7 +315,7 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
               transformSuperSelect(sel)
 
             case _ =>
-              mayNeedProtectedAccessor(sel, EmptyTree.asList, true)
+              mayNeedProtectedAccessor(sel, EmptyTree.asList, goToSuper = true)
           }
           }
           transformSelect
@@ -324,7 +324,7 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
           treeCopy.DefDef(tree, mods, name, tparams, vparamss, tpt, withInvalidOwner(transform(rhs)))
 
         case TypeApply(sel @ Select(qual, name), args) =>
-          mayNeedProtectedAccessor(sel, args, true)
+          mayNeedProtectedAccessor(sel, args, goToSuper = true)
 
         case Assign(lhs @ Select(qual, name), rhs) =>
           def transformAssign = {

--- a/src/compiler/scala/tools/nsc/typechecker/Tags.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Tags.scala
@@ -15,11 +15,11 @@ trait Tags {
       wrapper(inferImplicit(
         EmptyTree,
         taggedTp,
-        /*reportAmbiguous =*/ true,
-        /*isView =*/ false,
-        /*context =*/ context,
-        /*saveAmbiguousDivergent =*/ true,
-        /*pos =*/ pos
+        reportAmbiguous = true,
+        isView = false,
+        context,
+        saveAmbiguousDivergent = true,
+        pos
       ).tree)
     }
 

--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -236,8 +236,8 @@ trait TypeDiagnostics {
               val invariant = param.variance.isInvariant
 
               if (conforms)                             Some("")
-              else if ((arg <:< reqArg) && invariant)   mkMsg(true)   // covariant relationship
-              else if ((reqArg <:< arg) && invariant)   mkMsg(false)  // contravariant relationship
+              else if ((arg <:< reqArg) && invariant)   mkMsg(isSubtype = true)   // covariant relationship
+              else if ((reqArg <:< arg) && invariant)   mkMsg(isSubtype = false)  // contravariant relationship
               else None // we assume in other cases our ham-fisted advice will merely serve to confuse
           }
           val messages = relationships.flatten
@@ -544,7 +544,7 @@ trait TypeDiagnostics {
         // It is presumed if you are using a -Y option you would really like to hear
         // the warnings you've requested.
         if (settings.warnDeadCode.value && context.unit.exists && treeOK(tree) && exprOK)
-          context.warning(tree.pos, "dead code following this construct", true)
+          context.warning(tree.pos, "dead code following this construct", force = true)
         tree
       }
 

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -112,7 +112,7 @@ trait Typers extends Adaptations with Tags {
       override def isCoercible(tp: Type, pt: Type): Boolean = undoLog undo { // #3281
         tp.isError || pt.isError ||
         context0.implicitsEnabled && // this condition prevents chains of views
-        inferView(EmptyTree, tp, pt, false) != EmptyTree
+        inferView(EmptyTree, tp, pt, reportAmbiguous = false) != EmptyTree
       }
     }
 
@@ -136,7 +136,7 @@ trait Typers extends Adaptations with Tags {
           for(ar <- argResultsBuff)
             paramTp = paramTp.subst(ar.subst.from, ar.subst.to)
 
-          val res = if (paramFailed || (paramTp.isError && {paramFailed = true; true})) SearchFailure else inferImplicit(fun, paramTp, context.reportErrors, false, context)
+          val res = if (paramFailed || (paramTp.isError && {paramFailed = true; true})) SearchFailure else inferImplicit(fun, paramTp, context.reportErrors, isView = false, context)
           argResultsBuff += res
 
           if (res.isSuccess) {
@@ -179,7 +179,7 @@ trait Typers extends Adaptations with Tags {
     }
 
     def inferView(tree: Tree, from: Type, to: Type, reportAmbiguous: Boolean): Tree =
-      inferView(tree, from, to, reportAmbiguous, true)
+      inferView(tree, from, to, reportAmbiguous, saveErrors = true)
 
     /** Infer an implicit conversion (``view'') between two types.
      *  @param tree             The tree which needs to be converted.
@@ -201,7 +201,7 @@ trait Typers extends Adaptations with Tags {
         case PolyType(_, _) => EmptyTree
         case _ =>
           def wrapImplicit(from: Type): Tree = {
-            val result = inferImplicit(tree, functionType(from.withoutAnnotations :: Nil, to), reportAmbiguous, true, context, saveErrors)
+            val result = inferImplicit(tree, functionType(from.withoutAnnotations :: Nil, to), reportAmbiguous, isView = true, context, saveAmbiguousDivergent = saveErrors)
             if (result.subst != EmptyTreeTypeSubstituter) {
               result.subst traverse tree
               notifyUndetparamsInferred(result.subst.from, result.subst.to)
@@ -723,7 +723,7 @@ trait Typers extends Adaptations with Tags {
           featureTrait.owner.ownerChain.takeWhile(_ != languageFeatureModule.moduleClass).reverse
         val featureName = (nestedOwners map (_.name + ".")).mkString + featureTrait.name
         def action(): Boolean = {
-          def hasImport = inferImplicit(EmptyTree: Tree, featureTrait.tpe, true, false, context).isSuccess
+          def hasImport = inferImplicit(EmptyTree: Tree, featureTrait.tpe, reportAmbiguous = true, isView = false, context).isSuccess
           def hasOption = settings.language.value exists (s => s == featureName || s == "_")
           val OK = hasImport || hasOption
           if (!OK) {
@@ -1142,7 +1142,7 @@ trait Typers extends Adaptations with Tags {
                   if (context.implicitsEnabled && !pt.isError && !tree.isErrorTyped) {
                     // (14); the condition prevents chains of views
                     debuglog("inferring view from " + tree.tpe + " to " + pt)
-                    val coercion = inferView(tree, tree.tpe, pt, true)
+                    val coercion = inferView(tree, tree.tpe, pt, reportAmbiguous = true)
                     if (coercion != EmptyTree) {
                       def msg = "inferred view from " + tree.tpe + " to " + pt + " = " + coercion + ":" + coercion.tpe
                       if (settings.logImplicitConv.value)
@@ -1320,7 +1320,7 @@ trait Typers extends Adaptations with Tags {
                 reportError
             }
 
-      silent(_.adaptToMember(qual, HasMember(name), false)) orElse (err =>
+      silent(_.adaptToMember(qual, HasMember(name), reportAmbiguous = false)) orElse (err =>
         onError {
           if (reportAmbiguous) context issue err
           setError(tree)
@@ -3890,7 +3890,7 @@ trait Typers extends Adaptations with Tags {
           val targs = args map (_.tpe)
           checkBounds(tree, NoPrefix, NoSymbol, tparams, targs, "")
           if (fun.symbol == Predef_classOf)
-            typedClassOf(tree, args.head, true)
+            typedClassOf(tree, args.head, noGen = true)
           else {
             if (!isPastTyper && fun.symbol == Any_isInstanceOf && targs.nonEmpty) {
               val scrutineeType = fun match {
@@ -4393,7 +4393,7 @@ trait Typers extends Adaptations with Tags {
       }
 
       def tryTypedArgs(args: List[Tree], mode: Mode): Option[List[Tree]] = {
-        val c = context.makeSilent(false)
+        val c = context.makeSilent(reportAmbiguousErrors = false)
         c.retyping = true
         try {
           val res = newTyper(c).typedArgs(args, mode)
@@ -4452,7 +4452,7 @@ trait Typers extends Adaptations with Tags {
               tryTypedArgs(args, forArgMode(fun, mode)) match {
                 case Some(args1) =>
                   val qual1 =
-                    if (!pt.isError) adaptToArguments(qual, name, args1, pt, true, true)
+                    if (!pt.isError) adaptToArguments(qual, name, args1, pt, reportAmbiguous = true, saveErrors = true)
                     else qual
                   if (qual1 ne qual) {
                     val tree1 = Apply(Select(qual1, name) setPos fun.pos, args1) setPos tree.pos
@@ -4682,7 +4682,7 @@ trait Typers extends Adaptations with Tags {
           // member.  Added `| PATTERNmode` to allow enrichment in patterns (so we can add e.g., an
           // xml member to StringContext, which in turn has an unapply[Seq] method)
           if (name != nme.CONSTRUCTOR && mode.inExprModeOr(PATTERNmode)) {
-            val qual1 = adaptToMemberWithArgs(tree, qual, name, mode, true, true)
+            val qual1 = adaptToMemberWithArgs(tree, qual, name, mode, reportAmbiguous = true, saveErrors = true)
             if ((qual1 ne qual) && !qual1.isErrorTyped)
               return typed(treeCopy.Select(tree, qual1, name), mode, pt)
           }
@@ -4767,7 +4767,7 @@ trait Typers extends Adaptations with Tags {
             case _ if accessibleError.isDefined =>
               // don't adapt constructor, SI-6074
               val qual1 = if (name == nme.CONSTRUCTOR) qual
-                          else adaptToMemberWithArgs(tree, qual, name, mode, false, false)
+                          else adaptToMemberWithArgs(tree, qual, name, mode, reportAmbiguous = false, saveErrors = false)
               if (!qual1.isErrorTyped && (qual1 ne qual))
                 typed(Select(qual1, name) setPos tree.pos, mode, pt)
               else

--- a/src/compiler/scala/tools/nsc/util/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/util/ClassPath.scala
@@ -105,17 +105,17 @@ object ClassPath {
     /** Creators for sub classpaths which preserve this context.
      */
     def sourcesInPath(path: String): List[ClassPath[T]] =
-      for (file <- expandPath(path, false) ; dir <- Option(AbstractFile getDirectory file)) yield
+      for (file <- expandPath(path, expandStar = false) ; dir <- Option(AbstractFile getDirectory file)) yield
         new SourcePath[T](dir, this)
 
     def contentsOfDirsInPath(path: String): List[ClassPath[T]] =
-      for (dir <- expandPath(path, false) ; name <- expandDir(dir) ; entry <- Option(AbstractFile getDirectory name)) yield
+      for (dir <- expandPath(path, expandStar = false) ; name <- expandDir(dir) ; entry <- Option(AbstractFile getDirectory name)) yield
         newClassPath(entry)
 
     def classesInExpandedPath(path: String): IndexedSeq[ClassPath[T]] =
-      classesInPathImpl(path, true).toIndexedSeq
+      classesInPathImpl(path, expand = true).toIndexedSeq
 
-    def classesInPath(path: String) = classesInPathImpl(path, false)
+    def classesInPath(path: String) = classesInPathImpl(path, expand = false)
 
     // Internal
     private def classesInPathImpl(path: String, expand: Boolean) =
@@ -210,7 +210,7 @@ abstract class ClassPath[T] {
    * Does not support nested classes on .NET
    */
   def findClass(name: String): Option[AnyClassRep] =
-    splitWhere(name, _ == '.', true) match {
+    splitWhere(name, _ == '.', doDropIndex = true) match {
       case Some((pkg, rest)) =>
         val rep = packages find (_.name == pkg) flatMap (_ findClass rest)
         rep map {

--- a/src/compiler/scala/tools/nsc/util/ScalaClassLoader.scala
+++ b/src/compiler/scala/tools/nsc/util/ScalaClassLoader.scala
@@ -34,9 +34,9 @@ trait ScalaClassLoader extends JClassLoader {
   def setAsContext() { setContext(this) }
 
   /** Load and link a class with this classloader */
-  def tryToLoadClass[T <: AnyRef](path: String): Option[Class[T]] = tryClass(path, false)
+  def tryToLoadClass[T <: AnyRef](path: String): Option[Class[T]] = tryClass(path, initialize = false)
   /** Load, link and initialize a class with this classloader */
-  def tryToInitializeClass[T <: AnyRef](path: String): Option[Class[T]] = tryClass(path, true)
+  def tryToInitializeClass[T <: AnyRef](path: String): Option[Class[T]] = tryClass(path, initialize = true)
 
   private def tryClass[T <: AnyRef](path: String, initialize: Boolean): Option[Class[T]] =
     catching(classOf[ClassNotFoundException], classOf[SecurityException]) opt

--- a/src/compiler/scala/tools/reflect/package.scala
+++ b/src/compiler/scala/tools/reflect/package.scala
@@ -52,7 +52,7 @@ package object reflect {
     override def hasWarnings = reporter.hasWarnings
 
     def display(info: Info): Unit = info.severity match {
-      case API_INFO => reporter.info(info.pos, info.msg, false)
+      case API_INFO => reporter.info(info.pos, info.msg, force = false)
       case API_WARNING => reporter.warning(info.pos, info.msg)
       case API_ERROR => reporter.error(info.pos, info.msg)
     }

--- a/src/compiler/scala/tools/util/Javap.scala
+++ b/src/compiler/scala/tools/util/Javap.scala
@@ -125,10 +125,10 @@ class JavapClass(
           if (res.isDefined && loadable(res.get)) res else None
         }
         // try loading translated+suffix
-        val res = loadableOrNone(false)
+        val res = loadableOrNone(strip = false)
         // some synthetics lack a dollar, (e.g., suffix = delayedInit$body)
         // so as a hack, if prefix$$suffix fails, also try prefix$suffix
-        if (res.isDefined) res else loadableOrNone(true)
+        if (res.isDefined) res else loadableOrNone(strip = true)
       } else None
     }
     val p = path.asClassName   // scrub any suffix
@@ -649,7 +649,7 @@ object JavapClass {
       val fs = if (isReplish) {
         def outed(d: AbstractFile, p: Seq[String]): Option[AbstractFile] = {
           if (p.isEmpty) Option(d)
-          else Option(d.lookupName(p.head, true)) flatMap (f => outed(f, p.tail))
+          else Option(d.lookupName(p.head, directory = true)) flatMap (f => outed(f, p.tail))
         }
         outed(intp.get.replOutput.dir, splat.init) map { d =>
           listFunsInAbsFile(name, member, d) map packaged

--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -135,7 +135,7 @@ object PathResolver {
     }
     else {
       val settings = new Settings()
-      val rest = settings.processArguments(args.toList, false)._2
+      val rest = settings.processArguments(args.toList, processAll = false)._2
       val pr = new PathResolver(settings)
       println(" COMMAND: 'scala %s'".format(args.mkString(" ")))
       println("RESIDUAL: 'scala %s'\n".format(rest.mkString(" ")))

--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -399,7 +399,7 @@ object Array extends FallbackArrayBuilding {
   def range(start: Int, end: Int, step: Int): Array[Int] = {
     if (step == 0) throw new IllegalArgumentException("zero step")
     val b = newBuilder[Int]
-    b.sizeHint(immutable.Range.count(start, end, step, false))
+    b.sizeHint(immutable.Range.count(start, end, step, isInclusive = false))
 
     var i = start
     while (if (step < 0) end < i else i < end) {

--- a/src/library/scala/collection/SeqLike.scala
+++ b/src/library/scala/collection/SeqLike.scala
@@ -335,7 +335,7 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
       if (from > l) -1
       else if (tl < 1) clippedFrom
       else if (l < tl) -1
-      else SeqLike.kmpSearch(thisCollection, clippedFrom, l, that.seq, 0, tl, true)
+      else SeqLike.kmpSearch(thisCollection, clippedFrom, l, that.seq, 0, tl, forward = true)
     }
     else {
       var i = from
@@ -372,7 +372,7 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
     if (end < 0) -1
     else if (tl < 1) clippedL
     else if (l < tl) -1
-    else SeqLike.kmpSearch(thisCollection, 0, clippedL+tl, that.seq, 0, tl, false)
+    else SeqLike.kmpSearch(thisCollection, 0, clippedL+tl, that.seq, 0, tl, forward = false)
   }
 
   /** Tests whether this $coll contains a given sequence as a slice.
@@ -778,7 +778,7 @@ object SeqLike {
       case _ =>
         // We had better not index into S directly!
         val iter = S.iterator.drop(m0)
-        val Wopt = kmpOptimizeWord(W, n0, n1, true)
+        val Wopt = kmpOptimizeWord(W, n0, n1, forward = true)
         val T = kmpJumpTable(Wopt, n1-n0)
         val cache = new Array[AnyRef](n1-n0)  // Ring buffer--need a quick way to do a look-behind
         var largest = 0
@@ -851,7 +851,7 @@ object SeqLike {
     else if (s1 - s0 < t1 - t0) -1            // Source is too short to find target
     else {
       // Nontrivial search
-      val ans = kmpSearch(source, s0, s1, target, t0, t1, true)
+      val ans = kmpSearch(source, s0, s1, target, t0, t1, forward = true)
       if (ans < 0) ans else ans - math.min(slen, sourceOffset)
     }
   }
@@ -883,7 +883,7 @@ object SeqLike {
     else if (fixed_s1 - s0 < t1 - t0) -1      // Source is too short to find target
     else {
       // Nontrivial search
-      val ans = kmpSearch(source, s0, fixed_s1, target, t0, t1, false)
+      val ans = kmpSearch(source, s0, fixed_s1, target, t0, t1, forward = false)
       if (ans < 0) ans else ans - s0
     }
   }

--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -41,7 +41,7 @@ private[collection] final class INode[K, V](bn: MainNode[K, V], g: Gen) extends 
   @tailrec private def GCAS_Complete(m: MainNode[K, V], ct: TrieMap[K, V]): MainNode[K, V] = if (m eq null) null else {
     // complete the GCAS
     val prev = /*READ*/m.prev
-    val ctr = ct.readRoot(true)
+    val ctr = ct.readRoot(abort = true)
 
     prev match {
       case null =>
@@ -723,7 +723,7 @@ extends scala.collection.concurrent.Map[K, V]
   private def RDCSS_ROOT(ov: INode[K, V], expectedmain: MainNode[K, V], nv: INode[K, V]): Boolean = {
     val desc = RDCSS_Descriptor(ov, expectedmain, nv)
     if (CAS_ROOT(ov, desc)) {
-      RDCSS_Complete(false)
+      RDCSS_Complete(abort = false)
       /*READ*/desc.committed
     } else false
   }
@@ -1027,7 +1027,7 @@ private[collection] class TrieMapIterator[K, V](var level: Int, private var ct: 
         val (arr1, arr2) = stack(d).drop(stackpos(d) + 1).splitAt(rem / 2)
         stack(d) = arr1
         stackpos(d) = -1
-        val it = newIterator(level + 1, ct, false)
+        val it = newIterator(level + 1, ct, _mustInit = false)
         it.stack(0) = arr2
         it.stackpos(0) = -1
         it.depth = 0

--- a/src/library/scala/collection/generic/GenTraversableFactory.scala
+++ b/src/library/scala/collection/generic/GenTraversableFactory.scala
@@ -216,7 +216,7 @@ extends GenericCompanion[CC] {
 
     if (step == zero) throw new IllegalArgumentException("zero step")
     val b = newBuilder[T]
-    b sizeHint immutable.NumericRange.count(start, end, step, false)
+    b sizeHint immutable.NumericRange.count(start, end, step, isInclusive = false)
     var i = start
     while (if (step < zero) end < i else i < end) {
       b += i

--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -332,7 +332,7 @@ object Range {
     }
   }
   def count(start: Int, end: Int, step: Int): Int =
-    count(start, end, step, false)
+    count(start, end, step, isInclusive = false)
 
   class Inclusive(start: Int, end: Int, step: Int) extends Range(start, end, step) {
 //    override def par = new ParRange(this)

--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -252,7 +252,7 @@ object RedBlackTree {
     if (ordering.lt(tree.key, from)) return doFrom(tree.right, from)
     val newLeft = doFrom(tree.left, from)
     if (newLeft eq tree.left) tree
-    else if (newLeft eq null) upd(tree.right, tree.key, tree.value, false)
+    else if (newLeft eq null) upd(tree.right, tree.key, tree.value, overwrite = false)
     else rebalance(tree, newLeft, tree.right)
   }
   private[this] def doTo[A, B](tree: Tree[A, B], to: A)(implicit ordering: Ordering[A]): Tree[A, B] = {
@@ -260,7 +260,7 @@ object RedBlackTree {
     if (ordering.lt(to, tree.key)) return doTo(tree.left, to)
     val newRight = doTo(tree.right, to)
     if (newRight eq tree.right) tree
-    else if (newRight eq null) upd(tree.left, tree.key, tree.value, false)
+    else if (newRight eq null) upd(tree.left, tree.key, tree.value, overwrite = false)
     else rebalance(tree, tree.left, newRight)
   }
   private[this] def doUntil[A, B](tree: Tree[A, B], until: A)(implicit ordering: Ordering[A]): Tree[A, B] = {
@@ -268,7 +268,7 @@ object RedBlackTree {
     if (ordering.lteq(until, tree.key)) return doUntil(tree.left, until)
     val newRight = doUntil(tree.right, until)
     if (newRight eq tree.right) tree
-    else if (newRight eq null) upd(tree.left, tree.key, tree.value, false)
+    else if (newRight eq null) upd(tree.left, tree.key, tree.value, overwrite = false)
     else rebalance(tree, tree.left, newRight)
   }
   private[this] def doRange[A, B](tree: Tree[A, B], from: A, until: A)(implicit ordering: Ordering[A]): Tree[A, B] = {
@@ -278,8 +278,8 @@ object RedBlackTree {
     val newLeft = doFrom(tree.left, from)
     val newRight = doUntil(tree.right, until)
     if ((newLeft eq tree.left) && (newRight eq tree.right)) tree
-    else if (newLeft eq null) upd(newRight, tree.key, tree.value, false);
-    else if (newRight eq null) upd(newLeft, tree.key, tree.value, false);
+    else if (newLeft eq null) upd(newRight, tree.key, tree.value, overwrite = false);
+    else if (newRight eq null) upd(newLeft, tree.key, tree.value, overwrite = false);
     else rebalance(tree, newLeft, newRight)
   }
 
@@ -290,7 +290,7 @@ object RedBlackTree {
     if (n > count) return doDrop(tree.right, n - count - 1)
     val newLeft = doDrop(tree.left, n)
     if (newLeft eq tree.left) tree
-    else if (newLeft eq null) updNth(tree.right, n - count - 1, tree.key, tree.value, false)
+    else if (newLeft eq null) updNth(tree.right, n - count - 1, tree.key, tree.value, overwrite = false)
     else rebalance(tree, newLeft, tree.right)
   }
   private[this] def doTake[A, B](tree: Tree[A, B], n: Int): Tree[A, B] = {
@@ -300,7 +300,7 @@ object RedBlackTree {
     if (n <= count) return doTake(tree.left, n)
     val newRight = doTake(tree.right, n - count - 1)
     if (newRight eq tree.right) tree
-    else if (newRight eq null) updNth(tree.left, n, tree.key, tree.value, false)
+    else if (newRight eq null) updNth(tree.left, n, tree.key, tree.value, overwrite = false)
     else rebalance(tree, tree.left, newRight)
   }
   private[this] def doSlice[A, B](tree: Tree[A, B], from: Int, until: Int): Tree[A, B] = {
@@ -311,8 +311,8 @@ object RedBlackTree {
     val newLeft = doDrop(tree.left, from)
     val newRight = doTake(tree.right, until - count - 1)
     if ((newLeft eq tree.left) && (newRight eq tree.right)) tree
-    else if (newLeft eq null) updNth(newRight, from - count - 1, tree.key, tree.value, false)
-    else if (newRight eq null) updNth(newLeft, until, tree.key, tree.value, false)
+    else if (newLeft eq null) updNth(newRight, from - count - 1, tree.key, tree.value, overwrite = false)
+    else if (newRight eq null) updNth(newLeft, until, tree.key, tree.value, overwrite = false)
     else rebalance(tree, newLeft, newRight)
   }
 

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -128,7 +128,7 @@ class TreeMap[A, +B] private (tree: RB.Tree[A, B])(implicit val ordering: Orderi
    *  @param value   the value to be associated with `key`
    *  @return        a new $coll with the updated binding
    */
-  override def updated [B1 >: B](key: A, value: B1): TreeMap[A, B1] = new TreeMap(RB.update(tree, key, value, true))
+  override def updated [B1 >: B](key: A, value: B1): TreeMap[A, B1] = new TreeMap(RB.update(tree, key, value, overwrite = true))
 
   /** Add a key/value pair to this map.
    *  @tparam   B1   type of the value of the new binding, a supertype of `B`
@@ -168,7 +168,7 @@ class TreeMap[A, +B] private (tree: RB.Tree[A, B])(implicit val ordering: Orderi
    */
   def insert [B1 >: B](key: A, value: B1): TreeMap[A, B1] = {
     assert(!RB.contains(tree, key))
-    new TreeMap(RB.update(tree, key, value, true))
+    new TreeMap(RB.update(tree, key, value, overwrite = true))
   }
 
   def - (key:A): TreeMap[A, B] =

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -109,7 +109,7 @@ class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: Orderin
    *  @param elem    a new element to add.
    *  @return        a new $coll containing `elem` and all the elements of this $coll.
    */
-  def + (elem: A): TreeSet[A] = newSet(RB.update(tree, elem, (), false))
+  def + (elem: A): TreeSet[A] = newSet(RB.update(tree, elem, (), overwrite = false))
 
   /** A new `TreeSet` with the entry added is returned,
    *  assuming that elem is <em>not</em> in the TreeSet.
@@ -119,7 +119,7 @@ class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: Orderin
    */
   def insert(elem: A): TreeSet[A] = {
     assert(!RB.contains(tree, elem))
-    newSet(RB.update(tree, elem, (), false))
+    newSet(RB.update(tree, elem, (), overwrite = false))
   }
 
   /** Creates a new `TreeSet` with the entry removed.

--- a/src/library/scala/collection/mutable/FlatHashTable.scala
+++ b/src/library/scala/collection/mutable/FlatHashTable.scala
@@ -230,7 +230,7 @@ trait FlatHashTable[A] extends FlatHashTable.HashUtils[A] {
   private def checkConsistent() {
     for (i <- 0 until table.length)
       if (table(i) != null && !containsElem(entryToElem(table(i))))
-        assert(false, i+" "+table(i)+" "+table.mkString)
+        assert(assertion = false, i+" "+table(i)+" "+table.mkString)
   }
  
 

--- a/src/library/scala/collection/mutable/TreeSet.scala
+++ b/src/library/scala/collection/mutable/TreeSet.scala
@@ -67,7 +67,7 @@ class TreeSet[A] private (treeRef: ObjectRef[RB.Tree[A, Null]], from: Option[A],
   }
 
   override def +=(elem: A): this.type = {
-    treeRef.elem = RB.update(treeRef.elem, elem, null, false)
+    treeRef.elem = RB.update(treeRef.elem, elem, null, overwrite = false)
     this
   }
 

--- a/src/library/scala/collection/parallel/ParIterableLike.scala
+++ b/src/library/scala/collection/parallel/ParIterableLike.scala
@@ -823,7 +823,7 @@ self: ParIterableLike[T, Repr, Sequential] =>
     tasksupport.executeAndWaitResult(new Zip(combinerFactory(() => bf(repr).asCombiner), splitter, thatseq.splitter) mapResult { _.resultWithTaskSupport });
   } else setTaskSupport(seq.zip(that)(bf2seq(bf)), tasksupport)
 
-  def zipWithIndex[U >: T, That](implicit bf: CanBuildFrom[Repr, (U, Int), That]): That = this zip immutable.ParRange(0, size, 1, false)
+  def zipWithIndex[U >: T, That](implicit bf: CanBuildFrom[Repr, (U, Int), That]): That = this zip immutable.ParRange(0, size, 1, inclusive = false)
 
   def zipAll[S, U >: T, That](that: GenIterable[S], thisElem: U, thatElem: S)(implicit bf: CanBuildFrom[Repr, (U, S), That]): That = if (bf(repr).isCombiner && that.isParSeq) {
     val thatseq = that.asParSeq

--- a/src/library/scala/collection/parallel/ParIterableViewLike.scala
+++ b/src/library/scala/collection/parallel/ParIterableViewLike.scala
@@ -130,7 +130,7 @@ self =>
 
   override def zip[U >: T, S, That](that: GenIterable[S])(implicit bf: CanBuildFrom[This, (U, S), That]): That = newZippedTryParSeq(that).asInstanceOf[That]
   override def zipWithIndex[U >: T, That](implicit bf: CanBuildFrom[This, (U, Int), That]): That =
-    newZipped(ParRange(0, splitter.remaining, 1, false)).asInstanceOf[That]
+    newZipped(ParRange(0, splitter.remaining, 1, inclusive = false)).asInstanceOf[That]
   override def zipAll[S, U >: T, That](that: GenIterable[S], thisElem: U, thatElem: S)(implicit bf: CanBuildFrom[This, (U, S), That]): That =
     newZippedAllTryParSeq(that, thisElem, thatElem).asInstanceOf[That]
 

--- a/src/library/scala/collection/parallel/ParSeqViewLike.scala
+++ b/src/library/scala/collection/parallel/ParSeqViewLike.scala
@@ -147,7 +147,7 @@ self =>
   override def map[S, That](f: T => S)(implicit bf: CanBuildFrom[This, S, That]): That = newMapped(f).asInstanceOf[That]
   override def zip[U >: T, S, That](that: GenIterable[S])(implicit bf: CanBuildFrom[This, (U, S), That]): That = newZippedTryParSeq(that).asInstanceOf[That]
   override def zipWithIndex[U >: T, That](implicit bf: CanBuildFrom[This, (U, Int), That]): That =
-    newZipped(ParRange(0, splitter.remaining, 1, false)).asInstanceOf[That]
+    newZipped(ParRange(0, splitter.remaining, 1, inclusive = false)).asInstanceOf[That]
   override def reverse: This = newReversed.asInstanceOf[This]
   override def reverseMap[S, That](f: T => S)(implicit bf: CanBuildFrom[This, S, That]): That = reverse.map(f)
 

--- a/src/library/scala/collection/parallel/mutable/ParTrieMap.scala
+++ b/src/library/scala/collection/parallel/mutable/ParTrieMap.scala
@@ -136,7 +136,7 @@ extends TrieMapIterator[K, V](lev, ct, mustInit)
   }
 
   def dup = {
-    val it = newIterator(0, ct, false)
+    val it = newIterator(0, ct, _mustInit = false)
     dupTo(it)
     it.iterated = this.iterated
     it

--- a/src/library/scala/sys/process/ProcessBuilder.scala
+++ b/src/library/scala/sys/process/ProcessBuilder.scala
@@ -305,10 +305,10 @@ object ProcessBuilder extends ProcessBuilderImpl {
     protected def toSource: ProcessBuilder
 
     /** Writes the output stream of this process to the given file. */
-    def #> (f: File): ProcessBuilder = toFile(f, false)
+    def #> (f: File): ProcessBuilder = toFile(f, append = false)
 
     /** Appends the output stream of this process to the given file. */
-    def #>> (f: File): ProcessBuilder = toFile(f, true)
+    def #>> (f: File): ProcessBuilder = toFile(f, append = true)
 
     /** Writes the output stream of this process to the given OutputStream. The
       * argument is call-by-name, so the stream is recreated, written, and closed each

--- a/src/library/scala/sys/process/ProcessImpl.scala
+++ b/src/library/scala/sys/process/ProcessImpl.scala
@@ -17,7 +17,7 @@ private[process] trait ProcessImpl {
 
   /** Runs provided code in a new Thread and returns the Thread instance. */
   private[process] object Spawn {
-    def apply(f: => Unit): Thread = apply(f, false)
+    def apply(f: => Unit): Thread = apply(f, daemon = false)
     def apply(f: => Unit, daemon: Boolean): Thread = {
       val thread = new Thread() { override def run() = { f } }
       thread.setDaemon(daemon)

--- a/src/library/scala/xml/Attribute.scala
+++ b/src/library/scala/xml/Attribute.scala
@@ -94,7 +94,7 @@ abstract trait Attribute extends MetaData {
 
     sb append key append '='
     val sb2 = new StringBuilder()
-    Utility.sequenceToXML(value, TopScope, sb2, true)
+    Utility.sequenceToXML(value, TopScope, sb2, stripComments = true)
     Utility.appendQuoted(sb2.toString, sb)
   }
 }

--- a/src/library/scala/xml/Equality.scala
+++ b/src/library/scala/xml/Equality.scala
@@ -86,8 +86,8 @@ trait Equality extends scala.Equals {
    *  to maintain a semblance of order.
    */
   override def hashCode()         = basisForHashCode.##
-  override def equals(other: Any) = doComparison(other, false)
-  final def xml_==(other: Any)    = doComparison(other, true)
+  override def equals(other: Any) = doComparison(other, blithe = false)
+  final def xml_==(other: Any)    = doComparison(other, blithe = true)
   final def xml_!=(other: Any)    = !xml_==(other)
 
   /** The "blithe" parameter expresses the caller's unconcerned attitude

--- a/src/library/scala/xml/Node.scala
+++ b/src/library/scala/xml/Node.scala
@@ -163,7 +163,7 @@ abstract class Node extends NodeSeq {
   /**
    * Same as `toString('''false''')`.
    */
-  override def toString(): String = buildString(false)
+  override def toString(): String = buildString(stripComments = false)
 
   /**
    * Appends qualified name of this node to `StringBuilder`.

--- a/src/library/scala/xml/PrettyPrinter.scala
+++ b/src/library/scala/xml/PrettyPrinter.scala
@@ -147,7 +147,7 @@ class PrettyPrinter(width: Int, step: Int) {
       case _ =>
         val test = {
           val sb = new StringBuilder()
-          Utility.serialize(node, pscope, sb, false)
+          Utility.serialize(node, pscope, sb, stripComments = false)
           if (doPreserve(node)) sb.toString
           else TextBuffer.fromString(sb.toString).toText(0).data
         }

--- a/src/library/scala/xml/dtd/ElementValidator.scala
+++ b/src/library/scala/xml/dtd/ElementValidator.scala
@@ -99,21 +99,21 @@ class ElementValidator() extends Function1[Node,Boolean] {
    */
   def check(nodes: Seq[Node]): Boolean = contentModel match {
     case ANY    => true
-    case EMPTY  => getIterable(nodes, false).isEmpty
-    case PCDATA => getIterable(nodes, true).isEmpty
+    case EMPTY  => getIterable(nodes, skipPCDATA = false).isEmpty
+    case PCDATA => getIterable(nodes, skipPCDATA = true).isEmpty
     case MIXED(ContentModel.Alt(branches @ _*))  =>   // @todo
       val j = exc.length
       def find(Key: String): Boolean =
         branches exists { case ContentModel.Letter(ElemName(Key)) => true ; case _ => false }
 
-      getIterable(nodes, true) map (_.name) filterNot find foreach {
+      getIterable(nodes, skipPCDATA = true) map (_.name) filterNot find foreach {
         exc ::= MakeValidationException fromUndefinedElement _
       }
       (exc.length == j)   // - true if no new exception
 
     case _: ELEMENTS =>
       dfa isFinal {
-        getIterable(nodes, false).foldLeft(0) { (q, e) =>
+        getIterable(nodes, skipPCDATA = false).foldLeft(0) { (q, e) =>
           (dfa delta q).getOrElse(e, throw ValidationException("element %s not allowed here" format e))
         }
       }

--- a/src/library/scala/xml/parsing/MarkupParser.scala
+++ b/src/library/scala/xml/parsing/MarkupParser.scala
@@ -199,11 +199,11 @@ trait MarkupParser extends MarkupParserCommon with TokenTests
    *  // this is a bit more lenient than necessary...
    *  }}} */
   def prolog(): (Option[String], Option[String], Option[Boolean]) =
-    prologOrTextDecl(true)
+    prologOrTextDecl(isProlog = true)
 
   /** prolog, but without standalone */
   def textDecl(): (Option[String], Option[String]) =
-    prologOrTextDecl(false) match { case (x1, x2, _)  => (x1, x2) }
+    prologOrTextDecl(isProlog = false) match { case (x1, x2, _)  => (x1, x2) }
 
   /** {{{
    *  [22]     prolog      ::= XMLDecl? Misc* (doctypedecl Misc*)?
@@ -799,12 +799,12 @@ trait MarkupParser extends MarkupParserCommon with TokenTests
 
       val defdecl: DefaultDecl = ch match {
         case '\'' | '"' =>
-          DEFAULT(false, xAttributeValue())
+          DEFAULT(fixed = false, xAttributeValue())
 
         case '#' =>
           nextch
           xName match {
-            case "FIXED"    => xSpace ; DEFAULT(true, xAttributeValue())
+            case "FIXED"    => xSpace ; DEFAULT(fixed = true, xAttributeValue())
             case "IMPLIED"  => IMPLIED
             case "REQUIRED" => REQUIRED
           }

--- a/src/library/scala/xml/persistent/CachedFileStorage.scala
+++ b/src/library/scala/xml/persistent/CachedFileStorage.scala
@@ -76,7 +76,7 @@ abstract class CachedFileStorage(private val file1: File) extends Thread with Lo
     log("[load]\nloading "+theFile)
     val src = Source.fromFile(theFile)
     log("parsing "+theFile)
-    val res = ConstructingParser.fromSource(src,false).document.docElem(0)
+    val res = ConstructingParser.fromSource(src,preserveWS = false).document.docElem(0)
     switch
     log("[load done]")
     res.child.iterator
@@ -94,7 +94,7 @@ abstract class CachedFileStorage(private val file1: File) extends Thread with Lo
     // @todo: optimize
     val storageNode = <nodes>{ nodes.toList }</nodes>
     val w = Channels.newWriter(c, "utf-8")
-    XML.write(w, storageNode, "utf-8", true, null)
+    XML.write(w, storageNode, "utf-8", xmlDecl = true, doctype = null)
 
     log("writing to "+theFile)
 

--- a/src/reflect/scala/reflect/internal/CapturedVariables.scala
+++ b/src/reflect/scala/reflect/internal/CapturedVariables.scala
@@ -19,7 +19,7 @@ trait CapturedVariables { self: SymbolTable =>
   /** Convert type of a captured variable to *Ref type.
    */
   def capturedVariableType(vble: Symbol): Type =
-    capturedVariableType(vble, NoType, false)
+    capturedVariableType(vble, NoType, erasedTypes = false)
 
   /** Convert type of a captured variable to *Ref type.
    */

--- a/src/reflect/scala/reflect/internal/Kinds.scala
+++ b/src/reflect/scala/reflect/internal/Kinds.scala
@@ -86,7 +86,7 @@ trait Kinds {
   // plan: split into kind inference and subkinding
   // every Type has a (cached) Kind
   def kindsConform(tparams: List[Symbol], targs: List[Type], pre: Type, owner: Symbol): Boolean =
-    checkKindBounds0(tparams, targs, pre, owner, false).isEmpty
+    checkKindBounds0(tparams, targs, pre, owner, explainErrors = false).isEmpty
 
   /** Check whether `sym1`'s variance conforms to `sym2`'s variance.
    *

--- a/src/reflect/scala/reflect/internal/Positions.scala
+++ b/src/reflect/scala/reflect/internal/Positions.scala
@@ -12,7 +12,7 @@ trait Positions extends api.Positions { self: SymbolTable =>
    *  If some of the trees are ranges, returns a range position enclosing all ranges
    *  Otherwise returns default position that is either focused or not.
    */
-  def wrappingPos(default: Position, trees: List[Tree]) = wrappingPos(default, trees, true)
+  def wrappingPos(default: Position, trees: List[Tree]) = wrappingPos(default, trees, focus = true)
   def wrappingPos(default: Position, trees: List[Tree], focus: Boolean): Position = default
 
   /** A position that wraps the non-empty set of trees.
@@ -27,7 +27,7 @@ trait Positions extends api.Positions { self: SymbolTable =>
    *  shortening the range, assigning TransparentPositions
    *  to some of the nodes in `tree` or focusing on the position.
    */
-  def ensureNonOverlapping(tree: Tree, others: List[Tree]){ ensureNonOverlapping(tree, others, true) }
+  def ensureNonOverlapping(tree: Tree, others: List[Tree]){ ensureNonOverlapping(tree, others, focus = true) }
   def ensureNonOverlapping(tree: Tree, others: List[Tree], focus: Boolean) {}
 
   trait PosAssigner extends Traverser {

--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -25,8 +25,8 @@ trait Printers extends api.Printers { self: SymbolTable =>
     if (nme.keywords(term) && term != nme.USCOREkw) "`%s`" format s
     else s
   }
-  def quotedName(name: Name): String = quotedName(name, false)
-  def quotedName(name: String): String = quotedName(newTermName(name), false)
+  def quotedName(name: Name): String = quotedName(name, decode = false)
+  def quotedName(name: String): String = quotedName(newTermName(name), decode = false)
 
   private def symNameInternal(tree: Tree, name: Name, decoded: Boolean): String = {
     val sym = tree.symbol
@@ -43,8 +43,8 @@ trait Printers extends api.Printers { self: SymbolTable =>
     }
   }
 
-  def decodedSymName(tree: Tree, name: Name) = symNameInternal(tree, name, true)
-  def symName(tree: Tree, name: Name) = symNameInternal(tree, name, false)
+  def decodedSymName(tree: Tree, name: Name) = symNameInternal(tree, name, decoded = true)
+  def symName(tree: Tree, name: Name) = symNameInternal(tree, name, decoded = false)
 
   /** Turns a path into a String, introducing backquotes
    *  as necessary.

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2189,7 +2189,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     )
 
     /** The setter of this value or getter definition, or NoSymbol if none exists */
-    final def setter(base: Symbol): Symbol = setter(base, false)
+    final def setter(base: Symbol): Symbol = setter(base, hasExpandedName = false)
 
     final def setter(base: Symbol, hasExpandedName: Boolean): Symbol = {
       var sname = nme.getterToSetter(nme.getterName(name.toTermName))

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -705,7 +705,7 @@ trait Types extends api.Types { self: SymbolTable =>
       findMembers(excludedFlags, requiredFlags)
 
     def memberBasedOnName(name: Name, excludedFlags: Long): Symbol =
-      findMember(name, excludedFlags, 0, false)
+      findMember(name, excludedFlags, 0, stableOnly = false)
 
     /** The least type instance of given class which is a supertype
      *  of this type.  Example:
@@ -925,7 +925,7 @@ trait Types extends api.Types { self: SymbolTable =>
     def matches(that: Type): Boolean = matchesType(this, that, !phase.erasedTypes)
 
     /** Same as matches, except that non-method types are always assumed to match. */
-    def looselyMatches(that: Type): Boolean = matchesType(this, that, true)
+    def looselyMatches(that: Type): Boolean = matchesType(this, that, alwaysMatchSimple = true)
 
     /** The shortest sorted upwards closed array of types that contains
      *  this type as first element.
@@ -2842,7 +2842,7 @@ trait Types extends api.Types { self: SymbolTable =>
       val tvars = quantifiedFresh map (tparam => TypeVar(tparam))
       val underlying1 = underlying.instantiateTypeParams(quantified, tvars) // fuse subst quantified -> quantifiedFresh -> tvars
       op(underlying1) && {
-        solve(tvars, quantifiedFresh, quantifiedFresh map (_ => Invariant), false, depth) &&
+        solve(tvars, quantifiedFresh, quantifiedFresh map (_ => Invariant), upper = false, depth) &&
         isWithinBounds(NoPrefix, NoSymbol, quantifiedFresh, tvars map (_.constr.inst))
       }
     }
@@ -3256,7 +3256,7 @@ trait Types extends api.Types { self: SymbolTable =>
      * (`T` corresponds to @param sym)
      */
     def registerTypeSelection(sym: Symbol, tp: Type): Boolean = {
-      registerBound(HasTypeMember(sym.name.toTypeName, tp), false)
+      registerBound(HasTypeMember(sym.name.toTypeName, tp), isLowerBound = false)
     }
 
     private def isSkolemAboveLevel(tp: Type) = tp.typeSymbol match {
@@ -4966,7 +4966,7 @@ trait Types extends api.Types { self: SymbolTable =>
         }
       }
       else {
-        var rebind0 = pre.findMember(sym.name, BRIDGE, 0, true) orElse {
+        var rebind0 = pre.findMember(sym.name, BRIDGE, 0, stableOnly = true) orElse {
           if (sym.isAliasType) throw missingAliasException
           devWarning(s"$pre.$sym no longer exist at phase $phase")
           throw new MissingTypeControl // For build manager and presentation compiler purposes
@@ -5774,7 +5774,7 @@ trait Types extends api.Types { self: SymbolTable =>
           case AnnotatedType(_, _, _) | BoundedWildcardType(_) =>
             secondTry
           case _ =>
-            tv2.registerBound(tp1, true)
+            tv2.registerBound(tp1, isLowerBound = true)
         }
       case _ =>
         secondTry
@@ -5792,7 +5792,7 @@ trait Types extends api.Types { self: SymbolTable =>
       case BoundedWildcardType(bounds) =>
         isSubType(tp1.bounds.lo, tp2, depth)
       case tv @ TypeVar(_,_) =>
-        tv.registerBound(tp2, false)
+        tv.registerBound(tp2, isLowerBound = false)
       case ExistentialType(_, _) =>
         try {
           skolemizationLevel += 1
@@ -5970,7 +5970,7 @@ trait Types extends api.Types { self: SymbolTable =>
     def lastTry =
       tp2 match {
         case ExistentialType(_, res2) if alwaysMatchSimple =>
-          matchesType(tp1, res2, true)
+          matchesType(tp1, res2, alwaysMatchSimple = true)
         case MethodType(_, _) =>
           false
         case PolyType(_, _) =>
@@ -5990,7 +5990,7 @@ trait Types extends api.Types { self: SymbolTable =>
             if (params1.isEmpty) matchesType(res1, res2, alwaysMatchSimple)
             else matchesType(tp1, res2, alwaysMatchSimple)
           case ExistentialType(_, res2) =>
-            alwaysMatchSimple && matchesType(tp1, res2, true)
+            alwaysMatchSimple && matchesType(tp1, res2, alwaysMatchSimple = true)
           case TypeRef(_, sym, Nil) =>
             params1.isEmpty && sym.isModuleClass && matchesType(res1, tp2, alwaysMatchSimple)
           case _ =>
@@ -6003,7 +6003,7 @@ trait Types extends api.Types { self: SymbolTable =>
           case NullaryMethodType(res2) =>
             matchesType(res1, res2, alwaysMatchSimple)
           case ExistentialType(_, res2) =>
-            alwaysMatchSimple && matchesType(tp1, res2, true)
+            alwaysMatchSimple && matchesType(tp1, res2, alwaysMatchSimple = true)
           case TypeRef(_, sym, Nil) if sym.isModuleClass =>
             matchesType(res1, tp2, alwaysMatchSimple)
           case _ =>
@@ -6017,7 +6017,7 @@ trait Types extends api.Types { self: SymbolTable =>
             else
               matchesQuantified(tparams1, tparams2, res1, res2)
           case ExistentialType(_, res2) =>
-            alwaysMatchSimple && matchesType(tp1, res2, true)
+            alwaysMatchSimple && matchesType(tp1, res2, alwaysMatchSimple = true)
           case _ =>
             false // remember that tparams1.nonEmpty is now an invariant of PolyType
         }
@@ -6026,7 +6026,7 @@ trait Types extends api.Types { self: SymbolTable =>
           case ExistentialType(tparams2, res2) =>
             matchesQuantified(tparams1, tparams2, res1, res2)
           case _ =>
-            if (alwaysMatchSimple) matchesType(res1, tp2, true)
+            if (alwaysMatchSimple) matchesType(res1, tp2, alwaysMatchSimple = true)
             else lastTry
         }
       case TypeRef(_, sym, Nil) if sym.isModuleClass =>
@@ -6222,7 +6222,7 @@ trait Types extends api.Types { self: SymbolTable =>
 
     val columns: List[Column[List[Type]]] = mapWithIndex(sorted) {
       case ((k, v), idx) =>
-        Column(str(k), (xs: List[Type]) => str(xs(idx)), true)
+        Column(str(k), (xs: List[Type]) => str(xs(idx)), left = true)
     }
 
     val tableDef = TableDef(columns: _*)

--- a/src/reflect/scala/reflect/internal/util/TableDef.scala
+++ b/src/reflect/scala/reflect/internal/util/TableDef.scala
@@ -19,8 +19,8 @@ class TableDef[T](_cols: Column[T]*) {
    *      if none is specified, a space is used.
    */
   def ~(next: Column[T])            = retThis(cols :+= next)
-  def >>(pair: (String, T => Any))  = this ~ Column(pair._1, pair._2, false)
-  def <<(pair: (String, T => Any))  = this ~ Column(pair._1, pair._2, true)
+  def >>(pair: (String, T => Any))  = this ~ Column(pair._1, pair._2, left = false)
+  def <<(pair: (String, T => Any))  = this ~ Column(pair._1, pair._2, left = true)
   def >+(sep: String)               = retThis(separators += ((cols.size - 1, sep)))
 
   /** Below this point should all be considered private/internal.

--- a/src/reflect/scala/reflect/io/AbstractFile.scala
+++ b/src/reflect/scala/reflect/io/AbstractFile.scala
@@ -227,7 +227,7 @@ abstract class AbstractFile extends Iterable[AbstractFile] {
    */
   def fileNamed(name: String): AbstractFile = {
     assert(isDirectory, "Tried to find '%s' in '%s' but it is not a directory".format(name, path))
-    fileOrSubdirectoryNamed(name, false)
+    fileOrSubdirectoryNamed(name, isDir = false)
   }
 
   /**
@@ -236,7 +236,7 @@ abstract class AbstractFile extends Iterable[AbstractFile] {
    */
   def subdirectoryNamed(name: String): AbstractFile = {
     assert (isDirectory, "Tried to find '%s' in '%s' but it is not a directory".format(name, path))
-    fileOrSubdirectoryNamed(name, true)
+    fileOrSubdirectoryNamed(name, isDir = true)
   }
 
   protected def unsupported(): Nothing = unsupported(null)

--- a/src/reflect/scala/reflect/io/File.scala
+++ b/src/reflect/scala/reflect/io/File.scala
@@ -72,7 +72,7 @@ class File(jfile: JFile)(implicit constructorCodec: Codec) extends Path(jfile) w
 
   /** Wraps a BufferedWriter around the result of writer().
    */
-  def bufferedWriter(): BufferedWriter = bufferedWriter(false)
+  def bufferedWriter(): BufferedWriter = bufferedWriter(append = false)
   def bufferedWriter(append: Boolean): BufferedWriter = bufferedWriter(append, creationCodec)
   def bufferedWriter(append: Boolean, codec: Codec): BufferedWriter =
     new BufferedWriter(writer(append, codec))

--- a/src/reflect/scala/reflect/io/VirtualDirectory.scala
+++ b/src/reflect/scala/reflect/io/VirtualDirectory.scala
@@ -54,14 +54,14 @@ extends AbstractFile {
     (files get name filter (_.isDirectory == directory)).orNull
 
   override def fileNamed(name: String): AbstractFile =
-    Option(lookupName(name, false)) getOrElse {
+    Option(lookupName(name, directory = false)) getOrElse {
       val newFile = new VirtualFile(name, path+'/'+name)
       files(name) = newFile
       newFile
     }
 
   override def subdirectoryNamed(name: String): AbstractFile =
-    Option(lookupName(name, true)) getOrElse {
+    Option(lookupName(name, directory = true)) getOrElse {
       val dir = new VirtualDirectory(name, Some(this))
       files(name) = dir
       dir

--- a/src/reflect/scala/reflect/io/ZipArchive.scala
+++ b/src/reflect/scala/reflect/io/ZipArchive.scala
@@ -39,8 +39,8 @@ object ZipArchive {
    */
   def fromURL(url: URL): URLZipArchive = new URLZipArchive(url)
 
-  private def dirName(path: String)  = splitPath(path, true)
-  private def baseName(path: String) = splitPath(path, false)
+  private def dirName(path: String)  = splitPath(path, front = true)
+  private def baseName(path: String) = splitPath(path, front = false)
   private def splitPath(path0: String, front: Boolean): String = {
     val isDir = path0.charAt(path0.length - 1) == '/'
     val path  = if (isDir) path0.substring(0, path0.length - 1) else path0

--- a/test/files/jvm/named-args-in-order.check
+++ b/test/files/jvm/named-args-in-order.check
@@ -1,0 +1,3 @@
+bytecode identical
+bytecode identical
+bytecode identical

--- a/test/files/jvm/named-args-in-order/SameBytecode.scala
+++ b/test/files/jvm/named-args-in-order/SameBytecode.scala
@@ -1,0 +1,9 @@
+class SameBytecode {
+  def foo(a: Int, b: String) = 0
+  def foo(a: Int, b: Any) = 0
+
+  def a = foo(0, "")
+  def b = foo(a = 0, "")
+  def c = foo(0, b = "")
+  def d = foo(a = 0, b = "")
+}

--- a/test/files/jvm/named-args-in-order/Test.scala
+++ b/test/files/jvm/named-args-in-order/Test.scala
@@ -1,0 +1,10 @@
+import scala.tools.partest.BytecodeTest
+
+object Test extends BytecodeTest {
+  def show: Unit = {
+    val classNode = loadClassNode("SameBytecode")
+    def sameAsA(meth: String) =
+      sameBytecode(getMethod(classNode, "a"), getMethod(classNode, meth))
+    Seq("b", "c", "d").foreach(sameAsA)
+  }
+}


### PR DESCRIPTION
What would you prefer?

```
adaptToMemberWithArgs(tree, qual, name, mode, false, false)
```

Or:

```
adaptToMemberWithArgs(tree, qual, name, mode, reportAmbiguous = false, saveErrors = false)
```

compiler, reflect, and library have been swept.

A sanity check is included to show that using named args for clarity incurs no bytecode penalty.

Review by @paulp. Minor chuckles here: https://github.com/retronym/scala/pull/new/topic/bool-arg#L62L15
