### PR TITLE
SI-7102 efficient isEmpty for bitsets

### DIFF
--- a/src/library/scala/collection/BitSetLike.scala
+++ b/src/library/scala/collection/BitSetLike.scala
@@ -70,6 +70,8 @@ trait BitSetLike[+This <: BitSetLike[This] with SortedSet[Int]] extends SortedSe
     s
   }
 
+  override def isEmpty: Boolean = 0 until nwords forall (i => word(i) == 0)
+
   implicit def ordering: Ordering[Int] = Ordering.Int
 
   def rangeImpl(from: Option[Int], until: Option[Int]): This = {

--- a/test/files/run/bitsets.scala
+++ b/test/files/run/bitsets.scala
@@ -37,6 +37,19 @@ object TestMutable {
   Console.println("mi1 = " + ms1.toImmutable)
   Console.println("mi2 = " + ms2.toImmutable)
   Console.println
+
+  val N = 257
+  val gen = 3
+  val bs = BitSet((1 until N): _*)
+  (1 until N).foldLeft(gen) {
+    case (acc, i) =>
+      assert(bs.size == N-i, s"Bad size for $bs, expected ${N-i} actual ${bs.size}")
+      assert(!bs.isEmpty, s"Unexpected isEmpty for $bs")
+      bs -= acc
+      acc*gen % N
+  }
+  assert(bs.size == 0, s"Expected size == 0 for $bs")
+  assert(bs.isEmpty, s"Expected isEmpty for $bs")
 }
 
 object TestMutable2 {


### PR DESCRIPTION
Override isEmpty for bitsets with a specialized implementation rather than use default checking for size == 0.
Target 2.10.x since the change is binary-compatible.
Review by @JamesIry.
