### PR TITLE
SI-7410 REPL uses improved tools.jar locator

### DIFF
--- a/src/compiler/scala/tools/reflect/WrappedProperties.scala
+++ b/src/compiler/scala/tools/reflect/WrappedProperties.scala
@@ -25,6 +25,7 @@ trait WrappedProperties extends PropertiesTrait {
   override def clearProp(name: String)               = wrap(super.clearProp(name)).orNull
   override def envOrElse(name: String, alt: String)  = wrap(super.envOrElse(name, alt)) getOrElse alt
   override def envOrNone(name: String)               = wrap(super.envOrNone(name)).flatten
+  override def envOrSome(name: String, alt: Option[String]) = wrap(super.envOrNone(name)).flatten orElse alt
 
   def systemProperties: Iterator[(String, String)] = {
     import scala.collection.JavaConverters._

--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -10,23 +10,38 @@ package util
 import scala.tools.reflect.WrappedProperties.AccessControl
 import scala.tools.nsc.{ Settings, GenericRunnerSettings }
 import scala.tools.nsc.util.{ ClassPath, JavaClassPath, ScalaClassLoader }
-import scala.tools.nsc.io.{ File, Directory, Path, AbstractFile }
+import scala.reflect.io.{ File, Directory, Path, AbstractFile }
 import ClassPath.{ JavaContext, DefaultJavaContext, join, split }
 import PartialFunction.condOpt
 import scala.language.postfixOps
 
 // Loosely based on the draft specification at:
-// https://wiki.scala-lang.org/display/SW/Classpath
+// https://wiki.scala-lang.org/display/SIW/Classpath
 
 object PathResolver {
   // Imports property/environment functions which suppress security exceptions.
   import AccessControl._
+  import scala.compat.Platform.EOL
+
+  implicit class MkLines(val t: TraversableOnce[_]) extends AnyVal {
+    def mkLines: String = t.mkString("", EOL, EOL)
+    def mkLines(header: String, indented: Boolean = false, embraced: Boolean = false): String = {
+      val space = "\u0020"
+      val sep = if (indented) EOL + space * 2 else EOL
+      val (lbrace, rbrace) = if (embraced) (space + "{", EOL + "}") else ("", "")
+      t.mkString(header + lbrace + sep, sep, rbrace + EOL)
+    }
+  }
+  implicit class AsLines(val s: String) extends AnyVal {
+    // sm"""...""" could do this in one pass
+    def asLines = s.trim.stripMargin.lines.mkLines
+  }
 
   /** pretty print class path */
   def ppcp(s: String) = split(s) match {
     case Nil      => ""
     case Seq(x)   => x
-    case xs       => xs map ("\n" + _) mkString
+    case xs       => xs.mkString(EOL, EOL, "")
   }
 
   /** Values found solely by inspecting environment or property variables.
@@ -50,20 +65,14 @@ object PathResolver {
     def javaUserClassPath   = propOrElse("java.class.path", "")
     def useJavaClassPath    = propOrFalse("scala.usejavacp")
 
-    override def toString = """
+    override def toString = s"""
       |object Environment {
-      |  scalaHome          = %s (useJavaClassPath = %s)
-      |  javaBootClassPath  = <%d chars>
-      |  javaExtDirs        = %s
-      |  javaUserClassPath  = %s
-      |  scalaExtDirs       = %s
-      |}""".trim.stripMargin.format(
-        scalaHome, useJavaClassPath,
-        javaBootClassPath.length,
-        ppcp(javaExtDirs),
-        ppcp(javaUserClassPath),
-        ppcp(scalaExtDirs)
-      )
+      |  scalaHome          = $scalaHome (useJavaClassPath = $useJavaClassPath)
+      |  javaBootClassPath  = <${javaBootClassPath.length} chars>
+      |  javaExtDirs        = ${ppcp(javaExtDirs)}
+      |  javaUserClassPath  = ${ppcp(javaUserClassPath)}
+      |  scalaExtDirs       = ${ppcp(scalaExtDirs)}
+      |}""".asLines
   }
 
   /** Default values based on those in Environment as interpreted according
@@ -103,20 +112,15 @@ object PathResolver {
     def scalaExtDirs = Environment.scalaExtDirs
     def scalaPluginPath = (scalaHomeDir / "misc" / "scala-devel" / "plugins").path
 
-    override def toString = """
+    override def toString = s"""
       |object Defaults {
-      |  scalaHome            = %s
-      |  javaBootClassPath    = %s
-      |  scalaLibDirFound     = %s
-      |  scalaLibFound        = %s
-      |  scalaBootClassPath   = %s
-      |  scalaPluginPath      = %s
-      |}""".trim.stripMargin.format(
-        scalaHome,
-        ppcp(javaBootClassPath),
-        scalaLibDirFound, scalaLibFound,
-        ppcp(scalaBootClassPath), ppcp(scalaPluginPath)
-      )
+      |  scalaHome            = $scalaHome
+      |  javaBootClassPath    = ${ppcp(javaBootClassPath)}
+      |  scalaLibDirFound     = $scalaLibDirFound
+      |  scalaLibFound        = $scalaLibFound
+      |  scalaBootClassPath   = ${ppcp(scalaBootClassPath)}
+      |  scalaPluginPath      = ${ppcp(scalaPluginPath)}
+      |}""".asLines
   }
 
   /** Locations discovered by supplemental heuristics.
@@ -153,17 +157,14 @@ object PathResolver {
       (home flatMap jarAt) orElse (install flatMap jarAt) orElse (install map (_.parent) flatMap jarAt) orElse
         (jdkDir flatMap deeply)
     }
-    private def vals = List(
-      s"platformTools        = $platformTools"
-    )
-    override def toString = vals mkString (
-      f"object SupplementalLocations {%n  ",
-      f"%n  ",
-      f"%n}"
-    )
+    override def toString = s"""
+      |object SupplementalLocations {
+      |  platformTools        = $platformTools
+      |}""".asLines
   }
 
-  def fromPathString(path: String, context: JavaContext = DefaultJavaContext): JavaClassPath = { // called from scalap
+  // called from scalap
+  def fromPathString(path: String, context: JavaContext = DefaultJavaContext): JavaClassPath = {
     val s = new Settings()
     s.classpath.value = path
     new PathResolver(s, context) result
@@ -188,9 +189,10 @@ object PathResolver {
     }
   }
 }
-import PathResolver.{ Defaults, Environment, ppcp }
 
 class PathResolver(settings: Settings, context: JavaContext) {
+  import PathResolver.{ Defaults, Environment, AsLines, MkLines, ppcp }
+
   def this(settings: Settings) = this(settings, if (settings.inline) new JavaContext else DefaultJavaContext)
 
   private def cmdLineOrElse(name: String, alt: String) = {
@@ -261,24 +263,18 @@ class PathResolver(settings: Settings, context: JavaContext) {
 
     lazy val containers = basis.flatten.distinct
 
-    override def toString = """
+    override def toString = s"""
       |object Calculated {
-      |  scalaHome            = %s
-      |  javaBootClassPath    = %s
-      |  javaExtDirs          = %s
-      |  javaUserClassPath    = %s
-      |    useJavaClassPath   = %s
-      |  scalaBootClassPath   = %s
-      |  scalaExtDirs         = %s
-      |  userClassPath        = %s
-      |  sourcePath           = %s
-      |}""".trim.stripMargin.format(
-        scalaHome,
-        ppcp(javaBootClassPath), ppcp(javaExtDirs), ppcp(javaUserClassPath),
-        useJavaClassPath,
-        ppcp(scalaBootClassPath), ppcp(scalaExtDirs), ppcp(userClassPath),
-        ppcp(sourcePath)
-      )
+      |  scalaHome            = $scalaHome
+      |  javaBootClassPath    = ${ppcp(javaBootClassPath)}
+      |  javaExtDirs          = ${ppcp(javaExtDirs)}
+      |  javaUserClassPath    = ${ppcp(javaUserClassPath)}
+      |    useJavaClassPath   = $useJavaClassPath
+      |  scalaBootClassPath   = ${ppcp(scalaBootClassPath)}
+      |  scalaExtDirs         = ${ppcp(scalaExtDirs)}
+      |  userClassPath        = ${ppcp(userClassPath)}
+      |  sourcePath           = ${ppcp(sourcePath)}
+      |}""".asLines
   }
 
   def containers = Calculated.containers
@@ -286,13 +282,12 @@ class PathResolver(settings: Settings, context: JavaContext) {
   lazy val result = {
     val cp = new JavaClassPath(containers.toIndexedSeq, context)
     if (settings.Ylogcp) {
-      Console.println("Classpath built from " + settings.toConciseString)
-      Console.println("Defaults: " + PathResolver.Defaults)
-      Console.println("Calculated: " + Calculated)
+      Console print f"Classpath built from ${settings.toConciseString} %n"
+      Console print s"Defaults: ${PathResolver.Defaults}"
+      Console print s"Calculated: $Calculated"
 
       val xs = (Calculated.basis drop 2).flatten.distinct
-      println("After java boot/extdirs classpath has %d entries:" format xs.size)
-      xs foreach (x => println("  " + x))
+      Console print (xs mkLines (s"After java boot/extdirs classpath has ${xs.size} entries:", indented = true))
     }
     cp
   }

--- a/src/library/scala/util/Properties.scala
+++ b/src/library/scala/util/Properties.scala
@@ -60,6 +60,8 @@ private[scala] trait PropertiesTrait {
   def envOrElse(name: String, alt: String)      = Option(System getenv name) getOrElse alt
   def envOrNone(name: String)                   = Option(System getenv name)
 
+  def envOrSome(name: String, alt: Option[String])       = envOrNone(name) orElse alt
+
   // for values based on propFilename
   def scalaPropOrElse(name: String, alt: String): String = scalaProps.getProperty(name, alt)
   def scalaPropOrEmpty(name: String): String             = scalaPropOrElse(name, "")

--- a/src/partest/scala/tools/partest/nest/PathSettings.scala
+++ b/src/partest/scala/tools/partest/nest/PathSettings.scala
@@ -5,10 +5,8 @@
 package scala.tools.partest
 package nest
 
-import scala.tools.nsc.Properties.{ setProp, propOrEmpty, propOrNone, propOrElse }
 import scala.tools.nsc.util.ClassPath
 import scala.tools.nsc.io.{ Path, File, Directory }
-import scala.util.Properties.{ envOrElse, envOrNone, javaHome, jdkHome }
 import Path._
 
 object PathSettings {
@@ -80,34 +78,9 @@ object PathSettings {
   lazy val diffUtils: File =
     findJar(buildPackLibDir.files, "diffutils") getOrElse sys.error(s"No diffutils.jar found in '$buildPackLibDir'.")
 
-  /** The platform-specific support jar.
-   *  Usually this is tools.jar in the jdk/lib directory of the platform distribution.
-   *  The file location is determined by probing the lib directory under JDK_HOME or JAVA_HOME,
-   *  if one of those environment variables is set, then the lib directory under java.home,
-   *  and finally the lib directory under the parent of java.home. Or, as a last resort,
-   *  search deeply under those locations (except for the parent of java.home, on the notion
-   *  that if this is not a canonical installation, then that search would have little
-   *  chance of succeeding).
+  /** The platform-specific support jar, `tools.jar`.
    */
-  lazy val platformTools: Option[File] = {
-    val jarName = "tools.jar"
-    def jarPath(path: Path) = (path / "lib" / jarName).toFile
-    def jarAt(path: Path) = {
-      val f = jarPath(path)
-      if (f.isFile) Some(f) else None
-    }
-    val jdkDir = {
-      val d = Directory(jdkHome)
-      if (d.isDirectory) Some(d) else None
-    }
-    def deeply(dir: Directory) = dir.deepFiles find (_.name == jarName)
-
-    val home    = envOrNone("JDK_HOME") orElse envOrNone("JAVA_HOME") map (p => Path(p))
-    val install = Some(Path(javaHome))
-
-    (home flatMap jarAt) orElse (install flatMap jarAt) orElse (install map (_.parent) flatMap jarAt) orElse
-      (jdkDir flatMap deeply)
-  }
+  lazy val platformTools: Option[File] = PathResolver.SupplementalLocations.platformTools
 }
 
 class PathSettings() {

--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -255,16 +255,8 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     }
   }
 
-  private def findToolsJar() = {
-    val jdkPath = Directory(jdkHome)
-    val jar     = jdkPath / "lib" / "tools.jar" toFile
+  private def findToolsJar() = PathResolver.SupplementalLocations.platformTools
 
-    if (jar isFile)
-      Some(jar)
-    else if (jdkPath.isDirectory)
-      jdkPath.deepFiles find (_.name == "tools.jar")
-    else None
-  }
   private def addToolsJarToLoader() = {
     val cl = findToolsJar() match {
       case Some(tools) => ScalaClassLoader.fromURLs(Seq(tools.toURL), intp.classLoader)


### PR DESCRIPTION
SI-7410 REPL uses improved tools.jar locator

The logic in partest for snooping around for tools.jar
is moved to PathResolver, and ILoop uses it from there.

If JAVA_HOME is toolless, check out java.home.

The use case was that Ubuntu installed with `java` at
version 6 and `javac` at version 7; it's easy to wind
up with JAVA_HOME pointing at the version 6 JRE, as
I discovered.  It's confusing when that happens.

I hate to say it, but several months ago @paulp asked me to refactor this out of repl to a place partest could use it, then partest got the cadillac, so this ports it back to repl if @paulp reviews it and thinks it's worthwhile.

Also, @paulp is most likely to dislike or have a better suggestion for the second commit, for legibility of debug strings, which is something one needs and uses all the time.
