### PR TITLE
SI-6736, SI-6747 sort out Range boundary problems

### DIFF
--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -77,7 +77,7 @@ extends scala.collection.AbstractSeq[Int]
   final private lazy val lastElement     = start + (numRangeElements - 1) * step
   final private lazy val terminalElement = start + numRangeElements * step
 
-  override def last = if (isEmpty) Nil.last else lastElement
+  override def last = if (isEmpty) Nil.last else (start + (numRangeElements - 1) * step)
   override def head = if (isEmpty) Nil.head else start
 
   override def min[A1 >: Int](implicit ord: Ordering[A1]): Int =
@@ -128,15 +128,11 @@ extends scala.collection.AbstractSeq[Int]
   }
 
   @inline final override def foreach[@specialized(Unit) U](f: Int => U) {
-    val isCommonCase = (start != Int.MinValue || end != Int.MinValue)
     var i = start
     var count = 0
     val step = this.step
-    while(
-      // let the lazy vals jitted by putting them in the loop.
-      if(isCommonCase) { i != terminalElement }
-      else             { count < numRangeElements }
-    ) {
+    val numRange = numRangeElements
+    while(count < numRange) {
       f(i)
       count += 1
       i += step

--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -131,10 +131,10 @@ extends scala.collection.AbstractSeq[Int]
     val isCommonCase = (start != Int.MinValue || end != Int.MinValue)
     var i = start
     var count = 0
-    val terminal = terminalElement
     val step = this.step
     while(
-      if(isCommonCase) { i != terminal }
+      // let the lazy vals jitted by putting them in the loop.
+      if(isCommonCase) { i != terminalElement }
       else             { count < numRangeElements }
     ) {
       f(i)

--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -64,7 +64,8 @@ extends scala.collection.AbstractSeq[Int]
     || (start < end && step < 0)
     || (start == end && !isInclusive)
   )
-  final private lazy val numRangeElements: Int = {
+  @deprecated("This method will be made private, use length instead.", "2.11")
+  final lazy val numRangeElements: Int = {
     if (step == 0) throw new IllegalArgumentException("step cannot be 0.")
     else if (isEmpty) 0
     else {
@@ -74,8 +75,10 @@ extends scala.collection.AbstractSeq[Int]
       else len.toInt
     }
   }
-  final private lazy val lastElement     = start + (numRangeElements - 1) * step
-  final private lazy val terminalElement = start + numRangeElements * step
+  @deprecated("This method will be made private, use last instead.", "2.11")
+  final lazy val lastElement     = start + (numRangeElements - 1) * step
+  @deprecated("This method will be made private.", "2.11")
+  final lazy val terminalElement = start + numRangeElements * step
 
   override def last = if (isEmpty) Nil.last else (start + (numRangeElements - 1) * step)
   override def head = if (isEmpty) Nil.head else start

--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -64,17 +64,18 @@ extends scala.collection.AbstractSeq[Int]
     || (start < end && step < 0)
     || (start == end && !isInclusive)
   )
-  final val numRangeElements: Int = {
+  final private lazy val numRangeElements: Int = {
     if (step == 0) throw new IllegalArgumentException("step cannot be 0.")
     else if (isEmpty) 0
     else {
       val len = longLength
-      if (len > scala.Int.MaxValue) -1
+      if (len > scala.Int.MaxValue)
+        throw new IllegalArgumentException(description + ": seqs cannot contain more than Int.MaxValue elements.")
       else len.toInt
     }
   }
-  final val lastElement     = start + (numRangeElements - 1) * step
-  final val terminalElement = start + numRangeElements * step
+  final private lazy val lastElement     = start + (numRangeElements - 1) * step
+  final private lazy val terminalElement = start + numRangeElements * step
 
   override def last = if (isEmpty) Nil.last else lastElement
   override def head = if (isEmpty) Nil.head else start
@@ -103,19 +104,12 @@ extends scala.collection.AbstractSeq[Int]
   def isInclusive = false
 
   override def size = length
-  override def length = if (numRangeElements < 0) fail() else numRangeElements
+  override def length = numRangeElements
 
   private def description = "%d %s %d by %s".format(start, if (isInclusive) "to" else "until", end, step)
-  private def fail() = throw new IllegalArgumentException(description + ": seqs cannot contain more than Int.MaxValue elements.")
-  private def validateMaxLength() {
-    if (numRangeElements < 0)
-      fail()
-  }
 
   @deprecated("Range.foreach() is now self-contained, making this auxiliary method redundant.", "2.10.1")
   def validateRangeBoundaries(f: Int => Any): Boolean = {
-    validateMaxLength()
-
     start != Int.MinValue || end != Int.MinValue || {
       var count = 0
       var num = start
@@ -129,13 +123,11 @@ extends scala.collection.AbstractSeq[Int]
   }
 
   final def apply(idx: Int): Int = {
-    validateMaxLength()
     if (idx < 0 || idx >= numRangeElements) throw new IndexOutOfBoundsException(idx.toString)
     else start + (step * idx)
   }
 
   @inline final override def foreach[@specialized(Unit) U](f: Int => U) {
-    validateMaxLength()
     val isCommonCase = (start != Int.MinValue || end != Int.MinValue)
     var i = start
     var count = 0

--- a/test/files/run/range.scala
+++ b/test/files/run/range.scala
@@ -10,6 +10,17 @@ object Test {
   def boundaryTests() = {
     // #4321
     assert((Int.MinValue to Int.MaxValue by Int.MaxValue).size == 3)
+    // #6736
+    val tooLarge1 = (
+      try   {(Int.MinValue until 0).contains(4) ; false }
+      catch { case _: IllegalArgumentException => true }
+    )
+    assert(tooLarge1)
+    val tooLarge2 = (
+      try   {(0 to Int.MaxValue).contains(4) ; false }
+      catch { case _: IllegalArgumentException => true }
+    )
+    assert(tooLarge2)
     // #4308
     val caught = (
       try   { (Long.MinValue to Long.MaxValue).sum ; false }


### PR DESCRIPTION
When Range contains more than Int.MaxValue elements,
it should throw IllegalArgumentException before every
meaningful operation on it. It seems that the only
reason of delaying this exception is for allowing "by"
operation.

> (Int.MinValue to 0).contains(4) # should throw exception
> (Int.MinValue to 0 by 3).contains(4) # okay

The source of all evil here is irregular use of
`numRangeElements`. It returns -1 if Range object is
invalid. Some use sites of `numRangeElements` properly check
its validity before using it, but some of them miss this
check and cause the integer overflow problems (for example,
in `lastElements`).

I think better strategy is to make `numRangeElements` lazy
value and throw exception inside itself when initialized
but turned to be invalid.

Additionally, because they (`numRangeElements`,`lastElement`,
`terminalElement`) are completely undocumented and also have
better public alternatives (`last`,`length`), I propose to
make them private.
