### PR TITLE
SI-7330 better error when pattern's not a value

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -286,6 +286,24 @@ trait TypeDiagnostics {
     )
   }
 
+  def typePatternAdvice(sym: Symbol, ptSym: Symbol) = {
+    val clazz = if (sym.isModuleClass) sym.companionClass else sym
+    val caseString =
+      if (clazz.isCaseClass && (clazz isSubClass ptSym))
+        ( clazz.caseFieldAccessors
+          map (_ => "_")    // could use the actual param names here
+          mkString (s"`case ${clazz.name}(", ",", ")`")
+        )
+      else
+        "`case _: " + (clazz.typeParams match {
+          case Nil  => "" + clazz.name
+          case xs   => xs map (_ => "_") mkString (clazz.name + "[", ",", "]")
+        })+ "`"
+
+    "\nNote: if you intended to match against the class, try "+ caseString
+
+  }
+
   case class TypeDiag(tp: Type, sym: Symbol) extends Ordered[TypeDiag] {
     // save the name because it will be mutated until it has been
     // distinguished from the other types in the same error message

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5697,7 +5697,10 @@ trait Typers extends Modes with Adaptations with Tags {
       // as a compromise, context.enrichmentEnabled tells adaptToMember to go ahead and enrich,
       // but arbitrary conversions (in adapt) are disabled
       // TODO: can we achieve the pattern matching bit of the string interpolation SIP without this?
-      typingInPattern(context.withImplicitsDisabledAllowEnrichment(typed(tree, PATTERNmode, pt)))
+      typingInPattern(context.withImplicitsDisabledAllowEnrichment(typed(tree, PATTERNmode, pt))) match {
+        case tpt if tpt.isType => PatternMustBeValue(tpt, pt); tpt
+        case pat => pat
+      }
     }
 
     /** Types a (fully parameterized) type tree */

--- a/test/files/neg/t414.check
+++ b/test/files/neg/t414.check
@@ -1,7 +1,7 @@
 t414.scala:5: error: pattern type is incompatible with expected type;
  found   : Empty.type
  required: IntMap[a]
-Note: if you intended to match against the class, try `case _: Empty[_]` or `case Empty()`
+Note: if you intended to match against the class, try `case Empty()`
                 case Empty =>
                      ^
 t414.scala:7: error: type mismatch;

--- a/test/files/neg/t4879.check
+++ b/test/files/neg/t4879.check
@@ -1,13 +1,13 @@
 t4879.scala:6: error: pattern type is incompatible with expected type;
  found   : C.type
  required: C
-Note: if you intended to match against the class, try `case _: C` or `case C(_)`
+Note: if you intended to match against the class, try `case C(_)`
     case C  => true
          ^
 t4879.scala:10: error: pattern type is incompatible with expected type;
  found   : D.type
  required: D[T,U,V]
-Note: if you intended to match against the class, try `case _: D[_,_,_]` or `case D(_,_,_)`
+Note: if you intended to match against the class, try `case D(_,_,_)`
     case D  => true
          ^
 two errors found

--- a/test/files/neg/t7330.check
+++ b/test/files/neg/t7330.check
@@ -1,0 +1,5 @@
+t7330.scala:4: error: pattern must be a value: Y[_]
+Note: if you intended to match against the class, try `case _: Y[_]`
+  0 match { case Y[_] => }
+                  ^
+one error found

--- a/test/files/neg/t7330.scala
+++ b/test/files/neg/t7330.scala
@@ -1,0 +1,5 @@
+class Y[T]
+class Test {
+  // TypeTree is not a valid tree for a pattern
+  0 match { case Y[_] => }
+}


### PR DESCRIPTION
Somehow an applied type managed to sneak past the type checker in pattern mode.
Patterns must be values, though.

`case C[_] =>` was probably meant to be `case _: C[_] =>`
Advice is dispensed accordingly. (Generalizing the existing advice machinery.)

review by @retronym
