### PR TITLE
SI-7629 Deprecate view bounds

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2257,9 +2257,10 @@ self =>
         }
         if (contextBoundBuf ne null) {
           while (in.token == VIEWBOUND) {
-            contextBoundBuf += atPos(in.skipToken()) {
-              makeFunctionTypeTree(List(Ident(pname)), typ())
-            }
+            val msg = "Use an implicit parameter instead.\nExample: Instead of `def f[A <% Int](a: A)` use `def f[A](a: A)(implicit ev: A => Int)`."
+            if (settings.future)
+              deprecationWarning(in.offset, s"View bounds are deprecated. $msg")
+            contextBoundBuf += atPos(in.skipToken())(makeFunctionTypeTree(List(Ident(pname)), typ()))
           }
           while (in.token == COLON) {
             contextBoundBuf += atPos(in.skipToken()) {
@@ -2690,7 +2691,8 @@ self =>
           classContextBounds = contextBoundBuf.toList
           val tstart = (in.offset :: classContextBounds.map(_.pos.startOrPoint)).min
           if (!classContextBounds.isEmpty && mods.isTrait) {
-            syntaxError("traits cannot have type parameters with context bounds `: ...' nor view bounds `<% ...'", skipIt = false)
+            val viewBoundsExist = if (settings.future) "" else " nor view bounds `<% ...'"
+              syntaxError(s"traits cannot have type parameters with context bounds `: ...'$viewBoundsExist", skipIt = false)
             classContextBounds = List()
           }
           val constrAnnots = if (!mods.isTrait) constructorAnnotations() else Nil

--- a/test/files/neg/t7629-view-bounds-deprecation.check
+++ b/test/files/neg/t7629-view-bounds-deprecation.check
@@ -1,0 +1,11 @@
+t7629-view-bounds-deprecation.scala:2: warning: View bounds are deprecated. Use an implicit parameter instead.
+Example: Instead of `def f[A <% Int](a: A)` use `def f[A](a: A)(implicit ev: A => Int)`.
+  def f[A <% Int](a: A) = null
+          ^
+t7629-view-bounds-deprecation.scala:3: warning: View bounds are deprecated. Use an implicit parameter instead.
+Example: Instead of `def f[A <% Int](a: A)` use `def f[A](a: A)(implicit ev: A => Int)`.
+  def g[C, B <: C, A <% B : Numeric](a: A) = null
+                     ^
+error: No warnings can be incurred under -Xfatal-warnings.
+two warnings found
+one error found

--- a/test/files/neg/t7629-view-bounds-deprecation.flags
+++ b/test/files/neg/t7629-view-bounds-deprecation.flags
@@ -1,0 +1,1 @@
+-deprecation -Xfatal-warnings -Xfuture

--- a/test/files/neg/t7629-view-bounds-deprecation.scala
+++ b/test/files/neg/t7629-view-bounds-deprecation.scala
@@ -1,0 +1,4 @@
+object Test {
+  def f[A <% Int](a: A) = null
+  def g[C, B <: C, A <% B : Numeric](a: A) = null
+}

--- a/test/pending/t7629-view-bounds-removal.check
+++ b/test/pending/t7629-view-bounds-removal.check
@@ -1,0 +1,9 @@
+t7629-view-bounds-removal.scala:2: error: View bounds have been removed. Use an implicit parameter instead.
+Example: Instead of `def f[A <% Int](a: A)` use `def f[A](a: A)(implicit ev: A => Int)`.
+  def f[A <% Int](a: A) = null
+          ^
+t7629-view-bounds-removal.scala:3: error: View bounds have been removed. Use an implicit parameter instead.
+Example: Instead of `def f[A <% Int](a: A)` use `def f[A](a: A)(implicit ev: A => Int)`.
+  def g[C, B <: C, A <% B : Numeric](a: A) = null
+                     ^
+two errors found

--- a/test/pending/t7629-view-bounds-removal.flags
+++ b/test/pending/t7629-view-bounds-removal.flags
@@ -1,0 +1,1 @@
+-Xfuture

--- a/test/pending/t7629-view-bounds-removal.scala
+++ b/test/pending/t7629-view-bounds-removal.scala
@@ -1,0 +1,4 @@
+object Test {
+  def f[A <% Int](a: A) = null
+  def g[C, B <: C, A <% B : Numeric](a: A) = null
+}


### PR DESCRIPTION
This introduces a warning(/error with -Xfuture) with a general
migration advice. The IDE can use the warning to offer a quick fix
with the specific refactoring necessary.
