### PR TITLE
SI-6725 `f` interpolator now supports %n tokens

### DIFF
--- a/src/compiler/scala/tools/reflect/MacroImplementations.scala
+++ b/src/compiler/scala/tools/reflect/MacroImplementations.scala
@@ -117,7 +117,8 @@ abstract class MacroImplementations {
       if (!strIsEmpty) {
         val len = str.length
         while (idx < len) {
-          if (str(idx) == '%') {
+          def notPercentN = str(idx) != '%' || (idx + 1 < len && str(idx + 1) != 'n')
+          if (str(idx) == '%' && notPercentN) {
             bldr append (str substring (start, idx)) append "%%"
             start = idx + 1
           }


### PR DESCRIPTION
Currently the `f` interpolator supports format specifiers which
specify conversions for formatted arguments. However Java formatting
is not limited to argument-related conversions as explained in:
http://docs.oracle.com/javase/6/docs/api/java/util/Formatter.html#detail.

Conversions which don't correspond to any arguments are `%` (used to
emit verbatim `'%'` characters) and `n` (used to emit platform-specific
line separators). Of those only the former is supported, and this patch
fixes the oversight.
