### PR TITLE
SI-7383 - call ExecutionContext.prepare in Future.apply

### DIFF
--- a/src/library/scala/concurrent/impl/Future.scala
+++ b/src/library/scala/concurrent/impl/Future.scala
@@ -28,7 +28,7 @@ private[concurrent] object Future {
 
   def apply[T](body: =>T)(implicit executor: ExecutionContext): scala.concurrent.Future[T] = {
     val runnable = new PromiseCompletingRunnable(body)
-    executor.execute(runnable)
+    executor.prepare.execute(runnable)
     runnable.promise.future
   }
 }


### PR DESCRIPTION
https://issues.scala-lang.org/browse/SI-7383

Review by @phaller, @adriaanm

ExecutionContext.prepare is meant to be used as a way to capture context like ThreadLocals etc and then reinstating them when the the Runnable is executed.
