### PR TITLE
use relative symlink in distpack

### DIFF
--- a/src/build/pack.xml
+++ b/src/build/pack.xml
@@ -112,8 +112,10 @@ MAIN DISTRIBUTION PACKAGING
   </target>
 
   <target name="pack-archives.latest.unix" depends="pack-archives.src" unless="os.win">
+    <!-- be sure to use a relative symlink to make the distribution portable,
+        `resource` is relative to directory of `link` -->
     <symlink link="${dists.dir}/archives/scala-latest-sources.tgz"
-             resource="${dists.dir}/archives/scala-${version.number}-sources.tgz"
+             resource="scala-${version.number}-sources.tgz"
              overwrite="yes"/>
   </target>
 


### PR DESCRIPTION
To simplify building a release on jenkins, we run distpack-opt in one job,
store the `dists/` directory in a tar ball, archive that artifact and
copy it to the downstream jobs that package on windows and unix.

To make the tarball portable between machines, it must not use absolute symlinks.

review by @jamesiry
