### PR TITLE
[nomaster] unbreaks test.bc

### DIFF
--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -287,6 +287,9 @@ private[reflect] trait JavaMirrors extends internal.SymbolTable with api.JavaUni
         // if (!symbol.isMutable) ErrorSetImmutableField(symbol)
         jfield.set(receiver, value)
       }
+      // this dummy method is necessary to prevent the optimizer from stripping off ErrorSetImmutableField
+      // which would break binary compatibility with 2.10.0
+      private def dummy(symbol: Symbol) = ErrorSetImmutableField(symbol)
       override def toString = s"field mirror for ${symbol.fullName} (bound to $receiver)"
     }
 


### PR DESCRIPTION
The optimizer behaves unexpectedly smartly, stripping off unused private
methods. Unfortunately, sometimes private methods might be compiled down
to public Java methods, so stripping them off might lead to binary
incompatibilities.

This particular commit recovers from this problem caused by
https://github.com/scala/scala/commit/5e715396af.
