### PR TITLE
SI-1945 REPL accretes lines to fix syntax

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/package.scala
+++ b/src/repl/scala/tools/nsc/interpreter/package.scala
@@ -15,10 +15,8 @@ import scala.util.control.Exception.catching
 /** The main REPL related classes and values are as follows.
  *  In addition to standard compiler classes Global and Settings, there are:
  *
- *  History: an interface for session history.
- *  Completion: an interface for tab completion.
- *  ILoop (formerly InterpreterLoop): The umbrella class for a session.
- *  IMain (formerly Interpreter): Handles the evolving state of the session
+ *  ILoop: The umbrella class for a session.
+ *  IMain: Handles the evolving state of the session
  *    and handles submitting code to the compiler and handling the output.
  *  InteractiveReader: how ILoop obtains input.
  *  History: an interface for session history.

--- a/test/files/run/t1945-repl-accrete.scala
+++ b/test/files/run/t1945-repl-accrete.scala
@@ -1,0 +1,35 @@
+
+import scala.tools.partest.SessionTest
+
+// REPL will accrete lines in search of good syntax.
+object Test extends SessionTest {
+  def session =
+""" |Type in expressions to have them evaluated.
+    |Type :help for more information.
+    |
+    |scala> val i = 7
+    |i: Int = 7
+    |
+    |scala> if (i < 7) 8
+    |res0: AnyVal = ()
+    |
+    |scala> else 9
+    |res1: Int = 9
+    |
+    |scala> if (i > 3) 100
+    |res2: AnyVal = 100
+    |
+    |scala> else if (i > 4) 200
+    |res3: AnyVal = 100
+    |
+    |scala> else 300
+    |res4: Int = 100
+    |
+    |scala> "abc"
+    |res5: String = abc
+    |
+    |scala>      .length
+    |res6: Int = 3
+    |
+    |scala> """
+}


### PR DESCRIPTION
On a syntax error, if the last line compiled without
error, REPL will concatenate the two lines and try to
compile the result.

The use case is splitting an if/else over two lines
of input.

REPL will not retry on typer errors: that feature
would allow the use case currently handled by looking
for leading dot. For example, "abc"\nlength would work
as postfix invocation.

It does assist dot-completion in the case of extra
whitespace: "abc"\n .length works by accretion.
