### PR TITLE
Remove build.number.maven

### DIFF
--- a/build.number.maven
+++ b/build.number.maven
@@ -1,3 +1,0 @@
-version.major=2
-version.minor=11
-version.patch=0

--- a/src/build/pack.xml
+++ b/src/build/pack.xml
@@ -12,7 +12,7 @@ PROPERTIES
   
   <!-- the maven stuff requires version.major, version.minor and version.patch properties.
        the "get-scala-revision" script only returns "version.number" -->
-  <property file="${basedir}/build.number.maven"/>
+  <property file="${basedir}/build.number"/>
   <!-- also need to know scala binary version and versions for xml and parsers -->
   <property file="${basedir}/versions.properties"/>
 


### PR DESCRIPTION
I can't find any justification for having this information
in both build.number and build.number.maven.

They have drifted apart on the 2.10.x branch, although that
doesn't matter because build.number is correct, and loaded first,
and Ant properties are write-once.

I'm assuming that the Ant tasks in src/build/pack.xml are only
invoked through the <antcall>-s in ./build.xml.

Here's a test of that from the 2.10.x branch:

```
% cat build.number
#Tue Sep 11 19:21:09 CEST 2007
version.major=2
version.minor=10
version.patch=3
# This is the -N part of a version.  if it's 0, it's dropped from maven versions.
version.bnum=0

# Note: To build a release run ant with -Dbuild.release=true
# To build an RC, run ant with -Dmaven.version.suffix=-RCN

% cat build.number.maven
version.major=2
version.minor=10
version.patch=0

% git diff
diff --git a/build.xml b/build.xml
index 3a83aa4..5cb952c 100644
--- a/build.xml
+++ b/build.xml
@@ -62,6 +62,9 @@ TODO:
   <target name="distpack" depends="dist.done, docs.done">
     <ant antfile="${src.dir}/build/pack.xml" target="pack-all.done" inheritall="yes" inh

+  <target name="distpack.maven.info">
+    <ant antfile="${src.dir}/build/pack.xml" target="pack-maven.info" inheritall="yes" i
+
   <target name="distpack-maven" depends="dist.done, docs.done">
     <ant antfile="${src.dir}/build/pack.xml" target="pack-maven.done" inheritall="yes" i

diff --git a/src/build/pack.xml b/src/build/pack.xml
index 20c4034..56863ff 100644
--- a/src/build/pack.xml
+++ b/src/build/pack.xml
@@ -133,6 +133,10 @@ MAIN DISTRIBUTION PACKAGING
     <mkdir dir="${dists.dir}/maven/${version.number}"/>
   </target>

+  <target name="pack-maven.info">
+    <echo message="version.patch = ${version.patch}"/>
+  </target>
+
   <target name="pack-maven.libs" depends="pack-maven.start">
     <macrodef name="mvn-copy-lib">
       <attribute name="mvn.artifact.name"/>

% ant distpack.maven.info
Buildfile: /Users/jason/code/scala2/build.xml

distpack.maven.info:

pack-maven.info:
     [echo] version.patch = 3
```

Notice how the stale `version.patch=0` in build.number.maven is
ignored.

Review by @lrytz @jsuereth @gkossakowski
