### PR TITLE
SI-7391 Always use ForkJoin in Scala actors

### DIFF
--- a/src/actors/scala/actors/Reactor.scala
+++ b/src/actors/scala/actors/Reactor.scala
@@ -18,22 +18,8 @@ private[actors] object Reactor {
 
   val scheduler = new DelegatingScheduler {
     def makeNewScheduler: IScheduler = {
-      val sched = if (!ThreadPoolConfig.useForkJoin) {
-        // default is non-daemon
-        val workQueue = new LinkedBlockingQueue[Runnable]
-        ExecutorScheduler(
-          new ThreadPoolExecutor(ThreadPoolConfig.corePoolSize,
-                                 ThreadPoolConfig.maxPoolSize,
-                                 60000L,
-                                 TimeUnit.MILLISECONDS,
-                                 workQueue,
-                                 new ThreadPoolExecutor.CallerRunsPolicy))
-      } else {
-        // default is non-daemon, non-fair
-        val s = new ForkJoinScheduler(ThreadPoolConfig.corePoolSize, ThreadPoolConfig.maxPoolSize, false, false)
-        s.start()
-        s
-      }
+      val sched = new ForkJoinScheduler(ThreadPoolConfig.corePoolSize, ThreadPoolConfig.maxPoolSize, false, false)
+      sched.start()
       Debug.info(this+": starting new "+sched+" ["+sched.getClass+"]")
       sched
     }

--- a/src/actors/scala/actors/Scheduler.scala
+++ b/src/actors/scala/actors/Scheduler.scala
@@ -24,17 +24,8 @@ object Scheduler extends DelegatingScheduler {
   Debug.info("initializing "+this+"...")
 
   def makeNewScheduler: IScheduler = {
-    val sched = if (!ThreadPoolConfig.useForkJoin) {
-      // default is non-daemon
-      val s = new ResizableThreadPoolScheduler(false)
-      s.start()
-      s
-    } else {
-      // default is non-daemon, fair
-      val s = new ForkJoinScheduler
-      s.start()
-      s
-    }
+    val sched = new ForkJoinScheduler
+    sched.start()
     Debug.info(this+": starting new "+sched+" ["+sched.getClass+"]")
     sched
   }

--- a/src/actors/scala/actors/scheduler/DaemonScheduler.scala
+++ b/src/actors/scala/actors/scheduler/DaemonScheduler.scala
@@ -18,15 +18,8 @@ package scheduler
 object DaemonScheduler extends DelegatingScheduler {
 
   protected def makeNewScheduler(): IScheduler = {
-    val sched = if (!ThreadPoolConfig.useForkJoin) {
-      val s = new ResizableThreadPoolScheduler(true)
-      s.start()
-      s
-    } else {
-      val s = new ForkJoinScheduler(true)
-      s.start()
-      s
-    }
+    val sched = new ForkJoinScheduler(true)
+    sched.start()
     Debug.info(this+": starting new "+sched+" ["+sched.getClass+"]")
     sched
   }

--- a/src/actors/scala/actors/scheduler/ThreadPoolConfig.scala
+++ b/src/actors/scala/actors/scheduler/ThreadPoolConfig.scala
@@ -36,18 +36,4 @@ private[actors] object ThreadPoolConfig {
     val preMaxSize = getIntegerProp("actors.maxPoolSize") getOrElse 256
     if (preMaxSize >= corePoolSize) preMaxSize else corePoolSize
   }
-
-  private[actors] def useForkJoin: Boolean =
-    try !propIsSetTo("actors.enableForkJoin", "false") &&
-      (propIsSetTo("actors.enableForkJoin", "true") || {
-        Debug.info(this+": java.version = "+javaVersion)
-        Debug.info(this+": java.vm.vendor = "+javaVmVendor)
-
-        // on IBM J9 1.6 do not use ForkJoinPool
-        // XXX this all needs to go into Properties.
-        isJavaAtLeast("1.6") && ((javaVmVendor contains "Oracle") || (javaVmVendor contains "Sun") || (javaVmVendor contains "Apple"))
-      })
-    catch {
-      case _: SecurityException => false
-    }
 }


### PR DESCRIPTION
Like SI-7236 and SI-7237, the logic in
scala.actors.scheduler.ThreadPoolConfig.useForkJoin
(which resulted in a different thread pool implementation
being chosen) was causing random hangs in the test
concurrent-stream.scala when running on Avian.
