### PR TITLE
In the spirit of https://github.com/scala/scala/pull/2285

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -361,7 +361,7 @@ self =>
       if (mainModuleName == newTermName(ScriptRunner.defaultScriptMain))
         searchForMain() foreach { return _ }
 
-      /** Here we are building an AST representing the following source fiction,
+      /* Here we are building an AST representing the following source fiction,
        *  where `moduleName` is from -Xscript (defaults to "Main") and <stmts> are
        *  the result of parsing the script file.
        *

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -1179,7 +1179,7 @@ abstract class ClassfileParser {
         else enclosing.info member name
       )
       enteringTyperIfPossible(getMember)
-      /** There used to be an assertion that this result is not NoSymbol; changing it to an error
+      /* There used to be an assertion that this result is not NoSymbol; changing it to an error
        *  revealed it had been going off all the time, but has been swallowed by a catch t: Throwable
        *  in Repository.scala. Since it has been accomplishing nothing except misleading anyone who
        *  thought it wasn't triggering, I removed it entirely.

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
@@ -73,7 +73,7 @@ abstract class ICodeReader extends ClassfileParser {
   private def parseMember(field: Boolean): (JavaAccFlags, Symbol) = {
     val jflags   = JavaAccFlags(u2)
     val name     = pool getName u2
-    /** If we're parsing a scala module, the owner of members is always
+    /* If we're parsing a scala module, the owner of members is always
      *  the module symbol.
      */
     val owner = (

--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -266,7 +266,7 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
             gen.mkMethodCall(definitions.Boxes_isNumber, t :: Nil)
         )
 
-        /** The Tree => Tree function in the return is necessary to prevent the original qual
+        /* The Tree => Tree function in the return is necessary to prevent the original qual
          *  from being duplicated in the resulting code.  It may be a side-effecting expression,
          *  so all the test logic is routed through gen.evalOnce, which creates a block like
          *    { val x$1 = qual; if (x$1.foo || x$1.bar) f1(x$1) else f2(x$1) }

--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -378,7 +378,7 @@ abstract class ExplicitOuter extends InfoTransform
         if (outerAcc.isDeferred) EmptyTree
         else This(currentClass) DOT outerField(currentClass)
 
-      /** If we don't re-type the tree, we see self-type related crashes like #266.
+      /* If we don't re-type the tree, we see self-type related crashes like #266.
        */
       localTyper typed {
         (DEF(outerAcc) withPos currentClass.pos withType null) === rhs

--- a/src/compiler/scala/tools/nsc/transform/Mixin.scala
+++ b/src/compiler/scala/tools/nsc/transform/Mixin.scala
@@ -807,7 +807,7 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
         override def apply[T <: Tree](tree: T): T = if (from.isEmpty) tree else super.apply(tree)
       }
 
-      /** return a 'lazified' version of rhs. It uses double-checked locking to ensure
+      /* return a 'lazified' version of rhs. It uses double-checked locking to ensure
        *  initialization is performed at most once. For performance reasons the double-checked
        *  locking is split into two parts, the first (fast) path checks the bitmap without
        *  synchronizing, and if that fails it initializes the lazy val within the
@@ -1145,7 +1145,7 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
           qual
 
         case Apply(Select(qual, _), args) =>
-          /** Changes `qual.m(args)` where m refers to an implementation
+          /* Changes `qual.m(args)` where m refers to an implementation
            *  class method to Q.m(S, args) where Q is the implementation module of
            *  `m` and S is the self parameter for the call, which
            *  is determined as follows:

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -1387,7 +1387,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
 
     def transform1(tree: Tree) = {
       val symbol = tree.symbol
-      /** The specialized symbol of 'tree.symbol' for tree.tpe, if there is one */
+      /* The specialized symbol of 'tree.symbol' for tree.tpe, if there is one */
       def specSym(qual: Tree): Symbol = {
         val env = unify(symbol.tpe, tree.tpe, emptyEnv, false)
         def isMatch(member: Symbol) = (

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -515,7 +515,7 @@ trait Contexts { self: Analyzer =>
         (linked ne NoSymbol) && accessWithin(linked)
       }
 
-      /** Are we inside definition of `ab`? */
+      /* Are we inside definition of `ab`? */
       def accessWithin(ab: Symbol) = {
         // #3663: we must disregard package nesting if sym isJavaDefined
         if (sym.isJavaDefined) {

--- a/src/library/scala/collection/mutable/Map.scala
+++ b/src/library/scala/collection/mutable/Map.scala
@@ -47,7 +47,7 @@ trait Map[A, B]
    */
   def withDefaultValue(d: B): mutable.Map[A, B] = new Map.WithDefault[A, B](this, x => d)
 
-  /** Return a read-only projection of this map.  !!! or just use an (immutable) MapProxy?
+  /* Return a read-only projection of this map.  !!! or just use an (immutable) MapProxy?
   def readOnly : scala.collection.Map[A, B] = new scala.collection.Map[A, B] {
     override def size = self.size
     override def update(key: A, value: B) = self.update(key, value)

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3059,7 +3059,7 @@ trait Types
         else lhs <:< rhs
       }
 
-      /** Simple case: type arguments can be ignored, because either this typevar has
+      /* Simple case: type arguments can be ignored, because either this typevar has
        *  no type parameters, or we are comparing to Any/Nothing.
        *
        *  The latter condition is needed because HK unification is limited to constraints of the shape
@@ -3086,7 +3086,7 @@ trait Types
         } else false
       }
 
-      /** Full case: involving a check of the form
+      /* Full case: involving a check of the form
        *  {{{
        *    TC1[T1,..., TN] <: TC2[T'1,...,T'N]
        *  }}}

--- a/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
@@ -186,7 +186,7 @@ trait TypeComparers {
   }
 
   def isSameType2(tp1: Type, tp2: Type): Boolean = {
-    /** Here we highlight those unfortunate type-like constructs which
+    /* Here we highlight those unfortunate type-like constructs which
      *  are hidden bundles of mutable state, cruising the type system picking
      *  up any type constraints naive enough to get into their hot rods.
      */
@@ -215,7 +215,7 @@ trait TypeComparers {
       }
       case _ => false
     }
-    /** Those false cases certainly are ugly. There's a proposed SIP to deuglify it.
+    /* Those false cases certainly are ugly. There's a proposed SIP to deuglify it.
      *    https://docs.google.com/a/improving.org/document/d/1onPrzSqyDpHScc9PS_hpxJwa3FlPtthxw-bAuuEe8uA
      */
     def sameTypeAndSameCaseClass = tp1 match {


### PR DESCRIPTION
Changed unrecognized doc comments from Doc to C style, silencing scaladoc some
more

This has been obtained automatically by processing scaladoc log output, then checked manually
(for e.g. comments tha tshould be recognized as scaladoc)
