### PR TITLE
SI-7473 Bad for expr crashes postfix

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1474,8 +1474,9 @@ self =>
      *  }}}
      */
     def postfixExpr(): Tree = {
-      val base = opstack
-      var top = prefixExpr()
+      val start = in.offset
+      val base  = opstack
+      var top   = prefixExpr()
 
       while (isIdent) {
         top = reduceStack(isExpr = true, base, top, precedence(in.name), leftAssoc = treeInfo.isLeftAssoc(in.name))
@@ -1493,9 +1494,7 @@ self =>
           val topinfo = opstack.head
           opstack = opstack.tail
           val od = stripParens(reduceStack(isExpr = true, base, topinfo.operand, 0, leftAssoc = true))
-          return atPos(od.pos.startOrPoint, topinfo.offset) {
-            new PostfixSelect(od, topinfo.operator.encode)
-          }
+          return makePostfixSelect(start, topinfo.offset, od, topinfo.operator)
         }
       }
       reduceStack(isExpr = true, base, top, 0, leftAssoc = true)

--- a/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
@@ -245,6 +245,12 @@ abstract class TreeBuilder {
       Assign(lhs, rhs)
   }
 
+  /** Tree for `od op`, start is start0 if od.pos is borked. */
+  def makePostfixSelect(start0: Int, end: Int, od: Tree, op: Name): Tree = {
+    val start = if (od.pos.isDefined) od.pos.startOrPoint else start0
+    atPos(r2p(start, end, end)) { new PostfixSelect(od, op.encode) }
+  }
+
   /** A type tree corresponding to (possibly unary) intersection type */
   def makeIntersectionTypeTree(tps: List[Tree]): Tree =
     if (tps.tail.isEmpty) tps.head

--- a/test/files/neg/t7473.check
+++ b/test/files/neg/t7473.check
@@ -1,0 +1,7 @@
+t7473.scala:6: error: '<-' expected but '=' found.
+  (for (x = Option(i); if x == j) yield 42) toList
+          ^
+t7473.scala:6: error: illegal start of simple expression
+  (for (x = Option(i); if x == j) yield 42) toList
+                     ^
+two errors found

--- a/test/files/neg/t7473.scala
+++ b/test/files/neg/t7473.scala
@@ -1,0 +1,7 @@
+
+object Foo {
+  val i,j = 3
+  //for (x = Option(i); if x == j) yield 42  //t7473.scala:4: error: '<-' expected but '=' found.
+  // evil postfix!
+  (for (x = Option(i); if x == j) yield 42) toList
+}


### PR DESCRIPTION
This commit makes building PostfixSelect robust against a bad pos
on its operand, which can happen if a bad for expression results
in an EmptyTree.

Review by @paulp for his recent fix for munged while.
