### PR TITLE
SI-7870 Detect default getter clashes in constructors

### DIFF
--- a/test/files/neg/t7870.check
+++ b/test/files/neg/t7870.check
@@ -1,0 +1,4 @@
+t7870.scala:1: error: in class C, multiple overloaded alternatives of constructor C define default arguments.
+class C(a: Int = 0, b: Any) {
+      ^
+one error found

--- a/test/files/neg/t7870.scala
+++ b/test/files/neg/t7870.scala
@@ -1,0 +1,3 @@
+class C(a: Int = 0, b: Any) {
+  def this(a: Int = 0) = this(???, ???)
+}


### PR DESCRIPTION
Default getters for constructors live in the companion module.
These eluded the check for clashes in default getter names due
to overloading, which aims to give a more user friendly error
than "double definition: meth$default$1".

This commit checks for default getters in the companion module,
in addition to those in the template itself.

Review by @lrytz
