### PR TITLE
SI-7469 Make @deprecated elems in scala.concurrent private[scala]

### DIFF
--- a/src/library/scala/concurrent/FutureTaskRunner.scala
+++ b/src/library/scala/concurrent/FutureTaskRunner.scala
@@ -16,7 +16,7 @@ import scala.language.{implicitConversions, higherKinds}
  *  @author Philipp Haller
  */
 @deprecated("Use `ExecutionContext` instead.", "2.10.0")
-trait FutureTaskRunner extends TaskRunner {
+private[scala] trait FutureTaskRunner extends TaskRunner {
 
   /** The type of the futures that the underlying task runner supports.
    */

--- a/src/library/scala/concurrent/ManagedBlocker.scala
+++ b/src/library/scala/concurrent/ManagedBlocker.scala
@@ -13,7 +13,7 @@ package scala.concurrent
  *  @author Philipp Haller
  */
 @deprecated("Use `blocking` instead.", "2.10.0")
-trait ManagedBlocker {
+private[scala] trait ManagedBlocker {
 
   /**
    * Possibly blocks the current thread, for example waiting for

--- a/src/library/scala/concurrent/SyncVar.scala
+++ b/src/library/scala/concurrent/SyncVar.scala
@@ -79,7 +79,7 @@ class SyncVar[A] {
   // whether or not the SyncVar is already defined. So, set has been
   // deprecated in order to eventually be able to make "setting" private
   @deprecated("Use `put` instead, as `set` is potentionally error-prone", "2.10.0")
-  def set(x: A): Unit = setVal(x)
+  private[scala] def set(x: A): Unit = setVal(x)
 
   /** Places a value in the SyncVar. If the SyncVar already has a stored value,
    * it waits until another thread takes it */
@@ -98,7 +98,7 @@ class SyncVar[A] {
   // whether or not the SyncVar is already defined. So, unset has been
   // deprecated in order to eventually be able to make "unsetting" private
   @deprecated("Use `take` instead, as `unset` is potentionally error-prone", "2.10.0")
-  def unset(): Unit = synchronized {
+  private[scala] def unset(): Unit = synchronized {
     isDefined = false
     value = None
     notifyAll()

--- a/src/library/scala/concurrent/TaskRunner.scala
+++ b/src/library/scala/concurrent/TaskRunner.scala
@@ -15,7 +15,7 @@ import scala.language.{higherKinds, implicitConversions}
  *  @author Philipp Haller
  */
 @deprecated("Use `ExecutionContext` instead.", "2.10.0")
-trait TaskRunner {
+private[scala] trait TaskRunner {
 
   type Task[T]
 

--- a/src/library/scala/concurrent/ThreadPoolRunner.scala
+++ b/src/library/scala/concurrent/ThreadPoolRunner.scala
@@ -17,7 +17,7 @@ import scala.language.implicitConversions
  *  @author Philipp Haller
  */
 @deprecated("Use `ExecutionContext` instead.", "2.10.0")
-trait ThreadPoolRunner extends FutureTaskRunner {
+private[scala] trait ThreadPoolRunner extends FutureTaskRunner {
 
   type Task[T] = Callable[T] with Runnable
   type Future[T] = java.util.concurrent.Future[T]


### PR DESCRIPTION
They can't be removed yet because scala.actors depends on it.
