### PR TITLE
SI-2464 Resiliance against missing InnerClass attributes

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -588,10 +588,14 @@ abstract class ClassfileParser {
       // sealed java enums
       if (jflags.isEnum) {
         val enumClass = sym.owner.linkedClassOfClass
-        if (!enumClass.isSealed)
-          enumClass setFlag (SEALED | ABSTRACT)
-
-        enumClass addChild sym
+        enumClass match {
+          case NoSymbol =>
+            devWarning(s"no linked class for java enum $sym in ${sym.owner}. A referencing class file might be missing an InnerClasses entry.")
+          case linked =>
+            if (!linked.isSealed)
+              linked setFlag (SEALED | ABSTRACT)
+            linked addChild sym
+        }
       }
     }
   }

--- a/test/files/run/t2464/Annotated.java
+++ b/test/files/run/t2464/Annotated.java
@@ -1,0 +1,5 @@
+package test;
+
+@Connect(loadStyle = Connect.LoadStyle.EAGER)
+public class Annotated {
+}

--- a/test/files/run/t2464/Connect.java
+++ b/test/files/run/t2464/Connect.java
@@ -1,0 +1,20 @@
+package test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Connect {
+
+    LoadStyle loadStyle() default LoadStyle.EAGER;
+
+    public enum LoadStyle {
+        EAGER,
+        DEFERRED,
+        LAZY
+    }
+}

--- a/test/files/run/t2464/Test.scala
+++ b/test/files/run/t2464/Test.scala
@@ -1,0 +1,35 @@
+import scala.reflect.io.Streamable
+import scala.tools.asm.{ClassWriter, ClassReader}
+import scala.tools.asm.tree.ClassNode
+import scala.tools.partest._
+import scala.tools.partest.BytecodeTest.modifyClassFile
+import java.io.{FileOutputStream, FileInputStream, File}
+
+object Test extends DirectTest {
+  def code = ???
+
+  def compileCode(code: String) = {
+    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
+    compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(code)
+  }
+
+  def app = """
+    object O {
+      new test.Annotated
+    }
+  """
+
+  def show(): Unit = {
+    compileCode(app)
+    modifyClassFile(new File(testOutput.toFile, "test/Annotated.class")) {
+      (cn: ClassNode) =>
+        // As investigated https://issues.scala-lang.org/browse/SI-2464?focusedCommentId=64521&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-64521
+        // classfiles in the wild sometimes lack the required InnerClass attribute for nested enums that
+        // are referenced in an annotation. I don't know what compiler or bytecode processor leaves things
+        // that way, but this test makes sure we don't crash.
+        cn.innerClasses.clear()
+        cn
+    }
+    compileCode(app)
+  }
+}


### PR DESCRIPTION
A classfile in the wild related to Vaadin lacked the InnerClasses
attribute. As such, our class file parser treated a nested enum
class as top-level, which led to a crash when trying to find its
linked module.

More details of the investigation are available in the JIRA comments.

The test introduces a new facility to rewrite classfiles.

This commit turns this situation into a logged warning, rather
than crashing. Code by @paulp, test by yours truly.

Review by @paulp
