### PR TITLE
SI-7364 Allow raw types in parent position in Java sources

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1571,9 +1571,9 @@ trait Typers extends Adaptations with Tags {
         }
         typedType(decodedtpt)
       } else {
-        var supertpt = typedTypeConstructor(decodedtpt)
+        val supertpt = typedTypeConstructor(decodedtpt)
         val supertparams = if (supertpt.hasSymbolField) supertpt.symbol.typeParams else Nil
-        if (supertparams.nonEmpty) {
+        def inferParentTypeArgs: Tree = {
           typedPrimaryConstrBody(templ) {
             val supertpe = PolyType(supertparams, appliedType(supertpt.tpe, supertparams map (_.tpeHK)))
             val supercall = New(supertpe, mmap(argss)(_.duplicate))
@@ -1581,14 +1581,17 @@ trait Typers extends Adaptations with Tags {
             ctor setType supertpe // this is an essential hack, otherwise it will occasionally fail to typecheck
             atPos(supertpt.pos.focus)(supercall)
           } match {
-            case EmptyTree => MissingTypeArgumentsParentTpeError(supertpt)
-            case tpt => supertpt = TypeTree(tpt.tpe) setPos supertpt.pos  // SI-7224: don't .focus positions of the TypeTree of a parent that exists in source
+            case EmptyTree => MissingTypeArgumentsParentTpeError(supertpt); supertpt
+            case tpt       => TypeTree(tpt.tpe) setPos supertpt.pos  // SI-7224: don't .focus positions of the TypeTree of a parent that exists in source
           }
         }
+
+        val supertptWithTargs = if (supertparams.isEmpty || context.unit.isJava) supertpt else inferParentTypeArgs
+
         // this is the place where we tell the typer what argss should be used for the super call
         // if argss are nullary or empty, then (see the docs for `typedPrimaryConstrBody`)
         // the super call dummy is already good enough, so we don't need to do anything
-        if (argssAreTrivial) supertpt else supertpt updateAttachment SuperArgsAttachment(argss)
+        if (argssAreTrivial) supertptWithTargs else supertptWithTargs updateAttachment SuperArgsAttachment(argss)
       }
     }
 

--- a/test/files/pos/t7364/BadList.java
+++ b/test/files/pos/t7364/BadList.java
@@ -1,0 +1,3 @@
+public class BadList extends java.util.ArrayList {
+	public java.util.ArrayList foo() { return null; }
+}

--- a/test/files/pos/t7364/UseIt.scala
+++ b/test/files/pos/t7364/UseIt.scala
@@ -1,0 +1,4 @@
+class UseIt {
+  val list = new BadList
+  list.foo()
+}

--- a/test/files/pos/t7364b/BadList_1.java
+++ b/test/files/pos/t7364b/BadList_1.java
@@ -1,0 +1,3 @@
+public class BadList_1 extends java.util.ArrayList {
+	public java.util.ArrayList foo() { return null; }
+}

--- a/test/files/pos/t7364b/UseIt_2.scala
+++ b/test/files/pos/t7364b/UseIt_2.scala
@@ -1,0 +1,5 @@
+class UseIt {
+  val list = new BadList_1
+  list.foo()
+  list.set(0, list.get(0))
+}


### PR DESCRIPTION
To make this work, this commit simply restricts parent
type argument inference to Scala source files.

The surrounding code has also been refactored to avoid a var.

Review by @xeno-by (last seen in this area in 40063b00)
