### PR TITLE
fixes SI-7636 NPE in typer

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2010,7 +2010,7 @@ trait Typers extends Modes with Adaptations with Tags {
 
       // !!! This method is redundant with other, less buggy ones.
       def decompose(call: Tree): (Tree, List[Tree]) = call match {
-        case Apply(fn, args) =>
+        case Apply(fn, args) if fn.tpe != null =>
           // an object cannot be allowed to pass a reference to itself to a superconstructor
           // because of initialization issues; SI-473, SI-3913, SI-6928.
           foreachSubTreeBoundTo(args, clazz) { tree =>

--- a/test/files/neg/t7636-neg.check
+++ b/test/files/neg/t7636-neg.check
@@ -1,0 +1,10 @@
+t7636.scala:3: error: illegal inheritance;
+ self-type Main.ResultTable[_$3] does not conform to Main.ResultTable[_$3]'s selftype Main.ResultTable[_$3]
+  new ResultTable(Left(5):Either[_,_])(5){}
+      ^
+t7636.scala:3: error: type mismatch;
+ found   : Either[_$2,_$3(in constructor $anon)] where type _$3(in constructor $anon), type _$2
+ required: Either[_, _$3(in value <local Main>)] where type _$3(in value <local Main>)
+  new ResultTable(Left(5):Either[_,_])(5){}
+                         ^
+two errors found

--- a/test/files/neg/t7636.scala
+++ b/test/files/neg/t7636.scala
@@ -1,0 +1,4 @@
+object Main extends App{
+  class ResultTable[E]( query : Either[_,E] )( columns : Int )
+  new ResultTable(Left(5):Either[_,_])(5){}
+}


### PR DESCRIPTION
Not sure what lead to fn.tpe being null and if avoiding this "case" is the right solution, but it fixes the issue and all tests pass, except files/run/macro-typemacros-fifth-proto which did not pass before the change. 

**files/run/macro-typemacros-fifth-proto-run.log:**

<pre>
Impls_Macros_2.scala:71: error: `=', `&gt;:', or `&lt;:' expected
  type H2Db(url: String) = macro impl
           ^
one error found
</pre>
