### PR TITLE
Bring some sanity to the stability test.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -433,6 +433,7 @@ INITIALISATION
     <property name="scalac.args.quickonly" value=""/>
     <property name="scalac.args.all" value="${scalac.args.always} ${scalac.args} ${scalac.args.optimise}"/>
     <property name="scalac.args.quick" value="${scalac.args.all} ${scalac.args.quickonly}"/>
+    <property name="scalac.args.strap" value="${scalac.args.quick}"/>
     <!-- Setting-up Ant contrib tasks -->
     <taskdef resource="net/sf/antcontrib/antlib.xml" classpath="${lib.dir}/ant/ant-contrib.jar"/>
     <!-- This is the start time for the distribution -->
@@ -926,7 +927,6 @@ QUICK BUILD (QUICK)
     <uptodate property="quick.lib.available" targetfile="${build-quick.dir}/library.complete">
       <srcfiles dir="${src.dir}">
         <include name="library/**"/>
-        <include name="continuations/**"/>
         <include name="swing/**"/>
         <include name="actors/**"/>
       </srcfiles>
@@ -985,32 +985,14 @@ QUICK BUILD (QUICK)
     </propertyfile>
     <copy todir="${build-quick.dir}/classes/library">
       <fileset dir="${src.dir}/library">
-        <include name="**/*.tmpl"/>
-        <include name="**/*.xml"/>
-        <include name="**/*.js"/>
-        <include name="**/*.css"/>
-      </fileset>
+        <include name="rootdoc.txt"/>
+       </fileset>
     </copy>
-  </target>
-
-  <target name="quick.swing" depends="quick.lib" if="has.java6" unless="quick.lib.available">
-    <scalacfork
-      destdir="${build-quick.dir}/classes/library"
-      compilerpathref="locker.classpath"
-      params="${scalac.args.quick}"
-      srcdir="${src.dir}/swing"
-      jvmargs="${scalacfork.jvmargs}">
-      <include name="**/*.scala"/>
-      <compilationpath refid="quick.compilation.path"/>
-    </scalacfork>
-  </target>
-
-  <target name="quick.lib.done" depends="quick.swing, quick.lib">
-    <stopwatch name="quick.lib.timer" action="total"/>
     <touch file="${build-quick.dir}/library.complete" verbose="no"/>
+    <stopwatch name="quick.lib.timer" action="total"/>
   </target>
 
-  <target name="quick.pre-reflect" depends="quick.lib.done">
+  <target name="quick.pre-reflect" depends="quick.lib">
     <uptodate property="quick.reflect.available" targetfile="${build-quick.dir}/reflect.complete">
       <srcfiles dir="${src.dir}">
         <include name="reflect/**"/>
@@ -1031,30 +1013,17 @@ QUICK BUILD (QUICK)
       <compilationpath>
         <pathelement location="${build-quick.dir}/classes/library"/>
         <pathelement location="${build-quick.dir}/classes/reflect"/>
+        <path refid="forkjoin.classpath"/>
         <path refid="aux.libs"/>
         <pathelement location="${jline.jar}"/>
       </compilationpath>
     </scalacfork>
-    <!-- TODO - needed? -->
     <propertyfile file="${build-quick.dir}/classes/reflect/reflect.properties">
       <entry key="version.number" value="${version.number}"/>
       <entry key="maven.version.number" value="${maven.version.number}"/>
       <entry key="osgi.version.number" value="${osgi.version.number}"/>
       <entry key="copyright.string" value="${copyright.string}"/>
     </propertyfile>
-    <copy todir="${build-quick.dir}/classes/reflect">
-      <fileset dir="${src.dir}/reflect">
-        <include name="**/*.tmpl"/>
-        <include name="**/*.xml"/>
-        <include name="**/*.js"/>
-        <include name="**/*.html"/>
-        <include name="**/*.css"/>
-        <include name="**/*.properties"/>
-        <include name="**/*.swf"/>
-        <include name="**/*.png"/>
-        <include name="**/*.gif"/>
-      </fileset>
-    </copy>
     <touch file="${build-quick.dir}/reflect.complete" verbose="no"/>
     <stopwatch name="quick.reflect.timer" action="total"/>
   </target>
@@ -1095,18 +1064,23 @@ QUICK BUILD (QUICK)
       <fileset dir="${src.dir}/compiler">
         <include name="**/*.tmpl"/>
         <include name="**/*.xml"/>
