### PR TITLE
Quasiquotes: add syntactic extractor for assignment-like trees

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1403,7 +1403,7 @@ self =>
           if (in.token == EQUALS) {
             t match {
               case Ident(_) | Select(_, _) | Apply(_, _) =>
-                t = atPos(t.pos.startOrPoint, in.skipToken()) { makeAssign(t, expr()) }
+                t = atPos(t.pos.startOrPoint, in.skipToken()) { gen.mkAssign(t, expr()) }
               case _ =>
             }
           } else if (in.token == COLON) {

--- a/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
@@ -191,14 +191,6 @@ abstract class TreeBuilder {
     }
   }
 
-  /** Create a tree representing an assignment <lhs = rhs> */
-  def makeAssign(lhs: Tree, rhs: Tree): Tree = lhs match {
-    case Apply(fn, args) =>
-      Apply(atPos(fn.pos) { Select(fn, nme.update) }, args ::: List(rhs))
-    case _ =>
-      Assign(lhs, rhs)
-  }
-
   /** Tree for `od op`, start is start0 if od.pos is borked. */
   def makePostfixSelect(start0: Int, end: Int, od: Tree, op: Name): Tree = {
     val start = if (od.pos.isDefined) od.pos.startOrPoint else start0

--- a/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
@@ -10,7 +10,7 @@ trait Reifiers { self: Quasiquotes =>
   import global.build.{SyntacticClassDef, SyntacticTraitDef, SyntacticModuleDef,
                        SyntacticDefDef, SyntacticValDef, SyntacticVarDef,
                        SyntacticBlock, SyntacticApplied, SyntacticTypeApplied,
-                       SyntacticFunction, SyntacticNew}
+                       SyntacticFunction, SyntacticNew, SyntacticAssign}
   import global.treeInfo._
   import global.definitions._
   import Cardinality._
@@ -71,9 +71,9 @@ trait Reifiers { self: Quasiquotes =>
         reifyBuildCall(nme.SyntacticValDef, mods, name, tpt, rhs)
       case SyntacticVarDef(mods, name, tpt, rhs) =>
         reifyBuildCall(nme.SyntacticVarDef, mods, name, tpt, rhs)
-      case SyntacticApplied(fun, argss) if argss.length > 1 =>
-        reifyBuildCall(nme.SyntacticApplied, fun, argss)
-      case SyntacticApplied(fun, argss @ (_ :+ (_ :+ Placeholder(_, _, DotDotDot)))) =>
+      case SyntacticAssign(lhs, rhs) =>
+        reifyBuildCall(nme.SyntacticAssign, lhs, rhs)
+      case SyntacticApplied(fun, argss) if argss.nonEmpty =>
         reifyBuildCall(nme.SyntacticApplied, fun, argss)
       case SyntacticTypeApplied(fun, targs) if targs.nonEmpty =>
         reifyBuildCall(nme.SyntacticTypeApplied, fun, targs)

--- a/src/reflect/scala/reflect/api/BuildUtils.scala
+++ b/src/reflect/scala/reflect/api/BuildUtils.scala
@@ -193,5 +193,12 @@ private[reflect] trait BuildUtils { self: Universe =>
       def apply(mods: Modifiers, name: TermName, tpt: Tree, rhs: Tree): ValDef
       def unapply(tree: Tree): Option[(Modifiers, TermName, Tree, Tree)]
     }
+
+    val SyntacticAssign: SyntacticAssignExtractor
+
+    trait SyntacticAssignExtractor {
+      def apply(lhs: Tree, rhs: Tree): Tree
+      def unapply(tree: Tree): Option[(Tree, Tree)]
+    }
   }
 }

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -602,6 +602,7 @@ trait StdNames {
     val SelectFromTypeTree: NameType   = "SelectFromTypeTree"
     val StringContext: NameType        = "StringContext"
     val SyntacticApplied: NameType     = "SyntacticApplied"
+    val SyntacticAssign: NameType      = "SyntacticAssign"
     val SyntacticBlock: NameType       = "SyntacticBlock"
     val SyntacticClassDef: NameType    = "SyntacticClassDef"
     val SyntacticDefDef: NameType      = "SyntacticDefDef"

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -443,4 +443,12 @@ abstract class TreeGen extends macros.TreeBuilder {
     case head :: Nil => head
     case _ => gen.mkBlock(stats)
   }
+
+  /** Create a tree representing an assignment <lhs = rhs> */
+  def mkAssign(lhs: Tree, rhs: Tree): Tree = lhs match {
+    case Apply(fn, args) =>
+      Apply(atPos(fn.pos)(Select(fn, nme.update)), args :+ rhs)
+    case _ =>
+      Assign(lhs, rhs)
+  }
 }

