### PR TITLE
SI-7295 Fix windows batch file with args containing parentheses

### DIFF
--- a/src/compiler/scala/tools/ant/templates/tool-windows.tmpl
+++ b/src/compiler/scala/tools/ant/templates/tool-windows.tmpl
@@ -12,15 +12,18 @@ setlocal enableextensions enabledelayedexpansion
 
 set _LINE_TOOLCP=
 
-:another_param
-
 rem Use "%~1" to handle spaces in paths. See http://ss64.com/nt/syntax-args.html
-if "%~1"=="-toolcp" (
-    set _LINE_TOOLCP=%~2
-	shift
-	shift
-	goto another_param
+rem SI-7295 The goto here is needed to avoid problems with `scala Script.cmd "arg(with)paren"`,
+rem         we must not evaluate %~2 eagerly, but delayed expansion doesn't seem to allow
+rem         removal of quotation marks.
+if not [%~1]==[-toolcp] (
+  goto :notoolcp
 )
+shift
+set _LINE_TOOLCP=%~1
+shift
+
+:notoolcp
 
 rem We keep in _JAVA_PARAMS all -J-prefixed and -D-prefixed arguments
 set _JAVA_PARAMS=


### PR DESCRIPTION
In command scripts, substitution of `FOO` in `if cond ( %FOO% )` happens
_before_ the condition is evaluated. One can use delayed expansion with
`if cond (!FOO!)` to get a saner behaviour. Or, as I ended up doing here, use
a goto in the body of the if rather than referring directly to variables 
there.

Here's a cut down version to demonstrate the old problem:

```
C:\Users\IEUser>type test.cmd
@echo off

setlocal enableextensions enabledelayedexpansion

if [%~1]==[-toolcp] (
 set CP=%~2
 shift
 shift
)
echo -toolcp %CP%
echo %~1 %~2

C:\Users\IEUser>test.cmd a b
-toolcp
a b

C:\Users\IEUser>test.cmd -toolcp "c:\program files" a b
-toolcp c:\program files
a b

C:\Users\IEUser>test.cmd -toolcp "c:\program files" "a()b" "c()d"
-toolcp c:\program files
a()b c()d

C:\Users\IEUser>test.cmd "a()b" "c()d"
d was unexpected at this time.
```

I don't understand exactly why the parentheses only mess things up in this
situation. But regardless, lets find another way.

My first attempt to fix this was based on the suggestion in the ticket. But,
as shown below, this fails to capture the -toolcp.

```
C:\Users\IEUser>type test.cmd
@echo off

setlocal enableextensions enabledelayedexpansion

if [%~1]==[-toolcp] (
  set CP=!2!
  shift
  shift
)
echo -toolcp %CP%
echo %~1 %~2
C:\Users\IEUser>test.cmd "a()b" "c()d"
-toolcp
a()b c()d

C:\Users\IEUser>test.cmd -toolcp "c:\program files" "a()b" "c()d"
-toolcp
a()b c()d
```

Last stop was the goto you'll find in this patch.

With this patch applied, I tested on Windows 8 with the following:

```
C:\Users\IEUser>type Desktop\temp.cmd
::#!
@echo off
call scala %0 %*
goto :eof
::!#
println("hello, world")
println(argv.toList)

C:\Users\IEUser>scala Desktop\temp.cmd "foo(bar)baz"
"java" -Xmx256M -Xms32M -Dscala.home="C:\PROGRA~3\scala\bin\.."
-Denv.emacs="" -Dscala.usejavacp=true  -cp "..."
scala.tools.nsc.MainGenericRunner Desktop\temp.cmd "foo(bar)baz"

hello, world
List(foo(bar)baz)

C:\Users\IEUser>scala -toolcp "c:\program files" Desktop\temp.cmd "foo(bar)baz"
"java" -Xmx256M -Xms32M -Dscala.home="C:\PROGRA~3\scala\bin\.."
-Denv.emacs="" -Dscala.usejavacp=true  -cp "...;c:\program files"
scala.tools.nsc.MainGenericRunner  -toolcp "c:\program files" Desktop\temp.cmd "foo(bar)baz"

hello, world
List(foo(bar)baz)
```
