### PR TITLE
Add quasiquotes to reflection api

### DIFF
--- a/src/compiler/scala/reflect/reify/codegen/GenTrees.scala
+++ b/src/compiler/scala/reflect/reify/codegen/GenTrees.scala
@@ -42,12 +42,6 @@ trait GenTrees {
     // the second prototype reified external types, but avoided reifying local ones => this created an ugly irregularity
     // current approach is uniform and compact
     var rtree = tree match {
-      case global.EmptyTree =>
-        reifyMirrorObject(EmptyTree)
-      case global.emptyValDef =>
-        mirrorSelect(nme.emptyValDef)
-      case global.pendingSuperCall =>
-        mirrorSelect(nme.pendingSuperCall)
       case FreeDef(_, _, _, _, _) =>
         reifyNestedFreeDef(tree)
       case FreeRef(_, _) =>
@@ -56,12 +50,8 @@ trait GenTrees {
         reifyBoundTerm(tree)
       case BoundType(tree) =>
         reifyBoundType(tree)
-      case Literal(const @ Constant(_)) =>
-        mirrorCall(nme.Literal, reifyProduct(const))
-      case Import(expr, selectors) =>
-        mirrorCall(nme.Import, reify(expr), mkList(selectors map reifyProduct))
       case _ =>
-        reifyProduct(tree)
+        reifyBasicTree(tree)
     }
 
     // usually we don't reify symbols/types, because they can be re-inferred during subsequent reflective compilation
@@ -76,6 +66,21 @@ trait GenTrees {
     }
 
     rtree
+  }
+
+  def reifyBasicTree(tree: Tree) = tree match {
+    case global.EmptyTree =>
+      reifyMirrorObject(EmptyTree)
+    case global.emptyValDef =>
+      mirrorSelect(nme.emptyValDef)
+    case global.pendingSuperCall =>
+      mirrorSelect(nme.pendingSuperCall)
+    case Literal(const @ Constant(_)) =>
+      mirrorCall(nme.Literal, reifyProduct(const))
+    case Import(expr, selectors) =>
+      mirrorCall(nme.Import, reify(expr), mkList(selectors map reifyProduct))
+    case _ =>
+      reifyProduct(tree)
   }
 
   def reifyModifiers(m: global.Modifiers) =

--- a/src/compiler/scala/reflect/reify/package.scala
+++ b/src/compiler/scala/reflect/reify/package.scala
@@ -2,7 +2,7 @@ package scala
 package reflect
 
 import scala.reflect.macros.ReificationException
-import scala.tools.nsc.Global
+import scala.tools.nsc.{Global, ListOfNil}
 
 package object reify {
   private def mkReifier(global1: Global)(typer: global1.analyzer.Typer, universe: global1.Tree, mirror: global1.Tree, reifee: Any, concrete: Boolean): Reifier { val global: global1.type } = {
@@ -32,7 +32,14 @@ package object reify {
       // If we're in the constructor of an object or others don't have easy access to `this`, we have no good way to grab
       // the class of that object.  Instead, we construct an anonymous class and grab his class file, assuming
       // this is enough to get the correct class loadeer for the class we *want* a mirror for, the object itself.
-      rClassTree orElse Apply(Select(treeBuilder.makeAnonymousNew(Nil), sn.GetClass), Nil)
+      val anonObject = Block(List(
+        ClassDef(Modifiers(Flag.FINAL), tpnme.ANON_CLASS_NAME, Nil,
+          Template(
+            List(Select(Ident(nme.scala_), tpnme.AnyRef)),
+            emptyValDef,
+            List(DefDef(NoMods, nme.CONSTRUCTOR, Nil, ListOfNil, TypeTree(), Block(List(pendingSuperCall), Literal(Constant(())))), Literal(Constant(())))))),
+        Apply(Select(New(Ident(tpnme.ANON_CLASS_NAME)), nme.CONSTRUCTOR), Nil))
+      rClassTree orElse Apply(Select(anonObject, sn.GetClass), Nil)
     }
     // JavaUniverse is defined in scala-reflect.jar, so we must be very careful in case someone reifies stuff having only scala-library.jar on the classpath
     val isJavaUniverse = JavaUniverseClass != NoSymbol && universe.tpe <:< JavaUniverseClass.toTypeConstructor

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -102,17 +102,6 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
       typer.typed(mkCast(tree, pt))
   }
 
-  /** Trees fresh from the oven, mostly for use by the parser. */
-  object treeBuilder extends {
-    val global: Global.this.type = Global.this
-  } with TreeBuilder {
-    def freshName(prefix: String): Name               = freshTermName(prefix)
-    def freshTermName(prefix: String): TermName       = currentUnit.freshTermName(prefix)
-    def freshTypeName(prefix: String): TypeName       = currentUnit.freshTypeName(prefix)
-    def o2p(offset: Int): Position                    = new OffsetPosition(currentUnit.source, offset)
-    def r2p(start: Int, mid: Int, end: Int): Position = rangePos(currentUnit.source, start, mid, end)
-  }
-
   /** Fold constants */
   object constfold extends {
     val global: Global.this.type = Global.this

--- a/src/compiler/scala/tools/nsc/ast/TreeGen.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeGen.scala
@@ -112,7 +112,6 @@ abstract class TreeGen extends scala.reflect.internal.TreeGen with TreeDSL {
       else AppliedTypeTree(Ident(clazz), targs map TypeTree)
     ))
   }
-  def mkSuperInitCall: Select = Select(Super(This(tpnme.EMPTY), tpnme.EMPTY), nme.CONSTRUCTOR)
 
   def wildcardStar(tree: Tree) =
     atPos(tree.pos) { Typed(tree, Ident(tpnme.WILDCARD_STAR)) }

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -26,12 +26,21 @@ import util.FreshNameCreator
  *  the beginnings of a campaign against this latest incursion by Cutty
  *  McPastington and his army of very similar soldiers.
  */
-trait ParsersCommon extends ScannersCommon {
+trait ParsersCommon extends ScannersCommon { self =>
   val global : Global
   import global._
 
   def newLiteral(const: Any) = Literal(Constant(const))
   def literalUnit            = newLiteral(())
+
+  class ParserTreeBuilder extends TreeBuilder {
+    val global: self.global.type = self.global
+    def freshName(prefix: String): Name               = freshTermName(prefix)
+    def freshTermName(prefix: String): TermName       = currentUnit.freshTermName(prefix)
+    def freshTypeName(prefix: String): TypeName       = currentUnit.freshTypeName(prefix)
+    def o2p(offset: Int): Position                    = new OffsetPosition(currentUnit.source, offset)
+    def r2p(start: Int, mid: Int, end: Int): Position = rangePos(currentUnit.source, start, mid, end)
+  }
 
   /** This is now an abstract class, only to work around the optimizer:
    *  methods in traits are never inlined.
@@ -290,6 +299,7 @@ self =>
     /** whether a non-continuable syntax error has been seen */
     private var lastErrorOffset : Int = -1
 
+    val treeBuilder = new ParserTreeBuilder
     import treeBuilder.{global => _, _}
 
     /** The types of the context bounds of type parameters of the surrounding class
@@ -603,6 +613,8 @@ self =>
            PROTECTED | OVERRIDE | IMPLICIT | LAZY => true
       case _ => false
     }
+
+    def isAnnotation: Boolean = in.token == AT
 
     def isLocalModifier: Boolean = in.token match {
       case ABSTRACT | FINAL | SEALED | IMPLICIT | LAZY => true
@@ -1365,7 +1377,7 @@ self =>
               } else {
                 syntaxErrorOrIncomplete("`*' expected", skipIt = true)
               }
-            } else if (in.token == AT) {
+            } else if (isAnnotation) {
               t = (t /: annotations(skipNewLines = false))(makeAnnotated)
             } else {
               t = atPos(t.pos.startOrPoint, colonPos) {
@@ -2050,6 +2062,8 @@ self =>
 
 /* -------- PARAMETERS ------------------------------------------- */
 
+    def allowTypelessParams = false
+
     /** {{{
      *  ParamClauses      ::= {ParamClause} [[nl] `(' implicit Params `)']
      *  ParamClause       ::= [nl] `(' [Params] `)'
@@ -2086,7 +2100,7 @@ self =>
         val name = ident()
         var bynamemod = 0
         val tpt =
-          if (settings.YmethodInfer && !owner.isTypeName && in.token != COLON) {
+          if (((settings.YmethodInfer && !owner.isTypeName) || allowTypelessParams) && in.token != COLON) {
             TypeTree()
           } else { // XX-METHOD-INFER
             accept(COLON)
@@ -2867,7 +2881,7 @@ self =>
           case IMPORT =>
             in.flushDoc
             importClause()
-          case x if x == AT || isTemplateIntro || isModifier =>
+          case x if isAnnotation || isTemplateIntro || isModifier =>
             joinComment(topLevelTmplDef :: Nil)
           case _ =>
             if (isStatSep) Nil
@@ -2923,11 +2937,11 @@ self =>
         if (in.token == IMPORT) {
           in.flushDoc
           stats ++= importClause()
+        } else if (isDefIntro || isModifier || isAnnotation) {
+          stats ++= joinComment(nonLocalDefOrDcl)
         } else if (isExprIntro) {
           in.flushDoc
           stats += statement(InTemplate)
-        } else if (isDefIntro || isModifier || in.token == AT) {
-          stats ++= joinComment(nonLocalDefOrDcl)
         } else if (!isStatSep) {
           syntaxErrorOrIncomplete("illegal start of definition", skipIt = true)
         }
@@ -3007,7 +3021,7 @@ self =>
           stats += statement(InBlock)
           if (in.token != RBRACE && in.token != CASE) acceptStatSep()
         }
-        else if (isDefIntro || isLocalModifier || in.token == AT) {
+        else if (isDefIntro || isLocalModifier || isAnnotation) {
           if (in.token == IMPLICIT) {
             val start = in.skipToken()
             if (isIdent) stats += implicitClosure(start, InBlock)

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -71,17 +71,33 @@ trait Scanners extends ScannersCommon {
     /** the base of a number */
     var base: Int = 0
 
-    def copyFrom(td: TokenData) = {
+    def copyFrom(td: TokenData): this.type = {
       this.token = td.token
       this.offset = td.offset
       this.lastOffset = td.lastOffset
       this.name = td.name
       this.strVal = td.strVal
       this.base = td.base
+      this
     }
   }
 
-  abstract class Scanner extends CharArrayReader with TokenData with ScannerCommon {
+  trait ScannerData extends TokenData {
+    var ch: Char
+    var charOffset: Int
+    var lineStartOffset: Int
+    var lastLineStartOffset: Int
+    def copyFrom(sd: ScannerData): this.type = {
+      this.ch = sd.ch
+      this.charOffset = sd.charOffset
+      this.lineStartOffset = sd.lineStartOffset
+      this.lastLineStartOffset = sd.lastLineStartOffset
+      super.copyFrom(sd)
+      this
+    }
+  }
+
+  abstract class Scanner extends CharArrayReader with TokenData with ScannerData with ScannerCommon {
     private def isDigit(c: Char) = java.lang.Character isDigit c
 
     private var openComments = 0

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -190,6 +190,7 @@ trait ScalaSettings extends AbsScalaSettings
   val Yreifydebug             = BooleanSetting("-Yreify-debug", "Trace reification.")
   val Ytyperdebug             = BooleanSetting("-Ytyper-debug", "Trace all type assignments.")
   val Ypatmatdebug            = BooleanSetting("-Ypatmat-debug", "Trace pattern matching translation.")
+  val Yquasiquotedebug        = BooleanSetting("-Yquasiquote-debug", "Trace quasiquote-related activities.")
 
   /** Groups of Settings.
    */

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -624,20 +624,20 @@ trait Macros extends FastTrack with MacroRuntimes with Traces with Helpers {
 
   /** Captures statuses of macro expansions performed by `macroExpand1'.
    */
-  private sealed abstract class MacroStatus(val result: Tree)
-  private case class Success(expanded: Tree) extends MacroStatus(expanded)
-  private case class Fallback(fallback: Tree) extends MacroStatus(fallback) { currentRun.seenMacroExpansionsFallingBack = true }
-  private case class Delayed(delayed: Tree) extends MacroStatus(delayed)
-  private case class Skipped(skipped: Tree) extends MacroStatus(skipped)
-  private case class Failure(failure: Tree) extends MacroStatus(failure)
-  private def Delay(expanded: Tree) = Delayed(expanded)
-  private def Skip(expanded: Tree) = Skipped(expanded)
-  private def Cancel(expandee: Tree) = Failure(expandee)
+  sealed abstract class MacroStatus(val result: Tree)
+  case class Success(expanded: Tree) extends MacroStatus(expanded)
+  case class Fallback(fallback: Tree) extends MacroStatus(fallback) { currentRun.seenMacroExpansionsFallingBack = true }
+  case class Delayed(delayed: Tree) extends MacroStatus(delayed)
+  case class Skipped(skipped: Tree) extends MacroStatus(skipped)
+  case class Failure(failure: Tree) extends MacroStatus(failure)
+  def Delay(expanded: Tree) = Delayed(expanded)
+  def Skip(expanded: Tree) = Skipped(expanded)
+  def Cancel(expandee: Tree) = Failure(expandee)
 
   /** Does the same as `macroExpand`, but without typechecking the expansion
    *  Meant for internal use within the macro infrastructure, don't use it elsewhere.
    */
-  private def macroExpand1(typer: Typer, expandee: Tree): MacroStatus = {
+  def macroExpand1(typer: Typer, expandee: Tree): MacroStatus = {
     // verbose printing might cause recursive macro expansions, so I'm shutting it down here
     withInfoLevel(nodePrinters.InfoLevel.Quiet) {
       if (expandee.symbol.isErroneous || (expandee exists (_.isErroneous))) {

--- a/src/compiler/scala/tools/reflect/quasiquotes/Macros.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Macros.scala
@@ -1,0 +1,81 @@
+package scala.tools.reflect
+package quasiquotes
+
+import scala.tools.nsc.Global
+import scala.reflect.macros.runtime.Context
+import java.util.UUID.randomUUID
+import scala.collection.immutable.ListMap
+
+class Cardinality private[Cardinality](val value: Int) extends AnyVal {
+  def pred = { assert(value - 1 >= 0); new Cardinality(value - 1) }
+  def succ = new Cardinality(value + 1)
+  override def toString = if (value == 0) "zero" else "." * (value + 1)
+}
+
+object Cardinality {
+  val NoDot = new Cardinality(0)
+  val DotDot = new Cardinality(1)
+  val DotDotDot = new Cardinality(2)
+  def stripDots(part: String) =
+    if (part.endsWith("...")) (part.stripSuffix("..."), DotDotDot)
+    else if (part.endsWith("..")) (part.stripSuffix(".."), DotDot)
+    else (part, NoDot)
+}
+
+trait Macros { self: Quasiquotes =>
+  import c.universe._
+  import Cardinality._
+
+  /** Generates scala code to be parsed by parser and holes map from incoming args and parts. */
+  def generate(args: List[Tree], parts: List[String]): (String, Holes) = {
+    val sb = new StringBuilder()
+    var holes = ListMap[String, Hole]()
+
+    foreach2(args, parts.init) { (tree, p) =>
+      val (part, cardinality) = stripDots(p)
+      val freshname = c.fresh(nme.QUASIQUOTE_PREFIX)
+      sb.append(part)
+      sb.append(freshname)
+      holes += freshname -> Hole(tree, cardinality)
+    }
+    sb.append(parts.last)
+
+    (sb.toString, Holes(holes))
+  }
+
+  /** Quasiquote macro expansion core logic. */
+  def expand(universe: Tree, args: List[Tree], parts: List[String],
+             parse: (String, Set[String]) => Tree, reifier: (Tree, Holes) => Reifier) = {
+    val (code, holes) = generate(args, parts)
+    debug(s"\ncode to parse=\n$code\n")
+    val tree = parse(code, holes.keys.toSet)
+    debug(s"parsed tree\n=${tree}\n=${showRaw(tree)}\n")
+    val reified = reifier(universe, holes).reifyFillingHoles(tree)
+    debug(s"reified tree\n=${reified}\n=${showRaw(reified)}\n")
+    reified
+  }
+
+  /** Disassamble macroApplication tree and configure the required flavor for expansion. */
+  def dispatch = c.macroApplication match {
+    case Apply(Select(Select(Apply(Select(universe, _), List(Apply(_, parts0))), interpolator), method), args) =>
+      val parts = parts0.map {
+        case Literal(Constant(s: String)) => s
+        case part => c.abort(part.pos, "Quasiquotes can only be used with constant string arguments.")
+      }
+      val reifier = method match {
+        case nme.apply   => new ApplyReifier(_, _)
+        case nme.unapply => new UnapplyReifier(_, _)
+        case other       => global.abort(s"Unknown quasiquote api method: $other")
+      }
+      val parse = interpolator match {
+        case nme.q       => TermParser.parse(_, _)
+        case nme.tq      => TypeParser.parse(_, _)
+        case nme.cq      => CaseParser.parse(_, _)
+        case nme.pq      => PatternParser.parse(_, _)
+        case other       => global.abort(s"Unknown quasiquote flavor: $other")
+      }
+      expand(universe, args, parts, parse, reifier)
+    case _ =>
+      global.abort(s"Couldn't parse call prefix tree ${c.macroApplication}.")
+  }
+}

--- a/src/compiler/scala/tools/reflect/quasiquotes/Parsers.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Parsers.scala
@@ -1,0 +1,182 @@
+package scala.tools.reflect
+package quasiquotes
+
+import scala.tools.nsc.ast.parser.{Parsers => ScalaParser}
+import scala.tools.nsc.ast.parser.Tokens._
+import scala.compat.Platform.EOL
+import scala.reflect.internal.util.{BatchSourceFile, SourceFile}
+import scala.collection.mutable.ListBuffer
+
+trait Parsers { self: Quasiquotes =>
+  import global._
+
+  abstract class Parser extends {
+    val global: self.global.type = self.global
+  } with ScalaParser {
+    def wrapCode(code: String): String =
+      s"object wrapper { $$wrapper$$self => $EOL $code $EOL }"
+
+    def unwrapTree(wrappedTree: Tree): Tree = {
+      val PackageDef(_, List(ModuleDef(_, _, Template(_, _, _ :: parsed)))) = wrappedTree
+      parsed match {
+        case tree :: Nil => tree
+        case stats :+ tree => Block(stats, tree)
+      }
+    }
+
+    def parse(code: String, holes: Set[String]): Tree = {
+      try {
+        val wrapped = wrapCode(code)
+        debug(s"wrapped code\n=${wrapped}\n")
+        val file = new BatchSourceFile(nme.QUASIQUOTE_FILE, wrapped)
+        val tree = new QuasiquoteParser(file, holes).parse()
+        unwrapTree(tree)
+      } catch {
+        case mi: MalformedInput => c.abort(c.macroApplication.pos, s"syntax error: ${mi.msg}")
+      }
+    }
+
+    class QuasiquoteParser(source0: SourceFile, holes: Set[String]) extends SourceFileParser(source0) {
+      override val treeBuilder = new ParserTreeBuilder {
+        // q"(..$xs)"
+        override def makeTupleTerm(trees: List[Tree], flattenUnary: Boolean): Tree =
+          Apply(Ident(nme.QUASIQUOTE_TUPLE), trees)
+
+        // tq"(..$xs)"
+        override def makeTupleType(trees: List[Tree], flattenUnary: Boolean): Tree =
+          AppliedTypeTree(Ident(tpnme.QUASIQUOTE_TUPLE), trees)
+
+        // q"{ $x }"
+        override def makeBlock(stats: List[Tree]): Tree = stats match {
+          case Nil => Literal(Constant())
+          case _ :+ last if !last.isTerm => Block(stats, Literal(Constant()))
+          case (head @ Ident(TermName(name))) :: Nil if holes(name) => Block(Nil, head)
+          case head :: Nil => head
+          case first :+ last => Block(first, last)
+        }
+      }
+      import treeBuilder.{global => _, _}
+
+      // q"def foo($x)"
+      override def allowTypelessParams = true
+
+      // q"foo match { case $x }"
+      override def caseClauses(): List[CaseDef] = {
+        val cases = caseSeparated {
+          val casedef =
+            if (isPlaceholder && lookahead { in.token == CASE || in.token == RBRACE || in.token == SEMI }) {
+              val c = makeCaseDef(Apply(Ident(nme.QUASIQUOTE_CASE), List(Ident(ident()))), EmptyTree, EmptyTree)
+              while (in.token == SEMI) in.nextToken()
+              c
+            } else
+              makeCaseDef(pattern(), guard(), caseBlock())
+          atPos(in.offset)(casedef)
+        }
+        if (cases.isEmpty)  // trigger error if there are no cases
+          accept(CASE)
+
+        cases
+      }
+
+      private class PlainScannerData extends ScannerData {
+        var ch: Char = _
+        var charOffset: Int = 0
+        var lineStartOffset: Int = 0
+        var lastLineStartOffset: Int = 0
+      }
+
+      def lookahead[T](body: => T): T = {
+        // back up scanner state
+        val curr = new PlainScannerData().copyFrom(in)
+        val prev = new PlainScannerData().copyFrom(in.prev)
+        val next = new PlainScannerData().copyFrom(in.next)
+
+        in.nextToken()
+        val res = body
+
+        // restore saves state
+        in copyFrom curr
+        in.prev copyFrom prev
+        in.next copyFrom next
+
+        res
+      }
+
+      def isPlaceholder = isIdent && holes.contains(in.name.toString)
+
+      override def isAnnotation: Boolean =  super.isAnnotation || (isPlaceholder && lookahead { isAnnotation })
+
+      override def isModifier: Boolean = super.isModifier || (isPlaceholder && lookahead { isModifier })
+
+      override def isLocalModifier: Boolean = super.isLocalModifier || (isPlaceholder && lookahead { isLocalModifier })
+
+      override def isTemplateIntro: Boolean = super.isTemplateIntro || (isPlaceholder && lookahead { isTemplateIntro })
+
+      override def isDclIntro: Boolean = super.isDclIntro || (isPlaceholder && lookahead { isDclIntro })
+
+      def modsPlaceholderAnnot(name: TermName): Tree =
+        Apply(Select(New(Ident(tpnme.QUASIQUOTE_MODS)), nme.CONSTRUCTOR), List(Literal(Constant(name.toString))))
+
+      // $mods def foo
+      // $mods T
+      def quasiquoteReadAnnots(annot: => Tree): List[Tree] = {
+        val annots = new ListBuffer[Tree]
+        var break = false
+
+        while (!break) {
+          if (in.token == AT) {
+            in.nextToken()
+            annots += annot
+          } else if (isPlaceholder && lookahead { in.token == AT || isModifier || isDefIntro || isIdent}) {
+            annots += modsPlaceholderAnnot(in.name)
+            in.nextToken()
+          } else {
+            break = true
+          }
+        }
+        annots.toList
+      }
+
+      override def annotations(skipNewLines: Boolean): List[Tree] = quasiquoteReadAnnots {
+        val t = annotationExpr()
+        if (skipNewLines) newLineOpt()
+        t
+      }
+
+      override def constructorAnnotations(): List[Tree] = quasiquoteReadAnnots {
+        atPos(in.offset)(New(exprSimpleType(), List(argumentExprs())))
+      }
+    }
+  }
+
+  object TermParser extends Parser
+
+  object CaseParser extends Parser {
+    override def wrapCode(code: String) = super.wrapCode("something match { " + code + " }")
+
+    override def unwrapTree(wrappedTree: Tree): Tree = {
+      val Match(_, head :: tail) = super.unwrapTree(wrappedTree)
+      if (tail.nonEmpty)
+        c.abort(c.macroApplication.pos, "can't parse more than one casedef, generate match tree instead")
+      head
+    }
+  }
+
+  object PatternParser extends Parser {
+    override def wrapCode(code: String) = super.wrapCode("something match { case " + code + " => }")
+
+    override def unwrapTree(wrappedTree: Tree): Tree = {
+      val Match(_, List(CaseDef(pat, _, _))) = super.unwrapTree(wrappedTree)
+      pat
+    }
+  }
+
+  object TypeParser extends Parser {
+    override def wrapCode(code: String) = super.wrapCode("type T = " + code)
+
+    override def unwrapTree(wrappedTree: Tree): Tree = {
+      val TypeDef(_, _, _, rhs) = super.unwrapTree(wrappedTree)
+      rhs
+    }
+  }
+}

--- a/src/compiler/scala/tools/reflect/quasiquotes/Quasiquotes.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Quasiquotes.scala
@@ -1,0 +1,15 @@
+package scala.tools.reflect
+package quasiquotes
+
+import scala.reflect.macros.contexts.Context
+
+abstract class Quasiquotes extends Macros
+                              with Parsers
+                              with Reifiers  {
+  val c: Context
+  val global: c.universe.type = c.universe
+  import c.universe._
+
+  def debug(msg: String): Unit =
+    if (settings.Yquasiquotedebug.value) println(msg)
+}

--- a/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
@@ -1,0 +1,483 @@
+package scala.tools.reflect
+package quasiquotes
+
+import scala.tools.nsc.Global
+import scala.reflect.reify.{Reifier => ReflectReifier}
+import scala.reflect.macros
+import scala.collection.{immutable, mutable}
+import scala.reflect.internal.Flags._
+
+trait Reifiers { self: Quasiquotes =>
+  import global._
+  import global.build.SyntacticClassDef
+  import global.treeInfo._
+  import global.definitions._
+  import Cardinality._
+
+  case class Hole(tree: Tree, cardinality: Cardinality)
+  case class Holes(underlying: immutable.ListMap[String, Hole]) {
+    val accessed = mutable.Set[String]()
+    def keys = underlying.keys
+    def contains(key: String) = underlying.contains(key)
+    def apply(key: String) = {
+      accessed += key
+      underlying(key)
+    }
+    def get(key: String) = {
+      accessed += key
+      underlying.get(key)
+    }
+  }
+
+  abstract class Reifier(val universe: Tree, val holes: Holes) extends {
+    val global: self.global.type = self.global
+    val mirror = EmptyTree
+    val typer = null
+    val reifee = null
+    val concrete = false
+
+  } with ReflectReifier with Types {
+    // shortcut
+    val u = universe
+
+    /** Extractor that matches simple identity-like trees which
+     *  correspond to holes within quasiquote.
+     */
+    object Placeholder {
+      def unapply(tree: Tree): Option[String] = tree match {
+        case Ident(PlaceholderName(name)) => Some(name)
+        case TypeDef(_, PlaceholderName(name), List(), TypeBoundsTree(EmptyTree, EmptyTree)) => Some(name)
+        case ValDef(_, PlaceholderName(name), TypeTree(), EmptyTree) => Some(name)
+        case _ => None
+      }
+    }
+
+    object PlaceholderName {
+      def unapply(name: Name): Option[String] =
+        if (holes.contains(name.toString)) Some(name.toString)
+        else None
+    }
+
+    object AnnotPlaceholder {
+      def unapply(tree: Tree): Option[(String, List[Tree])] = tree match {
+        case Apply(Select(New(Placeholder(name)), nme.CONSTRUCTOR), args) => Some((name, args))
+        case _ => None
+      }
+    }
+
+    object ModsPlaceholder {
+      def unapply(tree: Tree): Option[String] = tree match {
+        case Apply(Select(New(Ident(tpnme.QUASIQUOTE_MODS)), nme.CONSTRUCTOR), List(Literal(Constant(s: String)))) => Some(s)
+        case _ => None
+      }
+    }
+
+    def reifyFillingHoles(tree: Tree): Tree = {
+      val reified = reifyTree(tree)
+      (holes.keys.toSet -- holes.accessed).foreach { hole =>
+        c.abort(holes(hole).tree.pos, "Don't know how to splice here")
+      }
+      reified
+    }
+
+    override def reifyTree(tree: Tree): Tree = reifyBasicTree(tree)
+
+    // Inline flags are those flags that have direct equivalent in scala code.
+    final val inlineFlags = List(
+      PRIVATE, PROTECTED, LAZY, IMPLICIT,
+      CASE, FINAL, COVARIANT, CONTRAVARIANT,
+      OVERRIDE, SEALED)
+
+    def ensureNoInlineFlags(m: Modifiers, pos: Position, action: String) = {
+      val flags = m.flags
+      inlineFlags.foreach { f =>
+        if ((flags & f) != 0L) c.abort(pos, "Can't $action Modifiers together with inline Flags")
+      }
+    }
+
+    override def mirrorSelect(name: String): Tree =
+      Select(universe, TermName(name))
+
+    override def mirrorCall(name: TermName, args: Tree*): Tree =
+      Apply(Select(universe, name), args.toList)
+
+    override def mirrorBuildCall(name: TermName, args: Tree*): Tree =
+      Apply(Select(Select(universe, nme.build), name), args.toList)
+  }
+
+  class ApplyReifier(universe: Tree, holes: Holes) extends Reifier(universe, holes) {
+    def isSupportedZeroCardinalityType(tpe: Type): Boolean =
+      tpe <:< treeType || tpe <:< nameType || tpe <:< modsType || tpe <:< flagsType || tpe <:< symbolType
+
+    object CorrespondsTo {
+      def unapply(name: Name): Option[(Tree, Type)] = unapply(name.toString)
+
+      def unapply(name: String): Option[(Tree, Type)] =
+        holes.get(name).flatMap { case Hole(tree, card) =>
+          (card, tree.tpe) match {
+            case (NoDot, tpe) if isSupportedZeroCardinalityType(tpe) =>
+              Some((tree, tpe))
+            case (NoDot, LiftableType(lift)) =>
+              Some((wrapLift(lift, tree), treeType))
+            case (card, iterable) if card != NoDot && iterable <:< iterableType =>
+              val (expected, tpe) = extractIterable(iterable)
+              if (expected != card)
+                c.abort(tree.pos, s"Expected $expected cardinality but got $card")
+              tpe match {
+                case tpe if tpe <:< treeType =>
+                  if (iterable <:< listTreeType || iterable <:< listListTreeType) Some(tree, iterable)
+                  else Some((wrapIterableN(tree, card) { t => t }, iterableN(card, tpe)))
+                case LiftableType(lift) =>
+                  Some((wrapIterableN(tree, card) { t => wrapLift(lift, t) }, iterableN(card, treeType)))
+                case tpe =>
+                  c.abort(tree.pos, s"Can't splice an Iterable of non-liftable type $tpe")
+              }
+            case (card, tpe) =>
+              val (itCard, itTpe) = extractIterable(tpe)
+              if (itCard != NoDot)
+                c.abort(tree.pos, s"To splice $tpe use $itCard cardinality or define a Liftable of this type")
+              else if (itCard == NoDot && card != NoDot)
+                c.abort(tree.pos, s"To splice $tpe use zero cardinality")
+              else
+                c.abort(tree.pos, s"Can't splice $tpe as it's neither Liftable nor one of natively supported types")
+          }
+        }
+
+      def wrapLift(lift: Tree, tree: Tree) = {
+        val lifted = Apply(lift, List(u, tree))
+        val targetType = Select(u, tpnme.Tree)
+        TypeApply(Select(lifted, nme.asInstanceOf_), List(targetType))
+      }
+
+      def wrapIterableN(tree: Tree, n: Cardinality)(default: Tree => Tree): Tree =
+        if (n == NoDot) default(tree)
+        else {
+          val x: TermName = c.freshName()
+          val wrapped = wrapIterableN(Ident(x), n.pred)(default)
+          val xToWrapped = Function(List(ValDef(Modifiers(PARAM), x, TypeTree(), EmptyTree)), wrapped)
+          Select(Apply(Select(tree, nme.map), List(xToWrapped)), nme.toList)
+        }
+
+      object LiftableType {
+        def unapply(tpe: Type): Option[Tree] = {
+          val liftType = appliedType(liftableType, List(tpe))
+          val lift = c.inferImplicitValue(liftType, silent = true)
+          if (lift != EmptyTree) Some(lift)
+          else None
+        }
+      }
+
+      def iterableN(n: Cardinality, tpe: Type): Type =
+        if (n == NoDot) tpe
+        else appliedType(IterableClass.toType, List(iterableN(n.pred, tpe)))
+
+      def extractIterable(tpe: Type): (Cardinality, Type) =
+        if (tpe <:< iterableType) {
+          val (card, innerTpe) = extractIterable(tpe.typeArguments(0))
+          (card.succ, innerTpe)
+        }
+        else (NoDot, tpe)
+    }
+
+    override def reifyBasicTree(tree: Tree): Tree = tree match {
+      case Ident(PlaceholderName(CorrespondsTo(sym, tpe))) if tpe <:< symbolType =>
+        Apply(Select(u, nme.Ident), List(sym))
+      case Select(tree, PlaceholderName(CorrespondsTo(sym, tpe))) if tpe <:< symbolType =>
+        Apply(Select(u, nme.Select), List(reifyTree(tree), sym))
+      case Literal(Constant(true)) =>
+        Select(Select(u, nme.build), nme.True)
+      case Literal(Constant(false)) =>
+        Select(Select(u, nme.build), nme.False)
+      case Placeholder(CorrespondsTo(tree, tpe)) if tpe <:< treeType =>
+        tree
+      case AppliedTypeTree(Ident(tpnme.QUASIQUOTE_TUPLE), args) =>
+        reifyTupleType(args)
+      case Apply(Ident(nme.QUASIQUOTE_TUPLE), args) =>
+        reifyTuple(args)
+      case Apply(f, List(Placeholder(CorrespondsTo(argss, tpe)))) if tpe <:< iterableIterableTreeType =>
+        val f1 = reifyTree(f)
+        val foldLeftF1 = Apply(TypeApply(Select(argss, nme.foldLeft), List(Select(u, tpnme.Tree))), List(f1))
+        def syntheticParam(name: TermName) = ValDef(Modifiers(PARAM | SYNTHETIC), name, TypeTree(), EmptyTree)
+        val uDotApply = Function(
+          List(syntheticParam(nme.x_1), syntheticParam(nme.x_2)),
+          Apply(Select(u, nme.Apply), List(Ident(nme.x_1), Ident(nme.x_2))))
+        Apply(foldLeftF1, List(uDotApply))
+      case Block(stats, p @ Placeholder(CorrespondsTo(tree, tpe))) =>
+        mirrorBuildCall(nme.Block, reifyList(stats :+ p))
+      case SyntacticClassDef(mods, name, tparams, constrmods, argss, parents, selfval, body) =>
+        mirrorBuildCall(nme.SyntacticClassDef, reifyModifiers(mods), reifyName(name),
+                        reifyList(tparams), reifyModifiers(constrmods), reifyList(argss),
+                        reifyList(parents), reifyTree(selfval), reifyList(body))
+      case CaseDef(Apply(Ident(nme.QUASIQUOTE_CASE), List(Placeholder(CorrespondsTo(tree, tpe)))), EmptyTree, EmptyTree) =>
+        if (!(tpe <:< caseDefType)) c.abort(tree.pos, s"CaseDef expected but $tpe found")
+        tree
+      case Placeholder(name) if holes(name).cardinality != NoDot =>
+        val Hole(tree, card) = holes(name)
+        c.abort(tree.pos, s"Can't splice with $card cardinality here")
+      case _ =>
+        super.reifyBasicTree(tree)
+    }
+
+    def reifyTuple(args: List[Tree]) = args match {
+      case Nil => reify(Literal(Constant(())))
+      case List(hole @ Placeholder(CorrespondsTo(tree, tpe))) if !(tpe <:< iterableType) => reify(hole)
+      case List(Placeholder(_)) => mirrorBuildCall(nme.TupleN, reifyList(args))
+      case List(other) => reify(other)
+      case _ => mirrorBuildCall(nme.TupleN, reifyList(args))
+    }
+
+    def reifyTupleType(args: List[Tree]) = args match {
+      case Nil => reify(Select(Ident(nme.scala_), tpnme.Unit))
+      case List(hole @ Placeholder(CorrespondsTo(tree, tpe))) if !(tpe <:< iterableType) => reify(hole)
+      case List(Placeholder(_)) => mirrorBuildCall(nme.TupleTypeN, reifyList(args))
+      case List(other) => reify(other)
+      case _ => mirrorBuildCall(nme.TupleTypeN, reifyList(args))
+    }
+
+    override def reifyName(name: Name): Tree = name match {
+      case CorrespondsTo(tree, tpe) =>
+        if (tpe <:< nameType) tree
+        else c.abort(tree.pos, s"Name expected but ${tpe} found")
+      case _ =>
+        super.reifyName(name)
+    }
+
+    /** Splits list into a list of groups where subsequent elements are considered
+     *  similar by the corresponding function.
+     *
+     *  Example:
+     *
+     *    > group(List(1, 1, 0, 0, 1, 0)) { _ == _ }
+     *    List(List(1, 1), List(0, 0), List(1), List(0))
+     *
+     */
+    def group[T](lst: List[T])(similar: (T, T) => Boolean) = lst.foldLeft[List[List[T]]](List()) {
+      case (Nil, el) => List(List(el))
+      case (ll :+ (last @ (lastinit :+ lastel)), el) if similar(lastel, el) => ll :+ (last :+ el)
+      case (ll, el) => ll :+ List(el)
+    }
+
+    /** Reifies list filling all the valid holes.
+     *
+     *  Reification of non-trivial list is done in two steps:
+     *
+     *  1. split the list into groups where every placeholder is always
+     *     put in a group of it's own and all subsquent non-holes are
+     *     grouped together; element is considered to be a placeholder if it's
+     *     in the domain of the fill function;
+     *
+     *  2. fold the groups into a sequence of lists added together with ++ using
+     *     fill reification for holes and fallback reification for non-holes.
+     *
+     *  Example:
+     *
+     *    reifyListGeneric(lst) {
+     *      // first we define patterns that extract high-cardinality holes (currently .. and ...)
+     *      case ListHolePattern(...) => listTree
+     *    } {
+     *      // in the end we define how single elements are reified, typically with default reify call
+     *      reify(_)
+     *    }
+     */
+    def reifyListGeneric[T](xs: List[T])(fill: PartialFunction[T, Tree])(fallback: T => Tree): Tree =
+      xs match {
+        case Nil => mkList(Nil)
+        case _ =>
+          def reifyGroup(group: List[T]): Tree = group match {
+            case List(elem) if fill.isDefinedAt(elem) => fill(elem)
+            case elems => mkList(elems.map(fallback))
+          }
+          val head :: tail = group(xs) { (a, b) => !fill.isDefinedAt(a) && !fill.isDefinedAt(b) }
+          // tail.foldLeft[Tree](reifyGroup(head)) { (tree, lst) => q"$tree ++ ${reifyGroup(lst)}" }
+          tail.foldLeft[Tree](reifyGroup(head)) { (tree, lst) => Apply(Select(tree, nme.PLUSPLUS), List(reifyGroup(lst))) }
+      }
+
+    /** Reifies arbitrary list filling ..$x and ...$y holes when they are put
+     *  in the correct position. Fallbacks to regular reification for non-high cardinality
+     *  elements.
+     */
+    override def reifyList(xs: List[Any]): Tree = reifyListGeneric(xs) {
+      case Placeholder(CorrespondsTo(tree, tpe)) if tpe <:< iterableTreeType => tree
+      case CaseDef(Apply(Ident(nme.QUASIQUOTE_CASE), List(Placeholder(CorrespondsTo(tree, tpe)))), EmptyTree, EmptyTree) if tpe <:< iterableCaseDefType => tree
+      case List(Placeholder(CorrespondsTo(tree, tpe))) if tpe <:< iterableIterableTreeType => tree
+    } {
+      reify(_)
+    }
+
+    /** Custom list reifier for annotations. It's required because they have different shape
+     *  and additional $u.build.mkAnnotatorCtor wrapping is needed to ensure that user won't
+     *  splice a non-constructor call in this position.
+     */
+    def reifyAnnotsList(annots: List[Tree]): Tree = reifyListGeneric(annots) {
+      case AnnotPlaceholder(CorrespondsTo(tree, tpe), args) if tpe <:< iterableTreeType =>
+        val x: TermName = c.freshName()
+        val xToAnnotationRepr = Function(
+          List(ValDef(Modifiers(PARAM), x, TypeTree(), EmptyTree)),
+          mirrorBuildCall(nme.mkAnnotatorCtor, Ident(x), reify(args)))
+        Apply(Select(tree, nme.map), List(xToAnnotationRepr))
+    } {
+      case AnnotPlaceholder(CorrespondsTo(tree, tpe), args) if tpe <:< treeType =>
+        mirrorBuildCall(nme.mkAnnotatorCtor, tree, reify(args))
+      case other => reify(other)
+    }
+
+    override def reifyModifiers(m: Modifiers) = {
+      val (modsholes, annots) = m.annotations.partition {
+        case ModsPlaceholder(_) => true
+        case _ => false
+      }
+      val (mods, flags) = modsholes.map {
+        case ModsPlaceholder(CorrespondsTo((tree, tpe))) => (tree, tpe)
+      }.partition { case (tree, tpe) =>
+        if (tpe <:< modsType) true
+        else if (tpe <:< flagsType) false
+        else c.abort(tree.pos, "Instance of FlagSet or Modifiers type is expected here but ${tree.tpe} found")
+      }
+      mods match {
+        case (tree, _) :: Nil =>
+          if (flags.nonEmpty) c.abort(flags(0)._1.pos, "Can't splice Flags together with Modifiers")
+          if (annots.nonEmpty) c.abort(tree.pos, "Can't splice Modifiers together with additional annotations")
+          ensureNoInlineFlags(m, tree.pos, "splice")
+          tree
+        case _ :: (second, _) :: Nil =>
+          c.abort(second.pos, "Can't splice multiple Modifiers")
+        case _ =>
+          val baseFlags = mirrorBuildCall(nme.flagsFromBits, reify(m.flags))
+          // val reifiedFlags = flags.foldLeft[Tree](baseFlags) { case (flag, (tree, _)) => q"$flag | $tree" }
+          val reifiedFlags = flags.foldLeft[Tree](baseFlags) { case (flag, (tree, _)) => Apply(Select(flag, nme.OR), List(tree)) }
+          mirrorFactoryCall(nme.Modifiers, reifiedFlags, reify(m.privateWithin), reifyAnnotsList(annots))
+      }
+    }
+  }
+
+  class UnapplyReifier(universe: Tree, holes: Holes) extends Reifier(universe, holes) {
+    object CorrespondsTo {
+      def unapply(name: String): Option[(Tree, Cardinality)] =
+        holes.get(name).map { case Hole(tree, card) => (tree, card) }
+    }
+
+    override def reifyBasicTree(tree: Tree): Tree = tree match {
+      case global.emptyValDef =>
+        mirrorBuildCall(nme.EmptyValDefLike)
+      case global.pendingSuperCall =>
+        mirrorBuildCall(nme.PendingSuperCallLike)
+      case Placeholder(CorrespondsTo(tree, card)) =>
+        if (card != NoDot) c.abort(tree.pos, s"Can't extract a part of the tree with $card cardinality here")
+        tree
+      case AppliedTypeTree(Ident(tpnme.QUASIQUOTE_TUPLE), args) => reifyTupleType(args)
+      case Apply(Ident(nme.QUASIQUOTE_TUPLE), args) => reifyTuple(args)
+      case Applied(fun, targs, argss) if fun != tree =>
+        if (targs.length > 0)
+          mirrorBuildCall(nme.Applied, reify(fun), reifyList(targs), reifyList(argss))
+        else
+          mirrorBuildCall(nme.Applied2, reify(fun), reifyList(argss))
+      case SyntacticClassDef(mods, name, tparams, constrmods, argss, parents, selfval, body) =>
+        mirrorBuildCall(nme.SyntacticClassDef, reifyModifiers(mods), reifyName(name),
+                        reifyList(tparams), reifyModifiers(constrmods), reifyList(argss),
+                        reifyList(parents), reifyTree(selfval), reifyList(body))
+      case _ =>
+        super.reifyBasicTree(tree)
+    }
+
+    def reifyTuple(args: List[Tree]) = args match {
+      case Nil => reify(Literal(Constant(())))
+      case List(hole @ Placeholder(CorrespondsTo(tree, NoDot))) => reify(hole)
+      case List(Placeholder(CorrespondsTo(tree, card))) => mirrorBuildCall(nme.TupleN, reifyList(args))
+      case List(other) => reify(other)
+      case _ => mirrorBuildCall(nme.TupleN, reifyList(args))
+    }
+
+    def reifyTupleType(args: List[Tree]) = args match {
+      case Nil => reify(Select(Ident(nme.scala_), tpnme.Unit))
+      case List(hole @ Placeholder(CorrespondsTo(tree, NoDot))) => reify(hole)
+      case List(Placeholder(CorrespondsTo(tree, card))) => mirrorBuildCall(nme.TupleTypeN, reifyList(args))
+      case List(other) => reify(other)
+      case _ => mirrorBuildCall(nme.TupleTypeN, reifyList(args))
+    }
+
+    override def scalaFactoryCall(name: String, args: Tree*): Tree =
+      call("scala." + name, args: _*)
+
+    override def reifyName(name: Name): Tree =
+      if (!holes.contains(name.toString)) super.reifyName(name)
+      else holes(name.toString).tree
+
+    def reifyListGeneric(xs: List[Any])(fill: PartialFunction[Any, Tree])(fallback: Any => Tree = reify) =
+      xs match {
+        case init :+ last if fill.isDefinedAt(last) =>
+          init.foldRight[Tree](fill(last)) { (el, rest) =>
+            val cons = Select(Select(Select(Ident(nme.scala_), nme.collection), nme.immutable), nme.CONS)
+            Apply(cons, List(fallback(el), rest))
+          }
+        case _ =>
+          mkList(xs.map(fallback))
+      }
+
+    override def reifyList(xs: List[Any]): Tree = reifyListGeneric(xs) {
+      case Placeholder(CorrespondsTo(tree, DotDot)) => tree
+      case List(Placeholder(CorrespondsTo(tree, DotDotDot))) => tree
+    } ()
+
+    def reifyAnnotsList(annots: List[Tree]): Tree = reifyListGeneric(annots) {
+      case AnnotPlaceholder(CorrespondsTo(tree, DotDot), Nil) => tree
+    } {
+      case AnnotPlaceholder(CorrespondsTo(tree, NoDot), args) =>
+        args match {
+          case Nil => tree
+          // case _ => q"$u.Apply($u.Select($u.New($tree), $u.nme.CONSTRUCTOR), ${reify(args)})"
+          case _ =>
+            val selectCONSTRUCTOR = Apply(Select(u, nme.Select), List(Apply(Select(u, nme.New), List(tree)), Select(Select(u, nme.nmeNme), nme.nmeCONSTRUCTOR)))
+            Apply(Select(u, nme.Apply), List(selectCONSTRUCTOR, reify(args)))
+        }
+      case other =>
+        reify(other)
+    }
+
+    override def reifyModifiers(m: Modifiers) = {
+      val mods = m.annotations.collect {
+        case ModsPlaceholder(CorrespondsTo(tree, _)) => tree
+      }
+      mods match {
+        case tree :: Nil =>
+          if (m.annotations.length != 1) c.abort(tree.pos, "Can't extract Modifiers together with additional annotations")
+          ensureNoInlineFlags(m, tree.pos, "extract")
+          tree
+        case _ :: second :: rest =>
+          c.abort(second.pos, "Can't extract multiple Modifiers")
+        case Nil =>
+          mirrorFactoryCall(nme.Modifiers, mirrorBuildCall(nme.FlagsAsBits, reify(m.flags)),
+                                           reify(m.privateWithin), reifyAnnotsList(m.annotations))
+      }
+    }
+  }
+
+  trait Types {
+    val universe: Tree
+
+    lazy val universeType = universe.tpe
+    lazy val nameType = memberType(universeType, tpnme.Name)
+    lazy val termNameType = memberType(universeType, tpnme.TypeName)
+    lazy val typeNameType = memberType(universeType, tpnme.TermName)
+    lazy val modsType = memberType(universeType, tpnme.Modifiers)
+    lazy val flagsType = memberType(universeType, tpnme.FlagSet)
+    lazy val symbolType = memberType(universeType, tpnme.Symbol)
+    lazy val treeType = memberType(universeType, tpnme.Tree)
+    lazy val typeDefType = memberType(universeType, tpnme.TypeDef)
+    lazy val caseDefType = memberType(universeType, tpnme.CaseDef)
+    lazy val liftableType = LiftableClass.toType
+    lazy val iterableType = appliedType(IterableClass.toType, List(AnyTpe))
+    lazy val iterableTreeType = appliedType(iterableType, List(treeType))
+    lazy val iterableCaseDefType = appliedType(iterableType, List(caseDefType))
+    lazy val iterableIterableTreeType = appliedType(iterableType, List(iterableTreeType))
+    lazy val listType = appliedType(ListClass.toType, List(AnyTpe))
+    lazy val listTreeType = appliedType(listType, List(treeType))
+    lazy val listListTreeType = appliedType(listType, List(listTreeType))
+    lazy val optionTreeType = appliedType(OptionClass.toType, List(treeType))
+    lazy val optionNameType = appliedType(OptionClass.toType, List(nameType))
+  }
+
+  def memberType(thistype: Type, name: TypeName): Type = {
+    val sym = thistype.typeSymbol.typeSignature.member(name)
+    sym.asType.toType.typeConstructor.asSeenFrom(thistype, sym.owner)
+  }
+}

--- a/src/reflect/scala/reflect/api/BuildUtils.scala
+++ b/src/reflect/scala/reflect/api/BuildUtils.scala
@@ -66,6 +66,8 @@ private[reflect] trait BuildUtils { self: Universe =>
 
     def Ident(sym: Symbol): Ident
 
+    def Block(stats: List[Tree]): Block
+
     def TypeTree(tp: Type): TypeTree
 
     def thisPrefix(sym: Symbol): Type
@@ -73,5 +75,58 @@ private[reflect] trait BuildUtils { self: Universe =>
     def setType[T <: Tree](tree: T, tpe: Type): T
 
     def setSymbol[T <: Tree](tree: T, sym: Symbol): T
+
+    def mkAnnotatorCtor(tree: Tree, args: List[Tree]): Tree
+
+    val FlagsAsBits: FlagsAsBitsExtractor
+
+    trait FlagsAsBitsExtractor {
+      def unapply(flags: Long): Option[Long]
+    }
+
+    val EmptyValDefLike: EmptyValDefExtractor
+
+    trait EmptyValDefExtractor {
+      def unapply(t: Tree): Boolean
+    }
+
+    val PendingSuperCallLike: PendingSuperCallExtractor
+
+    trait PendingSuperCallExtractor {
+      def unapply(t: Tree): Boolean
+    }
+
+    val Applied: AppliedExtractor
+
+    trait AppliedExtractor {
+      def unapply(tree: Tree): Option[(Tree, List[Tree], List[List[Tree]])]
+    }
+
+    val Applied2: Applied2Extractor
+
+    trait Applied2Extractor {
+      def unapply(tree: Tree): Option[(Tree, List[List[Tree]])]
+    }
+
+    val SyntacticClassDef: SyntacticClassDefExtractor
+
+    trait SyntacticClassDefExtractor {
+      def apply(mods: Modifiers, name: TypeName, tparams: List[TypeDef],
+                constrMods: Modifiers, vparamss: List[List[ValDef]], parents: List[Tree],
+                selfdef: ValDef, body: List[Tree]): Tree
+      def unapply(tree: Tree): Option[(Modifiers, TypeName, List[TypeDef], Modifiers,
+                                       List[List[ValDef]], List[Tree], ValDef, List[Tree])]
+    }
+
+    val TupleN: TupleNExtractor
+    val TupleTypeN: TupleNExtractor
+
+    trait TupleNExtractor {
+      def apply(args: List[Tree]): Tree
+      def unapply(tree: Tree): Option[List[Tree]]
+    }
+
+    def True: Tree
+    def False: Tree
   }
 }

--- a/src/reflect/scala/reflect/api/Liftable.scala
+++ b/src/reflect/scala/reflect/api/Liftable.scala
@@ -1,0 +1,32 @@
+package scala.reflect
+package api
+
+trait Liftable[T] {
+  def apply(universe: api.Universe, value: T): universe.Tree
+}
+
+object Liftable {
+  private class LiftableConstant[T] extends Liftable[T] {
+    def apply(universe: Universe, value: T): universe.Tree =
+      universe.Literal(universe.Constant(value))
+  }
+
+  implicit lazy val liftByte: Liftable[Byte] = new LiftableConstant[Byte]
+  implicit lazy val liftShort: Liftable[Short] = new LiftableConstant[Short]
+  implicit lazy val liftChar: Liftable[Char] = new LiftableConstant[Char]
+  implicit lazy val liftInt: Liftable[Int] = new LiftableConstant[Int]
+  implicit lazy val liftLong: Liftable[Long] = new LiftableConstant[Long]
+  implicit lazy val liftFloat: Liftable[Float] = new LiftableConstant[Float]
+  implicit lazy val liftDouble: Liftable[Double] = new LiftableConstant[Double]
+  implicit lazy val liftBoolean: Liftable[Boolean] = new LiftableConstant[Boolean]
+  implicit lazy val liftString: Liftable[String] = new LiftableConstant[String]
+  implicit lazy val liftUnit: Liftable[Unit] = new LiftableConstant[Unit]
+
+  implicit lazy val liftScalaSymbol: Liftable[scala.Symbol] = new Liftable[scala.Symbol] {
+    def apply(universe: Universe, value: scala.Symbol): universe.Tree = {
+      import universe._
+      val symbol = Select(Ident(TermName("scala")), TermName("Symbol"))
+      Apply(symbol, List(Literal(Constant(value.name))))
+    }
+  }
+}

--- a/src/reflect/scala/reflect/api/Quasiquotes.scala
+++ b/src/reflect/scala/reflect/api/Quasiquotes.scala
@@ -1,0 +1,20 @@
+package scala.reflect
+package api
+
+import language.experimental.macros
+
+trait Quasiquotes { self: Universe =>
+
+  // implementation is hardwired to `dispatch` method of `scala.tools.reflect.quasiquotes.Quasiquotes`
+  // using the mechanism implemented in `scala.tools.reflect.FastTrack`
+  implicit class Quasiquote(ctx: StringContext) {
+    protected trait api {
+      def apply(args: Any*): Any = macro ???
+      def unapply(subpatterns: Any*): Option[Any] = macro ???
+    }
+    object q extends api
+    object tq extends api
+    object сq extends api
+    object pq extends api
+  }
+}

--- a/src/reflect/scala/reflect/api/StandardLiftables.scala
+++ b/src/reflect/scala/reflect/api/StandardLiftables.scala
@@ -1,0 +1,36 @@
+package scala.reflect
+package api
+
+trait StandardLiftables { self: Universe =>
+
+  private def requireSameUniverse[T](universe: Universe, tp: String, value: T) =
+    require(universe eq self, s"Can't lift $tp ${showRaw(value)} from universe ${showRaw(universe)} using lift$tp defined for ${showRaw(self)}.")
+
+  implicit def liftExpr[T <: Expr[_]]: Liftable[T] = new Liftable[T] {
+    def apply(universe: Universe, value: T): universe.Tree = {
+      requireSameUniverse(universe, "Expr", value)
+      value.tree.asInstanceOf[universe.Tree]
+    }
+  }
+
+  implicit object liftType extends Liftable[Type] {
+    def apply(universe: Universe, value: Type): universe.Tree = {
+      requireSameUniverse(universe, "Type", value)
+      universe.TypeTree(value.asInstanceOf[universe.Type])
+    }
+  }
+
+  implicit def liftTypeTag[T <: WeakTypeTag[_]]: Liftable[T] = new Liftable[T] {
+    def apply(universe: Universe, value: T): universe.Tree = {
+      requireSameUniverse(universe, "TypeTag", value)
+      universe.TypeTree(value.asInstanceOf[universe.WeakTypeTag[_]].tpe)
+    }
+  }
+
+  implicit object liftConstant extends Liftable[Constant] {
+    def apply(universe: Universe, value: Constant): universe.Tree = {
+      requireSameUniverse(universe, "Constant", value)
+      universe.Literal(value.asInstanceOf[universe.Constant])
+    }
+  }
+}

--- a/src/reflect/scala/reflect/api/Universe.scala
+++ b/src/reflect/scala/reflect/api/Universe.scala
@@ -72,10 +72,12 @@ abstract class Universe extends Symbols
                            with ImplicitTags
                            with StandardDefinitions
                            with StandardNames
+                           with StandardLiftables
                            with BuildUtils
                            with Mirrors
                            with Printers
                            with Importers
+                           with Quasiquotes
 {
   /** Use `refiy` to produce the abstract syntax tree representing a given Scala expression.
    *

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -442,6 +442,7 @@ trait Definitions extends api.StandardDefinitions {
     // collections classes
     lazy val ConsClass          = requiredClass[scala.collection.immutable.::[_]]
     lazy val IteratorClass      = requiredClass[scala.collection.Iterator[_]]
+    lazy val IterableClass      = requiredClass[scala.collection.Iterable[_]]
     lazy val ListClass          = requiredClass[scala.collection.immutable.List[_]]
     lazy val SeqClass           = requiredClass[scala.collection.Seq[_]]
     lazy val StringBuilderClass = requiredClass[scala.collection.mutable.StringBuilder]
@@ -520,6 +521,7 @@ trait Definitions extends api.StandardDefinitions {
 
     lazy val TypeCreatorClass      = getClassIfDefined("scala.reflect.api.TypeCreator") // defined in scala-reflect.jar, so we need to be careful
     lazy val TreeCreatorClass      = getClassIfDefined("scala.reflect.api.TreeCreator") // defined in scala-reflect.jar, so we need to be careful
+    lazy val LiftableClass         = getClassIfDefined("scala.reflect.api.Liftable")    // defined in scala-reflect.jar, so we need to be careful
 
     lazy val MacroClass                   = getClassIfDefined("scala.reflect.macros.Macro") // defined in scala-reflect.jar, so we need to be careful
     lazy val MacroContextClass            = getClassIfDefined("scala.reflect.macros.Context") // defined in scala-reflect.jar, so we need to be careful
@@ -533,6 +535,11 @@ trait Definitions extends api.StandardDefinitions {
 
     lazy val StringContextClass           = requiredClass[scala.StringContext]
          def StringContext_f              = getMemberMethod(StringContextClass, nme.f)
+
+    lazy val QuasiquoteClass             = if (ApiUniverseClass != NoSymbol) getMember(ApiUniverseClass, tpnme.Quasiquote) else NoSymbol
+    lazy val QuasiquoteClass_api         = if (QuasiquoteClass != NoSymbol) getMember(QuasiquoteClass, tpnme.api) else NoSymbol
+    lazy val QuasiquoteClass_api_apply   = if (QuasiquoteClass_api != NoSymbol) getMember(QuasiquoteClass_api, nme.apply) else NoSymbol
+    lazy val QuasiquoteClass_api_unapply = if (QuasiquoteClass_api != NoSymbol) getMember(QuasiquoteClass_api, nme.unapply) else NoSymbol
 
     lazy val ScalaSignatureAnnotation = requiredClass[scala.reflect.ScalaSignature]
     lazy val ScalaLongSignatureAnnotation = requiredClass[scala.reflect.ScalaLongSignature]

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -216,23 +216,39 @@ trait StdNames {
 
     final val Any: NameType             = "Any"
     final val AnyVal: NameType          = "AnyVal"
+    final val FlagSet: NameType         = "FlagSet"
     final val Mirror: NameType          = "Mirror"
+    final val Modifiers: NameType       = "Modifiers"
     final val Nothing: NameType         = "Nothing"
     final val Null: NameType            = "Null"
     final val Object: NameType          = "Object"
+    final val Option: NameType          = "Option"
     final val PrefixType: NameType      = "PrefixType"
     final val Product: NameType         = "Product"
     final val Serializable: NameType    = "Serializable"
     final val Singleton: NameType       = "Singleton"
     final val Throwable: NameType       = "Throwable"
 
+    final val api: NameType                 = "api"
     final val Annotation: NameType          = "Annotation"
+    final val CaseDef: NameType             = "CaseDef"
     final val ClassfileAnnotation: NameType = "ClassfileAnnotation"
     final val ClassManifest: NameType       = "ClassManifest"
     final val Enum: NameType                = "Enum"
     final val Group: NameType               = "Group"
+    final val Name: NameType                = "Name"
     final val Tree: NameType                = "Tree"
+    final val TermName: NameType            = "TermName"
     final val Type : NameType               = "Type"
+    final val TypeName: NameType            = "TypeName"
+    final val TypeDef: NameType             = "TypeDef"
+    final val Tuple: NameType               = "Tuple"
+    final val Universe: NameType            = "Universe"
+    final val Quasiquote: NameType          = "Quasiquote"
+
+    // quasiquote-specific names
+    final val QUASIQUOTE_MODS: NameType     = "$quasiquote$mods$"
+    final val QUASIQUOTE_TUPLE: NameType    = "$quasiquote$tuple$"
 
     // Annotation simple names, used in Namer
     final val BeanPropertyAnnot: NameType = "BeanProperty"
@@ -304,6 +320,10 @@ trait StdNames {
     val REIFY_FREE_THIS_SUFFIX: NameType   = "$this"
     val REIFY_FREE_VALUE_SUFFIX: NameType  = "$value"
     val REIFY_SYMDEF_PREFIX: NameType      = "symdef$"
+    val QUASIQUOTE_PREFIX: String          = "$quasiquote$"
+    val QUASIQUOTE_FILE: String            = "<quasiquotes>"
+    val QUASIQUOTE_TUPLE: NameType         = "$quasiquote$tuple$"
+    val QUASIQUOTE_CASE: NameType          = "$quasiquote$case$"
     val MIXIN_CONSTRUCTOR: NameType        = "$init$"
     val MODULE_INSTANCE_FIELD: NameType    = NameTransformer.MODULE_INSTANCE_NAME  // "MODULE$"
     val OUTER: NameType                    = "$outer"
@@ -539,30 +559,43 @@ trait StdNames {
     val Annotation: NameType           = "Annotation"
     val Any: NameType                  = "Any"
     val AnyVal: NameType               = "AnyVal"
+    val Apply: NameType                = "Apply"
+    val Applied: NameType              = "Applied"
+    val Applied2: NameType             = "Applied2"
     val ArrayAnnotArg: NameType        = "ArrayAnnotArg"
+    val Block: NameType                = "Block"
     val ConstantType: NameType         = "ConstantType"
     val EmptyPackage: NameType         = "EmptyPackage"
     val EmptyPackageClass: NameType    = "EmptyPackageClass"
+    val EmptyValDefLike: NameType      = "EmptyValDefLike"
+    val False : NameType               = "False"
     val Flag : NameType                = "Flag"
+    val FlagsAsBits: NameType          = "FlagsAsBits"
     val Ident: NameType                = "Ident"
     val Import: NameType               = "Import"
     val Literal: NameType              = "Literal"
     val LiteralAnnotArg: NameType      = "LiteralAnnotArg"
     val Modifiers: NameType            = "Modifiers"
     val NestedAnnotArg: NameType       = "NestedAnnotArg"
+    val New: NameType                  = "New"
     val NoFlags: NameType              = "NoFlags"
     val NoSymbol: NameType             = "NoSymbol"
     val Nothing: NameType              = "Nothing"
     val Null: NameType                 = "Null"
     val Object: NameType               = "Object"
+    val PendingSuperCallLike: NameType = "PendingSuperCallLike"
     val RootPackage: NameType          = "RootPackage"
     val RootClass: NameType            = "RootClass"
     val Select: NameType               = "Select"
     val SelectFromTypeTree: NameType   = "SelectFromTypeTree"
     val StringContext: NameType        = "StringContext"
+    val SyntacticClassDef: NameType    = "SyntacticClassDef"
     val This: NameType                 = "This"
     val ThisType: NameType             = "ThisType"
+    val True : NameType                = "True"
     val Tuple2: NameType               = "Tuple2"
+    val TupleN: NameType               = "TupleN"
+    val TupleTypeN: NameType           = "TupleTypeN"
     val TYPE_ : NameType               = "TYPE"
     val TypeRef: NameType              = "TypeRef"
     val TypeTree: NameType             = "TypeTree"
@@ -593,6 +626,7 @@ trait StdNames {
     val checkInitialized: NameType     = "checkInitialized"
     val classOf: NameType              = "classOf"
     val clone_ : NameType              = "clone"
+    val collection: NameType           = "collection"
     val conforms: NameType             = "conforms"
     val copy: NameType                 = "copy"
     val create: NameType               = "create"
@@ -619,10 +653,13 @@ trait StdNames {
     val find_ : NameType               = "find"
     val flagsFromBits : NameType       = "flagsFromBits"
     val flatMap: NameType              = "flatMap"
+    val flatten: NameType              = "flatten"
+    val foldLeft: NameType             = "foldLeft"
     val foreach: NameType              = "foreach"
     val get: NameType                  = "get"
     val hashCode_ : NameType           = "hashCode"
     val hash_ : NameType               = "hash"
+    val immutable: NameType            = "immutable"
     val implicitly: NameType           = "implicitly"
     val in: NameType                   = "in"
     val inlinedEquals: NameType        = "inlinedEquals"
@@ -644,12 +681,15 @@ trait StdNames {
     val materializeWeakTypeTag: NameType = "materializeWeakTypeTag"
     val materializeTypeTag: NameType   = "materializeTypeTag"
     val moduleClass : NameType         = "moduleClass"
+    val mkAnnotatorCtor: NameType      = "mkAnnotatorCtor"
     val ne: NameType                   = "ne"
     val newArray: NameType             = "newArray"
     val newFreeTerm: NameType          = "newFreeTerm"
     val newFreeType: NameType          = "newFreeType"
     val newNestedSymbol: NameType      = "newNestedSymbol"
     val newScopeWith: NameType         = "newScopeWith"
+    val nmeCONSTRUCTOR: NameType       = "CONSTRUCTOR"
+    val nmeNme: NameType               = "nme"
     val notifyAll_ : NameType          = "notifyAll"
     val notify_ : NameType             = "notify"
     val null_ : NameType               = "null"
@@ -684,6 +724,7 @@ trait StdNames {
     val this_ : NameType               = "this"
     val thisPrefix : NameType          = "thisPrefix"
     val toArray: NameType              = "toArray"
+    val toList: NameType               = "toList"
     val toObjectArray : NameType       = "toObjectArray"
     val TopScope: NameType             = "TopScope"
     val toString_ : NameType           = "toString"
@@ -694,6 +735,7 @@ trait StdNames {
     val typedProductIterator: NameType = "typedProductIterator"
     val TypeName: NameType             = "TypeName"
     val typeTagToManifest: NameType    = "typeTagToManifest"
+
     val unapply: NameType              = "unapply"
     val unapplySeq: NameType           = "unapplySeq"
     val unbox: NameType                = "unbox"
@@ -707,6 +749,12 @@ trait StdNames {
     val wait_ : NameType               = "wait"
     val withFilter: NameType           = "withFilter"
     val zero: NameType                 = "zero"
+
+    // quasiquote interpolators:
+    val q: NameType                    = "q"
+    val tq: NameType                   = "tq"
+    val cq: NameType                   = "cq"
+    val pq: NameType                   = "pq"
 
     // unencoded operators
     object raw {
@@ -744,6 +792,7 @@ trait StdNames {
     val ADD      = encode("+")
     val AND      = encode("&")
     val ASR      = encode(">>")
+    val CONS     = encode("::")
     val DIV      = encode("/")
     val EQ       = encode("==")
     val EQL      = encode("=")
@@ -760,6 +809,7 @@ trait StdNames {
     val NE       = encode("!=")
     val OR       = encode("|")
     val PLUS     = ADD    // technically redundant, but ADD looks funny with MINUS
+    val PLUSPLUS = encode("++")
     val SUB      = MINUS  // ... as does SUB with PLUS
     val XOR      = encode("^")
     val ZAND     = encode("&&")

--- a/test/files/scalacheck/quasiquotes/ArbitraryTreesAndNames.scala
+++ b/test/files/scalacheck/quasiquotes/ArbitraryTreesAndNames.scala
@@ -1,0 +1,306 @@
+import org.scalacheck._
+import Prop._
+import Gen._
+import Arbitrary._
+
+import scala.reflect.api._
+import scala.reflect.runtime.universe._
+import scala.reflect.runtime.universe.Flag._
+
+trait ArbitraryTreesAndNames {
+  def smallList[T](size: Int, g: Gen[T]) = {
+    val n: Int = choose(0, size / 2 + 1).sample match {
+      case Some(i) => i
+      case None => 0
+    }
+    containerOfN[List, T](n, g)
+  }
+
+  def shortIdent(len: Int) =
+    for(name <- identifier)
+      yield if(name.length <= len) name
+            else name.substring(0, len - 1)
+
+  def genTermName = for(name <- shortIdent(8)) yield TermName(name)
+  def genTypeName = for(name <- shortIdent(8)) yield TypeName(name)
+  def genName = oneOf(genTermName, genTypeName)
+
+  def genFlagSet = oneOf(
+    TRAIT, INTERFACE, MUTABLE, MACRO,
+    DEFERRED, ABSTRACT, FINAL, SEALED,
+    IMPLICIT, LAZY, OVERRIDE, PRIVATE,
+    PROTECTED, LOCAL, CASE, ABSOVERRIDE,
+    BYNAMEPARAM, PARAM, COVARIANT, CONTRAVARIANT,
+    DEFAULTPARAM, PRESUPER, DEFAULTINIT
+  )
+
+  def genModifiers = for(flagset <- genFlagSet) yield Modifiers(flagset)
+
+  def genConstant =
+    for(value <- oneOf(arbitrary[Byte], arbitrary[Short], arbitrary[Char],
+                       arbitrary[Int], arbitrary[Long], arbitrary[Float],
+                       arbitrary[Double], arbitrary[Boolean], arbitrary[String]))
+      yield Constant(value)
+
+  def genAnnotated(size: Int, argGen: Int => Gen[Tree]) =
+    for(annot <- genTree(size - 1); arg <- argGen(size - 1))
+      yield Annotated(annot, arg)
+
+  def genAlternative(size: Int): Gen[Alternative] =
+    for(trees <- smallList(size, genTree(size - 1)))
+      yield Alternative(trees)
+
+  def genAppliedTypeTree(size: Int) =
+    for(tpt <- genTree(size - 1) if tpt.isType;
+        args <- smallList(size, genTree(size - 1)))
+      yield AppliedTypeTree(tpt, args)
+
+  def genApply(size: Int) =
+    for(fun <- genTree(size - 1);
+        args <- smallList(size, genTree(size - 1)))
+      yield Apply(fun, args)
+
+  def genAssign(size: Int) =
+    for(lhs <- genTree(size - 1); rhs <- genTree(size - 1))
+      yield Assign(lhs, rhs)
+
+  def genAssignOrNamedArg(size: Int) =
+    for(lhs <- genTree(size - 1); rhs <- genTree(size - 1))
+      yield AssignOrNamedArg(lhs, rhs)
+
+  def genBind(size: Int, nameGen: Gen[Name]) =
+    for(name <- nameGen; body <- genTree(size - 1))
+      yield Bind(name, body)
+
+  def genBlock(size: Int) =
+    for(stats <- smallList(size, genTree(size - 1)); expr <- genTree(size - 1))
+      yield Block(stats, expr)
+
+  def genCaseDef(size: Int) =
+    for(pat <- genTree(size - 1); guard <- genTree(size - 1); body <- genTree(size - 1))
+      yield CaseDef(pat, guard, body)
+
+  def genClassDef(size: Int) =
+    for(mods <- genModifiers; name <- genTypeName;
+        tparams <- smallList(size, genTypeDef(size - 1));
+        impl <- genTemplate(size - 1))
+      yield ClassDef(mods, name, tparams, impl)
+
+  def genCompoundTypeTree(size: Int) =
+    for(templ <- genTemplate(size - 1))
+      yield CompoundTypeTree(templ)
+
+  def genDefDef(size: Int) =
+    for(mods <- genModifiers; name <- genName;
+        tpt <- genTree(size -1); rhs <- genTree(size - 1);
+        tparams <- smallList(size, genTypeDef(size - 1));
+        vparamss <- smallList(size, smallList(size, genValDef(size - 1))))
+      yield DefDef(mods, name, tparams, vparamss, tpt, rhs)
+
+  def genExistentialTypeTree(size: Int) =
+    for(tpt <- genTree(size - 1); where <- smallList(size, genTree(size - 1)))
+      yield ExistentialTypeTree(tpt, where)
+
+  def genFunction(size: Int) =
+    for(vparams <- smallList(size, genValDef(size - 1)); body <- genTree(size - 1))
+      yield Function(vparams, body)
+
+  def genIdent(nameGen: Gen[Name] = genName) =
+    for(name <- nameGen) yield Ident(name)
+
+  def genIf(size: Int) =
+    for(cond <- genTree(size - 1); thenp <- genTree(size - 1); elsep <- genTree(size - 1))
+      yield If(cond, thenp, elsep)
+
+  def genImport(size: Int) =
+    for(expr <- genTree(size - 1); selectors <- smallList(size, genImportSelector(size - 1)))
+      yield Import(expr, selectors)
+
+  def genImportSelector(size: Int) =
+    for(name <- genName; namePos <- arbitrary[Int]; rename <- genName; renamePos <- arbitrary[Int])
+      yield ImportSelector(name, namePos, rename, renamePos)
+
+  def genTemplate(size: Int) =
+    for(parents <- smallList(size, genTree(size - 1));
+        self <- genValDef(size - 1);
+        body <- smallList(size, genTree(size - 1)))
+      yield Template(parents, self, body)
+
+  def genLabelDef(size: Int) =
+    for(name <- genTermName; params <- smallList(size, genIdent()); rhs <- genTree(size - 1))
+      yield LabelDef(name, params, rhs)
+
+  def genLiteral =
+    for(const <- genConstant) yield Literal(const)
+
+  def genMatch(size: Int) =
+    for(selector <- genTree(size - 1); cases <- smallList(size, genCaseDef(size - 1)))
+      yield Match(selector, cases)
+
+  def genModuleDef(size: Int) =
+    for(mods <- genModifiers; name <- genTermName; impl <- genTemplate(size - 1))
+      yield ModuleDef(mods, name, impl)
+
+  def genNew(size: Int) =
+    for(tpt <- genTree(size - 1))
+      yield New(tpt)
+
+  def genRefTree(size: Int) =
+    oneOf(genSelect(size), genIdent(), genSelectFromTypeTree(size))
+
+  def genPackageDef(size: Int) =
+    for(reftree <- genRefTree(size - 1); stats <- smallList(size, genTree(size - 1)))
+      yield PackageDef(reftree, stats)
+
+  def genTypeSelect(size: Int) =
+    for(qual <- genTree(size - 1); name <- genTypeName)
+      yield Select(qual, name)
+
+  def genSelect(size: Int, nameGen: Gen[Name] = genName) =
+    for(qual <- genTree(size - 1); name <- nameGen)
+      yield Select(qual, name)
+
+  def genSelectFromTypeTree(size: Int) =
+    for(qual <- genTreeIsType(size - 1); name <- genTypeName)
+      yield SelectFromTypeTree(qual, name)
+
+  def genReferenceToBoxed(size: Int) =
+    for(ident <- genIdent())
+      yield ReferenceToBoxed(ident)
+
+  def genReturn(size: Int) =
+    for(expr <- genTree(size - 1))
+      yield Return(expr)
+
+  def genSingletonTypeTree(size: Int) =
+    for(expr <- genTree(size - 1))
+      yield SingletonTypeTree(expr)
+
+  def genStar(size: Int) =
+    for(expr <- genTree(size - 1))
+      yield Star(expr)
+
+  def genSuper(size: Int) =
+    for(qual <- genTree(size - 1); mix <- genTypeName)
+      yield Super(qual, mix)
+
+  def genThis(size: Int) =
+    for(qual <- genTypeName)
+      yield This(qual)
+
+  def genThrow(size: Int) =
+    for(expr <- genTree(size - 1))
+      yield Throw(expr)
+
+  def genTry(size: Int) =
+    for(block <- genTree(size - 1);
+        catches <- smallList(size, genCaseDef(size - 1));
+        finalizer <- genTree(size - 1))
+      yield Try(block, catches, finalizer)
+
+  def genTypeApply(size: Int) =
+    for(fun <- genTreeIsTerm(size - 1); args <- smallList(size, genTree(size - 1)))
+      yield TypeApply(fun, args)
+
+  def genTypeBoundsTree(size: Int) =
+    for(lo <- genTree(size - 1); hi <- genTree(size - 1))
+      yield TypeBoundsTree(lo, hi)
+
+  def genTypeDef(size: Int): Gen[TypeDef] =
+    for(mods <- genModifiers; name <- genTypeName;
+        tparams <- smallList(size, genTypeDef(size - 1)); rhs <- genTree(size - 1))
+      yield TypeDef(mods, name, tparams, rhs)
+
+  def genTypeTree: Gen[TypeTree] = TypeTree()
+
+  def genTyped(size: Int) =
+    for(expr <- genTree(size - 1); tpt <- genTree(size - 1))
+      yield Typed(expr, tpt)
+
+  def genUnApply(size: Int) =
+    for(fun <- genTree(size - 1); args <- smallList(size, genTree(size - 1)))
+      yield UnApply(fun, args)
+
+  def genValDef(size: Int) =
+    for(mods <- genModifiers; name <- genTermName;
+        tpt <- genTree(size - 1); rhs <- genTree(size - 1))
+      yield ValDef(mods, name, tpt, rhs)
+
+  def genTree(size: Int): Gen[Tree] =
+    if (size <= 1) oneOf(EmptyTree, genTreeIsTerm(size), genTreeIsType(size))
+    else oneOf(genTree(1),
+               // these trees are neither terms nor types
+               genPackageDef(size - 1), genModuleDef(size - 1),
+               genCaseDef(size - 1), genDefDef(size - 1),
+               genTypeDef(size - 1), genTemplate(size - 1),
+               genClassDef(size - 1), genValDef(size - 1),
+               genImport(size - 1))
+
+  def genTreeIsTerm(size: Int): Gen[Tree] =
+    if (size <= 1) oneOf(genLiteral, genIdent(genTermName))
+    else oneOf(genTreeIsTerm(1), genBind(size - 1, genTermName),
+               genAnnotated(size - 1, genTreeIsTerm), genSelect(size - 1, genTermName),
+               genAlternative(size - 1), genApply(size - 1), genAssign(size - 1),
+               genAssignOrNamedArg(size - 1), genBlock(size - 1), genFunction(size - 1),
+               genIf(size - 1), genLabelDef(size - 1), genMatch(size - 1), genNew(size - 1),
+               genReturn(size - 1), genStar(size - 1), genSuper(size - 1), genThis(size - 1),
+               genThrow(size - 1), genTry(size - 1), genTypeApply(size - 1),
+               genTyped(size - 1), genUnApply(size - 1))
+
+  def genTreeIsType(size: Int): Gen[Tree] =
+    if (size <= 1) genIdent(genTypeName)
+    else oneOf(genTreeIsType(1), genAnnotated(size - 1, genTreeIsType),
+               genBind(size - 1, genTypeName), genSelect(size - 1, genTypeName),
+               genSingletonTypeTree(size - 1), genSelectFromTypeTree(size - 1),
+               genExistentialTypeTree(size - 1), genCompoundTypeTree(size - 1),
+               genAppliedTypeTree(size - 1), genTypeBoundsTree(size - 1))
+
+  /*  These are marker types that allow to write tests that
+   *  depend specificly on Trees that are terms or types.
+   *  They are transperantly tranformed to trees through
+   *  implicit conversions and liftables for quasiquotes.
+   */
+
+  case class TreeIsTerm(tree: Tree) { require(tree.isTerm, showRaw(tree)) }
+  case class TreeIsType(tree: Tree) { require(tree.isType, showRaw(tree)) }
+
+  def genTreeIsTermWrapped(size: Int) =
+    for(tit <- genTreeIsTerm(size)) yield TreeIsTerm(tit)
+
+  def genTreeIsTypeWrapped(size: Int) =
+    for(tit <- genTreeIsType(size)) yield TreeIsType(tit)
+
+  implicit object liftTreeIsTerm extends Liftable[TreeIsTerm] {
+    def apply(universe: Universe, value: TreeIsTerm): universe.Tree =
+      value.tree.asInstanceOf[universe.Tree]
+  }
+  implicit object liftTreeIsType extends Liftable[TreeIsType] {
+    def apply(universe: Universe, value: TreeIsType): universe.Tree =
+      value.tree.asInstanceOf[universe.Tree]
+  }
+  implicit def treeIsTerm2tree(tit: TreeIsTerm) = tit.tree
+  implicit def treeIsType2tree(tit: TreeIsType) = tit.tree
+
+  implicit val arbConstant: Arbitrary[Constant] = Arbitrary(genConstant)
+  implicit val arbModifiers: Arbitrary[Modifiers] = Arbitrary(genModifiers)
+  implicit val arbTermName: Arbitrary[TermName] = Arbitrary(genTermName)
+  implicit val arbTypeName: Arbitrary[TypeName] = Arbitrary(genTypeName)
+  implicit val arbName: Arbitrary[Name] = Arbitrary(genName)
+
+  // Trees generators are bound by this size to make
+  // generation times shorter and less memory hungry.
+  // TODO: is there any better solution?
+  val maxTreeSize = 5
+
+  def arbitrarySized[T](gen: Int => Gen[T]) =
+    Arbitrary(sized(s => gen(s.min(maxTreeSize))))
+
+  implicit val arbLiteral: Arbitrary[Literal] = Arbitrary(genLiteral)
+  implicit val arbIdent: Arbitrary[Ident] = Arbitrary(genIdent())
+  implicit val arbValDef: Arbitrary[ValDef] = arbitrarySized(genValDef)
+  implicit val arbDefDef: Arbitrary[DefDef] = arbitrarySized(genDefDef)
+  implicit val arbTypeDef: Arbitrary[TypeDef] = arbitrarySized(genTypeDef)
+  implicit val arbTree: Arbitrary[Tree] = arbitrarySized(genTree)
+  implicit val arbTreeIsTerm: Arbitrary[TreeIsTerm] = arbitrarySized(genTreeIsTermWrapped)
+  implicit val arbTreeIsType: Arbitrary[TreeIsType] = arbitrarySized(genTreeIsTypeWrapped)
+}

--- a/test/files/scalacheck/quasiquotes/ErrorProps.scala
+++ b/test/files/scalacheck/quasiquotes/ErrorProps.scala
@@ -1,0 +1,52 @@
+import org.scalacheck._
+import Prop._
+import Gen._
+import Arbitrary._
+
+import scala.reflect.runtime.universe._
+import Flag._
+
+object ErrorProps extends QuasiquoteProperties("errors") {
+  property("deconstruction: can't use two .. cardinalities in a row") = fails(
+    "Can't extract a part of the tree with .. cardinality here",
+    """
+      val xs = List(q"x1", q"x2")
+      val q"f(..$xs1, ..$xs2)" = xs
+    """)
+
+  property("can't splice with given cardinality") = fails(
+    "To splice List[reflect.runtime.universe.Ident] use .. cardinality or define a Liftable of this type",
+    """
+      val xs = List(q"x", q"x")
+      q"$xs"
+    """)
+
+  property("splice typename into typedef with default bounds") = fails(
+    "Name expected but reflect.runtime.universe.TypeDef found",
+    """
+      val T1 = TypeName("T1")
+      val T2 = q"type T"
+      val t = EmptyTree
+      q"type $T1[$T2 >: _root_.scala.Any <: _root_.scala.Nothing] = $t" ≈
+        TypeDef(Modifiers(), T1, List(T2), t)
+    """)
+
+  property("can't splice annotations with ... cardinality") = fails(
+    "Can't splice with ... cardinality here",
+    """
+      val annots = List(List(q"Foo"))
+      q"@...$annots def foo"
+    """)
+
+  property("@..$first @$rest def foo") = fails(
+    "Can't extract a part of the tree with .. cardinality here",
+    """
+      val a = annot("a")
+      val b = annot("b")
+      val c = annot("c")
+      val q"@..$first @$rest def foo" = q"@$a @$b @$c def foo"
+    """)
+
+  // // Make sure a nice error is reported in this case
+  // { import Flag._; val mods = NoMods; q"lazy $mods val x: Int" }
+}

--- a/test/files/scalacheck/quasiquotes/LiftableProps.scala
+++ b/test/files/scalacheck/quasiquotes/LiftableProps.scala
@@ -1,0 +1,79 @@
+import org.scalacheck._
+import Prop._
+import Gen._
+import Arbitrary._
+
+import scala.reflect.runtime.universe._
+import Flag._
+
+object LiftableProps extends QuasiquoteProperties("liftable") {
+  property("splice byte") = test {
+    val c: Byte = 0
+    assert(q"$c" ≈ Literal(Constant(c)))
+  }
+
+  property("splice short") = test {
+    val c: Short = 0
+    assert(q"$c" ≈ Literal(Constant(c)))
+  }
+
+  property("splice char") = test {
+    val c: Char = 'c'
+    assert(q"$c" ≈ Literal(Constant(c)))
+  }
+
+  property("splice int") = test {
+    val c: Int = 0
+    assert(q"$c" ≈ Literal(Constant(c)))
+  }
+
+  property("splice long") = test {
+    val c: Long = 0
+    assert(q"$c" ≈ Literal(Constant(c)))
+  }
+
+  property("splice float") = test {
+    val c: Float = 0.0f
+    assert(q"$c" ≈ Literal(Constant(c)))
+  }
+
+  property("splice double") = test {
+    val c: Double = 0.0
+    assert(q"$c" ≈ Literal(Constant(c)))
+  }
+
+  property("splice boolean") = test {
+    val c: Boolean = false
+    assert(q"$c" ≈ Literal(Constant(c)))
+  }
+
+  property("splice string") = test {
+    val c: String = "s"
+    assert(q"$c" ≈ Literal(Constant(c)))
+  }
+
+  property("splice unit") = test {
+    val c: Unit = ()
+    assert(q"$c" ≈ Literal(Constant(c)))
+  }
+
+  property("lift symbol") = test {
+    val s = rootMirror.staticClass("scala.Int")
+    assert(q"$s" ≈ Ident(s))
+  }
+
+  property("lift type") = test {
+    val tpe = rootMirror.staticClass("scala.Int").toType
+    assert(q"$tpe" ≈ TypeTree(tpe))
+  }
+
+  property("lift type tag") = test {
+    val tag = TypeTag.Int
+    assert(q"$tag" ≈ TypeTree(tag.tpe))
+  }
+
+  property("lift weak type tag") = test {
+    val tag = WeakTypeTag.Int
+    assert(q"$tag" ≈ TypeTree(tag.tpe))
+  }
+}

--- a/test/files/scalacheck/quasiquotes/QuasiquoteProperties.scala
+++ b/test/files/scalacheck/quasiquotes/QuasiquoteProperties.scala
@@ -1,0 +1,85 @@
+import scala.reflect.runtime.universe._
+import scala.tools.reflect.ToolBox
+import scala.tools.reflect.ToolBoxError
+import scala.reflect.macros.TypecheckException
+
+import org.scalacheck._
+import Prop._
+import Gen._
+import Arbitrary._
+
+class QuasiquoteProperties(name: String) extends Properties(name) with ArbitraryTreesAndNames with Helpers
+
+trait Helpers {
+  /** Runs a code block and returns proof confirmation
+   *  if no exception has been thrown while executing code
+   *  block. This is useful for simple one-off tests.
+   */
+  def test[T](block: => T)=
+    Prop { (params) =>
+      block
+      Result(Prop.Proof)
+    }
+
+  implicit class TestSimilarTree(tree1: Tree) {
+    def ≈(tree2: Tree) = tree1.equalsStructure(tree2)
+  }
+
+  implicit class TestSimilarListTree(lst: List[Tree]) {
+    def ≈(other: List[Tree]) = (lst.length == other.length) && lst.zip(other).forall { case (t1, t2) => t1 ≈ t2 }
+  }
+
+  implicit class TestSimilarListListTree(lst: List[List[Tree]]) {
+    def ≈(other: List[List[Tree]]) = (lst.length == other.length) && lst.zip(other).forall { case (l1, l2) => l1 ≈ l2 }
+  }
+
+  implicit class TestSimilarName(name: Name) {
+    def ≈(other: Name) = name == other
+  }
+
+  def assertThrows[T <: AnyRef](f: => Any)(implicit manifest: Manifest[T]): Unit = {
+    val clazz = manifest.erasure.asInstanceOf[Class[T]]
+    val thrown =
+      try {
+        f
+        false
+      } catch {
+        case u: Throwable =>
+          if (!clazz.isAssignableFrom(u.getClass))
+            assert(false, s"wrong exception: $u")
+          true
+      }
+    if(!thrown)
+      assert(false, "exception wasn't thrown")
+  }
+
+  def fails(msg: String, block: String) = {
+    def result(ok: Boolean, description: String = "") = {
+      val status = if (ok) Prop.Proof else Prop.False
+      val labels = if (description != "") Set(description) else Set.empty[String]
+      Prop { new Prop.Result(status, Nil, Set.empty, labels) }
+    }
+    try {
+      val tb = rootMirror.mkToolBox()
+      val tree = tb.parse(s"""
+        object Wrapper extends Helpers {
+          import scala.reflect.runtime.universe._
+          $block
+        }
+      """)
+      tb.compile(tree)
+      result(false, "given code doesn't fail to typecheck")
+    } catch {
+      case ToolBoxError(emsg, _) =>
+        if (!emsg.contains(msg))
+          result(false, s"error message '${emsg}' is not the same as expected '$msg'")
+        else
+          result(true)
+    }
+  }
+
+  def annot(name: String): Tree = annot(TypeName(name), Nil)
+  def annot(name: TypeName): Tree = annot(name, Nil)
+  def annot(name: String, args: List[Tree]): Tree = annot(TypeName(name), args)
+  def annot(name: TypeName, args: List[Tree]): Tree = q"new $name(..$args)"
+}

--- a/test/files/scalacheck/quasiquotes/TermConstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/TermConstructionProps.scala
@@ -1,0 +1,349 @@
+import org.scalacheck._
+import Prop._
+import Gen._
+import Arbitrary._
+
+import scala.reflect.runtime.universe._
+import Flag._
+
+object TermConstructionProps extends QuasiquoteProperties("term construction") {
+  val anyRef = Select(Ident(TermName("scala")), TypeName("AnyRef"))
+  val emtpyConstructor =
+    DefDef(
+      Modifiers(), nme.CONSTRUCTOR, List(),
+      List(List()), TypeTree(), Block(List(Apply(Select(Super(This(tpnme.EMPTY), tpnme.EMPTY), nme.CONSTRUCTOR), List())), Literal(Constant(()))))
+
+  def classWithMethods(name: TypeName, methods: List[DefDef] = Nil) =
+    ClassDef(
+      Modifiers(),  name, List(),
+      Template(List(anyRef), emptyValDef, List(emtpyConstructor) ++ methods))
+
+  property("splice single tree return tree itself") = forAll { (t: Tree) =>
+    q"$t" ≈ t
+  }
+
+  property("splice trees into if expression") = forAll { (t1: Tree, t2: Tree, t3: Tree) =>
+    q"if($t1) $t2 else $t3" ≈ If(t1, t2, t3)
+  }
+
+  property("splice term name into val") = forAll { (name: TermName) =>
+    q"val $name = 0" ≈ ValDef(Modifiers(), name, TypeTree(), Literal(Constant(0)))
+  }
+
+  property("splice type name into typedef") = forAll { (name1: TypeName, name2: TypeName) =>
+    q"type $name1 = $name2" ≈ TypeDef(Modifiers(), name1, List(), Ident(name2))
+  }
+
+  property("splice term name into class") = forAll { (name: TypeName) =>
+    q"class $name" ≈ classWithMethods(name)
+  }
+
+  property("splice method into class") = forAll { (name: TypeName, method: DefDef) =>
+    q"class $name { $method }" ≈ classWithMethods(name, List(method))
+  }
+
+  property("splice trees into ascriptiopn") = forAll { (t1: Tree, t2: Tree) =>
+    q"$t1 : $t2" ≈ Typed(t1, t2)
+  }
+
+  property("splice trees into apply") = forAll { (t1: Tree, t2: Tree, t3: Tree) =>
+    q"$t1($t2, $t3)" ≈ Apply(t1, List(t2, t3))
+  }
+
+  property("splice trees with .. cardinality into apply") = forAll { (ts: List[Tree]) =>
+    q"f(..$ts)" ≈ Apply(q"f", ts)
+  }
+
+  property("splice iterable into apply") = forAll { (trees: List[Tree]) =>
+    val itrees: Iterable[Tree] = trees
+    q"f(..$itrees)" ≈ Apply(q"f", trees)
+  }
+
+  property("splice trees with ... cardinality into apply") = forAll { (ts1: List[Tree], ts2: List[Tree]) =>
+    val argss = List(ts1, ts2)
+    q"f(...$argss)" ≈ Apply(Apply(q"f", ts1), ts2)
+  }
+
+  property("splice term name into assign") = forAll { (name: TermName, t: Tree) =>
+    q"$name = $t" ≈ Assign(Ident(name), t)
+  }
+
+  property("splice trees into block") = forAll { (t1: Tree, t2: Tree, t3: Tree) =>
+    q"""{
+      $t1
+      $t2
+      $t3
+    }""" ≈ Block(List(t1, t2), t3)
+  }
+
+  property("splice type name into class parents") = forAll { (name: TypeName, parent: TypeName) =>
+    q"class $name extends $parent" ≈
+      ClassDef(
+        Modifiers(),  name, List(),
+        Template(List(Ident(parent)), emptyValDef, List(emtpyConstructor)))
+  }
+
+  property("splice tree into new") = forAll { (tree: Tree) =>
+    q"new $tree" ≈ Apply(Select(New(tree), nme.CONSTRUCTOR), List())
+  }
+
+  property("splice tree into return") = forAll { (tree: Tree) =>
+    q"return $tree" ≈ Return(tree)
+  }
+
+  property("splice a list of arguments") = forAll { (fun: Tree, args: List[Tree]) =>
+    q"$fun(..$args)" ≈ Apply(fun, args)
+  }
+
+  property("splice list and non-list fun arguments") = forAll { (fun: Tree, arg1: Tree, arg2: Tree, args: List[Tree]) =>
+    q"$fun(..$args, $arg1, $arg2)" ≈ Apply(fun, args ++ List(arg1) ++ List(arg2)) &&
+    q"$fun($arg1, ..$args, $arg2)" ≈ Apply(fun, List(arg1) ++ args ++ List(arg2)) &&
+    q"$fun($arg1, $arg2, ..$args)" ≈ Apply(fun, List(arg1) ++ List(arg2) ++ args)
+  }
+
+  property("splice members into class") = forAll { (name: TypeName, defs: List[DefDef], extra: DefDef) =>
+    q"""class $name {
+      ..$defs
+      $extra
+    }""" ≈ classWithMethods(name, defs ++ List(extra))
+  }
+
+  property("splice into new") = forAll { (name: TypeName, body: List[Tree]) =>
+    q"new $name { ..$body }" ≈
+      q"""{
+        final class $$anon extends $name {
+          ..$body
+        }
+        new $$anon
+      }"""
+  }
+
+
+  property("splice tree into singleton type tree") = forAll { (name: TypeName, t: Tree) =>
+    q"type $name = $t.type" ≈ q"type $name = ${SingletonTypeTree(t)}"
+  }
+
+  property("splice type name into this") = forAll { (T: TypeName) =>
+    q"$T.this" ≈ This(T)
+  }
+
+  property("splice tree into throw") = forAll { (t: Tree) =>
+    q"throw $t" ≈ Throw(t)
+  }
+
+  property("splice trees into type apply") = forAll { (fun: TreeIsTerm, types: List[Tree]) =>
+    q"$fun[..$types]" ≈ TypeApply(fun, types)
+  }
+
+  property("splice type names into type bounds") = forAll { (T1: TypeName, T2: TypeName, T3: TypeName) =>
+    q"type $T1 >: $T2 <: $T3" ≈
+      TypeDef(
+        Modifiers(DEFERRED), T1, List(),
+        TypeBoundsTree(Ident(T2), Ident(T3)))
+  }
+
+  property("splice trees names into type bounds") = forAll { (T: TypeName, t1: Tree, t2: Tree) =>
+    q"type $T >: $t1 <: $t2" ≈
+      TypeDef(
+        Modifiers(DEFERRED), T, List(),
+        TypeBoundsTree(t1, t2))
+  }
+
+  property("splice tparams into typedef (1)") = forAll { (T: TypeName, targs: List[TypeDef], t: Tree) =>
+    q"type $T[..$targs] = $t" ≈ TypeDef(Modifiers(), T, targs, t)
+  }
+
+  property("splice tparams into typedef (2)") = forAll { (T: TypeName, targs1: List[TypeDef], targs2: List[TypeDef], t: Tree) =>
+    q"type $T[..$targs1, ..$targs2] = $t" ≈ TypeDef(Modifiers(), T, targs1 ++ targs2, t)
+  }
+
+  property("splice tparams into typedef (3)") = forAll { (T: TypeName, targ: TypeDef, targs: List[TypeDef], t: Tree) =>
+    q"type $T[$targ, ..$targs] = $t" ≈ TypeDef(Modifiers(), T, targ :: targs, t)
+  }
+
+  property("splice typename into typedef with default bounds") = forAll { (T1: TypeName, T2: TypeName, t: Tree) =>
+    q"type $T1[$T2 >: Any <: Nothing] = $t" ≈
+      TypeDef(
+        Modifiers(), T1,
+        List(TypeDef(
+          Modifiers(PARAM), T2,
+          List(),
+          TypeBoundsTree(
+            Ident(TypeName("Any")),
+            Ident(TypeName("Nothing"))))),
+        t)
+  }
+
+  property("splice type names into compound type tree") = forAll { (T: TypeName, A: TypeName, B: TypeName) =>
+    q"type $T = $A with $B" ≈
+      TypeDef(
+        Modifiers(), T, List(),
+        CompoundTypeTree(
+          Template(List(Ident(A), Ident(B)), ValDef(Modifiers(PRIVATE), nme.WILDCARD, TypeTree(), EmptyTree), List())))
+  }
+
+  property("splice trees into existential type tree") = forAll {
+    (T1: TypeName, T2: TypeName, X: TypeName, Lo: TypeName, Hi: TypeName) =>
+
+    q"type $T1 = $T2[$X] forSome { type $X >: $Lo <: $Hi }" ≈
+      TypeDef(
+        Modifiers(), T1, List(),
+        ExistentialTypeTree(
+          AppliedTypeTree(Ident(T2), List(Ident(X))),
+          List(
+            TypeDef(Modifiers(DEFERRED), X, List(), TypeBoundsTree(Ident(Lo), Ident(Hi))))))
+  }
+
+  property("splice names into import selector") = forAll {
+    (expr: Tree, plain: Name, oldname: Name, newname: Name, discard: Name) =>
+
+    val Import(expr1, List(
+      ImportSelector(plain11, _, plain12, _),
+      ImportSelector(oldname1, _, newname1, _),
+      ImportSelector(discard1, _, wildcard, _))) =
+        q"import $expr.{$plain, $oldname => $newname, $discard => _}"
+
+    expr1 ≈ expr && plain11 == plain12 && plain12 == plain &&
+    oldname1 == oldname && newname1 == newname && discard1 == discard && wildcard == nme.WILDCARD
+  }
+
+  property("splice trees into while loop") = forAll { (cond: Tree, body: Tree) =>
+    val LabelDef(_, List(), If(cond1, Block(List(body1), Apply(_, List())), Literal(Constant(())))) = q"while($cond) $body"
+    body1 ≈ body && cond1 ≈ cond
+  }
+
+  property("splice trees into do while loop") = forAll { (cond: Tree, body: Tree) =>
+    val LabelDef(_, List(), Block(List(body1), If(cond1, Apply(_, List()), Literal(Constant(()))))) = q"do $body while($cond)"
+    body1 ≈ body && cond1 ≈ cond
+  }
+
+  property("splice trees into alternative") = forAll { (c: Tree, A: Tree, B: Tree) =>
+    q"$c match { case $A | $B => }" ≈
+      Match(c, List(
+        CaseDef(Alternative(List(A, B)), EmptyTree, Literal(Constant(())))))
+  }
+
+  property("splice into applied type tree") = forAll { (T1: TypeName, T2: TypeName, args: List[Tree]) =>
+    q"type $T1 = $T2[..$args]" ≈
+      TypeDef(
+        Modifiers(), T1, List(),
+        AppliedTypeTree(Ident(T2), args))
+  }
+
+  property("splice list of trees into block (1)") = forAll { (trees: List[Tree]) =>
+    q"{ ..$trees }" ≈ (trees match {
+      case Nil => Block(Nil, q"()")
+      case _   => Block(trees.init, trees.last)
+    })
+  }
+
+  property("splice list of trees into block (2)") = forAll { (trees1: List[Tree], trees2: List[Tree]) =>
+    q"{ ..$trees1 ; ..$trees2 }" ≈ ((trees1 ++ trees2) match {
+      case Nil   => Block(Nil, Literal(Constant(())))
+      case trees => Block(trees.init, trees.last)
+    })
+  }
+
+  property("splice list of trees into block (3)") = forAll { (trees: List[Tree], tree: Tree) =>
+    q"{ ..$trees; $tree }" ≈ Block(trees, tree)
+  }
+
+  // TODO: this test needs to be implemented
+  // property("splice valdef into class param") = forAll { (name: TypeName, valdef: ValDef) =>
+  //   q"class $name($valdef)" ≈ ...
+  // }
+
+  // TODO: this test needs to be implemented
+  // property("splice tree into super") = forAll { (T: TypeName, t: Tree) =>
+  //   q"$t.super[$T]" ≈ ...
+  // }
+
+  // TODO: this test needs to be implemented
+  // property("splice targs into classdef") = forAll { (C: TypeName, targs: List[TypeDef], t: Tree) =>
+  //   q"class $C[..$targs]" ≈ ...
+  // }
+
+  def assertSameAnnots(tree: {def mods: Modifiers}, annots: List[Tree]) =
+    assert(tree.mods.annotations ≈ annots,
+           s"${tree.mods.annotations} =/= ${annots}")
+
+  def assertSameAnnots(tree1: {def mods: Modifiers}, tree2: {def mods: Modifiers}) =
+    assert(tree1.mods.annotations ≈ tree2.mods.annotations,
+           s"${tree1.mods.annotations} =/= ${tree2.mods.annotations}")
+
+  property("splice type name into annotation") = test {
+    val name = TypeName("annot")
+    assertSameAnnots(q"@$name def foo", List(annot(name)))
+  }
+
+  property("splice ident into annotation") = test {
+    val name = TypeName("annot")
+    val ident = Ident(name)
+    assertSameAnnots(q"@$ident def foo", List(annot(name)))
+  }
+
+  property("splice idents into annotation") = test {
+    val idents = List(Ident(TypeName("annot1")), Ident(TypeName("annot2")))
+    assertSameAnnots(q"@..$idents def foo",
+      idents.map { ident => Apply(Select(New(ident), nme.CONSTRUCTOR), List()) })
+  }
+
+  property("splice constructor calls into annotation") = test {
+    val ctorcalls = List(annot("a1"), annot("a2"))
+    assertSameAnnots(q"@..$ctorcalls def foo", ctorcalls)
+  }
+
+  property("splice multiple annotations (1)") = test {
+    val annot1 = annot("a1")
+    val annot2 = annot("a2")
+    val res = q"@$annot1 @$annot2 def foo"
+    assertSameAnnots(res, List(annot1, annot2))
+  }
+
+  property("splice multiple annotations (2)") = test {
+    val annot1 = annot("a1")
+    val annots = List(annot("a2"), annot("a3"))
+    val res = q"@$annot1 @..$annots def foo"
+    assertSameAnnots(res, annot1 :: annots)
+  }
+
+  property("splice annotations with arguments (1)") = test {
+    val a = annot("a", List(q"x"))
+    assertSameAnnots(q"@$a def foo", q"@a(x) def foo")
+  }
+
+  property("splice annotations with arguments (2)") = test {
+    val a = newTypeName("a")
+    assertSameAnnots(q"@$a(x) def foo", q"@a(x) def foo")
+  }
+
+  property("splice annotations with arguments (3") = test {
+    val a = Ident(newTypeName("a"))
+    assertSameAnnots(q"@$a(x) def foo", q"@a(x) def foo")
+  }
+
+  property("can't splice annotations with arguments specificed twice") = test {
+    val a = annot("a", List(q"x"))
+    assertThrows[IllegalArgumentException] {
+      q"@$a(y) def foo"
+    }
+  }
+
+  property("splice term into brackets") = test {
+    val a = q"a"
+    assert(q"($a)" ≈ a)
+  }
+
+  property("splice terms into tuple") = test {
+    val a1 = q"a1"
+    val a2 = q"a2"
+    val as = List(a1, a2)
+    assert(q"(..$as)" ≈ q"Tuple2($a1, $a2)")
+    assert(q"(a0, ..$as)" ≈ q"Tuple3(a0, $a1, $a2)")
+  }
+
+  property("splcie empty list into tuple") = test {
+    val empty = List[Tree]()
+    assert(q"(..$empty)" ≈ q"()")
+  }
+}

--- a/test/files/scalacheck/quasiquotes/TermDeconstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/TermDeconstructionProps.scala
@@ -1,0 +1,116 @@
+import org.scalacheck._
+import Prop._
+import Gen._
+import Arbitrary._
+
+import scala.reflect.runtime.universe._
+import Flag._
+
+object TermDeconstructionProps extends QuasiquoteProperties("term deconstruction") {
+  property("f(x)") = forAll { (x: Tree) =>
+    val q"f($x1)" = q"f($x)"
+    x1 ≈ x
+  }
+
+  property("f(..xs)") = forAll { (x1: Tree, x2: Tree) =>
+    val q"f(..$xs)" = q"f($x1, $x2)"
+    xs ≈ List(x1, x2)
+  }
+
+  property("f(y, ..ys)") = forAll { (x1: Tree, x2: Tree, x3: Tree) =>
+    val q"f($y, ..$ys)" = q"f($x1, $x2, $x3)"
+    y ≈ x1 && ys ≈ List(x2, x3)
+  }
+
+  property("f(y1, y2, ..ys)") = forAll { (x1: Tree, x2: Tree, x3: Tree) =>
+    val q"f($y1, $y2, ..$ys)" = q"f($x1, $x2, $x3)"
+    y1 ≈ x1 && y2 ≈ x2 && ys ≈ List(x3)
+  }
+
+  property("f(...xss)") = forAll { (x1: Tree, x2: Tree) =>
+    val q"f(...$argss)" = q"f($x1)($x2)"
+    argss ≈ List(List(x1), List(x2))
+  }
+
+  property("@$annot def foo") = forAll { (annotName: TypeName) =>
+    val q"@$annot def foo" = q"@$annotName def foo"
+    annot ≈ Apply(Select(New(Ident(annotName)), nme.CONSTRUCTOR), List())
+  }
+
+  property("@$annot(..$args) def foo") = forAll { (annotName: TypeName, tree: Tree) =>
+    val q"@$annot(..$args) def foo" = q"@$annotName($tree) def foo"
+    annot ≈ Ident(annotName) && args ≈ List(tree)
+  }
+
+  property("@..$annots def foo") = test {
+    val a = annot("a")
+    val b = annot("b")
+    val q"@..$annots def foo" = q"@$a @$b def foo"
+    annots ≈ List(a, b)
+  }
+
+  property("@$annot @..$annots def foo") = test {
+    val a = annot("a")
+    val b = annot("b")
+    val c = annot("c")
+    val q"@$first @..$rest def foo" = q"@$a @$b @$c def foo"
+    first ≈ a && rest ≈ List(b, c)
+  }
+
+  property("class without params") = test {
+    val q"class $name { ..$body }" = q"class Foo { def bar = 3 }"
+    assert(body ≈ List(q"def bar = 3"))
+  }
+
+  property("class constructor") = test {
+    val q"class $name(...$argss)" = q"class Foo(x: Int)(y: Int)"
+    assert(argss.length == 2)
+  }
+
+  property("class parents") = test {
+    val q"class $name extends ..$parents" = q"class Foo extends Bar with Blah"
+    assert(parents ≈ List(tq"Bar", tq"Blah"))
+  }
+
+  property("class selfdef") = test {
+    val q"class $name { $self => }" = q"class Foo { self: T => }"
+    assert(self.name ≈ TermName("self") && self.tpt ≈ tq"T")
+  }
+
+  property("class tparams") = test {
+    val q"class $name[..$tparams]" = q"class Foo[A, B]"
+    assert(tparams.map { _.name } == List(TypeName("A"), TypeName("B")))
+  }
+
+  property("deconstruct unit as tuple") = test {
+    val q"(..$xs)" = q"()"
+    assert(xs.isEmpty)
+  }
+
+  property("deconstruct tuple") = test {
+    val q"(..$xs)" = q"(a, b)"
+    assert(xs ≈ List(q"a", q"b"))
+  }
+
+  property("deconstruct tuple mixed") = test {
+    val q"($first, ..$rest)" = q"(a, b, c)"
+    assert(first ≈ q"a" && rest ≈ List(q"b", q"c"))
+  }
+
+  // TODO: FIX ME
+  // property("trait deconstruction") = test {
+  //   val q"trait $name { ..$body }" = q"trait Foo { def foo }"
+  //   assert(name ≈ TypeName("Foo") && body ≈ List(q"def foo"))
+  // }
+
+  // TODO: FIX ME
+  // property("deconstruct new") = forAll { (name: TypeName, args: List[Tree]) =>
+  //   val q"new $name1(..$args1)" = q"new $name(..$args)"
+  //   assert(name1 ≈ Ident(name) && args1 ≈ args)
+  // }
+
+  // TODO: FIX ME
+  // property("deconstruct early val defs") = test {
+  //   val q"new { ..$defs } with $bla " = q"new { val x = 0 } with Foo"
+  // }
+}

--- a/test/files/scalacheck/quasiquotes/Test.scala
+++ b/test/files/scalacheck/quasiquotes/Test.scala
@@ -1,0 +1,10 @@
+import org.scalacheck._
+
+object Test extends Properties("quasiquotes") {
+  include(TermConstructionProps)
+  include(TypeConstructionProps)
+  include(TermDeconstructionProps)
+  include(TypeDeconstructionProps)
+  include(LiftableProps)
+  include(ErrorProps)
+}

--- a/test/files/scalacheck/quasiquotes/TypeConstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/TypeConstructionProps.scala
@@ -1,0 +1,25 @@
+import org.scalacheck._
+import Prop._
+import Gen._
+import Arbitrary._
+
+import scala.reflect.runtime.universe._
+import Flag._
+
+object TypeConstructionProps extends QuasiquoteProperties("type construction")  {
+  property("bare idents contain type names") = test {
+    tq"x" ≈ Ident(TypeName("x"))
+  }
+
+  property("splice type names into AppliedTypeTree") = forAll { (name1: TypeName, name2: TypeName) =>
+    tq"$name1[$name2]" ≈ AppliedTypeTree(Ident(name1), List(Ident(name2)))
+  }
+
+  property("tuple type") = test {
+    val empty = List[Tree]()
+    val ts = List(tq"t1", tq"t2")
+    assert(tq"(..$empty)" ≈ tq"scala.Unit")
+    assert(tq"(..$ts)" ≈ tq"Tuple2[t1, t2]")
+    assert(tq"(t0, ..$ts)" ≈ tq"Tuple3[t0, t1, t2]")
+  }
+}

--- a/test/files/scalacheck/quasiquotes/TypeDeconstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/TypeDeconstructionProps.scala
@@ -1,0 +1,29 @@
+import org.scalacheck._
+import Prop._
+import Gen._
+import Arbitrary._
+
+import scala.reflect.runtime.universe._
+import Flag._
+
+object TypeDeconstructionProps extends QuasiquoteProperties("type deconstruction") {
+  property("ident(type name)") = forAll { (name: TypeName) =>
+    val t = Ident(name)
+    val tq"$t1" = t
+    t1 ≈ t
+  }
+
+  property("applied type tree") = forAll { (name1: TypeName, name2: TypeName) =>
+    val tq"$a[$b]" = AppliedTypeTree(Ident(name1), List(Ident(name2)))
+    a ≈ Ident(name1) && b ≈ Ident(name2)
+  }
+
+  property("tuple type") = test {
+    val tq"(..$empty)" = tq"scala.Unit"
+    assert(empty.isEmpty)
+    val tq"(..$ts)" = tq"(t1, t2)"
+    assert(ts ≈ List(tq"t1", tq"t2"))
+    val tq"($head, ..$tail)" = tq"(t0, t1, t2)"
+    assert(head ≈ tq"t0" && tail ≈ List(tq"t1", tq"t2"))
+  }
+}


### PR DESCRIPTION
The implementation consits of following parts:
- Additions to reflection api:
  - Quasiquotes implicit class that defines `q`, `tq`, `pq` and `cq` interpolators that now become a part of the `scala.reflect.api.Universe`. The implementation of given interpolators is macro-based and is hardwired to actual macro through `FastTrack`.
  - `Liftable` class and `StandardLiftables` slice of the cake which are parts of typeclass-like mechanism that allows to splice custom user-defined types into quasiquotes
  - Additional methods in `BuildUtils` which are used by quasiquotes macro to generate trees, notably:
    - `SyntacticClassDef`. An extractor/constructor that allows to construct and deconstruct classes using arguments that mirror syntactic form of ClassDefs (e.g. constructor outside of the body)
    - `TupleN`, `TupleTypeN`. Extractor/constructor for easy construction of ast that represents a tuple term or type with given amount of elements.
- Actual implementation of quasiquotes in `scala.tools.reflect.quasiquotes.package` which is organized into a cake called `Quasiquotes` with slices:
  - `Macros`. Core macro expansion logic with `dispatch` entry-point.
  - `Parsers`. Customized parser that contains modifications to support various types of extensions to the Scala language that are needed for quasiquotes. Due to the fact that code snippets need to be parsed differently depending on the quasiquote flavor that is being used at the moment (`q`, `tq` etc) there a few sub-Parsers with different code wrapping logic.
  - `Reifiers`. Customized reifiers that combines reification and substitution of trees that represent holes in a quote (placeholders) with corresponding spliced values. There are two main different reification strategies: `ApplyReifier` and `UnapplyReifier` that are used correspondingly for construction and deconstruction quasiquotes.
- Extremely minor patch to the typer that special-cases expansion of unapply quasiquotes so that they can expand directly into inline patterns
- A few minor changes to the parser that simplify implementation of customized parser for quasiquotes
- Scalacheck-based tests
