### PR TITLE
SI-942 A test case, five years adrift.

### DIFF
--- a/test/files/pos/t942/Amount_1.java
+++ b/test/files/pos/t942/Amount_1.java
@@ -1,0 +1,5 @@
+import java.util.concurrent.Callable;
+
+public abstract class Amount_1<Q> extends Object
+    implements Callable<Amount_1<?>> {
+}

--- a/test/files/pos/t942/Test_2.scala
+++ b/test/files/pos/t942/Test_2.scala
@@ -1,0 +1,3 @@
+abstract class Foo {
+  val x: Amount_1[Foo]
+}

--- a/test/pending/pos/t7778/Foo_1.java
+++ b/test/pending/pos/t7778/Foo_1.java
@@ -1,0 +1,6 @@
+import java.util.concurrent.Callable;
+
+public abstract class Foo_1<T> implements Callable<Foo_1<Object>.Inner> {
+    public abstract class Inner {
+    }
+}

--- a/test/pending/pos/t7778/Test_2.scala
+++ b/test/pending/pos/t7778/Test_2.scala
@@ -1,0 +1,3 @@
+class Test {
+  null: Foo_1[_]
+}


### PR DESCRIPTION
I'm looking at the changes made in 47f35b587, which
prevented cyclic errors in class file parsing. That fix
is insufficient for, or otherwise complicit in, SI-7778, for
which I've enclosed a pending test.

Review by @adriaanm
