### PR TITLE
SI-6771 Alias awareness for checkableType in match analysis.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -99,7 +99,9 @@ trait TreeAndTypeAnalysis extends Debugging {
       // TODO: when type tags are available, we will check -- when this is implemented, can we take that into account here?
       // similar to typer.infer.approximateAbstracts
       object typeArgsToWildcardsExceptArray extends TypeMap {
-        def apply(tp: Type): Type = tp match {
+        // SI-6771 dealias would be enough today, but future proofing with the dealiasWiden.
+        // See neg/t6771b.scala for elaboration
+        def apply(tp: Type): Type = tp.dealiasWiden match {
           case TypeRef(pre, sym, args) if args.nonEmpty && (sym ne ArrayClass) =>
             TypeRef(pre, sym, args map (_ => WildcardType))
           case _ =>

--- a/test/files/neg/t6771b.check
+++ b/test/files/neg/t6771b.check
@@ -1,0 +1,6 @@
+t6771b.scala:14: error: type mismatch;
+ found   : x.type (with underlying type String)
+ required: Test.a.type
+  b = b match { case x => x }
+                          ^
+one error found

--- a/test/files/neg/t6771b.scala
+++ b/test/files/neg/t6771b.scala
@@ -1,0 +1,16 @@
+// Currently, the pattern matcher widens the type of the
+// scrutinee, so this doesn't typecheck. This test just
+// confirms this behaviour, although it would be an improvement
+// to change this and make this a `pos` test.
+//
+// But, to the intrepid hacker who works on this, a few notes:
+// You'll have to look into places in the pattern matcher that
+// call `dealias`, and see if they need to be `dealiasWiden`.
+// For example, if `checkableType` used only `dealias`, `pos/t6671.scala`
+// would fail.
+object Test {
+  val a = ""; var b: a.type = a
+
+  b = b match { case x => x }
+}
+

--- a/test/files/pos/t6771.flags
+++ b/test/files/pos/t6771.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t6771.scala
+++ b/test/files/pos/t6771.scala
@@ -1,0 +1,9 @@
+object Test {
+  type Id[X] = X
+  val a: Id[Option[Int]] = None
+
+  a match {
+     case Some(x) => println(x)
+     case None    =>
+  }
+}


### PR DESCRIPTION
Failure to dealias the type of the scrutinee led the pattern
matcher to incorrectly reason about the type test in:

```
type Id[X] = X; (null: Id[Option[Int]]) match { case Some(_) => }
```

Before, `checkableType` returned `Id[?]`, now it returns `Some[?]`.

Review by @adriaanm
