### PR TITLE
SI-7895 Error reporting: avoid cascading, truncation

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -329,6 +329,7 @@ trait Contexts { self: Analyzer =>
 
     /** The first error, if any, in the report buffer */
     def firstError: Option[AbsTypeError] = reportBuffer.firstError
+    def errors: Seq[AbsTypeError] = reportBuffer.errors
     /** Does the report buffer contain any errors? */
     def hasErrors = reportBuffer.hasErrors
 

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2392,9 +2392,16 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       if (pat1.tpe.paramSectionCount > 0)
         pat1 modifyType (_.finalResultType)
 
-      for (bind @ Bind(name, _) <- cdef.pat)
-        if (name.toTermName != nme.WILDCARD && bind.symbol != null && bind.symbol != NoSymbol)
-          namer.enterIfNotThere(bind.symbol)
+      for (bind @ Bind(name, _) <- cdef.pat) {
+        val sym = bind.symbol
+        if (name.toTermName != nme.WILDCARD && sym != null) {
+          if (sym == NoSymbol) {
+            if (context.scope.lookup(name) == NoSymbol)
+              namer.enterInScope(context.owner.newErrorSymbol(name))
+          } else
+            namer.enterIfNotThere(sym)
+        }
+      }
 
       val guard1: Tree = if (cdef.guard == EmptyTree) EmptyTree
                          else typed(cdef.guard, BooleanTpe)

--- a/test/files/neg/any-vs-anyref.check
+++ b/test/files/neg/any-vs-anyref.check
@@ -36,12 +36,28 @@ Such types can participate in value classes, but instances
 cannot appear in singleton types or in reference comparisons.
   def foo5(x: Quux with Product)                                    = (x eq "abc") && ("abc" eq x)
                                                                          ^
+any-vs-anyref.scala:10: error: type mismatch;
+ found   : Quux with Product
+ required: AnyRef
+Note that the parents of this type (Quux, Product) extend Any, not AnyRef.
+Such types can participate in value classes, but instances
+cannot appear in singleton types or in reference comparisons.
+  def foo5(x: Quux with Product)                                    = (x eq "abc") && ("abc" eq x)
+                                                                                                ^
 any-vs-anyref.scala:11: error: value eq is not a member of Quux with Product{def f: Int}
 Note that the parents of this type (Quux, Product) extend Any, not AnyRef.
 Such types can participate in value classes, but instances
 cannot appear in singleton types or in reference comparisons.
   def foo6(x: Quux with Product { def f: Int })                     = (x eq "abc") && ("abc" eq x)
                                                                          ^
+any-vs-anyref.scala:11: error: type mismatch;
+ found   : Quux with Product{def f: Int}
+ required: AnyRef
+Note that the parents of this type (Quux, Product) extend Any, not AnyRef.
+Such types can participate in value classes, but instances
+cannot appear in singleton types or in reference comparisons.
+  def foo6(x: Quux with Product { def f: Int })                     = (x eq "abc") && ("abc" eq x)
+                                                                                                ^
 any-vs-anyref.scala:12: error: type mismatch;
  found   : Quux with Product{def eq(other: String): Boolean}
  required: AnyRef
@@ -61,4 +77,4 @@ any-vs-anyref.scala:27: error: type mismatch;
  required: Quux{def g(x: Int): Int}
   f(new Quux { def g(x: String) = x })
     ^
-9 errors found
+11 errors found

--- a/test/files/neg/applydynamic_sip.check
+++ b/test/files/neg/applydynamic_sip.check
@@ -4,9 +4,18 @@ applydynamic_sip.scala:7: error: applyDynamic does not support passing a vararg 
 applydynamic_sip.scala:8: error: applyDynamicNamed does not support passing a vararg parameter
   qual.sel(arg = a, a2: _*)
        ^
+applydynamic_sip.scala:8: error: not found: value arg
+  qual.sel(arg = a, a2: _*)
+           ^
 applydynamic_sip.scala:9: error: applyDynamicNamed does not support passing a vararg parameter
   qual.sel(arg, arg2 = "a2", a2: _*)
        ^
+applydynamic_sip.scala:9: error: not found: value arg
+  qual.sel(arg, arg2 = "a2", a2: _*)
+           ^
+applydynamic_sip.scala:9: error: not found: value arg2
+  qual.sel(arg, arg2 = "a2", a2: _*)
+                ^
 applydynamic_sip.scala:18: error: type mismatch;
  found   : String("sel")
  required: Int
@@ -28,6 +37,9 @@ error after rewriting to Test.this.bad1.applyDynamicNamed("sel")
 possible cause: maybe a wrong Dynamic method signature?
   bad1.sel(a = 1)
   ^
+applydynamic_sip.scala:20: error: reassignment to val
+  bad1.sel(a = 1)
+             ^
 applydynamic_sip.scala:21: error: type mismatch;
  found   : String("sel")
  required: Int
@@ -50,9 +62,12 @@ error after rewriting to Test.this.bad2.applyDynamicNamed("sel")
 possible cause: maybe a wrong Dynamic method signature?
   bad2.sel(a = 1)
   ^
+applydynamic_sip.scala:31: error: reassignment to val
+  bad2.sel(a = 1)
+             ^
 applydynamic_sip.scala:32: error: Int does not take parameters
 error after rewriting to Test.this.bad2.updateDynamic("sel")
 possible cause: maybe a wrong Dynamic method signature?
   bad2.sel = 1
   ^
-11 errors found
+16 errors found

--- a/test/files/neg/macro-basic-mamdmi.check
+++ b/test/files/neg/macro-basic-mamdmi.check
@@ -1,5 +1,5 @@
-Impls_Macros_Test_1.scala:36: error: macro implementation not found: foo
+Impls_Macros_Test_1.scala:36: error: macro implementation not found: quux
 (the most common reason for that is that you cannot use macro implementations in the same compilation run that defines them)
   println(foo(2) + Macros.bar(2) * new Macros().quux(4))
-             ^
+                                                    ^
 one error found

--- a/test/files/neg/names-defaults-neg.check
+++ b/test/files/neg/names-defaults-neg.check
@@ -7,6 +7,11 @@ names-defaults-neg.scala:5: error: type mismatch;
  required: Int
   test1(b = 2, a = "#")
                    ^
+names-defaults-neg.scala:5: error: type mismatch;
+ found   : Int(2)
+ required: String
+  test1(b = 2, a = "#")
+            ^
 names-defaults-neg.scala:8: error: positional after named argument.
   test1(b = "(*", 23)
                   ^
@@ -122,6 +127,12 @@ names-defaults-neg.scala:131: error: reference to var2 is ambiguous; it is both 
 names-defaults-neg.scala:134: error: missing parameter type for expanded function ((x$1) => a = x$1)
   val taf2: Int => Unit = testAnnFun(a = _, b = get("+"))
                                          ^
+names-defaults-neg.scala:134: error: not found: value a
+  val taf2: Int => Unit = testAnnFun(a = _, b = get("+"))
+                                     ^
+names-defaults-neg.scala:134: error: not found: value get
+  val taf2: Int => Unit = testAnnFun(a = _, b = get("+"))
+                                                ^
 names-defaults-neg.scala:135: error: parameter 'a' is already specified at parameter position 1
   val taf3 = testAnnFun(b = _: String, a = get(8))
                                          ^
@@ -131,6 +142,9 @@ names-defaults-neg.scala:136: error: missing parameter type for expanded functio
 names-defaults-neg.scala:136: error: missing parameter type for expanded function ((x$4) => b = x$4)
   val taf4: (Int, String) => Unit = testAnnFun(_, b = _)
                                                       ^
+names-defaults-neg.scala:136: error: not found: value b
+  val taf4: (Int, String) => Unit = testAnnFun(_, b = _)
+                                                  ^
 names-defaults-neg.scala:144: error: variable definition needs type because 'x' is used as a named argument in its body.
   def t3 { var x = t.f(x = 1) }
                ^
@@ -168,4 +182,4 @@ names-defaults-neg.scala:180: error: reference to x is ambiguous; it is both a m
   class u18 { var x: Int = u.f(x = 1) }
                                  ^
 four warnings found
-42 errors found
+46 errors found

--- a/test/files/neg/reflection-names-neg.check
+++ b/test/files/neg/reflection-names-neg.check
@@ -7,4 +7,7 @@ Note that implicit conversions are not applicable because they are ambiguous:
  are possible conversion functions from String("abc") to reflect.runtime.universe.Name
   val x2 = ("abc": Name) drop 1         // error
             ^
-one error found
+reflection-names-neg.scala:5: error: value drop is not a member of reflect.runtime.universe.Name
+  val x2 = ("abc": Name) drop 1         // error
+                         ^
+two errors found

--- a/test/files/neg/t0418.check
+++ b/test/files/neg/t0418.check
@@ -1,7 +1,4 @@
 t0418.scala:2: error: not found: value Foo12340771
   null match { case Foo12340771.Bar(x) => x }
                     ^
-t0418.scala:2: error: not found: value x
-  null match { case Foo12340771.Bar(x) => x }
-                                          ^
-two errors found
+one error found

--- a/test/files/neg/t418.check
+++ b/test/files/neg/t418.check
@@ -1,7 +1,4 @@
 t418.scala:2: error: not found: value Foo12340771
   null match { case Foo12340771.Bar(x) => x }
                     ^
-t418.scala:2: error: not found: value x
-  null match { case Foo12340771.Bar(x) => x }
-                                          ^
-two errors found
+one error found

--- a/test/files/neg/t4515.check
+++ b/test/files/neg/t4515.check
@@ -3,4 +3,14 @@ t4515.scala:37: error: type mismatch;
  required: _$2
         handler.onEvent(target, ctx.getEvent, node, ctx)
                                     ^
-one error found
+t4515.scala:37: error: type mismatch;
+ found   : Main.DerivedPushNode[_$1] where type _$1
+ required: Main.PushNode[_$2]
+        handler.onEvent(target, ctx.getEvent, node, ctx)
+                                              ^
+t4515.scala:37: error: type mismatch;
+ found   : Main.PushEventContext[_$1] where type _$1
+ required: Main.PushEventContext[_$2]
+        handler.onEvent(target, ctx.getEvent, node, ctx)
+                                                    ^
+three errors found

--- a/test/files/neg/t512.check
+++ b/test/files/neg/t512.check
@@ -1,4 +1,7 @@
 t512.scala:3: error: not found: value something
     val xxx = something ||
               ^
-one error found
+t512.scala:4: error: not found: value something_else
+        something_else;
+        ^
+two errors found

--- a/test/files/neg/t545.check
+++ b/test/files/neg/t545.check
@@ -1,7 +1,4 @@
 t545.scala:4: error: value blah is not a member of Test.Foo
   val x = foo.blah match {
               ^
-t545.scala:5: error: recursive value x needs type
-    case List(x) => x
-                    ^
-two errors found
+one error found

--- a/test/files/neg/t556.check
+++ b/test/files/neg/t556.check
@@ -1,4 +1,7 @@
 t556.scala:3: error: missing parameter type
   def g:Int = f((x,y)=>x)
                  ^
-one error found
+t556.scala:3: error: missing parameter type
+  def g:Int = f((x,y)=>x)
+                   ^
+two errors found

--- a/test/files/neg/t5572.check
+++ b/test/files/neg/t5572.check
@@ -3,9 +3,14 @@ t5572.scala:16: error: type mismatch;
  required: A
     Z.transf(a, b) match {
              ^
+t5572.scala:16: error: type mismatch;
+ found   : A
+ required: B
+    Z.transf(a, b) match {
+                ^
 t5572.scala:18: error: type mismatch;
  found   : A
  required: B
         run(sth, b)
                  ^
-two errors found
+three errors found

--- a/test/files/neg/t5761.check
+++ b/test/files/neg/t5761.check
@@ -13,4 +13,7 @@ Unspecified value parameter x.
 t5761.scala:13: error: not found: type Tread
   new Tread("sth") { }.run()
       ^
-four errors found
+t5761.scala:13: error: value run is not a member of AnyRef
+  new Tread("sth") { }.run()
+                       ^
+5 errors found

--- a/test/files/neg/t5903a.check
+++ b/test/files/neg/t5903a.check
@@ -1,7 +1,4 @@
 Test_2.scala:4: error: wrong number of patterns for <$anon: AnyRef> offering (SomeTree.type, SomeTree.type): expected 2, found 3
     case nq"$x + $y + $z" => println((x, y))
          ^
-Test_2.scala:4: error: not found: value x
-    case nq"$x + $y + $z" => println((x, y))
-                                      ^
-two errors found
+one error found

--- a/test/files/neg/t5903b.check
+++ b/test/files/neg/t5903b.check
@@ -3,7 +3,4 @@ Test_2.scala:4: error: type mismatch;
  required: String
     case t"$x" => println(x)
          ^
-Test_2.scala:4: error: not found: value x
-    case t"$x" => println(x)
-                          ^
-two errors found
+one error found

--- a/test/files/neg/t5903c.check
+++ b/test/files/neg/t5903c.check
@@ -1,7 +1,4 @@
 Test_2.scala:4: error: String is not supported
     case t"$x" => println(x)
          ^
-Test_2.scala:4: error: not found: value x
-    case t"$x" => println(x)
-                          ^
-two errors found
+one error found

--- a/test/files/neg/t5903d.check
+++ b/test/files/neg/t5903d.check
@@ -1,7 +1,4 @@
 Test_2.scala:4: error: extractor macros can only expand into extractor calls
     case t"$x" => println(x)
          ^
-Test_2.scala:4: error: not found: value x
-    case t"$x" => println(x)
-                          ^
-two errors found
+one error found

--- a/test/files/neg/t6829.check
+++ b/test/files/neg/t6829.check
@@ -20,11 +20,31 @@ t6829.scala:50: error: type mismatch;
  required: _53.State where val _53: G
         val r = rewards(agent).r(s,a,s2)
                                  ^
+t6829.scala:50: error: type mismatch;
+ found   : a.type (with underlying type T2)
+ required: _53.Action where val _53: G
+        val r = rewards(agent).r(s,a,s2)
+                                   ^
+t6829.scala:50: error: type mismatch;
+ found   : s2.type (with underlying type T3)
+ required: _53.State where val _53: G
+        val r = rewards(agent).r(s,a,s2)
+                                     ^
 t6829.scala:51: error: type mismatch;
  found   : s.type (with underlying type T1)
  required: _50.State
         agent.learn(s,a,s2,r): G#Agent
                     ^
+t6829.scala:51: error: type mismatch;
+ found   : a.type (with underlying type T2)
+ required: _50.Action
+        agent.learn(s,a,s2,r): G#Agent
+                      ^
+t6829.scala:51: error: type mismatch;
+ found   : s2.type (with underlying type T3)
+ required: _50.State
+        agent.learn(s,a,s2,r): G#Agent
+                        ^
 t6829.scala:53: error: not found: value nextState
 Error occurred in an application involving default arguments.
       copy(agents = updatedAgents, state = nextState, pastHistory = currentHistory)
@@ -33,4 +53,4 @@ t6829.scala:53: error: not found: value currentHistory
 Error occurred in an application involving default arguments.
       copy(agents = updatedAgents, state = nextState, pastHistory = currentHistory)
                                                                     ^
-9 errors found
+13 errors found

--- a/test/files/neg/t7895.check
+++ b/test/files/neg/t7895.check
@@ -1,0 +1,4 @@
+t7895.scala:4: error: not found: value Goop
+    case Goop(a, b, c) => Tuple2(a, b)
+         ^
+one error found

--- a/test/files/neg/t7895.scala
+++ b/test/files/neg/t7895.scala
@@ -1,0 +1,6 @@
+class A {
+  (null: Any) match {
+    // We don't want "symbol not found errors" for `a` and `b` in the case body.
+    case Goop(a, b, c) => Tuple2(a, b)
+  }
+}

--- a/test/files/neg/t7895b.check
+++ b/test/files/neg/t7895b.check
@@ -1,0 +1,7 @@
+t7895b.scala:4: error: not found: value a
+  foo(a, b)
+      ^
+t7895b.scala:4: error: not found: value b
+  foo(a, b)
+         ^
+two errors found

--- a/test/files/neg/t7895b.scala
+++ b/test/files/neg/t7895b.scala
@@ -1,0 +1,5 @@
+object Test {
+  def foo(a: Any*) = ()
+
+  foo(a, b)
+}

--- a/test/files/neg/t7895c.check
+++ b/test/files/neg/t7895c.check
@@ -1,0 +1,13 @@
+t7895c.scala:2: error: not found: value bong
+  def booboo = bong + booble + bippity - bazingo
+               ^
+t7895c.scala:2: error: not found: value booble
+  def booboo = bong + booble + bippity - bazingo
+                      ^
+t7895c.scala:2: error: not found: value bippity
+  def booboo = bong + booble + bippity - bazingo
+                               ^
+t7895c.scala:2: error: not found: value bazingo
+  def booboo = bong + booble + bippity - bazingo
+                                         ^
+four errors found

--- a/test/files/neg/t7895c.scala
+++ b/test/files/neg/t7895c.scala
@@ -1,0 +1,3 @@
+class A {
+  def booboo = bong + booble + bippity - bazingo
+}

--- a/test/files/neg/t997.check
+++ b/test/files/neg/t997.check
@@ -4,7 +4,4 @@ t997.scala:13: error: wrong number of patterns for object Foo offering (String, 
 t997.scala:13: error: wrong number of patterns for object Foo offering (String, String): expected 2, found 3
 "x" match { case Foo(a, b, c) => Console.println((a,b,c)) }
                     ^
-t997.scala:13: error: not found: value a
-"x" match { case Foo(a, b, c) => Console.println((a,b,c)) }
-                                                  ^
-three errors found
+two errors found

--- a/test/files/neg/typeerror.check
+++ b/test/files/neg/typeerror.check
@@ -3,4 +3,9 @@ typeerror.scala:6: error: type mismatch;
  required: scala.Long
     else add2(x.head, y.head) :: add(x.tail, y.tail)
                 ^
-one error found
+typeerror.scala:6: error: type mismatch;
+ found   : Long(in method add)
+ required: scala.Long
+    else add2(x.head, y.head) :: add(x.tail, y.tail)
+                        ^
+two errors found

--- a/test/files/run/constrained-types.check
+++ b/test/files/run/constrained-types.check
@@ -138,6 +138,15 @@ scala> val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
 <console>:8: error: not found: value e
        val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
                               ^
+<console>:8: error: not found: value f
+       val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
+                                ^
+<console>:8: error: not found: value g
+       val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
+                                  ^
+<console>:8: error: not found: value h
+       val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
+                                    ^
 
 scala> 
 

--- a/test/files/run/repl-reset.check
+++ b/test/files/run/repl-reset.check
@@ -33,6 +33,12 @@ scala> x1 + x2 + x3
 <console>:8: error: not found: value x1
               x1 + x2 + x3
               ^
+<console>:8: error: not found: value x2
+              x1 + x2 + x3
+                   ^
+<console>:8: error: not found: value x3
+              x1 + x2 + x3
+                        ^
 
 scala> val x1 = 4
 x1: Int = 4


### PR DESCRIPTION
- Enter error symbols for pattern binders in erroneous constructor patterns.
- issue all errors, rather than just the first, when coming out of the Cone of Silence (aka `Typer#silent`)
- typecheck args with `pt = ErrorType` even if the function is erroneous
- avoid cascading errors in `(x => 0): ErrorType`.

In total:

```
% scalac-hash v2.11.0-M5 sandbox/test.scala
[info] v2.11.0-M5 => /Users/jason/usr/scala-v2.11.0-M5-0-gd6fe890
sandbox/test.scala:2: error: not found: value bong
  def booboo = bong + booble + bippity
               ^
sandbox/test.scala:3: error: not found: value Tuple
  Tuple(wizzle, (x, y) => (x, wozzle))
  ^
sandbox/test.scala:5: error: not found: value Shmist
    case Shmist(a, b) => a :: b :: Nil
         ^
sandbox/test.scala:5: error: not found: value a
    case Shmist(a, b) => a :: b :: Nil
                         ^
sandbox/test.scala:5: error: not found: value b
    case Shmist(a, b) => a :: b :: Nil
                              ^
sandbox/test.scala:6: error: not found: value Goop
    case Goop(a)   => s"$a $b"
         ^
sandbox/test.scala:6: error: not found: value a
    case Goop(a)   => s"$a $b"
                         ^
7 errors found

% qbin/scalac sandbox/test.scala
sandbox/test.scala:2: error: not found: value bong
  def booboo = bong + booble + bippity
               ^
sandbox/test.scala:2: error: not found: value booble
  def booboo = bong + booble + bippity
                      ^
sandbox/test.scala:2: error: not found: value bippity
  def booboo = bong + booble + bippity
                               ^
sandbox/test.scala:3: error: not found: value Tuple
  Tuple(wizzle, (x, y) => (x, wozzle))
  ^
sandbox/test.scala:3: error: not found: value wizzle
  Tuple(wizzle, (x, y) => (x, wozzle))
        ^
sandbox/test.scala:3: error: not found: value wozzle
  Tuple(wizzle, (x, y) => (x, wozzle))
                              ^
sandbox/test.scala:5: error: not found: value Shmist
    case Shmist(a, b) => a :: b :: Nil
         ^
sandbox/test.scala:6: error: not found: value Goop
    case Goop(a)   => s"$a $b"
         ^
sandbox/test.scala:6: error: not found: value b
    case Goop(a)   => s"$a $b"
                            ^
9 errors found
```

Review by @paulp
