### PR TITLE
SI-7388 Be more robust against cycles in error symbol creation.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -286,7 +286,11 @@ trait Infer extends Checkable {
       //   println("set error: "+tree);
       //   throw new Error()
       // }
-      def name        = newTermName("<error: " + tree.symbol + ">")
+      def name = {
+        val sym = tree.symbol
+        val nameStr = try sym.toString catch { case _: CyclicReference => sym.nameString }
+        newTermName(s"<error: $nameStr>")
+      }
       def errorClass  = if (context.reportErrors) context.owner.newErrorClass(name.toTypeName) else stdErrorClass
       def errorValue  = if (context.reportErrors) context.owner.newErrorValue(name) else stdErrorValue
       def errorSym    = if (tree.isType) errorClass else errorValue

--- a/test/files/neg/t7388.check
+++ b/test/files/neg/t7388.check
@@ -1,0 +1,4 @@
+t7388.scala:1: error: doesnotexist is not an enclosing class
+class Test private[doesnotexist]()
+           ^
+one error found

--- a/test/files/neg/t7388.scala
+++ b/test/files/neg/t7388.scala
@@ -1,0 +1,1 @@
+class Test private[doesnotexist]()


### PR DESCRIPTION
`Symbol#toString` was triggering `CyclicReferenceError` (specifically,
`accurateKindString` which calls `owner.primaryConstructor`.)

The `toString` output is used when creating an error symbol to
assign to the tree after an error (in this case, a non-existent
access qualifier.)

This commit catches the error, and falls back to just using the
symbol's name.

Review by @paulp.
