### PR TITLE
WIP: compiler modules

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -276,6 +276,7 @@ TODO:
 
       <artifact:remoteRepository id="extra-repo" url="${extra.repo.url}"/>
 
+      <!-- TODO: delay until absolutely necessary to allow minimal build, also move out partest dependency from scaladoc -->
       <artifact:dependencies pathId="partest.classpath" filesetId="partest.fileset" versionsId="partest.versions">
         <!-- uncomment the following if you're deploying your own partest locally -->
         <!-- <localRepository path="${user.home}/.m2/repository"/> -->
@@ -586,8 +587,21 @@ TODO:
     <property name="reflect.skipPackages"          value="scala.reflect.macros.internal:scala.reflect.internal:scala.reflect.io"/>
 
     <property name="compiler.description"          value="Scala Compiler"/>
-    <property name="compiler.name"                 value="scala-compiler"/>
     <property name="compiler.docroot"              value="rootdoc.txt"/>
+
+    <property name="interactive.description"       value="Scala Interactive Compiler"   />
+    <property name="interactive.package"           value="modules." />
+    <property name="interactive.name"              value="scala-compiler-interactive"/>
+    <property name="interactive.namesuffix"        value="_${scala.binary.version}"/>
+    <property name="interactive.version"           value="${scala-compiler-interactive.version.number}"/>
+    <property name="interactive.targetjar"         value="scala-compiler-interactive_${scala.binary.version}-${scala-compiler-interactive.version.number}.jar"/>
+
+    <property name="scaladoc.description"          value="Scala Documentation Generator"/>
+    <property name="scaladoc.package"              value="modules." />
+    <property name="scaladoc.name"                 value="scala-compiler-doc"         />
+    <property name="scaladoc.namesuffix"           value="_${scala.binary.version}"/>
+    <property name="scaladoc.version"              value="${scala-compiler-doc.version.number}"/>
+    <property name="scaladoc.targetjar"            value="scala-compiler-doc_${scala.binary.version}-${scala-compiler-doc.version.number}.jar"/>
 
     <property name="actors.description"            value="Scala Actors Library"/>
 
@@ -636,7 +650,7 @@ TODO:
     </macrodef>
 
     <!-- projects without project-specific options: asm, forkjoin, manual, bin, repl -->
-    <for list="actors,compiler,continuations-library,continuations-plugin,library,parser-combinators,partest,partest-extras,partest-javaagent,reflect,scalap,swing,xml" param="project">
+    <for list="actors,compiler,interactive,scaladoc,continuations-library,continuations-plugin,library,parser-combinators,partest,partest-extras,partest-javaagent,reflect,scalap,swing,xml" param="project">
       <sequential>
         <!-- description is mandatory -->
         <init-project-prop project="@{project}" name="package"     default=""/>
@@ -779,7 +793,7 @@ TODO:
 
     <path id="quick.interactive.build.path">
       <path refid="quick.compiler.build.path"/>
-      <pathelement location="${build-quick.dir}/classes/scaladoc"/>
+      <!-- <pathelement location="${build-quick.dir}/classes/scaladoc"/> -->
       <pathelement location="${build-quick.dir}/classes/interactive"/>
     </path>
 
@@ -808,6 +822,7 @@ TODO:
       <pathelement location="${actors.jar}"/>
       <pathelement location="${reflect.jar}"/>
       <pathelement location="${compiler.jar}"/>
+      <pathelement location="${scaladoc.jar}"/>
       <pathelement location="${scalap.jar}"/>
       <path refid="repl.deps.classpath"/>
       <path refid="aux.libs"/>
@@ -826,11 +841,11 @@ TODO:
     <path id="pack.compiler.files">
       <fileset dir="${build-quick.dir}/classes/compiler"/>
       <fileset dir="${build-quick.dir}/classes/repl"/>
-      <fileset dir="${build-quick.dir}/classes/scaladoc"/>
-      <fileset dir="${build-quick.dir}/classes/interactive"/>
       <fileset dir="${asm-classes}"/>
     </path>
 
+    <path id="pack.scaladoc.files">   <fileset dir="${build-quick.dir}/classes/scaladoc"/> </path>
+    <path id="pack.interactive.files"><fileset dir="${build-quick.dir}/classes/interactive"/> </path>
     <path id="pack.swing.files">      <fileset dir="${build-quick.dir}/classes/swing"/> </path>
     <path id="pack.reflect.files">    <fileset dir="${build-quick.dir}/classes/reflect"/> </path>
     <path id="pack.continuations-plugin.files">    <fileset dir="${build-quick.dir}/classes/continuations-plugin"/> </path>
@@ -862,18 +877,22 @@ TODO:
     <path id="docs.library.build.path">               <path refid="quick.library.build.path"/>  </path>
     <path id="docs.reflect.build.path">               <path refid="quick.reflect.build.path"/>  </path>
     <path id="docs.compiler.build.path">              <path refid="quick.compiler.build.path"/> </path>
+    <path id="docs.scaladoc.build.path">              <path refid="quick.scaladoc.build.path"/> </path>
+    <path id="docs.interactive.build.path">           <path refid="quick.interactive.build.path"/> </path>
     <path id="docs.scalap.build.path">                <path refid="quick.scalap.build.path"/>   </path>
     <path id="docs.continuations-plugin.build.path">  <path refid="quick.continuations-plugin.build.path"/>  </path>
     <path id="docs.continuations-library.build.path"> <path refid="quick.continuations-plugin.build.path"/>  </path>
     <path id="docs.actors.build.path">                <path refid="quick.actors.build.path"/>   </path>
     <path id="docs.swing.build.path">                 <path refid="quick.swing.build.path"/>    </path>
 
-    <!-- run-time classpath for scaladoc: should be resolved through maven once it's an actual module -->
+    <!-- run-time classpath for scaladoc TODO: resolve through maven -->
     <path id="scaladoc.classpath">
       <path refid="external-modules-nocore"/>
       <pathelement location="${library.jar}"/>
       <pathelement location="${reflect.jar}"/>
       <pathelement location="${compiler.jar}"/>
+      <pathelement location="${interactive.jar}"/>
+      <pathelement location="${scaladoc.jar}"/>
       <pathelement location="${ant.jar}"/>
       <path refid="aux.libs"/>
     </path>
@@ -887,10 +906,8 @@ TODO:
 
     <!-- MISC -->
     <path id="sbt.compile.build.path">
-      <path refid="quick.compiler.build.path"/>
-      <pathelement location="${build-quick.dir}/classes/repl"/>
-      <pathelement location="${build-quick.dir}/classes/scaladoc"/>
-      <pathelement location="${build-quick.dir}/classes/interactive"/>
+      <path refid="scaladoc.classpath"/>
+      <!-- <pathelement location="${build-quick.dir}/classes/repl"/> TODO bring back when repl leaves compiler jar -->
       <pathelement location="${sbt.interface.jar}"/>
     </path>
 
@@ -905,10 +922,9 @@ TODO:
       <pathelement location="${reflect.jar}"/>
       <pathelement location="${compiler.jar}"/>
 
-      <!-- to test a quick build without packing, replace the above pathelements with:        (may need a little tweaking)
-      <path refid="quick.bin.tool.path">
-      <path refid="quick.interactive.build.path">
-      -->
+      <pathelement location="${scaladoc.jar}"/>
+      <pathelement location="${interactive.jar}"/>
+
 
       <!-- TODO: move scalap & actors out of repo -->
       <pathelement location="${scalap.jar}"/>
@@ -1348,6 +1364,8 @@ TODO:
     </sequential>
   </macrodef>
 
+
+
 <!-- ===========================================================================
                                   LOCAL REFERENCE BUILD (LOCKER)
 ============================================================================ -->
@@ -1454,7 +1472,7 @@ TODO:
 
   <target name="pack.reflect" depends="quick.reflect"> <staged-pack project="reflect"/> </target>
 
-  <target name="pack.comp"    depends="quick.comp, quick.scaladoc, quick.interactive, quick.repl, asm.done">
+  <target name="pack.comp"    depends="quick.comp, quick.repl, asm.done">
     <staged-pack project="compiler" manifest="${build-pack.dir}/META-INF/MANIFEST.MF">
       <pre> <!-- TODO the files copied here do not influence actuality of this target (nor does the manifest) -->
         <copy todir="${build-pack.dir}/lib">
@@ -1480,6 +1498,9 @@ TODO:
     </staged-pack>
   </target>
 
+  <target name="pack.scaladoc" depends="quick.scaladoc">       <staged-pack project="scaladoc"/> </target>
+  <target name="pack.interactive" depends="quick.interactive"> <staged-pack project="interactive"/> </target>
+
   <target name="pack.actors" depends="quick.actors"> <staged-pack project="actors"/> </target>
   <target name="pack.swing" if="has.java6" depends="quick.swing"> <staged-pack project="swing"/> </target>
 
@@ -1489,7 +1510,7 @@ TODO:
 
   <target name="pack.core" depends="pack.reflect, pack.comp, pack.lib"/>
 
-  <target name="pack.modules" depends="pack.core, pack.actors, pack.swing, pack.plugins, pack.scalap">
+  <target name="pack.modules" depends="pack.scaladoc, pack.interactive, pack.actors, pack.swing, pack.plugins, pack.scalap">
     <copy todir="${build-pack.dir}/lib">
       <path refid="external-modules-nocore" />
       <mapper type="flatten" />
@@ -1553,6 +1574,10 @@ TODO:
 <!-- ===========================================================================
                                   OSGi Artifacts
 ============================================================================ -->
+  <!-- This task takes the output of the pack stage and OSGi-fies the jars based on the bnd files in src/build/bnd
+       This means adding manifests and enforcing the Exports clauses (removing non-exported classes!)
+       These jars are then copied to the distribution and published to maven.
+  -->
   <macrodef name="make-bundle">
     <attribute name="project" />
     <element   name="srcs"        description="Sources for this bundle" optional="true" implicit="true"/>
@@ -1618,8 +1643,6 @@ TODO:
       <make-bundle project="compiler">
         <fileset dir="${src.dir}/compiler"/>
         <fileset dir="${src.dir}/repl"/>
-        <fileset dir="${src.dir}/scaladoc"/>
-        <fileset dir="${src.dir}/interactive"/>
       </make-bundle>
 
       <touch file="${build-osgi.dir}/bundles.core.complete" verbose="no"/>
@@ -1628,10 +1651,12 @@ TODO:
   </target>
 
   <target name="osgi.done" depends="pack.done, osgi.core">
-    <uptodate property="osgi.bundles.available" targetfile="${build-osgi.dir}/bundles.all.complete">
+    <uptodate property="osgi.all.bundles.available" targetfile="${build-osgi.dir}/bundles.all.complete">
       <srcfiles dir="${basedir}">
         <include name="build.xml"/>
         <include name="src/build/bnd/*.bnd"/>
+        <include name="${interactive.jar}"/>
+        <include name="${scaladoc.jar}"/>
         <include name="${actors.jar}"/>
         <include name="${continuations-plugin.jar}"/>
         <include name="${swing.jar}"/>
@@ -1640,9 +1665,20 @@ TODO:
       </srcfiles>
     </uptodate>
 
-    <if><not><isset property="osgi.bundles.available"/></not><then>
+    <if><not><isset property="osgi.all.bundles.available"/></not><then>
       <stopwatch name="osgi.all.timer"/>
 
+      <!-- TODO: refactor so that we can restrict exported packages to scala.tools.nsc.doc.*
+           move ant task, partest stuff to other jars,
+           and move scala.tools.nsc.ScalaDoc main class to scala.tools.nsc.doc -->
+      <make-bundle project="scaladoc">
+        <fileset dir="${src.dir}/scaladoc"/>
+      </make-bundle>
+
+      <!-- TODO: refactor so that we can restrict exported packages to scala.tools.nsc.interactive.* -->
+      <make-bundle project="interactive">
+        <fileset dir="${src.dir}/interactive"/>
+      </make-bundle>
 
       <make-bundle project="actors">
         <fileset dir="${src.dir}/actors"/>
@@ -1964,6 +2000,18 @@ TODO:
     </staged-docs>
   </target>
 
+  <target name="docs.scaladoc" depends="docs.start" unless="docs.skip">
+    <staged-docs project="scaladoc">
+      <include name="**/*.scala"/>
+    </staged-docs>
+  </target>
+
+  <target name="docs.interactive" depends="docs.start" unless="docs.skip">
+    <staged-docs project="interactive">
+      <include name="**/*.scala"/>
+    </staged-docs>
+  </target>
+
   <target name="docs.actors" depends="docs.start" unless="docs.skip">
     <staged-docs project="actors">
       <include name="**/*.scala"/>
@@ -2032,7 +2080,7 @@ TODO:
   </target>
 
   <target name="docs.core" depends="docs.lib, docs.reflect, docs.comp" unless="docs.skip"/>
-  <target name="docs.done" depends="docs.core, docs.actors, docs.swing, docs.scalap, docs.continuations-plugin, docs.continuations-library" unless="docs.skip"/>
+  <target name="docs.done" depends="docs.core, docs.scaladoc, docs.interactive, docs.actors, docs.swing, docs.scalap, docs.continuations-plugin, docs.continuations-library" unless="docs.skip"/>
 
 <!-- ===========================================================================
                                   DISTRIBUTION
@@ -2090,6 +2138,7 @@ TODO:
     <chmod perm="ugo+rx" file="${dist.dir}/bin/fsc"/>
     <chmod perm="ugo+rx" file="${dist.dir}/bin/scalap"/>
   </target>
+
 
   <target name="dist.doc" depends="dist.base, docs.done">
     <mkdir dir="${dist.dir}/doc/scala-devel-docs"/>
@@ -2251,6 +2300,8 @@ MAIN DISTRIBUTION PACKAGING
   </target>
 
   <target name="pack-maven.base" depends="pack-maven.core, osgi.done, docs.done">
+    <mvn-package project="interactive"/>
+    <mvn-package project="scaladoc"/>
     <mvn-package project="swing"/>
     <mvn-package project="actors"/>
     <mvn-package project="continuations-plugin"/>

--- a/build.xml
+++ b/build.xml
@@ -75,6 +75,14 @@ TODO:
   <target name="distpack-opt" description="Builds an optimised distribution."> <optimized name="distpack"/></target>
   <target name="distpack-maven-opt" description="Builds an optimised maven distribution."><optimized name="distpack-maven"/></target>
 
+  <!-- The IDE build requires actors/swing/continuations, so need to publish them during PR validation until they are modules -->
+  <target name="publish-opt-nodocs" description="Publishes Scala (optimized) without generating docs/testing (library/reflect/compiler/actors/swing/continuations).">
+    <antcall target="publish">
+      <param name="docs.skip" value="1"/>
+      <param name="scalac.args.optimise" value="-optimise"/>
+    </antcall>
+  </target>
+
   <target name="publish-core-opt-nodocs" description="Builds an untested, undocumented optimised core (library/reflect/compiler) and publishes to maven.">
     <antcall target="publish-core">
       <param name="docs.skip" value="1"/>

--- a/build.xml
+++ b/build.xml
@@ -269,7 +269,7 @@ TODO:
       </artifact:dependencies>
 
 
-      <artifact:remoteRepository id="sonatype-release" url="https://oss.sonatype.org/content/repositories/releases"/>
+      <artifact:remoteRepository id="extra-repo" url="${extra.repo.url}"/>
 
       <artifact:dependencies pathId="partest.classpath" filesetId="partest.fileset" versionsId="partest.versions">
         <!-- uncomment the following if you're deploying your own partest locally -->
