### PR TITLE
fixes handling of fancy nested classes in runtime reflection

### DIFF
--- a/src/reflect/scala/reflect/runtime/ReflectionUtils.scala
+++ b/src/reflect/scala/reflect/runtime/ReflectionUtils.scala
@@ -84,4 +84,18 @@ private[scala] object ReflectionUtils {
   def scalacShouldntLoadClassfile(fileName: String) = isTraitImplementation(fileName)
 
   def scalacShouldntLoadClass(name: scala.reflect.internal.SymbolTable#Name) = scalacShouldntLoadClassfile(name + ".class")
+
+  object PrimitiveOrArray {
+    def unapply(jclazz: jClass[_]) = jclazz.isPrimitive || jclazz.isArray
+  }
+
+  class EnclosedIn[T](enclosure: jClass[_] => T) {
+    def unapply(jclazz: jClass[_]): Option[T] = if (enclosure(jclazz) != null) Some(enclosure(jclazz)) else None
+  }
+
+  object EnclosedInMethod extends EnclosedIn(_.getEnclosingMethod)
+  object EnclosedInConstructor extends EnclosedIn(_.getEnclosingConstructor)
+  object EnclosedInClass extends EnclosedIn(_.getEnclosingClass)
+  object EnclosedInPackage extends EnclosedIn(_.getPackage)
 }
+

--- a/src/reflect/scala/reflect/runtime/SymbolLoaders.scala
+++ b/src/reflect/scala/reflect/runtime/SymbolLoaders.scala
@@ -97,9 +97,7 @@ private[reflect] trait SymbolLoaders { self: SymbolTable =>
       if (isCompilerUniverse) super.enter(sym)
       else {
         val existing = super.lookupEntry(sym.name)
-        // commented out to provide a hotfix for strange class files that javac sometimes emits
-        // see more details at: https://groups.google.com/forum/#!topic/scala-internals/hcnUFk75MgQ
-        // assert(existing == null || existing.sym.isMethod, s"pkgClass = $pkgClass, sym = $sym, existing = $existing")
+        assert(existing == null || existing.sym.isMethod, s"pkgClass = $pkgClass, sym = $sym, existing = $existing")
         super.enter(sym)
       }
     }

--- a/test/files/run/reflection-fancy-java-classes.check
+++ b/test/files/run/reflection-fancy-java-classes.check
@@ -1,0 +1,12 @@
+===== JAVA POV =====
+class Foo_1$1
+getEnclosingClass = class Foo_1
+getEnclosingMethod = null
+getEnclosingConstructor = null
+isMemberClass = false
+isLocalClass = false
+isAnonymousClass = true
+
+===== SCALA POV =====
+class 1
+object Foo_1

--- a/test/files/run/reflection-fancy-java-classes/Foo_1.java
+++ b/test/files/run/reflection-fancy-java-classes/Foo_1.java
@@ -1,0 +1,5 @@
+public class Foo_1 {
+  public static Bar bar = new Bar();
+  private static class Bar {
+  }
+}

--- a/test/files/run/reflection-fancy-java-classes/Test_2.scala
+++ b/test/files/run/reflection-fancy-java-classes/Test_2.scala
@@ -1,0 +1,20 @@
+import scala.reflect.runtime.{universe => ru}
+import scala.reflect.runtime.{currentMirror => cm}
+
+object Test extends App {
+  println("===== JAVA POV =====")
+  val jfancy = Class.forName("Foo_1$1")
+  println(jfancy)
+  println("getEnclosingClass = " + jfancy.getEnclosingClass)
+  println("getEnclosingMethod = " + jfancy.getEnclosingMethod)
+  println("getEnclosingConstructor = " + jfancy.getEnclosingConstructor)
+  println("isMemberClass = " + jfancy.isMemberClass)
+  println("isLocalClass = " + jfancy.isLocalClass)
+  println("isAnonymousClass = " + jfancy.isAnonymousClass)
+
+  println("")
+  println("===== SCALA POV =====")
+  val sfancy = cm.classSymbol(jfancy)
+  println(sfancy)
+  println(sfancy.owner)
+}


### PR DESCRIPTION
Replaces the `jclazz.isMemberClass` check for whether we have an
inner/nested class with `jclazz.getEnclosingClass != null`, because there
exist classes produced by javac (see the attached jar file and the test log)
which have the following properties:
- They are nested within a parent class
- getEnclosingClass returns a non-null value
- isMemberClass returns false

Previously such classes were incorrectly treated as non-nested, were
incorrectly put into an enclosing package rather than an enclosing class,
and had their names trimmed in the process, leading to situations when
a package has multiple declarations with the same name. This is now fixed.

When changing the check, we need to be careful with interpretation of
what Class.getEnclosingXXX methods return. If getEnclosingClass produces
a non-null result, this doesn't mean that the class is inner or nested,
because getEnclosingClass is also not null for local classes (the ones
with getEnclosingMethod != null || getEnclosingConstructor != null).
This is expressed in the order of pattern match clauses in `sOwner`.

Now when the bug is fixed, I also revert b18a2f8798b2, restoring a very
important integrity check in runtime reflection, which I had to disable
a couple hours ago to fix a master breakage. More details at scala-internals:
https://groups.google.com/forum/#!topic/scala-internals/hcnUFk75MgQ
