### PR TITLE
Prevent slash duplication.

### DIFF
--- a/src/compiler/scala/tools/nsc/doc/Settings.scala
+++ b/src/compiler/scala/tools/nsc/doc/Settings.scala
@@ -249,10 +249,7 @@ class Settings(error: String => Unit, val printMsg: String => Unit = println(_))
     }
   }
 
-  def appendIndex(url: String): String = {
-    val index = "/index.html"
-    if (url.endsWith(index)) url else url + index
-  }
+  def appendIndex(url: String): String = url.stripSuffix("index.html").stripSuffix("/") + "/index.html"
 
   // Deprecated together with 'docExternalUrls' option.
   lazy val extUrlPackageMapping: Map[String, String] = (Map.empty[String, String] /: docExternalUrls.value) {


### PR DESCRIPTION
Don't add trailing slash to external doc URL if it already ends with
one.
