### PR TITLE
SI-6900 Tail call elimination + dependent method type crasher

### DIFF
--- a/bincompat-backward.whitelist.conf
+++ b/bincompat-backward.whitelist.conf
@@ -158,6 +158,30 @@ filter {
         {
             matchName="scala.reflect.internal.Names#NameOps.name"
             problemName=MissingFieldProblem
+        },
+        {
+            matchName="scala.reflect.internal.ExistentialsAndSkolems.existentialTransform$default$3"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.ExistentialsAndSkolems.existentialTransform"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.ExistentialsAndSkolems.packSymbols"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.ExistentialsAndSkolems.packSymbols$default$3"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.ExistentialsAndSkolems.isRawParameter"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.Trees.substituteInfoParamsIntoDefDef"
+            problemName=MissingMethodProblem
         }
     ]
 }

--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -354,6 +354,54 @@ filter {
         {
             matchName="scala.reflect.internal.StdNames#TermNames.SelectFromTypeTree"
             problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.ExistentialsAndSkolems.existentialTransform$default$3"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.ExistentialsAndSkolems.existentialTransform"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.ExistentialsAndSkolems.packSymbols"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.ExistentialsAndSkolems.packSymbols$default$3"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.ExistentialsAndSkolems.isRawParameter"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.Trees.substituteInfoParamsIntoDefDef"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.SymbolTable.existentialTransform$default$3"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.SymbolTable.existentialTransform"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.SymbolTable.substituteInfoParamsIntoDefDef"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.SymbolTable.packSymbols"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.SymbolTable.packSymbols$default$3"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.SymbolTable.isRawParameter"
+            problemName=MissingMethodProblem
         }
     ]
 }

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -814,7 +814,8 @@ abstract class UnCurry extends InfoTransform
      *
      * This transformation erases the dependent method types by:
      *   - Widening the formal parameter type to existentially abstract
-     *     over the prior parameters (using `packSymbols`)
+     *     over the prior parameters (using `packSymbols`). This transformation
+     *     is performed in the the `InfoTransform`er [[scala.reflect.internal.transform.UnCurry]].
      *   - Inserting casts in the method body to cast to the original,
      *     precise type.
      *
@@ -842,15 +843,14 @@ abstract class UnCurry extends InfoTransform
        */
       def erase(dd: DefDef): (List[List[ValDef]], Tree) = {
         import dd.{ vparamss, rhs }
-        val vparamSyms = vparamss flatMap (_ map (_.symbol))
-
         val paramTransforms: List[ParamTransform] =
-          vparamss.flatten.map { p =>
-            val declaredType = p.symbol.info
-            // existentially abstract over value parameters
-            val packedType = typer.packSymbols(vparamSyms, declaredType)
-            if (packedType =:= declaredType) Identity(p)
+          map2(vparamss.flatten, dd.symbol.info.paramss.flatten) { (p, infoParam) =>
+            val packedType = infoParam.info
+            if (packedType =:= p.symbol.info) Identity(p)
             else {
+              // The Uncurry info transformer existentially abstracted over value parameters
+              // from the previous parameter lists.
+
               // Change the type of the param symbol
               p.symbol updateInfo packedType
 
@@ -862,8 +862,8 @@ abstract class UnCurry extends InfoTransform
               // the method body to refer to this, rather than the parameter.
               val tempVal: ValDef = {
                 val tempValName = unit freshTermName (p.name + "$")
-                val newSym = dd.symbol.newTermSymbol(tempValName, p.pos, SYNTHETIC).setInfo(declaredType)
-                atPos(p.pos)(ValDef(newSym, gen.mkAttributedCast(Ident(p.symbol), declaredType)))
+                val newSym = dd.symbol.newTermSymbol(tempValName, p.pos, SYNTHETIC).setInfo(p.symbol.info)
+                atPos(p.pos)(ValDef(newSym, gen.mkAttributedCast(Ident(p.symbol), p.symbol.info)))
               }
               Packed(newParam, tempVal)
             }
@@ -881,13 +881,6 @@ abstract class UnCurry extends InfoTransform
           Block(tempVals, rhsSubstituted)
         }
 
-        // update the type of the method after uncurry.
-        dd.symbol updateInfo {
-          val GenPolyType(tparams, tp) = dd.symbol.info
-          logResult("erased dependent param types for ${dd.symbol.info}") {
-            GenPolyType(tparams, MethodType(allParams map (_.symbol), tp.finalResultType))
-          }
-        }
         (allParams :: Nil, rhs1)
       }
     }

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -772,7 +772,10 @@ abstract class UnCurry extends InfoTransform
               case None    => newRhs
             }
           )
