### PR TITLE
SI-7938 - parallel collections should use default ExecutionContext

### DIFF
--- a/src/library/scala/collection/parallel/package.scala
+++ b/src/library/scala/collection/parallel/package.scala
@@ -41,7 +41,7 @@ package object parallel {
 
   private[parallel] def outofbounds(idx: Int) = throw new IndexOutOfBoundsException(idx.toString)
 
-  private[parallel] def getTaskSupport: TaskSupport = new ForkJoinTaskSupport
+  private[parallel] def getTaskSupport: TaskSupport = new ExecutionContextTaskSupport
 
   val defaultTaskSupport: TaskSupport = getTaskSupport
 

--- a/test/files/scalacheck/Ctrie.scala
+++ b/test/files/scalacheck/Ctrie.scala
@@ -20,9 +20,9 @@ object Test extends Properties("concurrent.TrieMap") {
 
   /* generators */
 
-  val sizes = choose(0, 200000)
+  val sizes = choose(0, 50000)
 
-  val threadCounts = choose(2, 16)
+  val threadCounts = choose(2, 8)
 
   val threadCountsAndSizes = for {
     p <- threadCounts

--- a/test/files/scalacheck/parallel-collections/ParallelArrayCheck.scala
+++ b/test/files/scalacheck/parallel-collections/ParallelArrayCheck.scala
@@ -50,7 +50,7 @@ abstract class ParallelArrayCheck[T](tp: String) extends ParallelSeqCheck[T]("Pa
 }
 
 
-object IntParallelArrayCheck extends ParallelArrayCheck[Int]("Int") with IntSeqOperators with IntValues {
+class IntParallelArrayCheck(tasksupport: TaskSupport) extends ParallelArrayCheck[Int]("Int") with IntSeqOperators with IntValues {
   override def instances(vals: Seq[Gen[Int]]) = oneOf(super.instances(vals), sized { sz =>
     (0 until sz).toArray.toSeq
   }, sized { sz =>

--- a/test/files/scalacheck/parallel-collections/pc.scala
+++ b/test/files/scalacheck/parallel-collections/pc.scala
@@ -7,10 +7,13 @@ import org.scalacheck._
 import scala.collection.parallel._
 
 class ParCollProperties extends Properties("Parallel collections") {
-  /*   Collections   */
+  // parallel arrays with default task support
+  include(new mutable.IntParallelArrayCheck(defaultTaskSupport))
 
-  // parallel arrays
-  include(mutable.IntParallelArrayCheck)
+  // parallel arrays with thread pool executors
+  val ec = scala.concurrent.ExecutionContext.fromExecutor(java.util.concurrent.Executors.newFixedThreadPool(5))
+  val ectasks = new collection.parallel.ExecutionContextTaskSupport(ec)
+  include(new mutable.IntParallelArrayCheck(ectasks))
 
   // parallel ranges
   include(immutable.ParallelRangeCheck)


### PR DESCRIPTION
Parallel collections now use scala.concurrent ExecutionContext
by default.

Review by @retronym @phaller.
