### PR TITLE
SI-7432 Range.min should throw NoSuchElementException on empty range

### DIFF
--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -81,14 +81,14 @@ extends scala.collection.AbstractSeq[Int]
 
   override def min[A1 >: Int](implicit ord: Ordering[A1]): Int =
     if (ord eq Ordering.Int) {
-      if (step > 0) start
+      if (step > 0) head
       else last
     } else super.min(ord)
 
   override def max[A1 >: Int](implicit ord: Ordering[A1]): Int =
     if (ord eq Ordering.Int) {
       if (step > 0) last
-      else start
+      else head
     } else super.max(ord)
 
   protected def copy(start: Int, end: Int, step: Int): Range = new Range(start, end, step)

--- a/test/files/run/range.scala
+++ b/test/files/run/range.scala
@@ -16,6 +16,17 @@ object Test {
       catch { case _: IllegalArgumentException => true }
     )
     assert(caught)
+    // #7432
+    val noElemAtMin = (
+      try   { (10 until 10).min ; false }
+      catch { case _: NoSuchElementException => true }
+    )
+    assert(noElemAtMin)
+    val noElemAtMax = (
+      try   { (10 until 10).max ; false }
+      catch { case _: NoSuchElementException => true }
+    )
+    assert(noElemAtMax)
   }
   
   case class GR[T](val x: T)(implicit val num: Integral[T]) {


### PR DESCRIPTION
For consistency, range.max and range.min should throw
NoSuchElementException on an empty range.
