### PR TITLE
SI-6286 IllegalArgumentException handling specialized method.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -976,27 +976,24 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
           debuglog("specialized overload %s for %s in %s: %s".format(om, overriding.name.decode, pp(env), om.info))
           typeEnv(om) = env
           addConcreteSpecMethod(overriding)
-          info(om) = (
-            if (overriding.isDeferred) {    // abstract override
-              debuglog("abstract override " + overriding.fullName + " with specialized " + om.fullName)
-              Forward(overriding)
+          if (overriding.isDeferred) {    // abstract override
+            debuglog("abstract override " + overriding.fullName + " with specialized " + om.fullName)
+            info(om) = Forward(overriding)
+          }
+          else {
+            // if the override is a normalized member, 'om' gets the
+            // implementation from its original target, and adds the
+            // environment of the normalized member (that is, any
+            // specialized /method/ type parameter bindings)
+            info get overriding match {
+              case Some(NormalizedMember(target)) =>
+                typeEnv(om) = env ++ typeEnv(overriding)
+                info(om) = Forward(target)
+              case _ =>
+                info(om) = SpecialOverride(overriding)
             }
-            else {
-              // if the override is a normalized member, 'om' gets the
-              // implementation from its original target, and adds the
-              // environment of the normalized member (that is, any
-              // specialized /method/ type parameter bindings)
-              val impl = info get overriding match {
-                case Some(NormalizedMember(target)) =>
-                  typeEnv(om) = env ++ typeEnv(overriding)
-                  target
-                case _ =>
-                  overriding
-              }
-              info(overriding) = Forward(om setPos overriding.pos)
-              SpecialOverride(impl)
-            }
-          )
+            info(overriding) = Forward(om setPos overriding.pos)
+          }
           newOverload(overriding, om, env)
           ifDebug(afterSpecialize(assert(
             overridden.owner.info.decl(om.name) != NoSymbol,

--- a/test/files/pos/spec-t6286.scala
+++ b/test/files/pos/spec-t6286.scala
@@ -1,0 +1,10 @@
+trait Foo[@specialized(Int) A] {
+  def fun[@specialized(Int) B](init: B)(f: (B, A) => B): B
+}
+
+class Bar(values: Array[Int]) extends Foo[Int] {
+  def fun[@specialized(Int) C](init: C)(f: (C, Int) => C): C = {
+    val arr = values
+    f(init, arr(0))
+  }
+}


### PR DESCRIPTION
Specialize assigns SpecialOverride info to a specialized method
even when there is a further specialization that should be forwarded
to.
