### PR TITLE
Quasiquotes: add syntactic extractor for assignment/update trees

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1405,7 +1405,7 @@ self =>
           if (in.token == EQUALS) {
             t match {
               case Ident(_) | Select(_, _) | Apply(_, _) =>
-                t = atPos(t.pos.startOrPoint, in.skipToken()) { makeAssign(t, expr()) }
+                t = atPos(t.pos.startOrPoint, in.skipToken()) { gen.mkAssign(t, expr()) }
               case _ =>
             }
           } else if (in.token == COLON) {

--- a/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
@@ -190,14 +190,6 @@ abstract class TreeBuilder {
     }
   }
 
-  /** Create a tree representing an assignment <lhs = rhs> */
-  def makeAssign(lhs: Tree, rhs: Tree): Tree = lhs match {
-    case Apply(fn, args) =>
-      Apply(atPos(fn.pos) { Select(fn, nme.update) }, args ::: List(rhs))
-    case _ =>
-      Assign(lhs, rhs)
-  }
-
   /** Tree for `od op`, start is start0 if od.pos is borked. */
   def makePostfixSelect(start0: Int, end: Int, od: Tree, op: Name): Tree = {
     val start = if (od.pos.isDefined) od.pos.startOrPoint else start0

--- a/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
@@ -10,7 +10,7 @@ trait Reifiers { self: Quasiquotes =>
   import global.build.{SyntacticClassDef, SyntacticTraitDef, SyntacticModuleDef,
                        SyntacticDefDef, SyntacticValDef, SyntacticVarDef,
                        SyntacticBlock, SyntacticApplied, SyntacticTypeApplied,
-                       SyntacticFunction, SyntacticNew}
+                       SyntacticFunction, SyntacticNew, SyntacticAssign}
   import global.treeInfo._
   import global.definitions._
   import Cardinality._
@@ -71,6 +71,8 @@ trait Reifiers { self: Quasiquotes =>
         reifyBuildCall(nme.SyntacticValDef, mods, name, tpt, rhs)
       case SyntacticVarDef(mods, name, tpt, rhs) =>
         reifyBuildCall(nme.SyntacticVarDef, mods, name, tpt, rhs)
+      case SyntacticAssign(lhs, rhs) =>
+        reifyBuildCall(nme.SyntacticAssign, lhs, rhs)
       case SyntacticApplied(fun, argss) if argss.length > 1 =>
         reifyBuildCall(nme.SyntacticApplied, fun, argss)
       case SyntacticApplied(fun, argss @ (_ :+ (_ :+ Placeholder(_, _, DotDotDot)))) =>

--- a/src/reflect/scala/reflect/api/BuildUtils.scala
+++ b/src/reflect/scala/reflect/api/BuildUtils.scala
@@ -193,5 +193,12 @@ private[reflect] trait BuildUtils { self: Universe =>
       def apply(mods: Modifiers, name: TermName, tpt: Tree, rhs: Tree): ValDef
       def unapply(tree: Tree): Option[(Modifiers, TermName, Tree, Tree)]
     }
+
+    val SyntacticAssign: SyntacticAssignExtractor
+
+    trait SyntacticAssignExtractor {
+      def apply(lhs: Tree, rhs: Tree): Tree
+      def unapply(tree: Tree): Option[(Tree, Tree)]
+    }
   }
 }

--- a/src/reflect/scala/reflect/internal/BuildUtils.scala
+++ b/src/reflect/scala/reflect/internal/BuildUtils.scala
@@ -404,6 +404,15 @@ trait BuildUtils { self: SymbolTable =>
 
     object SyntacticValDef extends SyntacticValDefBase { val isMutable = false }
     object SyntacticVarDef extends SyntacticValDefBase { val isMutable = true }
+
+    object SyntacticAssign extends SyntacticAssignExtractor {
+      def apply(lhs: Tree, rhs: Tree): Tree = gen.mkAssign(lhs, rhs)
+      def unapply(tree: Tree): Option[(Tree, Tree)] = tree match {
+        case Assign(lhs, rhs) => Some((lhs, rhs))
+        case Apply(Select(fn, nme.update), args :+ rhs) => Some((atPos(fn.pos)(Apply(fn, args)), rhs))
+        case _ => None
+      }
+    }
   }
 
   val build: BuildApi = new BuildImpl

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -591,6 +591,7 @@ trait StdNames {
     val SelectFromTypeTree: NameType   = "SelectFromTypeTree"
     val StringContext: NameType        = "StringContext"
     val SyntacticApplied: NameType     = "SyntacticApplied"
+    val SyntacticAssign: NameType      = "SyntacticAssign"
     val SyntacticBlock: NameType       = "SyntacticBlock"
     val SyntacticClassDef: NameType    = "SyntacticClassDef"
     val SyntacticDefDef: NameType      = "SyntacticDefDef"

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -437,4 +437,12 @@ abstract class TreeGen extends macros.TreeBuilder {
     else if (!stats.last.isTerm) Block(stats, Literal(Constant(())))
     else if (stats.length == 1) stats.head
     else Block(stats.init, stats.last)
+
+  /** Create a tree representing an assignment <lhs = rhs> */
+  def mkAssign(lhs: Tree, rhs: Tree): Tree = lhs match {
+    case Apply(fn, args) =>
+      Apply(atPos(fn.pos)(Select(fn, nme.update)), args :+ rhs)
+    case _ =>
+      Assign(lhs, rhs)
+  }
 }

--- a/test/files/scalacheck/quasiquotes/TermConstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/TermConstructionProps.scala
@@ -167,4 +167,24 @@ object TermConstructionProps extends QuasiquoteProperties("term construction") {
     val x = q"val x: Int = 1"
     assertThrows[IllegalArgumentException] { q"($x) => x" }
   }
+
+
+  property("assign variable") = test {
+    val v = q"v"
+    val value = q"foo"
+    assertEqAst(q"$v = $value", "v = foo")
+  }
+
+  property("assign update 1") = test {
+    val v = q"v"
+    val args = q"1" :: q"2" :: Nil
+    val value = q"foo"
+    assertEqAst(q"$v(..$args) = $value", "v(1, 2) = foo")
+  }
+
+  property("assign update 2") = test {
+    val a = q"v(0)"
+    val value = q"foo"
+    assertEqAst(q"$a = $value", "v(0) = foo")
+  }
 }

--- a/test/files/scalacheck/quasiquotes/TermDeconstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/TermDeconstructionProps.scala
@@ -91,4 +91,25 @@ object TermDeconstructionProps extends QuasiquoteProperties("term deconstruction
     matches("new { val early = 1} with Parent[Int] { body }")
     matches("new Foo { selfie => }")
   }
+
+  property("exhaustive assign pattern") = test {
+    def matches(line: String) {
+      val q"$rhs = $lhs" = parse(line)
+    }
+    matches("left = right")
+    matches("arr(1) = 2")
+  }
+
+  property("deconstruct update 1") = test {
+    val q"$obj(..$args) = $value" = q"foo(bar) = baz"
+    assert(obj ≈ q"foo")
+    assert(args ≈ List(q"bar"))
+    assert(value ≈ q"baz")
+  }
+
+  property("deconstruct update 2") = test {
+    val q"$left = $value" = q"foo(bar) = baz"
+    assert(left ≈ q"foo(bar)")
+    assert(value ≈ q"baz")
+  }
 }


### PR DESCRIPTION
Even though updates and assignments look the same syntactically they
are represented differently on the AST level. We need to abstract over
that.

review by @retronym 
