### PR TITLE
[forward-port] SI-7232 Fix Java import vs defn. binding precendence

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -530,7 +530,13 @@ trait Namers extends MethodSynthesis {
           // Setting the position at the import means that if there is
           // more than one hidden name, the second will not be warned.
           // So it is the position of the actual hidden name.
-          checkNotRedundant(tree.pos withPoint fromPos, from, to)
+          //
+          // Note: java imports have precence over definitions in the same package
+          //       so don't warn for them. There is a corresponding special treatment
+          //       in the shadowing rules in typedIdent to (SI-7232). In any case,
+          //       we shouldn't be emitting warnings for .java source files.
+          if (!context.unit.isJava)
+            checkNotRedundant(tree.pos withPoint fromPos, from, to)
         }
       }
 

--- a/test/files/pos/t7232.flags
+++ b/test/files/pos/t7232.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t7232/Foo.java
+++ b/test/files/pos/t7232/Foo.java
@@ -1,0 +1,9 @@
+package pack;
+
+import java.util.List;
+
+public class Foo {
+	public static java.util.List okay() { throw new Error(); }
+
+	public static List wrong() { throw new Error(); }
+}

--- a/test/files/pos/t7232/List.java
+++ b/test/files/pos/t7232/List.java
@@ -1,0 +1,4 @@
+package pack;
+
+public class List {
+}

--- a/test/files/pos/t7232/Test.scala
+++ b/test/files/pos/t7232/Test.scala
@@ -1,0 +1,5 @@
+object Test {
+  import pack._
+  Foo.okay().size()
+  Foo.wrong().size()
+}

--- a/test/files/pos/t7232b.flags
+++ b/test/files/pos/t7232b.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t7232b/Foo.java
+++ b/test/files/pos/t7232b/Foo.java
@@ -1,0 +1,8 @@
+package pack;
+
+import java.util.*;
+
+public class Foo {
+	// should be pack.List.
+	public static List list() { throw new Error(); }
+}

--- a/test/files/pos/t7232b/List.java
+++ b/test/files/pos/t7232b/List.java
@@ -1,0 +1,5 @@
+package pack;
+
+public class List {
+	public void packList() {}
+}

--- a/test/files/pos/t7232b/Test.scala
+++ b/test/files/pos/t7232b/Test.scala
@@ -1,0 +1,5 @@
+object Test {
+  import pack._
+
+  Foo.list().packList()
+}

--- a/test/files/pos/t7232c.flags
+++ b/test/files/pos/t7232c.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t7232c/Foo.java
+++ b/test/files/pos/t7232c/Foo.java
@@ -1,0 +1,10 @@
+package pack;
+
+import java.util.List;
+
+public class Foo {
+    public static class List {
+        public void isInnerList() {}
+    }
+	public static List innerList() { throw new Error(); }
+}

--- a/test/files/pos/t7232c/Test.scala
+++ b/test/files/pos/t7232c/Test.scala
@@ -1,0 +1,4 @@
+object Test {
+  import pack._
+  Foo.innerList().isInnerList()
+}

--- a/test/files/pos/t7232d.flags
+++ b/test/files/pos/t7232d.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t7232d/Entry.java
+++ b/test/files/pos/t7232d/Entry.java
@@ -1,0 +1,4 @@
+package pack;
+
+public class Entry {
+}

--- a/test/files/pos/t7232d/Foo.java
+++ b/test/files/pos/t7232d/Foo.java
@@ -1,0 +1,8 @@
+package pack;
+
+import java.util.Map.Entry;
+
+public class Foo {
+	public static Entry mapEntry() { throw new Error(); }
+	public static void javaTest() { mapEntry().getKey(); }
+}

--- a/test/files/pos/t7232d/Test.scala
+++ b/test/files/pos/t7232d/Test.scala
@@ -1,0 +1,4 @@
+object Test {
+  import pack._
+  Foo.mapEntry().getKey()
+}


### PR DESCRIPTION
Java Spec:

> A single-type-import declaration d in a compilation unit c
> of package p that imports a type named n shadows, throughout
> c, the declarations of:
> - any top level type named n declared in another compilation
>   unit of p
> - any type named n imported by a type-import-on-demand
>   declaration in c
> - any type named n imported by a static-import-on-demand
>   declaration in c

Scala Spec:

> Bindings of different kinds have a precedence deﬁned on them:
> 1. Deﬁnitions and declarations that are local, inherited, or made
>     available by a package clause in the same compilation unit where
>     the deﬁnition occurs have highest precedence.
> 2. Explicit imports have next highest precedence.

**This is a forward port of 6e79370, which did not merge cleanly
and was omitted in the regular merge from 2.10.x to master.**

Conflicts:
    src/compiler/scala/tools/nsc/typechecker/Typers.scala

Review by @adriaanm
