### PR TITLE
SI-7393, value classes leave no-ops in bytecode.

### DIFF
--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -14,6 +14,7 @@ import mutable.{ ArrayBuilder, ArraySeq }
 import scala.compat.Platform.arraycopy
 import scala.reflect.ClassTag
 import scala.runtime.ScalaRunTime.{ array_apply, array_update }
+import scala.annotation.unchecked.uncheckedPure
 
 /** Contains a fallback builder for arrays when the element type
  *  does not have a class tag. In that case a generic array is built.
@@ -47,7 +48,7 @@ class FallbackArrayBuilding {
  *  @author Martin Odersky
  *  @version 1.0
  */
-object Array extends FallbackArrayBuilding {
+@uncheckedPure object Array extends FallbackArrayBuilding {
   val emptyBooleanArray = new Array[Boolean](0)
   val emptyByteArray    = new Array[Byte](0)
   val emptyCharArray    = new Array[Char](0)

--- a/src/library/scala/Console.scala
+++ b/src/library/scala/Console.scala
@@ -11,6 +11,7 @@ package scala
 import java.io.{ BufferedReader, InputStream, InputStreamReader, OutputStream, PrintStream, Reader }
 import scala.io.{ AnsiColor, ReadStdin }
 import scala.util.DynamicVariable
+import scala.annotation.unchecked.uncheckedPure
 
 /** Implements functionality for
  *  printing Scala values on the terminal as well as reading specific values.
@@ -19,7 +20,7 @@ import scala.util.DynamicVariable
  *  @author  Matthias Zenger
  *  @version 1.0, 03/09/2003
  */
-object Console extends DeprecatedConsole with AnsiColor {
+@uncheckedPure object Console extends DeprecatedConsole with AnsiColor {
   private val outVar = new DynamicVariable[PrintStream](java.lang.System.out)
   private val errVar = new DynamicVariable[PrintStream](java.lang.System.err)
   private val inVar  = new DynamicVariable[BufferedReader](

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -13,6 +13,7 @@ import immutable.StringOps
 import mutable.ArrayOps
 import generic.CanBuildFrom
 import scala.annotation.{ elidable, implicitNotFound }
+import scala.annotation.unchecked.uncheckedPure
 import scala.annotation.elidable.ASSERTION
 import scala.language.{implicitConversions, existentials}
 import scala.io.ReadStdin
@@ -69,7 +70,7 @@ import scala.io.ReadStdin
  *  Short value to a Long value as required, and to add additional higher-order
  *  functions to Array values. These are described in more detail in the documentation of [[scala.Array]].
  */
-object Predef extends LowPriorityImplicits with DeprecatedPredef {
+@uncheckedPure object Predef extends LowPriorityImplicits with DeprecatedPredef {
   /**
    * Retrieve the runtime representation of a class type. `classOf[T]` is equivalent to
    * the class literal `T.class` in Java.
@@ -248,7 +249,7 @@ object Predef extends LowPriorityImplicits with DeprecatedPredef {
   // implicit classes -----------------------------------------------------
 
   implicit final class ArrowAssoc[A](val __leftOfArrow: A) extends AnyVal {
-    @inline def -> [B](y: B): Tuple2[A, B] = Tuple2(__leftOfArrow, y)
+    @inline def -> [B](y: B): Tuple2[A, B] = ((__leftOfArrow, y))
     def →[B](y: B): Tuple2[A, B] = ->(y)
   }
 

--- a/src/library/scala/ScalaReflectionException.scala
+++ b/src/library/scala/ScalaReflectionException.scala
@@ -1,0 +1,4 @@
+package scala
+
+/** An exception that indicates an error during Scala reflection */
+case class ScalaReflectionException(msg: String) extends Exception(msg)

--- a/src/library/scala/annotation/unchecked/uncheckedPure.scala
+++ b/src/library/scala/annotation/unchecked/uncheckedPure.scala
@@ -1,0 +1,15 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2002-2011, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala.annotation
+package unchecked
+
+/** Marker for objects which should be assumed by the optimizer
+ *  to be free of constructor side effects.
+ */
+final class uncheckedPure extends StaticAnnotation

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -13,7 +13,7 @@ import mutable.ArrayBuffer
 import scala.annotation.migration
 import immutable.Stream
 import scala.collection.generic.CanBuildFrom
-import scala.annotation.unchecked.{ uncheckedVariance => uV }
+import scala.annotation.unchecked.{ uncheckedPure, uncheckedVariance => uV }
 
 /** The `Iterator` object provides various functions for creating specialized iterators.
  *
@@ -22,7 +22,7 @@ import scala.annotation.unchecked.{ uncheckedVariance => uV }
  *  @version 2.8
  *  @since   2.8
  */
-object Iterator {
+@uncheckedPure object Iterator {
 
   /** With the advent of `TraversableOnce` and `Iterator`, it can be useful to have a builder which
    *  operates on `Iterator`s so they can be treated uniformly along with the collections.

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -6,8 +6,6 @@
 **                          |/                                          **
 \*                                                                      */
 
-
-
 package scala.collection
 package immutable
 
@@ -15,6 +13,7 @@ import generic._
 import mutable.{Builder, ListBuffer}
 import scala.annotation.tailrec
 import java.io._
+import scala.annotation.unchecked.uncheckedPure
 
 /** A class for immutable linked lists representing ordered collections
  *  of elements of type.
@@ -330,8 +329,8 @@ sealed abstract class List[+A] extends AbstractSeq[A]
  *  @since   2.8
  */
 @SerialVersionUID(0 - 8256821097970055419L)
-case object Nil extends List[Nothing] {
-  override def isEmpty = true
+@uncheckedPure case object Nil extends List[Nothing] {
+  @inline final override def isEmpty = true
   override def head: Nothing =
     throw new NoSuchElementException("head of empty list")
   override def tail: List[Nothing] =
@@ -384,7 +383,7 @@ final case class ::[B](private var hd: B, private[scala] var tl: List[B]) extend
  *  @define coll list
  *  @define Coll `List`
  */
-object List extends SeqFactory[List] {
+@uncheckedPure object List extends SeqFactory[List] {
   /** $genericCanBuildFromInfo */
   implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, List[A]] =
     ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]

--- a/src/library/scala/package.scala
+++ b/src/library/scala/package.scala
@@ -6,12 +6,15 @@
 **                          |/                                          **
 \*                                                                      */
 
+package scala
+
+import scala.annotation.unchecked.uncheckedPure
 
 /**
  * Core Scala types. They are always available without an explicit import.
  * @contentDiagram hideNodes "scala.Serializable"
  */
-package object scala {
+@uncheckedPure object `package` {
   type Throwable = java.lang.Throwable
   type Exception = java.lang.Exception
   type Error     = java.lang.Error

--- a/src/library/scala/reflect/ClassTag.scala
+++ b/src/library/scala/reflect/ClassTag.scala
@@ -4,6 +4,7 @@ package reflect
 import java.lang.{ Class => jClass }
 import scala.language.{implicitConversions, existentials}
 import scala.runtime.ScalaRunTime.{ arrayClass, arrayElementClass }
+import scala.annotation.unchecked.uncheckedPure
 
 /**
  *
@@ -28,7 +29,7 @@ import scala.runtime.ScalaRunTime.{ arrayClass, arrayElementClass }
  *   scala> mkArray("Japan","Brazil","Germany")
  *   res1: Array[String] = Array(Japan, Brazil, Germany)
  * }}}
- * 
+ *
  * See [[scala.reflect.api.TypeTags]] for more examples, or the
  * [[http://docs.scala-lang.org/overviews/reflection/typetags-manifests.html Reflection Guide: TypeTags]]
  * for more details.
@@ -106,7 +107,7 @@ trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serial
 /**
  * Class tags corresponding to primitive types and constructor/extractor for ClassTags.
  */
-object ClassTag {
+@uncheckedPure object ClassTag {
   private val ObjectTYPE = classOf[java.lang.Object]
   private val NothingTYPE = classOf[scala.runtime.Nothing$]
   private val NullTYPE = classOf[scala.runtime.Null$]

--- a/src/library/scala/reflect/package.scala
+++ b/src/library/scala/reflect/package.scala
@@ -1,8 +1,10 @@
 package scala
+package reflect
 
 import java.lang.reflect.{ AccessibleObject => jAccessibleObject }
+import scala.annotation.unchecked.uncheckedPure
 
-package object reflect {
+@uncheckedPure object `package` {
 
   // in the new scheme of things ClassManifests are aliased to ClassTags
   // this is done because we want `toArray` in collections work with ClassTags
@@ -42,7 +44,7 @@ package object reflect {
   // @deprecated("Use scala.reflect.ClassTag (to capture erasures), scala.reflect.runtime.universe.TypeTag (to capture types) or both instead", "2.10.0")
   val Manifest = ManifestFactory
 
-  def classTag[T](implicit ctag: ClassTag[T]) = ctag
+  @inline final def classTag[T](implicit ctag: ClassTag[T]) = ctag
 
   /** Make a java reflection object accessible, if it is not already
    *  and it is possible to do so. If a SecurityException is thrown in the
@@ -77,6 +79,3 @@ package object reflect {
   @deprecated("Use `@scala.beans.ScalaBeanInfo` instead", "2.10.0")
   type ScalaBeanInfo = scala.beans.ScalaBeanInfo
 }
-
-/** An exception that indicates an error during Scala reflection */
-case class ScalaReflectionException(msg: String) extends Exception(msg)

--- a/src/library/scala/runtime/RichInt.scala
+++ b/src/library/scala/runtime/RichInt.scala
@@ -57,17 +57,17 @@ final class RichInt(val self: Int) extends AnyVal with ScalaNumberProxy[Int] wit
   /**
     * @return `'''this'''` if `'''this''' < that` or `that` otherwise
     */
-  override def min(that: Int): Int = if (self < that) self else that
+  @inline override def min(that: Int): Int = if (self < that) self else that
 
   /**
     * @return `'''this'''` if `'''this''' > that` or `that` otherwise
     */
-  override def max(that: Int): Int = if (self > that) self else that
+  @inline override def max(that: Int): Int = if (self > that) self else that
 
   /**
     * Computes the absolute value of `'''this'''`.
     */
-  override def abs: Int = if (self < 0) -self else self
+  @inline override def abs: Int = if (self < 0) -self else self
 
   def toBinaryString: String = java.lang.Integer.toBinaryString(self)
   def toHexString: String = java.lang.Integer.toHexString(self)

--- a/src/library/scala/runtime/ScalaRunTime.scala
+++ b/src/library/scala/runtime/ScalaRunTime.scala
@@ -9,6 +9,7 @@
 package scala
 package runtime
 
+import scala.annotation.unchecked.uncheckedPure
 import scala.collection.{ Seq, IndexedSeq, TraversableView, AbstractIterator }
 import scala.collection.mutable.WrappedArray
 import scala.collection.immutable.{ StringLike, NumericRange, List, Stream, Nil, :: }
@@ -17,7 +18,6 @@ import scala.reflect.{ ClassTag, classTag }
 import scala.util.control.ControlThrowable
 import scala.xml.{ Node, MetaData }
 import java.lang.{ Class => jClass }
-
 import java.lang.Double.doubleToLongBits
 import java.lang.reflect.{ Modifier, Method => JMethod }
 
@@ -25,7 +25,7 @@ import java.lang.reflect.{ Modifier, Method => JMethod }
  *  the scala runtime.  All these methods should be considered
  *  outside the API and subject to change or removal without notice.
  */
-object ScalaRunTime {
+@uncheckedPure object ScalaRunTime {
   def isArray(x: Any, atLevel: Int = 1): Boolean =
     x != null && isArrayClass(x.getClass, atLevel)
 

--- a/src/library/scala/sys/package.scala
+++ b/src/library/scala/sys/package.scala
@@ -7,9 +7,11 @@
 \*                                                                      */
 
 package scala
+package sys
 
 import scala.collection.immutable
 import scala.collection.JavaConverters._
+import scala.annotation.unchecked.uncheckedPure
 
 /** The package object `scala.sys` contains methods for reading
  *  and altering core aspects of the virtual machine as well as the
@@ -19,7 +21,7 @@ import scala.collection.JavaConverters._
  *  @version 2.9
  *  @since   2.9
  */
-package object sys {
+@uncheckedPure object `package` {
   /** Throw a new RuntimeException with the supplied message.
    *
    *  @return   Nothing.

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -881,6 +881,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val SwitchClass                = requiredClass[scala.annotation.switch]
     lazy val TailrecClass               = requiredClass[scala.annotation.tailrec]
     lazy val VarargsClass               = requiredClass[scala.annotation.varargs]
+    lazy val UncheckedPureClass         = requiredClass[scala.annotation.unchecked.uncheckedPure]
     lazy val uncheckedStableClass       = requiredClass[scala.annotation.unchecked.uncheckedStable]
     lazy val uncheckedVarianceClass     = requiredClass[scala.annotation.unchecked.uncheckedVariance]
 

--- a/src/reflect/scala/reflect/internal/Variance.scala
+++ b/src/reflect/scala/reflect/internal/Variance.scala
@@ -7,6 +7,7 @@ package scala.reflect
 package internal
 
 import Variance._
+import scala.annotation.unchecked.uncheckedPure
 
 /** Variances form a lattice:
  *
@@ -32,11 +33,11 @@ import Variance._
  *  only for Covariant.
  */
 final class Variance private (val flags: Int) extends AnyVal {
-  def isBivariant     = flags == 2
-  def isCovariant     = flags == 1    // excludes bivariant
-  def isInvariant     = flags == 0
-  def isContravariant = flags == -1   // excludes bivariant
-  def isPositive      = flags > 0     // covariant or bivariant
+  @inline def isBivariant     = flags == 2
+  @inline def isCovariant     = flags == 1    // excludes bivariant
+  @inline def isInvariant     = flags == 0
+  @inline def isContravariant = flags == -1   // excludes bivariant
+  @inline def isPositive      = flags > 0     // covariant or bivariant
 
   def &(other: Variance): Variance = (
     if (this == other) this
@@ -52,10 +53,10 @@ final class Variance private (val flags: Int) extends AnyVal {
   )
 
   /** Flip between covariant and contravariant. I chose not to use unary_- because it doesn't stand out enough. */
-  def flip = if (isCovariant) Contravariant else if (isContravariant) Covariant else this
+  @inline def flip = if (isCovariant) Contravariant else if (isContravariant) Covariant else this
 
   /** Map everything below bivariant to invariant. */
-  def cut  = if (isBivariant) this else Invariant
+  @inline def cut  = if (isBivariant) this else Invariant
 
   /** The symbolic annotation used to indicate the given kind of variance. */
   def symbolicString = (
@@ -73,7 +74,7 @@ final class Variance private (val flags: Int) extends AnyVal {
   )
 }
 
-object Variance {
+@uncheckedPure object Variance {
   implicit class SbtCompat(val v: Variance) {
     def < (other: Int) = v.flags < other
     def > (other: Int) = v.flags > other

--- a/src/reflect/scala/reflect/internal/util/Statistics.scala
+++ b/src/reflect/scala/reflect/internal/util/Statistics.scala
@@ -1,8 +1,9 @@
 package scala.reflect.internal.util
 
 import scala.collection.mutable
+import scala.annotation.unchecked.uncheckedPure
 
-object Statistics {
+@uncheckedPure object Statistics {
 
   type TimerSnapshot = (Long, Long)
 


### PR DESCRIPTION
Created @pure annotation.

It's private[scala] and marks objects which can be assumed
not to side-effect on load.
