### PR TITLE
hotfix for reflection tests on Windows

### DIFF
--- a/test/files/run/t6240a/Test.scala
+++ b/test/files/run/t6240a/Test.scala
@@ -11,6 +11,5 @@ object Test extends App {
   assert(new File(testClassesDir).exists, testClassesDir)
   val fullTestClassesClasspath = testClassesDir + prop("path.separator") + prop("java.class.path")
   val javaBinary = if (new File(prop("javacmd")).isAbsolute) prop("javacmd") else prop("java.home") + "/bin/" + prop("javacmd")
-  assert(new File(javaBinary).exists, javaBinary)
   List(javaBinary, "-cp", testClassesDir, "-Dlaunch.classpath=" + fullTestClassesClasspath, "StepOne").!
 }

--- a/test/files/run/t6240b/Test.scala
+++ b/test/files/run/t6240b/Test.scala
@@ -11,6 +11,5 @@ object Test extends App {
   assert(new File(testClassesDir).exists, testClassesDir)
   val fullTestClassesClasspath = testClassesDir + prop("path.separator") + prop("java.class.path")
   val javaBinary = if (new File(prop("javacmd")).isAbsolute) prop("javacmd") else prop("java.home") + "/bin/" + prop("javacmd")
-  assert(new File(javaBinary).exists, javaBinary)
   List(javaBinary, "-cp", testClassesDir, "-Dlaunch.classpath=" + fullTestClassesClasspath, "StepOne").!
 }


### PR DESCRIPTION
Removes the Unix-specific command-line sanity check put in place in recently
committed reflection tests.

On Windows, something like `C:\Java\jdk1.6.0_24-x64\jre\bin\java` might
be a valid command (pointing to `java.exe` or `java.bat`) even if
the eponymous file does not exist.
