### PR TITLE
Make parameters to implicit value classes private

### DIFF
--- a/src/compiler/scala/tools/nsc/util/package.scala
+++ b/src/compiler/scala/tools/nsc/util/package.scala
@@ -75,7 +75,7 @@ package object util {
     s"$clazz$msg @ $frame"
   }
 
-  implicit class StackTraceOps(val e: Throwable) extends AnyVal with StackTracing {
+  implicit class StackTraceOps(private val e: Throwable) extends AnyVal with StackTracing {
     /** Format the stack trace, returning the prefix consisting of frames that satisfy
      *  a given predicate.
      *  The format is similar to the typical case described in the JavaDoc

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -244,33 +244,33 @@ object Predef extends LowPriorityImplicits with DeprecatedPredef {
 
   // implicit classes -----------------------------------------------------
 
-  implicit final class ArrowAssoc[A](val __leftOfArrow: A) extends AnyVal {
-    @inline def -> [B](y: B): Tuple2[A, B] = Tuple2(__leftOfArrow, y)
+  implicit final class ArrowAssoc[A](private val self: A) extends AnyVal {
+    @inline def -> [B](y: B): Tuple2[A, B] = Tuple2(self, y)
     def →[B](y: B): Tuple2[A, B] = ->(y)
   }
 
-  implicit final class Ensuring[A](val __resultOfEnsuring: A) extends AnyVal {
-    def ensuring(cond: Boolean): A = { assert(cond); __resultOfEnsuring }
-    def ensuring(cond: Boolean, msg: => Any): A = { assert(cond, msg); __resultOfEnsuring }
-    def ensuring(cond: A => Boolean): A = { assert(cond(__resultOfEnsuring)); __resultOfEnsuring }
-    def ensuring(cond: A => Boolean, msg: => Any): A = { assert(cond(__resultOfEnsuring), msg); __resultOfEnsuring }
+  implicit final class Ensuring[A](private val self: A) extends AnyVal {
+    def ensuring(cond: Boolean): A = { assert(cond); self }
+    def ensuring(cond: Boolean, msg: => Any): A = { assert(cond, msg); self }
+    def ensuring(cond: A => Boolean): A = { assert(cond(self)); self }
+    def ensuring(cond: A => Boolean, msg: => Any): A = { assert(cond(self), msg); self }
   }
 
-  implicit final class StringFormat[A](val __stringToFormat: A) extends AnyVal {
+  implicit final class StringFormat[A](private val self: A) extends AnyVal {
     /** Returns string formatted according to given `format` string.
      *  Format strings are as for `String.format`
      *  (@see java.lang.String.format).
      */
-    @inline def formatted(fmtstr: String): String = fmtstr format __stringToFormat
+    @inline def formatted(fmtstr: String): String = fmtstr format self
   }
 
-  implicit final class StringAdd[A](val __thingToAdd: A) extends AnyVal {
-    def +(other: String) = String.valueOf(__thingToAdd) + other
+  implicit final class StringAdd[A](private val self: A) extends AnyVal {
+    def +(other: String) = String.valueOf(self) + other
   }
 
-  implicit final class RichException(val __throwableToEnrich: Throwable) extends AnyVal {
+  implicit final class RichException(private val self: Throwable) extends AnyVal {
     import scala.compat.Platform.EOL
-    @deprecated("Use Throwable#getStackTrace", "2.11.0") def getStackTraceString = __throwableToEnrich.getStackTrace().mkString("", EOL, EOL)
+    @deprecated("Use Throwable#getStackTrace", "2.11.0") def getStackTraceString = self.getStackTrace().mkString("", EOL, EOL)
   }
 
   implicit final class SeqCharSequence(val __sequenceOfChars: scala.collection.IndexedSeq[Char]) extends CharSequence {

--- a/src/library/scala/concurrent/duration/package.scala
+++ b/src/library/scala/concurrent/duration/package.scala
@@ -40,15 +40,15 @@ package object duration {
   implicit def pairLongToDuration(p: (Long, TimeUnit)): FiniteDuration = Duration(p._1, p._2)
   implicit def durationToPair(d: Duration): (Long, TimeUnit)           = (d.length, d.unit)
 
-  implicit final class DurationInt(val n: Int) extends AnyVal with DurationConversions {
+  implicit final class DurationInt(private val n: Int) extends AnyVal with DurationConversions {
     override protected def durationIn(unit: TimeUnit): FiniteDuration = Duration(n.toLong, unit)
   }
 
-  implicit final class DurationLong(val n: Long) extends AnyVal with DurationConversions {
+  implicit final class DurationLong(private val n: Long) extends AnyVal with DurationConversions {
     override protected def durationIn(unit: TimeUnit): FiniteDuration = Duration(n, unit)
   }
 
-  implicit final class DurationDouble(val d: Double) extends AnyVal with DurationConversions {
+  implicit final class DurationDouble(private val d: Double) extends AnyVal with DurationConversions {
     override protected def durationIn(unit: TimeUnit): FiniteDuration =
       Duration(d, unit) match {
         case f: FiniteDuration => f
@@ -59,17 +59,17 @@ package object duration {
   /*
    * Avoid reflection based invocation by using non-duck type
    */
-  implicit final class IntMult(val i: Int) extends AnyVal {
+  implicit final class IntMult(private val i: Int) extends AnyVal {
     def *(d: Duration) = d * i.toDouble
     def *(d: FiniteDuration) = d * i.toLong
   }
 
-  implicit final class LongMult(val i: Long) extends AnyVal {
+  implicit final class LongMult(private val i: Long) extends AnyVal {
     def *(d: Duration) = d * i.toDouble
     def *(d: FiniteDuration) = d * i.toLong
   }
 
-  implicit final class DoubleMult(val f: Double) extends AnyVal {
+  implicit final class DoubleMult(private val f: Double) extends AnyVal {
     def *(d: Duration) = d * f.toDouble
   }
 }

--- a/src/library/scala/util/Either.scala
+++ b/src/library/scala/util/Either.scala
@@ -216,7 +216,7 @@ object Either {
    * r.merge: Seq[Int] // Vector(1)
    * }}}
    */
-  implicit class MergeableEither[A](val x: Either[A, A]) extends AnyVal {
+  implicit class MergeableEither[A](private val x: Either[A, A]) extends AnyVal {
     def merge: A = x match {
       case Left(a)  => a
       case Right(a) => a


### PR DESCRIPTION
So that they aren't offered as an autocomplete suggestion:

```
implicit class Shouty(string: String) extends AnyVal {
 def SHOUT_! = string.toUpperCase + "!"
}
"". // autocompletion offers `.string` here.
```

The original incarnation of value classes didn't allow this sort of
encapsulation, so we either invented goofy names like
`__thingToAdd` or just picked `x` or `self`. But SI-7859 has delivered us the
freedom to keep the accessor private.

Should we keep any of these accessors around in a deprecated form?

The implicit classes in Predef were added in 2.11.0-M2
(c26a8db067e4f), so they are okay.

I think we can make reason that these APIs were both accidental and unlikely
to be interpreted as public, so we can break them immediately.

```
scala> Left(1).x
res0: scala.util.Either[Int,Int] = Left(1)

scala> import concurrent.duration._
import concurrent.duration._

scala> 1.n
res1: Int = 1
```
