### PR TITLE
Fixes checkinit build failure caused by quasiquotes pull request

### DIFF
--- a/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
@@ -15,11 +15,11 @@ trait Reifiers { self: Quasiquotes =>
 
   abstract class Reifier extends {
     val global: self.global.type = self.global
+    val universe = self.universe
+    val reifee = EmptyTree
+    val mirror = EmptyTree
+    val concrete = false
   } with ReflectReifier {
-    val reifee     = EmptyTree
-    val universe   = self.universe
-    val mirror     = EmptyTree
-    val concrete   = false
     lazy val typer = throw new UnsupportedOperationException
 
     def isReifyingExpressions: Boolean


### PR DESCRIPTION
The failure was caused by recent refactoring that moved fields that are expected by reflection Reifier from early init block to the body of the class. According to checkinit this may cause initialization issues although they do not really happen in real life as most of these fields aren't used during quasiquotes' reification.
