### PR TITLE
fixes the craziness in JavaUniverse.log

### DIFF
--- a/src/reflect/scala/reflect/runtime/JavaUniverse.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverse.scala
@@ -17,7 +17,7 @@ class JavaUniverse extends internal.SymbolTable with ReflectSetup with runtime.S
   def forInteractive = false
   def forScaladoc = false
 
-  def log(msg: => AnyRef): Unit = println(" [] "+msg)
+  def log(msg: => AnyRef): Unit = if (settings.debug.value) println(" [] "+msg)
 
   type TreeCopier = InternalTreeCopierOps
   def newStrictTreeCopier: TreeCopier = new StrictTreeCopier


### PR DESCRIPTION
This long-standing, but trivial to fix nuisance in the implementation of
runtime reflection actively avoided being fixed in both 2.10.0 and 2.10.1.

It's finally the time to put it to a rest.
