### PR TITLE
[nomaster] SI-7862: MANIFEST.MF file for Scala sources

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1881,18 +1881,60 @@ TODO:
     </copy>
   </target>
 
+  <!--
+       A jar-like task that creates an OSGi source bundle. It adds the required MANIFEST.MF headers that allow
+       Eclipse to match sources with the corresponding binaries.
+  -->
+  <macrodef name="osgi.source.bundle">
+    <attribute name="destfile"     description="The jar file name"/>
+    <attribute name="symbolicName" description="The original bundle symbolic name (without .source at the end)"/>
+    <attribute name="bundleName"   description="A value for Bundle-Name, usually a textual description"/>
+    <element   name="file-sets"    description="A sequence of fileset elements to be included in the jar" optional="true" implicit="true"/>
+
+    <sequential>
+      <jar whenmanifestonly="fail" destfile="@{destFile}">
+        <file-sets/>
+        <manifest>
+          <attribute name="Manifest-Version" value="1.0"/>
+          <attribute name="Bundle-Name" value="@{bundleName}"/>
+          <attribute name="Bundle-SymbolicName" value="@{symbolicName}.source"/>
+          <attribute name="Bundle-Version" value="${osgi.version.number}"/>
+          <attribute name="Eclipse-SourceBundle" value="@{symbolicName};version=&quot;${osgi.version.number}&quot;;roots:=&quot;.&quot;" />
+        </manifest>
+      </jar>
+    </sequential>
+  </macrodef>
+
   <target name="dist.src" depends="dist.base">
     <mkdir dir="${dist.dir}/src"/>
-    <jar whenmanifestonly="fail" destfile="${dist.dir}/src/scala-library-src.jar">
+    <osgi.source.bundle destfile="${dist.dir}/src/scala-library-src.jar"
+                        symbolicName="org.scala-lang.scala-library"
+                        bundleName="Scala Library Sources">
       <fileset dir="${src.dir}/library"/>
       <fileset dir="${src.dir}/continuations/library"/>
-    </jar>
-    <jar whenmanifestonly="fail" destfile="${dist.dir}/src/scala-reflect-src.jar"  basedir="${src.dir}/reflect"/>
-    <jar whenmanifestonly="fail" destfile="${dist.dir}/src/scala-swing-src.jar"    basedir="${src.dir}/swing"/>
-    <jar whenmanifestonly="fail" destfile="${dist.dir}/src/scala-compiler-src.jar" basedir="${src.dir}/compiler"/>
+    </osgi.source.bundle>
+    <osgi.source.bundle destfile="${dist.dir}/src/scala-reflect-src.jar"
+                        symbolicName="org.scala-lang.scala-reflect"
+                        bundleName="Scala Reflect Sources">
+      <fileset dir="${src.dir}/reflect"/>
+    </osgi.source.bundle>
+    <osgi.source.bundle destfile="${dist.dir}/src/scala-swing-src.jar"
+                        symbolicName="org.scala-lang.scala-swing"
+                        bundleName="Scala Swing Sources">
+      <fileset dir="${src.dir}/swing"/>
+    </osgi.source.bundle>
+    <osgi.source.bundle destfile="${dist.dir}/src/scala-compiler-src.jar"
+                        symbolicName="org.scala-lang.scala-compiler"
+                        bundleName="Scala Compiler Sources">
+      <fileset dir="${src.dir}/compiler"/>
+    </osgi.source.bundle>
     <jar whenmanifestonly="fail" destfile="${dist.dir}/src/fjbg-src.jar"           basedir="${src.dir}/fjbg"/>
     <jar whenmanifestonly="fail" destfile="${dist.dir}/src/msil-src.jar"           basedir="${src.dir}/msil"/>
-    <jar whenmanifestonly="fail" destfile="${dist.dir}/src/scala-actors-src.jar"   basedir="${src.dir}/actors"/>
+    <osgi.source.bundle destfile="${dist.dir}/src/scala-actors-src.jar"
+                        symbolicName="org.scala-lang.scala-actors"
+                        bundleName="Scala Actors Sources">
+      <fileset dir="${src.dir}/actors"/>
+    </osgi.source.bundle>
     <jar whenmanifestonly="fail" destfile="${dist.dir}/src/scalap-src.jar"         basedir="${src.dir}/scalap"/>
     <jar whenmanifestonly="fail" destfile="${dist.dir}/src/scala-partest-src.jar"  basedir="${src.dir}/partest"/>
   </target>


### PR DESCRIPTION
In order to be able to use published Scala jars as OSGi bundles in the
Eclipse build, Eclipse needs to match sources and binaries. That is
done by making source jars _source bundles_. This PR adds the required
manifest entries. Nothing else should be affected (file names remain
the same).

