### PR TITLE
SI-7126 Account for the alias types that don't dealias.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -222,8 +222,13 @@ trait Typers extends Modes with Adaptations with Tags {
         new SubstWildcardMap(tparams).apply(tp)
       case TypeRef(_, sym, _) if sym.isAliasType =>
         val tp0 = tp.dealias
-        val tp1 = dropExistential(tp0)
-        if (tp1 eq tp0) tp else tp1
+        if (tp eq tp0) {
+          debugwarn(s"dropExistential did not progress dealiasing $tp, see SI-7126")
+          tp
+        } else {
+          val tp1 = dropExistential(tp0)
+          if (tp1 eq tp0) tp else tp1
+        }
       case _ => tp
     }
 

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3183,12 +3183,19 @@ trait Types extends api.Types { self: SymbolTable =>
        *    ?TC[?T] <: Any
        *  }}}
        */
-      def unifySimple = (
-        (params.isEmpty || tp.typeSymbol == NothingClass || tp.typeSymbol == AnyClass) && {
+      def unifySimple = {
+        val sym = tp.typeSymbol
+        if (sym == NothingClass || sym == AnyClass) { // kind-polymorphic
+          // SI-7126 if we register some type alias `T=Any`, we can later end
+          // with malformed types like `T[T]` during type inference in
+          // `handlePolymorphicCall`. No such problem if we register `Any`.
+          addBound(sym.tpe)
+          true
+        } else if (params.isEmpty) {
           addBound(tp)
           true
-        }
-      )
+        } else false
+      }
 
       /** Full case: involving a check of the form
        *  {{{

--- a/test/files/pos/t7126.scala
+++ b/test/files/pos/t7126.scala
@@ -1,0 +1,11 @@
+import language._
+
+object Test {
+  type T = Any
+  boom(???): Option[T] // SOE
+  def boom[CC[U]](t : CC[T]): Option[CC[T]] = None
+
+  // okay
+  foo(???): Option[Any]
+  def foo[CC[U]](t : CC[Any]): Option[CC[Any]] = None
+}


### PR DESCRIPTION
After this change:

```
qbin/scalac -Ydebug test/files/pos/t7126.scala 2>&1 | grep warning
warning: dropExistential did not progress dealiasing Test.this.T[Test.this.T], see SI-7126
one warning found
```

`T[T]`? Really? The true bug lies somewhere else; the comments of
the ticket illuminate the general areas of concern.

This is a shallow fix intended for 2.10.1. I'll keep investigating the deeper issue, to help inform the decision about whether we are comfortable releasing 2.10.1 with only this bandaid.

Review by @paulp
