### PR TITLE
SI-7848 Xlint no warn on $sym with params

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -145,12 +145,15 @@ trait ContextErrors {
         def errMsg = {
           val paramName = param.name
           val paramTp   = param.tpe
+          def evOrParam = (
+            if (paramName startsWith nme.EVIDENCE_PARAM_PREFIX)
+              "evidence parameter of type"
+            else
+              s"parameter $paramName:"
+          )
           paramTp.typeSymbolDirect match {
-              case ImplicitNotFoundMsg(msg) => msg.format(paramName, paramTp)
-              case _ =>
-                "could not find implicit value for "+
-                   (if (paramName startsWith nme.EVIDENCE_PARAM_PREFIX) "evidence parameter of type "
-                    else "parameter "+paramName+": ")+paramTp
+            case ImplicitNotFoundMsg(msg) => msg.format(paramName, paramTp)
+            case _ => s"could not find implicit value for $evOrParam $paramTp"
           }
         }
         issueNormalTypeError(tree, errMsg)

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1458,7 +1458,7 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
           applyChecks(sym.annotations)
           // validate implicitNotFoundMessage
           analyzer.ImplicitNotFoundMsg.check(sym) foreach { warn =>
-            unit.warning(tree.pos, "Invalid implicitNotFound message for %s%s:\n%s".format(sym, sym.locationString, warn))
+            unit.warning(tree.pos, f"Invalid implicitNotFound message for ${sym}%s${sym.locationString}%s:%n$warn")
           }
 
         case tpt@TypeTree() =>

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4875,18 +4875,22 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
       // Warn about likely interpolated strings which are missing their interpolators
       def warnMissingInterpolator(tree: Literal) = if (!isPastTyper) {
-        // Unfortunately implicit not found strings looks for all the world like
-        // missing interpolators.
-        def isArgToImplicitNotFound = context.enclosingApply.tree match {
-          case Apply(fn, _) => fn.symbol != null && fn.symbol.enclClass == ImplicitNotFoundClass
-          case _            => false
+        // attempt to avoid warning about the special interpolated message string
+        // for implicitNotFound or any standard interpolation (with embedded $$).
+        def isArgToCertainApply = context.enclosingApply.tree match {
+          case Apply(Select(Apply(Ident(n), parts), _), args) if n.toTypeName == StringContextClass.name
+                 => true    // parts contains tree
+          case Apply(Select(New(Ident(n)), _), _) if n == ImplicitNotFoundClass.name
+                 => true
+          case _ => false
         }
         def warnAbout(s: String) = {
           def names = InterpolatorIdentRegex findAllIn s map (n => TermName(n stripPrefix "$"))
-          def isSuspiciousExpr = (InterpolatorCodeRegex findFirstIn s).nonEmpty
-          //def isSuspiciousName = names exists (lookUp _ andThen (_.exists))
-          def suspiciousName   = names find (lookUp _ andThen (_.exists))
-          def lookUp(n: TermName)  = context.lookupSymbol(n, !_.alternatives.exists(symRequiresArg)).symbol
+          def isSuspiciousExpr    = (InterpolatorCodeRegex findFirstIn s).nonEmpty
+          //def isSuspiciousName  = names exists (lookUp _ andThen isCandidate _)
+          def suspiciousName      = names find (n => isCandidate(lookUp(n)))
+          def lookUp(n: TermName) = context.lookupSymbol(n, _ => true).symbol
+          def isCandidate(s: Symbol) = s.exists && s.alternatives.exists(alt => !symRequiresArg(alt))
           def symRequiresArg(s: Symbol) = (
                s.paramss.nonEmpty
             && (s.paramss.head.headOption filterNot (_.isImplicit)).isDefined
@@ -4901,7 +4905,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         tree.value match {
           case Constant(s: String) =>
             val noWarn = (
-                 isArgToImplicitNotFound
+                 isArgToCertainApply
               || !(s contains ' ') // another heuristic - e.g. a string with only "$asInstanceOf"
             )
             if (!noWarn) warnAbout(s)

--- a/test/files/neg/forgot-interpolator.check
+++ b/test/files/neg/forgot-interpolator.check
@@ -1,24 +1,21 @@
 forgot-interpolator.scala:4: warning: `$bippy` looks like an interpolated identifier! Did you forget the interpolator?
-  def f = "Put the $bippy in the $bippy!" // warn
+  def f = "Put the $bippy in the $bippy!" // warn 1
           ^
 forgot-interpolator.scala:14: warning: That looks like an interpolated expression! Did you forget the interpolator?
-  def f = """Put the ${println("bippy")} in the bippy!""" // warn
+  def f = """Put the ${println("bippy")} in the bippy!""" // warn 2
           ^
 forgot-interpolator.scala:30: warning: `$beppo` looks like an interpolated identifier! Did you forget the interpolator?
-      def f = "$beppo was a marx bros who saw dollars."  // warn
+      def f = "$beppo was a marx bros who saw dollars."  // warn 3
               ^
 forgot-interpolator.scala:34: warning: `$aleppo` looks like an interpolated identifier! Did you forget the interpolator?
-    def f = "$aleppo is a pepper and a city."  // warn
+    def f = "$aleppo is a pepper and a city."     // warn 4
             ^
-forgot-interpolator.scala:40: warning: `$bar` looks like an interpolated identifier! Did you forget the interpolator?
-    def f = "$bar is private, shall we warn just in case?" // warn
+forgot-interpolator.scala:42: warning: `$bar` looks like an interpolated identifier! Did you forget the interpolator?
+    def f = "$bar is private, shall we warn just in case?" // warn 5
             ^
-forgot-interpolator.scala:45: warning: `$hippo` looks like an interpolated identifier! Did you forget the interpolator?
-    def h = "$hippo takes an implicit"  // warn
+forgot-interpolator.scala:47: warning: `$hippo` looks like an interpolated identifier! Did you forget the interpolator?
+    def h = "$hippo takes an implicit"  // warn 6
             ^
-forgot-interpolator.scala:37: warning: private method in class Bar is never used
-    private def bar = 8
-                ^
 error: No warnings can be incurred under -Xfatal-warnings.
-7 warnings found
+6 warnings found
 one error found

--- a/test/files/neg/forgot-interpolator.scala
+++ b/test/files/neg/forgot-interpolator.scala
@@ -1,7 +1,7 @@
 class A {
   val bippy = 123
 
-  def f = "Put the $bippy in the $bippy!" // warn
+  def f = "Put the $bippy in the $bippy!" // warn 1
 }
 
 class B {
@@ -11,7 +11,7 @@ class B {
 }
 
 class C {
-  def f = """Put the ${println("bippy")} in the bippy!""" // warn
+  def f = """Put the ${println("bippy")} in the bippy!""" // warn 2
 }
 
 package object test {
@@ -27,21 +27,33 @@ package test {
     def beppo(i: Int) = 8 * i
     def beppo = 8
     class Dah extends Doo {
-      def f = "$beppo was a marx bros who saw dollars."  // warn
+      def f = "$beppo was a marx bros who saw dollars."  // warn 3
     }
   }
   class E {
-    def f = "$aleppo is a pepper and a city."  // warn
+    def f = "$aleppo is a pepper and a city."     // warn 4
+    def k = s"Just an interpolation of $aleppo"   // no warn
   }
   class Bar {
     private def bar = 8
+    if (bar > 8) ???       // use it to avoid extra warning
   }
   class Baz extends Bar {
-    def f = "$bar is private, shall we warn just in case?" // warn
+    def f = "$bar is private, shall we warn just in case?" // warn 5
   }
   class G {
     def g = "$greppo takes an arg"  // no warn
     def z = "$zappos takes an arg too"  // no warn
-    def h = "$hippo takes an implicit"  // warn
+    def h = "$hippo takes an implicit"  // warn 6
   }
+  class J {
+    def j = 8
+    class J2 {
+      def j(i: Int) = 2 * i
+      def jj = "shadowed $j"  // no warn
+    }
+  }
+  import annotation._
+  @implicitNotFound("No Z in ${A}")   // no warn
+  class Z[A]
 }

--- a/test/files/neg/t2462b.check
+++ b/test/files/neg/t2462b.check
@@ -6,9 +6,6 @@ t2462b.scala:9: warning: Invalid implicitNotFound message for trait Meh2 in pack
 The type parameter Elem referenced in the message of the @implicitNotFound annotation is not defined by trait Meh2.
 trait Meh2[-From, +To]
       ^
-t2462b.scala:12: error: overriding method x in class thankyoupartest of type => Int;
- method x needs `override' modifier
-class testmustfail extends thankyoupartest { def x = 43 }
-                                                 ^
+error: No warnings can be incurred under -Xfatal-warnings.
 two warnings found
 one error found

--- a/test/files/neg/t2462b.flags
+++ b/test/files/neg/t2462b.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/t2462b.scala
+++ b/test/files/neg/t2462b.scala
@@ -7,6 +7,3 @@ trait Meh[-From, +To]
 
 @implicitNotFound(msg = "Cannot construct a collection of type ${To} ${Elem}.")
 trait Meh2[-From, +To]
-
-class thankyoupartest { def x = 42 }
-class testmustfail extends thankyoupartest { def x = 43 }

--- a/test/files/neg/t2462c.check
+++ b/test/files/neg/t2462c.check
@@ -1,0 +1,7 @@
+t2462c.scala:18: error: No C of X$Y
+  f[X$Y]
+   ^
+t2462c.scala:24: error: No C of Foo[Int]
+  f[Foo[Int]]
+   ^
+two errors found

--- a/test/files/neg/t2462c.flags
+++ b/test/files/neg/t2462c.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/t2462c.scala
+++ b/test/files/neg/t2462c.scala
@@ -1,0 +1,25 @@
+
+import annotation._
+
+@implicitNotFound("No C of ${ A }")
+class C[A]
+
+trait X$Y
+/* using the $$ separator for expanded names is unwise
+trait X$$Y
+trait X$$$Y
+trait X$$$$Y
+ */
+
+trait Foo[A]
+
+class Test {
+  def f[A: C] = ???
+  f[X$Y]
+/* using the $$ separator for expanded names is unwise
+  f[X$$Y]
+  f[X$$$Y]
+  f[X$$$$Y]
+ */
+  f[Foo[Int]]
+}

--- a/test/files/neg/t7848-interp-warn.check
+++ b/test/files/neg/t7848-interp-warn.check
@@ -1,9 +1,12 @@
-t7848-interp-warn.scala:7: warning: `$foo` looks like an interpolated identifier! Did you forget the interpolator?
+t7848-interp-warn.scala:8: warning: `$foo` looks like an interpolated identifier! Did you forget the interpolator?
     "An important $foo message!"
     ^
-t7848-interp-warn.scala:11: warning: That looks like an interpolated expression! Did you forget the interpolator?
+t7848-interp-warn.scala:12: warning: That looks like an interpolated expression! Did you forget the interpolator?
     "A doubly important ${foo * 2} message!"
     ^
+t7848-interp-warn.scala:16: warning: `$bar` looks like an interpolated identifier! Did you forget the interpolator?
+  def j = s"Try using '${ "something like $bar" }' instead."  // warn
+                          ^
 error: No warnings can be incurred under -Xfatal-warnings.
-two warnings found
+three warnings found
 one error found

--- a/test/files/neg/t7848-interp-warn.scala
+++ b/test/files/neg/t7848-interp-warn.scala
@@ -2,6 +2,7 @@
 package test
 
 object Test {
+  def bar = "bar"
   def f = {
     val foo = "bar"
     "An important $foo message!"
@@ -10,4 +11,8 @@ object Test {
     val foo = "bar"
     "A doubly important ${foo * 2} message!"
   }
+  def h = s"Try using '$$bar' instead."  // no warn
+  def i = s"Try using '${ "$bar" }' instead."  // no warn on space test
+  def j = s"Try using '${ "something like $bar" }' instead."  // warn
+  def k = f"Try using '$bar' instead."  // no warn on other std interps
 }


### PR DESCRIPTION
This idea brought to you by retronym.

Also improve implicitNotFound detection at typer;
and avoid checking the standard interpolation
expression for cases like s"some $$x".

Some minor refactorings of implicitNotFound strings.

The intersobralator allows extra spaces, i.e., trims.

(This merge faked me out somehow.  Here's to workflow. Looks like the earlier
commits were unchanged.)