-        <include name="**/*.js"/>
-        <include name="**/*.css"/>
-        <include name="**/*.html"/>
-        <include name="**/*.properties"/>
-        <include name="**/*.swf"/>
-        <include name="**/*.png"/>
-        <include name="**/*.gif"/>
-        <include name="**/*.txt"/>
-      </fileset>
+        <include name="rootdoc.txt"/>
+       </fileset>
     </copy>
     <touch file="${build-quick.dir}/compiler.complete" verbose="no"/>
     <stopwatch name="quick.comp.timer" action="total"/>
+  </target>
+
+  <target name="quick.swing" depends="quick.comp" if="has.java6" unless="quick.comp.available">
+    <scalacfork
+      destdir="${build-quick.dir}/classes/library"
+      compilerpathref="locker.classpath"
+      params="${scalac.args.quick}"
+      srcdir="${src.dir}/swing"
+      jvmargs="${scalacfork.jvmargs}">
+      <include name="**/*.scala"/>
+      <compilationpath refid="quick.compilation.path"/>
+    </scalacfork>
   </target>
 
   <target name="quick.pre-plugins" depends="quick.comp">
@@ -1118,6 +1092,7 @@ QUICK BUILD (QUICK)
   <target name="quick.plugins" depends="quick.pre-plugins" unless="quick.plugins.available">
     <stopwatch name="quick.plugins.timer"/>
     <mkdir dir="${build-quick.dir}/classes/continuations-plugin"/>
+    <mkdir dir="${build-quick.dir}/classes/continuations-library"/>
     <scalacfork
       destdir="${build-quick.dir}/classes/continuations-plugin"
       compilerpathref="quick.classpath"
@@ -1144,7 +1119,7 @@ QUICK BUILD (QUICK)
     </jar>
     <!-- might split off library part into its own ant target -->
     <scalacfork
-      destdir="${build-quick.dir}/classes/library"
+      destdir="${build-quick.dir}/classes/continuations-library"
       compilerpathref="quick.classpath"
       params="${scalac.args.quick} -Xplugin-require:continuations -P:continuations:enable"
       srcdir="${src.dir}/continuations/library"
@@ -1360,6 +1335,7 @@ PACKED QUICK BUILD (PACK)
         <exclude name="scala/swing/**"/>
         <exclude name="scala/actors/**"/>
       </fileset>
+      <fileset dir="${build-quick.dir}/classes/continuations-library"/>
       <fileset dir="${build-libs.dir}/classes/forkjoin"/>
     </jar>
     <jar destfile="${build-pack.dir}/lib/scala-actors.jar">
@@ -1714,7 +1690,7 @@ BOOTSTRAPPING BUILD (STRAP)
       destdir="${build-strap.dir}/classes/library"
       compilerpathref="pack.classpath"
       srcpath="${src.dir}/library"
-      params="${scalac.args.quick}"
+      params="${scalac.args.strap}"
       srcdir="${src.dir}/library"
       jvmargs="${scalacfork.jvmargs}">
       <include name="**/*.scala"/>
@@ -1723,7 +1699,7 @@ BOOTSTRAPPING BUILD (STRAP)
     <scalacfork
       destdir="${build-strap.dir}/classes/library"
       compilerpathref="pack.classpath"
-      params="${scalac.args.quick}"
+      params="${scalac.args.strap}"
       srcdir="${src.dir}/actors"
       jvmargs="${scalacfork.jvmargs}">
       <include name="**/*.scala"/>
@@ -1737,34 +1713,18 @@ BOOTSTRAPPING BUILD (STRAP)
     </propertyfile>
     <copy todir="${build-strap.dir}/classes/library">
       <fileset dir="${src.dir}/library">
-        <include name="**/*.tmpl"/>
-        <include name="**/*.xml"/>
-        <include name="**/*.js"/>
-        <include name="**/*.css"/>
-      </fileset>
+        <include name="rootdoc.txt"/>
+       </fileset>
     </copy>
