### PR TITLE
Filter JVM debug output for custom options in partest

### DIFF
--- a/test/files/filters
+++ b/test/files/filters
@@ -1,3 +1,6 @@
 #
 #Java HotSpot(TM) 64-Bit Server VM warning: Failed to reserve shared memory (errno = 28).
 Java HotSpot\(TM\) .* warning:
+# Hotspot receiving VM options through the $_JAVA_OPTIONS
+# env variable outputs them on stderr
+Picked up _JAVA_OPTIONS:


### PR DESCRIPTION
The Picked up `_JAVA_OPTIONS` line occurs on Sun's JDK as a debug output when
you use that variable to set up custom VM options

review by @phaller, @som-snytt
