### PR TITLE
SI-7533 Adds Symbol.isAbstract

### DIFF
--- a/src/reflect/scala/reflect/api/Symbols.scala
+++ b/src/reflect/scala/reflect/api/Symbols.scala
@@ -481,6 +481,12 @@ trait Symbols { self: Universe =>
      */
     def isOverride: Boolean
 
+    /** Is this symbol abstract (i.e. an abstract class, an abstract method, value or type member)?
+     *
+     *  @group Tests
+     */
+    def isAbstract: Boolean
+
     /** Is this symbol labelled as "abstract override"?
      *
      *  @group Tests
@@ -744,6 +750,7 @@ trait Symbols { self: Universe =>
      *
      *  @group Type
      */
+    @deprecated("Use isAbstract instead", "2.11.0")
     def isAbstractType : Boolean
 
     /** Does this symbol represent an existentially bound type?
@@ -877,6 +884,7 @@ trait Symbols { self: Universe =>
      *
      *  @group Class
      */
+    @deprecated("Use isAbstract instead", "2.11.0")
     def isAbstractClass: Boolean
 
     /** Does this symbol represent a case class?

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -99,6 +99,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def isJava: Boolean = isJavaDefined
     def isVal: Boolean = isTerm && !isModule && !isMethod && !isMutable
     def isVar: Boolean = isTerm && !isModule && !isMethod && !isLazy && isMutable
+    def isAbstract: Boolean = isAbstractClass || isDeferred || isAbstractType
 
     def newNestedSymbol(name: Name, pos: Position, newFlags: Long, isClass: Boolean): Symbol = name match {
       case n: TermName => newTermSymbol(n, pos, newFlags)

--- a/test/files/run/t7533.check
+++ b/test/files/run/t7533.check
@@ -1,0 +1,30 @@
+Testing Symbol.isAbstract...
+=======class C=======
+class C => true
+constructor C => false
+value x1 => true
+value x2 => false
+value x2 => false
+method y1 => true
+method y2 => false
+type T1 => true
+type T2 => false
+=======trait T=======
+trait T => true
+method $init$ => false
+value z1 => true
+value z2 => false
+value z2 => false
+method w1 => true
+method w2 => false
+type U1 => true
+type U2 => false
+=======class D=======
+class D => false
+constructor D => false
+value x1 => false
+value x1 => false
+method y1 => false
+=======object M=======
+object M => false
+constructor M => false

--- a/test/files/run/t7533.scala
+++ b/test/files/run/t7533.scala
@@ -1,0 +1,38 @@
+import scala.reflect.runtime.universe._
+
+abstract class C {
+  val x1: Int
+  val x2: Int = 2
+  def y1: Int
+  def y2: Int = 2
+  type T1 <: Int
+  type T2 = Int
+}
+trait T {
+  val z1: Int
+  val z2: Int = 2
+  def w1: Int
+  def w2: Int = 2
+  type U1 <: Int
+  type U2 = Int
+}
+class D extends C {
+  val x1 = 3
+  def y1 = 3
+}
+object M
+
+object Test extends App {
+  println("Testing Symbol.isAbstract...")
+  def test[T: TypeTag] = {
+    val sym = typeOf[T].typeSymbol
+    println(s"=======$sym=======")
+    def printAbstract(sym: Symbol) = println(s"$sym => ${sym.isAbstract}")
+    printAbstract(sym)
+    sym.typeSignature.declarations.sorted.foreach(printAbstract)
+  }
+  test[C]
+  test[T]
+  test[D]
+  test[M.type]
+}


### PR DESCRIPTION
Amazingly enough, we've missed the fact that non-type symbols can also
be abstract. Having been enlightened by this, I'm exposing isDeferred
and merging it along with isAbstractType and isAbstractClass into the
unified Symbol.isAbstract method.