-  </target>
-
-  <target name="strap.swing" if="has.java6" unless="strap.lib.available" depends="strap.lib">
-    <scalacfork
-      destdir="${build-strap.dir}/classes/library"
-      compilerpathref="pack.classpath"
-      params="${scalac.args.quick}"
-      srcdir="${src.dir}/swing"
-      jvmargs="${scalacfork.jvmargs}">
-      <include name="**/*.scala"/>
-      <compilationpath refid="strap.compilation.path"/>
-    </scalacfork>
-  </target>
-
-  <target name="strap.lib.done" depends="strap.swing, strap.lib">
     <touch file="${build-strap.dir}/library.complete" verbose="no"/>
     <stopwatch name="strap.lib.timer" action="total"/>
   </target>
 
-  <target name="strap.pre-reflect" depends="strap.lib.done">
+  <target name="strap.pre-reflect" depends="strap.lib">
     <uptodate property="strap.reflect.available" targetfile="${build-strap.dir}/reflect.complete">
-      <srcfiles dir="${src.dir}/reflect"/>
+      <srcfiles dir="${src.dir}">
+        <include name="reflect/**"/>
+      </srcfiles>
     </uptodate>
   </target>
 
@@ -1792,22 +1752,8 @@ BOOTSTRAPPING BUILD (STRAP)
       <entry key="osgi.version.number" value="${osgi.version.number}"/>
       <entry key="copyright.string" value="${copyright.string}"/>
     </propertyfile>
-    <copy todir="${build-strap.dir}/classes/reflect">
-      <fileset dir="${src.dir}/reflect">
-        <include name="**/*.tmpl"/>
-        <include name="**/*.xml"/>
-        <include name="**/*.js"/>
-        <include name="**/*.css"/>
-        <include name="**/*.html"/>
-        <include name="**/*.properties"/>
-        <include name="**/*.swf"/>
-        <include name="**/*.png"/>
-        <include name="**/*.gif"/>
-        <include name="**/*.txt"/>
-       </fileset>
-    </copy>
     <touch file="${build-strap.dir}/reflect.complete" verbose="no"/>
-    <stopwatch name="strap.comp.timer" action="total"/>
+    <stopwatch name="strap.reflect.timer" action="total"/>
   </target>
 
   <target name="strap.pre-comp" depends="strap.reflect">
@@ -1822,7 +1768,7 @@ BOOTSTRAPPING BUILD (STRAP)
     <scalacfork
       destdir="${build-strap.dir}/classes/compiler"
       compilerpathref="pack.classpath"
-      params="${scalac.args.quick}"
+      params="${scalac.args.strap}"
       srcdir="${src.dir}/compiler"
       jvmargs="${scalacfork.jvmargs}">
       <include name="**/*.scala"/>
@@ -1846,167 +1792,14 @@ BOOTSTRAPPING BUILD (STRAP)
       <fileset dir="${src.dir}/compiler">
         <include name="**/*.tmpl"/>
         <include name="**/*.xml"/>
-        <include name="**/*.js"/>
-        <include name="**/*.css"/>
-        <include name="**/*.html"/>
-        <include name="**/*.properties"/>
-        <include name="**/*.swf"/>
-        <include name="**/*.png"/>
-        <include name="**/*.gif"/>
-        <include name="**/*.txt"/>
+        <include name="rootdoc.txt"/>
        </fileset>
     </copy>
     <touch file="${build-strap.dir}/compiler.complete" verbose="no"/>
     <stopwatch name="strap.comp.timer" action="total"/>
   </target>
 
