### PR TITLE
SI-7240 fixes language feature lookup

### DIFF
--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1046,7 +1046,7 @@ trait Definitions extends api.StandardDefinitions {
       getMemberIfDefined(owner, name) orElse {
         if (phase.flatClasses && name.isTypeName && !owner.isPackageObjectOrClass) {
           val pkg = owner.owner
-          val flatname = nme.flattenedName(owner.name, name)
+          val flatname = tpnme.flattenedName(owner.name, name)
           getMember(pkg, flatname)
         }
         else fatalMissingSymbol(owner, name)

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -3022,7 +3022,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       if (Statistics.canEnable) Statistics.incCounter(nameCount)
       if (needsFlatClasses) {
         if (flatname eq null)
-          flatname = nme.flattenedName(rawowner.name, rawname).toTypeName
+          flatname = tpnme.flattenedName(rawowner.name, rawname)
 
         flatname
       }

--- a/test/files/run/t7240/Macros_1.scala
+++ b/test/files/run/t7240/Macros_1.scala
@@ -1,0 +1,48 @@
+package bakery
+
+import scala.language.experimental.macros
+import scala.reflect.macros.Context
+
+trait FailureCake {
+  implicit def liftAnyFails[T: Manifest]: Any = ???
+
+  // This works
+  // implicit def liftAny[T]: Any = ???
+}
+
+object Bakery {
+
+  def failure: Any = macro failureImpl
+  def failureImpl(c: Context): c.Expr[Any] = {
+    import c.universe._
+
+    def dslTrait(dslName: String) = {
+      val names = dslName.split("\\.").toList.reverse
+      assert(names.length >= 1, "DSL trait name must be in the valid format. DSL trait name is " + dslName)
+
+      val tpeName = newTypeName(names.head)
+      names.tail.reverse match {
+        case head :: tail ⇒
+          Select(tail.foldLeft[Tree](Ident(newTermName(head)))((tree, name) ⇒ Select(tree, newTermName(name))), tpeName)
+        case Nil ⇒
+          Ident(tpeName)
+      }
+    }
+
+    def composeDSL(transformedBody: Tree) =
+      ClassDef(Modifiers(), newTypeName("eval"), List(), Template(
+        List(dslTrait("bakery.FailureCake")),
+        emptyValDef,
+        List(
+          DefDef(Modifiers(), nme.CONSTRUCTOR, List(), List(List()), TypeTree(),
+            Block(List(Apply(Select(Super(This(tpnme.EMPTY), tpnme.EMPTY), nme.CONSTRUCTOR), List())), Literal(Constant(())))),
+          DefDef(Modifiers(), newTermName("main"), List(), List(List()), Ident(newTypeName("Any")), transformedBody))))
+
+    def constructor = Apply(Select(New(Ident(newTypeName("eval"))), nme.CONSTRUCTOR), List())
+
+    c.eval(c.Expr[Any](
+      c.resetAllAttrs(Block(composeDSL(Literal(Constant(1))), constructor))))
+
+    c.Expr[Any](Literal(Constant(1)))
+  }
+}

--- a/test/files/run/t7240/Test_2.scala
+++ b/test/files/run/t7240/Test_2.scala
@@ -1,0 +1,3 @@
+object Test extends App {
+  bakery.Bakery.failure
+}


### PR DESCRIPTION
As I discovered today, Definitions.getMember have a fallback clause,
which accounts for the phases which have inner classes flattened.

This fallback uses nme.flattenedName to compute a flattened name, but
unfortunately nme.flattenedName produces a TermName, not a TypeName,
which means that the fallback will commence search in a wrong namespace
with predictable results.
