### PR TITLE
SI-7519 Less brutal attribute resetting in adapt fallback

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -833,8 +833,9 @@ trait Typers extends Adaptations with Tags {
                 else tpr.typed(withImplicitArgs, mode, pt)
               }
               orElse { _ =>
-                debuglog("fallback on implicits: " + tree + "/" + resetAllAttrs(original))
-                val tree1 = typed(resetAllAttrs(original), mode)
+                val resetTree = resetLocalAttrs(original)
+                debuglog(s"fallback on implicits: ${tree}/$resetTree")
+                val tree1 = typed(resetTree, mode)
                 // Q: `typed` already calls `pluginsTyped` and `adapt`. the only difference here is that
                 // we pass `EmptyTree` as the `original`. intended? added in 2009 (53d98e7d42) by martin.
                 tree1 setType pluginsTyped(tree1.tpe, this, tree1, mode, pt)

--- a/test/files/neg/t7519.check
+++ b/test/files/neg/t7519.check
@@ -1,0 +1,7 @@
+t7519.scala:5: error: could not find implicit value for parameter nada: Nothing
+    locally(0 : String) // was: "value conversion is not a member of C.this.C"
+            ^
+t7519.scala:15: error: could not find implicit value for parameter nada: Nothing
+      locally(0 : String) // was: "value conversion is not a member of U"
+              ^
+two errors found

--- a/test/files/neg/t7519.scala
+++ b/test/files/neg/t7519.scala
@@ -1,0 +1,18 @@
+class C {
+  implicit def conversion(m: Int)(implicit nada: Nothing): String = ???
+
+  class C { // rename class to get correct error, can't find implicit: Nothing.
+    locally(0 : String) // was: "value conversion is not a member of C.this.C"
+  }
+}
+
+object Test2 {
+  trait T; trait U
+  new T {
+    implicit def conversion(m: Int)(implicit nada: Nothing): String = ???
+
+    new U { // nested anonymous classes also share a name.
+      locally(0 : String) // was: "value conversion is not a member of U"
+    }
+  }
+}


### PR DESCRIPTION
Prefers `resetLocalAttrs` over `resetAllAttrs`. The latter loses
track of which enclosing class of the given name is referenced by
a `This` node which prefixes the an applied implicit view.

The code that `resetAllAttrs` originally landed in: https://github.com/scala/scala/commit/d4c63b#L6R804

Review by @xeno-by. Let's run it by @odersky, too.

I wonder: when would a `resetAllAttrs` _ever_ be appropriate?
