### PR TITLE
SI-7355 Handle spaces in paths in Windows batch files.

### DIFF
--- a/src/compiler/scala/tools/ant/templates/tool-windows.tmpl
+++ b/src/compiler/scala/tools/ant/templates/tool-windows.tmpl
@@ -14,8 +14,9 @@ set _LINE_TOOLCP=
 
 :another_param
 
-if "%1%"=="-toolcp" (
-    set _LINE_TOOLCP=%2%
+rem Use "%~1" to handle spaces in paths. See http://ss64.com/nt/syntax-args.html
+if "%~1"=="-toolcp" (
+    set _LINE_TOOLCP=%~2
 	shift
 	shift
 	goto another_param


### PR DESCRIPTION
Changed "%1%" and %2% to "%~1" and %~2 to allow spaces
in paths by surrounding quotes according to advice at:

  http://stackoverflow.com/questions/473117/pass-path-with-spaces-as-parameter-to-bat-file
  http://ss64.com/nt/syntax-args.html

Resubmission of #2429
