### PR TITLE
SI-7507 Fix lookup of private[this] member in presence of self type.

### DIFF
--- a/test/files/neg/t7507.check
+++ b/test/files/neg/t7507.check
@@ -1,0 +1,4 @@
+t7507.scala:6: error: value bippy in trait Cake cannot be accessed in Cake
+  locally(bippy)
+          ^
+one error found

--- a/test/files/neg/t7507.scala
+++ b/test/files/neg/t7507.scala
@@ -1,0 +1,7 @@
+trait Cake extends Slice {
+  private[this] val bippy = ()
+}
+
+trait Slice { self: Cake =>
+  locally(bippy)
+}

--- a/test/files/run/t7507.scala
+++ b/test/files/run/t7507.scala
@@ -1,0 +1,31 @@
+trait Cake extends Slice
+
+// Minimization
+trait Slice { self: Cake =>    // must have self type that extends `Slice`
+  private[this] val bippy = () // must be private[this]
+  locally(bippy)
+}
+
+// Originally reported bug:
+trait Cake1 extends Slice1
+trait Slice1 { self: Cake1 =>
+  import java.lang.String // any import will do!
+  val Tuple2(x, y) = ((1, 2))
+}
+
+
+// Nesting
+trait Cake3 extends Outer.Slice3
+
+// Minimization
+object Outer {
+  private[this] val bippy = ()
+  trait Slice3 { self: Cake3 =>
+    locally(bippy)
+  }
+}
+
+object Test extends App {
+  val s1 = new Cake1 {}
+  assert((s1.x, s1.y) == (1, 2), (s1.x, s1.y))
+}


### PR DESCRIPTION
In the following code:

```
trait Cake extends Slice

trait Slice { self: Cake =>    // must have self type that extends `Slice`
  private[this] val bippy = () // must be private[this]
  locally(bippy)
}
```

`ThisType(<Slice>).findMember(bippy)` excluded the private local member on
the grounds that the first class in the base type sequence, `Cake`, was
not contained in `Slice`.

```
scala> val thisType = typeOf[Slice].typeSymbol.thisType
thisType: $r.intp.global.Type = Slice.this.type

scala> thisType.baseClasses
res6: List[$r.intp.global.Symbol] = List(trait Cake, trait Slice, class Object, class Any)
```

This commit changes `findMember` to use the symbol of the `ThisType`, rather
than the first base class, as the location of the selection.

Review by @paulp
