### PR TITLE
SI-7655 Enforce stable id patterns conform to scrutinee type

### DIFF
--- a/src/actors/scala/actors/Future.scala
+++ b/src/actors/scala/actors/Future.scala
@@ -153,8 +153,8 @@ object Futures {
     val FutCh1 = ft1.inputChannel
     val FutCh2 = ft2.inputChannel
     Actor.receive {
-      case FutCh1 ! arg1 => arg1.asInstanceOf[B]
-      case FutCh2 ! arg2 => arg2.asInstanceOf[B]
+      case futCh1 ! arg1 if futCh1 == FutCh1 => arg1.asInstanceOf[B]
+      case futCh2 ! arg2 if futCh2 == FutCh2 => arg2.asInstanceOf[B]
     }
   }
 
@@ -188,9 +188,9 @@ object Futures {
     })
 
     val partFuns = unsetFts.map((p: Pair[Int, Future[Any]]) => {
-      val FutCh = p._2.inputChannel
+      val FutCh = p._2.inputChannel.asInstanceOf[Channel[Any]]
       val singleCase: PartialFunction[Any, Pair[Int, Any]] = {
-        case FutCh ! any => Pair(p._1, any)
+        case futCh ! any if futCh == FutCh => Pair(p._1, any)
       }
       singleCase
     })

--- a/src/actors/scala/actors/ReactChannel.scala
+++ b/src/actors/scala/actors/ReactChannel.scala
@@ -73,7 +73,7 @@ private[actors] class ReactChannel[Msg](receiver: InternalReplyReactor) extends 
     val C = this
     val recvActor = receiver.asInstanceOf[Actor]
     recvActor.reactWithin(msec) {
-      case C ! msg if (f.isDefinedAt(msg.asInstanceOf[Msg])) =>
+      case c ! msg if c == C && (f.isDefinedAt(msg.asInstanceOf[Msg])) =>
         f(msg.asInstanceOf[Msg])
       case TIMEOUT => f(TIMEOUT)
     }
@@ -89,7 +89,7 @@ private[actors] class ReactChannel[Msg](receiver: InternalReplyReactor) extends 
     val C = this
     val recvActor = receiver.asInstanceOf[Actor]
     recvActor.receive {
-      case C ! msg if (f.isDefinedAt(msg.asInstanceOf[Msg])) =>
+      case c ! msg if c == C && (f.isDefinedAt(msg.asInstanceOf[Msg])) =>
         f(msg.asInstanceOf[Msg])
     }
   }
@@ -105,7 +105,7 @@ private[actors] class ReactChannel[Msg](receiver: InternalReplyReactor) extends 
     val C = this
     val recvActor = receiver.asInstanceOf[Actor]
     recvActor.receiveWithin(msec) {
-      case C ! msg if (f.isDefinedAt(msg.asInstanceOf[Msg])) =>
+      case c ! msg if c == C && (f.isDefinedAt(msg.asInstanceOf[Msg])) =>
         f(msg.asInstanceOf[Msg])
       case TIMEOUT => f(TIMEOUT)
     }

