### PR TITLE
SI-7847 Static forwarders for case apply/unapply

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -866,11 +866,7 @@ abstract class BCodeHelpers extends BCodeTypes with BytecodeWriters {
     // a plain class lacking companion module, for details see `isCandidateForForwarders`).
     // -----------------------------------------------------------------------------------------
 
-    val ExcludedForwarderFlags = {
-      import symtab.Flags._
-      // Should include DEFERRED but this breaks findMember.
-      ( CASE | SPECIALIZED | LIFTED | PROTECTED | STATIC | EXPANDEDNAME | BridgeAndPrivateFlags | MACRO )
-    }
+    val ExcludedForwarderFlags = genASM.ExcludedForwarderFlags
 
     /* Adds a @remote annotation, actual use unknown.
      *

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenJVMASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenJVMASM.scala
@@ -18,10 +18,10 @@ trait GenJVMASM {
   import icodes._
   import definitions._
 
-  protected val ExcludedForwarderFlags = {
+  val ExcludedForwarderFlags = {
     import Flags._
     // Should include DEFERRED but this breaks findMember.
-    ( CASE | SPECIALIZED | LIFTED | PROTECTED | STATIC | EXPANDEDNAME | BridgeAndPrivateFlags | MACRO )
+    ( SPECIALIZED | LIFTED | PROTECTED | STATIC | EXPANDEDNAME | BridgeAndPrivateFlags | MACRO )
   }
 
   protected def isJavaEntryPoint(icls: IClass) = {

--- a/test/files/pos/t7847/A.scala
+++ b/test/files/pos/t7847/A.scala
@@ -1,0 +1,5 @@
+case class Blah(a: Int)
+
+object Blah {
+  def apply2(a: Int) = apply(a)
+}

--- a/test/files/pos/t7847/B.java
+++ b/test/files/pos/t7847/B.java
@@ -1,0 +1,10 @@
+public final class B {
+  void blah() {
+    Blah x = Blah.apply2(1);
+    Blah y = Blah.apply(1);
+    Blah z = Blah$.MODULE$.apply(1);
+
+    scala.Option un1 = Blah.unapply(null);
+    scala.Option un2 = Blah$.MODULE$.unapply(null);
+  }
+}


### PR DESCRIPTION
These were excluded in f901816b3f because at the time they
were compiler fiction and translated to calls to the case
class constructor or accessors.

But since they are now bona-fide methods (albeit still occasionally
bypassed as an optimization), we can expose them conveniently to our
Java brethren.

The cut-and-pastiness of GenBCode starts to hinder maintenance.
Here's a report of further duplication that we have to fix up
post haste: https://gist.github.com/retronym/6334389

Review by @gkossakowski
