### PR TITLE
SI-4365 nondeterministic failure in asSeenFrom

### DIFF
--- a/test/files/pos/t4365/a_1.scala
+++ b/test/files/pos/t4365/a_1.scala
@@ -1,0 +1,18 @@
+import scala.collection._
+
+trait SeqViewLike[+A,
+                  +Coll,
+                  +This <: SeqView[A, Coll] with SeqViewLike[A, Coll, This]]
+  extends Seq[A]   with GenSeqViewLike[A, Coll, This]
+{
+
+  trait Transformed[+B] extends super[GenSeqViewLike].Transformed[B]
+
+  abstract class AbstractTransformed[+B] extends Seq[B] with Transformed[B] {
+    def underlying: Coll = error("")
+  }
+
+  trait Reversed extends Transformed[A] with super[GenSeqViewLike].Reversed
+
+  protected def newReversed: Transformed[A] = new AbstractTransformed[A] with Reversed
+}

--- a/test/files/pos/t4365/b_1.scala
+++ b/test/files/pos/t4365/b_1.scala
@@ -1,0 +1,22 @@
+import scala.collection._
+
+trait GenSeqViewLike[+A,
+                     +Coll,
+                     +This <: GenSeqView[A, Coll] with GenSeqViewLike[A, Coll, This]]
+extends GenSeq[A] {
+self =>
+
+  trait Transformed[+B] {
+    def length: Int = 0
+    def apply(idx: Int): B = error("")
+  }
+
+  trait Reversed extends Transformed[A] {
+    def iterator: Iterator[A] = createReversedIterator
+
+    private def createReversedIterator: Iterator[A] = {
+      self.foreach(_ => ())
+      null
+    }
+  }
+}


### PR DESCRIPTION
Under some order-dependent conditions (if source files arrive
in one order it happens, in the other order it does not) more
than one set of type parameters are created for a given class.
Previously this would lead to a crash in asSeenFrom when a type
parameter had to be matched up with a type application.

Now when that situation arises I compare them by name and log
a dev warning if it hits. This does not risk anything undesirable
happening because the wayward type parameter's owner is always
the right class; it's only the class type parameters which don't
include the wayward one. Since in a given type parameter list
names are unique, we have enough information to salvage the
search.
