### PR TITLE
SI-7636 Fix a NPE in typing class constructors

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2010,6 +2010,8 @@ trait Typers extends Modes with Adaptations with Tags {
 
       // !!! This method is redundant with other, less buggy ones.
       def decompose(call: Tree): (Tree, List[Tree]) = call match {
+        case _ if call.isErrorTyped => // e.g. SI-7636
+          (call, Nil)
         case Apply(fn, args) =>
           // an object cannot be allowed to pass a reference to itself to a superconstructor
           // because of initialization issues; SI-473, SI-3913, SI-6928.

--- a/test/files/neg/t7636-neg.check
+++ b/test/files/neg/t7636-neg.check
@@ -1,0 +1,10 @@
+t7636.scala:3: error: illegal inheritance;
+ self-type Main.C does not conform to Main.ResultTable[_$3]'s selftype Main.ResultTable[_$3]
+  class C extends ResultTable(Left(5):Either[_,_])(5)
+                  ^
+t7636.scala:3: error: type mismatch;
+ found   : Either[_$2,_$3(in constructor C)] where type _$3(in constructor C), type _$2
+ required: Either[_, _$3(in object Main)] where type _$3(in object Main)
+  class C extends ResultTable(Left(5):Either[_,_])(5)
+                                     ^
+two errors found

--- a/test/files/neg/t7636.scala
+++ b/test/files/neg/t7636.scala
@@ -1,0 +1,7 @@
+object Main extends App{
+  class ResultTable[E]( query : Either[_,E] )( columns : Int )
+  class C extends ResultTable(Left(5):Either[_,_])(5)
+}
+// Inference of the existential type for the parent type argument
+// E still fails. That looks tricky to fix, see the comments in SI-7636.
+// But we at least prevent a cascading NPE.


### PR DESCRIPTION
If we encountered an erroneous super call due to a
failure in parent type argument inference, we must
avoid inspecting the untyped children of erroneous
trees.

Slight modification of #2731

Review by @cvogt
