### PR TITLE
Use forward slash in #2637's test on windows

### DIFF
--- a/test/files/run/t7439/Test_2.scala
+++ b/test/files/run/t7439/Test_2.scala
@@ -23,7 +23,8 @@ object Test extends StoreReporterDirectTest {
     val a1Class = new File(testOutput.path, "A_1.class")
     assert(a1Class.exists)
     assert(a1Class.delete())
-    println(s"Recompiling after deleting $a1Class")
+    // testIdent normalizes to separate names using '/' regardless of platform, drops all but last two parts
+    println(s"Recompiling after deleting ${a1Class.testIdent}")
 
     // bad symbolic reference error expected (but no stack trace!)
     compileCode(C)


### PR DESCRIPTION
Don't use toString to output file names in tests, its output is platform dependent -- use `testIdent` instead.

This makes #2637 Windows-friendly.

review by @retronym
