### PR TITLE
A test case for a recent LUB progression.

### DIFF
--- a/test/files/pos/lub-dealias-widen.scala
+++ b/test/files/pos/lub-dealias-widen.scala
@@ -1,0 +1,34 @@
+import scala.language.higherKinds
+
+sealed trait Path {
+  type EncodeFunc
+  type Route[R] = List[String] => R
+
+  def >>(f: Route[Int]): Sitelet[EncodeFunc] = ???
+}
+
+case object PAny extends Path {
+  type EncodeFunc = List[String] => String
+}
+
+case class PLit[Next <: Path]() extends Path {
+  type EncodeFunc = Next#EncodeFunc
+}
+
+trait Sitelet[EncodeFunc] { self =>
+  def &[G <: H, H >: EncodeFunc](that: Sitelet[G]): Sitelet[H] = ???
+}
+
+object Test {
+  val r: Sitelet[Int => (Int => String)] = ???
+
+  val p2: PLit[PAny.type] = ???
+  val r2 /*: Sitelet[List[String] => String] */ // annotate type and it compiles with 2.10.0
+     = p2 >> { (xs: List[String]) => 0 }
+
+  // This works after https://github.com/scala/scala/commit/a06d31f6a
+  // Before: error: inferred type arguments [List[String] => String,List[String] => String] 
+  //         do not conform to method &'s type parameter bounds
+  //         [G <: H,H >: Int => (Int => String)]
+  val s = r & r2
+}


### PR DESCRIPTION
A test distilled from a Lift example that compiles correctly
under 2.10.1, but not under 2.10.0.

I pinpointed the progression to:

  https://github.com/scala/scala/commit/a06d31f6#L0R6611

Chalk up another win for `dealiasWiden`.

Review by @lrytz

Thanks to @nafg for the [example](https://gist.github.com/nafg/c701f7757c55a24a7db3).
