### PR TITLE
SI-6386 typed existential type tree's original now have tpe set

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3887,8 +3887,16 @@ trait Typers extends Modes with Adaptations with Tags {
         if (vd.symbol.tpe.isVolatile)
           AbstractionFromVolatileTypeError(vd)
       val tpt1 = typedType(tree.tpt, mode)
-      existentialTransform(tree.whereClauses map (_.symbol), tpt1.tpe)((tparams, tp) =>
-        TypeTree(newExistentialType(tparams, tp)) setOriginal tree
+      existentialTransform(tree.whereClauses map (_.symbol), tpt1.tpe)((tparams, tp) => {
+        val original = tpt1 match {
+          case tpt : TypeTree => atPos(tree.pos)(ExistentialTypeTree(tpt.original, tree.whereClauses))
+          case _ => {
+            debuglog(s"cannot reconstruct the original for $tree, because $tpt1 is not a TypeTree")
+            tree
+          }
+        }
+        TypeTree(newExistentialType(tparams, tp)) setOriginal original
+      }
       )
     }
 

--- a/test/files/pos/t6386.scala
+++ b/test/files/pos/t6386.scala
@@ -1,0 +1,5 @@
+import scala.reflect.runtime.universe._
+
+object Test extends App {
+  reify(manifest[Some[_]])
+}


### PR DESCRIPTION
Tree reification fails for ExistentialTypeTree. The reason is that the
tree passed for reification (see reifyTree at GetTrees.scala) must have
not null tpe (see reifyBoundType at GenTrees.scala), which is not true
in the case of ExistentialTypeTree.

Why is it so? The tree passed to reifyTree was obtained in the reshape
phase of reificationusing using original TypeTrees that represent pre-
typer representation of a type. The problem is that original's tpe for
ExistentialTypeTree is not set.

So the solution to the issue is to create ExistentialTypeTree's original
in a such way that is has actual tpe set.
