### PR TITLE
SI-7014 Annot arg may refer to annotated class's member

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -952,9 +952,14 @@ abstract class ClassfileParser {
         case ENUM_TAG   =>
           val t = pool.getType(index)
           val n = pool.getName(in.nextChar)
-          val s = t.typeSymbol.companionModule.info.decls.lookup(n)
-          assert(s != NoSymbol, t)
-          Some(LiteralAnnotArg(Constant(s)))
+          val module = t.typeSymbol.companionModule
+          val s = module.info.decls.lookup(n)
+          if (s != NoSymbol) Some(LiteralAnnotArg(Constant(s)))
+          else {
+            warning(s"""While parsing annotations in ${in.file}, could not find $n in enum $module.\nThis is likely due to an implementation restriction: an annotation argument cannot refer to a member of the annotated class (SI-7014).""")
+            None
+          }
+
         case ARRAY_TAG  =>
           val arr = new ArrayBuffer[ClassfileAnnotArg]()
           var hasError = false

--- a/test/files/pos/t7014/ThreadSafety.java
+++ b/test/files/pos/t7014/ThreadSafety.java
@@ -1,0 +1,9 @@
+package t7014;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME) // must be exactly RUNTIME retention (those we parse)
+public @interface ThreadSafety {
+  ThreadSafetyLevel level();
+}

--- a/test/files/pos/t7014/ThreadSafetyLevel.java
+++ b/test/files/pos/t7014/ThreadSafetyLevel.java
@@ -1,0 +1,8 @@
+package t7014; // package needed due to other bug in scalac's java parser
+
+// since we parse eagerly, we have not yet parsed the classfile when parsing the annotation,
+// and on doing so, fail to find a symbol for the COMPLETELY_THREADSAFE reference
+// from the annotation's argument to the enum's member
+// for now, let's just not crash -- should implement lazy completing at some point
+@ThreadSafety(level=ThreadSafetyLevel.COMPLETELY_THREADSAFE)
+public enum ThreadSafetyLevel { COMPLETELY_THREADSAFE }

--- a/test/files/pos/t7014/t7014.scala
+++ b/test/files/pos/t7014/t7014.scala
@@ -1,0 +1,4 @@
+package t7014
+
+import ThreadSafetyLevel.COMPLETELY_THREADSAFE // refer to annotation so it gets parsed
+ 


### PR DESCRIPTION
This only reduces the crasher to a warning.

review by @JamesIry
