### PR TITLE
[backport] relax time constraint in duration-tck.scala (for Windows VMs)

### DIFF
--- a/test/files/jvm/duration-tck.scala
+++ b/test/files/jvm/duration-tck.scala
@@ -176,8 +176,9 @@ object Test extends App {
 
   Thread.sleep(1.second.toMillis)
 
-  { val l = dead.timeLeft; assert(l <= 1.second, s"$l > 1.second") }
-  { val l = dead2.timeLeft; assert(l <= 1.second, s"$l > 1.second") }
+  // unfortunately it can happen that the sleep() returns early without throwing
+  { val l = dead.timeLeft; assert(l <= 1100.millis, s"$l > 1100.millis") }
+  { val l = dead2.timeLeft; assert(l <= 1100.millis, s"$l > 1100.millis") }
 
 
   // test integer mul/div


### PR DESCRIPTION
(cherry picked from commit 3e0fbc0193f0b6f58dc16dae3824677e9902dc7b)

To bring stability to https://scala-webapps.epfl.ch/jenkins/job/scala-nightly-windows-2.10.x/
