### PR TITLE
SI-7868 Account for numeric widening in match translation

### DIFF
--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -784,10 +784,13 @@ abstract class TreeInfo {
    *  unapply (unwrapping nested Applies) and returns the fun part of that Apply.
    */
   object Unapplied {
+    // Duplicated with `spliceApply`
     def unapply(tree: Tree): Option[Tree] = tree match {
-      case Apply(fun, Ident(nme.SELECTOR_DUMMY) :: Nil) => Some(fun)
-      case Apply(fun, _)                                => unapply(fun)
-      case _                                            => None
+      // SI-7868 Admit Select() to account for numeric widening, e.g. <unappplySelector>.toInt
+      case Apply(fun, (Ident(nme.SELECTOR_DUMMY)| Select(Ident(nme.SELECTOR_DUMMY), _)) :: Nil)
+                         => Some(fun)
+      case Apply(fun, _) => unapply(fun)
+      case _             => None
     }
   }
 

--- a/test/files/run/t7868.scala
+++ b/test/files/run/t7868.scala
@@ -1,0 +1,13 @@
+object A {
+  def unapply(n: Int): Option[Int] = Some(n)
+
+  def run = (0: Short) match {
+    case A(_) =>
+    case _    =>
+  }
+}
+
+
+object Test extends App {
+  A.run
+}

--- a/test/files/run/t7868b.check
+++ b/test/files/run/t7868b.check
@@ -1,0 +1,6 @@
+Expr[Int]({
+  val x = (0: Short): @unchecked match {
+    case A((x @ _)) => x
+  };
+  x
+})

--- a/test/files/run/t7868b.scala
+++ b/test/files/run/t7868b.scala
@@ -1,0 +1,11 @@
+object A {
+  def unapply(n: Int): Option[Int] = Some(1)
+}
+
+object Test extends App {
+  import reflect.runtime.universe._
+  println(reify {
+    val A(x) = (0: Short)
+    x
+  })
+}


### PR DESCRIPTION
Pattern match translation was unprepared for trees of the shape:

```
(0: Short) match {
  case A.unapply(<unapply-selector>.toInt) <unapply> (_) => ()
  case _ => ()
}
```

While a scrutinee is inelibigle for implicit views in order to
conform to the type of the extractor call, it is allowed to
weakly conform. In this case, the typechecker will add the
numeric widening with a `toInt` call.

This commit:
- Changes treeInfo.Unapplied to recognize this tree shape
- Changes spliceApply to recognize and preserve the widening
  when substituting the unapply selector with the binder
- Tests reification of such pattern matches, which also depends
  on treeInfo.Unapplied.

Review by @adriaanm
