### PR TITLE
SI-7814 Avoid init cycle between Predef, `package`, ScalaRuntime

### DIFF
--- a/src/library/scala/runtime/ScalaRunTime.scala
+++ b/src/library/scala/runtime/ScalaRunTime.scala
@@ -34,20 +34,12 @@ object ScalaRunTime {
     clazz.isArray && (atLevel == 1 || isArrayClass(clazz.getComponentType, atLevel - 1))
 
   def isValueClass(clazz: jClass[_]) = clazz.isPrimitive()
-  def isTuple(x: Any) = x != null && tupleNames(x.getClass.getName)
+
+  // includes specialized subclasses and future proofed against hypothetical TupleN (for N > 22)
+  def isTuple(x: Any) = x != null && x.getClass.getName.startsWith("scala.Tuple")
   def isAnyVal(x: Any) = x match {
     case _: Byte | _: Short | _: Char | _: Int | _: Long | _: Float | _: Double | _: Boolean | _: Unit => true
     case _                                                                                             => false
-  }
-  // Avoiding boxing which messes up the specialized tests.  Don't ask.
-  private val tupleNames = {
-    var i = 22
-    var names: List[String] = Nil
-    while (i >= 1) {
-      names ::= ("scala.Tuple" + String.valueOf(i))
-      i -= 1
-    }
-    names.toSet
   }
 
   /** Return the class object representing an array with element class `clazz`.

--- a/src/library/scala/runtime/ScalaRunTime.scala
+++ b/src/library/scala/runtime/ScalaRunTime.scala
@@ -67,33 +67,37 @@ object ScalaRunTime {
     classTag[T].runtimeClass.asInstanceOf[jClass[T]]
 
   /** Retrieve generic array element */
-  def array_apply(xs: AnyRef, idx: Int): Any = xs match {
-    case x: Array[AnyRef]  => x(idx).asInstanceOf[Any]
-    case x: Array[Int]     => x(idx).asInstanceOf[Any]
-    case x: Array[Double]  => x(idx).asInstanceOf[Any]
-    case x: Array[Long]    => x(idx).asInstanceOf[Any]
-    case x: Array[Float]   => x(idx).asInstanceOf[Any]
-    case x: Array[Char]    => x(idx).asInstanceOf[Any]
-    case x: Array[Byte]    => x(idx).asInstanceOf[Any]
-    case x: Array[Short]   => x(idx).asInstanceOf[Any]
-    case x: Array[Boolean] => x(idx).asInstanceOf[Any]
-    case x: Array[Unit]    => x(idx).asInstanceOf[Any]
-    case null => throw new NullPointerException
+  def array_apply(xs: AnyRef, idx: Int): Any = {
+    xs match {
+      case x: Array[AnyRef]  => x(idx).asInstanceOf[Any]
+      case x: Array[Int]     => x(idx).asInstanceOf[Any]
+      case x: Array[Double]  => x(idx).asInstanceOf[Any]
+      case x: Array[Long]    => x(idx).asInstanceOf[Any]
+      case x: Array[Float]   => x(idx).asInstanceOf[Any]
+      case x: Array[Char]    => x(idx).asInstanceOf[Any]
+      case x: Array[Byte]    => x(idx).asInstanceOf[Any]
+      case x: Array[Short]   => x(idx).asInstanceOf[Any]
+      case x: Array[Boolean] => x(idx).asInstanceOf[Any]
+      case x: Array[Unit]    => x(idx).asInstanceOf[Any]
+      case null => throw new NullPointerException
+    }
   }
 
   /** update generic array element */
-  def array_update(xs: AnyRef, idx: Int, value: Any): Unit = xs match {
-    case x: Array[AnyRef]  => x(idx) = value.asInstanceOf[AnyRef]
-    case x: Array[Int]     => x(idx) = value.asInstanceOf[Int]
-    case x: Array[Double]  => x(idx) = value.asInstanceOf[Double]
-    case x: Array[Long]    => x(idx) = value.asInstanceOf[Long]
-    case x: Array[Float]   => x(idx) = value.asInstanceOf[Float]
-    case x: Array[Char]    => x(idx) = value.asInstanceOf[Char]
-    case x: Array[Byte]    => x(idx) = value.asInstanceOf[Byte]
-    case x: Array[Short]   => x(idx) = value.asInstanceOf[Short]
-    case x: Array[Boolean] => x(idx) = value.asInstanceOf[Boolean]
-    case x: Array[Unit]    => x(idx) = value.asInstanceOf[Unit]
-    case null => throw new NullPointerException
+  def array_update(xs: AnyRef, idx: Int, value: Any): Unit = {
+    xs match {
+      case x: Array[AnyRef]  => x(idx) = value.asInstanceOf[AnyRef]
+      case x: Array[Int]     => x(idx) = value.asInstanceOf[Int]
+      case x: Array[Double]  => x(idx) = value.asInstanceOf[Double]
+      case x: Array[Long]    => x(idx) = value.asInstanceOf[Long]
+      case x: Array[Float]   => x(idx) = value.asInstanceOf[Float]
+      case x: Array[Char]    => x(idx) = value.asInstanceOf[Char]
+      case x: Array[Byte]    => x(idx) = value.asInstanceOf[Byte]
+      case x: Array[Short]   => x(idx) = value.asInstanceOf[Short]
+      case x: Array[Boolean] => x(idx) = value.asInstanceOf[Boolean]
+      case x: Array[Unit]    => x(idx) = value.asInstanceOf[Unit]
+      case null => throw new NullPointerException
+    }
   }
 
   /** Get generic array length */

--- a/test/files/run/predef-cycle.scala
+++ b/test/files/run/predef-cycle.scala
@@ -1,0 +1,71 @@
+class Force {
+	val t1 = new Thread {
+    override def run() {
+      scala.`package`
+    }
+  }
+  val t2 = new Thread {
+    override def run() {
+      scala.Predef
+    }
+  }
+  t1.start()
+  t2.start()
+  t1.join()
+  t2.join()
+}
+
+object Test {
+  def main(args: Array[String]) {
+     new Force()
+  }
+}
+
+/* Was deadlocking:
+"Thread-2" prio=5 tid=7f9637268000 nid=0x119601000 in Object.wait() [119600000]
+   java.lang.Thread.State: RUNNABLE
+  at scala.Predef$.<init>(Predef.scala:90)
+  at scala.Predef$.<clinit>(Predef.scala)
+  at Force$$anon$2.run(predef-cycle.scala:10)
+
+"Thread-1" prio=5 tid=7f9637267800 nid=0x1194fe000 in Object.wait() [1194fb000]
+   java.lang.Thread.State: RUNNABLE
+  at scala.collection.immutable.Set$Set4.$plus(Set.scala:127)
+  at scala.collection.immutable.Set$Set4.$plus(Set.scala:121)
+  at scala.collection.mutable.SetBuilder.$plus$eq(SetBuilder.scala:24)
+  at scala.collection.mutable.SetBuilder.$plus$eq(SetBuilder.scala:22)
+  at scala.collection.generic.Growable$$anonfun$$plus$plus$eq$1.apply(Growable.scala:48)
+  at scala.collection.generic.Growable$$anonfun$$plus$plus$eq$1.apply(Growable.scala:48)
+  at scala.collection.immutable.List.foreach(List.scala:318)
+  at scala.collection.generic.Growable$class.$plus$plus$eq(Growable.scala:48)
+  at scala.collection.mutable.SetBuilder.$plus$plus$eq(SetBuilder.scala:22)
+  at scala.collection.TraversableLike$class.to(TraversableLike.scala:629)
+  at scala.collection.AbstractTraversable.to(Traversable.scala:105)
+  at scala.collection.TraversableOnce$class.toSet(TraversableOnce.scala:267)
+  at scala.collection.AbstractTraversable.toSet(Traversable.scala:105)
+  at scala.runtime.ScalaRunTime$.<init>(ScalaRunTime.scala:50)
+  at scala.runtime.ScalaRunTime$.<clinit>(ScalaRunTime.scala)
+  at scala.collection.mutable.HashTable$HashUtils$class.elemHashCode(HashTable.scala)
+  at scala.collection.mutable.HashMap.elemHashCode(HashMap.scala:39)
+  at scala.collection.mutable.HashTable$class.findOrAddEntry(HashTable.scala:161)
+  at scala.collection.mutable.HashMap.findOrAddEntry(HashMap.scala:39)
+  at scala.collection.mutable.HashMap.put(HashMap.scala:75)
+  at scala.collection.mutable.HashMap.update(HashMap.scala:80)
+  at scala.sys.SystemProperties$.addHelp(SystemProperties.scala:64)
+  at scala.sys.SystemProperties$.bool(SystemProperties.scala:68)
+  at scala.sys.SystemProperties$.noTraceSupression$lzycompute(SystemProperties.scala:80)
+  - locked <7b8b0e228> (a scala.sys.SystemProperties$)
+  at scala.sys.SystemProperties$.noTraceSupression(SystemProperties.scala:80)
+  at scala.util.control.NoStackTrace$.<init>(NoStackTrace.scala:31)
+  at scala.util.control.NoStackTrace$.<clinit>(NoStackTrace.scala)
+  at scala.util.control.NoStackTrace$class.fillInStackTrace(NoStackTrace.scala:22)
+  at scala.util.control.BreakControl.fillInStackTrace(Breaks.scala:93)
+  at java.lang.Throwable.<init>(Throwable.java:181)
+  at scala.util.control.BreakControl.<init>(Breaks.scala:93)
+  at scala.util.control.Breaks.<init>(Breaks.scala:28)
+  at scala.collection.Traversable$.<init>(Traversable.scala:96)
+  at scala.collection.Traversable$.<clinit>(Traversable.scala)
+  at scala.package$.<init>(package.scala:46)
+  at scala.package$.<clinit>(package.scala)
+  at Force$$anon$1.run(predef-cycle.scala:4)
+  */

--- a/test/instrumented/boxes.patch
+++ b/test/instrumented/boxes.patch
@@ -1,5 +1,5 @@
 9c9
-<
+< 
 ---
 > /* INSTRUMENTED VERSION */
 51a52,59

--- a/test/instrumented/library/scala/runtime/BoxesRunTime.java
+++ b/test/instrumented/library/scala/runtime/BoxesRunTime.java
@@ -1,6 +1,6 @@
 /*                     __                                               *\
 **     ________ ___   / /  ___     Scala API                            **
-**    / __/ __// _ | / /  / _ |    (c) 2006-2011, LAMP/EPFL             **
+**    / __/ __// _ | / /  / _ |    (c) 2006-2013, LAMP/EPFL             **
 **  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
 ** /____/\___/_/ |_/____/_/ | |                                         **
 **                          |/                                          **
@@ -244,7 +244,7 @@ public final class BoxesRunTime
      *  as yet have not.
      *
      *  Note: Among primitives, Float.NaN != Float.NaN, but the boxed
-     *  verisons are equal.  This still needs reconciliation.
+     *  versions are equal.  This still needs reconciliation.
      */
     public static int hashFromLong(java.lang.Long n) {
         int iv = n.intValue();
@@ -258,6 +258,9 @@ public final class BoxesRunTime
 
         long lv = n.longValue();
         if (lv == dv) return java.lang.Long.valueOf(lv).hashCode();
+
+        float fv = n.floatValue();
+        if (fv == dv) return java.lang.Float.valueOf(fv).hashCode();
         else return n.hashCode();
     }
     public static int hashFromFloat(java.lang.Float n) {

--- a/test/instrumented/srt.patch
+++ b/test/instrumented/srt.patch
@@ -1,67 +1,10 @@
 8a9,10
 > /* INSTRUMENTED VERSION */
 > 
-73a76,77
+68a71,72
 >   var arrayApplyCount = 0
 > 
-75,86c79,93
-<   def array_apply(xs: AnyRef, idx: Int): Any = xs match {
-<     case x: Array[AnyRef]  => x(idx).asInstanceOf[Any]
-<     case x: Array[Int]     => x(idx).asInstanceOf[Any]
-<     case x: Array[Double]  => x(idx).asInstanceOf[Any]
-<     case x: Array[Long]    => x(idx).asInstanceOf[Any]
-<     case x: Array[Float]   => x(idx).asInstanceOf[Any]
-<     case x: Array[Char]    => x(idx).asInstanceOf[Any]
-<     case x: Array[Byte]    => x(idx).asInstanceOf[Any]
-<     case x: Array[Short]   => x(idx).asInstanceOf[Any]
-<     case x: Array[Boolean] => x(idx).asInstanceOf[Any]
-<     case x: Array[Unit]    => x(idx).asInstanceOf[Any]
-<     case null => throw new NullPointerException
----
->   def array_apply(xs: AnyRef, idx: Int): Any = {
+70a75
 >     arrayApplyCount += 1
->     xs match {
->       case x: Array[AnyRef]  => x(idx).asInstanceOf[Any]
->       case x: Array[Int]     => x(idx).asInstanceOf[Any]
->       case x: Array[Double]  => x(idx).asInstanceOf[Any]
->       case x: Array[Long]    => x(idx).asInstanceOf[Any]
->       case x: Array[Float]   => x(idx).asInstanceOf[Any]
->       case x: Array[Char]    => x(idx).asInstanceOf[Any]
->       case x: Array[Byte]    => x(idx).asInstanceOf[Any]
->       case x: Array[Short]   => x(idx).asInstanceOf[Any]
->       case x: Array[Boolean] => x(idx).asInstanceOf[Any]
->       case x: Array[Unit]    => x(idx).asInstanceOf[Any]
->       case null => throw new NullPointerException
->     }
-88a96,97
->   var arrayUpdateCount = 0
-> 
-90,101c99,113
-<   def array_update(xs: AnyRef, idx: Int, value: Any): Unit = xs match {
-<     case x: Array[AnyRef]  => x(idx) = value.asInstanceOf[AnyRef]
-<     case x: Array[Int]     => x(idx) = value.asInstanceOf[Int]
-<     case x: Array[Double]  => x(idx) = value.asInstanceOf[Double]
-<     case x: Array[Long]    => x(idx) = value.asInstanceOf[Long]
-<     case x: Array[Float]   => x(idx) = value.asInstanceOf[Float]
-<     case x: Array[Char]    => x(idx) = value.asInstanceOf[Char]
-<     case x: Array[Byte]    => x(idx) = value.asInstanceOf[Byte]
-<     case x: Array[Short]   => x(idx) = value.asInstanceOf[Short]
-<     case x: Array[Boolean] => x(idx) = value.asInstanceOf[Boolean]
-<     case x: Array[Unit]    => x(idx) = value.asInstanceOf[Unit]
-<     case null => throw new NullPointerException
----
->   def array_update(xs: AnyRef, idx: Int, value: Any): Unit = {
->     arrayUpdateCount += 1
->     xs match {
->       case x: Array[AnyRef]  => x(idx) = value.asInstanceOf[AnyRef]
->       case x: Array[Int]     => x(idx) = value.asInstanceOf[Int]
->       case x: Array[Double]  => x(idx) = value.asInstanceOf[Double]
->       case x: Array[Long]    => x(idx) = value.asInstanceOf[Long]
->       case x: Array[Float]   => x(idx) = value.asInstanceOf[Float]
->       case x: Array[Char]    => x(idx) = value.asInstanceOf[Char]
->       case x: Array[Byte]    => x(idx) = value.asInstanceOf[Byte]
->       case x: Array[Short]   => x(idx) = value.asInstanceOf[Short]
->       case x: Array[Boolean] => x(idx) = value.asInstanceOf[Boolean]
->       case x: Array[Unit]    => x(idx) = value.asInstanceOf[Unit]
->       case null => throw new NullPointerException
->     }
+87a93
+>     arrayApplyCount += 1

--- a/test/junit/scala/runtime/ScalaRunTimeTest.scala
+++ b/test/junit/scala/runtime/ScalaRunTimeTest.scala
@@ -1,0 +1,70 @@
+package scala.runtime
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/** Tests for the private class DefaultPromise */
+@RunWith(classOf[JUnit4])
+class ScalaRunTimeTest {
+  @Test
+  def testIsTuple() {
+    import ScalaRunTime.isTuple
+    def check(v: Any) = {
+      assertTrue(v.toString, isTuple(v))
+    }
+
+    val s = ""
+    check(Tuple1(s))
+    check((s, s))
+    check((s, s, s))
+    check((s, s, s, s))
+    check((s, s, s, s, s))
+    check((s, s, s, s, s, s))
+    check((s, s, s, s, s, s, s))
+    check((s, s, s, s, s, s, s, s))
+    check((s, s, s, s, s, s, s, s, s))
+    check((s, s, s, s, s, s, s, s, s, s))
+    check((s, s, s, s, s, s, s, s, s, s, s))
+    check((s, s, s, s, s, s, s, s, s, s, s, s))
+    check((s, s, s, s, s, s, s, s, s, s, s, s, s))
+    check((s, s, s, s, s, s, s, s, s, s, s, s, s, s))
+    check((s, s, s, s, s, s, s, s, s, s, s, s, s, s, s))
+    check((s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s))
+    check((s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s))
+    check((s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s))
+    check((s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s))
+    check((s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s))
+    check((s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s))
+    check((s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s, s))
+
+    // some specialized variants will have mangled classnames
+    check(Tuple1(0))
+    check((0, 0))
+    check((0, 0, 0))
+    check((0, 0, 0, 0))
+    check((0, 0, 0, 0, 0))
+    check((0, 0, 0, 0, 0, 0))
+    check((0, 0, 0, 0, 0, 0, 0))
+    check((0, 0, 0, 0, 0, 0, 0, 0))
+    check((0, 0, 0, 0, 0, 0, 0, 0, 0))
+    check((0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+    check((0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+    check((0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+    check((0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+    check((0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+    check((0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+    check((0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+    check((0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+    check((0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+    check((0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+    check((0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+    check((0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+    check((0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+
+    case class C()
+    val c = new C()
+    assertFalse(c.toString, isTuple(c))
+  }
+}


### PR DESCRIPTION
Not every application will force these in a single thread; we
have to do our best to avoid cycles between them.

The enclosed test was failing every time before the change.

This commit breaks the cycle by avoiding computing `tupleNames`
in the constructor of `ScalaRuntime`. The new version has the
added benefit of including specialized tuple subclasses, which
is verified with a unit test for `isTuple`.

Are there more of these lurking? It seems likely. I'm more than
a little concerned about the way the `ControlThrowable` fires up
`scala.SystemProperties` to check whether or not to suppress
stack traces; there is already an ugly hack in place:

```
object NoStackTrace {
  final def noSuppression = _noSuppression

  // two-stage init to make checkinit happy,
  // since sys.SystemProperties.noTraceSupression.value
  // calls back into NoStackTrace.noSuppression
  final private var _noSuppression = false
  _noSuppression = sys.SystemProperties.noTraceSupression.value
}
```

Review by @paulp
