### PR TITLE
SI-7509 Avoid crasher as erronous args flow through NamesDefaults

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
@@ -333,9 +333,12 @@ trait NamesDefaults { self: Analyzer =>
           // type the application without names; put the arguments in definition-site order
           val typedApp = doTypedApply(tree, funOnly, reorderArgs(namelessArgs, argPos), mode, pt)
           typedApp match {
-            // Extract the typed arguments, restore the call-site evaluation order (using
-            // ValDef's in the block), change the arguments to these local values.
-            case Apply(expr, typedArgs) if !(typedApp :: typedArgs).exists(_.isErrorTyped) => // bail out with erroneous args, see SI-7238
+            case Apply(expr, typedArgs) if (typedApp :: typedArgs).exists(_.isErrorTyped) =>
+              setError(tree) // bail out with and erroneous Apply *or* erroneous arguments, see SI-7238, SI-7509
+            case Apply(expr, typedArgs) =>
+              // Extract the typed arguments, restore the call-site evaluation order (using
+              // ValDef's in the block), change the arguments to these local values.
+
               // typedArgs: definition-site order
               val formals = formalTypes(expr.tpe.paramTypes, typedArgs.length, removeByName = false, removeRepeated = false)
               // valDefs: call-site order

--- a/test/files/neg/t7509.check
+++ b/test/files/neg/t7509.check
@@ -1,0 +1,12 @@
+t7509.scala:3: error: inferred type arguments [Int] do not conform to method crash's type parameter bounds [R <: AnyRef]
+  crash(42)
+  ^
+t7509.scala:3: error: type mismatch;
+ found   : Int(42)
+ required: R
+  crash(42)
+        ^
+t7509.scala:3: error: could not find implicit value for parameter ev: R
+  crash(42)
+       ^
+three errors found

--- a/test/files/neg/t7509.scala
+++ b/test/files/neg/t7509.scala
@@ -1,0 +1,4 @@
+object NMWE {
+  def crash[R <: AnyRef](f: R)(implicit ev: R): Any = ???
+  crash(42)
+}


### PR DESCRIPTION
The fix for SI-7238 caused this regression.

This commit marks taints whole Apply with an ErrorType if it
has an erroneous argument, so as to stop a later crash trying
to further process the tree.

Review by @lrytz
