### PR TITLE
SI-6507 do not call .toString on REPL results when :silent is on.

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -838,6 +838,8 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
     def imports    = importedSymbols
     def value      = Some(handlers.last) filter (h => h.definesValue) map (h => definedSymbols(h.definesTerm.get)) getOrElse NoSymbol
 
+    val printResults = IMain.this.printResults
+
     val lineRep = new ReadEvalPrint()
 
     private var _originalLine: String = null

--- a/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
+++ b/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
@@ -107,7 +107,7 @@ trait MemberHandlers {
 
     override def resultExtractionCode(req: Request): String = {
       val isInternal = isUserVarName(name) && req.lookupTypeOf(name) == "Unit"
-      if (!mods.isPublic || isInternal) ""
+      if (!mods.isPublic || isInternal || !req.printResults) ""
       else {
         // if this is a lazy val we avoid evaluating it here
         val resultString =
@@ -151,11 +151,11 @@ trait MemberHandlers {
       """val %s = %s""".format(name, lhs)
 
     /** Print out lhs instead of the generated varName */
-    override def resultExtractionCode(req: Request) = {
+    override def resultExtractionCode(req: Request) = if (req.printResults) {
       val lhsType = string2code(req lookupTypeOf name)
       val res     = string2code(req fullPath name)
       """ + "%s: %s = " + %s + "\n" """.format(string2code(lhs.toString), lhsType, res) + "\n"
-    }
+    } else ""
   }
 
   class ModuleHandler(module: ModuleDef) extends MemberDefHandler(module) {

--- a/test/files/run/t6507.check
+++ b/test/files/run/t6507.check
@@ -1,0 +1,26 @@
+Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> 
+
+scala> :silent
+Switched off result printing.
+
+scala> class A { override def toString() = { println("!"); "A" } }
+
+scala> val a = new A
+
+scala> var b: A = new A
+
+scala> b = new A
+
+scala> new A
+
+scala> :silent
+Switched on result printing.
+
+scala> res0
+!
+res1: A = A
+
+scala> 

--- a/test/files/run/t6507.scala
+++ b/test/files/run/t6507.scala
@@ -1,0 +1,14 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  def code = """
+:silent
+class A { override def toString() = { println("!"); "A" } }
+val a = new A
+var b: A = new A
+b = new A
+new A
+:silent
+res0
+"""
+}


### PR DESCRIPTION
Member handlers used to always call .toString on REPL results, even when
:silent was on, which could force evaluation or cause unwanted side
effects.

This forwards the current value of `printResults` to the member
handlers (through Request) for them to decide what to do when the
results must not be printed.

2 handlers now do not return any extraction code when silent:
- ValHandler, so that it doesn't call toString on the val
- Assign, so that it doesn't call toString on the right-hand side
  of the assignement.

---

Review by @som-snytt, please :)
