### PR TITLE
SI-7328 Bail out of names/defaults when args are error typed

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
@@ -329,11 +329,10 @@ trait NamesDefaults { self: Analyzer =>
 
           // type the application without names; put the arguments in definition-site order
           val typedApp = doTypedApply(tree, funOnly, reorderArgs(namelessArgs, argPos), mode, pt)
-          if (typedApp.isErrorTyped) tree
-          else typedApp match {
+          typedApp match {
             // Extract the typed arguments, restore the call-site evaluation order (using
             // ValDef's in the block), change the arguments to these local values.
-            case Apply(expr, typedArgs) =>
+            case Apply(expr, typedArgs) if !(typedApp :: typedArgs).exists(_.isErrorTyped) => // bail out with erroneous args, see SI-7238
               // typedArgs: definition-site order
               val formals = formalTypes(expr.tpe.paramTypes, typedArgs.length, removeByName = false, removeRepeated = false)
               // valDefs: call-site order
@@ -361,6 +360,7 @@ trait NamesDefaults { self: Analyzer =>
               context.namedApplyBlockInfo =
                 Some((block, NamedApplyInfo(qual, targs, vargss :+ refArgs, blockTyper)))
               block
+            case _ => tree
           }
         }
 

--- a/test/files/neg/t7238.check
+++ b/test/files/neg/t7238.check
@@ -1,0 +1,6 @@
+t7238.scala:6: error: type mismatch;
+ found   : Seq[Any]
+ required: Seq[String]
+  c.c()(Seq[Any](): _*)
+                ^
+one error found

--- a/test/files/neg/t7238.scala
+++ b/test/files/neg/t7238.scala
@@ -1,0 +1,7 @@
+trait Main {
+  trait C {
+    def c(x: Any = 0)(bs: String*)
+  }
+  def c: C
+  c.c()(Seq[Any](): _*)
+}


### PR DESCRIPTION
To avoid a crasher later on with a null type inside a
sequence argument.

Review by @lrytz
