### PR TITLE
Restore sketchy dependency to quick.bin.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1388,6 +1388,7 @@ QUICK BUILD (QUICK)
       <pathelement location="${build-quick.dir}/classes/compiler"/>
       <pathelement location="${build-quick.dir}/classes/repl"/>
       <pathelement location="${build-quick.dir}/classes/scalap"/>
+      <pathelement location="${build-quick.dir}/classes/continuations-library"/>
       <pathelement location="${jline.jar}"/>
       <path refid="asm.classpath"/>
       <path refid="forkjoin.classpath"/>


### PR DESCRIPTION
Apparently we cannot run at all without the continuations
classes on the classpath. At least that it was I conclude
from the fact that quick/bin/scala hasn't worked since
I routed the plugin classes into continuations-library.

This restores them to quick's classpath so we can have
qscala again.
