### PR TITLE
Paring back the scope of our shared .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,10 +9,21 @@
 # see also test/files/.gitignore
 #
 
-*.jar
-*~
+#
+# JARs aren't checked in, they are fetched by Ant / pull_binary_libs.sh
+#
+# We could be more concise with /lib/**/*.jar but that assumes
+# a late-model git.
+#
+/lib/ant/*.jar
+/lib/*.jar
+/test/files/codelib/*.jar
+/test/files/lib/*.jar
+/test/files/speclib/instrumented.jar
+/tools/*.jar
 
-build.properties
+# Developer specific Ant properties
+/build.properties
 
 # target directories for ant build
 /build/
@@ -33,11 +44,5 @@ build.properties
 /.idea
 /.settings
 
-# bak files produced by ./cleanup-commit
-*.bak
-
 # Standard symbolic link to build/quick/bin
-qbin
-
-# Mac specific, but that is common enough a dev platform to warrant inclusion.
-.DS_Store
+/qbin


### PR DESCRIPTION
Importantly, limit the exclusion of build.properties
to the file in the root directory, paving the way for
the return of an SBT build.
- Unignores .bak, .jar, and ~
- limit ignorance of qbin to the root directory

.log files, generated by partest, are still ignored.

To see ignored files in your workspace, try:

```
git ls-files --others --ignored --exclude-standard -- test | grep log
git status --ignored -- test
```

Review by @paulp
