### PR TITLE
Reduce visibility of implicit class tags.

### DIFF
--- a/src/reflect/scala/reflect/api/Annotations.scala
+++ b/src/reflect/scala/reflect/api/Annotations.scala
@@ -45,12 +45,6 @@ trait Annotations { self: Universe =>
    */
   type Annotation >: Null <: AnyRef with AnnotationApi
 
-  /** A tag that preserves the identity of the `Annotation` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val AnnotationTag: ClassTag[Annotation]
-
    /** The constructor/extractor for `Annotation` instances.
     *  @group Extractors
     */
@@ -90,23 +84,12 @@ trait Annotations { self: Universe =>
    */
   type JavaArgument >: Null <: AnyRef
 
-  /** A tag that preserves the identity of the `JavaArgument` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val JavaArgumentTag: ClassTag[JavaArgument]
 
   /** A literal argument to a Java annotation as `"Use X instead"` in `@Deprecated("Use X instead")`
    *  @template
    *  @group Annotations
    */
   type LiteralArgument >: Null <: AnyRef with JavaArgument with LiteralArgumentApi
-
-  /** A tag that preserves the identity of the `LiteralArgument` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val LiteralArgumentTag: ClassTag[LiteralArgument]
 
   /** The constructor/extractor for `LiteralArgument` instances.
    *  @group Extractors
@@ -137,12 +120,6 @@ trait Annotations { self: Universe =>
    */
   type ArrayArgument >: Null <: AnyRef with JavaArgument with ArrayArgumentApi
 
-  /** A tag that preserves the identity of the `ArrayArgument` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val ArrayArgumentTag: ClassTag[ArrayArgument]
-
   /** The constructor/extractor for `ArrayArgument` instances.
    *  @group Extractors
    */
@@ -171,12 +148,6 @@ trait Annotations { self: Universe =>
    *  @group Annotations
    */
   type NestedArgument >: Null <: AnyRef with JavaArgument with NestedArgumentApi
-
-  /** A tag that preserves the identity of the `NestedArgument` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val NestedArgumentTag: ClassTag[NestedArgument]
 
   /** The constructor/extractor for `NestedArgument` instances.
    *  @group Extractors

--- a/src/reflect/scala/reflect/api/Constants.scala
+++ b/src/reflect/scala/reflect/api/Constants.scala
@@ -183,12 +183,6 @@ trait Constants {
    */
   type Constant >: Null <: AnyRef with ConstantApi
 
-  /** A tag that preserves the identity of the `Constant` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val ConstantTag: ClassTag[Constant]
-
   /** The constructor/extractor for `Constant` instances.
    *  @group Extractors
    */

--- a/src/reflect/scala/reflect/api/FlagSets.scala
+++ b/src/reflect/scala/reflect/api/FlagSets.scala
@@ -61,12 +61,6 @@ trait FlagSets { self: Universe =>
    */
   type FlagSet
 
-  /** A tag that preserves the identity of the `FlagSet` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val FlagSetTag: ClassTag[FlagSet]
-
   /** The API of `FlagSet` instances.
    *  The main source of information about flag sets is the [[scala.reflect.api.FlagSets]] page.
    *  @group Flags

--- a/src/reflect/scala/reflect/api/ImplicitTags.scala
+++ b/src/reflect/scala/reflect/api/ImplicitTags.scala
@@ -1,108 +1,116 @@
 package scala.reflect
 package api
 
+/** Tags which preserve the identity of abstract types in the face of erasure.
+ *  Can be used for pattern matching, instance tests, serialization and the like.
+ *  @group Tags
+ */
 trait ImplicitTags {
-  self: Types =>
+  self: Universe =>
 
-  /** A tag that preserves the identity of the `Type` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
+  // Tags for Types.
+  implicit val AnnotatedTypeTag: ClassTag[AnnotatedType]
+  implicit val BoundedWildcardTypeTag: ClassTag[BoundedWildcardType]
+  implicit val ClassInfoTypeTag: ClassTag[ClassInfoType]
+  implicit val CompoundTypeTag: ClassTag[CompoundType]
+  implicit val ConstantTypeTag: ClassTag[ConstantType]
+  implicit val ExistentialTypeTag: ClassTag[ExistentialType]
+  implicit val MethodTypeTag: ClassTag[MethodType]
+  implicit val NullaryMethodTypeTag: ClassTag[NullaryMethodType]
+  implicit val PolyTypeTag: ClassTag[PolyType]
+  implicit val RefinedTypeTag: ClassTag[RefinedType]
+  implicit val SingleTypeTag: ClassTag[SingleType]
+  implicit val SingletonTypeTag: ClassTag[SingletonType]
+  implicit val SuperTypeTag: ClassTag[SuperType]
+  implicit val ThisTypeTag: ClassTag[ThisType]
+  implicit val TypeBoundsTag: ClassTag[TypeBounds]
+  implicit val TypeRefTag: ClassTag[TypeRef]
   implicit val TypeTagg: ClassTag[Type]
 
-  /** A tag that preserves the identity of the `SingletonType` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val SingletonTypeTag: ClassTag[SingletonType]
+  // Tags for Names.
+  implicit val NameTag: ClassTag[Name]
+  implicit val TermNameTag: ClassTag[TermName]
+  implicit val TypeNameTag: ClassTag[TypeName]
 
-  /** A tag that preserves the identity of the `ThisType` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val ThisTypeTag: ClassTag[ThisType]
+  // Tags for Scopes.
+  implicit val ScopeTag: ClassTag[Scope]
+  implicit val MemberScopeTag: ClassTag[MemberScope]
 
-  /** A tag that preserves the identity of the `SingleType` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val SingleTypeTag: ClassTag[SingleType]
+  // Tags for Annotations.
+  implicit val AnnotationTag: ClassTag[Annotation]
+  implicit val JavaArgumentTag: ClassTag[JavaArgument]
+  implicit val LiteralArgumentTag: ClassTag[LiteralArgument]
+  implicit val ArrayArgumentTag: ClassTag[ArrayArgument]
+  implicit val NestedArgumentTag: ClassTag[NestedArgument]
 
-  /** A tag that preserves the identity of the `SuperType` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val SuperTypeTag: ClassTag[SuperType]
+  // Tags for Symbols.
+  implicit val TermSymbolTag: ClassTag[TermSymbol]
+  implicit val MethodSymbolTag: ClassTag[MethodSymbol]
+  implicit val SymbolTag: ClassTag[Symbol]
+  implicit val TypeSymbolTag: ClassTag[TypeSymbol]
+  implicit val ModuleSymbolTag: ClassTag[ModuleSymbol]
+  implicit val ClassSymbolTag: ClassTag[ClassSymbol]
+  implicit val FreeTermSymbolTag: ClassTag[FreeTermSymbol]
+  implicit val FreeTypeSymbolTag: ClassTag[FreeTypeSymbol]
 
-  /** A tag that preserves the identity of the `ConstantType` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val ConstantTypeTag: ClassTag[ConstantType]
+  // Tags for misc Tree relatives.
+  implicit val PositionTag: ClassTag[Position]
+  implicit val ConstantTag: ClassTag[Constant]
+  implicit val FlagSetTag: ClassTag[FlagSet]
+  implicit val ModifiersTag: ClassTag[Modifiers]
 
-  /** A tag that preserves the identity of the `TypeRef` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val TypeRefTag: ClassTag[TypeRef]
-
-  /** A tag that preserves the identity of the `CompoundType` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val CompoundTypeTag: ClassTag[CompoundType]
-
-  /** A tag that preserves the identity of the `RefinedType` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val RefinedTypeTag: ClassTag[RefinedType]
-
-  /** A tag that preserves the identity of the `ClassInfoType` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val ClassInfoTypeTag: ClassTag[ClassInfoType]
-
-  /** A tag that preserves the identity of the `MethodType` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val MethodTypeTag: ClassTag[MethodType]
-
-  /** A tag that preserves the identity of the `NullaryMethodType` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val NullaryMethodTypeTag: ClassTag[NullaryMethodType]
-
-  /** A tag that preserves the identity of the `PolyType` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val PolyTypeTag: ClassTag[PolyType]
-
-  /** A tag that preserves the identity of the `ExistentialType` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val ExistentialTypeTag: ClassTag[ExistentialType]
-
-  /** A tag that preserves the identity of the `AnnotatedType` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val AnnotatedTypeTag: ClassTag[AnnotatedType]
-
-  /** A tag that preserves the identity of the `TypeBounds` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val TypeBoundsTag: ClassTag[TypeBounds]
-
-  /** A tag that preserves the identity of the `BoundedWildcardType` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val BoundedWildcardTypeTag: ClassTag[BoundedWildcardType]
+  // Tags for Trees. WTF.
+  implicit val AlternativeTag: ClassTag[Alternative]
+  implicit val AnnotatedTag: ClassTag[Annotated]
+  implicit val AppliedTypeTreeTag: ClassTag[AppliedTypeTree]
+  implicit val ApplyTag: ClassTag[Apply]
+  implicit val AssignOrNamedArgTag: ClassTag[AssignOrNamedArg]
+  implicit val AssignTag: ClassTag[Assign]
+  implicit val BindTag: ClassTag[Bind]
+  implicit val BlockTag: ClassTag[Block]
+  implicit val CaseDefTag: ClassTag[CaseDef]
+  implicit val ClassDefTag: ClassTag[ClassDef]
+  implicit val CompoundTypeTreeTag: ClassTag[CompoundTypeTree]
+  implicit val DefDefTag: ClassTag[DefDef]
+  implicit val DefTreeTag: ClassTag[DefTree]
+  implicit val ExistentialTypeTreeTag: ClassTag[ExistentialTypeTree]
+  implicit val FunctionTag: ClassTag[Function]
+  implicit val GenericApplyTag: ClassTag[GenericApply]
+  implicit val IdentTag: ClassTag[Ident]
+  implicit val IfTag: ClassTag[If]
+  implicit val ImplDefTag: ClassTag[ImplDef]
+  implicit val ImportSelectorTag: ClassTag[ImportSelector]
+  implicit val ImportTag: ClassTag[Import]
+  implicit val LabelDefTag: ClassTag[LabelDef]
+  implicit val LiteralTag: ClassTag[Literal]
+  implicit val MatchTag: ClassTag[Match]
+  implicit val MemberDefTag: ClassTag[MemberDef]
+  implicit val ModuleDefTag: ClassTag[ModuleDef]
+  implicit val NameTreeTag: ClassTag[NameTree]
+  implicit val NewTag: ClassTag[New]
+  implicit val PackageDefTag: ClassTag[PackageDef]
+  implicit val RefTreeTag: ClassTag[RefTree]
+  implicit val ReferenceToBoxedTag: ClassTag[ReferenceToBoxed]
+  implicit val ReturnTag: ClassTag[Return]
+  implicit val SelectFromTypeTreeTag: ClassTag[SelectFromTypeTree]
+  implicit val SelectTag: ClassTag[Select]
+  implicit val SingletonTypeTreeTag: ClassTag[SingletonTypeTree]
+  implicit val StarTag: ClassTag[Star]
+  implicit val SuperTag: ClassTag[Super]
+  implicit val SymTreeTag: ClassTag[SymTree]
+  implicit val TemplateTag: ClassTag[Template]
+  implicit val TermTreeTag: ClassTag[TermTree]
+  implicit val ThisTag: ClassTag[This]
+  implicit val ThrowTag: ClassTag[Throw]
+  implicit val TreeTag: ClassTag[Tree]
+  implicit val TryTag: ClassTag[Try]
+  implicit val TypTreeTag: ClassTag[TypTree]
+  implicit val TypeApplyTag: ClassTag[TypeApply]
+  implicit val TypeBoundsTreeTag: ClassTag[TypeBoundsTree]
+  implicit val TypeDefTag: ClassTag[TypeDef]
+  implicit val TypeTreeTag: ClassTag[TypeTree]
+  implicit val TypedTag: ClassTag[Typed]
+  implicit val UnApplyTag: ClassTag[UnApply]
+  implicit val ValDefTag: ClassTag[ValDef]
+  implicit val ValOrDefDefTag: ClassTag[ValOrDefDef]
 }

--- a/src/reflect/scala/reflect/api/Names.scala
+++ b/src/reflect/scala/reflect/api/Names.scala
@@ -43,33 +43,15 @@ trait Names {
    */
   type Name >: Null <: NameApi
 
-  /** A tag that preserves the identity of the `Name` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val NameTag: ClassTag[Name]
-
   /** The abstract type of names representing terms.
    *  @group Names
    */
   type TypeName >: Null <: Name
 
-  /** A tag that preserves the identity of the `TypeName` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val TypeNameTag: ClassTag[TypeName]
-
   /** The abstract type of names representing types.
    *  @group Names
    */
   type TermName >: Null <: Name
-
-  /** A tag that preserves the identity of the `TermName` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val TermNameTag: ClassTag[TermName]
 
   /** The API of Name instances.
    *  @group API

--- a/src/reflect/scala/reflect/api/Positions.scala
+++ b/src/reflect/scala/reflect/api/Positions.scala
@@ -19,13 +19,6 @@ trait Positions {
    *  @group Positions
    */
   type Position >: Null <: scala.reflect.api.Position { type Pos = Position }
-
-  /** A tag that preserves the identity of the `Position` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val PositionTag: ClassTag[Position]
-
   /** A special "missing" position.
    *  @group Positions
    */

--- a/src/reflect/scala/reflect/api/Scopes.scala
+++ b/src/reflect/scala/reflect/api/Scopes.scala
@@ -33,12 +33,6 @@ trait Scopes { self: Universe =>
    */
   trait ScopeApi extends Iterable[Symbol]
 
-  /** A tag that preserves the identity of the `Scope` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val ScopeTag: ClassTag[Scope]
-
   /** Create a new scope with the given initial elements.
    *  @group Scopes
    */
@@ -61,10 +55,4 @@ trait Scopes { self: Universe =>
      */
     def sorted: List[Symbol]
   }
-
-  /** A tag that preserves the identity of the `MemberScope` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val MemberScopeTag: ClassTag[MemberScope]
 }

--- a/src/reflect/scala/reflect/api/Symbols.scala
+++ b/src/reflect/scala/reflect/api/Symbols.scala
@@ -61,24 +61,12 @@ trait Symbols { self: Universe =>
    */
   type Symbol >: Null <: SymbolApi
 
-  /** A tag that preserves the identity of the `Symbol` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val SymbolTag: ClassTag[Symbol]
-
   /** The type of type symbols representing type, class, and trait declarations,
    *  as well as type parameters.
    *  @group Symbols
    *  @template
    */
   type TypeSymbol >: Null <: Symbol with TypeSymbolApi
-
-  /** A tag that preserves the identity of the `TypeSymbol` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val TypeSymbolTag: ClassTag[TypeSymbol]
 
   /** The type of term symbols representing val, var, def, and object declarations as
    *  well as packages and value parameters.
@@ -87,23 +75,11 @@ trait Symbols { self: Universe =>
    */
   type TermSymbol >: Null <: Symbol with TermSymbolApi
 
-  /** A tag that preserves the identity of the `TermSymbol` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val TermSymbolTag: ClassTag[TermSymbol]
-
   /** The type of method symbols representing def declarations.
    *  @group Symbols
    *  @template
    */
   type MethodSymbol >: Null <: TermSymbol with MethodSymbolApi
-
-  /** A tag that preserves the identity of the `MethodSymbol` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val MethodSymbolTag: ClassTag[MethodSymbol]
 
   /** The type of module symbols representing object declarations.
    *  @group Symbols
@@ -111,23 +87,11 @@ trait Symbols { self: Universe =>
    */
   type ModuleSymbol >: Null <: TermSymbol with ModuleSymbolApi
 
-  /** A tag that preserves the identity of the `ModuleSymbol` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val ModuleSymbolTag: ClassTag[ModuleSymbol]
-
   /** The type of class symbols representing class and trait definitions.
    *  @group Symbols
    *  @template
    */
   type ClassSymbol >: Null <: TypeSymbol with ClassSymbolApi
-
-  /** A tag that preserves the identity of the `ClassSymbol` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val ClassSymbolTag: ClassTag[ClassSymbol]
 
   /** The type of free terms introduced by reification.
    *  @group Symbols
@@ -135,23 +99,11 @@ trait Symbols { self: Universe =>
    */
   type FreeTermSymbol >: Null <: TermSymbol with FreeTermSymbolApi
 
-  /** A tag that preserves the identity of the `FreeTermSymbol` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val FreeTermSymbolTag: ClassTag[FreeTermSymbol]
-
   /** The type of free types introduced by reification.
    *  @group Symbols
    *  @template
    */
   type FreeTypeSymbol >: Null <: TypeSymbol with FreeTypeSymbolApi
-
-  /** A tag that preserves the identity of the `FreeTypeSymbol` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val FreeTypeSymbolTag: ClassTag[FreeTypeSymbol]
 
   /** A special "missing" symbol. Commonly used in the API to denote a default or empty value.
    *  @group Symbols

--- a/src/reflect/scala/reflect/api/Trees.scala
+++ b/src/reflect/scala/reflect/api/Trees.scala
@@ -60,12 +60,6 @@ trait Trees { self: Universe =>
    */
   type Tree >: Null <: TreeApi
 
-  /** A tag that preserves the identity of the `Tree` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val TreeTag: ClassTag[Tree]
-
   /** The API that all trees support.
    *  The main source of information about trees is the [[scala.reflect.api.Trees]] page.
    *  @group API
@@ -230,12 +224,6 @@ trait Trees { self: Universe =>
    */
   type TermTree >: Null <: AnyRef with Tree with TermTreeApi
 
-  /** A tag that preserves the identity of the `TermTree` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val TermTreeTag: ClassTag[TermTree]
-
   /** The API that all term trees support
    *  @group API
    */
@@ -249,12 +237,6 @@ trait Trees { self: Universe =>
    */
   type TypTree >: Null <: AnyRef with Tree with TypTreeApi
 
-  /** A tag that preserves the identity of the `TypTree` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val TypTreeTag: ClassTag[TypTree]
-
   /** The API that all typ trees support
    *  @group API
    */
@@ -266,12 +248,6 @@ trait Trees { self: Universe =>
    *  @template
    */
   type SymTree >: Null <: AnyRef with Tree with SymTreeApi
-
-  /** A tag that preserves the identity of the `SymTree` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val SymTreeTag: ClassTag[SymTree]
 
   /** The API that all sym trees support
    *  @group API
@@ -286,12 +262,6 @@ trait Trees { self: Universe =>
    *  @template
    */
   type NameTree >: Null <: AnyRef with Tree with NameTreeApi
-
-  /** A tag that preserves the identity of the `NameTree` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val NameTreeTag: ClassTag[NameTree]
 
   /** The API that all name trees support
    *  @group API
@@ -310,12 +280,6 @@ trait Trees { self: Universe =>
    *  @template
    */
   type RefTree >: Null <: SymTree with NameTree with RefTreeApi
-
-  /** A tag that preserves the identity of the `RefTree` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val RefTreeTag: ClassTag[RefTree]
 
   /** The API that all ref trees support
    *  @group API
@@ -337,12 +301,6 @@ trait Trees { self: Universe =>
    */
   type DefTree >: Null <: SymTree with NameTree with DefTreeApi
 
-  /** A tag that preserves the identity of the `DefTree` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val DefTreeTag: ClassTag[DefTree]
-
   /** The API that all def trees support
    *  @group API
    */
@@ -358,12 +316,6 @@ trait Trees { self: Universe =>
    */
   type MemberDef >: Null <: DefTree with MemberDefApi
 
-  /** A tag that preserves the identity of the `MemberDef` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val MemberDefTag: ClassTag[MemberDef]
-
   /** The API that all member defs support
    *  @group API
    */
@@ -377,12 +329,6 @@ trait Trees { self: Universe =>
    *  @template
    */
   type PackageDef >: Null <: MemberDef with PackageDefApi
-
-  /** A tag that preserves the identity of the `PackageDef` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val PackageDefTag: ClassTag[PackageDef]
 
   /** The constructor/extractor for `PackageDef` instances.
    *  @group Extractors
@@ -417,12 +363,6 @@ trait Trees { self: Universe =>
    */
   type ImplDef >: Null <: MemberDef with ImplDefApi
 
-  /** A tag that preserves the identity of the `ImplDef` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val ImplDefTag: ClassTag[ImplDef]
-
   /** The API that all impl defs support
    *  @group API
    */
@@ -436,12 +376,6 @@ trait Trees { self: Universe =>
    *  @template
    */
   type ClassDef >: Null <: ImplDef with ClassDefApi
-
-  /** A tag that preserves the identity of the `ClassDef` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val ClassDefTag: ClassTag[ClassDef]
 
   /** The constructor/extractor for `ClassDef` instances.
    *  @group Extractors
@@ -488,12 +422,6 @@ trait Trees { self: Universe =>
    */
   type ModuleDef >: Null <: ImplDef with ModuleDefApi
 
-  /** A tag that preserves the identity of the `ModuleDef` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val ModuleDefTag: ClassTag[ModuleDef]
-
   /** The constructor/extractor for `ModuleDef` instances.
    *  @group Extractors
    */
@@ -534,12 +462,6 @@ trait Trees { self: Universe =>
    */
   type ValOrDefDef >: Null <: MemberDef with ValOrDefDefApi
 
-  /** A tag that preserves the identity of the `ValOrDefDef` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val ValOrDefDefTag: ClassTag[ValOrDefDef]
-
   /** The API that all val defs and def defs support
    *  @group API
    */
@@ -570,12 +492,6 @@ trait Trees { self: Universe =>
    *  @template
    */
   type ValDef >: Null <: ValOrDefDef with ValDefApi
-
-  /** A tag that preserves the identity of the `ValDef` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val ValDefTag: ClassTag[ValDef]
 
   /** The constructor/extractor for `ValDef` instances.
    *  @group Extractors
@@ -626,12 +542,6 @@ trait Trees { self: Universe =>
    */
   type DefDef >: Null <: ValOrDefDef with DefDefApi
 
-  /** A tag that preserves the identity of the `DefDef` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val DefDefTag: ClassTag[DefDef]
-
   /** The constructor/extractor for `DefDef` instances.
    *  @group Extractors
    */
@@ -680,12 +590,6 @@ trait Trees { self: Universe =>
    *  @template
    */
   type TypeDef >: Null <: MemberDef with TypeDefApi
-
-  /** A tag that preserves the identity of the `TypeDef` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val TypeDefTag: ClassTag[TypeDef]
 
   /** The constructor/extractor for `TypeDef` instances.
    *  @group Extractors
@@ -746,12 +650,6 @@ trait Trees { self: Universe =>
    */
   type LabelDef >: Null <: DefTree with TermTree with LabelDefApi
 
-  /** A tag that preserves the identity of the `LabelDef` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val LabelDefTag: ClassTag[LabelDef]
-
   /** The constructor/extractor for `LabelDef` instances.
    *  @group Extractors
    */
@@ -808,12 +706,6 @@ trait Trees { self: Universe =>
    */
   type ImportSelector >: Null <: AnyRef with ImportSelectorApi
 
-  /** A tag that preserves the identity of the `ImportSelector` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val ImportSelectorTag: ClassTag[ImportSelector]
-
   /** The constructor/extractor for `ImportSelector` instances.
    *  @group Extractors
    */
@@ -859,12 +751,6 @@ trait Trees { self: Universe =>
    *  @template
    */
   type Import >: Null <: SymTree with ImportApi
-
-  /** A tag that preserves the identity of the `Import` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val ImportTag: ClassTag[Import]
 
   /** The constructor/extractor for `Import` instances.
    *  @group Extractors
@@ -918,12 +804,6 @@ trait Trees { self: Universe =>
    */
   type Template >: Null <: SymTree with TemplateApi
 
-  /** A tag that preserves the identity of the `Template` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val TemplateTag: ClassTag[Template]
-
   /** The constructor/extractor for `Template` instances.
    *  @group Extractors
    */
@@ -976,12 +856,6 @@ trait Trees { self: Universe =>
    */
   type Block >: Null <: TermTree with BlockApi
 
-  /** A tag that preserves the identity of the `Block` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val BlockTag: ClassTag[Block]
-
   /** The constructor/extractor for `Block` instances.
    *  @group Extractors
    */
@@ -1020,12 +894,6 @@ trait Trees { self: Universe =>
    *  @template
    */
   type CaseDef >: Null <: AnyRef with Tree with CaseDefApi
-
-  /** A tag that preserves the identity of the `CaseDef` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val CaseDefTag: ClassTag[CaseDef]
 
   /** The constructor/extractor for `CaseDef` instances.
    *  @group Extractors
@@ -1074,12 +942,6 @@ trait Trees { self: Universe =>
    */
   type Alternative >: Null <: TermTree with AlternativeApi
 
-  /** A tag that preserves the identity of the `Alternative` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val AlternativeTag: ClassTag[Alternative]
-
   /** The constructor/extractor for `Alternative` instances.
    *  @group Extractors
    */
@@ -1111,12 +973,6 @@ trait Trees { self: Universe =>
    *  @template
    */
   type Star >: Null <: TermTree with StarApi
-
-  /** A tag that preserves the identity of the `Star` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val StarTag: ClassTag[Star]
 
   /** The constructor/extractor for `Star` instances.
    *  @group Extractors
@@ -1152,12 +1008,6 @@ trait Trees { self: Universe =>
    *  @template
    */
   type Bind >: Null <: DefTree with BindApi
-
-  /** A tag that preserves the identity of the `Bind` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val BindTag: ClassTag[Bind]
 
   /** The constructor/extractor for `Bind` instances.
    *  @group Extractors
@@ -1222,12 +1072,6 @@ trait Trees { self: Universe =>
    */
   type UnApply >: Null <: TermTree with UnApplyApi
 
-  /** A tag that preserves the identity of the `UnApply` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val UnApplyTag: ClassTag[UnApply]
-
   /** The constructor/extractor for `UnApply` instances.
    *  @group Extractors
    */
@@ -1263,12 +1107,6 @@ trait Trees { self: Universe =>
    *  @template
    */
   type Function >: Null <: TermTree with SymTree with FunctionApi
-
-  /** A tag that preserves the identity of the `Function` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val FunctionTag: ClassTag[Function]
 
   /** The constructor/extractor for `Function` instances.
    *  @group Extractors
@@ -1308,12 +1146,6 @@ trait Trees { self: Universe =>
    */
   type Assign >: Null <: TermTree with AssignApi
 
-  /** A tag that preserves the identity of the `Assign` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val AssignTag: ClassTag[Assign]
-
   /** The constructor/extractor for `Assign` instances.
    *  @group Extractors
    */
@@ -1349,12 +1181,6 @@ trait Trees { self: Universe =>
    *  @template
    */
   type AssignOrNamedArg >: Null <: TermTree with AssignOrNamedArgApi
-
-  /** A tag that preserves the identity of the `AssignOrNamedArg` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val AssignOrNamedArgTag: ClassTag[AssignOrNamedArg]
 
   /** The constructor/extractor for `AssignOrNamedArg` instances.
    *  @group Extractors
@@ -1396,12 +1222,6 @@ trait Trees { self: Universe =>
    *  @template
    */
   type If >: Null <: TermTree with IfApi
-
-  /** A tag that preserves the identity of the `If` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val IfTag: ClassTag[If]
 
   /** The constructor/extractor for `If` instances.
    *  @group Extractors
@@ -1454,12 +1274,6 @@ trait Trees { self: Universe =>
    */
   type Match >: Null <: TermTree with MatchApi
 
-  /** A tag that preserves the identity of the `Match` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val MatchTag: ClassTag[Match]
-
   /** The constructor/extractor for `Match` instances.
    *  @group Extractors
    */
@@ -1495,12 +1309,6 @@ trait Trees { self: Universe =>
    */
   type Return >: Null <: TermTree with SymTree with ReturnApi
 
-  /** A tag that preserves the identity of the `Return` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val ReturnTag: ClassTag[Return]
-
   /** The constructor/extractor for `Return` instances.
    *  @group Extractors
    */
@@ -1532,12 +1340,6 @@ trait Trees { self: Universe =>
    *  @template
    */
   type Try >: Null <: TermTree with TryApi
-
-  /** A tag that preserves the identity of the `Try` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val TryTag: ClassTag[Try]
 
   /** The constructor/extractor for `Try` instances.
    *  @group Extractors
@@ -1577,12 +1379,6 @@ trait Trees { self: Universe =>
    */
   type Throw >: Null <: TermTree with ThrowApi
 
-  /** A tag that preserves the identity of the `Throw` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val ThrowTag: ClassTag[Throw]
-
   /** The constructor/extractor for `Throw` instances.
    *  @group Extractors
    */
@@ -1612,12 +1408,6 @@ trait Trees { self: Universe =>
    *  @template
    */
   type New >: Null <: TermTree with NewApi
-
-  /** A tag that preserves the identity of the `New` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val NewTag: ClassTag[New]
 
   /** The constructor/extractor for `New` instances.
    *  @group Extractors
@@ -1669,12 +1459,6 @@ trait Trees { self: Universe =>
    */
   type Typed >: Null <: TermTree with TypedApi
 
-  /** A tag that preserves the identity of the `Typed` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val TypedTag: ClassTag[Typed]
-
   /** The constructor/extractor for `Typed` instances.
    *  @group Extractors
    */
@@ -1708,12 +1492,6 @@ trait Trees { self: Universe =>
    */
   type GenericApply >: Null <: TermTree with GenericApplyApi
 
-  /** A tag that preserves the identity of the `GenericApply` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val GenericApplyTag: ClassTag[GenericApply]
-
   /** The API that all applies support
    *  @group API
    */
@@ -1734,12 +1512,6 @@ trait Trees { self: Universe =>
    *  @template
    */
   type TypeApply >: Null <: GenericApply with TypeApplyApi
-
-  /** A tag that preserves the identity of the `TypeApply` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val TypeApplyTag: ClassTag[TypeApply]
 
   /** The constructor/extractor for `TypeApply` instances.
    *  @group Extractors
@@ -1779,12 +1551,6 @@ trait Trees { self: Universe =>
    */
   type Apply >: Null <: GenericApply with ApplyApi
 
-  /** A tag that preserves the identity of the `Apply` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val ApplyTag: ClassTag[Apply]
-
   /** The constructor/extractor for `Apply` instances.
    *  @group Extractors
    */
@@ -1821,12 +1587,6 @@ trait Trees { self: Universe =>
    *  @template
    */
   type Super >: Null <: TermTree with SuperApi
-
-  /** A tag that preserves the identity of the `Super` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val SuperTag: ClassTag[Super]
 
   /** The constructor/extractor for `Super` instances.
    *  @group Extractors
@@ -1874,12 +1634,6 @@ trait Trees { self: Universe =>
    */
   type This >: Null <: TermTree with SymTree with ThisApi
 
-  /** A tag that preserves the identity of the `This` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val ThisTag: ClassTag[This]
-
   /** The constructor/extractor for `This` instances.
    *  @group Extractors
    */
@@ -1914,12 +1668,6 @@ trait Trees { self: Universe =>
    *  @template
    */
   type Select >: Null <: RefTree with SelectApi
-
-  /** A tag that preserves the identity of the `Select` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val SelectTag: ClassTag[Select]
 
   /** The constructor/extractor for `Select` instances.
    *  @group Extractors
@@ -1960,12 +1708,6 @@ trait Trees { self: Universe =>
    */
   type Ident >: Null <: RefTree with IdentApi
 
-  /** A tag that preserves the identity of the `Ident` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val IdentTag: ClassTag[Ident]
-
   /** The constructor/extractor for `Ident` instances.
    *  @group Extractors
    */
@@ -2004,12 +1746,6 @@ trait Trees { self: Universe =>
    *  @template
    */
   type ReferenceToBoxed >: Null <: TermTree with ReferenceToBoxedApi
-
-  /** A tag that preserves the identity of the `ReferenceToBoxed` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val ReferenceToBoxedTag: ClassTag[ReferenceToBoxed]
 
   /** The constructor/extractor for `ReferenceToBoxed` instances.
    *  @group Extractors
@@ -2055,12 +1791,6 @@ trait Trees { self: Universe =>
    */
   type Literal >: Null <: TermTree with LiteralApi
 
-  /** A tag that preserves the identity of the `Literal` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val LiteralTag: ClassTag[Literal]
-
   /** The constructor/extractor for `Literal` instances.
    *  @group Extractors
    */
@@ -2093,12 +1823,6 @@ trait Trees { self: Universe =>
    *  @template
    */
   type Annotated >: Null <: AnyRef with Tree with AnnotatedApi
-
-  /** A tag that preserves the identity of the `Annotated` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val AnnotatedTag: ClassTag[Annotated]
 
   /** The constructor/extractor for `Annotated` instances.
    *  @group Extractors
@@ -2134,12 +1858,6 @@ trait Trees { self: Universe =>
    */
   type SingletonTypeTree >: Null <: TypTree with SingletonTypeTreeApi
 
-  /** A tag that preserves the identity of the `SingletonTypeTree` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val SingletonTypeTreeTag: ClassTag[SingletonTypeTree]
-
   /** The constructor/extractor for `SingletonTypeTree` instances.
    *  @group Extractors
    */
@@ -2169,12 +1887,6 @@ trait Trees { self: Universe =>
    *  @template
    */
   type SelectFromTypeTree >: Null <: TypTree with RefTree with SelectFromTypeTreeApi
-
-  /** A tag that preserves the identity of the `SelectFromTypeTree` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val SelectFromTypeTreeTag: ClassTag[SelectFromTypeTree]
 
   /** The constructor/extractor for `SelectFromTypeTree` instances.
    *  @group Extractors
@@ -2217,12 +1929,6 @@ trait Trees { self: Universe =>
    */
   type CompoundTypeTree >: Null <: TypTree with CompoundTypeTreeApi
 
-  /** A tag that preserves the identity of the `CompoundTypeTree` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val CompoundTypeTreeTag: ClassTag[CompoundTypeTree]
-
   /** The constructor/extractor for `CompoundTypeTree` instances.
    *  @group Extractors
    */
@@ -2252,12 +1958,6 @@ trait Trees { self: Universe =>
    *  @template
    */
   type AppliedTypeTree >: Null <: TypTree with AppliedTypeTreeApi
-
-  /** A tag that preserves the identity of the `AppliedTypeTree` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val AppliedTypeTreeTag: ClassTag[AppliedTypeTree]
 
   /** The constructor/extractor for `AppliedTypeTree` instances.
    *  @group Extractors
@@ -2301,12 +2001,6 @@ trait Trees { self: Universe =>
    */
   type TypeBoundsTree >: Null <: TypTree with TypeBoundsTreeApi
 
-  /** A tag that preserves the identity of the `TypeBoundsTree` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val TypeBoundsTreeTag: ClassTag[TypeBoundsTree]
-
   /** The constructor/extractor for `TypeBoundsTree` instances.
    *  @group Extractors
    */
@@ -2344,12 +2038,6 @@ trait Trees { self: Universe =>
    */
   type ExistentialTypeTree >: Null <: TypTree with ExistentialTypeTreeApi
 
-  /** A tag that preserves the identity of the `ExistentialTypeTree` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val ExistentialTypeTreeTag: ClassTag[ExistentialTypeTree]
-
   /** The constructor/extractor for `ExistentialTypeTree` instances.
    *  @group Extractors
    */
@@ -2386,12 +2074,6 @@ trait Trees { self: Universe =>
    *  @template
    */
   type TypeTree >: Null <: TypTree with TypeTreeApi
-
-  /** A tag that preserves the identity of the `TypeTree` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Tags
-   */
-  implicit val TypeTreeTag: ClassTag[TypeTree]
 
   /** The constructor/extractor for `TypeTree` instances.
    *  @group Extractors
@@ -2989,12 +2671,6 @@ trait Trees { self: Universe =>
    *  @group Traversal
    */
   type Modifiers >: Null <: AnyRef with ModifiersApi
-
-  /** A tag that preserves the identity of the `Modifiers` abstract type from erasure.
-   *  Can be used for pattern matching, instance tests, serialization and likes.
-   *  @group Traversal
-   */
-  implicit val ModifiersTag: ClassTag[Modifiers]
 
   /** The API that all Modifiers support
    *  @group API

--- a/src/reflect/scala/reflect/api/Types.scala
+++ b/src/reflect/scala/reflect/api/Types.scala
@@ -50,7 +50,7 @@ package api
  *
  *  @contentDiagram hideNodes "*Api"
  */
-trait Types extends ImplicitTags {
+trait Types {
   self: Universe =>
 
   /** The type of Scala types, and also Scala type signatures.

--- a/src/reflect/scala/reflect/api/Universe.scala
+++ b/src/reflect/scala/reflect/api/Universe.scala
@@ -68,6 +68,7 @@ abstract class Universe extends Symbols
                            with Exprs
                            with TypeTags
                            with TagInterop
+                           with ImplicitTags
                            with StandardDefinitions
                            with StandardNames
                            with BuildUtils


### PR DESCRIPTION
500 lines of generated boilerplate is _impossible to maintain_.
Generated code of this kind should never be allowed.

Three lines of documentation, duplicated 100 times, cannot
masquerade as three hundred lines of documentation. If someone
knows to look at the documentation of implicit ClassTags,
they _already know_ about implicit ClassTags. It is wherever
"match" is documented which needs this information (and I am
sure we can express it more clearly, given the luxury of
only saying it once.)

Documenting each ClassTag with the same boilerplate is
comparable in utility to attaching such text to every Int.
"An Int is a whole number within the range -2147483648 to
2147483647 inclusive. It's usually used to represent how
many of something there are, such as '5 bunnies' or '3
witty commit messages', but you can store about anything
in an Int if you can fit it into 32 bits."

We don't do that, because you're expected to discover what
an Int is in a manner which generalizes to all the Ints you
may encounter. The situation with implicit ClassTags is
immediately analogous.
