### PR TITLE
Eliminate TypeTrees with null original.

### DIFF
--- a/test/files/neg/classmanifests_new_deprecations.check
+++ b/test/files/neg/classmanifests_new_deprecations.check
@@ -7,9 +7,6 @@ classmanifests_new_deprecations.scala:3: warning: type ClassManifest in object P
 classmanifests_new_deprecations.scala:4: warning: type ClassManifest in object Predef is deprecated: Use `scala.reflect.ClassTag` instead
   val cm3: ClassManifest[Int] = null
            ^
-classmanifests_new_deprecations.scala:4: warning: type ClassManifest in object Predef is deprecated: Use `scala.reflect.ClassTag` instead
-  val cm3: ClassManifest[Int] = null
-      ^
 classmanifests_new_deprecations.scala:6: warning: type ClassManifest in package reflect is deprecated: Use scala.reflect.ClassTag instead
   def rcm1[T: scala.reflect.ClassManifest] = ???
             ^
@@ -19,9 +16,6 @@ classmanifests_new_deprecations.scala:7: warning: type ClassManifest in package 
 classmanifests_new_deprecations.scala:8: warning: type ClassManifest in package reflect is deprecated: Use scala.reflect.ClassTag instead
   val rcm3: scala.reflect.ClassManifest[Int] = null
                           ^
-classmanifests_new_deprecations.scala:8: warning: type ClassManifest in package reflect is deprecated: Use scala.reflect.ClassTag instead
-  val rcm3: scala.reflect.ClassManifest[Int] = null
-      ^
 classmanifests_new_deprecations.scala:10: warning: type ClassManifest in object Predef is deprecated: Use `scala.reflect.ClassTag` instead
   type CM[T] = ClassManifest[T]
                ^
@@ -29,5 +23,5 @@ classmanifests_new_deprecations.scala:15: warning: type ClassManifest in package
   type RCM[T] = scala.reflect.ClassManifest[T]
                               ^
 error: No warnings can be incurred under -Xfatal-warnings.
-10 warnings found
+8 warnings found
 one error found

--- a/test/files/neg/t935.check
+++ b/test/files/neg/t935.check
@@ -4,7 +4,4 @@ t935.scala:7: error: type arguments [Test3.B] do not conform to class E's type p
 t935.scala:13: error: type arguments [Test4.B] do not conform to class E's type parameter bounds [T <: String]
   val b: String @E[B](new B) = "hi"
                  ^
-t935.scala:13: error: type arguments [Test4.B] do not conform to class E's type parameter bounds [T <: String]
-  val b: String @E[B](new B) = "hi"
-      ^
-three errors found
+two errors found

--- a/test/files/run/existential-rangepos.check
+++ b/test/files/run/existential-rangepos.check
@@ -1,0 +1,13 @@
+[[syntax trees at end of                    patmat]] // newSource1.scala
+[0:76]package [0:0]<empty> {
+  [0:76]abstract class A[[17:18]T[17:18]] extends [20:76][76]scala.AnyRef {
+    [76]def <init>(): [20]A[T] = [76]{
+      [76][76][76]A.super.<init>();
+      [20]()
+    };
+    [24:51]private[this] val foo: [28]Set[_ <: T] = [47:51]null;
+    [28]<stable> <accessor> def foo: [28]Set[_ <: T] = [28][28]A.this.foo;
+    [54:74]<stable> <accessor> def bar: [58]Set[_ <: T]
+  }
+}
+

--- a/test/files/run/existential-rangepos.scala
+++ b/test/files/run/existential-rangepos.scala
@@ -1,0 +1,13 @@
+import scala.tools.partest._
+
+object Test extends DirectTest {
+  override def extraSettings: String = "-usejavacp -Yrangepos -Xprint:patmat -Xprint-pos -d " + testOutput.path
+
+  override def code = """
+abstract class A[T] {
+  val foo: Set[_ <: T] = null
+  val bar: Set[_ <: T]
+}""".trim
+
+  override def show(): Unit = Console.withErr(System.out)(compile())
+}


### PR DESCRIPTION
This is a retry of #2801 after figuring out the range position
error. Should there be anyone out there who compiles with -Xdev,
know that this commit eliminates the 1406 errors one presently
incurs compiling src/library.

A val declared in source code receives only one tree from the
parser, but two are needed - one for the field and one for the
getter. I discovered long ago that if the val had an existential
type, this was creating issues with incompatible existentials
between the field and the getter. However the remedy for that
did not take into account the whole of the wide range of super
subtle issues which accompany tree duplication.

In particular, the duplicated tree must be given not only a
fresh TypeTree(), but that TypeTree cannot share the same
original without running afoul of range position invariants.
That's because typedTypeTree resurrects the original tree with
whatever position it has - so the "original" needs to be a
duplicate of the original with a focused position.

Should the call to TypeTree.duplicate also duplicate the original?
I think so, but I bequeath this question to others.

This commit also eliminated some duplicate error messages, because
duplicate suppression depends on the errors having the same position.

See c478eb770d, 7a6fa80937 for previous related work.
