### PR TITLE
SI-1980 A lint warning for by-name parameters in right assoc methods

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1371,6 +1371,16 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
       member.typeParams.map(_.info.bounds.hi.widen) foreach checkAccessibilityOfType
     }
 
+    private def checkByNameRightAssociativeDef(tree: DefDef) {
+      tree match {
+        case DefDef(_, name, _, params :: _, _, _) =>
+          if (settings.lint && !treeInfo.isLeftAssoc(name.decodedName) && params.exists(p => isByName(p.symbol)))
+            unit.warning(tree.pos,
+              "by-name parameters will be evaluated eagerly when called as a right-associative infix operator. For more details, see SI-1980.")
+        case _ =>
+      }
+    }
+
     /** Check that a deprecated val or def does not override a
       * concrete, non-deprecated method.  If it does, then
       * deprecation is meaningless.
@@ -1593,6 +1603,10 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
             if (settings.warnInaccessible) {
               if (!sym.isConstructor && !sym.isEffectivelyFinal && !sym.isSynthetic)
                 checkAccessibilityOfReferencedTypes(tree)
+            }
+            tree match {
+              case dd: DefDef => checkByNameRightAssociativeDef(dd)
+              case _          =>
             }
             tree
 

--- a/test/files/neg/t1980.check
+++ b/test/files/neg/t1980.check
@@ -1,0 +1,12 @@
+t1980.scala:2: warning: by-name parameters will be evaluated eagerly when called as a right-associative infix operator. For more details, see SI-1980.
+  def op1_:(x: => Any) = ()                 // warn
+      ^
+t1980.scala:3: warning: by-name parameters will be evaluated eagerly when called as a right-associative infix operator. For more details, see SI-1980.
+  def op2_:(x: Any, y: => Any) = ()         // warn
+      ^
+t1980.scala:4: warning: by-name parameters will be evaluated eagerly when called as a right-associative infix operator. For more details, see SI-1980.
+  def op3_:(x: Any, y: => Any)(a: Any) = () // warn
+      ^
+error: No warnings can be incurred under -Xfatal-warnings.
+three warnings found
+one error found

--- a/test/files/neg/t1980.flags
+++ b/test/files/neg/t1980.flags
@@ -1,0 +1,1 @@
+-Xlint -Xfatal-warnings

--- a/test/files/neg/t1980.scala
+++ b/test/files/neg/t1980.scala
@@ -1,0 +1,9 @@
+object Test {
+  def op1_:(x: => Any) = ()                 // warn
+  def op2_:(x: Any, y: => Any) = ()         // warn
+  def op3_:(x: Any, y: => Any)(a: Any) = () // warn
+
+  def op4() = ()                            // no warn
+  def op5(x: => Any) = ()                   // no warn
+  def op6_:(x: Any)(a: => Any) = ()         // no warn
+}


### PR DESCRIPTION
The desugaring of right associative calls happens in the parser. This
eagerly evaluates the arguments (to preserve left-to-right evaluation
order the arguments are evaluated before the qualifier).

This is pretty surprising if the method being called has a by-name
parameter in the first parameter section.

This commit adds a warning under -Xlint when defining such a method.

The relevent spec snippets:

> SLS 4.6.1 says that call-by-name argument "is not evaluated at the point of function application, but instead is evaluated at each use within the function".
> 
> But 6.12.3 offers:
> "If op is right- associative, the same operation is interpreted as { val x=e1; e2.op(x ) }, where x is a fresh name."

Review by @JamesIry
