### PR TITLE
SI-7231 Fix assertion when adapting Null type to Array type

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
@@ -1025,7 +1025,7 @@ abstract class GenICode extends SubComponent  {
       // this value into a local of type Null and we want the JVM to see that it's
       // a null value so we don't have to also adapt local loads.
       if (from == NullReference && to != UNIT && to != ObjectReference && to != AnyRefReference) {
-        assert(to.isReferenceType, "Attempt to adapt a null to a non reference type $to.")
+        assert(to.isRefOrArrayType, s"Attempt to adapt a null to a non reference type $to.")
         // adapt by dropping what we've got and pushing a null which
         // will convince the JVM we really do have null
         ctx.bb.emit(DROP(from), pos)

--- a/test/files/run/t7231.check
+++ b/test/files/run/t7231.check
@@ -1,0 +1,2 @@
+null
+null

--- a/test/files/run/t7231.scala
+++ b/test/files/run/t7231.scala
@@ -1,0 +1,11 @@
+object Test extends App {
+   val bar: Null = null
+
+   def foo(x: Array[Int]) = x
+   def baz(x: String) = x
+
+   // first line was failing
+   println(foo(bar))
+   // this line worked but good to have a double check
+   println(baz(bar))
+}


### PR DESCRIPTION
GenICode was doing a sanity check when adapting an expression of type
Null to something else. It was just doing the wrong one. Instead of
checking whether the result expression type was a reference type it
was checking to see if it was an class reference type. This commit fixes
that and adds a test to make sure both forms of adaptation work as
expected.
