### PR TITLE
Par-Test includes log in transcript of failed exec

### DIFF
--- a/src/partest/scala/tools/partest/nest/Runner.scala
+++ b/src/partest/scala/tools/partest/nest/Runner.scala
@@ -227,10 +227,11 @@ class Runner(val testFile: File, fileManager: FileManager, val testRunParams: Te
   private def execTest(outDir: File, logFile: File): Boolean = {
     val cmd = assembleTestCommand(outDir, logFile)
 
-    pushTranscript(cmd.mkString(" \\\n  ") + " > " + logFile.getName)
-    nextTestActionExpectTrue("non-zero exit code", runCommand(cmd, logFile)) || {
-      _transcript append logFile.fileContents
-      false
+    pushTranscript((cmd mkString s" \\$EOL  ") + " > " + logFile.getName)
+    nextTestAction(runCommand(cmd, logFile)) {
+      case false =>
+        _transcript append EOL + logFile.fileContents
+        genFail("non-zero exit code")
     }
   }
 


### PR DESCRIPTION
The previous behavior was that the Failure is generated
before the log is appended to the transcript.

That meant that the summary transcripts wouldn't include
the log file. Luckily, the transcript would say something
like "jvm > showFail-run.log".

Sorry, I was just about to put this commit on my other partest PR, but for some reason it's been reviewed and merged already.  Thanks and the same note applies, that this improving tweak is deemed useful enough not to annoy with paltritude.  If that's not a word, I hope you'll take it as one.

For the record, I pursued this as part of the "empty util package" review.

(My other branch redirects stderr to the log file, so it's nice to see the log.)

Review by @paulp who takes a modern view
