### PR TITLE
Scrubbing up the IntelliJ Config

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -128,6 +128,7 @@ TODO:
 
   <!-- Sets location of build folders -->
   <property name="build.dir"               value="${basedir}/build"/>
+  <property name="build-deps.dir"          value="${build.dir}/deps"/>
   <property name="build-libs.dir"          value="${build.dir}/libs"/>
   <property name="build-asm.dir"           value="${build.dir}/asm"/>
   <property name="build-forkjoin.dir"      value="${build-libs.dir}"/>
@@ -192,6 +193,18 @@ TODO:
     </touch>
   </target>
 
+  <macrodef name="copy-deps" description="Copy a file set based on maven dependency resolution to a directory. Currently used by the IntelliJ config files.">
+    <attribute name="fileset.prefix"></attribute>
+    <attribute name="out"></attribute>
+    <sequential>
+      <delete dir="${build-deps.dir}/@{out}" includes="*.jar"/>
+      <copy todir="${build-deps.dir}/@{out}">
+        <fileset refid="@{fileset.prefix}.fileset" />
+        <mapper type="flatten" />
+      </copy>
+    </sequential>
+  </macrodef>
+
   <target name="init" depends="boot">
     <!-- Set up Ant contrib tasks so we can use <if><then><else> instead of the clunky `unless` attribute -->
     <taskdef resource="net/sf/antcontrib/antlib.xml" classpath="${lib-ant.dir}/ant-contrib.jar"/>
@@ -218,6 +231,7 @@ TODO:
       <artifact:dependencies pathId="junit.classpath" filesetId="junit.fileset">
         <dependency groupId="junit" artifactId="junit" version="${junit.version}"/>
       </artifact:dependencies>
+      <copy-deps fileset.prefix="junit" out="junit"/>
 
       <!-- Pax runner -->
       <property name="pax.exam.version" value="2.5.0"/>
@@ -238,10 +252,12 @@ TODO:
         <dependency groupId="com.googlecode.java-diff-utils" artifactId="diffutils" version="1.3.0"/>
         <dependency groupId="org.scala-tools.testing" artifactId="test-interface" version="0.5" />
       </artifact:dependencies>
+      <copy-deps fileset.prefix="partest.extras" out="partest"/>
 
       <artifact:dependencies pathId="repl.deps.classpath" filesetId="repl.deps.fileset" versionsId="repl.deps.versions">
         <dependency groupId="jline" artifactId="jline" version="${jline.version}"/>
       </artifact:dependencies>
+      <copy-deps fileset.prefix="repl.deps" out="repl"/>
 
       <!-- BND support -->
       <typedef resource="aQute/bnd/ant/taskdef.properties" classpathref="extra.tasks.classpath" />

--- a/src/intellij/README
+++ b/src/intellij/README
@@ -1,13 +1,8 @@
 Use the latest IntelliJ IDEA release and install the Scala plugin from within the IDE.
 
 The following steps are required to use IntelliJ IDEA on Scala trunk
- - compile "locker" using "ant locker.done"
- - Copy the *.iml.SAMPLE / *.ipr.SAMPLE files to *.iml / *.ipr
- - In IDEA, create a global library named "ant" which contains "ant.jar"
- - Also create an SDK entry named "1.6" containing the java 1.6 SDK
- - In the Scala Facet of the "library" and "reflect" modules, update the path in the
-   command-line argument for "-sourcepath"
- - In the Project Settings, update the "Version Control" to match your checkout
-
-Known problems
- - Due to SI-4365, the "library" module has to be built using "-Yno-generic-signatures"
+ - compile "locker" using "ant locker.done". This will also download some JARs from
+   Maven to ./build/deps, which are included in IntelliJ's classpath.
+ - Run src/intellij/setup.sh
+ - Open ./src/intellij/scala-lang.ipr in IntelliJ
+ - File, Project Settings, Project, SDK. Create an SDK entry named "1.6" containing the java 1.6 SDK

--- a/src/intellij/compiler.iml.SAMPLE
+++ b/src/intellij/compiler.iml.SAMPLE
@@ -19,9 +19,8 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="library" />
     <orderEntry type="module" module-name="reflect" />
