### PR TITLE
SI-6210 Test case for already-fixed pattern matcher bug

### DIFF
--- a/test/files/pos/t6210.flags
+++ b/test/files/pos/t6210.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t6210.scala
+++ b/test/files/pos/t6210.scala
@@ -1,0 +1,21 @@
+abstract sealed trait AST
+abstract sealed trait AExpr                  extends AST
+case class AAssign(name: String, v: AExpr)   extends AExpr
+case class AConstBool(v: Boolean)            extends AExpr
+
+trait Ty {}
+case class TInt() extends Ty
+case class TBool() extends Ty
+
+object Foo {
+  def checkExpr(ast: AExpr): Ty = {
+    var astTy:Ty = ast match {
+      case AAssign(nm: String, v:AExpr) => TBool() 
+
+      case AConstBool(v: Boolean) => TBool() 
+
+      case _                          => throw new Exception(s"Unhandled case check(ast: ${ast.getClass})")
+    }
+    astTy
+  }
+}


### PR DESCRIPTION
The fix arrived in SI-6022 / #1100 / 2.10.0-M7.

Review by @adriaanm.

```
% RUNNER=scalac scala-hash v2.10.0-M7~26 -Xfatal-warnings test/files/pos/t6210.scala
[warn] v2.10.0-M7 failed, using closest available
[info] 07f942971a => /Users/jason/usr/scala-v2.10.0-M6-214-g07f9429
test/files/pos/t6210.scala:15: error: unreachable code
      case AConstBool(v: Boolean) => TBool()
                                          ^
one error found
% RUNNER=scalac scala-hash v2.10.0-M7~25 -Xfatal-warnings test/files/pos/t6210.scala
[info] v2.10.0-M7 => /Users/jason/usr/scala-v2.10.0-M6-219-gd1bdafa
```
