### PR TITLE
Optimize matching on tuples

### DIFF
--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -422,6 +422,14 @@ filter {
         {
             matchName="scala.reflect.internal.Types#TypeVar.setInst"
             problemName=IncompatibleResultTypeProblem
+        },
+        {
+            matchName="scala.reflect.internal.TreeInfo.TupleCtor"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.TreeInfo.TuplePattern"
+            problemName=MissingMethodProblem
         }
     ]
 }

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -152,12 +152,12 @@ trait MatchApproximation extends TreeAndTypeAnalysis with ScalaLogic with MatchT
     }
 
 
-    class TreeMakersToPropsIgnoreNullChecks(root: Symbol) extends TreeMakersToProps(root) {
+    class TreeMakersToPropsIgnoreNullChecks(scrutinee: Scrutinee) extends TreeMakersToProps(scrutinee) {
       override def uniqueNonNullProp(p: Tree): Prop = True
     }
 
     // returns (tree, tests), where `tree` will be used to refer to `root` in `tests`
-    class TreeMakersToProps(val root: Symbol) {
+    class TreeMakersToProps(val scrutinee: Scrutinee) {
       prepareNewAnalysis() // reset hash consing for Var and Const
 
       private[this] val uniqueEqualityProps = new scala.collection.mutable.HashMap[(Tree, Tree), Eq]
@@ -175,7 +175,7 @@ trait MatchApproximation extends TreeAndTypeAnalysis with ScalaLogic with MatchT
         uniqueTypeProps getOrElseUpdate((testedPath, pt), Eq(Var(testedPath), TypeConst(checkableType(pt))))
 
       // a variable in this set should never be replaced by a tree that "does not consist of a selection on a variable in this set" (intuitively)
-      private val pointsToBound = mutable.HashSet(root)
+      private val pointsToBound = mutable.HashSet(scrutinee.sym)
       private val trees         = mutable.HashSet.empty[Tree]
 
       // the substitution that renames variables to variables in pointsToBound
@@ -321,8 +321,8 @@ trait MatchApproximation extends TreeAndTypeAnalysis with ScalaLogic with MatchT
       }
     }
 
-    def approximateMatchConservative(root: Symbol, cases: List[List[TreeMaker]]): List[List[Test]] =
-      (new TreeMakersToProps(root)).approximateMatch(cases)
+    def approximateMatchConservative(scrutinee: Scrutinee, cases: List[List[TreeMaker]]): List[List[Test]] =
+      (new TreeMakersToProps(scrutinee)).approximateMatch(cases)
 
     // turns a case (represented as a list of abstract tests)
     // into a proposition that is satisfiable if the case may match
@@ -365,13 +365,13 @@ trait MatchAnalysis extends MatchApproximation {
     // the case is reachable if there is a model for -P /\ C,
     // thus, the case is unreachable if there is no model for -(-P /\ C),
     // or, equivalently, P \/ -C, or C => P
-    def unreachableCase(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type): Option[Int] = {
+    def unreachableCase(scrutinee: Scrutinee, cases: List[List[TreeMaker]], pt: Type): Option[Int] = {
       val start = if (Statistics.canEnable) Statistics.startTimer(patmatAnaReach) else null
 
       // use the same approximator so we share variables,
       // but need different conditions depending on whether we're conservatively looking for failure or success
       // don't rewrite List-like patterns, as List() and Nil need to distinguished for unreachability
-      val approx = new TreeMakersToProps(prevBinder)
+      val approx = new TreeMakersToProps(scrutinee)
       def approximate(default: Prop) = approx.approximateMatch(cases, approx.onUnknown { tm =>
         approx.refutableRewrite.applyOrElse(tm, (_: TreeMaker) => default )
       })
@@ -419,14 +419,14 @@ trait MatchAnalysis extends MatchApproximation {
         if (reachable) None else Some(caseIndex)
       } catch {
         case ex: AnalysisBudget.Exception =>
-          warn(prevBinder.pos, ex, "unreachability")
+          warn(scrutinee.pos, ex, "unreachability")
           None // CNF budget exceeded
       }
     }
 
     // exhaustivity
 
-    def exhaustive(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type): List[String] = if (uncheckableType(prevBinder.info)) Nil else {
+    def exhaustive(scrutinee: Scrutinee, cases: List[List[TreeMaker]], pt: Type): List[String] = if (uncheckableType(scrutinee.info)) Nil else {
       // customize TreeMakersToProps (which turns a tree of tree makers into a more abstract DAG of tests)
       // - approximate the pattern `List()` (unapplySeq on List with empty length) as `Nil`,
       //   otherwise the common (xs: List[Any]) match { case List() => case x :: xs => } is deemed unexhaustive
@@ -436,7 +436,7 @@ trait MatchAnalysis extends MatchApproximation {
       val start = if (Statistics.canEnable) Statistics.startTimer(patmatAnaExhaust) else null
       var backoff = false
 
-      val approx = new TreeMakersToPropsIgnoreNullChecks(prevBinder)
+      val approx = new TreeMakersToPropsIgnoreNullChecks(scrutinee)
       val symbolicCases = approx.approximateMatch(cases, approx.onUnknown { tm =>
         approx.fullRewrite.applyOrElse[TreeMaker, Prop](tm, {
           case BodyTreeMaker(_, _) => True // irrelevant -- will be discarded by symbolCase later
@@ -447,8 +447,6 @@ trait MatchAnalysis extends MatchApproximation {
       }) map caseWithoutBodyToProp
 
       if (backoff) Nil else {
-        val prevBinderTree = approx.binderToUniqueTree(prevBinder)
-
         // TODO: null tests generate too much noise, so disabled them -- is there any way to bring them back?
         // assuming we're matching on a non-null scrutinee (prevBinder), when does the match fail?
         // val nonNullScrutineeCond =
@@ -473,16 +471,17 @@ trait MatchAnalysis extends MatchApproximation {
           // find the models (under which the match fails)
           val matchFailModels = findAllModelsFor(propToSolvable(matchFails))
 
-          val scrutVar = Var(prevBinderTree)
-          val counterExamples = matchFailModels.map(modelToCounterExample(scrutVar))
+          // result.length == matchFailModels.length so that transpose below is safe
+          def examplesFor(rootSym: Symbol) =
+            matchFailModels.map(modelToCounterExample(Var(approx.binderToUniqueTree(rootSym))))
 
-          val pruned = CounterExample.prune(counterExamples).map(_.toString).sorted
+          val examples = examplesFor(scrutinee.sym)
 
           if (Statistics.canEnable) Statistics.stopTimer(patmatAnaExhaust, start)
-          pruned
+          CounterExample.prune(examples).map(_.toString).sorted
         } catch {
           case ex : AnalysisBudget.Exception =>
-            warn(prevBinder.pos, ex, "exhaustivity")
+            warn(scrutinee.pos, ex, "exhaustivity")
             Nil // CNF budget exceeded
         }
       }
@@ -691,16 +690,16 @@ trait MatchAnalysis extends MatchApproximation {
       VariableAssignment(scrutVar).toCounterExample()
     }
 
-    def analyzeCases(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type, suppression: Suppression): Unit = {
+    def analyzeCases(scrutinee: Scrutinee, cases: List[List[TreeMaker]], pt: Type, suppression: Suppression): Unit = {
       if (!suppression.unreachable) {
-        unreachableCase(prevBinder, cases, pt) foreach { caseIndex =>
+        unreachableCase(scrutinee, cases, pt) foreach { caseIndex =>
           reportUnreachable(cases(caseIndex).last.pos)
         }
       }
       if (!suppression.exhaustive) {
-        val counterExamples = exhaustive(prevBinder, cases, pt)
+        val counterExamples = exhaustive(scrutinee, cases, pt)
         if (counterExamples.nonEmpty)
-          reportMissingCases(prevBinder.pos, counterExamples)
+          reportMissingCases(scrutinee.pos, counterExamples)
       }
     }
   }

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchCodeGen.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchCodeGen.scala
@@ -40,7 +40,7 @@ trait MatchCodeGen extends Interface {
 
     // codegen relevant to the structure of the translation (how extractors are combined)
     trait AbsCodegen {
-      def matcher(scrutinee: Scrutinee, restpe: Type)(cases: List[Casegen => Tree], matchFailGen: Option[Tree => Tree]): Tree
+      def matcher(scrutinee: Scrutinee, restpe: Type)(cases: List[Casegen => Tree], defaultCase: Option[Tree]): Tree
 
       // local / context-free
       def _asInstanceOf(b: Symbol, tp: Type): Tree
@@ -114,7 +114,7 @@ trait MatchCodeGen extends Interface {
       //// methods in MatchingStrategy (the monad companion) -- used directly in translation
       // __match.runOrElse(`scrut`)(`scrutSym` => `matcher`)
       // TODO: consider catchAll, or virtualized matching will break in exception handlers
-      def matcher(scrutinee: Scrutinee, restpe: Type)(cases: List[Casegen => Tree], matchFailGen: Option[Tree => Tree]): Tree =
+      def matcher(scrutinee: Scrutinee, restpe: Type)(cases: List[Casegen => Tree], defaultCase: Option[Tree]): Tree =
         _match(vpmName.runOrElse) APPLY (scrutinee.selector) APPLY (fun(scrutinee.sym, cases map (f => f(this)) reduceLeft typedOrElse))
 
       // __match.one(`res`)
@@ -157,7 +157,7 @@ trait MatchCodeGen extends Interface {
        * the matcher's optional result is encoded as a flag, keepGoing, where keepGoing == true encodes result.isEmpty,
        * if keepGoing is false, the result Some(x) of the naive translation is encoded as matchRes == x
        */
-      def matcher(scrutinee: Scrutinee, restpe: Type)(cases: List[Casegen => Tree], matchFailGen: Option[Tree => Tree]): Tree = {
+      def matcher(scrutinee: Scrutinee, restpe: Type)(cases: List[Casegen => Tree], defaultCase: Option[Tree]): Tree = {
         val matchEnd = newSynthCaseLabel("matchEnd")
         val matchRes = NoSymbol.newValueParameter(newTermName("x"), NoPosition, newFlags = SYNTHETIC) setInfo restpe.withoutAnnotations
         matchEnd setInfo MethodType(List(matchRes), restpe)
@@ -176,8 +176,8 @@ trait MatchCodeGen extends Interface {
         // must compute catchAll after caseLabels (side-effects nextCase)
         // catchAll.isEmpty iff no synthetic default case needed (the (last) user-defined case is a default)
         // if the last user-defined case is a default, it will never jump to the next case; it will go immediately to matchEnd
-        val catchAllDef = matchFailGen map { matchFailGen =>
-          LabelDef(_currCase, Nil, matchEnd APPLY (matchFailGen(scrutinee.ref)))
+        val catchAllDef = defaultCase map { defaultCase =>
+          LabelDef(_currCase, Nil, matchEnd APPLY (defaultCase))
         } toList // at most 1 element
 
         // the generated block is taken apart in TailCalls under the following assumptions
@@ -191,8 +191,8 @@ trait MatchCodeGen extends Interface {
       }
 
       class OptimizedCasegen(matchEnd: Symbol, nextCase: Symbol) extends CommonCodegen with Casegen {
-        def matcher(scrutinee: Scrutinee, restpe: Type)(cases: List[Casegen => Tree], matchFailGen: Option[Tree => Tree]): Tree =
-          optimizedCodegen.matcher(scrutinee, restpe)(cases, matchFailGen)
+        def matcher(scrutinee: Scrutinee, restpe: Type)(cases: List[Casegen => Tree], defaultCase: Option[Tree]): Tree =
+          optimizedCodegen.matcher(scrutinee, restpe)(cases, defaultCase)
 
         // only used to wrap the RHS of a body
         // res: T

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
@@ -605,10 +605,7 @@ trait MatchOptimization extends MatchTreeMaking with MatchAnalysis {
     override def optimizeCases(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type): (List[List[TreeMaker]], List[Tree]) = {
       // TODO: do CSE on result of doDCE(prevBinder, cases, pt)
       val optCases = doCSE(prevBinder, cases, pt)
-      val toHoist = (
-        for (treeMakers <- optCases)
-          yield treeMakers.collect{case tm: ReusedCondTreeMaker => tm.treesToHoist}
-        ).flatten.flatten.toList
+      val toHoist  = distinctBy(optCases.flatMap(treeMakers => treeMakers.collect{case tm: ReusedCondTreeMaker => tm.treesToHoist}.flatten))(_.symbol)
       (optCases, toHoist)
     }
   }

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
@@ -511,7 +511,11 @@ trait MatchOptimization extends MatchTreeMaking with MatchAnalysis {
     }
 
     class RegularSwitchMaker(scrutinee: Scrutinee, defaultCaseOverride: Option[Tree], val unchecked: Boolean) extends SwitchMaker {
-      val switchableTpe = Set(ByteClass.tpe, ShortClass.tpe, IntClass.tpe, CharClass.tpe)
+      private val switchableTpe = Set(ByteClass.tpe, ShortClass.tpe, IntClass.tpe, CharClass.tpe)
+      def switchable(scrutinee: Scrutinee) = scrutinee match {
+        case scrutinee: SingleScrutinee => switchableTpe(dealiasWiden(scrutinee.info))
+        case _ => false
+      }
       val alternativesSupported = true
       val canJump = true
 
@@ -545,7 +549,7 @@ trait MatchOptimization extends MatchTreeMaking with MatchAnalysis {
     override def emitSwitch(scrutinee: Scrutinee, cases: List[List[TreeMaker]], pt: Type, defaultCaseOverride: Option[Tree], unchecked: Boolean): Option[Tree] = { import CODE._
       val regularSwitchMaker = new RegularSwitchMaker(scrutinee, defaultCaseOverride, unchecked)
       // TODO: if patterns allow switch but the type of the scrutinee doesn't, cast (type-test) the scrutinee to the corresponding switchable type and switch on the result
-      if ((scrutinee.sym != NoSymbol) && regularSwitchMaker.switchableTpe(dealiasWiden(scrutinee.info))) {
+      if (regularSwitchMaker.switchable(scrutinee)) {
         val caseDefsWithDefault = regularSwitchMaker(cases map {c => (scrutinee.sym, c)}, pt)
         if (caseDefsWithDefault isEmpty) None // not worth emitting a switch.
         else {

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
@@ -510,7 +510,7 @@ trait MatchOptimization extends MatchTreeMaking with MatchAnalysis {
         }
     }
 
-    class RegularSwitchMaker(scrutinee: Scrutinee, matchFailGenOverride: Option[Tree => Tree], val unchecked: Boolean) extends SwitchMaker {
+    class RegularSwitchMaker(scrutinee: Scrutinee, defaultCaseOverride: Option[Tree], val unchecked: Boolean) extends SwitchMaker {
       val switchableTpe = Set(ByteClass.tpe, ShortClass.tpe, IntClass.tpe, CharClass.tpe)
       val alternativesSupported = true
       val canJump = true
@@ -536,14 +536,14 @@ trait MatchOptimization extends MatchTreeMaking with MatchAnalysis {
       }
 
       def defaultSym: Symbol = scrutinee.sym
-      def defaultBody: Tree  = { import CODE._; matchFailGenOverride map (gen => gen(scrutinee.ref)) getOrElse MATCHERROR(scrutinee.ref) }
+      def defaultBody: Tree  = { import CODE._; defaultCaseOverride getOrElse MATCHERROR(scrutinee.ref) }
       def defaultCase(scrutSym: Symbol = defaultSym, guard: Tree = EmptyTree, body: Tree = defaultBody): CaseDef = { import CODE._; atPos(body.pos) {
         (DEFAULT IF guard) ==> body
       }}
     }
 
-    override def emitSwitch(scrutinee: Scrutinee, cases: List[List[TreeMaker]], pt: Type, matchFailGenOverride: Option[Tree => Tree], unchecked: Boolean): Option[Tree] = { import CODE._
-      val regularSwitchMaker = new RegularSwitchMaker(scrutinee, matchFailGenOverride, unchecked)
+    override def emitSwitch(scrutinee: Scrutinee, cases: List[List[TreeMaker]], pt: Type, defaultCaseOverride: Option[Tree], unchecked: Boolean): Option[Tree] = { import CODE._
+      val regularSwitchMaker = new RegularSwitchMaker(scrutinee, defaultCaseOverride, unchecked)
       // TODO: if patterns allow switch but the type of the scrutinee doesn't, cast (type-test) the scrutinee to the corresponding switchable type and switch on the result
       if ((scrutinee.sym != NoSymbol) && regularSwitchMaker.switchableTpe(dealiasWiden(scrutinee.info))) {
         val caseDefsWithDefault = regularSwitchMaker(cases map {c => (scrutinee.sym, c)}, pt)

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
@@ -36,10 +36,10 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
 // the making of the trees
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   trait TreeMakers extends TypedSubstitution with CodegenCore {
-    def optimizeCases(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type): (List[List[TreeMaker]], List[Tree])
-    def analyzeCases(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type, suppression: Suppression): Unit
+    def optimizeCases(scrutinee: Scrutinee, cases: List[List[TreeMaker]], pt: Type): (List[List[TreeMaker]], List[Tree])
+    def analyzeCases(scrutinee: Scrutinee, cases: List[List[TreeMaker]], pt: Type, suppression: Suppression): Unit
 
-    def emitSwitch(scrut: Tree, scrutSym: Symbol, cases: List[List[TreeMaker]], pt: Type, matchFailGenOverride: Option[Tree => Tree], unchecked: Boolean): Option[Tree] =
+    def emitSwitch(scrutinee: Scrutinee, cases: List[List[TreeMaker]], pt: Type, matchFailGenOverride: Option[Tree => Tree], unchecked: Boolean): Option[Tree] =
       None
 
     // for catch (no need to customize match failure)
@@ -485,7 +485,7 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
             ((casegen: Casegen) => combineExtractors(altTreeMakers :+ TrivialTreeMaker(casegen.one(mkTRUE)))(casegen))
           )
 
-          val findAltMatcher = codegenAlt.matcher(EmptyTree, NoSymbol, BooleanClass.tpe)(combinedAlts, Some(x => mkFALSE))
+          val findAltMatcher = codegenAlt.matcher(NoScrutinee, BooleanClass.tpe)(combinedAlts, Some(x => mkFALSE))
           codegenAlt.ifThenElseZero(findAltMatcher, substitution(next))
         }
       }
@@ -518,21 +518,21 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
     }
 
     // calls propagateSubstitution on the treemakers
-    def combineCases(scrut: Tree, scrutSym: Symbol, casesRaw: List[List[TreeMaker]], pt: Type, owner: Symbol, matchFailGenOverride: Option[Tree => Tree]): Tree = {
+    def combineCases(scrutinee: Scrutinee, casesRaw: List[List[TreeMaker]], pt: Type, owner: Symbol, matchFailGenOverride: Option[Tree => Tree]): Tree = {
       // drops SubstOnlyTreeMakers, since their effect is now contained in the TreeMakers that follow them
       val casesNoSubstOnly = casesRaw map (propagateSubstitution(_, EmptySubstitution))
-      combineCasesNoSubstOnly(scrut, scrutSym, casesNoSubstOnly, pt, owner, matchFailGenOverride)
+      combineCasesNoSubstOnly(scrutinee, casesNoSubstOnly, pt, owner, matchFailGenOverride)
     }
 
     // pt is the fully defined type of the cases (either pt or the lub of the types of the cases)
-    def combineCasesNoSubstOnly(scrut: Tree, scrutSym: Symbol, casesNoSubstOnly: List[List[TreeMaker]], pt: Type, owner: Symbol, matchFailGenOverride: Option[Tree => Tree]): Tree =
-      fixerUpper(owner, scrut.pos){
+    def combineCasesNoSubstOnly(scrutinee: Scrutinee, casesNoSubstOnly: List[List[TreeMaker]], pt: Type, owner: Symbol, matchFailGenOverride: Option[Tree => Tree]): Tree =
+      fixerUpper(owner, scrutinee.pos){
         def matchFailGen = (matchFailGenOverride orElse Some(CODE.MATCHERROR(_: Tree)))
         debug.patmat("combining cases: "+ (casesNoSubstOnly.map(_.mkString(" >> ")).mkString("{", "\n", "}")))
 
         val (suppression, requireSwitch): (Suppression, Boolean) =
           if (settings.XnoPatmatAnalysis.value) (Suppression.NoSuppression, false)
-          else scrut match {
+          else scrutinee.selector match {
             case Typed(tree, tpt) =>
               val suppressExhaustive = tpt.tpe hasAnnotation UncheckedClass
               val supressUnreachable = tree match {
@@ -547,15 +547,15 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
               (Suppression.NoSuppression, false)
           }
 
-        emitSwitch(scrut, scrutSym, casesNoSubstOnly, pt, matchFailGenOverride, suppression.exhaustive).getOrElse{
-          if (requireSwitch) typer.context.unit.warning(scrut.pos, "could not emit switch for @switch annotated match")
+        emitSwitch(scrutinee, casesNoSubstOnly, pt, matchFailGenOverride, suppression.exhaustive).getOrElse{
+          if (requireSwitch) typer.context.unit.warning(scrutinee.pos, "could not emit switch for @switch annotated match")
 
           if (casesNoSubstOnly nonEmpty) {
             // before optimizing, check casesNoSubstOnly for presence of a default case,
             // since DCE will eliminate trivial cases like `case _ =>`, even if they're the last one
             // exhaustivity and reachability must be checked before optimization as well
             // TODO: improve notion of trivial/irrefutable -- a trivial type test before the body still makes for a default case
-            //   ("trivial" depends on whether we're emitting a straight match or an exception, or more generally, any supertype of scrutSym.tpe is a no-op)
+            //   ("trivial" depends on whether we're emitting a straight match or an exception, or more generally, any supertype of scrutinee.info is a no-op)
             //   irrefutability checking should use the approximation framework also used for CSE, unreachability and exhaustivity checking
             val synthCatchAll =
               if (casesNoSubstOnly.nonEmpty && {
@@ -564,15 +564,15 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
                   }) None
               else matchFailGen
 
-            analyzeCases(scrutSym, casesNoSubstOnly, pt, suppression)
+            analyzeCases(scrutinee, casesNoSubstOnly, pt, suppression)
 
-            val (cases, toHoist) = optimizeCases(scrutSym, casesNoSubstOnly, pt)
+            val (cases, toHoist) = optimizeCases(scrutinee, casesNoSubstOnly, pt)
 
-            val matchRes = codegen.matcher(scrut, scrutSym, pt)(cases map combineExtractors, synthCatchAll)
+            val matchRes = codegen.matcher(scrutinee, pt)(cases map combineExtractors, synthCatchAll)
 
             if (toHoist isEmpty) matchRes else Block(toHoist, matchRes)
           } else {
-            codegen.matcher(scrut, scrutSym, pt)(Nil, matchFailGen)
+            codegen.matcher(scrutinee, pt)(Nil, matchFailGen)
           }
         }
       }

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
@@ -103,10 +103,13 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
       override def toString = "B"+(body, matchPt)
     }
 
-    case class SubstOnlyTreeMaker(prevBinder: Symbol, nextBinder: Symbol) extends TreeMaker {
+    object SubstOnlyTreeMaker {
+      def apply(prevBinder: Symbol, nextBinder: Symbol) = new SubstOnlyTreeMaker(List(prevBinder), List(CODE.REF(nextBinder)))
+    }
+    case class SubstOnlyTreeMaker(binders: List[Symbol], refs: List[Tree]) extends TreeMaker {
       val pos = NoPosition
 
-      val localSubstitution = Substitution(prevBinder, CODE.REF(nextBinder))
+      val localSubstitution = Substitution(binders, refs)
       def chainBefore(next: Tree)(casegen: Casegen): Tree = substitution(next)
       override def toString = "S"+ localSubstitution
     }

--- a/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
@@ -13,7 +13,7 @@ import scala.tools.nsc.transform.TypingTransformers
 import scala.tools.nsc.transform.Transform
 import scala.reflect.internal.util.Statistics
 import scala.reflect.internal.Types
-import scala.reflect.internal.util.Position
+import scala.reflect.internal.util.{Position, NoPosition}
 
 /** Translate pattern matching.
   *
@@ -80,8 +80,8 @@ trait PatternMatching extends Transform with TypingTransformers
   }
 
   class PureMatchTranslator(val typer: analyzer.Typer, val matchStrategy: Tree) extends MatchTranslator with PureCodegen {
-    def optimizeCases(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type) = (cases, Nil)
-    def analyzeCases(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type, suppression: Suppression): Unit = {}
+    def optimizeCases(scrutinee: Scrutinee, cases: List[List[TreeMaker]], pt: Type) = (cases, Nil)
+    def analyzeCases(scrutinee: Scrutinee, cases: List[List[TreeMaker]], pt: Type, suppression: Suppression): Unit = {}
   }
 
   class OptimizingMatchTranslator(val typer: analyzer.Typer) extends MatchTranslator
@@ -101,7 +101,7 @@ trait Debugging {
 }
 
 trait Interface extends ast.TreeDSL {
-  import global.{newTermName, analyzer, Type, ErrorType, Symbol, Tree}
+  import global.{abort, gen, newTermName, analyzer, Type, NoType, ErrorType, Symbol, NoSymbol, Tree, EmptyTree, treeInfo}
   import analyzer.Typer
 
   // 2.10/2.11 compatibility
@@ -125,6 +125,69 @@ trait Interface extends ast.TreeDSL {
     val _match    = newTermName("__match") // don't call the val __match, since that will trigger virtual pattern matching...
 
     def counted(str: String, i: Int) = newTermName(str + i)
+  }
+
+
+  /** Abstract over single-scrutinee and multi-scrutinee (packed in a tuple) matches.
+   */
+  sealed abstract class Scrutinee {
+    def selector: Tree
+    def sym: Symbol
+    def info: Type
+    def setInfo(tp: Type): Symbol
+
+    def defs: List[Tree]
+    // for MatchError thrown by default case
+    def ref: Tree
+    def pos = selector.pos
+  }
+
+  // standard match
+  case class SingleScrutinee(selector: Tree, sym: Symbol) extends Scrutinee {
+    assert(sym ne NoSymbol, "Use NoScrutinee for no-symbol scrutinee "+ selector)
+
+    def info: Type = sym.info
+    def setInfo(tp: Type): Symbol = sym.setInfo(tp)
+
+    def defs = List(CODE.VAL(sym)  === selector)
+    def ref  = CODE.REF(sym)
+  }
+
+  // for an optimized match that unrolls the tuple that is the selector
+  case class TupleScrutinee(selector: Tree, defs: List[Tree]) extends Scrutinee {
+    def sym: Symbol               = NoSymbol
+    def setInfo(tp: Type): Symbol = NoSymbol
+
+    def info: Type = selector.tpe
+
+    lazy val rootSyms = defs map (_.symbol)
+    def elemRefs      = rootSyms map (CODE.REF(_))
+    def ref           = gen.mkTuple(elemRefs)
+  }
+
+  // not meant to emit a match, for try/catch translation
+  case class SymbolScrutinee(sym: Symbol) extends Scrutinee {
+    assert(sym ne NoSymbol, "Use NoScrutinee for no-symbol scrutinee "+ selector)
+
+    def info: Type = sym.info
+    def setInfo(tp: Type): Symbol = sym.setInfo(tp)
+
+    def ref = CODE.REF(sym)
+
+    def selector: Tree   = abort("SymbolScrutinee does not have a selector.")
+    def defs: List[Tree] = abort("SymbolScrutinee cannot emit a match. Use SingleScrutinee.")
+  }
+
+  // for alternatives
+  case object NoScrutinee extends Scrutinee {
+    def sym: Symbol               = NoSymbol
+    def info: Type                = NoType
+    def setInfo(tp: Type): Symbol = NoSymbol
+    def ref: Tree                 = EmptyTree
+    def defs: List[Tree]          = Nil
+    override def pos              = NoPosition
+
+    def selector: Tree            = abort("NoScrutinee does not have a selector.")
   }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/test/files/jvm/patmat_opt_tuple_scrut.check
+++ b/test/files/jvm/patmat_opt_tuple_scrut.check
@@ -1,0 +1,1 @@
+bytecode identical

--- a/test/files/jvm/patmat_opt_tuple_scrut.flags
+++ b/test/files/jvm/patmat_opt_tuple_scrut.flags
@@ -1,0 +1,1 @@
+-optimize

--- a/test/files/jvm/patmat_opt_tuple_scrut/Analyzed_1.scala
+++ b/test/files/jvm/patmat_opt_tuple_scrut/Analyzed_1.scala
@@ -1,0 +1,16 @@
+// method a's bytecode should be identical to method b's bytecode under -optimize
+final class SameBytecode {
+  def a(x1: Any, x2: Any): Int = (x1, x2) match {
+    case (s1: String, s2: String) => return 1
+    case (i1: Int, s2)            => return 2
+    case (s1, s2: String)         => return 3
+    case _                        => return 4
+  }
+
+  def b(x1: Any, x2: Any): Int = {
+    if (x1.isInstanceOf[String] && x2.isInstanceOf[String]) return 1
+    else if (x1.isInstanceOf[Int])                          return 2
+    else if (x2.isInstanceOf[String])                       return 3
+    else                                                    return 4
+  }
+}

--- a/test/files/jvm/patmat_opt_tuple_scrut/test.scala
+++ b/test/files/jvm/patmat_opt_tuple_scrut/test.scala
@@ -1,0 +1,15 @@
+import scala.tools.partest.BytecodeTest
+
+import scala.tools.nsc.util.JavaClassPath
+import java.io.InputStream
+import scala.tools.asm
+import asm.ClassReader
+import asm.tree.{ClassNode, InsnList}
+import scala.collection.JavaConverters._
+
+object Test extends BytecodeTest {
+  def show: Unit = {
+    val classNode = loadClassNode("SameBytecode")
+    sameBytecode(getMethod(classNode, "a"), getMethod(classNode, "b"))
+  }
+}

--- a/test/files/pos/patmat_cse_nested.scala
+++ b/test/files/pos/patmat_cse_nested.scala
@@ -1,0 +1,24 @@
+abstract class RedBlack[A] {
+  abstract class Tree[+B]
+  abstract class NonEmpty[+B] extends Tree[B] {
+    def del(k: A) = {
+      def balance(x: A, xv: B, tl: Tree[B], tr: Tree[B]) = (tl, tr) match {
+        case (RedTree(y, yv, a, b), RedTree(z, zv, c, d)) =>
+        case (RedTree(y, yv, RedTree(z, zv, a, b), c), d) =>
+        case (RedTree(y, yv, a, RedTree(z, zv, b, c)), d) =>
+        case (a, RedTree(y, yv, b, RedTree(z, zv, c, d))) =>
+        case (a, RedTree(y, yv, RedTree(z, zv, b, c), d)) =>
+        case _ =>
+      }
+
+    }
+  }
+  case class RedTree[+B](val key: A,
+                         val value: B,
+                         val left: Tree[B],
+                         val right: Tree[B]) extends NonEmpty[B]
+  case class BlackTree[+B](val key: A,
+                           val value: B,
+                           val left: Tree[B],
+                           val right: Tree[B]) extends NonEmpty[B]
+}


### PR DESCRIPTION
```
(e1,...,eN) match {
  case (p1, ..., pN) if g =>
  ...
  case (q1, ..., qN) if g' =>
  case _ if g'' =>
}
```

is compiled by introducing the prelude

```
val x1 = e1
...
val xN = eN
```

and then referring directly to the `xi` that corresponding to the `i`th subpattern,
in the translation of the match, rather than selecting the `_i` component of the tuple.

This eliminates the allocation of the tuple and the indirection of accessing its fields.

review by @paulp
