### PR TITLE
SI-6493 Fix existential type used to hide local classes

### DIFF
--- a/test/files/pos/t6493b.scala
+++ b/test/files/pos/t6493b.scala
@@ -1,0 +1,23 @@
+ trait T[T] {
+    trait U {
+      def x = ()
+    }
+    def u: U
+  }
+
+object Test {
+  def foo = new T[Any] {
+    def u: U = ???
+  }
+
+  // okay
+  (foo: T[Any]).u.x
+
+  // fails with if `TypeRef#coevolveSym` only looks in RefinedType's decls, rather than members.
+  // This happens trying to existentially extrapolate the type `_2.U` (where `_2` is a refinement)
+  // captured from `T.this.U`.
+  //
+  // This all comes about because `foo` returns a refinement type; if it were annotated with `T[Any]`
+  // now existential extrapolation occurs.
+  foo.u.x
+}

--- a/test/files/run/t6493/A_1.scala
+++ b/test/files/run/t6493/A_1.scala
@@ -1,0 +1,3 @@
+object one {
+  def foo() = { object Foo { class Bar } ; new Foo.Bar }
+}

--- a/test/files/run/t6493/B_2.scala
+++ b/test/files/run/t6493/B_2.scala
@@ -1,0 +1,3 @@
+object Test {
+  def main(args: Array[String]): Unit = one.foo
+}


### PR DESCRIPTION
In:

```
def foo = { object O { class C }; new O.C }
```

The inferred return type of can't refer to the local
symbols; they must not leak out of the compilation unit.

Instead, `packSymbols` is used to choose a less precise
existential type, `(AnyRef { type C <: AnyRef })#C)`.

This is implemented as a `TypeMap`, which is supposed to
takes care of rebinding `C` to something valid in the new
prefix (`(AnyRef { type C <: AnyRef })`).

If `C` was orginally a type alias, and the original
prefix was a refinement type, this was handled in
`AliasTypeRef#coevolveSym`, which looks for a type
in the new prefix with the name `C`. But for other
type refs (e.g. a class type ref, as in this case),
a no-op `coevolveSym` was used, deferring the rebinding
of abstract classes until `typeRef`.

But our case falls between the cracks, and we end up
propagating a type ref in which the prefix does not
contain the member.

With the help of `-uniqid`, this is clear:

```
<method> def foo#7445(): scala#21.this.AnyRef#2222{type Bar#12153 <: scala#21.this.AnyRef#2222}#Bar#12125
```

Notice the reference to symbol `#12125`, rather than `#12153`.

This commit moves the `coevolveSym` logic up to `TypeRef`,
generalizing it to work for any `pre1`. This example answered
the question in that code:

> // TODO: is there another way a typeref's symbol can refer to a symbol defined in its pre?

Review by @adriaanm. Found this patch in a dusty corner.
