### PR TITLE
SI-7292 Fixes test failures by updating *.check files

### DIFF
--- a/test/files/neg/t7292-deprecation.check
+++ b/test/files/neg/t7292-deprecation.check
@@ -1,11 +1,11 @@
-t7292-deprecation.scala:2: warning: Octal escape literals are deprecated, use /u0000 instead.
-  val chr1 = '/0'
+t7292-deprecation.scala:2: warning: Octal escape literals are deprecated, use \u0000 instead.
+  val chr1 = '\0'
               ^
-t7292-deprecation.scala:3: warning: Octal escape literals are deprecated, use /u0053 instead.
-  val str1 = "abc/123456"
+t7292-deprecation.scala:3: warning: Octal escape literals are deprecated, use \u0053 instead.
+  val str1 = "abc\123456"
                  ^
-t7292-deprecation.scala:4: warning: Octal escape literals are deprecated, use /n instead.
-  val lf = '/012'
+t7292-deprecation.scala:4: warning: Octal escape literals are deprecated, use \n instead.
+  val lf = '\012'
             ^
 error: No warnings can be incurred under -Xfatal-warnings.
 three warnings found

--- a/test/files/neg/t7292-removal.check
+++ b/test/files/neg/t7292-removal.check
@@ -1,10 +1,10 @@
-t7292-removal.scala:2: error: Octal escape literals are unsupported, use /u0000 instead.
-  val chr1 = '/0'
+t7292-removal.scala:2: error: Octal escape literals are unsupported, use \u0000 instead.
+  val chr1 = '\0'
               ^
-t7292-removal.scala:3: error: Octal escape literals are unsupported, use /u0053 instead.
-  val str1 = "abc/123456"
+t7292-removal.scala:3: error: Octal escape literals are unsupported, use \u0053 instead.
+  val str1 = "abc\123456"
                  ^
-t7292-removal.scala:4: error: Octal escape literals are unsupported, use /n instead.
-  val lf = '/012'
+t7292-removal.scala:4: error: Octal escape literals are unsupported, use \n instead.
+  val lf = '\012'
             ^
 three errors found

--- a/test/files/run/literals.check
+++ b/test/files/run/literals.check
@@ -1,4 +1,4 @@
-warning: there were 13 deprecation warning(s); re-run with -deprecation for details
+warning: there were 18 deprecation warning(s); re-run with -deprecation for details
 test '\u0024' == '$' was successful
 test '\u005f' == '_' was successful
 test 65.asInstanceOf[Char] == 'A' was successful

--- a/test/files/run/richs.check
+++ b/test/files/run/richs.check
@@ -1,3 +1,4 @@
+warning: there were 2 deprecation warning(s); re-run with -deprecation for details
 
 RichCharTest1:
 true


### PR DESCRIPTION
Looks like partest's confusion about / vs. \ was fixed between
the original Jenkins run of the fix for SI-7292 and its merge.
