### PR TITLE
SI-7183 Disable unreachability for withFilter matches.

### DIFF
--- a/test/files/pos/t7183.flags
+++ b/test/files/pos/t7183.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t7183.scala
+++ b/test/files/pos/t7183.scala
@@ -1,0 +1,13 @@
+class A
+object A {
+  def unapply(a: A): Some[A] = Some(a) // Change return type to Option[A] and the warning is gone
+}
+
+object Test {
+  for (A(a) <- List(new A)) yield a // spurious dead code warning.
+}
+
+// List(new A()).withFilter(((check$ifrefutable$2) => check$ifrefutable$2: @scala.unchecked match {
+//  case A((a @ _)) => true
+//  case _ => false // this is dead code, but it's compiler generated.
+// }))


### PR DESCRIPTION
This avoids spurious unreachable warnings on code
that the user didn't write.

The parser desugars for-comprehensions such as:

```
for (A(a) <- List(new A)) yield a
```

To:

```
List(new A()).withFilter(((check$ifrefutable$2) =>
  check$ifrefutable$2: @scala.unhecked match {
   case A((a @ _)) => true
   case _ => false
  })
)
```

But, if `A.unapply` returns `Some[_]`, the last case is dead code.
(Matching against a regular case class _would_ fall through in
the caes of a null scrutinee.)

In SI-6902, we enabled unreachability warnings, even if the
scrutinee was annotated as @unchecked. That was consistent
with the 2.9.2 behaviour, it was only disabled temporarily
(actually, accidentally) in 2.10.0. But, the old pattern matcher
didn't warn about this code.

This commit makes the pattern matcher recognise the special
scrutinee based on its name and disables both exhaustivity
_and_ unreachability analysis.

To do so, the we generalize the boolean flag `unchecked` to
the class `Suppression`.

Review by @adriaanm. 

This one shows up on typical usage of Slick, so I think its a fairly important regression. We need to get better at internal testing of new Scala releases; we had a regression from each of SBT, Akka, and Slick show up very late in the cycle.

```
/Users/jason/code/slick/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/NestingTest.scala:20: warning: unreachable code
      a ~ b <- mapped
```