@@ -277,7 +277,7 @@ TODO:
         <!-- so we don't have to wait for artifacts to synch to maven central
             (we don't distribute partest with Scala, so the risk of sonatype and maven being out of synch is irrelevant):
           -->
-        <artifact:remoteRepository refid="sonatype-release"/>
+        <artifact:remoteRepository refid="extra-repo"/>
         <dependency groupId="org.scala-lang.modules" artifactId="scala-partest_${scala.binary.version}" version="${partest.version.number}" />
       </artifact:dependencies>
       <copy-deps project="partest"/>
@@ -290,8 +290,7 @@ TODO:
       <!-- used by the test.osgi target to create osgi bundles for the xml, parser-combinator jars
            must specify sourcesFilesetId, javadocFilesetId to download these types of artifacts -->
       <artifact:dependencies pathId="external-modules.deps.classpath" sourcesFilesetId="external-modules.sources.fileset" javadocFilesetId="external-modules.javadoc.fileset">
-        <!-- sonatype is not enabled by default for modules to avoid a Scala release relying on a JAR that's not on maven (yet) -->
-        <!-- <artifact:remoteRepository refid="sonatype-release"/> -->
+        <artifact:remoteRepository refid="extra-repo"/>
         <dependency groupId="org.scala-lang.modules" artifactId="scala-xml_${scala.binary.version}" version="${scala-xml.version.number}"/>
         <dependency groupId="org.scala-lang.modules" artifactId="scala-parser-combinators_${scala.binary.version}" version="${scala-parser-combinators.version.number}"/>
       </artifact:dependencies>
@@ -363,6 +362,7 @@ TODO:
       <if><isset property="starr.use.released"/><then>
         <echo message="Using Scala ${starr.version} for STARR."/>
         <artifact:dependencies pathId="starr.core.path">
+          <artifact:remoteRepository refid="extra-repo"/>
           <dependency groupId="org.scala-lang" artifactId="scala-library" version="${starr.version}"/>
           <dependency groupId="org.scala-lang" artifactId="scala-reflect" version="${starr.version}"/>
           <dependency groupId="org.scala-lang" artifactId="scala-compiler" version="${starr.version}"/>

--- a/build.xml
+++ b/build.xml
@@ -533,6 +533,17 @@ TODO:
     <echo message="     OSGi version: ${osgi.version.number}" />
     <echo message="canonical version: ${version.number}" />
 
+    <echoproperties destfile="buildcharacter.properties">
+      <propertyset>
+        <propertyref regex="time.*" />
+        <propertyref regex="git.*" />
+        <propertyref name="java.vm.name" />
+        <propertyref regex=".*version.*" />
+        <propertyref regex="scalac.args.*" />
+        <propertyref name="scalacfork.jvmargs" />
+      </propertyset>
+    </echoproperties>
+
     <!-- validate version suffixes -->
     <if><equals arg1="${maven.version.suffix}" arg2="-SNAPSHOT"/><then>
       <condition property="version.suffixes.consistent"><and>

--- a/build.xml
+++ b/build.xml
@@ -561,6 +561,85 @@ TODO:
     <property name="forkjoin-classes" refid="forkjoin.classpath"/>
     <property name="asm-classes" refid="asm.classpath"/>
 
+    <!-- the following properties fully define staged-docs, staged-pack, make-bundle, copy-bundle and mvn-package for each of the projects -->
+    <property name="library.description"           value="Scala Standard Library"/>
+    <property name="library.docroot"               value="rootdoc.txt"/>
+    <property name="library.skipPackages"          value="scala.concurrent.impl"/>
+
+    <property name="reflect.description"           value="Scala Reflection Library"/>
+    <property name="reflect.skipPackages"          value="scala.reflect.macros.internal:scala.reflect.internal:scala.reflect.io"/>
+
+    <property name="compiler.description"          value="Scala Compiler"/>
+    <property name="compiler.name"                 value="scala-compiler"/>
+    <property name="compiler.docroot"              value="rootdoc.txt"/>
+
+    <property name="actors.description"            value="Scala Actors Library"/>
+
+    <property name="continuations-plugin.description"     value="Scala Delimited Continuations Compiler Plugin"/>
+    <property name="continuations-plugin.package"         value="plugins." />
+    <property name="continuations-plugin.dir"             value="plugins/"/>
+    <property name="continuations-plugin.name"            value="continuations"/>
+    <property name="continuations-plugin.targetdir"       value="misc/scala-devel/plugins"/>
+    <property name="continuations-plugin.srcdir"          value="continuations/plugin"/>
+
+    <property name="continuations-library.description" value="Scala Delimited Continuations Library"/>
+    <property name="continuations-library.srcdir"       value="continuations/library"/>
+
+    <property name="swing.description"             value="Scala Swing Library"/>
+
+    <property name="parser-combinators.description" value="Scala Parser Combinators Library"/>
+    <property name="parser-combinators.package"    value="modules."/>
+    <property name="parser-combinators.jar"        value="${scala-parser-combinators}"/>
+    <property name="parser-combinators.src"        value="false"/>
+    <property name="parser-combinators.srcjar"     value="${scala-parser-combinators-sources}"/>
+
+    <property name="xml.description"               value="Scala XML Library"/>
+    <property name="xml.package"                   value="modules."/>
+    <property name="xml.jar"                       value="${scala-xml}"/>
+    <property name="xml.src"                       value="false"/>
+    <property name="xml.srcjar"                    value="${scala-xml-sources}"/>
+
+    <property name="scalap.description"            value="Scala Bytecode Parser"/>
+    <property name="scalap.targetjar"              value="scalap.jar"/>
+
+    <property name="partest.description"           value="Scala Compiler Testing Tool"/>
+    <property name="partest-extras.description"    value="Scala Compiler Testing Tool (compiler-specific extras)"/>
+    <property name="partest-javaagent.description" value="Scala Compiler Testing Tool (compiler-specific java agent)"/>
+
+    <macrodef name="init-project-prop">
+      <attribute name="project" />
+      <attribute name="name" />
+      <attribute name="default" />
+      <sequential>
+        <local name="@{name}"/>
+
+        <if><not><isset property="@{project}.@{name}"/></not><then>
+          <property name="@{project}.@{name}" value="@{default}" />
+        </then></if>
+      </sequential>
+    </macrodef>
+
+    <!-- projects without project-specific options: asm, forkjoin, manual, bin, repl -->
+    <for list="actors,compiler,continuations-library,continuations-plugin,library,parser-combinators,partest,partest-extras,partest-javaagent,reflect,scalap,swing,xml" param="project">
+      <sequential>
+        <!-- description is mandatory -->
+        <init-project-prop project="@{project}" name="package"     default=""/>
+        <init-project-prop project="@{project}" name="dir"         default=""/>
+        <init-project-prop project="@{project}" name="name"        default="scala-@{project}"/>
+        <init-project-prop project="@{project}" name="namesuffix"  default=""/>
+        <init-project-prop project="@{project}" name="version"     default="${osgi.version.number}"/>
+        <init-project-prop project="@{project}" name="targetdir"   default="lib"/>
+        <init-project-prop project="@{project}" name="targetjar"   default="${@{project}.name}.jar"/>
+        <init-project-prop project="@{project}" name="jar"         default="${build-pack.dir}/${@{project}.targetdir}/${@{project}.targetjar}" />
+        <init-project-prop project="@{project}" name="docroot"     default="NOT SET"/>
+        <init-project-prop project="@{project}" name="skipPackages" default=""/>
+        <init-project-prop project="@{project}" name="srcdir"      default="@{project}"/>
+        <init-project-prop project="@{project}" name="src"         default="true"/>
+        <init-project-prop project="@{project}" name="srcjar"      default="${build-osgi.dir}/${@{project}.name}-src.jar"/>
+      </sequential>
+    </for>
+
+
     <!-- Compilers to use for the various stages.
 
       There must be a variable of the shape @{stage}.compiler.path  for all @{stage} in starr, locker, quick, strap.
@@ -591,7 +670,7 @@ TODO:
       There must be a variable of the shape @{stage}.@{project}.build.path
       for all @{stage} in locker, quick, strap
       and all @{project} in library, reflect, compiler
-        when stage is quick, @{project} also includes: actors, repl, swing, plugins, interactive, scaladoc, scalap
+        when stage is quick, @{project} also includes: actors, repl, swing, continuations-plugin, continuations-library, interactive, scaladoc, scalap
     -->
 
     <!-- LOCKER -->
@@ -649,7 +728,7 @@ TODO:
       <pathelement location="${build-quick.dir}/classes/swing"/>
     </path>
 
-    <path id="quick.plugins.build.path">
+    <path id="quick.continuations-plugin.build.path">
       <!-- plugins are run by locker compiler during quick stage,
       so must compile against the same classes the locker was compiled to
       -->
@@ -698,22 +777,22 @@ TODO:
 
     <!-- PACK -->
     <path id="pack.compiler.path">
-      <pathelement location="${build-pack.dir}/lib/scala-library.jar"/>
-      <pathelement location="${build-pack.dir}/lib/scala-reflect.jar"/>
-      <pathelement location="${build-pack.dir}/lib/scala-compiler.jar"/>
+      <pathelement location="${library.jar}"/>
+      <pathelement location="${reflect.jar}"/>
+      <pathelement location="${compiler.jar}"/>
       <pathelement location="${ant.jar}"/>
       <path refid="forkjoin.classpath"/>
       <path refid="aux.libs"/>
     </path>
 
     <path id="pack.bin.tool.path">
-      <pathelement location="${build-pack.dir}/lib/scala-library.jar"/>
-      <pathelement location="${build-pack.dir}/lib/scala-xml.jar"/>
-      <pathelement location="${build-pack.dir}/lib/scala-parser-combinators.jar"/>
-      <pathelement location="${build-pack.dir}/lib/scala-actors.jar"/>
-      <pathelement location="${build-pack.dir}/lib/scala-reflect.jar"/>
-      <pathelement location="${build-pack.dir}/lib/scala-compiler.jar"/>
-      <pathelement location="${build-pack.dir}/lib/scalap.jar"/>
+      <pathelement location="${library.jar}"/>
+      <pathelement location="${xml.jar}"/>
+      <pathelement location="${parser-combinators.jar}"/>
+      <pathelement location="${actors.jar}"/>
+      <pathelement location="${reflect.jar}"/>
+      <pathelement location="${compiler.jar}"/>
+      <pathelement location="${scalap.jar}"/>
       <path refid="repl.deps.classpath"/>
       <path refid="aux.libs"/>
     </path>
@@ -738,7 +817,7 @@ TODO:
 
     <path id="pack.swing.files">      <fileset dir="${build-quick.dir}/classes/swing"/> </path>
     <path id="pack.reflect.files">    <fileset dir="${build-quick.dir}/classes/reflect"/> </path>
-    <path id="pack.plugins.files">    <fileset dir="${build-quick.dir}/classes/continuations-plugin"/> </path>
+    <path id="pack.continuations-plugin.files">    <fileset dir="${build-quick.dir}/classes/continuations-plugin"/> </path>
     <path id="pack.scalap.files">     <fileset dir="${build-quick.dir}/classes/scalap"/>
                                       <fileset file="${src.dir}/scalap/decoder.properties"/> </path>
 
@@ -768,24 +847,24 @@ TODO:
     <path id="docs.reflect.build.path">               <path refid="quick.reflect.build.path"/>  </path>
     <path id="docs.compiler.build.path">              <path refid="quick.compiler.build.path"/> </path>
     <path id="docs.scalap.build.path">                <path refid="quick.scalap.build.path"/>   </path>
-    <path id="docs.continuations-plugin.build.path">  <path refid="quick.plugins.build.path"/>  </path>
-    <path id="docs.continuations-library.build.path"> <path refid="quick.plugins.build.path"/>  </path>
+    <path id="docs.continuations-plugin.build.path">  <path refid="quick.continuations-plugin.build.path"/>  </path>
+    <path id="docs.continuations-library.build.path"> <path refid="quick.continuations-plugin.build.path"/>  </path>
     <path id="docs.actors.build.path">                <path refid="quick.actors.build.path"/>   </path>
     <path id="docs.swing.build.path">                 <path refid="quick.swing.build.path"/>    </path>
 
     <!-- run-time classpath for scaladoc: should be resolved through maven once it's an actual module -->
     <path id="scaladoc.classpath">
       <path refid="external-modules-nocore"/>
-      <pathelement location="${build-pack.dir}/lib/scala-library.jar"/>
-      <pathelement location="${build-pack.dir}/lib/scala-reflect.jar"/>
-      <pathelement location="${build-pack.dir}/lib/scala-compiler.jar"/>
+      <pathelement location="${library.jar}"/>
+      <pathelement location="${reflect.jar}"/>
+      <pathelement location="${compiler.jar}"/>
       <pathelement location="${ant.jar}"/>
       <path refid="aux.libs"/>
     </path>
 
     <path id="manual.build.path">
       <path refid="external-modules-nocore"/> <!-- xml -->
-      <pathelement location="${build-pack.dir}/lib/scala-library.jar"/>
+      <pathelement location="${library.jar}"/>
       <pathelement location="${build.dir}/manmaker/classes"/>
       <path refid="aux.libs"/>  <!-- for ant -->
     </path>
@@ -806,9 +885,9 @@ TODO:
         Why, the compiler we're testing, of course, and partest with all its dependencies.
     -->
     <path id="partest.compilation.path">
-      <pathelement location="${build-pack.dir}/lib/scala-library.jar"/>
-      <pathelement location="${build-pack.dir}/lib/scala-reflect.jar"/>
-      <pathelement location="${build-pack.dir}/lib/scala-compiler.jar"/>
+      <pathelement location="${library.jar}"/>
+      <pathelement location="${reflect.jar}"/>
+      <pathelement location="${compiler.jar}"/>
 
       <!-- to test a quick build without packing, replace the above pathelements with:        (may need a little tweaking)
       <path refid="quick.bin.tool.path">
@@ -816,16 +895,16 @@ TODO:
       -->
 
       <!-- TODO: move scalap & actors out of repo -->
-      <pathelement location="${build-pack.dir}/lib/scalap.jar"/>
-      <pathelement location="${build-pack.dir}/lib/scala-actors.jar"/>
+      <pathelement location="${scalap.jar}"/>
+      <pathelement location="${actors.jar}"/>
 
       <!-- partest dependencies, without the jars we built locally
            TODO: figure out why scalap tests fail if we move this up-->
       <path refid="partest-deps-nocore"/>
 
       <!-- partest classes specific to the core compiler build -->
-      <pathelement location="${build-pack.dir}/lib/scala-partest-extras.jar"/>
-      <pathelement location="${build-pack.dir}/lib/scala-partest-javaagent.jar"/>
+      <pathelement location="${partest-extras.jar}"/>
+      <pathelement location="${partest-javaagent.jar}"/>
 
       <!-- sneaky extras used in tests -->
       <fileset dir="${partest.dir}/files/lib" includes="*.jar" />
@@ -1032,7 +1111,7 @@ TODO:
            would use it for locker but something is iffy in sbt: get a class cast error on global phase -->
       <if><and> <available file="tools/zinc"/>
                 <equals arg1="@{stage}" arg2="quick"/>
-                <not><equals arg1="@{project}" arg2="plugins"/></not> <!-- doesn't work in zinc because it requires the quick compiler, which isn't jarred up-->
+                <not><equals arg1="@{project}" arg2="continuations-plugins"/></not> <!-- doesn't work in zinc because it requires the quick compiler, which isn't jarred up-->
           </and><then>
         <zinc taskname="Z.@{stage}.@{project}"
           compilerpathref="@{with}.compiler.path"
@@ -1164,31 +1243,30 @@ TODO:
 
   <macrodef name="staged-pack">
     <attribute name="project"/>
-    <attribute name="targetdir" default="lib"/>
-    <attribute name="targetjar" default="scala-@{project}.jar"/>
-    <attribute name="destfile"  default="${build-pack.dir}/@{targetdir}/@{targetjar}"/>
     <attribute name="manifest"  default=""/>
     <element name="pre"         optional="true"/>
     <element name="jar-opts"    optional="true"/>
 
     <sequential>
-      <uptodate property="pack.@{project}.available" targetfile="@{destfile}">
+      <local name="destfile"/> <property name="destfile"  value="${build-pack.dir}/${@{project}.targetdir}/${@{project}.targetjar}"/>
+
+      <uptodate property="pack.@{project}.available" targetfile="${destfile}">
         <srcresources>
           <resources refid="pack.@{project}.files"/>
           <!-- <path><pathelement location="${build-quick.dir}/@{project}.complete"/></path> -->
         </srcresources>
       </uptodate>
       <if><not><isset property="pack.@{project}.available"/></not><then>
-        <mkdir dir="${build-pack.dir}/@{targetdir}"/>
+        <mkdir dir="${build-pack.dir}/${@{project}.targetdir}"/>
         <pre/>
 
         <if><not><equals arg1="@{manifest}" arg2=""/></not><then>
-          <jar whenmanifestonly="fail" destfile="@{destfile}" manifest="@{manifest}"> <!-- update="true" makes no difference on my machine, so starting from scratch-->
+          <jar whenmanifestonly="fail" destfile="${destfile}" manifest="@{manifest}"> <!-- update="true" makes no difference on my machine, so starting from scratch-->
             <jar-opts/>
             <path refid="pack.@{project}.files"/>
           </jar></then>
         <else>
-          <jar whenmanifestonly="fail" destfile="@{destfile}">
+          <jar whenmanifestonly="fail" destfile="${destfile}">
             <jar-opts/>
             <path refid="pack.@{project}.files"/>
           </jar>
@@ -1199,28 +1277,24 @@ TODO:
 
   <macrodef name="staged-docs">
     <attribute name="project"/>
-    <attribute name="dir" default="@{project}"/>
-    <attribute name="title"/>
-    <attribute name="docroot" default="NOT SET"/>
-    <attribute name="skipPackages" default=""/>
 
     <element name="includes" implicit="true"/>
 
     <sequential>
       <staged-uptodate stage="docs" project="@{project}">
-        <check><srcfiles dir="${src.dir}/@{dir}"/></check>
+        <check><srcfiles dir="${src.dir}/${@{project}.srcdir}"/></check>
         <do>
           <stopwatch name="docs.@{project}.timer"/>
           <mkdir dir="${build-docs.dir}/@{project}"/>
-          <if><equals arg1="@{docroot}" arg2="NOT SET"/><then>
+          <if><equals arg1="${@{project}.docroot}" arg2="NOT SET"/><then>
             <scaladoc
               destdir="${build-docs.dir}/@{project}"
-              doctitle="@{title}"
+              doctitle="${@{project}.description}"
               docfooter="epfl"
               docversion="${version.number}"
               sourcepath="${src.dir}"
               classpathref="docs.@{project}.build.path"
-              srcdir="${src.dir}/@{dir}"
+              srcdir="${src.dir}/${@{project}.srcdir}"
               addparams="${scalac.args.all}"
               implicits="on"
               diagrams="on"
@@ -1228,19 +1302,19 @@ TODO:
               rawOutput="${scaladoc.raw.output}"
               noPrefixes="${scaladoc.no.prefixes}"
               docUncompilable="${src.dir}/library-aux"
-              skipPackages="@{skipPackages}">
+              skipPackages="${@{project}.skipPackages}">
               <includes/>
             </scaladoc>
           </then><else>
             <scaladoc
               destdir="${build-docs.dir}/@{project}"
-              doctitle="@{title}"
+              doctitle="${@{project}.description}"
               docfooter="epfl"
               docversion="${version.number}"
               sourcepath="${src.dir}"
               classpathref="docs.@{project}.build.path"
-              srcdir="${src.dir}/@{dir}"
-              docRootContent="${src.dir}/@{project}/@{docroot}"
+              srcdir="${src.dir}/${@{project}.srcdir}"
+              docRootContent="${src.dir}/@{project}/${@{project}.docroot}"
               addparams="${scalac.args.all}"
               implicits="on"
               diagrams="on"
@@ -1248,7 +1322,7 @@ TODO:
               rawOutput="${scaladoc.raw.output}"
               noPrefixes="${scaladoc.no.prefixes}"
               docUncompilable="${src.dir}/library-aux"
-              skipPackages="@{skipPackages}">
+              skipPackages="${@{project}.skipPackages}">
               <includes/>
             </scaladoc>
           </else></if>
@@ -1321,28 +1395,28 @@ TODO:
 
 
   <target name="quick.plugins"    depends="quick.comp">
-    <staged-uptodate              stage="quick" project="plugins">
+    <staged-uptodate              stage="quick" project="continuations-plugin">
       <check><srcfiles dir="${src.dir}/continuations"/></check>
       <do>
-        <stopwatch name="quick.plugins.timer"/>
+        <stopwatch name="quick.continuations-plugin.timer"/>
 
         <mkdir dir="${build-quick.dir}/classes/continuations-plugin"/>
-        <staged-scalac with="locker" stage="quick" project="plugins" srcdir="continuations/plugin" destproject="continuations-plugin"/>
+        <staged-scalac with="locker" stage="quick" project="continuations-plugin" srcdir="${continuations-plugin.srcdir}"/>
         <copy
-           file="${src.dir}/continuations/plugin/scalac-plugin.xml"
+           file="${src.dir}/${continuations-plugin.srcdir}/scalac-plugin.xml"
            todir="${build-quick.dir}/classes/continuations-plugin"/>
 
         <!-- not very nice to create jar here but needed to load plugin -->
-        <mkdir dir="${build-quick.dir}/misc/scala-devel/plugins"/>
-        <jar whenmanifestonly="fail" destfile="${build-quick.dir}/misc/scala-devel/plugins/continuations.jar" basedir="${build-quick.dir}/classes/continuations-plugin"/>
+        <mkdir dir="${build-quick.dir}/${continuations-plugin.targetdir}"/>
+        <jar whenmanifestonly="fail" destfile="${build-quick.dir}/${continuations-plugin.targetdir}/continuations.jar" basedir="${build-quick.dir}/classes/continuations-plugin"/>
 
         <!-- might split off library part into its own ant target -->
         <mkdir dir="${build-quick.dir}/classes/continuations-library"/>
-        <staged-scalac with="locker" stage="quick" project="plugins"
+        <staged-scalac with="locker" stage="quick" project="continuations-plugin"
                        srcdir="continuations/library" destproject="continuations-library"
-                       args="-Xplugin-require:continuations -P:continuations:enable -Xpluginsdir ${build-quick.dir}/misc/scala-devel/plugins"/>
+                       args="-Xplugin-require:continuations -P:continuations:enable -Xpluginsdir ${build-quick.dir}/${continuations-plugin.targetdir}"/>
 
-        <stopwatch name="quick.plugins.timer" action="total"/>
+        <stopwatch name="quick.continuations-plugin.timer" action="total"/>
       </do>
     </staged-uptodate>
   </target>
@@ -1393,9 +1467,9 @@ TODO:
   <target name="pack.actors" depends="quick.actors"> <staged-pack project="actors"/> </target>
   <target name="pack.swing" if="has.java6" depends="quick.swing"> <staged-pack project="swing"/> </target>
 
-  <target name="pack.plugins"    depends="quick.plugins">    <staged-pack project="plugins"    targetdir="misc/scala-devel/plugins" targetjar="continuations.jar"/> </target>
+  <target name="pack.plugins"    depends="quick.plugins">    <staged-pack project="continuations-plugin"/> </target>
 
-  <target name="pack.scalap"     depends="quick.scalap">     <staged-pack project="scalap"     targetjar="scalap.jar"/> </target>
+  <target name="pack.scalap"     depends="quick.scalap">     <staged-pack project="scalap"/> </target>
 
   <target name="pack.core" depends="pack.reflect, pack.comp, pack.lib"/>
 
@@ -1464,47 +1538,42 @@ TODO:
                                   OSGi Artifacts
 ============================================================================ -->
   <macrodef name="make-bundle">
-    <attribute name="name" />
-    <attribute name="bundleName"   description="A value for Bundle-Name, usually a textual description"/>
-    <attribute name="jar" default="${build-pack.dir}/lib/@{name}.jar" />
-    <element   name="srcs" description="Sources for this bundle" optional="true" implicit="true"/>
-    <attribute name="src" default="true"/>
-    <attribute name="version" default="${osgi.version.number}"/>
-    <attribute name="namesuffix" default=""/>
-    <attribute name="pkg" default=""/>
+    <attribute name="project" />
+    <element   name="srcs"        description="Sources for this bundle" optional="true" implicit="true"/>
 
     <sequential>
-      <copy file="${src.dir}/build/bnd/@{name}.bnd" tofile="${build-osgi.dir}/@{name}.bnd" overwrite="true">
+      <copy file="${src.dir}/build/bnd/${@{project}.name}.bnd" tofile="${build-osgi.dir}/${@{project}.name}.bnd" overwrite="true">
         <filterset>
           <filter token="VERSION" value="${osgi.version.number}" />
           <filter token="SCALA_BINARY_VERSION" value="${scala.binary.version}" />
+          <filter token="SCALA_COMPILER_DOC_VERSION" value="${scala-compiler-doc.version.number}" />
+          <filter token="SCALA_COMPILER_INTERACTIVE_VERSION" value="${scala-compiler-interactive.version.number}" />
         </filterset>
       </copy>
-      <bnd classpath="@{jar}"
+      <bnd classpath="${@{project}.jar}"
            eclipse="false"
            failok="false"
            exceptions="true"
-           files="${build-osgi.dir}/@{name}.bnd"
+           files="${build-osgi.dir}/${@{project}.name}.bnd"
            output="${build-osgi.dir}"/>
-      <if><equals arg1="@{src}" arg2="true"/><then>
+      <if><equals arg1="${@{project}.src}" arg2="true"/><then>
         <!--
              A jar-like task that creates an OSGi source bundle. It adds the required MANIFEST.MF headers that allow
              Eclipse to match sources with the corresponding binaries.
         -->
-          <jar whenmanifestonly="fail" destfile="${build-osgi.dir}/@{name}-src.jar">
+          <jar whenmanifestonly="fail" destfile="${build-osgi.dir}/${@{project}.name}-src.jar">
             <srcs/>
             <manifest>
               <attribute name="Manifest-Version" value="1.0"/>
-              <attribute name="Bundle-Name" value="@{bundleName} Sources"/>
-              <attribute name="Bundle-SymbolicName" value="org.scala-lang.@{pkg}@{name}@{namesuffix}.source"/>
-              <attribute name="Bundle-Version" value="@{version}"/>
-              <attribute name="Eclipse-SourceBundle" value="org.scala-lang.@{pkg}@{name}@{namesuffix};version=&quot;@{version}&quot;;roots:=&quot;.&quot;" />
+              <attribute name="Bundle-Name" value="${@{project}.description} Sources"/>
+              <attribute name="Bundle-SymbolicName" value="org.scala-lang.${@{project}.package}${@{project}.name}${@{project}.namesuffix}.source"/>
+              <attribute name="Bundle-Version" value="${@{project}.version}"/>
+              <attribute name="Eclipse-SourceBundle" value="org.scala-lang.${@{project}.package}${@{project}.name}${@{project}.namesuffix};version=&quot;${@{project}.version}&quot;;roots:=&quot;.&quot;" />
             </manifest>
           </jar>
       </then></if>
     </sequential>
   </macrodef>
-
 
   <target name="osgi.core" depends="pack.core">
     <mkdir dir="${build-osgi.dir}"/>
@@ -1513,24 +1582,24 @@ TODO:
       <srcfiles dir="${basedir}">
         <include name="build.xml"/>
         <include name="src/build/bnd/*.bnd"/>
-        <include name="${build-pack.dir}/lib/scala-library.jar"/>
-        <include name="${build-pack.dir}/lib/scala-reflect.jar"/>
-        <include name="${build-pack.dir}/lib/scala-compiler.jar"/>
+        <include name="${library.jar}"/>
+        <include name="${reflect.jar}"/>
+        <include name="${compiler.jar}"/>
       </srcfiles>
     </uptodate>
 
     <if><not><isset property="osgi.bundles.available"/></not><then>
       <stopwatch name="osgi.core.timer"/>
-      <make-bundle name="scala-library" bundleName="Scala Library">
+      <make-bundle project="library">
         <fileset dir="${src.dir}/library"/>
         <fileset dir="${src.dir}/continuations/library"/>
       </make-bundle>
 
-      <make-bundle name="scala-reflect" bundleName="Scala Reflect">
+      <make-bundle project="reflect">
         <fileset dir="${src.dir}/reflect"/>
       </make-bundle>
 
-      <make-bundle name="scala-compiler" bundleName="Scala Compiler">
+      <make-bundle project="compiler">
         <fileset dir="${src.dir}/compiler"/>
         <fileset dir="${src.dir}/repl"/>
         <fileset dir="${src.dir}/scaladoc"/>
@@ -1547,11 +1616,11 @@ TODO:
       <srcfiles dir="${basedir}">
         <include name="build.xml"/>
         <include name="src/build/bnd/*.bnd"/>
-        <include name="${build-pack.dir}/lib/scala-actors.jar"/>
-        <include name="${build-pack.dir}/misc/scala-devel/plugins/continuations.jar"/>
-        <include name="${build-pack.dir}/lib/scala-swing.jar"/>
-        <include name="${scala-parser-combinators}"/>
-        <include name="${scala-xml}"/>
+        <include name="${actors.jar}"/>
+        <include name="${continuations-plugin.jar}"/>
+        <include name="${swing.jar}"/>
+        <include name="${parser-combinators.jar}"/>
+        <include name="${xml.jar}"/>
       </srcfiles>
     </uptodate>
 
@@ -1559,22 +1628,22 @@ TODO:
       <stopwatch name="osgi.all.timer"/>
 
 
-      <make-bundle name="scala-actors" bundleName="Scala Actors">
+      <make-bundle project="actors">
         <fileset dir="${src.dir}/actors"/>
       </make-bundle>
 
-      <make-bundle name="continuations" pkg="plugins." jar="${build-pack.dir}/misc/scala-devel/plugins/continuations.jar" bundleName="Scala Continuations Plugin">
-        <fileset dir="${src.dir}/continuations/plugin"/>
+      <make-bundle project="continuations-plugin">
+        <fileset dir="${src.dir}/${continuations-plugin.srcdir}"/>
       </make-bundle>
 
       <if><isset property="has.java6"/><then>
-        <make-bundle name="scala-swing" version="${osgi.version.number}" bundleName="Scala Swing">
+        <make-bundle project="swing">
           <fileset dir="${src.dir}/swing"/>
         </make-bundle>
       </then></if>
 
-      <make-bundle name="scala-parser-combinators" pkg="modules." jar="${scala-parser-combinators}" src="false" bundleName="Scala Parser Combinators"/>
-      <make-bundle name="scala-xml" pkg="modules." jar="${scala-xml}" src="false" bundleName="Scala XML"/>
+      <make-bundle project="parser-combinators"/>
+      <make-bundle project="xml"/>
 
       <touch file="${build-osgi.dir}/bundles.all.complete" verbose="no"/>
       <stopwatch name="osgi.all.timer" action="total"/>
@@ -1740,7 +1809,7 @@ TODO:
 
   <target name="test.continuations.suite" depends="test.suite.init">
     <testSuite kinds="continuations-neg continuations-run"
-          scalacOpts="${scalac.args.optimise} -Xpluginsdir ${build-quick.dir}/misc/scala-devel/plugins -Xplugin-require:continuations -P:continuations:enable"
+          scalacOpts="${scalac.args.optimise} -Xpluginsdir ${build-quick.dir}/${continuations-plugin.targetdir} -Xplugin-require:continuations -P:continuations:enable"
     />
   </target>
 
@@ -1804,17 +1873,17 @@ TODO:
   </macrodef>
 
   <macrodef name="bc.check">
-    <attribute name="jar-name"/>
+    <attribute name="project"/>
     <sequential>
         <bc.run-mima
-                jar-name="@{jar-name}"
-                prev="${org.scala-lang:@{jar-name}:jar}"
-                curr="${build-pack.dir}/lib/@{jar-name}.jar"
+                jar-name="scala-@{project}"
+                prev="${org.scala-lang:scala-@{project}:jar}"
+                curr="${@{name}.jar}"
                 direction="backward"/>
         <bc.run-mima
-                jar-name="@{jar-name}"
-                prev="${build-pack.dir}/lib/@{jar-name}.jar"
-                curr="${org.scala-lang:@{jar-name}:jar}"
+                jar-name="scala-@{project}"
+                prev="${@{name}.jar}"
+                curr="${org.scala-lang:scala-@{project}:jar}"
                 direction="forward"/>
     </sequential>
   </macrodef>
@@ -1824,9 +1893,9 @@ TODO:
   <!-- Enable after the release of the 2.11.0 or a prior RC that estabilishes the new baseline. -->
   <target name="test.bc"></target>
   <target name="test.bc.disabled" depends="bc.init, pack.lib, pack.reflect, pack.swing">
-    <bc.check jar-name="scala-library"/>
-    <bc.check jar-name="scala-reflect"/>
-    <bc.check jar-name="scala-swing"/>
+    <bc.check project="library"/>
+    <bc.check project="reflect"/>
+    <bc.check project="swing"/>
   </target>
 
 <!-- ===========================================================================
@@ -1854,8 +1923,7 @@ TODO:
   </target>
 
   <target name="docs.lib" depends="docs.start" unless="docs.skip">
-    <staged-docs project="library" title="Scala Standard Library" docroot="rootdoc.txt"
-                 skipPackages="scala.concurrent.impl">
+    <staged-docs project="library">
       <include name="**/*.scala"/>
       <exclude name="runtime/*$.scala"/>
       <exclude name="runtime/ScalaRunTime.scala"/>
@@ -1864,8 +1932,7 @@ TODO:
   </target>
 
   <target name="docs.reflect" depends="docs.start" unless="docs.skip">
-    <staged-docs project="reflect" title="Scala Reflection Library"
-                 skipPackages="scala.reflect.macros.internal:scala.reflect.internal:scala.reflect.io">
+    <staged-docs project="reflect">
       <include name="**/*.scala"/>
       <exclude name="reflect/Code.scala"/>
       <exclude name="reflect/Print.scala"/>
@@ -1876,37 +1943,37 @@ TODO:
   </target>
 
   <target name="docs.comp" depends="docs.start" unless="docs.skip">
-    <staged-docs project="compiler" title="Scala Compiler" docroot="rootdoc.txt">
+    <staged-docs project="compiler">
       <include name="**/*.scala"/>
     </staged-docs>
   </target>
 
   <target name="docs.actors" depends="docs.start" unless="docs.skip">
-    <staged-docs project="actors" title="Scala Actors Library">
+    <staged-docs project="actors">
       <include name="**/*.scala"/>
     </staged-docs>
   </target>
 
   <target name="docs.swing" depends="docs.start" unless="docs.skip">
-    <staged-docs project="swing" title="Scala Swing Library">
+    <staged-docs project="swing">
       <include name="**/*.scala"/>
     </staged-docs>
   </target>
 
   <target name="docs.scalap" depends="docs.start" unless="docs.skip">
-    <staged-docs project="scalap" title="Scalap">
+    <staged-docs project="scalap">
       <include name="**/*.scala"/>
     </staged-docs>
   </target>
 
   <target name="docs.continuations-plugin" depends="docs.start" unless="docs.skip">
-    <staged-docs project="continuations-plugin" dir="continuations/plugin" title="Delimited Continuations Compiler Plugin">
+    <staged-docs project="continuations-plugin">
       <include name="**/*.scala"/>
     </staged-docs>
   </target>
 
   <target name="docs.continuations-library" depends="docs.start" unless="docs.skip">
-    <staged-docs project="continuations-library" dir="continuations/library" title="Delimited Continuations Library">
+    <staged-docs project="continuations-library">
       <include name="**/*.scala"/>
     </staged-docs>
   </target>
@@ -1959,19 +2026,16 @@ TODO:
     <property name="dist.dir" value="${dists.dir}/${dist.name}"/>
 
     <macrodef name="copy-bundle">
-      <attribute name="name" />
-      <attribute name="pkg"    default=""/>
-      <attribute name="lib"    default="lib/"/>
-      <attribute name="srcjar" default="${build-osgi.dir}/@{name}-src.jar"/>
+      <attribute name="project" />
 
       <sequential>
-        <copy tofile="${dist.dir}/@{lib}@{name}.jar"   file="${build-osgi.dir}/org.scala-lang.@{pkg}@{name}.jar" overwrite="true"/>
-        <copy tofile="${dist.dir}/src/@{name}-src.jar" file="@{srcjar}" overwrite="true"/>
+        <copy tofile="${dist.dir}/${@{project}.targetdir}/${@{project}.name}.jar"   file="${build-osgi.dir}/org.scala-lang.${@{project}.package}${@{project}.name}.jar" overwrite="true"/>
+        <copy tofile="${dist.dir}/src/${@{project}.name}-src.jar" file="${@{project}.srcjar}" overwrite="true"/>
       </sequential>
     </macrodef>
 
     <mkdir dir="${dist.dir}/lib"/>
-    <mkdir dir="${dist.dir}/misc/scala-devel/plugins"/>
+    <mkdir dir="${dist.dir}/${continuations-plugin.targetdir}"/>
     <mkdir dir="${dist.dir}/src"/>
 
     <copy todir="${dist.dir}/lib" overwrite="true">
@@ -1981,16 +2045,16 @@ TODO:
     </copy>
 
     <!-- copy classfile jars and source jars from osgi build to dist -->
-    <copy-bundle name="scala-library"/>
-    <copy-bundle name="scala-reflect"/>
-    <copy-bundle name="scala-compiler"/>
+    <copy-bundle project="library"/>
+    <copy-bundle project="reflect"/>
+    <copy-bundle project="compiler"/>
 
-    <copy-bundle name="scala-swing"/>
-    <copy-bundle name="scala-actors"/>
+    <copy-bundle project="swing"/>
+    <copy-bundle project="actors"/>
 
-    <copy-bundle pkg="modules." name="scala-xml" srcjar="${scala-xml-sources}"/>
-    <copy-bundle pkg="modules." name="scala-parser-combinators" srcjar="${scala-parser-combinators-sources}"/>
-    <copy-bundle pkg="plugins." name="continuations" lib="misc/scala-devel/plugins/"/>
+    <copy-bundle project="xml"/>
+    <copy-bundle project="parser-combinators"/>
+    <copy-bundle project="continuations-plugin"/>
 
     <!-- scalap -->
     <copy toDir="${dist.dir}/lib" overwrite="true">
@@ -2143,19 +2207,15 @@ MAIN DISTRIBUTION PACKAGING
   </target>
 
   <macrodef name="mvn-package">
-    <attribute name="dir"    default=""/>
-    <attribute name="pkg"    default=""/>
     <attribute name="project"/>
-    <attribute name="name"   default="scala-@{project}"/>
-    <attribute name="jarsuffix" default=""/>
 
     <sequential>
-      <local name="artifact-base"/> <property name="artifact-base" value="${maven-base}/@{dir}@{name}/@{name}"/>
+      <local name="artifact-base"/> <property name="artifact-base" value="${maven-base}/${@{project}.dir}${@{project}.name}/${@{project}.name}"/>
 
-      <mkdir dir="${maven-base}/@{dir}@{name}"/>
-      <copy tofile="${artifact-base}.jar" file="${build-osgi.dir}/org.scala-lang.@{pkg}@{name}@{jarsuffix}.jar" overwrite="true"/>
-      <copy tofile="${artifact-base}-src.jar" file="${build-osgi.dir}/@{name}-src.jar" overwrite="true"/>
-      <copy tofile="${artifact-base}-pom.xml" file="${src.dir}/build/maven/@{dir}/@{name}-pom.xml" overwrite="true"/>
+      <mkdir dir="${maven-base}/${@{project}.dir}${@{project}.name}"/>
+      <copy tofile="${artifact-base}.jar" file="${build-osgi.dir}/org.scala-lang.${@{project}.package}${@{project}.name}${@{project}.namesuffix}.jar" overwrite="true"/>
+      <copy tofile="${artifact-base}-src.jar" file="${build-osgi.dir}/${@{project}.name}-src.jar" overwrite="true"/>
+      <copy tofile="${artifact-base}-pom.xml" file="${src.dir}/build/maven/${@{project}.dir}/${@{project}.name}-pom.xml" overwrite="true"/>
 
       <if><not><isset property="docs.skip"/></not><then>
         <jar destfile="${artifact-base}-docs.jar" basedir="${build-docs.dir}/@{project}" whenmanifestonly="fail">
@@ -2177,11 +2237,11 @@ MAIN DISTRIBUTION PACKAGING
   <target name="pack-maven.base" depends="pack-maven.core, osgi.done, docs.done">
     <mvn-package project="swing"/>
     <mvn-package project="actors"/>
-    <mvn-package project="continuations-plugin" name="continuations" dir="plugins/" pkg="plugins."/>
+    <mvn-package project="continuations-plugin"/>
 
     <!-- don't bother fitting scalap into the mould: it will move out soon -->
     <copy tofile="${maven-base}/scalap/scalap-pom.xml" file="${src.dir}/build/maven/scalap-pom.xml" overwrite="true"/>
-    <copy tofile="${maven-base}/scalap/scalap.jar" file="${build-pack.dir}/lib/scalap.jar" overwrite="true"/>
+    <copy tofile="${maven-base}/scalap/scalap.jar" file="${scalap.jar}" overwrite="true"/>
     <jar destfile="${maven-base}/scalap/scalap-src.jar" basedir="${src.dir}/scalap" whenmanifestonly="fail"/>
     <if><not><isset property="docs.skip"/></not><then>
       <jar destfile="${maven-base}/scalap/scalap-docs.jar" basedir="${build-docs.dir}/scalap"/>
@@ -2264,7 +2324,7 @@ MAIN DISTRIBUTION PACKAGING
   <target name="starr.start">
     <fail message="Library in build/pack not available">
       <condition><not><and>
-        <available file="${build-pack.dir}/lib/scala-library.jar"/>
+        <available file="${library.jar}"/>
       </and></not></condition>
     </fail>
     <fail message="Compiler in build/quick not available">

--- a/build.xml
+++ b/build.xml
@@ -75,11 +75,8 @@ TODO:
   <target name="distpack-opt" description="Builds an optimised distribution."> <optimized name="distpack"/></target>
   <target name="distpack-maven-opt" description="Builds an optimised maven distribution."><optimized name="distpack-maven"/></target>
 
-  <target name="publish-core-signed-opt" description="Builds an untested optimised core (library/reflect/compiler) and publishes to maven, signed.">
-    <optimized name="publish-core-signed"/>
-  </target>
-  <target name="publish-core-signed-opt-nodocs" description="Builds an untested, undocumented optimised core (library/reflect/compiler) and publishes to maven, signed.">
-    <antcall target="publish-core-signed">
+  <target name="publish-core-opt-nodocs" description="Builds an untested, undocumented optimised core (library/reflect/compiler) and publishes to maven.">
+    <antcall target="publish-core">
       <param name="docs.skip" value="1"/>
       <param name="scalac.args.optimise" value="-optimise"/>
     </antcall>
@@ -2320,10 +2317,9 @@ MAIN DISTRIBUTION PACKAGING
     <deploy-one dir="${maven-base}/" name="scala-library"  local="true"/>
     <deploy-one dir="${maven-base}/" name="scala-reflect"  local="true"/>
   </target>
-  <target name="publish-core-signed" depends="pack-maven.core, init.maven">
-    <deploy-one dir="${maven-base}/" name="scala-compiler" signed="true"/>
-    <deploy-one dir="${maven-base}/" name="scala-library"  signed="true"/>
-    <deploy-one dir="${maven-base}/" name="scala-reflect"  signed="true"/>
+
+  <target name="publish-core-opt" description="Builds an untested optimised core (library/reflect/compiler) and publishes to maven.">
+    <optimized name="publish-core"/>
   </target>
 
 <!-- ===========================================================================

--- a/dbuild-meta.json
+++ b/dbuild-meta.json
@@ -45,6 +45,24 @@
                     "extension": "jar",
                     "name": "scala-reflect",
                     "organization": "org.scala-lang"
+                }
+            ],
+            "name": "scala-compiler",
+            "organization": "org.scala-lang"
+        },
+        {
+            "artifacts": [
+                {
+                    "extension": "jar",
+                    "name": "scala-compiler-doc",
+                    "organization": "org.scala-lang.modules"
+                }
+            ],
+            "dependencies": [
+                {
+                    "extension": "jar",
+                    "name": "scala-compiler",
+                    "organization": "org.scala-lang"
                 },
                 {
                     "extension": "jar",
@@ -57,8 +75,26 @@
                     "organization": "org.scala-lang.modules"
                 }
             ],
-            "name": "scala-compiler",
-            "organization": "org.scala-lang"
+            "name": "scala-compiler-doc",
+            "organization": "org.scala-lang.modules"
+        },
+        {
+            "artifacts": [
+                {
+                    "extension": "jar",
+                    "name": "scala-compiler-interactive",
+                    "organization": "org.scala-lang.modules"
+                }
+            ],
+            "dependencies": [
+                {
+                    "extension": "jar",
+                    "name": "scala-compiler-doc",
+                    "organization": "org.scala-lang.modules"
+                }
+            ],
+            "name": "scala-compiler-interactive",
+            "organization": "org.scala-lang.modules"
         },
         {
             "artifacts": [

--- a/src/build/bnd/scala-compiler-doc.bnd
+++ b/src/build/bnd/scala-compiler-doc.bnd
@@ -1,0 +1,6 @@
+Bundle-Name: Scala Documentation Generator
+Bundle-SymbolicName: org.scala-lang.modules.scala-compiler-doc_@SCALA_BINARY_VERSION@
+ver: @SCALA_COMPILER_DOC_VERSION@
+Bundle-Version: ${ver}
+Export-Package: *;version=${ver}
+Import-Package: *

--- a/src/build/bnd/scala-compiler-interactive.bnd
+++ b/src/build/bnd/scala-compiler-interactive.bnd
@@ -1,0 +1,6 @@
+Bundle-Name: Scala Interactive Compiler
+Bundle-SymbolicName: org.scala-lang.modules.scala-compiler-interactive_@SCALA_BINARY_VERSION@
+ver: @SCALA_COMPILER_INTERACTIVE_VERSION@
+Bundle-Version: ${ver}
+Export-Package: *;version=${ver}
+Import-Package: *

--- a/src/build/bnd/scala-compiler.bnd
+++ b/src/build/bnd/scala-compiler.bnd
@@ -6,3 +6,5 @@ Export-Package: *;version=${ver}
 Import-Package: jline.*;resolution:=optional, \
                 org.apache.tools.ant.*;resolution:=optional, \
                 *
+Require-Bundle: org.scala-lang.modules.scala-compiler-interactive_@SCALA_BINARY_VERSION@;bundle-version=@SCALA_COMPILER_INTERACTIVE_VERSION@, \
+   org.scala-lang.modules.scala-compiler-doc_@SCALA_BINARY_VERSION@;bundle-version=@SCALA_COMPILER_DOC_VERSION@

--- a/src/build/maven/maven-deploy.xml
+++ b/src/build/maven/maven-deploy.xml
@@ -6,6 +6,46 @@
     SuperSabbus extension for deploying a distribution to Maven. THIS FILE IS MEANT TO BE RUN STANDALONE IN THE MAVEN "distpack" DIRECTORY
   </description>
 
+  <macrodef name="deploy-remote">
+    <attribute name="jar" default=""/>
+    <attribute name="pom"/>
+    <element name="artifacts" implicit="true" optional="true"/>
+    <sequential>
+      <artifact:deploy file="@{jar}" settingsFile="${settings.file}">
+        <artifact:remoteRepository url="${remote.repository}" id="${repository.credentials.id}" />
+        <artifact:pom refid="@{pom}" />
+        <artifacts/>
+      </artifact:deploy>
+    </sequential>
+  </macrodef>
+
+  <macrodef name="deploy-local">
+    <attribute name="jar" default=""/>
+    <attribute name="pom"/>
+    <element name="artifacts" implicit="true" optional="true"/>
+    <sequential>
+    <artifact:install file="@{jar}">
+      <artifact:localRepository path="${local.repository}"  id="${repository.credentials.id}" />
+      <artifact:pom refid="@{pom}" />
+      <artifacts/>
+    </artifact:install>
+    </sequential>
+  </macrodef>
+
+  <macrodef name="deploy-to">
+    <attribute name="jar" default=""/>
+    <attribute name="pom"/>
+    <attribute name="local"/>
+    <element name="artifacts" implicit="true" optional="true"/>
+    <sequential>
+      <if><equals arg1="@{local}" arg2="true"/><then>
+        <deploy-local jar="@{jar}" pom="@{pom}"> <artifacts/> </deploy-local>
+      </then><else>
+        <deploy-remote jar="@{jar}" pom="@{pom}"> <artifacts/> </deploy-remote>
+      </else></if>
+    </sequential>
+  </macrodef>
+
   <macrodef name="deploy-one">
     <attribute name="dir" default=""/>
     <attribute name="name" />
@@ -31,30 +71,15 @@
       <artifact:pom id="@{name}.pom" file="${path}-pom-filtered.xml" />
 
       <if><equals arg1="@{signed}" arg2="false"/><then>
-        <if><equals arg1="@{local}" arg2="false"/><then>
-          <artifact:deploy file="${path}.jar" settingsFile="${settings.file}">
-            <artifact:remoteRepository url="${remote.repository}" id="${repository.credentials.id}" />
-            <artifact:pom refid="@{name}.pom" />
+        <if><isset property="docs.skip"/><then>
+          <deploy-to local="@{local}" jar="${path}.jar" pom="@{name}.pom">
+            <artifact:attach type="jar" file="${path}-src.jar"  classifier="sources" />
+          </deploy-to>
+        </then><else>
+          <deploy-to local="@{local}" jar="${path}.jar" pom="@{name}.pom">
             <artifact:attach type="jar" file="${path}-src.jar"  classifier="sources" />
             <artifact:attach type="jar" file="${path}-docs.jar" classifier="javadoc" />
-          </artifact:deploy>
-        </then><else>
-          <if><isset property="docs.skip"/><then>
-             <artifact:install file="${path}.jar">
-               <artifact:localRepository path="${local.repository}"  id="${repository.credentials.id}" />
-               <artifact:pom refid="@{name}.pom" />
-               <artifact:attach type="jar" file="${path}-src.jar"  classifier="sources" />
-             </artifact:install>
-          </then>
-          <else>
-            <artifact:install file="${path}.jar">
-              <artifact:localRepository path="${local.repository}"  id="${repository.credentials.id}" />
-              <artifact:pom refid="@{name}.pom" />
-              <artifact:attach type="jar" file="${path}-src.jar"  classifier="sources" />
-              <artifact:attach type="jar" file="${path}-docs.jar" classifier="javadoc" />
-            </artifact:install>
-          </else>
-          </if>
+          </deploy-to>
         </else></if>
       </then><else>
         <local name="repo"/>

--- a/src/build/maven/maven-deploy.xml
+++ b/src/build/maven/maven-deploy.xml
@@ -63,6 +63,8 @@
           <filter token="SCALA_BINARY_VERSION" value="${scala.binary.version}" />
           <filter token="XML_VERSION" value="${scala-xml.version.number}" />
           <filter token="PARSER_COMBINATORS_VERSION" value="${scala-parser-combinators.version.number}" />
+          <filter token="SCALA_COMPILER_DOC_VERSION" value="${scala-compiler-doc.version.number}" />
+          <filter token="SCALA_COMPILER_INTERACTIVE_VERSION" value="${scala-compiler-interactive.version.number}" />
           <filter token="RELEASE_REPOSITORY" value="${remote.release.repository}" />
           <filter token="SNAPSHOT_REPOSITORY" value="${remote.snapshot.repository}" />
           <filter token="JLINE_VERSION" value="${jline.version}" />
@@ -112,6 +114,8 @@
       <deploy-one dir="@{dir}"          name="scala-library"     local="@{local}" signed="@{signed}"/>
       <deploy-one dir="@{dir}"          name="scala-reflect"     local="@{local}" signed="@{signed}"/>
       <deploy-one dir="@{dir}"          name="scala-compiler"    local="@{local}" signed="@{signed}"/>
+      <deploy-one dir="@{dir}"          name="scala-compiler-doc"         local="@{local}" signed="@{signed}"/>
+      <deploy-one dir="@{dir}"          name="scala-compiler-interactive" local="@{local}" signed="@{signed}"/>
       <deploy-one dir="@{dir}"          name="scala-actors"      local="@{local}" signed="@{signed}"/>
       <deploy-one dir="@{dir}"          name="scala-swing"       local="@{local}" signed="@{signed}"/>
       <deploy-one dir="@{dir}"          name="scalap"            local="@{local}" signed="@{signed}"/>

--- a/src/build/maven/scala-compiler-doc-pom.xml
+++ b/src/build/maven/scala-compiler-doc-pom.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.scala-lang</groupId>
-  <artifactId>scala-compiler</artifactId>
+  <groupId>org.scala-lang.modules</groupId>
+  <artifactId>scala-compiler-doc_@SCALA_BINARY_VERSION@</artifactId>
   <packaging>jar</packaging>
-  <version>@VERSION@</version>
-  <name>Scala Compiler</name>
-  <description>Compiler for the Scala Programming Language</description>
+  <version>@SCALA_COMPILER_DOC_VERSION@</version>
+  <name>Scala Documentation Generator</name>
+  <description>Documentation generator for the Scala Programming Language</description>
   <url>http://www.scala-lang.org/</url>
   <inceptionYear>2002</inceptionYear>
   <organization>
@@ -31,19 +31,18 @@
   <dependencies>
     <dependency>
       <groupId>org.scala-lang</groupId>
-      <artifactId>scala-library</artifactId>
+      <artifactId>scala-compiler</artifactId>
       <version>@VERSION@</version>
     </dependency>
     <dependency>
-      <groupId>org.scala-lang</groupId>
-      <artifactId>scala-reflect</artifactId>
-      <version>@VERSION@</version>
+      <groupId>org.scala-lang.modules</groupId>
+      <artifactId>scala-xml_@SCALA_BINARY_VERSION@</artifactId>
+      <version>@XML_VERSION@</version>
     </dependency>
-    <dependency> <!-- for repl -->
-      <groupId>jline</groupId>
-      <artifactId>jline</artifactId>
-      <version>@JLINE_VERSION@</version>
-      <optional>true</optional>
+    <dependency>
+      <groupId>org.scala-lang.modules</groupId>
+      <artifactId>scala-parser-combinators_@SCALA_BINARY_VERSION@</artifactId>
+      <version>@PARSER_COMBINATORS_VERSION@</version>
     </dependency>
   </dependencies>
   <distributionManagement>

--- a/src/build/maven/scala-compiler-interactive-pom.xml
+++ b/src/build/maven/scala-compiler-interactive-pom.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.scala-lang</groupId>
-  <artifactId>scala-compiler</artifactId>
+  <groupId>org.scala-lang.modules</groupId>
+  <artifactId>scala-compiler-interactive_@SCALA_BINARY_VERSION@</artifactId>
   <packaging>jar</packaging>
-  <version>@VERSION@</version>
-  <name>Scala Compiler</name>
-  <description>Compiler for the Scala Programming Language</description>
+  <version>@SCALA_COMPILER_INTERACTIVE_VERSION@</version>
+  <name>Scala Interactive Compiler</name>
+  <description>Interactive Compiler for the Scala Programming Language</description>
   <url>http://www.scala-lang.org/</url>
   <inceptionYear>2002</inceptionYear>
   <organization>
@@ -31,19 +31,8 @@
   <dependencies>
     <dependency>
       <groupId>org.scala-lang</groupId>
-      <artifactId>scala-library</artifactId>
+      <artifactId>scala-compiler</artifactId>
       <version>@VERSION@</version>
-    </dependency>
-    <dependency>
-      <groupId>org.scala-lang</groupId>
-      <artifactId>scala-reflect</artifactId>
-      <version>@VERSION@</version>
-    </dependency>
-    <dependency> <!-- for repl -->
-      <groupId>jline</groupId>
-      <artifactId>jline</artifactId>
-      <version>@JLINE_VERSION@</version>
-      <optional>true</optional>
     </dependency>
   </dependencies>
   <distributionManagement>

--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -13,7 +13,6 @@ import scala.tools.nsc.io.AbstractFile
 import scala.reflect.internal.util.{ SourceFile, BatchSourceFile, Position, NoPosition }
 import scala.tools.nsc.reporters._
 import scala.tools.nsc.symtab._
-import scala.tools.nsc.doc.ScaladocAnalyzer
 import scala.tools.nsc.typechecker.Analyzer
 import symtab.Flags.{ACCESSOR, PARAMACCESSOR}
 import scala.annotation.{ elidable, tailrec }
@@ -30,13 +29,6 @@ trait CommentPreservingTypers extends Typers {
   self: Analyzer =>
 
   override def resetDocComments() = {}
-}
-
-trait InteractiveScaladocAnalyzer extends InteractiveAnalyzer with ScaladocAnalyzer {
-  val global : Global
-  override def newTyper(context: Context) = new Typer(context) with InteractiveTyper with ScaladocTyper {
-    override def canAdaptConstantTypeToLiteral = false
-  }
 }
 
 trait InteractiveAnalyzer extends Analyzer {

--- a/src/interactive/scala/tools/nsc/interactive/tests/core/PresentationCompilerInstance.scala
+++ b/src/interactive/scala/tools/nsc/interactive/tests/core/PresentationCompilerInstance.scala
@@ -7,22 +7,16 @@ import reporters.{Reporter => CompilerReporter}
 /** Trait encapsulating the creation of a presentation compiler's instance.*/
 private[tests] trait PresentationCompilerInstance extends TestSettings {
   protected val settings = new Settings
-  protected val withDocComments = false
 
   protected val compilerReporter: CompilerReporter = new InteractiveReporter {
     override def compiler = PresentationCompilerInstance.this.compiler
   }
 
-  private class ScaladocEnabledGlobal extends Global(settings, compilerReporter) {
-    override lazy val analyzer = new {
-      val global: ScaladocEnabledGlobal.this.type = ScaladocEnabledGlobal.this
-    } with InteractiveScaladocAnalyzer
-  }
+  protected def createGlobal: Global = new Global(settings, compilerReporter)
 
   protected lazy val compiler: Global = {
     prepareSettings(settings)
-    if (withDocComments) new ScaladocEnabledGlobal
-    else new Global(settings, compilerReporter)
+    createGlobal
   }
 
   /**

--- a/src/library/scala/collection/GenTraversableOnce.scala
+++ b/src/library/scala/collection/GenTraversableOnce.scala
@@ -518,7 +518,7 @@ trait GenTraversableOnce[+A] extends Any {
    */
   def toIterator: Iterator[A]
 
-  /** Converts this $coll to a mutable buffer.
+  /** Uses the contents of this $coll to create a new mutable buffer.
    *  $willNotTerminateInf
    *  @return a buffer containing all elements of this $coll.
    */

--- a/src/library/scala/collection/IterableLike.scala
+++ b/src/library/scala/collection/IterableLike.scala
@@ -83,10 +83,26 @@ self =>
     iterator.foldRight(z)(op)
   override /*TraversableLike*/ def reduceRight[B >: A](op: (A, B) => B): B =
     iterator.reduceRight(op)
+    
+  
+  /** Returns this $coll as an iterable collection.
+   *
+   *  A new collection will not be built; lazy collections will stay lazy.
+   *
+   *  $willNotTerminateInf
+   *  @return an `Iterable` containing all elements of this $coll.
+   */
   override /*TraversableLike*/ def toIterable: Iterable[A] =
     thisCollection
-  override /*TraversableLike*/ def toIterator: Iterator[A] =
-    iterator
+  
+  /** Returns an Iterator over the elements in this $coll.  Produces the same
+   *  result as `iterator`.
+   *  $willNotTerminateInf
+   *  @return an Iterator containing all elements of this $coll.
+   */
+  @deprecatedOverriding("toIterator should stay consistent with iterator for all Iterables: override iterator instead.", "2.11.0")
+  override def toIterator: Iterator[A] = iterator
+  
   override /*TraversableLike*/ def head: A =
     iterator.next()
 

--- a/src/library/scala/collection/IterableProxyLike.scala
+++ b/src/library/scala/collection/IterableProxyLike.scala
@@ -23,6 +23,7 @@ import mutable.Buffer
  *  @version 2.8
  *  @since   2.8
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 trait IterableProxyLike[+A, +Repr <: IterableLike[A, Repr] with Iterable[A]]
     extends IterableLike[A, Repr]
     with TraversableProxyLike[A, Repr] {

--- a/src/library/scala/collection/MapProxyLike.scala
+++ b/src/library/scala/collection/MapProxyLike.scala
@@ -18,6 +18,7 @@ package collection
  *  @version 2.8
  *  @since   2.8
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 trait MapProxyLike[A, +B, +This <: MapLike[A, B, This] with Map[A, B]]
       extends MapLike[A, B, This]
       with IterableProxyLike[(A, B), This]

--- a/src/library/scala/collection/SeqLike.scala
+++ b/src/library/scala/collection/SeqLike.scala
@@ -622,7 +622,7 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
   /** Converts this $coll to a sequence.
    *  $willNotTerminateInf
    *
-   *  Overridden for efficiency.
+   *  A new collection will not be built; in particular, lazy sequences will stay lazy.
    */
   override def toSeq: Seq[A] = thisCollection
 

--- a/src/library/scala/collection/SeqProxy.scala
+++ b/src/library/scala/collection/SeqProxy.scala
@@ -18,4 +18,5 @@ package collection
  *  @version 2.8
  *  @since   2.8
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 trait SeqProxy[+A] extends Seq[A] with SeqProxyLike[A, Seq[A]]

--- a/src/library/scala/collection/SeqProxyLike.scala
+++ b/src/library/scala/collection/SeqProxyLike.scala
@@ -23,6 +23,7 @@ import generic._
  *  @version 2.8
  *  @since   2.8
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 trait SeqProxyLike[+A, +Repr <: SeqLike[A, Repr] with Seq[A]] extends SeqLike[A, Repr] with IterableProxyLike[A, Repr] {
   override def size = self.size
   override def toSeq: Seq[A] = self.toSeq

--- a/src/library/scala/collection/SetProxyLike.scala
+++ b/src/library/scala/collection/SetProxyLike.scala
@@ -17,6 +17,7 @@ package collection
  *  @author  Martin Odersky
  *  @version 2.8
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 trait SetProxyLike[A, +This <: SetLike[A, This] with Set[A]] extends SetLike[A, This] with IterableProxyLike[A, This] {
   def empty: This
   override def contains(elem: A): Boolean = self.contains(elem)

--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -623,7 +623,9 @@ trait TraversableLike[+A, +Repr] extends Any
     }
   }
 
+  @deprecatedOverriding("Enforce contract of toTraversable that if it is Traversable it returns itself.", "2.11.0")
   def toTraversable: Traversable[A] = thisCollection
+  
   def toIterator: Iterator[A] = toStream.iterator
   def toStream: Stream[A] = toBuffer.toStream
   // Override to provide size hint.

--- a/src/library/scala/collection/TraversableProxyLike.scala
+++ b/src/library/scala/collection/TraversableProxyLike.scala
@@ -24,6 +24,7 @@ import scala.reflect.ClassTag
  *  @version 2.8
  *  @since   2.8
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 trait TraversableProxyLike[+A, +Repr <: TraversableLike[A, Repr] with Traversable[A]] extends TraversableLike[A, Repr] with Proxy {
   def self: Repr
 

--- a/src/library/scala/collection/generic/IterableForwarder.scala
+++ b/src/library/scala/collection/generic/IterableForwarder.scala
@@ -26,6 +26,7 @@ import scala.collection._
  *  @version 2.8
  *  @since   2.8
  */
+@deprecated("Forwarding is inherently unreliable since it is not automated and methods can be forgotten.", "2.11.0")
 trait IterableForwarder[+A] extends Iterable[A] with TraversableForwarder[A] {
 
   /** The iterable object to which calls are forwarded */

--- a/src/library/scala/collection/generic/SeqForwarder.scala
+++ b/src/library/scala/collection/generic/SeqForwarder.scala
@@ -25,6 +25,7 @@ import scala.collection.immutable.Range
  *  @version 2.8
  *  @since   2.8
  */
+@deprecated("Forwarding is inherently unreliable since it is not automated and new methods can be forgotten.", "2.11.0")
 trait SeqForwarder[+A] extends Seq[A] with IterableForwarder[A] {
 
   protected override def underlying: Seq[A]

--- a/src/library/scala/collection/generic/TraversableForwarder.scala
+++ b/src/library/scala/collection/generic/TraversableForwarder.scala
@@ -27,6 +27,7 @@ import scala.reflect.ClassTag
  *  @version 2.8
  *  @since   2.8
  */
+@deprecated("Forwarding is inherently unreliable since it is not automated and new methods can be forgotten.", "2.11.0")
 trait TraversableForwarder[+A] extends Traversable[A] {
   /** The traversable object to which calls are forwarded. */
   protected def underlying: Traversable[A]

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -33,6 +33,7 @@ import parallel.immutable.ParHashMap
  *  @define willNotTerminateInf
  */
 @SerialVersionUID(2L)
+@deprecatedInheritance("The implementation details of immutable hash maps make inheriting from them unwise.", "2.11.0")
 class HashMap[A, +B] extends AbstractMap[A, B]
                         with Map[A, B]
                         with MapLike[A, B, HashMap[A, B]]

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -30,6 +30,7 @@ import scala.collection.parallel.immutable.ParHashSet
  *  @define coll immutable hash set
  */
 @SerialVersionUID(2L)
+@deprecatedInheritance("The implementation details of immutable hash sets make inheriting from them unwise.", "2.11.0")
 class HashSet[A] extends AbstractSet[A]
                     with Set[A]
                     with GenericSetTemplate[A, HashSet]

--- a/src/library/scala/collection/immutable/IndexedSeq.scala
+++ b/src/library/scala/collection/immutable/IndexedSeq.scala
@@ -23,6 +23,12 @@ trait IndexedSeq[+A] extends Seq[A]
                     with GenericTraversableTemplate[A, IndexedSeq]
                     with IndexedSeqLike[A, IndexedSeq[A]] {
   override def companion: GenericCompanion[IndexedSeq] = IndexedSeq
+  
+  /** Returns this $coll as an indexed sequence.
+   *  
+   *  A new indexed sequence will not be built; lazy collections will stay lazy.
+   */
+  @deprecatedOverriding("Immutable indexed sequences should do nothing on toIndexedSeq except cast themselves as an indexed sequence.", "2.11.0")
   override def toIndexedSeq: IndexedSeq[A] = this
   override def seq: IndexedSeq[A] = this
 }

--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -49,6 +49,7 @@ object ListMap extends ImmutableMapFactory[ListMap] {
  *  @define willNotTerminateInf
  */
 @SerialVersionUID(301002838095710379L)
+@deprecatedInheritance("The semantics of immutable collections makes inheriting from ListMap error-prone.", "2.11.0")
 class ListMap[A, +B]
 extends AbstractMap[A, B]
    with Map[A, B]

--- a/src/library/scala/collection/immutable/ListSet.scala
+++ b/src/library/scala/collection/immutable/ListSet.scala
@@ -64,6 +64,7 @@ object ListSet extends ImmutableSetFactory[ListSet] {
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  */
+@deprecatedInheritance("The semantics of immutable collections makes inheriting from ListSet error-prone.", "2.11.0")
 class ListSet[A] extends AbstractSet[A]
                     with Set[A]
                     with GenericSetTemplate[A, ListSet]

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -32,6 +32,12 @@ trait Map[A, +B] extends Iterable[(A, B)]
                     with MapLike[A, B, Map[A, B]] { self =>
 
   override def empty: Map[A, B] = Map.empty
+  
+  /** Returns this $coll as an immutable map.
+   *  
+   *  A new map will not be built; lazy collections will stay lazy.
+   */
+  @deprecatedOverriding("Immutable maps should do nothing on toMap except return themselves cast as a map.",  "2.11.0")
   override def toMap[T, U](implicit ev: (A, B) <:< (T, U)): immutable.Map[T, U] =
     self.asInstanceOf[immutable.Map[T, U]]
 

--- a/src/library/scala/collection/immutable/MapProxy.scala
+++ b/src/library/scala/collection/immutable/MapProxy.scala
@@ -23,6 +23,7 @@ package immutable
  *  @version 2.0, 31/12/2006
  *  @since   2.8
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 trait MapProxy[A, +B] extends Map[A, B] with MapProxyLike[A, B, Map[A, B]] {
   override def repr = this
   private def newProxy[B1 >: B](newSelf: Map[A, B1]): MapProxy[A, B1] =

--- a/src/library/scala/collection/immutable/PagedSeq.scala
+++ b/src/library/scala/collection/immutable/PagedSeq.scala
@@ -126,6 +126,7 @@ import PagedSeq._
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  */
+@deprecatedInheritance("The implementation details of paged sequences make inheriting from them unwise.", "2.11.0")
 class PagedSeq[T: ClassTag] protected(
   more: (Array[T], Int, Int) => Int,
   first1: Page[T],

--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -38,6 +38,7 @@ import scala.annotation.tailrec
  */
 
 @SerialVersionUID(-7622936493364270175L)
+@deprecatedInheritance("The implementation details of immutable queues make inheriting from them unwise.", "2.11.0")
 class Queue[+A] protected(protected val in: List[A], protected val out: List[A])
          extends AbstractSeq[A]
             with LinearSeq[A]

--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -42,6 +42,7 @@ import scala.collection.parallel.immutable.ParRange
  *         and its complexity is O(1).
  */
 @SerialVersionUID(7618862778670199309L)
+@deprecatedInheritance("The implementation details of Range makes inheriting from it unwise.", "2.11.0")
 class Range(val start: Int, val end: Int, val step: Int)
 extends scala.collection.AbstractSeq[Int]
    with IndexedSeq[Int]

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -33,7 +33,15 @@ trait Set[A] extends Iterable[A]
                 with Parallelizable[A, ParSet[A]]
 {
   override def companion: GenericCompanion[Set] = Set
+  
+  
+  /** Returns this $coll as an immutable map.
+   *  
+   *  A new map will not be built; lazy collections will stay lazy.
+   */
+  @deprecatedOverriding("Immutable sets should do nothing on toSet but return themselves cast as a Set.", "2.11.0")
   override def toSet[B >: A]: Set[B] = this.asInstanceOf[Set[B]]
+  
   override def seq: Set[A] = this
   protected override def parCombiner = ParSet.newCombiner[A] // if `immutable.SetLike` gets introduced, please move this there!
 }

--- a/src/library/scala/collection/immutable/SetProxy.scala
+++ b/src/library/scala/collection/immutable/SetProxy.scala
@@ -22,6 +22,7 @@ package immutable
  *
  *  @since 2.8
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 trait SetProxy[A] extends Set[A] with SetProxyLike[A, Set[A]] {
   override def repr = this
   private def newProxy[B >: A](newSelf: Set[B]): SetProxy[B] =

--- a/src/library/scala/collection/immutable/Stack.scala
+++ b/src/library/scala/collection/immutable/Stack.scala
@@ -46,6 +46,7 @@ object Stack extends SeqFactory[Stack] {
  *  @define willNotTerminateInf
  */
 @SerialVersionUID(1976480595012942526L)
+@deprecated("Stack is an inelegant and potentially poorly-performing wrapper around List.  Use List instead: stack push x becomes x :: list; stack.pop is list.tail.", "2.11.0")
 class Stack[+A] protected (protected val elems: List[A])
                  extends AbstractSeq[A]
                     with LinearSeq[A]

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -44,6 +44,7 @@ object TreeMap extends ImmutableSortedMapFactory[TreeMap] {
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  */
+@deprecatedInheritance("The implementation details of immutable tree maps make inheriting from them unwise.", "2.11.0")
 class TreeMap[A, +B] private (tree: RB.Tree[A, B])(implicit val ordering: Ordering[A])
   extends SortedMap[A, B]
      with SortedMapLike[A, B, TreeMap[A, B]]

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -49,6 +49,7 @@ object TreeSet extends ImmutableSortedSetFactory[TreeSet] {
  *  @define willNotTerminateInf
  */
 @SerialVersionUID(-5685982407650748405L)
+@deprecatedInheritance("The implementation details of immutable tree sets make inheriting from them unwise.", "2.11.0")
 class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: Ordering[A])
   extends SortedSet[A] with SortedSetLike[A, TreeSet[A]] with Serializable {
 

--- a/src/library/scala/collection/immutable/WrappedString.scala
+++ b/src/library/scala/collection/immutable/WrappedString.scala
@@ -29,6 +29,7 @@ import mutable.{Builder, StringBuilder}
  *  @define Coll `WrappedString`
  *  @define coll wrapped string
  */
+@deprecatedInheritance("Inherit from StringLike instead of WrappedString.", "2.11.0")
 class WrappedString(val self: String) extends AbstractSeq[Char] with IndexedSeq[Char] with StringLike[WrappedString] {
 
   override protected[this] def thisCollection: WrappedString = this

--- a/src/library/scala/collection/mutable/ArrayBuilder.scala
+++ b/src/library/scala/collection/mutable/ArrayBuilder.scala
@@ -52,6 +52,7 @@ object ArrayBuilder {
    *
    *  @tparam T     type of elements for the array builder, subtype of `AnyRef` with a `ClassTag` context bound.
    */
+  @deprecatedInheritance("ArrayBuilder.ofRef is an internal implementation not intended for subclassing.", "2.11.0")
   class ofRef[T <: AnyRef : ClassTag] extends ArrayBuilder[T] {
 
     private var elems: Array[T] = _
@@ -116,6 +117,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `byte`s. */
+  @deprecatedInheritance("ArrayBuilder.ofByte is an internal implementation not intended for subclassing.", "2.11.0")
   class ofByte extends ArrayBuilder[Byte] {
 
     private var elems: Array[Byte] = _
@@ -180,6 +182,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `short`s. */
+  @deprecatedInheritance("ArrayBuilder.ofShort is an internal implementation not intended for subclassing.", "2.11.0")
   class ofShort extends ArrayBuilder[Short] {
 
     private var elems: Array[Short] = _
@@ -244,6 +247,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `char`s. */
+  @deprecatedInheritance("ArrayBuilder.ofChar is an internal implementation not intended for subclassing.", "2.11.0")
   class ofChar extends ArrayBuilder[Char] {
 
     private var elems: Array[Char] = _
@@ -308,6 +312,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `int`s. */
+  @deprecatedInheritance("ArrayBuilder.ofInt is an internal implementation not intended for subclassing.", "2.11.0")
   class ofInt extends ArrayBuilder[Int] {
 
     private var elems: Array[Int] = _
@@ -372,6 +377,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `long`s. */
+  @deprecatedInheritance("ArrayBuilder.ofLong is an internal implementation not intended for subclassing.", "2.11.0")
   class ofLong extends ArrayBuilder[Long] {
 
     private var elems: Array[Long] = _
@@ -436,6 +442,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `float`s. */
+  @deprecatedInheritance("ArrayBuilder.ofFloat is an internal implementation not intended for subclassing.", "2.11.0")
   class ofFloat extends ArrayBuilder[Float] {
 
     private var elems: Array[Float] = _
@@ -500,6 +507,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `double`s. */
+  @deprecatedInheritance("ArrayBuilder.ofDouble is an internal implementation not intended for subclassing.", "2.11.0")
   class ofDouble extends ArrayBuilder[Double] {
 
     private var elems: Array[Double] = _
@@ -628,6 +636,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `Unit` type. */
+  @deprecatedInheritance("ArrayBuilder.ofUnit is an internal implementation not intended for subclassing.", "2.11.0")
   class ofUnit extends ArrayBuilder[Unit] {
 
     private var elems: Array[Unit] = _

--- a/src/library/scala/collection/mutable/ArrayLike.scala
+++ b/src/library/scala/collection/mutable/ArrayLike.scala
@@ -10,8 +10,9 @@ package scala
 package collection
 package mutable
 
-/** A common supertrait of `ArrayOps` and `WrappedArray` that factors out most
- *  operations on arrays and wrapped arrays.
+/** A common supertrait of `ArrayOps` and `WrappedArray` that factors out the 
+ * `deep` method for arrays and wrapped arrays and serves as a marker trait
+ * for array wrappers.
  *
  *  @tparam A     type of the elements contained in the array like object.
  *  @tparam Repr  the type of the actual collection containing the elements.

--- a/src/library/scala/collection/mutable/ArrayOps.scala
+++ b/src/library/scala/collection/mutable/ArrayOps.scala
@@ -33,6 +33,7 @@ import parallel.mutable.ParArray
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  */
+@deprecatedInheritance("ArrayOps will be sealed to facilitate greater flexibility with array/collections integration in future releases.", "2.11.0")
 trait ArrayOps[T] extends Any with ArrayLike[T, Array[T]] with CustomParallelizable[T, ParArray[T]] {
 
   private def elementClass: Class[_] =

--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -37,7 +37,7 @@ import BitSetLike.{LogWL, MaxSize, updateArray}
  *  @define willNotTerminateInf
  */
 @SerialVersionUID(8483111450368547763L)
-class BitSet(protected var elems: Array[Long]) extends AbstractSet[Int]
+class BitSet(protected final var elems: Array[Long]) extends AbstractSet[Int]
                                                   with SortedSet[Int]
                                                   with scala.collection.BitSet
                                                   with BitSetLike[BitSet]
@@ -54,16 +54,19 @@ class BitSet(protected var elems: Array[Long]) extends AbstractSet[Int]
 
   def this() = this(0)
 
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def nwords = elems.length
+  
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def word(idx: Int): Long =
     if (idx < nwords) elems(idx) else 0L
 
-  private def updateWord(idx: Int, w: Long) {
+  protected final def updateWord(idx: Int, w: Long) {
     ensureCapacity(idx)
     elems(idx) = w
   }
 
-  private def ensureCapacity(idx: Int) {
+  protected final def ensureCapacity(idx: Int) {
     require(idx < MaxSize)
     if (idx >= nwords) {
       var newlen = nwords
@@ -95,7 +98,10 @@ class BitSet(protected var elems: Array[Long]) extends AbstractSet[Int]
     } else false
   }
 
+  @deprecatedOverriding("Override add to prevent += and add from exhibiting different behavior.", "2.11.0")
   def += (elem: Int): this.type = { add(elem); this }
+  
+  @deprecatedOverriding("Override add to prevent += and add from exhibiting different behavior.", "2.11.0")
   def -= (elem: Int): this.type = { remove(elem); this }
 
   /** Updates this bitset to the union with another bitset by performing a bitwise "or".

--- a/src/library/scala/collection/mutable/BufferLike.scala
+++ b/src/library/scala/collection/mutable/BufferLike.scala
@@ -184,6 +184,7 @@ trait BufferLike[A, +This <: BufferLike[A, This] with Buffer[A]]
    *
    *  @param cmd  the message to send.
    */
+  @deprecated("Scripting is deprecated.", "2.11.0")
   def <<(cmd: Message[A]): Unit = cmd match {
     case Include(Start, x)      => prepend(x)
     case Include(End, x)        => append(x)

--- a/src/library/scala/collection/mutable/BufferProxy.scala
+++ b/src/library/scala/collection/mutable/BufferProxy.scala
@@ -26,6 +26,7 @@ import script._
  *  @define Coll `BufferProxy`
  *  @define coll buffer proxy
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 trait BufferProxy[A] extends Buffer[A] with Proxy {
 
   def self: Buffer[A]
@@ -131,6 +132,7 @@ trait BufferProxy[A] extends Buffer[A] with Proxy {
    *
    *  @param cmd  the message to send.
    */
+  @deprecated("Scripting is deprecated.", "2.11.0")
   override def <<(cmd: Message[A]) { self << cmd }
 
   /** Return a clone of this buffer.

--- a/src/library/scala/collection/mutable/DoubleLinkedList.scala
+++ b/src/library/scala/collection/mutable/DoubleLinkedList.scala
@@ -41,6 +41,7 @@ import generic._
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  */
+@deprecated("Low-level linked lists are deprecated due to idiosyncracies in interface and incomplete features.", "2.11.0")
 @SerialVersionUID(-8144992287952814767L)
 class DoubleLinkedList[A]() extends AbstractSeq[A]
                             with LinearSeq[A]
@@ -77,6 +78,7 @@ class DoubleLinkedList[A]() extends AbstractSeq[A]
  *  @define coll double linked list
  *  @define Coll `DoubleLinkedList`
  */
+@deprecated("Low-level linked lists are deprecated.", "2.11.0")
 object DoubleLinkedList extends SeqFactory[DoubleLinkedList] {
   /** $genericCanBuildFromInfo */
   implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, DoubleLinkedList[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]

--- a/src/library/scala/collection/mutable/DoubleLinkedListLike.scala
+++ b/src/library/scala/collection/mutable/DoubleLinkedListLike.scala
@@ -56,6 +56,7 @@ import scala.annotation.migration
  *  @define Coll `DoubleLinkedList`
  *  @define coll double linked list
  */
+@deprecated("Low-level linked lists are deprecated due to idiosyncracies in interface and incomplete features.", "2.11.0")
 trait DoubleLinkedListLike[A, This <: Seq[A] with DoubleLinkedListLike[A, This]] extends SeqLike[A, This] with LinkedListLike[A, This] { self =>
 
   /** A reference to the node in the linked list preceeding the current node. */

--- a/src/library/scala/collection/mutable/FlatHashTable.scala
+++ b/src/library/scala/collection/mutable/FlatHashTable.scala
@@ -107,6 +107,7 @@ trait FlatHashTable[A] extends FlatHashTable.HashUtils[A] {
   }
 
   /** Finds an entry in the hash table if such an element exists. */
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def findEntry(elem: A): Option[A] =
     findElemImpl(elem) match {
       case null => None
@@ -115,6 +116,7 @@ trait FlatHashTable[A] extends FlatHashTable.HashUtils[A] {
 
 
   /** Checks whether an element is contained in the hash table. */
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def containsElem(elem: A): Boolean = {
     null != findElemImpl(elem)
   }
@@ -248,15 +250,18 @@ trait FlatHashTable[A] extends FlatHashTable.HashUtils[A] {
    * where sizeMapBucketSize == 4.
    *
    */
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def nnSizeMapAdd(h: Int) = if (sizemap ne null) {
     val p = h >> sizeMapBucketBitSize
     sizemap(p) += 1
   }
 
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def nnSizeMapRemove(h: Int) = if (sizemap ne null) {
     sizemap(h >> sizeMapBucketBitSize) -= 1
   }
 
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def nnSizeMapReset(tableLength: Int) = if (sizemap ne null) {
     val nsize = calcSizeMapSize(tableLength)
     if (sizemap.length != nsize) sizemap = new Array[Int](nsize)
@@ -265,14 +270,17 @@ trait FlatHashTable[A] extends FlatHashTable.HashUtils[A] {
 
   private[collection] final def totalSizeMapBuckets = (table.length - 1) / sizeMapBucketSize + 1
 
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def calcSizeMapSize(tableLength: Int) = (tableLength >> sizeMapBucketBitSize) + 1
 
   // discards the previous sizemap and only allocates a new one
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def sizeMapInit(tableLength: Int) {
     sizemap = new Array[Int](calcSizeMapSize(tableLength))
   }
 
   // discards the previous sizemap and populates the new one
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def sizeMapInitAndRebuild() {
     // first allocate
     sizeMapInit(table.length)

--- a/src/library/scala/collection/mutable/HashTable.scala
+++ b/src/library/scala/collection/mutable/HashTable.scala
@@ -127,6 +127,7 @@ trait HashTable[A, Entry >: Null <: HashEntry[A, Entry]] extends HashTable.HashU
 
   /** Find entry with given key in table, null if not found.
    */
+  @deprecatedOverriding("No sensible way to override findEntry as private findEntry0 is used in multiple places internally.", "2.11.0")
   protected def findEntry(key: A): Entry =
     findEntry0(key, index(elemHashCode(key)))
 
@@ -139,6 +140,7 @@ trait HashTable[A, Entry >: Null <: HashEntry[A, Entry]] extends HashTable.HashU
   /** Add entry to table
    *  pre: no entry with same key exists
    */
+  @deprecatedOverriding("No sensible way to override addEntry as private addEntry0 is used in multiple places internally.", "2.11.0")
   protected def addEntry(e: Entry) {
     addEntry0(e, index(elemHashCode(e.key)))
   }
@@ -172,6 +174,7 @@ trait HashTable[A, Entry >: Null <: HashEntry[A, Entry]] extends HashTable.HashU
 
   /** Remove entry from table if present.
    */
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def removeEntry(key: A) : Entry = {
     val h = index(elemHashCode(key))
     var e = table(h).asInstanceOf[Entry]
@@ -282,14 +285,17 @@ trait HashTable[A, Entry >: Null <: HashEntry[A, Entry]] extends HashTable.HashU
    * is converted into a parallel hash table, the size map is initialized, as it will be needed
    * there.
    */
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def nnSizeMapAdd(h: Int) = if (sizemap ne null) {
     sizemap(h >> sizeMapBucketBitSize) += 1
   }
 
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def nnSizeMapRemove(h: Int) = if (sizemap ne null) {
     sizemap(h >> sizeMapBucketBitSize) -= 1
   }
 
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def nnSizeMapReset(tableLength: Int) = if (sizemap ne null) {
     val nsize = calcSizeMapSize(tableLength)
     if (sizemap.length != nsize) sizemap = new Array[Int](nsize)
@@ -298,6 +304,7 @@ trait HashTable[A, Entry >: Null <: HashEntry[A, Entry]] extends HashTable.HashU
 
   private[collection] final def totalSizeMapBuckets = if (sizeMapBucketSize < table.length) 1 else table.length / sizeMapBucketSize
 
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def calcSizeMapSize(tableLength: Int) = (tableLength >> sizeMapBucketBitSize) + 1
 
   // discards the previous sizemap and only allocates a new one
@@ -306,6 +313,7 @@ trait HashTable[A, Entry >: Null <: HashEntry[A, Entry]] extends HashTable.HashU
   }
 
   // discards the previous sizemap and populates the new one
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def sizeMapInitAndRebuild() {
     sizeMapInit(table.length)
 
@@ -336,8 +344,10 @@ trait HashTable[A, Entry >: Null <: HashEntry[A, Entry]] extends HashTable.HashU
     println(sizemap.toList)
   }
 
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def sizeMapDisable() = sizemap = null
 
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def isSizeMapDefined = sizemap ne null
 
   // override to automatically initialize the size map

--- a/src/library/scala/collection/mutable/ImmutableMapAdaptor.scala
+++ b/src/library/scala/collection/mutable/ImmutableMapAdaptor.scala
@@ -25,6 +25,7 @@ import scala.annotation.migration
  *  @version 2.0, 01/01/2007
  *  @since   1
  */
+@deprecated("Adaptors are inherently unreliable and prone to performance problems.", "2.11.0")
 class ImmutableMapAdaptor[A, B](protected var imap: immutable.Map[A, B])
 extends AbstractMap[A, B]
    with Map[A, B]

--- a/src/library/scala/collection/mutable/ImmutableSetAdaptor.scala
+++ b/src/library/scala/collection/mutable/ImmutableSetAdaptor.scala
@@ -20,6 +20,7 @@ package mutable
  *  @version 1.0, 21/07/2003
  *  @since   1
  */
+@deprecated("Adaptors are inherently unreliable and prone to performance problems.", "2.11.0")
 class ImmutableSetAdaptor[A](protected var set: immutable.Set[A])
 extends AbstractSet[A]
    with Set[A]

--- a/src/library/scala/collection/mutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/mutable/LinkedHashMap.scala
@@ -85,7 +85,10 @@ class LinkedHashMap[A, B] extends AbstractMap[A, B]
     }
   }
 
+  @deprecatedOverriding("+= should not be overridden so it stays consistent with put.", "2.11.0")
   def += (kv: (A, B)): this.type = { put(kv._1, kv._2); this }
+
+  @deprecatedOverriding("-= should not be overridden so it stays consistent with remove.", "2.11.0")
   def -=(key: A): this.type = { remove(key); this }
 
   def iterator: Iterator[(A, B)] = new AbstractIterator[(A, B)] {

--- a/src/library/scala/collection/mutable/LinkedHashSet.scala
+++ b/src/library/scala/collection/mutable/LinkedHashSet.scala
@@ -57,7 +57,10 @@ class LinkedHashSet[A] extends AbstractSet[A]
 
   def contains(elem: A): Boolean = findEntry(elem) ne null
 
+  @deprecatedOverriding("+= should not be overridden so it stays consistent with add.", "2.11.0")
   def += (elem: A): this.type = { add(elem); this }
+
+  @deprecatedOverriding("-= should not be overridden so it stays consistent with remove.", "2.11.0")
   def -= (elem: A): this.type = { remove(elem); this }
 
   override def add(elem: A): Boolean = findOrAddEntry(elem, null) eq null

--- a/src/library/scala/collection/mutable/LinkedList.scala
+++ b/src/library/scala/collection/mutable/LinkedList.scala
@@ -76,6 +76,7 @@ import generic._
   *  }}}
   */
 @SerialVersionUID(-7308240733518833071L)
+@deprecated("Low-level linked lists are deprecated due to idiosyncracies in interface and incomplete features.", "2.11.0")
 class LinkedList[A]() extends AbstractSeq[A]
                          with LinearSeq[A]
                          with GenericTraversableTemplate[A, LinkedList]
@@ -113,6 +114,7 @@ class LinkedList[A]() extends AbstractSeq[A]
  *  @define Coll `LinkedList`
  *  @define coll linked list
  */
+@deprecated("Low-level linked lists are deprecated.", "2.11.0")
 object LinkedList extends SeqFactory[LinkedList] {
   override def empty[A]: LinkedList[A] = new LinkedList[A]
   implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, LinkedList[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]

--- a/src/library/scala/collection/mutable/LinkedListLike.scala
+++ b/src/library/scala/collection/mutable/LinkedListLike.scala
@@ -55,6 +55,7 @@ import scala.annotation.tailrec
  *
  *  }}}
  */
+@deprecated("Low-level linked lists are deprecated due to idiosyncracies in interface and incomplete features.", "2.11.0")
 trait LinkedListLike[A, This <: Seq[A] with LinkedListLike[A, This]] extends SeqLike[A, This] { self =>
 
   var elem: A = _

--- a/src/library/scala/collection/mutable/ListMap.scala
+++ b/src/library/scala/collection/mutable/ListMap.scala
@@ -50,7 +50,10 @@ extends AbstractMap[A, B]
   def get(key: A): Option[B] = elems find (_._1 == key) map (_._2)
   def iterator: Iterator[(A, B)] = elems.iterator
 
+  @deprecatedOverriding("No sensible way to override += as private remove is used in multiple places internally.", "2.11.0")
   def += (kv: (A, B)) = { elems = remove(kv._1, elems, List()); elems = kv :: elems; siz += 1; this }
+
+  @deprecatedOverriding("No sensible way to override -= as private remove is used in multiple places internally.", "2.11.0")
   def -= (key: A) = { elems = remove(key, elems, List()); this }
 
   @tailrec
@@ -61,7 +64,10 @@ extends AbstractMap[A, B]
   }
 
 
+  @deprecatedOverriding("No sensible way to override as this functionality relies upon access to private methods.", "2.11.0")
   override def clear() = { elems = List(); siz = 0 }
+
+  @deprecatedOverriding("No sensible way to override as this functionality relies upon access to private methods.", "2.11.0")
   override def size: Int = siz
 }
 

--- a/src/library/scala/collection/mutable/MapProxy.scala
+++ b/src/library/scala/collection/mutable/MapProxy.scala
@@ -20,6 +20,7 @@ package mutable
  *  @version 2.0, 31/12/2006
  *  @since   1
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 trait MapProxy[A, B] extends Map[A, B] with MapProxyLike[A, B, Map[A, B]] {
   private def newProxy[B1 >: B](newSelf: Map[A, B1]): MapProxy[A, B1] =
     new MapProxy[A, B1] { val self = newSelf }

--- a/src/library/scala/collection/mutable/ObservableBuffer.scala
+++ b/src/library/scala/collection/mutable/ObservableBuffer.scala
@@ -23,6 +23,7 @@ import script._
  *  @version 1.0, 08/07/2003
  *  @since   1
  */
+@deprecated("Observables are deprecated because scripting is deprecated.", "2.11.0")
 trait ObservableBuffer[A] extends Buffer[A] with Publisher[Message[A] with Undoable]
 {
   type Pub <: ObservableBuffer[A]

--- a/src/library/scala/collection/mutable/ObservableMap.scala
+++ b/src/library/scala/collection/mutable/ObservableMap.scala
@@ -25,6 +25,7 @@ import script._
  *  @version 2.0, 31/12/2006
  *  @since   1
  */
+@deprecated("Observables are deprecated because scripting is deprecated.", "2.11.0")
 trait ObservableMap[A, B] extends Map[A, B] with Publisher[Message[(A, B)] with Undoable]
 {
 

--- a/src/library/scala/collection/mutable/ObservableSet.scala
+++ b/src/library/scala/collection/mutable/ObservableSet.scala
@@ -23,6 +23,7 @@ import script._
  *  @version 1.0, 08/07/2003
  *  @since   1
  */
+@deprecated("Observables are deprecated because scripting is deprecated.", "2.11.0")
 trait ObservableSet[A] extends Set[A] with Publisher[Message[A] with Undoable]
 {
 

--- a/src/library/scala/collection/mutable/OpenHashMap.scala
+++ b/src/library/scala/collection/mutable/OpenHashMap.scala
@@ -117,7 +117,10 @@ extends AbstractMap[Key, Value]
     put(key, hashOf(key), value)
   }
 
+  @deprecatedOverriding("+= should not be overridden in order to maintain consistency with put.", "2.11.0")
   def += (kv: (Key, Value)): this.type = { put(kv._1, kv._2); this }
+  
+  @deprecatedOverriding("-= should not be overridden in order to maintain consistency with remove.", "2.11.0")
   def -= (key: Key): this.type = { remove(key); this }
 
   override def put(key: Key, value: Value): Option[Value] =

--- a/src/library/scala/collection/mutable/PriorityQueue.scala
+++ b/src/library/scala/collection/mutable/PriorityQueue.scala
@@ -30,6 +30,7 @@ import generic._
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  */
+@deprecatedInheritance("PriorityQueue is not intended to be subclassed due to extensive private implementation details.", "2.11.0")
 class PriorityQueue[A](implicit val ord: Ordering[A])
    extends AbstractIterable[A]
       with Iterable[A]

--- a/src/library/scala/collection/mutable/PriorityQueueProxy.scala
+++ b/src/library/scala/collection/mutable/PriorityQueueProxy.scala
@@ -19,6 +19,7 @@ package mutable
  *  @version 1.0, 03/05/2004
  *  @since   1
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 abstract class PriorityQueueProxy[A](implicit ord: Ordering[A]) extends PriorityQueue[A]
          with Proxy
 {

--- a/src/library/scala/collection/mutable/Queue.scala
+++ b/src/library/scala/collection/mutable/Queue.scala
@@ -143,6 +143,7 @@ extends MutableList[A]
   /** Return the proper suffix of this list which starts with the first element that satisfies `p`.
    *  That element is unlinked from the list. If no element satisfies `p`, return None.
    */
+  @deprecated("extractFirst inappropriately exposes implementation details.  Use dequeue or dequeueAll.", "2.11.0")
   def extractFirst(start: LinkedList[A], p: A => Boolean): Option[LinkedList[A]] = {
     if (isEmpty) None
     else {

--- a/src/library/scala/collection/mutable/QueueProxy.scala
+++ b/src/library/scala/collection/mutable/QueueProxy.scala
@@ -21,6 +21,7 @@ package mutable
  *  @version 1.1, 03/05/2004
  *  @since   1
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 trait QueueProxy[A] extends Queue[A] with Proxy {
 
   def self: Queue[A]

--- a/src/library/scala/collection/mutable/SetLike.scala
+++ b/src/library/scala/collection/mutable/SetLike.scala
@@ -210,11 +210,12 @@ trait SetLike[A, +This <: SetLike[A, This] with Set[A]]
    *  @throws `Predef.UnsupportedOperationException`
    *  if the message was not understood.
    */
-   def <<(cmd: Message[A]): Unit = cmd match {
-     case Include(_, x)     => this += x
-     case Remove(_, x)      => this -= x
-     case Reset()           => clear()
-     case s: Script[_]      => s.iterator foreach <<
-     case _                 => throw new UnsupportedOperationException("message " + cmd + " not understood")
-   }
+  @deprecated("Scripting is deprecated.", "2.11.0")
+  def <<(cmd: Message[A]): Unit = cmd match {
+    case Include(_, x)     => this += x
+    case Remove(_, x)      => this -= x
+    case Reset()           => clear()
+    case s: Script[_]      => s.iterator foreach <<
+    case _                 => throw new UnsupportedOperationException("message " + cmd + " not understood")
+  }
 }

--- a/src/library/scala/collection/mutable/SetProxy.scala
+++ b/src/library/scala/collection/mutable/SetProxy.scala
@@ -18,6 +18,7 @@ package mutable
  *  @version 1.1, 09/05/2004
  *  @since   1
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 trait SetProxy[A] extends Set[A] with SetProxyLike[A, Set[A]] {
   override def repr = this
   override def empty = new SetProxy[A] { val self = SetProxy.this.self.empty }

--- a/src/library/scala/collection/mutable/StackProxy.scala
+++ b/src/library/scala/collection/mutable/StackProxy.scala
@@ -19,6 +19,7 @@ package mutable
  *  @version 1.0, 10/05/2004
  *  @since   1
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 trait StackProxy[A] extends Stack[A] with Proxy {
 
   def self: Stack[A]

--- a/src/library/scala/collection/mutable/SynchronizedBuffer.scala
+++ b/src/library/scala/collection/mutable/SynchronizedBuffer.scala
@@ -25,6 +25,7 @@ import script._
  *  @define Coll `SynchronizedBuffer`
  *  @define coll synchronized buffer
  */
+@deprecated("Synchronization via traits is deprecated as it is inherently unreliable.  Consider java.util.concurrent.ConcurrentLinkedQueue as an alternative.", "2.11.0")
 trait SynchronizedBuffer[A] extends Buffer[A] {
 
   import scala.collection.Traversable
@@ -161,6 +162,7 @@ trait SynchronizedBuffer[A] extends Buffer[A] {
     super.clear()
   }
 
+  @deprecated("Scripting is deprecated.", "2.11.0")
   override def <<(cmd: Message[A]): Unit = synchronized {
     super.<<(cmd)
   }

--- a/src/library/scala/collection/mutable/SynchronizedMap.scala
+++ b/src/library/scala/collection/mutable/SynchronizedMap.scala
@@ -24,6 +24,7 @@ import scala.annotation.migration
  *  @define Coll `SynchronizedMap`
  *  @define coll synchronized map
  */
+@deprecated("Synchronization via traits is deprecated as it is inherently unreliable.  Consider java.util.concurrent.ConcurrentHashMap as an alternative.", "2.11.0")
 trait SynchronizedMap[A, B] extends Map[A, B] {
 
   abstract override def get(key: A): Option[B] = synchronized { super.get(key) }

--- a/src/library/scala/collection/mutable/SynchronizedPriorityQueue.scala
+++ b/src/library/scala/collection/mutable/SynchronizedPriorityQueue.scala
@@ -24,6 +24,7 @@ package mutable
  *  @define Coll `SynchronizedPriorityQueue`
  *  @define coll synchronized priority queue
  */
+@deprecated("Comprehensive synchronization via selective overriding of methods is inherently unreliable.  Consider java.util.concurrent.ConcurrentSkipListSet as an alternative.", "2.11.0")
 class SynchronizedPriorityQueue[A](implicit ord: Ordering[A]) extends PriorityQueue[A] {
 
   /** Checks if the queue is empty.

--- a/src/library/scala/collection/mutable/SynchronizedQueue.scala
+++ b/src/library/scala/collection/mutable/SynchronizedQueue.scala
@@ -25,6 +25,7 @@ package mutable
  *  @define Coll `SynchronizedQueue`
  *  @define coll synchronized queue
  */
+@deprecated("Synchronization via selective overriding of methods is inherently unreliable.  Consider java.util.concurrent.ConcurrentLinkedQueue as an alternative.", "2.11.0")
 class SynchronizedQueue[A] extends Queue[A] {
   /** Checks if the queue is empty.
    *

--- a/src/library/scala/collection/mutable/SynchronizedSet.scala
+++ b/src/library/scala/collection/mutable/SynchronizedSet.scala
@@ -24,6 +24,7 @@ import script._
  *  @define Coll `SynchronizedSet`
  *  @define coll synchronized set
  */
+@deprecated("Synchronization via traits is deprecated as it is inherently unreliable.  Consider java.util.concurrent.ConcurrentHashMap[A,Unit] as an alternative.", "2.11.0")
 trait SynchronizedSet[A] extends Set[A] {
   abstract override def size: Int = synchronized {
     super.size
@@ -93,6 +94,7 @@ trait SynchronizedSet[A] extends Set[A] {
     super.toString
   }
 
+  @deprecated("Scripting is deprecated.", "2.11.0")
   override def <<(cmd: Message[A]): Unit = synchronized {
     super.<<(cmd)
   }

--- a/src/library/scala/collection/mutable/SynchronizedStack.scala
+++ b/src/library/scala/collection/mutable/SynchronizedStack.scala
@@ -25,6 +25,7 @@ package mutable
  *  @define Coll `SynchronizedStack`
  *  @define coll synchronized stack
  */
+@deprecated("Synchronization via selective overriding of methods is inherently unreliable.  Consider java.util.concurrent.LinkedBlockingDequeue instead.", "2.11.0")
 class SynchronizedStack[A] extends Stack[A] {
   import scala.collection.Traversable
 

--- a/src/library/scala/collection/mutable/TreeSet.scala
+++ b/src/library/scala/collection/mutable/TreeSet.scala
@@ -37,6 +37,7 @@ object TreeSet extends MutableSortedSetFactory[TreeSet] {
  * @author Lucien Pereira
  *
  */
+@deprecatedInheritance("TreeSet is not designed to enable meaningful subclassing.", "2.11.0")
 class TreeSet[A] private (treeRef: ObjectRef[RB.Tree[A, Null]], from: Option[A], until: Option[A])(implicit val ordering: Ordering[A])
   extends SortedSet[A] with SetLike[A, TreeSet[A]]
   with SortedSetLike[A, TreeSet[A]] with Set[A] with Serializable {

--- a/src/library/scala/collection/mutable/UnrolledBuffer.scala
+++ b/src/library/scala/collection/mutable/UnrolledBuffer.scala
@@ -43,6 +43,7 @@ import scala.reflect.ClassTag
  *
  */
 @SerialVersionUID(1L)
+@deprecatedInheritance("UnrolledBuffer is not designed to enable meaningful subclassing.", "2.11.0")
 class UnrolledBuffer[T](implicit val tag: ClassTag[T])
 extends scala.collection.mutable.AbstractBuffer[T]
    with scala.collection.mutable.Buffer[T]
@@ -67,7 +68,20 @@ extends scala.collection.mutable.AbstractBuffer[T]
 
   protected def newUnrolled = new Unrolled[T](this)
 
-  private[collection] def calcNextLength(sz: Int) = sz
+  // The below would allow more flexible behavior without requiring inheritance
+  // that is risky because all the important internals are private.
+  // private var myLengthPolicy: Int => Int = x => x
+  // 
+  // /** Specifies how the array lengths should vary.
+  //   * 
+  //   *  By default,  `UnrolledBuffer` uses arrays of a fixed size.  A length
+  //   *  policy can be given that changes this scheme to, for instance, an
+  //   *  exponential growth.
+  //   * 
+  //   *  @param nextLength   computes the length of the next array from the length of the latest one
+  //   */
+  // def setLengthPolicy(nextLength: Int => Int): Unit = { myLengthPolicy = nextLength }
+  private[collection] def calcNextLength(sz: Int) = sz // myLengthPolicy(sz)
 
   def classTagCompanion = UnrolledBuffer
 

--- a/src/library/scala/collection/parallel/mutable/UnrolledParArrayCombiner.scala
+++ b/src/library/scala/collection/parallel/mutable/UnrolledParArrayCombiner.scala
@@ -20,6 +20,7 @@ import scala.collection.parallel.Combiner
 import scala.collection.parallel.Task
 import scala.reflect.ClassTag
 
+// Todo -- revisit whether inheritance is the best way to achieve this functionality
 private[mutable] class DoublingUnrolledBuffer[T](implicit t: ClassTag[T]) extends UnrolledBuffer[T]()(t) {
   override def calcNextLength(sz: Int) = if (sz < 10000) sz * 2 else sz
   protected override def newUnrolled = new Unrolled[T](0, new Array[T](4), null, this)

--- a/src/library/scala/collection/script/Location.scala
+++ b/src/library/scala/collection/script/Location.scala
@@ -18,8 +18,17 @@ package script
  *  @since   2.8
  */
 
+@deprecated("Scripting is deprecated.", "2.11.0")
 sealed abstract class Location
+
+@deprecated("Scripting is deprecated.", "2.11.0")
 case object Start extends Location
+
+@deprecated("Scripting is deprecated.", "2.11.0")
 case object End extends Location
+
+@deprecated("Scripting is deprecated.", "2.11.0")
 case object NoLo extends Location
+
+@deprecated("Scripting is deprecated.", "2.11.0")
 case class Index(n: Int) extends Location

--- a/src/library/scala/collection/script/Message.scala
+++ b/src/library/scala/collection/script/Message.scala
@@ -21,6 +21,7 @@ import mutable.ArrayBuffer
  *  @version 1.0, 08/07/2003
  *  @since   2.8
  */
+@deprecated("Scripting is deprecated.", "2.11.0")
 trait Message[+A]
 
 /** This observable update refers to inclusion operations that add new elements
@@ -29,6 +30,7 @@ trait Message[+A]
  *  @author  Matthias Zenger
  *  @version 1.0, 08/07/2003
  */
+@deprecated("Scripting is deprecated.", "2.11.0")
 case class Include[+A](location: Location, elem: A) extends Message[A] {
   def this(elem: A) = this(NoLo, elem)
 }
@@ -39,6 +41,7 @@ case class Include[+A](location: Location, elem: A) extends Message[A] {
  *  @author  Matthias Zenger
  *  @version 1.0, 08/07/2003
  */
+@deprecated("Scripting is deprecated.", "2.11.0")
 case class Update[+A](location: Location, elem: A) extends Message[A] {
   def this(elem: A) = this(NoLo, elem)
 }
@@ -49,6 +52,7 @@ case class Update[+A](location: Location, elem: A) extends Message[A] {
  *  @author  Matthias Zenger
  *  @version 1.0, 08/07/2003
  */
+@deprecated("Scripting is deprecated.", "2.11.0")
 case class Remove[+A](location: Location, elem: A) extends Message[A] {
   def this(elem: A) = this(NoLo, elem)
 }
@@ -58,6 +62,7 @@ case class Remove[+A](location: Location, elem: A) extends Message[A] {
  *  @author  Matthias Zenger
  *  @version 1.0, 08/07/2003
  */
+@deprecated("Scripting is deprecated.", "2.11.0")
 case class Reset[+A]() extends Message[A]
 
 /** Objects of this class represent compound messages consisting
@@ -66,6 +71,7 @@ case class Reset[+A]() extends Message[A]
  *  @author  Matthias Zenger
  *  @version 1.0, 10/05/2004
  */
+@deprecated("Scripting is deprecated.", "2.11.0")
 class Script[A] extends ArrayBuffer[Message[A]] with Message[A] {
 
   override def toString(): String = {

--- a/src/library/scala/collection/script/Scriptable.scala
+++ b/src/library/scala/collection/script/Scriptable.scala
@@ -17,6 +17,7 @@ package script
  *  @version 1.0, 09/05/2004
  *  @since   2.8
  */
+@deprecated("Scripting is deprecated.", "2.11.0")
 trait Scriptable[A] {
   /** Send a message to this scriptable object.
    */

--- a/src/swing/scala/swing/ListView.scala
+++ b/src/swing/scala/swing/ListView.scala
@@ -200,9 +200,7 @@ class ListView[A] extends Component {
     /**
      * The currently selected items.
      */
-    object items extends scala.collection.SeqProxy[A] {
-      def self = peer.getSelectedValues.map(_.asInstanceOf[A])
-    }
+    lazy val items = peer.getSelectedValues.map(_.asInstanceOf[A])
 
     def intervalMode: IntervalMode.Value = IntervalMode(peer.getSelectionModel.getSelectionMode)
     def intervalMode_=(m: IntervalMode.Value) { peer.getSelectionModel.setSelectionMode(m.id) }

--- a/test/files/jvm/future-spec.check
+++ b/test/files/jvm/future-spec.check
@@ -1,2 +1,1 @@
 warning: there were 1 deprecation warning(s); re-run with -deprecation for details
-Stack(8, 7, 6, 5, 4, 3)

--- a/test/files/jvm/serialization-new.check
+++ b/test/files/jvm/serialization-new.check
@@ -1,3 +1,4 @@
+warning: there were 2 deprecation warning(s); re-run with -deprecation for details
 a1 = Array[1,2,3]
 _a1 = Array[1,2,3]
 arrayEquals(a1, _a1): true

--- a/test/files/jvm/serialization.check
+++ b/test/files/jvm/serialization.check
@@ -1,3 +1,4 @@
+warning: there were 2 deprecation warning(s); re-run with -deprecation for details
 a1 = Array[1,2,3]
 _a1 = Array[1,2,3]
 arrayEquals(a1, _a1): true

--- a/test/files/presentation/memory-leaks/MemoryLeaksTest.scala
+++ b/test/files/presentation/memory-leaks/MemoryLeaksTest.scala
@@ -25,7 +25,20 @@ import scala.tools.nsc.doc
 object Test extends InteractiveTest {
   final val mega = 1024 * 1024
 
-  override val withDocComments = true
+  trait InteractiveScaladocAnalyzer extends InteractiveAnalyzer with scala.tools.nsc.doc.ScaladocAnalyzer {
+    val global : Global
+    override def newTyper(context: Context) = new Typer(context) with InteractiveTyper with ScaladocTyper {
+      override def canAdaptConstantTypeToLiteral = false
+    }
+  }
+
+  private class ScaladocEnabledGlobal extends Global(settings, compilerReporter) {
+    override lazy val analyzer = new {
+      val global: ScaladocEnabledGlobal.this.type = ScaladocEnabledGlobal.this
+    } with InteractiveScaladocAnalyzer
+  }
+
+  override def createGlobal: Global = new ScaladocEnabledGlobal
 
   override def execute(): Unit = memoryConsumptionTest()
 

--- a/test/files/run/collection-stacks.check
+++ b/test/files/run/collection-stacks.check
@@ -1,3 +1,4 @@
+warning: there were 1 deprecation warning(s); re-run with -deprecation for details
 3-2-1: true
 3-2-1: true
 apply

--- a/test/files/run/colltest.check
+++ b/test/files/run/colltest.check
@@ -1,3 +1,4 @@
+warning: there were 2 deprecation warning(s); re-run with -deprecation for details
 true
 false
 true

--- a/test/files/run/t3361.check
+++ b/test/files/run/t3361.check
@@ -1,0 +1,1 @@
+warning: there were 16 deprecation warning(s); re-run with -deprecation for details

--- a/test/files/run/t3970.check
+++ b/test/files/run/t3970.check
@@ -1,0 +1,1 @@
+warning: there were 5 deprecation warning(s); re-run with -deprecation for details

--- a/test/files/run/t3996.check
+++ b/test/files/run/t3996.check
@@ -1,4 +1,1 @@
 warning: there were 2 deprecation warning(s); re-run with -deprecation for details
-LinkedList(1)
-LinkedList(1)
-true

--- a/test/files/run/t4080.check
+++ b/test/files/run/t4080.check
@@ -1,1 +1,2 @@
+warning: there were 3 deprecation warning(s); re-run with -deprecation for details
 LinkedList(1, 0, 2, 3)

--- a/test/files/run/t4461.check
+++ b/test/files/run/t4461.check
@@ -1,3 +1,4 @@
+warning: there were 4 deprecation warning(s); re-run with -deprecation for details
 Include(End,1)
 Include(End,2)
 Include(End,3)

--- a/test/files/run/t4813.check
+++ b/test/files/run/t4813.check
@@ -1,4 +1,1 @@
 warning: there were 2 deprecation warning(s); re-run with -deprecation for details
-LinkedList(1)
-LinkedList(1)
-true

--- a/test/files/run/t6292.check
+++ b/test/files/run/t6292.check
@@ -1,0 +1,1 @@
+warning: there were 7 deprecation warning(s); re-run with -deprecation for details

--- a/test/files/run/t6690.check
+++ b/test/files/run/t6690.check
@@ -1,4 +1,1 @@
 warning: there were 2 deprecation warning(s); re-run with -deprecation for details
-LinkedList(1)
-LinkedList(1)
-true

--- a/test/files/run/unittest_collection.check
+++ b/test/files/run/unittest_collection.check
@@ -1,2 +1,1 @@
 warning: there were 1 deprecation warning(s); re-run with -deprecation for details
-Stack(8, 7, 6, 5, 4, 3)

--- a/versions.properties
+++ b/versions.properties
@@ -1,4 +1,5 @@
-starr.version=2.11.0-M5
+starr.version=2.11.0-M6
+starr.use.released=1
 
 # the below is used for depending on dependencies like partest
 scala.binary.version=2.11.0-M5

--- a/versions.properties
+++ b/versions.properties
@@ -6,3 +6,5 @@ scala.binary.version=2.11.0-M5
 partest.version.number=1.0-RC5
 scala-xml.version.number=1.0-RC4
 scala-parser-combinators.version.number=1.0-RC2
+scala-compiler-doc.version.number=1.0.0-RC1
+scala-compiler-interactive.version.number=1.0.0-RC1


### PR DESCRIPTION
Enforce consistency of pack, docs, osgi, maven tasks.

Instead of scattering properties all over invocations of
staged-docs, staged-pack, make-bundle, copy-bundle and mvn-package,
these are now all fully determined by the project they act on.

The varying arguments to these macros are all centralized.
They are named like `project.prop`, where `prop` is one of:
description, package, dir, name, namesuffix, version,
targetdir, targetjar, jar, docroot, skipPackage, srcdir, src, srcjar.

The defaults for these properties are computed using `init-project-prop`.