-          addJavaVarargsForwarders(dd, flatdd)
+          // SI-6900 We need to keep our symbols of the parameters in the tree
+          //         in line with those in the info of the DefDef, otherwise we'll
+          //         run into problems in TailCalls.
+          addJavaVarargsForwarders(dd, substituteInfoParamsIntoDefDef(flatdd))
 
         case tree: Try =>
           postTransformTry(tree)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3768,77 +3768,9 @@ trait Typers extends Modes with Adaptations with Tags {
       } else res
     }
 
-    def isRawParameter(sym: Symbol) = // is it a type parameter leaked by a raw type?
-      sym.isTypeParameter && sym.owner.isJavaDefined
-
-    /** If we map a set of hidden symbols to their existential bounds, we
-     *  have a problem: the bounds may themselves contain references to the
-     *  hidden symbols.  So this recursively calls existentialBound until
-     *  the typeSymbol is not amongst the symbols being hidden.
-     */
-    def existentialBoundsExcludingHidden(hidden: List[Symbol]): Map[Symbol, Type] = {
-      def safeBound(t: Type): Type =
-        if (hidden contains t.typeSymbol) safeBound(t.typeSymbol.existentialBound.bounds.hi) else t
-
-      def hiBound(s: Symbol): Type = safeBound(s.existentialBound.bounds.hi) match {
-        case tp @ RefinedType(parents, decls) =>
-          val parents1 = parents mapConserve safeBound
-          if (parents eq parents1) tp
-          else copyRefinedType(tp, parents1, decls)
-        case tp => tp
-      }
-
-      // Hanging onto lower bound in case anything interesting
-      // happens with it.
-      mapFrom(hidden)(s => s.existentialBound match {
-        case TypeBounds(lo, hi) => TypeBounds(lo, hiBound(s))
-        case _                  => hiBound(s)
-      })
-    }
-
-    /** Given a set `rawSyms` of term- and type-symbols, and a type
-     *  `tp`, produce a set of fresh type parameters and a type so that
-     *  it can be abstracted to an existential type. Every type symbol
-     *  `T` in `rawSyms` is mapped to a clone. Every term symbol `x` of
-     *  type `T` in `rawSyms` is given an associated type symbol of the
-     *  following form:
-     *
-     *    type x.type <: T with Singleton
-     *
-     *  The name of the type parameter is `x.type`, to produce nice
-     *  diagnostics. The Singleton parent ensures that the type
-     *  parameter is still seen as a stable type. Type symbols in
-     *  rawSyms are fully replaced by the new symbols. Term symbols are
-     *  also replaced, except for term symbols of an Ident tree, where
-     *  only the type of the Ident is changed.
-     */
-    protected def existentialTransform[T](rawSyms: List[Symbol], tp: Type)(creator: (List[Symbol], Type) => T): T = {
-      val allBounds = existentialBoundsExcludingHidden(rawSyms)
-      val typeParams: List[Symbol] = rawSyms map { sym =>
-        val name = sym.name match {
-          case x: TypeName  => x
-          case x            => tpnme.singletonName(x)
-        }
-        val bound      = allBounds(sym)
-        val sowner     = if (isRawParameter(sym)) context.owner else sym.owner
-        val quantified = sowner.newExistential(name, sym.pos)
-
-        quantified setInfo bound.cloneInfo(quantified)
-      }
-      // Higher-kinded existentials are not yet supported, but this is
-      // tpeHK for when they are: "if a type constructor is expected/allowed,
-      // tpeHK must be called instead of tpe."
-      val typeParamTypes = typeParams map (_.tpeHK)
-      def doSubst(info: Type) = info.subst(rawSyms, typeParamTypes)
-
-      creator(typeParams map (_ modifyInfo doSubst), doSubst(tp))
-    }
-
     /** Compute an existential type from raw hidden symbols `syms` and type `tp`
      */
