### PR TITLE
SI-4684 Repl supports whole-file paste (rebased)

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -216,8 +216,8 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     cmd("implicits", "[-v]", "show the implicits in scope", intp.implicitsCommand),
     cmd("javap", "<path|class>", "disassemble a file or class name", javapCommand),
     cmd("line", "<id>|<line>", "place line(s) at the end of history", lineCommand),
-    cmd("load", "<path>", "load and interpret a Scala file", loadCommand),
-    nullary("paste", "enter paste mode: all input up to ctrl-D compiled together", pasteCommand),
+    cmd("load", "<path>", "interpret lines in a file", loadCommand),
+    cmd("paste", "[path]", "enter paste mode or paste a file", pasteCommand),
     nullary("power", "enable power user mode", powerCmd),
     nullary("quit", "exit the interpreter", () => Result(keepRunning = false, None)),
     nullary("replay", "reset execution and replay all previous commands", replay),
@@ -585,11 +585,10 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     }
   }
 
-  def withFile(filename: String)(action: File => Unit) {
-    val f = File(filename)
-
-    if (f.exists) action(f)
-    else echo("That file does not exist")
+  def withFile[A](filename: String)(action: File => A): Option[A] = {
+    val res = Some(File(filename)) filter (_.exists) map action
+    if (res.isEmpty) echo("That file does not exist")  // courtesy side-effect
+    res
   }
 
   def loadCommand(arg: String) = {
@@ -665,13 +664,26 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     Iterator continually in.readLine("") takeWhile (x => x != null && cond(x))
   }
 
-  def pasteCommand(): Result = {
-    echo("// Entering paste mode (ctrl-D to finish)\n")
-    val code = readWhile(_ => true) mkString "\n"
-    if (code.trim.isEmpty) {
-      echo("\n// Nothing pasted, nothing gained.\n")
-    } else {
-      echo("\n// Exiting paste mode, now interpreting.\n")
+  def pasteCommand(arg: String): Result = {
+    var shouldReplay: Option[String] = None
+    val code = (
+      if (arg.nonEmpty) {
+        withFile(arg)(f => {
+          shouldReplay = Some(s":paste $arg")
+          val s = f.slurp.trim
+          if (s.isEmpty) echo(s"File contains no code: $f")
+          else echo(s"Pasting file $f...")
+          s
+        }) getOrElse ""
+      } else {
+        echo("// Entering paste mode (ctrl-D to finish)\n")
+        val text = (readWhile(_ => true) mkString "\n").trim
+        if (text.isEmpty) echo("\n// Nothing pasted, nothing gained.\n")
+        else echo("\n// Exiting paste mode, now interpreting.\n")
+        text
+      }
+    )
+    if (code.nonEmpty) {
       val res = intp interpret code
       // if input is incomplete, let the compiler try to say why
       if (res == IR.Incomplete) {
@@ -681,7 +693,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
         if (errless) echo("...but compilation found no error? Good luck with that.")
       }
     }
-    ()
+    Result(keepRunning = true, shouldReplay)
   }
 
   private object paste extends Pasted {

--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -217,7 +217,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     cmd("javap", "<path|class>", "disassemble a file or class name", javapCommand),
     cmd("line", "<id>|<line>", "place line(s) at the end of history", lineCommand),
     cmd("load", "<path>", "interpret lines in a file", loadCommand),
-    cmd("paste", "[path]", "enter paste mode or paste a file", pasteCommand),
+    cmd("paste", "[-raw] [path]", "enter paste mode or paste a file", pasteCommand),
     nullary("power", "enable power user mode", powerCmd),
     nullary("quit", "exit the interpreter", () => Result(keepRunning = false, None)),
     nullary("replay", "reset execution and replay all previous commands", replay),
@@ -666,24 +666,38 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
 
   def pasteCommand(arg: String): Result = {
     var shouldReplay: Option[String] = None
-    val code = (
-      if (arg.nonEmpty) {
-        withFile(arg)(f => {
+    def result = Result(keepRunning = true, shouldReplay)
+    val (raw, file) =
+      if (arg.isEmpty) (false, None)
+      else {
+        val r = """(-raw)?(\s+)?([^\-]\S*)?""".r
+        arg match {
+          case r(flag, sep, name) =>
+            if (flag != null && name != null && sep == null)
+              echo(s"""I assume you mean "$flag $name"?""")
+            (flag != null, Option(name))
+          case _ =>
+            echo("usage: :paste -raw file")
+            return result
+        }
+      }
+    val code = file match {
+      case Some(name) =>
+        withFile(name)(f => {
           shouldReplay = Some(s":paste $arg")
           val s = f.slurp.trim
           if (s.isEmpty) echo(s"File contains no code: $f")
           else echo(s"Pasting file $f...")
           s
         }) getOrElse ""
-      } else {
+      case None =>
         echo("// Entering paste mode (ctrl-D to finish)\n")
         val text = (readWhile(_ => true) mkString "\n").trim
         if (text.isEmpty) echo("\n// Nothing pasted, nothing gained.\n")
         else echo("\n// Exiting paste mode, now interpreting.\n")
         text
-      }
-    )
-    if (code.nonEmpty) {
+    }
+    def interpretCode() = {
       val res = intp interpret code
       // if input is incomplete, let the compiler try to say why
       if (res == IR.Incomplete) {
@@ -693,7 +707,14 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
         if (errless) echo("...but compilation found no error? Good luck with that.")
       }
     }
-    Result(keepRunning = true, shouldReplay)
+    def compileCode() = {
+      val errless = intp compileSources new BatchSourceFile("<pastie>", code)
+      if (!errless) echo("There were compilation errors!")
+    }
+    if (code.nonEmpty) {
+      if (raw) compileCode() else interpretCode()
+    }
+    result
   }
 
   private object paste extends Pasted {

--- a/test/files/run/repl-paste-4.pastie
+++ b/test/files/run/repl-paste-4.pastie
@@ -1,0 +1,4 @@
+
+// if we are truly companions, I can see your foo
+class Foo { private val foo = 7 }
+object Foo { def apply(f: Foo) = f.foo }

--- a/test/files/run/repl-paste-4.scala
+++ b/test/files/run/repl-paste-4.scala
@@ -1,0 +1,20 @@
+
+import scala.tools.partest.SessionTest
+
+object Test extends SessionTest {
+  def session =
+s"""|Type in expressions to have them evaluated.
+    |Type :help for more information.
+    |
+    |scala> :paste $pastie
+    |Pasting file $pastie...
+    |defined class Foo
+    |defined object Foo
+    |
+    |scala> Foo(new Foo)
+    |res0: Int = 7
+    |
+    |scala> """
+  def pastie = testPath changeExtension "pastie"
+}
+

--- a/test/files/run/repl-paste-raw.pastie
+++ b/test/files/run/repl-paste-raw.pastie
@@ -1,0 +1,8 @@
+
+// a raw paste is not a script
+// hence it can be packaged
+
+package brown_paper
+
+// these are a few of my favorite things
+case class Gift (hasString: Boolean)

--- a/test/files/run/repl-paste-raw.scala
+++ b/test/files/run/repl-paste-raw.scala
@@ -1,0 +1,20 @@
+
+import scala.tools.partest.SessionTest
+
+object Test extends SessionTest {
+  def session =
+s"""|Type in expressions to have them evaluated.
+    |Type :help for more information.
+    |
+    |scala> :paste -raw $pastie
+    |Pasting file $pastie...
+    |
+    |scala> val favoriteThing = brown_paper.Gift(true)
+    |favoriteThing: brown_paper.Gift = Gift(true)
+    |
+    |scala> favoriteThing.hasString
+    |res0: Boolean = true
+    |
+    |scala> """
+  def pastie = testPath changeExtension "pastie"
+}


### PR DESCRIPTION
Re-rebased #2719: Rebased #2696 

The first test repl-paste4 was failing for an unknown reason, with no diff in the build output.

This version makes that test a SessionTest with no check file.  The research question is whether that changes how line endings are handled.

The second test was already a SessionTest but used a private version, but now it can use the class in partest.
