### PR TITLE
Damage control related to AnyRef specialization

### DIFF
--- a/src/build/genprod.scala
+++ b/src/build/genprod.scala
@@ -113,8 +113,8 @@ object FunctionZero extends Function(0) {
 
 object FunctionOne extends Function(1) {
   override def classAnnotation    = "@annotation.implicitNotFound(msg = \"No implicit view available from ${T1} => ${R}.\")\n"
-  override def contravariantSpecs = "@specialized(scala.Int, scala.Long, scala.Float, scala.Double/*, scala.AnyRef*/) "
-  override def covariantSpecs     = "@specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double/*, scala.AnyRef*/) "
+  override def contravariantSpecs = "@specialized(scala.Int, scala.Long, scala.Float, scala.Double) "
+  override def covariantSpecs     = "@specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double) "
 
   override def descriptiveComment = "  " + functionNTemplate.format("succ", "anonfun1",
 """

--- a/src/library/scala/Function0.scala
+++ b/src/library/scala/Function0.scala
@@ -6,7 +6,7 @@
 **                          |/                                          **
 \*                                                                      */
 // GENERATED CODE: DO NOT EDIT.
-// genprod generated these sources at: Sun Mar 24 14:14:12 CET 2013
+// genprod generated these sources at: Sun Sep 15 20:42:00 CEST 2013
 
 package scala
 

--- a/src/library/scala/Function1.scala
+++ b/src/library/scala/Function1.scala
@@ -32,7 +32,7 @@ package scala
 
  */
 @annotation.implicitNotFound(msg = "No implicit view available from ${T1} => ${R}.")
-trait Function1[@specialized(scala.Int, scala.Long, scala.Float, scala.Double/*, scala.AnyRef*/) -T1, @specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double/*, scala.AnyRef*/) +R] extends AnyRef { self =>
+trait Function1[@specialized(scala.Int, scala.Long, scala.Float, scala.Double) -T1, @specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double) +R] extends AnyRef { self =>
   /** Apply the body of this function to the argument.
    *  @return   the result of function application.
    */

--- a/src/library/scala/runtime/AbstractFunction1.scala
+++ b/src/library/scala/runtime/AbstractFunction1.scala
@@ -9,6 +9,6 @@
 
 package scala.runtime
 
-abstract class AbstractFunction1[@specialized(scala.Int, scala.Long, scala.Float, scala.Double/*, scala.AnyRef*/) -T1, @specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double/*, scala.AnyRef*/) +R] extends Function1[T1, R] {
+abstract class AbstractFunction1[@specialized(scala.Int, scala.Long, scala.Float, scala.Double) -T1, @specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double) +R] extends Function1[T1, R] {
 
 }

--- a/src/library/scala/runtime/AbstractPartialFunction.scala
+++ b/src/library/scala/runtime/AbstractPartialFunction.scala
@@ -25,7 +25,7 @@ import scala.annotation.unspecialized
  *  @author  Pavel Pavlov
  *  @since   2.10
  */
-abstract class AbstractPartialFunction[@specialized(scala.Int, scala.Long, scala.Float, scala.Double, scala.AnyRef) -T1, @specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double, scala.AnyRef) +R] extends Function1[T1, R] with PartialFunction[T1, R] { self =>
+abstract class AbstractPartialFunction[@specialized(scala.Int, scala.Long, scala.Float, scala.Double) -T1, @specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double) +R] extends Function1[T1, R] with PartialFunction[T1, R] { self =>
   // this method must be overridden for better performance,
   // for backwards compatibility, fall back to the one inherited from PartialFunction
   // this assumes the old-school partial functions override the apply method, though
@@ -34,4 +34,16 @@ abstract class AbstractPartialFunction[@specialized(scala.Int, scala.Long, scala
   // probably okay to make final since classes compiled before have overridden against the old version of AbstractPartialFunction
   // let's not make it final so as not to confuse anyone
   /*final*/ def apply(x: T1): R = applyOrElse(x, PartialFunction.empty)
+}
+
+// Manual stand-ins for formerly specialized variations.
+// Not comprehensive, only sufficent to run scala-check built scala 2.11.0-M5
+// TODO Scala 2.10.0.M6 Remove this once scalacheck is published against M6.
+private[runtime] abstract class AbstractPartialFunction$mcIL$sp extends scala.runtime.AbstractPartialFunction[Any, Int] {
+    override def apply(x: Any): Int = apply$mcIL$sp(x)
+    def apply$mcIL$sp(x: Any): Int = applyOrElse(x, PartialFunction.empty)
+}
+private[runtime] abstract class AbstractPartialFunction$mcFL$sp extends scala.runtime.AbstractPartialFunction[Any, Float] {
+    override def apply(x: Any): Float = apply$mcIL$sp(x)
+    def apply$mcIL$sp(x: Any): Float = applyOrElse(x, PartialFunction.empty)
 }

--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -90,6 +90,8 @@ trait Names extends api.Names {
    */
   final def newTermName(cs: Array[Char], offset: Int, len: Int, cachedString: String): TermName = {
     def body = {
+      require(offset >= 0, "offset must be non-negative, got " + offset)
+      require(len >= 0, "length must be non-negative, got " + len)
       val h = hashValue(cs, offset, len) & HASH_MASK
       var n = termHashtable(h)
       while ((n ne null) && (n.length != len || !equals(n.start, cs, offset, len)))

--- a/test/junit/scala/tools/nsc/symtab/StdNamesTest.scala
+++ b/test/junit/scala/tools/nsc/symtab/StdNamesTest.scala
@@ -1,0 +1,46 @@
+package scala.tools.nsc
+package symtab
+
+import org.junit.Assert._
+import scala.tools.testing.AssertUtil._
+import org.junit.{Ignore, Test}
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class StdNamesTest {
+  object symbolTable extends SymbolTableForUnitTesting
+  import symbolTable._
+  import nme.{SPECIALIZED_SUFFIX, unspecializedName, splitSpecializedName}
+
+  @Test
+  def testNewTermNameInvalid(): Unit = {
+    assertThrows[IllegalArgumentException](newTermName("foo".toCharArray, 0, -1))
+    assertThrows[IllegalArgumentException](newTermName("foo".toCharArray, 0, 0))
+    assertThrows[IllegalArgumentException](newTermName("foo".toCharArray, -1, 1))
+  }
+
+  @Test
+  def testUnspecializedName(): Unit = {
+    def test(expected: Name, nme: Name) {
+      assertEquals(expected, unspecializedName(nme))
+    }
+    test(TermName("Tuple2"), TermName("Tuple2$mcII" + SPECIALIZED_SUFFIX))
+    test(TermName("foo"), TermName("foo$mIcD" + SPECIALIZED_SUFFIX))
+    test(TermName("foo"), TermName("foo$mIc" + SPECIALIZED_SUFFIX))
+    test(TermName("T1"), TermName(s"T1$SPECIALIZED_SUFFIX"))
+    test(TermName(""), SPECIALIZED_SUFFIX)
+  }
+
+  @Test
+  def testSplitSpecializedName(): Unit = {
+    def test(expected: (Name, String, String), nme: Name) {
+      assertEquals(expected, splitSpecializedName(nme))
+    }
+    test((TermName("Tuple2"), "II", ""), TermName("Tuple2$mcII" + SPECIALIZED_SUFFIX))
+    test((TermName("foo"), "D", "I"), TermName("foo$mIcD" + SPECIALIZED_SUFFIX))
+    test((TermName("foo"), "", "I"), TermName("foo$mIc" + SPECIALIZED_SUFFIX))
+    test((TermName("T1"), "", ""), TermName(s"T1$SPECIALIZED_SUFFIX"))
+    test((TermName(""), "", ""), SPECIALIZED_SUFFIX)
+  }
+}


### PR DESCRIPTION
- Remove its use from `AbstractPartialFunction`
- Reject `Name`-s with negative length or offset.
- Harden and test `unspecializedName` / `splitSpecializedName`

I stop short of removing this facility altogether. When we do, we should remember to touch the group `Specialized.All`.

Review by @gkossakowski 
