### PR TITLE
Collections: remove redundant calls to .seq

### DIFF
--- a/src/library/scala/collection/IterableLike.scala
+++ b/src/library/scala/collection/IterableLike.scala
@@ -202,7 +202,7 @@ self =>
     b.sizeHintBounded(n, this)
     val lead = this.iterator drop n
     var go = false
-    for (x <- this.seq) {
+    for (x <- this) {
       if (lead.hasNext) lead.next()
       else go = true
       if (go) b += x

--- a/src/library/scala/collection/SeqLike.scala
+++ b/src/library/scala/collection/SeqLike.scala
@@ -273,7 +273,7 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
 
   def reverseMap[B, That](f: A => B)(implicit bf: CanBuildFrom[Repr, B, That]): That = {
     var xs: List[A] = List()
-    for (x <- this.seq)
+    for (x <- this)
       xs = x :: xs
     val b = bf(repr)
     for (x <- xs)
@@ -478,7 +478,7 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
 
   private def occCounts[B](sq: Seq[B]): mutable.Map[B, Int] = {
     val occ = new mutable.HashMap[B, Int] { override def default(k: B) = 0 }
-    for (y <- sq.seq) occ(y) += 1
+    for (y <- sq) occ(y) += 1
     occ
   }
 
@@ -608,7 +608,7 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
     val len = this.length
     val arr = new ArraySeq[A](len)
     var i = 0
-    for (x <- this.seq) {
+    for (x <- this) {
       arr(i) = x
       i += 1
     }

--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -481,7 +481,7 @@ trait TraversableLike[+A, +Repr] extends Any
     var follow = false
     val b = newBuilder
     b.sizeHint(this, -1)
-    for (x <- this.seq) {
+    for (x <- this) {
       if (follow) b += lst
       else follow = true
       lst = x
@@ -506,7 +506,7 @@ trait TraversableLike[+A, +Repr] extends Any
   private[this] def sliceInternal(from: Int, until: Int, b: Builder[A, Repr]): Repr = {
     var i = 0
     breakable {
-      for (x <- this.seq) {
+      for (x <- this) {
         if (i >= from) b += x
         i += 1
         if (i >= until) break

--- a/src/library/scala/collection/TraversableOnce.scala
+++ b/src/library/scala/collection/TraversableOnce.scala
@@ -97,7 +97,7 @@ trait TraversableOnce[+A] extends Any with GenTraversableOnce[A] {
   // for internal use
   protected[this] def reversed = {
     var elems: List[A] = Nil
-    self.seq foreach (elems ::= _)
+    self foreach (elems ::= _)
     elems
   }
 
@@ -140,7 +140,7 @@ trait TraversableOnce[+A] extends Any with GenTraversableOnce[A] {
 
   def foldLeft[B](z: B)(op: (B, A) => B): B = {
     var result = z
-    this.seq foreach (x => result = op(result, x))
+    this foreach (x => result = op(result, x))
     result
   }
 

--- a/src/library/scala/collection/generic/Growable.scala
+++ b/src/library/scala/collection/generic/Growable.scala
@@ -54,7 +54,7 @@ trait Growable[-A] extends Clearable {
         loop(xs.tail)
       }
     }
-    xs.seq match {
+    xs match {
       case xs: scala.collection.LinearSeq[_] => loop(xs)
       case xs                                => xs foreach +=
     }

--- a/src/library/scala/collection/generic/Shrinkable.scala
+++ b/src/library/scala/collection/generic/Shrinkable.scala
@@ -46,5 +46,5 @@ trait Shrinkable[-A] {
    *  @param xs   the iterator producing the elements to remove.
    *  @return the $coll itself
    */
-  def --=(xs: TraversableOnce[A]): this.type = { xs.seq foreach -= ; this }
+  def --=(xs: TraversableOnce[A]): this.type = { xs foreach -= ; this }
 }

--- a/src/library/scala/collection/immutable/DefaultMap.scala
+++ b/src/library/scala/collection/immutable/DefaultMap.scala
@@ -46,7 +46,7 @@ trait DefaultMap[A, +B] extends Map[A, B] { self =>
    */
   override def - (key: A): Map[A, B] = {
     val b = newBuilder
-    for (kv <- this.seq ; if kv._1 != key) b += kv
+    for (kv <- this ; if kv._1 != key) b += kv
     b.result()
   }
 }

--- a/src/library/scala/collection/mutable/ArrayStack.scala
+++ b/src/library/scala/collection/mutable/ArrayStack.scala
@@ -157,7 +157,7 @@ extends AbstractSeq[T]
    *  @param xs The source of elements to push.
    *  @return   A reference to this stack.
    */
-  override def ++=(xs: TraversableOnce[T]): this.type = { xs.seq foreach += ; this }
+  override def ++=(xs: TraversableOnce[T]): this.type = { xs foreach += ; this }
 
   /** Does the same as `push`, but returns the updated stack.
    *

--- a/src/library/scala/collection/mutable/Stack.scala
+++ b/src/library/scala/collection/mutable/Stack.scala
@@ -119,7 +119,7 @@ extends AbstractSeq[A]
    *  @param xs the traversable object.
    *  @return the stack with the new elements on top.
    */
-  def pushAll(xs: TraversableOnce[A]): this.type = { xs.seq foreach push ; this }
+  def pushAll(xs: TraversableOnce[A]): this.type = { xs foreach push ; this }
 
   /** Returns the top element of the stack. This method will not remove
    *  the element from the stack. An error is signaled if there is no


### PR DESCRIPTION
Students of Scala's history might recall that at introduction of
parallel collections, GenIterable et al were _not_ added; instead
the parallel collections inherited from the existing interfaces.

This of course was an invitation to widespread disaster as any
existing code that foreach-ed over a collection might now experience
unwanted concurrency.

The first attempt to fix this was to add the `.seq` method to
convert a parallel colleciton to a sequential one. This was added
in e579152f732, and call sites in the standard library with
side-effecting foreach calls were changed to use that.

But this was (rightly) deemed inadequate, as we could hardly expect
people to change existing code or remember to do this in new code.

So later, in 3de96153e5b, GenIterable was sprouted, and parallel
collections were re-parented.

This commit removes residual needless calls to .seq when the static
type of the receiver is already a plain Iterable, which are no-ops.

Review by @axel22
