### PR TITLE
reifier is now aware of SI-7235

### DIFF
--- a/src/compiler/scala/reflect/reify/Errors.scala
+++ b/src/compiler/scala/reflect/reify/Errors.scala
@@ -27,6 +27,11 @@ trait Errors {
     throw new ReificationException(defaultErrorPosition, msg)
   }
 
+  def CannotReifyCompoundTypeTreeWithNonEmptyBody(ctt: CompoundTypeTree) = {
+    val msg = "implementation restriction: cannot reify refinement type trees with non-empty bodies"
+    throw new ReificationException(ctt.pos, msg)
+  }
+
   def CannotReifyWeakType(details: Any) = {
     val msg = "cannot create a TypeTag" + details + ": use WeakTypeTag instead"
     throw new ReificationException(defaultErrorPosition, msg)

--- a/src/compiler/scala/reflect/reify/phases/Reshape.scala
+++ b/src/compiler/scala/reflect/reify/phases/Reshape.scala
@@ -181,6 +181,7 @@ trait Reshape {
 
     private def toPreTyperCompoundTypeTree(ctt: CompoundTypeTree): Tree = {
       val CompoundTypeTree(tmpl @ Template(parents, self, stats)) = ctt
+      if (stats.nonEmpty) CannotReifyCompoundTypeTreeWithNonEmptyBody(ctt)
       assert(self eq emptyValDef, self)
       val att = tmpl.attachments.get[CompoundTypeTreeOriginalAttachment]
       val CompoundTypeTreeOriginalAttachment(parents1, stats1) = att.getOrElse(CompoundTypeTreeOriginalAttachment(parents, stats))

--- a/test/files/neg/t7235.check
+++ b/test/files/neg/t7235.check
@@ -1,0 +1,4 @@
+t7235.scala:9: error: implementation restriction: cannot reify refinement type trees with non-empty bodies
+  val Block(List(ValDef(_, _, tpt: CompoundTypeTree, _)), _) = reify{ val x: C { def x: Int } = ??? }.tree
+                                                                             ^
+one error found

--- a/test/files/neg/t7235.scala
+++ b/test/files/neg/t7235.scala
@@ -1,0 +1,14 @@
+import scala.reflect.runtime.universe._
+import scala.reflect.runtime.{universe => ru}
+import scala.reflect.runtime.{currentMirror => cm}
+import scala.tools.reflect.ToolBox
+
+class C
+
+object Test extends App {
+  val Block(List(ValDef(_, _, tpt: CompoundTypeTree, _)), _) = reify{ val x: C { def x: Int } = ??? }.tree
+  println(tpt)
+  println(tpt.templ.parents)
+  println(tpt.templ.self)
+  println(tpt.templ.body)
+}

--- a/test/files/run/t7235.check
+++ b/test/files/run/t7235.check
@@ -1,0 +1,4 @@
+C
+List(C)
+private val _ = _
+List()

--- a/test/files/run/t7235.scala
+++ b/test/files/run/t7235.scala
@@ -1,0 +1,14 @@
+import scala.reflect.runtime.universe._
+import scala.reflect.runtime.{universe => ru}
+import scala.reflect.runtime.{currentMirror => cm}
+import scala.tools.reflect.ToolBox
+
+class C
+
+object Test extends App {
+  val Block(List(ValDef(_, _, tpt: CompoundTypeTree, _)), _) = reify{ val x: C{} = ??? }.tree
+  println(tpt)
+  println(tpt.templ.parents)
+  println(tpt.templ.self)
+  println(tpt.templ.body)
+}


### PR DESCRIPTION
SI-7235 is caused by a long-standing todo in typedRefinement, which leads
to originals of compound type trees swallowing their stats.

I'm not sure how exactly to fix SI-7235, but what I am sure about is that
we shouldn't silently discard stats during reification. This patch
introduces a new implementation restrictions, which now reports that
reify of compound type trees with non-empty stats isn't going to work.
