### PR TITLE
SI-4742 Make -Xcheckinit aware of constants.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Mixin.scala
+++ b/src/compiler/scala/tools/nsc/transform/Mixin.scala
@@ -89,6 +89,7 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
         settings.checkInit
      && sym.isGetter
      && !sym.isInitializedToDefault
+     && !isConstantType(sym.info.finalResultType) // SI-4742
      && !sym.hasFlag(PARAMACCESSOR | SPECIALIZED | LAZY)
      && !sym.accessed.hasFlag(PRESUPER)
      && !sym.isOuterAccessor

--- a/test/files/run/t4742.flags
+++ b/test/files/run/t4742.flags
@@ -1,0 +1,1 @@
+-Xcheckinit

--- a/test/files/run/t4742.scala
+++ b/test/files/run/t4742.scala
@@ -1,0 +1,7 @@
+trait T { val x: Int = 0 }
+object O extends T { override final val x = 1 }
+
+object Test extends App {
+  // was throwing an UnitializedFieldError as constant 1 is folded into the accessor
+  assert((O: T).x == 1)
+}


### PR DESCRIPTION
Members defined as `final val x = <literal>` are given
a ConstantType. The constant is folded into the accessor
method `x`, and the field itself is never initialized.
(Related discussion: SI-4605)

As such, -Xcheckinit spuriously warns when calling that
accessor.

This commit disables the checks for constants.

This will also fix the checkinit build (failure tracked as SI-7839),
which is the victim of this a spurious scolding.

Review by @adriaanm
