### PR TITLE
SI-7233 Account for aliased imports in EtaExpansion / Erasure 

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -781,7 +781,7 @@ abstract class Erasure extends AddInterfaces
           else if (tree.symbol == Any_isInstanceOf)
             adaptMember(atPos(tree.pos)(Select(qual, Object_isInstanceOf)))
           else if (tree.symbol.owner == AnyClass)
-            adaptMember(atPos(tree.pos)(Select(qual, getMember(ObjectClass, name))))
+            adaptMember(atPos(tree.pos)(Select(qual, getMember(ObjectClass, tree.symbol.name))))
           else {
             var qual1 = typedQualifier(qual)
             if ((isPrimitiveValueType(qual1.tpe) && !isPrimitiveValueMember(tree.symbol)) ||

--- a/src/compiler/scala/tools/nsc/typechecker/EtaExpansion.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/EtaExpansion.scala
@@ -101,6 +101,7 @@ trait EtaExpansion { self: Analyzer =>
         case TypeApply(fn, args) =>
           treeCopy.TypeApply(tree, liftoutPrefix(fn), args) setType null
         case Select(qual, name) =>
+          val name = tree.symbol.name // account for renamed imports, SI-7233
           treeCopy.Select(tree, liftout(qual, false), name) setSymbol NoSymbol setType null
         case Ident(name) =>
           tree

--- a/test/files/pos/t7233.scala
+++ b/test/files/pos/t7233.scala
@@ -1,0 +1,14 @@
+object Foo {
+  def bar(i: Int) = i
+
+  def ol(i: Int) = i
+  def ol(i: String) = i
+}
+object Test {
+  import Foo.{ bar => quux, toString => bar, ol => olRenamed}
+
+  val f1 = quux _
+  val f1Typed: (Int => Int) = f1
+
+  val f2: String => String = olRenamed _
+}

--- a/test/files/pos/t7233b.scala
+++ b/test/files/pos/t7233b.scala
@@ -1,0 +1,8 @@
+object Test {
+  // crash
+  def foo(a: Any) = { import a.{toString => toS}; toS }
+
+  // okay
+  def ok1(a: String) = { import a.{isInstanceOf => iio}; iio[String] }
+  def ok2(a: Int) = { import a.{toInt => ti}; ti }
+}


### PR DESCRIPTION
Buggy:

```
treeCopy.Select(sel, sel.qual, sel.name) setSymbol null
Select(sel, sel.qual, sel.name)
```

Okay:

```
treeCopy.Select(sel, sel.qual, sel.name)
Select(sel, sel.qual, sel.symbol.name) // but doesn't copyAttrs!
```

Review by @JamesIry
