### PR TITLE
STARR: use 2.11.0-M4, built with 2.11.0-M3

### DIFF
--- a/lib/scala-compiler-src.jar.desired.sha1
+++ b/lib/scala-compiler-src.jar.desired.sha1
@@ -1,1 +1,1 @@
-19d04510ac6f25d088da82527d8435b68c00153d ?scala-compiler-src.jar
+d62bc132cba37b17c8d5ac65feb20193a3f8cc28 ?scala-compiler-src.jar

--- a/lib/scala-compiler.jar.desired.sha1
+++ b/lib/scala-compiler.jar.desired.sha1
@@ -1,1 +1,1 @@
-3585351c6a62186097be55fff88bee88a985f5c0 ?scala-compiler.jar
+d049885894b93e12f034d4d871c38bfc4d026525 ?scala-compiler.jar

--- a/lib/scala-library-src.jar.desired.sha1
+++ b/lib/scala-library-src.jar.desired.sha1
@@ -1,1 +1,1 @@
-e606934dc00ced6bfac715bbdba427f9c2c18bc7 ?scala-library-src.jar
+58db8f554695791217de332aa6500a7aa240e480 ?scala-library-src.jar

--- a/lib/scala-library.jar.desired.sha1
+++ b/lib/scala-library.jar.desired.sha1
@@ -1,1 +1,1 @@
-36456c52b0395fc1e6e367291e45bd503fa019c5 ?scala-library.jar
+12007d1b1b913b563093b22e947e6c05fe40f3de ?scala-library.jar

--- a/lib/scala-reflect-src.jar.desired.sha1
+++ b/lib/scala-reflect-src.jar.desired.sha1
@@ -1,1 +1,1 @@
-51787a41cae5b0ec6910c5a1a6af392e17550856 ?scala-reflect-src.jar
+c842d370d814515f15159cefa4b9c495d99bb1a9 ?scala-reflect-src.jar

--- a/lib/scala-reflect.jar.desired.sha1
+++ b/lib/scala-reflect.jar.desired.sha1
@@ -1,1 +1,1 @@
-d4a4c0aab882412461fbd9d39cf47da5a619855e ?scala-reflect.jar
+a6595b3d7589085f683d4ad5a6072a057ab15ef9 ?scala-reflect.jar

--- a/starr.number
+++ b/starr.number
@@ -1,1 +1,1 @@
-starr.version=2.11.0-M2
+starr.version=2.11.0-M4


### PR DESCRIPTION
Replaced starr jars with 2.11.0-M4, built with Scala 2.11.0-M3.

I used `ant replacestarr-opt -Dstarr.use.released=1`, with `starr.number`:

```
starr.version=2.11.0-M3
```

Then pushed the jars to artifactory after moving `lib/jline.jar` out of the way,
as it's no longer "desired" (i.e., not pulled from artifactory). Its presence
seemed to break `./push-binary-libs.sh $ARTIFACTORY_USER $ARTIFACTORY_PASS`.

You can by-pass the custom starr artifact download and use a (released) version
of Scala by changing your `build.properties` to include

```
starr.use.released=1
```

You may optionally change `starr.version` in `starr.number` to whichever version
that maven can resolve for you.

review by @retronym
