### PR TITLE
SI-7785 Preserve TypeVar suspension through TypeMaps

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2847,6 +2847,9 @@ trait Types
   // but pattern-matching returned the original constr0 (a bug)
   // now, pattern-matching returns the most recent constr
   object TypeVar {
+    private val ConstantTrue = ConstantType(Constant(true))
+    private val ConstantFalse = ConstantType(Constant(false))
+
     @inline final def trace[T](action: String, msg: => String)(value: T): T = {
       if (traceTypeVars) {
         val s = msg match {
@@ -3003,6 +3006,7 @@ trait Types
         this
       else if (newArgs.size == params.size) {
         val tv = TypeVar(origin, constr, newArgs, params)
+        tv.linkSuspended(this)
         TypeVar.trace("applyArgs", "In " + originLocation + ", apply args " + newArgs.mkString(", ") + " to " + originName)(tv)
       }
       else
@@ -3065,7 +3069,16 @@ trait Types
     // </region>
 
     // ignore subtyping&equality checks while true -- see findMember
-    private[Types] var suspended = false
+    // OPT: This could be Either[TypeVar, Boolean], but this encoding was chosen instead to save allocations.
+    private var _suspended: Type = TypeVar.ConstantFalse
+    private[Types] def suspended: Boolean = (_suspended: @unchecked) match {
+      case TypeVar.ConstantFalse => false
+      case TypeVar.ConstantTrue  => true
+      case tv: TypeVar           => tv.suspended
+    }
+    private[Types] def suspended_=(b: Boolean): Unit = _suspended = if (b) TypeVar.ConstantTrue else TypeVar.ConstantFalse
+    // SI-7785 Link the suspended attribute of a TypeVar created in, say, a TypeMap (e.g. AsSeenFrom) to its originator
+    private[Types] def linkSuspended(origin: TypeVar): Unit = _suspended = origin
 
     /** Called when a TypeVar is involved in a subtyping check.  Result is whether
      *  this TypeVar could plausibly be a [super/sub]type of argument `tp` and if so,

--- a/test/files/pos/t7785.scala
+++ b/test/files/pos/t7785.scala
@@ -1,0 +1,34 @@
+import scala.language._
+
+trait R[+Repr]
+
+trait TraversableOps {
+  implicit val R: R[Nothing] = ???
+
+  // Removing the implicit parameter in both fixes the crash
+  // removing it into one only gives a valid compiler error.
+  trait OpsDup1[Repr] {
+    def force(implicit bf: R[Repr]): Any
+  }
+
+  trait Ops[Repr] extends OpsDup1[Repr] {
+    def force(implicit bf: R[Repr], dummy: DummyImplicit): Any
+  }
+
+  implicit def ct2ops[T, C[+X]](t: C[T]):
+    Ops[C[T]]
+
+  def force[T](t: Option[T]) =
+    // ct2ops(t).force
+    t.force //Fails compilation on 2.10.2.
+
+
+  /* To get a closer look at the crash:
+  :power
+  val foo = typeOf[C].member(TermName("foo"))
+  val pt = analyzer.HasMember(TermName("force"))
+  val instantiated = foo.info.finalResultType.instantiateTypeParams(foo.typeParams, foo.typeParams.map(TypeVar(_)))
+  instantiated <:< pt
+  */
+  def foo[T, C[+X]]: Ops[C[T]]
+}


### PR DESCRIPTION
During `findMember`, TypeVars in `this` are placed into suspended
animation. This is to avoid running into recursive types when
matching members to those in base classes.

However, the mechanism used to do this is superficial, and doesn't
work when TypeVars are copied by TypeMaps. This seems to crop up
when using `AppliedTypeVar` with higher-kinded type vars.

In the enclosed test case, the cyclic type led to a SOE in
CommonOwnerMap.

This commit allows a TypeVar to delegate its `suspended` attribute
to the TypeVar from which it was copied. This is done in
`TypeVar#applyArgs`, which is called by:

```
// TypeMap#mapOver
case tv@TypeVar(_, constr) =>
  if (constr.instValid) this(constr.inst)
  else tv.applyArgs(mapOverArgs(tv.typeArgs, tv.params))
```

We should review the other places this is called to make sure
that it make sense to link in this way:

```
Types#appliedType
TypeVar#normalize
```

Review by @adriaanm.

Even though this was a regression in 2.10.1, I'm submitting this to 2.11 as the change isn't without risk, and the only reason this worked in 2.10.0 was because of another bug (`TypeVar` had a structural equals.)
