### PR TITLE
SI-7634 resurrect the REPL's :sh command

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -579,7 +579,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     def apply(line: String): Result = line match {
       case ""   => showUsage()
       case _    =>
-        val toRun = classOf[ProcessResult].getName + "(" + string2codeQuoted(line) + ")"
+        val toRun = s"new ${classOf[ProcessResult].getName}(${string2codeQuoted(line)})"
         intp interpret toRun
         ()
     }

--- a/test/files/run/t7634.check
+++ b/test/files/run/t7634.check
@@ -1,0 +1,8 @@
+Type in expressions to have them evaluated.
+Type :help for more information.
+
+
+scala> .lines
+res1: List[String] = List(shello, world.)
+
+scala> 

--- a/test/files/run/t7634.scala
+++ b/test/files/run/t7634.scala
@@ -1,0 +1,22 @@
+import java.io.File
+import scala.tools.partest.ReplTest
+import scala.util.Properties.propOrElse
+
+/**
+* filter out absolute path to java
+* filter: java
+*/
+object Test extends ReplTest {
+  def java = propOrElse("javacmd", "java")
+  def code = s""":sh $java -classpath $testOutput hello.Hello
+                |.lines""".stripMargin
+}
+
+package hello {
+  object Hello {
+    def main(a: Array[String]) {
+      System.out.println("shello, world.")
+    }
+  }
+}
+


### PR DESCRIPTION
ProcessResult had a companion object in 2.10 that somehow disappeared in
2.11. It only called "new ProcessResult(...)", so the REPL might just as
well do that.

---

This regression happened because `:sh` isn't tested; but then, I am not sure how to write a test for this that isn't platform-dependent.

Review by @som-snytt
