### PR TITLE
SI-6580 Scaladoc: Should not close void elements

### DIFF
--- a/test/scaladoc/run/SI-6580.check
+++ b/test/scaladoc/run/SI-6580.check
@@ -1,0 +1,11 @@
+Chain(List(Chain(List(Text(Here z(1) is defined as follows:), Text(
+), HtmlTag(<br>), Text(
+), Text(  ), HtmlTag(<img src='http://example.com/fig1.png'>), Text(
+), HtmlTag(<br>), Text(
+), Text(plus z(1) times), Text(
+), HtmlTag(<br>), Text(
+), Text(  ), HtmlTag(<img src='http://example.com/fig2.png'>), Text(
+), HtmlTag(<br>), Text(
+), Text(equals QL of something
+)))))
+Done.

--- a/test/scaladoc/run/SI-6580.scala
+++ b/test/scaladoc/run/SI-6580.scala
@@ -1,0 +1,32 @@
+import scala.tools.nsc.doc
+import scala.tools.nsc.doc.model._
+import scala.tools.nsc.doc.html.page.{Index, ReferenceIndex}
+import scala.tools.partest.ScaladocModelTest
+
+object Test extends ScaladocModelTest {
+  override def scaladocSettings = ""
+  override def code = """
+
+  object Test {
+    /** Here z(1) is defined as follows:
+      * <br>
+      *   <img src='http://example.com/fig1.png'>
+      * <br>
+      * plus z(1) times
+      * <br>
+      *   <img src='http://example.com/fig2.png'>
+      * <br>
+      * equals QL of something
+      */
+    def f = 1
+  }
+
+  """
+
+  def testModel(rootPackage: Package) {
+    import access._
+
+    val f = rootPackage._object("Test")._method("f")
+    println(f.comment.get.short)
+  }
+}


### PR DESCRIPTION
Because it will generate a useless element like "</img>".

To made matters worse, Scaladoc used to generate the element with
attributes (like </img src="...">). That's why we had SI-6580.
