### PR TITLE
SI-6816 Deprecate -Yeta-expand-keeps-star

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -167,7 +167,8 @@ trait ScalaSettings extends AbsScalaSettings
   val Yreploutdir     = StringSetting     ("-Yrepl-outdir", "path", "Write repl-generated classfiles to given output directory (use \"\" to generate a temporary dir)" , "")
   val Ynotnull        = BooleanSetting    ("-Ynotnull", "Enable (experimental and incomplete) scala.NotNull.")
   val YmethodInfer    = BooleanSetting    ("-Yinfer-argument-types", "Infer types for arguments of overriden methods.")
-  val etaExpandKeepsStar = BooleanSetting ("-Yeta-expand-keeps-star", "Eta-expand varargs methods to T* rather than Seq[T].  This is a temporary option to ease transition.")
+  val etaExpandKeepsStar = BooleanSetting ("-Yeta-expand-keeps-star", "Eta-expand varargs methods to T* rather than Seq[T].  This is a temporary option to ease transition.").
+                                          withDeprecationMessage("This flag is scheduled for removal in 2.12. If you have a case where you need this flag then please report a bug.")
   val Yinvalidate     = StringSetting     ("-Yinvalidate", "classpath-entry", "Invalidate classpath entry before run", "")
   val noSelfCheck     = BooleanSetting    ("-Yno-self-type-checks", "Suppress check for self-type conformance among inherited members.")
   val YvirtClasses    = false // too embryonic to even expose as a -Y //BooleanSetting    ("-Yvirtual-classes", "Support virtual classes")

--- a/test/files/neg/eta-expand-star-deprecation.check
+++ b/test/files/neg/eta-expand-star-deprecation.check
@@ -1,0 +1,4 @@
+warning: -Yeta-expand-keeps-star is deprecated: This flag is scheduled for removal in 2.12. If you have a case where you need this flag then please report a bug.
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/eta-expand-star-deprecation.flags
+++ b/test/files/neg/eta-expand-star-deprecation.flags
@@ -1,0 +1,1 @@
+-Yeta-expand-keeps-star -deprecation -Xfatal-warnings

--- a/test/files/neg/eta-expand-star-deprecation.scala
+++ b/test/files/neg/eta-expand-star-deprecation.scala
@@ -1,0 +1,8 @@
+object Test {
+  def f[T](xs: T*): Unit = ()
+  def g[T] = f[T] _
+
+  def main(args: Array[String]): Unit = {
+    g(1, 2)
+  }
+}


### PR DESCRIPTION
This commit deprecates the -Yeta-expand-keeps-star flag. It was created
in 2.10 to help in the transition from 2.9 but by the time 2.11 comes
out it should no longer be necessary.
