### PR TITLE
SI-7815 Dealias before deeming method type as dependent

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2626,7 +2626,7 @@ trait Types extends api.Types { self: SymbolTable =>
 
     private var isdepmeth: ThreeValue = UNKNOWN
     override def isDependentMethodType: Boolean = {
-      if (isdepmeth == UNKNOWN) isdepmeth = fromBoolean(IsDependentCollector.collect(resultType))
+      if (isdepmeth == UNKNOWN) isdepmeth = fromBoolean(IsDependentCollector.collect(resultType.dealias))
       toBoolean(isdepmeth)
     }
 
@@ -4807,7 +4807,7 @@ trait Types extends api.Types { self: SymbolTable =>
   object IsDependentCollector extends TypeCollector(false) {
     def traverse(tp: Type) {
       if (tp.isImmediatelyDependent) result = true
-      else if (!result) mapOver(tp)
+      else if (!result) mapOver(tp.dealias)
     }
   }
 

--- a/test/files/pos/t7815.scala
+++ b/test/files/pos/t7815.scala
@@ -1,0 +1,30 @@
+import language.higherKinds
+
+trait Foo[A <: AnyRef] {
+  type Repr
+  def f(a: A): Repr
+  def g(a: A): Option[Repr]
+
+  type M[X]
+  def m(a: A): M[a.type]
+
+  type Id[X] = X
+  def n(a: A): Id[(Repr, M[a.type])]
+
+}
+
+object Foo {
+  type Aux[A <: AnyRef, B] = Foo[A] { type Repr = B; type M[X] = Int }
+
+}
+
+object Main extends App {
+  def mapWithFoo[A <: AnyRef, B](as: List[A])(implicit foo: Foo.Aux[A, B]) = {
+    // Should be Eta expandable because the result type of `f` is not
+    // dependant on the value, it is just `B`.
+    as map foo.f
+    as map foo.g
+    as map foo.m
+    as map foo.n
+  }
+}


### PR DESCRIPTION
To enable eta-expansion of method types seen from a prefix that
renders the result type as independent from the parameter symbols.

The enclosed test shows that we dealias types before checking
dependence, and that we do this deeply (e.g. type arguments are
also dealised.)

An existing test, neg/error_dependentMethodTpeConversionToFunction,
confirms that bona-fide dependent methods are still prohibited from
eta expansion.

Review by @adriaanm. I think this is sufficiently localised and easy enough for us to reason about to consider inclusion in 2.10.4, but if you prefer I'll retarget at master.
