### PR TITLE
SI-7264 Initialize owner when searching for companion.

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1391,9 +1391,13 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
     def registerPickle(sym: Symbol): Unit = ()
 
     /** does this run compile given class, module, or case factory? */
+    // NOTE: Early initialized members temporarily typechecked before the enclosing class, see typedPrimaryConstrBody!
+    //       Here we work around that wrinkle by claiming that a top-level, early-initialized member is compiled in
+    //       *every* run. This approximation works because this method is exclusively called with `this` == `currentRun`.
     def compiles(sym: Symbol): Boolean =
       if (sym == NoSymbol) false
       else if (symSource.isDefinedAt(sym)) true
+      else if (sym.isTopLevel && sym.isEarlyInitialized) true
       else if (!sym.isTopLevel) compiles(sym.enclosingTopLevelClass)
       else if (sym.isModuleClass) compiles(sym.sourceModule)
       else false

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1686,8 +1686,13 @@ trait Namers extends MethodSynthesis {
    *  call this method?
    */
   def companionSymbolOf(original: Symbol, ctx: Context): Symbol = {
+    val owner = original.owner
+    // SI-7264 Force the info of owners from previous compilation runs.
+    //         Doing this generally would trigger cycles; that's what we also
+    //         use the lower-level scan through the current Context as a fall back.
+    if (!currentRun.compiles(owner)) owner.initialize
     original.companionSymbol orElse {
-      ctx.lookup(original.name.companionName, original.owner).suchThat(sym =>
+      ctx.lookup(original.name.companionName, owner).suchThat(sym =>
         (original.isTerm || sym.hasModuleFlag) &&
         (sym isCoDefinedWith original)
       )

--- a/test/files/pos/t7264/A_1.scala
+++ b/test/files/pos/t7264/A_1.scala
@@ -1,0 +1,11 @@
+object Foo {
+  object Values {
+    implicit def fromInt(x: Int): Values = ???
+  }
+  trait Values
+}
+final class Foo(name: String) {
+  def bar(values: Foo.Values): Bar = ???
+}
+
+trait Bar

--- a/test/files/pos/t7264/B_2.scala
+++ b/test/files/pos/t7264/B_2.scala
@@ -1,0 +1,7 @@
+object Test {
+  // if the following line is uncommented, things compile
+  // type X = Foo.Values
+  
+
+  def foo(f: Foo) = f.bar(0 /* : Foo.Values */)
+}


### PR DESCRIPTION
From ClassSymbol:

```
protected final def companionModule0: Symbol =
  flatOwnerInfo.decl(name.toTermName).suchThat(sym => sym.isModuleNotMethod && (sym isCoDefinedWith this))

protected final def flatOwnerInfo: Type = {
  if (needsFlatClasses)
    info
  owner.rawInfo
}
```

Note the call to `rawInfo`; in the enclosed test case, that gives
us back an uninitialized type for the module class of `Foo`, and
consequently we don't find the companion for `Foo.Values`.

This commit forces the initialization of the owning symbol if it
was compiled in a prior run.

In addition, it adds a special case to `Run#compiles` for early
initialized symbols, which start out in life with the wrong owner.
As best as I can see, that complexity stems from allowing early
initialized members _without_ return types to be used as value arguments
to the super call, which in turn is needed to infer parent type arguments.
The situation is described a little further in existing comments of
`typedPrimaryConstrBody`.

This bug is essentially another case of SI-6976. See the comments in pull
request of that patch (https://github.com/scala/scala/pull/1910) for
commit archaeology that shows why we're reluctant to force the owner
info more broadly than is done in this commit.

Review by @paulp / @lrytz

This PR is more a suggestion, rather than a final proposal. I lack confidence that the cycles we're afraid of are tested, and the intuition to craft said tests retrospectively.
