### PR TITLE
Remove no-longer necessary workaround for SI-5731.

### DIFF
--- a/src/partest/scala/tools/partest/DirectTest.scala
+++ b/src/partest/scala/tools/partest/DirectTest.scala
@@ -115,10 +115,10 @@ abstract class DirectTest extends App {
     val preamble = if (shouldRun) "Attempting" else "Doing fallback for"
 
     def logInfo() = log(s"$preamble java $version specific test under java version $javaVersion")
- 
+
    /*
     * If the current java version is at least 'version' then 'yesRun' is evaluated
-    * otherwise 'fallback' is 
+    * otherwise 'fallback' is
     */
     def otherwise(fallback: =>A): A = {
       logInfo()

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -386,8 +386,8 @@ trait Definitions extends api.StandardDefinitions {
       def arrayClassMethod = getMemberMethod(ScalaRunTimeModule, nme.arrayClass)
 
     // classes with special meanings
-    lazy val StringAddClass             = requiredClass[scala.runtime.StringAdd]
-    lazy val ArrowAssocClass            = getRequiredClass("scala.Predef.ArrowAssoc") // SI-5731
+    lazy val StringAddClass             = requiredClass[scala.Predef.StringAdd[_]]
+    lazy val ArrowAssocClass            = requiredClass[scala.Predef.ArrowAssoc[_]]
     lazy val StringAdd_+                = getMemberMethod(StringAddClass, nme.PLUS)
     lazy val ScalaNumberClass           = requiredClass[scala.math.ScalaNumber]
     lazy val TraitSetterAnnotationClass = requiredClass[scala.runtime.TraitSetter]

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -905,7 +905,7 @@ trait Types
         if (sym == btssym) return mid
         else if (sym isLess btssym) hi = mid - 1
         else if (btssym isLess sym) lo = mid + 1
-        else abort()
+        else abort(s"Discovered fourth possibility for comparisons! " + ((sym, btssym)))
       }
       -1
     }


### PR DESCRIPTION
And avoid deprecated 0-arg abort and deprecated runtime classes.
