### PR TITLE
SI-4684 Repl supports whole-file paste

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -214,8 +214,8 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     cmd("imports", "[name name ...]", "show import history, identifying sources of names", importsCommand),
     cmd("implicits", "[-v]", "show the implicits in scope", intp.implicitsCommand),
     cmd("javap", "<path|class>", "disassemble a file or class name", javapCommand),
-    cmd("load", "<path>", "load and interpret a Scala file", loadCommand),
-    nullary("paste", "enter paste mode: all input up to ctrl-D compiled together", pasteCommand),
+    cmd("load", "<path>", "interpret lines in a file", loadCommand),
+    cmd("paste", "[path]", "enter paste mode or paste a file", pasteCommand),
     nullary("power", "enable power user mode", powerCmd),
     nullary("quit", "exit the interpreter", () => Result(keepRunning = false, None)),
     nullary("replay", "reset execution and replay all previous commands", replay),
@@ -454,11 +454,10 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     }
   }
 
-  def withFile(filename: String)(action: File => Unit) {
-    val f = File(filename)
-
-    if (f.exists) action(f)
-    else echo("That file does not exist")
+  def withFile[A](filename: String)(action: File => A): Option[A] = {
+    val res = Some(File(filename)) filter (_.exists) map action
+    if (res.isEmpty) echo("That file does not exist")  // courtesy side-effect
+    res
   }
 
   def loadCommand(arg: String) = {
@@ -528,13 +527,26 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     Iterator continually in.readLine("") takeWhile (x => x != null && cond(x))
   }
 
-  def pasteCommand(): Result = {
-    echo("// Entering paste mode (ctrl-D to finish)\n")
-    val code = readWhile(_ => true) mkString "\n"
-    if (code.trim.isEmpty) {
-      echo("\n// Nothing pasted, nothing gained.\n")
-    } else {
-      echo("\n// Exiting paste mode, now interpreting.\n")
+  def pasteCommand(arg: String): Result = {
+    var shouldReplay: Option[String] = None
+    val code = (
+      if (arg.nonEmpty) {
+        withFile(arg)(f => {
+          shouldReplay = Some(s":paste $arg")
+          val s = f.slurp.trim
+          if (s.isEmpty) echo(s"File contains no code: $f")
+          else echo(s"Pasting file $f...")
+          s
+        }) getOrElse ""
+      } else {
+        echo("// Entering paste mode (ctrl-D to finish)\n")
+        val text = (readWhile(_ => true) mkString "\n").trim
+        if (text.isEmpty) echo("\n// Nothing pasted, nothing gained.\n")
+        else echo("\n// Exiting paste mode, now interpreting.\n")
+        text
+      }
+    )
+    if (code.nonEmpty) {
       val res = intp interpret code
       // if input is incomplete, let the compiler try to say why
       if (res == IR.Incomplete) {
@@ -544,7 +556,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
         if (errless) echo("...but compilation found no error? Good luck with that.")
       }
     }
-    ()
+    Result(keepRunning = true, shouldReplay)
   }
 
   private object paste extends Pasted {

--- a/test/files/run/repl-paste-4.check
+++ b/test/files/run/repl-paste-4.check
@@ -1,0 +1,12 @@
+Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> :paste repl-paste-4.pastie
+Pasting file repl-paste-4.pastie...
+defined class Foo
+defined object Foo
+
+scala> Foo(new Foo)
+res0: Int = 7
+
+scala> 

--- a/test/files/run/repl-paste-4.pastie
+++ b/test/files/run/repl-paste-4.pastie
@@ -1,0 +1,4 @@
+
+// if we are truly companions, I can see your foo
+class Foo { private val foo = 7 }
+object Foo { def apply(f: Foo) = f.foo }

--- a/test/files/run/repl-paste-4.scala
+++ b/test/files/run/repl-paste-4.scala
@@ -1,0 +1,7 @@
+
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  def code = s":paste $pastie\nFoo(new Foo)\n"
+  def pastie = testPath.changeExtension("pastie")
+}

--- a/test/files/run/repl-paste-raw.pastie
+++ b/test/files/run/repl-paste-raw.pastie
@@ -1,0 +1,8 @@
+
+// a raw paste is not a script
+// hence it can be packaged
+
+package brown_paper
+
+// these are a few of my favorite things
+case class Gift (hasString: Boolean)

--- a/test/files/run/repl-paste-raw.scala
+++ b/test/files/run/repl-paste-raw.scala
@@ -1,0 +1,43 @@
+
+import scala.tools.partest.ReplTest
+import scala.tools.partest.nest.FileUtil
+
+
+// arrives in partest in PR# 2701
+abstract class SessionTest extends ReplTest with FileUtil {
+  def session: String
+  override final def code = expected filter (_.startsWith(prompt)) map (_.drop(prompt.length)) mkString "\n"
+  def expected = session.stripMargin.lines.toList
+  final def prompt = "scala> "
+  override def show() = {
+    val out = eval().toList
+    if (out.size != expected.size) Console println s"Expected ${expected.size} lines, got ${out.size}"
+    if (out != expected) Console print compareContents(expected, out, "expected", "actual")
+  }
+}
+
+object Test extends SessionTest {
+  /* old ReplTest
+  def code = s"""
+  |:paste -raw $pastie
+  |val favoriteThing = brown_paper.Gift(true)
+  |favoriteThing.hasString
+  |""".stripMargin.trim
+  */
+  def pastie = testPath changeExtension "pastie"
+
+  def session =
+s"""|Type in expressions to have them evaluated.
+    |Type :help for more information.
+    |
+    |scala> :paste -raw $pastie
+    |Pasting file $pastie...
+    |
+    |scala> val favoriteThing = brown_paper.Gift(true)
+    |favoriteThing: brown_paper.Gift = Gift(true)
+    |
+    |scala> favoriteThing.hasString
+    |res0: Boolean = true
+    |
+    |scala> """
+}


### PR DESCRIPTION
Add a file argument to the :paste command which loads the
file's contents as though entered in :paste mode.

The :paste command is replayable.

Samples, including companions defined together:

```
scala> :paste junk.scala
File contains no code: junk.scala

scala> :paste no-file.scala
That file does not exist

scala> :paste obj-repl.scala
Pasting file obj-repl.scala...
<console>:2: error: expected start of definition
         private foo = 7
                 ^

scala> :paste hw-repl.scala
Pasting file hw-repl.scala...
The pasted code is incomplete!

<pastie>:5: error: illegal start of simple expression
}
^

scala> :replay
Replaying: :paste junk.scala
File contains no code: junk.scala

Replaying: :paste obj-repl.scala
Pasting file obj-repl.scala...
defined trait Foo
defined object Foo

Replaying: Foo(new Foo{})
res0: Int = 7
```

Review by @retronym for whom I'll throw in `:paste -raw` if it otherwise looks good to him.

`-raw` is repl speak for "without wrapping", hence top-level.
