### PR TITLE
SI-6385 Avoid bridges to identical signatures over value classes

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/PostErasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/PostErasure.scala
@@ -22,7 +22,7 @@ trait PostErasure extends InfoTransform with TypingTransformers {
   object elimErasedValueType extends TypeMap {
     def apply(tp: Type) = tp match {
       case ConstantType(Constant(tp: Type)) => ConstantType(Constant(apply(tp)))
-      case ErasedValueType(tref)            => enteringErasure(erasure.erasedValueClassArg(tref))
+      case ErasedValueType(_, underlying)   => underlying
       case _                                => mapOver(tp)
     }
   }

--- a/src/reflect/scala/reflect/internal/Constants.scala
+++ b/src/reflect/scala/reflect/internal/Constants.scala
@@ -223,7 +223,15 @@ trait Constants extends api.Constants {
         case ClazzTag  =>
           def show(tpe: Type) = "classOf[" + signature(tpe) + "]"
           typeValue match {
-            case ErasedValueType(orig) => show(orig)
+            case ErasedValueType(clazz, underlying) =>
+              // A note on tpe_* usage here:
+              //
+              // We've intentionally erased the type arguments to the value class so that different
+              // instantiations of a particular value class that erase to the same underlying type
+              // don't result in spurious bridges (e.g. run/t6385.scala). I don't think that matters;
+              // printing trees of `classOf[ValueClass[String]]` shows `classOf[ValueClass]` at phase
+              // erasure both before and after the use of `tpe_*` here.
+              show(clazz.tpe_*)
             case _ => show(typeValue)
           }
         case CharTag   => "'" + escapedChar(charValue) + "'"

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3341,18 +3341,25 @@ trait Types
   /** A temporary type representing the erasure of a user-defined value type.
    *  Created during phase erasure, eliminated again in posterasure.
    *
-   *  @param   original  The underlying type before erasure
+   *  SI-6385 Erasure's creation of bridges considers method signatures `exitingErasure`,
+   *          which contain `ErasedValueType`-s. In order to correctly consider the overriding
+   *          and overriden signatures as equivalent in `run/t6385.scala`, it is critical that
+   *          this type contains the erasure of the wrapped type, rather than the unerased type
+   *          of the value class itself, as was originally done.
+   *
+   *  @param   valueClazz        The value class symbol
+   *  @param   erasedUnderlying  The erased type of the unboxed value
    */
-  abstract case class ErasedValueType(original: TypeRef) extends UniqueType {
-    override def safeToString = "ErasedValueType("+original+")"
+  abstract case class ErasedValueType(valueClazz: Symbol, erasedUnderlying: Type) extends UniqueType {
+    override def safeToString = s"ErasedValueType($valueClazz, $erasedUnderlying)"
   }
 
-  final class UniqueErasedValueType(original: TypeRef) extends ErasedValueType(original)
+  final class UniqueErasedValueType(valueClazz: Symbol, erasedUnderlying: Type) extends ErasedValueType(valueClazz, erasedUnderlying)
 
   object ErasedValueType {
-    def apply(original: TypeRef): Type = {
-      assert(original.sym ne NoSymbol, "ErasedValueType over NoSymbol")
-      unique(new UniqueErasedValueType(original))
+    def apply(valueClazz: Symbol, erasedUnderlying: Type): Type = {
+      assert(valueClazz ne NoSymbol, "ErasedValueType over NoSymbol")
+      unique(new UniqueErasedValueType(valueClazz, erasedUnderlying))
     }
   }
 

--- a/src/reflect/scala/reflect/internal/transform/Erasure.scala
+++ b/src/reflect/scala/reflect/internal/transform/Erasure.scala
@@ -257,11 +257,11 @@ trait Erasure {
 
   /** This is used as the Scala erasure during the erasure phase itself
    *  It differs from normal erasure in that value classes are erased to ErasedValueTypes which
-   *  are then later converted to the underlying parameter type in phase posterasure.
+   *  are then later unwrapped to the underlying parameter type in phase posterasure.
    */
   object specialScalaErasure extends ScalaErasureMap {
     override def eraseDerivedValueClassRef(tref: TypeRef): Type =
-      ErasedValueType(tref)
+      ErasedValueType(tref.sym, erasedValueClassArg(tref))
   }
 
   object javaErasure extends JavaErasureMap

--- a/test/files/neg/t6260b.check
+++ b/test/files/neg/t6260b.check
@@ -1,0 +1,7 @@
+t6260b.scala:3: error: bridge generated for member method apply: ()X in <$anon: () => X>
+which overrides method apply: ()R in trait Function0
+clashes with definition of the member itself;
+both have erased type ()Object
+class Y { def f = new X("") or new X("") }
+                               ^
+one error found

--- a/test/files/neg/t6260b.scala
+++ b/test/files/neg/t6260b.scala
@@ -1,0 +1,3 @@
+
+class X(val value: Object) extends AnyVal { def or(alt: => X): X = this }
+class Y { def f = new X("") or new X("") }

--- a/test/files/neg/t6260c.check
+++ b/test/files/neg/t6260c.check
@@ -1,0 +1,7 @@
+t6260c.scala:4: error: bridge generated for member method f: ()Option[A] in class Bar1
+which overrides method f: ()A in class Foo1
+clashes with definition of the member itself;
+both have erased type ()Object
+         class Bar1[A] extends Foo1[Option[A]] { def f(): Option[A] = ??? }
+                                                     ^
+one error found

--- a/test/files/neg/t6260c.scala
+++ b/test/files/neg/t6260c.scala
@@ -1,0 +1,4 @@
+final class Option[+A](val value: A) extends AnyVal
+
+abstract class Foo1[A]                         { def f(): A }
+         class Bar1[A] extends Foo1[Option[A]] { def f(): Option[A] = ??? }

--- a/test/files/neg/t6385.check
+++ b/test/files/neg/t6385.check
@@ -1,7 +1,0 @@
-t6385.scala:12: error: bridge generated for member method x: ()C[T] in class C
-which overrides method x: ()C[T] in trait AA
-clashes with definition of the member itself;
-both have erased type ()Object
-   def x = this
-       ^
-one error found

--- a/test/files/pos/t6260a.scala
+++ b/test/files/pos/t6260a.scala
@@ -1,0 +1,15 @@
+final class Option[+A](val value: A) extends AnyVal
+
+// Was: sandbox/test.scala:21: error: bridge generated for member method f: ()Option[A] in class Bar
+//      which overrides method f: ()Option[A] in class Foo" 
+abstract class Foo[A]                { def f(): Option[A] }
+         class Bar[A] extends Foo[A] { def f(): Option[A] = ??? }
+
+// User reported this as erroneous but I couldn't reproduce with 2.10.{0,1,2,3}
+// https://issues.scala-lang.org/browse/SI-6260?focusedCommentId=64764&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-64764
+// I suspect he whittled down the example too far.
+class Wrapper(val value: Int) extends AnyVal
+abstract class Test { def check(the: Wrapper): Boolean }
+object T {
+  new Test { def check(the: Wrapper) = true }
+}

--- a/test/files/run/t6260b.scala
+++ b/test/files/run/t6260b.scala
@@ -1,0 +1,13 @@
+class C[A](val a: A) extends AnyVal
+
+class DD {
+  def foo(c: C[String]) = ()
+  def bar[A <: String](c: C[A]) = ()
+  def baz[A](c: C[A]) = ()
+}
+
+object Test extends App {
+  classOf[DD].getMethod("foo", classOf[String])
+  classOf[DD].getMethod("bar", classOf[String])
+  classOf[DD].getMethod("baz", classOf[Object])
+}

--- a/test/files/run/t6385.scala
+++ b/test/files/run/t6385.scala
@@ -1,8 +1,8 @@
-object N {
+object Test {
    def main(args: Array[String]) {
       val y: AA[Int] = C(2)
       val c: Int = y.x.y
-      println(c)
+      assert(c == 2)
    }
 }
 trait AA[T] extends Any {

--- a/test/pending/run/t5866b.scala
+++ b/test/pending/run/t5866b.scala
@@ -1,0 +1,17 @@
+class Foo(val d: Double) extends AnyVal {
+  override def toString = s"Foo($d)"
+}
+
+class Bar(val d: String) extends AnyVal {
+  override def toString = s"Foo($d)"
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val f: Foo = {val n: Any = null; n.asInstanceOf[Foo]}
+    println(f)
+
+    val b: Bar = {val n: Any = null; n.asInstanceOf[Bar]}
+    println(b)
+  }
+}


### PR DESCRIPTION
As Paul noted in the comments to SI-6260 (from which I mined some
test cases) "there is no possible basis for conflict here":

```
scala> class C[A](val a: Any) extends AnyVal
defined class C

scala> class B { def x[A](ca: C[A]) = () }
defined class B

scala> class D extends B { override def x[A](ca: C[A]) = () }
<console>:8: error: bridge generated for member method x: [A](ca: C[A])Unit in class D
which overrides method x: [A](ca: C[A])Unit in class B
clashes with definition of the member itself;
both have erased type (ca: Object)Unit
       class D extends B { override def x[A](ca: C[A]) = () }
                                        ^
```

What was happening?

Bridge computation compares `B#x` and `D#x` exitingErasure, which
results in comparing:

```
ErasedValueType(C[A(in B#x)]) =:= ErasedValueType(C[A(in D#x)])
```

These types were considered distinct (on the grounds of the unique
type hash consing), even though they have the same erasure and
involve the same value class.

That triggered creation of an bridge. After post-erasure eliminates
the `ErasedValuedType`s, we find that this marvel of enginineering is
bridges `(Object)Unit` right back onto itself. The previous
resolution of SI-6385 (d435f72e5fb7fe) was a test case that confirmed
that we detected the zero-length bridge and reported it nicely, which
happened after related work in SI-6260. But we can simply avoid
creating in it in the first place.

That's what this commit does. It does so by reducing the amount
of information carried in `ErasedValueType` to the bare minimum needed
during the erasure -> posterasure transition.

We need to know:
1. which value class wraps the value, so we can box and unbox
    as needed
2. the erasure of the underlying value, which will replace this
    type in post-erasure.

This construction means that the bridge above computation now
compares:

   ErasedValueType(C, Any) =:= ErasedValueType(C, Any])

I have included a test to show that:
- we don't incur any linkage or other runtime errors in the
  reported case (run/t6385.scala)
- a similar case compiles when the signatures align
  (pos/t6260a.scala), but does _not_ compile when the just
  erasures align (neg/t6260c.scala)
- polymorphic value classes continue to erase to the instantiated
  type of the unbox: (run/t6260b.scala)
- other cases in SI-6260 remains unsolved and indeed unsolvable
  without an overhaul of value classes: (neg/t6260b.scala)

In my travels I spotted a bug in corner case of null, asInstanceOf
and value classes, which I have described in a pending test.
