### PR TITLE
SI-7571 Allow nesting of anonymous classes in value classes

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1455,8 +1455,8 @@ trait Typers extends Modes with Adaptations with Tags {
               implRestriction(tree, "nested object")
             //see https://issues.scala-lang.org/browse/SI-6444
             //see https://issues.scala-lang.org/browse/SI-6463
-            case _: ClassDef =>
-              implRestriction(tree, "nested class")
+            case cd: ClassDef if !cd.symbol.isAnonymousClass => // Don't warn about partial functions, etc. SI-7571
+              implRestriction(tree, "nested class") // avoiding Type Tests that might check the $outer pointer.
             case Select(sup @ Super(qual, mix), selector) if selector != nme.CONSTRUCTOR && qual.symbol == clazz && mix != tpnme.EMPTY =>
               //see https://issues.scala-lang.org/browse/SI-6483
               implRestriction(sup, "qualified super reference")

--- a/test/files/neg/valueclasses-impl-restrictions.check
+++ b/test/files/neg/valueclasses-impl-restrictions.check
@@ -6,12 +6,8 @@ valueclasses-impl-restrictions.scala:9: error: implementation restriction: neste
 This restriction is planned to be removed in subsequent releases.
   trait I2 {
         ^
-valueclasses-impl-restrictions.scala:15: error: implementation restriction: nested class is not allowed in value class
-This restriction is planned to be removed in subsequent releases.
-    val i2 = new I2 { val q = x.s }
-                 ^
-valueclasses-impl-restrictions.scala:21: error: implementation restriction: nested class is not allowed in value class
+valueclasses-impl-restrictions.scala:23: error: implementation restriction: nested class is not allowed in value class
 This restriction is planned to be removed in subsequent releases.
   private[this] class I2(val q: String)
                       ^
-four errors found
+three errors found

--- a/test/files/neg/valueclasses-impl-restrictions.scala
+++ b/test/files/neg/valueclasses-impl-restrictions.scala
@@ -12,8 +12,10 @@ class X1(val s: String) extends AnyVal {
   }
 
   def y(x: X1) = {
-    val i2 = new I2 { val q = x.s }
+    val i2 = new I2 { val q = x.s } // allowed as of SI-7571
     i2.z
+
+    { case x => x } : PartialFunction[Int, Int] // allowed
   }
 }
 

--- a/test/files/run/t7571.scala
+++ b/test/files/run/t7571.scala
@@ -1,0 +1,12 @@
+class Foo(val a: Int) extends AnyVal {
+  def foo = { {case x => x + a}: PartialFunction[Int, Int]}
+
+  def bar = (new {}).toString
+}
+
+object Test extends App {
+  val x = new Foo(1).foo.apply(2)
+  assert(x == 3, x)
+  val s = new Foo(1).bar
+  assert(s.nonEmpty, s)
+}


### PR DESCRIPTION
5d9cde105e added deep prohibition of nested classes within
a value class. This has the undesirable side effect of
prohibiting partial functions literals in method bodies
of a value class.

The intention of that prohibition was to avoid problems
in code using Type Tests, such as:

```
class C(val inner: A) extends AnyVal {
  class D
}
def foo(a: Any, other: C) = a match { case _ : other.D }
```

Here, the pattern usually checks that `a.$outer == other`.
But that is incongruent with the way that `other` is erased
to `A`.

However, not all nested classes could lead us into this trap.
This commit slightly relaxes the restriction to allow anonymou
classes, which can't appear in a type test.
The test shows that the translation generates working code.

Review by @gkossakowski
