### PR TITLE
SI-7299 Improve error message for eta-expanding 23+ param method

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4461,6 +4461,12 @@ trait Typers extends Modes with Adaptations with Tags {
           treeCopy.New(tree, tpt1).setType(tp)
       }
 
+      def functionTypeWildcard(tree: Tree, arity: Int): Type = {
+        val tp = functionType(List.fill(arity)(WildcardType), WildcardType)
+        if (tp == NoType) MaxFunctionArityError(tree)
+        tp
+      }
+
       def typedEta(expr1: Tree): Tree = expr1.tpe match {
         case TypeRef(_, ByNameParamClass, _) =>
           val expr2 = Function(List(), expr1) setPos expr1.pos
@@ -4472,7 +4478,7 @@ trait Typers extends Modes with Adaptations with Tags {
           typed1(expr2, mode, pt)
         case PolyType(_, MethodType(formals, _)) =>
           if (isFunctionType(pt)) expr1
-          else adapt(expr1, mode, functionType(formals map (t => WildcardType), WildcardType))
+          else adapt(expr1, mode, functionTypeWildcard(expr1, formals.length))
         case MethodType(formals, _) =>
           if (isFunctionType(pt)) expr1
           else expr1 match {
@@ -4491,7 +4497,7 @@ trait Typers extends Modes with Adaptations with Tags {
               val rhs = Apply(f, args)
               typed(rhs)
             case _ =>
-              adapt(expr1, mode, functionType(formals map (t => WildcardType), WildcardType))
+              adapt(expr1, mode, functionTypeWildcard(expr1, formals.length))
           }
         case ErrorType =>
           expr1

--- a/test/files/neg/t7299.check
+++ b/test/files/neg/t7299.check
@@ -1,0 +1,7 @@
+t7299.scala:4: error: implementation restricts functions to 22 parameters
+   val eta1 = f _
+              ^
+t7299.scala:5: error: implementation restricts functions to 22 parameters
+   val eta2 = g[Any] _
+               ^
+two errors found

--- a/test/files/neg/t7299.scala
+++ b/test/files/neg/t7299.scala
@@ -1,0 +1,6 @@
+object Test {
+   def f(a1: Int, a2: Int, a3: Int, a4: Int, a5: Int, a6: Int, a7: Int, a8: Int, a9: Int, a10: Int, a11: Int, a12: Int, a13: Int, a14: Int, a15: Int, a16: Int, a17: Int, a18: Int, a19: Int, a20: Int, a21: Int, a22: Int, a23: Int) = 0
+   def g[A](a1: Int, a2: Int, a3: Int, a4: Int, a5: Int, a6: Int, a7: Int, a8: Int, a9: Int, a10: Int, a11: Int, a12: Int, a13: Int, a14: Int, a15: Int, a16: Int, a17: Int, a18: Int, a19: Int, a20: Int, a21: Int, a22: Int, a23: Int) = 0
+   val eta1 = f _
+   val eta2 = g[Any] _
+}


### PR DESCRIPTION
Before, we got `error: missing arguments for method f`.

Review by @szeiger
