### PR TITLE
SI-3971 error message carat mispoints at curried methods.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4177,6 +4177,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             case If(_, t, e)                        => treesInResult(t) ++ treesInResult(e)
             case Try(b, catches, _)                 => treesInResult(b) ++ catches
             case Typed(r, Function(Nil, EmptyTree)) => treesInResult(r)
+            case Select(qual, name)                 => treesInResult(qual)
+            case Apply(fun, args)                   => treesInResult(fun) ++ args.flatMap(treesInResult)
+            case TypeApply(fun, args)               => treesInResult(fun) ++ args.flatMap(treesInResult)
             case _                                  => Nil
           })
           def errorInResult(tree: Tree) = treesInResult(tree) exists (_.pos == typeError.errPos)

--- a/test/files/neg/t3971.check
+++ b/test/files/neg/t3971.check
@@ -1,0 +1,21 @@
+t3971.scala:6: error: type mismatch;
+ found   : Int
+ required: String
+  f(g("abc")("def")) // g returns Int, needs String
+     ^
+t3971.scala:7: error: type mismatch;
+ found   : Int(5)
+ required: String
+  f(5)
+    ^
+t3971.scala:8: error: type mismatch;
+ found   : Int
+ required: String
+  f(h("abc"))
+     ^
+t3971.scala:11: error: type mismatch;
+ found   : Boolean
+ required: String
+  ({"ab".reverse; "ba".equals})(0): String
+                               ^
+four errors found

--- a/test/files/neg/t3971.scala
+++ b/test/files/neg/t3971.scala
@@ -1,0 +1,12 @@
+class A {
+  def f(x: String) = x
+  def g(x: String)(y: String): Int = x.length + y.length
+  def h(x: String) = x.length
+
+  f(g("abc")("def")) // g returns Int, needs String
+  f(5)
+  f(h("abc"))
+
+  // a perverse piece of code from a perverse coder
+  ({"ab".reverse; "ba".equals})(0): String
+}


### PR DESCRIPTION
I found it to be a general palliative to unwrap applies when reporting errors.
Point at the thing being applied, not at the opening paren of a possibly
distant argument list. This might be slightly less accurate in a few cases,
but it is vastly less inaccurate in most cases, so I think it is an easy
victory for the forces of clarity.

Thanks to retronym for figuring out why issuing a better error message broke
the compiler on non-erroneous compile runs. The changes to "treesInResult" are
the consequence.
