### PR TITLE
Improve type printing (crashes)

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/Trees.scala
+++ b/src/compiler/scala/tools/nsc/ast/Trees.scala
@@ -14,6 +14,7 @@ import scala.reflect.internal.Flags.PARAMACCESSOR
 import scala.reflect.internal.Flags.PRESUPER
 import scala.reflect.internal.Flags.TRAIT
 import scala.compat.Platform.EOL
+import scala.reflect.internal.CompileRunAborted
 
 trait Trees extends scala.reflect.internal.Trees { self: Global =>
   // --- additional cases --------------------------------------------------------
@@ -147,12 +148,7 @@ trait Trees extends scala.reflect.internal.Trees { self: Global =>
 
   class Transformer extends super.Transformer {
     def transformUnit(unit: CompilationUnit) {
-      try unit.body = transform(unit.body)
-      catch {
-        case ex: Exception =>
-          log(supplementErrorMessage("unhandled exception while transforming "+unit))
-          throw ex
-      }
+      unit.body = transform(unit.body)
     }
   }
 

--- a/src/compiler/scala/tools/nsc/typechecker/TypersTracking.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypersTracking.scala
@@ -23,7 +23,24 @@ trait TypersTracking {
   // TODO - this only catches trees which go through def typed,
   // but there are all kinds of back ways - typedClassDef, etc. etc.
   // Funnel everything through one doorway.
-  var lastTreeToTyper: Tree = EmptyTree
+  private var _lastTreeToTyper: Tree = EmptyTree
+  private var _typerTreeDepth: Int = 0
+  // Track the depth of the "typed" stack so we know whether the
+  // last tree to typer is an interesting thing to report on when the
+  // compiler crashes.
+  def typerTreeDepth: Int = _typerTreeDepth
+  def lastTreeToTyper = _lastTreeToTyper
+  def pushLastTreeToTyper(tree: Tree) {
+    _lastTreeToTyper = tree
+    _typerTreeDepth += 1
+  }
+  def popLastTreeToTyper() {
+    _typerTreeDepth -= 1
+  }
+  def clearLastTreeToTyper() {
+    _lastTreeToTyper = EmptyTree
+    _typerTreeDepth = 0
+  }
 
   def fullSiteString(context: Context): String = {
     def owner_long_s = (

--- a/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
+++ b/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
@@ -49,7 +49,7 @@ abstract class ToolBoxFactory[U <: JavaUniverse](val u: U) { factorySelf =>
       def cleanupCaches(): Unit = {
         perRunCaches.clearAll()
         undoLog.clear()
-        analyzer.lastTreeToTyper = EmptyTree
+        analyzer.clearLastTreeToTyper()
         lastSeenSourceFile = NoSourceFile
         lastSeenContext = null
       }

--- a/src/reflect/scala/reflect/internal/CompileRunAborted.scala
+++ b/src/reflect/scala/reflect/internal/CompileRunAborted.scala
@@ -1,0 +1,14 @@
+/* NSC -- new Scala compiler
+ * Copyright 2005-2013 LAMP/EPFL
+ * @author  Paul Phillips
+ */
+package scala
+package reflect.internal
+
+/** A slightly more principled way of propagating information about
+ *  compiler crashes. When abort is called, the message is wrapped up with
+ *  a stack trace to be propagated upward. A compile run is wrapped at
+ *  the only entry point to "Run", where this can be caught, unwrapped,
+ *  and reported (or not) as appropriate.
+ */
+final case class CompileRunAborted(msg: String, caught: Throwable) extends Exception(msg, caught) { }

--- a/src/reflect/scala/reflect/internal/FatalError.scala
+++ b/src/reflect/scala/reflect/internal/FatalError.scala
@@ -4,4 +4,5 @@
  */
 package scala
 package reflect.internal
-case class FatalError(msg: String) extends Exception(msg)
+
+case class FatalError(msg: String) extends Exception(msg) { }

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -50,7 +50,9 @@ abstract class SymbolTable extends macros.Universe
   def warning(msg: String): Unit     = Console.err.println(msg)
   def inform(msg: String): Unit      = Console.err.println(msg)
   def globalError(msg: String): Unit = abort(msg)
-  def abort(msg: String): Nothing    = throw new FatalError(supplementErrorMessage(msg))
+
+  def abort(msg: String): Nothing                    = abort(msg, new FatalError(msg))
+  def abort(msg: String, caught: Throwable): Nothing = throw new CompileRunAborted(msg, caught)
 
   def shouldLogAtThisPhase = false
   def isPastTyper = false
@@ -68,9 +70,6 @@ abstract class SymbolTable extends macros.Universe
 
   /** Prints a stack trace if -Ydebug or equivalent was given, otherwise does nothing. */
   def debugStack(t: Throwable): Unit  = devWarning(throwableAsString(t))
-
-  /** Overridden when we know more about what was happening during a failure. */
-  def supplementErrorMessage(msg: String): String = msg
 
   private[scala] def printCaller[T](msg: String)(result: T) = {
     Console.err.println("%s: %s\nCalled from: %s".format(msg, result,


### PR DESCRIPTION
Crashes now unroll more like this:

// SI-7406
class Arne[@specialized(Int) T](x: T) { lazy val y = x }

% scalac a.scala
error: assertion failed: Arne$mcI$sp.this.$asInstanceOf[Int.type]().unbox

  at scala.tools.nsc.ast.TreeGen.mkCast(TreeGen.scala:146)
  at scala.tools.nsc.Global$gen$.mkAttributedCast(Global.scala:106)
  at scala.tools.nsc.transform.Erasure$Eraser.cast(Erasure.scala:636)
  at scala.tools.nsc.transform.Erasure$Eraser.scala$tools$nsc$transform$Erasure$Eraser$$adaptToType(Erasure.scala:665)
  at scala.tools.nsc.transform.Erasure$Eraser.adapt(Erasure.scala:765)
  at scala.tools.nsc.typechecker.Typers$Typer.runTyper$1(Typers.scala:5345)
  at scala.tools.nsc.typechecker.Typers$Typer.scala$tools$nsc$typechecker$Typers$Typer$$typedInternal(Typers.scala:5358)
  at scala.tools.nsc.typechecker.Typers$Typer.body$3(Typers.scala:5305)
  at scala.tools.nsc.typechecker.Typers$Typer.typed(Typers.scala:5310)
  at scala.tools.nsc.typechecker.Typers$Typer$$anonfun$60.apply(Typers.scala:3021)

```
 while compiling: a.scala
    during phase: mixin
 library version: version 2.11.0-20130608-020907-869ebd8bf2
compiler version: version 2.11.0-20130608-041104-feb660ccd7
```

one error found
