### PR TITLE
SI-7201 scala-library's pom points to scaladoc url

### DIFF
--- a/src/build/maven/scala-actors-pom.xml
+++ b/src/build/maven/scala-actors-pom.xml
@@ -30,6 +30,9 @@
       <system>JIRA</system>
       <url>https://issues.scala-lang.org/</url>
    </issueManagement>	
+   <properties>
+       <info.apiURL>http://www.scala-lang.org/api/@VERSION@/</info.apiURL>
+   </properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.scala-lang</groupId>

--- a/src/build/maven/scala-library-pom.xml
+++ b/src/build/maven/scala-library-pom.xml
@@ -30,6 +30,9 @@
       <system>JIRA</system>
       <url>https://issues.scala-lang.org/</url>
    </issueManagement>
+   <properties>
+       <info.apiURL>http://www.scala-lang.org/api/@VERSION@/</info.apiURL>
+   </properties>
    <dependencies>
       <!--<dependency>
          <groupId>com.typesafe</groupId>

--- a/src/build/maven/scala-reflect-pom.xml
+++ b/src/build/maven/scala-reflect-pom.xml
@@ -30,7 +30,9 @@
                 <system>JIRA</system>
                 <url>https://issues.scala-lang.org/</url>
 	</issueManagement>
-
+  <properties>
+      <info.apiURL>http://www.scala-lang.org/api/@VERSION@/</info.apiURL>
+  </properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.scala-lang</groupId>

--- a/src/build/maven/scala-swing-pom.xml
+++ b/src/build/maven/scala-swing-pom.xml
@@ -30,6 +30,9 @@
       <system>JIRA</system>
       <url>https://issues.scala-lang.org/</url>
    </issueManagement>	
+   <properties>
+       <info.apiURL>http://www.scala-lang.org/api/@VERSION@/</info.apiURL>
+   </properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.scala-lang</groupId>


### PR DESCRIPTION
The project/properties/info.apiURL pom property is used by SBT
to link to an artifact's scaladoc.

For scala-library version $v, the url is http://www.scala-lang.org/api/$v/

I verified the substitution works by inspecting the pom generated by `ant deploy.local`

review by @harrah or @jsuereth
