### PR TITLE
Follow good interrupt discipline in Response

### DIFF
--- a/src/interactive/scala/tools/nsc/interactive/Response.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Response.scala
@@ -55,7 +55,10 @@ class Response[T] {
       try {
         wait()
       } catch {
-        case exc: InterruptedException => raise(exc)
+        case exc: InterruptedException => {
+          Thread.currentThread().interrupt()
+          raise(exc)
+        }
       }
     }
     data.get
@@ -73,7 +76,10 @@ class Response[T] {
       try {
         wait(timeout - (current - start))
       } catch {
-        case exc: InterruptedException => raise(exc)
+        case exc: InterruptedException => {
+          Thread.currentThread().interrupt()
+          raise(exc)
+        }
       }
       current = System.currentTimeMillis
     }


### PR DESCRIPTION
Restores the interrupted status of the waiting thread after catching an
InterruptException.

review by @dotta
