### PR TITLE
SI-7649 Fix positions for reshaped tag materializers

### DIFF
--- a/test/files/pos/t7649.flags
+++ b/test/files/pos/t7649.flags
@@ -1,0 +1,1 @@
+-Yrangepos

--- a/test/files/pos/t7649.scala
+++ b/test/files/pos/t7649.scala
@@ -1,0 +1,20 @@
+object Test {
+  val c: reflect.macros.Context = ???
+  import c.universe._
+  reify {
+    // The lookup of the implicit WeakTypeTag[Any]
+    // was triggering an unpositioned tree.
+    c.Expr[Any](Literal(Constant(0))).splice
+  }
+
+  import scala.reflect.ClassTag
+  def ct[A: ClassTag]: Expr[A] = ???
+  def tt[A: TypeTag]: Expr[A] = ???
+  def wtt[A: WeakTypeTag]: Expr[A] = ???
+
+  reify {
+    ct[String].splice
+    tt[String].splice
+    wtt[String].splice
+  }
+}


### PR DESCRIPTION
Calls to `materializeClassTag[T]` are replaced during reification with
`implicitly[ClassTag[T]]` in the `reify` macro. This is done to avoid
referring to symbols in scala-compiler.jar. Class- and Type-Tag
materialization is treated in the same way.

This change positions the replacement trees to avoid triggering
assertions under -Yrangepos.

Review by @xeno-by.

Are we in a better shape to address this problem properly in master?

``` scala
// when implicit macros are fixed, these sneaky macros will move to corresponding companion objects
// of, say, ClassTag or TypeTag
```
