### PR TITLE
Restored LOCAL_SUFFIX to originalName.

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -998,7 +998,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     /** If this symbol has an expanded name, its original name, otherwise its name itself.
      *  @see expandName
      */
-    def originalName: Name = nme.originalName(nme.dropLocalSuffix(name))
+    def originalName: Name = nme.originalName(name)
 
     /** The name of the symbol before decoding, e.g. `\$eq\$eq` instead of `==`.
      */
@@ -1006,7 +1006,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
 
     /** The decoded name of the symbol, e.g. `==` instead of `\$eq\$eq`.
      */
-    def decodedName: String = nme.dropLocalSuffix(name).decode
+    def decodedName: String = name.decode
 
     private def addModuleSuffix(n: Name): Name =
       if (needsModuleSuffix) n append nme.MODULE_SUFFIX_STRING else n


### PR DESCRIPTION
It looks like in an attempt to make originalName print
consistently with decodedName, I went a little too far and
stripped invisible trailing spaces from originalName. This
meant outer fields would have an originalName of '$outer'
instead of '$outer ', which in turn could have caused them to
be mis-recognized as outer accessors, because the logic of
outerSource hinges upon "originalName == nme.OUTER".

I don't know if this affected anything - I noticed it by
inspection, improbably enough.

As a side note, LOCAL_SUFFIX is the worst. Significant
trailing whitespace! Time bomb.
