### PR TITLE
SI-7756 Uncripple refchecks in case bodies

### DIFF
--- a/test/files/neg/t7756a.check
+++ b/test/files/neg/t7756a.check
@@ -1,0 +1,7 @@
+t7756a.scala:7: error: type arguments [Object] do not conform to trait TA's type parameter bounds [X <: CharSequence]
+        locally(null: TA[Object])
+        ^
+t7756a.scala:7: error: type arguments [Object] do not conform to trait TA's type parameter bounds [X <: CharSequence]
+        locally(null: TA[Object])
+                      ^
+two errors found

--- a/test/files/neg/t7756a.scala
+++ b/test/files/neg/t7756a.scala
@@ -1,0 +1,11 @@
+object Test {
+  def test: Unit = {
+    trait TA[X <: CharSequence]
+    0 match {
+      case _ =>
+        // the bounds violation isn't reported. RefChecks seems to be too broadly disabled under virtpatmat: see 65340ed4ad2e
+        locally(null: TA[Object])
+        ()
+    }
+  }
+}

--- a/test/files/neg/t7756b.check
+++ b/test/files/neg/t7756b.check
@@ -1,0 +1,6 @@
+t7756b.scala:3: warning: comparing values of types Int and String using `==' will always yield false
+    case _ => 0 == ""
+                ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/t7756b.flags
+++ b/test/files/neg/t7756b.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/t7756b.scala
+++ b/test/files/neg/t7756b.scala
@@ -1,0 +1,5 @@
+object Test {
+  0 match {
+    case _ => 0 == ""
+  }
+}


### PR DESCRIPTION
In 65340ed4ad2e, parts of RefChecks were disabled when
we traversed into the results of the new pattern matcher.
Similar logic existed for the old pattern matcher, but in
that case the Match / CaseDef nodes still existed in the tree.

The new approach was too broad: important checks no longer
scrutinized the body of cases.

This commit turns the checks back on when it finds the remnants
of a case body, which appears as an application to a label def.

Review by @adriaanm
