### PR TITLE
SI-7302 importing from Any.

### DIFF
--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -244,8 +244,8 @@ trait Definitions extends api.StandardDefinitions {
          (sym eq NoSymbol)
       || sym.isConstructor
       || sym.isPrivateLocal
-      || isUniversalMember(sym)
     )
+    def isUnimportableUnlessRenamed(sym: Symbol) = isUnimportable(sym) || isUniversalMember(sym)
     def isImportable(sym: Symbol) = !isUnimportable(sym)
 
     /** Is this type equivalent to Any, AnyVal, or AnyRef? */


### PR DESCRIPTION
Turns out the "minor tweaks" in 632daed4ed were only minor
for major values of minor. You can indeed import members from
Any/Object, so long as you rename them. Reverted logic error.
Test case will accompany SI-7233 upon merge into master.
