### PR TITLE
Ignore inner class scanning in the compiler to support dynamic languages like groovy [SI-7741]

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
@@ -43,6 +43,7 @@ trait StandardScalaSettings {
   val unchecked =      BooleanSetting ("-unchecked", "Enable additional warnings where generated code depends on assumptions.")
   val uniqid =         BooleanSetting ("-uniqid", "Uniquely tag all identifiers in debugging output.")
   val usejavacp =      BooleanSetting ("-usejavacp", "Utilize the java.class.path in classpath resolution.")
+  val ignoreinnercls =  BooleanSetting ("-ignoreinnercls", "Ignore inner class scanning, this is required when integrating with dynamic languages where inner classes may not exist")
   val usemanifestcp =  BooleanSetting ("-usemanifestcp", "Utilize the manifest in classpath resolution.")
   val verbose =        BooleanSetting ("-verbose", "Output messages about what the compiler is doing.")
   val version =        BooleanSetting ("-version", "Print product version and exit.")

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -113,7 +113,7 @@ abstract class ClassfileParser {
 
   private def parseErrorHandler[T]: PartialFunction[Throwable, T] = {
     case e: MissingRequirementError => handleMissing(e)
-    case e: RuntimeException        => handleError(e);
+    case e: RuntimeException        => handleError(e)
   }
   @inline private def pushBusy[T](sym: Symbol)(body: => T): T = {
     if (busy eq sym)

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -1036,10 +1036,11 @@ abstract class ClassfileParser {
     for (entry <- innerClasses.entries) {
       // create a new class member for immediate inner classes
       if (entry.outerName == currentClass) {
-        val file = classPath.findSourceFile(entry.externalName.toString) getOrElse {
-          throw new AssertionError(entry.externalName)
-        }
-        enterClassAndModule(entry, file)
+        val file = classPath.findSourceFile(entry.externalName.toString).get
+        if(file == None)
+         debugwarn(s"Class file for ${entry.externalName} not found")
+        else
+         enterClassAndModule(entry, file)
       }
     }
   }


### PR DESCRIPTION
related to https://issues.scala-lang.org/browse/SI-7741
