### PR TITLE
SI-7605 Deprecate procedure syntax

### DIFF
--- a/test/files/neg/t7605-deprecation.check
+++ b/test/files/neg/t7605-deprecation.check
@@ -1,0 +1,12 @@
+t7605-deprecation.scala:2: warning: Procedure syntax is deprecated. Convert procedure to method by adding `: Unit =`.
+  def this(i: Int) { this() }
+                   ^
+t7605-deprecation.scala:3: warning: Procedure syntax is deprecated. Convert procedure to method by adding `: Unit =`.
+  def bar {}
+          ^
+t7605-deprecation.scala:4: warning: Procedure syntax is deprecated. Convert procedure to method by adding `: Unit`.
+  def baz
+         ^
+error: No warnings can be incurred under -Xfatal-warnings.
+three warnings found
+one error found

--- a/test/files/neg/t7605-deprecation.flags
+++ b/test/files/neg/t7605-deprecation.flags
@@ -1,0 +1,1 @@
+-deprecation -Xfuture -Xfatal-warnings

--- a/test/files/neg/t7605-deprecation.scala
+++ b/test/files/neg/t7605-deprecation.scala
@@ -1,0 +1,5 @@
+abstract class Foo {
+  def this(i: Int) { this() }
+  def bar {}
+  def baz
+}


### PR DESCRIPTION
This commit covers three cases:
- constructor definitions      (def this {...})
- concrete method definitions  (def foo {...})
- abstract method declarations (def foo)

The deprecation is currently hidden behind -Xfuture pending IDE support
for migrating users from procedures to methods.
