### PR TITLE
SI-7596 Curtail overloaded symbols during unpickling

### DIFF
--- a/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
+++ b/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
@@ -334,7 +334,9 @@ abstract class UnPickler {
         case THIStpe =>
           ThisType(readSymbolRef())
         case SINGLEtpe =>
-          SingleType(readTypeRef(), readSymbolRef()) // !!! was singleType
+          val pre = readTypeRef()
+          val sym = readSymbolRef().filter(_.paramss.isEmpty) // SI-7596 cut overloaded symbols down to size.
+          SingleType(pre, sym) // !!! was singleType
         case SUPERtpe =>
           val thistpe = readTypeRef()
           val supertpe = readTypeRef()

--- a/test/files/pos/t7596/A_1.scala
+++ b/test/files/pos/t7596/A_1.scala
@@ -1,0 +1,10 @@
+trait Driver {
+  abstract class Table
+}
+
+object Config {
+  val driver : Driver = ???
+  def driver(a: Any) = ???
+}
+
+object Sites extends Config.driver.Table

--- a/test/files/pos/t7596/B_2.scala
+++ b/test/files/pos/t7596/B_2.scala
@@ -1,0 +1,19 @@
+object Test {
+  locally {
+    Sites: Config.driver.Table
+  }
+}
+
+// Under separate compilation, the pickler is foiled by the 
+// overloaded term `Config.driver`, and results in:
+
+// qbin/scalac test/files/pos/t7596/A_1.scala && qbin/scalac -explaintypes test/files/pos/t7596/B_2.scala
+// test/files/pos/t7596/B_2.scala:3: error: type mismatch;
+//  found   : Sites.type
+//  required: Config.driver.Table
+//     Sites: Config.driver.Table
+//     ^
+// Sites.type <: Config.driver.Table?
+//   Driver.this.type = Config.driver.type?
+//   false
+// false

--- a/test/files/pos/t7596b/A.scala
+++ b/test/files/pos/t7596b/A.scala
@@ -1,0 +1,10 @@
+trait H2Driver{
+    abstract class Table[T]
+}
+
+object Config {
+  val driver : H2Driver = ???
+  def driver(app: Any): H2Driver = ???
+}
+
+class Sites extends Config.driver.Table[String]

--- a/test/files/pos/t7596b/B.scala
+++ b/test/files/pos/t7596b/B.scala
@@ -1,0 +1,6 @@
+class DAOBase[E]{
+  type TableType <: Config.driver.Table[E]
+}
+class SitesDAO extends DAOBase[String]{
+  type TableType = Sites
+}

--- a/test/files/pos/t7596c/A_1.scala
+++ b/test/files/pos/t7596c/A_1.scala
@@ -1,0 +1,11 @@
+trait Driver {
+  abstract class Table
+}
+
+object Config {
+  val driver : Driver = ???
+  val driverUniqueName: driver.type = driver
+  def driver(a: Any) = ???
+}
+
+object Sites extends Config.driver.Table

--- a/test/files/pos/t7596c/B_2.scala
+++ b/test/files/pos/t7596c/B_2.scala
@@ -1,0 +1,9 @@
+object Test {
+  locally {
+    Sites: Config.driver.Table
+  }
+}
+
+// This variation worked by avoiding referring to the
+// overloaded term `Config.driver` in the parent type of
+// Sites


### PR DESCRIPTION
In code like:

```
object O { val x = A; def x(a: Any) = ... }
object P extends O.x.A
```

The unpickler was using an overloaded symbol for `x` in the
parent type of `P`. This led to compilation failures under
separate compilation.

The code that leads to this is in `Unpicklers`:

```
def fromName(name: Name) = name.toTermName match {
  case nme.ROOT     => loadingMirror.RootClass
  case nme.ROOTPKG  => loadingMirror.RootPackage
  case _            => adjust(owner.info.decl(name))
}
```

This commit filters the overloaded symbol based on the
parameter list size when unpickling a singleton type.
That seemed a slightly safer place than in `fromName`.

Review by @gkossakowski

Points for review:
- where do you think the right place is to filter the symbol? 
- I chose `filter` over `suchThat` to defer errors in the case that the val no longer exists. But I didn't test that case, and don't really think the precise error mode is too important; things will blow up quickly either way.
- is there a cleaner, flag-driven alternative to `paramss.isEmpty`?
