### PR TITLE
SI-7877 Only look for unapplies in term trees

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3245,7 +3245,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           if (!tree.isErrorTyped) setError(tree) else tree
           // @H change to setError(treeCopy.Apply(tree, fun, args))
 
-        case ExtractorType(unapply) if mode.inPatternMode =>
+        // SI-7877 `isTerm` needed to exclude `class T[A] { def unapply(..) }; ... case T[X] =>`
+        case HasUnapply(unapply) if mode.inPatternMode && fun.isTerm =>
           if (unapply == QuasiquoteClass_api_unapply) macroExpandUnapply(this, tree, fun, unapply, args, mode, pt)
           else doTypedUnapply(tree, fun0, fun, args, mode, pt)
 

--- a/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
@@ -39,7 +39,7 @@ trait Unapplies extends ast.TreeDSL {
    */
   def unapplyMember(tp: Type): Symbol = directUnapplyMember(tp) filter (sym => !hasMultipleNonImplicitParamLists(sym))
 
-  object ExtractorType {
+  object HasUnapply {
     def unapply(tp: Type): Option[Symbol] = unapplyMember(tp).toOption
   }
 

--- a/test/files/neg/t7877.check
+++ b/test/files/neg/t7877.check
@@ -1,0 +1,7 @@
+t7877.scala:6: error: not found: value Y
+    case Y() => ()             // not allowed
+         ^
+t7877.scala:7: error: OnNext[Any] does not take parameters
+    case OnNext[Any]() => ()   // should *not* be allowed, but was.
+                    ^
+two errors found

--- a/test/files/neg/t7877.scala
+++ b/test/files/neg/t7877.scala
@@ -1,0 +1,13 @@
+class Test {
+  val X: OnNext[Any] = null
+  def Y: OnNext[Any] = null
+  (null: Any) match {
+    case X() => ()             // allowed
+    case Y() => ()             // not allowed
+    case OnNext[Any]() => ()   // should *not* be allowed, but was.
+  }
+}
+
+class OnNext[+T] {
+  def unapply(x: Any) = false
+}


### PR DESCRIPTION
Since Scala 2.10.2, the enclosed test case has crashed
in the backend. Before, we correctly rejected this pattern match.

My bisection landed at a merge commit f16f4ab157, although both
parents were good. So I don't quite trust that.

I do think the regression stems from the changes to allow:

```
case rx"AB(.+)" =>
```

Examples of this are in run/t7715.scala.

This commit limits the search for extractors to cases where the
function within the Apply is a term tree.

Review by @xeno-by
