### PR TITLE
SI-6507 completely sidestep handlers in REPL when :silent in on

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -838,8 +838,6 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
     def imports    = importedSymbols
     def value      = Some(handlers.last) filter (h => h.definesValue) map (h => definedSymbols(h.definesTerm.get)) getOrElse NoSymbol
 
-    val printResults = IMain.this.printResults
-
     val lineRep = new ReadEvalPrint()
 
     private var _originalLine: String = null
@@ -948,7 +946,8 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
         }
 
         // compile the result-extraction object
-        withoutWarnings(lineRep compile ResultObjectSourceCode(handlers))
+        val handls = if (printResults) handlers else Nil
+        withoutWarnings(lineRep compile ResultObjectSourceCode(handls))
       }
     }
 

--- a/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
+++ b/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
@@ -107,7 +107,7 @@ trait MemberHandlers {
 
     override def resultExtractionCode(req: Request): String = {
       val isInternal = isUserVarName(name) && req.lookupTypeOf(name) == "Unit"
-      if (!mods.isPublic || isInternal || !req.printResults) ""
+      if (!mods.isPublic || isInternal) ""
       else {
         // if this is a lazy val we avoid evaluating it here
         val resultString =
@@ -151,11 +151,11 @@ trait MemberHandlers {
       """val %s = %s""".format(name, lhs)
 
     /** Print out lhs instead of the generated varName */
-    override def resultExtractionCode(req: Request) = if (req.printResults) {
+    override def resultExtractionCode(req: Request) = {
       val lhsType = string2code(req lookupTypeOf name)
       val res     = string2code(req fullPath name)
       """ + "%s: %s = " + %s + "\n" """.format(string2code(lhs.toString), lhsType, res) + "\n"
-    } else ""
+    }
   }
 
   class ModuleHandler(module: ModuleDef) extends MemberDefHandler(module) {


### PR DESCRIPTION
This is a cleanup of 6db8a52, the original fix for SI-6507.

When the REPL is :silent, all handlers are ignored when it comes to
generating the printed result. The result extraction code (`lazy val
resN = ...`) is still generated, but now it isn't called until the
user calls it.

---

Review by @som-snytt. The diff for the whole fix, both commits together (much more readable) [is here](https://github.com/gourlaysama/scala/compare/scala:b8d71c590e9f64345bab86e6dd304a92145f52ea...wip/t6507-2).
