### PR TITLE
SI-7844 Intellij setup.sh is not working for Ubuntu 12.04

### DIFF
--- a/src/intellij/setup.sh
+++ b/src/intellij/setup.sh
@@ -9,7 +9,7 @@ export BASE="$( cd "$( dirname "$0" )"/../.. && pwd )"
 echo "About to delete .ipr and .iml files and replace with the .SAMPLE files. Press enter to continue or CTRL-C to cancel."
 read
 
-(rm *.ipr *.iml 2>/dev/null)
+(rm -f *.ipr *.iml 2>/dev/null)
 for f in $(ls "$SCRIPT_DIR"/*.SAMPLE); do
 	NEW_FILE=`echo $f | perl -pe 's/.SAMPLE//'`;
 


### PR DESCRIPTION
I looked into the problem. It is not related to the system.

It is because when there is no file can be removed, "rm" will return error, but the bash script is using "set -e".
