### PR TITLE
SI-7517 type constructors too eagerly normalized.

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3222,7 +3222,7 @@ trait Types
       if (constr.instValid) constr.inst
       // get here when checking higher-order subtyping of the typevar by itself
       // TODO: check whether this ever happens?
-      else if (isHigherKinded) logResult("Normalizing HK $this")(typeFun(params, applyArgs(params map (_.typeConstructor))))
+      else if (isHigherKinded) logResult(s"Normalizing HK $this")(typeFun(params, applyArgs(params map (_.typeConstructor))))
       else super.normalize
     )
     override def typeSymbol = origin.typeSymbol
@@ -3649,7 +3649,7 @@ trait Types
   def existentialAbstraction(tparams: List[Symbol], tpe0: Type): Type =
     if (tparams.isEmpty) tpe0
     else {
-      val tpe      = normalizeAliases(tpe0)
+      val tpe      = tpe0 map (_.dealias)
       val tpe1     = new ExistentialExtrapolation(tparams) extrapolate tpe
       var tparams0 = tparams
       var tparams1 = tparams0 filter tpe1.contains

--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -12,19 +12,6 @@ private[internal] trait TypeMaps {
   self: SymbolTable =>
   import definitions._
 
-  /** Normalize any type aliases within this type (@see Type#normalize).
-    *  Note that this depends very much on the call to "normalize", not "dealias",
-    *  so it is no longer carries the too-stealthy name "deAlias".
-    */
-  object normalizeAliases extends TypeMap {
-    def apply(tp: Type): Type = tp match {
-      case TypeRef(_, sym, _) if sym.isAliasType =>
-        def msg = if (tp.isHigherKinded) s"Normalizing type alias function $tp" else s"Dealiasing type alias $tp"
-        mapOver(logResult(msg)(tp.normalize))
-      case _                                     => mapOver(tp)
-    }
-  }
-
   /** Remove any occurrence of type <singleton> from this type and its parents */
   object dropSingletonType extends TypeMap {
     def apply(tp: Type): Type = {
@@ -389,7 +376,7 @@ private[internal] trait TypeMaps {
         case TypeRef(pre, sym, args) if tparams contains sym =>
           val repl = if (variance.isPositive) dropSingletonType(tp1.bounds.hi) else tp1.bounds.lo
           val count = occurCount(sym)
-          val containsTypeParam = tparams exists (repl contains _)
+          val containsTypeParam = tparams exists repl.contains
           def msg = {
             val word = if (variance.isPositive) "upper" else "lower"
             s"Widened lone occurrence of $tp1 inside existential to $word bound"

--- a/test/files/neg/t2994a.check
+++ b/test/files/neg/t2994a.check
@@ -1,0 +1,7 @@
+t2994a.scala:24: error: kinds of the type arguments (m#a,s) do not conform to the expected kinds of the type parameters (type n,type s) in trait curry.
+m#a's type parameters do not match type n's expected parameters:
+type _'s bounds <: Naturals.NAT are stricter than type _'s declared bounds >: Nothing <: Any, type z's bounds <: Naturals.NAT are stricter than type _'s declared bounds >: Nothing <: Any, s's type parameters do not match type s's expected parameters:
+type _'s bounds <: Naturals.NAT are stricter than type _ (in trait curry)'s declared bounds >: Nothing <: Any
+    type a[s[_ <: NAT] <: NAT, z <: NAT] = n#a[curry[m#a, s]#f, z]
+                                             ^
+one error found

--- a/test/files/neg/t2994a.scala
+++ b/test/files/neg/t2994a.scala
@@ -17,9 +17,11 @@ object Naturals {
   type _5 = SUCC[_4]
   type _6 = SUCC[_5]
 
-  // crashes scala-2.8.0 beta1
+  
+  // crashes scala-2.8.0 beta1  
   trait MUL[n <: NAT, m <: NAT] extends NAT {
-    trait curry[ n[ m[x1 <: NAT], x2 <: NAT], s[x3 <: NAT] ] { type f[z <: NAT] = n[s, z] }
+    trait curry[n[_[_], _], s[_]] { type f[z <: NAT] = n[s, z] }
     type a[s[_ <: NAT] <: NAT, z <: NAT] = n#a[curry[m#a, s]#f, z]
   }
+
 }

--- a/test/files/pos/t2994c.scala
+++ b/test/files/pos/t2994c.scala
@@ -1,0 +1,8 @@
+object Test {
+  trait Bar[X[_]]
+  trait Qux[S[_] <: Bar[S], T]
+  trait Baz[S[_] <: Bar[S]] {
+    type Apply[T] = Qux[S,T]
+  }
+  trait Foo[/**/V[_] <: Bar[V]/**/] extends Bar[Baz[V]#Apply]
+}

--- a/test/files/pos/t7517.scala
+++ b/test/files/pos/t7517.scala
@@ -1,0 +1,22 @@
+trait Box[ K[A[x]] ]
+
+object Box {
+   // type constructor composition
+   sealed trait ∙[A[_], B[_]] { type l[T] = A[B[T]] }
+
+   // composes type constructors inside K
+   type SplitBox[K[A[x]], B[x]] = Box[ ({ type l[A[x]] = K[ (A ∙ B)#l] })#l ]
+
+   def split[ K[A[x]], B[x] ](base: Box[K]): SplitBox[K,B] = ???
+
+   class Composed[B[_], K[A[x]] ] {
+      val box: Box[K] = ???
+
+      type Split[ A[x] ] = K[ (A ∙ B)#l ]
+      val a: Box[Split] = Box.split(box)
+
+      //Either of these work:
+      //val a: Box[Split] = Box.split[K,B](box)
+      //val a: Box[ ({ type l[A[x]] = K[ (A ∙ B)#l ] })#l ] = Box.split(box)
+   }
+}

--- a/test/files/run/t6113.check
+++ b/test/files/run/t6113.check
@@ -1,1 +1,1 @@
-Foo[[X](Int, X)]
+Foo[AnyRef{type l[X] = (Int, X)}#l]

--- a/test/pending/neg/t2994b.scala
+++ b/test/pending/neg/t2994b.scala
@@ -1,0 +1,8 @@
+trait curry[s[_]] { type f = Double }
+
+// a1 and a2 fail to compile, but all three should fail.
+class A {
+  type a1[s[_ <: Int]] = curry[s]
+  type a2[s[_ <: Int]] = curry[s]#f
+  type a3[s[_ <: Int]] = Set[curry[s]#f]
+}

--- a/test/pending/pos/lubbing-aliases.scala
+++ b/test/pending/pos/lubbing-aliases.scala
@@ -1,0 +1,40 @@
+trait outer[cc[x], t] {
+  type M[x]
+  type V
+}
+
+trait Coll[+A]
+trait List[+A] extends Coll[A]
+trait Set[A] extends Coll[A]
+trait Stream[+A] extends Coll[A]
+trait Vector[A] extends Coll[A]
+
+trait Foo[A] {
+  type M1[CC[x]] = outer[CC, A]#V
+  type M2[CC[x]] = M1[CC]
+  type M3[CC[x]] = outer[CC, A]#M[A]
+  type M4[CC[x]] = M3[CC]
+
+  def f1: M1[List]
+  def f2: M2[Set]
+  def f3: M3[Stream]
+  def f4: M4[Vector]
+
+  def g12 = List(f1, f2).head
+  def g13 = List(f1, f3).head
+  def g14 = List(f1, f4).head
+  def g23 = List(f2, f3).head
+  def g24 = List(f2, f4).head
+  def g34 = List(f3, f4).head
+}
+
+trait Bar extends Foo[Int] {
+  class Bippy {
+    def g12 = List(f1, f2).head
+    def g13 = List(f1, f3).head
+    def g14 = List(f1, f4).head
+    def g23 = List(f2, f3).head
+    def g24 = List(f2, f4).head
+    def g34 = List(f3, f4).head
+  }
+}


### PR DESCRIPTION
I think 403eadd0f1 was largely a symptomatic remedy (not that
we shouldn't harden against such outcomes) and that this commit
gets closer to the root causes. The unanticipated change to
test/files/run/t6113.check is like a cry of support from the jury box.

``` diff
-Foo[[X](Int, X)]
+Foo[AnyRef{type l[X] = (Int, X)}#l]
```

We should continue to look upon calls to normalize with grave suspicion.
