### PR TITLE
fixes a checkfile breakage in 2.10.x

### DIFF
--- a/test/files/run/t7271.check
+++ b/test/files/run/t7271.check
@@ -1,4 +1,4 @@
-[[syntax trees at end of                    parser]] // newSource1
+[[syntax trees at end of                    parser]] // newSource1.scala
 [0:91]package [0:0]<empty> {
   [0:91]class C extends [8:91][91]scala.AnyRef {
     [8]def <init>() = [8]{


### PR DESCRIPTION
The breakage is caused by https://github.com/scala/scala/commit/fbb13630d3
and https://github.com/scala/scala/commit/a8edefcef8 having been merged
independently from each other.
