### PR TITLE
Read-eval-print : the script engine does not need print so make it lazy

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -899,7 +899,7 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
       val preamble = """
       |object %s {
       |  %s
-      |  val %s: String = %s {
+      |  lazy val %s: String = %s {
       |    %s
       |    (""
       """.stripMargin.format(


### PR DESCRIPTION
This can have a dramatic effect on computing time in cases with big
intermediate results but simple final one.
