### PR TITLE
[nomaster] macro errors now always have positions

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -697,7 +697,7 @@ trait ContextErrors {
         def msgForLog = if (msg != null && (msg contains "exception during macro expansion")) msg.split(EOL).drop(1).headOption.getOrElse("?") else msg
         macroLogLite("macro expansion has failed: %s".format(msgForLog))
         val errorPos = if (pos != NoPosition) pos else (if (expandee.pos != NoPosition) expandee.pos else enclosingMacroPosition)
-        if (msg != null) context.error(pos, msg) // issueTypeError(PosAndMsgTypeError(..)) won't work => swallows positions
+        if (msg != null) context.error(errorPos, msg) // issueTypeError(PosAndMsgTypeError(..)) won't work => swallows positions
         setError(expandee)
         throw MacroExpansionException
       }

--- a/test/files/neg/macro-abort.check
+++ b/test/files/neg/macro-abort.check
@@ -1,0 +1,4 @@
+Test_2.scala:2: error: aborted
+  Macros.abort
+         ^
+one error found

--- a/test/files/neg/macro-abort/Macros_1.scala
+++ b/test/files/neg/macro-abort/Macros_1.scala
@@ -1,0 +1,9 @@
+import scala.language.experimental.macros
+import scala.reflect.macros.Context
+
+object Macros {
+  def impl(c: Context) = {
+    c.abort(c.enclosingPosition, "aborted")
+  }
+  def abort = macro impl
+}

--- a/test/files/neg/macro-abort/Test_2.scala
+++ b/test/files/neg/macro-abort/Test_2.scala
@@ -1,0 +1,3 @@
+object Test extends App {
+  Macros.abort
+}

--- a/test/files/neg/macro-exception.check
+++ b/test/files/neg/macro-exception.check
@@ -1,0 +1,7 @@
+Test_2.scala:2: error: exception during macro expansion: 
+java.lang.Exception
+	at Macros$.impl(Macros_1.scala:6)
+
+  Macros.exception
+         ^
+one error found

--- a/test/files/neg/macro-exception/Macros_1.scala
+++ b/test/files/neg/macro-exception/Macros_1.scala
@@ -1,0 +1,9 @@
+import scala.language.experimental.macros
+import scala.reflect.macros.Context
+
+object Macros {
+  def impl(c: Context) = {
+    throw new Exception()
+  }
+  def exception = macro impl
+}

--- a/test/files/neg/macro-exception/Test_2.scala
+++ b/test/files/neg/macro-exception/Test_2.scala
@@ -1,0 +1,3 @@
+object Test extends App {
+  Macros.exception
+}


### PR DESCRIPTION
Back then when I implemented macros for inclusion in trunk (Spring 2012),
partest didn't support the _1, _2, ... convention for neg tests, so I had
to use toolboxes to test macro-generated exceptions.

Unfortunately toolboxes aren't very good with positions (mostly because
their inputs are almost always constructed without corresponding sources)
so I didn't notice that errors signalizing about macro-generated
exceptions actually don't carry positions with them because of a typo.

This patch fixes the oversight, but it doesn't need to be ported to master,
because over there everything's already fixed by one of the backports
from macro paradise.
