### PR TITLE
Refactor the cake so SymbolTable does not depend on Global

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -364,7 +364,7 @@ TODO:
     </then></if>
 
     <!-- Allow this to be overridden simply -->
-    <property name="sbt.latest.version"    value="0.12.2"/>
+    <property name="sbt.latest.version"    value="0.12.4"/>
 
     <property name="sbt.src.dir"           value="${build-sbt.dir}/${sbt.latest.version}/src"/>
     <property name="sbt.lib.dir"           value="${build-sbt.dir}/${sbt.latest.version}/lib"/>

--- a/build.xml
+++ b/build.xml
@@ -1538,7 +1538,7 @@ TODO:
   <target name="test.junit" depends="test.junit.comp">
     <stopwatch name="test.junit.timer"/>
     <mkdir dir="${test.junit.classes}"/>
-    <junit fork="yes" haltonfailure="yes" showoutput="yes" printsummary="on">
+    <junit fork="yes" haltonfailure="yes" printsummary="on">
       <classpath refid="test.junit.compiler.build.path"/>
       <batchtest fork="yes" todir="${build-junit.dir}">
         <fileset dir="${test.junit.classes}">

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -356,6 +356,15 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
 
   lazy val loaders = new SymbolLoaders {
     val global: Global.this.type = Global.this
+    def lookupMemberAtTyperPhaseIfPossible(sym: Symbol, name: Name): Symbol = {
+      def lookup = sym.info.member(name)
+      // if loading during initialization of `definitions` typerPhase is not yet set.
+      // in that case we simply load the member at the current phase
+      if (currentRun.typerPhase eq null)
+        lookup
+      else
+        enteringTyper { lookup }
+    }
   }
 
   /** Returns the mirror that loaded given symbol */

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -85,7 +85,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
   lazy val platform: ThisPlatform =
     new { val global: Global.this.type = Global.this } with JavaPlatform
 
-  type PlatformClassPath = ClassPath[platform.BinaryRepr]
+  type PlatformClassPath = ClassPath[AbstractFile]
   type OptClassPath = Option[PlatformClassPath]
 
   def classPath: PlatformClassPath = platform.classPath
@@ -924,7 +924,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
              invalidated: mutable.ListBuffer[ClassSymbol], failed: mutable.ListBuffer[ClassSymbol]) {
     ifDebug(informProgress(s"syncing $root, $oldEntries -> $newEntries"))
 
-    val getName: ClassPath[platform.BinaryRepr] => String = (_.name)
+    val getName: ClassPath[AbstractFile] => String = (_.name)
     def hasClasses(cp: OptClassPath) = cp.isDefined && cp.get.classes.nonEmpty
     def invalidateOrRemove(root: ClassSymbol) = {
       allEntries match {

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -353,22 +353,9 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
   }
 
   lazy val loaders = new {
-    val symbolTable: Global.this.type = Global.this
+    val global: Global.this.type = Global.this
     val platform: Global.this.platform.type = Global.this.platform
-  } with SymbolLoaders {
-    protected override def lookupMemberAtTyperPhaseIfPossible(sym: Symbol, name: Name): Symbol = {
-      def lookup = sym.info.member(name)
-      // if loading during initialization of `definitions` typerPhase is not yet set.
-      // in that case we simply load the member at the current phase
-      if (currentRun.typerPhase eq null)
-        lookup
-      else
-        enteringTyper { lookup }
-    }
-    protected override def compileLate(srcfile: AbstractFile): Unit =
-      currentRun.compileLate(srcfile)
-
-  }
+  } with GlobalSymbolLoaders
 
   /** Returns the mirror that loaded given symbol */
   def mirrorThatLoaded(sym: Symbol): Mirror = rootMirror

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -85,7 +85,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
     val settings: Settings = Global.this.settings
   } with JavaPlatform
 
-  type ThisPlatform = Platform { val symbolTable: Global.this.type }
+  type ThisPlatform = JavaPlatform { val global: Global.this.type }
   lazy val platform: ThisPlatform  = new GlobalPlatform
 
   type PlatformClassPath = ClassPath[AbstractFile]

--- a/src/compiler/scala/tools/nsc/GlobalSymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/GlobalSymbolLoaders.scala
@@ -1,0 +1,30 @@
+/* NSC -- new Scala compiler
+ * Copyright 2005-2013 LAMP/EPFL
+ * @author  Martin Odersky
+ */
+
+package scala
+package tools
+package nsc
+
+/**
+ * Symbol loaders implementation that wires dependencies using Global.
+ */
+abstract class GlobalSymbolLoaders extends symtab.SymbolLoaders {
+  val global: Global
+  val symbolTable: global.type = global
+  val platform: symbolTable.platform.type
+  import global._
+  def lookupMemberAtTyperPhaseIfPossible(sym: Symbol, name: Name): Symbol = {
+    def lookup = sym.info.member(name)
+    // if loading during initialization of `definitions` typerPhase is not yet set.
+    // in that case we simply load the member at the current phase
+    if (currentRun.typerPhase eq null)
+      lookup
+    else
+      enteringTyper { lookup }
+  }
+
+  protected def compileLate(srcfile: io.AbstractFile): Unit =
+    currentRun.compileLate(srcfile)
+}

