### PR TITLE
Update tool-windows.tmpl

### DIFF
--- a/src/compiler/scala/tools/ant/templates/tool-windows.tmpl
+++ b/src/compiler/scala/tools/ant/templates/tool-windows.tmpl
@@ -13,9 +13,9 @@ setlocal enableextensions enabledelayedexpansion
 set _LINE_TOOLCP=
 
 :another_param
-
-if "%1%"=="-toolcp" (
-    set _LINE_TOOLCP=%2%
+rem fix ~ according to http://ss64.com/nt/syntax-args.html
+if "%~1"=="-toolcp" (
+    set _LINE_TOOLCP=%~2
 	shift
 	shift
 	goto another_param


### PR DESCRIPTION
changed "%1%" and %2% to "%~1" and %~2 to allow spaces in paths by surrounding quotes
according to advice at 
http://stackoverflow.com/questions/473117/pass-path-with-spaces-as-parameter-to-bat-file
http://ss64.com/nt/syntax-args.html

test case:
PS C:\Users\bjornr> scala -toolcp "test blank/myJar.jar" "test blank/myJar.jar"

with the suggested fix this test case will NOT print this error msg:
blank/myJar.jar""=="-toolcp" was unexpected at this time.
