### PR TITLE
SI-6532 emit debug info in compiled java.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -772,6 +772,7 @@ TODO:
         <stopwatch name="@{project}.timer"/>
         <mkdir dir="${@{project}-classes}"/>
         <javac
+          debug="true"
           srcdir="${src.dir}/@{project}"
           destdir="${@{project}-classes}"
           classpath="${@{project}-classes}"
@@ -805,6 +806,7 @@ TODO:
 
     <sequential>
       <javac
+        debug="true"
         srcdir="${src.dir}/@{project}"
         destdir="${build-@{stage}.dir}/classes/@{destproject}"
         includes="**/*.java"


### PR DESCRIPTION
Our handful of java source files weren't being compiled with line numbers,
sourcefile, and other debugger aids. I don't really know how to test this so
I'll enclose an excerpt of the bytecode diff of scala.runtime.IntRef to show
that this change results in debug information.

``` diff
 2,3c2,4
 >   Compiled from "IntRef.java"
 4a6
 >   SourceFile: "IntRef.java"
 53a62,67
 >       LineNumberTable:
 >         line 18: 0
 >       LocalVariableTable:
 >         Start  Length  Slot  Name   Signature
 >                0      10     0  this   Lscala/runtime/IntRef;
 >                0      10     1  elem   I
 62a77,81
 >       LineNumberTable:
 >         line 19: 0
 >       LocalVariableTable:
 >         Start  Length  Slot  Name   Signature
 >                0       8     0  this   Lscala/runtime/IntRef;
```
