### PR TITLE
SI-6775 Racy synchronization of specialized methods.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -967,12 +967,8 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
       needsSpecialOverride(overriding) match {
         case (NoSymbol, _)     => None
         case (overridden, env) =>
-          val om = specializedOverload(clazz, overridden, env)
-          foreachWithIndex(om.paramss) { (params, i) =>
-            foreachWithIndex(params) { (param, j) =>
-              param.name = overriding.paramss(i)(j).name // SI-6555 Retain the parameter names from the subclass.
-            }
-          }
+          val newFlags = (overriding.flags | SPECIALIZED) & ~CASEACCESSOR
+          val om = overriding.cloneSymbol(clazz, newFlags, specializedName(overridden, env))
           debuglog("specialized overload %s for %s in %s: %s".format(om, overriding.name.decode, pp(env), om.info))
           typeEnv(om) = env
           addConcreteSpecMethod(overriding)

--- a/test/files/run/t6028.check
+++ b/test/files/run/t6028.check
@@ -30,7 +30,7 @@ package <empty> {
         ()
       };
       final def apply(): Int = $anonfun$foo$1.this.apply$mcI$sp();
-      <specialized> def apply$mcI$sp(): Int = $anonfun$foo$1.this.$outer.T$$classParam.+($anonfun$foo$1.this.$outer.field()).+($anonfun$foo$1.this.methodParam$1).+($anonfun$foo$1.this.methodLocal$1);
+      final <specialized> def apply$mcI$sp(): Int = $anonfun$foo$1.this.$outer.T$$classParam.+($anonfun$foo$1.this.$outer.field()).+($anonfun$foo$1.this.methodParam$1).+($anonfun$foo$1.this.methodLocal$1);
       <synthetic> <paramaccessor> private[this] val $outer: T = _;
       <synthetic> <stable> def T$$anonfun$$$outer(): T = $anonfun$foo$1.this.$outer;
       final <bridge> def apply(): Object = scala.Int.box($anonfun$foo$1.this.apply());
@@ -66,7 +66,7 @@ package <empty> {
         ()
       };
       final def apply(): Unit = $anonfun$tryy$1.this.apply$mcV$sp();
-      <specialized> def apply$mcV$sp(): Unit = try {
+      final <specialized> def apply$mcV$sp(): Unit = try {
         $anonfun$tryy$1.this.tryyLocal$1.elem = $anonfun$tryy$1.this.tryyParam$1
       } finally ();
       <synthetic> <paramaccessor> private[this] val $outer: T = _;

--- a/test/files/run/t6555.check
+++ b/test/files/run/t6555.check
@@ -12,7 +12,7 @@ package <empty> {
           ()
         };
         final def apply(param: Int): Int = $anonfun.this.apply$mcII$sp(param);
-        <specialized> def apply$mcII$sp(param: Int): Int = param
+        final <specialized> def apply$mcII$sp(param: Int): Int = param
       };
       (new anonymous class $anonfun(): Int => Int)
     };

--- a/test/files/run/t6775.check
+++ b/test/files/run/t6775.check
@@ -1,0 +1,26 @@
+[[syntax trees at end of                specialize]] // newSource1
+package <empty> {
+  abstract trait Counter[@specialized(scala.Int) T >: Nothing <: Any] extends Object {
+    def apply(): T;
+    <specialized> def apply$mcI$sp(): Int = Counter.this.apply().asInstanceOf[Int]()
+  };
+  class IntCounter extends Object with Counter$mcI$sp {
+    <paramaccessor> private[this] var state: Int = _;
+    <accessor> <paramaccessor> def state(): Int = IntCounter.this.state;
+    <accessor> <paramaccessor> def state_=(x$1: Int): Unit = IntCounter.this.state = x$1;
+    def <init>(state: Int): IntCounter = {
+      IntCounter.super.<init>();
+      ()
+    };
+    <synchronized> def apply(): Int = IntCounter.this.apply$mcI$sp();
+    <specialized> <synchronized> def apply$mcI$sp(): Int = {
+      val n: Int = IntCounter.this.state();
+      IntCounter.this.state_=(IntCounter.this.state().+(1));
+      n
+    }
+  };
+  abstract <specialized> trait Counter$mcI$sp extends AnyRef with Counter[Int] {
+    <specialized> def apply(): Int
+  }
+}
+

--- a/test/files/run/t6775.scala
+++ b/test/files/run/t6775.scala
@@ -1,0 +1,28 @@
+import scala.tools.partest._
+import java.io.{Console => _, _}
+
+object Test extends DirectTest {
+
+  override def extraSettings: String = "-usejavacp -Xprint:specialize"
+
+  override def code = 
+    """
+trait Counter[@specialized(Int) +T] {
+  def apply(): T
+}
+
+class IntCounter(var state: Int) extends Counter[Int] {
+  def apply(): Int = synchronized { // not properly synchronized
+    val n = state
+    state += 1
+    n
+  }
+}
+"""
+
+  override def show(): Unit = {
+    Console.withErr(System.out) {
+      compile()
+    }
+  }
+}


### PR DESCRIPTION
When the new specialized method is created that overrides a method
in a base class, cloneSymbol is called on a base method, rather than
on a non-specialized overrider.

This results in flags incorrectly (un)set on the clone, which include,
among others, SYNCHRONIZED snd FINAL.

To fix the problem, we don't forward to specializedOverload, but
rather clone overriding method directly.
