### PR TITLE
SI-6138 Centralize and refine detection of `getClass` calls

### DIFF
--- a/bincompat-backward.whitelist.conf
+++ b/bincompat-backward.whitelist.conf
@@ -219,6 +219,14 @@ filter {
         {
             matchName="scala.concurrent.forkjoin.ForkJoinPool.helpJoinOnce"
             problemName=IncompatibleResultTypeProblem
+        },
+        {
+            matchName="scala.reflect.internal.Definitions#DefinitionsClass.getClassMethods"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.Definitions#DefinitionsClass.primitiveGetClassMethods"
+            problemName=MissingMethodProblem
         }
     ]
 }

--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -471,6 +471,14 @@ filter {
         {
              matchName="scala.concurrent.impl.Promise$CompletionLatch"
              problemName=MissingClassProblem
+        },
+        {
+            matchName="scala.reflect.internal.Definitions#DefinitionsClass.getClassMethods"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.Definitions#DefinitionsClass.primitiveGetClassMethods"
+            problemName=MissingMethodProblem
         }
     ]
 }

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -341,11 +341,6 @@ abstract class Erasure extends AddInterfaces
     }
   }
   
-  // Each primitive value class has its own getClass for ultra-precise class object typing.
-  private lazy val primitiveGetClassMethods = Set[Symbol](Any_getClass, AnyVal_getClass) ++ (
-    ScalaValueClasses map (_.tpe member nme.getClass_)
-  )
-  
   // ## requires a little translation
   private lazy val poundPoundMethods = Set[Symbol](Any_##, Object_##)
   

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -656,8 +656,7 @@ trait Typers extends Modes with Adaptations with Tags {
         // To fully benefit from special casing the return type of
         // getClass, we have to catch it immediately so expressions
         // like x.getClass().newInstance() are typed with the type of x.
-        else if (  tree.symbol.name == nme.getClass_
-                && tree.tpe.params.isEmpty
+        else if (  isGetClass(tree.symbol)
                 // TODO: If the type of the qualifier is inaccessible, we can cause private types
                 // to escape scope here, e.g. pos/t1107.  I'm not sure how to properly handle this
                 // so for now it requires the type symbol be public.

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -110,8 +110,10 @@ trait Definitions extends api.StandardDefinitions {
     /** Is symbol a numeric value class? */
     def isNumericValueClass(sym: Symbol) = ScalaNumericValueClasses contains sym
 
-    def isGetClass(sym: Symbol) =
-      (sym.name == nme.getClass_) && flattensToEmpty(sym.paramss)
+    def isGetClass(sym: Symbol) = (
+         sym.name == nme.getClass_ // this condition is for performance only, this is called from `Typer#stabliize`.
+      && getClassMethods(sym)
+    )
 
     lazy val UnitClass    = valueClassSymbol(tpnme.Unit)
     lazy val ByteClass    = valueClassSymbol(tpnme.Byte)
@@ -804,6 +806,12 @@ trait Definitions extends api.StandardDefinitions {
     lazy val Any_getClass     = enterNewMethod(AnyClass, nme.getClass_, Nil, getMemberMethod(ObjectClass, nme.getClass_).tpe.resultType, DEFERRED)
     lazy val Any_isInstanceOf = newT1NullaryMethod(AnyClass, nme.isInstanceOf_, FINAL)(_ => booltype)
     lazy val Any_asInstanceOf = newT1NullaryMethod(AnyClass, nme.asInstanceOf_, FINAL)(_.typeConstructor)
+
+    lazy val primitiveGetClassMethods = Set[Symbol](Any_getClass, AnyVal_getClass) ++ (
+      ScalaValueClasses map (_.tpe member nme.getClass_)
+    )
+
+    lazy val getClassMethods: Set[Symbol] = primitiveGetClassMethods + Object_getClass
 
   // A type function from T => Class[U], used to determine the return
     // type of getClass calls.  The returned type is:

--- a/test/files/neg/t6138.check
+++ b/test/files/neg/t6138.check
@@ -1,0 +1,7 @@
+t6138.scala:4: error: ambiguous reference to overloaded definition,
+both method getClass in object definitions of type (s: Int)Any
+and  method getClass in object definitions of type (s: String)Any
+match argument types (Nothing)
+  getClass(???): String
+  ^
+one error found

--- a/test/files/neg/t6138.scala
+++ b/test/files/neg/t6138.scala
@@ -1,0 +1,5 @@
+object definitions {
+  def getClass(s: String): Any = ???
+  def getClass(s: Int): Any = ???
+  getClass(???): String
+}


### PR DESCRIPTION
`getClass` is special cased in the compiler; this is described
in in the comments on `Definitions.Any_getClass`.

Part of this happens in `Typer#stabilize`. This was trying to determine
if an Ident or Select node was a call to `getClass` by merits of the name
of the tree's symbol and by checking that the its type (if it was a
MethodType or PolyType) had no parameters in the primary parameter list.

Overloaded user defined `getClass` methods confused this check. In the
enclosed test case, the tree `definitions.this.getClass` had an
`OverloadedType`, and such types always report an empty list of `params`.

This commit:
- changes `stabilize` to use `isGetClass`, rather than the
  homebrew check
- changes `isGetClass` to consider a `Set[Symbol]` containing all
  `getClass` variants. This moves some similar code from `Erasure`
  to `Definitions`
- keeps a fast negative path in `isGetClass` based on the symbol's name

Review by @adriaanm
