### PR TITLE
Fix encoding problems in output of scaladoc -help

### DIFF
--- a/src/compiler/scala/tools/ant/templates/tool-unix.tmpl
+++ b/src/compiler/scala/tools/ant/templates/tool-unix.tmpl
@@ -198,6 +198,7 @@ execCommand \
   $(classpathArgs) \
   -Dscala.home="$SCALA_HOME" \
   -Dscala.usejavacp=true \
+  -Dfile.encoding=UTF-8 \
   $EMACS_OPT \
   $WINDOWS_OPT \
   @properties@ @class@ @toolflags@ "$@@"

--- a/src/compiler/scala/tools/ant/templates/tool-windows.tmpl
+++ b/src/compiler/scala/tools/ant/templates/tool-windows.tmpl
@@ -123,7 +123,7 @@ if "%_TOOL_CLASSPATH%"=="" (
 
 if not "%_LINE_TOOLCP%"=="" call :add_cpath "%_LINE_TOOLCP%"
 
-set _PROPS=-Dscala.home="!_SCALA_HOME!" -Denv.emacs="%EMACS%" -Dscala.usejavacp=true @properties@
+set _PROPS=-Dscala.home="!_SCALA_HOME!" -Denv.emacs="%EMACS%" -Dscala.usejavacp=true -Dfile.encoding=UTF-8 @properties@
 
 rem echo "%_JAVACMD%" %_JAVA_OPTS% %_PROPS% -cp "%_TOOL_CLASSPATH%" @class@ @toolflags@ %*
 "%_JAVACMD%" %_JAVA_OPTS% %_PROPS% -cp "%_TOOL_CLASSPATH%" @class@ @toolflags@ %*

--- a/src/compiler/scala/tools/nsc/doc/Settings.scala
+++ b/src/compiler/scala/tools/nsc/doc/Settings.scala
@@ -66,7 +66,7 @@ class Settings(error: String => Unit, val printMsg: String => Unit = println(_))
   val docsourceurl = StringSetting (
     "-doc-source-url",
     "url",
-    "A URL pattern used to build links to template sources; use variables, for example: ?{TPL_NAME} ('Seq'), ?{TPL_OWNER} ('scala.collection'), ?{FILE_PATH} ('scala/collection/Seq')",
+    "A URL pattern used to build links to template sources; use variables, for example: €{TPL_NAME} ('Seq'), €{TPL_OWNER} ('scala.collection'), €{FILE_PATH} ('scala/collection/Seq')",
     ""
   )
 


### PR DESCRIPTION
From the output of `scaladoc -help`:

```
  -doc-source-url <url>                       A URL pattern used to
  build links to template sources; use variables, for example:
  ?{TPL_NAME} ('Seq'), ?{TPL_OWNER} ('scala.collection'),
  ?{FILE_PATH} ('scala/collection/Seq')
```

The ? should be €. Fix that in the source, using the correct encoding (which is already UTF-8).

The encoding problem was introduced in 2011 by commit 2621ee63285808785159a3c24c9e5a5a723b8b9c, and seems to not have been reported till now.

---

To make the above work, the output should also be encoded correctly.
On my system, this requires the _default JVM encoding_ to be UTF-8 when the script is run, that is, passing `-Dfile.encoding=UTF-8`.

So, after this commit, the euro sign is garbled in the output of `./qbin/scaladoc -help` and correctly displayed in the output of `./qbin/scaladoc -Dfile.encoding=UTF-8 -help`.

That change might be necessary:
1. in general, or
2. only on systems with UTF-8 terminals and non-UTF-8 default encoding.

For option 1, I attach a commit making that option the default, and with bigger potential for bugs, so probably this should not go in 2.10.3.
For option 2, the first commit is enough, and it's trivial enough for 2.10.3.

What do you think?
