### PR TITLE
Partest can --show-diff again after incremental report.

### DIFF
--- a/src/partest/scala/tools/partest/nest/ConsoleRunner.scala
+++ b/src/partest/scala/tools/partest/nest/ConsoleRunner.scala
@@ -95,6 +95,7 @@ class ConsoleRunner extends DirectRunner {
     if (parsed isSet "--debug") NestUI.setDebug()
     if (parsed isSet "--verbose") NestUI.setVerbose()
     if (parsed isSet "--terse") NestUI.setTerse()
+    if (parsed isSet "--show-diff") NestUI.setDiffOnFail()
 
     // Early return on no args, version, or invalid args
     if (parsed isSet "--version") return echo(versionMsg)

--- a/src/partest/scala/tools/partest/nest/NestUI.scala
+++ b/src/partest/scala/tools/partest/nest/NestUI.scala
@@ -84,7 +84,13 @@ object NestUI {
         dotCount += 1
       }
     }
-    else echo(statusLine(state))
+    else {
+      echo(statusLine(state))
+      if (!state.isOk && isDiffy) {
+        val differ = bold(red("% ")) + "diff "
+        state.transcript find (_ startsWith differ) foreach (echo(_))
+      }
+    }
   }
 
   def echo(message: String): Unit = synchronized {
@@ -172,10 +178,12 @@ object NestUI {
   var _verbose = false
   var _debug = false
   var _terse = false
+  var _diff  = false
 
   def isVerbose = _verbose
   def isDebug = _debug
   def isTerse = _terse
+  def isDiffy = _diff
 
   def setVerbose() {
     _verbose = true
@@ -185,6 +193,9 @@ object NestUI {
   }
   def setTerse() {
     _terse = true
+  }
+  def setDiffOnFail() {
+    _diff = true
   }
   def verbose(msg: String) {
     if (isVerbose)


### PR DESCRIPTION
A flag is set in NestUI to look for "diff" in the transcript of failing tests.

The diff is echoed after the incremental status line for the test.

The use case is that if you ctl-c, you don't see the summary transcripts.

Sorry to annoy, I know you want to do clean-up. It's the middle of the night and I needed it.  I needed it bad.

Review or repulse by @paulp
