### PR TITLE
SI-7782 Derive type skolems at the ground level

### DIFF
--- a/src/reflect/scala/reflect/internal/ExistentialsAndSkolems.scala
+++ b/src/reflect/scala/reflect/internal/ExistentialsAndSkolems.scala
@@ -19,6 +19,9 @@ trait ExistentialsAndSkolems {
    *  can be deskolemized to the original type parameter. (A skolem is a
    *  representation of a bound variable when viewed inside its scope.)
    *  !!!Adriaan: this does not work for hk types.
+   *
+   *  Skolems will be created at level 0, rather than the current value
+   *  of `skolemizationLevel`. (See SI-7782)
    */
   def deriveFreshSkolems(tparams: List[Symbol]): List[Symbol] = {
     class Deskolemizer extends LazyType {
@@ -30,7 +33,11 @@ trait ExistentialsAndSkolems {
         sym setInfo sym.deSkolemize.info.substSym(typeParams, typeSkolems)
       }
     }
-    (new Deskolemizer).typeSkolems
+
+    val saved = skolemizationLevel
+    skolemizationLevel = 0
+    try new Deskolemizer().typeSkolems
+    finally skolemizationLevel = saved
   }
 
   def isRawParameter(sym: Symbol) = // is it a type parameter leaked by a raw type?

--- a/test/files/pos/t7782.scala
+++ b/test/files/pos/t7782.scala
@@ -1,0 +1,25 @@
+package pack
+
+object Test {
+  import O.empty
+  empty // this will trigger completion of `test`
+        // with skolemizationLevel = 1
+}
+
+object O {
+  // order matters (!!!)
+
+  // this order breaks under 2.10.x
+  def empty[E]: C[E] = ???
+  def empty(implicit a: Any): Any = ???
+}
+
+abstract class C[E] {
+  def foo[BB](f: BB)
+  def test[B](f: B): Any = foo(f)
+  // error: no type parameters for method foo: (<param> f: BB)scala.this.Unit exist so that it can be applied to arguments (B&1)
+  // --- because ---
+  // argument expression's type is not compatible with formal parameter type;
+  // found   : B&1
+  // required: ?BB
+}

--- a/test/files/pos/t7782b.scala
+++ b/test/files/pos/t7782b.scala
@@ -1,0 +1,25 @@
+package pack
+
+object Test {
+  import O.empty
+  empty // this will trigger completion of `test`
+        // with skolemizationLevel = 1
+}
+
+object O {
+  // order matters (!!!)
+
+  // this order breaks under 2.11.x
+  def empty(implicit a: Any): Any = ???
+  def empty[E]: C[E] = ???
+}
+
+abstract class C[E] {
+  def foo[BB](f: BB)
+  def test[B](f: B): Any = foo(f)
+  // error: no type parameters for method foo: (<param> f: BB)scala.this.Unit exist so that it can be applied to arguments (B&1)
+  // --- because ---
+  // argument expression's type is not compatible with formal parameter type;
+  // found   : B&1
+  // required: ?BB
+}


### PR DESCRIPTION
Rather than at the current value of `skolemizationLevel`,
which could be influenced by an in-flight existential
subtype computation.

This method is called in `PolyTypeCompleter`, which
could be constructed by the lazy type completer of the
enclosing class. So currently it is closing over a mutable
variable; hence the Heisenbug.

This issue was exposed by the changes in b74c33e,
which was introduced in Scala 2.10.1.

Review by @adriaanm, /cc @lrytz
