### PR TITLE
Deprecate parameter names in scala.concurrent

### DIFF
--- a/src/library/scala/concurrent/ExecutionContext.scala
+++ b/src/library/scala/concurrent/ExecutionContext.scala
@@ -25,7 +25,7 @@ trait ExecutionContext {
   
   /** Reports that an asynchronous computation failed.
    */
-  def reportFailure(t: Throwable): Unit
+  def reportFailure(@deprecatedName('t) cause: Throwable): Unit
   
   /** Prepares for the execution of a task. Returns the prepared
    *  execution context. A valid implementation of `prepare` is one
@@ -83,7 +83,7 @@ object ExecutionContext {
   
   /** The default reporter simply prints the stack trace of the `Throwable` to System.err.
    */
-  def defaultReporter: Throwable => Unit = (t: Throwable) => t.printStackTrace()
+  def defaultReporter: Throwable => Unit = _.printStackTrace()
 }
 
 

--- a/src/library/scala/concurrent/Promise.scala
+++ b/src/library/scala/concurrent/Promise.scala
@@ -86,7 +86,7 @@ trait Promise[T] {
    *
    *  $promiseCompletion
    */
-  def success(v: T): this.type = complete(Success(v))
+  def success(@deprecatedName('v) value: T): this.type = complete(Success(value))
 
   /** Tries to complete the promise with a value.
    *
@@ -104,7 +104,7 @@ trait Promise[T] {
    *
    *  $promiseCompletion
    */
-  def failure(t: Throwable): this.type = complete(Failure(t))
+  def failure(@deprecatedName('t) cause: Throwable): this.type = complete(Failure(cause))
 
   /** Tries to complete the promise with an exception.
    *
@@ -112,7 +112,7 @@ trait Promise[T] {
    *
    *  @return    If the promise has already been completed returns `false`, or `true` otherwise.
    */
-  def tryFailure(t: Throwable): Boolean = tryComplete(Failure(t))
+  def tryFailure(@deprecatedName('t) cause: Throwable): Boolean = tryComplete(Failure(cause))
 }
 
 

--- a/src/library/scala/concurrent/package.scala
+++ b/src/library/scala/concurrent/package.scala
@@ -24,10 +24,10 @@ package object concurrent {
    *  
    *  @tparam T       the type of the result
    *  @param body     the asynchronous computation
-   *  @param execctx  the execution context on which the future is run
+   *  @param executor the execution context on which the future is run
    *  @return         the `Future` holding the result of the computation
    */
-  def future[T](body: =>T)(implicit execctx: ExecutionContext): Future[T] = Future[T](body)
+  def future[T](body: =>T)(implicit @deprecatedName('execctx) executor: ExecutionContext): Future[T] = Future[T](body)
 
   /** Creates a promise object which can be completed with a value or an exception.
    *  


### PR DESCRIPTION
for the purpose of being consistent.
Also switches to Future.successful iso
Promise.successful(..).future for brevity
in implementation code.
