### PR TITLE
SI-7337 Error out on missing -d directory.

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -251,8 +251,7 @@ class MutableSettings(val errorFn: String => Unit)
       else if (allowJar && dir == null && Jar.isJarOrZip(name, examineFile = false))
         new PlainFile(Path(name))
       else
-//      throw new FatalError(name + " does not exist or is not a directory")
-        dir
+        throw new FatalError(name + " does not exist or is not a directory")
     )
 
     /** Set the single output directory. From now on, all files will

--- a/test/files/run/t7337.check
+++ b/test/files/run/t7337.check
@@ -1,0 +1,1 @@
+doesnotexist does not exist or is not a directory

--- a/test/files/run/t7337.scala
+++ b/test/files/run/t7337.scala
@@ -1,0 +1,19 @@
+import scala.tools.partest._
+import scala.tools.nsc._
+import util.{CommandLineParser}
+
+object Test extends DirectTest {
+  override def code = "class C"
+  override def newCompiler(args: String*): Global = {
+    val settings = newSettings((CommandLineParser tokenize ("-d doesnotexist " + extraSettings)) ++ args.toList)
+    newCompiler(settings)
+  }
+
+  override def show() {
+    try {
+      newCompiler()
+    } catch {
+      case fe: FatalError => println(fe.getMessage)
+    }
+  }
+}


### PR DESCRIPTION
This check was removed without comment in 3a30af154, the addition
of JSR-223 support for the interpreter.

After this commit, I manually tested that JSR-223 support works.

```
scala> import javax.script._, collection.JavaConverters._; val manager = new ScriptEngineManager; manager.getEngineByName("scala").eval("List(1)")
import javax.script._
import collection.JavaConverters._
manager: javax.script.ScriptEngineManager = javax.script.ScriptEngineManager@4418f61b
res1: Object = List(1)
```

3a30af154 did not include a test case, so I don't know whether I've
broken some other aspect of it. I tried the above as a `run` test,
but hit two problems, one of them seemingly our fault, and the other
a MacOS JDK wrinkle.
1. scala.reflect.internal.MissingRequirementError: object scala.runtime in compiler mirror not found.
2. java.lang.UnsatisfiedLinkError: no AppleScriptEngine in java.library.path

I can't find my way to fix these, so JSR-223 remains untested. I don't
think that #2238 was really up to standard; it could handle additional
review, documentation, and testing. It might even be modularized so as
not to pollute the REPL itself.

Review by @paulp
