### PR TITLE
Scaladoc: Load scripts at the bottom, and with a defer attribute

### DIFF
--- a/src/compiler/scala/tools/nsc/doc/html/page/Index.scala
+++ b/src/compiler/scala/tools/nsc/doc/html/page/Index.scala
@@ -27,12 +27,18 @@ class Index(universe: doc.Universe, val index: doc.Index) extends HtmlPage {
   val headers =
     <xml:group>
       <link href={ relativeLinkTo{List("index.css", "lib")} }  media="screen" type="text/css" rel="stylesheet"/>
-      <script type="text/javascript" src={ relativeLinkTo{List("jquery.js", "lib")} }></script>
-      <script type="text/javascript" src={ relativeLinkTo{List("jquery-ui.js", "lib")} }></script>
-      <script type="text/javascript" src={ relativeLinkTo{List("jquery.layout.js", "lib")} }></script>
-      <script type="text/javascript" src={ relativeLinkTo{List("index.js", "lib")} }></script>
-      <script type="text/javascript" src={ relativeLinkTo{List("scheduler.js", "lib")} }></script>
     </xml:group>
+
+  private val scripts = {
+    val sources =
+      (List("jquery.js", "jquery-ui.js", "jquery.layout.js", "scheduler.js", "index.js").map {
+        x => relativeLinkTo(List(x, "lib"))
+      }) :+ "index.js"
+
+    sources map {
+      src => <script defer="defer" type="text/javascript" src={src}></script>
+    }
+  }
 
   val body =
     <body>
@@ -46,6 +52,7 @@ class Index(universe: doc.Universe, val index: doc.Index) extends HtmlPage {
       <div id="content" class="ui-layout-center">
         <iframe id="template" name="template" src={ relativeLinkTo{List("package.html")} }/>
       </div>
+      { scripts }
     </body>
 
   def letters: NodeSeq =
@@ -125,7 +132,7 @@ class Index(universe: doc.Universe, val index: doc.Index) extends HtmlPage {
           </xml:group>
         }
         packageElem(universe.rootPackage)
-      }</div></div><script src="index.js"></script>
+      }</div></div>
     </div>
 
   def packageQualifiedName(ety: DocTemplateEntity): String =

--- a/src/compiler/scala/tools/nsc/doc/html/page/Template.scala
+++ b/src/compiler/scala/tools/nsc/doc/html/page/Template.scala
@@ -40,14 +40,6 @@ class Template(universe: doc.Universe, generator: DiagramGenerator, tpl: DocTemp
     <xml:group>
       <link href={ relativeLinkTo{List("template.css", "lib")} } media="screen" type="text/css" rel="stylesheet"/>
       <link href={ relativeLinkTo{List("diagrams.css", "lib")} } media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
-      <script type="text/javascript" src={ relativeLinkTo{List("jquery.js", "lib")} } id="jquery-js"></script>
-      <script type="text/javascript" src={ relativeLinkTo{List("jquery-ui.js", "lib")} }></script>
-      <script type="text/javascript" src={ relativeLinkTo{List("template.js", "lib")} }></script>
-      <script type="text/javascript" src={ relativeLinkTo{List("tools.tooltip.js", "lib")} }></script>
-      { if (universe.settings.docDiagrams.value) {
-      <script type="text/javascript" src={ relativeLinkTo{List("modernizr.custom.js", "lib")} }></script>
-      <script type="text/javascript" src={ relativeLinkTo{List("diagrams.js", "lib")} } id="diagrams-js"></script>
-      } else NodeSeq.Empty }
       <script type="text/javascript">
          if(top === self) {{
             var url = '{ val p = templateToPath(tpl); "../" * (p.size - 1) + "index.html" }';
@@ -60,6 +52,22 @@ class Template(universe: doc.Universe, generator: DiagramGenerator, tpl: DocTemp
          }}
    	  </script>
     </xml:group>
+
+  private val scripts = {
+    val sources = {
+      val default = List("jquery.js", "jquery-ui.js", "tools.tooltip.js", "template.js")
+      val forDiagrams = List("modernizr.custom.js", "diagrams.js")
+
+      (default ++ (if (universe.settings.docDiagrams.value) forDiagrams else Nil)) map {
+        x => x.replace('.', '-') -> relativeLinkTo(List(x, "lib"))
+      }
+    }
+
+    sources map {
+      case (id, src) =>
+        <script defer="defer" type="text/javascript" id={id} src={src}></script>
+    }
+  }
 
   val valueMembers =
     tpl.methods ++ tpl.values ++ tpl.templates.filter(x => x.isObject || x.isPackage) sorted
@@ -280,8 +288,7 @@ class Template(universe: doc.Universe, generator: DiagramGenerator, tpl: DocTemp
         else
           <div id="footer"> { tpl.universe.settings.docfooter.value } </div>
       }
-
-
+      { scripts }
     </body>
   }
 

--- a/test/scaladoc/scalacheck/IndexTest.scala
+++ b/test/scaladoc/scalacheck/IndexTest.scala
@@ -71,14 +71,7 @@ object Test extends Properties("Index") {
       case None => false
     }
   }
-  property("browser contants a script element") = {
-    createIndex("src/compiler/scala/tools/nsc/doc/html/page/Index.scala") match {
-      case Some(index) =>
-        (index.browser \ "script").size == 1
 
-      case None => false
-    }
-  }
   property("package objects in index") = {
     createIndex("test/scaladoc/resources/SI-5558.scala") match {
       case Some(index) =>


### PR DESCRIPTION
To improve latency on modern browsers (which supports defer) and old browsers:
- https://www.webkit.org/blog/1395/running-scripts-in-webkit/
- http://developer.yahoo.com/blogs/ydn/posts/2007/07/high_performanc_5/
