### PR TITLE
SI-7517 Fix higher kinded type inference regression

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3218,10 +3218,9 @@ trait Types extends api.Types { self: SymbolTable =>
           sameLength(typeArgs, tp.typeArgs) && {
             val lhs = if (isLowerBound) tp.typeArgs else typeArgs
             val rhs = if (isLowerBound) typeArgs else tp.typeArgs
-            // this is a higher-kinded type var with same arity as tp.
-            // side effect: adds the type constructor itself as a bound
-            addBound(tp.typeConstructor)
-            isSubArgs(lhs, rhs, params, AnyDepth)
+            // This is a higher-kinded type var with same arity as tp.
+            // If so (see SI-7517), side effect: adds the type constructor itself as a bound.
+            isSubArgs(lhs, rhs, params, AnyDepth) && { addBound(tp.typeConstructor); true }
           }
         }
         // The type with which we can successfully unify can be hidden

--- a/test/files/pos/t7517.scala
+++ b/test/files/pos/t7517.scala
@@ -1,0 +1,22 @@
+trait Box[ K[A[x]] ]
+
+object Box {
+   // type constructor composition
+   sealed trait ∙[A[_], B[_]] { type l[T] = A[B[T]] }
+
+   // composes type constructors inside K
+   type SplitBox[K[A[x]], B[x]] = Box[ ({ type l[A[x]] = K[ (A ∙ B)#l] })#l ]
+
+   def split[ K[A[x]], B[x] ](base: Box[K]): SplitBox[K,B] = ???
+
+   class Composed[B[_], L[A[x]] ] {
+      val box: Box[L] = ???
+
+      type Split[ A[x] ] = L[ (A ∙ B)#l ]
+      val a: Box[Split] = Box.split(box)
+
+      //Either of these work:
+      val a1: Box[Split] = Box.split[L,B](box)
+      val a2: Box[ ({ type l[A[x]] = L[ (A ∙ B)#l ] })#l ] = Box.split(box)
+   }
+}


### PR DESCRIPTION
- Discovered in 2.10.2-RC1
- Ostensibly regressed in 7e52fb910b, which conceptually reverted
  part of 0cde930b so that (mutable) TypeVars don't use structural equality.
- But, does _not_ fail if 7e52fb910b is cherry-picked directly after 0cde930b,
  suggesting that it shone a light on a behaviour change in some other commit
  in between the two.
- Indeed, the true regression came in https://github.com/scala/scala/commit/e5da30b843#L5L3176
- A targeted revert of e5da30b843 is undesirable, as we'd like SI-6846 to stay fixed

What's happening here? In the enclosed test case, higher kinded type
inference explores two possibilities:

```
Composed.this.Split[A]
K[[T]A[B[T]]]           // `Split[A]` dealiased
```

The difference in the flow of type inference can be seen from the diff
below. Notice how now we no longer register `?K.addBound(Composed.this.Split)`,
we instead only register `?K.addBound(K)`

Review by @adriaanm @paulp

``` patch
--- sandbox/old.log 2013-05-30 00:27:34.000000000 +0200
+++ sandbox/new.log 2013-05-30 00:28:28.000000000 +0200
@@ -1,55 +1,114 @@
 ?K.unifyFull(Composed.this.Split[A])
   ?K.unifySpecific(Composed.this.Split[A])
-  ?K.addBound(Composed.this.Split)
     ?B.unifyFull(T)
       ?B.unifySpecific(T)
       `-> false
     ?B.unifyFull(Any)
       ?B.unifySpecific(Any)
       `-> false
   `-> false
   ?K.unifySpecific(L[[T]A[B[T]]])
-  ?K.addBound(L)
     ?B.unifyFull(B[T])
       ?B.unifySpecific(B[T])
       ?B.addBound(B)
       `-> true
     ?B.unifyFull(B[T])
       ?B.unifySpecific(B[T])
       ?B.addBound(B)
       `-> true
     ?B.unifyFull(B[T])
       ?B.unifySpecific(B[T])
       ?B.addBound(B)
       `-> true
     ?B.unifyFull(B[T])
       ?B.unifySpecific(B[T])
       ?B.addBound(B)
       `-> true
+  ?K.addBound(L)
   `-> true
 ?K.unifyFull(Composed.this.Split[A])
   ?K.unifySpecific(Composed.this.Split[A])
-  ?K.addBound(Composed.this.Split)
     ?B.unifyFull(x)
       ?B.unifySpecific(x)
       `-> false
   `-> false
   ?K.unifySpecific(L[[T]A[B[T]]])
+    ?B.unifyFull(B[T])
+      ?B.unifySpecific(B[T])
+      ?B.addBound(B)
+      `-> true
+    ?B.unifyFull(B[T])
+      ?B.unifySpecific(B[T])
+      ?B.addBound(B)
+      `-> true
+    ?B.unifyFull(B[T])
+      ?B.unifySpecific(B[T])
+      ?B.addBound(B)
+      `-> true
+    ?B.unifyFull(B[T])
+      ?B.unifySpecific(B[T])
+      ?B.addBound(B)
+      `-> true
   ?K.addBound(L)
+  `-> true
+?K.unifyFull(Composed.this.Split[A])
+  ?K.unifySpecific(Composed.this.Split[A])
+    ?B.unifyFull(T)
+      ?B.unifySpecific(T)
+      `-> false
+    ?B.unifyFull(Any)
+      ?B.unifySpecific(Any)
+      `-> false
+  `-> false
+  ?K.unifySpecific(L[[T]A[B[T]]])
     ?B.unifyFull(B[T])
       ?B.unifySpecific(B[T])
       ?B.addBound(B)
       `-> true
     ?B.unifyFull(B[T])
       ?B.unifySpecific(B[T])
       ?B.addBound(B)
       `-> true
     ?B.unifyFull(B[T])
       ?B.unifySpecific(B[T])
       ?B.addBound(B)
       `-> true
     ?B.unifyFull(B[T])
       ?B.unifySpecific(B[T])
       ?B.addBound(B)
       `-> true
+  ?K.addBound(L)
+  `-> true
+?K.unifyFull(Composed.this.Split[A])
+  ?K.unifySpecific(Composed.this.Split[A])
+    ?B.unifyFull(x)
+      ?B.unifySpecific(x)
+      `-> false
+  `-> false
+  ?K.unifySpecific(L[[T]A[B[T]]])
+    ?B.unifyFull(B[T])
+      ?B.unifySpecific(B[T])
+      ?B.addBound(B)
+      `-> true
+    ?B.unifyFull(B[T])
+      ?B.unifySpecific(B[T])
+      ?B.addBound(B)
+      `-> true
+    ?B.unifyFull(B[T])
+      ?B.unifySpecific(B[T])
+      ?B.addBound(B)
+      `-> true
+    ?B.unifyFull(B[T])
+      ?B.unifySpecific(B[T])
+      ?B.addBound(B)
+      `-> true
+  ?K.addBound(L)
+  `-> true
+?K.unifyFull(L[A])
+  ?K.unifySpecific(L[A])
+  ?K.addBound(L)
+  `-> true
+?K.unifyFull(L[A])
+  ?K.unifySpecific(L[A])
+  ?K.addBound(L)
   `-> true
```
