### PR TITLE
relax time constraint in duration-tck.scala (for Windows)

### DIFF
--- a/test/files/jvm/duration-tck.scala
+++ b/test/files/jvm/duration-tck.scala
@@ -176,8 +176,9 @@ object Test extends App {
 
   Thread.sleep(1.second.toMillis)
 
-  { val l = dead.timeLeft; assert(l <= 1.second, s"$l > 1.second") }
-  { val l = dead2.timeLeft; assert(l <= 1.second, s"$l > 1.second") }
+  // unfortunately it can happen that the sleep() returns early without throwing
+  { val l = dead.timeLeft; assert(l <= 1100.millis, s"$l > 1100.millis") }
+  { val l = dead2.timeLeft; assert(l <= 1100.millis, s"$l > 1100.millis") }
 
 
   // test integer mul/div


### PR DESCRIPTION
It seems that on Windows Thread.sleep can actually return early even if it does not throw an exception.

review-by: @phaller @adriaanm
