### PR TITLE
SI-6582 Use Tseitin transformation to convert propositional formulae into CNF.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/CNF.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/CNF.scala
@@ -1,0 +1,89 @@
+/* NSC -- new Scala compiler
+ *
+ * @author Gerard Basler
+ */
+
+package scala.tools.nsc.transform.patmat
+
+/**
+ * Conjunctive normal form (of a Boolean formula).
+ * A formula in this form is amenable to a SAT solver
+ * (i.e., solver that decides satisfiability of a formula).
+ */
+class CNF {
+
+  import scala.collection.mutable.ArrayBuffer
+
+  // a clause is a disjunction of distinct literals
+  type Clause = Set[Lit]
+  type ClauseBuilder = ArrayBuffer[Clause]
+
+  var noLiterals = 0
+
+  val buff = ArrayBuffer[Clause]()
+
+  def clauses: Array[Clause] = buff.toArray
+
+  def newLiteral(): Lit = {
+    noLiterals += 1
+    Lit(noLiterals, false)
+  }
+
+  val constTrue: Lit = {
+    val constTrue = newLiteral()
+    addClauseProcessed(constTrue.pos)
+    constTrue
+  }
+
+  val constFalse: Lit = -constTrue
+
+  def isConst(l: Lit): Boolean = l == constTrue || l == constFalse
+
+  def addClauseRaw(clause: Clause): Unit = buff += clause
+
+  /**
+   * Add literals vector, ignores clauses that are trivially satisfied
+   *
+   * @param bv
+   */
+  def addClauseProcessed(bv: Lit*) {
+    val clause = processClause(bv: _*)
+    if (clause.nonEmpty)
+      addClauseRaw(clause)
+  }
+
+  /**
+   * @return empty clause, if clause trivially satisfied
+   */
+  private def processClause(bv: Lit*): Clause = {
+    val clause = bv.distinct
+
+    val isTautology = clause.combinations(2).exists {
+      case Seq(a, b) => a == -b
+    }
+
+    if (isTautology)
+      Set()
+    else
+      clause.toSet
+  }
+
+  override def toString: String = {
+    for {
+      clause <- buff
+    } yield {
+      clause.mkString("(", " ", ")")
+    }
+  }.mkString("\n")
+
+  def dimacs: String = {
+    val header = s"p cnf ${noLiterals} ${buff.length}\n"
+    header + {
+      for {
+        clause <- buff
+      } yield {
+        clause.toSeq.sortBy(l => math.abs(l.v)) mkString("", " ", " 0")
+      }
+    }.mkString("\n")
+  }
+}

