### PR TITLE
SI-7650 No bang expansions in REPL jline

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/JLineReader.scala
+++ b/src/repl/scala/tools/nsc/interpreter/JLineReader.scala
@@ -34,6 +34,9 @@ class JLineReader(_completion: => Completion) extends InteractiveReader {
   }
 
   class JLineConsoleReader extends ConsoleReader with ConsoleReaderHelper {
+    // ASAP
+    this setExpandEvents false
+
     // working around protected/trait/java insufficiencies.
     def goBack(num: Int): Unit = back(num)
     if ((history: History) ne NoHistory)


### PR DESCRIPTION
Disable expandEvents at the earliest opportunity.

A SessionTest succeeds trivially, presumably because input is not a tty.
