### PR TITLE
SI-6937 core type tags are no longer referentially unique

### DIFF
--- a/src/reflect/scala/reflect/api/TypeTags.scala
+++ b/src/reflect/scala/reflect/api/TypeTags.scala
@@ -221,24 +221,7 @@ trait TypeTags { self: Universe =>
 
 
     def apply[T](mirror1: scala.reflect.api.Mirror[self.type], tpec1: TypeCreator): WeakTypeTag[T] =
-      tpec1(mirror1) match {
-        case ByteTpe    => WeakTypeTag.Byte.asInstanceOf[WeakTypeTag[T]]
-        case ShortTpe   => WeakTypeTag.Short.asInstanceOf[WeakTypeTag[T]]
-        case CharTpe    => WeakTypeTag.Char.asInstanceOf[WeakTypeTag[T]]
-        case IntTpe     => WeakTypeTag.Int.asInstanceOf[WeakTypeTag[T]]
-        case LongTpe    => WeakTypeTag.Long.asInstanceOf[WeakTypeTag[T]]
-        case FloatTpe   => WeakTypeTag.Float.asInstanceOf[WeakTypeTag[T]]
-        case DoubleTpe  => WeakTypeTag.Double.asInstanceOf[WeakTypeTag[T]]
-        case BooleanTpe => WeakTypeTag.Boolean.asInstanceOf[WeakTypeTag[T]]
-        case UnitTpe    => WeakTypeTag.Unit.asInstanceOf[WeakTypeTag[T]]
-        case AnyTpe     => WeakTypeTag.Any.asInstanceOf[WeakTypeTag[T]]
-        case AnyValTpe  => WeakTypeTag.AnyVal.asInstanceOf[WeakTypeTag[T]]
-        case AnyRefTpe  => WeakTypeTag.AnyRef.asInstanceOf[WeakTypeTag[T]]
-        case ObjectTpe  => WeakTypeTag.Object.asInstanceOf[WeakTypeTag[T]]
-        case NothingTpe => WeakTypeTag.Nothing.asInstanceOf[WeakTypeTag[T]]
-        case NullTpe    => WeakTypeTag.Null.asInstanceOf[WeakTypeTag[T]]
-        case _          => new WeakTypeTagImpl[T](mirror1.asInstanceOf[Mirror], tpec1)
-      }
+      new WeakTypeTagImpl[T](mirror1.asInstanceOf[Mirror], tpec1)
 
     def unapply[T](ttag: WeakTypeTag[T]): Option[Type] = Some(ttag.tpe)
   }
@@ -299,24 +282,7 @@ trait TypeTags { self: Universe =>
     val Null:    TypeTag[scala.Null]       = new PredefTypeTag[scala.Null]       (NullTpe,    _.TypeTag.Null)
 
     def apply[T](mirror1: scala.reflect.api.Mirror[self.type], tpec1: TypeCreator): TypeTag[T] =
-      tpec1(mirror1) match {
-        case ByteTpe    => TypeTag.Byte.asInstanceOf[TypeTag[T]]
-        case ShortTpe   => TypeTag.Short.asInstanceOf[TypeTag[T]]
-        case CharTpe    => TypeTag.Char.asInstanceOf[TypeTag[T]]
-        case IntTpe     => TypeTag.Int.asInstanceOf[TypeTag[T]]
-        case LongTpe    => TypeTag.Long.asInstanceOf[TypeTag[T]]
-        case FloatTpe   => TypeTag.Float.asInstanceOf[TypeTag[T]]
-        case DoubleTpe  => TypeTag.Double.asInstanceOf[TypeTag[T]]
-        case BooleanTpe => TypeTag.Boolean.asInstanceOf[TypeTag[T]]
-        case UnitTpe    => TypeTag.Unit.asInstanceOf[TypeTag[T]]
-        case AnyTpe     => TypeTag.Any.asInstanceOf[TypeTag[T]]
-        case AnyValTpe  => TypeTag.AnyVal.asInstanceOf[TypeTag[T]]
-        case AnyRefTpe  => TypeTag.AnyRef.asInstanceOf[TypeTag[T]]
-        case ObjectTpe  => TypeTag.Object.asInstanceOf[TypeTag[T]]
-        case NothingTpe => TypeTag.Nothing.asInstanceOf[TypeTag[T]]
-        case NullTpe    => TypeTag.Null.asInstanceOf[TypeTag[T]]
-        case _          => new TypeTagImpl[T](mirror1.asInstanceOf[Mirror], tpec1)
-      }
+      new TypeTagImpl[T](mirror1.asInstanceOf[Mirror], tpec1)
 
     def unapply[T](ttag: TypeTag[T]): Option[Type] = Some(ttag.tpe)
   }

--- a/test/files/run/macro-expand-nullary-generic.check
+++ b/test/files/run/macro-expand-nullary-generic.check
@@ -1,6 +1,6 @@
-it works TypeTag[Int]
-it works TypeTag[Int]
-it works TypeTag[Int]
-it works TypeTag[Int]
-it works TypeTag[Int]
+it works WeakTypeTag[Int]
+it works WeakTypeTag[Int]
+it works WeakTypeTag[Int]
+it works WeakTypeTag[Int]
+it works WeakTypeTag[Int]
 kkthxbai

