### PR TITLE
SI-7498 ParTrieMap.foreach no longer crashes

### DIFF
--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -1012,8 +1012,11 @@ private[collection] class TrieMapIterator[K, V](var level: Int, private var ct: 
    */
   protected def subdivide(): Seq[Iterator[(K, V)]] = if (subiter ne null) {
     // the case where an LNode is being iterated
-    val it = subiter
-    subiter = null
+    val it = newIterator(level + 1, ct, _mustInit = false)
+    it.depth = -1
+    it.subiter = this.subiter
+    it.current = null
+    this.subiter = null
     advance()
     this.level += 1
     Seq(it, this)

--- a/test/files/run/t7498.scala
+++ b/test/files/run/t7498.scala
@@ -1,0 +1,20 @@
+
+
+
+
+
+
+
+object Test extends App {
+  import scala.collection.concurrent.TrieMap
+
+  class Collision(val idx: Int) {
+    override def hashCode = idx % 10
+  }
+
+  val tm = TrieMap[Collision, Unit]()
+  for (i <- 0 until 1000) tm(new Collision(i)) = ()
+
+  tm.par.foreach(kv => ())
+}
+


### PR DESCRIPTION
Previously, the `split` method of the `ParTrieMap` iterator threw
an exception when splitting a splitter that iterated over nodes
whose hash codes collide.
This was due to reusing the iterator of the list of colliding keys
rather than creating a new splitter.

This commit changes the `subdivide` method to create a new
iterator using the factory method of the current trie map
iterator rather than returning a `LinearSeqLike` iterator.

Review by @retronym 
