### PR TITLE
Type housekeeping.

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/NodePrinters.scala
+++ b/src/compiler/scala/tools/nsc/ast/NodePrinters.scala
@@ -282,7 +282,7 @@ abstract class NodePrinters {
             traverseList("[]", "type parameter")(tparams)
             vparamss match {
               case Nil        => println("Nil")
-              case Nil :: Nil => println("List(Nil)")
+              case ListOfNil  => println("List(Nil)")
               case ps  :: Nil =>
                 printLine("", "1 parameter list")
                 ps foreach traverse

--- a/src/compiler/scala/tools/nsc/package.scala
+++ b/src/compiler/scala/tools/nsc/package.scala
@@ -23,5 +23,6 @@ package object nsc {
   type MissingRequirementError = scala.reflect.internal.MissingRequirementError
   val MissingRequirementError = scala.reflect.internal.MissingRequirementError
 
-  val ListOfNil = List(Nil)
+  @deprecated("Use scala.reflect.internal.util.ListOfNil", "2.11.0")
+  lazy val ListOfNil = scala.reflect.internal.util.ListOfNil
 }

--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -276,18 +276,16 @@ abstract class ExplicitOuter extends InfoTransform
       else outerPath(outerSelect(base), from.outerClass, to)
     }
 
-
     override def transform(tree: Tree): Tree = {
+      def sym = tree.symbol
       val savedOuterParam = outerParam
       try {
         tree match {
           case Template(_, _, _) =>
             outerParam = NoSymbol
-          case DefDef(_, _, _, vparamss, _, _) =>
-            if (tree.symbol.isClassConstructor && isInner(tree.symbol.owner)) {
-              outerParam = vparamss.head.head.symbol
-              assert(outerParam.name startsWith nme.OUTER, outerParam.name)
-            }
+          case DefDef(_, _, _, (param :: _) :: _, _, _) if sym.isClassConstructor && isInner(sym.owner) =>
+            outerParam = param.symbol
+            assert(outerParam.name startsWith nme.OUTER, outerParam.name)
           case _ =>
         }
         super.transform(tree)

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -50,7 +50,7 @@ trait TreeAndTypeAnalysis extends Debugging {
         case UnitClass =>
           Some(List(UnitTpe))
         case BooleanClass =>
-          Some((List(ConstantType(Constant(true)), ConstantType(Constant(false)))))
+          Some(ConstantTrue :: ConstantFalse :: Nil)
         // TODO case _ if tp.isTupleType => // recurse into component types
         case modSym: ModuleClassSymbol =>
           Some(List(tp))
@@ -271,9 +271,9 @@ trait MatchApproximation extends TreeAndTypeAnalysis with ScalaLogic with MatchT
             case SubstOnlyTreeMaker(_, _)                             => True
             case GuardTreeMaker(guard) =>
               guard.tpe match {
-                case ConstantType(Constant(true))  => True
-                case ConstantType(Constant(false)) => False
-                case _                             => handleUnknown(tm)
+                case ConstantTrue  => True
+                case ConstantFalse => False
+                case _             => handleUnknown(tm)
               }
             case ExtractorTreeMaker(_, _, _) |
                  ProductExtractorTreeMaker(_, _) |

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
@@ -402,23 +402,15 @@ trait MatchOptimization extends MatchTreeMaking with MatchAnalysis {
       private def noGuards(cs: List[CaseDef]): Boolean = !cs.exists(isGuardedCase)
 
       // must do this before removing guards from cases and collapsing (SI-6011, SI-6048)
-      private def unreachableCase(cs: List[CaseDef]): Option[CaseDef] = {
-        var cases = cs
-        var unreachable: Option[CaseDef] = None
-
-        while (cases.nonEmpty && unreachable.isEmpty) {
-          val currCase = cases.head
-          if (isDefault(currCase) && cases.tail.nonEmpty) // subsumed by the `else if` that follows, but faster
-            unreachable = Some(cases.tail.head)
-          else if (!isGuardedCase(currCase) || currCase.guard.tpe =:= ConstantType(Constant(true)))
-            unreachable = cases.tail.find(caseImplies(currCase))
-          else if (currCase.guard.tpe =:= ConstantType(Constant(false)))
-            unreachable = Some(currCase)
-
-          cases = cases.tail
+      private def unreachableCase(cases: List[CaseDef]): Option[CaseDef] = {
+        def loop(cases: List[CaseDef]): Option[CaseDef] = cases match {
+          case head :: next :: _ if isDefault(head)                                    => Some(next) // subsumed by the next case, but faster
+          case head :: rest if !isGuardedCase(head) || head.guard.tpe =:= ConstantTrue => rest find caseImplies(head) orElse loop(rest)
+          case head :: _ if head.guard.tpe =:= ConstantFalse                           => Some(head)
+          case _ :: rest                                                               => loop(rest)
+          case _                                                                       => None
         }
-
-        unreachable
+        loop(cases)
       }
 
       // empty list ==> failure

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
@@ -288,8 +288,8 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
       def irrefutableExtractorType(tp: Type): Boolean = tp.resultType.dealias match {
         case TypeRef(_, SomeClass, _) => true
         // probably not useful since this type won't be inferred nor can it be written down (yet)
-        case ConstantType(Constant(true)) => true
-        case _ => false
+        case ConstantTrue => true
+        case _            => false
       }
 
       def unapply(xtm: ExtractorTreeMaker): Option[(Tree, Symbol)] = xtm match {

--- a/src/compiler/scala/tools/nsc/transform/patmat/Solving.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Solving.scala
@@ -9,6 +9,7 @@ package scala.tools.nsc.transform.patmat
 import scala.collection.mutable
 import scala.reflect.internal.util.Statistics
 import scala.language.postfixOps
+import scala.reflect.internal.util.Collections._
 
 // naive CNF translation and simple DPLL solver
 trait Solving extends Logic {
@@ -205,9 +206,8 @@ trait Solving extends Logic {
             // SI-7020 Linked- for deterministic counter examples.
             val pos = new mutable.LinkedHashSet[Sym]()
             val neg = new mutable.LinkedHashSet[Sym]()
-            f.foreach{_.foreach{ lit =>
-              if (lit.pos) pos += lit.sym else neg += lit.sym
-            }}
+            mforeach(f)(lit => if (lit.pos) pos += lit.sym else neg += lit.sym)
+
             // appearing in both positive and negative
             val impures: mutable.LinkedHashSet[Sym] = pos intersect neg
             // appearing only in either positive/negative positions

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1183,8 +1183,8 @@ trait Namers extends MethodSynthesis {
       // value parameters of the base class (whose defaults might be overridden)
       var baseParamss = (vparamss, overridden.tpe.paramss) match {
         // match empty and missing parameter list
-        case (Nil, List(Nil)) => Nil
-        case (List(Nil), Nil) => ListOfNil
+        case (Nil, ListOfNil) => Nil
+        case (ListOfNil, Nil) => ListOfNil
         case (_, paramss)     => paramss
       }
       assert(

--- a/src/library/scala/concurrent/duration/Duration.scala
+++ b/src/library/scala/concurrent/duration/Duration.scala
@@ -221,7 +221,7 @@ object Duration {
     final def toMinutes: Long = fail("toMinutes")
     final def toHours: Long   = fail("toHours")
     final def toDays: Long    = fail("toDays")
-	
+
     final def toCoarsest: Duration = this
   }
 
@@ -532,7 +532,7 @@ sealed abstract class Duration extends Serializable with Ordered[Duration] {
    * Duration(48, HOURS).toCoarsest // Duration(2, DAYS)
    * Duration(5, SECONDS).toCoarsest // Duration(5, SECONDS)
    * }}}
-   */  
+   */
   def toCoarsest: Duration
 }
 

--- a/src/reflect/scala/reflect/internal/BuildUtils.scala
+++ b/src/reflect/scala/reflect/internal/BuildUtils.scala
@@ -3,6 +3,7 @@ package reflect
 package internal
 
 import Flags._
+import util._
 
 trait BuildUtils { self: SymbolTable =>
   import definitions.{TupleClass, FunctionClass, ScalaPackage, UnitClass}
@@ -364,7 +365,7 @@ trait BuildUtils { self: SymbolTable =>
       def unapply(tree: Tree): Option[(List[Tree], List[Tree], ValDef, List[Tree])] = tree match {
         case SyntacticApplied(Select(New(SyntacticTypeApplied(ident, targs)), nme.CONSTRUCTOR), argss) =>
           Some((Nil, SyntacticApplied(SyntacticTypeApplied(ident, targs), argss) :: Nil, emptyValDef, Nil))
-        case SyntacticBlock(SyntacticClassDef(_, tpnme.ANON_CLASS_NAME, Nil, _, List(Nil), earlyDefs, parents, selfdef, body) ::
+        case SyntacticBlock(SyntacticClassDef(_, tpnme.ANON_CLASS_NAME, Nil, _, ListOfNil, earlyDefs, parents, selfdef, body) ::
                             Apply(Select(New(Ident(tpnme.ANON_CLASS_NAME)), nme.CONSTRUCTOR), Nil) :: Nil) =>
           Some((earlyDefs, parents, selfdef, body))
         case _ =>

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -285,6 +285,10 @@ trait Definitions extends api.StandardDefinitions {
     lazy val StringTpe       = StringClass.tpe
     lazy val ThrowableTpe    = ThrowableClass.tpe
 
+    lazy val ConstantTrue  = ConstantType(Constant(true))
+    lazy val ConstantFalse = ConstantType(Constant(false))
+    lazy val ConstantNull  = ConstantType(Constant(null))
+
     // Note: this is not the type alias AnyRef, it's a companion-like
     // object used by the @specialize annotation.
     lazy val AnyRefModule = getMemberModule(ScalaPackageClass, nme.AnyRef)

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -3,6 +3,7 @@ package reflect
 package internal
 
 import Flags._
+import util._
 
 abstract class TreeGen extends macros.TreeBuilder {
   val global: SymbolTable
@@ -355,8 +356,9 @@ abstract class TreeGen extends macros.TreeBuilder {
         if (body forall treeInfo.isInterfaceMember) None
         else Some(
           atPos(wrappingPos(superPos, lvdefs)) (
-            DefDef(NoMods, nme.MIXIN_CONSTRUCTOR, List(), List(Nil), TypeTree(), Block(lvdefs, Literal(Constant())))))
-      } else {
+            DefDef(NoMods, nme.MIXIN_CONSTRUCTOR, Nil, ListOfNil, TypeTree(), Block(lvdefs, Literal(Constant())))))
+      }
+      else {
         // convert (implicit ... ) to ()(implicit ... ) if its the only parameter section
         if (vparamss1.isEmpty || !vparamss1.head.isEmpty && vparamss1.head.head.mods.isImplicit)
           vparamss1 = List() :: vparamss1
@@ -416,7 +418,7 @@ abstract class TreeGen extends macros.TreeBuilder {
             atPos(cpos) {
               ClassDef(
                 Modifiers(FINAL), x, Nil,
-                mkTemplate(parents, self, NoMods, List(Nil), stats, cpos.focus))
+                mkTemplate(parents, self, NoMods, ListOfNil, stats, cpos.focus))
             }),
           atPos(npos) {
             New(

--- a/src/reflect/scala/reflect/internal/TypeDebugging.scala
+++ b/src/reflect/scala/reflect/internal/TypeDebugging.scala
@@ -7,7 +7,7 @@ package scala
 package reflect
 package internal
 
-import util.shortClassOfInstance
+import util._
 
 trait TypeDebugging {
   self: SymbolTable =>
@@ -39,17 +39,17 @@ trait TypeDebugging {
     def skipType(tpe: Type): Boolean = (tpe eq null) || skipSym(tpe.typeSymbolDirect)
 
     def skip(t: Tree): Boolean = t match {
-      case EmptyTree                                           => true
-      case PackageDef(_, _)                                    => true
-      case t: RefTree                                          => skipRefTree(t)
-      case TypeBoundsTree(lo, hi)                              => skip(lo) && skip(hi)
-      case Block(Nil, expr)                                    => skip(expr)
-      case Apply(fn, Nil)                                      => skip(fn)
-      case Block(stmt :: Nil, expr)                            => skip(stmt) && skip(expr)
-      case DefDef(_, nme.CONSTRUCTOR, Nil, Nil :: Nil, _, rhs) => skip(rhs)
-      case Literal(Constant(()))                               => true
-      case tt @ TypeTree()                                     => skipType(tt.tpe)
-      case _                                                   => skipSym(t.symbol)
+      case EmptyTree                                          => true
+      case PackageDef(_, _)                                   => true
+      case t: RefTree                                         => skipRefTree(t)
+      case TypeBoundsTree(lo, hi)                             => skip(lo) && skip(hi)
+      case Block(Nil, expr)                                   => skip(expr)
+      case Apply(fn, Nil)                                     => skip(fn)
+      case Block(stmt :: Nil, expr)                           => skip(stmt) && skip(expr)
+      case DefDef(_, nme.CONSTRUCTOR, Nil, ListOfNil, _, rhs) => skip(rhs)
+      case Literal(Constant(()))                              => true
+      case tt @ TypeTree()                                    => skipType(tt.tpe)
+      case _                                                  => skipSym(t.symbol)
     }
     def apply(t: Tree) = skip(t)
   }

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2835,9 +2835,6 @@ trait Types
   // but pattern-matching returned the original constr0 (a bug)
   // now, pattern-matching returns the most recent constr
   object TypeVar {
-    private val ConstantTrue = ConstantType(Constant(true))
-    private val ConstantFalse = ConstantType(Constant(false))
-
     @inline final def trace[T](action: String, msg: => String)(value: T): T = {
       if (traceTypeVars) {
         val s = msg match {
@@ -3059,13 +3056,13 @@ trait Types
 
     // ignore subtyping&equality checks while true -- see findMember
     // OPT: This could be Either[TypeVar, Boolean], but this encoding was chosen instead to save allocations.
-    private var _suspended: Type = TypeVar.ConstantFalse
+    private var _suspended: Type = ConstantFalse
     private[Types] def suspended: Boolean = (_suspended: @unchecked) match {
-      case TypeVar.ConstantFalse => false
-      case TypeVar.ConstantTrue  => true
-      case tv: TypeVar           => tv.suspended
+      case ConstantFalse => false
+      case ConstantTrue  => true
+      case tv: TypeVar   => tv.suspended
     }
-    private[Types] def suspended_=(b: Boolean): Unit = _suspended = if (b) TypeVar.ConstantTrue else TypeVar.ConstantFalse
+    private[Types] def suspended_=(b: Boolean): Unit = _suspended = if (b) ConstantTrue else ConstantFalse
     // SI-7785 Link the suspended attribute of a TypeVar created in, say, a TypeMap (e.g. AsSeenFrom) to its originator
     private[Types] def linkSuspended(origin: TypeVar): Unit = _suspended = origin
 

--- a/src/reflect/scala/reflect/internal/util/Collections.scala
+++ b/src/reflect/scala/reflect/internal/util/Collections.scala
@@ -34,13 +34,18 @@ trait Collections {
     xss forall (_ forall p)
   final def mmap[A, B](xss: List[List[A]])(f: A => B) =
     xss map (_ map f)
-  final def mforeach[A](xss: List[List[A]])(f: A => Unit) =
-    xss foreach (_ foreach f)
   final def mfind[A](xss: List[List[A]])(p: A => Boolean): Option[A] = {
     var res: Option[A] = null
     mforeach(xss)(x => if ((res eq null) && p(x)) res = Some(x))
     if (res eq null) None else res
   }
+
+  /** These are all written in terms of List because we're trying to wring all
+   *  the performance we can and List is used almost exclusively in the compiler,
+   *  but people are branching out in their collections so here's an overload.
+   */
+  final def mforeach[A](xss: List[List[A]])(f: A => Unit) = xss foreach (_ foreach f)
+  final def mforeach[A](xss: Traversable[Traversable[A]])(f: A => Unit) = xss foreach (_ foreach f)
 
   final def map2[A, B, C](xs1: List[A], xs2: List[B])(f: (A, B) => C): List[C] = {
     val lb = new ListBuffer[C]

--- a/src/reflect/scala/reflect/internal/util/package.scala
+++ b/src/reflect/scala/reflect/internal/util/package.scala
@@ -7,6 +7,9 @@ import scala.language.existentials // SI-6541
 package object util {
   import StringOps.longestCommonPrefix
 
+  // An allocation-avoiding reusable instance of the so-common List(Nil).
+  val ListOfNil: List[List[Nothing]] = Nil :: Nil
+
   def andFalse(body: Unit): Boolean = false
 
   // Shorten a name like Symbols$FooSymbol to FooSymbol.


### PR DESCRIPTION
Moved ListOfNil somewhere more generally accessible. No
reason the compiler should hoard it for itself. Flitted
to a few locations with constructs like ".head.head" and
".tail.head" looking for code which could be rewritten. Found
some, admittedly not always making use of ListOfNil.

Made overdue moves of ConstantType(Constant(true|false|null))
to vals in Definitions.
