### PR TITLE
An attempt to make tests deterministic.

### DIFF
--- a/src/interactive/scala/tools/nsc/interactive/CompilerControl.scala
+++ b/src/interactive/scala/tools/nsc/interactive/CompilerControl.scala
@@ -297,6 +297,11 @@ trait CompilerControl { self: Global =>
     def implicitlyAdded = false
 
     private def accessible_s = if (accessible) "" else "[inaccessible] "
+    def forceInfoString = {
+      definitions.fullyInitializeSymbol(sym)
+      definitions.fullyInitializeType(tpe)
+      infoString
+    }
     def infoString = s"$accessible_s${sym.defStringSeenAs(tpe)}"
   }
 

--- a/src/interactive/scala/tools/nsc/interactive/tests/core/CoreTestDefs.scala
+++ b/src/interactive/scala/tools/nsc/interactive/tests/core/CoreTestDefs.scala
@@ -27,7 +27,7 @@ private[tests] trait CoreTestDefs
           reporter.println("retrieved %d members".format(members.size))
           compiler ask { () =>
             val filtered = members.filterNot(member => (member.sym.name string_== "getClass") || member.sym.isConstructor)
-            reporter println (filtered.map(_.infoString).sorted mkString "\n")
+            reporter println (filtered.map(_.forceInfoString).sorted mkString "\n")
           }
         }
       }

--- a/test/files/presentation/ide-bug-1000531.check
+++ b/test/files/presentation/ide-bug-1000531.check
@@ -7,7 +7,7 @@ retrieved 124 members
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit
 [inaccessible] protected[this] def reversed: List[B]
-class GroupedIterator[B <: <?>] extends AbstractIterator[Seq[B]] with Iterator[Seq[B]]
+class GroupedIterator[B >: A] extends AbstractIterator[Seq[B]] with Iterator[Seq[B]]
 def +(other: String): String
 def ++[B >: B](that: => scala.collection.GenTraversableOnce[B]): Iterator[B]
 def ->[B](y: B): (java.util.Iterator[B], B)

--- a/test/files/presentation/implicit-member.check
+++ b/test/files/presentation/implicit-member.check
@@ -15,7 +15,7 @@ def formatted(fmtstr: String): String
 def hashCode(): Int
 def toString(): String
 def →[B](y: B): (Implicit.type, B)
-final class AppliedImplicit[A <: <?>] extends AnyRef
+final class AppliedImplicit[A] extends AnyRef
 final def !=(x$1: Any): Boolean
 final def !=(x$1: AnyRef): Boolean
 final def ##(): Int


### PR DESCRIPTION
The nondeterminism presently showing itself in presentation/implicit-member is
a consequence of the presentation compiler tests relying on details of the
behavior of toString calls. We need to stomp this out, but it will take a
while. Based on the check file changes enclosed with this commit, this will
suffice for the presentation compiler tests. A broader assault will have to
take place, but not yet.
