### PR TITLE
SI-7265 General test for spec version

### DIFF
--- a/test/files/run/t7265.scala
+++ b/test/files/run/t7265.scala
@@ -1,0 +1,27 @@
+
+import scala.util.Properties._
+
+object Test extends App {
+
+  setProp("java.specification.version", "1.7")
+
+  assert( isJavaAtLeast("1.5"))
+  assert( isJavaAtLeast("1.6"))
+  assert( isJavaAtLeast("1.7"))
+  assert(!isJavaAtLeast("1.8"))
+  assert(!isJavaAtLeast("1.71"))
+
+  failing(isJavaAtLeast("1.a"))
+  failing(isJavaAtLeast("1"))
+  failing(isJavaAtLeast(""))
+  failing(isJavaAtLeast("."))
+  failing(isJavaAtLeast(".5"))
+  failing(isJavaAtLeast("1.7.1"))
+
+  def failing(u: =>Unit) = try {
+    u
+    assert(false, "Expected Exception")
+  } catch {
+    case _: NumberFormatException =>
+  }
+}

--- a/test/pending/junit/scala/util/t7265.scala
+++ b/test/pending/junit/scala/util/t7265.scala
@@ -1,0 +1,46 @@
+
+package scala.util
+package test
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.util.PropertiesTrait
+
+/** The java version property uses the spec version
+ *  and must work for all "major.minor" and fail otherwise.
+ */
+@RunWith(classOf[JUnit4])
+class SpecVersionTest {
+  val sut = new PropertiesTrait {
+    override def javaSpecVersion = "1.7"
+
+    override protected def pickJarBasedOn: Class[_] = ???
+    override protected def propCategory: String = "test"
+
+    // override because of vals like releaseVersion
+    override lazy val scalaProps = new java.util.Properties
+  }
+
+  @Test
+  def comparesCorrectly(): Unit = {
+    assert(sut isJavaAtLeast "1.5")
+    assert(sut isJavaAtLeast "1.6")
+    assert(sut isJavaAtLeast "1.7")
+    assert(!(sut isJavaAtLeast "1.8"))
+  }
+  @Test(expected = classOf[NumberFormatException])
+  def badVersion(): Unit = {
+    sut isJavaAtLeast "1.a"
+  }
+  @Test(expected = classOf[NumberFormatException])
+  def missingVersion(): Unit = {
+    sut isJavaAtLeast "1"
+  }
+  @Test(expected = classOf[NumberFormatException])
+  def notASpec(): Unit = {
+    sut isJavaAtLeast "1.7.1"
+  }
+}


### PR DESCRIPTION
```
The test for isJavaAtLeast uses the specification.version.

The method argument must have the form "major.minor".

The scaladoc is updated to reflect the new reality and a
test is added under junit.

Note that this implementation aims to be a simple
compromise between the functional and imperative camps,
that is, to be free of both closures and while loops.
And to elicit no cruft like regexes and wrappers for strings.
No doubt even more could be done in this department, but we
don't wish to spoil the fun on codegolf.stackexchange.com.
However, we might decide to sponsor a new site:
codereviewpingpong.com

For 2.10.x, javaSpecVersion is provided as a private member.
The active test is under `run` and the `junit` test must
bide its time in `pending`.

For 2.11, the private members can be public and the app test
replaced with the unit test.
```

Review by @soc and @adriaanm 
