### PR TITLE
Actors - allow setting of timeout for opening remote Socket connections

### DIFF
--- a/src/actors/scala/actors/remote/TcpService.scala
+++ b/src/actors/scala/actors/remote/TcpService.scala
@@ -14,7 +14,7 @@ package remote
 
 import java.io.{DataInputStream, DataOutputStream, IOException}
 import java.lang.{Thread, SecurityException}
-import java.net.{InetAddress, ServerSocket, Socket, UnknownHostException}
+import java.net.{InetAddress, InetSocketAddress, ServerSocket, Socket, SocketTimeoutException, UnknownHostException}
 
 import scala.collection.mutable
 import scala.util.Random
@@ -57,6 +57,23 @@ object TcpService {
         // do nothing
     }
     portnum
+  }
+
+  val connectTimeoutMillis = {
+    val propName = "scala.actors.tcpSocket.connectTimeoutMillis"
+    val defaultTimeoutMillis = 0
+    sys.props get propName flatMap {
+      timeout =>
+        try {
+          val to = timeout.toInt
+          Debug.info("Using socket timeout $to")
+          Some(to)
+        } catch {
+          case e: NumberFormatException =>
+            Debug.warning(s"""Could not parse $propName = "$timeout" as an Int""")
+            None
+        }
+    } getOrElse defaultTimeoutMillis
   }
 
   var BufSize: Int = 65536
@@ -176,7 +193,15 @@ class TcpService(port: Int, cl: ClassLoader) extends Thread with Service {
   }
 
   def connect(n: Node): TcpServiceWorker = synchronized {
-    val socket = new Socket(n.address, n.port)
+    val socket = new Socket()
+    val start = System.nanoTime()
+    try {
+      socket.connect(new InetSocketAddress(n.address, n.port), TcpService.connectTimeoutMillis)
+    } catch {
+      case e: SocketTimeoutException =>
+        Debug.warning(f"Timed out connecting to [${n.address}%s:${n.port}%s] after ${(System.nanoTime - start) / math.pow(10, 9)}%.3f seconds")
+        throw e
+    }
     val worker = new TcpServiceWorker(this, socket)
     worker.sendNode(n)
     worker.start()


### PR DESCRIPTION
This is a fix for the issue raised by Chris Marshall in SI-5734 which should alleviate problems where opening a Socket to a remote Node blocks (for up to a minute in our experience) not allowing other remote messages to be sent during this time.  An optional timeout can be set through a system property that is passed to the Socket when it is connected.

Default behaviour is unchanged, since the property defaults to 0, which signifies "no timeout" to the java.net.Socket.
