### PR TITLE
SI-7376 Scaladoc warns when discarding local doc comments with API tags

### DIFF
--- a/src/compiler/scala/reflect/macros/runtime/Typers.scala
+++ b/src/compiler/scala/reflect/macros/runtime/Typers.scala
@@ -11,7 +11,7 @@ trait Typers {
   def openImplicits: List[(Type, Tree)] = callsiteTyper.context.openImplicits
 
   /**
-   * @see [[scala.tools.reflect.Toolbox.typeCheck]]
+   * @see [[scala.tools.reflect.ToolBox.typeCheck]]
    */
   def typeCheck(tree: Tree, pt: Type = universe.WildcardType, silent: Boolean = false, withImplicitViewsDisabled: Boolean = false, withMacrosDisabled: Boolean = false): Tree = {
     macroLogVerbose("typechecking %s with expected type %s, implicit views = %s, macros = %s".format(tree, pt, !withImplicitViewsDisabled, !withMacrosDisabled))

--- a/src/compiler/scala/reflect/reify/Reifier.scala
+++ b/src/compiler/scala/reflect/reify/Reifier.scala
@@ -8,8 +8,9 @@ import scala.reflect.reify.utils.Utils
 /** Given a tree or a type, generate a tree that when executed at runtime produces the original tree or type.
  *  See more info in the comments to `reify` in scala.reflect.api.Universe.
  *
- * @author Martin Odersky
- *  @version 2.10
+ *  @author   Martin Odersky
+ *  @version  2.10
+ *  @since    2.10
  */
 abstract class Reifier extends States
                           with Phases
@@ -31,20 +32,20 @@ abstract class Reifier extends States
     this.asInstanceOf[Reifier { val global: Reifier.this.global.type }]
   override def hasReifier = true
 
-  /**
-   *  For `reifee` and other reification parameters, generate a tree of the form
-   *
+  /** For `reifee` and other reification parameters, generate a tree of the form
+   *  {{{
    *    {
-   *      val $u: universe.type = <[ universe ]>
-   *      val $m: $u.Mirror = <[ mirror ]>
-   *      $u.Expr[T](rtree)       // if data is a Tree
-   *      $u.TypeTag[T](rtree)    // if data is a Type
+   *      val \$u: universe.type = <[ universe ]>
+   *      val \$m: \$u.Mirror = <[ mirror ]>
+   *      \$u.Expr[T](rtree)       // if data is a Tree
+   *      \$u.TypeTag[T](rtree)    // if data is a Type
    *    }
+   *  }}}
    *
    *  where
    *
-   *    - `universe` is the tree that represents the universe the result will be bound to
-   *    - `mirror` is the tree that represents the mirror the result will be initially bound to
+   *    - `universe` is the tree that represents the universe the result will be bound to.
+   *    - `mirror` is the tree that represents the mirror the result will be initially bound to.
    *    - `rtree` is code that generates `reifee` at runtime.
    *    - `T` is the type that corresponds to `data`.
    *

--- a/src/compiler/scala/reflect/reify/phases/Metalevels.scala
+++ b/src/compiler/scala/reflect/reify/phases/Metalevels.scala
@@ -11,7 +11,7 @@ trait Metalevels {
   /**
    *  Makes sense of cross-stage bindings.
    *
-   *  ================
+   *  ----------------
    *
    *  Analysis of cross-stage bindings becomes convenient if we introduce the notion of metalevels.
    *  Metalevel of a tree is a number that gets incremented every time you reify something and gets decremented when you splice something.
@@ -53,7 +53,7 @@ trait Metalevels {
    *  1) Runtime eval that services dynamic splices requires scala-compiler.jar, which might not be on library classpath
    *  2) Runtime eval incurs a severe performance penalty, so it'd better to be explicit about it
    *
-   *  ================
+   *  ----------------
    *
    *  As we can see, the only problem is the fact that lhs'es of `splice` can be code blocks that can capture variables from the outside.
    *  Code inside the lhs of an `splice` is not reified, while the code from the enclosing reify is.

--- a/src/compiler/scala/tools/nsc/ast/DocComments.scala
+++ b/src/compiler/scala/tools/nsc/ast/DocComments.scala
@@ -366,7 +366,10 @@ trait DocComments { self: Global =>
             case vname  =>
               lookupVariable(vname, site) match {
                 case Some(replacement) => replaceWith(replacement)
-                case None              => reporter.warning(sym.pos, "Variable " + vname + " undefined in comment for " + sym + " in " + site)
+                case None              =>
+                  val pos = docCommentPos(sym)
+                  val loc = pos withPoint (pos.start + vstart + 1)
+                  reporter.warning(loc, s"Variable $vname undefined in comment for $sym in $site")
               }
             }
         }

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenJVMASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenJVMASM.scala
@@ -8,11 +8,11 @@ package backend.jvm
 import scala.tools.nsc.io.AbstractFile
 import scala.tools.nsc.symtab._
 
-/** Code shared between the legagy backend [[scala.tools.nsc.backend.jvm.GenJVM]]
-  * and the new backend [[scala.tools.nsc.backend.jvm.GenASM]]. There should be
-  * more here, but for now I'm starting with the refactorings that are either
-  * straightforward to review or necessary for maintenance.
-  */
+/** Code shared between the erstwhile legacy backend (aka GenJVM)
+ *  and the new backend [[scala.tools.nsc.backend.jvm.GenASM]]. There should be
+ *  more here, but for now I'm starting with the refactorings that are either
+ *  straightforward to review or necessary for maintenance.
+ */
 trait GenJVMASM {
   val global: Global
   import global._

--- a/test/scaladoc/run/t5527.check
+++ b/test/scaladoc/run/t5527.check
@@ -1,6 +1,12 @@
 newSource1:47: warning: discarding unmoored doc comment
         /** Document this crucial constant for posterity.
         ^
+newSource1:64: warning: discarding unmoored doc comment
+        /*************************\
+        ^
+newSource1:73: warning: discarding unmoored doc comment
+        val i = 10 */** Important!
+                   ^
 [[syntax trees at end of                    parser]] // newSource1
 package <empty> {
   object UselessComments extends scala.AnyRef {
@@ -54,6 +60,14 @@ package <empty> {
     def test7 = {
       val u = 4;
       0.to(u).foreach(((i) => println(i)))
+    };
+    def test8 = {
+      val z = "fancy";
+      z.replace("fanc", "arts")
+    };
+    def test9 = {
+      val i = 10.$times(10);
+      assert(i.$eq$eq(100))
     }
   };
   /** comments that we should keep */
@@ -108,7 +122,11 @@ package <empty> {
         super.<init>();
         ()
       }
-    }
+    };
+    /** Get the simple value.
+       *  @return the default value
+       */
+    def value: Int = 7
   }
 }
 

--- a/test/scaladoc/run/t5527.check
+++ b/test/scaladoc/run/t5527.check
@@ -1,11 +1,5 @@
-newSource1:17: warning: discarding unmoored doc comment
-          /** Testing 123 */
-          ^
-newSource1:27: warning: discarding unmoored doc comment
-        /** Calculate this result. */
-        ^
-newSource1:34: warning: discarding unmoored doc comment
-        /** Another digit is a giveaway. */
+newSource1:47: warning: discarding unmoored doc comment
+        /** Document this crucial constant for posterity.
         ^
 [[syntax trees at end of                    parser]] // newSource1
 package <empty> {
@@ -48,6 +42,18 @@ package <empty> {
     val test4 = 'a' match {
       case ('0'| '1'| '2'| '3'| '4'| '5'| '6'| '7'| '8'| '9') => true
       case _ => false
+    };
+    def test5: scala.Unit = if (true)
+      $qmark$qmark$qmark
+    else
+      ();
+    def test6 = {
+      val u = 4;
+      0.to(u).foreach(((i) => println(i)))
+    };
+    def test7 = {
+      val u = 4;
+      0.to(u).foreach(((i) => println(i)))
     }
   };
   /** comments that we should keep */

--- a/test/scaladoc/run/t5527.scala
+++ b/test/scaladoc/run/t5527.scala
@@ -72,6 +72,24 @@ object Test extends DirectTest {
         for (i <- 0 to u)
           println(i)
       }
+      def test8 = {
+        /*************************\
+         * Fancy ASCII Art Block *
+         *   @author som-snytt   *
+        \*************************/
+        // this is just a local
+        val z = "fancy"
+        z replace ("fanc", "arts")
+      }
+      def test9 = {
+        val i = 10 */** Important!
+                     *  We have to multiply here!
+                     *  @author community
+                     *  @see SI-1234
+                     */
+                10
+        assert(i == 100)
+      }
     }
 
     /** comments that we should keep */
