### PR TITLE
Remove unrecognized doc comments

### DIFF
--- a/src/compiler/scala/reflect/reify/codegen/GenSymbols.scala
+++ b/src/compiler/scala/reflect/reify/codegen/GenSymbols.scala
@@ -42,7 +42,7 @@ trait GenSymbols {
     else if (sym.isPackage)
       mirrorMirrorCall(nme.staticPackage, reify(sym.fullName))
     else if (sym.isLocatable) {
-      /** This is a fancy conundrum that stems from the fact that Scala allows
+      /*  This is a fancy conundrum that stems from the fact that Scala allows
        *  packageless packages and packageless objects with the same names in the same program.
        *
        *  For more details read the docs to staticModule and staticPackage.

--- a/src/compiler/scala/tools/ant/sabbus/ScalacFork.scala
+++ b/src/compiler/scala/tools/ant/sabbus/ScalacFork.scala
@@ -114,7 +114,7 @@ class ScalacFork extends ScalaMatchingTask with ScalacShared with TaskArgs {
         mapper
       ) map (x => new File(sourceDir, x))
 
-    /** Nothing to do. */
+    /* Nothing to do. */
     if (includedFiles.isEmpty && argfile.isEmpty)
       return
 

--- a/src/compiler/scala/tools/cmd/CommandLine.scala
+++ b/src/compiler/scala/tools/cmd/CommandLine.scala
@@ -36,7 +36,7 @@ class CommandLine(val spec: Reference, val originalArgs: List[String]) extends C
     def loop(args: List[String]): Map[String, String] = {
       def residual(xs: List[String]) = { residualBuffer ++= xs ; Map[String, String]() }
 
-      /** Returns Some(List(args)) if this option expands to an
+      /*  Returns Some(List(args)) if this option expands to an
        *  argument list and it's not returning only the same arg.
        */
       def expand(s1: String) = {
@@ -48,7 +48,7 @@ class CommandLine(val spec: Reference, val originalArgs: List[String]) extends C
         else None
       }
 
-      /** Assumes known options have all been ruled out already. */
+      /* Assumes known options have all been ruled out already. */
       def isUnknown(opt: String) =
         onlyKnownOptions && (opt startsWith "-") && {
           errorFn("Option '%s' not recognized.".format(opt))

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1114,7 +1114,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
   override def currentRunId = curRunId
 
   def echoPhaseSummary(ph: Phase) = {
-    /** Only output a summary message under debug if we aren't echoing each file. */
+    /* Only output a summary message under debug if we aren't echoing each file. */
     if (settings.debug.value && !(settings.verbose.value || currentRun.size < 5))
       inform("[running phase " + ph.name + " on " + currentRun.size +  " compilation units]")
   }
@@ -1208,7 +1208,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
       curRunId += 1
       curRun = this
 
-      /** Set phase to a newly created syntaxAnalyzer and call definitions.init. */
+      /* Set phase to a newly created syntaxAnalyzer and call definitions.init. */
       val parserPhase: Phase = syntaxAnalyzer.newPhase(NoPhase)
       phase = parserPhase
       definitions.init()

--- a/src/compiler/scala/tools/nsc/ScriptRunner.scala
+++ b/src/compiler/scala/tools/nsc/ScriptRunner.scala
@@ -84,8 +84,8 @@ class ScriptRunner extends HasCompileSocket {
   {
     def mainClass = scriptMain(settings)
 
-    /** Compiles the script file, and returns the directory with the compiled
-     *  class files, if the compilation succeeded.
+    /* Compiles the script file, and returns the directory with the compiled
+     * class files, if the compilation succeeded.
      */
     def compile: Option[Directory] = {
       val compiledPath = Directory makeTemp "scalascript"
@@ -96,8 +96,8 @@ class ScriptRunner extends HasCompileSocket {
       settings.outdir.value = compiledPath.path
 
       if (settings.nc.value) {
-        /** Setting settings.script.value informs the compiler this is not a
-         *  self contained compilation unit.
+        /* Setting settings.script.value informs the compiler this is not a
+         * self contained compilation unit.
          */
         settings.script.value = mainClass
         val reporter = new ConsoleReporter(settings)
@@ -110,8 +110,8 @@ class ScriptRunner extends HasCompileSocket {
       else None
     }
 
-    /** The script runner calls sys.exit to communicate a return value, but this must
-     *  not take place until there are no non-daemon threads running.  Tickets #1955, #2006.
+    /* The script runner calls sys.exit to communicate a return value, but this must
+     * not take place until there are no non-daemon threads running.  Tickets #1955, #2006.
      */
     util.waitingForThreads {
       if (settings.save.value) {

--- a/src/compiler/scala/tools/nsc/ast/DocComments.scala
+++ b/src/compiler/scala/tools/nsc/ast/DocComments.scala
@@ -501,7 +501,7 @@ trait DocComments { self: Global =>
         result
       }
 
-      /**
+      /*
        * work around the backticks issue suggested by Simon in
        * https://groups.google.com/forum/?hl=en&fromgroups#!topic/scala-internals/z7s1CCRCz74
        * ideally, we'd have a removeWikiSyntax method in the CommentFactory to completely eliminate the wiki markup

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -321,38 +321,38 @@ self =>
       accept(EOF)
 
       def mainModuleName = newTermName(settings.script.value)
-      /** If there is only a single object template in the file and it has a
-       *  suitable main method, we will use it rather than building another object
-       *  around it.  Since objects are loaded lazily the whole script would have
-       *  been a no-op, so we're not taking much liberty.
+      /* If there is only a single object template in the file and it has a
+       * suitable main method, we will use it rather than building another object
+       * around it.  Since objects are loaded lazily the whole script would have
+       * been a no-op, so we're not taking much liberty.
        */
       def searchForMain(): Option[Tree] = {
-        /** Have to be fairly liberal about what constitutes a main method since
-         *  nothing has been typed yet - for instance we can't assume the parameter
-         *  type will look exactly like "Array[String]" as it could have been renamed
-         *  via import, etc.
+        /* Have to be fairly liberal about what constitutes a main method since
+         * nothing has been typed yet - for instance we can't assume the parameter
+         * type will look exactly like "Array[String]" as it could have been renamed
+         * via import, etc.
          */
         def isMainMethod(t: Tree) = t match {
           case DefDef(_, nme.main, Nil, List(_), _, _)  => true
           case _                                        => false
         }
-        /** For now we require there only be one top level object. */
+        /* For now we require there only be one top level object. */
         var seenModule = false
         val newStmts = stmts collect {
           case t @ Import(_, _) => t
           case md @ ModuleDef(mods, name, template) if !seenModule && (md exists isMainMethod) =>
             seenModule = true
-            /** This slightly hacky situation arises because we have no way to communicate
-             *  back to the scriptrunner what the name of the program is.  Even if we were
-             *  willing to take the sketchy route of settings.script.value = progName, that
-             *  does not work when using fsc.  And to find out in advance would impose a
-             *  whole additional parse.  So instead, if the actual object's name differs from
-             *  what the script is expecting, we transform it to match.
+            /* This slightly hacky situation arises because we have no way to communicate
+             * back to the scriptrunner what the name of the program is.  Even if we were
+             * willing to take the sketchy route of settings.script.value = progName, that
+             * does not work when using fsc.  And to find out in advance would impose a
+             * whole additional parse.  So instead, if the actual object's name differs from
+             * what the script is expecting, we transform it to match.
              */
             if (name == mainModuleName) md
             else treeCopy.ModuleDef(md, mods, mainModuleName, template)
           case _ =>
-            /** If we see anything but the above, fail. */
+            /* If we see anything but the above, fail. */
             return None
         }
         Some(makePackaging(0, emptyPkg, newStmts))
@@ -2265,8 +2265,8 @@ self =>
         accept(DOT)
         result
       }
-      /** Walks down import `foo.bar.baz.{ ... }` until it ends at a
-       *  an underscore, a left brace, or an undotted identifier.
+      /* Walks down import `foo.bar.baz.{ ... }` until it ends at a
+       * an underscore, a left brace, or an undotted identifier.
        */
       def loop(expr: Tree): Tree = {
         expr setPos expr.pos.makeTransparent

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -303,11 +303,11 @@ trait Scanners extends ScannersCommon {
         next.token = EMPTY
       }
 
-      /** Insert NEWLINE or NEWLINES if
-       *  - we are after a newline
-       *  - we are within a { ... } or on toplevel (wrt sepRegions)
-       *  - the current token can start a statement and the one before can end it
-       *  insert NEWLINES if we are past a blank line, NEWLINE otherwise
+      /* Insert NEWLINE or NEWLINES if
+       * - we are after a newline
+       * - we are within a { ... } or on toplevel (wrt sepRegions)
+       * - the current token can start a statement and the one before can end it
+       * insert NEWLINES if we are past a blank line, NEWLINE otherwise
        */
       if (!applyBracePatch() && afterLineEnd() && inLastOfStat(lastToken) && inFirstOfStat(token) &&
           (sepRegions.isEmpty || sepRegions.head == RBRACE)) {
@@ -440,7 +440,7 @@ trait Scanners extends ScannersCommon {
               nextChar()
               base = 16
             } else {
-              /**
+              /*
                * What should leading 0 be in the future? It is potentially dangerous
                *  to let it be base-10 because of history.  Should it be an error? Is
                *  there a realistic situation where one would need it?
@@ -959,7 +959,7 @@ trait Scanners extends ScannersCommon {
       }
       token = INTLIT
 
-      /** When we know for certain it's a number after using a touch of lookahead */
+      /* When we know for certain it's a number after using a touch of lookahead */
       def restOfNumber() = {
         putChar(ch)
         nextChar()
@@ -987,8 +987,8 @@ trait Scanners extends ScannersCommon {
         val lookahead = lookaheadReader
         val c = lookahead.getc()
 
-        /** As of scala 2.11, it isn't a number unless c here is a digit, so
-         *  settings.future.value excludes the rest of the logic.
+        /* As of scala 2.11, it isn't a number unless c here is a digit, so
+         * settings.future.value excludes the rest of the logic.
          */
         if (settings.future.value && !isDigit(c))
           return setStrVal()
@@ -998,16 +998,16 @@ trait Scanners extends ScannersCommon {
           case '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'  =>
             true
 
-          /** Backquoted idents like 22.`foo`. */
+          /* Backquoted idents like 22.`foo`. */
           case '`' =>
             return setStrVal()  /** Note the early return */
 
-          /** These letters may be part of a literal, or a method invocation on an Int.
+          /* These letters may be part of a literal, or a method invocation on an Int.
            */
           case 'd' | 'D' | 'f' | 'F' =>
             !isIdentifierPart(lookahead.getc())
 
-          /** A little more special handling for e.g. 5e7 */
+          /* A little more special handling for e.g. 5e7 */
           case 'e' | 'E' =>
             val ch = lookahead.getc()
             !isIdentifierPart(ch) || (isDigit(ch) || ch == '+' || ch == '-')

--- a/src/compiler/scala/tools/nsc/ast/parser/SymbolicXMLBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/SymbolicXMLBuilder.scala
@@ -196,7 +196,7 @@ abstract class SymbolicXMLBuilder(p: Parsers#Parser, preserveWS: Boolean) {
       uri1
     }
 
-    /** Extract all the namespaces from the attribute map. */
+    /* Extract all the namespaces from the attribute map. */
     val namespaces: List[Tree] =
       for (z <- attrMap.keys.toList ; if z startsWith xmlns) yield {
         val ns = splitPrefix(z) match {

--- a/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
@@ -353,9 +353,9 @@ abstract class TreeBuilder {
   */
   private def makeFor(mapName: TermName, flatMapName: TermName, enums: List[Enumerator], body: Tree): Tree = {
 
-    /** make a closure pat => body.
-     *  The closure is assigned a transparent position with the point at pos.point and
-     *  the limits given by pat and body.
+    /* make a closure pat => body.
+     * The closure is assigned a transparent position with the point at pos.point and
+     * the limits given by pat and body.
      */
     def makeClosure(pos: Position, pat: Tree, body: Tree): Tree = {
       def splitpos = wrappingPos(List(pat, body)).withPoint(pos.point).makeTransparent
@@ -371,26 +371,23 @@ abstract class TreeBuilder {
       }
     }
 
-    /** Make an application  qual.meth(pat => body) positioned at `pos`.
+    /* Make an application  qual.meth(pat => body) positioned at `pos`.
      */
     def makeCombination(pos: Position, meth: TermName, qual: Tree, pat: Tree, body: Tree): Tree =
       Apply(Select(qual, meth) setPos qual.pos, List(makeClosure(pos, pat, body))) setPos pos
 
-    /** If `pat` is not yet a `Bind` wrap it in one with a fresh name
-     */
+    /* If `pat` is not yet a `Bind` wrap it in one with a fresh name */
     def makeBind(pat: Tree): Tree = pat match {
       case Bind(_, _) => pat
       case _ => Bind(freshName(), pat) setPos pat.pos
     }
 
-    /** A reference to the name bound in Bind `pat`.
-     */
+    /* A reference to the name bound in Bind `pat`. */
     def makeValue(pat: Tree): Tree = pat match {
       case Bind(name, _) => Ident(name) setPos pat.pos.focus
     }
 
-    /** The position of the closure that starts with generator at position `genpos`.
-     */
+    /* The position of the closure that starts with generator at position `genpos`. */
     def closurePos(genpos: Position) = {
       val end = body.pos match {
         case NoPosition => genpos.point

--- a/src/compiler/scala/tools/nsc/backend/icode/BasicBlocks.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/BasicBlocks.scala
@@ -68,10 +68,10 @@ trait BasicBlocks {
           addBlock(scratchBlocks.head)
           scratchBlocks = scratchBlocks.tail
         }
-        /** Return a list of successors for 'b' that come from exception handlers
-         *  covering b's (non-exceptional) successors. These exception handlers
-         *  might not cover 'b' itself. This situation corresponds to an
-         *  exception being thrown as the first thing of one of b's successors.
+        /* Return a list of successors for 'b' that come from exception handlers
+         * covering b's (non-exceptional) successors. These exception handlers
+         * might not cover 'b' itself. This situation corresponds to an
+         * exception being thrown as the first thing of one of b's successors.
          */
         while (scratchHandlers ne Nil) {
           val handler = scratchHandlers.head
@@ -332,8 +332,8 @@ trait BasicBlocks {
 
       if (ignore) {
         if (settings.debug.value) {
-          /** Trying to pin down what it's likely to see after a block has been
-           *  put into ignore mode so we hear about it if there's a problem.
+          /* Trying to pin down what it's likely to see after a block has been
+           * put into ignore mode so we hear about it if there's a problem.
            */
           instr match {
             case JUMP(_) | RETURN(_) | THROW(_) | SCOPE_EXIT(_)               => // ok

--- a/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
@@ -777,8 +777,8 @@ abstract class GenICode extends SubComponent  {
               ctx1 = genLoadArguments(args, sym.info.paramTypes, ctx1)
               val cm = CALL_METHOD(sym, invokeStyle)
 
-              /** In a couple cases, squirrel away a little extra information in the
-               *  CALL_METHOD for use by GenASM.
+              /* In a couple cases, squirrel away a little extra information in the
+               * CALL_METHOD for use by GenASM.
                */
               fun match {
                 case Select(qual, _) =>
@@ -1470,11 +1470,11 @@ abstract class GenICode extends SubComponent  {
         ctx.makeLocal(l.pos, AnyRefClass.tpe, nme.EQEQ_LOCAL_VAR.toString)
       }
 
-      /** True if the equality comparison is between values that require the use of the rich equality
-        * comparator (scala.runtime.Comparator.equals). This is the case when either side of the
-        * comparison might have a run-time type subtype of java.lang.Number or java.lang.Character.
-        * When it is statically known that both sides are equal and subtypes of Number of Character,
-        * not using the rich equality is possible (their own equals method will do ok.)*/
+      /* True if the equality comparison is between values that require the use of the rich equality
+       * comparator (scala.runtime.Comparator.equals). This is the case when either side of the
+       * comparison might have a run-time type subtype of java.lang.Number or java.lang.Character.
+       * When it is statically known that both sides are equal and subtypes of Number of Character,
+       * not using the rich equality is possible (their own equals method will do ok.)*/
       def mustUseAnyComparator: Boolean = {
         def areSameFinals = l.tpe.isFinalType && r.tpe.isFinalType && (l.tpe =:= r.tpe)
         !areSameFinals && isMaybeBoxed(l.tpe.typeSymbol) && isMaybeBoxed(r.tpe.typeSymbol)
@@ -1568,12 +1568,12 @@ abstract class GenICode extends SubComponent  {
       debugassert(ctx.clazz.symbol eq cls,
                "Classes are not the same: " + ctx.clazz.symbol + ", " + cls)
 
-      /** Non-method term members are fields, except for module members. Module
-       *  members can only happen on .NET (no flatten) for inner traits. There,
-       *  a module symbol is generated (transformInfo in mixin) which is used
-       *  as owner for the members of the implementation class (so that the
-       *  backend emits them as static).
-       *  No code is needed for this module symbol.
+      /* Non-method term members are fields, except for module members. Module
+       * members can only happen on .NET (no flatten) for inner traits. There,
+       * a module symbol is generated (transformInfo in mixin) which is used
+       * as owner for the members of the implementation class (so that the
+       * backend emits them as static).
+       * No code is needed for this module symbol.
        */
       for (f <- cls.info.decls ; if !f.isMethod && f.isTerm && !f.isModule)
         ctx.clazz addField new IField(f)

--- a/src/compiler/scala/tools/nsc/backend/icode/ICodeCheckers.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/ICodeCheckers.scala
@@ -169,10 +169,10 @@ abstract class ICodeCheckers {
 
       def hasNothingType(s: TypeStack) = s.nonEmpty && (s.head == NothingReference)
 
-      /** XXX workaround #1: one stack empty, the other has BoxedUnit.
-       *  One example where this arises is:
+      /* XXX workaround #1: one stack empty, the other has BoxedUnit.
+       * One example where this arises is:
        *
-       *  def f(b: Boolean): Unit = synchronized { if (b) () }
+       * def f(b: Boolean): Unit = synchronized { if (b) () }
        */
       def allUnits(s: TypeStack)   = s.types forall (_ == BoxedUnitReference)
 
@@ -181,10 +181,10 @@ abstract class ICodeCheckers {
         case (x1, x2) if f(x2)  => x1
       }
 
-      /** XXX workaround #2: different stacks heading into an exception
-       *  handler which will clear them anyway.  Examples where it arises:
+      /* XXX workaround #2: different stacks heading into an exception
+       * handler which will clear them anyway.  Examples where it arises:
        *
-       *  var bippy: Int = synchronized { if (b) 5 else 10 }
+       * var bippy: Int = synchronized { if (b) 5 else 10 }
        */
       def isHandlerBlock() = bl.exceptionHandlerStart
 
@@ -336,7 +336,7 @@ abstract class ICodeCheckers {
       def popStack2    = { checkStack(2) ; (popStackN(2): @unchecked) match { case List(x, y) => (x, y) } }
       def popStack3    = { checkStack(3) ; (popStackN(3): @unchecked) match { case List(x, y, z) => (x, y, z) } }
 
-      /** Called by faux instruction LOAD_EXCEPTION to wipe out the stack. */
+      /* Called by faux instruction LOAD_EXCEPTION to wipe out the stack. */
       def clearStack() = {
         if (stack.nonEmpty)
           logChecker("Wiping out the " + stack.length + " element stack for exception handler: " + stack)
@@ -385,7 +385,7 @@ abstract class ICodeCheckers {
             icodeError(" expected reference type, but " + obj + " found")
         }
 
-        /** Checks that tpe is a subtype of one of the allowed types */
+        /* Checks that tpe is a subtype of one of the allowed types */
         def checkType(tpe: TypeKind, allowed: TypeKind*) = (
           if (allowed exists (k => isSubtype(tpe, k))) ()
           else icodeError(tpe + " is not one of: " + allowed.mkString("{ ", ", ", " }"))
@@ -393,16 +393,14 @@ abstract class ICodeCheckers {
         def checkNumeric(tpe: TypeKind) =
           checkType(tpe, BYTE, CHAR, SHORT, INT, LONG, FLOAT, DOUBLE)
 
-        /** Checks that the 2 topmost elements on stack are of the
-         *  kind TypeKind.
-         */
+        /* Checks that the 2 topmost elements on stack are of the kind TypeKind. */
         def checkBinop(kind: TypeKind) {
           val (a, b) = popStack2
           checkType(a, kind)
           checkType(b, kind)
         }
 
-        /** Check that arguments on the stack match method params. */
+        /* Check that arguments on the stack match method params. */
         def checkMethodArgs(method: Symbol) {
           val params = method.info.paramTypes
           checkStack(params.length)
@@ -412,8 +410,8 @@ abstract class ICodeCheckers {
           )
         }
 
-        /** Checks that the object passed as receiver has a method
-         *  `method` and that it is callable from the current method.
+        /* Checks that the object passed as receiver has a method
+         * `method` and that it is callable from the current method.
          */
         def checkMethod(receiver: TypeKind, method: Symbol) =
           receiver match {

--- a/src/compiler/scala/tools/nsc/backend/icode/TypeKinds.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/TypeKinds.scala
@@ -130,21 +130,21 @@ trait TypeKinds { self: ICodes =>
    * The lub is based on the lub of scala types.
    */
   def lub(a: TypeKind, b: TypeKind): TypeKind = {
-    /** The compiler's lub calculation does not order classes before traits.
-     *  This is apparently not wrong but it is inconvenient, and causes the
-     *  icode checker to choke when things don't match up.  My attempts to
-     *  alter the calculation at the compiler level were failures, so in the
-     *  interests of a working icode checker I'm making the adjustment here.
+    /* The compiler's lub calculation does not order classes before traits.
+     * This is apparently not wrong but it is inconvenient, and causes the
+     * icode checker to choke when things don't match up.  My attempts to
+     * alter the calculation at the compiler level were failures, so in the
+     * interests of a working icode checker I'm making the adjustment here.
      *
-     *  Example where we'd like a different answer:
+     * Example where we'd like a different answer:
      *
-     *    abstract class Tom
-     *    case object Bob extends Tom
-     *    case object Harry extends Tom
-     *    List(Bob, Harry)  // compiler calculates "Product with Tom" rather than "Tom with Product"
+     *   abstract class Tom
+     *   case object Bob extends Tom
+     *   case object Harry extends Tom
+     *   List(Bob, Harry)  // compiler calculates "Product with Tom" rather than "Tom with Product"
      *
-     *  Here we make the adjustment by rewinding to a pre-erasure state and
-     *  sifting through the parents for a class type.
+     * Here we make the adjustment by rewinding to a pre-erasure state and
+     * sifting through the parents for a class type.
      */
     def lub0(tk1: TypeKind, tk2: TypeKind): Type = enteringUncurry {
       val tp = global.lub(List(tk1.toType, tk2.toType))

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
@@ -513,7 +513,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
      */
     def javaName(sym: Symbol): String = {
 
-        /**
+        /*
          * Checks if given symbol corresponds to inner class/object and add it to innerClassBuffer
          *
          * Note: This method is called recursively thus making sure that we add complete chain
@@ -608,9 +608,9 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
     def isDeprecated(sym: Symbol): Boolean = { sym.annotations exists (_ matches definitions.DeprecatedAttr) }
 
     def addInnerClasses(csym: Symbol, jclass: asm.ClassVisitor) {
-      /** The outer name for this inner class. Note that it returns null
-       *  when the inner class should not get an index in the constant pool.
-       *  That means non-member classes (anonymous). See Section 4.7.5 in the JVMS.
+      /* The outer name for this inner class. Note that it returns null
+       * when the inner class should not get an index in the constant pool.
+       * That means non-member classes (anonymous). See Section 4.7.5 in the JVMS.
        */
       def outerName(innerSym: Symbol): String = {
         if (innerSym.originalEnclosingMethod != NoSymbol)
@@ -1044,9 +1044,9 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
       val paramJavaTypes: List[asm.Type] = methodInfo.paramTypes map javaType
       // val paramNames     = 0 until paramJavaTypes.length map ("x_" + _)
 
-      /** Forwarders must not be marked final,
-       *  as the JVM will not allow redefinition of a final static method,
-       *  and we don't know what classes might be subclassing the companion class.  See SI-4827.
+      /* Forwarders must not be marked final,
+       * as the JVM will not allow redefinition of a final static method,
+       * and we don't know what classes might be subclassing the companion class.  See SI-4827.
        */
       // TODO: evaluate the other flags we might be dropping on the floor here.
       // TODO: ACC_SYNTHETIC ?
@@ -1270,8 +1270,8 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
           case _                => None
         }
 
-        /** Drop redundant interfaces (ones which are implemented by some other parent) from the immediate parents.
-         *  This is important on Android because there is otherwise an interface explosion.
+        /* Drop redundant interfaces (ones which are implemented by some other parent) from the immediate parents.
+         * This is important on Android because there is otherwise an interface explosion.
          */
         def minimizeInterfaces(lstIfaces: List[Symbol]): List[Symbol] = {
           var rest   = lstIfaces
@@ -1847,7 +1847,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
         val keyMax = keys(keys.length - 1)
 
         val isDenseEnough: Boolean = {
-          /** Calculate in long to guard against overflow. TODO what overflow??? */
+          /* Calculate in long to guard against overflow. TODO what overflow??? */
           val keyRangeD: Double = (keyMax.asInstanceOf[Long] - keyMin + 1).asInstanceOf[Double]
           val klenD:     Double = keys.length
           val kdensity:  Double = (klenD / keyRangeD)
@@ -1982,7 +1982,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
       // Part 2 of genCode(): demarcating exception handler boundaries (visitTryCatchBlock() must be invoked before visitLabel() in genBlock())
       // ------------------------------------------------------------------------------------------------------------
 
-        /**Generate exception handlers for the current method.
+        /* Generate exception handlers for the current method.
          *
          * Quoting from the JVMS 4.7.3 The Code Attribute
          * The items of the Code_attribute structure are as follows:
@@ -2005,16 +2005,16 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
          */
         def genExceptionHandlers() {
 
-          /** Return a list of pairs of intervals where the handler is active.
-           *  Each interval is closed on both ends, ie. inclusive both in the left and right endpoints: [start, end].
-           *  Preconditions:
-           *    - e.covered non-empty
-           *  Postconditions for the result:
-           *    - always non-empty
-           *    - intervals are sorted as per `linearization`
-           *    - the argument's `covered` blocks have been grouped into maximally contiguous intervals,
-           *      ie. between any two intervals in the result there is a non-empty gap.
-           *    - each of the `covered` blocks in the argument is contained in some interval in the result
+          /* Return a list of pairs of intervals where the handler is active.
+           * Each interval is closed on both ends, ie. inclusive both in the left and right endpoints: [start, end].
+           * Preconditions:
+           *   - e.covered non-empty
+           * Postconditions for the result:
+           *   - always non-empty
+           *   - intervals are sorted as per `linearization`
+           *   - the argument's `covered` blocks have been grouped into maximally contiguous intervals,
+           *     ie. between any two intervals in the result there is a non-empty gap.
+           *   - each of the `covered` blocks in the argument is contained in some interval in the result
            */
           def intervals(e: ExceptionHandler): List[BlockInteval] = {
             assert(e.covered.nonEmpty, e)
@@ -2460,7 +2460,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
           case icodes.mthdsCat =>
           def genMethodsInstr() = (instr: @unchecked) match {
 
-            /** Special handling to access native Array.clone() */
+            /* Special handling to access native Array.clone() */
             case call @ CALL_METHOD(definitions.Array_clone, Dynamic) =>
               val target: String = javaType(call.targetTypeKind).getInternalName
               jcode.invokevirtual(target, "clone", mdesc_arrayClone)
@@ -2610,7 +2610,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
         }
       }
 
-      /**
+      /*
        * Emits one or more conversion instructions based on the types given as arguments.
        *
        * @param from The type of the value to be converted into another type.
@@ -3171,7 +3171,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
         }
       }
 
-      /**
+      /*
        * Computes a mapping from jump only block to its
        * final destination which is either a non-jump-only
        * block or, if it's in a jump-only block cycle, is

--- a/src/compiler/scala/tools/nsc/backend/opt/ConstantOptimization.scala
+++ b/src/compiler/scala/tools/nsc/backend/opt/ConstantOptimization.scala
@@ -423,9 +423,7 @@ abstract class ConstantOptimization extends SubComponent {
         in1 mightEqual Possible(tagSet.toSet map { tag: Int => Const(Constant(tag)) })
       }
 
-      /**
-       * common code for interpreting CJUMP and CZJUMP
-       */
+      /* common code for interpreting CJUMP and CZJUMP */
       def interpretConditional(kind: TypeKind, val1: Contents, val2: Contents, success: BasicBlock, failure: BasicBlock, cond: TestOp): (Map[BasicBlock, State], List[Instruction]) = {
         // TODO use reaching analysis to update the state in the two branches
         // e.g. if the comparison was checking null equality on local x

--- a/src/compiler/scala/tools/nsc/backend/opt/Inliners.scala
+++ b/src/compiler/scala/tools/nsc/backend/opt/Inliners.scala
@@ -342,7 +342,7 @@ abstract class Inliners extends SubComponent {
         inlineWithoutTFA(inputBlocks, callsites)
       }
 
-      /**
+      /*
        *  Inline straightforward callsites (those that can be inlined without a TFA).
        *
        *  To perform inlining, all we need to know is listed as formal params in `analyzeInc()`:
@@ -372,7 +372,7 @@ abstract class Inliners extends SubComponent {
         inlineCount
       }
 
-      /**
+      /*
        *  Decides whether it's feasible and desirable to inline the body of the method given by `concreteMethod`
        *  at the program point given by `i` (a callsite). The boolean result indicates whether inlining was performed.
        *
@@ -788,7 +788,7 @@ abstract class Inliners extends SubComponent {
 
         val varsInScope = mutable.HashSet[Local]() ++= block.varsInScope
 
-        /** Side effects varsInScope when it sees SCOPE_ENTERs. */
+        /* Side effects varsInScope when it sees SCOPE_ENTERs. */
         def instrBeforeFilter(i: Instruction): Boolean = {
           i match { case SCOPE_ENTER(l) => varsInScope += l ; case _ => () }
           i ne instr
@@ -801,7 +801,7 @@ abstract class Inliners extends SubComponent {
         // store the '$this' into the special local
         val inlinedThis = newLocal("$inlThis", REFERENCE(ObjectClass))
 
-        /** buffer for the returned value */
+        /* buffer for the returned value */
         val retVal = inc.m.returnType match {
           case UNIT  => null
           case x     => newLocal("$retVal", x)
@@ -809,7 +809,7 @@ abstract class Inliners extends SubComponent {
 
         val inlinedLocals = mutable.HashMap.empty[Local, Local]
 
-        /** Add a new block in the current context. */
+        /* Add a new block in the current context. */
         def newBlock() = {
           val b = caller.m.code.newBlock()
           activeHandlers foreach (_ addCoveredBlock b)
@@ -826,7 +826,7 @@ abstract class Inliners extends SubComponent {
           handler
         }
 
-        /** alfa-rename `l` in caller's context. */
+        /* alfa-rename `l` in caller's context. */
         def dupLocal(l: Local): Local = {
           val sym = caller.sym.newVariable(freshName(l.sym.name.toString), l.sym.pos)
           // sym.setInfo(l.sym.tpe)
@@ -837,10 +837,10 @@ abstract class Inliners extends SubComponent {
 
         val afterBlock = newBlock()
 
-        /** Map from nw.init instructions to their matching NEW call */
+        /* Map from nw.init instructions to their matching NEW call */
         val pending: mutable.Map[Instruction, NEW] = new mutable.HashMap
 
-        /** Map an instruction from the callee to one suitable for the caller. */
+        /* Map an instruction from the callee to one suitable for the caller. */
         def map(i: Instruction): Instruction = {
           def assertLocal(l: Local) = {
             assert(caller.locals contains l, "Could not find local '" + l + "' in locals, nor in inlinedLocals: " + inlinedLocals)

--- a/src/compiler/scala/tools/nsc/plugins/Plugins.scala
+++ b/src/compiler/scala/tools/nsc/plugins/Plugins.scala
@@ -79,11 +79,11 @@ trait Plugins {
 
     val plugs = pick(roughPluginsList, Set(), (phasesSet map (_.phaseName)).toSet)
 
-    /** Verify requirements are present. */
+    /* Verify requirements are present. */
     for (req <- settings.require.value ; if !(plugs exists (_.name == req)))
       globalError("Missing required plugin: " + req)
 
-    /** Process plugin options. */
+    /* Process plugin options. */
     def namec(plug: Plugin) = plug.name + ":"
     def optList(xs: List[String], p: Plugin) = xs filter (_ startsWith namec(p))
     def doOpts(p: Plugin): List[String] =
@@ -95,7 +95,7 @@ trait Plugins {
         p.processOptions(opts, globalError)
     }
 
-    /** Verify no non-existent plugin given with -P */
+    /* Verify no non-existent plugin given with -P */
     for (opt <- settings.pluginOptions.value ; if plugs forall (p => optList(List(opt), p).isEmpty))
       globalError("bad option: -P:" + opt)
 

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -503,8 +503,8 @@ abstract class ClassfileParser {
     val nameIdx      = in.nextChar
     currentClass     = pool.getClassName(nameIdx)
 
-    /** Parse parents for Java classes. For Scala, return AnyRef, since the real type will be unpickled.
-     *  Updates the read pointer of 'in'. */
+    /* Parse parents for Java classes. For Scala, return AnyRef, since the real type will be unpickled.
+     * Updates the read pointer of 'in'. */
     def parseParents: List[Type] = {
       if (isScala) {
         in.nextChar              // skip superclass
@@ -984,8 +984,8 @@ abstract class ClassfileParser {
       Some(ScalaSigBytes(pool.getBytes(entries.toList)))
     }
 
-    /** Parse and return a single annotation.  If it is malformed,
-     *  return None.
+    /* Parse and return a single annotation.  If it is malformed,
+     * return None.
      */
     def parseAnnotation(attrNameIndex: Char): Option[AnnotationInfo] = try {
       val attrType = pool.getType(attrNameIndex)
@@ -1030,7 +1030,7 @@ abstract class ClassfileParser {
         None // ignore malformed annotations
     }
 
-    /**
+    /*
      * Parse the "Exceptions" attribute which denotes the exceptions
      * thrown by a method.
      */
@@ -1046,8 +1046,8 @@ abstract class ClassfileParser {
       }
     }
 
-    /** Parse a sequence of annotations and attaches them to the
-     *  current symbol sym, except for the ScalaSignature annotation that it returns, if it is available. */
+    /* Parse a sequence of annotations and attaches them to the
+     * current symbol sym, except for the ScalaSignature annotation that it returns, if it is available. */
     def parseAnnotations(len: Int): Option[AnnotationInfo] =  {
       val nAttr = in.nextChar
       var scalaSigAnnot: Option[AnnotationInfo] = None
@@ -1173,7 +1173,7 @@ abstract class ClassfileParser {
      *  If the given name is not an inner class, it returns the symbol found in `definitions`.
      */
     def classSymbol(externalName: Name): Symbol = {
-      /** Return the symbol of `innerName`, having the given `externalName`. */
+      /* Return the symbol of `innerName`, having the given `externalName`. */
       def innerSymbol(externalName: Name, innerName: Name, static: Boolean): Symbol = {
         def getMember(sym: Symbol, name: Name): Symbol =
           if (static)

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
@@ -197,7 +197,7 @@ abstract class ICodeReader extends ClassfileParser {
       import code._
       var size = 1 // instruction size
 
-      /** Parse 16 bit jump target. */
+      /* Parse 16 bit jump target. */
       def parseJumpTarget = {
         size += 2
         val offset = in.nextChar.toShort
@@ -206,7 +206,7 @@ abstract class ICodeReader extends ClassfileParser {
         target
       }
 
-      /** Parse 32 bit jump target. */
+      /* Parse 32 bit jump target. */
       def parseJumpTargetW: Int = {
         size += 4
         val offset = in.nextInt

--- a/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
@@ -222,7 +222,7 @@ abstract class Pickler extends SubComponent {
         case NullaryMethodType(restpe) =>
           putType(restpe)
         case PolyType(tparams, restpe) =>
-          /** no longer needed since all params are now local
+          /* no longer needed since all params are now local
           tparams foreach { tparam =>
             if (!isLocal(tparam)) locals += tparam // similar to existential types, these tparams are local
           }

--- a/src/compiler/scala/tools/nsc/transform/AddInterfaces.scala
+++ b/src/compiler/scala/tools/nsc/transform/AddInterfaces.scala
@@ -174,8 +174,8 @@ abstract class AddInterfaces extends InfoTransform { self: Erasure =>
     override def complete(implSym: Symbol) {
       debuglog("LazyImplClassType completing " + implSym)
 
-      /** If `tp` refers to a non-interface trait, return a
-       *  reference to its implementation class. Otherwise return `tp`.
+      /* If `tp` refers to a non-interface trait, return a
+       * reference to its implementation class. Otherwise return `tp`.
        */
       def mixinToImplClass(tp: Type): Type = AddInterfaces.this.erasure(implSym) {
         tp match { //@MATN: no normalize needed (comes after erasure)

--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -351,7 +351,7 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
               else if (resultSym == ObjectClass) tree                                     // no cast necessary
               else gen.mkCast(tree, boxedResType)                                         // cast to expected type
 
-            /** Normal non-Array call */
+            /* Normal non-Array call */
             def genDefaultCall = {
               // reflective method call machinery
               val invokeName  = MethodClass.tpe member nme.invoke_                                  // scala.reflect.Method.invoke(...)
@@ -369,7 +369,7 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
               fixResult(TRY (invocation) CATCH { CASE (catchVar) ==> catchBody } ENDTRY)
             }
 
-            /** A possible primitive method call, represented by methods in BoxesRunTime. */
+            /* A possible primitive method call, represented by methods in BoxesRunTime. */
             def genValueCall(operator: Symbol) = fixResult(REF(operator) APPLY args)
             def genValueCallWithTest = {
               getPrimitiveReplacementForStructuralCall(methSym.name) match {
@@ -380,7 +380,7 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
               }
             }
 
-            /** A native Array call. */
+            /* A native Array call. */
             def genArrayCall = fixResult(
               methSym.name match {
                 case nme.length => REF(boxMethod(IntClass)) APPLY (REF(arrayLengthMethod) APPLY args)
@@ -391,9 +391,9 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
               mustBeUnit = methSym.name == nme.update
             )
 
-            /** A conditional Array call, when we can't determine statically if the argument is
-             *  an Array, but the structural type method signature is consistent with an Array method
-             *  so we have to generate both kinds of code.
+            /* A conditional Array call, when we can't determine statically if the argument is
+             * an Array, but the structural type method signature is consistent with an Array method
+             * so we have to generate both kinds of code.
              */
             def genArrayCallWithTest =
               IF ((qual1() GETCLASS()) DOT nme.isArray) THEN genArrayCall ELSE genDefaultCall

--- a/src/compiler/scala/tools/nsc/transform/Constructors.scala
+++ b/src/compiler/scala/tools/nsc/transform/Constructors.scala
@@ -303,10 +303,10 @@ abstract class Constructors extends Transform with ast.TreeDSL {
         copyParam(acc, parameter(acc))
       }
 
-      /** Return a single list of statements, merging the generic class constructor with the
-       *  specialized stats. The original statements are retyped in the current class, and
-       *  assignments to generic fields that have a corresponding specialized assignment in
-       *  `specializedStats` are replaced by the specialized assignment.
+      /* Return a single list of statements, merging the generic class constructor with the
+       * specialized stats. The original statements are retyped in the current class, and
+       * assignments to generic fields that have a corresponding specialized assignment in
+       * `specializedStats` are replaced by the specialized assignment.
        */
       def mergeConstructors(genericClazz: Symbol, originalStats: List[Tree], specializedStats: List[Tree]): List[Tree] = {
         val specBuf = new ListBuffer[Tree]
@@ -321,10 +321,10 @@ abstract class Constructors extends Transform with ast.TreeDSL {
             case _ => false
           }
 
-        /** Rewrite calls to ScalaRunTime.array_update to the proper apply method in scala.Array.
-         *  Erasure transforms Array.update to ScalaRunTime.update when the element type is a type
-         *  variable, but after specialization this is a concrete primitive type, so it would
-         *  be an error to pass it to array_update(.., .., Object).
+        /* Rewrite calls to ScalaRunTime.array_update to the proper apply method in scala.Array.
+         * Erasure transforms Array.update to ScalaRunTime.update when the element type is a type
+         * variable, but after specialization this is a concrete primitive type, so it would
+         * be an error to pass it to array_update(.., .., Object).
          */
         def rewriteArrayUpdate(tree: Tree): Tree = {
           val adapter = new Transformer {
@@ -373,14 +373,14 @@ abstract class Constructors extends Transform with ast.TreeDSL {
         res
       }
 
-      /** Add an 'if' around the statements coming after the super constructor. This
-       *  guard is necessary if the code uses specialized fields. A specialized field is
-       *  initialized in the subclass constructor, but the accessors are (already) overridden
-       *  and pointing to the (empty) fields. To fix this, a class with specialized fields
-       *  will not run its constructor statements if the instance is specialized. The specialized
-       *  subclass includes a copy of those constructor statements, and runs them. To flag that a class
-       *  has specialized fields, and their initialization should be deferred to the subclass, method
-       *  'specInstance$' is added in phase specialize.
+      /* Add an 'if' around the statements coming after the super constructor. This
+       * guard is necessary if the code uses specialized fields. A specialized field is
+       * initialized in the subclass constructor, but the accessors are (already) overridden
+       * and pointing to the (empty) fields. To fix this, a class with specialized fields
+       * will not run its constructor statements if the instance is specialized. The specialized
+       * subclass includes a copy of those constructor statements, and runs them. To flag that a class
+       * has specialized fields, and their initialization should be deferred to the subclass, method
+       * 'specInstance$' is added in phase specialize.
        */
       def guardSpecializedInitializer(stats: List[Tree]): List[Tree] = if (settings.nospecialization.value) stats else {
         // split the statements in presuper and postsuper
@@ -425,8 +425,7 @@ abstract class Constructors extends Transform with ast.TreeDSL {
       }
 */
 
-      /** Create a getter or a setter and enter into `clazz` scope
-       */
+      /* Create a getter or a setter and enter into `clazz` scope */
       def addAccessor(sym: Symbol, name: TermName, flags: Long) = {
         val m = clazz.newMethod(name, sym.pos, flags & ~(LOCAL | PRIVATE)) setPrivateWithin clazz
         clazz.info.decls enter m
@@ -555,7 +554,7 @@ abstract class Constructors extends Transform with ast.TreeDSL {
         gen.mkMethodCall(This(clazz), delayedInitMethod, Nil, List(New(closure.symbol.tpe, This(clazz))))
       }
 
-      /** Return a pair consisting of (all statements up to and including superclass and trait constr calls, rest) */
+      /* Return a pair consisting of (all statements up to and including superclass and trait constr calls, rest) */
       def splitAtSuper(stats: List[Tree]) = {
         def isConstr(tree: Tree) = (tree.symbol ne null) && tree.symbol.isConstructor
         val (pre, rest0) = stats span (!isConstr(_))
@@ -566,12 +565,12 @@ abstract class Constructors extends Transform with ast.TreeDSL {
       val (uptoSuperStats, remainingConstrStats0) = splitAtSuper(constrStatBuf.toList)
       var remainingConstrStats = remainingConstrStats0
 
-      /** XXX This is not corect: remainingConstrStats.nonEmpty excludes too much,
-       *  but excluding it includes too much.  The constructor sequence being mimicked
-       *  needs to be reproduced with total fidelity.
+      /* XXX This is not corect: remainingConstrStats.nonEmpty excludes too much,
+       * but excluding it includes too much.  The constructor sequence being mimicked
+       * needs to be reproduced with total fidelity.
        *
-       *  See test case files/run/bug4680.scala, the output of which is wrong in many
-       *  particulars.
+       * See test case files/run/bug4680.scala, the output of which is wrong in many
+       * particulars.
        */
       val needsDelayedInit =
         (clazz isSubClass DelayedInitClass) /*&& !(defBuf exists isInitDef)*/ && remainingConstrStats.nonEmpty

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -559,11 +559,11 @@ abstract class Erasure extends AddInterfaces
           case x          =>
             assert(x != ArrayClass)
             tree match {
-              /** Can't always remove a Box(Unbox(x)) combination because the process of boxing x
-               *  may lead to throwing an exception.
+              /* Can't always remove a Box(Unbox(x)) combination because the process of boxing x
+               * may lead to throwing an exception.
                *
-               *  This is important for specialization: calls to the super constructor should not box/unbox specialized
-               *  fields (see TupleX). (ID)
+               * This is important for specialization: calls to the super constructor should not box/unbox specialized
+               * fields (see TupleX). (ID)
                */
               case Apply(boxFun, List(arg)) if isSafelyRemovableUnbox(tree, arg) =>
                 log(s"boxing an unbox: ${tree.symbol} -> ${arg.tpe}")

--- a/src/compiler/scala/tools/nsc/transform/InlineErasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/InlineErasure.scala
@@ -4,8 +4,8 @@ package transform
 trait InlineErasure {
   self: Erasure =>
 
-/**
+/*
   import global._
   import definitions._
- **/
+ */
 }

--- a/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
+++ b/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
@@ -253,8 +253,7 @@ abstract class LambdaLift extends InfoTransform {
         }
       }
 
-      /** Rename a trait's interface and implementation class in coordinated fashion.
-       */
+      /* Rename a trait's interface and implementation class in coordinated fashion. */
       def renameTrait(traitSym: Symbol, implSym: Symbol) {
         val originalImplName = implSym.name
         renameSym(traitSym)
@@ -457,7 +456,7 @@ abstract class LambdaLift extends InfoTransform {
               case arg => arg
             }
 
-            /** Wrap expr argument in new *Ref(..) constructor. But try/catch
+            /* Wrap expr argument in new *Ref(..) constructor. But try/catch
              * is a problem because a throw will clear the stack and post catch
              * we would expect the partially-constructed object to be on the stack
              * for the call to init. So we recursively

--- a/src/compiler/scala/tools/nsc/transform/Mixin.scala
+++ b/src/compiler/scala/tools/nsc/transform/Mixin.scala
@@ -201,7 +201,7 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
       treatedClassInfos(clazz) = clazz.info
       assert(phase == currentRun.mixinPhase, phase)
 
-      /** Create a new getter. Getters are never private or local. They are
+      /* Create a new getter. Getters are never private or local. They are
        *  always accessors and deferred. */
       def newGetter(field: Symbol): Symbol = {
         // println("creating new getter for "+ field +" : "+ field.info +" at "+ field.locationString+(field hasFlag MUTABLE))
@@ -210,8 +210,8 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
         clazz.newMethod(nme.getterName(field.name.toTermName), field.pos, newFlags) setInfo MethodType(Nil, field.info)
       }
 
-      /** Create a new setter. Setters are never private or local. They are
-       *  always accessors and deferred. */
+      /* Create a new setter. Setters are never private or local. They are
+       * always accessors and deferred. */
       def newSetter(field: Symbol): Symbol = {
         //println("creating new setter for "+field+field.locationString+(field hasFlag MUTABLE))
         val setterName = nme.getterToSetter(nme.getterName(field.name.toTermName))
@@ -264,7 +264,7 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
         resetFlag DEFERRED | lateDEFERRED
     )
 
-    /** Mix in members of implementation class mixinClass into class clazz */
+    /* Mix in members of implementation class mixinClass into class clazz */
     def mixinImplClassMembers(mixinClass: Symbol, mixinInterface: Symbol) {
       if (!mixinClass.isImplClass) debugwarn ("Impl class flag is not set " +
         ((mixinClass.debugLocationString, mixinInterface.debugLocationString)))
@@ -280,9 +280,9 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
       }
     }
 
-    /** Mix in members of trait mixinClass into class clazz. Also,
-     *  for each lazy field in mixinClass, add a link from its mixed in member to its
-     *  initializer method inside the implclass.
+    /* Mix in members of trait mixinClass into class clazz. Also,
+     * for each lazy field in mixinClass, add a link from its mixed in member to its
+     * initializer method inside the implclass.
      */
     def mixinTraitMembers(mixinClass: Symbol) {
       // For all members of a trait's interface do:
@@ -649,34 +649,34 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
     private def addNewDefs(clazz: Symbol, stats: List[Tree]): List[Tree] = {
       val newDefs = mutable.ListBuffer[Tree]()
 
-      /** Attribute given tree and anchor at given position */
+      /* Attribute given tree and anchor at given position */
       def attributedDef(pos: Position, tree: Tree): Tree = {
         debuglog("add new def to " + clazz + ": " + tree)
         typedPos(pos)(tree)
       }
 
-      /** The position of given symbol, or, if this is undefined,
-       *  the position of the current class.
+      /* The position of given symbol, or, if this is undefined,
+       * the position of the current class.
        */
       def position(sym: Symbol) =
         if (sym.pos == NoPosition) clazz.pos else sym.pos
 
-      /** Add tree at given position as new definition */
+      /* Add tree at given position as new definition */
       def addDef(pos: Position, tree: Tree) {
         newDefs += attributedDef(pos, tree)
       }
 
-      /** Add new method definition.
+      /* Add new method definition.
        *
-       *  @param sym   The method symbol.
-       *  @param rhs   The method body.
+       * @param sym   The method symbol.
+       * @param rhs   The method body.
        */
       def addDefDef(sym: Symbol, rhs: Tree = EmptyTree) = addDef(position(sym), DefDef(sym, rhs))
       def addValDef(sym: Symbol, rhs: Tree = EmptyTree) = addDef(position(sym), ValDef(sym, rhs))
 
-      /** Add `newdefs` to `stats`, removing any abstract method definitions
-       *  in `stats` that are matched by some symbol defined in
-       *  `newDefs`.
+      /* Add `newdefs` to `stats`, removing any abstract method definitions
+       * in `stats` that are matched by some symbol defined in
+       * `newDefs`.
        */
       def add(stats: List[Tree], newDefs: List[Tree]) = {
         val newSyms = newDefs map (_.symbol)
@@ -692,12 +692,12 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
         else newDefs ::: (stats filter isNotDuplicate)
       }
 
-      /** If `stat` is a superaccessor, complete it by adding a right-hand side.
-       *  Note: superaccessors are always abstract until this point.
-       *   The method to call in a superaccessor is stored in the accessor symbol's alias field.
-       *  The rhs is:
-       *    super.A(xs)  where A is the super accessor's alias and xs are its formal parameters.
-       *  This rhs is typed and then mixin transformed.
+      /* If `stat` is a superaccessor, complete it by adding a right-hand side.
+       * Note: superaccessors are always abstract until this point.
+       *  The method to call in a superaccessor is stored in the accessor symbol's alias field.
+       * The rhs is:
+       *   super.A(xs)  where A is the super accessor's alias and xs are its formal parameters.
+       * This rhs is typed and then mixin transformed.
        */
       def completeSuperAccessor(stat: Tree) = stat match {
         case DefDef(_, _, _, vparams :: Nil, _, EmptyTree) if stat.symbol.isSuperAccessor =>
@@ -709,7 +709,7 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
           stat
       }
 
-      /**
+      /*
        *  Return the bitmap field for 'offset'. Depending on the hierarchy it is possible to reuse
        *  the bitmap of its parents. If that does not exist yet we create one.
        */
@@ -751,7 +751,7 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
         if (kind == LongClass ) LIT(1L << realOffset) else LIT(1 << realOffset)
       }
 
-      /** Return an (untyped) tree of the form 'Clazz.this.bmp = Clazz.this.bmp | mask'. */
+      /* Return an (untyped) tree of the form 'Clazz.this.bmp = Clazz.this.bmp | mask'. */
       def mkSetFlag(clazz: Symbol, offset: Int, valSym: Symbol, kind: ClassSymbol): Tree = {
         val bmp      = bitmapFor(clazz, offset, valSym)
         def mask     = maskForOffset(offset, valSym, kind)
@@ -761,8 +761,8 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
         x === newValue
       }
 
-      /** Return an (untyped) tree of the form 'clazz.this.bitmapSym & mask (==|!=) 0', the
-       *  precise comparison operator depending on the value of 'equalToZero'.
+      /* Return an (untyped) tree of the form 'clazz.this.bitmapSym & mask (==|!=) 0', the
+       * precise comparison operator depending on the value of 'equalToZero'.
        */
       def mkTest(clazz: Symbol, mask: Tree, bitmapSym: Symbol, equalToZero: Boolean, kind: ClassSymbol): Tree = {
         val bitmapTree  = (This(clazz) DOT bitmapSym)
@@ -800,17 +800,17 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
       }
 
 
-	  /** Always copy the tree if we are going to perform sym substitution,
-	   *  otherwise we will side-effect on the tree that is used in the fast path
-	   */
-	  class TreeSymSubstituterWithCopying(from: List[Symbol], to: List[Symbol]) extends TreeSymSubstituter(from, to) {
-	    override def transform(tree: Tree): Tree =
-	      if (tree.hasSymbolField && from.contains(tree.symbol))
-	        super.transform(tree.duplicate)
-	      else super.transform(tree.duplicate)
+      /* Always copy the tree if we are going to perform sym substitution,
+       * otherwise we will side-effect on the tree that is used in the fast path
+       */
+      class TreeSymSubstituterWithCopying(from: List[Symbol], to: List[Symbol]) extends TreeSymSubstituter(from, to) {
+        override def transform(tree: Tree): Tree =
+          if (tree.hasSymbolField && from.contains(tree.symbol))
+            super.transform(tree.duplicate)
+          else super.transform(tree.duplicate)
 
-	    override def apply[T <: Tree](tree: T): T = if (from.isEmpty) tree else super.apply(tree)
-	  }
+        override def apply[T <: Tree](tree: T): T = if (from.isEmpty) tree else super.apply(tree)
+      }
 
       /** return a 'lazified' version of rhs. It uses double-checked locking to ensure
        *  initialization is performed at most once. For performance reasons the double-checked
@@ -889,11 +889,11 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
         typedPos(pos)(BLOCK(result, retVal))
       }
 
-      /** Complete lazy field accessors. Applies only to classes,
-       *  for it's own (non inherited) lazy fields. If 'checkinit'
-       *  is enabled, getters that check for the initialized bit are
-       *  generated, and the class constructor is changed to set the
-       *  initialized bits.
+      /* Complete lazy field accessors. Applies only to classes,
+       * for it's own (non inherited) lazy fields. If 'checkinit'
+       * is enabled, getters that check for the initialized bit are
+       * generated, and the class constructor is changed to set the
+       * initialized bits.
        */
       def addCheckedGetters(clazz: Symbol, stats: List[Tree]): List[Tree] = {
         def dd(stat: DefDef) = {
@@ -974,17 +974,17 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
         }
       }
 
-      /** Adds statements to set the 'init' bit for each field initialized
-       *  in the body of a constructor.
+      /* Adds statements to set the 'init' bit for each field initialized
+       * in the body of a constructor.
        */
       def addInitBits(clazz: Symbol, rhs: Tree): Tree =
         new AddInitBitsTransformer(clazz) transform rhs
 
       // begin addNewDefs
 
-      /** Fill the map from fields to offset numbers.
-       *  Instead of field symbols, the map keeps their getter symbols. This makes
-       *  code generation easier later.
+      /* Fill the map from fields to offset numbers.
+       * Instead of field symbols, the map keeps their getter symbols. This makes
+       * code generation easier later.
        */
       def buildBitmapOffsets() {
         def fold(fields: List[Symbol], category: Name) = {

--- a/src/compiler/scala/tools/nsc/transform/PostErasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/PostErasure.scala
@@ -33,11 +33,11 @@ trait PostErasure extends InfoTransform with TypingTransformers {
     override def transform(tree: Tree) = {
       def finish(res: Tree) = logResult(s"Posterasure reduction\n  Old: $tree\n  New")(res)
 
-      /** We use the name of the operation being performed and not the symbol
-       *  itself because the symbol hails from the boxed class, and this transformation
-       *  exists to operate directly on the values. So we are for instance looking
-       *  up == on an lhs of type Int, whereas the symbol which has been passed in
-       *  is from java.lang.Integer.
+      /* We use the name of the operation being performed and not the symbol
+       * itself because the symbol hails from the boxed class, and this transformation
+       * exists to operate directly on the values. So we are for instance looking
+       * up == on an lhs of type Int, whereas the symbol which has been passed in
+       * is from java.lang.Integer.
        */
       def binop(lhs: Tree, op: Symbol, rhs: Tree) =
         finish(localTyper typed (Apply(Select(lhs, op.name) setPos tree.pos, rhs :: Nil) setPos tree.pos))

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -518,9 +518,9 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
    */
   def specializeClass(clazz: Symbol, outerEnv: TypeEnv): List[Symbol] = {
     def specializedClass(env0: TypeEnv, normMembers: List[Symbol]): Symbol = {
-      /** It gets hard to follow all the clazz and cls, and specializedClass
-       *  was both already used for a map and mucho long.  So "sClass" is the
-       *  specialized subclass of "clazz" throughout this file.
+      /* It gets hard to follow all the clazz and cls, and specializedClass
+       * was both already used for a map and mucho long.  So "sClass" is the
+       * specialized subclass of "clazz" throughout this file.
        */
 
       // SI-5545: Eliminate classes with the same name loaded from the bytecode already present - all we need to do is
@@ -558,12 +558,12 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
         def applyContext(tpe: Type) =
           subst(env, tpe).instantiateTypeParams(oldClassTParams, newClassTParams map (_.tpe))
 
-        /** Return a list of specialized parents to be re-mixed in a specialized subclass.
-         *  Assuming env = [T -> Int] and
-         *    class Integral[@specialized T] extends Numeric[T]
-         *  and Numeric[U] is specialized on U, this produces List(Numeric$mcI).
+        /* Return a list of specialized parents to be re-mixed in a specialized subclass.
+         * Assuming env = [T -> Int] and
+         *   class Integral[@specialized T] extends Numeric[T]
+         * and Numeric[U] is specialized on U, this produces List(Numeric$mcI).
          *
-         *  so that class Integral$mci extends Integral[Int] with Numeric$mcI.
+         * so that class Integral$mci extends Integral[Int] with Numeric$mcI.
          */
         def specializedParents(parents: List[Type]): List[Type] = {
           var res: List[Type] = Nil
@@ -604,10 +604,10 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
       exitingSpecialize(sClass setInfo specializedInfoType)
       val fullEnv = outerEnv ++ env
 
-      /** Enter 'sym' in the scope of the current specialized class. It's type is
-       *  mapped through the active environment, binding type variables to concrete
-       *  types. The existing typeEnv for `sym` is composed with the current active
-       *  environment
+      /* Enter 'sym' in the scope of the current specialized class. It's type is
+       * mapped through the active environment, binding type variables to concrete
+       * types. The existing typeEnv for `sym` is composed with the current active
+       * environment
        */
       def enterMember(sym: Symbol): Symbol = {
         typeEnv(sym) = fullEnv ++ typeEnv(sym) // append the full environment
@@ -620,18 +620,18 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
         decls1 enter subst(fullEnv)(sym)
       }
 
-      /** Create and enter in scope an overridden symbol m1 for `m` that forwards
-       *  to `om`. `om` is a fresh, special overload of m1 that is an implementation
-       *  of `m`. For example, for a
+      /* Create and enter in scope an overridden symbol m1 for `m` that forwards
+       * to `om`. `om` is a fresh, special overload of m1 that is an implementation
+       * of `m`. For example, for a
        *
-       *  class Foo[@specialized A] {
-       *    def m(x: A) = <body> // m
-       *  }
-       *  , for class Foo$I extends Foo[Int], this method enters two new symbols in
-       *  the scope of Foo$I:
+       * class Foo[@specialized A] {
+       *   def m(x: A) = <body> // m
+       * }
+       * , for class Foo$I extends Foo[Int], this method enters two new symbols in
+       * the scope of Foo$I:
        *
-       *    def m(x: Int) = m$I(x) // m1
-       *    def m$I(x: Int) = <body>/adapted to env {A -> Int} // om
+       *   def m(x: Int) = m$I(x) // m1
+       *   def m$I(x: Int) = <body>/adapted to env {A -> Int} // om
        */
       def forwardToOverload(m: Symbol): Symbol = {
         val specMember = enterMember(cloneInSpecializedClass(m, f => (f | OVERRIDE) & ~(DEFERRED | CASEACCESSOR)))
@@ -935,13 +935,13 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
    *  this method will return List('apply$mcII$sp')
    */
   private def specialOverrides(clazz: Symbol) = logResultIf[List[Symbol]]("specialized overrides in " + clazz, _.nonEmpty) {
-    /** Return the overridden symbol in syms that needs a specialized overriding symbol,
-     *  together with its specialization environment. The overridden symbol may not be
-     *  the closest to 'overriding', in a given hierarchy.
+    /* Return the overridden symbol in syms that needs a specialized overriding symbol,
+     * together with its specialization environment. The overridden symbol may not be
+     * the closest to 'overriding', in a given hierarchy.
      *
-     *  An method m needs a special override if
-     *    * m overrides a method whose type contains specialized type variables
-     *    * there is a valid specialization environment that maps the overridden method type to m's type.
+     * An method m needs a special override if
+     *   * m overrides a method whose type contains specialized type variables
+     *   * there is a valid specialization environment that maps the overridden method type to m's type.
      */
     def needsSpecialOverride(overriding: Symbol): (Symbol, TypeEnv) = {
       def checkOverriddenTParams(overridden: Symbol) {
@@ -1797,11 +1797,11 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
   private def forwardCtorCall(pos: scala.reflect.internal.util.Position, receiver: Tree, paramss: List[List[ValDef]], clazz: Symbol): Tree = {
     log(s"forwardCtorCall($pos, $receiver, $paramss, $clazz)")
 
-    /** A constructor parameter `f` initializes a specialized field
-     *  iff:
-     *    - it is specialized itself
-     *    - there is a getter for the original (non-specialized) field in the same class
-     *    - there is a getter for the specialized field in the same class
+    /* A constructor parameter `f` initializes a specialized field
+     * iff:
+     *   - it is specialized itself
+     *   - there is a getter for the original (non-specialized) field in the same class
+     *   - there is a getter for the specialized field in the same class
      */
     def initializesSpecializedField(f: Symbol) = (
          (f.name endsWith nme.SPECIALIZED_SUFFIX)

--- a/src/compiler/scala/tools/nsc/transform/TailCalls.scala
+++ b/src/compiler/scala/tools/nsc/transform/TailCalls.scala
@@ -134,9 +134,9 @@ abstract class TailCalls extends Transform {
         this.tailPos  = true
         this.failPos  = dd.pos
 
-        /** Create a new method symbol for the current method and store it in
-          * the label field.
-          */
+        /* Create a new method symbol for the current method and store it in
+         * the label field.
+         */
         this.label    = {
           val label     = method.newLabel(newTermName("_" + method.name), method.pos)
           val thisParam = method.newSyntheticValueParam(currentClass.typeOfThis)
@@ -186,8 +186,7 @@ abstract class TailCalls extends Transform {
     }
 
     override def transform(tree: Tree): Tree = {
-      /** A possibly polymorphic apply to be considered for tail call transformation.
-       */
+      /* A possibly polymorphic apply to be considered for tail call transformation. */
       def rewriteApply(target: Tree, fun: Tree, targs: List[Tree], args: List[Tree]) = {
         val receiver: Tree = fun match {
           case Select(qual, _)  => qual
@@ -200,8 +199,8 @@ abstract class TailCalls extends Transform {
         def transformArgs     = noTailTransforms(args)
         def matchesTypeArgs   = ctx.tparams sameElements (targs map (_.tpe.typeSymbol))
 
-        /** Records failure reason in Context for reporting.
-         *  Position is unchanged (by default, the method definition.)
+        /* Records failure reason in Context for reporting.
+         * Position is unchanged (by default, the method definition.)
          */
         def fail(reason: String) = {
           debuglog("Cannot rewrite recursive call at: " + fun.pos + " because: " + reason)
@@ -209,8 +208,7 @@ abstract class TailCalls extends Transform {
           ctx.failReason = reason
           treeCopy.Apply(tree, noTailTransform(target), transformArgs)
         }
-        /** Position of failure is that of the tree being considered.
-         */
+        /* Position of failure is that of the tree being considered. */
         def failHere(reason: String) = {
           ctx.failPos = fun.pos
           fail(reason)
@@ -264,8 +262,8 @@ abstract class TailCalls extends Transform {
 
           deriveDefDef(tree){rhs =>
             if (newCtx.isTransformed) {
-              /** We have rewritten the tree, but there may be nested recursive calls remaining.
-               *  If @tailrec is given we need to fail those now.
+              /* We have rewritten the tree, but there may be nested recursive calls remaining.
+               * If @tailrec is given we need to fail those now.
                */
               if (newCtx.isMandatory) {
                 for (t @ Apply(fn, _) <- newRHS ; if fn.symbol == newCtx.method) {

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -401,8 +401,7 @@ abstract class UnCurry extends InfoTransform
         finally needTryLift = saved
       }
 
-      /** Transform tree `t` to { def f = t; f } where `f` is a fresh name
-       */
+      /* Transform tree `t` to { def f = t; f } where `f` is a fresh name */
       def liftTree(tree: Tree) = {
         debuglog("lifting tree at: " + (tree.pos))
         val sym = currentOwner.newMethod(unit.freshTermName("liftedTree"), tree.pos)

--- a/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
@@ -366,7 +366,7 @@ trait ScalaLogic extends Interface with Logic with TreeAndTypeAnalysis {
        * and thus in this variable's equality symbols), but reachability also requires us to model things like V = 1 precluding V = "1"
        */
       lazy val implications = {
-        /** when we know V = C, which other equalities must hold
+        /* when we know V = C, which other equalities must hold
          *
          * in general, equality to some type implies equality to its supertypes
          * (this multi-valued kind of equality is necessary for unreachability)
@@ -385,7 +385,7 @@ trait ScalaLogic extends Interface with Logic with TreeAndTypeAnalysis {
           // else  debug.patmat("NOT implies: "+(lower, upper))
 
 
-        /** does V = C preclude V having value `other`?
+        /* does V = C preclude V having value `other`?
          (1) V = null is an exclusive assignment,
          (2) V = A and V = B, for A and B value constants, are mutually exclusive unless A == B
              we err on the safe side, for example:

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
@@ -309,7 +309,7 @@ trait MatchTranslation { self: PatternMatching  =>
           // debug.patmat("unfun: "+ (unfun.tpe, unfun.symbol.ownerChain, unfun.symbol.info, patBinder.info))
           translateExtractorPattern(ExtractorCall(unfun, args))
 
-        /** A constructor pattern is of the form c(p1, ..., pn) where n ≥ 0.
+        /* A constructor pattern is of the form c(p1, ..., pn) where n ≥ 0.
           It consists of a stable identifier c, followed by element patterns p1, ..., pn.
           The constructor c is a simple or qualified name which denotes a case class (§5.3.2).
 
@@ -328,22 +328,22 @@ trait MatchTranslation { self: PatternMatching  =>
             noFurtherSubPats()
           }
 
-        /** A typed pattern x : T consists of a pattern variable x and a type pattern T.
-            The type of x is the type pattern T, where each type variable and wildcard is replaced by a fresh, unknown type.
-            This pattern matches any value matched by the type pattern T (§8.2); it binds the variable name to that value.
-        **/
+        /* A typed pattern x : T consists of a pattern variable x and a type pattern T.
+           The type of x is the type pattern T, where each type variable and wildcard is replaced by a fresh, unknown type.
+           This pattern matches any value matched by the type pattern T (§8.2); it binds the variable name to that value.
+        */
         // must treat Typed and Bind together -- we need to know the patBinder of the Bind pattern to get at the actual type
         case MaybeBoundTyped(subPatBinder, pt) =>
           val next = glb(List(dealiasWiden(patBinder.info), pt)).normalize
           // a typed pattern never has any subtrees
           noFurtherSubPats(TypeTestTreeMaker(subPatBinder, patBinder, pt, next)(pos))
 
-        /** A pattern binder x@p consists of a pattern variable x and a pattern p.
-            The type of the variable x is the static type T of the pattern p.
-            This pattern matches any value v matched by the pattern p,
-            provided the run-time type of v is also an instance of T,  <-- TODO! https://issues.scala-lang.org/browse/SI-1503
-            and it binds the variable name to that value.
-        **/
+        /* A pattern binder x@p consists of a pattern variable x and a pattern p.
+           The type of the variable x is the static type T of the pattern p.
+           This pattern matches any value v matched by the pattern p,
+           provided the run-time type of v is also an instance of T,  <-- TODO! https://issues.scala-lang.org/browse/SI-1503
+           and it binds the variable name to that value.
+        */
         case Bound(subpatBinder, p)          =>
           // replace subpatBinder by patBinder (as if the Bind was not there)
           withSubPats(List(SubstOnlyTreeMaker(subpatBinder, patBinder)),
@@ -351,14 +351,14 @@ trait MatchTranslation { self: PatternMatching  =>
             (patBinder, p)
           )
 
-        /** 8.1.4 Literal Patterns
-              A literal pattern L matches any value that is equal (in terms of ==) to the literal L.
-              The type of L must conform to the expected type of the pattern.
+        /* 8.1.4 Literal Patterns
+             A literal pattern L matches any value that is equal (in terms of ==) to the literal L.
+             The type of L must conform to the expected type of the pattern.
 
-            8.1.5 Stable Identifier Patterns  (a stable identifier r (see §3.1))
-              The pattern matches any value v such that r == v (§12.1).
-              The type of r must conform to the expected type of the pattern.
-        **/
+           8.1.5 Stable Identifier Patterns  (a stable identifier r (see §3.1))
+             The pattern matches any value v such that r == v (§12.1).
+             The type of r must conform to the expected type of the pattern.
+        */
         case Literal(Constant(_)) | Ident(_) | Select(_, _) | This(_) =>
           noFurtherSubPats(EqualityTestTreeMaker(patBinder, patTree, pos))
 

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -302,7 +302,7 @@ trait ContextErrors {
           val target           = qual.tpe.widen
           def targetKindString = if (owner.isTypeParameterOrSkolem) "type parameter " else ""
           def nameString       = decodeWithKind(name, owner)
-          /** Illuminating some common situations and errors a bit further. */
+          /* Illuminating some common situations and errors a bit further. */
           def addendum         = {
             val companion = {
               if (name.isTermName && owner.isPackageClass) {

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -532,7 +532,7 @@ trait Contexts { self: Analyzer =>
         case _ => false
       }
 
-      /** Is protected access to target symbol permitted */
+      /* Is protected access to target symbol permitted */
       def isProtectedAccessOK(target: Symbol) = {
         val c = enclosingSubClassContext(sym.owner)
         if (c == NoContext)

--- a/src/compiler/scala/tools/nsc/typechecker/EtaExpansion.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/EtaExpansion.scala
@@ -56,8 +56,8 @@ trait EtaExpansion { self: Analyzer =>
     }
     val defs = new ListBuffer[Tree]
 
-    /** Append to `defs` value definitions for all non-stable
-     *  subexpressions of the function application `tree`.
+    /* Append to `defs` value definitions for all non-stable
+     * subexpressions of the function application `tree`.
      */
     def liftoutPrefix(tree: Tree): Tree = {
       def liftout(tree: Tree, byName: Boolean): Tree =
@@ -106,8 +106,7 @@ trait EtaExpansion { self: Analyzer =>
       tree1
     }
 
-    /** Eta-expand lifted tree.
-     */
+    /* Eta-expand lifted tree. */
     def expand(tree: Tree, tpe: Type): Tree = tpe match {
       case mt @ MethodType(paramSyms, restpe) if !mt.isImplicit =>
         val params: List[(ValDef, Boolean)] = paramSyms.map {

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -873,8 +873,8 @@ trait Implicits {
         }
 
         if (best.isFailure) {
-          /** If there is no winner, and we witnessed and caught divergence,
-           *  now we can throw it for the error message.
+          /* If there is no winner, and we witnessed and caught divergence,
+           * now we can throw it for the error message.
            */
           if (divergence)
             throw DivergentImplicit
@@ -934,8 +934,8 @@ trait Implicits {
      */
     private def companionImplicitMap(tp: Type): InfoMap = {
 
-      /** Populate implicit info map by traversing all parts of type `tp`.
-       *  Parameters as for `getParts`.
+      /* Populate implicit info map by traversing all parts of type `tp`.
+       * Parameters as for `getParts`.
        */
       def getClassParts(tp: Type)(implicit infoMap: InfoMap, seen: mutable.Set[Type], pending: Set[Symbol]) = tp match {
         case TypeRef(pre, sym, args) =>
@@ -967,13 +967,13 @@ trait Implicits {
             }
       }
 
-      /** Populate implicit info map by traversing all parts of type `tp`.
-       *  This method is performance critical.
-       *  @param tp   The type for which we want to traverse parts
-       *  @param infoMap  The infoMap in which implicit infos corresponding to parts are stored
-       *  @param seen     The types that were already visited previously when collecting parts for the given infoMap
-       *  @param pending  The set of static symbols for which we are currently trying to collect their parts
-       *                  in order to cache them in infoMapCache
+      /* Populate implicit info map by traversing all parts of type `tp`.
+       * This method is performance critical.
+       * @param tp   The type for which we want to traverse parts
+       * @param infoMap  The infoMap in which implicit infos corresponding to parts are stored
+       * @param seen     The types that were already visited previously when collecting parts for the given infoMap
+       * @param pending  The set of static symbols for which we are currently trying to collect their parts
+       *                 in order to cache them in infoMapCache
        */
       def getParts(tp: Type)(implicit infoMap: InfoMap, seen: mutable.Set[Type], pending: Set[Symbol]) {
         if (seen(tp))
@@ -1136,7 +1136,7 @@ trait Implicits {
       val full = flavor == FullManifestClass
       val opt = flavor == OptManifestClass
 
-      /** Creates a tree that calls the factory method called constructor in object scala.reflect.Manifest */
+      /* Creates a tree that calls the factory method called constructor in object scala.reflect.Manifest */
       def manifestFactoryCall(constructor: String, tparg: Type, args: Tree*): Tree =
         if (args contains EmptyTree) EmptyTree
         else typedPos(tree.pos.focus) {
@@ -1145,12 +1145,12 @@ trait Implicits {
           mani
         }
 
-      /** Creates a tree representing one of the singleton manifests.*/
+      /* Creates a tree representing one of the singleton manifests.*/
       def findSingletonManifest(name: String) = typedPos(tree.pos.focus) {
         Select(gen.mkAttributedRef(FullManifestModule), name)
       }
 
-      /** Re-wraps a type in a manifest before calling inferImplicit on the result */
+      /* Re-wraps a type in a manifest before calling inferImplicit on the result */
       def findManifest(tp: Type, manifestClass: Symbol = if (full) FullManifestClass else PartialManifestClass) =
         inferImplicit(tree, appliedType(manifestClass, tp), reportAmbiguous = true, isView = false, context).tree
 

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -304,12 +304,11 @@ trait Infer extends Checkable {
 
     def isPossiblyMissingArgs(found: Type, req: Type) = (
       false
-      /** However it is that this condition is expected to imply
-       *  "is possibly missing args", it is too weak.  It is
-       *  better to say nothing than to offer misleading guesses.
+      /* However it is that this condition is expected to imply
+       * "is possibly missing args", it is too weak.  It is
+       * better to say nothing than to offer misleading guesses.
 
-         (found.resultApprox ne found)
-      && isWeaklyCompatible(found.resultApprox, req)
+       * (found.resultApprox ne found) && isWeaklyCompatible(found.resultApprox, req)
       */
     )
 
@@ -509,8 +508,8 @@ trait Infer extends Checkable {
     */
     def protoTypeArgs(tparams: List[Symbol], formals: List[Type], restpe: Type,
                       pt: Type): List[Type] = {
-      /** Map type variable to its instance, or, if `variance` is covariant/contravariant,
-       *  to its upper/lower bound */
+      /* Map type variable to its instance, or, if `variance` is covariant/contravariant,
+       * to its upper/lower bound */
       def instantiateToBound(tvar: TypeVar, variance: Variance): Type = {
         lazy val hiBounds = tvar.constr.hiBounds
         lazy val loBounds = tvar.constr.loBounds
@@ -1250,8 +1249,7 @@ trait Infer extends Checkable {
 
       debuglog("infer constr inst "+ tree +"/"+ undetparams +"/ pt= "+ pt +" pt0= "+ pt0 +" resTp: "+ resTp)
 
-      /** Compute type arguments for undetermined params
-       */
+      /* Compute type arguments for undetermined params */
       def inferFor(pt: Type): Option[List[Type]] = {
         val tvars   = undetparams map freshVar
         val resTpV  = resTp.instantiateTypeParams(undetparams, tvars)
@@ -1384,9 +1382,9 @@ trait Infer extends Checkable {
       def ptMatchesPattp = pt matchesPattern pattp.widen
       def pattpMatchesPt = pattp matchesPattern pt
 
-      /** If we can absolutely rule out a match we can fail early.
-       *  This is the case if the scrutinee has no unresolved type arguments
-       *  and is a "final type", meaning final + invariant in all type parameters.
+      /* If we can absolutely rule out a match we can fail early.
+       * This is the case if the scrutinee has no unresolved type arguments
+       * and is a "final type", meaning final + invariant in all type parameters.
        */
       if (pt.isFinalType && ptparams.isEmpty && !ptMatchesPattp) {
         IncompatibleScrutineeTypeError(tree0, pattp, pt)
@@ -1422,9 +1420,9 @@ trait Infer extends Checkable {
         }
         tvars foreach instantiateTypeVar
       }
-      /** If the scrutinee has free type parameters but the pattern does not,
-       *  we have to flip the arguments so the expected type is treated as more
-       *  general when calculating the intersection.  See run/bug2755.scala.
+      /* If the scrutinee has free type parameters but the pattern does not,
+       * we have to flip the arguments so the expected type is treated as more
+       * general when calculating the intersection.  See run/bug2755.scala.
        */
       if (tpparams.isEmpty && ptparams.nonEmpty) intersect(pattp, pt)
       else intersect(pt, pattp)

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -554,8 +554,8 @@ trait Namers extends MethodSynthesis {
       val sym      = copyDef.symbol
       val lazyType = completerOf(copyDef)
 
-      /** Assign the types of the class parameters to the parameters of the
-       *  copy method. See comment in `Unapplies.caseClassCopyMeth` */
+      /* Assign the types of the class parameters to the parameters of the
+       * copy method. See comment in `Unapplies.caseClassCopyMeth` */
       def assignParamTypes() {
         val clazz = sym.owner
         val constructorType = clazz.primaryConstructor.tpe
@@ -985,7 +985,7 @@ trait Namers extends MethodSynthesis {
       var vparamSymss = enterValueParams(vparamss)
 
 
-      /**
+      /*
        * Creates a method type using tparamSyms and vparamsSymss as argument symbols and `respte` as result type.
        * All typeRefs to type skolems are replaced by references to the corresponding non-skolem type parameter,
        * so the resulting type is a valid external method type, it does not contain (references to) skolems.
@@ -1019,7 +1019,7 @@ trait Namers extends MethodSynthesis {
         res.substSym(tparamSkolems, tparamSyms)
       }
 
-      /**
+      /*
        * Creates a schematic method type which has WildcardTypes for non specified
        * return or parameter types. For instance, in `def f[T](a: T, b) = ...`, the
        * type schema is
@@ -1043,7 +1043,7 @@ trait Namers extends MethodSynthesis {
       // def overriddenSymbol = meth.nextOverriddenSymbol
 
 
-      /**
+      /*
        * If `meth` doesn't have an explicit return type, extracts the return type from the method
        * overridden by `meth` (if there's an unique one). This type is lateron used as the expected
        * type for computing the type of the rhs. The resulting type references type skolems for
@@ -1387,12 +1387,12 @@ trait Namers extends MethodSynthesis {
      */
     def typeSig(tree: Tree): Type = {
       // log("typeSig " + tree)
-      /** For definitions, transform Annotation trees to AnnotationInfos, assign
-       *  them to the sym's annotations. Type annotations: see Typer.typedAnnotated
-       *  We have to parse definition annotations here (not in the typer when traversing
-       *  the MemberDef tree): the typer looks at annotations of certain symbols; if
-       *  they were added only in typer, depending on the compilation order, they may
-       *  or may not be visible.
+      /* For definitions, transform Annotation trees to AnnotationInfos, assign
+       * them to the sym's annotations. Type annotations: see Typer.typedAnnotated
+       * We have to parse definition annotations here (not in the typer when traversing
+       * the MemberDef tree): the typer looks at annotations of certain symbols; if
+       * they were added only in typer, depending on the compilation order, they may
+       * or may not be visible.
        */
       def annotate(annotated: Symbol) = {
         // typeSig might be called multiple times, e.g. on a ValDef: val, getter, setter

--- a/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
@@ -111,7 +111,7 @@ trait NamesDefaults { self: Analyzer =>
     val context = typer.context
     import context.unit
 
-    /**
+    /*
      * Transform a function into a block, and passing context.namedApplyBlockInfo to
      * the new block as side-effect.
      *
@@ -256,7 +256,7 @@ trait NamesDefaults { self: Analyzer =>
       }
     }
 
-    /**
+    /*
      * For each argument (arg: T), create a local value
      *  x$n: T = arg
      *

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -281,8 +281,8 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
          else "")
       }
 
-      /** Check that all conditions for overriding `other` by `member`
-       *  of class `clazz` are met.
+      /* Check that all conditions for overriding `other` by `member`
+       * of class `clazz` are met.
        */
       def checkOverride(member: Symbol, other: Symbol) {
         debuglog("Checking validity of %s overriding %s".format(member.fullLocationString, other.fullLocationString))
@@ -361,8 +361,7 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
           }
         }
 
-        /** Is the intersection between given two lists of overridden symbols empty?
-         */
+        /* Is the intersection between given two lists of overridden symbols empty? */
         def intersectionIsEmpty(syms1: List[Symbol], syms2: List[Symbol]) =
           !(syms1 exists (syms2 contains _))
 
@@ -736,9 +735,9 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
         }
       }
 
-      /** Returns whether there is a symbol declared in class `inclazz`
-       *  (which must be different from `clazz`) whose name and type
-       *  seen as a member of `class.thisType` matches `member`'s.
+      /* Returns whether there is a symbol declared in class `inclazz`
+       * (which must be different from `clazz`) whose name and type
+       * seen as a member of `class.thisType` matches `member`'s.
        */
       def hasMatchingSym(inclazz: Symbol, member: Symbol): Boolean = {
         val isVarargs = hasRepeatedParam(member.tpe)
@@ -750,22 +749,22 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
 
           matches(member.tpe) || (isVarargs && matches(varargsType))
         }
-        /** The rules for accessing members which have an access boundary are more
-         *  restrictive in java than scala.  Since java has no concept of package nesting,
-         *  a member with "default" (package-level) access can only be accessed by members
-         *  in the exact same package.  Example:
+        /* The rules for accessing members which have an access boundary are more
+         * restrictive in java than scala.  Since java has no concept of package nesting,
+         * a member with "default" (package-level) access can only be accessed by members
+         * in the exact same package.  Example:
          *
-         *    package a.b;
-         *    public class JavaClass { void foo() { } }
+         *   package a.b;
+         *   public class JavaClass { void foo() { } }
          *
-         *  The member foo() can be accessed only from members of package a.b, and not
-         *  nested packages like a.b.c.  In the analogous scala class:
+         * The member foo() can be accessed only from members of package a.b, and not
+         * nested packages like a.b.c.  In the analogous scala class:
          *
-         *    package a.b
-         *    class ScalaClass { private[b] def foo() = () }
+         *   package a.b
+         *   class ScalaClass { private[b] def foo() = () }
          *
-         *  The member IS accessible to classes in package a.b.c.  The javaAccessCheck logic
-         *  is restricting the set of matching signatures according to the above semantics.
+         * The member IS accessible to classes in package a.b.c.  The javaAccessCheck logic
+         * is restricting the set of matching signatures according to the above semantics.
          */
         def javaAccessCheck(sym: Symbol) = (
              !inclazz.isJavaDefined                             // not a java defined member
@@ -812,7 +811,7 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
       for (i <- 0 until seenTypes.length)
         seenTypes(i) = Nil
 
-      /** validate all base types of a class in reverse linear order. */
+      /* validate all base types of a class in reverse linear order. */
       def register(tp: Type): Unit = {
 //        if (clazz.fullName.endsWith("Collection.Projection"))
 //            println("validate base type "+tp)
@@ -948,7 +947,7 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
         // @MAT normalize for consistency in error message, otherwise only part is normalized due to use of `typeSymbol`
         def typesString = normalizeAll(qual.tpe.widen)+" and "+normalizeAll(args.head.tpe.widen)
 
-        /** Symbols which limit the warnings we can issue since they may be value types */
+        /* Symbols which limit the warnings we can issue since they may be value types */
         val isMaybeValue = Set[Symbol](AnyClass, AnyRefClass, AnyValClass, ObjectClass, ComparableClass, JavaSerializableClass)
 
         // Whether def equals(other: Any) has known behavior: it is the default
@@ -1455,11 +1454,11 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
       val Select(qual, _) = tree
       val sym = tree.symbol
 
-      /** Note: if a symbol has both @deprecated and @migration annotations and both
-       *  warnings are enabled, only the first one checked here will be emitted.
-       *  I assume that's a consequence of some code trying to avoid noise by suppressing
-       *  warnings after the first, but I think it'd be better if we didn't have to
-       *  arbitrarily choose one as more important than the other.
+      /* Note: if a symbol has both @deprecated and @migration annotations and both
+       * warnings are enabled, only the first one checked here will be emitted.
+       * I assume that's a consequence of some code trying to avoid noise by suppressing
+       * warnings after the first, but I think it'd be better if we didn't have to
+       * arbitrarily choose one as more important than the other.
        */
       checkDeprecated(sym, tree.pos)
       if(settings.Xmigration.value != NoScalaVersion)

--- a/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
@@ -1,3 +1,4 @@
+
 /* NSC -- new Scala compiler
  * Copyright 2005-2013 LAMP/EPFL
  * @author Martin Odersky
@@ -264,7 +265,7 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
                 debuglog("alias replacement: " + tree + " ==> " + result); //debug
                 localTyper.typed(gen.maybeMkAsInstanceOf(transformSuperSelect(result), sym.tpe, sym.alias.tpe, beforeRefChecks = true))
               } else {
-                /**
+                /*
                  * A trait which extends a class and accesses a protected member
                  *  of that class cannot implement the necessary accessor method
                  *  because its implementation is in an implementation class (e.g.

--- a/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
@@ -126,8 +126,7 @@ trait SyntheticMethods extends ast.TreeDSL {
       )
     }
 
-    /** Common code for productElement and (currently disabled) productElementName
-     */
+    /* Common code for productElement and (currently disabled) productElementName */
     def perElementMethod(name: Name, returnType: Type)(caseFn: Symbol => Tree): Tree =
       createSwitchMethod(name, accessors.indices, returnType)(idx => caseFn(accessors(idx)))
 
@@ -135,8 +134,8 @@ trait SyntheticMethods extends ast.TreeDSL {
 
     var syntheticCanEqual = false
 
-    /** The canEqual method for case classes.
-     *    def canEqual(that: Any) = that.isInstanceOf[This]
+    /* The canEqual method for case classes.
+     *   def canEqual(that: Any) = that.isInstanceOf[This]
      */
     def canEqualMethod: Tree = {
       syntheticCanEqual = true
@@ -144,13 +143,13 @@ trait SyntheticMethods extends ast.TreeDSL {
         Ident(m.firstParam) IS_OBJ classExistentialType(clazz))
     }
 
-    /** that match { case _: this.C => true ; case _ => false }
-     *  where `that` is the given method's first parameter.
+    /* that match { case _: this.C => true ; case _ => false }
+     * where `that` is the given method's first parameter.
      *
-     *  An isInstanceOf test is insufficient because it has weaker
-     *  requirements than a pattern match. Given an inner class Foo and
-     *  two different instantiations of the container, an x.Foo and and a y.Foo
-     *  are both .isInstanceOf[Foo], but the one does not match as the other.
+     * An isInstanceOf test is insufficient because it has weaker
+     * requirements than a pattern match. Given an inner class Foo and
+     * two different instantiations of the container, an x.Foo and and a y.Foo
+     * are both .isInstanceOf[Foo], but the one does not match as the other.
      */
     def thatTest(eqmeth: Symbol): Tree = {
       Match(
@@ -162,19 +161,19 @@ trait SyntheticMethods extends ast.TreeDSL {
       )
     }
 
-    /** (that.asInstanceOf[this.C])
-     *  where that is the given methods first parameter.
+    /* (that.asInstanceOf[this.C])
+     * where that is the given methods first parameter.
      */
     def thatCast(eqmeth: Symbol): Tree =
       gen.mkCast(Ident(eqmeth.firstParam), clazz.tpe)
 
-    /** The equality method core for case classes and inline clases.
-     *  1+ args:
-     *    (that.isInstanceOf[this.C]) && {
-     *        val x$1 = that.asInstanceOf[this.C]
-     *        (this.arg_1 == x$1.arg_1) && (this.arg_2 == x$1.arg_2) && ... && (x$1 canEqual this)
-     *       }
-     *  Drop canBuildFrom part if class is final and canBuildFrom is synthesized
+    /* The equality method core for case classes and inline clases.
+     * 1+ args:
+     *   (that.isInstanceOf[this.C]) && {
+     *       val x$1 = that.asInstanceOf[this.C]
+     *       (this.arg_1 == x$1.arg_1) && (this.arg_2 == x$1.arg_2) && ... && (x$1 canEqual this)
+     *      }
+     * Drop canBuildFrom part if class is final and canBuildFrom is synthesized
      */
     def equalsCore(eqmeth: Symbol, accessors: List[Symbol]) = {
       val otherName = context.unit.freshTermName(clazz.name + "$")
@@ -189,16 +188,16 @@ trait SyntheticMethods extends ast.TreeDSL {
       )
     }
 
-    /** The equality method for case classes.
-     *  0 args:
-     *    def equals(that: Any) = that.isInstanceOf[this.C] && that.asInstanceOf[this.C].canEqual(this)
-     *  1+ args:
-     *    def equals(that: Any) = (this eq that.asInstanceOf[AnyRef]) || {
-     *      (that.isInstanceOf[this.C]) && {
-     *        val x$1 = that.asInstanceOf[this.C]
-     *        (this.arg_1 == x$1.arg_1) && (this.arg_2 == x$1.arg_2) && ... && (x$1 canEqual this)
-     *       }
-     *    }
+    /* The equality method for case classes.
+     * 0 args:
+     *   def equals(that: Any) = that.isInstanceOf[this.C] && that.asInstanceOf[this.C].canEqual(this)
+     * 1+ args:
+     *   def equals(that: Any) = (this eq that.asInstanceOf[AnyRef]) || {
+     *     (that.isInstanceOf[this.C]) && {
+     *       val x$1 = that.asInstanceOf[this.C]
+     *       (this.arg_1 == x$1.arg_1) && (this.arg_2 == x$1.arg_2) && ... && (x$1 canEqual this)
+     *      }
+     *   }
      */
     def equalsCaseClassMethod: Tree = createMethod(nme.equals_, List(AnyClass.tpe), BooleanClass.tpe) { m =>
       if (accessors.isEmpty)
@@ -208,25 +207,25 @@ trait SyntheticMethods extends ast.TreeDSL {
         (mkThis ANY_EQ Ident(m.firstParam)) OR equalsCore(m, accessors)
     }
 
-    /** The equality method for value classes
-     *  def equals(that: Any) = (this.asInstanceOf[AnyRef]) eq that.asInstanceOf[AnyRef]) || {
-     *    (that.isInstanceOf[this.C]) && {
-     *     val x$1 = that.asInstanceOf[this.C]
-     *     (this.underlying == that.underlying
+    /* The equality method for value classes
+     * def equals(that: Any) = (this.asInstanceOf[AnyRef]) eq that.asInstanceOf[AnyRef]) || {
+     *   (that.isInstanceOf[this.C]) && {
+     *    val x$1 = that.asInstanceOf[this.C]
+     *    (this.underlying == that.underlying
      */
     def equalsDerivedValueClassMethod: Tree = createMethod(nme.equals_, List(AnyClass.tpe), BooleanClass.tpe) { m =>
       equalsCore(m, List(clazz.derivedValueClassUnbox))
     }
 
-    /** The hashcode method for value classes
+    /* The hashcode method for value classes
      * def hashCode(): Int = this.underlying.hashCode
      */
     def hashCodeDerivedValueClassMethod: Tree = createMethod(nme.hashCode_, Nil, IntClass.tpe) { m =>
       Select(mkThisSelect(clazz.derivedValueClassUnbox), nme.hashCode_)
     }
 
-    /** The _1, _2, etc. methods to implement ProductN, disabled
-     *  until we figure out how to introduce ProductN without cycles.
+    /* The _1, _2, etc. methods to implement ProductN, disabled
+     * until we figure out how to introduce ProductN without cycles.
      */
     /****
     def productNMethods = {
@@ -308,11 +307,11 @@ trait SyntheticMethods extends ast.TreeDSL {
       // Object_equals   -> (() => createMethod(Object_equals)(m => This(clazz) ANY_EQ Ident(m.firstParam)))
     )
 
-    /** If you serialize a singleton and then deserialize it twice,
-     *  you will have two instances of your singleton unless you implement
-     *  readResolve.  Here it is implemented for all objects which have
-     *  no implementation and which are marked serializable (which is true
-     *  for all case objects.)
+    /* If you serialize a singleton and then deserialize it twice,
+     * you will have two instances of your singleton unless you implement
+     * readResolve.  Here it is implemented for all objects which have
+     * no implementation and which are marked serializable (which is true
+     * for all case objects.)
      */
     def needsReadResolve = (
          clazz.isModuleClass
@@ -330,8 +329,8 @@ trait SyntheticMethods extends ast.TreeDSL {
         else Nil
       )
 
-      /** Always generate overrides for equals and hashCode in value classes,
-       *  so they can appear in universal traits without breaking value semantics.
+      /* Always generate overrides for equals and hashCode in value classes,
+       * so they can appear in universal traits without breaking value semantics.
        */
       def impls = {
         def shouldGenerate(m: Symbol) = {
@@ -363,11 +362,11 @@ trait SyntheticMethods extends ast.TreeDSL {
       catch { case _: TypeError if reporter.hasErrors => Nil }
     }
 
-    /** If this case class has any less than public accessors,
-     *  adds new accessors at the correct locations to preserve ordering.
-     *  Note that this must be done before the other method synthesis
-     *  because synthesized methods need refer to the new symbols.
-     *  Care must also be taken to preserve the case accessor order.
+    /* If this case class has any less than public accessors,
+     * adds new accessors at the correct locations to preserve ordering.
+     * Note that this must be done before the other method synthesis
+     * because synthesized methods need refer to the new symbols.
+     * Care must also be taken to preserve the case accessor order.
      */
     def caseTemplateBody(): List[Tree] = {
       val lb = ListBuffer[Tree]()

--- a/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
@@ -221,7 +221,7 @@ abstract class TreeCheckers extends Analyzer {
                 case _: ConstantType  => ()
                 case _                =>
                   checkSym(tree)
-                  /** XXX: lots of syms show up here with accessed == NoSymbol. */
+                  /* XXX: lots of syms show up here with accessed == NoSymbol. */
                   if (accessed != NoSymbol) {
                     val agetter = accessed.getter(sym.owner)
                     val asetter = accessed.setter(sym.owner)
@@ -248,7 +248,7 @@ abstract class TreeCheckers extends Analyzer {
             else if (currentOwner.ownerChain takeWhile (_ != sym) exists (_ == NoSymbol))
               return fail("tree symbol "+sym+" does not point to enclosing class; tree = ")
 
-          /** XXX: temporary while Import nodes are arriving untyped. */
+          /* XXX: temporary while Import nodes are arriving untyped. */
           case Import(_, _) =>
             return
           case _ =>

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -905,7 +905,7 @@ trait Typers extends Adaptations with Tags {
         }
       }
 
-      /**
+      /*
        * To deal with the type slack between actual (run-time) types and statically known types, for each abstract type T,
        * reflect its variance as a skolem that is upper-bounded by T (covariant position), or lower-bounded by T (contravariant).
        *
@@ -2156,7 +2156,7 @@ trait Typers extends Adaptations with Tags {
         unit.error(pos, msg)
         false
       }
-      /** Have to examine all parameters in all lists.
+      /* Have to examine all parameters in all lists.
        */
       def paramssTypes(tp: Type): List[List[Type]] = tp match {
         case mt @ MethodType(_, restpe) => mt.paramTypes :: paramssTypes(restpe)
@@ -2175,10 +2175,10 @@ trait Typers extends Adaptations with Tags {
           val sym = paramType.typeSymbol
           def paramPos = nthParamPos(listIdx, paramIdx)
 
-          /** Not enough to look for abstract types; have to recursively check the bounds
-           *  of each abstract type for more abstract types. Almost certainly there are other
-           *  exploitable type soundness bugs which can be seen by bounding a type parameter
-           *  by an abstract type which itself is bounded by an abstract type.
+          /* Not enough to look for abstract types; have to recursively check the bounds
+           * of each abstract type for more abstract types. Almost certainly there are other
+           * exploitable type soundness bugs which can be seen by bounding a type parameter
+           * by an abstract type which itself is bounded by an abstract type.
            */
           def checkAbstract(tp0: Type, what: String): Boolean = {
             def check(sym: Symbol): Boolean = !sym.isAbstractType || {
@@ -2864,8 +2864,8 @@ trait Typers extends Adaptations with Tags {
           }
       }
 
-      /** 'accessor' and 'accessed' are so similar it becomes very difficult to
-       *  follow the logic, so I renamed one to something distinct.
+      /* 'accessor' and 'accessed' are so similar it becomes very difficult to
+       * follow the logic, so I renamed one to something distinct.
        */
       def accesses(looker: Symbol, accessed: Symbol) = accessed.hasLocalFlag && (
            (accessed.isParamAccessor)
@@ -3122,9 +3122,9 @@ trait Typers extends Adaptations with Tags {
           val argslen = args.length
           val formals = formalTypes(paramTypes, argslen)
 
-          /** Try packing all arguments into a Tuple and apply `fun`
-           *  to that. This is the last thing which is tried (after
-           *  default arguments)
+          /* Try packing all arguments into a Tuple and apply `fun`
+           * to that. This is the last thing which is tried (after
+           * default arguments)
            */
           def tryTupleApply: Option[Tree] = (
             if (eligibleForTupleConversion(paramTypes, argslen) && !phase.erasedTypes) {
@@ -3145,10 +3145,10 @@ trait Typers extends Adaptations with Tags {
             else None
           )
 
-          /** Treats an application which uses named or default arguments.
-           *  Also works if names + a vararg used: when names are used, the vararg
-           *  parameter has to be specified exactly once. Note that combining varargs
-           *  and defaults is ruled out by typedDefDef.
+          /* Treats an application which uses named or default arguments.
+           * Also works if names + a vararg used: when names are used, the vararg
+           * parameter has to be specified exactly once. Note that combining varargs
+           * and defaults is ruled out by typedDefDef.
            */
           def tryNamesDefaults: Tree = {
             val lencmp = compareLengths(args, formals)
@@ -3258,7 +3258,7 @@ trait Typers extends Adaptations with Tags {
                   case _ => tp
                 }
 
-                /**
+                /*
                  * This is translating uses of List() into Nil.  This is less
                  *  than ideal from a consistency standpoint, but it shouldn't be
                  *  altered without due caution.
@@ -3475,8 +3475,8 @@ trait Typers extends Adaptations with Tags {
         ErroneousAnnotation
       }
 
-      /** Calling constfold right here is necessary because some trees (negated
-       *  floats and literals in particular) are not yet folded.
+      /* Calling constfold right here is necessary because some trees (negated
+       * floats and literals in particular) are not yet folded.
        */
       def tryConst(tr: Tree, pt: Type): Option[LiteralAnnotArg] = {
         // The typed tree may be relevantly different than the tree `tr`,
@@ -3498,8 +3498,8 @@ trait Typers extends Adaptations with Tags {
           Some(LiteralAnnotArg(const))
       }
 
-      /** Converts an untyped tree to a ClassfileAnnotArg. If the conversion fails,
-       *  an error message is reported and None is returned.
+      /* Converts an untyped tree to a ClassfileAnnotArg. If the conversion fails,
+       * an error message is reported and None is returned.
        */
       def tree2ConstArg(tree: Tree, pt: Type): Option[ClassfileAnnotArg] = tree match {
         case Apply(Select(New(tpt), nme.CONSTRUCTOR), args) if (pt.typeSymbol == ArrayClass) =>
@@ -3998,13 +3998,13 @@ trait Typers extends Adaptations with Tags {
           def applyOp(args: List[Tree]) = if (hasNamed(args)) nme.applyDynamicNamed else nme.applyDynamic
           def matches(t: Tree)          = isDesugaredApply || treeInfo.dissectApplied(t).core == treeSelection
 
-          /** Note that the trees which arrive here are potentially some distance from
-           *  the trees of direct interest. `cxTree` is some enclosing expression which
-           *  may apparently be arbitrarily larger than `tree`; and `tree` itself is
-           *  too small, having at least in some cases lost its explicit type parameters.
-           *  This logic is designed to use `tree` to pinpoint the immediately surrounding
-           *  Apply/TypeApply/Select node, and only then creates the dynamic call.
-           *  See SI-6731 among others.
+          /* Note that the trees which arrive here are potentially some distance from
+           * the trees of direct interest. `cxTree` is some enclosing expression which
+           * may apparently be arbitrarily larger than `tree`; and `tree` itself is
+           * too small, having at least in some cases lost its explicit type parameters.
+           * This logic is designed to use `tree` to pinpoint the immediately surrounding
+           * Apply/TypeApply/Select node, and only then creates the dynamic call.
+           * See SI-6731 among others.
            */
           def findSelection(t: Tree): Option[(TermName, Tree)] = t match {
             case Apply(fn, args) if hasStar(args) => DynamicVarArgUnsupported(tree, applyOp(args)) ; None
@@ -4063,7 +4063,7 @@ trait Typers extends Adaptations with Tags {
       def typedAnnotated(atd: Annotated): Tree = {
         val ann = atd.annot
         val arg1 = typed(atd.arg, mode, pt)
-        /** mode for typing the annotation itself */
+        /* mode for typing the annotation itself */
         val annotMode = (mode &~ TYPEmode) | EXPRmode
 
         def resultingTypeTree(tpe: Type) = {
@@ -4339,8 +4339,8 @@ trait Typers extends Adaptations with Tags {
           else tpt0
         }
 
-        /** If current tree <tree> appears in <val x(: T)? = <tree>>
-         *  return `tp with x.type' else return `tp`.
+        /* If current tree <tree> appears in <val x(: T)? = <tree>>
+         * return `tp with x.type' else return `tp`.
          */
         def narrowRhs(tp: Type) = { val sym = context.tree.symbol
           context.tree match {
@@ -4409,8 +4409,8 @@ trait Typers extends Adaptations with Tags {
         }
       }
 
-      /** Try to apply function to arguments; if it does not work, try to convert Java raw to existentials, or try to
-       *  insert an implicit conversion.
+      /* Try to apply function to arguments; if it does not work, try to convert Java raw to existentials, or try to
+       * insert an implicit conversion.
        */
       def tryTypedApply(fun: Tree, args: List[Tree]): Tree = {
         val start = if (Statistics.canEnable) Statistics.startTimer(failedApplyNanos) else null
@@ -4646,8 +4646,8 @@ trait Typers extends Adaptations with Tags {
             if (isStableContext(tree, mode, pt)) tree setType clazz.thisType else tree
         }
 
-      /** Attribute a selection where `tree` is `qual.name`.
-       *  `qual` is already attributed.
+      /* Attribute a selection where `tree` is `qual.name`.
+       * `qual` is already attributed.
        */
       def typedSelect(tree: Tree, qual: Tree, name: Name): Tree = {
         val t = typedSelectInternal(tree, qual, name)
@@ -4803,7 +4803,7 @@ trait Typers extends Adaptations with Tags {
         }
       }
 
-      /** A symbol qualifies if:
+      /* A symbol qualifies if:
        *  - it exists
        *  - it is not stale (stale symbols are made to disappear here)
        *  - if we are in a pattern constructor, method definitions do not qualify
@@ -4815,12 +4815,12 @@ trait Typers extends Adaptations with Tags {
         && !(inPatternConstructor && sym.isMethod && !sym.isStable)
       )
 
-      /** Attribute an identifier consisting of a simple name or an outer reference.
+      /* Attribute an identifier consisting of a simple name or an outer reference.
        *
-       *  @param tree      The tree representing the identifier.
-       *  @param name      The name of the identifier.
-       *  Transformations: (1) Prefix class members with this.
-       *                   (2) Change imported symbols to selections
+       * @param tree      The tree representing the identifier.
+       * @param name      The name of the identifier.
+       * Transformations: (1) Prefix class members with this.
+       *                  (2) Change imported symbols to selections
        */
       def typedIdent(tree: Tree, name: Name): Tree = {
         // setting to enable unqualified idents in empty package (used by the repl)
@@ -4962,7 +4962,7 @@ trait Typers extends Adaptations with Tags {
         treeCopy.PackageDef(tree, pid1, stats1) setType NoType
       }
 
-      /**
+      /*
        * The typer with the correct context for a method definition. If the method is a default getter for
        * a constructor default, the resulting typer has a constructor context (fixes SI-5543).
        */

--- a/src/compiler/scala/tools/nsc/util/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/util/ClassPath.scala
@@ -29,7 +29,7 @@ object ClassPath {
   private def expandS(pattern: String): List[String] = {
     val wildSuffix = File.separator + "*"
 
-    /** Get all subdirectories, jars, zips out of a directory. */
+    /* Get all subdirectories, jars, zips out of a directory. */
     def lsDir(dir: Directory, filt: String => Boolean = _ => true) =
       dir.list filter (x => filt(x.name) && (x.isDirectory || isJarOrZip(x))) map (_.path) toList
 

--- a/src/compiler/scala/tools/nsc/util/ShowPickled.scala
+++ b/src/compiler/scala/tools/nsc/util/ShowPickled.scala
@@ -163,7 +163,7 @@ object ShowPickled extends Names {
         out.print(" %s[%s]".format(toHexString(pflags), flagString))
       }
 
-      /** Might be info or privateWithin */
+      /* Might be info or privateWithin */
       val x = buf.readNat()
       if (buf.readIndex == end) {
         printFlags(None)
@@ -175,9 +175,9 @@ object ShowPickled extends Names {
       }
     }
 
-    /** Note: the entries which require some semantic analysis to be correctly
-     *  interpreted are for the most part going to tell you the wrong thing.
-     *  It's not so easy to duplicate the logic applied in the UnPickler.
+    /* Note: the entries which require some semantic analysis to be correctly
+     * interpreted are for the most part going to tell you the wrong thing.
+     * It's not so easy to duplicate the logic applied in the UnPickler.
      */
     def printEntry(i: Int) {
       buf.readIndex = index(i)

--- a/src/continuations/plugin/scala/tools/selectivecps/SelectiveANFTransform.scala
+++ b/src/continuations/plugin/scala/tools/selectivecps/SelectiveANFTransform.scala
@@ -400,9 +400,9 @@ abstract class SelectiveANFTransform extends PluginComponent with Transform with
 
           try {
             val Some((a, b)) = cpsR
-            /** Since shiftUnit is bounded [A,B,C>:B] this may not typecheck
-             *  if C is overly specific.  So if !(B <:< C), call shiftUnit0
-             *  instead, which takes only two type arguments.
+            /* Since shiftUnit is bounded [A,B,C>:B] this may not typecheck
+             * if C is overly specific.  So if !(B <:< C), call shiftUnit0
+             * instead, which takes only two type arguments.
              */
             val conforms = a <:< b
             val call = localTyper.typedPos(tree.pos)(

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -555,7 +555,7 @@ trait Iterator[+A] extends TraversableOnce[A] {
   def span(p: A => Boolean): (Iterator[A], Iterator[A]) = {
     val self = buffered
 
-    /**
+    /*
      * Giving a name to following iterator (as opposed to trailing) because
      * anonymous class is represented as a structural type that trailing
      * iterator is referring (the finish() method) and thus triggering

--- a/src/library/scala/collection/SeqLike.scala
+++ b/src/library/scala/collection/SeqLike.scala
@@ -210,13 +210,13 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
       if (!hasNext)
         Iterator.empty.next()
 
-      /** Calculate this result. */
+      /* Calculate this result. */
       val buf = self.newBuilder
       for(k <- 0 until nums.length; j <- 0 until nums(k))
         buf += elms(offs(k)+j)
       val res = buf.result()
 
-      /** Prepare for the next call to next. */
+      /* Prepare for the next call to next. */
       var idx = nums.length - 1
       while (idx >= 0 && nums(idx) == cnts(idx))
         idx -= 1

--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -220,10 +220,10 @@ object NumericRange {
         if (!isInclusive && zero == remainder) 0 else 1
       )
 
-      /** The edge cases keep coming.  Since e.g.
-       *    Long.MaxValue + 1 == Long.MinValue
-       *  we do some more improbable seeming checks lest
-       *  overflow turn up as an empty range.
+      /* The edge cases keep coming.  Since e.g.
+       * Long.MaxValue + 1 == Long.MinValue
+       * we do some more improbable seeming checks lest
+       * overflow turn up as an empty range.
        */
       // The second condition contradicts an empty result.
       val isOverflow = longCount == 0 && num.lt(num.plus(start, step), end) == upward

--- a/src/library/scala/concurrent/SyncVar.scala
+++ b/src/library/scala/concurrent/SyncVar.scala
@@ -41,9 +41,9 @@ class SyncVar[A] {
    *  @return            `None` if variable is undefined after `timeout`, `Some(value)` otherwise
    */
   def get(timeout: Long): Option[A] = synchronized {
-    /** Defending against the system clock going backward
-     *  by counting time elapsed directly.  Loop required
-     *  to deal with spurious wakeups.
+    /* Defending against the system clock going backward
+     * by counting time elapsed directly.  Loop required
+     * to deal with spurious wakeups.
      */
     var rest = timeout
     while (!isDefined && rest > 0) {

--- a/src/library/scala/xml/parsing/MarkupParser.scala
+++ b/src/library/scala/xml/parsing/MarkupParser.scala
@@ -108,7 +108,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests
         val ilen = inpStack.length
         //Console.println("  ilen = "+ilen+ " extIndex = "+extIndex);
         if ((ilen != extIndex) && (ilen > 0)) {
-          /** for external source, inpStack == Nil ! need notify of eof! */
+          /* for external source, inpStack == Nil ! need notify of eof! */
           pop()
         } else {
           reachedEof = true
@@ -880,7 +880,7 @@ trait MarkupParser extends MarkupParserCommon with TokenTests
       externalID()
     }
     else if (ch == 'P') {
-      /** PublicID (without system, only used in NOTATION) */
+      /* PublicID (without system, only used in NOTATION) */
       nextch()
       xToken("UBLIC")
       xSpace()

--- a/src/partest/scala/tools/partest/nest/ConsoleRunner.scala
+++ b/src/partest/scala/tools/partest/nest/ConsoleRunner.scala
@@ -76,7 +76,7 @@ class ConsoleRunner extends DirectRunner {
     val parsed = CommandLineParser(argstr) withUnaryArgs unaryArgs withBinaryArgs binaryArgs
     val args   = onlyValidTestPaths(parsed.residualArgs)
 
-    /** Early return on no args, version, or invalid args */
+    /* Early return on no args, version, or invalid args */
     if (argstr == "") return NestUI.usage()
     if (parsed isSet "--version") return printVersion
     if (parsed isSet "--help") return NestUI.usage()

--- a/src/reflect/scala/reflect/internal/ClassfileConstants.scala
+++ b/src/reflect/scala/reflect/internal/ClassfileConstants.scala
@@ -350,7 +350,7 @@ object ClassfileConstants {
     }
     private def translateFlags(jflags: Int, baseFlags: Long): Long = {
       var res: Long = JAVA | baseFlags
-      /** fast, elegant, maintainable, pick any two... */
+      /* fast, elegant, maintainable, pick any two... */
       res |= translateFlag(jflags & JAVA_ACC_PRIVATE)
       res |= translateFlag(jflags & JAVA_ACC_PROTECTED)
       res |= translateFlag(jflags & JAVA_ACC_FINAL)

--- a/src/reflect/scala/reflect/internal/Mirrors.scala
+++ b/src/reflect/scala/reflect/internal/Mirrors.scala
@@ -197,8 +197,8 @@ trait Mirrors extends api.Mirrors {
     /************************ helpers ************************/
 
     def erasureName[T: ClassTag] : String = {
-      /** We'd like the String representation to be a valid
-       *  scala type, so we have to decode the jvm's secret language.
+      /* We'd like the String representation to be a valid
+       * scala type, so we have to decode the jvm's secret language.
        */
       def erasureString(clazz: Class[_]): String = {
         if (clazz.isArray) "Array[" + erasureString(clazz.getComponentType) + "]"

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2825,10 +2825,10 @@ trait Types
        *  See SI-5359.
        */
       val bounds  = tparam.info.bounds
-      /** We can seed the type constraint with the type parameter
-       *  bounds as long as the types are concrete.  This should lower
-       *  the complexity of the search even if it doesn't improve
-       *  any results.
+      /* We can seed the type constraint with the type parameter
+       * bounds as long as the types are concrete.  This should lower
+       * the complexity of the search even if it doesn't improve
+       * any results.
        */
       if (propagateParameterBoundsToTypeVars) {
         val exclude = bounds.isEmptyBounds || (bounds exists typeIsNonClassType)
@@ -3533,7 +3533,7 @@ trait Types
     if (args.isEmpty)
       return tycon //@M! `if (args.isEmpty) tycon' is crucial (otherwise we create new types in phases after typer and then they don't get adapted (??))
 
-    /** Disabled - causes cycles in tcpoly tests. */
+    /* Disabled - causes cycles in tcpoly tests. */
     if (false && isDefinitionsInitialized) {
       assert(isUseableAsTypeArgs(args), {
         val tapp_s = s"""$tycon[${args mkString ", "}]"""
@@ -4596,7 +4596,7 @@ object TypesStats {
   val singletonBaseTypeSeqCount = Statistics.newSubCounter("  of which for singletons", baseTypeSeqCount)
   val typeOpsStack = Statistics.newTimerStack()
 
-  /** Commented out, because right now this does not inline, so creates a closure which will distort statistics
+  /* Commented out, because right now this does not inline, so creates a closure which will distort statistics
   @inline final def timedTypeOp[T](c: Statistics.StackableTimer)(op: => T): T = {
     val start = Statistics.pushTimer(typeOpsStack, c)
     try op

--- a/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
+++ b/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
@@ -516,18 +516,18 @@ abstract class UnPickler {
       var mods: Modifiers = null
       var name: Name = null
 
-      /** Read a Symbol, Modifiers, and a Name */
+      /* Read a Symbol, Modifiers, and a Name */
       def setSymModsName() {
         symbol = readSymbolRef()
         mods = readModifiersRef()
         name = readNameRef()
       }
-      /** Read a Symbol and a Name */
+      /* Read a Symbol and a Name */
       def setSymName() {
         symbol = readSymbolRef()
         name = readNameRef()
       }
-      /** Read a Symbol */
+      /* Read a Symbol */
       def setSym() {
         symbol = readSymbolRef()
       }

--- a/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
@@ -396,11 +396,11 @@ trait TypeComparers {
     if (isSingleType(tp1) && isSingleType(tp2) || isConstantType(tp1) && isConstantType(tp2)) return tp1 =:= tp2
     if (tp1.isHigherKinded || tp2.isHigherKinded) return isHKSubType(tp1, tp2, depth)
 
-    /** First try, on the right:
-      *   - unwrap Annotated types, BoundedWildcardTypes,
-      *   - bind TypeVars  on the right, if lhs is not Annotated nor BoundedWildcard
-      *   - handle common cases for first-kind TypeRefs on both sides as a fast path.
-      */
+    /* First try, on the right:
+     *   - unwrap Annotated types, BoundedWildcardTypes,
+     *   - bind TypeVars  on the right, if lhs is not Annotated nor BoundedWildcard
+     *   - handle common cases for first-kind TypeRefs on both sides as a fast path.
+     */
     def firstTry = tp2 match {
       // fast path: two typerefs, none of them HK
       case tr2: TypeRef =>
@@ -445,11 +445,11 @@ trait TypeComparers {
         secondTry
     }
 
-    /** Second try, on the left:
-      *   - unwrap AnnotatedTypes, BoundedWildcardTypes,
-      *   - bind typevars,
-      *   - handle existential types by skolemization.
-      */
+    /* Second try, on the left:
+     *   - unwrap AnnotatedTypes, BoundedWildcardTypes,
+     *   - bind typevars,
+     *   - handle existential types by skolemization.
+     */
     def secondTry = tp1 match {
       case AnnotatedType(_, _, _) =>
         isSubType(tp1.withoutAnnotations, tp2.withoutAnnotations, depth) &&
@@ -487,11 +487,11 @@ trait TypeComparers {
       }
     }
 
-    /** Third try, on the right:
-      *   - decompose refined types.
-      *   - handle typerefs and existentials.
-      *   - handle left+right method types, polytypes, typebounds
-      */
+    /* Third try, on the right:
+     *   - decompose refined types.
+     *   - handle typerefs and existentials.
+     *   - handle left+right method types, polytypes, typebounds
+     */
     def thirdTry = tp2 match {
       case tr2: TypeRef =>
         thirdTryRef(tp1, tr2)
@@ -532,9 +532,9 @@ trait TypeComparers {
         fourthTry
     }
 
-    /** Fourth try, on the left:
-      *   - handle typerefs, refined types, and singleton types.
-      */
+    /* Fourth try, on the left:
+     *   - handle typerefs, refined types, and singleton types.
+     */
     def fourthTry = {
       def retry(lhs: Type, rhs: Type)  = isSubType(lhs, rhs, depth)
       def abstractTypeOnLeft(hi: Type) = isDifferentTypeConstructor(tp1, hi) && retry(hi, tp2)

--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -1033,7 +1033,7 @@ private[internal] trait TypeMaps {
           devWarning(s"$pre.$sym no longer exist at phase $phase")
           throw new MissingTypeControl // For build manager and presentation compiler purposes
         }
-        /** The two symbols have the same fully qualified name */
+        /* The two symbols have the same fully qualified name */
         def corresponds(sym1: Symbol, sym2: Symbol): Boolean =
           sym1.name == sym2.name && (sym1.isPackageClass || corresponds(sym1.owner, sym2.owner))
         if (!corresponds(sym.owner, rebind0.owner)) {

--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -60,7 +60,7 @@ private[reflect] trait JavaMirrors extends internal.SymbolTable with api.JavaUni
 
   /** The API of a mirror for a reflective universe */
   class JavaMirror(owner: Symbol,
-    /** Class loader that is a mastermind behind the reflexive mirror */
+    /* Class loader that is a mastermind behind the reflexive mirror */
     val classLoader: ClassLoader
   ) extends Roots(owner) with super.JavaMirror { thisMirror =>
 


### PR DESCRIPTION
Doc -> C-style comments for local symbols to avoid "discarding unmoored doc comment" warning when building distribution for scala itself.
