### PR TITLE
Fix repl-save test

### DIFF
--- a/test/files/run/repl-save.check
+++ b/test/files/run/repl-save.check
@@ -1,18 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
-
-scala> val i = 7
-i: Int = 7
-
-scala> val j = 8
-j: Int = 8
-
-scala> i * j
-res0: Int = 56
-
-scala> :save repl-save-run.obj/session.repl
-
-scala> 
 val i = 7
 val j = 8
 i * j

--- a/test/files/run/repl-save.scala
+++ b/test/files/run/repl-save.scala
@@ -1,14 +1,23 @@
-import scala.tools.partest.ReplTest
+import scala.tools.partest.SessionTest
 
-object Test extends ReplTest {
-  def code = s"""
-    |val i = 7
-    |val j = 8
-    |i * j
-    |:save $saveto
-  """.stripMargin.trim
+object Test extends SessionTest {
+  def session =
+s"""|Type in expressions to have them evaluated.
+    |Type :help for more information.
+    |
+    |scala> val i = 7
+    |i: Int = 7
+    |
+    |scala> val j = 8
+    |j: Int = 8
+    |
+    |scala> i * j
+    |res0: Int = 56
+    |
+    |scala> :save $saveto
+    |
+    |scala> """
   def saveto = testOutput / "session.repl"
-
   override def show() = {
     super.show()
     Console print saveto.toFile.slurp


### PR DESCRIPTION
Running by the validator; I'll have to reboot to test in Windows -- I'll do that in a bit.  But it seems like it might work.

Make the test a SessionTest, where the file name appears just
once, in the transcript, and is trivially compared against itself.

The contents of the saved file are still output and compared with
the check file.
