### PR TITLE
SI-7289 Discard ill-kinded type constraints during inference

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3131,17 +3131,25 @@ trait Types extends api.Types { self: SymbolTable =>
     }
 
     def addLoBound(tp: Type, isNumericBound: Boolean = false) {
-      assert(tp != this, tp) // implies there is a cycle somewhere (?)
-      //println("addLoBound: "+(safeToString, debugString(tp))) //DEBUG
-      undoLog record this
-      constr.addLoBound(tp, isNumericBound)
+      addBound(tp, isNumericBound, isHigh = false)
     }
 
     def addHiBound(tp: Type, isNumericBound: Boolean = false) {
-      // assert(tp != this)
-      //println("addHiBound: "+(safeToString, debugString(tp))) //DEBUG
-      undoLog record this
-      constr.addHiBound(tp, isNumericBound)
+      addBound(tp, isNumericBound, isHigh = true)
+    }
+
+    private def addBound(tp: Type, isNumericBound: Boolean, isHigh: Boolean) {
+      if (isHigherKinded && !tp.isHigherKinded) {
+        log(s"discarding non higher-kinded bound ${tp} for HK type variable $this")
+      } else {
+        // assert(tp != this)
+        //println("addBound: "+(safeToString, debugString(tp), isHigh)) //DEBUG
+        undoLog record this
+        if (isHigh)
+          constr.addHiBound(tp, isNumericBound)
+        else
+          constr.addLoBound(tp, isNumericBound)
+      }
     }
     // </region>
 

--- a/test/files/neg/t7289.check
+++ b/test/files/neg/t7289.check
@@ -1,0 +1,4 @@
+t7289.scala:8: error: could not find implicit value for parameter e: Test.Schtroumpf[scala.collection.immutable.Nil.type]
+  implicitly[Schtroumpf[Nil.type]]
+            ^
+one error found

--- a/test/files/neg/t7289.scala
+++ b/test/files/neg/t7289.scala
@@ -1,0 +1,39 @@
+object Test extends App {
+  trait Schtroumpf[T]
+
+  implicit def schtroumpf[T, U <: Coll[T], Coll[X] <: Traversable[X]]
+    (implicit minorSchtroumpf: Schtroumpf[T]): Schtroumpf[U] = ???
+
+  implicit val qoo: Schtroumpf[Int] = new Schtroumpf[Int]{}
+  implicitly[Schtroumpf[Nil.type]]
+}
+
+/*
+info1 = {scala.tools.nsc.typechecker.Implicits$ImplicitInfo@3468}"qoo: => Test.Schtroumpf[Int]"
+info2 = {scala.tools.nsc.typechecker.Implicits$ImplicitInfo@3469}"schtroumpf: [T, U <: Coll[T], Coll[_] <: Traversable[_]](implicit minorSchtroumpf: Test.Schtroumpf[T])Test.Schtroumpf[U]"
+isStrictlyMoreSpecific(info1, info2)
+  isSubType(Test.Schtroumpf[Int], Test.Schtroumpf[U] forSome { T; U <: Coll[T]; Coll[_] <: Traversable[_] })
+    isAsSpecificValueType(Test.Schtroumpf[Int], Test.Schtroumpf[U], undef2 = List(type T, type U, type Coll))
+
+      val et: ExistentialType = Test.Schtroumpf[U] forSome { T; U <: Coll[T]; Coll[_] <: Traversable[_] }
+      val tp1 = Test.Schtroumpf[Int]
+      et.withTypeVars(isSubType(tp1, _, depth))
+        solve()
+        tvars = tList(=?Nothing, =?Int, =?=?Int)
+
+
+[    create] ?T                       ( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]] )
+[    create] ?U                       ( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]] )
+[    create] ?Coll                    ( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]] )
+[   setInst] Nothing                  ( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]], T=Nothing )
+[   setInst] scala.collection.immutable.Nil.type( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]], U=scala.collection.immutable.Nil.type )
+[   setInst] =?scala.collection.immutable.Nil.type( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]], Coll==?scala.collection.immutable.Nil.type )
+[    create] ?T                       ( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]] )
+[   setInst] Int                      ( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]], T=Int )
+[    create] ?T                       ( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]] )
+[    create] ?U                       ( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]] )
+[    create] ?Coll                    ( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]] )
+[   setInst] Nothing                  ( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]], T=Nothing )
+[   setInst] Int                      ( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]], U=Int )
+[   setInst] =?Int                    ( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]], Coll==?Int )
+*/


