### PR TITLE
SI-7834 Type equivalence of C.this and C.super.

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4013,15 +4013,11 @@ trait Types
    *  type selections with the same name of equal (as determined by `=:=`) prefixes are
    *  considered equal in regard to `=:=`.
    */
-  def beginsWithTypeVarOrIsRefined(tp: Type): Boolean = tp match {
-    case SingleType(pre, sym) =>
-      !(sym hasFlag PACKAGE) && beginsWithTypeVarOrIsRefined(pre)
-    case tv@TypeVar(_, constr) =>
-      !tv.instValid || beginsWithTypeVarOrIsRefined(constr.inst)
-    case RefinedType(_, _) =>
-      true
-    case _ =>
-      false
+  def isEligibleForPrefixUnification(tp: Type): Boolean = tp match {
+    case SingleType(pre, sym)  => !(sym hasFlag PACKAGE) && isEligibleForPrefixUnification(pre)
+    case tv@TypeVar(_, constr) => !tv.instValid || isEligibleForPrefixUnification(constr.inst)
+    case RefinedType(_, _)     => true
+    case _                     => false
   }
 
   def isErrorOrWildcard(tp: Type) = (tp eq ErrorType) || (tp eq WildcardType)

--- a/test/files/neg/t7834neg.check
+++ b/test/files/neg/t7834neg.check
@@ -1,0 +1,41 @@
+t7834neg.scala:48: error: type mismatch;
+ found   : C.super.q.type (with underlying type M2)
+ required: C.super.q.type
+  x1 = x2  // fail
+       ^
+t7834neg.scala:50: error: type mismatch;
+ found   : C.super.q.type (with underlying type M1)
+ required: C.super.q.type
+  x2 = x1  // fail
+       ^
+t7834neg.scala:53: error: type mismatch;
+ found   : C.super.q.type (with underlying type M1)
+ required: C.this.q.type
+  x3 = x1  // fail
+       ^
+t7834neg.scala:54: error: type mismatch;
+ found   : C.super.q.type (with underlying type M2)
+ required: C.this.q.type
+  x3 = x2  // fail
+       ^
+t7834neg.scala:69: error: type mismatch;
+ found   : C.super.q.type (with underlying type M2)
+ required: C.super.q.type
+  x1 = super[S2].q  // fail
+                 ^
+t7834neg.scala:71: error: type mismatch;
+ found   : C.super.q.type (with underlying type M1)
+ required: C.super.q.type
+  x2 = super[S1].q  // fail
+                 ^
+t7834neg.scala:74: error: type mismatch;
+ found   : C.super.q.type (with underlying type M1)
+ required: C.this.q.type
+  x3 = super[S1].q  // fail
+                 ^
+t7834neg.scala:75: error: type mismatch;
+ found   : C.super.q.type (with underlying type M2)
+ required: C.this.q.type
+  x3 = super[S2].q  // fail
+                 ^
+8 errors found

--- a/test/files/neg/t7834neg.scala
+++ b/test/files/neg/t7834neg.scala
@@ -1,0 +1,76 @@
+class M1
+class M2 extends M1
+class M3 extends M2
+
+trait S1 { val q = new M1 ; val q1: q.type = q }
+trait S2 { val q = new M2 ; val q2: q.type = q }
+
+class B extends S1 with S2 {
+  override val q = new M3
+  val q3: q.type = q
+
+  var x1: B.super[S1].q1.type = null
+  var x2: B.super[S2].q2.type = null
+  var x3: B.this.q3.type      = null
+
+  x1 = x1
+  x1 = x2
+  x1 = x3
+  x2 = x1
+  x2 = x2
+  x2 = x3
+  x3 = x1
+  x3 = x2
+  x3 = x3
+
+  x1 = q1
+  x1 = q2
+  x1 = q3
+  x2 = q1
+  x2 = q2
+  x2 = q3
+  x3 = q1
+  x3 = q2
+  x3 = x3
+}
+
+class C extends S1 with S2 {
+  override val q = new M3
+  val q3: q.type = q
+
+  // x1's type and x2's type are incompatible
+  // x3's is assignable to x1 or x2, but not vice versa
+  var x1: C.super[S1].q.type = null
+  var x2: C.super[S2].q.type = null
+  var x3: C.this.q.type      = null
+
+  x1 = x1
+  x1 = x2  // fail
+  x1 = x3
+  x2 = x1  // fail
+  x2 = x2
+  x2 = x3
+  x3 = x1  // fail
+  x3 = x2  // fail
+  x3 = x3
+
+  x1 = q1
+  x1 = q2
+  x1 = q3
+  x2 = q1
+  x2 = q2
+  x2 = q3
+  x3 = q1
+  x3 = q2
+  x3 = x3
+
+  x1 = q
+  x1 = super[S1].q
+  x1 = super[S2].q  // fail
+  x2 = q
+  x2 = super[S1].q  // fail
+  x2 = super[S2].q
+  x3 = q
+  x3 = super[S1].q  // fail
+  x3 = super[S2].q  // fail
+}

--- a/test/files/pos/t7834.scala
+++ b/test/files/pos/t7834.scala
@@ -1,0 +1,6 @@
+class S { val q = "" }
+
+class B extends S {
+  val x1: B.super.q.type = q
+  val x2: B.this.q.type  = q
+}


### PR DESCRIPTION
Foo.this.x and Foo.super.x were roughly unrelated in the eyes
of isSubType. I implemented conformance as described in the comment:

```
  This is looking for situations such as B.this.x.type <:< B.super.x.type.
  If it's a ThisType on the lhs and a SuperType on the right, and they originate
  in the same class, and the 'x' in the ThisType has in its override chain
  the 'x' in the SuperType, then the types conform.
```

I think this is overly conservative but it's way ahead of
where it was.
