### PR TITLE
Harden partest against duplicate paths.

### DIFF
--- a/src/reflect/scala/reflect/internal/util/Collections.scala
+++ b/src/reflect/scala/reflect/internal/util/Collections.scala
@@ -209,3 +209,5 @@ trait Collections {
     case _: IllegalArgumentException => None
   }
 }
+
+object Collections extends Collections


### PR DESCRIPTION
A serious issue: partest would launch the same test multiple times if a test
path was given in multiple forms (e.g. absolute and relative paths.)
Unfortunately all those tests would share the same logfile, output directory,
etc. which would predictably lead to explosions.

Since overwriting classfiles while being loaded can lead to jvm core dumps,
it's possible this is involved in recent jvm crashes and other test
breakdowns.

This commit also alters the default partest verbosity to only full print test
transcripts under --verbose.
