### PR TITLE
SI-6840 fixes weird typing of quasiquote arguments

### DIFF
--- a/src/compiler/scala/tools/reflect/quasiquotes/Quasiquotes.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Quasiquotes.scala
@@ -15,7 +15,7 @@ abstract class Quasiquotes extends Parsers
     if (settings.Yquasiquotedebug.value) println(msg)
 
   lazy val (universe: Tree, args, parts, parse, reify, method) = c.macroApplication match {
-    case Apply(Select(Select(Apply(Select(universe0, _), List(Apply(_, parts0))), interpolator0), method0), args0) =>
+    case Apply(build.SyntacticTypeApplied(Select(Select(Apply(Select(universe0, _), List(Apply(_, parts0))), interpolator0), method0), _), args0) =>
       debug(s"\nparse prefix:\nuniverse=$universe0\nparts=$parts0\ninterpolator=$interpolator0\nmethod=$method0\nargs=$args0\n")
       val parts1 = parts0.map {
         case lit @ Literal(Constant(s: String)) => s -> lit.pos

--- a/src/reflect/scala/reflect/api/Quasiquotes.scala
+++ b/src/reflect/scala/reflect/api/Quasiquotes.scala
@@ -7,7 +7,7 @@ trait Quasiquotes { self: Universe =>
   // using the mechanism implemented in `scala.tools.reflect.FastTrack`
   implicit class Quasiquote(ctx: StringContext) {
     protected trait api {
-      def apply(args: Any*): Any = macro ???
+      def apply[T](args: T*): Any = macro ???
       def unapply(scrutinee: Any): Any = macro ???
     }
     object q extends api

--- a/test/files/scalacheck/quasiquotes/TermConstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/TermConstructionProps.scala
@@ -199,4 +199,13 @@ object TermConstructionProps extends QuasiquoteProperties("term construction") {
     def withEvidence = q"def foo[T: X]"
     assert(!(withEvidence ≈ withEvidence))
   }
+
+  property("make sure inference doesn't infer any") = test {
+    val l1 = List(q"foo")
+    val l2 = List(q"bar")
+    val baz = q"baz"
+    assert(q"f(..${l1 ++ l2})" ≈ q"f(foo, bar)")
+    assert(q"f(..${l1 ++ l2}, $baz)" ≈ q"f(foo, bar, baz)")
+    assert(q"f(${if (true) q"a" else q"b"})" ≈ q"f(a)")
+  }
 }


### PR DESCRIPTION
Previously quasiquote arguments were type checked against Any
which caused weird inference that made splicing of complex expressions
unusable:

``` scala
   val l1 = List(q"foo")
   val l2 = List(q"bar")
   q"f(..${l1 ++ l2})" // argument type checked as Any instead of List[Tree]
```

This is fixed by forcing compiler to type check against type
variable which itself isn't used in any other way.

review by @retronym 
