### PR TITLE
SI-7519: Additional test case covering sbt/sbt#914

### DIFF
--- a/test/files/neg/t7519-b.check
+++ b/test/files/neg/t7519-b.check
@@ -1,0 +1,6 @@
+Use_2.scala:6: error: type mismatch;
+ found   : String
+ required: Q
+  val x: Q = ex.Mac.mac("asdf")
+                       ^
+one error found

--- a/test/files/neg/t7519-b/Mac_1.scala
+++ b/test/files/neg/t7519-b/Mac_1.scala
@@ -1,0 +1,14 @@
+// get expected error message without package declaration
+package ex
+
+import scala.language.experimental.macros
+import scala.reflect.macros._
+
+object IW {
+  def foo(a: String): String = ???
+}
+object Mac {
+  def mac(s: String): String = macro macImpl
+  def macImpl(c: Context)(s: c.Expr[String]): c.Expr[String] = 
+    c.universe.reify(IW.foo(s.splice))
+}

--- a/test/files/neg/t7519-b/Use_2.scala
+++ b/test/files/neg/t7519-b/Use_2.scala
@@ -1,0 +1,8 @@
+trait Q
+trait K
+
+object Use {
+  implicit def cd[T](p: T)(implicit ev: T => K): Q = ???
+  val x: Q = ex.Mac.mac("asdf")
+}
+


### PR DESCRIPTION
Commit 32b5d50d6635320f448c92c27bc6df3acbb04451, associated with [SI-7519](https://issues.scala-lang.org/browse/SI-7519) and included in 2.11.0-M4, fixes sbt issue https://github.com/sbt/sbt/issues/914. This is a partest test covering the sbt issue.

Review by @retronym.
