### PR TITLE
SI-7747 Making scala repl's class generation customizable

### DIFF
--- a/src/partest/scala/tools/partest/ReplClassBasedWrappers.scala
+++ b/src/partest/scala/tools/partest/ReplClassBasedWrappers.scala
@@ -1,0 +1,75 @@
+/* NSC -- new Scala compiler
+ * Copyright 2005-2013 LAMP/EPFL
+ * @author Prashant Sharma
+ */
+
+package scala.tools.partest
+
+import scala.tools.nsc.interpreter._
+
+/**
+ * This changes the standard wrapper generation strategy to generate classes as wrappers instead of objects
+ */
+class ReplClassBasedWrappers extends ReplAdvancedConfig {
+
+  override def isModule = false
+
+  override def codeWrapper(impname: String, code: StringBuilder) = code append "class %sC extends Serializable {\n".format(impname)
+
+  override def trailBracesWrapper(impname: String, trailingBraces: StringBuilder) = trailingBraces append "}\nval " + impname + " = new " + impname + "C;\n"
+
+  override def accessPathWrapper (impname: String , accessPath: StringBuilder) = accessPath append ("." + impname)
+
+  //Code before and after import wrapper
+  override def codeIWrapper(req: IMain#Request, x: MemberHandlers#MemberHandler, code: StringBuilder, symName: String) = {
+    val objName = req.lineRep.readPath
+    val valName = "$VAL" + newValId();
+    if(!code.toString.endsWith(".`" + symName + "`;\n")) { // Which means already imported
+      code.append("val " + valName + " = " + objName + ".INSTANCE;\n")
+      code.append("import " + valName + req.accessPath + ".`" + symName + "`;\n")
+    }
+    code
+  }
+
+  override def removeExtraUserWrappers(s: String)  = (s.replaceAll("""\$(iw|iwC|read|eval|print)[$.]""", "")).replaceAll("""\$VAL[0-9]+[$.]""", "")
+
+  override def preambleObjSrcCode(lineRep: IMain#ReadEvalPrint, envLines: String, importsPreamble: String, toCompute: String ): String = """
+  |class %s extends Serializable {
+  | %s%s%s
+  """.stripMargin.format(lineRep.readName, envLines, importsPreamble, toCompute)
+
+
+  override def postambleObjSrcCode(lineRep: IMain#ReadEvalPrint, importsTrailer: String ): String = {
+    importsTrailer + "\n}" + "\n" +
+    "object " + lineRep.readName + " {\n" +
+    "  val INSTANCE = new " + lineRep.readName + "();\n" +
+    "}\n"
+  }
+
+ override def preambleResObjSrcCode(lineRep: IMain#ReadEvalPrint, evalResult: String, executionWrapper: String, accessPath: String): String = """
+      |object %s {
+      |  %s
+      |  lazy val %s: String = %s {
+      |    %s
+      |    (""
+      """.stripMargin.format(
+        lineRep.evalName, evalResult, lineRep.printName,
+        executionWrapper, lineRep.readName + ".INSTANCE" + accessPath
+      )
+
+  override def fullPath(lineRep: IMain#ReadEvalPrint, accessPath: String, vname: String) = {
+    s"${lineRep.readPath}.INSTANCE$accessPath.`$vname`"
+  }
+
+  override def originalPathExtended(path: String): String  =  {
+    path.replaceFirst("read","read.INSTANCE").replaceAll("iwC","iw")
+  }
+
+  private var curValId = 0
+
+  private def newValId(): Int = {
+    curValId += 1
+    curValId
+  }
+
+}

--- a/src/partest/scala/tools/partest/ReplTest.scala
+++ b/src/partest/scala/tools/partest/ReplTest.scala
@@ -31,6 +31,17 @@ abstract class ReplTest extends DirectTest {
   def show() = eval() foreach println
 }
 
+/** For testing repl code with class based wrappers. It drops the first line
+ *  of output because the real repl prints a version number.
+ */
+abstract class ReplClassBasedWrappersTest extends ReplTest {
+  override def eval() = {
+    val s = settings
+    log("eval(): settings = " + s)
+    ILoop.runForTranscript(code, s, new ReplClassBasedWrappers).lines drop 1
+  }
+}
+
 abstract class SessionTest extends ReplTest with FileUtil {
   def session: String
   override final def code = expected filter (_.startsWith(prompt)) map (_.drop(prompt.length)) mkString "\n"

--- a/src/repl/scala/tools/nsc/MainGenericRunner.scala
+++ b/src/repl/scala/tools/nsc/MainGenericRunner.scala
@@ -78,7 +78,7 @@ class MainGenericRunner {
         Right(false)
       case _  =>
         // We start the repl when no arguments are given.
-        Right(new interpreter.ILoop process settings)
+        Right(new interpreter.ILoop process(settings, new interpreter.ReplAdvancedConfig))
     }
 
     /** If -e and -i were both given, we want to execute the -e code after the

--- a/src/repl/scala/tools/nsc/interpreter/Imports.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Imports.scala
@@ -131,11 +131,12 @@ trait Imports {
     // add code for a new object to hold some imports
     def addWrapper() {
       val impname = nme.INTERPRETER_IMPORT_WRAPPER
-      code append "object %s {\n".format(impname)
-      trailingBraces append "}\n"
-      accessPath append ("." + impname)
+      advancedConfig.codeWrapper(impname, code)
+      advancedConfig.trailBracesWrapper(impname, trailingBraces)
+      advancedConfig.accessPathWrapper(impname, accessPath)
       currentImps.clear()
     }
+
     def maybeWrap(names: Name*) = if (names exists currentImps) addWrapper()
     def wrapBeforeAndAfter[T](op: => T): T = {
       addWrapper()
@@ -163,7 +164,7 @@ trait Imports {
           case x =>
             for (sym <- x.definedSymbols) {
               maybeWrap(sym.name)
-              code append s"import ${x.path}\n"
+              advancedConfig.codeIWrapper(req, x, code, sym.name.toString)
               currentImps += sym.name
             }
         }

--- a/src/repl/scala/tools/nsc/interpreter/JLineCompletion.scala
+++ b/src/repl/scala/tools/nsc/interpreter/JLineCompletion.scala
@@ -12,7 +12,7 @@ import scala.reflect.internal.util.StringOps.longestCommonPrefix
 
 // REPL completor - queries supplied interpreter for valid
 // completions based on current contents of buffer.
-class JLineCompletion(val intp: IMain) extends Completion with CompletionOutput {
+class JLineCompletion(val intp: IMain, advancedConfig : ReplAdvancedConfig = new ReplAdvancedConfig) extends Completion with CompletionOutput {
   val global: intp.global.type = intp.global
   import global._
   import definitions._
@@ -106,7 +106,7 @@ class JLineCompletion(val intp: IMain) extends Completion with CompletionOutput 
     def excludeNames: List[String] = (anyref.methodNames filterNot anyRefMethodsToShow) :+ "_root_"
 
     def methodSignatureString(sym: Symbol) = {
-      IMain stripString exitingTyper(new MethodSymbolOutput(sym).methodString())
+      advancedConfig.removeExtraUserWrappers(IMain stripString exitingTyper(new MethodSymbolOutput(sym).methodString()))
     }
 
     def exclude(name: String): Boolean = (

--- a/src/repl/scala/tools/nsc/interpreter/ReplAdvancedConfig.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplAdvancedConfig.scala
@@ -1,0 +1,56 @@
+/* NSC -- new Scala compiler
+ * Copyright 2005-2013 LAMP/EPFL
+ * @author Prashant Sharma
+ */
+
+package scala
+package tools.nsc
+package interpreter
+
+class ReplAdvancedConfig {
+
+  /** To tell repl that we are generating wrappper code with object and not classes */
+  def isModule = true
+
+  def codeWrapper(impname: String, code: StringBuilder) = code append "object %s {\n".format(impname)
+
+  def trailBracesWrapper(impname: String, trailingBraces: StringBuilder) = trailingBraces append "}\n"
+
+  def accessPathWrapper (impname: String , accessPath: StringBuilder) = accessPath append ("." + impname)
+
+  //Code before and after import wrapper
+  def codeIWrapper(req: IMain#Request, x: MemberHandlers#MemberHandler, code: StringBuilder, symName: String) = {
+    code append s"import ${x.path}\n"}
+
+  val welcomeMessage: String = ""
+
+  def removeExtraUserWrappers(s: String)  = s
+
+  def preambleObjSrcCode(lineRep: IMain#ReadEvalPrint, envLines: String, importsPreamble: String, toCompute: String ): String = """
+  |object %s {
+  |%s%s%s
+  """.stripMargin.format(lineRep.readName, envLines, importsPreamble, toCompute)
+
+  def preambleResObjSrcCode(lineRep: IMain#ReadEvalPrint, evalResult: String, executionWrapper: String, accessPath: String): String = """
+      |object %s {
+      |  %s
+      |  lazy val %s: String = %s {
+      |    %s
+      |    (""
+      """.stripMargin.format(
+        lineRep.evalName, evalResult, lineRep.printName,
+        executionWrapper, lineRep.readName + accessPath
+      )
+
+  def postambleObjSrcCode(lineRep: IMain#ReadEvalPrint, importsTrailer: String): String = importsTrailer + "\n}"
+
+  def postambleResObjSrcCode(lineRep: IMain#ReadEvalPrint, evalResult: String, executionWrapper: String, accessPath: String): String = """
+      |    )
+      |  }
+      |}
+      """.stripMargin
+
+  def fullPath(lineRep: IMain#ReadEvalPrint, accessPath: String, vname: String) = s"${lineRep.readPath}$accessPath.`$vname`"
+
+  def originalPathExtended(path: String): String  = path
+}

--- a/test/files/run/t7747-repl.check
+++ b/test/files/run/t7747-repl.check
@@ -1,0 +1,249 @@
+Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> 
+
+scala> var x = 10
+x: Int = 10
+
+scala> var y = 11
+y: Int = 11
+
+scala> x = 12
+x: Int = 12
+
+scala> y = 13
+y: Int = 13
+
+scala> val z = x * y
+z: Int = 156
+
+scala> 2 ; 3
+<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+              2 ;;
+              ^
+res0: Int = 3
+
+scala> { 2 ; 3 }
+<console>:8: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+              { 2 ; 3 }
+                ^
+res1: Int = 3
+
+scala> 5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+  1 +
+  2 +
+  3 } ; bippy+88+11
+<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+              5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+              ^
+<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+              5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+                  ^
+<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+              5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+                                         ^
+<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+              5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+                                                                                                ^
+defined object Cow
+defined class Moo
+bippy: Int
+res2: Int = 105
+
+scala> 
+
+scala> object Bovine { var x: List[_] = null } ; case class Ruminant(x: Int) ; bippy * bippy * bippy
+defined object Bovine
+defined class Ruminant
+res3: Int = 216
+
+scala> Bovine.x = List(Ruminant(5), Cow, new Moo)
+Bovine.x: List[Any] = List(Ruminant(5), Cow, Moooooo)
+
+scala> Bovine.x
+res4: List[Any] = List(Ruminant(5), Cow, Moooooo)
+
+scala> 
+
+scala> (2)
+res5: Int = 2
+
+scala> (2 + 2)
+res6: Int = 4
+
+scala> ((2 + 2))
+res7: Int = 4
+
+scala>   ((2 + 2))
+res8: Int = 4
+
+scala>   (  (2 + 2))
+res9: Int = 4
+
+scala>   (  (2 + 2 )  )
+res10: Int = 4
+
+scala> 5 ;   (  (2 + 2 )  ) ; ((5))
+<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+              5 ;   (  (2 + 2 )  ) ;;
+              ^
+<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+              5 ;   (  (2 + 2 )  ) ;;
+                          ^
+res11: Int = 5
+
+scala> (((2 + 2)), ((2 + 2)))
+res12: (Int, Int) = (4,4)
+
+scala> (((2 + 2)), ((2 + 2)), 2)
+res13: (Int, Int, Int) = (4,4,2)
+
+scala> (((((2 + 2)), ((2 + 2)), 2).productIterator ++ Iterator(3)).mkString)
+res14: String = 4423
+
+scala> 
+
+scala> 55 ; ((2 + 2)) ; (1, 2, 3)
+<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+              55 ; ((2 + 2)) ;;
+              ^
+<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+              55 ; ((2 + 2)) ;;
+                       ^
+res15: (Int, Int, Int) = (1,2,3)
+
+scala> 55 ; (x: Int) => x + 1 ; () => ((5))
+<console>:9: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+              55 ; (x: Int) => x + 1 ;;
+              ^
+res16: () => Int = <function0>
+
+scala> 
+
+scala> () => 5
+res17: () => Int = <function0>
+
+scala> 55 ; () => 5
+<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+              55 ;;
+              ^
+res18: () => Int = <function0>
+
+scala> () => { class X ; new X }
+res19: () => AnyRef = <function0>
+
+scala> 
+
+scala> def foo(x: Int)(y: Int)(z: Int) = x+y+z
+foo: (x: Int)(y: Int)(z: Int)Int
+
+scala> foo(5)(10)(15)+foo(5)(10)(15)
+res20: Int = 60
+
+scala> 
+
+scala> List(1) ++ List('a')
+res21: List[AnyVal] = List(1, a)
+
+scala> 
+
+scala> 1 to 100 map (_  + 1)
+res22: scala.collection.immutable.IndexedSeq[Int] = Vector(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101)
+
+scala> val x1 = 1
+x1: Int = 1
+
+scala> val x2 = 2
+x2: Int = 2
+
+scala> val x3 = 3
+x3: Int = 3
+
+scala> case class BippyBungus()
+defined class BippyBungus
+
+scala> x1 + x2 + x3
+res23: Int = 6
+
+scala> :reset
+Resetting interpreter state.
+Forgetting this session history:
+
+var x = 10
+var y = 11
+x = 12
+y = 13
+val z = x * y
+2 ; 3
+{ 2 ; 3 }
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+  1 +
+  2 +
+  3 } ; bippy+88+11
+object Bovine { var x: List[_] = null } ; case class Ruminant(x: Int) ; bippy * bippy * bippy
+Bovine.x = List(Ruminant(5), Cow, new Moo)
+Bovine.x
+(2)
+(2 + 2)
+((2 + 2))
+  ((2 + 2))
+  (  (2 + 2))
+  (  (2 + 2 )  )
+5 ;   (  (2 + 2 )  ) ; ((5))
+(((2 + 2)), ((2 + 2)))
+(((2 + 2)), ((2 + 2)), 2)
+(((((2 + 2)), ((2 + 2)), 2).productIterator ++ Iterator(3)).mkString)
+55 ; ((2 + 2)) ; (1, 2, 3)
+55 ; (x: Int) => x + 1 ; () => ((5))
+() => 5
+55 ; () => 5
+() => { class X ; new X }
+def foo(x: Int)(y: Int)(z: Int) = x+y+z
+foo(5)(10)(15)+foo(5)(10)(15)
+List(1) ++ List('a')
+1 to 100 map (_  + 1)
+val x1 = 1
+val x2 = 2
+val x3 = 3
+case class BippyBungus()
+x1 + x2 + x3
+
+Forgetting all expression results and named terms: $intp, BippyBungus, Bovine, Cow, Ruminant, bippy, foo, x, x1, x2, x3, y, z
+Forgetting defined types: BippyBungus, Moo, Ruminant
+
+scala> x1 + x2 + x3
+<console>:8: error: not found: value x1
+              x1 + x2 + x3
+              ^
+
+scala> val x1 = 4
+x1: Int = 4
+
+scala> new BippyBungus
+<console>:8: error: not found: type BippyBungus
+              new BippyBungus
+                  ^
+
+scala> class BippyBungus() { def f = 5 }
+defined class BippyBungus
+
+scala> { new BippyBungus ; x1 }
+res2: Int = 4
+
+scala> object x {class y { case object z } }
+defined object x
+
+scala> case class BippyBups()
+defined class BippyBups
+
+scala> case class PuppyPups()
+defined class PuppyPups
+
+scala> case class Bingo()
+defined class Bingo
+
+scala> List(BippyBups(), PuppyPups(), Bingo())
+res3: List[Product with Serializable] = List(BippyBups(), PuppyPups(), Bingo())
+
+scala> 

--- a/test/files/run/t7747-repl/repl-class-based-wrappers.scala
+++ b/test/files/run/t7747-repl/repl-class-based-wrappers.scala
@@ -1,0 +1,62 @@
+import scala.tools.partest.ReplClassBasedWrappersTest
+
+object Test extends ReplClassBasedWrappersTest {
+  def code = """
+    |var x = 10
+    |var y = 11
+    |x = 12
+    |y = 13
+    |val z = x * y
+    |2 ; 3
+    |{ 2 ; 3 }
+    |5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+    |  1 +
+    |  2 +
+    |  3 } ; bippy+88+11
+    |
+    |object Bovine { var x: List[_] = null } ; case class Ruminant(x: Int) ; bippy * bippy * bippy
+    |Bovine.x = List(Ruminant(5), Cow, new Moo)
+    |Bovine.x
+    |
+    |(2)
+    |(2 + 2)
+    |((2 + 2))
+    |  ((2 + 2))
+    |  (  (2 + 2))
+    |  (  (2 + 2 )  )
+    |5 ;   (  (2 + 2 )  ) ; ((5))
+    |(((2 + 2)), ((2 + 2)))
+    |(((2 + 2)), ((2 + 2)), 2)
+    |(((((2 + 2)), ((2 + 2)), 2).productIterator ++ Iterator(3)).mkString)
+    |
+    |55 ; ((2 + 2)) ; (1, 2, 3)
+    |55 ; (x: Int) => x + 1 ; () => ((5))
+    |
+    |() => 5
+    |55 ; () => 5
+    |() => { class X ; new X }
+    |
+    |def foo(x: Int)(y: Int)(z: Int) = x+y+z
+    |foo(5)(10)(15)+foo(5)(10)(15)
+    |
+    |List(1) ++ List('a')
+    |
+    |1 to 100 map (_  + 1)
+    |val x1 = 1
+    |val x2 = 2
+    |val x3 = 3
+    |case class BippyBungus()
+    |x1 + x2 + x3
+    |:reset
+    |x1 + x2 + x3
+    |val x1 = 4
+    |new BippyBungus
+    |class BippyBungus() { def f = 5 }
+    |{ new BippyBungus ; x1 }
+    |object x {class y { case object z } }
+    |case class BippyBups()
+    |case class PuppyPups()
+    |case class Bingo()
+    |List(BippyBups(), PuppyPups(), Bingo())
+    |""".stripMargin
+}


### PR DESCRIPTION
We at spark, have to customize scala repl to support our way of "code wrapping" for input code. The reason we want it that way is spark needs code serializable so that it can be executed on a remote worker.

 I wish it was possible to configure rather than port scala repl code for every scala release migration. This pull request may _only_ present my intention which is, we may not need a complete overhauling of scala REPL to support it and thus there should be a simpler solution to it.  It also has a sample customization which uses `class` instead of `object` for wrapping code to be executed. The sample customization is exactly what we would need for spark i.e. serializable. Actually there is more space for making things in the repl customizable, but then this is just a beginning. This has been done in this particular way only to achieve the goal in minimal code change at expense of elegance. Of course suggestions and reviews comments are welcomed for me being on lurker side trying to step into space that might not be welcoming for its technical depth. 

For Example

``` scala

scala> val a = 10
a: Int = 10

scala> val b = a * 2 // show
class $read extends Serializable {
  def <init>() = {
    super.<init>;
    ()
  };
  class $iwC extends Serializable {
    def <init>() = {
      super.<init>;
      ()
    };
    val $VAL1 = $line3.$read.INSTANCE;
    import $VAL1.$iw.$iw.a;
    class $iwC extends Serializable {
      def <init>() = {
        super.<init>;
        ()
      };
      val b = a * 2
    };
    val $iw = new $iwC.<init>
  };
  val $iw = new $iwC.<init>
}
object $read extends scala.AnyRef {
  def <init>() = {
    super.<init>;
    ()
  };
  val INSTANCE = new $read.<init>
}
b: Int = 20

scala> 

```
