### PR TITLE
SI-7791 Line number table reflects underlying file

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
@@ -2316,7 +2316,8 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
               lastLineNr = currentLineNr
               val lineLab = new asm.Label
               jmethod.visitLabel(lineLab)
-              lnEntries ::= LineNumberEntry(currentLineNr, lineLab)
+              val actual = iPos inUltimateSource iPos.source
+              lnEntries ::= LineNumberEntry(actual.line, lineLab)
             }
           }
 

--- a/src/partest-extras/scala/tools/partest/ScriptTest.scala
+++ b/src/partest-extras/scala/tools/partest/ScriptTest.scala
@@ -1,0 +1,21 @@
+/* NSC -- new Scala compiler
+ * Copyright 2005-2013 LAMP/EPFL
+ */
+
+package scala.tools.partest
+
+import scala.reflect.internal.util.ScalaClassLoader
+
+/** A `ScriptTest` is a `DirectTest` for which the code
+ *  is the contents of a script file.
+ */
+abstract class ScriptTest extends DirectTest {
+  def testmain = "TestMain"
+  override def extraSettings = s"-usejavacp -Xscript $testmain"
+  def scriptPath = testPath changeExtension "script"
+  def code = scriptPath.toFile.slurp
+  def show() = {
+    compile()
+    ScalaClassLoader(getClass.getClassLoader).run(testmain, Seq.empty[String])
+  }
+}

--- a/src/reflect/scala/reflect/internal/util/SourceFile.scala
+++ b/src/reflect/scala/reflect/internal/util/SourceFile.scala
@@ -86,6 +86,11 @@ object ScriptSourceFile {
 
     stripped
   }
+
+  def apply(underlying: BatchSourceFile) = {
+    val headerLen = headerLength(underlying.content)
+    new ScriptSourceFile(underlying, underlying.content drop headerLen, headerLen)
+  }
 }
 
 class ScriptSourceFile(underlying: BatchSourceFile, content: Array[Char], override val start: Int) extends BatchSourceFile(underlying.file, content) {

--- a/test/files/run/t7791-script-linenums.check
+++ b/test/files/run/t7791-script-linenums.check
@@ -1,0 +1,1 @@
+hello, scripted test

--- a/test/files/run/t7791-script-linenums.scala
+++ b/test/files/run/t7791-script-linenums.scala
@@ -1,0 +1,16 @@
+
+import scala.tools.partest.ScriptTest
+
+object Test extends ScriptTest {
+  object ExceptionLine {
+    def unapply(e: Exception) = Some(e.getStackTrace()(0).getLineNumber)
+  }
+  override def show() = {
+    import util._
+    Try(super.show()) match {
+      case Failure(ExceptionLine(7)) => ()
+      case Failure(e) => e.printStackTrace()
+      case Success(_) => Console println "Expected error"
+    }
+  }
+}

--- a/test/files/run/t7791-script-linenums.script
+++ b/test/files/run/t7791-script-linenums.script
@@ -1,0 +1,8 @@
+#!/bin/bash
+exec ${SCALA_HOME}/bin/scala "$0" "$@" 2>&1
+!#
+
+Console println s"hello, scripted test"
+
+throw new RuntimeException("failing")  // line 7
+


### PR DESCRIPTION
Since positions ultimately know their ultimate
positions in their ultimate source, use that line
number, ultimately, when emitting line number
table entries.

It is possible, but possibly not useful, to emit
both the actual (ultimate) line number and the
nominal one.

The `int`-valued line number of the `StackTraceElement`
is "derived" from the attribute.

note: working on clever way to test it.  Since REPL and scripter do the same thing, i.e., wrap some code, it ought to be easy to test them the same way.  The wrapping mechanism is quite different, but maybe this is an opportunity to reconsider that, under the aegis of replating.

I did see extempore's screed from 11/21/11, which you kind of wish had been backdated to 11/11/11:

```
This is a fresh start for script tests.
```
