### PR TITLE
[backport] SI-7497 Use `osName startsWith "Mac OS X"` ...

### DIFF
--- a/src/library/scala/util/Properties.scala
+++ b/src/library/scala/util/Properties.scala
@@ -128,8 +128,10 @@ private[scala] trait PropertiesTrait {
   /* Some derived values. */
   /** Returns `true` iff the underlying operating system is a version of Microsoft Windows. */
   def isWin                 = osName startsWith "Windows"
+  // See http://mail.openjdk.java.net/pipermail/macosx-port-dev/2012-November/005148.html for
+  // the reason why we don't follow developer.apple.com/library/mac/#technotes/tn2002/tn2110.
   /** Returns `true` iff the underlying operating system is a version of Apple Mac OSX.  */
-  def isMac                 = osName contains   "OS X" // See developer.apple.com/library/mac/#technotes/tn2002/tn2110
+  def isMac                 = osName startsWith "Mac OS X" 
 
   def versionMsg            = "Scala %s %s -- %s".format(propCategory, versionString, copyrightString)
   def scalaCmd              = if (isWin) "scala.bat" else "scala"


### PR DESCRIPTION
... instead of `osName contains "OS X"`

See http://mail.openjdk.java.net/pipermail/macosx-port-dev/2012-November/005148.html
for the reason why we don't follow developer.apple.com/library/mac/#technotes/tn2002/tn2110.
