### PR TITLE
Small refactorings giving hooks for Scala.js

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
@@ -164,9 +164,16 @@ abstract class SymbolLoaders {
         if (settings.verbose) inform("[symloader] no class, picked up source file for " + src.path)
         enterToplevelsFromSource(owner, classRep.name, src)
       case (Some(bin), _) =>
-        enterClassAndModule(owner, classRep.name, new ClassfileLoader(bin))
+        enterClassAndModule(owner, classRep.name, newClassLoader(bin))
     }
   }
+
+  /** Create a new loader from a binary classfile.
+   *  This is intented as a hook allowing to support loading symbols from
+   *  files other than .class files.
+   */
+  protected def newClassLoader(bin: AbstractFile): SymbolLoader =
+    new ClassfileLoader(bin)
 
   /**
    * A lazy type that completes itself by calling parameter doComplete.

--- a/src/compiler/scala/tools/nsc/util/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/util/ClassPath.scala
@@ -96,6 +96,12 @@ object ClassPath {
      */
     def isValidName(name: String): Boolean = true
 
+    /** Filters for assessing validity of various entities.
+     */
+    def validClassFile(name: String)  = endsClass(name) && isValidName(name)
+    def validPackage(name: String)    = (name != "META-INF") && (name != "") && (name.charAt(0) != '.')
+    def validSourceFile(name: String) = endsScala(name) || endsJava(name)
+
     /** From the representation to its identifier.
      */
     def toBinaryName(rep: T): String
@@ -208,9 +214,9 @@ abstract class ClassPath[T] {
 
   /** Filters for assessing validity of various entities.
    */
-  def validClassFile(name: String)  = endsClass(name) && context.isValidName(name)
-  def validPackage(name: String)    = (name != "META-INF") && (name != "") && (name.charAt(0) != '.')
-  def validSourceFile(name: String) = endsScala(name) || endsJava(name)
+  def validClassFile(name: String)  = context.validClassFile(name)
+  def validPackage(name: String)    = context.validPackage(name)
+  def validSourceFile(name: String) = context.validSourceFile(name)
 
   /**
    * Find a ClassRep given a class name of the form "package.subpackage.ClassName".


### PR DESCRIPTION
I have reviewed the ugliest parts of Scala.js, where I need to circumvent the lack of appropriate hooks in scalac, and I came up with these three small refactorings.

Each one of these has its corresponding simplifying commit in Scala.js, in the following comparison:
https://github.com/sjrd/scala-js/compare/scala-2.11...topic/what-if-scalac-was-nicer-to-us
(in the same order).

There is no test accompanying this pull request, because there is absolutely no functionality change (it's only refactoring) and I don't quite see how to test that with partest. I'll be glad to add tests if someone can hint at me how.

(In case you care:) Incidentally, these hooks are the only ones on which Scala.js relies, in addition to being able to manipulate the phase set. Which means that _if_ they were (experimentally) overridable by plugins, then Scala.js could be implemented as a plugin, which would bring lots of advantages in terms of integration with our various tools (sbt and IDE mainly).

(There are still two files with a non-negligible amount of code duplication in Scala.js, [JSSymbolLoaders.scala](https://github.com/sjrd/scala-js/blob/topic/what-if-scalac-was-nicer-to-us/compiler/src/main/scala/scala/tools/nsc/scalajs/JSSymbolLoaders.scala) and [JSTypefileParser.scala](https://github.com/sjrd/scala-js/blob/topic/what-if-scalac-was-nicer-to-us/compiler/src/main/scala/scala/tools/nsc/scalajs/JSTypefileParser.scala), but a proper fix to these two would require much bigger refactorings in scalac; and I don't care so much about these because they are not specifically the hooks I am relying on.)
