### PR TITLE
SI-7258 Don't assume order of reflection values in t6223

### DIFF
--- a/test/files/run/t6223.check
+++ b/test/files/run/t6223.check
@@ -1,4 +1,4 @@
 bar
-bar$mcI$sp
 bar$mIc$sp
 bar$mIcI$sp
+bar$mcI$sp

--- a/test/files/run/t6223.scala
+++ b/test/files/run/t6223.scala
@@ -5,7 +5,7 @@ class Foo[@specialized(Int) A](a:A) {
 object Test {
   def main(args:Array[String]) {
     val f = new Foo(333)
-    val ms = f.getClass().getDeclaredMethods()
-    ms.foreach(m => println(m.getName))
+    val ms = f.getClass().getDeclaredMethods().map(_.getName).sorted
+    ms.foreach(println)
   }
 }


### PR DESCRIPTION
test/files/run/t6223's check file expects a specific
ordering of the reflected values. The ordering is not
guaranteed by the runtime/reflection API and can change.

Therefore, sort the values before comparing them.
