### PR TITLE
Limit unnecessary calls to Type#toString.

### DIFF
--- a/test/files/neg/tailrec-2.check
+++ b/test/files/neg/tailrec-2.check
@@ -1,4 +1,4 @@
-tailrec-2.scala:8: error: could not optimize @tailrec annotated method f: it contains a recursive call targeting supertype Super[A]
+tailrec-2.scala:8: error: could not optimize @tailrec annotated method f: it contains a recursive call targeting a supertype
   @annotation.tailrec final def f[B >: A](mem: List[B]): List[B] = (null: Super[A]).f(mem)
                                                                                     ^
 tailrec-2.scala:9: error: @tailrec annotated method contains no recursive calls


### PR DESCRIPTION
Logging revealed a few thousand calls to the often expensive Type#toString
emerging from tailcalls. The error message was being generated for all methods
even though it was only issued in rare cases (and for the particular tailrec
failure which made the call, extremely rare.)

The remaining boatload of unnecessary Type#toString calls are much harder to
fix due to the design of "AbsTypeError" and the fact that the compiler
approaches mutability like a cat approaches a loaded gun. See SI-6149.
