### PR TITLE
SI-7600 [Avian] Skip tests r/stream_length and r/t4294

### DIFF
--- a/test/files/run/stream_length.check
+++ b/test/files/run/stream_length.check
@@ -1,1 +1,6 @@
+#partest !avian
 Length: 970299
+
+#partest avian
+!!!TEST SKIPPED!!!
+See SI-7600 for further information.

--- a/test/files/run/stream_length.scala
+++ b/test/files/run/stream_length.scala
@@ -10,6 +10,10 @@ object Test {
   }
 
   def main(args: Array[String]) {
-    println("Length: " + walk(3, "---").length)
+    if (scala.tools.partest.utils.Properties.isAvian) {
+      println("!!!TEST SKIPPED!!!")
+      println("See SI-7600 for further information.")
+    } else
+      println("Length: " + walk(3, "---").length)
   }
 }

--- a/test/files/run/t4294.scala
+++ b/test/files/run/t4294.scala
@@ -1,7 +1,12 @@
 object Test {
   def main(args: Array[String]) {
+    // Skip test on Avian, see SI-7600 for further information
+    if (!scala.tools.partest.utils.Properties.isAvian)
+      run()
+  }
+
+  def run(): Unit = {
     (Stream.from(1).collect{case x if x > 5000000 => x}: Stream[Int])
-    
     assert((Stream from 1 take 10 collect { case x if x <= 3 => x*x }).sum == 14)
   }
 }


### PR DESCRIPTION
The issue is that Avian's GC is currently not precise enough to
determine the exact lifetime of each local/stack reference, and
therefore considers the this reference to be reachable in situations
where it could have been collected.

This can cause issues (as seen in run/stream_length and run/t4294:
`java.lang.OutOfMemoryError`) if code relies on the garbage collection
of these values to keep memory consumption constant.

This commit simply skips these two tests on Avian until the GC
implementation is fixed.
