### PR TITLE
SI-7899 Allow by-name inference outside of -Xstrict-inference

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -913,7 +913,11 @@ trait Infer extends Checkable {
       val targs  = exprTypeArgs(tvars, tparams, treeTp, pt, useWeaklyCompatible)
       def infer_s = map3(tparams, tvars, targs)((tparam, tvar, targ) => s"$tparam=$tvar/$targ") mkString ","
       printTyping(tree, s"infer expr instance from pt=$pt, $infer_s")
-      def targsStrict = if (targs eq null) null else targs mapConserve dropByName
+
+      // SI-7899 infering by-name types is unsound. The correct behaviour is conditional because the hole is
+      //         exploited in Scalaz (Free.scala), as seen in: run/t7899-regression.
+      def dropByNameIfStrict(tp: Type): Type = if (settings.strictInference) dropByName(tp) else tp
+      def targsStrict = if (targs eq null) null else targs mapConserve dropByNameIfStrict
 
       if (keepNothings || (targs eq null)) { //@M: adjustTypeArgs fails if targs==null, neg/t0226
         substExpr(tree, tparams, targsStrict, pt)

--- a/test/files/neg/t7899.flags
+++ b/test/files/neg/t7899.flags
@@ -1,0 +1,1 @@
+-Xstrict-inference

--- a/test/files/run/t7899-regression.scala
+++ b/test/files/run/t7899-regression.scala
@@ -1,0 +1,24 @@
+import language.higherKinds
+
+object Test {
+  trait Monad[M[_]] {
+    def foo[A](ma: M[A])(f: M[A] => Any) = f(ma)
+  }
+  implicit def function1Covariant[T]: Monad[({type l[a] = (T => a)})#l] =
+    new Monad[({type l[a] = (T => a)})#l] {}
+
+  def main(args: Array[String]) {
+    // inference of T = (=> Any) here was outlawed by SI-7899 / 8ed7099
+    // but this pattern is used in Scalaz in just a few places and caused
+    // a regression.
+    //
+    // Inference of a by-name type doesn't *always* lead to a ClassCastException,
+    // it only gets there if a method in generic code accepts a parameter of
+    // that type.
+    //
+    // We need to introduce the stricter inference rules gradually, probably
+    // with a warning.
+    val m = implicitly[Monad[({type f[+x] = (=> Any) => x})#f]]
+    assert(m.foo[Int]((x => 0))(f => f(???)) == 0)
+  }
+}

--- a/test/files/run/t7899.flags
+++ b/test/files/run/t7899.flags
@@ -1,0 +1,1 @@
+-Xstrict-inference


### PR DESCRIPTION
As usual, the hole has been exploited in the wild. While you can't abstract
over by-name-ness without running into the ClassCastException or an un-applied
Function0, there are cases like the enclosed test where you can tiptoe around
those cases.

I'll try to change Scalaz to avoid using this (it's only used in one file) but
until then this commit conditionally moves the sound inference behind the
recently added -Xstrict-inference.