-    def packSymbols(hidden: List[Symbol], tp: Type): Type =
-      if (hidden.isEmpty) tp
-      else existentialTransform(hidden, tp)(existentialAbstraction)
+    def packSymbols(hidden: List[Symbol], tp: Type): Type = global.packSymbols(hidden, tp, Some(context0.owner))
 
     def isReferencedFrom(ctx: Context, sym: Symbol): Boolean =
       ctx.owner.isTerm &&

--- a/src/reflect/scala/reflect/internal/ExistentialsAndSkolems.scala
+++ b/src/reflect/scala/reflect/internal/ExistentialsAndSkolems.scala
@@ -32,4 +32,81 @@ trait ExistentialsAndSkolems {
     }
     (new Deskolemizer).typeSkolems
   }
+
+  def isRawParameter(sym: Symbol) = // is it a type parameter leaked by a raw type?
+    sym.isTypeParameter && sym.owner.isJavaDefined
+
+  /** If we map a set of hidden symbols to their existential bounds, we
+   *  have a problem: the bounds may themselves contain references to the
+   *  hidden symbols.  So this recursively calls existentialBound until
+   *  the typeSymbol is not amongst the symbols being hidden.
+   */
+  private def existentialBoundsExcludingHidden(hidden: List[Symbol]): Map[Symbol, Type] = {
+    def safeBound(t: Type): Type =
+      if (hidden contains t.typeSymbol) safeBound(t.typeSymbol.existentialBound.bounds.hi) else t
+
+    def hiBound(s: Symbol): Type = safeBound(s.existentialBound.bounds.hi) match {
+      case tp @ RefinedType(parents, decls) =>
+        val parents1 = parents mapConserve safeBound
+        if (parents eq parents1) tp
+        else copyRefinedType(tp, parents1, decls)
+      case tp => tp
+    }
+
+    // Hanging onto lower bound in case anything interesting
+    // happens with it.
+    mapFrom(hidden)(s => s.existentialBound match {
+      case TypeBounds(lo, hi) => TypeBounds(lo, hiBound(s))
+      case _                  => hiBound(s)
+    })
+  }
+
+  /** Given a set `rawSyms` of term- and type-symbols, and a type
+   *  `tp`, produce a set of fresh type parameters and a type so that
+   *  it can be abstracted to an existential type. Every type symbol
+   *  `T` in `rawSyms` is mapped to a clone. Every term symbol `x` of
+   *  type `T` in `rawSyms` is given an associated type symbol of the
+   *  following form:
+   *
+   *    type x.type <: T with Singleton
+   *
+   *  The name of the type parameter is `x.type`, to produce nice
+   *  diagnostics. The Singleton parent ensures that the type
+   *  parameter is still seen as a stable type. Type symbols in
+   *  rawSyms are fully replaced by the new symbols. Term symbols are
+   *  also replaced, except for term symbols of an Ident tree, where
+   *  only the type of the Ident is changed.
+   */
+  final def existentialTransform[T](rawSyms: List[Symbol], tp: Type, rawOwner: Option[Symbol] = None)(creator: (List[Symbol], Type) => T): T = {
+    val allBounds = existentialBoundsExcludingHidden(rawSyms)
+    val typeParams: List[Symbol] = rawSyms map { sym =>
+      val name = sym.name match {
+        case x: TypeName  => x
+        case x            => tpnme.singletonName(x)
+      }
+      def rawOwner0  = rawOwner.getOrElse(abort(s"no owner provided for existential transform over raw parameter: $sym"))
+      val bound      = allBounds(sym)
+      val sowner     = if (isRawParameter(sym)) rawOwner0 else sym.owner
+      val quantified = sowner.newExistential(name, sym.pos)
+
+      quantified setInfo bound.cloneInfo(quantified)
+    }
+    // Higher-kinded existentials are not yet supported, but this is
+    // tpeHK for when they are: "if a type constructor is expected/allowed,
+    // tpeHK must be called instead of tpe."
+    val typeParamTypes = typeParams map (_.tpeHK)
+    def doSubst(info: Type) = info.subst(rawSyms, typeParamTypes)
+
+    creator(typeParams map (_ modifyInfo doSubst), doSubst(tp))
+  }
+
+  /**
+   * Compute an existential type from hidden symbols `hidden` and type `tp`.
+   * @param hidden   The symbols that will be existentially abstracted
+   * @param hidden   The original type
+   * @param rawOwner The owner for Java raw types.
+   */
+  final def packSymbols(hidden: List[Symbol], tp: Type, rawOwner: Option[Symbol] = None): Type =
+    if (hidden.isEmpty) tp
+    else existentialTransform(hidden, tp, rawOwner)(existentialAbstraction)
 }

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -1434,6 +1434,11 @@ trait Trees extends api.Trees { self: SymbolTable =>
   /** Substitute symbols in `from` with symbols in `to`. Returns a new
    *  tree using the new symbols and whose Ident and Select nodes are
    *  name-consistent with the new symbols.
+   *
+   *  Note: This is currently a destructive operation on the original Tree.
+   *  Trees currently assigned a symbol in `from` will be assigned the new symbols
+   *  without copying, and trees that define symbols with an `info` that refer
+   *  a symbol in `from` will have a new type assigned.
    */
   class TreeSymSubstituter(from: List[Symbol], to: List[Symbol]) extends Transformer {
     val symSubst = new SubstSymMap(from, to)

--- a/test/files/pos/t6900.scala
+++ b/test/files/pos/t6900.scala
@@ -1,0 +1,8 @@
+trait Test {
+  class Tree
+  @annotation.tailrec
+  private def check[T <: Tree](tree: T): T = {
+    val x: tree.type = tree
+    check(x)
+  }
+}

--- a/test/files/run/t6900.scala
+++ b/test/files/run/t6900.scala
@@ -1,0 +1,36 @@
+import annotation.tailrec
+
+trait Universe {
+  type T <: AnyRef
+}
+
+final class Bug {
+  var i = 1
+  def stop() = { i -= 1; i < 0 }
+  // the alias bypasses the fast path in erasures InfoTransformer
+  // predicated on `TypeMap.noChangeToSymbols`
+  type Alias = Any
+
+  @tailrec
+  // So we get two symbols for `universe`, the original on the ValDef
+  // and a clone in the MethodType of `f`.
+  def f(universe: Universe, l: Alias): universe.T = {
+    if (stop()) null.asInstanceOf[universe.T] else f(universe, null)
+  }
+
+  @tailrec
+  def g(universe: Universe)(l: Alias): universe.T = {
+    if (stop()) null.asInstanceOf[universe.T] else g(universe)(l)
+  }
+
+  @tailrec
+  def h(universe: Universe)(l: List[universe.T]): List[universe.T] = {
+    if (stop()) Nil else h(universe)(l)
+  }
+}
+
+object Test extends App {
+  assert(new Bug().f(null, null) == null)
+  assert(new Bug().g(null)(null) == null)
+  assert(new Bug().h(null)(null) == Nil)
+}


### PR DESCRIPTION
The primary contribution of this change is best expressed as a diff:

```
% cat sandbox/test.scala
trait U { type A }
object Test {
  def foo(u: U)(as: List[Any]): u.A = ???
}

% diff <(scalac210 -uniqid -Xprint:uncurry sandbox/test.scala) <(qbin/scalac -uniqid -Xprint:uncurry sandbox/test.scala)
...
<     def foo#7375(u#12217: U#7060, as#12218: List#11817[Any#3337]): u#12835.A#7371 = scala#23.this.Predef#832.???#6656()

---
>     def foo#7421(u#12273: U#7106, as#12274: List#11294[Any#3337]): u#12273.A#7417 = scala#21.this.Predef#1084.???#6702()
```

The symbols of the `ValDef`s in the tree agree with the (cloned) symbols in the method type that was generated by the uncurry `InfoTransformer`.

One corner of the compiler universe fares a little better at the "[usual grand problem of keeping trees, symbols, and types in tune with one another](https://groups.google.com/d/msg/scala-internals/DwjBfws47Y8/8n7eaWMlDUIJ)".

I'm quoting @paulp, which is a nice thing to do before I ask him to review. In particular, should we (and, where could we) plug `substituteInfoParamsIntoDefDef` into the tree transformers of all phases that install info transformers?

This PR also includes rework of SI-6135 which became apparent to me after spending more time in `uncurry` and was closely related to this change.
