### PR TITLE
SI-6675 Avoid spurious warning about pattern bind arity.

### DIFF
--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -422,6 +422,10 @@ filter {
         {
             matchName="scala.reflect.internal.Types#TypeVar.setInst"
             problemName=IncompatibleResultTypeProblem
+        },
+        {
+             matchName="scala.reflect.internal.TreeInfo.effectivePatternArity"
+             problemName=MissingMethodProblem
         }
     ]
 }

--- a/src/compiler/scala/tools/nsc/matching/Patterns.scala
+++ b/src/compiler/scala/tools/nsc/matching/Patterns.scala
@@ -402,7 +402,7 @@ trait Patterns extends ast.TreeDSL {
       case _                                => toPats(args)
     }
 
-    def resTypes = analyzer.unapplyTypeList(unfn.pos, unfn.symbol, unfn.tpe, args.length)
+    def resTypes = analyzer.unapplyTypeList(unfn.pos, unfn.symbol, unfn.tpe, args)
     def resTypesString = resTypes match {
       case Nil  => "Boolean"
       case xs   => xs.mkString(", ")

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -623,7 +623,7 @@ abstract class UnCurry extends InfoTransform
             val fn1 = withInPattern(false)(transform(fn))
             val args1 = transformTrees(fn.symbol.name match {
               case nme.unapply    => args
-              case nme.unapplySeq => transformArgs(tree.pos, fn.symbol, args, analyzer.unapplyTypeList(fn.pos, fn.symbol, fn.tpe, args.length))
+              case nme.unapplySeq => transformArgs(tree.pos, fn.symbol, args, analyzer.unapplyTypeList(fn.pos, fn.symbol, fn.tpe, args))
               case _              => sys.error("internal error: UnApply node has wrong symbol")
             })
             treeCopy.UnApply(tree, fn1, args1)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3480,8 +3480,8 @@ trait Typers extends Modes with Adaptations with Tags {
       else {
         val resTp     = fun1.tpe.finalResultType.normalize
         val nbSubPats = args.length
-
-        val (formals, formalsExpanded) = extractorFormalTypes(fun0.pos, resTp, nbSubPats, fun1.symbol)
+        val (formals, formalsExpanded) =
+          extractorFormalTypes(fun0.pos, resTp, nbSubPats, fun1.symbol, treeInfo.effectivePatternArity(args))
         if (formals == null) duplErrorTree(WrongNumberOfArgsError(tree, fun))
         else {
           val args1 = typedArgs(args, mode, formals, formalsExpanded)
@@ -5297,7 +5297,7 @@ trait Typers extends Modes with Adaptations with Tags {
 
       def typedUnApply(tree: UnApply) = {
         val fun1 = typed(tree.fun)
-        val tpes = formalTypes(unapplyTypeList(tree.fun.pos, tree.fun.symbol, fun1.tpe, tree.args.length), tree.args.length)
+        val tpes = formalTypes(unapplyTypeList(tree.fun.pos, tree.fun.symbol, fun1.tpe, tree.args), tree.args.length)
         val args1 = map2(tree.args, tpes)(typedPattern)
         treeCopy.UnApply(tree, fun1, args1) setType pt
       }

--- a/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
@@ -34,12 +34,13 @@ trait Unapplies extends ast.TreeDSL
   /** returns type list for return type of the extraction
    * @see extractorFormalTypes
    */
-  def unapplyTypeList(pos: Position, ufn: Symbol, ufntpe: Type, nbSubPats: Int) = {
+  def unapplyTypeList(pos: Position, ufn: Symbol, ufntpe: Type, args: List[Tree]) = {
     assert(ufn.isMethod, ufn)
+    val nbSubPats = args.length
     //Console.println("utl "+ufntpe+" "+ufntpe.typeSymbol)
     ufn.name match {
       case nme.unapply | nme.unapplySeq =>
-        val (formals, _) = extractorFormalTypes(pos, unapplyUnwrap(ufntpe), nbSubPats, ufn)
+        val (formals, _) = extractorFormalTypes(pos, unapplyUnwrap(ufntpe), nbSubPats, ufn, treeInfo.effectivePatternArity(args))
         if (formals == null) throw new TypeError(s"$ufn of type $ufntpe cannot extract $nbSubPats sub-patterns")
         else formals
       case _ => throw new TypeError(ufn+" is not an unapply or unapplySeq")

--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -17,7 +17,7 @@ abstract class TreeInfo {
   val global: SymbolTable
 
   import global._
-  import definitions.{ isVarArgsList, isCastSymbol, ThrowableClass, TupleClass, MacroContextClass, MacroContextPrefixType }
+  import definitions.{ isTupleSymbol, isVarArgsList, isCastSymbol, ThrowableClass, TupleClass, MacroContextClass, MacroContextPrefixType }
 
   /* Does not seem to be used. Not sure what it does anyway.
   def isOwnerDefinition(tree: Tree): Boolean = tree match {
@@ -514,6 +514,20 @@ abstract class TreeInfo {
     case Star(_)  => true
     case _        => false
   }
+
+  /**
+   * {{{
+   * //------------------------ => effectivePatternArity(args)
+   * case Extractor(a)          => 1
+   * case Extractor(a, b)       => 2
+   * case Extractor((a, b))     => 2
+   * case Extractor(a @ (b, c)) => 2
+   * }}}
+   */
+  def effectivePatternArity(args: List[Tree]): Int = (args.map(unbind) match {
+    case Apply(fun, xs) :: Nil if isTupleSymbol(fun.symbol) => xs
+    case xs                                                 => xs
+  }).length
 
 
   // used in the symbols for labeldefs and valdefs emitted by the pattern matcher

--- a/test/files/pos/t6675.flags
+++ b/test/files/pos/t6675.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t6675.scala
+++ b/test/files/pos/t6675.scala
@@ -1,0 +1,20 @@
+object LeftOrRight {
+  def unapply[A](value: Either[A, A]): Option[A] = value match {
+    case scala.Left(x) => Some(x)
+    case scala.Right(x) => Some(x)
+  }
+}
+
+object Test {
+  (Left((0, 0)): Either[(Int, Int), (Int, Int)]) match {
+    case LeftOrRight(pair @ (a, b)) => a // false -Xlint warning: "extractor pattern binds a single value to a Product2 of type (Int, Int)"
+  }
+
+  (Left((0, 0)): Either[(Int, Int), (Int, Int)]) match {
+    case LeftOrRight((a, b)) => a // false -Xlint warning: "extractor pattern binds a single value to a Product2 of type (Int, Int)"
+  }
+
+  (Left((0, 0)): Either[(Int, Int), (Int, Int)]) match {
+    case LeftOrRight(a, b) => a // false -Xlint warning: "extractor pattern binds a single value to a Product2 of type (Int, Int)"
+  }
+}


### PR DESCRIPTION
In 692372ce, we added a warning (under -Xlint) when binding
a `TupleN` in to a single pattern binder, which wasn't allowed
before 2.10.0, and more often than not represents a bug.

However, that warning overstretched, and warned even when
using a Tuple Pattern to bind to the elements of such a value.

This commit checks for this case, and avoids the spurious warnings.

A new test case is added for this case to go with the existing
test for SI-6675:

```
$ ./tools/partest-ack 6675
% tests-with-matching-paths      ...  3
% tests-with-matching-code       ...  2
#3 tests to run.
test/partest --show-diff --show-log                  \
  test/files/neg/t6675-old-patmat.scala              \
  test/files/neg/t6675.scala                         \
  test/files/pos/t6675.scala                         \
  ""

Testing individual files
testing: [...]/files/pos/t6675.scala                                  [  OK  ]

Testing individual files
testing: [...]/files/neg/t6675-old-patmat.scala                       [  OK  ]
testing: [...]/files/neg/t6675.scala                                  [  OK  ]
All of 3 tests were successful (elapsed time: 00:00:03)
```

Review by @adriaanm. This change **does not close the ticket**, it just refines the warning.