Cherry picked from 655b7d2601d7db9e98bb405da0a67c9068c98626

Conflicts:
    build.xml

After this commit:

```
% ant -q dist.src
% for f in dists/scala-2.10.3-20130921-144112-892aa93cf7/src/*.jar; do \
    echo $f                                                            \
    unzip -p $f META-INF/MANIFEST.MF                                   \
  done

dists/scala-2.10.3-20130921-144112-892aa93cf7/src/fjbg-src.jar
Manifest-Version: 1.0
Ant-Version: Apache Ant 1.8.4
Created-By: 1.6.0_37-b06-434-11M4509 (Apple Inc.)

dists/scala-2.10.3-20130921-144112-892aa93cf7/src/msil-src.jar
Manifest-Version: 1.0
Ant-Version: Apache Ant 1.8.4
Created-By: 1.6.0_37-b06-434-11M4509 (Apple Inc.)

dists/scala-2.10.3-20130921-144112-892aa93cf7/src/scala-actors-src.jar
Manifest-Version: 1.0
Ant-Version: Apache Ant 1.8.4
Created-By: 1.6.0_37-b06-434-11M4509 (Apple Inc.)
Bundle-Name: Scala Actors Sources
Bundle-SymbolicName: org.scala-lang.scala-actors.source
Bundle-Version: 2.10.3.v20130921-144112-892aa93cf7
Eclipse-SourceBundle: org.scala-lang.scala-actors;version="2.10.3.v201
 30921-144112-892aa93cf7";roots:="."

dists/scala-2.10.3-20130921-144112-892aa93cf7/src/scala-compiler-src.jar
Manifest-Version: 1.0
Ant-Version: Apache Ant 1.8.4
Created-By: 1.6.0_37-b06-434-11M4509 (Apple Inc.)
Bundle-Name: Scala Compiler Sources
Bundle-SymbolicName: org.scala-lang.scala-compiler.source
Bundle-Version: 2.10.3.v20130921-144112-892aa93cf7
Eclipse-SourceBundle: org.scala-lang.scala-compiler;version="2.10.3.v2
 0130921-144112-892aa93cf7";roots:="."

dists/scala-2.10.3-20130921-144112-892aa93cf7/src/scala-library-src.jar
Manifest-Version: 1.0
Ant-Version: Apache Ant 1.8.4
Created-By: 1.6.0_37-b06-434-11M4509 (Apple Inc.)
Bundle-Name: Scala Library Sources
Bundle-SymbolicName: org.scala-lang.scala-library.source
Bundle-Version: 2.10.3.v20130921-144112-892aa93cf7
Eclipse-SourceBundle: org.scala-lang.scala-library;version="2.10.3.v20
 130921-144112-892aa93cf7";roots:="."

dists/scala-2.10.3-20130921-144112-892aa93cf7/src/scala-partest-src.jar
Manifest-Version: 1.0
Ant-Version: Apache Ant 1.8.4
Created-By: 1.6.0_37-b06-434-11M4509 (Apple Inc.)

dists/scala-2.10.3-20130921-144112-892aa93cf7/src/scala-reflect-src.jar
Manifest-Version: 1.0
Ant-Version: Apache Ant 1.8.4
Created-By: 1.6.0_37-b06-434-11M4509 (Apple Inc.)
Bundle-Name: Scala Reflect Sources
Bundle-SymbolicName: org.scala-lang.scala-reflect.source
Bundle-Version: 2.10.3.v20130921-144112-892aa93cf7
Eclipse-SourceBundle: org.scala-lang.scala-reflect;version="2.10.3.v20
 130921-144112-892aa93cf7";roots:="."

dists/scala-2.10.3-20130921-144112-892aa93cf7/src/scala-swing-src.jar
Manifest-Version: 1.0
Ant-Version: Apache Ant 1.8.4
Created-By: 1.6.0_37-b06-434-11M4509 (Apple Inc.)
Bundle-Name: Scala Swing Sources
Bundle-SymbolicName: org.scala-lang.scala-swing.source
Bundle-Version: 2.10.3.v20130921-144112-892aa93cf7
Eclipse-SourceBundle: org.scala-lang.scala-swing;version="2.10.3.v2013
 0921-144112-892aa93cf7";roots:="."

dists/scala-2.10.3-20130921-144112-892aa93cf7/src/scalap-src.jar
Manifest-Version: 1.0
Ant-Version: Apache Ant 1.8.4
Created-By: 1.6.0_37-b06-434-11M4509 (Apple Inc.)
```

Targetting 2.10.3-RC3

Review by @dragos
