### PR TITLE
check added instruction to ASM MethodNode

### DIFF
--- a/src/asm/scala/tools/asm/tree/InsnList.java
+++ b/src/asm/scala/tools/asm/tree/InsnList.java
@@ -244,6 +244,14 @@ public class InsnList {
      *            {@link InsnList}</i>.
      */
     public void add(final AbstractInsnNode insn) {
+        if(insn.prev != null || insn.next != null) {
+            // Adding an instruction that still refers to others (in the same or another InsnList) leads to hard to debug bugs.
+            // Initially everything may look ok (e.g. iteration follows `next` thus a stale `prev` isn't noticed).
+            // However, a stale link brings the doubly-linked into disarray e.g. upon removing an element,
+            // which results in the `next` of a stale `prev` being updated, among other failure scenarios.
+            // Better fail early.
+            throw new RuntimeException("Instruction " + insn + " already belongs to some InsnList.");
+        }
         ++size;
         if (last == null) {
             first = insn;


### PR DESCRIPTION
Guarding against inadvertent sharing of ASM-level bytecode instructions across MethodNodes. In those rare occassions where it's needed, this check helps big time.

review by @gkossakowski or @JamesIry
