### PR TITLE
SI-7174 Fix initialization issues

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
@@ -29,8 +29,9 @@ trait Analyzer extends AnyRef
   val global : Global
   import global._
 
-  object namerFactory extends SubComponent {
+  object namerFactory extends {
     val global: Analyzer.this.global.type = Analyzer.this.global
+  } with SubComponent {
     val phaseName = "namer"
     val runsAfter = List[String]("parser")
     val runsRightAfter = None
@@ -44,8 +45,9 @@ trait Analyzer extends AnyRef
     }
   }
 
-  object packageObjects extends SubComponent {
+  object packageObjects extends {
     val global: Analyzer.this.global.type = Analyzer.this.global
+  } with SubComponent {
     val phaseName = "packageobjects"
     val runsAfter = List[String]()
     val runsRightAfter= Some("namer")
@@ -71,9 +73,10 @@ trait Analyzer extends AnyRef
     }
   }
 
-  object typerFactory extends SubComponent {
-    import scala.reflect.internal.TypesStats.typerNanos
+  object typerFactory extends {
     val global: Analyzer.this.global.type = Analyzer.this.global
+  } with SubComponent {
+    import scala.reflect.internal.TypesStats.typerNanos
     val phaseName = "typer"
     val runsAfter = List[String]()
     val runsRightAfter = Some("packageobjects")

--- a/src/continuations/plugin/scala/tools/selectivecps/SelectiveCPSPlugin.scala
+++ b/src/continuations/plugin/scala/tools/selectivecps/SelectiveCPSPlugin.scala
@@ -11,22 +11,18 @@ class SelectiveCPSPlugin(val global: Global) extends Plugin {
   val name = "continuations"
   val description = "applies selective cps conversion"
 
-  val anfPhase = new SelectiveANFTransform() {
-    val global = SelectiveCPSPlugin.this.global
+  val anfPhase = new {val global = SelectiveCPSPlugin.this.global } with SelectiveANFTransform() {
     val runsAfter = List("pickler")
   }
 
-  val cpsPhase = new SelectiveCPSTransform() {
-    val global = SelectiveCPSPlugin.this.global
+  val cpsPhase = new {val global = SelectiveCPSPlugin.this.global } with SelectiveCPSTransform() {
     val runsAfter = List("selectiveanf")
     override val runsBefore = List("uncurry")
   }
 
   val components = List[PluginComponent](anfPhase, cpsPhase)
 
-  val checker = new CPSAnnotationChecker {
-    val global: SelectiveCPSPlugin.this.global.type = SelectiveCPSPlugin.this.global
-  }
+  val checker = new { val global: SelectiveCPSPlugin.this.global.type = SelectiveCPSPlugin.this.global } with CPSAnnotationChecker
   global.addAnnotationChecker(checker.checker)
   global.analyzer.addAnalyzerPlugin(checker.plugin)
 


### PR DESCRIPTION
Without constant inlining, the compiler would not even bootstrap
because it depends on constant inlining hiding initialization issues
which would cause a NPE otherwise.