--- a/src/compiler/scala/tools/nsc/backend/JavaPlatform.scala
+++ b/src/compiler/scala/tools/nsc/backend/JavaPlatform.scala
@@ -14,29 +14,18 @@ trait JavaPlatform extends Platform {
   import global._
   import definitions._
 
-  type BinaryRepr = AbstractFile
+  private var currentClassPath: Option[MergedClassPath[AbstractFile]] = None
 
-  private var currentClassPath: Option[MergedClassPath[BinaryRepr]] = None
-
-  def classPath: ClassPath[BinaryRepr] = {
+  def classPath: ClassPath[AbstractFile] = {
     if (currentClassPath.isEmpty) currentClassPath = Some(new PathResolver(settings).result)
     currentClassPath.get
   }
 
   /** Update classpath with a substituted subentry */
-  def updateClassPath(subst: Map[ClassPath[BinaryRepr], ClassPath[BinaryRepr]]) =
+  def updateClassPath(subst: Map[ClassPath[AbstractFile], ClassPath[AbstractFile]]) =
     currentClassPath = Some(new DeltaClassPath(currentClassPath.get, subst))
 
-  def rootLoader = new loaders.PackageLoader(classPath.asInstanceOf[ClassPath[platform.BinaryRepr]])
-    // [Martin] Why do we need a cast here?
-    // The problem is that we cannot specify at this point that global.platform should be of type JavaPlatform.
-    // So we cannot infer that global.platform.BinaryRepr is AbstractFile.
-    // Ideally, we should be able to write at the top of the JavaPlatform trait:
-    //   val global: Global { val platform: JavaPlatform }
-    //   import global._
-    // Right now, this does nothing because the concrete definition of platform in Global
-    // replaces the tighter abstract definition here. If we had DOT typing rules, the two
-    // types would be conjoined and everything would work out. Yet another reason to push for DOT.
+  def rootLoader = new loaders.PackageLoader(classPath)
 
   private def classEmitPhase =
     if (settings.isBCodeActive) genBCode
@@ -69,7 +58,7 @@ trait JavaPlatform extends Platform {
   def newClassLoader(bin: AbstractFile): loaders.SymbolLoader =
     new loaders.ClassfileLoader(bin)
 
-  def doLoad(cls: ClassPath[BinaryRepr]#ClassRep): Boolean = true
+  def doLoad(cls: ClassPath[AbstractFile]#ClassRep): Boolean = true
 
   def needCompile(bin: AbstractFile, src: AbstractFile) =
     src.lastModified >= bin.lastModified

--- a/src/compiler/scala/tools/nsc/backend/JavaPlatform.scala
+++ b/src/compiler/scala/tools/nsc/backend/JavaPlatform.scala
@@ -11,6 +11,8 @@ import util.{ClassPath,MergedClassPath,DeltaClassPath}
 import scala.tools.util.PathResolver
 
 trait JavaPlatform extends Platform {
+  val global: Global
+  override val symbolTable: global.type = global
   import global._
   import definitions._
 
@@ -24,8 +26,6 @@ trait JavaPlatform extends Platform {
   /** Update classpath with a substituted subentry */
   def updateClassPath(subst: Map[ClassPath[AbstractFile], ClassPath[AbstractFile]]) =
     currentClassPath = Some(new DeltaClassPath(currentClassPath.get, subst))
-
-  def rootLoader = new loaders.PackageLoader(classPath)
 
   private def classEmitPhase =
     if (settings.isBCodeActive) genBCode
@@ -54,9 +54,6 @@ trait JavaPlatform extends Platform {
     (sym isNonBottomSubClass BoxedCharacterClass) ||
     (sym isNonBottomSubClass BoxedBooleanClass)
   }
-
-  def newClassLoader(bin: AbstractFile): loaders.SymbolLoader =
-    new loaders.ClassfileLoader(bin)
 
   def doLoad(cls: ClassPath[AbstractFile]#ClassRep): Boolean = true
 

--- a/src/compiler/scala/tools/nsc/backend/Platform.scala
+++ b/src/compiler/scala/tools/nsc/backend/Platform.scala
@@ -16,16 +16,17 @@ trait Platform {
   import global._
 
   /** The binary classfile representation type */
-  type BinaryRepr
+  @deprecated("BinaryRepr is not an abstract type anymore. It's an alias that points at AbstractFile. It'll be removed before Scala 2.11 is released.", "2.11.0-M5")
+  type BinaryRepr = AbstractFile
 
   /** The compiler classpath. */
-  def classPath: ClassPath[BinaryRepr]
+  def classPath: ClassPath[AbstractFile]
 
   /** The root symbol loader. */
   def rootLoader: LazyType
 
   /** Update classpath with a substitution that maps entries to entries */
-  def updateClassPath(subst: Map[ClassPath[BinaryRepr], ClassPath[BinaryRepr]])
+  def updateClassPath(subst: Map[ClassPath[AbstractFile], ClassPath[AbstractFile]])
 
   /** Any platform-specific phases. */
   def platformPhases: List[SubComponent]
@@ -37,7 +38,7 @@ trait Platform {
   def isMaybeBoxed(sym: Symbol): Boolean
 
   /** Create a new class loader to load class file `bin` */
-  def newClassLoader(bin: BinaryRepr): loaders.SymbolLoader
+  def newClassLoader(bin: AbstractFile): loaders.SymbolLoader
 
   /**
    * Tells whether a class should be loaded and entered into the package
@@ -45,7 +46,7 @@ trait Platform {
    * (anonymous classes, implementation classes, module classes), their
    * symtab is encoded in the pickle of another class.
    */
-  def doLoad(cls: ClassPath[BinaryRepr]#ClassRep): Boolean
+  def doLoad(cls: ClassPath[AbstractFile]#ClassRep): Boolean
 
   /**
    * Tells whether a class with both a binary and a source representation
@@ -53,6 +54,6 @@ trait Platform {
    * on the JVM similar to javac, i.e. if the source file is newer than the classfile,
    * a re-compile is triggered. On .NET by contrast classfiles always take precedence.
    */
-  def needCompile(bin: BinaryRepr, src: AbstractFile): Boolean
+  def needCompile(bin: AbstractFile, src: AbstractFile): Boolean
 }
 

--- a/src/compiler/scala/tools/nsc/backend/Platform.scala
+++ b/src/compiler/scala/tools/nsc/backend/Platform.scala
@@ -12,8 +12,8 @@ import io.AbstractFile
 /** The platform dependent pieces of Global.
  */
 trait Platform {
-  val global: Global
-  import global._
+  val symbolTable: symtab.SymbolTable
+  import symbolTable._
 
   /** The binary classfile representation type */
   @deprecated("BinaryRepr is not an abstract type anymore. It's an alias that points at AbstractFile. It'll be removed before Scala 2.11 is released.", "2.11.0-M5")
@@ -21,9 +21,6 @@ trait Platform {
 
   /** The compiler classpath. */
   def classPath: ClassPath[AbstractFile]
-
-  /** The root symbol loader. */
-  def rootLoader: LazyType
 
   /** Update classpath with a substitution that maps entries to entries */
   def updateClassPath(subst: Map[ClassPath[AbstractFile], ClassPath[AbstractFile]])
@@ -36,9 +33,6 @@ trait Platform {
 
   /** The various ways a boxed primitive might materialize at runtime. */
   def isMaybeBoxed(sym: Symbol): Boolean
-
-  /** Create a new class loader to load class file `bin` */
-  def newClassLoader(bin: AbstractFile): loaders.SymbolLoader
 
   /**
    * Tells whether a class should be loaded and entered into the package

--- a/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
@@ -1479,12 +1479,16 @@ abstract class GenICode extends SubComponent  {
 
       if (mustUseAnyComparator) {
         // when -optimise is on we call the @inline-version of equals, found in ScalaRunTime
-        val equalsMethod =
+        val equalsMethod: Symbol =
           if (!settings.optimise) {
             def default = platform.externalEquals
             platform match {
+              // TODO: define `externalEqualsNumNum`, `externalEqualsNumChar` and `externalEqualsNumObject` in Platform
+              // so we don't need special casing here
               case x: JavaPlatform =>
-                import x._
+                // We need this cast because pattern matcher doesn't narrow type properly
+                val javaPlatformRefined = x.asInstanceOf[JavaPlatform { val global: GenICode.this.global.type }]
+                import javaPlatformRefined._
                   if (l.tpe <:< BoxedNumberClass.tpe) {
                     if (r.tpe <:< BoxedNumberClass.tpe) externalEqualsNumNum
                     else if (r.tpe <:< BoxedCharacterClass.tpe) externalEqualsNumChar

--- a/src/compiler/scala/tools/nsc/backend/icode/ICodes.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/ICodes.scala
@@ -110,15 +110,8 @@ abstract class ICodes extends AnyRef
   object icodeReader extends ICodeReader {
     lazy val global: ICodes.this.global.type = ICodes.this.global
     import global._
-    def lookupMemberAtTyperPhaseIfPossible(sym: Symbol, name: Name): Symbol = {
-      def lookup = sym.info.member(name)
-      // if loading during initialization of `definitions` typerPhase is not yet set.
-      // in that case we simply load the member at the current phase
-      if (currentRun.typerPhase eq null)
-        lookup
-      else
-        enteringTyper { lookup }
-    }
+    def lookupMemberAtTyperPhaseIfPossible(sym: Symbol, name: Name): Symbol =
+      global.loaders.lookupMemberAtTyperPhaseIfPossible(sym, name)
     lazy val symbolTable: global.type = global
     lazy val loaders: global.loaders.type = global.loaders
     def classPath: util.ClassPath[AbstractFile] = ICodes.this.global.platform.classPath

--- a/src/compiler/scala/tools/nsc/backend/icode/ICodes.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/ICodes.scala
@@ -10,6 +10,7 @@ package icode
 import java.io.PrintWriter
 import analysis.{ Liveness, ReachingDefinitions }
 import scala.tools.nsc.symtab.classfile.ICodeReader
+import scala.reflect.io.AbstractFile
 
 /** Glue together ICode parts.
  *
@@ -118,6 +119,9 @@ abstract class ICodes extends AnyRef
       else
         enteringTyper { lookup }
     }
+    lazy val symbolTable: global.type = global
+    lazy val loaders: global.loaders.type = global.loaders
+    def classPath: util.ClassPath[AbstractFile] = ICodes.this.global.platform.classPath
   }
 
   /** A phase which works on icode. */

--- a/src/compiler/scala/tools/nsc/backend/icode/ICodes.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/ICodes.scala
@@ -108,6 +108,16 @@ abstract class ICodes extends AnyRef
 
   object icodeReader extends ICodeReader {
     lazy val global: ICodes.this.global.type = ICodes.this.global
+    import global._
+    def lookupMemberAtTyperPhaseIfPossible(sym: Symbol, name: Name): Symbol = {
+      def lookup = sym.info.member(name)
+      // if loading during initialization of `definitions` typerPhase is not yet set.
+      // in that case we simply load the member at the current phase
+      if (currentRun.typerPhase eq null)
+        lookup
+      else
+        enteringTyper { lookup }
+    }
   }
 
   /** A phase which works on icode. */

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -1187,13 +1187,17 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
       }
 
       if (mustUseAnyComparator) {
-        val equalsMethod = {
+        val equalsMethod: Symbol = {
 
-          def default = platform.externalEquals
+          def default: Symbol = platform.externalEquals
 
           platform match {
+            // TODO: define `externalEqualsNumNum`, `externalEqualsNumChar` and `externalEqualsNumObject` in Platform
+            // so we don't need special casing here
             case x: JavaPlatform =>
-              import x._
+              // We need this cast because pattern matcher doesn't narrow type properly
+              val javaPlatformRefined = x.asInstanceOf[JavaPlatform { val global: BCodeBodyBuilder.this.global.type }]
+              import javaPlatformRefined._
                 if (l.tpe <:< BoxedNumberClass.tpe) {
                   if (r.tpe <:< BoxedNumberClass.tpe) externalEqualsNumNum
                   else if (r.tpe <:< BoxedCharacterClass.tpe) externalEqualsNumChar

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -1188,25 +1188,11 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
 
       if (mustUseAnyComparator) {
         val equalsMethod: Symbol = {
-
-          def default: Symbol = platform.externalEquals
-
-          platform match {
-            // TODO: define `externalEqualsNumNum`, `externalEqualsNumChar` and `externalEqualsNumObject` in Platform
-            // so we don't need special casing here
-            case x: JavaPlatform =>
-              // We need this cast because pattern matcher doesn't narrow type properly
-              val javaPlatformRefined = x.asInstanceOf[JavaPlatform { val global: BCodeBodyBuilder.this.global.type }]
-              import javaPlatformRefined._
-                if (l.tpe <:< BoxedNumberClass.tpe) {
-                  if (r.tpe <:< BoxedNumberClass.tpe) externalEqualsNumNum
-                  else if (r.tpe <:< BoxedCharacterClass.tpe) externalEqualsNumChar
-                  else externalEqualsNumObject
-                }
-                else default
-
-            case _ => default
-          }
+          if (l.tpe <:< BoxedNumberClass.tpe) {
+            if (r.tpe <:< BoxedNumberClass.tpe) platform.externalEqualsNumNum
+            else if (r.tpe <:< BoxedCharacterClass.tpe) platform.externalEqualsNumChar
+            else platform.externalEqualsNumObject
+          } else platform.externalEquals
         }
         genLoad(l, ObjectReference)
         genLoad(r, ObjectReference)

--- a/src/compiler/scala/tools/nsc/symtab/BrowsingLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/BrowsingLoaders.scala
@@ -13,8 +13,11 @@ import scala.tools.nsc.io.AbstractFile
  *  are managed automatically.
  */
 abstract class BrowsingLoaders extends SymbolLoaders {
-  import global._
+  val global: Global
+  val symbolTable: global.type
+  protected def compileLate(srcfile: AbstractFile) = global.currentRun.compileLate(srcfile)
 
+  import global._
   import syntaxAnalyzer.{OutlineParser, MalformedInput}
 
   /*

--- a/src/compiler/scala/tools/nsc/symtab/BrowsingLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/BrowsingLoaders.scala
@@ -17,6 +17,20 @@ abstract class BrowsingLoaders extends SymbolLoaders {
 
   import syntaxAnalyzer.{OutlineParser, MalformedInput}
 
+  /*
+   * BrowsingLoaders has dependency on Global so we can implement this method here instead of forcing subclasses
+   * of BrowsingLoaders (e.g. in interactive) to implement it.
+   */
+  override def lookupMemberAtTyperPhaseIfPossible(sym: Symbol, name: Name): Symbol = {
+      def lookup = sym.info.member(name)
+      // if loading during initialization of `definitions` typerPhase is not yet set.
+      // in that case we simply load the member at the current phase
+      if (currentRun.typerPhase eq null)
+        lookup
+      else
+        enteringTyper { lookup }
+  }
+
   /** In browse mode, it can happen that an encountered symbol is already
    *  present. For instance, if the source file has a name different from
    *  the classes and objects it contains, the symbol loader will always

--- a/src/compiler/scala/tools/nsc/symtab/BrowsingLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/BrowsingLoaders.scala
@@ -12,27 +12,11 @@ import scala.tools.nsc.io.AbstractFile
  *  This class should be used whenever file dependencies and recompile sets
  *  are managed automatically.
  */
-abstract class BrowsingLoaders extends SymbolLoaders {
+abstract class BrowsingLoaders extends GlobalSymbolLoaders {
   val global: Global
-  val symbolTable: global.type
-  protected def compileLate(srcfile: AbstractFile) = global.currentRun.compileLate(srcfile)
 
   import global._
   import syntaxAnalyzer.{OutlineParser, MalformedInput}
-
-  /*
-   * BrowsingLoaders has dependency on Global so we can implement this method here instead of forcing subclasses
-   * of BrowsingLoaders (e.g. in interactive) to implement it.
-   */
-  override def lookupMemberAtTyperPhaseIfPossible(sym: Symbol, name: Name): Symbol = {
-      def lookup = sym.info.member(name)
-      // if loading during initialization of `definitions` typerPhase is not yet set.
-      // in that case we simply load the member at the current phase
-      if (currentRun.typerPhase eq null)
-        lookup
-      else
-        enteringTyper { lookup }
-  }
 
   /** In browse mode, it can happen that an encountered symbol is already
    *  present. For instance, if the source file has a name different from

--- a/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
@@ -30,7 +30,7 @@ abstract class SymbolLoaders {
   /**
    * Required by ClassfileParser. Check documentation in that class for details.
    */
-  protected def lookupMemberAtTyperPhaseIfPossible(sym: Symbol, name: Name): Symbol
+  def lookupMemberAtTyperPhaseIfPossible(sym: Symbol, name: Name): Symbol
   /**
    * Should forward to `Run.compileLate`. The more principled fix would be to
    * determine why this functionality is needed and extract it into a separate

--- a/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
@@ -144,7 +144,7 @@ abstract class SymbolLoaders {
 
   /** Initialize toplevel class and module symbols in `owner` from class path representation `classRep`
    */
-  def initializeFromClassPath(owner: Symbol, classRep: ClassPath[platform.BinaryRepr]#ClassRep) {
+  def initializeFromClassPath(owner: Symbol, classRep: ClassPath[AbstractFile]#ClassRep) {
     ((classRep.binary, classRep.source) : @unchecked) match {
       case (Some(bin), Some(src))
       if platform.needCompile(bin, src) && !binaryOnly(owner, classRep.name) =>
@@ -226,7 +226,7 @@ abstract class SymbolLoaders {
   /**
    * Load contents of a package
    */
-  class PackageLoader(classpath: ClassPath[platform.BinaryRepr]) extends SymbolLoader with FlagAgnosticCompleter {
+  class PackageLoader(classpath: ClassPath[AbstractFile]) extends SymbolLoader with FlagAgnosticCompleter {
     protected def description = "package loader "+ classpath.name
 
     protected def doComplete(root: Symbol) {

--- a/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
@@ -22,6 +22,11 @@ import scala.reflect.io.{ AbstractFile, NoAbstractFile }
 abstract class SymbolLoaders {
   val global: Global
   import global._
+
+  /**
+   * Required by ClassfileParser. Check documentation in that class for details.
+   */
+  protected def lookupMemberAtTyperPhaseIfPossible(sym: Symbol, name: Name): Symbol
   import SymbolLoadersStats._
 
   protected def enterIfNew(owner: Symbol, member: Symbol, completer: SymbolLoader): Symbol = {
@@ -249,6 +254,8 @@ abstract class SymbolLoaders {
     } with ClassfileParser {
       override protected type ThisConstantPool = ConstantPool
       override protected def newConstantPool: ThisConstantPool = new ConstantPool
+      override protected def lookupMemberAtTyperPhaseIfPossible(sym: Symbol, name: Name): Symbol =
+        SymbolLoaders.this.lookupMemberAtTyperPhaseIfPossible(sym, name)
     }
 
     protected def description = "class file "+ classfile.toString

--- a/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
@@ -20,13 +20,23 @@ import scala.reflect.io.{ AbstractFile, NoAbstractFile }
  *  @version 1.0
  */
 abstract class SymbolLoaders {
-  val global: Global
-  import global._
-
+  val symbolTable: symtab.SymbolTable {
+    def settings: Settings
+  }
+  val platform: backend.Platform {
+    val symbolTable: SymbolLoaders.this.symbolTable.type
+  }
+  import symbolTable._
   /**
    * Required by ClassfileParser. Check documentation in that class for details.
    */
   protected def lookupMemberAtTyperPhaseIfPossible(sym: Symbol, name: Name): Symbol
+  /**
+   * Should forward to `Run.compileLate`. The more principled fix would be to
+   * determine why this functionality is needed and extract it into a separate
+   * interface.
+   */
+  protected def compileLate(srcfile: AbstractFile): Unit
   import SymbolLoadersStats._
 
   protected def enterIfNew(owner: Symbol, member: Symbol, completer: SymbolLoader): Symbol = {
@@ -80,14 +90,14 @@ abstract class SymbolLoaders {
           name+"\none of them needs to be removed from classpath"
         )
       else if (settings.termConflict.value == "package") {
-        global.warning(
+        warning(
           "Resolving package/object name conflict in favor of package " +
           preExisting.fullName + ".  The object will be inaccessible."
         )
         root.info.decls.unlink(preExisting)
       }
       else {
-        global.warning(
+        warning(
           "Resolving package/object name conflict in favor of object " +
           preExisting.fullName + ".  The package will be inaccessible."
         )
@@ -149,12 +159,12 @@ abstract class SymbolLoaders {
       case (Some(bin), Some(src))
       if platform.needCompile(bin, src) && !binaryOnly(owner, classRep.name) =>
         if (settings.verbose) inform("[symloader] picked up newer source file for " + src.path)
-        global.loaders.enterToplevelsFromSource(owner, classRep.name, src)
+        enterToplevelsFromSource(owner, classRep.name, src)
       case (None, Some(src)) =>
         if (settings.verbose) inform("[symloader] no class, picked up source file for " + src.path)
-        global.loaders.enterToplevelsFromSource(owner, classRep.name, src)
+        enterToplevelsFromSource(owner, classRep.name, src)
       case (Some(bin), _) =>
-        global.loaders.enterClassAndModule(owner, classRep.name, platform.newClassLoader(bin))
+        enterClassAndModule(owner, classRep.name, new ClassfileLoader(bin))
     }
   }
 
@@ -250,12 +260,23 @@ abstract class SymbolLoaders {
 
   class ClassfileLoader(val classfile: AbstractFile) extends SymbolLoader with FlagAssigningCompleter {
     private object classfileParser extends {
-      val global: SymbolLoaders.this.global.type = SymbolLoaders.this.global
+      val symbolTable: SymbolLoaders.this.symbolTable.type = SymbolLoaders.this.symbolTable
     } with ClassfileParser {
       override protected type ThisConstantPool = ConstantPool
       override protected def newConstantPool: ThisConstantPool = new ConstantPool
       override protected def lookupMemberAtTyperPhaseIfPossible(sym: Symbol, name: Name): Symbol =
         SymbolLoaders.this.lookupMemberAtTyperPhaseIfPossible(sym, name)
+      /*
+       * The type alias and the cast (where the alias is used) is needed due to problem described
+       * in SI-7585. In this particular case, the problem is that we need to make sure that symbol
+       * table used by symbol loaders is exactly the same as they one used by classfileParser.
+       * If you look at the path-dependent types we have here everything should work out ok but
+       * due to issue described in SI-7585 type-checker cannot tie the knot here.
+       *
+       */
+      private type SymbolLoadersRefined = SymbolLoaders { val symbolTable: classfileParser.symbolTable.type }
+      val loaders = SymbolLoaders.this.asInstanceOf[SymbolLoadersRefined]
+      val classPath = platform.classPath
     }
 
     protected def description = "class file "+ classfile.toString
@@ -282,7 +303,7 @@ abstract class SymbolLoaders {
     protected def description = "source file "+ srcfile.toString
     override def fromSource = true
     override def sourcefile = Some(srcfile)
-    protected def doComplete(root: Symbol): Unit = global.currentRun.compileLate(srcfile)
+    protected def doComplete(root: Symbol): Unit = compileLate(srcfile)
   }
 
   object moduleClassLoader extends SymbolLoader with FlagAssigningCompleter {

--- a/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
@@ -246,7 +246,10 @@ abstract class SymbolLoaders {
   class ClassfileLoader(val classfile: AbstractFile) extends SymbolLoader with FlagAssigningCompleter {
     private object classfileParser extends {
       val global: SymbolLoaders.this.global.type = SymbolLoaders.this.global
-    } with ClassfileParser
+    } with ClassfileParser {
+      override protected type ThisConstantPool = ConstantPool
+      override protected def newConstantPool: ThisConstantPool = new ConstantPool
+    }
 
     protected def description = "class file "+ classfile.toString
 

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
@@ -20,6 +20,8 @@ import scala.reflect.internal.JavaAccFlags
  */
 abstract class ICodeReader extends ClassfileParser {
   val global: Global
+  val symbolTable: global.type
+  val loaders: global.loaders.type
   import global._
   import icodes._
 

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
@@ -28,6 +28,95 @@ abstract class ICodeReader extends ClassfileParser {
   var method: IMethod = NoIMethod          // the current IMethod
   var isScalaModule = false
 
+  override protected type ThisConstantPool = ICodeConstantPool
+  override protected def newConstantPool = new ICodeConstantPool
+
+  /** Try to force the chain of enclosing classes for the given name. Otherwise
+   *  flatten would not lift classes that were not referenced in the source code.
+   */
+  def forceMangledName(name: Name, module: Boolean): Symbol = {
+    val parts = name.decode.toString.split(Array('.', '$'))
+    var sym: Symbol = rootMirror.RootClass
+
+    // was "at flatten.prev"
+    enteringFlatten {
+      for (part0 <- parts; if !(part0 == ""); part = newTermName(part0)) {
+        val sym1 = enteringIcode {
+          sym.linkedClassOfClass.info
+          sym.info.decl(part.encode)
+        }//.suchThat(module == _.isModule)
+
+        sym = sym1 orElse sym.info.decl(part.encode.toTypeName)
+      }
+    }
+    sym
+  }
+
+  protected class ICodeConstantPool extends ConstantPool {
+    /** Return the symbol of the class member at `index`.
+     *  The following special cases exist:
+     *   - If the member refers to special `MODULE$` static field, return
+     *  the symbol of the corresponding module.
+     *   - If the member is a field, and is not found with the given name,
+     *     another try is made by appending `nme.LOCAL_SUFFIX_STRING`
+     *   - If no symbol is found in the right tpe, a new try is made in the
+     *     companion class, in case the owner is an implementation class.
+     */
+    def getMemberSymbol(index: Int, static: Boolean): Symbol = {
+      if (index <= 0 || len <= index) errorBadIndex(index)
+      var f = values(index).asInstanceOf[Symbol]
+      if (f eq null) {
+        val start = starts(index)
+        val first = in.buf(start).toInt
+        if (first != CONSTANT_FIELDREF &&
+            first != CONSTANT_METHODREF &&
+            first != CONSTANT_INTFMETHODREF) errorBadTag(start)
+        val ownerTpe = getClassOrArrayType(in.getChar(start + 1).toInt)
+        debuglog("getMemberSymbol(static: " + static + "): owner type: " + ownerTpe + " " + ownerTpe.typeSymbol.originalName)
+        val (name0, tpe0) = getNameAndType(in.getChar(start + 3).toInt, ownerTpe)
+        debuglog("getMemberSymbol: name and tpe: " + name0 + ": " + tpe0)
+
+        forceMangledName(tpe0.typeSymbol.name, module = false)
+        val (name, tpe) = getNameAndType(in.getChar(start + 3).toInt, ownerTpe)
+        if (name == nme.MODULE_INSTANCE_FIELD) {
+          val index = in.getChar(start + 1).toInt
+          val name = getExternalName(in.getChar(starts(index).toInt + 1).toInt)
+          //assert(name.endsWith("$"), "Not a module class: " + name)
+          f = forceMangledName(name dropRight 1, module = true)
+          if (f == NoSymbol)
+            f = rootMirror.getModuleByName(name dropRight 1)
+        } else {
+          val origName = nme.unexpandedName(name)
+          val owner = if (static) ownerTpe.typeSymbol.linkedClassOfClass else ownerTpe.typeSymbol
+          f = owner.info.findMember(origName, 0, 0, stableOnly = false).suchThat(_.tpe.widen =:= tpe)
+          if (f == NoSymbol)
+            f = owner.info.findMember(newTermName(origName + nme.LOCAL_SUFFIX_STRING), 0, 0, stableOnly = false).suchThat(_.tpe =:= tpe)
+          if (f == NoSymbol) {
+            // if it's an impl class, try to find it's static member inside the class
+            if (ownerTpe.typeSymbol.isImplClass) {
+              f = ownerTpe.findMember(origName, 0, 0, stableOnly = false).suchThat(_.tpe =:= tpe)
+            } else {
+              log("Couldn't find " + name + ": " + tpe + " inside: \n" + ownerTpe)
+              f = tpe match {
+                case MethodType(_, _) => owner.newMethod(name.toTermName, owner.pos)
+                case _                => owner.newVariable(name.toTermName, owner.pos)
+              }
+              f setInfo tpe
+              log("created fake member " + f.fullName)
+            }
+          }
+        }
+        assert(f != NoSymbol,
+          s"could not find $name: $tpe in $ownerTpe" + (
+            if (settings.debug.value) ownerTpe.members.mkString(", members are:\n  ", "\n  ", "") else ""
+          )
+        )
+        values(index) = f
+      }
+      f
+    }
+  }
+
   /** Read back bytecode for the given class symbol. It returns
    *  two IClass objects, one for static members and one
    *  for non-static members.

--- a/src/eclipse/interactive/.classpath
+++ b/src/eclipse/interactive/.classpath
@@ -3,7 +3,7 @@
 	<classpathentry kind="src" path="interactive"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scaladoc"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_COMPILER_CONTAINER"/>
-	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/scala-compiler"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/scala-library"/>
 	<classpathentry kind="output" path="build-quick-interactive"/>
 </classpath>

--- a/src/eclipse/scala-compiler/.classpath
+++ b/src/eclipse/scala-compiler/.classpath
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="compiler"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/asm"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/reflect"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/scala-library"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/continuations-library"/>
+	<classpathentry combineaccessrules="false" exported="true" kind="src" path="/asm"/>
+	<classpathentry combineaccessrules="false" exported="true" kind="src" path="/reflect"/>
+	<classpathentry combineaccessrules="false" exported="true" kind="src" path="/scala-library"/>
+	<classpathentry combineaccessrules="false" exported="true" kind="src" path="/continuations-library"/>
 	<classpathentry kind="var" path="SCALA_BASEDIR/lib/ant/ant.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="output" path="build-quick-compiler"/>

--- a/src/eclipse/scaladoc/.classpath
+++ b/src/eclipse/scaladoc/.classpath
@@ -3,8 +3,10 @@
 	<classpathentry kind="src" path="scaladoc"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/partest"/>
 	<classpathentry kind="var" path="SCALA_BASEDIR/lib/ant/ant.jar"/>
-	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_COMPILER_CONTAINER"/>
-	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/scala-compiler"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/scala-library"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/scala-xml"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/scala-parser-combinators"/>
 	<classpathentry kind="output" path="build-quick-scaladoc"/>
 </classpath>

--- a/src/eclipse/test-junit/.classpath
+++ b/src/eclipse/test-junit/.classpath
@@ -7,5 +7,6 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/scala-library"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/continuations-library"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/scala-compiler"/>
 	<classpathentry kind="output" path="build-test-junit"/>
 </classpath>

--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -369,9 +369,18 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
    *  top-level idents. Therefore, we can detect top-level symbols that have a name
    *  different from their source file
    */
-  override lazy val loaders: SymbolLoaders { val global: Global.this.type } = new BrowsingLoaders {
-    val global: Global.this.type = Global.this
+  protected type SymbolLoadersInInteractive = SymbolLoaders {
+    // `global` val is needed so we conform to loaders type in Global in Scala 2.11.0-M4
+    // TODO: remove once 2.11.0-M5 is used to build interactive
+    val global: Global.this.type
+    val symbolTable: Global.this.type
+    val platform: Global.this.platform.type
   }
+  override lazy val loaders: SymbolLoadersInInteractive = new {
+    val global: Global.this.type = Global.this
+    val symbolTable: Global.this.type = Global.this
+    val platform: Global.this.platform.type = Global.this.platform
+  } with BrowsingLoaders
 
   // ----------------- Polling ---------------------------------------
 

--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -365,20 +365,16 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
    */
   override def registerTopLevelSym(sym: Symbol) { currentTopLevelSyms += sym }
 
+  protected type SymbolLoadersInInteractive = GlobalSymbolLoaders {
+    val global: Global.this.type
+    val platform: Global.this.platform.type
+  }
   /** Symbol loaders in the IDE parse all source files loaded from a package for
    *  top-level idents. Therefore, we can detect top-level symbols that have a name
    *  different from their source file
    */
-  protected type SymbolLoadersInInteractive = SymbolLoaders {
-    // `global` val is needed so we conform to loaders type in Global in Scala 2.11.0-M4
-    // TODO: remove once 2.11.0-M5 is used to build interactive
-    val global: Global.this.type
-    val symbolTable: Global.this.type
-    val platform: Global.this.platform.type
-  }
   override lazy val loaders: SymbolLoadersInInteractive = new {
     val global: Global.this.type = Global.this
-    val symbolTable: Global.this.type = Global.this
     val platform: Global.this.platform.type = Global.this.platform
   } with BrowsingLoaders
 

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -52,6 +52,12 @@ abstract class SymbolTable extends macros.Universe
   def globalError(msg: String): Unit = abort(msg)
   def abort(msg: String): Nothing    = throw new FatalError(supplementErrorMessage(msg))
 
+  protected def elapsedMessage(msg: String, start: Long) =
+    msg + " in " + (System.currentTimeMillis() - start) + "ms"
+
+  def informProgress(msg: String)          = if (settings.verbose) inform("[" + msg + "]")
+  def informTime(msg: String, start: Long) = informProgress(elapsedMessage(msg, start))
+
   def shouldLogAtThisPhase = false
   def isPastTyper = false
 

--- a/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
+++ b/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
@@ -22,8 +22,8 @@ import scala.annotation.switch
  *  @version 1.0
  */
 abstract class UnPickler {
-  val global: SymbolTable
-  import global._
+  val symbolTable: SymbolTable
+  import symbolTable._
 
   /** Unpickle symbol table information descending from a class and/or module root
    *  from an array of bytes.

--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -529,7 +529,7 @@ private[reflect] trait JavaMirrors extends internal.SymbolTable with api.JavaUni
     }
 
     private object unpickler extends UnPickler {
-      val global: thisUniverse.type = thisUniverse
+      val symbolTable: thisUniverse.type = thisUniverse
     }
 
     /** how connected????

--- a/src/repl/scala/tools/nsc/interpreter/ReplVals.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplVals.scala
@@ -39,7 +39,7 @@ class StdReplVals(final val r: ILoop) extends ReplVals {
   def lastRequest = intp.lastRequest
 
   class ReplImplicits extends power.Implicits2 {
-    import intp.global._
+    import intp.global.Symbol
 
     private val tagFn = ReplVals.mkCompilerTypeFromTag[intp.global.type](global)
     implicit def mkCompilerTypeFromTag(sym: Symbol) = tagFn(sym)

--- a/src/scaladoc/scala/tools/nsc/doc/ScaladocGlobal.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/ScaladocGlobal.scala
@@ -32,6 +32,16 @@ trait ScaladocGlobalTrait extends Global {
     override protected def signalError(root: Symbol, ex: Throwable) {
       log(s"Suppressing error involving $root: $ex")
     }
+
+    def lookupMemberAtTyperPhaseIfPossible(sym: Symbol, name: Name): Symbol = {
+      def lookup = sym.info.member(name)
+      // if loading during initialization of `definitions` typerPhase is not yet set.
+      // in that case we simply load the member at the current phase
+      if (currentRun.typerPhase eq null)
+        lookup
+      else
+        enteringTyper { lookup }
+    }
   }
 }
 

--- a/src/scaladoc/scala/tools/nsc/doc/ScaladocGlobal.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/ScaladocGlobal.scala
@@ -25,32 +25,14 @@ trait ScaladocGlobalTrait extends Global {
   }
 
   override lazy val loaders = new {
-    val symbolTable: outer.type = outer
-    val platform: outer.platform.type = outer.platform
-    // `global` val is needed so we conform to loaders type in Global in Scala 2.11.0-M4
-    // TODO: remove once 2.11.0-M5 is used to build Scaladoc
     val global: outer.type = outer
-  } with SymbolLoaders {
+    val platform: outer.platform.type = outer.platform
+  } with GlobalSymbolLoaders {
     // SI-5593 Scaladoc's current strategy is to visit all packages in search of user code that can be documented
     // therefore, it will rummage through the classpath triggering errors whenever it encounters package objects
     // that are not in their correct place (see bug for details)
     override protected def signalError(root: Symbol, ex: Throwable) {
       log(s"Suppressing error involving $root: $ex")
-    }
-
-    // TODO: Add `override` modifier once Scala 2.11.0-M5 is used to build Scaladoc
-    protected /*override*/ def compileLate(srcfile: io.AbstractFile): Unit =
-        currentRun.compileLate(srcfile)
-
-    // TODO: Add `override` modifier once Scala 2.11.0-M5 is used to build Scaladoc
-    protected def /*override*/ lookupMemberAtTyperPhaseIfPossible(sym: Symbol, name: Name): Symbol = {
-      def lookup = sym.info.member(name)
-      // if loading during initialization of `definitions` typerPhase is not yet set.
-      // in that case we simply load the member at the current phase
-      if (currentRun.typerPhase eq null)
-        lookup
-      else
-        enteringTyper { lookup }
     }
   }
 }

--- a/test/files/presentation/doc/doc.scala
+++ b/test/files/presentation/doc/doc.scala
@@ -51,10 +51,6 @@ object Test extends InteractiveTest {
           new Typer(context) with InteractiveTyper with ScaladocTyper
       }
 
-      override lazy val loaders = new scala.tools.nsc.symtab.SymbolLoaders {
-        val global: outer.type = outer
-      }
-
       def chooseLink(links: List[LinkTo]): LinkTo = links.head
       def internalLink(sym: Symbol, site: Symbol) = None
       def toString(link: LinkTo) = link.toString

--- a/test/junit/scala/tools/nsc/symtab/SymbolTableForUnitTesting.scala
+++ b/test/junit/scala/tools/nsc/symtab/SymbolTableForUnitTesting.scala
@@ -42,7 +42,7 @@ class SymbolTableForUnitTesting extends SymbolTable {
   object loaders extends symtab.SymbolLoaders {
     val symbolTable: SymbolTableForUnitTesting.this.type = SymbolTableForUnitTesting.this
     lazy val platform: symbolTable.platform.type = symbolTable.platform
-    protected def lookupMemberAtTyperPhaseIfPossible(sym: Symbol, name: Name): Symbol =
+    def lookupMemberAtTyperPhaseIfPossible(sym: Symbol, name: Name): Symbol =
       sym.info.member(name)
     protected override def compileLate(srcfile: AbstractFile): Unit =
       sys.error(s"We do not expect compileLate to be called in SymbolTableTest. The srcfile passed in is $srcfile")

--- a/test/junit/scala/tools/nsc/symtab/SymbolTableForUnitTesting.scala
+++ b/test/junit/scala/tools/nsc/symtab/SymbolTableForUnitTesting.scala
@@ -1,0 +1,89 @@
+package scala.tools.nsc
+package symtab
+
+import scala.reflect.internal.{Phase, NoPhase, SomePhase}
+import scala.tools.util.PathResolver
+import util.ClassPath
+import io.AbstractFile
+
+/**
+ * A complete SymbolTable implementation designed to be used in JUnit tests.
+ *
+ * It enables `usejavacp` setting so classpath of JUnit runner is being used
+ * for symbol table's classpath.
+ *
+ * This class contains enough of logic implemented to make it possible to
+ * initialize definitions and inspect symbols.
+ */
+class SymbolTableForUnitTesting extends SymbolTable {
+  // Members declared in scala.reflect.api.Trees
+  override def newStrictTreeCopier: TreeCopier = new StrictTreeCopier
+  override def newLazyTreeCopier: TreeCopier = new LazyTreeCopier
+  trait TreeCopier extends InternalTreeCopierOps
+  // these should be mocks
+  class StrictTreeCopier extends super.StrictTreeCopier with TreeCopier
+  class LazyTreeCopier extends super.LazyTreeCopier with TreeCopier
+
+  override def isCompilerUniverse: Boolean = true
+  def classPath = new PathResolver(settings).result
+
+  object platform extends backend.Platform {
+    val symbolTable: SymbolTableForUnitTesting.this.type = SymbolTableForUnitTesting.this
+    lazy val loaders: SymbolTableForUnitTesting.this.loaders.type = SymbolTableForUnitTesting.this.loaders
+    def platformPhases: List[SubComponent] = Nil
+    val classPath: ClassPath[AbstractFile] = new PathResolver(settings).result
+    def doLoad(cls: ClassPath[AbstractFile]#ClassRep): Boolean = true
+    def isMaybeBoxed(sym: Symbol): Boolean = ???
+    def needCompile(bin: AbstractFile, src: AbstractFile): Boolean = ???
+    def externalEquals: Symbol = ???
+    def updateClassPath(subst: Map[ClassPath[AbstractFile], ClassPath[AbstractFile]]): Unit = ???
+  }
+
+  object loaders extends symtab.SymbolLoaders {
+    val symbolTable: SymbolTableForUnitTesting.this.type = SymbolTableForUnitTesting.this
+    lazy val platform: symbolTable.platform.type = symbolTable.platform
+    protected def lookupMemberAtTyperPhaseIfPossible(sym: Symbol, name: Name): Symbol =
+      sym.info.member(name)
+    protected override def compileLate(srcfile: AbstractFile): Unit =
+      sys.error(s"We do not expect compileLate to be called in SymbolTableTest. The srcfile passed in is $srcfile")
+  }
+
+  class GlobalMirror extends Roots(NoSymbol) {
+    val universe: SymbolTableForUnitTesting.this.type = SymbolTableForUnitTesting.this
+    def rootLoader: LazyType = new loaders.PackageLoader(classPath)
+    override def toString = "compiler mirror"
+  }
+
+  lazy val rootMirror: Mirror = {
+    val rm = new GlobalMirror
+    rm.init()
+    rm.asInstanceOf[Mirror]
+  }
+
+  def settings: Settings = {
+    val s = new Settings
+    // initialize classpath using java classpath
+    s.usejavacp.value = true
+    s
+  }
+
+   // Members declared in scala.reflect.internal.Required
+  def picklerPhase: scala.reflect.internal.Phase = SomePhase
+
+  // Members declared in scala.reflect.internal.SymbolTable
+  def currentRunId: Int = 1
+  def log(msg: => AnyRef): Unit = println(msg)
+  def mirrorThatLoaded(sym: Symbol): Mirror = rootMirror
+  val phases: Seq[Phase] = List(NoPhase, SomePhase)
+  val phaseWithId: Array[Phase] = {
+    val maxId = phases.map(_.id).max
+    val phasesArray = Array.ofDim[Phase](maxId+1)
+    phases foreach { phase =>
+      phasesArray(phase.id) = phase
+    }
+    phasesArray
+  }
+  lazy val treeInfo: scala.reflect.internal.TreeInfo{val global: SymbolTableForUnitTesting.this.type} = ???
+
+  phase = SomePhase
+}

--- a/test/junit/scala/tools/nsc/symtab/SymbolTableTest.scala
+++ b/test/junit/scala/tools/nsc/symtab/SymbolTableTest.scala
@@ -26,4 +26,25 @@ class SymbolTableTest {
     assertTrue("List should be subclass of Seq", listClassTpe <:< seqClassTpe)
   }
 
+  /**
+   * Demonstrates how one can create symbols and type completely
+   * from scratch and perform sub type check.
+   */
+  @Test
+  def customClassesSubTypeCheck: Unit = {
+    val symbolTable = createSymbolTable
+    import symbolTable._
+    symbolTable.definitions.init()
+    val rootClass = symbolTable.rootMirror.RootClass
+    val fooSymbol = rootClass.newClassSymbol("Foo": TypeName, NoPosition, 0)
+    val fooType = new ClassInfoType(Nil, EmptyScope, fooSymbol)
+    fooSymbol.info = fooType
+    val barSymbol = rootClass.newClassSymbol("Bar": TypeName, NoPosition, 0)
+    val fooTypeRef = TypeRef(fooSymbol.owner.tpe, fooSymbol, Nil)
+    val barType = new ClassInfoType(List(fooTypeRef), EmptyScope, barSymbol)
+    barSymbol.info = barType
+    assertTrue("Bar should be subclass of Foo", barSymbol.tpe <:< fooSymbol.tpe)
+    assertFalse("Foo should be a superclass of Foo", fooSymbol.tpe <:< barSymbol.tpe)
+  }
+
 }

--- a/test/junit/scala/tools/nsc/symtab/SymbolTableTest.scala
+++ b/test/junit/scala/tools/nsc/symtab/SymbolTableTest.scala
@@ -1,0 +1,29 @@
+package scala.tools.nsc
+package symtab
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class SymbolTableTest {
+  private def createSymbolTable: SymbolTable = new SymbolTableForUnitTesting
+
+  @Test
+  def initDefinitions = {
+    val symbolTable = createSymbolTable
+    symbolTable.definitions.init()
+  }
+
+  @Test
+  def basicSubTypeCheck = {
+    val symbolTable = createSymbolTable
+    symbolTable.definitions.init()
+    val listClassTpe = symbolTable.definitions.ListClass.tpe
+    val seqClassTpe = symbolTable.definitions.SeqClass.tpe
+    assertTrue("List should be subclass of Seq", listClassTpe <:< seqClassTpe)
+  }
+
+}


### PR DESCRIPTION
_The description of PR is copied from 364fcd9. All other commits are mostly supporting that big change._

This is rather large commit so I'll first explain the motivation behind it and then go through all changes in detail explaining the choices I made.

The motivation behind this refactoring was to make SymbolTable unit testable. I wanted a lightweight way of initializing SymbolTable and then writing unit tests for subtyping algorithm, various functionality related to Symbols, etc. All of that should be possible by precisely controlling what we test, e.g., create types and symbols by hand and not have them defined in source code as we normally do in partest (functional) tests.

The other motivation was to reduce and clarify dependencies we have in the compiler. Explicit dependencies lead to cleaner design. Also, explicit and reduced dependencies help incremental compilation which is a big problem for us in compiler's code base at the moment.

One of the challenges I faced during that refactoring was cyclic dependency between Platform and SymbolLoaders.

Platform depended on `SymbolLoaders.SymbolLoader` because it would define a root loader. SymbolLoaders depended on Platform for numerous reasons like deferring decision how to load a given symbol based on some Platform-specific hooks.

I decided to break that cycle by removing methods related to symbol loading from Platform interface. One could argue, that better fix would be to make SymbolLoaders to not depend on Platform (backend) concept but that would be much bigger refactoring. Also, we have a new concept for dealing with symbol loading: Mirrors.

For those reasons both `newClassLoader` and `rootLoader` were dropped from Platform interface.

Note that JavaPlatform still depends on Global so it can access phases defined in Global to implement `platformPhases` method.

Both GenICode and BCodeBodyBuilder have some Platform specific logic that requires casting because pattern matcher doesn't narrow types to give them a proper refinement. Check the changes for details.

Some logging utilities has been moved from Global to SymbolTable because they are accessed by SymbolTable. Since Global inherits from SymbolTable this should be a source compatible change.

The SymbolLoaders has dependency on `compileLate` method defined in Global. The purpose behind `compileLate` is not clear to me but the dependency looks a little bit dubious. At least we made that dependency explicit.

ScaladocGlobal and Global defined in interactive has been adapted in a way that makes them compile both with quick.comp and 2.11.0-M4 so my refactorings are not blocking the modularization effort.
