### PR TITLE
SI-7331 importers now import tree positions

### DIFF
--- a/src/reflect/scala/reflect/internal/Importers.scala
+++ b/src/reflect/scala/reflect/internal/Importers.scala
@@ -443,7 +443,7 @@ trait Importers extends api.Importers { self: SymbolTable =>
         }
       })
       tryFixup()
-      mytree
+      mytree setPos importPosition(tree.pos)
     }
 
     def importValDef(tree: from.ValDef): ValDef = importTree(tree).asInstanceOf[ValDef]

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -968,7 +968,7 @@ trait Trees extends api.Trees { self: SymbolTable =>
   object emptyValDef extends ValDef(Modifiers(PRIVATE), nme.WILDCARD, TypeTree(NoType), EmptyTree) {
     override def isEmpty = true
     super.setPos(NoPosition)
-    override def setPos(pos: Position) = { assert(false); this }
+    override def setPos(pos: Position) = this
   }
 
   def DefDef(sym: Symbol, mods: Modifiers, vparamss: List[List[ValDef]], rhs: Tree): DefDef =

--- a/test/files/run/t7331.check
+++ b/test/files/run/t7331.check
@@ -1,0 +1,2 @@
+source-<toolbox>,line-1,offset=0
+2

--- a/test/t7331.scala
+++ b/test/t7331.scala
@@ -1,0 +1,10 @@
+import scala.reflect.runtime.universe._
+import scala.reflect.runtime.{currentMirror => cm}
+import scala.tools.reflect.ToolBox
+
+object Test extends App {
+  val tb = cm.mkToolBox()
+  val tree = tb.parse("x")
+  println(tree.pos)
+  println(tree.pos.source.content.length)
+}


### PR DESCRIPTION
There was also an issue where because of the wrapper code that the toolbox adds in order to support a wider range of string inputs than the vanilla compiler, it was necessary to adjust the positions associated with the trees generated by the compiler in order to provide a coherent interface to client code.

Furthermore, an assert was removed from emptyValDef in favour of a more lenient implementation that avoids needless guards against emptyValDef in client code.
