### PR TITLE
SI-7825 Consider DEFAULTMETHOD when refchecking concreteness

### DIFF
--- a/bincompat-backward.whitelist.conf
+++ b/bincompat-backward.whitelist.conf
@@ -303,6 +303,14 @@ filter {
         {
             matchName="scala.reflect.internal.Types.scala$reflect$internal$Types$$uniques_="
             problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.HasFlags.isDeferredOrDefault"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.HasFlags.isDeferredNotDefault"
+            problemName=MissingMethodProblem
         }
     ]
 }

--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -1407,6 +1407,30 @@ filter {
         {
             matchName="scala.reflect.internal.Types.scala$reflect$internal$Types$$uniques_="
             problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.Symbols#Symbol.isDeferredOrDefault"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.Symbols#Symbol.isDeferredNotDefault"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.HasFlags.isDeferredOrDefault"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.HasFlags.isDeferredNotDefault"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.Trees#Modifiers.isDeferredOrDefault"
+            problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.internal.Trees#Modifiers.isDeferredNotDefault"
+            problemName=MissingMethodProblem
         }
     ]
 }

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -383,7 +383,7 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
             overrideError("cannot be used here - classes can only override abstract types");
           } else if (other.isEffectivelyFinal) { // (1.2)
             overrideError("cannot override final member");
-          } else if (!other.isDeferred && !other.hasFlag(DEFAULTMETHOD) && !member.isAnyOverride && !member.isSynthetic) { // (*)
+          } else if (!other.isDeferredOrDefault && !member.isAnyOverride && !member.isSynthetic) { // (*)
             // (*) Synthetic exclusion for (at least) default getters, fixes SI-5178. We cannot assign the OVERRIDE flag to
             // the default getter: one default getter might sometimes override, sometimes not. Example in comment on ticket.
               if (isNeitherInClass && !(other.owner isSubClass member.owner))
@@ -565,7 +565,7 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
         def checkNoAbstractMembers(): Unit = {
           // Avoid spurious duplicates: first gather any missing members.
           def memberList = clazz.info.nonPrivateMembersAdmitting(VBRIDGE)
-          val (missing, rest) = memberList partition (m => m.isDeferred && !ignoreDeferred(m))
+          val (missing, rest) = memberList partition (m => m.isDeferredNotDefault && !ignoreDeferred(m))
           // Group missing members by the name of the underlying symbol,
           // to consolidate getters and setters.
           val grouped = missing groupBy (sym => analyzer.underlyingSymbol(sym).name)

--- a/src/reflect/scala/reflect/internal/HasFlags.scala
+++ b/src/reflect/scala/reflect/internal/HasFlags.scala
@@ -115,6 +115,9 @@ trait HasFlags {
   def isSynthetic        = hasFlag(SYNTHETIC)
   def isTrait            = hasFlag(TRAIT) && !hasFlag(PARAM)
 
+  def isDeferredOrDefault  = hasFlag(DEFERRED | DEFAULTMETHOD)
+  def isDeferredNotDefault = isDeferred && !hasFlag(DEFAULTMETHOD)
+
   def flagBitsToString(bits: Long): String = {
     // Fast path for common case
     if (bits == 0L) "" else {

--- a/test/files/run/t7398.scala
+++ b/test/files/run/t7398.scala
@@ -3,11 +3,9 @@ import scala.tools.partest._
 object Test extends CompilerTest {
   import global._
 
-  // This way we auto-pass on non-java8 since there's nothing to check
-  override lazy val units: List[CompilationUnit]  = testUnderJavaAtLeast("1.8") {
+  override lazy val units: List[CompilationUnit] = {
+    // This test itself does not depend on JDK8.
     javaCompilationUnits(global)(defaultMethodSource)
-  } otherwise {
-    Nil
   }
 
   private def defaultMethodSource = """

--- a/test/files/run/t7825.scala
+++ b/test/files/run/t7825.scala
@@ -1,0 +1,34 @@
+import scala.tools.partest._
+
+object Test extends CompilerTest {
+  import global._
+
+  override lazy val units: List[CompilationUnit] = {
+    // We can test this on JDK6.
+    javaCompilationUnits(global)(defaultMethodSource) ++ compilationUnits(global)(scalaExtendsDefault)
+  }
+
+  private def defaultMethodSource = """
+public interface Iterator<E> {
+    boolean hasNext();
+    E next();
+    default void remove() {
+        throw new UnsupportedOperationException("remove");
+    }
+}
+  """
+
+  private def scalaExtendsDefault = """
+object Test {
+  object X extends Iterator[String] {
+    def hasNext = true
+    def next = "!"
+  }
+}
+  """
+
+  // We're only checking we that the Scala compilation unit passes refchecks
+  // No further checks are needed here.
+  def check(source: String, unit: global.CompilationUnit): Unit = {
+  }
+}


### PR DESCRIPTION
A class should not be required to implement a Java default method.

This commit uses `isDeferredNotDefault` in place of `isDeferred`
when finding unimplemented methods.

The test itself does not depend on Java 8 as we use scalac's
Java source parser to set things up.

Review by @gkossakowski
