### PR TITLE
SI-6736, SI-6747 (alternative impl.) sort out Range boundary problems

### DIFF
--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -64,7 +64,7 @@ extends scala.collection.AbstractSeq[Int]
     || (start < end && step < 0)
     || (start == end && !isInclusive)
   )
-  final val numRangeElements: Int = {
+  final private val numRangeElements: Int = {
     if (step == 0) throw new IllegalArgumentException("step cannot be 0.")
     else if (isEmpty) 0
     else {
@@ -73,10 +73,10 @@ extends scala.collection.AbstractSeq[Int]
       else len.toInt
     }
   }
-  final val lastElement     = start + (numRangeElements - 1) * step
-  final val terminalElement = start + numRangeElements * step
+  final private val lastElement     = start + (numRangeElements - 1) * step
+  final private val terminalElement = start + numRangeElements * step
 
-  override def last = if (isEmpty) Nil.last else lastElement
+  override def last = if (isEmpty) Nil.last else {validateMaxLength(); lastElement}
   override def head = if (isEmpty) Nil.head else start
 
   override def min[A1 >: Int](implicit ord: Ordering[A1]): Int =
@@ -103,7 +103,7 @@ extends scala.collection.AbstractSeq[Int]
   def isInclusive = false
 
   override def size = length
-  override def length = if (numRangeElements < 0) fail() else numRangeElements
+  override def length = {validateMaxLength(); numRangeElements}
 
   private def description = "%d %s %d by %s".format(start, if (isInclusive) "to" else "until", end, step)
   private def fail() = throw new IllegalArgumentException(description + ": seqs cannot contain more than Int.MaxValue elements.")
@@ -158,11 +158,12 @@ extends scala.collection.AbstractSeq[Int]
    *  @param n  the number of elements to take.
    *  @return   a new range consisting of `n` first elements.
    */
-  final override def take(n: Int): Range = (
+  final override def take(n: Int): Range = {
+    validateMaxLength()
     if (n <= 0 || isEmpty) newEmptyRange(start)
     else if (n >= numRangeElements) this
     else new Range.Inclusive(start, locationAfterN(n - 1), step)
-  )
+  }
 
   /** Creates a new range containing all the elements of this range except the first `n` elements.
    *
@@ -171,11 +172,12 @@ extends scala.collection.AbstractSeq[Int]
    *  @param n  the number of elements to drop.
    *  @return   a new range consisting of all the elements of this range except `n` first elements.
    */
-  final override def drop(n: Int): Range = (
+  final override def drop(n: Int): Range = {
+    validateMaxLength()
     if (n <= 0 || isEmpty) this
     else if (n >= numRangeElements) newEmptyRange(end)
     else copy(locationAfterN(n), end, step)
-  )
+  }
 
   /** Creates a new range containing all the elements of this range except the last one.
    *
@@ -205,6 +207,7 @@ extends scala.collection.AbstractSeq[Int]
 
   // Counts how many elements from the start meet the given test.
   private def skipCount(p: Int => Boolean): Int = {
+    validateMaxLength()
     var current = start
     var counted = 0
 
@@ -270,6 +273,7 @@ extends scala.collection.AbstractSeq[Int]
   final def contains(x: Int) = isWithinBoundaries(x) && ((x - start) % step == 0)
 
   final override def sum[B >: Int](implicit num: Numeric[B]): Int = {
+    validateMaxLength()
     if (isEmpty) 0
     else if (numRangeElements == 1) head
     else (numRangeElements.toLong * (head + last) / 2).toInt
@@ -293,6 +297,7 @@ extends scala.collection.AbstractSeq[Int]
    */
 
   override def toString() = {
+    validateMaxLength()
     val endStr = if (numRangeElements > Range.MAX_PRINT) ", ... )" else ")"
     take(Range.MAX_PRINT).mkString("Range(", ", ", endStr)
   }

--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -64,7 +64,8 @@ extends scala.collection.AbstractSeq[Int]
     || (start < end && step < 0)
     || (start == end && !isInclusive)
   )
-  final private val numRangeElements: Int = {
+  @deprecated("This method will be made private, use length instead.", "2.11")
+  final val numRangeElements: Int = {
     if (step == 0) throw new IllegalArgumentException("step cannot be 0.")
     else if (isEmpty) 0
     else {
@@ -73,8 +74,10 @@ extends scala.collection.AbstractSeq[Int]
       else len.toInt
     }
   }
-  final private val lastElement     = start + (numRangeElements - 1) * step
-  final private val terminalElement = start + numRangeElements * step
+  @deprecated("This method will be made private, use last instead.", "2.11")
+  final val lastElement     = start + (numRangeElements - 1) * step
+  @deprecated("This method will be made private.", "2.11")
+  final val terminalElement = start + numRangeElements * step
 
   override def last = if (isEmpty) Nil.last else {validateMaxLength(); lastElement}
   override def head = if (isEmpty) Nil.head else start

--- a/test/files/run/range.scala
+++ b/test/files/run/range.scala
@@ -10,6 +10,17 @@ object Test {
   def boundaryTests() = {
     // #4321
     assert((Int.MinValue to Int.MaxValue by Int.MaxValue).size == 3)
+    // #6736
+    val tooLarge1 = (
+      try   {(Int.MinValue until 0).contains(4) ; false }
+      catch { case _: IllegalArgumentException => true }
+    )
+    assert(tooLarge1)
+    val tooLarge2 = (
+      try   {(0 to Int.MaxValue).contains(4) ; false }
+      catch { case _: IllegalArgumentException => true }
+    )
+    assert(tooLarge2)
     // #4308
     val caught = (
       try   { (Long.MinValue to Long.MaxValue).sum ; false }


### PR DESCRIPTION
When Range contains more than Int.MaxValue elements,
it should throw IllegalArgumentException before every
meaningful operation on it. It seems that the only
reason of delaying this exception is for allowing "by"
operation.

> (Int.MinValue to 0).contains(4) # should throw exception
> (Int.MinValue to 0 by 3).contains(4) # okay

The source of all evil here is irregular use of
`numRangeElements`. It returns -1 if Range object is
invalid. Some use sites of `numRangeElements` properly check
its validity before using it, but some of them miss this
check and cause the integer overflow problems (for example,
in `lastElements`).

This commit adds missing checks.

Additionally, because they (`numRangeElements`,`lastElement`,
`terminalElement`) are completely undocumented and also have
better public alternatives (`last`,`length`), I propose to
make them private.
