### PR TITLE
SI-7464 allows FieldMirror.set to update vals

### DIFF
--- a/src/reflect/scala/reflect/api/Mirrors.scala
+++ b/src/reflect/scala/reflect/api/Mirrors.scala
@@ -133,9 +133,7 @@ package api
  *   scala> fmX.get
  *   res0: Any = 2
  *
- *   scala> fmX.set(3)
- *   scala.ScalaReflectionException: cannot set an immutable field x
- *   ...
+ *   scala> fmX.set(3) // NOTE: can set an underlying value of an immutable field!
  *
  *   scala> val fieldY = typeOf[C].declaration(newTermName("y")).asTerm.accessed.asTerm
  *   fieldY: reflect.runtime.universe.TermSymbol = variable y

--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -133,6 +133,7 @@ private[reflect] trait JavaMirrors extends internal.SymbolTable with api.JavaUni
       sm"""Scala field ${sym.name} isn't represented as a Java field, neither it has a Java accessor method
           |note that private parameters of class constructors don't get mapped onto fields and/or accessors,
           |unless they are used outside of their declaring constructors.""")
+    @deprecated("corresponding check has been removed from FieldMirror.set, this method is also being phased out", "2.11.0")
     private def ErrorSetImmutableField(sym: Symbol) = throw new ScalaReflectionException(s"cannot set an immutable field ${sym.name}")
     private def ErrorNotConstructor(sym: Symbol, owner: Symbol) = throw new ScalaReflectionException(s"expected a constructor of $owner, you provided $sym")
     private def ErrorFree(member: Symbol, freeType: Symbol) = throw new ScalaReflectionException(s"cannot reflect ${member.kindString} ${member.name}, because it's a member of a weak type ${freeType.name}")
@@ -282,7 +283,8 @@ private[reflect] trait JavaMirrors extends internal.SymbolTable with api.JavaUni
       }
       def get = jfield.get(receiver)
       def set(value: Any) = {
-        if (!symbol.isMutable) ErrorSetImmutableField(symbol)
+        // it appears useful to be able to set values of vals, therefore I'm disabling this check
+        // if (!symbol.isMutable) ErrorSetImmutableField(symbol)
         jfield.set(receiver, value)
       }
       override def toString = s"field mirror for ${symbol.fullName} (bound to $receiver)"

--- a/test/files/run/reflection-fieldmirror-getsetval.check
+++ b/test/files/run/reflection-fieldmirror-getsetval.check
@@ -1,2 +1,2 @@
 42
-cannot set an immutable field x 
+2

--- a/test/files/run/reflection-fieldmirror-getsetval.scala
+++ b/test/files/run/reflection-fieldmirror-getsetval.scala
@@ -12,13 +12,7 @@ object Test extends App {
   val cs = im.symbol
   val f = cs.typeSignature.declaration(newTermName("x" + nme.LOCAL_SUFFIX_STRING)).asTerm
   val fm: FieldMirror = im.reflectField(f)
-  try {
-    println(fm.get)
-    fm.set(2)
-    println(fm.get)
-    println("this indicates a failure")
-  } catch {
-    case ex: Throwable =>
-      println(ex.getMessage)
-  }
+  println(fm.get)
+  fm.set(2)
+  println(fm.get)
 }


### PR DESCRIPTION
There's no reason to leave such sentinels in place inside a facility
designed to circumvent usual restrictions of static types / visibility.
