### PR TITLE
Document exceptions thrown in some conversion methods of String

### DIFF
--- a/src/library/scala/collection/immutable/StringLike.scala
+++ b/src/library/scala/collection/immutable/StringLike.scala
@@ -222,12 +222,33 @@ self =>
    */
   def r(groupNames: String*): Regex = new Regex(toString, groupNames: _*)
 
+  /**
+   * @throws `java.lang.NumberFormatException` - If the string does not contain a parsable boolean.
+   */
   def toBoolean: Boolean = parseBoolean(toString)
+  /**
+   * @throws `java.lang.NumberFormatException` - If the string does not contain a parsable byte.
+   */
   def toByte: Byte       = java.lang.Byte.parseByte(toString)
+  /**
+   * @throws `java.lang.NumberFormatException` - If the string does not contain a parsable short.
+   */
   def toShort: Short     = java.lang.Short.parseShort(toString)
+  /**
+   * @throws `java.lang.NumberFormatException`  - If the string does not contain a parsable int.
+   */
   def toInt: Int         = java.lang.Integer.parseInt(toString)
+  /**
+   * @throws `java.lang.NumberFormatException`  - If the string does not contain a parsable long.
+   */
   def toLong: Long       = java.lang.Long.parseLong(toString)
+  /**
+   * @throws `java.lang.NumberFormatException` - If the string does not contain a parsable float.
+   */
   def toFloat: Float     = java.lang.Float.parseFloat(toString)
+  /**
+   * @throws `java.lang.NumberFormatException` - If the string does not contain a parsable double.
+   */
   def toDouble: Double   = java.lang.Double.parseDouble(toString)
 
   private def parseBoolean(s: String): Boolean =

--- a/src/library/scala/collection/immutable/StringLike.scala
+++ b/src/library/scala/collection/immutable/StringLike.scala
@@ -223,7 +223,7 @@ self =>
   def r(groupNames: String*): Regex = new Regex(toString, groupNames: _*)
 
   /**
-   * @throws `java.lang.NumberFormatException` - If the string does not contain a parsable boolean.
+   * @throws `java.lang.IllegalArgumentException` - If the string does not contain a parsable boolean.
    */
   def toBoolean: Boolean = parseBoolean(toString)
   /**


### PR DESCRIPTION
It is very frustrating when public facing methods in the Scala Standard library do not document the exceptions that they throw. So instead of bitterly complaining, I will put actions behind my words.
