### PR TITLE
SI-7564 Fix detection of reflective calls on Avian

### DIFF
--- a/test/files/run/t3425b/Base_1.scala
+++ b/test/files/run/t3425b/Base_1.scala
@@ -9,7 +9,7 @@ class ABC extends A with B with C {
   private def reflected = (
     Thread.currentThread.getStackTrace
       takeWhile (_.getMethodName != "main")
-      exists (_.toString contains "java.lang.reflect.")
+      exists (_.toString contains "sun.reflect.")
   )
   lazy val y: PQ = new PQ(reflected)
 }


### PR DESCRIPTION
Base_1.scala checks whether reflection was used by inspecting
the stacktrace and looking for “java.lang.reflect.”.

The stacktrace looks differently on Avian and therefore the
test fails.

This change looks for “sun.reflect.” instead, which seems to
work on OpenJDK and Avian.
