### PR TITLE
Update links to old website, in preparation for launch.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ These guidelines are meant to be a living document that should be changed and ad
 
 This is the process for committing code to the Scala project. There are of course exceptions to these rules, for example minor changes to comments and documentation, fixing a broken build etc.
 
-1. Make sure you have signed the [Scala CLA](http://www.scala-lang.org/sites/default/files/contributor_agreement.pdf), if not, sign it.
+1. Make sure you have signed the [Scala CLA](http://typesafe.com/contribute/cla/scala), if not, sign it.
 2. Before starting to work on a feature or a fix, it's good practice to ensure that:
     1. There is a ticket for your work in the project's issue tracker. If not, create it first (perhaps given a thumbs up from the scala-internals mailing list first).
     2. The ticket has been discussed and prioritized by the team.

--- a/README.rst
+++ b/README.rst
@@ -182,7 +182,7 @@ In detail:
   http://docs.scala-lang.org
 
 - Scala mailing lists:
-  http://www.scala-lang.org/node/199
+  http://www.scala-lang.org/community/#mailing_lists
 
 - Scala bug and issue tracker:
   https://issues.scala-lang.org
@@ -190,15 +190,10 @@ In detail:
 - Scala live git source tree:
   http://github.com/scala/scala
 
-- Contact form:
-  http://www.scala-lang.org/node/188
-
-
-If you are interested in contributing code, we ask you to complete and submit
-to us the Scala Contributor License Agreement, which allows us to ensure that
-all code submitted to the project is unencumbered by copyrights or patents.
-The form is available at:
-http://www.scala-lang.org/sites/default/files/contributor_agreement.pdf
+If you are interested in contributing code, we ask you to sign the
+[Scala Contributor License Agreement](http://typesafe.com/contribute/cla/scala),
+which allows us to ensure that all code submitted to the project is
+unencumbered by copyrights or patents.
 
 Before submitting a pull-request, please make sure you have followed the guidelines
 outlined in our `Pull Request Policy <https://github.com/scala/scala/wiki/Pull-Request-Policy>`_.


### PR DESCRIPTION
Removed the contact form, since it's redundant with mailing lists and
issue tracker.

Review by @jsuereth
