### PR TITLE
SI-7839 Final val breaks checkinit build

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -629,7 +629,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
   object terminal extends {
     val global: Global.this.type = Global.this
   } with SubComponent {
-    final val phaseName = "terminal"
+    val phaseName = "terminal"
     val runsAfter = List("jvm")
     val runsRightAfter = None
     override val terminal = true


### PR DESCRIPTION
Scalac does not care to initialize the unused field it emits
for a `final val`.  Users of the accessor method, which supplies
the constant definition inline, will find that -Xcheckinit will
throw.

Therefore, we don't use `final` for the `val phaseName`.
