### PR TITLE
Make tree traversal uniform.

### DIFF
--- a/src/reflect/scala/reflect/api/Trees.scala
+++ b/src/reflect/scala/reflect/api/Trees.scala
@@ -2547,6 +2547,12 @@ trait Trees { self: Universe =>
     /** Traverses a single tree. */
     def traverse(tree: Tree): Unit = itraverse(this, tree)
 
+    def traverseName(name: Name): Unit = ()
+
+    def traverseModifiers(mods: Modifiers) {
+      traverseTrees(mods.annotations)
+    }
+
     /** Traverses a list of trees. */
     def traverseTrees(trees: List[Tree]) {
       trees foreach traverse


### PR DESCRIPTION
There's a huge amount of tree traversal related duplication
which is hard to eliminate only because trees aren't properly
traversed. Key not-quite-tree bits of key trees are ignored
during traversals, making it impossible to write e.g. a
pretty printer without duplicating almost the entire traversal
logic (as indeed is done for printing purposes in more than one
place.) And almost the entire pickler logic is redundant with
Traverser, except since it's all duplicated of course it diverged.

The not-quite-trees not quite being traversed were Modifiers and Name.
This commit contains two key contributions, one to traversal and one
to pickling:
- traverse every case field of every tree
- do all pickling in an order consistent with tree traversal

There had been ad hoc adjustments to the pickling scheme here and
there, probably in pursuit of tiny performance improvements.
For instance, a Block was pickled expr/stats instead of stats/expr,
a TypeDef was pickled rhs/tparams instead of tparams/rhs.
The benefits derived are invisible compared to the cost of having
several hundred lines of tree traversal code duplicated in half a
dozen or more places.

It's now possible to eliminate all the pickler tree traversal
code and use regular traversers (but unfortunately that step does
not accompany this commit.) For illustration, here's what DefDef
looks like in Pickler now:

```
  case DefDef(mods, name, tparams, vparamss, tpt, rhs) =>
    putMods(mods)
    putEntry(name)
    putTrees(tparams)
    putTreess(vparamss)
    putTree(tpt)
    putTree(rhs)
```

Here's what it looks like in Trees#itraverse:

```
  case DefDef(mods, name, tparams, vparamss, tpt, rhs) =>
    atOwner(tree.symbol) {
      traverseModifiers(mods)
      traverseName(name)
      traverseTrees(tparams)
      traverseTreess(vparamss)
      traverse(tpt)
      traverse(rhs)
    }
```

I leave the details of how one might use the tree traverser
to eliminate this redundancy as an exercise for Dear Reviewer.
It is ALSO now possible to write a vastly cleaner tree printer
than the ones presently in trunk, but this too is an exercise
for Dear Reviewer.
