### PR TITLE
Warn on selection of vals from DelayedInit subclasses.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1396,6 +1396,16 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
       }
     }
 
+    private def checkDelayedInitSelect(qual: Tree, sym: Symbol, pos: Position) = {
+      def isLikelyUninitialized = (
+           (sym.owner isSubClass DelayedInitClass)
+        && !qual.tpe.isInstanceOf[ThisType]
+        && sym.accessedOrSelf.isVal
+      )
+      if (settings.lint.value && isLikelyUninitialized)
+        unit.warning(pos, s"Selecting ${sym} from ${sym.owner}, which extends scala.DelayedInit, is likely to yield an uninitialized value")
+    }
+
     private def lessAccessible(otherSym: Symbol, memberSym: Symbol): Boolean = (
          (otherSym != NoSymbol)
       && !otherSym.isProtected
@@ -1595,6 +1605,7 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
       if(settings.Xmigration.value != NoScalaVersion)
         checkMigration(sym, tree.pos)
       checkCompileTimeOnly(sym, tree.pos)
+      checkDelayedInitSelect(qual, sym, tree.pos)
 
       if (sym eq NoSymbol) {
         unit.warning(tree.pos, "Select node has NoSymbol! " + tree + " / " + tree.tpe)

--- a/test/files/neg/delayed-init-ref.check
+++ b/test/files/neg/delayed-init-ref.check
@@ -1,0 +1,10 @@
+delayed-init-ref.scala:17: error: Selecting value vall from object O, which extends scala.DelayedInit, is likely to yield an uninitialized value
+  println(O.vall)     // warn
+            ^
+delayed-init-ref.scala:19: error: Selecting value vall from object O, which extends scala.DelayedInit, is likely to yield an uninitialized value
+  println(vall)       // warn
+          ^
+delayed-init-ref.scala:40: error: Selecting value foo from trait UserContext, which extends scala.DelayedInit, is likely to yield an uninitialized value
+    println({locally(()); this}.foo)  // warn (spurious, but we can't discriminate)
+                                ^
+three errors found

--- a/test/files/neg/delayed-init-ref.flags
+++ b/test/files/neg/delayed-init-ref.flags
@@ -1,0 +1,1 @@
+-Xlint -Xfatal-warnings

--- a/test/files/neg/delayed-init-ref.scala
+++ b/test/files/neg/delayed-init-ref.scala
@@ -1,0 +1,42 @@
+trait T {
+  val traitVal = ""
+}
+
+object O extends App with T {
+  val vall = ""
+  lazy val lazyy = ""
+  def deff = ""
+
+  println(vall)       // no warn
+  new {
+    println(vall)     // no warn
+  }
+}
+
+object Client {
+  println(O.vall)     // warn
+  import O.vall
+  println(vall)       // warn
+
+  println(O.lazyy)    // no warn
+  println(O.deff)     // no warn
+  println(O.traitVal) // no warn
+}
+
+// Delayed init usage pattern from Specs2
+// See: https://groups.google.com/d/msg/scala-sips/wP6dL8nIAQs/ogjoPE-MSVAJ
+trait Before extends DelayedInit {
+  def before()
+  override def delayedInit(x: => Unit): Unit = { before; x }
+}
+object Spec {
+  trait UserContext extends Before {
+    def before() = ()
+    val foo = "foo"
+  }
+  new UserContext {
+    println(foo)                      // no warn
+    println(this.foo)                 // no warn
+    println({locally(()); this}.foo)  // warn (spurious, but we can't discriminate)
+  }
+}


### PR DESCRIPTION
Which are likely to yield null, if the program didn't start
via the `App`-s main method, or, more generally, if the
`DelayedInit` is still pending initialization.

This is a common source of confusion for people new to
the language, as was seen during the Coursera course.

The test case shows that the usage pattern within Specs2
won't generate these warnings.

Review by @lrytz, who once [noted](http://comments.gmane.org/gmane.comp.lang.scala.internals/13194) that 

> I understand what's going on here, but from a beginner's perspective this is not ideal.
> Especially since "App" is made for beginners.

I'm also open to the idea of moving this out of the shadow of `-Xlint`. Perhaps it would be a touch more conservative to do that for `App`, rather than unknown `DelayedInit`-s.
