### PR TITLE
Remove lint warnings in the library:

### DIFF
--- a/src/compiler/scala/tools/nsc/CompilationUnits.scala
+++ b/src/compiler/scala/tools/nsc/CompilationUnits.scala
@@ -108,6 +108,9 @@ trait CompilationUnits { self: Global =>
     def echo(pos: Position, msg: String) =
       reporter.echo(pos, msg)
 
+    def info(pos: Position, msg: String) =
+      reporter.info(pos, msg, force=false)
+
     def error(pos: Position, msg: String) =
       reporter.error(pos, msg)
 

--- a/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
@@ -31,18 +31,6 @@ abstract class Pickler extends SubComponent {
   def newPhase(prev: Phase): StdPhase = new PicklePhase(prev)
 
   class PicklePhase(prev: Phase) extends StdPhase(prev) {
-    override def run() {
-      super.run()
-      // This is run here rather than after typer because I found
-      // some symbols - usually annotations, possibly others - had not
-      // yet performed the necessary symbol lookup, leading to
-      // spurious claims of unusedness.
-      if (settings.lint.value) {
-        log("Clearing recorded import selectors.")
-        analyzer.clearUnusedImports()
-      }
-    }
-
     def apply(unit: CompilationUnit) {
       def pickle(tree: Tree) {
         def add(sym: Symbol, pickle: Pickle) = {
@@ -83,8 +71,6 @@ abstract class Pickler extends SubComponent {
       }
 
       pickle(unit.body)
-      if (settings.lint.value)
-        analyzer.warnUnusedImports(unit)
     }
   }
 

--- a/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
@@ -95,12 +95,16 @@ trait Analyzer extends AnyRef
       }
       def apply(unit: CompilationUnit) {
         try {
+          if (settings.lint.value)
+            clearUnusedImports()
           val typer = newTyper(rootContext(unit))
           unit.body = typer.typed(unit.body)
           if (global.settings.Yrangepos.value && !global.reporter.hasErrors) global.validatePositions(unit.body)
           for (workItem <- unit.toCheck) workItem()
-          if (settings.lint.value)
+          if (settings.lint.value) {
             typer checkUnused unit
+            warnUnusedImports(unit)
+          }
         }
         finally {
           unit.toCheck.clear()

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -58,7 +58,10 @@ trait Contexts { self: Analyzer =>
   def warnUnusedImports(unit: CompilationUnit) = {
     val imps = allImportInfos(unit).reverse.distinct
 
-    for (imp <- imps) {
+    def languageFeatureImport(imp: ImportInfo): Boolean =
+      imp.qual.symbol eq ScalaPackage.info.decl("language": TermName)
+
+    for (imp <- imps if !languageFeatureImport(imp)) {
       val used = allUsedSelectors(imp)
       def isMask(s: ImportSelector) = s.name != nme.WILDCARD && s.rename == nme.WILDCARD
 

--- a/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
@@ -334,7 +334,7 @@ trait SyntheticMethods extends ast.TreeDSL {
             clazz.isDerivedValueClass && (m == Any_hashCode || m == Any_equals) && {
               if (settings.lint.value) {
                 (clazz.info nonPrivateMember m.name) filter (m => (m.owner != AnyClass) && (m.owner != clazz) && !m.isDeferred) andAlso { m =>
-                  currentUnit.warning(clazz.pos, s"Implementation of ${m.name} inherited from ${m.owner} overridden in $clazz to enforce value class semantics")
+                  currentUnit.info(clazz.pos, s"Implementation of ${m.name} inherited from ${m.owner} overridden in $clazz to enforce value class semantics")
                 }
               }
               true

--- a/src/library/scala/collection/LinearSeqOptimized.scala
+++ b/src/library/scala/collection/LinearSeqOptimized.scala
@@ -10,7 +10,6 @@ package scala.collection
 
 import mutable.ListBuffer
 import immutable.List
-import scala.util.control.Breaks._
 import scala.annotation.tailrec
 
 /** A template trait for linear sequences of type `LinearSeq[A]`  which optimizes

--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -95,7 +95,7 @@ extends AbstractMap[A, B]
 
   def iterator = entriesIterator map {e => (e.key, e.value)}
 
-  override def foreach[C](f: ((A, B)) => C): Unit = foreachEntry(e => f(e.key, e.value))
+  override def foreach[C](f: ((A, B)) => C): Unit = foreachEntry(e => f(e.key -> e.value))
 
   /* Override to avoid tuple allocation in foreach */
   override def keySet: scala.collection.Set[A] = new DefaultKeySet {

--- a/src/library/scala/collection/parallel/immutable/ParRange.scala
+++ b/src/library/scala/collection/parallel/immutable/ParRange.scala
@@ -12,7 +12,6 @@ import scala.collection.immutable.Range
 import scala.collection.parallel.Combiner
 import scala.collection.parallel.SeqSplitter
 import scala.collection.generic.CanCombineFrom
-import scala.collection.parallel.IterableSplitter
 import scala.collection.Iterator
 
 /** Parallel ranges.

--- a/src/library/scala/xml/NamespaceBinding.scala
+++ b/src/library/scala/xml/NamespaceBinding.scala
@@ -38,8 +38,6 @@ case class NamespaceBinding(prefix: String, uri: String, parent: NamespaceBindin
 
   override def toString(): String = sbToString(buildString(_, TopScope))
 
-  private def shadowRedefined: NamespaceBinding = shadowRedefined(TopScope)
-
   private def shadowRedefined(stop: NamespaceBinding): NamespaceBinding = {
     def prefixList(x: NamespaceBinding): List[String] =
       if ((x == null) || (x eq stop)) Nil

--- a/test/files/neg/warn-unused-imports.scala
+++ b/test/files/neg/warn-unused-imports.scala
@@ -122,4 +122,9 @@ trait Nested {
     }
     println(new Warn { })
   }
+
+  {
+    import scala.language.postfixOps  // no warn (regardless of whether the feature is used)
+    List() distinct
+  }
 }


### PR DESCRIPTION
-Remove truly unused symbols.
-Turn the "copy the implementation from super trait in a class inheriting from AnyVal" from warning to info.
-Filter out language._ imports from the unused.
