### PR TITLE
SI-7689 Fix typing regression with default arguments

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -35,7 +35,8 @@ trait Namers extends MethodSynthesis {
     }
     def apply(tree: Tree) = {
       val r = transform(tree)
-      if (r.exists(_.isEmpty)) TypeTree()
+      if (r exists { case tt: TypeTree => tt.isEmpty case _ => false })
+        TypeTree()
       else r
     }
   }

--- a/test/files/pos/t7689.scala
+++ b/test/files/pos/t7689.scala
@@ -1,0 +1,7 @@
+object A {
+  // The default getter must have an explicit return type (List[_] => Int)
+  // This wasn't happening since e28c3edda4. That commit encoded upper/lower
+  // bounds of Any/Nothing as EmptyTree, which were triggering an .isEmpty
+  // check in Namers#TypeTreeSubstitutor
+  def x(f: List[_] => Int = _ => 3) = 9
+}


### PR DESCRIPTION
Regressed in e28c3edda4. That commit encoded upper/lower bounds
of Any/Nothing as EmptyTree, which were triggering the .isEmpty
check in Namers#TypeTreeSubstitutor and resulting in the default
getter having TypeTree() as the return type. This resulted in a
"missing parmameter type" error.

This commit tightens up that condition to only consider empty
TypeTrees (those wrapping null or NoType.)

Review by @paulp
