### PR TITLE
update eclipse projects (partest, repl & scaladoc)

### DIFF
--- a/src/eclipse/partest/.classpath
+++ b/src/eclipse/partest/.classpath
@@ -10,5 +10,6 @@
 	<classpathentry kind="lib" path="lib/jline.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/asm"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/continuations-library"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/repl"/>
 	<classpathentry kind="output" path="build-quick-partest"/>
 </classpath>

--- a/src/eclipse/repl/.classpath
+++ b/src/eclipse/repl/.classpath
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+        <classpathentry kind="src" path="repl"/>
+        <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+        <classpathentry combineaccessrules="false" kind="src" path="/reflect"/>
+        <classpathentry combineaccessrules="false" kind="src" path="/scala-compiler"/>
+        <classpathentry combineaccessrules="false" kind="src" path="/scala-library"/>
+        <classpathentry kind="var" path="SCALA_BASEDIR/lib/jline.jar"/>
+        <classpathentry combineaccessrules="false" kind="src" path="/asm"/>
+        <classpathentry kind="output" path="build-quick-repl"/>
+</classpath>

--- a/src/eclipse/repl/.project
+++ b/src/eclipse/repl/.project
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+        <name>repl</name>
+        <comment></comment>
+        <projects>
+        </projects>
+        <buildSpec>
+                <buildCommand>
+                        <name>org.scala-ide.sdt.core.scalabuilder</name>
+                        <arguments>
+                        </arguments>
+                </buildCommand>
+        </buildSpec>
+        <natures>
+                <nature>org.scala-ide.sdt.core.scalanature</nature>
+                <nature>org.eclipse.jdt.core.javanature</nature>
+        </natures>
+        <linkedResources>
+                <link>
+                        <name>build-quick-repl</name>
+                        <type>2</type>
+                        <locationURI>SCALA_BASEDIR/build/quick/classes/repl</locationURI>
+                </link>
+                <link>
+                        <name>lib</name>
+                        <type>2</type>
+                        <locationURI>SCALA_BASEDIR/lib</locationURI>
+                </link>
+                <link>
+                        <name>repl</name>
+                        <type>2</type>
+                        <locationURI>SCALA_BASEDIR/src/repl</locationURI>
+                </link>
+        </linkedResources>
+</projectDescription>

--- a/src/eclipse/scaladoc/.classpath
+++ b/src/eclipse/scaladoc/.classpath
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry combineaccessrules="false" kind="src" path="/partest"/>
 	<classpathentry kind="src" path="scaladoc"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/reflect"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scala-library"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scala-compiler"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/lib/ant/ant.jar"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/continuations-library"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/asm"/>
 	<classpathentry kind="output" path="build-quick-scaladoc"/>
 </classpath>


### PR DESCRIPTION
Since we've removed scala.annotations.serializable in 2.11,
on top of this, you'll need to following bandaid to use eclipse on master.

This is the easiest fix, but certainly not recommended in general.

```
--- i/src/eclipse/scala-library/.classpath
+++ w/src/eclipse/scala-library/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
        <classpathentry kind="src" path="library"/>
-       <classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
+       <classpathentry exported="true" kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
```

This corresponds to checking the export check box for the scala library jar
in the library's build path.
