### PR TITLE
SI-7582 Only inline accessible calls to package-private Java code

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/opt/Inliners.scala
+++ b/src/compiler/scala/tools/nsc/backend/opt/Inliners.scala
@@ -679,9 +679,18 @@ abstract class Inliners extends SubComponent {
         }
         */
 
-        def checkField(f: Symbol)   = check(f, f.isPrivate && !canMakePublic(f))
-        def checkSuper(n: Symbol)   = check(n, n.isPrivate || !n.isClassConstructor)
-        def checkMethod(n: Symbol)  = check(n, n.isPrivate)
+
+        def isPrivateForInlining(sym: Symbol): Boolean = {
+          if (sym.isJavaDefined) {
+            def check(sym: Symbol) = !(sym.isPublic || sym.isProtected)
+            check(sym) || check(sym.owner) // SI-7582 Must check the enclosing class *and* the symbol for Java.
+          }
+          else sym.isPrivate // Scala never emits package-private bytecode
+        }
+
+        def checkField(f: Symbol)   = check(f, isPrivateForInlining(f) && !canMakePublic(f))
+        def checkSuper(n: Symbol)   = check(n, isPrivateForInlining(n) || !n.isClassConstructor)
+        def checkMethod(n: Symbol)  = check(n, isPrivateForInlining(n))
 
         def getAccess(i: Instruction) = i match {
           case CALL_METHOD(n, SuperCall(_)) => checkSuper(n)

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -517,7 +517,7 @@ abstract class ClassfileParser {
     skipMembers() // methods
     if (!isScala) {
       clazz setFlag sflags
-      propagatePackageBoundary(jflags, clazz, staticModule)
+      propagatePackageBoundary(jflags, clazz, staticModule, staticModule.moduleClass)
       clazz setInfo classInfo
       moduleClass setInfo staticInfo
       staticModule setInfo moduleClass.tpe

--- a/test/files/run/t7582-private-within.check
+++ b/test/files/run/t7582-private-within.check
@@ -1,0 +1,12 @@
+private[package pack] class JavaPackagePrivate
+private[package pack] module JavaPackagePrivate
+private[package pack] module class JavaPackagePrivate
+private[package pack] field field
+private[package pack] primary constructor <init>
+private[package pack] method meth
+private[package pack] field staticField
+private[package pack] method staticMeth
+private[package pack] method <clinit>
+private[package pack] field staticField
+private[package pack] method staticMeth
+private[package pack] method <clinit>

--- a/test/files/run/t7582-private-within/JavaPackagePrivate.java
+++ b/test/files/run/t7582-private-within/JavaPackagePrivate.java
@@ -1,0 +1,8 @@
+package pack;
+
+class JavaPackagePrivate {
+	int field = 0;
+	static int staticField = 0;
+	void meth() { }
+	static void staticMeth() { }
+}

--- a/test/files/run/t7582-private-within/Test.scala
+++ b/test/files/run/t7582-private-within/Test.scala
@@ -1,0 +1,22 @@
+import scala.tools.partest.DirectTest
+
+// Testing that the `privateWithin` field is correctly populated on all
+// the related symbols (e.g. module class) under separate compilation.
+object Test extends DirectTest {
+  def code = ???
+
+  def show(): Unit = {
+    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
+    val global = newCompiler("-usejavacp", "-cp", classpath, "-d", testOutput.path)
+    import global._
+    withRun(global) { _ =>
+      def check(sym: Symbol) = {
+        sym.initialize
+        println(f"${sym.accessString}%12s ${sym.accurateKindString} ${sym.name.decode}") // we want to see private[pack] for all of these.
+      }
+      val sym = rootMirror.getRequiredClass("pack.JavaPackagePrivate")
+      val syms = Seq(sym, sym.companionModule, sym.companionModule.moduleClass)
+      (syms ++ syms.flatMap(_.info.decls)).foreach(check)
+    }
+  }
+}

--- a/test/files/run/t7582.check
+++ b/test/files/run/t7582.check
@@ -1,0 +1,2 @@
+warning: there were 1 inliner warning(s); re-run with -Yinline-warnings for details
+2

--- a/test/files/run/t7582.flags
+++ b/test/files/run/t7582.flags
@@ -1,0 +1,1 @@
+-optimize

--- a/test/files/run/t7582/InlineHolder.scala
+++ b/test/files/run/t7582/InlineHolder.scala
@@ -1,0 +1,16 @@
+package p1 {
+  object InlineHolder {
+    @inline def inlinable = p1.PackageProtectedJava.protectedMethod() + 1
+  }
+}
+
+object O {
+  @noinline
+  def x = p1.InlineHolder.inlinable
+}
+
+object Test {
+  def main(args: Array[String]) {
+    println(O.x)
+  }
+}

--- a/test/files/run/t7582/PackageProtectedJava.java
+++ b/test/files/run/t7582/PackageProtectedJava.java
@@ -1,0 +1,6 @@
+package p1;
+
+// public class, protected method
+public class PackageProtectedJava {
+	static final int protectedMethod() { return 1; }
+}

--- a/test/files/run/t7582b.check
+++ b/test/files/run/t7582b.check
@@ -1,0 +1,2 @@
+warning: there were 1 inliner warning(s); re-run with -Yinline-warnings for details
+2

--- a/test/files/run/t7582b.flags
+++ b/test/files/run/t7582b.flags
@@ -1,0 +1,1 @@
+-optimize

--- a/test/files/run/t7582b/InlineHolder.scala
+++ b/test/files/run/t7582b/InlineHolder.scala
@@ -1,0 +1,16 @@
+package p1 {
+  object InlineHolder {
+    @inline def inlinable = p1.PackageProtectedJava.protectedMethod() + 1
+  }
+}
+
+object O {
+  @noinline
+  def x = p1.InlineHolder.inlinable
+}
+
+object Test {
+  def main(args: Array[String]) {
+    println(O.x)
+  }
+}

--- a/test/files/run/t7582b/PackageProtectedJava.java
+++ b/test/files/run/t7582b/PackageProtectedJava.java
@@ -1,0 +1,6 @@
+package p1;
+
+// protected class, public method
+class PackageProtectedJava {
+	public static final int protectedMethod() { return 1; }
+}


### PR DESCRIPTION
The inliner was using `isPrivate` / `isProtected` to determine access.
The fallthrough considered things to be (bytecode) public. This is okay
in practice for Scala code, which never emits package private code.

This commit turns the logic around to use `!isPublic && !isProtected` to
equate to "don't inline". This alone is enough to pass `run/t7582`.

Secondly, we must check accessibility of the called symbol _and_ its
owner.

Review by @JamesIry

The change to `ClassFileParser` was reviewed in person by @odersky
