### PR TITLE
SI-7340 no longer allows to convert vampires to zombies

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2387,6 +2387,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       else if (isVariable) "var"
       else if (isPackage) "package"
       else if (isModule) "object"
+      else if (isMacro) "macro"
       else if (isSourceMethod) "def"
       else if (isTerm && (!isParameter || isParamAccessor)) "val"
       else ""

--- a/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
@@ -475,7 +475,7 @@ trait TypeComparers {
         thirdTryRef(tp1, tr2)
       case rt2: RefinedType =>
         (rt2.parents forall (isSubType(tp1, _, depth))) &&
-          (rt2.decls forall (specializesSym(tp1, _, depth)))
+        (rt2.decls forall (sym => canSpecializeRefinement(tp1, sym) && specializesSym(tp1, sym, depth)))
       case et2: ExistentialType =>
         et2.withTypeVars(isSubType(tp1, _, depth), depth) || fourthTry
       case mt2: MethodType =>

--- a/test/files/neg/macro-vampire-not-zombie.check
+++ b/test/files/neg/macro-vampire-not-zombie.check
@@ -1,0 +1,6 @@
+Test_2.scala:3: error: type mismatch;
+ found   : AnyRef{macro x: Any; macro y: Any}
+ required: AnyRef{def x: Any; def y: Any}
+  val bar: { def x: Any; def y: Any } = foo
+                                        ^
+one error found

--- a/test/files/neg/macro-vampire-not-zombie/Macros_1.scala
+++ b/test/files/neg/macro-vampire-not-zombie/Macros_1.scala
@@ -1,0 +1,52 @@
+// As per http://meta.plasm.us/posts/2013/08/31/feeding-our-vampires/
+
+import scala.annotation.StaticAnnotation
+import scala.reflect.macros.Context
+import scala.language.experimental.macros
+
+class body(tree: Any) extends StaticAnnotation
+
+object Macros {
+  def selFieldImpl(c: Context) = {
+    import c.universe._
+    val field = c.macroApplication.symbol
+    val bodyAnn = field.annotations.filter(_.tpe <:< typeOf[body]).head
+    c.Expr[Any](bodyAnn.scalaArgs.head)
+  }
+
+  def mkObjectImpl(c: Context)(xs: c.Expr[Any]*) = {
+    import c.universe._
+    import Flag._
+    // val kvps = xs.toList map { case q"${_}(${Literal(Constant(name: String))}).->[${_}]($value)" => name -> value }
+    val kvps = xs.map(_.tree).toList map { case Apply(TypeApply(Select(Apply(_, List(Literal(Constant(name: String)))), _), _), List(value)) => name -> value }
+    // val fields = kvps map { case (k, v) => q"@body($v) def ${TermName(k)} = macro Macros.selFieldImpl" }
+    val fields = kvps map { case (k, v) => DefDef(
+      Modifiers(MACRO, tpnme.EMPTY, List(Apply(Select(New(Ident(newTypeName("body"))), nme.CONSTRUCTOR), List(v)))),
+      newTermName(k), Nil, Nil, TypeTree(), Select(Ident(newTermName("Macros")), newTermName("selFieldImpl"))) }
+    // q"import scala.language.experimental.macros; class Workaround { ..$fields }; new Workaround{}"
+    c.Expr[Any](Block(
+      List(
+        Import(Select(Select(Ident(newTermName("scala")), newTermName("language")), newTermName("experimental")), List(ImportSelector(newTermName("macros"), 51, newTermName("macros"), 51))),
+        ClassDef(
+          NoMods, newTypeName("Workaround"), Nil,
+          Template(
+            List(Select(Ident(newTermName("scala")), newTypeName("AnyRef"))), emptyValDef,
+            DefDef(
+              NoMods, nme.CONSTRUCTOR, Nil, List(Nil), TypeTree(),
+              Block(List(Apply(Select(Super(This(tpnme.EMPTY), tpnme.EMPTY), nme.CONSTRUCTOR), List())), Literal(Constant(()))))
+            +: fields)),
+        ClassDef(
+          Modifiers(FINAL), newTypeName("$anon"), Nil,
+          Template(
+            List(Ident(newTypeName("Workaround"))), emptyValDef,
+            List(
+              DefDef(
+                NoMods, nme.CONSTRUCTOR, Nil, List(Nil), TypeTree(),
+                Block(List(Apply(Select(Super(This(tpnme.EMPTY), tpnme.EMPTY), nme.CONSTRUCTOR), List())), Literal(Constant(())))))))),
+      Apply(Select(New(Ident(newTypeName("$anon"))), nme.CONSTRUCTOR), List())))
+  }
+}
+
+object mkObject {
+  def apply(xs: Any*) = macro Macros.mkObjectImpl
+}

--- a/test/files/neg/macro-vampire-not-zombie/Test_2.scala
+++ b/test/files/neg/macro-vampire-not-zombie/Test_2.scala
@@ -1,0 +1,6 @@
+object Test extends App {
+  val foo = mkObject("x" -> "2", "y" -> 3)
+  val bar: { def x: Any; def y: Any } = foo
+  println(bar.x)
+  println(bar.y)
+}

--- a/test/files/neg/t7340a.check
+++ b/test/files/neg/t7340a.check
@@ -1,0 +1,7 @@
+Test_2.scala:5: error: type mismatch;
+ found   : B
+ required: C.Greeter
+    (which expands to)  AnyRef{def hello(): Unit}
+  val g: Greeter = new B
+                   ^
+one error found

--- a/test/files/neg/t7340a/Macros_1.scala
+++ b/test/files/neg/t7340a/Macros_1.scala
@@ -1,0 +1,15 @@
+import scala.language.experimental.macros
+import scala.reflect.macros.Context
+
+object A {
+  def hello_impl(c: Context): c.Expr[Unit] = {
+    import c.universe._
+    reify {
+      println("hello world")
+    }
+  }
+}
+
+class B{
+  def hello = macro A.hello_impl
+}

--- a/test/files/neg/t7340a/Test_2.scala
+++ b/test/files/neg/t7340a/Test_2.scala
@@ -1,0 +1,7 @@
+object C extends App {
+  type Greeter = {
+    def hello(): Unit
+  }
+  val g: Greeter = new B
+  g.hello()
+}

--- a/test/files/neg/t7340b.check
+++ b/test/files/neg/t7340b.check
@@ -1,0 +1,13 @@
+Test_2.scala:5: error: type mismatch;
+ found   : B
+ required: C.Greeter[_]
+    (which expands to)  AnyRef{def hello: _$1} forSome { type _$1 }
+  val g1: Greeter[_] = new B
+                       ^
+Test_2.scala:6: error: type mismatch;
+ found   : B
+ required: C.Greeter[Unit]
+    (which expands to)  AnyRef{def hello: Unit}
+  val g2: Greeter[Unit] = new B
+                          ^
+two errors found

--- a/test/files/neg/t7340b/Macros_1.scala
+++ b/test/files/neg/t7340b/Macros_1.scala
@@ -1,0 +1,15 @@
+import scala.language.experimental.macros
+import scala.reflect.macros.Context
+
+object A {
+  def hello_impl(c: Context): c.Expr[Unit] = {
+    import c.universe._
+    reify {
+      println("hello world")
+    }
+  }
+}
+
+class B{
+  def hello: Unit = macro A.hello_impl
+}

--- a/test/files/neg/t7340b/Test_2.scala
+++ b/test/files/neg/t7340b/Test_2.scala
@@ -1,0 +1,7 @@
+object C extends App {
+  type Greeter[T] = {
+    def hello: T
+  }
+  val g1: Greeter[_] = new B
+  val g2: Greeter[Unit] = new B
+}

--- a/test/files/run/t7340c.check
+++ b/test/files/run/t7340c.check
@@ -1,0 +1,29 @@
+===== lubs =====
+java.lang.Object
+java.lang.Object
+AnyRef{def foo: Unit}
+AnyRef{def foo: Unit}
+java.lang.Object
+java.lang.Object
+C1
+C1
+C2
+C2
+===== glbs =====
+X
+X
+Y
+Y
+X with Y
+Y with X
+D1
+D1
+D2
+D2
+===== classBound =====
+AnyRef{def foo: Unit}
+C1
+AnyRef{macro foo: Unit}
+C2
+AnyRef{macro foo: Unit}
+AnyRef{def foo: Unit}

--- a/test/files/run/t7340c/Macros_1.scala
+++ b/test/files/run/t7340c/Macros_1.scala
@@ -1,0 +1,6 @@
+import scala.language.experimental.macros
+import scala.reflect.macros.Context
+
+object Macros {
+  def impl(c: Context) = c.literalUnit
+}

--- a/test/files/run/t7340c/Test_2.scala
+++ b/test/files/run/t7340c/Test_2.scala
@@ -1,0 +1,42 @@
+import scala.reflect.runtime.universe._
+import scala.language.experimental.macros
+
+class C1 { def foo: Unit = () }
+class D1 extends C1 { override def foo: Unit = macro Macros.impl }
+
+class C2 { def foo: Unit = macro Macros.impl }
+class D2 extends C2 { override def foo: Unit = macro Macros.impl }
+
+class X { def foo: Unit = macro Macros.impl }
+class Y { def foo: Unit = () }
+
+object Test extends App {
+  def test1(header: String, fn: List[Type] => Any): Unit = {
+    println(s"===== $header =====")
+    println(fn(List(typeOf[AnyRef { def foo: Unit }], typeOf[X])))
+    println(fn(List(typeOf[X], typeOf[AnyRef { def foo: Unit }])))
+    println(fn(List(typeOf[AnyRef { def foo: Unit }], typeOf[Y])))
+    println(fn(List(typeOf[Y], typeOf[AnyRef { def foo: Unit }])))
+    println(fn(List(typeOf[X], typeOf[Y])))
+    println(fn(List(typeOf[Y], typeOf[X])))
+    println(fn(List(typeOf[C1], typeOf[D1])))
+    println(fn(List(typeOf[D1], typeOf[C1])))
+    println(fn(List(typeOf[C2], typeOf[D2])))
+    println(fn(List(typeOf[D2], typeOf[C2])))
+  }
+
+  def test2(): Unit = {
+    def test(tp: Type) = println(tp.typeSymbol.asInstanceOf[scala.reflect.internal.Symbols#Symbol].classBound)
+    println(s"===== classBound =====")
+    test(typeOf[C1])
+    test(typeOf[D1])
+    test(typeOf[C2])
+    test(typeOf[D2])
+    test(typeOf[X])
+    test(typeOf[Y])
+  }
+
+  test1("lubs", lub _)
+  test1("glbs", glb _)
+  test2()
+}


### PR DESCRIPTION
As eloquently elaborated and cleverly named by Travis Brown, macros
defined in structural types are useful:
http://meta.plasm.us/posts/2013/07/12/vampire-methods-for-structural-types/.

However, since such macros are on the intersection of a number of language
features, as usual, there are bugs.

Before this commit, subtyping checks between structural types didn't
distinguish regular methods structural types (zombies, as per Travis'
classification) and macros (vampires, again as per the same bestiary).

There's one detail though. Since implicit conversions are looked up using
structural types, that look like: "? { def foo: ? }", where question marks
stand for WildcardType, we need to allow such structural types to match
situations when the target member is a macro.

Unlike the original subtyping rule, this one is not a soundness hole,
because: 1) the way the compiler uses such types is guaranteed to be sound,
because they aren't assigned to any term and are discarded right away
after implicit search, 2) users can't actually write such types, so they
can't exploit the situations that lead to unsoundness.
