### PR TITLE
Add JUnit support

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -137,12 +137,16 @@ TODO:
   <property name="build-quick.dir"         value="${build.dir}/quick"/>
   <property name="build-pack.dir"          value="${build.dir}/pack"/>
   <property name="build-osgi.dir"          value="${build.dir}/osgi"/>
+  <property name="build-junit.dir"         value="${build.dir}/junit"/>
   <property name="build-strap.dir"         value="${build.dir}/strap"/>
   <property name="build-docs.dir"          value="${build.dir}/scaladoc"/>
   <property name="build-sbt.dir"           value="${build.dir}/sbt-interface"/>
 
   <property name="test.osgi.src"           value="${partest.dir}/osgi/src"/>
   <property name="test.osgi.classes"       value="${build-osgi.dir}/classes"/>
+
+  <property name="test.junit.src"          value="${partest.dir}/junit"/>
+  <property name="test.junit.classes"      value="${build-junit.dir}/classes"/>
 
   <property name="dists.dir"               value="${basedir}/dists"/>
 
@@ -208,6 +212,12 @@ TODO:
         <dependency groupId="biz.aQute" artifactId="bnd" version="1.50.0"/>
       </artifact:dependencies>
 
+      <!-- JUnit -->
+      <property name="junit.version" value="4.10"/>
+      <artifact:dependencies pathId="junit.classpath" filesetId="junit.fileset">
+        <dependency groupId="junit" artifactId="junit" version="${junit.version}"/>
+      </artifact:dependencies>
+
       <!-- Pax runner -->
       <property name="pax.exam.version" value="2.5.0"/>
       <artifact:dependencies pathId="pax.exam.classpath" filesetId="pax.exam.fileset">
@@ -218,9 +228,10 @@ TODO:
         <dependency groupId="org.ops4j.pax.swissbox" artifactId="pax-swissbox-framework" version="1.5.1"/>
         <dependency groupId="ch.qos.logback" artifactId="logback-core" version="0.9.20"/>
         <dependency groupId="ch.qos.logback" artifactId="logback-classic" version="0.9.20"/>
-        <dependency groupId="junit" artifactId="junit" version="4.10"/>
+        <dependency groupId="junit" artifactId="junit" version="${junit.version}"/>
         <dependency groupId="org.apache.felix" artifactId="org.apache.felix.framework" version="3.2.2"/>
       </artifact:dependencies>
+
 
       <artifact:dependencies pathId="partest.extras.classpath" filesetId="partest.extras.fileset" versionsId="partest.extras.versions">
         <dependency groupId="com.googlecode.java-diff-utils" artifactId="diffutils" version="1.3.0"/>
