### PR TITLE
SI-7668 Better return type inheritance for dep. method types

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1084,6 +1084,9 @@ trait Namers extends MethodSynthesis {
             overriddenTp = overriddenTp.resultType
           }
 
+          // SI-7668 Substitute parameters from the parent method with those of the overriding method.
+          overriddenTp = overriddenTp.substSym(overridden.paramss.flatten, vparamss.flatten.map(_.symbol))
+
           overriddenTp match {
             case NullaryMethodType(rtpe) => overriddenTp = rtpe
             case MethodType(List(), rtpe) => overriddenTp = rtpe

--- a/test/files/pos/t7668.scala
+++ b/test/files/pos/t7668.scala
@@ -1,0 +1,12 @@
+trait Space {
+  type T
+  val x: T
+}
+
+trait Extractor {
+  def extract(s: Space): s.T
+}
+
+class Sub extends Extractor {
+  def extract(s: Space) = s.x
+}


### PR DESCRIPTION
Return type inheritance already handles substitution of
type parameters of the overriding method for those of the
overriding.

This commit extends this to do the same for parameter symbols.

Review by @adriaanm
