### PR TITLE
SI-7763 Avoid dropping casts in erasure

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/opt/DeadCodeElimination.scala
+++ b/src/compiler/scala/tools/nsc/backend/opt/DeadCodeElimination.scala
@@ -159,7 +159,7 @@ abstract class DeadCodeElimination extends SubComponent {
 
             case RETURN(_) | JUMP(_) | CJUMP(_, _, _, _) | CZJUMP(_, _, _, _) | STORE_FIELD(_, _) |
                  THROW(_)   | LOAD_ARRAY_ITEM(_) | STORE_ARRAY_ITEM(_) | SCOPE_ENTER(_) | SCOPE_EXIT(_) | STORE_THIS(_) |
-                 LOAD_EXCEPTION(_) | SWITCH(_, _) | MONITOR_ENTER() | MONITOR_EXIT() =>
+                 LOAD_EXCEPTION(_) | SWITCH(_, _) | MONITOR_ENTER() | MONITOR_EXIT() | CHECK_CAST(_) =>
               moveToWorkList()
 
             case CALL_METHOD(m1, _) if isSideEffecting(m1) =>

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -680,7 +680,7 @@ abstract class Erasure extends AddInterfaces
     private def adaptMember(tree: Tree): Tree = {
       //Console.println("adaptMember: " + tree);
       tree match {
-        case Apply(TypeApply(sel @ Select(qual, name), List(targ)), List())
+        case Apply(ta @ TypeApply(sel @ Select(qual, name), List(targ)), List())
         if tree.symbol == Any_asInstanceOf =>
           val qual1 = typedQualifier(qual, NOmode, ObjectTpe) // need to have an expected type, see #3037
 
@@ -705,7 +705,7 @@ abstract class Erasure extends AddInterfaces
 //                }
               typed(untyped)
             }
-          } else qual1
+          } else treeCopy.Apply(tree, treeCopy.TypeApply(ta, treeCopy.Select(sel, qual1, name), List(targ)), List())
 
         case Apply(TypeApply(sel @ Select(qual, name), List(targ)), List())
         if tree.symbol == Any_isInstanceOf =>

--- a/test/files/run/t7763.flags
+++ b/test/files/run/t7763.flags
@@ -1,0 +1,1 @@
+-Ynooptimize

--- a/test/files/run/t7763.flags
+++ b/test/files/run/t7763.flags
@@ -1,1 +1,0 @@
--Ynooptimize

--- a/test/files/run/t7763.scala
+++ b/test/files/run/t7763.scala
@@ -1,0 +1,20 @@
+object Test {
+  class A; class B
+  def main(args: Array[String]) {
+    def noExpectedType() {
+      a().asInstanceOf[B] // cast elided!
+    }
+    def withExpectedType(): B = {
+      a().asInstanceOf[B]
+    }
+    def test(a: => Any) = try {
+      a
+      sys.error("no CCE!")
+    } catch {case _: ClassCastException => }
+
+    test(noExpectedType())
+    test(withExpectedType())
+  }
+
+  def a(): Object = new A
+}


### PR DESCRIPTION
466b7d29f avoided quadratic complexity in Erasure's treatment
of chained `asInstanceOf` calls. It did so by using the typechecked
qualifier, rather than discarding it.

However, that also dropped the cast altogether! In many cases this
was masked by later inclusion of a cast to the expected type
by `adaptToType`:

```
  at scala.tools.nsc.transform.Erasure$Eraser.cast(Erasure.scala:636)
  at scala.tools.nsc.transform.Erasure$Eraser.scala$tools$nsc$transform$Erasure$Eraser$$adaptToType(Erasure.scala:665)
  at scala.tools.nsc.transform.Erasure$Eraser.adapt(Erasure.scala:766)
  at scala.tools.nsc.typechecker.Typers$Typer.runTyper$1(Typers.scala:5352)
```

This commit re-wraps the typechecked `qual` in its original
`<qual>.asInstanceOf[T]` to preserve semantics while avoiding
the big-O blowup.

Review by @paulp, @magarcia
