### PR TITLE
SI-7487 Revert "Removed -Ymacro-no-expand."

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -166,6 +166,7 @@ trait ScalaSettings extends AbsScalaSettings
   val Yrangepos       = BooleanSetting    ("-Yrangepos", "Use range positions for syntax trees.")
   val Ymemberpos      = StringSetting     ("-Yshow-member-pos", "output style", "Show start and end positions of members", "") withPostSetHook (_ => Yrangepos.value = true)
   val Yreifycopypaste = BooleanSetting    ("-Yreify-copypaste", "Dump the reified trees in copypasteable representation.")
+  val Ymacronoexpand  = BooleanSetting    ("-Ymacro-no-expand", "Don't expand macros. Might be useful for scaladoc and presentation compiler, but will crash anything which uses macros and gets past typer.")
   val Yreplsync       = BooleanSetting    ("-Yrepl-sync", "Do not use asynchronous code for repl startup")
   val Yreploutdir     = StringSetting     ("-Yrepl-outdir", "path", "Write repl-generated classfiles to given output directory (use \"\" to generate a temporary dir)" , "")
   val YmethodInfer    = BooleanSetting    ("-Yinfer-argument-types", "Infer types for arguments of overriden methods.")

--- a/test/scaladoc/run/SI-6812.scala
+++ b/test/scaladoc/run/SI-6812.scala
@@ -1,0 +1,24 @@
+import scala.tools.nsc.doc.model._
+import scala.tools.partest.ScaladocModelTest
+import language._
+
+object Test extends ScaladocModelTest {
+
+  override def code = """
+    import scala.reflect.macros.Context
+    import language.experimental.macros
+
+    object Macros {
+      def impl(c: Context) = c.literalUnit
+      def foo = macro impl
+    }
+
+    class C {
+      def bar = Macros.foo
+    }
+  """
+
+  def scaladocSettings = ""
+  override def extraSettings = super.extraSettings + " -Ymacro-no-expand"
+  def testModel(root: Package) = ()
+}


### PR DESCRIPTION
This reverts commit 71fb0b83a, which itself reverted the fix for SI-6812.

/cc @harrah, sorry it took so long! Hope this still works...
