### PR TITLE
Don't avoid to load trait impl .class without inliner.

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -181,6 +181,7 @@ trait ScalaSettings extends AbsScalaSettings
   val Yinvalidate     = StringSetting     ("-Yinvalidate", "classpath-entry", "Invalidate classpath entry before run", "")
   val YvirtClasses    = false // too embryonic to even expose as a -Y //BooleanSetting    ("-Yvirtual-classes", "Support virtual classes")
   val YdisableUnreachablePrevention = BooleanSetting("-Ydisable-unreachable-prevention", "Disable the prevention of unreachable blocks in code generation.")
+  val YnoLoadImplClass = BooleanSetting   ("-Yno-load-impl-class", "Do not load $class.class files.")
 
   val exposeEmptyPackage = BooleanSetting("-Yexpose-empty-package", "Internal only: expose the empty package.").internalOnly()
 

--- a/src/compiler/scala/tools/nsc/util/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/util/ClassPath.scala
@@ -139,9 +139,7 @@ object ClassPath {
     def newClassPath(dir: AbstractFile) = new DirectoryClassPath(dir, this)
   }
 
-  object DefaultJavaContext extends JavaContext {
-    override def isValidName(name: String) = !ReflectionUtils.scalacShouldntLoadClassfile(name)
-  }
+  object DefaultJavaContext extends JavaContext
 
   private def endsClass(s: String) = s.length > 6 && s.substring(s.length - 6) == ".class"
   private def endsScala(s: String) = s.length > 6 && s.substring(s.length - 6) == ".scala"

--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -11,6 +11,7 @@ import scala.tools.reflect.WrappedProperties.AccessControl
 import scala.tools.nsc.{ Settings }
 import scala.tools.nsc.util.{ ClassPath, JavaClassPath }
 import scala.reflect.io.{ File, Directory, Path, AbstractFile }
+import scala.reflect.runtime.ReflectionUtils
 import ClassPath.{ JavaContext, DefaultJavaContext, join, split }
 import PartialFunction.condOpt
 import scala.language.postfixOps
@@ -163,6 +164,12 @@ object PathResolver {
       |}""".asLines
   }
 
+  // used in PathResolver constructor
+  private object NoImplClassJavaContext extends JavaContext {
+    override def isValidName(name: String): Boolean =
+      !ReflectionUtils.scalacShouldntLoadClassfile(name)
+  }
+
   // called from scalap
   def fromPathString(path: String, context: JavaContext = DefaultJavaContext): JavaClassPath = {
     val s = new Settings()
@@ -193,7 +200,9 @@ object PathResolver {
 class PathResolver(settings: Settings, context: JavaContext) {
   import PathResolver.{ Defaults, Environment, AsLines, MkLines, ppcp }
 
-  def this(settings: Settings) = this(settings, DefaultJavaContext)
+  def this(settings: Settings) = this(settings,
+      if (settings.YnoLoadImplClass) PathResolver.NoImplClassJavaContext
+      else DefaultJavaContext)
 
   private def cmdLineOrElse(name: String, alt: String) = {
     (commandLineFor(name) match {

--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -193,7 +193,7 @@ object PathResolver {
 class PathResolver(settings: Settings, context: JavaContext) {
   import PathResolver.{ Defaults, Environment, AsLines, MkLines, ppcp }
 
-  def this(settings: Settings) = this(settings, if (settings.inline) new JavaContext else DefaultJavaContext)
+  def this(settings: Settings) = this(settings, DefaultJavaContext)
 
   private def cmdLineOrElse(name: String, alt: String) = {
     (commandLineFor(name) match {


### PR DESCRIPTION
This follows from the discussion in #2963, remove the logic that avoids to load `$class.class` files when the inliner is off.

An alternative could be never to load `$class.class` files (instead of always load them). @gkossakowski said in #2963 that inlining does not work anyway for methods of traits.
However I think this is less regular, and it would definitely take one step _behind_ of fixing that issue.
After all, we do load `.class` files for inner classes, which is also pointless in the absence of inlining. So if we really want to do this, we should also avoid loading all the `.class` files not corresponding to a top-level symbol.

See also:
https://issues.scala-lang.org/browse/SI-4767 Methods defined in traits are not inlined