### PR DESCRIPTION
Let's disect the reported test case.

Define the first implicit:

```
scala> trait Schtroumpf[T]
defined trait Schtroumpf

scala> implicit def schtroumpf[T, U <: Coll[T], Coll[X] <: Traversable[X]]
     |     (implicit minorSchtroumpf: Schtroumpf[T]): Schtroumpf[U] = ???
schtroumpf: [T, U <: Coll[T], Coll[X] <: Traversable[X]](implicit minorSchtroumpf: Schtroumpf[T])Schtroumpf[U]
```

Call it explicitly => kind error during type inference reported.

```
scala> schtroumpf(null): Schtroumpf[Int]
<console>:10: error: inferred kinds of the type arguments (Nothing,Int,Int) do not conform to the expected kinds of the type parameters (type T,type U,type Coll).
Int's type parameters do not match type Coll's expected parameters:
class Int has no type parameters, but type Coll has one
              schtroumpf(null): Schtroumpf[Int]
              ^
<console>:10: error: type mismatch;
 found   : Schtroumpf[U]
 required: Schtroumpf[Int]
              schtroumpf(null): Schtroumpf[Int]
                        ^
```

Add another implicit, and let implicit search weigh them up.

```
scala> implicitly[Schtroumpf[Int]]
<console>:10: error: diverging implicit expansion for type Schtroumpf[Int]
starting with method schtroumpf
              implicitly[Schtroumpf[Int]]
                        ^

scala> implicit val qoo = new Schtroumpf[Int]{}
qoo: Schtroumpf[Int] = $anon$1@c1b9b03

scala> implicitly[Schtroumpf[Int]]
<crash>
```

Implicit search compares the two in-scope implicits in `isStrictlyMoreSpecific`,
which constructs an existential type:

  type ET = Schtroumpf[U] forSome { type T; type U <: Coll[T]; type Coll[_] <: Traversable[_] }

A subsequent subtype check `ET <:< Schtroumpf[Int]` gets to `withTypeVars`, which
replaces the quantified types with type variables, checks conformance of that
substitued underlying type against `Schtroumpf[Int]`, and then tries to solve
the collected type constraints. The type var trace looks like:

```
[    create] ?T                       ( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]] )
[    create] ?U                       ( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]] )
[    create] ?Coll                    ( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]] )
[   setInst] Nothing                  ( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]], T=Nothing )
[   setInst] scala.collection.immutable.Nil.type( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]], U=scala.collection.immutable.Nil.type )
[   setInst] =?scala.collection.immutable.Nil.type( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]], Coll==?scala.collection.immutable.Nil.type )
[    create] ?T                       ( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]] )
[   setInst] Int                      ( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]], T=Int )
[    create] ?T                       ( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]] )
[    create] ?U                       ( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]] )
[    create] ?Coll                    ( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]] )
[   setInst] Nothing                  ( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]], T=Nothing )
[   setInst] Int                      ( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]], U=Int )
[   setInst] =?Int                    ( In Test#schtroumpf[T,U <: Coll[T],Coll[_] <: Traversable[_]], Coll==?Int )
```

The problematic part is when `?Int` (the type var originated from `U`) is registered
as a lower bound for `Coll`. That happens in `solveOne`:

```
for (tparam2 <- tparams)
  tparam2.info.bounds.hi.dealias match {
    case TypeRef(_, `tparam`, _) =>
      log(s"$tvar addLoBound $tparam2.tpeHK.instantiateTypeParams($tparams, $tvars)")
      tvar addLoBound tparam2.tpeHK.instantiateTypeParams(tparams, tvars)
    case _ =>
  }
```

This commit changes `addHiBound` and `addLoBound` to discard non higher-kinded
bounds for higher-kinded type variables.

Review by @adriaanm

This is more of a review request than a pull request, I think more test cases are needed, and would appreciate your ideas there.

This didn't crash prior to c800d1fec (implicit search failure was correctly reported), but I don't know exactly why.
