### PR TITLE
Make all numeric coercions explicit.

### DIFF
--- a/src/actors/scala/actors/scheduler/ForkJoinScheduler.scala
+++ b/src/actors/scala/actors/scheduler/ForkJoinScheduler.scala
@@ -63,7 +63,7 @@ class ForkJoinScheduler(val initCoreSize: Int, val maxSize: Int, daemon: Boolean
       while (true) {
         this.synchronized {
           try {
-            wait(CHECK_FREQ)
+            wait(CHECK_FREQ.toLong)
           } catch {
             case _: InterruptedException =>
           }

--- a/src/actors/scala/actors/scheduler/ResizableThreadPoolScheduler.scala
+++ b/src/actors/scala/actors/scheduler/ResizableThreadPoolScheduler.scala
@@ -103,7 +103,7 @@ class ResizableThreadPoolScheduler(protected val terminate: Boolean,
       while (true) {
         this.synchronized {
           try {
-            wait(CHECK_FREQ)
+            wait(CHECK_FREQ.toLong)
           } catch {
             case _: InterruptedException =>
           }

--- a/src/actors/scala/actors/scheduler/TerminationService.scala
+++ b/src/actors/scala/actors/scheduler/TerminationService.scala
@@ -39,7 +39,7 @@ private[scheduler] trait TerminationService extends TerminationMonitor {
       while (true) {
         this.synchronized {
           try {
-            wait(CHECK_FREQ)
+            wait(CHECK_FREQ.toLong)
           } catch {
             case _: InterruptedException =>
           }

--- a/src/compiler/scala/tools/nsc/CompileSocket.scala
+++ b/src/compiler/scala/tools/nsc/CompileSocket.scala
@@ -113,7 +113,7 @@ class CompileSocket extends CompileOutputCommon {
    */
   def getPort(vmArgs: String): Int = {
     val maxPolls = 300
-    val sleepTime = 25
+    val sleepTime = 25L
 
     var attempts = 0
     var port = pollPort()
@@ -152,9 +152,9 @@ class CompileSocket extends CompileOutputCommon {
     * cannot be established.
     */
   def getOrCreateSocket(vmArgs: String, create: Boolean = true): Option[Socket] = {
-    val maxMillis = 10 * 1000   // try for 10 seconds
-    val retryDelay = 50
-    val maxAttempts = maxMillis / retryDelay
+    val maxMillis = 10L * 1000   // try for 10 seconds
+    val retryDelay = 50L
+    val maxAttempts = (maxMillis / retryDelay).toInt
 
     def getsock(attempts: Int): Option[Socket] = attempts match {
       case 0    => warn("Unable to establish connection to compilation daemon") ; None

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2067,7 +2067,7 @@ self =>
           if (mods.isLazy) syntaxError("lazy modifier not allowed here. Use call-by-name parameters instead", skipIt = false)
           in.token match {
             case v @ (VAL | VAR) =>
-              mods = mods withPosition (in.token, tokenRange(in))
+              mods = mods withPosition (in.token.toLong, tokenRange(in))
               if (v == VAR) mods |= Flags.MUTABLE
               in.nextToken()
             case _ =>
@@ -2105,7 +2105,7 @@ self =>
             expr()
           } else EmptyTree
         atPos(start, if (name == nme.ERROR) start else nameOffset) {
-          ValDef((mods | implicitmod | bynamemod) withAnnotations annots, name.toTermName, tpt, default)
+          ValDef((mods | implicitmod.toLong | bynamemod) withAnnotations annots, name.toTermName, tpt, default)
         }
       }
       def paramClause(): List[ValDef] = {
@@ -2970,7 +2970,7 @@ self =>
     def localDef(implicitMod: Int): List[Tree] = {
       val annots = annotations(skipNewLines = true)
       val pos = in.offset
-      val mods = (localModifiers() | implicitMod) withAnnotations annots
+      val mods = (localModifiers() | implicitMod.toLong) withAnnotations annots
       val defs =
         if (!(mods hasFlag ~(Flags.IMPLICIT | Flags.LAZY))) defOrDcl(pos, mods)
         else List(tmplDef(pos, mods))

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -561,7 +561,7 @@ trait Scanners extends ScannersCommon {
               nextChar()
               getOperatorRest()
             } else {
-              syntaxError("illegal character '" + ("" + '\\' + 'u' + "%04x".format(ch: Int)) + "'")
+              syntaxError("illegal character '" + ("" + '\\' + 'u' + "%04x".format(ch.toInt)) + "'")
               nextChar()
             }
           }
@@ -884,7 +884,7 @@ trait Scanners extends ScannersCommon {
      */
     def intVal(negated: Boolean): Long = {
       if (token == CHARLIT && !negated) {
-        charVal
+        charVal.toLong
       } else {
         var value: Long = 0
         val divider = if (base == 10) 1 else 2

--- a/src/compiler/scala/tools/nsc/backend/icode/Opcodes.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/Opcodes.scala
@@ -407,7 +407,7 @@ trait Opcodes { self: ICodes =>
      * there's been a serious misunderstanding
      */
     // TODO do the real thing
-    case class INVOKE_DYNAMIC(poolEntry: Char) extends Instruction {
+    case class INVOKE_DYNAMIC(poolEntry: Int) extends Instruction {
       private def error = sys.error("INVOKE_DYNAMIC is not fully implemented and should not be analyzed")
       override def consumed = error
       override def produced = error

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
@@ -1661,8 +1661,8 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
 
         case BooleanTag => jcode.boolconst(const.booleanValue)
 
-        case ByteTag    => jcode.iconst(const.byteValue)
-        case ShortTag   => jcode.iconst(const.shortValue)
+        case ByteTag    => jcode.iconst(const.byteValue.toInt)
+        case ShortTag   => jcode.iconst(const.shortValue.toInt)
         case CharTag    => jcode.iconst(const.charValue)
         case IntTag     => jcode.iconst(const.intValue)
 
@@ -1709,6 +1709,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
 
       final def boolconst(b: Boolean) { iconst(if(b) 1 else 0) }
 
+      def iconst(cst: Char) { iconst(cst.toInt) }
       def iconst(cst: Int) {
         if (cst >= -1 && cst <= 5) {
           jmethod.visitInsn(Opcodes.ICONST_0 + cst)
@@ -1859,7 +1860,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
         val isDenseEnough: Boolean = {
           /* Calculate in long to guard against overflow. TODO what overflow??? */
           val keyRangeD: Double = (keyMax.asInstanceOf[Long] - keyMin + 1).asInstanceOf[Double]
-          val klenD:     Double = keys.length
+          val klenD:     Double = keys.length.toDouble
           val kdensity:  Double = (klenD / keyRangeD)
 
           kdensity >= minDensity

--- a/src/compiler/scala/tools/nsc/io/Lexer.scala
+++ b/src/compiler/scala/tools/nsc/io/Lexer.scala
@@ -23,7 +23,7 @@ object Lexer {
   /** A subclass of `Token` representing single-character delimiters
    *  @param char the delimiter character making up this token
    */
-  case class Delim(char: Char) extends Token("'"+char.toString+"'")
+  case class Delim(char: Char) extends Token(s"'$char'")
 
   /** A subclass of token representing integer literals */
   case class IntLit(override val str: String) extends Token(str)
@@ -88,7 +88,7 @@ object Lexer {
       case '\\' => buf ++= "\\\\"
       case _ =>
         if (' ' <= ch && ch < 128) buf += ch
-        else buf ++= "\\u" += toUDigit(ch >>> 12) += toUDigit(ch >>> 8) += toUDigit(ch >>> 4) += toUDigit(ch)
+        else buf ++= "\\u" += toUDigit(ch >>> 12) += toUDigit(ch >>> 8) += toUDigit(ch >>> 4) += toUDigit(ch.toInt)
     }
   }
 

--- a/src/compiler/scala/tools/nsc/io/PrettyWriter.scala
+++ b/src/compiler/scala/tools/nsc/io/PrettyWriter.scala
@@ -16,7 +16,7 @@ class PrettyWriter(wr: Writer) extends Writer {
       str(off) match {
         case '{' | '[' | '(' =>
           indent += 1
-          wr.write(str(off))
+          wr.write(str(off).toInt)
           newLine()
           wr.write(str, off + 1, len - 1)
         case '}' | ']' | ')' =>

--- a/src/compiler/scala/tools/nsc/javac/JavaScanners.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaScanners.scala
@@ -724,7 +724,7 @@ trait JavaScanners extends ast.parser.ScannersCommon {
      */
     def intVal(negated: Boolean): Long = {
       if (token == CHARLIT && !negated) {
-        if (name.length > 0) name.charAt(0) else 0
+        if (name.length > 0) name.charAt(0).toLong else 0
       } else {
         var value: Long = 0
         val divider = if (base == 10) 1 else 2

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
@@ -505,7 +505,7 @@ abstract class ICodeReader extends ClassfileParser {
           // TODO, this is just a place holder. A real implementation must parse the class constant entry
           debuglog("Found JVM invokedynamic instructionm, inserting place holder ICode INVOKE_DYNAMIC.")
           containsInvokeDynamic = true
-          val poolEntry = in.nextChar
+          val poolEntry = in.nextChar.toInt
           in.skip(2)
           code.emit(INVOKE_DYNAMIC(poolEntry))
 
@@ -919,6 +919,7 @@ abstract class ICodeReader extends ClassfileParser {
     }
 
     /** Return the local at given index, with the given type. */
+    def getLocal(idx: Char, kind: TypeKind): Local = getLocal(idx.toInt, kind)
     def getLocal(idx: Int, kind: TypeKind): Local = {
       assert(idx < maxLocals, "Index too large for local variable.")
 

--- a/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
@@ -632,7 +632,7 @@ abstract class Pickler extends SubComponent {
         case c @ Constant(_) =>
           if (c.tag == BooleanTag) writeLong(if (c.booleanValue) 1 else 0)
           else if (ByteTag <= c.tag && c.tag <= LongTag) writeLong(c.longValue)
-          else if (c.tag == FloatTag) writeLong(floatToIntBits(c.floatValue))
+          else if (c.tag == FloatTag) writeLong(floatToIntBits(c.floatValue).toLong)
           else if (c.tag == DoubleTag) writeLong(doubleToLongBits(c.doubleValue))
           else if (c.tag == StringTag) writeRef(newTermName(c.stringValue))
           else if (c.tag == ClazzTag) writeRef(c.typeValue)

--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -78,7 +78,7 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
             if (isFinal) FINAL else 0
           )
 
-          val varSym = currentClass.newVariable(mkTerm("" + forName), ad.pos, flags) setInfoAndEnter forType
+          val varSym = currentClass.newVariable(mkTerm("" + forName), ad.pos, flags.toLong) setInfoAndEnter forType
           if (!isFinal)
             varSym.addAnnotation(VolatileAttr)
 

--- a/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
+++ b/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
@@ -304,7 +304,7 @@ abstract class LambdaLift extends InfoTransform {
           proxies(owner) =
             for (fv <- freeValues.toList) yield {
               val proxyName = proxyNames.getOrElse(fv, fv.name)
-              val proxy = owner.newValue(proxyName.toTermName, owner.pos, newFlags) setInfo fv.info
+              val proxy = owner.newValue(proxyName.toTermName, owner.pos, newFlags.toLong) setInfo fv.info
               if (owner.isClass) owner.info.decls enter proxy
               proxy
             }

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -1099,11 +1099,11 @@ trait ContextErrors {
 
 
       def AbstractMemberWithModiferError(sym: Symbol, flag: Int) =
-        issueSymbolTypeError(sym, "abstract member may not have " + Flags.flagsToString(flag) + " modifier")
+        issueSymbolTypeError(sym, "abstract member may not have " + Flags.flagsToString(flag.toLong) + " modifier")
 
       def IllegalModifierCombination(sym: Symbol, flag1: Int, flag2: Int) =
         issueSymbolTypeError(sym, "illegal combination of modifiers: %s and %s for: %s".format(
-            Flags.flagsToString(flag1), Flags.flagsToString(flag2), sym))
+            Flags.flagsToString(flag1.toLong), Flags.flagsToString(flag2.toLong), sym))
 
       def IllegalDependentMethTpeError(sym: Symbol)(context: Context) = {
         val errorAddendum =

--- a/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
@@ -382,7 +382,7 @@ trait MethodSynthesis {
       def name       = tree.name
       def category   = GetterTargetClass
       def flagsMask  = GetterFlags
-      def flagsExtra = ACCESSOR | ( if (tree.mods.isMutable) 0 else STABLE )
+      def flagsExtra = ACCESSOR.toLong | ( if (tree.mods.isMutable) 0 else STABLE )
 
       override def validate() {
         assert(derivedSym != NoSymbol, tree)

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1267,7 +1267,7 @@ trait Namers extends MethodSynthesis {
 
             val defaultTree = atPos(vparam.pos.focus) {
               DefDef(
-                Modifiers(meth.flags & DefaultGetterFlags) | SYNTHETIC | DEFAULTPARAM | oflag,
+                Modifiers(meth.flags & DefaultGetterFlags) | (SYNTHETIC | DEFAULTPARAM | oflag).toLong,
                 name, deftParams, defvParamss, defTpt, defRhs)
             }
             if (!isConstr)
@@ -1516,7 +1516,7 @@ trait Namers extends MethodSynthesis {
           AbstractMemberWithModiferError(sym, flag)
       }
       def checkNoConflict(flag1: Int, flag2: Int) {
-        if (sym hasAllFlags flag1 | flag2)
+        if (sym hasAllFlags flag1.toLong | flag2)
           IllegalModifierCombination(sym, flag1, flag2)
       }
       if (sym.isImplicit) {

--- a/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
@@ -254,13 +254,14 @@ trait SyntheticMethods extends ast.TreeDSL {
 
     def hashcodeImplementation(sym: Symbol): Tree = {
       sym.tpe.finalResultType.typeSymbol match {
-        case UnitClass | NullClass                         => Literal(Constant(0))
-        case BooleanClass                                  => If(Ident(sym), Literal(Constant(1231)), Literal(Constant(1237)))
-        case IntClass | ShortClass | ByteClass | CharClass => Ident(sym)
-        case LongClass                                     => callStaticsMethod("longHash")(Ident(sym))
-        case DoubleClass                                   => callStaticsMethod("doubleHash")(Ident(sym))
-        case FloatClass                                    => callStaticsMethod("floatHash")(Ident(sym))
-        case _                                             => callStaticsMethod("anyHash")(Ident(sym))
+        case UnitClass | NullClass              => Literal(Constant(0))
+        case BooleanClass                       => If(Ident(sym), Literal(Constant(1231)), Literal(Constant(1237)))
+        case IntClass                           => Ident(sym)
+        case ShortClass | ByteClass | CharClass => Select(Ident(sym), nme.toInt)
+        case LongClass                          => callStaticsMethod("longHash")(Ident(sym))
+        case DoubleClass                        => callStaticsMethod("doubleHash")(Ident(sym))
+        case FloatClass                         => callStaticsMethod("floatHash")(Ident(sym))
+        case _                                  => callStaticsMethod("anyHash")(Ident(sym))
       }
     }
 

--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -126,7 +126,7 @@ trait TypeDiagnostics {
     else if (!member.isDeferred) member.accessed
     else {
       val getter = if (member.isSetter) member.getter(member.owner) else member
-      val flags  = if (getter.setter(member.owner) != NoSymbol) DEFERRED | MUTABLE else DEFERRED
+      val flags  = if (getter.setter(member.owner) != NoSymbol) DEFERRED.toLong | MUTABLE else DEFERRED
 
       getter.owner.newValue(getter.name.toTermName, getter.pos, flags) setInfo getter.tpe.resultType
     }

--- a/src/compiler/scala/tools/nsc/util/ShowPickled.scala
+++ b/src/compiler/scala/tools/nsc/util/ShowPickled.scala
@@ -108,7 +108,7 @@ object ShowPickled extends Names {
     var result = 0L
     var b = 0L
     do {
-      b = data(idx)
+      b = data(idx).toLong
       idx += 1
       result = (result << 7) + (b & 0x7f)
     } while((b & 0x80) != 0L)

--- a/src/interactive/scala/tools/nsc/interactive/REPL.scala
+++ b/src/interactive/scala/tools/nsc/interactive/REPL.scala
@@ -165,7 +165,7 @@ object REPL {
           show(reloadResult)
         case "reloadAndAskType" :: file :: millis :: Nil =>
           comp.askReload(List(toSourceFile(file)), reloadResult)
-          Thread.sleep(millis.toInt)
+          Thread.sleep(millis.toLong)
           println("ask type now")
           comp.askLoadedTyped(toSourceFile(file), typedResult)
           typedResult.get

--- a/src/interactive/scala/tools/nsc/interactive/tests/Tester.scala
+++ b/src/interactive/scala/tools/nsc/interactive/tests/Tester.scala
@@ -26,7 +26,7 @@ class Tester(ntests: Int, inputs: Array[SourceFile], settings: Settings) {
     while (!res.isComplete && !res.isCancelled) {
       if (System.currentTimeMillis() > limit) {
         print("c"); res.cancel()
-      } else res.get(TIMEOUT) match {
+      } else res.get(TIMEOUT.toLong) match {
         case Some(Left(t)) =>
           /**/
           if (settings.verbose) println(t)

--- a/src/library/scala/collection/mutable/StringBuilder.scala
+++ b/src/library/scala/collection/mutable/StringBuilder.scala
@@ -256,8 +256,8 @@ final class StringBuilder(private val underlying: JavaStringBuilder)
    *  @return     This StringBuilder.
    */
   def append(x: Boolean): StringBuilder = { underlying append x ; this }
-  def append(x: Byte): StringBuilder = { underlying append x ; this }
-  def append(x: Short): StringBuilder = { underlying append x ; this }
+  def append(x: Byte): StringBuilder = append(x.toInt)
+  def append(x: Short): StringBuilder = append(x.toInt)
   def append(x: Int): StringBuilder = { underlying append x ; this }
   def append(x: Long): StringBuilder = { underlying append x ; this }
   def append(x: Float): StringBuilder = { underlying append x ; this }
@@ -360,8 +360,8 @@ final class StringBuilder(private val underlying: JavaStringBuilder)
    *  @return       this StringBuilder.
    */
   def insert(index: Int, x: Boolean): StringBuilder = insert(index, String.valueOf(x))
-  def insert(index: Int, x: Byte): StringBuilder    = insert(index, String.valueOf(x))
-  def insert(index: Int, x: Short): StringBuilder   = insert(index, String.valueOf(x))
+  def insert(index: Int, x: Byte): StringBuilder    = insert(index, x.toInt)
+  def insert(index: Int, x: Short): StringBuilder   = insert(index, x.toInt)
   def insert(index: Int, x: Int): StringBuilder     = insert(index, String.valueOf(x))
   def insert(index: Int, x: Long): StringBuilder    = insert(index, String.valueOf(x))
   def insert(index: Int, x: Float): StringBuilder   = insert(index, String.valueOf(x))

--- a/src/library/scala/concurrent/duration/package.scala
+++ b/src/library/scala/concurrent/duration/package.scala
@@ -36,12 +36,12 @@ package object duration {
   final val NANOSECONDS  = java.util.concurrent.TimeUnit.NANOSECONDS
   final val SECONDS      = java.util.concurrent.TimeUnit.SECONDS
 
-  implicit def pairIntToDuration(p: (Int, TimeUnit)): Duration         = Duration(p._1, p._2)
+  implicit def pairIntToDuration(p: (Int, TimeUnit)): Duration         = Duration(p._1.toLong, p._2)
   implicit def pairLongToDuration(p: (Long, TimeUnit)): FiniteDuration = Duration(p._1, p._2)
   implicit def durationToPair(d: Duration): (Long, TimeUnit)           = (d.length, d.unit)
 
   implicit final class DurationInt(val n: Int) extends AnyVal with DurationConversions {
-    override protected def durationIn(unit: TimeUnit): FiniteDuration = Duration(n, unit)
+    override protected def durationIn(unit: TimeUnit): FiniteDuration = Duration(n.toLong, unit)
   }
 
   implicit final class DurationLong(val n: Long) extends AnyVal with DurationConversions {
@@ -60,16 +60,16 @@ package object duration {
    * Avoid reflection based invocation by using non-duck type
    */
   implicit final class IntMult(val i: Int) extends AnyVal {
-    def *(d: Duration) = d * i
-    def *(d: FiniteDuration) = d * i
+    def *(d: Duration) = d * i.toDouble
+    def *(d: FiniteDuration) = d * i.toLong
   }
 
   implicit final class LongMult(val i: Long) extends AnyVal {
-    def *(d: Duration) = d * i
-    def *(d: FiniteDuration) = d * i
+    def *(d: Duration) = d * i.toDouble
+    def *(d: FiniteDuration) = d * i.toLong
   }
 
   implicit final class DoubleMult(val f: Double) extends AnyVal {
-    def *(d: Duration) = d * f
+    def *(d: Duration) = d * f.toDouble
   }
 }

--- a/src/library/scala/io/BufferedSource.scala
+++ b/src/library/scala/io/BufferedSource.scala
@@ -55,7 +55,7 @@ class BufferedSource(inputStream: InputStream, bufferSize: Int)(implicit val cod
       // immediately on the source.
       if (charReaderCreated && iter.hasNext) {
         val pb = new PushbackReader(charReader)
-        pb unread iter.next()
+        pb unread iter.next().toInt
         new BufferedReader(pb, bufferSize)
       }
       else charReader

--- a/src/library/scala/math/BigDecimal.scala
+++ b/src/library/scala/math/BigDecimal.scala
@@ -44,6 +44,7 @@ object BigDecimal {
    */
   def valueOf(d: Double): BigDecimal = apply(BigDec valueOf d)
   def valueOf(d: Double, mc: MathContext): BigDecimal = apply(BigDec valueOf d, mc)
+  def valueOf(x: Long): BigDecimal = apply(x.toDouble)
 
   /** Constructs a `BigDecimal` whose value is equal to that of the
    *  specified `Integer` value.
@@ -56,10 +57,10 @@ object BigDecimal {
     if (mc == defaultMathContext && minCached <= i && i <= maxCached) {
       val offset = i - minCached
       var n = cache(offset)
-      if (n eq null) { n = new BigDecimal(BigDec.valueOf(i), mc); cache(offset) = n }
+      if (n eq null) { n = new BigDecimal(BigDec.valueOf(i.toLong), mc); cache(offset) = n }
       n
     }
-    else new BigDecimal(BigDec.valueOf(i), mc)
+    else new BigDecimal(BigDec.valueOf(i.toLong), mc)
 
   /** Constructs a `BigDecimal` whose value is equal to that of the
    *  specified long value.
@@ -98,6 +99,9 @@ object BigDecimal {
   // a MathContext, but we should be duplicating its logic, modulo caching.
   def apply(d: Double, mc: MathContext): BigDecimal =
     new BigDecimal(new BigDec(jl.Double.toString(d), mc), mc)
+
+  def apply(x: Float): BigDecimal = apply(x.toDouble)
+  def apply(x: Float, mc: MathContext): BigDecimal = apply(x.toDouble, mc)
 
   /** Translates a character array representation of a `BigDecimal`
    *  into a `BigDecimal`.
@@ -193,7 +197,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable {
     */
   def isValidFloat = {
     val f = toFloat
-    !f.isInfinity && bigDecimal.compareTo(new java.math.BigDecimal(f)) == 0
+    !f.isInfinity && bigDecimal.compareTo(new java.math.BigDecimal(f.toDouble)) == 0
   }
   /** Returns `true` iff this can be represented exactly by [[scala.Double]]; otherwise returns `false`.
     */

--- a/src/library/scala/math/BigInt.scala
+++ b/src/library/scala/math/BigInt.scala
@@ -34,9 +34,9 @@ object BigInt {
     if (minCached <= i && i <= maxCached) {
       val offset = i - minCached
       var n = cache(offset)
-      if (n eq null) { n = new BigInt(BigInteger.valueOf(i)); cache(offset) = n }
+      if (n eq null) { n = new BigInt(BigInteger.valueOf(i.toLong)); cache(offset) = n }
       n
-    } else new BigInt(BigInteger.valueOf(i))
+    } else new BigInt(BigInteger.valueOf(i.toLong))
 
   /** Constructs a `BigInt` whose value is equal to that of the
    *  specified long value.

--- a/src/library/scala/math/Numeric.scala
+++ b/src/library/scala/math/Numeric.scala
@@ -51,9 +51,9 @@ object Numeric {
     def negate(x: Int): Int = -x
     def fromInt(x: Int): Int = x
     def toInt(x: Int): Int = x
-    def toLong(x: Int): Long = x
-    def toFloat(x: Int): Float = x
-    def toDouble(x: Int): Double = x
+    def toLong(x: Int): Long = x.toLong
+    def toFloat(x: Int): Float = x.toFloat
+    def toDouble(x: Int): Double = x.toDouble
   }
   implicit object IntIsIntegral extends IntIsIntegral with Ordering.IntOrdering
 
@@ -109,11 +109,11 @@ object Numeric {
     def quot(x: Long, y: Long): Long = x / y
     def rem(x: Long, y: Long): Long = x % y
     def negate(x: Long): Long = -x
-    def fromInt(x: Int): Long = x
+    def fromInt(x: Int): Long = x.toLong
     def toInt(x: Long): Int = x.toInt
     def toLong(x: Long): Long = x
-    def toFloat(x: Long): Float = x
-    def toDouble(x: Long): Double = x
+    def toFloat(x: Long): Float = x.toFloat
+    def toDouble(x: Long): Double = x.toDouble
   }
   implicit object LongIsIntegral extends LongIsIntegral with Ordering.LongOrdering
 
@@ -122,11 +122,11 @@ object Numeric {
     def minus(x: Float, y: Float): Float = x - y
     def times(x: Float, y: Float): Float = x * y
     def negate(x: Float): Float = -x
-    def fromInt(x: Int): Float = x
+    def fromInt(x: Int): Float = x.toFloat
     def toInt(x: Float): Int = x.toInt
     def toLong(x: Float): Long = x.toLong
     def toFloat(x: Float): Float = x
-    def toDouble(x: Float): Double = x
+    def toDouble(x: Float): Double = x.toDouble
   }
   trait FloatIsFractional extends FloatIsConflicted with Fractional[Float] {
     def div(x: Float, y: Float): Float = x / y
@@ -144,7 +144,7 @@ object Numeric {
     def minus(x: Double, y: Double): Double = x - y
     def times(x: Double, y: Double): Double = x * y
     def negate(x: Double): Double = -x
-    def fromInt(x: Int): Double = x
+    def fromInt(x: Int): Double = x.toDouble
     def toInt(x: Double): Int = x.toInt
     def toLong(x: Double): Long = x.toLong
     def toFloat(x: Double): Float = x.toFloat

--- a/src/library/scala/math/package.scala
+++ b/src/library/scala/math/package.scala
@@ -62,7 +62,7 @@ package object math {
   def sqrt(x: Double): Double = java.lang.Math.sqrt(x)
   def IEEEremainder(x: Double, y: Double): Double = java.lang.Math.IEEEremainder(x, y)
 
-  def ceil(x: Double): Double = java.lang.Math.ceil(x)
+  def ceil(x: Double): Double  = java.lang.Math.ceil(x)
   def floor(x: Double): Double = java.lang.Math.floor(x)
 
   /** Returns the `double` value that is closest in value to the
@@ -100,24 +100,30 @@ package object math {
    */
   def round(x: Float): Int = java.lang.Math.round(x)
   def round(x: Double): Long = java.lang.Math.round(x)
-  def abs(x: Int): Int = java.lang.Math.abs(x)
-  def abs(x: Long): Long = java.lang.Math.abs(x)
-  def abs(x: Float): Float = java.lang.Math.abs(x)
+
+  def abs(x: Int): Int       = java.lang.Math.abs(x)
+  def abs(x: Long): Long     = java.lang.Math.abs(x)
+  def abs(x: Float): Float   = java.lang.Math.abs(x)
   def abs(x: Double): Double = java.lang.Math.abs(x)
 
-  def max(x: Int, y: Int): Int = java.lang.Math.max(x, y)
-  def max(x: Long, y: Long): Long = java.lang.Math.max(x, y)
-  def max(x: Float, y: Float): Float = java.lang.Math.max(x, y)
+  def max(x: Int, y: Int): Int          = java.lang.Math.max(x, y)
+  def max(x: Long, y: Long): Long       = java.lang.Math.max(x, y)
+  def max(x: Float, y: Float): Float    = java.lang.Math.max(x, y)
   def max(x: Double, y: Double): Double = java.lang.Math.max(x, y)
 
-  def min(x: Int, y: Int): Int = java.lang.Math.min(x, y)
-  def min(x: Long, y: Long): Long  = java.lang.Math.min(x, y)
-  def min(x: Float, y: Float): Float  = java.lang.Math.min(x, y)
+  def min(x: Int, y: Int): Int          = java.lang.Math.min(x, y)
+  def min(x: Long, y: Long): Long       = java.lang.Math.min(x, y)
+  def min(x: Float, y: Float): Float    = java.lang.Math.min(x, y)
   def min(x: Double, y: Double): Double = java.lang.Math.min(x, y)
 
-  def signum(x: Int): Int = java.lang.Integer.signum(x)
-  def signum(x: Long): Long = java.lang.Long.signum(x)
-  def signum(x: Float): Float = java.lang.Math.signum(x)
+  /** Note that these are not pure forwarders to the java versions.
+   *  In particular, the return type of java.lang.Long.signum is Int,
+   *  but here it is widened to Long so that each overloaded variant
+   *  will return the same numeric type it is passed.
+   */
+  def signum(x: Int): Int       = java.lang.Integer.signum(x)
+  def signum(x: Long): Long     = java.lang.Long.signum(x)
+  def signum(x: Float): Float   = java.lang.Math.signum(x)
   def signum(x: Double): Double = java.lang.Math.signum(x)
 
   // -----------------------------------------------------------------------

--- a/src/library/scala/reflect/NameTransformer.scala
+++ b/src/library/scala/reflect/NameTransformer.scala
@@ -30,9 +30,9 @@ object NameTransformer {
   private val op2code = new Array[String](nops)
   private val code2op = new Array[OpCodes](ncodes)
   private def enterOp(op: Char, code: String) = {
-    op2code(op) = code
+    op2code(op.toInt) = code
     val c = (code.charAt(1) - 'a') * 26 + code.charAt(2) - 'a'
-    code2op(c) = new OpCodes(op, code, code2op(c))
+    code2op(c.toInt) = new OpCodes(op, code, code2op(c))
   }
 
   /* Note: decoding assumes opcodes are only ever lowercase. */
@@ -66,12 +66,12 @@ object NameTransformer {
     var i = 0
     while (i < len) {
       val c = name charAt i
-      if (c < nops && (op2code(c) ne null)) {
+      if (c < nops && (op2code(c.toInt) ne null)) {
         if (buf eq null) {
           buf = new StringBuilder()
           buf.append(name.substring(0, i))
         }
-        buf.append(op2code(c))
+        buf.append(op2code(c.toInt))
       /* Handle glyphs that are not valid Java/JVM identifiers */
       }
       else if (!Character.isJavaIdentifierPart(c)) {

--- a/src/library/scala/runtime/RichFloat.scala
+++ b/src/library/scala/runtime/RichFloat.scala
@@ -15,22 +15,22 @@ final class RichFloat(val self: Float) extends AnyVal with FractionalProxy[Float
   protected def integralNum = scala.math.Numeric.FloatAsIfIntegral
 
   def round: Int   = math.round(self)
-  def ceil: Float  = math.ceil(self).toFloat
-  def floor: Float = math.floor(self).toFloat
+  def ceil: Float  = math.ceil(self.toDouble).toFloat
+  def floor: Float = math.floor(self.toDouble).toFloat
 
   /** Converts an angle measured in degrees to an approximately equivalent
    *  angle measured in radians.
    *
    *  @return the measurement of the angle `x` in radians.
    */
-  def toRadians: Float = math.toRadians(self).toFloat
+  def toRadians: Float = math.toRadians(self.toDouble).toFloat
 
   /** Converts an angle measured in radians to an approximately equivalent
    *  angle measured in degrees.
    *
    *  @return the measurement of the angle `x` in degrees.
    */
-  def toDegrees: Float = math.toDegrees(self).toFloat
+  def toDegrees: Float = math.toDegrees(self.toDouble).toFloat
 
   // isNaN is provided by the implicit conversion to java.lang.Float
   // def isNaN: Boolean = java.lang.Float.isNaN(self)

--- a/src/library/scala/runtime/WorksheetSupport.scala
+++ b/src/library/scala/runtime/WorksheetSupport.scala
@@ -21,7 +21,7 @@ object WorksheetSupport {
     private var lastFlush: Long = 0L
     private var col = -1
     override def write(b: Array[Byte], off: Int, len: Int) = {
-      for (idx <- off until (off + len min b.length)) writeOne(b(idx))
+      for (idx <- off until (off + len min b.length)) writeOne(b(idx).toInt)
       flush()
     }
     override def write(c: Int) {

--- a/src/library/scala/util/MurmurHash.scala
+++ b/src/library/scala/util/MurmurHash.scala
@@ -172,7 +172,7 @@ object MurmurHash {
       k = nextMagicB(k)
       j += 2
     }
-    if (j < s.length) h = extendHash(h,s.charAt(j),c,k)
+    if (j < s.length) h = extendHash(h,s.charAt(j).toInt,c,k)
     finalizeHash(h)
   }
 

--- a/src/library/scala/util/hashing/MurmurHash3.scala
+++ b/src/library/scala/util/hashing/MurmurHash3.scala
@@ -77,7 +77,7 @@ private[hashing] class MurmurHash3 {
       h = mix(h, data)
       i += 2
     }
-    if (i < str.length) h = mixLast(h, str.charAt(i))
+    if (i < str.length) h = mixLast(h, str.charAt(i).toInt)
     finalizeHash(h, str.length)
   }
 

--- a/src/library/scala/util/parsing/json/Parser.scala
+++ b/src/library/scala/util/parsing/json/Parser.scala
@@ -83,7 +83,7 @@ object JSONFormat {
        * Per RFC4627, section 2.5, we're not technically required to
        * encode the C1 codes, but we do to be safe.
        */
-      case c if ((c >= '\u0000' && c <= '\u001f') || (c >= '\u007f' && c <= '\u009f')) => "\\u%04x".format(c: Int)
+      case c if ((c >= '\u0000' && c <= '\u001f') || (c >= '\u007f' && c <= '\u009f')) => "\\u%04x".format(c.toInt)
       case c => c
     }.mkString
 }

--- a/src/library/scala/xml/include/sax/XIncluder.scala
+++ b/src/library/scala/xml/include/sax/XIncluder.scala
@@ -95,7 +95,7 @@ class XIncluder(outs: OutputStream, encoding: String) extends ContentHandler wit
         // However, it is required if text contains ]]>
         // (The end CDATA section delimiter)
         else if (c == '>') out.write("&gt;")
-        else out.write(c)
+        else out.write(c.toInt)
         i += 1
       }
     }

--- a/src/library/scala/xml/persistent/CachedFileStorage.scala
+++ b/src/library/scala/xml/persistent/CachedFileStorage.scala
@@ -112,7 +112,7 @@ abstract class CachedFileStorage(private val file1: File) extends Thread {
   override def run = {
     log("[run]\nstarting storage thread, checking every "+interval+" ms")
     while (true) {
-      Thread.sleep( this.interval )
+      Thread.sleep( this.interval.toLong )
       save()
     }
   }

--- a/src/reflect/scala/reflect/internal/Constants.scala
+++ b/src/reflect/scala/reflect/internal/Constants.scala
@@ -212,7 +212,7 @@ trait Constants extends api.Constants {
       case '"'  => "\\\""
       case '\'' => "\\\'"
       case '\\' => "\\\\"
-      case _    => if (ch.isControl) "\\0" + toOctalString(ch) else String.valueOf(ch)
+      case _    => if (ch.isControl) "\\0" + toOctalString(ch.toInt) else String.valueOf(ch)
     }
 
     def escapedStringValue: String = {

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -269,7 +269,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       val newName  = nme.moduleVarName(accessor.name.toTermName)
       val newFlags = MODULEVAR | ( if (this.isClass) PrivateLocal | SYNTHETIC else 0 )
       val newInfo  = accessor.tpe.finalResultType
-      val mval     = newVariable(newName, accessor.pos.focus, newFlags) addAnnotation VolatileAttr
+      val mval     = newVariable(newName, accessor.pos.focus, newFlags.toLong) addAnnotation VolatileAttr
 
       if (this.isClass)
         mval setInfoAndEnter newInfo
@@ -627,6 +627,8 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       if (!isCompilerUniverse && needsInitialize(isFlagRelated = true, mask = mask)) initialize
       (flags & mask) != 0
     }
+    def hasFlag(mask: Int): Boolean = hasFlag(mask.toLong)
+
     /** Does symbol have ALL the flags in `mask` set? */
     final def hasAllFlags(mask: Long): Boolean = {
       if (!isCompilerUniverse && needsInitialize(isFlagRelated = true, mask = mask)) initialize
@@ -2967,7 +2969,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     // a type symbol bound by an existential type, for instance the T in
     // List[T] forSome { type T }
     override def isExistentialSkolem = this hasFlag EXISTENTIAL
-    override def isGADTSkolem        = this hasAllFlags GADT_SKOLEM_FLAGS
+    override def isGADTSkolem        = this hasAllFlags GADT_SKOLEM_FLAGS.toLong
     override def isTypeSkolem        = this hasFlag PARAM
     override def isAbstractType      = this hasFlag DEFERRED
 

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -944,6 +944,7 @@ trait Trees extends api.Trees { self: SymbolTable =>
       if (flags1 == flags) this
       else Modifiers(flags1, privateWithin, annotations) setPositions positions
     }
+    def | (flag: Int): Modifiers = this | flag.toLong
     def | (flag: Long): Modifiers = {
       val flags1 = flags | flag
       if (flags1 == flags) this

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -961,7 +961,7 @@ trait Types
       var sym: Symbol = NoSymbol
       var e: ScopeEntry = decls.lookupEntry(name)
       while (e ne null) {
-        if (!e.sym.hasFlag(excludedFlags)) {
+        if (!e.sym.hasFlag(excludedFlags.toLong)) {
           if (sym == NoSymbol) sym = e.sym
           else {
             if (alts.isEmpty) alts = sym :: Nil

--- a/src/reflect/scala/reflect/internal/pickling/ByteCodecs.scala
+++ b/src/reflect/scala/reflect/internal/pickling/ByteCodecs.scala
@@ -128,7 +128,7 @@ object ByteCodecs {
     var j = 0
     val dstlen = (srclen * 7 + 7) / 8
     while (i + 7 < srclen) {
-      var out: Int = src(i)
+      var out: Int = src(i).toInt
       var in: Byte = src(i + 1)
       src(j) = (out | (in & 0x01) << 7).toByte
       out = in >>> 1
@@ -153,7 +153,7 @@ object ByteCodecs {
       j += 7
     }
     if (i < srclen) {
-      var out: Int = src(i)
+      var out: Int = src(i).toInt
       if (i + 1 < srclen) {
         var in: Byte = src(i + 1)
         src(j) = (out | (in & 0x01) << 7).toByte; j += 1

--- a/src/reflect/scala/reflect/internal/pickling/PickleBuffer.scala
+++ b/src/reflect/scala/reflect/internal/pickling/PickleBuffer.scala
@@ -94,7 +94,7 @@ class PickleBuffer(data: Array[Byte], from: Int, to: Int) {
 
   /** Read a byte */
   def readByte(): Int = {
-    val x = bytes(readIndex); readIndex += 1; x
+    val x = bytes(readIndex).toInt; readIndex += 1; x
   }
 
   /** Read a natural number in big endian format, base 128.
@@ -105,7 +105,7 @@ class PickleBuffer(data: Array[Byte], from: Int, to: Int) {
     var b = 0L
     var x = 0L
     do {
-      b = readByte()
+      b = readByte().toLong
       x = (x << 7) + (b & 0x7f)
     } while ((b & 0x80) != 0L)
     x

--- a/src/reflect/scala/reflect/internal/util/Statistics.scala
+++ b/src/reflect/scala/reflect/internal/util/Statistics.scala
@@ -103,8 +103,8 @@ quant)
     for ((_, q) <- qs if q.underlying == q;
          r <- q :: q.children.toList if r.prefix.nonEmpty) yield r
 
-  private def showPercent(x: Double, base: Double) =
-    if (base == 0) "" else f" (${x / base * 100}%2.1f%%)"
+  private def showPercent(x: Long, base: Long) =
+    if (base == 0) "" else f" (${x.toDouble / base.toDouble * 100}%2.1f%%)"
 
   /** The base trait for quantities.
    *  Quantities with non-empty prefix are printed in the statistics info.
@@ -156,7 +156,7 @@ quant)
       value = value0 + underlying.value - uvalue0
     }
     override def toString =
-      value + showPercent(value, underlying.value)
+      value + showPercent(value.toLong, underlying.value.toLong)
   }
 
   class Timer(val prefix: String, val phases: Seq[String]) extends Quantity {

--- a/src/scaladoc/scala/tools/nsc/doc/html/SyntaxHigh.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/SyntaxHigh.scala
@@ -260,8 +260,8 @@ private[html] object SyntaxHigh {
             parse(buf(i).toChar.toString, i+1)
         case _ =>
           if (i == 0 || (i >= 1 && !Character.isJavaIdentifierPart(buf(i-1).toChar))) {
-            if (Character.isDigit(buf(i)) ||
-                (buf(i) == '.' && i + 1 < buf.length && Character.isDigit(buf(i+1)))) {
+            if (Character.isDigit(buf(i).toInt) ||
+                (buf(i) == '.' && i + 1 < buf.length && Character.isDigit(buf(i+1).toInt))) {
               val s = numlit(i)
               parse("<span class=\"num\">"+s+"</span>", i+s.length)
             } else {

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/diagram/DotRunner.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/diagram/DotRunner.scala
@@ -98,7 +98,7 @@ class DotProcess(settings: doc.Settings) {
       assert(!inputString.isSet)
       assert(!outputString.isSet)
       inputString.put(input)
-      var result = outputString.take(settings.docDiagramsDotTimeout.value * 1000)
+      var result = outputString.take(settings.docDiagramsDotTimeout.value * 1000L)
       if (error) result = null
 
       result

--- a/src/scalap/scala/tools/scalap/Classfile.scala
+++ b/src/scalap/scala/tools/scalap/Classfile.scala
@@ -32,7 +32,7 @@ class Classfile(in: ByteArrayReader) {
     var attribs: List[Attribute] = Nil
     var i = 0
     while (i < n) {
-      attribs = Attribute(in.nextChar, in.nextBytes(in.nextInt)) :: attribs
+      attribs = Attribute(in.nextChar.toInt, in.nextBytes(in.nextInt)) :: attribs
       i = i + 1
     }
     attribs
@@ -43,7 +43,7 @@ class Classfile(in: ByteArrayReader) {
     var members: List[Member] = Nil
     var i = 0
     while (i < n) {
-      members = Member(field, in.nextChar, in.nextChar, in.nextChar, readAttribs) :: members
+      members = Member(field, in.nextChar.toInt, in.nextChar.toInt, in.nextChar.toInt, readAttribs) :: members
       i = i + 1
     }
     members
@@ -54,7 +54,7 @@ class Classfile(in: ByteArrayReader) {
     var intfs: List[Int] = Nil
     var i = 0
     while (i < n) {
-      intfs = in.nextChar :: intfs
+      intfs = in.nextChar.toInt :: intfs
       i = i + 1
     }
     intfs
@@ -81,7 +81,7 @@ class Classfile(in: ByteArrayReader) {
     case object Empty extends PoolEntry(0) { }
 
     val entries = {
-      val pool = new Array[PoolEntry](in.nextChar)
+      val pool = new Array[PoolEntry](in.nextChar.toInt)
       var i = 1
       while (i < pool.length) {
         val tag = in.nextByte
@@ -92,7 +92,7 @@ class Classfile(in: ByteArrayReader) {
           pool(i) = Empty
         }
         else pool(i) = tag match {
-          case CONSTANT_UTF8            => UTF8(in.nextUTF8(in.nextChar))
+          case CONSTANT_UTF8            => UTF8(in.nextUTF8(in.nextChar.toInt))
           case CONSTANT_UNICODE         => in.skip(in.nextChar) ; Empty
           case CONSTANT_CLASS           => ClassRef(in.nextChar)
           case CONSTANT_STRING          => StringConst(in.nextChar)

--- a/src/scalap/scala/tools/scalap/CodeWriter.scala
+++ b/src/scalap/scala/tools/scalap/CodeWriter.scala
@@ -98,9 +98,9 @@ class CodeWriter(writer: Writer) {
 
   def print(value: Boolean): CodeWriter = print(String.valueOf(value))
 
-  def print(value: Byte): CodeWriter = print(String.valueOf(value))
+  def print(value: Byte): CodeWriter = print(String.valueOf(value.toInt))
 
-  def print(value: Short): CodeWriter = print(String.valueOf(value))
+  def print(value: Short): CodeWriter = print(String.valueOf(value.toInt))
 
   def print(value: Char): CodeWriter = print(String.valueOf(value))
 

--- a/src/swing/scala/swing/Component.scala
+++ b/src/swing/scala/swing/Component.scala
@@ -83,9 +83,9 @@ abstract class Component extends UIElement {
    * Used by certain layout managers, e.g., BoxLayout or OverlayLayout to
    * align components relative to each other.
    */
-  def xLayoutAlignment: Double = peer.getAlignmentX
+  def xLayoutAlignment: Double = peer.getAlignmentX.toDouble
   def xLayoutAlignment_=(x: Double) = peer.setAlignmentX(x.toFloat)
-  def yLayoutAlignment: Double = peer.getAlignmentY
+  def yLayoutAlignment: Double = peer.getAlignmentY.toDouble
   def yLayoutAlignment_=(y: Double) = peer.setAlignmentY(y.toFloat)
 
   def border: Border = peer.getBorder


### PR DESCRIPTION
Optimistically, this is preparation for a day when we don't let numeric types
drift with the winds. Even without the optimism it's a good idea. I found a
couple bugs in the process - how many people would see this one coming without
compiler help. One of these methods has an inappropriately wide return type.

  def signum(x: Int): Int       = java.lang.Integer.signum(x)
 def signum(x: Long): Long     = java.lang.Long.signum(x)
 def signum(x: Float): Float   = java.lang.Math.signum(x)
 def signum(x: Double): Double = java.lang.Math.signum(x)

Managing type coercions manually is a bit tedious, no doubt, but it's not
tedious enough to warrant abandoning type safety just because java did it.
