### PR TITLE
Require Ant >= 1.8.2

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -211,6 +211,11 @@ TODO:
     <!-- Set up Ant contrib tasks so we can use <if><then><else> instead of the clunky `unless` attribute -->
     <taskdef resource="net/sf/antcontrib/antlib.xml" classpath="${lib-ant.dir}/ant-contrib.jar"/>
 
+    <property name="scala.ant.min.version" value="1.8.2"/>
+    <if><not><antversion atleast="${scala.ant.min.version}"/></not>
+      <then><fail message="Ant version ${scala.ant.min.version} is required. You are running ${ant.version}"/></then>
+    </if>
+
     <!-- Add our maven ant tasks -->
     <path id="maven-ant-tasks.classpath" path="${lib-ant.dir}/maven-ant-tasks-2.1.1.jar" />
     <typedef resource="org/apache/maven/artifact/ant/antlib.xml" uri="urn:maven-artifact-ant" classpathref="maven-ant-tasks.classpath" />


### PR DESCRIPTION
Reportedly our build fails with earlier incarnations. Time to raise the
bar.

Tested by temporarily setting the requirement to 1.8.5 and observing:

```
% ant init
Buildfile: /Users/jason/code/scala/build.xml

desired.jars.uptodate:

boot:

init:

BUILD FAILED
/Users/jason/code/scala/build.xml:216: Ant version 1.8.5 is required. You are running Apache Ant(TM) version 1.8.4 compiled on May 22 2012
```

Review by @gkossakowski
