### PR TITLE
SI-7810 Reflect private constructor

### DIFF
--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -1228,7 +1228,7 @@ private[reflect] trait JavaMirrors extends internal.SymbolTable with api.JavaUni
       val effectiveParamClasses =
         if (!constr.owner.owner.isStaticOwner) jclazz.getEnclosingClass +: paramClasses
         else paramClasses
-      jclazz getConstructor (effectiveParamClasses: _*)
+      jclazz getDeclaredConstructor (effectiveParamClasses: _*)
     }
 
     private def jArrayClass(elemClazz: jClass[_]): jClass[_] = {

--- a/test/files/run/reflect-priv-ctor.check
+++ b/test/files/run/reflect-priv-ctor.check
@@ -1,0 +1,1 @@
+privately constructed

--- a/test/files/run/reflect-priv-ctor.scala
+++ b/test/files/run/reflect-priv-ctor.scala
@@ -1,0 +1,22 @@
+
+import language.postfixOps
+import reflect.runtime._
+import universe._
+
+object Test {
+
+  class Foo private () {
+    override def toString = "privately constructed"
+  }
+
+  def main(args: Array[String]): Unit = {
+
+    //val foo = new Foo  // no access
+    val klass = currentMirror reflectClass typeOf[Foo].typeSymbol.asClass
+    val init  = typeOf[Foo].members find { case m: MethodSymbol => m.isConstructor case _ => false } get
+    val ctor  = klass reflectConstructor init.asMethod
+    val foo   = ctor()   // no access?
+    Console println foo
+  }
+}
+


### PR DESCRIPTION
`JavaMirror.constructorToJava` uses `getDeclaredConstructor` now
instead of `getConstructor`. This enables reflecting a private ctor.
