### PR TITLE
SI-6815 untangle isStable and hasVolatileType

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -141,7 +141,7 @@ trait ContextErrors {
         }
         issueNormalTypeError(tree,
           "stable identifier required, but "+tree+" found." + (
-          if (isStableExceptVolatile(tree)) addendum else ""))
+          if (treeInfo.hasVolatileType(tree)) addendum else ""))
         setError(tree)
       }
 

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1342,13 +1342,16 @@ trait Namers extends MethodSynthesis {
     private def importSig(imp: Import) = {
       val Import(expr, selectors) = imp
       val expr1 = typer.typedQualifier(expr)
-      typer checkStable expr1
+
       if (expr1.symbol != null && expr1.symbol.isRootPackage)
         RootImportError(imp)
 
       if (expr1.isErrorTyped)
         ErrorType
       else {
+        if (!treeInfo.isStableIdentifierPattern(expr1))
+          typer.TyperErrorGen.UnstableTreeError(expr1)
+
         val newImport = treeCopy.Import(imp, expr1, selectors).asInstanceOf[Import]
         checkSelectors(newImport)
         transformed(imp) = newImport

--- a/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
@@ -202,7 +202,7 @@ trait NamesDefaults { self: Analyzer =>
           if (module == NoSymbol) None
           else {
             val ref = atPos(pos.focus)(gen.mkAttributedRef(pre, module))
-            if (module.isStable && pre.isStable)    // fixes #4524. the type checker does the same for
+            if (treeInfo.admitsTypeSelection(ref))  // fixes #4524. the type checker does the same for
               ref.setType(singleType(pre, module))  // typedSelect, it calls "stabilize" on the result.
             Some(ref)
           }

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -511,7 +511,10 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
             }
 
             if (member.isStable && !otherTp.isVolatile) {
-	            if (memberTp.isVolatile)
+              // (1.4), pt 2 -- member.isStable && memberTp.isVolatile started being possible after SI-6815
+              // (before SI-6815, !symbol.tpe.isVolatile was implied by symbol.isStable)
+              // TODO: allow overriding when @uncheckedStable?
+              if (memberTp.isVolatile)
                 overrideError("has a volatile type; cannot override a member with non-volatile type")
               else memberTp.dealiasWiden.resultType match {
                 case rt: RefinedType if !(rt =:= otherTp) && !(checkedCombinations contains rt.parents) =>

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -250,29 +250,6 @@ trait Typers extends Adaptations with Tags {
       case _ => tp
     }
 
-    /** Check that `tree` is a stable expression.
-     */
-    def checkStable(tree: Tree): Tree = (
-      if (treeInfo.isExprSafeToInline(tree)) tree
-      else if (tree.isErrorTyped) tree
-      else UnstableTreeError(tree)
-    )
-
-    /** Would tree be a stable (i.e. a pure expression) if the type
-     *  of its symbol was not volatile?
-     */
-    protected def isStableExceptVolatile(tree: Tree) = {
-      tree.hasSymbolField && tree.symbol != NoSymbol && tree.tpe.isVolatile &&
-      { val savedTpe = tree.symbol.info
-        val savedSTABLE = tree.symbol getFlag STABLE
-        tree.symbol setInfo AnyRefClass.tpe
-        tree.symbol setFlag STABLE
-        val result = treeInfo.isExprSafeToInline(tree)
-        tree.symbol setInfo savedTpe
-        tree.symbol setFlag savedSTABLE
-        result
-      }
-    }
     private def errorNotClass(tpt: Tree, found: Type)  = { ClassTypeRequiredError(tpt, found); false }
     private def errorNotStable(tpt: Tree, found: Type) = { TypeNotAStablePrefixError(tpt, found); false }
 

--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -925,14 +925,14 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
   }
 
   def stabilizedType(tree: Tree): Type = tree match {
-    case Ident(_) if tree.symbol.isStable =>
+    case Ident(_) if treeInfo.admitsTypeSelection(tree) =>
       singleType(NoPrefix, tree.symbol)
-    case Select(qual, _) if qual.tpe != null && tree.symbol.isStable =>
+    case Select(qual, _) if treeInfo.admitsTypeSelection(tree) =>
       singleType(qual.tpe, tree.symbol)
     case Import(expr, selectors) =>
       tree.symbol.info match {
         case analyzer.ImportType(expr) => expr match {
-          case s@Select(qual, name) => singleType(qual.tpe, s.symbol)
+          case s@Select(qual, name) if treeInfo.admitsTypeSelection(expr) => singleType(qual.tpe, s.symbol)
           case i : Ident => i.tpe
           case _ => tree.tpe
         }

--- a/src/interactive/scala/tools/nsc/interactive/Picklers.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Picklers.scala
@@ -96,7 +96,7 @@ trait Picklers { self: Global =>
       if (!sym.isRoot) {
         ownerNames(sym.owner, buf)
         buf += (if (sym.isModuleClass) sym.sourceModule else sym).name
-        if (!sym.isType && !sym.isStable) {
+        if (!sym.isType && !sym.isStable) { // TODO: what's the reasoning behind this condition!?
           val sym1 = sym.owner.info.decl(sym.name)
           if (sym1.isOverloaded) {
             val index = sym1.alternatives.indexOf(sym)

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -126,6 +126,8 @@ abstract class SymbolTable extends macros.Universe
     val global: SymbolTable.this.type = SymbolTable.this
   } with util.TraceSymbolActivity
 
+  val treeInfo: TreeInfo { val global: SymbolTable.this.type }
+
   /** Check that the executing thread is the compiler thread. No-op here,
    *  overridden in interactive.Global. */
   @elidable(elidable.WARNING)

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -790,8 +790,12 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     /** Is this symbol an accessor method for outer? */
     final def isOuterField = isArtifact && (unexpandedName == nme.OUTER_LOCAL)
 
-    /** Does this symbol denote a stable value? */
-    def isStable = false
+    /** Does this symbol denote a stable value, ignoring volatility?
+     *
+     * Stability and volatility are checked separately to allow volatile paths in patterns that amount to equality checks. SI-6815
+     */
+    final def isStable        = isTerm && !isMutable && !(hasFlag(BYNAMEPARAM)) && (!isMethod || hasStableFlag)
+    final def hasVolatileType = tpe.isVolatile && !hasAnnotation(uncheckedStableClass)
 
     /** Does this symbol denote the primary constructor of its enclosing class? */
     final def isPrimaryConstructor =
@@ -2589,13 +2593,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     override def isMixinConstructor = name == nme.MIXIN_CONSTRUCTOR
     override def isConstructor      = nme.isConstructorName(name)
 
-    override def isPackageObject  = isModule && (name == nme.PACKAGE)
-    override def isStable = !isUnstable
-    private def isUnstable = (
-         isMutable
-      || (hasFlag(METHOD | BYNAMEPARAM) && !hasFlag(STABLE))
-      || (tpe.isVolatile && !hasAnnotation(uncheckedStableClass))
-    )
+    override def isPackageObject = isModule && (name == nme.PACKAGE)
 
     // The name in comments is what it is being disambiguated from.
     // TODO - rescue CAPTURED from BYNAMEPARAM so we can see all the names.

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -92,6 +92,8 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
 
     def isExistential: Boolean = this.isExistentiallyBound
     def isParamWithDefault: Boolean = this.hasDefault
+    // `isByNameParam` is only true for a call-by-name parameter of a *method*,
+    // an argument of the primary constructor seen in the class body is excluded by `isValueParameter`
     def isByNameParam: Boolean = this.isValueParameter && (this hasFlag BYNAMEPARAM)
     def isImplementationArtifact: Boolean = (this hasFlag BRIDGE) || (this hasFlag VBRIDGE) || (this hasFlag ARTIFACT)
     def isJava: Boolean = isJavaDefined

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -142,17 +142,15 @@ abstract class TreeGen extends macros.TreeBuilder {
   }
 
   /** Computes stable type for a tree if possible */
-  def stableTypeFor(tree: Tree): Option[Type] = tree match {
-    case This(_) if tree.symbol != null && !tree.symbol.isError =>
-      Some(ThisType(tree.symbol))
-    case Ident(_) if tree.symbol.isStable =>
-      Some(singleType(tree.symbol.owner.thisType, tree.symbol))
-    case Select(qual, _) if ((tree.symbol ne null) && (qual.tpe ne null)) && // turned assert into guard for #4064
-                            tree.symbol.isStable && qual.tpe.isStable =>
-      Some(singleType(qual.tpe, tree.symbol))
-    case _ =>
-      None
-  }
+  def stableTypeFor(tree: Tree): Option[Type] =
+    if (treeInfo.admitsTypeSelection(tree))
+      tree match {
+        case This(_)         => Some(ThisType(tree.symbol))
+        case Ident(_)        => Some(singleType(tree.symbol.owner.thisType, tree.symbol))
+        case Select(qual, _) => Some(singleType(qual.tpe, tree.symbol))
+        case _               => None
+      }
+    else None
 
   /** Builds a reference with stable type to given symbol */
   def mkAttributedStableRef(pre: Type, sym: Symbol): Tree =

--- a/src/reflect/scala/reflect/runtime/JavaUniverse.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverse.scala
@@ -21,5 +21,10 @@ class JavaUniverse extends internal.SymbolTable with ReflectSetup with runtime.S
   def newStrictTreeCopier: TreeCopier = new StrictTreeCopier
   def newLazyTreeCopier: TreeCopier = new LazyTreeCopier
 
+  // can't put this in runtime.Trees since that's mixed with Global in ReflectGlobal, which has the definition from internal.Trees
+  object treeInfo extends {
+    val global: JavaUniverse.this.type = JavaUniverse.this
+  } with internal.TreeInfo
+
   init()
 }

--- a/test/files/neg/t6815.check
+++ b/test/files/neg/t6815.check
@@ -1,0 +1,5 @@
+t6815.scala:15: error: stable identifier required, but Test.this.u.emptyValDef found.
+ Note that value emptyValDef is not stable because its type, Test.u.ValDef, is volatile.
+    case _: u.emptyValDef.T => // and, unlike in pos/t6185.scala, we shouldn't allow this.
+              ^
+one error found

--- a/test/files/neg/t6815.scala
+++ b/test/files/neg/t6815.scala
@@ -1,0 +1,17 @@
+trait U {
+  trait ValOrDefDefApi {
+    def name: Any
+  }
+  type ValOrDefDef <: ValOrDefDefApi
+  type ValDef <: ValOrDefDef with ValDefApi { type T }
+  trait ValDefApi extends ValOrDefDefApi { this: ValDef => }
+  val emptyValDef: ValDef // the result type is volatile
+}
+
+object Test {
+  val u: U = ???
+
+  (null: Any) match {
+    case _: u.emptyValDef.T => // and, unlike in pos/t6185.scala, we shouldn't allow this.
+  }
+}

--- a/test/files/neg/volatile_no_override.check
+++ b/test/files/neg/volatile_no_override.check
@@ -1,0 +1,5 @@
+volatile_no_override.scala:13: error: overriding value x in class A of type Volatile.this.D;
+ value x has a volatile type; cannot override a member with non-volatile type
+  val x: A with D = null
+      ^
+one error found

--- a/test/files/neg/volatile_no_override.scala
+++ b/test/files/neg/volatile_no_override.scala
@@ -1,0 +1,14 @@
+class B
+class C(x: String) extends B
+
+abstract class A {
+  class D { type T >: C <: B }
+  val x: D
+  var y: x.T = new C("abc")
+}
+
+class Volatile extends A {
+  type A >: Null
+  // test (1.4), pt 2 in RefChecks
+  val x: A with D = null
+}

--- a/test/files/pos/t6815.scala
+++ b/test/files/pos/t6815.scala
@@ -1,0 +1,17 @@
+trait U {
+  trait ValOrDefDefApi {
+    def name: Any
+  }
+  type ValOrDefDef <: ValOrDefDefApi
+  type ValDef <: ValOrDefDef with ValDefApi
+  trait ValDefApi extends ValOrDefDefApi { this: ValDef => }
+  val emptyValDef: ValDef // the result type is volatile
+}
+
+object Test {
+  val u: U = ???
+
+  u.emptyValDef match {
+    case u.emptyValDef => // but we shouldn't let that stop us from treating it as a stable identifier pattern.
+  }
+}

--- a/test/files/pos/t6815_import.scala
+++ b/test/files/pos/t6815_import.scala
@@ -1,0 +1,16 @@
+trait U {
+  trait ValOrDefDefApi {
+    def name: Any
+  }
+  type ValOrDefDef <: ValOrDefDefApi
+  type ValDef <: ValOrDefDef with ValDefApi
+  trait ValDefApi extends ValOrDefDefApi { this: ValDef => }
+  val emptyValDef: ValDef // the result type is volatile
+}
+
+object Test {
+  val u: U = ???
+
+  // but we shouldn't let that stop us from treating it as a stable identifier for import
+  import u.emptyValDef.name
+}


### PR DESCRIPTION
`Symbol::isStable` is now independent of `Symbol::hasVolatileType`,
so that we can allow stable identifiers that are volatile in ident patterns.

This split is validated by SI-6815 and the old logic in RefChecks,
which seems to assume this independence, and thus I don't think ever worked:

```
if (member.isStable && !otherTp.isVolatile) {
  if (memberTp.isVolatile)
    overrideError("has a volatile type; cannot override a member with non-volatile type")
```

Introduces `admitsTypeSelection` and `isStableIdentifierPattern` in treeInfo,
and uses them instead of duplicating that logic all over the place.

Since volatility only matters in the context of type application,
`isStableIdentifierPattern` is used to check patterns (resulting in `==` checks)
and imports.

review by @retronym & @paulp

I decided not to backport this to 2.10.x as it may introduce new errors.
