### PR TITLE
IterableLike grouped : fix documentation

### DIFF
--- a/src/library/scala/collection/IterableLike.scala
+++ b/src/library/scala/collection/IterableLike.scala
@@ -152,7 +152,7 @@ self =>
    *
    *  @param size the number of elements per group
    *  @return An iterator producing ${coll}s of size `size`, except the
-   *          last will be truncated if the elements don't divide evenly.
+   *          last will be kept if the elements don't divide evenly.
    */
   def grouped(size: Int): Iterator[Repr] =
     for (xs <- iterator grouped size) yield {

--- a/src/library/scala/collection/IterableLike.scala
+++ b/src/library/scala/collection/IterableLike.scala
@@ -152,7 +152,7 @@ self =>
    *
    *  @param size the number of elements per group
    *  @return An iterator producing ${coll}s of size `size`, except the
-   *          last will be kept if the elements don't divide evenly.
+   *          last will be less than size `size` if the elements don't divide evenly.
    */
   def grouped(size: Int): Iterator[Repr] =
     for (xs <- iterator grouped size) yield {


### PR DESCRIPTION
``` scala
scala> Seq(1,2,3).grouped(2).toList
res1: List[Seq[Int]] = List(List(1, 2), List(3))
```
