### PR TITLE
SI-7688 Fix AsSeenFrom of ThisType from TypeVar prefix

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -581,6 +581,7 @@ private[internal] trait TypeMaps {
         else if (!matchesPrefixAndClass(pre, clazz)(tparam.owner))
           loop(nextBase.prefix, clazz.owner)
         else nextBase match {
+          case NoType                         => loop(NoType, clazz.owner) // backstop for SI-2797, must remove `SingletonType#isHigherKinded` and run pos/t2797.scala to get here.
           case applied @ TypeRef(_, _, _)     => correspondingTypeArgument(classParam, applied)
           case ExistentialType(eparams, qtpe) => captureSkolems(eparams) ; loop(qtpe, clazz)
           case t                              => abort(s"$tparam in ${tparam.owner} cannot be instantiated from ${seenFromPrefix.widen}")
@@ -593,10 +594,8 @@ private[internal] trait TypeMaps {
     // Since pre may be something like ThisType(A) where trait A { self: B => },
     // we have to test the typeSymbol of the widened type, not pre.typeSymbol, or
     // B will not be considered.
-    private def matchesPrefixAndClass(pre: Type, clazz: Symbol)(candidate: Symbol) = pre.widen match {
-      case _: TypeVar => false
-      case wide       => (clazz == candidate) && (wide.typeSymbol isSubClass clazz)
-    }
+    private def matchesPrefixAndClass(pre: Type, clazz: Symbol)(candidate: Symbol) =
+      (clazz == candidate) && (pre.widen.typeSymbol isSubClass clazz)
 
     // Whether the annotation tree currently being mapped over has had a This(_) node rewritten.
     private[this] var wroteAnnotation = false

--- a/test/files/pos/t7688.scala
+++ b/test/files/pos/t7688.scala
@@ -1,0 +1,7 @@
+import scala.reflect.macros._
+
+class A[C <: Context with Singleton](position: C#Position)
+
+object A {
+  def apply(c: Context)(in: c.Tree): A[c.type] = new A(in.pos)
+}


### PR DESCRIPTION
Restores behaviour for the AsSeenFrom before the refactoring in b457b6c477.

This commit uniformly considered that a `TypeVar` prefix should not
`matchesPrefixAndClass`; a condition that formerly was only applied if the
type being viewed was a `TypeRef`. This condition was originally added in
cc9e8eda3364d as a backstop for pos/t2797.scala.

This commit leaves that backstop in place where it was, although it expresses
it more directly by checking if `pre baseType clazz` is
`NoType`, which was the case that cropped up in :

```
scala> type T = bc._1.type forSome { val bc: (AnyRef, AnyRef) }
warning: there were 1 feature warning(s); re-run with -feature for details
defined type alias T
scala> val et = typeOf[T].dealias.asInstanceOf[ExistentialType]
et: $r.intp.global.ExistentialType = bc._1.type forSome { val bc: (AnyRef, AnyRef) }

scala> et.withTypeVars( { x =>
|   println(x.prefix.typeSymbol)
|   println(x.prefix.typeSymbol.isSubClass(typeOf[Tuple2[_,_]].typeSymbol))
|   println(x.prefix.baseType(typeOf[Tuple2[_, _]].typeSymbol))
|   true
| } , reflect.internal.Depth(0))
 type bc.type
 true
 <notype>
 res98: Boolean = true
```
