### PR TITLE
transformers no longer ignore UnApply.fun

### DIFF
--- a/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
+++ b/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
@@ -2,9 +2,11 @@ package scala
 package tools
 package reflect
 
+import scala.tools.cmd.CommandLineParser
+import scala.tools.nsc.Global
 import scala.tools.nsc.reporters._
 import scala.tools.nsc.CompilerCommand
-import scala.tools.nsc.io.VirtualDirectory
+import scala.tools.nsc.io.{AbstractFile, VirtualDirectory}
 import scala.tools.nsc.util.AbstractFileClassLoader
 import scala.reflect.internal.Flags._
 import scala.reflect.internal.util.{BatchSourceFile, NoSourceFile, NoFile}
@@ -29,6 +31,13 @@ abstract class ToolBoxFactory[U <: JavaUniverse](val u: U) { factorySelf =>
     lazy val classLoader = new AbstractFileClassLoader(virtualDirectory, factorySelf.mirror.classLoader)
     lazy val mirror: u.Mirror = u.runtimeMirror(classLoader)
 
+    lazy val arguments = CommandLineParser.tokenize(options)
+    lazy val virtualDirectory =
+      arguments.iterator.sliding(2).collectFirst{ case Seq("-d", dir) => dir } match {
+        case Some(outDir) => AbstractFile.getDirectory(outDir)
+        case None => new VirtualDirectory("(memory)", None)
+      }
+
     class ToolBoxGlobal(settings: scala.tools.nsc.Settings, reporter0: Reporter)
     extends ReflectGlobal(settings, reporter0, toolBoxSelf.classLoader) {
       import definitions._
@@ -47,7 +56,6 @@ abstract class ToolBoxFactory[U <: JavaUniverse](val u: U) { factorySelf =>
       }
 
       // should be called after every use of ToolBoxGlobal in order to prevent leaks
-      // there's the `withCleanupCaches` method defined below, which provides a convenient interface for that
       def cleanupCaches(): Unit = {
         perRunCaches.clearAll()
         undoLog.clear()
@@ -55,14 +63,6 @@ abstract class ToolBoxFactory[U <: JavaUniverse](val u: U) { factorySelf =>
         lastSeenSourceFile = NoSourceFile
         lastSeenContext = null
       }
-
-      def withCleanupCaches[T](body: => T): T =
-        try body
-        finally cleanupCaches()
-
-      def wrappingFatalErrors[T](body: => T): T =
-        try body
-        catch { case ex: FatalError => throw ToolBoxError(s"fatal compiler error", ex) }
 
       def verify(expr: Tree): Unit = {
         // Previously toolboxes used to typecheck their inputs before compiling.
@@ -307,50 +307,56 @@ abstract class ToolBoxFactory[U <: JavaUniverse](val u: U) { factorySelf =>
       }
     }
 
-    // todo. is not going to work with quoted arguments with embedded whitespaces
-    lazy val arguments = options.split(" ")
+    trait CompilerApi {
+      val compiler: ToolBoxGlobal
+      val importer: compiler.Importer { val from: u.type }
+      val exporter: u.Importer { val from: compiler.type }
+    }
 
-    lazy val virtualDirectory =
-      (arguments zip arguments.tail).collect{ case ("-d", dir) => dir }.lastOption match {
-        case Some(outDir) => scala.tools.nsc.io.AbstractFile.getDirectory(outDir)
-        case None => new VirtualDirectory("(memory)", None)
+    object withCompilerApi {
+      private object api extends CompilerApi {
+        lazy val compiler: ToolBoxGlobal = {
+          try {
+            val errorFn: String => Unit = msg => frontEnd.log(scala.reflect.internal.util.NoPosition, msg, frontEnd.ERROR)
+            val command = new CompilerCommand(arguments.toList, errorFn)
+            command.settings.outputDirs setSingleOutput virtualDirectory
+            val instance = new ToolBoxGlobal(command.settings, frontEndToReporter(frontEnd, command.settings))
+            if (frontEnd.hasErrors) {
+              throw ToolBoxError(
+                "reflective compilation has failed: cannot initialize the compiler:" + EOL + EOL +
+                (frontEnd.infos map (_.msg) mkString EOL)
+              )
+            }
+            instance
+          } catch {
+            case ex: Throwable =>
+              throw ToolBoxError(s"reflective compilation has failed: cannot initialize the compiler due to $ex", ex)
+          }
+        }
+
+        lazy val importer = compiler.mkImporter(u)
+        lazy val exporter = importer.reverse
       }
 
-    lazy val compiler: ToolBoxGlobal = {
-      try {
-        val errorFn: String => Unit = msg => frontEnd.log(scala.reflect.internal.util.NoPosition, msg, frontEnd.ERROR)
-        val command = new CompilerCommand(arguments.toList, errorFn)
-        command.settings.outputDirs setSingleOutput virtualDirectory
-        val instance = new ToolBoxGlobal(command.settings, frontEndToReporter(frontEnd, command.settings))
-        if (frontEnd.hasErrors) {
-          throw ToolBoxError(
-            "reflective compilation has failed: cannot initialize the compiler:" + EOL + EOL +
-            (frontEnd.infos map (_.msg) mkString EOL)
-          )
-        }
-        instance
-      } catch {
-        case ex: Throwable =>
-          throw ToolBoxError(s"reflective compilation has failed: cannot initialize the compiler due to $ex", ex)
+      def apply[T](f: CompilerApi => T): T = {
+        try f(api)
+        catch { case ex: FatalError => throw ToolBoxError(s"fatal compiler error", ex) }
+        finally api.compiler.cleanupCaches()
       }
     }
 
-    lazy val importer = compiler.mkImporter(u)
-    lazy val exporter = importer.reverse
+    def typeCheck(tree: u.Tree, expectedType: u.Type, silent: Boolean = false, withImplicitViewsDisabled: Boolean = false, withMacrosDisabled: Boolean = false): u.Tree = withCompilerApi { compilerApi =>
+      import compilerApi._
 
-    def typeCheck(tree: u.Tree, expectedType: u.Type, silent: Boolean = false, withImplicitViewsDisabled: Boolean = false, withMacrosDisabled: Boolean = false): u.Tree =
-      compiler.wrappingFatalErrors {
-        compiler.withCleanupCaches {
-          if (compiler.settings.verbose) println("importing "+tree+", expectedType = "+expectedType)
-          val ctree: compiler.Tree = importer.importTree(tree)
-          val cexpectedType: compiler.Type = importer.importType(expectedType)
+      if (compiler.settings.verbose) println("importing "+tree+", expectedType = "+expectedType)
+      val ctree: compiler.Tree = importer.importTree(tree)
+      val cexpectedType: compiler.Type = importer.importType(expectedType)
 
-          if (compiler.settings.verbose) println("typing "+ctree+", expectedType = "+expectedType)
-          val ttree: compiler.Tree = compiler.typeCheck(ctree, cexpectedType, silent = silent, withImplicitViewsDisabled = withImplicitViewsDisabled, withMacrosDisabled = withMacrosDisabled)
-          val uttree = exporter.importTree(ttree)
-          uttree
-        }
-      }
+      if (compiler.settings.verbose) println("typing "+ctree+", expectedType = "+expectedType)
+      val ttree: compiler.Tree = compiler.typeCheck(ctree, cexpectedType, silent = silent, withImplicitViewsDisabled = withImplicitViewsDisabled, withMacrosDisabled = withMacrosDisabled)
+      val uttree = exporter.importTree(ttree)
+      uttree
+    }
 
     def inferImplicitValue(pt: u.Type, silent: Boolean = true, withMacrosDisabled: Boolean = false, pos: u.Position = u.NoPosition): u.Tree = {
       inferImplicit(u.EmptyTree, pt, isView = false, silent = silent, withMacrosDisabled = withMacrosDisabled, pos = pos)
@@ -362,43 +368,47 @@ abstract class ToolBoxFactory[U <: JavaUniverse](val u: U) { factorySelf =>
       inferImplicit(tree, viewTpe, isView = true, silent = silent, withMacrosDisabled = withMacrosDisabled, pos = pos)
     }
 
-    private def inferImplicit(tree: u.Tree, pt: u.Type, isView: Boolean, silent: Boolean, withMacrosDisabled: Boolean, pos: u.Position): u.Tree =
-      compiler.wrappingFatalErrors {
-        compiler.withCleanupCaches {
-          if (compiler.settings.verbose) println(s"importing pt=$pt, tree=$tree, pos=$pos")
-          val ctree: compiler.Tree = importer.importTree(tree)
-          val cpt: compiler.Type = importer.importType(pt)
-          val cpos: compiler.Position = importer.importPosition(pos)
+    private def inferImplicit(tree: u.Tree, pt: u.Type, isView: Boolean, silent: Boolean, withMacrosDisabled: Boolean, pos: u.Position): u.Tree = withCompilerApi { compilerApi =>
+      import compilerApi._
 
-          if (compiler.settings.verbose) println("inferring implicit %s of type %s, macros = %s".format(if (isView) "view" else "value", pt, !withMacrosDisabled))
-          val itree: compiler.Tree = compiler.inferImplicit(ctree, cpt, isView = isView, silent = silent, withMacrosDisabled = withMacrosDisabled, pos = cpos)
-          val uitree = exporter.importTree(itree)
-          uitree
-        }
-      }
+      if (compiler.settings.verbose) println(s"importing pt=$pt, tree=$tree, pos=$pos")
+      val ctree: compiler.Tree = importer.importTree(tree)
+      val cpt: compiler.Type = importer.importType(pt)
+      val cpos: compiler.Position = importer.importPosition(pos)
 
-    def resetAllAttrs(tree: u.Tree): u.Tree = compiler.wrappingFatalErrors {
+      if (compiler.settings.verbose) println("inferring implicit %s of type %s, macros = %s".format(if (isView) "view" else "value", pt, !withMacrosDisabled))
+      val itree: compiler.Tree = compiler.inferImplicit(ctree, cpt, isView = isView, silent = silent, withMacrosDisabled = withMacrosDisabled, pos = cpos)
+      val uitree = exporter.importTree(itree)
+      uitree
+    }
+
+    def resetAllAttrs(tree: u.Tree): u.Tree = withCompilerApi { compilerApi =>
+      import compilerApi._
       val ctree: compiler.Tree = importer.importTree(tree)
       val ttree: compiler.Tree = compiler.resetAllAttrs(ctree)
       val uttree = exporter.importTree(ttree)
       uttree
     }
 
-    def resetLocalAttrs(tree: u.Tree): u.Tree = compiler.wrappingFatalErrors {
+    def resetLocalAttrs(tree: u.Tree): u.Tree = withCompilerApi { compilerApi =>
+      import compilerApi._
       val ctree: compiler.Tree = importer.importTree(tree)
       val ttree: compiler.Tree = compiler.resetLocalAttrs(ctree)
       val uttree = exporter.importTree(ttree)
       uttree
     }
 
-    def parse(code: String): u.Tree = compiler.wrappingFatalErrors {
+    def parse(code: String): u.Tree = withCompilerApi { compilerApi =>
+      import compilerApi._
       if (compiler.settings.verbose) println("parsing "+code)
       val ctree: compiler.Tree = compiler.parse(code)
       val utree = exporter.importTree(ctree)
       utree
     }
 
-    def compile(tree: u.Tree): () => Any = compiler.wrappingFatalErrors {
+    def compile(tree: u.Tree): () => Any = withCompilerApi { compilerApi =>
+      import compilerApi._
+
       if (compiler.settings.verbose) println("importing "+tree)
       val ctree: compiler.Tree = importer.importTree(tree)
 

--- a/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
+++ b/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
@@ -13,6 +13,7 @@ import scala.compat.Platform.EOL
 import scala.reflect.NameTransformer
 import scala.reflect.api.JavaUniverse
 import scala.reflect.io.NoAbstractFile
+import scala.reflect.internal.FatalError
 
 abstract class ToolBoxFactory[U <: JavaUniverse](val u: U) { factorySelf =>
 
@@ -58,6 +59,10 @@ abstract class ToolBoxFactory[U <: JavaUniverse](val u: U) { factorySelf =>
       def withCleanupCaches[T](body: => T): T =
         try body
         finally cleanupCaches()
+
+      def wrappingFatalErrors[T](body: => T): T =
+        try body
+        catch { case ex: FatalError => throw ToolBoxError(s"fatal compiler error", ex) }
 
       def verify(expr: Tree): Unit = {
         // Previously toolboxes used to typecheck their inputs before compiling.
@@ -333,16 +338,19 @@ abstract class ToolBoxFactory[U <: JavaUniverse](val u: U) { factorySelf =>
     lazy val importer = compiler.mkImporter(u)
     lazy val exporter = importer.reverse
 
-    def typeCheck(tree: u.Tree, expectedType: u.Type, silent: Boolean = false, withImplicitViewsDisabled: Boolean = false, withMacrosDisabled: Boolean = false): u.Tree = compiler.withCleanupCaches {
-      if (compiler.settings.verbose) println("importing "+tree+", expectedType = "+expectedType)
-      val ctree: compiler.Tree = importer.importTree(tree)
-      val cexpectedType: compiler.Type = importer.importType(expectedType)
+    def typeCheck(tree: u.Tree, expectedType: u.Type, silent: Boolean = false, withImplicitViewsDisabled: Boolean = false, withMacrosDisabled: Boolean = false): u.Tree =
+      compiler.wrappingFatalErrors {
+        compiler.withCleanupCaches {
+          if (compiler.settings.verbose) println("importing "+tree+", expectedType = "+expectedType)
+          val ctree: compiler.Tree = importer.importTree(tree)
+          val cexpectedType: compiler.Type = importer.importType(expectedType)
 
-      if (compiler.settings.verbose) println("typing "+ctree+", expectedType = "+expectedType)
-      val ttree: compiler.Tree = compiler.typeCheck(ctree, cexpectedType, silent = silent, withImplicitViewsDisabled = withImplicitViewsDisabled, withMacrosDisabled = withMacrosDisabled)
-      val uttree = exporter.importTree(ttree)
-      uttree
-    }
+          if (compiler.settings.verbose) println("typing "+ctree+", expectedType = "+expectedType)
+          val ttree: compiler.Tree = compiler.typeCheck(ctree, cexpectedType, silent = silent, withImplicitViewsDisabled = withImplicitViewsDisabled, withMacrosDisabled = withMacrosDisabled)
+          val uttree = exporter.importTree(ttree)
+          uttree
+        }
+      }
 
     def inferImplicitValue(pt: u.Type, silent: Boolean = true, withMacrosDisabled: Boolean = false, pos: u.Position = u.NoPosition): u.Tree = {
       inferImplicit(u.EmptyTree, pt, isView = false, silent = silent, withMacrosDisabled = withMacrosDisabled, pos = pos)
@@ -354,40 +362,43 @@ abstract class ToolBoxFactory[U <: JavaUniverse](val u: U) { factorySelf =>
       inferImplicit(tree, viewTpe, isView = true, silent = silent, withMacrosDisabled = withMacrosDisabled, pos = pos)
     }
 
-    private def inferImplicit(tree: u.Tree, pt: u.Type, isView: Boolean, silent: Boolean, withMacrosDisabled: Boolean, pos: u.Position): u.Tree = compiler.withCleanupCaches {
-      if (compiler.settings.verbose) println(s"importing pt=$pt, tree=$tree, pos=$pos")
-      val ctree: compiler.Tree = importer.importTree(tree)
-      val cpt: compiler.Type = importer.importType(pt)
-      val cpos: compiler.Position = importer.importPosition(pos)
+    private def inferImplicit(tree: u.Tree, pt: u.Type, isView: Boolean, silent: Boolean, withMacrosDisabled: Boolean, pos: u.Position): u.Tree =
+      compiler.wrappingFatalErrors {
+        compiler.withCleanupCaches {
+          if (compiler.settings.verbose) println(s"importing pt=$pt, tree=$tree, pos=$pos")
+          val ctree: compiler.Tree = importer.importTree(tree)
+          val cpt: compiler.Type = importer.importType(pt)
+          val cpos: compiler.Position = importer.importPosition(pos)
 
-      if (compiler.settings.verbose) println("inferring implicit %s of type %s, macros = %s".format(if (isView) "view" else "value", pt, !withMacrosDisabled))
-      val itree: compiler.Tree = compiler.inferImplicit(ctree, cpt, isView = isView, silent = silent, withMacrosDisabled = withMacrosDisabled, pos = cpos)
-      val uitree = exporter.importTree(itree)
-      uitree
-    }
+          if (compiler.settings.verbose) println("inferring implicit %s of type %s, macros = %s".format(if (isView) "view" else "value", pt, !withMacrosDisabled))
+          val itree: compiler.Tree = compiler.inferImplicit(ctree, cpt, isView = isView, silent = silent, withMacrosDisabled = withMacrosDisabled, pos = cpos)
+          val uitree = exporter.importTree(itree)
+          uitree
+        }
+      }
 
-    def resetAllAttrs(tree: u.Tree): u.Tree = {
+    def resetAllAttrs(tree: u.Tree): u.Tree = compiler.wrappingFatalErrors {
       val ctree: compiler.Tree = importer.importTree(tree)
       val ttree: compiler.Tree = compiler.resetAllAttrs(ctree)
       val uttree = exporter.importTree(ttree)
       uttree
     }
 
-    def resetLocalAttrs(tree: u.Tree): u.Tree = {
+    def resetLocalAttrs(tree: u.Tree): u.Tree = compiler.wrappingFatalErrors {
       val ctree: compiler.Tree = importer.importTree(tree)
       val ttree: compiler.Tree = compiler.resetLocalAttrs(ctree)
       val uttree = exporter.importTree(ttree)
       uttree
     }
 
-    def parse(code: String): u.Tree = {
+    def parse(code: String): u.Tree = compiler.wrappingFatalErrors {
       if (compiler.settings.verbose) println("parsing "+code)
       val ctree: compiler.Tree = compiler.parse(code)
       val utree = exporter.importTree(ctree)
       utree
     }
 
-    def compile(tree: u.Tree): () => Any = {
+    def compile(tree: u.Tree): () => Any = compiler.wrappingFatalErrors {
       if (compiler.settings.verbose) println("importing "+tree)
       val ctree: compiler.Tree = importer.importTree(tree)
 

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -1381,7 +1381,7 @@ trait Trees extends api.Trees { self: SymbolTable =>
       case Star(elem) =>
         treeCopy.Star(tree, transform(elem))
       case UnApply(fun, args) =>
-        treeCopy.UnApply(tree, fun, transformTrees(args)) // bq: see test/.../unapplyContexts2.scala
+        treeCopy.UnApply(tree, transform(fun), transformTrees(args)) // bq: see test/.../unapplyContexts2.scala
       case ArrayValue(elemtpt, trees) =>
         treeCopy.ArrayValue(tree, transform(elemtpt), transformTrees(trees))
       case ApplyDynamic(qual, args) =>

--- a/test/files/run/t7871.check
+++ b/test/files/run/t7871.check
@@ -1,0 +1,1 @@
+(SomeTree,SomeTree)

--- a/test/files/run/t7871/Macros_1.scala
+++ b/test/files/run/t7871/Macros_1.scala
@@ -1,0 +1,27 @@
+import scala.reflect.macros.Context
+import language.experimental.macros
+
+trait Tree
+case object SomeTree extends Tree
+
+object NewQuasiquotes {
+  implicit class QuasiquoteInterpolation(c: StringContext) {
+    object nq {
+      def unapply(t: Tree) = macro QuasiquoteMacros.unapplyImpl
+    }
+  }
+}
+
+object QuasiquoteMacros {
+  def unapplyImpl(c: Context)(t: c.Tree) = {
+    import c.universe._
+    q"""
+      new {
+        def unapply(t: Tree) = t match {
+          case SomeTree => Some((SomeTree, SomeTree))
+          case _ => None
+        }
+      }.unapply($t)
+    """
+  }
+}

--- a/test/files/run/t7871/Test_2.scala
+++ b/test/files/run/t7871/Test_2.scala
@@ -1,0 +1,6 @@
+object Test extends App {
+  import NewQuasiquotes._
+  SomeTree match {
+    case nq"$x + $y" => println((x, y))
+  }
+}


### PR DESCRIPTION
Second time's the charm. I remember trying to do exactly the same somewhen
around 2.10.0-M4, but then some continuations tests were failing.
Luckily, today everything went smoothly.

Please note that this fix changes the way that SI-5465 manifests itself.
Previously it produced type errors, now it simply crashes the compiler.
Therefore I had to attach the try/catch FatalError clause to invocations
of toolbox methods, so that compiler crashes get caught and translated to
ToolBoxErrors.

Also fixes SI-7871, and that clears the way for implementing quasiquotes
with conventional macros rather than relying on a special case in typer.
