### PR TITLE
SI-7314 Partest locates tools.jar and javac

### DIFF
--- a/src/partest/scala/tools/partest/nest/RunnerManager.scala
+++ b/src/partest/scala/tools/partest/nest/RunnerManager.scala
@@ -74,8 +74,10 @@ object Output {
 
 class RunnerManager(kind: String, val fileManager: FileManager, params: TestRunParams) {
   import fileManager._
+
   fileManager.CLASSPATH += File.pathSeparator + PathSettings.scalaCheck
   fileManager.CLASSPATH += File.pathSeparator + PathSettings.diffUtils // needed to put diffutils on test/partest's classpath
+  PathSettings.platformTools foreach (fileManager.CLASSPATH += File.pathSeparator + _)
 
   def runTest(testFile: File): TestState = {
     val runner = new Runner(testFile, fileManager) {

--- a/test/partest
+++ b/test/partest
@@ -75,6 +75,22 @@ if [ -z "$EXT_CLASSPATH" ] ; then
     fi
 fi
 
+# Locate a javac command
+# Try: JAVA_HOME, sibling to specific JAVACMD, or PATH
+# Don't fail if there is no javac, since not all tests require it.
+if [ -z "$JAVAC_CMD" ] ; then
+    if [ -n "${JAVA_HOME}" ] && [ -f "${JAVA_HOME}/bin/javac" ] ; then
+        JAVAC_CMD="${JAVA_HOME}/bin/javac"
+    fi
+    if [ -z "$JAVAC_CMD" ] && [ -n "$JAVACMD" ] ; then
+        JDIR=`dirname "${JAVACMD}"`
+        JAVAC_CMD="${JDIR}/javac"
+    fi
+    if [ -z "$JAVAC_CMD" ] ; then
+        JAVAC_CMD=`type -p javac`
+    fi
+fi
+
 if $cygwin; then
     if [ "$OS" = "Windows_NT" ] && cygpath -m .>/dev/null 2>/dev/null ; then
         format=mixed
@@ -87,6 +103,9 @@ if $cygwin; then
     if [ -n "${JAVACMD}" ] ; then
         JAVACMD=`cygpath --$format "$JAVACMD"`
     fi
+    if [ -n "${JAVAC_CMD}" ] ; then
+        JAVAC_CMD=`cygpath --$format "$JAVAC_CMD"`
+    fi
     SCALA_HOME=`cygpath --$format "$SCALA_HOME"`
     EXT_CLASSPATH=`cygpath --path --$format "$EXT_CLASSPATH"`
 fi
@@ -97,8 +116,8 @@ fi
 JAVA_OPTS="-Xmx1024M -Xms64M -XX:MaxPermSize=128M $JAVA_OPTS"
 
 # the ant task doesn't supply any options by default,
-# so don't to that here either -- note that you may want to pass -optimise
-# to mimic what happens during nightlies
+# so don't do that here either -- note that you may want to pass -optimise
+# to mimic what happens during nightlies.
 # [ -n "$SCALAC_OPTS" ] || SCALAC_OPTS="-deprecation"
 
 partestDebugStr=""
@@ -114,5 +133,5 @@ fi
   -Dpartest.javacmd="${JAVACMD}" \
   -Dpartest.java_opts="${JAVA_OPTS}" \
   -Dpartest.scalac_opts="${SCALAC_OPTS}" \
-  -Dpartest.javac_cmd="${JAVA_HOME}/bin/javac" \
+  -Dpartest.javac_cmd="${JAVAC_CMD}" \
   scala.tools.partest.nest.NestRunner "$@"


### PR DESCRIPTION
This commit lets partest locate tools.jar the way REPL does, with
the addition that java.home.parent is also tried.

The partest script will use JAVAC_CMD if set, or else JAVA_HOME, and
will try the sibling of JAVACMD if set (on the theory that if you specify
java, you are avoiding the path lookup and javac may also be in
that special place), or else query the path for javac.

The use cases are: no env vars, look around java.home; JDK or JAVA_HOME is
set; JAVACMD is set; and finally tools.jar can live in jre/lib/ext and
the fallback deep search will find it.

These cases have been tried on cygwin with Java installed under
s"Program${space}Files", which is usually the most brittle environment.
That means tested with bash.

The windows partest.bat has not been upgraded or side-graded.

Review by @paulp because he doesn't have enough to do already, plus he's a pretty snazzy shell scripter
