### PR TITLE
SI-7271 fixes positions of string interpolation parts

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1152,7 +1152,7 @@ self =>
       val exprBuf = new ListBuffer[Tree]
       in.nextToken()
       while (in.token == STRINGPART) {
-        partsBuf += literal()
+        partsBuf += atPos(in.offset)(literal())
         exprBuf += {
           if (inPattern) dropAnyBraces(pattern())
           else {
@@ -1166,7 +1166,7 @@ self =>
           }
         }
       }
-      if (in.token == STRINGLIT) partsBuf += literal()
+      if (in.token == STRINGLIT) partsBuf += atPos(in.offset)(literal())
 
       val t1 = atPos(o2p(start)) { Ident(nme.StringContext) }
       val t2 = atPos(start) { Apply(t1, partsBuf.toList) }

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -425,6 +425,7 @@ trait Scanners extends ScannersCommon {
               if (ch == '\"') {
                 nextRawChar()
                 if (ch == '\"') {
+                  offset += 3
                   nextRawChar()
                   getStringPart(multiLine = true)
                   sepRegions = STRINGPART :: sepRegions // indicate string part
@@ -434,6 +435,7 @@ trait Scanners extends ScannersCommon {
                   strVal = ""
                 }
               } else {
+                offset += 1
                 getStringPart(multiLine = false)
                 sepRegions = STRINGLIT :: sepRegions // indicate single line string part
               }

--- a/test/files/run/t7271.check
+++ b/test/files/run/t7271.check
@@ -1,0 +1,12 @@
+[[syntax trees at end of                    parser]] // newSource1
+[0:91]package [0:0]<empty> {
+  [0:91]class C extends [8:91][91]scala.AnyRef {
+    [8]def <init>() = [8]{
+      [8][8][8]super.<init>();
+      [8]()
+    };
+    [16:44]def quote = [28:44]<28:44><28:44>[28]StringContext([30:34]"foo", [40:44]"baz").s([35:39]this);
+    [51:85]def tripleQuote = [69:85]<69:85><69:85>[69]StringContext([71:75]"foo", [81:85]"baz").s([76:80]this)
+  }
+}
+

--- a/test/files/run/t7271.scala
+++ b/test/files/run/t7271.scala
@@ -1,0 +1,34 @@
+import scala.tools.partest._
+import java.io._
+import scala.tools.nsc._
+import scala.tools.nsc.util.CommandLineParser
+import scala.tools.nsc.{Global, Settings, CompilerCommand}
+import scala.tools.nsc.reporters.ConsoleReporter
+
+object Test extends DirectTest {
+
+  override def extraSettings: String = "-usejavacp -Xprint:parser -Ystop-after:parser -d " + testOutput.path
+
+  override def code = """
+    class C {
+      def quote = s"foo${this}baz"
+      def tripleQuote = s"foo${this}baz"
+    }
+  """.trim
+
+  override def show(): Unit = {
+    // redirect err to out, for logging
+    val prevErr = System.err
+    System.setErr(System.out)
+    compile()
+    System.setErr(prevErr)
+  }
+
+  override def newCompiler(args: String*): Global = {
+
+    val settings = new Settings()
+    settings.Xprintpos.value = true
+    val command = new CompilerCommand((CommandLineParser tokenize extraSettings) ++ args.toList, settings)
+    new Global(command.settings, new ConsoleReporter(settings)) with interactive.RangePositions
+  }
+}


### PR DESCRIPTION
Positions of static parts are now set explicitly during parsing rather
than filled in wholesale during subsequent atPos after parsing.

I also had to change the offsets that scanner uses for initial static
parts of string interpolations so that they no longer point to the
opening double quote, but rather to the actual beginning of the part.
