### PR TITLE
SI-7132 - don't discard Unit type in interpreter

### DIFF
--- a/src/compiler/scala/tools/nsc/interpreter/ExprTyper.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/ExprTyper.scala
@@ -49,15 +49,13 @@ trait ExprTyper {
       // Typing it with a lazy val would give us the right type, but runs
       // into compiler bugs with things like existentials, so we compile it
       // behind a def and strip the NullaryMethodType which wraps the expr.
-      val line = "def " + name + " = {\n" + code + "\n}"
+      val line = "def " + name + " = " + code
 
       interpretSynthetic(line) match {
         case IR.Success =>
           val sym0 = symbolOfTerm(name)
           // drop NullaryMethodType
-          val sym = sym0.cloneSymbol setInfo exitingTyper(sym0.info.finalResultType)
-          if (sym.info.typeSymbol eq UnitClass) NoSymbol
-          else sym
+          sym0.cloneSymbol setInfo exitingTyper(sym0.info.finalResultType)
         case _          => NoSymbol
       }
     }
@@ -74,7 +72,11 @@ trait ExprTyper {
         case _ => NoSymbol
       }
     }
-    beQuietDuring(asExpr()) orElse beQuietDuring(asDefn())
+    def asError(): Symbol = {
+      interpretSynthetic(code)
+      NoSymbol
+    }
+    beSilentDuring(asExpr()) orElse beSilentDuring(asDefn()) orElse asError()
   }
 
   private var typeOfExpressionDepth = 0

--- a/test/files/run/repl-colon-type.check
+++ b/test/files/run/repl-colon-type.check
@@ -4,12 +4,6 @@ Type :help for more information.
 scala> 
 
 scala> :type List[1, 2, 3]
-<console>:2: error: identifier expected but integer literal found.
-       List[1, 2, 3]
-            ^
-<console>:3: error: ']' expected but '}' found.
-       }
-       ^
 <console>:1: error: identifier expected but integer literal found.
        List[1, 2, 3]
             ^
@@ -44,12 +38,9 @@ scala> :type lazy val f = 5
 Int
 
 scala> :type protected lazy val f = 5
-<console>:2: error: illegal start of statement (no modifiers allowed here)
-       protected lazy val f = 5
-       ^
 <console>:5: error: lazy value f cannot be accessed in object $iw
  Access to protected value f not permitted because
- enclosing object $eval in package $line19 is not a subclass of 
+ enclosing object $eval in package $line13 is not a subclass of 
  object $iw where target is defined
   lazy val $result = f
                                            ^
@@ -218,6 +209,16 @@ PolyType(
     )
   )
 )
+
+scala> 
+
+scala> // SI-7132 - :type doesn't understand Unit
+
+scala> :type ()
+Unit
+
+scala> :type println("side effect!")
+Unit
 
 scala> 
 

--- a/test/files/run/repl-colon-type.scala
+++ b/test/files/run/repl-colon-type.scala
@@ -26,6 +26,10 @@ object Test extends ReplTest {
     |:type -v Nil.combinations _
     |:type -v def f[T <: AnyVal] = List[T]().combinations _
     |:type -v def f[T, U >: T](x: T, y: List[U]) = x :: y
+    |
+    |// SI-7132 - :type doesn't understand Unit
+    |:type ()
+    |:type println("side effect!")
   """.stripMargin
 }
 


### PR DESCRIPTION
This is my first pull request here, so apologies in advance if I've (likely) screwed something up.

This is to fix a bug in the REPL, apparently introduced in 4a6f54b, in which the `:type` command fully evaluates expressions of type `Unit`, rather than just printing the type name `Unit`.

@paulp I think I'm supposed to ask you to review...
