### PR TITLE
Move some code from s.t.n.io to s.t.n.interactive

### DIFF
--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -9,7 +9,7 @@ import java.io.{ PrintWriter, StringWriter, FileReader, FileWriter }
 import scala.collection.mutable
 import mutable.{LinkedHashMap, SynchronizedMap, HashSet, SynchronizedSet}
 import scala.util.control.ControlThrowable
-import scala.tools.nsc.io.{ AbstractFile, LogReplay, Logger, NullLogger, Replayer }
+import scala.tools.nsc.io.{ AbstractFile }
 import scala.tools.nsc.util.MultiHashMap
 import scala.reflect.internal.util.{ SourceFile, BatchSourceFile, Position, NoPosition }
 import scala.tools.nsc.reporters._

--- a/src/interactive/scala/tools/nsc/interactive/Lexer.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Lexer.scala
@@ -1,4 +1,4 @@
-package scala.tools.nsc.io
+package scala.tools.nsc.interactive
 
 import java.io.Reader
 

--- a/src/interactive/scala/tools/nsc/interactive/Pickler.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Pickler.scala
@@ -1,4 +1,4 @@
-package scala.tools.nsc.io
+package scala.tools.nsc.interactive
 
 import Lexer._
 import java.io.Writer

--- a/src/interactive/scala/tools/nsc/interactive/Picklers.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Picklers.scala
@@ -7,10 +7,10 @@ package interactive
 
 import util.InterruptReq
 import scala.reflect.internal.util.{ SourceFile, BatchSourceFile }
-import io.{ AbstractFile, PlainFile, Pickler, CondPickler }
+import io.{ AbstractFile, PlainFile }
 import util.EmptyAction
 import scala.reflect.internal.util.{ RangePosition, OffsetPosition, TransparentPosition }
-import io.Pickler._
+import Pickler._
 import scala.collection.mutable
 import mutable.ListBuffer
 

--- a/src/interactive/scala/tools/nsc/interactive/PrettyWriter.scala
+++ b/src/interactive/scala/tools/nsc/interactive/PrettyWriter.scala
@@ -1,4 +1,4 @@
-package scala.tools.nsc.io
+package scala.tools.nsc.interactive
 
 import java.io.Writer
 

--- a/src/interactive/scala/tools/nsc/interactive/Replayer.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Replayer.scala
@@ -1,4 +1,4 @@
-package scala.tools.nsc.io
+package scala.tools.nsc.interactive
 
 import java.io.{Reader, Writer}
 


### PR DESCRIPTION
The only usages of scala.tools.nsc.io.{Lexer,Pickler,PrettyWriter,
Replayer} can be found in scala.tools.nsc.interactive.

Let's move those files closer to their dependencies.
