### PR TITLE
SI-7612 Fix SOE regression in lubs

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -6696,7 +6696,9 @@ trait Types extends api.Types { self: SymbolTable =>
     val ts0 = elimSub0(ts)
     if (ts0.isEmpty || ts0.tail.isEmpty) ts0
     else {
-      val ts1 = ts0 mapConserve (t => elimAnonymousClass(t.dealiasWiden))
+      // This was changed to `dealiasWiden` after deliberation https://github.com/scala/scala/pull/2022#discussion_r2832997
+      // That triggered a regression SI-7612, so reverting to `.underlying`.
+      val ts1 = ts0 mapConserve (t => elimAnonymousClass(t.underlying))
       if (ts1 eq ts0) ts0
       else elimSub(ts1, depth)
     }

--- a/test/files/pos/t7612.scala
+++ b/test/files/pos/t7612.scala
@@ -1,0 +1,34 @@
+trait BaseMapper  {
+  type M
+  def primaryKeyField: MappedField[M]
+}
+
+trait Mapper[A] extends BaseMapper {
+  type M = A
+}
+
+trait IdPK {
+  self: BaseMapper =>
+  object id extends MappedField[M]
+}
+
+trait KeyedMapper[A]
+  extends Mapper[A] with BaseMapper
+
+trait MappedField[A]
+
+abstract class A extends KeyedMapper[A] {
+  def primaryKeyField: MappedField[A]
+}
+
+abstract class B extends Mapper[B] with BaseMapper with IdPK {
+  // okay
+  // def primaryKeyField: MappedField[M]
+
+  // SOE
+  def primaryKeyField: id.type
+}
+
+object Test {
+  def foo(a: A, b: B) = if (true) a else b // LUB triggers StackOverflowError
+}


### PR DESCRIPTION
The enclosed test case (whittled down lovingly from lift-mapper)
triggers the cycle in `elimSub`.

Regressed in a06d31f6a. The change was dicussed
https://github.com/scala/scala/pull/2022#discussion_r2832997.

This patch reverts to using `.underlying`.

Below, I've shown the different paths that are taken through
that method with before and after this patch. The key divergence
is when `<refinement>.this.M.dealias` reveals a captured existential
type symbol.

A more detailed look at how that happens:
   https://gist.github.com/retronym/5874775

Review by @adriaanm.

Targetting 2.10.x on grounds of locality of the fix and regression from 2.10.0 -> 2.10.1.