--- a/test/files/neg/macro-quasiquotes.check
+++ b/test/files/neg/macro-quasiquotes.check
@@ -1,6 +1,6 @@
 Macros_1.scala:14: error: macro implementation has wrong shape:
  required: (x: Impls.this.c.Expr[Int]): Impls.this.c.Expr[Any]
- found   : (x: Impls.this.c.universe.Block): Impls.this.c.universe.Apply
+ found   : (x: Impls.this.c.universe.Block): Impls.this.c.universe.Tree
 type mismatch for parameter x: Impls.this.c.Expr[Int] does not conform to Impls.this.c.universe.Block
   def m3(x: Int) = macro Impls.impl3
       ^

--- a/test/files/scalacheck/quasiquotes/TermConstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/TermConstructionProps.scala
@@ -167,4 +167,28 @@ object TermConstructionProps extends QuasiquoteProperties("term construction") {
     val x = q"val x: Int = 1"
     assertThrows[IllegalArgumentException] { q"($x) => x" }
   }
+
+  property("assign variable") = test {
+    val v = q"v"
+    val value = q"foo"
+    assertEqAst(q"$v = $value", "v = foo")
+  }
+
+  property("assign update 1") = test {
+    val v = q"v"
+    val args = q"1" :: q"2" :: Nil
+    val value = q"foo"
+    assertEqAst(q"$v(..$args) = $value", "v(1, 2) = foo")
+  }
+
+  property("assign update 2") = test {
+    val a = q"v(0)"
+    val value = q"foo"
+    assertEqAst(q"$a = $value", "v(0) = foo")
+  }
+
+  property("assign or named arg") = test {
+    val assignx = q"x = 1"
+    assertEqAst(q"f($assignx)", "f(x = 1)")
+  }
 }

--- a/test/files/scalacheck/quasiquotes/TermDeconstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/TermDeconstructionProps.scala
@@ -91,4 +91,24 @@ object TermDeconstructionProps extends QuasiquoteProperties("term deconstruction
     matches("new { val early = 1} with Parent[Int] { body }")
     matches("new Foo { selfie => }")
   }
+
+  property("exhaustive assign pattern") = test {
+    def matches(tree: Tree) { val q"$rhs = $lhs" = tree }
+    matches(parse("left = right"))
+    matches(parse("arr(1) = 2"))
+    matches(AssignOrNamedArg(EmptyTree, EmptyTree))
+  }
+
+  property("deconstruct update 1") = test {
+    val q"$obj(..$args) = $value" = q"foo(bar) = baz"
+    assert(obj ≈ q"foo")
+    assert(args ≈ List(q"bar"))
+    assert(value ≈ q"baz")
+  }
+
+  property("deconstruct update 2") = test {
+    val q"$left = $value" = q"foo(bar) = baz"
+    assert(left ≈ q"foo(bar)")
+    assert(value ≈ q"baz")
+  }
 }


### PR DESCRIPTION
There are three kinds of assign-like trees:

```
1. Assign(lhs, rhs)                          // $lhs = $rhs
3. AssignOrNamedArg(lhs, rhs)                // $lhs = $rhs
2. Apply(Select(f, nme.update), args :+ rhs) // $f(..$args) = $rhs
```

New syntactic combinator unifies all of them and lets users not to think
about these implementation details.
