### PR TITLE
Rework cff8b569 to heal the windows build.

### DIFF
--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -87,11 +87,13 @@ trait Names extends api.Names {
    *  TODO - have a mode where name validation is performed at creation time
    *  (e.g. if a name has the string "$class" in it, then fail if that
    *  string is not at the very end.)
+   *
+   *  @param len0 the length of the name. Negative lengths result in empty names.
    */
-  final def newTermName(cs: Array[Char], offset: Int, len: Int, cachedString: String): TermName = {
+  final def newTermName(cs: Array[Char], offset: Int, len0: Int, cachedString: String): TermName = {
     def body = {
       require(offset >= 0, "offset must be non-negative, got " + offset)
-      require(len >= 0, "length must be non-negative, got " + len)
+      val len = math.max(len0, 0)
       val h = hashValue(cs, offset, len) & HASH_MASK
       var n = termHashtable(h)
       while ((n ne null) && (n.length != len || !equals(n.start, cs, offset, len)))

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -409,11 +409,8 @@ trait StdNames {
      */
     def unspecializedName(name: Name): Name = (
       // DUPLICATED LOGIC WITH `splitSpecializedName`
-      if (name endsWith SPECIALIZED_SUFFIX) {
-        val idxM = name.lastIndexOf('m')
-        val to = (if (idxM > 0) idxM - 1 else name.length - SPECIALIZED_SUFFIX.length)
-        name.subName(0, to)
-      }
+      if (name endsWith SPECIALIZED_SUFFIX)
+        name.subName(0, name.lastIndexOf('m') - 1)
       else name
     )
 
@@ -428,19 +425,18 @@ trait StdNames {
     *
     *  @return (unspecializedName, class tparam specializations, method tparam specializations)
     */
-    def splitSpecializedName(name: Name): (Name, String, String) = {
+    def splitSpecializedName(name: Name): (Name, String, String) =
       // DUPLICATED LOGIC WITH `unspecializedName`
-      if (name endsWith SPECIALIZED_SUFFIX) {
-        val name1 = name dropRight SPECIALIZED_SUFFIX.length
-        val idxC  = name1 lastIndexOf 'c'
-        val idxM  = name1 lastIndexOf 'm'
-        if (idxC > idxM && idxM > 0)
-          (name1.subName(0, idxM - 1), name1.subName(idxC + 1, name1.length).toString, name1.subName(idxM + 1, idxC).toString)
-        else
-          (name.subName(0, name.length - SPECIALIZED_SUFFIX.length), "", "")
-      }
-      else (name, "", "")
-    }
+    if (name endsWith SPECIALIZED_SUFFIX) {
+      val name1 = name dropRight SPECIALIZED_SUFFIX.length
+      val idxC  = name1 lastIndexOf 'c'
+      val idxM  = name1 lastIndexOf 'm'
+
+      (name1.subName(0, idxM - 1),
+      name1.subName(idxC + 1, name1.length).toString,
+      name1.subName(idxM + 1, idxC).toString)
+    } else
+    (name, "", "")
 
     // Nominally, name$default$N, encoded for <init>
     def defaultGetterName(name: Name, pos: Int): TermName = (

--- a/test/files/run/global-showdef.scala
+++ b/test/files/run/global-showdef.scala
@@ -54,7 +54,7 @@ object Bippy {
       val run = new compiler.Run()
       run.compileSources(List(src))
     }
-    (output split "\\n").toList
+    output.linesIterator.toList
   }
   def showClass(name: String) = lines("-Yshow:typer", "-Xshow-class", name)
   def showObject(name: String) = lines("-Yshow:typer", "-Xshow-object", name)

--- a/test/junit/scala/tools/nsc/symtab/StdNamesTest.scala
+++ b/test/junit/scala/tools/nsc/symtab/StdNamesTest.scala
@@ -28,8 +28,8 @@ class StdNamesTest {
     test(TermName("Tuple2"), TermName("Tuple2$mcII" + SPECIALIZED_SUFFIX))
     test(TermName("foo"), TermName("foo$mIcD" + SPECIALIZED_SUFFIX))
     test(TermName("foo"), TermName("foo$mIc" + SPECIALIZED_SUFFIX))
-    test(TermName("T1"), TermName(s"T1$SPECIALIZED_SUFFIX"))
-    test(TermName(""), SPECIALIZED_SUFFIX)
+    test(nme.EMPTY, TermName(s"T1$SPECIALIZED_SUFFIX"))
+    test(nme.EMPTY, SPECIALIZED_SUFFIX)
   }
 
   @Test
@@ -40,7 +40,7 @@ class StdNamesTest {
     test((TermName("Tuple2"), "II", ""), TermName("Tuple2$mcII" + SPECIALIZED_SUFFIX))
     test((TermName("foo"), "D", "I"), TermName("foo$mIcD" + SPECIALIZED_SUFFIX))
     test((TermName("foo"), "", "I"), TermName("foo$mIc" + SPECIALIZED_SUFFIX))
-    test((TermName("T1"), "", ""), TermName(s"T1$SPECIALIZED_SUFFIX"))
-    test((TermName(""), "", ""), SPECIALIZED_SUFFIX)
+    test((nme.EMPTY, "T1", ""), TermName(s"T1$SPECIALIZED_SUFFIX"))
+    test((nme.EMPTY, "", ""), SPECIALIZED_SUFFIX)
   }
 }


### PR DESCRIPTION
- change newTermName to fix negative length names
  rather than reject them
- restore the old logic in unspecializedName for names that
  result from AnyRef specialized type parameters.

Why does fix the windows build? I remain none the wiser.
