### PR TITLE
SI-7285 Fix match analysis with nested objects

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
@@ -574,6 +574,7 @@ trait ScalaLogic extends Interface with Logic with TreeAndTypeAnalysis {
         assert(tp.isInstanceOf[SingletonType])
         val toString = tp match {
           case ConstantType(c) => c.escapedStringValue
+          case _ if tp.typeSymbol.isModuleClass => tp.typeSymbol.name.toString
           case _ => tp.toString
         }
         Const.unique(tp, new ValueConst(tp, tp.widen, toString))

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -5036,10 +5036,11 @@ trait Types extends api.Types { self: SymbolTable =>
       if (tp.isTrivial) tp
       else if (tp.prefix.typeSymbol isNonBottomSubClass owner) {
         val widened = tp match {
-          case _: ConstantType => tp        // Java enum constants: don't widen to the enum type!
-          case _               => tp.widen  // C.X.type widens to C.this.X.type, otherwise `tp asSeenFrom (pre, C)` has no effect.
+          case _: ConstantType => tp // Java enum constants: don't widen to the enum type!
+          case _               => tp.widen // C.X.type widens to C.this.X.type, otherwise `tp asSeenFrom (pre, C)` has no effect.
         }
-        widened asSeenFrom (pre, tp.typeSymbol.owner)
+        val memType = widened asSeenFrom (pre, tp.typeSymbol.owner)
+        if (tp eq widened) memType else memType.narrow
       }
       else loop(tp.prefix) memberType tp.typeSymbol
 

--- a/test/files/neg/t7285.check
+++ b/test/files/neg/t7285.check
@@ -1,0 +1,13 @@
+t7285.scala:15: error: match may not be exhaustive.
+It would fail on the following input: (Up, Down)
+      (d1, d2) match {
+      ^
+t7285.scala:33: error: match may not be exhaustive.
+It would fail on the following input: Down
+      (d1) match {
+       ^
+t7285.scala:51: error: match may not be exhaustive.
+It would fail on the following input: (Up, Down)
+    (d1, d2) match {
+    ^
+three errors found

--- a/test/files/neg/t7285.flags
+++ b/test/files/neg/t7285.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/t7285.scala
+++ b/test/files/neg/t7285.scala
@@ -1,0 +1,55 @@
+sealed abstract class Base
+
+
+object Test1 {
+  sealed abstract class Base
+
+  object Base {
+    case object Down extends Base {
+    }
+
+    case object Up extends Base {
+    }
+
+    (d1: Base, d2: Base) =>
+      (d1, d2) match {
+        case (Up, Up) | (Down, Down) => false
+        case (Down, Up)              => true
+      }
+  }
+}
+
+object Test2 {
+  sealed abstract class Base
+
+  object Base {
+    case object Down extends Base {
+    }
+
+    case object Up extends Base {
+    }
+
+    (d1: Base, d2: Base) =>
+      (d1) match {
+        case Test2.Base.Up => false
+      }
+  }
+}
+
+
+object Test4 {
+  sealed abstract class Base
+
+  object Base {
+    case object Down extends Base
+
+    case object Up extends Base
+  }
+
+  import Test4.Base._
+  (d1: Base, d2: Base) =>
+    (d1, d2) match {
+      case (Up, Up) | (Down, Down) => false
+      case (Down, Test4.Base.Up)   => true
+    }
+}

--- a/test/files/pos/t7285a.flags
+++ b/test/files/pos/t7285a.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t7285a.scala
+++ b/test/files/pos/t7285a.scala
@@ -1,0 +1,83 @@
+sealed abstract class Base
+
+object Test {
+  case object Up extends Base
+
+  def foo(d1: Base) =
+    d1 match {
+      case Up  =>
+    }
+
+    // Sealed subtype: ModuleTypeRef   <empty>.this.Test.Up.type
+    // Pattern:        UniqueThisType  Test.this.type
+}
+
+
+object Test1 {
+  sealed abstract class Base
+
+  object Base {
+    case object Down extends Base {
+    }
+
+    case object Up extends Base {
+    }
+
+    (d1: Base, d2: Base) =>
+      (d1, d2) match {
+        case (Up, Up) | (Down, Down) => false
+        case (Down, Up)              => true
+        case (Up, Down)              => false
+      }
+  }
+}
+
+object Test2 {
+  sealed abstract class Base
+
+  object Base {
+    case object Down extends Base {
+    }
+
+    case object Up extends Base {
+    }
+
+    (d1: Base, d2: Base) =>
+      (d1) match {
+        case Up | Down => false
+      }
+  }
+}
+
+object Test3 {
+  sealed abstract class Base
+
+  object Base {
+    case object Down extends Base
+
+    (d1: Base, d2: Base) =>
+      (d1, d2) match {
+        case (Down, Down) => false
+      }
+  }
+}
+
+object Test4 {
+  sealed abstract class Base
+
+  object Base {
+    case object Down extends Base {
+    }
+
+    case object Up extends Base {
+    }
+
+  }
+  import Test4.Base._
+  (d1: Base, d2: Base) =>
+    (d1, d2) match {
+      case (Up, Up) | (Down, Down) => false
+      case (Down, Test4.Base.Up)   => true
+      case (Up, Down)              => false
+    }
+}

--- a/test/files/run/t6146b.check
+++ b/test/files/run/t6146b.check
@@ -43,10 +43,7 @@ mt1: u.Type = O.X.S1.type
 scala> global.typeDeconstruct.show(mt1)
 res0: String = 
 TypeRef(
-  pre = TypeRef(
-    pre = ThisType(object O)
-    TypeSymbol(class X extends AnyRef)
-  )
+  pre = SingleType(pre = ThisType(object O), object X)
   TypeSymbol(class S1 extends C.this.F[T])
 )
 

--- a/test/files/run/t6146b.check
+++ b/test/files/run/t6146b.check
@@ -37,8 +37,18 @@ memType: (sub: u.Type, scrut: u.Type)u.Type
 
 scala> 
 
-scala> memType(S1, fTpe)
-res0: u.Type = O.X.S1.type
+scala> val mt1 = memType(S1, fTpe)
+mt1: u.Type = O.X.S1.type
+
+scala> global.typeDeconstruct.show(mt1)
+res0: String = 
+TypeRef(
+  pre = TypeRef(
+    pre = ThisType(object O)
+    TypeSymbol(class X extends AnyRef)
+  )
+  TypeSymbol(class S1 extends C.this.F[T])
+)
 
 scala> memType(S2, fTpe)
 res1: u.Type = O.S2

--- a/test/files/run/t6146b.scala
+++ b/test/files/run/t6146b.scala
@@ -31,7 +31,8 @@ val fTpe = typeOf[O.type].decl(newTermName("foo")).paramss.head.head.tpe
 def memType(sub: Type, scrut: Type): Type =
   nestedMemberType(sub.typeSymbol, scrut.prefix, scrut.typeSymbol.owner)
 
-memType(S1, fTpe)
+val mt1 = memType(S1, fTpe)
+global.typeDeconstruct.show(mt1)
 memType(S2, fTpe)
 memType(S3, fTpe)
 memType(S4, fTpe)


### PR DESCRIPTION
The fix for SI-6146 introduced `nestedMemberType` to
figure out set of the sealed subtypes based on the
(prefixed) type of the scrutinee and the symbols of its
sealed subclasses. That method needed to widen
`ThisType(modSym)`s to `ModuleTypeRef(modSym)` before
calling `asSeenFrom`.

However, this could lead to the sealed subtypes being
`ModuleTypeRef`s were not =:= to the singleton type on the module.
The pattern matcher analysis treated them as distinct, and spurious
warnings ensued.

This commit makes two changes:
- conditionally re-narrow the result of `asSeenFrom` in `nestedMemberType`.
- present `a.b.SomeModule.type` as `SomeModule` in warnings emitted
  by the pattern matcher.

Review by @adriaanm
