### PR TITLE
SI-7853 Regression in explicit outer

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -90,7 +90,7 @@ abstract class ExplicitOuter extends InfoTransform
 
     sym expandName clazz
     sym.referenced = clazz
-    sym setInfo MethodType(Nil, restpe.widen)
+    sym setInfo MethodType(Nil, restpe)
   }
   def newOuterField(clazz: Symbol) = {
     val accFlags = SYNTHETIC | ARTIFACT | PARAMACCESSOR | ( if (clazz.isEffectivelyFinal) PrivateLocal else PROTECTED )
@@ -361,10 +361,10 @@ abstract class ExplicitOuter extends InfoTransform
     /** The definition tree of the outer accessor of current class
      */
     def outerAccessorDef: Tree = localTyper typed {
-      outerAccessor(currentClass) match {
-        case acc if acc.isDeferred => DefDef(acc, EmptyTree)
-        case acc                   => DefDef(acc, Select(This(currentClass), outerField(currentClass)))
-      }
+      val acc = outerAccessor(currentClass)
+      val rhs = if (acc.isDeferred) EmptyTree else Select(This(currentClass), outerField(currentClass))
+      val tp = (currentClass.thisType memberType acc).finalResultType
+      newDefDef(acc, rhs)(tpt = TypeTree(tp))
     }
 
     /** The definition tree of the outer accessor for class mixinClass.

--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -363,8 +363,7 @@ abstract class ExplicitOuter extends InfoTransform
     def outerAccessorDef: Tree = localTyper typed {
       val acc = outerAccessor(currentClass)
       val rhs = if (acc.isDeferred) EmptyTree else Select(This(currentClass), outerField(currentClass))
-      val tp = (currentClass.thisType memberType acc).finalResultType
-      newDefDef(acc, rhs)(tpt = TypeTree(tp))
+      DefDef(acc, rhs)
     }
 
     /** The definition tree of the outer accessor for class mixinClass.

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2606,7 +2606,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         }
 
         val rhs    = methodBodyTyper.virtualizedMatch(match_, mode, B1.tpe)
-        val defdef = newDefDef(methodSym, rhs)(vparamss = mapParamss(methodSym)(newParam))
+        val defdef = newDefDef(methodSym, rhs)(vparamss = mapParamss(methodSym)(newParam), tpt = TypeTree(B1.tpe))
 
         (defdef, matchResTp)
       }

--- a/test/files/pos/t4970b.scala
+++ b/test/files/pos/t4970b.scala
@@ -1,0 +1,32 @@
+object Traits {
+  trait OuterClass[V <: OuterClass[V]#InnerClass] {
+  trait InnerClass {self: V =>
+      def method = ()
+    }
+  }
+
+  trait SubOuterClass[T <: SubOuterClass[T]#SubInnerClass] extends OuterClass[T] {
+    trait SubInnerClass extends super.InnerClass {self: T =>  }
+  }
+
+  trait SubOuterClass2[T <: SubOuterClass2[T]#SubInnerClass2] extends OuterClass[T] {
+    trait SubInnerClass2 extends super.InnerClass {self: InnerClass with T =>  }
+  }
+
+}
+
+// object Classes {
+//   class OuterClass[V <: OuterClass[V]#InnerClass] {
+//   class InnerClass {self: V =>
+//       def method = ()
+//     }
+//   }
+
+//   class SubOuterClass[T <: SubOuterClass[T]#SubInnerClass] extends OuterClass[T] {
+//     class SubInnerClass extends super.InnerClass {self: T =>  }
+//   }
+
+//   class SubOuterClass2[T <: SubOuterClass2[T]#SubInnerClass2] extends OuterClass[T] {
+//     class SubInnerClass2 extends super.InnerClass {self: InnerClass with T =>  }
+//   }
+// }

--- a/test/files/pos/t7853-partial-function.scala
+++ b/test/files/pos/t7853-partial-function.scala
@@ -1,0 +1,7 @@
+object Test  {
+
+  def testCons: Unit = {
+    def x[A](a: PartialFunction[Any, A]): A = a(0)
+    val eval0 = x { case list: List[Int @unchecked] => list }
+  }
+}

--- a/test/files/pos/t7853.scala
+++ b/test/files/pos/t7853.scala
@@ -1,0 +1,11 @@
+trait S {
+  trait T {
+    this: Any =>
+
+    trait U {
+      trait V {
+        S.this
+      }
+    }
+  }
+}

--- a/test/files/run/compiler-asSeenFrom.check
+++ b/test/files/run/compiler-asSeenFrom.check
@@ -363,8 +363,8 @@ value jZ { // after parser
 
 value jZ { // after explicitouter
   protected val $outer: D.this.type
-  val $outer(): ll.D[T3]
-  val $outer(): ll.C[T1]
+  val $outer(): D.this.type
+  val $outer(): C.this.type
   def thisI(): I.this.type
   def thisC(): C.this.type
   def t2(): T2


### PR DESCRIPTION
The attempt to placate pos/t4970.scala in 55c6fd4 roused another
dragon.

We've got two levers here: the type of the symbol of the outer
accessor, and the type of its DefDef.

They have been historically out of sync due to the vaguaries of
finalResultType (which is far less vague since 671e6e03c7), but
the finicky operation of ExplicitOuter now has a hard time when
we try to bring them into line.

This stuff is notoriously difficult to understand because the
trees you see from `-Xprint` show a tpt derived from the method
symbol's info, and discards the actual tpt in the tree.

Rather than letting `DefDef(acc)` call `TypeTree(sym)` and use
`sym.tpe_*.finalResultType`, this commit computes the member type
of the accessor from the current class and explicitly uses that as
the return type of the outer accessor def.

We should try to push this a little deeper. I tried to put it into
`def TypeTree`, but that broke, among others,
run/concurrent-stream.scala. Maybe `def DefDef` and `def ValDef`?

But a localised fix is the right start as it addresses the regress
in a minimal fashion to get the IDE building again.
# 

A less ad-hoc place to call memberType

Rather than localizing the fix to the outerAccessor, this
commit pushed the call to `memberType` into _all_ usages of
`newValDef` and `newDefDef`.
