### PR TITLE
[backport] SI-7237 Always choose ForkJoinTaskSupport

### DIFF
--- a/src/library/scala/collection/parallel/package.scala
+++ b/src/library/scala/collection/parallel/package.scala
@@ -46,11 +46,8 @@ package object parallel {
   private[parallel] def outofbounds(idx: Int) = throw new IndexOutOfBoundsException(idx.toString)
 
   private[parallel] def getTaskSupport: TaskSupport =
-    if (util.Properties.isJavaAtLeast("1.6")) {
-      val vendor = util.Properties.javaVmVendor
-      if ((vendor contains "Oracle") || (vendor contains "Sun") || (vendor contains "Apple")) new ForkJoinTaskSupport
-      else new ThreadPoolTaskSupport
-    } else new ThreadPoolTaskSupport
+    if (scala.util.Properties.isJavaAtLeast("1.6")) new ForkJoinTaskSupport
+    else new ThreadPoolTaskSupport
 
   val tasksupport = getTaskSupport
 


### PR DESCRIPTION
... on Java 6 and above.

ForkJoinTaskSupport works on Hotspot, Avian and J9,
while ThreadPoolTaskSupport causes the test
test/files/scalacheck/parallel-collections
to reliably hang on all three.

We keep ThreadPoolTaskSupport around to keep the hope
alive that we still have a glimpse of 1.5 support.
