### PR TITLE
add scaladoc canonical name

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -600,11 +600,11 @@ TODO:
     </path>
 
     <path id="quick.scaladoc.build.path">
+      <pathelement location="${build-quick.dir}/classes/scaladoc"/>
       <path refid="quick.xml.build.path"/>
       <path refid="quick.compiler.build.path"/>
       <path refid="quick.parser-combinators.build.path"/>
       <path refid="partest.classpath"/>
-      <pathelement location="${build-quick.dir}/classes/scaladoc"/>
     </path>
 
     <path id="quick.interactive.build.path">

--- a/src/library/scala/collection/GenTraversableLike.scala
+++ b/src/library/scala/collection/GenTraversableLike.scala
@@ -255,6 +255,8 @@ trait GenTraversableLike[+A, +Repr] extends Any with GenTraversableOnce[A] with 
    *  right hand operand. The element type of the $coll is the most specific superclass encompassing
    *  the element types of the two operands.
    *
+   *  @canonical    addCollection
+   *
    *  @param that   the traversable to append.
    *  @tparam B     the element type of the returned collection.
    *  @tparam That  $thatinfo

--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -173,6 +173,8 @@ trait TraversableLike[+A, +Repr] extends Any
    *  @return       a new collection of type `That` which contains all elements
    *                of this $coll followed by all elements of `that`.
    *
+   *  @canonical addOtherCollection
+   *
    *  @usecase def ++:[B](that: TraversableOnce[B]): $Coll[B]
    *    @inheritdoc
    *

--- a/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
@@ -46,7 +46,8 @@ trait CommentFactoryBase { this: MemberLookupBase =>
     group0:          Option[Body]     = None,
     groupDesc0:      Map[String,Body] = Map.empty,
     groupNames0:     Map[String,Body] = Map.empty,
-    groupPrio0:      Map[String,Body] = Map.empty
+    groupPrio0:      Map[String,Body] = Map.empty,
+    canonical0:      Option[String]   = None
   ) : Comment = new Comment{
     val body           = if(body0 isDefined) body0.get else Body(Seq.empty)
     val authors        = authors0
@@ -92,7 +93,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
           case _: java.lang.NumberFormatException => List()
         }
     }
-
+    val canonical = canonical0
   }
 
   private val endOfText = '\u0003'
@@ -344,6 +345,11 @@ trait CommentFactoryBase { this: MemberLookupBase =>
           Map.empty[String, Body] ++ pairs
         }
 
