### PR TITLE
SI-7185 Avoid NPE in TreeInfo.isExprSafeToInline

### DIFF
--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -98,7 +98,8 @@ abstract class TreeInfo {
       // However, before typing, applications of nullary functional values are also
       // Apply(function, Nil) trees. To prevent them from being treated as pure,
       // we check that the callee is a method.
-      fn.symbol.isMethod && !fn.symbol.isLazy && isExprSafeToInline(fn)
+      // The callee might also be a Block, which has a null symbol, so we guard against that (SI-7185)
+      fn.symbol != null && fn.symbol.isMethod && !fn.symbol.isLazy && isExprSafeToInline(fn)
     case Typed(expr, _) =>
       isExprSafeToInline(expr)
     case Block(stats, expr) =>

--- a/test/files/neg/t7185.check
+++ b/test/files/neg/t7185.check
@@ -1,0 +1,7 @@
+t7185.scala:2: error: overloaded method value apply with alternatives:
+  (f: scala.xml.Node => Boolean)scala.xml.NodeSeq <and>
+  (i: Int)scala.xml.Node
+ cannot be applied to ()
+  <e></e>()
+   ^
+one error found

--- a/test/files/neg/t7185.scala
+++ b/test/files/neg/t7185.scala
@@ -1,0 +1,3 @@
+object Test {
+  <e></e>()
+}

--- a/test/files/run/t7185.check
+++ b/test/files/run/t7185.check
@@ -1,0 +1,34 @@
+Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> 
+
+scala> import scala.tools.reflect.ToolBox
+import scala.tools.reflect.ToolBox
+
+scala> import scala.reflect.runtime.universe._
+import scala.reflect.runtime.universe._
+
+scala> object O { def apply() = 0 }
+defined module O
+
+scala> val ORef = reify { O }.tree
+ORef: reflect.runtime.universe.Tree = $read.O
+
+scala> val tree = Apply(Block(Nil, Block(Nil, ORef)), Nil)
+tree: reflect.runtime.universe.Apply = 
+{
+  {
+    $read.O
+  }
+}()
+
+scala> {val tb = reflect.runtime.currentMirror.mkToolBox(); tb.typeCheck(tree): Any}
+res0: Any = 
+{
+  {
+    $read.O.apply()
+  }
+}
+
+scala> 

--- a/test/files/run/t7185.scala
+++ b/test/files/run/t7185.scala
@@ -1,0 +1,12 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  override def code = """
+import scala.tools.reflect.ToolBox
+import scala.reflect.runtime.universe._
+object O { def apply() = 0 }
+val ORef = reify { O }.tree
+val tree = Apply(Block(Nil, Block(Nil, ORef)), Nil)
+{val tb = reflect.runtime.currentMirror.mkToolBox(); tb.typeCheck(tree): Any}
+"""
+}


### PR DESCRIPTION
We got there typechecking code with a redundant
layer of Block.

We can't express that in source code, so we test
this with manual tree construction and with XML
literals, which as reported produce such trees.

Review by @xeno-by