@@ -678,6 +689,12 @@ TODO:
       <path refid="pack.compiler.path"/>
       <fileset dir="${partest.dir}/files/lib" includes="*.jar" />
       <pathelement location="${pack.dir}/lib/scala-swing.jar"/> <!-- TODO - segregate swing tests (there can't be many) -->
+    </path>
+
+    <path id="test.junit.compiler.build.path">
+      <pathelement location="${test.junit.classes}"/>
+      <path refid="quick.compiler.build.path"/>
+      <path refid="junit.classpath"/>
     </path>
 
     <path id="test.osgi.compiler.build.path">
@@ -1445,6 +1462,45 @@ TODO:
     <stopwatch name="quick.sbt-interface.timer" action="total"/>
   </target>
 
+  <target name="test.junit.init" depends="quick.done">
+    <uptodate property="test.junit.available" targetfile="${build-junit.dir}/test-compile.complete">
+      <srcfiles dir="${test.junit.src}">
+        <include name="**/*.scala"/>
+      </srcfiles>
+    </uptodate>
+  </target>
+
+  <target name="test.junit.comp" depends="test.junit.init, quick.done" unless="test.junit.available">
+    <stopwatch name="test.junit.compiler.timer"/>
+    <mkdir dir="${test.junit.classes}"/>
+    <scalacfork
+      destdir="${test.junit.classes}"
+      compilerpathref="quick.compiler.path"
+      params="${scalac.args.quick}"
+      srcdir="${test.junit.src}"
+      jvmargs="${scalacfork.jvmargs}">
+      <include name="**/*.scala"/>
+      <compilationpath refid="test.junit.compiler.build.path"/>
+    </scalacfork>
+    <touch file="${build-junit.dir}/test-compile.complete" verbose="no"/>
+    <stopwatch name="test.junit.compiler.timer" action="total"/>
+  </target>
+
+  <target name="test.junit" depends="test.junit.comp">
+    <stopwatch name="test.junit.timer"/>
+    <mkdir dir="${test.junit.classes}"/>
+    <junit fork="yes" haltonfailure="yes" showoutput="yes" printsummary="on">
+      <classpath refid="test.junit.compiler.build.path"/>
+      <batchtest fork="yes" todir="${build-junit.dir}">
+        <fileset dir="${test.junit.classes}">
+          <include name="**/*Test.class"/>
+        </fileset>
+      </batchtest>
+      <formatter type="plain"/>
+    </junit>
+    <stopwatch name="test.junit.timer" action="total"/>
+  </target>
+
   <property name="partest.srcdir" value="files" /> <!-- TODO: make targets for `pending` and other subdirs -->
 
   <target name="test.run" depends="pack.done">
@@ -1516,7 +1572,7 @@ TODO:
 
   <!-- for use in PR validation, where stability is rarely broken, so we're going to use starr for locker,
        and skip test.stability (which requires locker == quick) -->
-  <target name="test.core" depends="test.osgi, test.sbt, test.bc, test.interactive, test.continuations.suite, test.scaladoc, test.suite"/>
+  <target name="test.core" depends="test.osgi, test.sbt, test.bc, test.junit, test.interactive, test.continuations.suite, test.scaladoc, test.suite"/>
   <target name="test.done" depends="test.core, test.stability"/>
 
 

--- a/src/eclipse/README.md
+++ b/src/eclipse/README.md
@@ -11,6 +11,9 @@ IMPORTANT
 Preferences/General/Workspace/Linked Resources. The value should be the absolute 
 path to your scala checkout. All paths in project files are relative to this one,
 so nothing will work before you do so.
+Additionally, we start using Maven dependencies (e.g. junit) so you need to define
+`classpath variable` inside Eclipse. Define `M2_REPO` in Java/Build Path/Classpath Variables
+to point to your local Maven repository (e.g. $HOME/.m2/repository).
 
 2. The Eclipse Java compiler does not allow certain calls to restricted APIs in the
 JDK. The Scala library uses such APIs, so you'd see this error:

--- a/src/eclipse/test-junit/.classpath
+++ b/src/eclipse/test-junit/.classpath
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="test-junit"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/reflect"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/scala-library"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="lib" path="lib/ant/ant.jar"/>
+	<classpathentry kind="lib" path="lib/jline.jar"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/scala-compiler"/>
+	<classpathentry kind="var" path="M2_REPO/junit/junit/4.10/junit-4.10.jar"/>
+	<classpathentry kind="output" path="build-test-junit"/>
+</classpath>

--- a/src/eclipse/test-junit/.project
+++ b/src/eclipse/test-junit/.project
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>test-junit</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.scala-ide.sdt.core.scalabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.scala-ide.sdt.core.scalanature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+	<linkedResources>
+		<link>
+			<name>build-test-junit</name>
+			<type>2</type>
+			<locationURI>SCALA_BASEDIR/build/junit/classes</locationURI>
+		</link>
+		<link>
+			<name>lib</name>
+			<type>2</type>
+			<locationURI>SCALA_BASEDIR/lib</locationURI>
+		</link>
+		<link>
+			<name>test-junit</name>
+			<type>2</type>
+			<locationURI>SCALA_BASEDIR/test/junit</locationURI>
+		</link>
+	</linkedResources>
+</projectDescription>

--- a/test/junit/scala/tools/nsc/SampleTest.scala
+++ b/test/junit/scala/tools/nsc/SampleTest.scala
@@ -1,0 +1,17 @@
+package scala.tools.nsc
+package test
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/** Sample JUnit test that shows that all pieces
+    of JUnit infrastructure work correctly */
+@RunWith(classOf[JUnit4])
+class SampleTest {
+  @Test
+  def testMath: Unit = {
+    assert(2+2 == 4, "you didn't get the math right fellow")
+  }
+}


### PR DESCRIPTION
As discussed on [scala-internals](https://groups.google.com/d/msg/scala-internals/qPbD5d15kvA/p0Nn2-YKvtkJ) adding JUnit support is probably a good idea. We write unit tests in partest which wasn't designed for that.

This PR adds a basic infrastructure for running JUnit tests:
- an Ant task `test.junit` that runs all JUnit tests defined in `test/junit` directory
- an Eclipse project definitions that allows us one to import all the tests to Eclipse

There will be a follow up PR for master which merges this PR and migrates WeakHashMap test to be a junit test.
