### PR TITLE
SI-7775 Avoid iterating over System.getProperties 

### DIFF
--- a/src/compiler/scala/tools/cmd/Property.scala
+++ b/src/compiler/scala/tools/cmd/Property.scala
@@ -57,8 +57,12 @@ trait Property extends Reference {
   def loadProperties(file: File): Properties  =
     returning(new Properties)(_ load new FileInputStream(file.path))
 
-  def systemPropertiesToOptions: List[String] =
-    propertiesToOptions(System.getProperties)
+  def systemPropertiesToOptions: List[String] = {
+    val ps  = new scala.sys.SystemProperties
+    val all = for (n <- ps.names; v <- ps get n) yield (n -> v)
+    propertiesToOptions(all.toList)
+    //propertiesToOptions(System.getProperties) // prone to concurrent modification
+  }
 
   def propertiesToOptions(file: File): List[String] =
     propertiesToOptions(loadProperties(file))

--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -13,6 +13,7 @@ import nsc.util.{ ClassPath, JavaClassPath, ScalaClassLoader }
 import nsc.io.{ File, Directory, Path, AbstractFile }
 import ClassPath.{ JavaContext, DefaultJavaContext, join, split }
 import PartialFunction.condOpt
+import scala.sys.SystemProperties
 import scala.language.postfixOps
 
 // Loosely based on the draft specification at:
@@ -39,9 +40,10 @@ object PathResolver {
   /** Values found solely by inspecting environment or property variables.
    */
   object Environment {
-    private def searchForBootClasspath = (
-      systemProperties find (_._1 endsWith ".boot.class.path") map (_._2) getOrElse ""
-    )
+    private def searchForBootClasspath = {
+      val ps = new SystemProperties
+      ps.names find (_ endsWith ".boot.class.path") flatMap (ps.get) getOrElse ""
+    }
 
     /** Environment variables which java pays attention to so it
      *  seems we do as well.

--- a/src/library/scala/sys/SystemProperties.scala
+++ b/src/library/scala/sys/SystemProperties.scala
@@ -34,6 +34,8 @@ extends mutable.AbstractMap[String, String]
 
   def iterator: Iterator[(String, String)] =
     wrapAccess(System.getProperties().asScala.iterator) getOrElse Iterator.empty
+  def names: Iterator[String] =
+    wrapAccess(System.getProperties().stringPropertyNames().asScala.iterator) getOrElse Iterator.empty
   def get(key: String) =
     wrapAccess(Option(System.getProperty(key))) flatMap (x => x)
   override def contains(key: String) =


### PR DESCRIPTION
I don't know why it didn't use my commit message... This is for visibility in case it's useful. It was fun just reading the code. Oh, and helpfully I held off on a test until someone said this was what they wanted.

```
Just when you want to iterate over system properties in search
of a setting, someone else wants to configure their module by
setting a property.

Avoid ConcurrentModificationExceptions by iterating over property
names only, which are not backed by the underlying map.
```
