### PR TITLE
SI-7391 Always use ForkJoin in Scala actors on ...

### DIFF
--- a/src/actors/scala/actors/scheduler/ThreadPoolConfig.scala
+++ b/src/actors/scala/actors/scheduler/ThreadPoolConfig.scala
@@ -39,14 +39,7 @@ private[actors] object ThreadPoolConfig {
 
   private[actors] def useForkJoin: Boolean =
     try !propIsSetTo("actors.enableForkJoin", "false") &&
-      (propIsSetTo("actors.enableForkJoin", "true") || {
-        Debug.info(this+": java.version = "+javaVersion)
-        Debug.info(this+": java.vm.vendor = "+javaVmVendor)
-
-        // on IBM J9 1.6 do not use ForkJoinPool
-        // XXX this all needs to go into Properties.
-        isJavaAtLeast("1.6") && ((javaVmVendor contains "Oracle") || (javaVmVendor contains "Sun") || (javaVmVendor contains "Apple"))
-      })
+      (propIsSetTo("actors.enableForkJoin", "true") || isJavaAtLeast("1.6"))
     catch {
       case _: SecurityException => false
     }


### PR DESCRIPTION
... Java 6 and above (except when the porperty
actors.enableForkJoin says otherwise)

Like SI-7236 and SI-7237, the logic in
scala.actors.scheduler.ThreadPoolConfig.useForkJoin
(which resulted in a different thread pool implementation
being chosen) was causing random hangs in the test
concurrent-stream.scala when running on Avian.
