### PR TITLE
SI-7329 duplicate default getters for specialized parameters.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -796,7 +796,11 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
   private def normalizeMember(owner: Symbol, sym: Symbol, outerEnv: TypeEnv): List[Symbol] = {
     sym :: (
       if (!sym.isMethod || beforeTyper(sym.typeParams.isEmpty)) Nil
-      else {
+      else if (sym.hasDefault) {
+        /* Specializing default getters is useless, also see SI-7329 . */
+        sym.resetFlag(SPECIALIZED)
+        Nil
+      } else {
         // debuglog("normalizeMember: " + sym.fullNameAsName('.').decode)
         var specializingOn = specializedParams(sym)
         val unusedStvars   = specializingOn filterNot specializedTypeVars(sym.info)

--- a/test/files/pos/t7329.scala
+++ b/test/files/pos/t7329.scala
@@ -1,0 +1,1 @@
+class TwoParamSpecializedWithDefault[@specialized A, @specialized B](a: A, b: B = (??? : B))


### PR DESCRIPTION
The default getter is generated with @specialized annotation if the
type parameter corresponding to the type of the parameter is
specialized. Consequently specialize pass tries to generate overloads.

Rather than pruning overloads to exclude duplicates, let's notice
that default getter specialization is not needed at all:
- The dynamic scope of default getter doesn't include specialized
  method or class constructor.
- generic default getter is called even when calling specialized
  method.
