### PR TITLE
Merge 2.10.x into master

### DIFF
--- a/build.number
+++ b/build.number
@@ -1,7 +1,7 @@
 #Tue Sep 11 19:21:09 CEST 2007
 version.major=2
 version.minor=10
-version.patch=3
+version.patch=4
 # This is the -N part of a version.  if it's 0, it's dropped from maven versions.
 version.bnum=0
 

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1515,7 +1515,11 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
 
     private def checkTypeRef(tp: Type, tree: Tree, skipBounds: Boolean) = tp match {
       case TypeRef(pre, sym, args) =>
-        checkDeprecated(sym, tree.pos)
+        tree match {
+          case tt: TypeTree if tt.original == null => // SI-7783 don't warn about inferred types
+          case _ =>
+            checkDeprecated(sym, tree.pos)
+        }
         if(sym.isJavaDefined)
           sym.typeParams foreach (_.cookJavaRawInfo())
         if (!tp.isHigherKinded && !skipBounds)

--- a/test/files/neg/classmanifests_new_deprecations.check
+++ b/test/files/neg/classmanifests_new_deprecations.check
@@ -7,9 +7,6 @@ classmanifests_new_deprecations.scala:3: error: type ClassManifest in object Pre
 classmanifests_new_deprecations.scala:4: error: type ClassManifest in object Predef is deprecated: Use scala.reflect.ClassTag instead
   val cm3: ClassManifest[Int] = null
            ^
-classmanifests_new_deprecations.scala:4: error: type ClassManifest in object Predef is deprecated: Use scala.reflect.ClassTag instead
-  val cm3: ClassManifest[Int] = null
-      ^
 classmanifests_new_deprecations.scala:6: error: type ClassManifest in package reflect is deprecated: Use scala.reflect.ClassTag instead
   def rcm1[T: scala.reflect.ClassManifest] = ???
             ^
@@ -19,13 +16,10 @@ classmanifests_new_deprecations.scala:7: error: type ClassManifest in package re
 classmanifests_new_deprecations.scala:8: error: type ClassManifest in package reflect is deprecated: Use scala.reflect.ClassTag instead
   val rcm3: scala.reflect.ClassManifest[Int] = null
                           ^
-classmanifests_new_deprecations.scala:8: error: type ClassManifest in package reflect is deprecated: Use scala.reflect.ClassTag instead
-  val rcm3: scala.reflect.ClassManifest[Int] = null
-      ^
 classmanifests_new_deprecations.scala:10: error: type ClassManifest in object Predef is deprecated: Use scala.reflect.ClassTag instead
   type CM[T] = ClassManifest[T]
                ^
 classmanifests_new_deprecations.scala:15: error: type ClassManifest in package reflect is deprecated: Use scala.reflect.ClassTag instead
   type RCM[T] = scala.reflect.ClassManifest[T]
                               ^
-10 errors found
+8 errors found

--- a/test/files/neg/t7783.check
+++ b/test/files/neg/t7783.check
@@ -1,0 +1,16 @@
+t7783.scala:1: error: type D in object O is deprecated: 
+object O { class C; @deprecated("", "") type D = C; def foo: Seq[D] = Nil }
+                                                             ^
+t7783.scala:11: error: type D in object O is deprecated: 
+  type T = O.D
+             ^
+t7783.scala:12: error: type D in object O is deprecated: 
+  locally(null: O.D)
+                  ^
+t7783.scala:13: error: type D in object O is deprecated: 
+  val x: O.D = null
+           ^
+t7783.scala:14: error: type D in object O is deprecated: 
+  locally(null.asInstanceOf[O.D])
+                              ^
+5 errors found

--- a/test/files/neg/t7783.flags
+++ b/test/files/neg/t7783.flags
@@ -1,0 +1,1 @@
+-deprecation -Xfatal-warnings

--- a/test/files/neg/t7783.scala
+++ b/test/files/neg/t7783.scala
@@ -1,0 +1,15 @@
+object O { class C; @deprecated("", "") type D = C; def foo: Seq[D] = Nil }
+
+object NoWarn {
+  O.foo                        // nowarn
+  O.foo +: Nil                 // nowarn
+  def bar(a: Any, b: Any) = () // nowarn
+  bar(b = O.foo, a = ())       // nowarn
+}
+
+object Warn {
+  type T = O.D
+  locally(null: O.D)
+  val x: O.D = null
+  locally(null.asInstanceOf[O.D])
+}

--- a/test/files/run/t4542.check
+++ b/test/files/run/t4542.check
@@ -11,9 +11,6 @@ defined class Foo
 scala> val f = new Foo
 <console>:8: warning: class Foo is deprecated: foooo
        val f = new Foo
-           ^
-<console>:8: warning: class Foo is deprecated: foooo
-       val f = new Foo
                    ^
 f: Foo = Bippy
 


### PR DESCRIPTION
The merge started to fail mainly due to 2.10.3 release which modified `build.number`. Other than that, the merge was trivial.
