### PR TITLE
Better formatting for import clauses

### DIFF
--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -9,11 +9,11 @@
 package scala
 
 import scala.collection.generic._
-import scala.collection.{ mutable, immutable }
-import mutable.{ ArrayBuilder, ArraySeq }
+import scala.collection.{mutable, immutable}
+import mutable.{ArrayBuilder, ArraySeq}
 import scala.compat.Platform.arraycopy
 import scala.reflect.ClassTag
-import scala.runtime.ScalaRunTime.{ array_apply, array_update }
+import scala.runtime.ScalaRunTime.{array_apply, array_update}
 
 /** Contains a fallback builder for arrays when the element type
  *  does not have a class tag. In that case a generic array is built.

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -8,11 +8,11 @@
 
 package scala
 
-import scala.collection.{ mutable, immutable, generic }
+import scala.collection.{mutable, immutable, generic}
 import immutable.StringOps
 import mutable.ArrayOps
 import generic.CanBuildFrom
-import scala.annotation.{ elidable, implicitNotFound }
+import scala.annotation.{elidable, implicitNotFound}
 import scala.annotation.elidable.ASSERTION
 import scala.language.{implicitConversions, existentials}
 import scala.io.ReadStdin


### PR DESCRIPTION
I think

...
import p.{x, y}
...

is better than

...
import p.{ x, y }
...
