### PR TITLE
SI-7360 Don't let a follow-up TypeError obscure the original error.

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1180,7 +1180,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
 
       ("\n" + info1) :: info2 :: info3 mkString "\n\n"
     }
-    catch { case x: Exception => errorMessage }
+    catch { case _: Exception | _: TypeError => errorMessage }
 
   /** The id of the currently active run
    */


### PR DESCRIPTION
When supplementing a fatal error message with context (current
compilation unit, tree, phase, etcetera), we must be cautious to
not to trigger another error which will obscure the original one.

Currently, `supplementErrorMessage` does its working a try catch
that only catches `Exception`. But this fails to catch
CyclicReferenceError (<: TypeError <: Throwable), as was seen
in a recent mailing list post by Greg Meredith.

This commit extends the catch clause.

Review by @paulp
