### PR TITLE
SI-3936 - add test case to show that SI-3936 is already fixed

### DIFF
--- a/test/files/pos/t3936/BlockingQueue.java
+++ b/test/files/pos/t3936/BlockingQueue.java
@@ -1,0 +1,3 @@
+package pack;
+import java.util.Queue;
+public interface BlockingQueue<E> extends Queue<E> { }

--- a/test/files/pos/t3936/Queue.java
+++ b/test/files/pos/t3936/Queue.java
@@ -1,0 +1,2 @@
+package pack;
+public interface Queue { }

--- a/test/files/pos/t3936/Test.scala
+++ b/test/files/pos/t3936/Test.scala
@@ -1,0 +1,4 @@
+package pack
+trait Test {
+  val b: BlockingQueue[Nothing]
+}


### PR DESCRIPTION
These are exactly the examples given by Lukas Rytz in SI-3936.
They fail with 2.10.1 and compile with 2.10.2 as well as current master.

(And many thanks for fixing this bug and all the other great work the contributors are doing!)
