### PR TITLE
SI-7643 Enable newPatternMatching in interactive.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/PatternTypers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternTypers.scala
@@ -45,12 +45,6 @@ trait PatternTypers {
     }
   }
 
-  // when true:
-  //  - we may virtualize matches (if -Xexperimental and there's a suitable __match in scope)
-  //  - we synthesize PartialFunction implementations for `x => x match {...}` and `match {...}` when the expected type is PartialFunction
-  // this is disabled by: interactive compilation (we run it for scaladoc due to SI-5933)
-  protected def newPatternMatching = true // presently overridden in the presentation compiler
-
   trait PatternTyper {
     self: Typer =>
 

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2436,7 +2436,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
       // TODO: add fallback __match sentinel to predef
       val matchStrategy: Tree =
-        if (!(newPatternMatching && settings.Xexperimental && context.isNameInScope(vpmName._match))) null    // fast path, avoiding the next line if there's no __match to be seen
+        if (!(settings.Xexperimental && context.isNameInScope(vpmName._match))) null    // fast path, avoiding the next line if there's no __match to be seen
         else newTyper(context.makeImplicit(reportAmbiguousErrors = false)).silent(_.typed(Ident(vpmName._match)), reportAmbiguousErrors = false) orElse (_ => null)
 
       if (matchStrategy ne null) // virtualize
@@ -2713,7 +2713,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         fun.body match {
           // translate `x => x match { <cases> }` : PartialFunction to
           // `new PartialFunction { def applyOrElse(x, default) = x match { <cases> } def isDefinedAt(x) = ... }`
-          case Match(sel, cases) if (sel ne EmptyTree) && newPatternMatching && (pt.typeSymbol == PartialFunctionClass) =>
+          case Match(sel, cases) if (sel ne EmptyTree) && (pt.typeSymbol == PartialFunctionClass) =>
             // go to outer context -- must discard the context that was created for the Function since we're discarding the function
             // thus, its symbol, which serves as the current context.owner, is not the right owner
             // you won't know you're using the wrong owner until lambda lift crashes (unless you know better than to use the wrong owner)
@@ -3997,7 +3997,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         val selector = tree.selector
         val cases = tree.cases
         if (selector == EmptyTree) {
-          if (newPatternMatching && (pt.typeSymbol == PartialFunctionClass))
+          if (pt.typeSymbol == PartialFunctionClass)
             synthesizePartialFunction(newTermName(context.unit.fresh.newName("x")), tree.pos, tree, mode, pt)
           else {
             val arity = if (isFunctionType(pt)) pt.dealiasWiden.typeArgs.length - 1 else 1

--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -32,7 +32,6 @@ trait InteractiveAnalyzer extends Analyzer {
 
   override def newTyper(context: Context): InteractiveTyper = new Typer(context) with InteractiveTyper
   override def newNamer(context: Context): InteractiveNamer = new Namer(context) with InteractiveNamer
-  override protected def newPatternMatching = false
 
   trait InteractiveTyper extends Typer {
     override def canAdaptConstantTypeToLiteral = false

--- a/test/files/presentation/partial-fun.check
+++ b/test/files/presentation/partial-fun.check
@@ -1,0 +1,2 @@
+reload: PartialFun.scala
+ArrayBuffer()

--- a/test/files/presentation/partial-fun/Runner.scala
+++ b/test/files/presentation/partial-fun/Runner.scala
@@ -1,0 +1,10 @@
+import scala.tools.nsc.interactive.tests.InteractiveTest
+
+object Test extends InteractiveTest {
+  override def runDefaultTests() {
+    sourceFiles foreach (src => askLoadedTyped(src).get)
+    super.runDefaultTests()
+
+    println(compiler.unitOfFile.values.map(_.problems).mkString("", "\n", ""))
+  }
+}

--- a/test/files/presentation/partial-fun/partial-fun.check
+++ b/test/files/presentation/partial-fun/partial-fun.check
@@ -1,0 +1,1 @@
+reload: PartialFun.scala

--- a/test/files/presentation/partial-fun/src/PartialFun.scala
+++ b/test/files/presentation/partial-fun/src/PartialFun.scala
@@ -1,0 +1,5 @@
+class A {
+  def foo {
+    val x: PartialFunction[Int, Int] = ({ case 0 => 0 })
+  }
+}


### PR DESCRIPTION
Without it, the enclosed test fails with:

```
ArrayBuffer(Problem(RangePosition(partial-fun/src/PartialFun.scala, 62, 62, 77),type mismatch;
 found   : Int => Int
 required: PartialFunction[Int,Int],2))
```

And with that, we can remove this option altogether.

Review by @adriaanm
