### PR TITLE
SI-7584 Fix typer regression with by-name parameter types

### DIFF
--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -208,7 +208,7 @@ abstract class TreeInfo {
       }
       def isWarnableSymbol = {
         val sym = tree.symbol
-        (sym == null) || !(sym.isModule || sym.isLazy) || {
+        (sym == null) || !(sym.isModule || sym.isLazy || definitions.isByNameParamType(sym.tpe_*)) || {
           debuglog("'Pure' but side-effecting expression in statement position: " + tree)
           false
         }

--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -98,7 +98,7 @@ abstract class TreeInfo {
    */
   def isStableIdentifier(tree: Tree, allowVolatile: Boolean): Boolean =
     tree match {
-      case Ident(_)        => symOk(tree.symbol) && tree.symbol.isStable && !tree.symbol.hasVolatileType // TODO SPEC: not required by spec
+      case i @ Ident(_)    => isStableIdent(i)
       case Select(qual, _) => isStableMemberOf(tree.symbol, qual, allowVolatile) && isPath(qual, allowVolatile)
       case Apply(Select(free @ Ident(_), nme.apply), _) if free.symbol.name endsWith nme.REIFY_FREE_VALUE_SUFFIX =>
         // see a detailed explanation of this trick in `GenSymbols.reifyFreeTerm`
@@ -117,6 +117,13 @@ abstract class TreeInfo {
   def isStableMemberOf(sym: Symbol, tree: Tree, allowVolatile: Boolean): Boolean = (
     symOk(sym)       && (!sym.isTerm   || (sym.isStable && (allowVolatile || !sym.hasVolatileType))) &&
     typeOk(tree.tpe) && (allowVolatile || !hasVolatileType(tree)) && !definitions.isByNameParamType(tree.tpe)
+  )
+
+  private def isStableIdent(tree: Ident): Boolean = (
+       symOk(tree.symbol)
+    && tree.symbol.isStable
+    && !definitions.isByNameParamType(tree.tpe)
+    && !tree.symbol.hasVolatileType // TODO SPEC: not required by spec
   )
 
   /** Is `tree`'s type volatile? (Ignored if its symbol has the @uncheckedStable annotation.)

--- a/test/files/pos/t7584.scala
+++ b/test/files/pos/t7584.scala
@@ -1,0 +1,11 @@
+object Test {
+  def fold[A, B](f: (A, => B) => B) = ???
+  def f[A, B](x: A, y: B): B = ???
+  def bip[A, B] = fold[A, B]((x, y) => f(x, y))
+  def bop[A, B] = fold[A, B](f)
+
+  // these work:
+  fold[Int, Int]((x, y) => f(x, y))
+  fold[Int, Int](f)
+}
+

--- a/test/files/run/t7584.check
+++ b/test/files/run/t7584.check
@@ -1,0 +1,6 @@
+no calls
+call A
+a
+call B twice
+b
+b

--- a/test/files/run/t7584.flags
+++ b/test/files/run/t7584.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/run/t7584.scala
+++ b/test/files/run/t7584.scala
@@ -1,0 +1,14 @@
+// Test case added to show the behaviour of functions with
+// by-name parameters.  The evaluation behaviour was already correct.
+//
+// We did flush out a spurious "pure expression does nothing in statement position"
+// warning, hence -Xfatal-warnings in the flags file.
+object Test extends App {
+  def foo(f: (=> Int, => Int) => Unit) = f({println("a"); 0}, {println("b"); 1})
+  println("no calls")
+  foo((a, b) => ())
+  println("call A")
+  foo((a, b) => a)
+  println("call B twice")
+  foo((a, b) => {b; b})
+}


### PR DESCRIPTION
It regressed in https://github.com/scala/scala/commit/fada1ef#L4L614. Partially reverting just
this change restores the correct behaviour:

``` patch
-        if (sym.isStable && pre.isStable && !isByNameParamType(tree.tpe) &&
+        if (treeInfo.admitsTypeSelection(tree) &&
```

This patch embeds the check for by-name parameter types into
`TreeInfo.isStableIdentifier`. That code already checks for
`Symbol#isStable`, which exludes direct references to by-name
parameters. But the additional check is required to deal with
by-name parameters in function types, e.g `(=> Int) => Any`.

Open question: should we go further and embed this check in `isStable`?

Currently:

```
final def isStable        = isTerm && !isMutable && !(hasFlag(BYNAMEPARAM)) && (!isMethod || hasStableFlag)
```

Review by @adriaanm
