### PR TITLE
Absolute path in error message.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -780,16 +780,19 @@ trait Typers extends Modes with Adaptations with Tags {
           if (!OK) {
             val Some(AnnotationInfo(_, List(Literal(Constant(featureDesc: String)), Literal(Constant(required: Boolean))), _)) =
               featureTrait getAnnotation LanguageFeatureAnnot
-            val req = if (required) "needs to" else "should"
-            var raw = featureDesc + " " + req + " be enabled\n" +
-              "by making the implicit value language." + featureName + " visible."
-            if (!(currentRun.reportedFeature contains featureTrait))
-              raw += "\nThis can be achieved by adding the import clause 'import scala.language." + featureName + "'\n" +
-                "or by setting the compiler option -language:" + featureName + ".\n" +
-                "See the Scala docs for value scala.language." + featureName + " for a discussion\n" +
-                "why the feature " + req + " be explicitly enabled."
+            val req     = if (required) "needs to" else "should"
+            val fqname  = "scala.language." + featureName
+            val explain = (
+              if (currentRun.reportedFeature contains featureTrait) "" else
+              s"""|
+                  |This can be achieved by adding the import clause 'import $fqname'
+                  |or by setting the compiler option -language:$featureName.
+                  |See the Scala docs for value $fqname for a discussion
+                  |why the feature $req be explicitly enabled.""".stripMargin
+            )
             currentRun.reportedFeature += featureTrait
-            val msg = raw replace ("#", construct)
+
+            val msg = s"$featureDesc $req be enabled\nby making the implicit value $fqname visible.$explain" replace ("#", construct)
             if (required) unit.error(pos, msg)
             else currentRun.featureWarnings.warn(pos, msg)
           }

--- a/test/files/neg/macro-without-xmacros-a.check
+++ b/test/files/neg/macro-without-xmacros-a.check
@@ -1,5 +1,5 @@
 Macros_2.scala:5: error: macro definition needs to be enabled
-by making the implicit value language.experimental.macros visible.
+by making the implicit value scala.language.experimental.macros visible.
 This can be achieved by adding the import clause 'import scala.language.experimental.macros'
 or by setting the compiler option -language:experimental.macros.
 See the Scala docs for value scala.language.experimental.macros for a discussion
@@ -7,11 +7,11 @@ why the feature needs to be explicitly enabled.
     def foo(x: Int): Int = macro foo_impl
         ^
 Macros_2.scala:7: error: macro definition needs to be enabled
-by making the implicit value language.experimental.macros visible.
+by making the implicit value scala.language.experimental.macros visible.
   def bar(x: Int): Int = macro bar_impl
       ^
 Macros_2.scala:11: error: macro definition needs to be enabled
-by making the implicit value language.experimental.macros visible.
+by making the implicit value scala.language.experimental.macros visible.
   def quux(x: Int): Int = macro quux_impl
       ^
 three errors found

--- a/test/files/neg/macro-without-xmacros-b.check
+++ b/test/files/neg/macro-without-xmacros-b.check
@@ -1,5 +1,5 @@
 Macros_2.scala:3: error: macro definition needs to be enabled
-by making the implicit value language.experimental.macros visible.
+by making the implicit value scala.language.experimental.macros visible.
 This can be achieved by adding the import clause 'import scala.language.experimental.macros'
 or by setting the compiler option -language:experimental.macros.
 See the Scala docs for value scala.language.experimental.macros for a discussion
@@ -7,11 +7,11 @@ why the feature needs to be explicitly enabled.
     def foo(x: Int): Int = macro Impls.foo_impl
         ^
 Macros_2.scala:5: error: macro definition needs to be enabled
-by making the implicit value language.experimental.macros visible.
+by making the implicit value scala.language.experimental.macros visible.
   def bar(x: Int): Int = macro Impls.bar_impl
       ^
 Macros_2.scala:9: error: macro definition needs to be enabled
-by making the implicit value language.experimental.macros visible.
+by making the implicit value scala.language.experimental.macros visible.
   def quux(x: Int): Int = macro Impls.quux_impl
       ^
 three errors found

--- a/test/files/neg/t6040.check
+++ b/test/files/neg/t6040.check
@@ -1,5 +1,5 @@
 t6040.scala:1: error: extension of type scala.Dynamic needs to be enabled
-by making the implicit value language.dynamics visible.
+by making the implicit value scala.language.dynamics visible.
 This can be achieved by adding the import clause 'import scala.language.dynamics'
 or by setting the compiler option -language:dynamics.
 See the Scala docs for value scala.language.dynamics for a discussion

--- a/test/files/neg/t6952.check
+++ b/test/files/neg/t6952.check
@@ -1,5 +1,5 @@
 t6952.scala:2: error: extension of type scala.Dynamic needs to be enabled
-by making the implicit value language.dynamics visible.
+by making the implicit value scala.language.dynamics visible.
 This can be achieved by adding the import clause 'import scala.language.dynamics'
 or by setting the compiler option -language:dynamics.
 See the Scala docs for value scala.language.dynamics for a discussion
@@ -7,7 +7,7 @@ why the feature needs to be explicitly enabled.
 trait B extends Dynamic
                 ^
 t6952.scala:3: error: extension of type scala.Dynamic needs to be enabled
-by making the implicit value language.dynamics visible.
+by making the implicit value scala.language.dynamics visible.
 trait C extends A with Dynamic
                        ^
 two errors found


### PR DESCRIPTION
As soon as you have a directory called "language" lying around,
you will appreciate why the advice given regarding SIP-18
should be "import scala.language..." not "import language..."
