### PR TITLE
SI-7694 @uncheckedBounds, an opt-out from type bounds checking

### DIFF
--- a/bincompat-backward.whitelist.conf
+++ b/bincompat-backward.whitelist.conf
@@ -239,6 +239,10 @@ filter {
         {
             matchName="scala.reflect.internal.StdAttachments.isMacroExpansionSuppressed"
             problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.Types.uncheckedBounds"
+            problemName=MissingMethodProblem
         }
     ]
 }

--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -515,6 +515,22 @@ filter {
         {
             matchName="scala.reflect.runtime.JavaMirrors#JavaMirror#FromJavaClassCompleter.scala$reflect$runtime$JavaMirrors$JavaMirror$FromJavaClassCompleter$$enterEmptyCtorIfNecessary$1"
             problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.SymbolTable.uncheckedBounds"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.Types.uncheckedBounds"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.Definitions#DefinitionsClass.UncheckedBoundsClass"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.annotations.uncheckedBounds"
+            problemName=MissingClassProblem
         }
     ]
 }

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1513,17 +1513,35 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
         false
     }
 
-    private def checkTypeRef(tp: Type, tree: Tree) = tp match {
+    private def checkTypeRef(tp: Type, tree: Tree, skipBounds: Boolean) = tp match {
       case TypeRef(pre, sym, args) =>
         checkDeprecated(sym, tree.pos)
         if(sym.isJavaDefined)
           sym.typeParams foreach (_.cookJavaRawInfo())
-        if (!tp.isHigherKinded)
+        if (!tp.isHigherKinded && !skipBounds)
           checkBounds(tree, pre, sym.owner, sym.typeParams, args)
       case _ =>
     }
 
-    private def checkAnnotations(tpes: List[Type], tree: Tree) = tpes foreach (tp => checkTypeRef(tp, tree))
+    private def checkTypeRefBounds(tp: Type, tree: Tree) = {
+      var skipBounds = false
+      tp match {
+        case AnnotatedType(ann :: Nil, underlying, selfSym) if ann.symbol == UncheckedBoundsClass =>
+          skipBounds = true
+          underlying
+        case TypeRef(pre, sym, args) =>
+          if (!tp.isHigherKinded && !skipBounds)
+            checkBounds(tree, pre, sym.owner, sym.typeParams, args)
+          tp
+        case _ =>
+          tp
+      }
+    }
+
+    private def checkAnnotations(tpes: List[Type], tree: Tree) = tpes foreach { tp =>
+      checkTypeRef(tp, tree, skipBounds = false)
+      checkTypeRefBounds(tp, tree)
+    }
     private def doTypeTraversal(tree: Tree)(f: Type => Unit) = if (!inPattern) tree.tpe foreach f
 
     private def applyRefchecksToAnnotations(tree: Tree): Unit = {
@@ -1551,8 +1569,9 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
           }
 
           doTypeTraversal(tree) {
-            case AnnotatedType(annots, _, _)  => applyChecks(annots)
-            case _ =>
+            case tp @ AnnotatedType(annots, _, _)  =>
+              applyChecks(annots)
+            case tp =>
           }
         case _ =>
       }
@@ -1735,13 +1754,27 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
             }
 
             val existentialParams = new ListBuffer[Symbol]
