### PR TITLE
SI-7433 Fix spurious warning about catching control throwable

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -187,8 +187,14 @@ abstract class UnCurry extends InfoTransform
         val keyDef   = ValDef(key, New(ObjectTpe))
         val tryCatch = Try(body, pat -> rhs)
 
-        for (Try(t, catches, _) <- body ; cdef <- catches ; if treeInfo catchesThrowable cdef)
+        import treeInfo.{catchesThrowable, isSyntheticCase}
+        for {
+          Try(t, catches, _) <- body
+          cdef <- catches
+          if catchesThrowable(cdef) && !isSyntheticCase(cdef)
+        } {
           unit.warning(body.pos, "catch block may intercept non-local return from " + meth)
+        }
 
         Block(List(keyDef), tryCatch)
       }

--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -553,6 +553,12 @@ abstract class TreeInfo {
     })
   )
 
+  /** Is this CaseDef synthetically generated, e.g. by `MatchTranslation.translateTry`? */
+  def isSyntheticCase(cdef: CaseDef) = cdef.pat.exists {
+    case dt: DefTree => dt.symbol.isSynthetic
+    case _           => false
+  }
+
   /** Is this pattern node a catch-all or type-test pattern? */
   def isCatchCase(cdef: CaseDef) = cdef match {
     case CaseDef(Typed(Ident(nme.WILDCARD), tpt), EmptyTree, _) =>

--- a/test/files/pos/t7433.flags
+++ b/test/files/pos/t7433.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t7433.scala
+++ b/test/files/pos/t7433.scala
@@ -1,0 +1,10 @@
+object Test {
+  def foo() {
+    try {
+      for (i <- 1 until 5) return
+    } catch {
+      case _: NullPointerException | _: RuntimeException =>
+        // was: "catch block may intercept non-local return from method check"
+    }
+  }
+}


### PR DESCRIPTION
In the same vein as SI-6994, such warnings should only be run
in the typer phase, and not in later typechecking (usually in
erasure.)

Why? After translation of pattern matching, we end up with:

```
case (ex8 @ _) => {
<synthetic> val x5: Throwable = ex8;
case11(){
  if ({
    case14(){
      if (x5.$isInstanceOf[NullPointerException]())
        matchEnd13(true)
      else
        case15()
    };
    case15(){
      if (x5.$isInstanceOf[RuntimeException]())
        matchEnd13(true)
      else
        case16()
    };
    case16(){
      matchEnd13(false)
    };
    matchEnd13(x: Boolean){
      x
    }
  })
```

Review by @gkossakowski
