### PR TITLE
SI-7669 Fix exhaustivity warnings for recursive ADTs.

### DIFF
--- a/test/files/neg/exhausting.check
+++ b/test/files/neg/exhausting.check
@@ -1,5 +1,5 @@
 exhausting.scala:21: warning: match may not be exhaustive.
-It would fail on the following input: List(_, _, _)
+It would fail on the following inputs: List(_), List(_, _, _)
   def fail1[T](xs: List[T]) = xs match {
                               ^
 exhausting.scala:27: warning: match may not be exhaustive.

--- a/test/files/neg/exhausting.scala
+++ b/test/files/neg/exhausting.scala
@@ -17,7 +17,7 @@ object Test {
     case (_: Foo[_], _: Foo[_]) => ()
   }
 
-  // fails for: ::(_, ::(_, ::(_, _)))
+  // fails for: ::(_, Nil), ::(_, ::(_, ::(_, _))), ...
   def fail1[T](xs: List[T]) = xs match {
     case Nil            => "ok"
     case x :: y :: Nil  => "ok"

--- a/test/files/neg/t7669.check
+++ b/test/files/neg/t7669.check
@@ -1,0 +1,7 @@
+t7669.scala:9: warning: match may not be exhaustive.
+It would fail on the following input: NotHandled(_)
+  def exhausto(expr: Expr): Unit = expr match {
+                                   ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/t7669.flags
+++ b/test/files/neg/t7669.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/t7669.scala
+++ b/test/files/neg/t7669.scala
@@ -1,0 +1,13 @@
+object Test {
+
+  sealed abstract class Expr
+  // Change type of `arg` to `Any` and the exhaustiveness warning
+  // is issued below
+  case class Op(arg: Expr) extends Expr
+  case class NotHandled(num: Double) extends Expr
+
+  def exhausto(expr: Expr): Unit = expr match {
+    case Op(Op(_)) =>
+    case Op(_) =>
+  }
+}

--- a/test/files/run/virtpatmat_casting.scala
+++ b/test/files/run/virtpatmat_casting.scala
@@ -4,5 +4,6 @@ object Test extends App {
 // since the :: extractor's argument must be a ::, there has to be a cast before its unapply is invoked    
     case x :: y :: z :: a :: xs => xs ++ List(x)
     case x :: y :: z :: xs => xs ++ List(x)
+    case _ => List(0)
   })
 }


### PR DESCRIPTION
The pattern matcher's analysis was correctly finding
models under which the match in the enclosed test
could fail. But, when trying to render that model
as a counter example, it ran into an internal inconsistency
and gave up.

That inconsistency arose from VariableAssignment, which:

> turn the variable assignments into a tree
> the root is the scrutinee (x1), edges are labelled
> by the fields that are assigned a node is a variable
> example (which is later turned into a counter example)

In the process, it notes the unreachable case `V2 = NotHandled`,
which can only arise if `V1 = Op`, ie the scrutinee is `Op(NotHandled())`.
V2 is assosicated with the path `x1.arg`. The code then looked for
any variable assosicated with the prefix `x1` and registered that its
field `arg` was assosicated with this variable assignment.

However, the assignment for `V1 = NotHandled` (another missing case)
is also associated with the path `x1`. Registering this field makes
no sense here; we should only do that for `Op`.

This commit conditioanlly registers the fields based on the class
of `VariableAssignment#cls`. We no longer hit the inconsistency in
`VariableAssignment#allFieldAssignmentsLegal`.

This changes the results of an existing test, in what seems to be
a positive way.

Review by @adriaanm
