### PR TITLE
SI-6754 Support @tailrec for extension methods.

### DIFF
--- a/test/files/neg/t6574.check
+++ b/test/files/neg/t6574.check
@@ -1,0 +1,7 @@
+t6574.scala:4: error: could not optimize @tailrec annotated method notTailPos$extension: it contains a recursive call not in tail position
+    println("tail")
+    ^
+t6574.scala:8: error: could not optimize @tailrec annotated method differentTypeArgs$extension: it is called recursively with different type arguments
+    {(); new Bad[String, Unit](0)}.differentTypeArgs
+                                   ^
+two errors found

--- a/test/files/neg/t6574.scala
+++ b/test/files/neg/t6574.scala
@@ -1,0 +1,10 @@
+class Bad[X, Y](val v: Int) extends AnyVal {
+  @annotation.tailrec final def notTailPos[Z](a: Int)(b: String) {
+    this.notTailPos[Z](a)(b)
+    println("tail")
+  }
+
+  @annotation.tailrec final def differentTypeArgs {
+    {(); new Bad[String, Unit](0)}.differentTypeArgs
+  }
+}

--- a/test/files/pos/t6574.scala
+++ b/test/files/pos/t6574.scala
@@ -1,0 +1,14 @@
+class Bad[X, Y](val v: Int) extends AnyVal {
+  def vv = v
+  @annotation.tailrec final def foo[Z](a: Int)(b: String) {
+    this.foo[Z](a)(b)
+  }
+
+  @annotation.tailrec final def differentReceiver {
+    {(); new Bad[X, Y](0)}.differentReceiver
+  }
+
+  @annotation.tailrec final def dependent[Z](a: Int)(b: String): b.type = {
+    this.dependent[Z](a)(b)
+  }
+}


### PR DESCRIPTION
- move the annotation from the class method to the extension method.
  - rewrite recursive calls on in the method body to call the extension
    method.

Review by @paulp
