### PR TITLE
SI-7603 Fix thread safety of FlagTranslation 

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1425,14 +1425,6 @@ trait Namers extends MethodSynthesis {
               annCtx.setReportErrors()
               // need to be lazy, #1782. beforeTyper to allow inferView in annotation args, SI-5892.
               AnnotationInfo lazily {
-                if (typer.context ne ctx)
-                  log(sm"""|The var `typer.context` in ${Namer.this} was mutated before the annotation ${ann} was forced.
-                           |
-                           |current value  = ${typer.context}
-                           |original value = $ctx
-                           |
-                           |This confirms the hypothesis for the cause of SI-7603. If you see this message, please comment on that ticket.""")
-
                 beforeTyper(newTyper(annCtx) typedAnnotation ann)
               }
             }

--- a/src/reflect/scala/reflect/internal/ClassfileConstants.scala
+++ b/src/reflect/scala/reflect/internal/ClassfileConstants.scala
@@ -335,13 +335,8 @@ object ClassfileConstants {
   abstract class FlagTranslation {
     import Flags._
 
-    private var isAnnotation = false
-    private var isClass      = false
-    private def initFields(flags: Int) = {
-      isAnnotation = (flags & JAVA_ACC_ANNOTATION) != 0
-      isClass      = false
-    }
-    private def translateFlag(jflag: Int): Long = (jflag: @switch) match {
+    private def isAnnotation(flags: Int): Boolean = (flags & JAVA_ACC_ANNOTATION) != 0
+    private def translateFlag(jflag: Int, isAnnotation: Boolean, isClass: Boolean): Long = (jflag: @switch) match {
       case JAVA_ACC_PRIVATE    => PRIVATE
       case JAVA_ACC_PROTECTED  => PROTECTED
       case JAVA_ACC_FINAL      => FINAL
@@ -351,31 +346,28 @@ object ClassfileConstants {
       case JAVA_ACC_INTERFACE  => if (isAnnotation) 0L else TRAIT | INTERFACE | ABSTRACT
       case _                   => 0L
     }
-    private def translateFlags(jflags: Int, baseFlags: Long): Long = {
+    private def translateFlags(jflags: Int, baseFlags: Long, isAnnotation: Boolean, isClass: Boolean): Long = {
+      def translateFlag0(jflags: Int): Long = translateFlag(jflags, isAnnotation, isClass)
       var res: Long = JAVA | baseFlags
       /** fast, elegant, maintainable, pick any two... */
-      res |= translateFlag(jflags & JAVA_ACC_PRIVATE)
-      res |= translateFlag(jflags & JAVA_ACC_PROTECTED)
-      res |= translateFlag(jflags & JAVA_ACC_FINAL)
-      res |= translateFlag(jflags & JAVA_ACC_SYNTHETIC)
-      res |= translateFlag(jflags & JAVA_ACC_STATIC)
-      res |= translateFlag(jflags & JAVA_ACC_ABSTRACT)
-      res |= translateFlag(jflags & JAVA_ACC_INTERFACE)
+      res |= translateFlag0(jflags & JAVA_ACC_PRIVATE)
+      res |= translateFlag0(jflags & JAVA_ACC_PROTECTED)
+      res |= translateFlag0(jflags & JAVA_ACC_FINAL)
+      res |= translateFlag0(jflags & JAVA_ACC_SYNTHETIC)
+      res |= translateFlag0(jflags & JAVA_ACC_STATIC)
+      res |= translateFlag0(jflags & JAVA_ACC_ABSTRACT)
+      res |= translateFlag0(jflags & JAVA_ACC_INTERFACE)
       res
     }
 
     def classFlags(jflags: Int): Long = {
-      initFields(jflags)
-      isClass = true
-      translateFlags(jflags, 0)
+      translateFlags(jflags, 0, isAnnotation(jflags), isClass = true)
     }
     def fieldFlags(jflags: Int): Long = {
-      initFields(jflags)
-      translateFlags(jflags, if ((jflags & JAVA_ACC_FINAL) == 0) MUTABLE else 0)
+      translateFlags(jflags, if ((jflags & JAVA_ACC_FINAL) == 0) MUTABLE else 0 , isAnnotation(jflags), isClass = false)
     }
     def methodFlags(jflags: Int): Long = {
-      initFields(jflags)
-      translateFlags(jflags, if ((jflags & JAVA_ACC_BRIDGE) != 0) BRIDGE else 0)
+      translateFlags(jflags, if ((jflags & JAVA_ACC_BRIDGE) != 0) BRIDGE else 0, isAnnotation(jflags), isClass = false)
     }
   }
   object FlagTranslation extends FlagTranslation { }


### PR DESCRIPTION
This is outside of the Global cake, so we can't assume single
threaded access. A var was introduced in af3daf6 that can lead
to incorrect flag interpretation. The reported bug was triggered
in a multi-project SBT build. Java Annotations read from classfiles
were occasionally conferred the TRAIT|INFERFACE|ABSTRACT flag set,
leading to `@Foo is abstract, cannot be instatiated` later down the
line.

Review by @JamesIry. I could add a test to prod those functions for thread-safety, but I don't think an isolated test like that adds much value to our test suite.

(This one will fix Typesafe tickets 2209 and 2323. I just got access to a build today that allowed the diagnosis, hence the eleventh hour submission for 2.10.3)
