### PR TITLE
SI-7729 Does Par-Test work?  Absolutely!

### DIFF
--- a/src/partest/scala/tools/partest/nest/ConsoleRunner.scala
+++ b/src/partest/scala/tools/partest/nest/ConsoleRunner.scala
@@ -138,7 +138,7 @@ class ConsoleRunner(argstr: String) extends {
     val rerunTests = if (isRerun) TestKinds.failedTests else Nil
     def miscTests = partestTests ++ individualTests ++ greppedTests ++ rerunTests
 
-    val givenKinds = standardKinds filter parsed.isSet
+    val givenKinds = standardKinds filter (parsed isSet "--" + _)
     val kinds = (
       if (optAll) standardKinds
       else if (givenKinds.nonEmpty) givenKinds
@@ -197,7 +197,7 @@ class ConsoleRunner(argstr: String) extends {
         val num = paths.size
         val ss = if (num == 1) "" else "s"
         comment(s"starting $num test$ss in $kind")
-        val results = runTestsForFiles(paths map (_.jfile), kind)
+        val results = runTestsForFiles(paths map (_.jfile.getAbsoluteFile), kind)
         val (passed, failed) = results partition (_.isOk)
 
         passedTests ++= passed

--- a/src/partest/scala/tools/partest/nest/FileManager.scala
+++ b/src/partest/scala/tools/partest/nest/FileManager.scala
@@ -148,7 +148,7 @@ trait FileManager extends FileUtil {
         val srcpath = Path(srcdir.path)
         val pd      = (srcpath / plugxml).toFile
         if (pd.exists) pd copyTo (pout / plugxml)
-        pout
+        pout.toAbsolute
       } else Path(p)
     def absolutize(path: String) = pathOrCwd(path) match {
       case x if x.isAbsolute  => x.path

--- a/src/partest/scala/tools/partest/nest/Runner.scala
+++ b/src/partest/scala/tools/partest/nest/Runner.scala
@@ -715,6 +715,9 @@ class Runner(val testFile: File, fileManager: FileManager, val testRunParams: Te
   }
 
   def run(): TestState = {
+    // javac runner, for one, would merely append to an existing log file, so just delete it before we start
+    logFile.delete()
+
     if (kind == "neg" || (kind endsWith "-neg")) runNegTest()
     else kind match {
       case "pos"          => runTestCommon(true)

--- a/src/partest/scala/tools/partest/nest/Runner.scala
+++ b/src/partest/scala/tools/partest/nest/Runner.scala
@@ -270,60 +270,54 @@ class Runner(val testFile: File, fileManager: FileManager, val testRunParams: Te
     false
   }
 
-  /** Filter the diff for conditional blocks.
+  /** Filter the check file for conditional blocks.
    *  The check file can contain lines of the form:
    *  `#partest java7`
    *  where the line contains a conventional flag name.
-   *  In the diff output, these lines have the form:
-   *  `> #partest java7`
-   *  Blocks which don't apply are filtered out,
-   *  and what remains is the desired diff.
-   *  Line edit commands such as `0a1,6` don't count
-   *  as diff, so return a nonempty diff only if
-   *  material diff output was seen.
-   *  Filtering the diff output (instead of every check
-   *  file) means that we only post-process a test that
-   *  might be failing, in the normal case.
+   *  If the flag tests true, succeeding lines are retained
+   *  (removed on false) until the next #partest flag.
+   *  A missing flag evaluates the same as true.
    */
-  def diffilter(d: String) = {
+  def filteredCheck: Seq[String] = {
     import scala.util.Properties.{javaVersion, isAvian}
-    val prefix = "#partest"
-    val margin = "> "
-    val leader = margin + prefix
     // use lines in block so labeled? Default to sorry, Charlie.
-    def retainOn(f: String) = {
+    def retainOn(expr: String) = {
+      val f = expr.trim
+      def flagWasSet(f: String) = fileManager.SCALAC_OPTS contains f
       val (invert, token) =
         if (f startsWith "!") (true, f drop 1) else (false, f)
-      val cond = token match {
+      val cond = token.trim match {
         case "java7"  => javaVersion startsWith "1.7"
         case "java6"  => javaVersion startsWith "1.6"
         case "avian"  => isAvian
         case "true"   => true
-        case _        => false
+        case "-optimise" | "-optimize"
+                      => flagWasSet("-optimise") || flagWasSet("-optimize")
+        case flag if flag startsWith "-"
+                      => flagWasSet(flag)
+        case rest     => rest.isEmpty
       }
       if (invert) !cond else cond
     }
-    if (d contains prefix) {
-      val sb = new StringBuilder
-      var retain = true           // use the current line
-      var material = false        // saw a line of diff
-      for (line <- d.lines)
-        if (line startsWith leader) {
-          val rest = (line stripPrefix leader).trim
-          retain = retainOn(rest)
-        } else if (retain) {
-          if (line startsWith margin) material = true
-          sb ++= line
-          sb ++= EOL
-        }
-      if (material) sb.toString else ""
-    } else d
+    val prefix = "#partest"
+    val b = new ListBuffer[String]()
+    var on = true
+    for (line <- file2String(checkFile).lines) {
+      if (line startsWith prefix) {
+        on = retainOn(line stripPrefix prefix)
+      } else if (on) {
+        b += line
+      }
+    }
+    b.toList
   }
 
-  def currentDiff = (
-    if (checkFile.canRead) diffilter(compareFiles(logFile, checkFile))
-    else compareContents(augmentString(file2String(logFile)).lines.toList, Nil)
-  )
+  def currentDiff = {
+    val logged = augmentString(file2String(logFile)).lines.toList
+    val (other, othername) =
+      if (checkFile.canRead) (filteredCheck, checkFile.getName) else (Nil, "empty")
+    compareContents(logged, other, logFile.getName, othername)
+  }
 
   val gitRunner = List("/usr/local/bin/git", "/usr/bin/git") map (f => new java.io.File(f)) find (_.canRead)
   val gitDiffOptions = "--ignore-space-at-eol --no-index " + propOrEmpty("partest.git_diff_options")

--- a/src/partest/scala/tools/partest/nest/Runner.scala
+++ b/src/partest/scala/tools/partest/nest/Runner.scala
@@ -780,7 +780,7 @@ trait DirectRunner {
     //val parentClassLoader = ScalaClassLoader fromURLs (List(scalaCheck.toURL), getClass().getClassLoader)
     val pool              = Executors newFixedThreadPool numThreads
     val manager           = new RunnerManager(kind, fileManager, TestRunParams(parentClassLoader))
-    val futures           = kindFiles map (f => pool submit callable(manager runTest f))
+    val futures           = kindFiles map (f => pool submit callable(manager runTest f.getAbsoluteFile))
 
     pool.shutdown()
     Try (pool.awaitTermination(waitTime) {

--- a/test/files/run/repl-javap-app.check
+++ b/test/files/run/repl-javap-app.check
@@ -6,14 +6,13 @@ scala> :javap -app MyApp$
 public final void delayedEndpoint$MyApp$1();
   Code:
    Stack=2, Locals=1, Args_size=1
-   0: getstatic   #61; //Field scala/Console$.MODULE$:Lscala/Console$;
-   3: ldc #63; //String Hello, delayed world.
-   5: invokevirtual   #67; //Method scala/Console$.println:(Ljava/lang/Object;)V
-   8: return
+   0:	getstatic	#61; //Field scala/Console$.MODULE$:Lscala/Console$;
+   3:	ldc	#63; //String Hello, delayed world.
+   5:	invokevirtual	#67; //Method scala/Console$.println:(Ljava/lang/Object;)V
+   8:	return
   LocalVariableTable: 
    Start  Length  Slot  Name   Signature
    0      9      0    this       LMyApp$;
-}
 
 scala> 
 #partest !java6

--- a/test/files/run/stream_length.check
+++ b/test/files/run/stream_length.check
@@ -1,6 +1,5 @@
 #partest !avian
 Length: 970299
-
 #partest avian
 !!!TEST SKIPPED!!!
 See SI-7600 for further information.

--- a/test/files/run/tailcalls.check
+++ b/test/files/run/tailcalls.check
@@ -52,7 +52,6 @@ test TailCall.b2 was successful
 test FancyTailCalls.tcTryLocal was successful
 test FancyTailCalls.differentInstance was successful
 test PolyObject.tramp was successful
-
 #partest avian
 test Object .f was successful
 test Final .f was successful

--- a/test/partest
+++ b/test/partest
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 #
-
 ##############################################################################
 # Scala test runner 2.10.0
 ##############################################################################
@@ -10,6 +9,17 @@
 # There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE.
 ##############################################################################
+
+findScalaHome () {
+  # see SI-2092 and SI-5792
+  local source="${BASH_SOURCE[0]}"
+  while [ -h "$source" ] ; do
+    local linked="$(readlink "$source")"
+    local dir="$( cd -P $(dirname "$source") && cd -P $(dirname "$linked") && pwd )"
+    source="$dir/$(basename "$linked")"
+  done
+  ( ( cd -P "$(dirname "$source")/.." > /dev/null ) && pwd )
+}
 
 # Use tput to detect color-capable terminal.
 term_colors=$(tput colors 2>/dev/null)
@@ -29,23 +39,7 @@ case "`uname`" in
 esac
 
 # Finding the root folder for this Scala distribution
-SOURCE=$0;
-SCRIPT=`basename "$SOURCE"`;
-while [ -h "$SOURCE" ]; do
-    SCRIPT=`basename "$SOURCE"`;
-    LOOKUP=`ls -ld "$SOURCE"`;
-    TARGET=`expr "$LOOKUP" : '.*-> \(.*\)$'`;
-    if expr "${TARGET:-.}/" : '/.*/$' > /dev/null; then
-        SOURCE=${TARGET:-.};
-    else
-        SOURCE=`dirname "$SOURCE"`/${TARGET:-.};
-    fi;
-done;
-
-# see #2092
-SCALA_HOME=`dirname "$SOURCE"`
-SCALA_HOME=`cd "$SCALA_HOME"; pwd -P`
-SCALA_HOME=`cd "$SCALA_HOME"/..; pwd`
+SCALA_HOME="$(findScalaHome)"
 
 if $cygwin; then
     SCALA_HOME=`cygpath --windows --short-name "$SCALA_HOME"`


### PR DESCRIPTION
Absolutize paths where possible; cherry-pick the fix for #ifdiff check files; and zap the log file before starting a run.

It also touches the partest script with the new voudou and to cd -P > /dev/null, to ignore the extra echo if CDPATH matches.

Why isn't this a problem with scalac? Presumably I never run it from that location.

In fact,

```
apm@mara:~/projects/snytt$ build/pack/bin/scala
Error: Could not find or load main class .home.apm.projects.snytt.build.pack.lib.diffutils.jar
```

Ha, I don't even know what that means.

My usual aliases have absolute paths.

Almost forgot:

Review by @paulp 
