### PR TITLE
SI-4829 the :load command now fails if the command ends with a space

### DIFF
--- a/src/compiler/scala/tools/util/StringOps.scala
+++ b/src/compiler/scala/tools/util/StringOps.scala
@@ -55,7 +55,7 @@ trait StringOps {
     else Some(str take idx, str drop (if (doDropIndex) idx + 1 else idx))
 
   def splitLeft(str: String, ch: Char): Option[(String, String)] = {
-    splitAt(str, str.indexOf(' '), true)
+    splitAt(str, str.indexOf(ch), true)
   }
 
   /** Returns a string meaning "n elements".

--- a/src/compiler/scala/tools/util/StringOps.scala
+++ b/src/compiler/scala/tools/util/StringOps.scala
@@ -54,6 +54,10 @@ trait StringOps {
     if (idx == -1) None
     else Some(str take idx, str drop (if (doDropIndex) idx + 1 else idx))
 
+  def splitLeft(str: String, ch: Char): Option[(String, String)] = {
+    splitAt(str, str.indexOf(' '), true)
+  }
+
   /** Returns a string meaning "n elements".
    *
    *  @param n        ...


### PR DESCRIPTION
The :load command now tries to be smart by detecting the presence of trailing spaces that might be insignificant.

On certain file systems, files with trailing whitespaces are permitted which is why we don't naievely trim the argument.
