### PR TITLE
[forward port] SI-7259 Fix detection of Java defined Selects

### DIFF
--- a/test/files/neg/t7259.check
+++ b/test/files/neg/t7259.check
@@ -1,0 +1,7 @@
+t7259.scala:1: error: not found: type xxxxx
+@xxxxx // error: not found: type xxxx
+ ^
+t7259.scala:8: error: type xxxxx is not a member of package annotation
+@annotation.xxxxx // error: not found: type scala
+            ^
+two errors found

--- a/test/files/neg/t7259.scala
+++ b/test/files/neg/t7259.scala
@@ -1,0 +1,9 @@
+@xxxxx // error: not found: type xxxx
+class Ok
+
+//
+// This had the wrong error message in 2.9 and 2.10.
+//
+
+@annotation.xxxxx // error: not found: type scala
+class WrongErrorMessage

--- a/test/files/pos/t3120/J1.java
+++ b/test/files/pos/t3120/J1.java
@@ -1,0 +1,4 @@
+class J1 {
+    public class Inner1 { }
+    public static class Inner2 { }
+}

--- a/test/files/pos/t3120/J2.java
+++ b/test/files/pos/t3120/J2.java
@@ -1,0 +1,4 @@
+public class J2 {
+    public void f1(J1.Inner1 p) { }
+    public void f2(J1.Inner2 p) { }
+}

--- a/test/files/pos/t3120/Q.java
+++ b/test/files/pos/t3120/Q.java
@@ -1,0 +1,3 @@
+public class Q {
+    public static void passInner(J1.Inner1 myInner) {}
+}

--- a/test/files/pos/t3120/Test.scala
+++ b/test/files/pos/t3120/Test.scala
@@ -1,0 +1,3 @@
+object Test {
+  Q.passInner(null)
+}


### PR DESCRIPTION
The fix for SI-3120, 3ff7743, introduced a fallback within
`typedSelect` that accounted for the ambiguity of a Java
selection syntax. Does `A.B` refer to a member of the type `A`
or of the companion object `A`? (The companion object here is a
fiction used by scalac to group the static members of a Java
class.)

The fallback in `typedSelect` was predicated on
`context.owner.enclosingTopLevelClass.isJavaDefined`.
However, this was incorrectly including Select-s in top-level
annotations in Scala files, which are owned by the enclosing
package class, which is considered to be Java defined. This
led to nonsensical error messages ("type scala not found.")

Instead, this commit checks the compilation unit of the context,
which is more direct and correct. (As I learned recently,
`currentUnit.isJavaDefined` would _not_ be correct, as a lazy type
might complete a Java signature while compiling some other compilation
unit!)

A bonus post factum test case is included for SI-3120.

**Manual forward port of f046853 which was not merged as
part of the routine 2.10.x to master merge.** The test case
uncovered a NullPointerExceptiion crasher in annotation
typechecking introduced in 5878099c; this has been prevented
with a null check.

Conflicts:
    src/compiler/scala/tools/nsc/typechecker/Typers.scala

Review by @adriaanm
