### PR TITLE
SI-7804 Build partest.task with pack

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1337,7 +1337,7 @@ TODO:
   </target>
 
   <!-- depend on quick.done so quick.bin is run when pack.done is -->
-  <target name="pack.done" depends="quick.done, pack.bin">
+  <target name="pack.done" depends="quick.done, pack.bin, partest.task">
     <!-- copy dependencies to build/pack/lib, it only takes a second so don't bother with uptodate checks -->
     <taskdef resource="scala/tools/ant/antlib.xml" classpathref="docs.compiler.path"/>
   </target>


### PR DESCRIPTION
Currently, you can build the `partest.task` target explicitly;
otherwise, it's a dependency for the test suite. But if I'm
tweaking some code, I'm not running test suite.

This commit makes pack freshen partest.task, which is not
burdensome.
