### PR TITLE
Close after slurping (fixes SI-7244)

### DIFF
--- a/src/reflect/scala/reflect/io/Streamable.scala
+++ b/src/reflect/scala/reflect/io/Streamable.scala
@@ -106,7 +106,10 @@ object Streamable {
     /** Convenience function to import entire file into a String.
      */
     def slurp(): String = slurp(creationCodec)
-    def slurp(codec: Codec) = chars(codec).mkString
+    def slurp(codec: Codec) = {
+      val src = chars(codec)
+      try src.mkString finally src.close()  // Always Be Closing
+    }
   }
 
   /** Call a function on something Closeable, finally closing it. */


### PR DESCRIPTION
Since slurp by definition is the noise made by the straw when
the cup is empty and all milk shake is consumed, we can safely
close after slurping.

Use case was deleting a test artifact on Windows.

Speaking of testing, it's not obvious that this change wants a partest test.  But if instructed where to put it, I would add a unit test, perhaps someplace friendly to sbt.
