### PR TITLE
SI-6622 Emit EnclosingMethod attribute for val-nested classes

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -80,6 +80,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
   }
   protected def originalEnclosingMethod(sym: Symbol): Symbol = {
     if (sym.isMethod || sym == NoSymbol) sym
+    else if (sym.isValue && !sym.isLocal) sym.getter(sym.owner)
     else {
       val owner = originalOwner.getOrElse(sym, sym.rawowner)
       if (sym.isLocalDummy) owner.enclClass.primaryConstructor
@@ -1981,6 +1982,9 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     /** Return the original enclosing method of this symbol. It should return
      *  the same thing as enclMethod when called before lambda lift,
      *  but it preserves the original nesting when called afterwards.
+     *
+     *  If this symbol is enclosed in a field, the getter of that
+     *  field is returned.
      *
      *  @note This method is NOT available in the presentation compiler run. The
      *        originalOwner map is not populated for memory considerations (the symbol

--- a/test/files/run/t6622.check
+++ b/test/files/run/t6622.check
@@ -1,0 +1,10 @@
+ O1.resultVal isMemberClass = false, public void O1$.resultVal()
+class A$1
+ O1.resultDef isMemberClass = false, public void O1$.resultDef()
+class A$2
+ O2.resultVal isMemberClass = false, public void C2.resultVal()
+class $B$1
+ O3.resultDef isMemberClass = false, public void O3$.resultDef()
+class C$1
+ O4.resultDefDefault isMemberClass = false, public java.lang.Object O4$.resultDefDefault$default$1()
+class C$2

--- a/test/files/run/t6622.scala
+++ b/test/files/run/t6622.scala
@@ -1,0 +1,50 @@
+import Test.check
+
+object O1 {
+  lazy val resultVal = {
+    class A
+    check("O1.resultVal", classOf[A])
+  }
+
+  def resultDef = {
+    class A
+    check("O1.resultDef", classOf[A])
+  }
+}
+
+class C2 {
+  val resultVal = {
+    val tmp = {
+      class B
+      check("O2.resultVal", classOf[B])
+    }
+  }
+}
+
+object O3 {
+  def resultDef = {
+    class C
+    check("O3.resultDef", classOf[C])
+  }
+}
+
+object O4 {
+  def resultDefDefault(a: Any = {
+    class C
+    check("O4.resultDefDefault", classOf[C])
+  }) = ();
+}
+
+
+object Test extends App {
+  def check(desc: String, clazz: Class[_]) {
+    println(s" $desc isMemberClass = ${clazz.isMemberClass}, ${clazz.getEnclosingMethod}")
+    println(reflect.runtime.currentMirror.classSymbol(clazz))
+  }
+
+  O1.resultVal
+  O1.resultDef
+  new C2().resultVal
+  O3.resultDef
+  O4.resultDefDefault()
+}


### PR DESCRIPTION
Otherwise, Java reflection reports them as member classes. This
in turn causes Scala reflection to fail to conjure a class symbol
for them.

We use the corresponding getter method as the enclosing method.

Review by @JamesIry, @xeno-by
