### PR TITLE
[nomaster] SI-6026 backport getResource bug fix

### DIFF
--- a/src/compiler/scala/tools/nsc/interpreter/AbstractFileClassLoader.scala
+++ b/src/compiler/scala/tools/nsc/interpreter/AbstractFileClassLoader.scala
@@ -7,7 +7,7 @@ package interpreter
 
 import scala.tools.nsc.io.{ File, AbstractFile }
 import util.ScalaClassLoader
-import java.net.URL
+import java.net.{ URL, URLConnection, URLStreamHandler }
 import scala.collection.{ mutable, immutable }
 
 /**
@@ -55,10 +55,24 @@ class AbstractFileClassLoader(val root: AbstractFile, parent: ClassLoader)
     return file
   }
 
+  // parent delegation in JCL uses getResource; so either add parent.getResAsStream
+  // or implement findResource, which we do here as a study in scarlet (my complexion
+  // after looking at CLs and URLs)
+  override def findResource(name: String): URL = findAbstractFile(name) match {
+    case null => null
+    case file => new URL(null, "repldir:" + file.path, new URLStreamHandler {
+      override def openConnection(url: URL): URLConnection = new URLConnection(url) {
+        override def connect() { }
+        override def getInputStream = file.input
+      }
+    })
+  }
+  // this inverts delegation order: super.getResAsStr calls parent.getRes if we fail
   override def getResourceAsStream(name: String) = findAbstractFile(name) match {
     case null => super.getResourceAsStream(name)
     case file => file.input
   }
+  // ScalaClassLoader.classBytes uses getResAsStream, so we'll try again before delegating 
   override def classBytes(name: String): Array[Byte] = findAbstractFile(name) match {
     case null => super.classBytes(name)
     case file => file.toByteArray

--- a/test/disabled/run/t6026.check
+++ b/test/disabled/run/t6026.check
@@ -1,0 +1,9 @@
+Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> class Foo
+defined class Foo
+
+scala> :javap Foo
+Compiled from "<console>"public class Foo extends java.lang.Object{    public Foo();}
+scala> 

--- a/test/disabled/run/t6026.scala
+++ b/test/disabled/run/t6026.scala
@@ -1,0 +1,9 @@
+
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  override def code =
+"""|class Foo
+   |:javap Foo
+   |""".stripMargin
+}


### PR DESCRIPTION
Submitted to master under SI-4936, this fix allows :javap
to work when tools.jar is discovered by REPL.