-  <target name="strap.pre-plugins" depends="strap.comp">
-    <uptodate property="strap.plugins.available" targetfile="${build-strap.dir}/plugins.complete">
-      <srcfiles dir="${src.dir}/continuations"/>
-    </uptodate>
-  </target>
-
-  <target name="strap.plugins" depends="strap.pre-plugins" unless="strap.plugins.available">
-    <stopwatch name="strap.plugins.timer"/>
-    <mkdir dir="${build-strap.dir}/classes/continuations-plugin"/>
-    <scalacfork
-      destdir="${build-strap.dir}/classes/continuations-plugin"
-      compilerpathref="pack.classpath"
-      params="${scalac.args.quick}"
-      srcdir="${src.dir}/continuations/plugin"
-      jvmargs="${scalacfork.jvmargs}">
-      <include name="**/*.scala"/>
-      <compilationpath>
-        <pathelement location="${build-strap.dir}/classes/library"/>
-        <pathelement location="${build-strap.dir}/classes/reflect"/>
-        <pathelement location="${build-strap.dir}/classes/compiler"/>
-        <pathelement location="${build-strap.dir}/classes/continuations-plugin"/>
-        <path refid="forkjoin.classpath"/>
-        <path refid="aux.libs"/>
-      </compilationpath>
-    </scalacfork>
-    <copy
-       file="${src.dir}/continuations/plugin/scalac-plugin.xml"
-       todir="${build-strap.dir}/classes/continuations-plugin"/>
-    <!-- not very nice to create jar here but needed to load plugin -->
-    <mkdir dir="${build-strap.dir}/misc/scala-devel/plugins"/>
-    <jar destfile="${build-strap.dir}/misc/scala-devel/plugins/continuations.jar">
-      <fileset dir="${build-strap.dir}/classes/continuations-plugin"/>
-    </jar>
-    <!-- might split off library part into its own ant target -->
-    <scalacfork
-      destdir="${build-strap.dir}/classes/library"
-      compilerpathref="pack.classpath"
-      params="${scalac.args.quick} -Xplugin-require:continuations -P:continuations:enable"
-      srcdir="${src.dir}/continuations/library"
-      jvmargs="${scalacfork.jvmargs}">
-      <include name="**/*.scala"/>
-      <compilationpath refid="strap.compilation.path"/>
-      <compilerarg value="-Xpluginsdir"/>
-      <compilerarg file="${build-strap.dir}/misc/scala-devel/plugins"/>
-    </scalacfork>
-    <touch file="${build-strap.dir}/plugins.complete" verbose="no"/>
-    <stopwatch name="strap.plugins.timer" action="total"/>
-  </target>
-
-  <target name="strap.scalacheck" depends="strap.plugins">
-    <mkdir dir="${build-strap.dir}/classes/scalacheck"/>
-    <scalacfork
-      destdir="${build-strap.dir}/classes/scalacheck"
-      compilerpathref="pack.classpath"
-      params="${scalac.args.quick} -nowarn"
-      srcdir="${src.dir}/scalacheck"
-      jvmargs="${scalacfork.jvmargs}">
-      <include name="**/*.scala"/>
-      <compilationpath>
-        <pathelement location="${build-strap.dir}/classes/library"/>
-      </compilationpath>
-    </scalacfork>
-  </target>
-
-  <target name="strap.pre-scalap" depends="strap.scalacheck">
-    <uptodate property="strap.scalap.available" targetfile="${build-strap.dir}/scalap.complete">
-      <srcfiles dir="${src.dir}/scalap"/>
-    </uptodate>
-  </target>
-
-  <target name="strap.scalap" depends="strap.pre-scalap" unless="strap.scalap.available">
-    <stopwatch name="strap.scalap.timer"/>
-    <mkdir dir="${build-strap.dir}/classes/scalap"/>
-    <scalacfork
-      destdir="${build-strap.dir}/classes/scalap"
-      compilerpathref="pack.classpath"
-      params="${scalac.args.quick}"
-      srcdir="${src.dir}/scalap"
-      jvmargs="${scalacfork.jvmargs}">
-      <include name="**/*.scala"/>
-      <compilationpath>
-        <pathelement location="${build-strap.dir}/classes/library"/>
-        <pathelement location="${build-strap.dir}/classes/reflect"/>
-        <pathelement location="${build-strap.dir}/classes/compiler"/>
-        <pathelement location="${build-strap.dir}/classes/scalap"/>
-        <pathelement location="${build-strap.dir}/classes/partest"/>
-        <pathelement location="${ant.jar}"/>
-        <path refid="forkjoin.classpath"/>
-      </compilationpath>
-    </scalacfork>
-    <touch file="${build-strap.dir}/scalap.complete" verbose="no"/>
-    <stopwatch name="strap.scalap.timer" action="total"/>
-  </target>
-
-  <target name="strap.pre-partest" depends="strap.scalap, asm.done">
-    <uptodate property="strap.partest.available" targetfile="${build-strap.dir}/partest.complete">
-      <srcfiles dir="${src.dir}/partest"/>
-    </uptodate>
-  </target>
-
-  <target name="strap.partest" depends="strap.pre-partest" unless="strap.partest.available">
-    <stopwatch name="strap.partest.timer"/>
-    <mkdir dir="${build-strap.dir}/classes/partest"/>
-    <javac
-      srcdir="${src.dir}/partest"
-      destdir="${build-strap.dir}/classes/partest"
-      target="1.6" source="1.5">
-      <classpath>
-        <pathelement location="${build-strap.dir}/classes/library"/>
-        <pathelement location="${build-strap.dir}/classes/reflect"/>
-        <pathelement location="${build-strap.dir}/classes/compiler"/>
-        <pathelement location="${build-strap.dir}/classes/scalap"/>
-        <pathelement location="${build-strap.dir}/classes/partest"/>
-        <path refid="asm.classpath"/>
-      </classpath>
-      <include name="**/*.java"/>
-      <compilerarg line="${javac.args}"/>
-    </javac>
-    <scalacfork
-      destdir="${build-strap.dir}/classes/partest"
-      compilerpathref="pack.classpath"
-      params="${scalac.args.quick}"
-      srcdir="${src.dir}/partest"
-      jvmargs="${scalacfork.jvmargs}">
-      <include name="**/*.scala"/>
-      <compilationpath>
-        <pathelement location="${build-strap.dir}/classes/library"/>
-        <pathelement location="${build-strap.dir}/classes/reflect"/>
-        <pathelement location="${build-strap.dir}/classes/compiler"/>
-        <pathelement location="${build-strap.dir}/classes/scalap"/>
-        <pathelement location="${build-strap.dir}/classes/partest"/>
-        <pathelement location="${ant.jar}"/>
-        <path refid="forkjoin.classpath"/>
-        <path refid="asm.classpath"/>
-        <pathelement location="${scalacheck.jar}"/>
-      </compilationpath>
-    </scalacfork>
-    <copy todir="${build-strap.dir}/classes/partest">
-      <fileset dir="${src.dir}/partest">
-        <include name="**/*.xml"/>
-      </fileset>
-    </copy>
-    <touch file="${build-strap.dir}/partest.complete" verbose="no"/>
-    <stopwatch name="strap.partest.timer" action="total"/>
-  </target>
-
-  <target name="strap.done" depends="strap.partest"/>
+  <target name="strap.done" depends="strap.comp"/>
 
   <target name="strap.clean">
     <delete dir="${build-strap.dir}" includeemptydirs="yes" quiet="yes" failonerror="no"/>
