### PR TITLE
SI-7426 Crash in pickler.

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
@@ -293,7 +293,6 @@ abstract class Pickler extends SubComponent {
           putTree(definition)
 */
         case Template(parents, self, body) =>
-          writeNat(parents.length)
           putTrees(parents)
           putTree(self)
           putTrees(body)

--- a/test/files/pos/t7426.scala
+++ b/test/files/pos/t7426.scala
@@ -1,0 +1,3 @@
+class foo(x: Any) extends annotation.StaticAnnotation
+
+@foo(new AnyRef { }) trait A


### PR DESCRIPTION
I wonder if the supply of copy-pasted code, and the bugs
which always accompany it, will ever run low. Here we have
a couple hundred lines of tree traversal which appears
roughly identical in structure to a different couple hundred
lines of tree traversal, except one calls methods called
putXXX and the other calls methods called writeXXX.

Except there was one call to writeXXX among all the putXXX
calls. Guess where it was crashing.

This entire file should be expunged.
