### PR TITLE
SI-7598 Make erasure of isInstanceOf[X.type] $outer-aware

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -294,6 +294,13 @@ abstract class ExplicitOuter extends InfoTransform
     }
   }
 
+  final def transformTreeAtOwner(owner: Symbol, tree: Tree): Tree = {
+    val explicitOuterTransformer = new explicitOuter.ExplicitOuterTransformer(currentUnit)
+    explicitOuterTransformer.atOwner(owner) {
+      explicitOuterTransformer.transform(tree)
+    }
+  }
+
   /** <p>
    *    The phase performs the following transformations on terms:
    *  </p>

--- a/test/files/run/t7598.scala
+++ b/test/files/run/t7598.scala
@@ -1,0 +1,55 @@
+class Outer {
+  object X
+  val xx: X.type = X
+
+  class Inner {
+    assert(X.isInstanceOf[X.type])
+    assert(!new Outer().X.isInstanceOf[X.type])
+    assert(Outer.this.isInstanceOf[Outer.this.type])
+    assert(!new Outer().isInstanceOf[Outer.this.type])
+
+    class DoubleInner {
+      assert(X.isInstanceOf[X.type])
+      assert(!new Outer().X.isInstanceOf[X.type])
+      assert(Outer.this.isInstanceOf[Outer.this.type])
+      assert(!new Outer().isInstanceOf[Outer.this.type])
+    }
+    object O2 {
+      assert(X.isInstanceOf[X.type])
+      assert(!new Outer().X.isInstanceOf[X.type])
+      assert(Outer.this.isInstanceOf[Outer.this.type])
+      assert(!new Outer().isInstanceOf[Outer.this.type])
+    }
+  }
+
+  object InnerObj {
+    assert(X.isInstanceOf[X.type])
+    assert(!new Outer().X.isInstanceOf[X.type])
+    assert(Outer.this.isInstanceOf[Outer.this.type])
+    assert(!new Outer().isInstanceOf[Outer.this.type])
+ 
+    trait DoubleInner {
+      assert(X.isInstanceOf[X.type])
+      assert(!new Outer().X.isInstanceOf[X.type])
+      assert(Outer.this.isInstanceOf[Outer.this.type])
+      assert(!new Outer().isInstanceOf[Outer.this.type])
+    }
+  }
+
+  final class InnerFinal {
+    assert(xx.isInstanceOf[xx.type])
+    assert(!new Outer().X.isInstanceOf[xx.type])
+    assert(Outer.this.isInstanceOf[Outer.this.type])
+    assert(!new Outer().isInstanceOf[Outer.this.type])
+  }
+}
+
+object Test extends App {
+  val outer = new Outer
+  val outerInner = new outer.Inner
+  new outerInner.DoubleInner
+  outerInner.O2
+  outer.InnerObj
+  new outer.InnerObj.DoubleInner {}
+  new outer.InnerFinal
+}

--- a/test/files/run/t7598b.scala
+++ b/test/files/run/t7598b.scala
@@ -1,0 +1,19 @@
+trait Component
+
+class Owner {
+  object Timestamp extends Component {
+    def unapply(name: Timestamp.type): Boolean = true
+  }
+ 
+  class Inner {
+    def foo(c: Component) = c match {
+      case Timestamp() =>
+    }
+  }
+}
+
+object Test extends App {
+  val outer = new Owner
+  val inner = new outer.Inner
+  inner.foo(outer.Timestamp)
+}


### PR DESCRIPTION
Type tests against Singleton-, This- and, Super- types are translated
into reference equality checks in erasure.

For instance:

```
class C { object X; X.isInstanceOf[X.type] }
```

Results in:

```
class C { object X; X eq X }
```

But, the term tree created to refer to the object behind the
SingleType was constructed without being explicit about outer
pointers.

After typer:

```
class C { object X; class Inner { X.isInstanceOf[X.type] } }
```

After explicitouter:

```
class C { object X; class Inner($outer: C) { $outer().X().isInstanceOf[X.type] } }
```

After erasure:

```
class C { object X; class Inner($outer: C) { $outer().X() eq Outer.this.X() } }
```

That leads to a crash in `icode`.

This commit runs the explicit outer tree transformer over the argument
to `eq`.

Review by @gkossakowski or @JamesIry 
