### PR TITLE
SI-7408 Fix test by sorting results of getDeclaredClasses

### DIFF
--- a/test/files/run/t4023.scala
+++ b/test/files/run/t4023.scala
@@ -7,17 +7,28 @@ object Test {
     object B5 extends B1
     private object B6 extends B2 
  
-    val valuesTry1 = this.getClass.getDeclaredClasses
-    val valuesTry2 = C.getClass.getDeclaredClasses
-    val valuesTry3 = getClass.getDeclaredClasses
+    val classes1 = this.getClass.getDeclaredClasses
+    val classes2 = C.getClass   .getDeclaredClasses
+    val classes3 = getClass     .getDeclaredClasses
+  }
+
+  // sortBy(_.getName) introduces additional classes which we don't want to see in C,
+  // so we call sortBy outside of C.
+  object TestHelper {
+    val valuesTry1 = C.classes1.sortBy(_.getName)
+    val valuesTry2 = C.classes2.sortBy(_.getName)
+    val valuesTry3 = C.classes3.sortBy(_.getName)
   }
         
   def main(args: Array[String]) {
-    println("Try 1: (" + C.valuesTry1.length + " classes)")
-    C.valuesTry1.foreach(println)
-    println("Try 2: (" + C.valuesTry2.length + " classes)")
-    C.valuesTry2.foreach(println)
-    println("Try 3: (" + C.valuesTry3.length + " classes)")
-    C.valuesTry3.foreach(println)
+    println("Try 1: (" + TestHelper.valuesTry1.length + " classes)")
+    TestHelper.valuesTry1.foreach(println)
+    println("Try 2: (" + TestHelper.valuesTry2.length + " classes)")
+    TestHelper.valuesTry2.foreach(println)
+    println("Try 3: (" + TestHelper.valuesTry3.length + " classes)")
+    TestHelper.valuesTry3.foreach(println)
   }
+
+
 }
+


### PR DESCRIPTION
run/t4023 can fail (and has already) because the order of elements
in the reflection API is not specified and can differ between platforms
(e. g. HotSpot and Avian) or even versions (Java 7 vs. Java 8).
