### PR TITLE
SI-7331 tb.parse returns unpositioned trees

### DIFF
--- a/src/reflect/scala/reflect/internal/Importers.scala
+++ b/src/reflect/scala/reflect/internal/Importers.scala
@@ -443,7 +443,12 @@ trait Importers extends api.Importers { self: SymbolTable =>
         }
       })
       tryFixup()
-      mytree
+      // we have to be careful with position import as some shared trees
+      // like EmptyTree, emptyValDef don't support position assignment
+      if (tree.pos != NoPosition)
+        mytree.setPos(importPosition(tree.pos))
+      else
+        mytree
     }
 
     def importValDef(tree: from.ValDef): ValDef = importTree(tree).asInstanceOf[ValDef]

--- a/test/files/run/t7331a.check
+++ b/test/files/run/t7331a.check
@@ -1,0 +1,2 @@
+source-<toolbox>,line-1,offset=0
+2

--- a/test/files/run/t7331a.scala
+++ b/test/files/run/t7331a.scala
@@ -1,0 +1,10 @@
+import scala.reflect.runtime.universe._
+import scala.reflect.runtime.{currentMirror => cm}
+import scala.tools.reflect.ToolBox
+
+object Test extends App {
+  val tb = cm.mkToolBox()
+  val tree = tb.parse("x")
+  println(tree.pos)
+  println(tree.pos.source.content.length)
+}

--- a/test/files/run/t7331b.check
+++ b/test/files/run/t7331b.check
@@ -1,0 +1,3 @@
+reflective compilation has failed: 
+
+')' expected but eof found.

--- a/test/files/run/t7331b.scala
+++ b/test/files/run/t7331b.scala
@@ -1,0 +1,11 @@
+import scala.reflect.runtime.universe._
+import scala.reflect.runtime.{currentMirror => cm}
+import scala.tools.reflect.{ToolBox, ToolBoxError}
+
+object Test extends App {
+  val tb = cm.mkToolBox()
+  try tb.parse("f(x")
+  catch {
+    case ToolBoxError(msg, _) => println(msg)
+  }
+}

--- a/test/files/run/t7331c.check
+++ b/test/files/run/t7331c.check
@@ -1,0 +1,3 @@
+ClassDef(Modifiers(), newTypeName("C"), List(), Template(List(Select(Ident(scala), newTypeName("AnyRef"))), emptyValDef, List(DefDef(Modifiers(), nme.CONSTRUCTOR, List(), List(List()), TypeTree(), Block(List(Apply(Select(Super(This(tpnme.EMPTY), tpnme.EMPTY), nme.CONSTRUCTOR), List())), Literal(Constant(())))))))
+source-<toolbox>,line-1,offset=6
+NoPosition

--- a/test/files/run/t7331c.scala
+++ b/test/files/run/t7331c.scala
@@ -1,0 +1,11 @@
+import scala.reflect.runtime.universe._
+import scala.reflect.runtime.{currentMirror => cm}
+import scala.tools.reflect.ToolBox
+
+object Test extends App {
+  val tb = cm.mkToolBox()
+  val tree = tb.parse("class C").asInstanceOf[ClassDef]
+  println(showRaw(tree))
+  println(tree.pos)
+  println(tree.impl.self.pos)
+}


### PR DESCRIPTION
This pull request gets rid off code wrapping that was previously used by toolbox to get into correct parsing mode. Instead combination of templateStats/accept(EOF) is used. This is the same solution as the one used in repl and built-in scriptRunner

This pull request doesn't attempt to generalize this approach in any way and re-use it all over the place due to the caution of accidental compatibility breakage. I plan to do it separately against master.

Additionally there are a few more changes that make importers be aware of positions and a test for that (via @jedesah).
