### PR TITLE
When skipping locker, print version of starr we are using.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -438,7 +438,10 @@ TODO:
 
     <!-- Skip locker with -Dlocker.skip=YESSIR. Uses STARR instead. -->
     <if><isset property="locker.skip"/><then>
-      <echo message="Skipping locker! Using STARR instead."/>
+      <!-- Loading these poperties here because we need them only here but feel free to move it somewhere
+           else if needed -->
+      <property resource="compiler.properties" prefix="starr.resolved" classpathref="starr.compiler.path"/>
+      <echo message="Skipping locker! Using STARR ${starr.resolved.version.number} instead."/>
       <path id="locker.compiler.path"><path refid="starr.compiler.path"/></path>
       <property name="locker.locked" value="locker skipped"/></then>
     <else>


### PR DESCRIPTION
As SI-7339 shows, it's easy to misunderstand behavior of `-Dlocker.skip=1`.
We can help by printing version of STARR we use for locker.

This is achieved by loading `compiler.properties` file and printing
`build.number` property.
