### PR TITLE
SI-7377 Fix retypechecking of patterns on case companion alias

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4532,8 +4532,13 @@ trait Typers extends Modes with Adaptations with Tags {
 
       def normalTypedApply(tree: Tree, fun: Tree, args: List[Tree]) = {
         val stableApplication = (fun.symbol ne null) && fun.symbol.isMethod && fun.symbol.isStable
-        if (stableApplication && isPatternMode) {
+        if (args.isEmpty && stableApplication && isPatternMode) {
           // treat stable function applications f() as expressions.
+          //
+          // [JZ] According to Martin, this is related to the old pattern matcher, which
+          //      needs to typecheck after a the translation of `x.f` to `x.f()` in a prior
+          //      compilation phase. As part of SI-7377, this has been tightened with `args.isEmpty`,
+          //      but we should remove it altogether in Scala 2.11.
           typed1(tree, mode & ~PATTERNmode | EXPRmode, pt)
         } else {
           val funpt = if (isPatternMode) pt else WildcardType

--- a/test/files/pos/t7377/Client_2.scala
+++ b/test/files/pos/t7377/Client_2.scala
@@ -1,0 +1,11 @@
+object Test {
+  M.noop(List(1) match { case Nil => 0; case (x::xs) => x })
+
+  case class Foo(a: Int)
+  val FooAlias: Foo.type = Foo
+  M.noop(Foo(0) match { case FooAlias(_) => 0 })
+
+  case class Bar()
+  val BarAlias: Bar.type = Bar
+  M.noop(Bar() match { case BarAlias() => 0 })
+}

--- a/test/files/pos/t7377/Macro_1.scala
+++ b/test/files/pos/t7377/Macro_1.scala
@@ -1,0 +1,7 @@
+import language.experimental._
+import reflect.macros.Context
+
+object M {
+  def noopImpl[A](c: Context)(expr: c.Expr[A]): c.Expr[A] = c.Expr(c.typeCheck(c.resetLocalAttrs(expr.tree)))
+  def noop[A](expr: A): A = macro noopImpl[A]
+}

--- a/test/files/pos/t7377b.flags
+++ b/test/files/pos/t7377b.flags
@@ -1,0 +1,1 @@
+-Xoldpatmat

--- a/test/files/pos/t7377b.scala
+++ b/test/files/pos/t7377b.scala
@@ -1,0 +1,13 @@
+object Test {
+  List(1) match { case Nil => 0; case (x::xs) => x }
+
+  case class Foo(a: Int)
+  val FooAlias: Foo.type = Foo
+  Foo(0) match { case FooAlias(_) => 0 }
+  Foo(0) match { case Foo(_) => 0 }
+
+  case class Bar()
+  val BarAlias: Bar.type = Bar
+  Bar() match { case BarAlias() => 0 }
+  Bar() match { case Bar() => 0 }
+}


### PR DESCRIPTION
Some ancient code in Typers switches from PATTERNmode to
EXPRmode when encountering `stableF(...)`. It just
typechecks `stableF` and discards the arguments.

To the best of Martin's recollection, this has something
to do with the need to typecheck patterns rather late in
the compiler, after `a.b` had been translated to `a.b()`
in `Uncurry`. I'm not able to motivate this with tests
using `-Xoldpatmat`; was there ever an even older pattern
matcher that ran _after_ uncurry?

What changed in 2.10.1 to expose this wrinkle? dfbaaa17
fixed `TypeTree.copyAttrs` to copy the original tree.
During the descent of `ResetAttrs`, sub-trees are duplicated
before begin further transformed. Duplicating the `Match`
in 2.10.0 would forget that the original tree of:

```
pat = (a: Int)Foo(_)
      `----------`
           `- TypeTree((a: Int)Foo), with original Select(..., "FooAlias")
```

The retypechecking would operate on the `MethodType`, rather
than the `Select`, which was not considered a stable
application.

For 2.10.x, I've just tightened up the condition to only
hit this if `args` is empty. I'm almost certain that the code
can be removed altogether, and I'll do that when this is merged
to master.

Review by @paulp
