### PR TITLE
c.typeCheck(silent = true) now suppresses ambiguous errors

### DIFF
--- a/src/compiler/scala/reflect/macros/runtime/Typers.scala
+++ b/src/compiler/scala/reflect/macros/runtime/Typers.scala
@@ -22,7 +22,7 @@ trait Typers {
     // typechecking uses silent anyways (e.g. in typedSelect), so you'll only waste your time
     // I'd advise fixing the root cause: finding why the context is not set to report errors
     // (also see reflect.runtime.ToolBoxes.typeCheckExpr for a workaround that might work for you)
-    wrapper(callsiteTyper.silent(_.typed(tree, universe.analyzer.EXPRmode, pt)) match {
+    wrapper(callsiteTyper.silent(_.typed(tree, universe.analyzer.EXPRmode, pt), reportAmbiguousErrors = false) match {
       case universe.analyzer.SilentResultValue(result) =>
         macroLogVerbose(result)
         result

--- a/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
+++ b/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
@@ -166,7 +166,7 @@ abstract class ToolBoxFactory[U <: JavaUniverse](val u: U) { factorySelf =>
         transformDuringTyper(expr, withImplicitViewsDisabled = withImplicitViewsDisabled, withMacrosDisabled = withMacrosDisabled)(
           (currentTyper, expr) => {
             trace("typing (implicit views = %s, macros = %s): ".format(!withImplicitViewsDisabled, !withMacrosDisabled))(showAttributed(expr, true, true, settings.Yshowsymkinds.value))
-            currentTyper.silent(_.typed(expr, analyzer.EXPRmode, pt)) match {
+            currentTyper.silent(_.typed(expr, analyzer.EXPRmode, pt), reportAmbiguousErrors = false) match {
               case analyzer.SilentResultValue(result) =>
                 trace("success: ")(showAttributed(result, true, true, settings.Yshowsymkinds.value))
                 result

--- a/test/files/pos/t7461/Macros_1.scala
+++ b/test/files/pos/t7461/Macros_1.scala
@@ -1,0 +1,13 @@
+import scala.reflect.macros.Context
+import language.experimental.macros
+
+object Macros {
+  def impl(c: Context) = {
+    import c.universe._
+    val wut = c.typeCheck(Select(Literal(Constant(10)), newTermName("$minus")), silent = true)
+    // println(showRaw(wut, printIds = true, printTypes = true))
+    c.literalUnit
+  }
+
+  def foo = macro impl
+}

--- a/test/files/pos/t7461/Test_2.scala
+++ b/test/files/pos/t7461/Test_2.scala
@@ -1,0 +1,3 @@
+class C {
+  def foo = Macros.foo
+}


### PR DESCRIPTION
Otherwise use cases like the one shown in the attached test (trying to
typecheck something, which leads to an ambiguous overload error) will
mysteriously fail compilation.
