### PR TITLE
SI-7319 Avoid unflushed error/warning buffers in startContext

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -84,6 +84,8 @@ trait Contexts { self: Analyzer =>
         case Import(qual, _) => qual.tpe = singleType(qual.symbol.owner.thisType, qual.symbol)
         case _ =>
       }
+      sc.flushAndReturnBuffer()
+      sc.flushAndReturnWarningsBuffer()
       sc = sc.outer
     }
   }

--- a/test/files/run/t7319.check
+++ b/test/files/run/t7319.check
@@ -1,0 +1,38 @@
+Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> 
+
+scala> class M[A]
+defined class M
+
+scala> implicit def ma0[A](a: A): M[A] = null
+warning: there were 1 feature warning(s); re-run with -feature for details
+ma0: [A](a: A)M[A]
+
+scala> implicit def ma1[A](a: A): M[A] = null
+warning: there were 1 feature warning(s); re-run with -feature for details
+ma1: [A](a: A)M[A]
+
+scala> def convert[F[X <: F[X]]](builder: F[_ <: F[_]]) = 0
+warning: there were 1 feature warning(s); re-run with -feature for details
+convert: [F[X <: F[X]]](builder: F[_ <: F[_]])Int
+
+scala> convert(Some[Int](0))
+<console>:12: error: no type parameters for method convert: (builder: F[_ <: F[_]])Int exist so that it can be applied to arguments (Some[Int])
+ --- because ---
+argument expression's type is not compatible with formal parameter type;
+ found   : Some[Int]
+ required: ?F forSome { type _$1 <: ?F forSome { type _$2 } }
+              convert(Some[Int](0))
+              ^
+<console>:12: error: type mismatch;
+ found   : Some[Int]
+ required: F[_ <: F[_]]
+              convert(Some[Int](0))
+                               ^
+
+scala> 0
+res1: Int = 0
+
+scala> 

--- a/test/files/run/t7319.scala
+++ b/test/files/run/t7319.scala
@@ -1,0 +1,13 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  // so we can provide the ambiguities, rather than relying in Predef implicits
+  override def extraSettings = "-Yno-predef"
+  override def code = """
+class M[A]
+implicit def ma0[A](a: A): M[A] = null
+implicit def ma1[A](a: A): M[A] = null
+def convert[F[X <: F[X]]](builder: F[_ <: F[_]]) = 0
+convert(Some[Int](0))
+0""" // before the fix, this line, and all that followed, re-issued the implicit ambiguity error.
+}


### PR DESCRIPTION
Which can render a REPL inoperable, or doubly report errors in regular compilation.

I plan to invest some much needed TLC into this area over on master as SI-7345; this PR tries to tread lightly.

Review by the P-s: @hubertp / @paulp
