### PR TITLE
Weed out remnants of early type defs

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2799,10 +2799,8 @@ self =>
           val earlyDefs: List[Tree] = body flatMap {
             case vdef @ ValDef(mods, _, _, _) if !mods.isDeferred =>
               List(copyValDef(vdef)(mods = mods | Flags.PRESUPER))
-            case tdef @ TypeDef(mods, name, tparams, rhs) =>
-              List(treeCopy.TypeDef(tdef, mods | Flags.PRESUPER, name, tparams, rhs))
             case stat if !stat.isEmpty =>
-              syntaxError(stat.pos, "only type definitions and concrete field definitions allowed in early object initialization section", skipIt = false)
+              syntaxError(stat.pos, "only concrete field definitions allowed in early object initialization section", skipIt = false)
               List()
             case _ => List()
           }

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -334,8 +334,7 @@ abstract class TreeGen extends macros.TreeBuilder {
         ValDef(mods withAnnotations vd.mods.annotations, vd.name, vd.tpt.duplicate, vd.rhs.duplicate)
       }
     }
-    val (edefs, rest) = body span treeInfo.isEarlyDef
-    val (evdefs, etdefs) = edefs partition treeInfo.isEarlyValDef
+    val (evdefs, rest) = body span treeInfo.isEarlyDef
     val gvdefs = evdefs map {
       case vdef @ ValDef(_, _, tpt, _) =>
         copyValDef(vdef)(
@@ -376,6 +375,6 @@ abstract class TreeGen extends macros.TreeBuilder {
     // Field definitions for the class - remove defaults.
     val fieldDefs = vparamss.flatten map (vd => copyValDef(vd)(mods = vd.mods &~ DEFAULTPARAM, rhs = EmptyTree))
 
-    global.Template(parents, self, gvdefs ::: fieldDefs ::: constrs ::: etdefs ::: rest)
+    global.Template(parents, self, gvdefs ::: fieldDefs ::: constrs ::: rest)
   }
 }

--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -414,24 +414,13 @@ abstract class TreeInfo {
 
   /** The value definitions marked PRESUPER in this statement sequence */
   def preSuperFields(stats: List[Tree]): List[ValDef] =
-    stats collect { case vd: ValDef if isEarlyValDef(vd) => vd }
+    stats collect { case vd: ValDef if isEarlyDef(vd) => vd }
 
   def hasUntypedPreSuperFields(stats: List[Tree]): Boolean =
     preSuperFields(stats) exists (_.tpt.isEmpty)
 
   def isEarlyDef(tree: Tree) = tree match {
-    case TypeDef(mods, _, _, _) => mods hasFlag PRESUPER
     case ValDef(mods, _, _, _) => mods hasFlag PRESUPER
-    case _ => false
-  }
-
-  def isEarlyValDef(tree: Tree) = tree match {
-    case ValDef(mods, _, _, _) => mods hasFlag PRESUPER
-    case _ => false
-  }
-
-  def isEarlyTypeDef(tree: Tree) = tree match {
-    case TypeDef(mods, _, _, _) => mods hasFlag PRESUPER
     case _ => false
   }
 

--- a/test/files/neg/macro-invalidusage-presuper.check
+++ b/test/files/neg/macro-invalidusage-presuper.check
@@ -1,4 +1,4 @@
-Macros_Test_2.scala:3: error: only type definitions and concrete field definitions allowed in early object initialization section
+Macros_Test_2.scala:3: error: only concrete field definitions allowed in early object initialization section
 class D extends { def x = macro impl } with AnyRef
                       ^
 one error found

--- a/test/files/neg/prohibit-early-type-def.check
+++ b/test/files/neg/prohibit-early-type-def.check
@@ -1,0 +1,4 @@
+prohibit-early-type-def.scala:1: error: only concrete field definitions allowed in early object initialization section
+class C extends { type T = Int } with Any
+                       ^
+one error found

--- a/test/files/neg/prohibit-early-type-def.scala
+++ b/test/files/neg/prohibit-early-type-def.scala
@@ -1,0 +1,1 @@
+class C extends { type T = Int } with Any

--- a/test/files/neg/t2796.scala
+++ b/test/files/neg/t2796.scala
@@ -7,11 +7,6 @@ trait T1 extends {
   val abstractVal = "T1.abstractVal" // warn
 } with Base
 
-trait T2 extends {
-  type X = Int                       // okay
-} with Base
-
-
 class C1 extends {
   val abstractVal = "C1.abstractVal" // okay
 } with Base

--- a/test/files/run/analyzerPlugins.scala
+++ b/test/files/run/analyzerPlugins.scala
@@ -8,7 +8,9 @@ object Test extends DirectTest {
   def code = """
     class testAnn extends annotation.TypeConstraint
 
-    class A(param: Double) extends { val x: Int = 1; val y = "two"; type T = A } with AnyRef {
+    class A(param: Double) extends { val x: Int = 1; val y = "two" } with AnyRef {
+      type T = A
+
       val inferField = ("str": @testAnn)
       val annotField: Boolean @testAnn = false
 
@@ -81,7 +83,7 @@ object Test extends DirectTest {
         output += s"pluginsPt($pt, ${treeClass(tree)})"
         pt
       }
-  
+
       override def pluginsTyped(tpe: Type, typer: Typer, tree: Tree, mode: Mode, pt: Type): Type = {
         output += s"pluginsTyped($tpe, ${treeClass(tree)})"
         tpe


### PR DESCRIPTION
This commit removes the dead code that was originally intended for
implementation of early type definitions.

[Discussion on the scala-internals](https://groups.google.com/d/msg/scala-internals/k4DzIge9MJU/XecXvqkQDdYJ).

Review @adriaanm 
