### PR TITLE
SI-7237 Always choose ForkJoinTaskSupport

### DIFF
--- a/src/library/scala/collection/parallel/package.scala
+++ b/src/library/scala/collection/parallel/package.scala
@@ -42,11 +42,7 @@ package object parallel {
   private[parallel] def outofbounds(idx: Int) = throw new IndexOutOfBoundsException(idx.toString)
 
   private[parallel] def getTaskSupport: TaskSupport =
-    if (scala.util.Properties.isJavaAtLeast("1.6")) {
-      val vendor = scala.util.Properties.javaVmVendor
-      if ((vendor contains "Oracle") || (vendor contains "Sun") || (vendor contains "Apple")) new ForkJoinTaskSupport
-      else new ThreadPoolTaskSupport
-    } else new ThreadPoolTaskSupport
+    new ForkJoinTaskSupport
 
   val defaultTaskSupport: TaskSupport = getTaskSupport
 


### PR DESCRIPTION
ForkJoinTaskSupport works on Hotspot, Avian and J9,
while ThreadPoolTaskSupport causes the test
test/files/scalacheck/parallel-collections
to reliably hang on all three.
