### PR TITLE
Correct sorting example for Ordering in scaladoc

### DIFF
--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -26,7 +26,7 @@ import scala.language.{implicitConversions, higherKinds}
   * val pairs = Array(("a", 5, 2), ("c", 3, 1), ("b", 1, 3))
   *
   * // sort by 2nd element
-  * Sorting.quickSort(pairs)(Ordering.by[(String, Int, Int), Int](_._2)
+  * Sorting.quickSort(pairs)(Ordering.by[(String, Int, Int), Int](_._2))
   *
   * // sort by the 3rd element, then 1st
   * Sorting.quickSort(pairs)(Ordering[(Int, String)].on(x => (x._3, x._1)))


### PR DESCRIPTION
### Sorting example for Ordering in scaladoc corrected

Ordering example code for

``` scala
Sorting.quickSort(pairs)(Ordering.by[(String, Int, Int), Int](_._2)
```

should be fixed like below    

``` scala
Sorting.quickSort(pairs)(Ordering.by[(String, Int, Int), Int](_._2))
```