+        def canonicalText: Option[String] = oneTag(SimpleTagKey("canonical")) match {
+          case Some(Body(List(Paragraph(Chain(List(Summary(Text(canonical)))))))) => Some(canonical.toString.trim)
+          case _ => None
+        }
+
         val com = createComment (
           body0           = Some(parseWikiAtSymbol(docBody.toString, pos, site)),
           authors0        = allTags(SimpleTagKey("author")),
@@ -365,7 +371,8 @@ trait CommentFactoryBase { this: MemberLookupBase =>
           group0          = oneTag(SimpleTagKey("group")),
           groupDesc0      = allSymsOneTag(SimpleTagKey("groupdesc")),
           groupNames0     = allSymsOneTag(SimpleTagKey("groupname")),
-          groupPrio0      = allSymsOneTag(SimpleTagKey("groupprio"))
+          groupPrio0      = allSymsOneTag(SimpleTagKey("groupprio")),
+          canonical0      = canonicalText
         )
 
         for ((key, _) <- bodyTags)

--- a/src/scaladoc/scala/tools/nsc/doc/base/comment/Comment.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/comment/Comment.scala
@@ -123,9 +123,14 @@ abstract class Comment {
   /** Member group priorities */
   def groupPrio: Map[String,Int]
 
+  /** Canonical Name */
+  def canonical: Option[String]
+
+
   override def toString =
     body.toString + "\n" +
     (authors map ("@author " + _.toString)).mkString("\n") +
     (result map ("@return " + _.toString)).mkString("\n") +
-    (version map ("@version " + _.toString)).mkString
+    (version map ("@version " + _.toString)).mkString("\n") +
+    (canonical map ("@canonical " + _.toString)).mkString
 }

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
@@ -723,6 +723,14 @@ class Template(universe: doc.Universe, generator: DiagramGenerator, tpl: DocTemp
       </span>
       <span class="symbol">
         {
+          mbr match {
+            case nte: NonTemplateMemberEntity if nte.isUseCase =>
+              nte.useCaseOf.flatMap(_.comment).flatMap(_.canonical).map { canonical =>
+                <span class="canonical" title="Canonical / Searchable Name">{canonical}</span>
+              }.getOrElse(NodeSeq.Empty)
+            case _ => NodeSeq.Empty
+          }
+        }{
           val nameClass =
             if (mbr.isImplicitlyInherited)
               if (mbr.isShadowedOrAmbiguousImplicit)
@@ -734,21 +742,10 @@ class Template(universe: doc.Universe, generator: DiagramGenerator, tpl: DocTemp
 
           val nameHtml = {
             val value = if (mbr.isConstructor) tpl.name else mbr.name
-            val span = if (mbr.deprecation.isDefined)
+            if (mbr.deprecation.isDefined)
               <span class={ nameClass + " deprecated"} title={"Deprecated: "+bodyToStr(mbr.deprecation.get)}>{ value }</span>
             else
               <span class={ nameClass }>{ value }</span>
-            val encoded = scala.reflect.NameTransformer.encode(value)
-            if (encoded != value) {
-              span % new UnprefixedAttribute("title",
-                                             "gt4s: " + encoded +
-                                             span.attribute("title").map(
-                                               node => ". " + node
-                                             ).getOrElse(""),
-                                             scala.xml.Null)
-            } else {
-              span
-            }
           }
           if (!nameLink.isEmpty)
             <a href={nameLink}>{nameHtml}</a>

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
@@ -723,12 +723,19 @@ class Template(universe: doc.Universe, generator: DiagramGenerator, tpl: DocTemp
       </span>
       <span class="symbol">
         {
-          mbr match {
+          val maybeCanonical: Option[String] = mbr match {
             case nte: NonTemplateMemberEntity if nte.isUseCase =>
-              nte.useCaseOf.flatMap(_.comment).flatMap(_.canonical).map { canonical =>
-                <span class="canonical" title="Canonical / Searchable Name">{canonical}</span>
-              }.getOrElse(NodeSeq.Empty)
-            case _ => NodeSeq.Empty
+              nte.useCaseOf.flatMap(_.comment).flatMap(_.canonical)
+            case _: MemberEntity if mbr.comment.flatMap(_.canonical).isDefined =>
+              mbr.comment.flatMap(_.canonical)
+            case _ =>
+              None
+          }
+          maybeCanonical match {
+            case Some(canonical) =>
+              <span class="canonical" title="Canonical / Searchable Name">{canonical}</span>
+            case _ =>
+              NodeSeq.Empty
           }
         }{
           val nameClass =

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
@@ -114,6 +114,7 @@ class Template(universe: doc.Universe, generator: DiagramGenerator, tpl: DocTemp
       </div>
 
       { signature(tpl, isSelf = true) }
+      { memberToCanonicalName(tpl) }
       { memberToCommentHtml(tpl, tpl.inTemplate, isSelf = true) }
 
       <div id="mbrsel">
@@ -286,6 +287,23 @@ class Template(universe: doc.Universe, generator: DiagramGenerator, tpl: DocTemp
     </body>
   }
 
+  def memberToCanonicalName(mbr: MemberEntity): NodeSeq = {
+    val maybeCanonical: Option[String] = mbr match {
+      case nte: NonTemplateMemberEntity if nte.isUseCase =>
+        nte.useCaseOf.flatMap(_.comment).flatMap(_.canonical)
+      case _: MemberEntity if mbr.comment.flatMap(_.canonical).isDefined =>
+        mbr.comment.flatMap(_.canonical)
+      case _ =>
+        None
+    }
+    maybeCanonical match {
+      case Some(canonical) =>
+        <p class="canonical">Canonical / Searchable Name: {canonical}</p>
+      case _ =>
+        NodeSeq.Empty
+    }
+  }
+
   def memberToHtml(mbr: MemberEntity, inTpl: DocTemplateEntity): NodeSeq = {
     val memberComment = memberToCommentHtml(mbr, inTpl, isSelf = false)
     <li name={ mbr.definitionName } visbl={ if (mbr.visibility.isProtected) "prt" else "pub" }
@@ -295,6 +313,7 @@ class Template(universe: doc.Universe, generator: DiagramGenerator, tpl: DocTemp
       <a id={ mbr.signature }/>
       <a id={ mbr.signatureCompat }/>
       { signature(mbr, isSelf = false) }
+      { memberToCanonicalName(mbr) }
       { memberComment }
     </li>
   }
@@ -723,21 +742,6 @@ class Template(universe: doc.Universe, generator: DiagramGenerator, tpl: DocTemp
       </span>
       <span class="symbol">
         {
-          val maybeCanonical: Option[String] = mbr match {
-            case nte: NonTemplateMemberEntity if nte.isUseCase =>
-              nte.useCaseOf.flatMap(_.comment).flatMap(_.canonical)
-            case _: MemberEntity if mbr.comment.flatMap(_.canonical).isDefined =>
-              mbr.comment.flatMap(_.canonical)
-            case _ =>
-              None
-          }
-          maybeCanonical match {
-            case Some(canonical) =>
-              <span class="canonical" title="Canonical / Searchable Name">{canonical}</span>
-            case _ =>
-              NodeSeq.Empty
-          }
-        }{
           val nameClass =
             if (mbr.isImplicitlyInherited)
               if (mbr.isShadowedOrAmbiguousImplicit)

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.css
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.css
@@ -344,14 +344,6 @@ div.members > ol > li:last-child {
   color: darkseagreen;
 }
 
-.signature .symbol .canonical {
-  color: #ccc;
-}
-
-.signature .symbol .canonical:after {
-  content: " ";
-}
-
 .signature .symbol .params > .implicit {
   font-style: italic;
 }
@@ -577,6 +569,11 @@ div.fullcomment {
 }
 
 #template .shortcomment {
+  margin: 5px 0 0 14.7em;
+  padding: 0;
+}
+
+#template .canonical {
   margin: 5px 0 0 14.7em;
   padding: 0;
 }

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.css
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.css
@@ -344,6 +344,14 @@ div.members > ol > li:last-child {
   color: darkseagreen;
 }
 
+.signature .symbol .canonical {
+  color: #ccc;
+}
+
+.signature .symbol .canonical:after {
+  content: " ";
+}
+
 .signature .symbol .params > .implicit {
   font-style: italic;
 }

--- a/src/scaladoc/scala/tools/nsc/doc/model/IndexModelFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/IndexModelFactory.scala
@@ -18,21 +18,29 @@ object IndexModelFactory {
 
       object result extends mutable.HashMap[Char,SymbolMap] {
 
+        def firstLetter(name: String): Char = {
+          val ch = name.head.toLower
+          if(ch.isLetterOrDigit) ch else '_'
+        }
+
+        def letter(firstLetter: Char): SortedMap[String, SortedSet[MemberEntity]] = this.get(firstLetter).getOrElse {
+          immutable.SortedMap[String, SortedSet[MemberEntity]]()
+        }
+
         /* symbol name ordering */
         implicit def orderingMap = math.Ordering.String
 
         def addMember(d: MemberEntity) = {
-          val firstLetter = {
-            val ch = d.name.head.toLower
-            if(ch.isLetterOrDigit) ch else '_'
-          }
-          val letter = this.get(firstLetter).getOrElse {
-            immutable.SortedMap[String, SortedSet[MemberEntity]]()
-          }
-          val members = letter.get(d.name).getOrElse {
+          val dFirstLetter = firstLetter(d.name)
+          val dLetter = letter(dFirstLetter)
+          val members = dLetter.get(d.name).getOrElse {
             SortedSet.empty[MemberEntity](Ordering.by { _.toString })
           } + d
-          this(firstLetter) = letter + (d.name -> members)
+          d.useCaseOf.flatMap(_.comment).flatMap(_.canonical).foreach { canonicalName =>
+            val firstCanonicalLetter = firstLetter(canonicalName)
+            this(firstCanonicalLetter) = letter(firstCanonicalLetter) + (canonicalName -> members)
+          }
+          this(dFirstLetter) = dLetter + (d.name -> members)
         }
       }
 

--- a/test/scaladoc/resources/canonical.scala
+++ b/test/scaladoc/resources/canonical.scala
@@ -1,0 +1,10 @@
+package com.example.p1 {
+  class Foo {
+    /**
+     * @canonical addSomething
+     */
+    def ++ = "foo"
+  }
+
+  class Bar extends Foo
+}

--- a/test/scaladoc/scalacheck/HtmlFactoryTest.scala
+++ b/test/scaladoc/scalacheck/HtmlFactoryTest.scala
@@ -687,13 +687,13 @@ object Test extends Properties("HtmlFactory") {
 
     property("Foo") = files.get("com/example/p1/Foo.html") match {
       case Some(node: scala.xml.Node) =>
-        node.toString contains """<span class="canonical" title="Canonical / Searchable Name">addSomething</span>"""
+        node.toString contains """<p class="canonical">Canonical / Searchable Name: addSomething</p>"""
       case _ => false
     }
 
     property("Bar") = files.get("com/example/p1/Bar.html") match {
       case Some(node: scala.xml.Node) =>
-        node.toString contains """<span class="canonical" title="Canonical / Searchable Name">addSomething</span>"""
+        node.toString contains """<p class="canonical">Canonical / Searchable Name: addSomething</p>"""
       case _ => false
     }
   }

--- a/test/scaladoc/scalacheck/HtmlFactoryTest.scala
+++ b/test/scaladoc/scalacheck/HtmlFactoryTest.scala
@@ -204,18 +204,6 @@ object Test extends Properties("HtmlFactory") {
     createTemplate("Trac4180.scala") != None
   }
 
-  property("Trac #4372") = {
-    createTemplate("Trac4372.scala") match {
-      case node: scala.xml.Node => {
-        val html = node.toString
-        html.contains("<span title=\"gt4s: $plus$colon\" class=\"name\">+:</span>") &&
-          html.contains("<span title=\"gt4s: $minus$colon\" class=\"name\">-:</span>") &&
-            html.contains("""<span class="params">(<span name="n">n: <span class="extype" name="scala.Int">Int</span></span>)</span><span class="result">: <span class="extype" name="scala.Int">Int</span></span>""")
-      }
-      case _ => false
-    }
-  }
-
   property("Trac #4374 - public") = {
     val files = createTemplates("Trac4374.scala")
     files("WithPublic.html") match {
@@ -671,12 +659,6 @@ object Test extends Properties("HtmlFactory") {
       case Some(node: scala.xml.Node) => {
         property("implicit convertion") =
           node.toString contains "<span class=\"modifier\">implicit </span>"
-
-        property("gt4s") =
-          node.toString contains "title=\"gt4s: $colon$colon\""
-
-        property("gt4s of a deprecated method") =
-          node.toString contains "title=\"gt4s: $colon$colon$colon$colon. Deprecated: "
         true
       }
       case _ => false
@@ -699,4 +681,21 @@ object Test extends Properties("HtmlFactory") {
       case _ => false
     }
   }
+
+  {
+    val files = createTemplates("canonical.scala")
+
+    property("Foo") = files.get("com/example/p1/Foo.html") match {
+      case Some(node: scala.xml.Node) =>
+        node.toString contains """<span class="canonical" title="Canonical / Searchable Name">addSomething</span>"""
+      case _ => false
+    }
+
+    property("Bar") = files.get("com/example/p1/Bar.html") match {
+      case Some(node: scala.xml.Node) =>
+        node.toString contains """<span class="canonical" title="Canonical / Searchable Name">addSomething</span>"""
+      case _ => false
+    }
+  }
+
 }


### PR DESCRIPTION
One of the challenges I've had learning and using Scala is the use of symbol methods like `++:` because they lack a name.  Without a name symbols are hard to comprehend, search for, and talk about.  I find it is hard to mentally parse code that uses symbols that I don't have a name for.  Also, trying to search StackOverflow or DuckDuckGo for symbols is usually impossible or difficult.  An attempt was made to use a `Google Tag for Scala` (gt4s) that would provide a searchable name for symbols.  However this doesn't seem to have caught on possibly because the tag names were derived (lacking meaning) and because the ScalaDoc UI didn't plainly expose them.

This pull request tries a different approach by adding a new ScalaDoc tag, `@canonical` which allows symbol authors to provide a canonical name for a symbol.  That name is then displayed in the ScalaDoc signature:
![scaladoc-canonical](https://f.cloud.github.com/assets/65043/1020999/b4bc4b66-0cd7-11e3-97fe-df611a5ced3b.png)

This pull request includes two symbol names in `GenTraversableLike.scala` which are likely the wrong names but included as examples.
