### PR TITLE
easy way of writing not implemented macros

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -1307,6 +1307,11 @@ trait ContextErrors {
       throw MacroBodyTypecheckException // don't call fail, because we don't need IS_ERROR
     }
 
+    def MacroDefIsQmarkQmarkQmark() = {
+      macroLogVerbose("typecheck terminated unexpectedly: macro is ???")
+      throw MacroBodyTypecheckException
+    }
+
     def MacroFeatureNotEnabled() = {
       macroLogVerbose("typecheck terminated unexpectedly: language.experimental.macros feature is not enabled")
       fail()

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5792,7 +5792,7 @@ trait Typers extends Modes with Adaptations with Tags {
           tree1
         }
 
-      val isMacroBodyOkay = !tree.symbol.isErroneous && !(tree1 exists (_.isErroneous))
+      val isMacroBodyOkay = !tree.symbol.isErroneous && !(tree1 exists (_.isErroneous)) && tree1 != EmptyTree
       val shouldInheritMacroImplReturnType = ddef.tpt.isEmpty
       if (isMacroBodyOkay && shouldInheritMacroImplReturnType) computeMacroDefTypeFromMacroImpl(ddef, tree1.symbol) else AnyClass.tpe
     }

--- a/test/files/neg/macro-qmarkqmarkqmark.check
+++ b/test/files/neg/macro-qmarkqmarkqmark.check
@@ -1,0 +1,13 @@
+macro-qmarkqmarkqmark.scala:5: error: macro implementation is missing
+  foo1
+  ^
+macro-qmarkqmarkqmark.scala:8: error: macros cannot be partially applied
+  foo2
+  ^
+macro-qmarkqmarkqmark.scala:9: error: macro implementation is missing
+  foo2(1)
+      ^
+macro-qmarkqmarkqmark.scala:12: error: macro implementation is missing
+  foo3[Int]
+      ^
+four errors found

--- a/test/files/neg/macro-qmarkqmarkqmark.scala
+++ b/test/files/neg/macro-qmarkqmarkqmark.scala
@@ -1,0 +1,13 @@
+import language.experimental.macros
+
+object Macros {
+  def foo1 = macro ???
+  foo1
+
+  def foo2(x: Int) = macro ???
+  foo2
+  foo2(1)
+
+  def foo3[T] = macro ???
+  foo3[Int]
+}

--- a/test/files/pos/macro-qmarkqmarkqmark.scala
+++ b/test/files/pos/macro-qmarkqmarkqmark.scala
@@ -1,0 +1,7 @@
+import language.experimental.macros
+
+object Macros {
+  def foo1 = macro ???
+  def foo2(x: Int) = macro ???
+  def foo3[T] = macro ???
+}


### PR DESCRIPTION
Even though it's easy to mark regular method bodies as stubs (using ???),
there's no simple way of doing the same for macro methods. This patch
fixes the inconvenience.
