### PR TITLE
SI-7209 Another test for a fixed bug with Java generics

### DIFF
--- a/test/files/neg/t7209.scala
+++ b/test/files/neg/t7209.scala
@@ -1,0 +1,13 @@
+trait Base[+T]
+trait Sub[+T] extends Base[T]
+class SubSub[+T] extends Sub[T]
+
+class S {
+  def s[T](x: Base[_ <: T]): T = ???
+  def s[U](x: Sub[_ <: U]): U = ???
+
+  def subsub: Sub[Int] = ???
+
+  s[Int](subsub) // ok
+  s(subsub)      // fails (as expected, see comments on SI-7209)
+}

--- a/test/files/run/t7209.check
+++ b/test/files/run/t7209.check
@@ -1,0 +1,12 @@
+Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> 
+
+scala> j.J.copyOf[String](new java.util.ArrayList[String]: java.util.Collection[_ <: String])
+res0: java.util.List[String] = null
+
+scala> j.J.copyOf[String](new java.util.ArrayList[String]: java.util.Collection[_ <: String])
+res1: java.util.List[String] = null
+
+scala> 

--- a/test/files/run/t7209/J.java
+++ b/test/files/run/t7209/J.java
@@ -1,0 +1,10 @@
+package j;
+
+import java.util.*;
+
+public class J {
+  public static <E> List<E> copyOf(Iterable<? extends E> elements) { return null; }
+  public static <E> List<E> copyOf(Collection<? extends E> elements) { return null; }
+  public static <E> List<E> copyOf(Iterator<? extends E> elements) { return null; }
+  public static <E> List<E> copyOf(E[] elements) { return null; }
+}

--- a/test/files/run/t7209/Test.scala
+++ b/test/files/run/t7209/Test.scala
@@ -1,0 +1,16 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  override def code = """
+j.J.copyOf[String](new java.util.ArrayList[String]: java.util.Collection[_ <: String])
+j.J.copyOf[String](new java.util.ArrayList[String]: java.util.Collection[_ <: String])
+"""
+
+// The second call was resulting in:
+// <console>:34: error: type mismatch;
+// found   : java.util.ArrayList[?0] where type ?0
+// required: java.util.Collection[_ <: String]
+//              j.J.copyOf[String](new java.util.ArrayList[String]: java.util.Collection[_ <: String])
+//
+// This was fixed in SI-7482
+}


### PR DESCRIPTION
Erased types were being treated as raw types and incorrectly
being cooked, this is visible in the REPL which reuses the symbol
table.

The fix for this came earlier in SI-7482.

Review by @paulp
