### PR TITLE
Improve testing interactive experience.

### DIFF
--- a/src/interactive/scala/tools/nsc/interactive/tests/InteractiveTest.scala
+++ b/src/interactive/scala/tools/nsc/interactive/tests/InteractiveTest.scala
@@ -74,7 +74,7 @@ abstract class InteractiveTest
   /** Test's entry point */
   def main(args: Array[String]) {
     try execute()
-    finally shutdown()
+    finally askShutdown()
   }
 
   protected def execute(): Unit = {
@@ -110,14 +110,4 @@ abstract class InteractiveTest
     tester.run()
   }
   ****/
-
-  /** shutdown the presentation compiler. */
-  protected def shutdown() {
-    askShutdown()
-
-    // this is actually needed to force exit on test completion.
-    // Note: May be a bug on either the testing framework or (less likely)
-    //           the presentation compiler
-    sys.exit(0)
-  }
 }

--- a/src/interactive/scala/tools/nsc/interactive/tests/core/SourcesCollector.scala
+++ b/src/interactive/scala/tools/nsc/interactive/tests/core/SourcesCollector.scala
@@ -11,7 +11,7 @@ private[tests] object SourcesCollector {
    * With the default `filter` only .scala and .java files are collected.
    * */
   def apply(base: Path, filter: SourceFilter): Array[SourceFile] = {
-    assert(base.isDirectory)
+    assert(base.isDirectory, base + " is not a directory")
     base.walk.filter(filter).map(source).toList.toArray.sortBy(_.file.name)
   }
 

--- a/test/files/presentation/doc/doc.scala
+++ b/test/files/presentation/doc/doc.scala
@@ -127,16 +127,17 @@ object Test extends InteractiveTest {
     val baseSource = findSource("Base.scala")
     val derivedSource = findSource("Derived.scala")
     def existsText(where: Any, text: String): Boolean = where match {
-      case `text` => true
+      case s: String => s contains text
       case s: Seq[_] => s exists (existsText(_, text))
       case p: Product => p.productIterator exists (existsText(_, text))
+      case c: Comment => existsText(c.body, text)
     }
     val (derived, base) = compiler.ask { () =>
       val derived = definitions.RootPackage.info.decl(newTermName("p")).info.decl(newTypeName("Derived"))
       (derived, derived.ancestors(0))
     }
     val cmt1 = getComment(derived, derivedSource, (base, baseSource)::(derived, derivedSource)::Nil)
-    if (!existsText(cmt1, "Derived comment."))
+    if (!existsText(cmt1, "This is Derived comment"))
       println("Unexpected Derived class comment:"+cmt1)
 
     val (fooDerived, fooBase) = compiler.ask { () =>
@@ -145,7 +146,7 @@ object Test extends InteractiveTest {
     }
 
     val cmt2 = getComment(fooDerived, derivedSource, (fooBase, baseSource)::(fooDerived, derivedSource)::Nil)
-    if (!existsText(cmt2, "Base method has documentation."))
+    if (!existsText(cmt2, "Base method has documentation"))
       println("Unexpected foo method comment:"+cmt2)
   }
 }

--- a/test/files/presentation/doc/src/p/Base.scala
+++ b/test/files/presentation/doc/src/p/Base.scala
@@ -1,7 +1,7 @@
 package p
 
 /**
- * @define BaseComment $BaseVar comment.
+ * @define BaseComment This is $BaseVar comment.
  */
 trait Base {
   /**


### PR DESCRIPTION
Currently the exceptions that happen in the test are swallowed, as
the JVM is forced to exit before printing the stack trace.
Also assert message doesn't contain information about the problem.

The call to "sys.exit" masks bugs in the testing framework, that
has to be addressed more elaborately, so here we remove it. Also
add the message parameter to assert to make it more informative.

After removing "sys.exit" call, doc test starts failing. I suspect
there might be a problem when expanding doc variables, but this
should be addressed separately.
