### PR TITLE
SI-7226 Fix inference regression caused by TypeVar equality

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3052,6 +3052,12 @@ trait Types extends api.Types { self: SymbolTable =>
     val origin: Type,
     var constr: TypeConstraint
   ) extends Type {
+
+    // We don't want case class equality/hashing as TypeVar-s are mutable,
+    // and TypeRefs based on them get wrongly `uniqued` otherwise. See SI-7226.
+    override def hashCode(): Int = System.identityHashCode(this)
+    override def equals(other: Any): Boolean = this eq other.asInstanceOf[AnyRef]
+
     def untouchable = false   // by other typevars
     override def params: List[Symbol] = Nil
     override def typeArgs: List[Type] = Nil

--- a/test/files/pos/t7226.scala
+++ b/test/files/pos/t7226.scala
@@ -1,0 +1,26 @@
+trait HK {
+  type Rep[X]
+
+  // okay
+  def unzip2[A, B](ps: Rep[List[(A, B)]])
+  unzip2(null.asInstanceOf[Rep[List[(Int, String)]]])
+
+  // okay
+  def unzipHK[A, B, C[_]](ps: Rep[C[(A, B)]])
+  unzipHK(null.asInstanceOf[Rep[List[(Int, String)]]])
+
+  def unzipHKRet0[A, C[_]](ps: C[A]): C[Int]
+  def ls: List[String]
+  unzipHKRet0(ls)
+
+  // fail
+  def unzipHKRet[A, C[_]](ps: Rep[C[A]]): Rep[C[Int]]
+  def rls: Rep[List[String]]
+  unzipHKRet(rls)
+}
+
+trait HK1 {
+  type Rep[A]
+  def unzip1[A, B, C[_]](ps: Rep[C[(A, B)]]): (Rep[C[A]], Rep[C[B]])
+  def doUnzip1[A, B](ps: Rep[List[(A, B)]]) = unzip1(ps)
+}


### PR DESCRIPTION
TypeVars, being mutable creatures, mustn't have structural
equality/hashing, otherwise TypeRefs that differ only by
having distinct TypeVars as components get wrongly uniqued
together.

The reported bug showed the disaterous consequences: constraints
from the `C?[Int]` in the return type applied to the `?C[?A]` in
the parameter list.

This commit overrides `equals` and `hashCode` in `TypeVar`
to use reference equality. An alternative fix would be to drop
the `case`-ness of the class, as was the case before 0cde930b
when this regressed.

Review by @adriaanm
