### PR TITLE
SI-7492 Remove -Ystruct-dispatch and associated code

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -163,8 +163,6 @@ trait ScalaSettings extends AbsScalaSettings
   val Ystatistics     = BooleanSetting    ("-Ystatistics", "Print compiler statistics.") andThen (scala.reflect.internal.util.Statistics.enabled = _)
   val stopAfter       = PhasesSetting     ("-Ystop-after", "Stop after") withAbbreviation ("-stop") // backward compat
   val stopBefore      = PhasesSetting     ("-Ystop-before", "Stop before")
-  val refinementMethodDispatch
-                      = ChoiceSetting     ("-Ystruct-dispatch", "policy", "structural method dispatch policy", List("no-cache", "mono-cache", "poly-cache", "invoke-dynamic"), "poly-cache")
   val Yrangepos       = BooleanSetting    ("-Yrangepos", "Use range positions for syntax trees.")
   val Ymemberpos      = StringSetting     ("-Yshow-member-pos", "output style", "Show start and end positions of members", "") withPostSetHook (_ => Yrangepos.value = true)
   val Yreifycopypaste = BooleanSetting    ("-Yreify-copypaste", "Dump the reified trees in copypasteable representation.")

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5094,10 +5094,9 @@ trait Typers extends Adaptations with Tags {
 
       def typedApplyDynamic(tree: ApplyDynamic) = {
         assert(phase.erasedTypes)
-        val reflectiveCalls = !(settings.refinementMethodDispatch.value == "invoke-dynamic")
         val qual1 = typed(tree.qual, AnyRefClass.tpe)
-        val args1 = tree.args mapConserve (arg => if (reflectiveCalls) typed(arg, AnyRefClass.tpe) else typed(arg))
-        treeCopy.ApplyDynamic(tree, qual1, args1) setType (if (reflectiveCalls) AnyRefClass.tpe else tree.symbol.info.resultType)
+        val args1 = tree.args mapConserve (arg => typed(arg, AnyRefClass.tpe))
+        treeCopy.ApplyDynamic(tree, qual1, args1) setType AnyRefClass.tpe
       }
 
       def typedReferenceToBoxed(tree: ReferenceToBoxed) = {


### PR DESCRIPTION
This means that the private option is gone as well as the untested
code for no-cache and mono-cache and the non-working code for
invoke-dynamic.

poly-cache is now always used. For the future it probably makes more
sense to let the backend decide how it wants to treat structural
dispatch instead of allowing the user to “mix and match” backends
with structural dispatch implementations.
