### PR TITLE
Moves AbstractFileClassLoader to scala-reflect.jar

### DIFF
--- a/src/compiler/scala/tools/nsc/util/package.scala
+++ b/src/compiler/scala/tools/nsc/util/package.scala
@@ -133,4 +133,13 @@ package object util {
 
   @deprecated("Moved to scala.reflect.internal.util.BatchSourceFile", "2.10.0")
   type BatchSourceFile = scala.reflect.internal.util.BatchSourceFile
+
+  @deprecated("Moved to scala.reflect.internal.util.AbstractFileClassLoader", "2.11.0")
+  type AbstractFileClassLoader = scala.reflect.internal.util.AbstractFileClassLoader
+
+  @deprecated("Moved to scala.reflect.internal.util.ScalaClassLoader", "2.11.0")
+  val ScalaClassLoader = scala.reflect.internal.util.ScalaClassLoader
+
+  @deprecated("Moved to scala.reflect.internal.util.ScalaClassLoader", "2.11.0")
+  type ScalaClassLoader = scala.reflect.internal.util.ScalaClassLoader
 }

--- a/src/reflect/scala/reflect/internal/util/AbstractFileClassLoader.scala
+++ b/src/reflect/scala/reflect/internal/util/AbstractFileClassLoader.scala
@@ -2,10 +2,10 @@
  * Copyright 2005-2013 LAMP/EPFL
  */
 
-package scala.tools.nsc
-package util
+package scala
+package reflect.internal.util
 
-import scala.tools.nsc.io.AbstractFile
+import scala.reflect.io.AbstractFile
 import java.security.cert.Certificate
 import java.security.{ ProtectionDomain, CodeSource }
 import java.net.{ URL, URLConnection, URLStreamHandler }

--- a/src/reflect/scala/reflect/internal/util/ScalaClassLoader.scala
+++ b/src/reflect/scala/reflect/internal/util/ScalaClassLoader.scala
@@ -3,8 +3,8 @@
  * @author  Paul Phillips
  */
 
-package scala.tools.nsc
-package util
+package scala
+package reflect.internal.util
 
 import java.lang.{ ClassLoader => JClassLoader }
 import java.lang.reflect.{ Constructor, Modifier, Method }
@@ -49,7 +49,7 @@ trait ScalaClassLoader extends JClassLoader {
   /** The actual bytes for a class file, or an empty array if it can't be found. */
   def classBytes(className: String): Array[Byte] = classAsStream(className) match {
     case null   => Array()
-    case stream => io.Streamable.bytes(stream)
+    case stream => scala.reflect.io.Streamable.bytes(stream)
   }
 
   /** An InputStream representing the given class name, or null if not found. */

--- a/src/reflect/scala/reflect/runtime/ReflectionUtils.scala
+++ b/src/reflect/scala/reflect/runtime/ReflectionUtils.scala
@@ -8,6 +8,7 @@ package reflect.runtime
 
 import java.lang.{Class => jClass}
 import java.lang.reflect.{ Method, InvocationTargetException, UndeclaredThrowableException }
+import scala.reflect.internal.util.AbstractFileClassLoader
 
 /** A few java-reflection oriented utility functions useful during reflection bootstrapping.
  */
@@ -34,7 +35,7 @@ private[scala] object ReflectionUtils {
 
     def isAbstractFileClassLoader(clazz: Class[_]): Boolean = {
       if (clazz == null) return false
-      if (clazz.getName == "scala.tools.nsc.interpreter.AbstractFileClassLoader") return true
+      if (clazz == classOf[AbstractFileClassLoader]) return true
       isAbstractFileClassLoader(clazz.getSuperclass)
     }
     def inferClasspath(cl: ClassLoader): String = cl match {


### PR DESCRIPTION
Its string name was used in ReflectionUtils and became broken after repl
got factored out. This hints that that classloader belongs to where it is
used, i.e. to scala-reflect.jar.

Moreover AbstractFile is defined in scala-reflect.jar, so it's only
logical to also define a derived classloader in scala-reflect.jar.
