### PR TITLE
SI-7234 Make named args play nice with dep. method types

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
@@ -273,22 +273,25 @@ trait NamesDefaults { self: Analyzer =>
      */
     def argValDefs(args: List[Tree], paramTypes: List[Type], blockTyper: Typer): List[Option[ValDef]] = {
       val context = blockTyper.context
-      val symPs = map2(args, paramTypes)((arg, tpe) => arg match {
+      val symPs = map2(args, paramTypes)((arg, paramTpe) => arg match {
         case Ident(nme.SELECTOR_DUMMY) =>
           None // don't create a local ValDef if the argument is <unapply-selector>
         case _ =>
-          val byName   = isByNameParamType(tpe)
-          val repeated = isScalaRepeatedParamType(tpe)
+          val byName   = isByNameParamType(paramTpe)
+          val repeated = isScalaRepeatedParamType(paramTpe)
           val argTpe = (
             if (repeated) arg match {
               case Typed(expr, Ident(tpnme.WILDCARD_STAR)) => expr.tpe
               case _                                       => seqType(arg.tpe)
             }
-            else arg.tpe
-            ).widen // have to widen or types inferred from literal defaults will be singletons
+            else
+              // Note stabilizing can lead to a non-conformant argument when existentials are involved, e.g. neg/t3507-old.scala, hence the filter.
+              // We have to deconst or types inferred from literal arguments will be Constant(_), e.g. pos/z1730.scala.
+              gen.stableTypeFor(arg).filter(_ <:< paramTpe).getOrElse(arg.tpe).deconst
+          )
           val s = context.owner.newValue(unit.freshTermName("x$"), arg.pos) setInfo (
-              if (byName) functionType(Nil, argTpe) else argTpe
-              )
+            if (byName) functionType(Nil, argTpe) else argTpe
+          )
           Some((context.scope.enter(s), byName, repeated))
       })
       map2(symPs, args) {

--- a/test/files/pos/t7234.scala
+++ b/test/files/pos/t7234.scala
@@ -1,0 +1,15 @@
+trait Main {
+  trait A {
+    type B
+  }
+  trait C {
+    def c(a: A, x: Int = 0)(b: a.B)
+  }
+  def c: C
+  def d(a: A, x: Int = 0)(b: a.B)
+
+  def ok1(a: A)(b: a.B) = c.c(a, 42)(b)
+  def ok2(a: A)(b: a.B) = d(a)(b)
+
+  def fail(a: A)(b: a.B) = c.c(a)(b)
+}

--- a/test/files/pos/t7234b.scala
+++ b/test/files/pos/t7234b.scala
@@ -1,0 +1,20 @@
+trait Main {
+  trait A {
+    type B
+    def b: B
+  }
+  trait C {
+    def c(a: A, x: Int = 0)(b: => a.B, bs: a.B*)
+    def d(a: A = null, x: Int = 0)(b1: => a.B = a.b, b2: a.B = a.b)
+  }
+  def c: C
+  def ok(a: A)(b: a.B) = c.c(a, 42)(b)
+  def fail(a: A)(b: a.B) = c.c(a)(b)
+  def fail2(a: A)(b: a.B) = c.c(a)(b, b)
+  def fail3(a: A)(b: a.B) = c.c(a)(b, Seq[a.B](b): _*)
+
+  def fail4(a: A)(b: a.B) = c.d(a)()
+  def fail5(a: A)(b: a.B) = c.d(a)(b1 = a.b)
+  def fail6(a: A)(b: a.B) = c.d(a)(b2 = a.b)
+  def fail7(a: A)(b: a.B) = c.d()()
+}


### PR DESCRIPTION
Some care is needed to avoid interaction with constant
types (e.g pos/z1730.scala) and with existentials
(e.g. t3507-old.scala).

Review by @lrytz