-            doTypeTraversal(tree) { // check all bounds, except those that are existential type parameters
-              case ExistentialType(tparams, tpe) =>
+            var skipBounds = false
+            // check all bounds, except those that are existential type parameters
+            // or those within typed annotated with @uncheckedBounds
+            doTypeTraversal(tree) {
+              case tp @ ExistentialType(tparams, tpe) =>
                 existentialParams ++= tparams
-              case t: TypeRef =>
-                checkTypeRef(deriveTypeWithWildcards(existentialParams.toList)(t), tree)
+              case ann: AnnotatedType if ann.hasAnnotation(UncheckedBoundsClass) =>
+                // SI-7694 Allow code synthetizers to disable checking of bounds for TypeTrees based on inferred LUBs
+                // which might not conform to the constraints.
+                skipBounds = true
+              case tp: TypeRef =>
+                val tpWithWildcards = deriveTypeWithWildcards(existentialParams.toList)(tp)
+                checkTypeRef(tpWithWildcards, tree, skipBounds)
               case _ =>
             }
+            if (skipBounds) {
+              tree.tpe = tree.tpe.map {
+                _.filterAnnotations(_.symbol != UncheckedBoundsClass)
+              }
+            }
+
             tree
 
           case TypeApply(fn, args) =>

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -983,6 +983,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val ThrowsClass                = requiredClass[scala.throws[_]]
     lazy val TransientAttr              = requiredClass[scala.transient]
     lazy val UncheckedClass             = requiredClass[scala.unchecked]
+    lazy val UncheckedBoundsClass       = getClassIfDefined("scala.reflect.internal.annotations.uncheckedBounds")
     lazy val UnspecializedClass         = requiredClass[scala.annotation.unspecialized]
     lazy val VolatileAttr               = requiredClass[scala.volatile]
 

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -7314,6 +7314,12 @@ trait Types extends api.Types { self: SymbolTable =>
     else (ps :+ SerializableClass.tpe).toList
   )
 
+  /** Adds the @uncheckedBound annotation if the given `tp` has type arguments */
+  final def uncheckedBounds(tp: Type): Type = {
+    if (tp.typeArgs.isEmpty || UncheckedBoundsClass == NoSymbol) tp // second condition for backwards compatibilty with older scala-reflect.jar
+    else tp.withAnnotation(AnnotationInfo marker UncheckedBoundsClass.tpe)
+  }
+
   /** Members of the given class, other than those inherited
    *  from Any or AnyRef.
    */

--- a/src/reflect/scala/reflect/internal/annotations/uncheckedBounds.scala
+++ b/src/reflect/scala/reflect/internal/annotations/uncheckedBounds.scala
@@ -1,0 +1,13 @@
+package scala.reflect
+package internal
+package annotations
+
+/**
+ * An annotation that designates the annotated type should not be checked for violations of
+ * type parameter bounds in the `refchecks` phase of the compiler. This can be used by synthesized
+ * code the uses an inferred type of an expression as the type of an artifict val/def (for example,
+ * a temporary value introduced by an ANF transform). See [[https://issues.scala-lang.org/browse/SI-7694]].
+ *
+ * @since  2.10.3
+ */
+final class uncheckedBounds extends scala.annotation.StaticAnnotation

--- a/test/files/neg/t7694b.check
+++ b/test/files/neg/t7694b.check
@@ -1,0 +1,7 @@
+t7694b.scala:8: error: type arguments [_3,_4] do not conform to trait L's type parameter bounds [A2,B2 <: A2]
+  def d = if (true) (null: L[A, A]) else (null: L[B, B])
+      ^
+t7694b.scala:9: error: type arguments [_1,_2] do not conform to trait L's type parameter bounds [A2,B2 <: A2]
+  val v = if (true) (null: L[A, A]) else (null: L[B, B])
+      ^
+two errors found

--- a/test/files/pos/t7694.scala
+++ b/test/files/pos/t7694.scala
@@ -1,0 +1,40 @@
+trait A
+trait B
+
+trait L[A2, B2 <: A2] {
+  def bar(a: Any, b: Any) = 0
+}
+
+object Lub {
+  // use named args transforms to include TypeTree(<lub.tpe>) in the AST before refchecks.
+  def foo(a: L[_, _], b: Any) = 0
+
+  foo(b = 0, a = if (true) (null: L[A, A]) else (null: L[B, B]))
+
+  (if (true) (null: L[A, A]) else (null: L[B, B])).bar(b = 0, a = 0)
+}
+
+/*
+The LUB ends up as:
+
+TypeRef(
+  TypeSymbol(
+    abstract trait L#7038[A2#7039, B2#7040 <: A2#7039] extends AnyRef#2197
+
+  )
+  args = List(
+    AbstractTypeRef(
+      AbstractType(
+        type _1#13680 >: A#7036 with B#7037 <: Object#1752
+      )
+    )
+    AbstractTypeRef(
+      AbstractType(
+        type _2#13681 >: A#7036 with B#7037 <: Object#1752
+      )
+    )
+  )
+)
+
+Note that type _2#13681 is *not* bound by _1#13680
+*/


### PR DESCRIPTION
Synthetic defs introduced by transforms like named/default arguments,
ANF (in scala-async) often introduce a type tree (the tpt of the temporary)
that are based on the types of expressions. These types are scrutinized in
RefChecks to check that type parameter bounds are satisfied.

However, the type of the expression might be based on slack a LUB that
fails to capture constraints between type parameters.

This slackness is noted in `mergePrefixAndArgs`:

```
// Martin: I removed this, because incomplete. Not sure there is a
// good way to fix it. For the moment we just err on the conservative
// side, i.e. with a bound that is too high.
```

The synthesizer can now opt out of bounds by annotating the type as follows:

   val temp: (<expr.tpe> @uncheckedBounds) = expr

This facility is now used in named/default arguments for the temporaries
used for the reciever and arguments.

The annotation is hidden under scala.reflect.internal, rather than in
the more prominent scala.annotation.unchecked, to reflect the intention
that it should only be used in tree transformers.

Targetting 2.10.3 as this fix is needed by a customer.

**UPDATE** 

It occurred to me that we should be robust against running the 2.10.3 compiler with the 2.10.2 library, so I've split this PR into two commits. More details in their comments.
