### PR TITLE
SI-7569 Fix end position in PostfixSelect tree

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
@@ -245,7 +245,7 @@ abstract class TreeBuilder {
   /** Tree for `od op`, start is start0 if od.pos is borked. */
   def makePostfixSelect(start0: Int, end: Int, od: Tree, op: Name): Tree = {
     val start = if (od.pos.isDefined) od.pos.startOrPoint else start0
-    atPos(r2p(start, end, end)) { new PostfixSelect(od, op.encode) }
+    atPos(r2p(start, end, end + op.length)) { new PostfixSelect(od, op.encode) }
   }
 
   /** A type tree corresponding to (possibly unary) intersection type */

--- a/test/files/run/t7569.check
+++ b/test/files/run/t7569.check
@@ -1,0 +1,12 @@
+source-newSource1.scala,line-3,offset=49 A.this.one
+source-newSource1.scala,line-3,offset=49 A.this
+source-newSource1.scala,line-4,offset=67 A.super.<init>()
+source-newSource1.scala,line-4,offset=67 A.super.<init>
+source-newSource1.scala,line-4,offset=67 this
+source-newSource1.scala,line-3,offset=49 A.this.one
+source-newSource1.scala,line-3,offset=49 A.this
+RangePosition(newSource1.scala, 55, 57, 65) scala.Int.box(1).toString()
+RangePosition(newSource1.scala, 55, 57, 65) scala.Int.box(1).toString
+RangePosition(newSource1.scala, 55, 55, 56) scala.Int.box(1)
+NoPosition      scala.Int.box
+NoPosition      scala.Int

--- a/test/files/run/t7569.scala
+++ b/test/files/run/t7569.scala
@@ -1,0 +1,19 @@
+import scala.tools.partest._
+object Test extends CompilerTest {
+  import global._
+  override def extraSettings = super.extraSettings + " -Yrangepos"
+  override def sources = List(
+    """|import scala.language.postfixOps
+       |class A {
+       |  val one = 1 toString
+       |}""".stripMargin
+  )
+  def check(source: String, unit: CompilationUnit) {
+    for (ClassDef(_, _, _, Template(_, _, stats)) <- unit.body ; stat <- stats ; t <- stat) {
+      t match {
+        case _: Select | _ : Apply | _:This => println("%-15s %s".format(t.pos.toString, t))
+        case _                              =>
+      }
+    }
+  }
+}


### PR DESCRIPTION
introduced in 5b54681: the end position of Postfix operators should take the
operator length into account.

review by @som-snytt
