### PR TITLE
Fix problem assembling sources and docs of modules.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1944,7 +1944,7 @@ TODO:
 
   <target name="dist.doc" depends="dist.base, docs.done">
     <mkdir dir="${dist.dir}/doc/scala-devel-docs"/>
-    <copy toDir="${dist.dir}/doc/scala-devel-docs" overwrite="true">
+    <copy toDir="${dist.dir}/doc/scala-devel-docs" overwrite="true" flatten="true">
       <file file="${scala-xml-javadoc}"/>
       <file file="${scala-parser-combinators-javadoc}"/>
     </copy>
@@ -2003,7 +2003,7 @@ TODO:
 
   <target name="dist.src" depends="dist.base">
     <mkdir dir="${dist.dir}/src"/>
-    <copy toDir="${dist.dir}/src" overwrite="true">
+    <copy toDir="${dist.dir}/src" overwrite="true" flatten="true">
       <file file="${scala-xml-sources}"/>
       <file file="${scala-parser-combinators-sources}"/>
     </copy>


### PR DESCRIPTION
A recent commit added 'overwrite=true' to all usages of the Ant copy task.

This was enough to show up a bug in our dist.src and dist.docs tasks, as was
seen on the Windows build:

```
Failed to copy:
```

C:\Users\scala.m2\repository\org\scala-lang\modules\scala-xml_2.11.0-M5\1.0-RC4\scala-xml_2.11.0-M5-1.0-RC4-javadoc.jar
to

H:\jenkins\workspace\scala-nightly-windows\dists\scala-2.11.0-20131019-064627-8848f24161\doc\scala-devel-docs\C:\Users\scala.m2\repository\org\scala-lang\modules\scala-xml_2.11.0-M5\1.0-RC4\scala-xml_2.11.0-M5-1.0-RC4-javadoc.jar
...

This commit uses a "flattening" copy to put the JARs directly into 
scala-devel-docs.

The Ant docs note [1] this gotcha:

> Note that some resources (for example the file resource) return
> absolute paths as names and the result of using them without
> using a nested mapper (or the flatten attribute) may not be what
> you expect.

These appear to be the only places we fell into the trap:

```
% ack '<file\b' --xml
build.xml
1948:      <file file="${scala-xml-javadoc}"/>
1949:      <file file="${scala-parser-combinators-javadoc}"/>
1992:        <file-sets/>
2007:      <file file="${scala-xml-sources}"/>
2008:      <file file="${scala-parser-combinators-sources}"/>
```

[1] http://ant.apache.org/manual/Tasks/copy.html
