### PR TITLE
currentRun.compiles now correctly works in toolboxes

### DIFF
--- a/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
+++ b/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
@@ -15,6 +15,7 @@ import java.lang.{Class => jClass}
 import scala.compat.Platform.EOL
 import scala.reflect.NameTransformer
 import scala.reflect.api.JavaUniverse
+import scala.reflect.io.NoAbstractFile
 
 abstract class ToolBoxFactory[U <: JavaUniverse](val u: U) { factorySelf =>
 
@@ -138,7 +139,9 @@ abstract class ToolBoxFactory[U <: JavaUniverse](val u: U) { factorySelf =>
         val wrapper2      = if (!withMacrosDisabled) (currentTyper.context.withMacrosEnabled[Tree] _) else (currentTyper.context.withMacrosDisabled[Tree] _)
         def wrapper       (tree: => Tree) = wrapper1(wrapper2(tree))
 
-        phase = (new Run).typerPhase // need to set a phase to something <= typerPhase, otherwise implicits in typedSelect will be disabled
+        val run = new Run
+        run.symSource(ownerClass) = NoAbstractFile // need to set file to something different from null, so that currentRun.defines works
+        phase = run.typerPhase // need to set a phase to something <= typerPhase, otherwise implicits in typedSelect will be disabled
         currentTyper.context.setReportErrors() // need to manually set context mode, otherwise typer.silent will throw exceptions
         reporter.reset()
 

--- a/test/files/run/toolbox_current_run_compiles.check
+++ b/test/files/run/toolbox_current_run_compiles.check
@@ -1,0 +1,2 @@
+true
+false

--- a/test/files/run/toolbox_current_run_compiles.scala
+++ b/test/files/run/toolbox_current_run_compiles.scala
@@ -1,0 +1,28 @@
+package pkg {
+  import scala.reflect.macros.Context
+  import scala.language.experimental.macros
+
+  object Macros {
+    def impl[T: c.WeakTypeTag](c: Context) = {
+      import c.universe._
+      val sym = c.weakTypeOf[T].typeSymbol
+      val g = c.universe.asInstanceOf[scala.tools.nsc.Global]
+      c.Expr[Boolean](Literal(Constant(g.currentRun.compiles(sym.asInstanceOf[g.Symbol]))))
+    }
+    def compiles[T] = macro impl[T]
+  }
+}
+
+import scala.reflect.runtime.universe._
+import scala.reflect.runtime.{universe => ru}
+import scala.tools.reflect.ToolBox
+
+object Test extends App {
+  val cm = ru.runtimeMirror(getClass.getClassLoader)
+  val toolbox = cm.mkToolBox()
+  toolbox.eval(toolbox.parse("""{
+    class C
+    println(pkg.Macros.compiles[C])
+    println(pkg.Macros.compiles[Object])
+  }"""))
+}


### PR DESCRIPTION
Another random bug uncovered and extinguished when hacking macro annots.
