### PR TITLE
revert ace7a61e663e8369cc50e527c990ee4c3751cb89

### DIFF
--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -121,12 +121,14 @@ extends AbstractMap[A, B]
       def hasNext = !self.isEmpty
       def next(): (A,B) =
         if (!hasNext) throw new NoSuchElementException("next on empty iterator")
-        else { val res = (self.key, self.value); self = self.tail; res }
+        else { val res = (self.key, self.value); self = self.next; res }
     }.toList.reverseIterator
 
   protected def key: A = throw new NoSuchElementException("empty map")
   protected def value: B = throw new NoSuchElementException("empty map")
-  override def tail: ListMap[A, B] = throw new NoSuchElementException("empty map")
+  protected def next: ListMap[A, B] = throw new NoSuchElementException("empty map")
+  // Stub to preserve binary compatibility in 2.10, remove it in 2.11.
+  override def tail: ListMap[A, B] = super.tail
 
   /** This class represents an entry in the `ListMap`.
    */
@@ -140,7 +142,7 @@ extends AbstractMap[A, B]
     override def size: Int = size0(this, 0)
 
     // to allow tail recursion and prevent stack overflows
-    @tailrec private def size0(cur: ListMap[A, B1], acc: Int): Int = if (cur.isEmpty) acc else size0(cur.tail, acc + 1)
+    @tailrec private def size0(cur: ListMap[A, B1], acc: Int): Int = if (cur.isEmpty) acc else size0(cur.next, acc + 1)
 
     /** Is this an empty map?
      *
@@ -156,12 +158,11 @@ extends AbstractMap[A, B]
      *  @return     the value associated with the given key.
      */
     override def apply(k: A): B1 = apply0(this, k)
- 
     
     @tailrec private def apply0(cur: ListMap[A, B1], k: A): B1 = 
       if (cur.isEmpty) throw new NoSuchElementException("key not found: "+k)
       else if (k == cur.key) cur.value
-      else apply0(cur.tail, k)  
+      else apply0(cur.next, k)  
 
     /** Checks if this map maps `key` to a value and return the
      *  value if it exists.
@@ -173,7 +174,7 @@ extends AbstractMap[A, B]
 
     @tailrec private def get0(cur: ListMap[A, B1], k: A): Option[B1] =
       if (k == cur.key) Some(cur.value)
-      else if (cur.tail.nonEmpty) get0(cur.tail, k) else None
+      else if (cur.next.nonEmpty) get0(cur.next, k) else None
 
     /** This method allows one to create a new map with an additional mapping
      *  from `key` to `value`. If the map contains already a mapping for `key`,
@@ -202,7 +203,7 @@ extends AbstractMap[A, B]
       var lst: List[(A, B1)] = Nil
       while (cur.nonEmpty) {
         if (k != cur.key) lst ::= ((cur.key, cur.value))
-        cur = cur.tail
+        cur = cur.next
       }
       var acc = ListMap[A, B1]()
       while (lst != Nil) {
@@ -215,6 +216,6 @@ extends AbstractMap[A, B]
     }
 
 
-    override def tail: ListMap[A, B1] = ListMap.this
+    override protected def next: ListMap[A, B1] = ListMap.this
   }
 }

--- a/test/files/run/list_map.scala
+++ b/test/files/run/list_map.scala
@@ -1,0 +1,17 @@
+import scala.collection.immutable.ListMap
+
+object Test {
+  def testHeadTailSync() {
+    val r = 1 to 100
+    var lm = ListMap(r map (i => (i, i)): _*)
+    for (i <- r) {
+      val (j, _) = lm.head
+      assert (j == i, s"$j != $i")
+      lm = lm.tail
+    }
+  }
+
+  def main(args: Array[String]) {
+    testHeadTailSync()
+  }
+}

--- a/test/files/run/t6261.scala
+++ b/test/files/run/t6261.scala
@@ -2,12 +2,6 @@ import scala.collection.immutable._
 
 object Test extends App {
 
-  def test0() {
-    val m=ListMap(1->2,3->4)
-    if(m.tail ne m.tail)
-      println("ListMap.tail uses a builder, so it is not O(1)")
-  }
-
   def test1() {
     // test that a HashTrieMap with one leaf element is not created!
     val x = HashMap.empty + (1->1) + (2->2)
@@ -92,7 +86,7 @@ object Test extends App {
     // StructureTests.printStructure(z)
     require(z.size == 2 && z.contains(a._1) && z.contains(c._1))
   }
-  test0()
+
   test1()
   test2()
   test3()


### PR DESCRIPTION
This change causes head/tail inconsistency as demonstrated in SI-7445.
