### PR TITLE
SI-7590 TreeSet should fail fast if Ordering is null

### DIFF
--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -52,6 +52,9 @@ object TreeSet extends ImmutableSortedSetFactory[TreeSet] {
 class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: Ordering[A])
   extends SortedSet[A] with SortedSetLike[A, TreeSet[A]] with Serializable {
 
+  if (ordering eq null)
+    throw new NullPointerException("ordering must not be null")
+
   override def stringPrefix = "TreeSet"
 
   override def size = RB.count(tree)

--- a/test/files/scalacheck/si4147.scala
+++ b/test/files/scalacheck/si4147.scala
@@ -1,4 +1,4 @@
-import org.scalacheck.Prop.forAll
+import org.scalacheck.Prop.{forAll, throws}
 import org.scalacheck.Properties
 import org.scalacheck.ConsoleReporter.testStatsEx
 import org.scalacheck.Gen
@@ -64,4 +64,7 @@ object Test extends Properties("Mutable TreeSet") {
       view.filter(_ < 50) == Set[Int]() && view.filter(_ >= 150) == Set[Int]()
     }
   }
+
+  property("ordering must not be null") =
+    throws(mutable.TreeSet.empty[Int](null), classOf[NullPointerException])
 }

--- a/test/files/scalacheck/treeset.scala
+++ b/test/files/scalacheck/treeset.scala
@@ -149,4 +149,7 @@ object Test extends Properties("TreeSet") {
     val result = subject.foldLeft(subject)((acc, elt) => acc - elt)
     result.isEmpty
   }
+  
+  property("ordering must not be null") =
+    throws(TreeSet.empty[Int](null), classOf[NullPointerException])
 }


### PR DESCRIPTION
While migrating scala.tools.nsc.util.TreeSet to
scala.collection.mutable.TreeSet, I messed up initialization order
and realized that TreeSet accepts null as an Ordering and only fails
much later.

This change makes mutable.TreeSet and immutable.TreeSet fail
immediately.
