### PR TITLE
SI-7716 Exclude patmat synthetics from bounds checking

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1826,9 +1826,11 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
           case LabelDef(_, _, _) if treeInfo.hasSynthCaseSymbol(result) =>
             val old = inPattern
             inPattern = true
-            val res = deriveLabelDef(result)(transform)
+            val res = deriveLabelDef(result)(transform) // TODO SI-7756 Too broad! The code from the original case body should be fully refchecked!
             inPattern = old
             res
+          case ValDef(_, _, _, _) if treeInfo.hasSynthCaseSymbol(result) =>
+            deriveValDef(result)(transform) // SI-7716 Don't refcheck the tpt of the synthetic val that holds the selector.
           case _ =>
             super.transform(result)
         }

--- a/test/files/pos/t7716.scala
+++ b/test/files/pos/t7716.scala
@@ -1,0 +1,16 @@
+object Test {
+  def test: Unit = {
+    val e: java.lang.Enum[_] = java.util.concurrent.TimeUnit.SECONDS
+    e match { case x => println(x) }
+
+
+    trait TA[X <: CharSequence]
+    val ta: TA[_] = new TA[String] {}
+
+    ta match {
+      case _ => println("hi")
+    }
+
+    def f(ta: TA[_]) = ta match { case _ => "hi" }
+  }
+}


### PR DESCRIPTION
Consider this pattern match translation, that occurs _before_ refchecks:

```
scala> val e: java.lang.Enum[_] = java.util.concurrent.TimeUnit.SECONDS

scala> e match { case x => x }
<console>:9: error: type arguments [_$1] do not conform to class Enum's type parameter bounds [E <: Enum[E]]
              e match { case x => x }
              ^
[[syntax trees at end of                 refchecks]] // <console>
package $line5 {
          case <synthetic> val x1: Enum[_$1] = $line3.$read.$iw.$iw.e;
          case4(){
            matchEnd3(x1)
          };
          matchEnd3(x: Enum[_$1]){
            x
          }
```

RefChecks turns a blind eye to the non-conformant type `Enum[_$1]` in
the label defs because of 65340ed4ad2. (Incidentally, that is far
too broad, as I've noted in SI-7756.)

This commit extends this exception to cover the synthetic ValDef `x1`.

Commit log watchers might notice the similarities to SI-7694.

Review by @adriaanm / @JamesIry. I think this one makes sense for 2.10.3. It was a regression from 2.9.x.
