### PR TITLE
SI-6419 Repl save session command

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -220,6 +220,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     nullary("quit", "exit the interpreter", () => Result(keepRunning = false, None)),
     nullary("replay", "reset execution and replay all previous commands", replay),
     nullary("reset", "reset the repl to its initial state, forgetting all session entries", resetCommand),
+    cmd("save", "<path>", "save replayable session to a file", saveCommand),
     shCommand,
     nullary("silent", "disable/enable automatic printing of results", verbosity),
     cmd("type", "[-v] <expr>", "display the type of an expression without evaluating it", typeCommand),
@@ -469,6 +470,12 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     })
     Result(keepRunning = true, shouldReplay)
   }
+
+  def saveCommand(filename: String): Result = (
+    if (filename.isEmpty) echo("File name is required.")
+    else if (replayCommandStack.isEmpty) echo("No replay commands in session")
+    else File(filename).printlnAll(replayCommands: _*)
+  )
 
   def addClasspath(arg: String): Unit = {
     val f = File(arg).normalize

--- a/test/files/run/repl-save.check
+++ b/test/files/run/repl-save.check
@@ -1,0 +1,18 @@
+Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> val i = 7
+i: Int = 7
+
+scala> val j = 8
+j: Int = 8
+
+scala> i * j
+res0: Int = 56
+
+scala> :save repl-save-run.obj/session.repl
+
+scala> 
+val i = 7
+val j = 8
+i * j

--- a/test/files/run/repl-save.scala
+++ b/test/files/run/repl-save.scala
@@ -1,0 +1,16 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  def code = s"""
+    |val i = 7
+    |val j = 8
+    |i * j
+    |:save $saveto
+  """.stripMargin.trim
+  def saveto = testOutput / "session.repl"
+
+  override def show() = {
+    super.show()
+    Console print saveto.toFile.slurp
+  }
+}


### PR DESCRIPTION
A simple save command to write out the current replay stack.

One can imagine a distinct "store session" command that saves state. (`:store` and `:restore`)

```
scala> val i = 7
i: Int = 7

scala> val j=  8
j: Int = 8

scala> i * j
res0: Int = 56

scala> :save multy.script

scala> :q
apm@mara:~/tmp$ cat multy.script
val i = 7
val j=  8
i * j
apm@mara:~/tmp$ skala
Welcome to Scala version 2.11.0-20130626-204845-a83ca5bdf7 (OpenJDK 64-Bit Server VM, Java 1.7.0_21).
Type in expressions to have them evaluated.
Type :help for more information.

scala> :load multy.script
Loading multy.script...
i: Int = 7
j: Int = 8
res0: Int = 56

scala> :load multy.script
Loading multy.script...
i: Int = 7
j: Int = 8
res1: Int = 56
```

The commit omits to cite:

```
scala> :save foo
No replay commands in session

scala> :save
File name is required.
```

Review by @retronym who might give me a two-fer favor for paste -raw.
