### PR TITLE
SI-5699 correct java parser for annotation defs.

### DIFF
--- a/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
@@ -800,13 +800,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
       val pos = in.currentPos
       val name = identForType()
       val (statics, body) = typeBody(AT, name)
-      def getValueMethodType(tree: Tree) = tree match {
-        case DefDef(_, nme.value, _, _, tpt, _) => Some(tpt.duplicate)
-        case _ => None
-      }
-      var templ = makeTemplate(annotationParents, body)
-      for (stat <- templ.body; tpt <- getValueMethodType(stat))
-        templ = makeTemplate(annotationParents, makeConstructor(List(tpt)) :: templ.body)
+      val templ = makeTemplate(annotationParents, body)
       addCompanionObject(statics, atPos(pos) {
         ClassDef(mods, name, List(), templ)
       })

--- a/test/files/run/t5699.check
+++ b/test/files/run/t5699.check
@@ -1,0 +1,11 @@
+[[syntax trees at end of                    parser]] // annodef.java
+package <empty> {
+  object MyAnnotation extends  {
+    def <init>() = _
+  };
+  class MyAnnotation extends scala.annotation.Annotation with _root_.java.lang.annotation.Annotation with scala.annotation.ClassfileAnnotation {
+    def <init>() = _;
+    def value(): String
+  }
+}
+

--- a/test/files/run/t5699.scala
+++ b/test/files/run/t5699.scala
@@ -1,0 +1,24 @@
+import scala.tools.partest.DirectTest
+import scala.tools.nsc.util.BatchSourceFile
+
+object Test extends DirectTest {
+  // Java code
+  override def code = """
+    |public @interface MyAnnotation { String value(); }
+  """.stripMargin
+
+  override def extraSettings: String = "-usejavacp -Ystop-after:typer -Xprint:parser"
+
+  override def show(): Unit = {
+    // redirect err to out, for logging
+    val prevErr = System.err
+    System.setErr(System.out)
+    compile()
+    System.setErr(prevErr)
+  }
+
+  override def newSources(sourceCodes: String*) = {
+    assert(sourceCodes.size == 1)
+    List(new BatchSourceFile("annodef.java", sourceCodes(0)))
+  }
+}


### PR DESCRIPTION
Correct java source parser not to insert a constructor with the type of its <b>value</b> method.

Target 2.10.x since the current behavior affects java interop in e.g. scaladoc, see
https://issues.scala-lang.org/browse/SI-5684.
