### PR TITLE
SI-6123: -explaintypes should not explain errors which won't be reported, new attempt

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -173,8 +173,7 @@ trait ContextErrors {
         assert(!foundType.isErroneous && !req.isErroneous, (foundType, req))
 
         issueNormalTypeError(tree, withAddendum(tree.pos)(typeErrorMsg(foundType, req, infer.isPossiblyMissingArgs(foundType, req))) )
-        if (settings.explaintypes.value)
-          explainTypes(foundType, req)
+        infer.explainTypes(foundType, req)
       }
 
       def WithFilterError(tree: Tree, ex: AbsTypeError) = {
@@ -1274,11 +1273,12 @@ trait ContextErrors {
     // not exactly an error generator, but very related
     // and I dearly wanted to push it away from Macros.scala
     private def checkSubType(slot: String, rtpe: Type, atpe: Type) = {
-      val ok = if (macroDebugVerbose || settings.explaintypes.value) {
-        if (rtpe eq atpe) println(rtpe + " <: " + atpe + "?" + EOL + "true")
+      val ok = if (macroDebugVerbose) {
         withTypesExplained(rtpe <:< atpe)
       } else rtpe <:< atpe
       if (!ok) {
+        if (!macroDebugVerbose)
+          explainTypes(rtpe, atpe)
         compatibilityError("type mismatch for %s: %s does not conform to %s".format(slot, abbreviateCoreAliases(rtpe.toString), abbreviateCoreAliases(atpe.toString)))
       }
     }

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -313,8 +313,10 @@ trait Infer extends Checkable {
       */
     )
 
-    def explainTypes(tp1: Type, tp2: Type) =
-      withDisambiguation(List(), tp1, tp2)(global.explainTypes(tp1, tp2))
+    def explainTypes(tp1: Type, tp2: Type) = {
+      if (context.reportErrors)
+        withDisambiguation(List(), tp1, tp2)(global.explainTypes(tp1, tp2))
+    }
 
     /* -- Tests & Checks---------------------------------------------------- */
 

--- a/test/files/neg/abstract-explaintypes.check
+++ b/test/files/neg/abstract-explaintypes.check
@@ -1,0 +1,11 @@
+abstract-explaintypes.scala:6: error: type mismatch;
+ found   : A
+ required: A.this.T
+  def foo2: T = bar().baz();
+                         ^
+abstract-explaintypes.scala:9: error: type mismatch;
+ found   : A
+ required: A.this.T
+  def foo5: T = baz().baz();
+                         ^
+two errors found

--- a/test/files/neg/abstract-explaintypes.flags
+++ b/test/files/neg/abstract-explaintypes.flags
@@ -1,0 +1,1 @@
+-explaintypes

--- a/test/files/neg/abstract-explaintypes.scala
+++ b/test/files/neg/abstract-explaintypes.scala
@@ -1,0 +1,11 @@
+trait A {
+  type T <: A;
+  def baz(): A;
+  def bar(): T;
+  def foo1: A = bar().bar();
+  def foo2: T = bar().baz();
+  def foo3 = bar().baz();
+  def foo4: A = baz().bar();
+  def foo5: T = baz().baz();
+  def foo6 = baz().baz();
+}

--- a/test/files/pos/t6123-explaintypes-implicits.flags
+++ b/test/files/pos/t6123-explaintypes-implicits.flags
@@ -1,0 +1,1 @@
+-explaintypes

--- a/test/files/pos/t6123-explaintypes-implicits.scala
+++ b/test/files/pos/t6123-explaintypes-implicits.scala
@@ -1,0 +1,13 @@
+object ImplicitBugReport {
+  trait Exp[+T]
+  trait CanBuildExp[-Elem, +To] extends (Exp[Elem] => To)
+  trait TraversableExp[T, ExpT <: Exp[T]] extends Exp[Traversable[T]]
+
+  implicit def canBuildExp[T]: CanBuildExp[T, Exp[T]] = ???
+  implicit def canBuildExpTrav[T, ExpT <: Exp[T]](implicit c: CanBuildExp[T, ExpT]): CanBuildExp[Traversable[T], TraversableExp[T, ExpT]] = ???
+  def toExpTempl[T, That](t: T)(implicit c: CanBuildExp[T, That]): That = ???
+
+  def testBug() {
+    val a1 = toExpTempl(Seq(1, 2, 3, 5))
+  }
+}

--- a/test/files/pos/t6123-explaintypes-macros.flags
+++ b/test/files/pos/t6123-explaintypes-macros.flags
@@ -1,0 +1,1 @@
+-explaintypes

--- a/test/files/pos/t6123-explaintypes-macros.scala
+++ b/test/files/pos/t6123-explaintypes-macros.scala
@@ -1,0 +1,7 @@
+import scala.language.experimental.macros
+import scala.reflect.macros.Context
+
+object Macros {
+  def printf(format: String, params: Any*): Unit = macro printf_impl
+  def printf_impl(c: Context)(format: c.Expr[String], params: c.Expr[Any]*): c.Expr[Unit] = ???
+}


### PR DESCRIPTION
-explainTypes means that only type tests which fail should be reported in more
detail by using explainTypes. Hence, callers of explainTypes should check if
type errors are being ignored, by checking context.reportErrors. Hence, this
check is added to Inferencer, and another call site is redirected to that
method.

Note that this patch does not fix all occurrences, but only the ones which
showed up during debugging. The other ones never cause problems, maybe because
they occur when contextErrors is in fact guaranteed to be true. We might want to
fix those ones anyway.

Compared to the old request (https://github.com/scala/scala/pull/1940), I added some tests. However, these tests will become fully effective only once SI-7003 is finally fixed - right now there's no way of testing this, especially not of saying "for a compiling program, `-explaintypes` should add no extra output".

Review by @hubertp.
Refs #6123
backport to 2.10.x
