### PR TITLE
Quiet down overloaded implicit warning.

### DIFF
--- a/test/files/pos/xlint1.flags
+++ b/test/files/pos/xlint1.flags
@@ -1,0 +1,1 @@
+-Xlint -Xfatal-warnings

--- a/test/files/pos/xlint1.scala
+++ b/test/files/pos/xlint1.scala
@@ -1,0 +1,13 @@
+package object foo {
+  implicit class Bar[T](val x: T) extends AnyVal {
+    def bippy = 1
+  }
+}
+
+package foo {
+  object Baz {
+    def main(args: Array[String]): Unit = {
+      "abc".bippy
+    }
+  }
+}


### PR DESCRIPTION
Apparently implicit classes product both a method symbol and
a module symbol, both of which are marked implicit, which left
this warning code believing there was an overloaded implicit
method.
