### PR TITLE
SI-7190 macros no longer give rise to bridges

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -477,6 +477,7 @@ abstract class Erasure extends AddInterfaces
     def checkPair(member: Symbol, other: Symbol) {
       val otpe = specialErasure(root)(other.tpe)
       val bridgeNeeded = afterErasure (
+        !member.isMacro &&
         !(other.tpe =:= member.tpe) &&
         !(deconstMap(other.tpe) =:= deconstMap(member.tpe)) &&
         { var e = bridgesScope.lookupEntry(member.name)

--- a/test/files/pos/t7190.scala
+++ b/test/files/pos/t7190.scala
@@ -1,0 +1,26 @@
+import scala.language.experimental.macros
+import scala.reflect.macros._
+
+trait A[T] {
+  def min[U >: T](implicit ord: Numeric[U]): T = macro A.min[T, U]
+}
+
+object A {
+  def min[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: Context)(ord: c.Expr[Numeric[U]]): c.Expr[T] = {
+    c.universe.reify {
+      ord.splice.zero.asInstanceOf[T]
+    }
+  }
+}
+
+class B extends A[Int] {
+  override def min[U >: Int](implicit ord: Numeric[U]): Int = macro B.min[U]
+}
+
+object B {
+  def min[U >: Int: c.WeakTypeTag](c: Context)(ord: c.Expr[Numeric[U]]): c.Expr[Int] = {
+    c.universe.reify {
+      ord.splice.zero.asInstanceOf[Int]
+    }
+  }
+}


### PR DESCRIPTION
Amazingly enough, this got through all the testing we performed. But now
erasure knows that it shouldn't generate bridges for macro methods.
