### PR TITLE
SI-6039 Harden against irrelevant filesystem details

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
@@ -234,10 +234,14 @@ abstract class SymbolLoaders {
         }
       }
       if (!root.isEmptyPackageClass) {
+        // Only enter packages which contain a class or a non-empty package
         for (pkg <- classpath.packages) {
-          enterPackage(root, pkg.name, new PackageLoader(pkg))
+          if (pkg.isEmptyOfClassfiles) {
+            log(s"Discarding $root/$pkg as it contains no classfiles.")
+          }
+          else
+            enterPackage(root, pkg.name, new PackageLoader(pkg))
         }
-
         openPackageModule(root)
       }
     }

--- a/src/compiler/scala/tools/nsc/util/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/util/ClassPath.scala
@@ -211,6 +211,8 @@ abstract class ClassPath[T] {
   def validPackage(name: String)    = (name != "META-INF") && (name != "") && (name.charAt(0) != '.')
   def validSourceFile(name: String) = endsScala(name) || endsJava(name)
 
+  def isEmptyOfClassfiles: Boolean = classes.isEmpty && packages.forall(_.isEmptyOfClassfiles)
+
   /**
    * Find a ClassRep given a class name of the form "package.subpackage.ClassName".
    * Does not support nested classes on .NET

--- a/test/files/run/t6039.scala
+++ b/test/files/run/t6039.scala
@@ -1,0 +1,18 @@
+import scala.tools.partest._
+
+object Test extends StoreReporterDirectTest {
+  private def compileCode(): Boolean = {
+    new java.io.File("util") mkdirs
+    val classpath = List(sys.props("partest.lib"), ".") mkString sys.props("path.separator")
+    log(s"classpath = $classpath")
+    compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(packageCode)
+  }
+  def code = ???
+  def packageCode = """
+package scala.bippy
+class A { new util.Random() }
+"""
+  def show(): Unit = {
+    assert(compileCode(), filteredInfos take 1 mkString "")
+  }
+}


### PR DESCRIPTION
The symbol loader need not create and populate package symbols merely because
there is a directory somewhere. Every package created based on the existence
of a directory should contain a classfile, either directly or indirectly.
