### PR TITLE
SI-7592 Deprecate s.c.m.DefaultMapModel

### DIFF
--- a/src/library/scala/collection/mutable/DefaultMapModel.scala
+++ b/src/library/scala/collection/mutable/DefaultMapModel.scala
@@ -19,6 +19,7 @@ package mutable
  *  @version 1.0, 08/07/2003
  *  @since   1
  */
+@deprecated("This trait will be removed.", "2.11.0")
 trait DefaultMapModel[A, B] extends Map[A, B] {
 
   type Entry = DefaultEntry[A, B]


### PR DESCRIPTION
“This class is used internally.” — No, it isn't.
It isn't used anywhere else either and it doesn't add much benefit,
considering that it lacks documentation and has no tests at all.
