### PR TITLE
Enabling commit for interactive/scaladoc modules.

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -425,11 +425,13 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
   val printInfers = settings.Yinferdebug.value
 
   // phaseName = "parser"
-  object syntaxAnalyzer extends {
+  lazy val syntaxAnalyzer = new {
     val global: Global.this.type = Global.this
     val runsAfter = List[String]()
     val runsRightAfter = None
   } with SyntaxAnalyzer
+
+  import syntaxAnalyzer.{ UnitScanner, UnitParser }
 
   // !!! I think we're overdue for all these phase objects being lazy vals.
   // There's no way for a Global subclass to provide a custom typer
@@ -1120,9 +1122,11 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
         warning("there were %d %s warning(s); re-run with %s for details".format(warnings.size, what, option.name))
   }
 
-  def newUnitParser(code: String)      = new syntaxAnalyzer.UnitParser(newCompilationUnit(code))
-  def newCompilationUnit(code: String) = new CompilationUnit(newSourceFile(code))
-  def newSourceFile(code: String)      = new BatchSourceFile("<console>", code)
+  def newCompilationUnit(code: String)                   = new CompilationUnit(newSourceFile(code))
+  def newSourceFile(code: String)                        = new BatchSourceFile("<console>", code)
+  def newUnitScanner(unit: CompilationUnit): UnitScanner = new UnitScanner(unit)
+  def newUnitParser(unit: CompilationUnit): UnitParser   = new UnitParser(unit)
+  def newUnitParser(code: String): UnitParser            = newUnitParser(newCompilationUnit(code))
 
   /** A Run is a single execution of the compiler on a sets of units
    */

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -142,9 +142,9 @@ self =>
       if (source.isSelfContained) () => compilationUnit()
       else () => scriptBody()
 
-    def newScanner = new SourceFileScanner(source)
+    def newScanner(): Scanner = new SourceFileScanner(source)
 
-    val in = newScanner
+    val in = newScanner()
     in.init()
 
     private val globalFresh = new FreshNameCreator.Default
@@ -196,10 +196,9 @@ self =>
   }
 
   class UnitParser(val unit: global.CompilationUnit, patches: List[BracePatch]) extends SourceFileParser(unit.source) {
+    def this(unit: global.CompilationUnit) = this(unit, Nil)
 
-    def this(unit: global.CompilationUnit) = this(unit, List())
-
-    override def newScanner = new UnitScanner(unit, patches)
+    override def newScanner() = new UnitScanner(unit, patches)
 
     override def freshTermName(prefix: String): TermName = unit.freshTermName(prefix)
     override def freshTypeName(prefix: String): TypeName = unit.freshTypeName(prefix)
@@ -219,6 +218,7 @@ self =>
       try body
       finally smartParsing = saved
     }
+    def withPatches(patches: List[BracePatch]): UnitParser = new UnitParser(unit, patches)
 
     val syntaxErrors = new ListBuffer[(Int, String)]
     def showSyntaxErrors() =
@@ -244,7 +244,7 @@ self =>
       if (syntaxErrors.isEmpty) firstTry
       else in.healBraces() match {
         case Nil      => showSyntaxErrors() ; firstTry
-        case patches  => new UnitParser(unit, patches).parse()
+        case patches  => (this withPatches patches).parse()
       }
     }
   }

--- a/src/compiler/scala/tools/nsc/ast/parser/SyntaxAnalyzer.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/SyntaxAnalyzer.scala
@@ -28,8 +28,8 @@ abstract class SyntaxAnalyzer extends SubComponent with Parsers with MarkupParse
       if (unit.body == EmptyTree) {
         unit.body =
           if (unit.isJava) new JavaUnitParser(unit).parse()
-          else if (reporter.incompleteHandled) new UnitParser(unit).parse()
-          else new UnitParser(unit).smartParse()
+          else if (reporter.incompleteHandled) newUnitParser(unit).parse()
+          else newUnitParser(unit).smartParse()
       }
 
       if (settings.Yrangepos.value && !reporter.hasErrors)

