### PR TITLE
SI-7544 Interpolation message for %% literal 

### DIFF
--- a/src/compiler/scala/tools/reflect/MacroImplementations.scala
+++ b/src/compiler/scala/tools/reflect/MacroImplementations.scala
@@ -94,7 +94,8 @@ abstract class MacroImplementations {
       def errorAtIndex(idx: Int, msg: String) = c.error(new OffsetPosition(strTree.pos.source, strTree.pos.point + idx), msg)
       def wrongConversionString(idx: Int) = errorAtIndex(idx, "wrong conversion string")
       def illegalConversionCharacter(idx: Int) = errorAtIndex(idx, "illegal conversion character")
-      def nonEscapedPercent(idx: Int) = errorAtIndex(idx, "percent signs not directly following splicees must be escaped")
+      def nonEscapedPercent(idx: Int) = errorAtIndex(idx,
+        "conversions must follow a splice; use %% for literal %, %n for newline")
 
       // STEP 1: handle argument conversion
       // 1) "...${smth}" => okay, equivalent to "...${smth}%s"

--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -59,7 +59,8 @@ case class StringContext(parts: String*) {
    */
   def checkLengths(args: Seq[Any]): Unit =
     if (parts.length != args.length + 1)
-      throw new IllegalArgumentException("wrong number of arguments for interpolated string")
+      throw new IllegalArgumentException("wrong number of arguments ("+ args.length
+        +") for interpolated string with "+ parts.length +" parts")
 
 
   /** The simple string interpolator.

--- a/test/files/neg/t7325.check
+++ b/test/files/neg/t7325.check
@@ -1,19 +1,19 @@
-t7325.scala:2: error: percent signs not directly following splicees must be escaped
+t7325.scala:2: error: conversions must follow a splice; use %% for literal %, %n for newline
   println(f"%")
             ^
-t7325.scala:4: error: percent signs not directly following splicees must be escaped
+t7325.scala:4: error: conversions must follow a splice; use %% for literal %, %n for newline
   println(f"%%%")
               ^
-t7325.scala:6: error: percent signs not directly following splicees must be escaped
+t7325.scala:6: error: conversions must follow a splice; use %% for literal %, %n for newline
   println(f"%%%%%")
                 ^
 t7325.scala:16: error: wrong conversion string
   println(f"${0}%")
                 ^
-t7325.scala:19: error: percent signs not directly following splicees must be escaped
+t7325.scala:19: error: conversions must follow a splice; use %% for literal %, %n for newline
   println(f"${0}%%%d")
                   ^
-t7325.scala:21: error: percent signs not directly following splicees must be escaped
+t7325.scala:21: error: conversions must follow a splice; use %% for literal %, %n for newline
   println(f"${0}%%%%%d")
                     ^
 6 errors found

--- a/test/files/run/interpolation.flags
+++ b/test/files/run/interpolation.flags
@@ -1,1 +1,0 @@
--Xexperimental

--- a/test/files/run/interpolationArgs.check
+++ b/test/files/run/interpolationArgs.check
@@ -1,2 +1,2 @@
-java.lang.IllegalArgumentException: wrong number of arguments for interpolated string
-java.lang.IllegalArgumentException: wrong number of arguments for interpolated string
+java.lang.IllegalArgumentException: wrong number of arguments (1) for interpolated string with 3 parts
+java.lang.IllegalArgumentException: wrong number of arguments (1) for interpolated string with 1 parts

--- a/test/files/run/interpolationArgs.flags
+++ b/test/files/run/interpolationArgs.flags
@@ -1,1 +1,0 @@
--Xexperimental

--- a/test/files/run/interpolationMultiline1.flags
+++ b/test/files/run/interpolationMultiline1.flags
@@ -1,1 +1,0 @@
--Xexperimental

--- a/test/files/run/interpolationMultiline2.flags
+++ b/test/files/run/interpolationMultiline2.flags
@@ -1,1 +1,0 @@
--Xexperimental


### PR DESCRIPTION
The new error text: "conversions must follow a splice; use %% for
literal %, %n for newline".

Review by @adriaanm 
