### PR TITLE
Tone down a soft-warning to only show under -Ydebug.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
@@ -2143,8 +2143,8 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
                 val start = st.pop()
                 seen ::= LocVarEntry(lv, start, end)
               case _ =>
-                // TODO SI-6049
-                getCurrentCUnit().warning(iPos, "Visited SCOPE_EXIT before visiting corresponding SCOPE_ENTER. SI-6049")
+                // TODO SI-6049 track down the cause for these.
+                debugwarn(s"$iPos: Visited SCOPE_EXIT before visiting corresponding SCOPE_ENTER. SI-6191")
             }
           }
 


### PR DESCRIPTION
SI-6191 remains open and can lead to incomplete debug
scope information. In 2.10.0, the backend detected when
this happend, and warned the user. But there is little
the user can do about the warning. We have a few test
cases for the problem now, so we should not pollute
the compile output.

Review by @JamesIry