@@ -2370,13 +2163,10 @@ DOCUMENTATION
 BOOTRAPING TEST AND TEST SUITE
 ============================================================================ -->
 
-  <target name="test.stability" depends="strap.done, init">
-    <same dir="${build-quick.dir}" todir="${build-strap.dir}" failondifferent="yes">
-      <exclude name="**/*.properties"/>
-      <exclude name="bin/**"/>
-      <exclude name="*.complete"/>
-      <exclude name="misc/scala-devel/plugins/*.jar"/>
-    </same>
+  <target name="test.stability" depends="pack.done, strap.done">
+    <exec osfamily="unix" vmlauncher="false" executable="${basedir}/tools/stability-test.sh" failonerror="true" />
+    <!-- I think doing it this way means it will auto-pass on windows... that's the idea. If not, something like this. -->
+    <!-- <exec osfamily="windows" executable="foo" failonerror="false" failifexecutionfails="false" /> -->
   </target>
 
   <target name="test.classload" depends="pack.done">

--- a/tools/stability-test.sh
+++ b/tools/stability-test.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+
+declare failed
+
+echo "Comparing build/quick/classes and build/strap/classes"
+for dir in library reflect compiler; do
+  if diff --exclude='*.properties' -rw build/{quick,strap}/classes/$dir; then
+    classes=$(find build/quick/classes/$dir -name '*.class' | wc -l)
+    printf "%8s: %5d classfiles verified identical\n" $dir $classes
+  else
+    failed=true
+  fi
+done
+
+[[ -z $failed ]] || exit 127


### PR DESCRIPTION
There is no reason to be stability testing every piece of
bytecode we've ever encountered. If the compilation products
are unstable, then testing 20,000 classfiles will reveal it.
Or it won't; either way, we can stop there. So I cut a gordian
knot and focused the stability test solely on the contents of:

  library reflect compiler

Next I cut the "custom ant task" cord. There's a tool for
diffing files, it's decades old, it's called diff. It does
the entire job we need. If it doesn't work on windows, it
doesn't matter. The stability test is not something which
needs to run in every environment. Either the classfiles
are stable or they aren't.

Generated the ant xml for building quick.{lib,reflect,comp}
and strap.{lib,reflect,comp} so they are identical modulo the
compiler used to build them, probably for the first time ever.
I'm sure they won't stay that way, but it's a step.
