### PR TITLE
Renamed type param to be consistent with convention.

### DIFF
--- a/src/library/scala/collection/TraversableOnce.scala
+++ b/src/library/scala/collection/TraversableOnce.scala
@@ -383,17 +383,17 @@ object TraversableOnce {
     new FlattenOps[A](travs map ev)
 
   /* Functionality reused in Iterator.CanBuildFrom */
-  private[collection] abstract class BufferedCanBuildFrom[A, Coll[X] <: TraversableOnce[X]] extends generic.CanBuildFrom[Coll[_], A, Coll[A]] {
-    def bufferToColl[B](buff: ArrayBuffer[B]): Coll[B]
-    def traversableToColl[B](t: GenTraversable[B]): Coll[B]
+  private[collection] abstract class BufferedCanBuildFrom[A, CC[X] <: TraversableOnce[X]] extends generic.CanBuildFrom[CC[_], A, CC[A]] {
+    def bufferToColl[B](buff: ArrayBuffer[B]): CC[B]
+    def traversableToColl[B](t: GenTraversable[B]): CC[B]
 
-    def newIterator: Builder[A, Coll[A]] = new ArrayBuffer[A] mapResult bufferToColl
+    def newIterator: Builder[A, CC[A]] = new ArrayBuffer[A] mapResult bufferToColl
 
     /** Creates a new builder on request of a collection.
      *  @param from  the collection requesting the builder to be created.
      *  @return the result of invoking the `genericBuilder` method on `from`.
      */
-    def apply(from: Coll[_]): Builder[A, Coll[A]] = from match {
+    def apply(from: CC[_]): Builder[A, CC[A]] = from match {
       case xs: generic.GenericTraversableTemplate[_, _] => xs.genericBuilder.asInstanceOf[Builder[A, Traversable[A]]] mapResult {
         case res => traversableToColl(res.asInstanceOf[GenTraversable[A]])
       }


### PR DESCRIPTION
It's super confusing to see debugging output showing
a type constructor called "Coll". The convention in the
collections is that CC[A] takes type parameters and
Coll is an alias for the applied type.
