### PR TITLE
SI-7080 improve boundary value checking for BitSet

### DIFF
--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -12,7 +12,7 @@ package scala.collection
 package mutable
 
 import generic._
-import BitSetLike.{LogWL, updateArray}
+import BitSetLike.{LogWL, MaxSize, updateArray}
 
 /** A class for mutable bitsets.
  *
@@ -63,9 +63,10 @@ class BitSet(protected var elems: Array[Long]) extends AbstractSet[Int]
   }
 
   private def ensureCapacity(idx: Int) {
+    require(idx < MaxSize)
     if (idx >= nwords) {
       var newlen = nwords
-      while (idx >= newlen) newlen = newlen * 2
+      while (idx >= newlen) newlen = (newlen * 2) min MaxSize
       val elems1 = new Array[Long](newlen)
       Array.copy(elems, 0, elems1, 0, nwords)
       elems = elems1

--- a/test/files/run/bitsets.check
+++ b/test/files/run/bitsets.check
@@ -42,6 +42,10 @@ b2:BitSet(5)
 b3:BitSet(5, 7)
 b4:BitSet(7)
 b0:BitSet(5, 6, 7)
+bMax:BitSet(2147483647)
+2147483647
+bLarge:BitSet(2000000001)
+false
 is0 = BitSet()
 is1 = BitSet()
 is2 = BitSet(2)

--- a/test/files/run/bitsets.scala
+++ b/test/files/run/bitsets.scala
@@ -115,6 +115,19 @@ object TestMutable3 {
   println(s"b0:$b0")
 }
 
+object TestMutable4 {
+  import scala.collection.mutable.BitSet
+
+  val bMax = BitSet(Int.MaxValue)
+  println(s"bMax:$bMax")
+  bMax.foreach(println)
+
+  val bLarge = BitSet(2000000001)
+  println(s"bLarge:$bLarge")
+
+  println(bMax == bLarge)
+}
+
 object TestImmutable {
   import scala.collection.immutable.BitSet
 
@@ -190,6 +203,7 @@ object Test extends App {
   TestMutable
   TestMutable2
   TestMutable3
+  TestMutable4
   TestImmutable
   TestImmutable2
 }


### PR DESCRIPTION
When BitSet accepts a very large integer such as Integer.MAX_VALUE,
integer overflow possibly occurs in the calculation of boundary value
"nwords \* WordLength". This faulty boundary condition causes
empty-iterator problem like following:

scala> import collection.mutable.BitSet
import collection.mutable.BitSet

scala> val x = BitSet(Integer.MAX_VALUE)
x: scala.collection.mutable.BitSet = BitSet()

scala> x.iterator
res0: Iterator[Int] = empty iterator
