### PR TITLE
SI-7358 Partest fails on scalacheck failure

### DIFF
--- a/src/partest/scala/tools/partest/nest/DirectRunner.scala
+++ b/src/partest/scala/tools/partest/nest/DirectRunner.scala
@@ -31,7 +31,7 @@ trait DirectRunner {
   )
   def runTestsForFiles(kindFiles: List[File], kind: String): List[TestState] = {
 
-    NestUI.resetTestNumber()
+    NestUI.resetTestNumber(kindFiles.size)
 
     val allUrls           = PathSettings.scalaCheck.toURL :: fileManager.latestUrls
     val parentClassLoader = ScalaClassLoader fromURLs allUrls

--- a/src/partest/scala/tools/partest/nest/NestUI.scala
+++ b/src/partest/scala/tools/partest/nest/NestUI.scala
@@ -27,9 +27,14 @@ class Colors(enabled: => Boolean) {
 
 object NestUI {
   private val testNum = new java.util.concurrent.atomic.AtomicInteger(1)
+  @volatile private var testNumberFmt = "%3d"
   // @volatile private var testNumber = 1
-  private def testNumber = "%3d" format testNum.getAndIncrement()
-  def resetTestNumber() = testNum set 1
+  private def testNumber = testNumberFmt format testNum.getAndIncrement()
+  def resetTestNumber(max: Int = -1) {
+    testNum set 1
+    val width = if (max > 0) max.toString.length else 3
+    testNumberFmt = s"%${width}d"
+  }
 
   var colorEnabled = sys.props contains "partest.colors"
   val color = new Colors(colorEnabled)
@@ -62,7 +67,7 @@ object NestUI {
       else if (isOk) green("ok")
       else red("!!")
     )
-    word + f" $testNumber%3s - $testIdent%-40s$reasonString"
+    f"$word $testNumber - $testIdent%-40s$reasonString"
   }
 
   def reportTest(state: TestState) = {


### PR DESCRIPTION
A failing test generates a test failure.
The failure log is added to the transcript.

Also, Partest testnum field width is sensitive to total tests.

Allow the hyphens to line up on a column within the output
for a test category or "kind".

```
$ partest files/neg/t4134.scala --run
Selected 1348 tests drawn from 1 named test categories, specified tests

& starting 1 test in neg
ok 1 - neg/t4134.scala

& starting 1347 tests in run
ok    1 - run/absoverride.scala
ok    2 - run/amp.scala
ok    3 - run/adding-growing-set.scala
```

Review by @soc who asked for it and @paulp who callled them transcripts instead of autopsies.
