### PR TITLE
SI-7564 [Avian] Whitespace fixes to run/tailcalls.check

### DIFF
--- a/test/files/run/tailcalls.check
+++ b/test/files/run/tailcalls.check
@@ -53,27 +53,27 @@ test FancyTailCalls.tcTryLocal was successful
 test FancyTailCalls.differentInstance was successful
 test PolyObject.tramp was successful
 #partest avian
-test Object .f was successful
-test Final .f was successful
-test Class .f was successful
+test Object   .f was successful
+test Final    .f was successful
+test Class    .f was successful
 test SubClass .f was successful
-test Sealed .f was successful
+test Sealed   .f was successful
 test SubSealed.f was successful
 
-test O .f was successful
-test c .f was successful
-test O.O .f was successful
-test O.c .f was successful
-test c.O .f was successful
-test c.c .f was successful
-test O.O.O .f was successful
-test O.O.c .f was successful
-test O.c.O .f was successful
-test O.c.c .f was successful
-test c.O.O .f was successful
-test c.O.c .f was successful
-test c.c.O .f was successful
-test c.c.c .f was successful
+test O      .f was successful
+test c      .f was successful
+test O.O    .f was successful
+test O.c    .f was successful
+test c.O    .f was successful
+test c.c    .f was successful
+test O.O.O  .f was successful
+test O.O.c  .f was successful
+test O.c.O  .f was successful
+test O.c.c  .f was successful
+test c.O.O  .f was successful
+test c.O.c  .f was successful
+test c.c.O  .f was successful
+test c.c.c  .f was successful
 test O.O.O.O.f was successful
 test O.O.O.c.f was successful
 test O.O.c.O.f was successful


### PR DESCRIPTION
Looks like the differences in the whitespace caused the test to fail
on Avian.
