### PR TITLE
Print raw types correctly.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -273,7 +273,8 @@ trait Implicits {
   /** An extractor for types of the form ? { name: (? >: argtpe <: Any*)restp }
    */
   object HasMethodMatching {
-    val dummyMethod = NoSymbol.newTermSymbol(newTermName("typer$dummy"))
+    val dummyMethod = NoSymbol.newTermSymbol("typer$dummy") setInfo NullaryMethodType(AnyTpe)
+
     def templateArgType(argtpe: Type) = new BoundedWildcardType(TypeBounds.lower(argtpe))
 
     def apply(name: Name, argtpes: List[Type], restpe: Type): Type = {

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -604,8 +604,10 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
           def stubImplementations: List[String] = {
             // Grouping missing methods by the declaring class
             val regrouped = missingMethods.groupBy(_.owner).toList
-            def membersStrings(members: List[Symbol]) =
-              members.sortBy("" + _.name) map (m => m.defStringSeenAs(clazz.tpe memberType m) + " = ???")
+            def membersStrings(members: List[Symbol]) = {
+              members foreach fullyInitializeSymbol
+              members.sortBy(_.name) map (m => m.defStringSeenAs(clazz.tpe_* memberType m) + " = ???")
+            }
 
             if (regrouped.tail.isEmpty)
               membersStrings(regrouped.head._2)

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -207,13 +207,17 @@ trait Definitions extends api.StandardDefinitions {
      */
     def fullyInitializeSymbol(sym: Symbol): Symbol = {
       sym.initialize
+      // Watch out for those darn raw types on method parameters
+      if (sym.owner.initialize.isJavaDefined)
+        sym.cookJavaRawInfo()
+
       fullyInitializeType(sym.info)
       fullyInitializeType(sym.tpe_*)
       sym
     }
     def fullyInitializeType(tp: Type): Type = {
       tp.typeParams foreach fullyInitializeSymbol
-      tp.paramss.flatten foreach fullyInitializeSymbol
+      mforeach(tp.paramss)(fullyInitializeSymbol)
       tp
     }
     def fullyInitializeScope(scope: Scope): Scope = {

--- a/test/files/neg/raw-types-stubs.check
+++ b/test/files/neg/raw-types-stubs.check
@@ -1,0 +1,11 @@
+S_3.scala:1: error: class Sub needs to be abstract, since:
+it has 2 unimplemented members.
+/** As seen from class Sub, the missing signatures are as follows.
+ *  For convenience, these are usable as stub implementations.
+ */
+  def raw(x$1: M_1[_ <: String]): Unit = ???
+  def raw(x$1: Any): Unit = ???
+
+class Sub extends Raw_2 { }
+      ^
+one error found

--- a/test/files/neg/raw-types-stubs/M_1.java
+++ b/test/files/neg/raw-types-stubs/M_1.java
@@ -1,0 +1,3 @@
+public class M_1<K extends String> { }
+
+

--- a/test/files/neg/raw-types-stubs/Raw_2.java
+++ b/test/files/neg/raw-types-stubs/Raw_2.java
@@ -1,0 +1,4 @@
+public abstract class Raw_2 {
+  public abstract void raw(Object list);
+  public abstract void raw(M_1 list);
+}

--- a/test/files/neg/raw-types-stubs/S_3.scala
+++ b/test/files/neg/raw-types-stubs/S_3.scala
@@ -1,0 +1,1 @@
+class Sub extends Raw_2 { }


### PR DESCRIPTION
The "For convenience, these are usable as stub implementations" bit has
generated surprisingly few angry letters, but I noticed today it blows it on
raw types. Or, used to blow it.

``` scala
  /** As seen from class Sub, the missing signatures are as follows.
  *  For convenience, these are usable as stub implementations.
  *  (First one before this commitw as 'def raw(x$1: M_1)'
  */

  def raw(x$1: M_1[_ <: String]): Unit = ???
  def raw(x$1: Any): Unit = ???
```