--- a/test/files/run/macro-expand-tparams-explicit.check
+++ b/test/files/run/macro-expand-tparams-explicit.check
@@ -1,1 +1,1 @@
-TypeTag[Int]
+WeakTypeTag[Int]

--- a/test/files/run/macro-expand-tparams-implicit.check
+++ b/test/files/run/macro-expand-tparams-implicit.check
@@ -1,2 +1,2 @@
-TypeTag[Int]
+WeakTypeTag[Int]
 WeakTypeTag[String]

--- a/test/files/run/macro-expand-tparams-prefix-a.check
+++ b/test/files/run/macro-expand-tparams-prefix-a.check
@@ -1,4 +1,4 @@
-TypeTag[Int]
-TypeTag[Int]
+WeakTypeTag[Int]
+WeakTypeTag[Int]
 WeakTypeTag[String]
-TypeTag[Boolean]
+WeakTypeTag[Boolean]

--- a/test/files/run/macro-expand-tparams-prefix-b.check
+++ b/test/files/run/macro-expand-tparams-prefix-b.check
@@ -1,2 +1,2 @@
-TypeTag[Boolean] TypeTag[Int]
-TypeTag[Boolean] WeakTypeTag[String]
+WeakTypeTag[Boolean] WeakTypeTag[Int]
+WeakTypeTag[Boolean] WeakTypeTag[String]

--- a/test/files/run/macro-expand-tparams-prefix-c1.check
+++ b/test/files/run/macro-expand-tparams-prefix-c1.check
@@ -1,3 +1,3 @@
-TypeTag[Int]
+WeakTypeTag[Int]
 WeakTypeTag[String]
-TypeTag[Boolean]
+WeakTypeTag[Boolean]

--- a/test/files/run/macro-expand-tparams-prefix-c2.check
+++ b/test/files/run/macro-expand-tparams-prefix-c2.check
@@ -1,3 +1,3 @@
-TypeTag[Int]
+WeakTypeTag[Int]
 WeakTypeTag[String]
-TypeTag[Boolean]
+WeakTypeTag[Boolean]

--- a/test/files/run/macro-expand-tparams-prefix-d1.check
+++ b/test/files/run/macro-expand-tparams-prefix-d1.check
@@ -1,3 +1,3 @@
 WeakTypeTag[T]
 WeakTypeTag[U]
-TypeTag[Boolean]
+WeakTypeTag[Boolean]

--- a/test/files/run/macro-undetparams-consfromsls.check
+++ b/test/files/run/macro-undetparams-consfromsls.check
@@ -1,5 +1,5 @@
-A = TypeTag[Int]
-B = TypeTag[Nothing]
+A = WeakTypeTag[Int]
+B = WeakTypeTag[Nothing]
 List(1)
-A = TypeTag[Any]
+A = WeakTypeTag[Any]
 List(abc, 1)

--- a/test/files/run/macro-undetparams-macroitself.check
+++ b/test/files/run/macro-undetparams-macroitself.check
@@ -1,2 +1,2 @@
-TypeTag[Int]
+WeakTypeTag[Int]
 WeakTypeTag[String]

--- a/test/files/run/t6937.check
+++ b/test/files/run/t6937.check
@@ -1,0 +1,26 @@
+Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> 
+
+scala>     import scala.reflect.runtime.{universe => ru}
+import scala.reflect.runtime.{universe=>ru}
+
+scala>     import scala.reflect.runtime.{currentMirror => cm}
+import scala.reflect.runtime.{currentMirror=>cm}
+
+scala>     import scala.reflect.api.{Universe => ApiUniverse}
+import scala.reflect.api.{Universe=>ApiUniverse}
+
+scala>     class A
+defined class A
+
+scala>     lazy val apiru = ru: ApiUniverse
+apiru: scala.reflect.api.Universe = <lazy>
+
+scala>     apiru.typeTag[A].in(cm)
+res0: reflect.runtime.universe.TypeTag[A] = TypeTag[A]
+
+scala> 
+
+scala> 

--- a/test/files/run/t6937.scala
+++ b/test/files/run/t6937.scala
@@ -1,0 +1,12 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  def code = """
+    import scala.reflect.runtime.{universe => ru}
+    import scala.reflect.runtime.{currentMirror => cm}
+    import scala.reflect.api.{Universe => ApiUniverse}
+    class A
+    lazy val apiru = ru: ApiUniverse
+    apiru.typeTag[A].in(cm)
+  """
+}


### PR DESCRIPTION
Type tag factory used to evaluate the provided type creator in the
context of the initial mirror in order to maintain referential equality
of instances of standard tags. Unfortunately this evaluation might fail
if the mirror provided doesn't contain the classes being referred to.
Therefore I think we should avoid evaluating type creators there.

Note that failure of evaluation doesn't mean that there's something
bad going on. When one creates a type tag, the correct mirror /
classloader to interpret that tag in might be unknown (like it happens
here). This is okay, and this is exactly what the 2.10.0-M4 refactoring
has addressed.

Something like `res2.typeTag[A].in(currentMirror)` should be okay.
