### PR TITLE
Silence pos/t3960's -Ycheck output.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
@@ -171,8 +171,8 @@ abstract class TreeCheckers extends Analyzer {
   )
 
 
-  def errorFn(msg: Any): Unit                = Console.err println "[check: %s] %s".format(phase.prev, msg)
-  def errorFn(pos: Position, msg: Any): Unit = errorFn(posstr(pos) + ": " + msg)
+  def errorFn(pos: Position, msg: Any): Unit = currentUnit.warning(pos, "[check: %s] %s".format(phase.prev, msg))
+  def errorFn(msg: Any): Unit                = errorFn(NoPosition, msg)
 
   def informFn(msg: Any) {
     if (settings.verbose || settings.debug)


### PR DESCRIPTION
Someday someone will have to straighten out where output goes.
Clearly under current conditions, Console.err is not a good place.
I rerouted through unit.warning so the output will be swallowed
like all the other warnings.
