### PR TITLE
Longer timeout for repl test.

### DIFF
--- a/test/files/run/t7805-repl-i.scala
+++ b/test/files/run/t7805-repl-i.scala
@@ -34,7 +34,7 @@ trait HangingRepl extends ReplTest {
   import scala.concurrent.duration._
   import ExecutionContext.Implicits._
   import Resulting._
-  def timeout = 15 seconds
+  def timeout = 120 seconds
   def hanging[A](a: =>A): A = future(a) resultWithin timeout
   override def show() = Try(hanging(super.show())) recover {
     case e => e.printStackTrace()


### PR DESCRIPTION
15 seconds is crazy aggressive. I have fast hardware and it's still
really easy for a test to take to fifteen seconds under load.
