### PR TITLE
SI-7558 Fix capture of free local vars in toolbox compiler

### DIFF
--- a/src/reflect/scala/reflect/internal/CapturedVariables.scala
+++ b/src/reflect/scala/reflect/internal/CapturedVariables.scala
@@ -29,7 +29,7 @@ trait CapturedVariables { self: SymbolTable =>
     def refType(valueRef: Map[Symbol, Symbol], objectRefClass: Symbol) =
       if (isPrimitiveValueClass(symClass) && symClass != UnitClass) valueRef(symClass).tpe
       else if (erasedTypes) objectRefClass.tpe
-      else appliedType(objectRefClass, tpe)
+      else appliedType(objectRefClass, tpe1)
     if (vble.hasAnnotation(VolatileAttr)) refType(volatileRefClass, VolatileObjectRefClass)
     else refType(refClass, ObjectRefClass)
   }

--- a/test/files/run/t7558.scala
+++ b/test/files/run/t7558.scala
@@ -1,0 +1,9 @@
+object Test extends App {
+  val cm = reflect.runtime.currentMirror
+  val u = cm.universe
+  import scala.tools.reflect.ToolBox
+  val tb = cm.mkToolBox()
+  val t = { var x = "ab".toList; u.reify { x = x.reverse; x }.tree }
+  val evaluated = tb.eval(t)
+  assert(evaluated == "ba".toList, evaluated)
+}


### PR DESCRIPTION
It was creating an `ObjectRef[<notype>]` because of a small
bug in `capturedVariableType`.

Review by @xeno-by
