### PR TITLE
SI-7779 Account for class name compactification in reflection

### DIFF
--- a/bincompat-backward.whitelist.conf
+++ b/bincompat-backward.whitelist.conf
@@ -267,6 +267,10 @@ filter {
         {
             matchName="scala.reflect.internal.SymbolTable.scala$reflect$internal$Trees$$duplicator"
             problemName=IncompatibleResultTypeProblem
+        },
+        {
+            matchName="scala.reflect.internal.StdNames.compactifyName"
+            problemName=MissingMethodProblem
         }
     ]
 }

--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -571,6 +571,18 @@ filter {
         {
             matchName="scala.reflect.internal.SymbolTable.scala$reflect$internal$Trees$$duplicator"
             problemName=IncompatibleResultTypeProblem
+        },
+        {
+            matchName="scala.reflect.runtime.JavaMirrors#JavaMirror.scala$reflect$runtime$JavaMirrors$JavaMirror$$PackageAndClassPattern"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.SymbolTable.compactifyName"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.StdNames.compactifyName"
+            problemName=MissingMethodProblem
         }
     ]
 }

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -44,6 +44,7 @@ trait StdNames {
     }
   }
 
+  private[reflect] def compactifyName(orig: String): String = compactify(orig)
   private final object compactify extends (String => String) {
     val md5 = MessageDigest.getInstance("MD5")
 

--- a/test/files/run/t7779.scala
+++ b/test/files/run/t7779.scala
@@ -1,0 +1,67 @@
+// -Xmax-classfile-length doesn't compress top-level classes.
+// class :::::::::::::::::::::::::::::::::::::::::::::::::
+
+trait Marker
+
+class Short extends Marker
+
+// We just test with member classes
+object O {
+  object ::::::::::::::::::::::::::::::::::::::::::::::::: extends Marker
+}
+class C {
+  class D {
+    class ::::::::::::::::::::::::::::::::::::::::::::::::: extends Marker
+  }
+}
+
+package pack {
+  // abbreviates to: $colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon to $read$$iw$$iw$$colon$colon$colon$colon$colon$colon$colon$colon$$$$c39b3f245029fbed9732fc888d44231b$$$$on$colon$colon$colon$colon$colon$colon$colon$colon$colon$colon
+  // class :::::::::::::::::::::::::::::::::::::::::::::::::
+
+  class Short extends Marker
+
+  // We just test with member classes
+  object O {
+    object ::::::::::::::::::::::::::::::::::::::::::::::::: extends Marker
+  }
+  class C {
+    class D {
+      class ::::::::::::::::::::::::::::::::::::::::::::::::: extends Marker
+    }
+  }
+  package p2 {
+    class Short extends Marker
+
+    object O {
+      object ::::::::::::::::::::::::::::::::::::::::::::::::: extends Marker
+    }
+    class C {
+      class D {
+        class ::::::::::::::::::::::::::::::::::::::::::::::::: extends Marker
+      }
+    }
+  }
+}
+
+
+object Test extends App {
+  import reflect.runtime.universe._
+  def test[T: TypeTag] = {
+    val tt = typeTag[T]
+    val clz = tt.mirror.runtimeClass(tt.tpe)
+    assert(classOf[Marker].isAssignableFrom(clz), clz.toString)
+  }
+
+  test[Short]
+  test[O.:::::::::::::::::::::::::::::::::::::::::::::::::.type]
+  test[C#D#`:::::::::::::::::::::::::::::::::::::::::::::::::`]
+
+  test[pack.Short]
+  test[pack.O.:::::::::::::::::::::::::::::::::::::::::::::::::.type]
+  test[pack.C#D#`:::::::::::::::::::::::::::::::::::::::::::::::::`]
+
+  test[pack.p2.Short]
+  test[pack.p2.O.:::::::::::::::::::::::::::::::::::::::::::::::::.type]
+  test[pack.p2.C#D#`:::::::::::::::::::::::::::::::::::::::::::::::::`]
+}


### PR DESCRIPTION
We have to assume that the classes we are reflecting on were
compiled with the default value for -Xmax-classfile-name (255).

With this assumption, we can apply the same name compactification
as done in the regular compiler.

The REPL is particularly prone to generating long class names
with the '$iw' prefixes, so this is an important fix for runtime
reflection.

Also adds support for getting the runtime class of `O.type` if
`O` is a module.

Review by @xeno-by
