### PR TITLE
Add option to disable optimization

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -43,6 +43,7 @@ trait ScalaSettings extends AbsScalaSettings
   /** Internal use - syntax enhancements. */
   private class EnableSettings[T <: BooleanSetting](val s: T) {
     def enabling(toEnable: List[BooleanSetting]): s.type = s withPostSetHook (_ => toEnable foreach (_.value = s.value))
+    def disabling(toDisable: List[BooleanSetting]): s.type = s withPostSetHook (_ => toDisable foreach (_.value = !s.value))
     def andThen(f: s.T => Unit): s.type                  = s withPostSetHook (setting => f(setting.value))
   }
   private implicit def installEnableSettings[T <: BooleanSetting](s: T) = new EnableSettings(s)
@@ -194,6 +195,7 @@ trait ScalaSettings extends AbsScalaSettings
    */
   val future        = BooleanSetting("-Xfuture", "Turn on future language features.") enabling futureSettings
   val optimise      = BooleanSetting("-optimise", "Generates faster bytecode by applying optimisations to the program") withAbbreviation "-optimize" enabling optimiseSettings
+  val nooptimise    = BooleanSetting("-Ynooptimise", "Clears all the flags set by -optimise. Useful for testing optimizations in isolation.") withAbbreviation "-Ynooptimize" disabling optimise::optimiseSettings
   val Xexperimental = BooleanSetting("-Xexperimental", "Enable experimental extensions.") enabling experimentalSettings
 
   // Feature extensions

--- a/test/files/jvm/nooptimise/Foo_1.flags
+++ b/test/files/jvm/nooptimise/Foo_1.flags
@@ -1,0 +1,1 @@
+-optimise -Ynooptimise

--- a/test/files/jvm/nooptimise/Foo_1.scala
+++ b/test/files/jvm/nooptimise/Foo_1.scala
@@ -1,0 +1,8 @@
+class Foo_1 {
+  def foo() {
+    // optimization will remove this magic 3 from appearing in the source
+    // so -Ynooptimize should prevent that
+    val x = 3
+     
+  }
+}

--- a/test/files/jvm/nooptimise/Test.scala
+++ b/test/files/jvm/nooptimise/Test.scala
@@ -1,0 +1,23 @@
+import scala.tools.partest.BytecodeTest
+import scala.tools.asm
+import asm.tree.InsnList
+import scala.collection.JavaConverters._
+
+object Test extends BytecodeTest {
+  def show: Unit = {
+    val classNode = loadClassNode("Foo_1")
+    val methodNode = getMethod(classNode, "foo")
+    // if optimization didn't run then
+    // there should be some useless instructions 
+    // with the magic constant 3
+    val expected = 1
+    val got = countMagicThrees(methodNode.instructions)
+    assert(got == expected, s"expected $expected but got $got magic threes")
+  }
+
+  def countMagicThrees(insnList: InsnList): Int = {
+    def isMagicThree(node: asm.tree.AbstractInsnNode): Boolean =
+      (node.getOpcode == asm.Opcodes.ICONST_3)
+    insnList.iterator.asScala.count(isMagicThree)
+  }
+}

--- a/test/files/jvm/t7006/Foo_1.flags
+++ b/test/files/jvm/t7006/Foo_1.flags
@@ -1,1 +1,1 @@
- -Ydead-code -Ydebug -Xfatal-warnings
+-Ynooptimise -Ydead-code -Ydebug -Xfatal-warnings


### PR DESCRIPTION
By default we run par test under -optimise. But occasionally we need
to test optimizations in isolation. This commit adds a Ynooptimise
flag that turns the optimize flags off back off after they've been
turned on.

A test is included to ensure that -Ynooptimise turns off optimizations
and an existing test is modified to show that optimizations coming
after -Ynooptimise in command line are enabled.