--- a/src/compiler/scala/tools/nsc/transform/patmat/Lit.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Lit.scala
@@ -1,0 +1,28 @@
+/* NSC -- new Scala compiler
+ *
+ * @author Gerard Basler
+ */
+
+package scala.tools.nsc.transform.patmat
+
+/**
+ * A pair of a variable number and a sign, encoded as follows:
+ *
+ * @param sign 'false' means positive
+ *             'true' means negative
+ */
+case class Lit(v: Int, sign: Boolean) {
+  require(v > 0, "literal must be strictly positive")
+
+  override def toString = s"${
+    if (sign) "-" else "+"
+  }$v"
+
+  def unary_- : Lit = Lit(v, !sign)
+
+  def neg: Lit = -this
+
+  def pos: Lit = this
+
+  def dimacs = if (sign) -v else v
+}

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
@@ -53,16 +53,16 @@ trait MatchOptimization extends MatchTreeMaking with MatchAnalysis {
         val cond = test.prop
 
         def simplify(c: Prop): Set[Prop] = c match {
-          case And(a, b)                  => simplify(a) ++ simplify(b)
-          case Or(_, _)                   => Set(False) // TODO: make more precise
-          case Not(Eq(Var(_), NullConst)) => Set(True)  // not worth remembering
+          case And(ops)                   => ops flatMap simplify
+          case Or(ops)                    => Set(False) // TODO: make more precise
+          case Not(Eq(Var(_), NullConst)) => Set(True) // not worth remembering
           case _                          => Set(c)
         }
         val conds = simplify(cond)
 
         if (conds(False)) false // stop when we encounter a definite "no" or a "not sure"
         else {
-          val nonTrivial = conds filterNot (_ == True)
+          val nonTrivial = conds - True
           if (nonTrivial nonEmpty) {
             tested ++= nonTrivial
 

--- a/src/compiler/scala/tools/nsc/transform/patmat/Solving.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Solving.scala
@@ -6,19 +6,188 @@
 
 package scala.tools.nsc.transform.patmat
 
-import scala.collection.mutable
 import scala.reflect.internal.util.Statistics
+import scala.language.postfixOps
+import scala.collection.{immutable, mutable}
 
-// naive CNF translation and simple DPLL solver
+/**
+ * Solve pattern matcher exhaustivity problem via DPLL.
+ */
 trait Solving extends Logic {
+
+  private def traverse[A, B](a: Set[A])(f: A => Option[B]): Option[Set[B]] = {
+    val s = immutable.Set.newBuilder[B]
+    val i = a.iterator
+    while (i.hasNext) {
+      val e = i.next()
+      f(e) match {
+        case Some(x) =>
+          s += x
+        case None    =>
+          return None
+      }
+    }
+    Some(s.result)
+  }
+
   import PatternMatchingStats._
-  trait CNF extends PropositionalLogic {
+
+  /**
+   * Tseitin transformation: used for conversion of a
+   * propositional formula into conjunctive normal form (CNF)
+   * (input format for SAT solver).
+   * A simple conversion into CNF via Shannon expansion would
+   * also be possible but it's worst-case complexity is exponential
+   * (in the number of variables) and thus even simple problems
+   * could become untractable.
+   * The Tseitin transformation results in an _equisatisfiable_
+   * CNF-formula (it generates auxiliary variables)
+   * but runs with linear complexity.
+   */
+  trait TseitinCNF extends PropositionalLogic {
+
+    def eqFreePropToSolvable(p: Prop): Solvable = {
+      type Cache = Map[Prop, Lit]
+
+      val cache = mutable.Map[Prop, Lit]()
+
+      val cnf = new CNF
+
+      def convertWithoutCache(p: Prop): Lit = {
+        p match {
+          case And(fv)   =>
+            and(fv.map(convertWithCache))
+          case Or(fv)    =>
+            or(fv.map(convertWithCache))
+          case Not(a)    =>
+            not(convertWithCache(a))
+          case _: Sym =>
+            cnf.newLiteral()
+          case True      =>
+            cnf.constTrue
+          case False     =>
+            cnf.constFalse
+          case _: Eq =>
+            sys.error("Forgot to call propToSolvable()?")
+        }
+      }
+
+      def convertWithCache(p: Prop): Lit = {
+        cache.getOrElse(p, {
+          val l = convertWithoutCache(p)
+          require(!cache.isDefinedAt(p), "loop in formula?")
+          cache += (p -> l)
+          l
+        })
+      }
+
+      def and(bv: Set[Lit]): Lit = {
+        import cnf._
+        if (bv.isEmpty) {
+          constTrue
+        } else if (bv.size == 1) {
+          bv.head
+        } else if (bv.contains(constFalse)) {
+          constFalse
+        } else {
+          // op1*op2*...*opx <==> (op1 + o')(op2 + o')... (opx + o')(op1' + op2' +... + opx' + o)
+          val new_bv = bv - constTrue // ignore `True`
+          val o = newLiteral() // auxiliary Tseitin variable
+          new_bv.map(op => addClauseProcessed(op.pos, o.neg))
+          addClauseProcessed((new_bv.map(_.neg) + o.pos).toSeq: _*)
+          o
+        }
+      }
+
+      def or(bv: Set[Lit]): Lit = {
+        import cnf._
+        if (bv.isEmpty) {
+          constFalse
+        } else if (bv.size == 1) {
+          bv.head
+        } else if (bv.contains(constTrue)) {
+          constTrue
+        } else {
+          // op1+op2+...+opx <==> (op1' + o)(op2' + o)... (opx' + o)(op1 + op2 +... + opx + o')
+          val new_bv = bv - constFalse // ignore `False`
+          val o = newLiteral() // auxiliary Tseitin variable
+          new_bv.map(op => addClauseProcessed(op.neg, o.pos))
+          addClauseProcessed((new_bv.map(_.pos) + o.neg).toSeq: _*)
+          o
+        }
+      }
+
+      // no need for auxiliary variable
+      def not(a: Lit): Lit = -a
+
+      object ToLiteral {
+        def unapply(f: Prop): Option[Lit] = f match {
+          case Not(a)    =>
+            ToLiteral.unapply(a).map(_.neg)
+          case _: Sym =>
+            Some(convertWithCache(f)) // go via cache in order to get single literal for variable
+          case True      =>
+            Some(cnf.constTrue)
+          case False     =>
+            Some(cnf.constFalse)
+          case _         =>
+            None
+        }
+      }
+
+      object ToDisjunction {
+        def unapply(p: Prop): Option[CNF#Clause] = p match {
+          case Or(fv) =>
+            traverse(fv)(ToLiteral.unapply)
+          case p =>
+            ToLiteral.unapply(p).map(Set(_))
+        }
+      }
+
+      /**
+       * Checks if propositional formula is already in CNF
+       */
+      object ToCnf {
+        def unapply(f: Prop): Option[Seq[CNF#Clause]] = f match {
+          case And(fv) =>
+            traverse(fv)(ToDisjunction.unapply).map(_.toSeq)
+          case p =>
+            ToDisjunction.unapply(p).map(Seq(_))
+        }
+      }
+
+      val simplified = simplify(p)
+      simplified match {
+        case ToCnf(clauses) =>
+          // already in CNF, just add clauses
+          clauses.foreach(cnf.addClauseRaw)
+        case p                       =>
+          // add intermediate variable since we want the formula to be SAT!
+          cnf.addClauseProcessed(convertWithCache(p))
+      }
+
+      // all variables are guaranteed to be in cache
+      // (doesn't mean they will appear in the resulting formula)
+      val symForVar: Map[Int, Sym] = cache.collect {
+        case (sym: Sym, lit) => lit.v -> sym
+      }(collection.breakOut) // breakOut in order to obtain immutable Map
+
+      Solvable(cnf, symForVar)
+    }
+
+  }
+
+  // simple solver using DPLL
+  trait Solver extends TseitinCNF {
+    type Clause  = CNF#Clause
 
     /** Override Array creation for efficiency (to not go through reflection). */
     private implicit val clauseTag: scala.reflect.ClassTag[Clause] = new scala.reflect.ClassTag[Clause] {
       def runtimeClass: java.lang.Class[Clause] = classOf[Clause]
       final override def newArray(len: Int): Array[Clause] = new Array[Clause](len)
     }
+
+    def cnfString(f: Formula) = alignAcrossRows(f map (_.toList) toList, "\\/", " /\\\n")
 
     import scala.collection.mutable.ArrayBuffer
     type FormulaBuilder = ArrayBuffer[Clause]
@@ -31,153 +200,70 @@ trait Solving extends Logic {
     type Formula = FormulaBuilder
     def formula(c: Clause*): Formula = ArrayBuffer(c: _*)
 
-    type Clause  = Set[Lit]
     // a clause is a disjunction of distinct literals
     def clause(l: Lit*): Clause = l.toSet
-
-    type Lit
-    def Lit(sym: Sym, pos: Boolean = true): Lit
-
-    def andFormula(a: Formula, b: Formula): Formula = a ++ b
-    def simplifyFormula(a: Formula): Formula = a.distinct
-
-    private def merge(a: Clause, b: Clause) = a ++ b
-
-    // throws an AnalysisBudget.Exception when the prop results in a CNF that's too big
-    // TODO: be smarter/more efficient about this (http://lara.epfl.ch/w/sav09:tseitin_s_encoding)
-    def eqFreePropToSolvable(p: Prop): Formula = {
-      def negationNormalFormNot(p: Prop, budget: Int): Prop =
-        if (budget <= 0) throw AnalysisBudget.exceeded
-        else p match {
-          case And(a, b) =>  Or(negationNormalFormNot(a, budget - 1), negationNormalFormNot(b, budget - 1))
-          case Or(a, b)  => And(negationNormalFormNot(a, budget - 1), negationNormalFormNot(b, budget - 1))
-          case Not(p)    => negationNormalForm(p, budget - 1)
-          case True      => False
-          case False     => True
-          case s: Sym    => Not(s)
-        }
-
-      def negationNormalForm(p: Prop, budget: Int = AnalysisBudget.max): Prop =
-        if (budget <= 0) throw AnalysisBudget.exceeded
-        else p match {
-          case And(a, b)      => And(negationNormalForm(a, budget - 1), negationNormalForm(b, budget - 1))
-          case Or(a, b)       =>  Or(negationNormalForm(a, budget - 1), negationNormalForm(b, budget - 1))
-          case Not(negated)   => negationNormalFormNot(negated, budget - 1)
-          case True
-             | False
-             | (_ : Sym)      => p
-        }
-
-      val TrueF          = formula()
-      val FalseF         = formula(clause())
-      def lit(s: Sym)    = formula(clause(Lit(s)))
-      def negLit(s: Sym) = formula(clause(Lit(s, false)))
-
-      def conjunctiveNormalForm(p: Prop, budget: Int = AnalysisBudget.max): Formula = {
-        def distribute(a: Formula, b: Formula, budget: Int): Formula =
-          if (budget <= 0) throw AnalysisBudget.exceeded
-          else
-            (a, b) match {
-              // true \/ _ = true
-              // _ \/ true = true
-              case (trueA, trueB) if trueA.size == 0 || trueB.size == 0 => TrueF
-              // lit \/ lit
-              case (a, b) if a.size == 1 && b.size == 1 => formula(merge(a(0), b(0)))
-              // (c1 /\ ... /\ cn) \/ d = ((c1 \/ d) /\ ... /\ (cn \/ d))
-              // d \/ (c1 /\ ... /\ cn) = ((d \/ c1) /\ ... /\ (d \/ cn))
-              case (cs, ds) =>
-                val (big, small) = if (cs.size > ds.size) (cs, ds) else (ds, cs)
-                big flatMap (c => distribute(formula(c), small, budget - (big.size*small.size)))
-            }
-
-        if (budget <= 0) throw AnalysisBudget.exceeded
-
-        p match {
-          case True        => TrueF
-          case False       => FalseF
-          case s: Sym      => lit(s)
-          case Not(s: Sym) => negLit(s)
-          case And(a, b)   =>
-            val cnfA = conjunctiveNormalForm(a, budget - 1)
-            val cnfB = conjunctiveNormalForm(b, budget - cnfA.size)
-            cnfA ++ cnfB
-          case Or(a, b)    =>
-            val cnfA = conjunctiveNormalForm(a)
-            val cnfB = conjunctiveNormalForm(b)
-            distribute(cnfA, cnfB, budget - (cnfA.size + cnfB.size))
-        }
-      }
-
-      val start = if (Statistics.canEnable) Statistics.startTimer(patmatCNF) else null
-      val res   = conjunctiveNormalForm(negationNormalForm(p))
-
-      if (Statistics.canEnable) Statistics.stopTimer(patmatCNF, start)
-
-      //
-      if (Statistics.canEnable) patmatCNFSizes(res.size).value += 1
-
-//      debug.patmat("cnf for\n"+ p +"\nis:\n"+cnfString(res))
-      res
-    }
-  }
-
-  // simple solver using DPLL
-  trait Solver extends CNF {
-    // a literal is a (possibly negated) variable
-    def Lit(sym: Sym, pos: Boolean = true) = new Lit(sym, pos)
-    class Lit(val sym: Sym, val pos: Boolean) {
-      override def toString = if (!pos) "-"+ sym.toString else sym.toString
-      override def equals(o: Any) = o match {
-        case o: Lit => (o.sym eq sym) && (o.pos == pos)
-        case _ => false
-      }
-      override def hashCode = sym.hashCode + pos.hashCode
-
-      def unary_- = Lit(sym, !pos)
-    }
-
-    def cnfString(f: Formula) = alignAcrossRows(f map (_.toList) toList, "\\/", " /\\\n")
 
     // adapted from http://lara.epfl.ch/w/sav10:simple_sat_solver (original by Hossein Hojjat)
     val EmptyModel = Map.empty[Sym, Boolean]
     val NoModel: Model = null
 
+    // this model contains the auxiliary variables as well
+    type TseitinModel = Set[Lit]
+    val EmptyTseitinModel = Set.empty[Lit]
+    val NoTseitinModel: TseitinModel = null
+
+    private def stoppingTimeFor(timeout: Long) = if (timeout == 0) 0 else System.currentTimeMillis() + timeout
+
     // returns all solutions, if any (TODO: better infinite recursion backstop -- detect fixpoint??)
-    def findAllModelsFor(f: Formula): List[Model] = {
-      val vars: Set[Sym] = f.flatMap(_ collect {case l: Lit => l.sym}).toSet
+    def findAllModelsFor(solvable: Solvable, timeout: Long): List[Model] = {
+      import solvable._
+
+      val stoppingTime: Long = stoppingTimeFor(timeout)
+
+      // variables of the problem
+      val allVars: Set[Int] = (1 to cnf.noLiterals).toSet
       // debug.patmat("vars "+ vars)
       // the negation of a model -(S1=True/False /\ ... /\ SN=True/False) = clause(S1=False/True, ...., SN=False/True)
-      def negateModel(m: Model) = clause(m.toSeq.map{ case (sym, pos) => Lit(sym, !pos) } : _*)
+      // (i.e. the blocking clause - used for ALL-SAT)
+      def negateModel(m: TseitinModel) = m.map(_.neg)
 
-      def findAllModels(f: Formula, models: List[Model], recursionDepthAllowed: Int = 10): List[Model]=
+      def findAllModels(f: Formula, models: List[TseitinModel], recursionDepthAllowed: Int = 10): List[TseitinModel] =
         if (recursionDepthAllowed == 0) models
         else {
-          debug.patmat("find all models for\n"+ cnfString(f))
-          val model = findModelFor(f)
+          debug.patmat("find all models for\n" + cnfString(f))
+          val model = findTseitinModelFor(f, stoppingTime)
           // if we found a solution, conjunct the formula with the model's negation and recurse
-          if (model ne NoModel) {
-            val unassigned = (vars -- model.keySet).toList
-            debug.patmat("unassigned "+ unassigned +" in "+ model)
+          if (model ne NoTseitinModel) {
+            val unassigned = (allVars -- model.map(_.v)).toList
+            debug.patmat("unassigned " + unassigned + " in " + model)
             def force(lit: Lit) = {
-              val model = withLit(findModelFor(dropUnit(f, lit)), lit)
-              if (model ne NoModel) List(model)
+              val model = withLit(findTseitinModelFor(dropUnit(f.toArray, lit), stoppingTime), lit)
+              if (model ne NoTseitinModel) List(model)
               else Nil
             }
-            val forced = unassigned flatMap { s =>
-              force(Lit(s, true)) ++ force(Lit(s, false))
+            val forced = unassigned flatMap {
+              l =>
+                force(Lit(l, false)) ++ force(Lit(l, true))
             }
-            debug.patmat("forced "+ forced)
+            debug.patmat("forced " + forced)
             val negated = negateModel(model)
             findAllModels(f :+ negated, model :: (forced ++ models), recursionDepthAllowed - 1)
           }
           else models
         }
 
-      findAllModels(f, Nil)
+      val tseitinModels = findAllModels(cnf.buff, Nil)
+      val models = tseitinModels.map(projectToModel(_, symForVar))
+      debug.patmat(s"cnf: ${cnf.dimacs}")
+      debug.patmat(s"models: ${models.mkString(",")}")
+      models
     }
 
-    private def withLit(res: Model, l: Lit): Model = if (res eq NoModel) NoModel else res + (l.sym -> l.pos)
-    private def dropUnit(f: Formula, unitLit: Lit): Formula = {
+    private def withLit(res: TseitinModel, l: Lit): TseitinModel = {
+      if (res eq NoTseitinModel) NoTseitinModel else res + l
+    }
+
+    private def dropUnit(f: Array[CNF#Clause], unitLit: Lit): Formula = {
       val negated = -unitLit
       // drop entire clauses that are trivially true
       // (i.e., disjunctions that contain the literal we're making true in the returned model),
@@ -191,52 +277,73 @@ trait Solving extends Logic {
       dropped
     }
 
-    def findModelFor(f: Formula): Model = {
-      @inline def orElse(a: Model, b: => Model) = if (a ne NoModel) a else b
+    def findModelFor(solvable: Solvable, timeout: Long): Model = {
+      val stoppingTime: Long = stoppingTimeFor(timeout)
+      projectToModel(findTseitinModelFor(solvable.cnf.buff, stoppingTime), solvable.symForVar)
+    }
 
-      debug.patmat("DPLL\n"+ cnfString(f))
+    def findTseitinModelFor(f: Formula, stoppingTime: Long): TseitinModel = {
+      @inline def orElse(a: TseitinModel, b: => TseitinModel) = if (a ne NoTseitinModel) a else b
+
+      if(stoppingTime != 0 && System.currentTimeMillis() > stoppingTime) throw AnalysisBudget.timeout
+
+      debug.patmat(s"DPLL\n${cnfString(f)}")
 
       val start = if (Statistics.canEnable) Statistics.startTimer(patmatAnaDPLL) else null
 
-      val satisfiableWithModel: Model =
-        if (f isEmpty) EmptyModel
-        else if(f exists (_.isEmpty)) NoModel
+      val satisfiableWithModel: TseitinModel =
+        if (f isEmpty) EmptyTseitinModel
+        else if (f exists (_.isEmpty)) NoTseitinModel
         else f.find(_.size == 1) match {
           case Some(unitClause) =>
             val unitLit = unitClause.head
-            // debug.patmat("unit: "+ unitLit)
-            withLit(findModelFor(dropUnit(f, unitLit)), unitLit)
-          case _ =>
+            withLit(findTseitinModelFor(dropUnit(f.toArray, unitLit), stoppingTime), unitLit)
+          case _                =>
             // partition symbols according to whether they appear in positive and/or negative literals
-            val pos = new mutable.HashSet[Sym]()
-            val neg = new mutable.HashSet[Sym]()
-            f.foreach{_.foreach{ lit =>
-              if (lit.pos) pos += lit.sym else neg += lit.sym
-            }}
+            val pos = new mutable.HashSet[Int]()
+            val neg = new mutable.HashSet[Int]()
+            f.foreach {
+              _.foreach {
+                lit =>
+                  if (!lit.sign) pos += lit.v else neg += lit.v
+              }
+            }
             // appearing in both positive and negative
-            val impures = pos intersect neg
+            val impures: mutable.HashSet[Int] = pos intersect neg
             // appearing only in either positive/negative positions
-            val pures = (pos ++ neg) -- impures
+            val pures: mutable.HashSet[Int] = (pos ++ neg) -- impures
 
             if (pures nonEmpty) {
-              val pureSym = pures.head
+              val pureVar: Int = pures.head
               // turn it back into a literal
               // (since equality on literals is in terms of equality
               //  of the underlying symbol and its positivity, simply construct a new Lit)
-              val pureLit = Lit(pureSym, pos(pureSym))
+              val pureLit = Lit(pureVar, neg(pureVar))
               // debug.patmat("pure: "+ pureLit +" pures: "+ pures +" impures: "+ impures)
               val simplified = f.filterNot(_.contains(pureLit))
-              withLit(findModelFor(simplified), pureLit)
+              withLit(findTseitinModelFor(simplified, stoppingTime), pureLit)
             } else {
               val split = f.head.head
               // debug.patmat("split: "+ split)
-              orElse(findModelFor(f :+ clause(split)), findModelFor(f :+ clause(-split)))
+              orElse(findTseitinModelFor(f :+ clause(split), stoppingTime), findTseitinModelFor(f :+ clause(-split), stoppingTime))
             }
         }
 
-        if (Statistics.canEnable) Statistics.stopTimer(patmatAnaDPLL, start)
+      if (Statistics.canEnable) Statistics.stopTimer(patmatAnaDPLL, start)
 
-        satisfiableWithModel
+      satisfiableWithModel
+    }
+
+    private def projectToModel(model: TseitinModel, symForLit: Map[Int, Sym]): Model = {
+
+      if (model eq NoTseitinModel) return NoModel
+
+      (for {
+        lit <- model
+        sym <- symForLit.get(lit.v)
+      } yield {
+        sym -> !lit.sign
+      }).toMap
     }
   }
 }

--- a/src/intellij/test/files/neg/virtpatmat_exhaust_big.check
+++ b/src/intellij/test/files/neg/virtpatmat_exhaust_big.check
@@ -1,0 +1,7 @@
+virtpatmat_exhaust_big.scala:27: warning: match may not be exhaustive.
+It would fail on the following input: Z11()
+  def foo(z: Z) = z match {
+                  ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/src/intellij/test/files/neg/virtpatmat_exhaust_big.flags
+++ b/src/intellij/test/files/neg/virtpatmat_exhaust_big.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -unchecked

--- a/src/intellij/test/files/neg/virtpatmat_exhaust_big.scala
+++ b/src/intellij/test/files/neg/virtpatmat_exhaust_big.scala
@@ -1,0 +1,32 @@
+sealed abstract class Z
+object Z {
+   object     Z0    extends Z
+   case class Z1()  extends Z
+   object     Z2    extends Z
+   case class Z3()  extends Z
+   object     Z4    extends Z
+   case class Z5()  extends Z
+   object     Z6    extends Z
+   case class Z7()  extends Z
+   object     Z8    extends Z
+   case class Z9()  extends Z
+   object     Z10   extends Z
+   case class Z11() extends Z
+   object     Z12   extends Z
+   case class Z13() extends Z
+   object     Z14   extends Z
+   case class Z15() extends Z
+   object     Z16   extends Z
+   case class Z17() extends Z
+   object     Z18   extends Z
+   case class Z19() extends Z
+}
+
+object Test {
+  import Z._
+  def foo(z: Z) = z match {
+    case Z0  | Z1()  | Z2  | Z3()  | Z4  | Z5()  | Z6  | Z7()  | Z8  | Z9() |
+         Z10 | Z12 | Z13() | Z14 | Z15() | Z16 | Z17() | Z18 | Z19()
+         =>
+  }
+}

--- a/src/intellij/test/files/pos/virtpatmat_exhaust_big.scala
+++ b/src/intellij/test/files/pos/virtpatmat_exhaust_big.scala
@@ -1,0 +1,34 @@
+sealed abstract class Z
+object Z {
+   object     Z0    extends Z
+   case class Z1()  extends Z
+   object     Z2    extends Z
+   case class Z3()  extends Z
+   object     Z4    extends Z
+   case class Z5()  extends Z
+   object     Z6    extends Z
+   case class Z7()  extends Z
+   object     Z8    extends Z
+   case class Z9()  extends Z
+   object     Z10   extends Z
+   case class Z11() extends Z
+   object     Z12   extends Z
+   case class Z13() extends Z
+   object     Z14   extends Z
+   case class Z15() extends Z
+   object     Z16   extends Z
+   case class Z17() extends Z
+   object     Z18   extends Z
+   case class Z19() extends Z
+}
+
+// drop any case and it will report an error
+object Test {
+  import Z._
+  def foo(z: Z) = z match {
+    case Z0  | Z1()  | Z2  | Z3()  | Z4  | Z5()  | Z6  | Z7()  | Z8  | Z9() |
+         Z10 | Z11() | Z12 | Z13() | Z14 | Z15() | Z16 | Z17() | Z18 | Z19()
+         =>
+  }
+}
+- 


### PR DESCRIPTION
This resolves the `AnalysisBudgetException` problem for big pattern matches.

Initial experiments indicate that the problem is even simpler than initially thought: all formulae I got from the exhaustiveness check could be transformed directly into CNF by formula simplification, neither expansion not Tseitin transformation where needed.
Thus the framework introduced here might be overkill and a much simpler implementation could work as well.

For Scala 2.11 I'd suggest to replace the DPLL procedure with Sat4j. See separate branch.

Review by @adriaanm 
