### PR TITLE
SI-6815 Loosen definition of stability in stable ID patterns

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -238,10 +238,17 @@ trait Typers extends Modes with Adaptations with Tags {
      *  @return     ...
      */
     def checkStable(tree: Tree): Tree = (
-      if (treeInfo.isExprSafeToInline(tree)) tree
-      else if (tree.isErrorTyped) tree
+      if (isStableOrErrorTyped(tree)) tree
       else UnstableTreeError(tree)
     )
+
+    def checkStableOrStableExceptVolatile(tree: Tree): Tree = (
+      if (isStableOrErrorTyped(tree) || isStableExceptVolatile(tree)) tree
+      else UnstableTreeError(tree)
+    )
+
+    private def isStableOrErrorTyped(tree: Tree) =
+      treeInfo.isExprSafeToInline(tree) || tree.isErrorTyped
 
     /** Would tree be a stable (i.e. a pure expression) if the type
      *  of its symbol was not volatile?
@@ -639,7 +646,7 @@ trait Typers extends Modes with Adaptations with Tags {
       if (tree.isErrorTyped) tree
       else if ((mode & (PATTERNmode | FUNmode)) == PATTERNmode && tree.isTerm) { // (1)
         if (sym.isValue) {
-          val tree1 = checkStable(tree)
+          val tree1 = checkStableOrStableExceptVolatile(tree) // SI-6815 volatile return type is okay, we're only calling ==, not selecting a type.
           // A module reference in a pattern has type Foo.type, not "object Foo"
           if (sym.isModule && !sym.isMethod) tree1 setType singleType(pre, sym)
           else tree1

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -965,7 +965,7 @@ trait Trees extends api.Trees { self: SymbolTable =>
 
   def ValDef(sym: Symbol): ValDef = ValDef(sym, EmptyTree)
 
-  object emptyValDef extends ValDef(Modifiers(PRIVATE), nme.WILDCARD, TypeTree(NoType), EmptyTree) {
+  final object emptyValDef extends ValDef(Modifiers(PRIVATE), nme.WILDCARD, TypeTree(NoType), EmptyTree) {
     override def isEmpty = true
     super.setPos(NoPosition)
     override def setPos(pos: Position) = { assert(false); this }

--- a/test/files/neg/t6815.check
+++ b/test/files/neg/t6815.check
@@ -1,0 +1,5 @@
+t6815.scala:15: error: stable identifier required, but Test.this.u.emptyValDef found.
+ Note that value emptyValDef is not stable because its type, Test.u.ValDef, is volatile.
+    case _: u.emptyValDef.T => // and, unlike in pos/t6185.scala, we shouldn't allow this.
+              ^
+one error found

--- a/test/files/neg/t6815.scala
+++ b/test/files/neg/t6815.scala
@@ -1,0 +1,17 @@
+trait U {
+  trait ValOrDefDefApi {
+    def name: Any
+  }
+  type ValOrDefDef <: ValOrDefDefApi
+  type ValDef <: ValOrDefDef with ValDefApi { type T }
+  trait ValDefApi extends ValOrDefDefApi { this: ValDef => }
+  val emptyValDef: ValDef // the result type is volatile
+}
+
+object Test {
+  val u: U = ???
+
+  (null: Any) match {
+    case _: u.emptyValDef.T => // and, unlike in pos/t6185.scala, we shouldn't allow this.
+  }
+}

--- a/test/files/pos/t6815.scala
+++ b/test/files/pos/t6815.scala
@@ -1,0 +1,17 @@
+trait U {
+  trait ValOrDefDefApi {
+    def name: Any
+  }
+  type ValOrDefDef <: ValOrDefDefApi
+  type ValDef <: ValOrDefDef with ValDefApi
+  trait ValDefApi extends ValOrDefDefApi { this: ValDef => }
+  val emptyValDef: ValDef // the result type is volatile
+}
+
+object Test {
+  val u: U = ???
+
+  u.emptyValDef match {
+    case u.emptyValDef => // but we shouldn't let that stop us from treating it as a stable identifier pattern.
+  }
+}


### PR DESCRIPTION
Before, a stable identifier pattern was vetted by `isStable`,
which delegates to `isExprSafeToInline`. This requires that
the result type of the expression is non-volatile.

But, according to @adriaanm, while "it's unsound to select
types on a prefix with a volatile type", it "should be fine
to compare it for equality."

The infrastructure to perform the looser check was already
in place for reporting stability errors; this commit employs
it when checking stability of patterns.

The enclosed `neg` test shows that this doesn't overreach:
type selections are still disallowed.

Review by @adriaanm
