### PR TITLE
SI-6308 Specialize methods that have some unspecialized params

### DIFF
--- a/test/files/run/t6308.check
+++ b/test/files/run/t6308.check
@@ -1,0 +1,16 @@
+- Unspecialized type args
+// Specialized
+f1 f1$mIc$sp
+f2 f2$mIc$sp
+f3 f3$mIc$sp
+f4 f4$mIc$sp
+f5 f5$mIc$sp
+
+// Unspecialized type args
+f4(Boolean) f4
+f4(String)  f4
+
+// Ideally these would be specialized
+todo1 todo1
+todo2 todo2
+todo3 todo3

--- a/test/files/run/t6308.scala
+++ b/test/files/run/t6308.scala
@@ -1,0 +1,41 @@
+import scala.{specialized => sp}
+
+object Test {
+  def caller = new Exception().getStackTrace()(1).getMethodName
+  def f1[@sp(Int) A](a: A, b: Any)             = caller
+  def f2[@sp(Int) A, B](a: A, b: String)       = caller
+  def f3[B, @sp(Int) A](a: A, b: List[B])      = caller
+  def f4[B, @sp(Int) A](a: A, b: List[(A, B)]) = caller
+
+  def f5[@sp(Int) A, B <: Object](a: A, b: B)  = caller
+
+  // `uncurryTreeType` calls a TypeMap on the call to this method and we end up with new
+  // type parameter symbols, which are not found in `TypeEnv.includes(typeEnv(member), env)`
+  // in `specSym`. (One of `uncurry`'s tasks is to expand type aliases in signatures.)
+  type T = Object
+  def todo1[@sp(Int) A, B <: T](a: A, b: String)           = caller
+  def todo2[@sp(Int) A, B <: AnyRef](a: A, b: String)      = caller
+  def todo3[B <: List[A], @specialized(Int) A](a: A, b: B) = caller
+
+  def main(args: Array[String]) {
+    val s = ""
+    val result =
+      s"""|- Unspecialized type args
+          |// Specialized
+          |f1 ${f1(1,"some ref")}
+          |f2 ${f2(1,"some ref")}
+          |f3 ${f3(1,List("some ref"))}
+          |f4 ${f4(1,Nil)}
+          |f5 ${f5(1,s)}
+          |
+          |// Unspecialized type args
+          |f4(Boolean) ${f4(Boolean,Nil)}
+          |f4(String)  ${f4("",Nil)}
+          |
+          |// Ideally these would be specialized
+          |todo1 ${todo1(1,s)}
+          |todo2 ${todo2(1,s)}
+          |todo3 ${todo3(1,List(0))}""".stripMargin
+    println(result)
+  }
+}


### PR DESCRIPTION
This is a continuation of 1591c14e50, which didn't go far enough
to handle method calls with a mix of specialized and unspecialized
type parameters.

This commit modifies `specSym` to calculate the residual type
of the original method after specialized type parameters have
been removed and the type environment of the candidate specialized
variant has been subsituted.

For example, here is trace of `specSym` when searcing for the
specialized variant of `f4` in the enclosed test:

```
tree             = Main.this.f4[Nothing, Int]
tree.tpe         = (a: Int, b: List[(Int, Nothing)])String
fun.tpe          = [B, A](a: A, b: List[(A, B)])String
residualTreeType = [B](a: Int, b: List[(Int, B)])String
memberType       = [B](a: Int, b: List[(Int, B)])String
env              = Map(type A -> Int)
doesConform      = true
```

A few "todo" tests are included that highlight an endemic
issue with the current specialization implementation: type
parameters that show up after `uncurry` might be clones of
the original symbols from typer, if they have been through
a TypeMap (e.g. within a call to `uncurryTreeType`). So testing
them for existence with the `typeEnv` map is fruitless.

No amount of `atPhase` acrobatics can rescue us from this;
we need to transport this information in a symbol-cloning
resiliant manner. Maybe Symbol Attachments?

Review by @vladureche, /cc @d6
