### PR TITLE
SI-3772 local companion objects no longer produce errors

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -190,11 +190,6 @@ trait Namers extends MethodSynthesis {
       sym.isSourceMethod && sym.owner.isClass && !sym.owner.isPackageClass
     )
 
-    private def inCurrentScope(m: Symbol): Boolean = {
-      if (owner.isClass) owner == m.owner
-      else m.owner.isClass && context.scope == m.owner.info.decls
-    }
-
     /** Enter symbol into context's scope and return symbol itself */
     def enterInScope(sym: Symbol): Symbol = enterInScope(sym, context.scope)
 
@@ -414,7 +409,7 @@ trait Namers extends MethodSynthesis {
     def enterModuleSymbol(tree : ModuleDef): Symbol = {
       var m: Symbol = context.scope lookupAll tree.name find (_.isModule) getOrElse NoSymbol
       val moduleFlags = tree.mods.flags | MODULE
-      if (m.isModule && !m.isPackage && inCurrentScope(m) && (currentRun.canRedefine(m) || m.isSynthetic)) {
+      if (m.isModule && !m.isPackage && (currentRun.canRedefine(m) || m.isSynthetic)) {
         updatePosFlags(m, tree.pos, moduleFlags)
         setPrivateWithin(tree, m)
         m.moduleClass andAlso (setPrivateWithin(tree, _))

--- a/test/files/pos/t3772a.scala
+++ b/test/files/pos/t3772a.scala
@@ -1,0 +1,6 @@
+object Test extends App {
+  {
+    class C(val x: Int = 2)
+    object C
+  }
+}

--- a/test/files/pos/t3772b.scala
+++ b/test/files/pos/t3772b.scala
@@ -1,0 +1,6 @@
+object Test extends App {
+  {
+    case class C(x: Int)
+    object C
+  }
+}


### PR DESCRIPTION
The bug is caused by Namers.inCurrentScope preventing the namer from
overwriting synthetic companion modules (created for case classes and
classes with default arguments) with companions explicitly declared by
the programmer, in case when these companions are written after their
corresponding classes.

I tried to understand what the Namers.inCurrentScope method does, but
this wasn't particularly successful. Then I noticed that this method
is used only when entering modules, so I simply removed it and ran
the test suite. Amazingly enough, nothing broke, and the test got fixed.
