### PR TITLE
SI-7436 Varargs awareness for super param aliasing.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2051,7 +2051,7 @@ trait Typers extends Modes with Adaptations with Tags {
                 orElse (superAcc getter superAcc.owner)
                 filter (alias => superClazz.info.nonPrivateMember(alias.name) == alias)
             )
-            if (alias.exists && !alias.accessed.isVariable) {
+            if (alias.exists && !alias.accessed.isVariable && !isRepeatedParamType(alias.accessed.info)) {
               val ownAcc = clazz.info decl name suchThat (_.isParamAccessor) match {
                 case acc if !acc.isDeferred && acc.hasAccessorFlag => acc.accessed
                 case acc                                           => acc

--- a/test/files/run/t7436.scala
+++ b/test/files/run/t7436.scala
@@ -1,0 +1,9 @@
+class A(val p: Int*)
+
+class B(val p1: Int) extends A(p1)
+
+object Test {
+  def main(args: Array[String]) {
+    new B(1).p1 // threw java.lang.ClassCastException: scala.collection.mutable.WrappedArray$ofInt cannot be cast to java.lang.Integer
+  }
+}


### PR DESCRIPTION
Don't consider a super class parameter accessor to be
an alias if it is a repeated. Parameter aliases are used
to avoid retaining redundant fields in the subclass; but
that optimization is out of the question here.

Review by @paulp
