### PR TITLE
Route -explaintypes through reporter.

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -218,7 +218,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
   // not deprecated yet, but a method called "error" imported into
   // nearly every trait really must go.  For now using globalError.
   def error(msg: String)                = globalError(msg)
-  def inform(msg: String)               = reporter.echo(msg)
+  override def inform(msg: String)      = reporter.echo(msg)
   override def globalError(msg: String) = reporter.error(NoPosition, msg)
   override def warning(msg: String)     =
     if (settings.fatalWarnings) globalError(msg)

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -47,6 +47,7 @@ abstract class SymbolTable extends macros.Universe
 
   def log(msg: => AnyRef): Unit
   def warning(msg: String): Unit     = Console.err.println(msg)
+  def inform(msg: String): Unit      = Console.err.println(msg)
   def globalError(msg: String): Unit = abort(msg)
   def abort(msg: String): Nothing    = throw new FatalError(supplementErrorMessage(msg))
 

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4434,11 +4434,11 @@ trait Types
 
   /** Perform operation `p` on arguments `tp1`, `arg2` and print trace of computation. */
   protected def explain[T](op: String, p: (Type, T) => Boolean, tp1: Type, arg2: T): Boolean = {
-    Console.println(indent + tp1 + " " + op + " " + arg2 + "?" /* + "("+tp1.getClass+","+arg2.getClass+")"*/)
+    inform(indent + tp1 + " " + op + " " + arg2 + "?" /* + "("+tp1.getClass+","+arg2.getClass+")"*/)
     indent = indent + "  "
     val result = p(tp1, arg2)
     indent = indent stripSuffix "  "
-    Console.println(indent + result)
+    inform(indent + result)
     result
   }
 

--- a/src/reflect/scala/reflect/runtime/JavaUniverse.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverse.scala
@@ -9,12 +9,12 @@ package runtime
  */
 class JavaUniverse extends internal.SymbolTable with ReflectSetup with runtime.SymbolTable { self =>
 
-  def inform(msg: String): Unit = log(msg)
+  override def inform(msg: String): Unit = log(msg)
   def picklerPhase = internal.SomePhase
   lazy val settings = new Settings
   private val isLogging = sys.props contains "scala.debug.reflect"
 
-  def log(msg: => AnyRef): Unit = if (isLogging) Console.err.println("[reflect] " + msg)  
+  def log(msg: => AnyRef): Unit = if (isLogging) Console.err.println("[reflect] " + msg)
 
   type TreeCopier = InternalTreeCopierOps
   def newStrictTreeCopier: TreeCopier = new StrictTreeCopier

--- a/test/files/neg/abstract-explaintypes.check
+++ b/test/files/neg/abstract-explaintypes.check
@@ -3,9 +3,13 @@ abstract-explaintypes.scala:6: error: type mismatch;
  required: A.this.T
   def foo2: T = bar().baz();
                          ^
+A <: A.this.T?
+false
 abstract-explaintypes.scala:9: error: type mismatch;
  found   : A
  required: A.this.T
   def foo5: T = baz().baz();
                          ^
+A <: A.this.T?
+false
 two errors found


### PR DESCRIPTION
Sick of seeing Console printlns during partest runs. You should not print
anything to Console.{out,err} if it's ever going to happen outside
developerland.