--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -304,7 +304,7 @@ abstract class CleanUp extends Transform with ast.TreeDSL {
 
             /* A native Array call. */
             def genArrayCall = fixResult(
-              methSym.name match {
+              (methSym.name: Name) match {
                 case nme.length => REF(boxMethod(IntClass)) APPLY (REF(arrayLengthMethod) APPLY args)
                 case nme.update => REF(arrayUpdateMethod) APPLY List(args(0), (REF(unboxMethod(IntClass)) APPLY args(1)), args(2))
                 case nme.apply  => REF(arrayApplyMethod) APPLY List(args(0), (REF(unboxMethod(IntClass)) APPLY args(1)))

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -475,7 +475,7 @@ abstract class UnCurry extends InfoTransform
               super.transform(tree)
           case UnApply(fn, args) =>
             val fn1 = withInPattern(value = false)(transform(fn))
-            val args1 = transformTrees(fn.symbol.name match {
+            val args1 = transformTrees((fn.symbol.name: Name) match {
               case nme.unapply    => args
               case nme.unapplySeq => transformArgs(tree.pos, fn.symbol, args, analyzer.unapplyTypeList(fn.pos, fn.symbol, fn.tpe, args))
               case _              => sys.error("internal error: UnApply node has wrong symbol")

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1298,8 +1298,8 @@ trait Infer extends Checkable {
       else intersect(pt, pattp)
     }
 
-    def inferModulePattern(pat: Tree, pt: Type) =
-      if (!(pat.tpe <:< pt)) {
+    def inferStableIdPattern(pat: Tree, pt: Type) =
+      if (!(pat.tpe weak_<:< pt)) {
         val ptparams = freeTypeParamsOfTerms(pt)
         debuglog("free type params (2) = " + ptparams)
         val ptvars = ptparams map freshVar

--- a/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
@@ -528,7 +528,7 @@ trait NamesDefaults { self: Analyzer =>
     var positionalAllowed = true
     val namelessArgs = mapWithIndex(args) { (arg, argIndex) =>
       arg match {
-        case arg @ AssignOrNamedArg(Ident(name), rhs) =>
+        case arg @ AssignOrNamedArg(Ident(name: TermName), rhs) =>
           def matchesName(param: Symbol) = !param.isSynthetic && (
             (param.name == name) || (param.deprecatedParamName match {
               case Some(`name`) =>

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -545,7 +545,7 @@ trait Typers extends Adaptations with Tags {
           // TODO SI-6609 Eliminate this special case once the old pattern matcher is removed.
           def dealias(sym: Symbol) =
             (atPos(tree.pos.makeTransparent) {gen.mkAttributedRef(sym)} setPos tree.pos, sym.owner.thisType)
-          sym.name match {
+          (sym.name: Name) match {
             case nme.List => return dealias(ListModule)
             case nme.Seq  => return dealias(SeqModule)
             case nme.Nil  => return dealias(NilModule)
@@ -1131,8 +1131,11 @@ trait Typers extends Adaptations with Tags {
 
       def fallbackAfterVanillaAdapt(): Tree = {
         def isPopulatedPattern = {
-          if ((tree.symbol ne null) && tree.symbol.isModule)
-            inferModulePattern(tree, pt)
+          if (treeInfo.isStableIdentifier(tree, allowVolatile = true))
+            // 8.1.5 A stable identifier pattern is a stable identifier r (§3.1).
+            // The type of r must conform to the expected type of the pattern.
+            // The pattern matches any value v such that r == v (§12.1).
+            inferStableIdPattern(tree, pt)
 
           isPopulated(tree.tpe, approximateAbstracts(pt))
         }

--- a/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
@@ -37,7 +37,7 @@ trait Unapplies extends ast.TreeDSL
     assert(ufn.isMethod, ufn)
     val nbSubPats = args.length
     //Console.println("utl "+ufntpe+" "+ufntpe.typeSymbol)
-    ufn.name match {
+    (ufn.name: Name) match {
       case nme.unapply | nme.unapplySeq =>
         val (formals, _) = extractorFormalTypes(pos, unapplyUnwrap(ufntpe), nbSubPats, ufn, treeInfo.effectivePatternArity(args))
         if (formals == null) throw new TypeError(s"$ufn of type $ufntpe cannot extract $nbSubPats sub-patterns")

--- a/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
+++ b/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
@@ -439,7 +439,7 @@ abstract class UnPickler {
     /** Read an annotation argument, which is pickled either
      *  as a Constant or a Tree.
      */
-    protected def readAnnotArg(i: Int): Tree = bytes(index(i)) match {
+    protected def readAnnotArg(i: Int): Tree = (bytes(index(i)): Int) match {
       case TREE => at(i, readTree)
       case _    =>
         val const = at(i, readConstant)
@@ -453,7 +453,7 @@ abstract class UnPickler {
       val end = readEnd()
       until(end, () => readClassfileAnnotArg(readNat())).toArray(JavaArgumentTag)
     }
-    protected def readClassfileAnnotArg(i: Int): ClassfileAnnotArg = bytes(index(i)) match {
+    protected def readClassfileAnnotArg(i: Int): ClassfileAnnotArg = (bytes(index(i)): Int) match {
       case ANNOTINFO     => NestedAnnotArg(at(i, readAnnotation))
       case ANNOTARGARRAY => at(i, () => ArrayAnnotArg(readArrayAnnot()))
       case _             => LiteralAnnotArg(at(i, readConstant))

--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -418,7 +418,7 @@ private[reflect] trait JavaMirrors extends internal.SymbolTable with api.JavaUni
           jinvoke(jmeths.head, null, objReceiver +: objArgs)
         }
 
-        symbol match {
+         (symbol: TermSymbol) match {
           case Any_== | Object_==                     => ScalaRunTime.inlinedEquals(objReceiver, objArg0)
           case Any_!= | Object_!=                     => !ScalaRunTime.inlinedEquals(objReceiver, objArg0)
           case Any_## | Object_##                     => ScalaRunTime.hash(objReceiver)
@@ -428,7 +428,7 @@ private[reflect] trait JavaMirrors extends internal.SymbolTable with api.JavaUni
           case Object_eq                              => objReceiver eq objArg0
           case Object_ne                              => objReceiver ne objArg0
           case Object_synchronized                    => objReceiver.synchronized(objArg0)
-          case sym if isGetClass(sym)                 => preciseClass(receiver)
+          case _ if isGetClass(symbol)                => preciseClass(receiver)
           case Any_asInstanceOf                       => fail("Any.asInstanceOf requires a type argument")
           case Any_isInstanceOf                       => fail("Any.isInstanceOf requires a type argument")
           case Object_asInstanceOf                    => fail("AnyRef.$asInstanceOf is an internal method")
@@ -437,7 +437,7 @@ private[reflect] trait JavaMirrors extends internal.SymbolTable with api.JavaUni
           case Array_apply                            => ScalaRunTime.array_apply(objReceiver, args(0).asInstanceOf[Int])
           case Array_update                           => ScalaRunTime.array_update(objReceiver, args(0).asInstanceOf[Int], args(1))
           case Array_clone                            => ScalaRunTime.array_clone(objReceiver)
-          case sym if isStringConcat(sym)             => receiver.toString + objArg0
+          case _ if isStringConcat(symbol)            => receiver.toString + objArg0
           case sym if sym.owner.isPrimitiveValueClass => invokePrimitiveMethod
           case sym if sym == Predef_classOf           => fail("Predef.classOf is a compile-time function")
           case sym if sym.isMacro                     => fail(s"${symbol.fullName} is a macro, i.e. a compile-time function")

--- a/src/scalap/scala/tools/scalap/Classfile.scala
+++ b/src/scalap/scala/tools/scalap/Classfile.scala
@@ -91,7 +91,7 @@ class Classfile(in: ByteArrayReader) {
           i = i + 1
           pool(i) = Empty
         }
-        else pool(i) = tag match {
+        else pool(i) = (tag: Int) match {
           case CONSTANT_UTF8            => UTF8(in.nextUTF8(in.nextChar.toInt))
           case CONSTANT_UNICODE         => in.skip(in.nextChar) ; Empty
           case CONSTANT_CLASS           => ClassRef(in.nextChar)

--- a/test/files/neg/t7655.check
+++ b/test/files/neg/t7655.check
@@ -1,0 +1,13 @@
+t7655.scala:9: error: pattern type is incompatible with expected type;
+ found   : Test.Other.type
+ required: Test.Foo
+Note: if you intended to match against the class, try `case _: <none>`
+    case Other => true // warns
+         ^
+t7655.scala:14: error: pattern type is incompatible with expected type;
+ found   : Test.Other.type
+ required: Test.Foo
+Note: if you intended to match against the class, try `case _: <none>`
+    case OtherAlias => true // no warning.
+         ^
+two errors found

--- a/test/files/neg/t7655.flags
+++ b/test/files/neg/t7655.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/t7655.scala
+++ b/test/files/neg/t7655.scala
@@ -1,0 +1,17 @@
+object Test {
+  sealed trait Foo
+  object Bar extends Foo
+
+  object Other
+  val OtherAlias = Other
+
+  def f(x: Foo) = x match {
+    case Other => true // warns
+    case _     => false
+  }
+
+  def g(x: Foo) = x match {
+    case OtherAlias => true // no warning.
+    case _          => false
+  }
+}


### PR DESCRIPTION
This was only being done if the stable id pattern was a direct
reference to a module.

This commit distinguishes stable ID patterns with the recently
added facility in TreeInfo. (Actually, this might be overkill
in adapt and we could probably get away with just checking for
`_: Ident | _: Select`.)

Review by @adriaanm.

Opinions on the particular way to check for the stable ID pattern are welcome.
