### PR TITLE
SI-7715 Etapolator s"$_"

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1137,32 +1137,65 @@ self =>
       })
     }
 
-    private def interpolatedString(inPattern: Boolean): Tree = atPos(in.offset) {
-      val start = in.offset
-      val interpolator = in.name
-
-      val partsBuf = new ListBuffer[Tree]
-      val exprBuf = new ListBuffer[Tree]
-      in.nextToken()
-      while (in.token == STRINGPART) {
-        partsBuf += literal()
-        exprBuf += (
-          if (inPattern) dropAnyBraces(pattern())
-          else in.token match {
-            case IDENTIFIER => atPos(in.offset)(Ident(ident()))
-            case LBRACE     => expr()
-            case THIS       => in.nextToken(); atPos(in.offset)(This(tpnme.EMPTY))
-            case _          => syntaxErrorOrIncompleteAnd("error in interpolated string: identifier or block expected", skipIt = true)(EmptyTree)
-          }
-        )
+    /** Handle placeholder syntax.
+     *  If evaluating the tree produces placeholders, then make it a function.
+     */
+    private def withPlaceholders(tree: =>Tree): Tree = {
+      val savedPlaceholderParams = placeholderParams
+      placeholderParams = List()
+      var res = tree
+      if (!placeholderParams.isEmpty && !isWildcard(res)) {
+        res = atPos(res.pos)(Function(placeholderParams.reverse, res))
+        placeholderParams = List()
       }
-      if (in.token == STRINGLIT) partsBuf += literal()
+      placeholderParams = placeholderParams ::: savedPlaceholderParams
+      res
+    }
 
-      val t1 = atPos(o2p(start)) { Ident(nme.StringContext) }
-      val t2 = atPos(start) { Apply(t1, partsBuf.toList) }
-      t2 setPos t2.pos.makeTransparent
-      val t3 = Select(t2, interpolator) setPos t2.pos
-      atPos(start) { Apply(t3, exprBuf.toList) }
+    /** Consume a USCORE and create a fresh synthetic placeholder param. */
+    private def freshPlaceholder(isAny: Boolean): Tree = {
+      val start = in.offset
+      val pname = freshName("x$")
+      in.nextToken()
+      val id = atPos(start)(Ident(pname))
+      val param = atPos(id.pos.focus)(gen.mkSyntheticParam(pname.toTermName))
+      if (isAny) param.tpt setType definitions.AnyTpe
+      placeholderParams = param :: placeholderParams
+      id
+    }
+
+    private def interpolatedString(inPattern: Boolean): Tree = {
+      // Like Swiss cheese, with holes
+      def stringCheese: Tree = atPos(in.offset) {
+        val start = in.offset
+        val interpolator = in.name
+
+        val partsBuf = new ListBuffer[Tree]
+        val exprBuf = new ListBuffer[Tree]
+        in.nextToken()
+        while (in.token == STRINGPART) {
+          partsBuf += literal()
+          exprBuf += (
+            if (inPattern) dropAnyBraces(pattern())
+            else in.token match {
+              case IDENTIFIER => atPos(in.offset)(Ident(ident()))
+              case USCORE     => freshPlaceholder(isAny = true) // strinterpolator params are Any* by definition
+              case LBRACE     => expr()
+              case THIS       => in.nextToken(); atPos(in.offset)(This(tpnme.EMPTY))
+              case _          => syntaxErrorOrIncompleteAnd("error in interpolated string: identifier or block expected", skipIt = true)(EmptyTree)
+            }
+          )
+        }
+        if (in.token == STRINGLIT) partsBuf += literal()
+
+        val t1 = atPos(o2p(start)) { Ident(nme.StringContext) }
+        val t2 = atPos(start) { Apply(t1, partsBuf.toList) }
+        t2 setPos t2.pos.makeTransparent
+        val t3 = Select(t2, interpolator) setPos t2.pos
+        atPos(start) { Apply(t3, exprBuf.toList) }
+      }
+      if (inPattern) stringCheese
+      else withPlaceholders(stringCheese)
     }
 
 /* ------------- NEW LINES ------------------------------------------------- */
@@ -1260,18 +1293,7 @@ self =>
      */
     def expr(): Tree = expr(Local)
 
-    def expr(location: Int): Tree = {
-      val savedPlaceholderParams = placeholderParams
-      placeholderParams = List()
-      var res = expr0(location)
-      if (!placeholderParams.isEmpty && !isWildcard(res)) {
-        res = atPos(res.pos){ Function(placeholderParams.reverse, res) }
-        placeholderParams = List()
-      }
-      placeholderParams = placeholderParams ::: savedPlaceholderParams
-      res
-    }
-
+    def expr(location: Int): Tree = withPlaceholders(expr0(location))
 
     def expr0(location: Int): Tree = (in.token: @scala.annotation.switch) match {
       case IF =>
@@ -1520,13 +1542,7 @@ self =>
           case IDENTIFIER | BACKQUOTED_IDENT | THIS | SUPER =>
             path(thisOK = true, typeOK = false)
           case USCORE =>
-            val start = in.offset
-            val pname = freshName("x$")
-            in.nextToken()
-            val id = atPos(start) (Ident(pname))
-            val param = atPos(id.pos.focus){ gen.mkSyntheticParam(pname.toTermName) }
-            placeholderParams = param :: placeholderParams
-            id
+            freshPlaceholder(isAny = false)
           case LPAREN =>
             atPos(in.offset)(makeParens(commaSeparated(expr())))
           case LBRACE =>

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -741,6 +741,10 @@ trait Scanners extends ScannersCommon {
           finishStringPart()
           nextRawChar()
           next.token = LBRACE
+        } else if (ch == '_') {
+          finishStringPart()
+          nextRawChar()
+          next.token = USCORE
         } else if (Character.isUnicodeIdentifierStart(ch)) {
           finishStringPart()
           do {

--- a/src/compiler/scala/tools/reflect/MacroImplementations.scala
+++ b/src/compiler/scala/tools/reflect/MacroImplementations.scala
@@ -94,7 +94,8 @@ abstract class MacroImplementations {
       def errorAtIndex(idx: Int, msg: String) = c.error(new OffsetPosition(strTree.pos.source, strTree.pos.point + idx), msg)
       def wrongConversionString(idx: Int) = errorAtIndex(idx, "wrong conversion string")
       def illegalConversionCharacter(idx: Int) = errorAtIndex(idx, "illegal conversion character")
-      def nonEscapedPercent(idx: Int) = errorAtIndex(idx, "percent signs not directly following splicees must be escaped")
+      def nonEscapedPercent(idx: Int) = errorAtIndex(idx,
+        "conversions must follow a splice; use %% for literal %, %n for newline")
 
       // STEP 1: handle argument conversion
       // 1) "...${smth}" => okay, equivalent to "...${smth}%s"

--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -59,7 +59,8 @@ case class StringContext(parts: String*) {
    */
   def checkLengths(args: Seq[Any]): Unit =
     if (parts.length != args.length + 1)
-      throw new IllegalArgumentException("wrong number of arguments for interpolated string")
+      throw new IllegalArgumentException("wrong number of arguments ("+ args.length
+        +") for interpolated string with "+ parts.length +" parts")
 
 
   /** The simple string interpolator.

--- a/test/files/neg/t7325.check
+++ b/test/files/neg/t7325.check
@@ -1,19 +1,19 @@
-t7325.scala:2: error: percent signs not directly following splicees must be escaped
+t7325.scala:2: error: conversions must follow a splice; use %% for literal %, %n for newline
   println(f"%")
             ^
-t7325.scala:4: error: percent signs not directly following splicees must be escaped
+t7325.scala:4: error: conversions must follow a splice; use %% for literal %, %n for newline
   println(f"%%%")
               ^
-t7325.scala:6: error: percent signs not directly following splicees must be escaped
+t7325.scala:6: error: conversions must follow a splice; use %% for literal %, %n for newline
   println(f"%%%%%")
                 ^
 t7325.scala:16: error: wrong conversion string
   println(f"${0}%")
                 ^
-t7325.scala:19: error: percent signs not directly following splicees must be escaped
+t7325.scala:19: error: conversions must follow a splice; use %% for literal %, %n for newline
   println(f"${0}%%%d")
                   ^
-t7325.scala:21: error: percent signs not directly following splicees must be escaped
+t7325.scala:21: error: conversions must follow a splice; use %% for literal %, %n for newline
   println(f"${0}%%%%%d")
                     ^
 6 errors found

--- a/test/files/run/interpolation.flags
+++ b/test/files/run/interpolation.flags
@@ -1,1 +1,0 @@
--Xexperimental

--- a/test/files/run/interpolationArgs.check
+++ b/test/files/run/interpolationArgs.check
@@ -1,2 +1,2 @@
-java.lang.IllegalArgumentException: wrong number of arguments for interpolated string
-java.lang.IllegalArgumentException: wrong number of arguments for interpolated string
+java.lang.IllegalArgumentException: wrong number of arguments (1) for interpolated string with 3 parts
+java.lang.IllegalArgumentException: wrong number of arguments (1) for interpolated string with 1 parts

--- a/test/files/run/interpolationArgs.flags
+++ b/test/files/run/interpolationArgs.flags
@@ -1,1 +1,0 @@
--Xexperimental

--- a/test/files/run/interpolationMultiline1.flags
+++ b/test/files/run/interpolationMultiline1.flags
@@ -1,1 +1,0 @@
--Xexperimental

--- a/test/files/run/interpolationMultiline2.flags
+++ b/test/files/run/interpolationMultiline2.flags
@@ -1,1 +1,0 @@
--Xexperimental

--- a/test/files/run/t7715-etapolator.check
+++ b/test/files/run/t7715-etapolator.check
@@ -1,0 +1,28 @@
+On the 1th day of Christmas
+On the 2th day of Christmas
+On the 3th day of Christmas
+On the 4th day of Christmas
+On the 5th day of Christmas
+On the 6th day of Christmas
+On the 7th day of Christmas
+On the 8th day of Christmas
+On the 9th day of Christmas
+On the 10th day of Christmas
+On the 11th day of Christmas
+On the 12th day of Christmas
+true
+1 by 1
+2 by 2
+3 by 3
+4 by 4
+5 by 5
+6 by 6
+7 by 7
+8 by 8
+9 by 9
+10 by 10
+11 by 11
+12 by 12
+6
+4
+4

--- a/test/files/run/t7715-etapolator.scala
+++ b/test/files/run/t7715-etapolator.scala
@@ -1,0 +1,39 @@
+
+import PartialFunction.cond
+import util._
+
+object Test extends App {
+  val days = (1 to 12).toList
+
+  days map s"On the $_th day of Christmas" foreach println
+
+  val rf = (n: Int) => s"\\*{$_}"(n).r
+  def stars(n: Int)(s: String) = {
+    val r = rf(n)
+    cond(s) { case r(_*) => true }
+  }
+  Console println stars(5)("*****")
+
+  days zip days map s"$_ by $_".tupled foreach println
+
+  object I { def unapply(x: String): Option[Int] = Try(x.toInt).toOption }
+  implicit class RX(val sc: StringContext) {
+    object rx {
+      def apply(args: Any*) = sc s (args: _*)
+      def unapplySeq(s: String): Option[Seq[String]] = sc.parts.mkString("(.+)").r.unapplySeq(s)
+    }
+  }
+
+  Console println ("2 by 4" match {
+    case rx"${I(a)} by ${I(b)}" => a+b
+    case _                      => -1
+  })
+  Console println ("2 by 4" match {
+    case rx"${_} by ${I(b)}"    => b    // pattern placeholder
+    case _                      => -1
+  })
+  Console println ("2 by 4" match {
+    case rx"$_ by ${I(b)}"      => b    // is emitted this way, too
+    case _                      => -1
+  })
+}


### PR DESCRIPTION
Allows `vs map s"How many? $_"`.

Or `vs zip vs map s"How many? $_ by $_".tupled`.

And `s"How many? $_ by $_ by $_"("one","two","three")`.

In a pattern,

```
    scala> val rx"$_ by ${I(b)}" = "2 by 4"
    b: Int = 4
```

scala/bug#7715