### PR TITLE
Avoid needless Type stringification when logging is disabled.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -316,7 +316,7 @@ trait Implicits {
    */
   class ImplicitSearch(tree: Tree, pt: Type, isView: Boolean, context0: Context, pos0: Position = NoPosition) extends Typer(context0) with ImplicitsContextErrors {
     val searchId = implicitSearchId()
-    private def typingLog(what: String, msg: String) =
+    private def typingLog(what: String, msg: => String) =
       typingStack.printTyping(tree, f"[search #$searchId] $what $msg")
 
     import infer._


### PR DESCRIPTION
Since 4d6be05c28, we've been a tad wasteful in implicit searches.

This adds a by-name parameter to the local logging method to
avoid that.

Review by @paulp
