### PR TITLE
SI-4829 the :load command now fails if the command ends with a space (Pre-port)

### DIFF
--- a/src/compiler/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/ILoop.scala
@@ -12,7 +12,7 @@ import java.util.concurrent.locks.ReentrantLock
 import scala.sys.process.Process
 import session._
 import scala.util.Properties.{ jdkHome, javaVersion }
-import scala.tools.util.{ Javap }
+import scala.tools.util.Javap
 import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.ops
@@ -25,6 +25,7 @@ import ScalaClassLoader._
 import scala.tools.util._
 import scala.language.{implicitConversions, existentials}
 import scala.reflect.{ClassTag, classTag}
+import scala.reflect.internal.util.StringOps
 import scala.tools.reflect.StdRuntimeTags._
 
 /** The Scala interactive shell.  It provides a read-eval-print loop
@@ -632,16 +633,18 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     }
   }
 
-  def withFile(filename: String)(action: File => Unit) {
-    val f = File(filename)
+  def smartPath(path: String) = if (File(path).exists) path else path.trim
+
+  def withPath(path: String)(action: File => Unit) {
+    val f = File(path)
 
     if (f.exists) action(f)
-    else echo("That file does not exist")
+    else echo(s"The path '$f' doesn't seem to exist.")
   }
 
   def loadCommand(arg: String) = {
     var shouldReplay: Option[String] = None
-    withFile(arg)(f => {
+    withPath(smartPath(arg))(f => {
       interpretAllFrom(f)
       shouldReplay = Some(":load " + arg)
     })
@@ -649,14 +652,12 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
   }
 
   def addClasspath(arg: String): Unit = {
-    val f = File(arg).normalize
-    if (f.exists) {
+    withPath(File(arg).normalize.path)(f => {
       addedClasspath = ClassPath.join(addedClasspath, f.path)
       val totalClasspath = ClassPath.join(settings.classpath.value, addedClasspath)
       echo("Added '%s'.  Your new classpath is:\n\"%s\"".format(f.path, totalClasspath))
       replay()
-    }
-    else echo("The path '" + f + "' doesn't seem to exist.")
+    })
   }
 
   def powerCmd(): Result = {
@@ -692,9 +693,10 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     * if any. */
   def command(line: String): Result = {
     if (line startsWith ":") {
-      val cmd = line.tail takeWhile (x => !x.isWhitespace)
+      val lineNoColon = line.tail
+      val (cmd, arg) = StringOps.splitLeft(lineNoColon, ' ').getOrElse((lineNoColon, ""))
       uniqueCommand(cmd) match {
-        case Some(lc) => lc(line.tail stripPrefix cmd dropWhile (_.isWhitespace))
+        case Some(lc) => lc(arg)
         case _        => ambiguousError(cmd)
       }
     }

--- a/src/reflect/scala/reflect/internal/util/StringOps.scala
+++ b/src/reflect/scala/reflect/internal/util/StringOps.scala
@@ -64,6 +64,11 @@ trait StringOps {
     if (idx == -1) None
     else Some((str take idx, str drop (if (doDropIndex) idx + 1 else idx)))
 
+  def splitLeft(str: String, ch: Char): Option[(String, String)] = {
+    splitAt(str, str.indexOf(ch), true)
+  }
+
+
   /** Returns a string meaning "n elements".
    *
    *  @param n        ...


### PR DESCRIPTION
The :load command now tries to be smart by detecting the presence of trailing spaces that might be insignificant.

On certain file systems, files with trailing whitespaces are permitted which is why we don't naively trim the argument.

Please review @adriaanm
