### PR TITLE
Platform independence for SI-6240 test case

### DIFF
--- a/test/files/run/t6240a/StepOne.java
+++ b/test/files/run/t6240a/StepOne.java
@@ -12,7 +12,7 @@ import java.net.MalformedURLException;
 public class StepOne {
   public static void main(String[] args)
   throws MalformedURLException, ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, IOException {
-    String[] launchPaths = System.getProperty("launch.classpath").split(":");
+    String[] launchPaths = System.getProperty("launch.classpath").split(File.pathSeparator);
 
     // move away StepThree
     File tempDir = File.createTempFile("temp", Long.toString(System.nanoTime()));

--- a/test/files/run/t6240b/StepOne.java
+++ b/test/files/run/t6240b/StepOne.java
@@ -12,7 +12,7 @@ import java.net.MalformedURLException;
 public class StepOne {
   public static void main(String[] args)
   throws MalformedURLException, ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, IOException {
-    String[] launchPaths = System.getProperty("launch.classpath").split(":");
+    String[] launchPaths = System.getProperty("launch.classpath").split(File.pathSeparator);
 
     // move away StepThree
     File tempDir = File.createTempFile("temp", Long.toString(System.nanoTime()));


### PR DESCRIPTION
File.pathSeparator, rather than ":"

Review by @xeno-by
