### PR TITLE
DefDef.name is now TermName again

### DIFF
--- a/src/compiler/scala/reflect/reify/phases/Reshape.scala
+++ b/src/compiler/scala/reflect/reify/phases/Reshape.scala
@@ -256,7 +256,7 @@ trait Reshape {
       val flags1 = (flags0 & GetterFlags) & ~(STABLE | ACCESSOR | METHOD)
       val mods1 = Modifiers(flags1, privateWithin0, annotations0) setPositions mods0.positions
       val mods2 = toPreTyperModifiers(mods1, ddef.symbol)
-      ValDef(mods2, name1.toTermName, tpt0, extractRhs(rhs0))
+      ValDef(mods2, name1, tpt0, extractRhs(rhs0))
     }
 
     private def trimAccessors(deff: Tree, stats: List[Tree]): List[Tree] = {

--- a/src/compiler/scala/tools/nsc/ast/TreeDSL.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeDSL.scala
@@ -187,7 +187,7 @@ trait TreeDSL {
       def vparamss: List[List[ValDef]]
 
       type ResultTreeType = DefDef
-      def mkTree(rhs: Tree): DefDef = DefDef(mods, name, tparams, vparamss, tpt, rhs)
+      def mkTree(rhs: Tree): DefDef = DefDef(mods, name.toTermName, tparams, vparamss, tpt, rhs)
     }
 
     class DefSymStart(val sym: Symbol) extends SymVODDStart with DefCreator {

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2542,7 +2542,7 @@ self =>
             }
             expr()
           }
-        DefDef(newmods, name, tparams, vparamss, restype, rhs)
+        DefDef(newmods, name.toTermName, tparams, vparamss, restype, rhs)
       }
       signalParseProgress(result.pos)
       result

--- a/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
@@ -510,7 +510,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
           if (inInterface) mods1 |= Flags.DEFERRED
           List {
             atPos(pos) {
-              DefDef(mods1, name, tparams, List(vparams), rtpt, body)
+              DefDef(mods1, name.toTermName, tparams, List(vparams), rtpt, body)
             }
           }
         } else {

--- a/src/reflect/scala/reflect/api/Trees.scala
+++ b/src/reflect/scala/reflect/api/Trees.scala
@@ -572,8 +572,8 @@ trait Trees { self: Universe =>
    *  @group Extractors
    */
   abstract class DefDefExtractor {
-    def apply(mods: Modifiers, name: Name, tparams: List[TypeDef], vparamss: List[List[ValDef]], tpt: Tree, rhs: Tree): DefDef
-    def unapply(defDef: DefDef): Option[(Modifiers, Name, List[TypeDef], List[List[ValDef]], Tree, Tree)]
+    def apply(mods: Modifiers, name: TermName, tparams: List[TypeDef], vparamss: List[List[ValDef]], tpt: Tree, rhs: Tree): DefDef
+    def unapply(defDef: DefDef): Option[(Modifiers, TermName, List[TypeDef], List[List[ValDef]], Tree, Tree)]
   }
 
   /** The API that all def defs support
@@ -584,7 +584,7 @@ trait Trees { self: Universe =>
     def mods: Modifiers
 
     /** @inheritdoc */
-    def name: Name
+    def name: TermName
 
     /** The type parameters of the method. */
     def tparams: List[TypeDef]

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -312,7 +312,7 @@ trait Trees extends api.Trees { self: SymbolTable =>
   case class ValDef(mods: Modifiers, name: TermName, tpt: Tree, rhs: Tree) extends ValOrDefDef with ValDefApi
   object ValDef extends ValDefExtractor
 
-  case class DefDef(mods: Modifiers, name: Name, tparams: List[TypeDef],
+  case class DefDef(mods: Modifiers, name: TermName, tparams: List[TypeDef],
                     vparamss: List[List[ValDef]], tpt: Tree, rhs: Tree) extends ValOrDefDef with DefDefApi
   object DefDef extends DefDefExtractor
 

--- a/test/files/scalacheck/quasiquotes/ArbitraryTreesAndNames.scala
+++ b/test/files/scalacheck/quasiquotes/ArbitraryTreesAndNames.scala
@@ -91,7 +91,7 @@ trait ArbitraryTreesAndNames {
       yield CompoundTypeTree(templ)
 
   def genDefDef(size: Int) =
-    for(mods <- genModifiers; name <- genName;
+    for(mods <- genModifiers; name <- genTermName;
         tpt <- genTree(size -1); rhs <- genTree(size - 1);
         tparams <- smallList(size, genTypeDef(size - 1));
         vparamss <- smallList(size, smallList(size, genValDef(size - 1))))


### PR DESCRIPTION
Now when there's no hope left for type macros, it's reasonable to provide
a more specific type for DefDef.name.
