### PR TITLE
Optimize file metadata access

### DIFF
--- a/src/reflect/scala/reflect/io/AbstractFile.scala
+++ b/src/reflect/scala/reflect/io/AbstractFile.scala
@@ -11,6 +11,7 @@ import java.io.{ FileOutputStream, IOException, InputStream, OutputStream, Buffe
 import java.io.{ File => JFile }
 import java.net.URL
 import scala.collection.mutable.ArrayBuffer
+import scala.reflect.internal.util.Statistics
 
 /**
  * An abstraction over files for use in the reflection/compiler libraries.
@@ -112,7 +113,10 @@ abstract class AbstractFile extends Iterable[AbstractFile] {
   def underlyingSource: Option[AbstractFile] = None
 
   /** Does this abstract file denote an existing file? */
-  def exists: Boolean = (file eq null) || file.exists
+  def exists: Boolean = {
+    if (Statistics.canEnable) Statistics.incCounter(IOStats.fileExistsCount)
+    (file eq null) || file.exists
+  }
 
   /** Does this abstract file represent something which can contain classfiles? */
   def isClassContainer = isDirectory || (file != null && (extension == "jar" || extension == "zip"))

--- a/src/reflect/scala/reflect/io/IOStats.scala
+++ b/src/reflect/scala/reflect/io/IOStats.scala
@@ -1,0 +1,31 @@
+package scala.reflect.io
+
+import scala.reflect.internal.util.Statistics
+
+// Due to limitations in the Statistics machinery, these are only
+// reported if this patch is applied.
+//
+// --- a/src/reflect/scala/reflect/internal/util/Statistics.scala
+// +++ b/src/reflect/scala/reflect/internal/util/Statistics.scala
+// @@ -109,7 +109,7 @@ quant)
+//     *  Quantities with non-empty prefix are printed in the statistics info.
+//     */
+//    trait Quantity {
+// -    if (enabled && prefix.nonEmpty) {
+// +    if (prefix.nonEmpty) {
+//        val key = s"${if (underlying != this) underlying.prefix else ""}/$prefix"
+//        qs(key) = this
+//      }
+// @@ -243,7 +243,7 @@ quant)
+//     *
+//     *  to remove all Statistics code from build
+//     */
+// -  final val canEnable = _enabled
+// +  final val canEnable = true // _enabled
+//
+// We can commit this change as the first diff reverts a fix for an IDE memory leak.
+private[io] object IOStats {
+  val fileExistsCount      = Statistics.newCounter("# File.exists calls")
+  val fileIsDirectoryCount = Statistics.newCounter("# File.isDirectory calls")
+  val fileIsFileCount      = Statistics.newCounter("# File.isFile calls")
+}

--- a/src/reflect/scala/reflect/io/Path.scala
+++ b/src/reflect/scala/reflect/io/Path.scala
@@ -13,6 +13,7 @@ import java.io.{ File => JFile }
 import java.net.{ URI, URL }
 import scala.util.Random.alphanumeric
 import scala.language.implicitConversions
+import scala.reflect.internal.util.Statistics
 
 /** An abstraction for filesystem paths.  The differences between
  *  Path, File, and Directory are primarily to communicate intent.
@@ -57,8 +58,18 @@ object Path {
 
   def apply(path: String): Path = apply(new JFile(path))
   def apply(jfile: JFile): Path = try {
-    if (jfile.isFile) new File(jfile)
-    else if (jfile.isDirectory) new Directory(jfile)
+    def isFile = {
+      if (Statistics.canEnable) Statistics.incCounter(IOStats.fileIsFileCount)
+      jfile.isFile
+    }
+
+    def isDirectory = {
+      if (Statistics.canEnable) Statistics.incCounter(IOStats.fileIsDirectoryCount)
+      jfile.isDirectory
+    }
+
+    if (isFile) new File(jfile)
+    else if (isDirectory) new Directory(jfile)
     else new Path(jfile)
   } catch { case ex: SecurityException => new Path(jfile) }
 
@@ -187,10 +198,19 @@ class Path private[io] (val jfile: JFile) {
   // Boolean tests
   def canRead = jfile.canRead()
   def canWrite = jfile.canWrite()
-  def exists = try jfile.exists() catch { case ex: SecurityException => false }
+  def exists = {
+    if (Statistics.canEnable) Statistics.incCounter(IOStats.fileExistsCount)
+    try jfile.exists() catch { case ex: SecurityException => false }
+  }
 
-  def isFile = try jfile.isFile() catch { case ex: SecurityException => false }
-  def isDirectory = try jfile.isDirectory() catch { case ex: SecurityException => false }
+  def isFile = {
+    if (Statistics.canEnable) Statistics.incCounter(IOStats.fileIsFileCount)
+    try jfile.isFile() catch { case ex: SecurityException => false }
+  }
+  def isDirectory = {
+    if (Statistics.canEnable) Statistics.incCounter(IOStats.fileIsDirectoryCount)
+    try jfile.isDirectory() catch { case ex: SecurityException => false }
+  }
   def isAbsolute = jfile.isAbsolute()
   def isEmpty = path.length == 0
 

--- a/src/reflect/scala/reflect/io/PlainFile.scala
+++ b/src/reflect/scala/reflect/io/PlainFile.scala
@@ -56,8 +56,14 @@ class PlainFile(val givenPath: Path) extends AbstractFile {
 
   /** Returns all abstract subfiles of this abstract directory. */
   def iterator: Iterator[AbstractFile] = {
+    // Optimization: Assume that the file was not deleted and did not have permissions changed
+    // between the call to `list` and the iteration. This saves a call to `exists`.
+    def existsFast(path: Path) = path match {
+      case (_: Directory | _: io.File) => true
+      case _                           => path.exists
+    }
     if (!isDirectory) Iterator.empty
-    else givenPath.toDirectory.list filter (_.exists) map (new PlainFile(_))
+    else givenPath.toDirectory.list filter existsFast map (new PlainFile(_))
   }
 
   /**


### PR DESCRIPTION
Background: When profiling an application that was using the interpreter to compile
a script, a lot of time was reported in `exists`/`isDirectory`/`isFile`. I happened to be profiling on Windows. 

Turns out some of these calls are redundant, this PR eliminate two such places.

Here's an example of how it helps:

Taking a Hello, Akka! application, and compiling it with the compiler
and library on a directory classpath (ie, using build/quick):

```
class HelloActor extends Actor {
  def receive = {
    case "hello" => println("hello back at you")
    case _       => println("huh?")
  }
}

object Main extends App {
  val system = ActorSystem("HelloSystem")
  // default Actor constructor
  val helloActor = system.actorOf(Props[HelloActor], name = "helloactor")
  helloActor ! "hello"
  helloActor ! "buenos dias"
}

% qbin/scalac -Ystatistics -classpath ~/.ivy2/cache/com.typesafe.akka/akka-actor_2.10/jars/akka-actor_2.10-2.1.1.jar:/Users/jason/.ivy2/cache/com.typesafe/config/bundles/config-1.0.0.jar sandbox/test.scala 2>&1 | grep File
```

```
Before
----------------------------------
File.isFile calls           : 7620
File.isDirectory calls      : 8348
File.exists calls           : 5770

After
----------------------------------
File.isFile calls           : 7620
File.isDirectory calls      : 2319
File.exists calls           : 345
```
