### PR TITLE
SI-7312 @deprecatedInheritance now ignores same-file subclasses

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1738,14 +1738,16 @@ trait Typers extends Adaptations with Tags {
           if (psym.isFinal)
             pending += ParentFinalInheritanceError(parent, psym)
 
-          if (psym.hasDeprecatedInheritanceAnnotation) {
+          val sameSourceFile = context.unit.source.file == psym.sourceFile
+
+          if (psym.hasDeprecatedInheritanceAnnotation && !sameSourceFile) {
             val suffix = psym.deprecatedInheritanceMessage map (": " + _) getOrElse ""
             val msg = s"inheritance from ${psym.fullLocationString} is deprecated$suffix"
             unit.deprecationWarning(parent.pos, msg)
           }
 
           if (psym.isSealed && !phase.erasedTypes)
-            if (context.unit.source.file == psym.sourceFile)
+            if (sameSourceFile)
               psym addChild context.owner
             else
               pending += ParentSealedInheritanceError(parent, psym)

--- a/src/library/scala/deprecatedInheritance.scala
+++ b/src/library/scala/deprecatedInheritance.scala
@@ -11,7 +11,8 @@ package scala
 /** An annotation that designates that inheriting from a class is deprecated.
  *
  *  This is usually done to warn about a non-final class being made final in a future version.
- *  Sub-classing such a class then generates a warning.
+ *  Sub-classing such a class then generates a warning. No warnings are generated if the
+ *  subclass is in the same compilation unit.
  *
  *  @param  message the message to print during compilation if the class was sub-classed
  *  @param  since   a string identifying the first version in which inheritance was deprecated

--- a/test/files/neg/t6162-inheritance.check
+++ b/test/files/neg/t6162-inheritance.check
@@ -1,16 +1,16 @@
-t6162-inheritance.scala:6: warning: inheritance from class Foo in package t6126 is deprecated: `Foo` will be made final in a future version.
+usage.scala:3: warning: inheritance from class Foo in package t6126 is deprecated: `Foo` will be made final in a future version.
 class SubFoo extends Foo
                      ^
-t6162-inheritance.scala:11: warning: inheritance from trait T in package t6126 is deprecated
+usage.scala:5: warning: inheritance from trait T in package t6126 is deprecated
 object SubT extends T
                     ^
-t6162-inheritance.scala:17: warning: inheritance from trait S in package t6126 is deprecated
+usage.scala:8: warning: inheritance from trait S in package t6126 is deprecated
   new S {
       ^
-t6162-inheritance.scala:6: warning: inheritance from class Foo in package t6126 is deprecated: `Foo` will be made final in a future version.
+usage.scala:3: warning: inheritance from class Foo in package t6126 is deprecated: `Foo` will be made final in a future version.
 class SubFoo extends Foo
              ^
-t6162-inheritance.scala:11: warning: inheritance from trait T in package t6126 is deprecated
+usage.scala:5: warning: inheritance from trait T in package t6126 is deprecated
 object SubT extends T
             ^
 error: No warnings can be incurred under -Xfatal-warnings.

--- a/test/files/neg/t6162-inheritance/defn.scala
+++ b/test/files/neg/t6162-inheritance/defn.scala
@@ -3,17 +3,8 @@ package scala.t6126
 @deprecatedInheritance("`Foo` will be made final in a future version.", "2.10.0")
 class Foo
 
-class SubFoo extends Foo
-
 @deprecatedInheritance()
 trait T
 
-object SubT extends T
-
 @deprecatedInheritance()
 trait S
-
-object O {
-  new S {
-  }
-}

--- a/test/files/neg/t6162-inheritance/usage.scala
+++ b/test/files/neg/t6162-inheritance/usage.scala
@@ -1,0 +1,10 @@
+package scala.t6126
+
+class SubFoo extends Foo
+
+object SubT extends T
+
+object O {
+  new S {
+  }
+}

--- a/test/files/pos/t6162-inheritance.flags
+++ b/test/files/pos/t6162-inheritance.flags
@@ -1,0 +1,1 @@
+-deprecation -Xfatal-warnings

--- a/test/files/pos/t6162-inheritance.scala
+++ b/test/files/pos/t6162-inheritance.scala
@@ -1,0 +1,22 @@
+package scala.t6126
+
+// Don't warn about inheritance in the same file.
+// We might use that as a prelude to sealing a class.
+
+@deprecatedInheritance("`Foo` will be made final in a future version.", "2.10.0")
+class Foo
+
+class SubFoo extends Foo
+
+@deprecatedInheritance()
+trait T
+
+object SubT extends T
+
+@deprecatedInheritance()
+trait S
+
+object O {
+  new S {
+  }
+}

--- a/test/files/pos/t7315.flags
+++ b/test/files/pos/t7315.flags
@@ -1,0 +1,1 @@
+-deprecation -Xfatal-warnings

--- a/test/files/pos/t7315.scala
+++ b/test/files/pos/t7315.scala
@@ -1,0 +1,4 @@
+package scala.pack
+
+@deprecatedInheritance
+class C[@specialized A]


### PR DESCRIPTION
This allows us to deprecate external inheritances as a prelude
to sealing a class, without enduring the warnings ourselved in
interlude.

The `neg` test from SI-6162 has been split into a pos test (subclasses in the same compilation unit), and a neg test (subclasses in a different compilation unit.)

This will also silence these recently introduced spurious warnings (SI-7315):

```
qbin/scalac -deprecation src/library/scala/Tuple*.scala
src/library/scala/Tuple1.scala:19: warning: inheritance from class Tuple1 in package scala is deprecated: Tuples will be made final in a future version.
case class Tuple1[@specialized(Int, Long, Double) +T1](_1: T1)
```

Review by @JamesIry.