@@ -108,6 +126,13 @@ object Test extends DirectTest {
       /** class D */
       @deprecated("use ... instead", "2.10.0")
       class D
+
+      /** Get the simple value.
+       *  @return the default value
+       */
+      // an intervening line comment
+      /* I had more to say, but didn't want to pollute the scaladoc. */
+      def value: Int = 7
     }
   """.trim
 

--- a/test/scaladoc/run/t5527.scala
+++ b/test/scaladoc/run/t5527.scala
@@ -49,6 +49,29 @@ object Test extends DirectTest {
         case _ =>
           false
       }
+
+      def test5 {
+        /** @martin is this right? It shouldn't flag me as scaladoc. */
+        if (true) ???
+      }
+
+      def test6 = {
+        /** Document this crucial constant for posterity.
+         *  Don't forget to dedoc this comment if you refactor to a local.
+         *  @author Paul Phillips
+         */
+        val u = 4
+        for (i <- 0 to u)
+          println(i)
+      }
+      def test7 = {
+        /** Some standard tags are tolerated locally and shouldn't trigger a warning.
+         *  @note Don't change this unless you know what you're doing. This means you.
+         */
+        val u = 4
+        for (i <- 0 to u)
+          println(i)
+      }
     }
 
     /** comments that we should keep */


### PR DESCRIPTION
Double-star doc comments in non-dockable positions at the end of a block
will emit a warning only if API tags like @author are present, or under
-Xlint.

A real comment parser is applied early to probe for tags, to minimize
ad hoc testing or duplication, but warnings are suppressed. Residual
ad hockiness lies in precisely which tags to warn on.  Ad hoc or ad doc.

This fix is a stop gap; a richer solution would also report about other
doc locations that won't be processed.

Review by @paulp, of whose idea this is a refinement.  Of whom?

I'll also take advice from Mr Thor @author.  Not sure whom best to impose upon.  Upon whom?
