### PR TITLE
taming outer refs: anon-closures that retain fewer heap objects

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -39,7 +39,7 @@ abstract class ExplicitOuter extends InfoTransform
     new ExplicitOuterTransformer(unit)
 
   /** Is given clazz an inner class? */
-  private def isInner(clazz: Symbol) =
+  def isInner(clazz: Symbol) =
     !clazz.isPackageClass && !clazz.outerClass.isStaticOwner
 
   private def haveSameOuter(parent: Type, clazz: Symbol) = {

--- a/test/files/jvm/jump-over-outers/C_1.flags
+++ b/test/files/jvm/jump-over-outers/C_1.flags
@@ -1,0 +1,1 @@
+-Ynooptimise

--- a/test/files/jvm/jump-over-outers/C_1.scala
+++ b/test/files/jvm/jump-over-outers/C_1.scala
@@ -1,0 +1,16 @@
+
+// tests one of the transformations performed in the constructors phase,
+// (shortening navigation-paths over outer-instances to minimize heap retention at runtime)
+
+// The anon-closure below should be emitted not with an outer-field holding a MyActor value
+// but a C_1 value (the nearmost outer-instance that's actually needed, in the example to access field `name`)
+
+class C_1 {
+  var name = "abc"
+  class MyActor {
+    def doSomeWork() {
+      (1 to 10) foreach { i => println(name) }
+    }
+  }
+}
+

--- a/test/files/jvm/jump-over-outers/Test.scala
+++ b/test/files/jvm/jump-over-outers/Test.scala
@@ -1,0 +1,13 @@
+import scala.tools.partest.BytecodeTest
+import scala.collection.JavaConverters._
+
+object Test extends BytecodeTest {
+  def show: Unit = {
+    val classNode = loadClassNode("C_1$MyActor$$anonfun$doSomeWork$1")
+    val cachedField = classNode.fields.asScala.find( f => f.name.startsWith("cachedOuter$") ).get
+    assert(cachedField.desc == "LC_1;")
+    val outerFieldOpt = classNode.fields.asScala.find( f => f.name.startsWith("outer$") )
+    assert(outerFieldOpt.isEmpty)
+  }
+}
+


### PR DESCRIPTION
Original discussion at https://groups.google.com/forum/#!topic/scala-internals/jQiRINTvhZQ

review by @JamesIry or @paulp