--- a/src/compiler/scala/tools/nsc/doc/DocParser.scala
+++ b/src/compiler/scala/tools/nsc/doc/DocParser.scala
@@ -42,7 +42,7 @@ class DocParser(settings: nsc.Settings, reporter: Reporter) extends Global(setti
    */
   def docUnit(code: String) = {
     val unit    = new CompilationUnit(new BatchSourceFile("<console>", code))
-    val scanner = new syntaxAnalyzer.UnitParser(unit)
+    val scanner = newUnitParser(unit)
 
     scanner.compilationUnit()
   }

--- a/src/compiler/scala/tools/nsc/interactive/CompilerControl.scala
+++ b/src/compiler/scala/tools/nsc/interactive/CompilerControl.scala
@@ -263,7 +263,7 @@ trait CompilerControl { self: Global =>
    *  compiler thread.
    */
   def parseTree(source: SourceFile): Tree = {
-    new UnitParser(new CompilationUnit(source)).parse()
+    newUnitParser(new CompilationUnit(source)).parse()
   }
 
   /** Asks for a computation to be done quickly on the presentation compiler thread */

--- a/src/compiler/scala/tools/nsc/interactive/RangePositions.scala
+++ b/src/compiler/scala/tools/nsc/interactive/RangePositions.scala
@@ -10,4 +10,5 @@ package interactive
 trait RangePositions extends scala.reflect.internal.Positions with ast.Trees with ast.Positions {
   self: scala.tools.nsc.Global =>
 
+  override def useOffsetPositions = false
 }

--- a/src/compiler/scala/tools/nsc/javac/JavaScanners.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaScanners.scala
@@ -10,7 +10,7 @@ import scala.tools.nsc.util.JavaCharArrayReader
 import scala.reflect.internal.util._
 import scala.reflect.internal.Chars._
 import JavaTokens._
-import scala.annotation.switch
+import scala.annotation.{ switch, tailrec }
 import scala.language.implicitConversions
 
 // Todo merge these better with Scanners
@@ -587,33 +587,20 @@ trait JavaScanners extends ast.parser.ScannersCommon {
       }
     }
 
-    private def skipComment(): Boolean = {
-      if (in.ch == '/') {
-        do {
-          in.next()
-        } while ((in.ch != CR) && (in.ch != LF) && (in.ch != SU))
-        true
-      } else if (in.ch == '*') {
-        docBuffer = null
-        in.next()
-        val scalaDoc = ("/**", "*/")
-        if (in.ch == '*' && forScaladoc)
-          docBuffer = new StringBuilder(scalaDoc._1)
-        do {
-          do {
-            if (in.ch != '*' && in.ch != SU) {
-              in.next(); putDocChar(in.ch)
-            }
-          } while (in.ch != '*' && in.ch != SU)
-          while (in.ch == '*') {
-            in.next(); putDocChar(in.ch)
-          }
-        } while (in.ch != '/' && in.ch != SU)
-        if (in.ch == '/') in.next()
-        else incompleteInputError("unclosed comment")
-        true
-      } else {
-        false
+    protected def skipComment(): Boolean = {
+      @tailrec def skipLineComment(): Unit = in.ch match {
+        case CR | LF | SU =>
+        case _            => in.next; skipLineComment()
+      }
+      @tailrec def skipJavaComment(): Unit = in.ch match {
+        case SU  => incompleteInputError("unclosed comment")
+        case '*' => in.next; if (in.ch == '/') in.next else skipJavaComment()
+        case _   => in.next; skipJavaComment()
+      }
+      in.ch match {
+        case '/' => in.next ; skipLineComment() ; true
+        case '*' => in.next ; skipJavaComment() ; true
+        case _   => false
       }
     }
 

--- a/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
@@ -30,6 +30,18 @@ abstract class SymbolLoaders {
     member
   }
 
+  protected def signalError(root: Symbol, ex: Throwable) {
+    if (settings.debug.value) ex.printStackTrace()
+    // SI-5593 Scaladoc's current strategy is to visit all packages in search of user code that can be documented
+    // therefore, it will rummage through the classpath triggering errors whenever it encounters package objects
+    // that are not in their correct place (see bug for details)
+    if (!settings.isScaladoc)
+      globalError(ex.getMessage() match {
+        case null => "i/o error while loading " + root.name
+        case msg  => "error while loading " + root.name + ", " + msg
+      })
+  }
+
   /** Enter class with given `name` into scope of `root`
    *  and give them `completer` as type.
    */
@@ -168,18 +180,6 @@ abstract class SymbolLoaders {
     }
 
     override def complete(root: Symbol) {
-      def signalError(ex: Exception) {
-        ok = false
-        if (settings.debug.value) ex.printStackTrace()
-        val msg = ex.getMessage()
-        // SI-5593 Scaladoc's current strategy is to visit all packages in search of user code that can be documented
-        // therefore, it will rummage through the classpath triggering errors whenever it encounters package objects
-        // that are not in their correct place (see bug for details)
-        if (!settings.isScaladoc)
-          globalError(
-            if (msg eq null) "i/o error while loading " + root.name
-            else "error while loading " + root.name + ", " + msg)
-      }
       try {
         val start = currentTime
         val currentphase = phase
@@ -189,11 +189,11 @@ abstract class SymbolLoaders {
         ok = true
         setSource(root)
         setSource(root.companionSymbol) // module -> class, class -> module
-      } catch {
-        case ex: IOException =>
-          signalError(ex)
-        case ex: MissingRequirementError =>
-          signalError(ex)
+      }
+      catch {
+        case ex @ (_: IOException | _: MissingRequirementError) =>
+          ok = false
+          signalError(root, ex)
       }
       initRoot(root)
       if (!root.isPackageClass) initRoot(root.companionSymbol)

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1694,7 +1694,7 @@ trait Infer extends Checkable {
           }
           else if (sym.isOverloaded) {
             val xs      = sym.alternatives
-            val tparams = new AsSeenFromMap(pre, xs.head.owner) mapOver xs.head.typeParams
+            val tparams = newAsSeenFromMap(pre, xs.head.owner) mapOver xs.head.typeParams
             val bounds  = tparams map (_.tpeHK) // see e.g., #1236
             val tpe     = PolyType(tparams, OverloadedType(AntiPolyType(pre, bounds), xs))
 

--- a/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
+++ b/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
@@ -283,7 +283,7 @@ abstract class ToolBoxFactory[U <: JavaUniverse](val u: U) { factorySelf =>
         val file = new BatchSourceFile("<toolbox>", wrappedCode)
         val unit = new CompilationUnit(file)
         phase = run.parserPhase
-        val parser = new syntaxAnalyzer.UnitParser(unit)
+        val parser = newUnitParser(unit)
         val wrappedTree = parser.parse()
         throwIfErrors()
         val PackageDef(_, List(ModuleDef(_, _, Template(_, _, _ :: parsed)))) = wrappedTree


### PR DESCRIPTION
This is a non-behaviorally-changing setup commit which
re-routes bits of code through avenues which can more easily
be influenced by subclasses of Global.