-    <orderEntry type="module" module-name="asm" />
-    <orderEntry type="library" name="ant" level="application" />
-    <orderEntry type="library" name="jline" level="project" />
+    <orderEntry type="module" module-name="asm" exported="" />
+    <orderEntry type="library" exported="" name="ant" level="project" />
   </component>
 </module>
 

--- a/src/intellij/diff.sh
+++ b/src/intellij/diff.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#
+# Diffs the SAMPLE files against the working project config.
+#
+export SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+for f in "$SCRIPT_DIR"/*.{iml,ipr}; do
+	echo $f; diff -u $f.SAMPLE $f;
+done

--- a/src/intellij/library.iml.SAMPLE
+++ b/src/intellij/library.iml.SAMPLE
@@ -5,7 +5,7 @@
       <configuration>
         <option name="compilerLibraryLevel" value="Project" />
         <option name="compilerLibraryName" value="compiler-locker" />
-        <option name="compilerOptions" value="-sourcepath /Users/luc/scala/scala/src/library -Yno-generic-signatures" />
+        <option name="compilerOptions" value="-sourcepath $BASE_DIR$/src/library" />
         <option name="maximumHeapSize" value="1536" />
         <option name="vmOptions" value="-Xms1536m -Xss1m -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=256m -XX:+CMSClassUnloadingEnabled -XX:+UseCompressedOops -XX:+UseParallelGC" />
       </configuration>

--- a/src/intellij/manual.iml.SAMPLE
+++ b/src/intellij/manual.iml.SAMPLE
@@ -18,7 +18,8 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="library" />
-    <orderEntry type="library" name="ant" level="application" />
+    <orderEntry type="module" module-name="xml" />
+    <orderEntry type="library" name="ant" level="project" />
   </component>
 </module>
 

--- a/src/intellij/parser-combinators.iml.SAMPLE
+++ b/src/intellij/parser-combinators.iml.SAMPLE
@@ -12,16 +12,11 @@
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
-    <content url="file://$MODULE_DIR$/../scaladoc">
-      <sourceFolder url="file://$MODULE_DIR$/../scaladoc" isTestSource="false" />
+    <content url="file://$MODULE_DIR$/../parser-combinators">
+      <sourceFolder url="file://$MODULE_DIR$/../parser-combinators" isTestSource="false" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="library" />
-    <orderEntry type="module" module-name="reflect" />
-    <orderEntry type="module" module-name="compiler" />
-    <orderEntry type="module" module-name="xml" />
-    <orderEntry type="module" module-name="parser-combinators" />
-    <orderEntry type="module" module-name="partest" />
   </component>
 </module>

--- a/src/intellij/partest.iml.SAMPLE
+++ b/src/intellij/partest.iml.SAMPLE
@@ -18,11 +18,13 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="library" />
+    <orderEntry type="module" module-name="xml" />
     <orderEntry type="module" module-name="reflect" />
     <orderEntry type="module" module-name="actors" />
     <orderEntry type="module" module-name="scalap" />
     <orderEntry type="module" module-name="compiler" />
-    <orderEntry type="library" name="ant" level="application" />
+    <orderEntry type="library" name="partest-deps" level="project" />
+    <orderEntry type="module" module-name="repl" />
   </component>
 </module>
 

--- a/src/intellij/reflect.iml.SAMPLE
+++ b/src/intellij/reflect.iml.SAMPLE
@@ -5,7 +5,7 @@
       <configuration>
         <option name="compilerLibraryLevel" value="Project" />
         <option name="compilerLibraryName" value="compiler-locker" />
-        <option name="compilerOptions" value="-sourcepath /Users/luc/scala/scala/src/reflect" />
+        <option name="compilerOptions" value="-sourcepath $BASE_DIR$/src/reflect" />
         <option name="maximumHeapSize" value="1536" />
         <option name="vmOptions" value="-Xms1536m -Xss1m -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=256m -XX:+CMSClassUnloadingEnabled -XX:+UseCompressedOops -XX:+UseParallelGC" />
       </configuration>

--- a/src/intellij/repl.iml.SAMPLE
+++ b/src/intellij/repl.iml.SAMPLE
@@ -20,6 +20,6 @@
     <orderEntry type="module" module-name="library" />
     <orderEntry type="module" module-name="reflect" />
     <orderEntry type="module" module-name="compiler" />
+    <orderEntry type="library" name="repl-deps" level="project" />
   </component>
 </module>
-

--- a/src/intellij/scala-lang.ipr.SAMPLE
+++ b/src/intellij/scala-lang.ipr.SAMPLE
@@ -33,6 +33,9 @@
   <component name="EntryPointsManager">
     <entry_points version="2.0" />
   </component>
+  <component name="HighlightingAdvisor">
+    <option name="SUGGEST_TYPE_AWARE_HIGHLIGHTING" value="false" />
+  </component>
   <component name="InspectionProjectProfileManager">
     <profiles>
       <profile version="1.0" is_locked="false">
@@ -204,6 +207,7 @@
       <module fileurl="file://$PROJECT_DIR$/interactive.iml" filepath="$PROJECT_DIR$/interactive.iml" />
       <module fileurl="file://$PROJECT_DIR$/library.iml" filepath="$PROJECT_DIR$/library.iml" />
       <module fileurl="file://$PROJECT_DIR$/manual.iml" filepath="$PROJECT_DIR$/manual.iml" />
+      <module fileurl="file://$PROJECT_DIR$/parser-combinators.iml" filepath="$PROJECT_DIR$/parser-combinators.iml" />
       <module fileurl="file://$PROJECT_DIR$/partest.iml" filepath="$PROJECT_DIR$/partest.iml" />
       <module fileurl="file://$PROJECT_DIR$/reflect.iml" filepath="$PROJECT_DIR$/reflect.iml" />
       <module fileurl="file://$PROJECT_DIR$/repl.iml" filepath="$PROJECT_DIR$/repl.iml" />
@@ -212,6 +216,7 @@
       <module fileurl="file://$PROJECT_DIR$/scalap.iml" filepath="$PROJECT_DIR$/scalap.iml" />
       <module fileurl="file://$PROJECT_DIR$/swing.iml" filepath="$PROJECT_DIR$/swing.iml" />
       <module fileurl="file://$PROJECT_DIR$/test.iml" filepath="$PROJECT_DIR$/test.iml" />
+      <module fileurl="file://$PROJECT_DIR$/xml.iml" filepath="$PROJECT_DIR$/xml.iml" />
     </modules>
   </component>
   <component name="ProjectResources">
@@ -228,6 +233,13 @@
     <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
   </component>
   <component name="libraryTable">
+    <library name="ant">
+      <CLASSES>
+        <root url="jar://$PROJECT_DIR$/../../lib/ant/ant.jar!/" />
+      </CLASSES>
+      <JAVADOC />
+      <SOURCES />
+    </library>
     <library name="compiler-locker">
       <CLASSES>
         <root url="file://$PROJECT_DIR$/../../build/locker/classes/library" />
@@ -238,13 +250,35 @@
       <JAVADOC />
       <SOURCES />
     </library>
-    <library name="jline">
+    <library name="junit">
       <CLASSES>
-        <root url="jar://$PROJECT_DIR$/../../lib/jline.jar!/" />
+        <root url="file://$PROJECT_DIR$/../../build/deps/junit" />
       </CLASSES>
       <JAVADOC />
-      <SOURCES />
+      <SOURCES>
+        <root url="file://$PROJECT_DIR$/../../build/deps/junit" />
+      </SOURCES>
+      <jarDirectory url="file://$PROJECT_DIR$/../../build/deps/junit" recursive="false" />
+      <jarDirectory url="file://$PROJECT_DIR$/../../build/deps/junit" recursive="false" type="SOURCES" />
     </library>
+    <library name="partest-deps">
+      <CLASSES>
+        <root url="file://$PROJECT_DIR$/../../build/deps/partest" />
+      </CLASSES>
+      <JAVADOC />
+      <SOURCES>
+        <root url="file://$PROJECT_DIR$/../../build/deps/junit" />
+      </SOURCES>
+      <jarDirectory url="file://$PROJECT_DIR$/../../build/deps/partest" recursive="false" />
+      <jarDirectory url="file://$PROJECT_DIR$/../../build/deps/junit" recursive="false" type="SOURCES" />
+    </library>
+    <library name="repl-deps">
+       <CLASSES>
+        <root url="file://$PROJECT_DIR$/../../build/deps/repl" />
+       </CLASSES>
+       <JAVADOC />
+       <SOURCES />
+      <jarDirectory url="file://$PROJECT_DIR$/../../build/deps/repl" recursive="false" />
+     </library>
   </component>
 </project>
-

--- a/src/intellij/scala.iml.SAMPLE
+++ b/src/intellij/scala.iml.SAMPLE
@@ -2,7 +2,9 @@
 <module type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
-    <content url="file://$MODULE_DIR$/../.." />
+    <content url="file://$MODULE_DIR$/../..">
+      <excludeFolder url="file://$MODULE_DIR$/../../build" />
+    </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>

--- a/src/intellij/setup.sh
+++ b/src/intellij/setup.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Generates IntelliJ IDEA project files based on the checked-in samples.
+#
+
+set -e
+export SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+export BASE="$( cd "$( dirname "$0" )"/../.. && pwd )"
+echo "About to delete .ipr and .iml files and replace with the .SAMPLE files. Press enter to continue or CTRL-C to cancel."
+read
+
+(rm *.ipr *.iml 2>/dev/null)
+for f in $(ls "$SCRIPT_DIR"/*.SAMPLE); do
+	NEW_FILE=`echo $f | perl -pe 's/.SAMPLE//'`;
+
+	cp $f $NEW_FILE
+
+	# IntelliJ doesn't process the "compilerOptions" setting for variable
+	# replacement. If it did, we would just use "$PROJECT_DIR$". Instead,
+	# we do this replacement ourselves.
+	perl -pi -e 's/\$BASE_DIR\$/$ENV{"BASE"}/g' $NEW_FILE
+	echo "Created $NEW_FILE"
+done

--- a/src/intellij/test.iml.SAMPLE
+++ b/src/intellij/test.iml.SAMPLE
@@ -6,6 +6,8 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="library" />
+    <orderEntry type="module" module-name="xml" />
+    <orderEntry type="module" module-name="parser-combinators" />
     <orderEntry type="module" module-name="reflect" />
     <orderEntry type="module" module-name="compiler" />
     <orderEntry type="module" module-name="actors" />
@@ -13,6 +15,7 @@
     <orderEntry type="module" module-name="partest" />
     <orderEntry type="module" module-name="asm" />
     <orderEntry type="module" module-name="forkjoin" />
+    <orderEntry type="library" name="junit" level="project" />
   </component>
 </module>
 

--- a/src/intellij/xml.iml.SAMPLE
+++ b/src/intellij/xml.iml.SAMPLE
@@ -12,16 +12,11 @@
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
-    <content url="file://$MODULE_DIR$/../scaladoc">
-      <sourceFolder url="file://$MODULE_DIR$/../scaladoc" isTestSource="false" />
+    <content url="file://$MODULE_DIR$/../xml">
+      <sourceFolder url="file://$MODULE_DIR$/../xml" isTestSource="false" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="library" />
-    <orderEntry type="module" module-name="reflect" />
-    <orderEntry type="module" module-name="compiler" />
-    <orderEntry type="module" module-name="xml" />
-    <orderEntry type="module" module-name="parser-combinators" />
-    <orderEntry type="module" module-name="partest" />
   </component>
 </module>


### PR DESCRIPTION
- Add recently sprouted modules (xml and parser-combinators)
  - Replace some of the documentation with a setup script
  - Update Ant build to copy Maven sourced JARs to ./build/deps.
    These are included in the IntelliJ classpath.
  - Define the library for Ant at the project level based on
    ./lib, rather than asking the user to define global library.
  - Disable Type Aware Highlighting by default.

IntelliJ now can build everything within the IDE with CTRL-F9.
