### PR TITLE
SI-7532 Fix regression in Java inner classfile reader

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -44,8 +44,6 @@ abstract class ClassfileParser {
 
   def srcfile = srcfile0
 
-  private def currentIsTopLevel = !(currentClass.decodedName containsChar '$')
-
   private object unpickler extends scala.reflect.internal.pickling.UnPickler {
     val global: ClassfileParser.this.global.type = ClassfileParser.this.global
   }
@@ -515,8 +513,10 @@ abstract class ClassfileParser {
       }
     }
 
-    val c = if (currentIsTopLevel) pool.getClassSymbol(nameIdx) else clazz
-    if (currentIsTopLevel) {
+    val isTopLevel = !(currentClass containsChar '$') // Java class name; *don't* try to to use Scala name decoding (SI-7532)
+
+    val c = if (isTopLevel) pool.getClassSymbol(nameIdx) else clazz
+    if (isTopLevel) {
       if (c != clazz) {
         if ((clazz eq NoSymbol) && (c ne NoSymbol)) clazz = c
         else mismatchError(c)

--- a/test/files/pos/t7532/A_1.java
+++ b/test/files/pos/t7532/A_1.java
@@ -1,0 +1,6 @@
+class R {
+	public class attr { // Will have the bytecode name `R$attr`, not to be confused with `R@tr`!
+	}
+	public static class attr1 {
+	}
+}

--- a/test/files/pos/t7532/B_2.scala
+++ b/test/files/pos/t7532/B_2.scala
@@ -1,0 +1,5 @@
+object Test {
+  val r = new R
+  new r.attr() // Was: error while loading attr, class file '.../t7532-pos.obj/R$attr.class' has location not matching its contents: contains class
+  new R.attr1
+}

--- a/test/files/pos/t7532b/A_1.scala
+++ b/test/files/pos/t7532b/A_1.scala
@@ -1,0 +1,7 @@
+package pack
+class R {
+	class attr // Will have the bytecode name `R$attr`, not to be confused with `R@tr`!
+	class `@`
+}
+
+class `@`

--- a/test/files/pos/t7532b/B_2.scala
+++ b/test/files/pos/t7532b/B_2.scala
@@ -1,0 +1,8 @@
+import pack._
+
+object Test {
+  val r = new R
+  new r.attr()
+  new r.`@`
+  new `@`
+}


### PR DESCRIPTION
395e90a modified the detection of top-level classes in
ClassfileParser in two ways:
1. used `Name#containsChar` rather than `toString.indexOf ...` (good!)
2. decoded the name before doing this check (bad!)

That code is actually only run for non-Scala classfiles, whose
names don't need decoding. Attempting to do so converted `R$attr`
to `R@tr`, which no longer contains a '$', and was wrongly treated
as a top level class.

This commit reverts the use of `decodedName`, and inlines the method
to its only call site for clarity.

Review by @paulp and @JamesIry (for 2.10.2-RC2 inclusion)
