### PR TITLE
Add deprecation warning to scala.concurrent.Lock class

### DIFF
--- a/src/library/scala/concurrent/Lock.scala
+++ b/src/library/scala/concurrent/Lock.scala
@@ -14,6 +14,7 @@ package scala.concurrent
  *
  *  @author  Martin Odersky
  *  @version 1.0, 10/03/2003
+ *  @deprecated("Use java.util.concurrent.locks.Lock", "2.11.0")
  */
 class Lock {
   var available = true


### PR DESCRIPTION
@retronym Here is that deprecation of the Lock class.
