### PR TITLE
SI-7687 Handle spaces in %COMSPEC% path in scala.bat.

### DIFF
--- a/src/compiler/scala/tools/ant/templates/tool-windows.tmpl
+++ b/src/compiler/scala/tools/ant/templates/tool-windows.tmpl
@@ -89,4 +89,4 @@ goto :eof
 @@endlocal
 
 REM exit code fix, see http://stackoverflow.com/questions/4632891/exiting-batch-with-exit-b-x-where-x-1-acts-as-if-command-completed-successfu
-@@%COMSPEC% /C exit %errorlevel% >nul
+@@"%COMSPEC%" /C exit %errorlevel% >nul


### PR DESCRIPTION
Double quoted %COMSPEC% to allow for spaces in the path to the
default interpreter (cmd.exe or equivalent).

---

I manually tested before/after on Windows 7.
I also signed the CLA some time ago (this is my first contribution).

Review by... @retronym? (The pull request policy doesn't list anyone for that kind of things, so I don't know... :) )
