### PR TITLE
Use scala-partest 1.0-RC4

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -251,7 +251,10 @@ TODO:
 
 
       <artifact:dependencies pathId="partest.classpath" filesetId="partest.fileset" versionsId="partest.versions">
+        <!-- to facilitate building and publishing partest locally -->
         <localRepository path="${user.home}/.m2/repository"/>
+        <!-- so we don't have to wait for artifacts to synch to maven central: -->
+        <artifact:remoteRepository id="sonatype-release" url="https://oss.sonatype.org/content/repositories/releases"/>
         <dependency groupId="org.scala-lang.modules" artifactId="scala-partest_${scala.binary.version}" version="${partest.version.number}" />
       </artifact:dependencies>
       <copy-deps fileset.prefix="partest" out="partest"/>

--- a/versions.properties
+++ b/versions.properties
@@ -2,6 +2,6 @@ starr.version=2.11.0-M4
 
 # the below is used for depending on dependencies like partest
 scala.binary.version=2.11.0-M4
-partest.version.number=1.0-RC3
+partest.version.number=1.0-RC4
 scala-xml.version.number=1.0-RC2
 scala-parser-combinators.version.number=1.0-RC1


### PR DESCRIPTION
RC3 had a binary incompatibility that led to a crash in parsing options,
due to:
- https://github.com/scala/scala-partest/commit/9ff138ab4b
- https://github.com/scala/scala/commit/2b1563fa74

Also added sonatype as a repo for resolving partest,
so we don't have to wait for artifacts to synch to maven central.
