### PR TITLE
SI-7704 Fix partest's test category selection

### DIFF
--- a/src/compiler/scala/tools/cmd/CommandLine.scala
+++ b/src/compiler/scala/tools/cmd/CommandLine.scala
@@ -30,7 +30,7 @@ class CommandLine(val spec: Reference, val originalArgs: List[String]) extends C
   /** argMap is option -> argument (or "" if it is a unary argument)
    *  residualArgs are what is left after removing the options and their args.
    */
-  lazy val (argMap, residualArgs) = {
+  lazy val (argMap, residualArgs): (Map[String, String], List[String]) = {
     val residualBuffer = new ListBuffer[String]
 
     def loop(args: List[String]): Map[String, String] = {

--- a/src/compiler/scala/tools/cmd/CommandLine.scala
+++ b/src/compiler/scala/tools/cmd/CommandLine.scala
@@ -24,7 +24,7 @@ class CommandLine(val spec: Reference, val originalArgs: List[String]) extends C
   val Terminator = "--"
   val ValueForUnaryOption = "true"  // so if --opt is given, x(--opt) = true
 
-  def mapForUnary(opt: String) = Map(opt -> ValueForUnaryOption)
+  def mapForUnary(opt: String) = Map(fromOpt(opt) -> ValueForUnaryOption)
   def errorFn(msg: String) = println(msg)
 
   /** argMap is option -> argument (or "" if it is a unary argument)
@@ -72,7 +72,7 @@ class CommandLine(val spec: Reference, val originalArgs: List[String]) extends C
 
           if (x2 == Terminator)         mapForUnary(x1) ++ residual(xs)
           else if (isUnaryOption(x1))   mapForUnary(x1) ++ loop(args.tail)
-          else if (isBinaryOption(x1))  Map(x1 -> x2) ++ loop(xs)
+          else if (isBinaryOption(x1))  Map(fromOpt(x1) -> x2) ++ loop(xs)
           else if (isUnknown(x1))       loop(args.tail)
           else                          residual(List(x1)) ++ loop(args.tail)
       }

--- a/src/compiler/scala/tools/cmd/Opt.scala
+++ b/src/compiler/scala/tools/cmd/Opt.scala
@@ -26,7 +26,7 @@ object Opt {
   trait Implicit {
     def name: String
     def programInfo: Info
-    protected def opt = toOpt(name)
+    protected def opt = fromOpt(name)
 
     def --? : Boolean                       // --opt is set
     def --> (body: => Unit): Unit           // if --opt is set, execute body

--- a/src/compiler/scala/tools/cmd/Opt.scala
+++ b/src/compiler/scala/tools/cmd/Opt.scala
@@ -29,7 +29,7 @@ object Opt {
     protected def opt = fromOpt(name)
 
     def --? : Boolean                       // --opt is set
-    def --> (body: => Unit): Unit           // if --opt is set, execute body
+    def --> (body: => Unit): Boolean        // if --opt is set, execute body
     def --| : Option[String]                // --opt <arg: String> is optional, result is Option[String]
     def --^[T: FromString] : Option[T]      // --opt <arg: T> is optional, result is Option[T]
 
@@ -51,7 +51,7 @@ object Opt {
     import options._
 
     def --?                             = { addUnary(opt) ; false }
-    def --> (body: => Unit)             = { addUnary(opt) }
+    def --> (body: => Unit)             = { addUnary(opt) ; false }
     def --|                             = { addBinary(opt) ; None }
     def --^[T: FromString]              = { addBinary(opt) ; None }
 
@@ -65,7 +65,7 @@ object Opt {
 
   class Instance(val programInfo: Info, val parsed: CommandLine, val name: String) extends Implicit with Error {
     def --?                             = parsed isSet opt
-    def --> (body: => Unit)             = if (parsed isSet opt) body
+    def --> (body: => Unit)             = { val isSet = parsed isSet opt ; if (isSet) body ; isSet }
     def --|                             = parsed get opt
     def --^[T: FromString]              = {
       val fs = implicitly[FromString[T]]

--- a/src/compiler/scala/tools/cmd/Reference.scala
+++ b/src/compiler/scala/tools/cmd/Reference.scala
@@ -23,9 +23,9 @@ trait Reference extends Spec {
   def helpMsg     = options.helpMsg
   def propertyArgs: List[String] = Nil
 
-  def isUnaryOption(s: String)  = unary contains toOpt(s)
-  def isBinaryOption(s: String) = binary contains toOpt(s)
-  def isExpandOption(s: String) = expansionMap contains toOpt(s)
+  def isUnaryOption(s: String)  = unary contains fromOpt(s)
+  def isBinaryOption(s: String) = binary contains fromOpt(s)
+  def isExpandOption(s: String) = expansionMap contains fromOpt(s)
 
   def expandArg(arg: String)      = expansionMap.getOrElse(fromOpt(arg), List(arg))
 

--- a/src/compiler/scala/tools/cmd/Reference.scala
+++ b/src/compiler/scala/tools/cmd/Reference.scala
@@ -27,9 +27,9 @@ trait Reference extends Spec {
   def isBinaryOption(s: String) = binary contains fromOpt(s)
   def isExpandOption(s: String) = expansionMap contains fromOpt(s)
 
-  def expandArg(arg: String)      = expansionMap.getOrElse(fromOpt(arg), List(arg))
+  def expandArg(arg: String): List[String] = expansionMap.getOrElse(fromOpt(arg), List(arg))
 
-  protected def help(str: => String)        = addHelp(() => str)
+  protected def help(str: => String): Unit = addHelp(() => str)
 
   type ThisCommandLine <: CommandLine
 
@@ -53,20 +53,20 @@ object Reference {
     def helpFormatStr     = "    %-" + longestArg + "s %s"
     def defaultFormatStr  = (" " * (longestArg + 7)) + "%s"
 
-    def addUnary(s: String)   = _unary +:= s
-    def addBinary(s: String)  = _binary +:= s
+    def addUnary(s: String): Unit  = _unary +:= s
+    def addBinary(s: String): Unit = _binary +:= s
 
     def addExpand(opt: String, expanded: List[String]) =
       _expand += (opt -> expanded)
 
-    def mapHelp(g: String => String) = {
+    def mapHelp(g: String => String): Unit = {
       val idx = _help.length - 1
       val f = _help(idx)
 
       _help(idx) = () => g(f())
     }
 
-    def addHelp(f: () => String)      = _help += f
+    def addHelp(f: () => String): Unit = _help += f
     def addHelpAlias(f: () => String) = mapHelp { s =>
       val str = "alias for '%s'" format f()
       def noHelp = (helpFormatStr.format("", "")).length == s.length
@@ -74,13 +74,13 @@ object Reference {
 
       s + str2
     }
-    def addHelpDefault(f: () => String) = mapHelp { s =>
+    def addHelpDefault(f: () => String): Unit = mapHelp { s =>
       val str = "(default: %s)" format f()
 
       if (s.length + str.length < MaxLine) s + " " + str
       else defaultFormatStr.format(s, str)
     }
-    def addHelpEnvDefault(name: String) = mapHelp { s =>
+    def addHelpEnvDefault(name: String): Unit = mapHelp { s =>
       val line1     = "%s (default: %s)".format(s, name)
       val envNow    = envOrNone(name) map ("'" + _ + "'") getOrElse "unset"
       val line2     = defaultFormatStr.format("Currently " + envNow)

--- a/src/compiler/scala/tools/cmd/package.scala
+++ b/src/compiler/scala/tools/cmd/package.scala
@@ -13,19 +13,19 @@ package object cmd {
   implicit def implicitConversions = scala.language.implicitConversions
   implicit def postfixOps = scala.language.postfixOps
 
-  private[cmd] def debug(msg: String) = println(msg)
+  private[cmd] def debug(msg: String): Unit = println(msg)
 
   def runAndExit(body: => Unit): Nothing = {
     body
     sys.exit(0)
   }
 
-  def toOpt(s: String)              = if (s startsWith "--") s else "--" + s
-  def fromOpt(s: String)            = s stripPrefix "--"
-  def toArgs(line: String)          = CommandLineParser tokenize line
-  def fromArgs(args: List[String])  = args mkString " "
+  def toOpt(s: String): String             = if (s startsWith "--") s else "--" + s
+  def fromOpt(s: String): String           = s stripPrefix "--"
+  def toArgs(line: String): List[String]   = CommandLineParser tokenize line
+  def fromArgs(args: List[String]): String = args mkString " "
 
-  def stripQuotes(s: String) = {
+  def stripQuotes(s: String): String = {
     def isQuotedBy(c: Char) = s.length > 0 && s.head == c && s.last == c
     if (List('"', '\'') exists isQuotedBy) s.tail.init else s
   }

--- a/src/partest/scala/tools/partest/nest/ConsoleRunner.scala
+++ b/src/partest/scala/tools/partest/nest/ConsoleRunner.scala
@@ -89,11 +89,6 @@ class ConsoleRunner(argstr: String) extends {
   }
 
   def run(): Unit = {
-    if (optDebug) NestUI.setDebug()
-    if (optVerbose) NestUI.setVerbose()
-    if (optTerse) NestUI.setTerse()
-    if (optShowDiff) NestUI.setDiffOnFail()
-
     // Early return on no args, version, or invalid args
     if (optVersion) return echo(versionMsg)
     if ((argstr == "") || optHelp) return NestUI.usage()
@@ -212,7 +207,7 @@ class ConsoleRunner(argstr: String) extends {
     issueSummaryReport()
     System exit ( if (isSuccess) 0 else 1 )
   }
-  
+
   run()
 }
 

--- a/src/partest/scala/tools/partest/nest/ConsoleRunnerSpec.scala
+++ b/src/partest/scala/tools/partest/nest/ConsoleRunnerSpec.scala
@@ -36,11 +36,11 @@ trait ConsoleRunnerSpec extends Spec with Meta.StdOpts with Interpolation {
   val optSourcePath   = "srcpath"      / "set (relative) path to test source files (ex.: --srcpath pending)"              --|
 
   heading("Test output options:")
-  val optShowDiff     = "show-diff"    / "show diffs for failed tests"       --?
-  val optVerbose      = "verbose"      / "show verbose progress information" --?
-  val optTerse        = "terse"        / "show terse progress information"   --?
-  val optDebug        = "debug"        / "enable debugging output"           --?
-  
+  val optShowDiff     = "show-diff"    / "show diffs for failed tests"       --> NestUI.setDiffOnFail()
+  val optVerbose      = "verbose"      / "show verbose progress information" --> NestUI.setVerbose()
+  val optTerse        = "terse"        / "show terse progress information"   --> NestUI.setTerse()
+  val optDebug        = "debug"        / "enable debugging output"           --> NestUI.setDebug()
+
   heading("Other options:")
   val optVersion      = "version"      / "show Scala version and exit"  --?
   val optSelfTest     = "self-test"    / "run tests for partest itself" --?

--- a/src/partest/scala/tools/partest/nest/NestUI.scala
+++ b/src/partest/scala/tools/partest/nest/NestUI.scala
@@ -28,7 +28,6 @@ class Colors(enabled: => Boolean) {
 object NestUI {
   private val testNum = new java.util.concurrent.atomic.AtomicInteger(1)
   @volatile private var testNumberFmt = "%3d"
-  // @volatile private var testNumber = 1
   private def testNumber = testNumberFmt format testNum.getAndIncrement()
   def resetTestNumber(max: Int = -1) {
     testNum set 1


### PR DESCRIPTION
My recent changes to command line parsing in 609070953c broke partest's
functionality of picking test categories (e. g. --pos or --run).

The breakage was caused because scala.tools.cmd._ stored the command
line options with the `--` prefix, but TestKinds.standardKinds did not.
