### PR TITLE
SI-6747 Deprecate Range#{numRange,last,terminal}Element{s,}

### DIFF
--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -65,6 +65,7 @@ extends scala.collection.AbstractSeq[Int]
     || (start < end && step < 0)
     || (start == end && !isInclusive)
   )
+  @deprecated("This method will be made private, use `length` instead.", "2.11") 
   final val numRangeElements: Int = {
     if (step == 0) throw new IllegalArgumentException("step cannot be 0.")
     else if (isEmpty) 0
@@ -74,7 +75,9 @@ extends scala.collection.AbstractSeq[Int]
       else len.toInt
     }
   }
+  @deprecated("This method will be made private, use `last` instead.", "2.11")
   final val lastElement     = start + (numRangeElements - 1) * step
+  @deprecated("This method will be made private.", "2.11") 
   final val terminalElement = start + numRangeElements * step
 
   override def last = if (isEmpty) Nil.last else lastElement


### PR DESCRIPTION
There are already better replacements which expose less surprising behaviour.
