### PR TITLE
A better diagnostic error for corrupt or missing JARs.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1560,6 +1560,7 @@ TODO:
   <target name="test.junit" depends="test.junit.comp">
     <stopwatch name="test.junit.timer"/>
     <mkdir dir="${test.junit.classes}"/>
+    <echo message="Note: details of failed tests will be output to ${build-junit.dir}"/>
     <junit fork="yes" haltonfailure="yes" printsummary="on">
       <classpath refid="test.junit.compiler.build.path"/>
       <batchtest fork="yes" todir="${build-junit.dir}">

--- a/src/reflect/scala/reflect/io/ZipArchive.scala
+++ b/src/reflect/scala/reflect/io/ZipArchive.scala
@@ -126,7 +126,11 @@ abstract class ZipArchive(override val file: JFile) extends AbstractFile with Eq
 /** ''Note:  This library is considered experimental and should not be used unless you know what you are doing.'' */
 final class FileZipArchive(file: JFile) extends ZipArchive(file) {
   def iterator: Iterator[Entry] = {
-    val zipFile = new ZipFile(file)
+    val zipFile = try {
+      new ZipFile(file)
+    } catch {
+      case ioe: IOException => throw new IOException("Error accessing " + file.getPath, ioe)
+    }
     val root    = new DirEntry("/")
     val dirs    = mutable.HashMap[String, DirEntry]("/" -> root)
     val enum    = zipFile.entries()

--- a/test/junit/scala/reflect/io/ZipArchiveTest.scala
+++ b/test/junit/scala/reflect/io/ZipArchiveTest.scala
@@ -1,0 +1,37 @@
+package scala.reflect.io
+
+import java.io.{IOException, File => JFile}
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class ZipArchiveTest {
+
+  @Test
+  def corruptZip {
+    val f = JFile.createTempFile("test", ".jar")
+    val fza = new FileZipArchive(f)
+    try {
+      fza.iterator
+    } catch {
+      case x: IOException =>
+        assertTrue(x.getMessage, x.getMessage.contains(f.getPath))
+    } finally {
+      f.delete()
+    }
+  }
+
+  @Test
+  def missingFile {
+    val f = new JFile("xxx.does.not.exist")
+    val fza = new FileZipArchive(f)
+    try {
+      fza.iterator
+    } catch {
+      case x: IOException =>
+        assertTrue(x.getMessage, x.getMessage.contains(f.getPath))
+    }
+  }
+}


### PR DESCRIPTION
Augment the IOException with the name of the file we're trying
to open.

Motivated by a troubleshooting session with partial downloads
of JARs from Maven central breaking the Scala build on Martin's
laptop.

The test case only tests our part of the error message, so as not
to be platform / JDK specific. Otherwise, it would check that the
correct cause exception was present and accounted for.

Review by @gkossakowski
