### PR TITLE
SI-6406 Restore deprecated API

### DIFF
--- a/src/library/scala/util/matching/Regex.scala
+++ b/src/library/scala/util/matching/Regex.scala
@@ -205,6 +205,20 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
     else if (m.matcher.pattern == this.pattern) Some(1 to m.groupCount map m.group)
     else unapplySeq(m.matched)
 
+  /** Tries to match target.
+   *  @param target The string to match
+   *  @return       The matches
+   */
+  @deprecated("Extracting a match result from anything but a CharSequence or Match is deprecated", "2.11.0")
+  def unapplySeq(target: Any): Option[List[String]] = target match {
+    case s: CharSequence =>
+      val m = pattern matcher s
+      if (runMatcher(m)) Some((1 to m.groupCount).toList map m.group)
+      else None
+    case m: Match => unapplySeq(m.matched)
+    case _ => None
+  }
+
   //  @see UnanchoredRegex
   protected def runMatcher(m: Matcher) = m.matches()
 

--- a/test/files/neg/t6406-regextract.check
+++ b/test/files/neg/t6406-regextract.check
@@ -1,7 +1,6 @@
-t6406-regextract.scala:4: error: cannot resolve overloaded unapply
+t6406-regextract.scala:4: warning: method unapplySeq in class Regex is deprecated: Extracting a match result from anything but a CharSequence or Match is deprecated
   List(1) collect { case r(i) => i }
                          ^
-t6406-regextract.scala:4: error: not found: value i
-  List(1) collect { case r(i) => i }
-                                 ^
-two errors found
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found


### PR DESCRIPTION
The original patch for SI-6406 was intended for 2.10 but during
those volatile weeks of early autumn, it missed the boat.

A deprecated method was incorrectly tagged at 2.10 and later
removed; this restores the method and its test, and resets
the deprecation clock to 2.11.

The deprecation tool should confirm that changes occur on the
git timeline as claimed.

This partially reverts f931833df8cc69d119f636d8a553941bf7ce2349.

Review by @soc aka The Scourge of Deprecation
