### PR TITLE
Move to java.util.concurrent.locks.Lock (Was: Add concurrent.Lock#doWith)

### DIFF
--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -352,6 +352,8 @@ object Predef extends LowPriorityImplicits with DeprecatedPredef {
   implicit def Double2double(x: java.lang.Double): Double     = x.doubleValue
   implicit def Boolean2boolean(x: java.lang.Boolean): Boolean = x.booleanValue
 
+  implicit def Lock2RichLock(x: java.util.concurrent.locks.Lock) = new runtime.RichLock(x)
+
   // Type Constraints --------------------------------------------------------------
 
   /**

--- a/src/library/scala/concurrent/Lock.scala
+++ b/src/library/scala/concurrent/Lock.scala
@@ -14,6 +14,7 @@ package scala.concurrent
  *
  *  @author  Martin Odersky
  *  @version 1.0, 10/03/2003
+ *  @deprecated("Use java.util.concurrent.locks.Lock", "2.11")
  */
 class Lock {
   var available = true
@@ -27,19 +28,4 @@ class Lock {
     available = true
     notify()
   }
-
-  /**
-    *  Run `body` after acquiring this lock, and then releasing it after
-    *
-    * @author Luke Cycon <luke@lukecycon.com>
-    */
-  def doWith[T](body: => T): T = {
-    acquire()
-    try {
-      body
-    } finally {
-      release()
-    }
-  }
-
 }

--- a/src/library/scala/concurrent/Lock.scala
+++ b/src/library/scala/concurrent/Lock.scala
@@ -27,4 +27,19 @@ class Lock {
     available = true
     notify()
   }
+
+  /**
+    *  Run `body` after acquiring this lock, and then releasing it after
+    *
+    * @author Luke Cycon <luke@lukecycon.com>
+    */
+  def doWith[T](body: => T): T = {
+    acquire()
+    try {
+      body
+    } finally {
+      release()
+    }
+  }
+
 }

--- a/src/library/scala/runtime/RichLock.scala
+++ b/src/library/scala/runtime/RichLock.scala
@@ -1,0 +1,31 @@
+/*                     __                                               *\
+ * *     ________ ___   / /  ___     Scala API                            **
+ * *    / __/ __// _ | / /  / _ |    (c) 2006-2013, LAMP/EPFL             **
+ * *  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+ * * /____/\___/_/ |_/____/_/ | |                                         **
+ * *                          |/                                          **
+\*                                                                      */
+
+package scala
+package runtime
+
+import java.util.concurrent.locks.Lock
+
+/**
+  * @author Luke Cycon <luke@lukecycon.com>
+  */
+final class RichLock(val self: Lock) extends AnyRef {
+
+  /**
+    *   Run `body` after acquiring this lock, and then releasing it after
+    */
+  def doWith[T](body: => T): T = {
+    self.lock()
+    try {
+      body
+    } finally {
+      self.unlock()
+    }
+  }
+
+}


### PR DESCRIPTION
A method I have used on a few occasions to eliminate the boilerplate acquire/release when executing simple statements in a locked environment.

Review by @phaller please!
