### PR TITLE
SI_7179: add variance annotations to scala.math.Equiv and scala.math.PartialOrdering.

### DIFF
--- a/src/library/scala/math/Equiv.scala
+++ b/src/library/scala/math/Equiv.scala
@@ -29,7 +29,7 @@ import java.util.Comparator
  *  @since 2.7
  */
 
-trait Equiv[T] extends Any with Serializable {
+trait Equiv[-T] extends Any with Serializable {
   /** Returns `true` iff `x` is equivalent to `y`.
    */
   def equiv(x: T, y: T): Boolean

--- a/src/library/scala/math/PartialOrdering.scala
+++ b/src/library/scala/math/PartialOrdering.scala
@@ -30,7 +30,7 @@ package scala.math
  *  @since 2.7
  */
 
-trait PartialOrdering[T] extends Equiv[T] {
+trait PartialOrdering[-T] extends Equiv[T] {
   outer =>
 
   /** Result of comparing `x` with operand `y`.

--- a/src/library/scala/package.scala
+++ b/src/library/scala/package.scala
@@ -85,7 +85,7 @@ package object scala {
   type BigInt = scala.math.BigInt
   val BigInt = scala.math.BigInt
 
-  type Equiv[T] = scala.math.Equiv[T]
+  type Equiv[-T] = scala.math.Equiv[T]
   val Equiv = scala.math.Equiv
 
   type Fractional[T] = scala.math.Fractional[T]
@@ -103,8 +103,8 @@ package object scala {
   type Ordering[T] = scala.math.Ordering[T]
   val Ordering = scala.math.Ordering
 
-  type PartialOrdering[T] = scala.math.PartialOrdering[T]
-  type PartiallyOrdered[T] = scala.math.PartiallyOrdered[T]
+  type PartialOrdering[-T] = scala.math.PartialOrdering[T]
+  type PartiallyOrdered[+T] = scala.math.PartiallyOrdered[T]
 
   type Either[+A, +B] = scala.util.Either[A, B]
   val Either = scala.util.Either


### PR DESCRIPTION
Also annotate aliases in scala.Predef. Review by @paulp.
