### PR TITLE
SI-7790 No ScriptEngine in 2.10 build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1240,9 +1240,11 @@ TODO:
           <attribute name="Class-Path" value="scala-reflect.jar scala-library.jar"/>
         </manifest>
       </pre>
+      <!-- script api is 2.11-only so far
       <jar-opts>
         <service type="javax.script.ScriptEngineFactory" provider="scala.tools.nsc.interpreter.IMain$Factory"/>
       </jar-opts>
+      -->
     </staged-pack>
   </target>
 


### PR DESCRIPTION
The service entry was inadvertendly added in
`e3b5e0ba40447970d621cfeed5cc1770df69884f`,
"Sanity for build.xml: exscriptus&positus delendus est,"
which is ant latin for: "Reduced copy/pasting to the best
of my antabilities."

With that degree of hubris, it was inevitable that the
commit introduced a copy/paste bug.  What is the Attic
Greek for copy/paste?

I'm pretty sure that in fifth century Athens they would
just pound one inscription to rubble using a bigger
inscription. They had slaves for that kind of work.
You never hear about Socrates tweaking the build script.
That's the reason he never wrote anything down.

Review by @adriaanm 
