### PR TITLE
SI-7598 Make erasure of isInstanceOf[X.type] $outer-aware

### DIFF
--- a/test/files/run/t7598.scala
+++ b/test/files/run/t7598.scala
@@ -1,0 +1,64 @@
+class Base(a: Any)
+
+class Outer {
+  object X
+  val xx: X.type = X
+
+  class Inner {
+    assert(X.isInstanceOf[X.type])
+    assert(!new Outer().X.isInstanceOf[X.type])
+    assert(Outer.this.isInstanceOf[Outer.this.type])
+    assert(!new Outer().isInstanceOf[Outer.this.type])
+
+    class DoubleInner {
+      assert(X.isInstanceOf[X.type])
+      assert(!new Outer().X.isInstanceOf[X.type])
+      assert(Outer.this.isInstanceOf[Outer.this.type])
+      assert(!new Outer().isInstanceOf[Outer.this.type])
+    }
+    object O2 {
+      assert(X.isInstanceOf[X.type])
+      assert(!new Outer().X.isInstanceOf[X.type])
+      assert(Outer.this.isInstanceOf[Outer.this.type])
+      assert(!new Outer().isInstanceOf[Outer.this.type])
+    }
+  }
+
+  object InnerObj {
+    assert(X.isInstanceOf[X.type])
+    assert(!new Outer().X.isInstanceOf[X.type])
+    assert(Outer.this.isInstanceOf[Outer.this.type])
+    assert(!new Outer().isInstanceOf[Outer.this.type])
+
+    trait DoubleInner {
+      assert(X.isInstanceOf[X.type])
+      assert(!new Outer().X.isInstanceOf[X.type])
+      assert(Outer.this.isInstanceOf[Outer.this.type])
+      assert(!new Outer().isInstanceOf[Outer.this.type])
+    }
+  }
+
+  final class InnerFinal {
+    assert(xx.isInstanceOf[xx.type])
+    assert(!new Outer().X.isInstanceOf[xx.type])
+    assert(Outer.this.isInstanceOf[Outer.this.type])
+    assert(!new Outer().isInstanceOf[Outer.this.type])
+  }
+
+  class InnerConstructor extends Base({
+    assert(X.isInstanceOf[X.type])
+    assert(!new Outer().X.isInstanceOf[X.type])
+    assert(Outer.this.isInstanceOf[Outer.this.type])
+  })
+}
+
+object Test extends App {
+  val outer = new Outer
+  val outerInner = new outer.Inner
+  new outerInner.DoubleInner
+  outerInner.O2
+  outer.InnerObj
+  new outer.InnerObj.DoubleInner {}
+  new outer.InnerFinal
+  new outer.InnerConstructor
+}

--- a/test/files/run/t7598b.scala
+++ b/test/files/run/t7598b.scala
@@ -1,0 +1,19 @@
+trait Component
+
+class Owner {
+  object Timestamp extends Component {
+    def unapply(name: Timestamp.type): Boolean = true
+  }
+
+  class Inner {
+    def foo(c: Component) = c match {
+      case Timestamp() =>
+    }
+  }
+}
+
+object Test extends App {
+  val outer = new Owner
+  val inner = new outer.Inner
+  inner.foo(outer.Timestamp)
+}

--- a/test/files/run/t7598c.scala
+++ b/test/files/run/t7598c.scala
@@ -1,0 +1,11 @@
+class Base { trait T; object T extends T }
+class Derived extends Base {
+  class Inner {
+    assert(T.isInstanceOf[Derived.super.T])
+  }
+}
+
+object Test extends App {
+  val d = new Derived
+  new d.Inner
+}

--- a/test/files/run/t7598d.scala
+++ b/test/files/run/t7598d.scala
@@ -1,0 +1,13 @@
+class Outer {
+  class Inner {
+    def foo = {
+      () => assert(!null.isInstanceOf[Outer.this.type])
+    }
+  }
+}
+
+object Test extends App {
+  val outer = new Outer
+  val inner = new outer.Inner
+  inner.foo.apply()
+}


### PR DESCRIPTION
Type tests against Singleton-, This- and, Super- types are translated
into reference equality checks in erasure.

For instance:

```
class C { object X; X.isInstanceOf[X.type] }
```

Results in:

```
class C { object X; X eq X }
```

But, the term tree created to refer to the object behind the
SingleType was constructed without being explicit about outer
pointers.

After typer:

```
class C { object X; class Inner { X.isInstanceOf[X.type] } }
```

After explicitouter:

```
class C { object X; class Inner($outer: C) { $outer().X().isInstanceOf[X.type] } }
```

After erasure:

```
class C { object X; class Inner($outer: C) { $outer().X() eq Outer.this.X() } }
```

That leads to a crash in icode.

This commit changes the explicit outer tree transformer to transform
the types of TypeTrees:

After exlicitouter:

```
Inner.this.$outer().X().isInstanceOf[Inner.this.$outer.X.type](
```

Do to this, we need versions of outerValue, outerSelect, and outerPath
that operate on types. I also refactored the term-level versions of
these to help emphasise the similarities and differences with the new
versions.

Some robustness is needed in the face of ill-scoped references left
in the trees after extension methods and tail call elimination have
left a mess in pos/t6891.scala.

This is a resubmission of #3066 that addresses the problem at the source
(explicitouter) rather than in erasure.

Review by @gkossakowski / @odersky . 
