### PR TITLE
SI-4695, package object separate compilation.

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -410,6 +410,14 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
 
   lazy val loaders = new SymbolLoaders {
     val global: Global.this.type = Global.this
+
+    override protected def enterIfNew(owner: Symbol, member: Symbol, completer: SymbolLoader): Symbol = {
+      owner.info.decls.lookup(member.name) andAlso { existing =>
+        log(s"Unlinking early-load symbol $existing.")
+        owner.info.decls unlink existing
+      }
+      super.enterIfNew(owner, member, completer)
+    }
   }
 
   /** Returns the mirror that loaded given symbol */
@@ -1207,6 +1215,21 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
   def newUnitScanner(code: String)     = new syntaxAnalyzer.UnitScanner(newCompilationUnit(code))
   def newCompilationUnit(code: String) = new CompilationUnit(newSourceFile(code))
   def newSourceFile(code: String)      = new BatchSourceFile("<console>", code)
+
+  override def missingHook(owner: Symbol, name: Name): Symbol = {
+    currentRun.units foreach { unit =>
+      for (PackageDef(pid, stats) <- unit.body) {
+        if (owner.fullName.toString == pid.toString) {
+          loaders.enterToplevelsFromSource(owner, name.toString, unit.source.file)
+          val member = owner.info decl name
+          member.associatedFile = unit.source.file
+          log(s"Early load of source symbol for $member with file ${member.associatedFile}")
+          return member
+        }
+      }
+    }
+    super.missingHook(owner, name)
+  }
 
   /** A Run is a single execution of the compiler on a sets of units
    */

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -289,15 +289,24 @@ abstract class SymbolTable extends macros.Universe
 
   /** if there's a `package` member object in `pkgClass`, enter its members into it. */
   def openPackageModule(pkgClass: Symbol) {
-
     val pkgModule = pkgClass.info.decl(nme.PACKAGEkw)
-    def fromSource = pkgModule.rawInfo match {
-      case ltp: SymLoader => ltp.fromSource
-      case _ => false
-    }
-    if (pkgModule.isModule && !fromSource) {
-      // println("open "+pkgModule)//DEBUG
-      openPackageModule(pkgModule, pkgClass)
+    if (pkgModule.isModule) {
+      val fromSource = pkgModule.rawInfo match {
+        case ltp: SymLoader if ltp.fromSource =>
+          // As nearly as I can tell, this condition never happens.
+          // Leaving it in case it's doing something for the IDE.
+          log(s"$pkgModule is from source, no forcing.") ; true
+        case _                                =>
+          // Must force the info here before we assume there is no source file
+          // associated with this package object.  See SI-4695 among others.
+          log(s"forcing info of $pkgModule to ensure there's no source.")
+          pkgModule.info
+          (pkgModule.associatedFile ne null) && (pkgModule.associatedFile hasExtension "scala")
+      }
+      if (!fromSource) {
+        log(s"Opening binary package module $pkgModule (file = ${pkgModule.associatedFile})")
+        openPackageModule(pkgModule, pkgClass)
+      }
     }
   }
 

--- a/src/reflect/scala/reflect/runtime/SymbolLoaders.scala
+++ b/src/reflect/scala/reflect/runtime/SymbolLoaders.scala
@@ -26,7 +26,7 @@ private[reflect] trait SymbolLoaders { self: SymbolTable =>
 
     override def complete(sym: Symbol) = {
       debugInfo("completing "+sym+"/"+clazz.fullName)
-      assert(sym == clazz || sym == module || sym == module.moduleClass)
+      assert(sym == clazz || sym == module || sym == module.moduleClass, sym.defString)
 //      try {
       atPhaseNotLaterThan(picklerPhase) {
         val loadingMirror = mirrorThatLoaded(sym)

--- a/test/files/run/t4695.scala
+++ b/test/files/run/t4695.scala
@@ -1,0 +1,29 @@
+import scala.tools.partest._
+import java.io.File
+
+object Test extends StoreReporterDirectTest {
+  def code = ???
+
+  def compileCode(code: String) = {
+    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
+    compileString(newCompiler("-cp", classpath, "-d", testOutput.path, "-Ydebug"))(code)
+  }
+
+  def code1 = """
+    package pack1
+    trait T
+    object `package` extends T
+  """
+
+  def show(): Unit = {
+    compileCode(code1)
+    val pack1 = new File(testOutput.path, "pack1")
+    val tClass = new File(pack1, "T.class")
+    assert(tClass.exists)
+    assert(tClass.delete())
+
+    // allowed to compile, no direct reference to `T`
+    compileCode(code1)
+    assert(filteredInfos.isEmpty, filteredInfos)
+  }
+}


### PR DESCRIPTION
The mechanism being used to notice when a package object
is being compiled from source does not appear to work at all.
I applied a different mechanism, which does appear to.
