### PR TITLE
SI-7599 Modify methods to be non-tail-callable ...

### DIFF
--- a/test/files/run/t6308.scala
+++ b/test/files/run/t6308.scala
@@ -1,21 +1,25 @@
 import scala.{specialized => sp}
 
+// NOTE: `{ val c = caller; print(""); c }` is used instead of a simple `caller`,
+//       because we want to prevent tail-call optimization from eliding the stack-
+//       frames we want to inspect.
+
 object Test {
   def caller = new Exception().getStackTrace()(1).getMethodName
-  def f1[@sp(Int) A](a: A, b: Any)             = caller
-  def f2[@sp(Int) A, B](a: A, b: String)       = caller
-  def f3[B, @sp(Int) A](a: A, b: List[B])      = caller
-  def f4[B, @sp(Int) A](a: A, b: List[(A, B)]) = caller
+  def f1[@sp(Int) A](a: A, b: Any)             = { val c = caller; print(""); c }
+  def f2[@sp(Int) A, B](a: A, b: String)       = { val c = caller; print(""); c }
+  def f3[B, @sp(Int) A](a: A, b: List[B])      = { val c = caller; print(""); c }
+  def f4[B, @sp(Int) A](a: A, b: List[(A, B)]) = { val c = caller; print(""); c }
 
-  def f5[@sp(Int) A, B <: Object](a: A, b: B)  = caller
+  def f5[@sp(Int) A, B <: Object](a: A, b: B)  = { val c = caller; print(""); c }
 
   // `uncurryTreeType` calls a TypeMap on the call to this method and we end up with new
   // type parameter symbols, which are not found in `TypeEnv.includes(typeEnv(member), env)`
   // in `specSym`. (One of `uncurry`'s tasks is to expand type aliases in signatures.)
   type T = Object
-  def todo1[@sp(Int) A, B <: T](a: A, b: String)           = caller
-  def todo2[@sp(Int) A, B <: AnyRef](a: A, b: String)      = caller
-  def todo3[B <: List[A], @specialized(Int) A](a: A, b: B) = caller
+  def todo1[@sp(Int) A, B <: T](a: A, b: String)           = { val c = caller; print(""); c }
+  def todo2[@sp(Int) A, B <: AnyRef](a: A, b: String)      = { val c = caller; print(""); c }
+  def todo3[B <: List[A], @specialized(Int) A](a: A, b: B) = { val c = caller; print(""); c }
 
   def main(args: Array[String]) {
     val s = ""


### PR DESCRIPTION
... to prevent Avian from eliding the stack frames we want to inspect.
