### PR TITLE
Value class Depth.

### DIFF
--- a/src/compiler/scala/reflect/macros/compiler/Validators.scala
+++ b/src/compiler/scala/reflect/macros/compiler/Validators.scala
@@ -57,7 +57,7 @@ trait Validators {
       checkMacroImplResultTypeMismatch(atpeToRtpe(aret), rret)
 
       val maxLubDepth = lubDepth(aparamss.flatten map (_.tpe)) max lubDepth(rparamss.flatten map (_.tpe))
-      val atargs = solvedTypes(atvars, atparams, atparams map varianceInType(aret), upper = false, depth = maxLubDepth)
+      val atargs = solvedTypes(atvars, atparams, atparams map varianceInType(aret), upper = false, maxLubDepth)
       val boundsOk = typer.silent(_.infer.checkBounds(macroDdef, NoPrefix, NoSymbol, atparams, atargs, ""))
       boundsOk match {
         case SilentResultValue(true) => // do nothing, success

--- a/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
@@ -72,7 +72,7 @@ abstract class GenICode extends SubComponent  {
      *  it is the host class; otherwise the symbol's owner.
      */
     def findHostClass(selector: Type, sym: Symbol) = selector member sym.name match {
-      case NoSymbol   => log(s"Rejecting $selector as host class for $sym") ; sym.owner
+      case NoSymbol   => debuglog(s"Rejecting $selector as host class for $sym") ; sym.owner
       case _          => selector.typeSymbol
     }
 
@@ -739,7 +739,7 @@ abstract class GenICode extends SubComponent  {
                 resolveForwardLabel(ctx.defdef, ctx, sym)
                 ctx.labels.get(sym) match {
                   case Some(l) =>
-                    log("Forward jump for " + sym.fullLocationString + ": scan found label " + l)
+                    debuglog("Forward jump for " + sym.fullLocationString + ": scan found label " + l)
                     l
                   case _       =>
                     abort("Unknown label target: " + sym + " at: " + (fun.pos) + ": ctx: " + ctx)
@@ -845,7 +845,7 @@ abstract class GenICode extends SubComponent  {
             val sym = tree.symbol
             generatedType = toTypeKind(sym.info)
             val hostClass = findHostClass(qualifier.tpe, sym)
-            log(s"Host class of $sym with qual $qualifier (${qualifier.tpe}) is $hostClass")
+            debuglog(s"Host class of $sym with qual $qualifier (${qualifier.tpe}) is $hostClass")
             val qualSafeToElide = treeInfo isQualifierSafeToElide qualifier
 
             def genLoadQualUnlessElidable: Context =
@@ -1026,7 +1026,7 @@ abstract class GenICode extends SubComponent  {
      * type Null is holding a null.
      */
     private def adaptNullRef(from: TypeKind, to: TypeKind, ctx: Context, pos: Position) {
-      log(s"GenICode#adaptNullRef($from, $to, $ctx, $pos)")
+      debuglog(s"GenICode#adaptNullRef($from, $to, $ctx, $pos)")
 
       // Don't need to adapt null to unit because we'll just drop it anyway. Don't
       // need to adapt to Object or AnyRef because the JVM is happy with
@@ -1046,7 +1046,7 @@ abstract class GenICode extends SubComponent  {
     private def adapt(from: TypeKind, to: TypeKind, ctx: Context, pos: Position) {
       // An awful lot of bugs explode here - let's leave ourselves more clues.
       // A typical example is an overloaded type assigned after typer.
-      log(s"GenICode#adapt($from, $to, $ctx, $pos)")
+      debuglog(s"GenICode#adapt($from, $to, $ctx, $pos)")
 
       def coerce(from: TypeKind, to: TypeKind) = ctx.bb.emit(CALL_PRIMITIVE(Conversion(from, to)), pos)
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -36,7 +36,7 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
      *  it is the host class; otherwise the symbol's owner.
      */
     def findHostClass(selector: Type, sym: Symbol) = selector member sym.name match {
-      case NoSymbol   => log(s"Rejecting $selector as host class for $sym") ; sym.owner
+      case NoSymbol   => debuglog(s"Rejecting $selector as host class for $sym") ; sym.owner
       case _          => selector.typeSymbol
     }
 
@@ -330,7 +330,7 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
           val sym = tree.symbol
           generatedType = symInfoTK(sym)
           val hostClass = findHostClass(qualifier.tpe, sym)
-          log(s"Host class of $sym with qual $qualifier (${qualifier.tpe}) is $hostClass")
+          debuglog(s"Host class of $sym with qual $qualifier (${qualifier.tpe}) is $hostClass")
           val qualSafeToElide = treeInfo isQualifierSafeToElide qualifier
 
           def genLoadQualUnlessElidable() { if (!qualSafeToElide) { genLoadQualifier(tree) } }

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
@@ -1122,13 +1122,13 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
 
       for (m <- moduleClass.info.membersBasedOnFlags(ExcludedForwarderFlags, Flags.METHOD)) {
         if (m.isType || m.isDeferred || (m.owner eq ObjectClass) || m.isConstructor)
-          debuglog("No forwarder for '%s' from %s to '%s'".format(m, jclassName, moduleClass))
+          debuglog(s"No forwarder for '$m' from $jclassName to '$moduleClass'")
         else if (conflictingNames(m.name))
-          log("No forwarder for " + m + " due to conflict with " + linkedClass.info.member(m.name))
+          log(s"No forwarder for $m due to conflict with " + linkedClass.info.member(m.name))
         else if (m.hasAccessBoundary)
           log(s"No forwarder for non-public member $m")
         else {
-          log("Adding static forwarder for '%s' from %s to '%s'".format(m, jclassName, moduleClass))
+          debuglog(s"Adding static forwarder for '$m' from $jclassName to '$moduleClass'")
           addForwarder(isRemoteClass, jclass, moduleClass, m)
         }
       }

--- a/src/compiler/scala/tools/nsc/transform/Constructors.scala
+++ b/src/compiler/scala/tools/nsc/transform/Constructors.scala
@@ -44,8 +44,8 @@ abstract class Constructors extends Transform with ast.TreeDSL {
       val uninitializedVals = mutable.Set[Symbol](
         stats collect { case vd: ValDef if checkableForInit(vd.symbol) => vd.symbol.accessedOrSelf }: _*
       )
-      if (uninitializedVals.nonEmpty)
-        log("Checking constructor for init order issues among: " + uninitializedVals.map(_.name).mkString(", "))
+      if (uninitializedVals.size > 1)
+        log("Checking constructor for init order issues among: " + uninitializedVals.toList.map(_.name.toString.trim).distinct.sorted.mkString(", "))
 
       for (stat <- stats) {
         // Checking the qualifier symbol is necessary to prevent a selection on

--- a/src/compiler/scala/tools/nsc/transform/Flatten.scala
+++ b/src/compiler/scala/tools/nsc/transform/Flatten.scala
@@ -24,8 +24,8 @@ abstract class Flatten extends InfoTransform {
     val old   = (scope lookupUnshadowedEntries sym.name).toList
     old foreach (scope unlink _)
     scope enter sym
-    log(s"lifted ${sym.fullLocationString}" + ( if (old.isEmpty) "" else s" after unlinking $old from scope." ))
-    old
+    def old_s = old map (_.sym) mkString ", "
+    debuglog(s"In scope of ${sym.owner}, unlinked $old_s and entered $sym")
   }
 
   private def liftClass(sym: Symbol) {

--- a/src/compiler/scala/tools/nsc/typechecker/Checkable.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Checkable.scala
@@ -277,7 +277,9 @@ trait Checkable {
           parents foreach (p => checkCheckable(tree, p, X, inPattern, canRemedy))
         case _ =>
           val checker = new CheckabilityChecker(X, P)
-          log(checker.summaryString)
+          if (checker.result == RuntimeCheckable)
+            log(checker.summaryString)
+
           if (checker.neverMatches) {
             val addendum = if (checker.neverSubClass) "" else " (but still might match its erasure)"
             getContext.unit.warning(tree.pos, s"fruitless type test: a value of type $X cannot also be a $P$addendum")

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1026,7 +1026,7 @@ trait Contexts { self: Analyzer =>
         (scope lookupUnshadowedEntries name filter (e => qualifies(e.sym))).toList
 
       def newOverloaded(owner: Symbol, pre: Type, entries: List[ScopeEntry]) =
-        logResult(s"!!! lookup overloaded")(owner.newOverloaded(pre, entries map (_.sym)))
+        logResult(s"overloaded symbol in $pre")(owner.newOverloaded(pre, entries map (_.sym)))
 
       // Constructor lookup should only look in the decls of the enclosing class
       // not in the self-type, nor in the enclosing context, nor in imports (SI-4460, SI-6745)

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -644,8 +644,7 @@ trait Implicits {
             if (tvars.nonEmpty)
               typingLog("solve", ptLine("tvars" -> tvars, "tvars.constr" -> tvars.map(_.constr)))
 
-            val targs = solvedTypes(tvars, undetParams, undetParams map varianceInType(pt),
-                                    upper = false, lubDepth(List(itree2.tpe, pt)))
+            val targs = solvedTypes(tvars, undetParams, undetParams map varianceInType(pt), upper = false, lubDepth(itree2.tpe :: pt :: Nil))
 
             // #2421: check that we correctly instantiated type parameters outside of the implicit tree:
             checkBounds(itree2, NoPrefix, NoSymbol, undetParams, targs, "inferred ")

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -9,6 +9,7 @@ package typechecker
 import scala.collection.{ mutable, immutable }
 import scala.util.control.ControlThrowable
 import symtab.Flags._
+import scala.reflect.internal.Depth
 
 /** This trait contains methods related to type parameter inference.
  *
@@ -21,6 +22,7 @@ trait Infer extends Checkable {
   import global._
   import definitions._
   import typeDebug.ptBlock
+  import typeDebug.str.parentheses
   import typingStack.{ printTyping }
 
   /** The formal parameter types corresponding to `formals`.
@@ -132,34 +134,17 @@ trait Infer extends Checkable {
    *  @param upper      When `true` search for max solution else min.
    *  @throws NoInstance
    */
-  def solvedTypes(tvars: List[TypeVar], tparams: List[Symbol],
-                  variances: List[Variance], upper: Boolean, depth: Int): List[Type] = {
-
-    if (tvars.nonEmpty) {
-      def tp_s = (tparams, tvars).zipped map { case (tp, tv) => s"${tp.name}/$tv" } mkString ","
-      printTyping(s"solving for $tp_s")
+  def solvedTypes(tvars: List[TypeVar], tparams: List[Symbol], variances: List[Variance], upper: Boolean, depth: Depth): List[Type] = {
+    if (tvars.isEmpty) Nil else {
+      printTyping("solving for " + parentheses((tparams, tvars).zipped map ((p, tv) => s"${p.name}: $tv")))
+      // !!! What should be done with the return value of "solve", which is at present ignored?
+      // The historical commentary says "no panic, it's good enough to just guess a solution,
+      // we'll find out later whether it works", meaning don't issue an error here when types
+      // don't conform to bounds. That means you can never trust the results of implicit search.
+      // For an example where this was not being heeded, SI-2421.
+      solve(tvars, tparams, variances, upper, depth)
+      tvars map instantiate
     }
-
-    if (!solve(tvars, tparams, variances, upper, depth)) {
-      // no panic, it's good enough to just guess a solution, we'll find out
-      // later whether it works.  *ZAP* @M danger, Will Robinson! this means
-      // that you should never trust inferred type arguments!
-      //
-      // Need to call checkBounds on the args/typars or type1 on the tree
-      // for the expression that results from type inference see e.g., #2421:
-      // implicit search had been ignoring this caveat
-      // throw new DeferredNoInstance(() =>
-      //   "no solution exists for constraints"+(tvars map boundsString))
-    }
-    for (tvar <- tvars ; if tvar.constr.inst == tvar) {
-      if (tvar.origin.typeSymbol.info eq ErrorType)
-        // this can happen if during solving a cyclic type parameter
-        // such as T <: T gets completed. See #360
-        tvar.constr.inst = ErrorType
-      else
-        abort(tvar.origin+" at "+tvar.origin.typeSymbol.owner)
-    }
-    tvars map instantiate
   }
 
   def skipImplicit(tp: Type) = tp match {
@@ -554,10 +539,7 @@ trait Infer extends Checkable {
             "argument expression's type is not compatible with formal parameter type" + foundReqMsg(tp1, pt1))
         }
       }
-      val targs = solvedTypes(
-        tvars, tparams, tparams map varianceInTypes(formals),
-        upper = false, lubDepth(formals) max lubDepth(argtpes)
-      )
+      val targs = solvedTypes(tvars, tparams, tparams map varianceInTypes(formals), upper = false, lubDepth(formals) max lubDepth(argtpes))
       // Can warn about inferring Any/AnyVal as long as they don't appear
       // explicitly anywhere amongst the formal, argument, result, or expected type.
       def canWarnAboutAny = !(pt :: restpe :: formals ::: argtpes exists (t => (t contains AnyClass) || (t contains AnyValClass)))
@@ -1030,7 +1012,10 @@ trait Infer extends Checkable {
             val variances  =
               if (ctorTp.paramTypes.isEmpty) undetparams map varianceInType(ctorTp)
               else undetparams map varianceInTypes(ctorTp.paramTypes)
-            val targs      = solvedTypes(tvars, undetparams, variances, upper = true, lubDepth(List(resTp, pt)))
+
+            // Note: this is the only place where solvedTypes (or, indirectly, solve) is called
+            // with upper = true.
+            val targs = solvedTypes(tvars, undetparams, variances, upper = true, lubDepth(resTp :: pt :: Nil))
             // checkBounds(tree, NoPrefix, NoSymbol, undetparams, targs, "inferred ")
             // no checkBounds here. If we enable it, test bug602 fails.
             // TODO: reinstate checkBounds, return params that fail to meet their bounds to undetparams
@@ -1099,7 +1084,7 @@ trait Infer extends Checkable {
       val tvars1 = tvars map (_.cloneInternal)
       // Note: right now it's not clear that solving is complete, or how it can be made complete!
       // So we should come back to this and investigate.
-      solve(tvars1, tvars1 map (_.origin.typeSymbol), tvars1 map (_ => Variance.Covariant), upper = false)
+      solve(tvars1, tvars1 map (_.origin.typeSymbol), tvars1 map (_ => Variance.Covariant), upper = false, Depth.AnyDepth)
     }
 
     // this is quite nasty: it destructively changes the info of the syms of e.g., method type params

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -291,10 +291,13 @@ trait Namers extends MethodSynthesis {
     }
 
     private def logAssignSymbol(tree: Tree, sym: Symbol): Symbol = {
-      sym.name.toTermName match {
+      if (isPastTyper) sym.name.toTermName match {
         case nme.IMPORT | nme.OUTER | nme.ANON_CLASS_NAME | nme.ANON_FUN_NAME | nme.CONSTRUCTOR => ()
         case _                                                                                  =>
-          log("[+symbol] " + sym.debugLocationString)
+          tree match {
+            case md: DefDef => log("[+symbol] " + sym.debugLocationString)
+            case _          =>
+          }
       }
       tree.symbol = sym
       sym

--- a/src/compiler/scala/tools/nsc/typechecker/PatternTypers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternTypers.scala
@@ -340,11 +340,7 @@ trait PatternTypers {
 
       // use "tree" for the context, not context.tree: don't make another CaseDef context,
       // as instantiateTypeVar's bounds would end up there
-      log(sm"""|convert to case constructor {
-               |         tree: $tree: ${tree.tpe}
-               |       ptSafe: $ptSafe
-               | context.tree: ${context.tree}: ${context.tree.tpe}
-               |}""".trim)
+      log(s"convert ${tree.summaryString}: ${tree.tpe} to case constructor, pt=$ptSafe")
 
       val ctorContext = context.makeNewScope(tree, context.owner)
       freeVars foreach ctorContext.scope.enter

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3717,7 +3717,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
        *
        */
       def mkInvoke(cxTree: Tree, tree: Tree, qual: Tree, name: Name): Option[Tree] = {
-        log(s"dyna.mkInvoke($cxTree, $tree, $qual, $name)")
+        debuglog(s"dyna.mkInvoke($cxTree, $tree, $qual, $name)")
         val treeInfo.Applied(treeSelection, _, _) = tree
         def isDesugaredApply = treeSelection match {
           case Select(`qual`, nme.apply) => true

--- a/src/reflect/scala/reflect/internal/BaseTypeSeqs.scala
+++ b/src/reflect/scala/reflect/internal/BaseTypeSeqs.scala
@@ -130,9 +130,9 @@ trait BaseTypeSeqs {
 
     lazy val maxDepth = maxDepthOfElems
 
-    protected def maxDepthOfElems: Int = {
-      var d = 0
-      for (i <- 1 until length) d = max(d, typeDepth(elems(i)))
+    protected def maxDepthOfElems: Depth = {
+      var d = Depth.Zero
+      1 until length foreach (i => d = d max typeDepth(elems(i)))
       d
     }
 
@@ -234,7 +234,7 @@ trait BaseTypeSeqs {
     override def map(g: Type => Type) = lateMap(g)
     override def lateMap(g: Type => Type) = orig.lateMap(x => g(f(x)))
     override def exists(p: Type => Boolean) = elems exists (x => p(f(x)))
-    override protected def maxDepthOfElems: Int = elems.map(x => typeDepth(f(x))).max
+    override protected def maxDepthOfElems: Depth = elems.map(x => typeDepth(f(x))).max
     override def toString = elems.mkString("MBTS(", ",", ")")
   }
 

--- a/src/reflect/scala/reflect/internal/Depth.scala
+++ b/src/reflect/scala/reflect/internal/Depth.scala
@@ -1,0 +1,28 @@
+package scala
+package reflect
+package internal
+
+import Depth._
+
+final class Depth private (val depth: Int) extends AnyVal with Ordered[Depth] {
+  def max(that: Depth): Depth   = if (this < that) that else this
+  def decr(n: Int): Depth       = if (isAnyDepth) this else Depth(depth - n)
+  def incr(n: Int): Depth       = if (isAnyDepth) this else Depth(depth + n)
+  def decr: Depth               = decr(1)
+  def incr: Depth               = incr(1)
+
+  def isNegative = depth < 0
+  def isZero     = depth == 0
+  def isAnyDepth = this == AnyDepth
+
+  def compare(that: Depth): Int = if (depth < that.depth) -1 else if (this == that) 0 else 1
+  override def toString = s"Depth($depth)"
+}
+
+object Depth {
+  // A don't care value for the depth parameter in lubs/glbs and related operations.
+  final val AnyDepth = new Depth(Int.MinValue)
+  final val Zero     = new Depth(0)
+
+  @inline final def apply(depth: Int): Depth = if (depth < 0) AnyDepth else new Depth(depth)
+}

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -147,7 +147,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def name: NameType
     def name_=(n: Name): Unit = {
       if (shouldLogAtThisPhase) {
-        val msg = s"Renaming $fullLocationString to $n"
+        def msg = s"In $owner, renaming $name -> $n"
         if (isSpecialized) debuglog(msg) else log(msg)
       }
     }
@@ -2524,7 +2524,14 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     }
 
     def infosString = infos.toString
-    def debugLocationString = fullLocationString + " (flags: " + debugFlagString + ")"
+    def debugLocationString = {
+      val pre = flagString match {
+        case ""                  => ""
+        case s if s contains ' ' => "(" + s + ") "
+        case s                   => s + " "
+      }
+      pre + fullLocationString
+    }
 
     private def defStringCompose(infoString: String) = compose(
       flagString,

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -800,7 +800,7 @@ trait Types
       case TypeRef(_, sym, args) =>
         val that1 = existentialAbstraction(args map (_.typeSymbol), that)
         (that ne that1) && (this <:< that1) && {
-          log(s"$this.matchesPattern($that) depended on discarding args and testing <:< $that1")
+          debuglog(s"$this.matchesPattern($that) depended on discarding args and testing <:< $that1")
           true
         }
       case _ =>

--- a/src/reflect/scala/reflect/internal/Variance.scala
+++ b/src/reflect/scala/reflect/internal/Variance.scala
@@ -60,8 +60,7 @@ final class Variance private (val flags: Int) extends AnyVal {
 
   /** The symbolic annotation used to indicate the given kind of variance. */
   def symbolicString = (
-    if (isBivariant) "+/-"
-    else if (isCovariant) "+"
+    if (isCovariant) "+"
     else if (isContravariant) "-"
     else ""
   )

--- a/src/reflect/scala/reflect/internal/Variances.scala
+++ b/src/reflect/scala/reflect/internal/Variances.scala
@@ -92,7 +92,9 @@ trait Variances {
         val relative = relativeVariance(sym)
         val required = relative * variance
         if (!relative.isBivariant) {
-          log(s"verifying $sym (${sym.variance}${sym.locationString}) is $required at $base in ${base.owner}")
+          def sym_s  = s"$sym (${sym.variance}${sym.locationString})"
+          def base_s = s"$base in ${base.owner}" + (if (base.owner.isClass) "" else " in " + base.owner.enclClass)
+          log(s"verifying $sym_s is $required at $base_s")
           if (sym.variance != required)
             issueVarianceError(base, sym, required)
         }
@@ -146,7 +148,7 @@ trait Variances {
       )
       tree match {
         case defn: MemberDef if skip =>
-          log(s"Skipping variance check of ${sym.defString}")
+          debuglog(s"Skipping variance check of ${sym.defString}")
         case ClassDef(_, _, _, _) | TypeDef(_, _, _, _) =>
           validateVariance(sym)
           super.traverse(tree)

--- a/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
+++ b/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
@@ -19,7 +19,7 @@ private[internal] trait GlbLubs {
   private final val verifyLubs = true
 
 
-  private def printLubMatrix(btsMap: Map[Type, List[Type]], depth: Int) {
+  private def printLubMatrix(btsMap: Map[Type, List[Type]], depth: Depth) {
     import util.TableDef
     import TableDef.Column
     def str(tp: Type) = {
@@ -76,8 +76,8 @@ private[internal] trait GlbLubs {
     *                  (except that type constructors have been applied to their dummyArgs)
     *  @See baseTypeSeq  for a definition of sorted and upwards closed.
     */
-  def lubList(ts: List[Type], depth: Int): List[Type] = {
-    var lubListDepth = 0
+  def lubList(ts: List[Type], depth: Depth): List[Type] = {
+    var lubListDepth = Depth.Zero
     // This catches some recursive situations which would otherwise
     // befuddle us, e.g. pos/hklub0.scala
     def isHotForTs(xs: List[Type]) = ts exists (_.typeParams == xs.map(_.typeSymbol))
@@ -89,7 +89,7 @@ private[internal] trait GlbLubs {
     }
     // pretypes is a tail-recursion-preserving accumulator.
     @tailrec def loop(pretypes: List[Type], tsBts: List[List[Type]]): List[Type] = {
-      lubListDepth += 1
+      lubListDepth = lubListDepth.incr
 
       if (tsBts.isEmpty || (tsBts exists typeListIsEmpty)) pretypes.reverse
       else if (tsBts.tail.isEmpty) pretypes.reverse ++ tsBts.head
@@ -181,13 +181,13 @@ private[internal] trait GlbLubs {
 
   /** Eliminate from list of types all elements which are a subtype
     *  of some other element of the list. */
-  private def elimSub(ts: List[Type], depth: Int): List[Type] = {
+  private def elimSub(ts: List[Type], depth: Depth): List[Type] = {
     def elimSub0(ts: List[Type]): List[Type] = ts match {
       case List() => List()
       case List(t) => List(t)
       case t :: ts1 =>
-        val rest = elimSub0(ts1 filter (t1 => !isSubType(t1, t, decr(depth))))
-        if (rest exists (t1 => isSubType(t, t1, decr(depth)))) rest else t :: rest
+        val rest = elimSub0(ts1 filter (t1 => !isSubType(t1, t, depth.decr)))
+        if (rest exists (t1 => isSubType(t, t1, depth.decr))) rest else t :: rest
     }
     val ts0 = elimSub0(ts)
     if (ts0.isEmpty || ts0.tail.isEmpty) ts0
@@ -251,8 +251,8 @@ private[internal] trait GlbLubs {
       else if (isNumericSubType(t2, t1)) t1
       else IntTpe)
 
-  private val lubResults = new mutable.HashMap[(Int, List[Type]), Type]
-  private val glbResults = new mutable.HashMap[(Int, List[Type]), Type]
+  private val lubResults = new mutable.HashMap[(Depth, List[Type]), Type]
+  private val glbResults = new mutable.HashMap[(Depth, List[Type]), Type]
 
   /** Given a list of types, finds all the base classes they have in
     *  common, then returns a list of type constructors derived directly
@@ -299,7 +299,7 @@ private[internal] trait GlbLubs {
   }
 
   /** The least upper bound wrt <:< of a list of types */
-  protected[internal] def lub(ts: List[Type], depth: Int): Type = {
+  protected[internal] def lub(ts: List[Type], depth: Depth): Type = {
     def lub0(ts0: List[Type]): Type = elimSub(ts0, depth) match {
       case List() => NothingTpe
       case List(t) => t
@@ -321,7 +321,7 @@ private[internal] trait GlbLubs {
             lubType
           case None =>
             lubResults((depth, ts)) = AnyTpe
-            val res = if (depth < 0) AnyTpe else lub1(ts)
+            val res = if (depth.isNegative) AnyTpe else lub1(ts)
             lubResults((depth, ts)) = res
             res
         }
@@ -333,7 +333,7 @@ private[internal] trait GlbLubs {
       val lubOwner                 = commonOwner(ts)
       val lubBase                  = intersectionType(lubParents, lubOwner)
       val lubType =
-        if (phase.erasedTypes || depth == 0 ) lubBase
+        if (phase.erasedTypes || depth.isZero ) lubBase
         else {
           val lubRefined  = refinedType(lubParents, lubOwner)
           val lubThisType = lubRefined.typeSymbol.thisType
@@ -357,12 +357,12 @@ private[internal] trait GlbLubs {
               val symtypes =
                 map2(narrowts, syms)((t, sym) => t.memberInfo(sym).substThis(t.typeSymbol, lubThisType))
               if (proto.isTerm) // possible problem: owner of info is still the old one, instead of new refinement class
-                proto.cloneSymbol(lubRefined.typeSymbol).setInfoOwnerAdjusted(lub(symtypes, decr(depth)))
+                proto.cloneSymbol(lubRefined.typeSymbol).setInfoOwnerAdjusted(lub(symtypes, depth.decr))
               else if (symtypes.tail forall (symtypes.head =:= _))
                 proto.cloneSymbol(lubRefined.typeSymbol).setInfoOwnerAdjusted(symtypes.head)
               else {
                 def lubBounds(bnds: List[TypeBounds]): TypeBounds =
-                  TypeBounds(glb(bnds map (_.lo), decr(depth)), lub(bnds map (_.hi), decr(depth)))
+                  TypeBounds(glb(bnds map (_.lo), depth.decr), lub(bnds map (_.hi), depth.decr))
                 lubRefined.typeSymbol.newAbstractType(proto.name.toTypeName, proto.pos)
                   .setInfoOwnerAdjusted(lubBounds(symtypes map (_.bounds)))
               }
@@ -432,8 +432,8 @@ private[internal] trait GlbLubs {
     *  The counter breaks this recursion after two calls.
     *  If the recursion is broken, no member is added to the glb.
     */
-  private var globalGlbDepth = 0
-  private final val globalGlbLimit = 2
+  private var globalGlbDepth = Depth.Zero
+  private final val globalGlbLimit = Depth(2)
 
   /** The greatest lower bound of a list of types (as determined by `<:<`). */
   def glb(ts: List[Type]): Type = elimSuper(ts) match {
@@ -451,7 +451,7 @@ private[internal] trait GlbLubs {
       }
   }
 
-  protected[internal] def glb(ts: List[Type], depth: Int): Type = elimSuper(ts) match {
+  protected[internal] def glb(ts: List[Type], depth: Depth): Type = elimSuper(ts) match {
     case List() => AnyTpe
     case List(t) => t
     case ts0 => glbNorm(ts0, depth)
@@ -459,7 +459,7 @@ private[internal] trait GlbLubs {
 
   /** The greatest lower bound of a list of types (as determined by `<:<`), which have been normalized
     *  with regard to `elimSuper`. */
-  protected def glbNorm(ts: List[Type], depth: Int): Type = {
+  protected def glbNorm(ts: List[Type], depth: Depth): Type = {
     def glb0(ts0: List[Type]): Type = ts0 match {
       case List() => AnyTpe
       case List(t) => t
@@ -479,7 +479,7 @@ private[internal] trait GlbLubs {
             glbType
           case _ =>
             glbResults((depth, ts)) = NothingTpe
-            val res = if (depth < 0) NothingTpe else glb1(ts)
+            val res = if (depth.isNegative) NothingTpe else glb1(ts)
             glbResults((depth, ts)) = res
             res
         }
@@ -501,7 +501,7 @@ private[internal] trait GlbLubs {
         val ts1 = ts flatMap refinedToParents
         val glbBase = intersectionType(ts1, glbOwner)
         val glbType =
-          if (phase.erasedTypes || depth == 0) glbBase
+          if (phase.erasedTypes || depth.isZero) glbBase
           else {
             val glbRefined = refinedType(ts1, glbOwner)
             val glbThisType = glbRefined.typeSymbol.thisType
@@ -514,15 +514,15 @@ private[internal] trait GlbLubs {
               val symtypes = syms map glbThisType.memberInfo
               assert(!symtypes.isEmpty)
               proto.cloneSymbol(glbRefined.typeSymbol).setInfoOwnerAdjusted(
-                if (proto.isTerm) glb(symtypes, decr(depth))
+                if (proto.isTerm) glb(symtypes, depth.decr)
                 else {
                   def isTypeBound(tp: Type) = tp match {
                     case TypeBounds(_, _) => true
                     case _ => false
                   }
                   def glbBounds(bnds: List[Type]): TypeBounds = {
-                    val lo = lub(bnds map (_.bounds.lo), decr(depth))
-                    val hi = glb(bnds map (_.bounds.hi), decr(depth))
+                    val lo = lub(bnds map (_.bounds.lo), depth.decr)
+                    val hi = glb(bnds map (_.bounds.hi), depth.decr)
                     if (lo <:< hi) TypeBounds(lo, hi)
                     else throw GlbFailure
                   }
@@ -539,7 +539,7 @@ private[internal] trait GlbLubs {
             }
             if (globalGlbDepth < globalGlbLimit)
               try {
-                globalGlbDepth += 1
+                globalGlbDepth = globalGlbDepth.incr
                 val dss = ts flatMap refinedToDecls
                 for (ds <- dss; sym <- ds.iterator)
                   if (globalGlbDepth < globalGlbLimit && !specializesSym(glbThisType, sym, depth))
@@ -549,7 +549,7 @@ private[internal] trait GlbLubs {
                       case ex: NoCommonType =>
                     }
               } finally {
-                globalGlbDepth -= 1
+                globalGlbDepth = globalGlbDepth.decr
               }
             if (glbRefined.decls.isEmpty) glbBase else glbRefined
           }

--- a/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
@@ -232,9 +232,7 @@ trait TypeComparers {
     )
   }
 
-  def isSubType(tp1: Type, tp2: Type): Boolean = isSubType(tp1, tp2, AnyDepth)
-
-  def isSubType(tp1: Type, tp2: Type, depth: Int): Boolean = try {
+  def isSubType(tp1: Type, tp2: Type, depth: Depth = Depth.AnyDepth): Boolean = try {
     subsametypeRecursions += 1
 
     //OPT cutdown on Function0 allocation
@@ -314,7 +312,7 @@ trait TypeComparers {
     else TriState.Unknown
   }
 
-  private def isSubType1(tp1: Type, tp2: Type, depth: Int): Boolean = typeRelationPreCheck(tp1, tp2) match {
+  private def isSubType1(tp1: Type, tp2: Type, depth: Depth): Boolean = typeRelationPreCheck(tp1, tp2) match {
     case state if state.isKnown                                  => state.booleanValue
     case _ if typeHasAnnotations(tp1) || typeHasAnnotations(tp2) => annotationsConform(tp1, tp2) && (tp1.withoutAnnotations <:< tp2.withoutAnnotations)
     case _                                                       => isSubType2(tp1, tp2, depth)
@@ -338,7 +336,7 @@ trait TypeComparers {
   }
 
   // @assume tp1.isHigherKinded || tp2.isHigherKinded
-  def isHKSubType(tp1: Type, tp2: Type, depth: Int): Boolean = {
+  def isHKSubType(tp1: Type, tp2: Type, depth: Depth): Boolean = {
     def isSub(ntp1: Type, ntp2: Type) = (ntp1.withoutAnnotations, ntp2.withoutAnnotations) match {
       case (TypeRef(_, AnyClass, _), _)                                     => false                    // avoid some warnings when Nothing/Any are on the other side
       case (_, TypeRef(_, NothingClass, _))                                 => false
@@ -357,7 +355,7 @@ trait TypeComparers {
   }
 
   /** Does type `tp1` conform to `tp2`? */
-  private def isSubType2(tp1: Type, tp2: Type, depth: Int): Boolean = {
+  private def isSubType2(tp1: Type, tp2: Type, depth: Depth): Boolean = {
     def retry(lhs: Type, rhs: Type) = ((lhs ne tp1) || (rhs ne tp2)) && isSubType(lhs, rhs, depth)
 
     if (isSingleType(tp1) && isSingleType(tp2) || isConstantType(tp1) && isConstantType(tp2))

--- a/src/reflect/scala/reflect/internal/tpe/TypeConstraints.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeConstraints.scala
@@ -6,7 +6,6 @@ package tpe
 import scala.collection.{ generic }
 import generic.Clearable
 
-
 private[internal] trait TypeConstraints {
   self: SymbolTable =>
   import definitions._
@@ -191,12 +190,17 @@ private[internal] trait TypeConstraints {
 
     override def toString = {
       val boundsStr = {
-        val lo    = loBounds filterNot typeIsNothing
-        val hi    = hiBounds filterNot typeIsAny
-        val lostr = if (lo.isEmpty) Nil else List(lo.mkString(" >: (", ", ", ")"))
-        val histr = if (hi.isEmpty) Nil else List(hi.mkString(" <: (", ", ", ")"))
-
-        lostr ++ histr mkString ("[", " | ", "]")
+        val lo = loBounds filterNot typeIsNothing match {
+          case Nil       => ""
+          case tp :: Nil => " >: " + tp
+          case tps       => tps.mkString(" >: (", ", ", ")")
+        }
+        val hi = hiBounds filterNot typeIsAny match {
+          case Nil       => ""
+          case tp :: Nil => " <: " + tp
+          case tps       => tps.mkString(" <: (", ", ", ")")
+        }
+        lo + hi
       }
       if (inst eq NoType) boundsStr
       else boundsStr + " _= " + inst.safeToString
@@ -234,25 +238,25 @@ private[internal] trait TypeConstraints {
         if (!cyclic) {
           if (up) {
             if (bound.typeSymbol != AnyClass) {
-              log(s"$tvar addHiBound $bound.instantiateTypeParams($tparams, $tvars)")
+              debuglog(s"$tvar addHiBound $bound.instantiateTypeParams($tparams, $tvars)")
               tvar addHiBound bound.instantiateTypeParams(tparams, tvars)
             }
             for (tparam2 <- tparams)
               tparam2.info.bounds.lo.dealias match {
                 case TypeRef(_, `tparam`, _) =>
-                  log(s"$tvar addHiBound $tparam2.tpeHK.instantiateTypeParams($tparams, $tvars)")
+                  debuglog(s"$tvar addHiBound $tparam2.tpeHK.instantiateTypeParams($tparams, $tvars)")
                   tvar addHiBound tparam2.tpeHK.instantiateTypeParams(tparams, tvars)
                 case _ =>
               }
           } else {
             if (bound.typeSymbol != NothingClass && bound.typeSymbol != tparam) {
-              log(s"$tvar addLoBound $bound.instantiateTypeParams($tparams, $tvars)")
+              debuglog(s"$tvar addLoBound $bound.instantiateTypeParams($tparams, $tvars)")
               tvar addLoBound bound.instantiateTypeParams(tparams, tvars)
             }
             for (tparam2 <- tparams)
               tparam2.info.bounds.hi.dealias match {
                 case TypeRef(_, `tparam`, _) =>
-                  log(s"$tvar addLoBound $tparam2.tpeHK.instantiateTypeParams($tparams, $tvars)")
+                  debuglog(s"$tvar addLoBound $tparam2.tpeHK.instantiateTypeParams($tparams, $tvars)")
                   tvar addLoBound tparam2.tpeHK.instantiateTypeParams(tparams, tvars)
                 case _ =>
               }

--- a/src/reflect/scala/reflect/internal/util/package.scala
+++ b/src/reflect/scala/reflect/internal/util/package.scala
@@ -7,6 +7,8 @@ import scala.language.existentials // SI-6541
 package object util {
   import StringOps.longestCommonPrefix
 
+  def andFalse(body: Unit): Boolean = false
+
   // Shorten a name like Symbols$FooSymbol to FooSymbol.
   private def shortenName(name: String): String = {
     if (name == "") return ""

--- a/src/reflect/scala/reflect/runtime/SynchronizedTypes.scala
+++ b/src/reflect/scala/reflect/runtime/SynchronizedTypes.scala
@@ -4,6 +4,7 @@ package runtime
 
 import scala.collection.mutable.WeakHashMap
 import java.lang.ref.WeakReference
+import scala.reflect.internal.Depth
 
 /** This trait overrides methods in reflect.internal, bracketing
  *  them in synchronized { ... } to make them thread-safe
@@ -57,7 +58,7 @@ private[reflect] trait SynchronizedTypes extends internal.Types { self: SymbolTa
   override def isDifferentType(tp1: Type, tp2: Type): Boolean =
     subsametypeLock.synchronized { super.isDifferentType(tp1, tp2) }
 
-  override def isSubType(tp1: Type, tp2: Type, depth: Int): Boolean =
+  override def isSubType(tp1: Type, tp2: Type, depth: Depth): Boolean =
     subsametypeLock.synchronized { super.isSubType(tp1, tp2, depth) }
 
   private object lubglbLock


### PR DESCRIPTION
It's the obvious translation from a raw Int into a value class.

It wasn't that long ago one could find a signature like this:

```
  def merge(tps: List[Type], variance: Int, depth: Int): Type
```

Do you feel lucky, method caller? Well, do ya?

Anyway, now it is:

```
  def merge(tps: List[Type], variance: Variance, depth: Depth): Type
```

Forget for a moment the fact that you'd probably rather not pass variance
for depth and depth for variance and look at the type signatures:

```
  (List[Type], Variance, Depth) => Type
  (List[Type], Int, Int) => Type
```
