### PR TITLE
[backport] SI-7391 Always use ForkJoin in Scala actors

### DIFF
--- a/src/actors/scala/actors/scheduler/ThreadPoolConfig.scala
+++ b/src/actors/scala/actors/scheduler/ThreadPoolConfig.scala
@@ -37,17 +37,5 @@ private[actors] object ThreadPoolConfig {
     if (preMaxSize >= corePoolSize) preMaxSize else corePoolSize
   }
 
-  private[actors] def useForkJoin: Boolean =
-    try !propIsSetTo("actors.enableForkJoin", "false") &&
-      (propIsSetTo("actors.enableForkJoin", "true") || {
-        Debug.info(this+": java.version = "+javaVersion)
-        Debug.info(this+": java.vm.vendor = "+javaVmVendor)
-
-        // on IBM J9 1.6 do not use ForkJoinPool
-        // XXX this all needs to go into Properties.
-        isJavaAtLeast("1.6") && ((javaVmVendor contains "Oracle") || (javaVmVendor contains "Sun") || (javaVmVendor contains "Apple"))
-      })
-    catch {
-      case _: SecurityException => false
-    }
+  private[actors] val useForkJoin: Boolean = scala.util.Properties.isJavaAtLeast("1.6")
 }


### PR DESCRIPTION
... on Java 6 and above.

Like SI-7236 and SI-7237, the logic in
scala.actors.scheduler.ThreadPoolConfig.useForkJoin
(which resulted in a different thread pool implementation
being chosen) was causing random hangs in the test
concurrent-stream.scala when running on Avian.
