### PR TITLE
SI-7438 Avoid a performance bug in our JSR166 redistribution

### DIFF
--- a/src/library/scala/concurrent/impl/ExecutionContextImpl.scala
+++ b/src/library/scala/concurrent/impl/ExecutionContextImpl.scala
@@ -115,10 +115,16 @@ private[scala] class ExecutionContextImpl private[impl] (es: Executor, reporter:
           }
         }
       }
-      Thread.currentThread match {
-        case fjw: ForkJoinWorkerThread if fjw.getPool eq fj => fjt.fork()
-        case _ => fj execute fjt
-      }
+      // SI-7438 `fork` offers some performance benefits (it submits work to a local
+      //         queue), but is buggy in the version of Fork/Join that we redistributed
+      //         with Scala 2.10.{0, 1}.
+      //
+      //         TODO Restore this optimization once after updating to the latest JSR-166 sources.
+      // Thread.currentThread match {
+      //   case fjw: ForkJoinWorkerThread if fjw.getPool eq fj => fjt.fork()
+      //   case _ => fj execute fjt
+      // }
+      fj execute fjt
     case generic => generic execute runnable
   }
 


### PR DESCRIPTION
Use `execute` unconditionally, rather than `fork`, which in some
fairly easy to provoke circumstances fails to utilize all available
cores.

The longer term fix is the update to the latest version of the JSR133
code, and then the restore the use of `fork`.

Benchmark and results:

  https://gist.github.com/retronym/5495585

Review by @phaller.

Even if we do decide to update FJ in 2.10.2, I think that we should start with this commit. This gives us better "rollback-ability" of the FJ update in case of some unexpected problem.
