### PR TITLE
SI-7474 Parallel collections: End the exception handling madness

### DIFF
--- a/src/library/scala/collection/parallel/Tasks.scala
+++ b/src/library/scala/collection/parallel/Tasks.scala
@@ -72,11 +72,13 @@ trait Task[R, +Tp] {
   }
 
   private[parallel] def mergeThrowables(that: Task[_, _]) {
-    if (this.throwable != null && that.throwable != null) {
-      // merge exceptions, since there were multiple exceptions
-      this.throwable = this.throwable alongWith that.throwable
-    } else if (that.throwable != null) this.throwable = that.throwable
-      else this.throwable = this.throwable
+    // TODO: As soon as we target Java >= 7, use Throwable#addSuppressed
+    // to pass additional Throwables to the caller, e. g.
+    // if (this.throwable != null && that.throwable != null)
+    //   this.throwable.addSuppressed(that.throwable)
+    // For now, we just use whatever Throwable comes across “first”.
+    if (this.throwable == null && that.throwable != null)
+      this.throwable = that.throwable
   }
 
   // override in concrete task implementations to signal abort to other tasks

--- a/src/library/scala/collection/parallel/package.scala
+++ b/src/library/scala/collection/parallel/package.scala
@@ -114,7 +114,9 @@ package parallel {
     def toParArray: ParArray[T]
   }
 
+  @deprecated("This trait will be removed.", "2.11.0")
   trait ThrowableOps {
+    @deprecated("This method will be removed.", "2.11.0")
     def alongWith(that: Throwable): Throwable
   }
 
@@ -133,9 +135,8 @@ package parallel {
   }
 
   /** Composite throwable - thrown when multiple exceptions are thrown at the same time. */
-  final case class CompositeThrowable(
-                                       throwables: Set[Throwable]
-  ) extends Exception(
+  @deprecated("This class will be removed.", "2.11.0")
+  final case class CompositeThrowable(throwables: Set[Throwable]) extends Exception(
     "Multiple exceptions thrown during a parallel computation: " +
       throwables.map(t => t + "\n" + t.getStackTrace.take(10).++("...").mkString("\n")).mkString("\n\n")
   )

--- a/test/files/run/t5375.check
+++ b/test/files/run/t5375.check
@@ -1,1 +1,1 @@
-Composite throwable
+Runtime exception

--- a/test/files/run/t5375.scala
+++ b/test/files/run/t5375.scala
@@ -1,19 +1,8 @@
-
-
-
-import collection.parallel.CompositeThrowable
-
-
-
-object Test {
-  
-  def main(args: Array[String]) {
-    val foos = (1 to 1000).toSeq
-    try {
-      foos.par.map(i => if (i % 37 == 0) sys.error("i div 37") else i)
-    } catch {
-      case CompositeThrowable(thr) => println("Composite throwable")
-    }
+object Test extends App {
+  val foos = (1 to 1000).toSeq
+  try
+    foos.par.map(i => if (i % 37 == 0) sys.error("i div 37") else i)
+  catch {
+    case ex: RuntimeException => println("Runtime exception")
   }
-  
 }


### PR DESCRIPTION
"What's wrong with an API which non-deterministically returns either
type A or type B(Set(A, ...))?"

This is pretty much what the exception handling behavior of the
parallel collections does: If exceptions of type A occur, either an
exception of type A or an exception of type B, wrapping multiple
exceptions of A's, are returned.

This behavior is incredibly broken and so unintuitive, that even
people writing tests don't handle it correctly.
See files/run/t5375.scala.

Concerning “non-deterministic”:
How many exceptions are observed before the operation is aborted
depends on the machine, the available cores and hyper-threading,
the operating system, the threadpool implementation and
configuration, the size of the collection and the runtime itself.

In fact, files/run/t5375.scala is failing on both jdk7u and Avian
because of this issue.

With this change, we just pass the "first" exception which occurs.
This seems to be what C# and Java both do, too.

“Why don't we wrap everything in CompositeThrowables?”
Even consistently returning CompositeThrowable doesn't make much
sense (because we have fail-fast behaviour and don't wait until
all tasks have finished or have thrown an exception).
Therefore, there is no useful semantic in having a
CompositeThrowable which returns "some" exceptions.

Either
a) gather and return all the exceptions or
b) just return one, instead of wrapping a non-deterministic
   number of exceptions into a completely unrelated wrapper type.

Considering that changing the parallel collection semantics in
such a profound way as described in a) is out of question, the
second option is chosen.

As soon as Scala targets Java > 7 Throwable#addSurpressed can be
used to add further exceptions to the one which gets returned.
