### PR TITLE
Nicer partest formatting of 4-digit test numbers

### DIFF
--- a/src/partest/scala/tools/partest/nest/NestUI.scala
+++ b/src/partest/scala/tools/partest/nest/NestUI.scala
@@ -62,7 +62,7 @@ object NestUI {
       else if (isOk) green("ok")
       else red("!!")
     )
-    word + f" $testNumber%3s - $testIdent%-40s$reasonString"
+    word + f" $testNumber%4s - $testIdent%-40s$reasonString"
   }
 
   def reportTest(state: TestState) = {


### PR DESCRIPTION
Because

  ...
  [partest] ok  999 - pos/t3534.scala
  [partest] ok 1000 - pos/t261-ba.scala
  ...

is so much nicer than

  ...
  [partest] ok 999 - pos/t3534.scala
  [partest] ok 1000 - pos/t261-ba.scala
  ...
