### PR TITLE
SI-7180 Fix regression in implicit scope of HK type alias.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1015,7 +1015,7 @@ trait Implicits {
                 args foreach (getParts(_))
               }
             } else if (sym.isAliasType) {
-              getParts(tp.dealias)
+              getParts(tp.normalize) // SI-7180 Normalize needed to expand HK type refs
             } else if (sym.isAbstractType) {
               getParts(tp.bounds.hi)
             }

--- a/test/files/pos/t7180.scala
+++ b/test/files/pos/t7180.scala
@@ -1,0 +1,13 @@
+trait Higher[F[_]]
+
+trait Box[A]
+object Box {
+  implicit def HigherBox = new Higher[Box] {}
+}
+
+object Foo {
+  val box = implicitly[Higher[Box]] // compiles fine !!!
+
+  type Bar[A] = Box[A]
+  val bar = implicitly[Higher[Bar]] // <-- this doesn't compile in 2.10.1-RC1, but does in 2.10.0 !!!
+}


### PR DESCRIPTION
We actually need to call normalize here, otherwise we don't
progress through 1. below.

```
[infer implicit] scala.this.Predef.implicitly[Higher[Foo.Bar]] with pt=Higher[Foo.Bar] in object Foo
1. tp=Foo.Bar tp.normalize=[A <: <?>]Foo.Bar[A] tp.dealias=Foo.Bar
2. tp=Foo.Bar[A] tp.normalize=Box[A] tp.dealias=Box[A]
```

Review by @adriaanm

I'm submitting against 2.10.1 as I think it meets the criteria for an RC3: it's a regression against 2.10.0, its very difficult for users to diagnose, and the workaround is unpalatable (manually expanding the type alias at the point of implicit search breaks the users abstractions).
