### PR TITLE
Actual SI-6555 fix, Scaladoc filter works now WITH keyboard shortcuts too

### DIFF
--- a/src/compiler/scala/tools/nsc/doc/html/resource/lib/index.js
+++ b/src/compiler/scala/tools/nsc/doc/html/resource/lib/index.js
@@ -14,9 +14,9 @@ var title = $(document).attr('title');
 var lastHash = "";
 
 $(document).ready(function() {
-    $('body').layout({ 
+    $('body').layout({
         west__size: '20%',
-        center__maskContents: true 
+        center__maskContents: true
     });
     $('#browser').layout({
         center__paneSelector: ".ui-west-center"
@@ -342,14 +342,17 @@ function configureTextFilter() {
             if (event.keyCode == 27) { // escape
                 input.attr("value", "");
             }
-            if (event.keyCode == 9) { // tab
-                $("#template").contents().find("#mbrsel-input").focus();
-                input.attr("value", "");
-                return false;
-            }
             if (event.keyCode == 40) { // down arrow
                 $(window).unbind("keydown");
                 keyboardScrolldownLeftPane();
+                return false;
+            }
+            textFilter();
+        });
+        input.bind('keydown', function(event) {
+            if (event.keyCode == 9) { // tab
+                $("#template").contents().find("#mbrsel-input").focus();
+                input.attr("value", "");
                 return false;
             }
             textFilter();


### PR DESCRIPTION
Commit daefab18b8b0c170c372991022357413ec69b2af attempted to fix a bug related to Scaladoc filtering, meanwhile breaking Scaladoc keyboard shortcuts.

Before commit daefab18b8b0c170c372991022357413ec69b2af, Scaladoc's filter wouldn't consider the last character of a search term entered into the (left) Scaladoc filter pane, but toggling with the `tab` key between filter panes did work.

After daefab18b8b0c170c372991022357413ec69b2af, Scaladoc's left pane filter correctly searches for the full search term, but pressing the `tab` key causes the "focus" of the input bar to be stuck on the filter panel in the right Scaladoc filter pane, rendering it useless.

End result: annoying Scaladoc interface bug present in 2.10.1, but which wasn't present in 2.10.0.

This pull request fixes this, enabling both behaviors. The `tab` key toggle needed to be triggered on a `keydown` event, while everything else is fine to be triggered on a `keyup` event. This pull request enables the correct behavior by binding both a `keydown` and a `keyup` event rather than lumping everything all together in a `keyup` event (as was the case before).
