### PR TITLE
[nomaster] SI-7519 Less brutal attribute resetting in adapt fallback

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -876,8 +876,9 @@ trait Typers extends Modes with Adaptations with Tags {
               case SilentResultValue(result) =>
                 result
               case _ =>
-                debuglog("fallback on implicits: " + tree + "/" + resetAllAttrs(original))
-                val tree1 = typed(resetAllAttrs(original), mode, WildcardType)
+                val resetTree = resetLocalAttrs(original)
+                debuglog(s"fallback on implicits: ${tree}/$resetTree")
+                val tree1 = typed(resetTree, mode, WildcardType)
                 // Q: `typed` already calls `pluginsTyped` and `adapt`. the only difference here is that
                 // we pass `EmptyTree` as the `original`. intended? added in 2009 (53d98e7d42) by martin.
                 tree1.tpe = pluginsTyped(tree1.tpe, this, tree1, mode, pt)

--- a/test/files/neg/t7519-b.check
+++ b/test/files/neg/t7519-b.check
@@ -1,0 +1,4 @@
+Use_2.scala:6: error: No implicit view available from String => K.
+  val x: Q = ex.Mac.mac("asdf")
+                       ^
+one error found

--- a/test/files/neg/t7519-b/Mac_1.scala
+++ b/test/files/neg/t7519-b/Mac_1.scala
@@ -1,0 +1,14 @@
+// get expected error message without package declaration
+package ex
+
+import scala.language.experimental.macros
+import scala.reflect.macros._
+
+object IW {
+  def foo(a: String): String = ???
+}
+object Mac {
+  def mac(s: String): String = macro macImpl
+  def macImpl(c: Context)(s: c.Expr[String]): c.Expr[String] = 
+    c.universe.reify(IW.foo(s.splice))
+}

--- a/test/files/neg/t7519-b/Use_2.scala
+++ b/test/files/neg/t7519-b/Use_2.scala
@@ -1,0 +1,8 @@
+trait Q
+trait K
+
+object Use {
+  implicit def cd[T](p: T)(implicit ev: T => K): Q = ???
+  val x: Q = ex.Mac.mac("asdf")
+}
+

--- a/test/files/neg/t7519.check
+++ b/test/files/neg/t7519.check
@@ -1,0 +1,7 @@
+t7519.scala:5: error: could not find implicit value for parameter nada: Nothing
+    locally(0 : String) // was: "value conversion is not a member of C.this.C"
+            ^
+t7519.scala:15: error: could not find implicit value for parameter nada: Nothing
+      locally(0 : String) // was: "value conversion is not a member of U"
+              ^
+two errors found

--- a/test/files/neg/t7519.scala
+++ b/test/files/neg/t7519.scala
@@ -1,0 +1,18 @@
+class C {
+  implicit def conversion(m: Int)(implicit nada: Nothing): String = ???
+
+  class C { // rename class to get correct error, can't find implicit: Nothing.
+    locally(0 : String) // was: "value conversion is not a member of C.this.C"
+  }
+}
+
+object Test2 {
+  trait T; trait U
+  new T {
+    implicit def conversion(m: Int)(implicit nada: Nothing): String = ???
+
+    new U { // nested anonymous classes also share a name.
+      locally(0 : String) // was: "value conversion is not a member of U"
+    }
+  }
+}


### PR DESCRIPTION
Prefers `resetLocalAttrs` over `resetAllAttrs`. The latter loses track of
which enclosing class of the given name is referenced by a `This` node which
prefixes the an applied implicit view.

The code that `resetAllAttrs` originally landed in:
https://github.com/scala/scala/commit/d4c63b#L6R804

Cherry picked from 433880e91cba9e1e926e9fcbf04ecd4aeb1d73eb

Conflicts:
src/compiler/scala/tools/nsc/typechecker/Typers.scala
