### PR TITLE
Upgrade: starr=M5, partest=RC5, xml=RC4, parsers=RC2.

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -1,7 +1,7 @@
-starr.version=2.11.0-M4
+starr.version=2.11.0-M5
 
 # the below is used for depending on dependencies like partest
-scala.binary.version=2.11.0-M4
-partest.version.number=1.0-RC4
-scala-xml.version.number=1.0-RC3
-scala-parser-combinators.version.number=1.0-RC1
+scala.binary.version=2.11.0-M5
+partest.version.number=1.0-RC5
+scala-xml.version.number=1.0-RC4
+scala-parser-combinators.version.number=1.0-RC2


### PR DESCRIPTION
Bump starr, binary version for dependencies to M5.
Upgrade to corresponding versions of modules: partest (1.0-RC5), xml (1.0-RC4), parsers (1.0-RC2).

review by @gkossakowski
