### PR TITLE
SI-7445 element order of ListMap.iterator should be reversed

### DIFF
--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -123,7 +123,7 @@ extends AbstractMap[A, B]
       def next(): (A,B) =
         if (!hasNext) throw new NoSuchElementException("next on empty iterator")
         else { val res = (self.key, self.value); self = self.tail; res }
-    }.toList.reverseIterator
+    }.toList.iterator
 
   protected def key: A = throw new NoSuchElementException("empty map")
   protected def value: B = throw new NoSuchElementException("empty map")
@@ -217,5 +217,6 @@ extends AbstractMap[A, B]
 
 
     override def tail: ListMap[A, B1] = ListMap.this
+    override def head: (A, B1) = (key,value)
   }
 }

--- a/test/files/jvm/serialization-new.check
+++ b/test/files/jvm/serialization-new.check
@@ -84,8 +84,8 @@ x = List((buffers,20), (layers,2), (title,3))
 y = List((buffers,20), (layers,2), (title,3))
 x equals y: true, y equals x: true
 
-x = Map(buffers -> 20, layers -> 2, title -> 3)
-y = Map(buffers -> 20, layers -> 2, title -> 3)
+x = Map(title -> 3, layers -> 2, buffers -> 20)
+y = Map(title -> 3, layers -> 2, buffers -> 20)
 x equals y: true, y equals x: true
 
 x = ListSet(5, 3)

--- a/test/files/jvm/serialization.check
+++ b/test/files/jvm/serialization.check
@@ -84,8 +84,8 @@ x = List((buffers,20), (layers,2), (title,3))
 y = List((buffers,20), (layers,2), (title,3))
 x equals y: true, y equals x: true
 
-x = Map(buffers -> 20, layers -> 2, title -> 3)
-y = Map(buffers -> 20, layers -> 2, title -> 3)
+x = Map(title -> 3, layers -> 2, buffers -> 20)
+y = Map(title -> 3, layers -> 2, buffers -> 20)
 x equals y: true, y equals x: true
 
 x = ListSet(5, 3)

--- a/test/files/run/t5387.scala
+++ b/test/files/run/t5387.scala
@@ -4,11 +4,11 @@
 import scala.collection.immutable.ListMap
 object Test extends App{
   val subject = ListMap(1->1,2->2,3->3,4->4,5->5)
-  val result  = ListMap(3->3,4->4,5->5)
+  val result  = ListMap(1->1,2->2,3->3)
   assert( result == subject.dropWhile{
        case (key, value) => {
-         assert( key <= 3, "predicate evaluated more often than needed, key "+key )
-         key < 3
+         assert( key >= 3, "predicate evaluated more often than needed, key "+key )
+         key > 3
        }
     }
   )

--- a/test/files/run/t7445.scala
+++ b/test/files/run/t7445.scala
@@ -1,0 +1,11 @@
+/*
+ * Since ListMap is an ordered collection, head and tail should also respect the order, see https://issues.scala-lang.org/browse/SI-7445
+ */
+import scala.collection.immutable.ListMap
+import scala.collection.mutable.{ListMap => MListMap}
+object Test extends App{
+  val subject = ListMap(1->1,2->2,3->3,4->4,5->5)
+  assert(subject.tail+subject.head == subject)
+  val msubject = MListMap(1->1,2->2,3->3,4->4,5->5)
+  assert(subject.head == msubject.head)
+}


### PR DESCRIPTION
Since the underlying collection of ListMap is indeed a List,
order-related methods of ListMap should respect the order
of elements in the underlying List.

Since the underlying List of ListMap stores elements in a
reversed input order (i.e. LIFO), it is natural that
ListMap.iterator also returns elements in the same order.
