### PR TITLE
Par-Test allows redefinition of srcDir by Ant

### DIFF
--- a/src/partest/scala/tools/partest/nest/PathSettings.scala
+++ b/src/partest/scala/tools/partest/nest/PathSettings.scala
@@ -27,8 +27,8 @@ object PathSettings {
     candidates find isPartestDir getOrElse sys.error("Directory 'test' not found.")
   }
 
-  // Directory <root>/test/files
-  lazy val srcDir = Directory(testRoot / srcDirName toCanonical)
+  // Directory <root>/test/files or .../scaladoc
+  def srcDir = Directory(testRoot / srcDirName toCanonical)
 
   // Directory <root>/test/files/lib
   lazy val srcLibDir = Directory(srcDir / "lib")
@@ -82,7 +82,7 @@ object PathSettings {
    *  if one of those environment variables is set, then the lib directory under java.home,
    *  and finally the lib directory under the parent of java.home. Or, as a last resort,
    *  search deeply under those locations (except for the parent of java.home, on the notion
-   *  that if this is not a canonical installation, then that search would have litte
+   *  that if this is not a canonical installation, then that search would have little
    *  chance of succeeding).
    */
   lazy val platformTools: Option[File] = {


### PR DESCRIPTION
Since srcDir is no longer used to extract the test kind from any
given test path, it is especially benign to rely on the defness
of srcDir in order to allow redefinition during an Ant run (as
required by test.scaladoc).

The parameter is configured via the partest.srcdir property.

Maybe the keyword should be def for definite values and
red for redefinable values and ind for indefinite values.
And ded for dedefinable values optionally reset to None.

Review by @hubertp who spotted it
