### PR TITLE
SI-7805 REPL -i startup

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -854,9 +854,9 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     globalFuture = future {
       intp.initializeSynchronous()
       loopPostInit()
-      loadFiles(settings)
       !intp.reporter.hasErrors
     }
+    loadFiles(settings)
     printWelcome()
 
     try loop()

--- a/test/files/run/repl-trim-stack-trace.scala
+++ b/test/files/run/repl-trim-stack-trace.scala
@@ -1,10 +1,11 @@
 
-import scala.tools.partest.SessionTest
+import scala.tools.partest.{ SessionTest, Welcoming }
 
 // SI-7740
-object Test extends SessionTest {
+object Test extends SessionTest with Welcoming {
   def session =
-"""Type in expressions to have them evaluated.
+"""Welcome to Scala
+Type in expressions to have them evaluated.
 Type :help for more information.
 
 scala> def f = throw new Exception("Uh-oh")
@@ -35,10 +36,10 @@ scala> """
 
   // normalize the "elided" lines because the frame count depends on test context
   lazy val elided = """(\s+\.{3} )\d+( elided)""".r
-  def normalize(line: String) = line match {
+  override def normalize(line: String) = line match {
+    case welcome(w)               => w
     case elided(ellipsis, suffix) => s"$ellipsis???$suffix"
     case s                        => s
   }
-  override def eval()   = super.eval() map normalize
   override def expected = super.expected map normalize
 }

--- a/test/files/run/t7805-repl-i.check
+++ b/test/files/run/t7805-repl-i.check
@@ -1,0 +1,11 @@
+Loading t7805-repl-i.script...
+import util._
+
+Welcome to Scala
+Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> Console println Try(8)
+Success(8)
+
+scala> 

--- a/test/files/run/t7805-repl-i.scala
+++ b/test/files/run/t7805-repl-i.scala
@@ -1,0 +1,42 @@
+
+import scala.tools.partest.{ ReplTest, Welcoming }
+import scala.tools.nsc.{ GenericRunnerSettings, Settings }
+import scala.tools.nsc.settings.MutableSettings
+
+object Test extends ReplTest with HangingRepl with Welcoming {
+  def script = testPath changeExtension "script"
+  override def transformSettings(s: Settings) = s match {
+    case m: MutableSettings =>
+      val t = new GenericRunnerSettings(s.errorFn)
+      m copyInto t
+      t processArgumentString s"-i $script"
+      t
+    case _ => s
+  }
+  def code = "Console println Try(8)"
+}
+
+object Resulting {
+  import scala.concurrent._
+  import scala.concurrent.duration._
+  implicit class AwaitResult[A](val f: Future[A]) extends AnyVal {
+    def resultWithin(d: Duration): A = Await.result(f, d)
+  }
+}
+
+/** Test that hangs the REPL.
+ *  Usually that is the "before" case.
+ */
+trait HangingRepl extends ReplTest {
+  import scala.language.postfixOps
+  import scala.util._
+  import scala.concurrent._
+  import scala.concurrent.duration._
+  import ExecutionContext.Implicits._
+  import Resulting._
+  def timeout = 15 seconds
+  def hanging[A](a: =>A): A = future(a) resultWithin timeout
+  override def show() = Try(hanging(super.show())) recover {
+    case e => e.printStackTrace()
+  }
+}

--- a/test/files/run/t7805-repl-i.script
+++ b/test/files/run/t7805-repl-i.script
@@ -1,0 +1,1 @@
+import util._


### PR DESCRIPTION
Tested with a ReplTest that loads an include script.

ReplTests can choose to be `Welcoming` and keep a
normalized welcome message in their check transcript.

Review by @retronym 
