### PR TITLE
Implicit search optimizations

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1551,6 +1551,9 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
       }
     }
 
+    /** Caching member symbols that are def-s in Defintions because they might change from Run to Run. */
+    val runDefinitions: definitions.RunDefinitions = new definitions.RunDefinitions
+
     /** Compile list of source files,
      *  unless there is a problem already,
      *  such as a plugin was passed a bad option.

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -560,7 +560,7 @@ trait Implicits {
       // side is a class, else we may not know enough.
       case tr1 @ TypeRef(_, sym1, _) if sym1.isClass =>
         tp2.dealiasWiden match {
-          case TypeRef(_, sym2, _)         => sym2.isClass && !(sym1 isWeakSubClass sym2)
+          case TypeRef(_, sym2, _)         => ((sym1 eq ByNameParamClass) != (sym2 eq ByNameParamClass)) || (sym2.isClass && !(sym1 isWeakSubClass sym2))
           case RefinedType(parents, decls) => decls.nonEmpty && tr1.member(decls.head.name) == NoSymbol
           case _                           => false
         }

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -333,6 +333,9 @@ trait Implicits {
     val undetParams = if (isView) Nil else context.outer.undetparams
     val wildPt = approximate(pt)
 
+    private val runDefintions = currentRun.runDefinitions
+    import runDefintions.{ TagMaterializers, TagSymbols, Predef_conforms, PartialManifestClass, ManifestSymbols }
+
     def undet_s = if (undetParams.isEmpty) "" else undetParams.mkString(" inferring ", ", ", "")
     def tree_s = typeDebug ptTree tree
     def ctx_s = fullSiteString(context)
@@ -802,7 +805,7 @@ trait Implicits {
 
       private def isIneligible(info: ImplicitInfo) = (
            info.isCyclicOrErroneous
-        || isView && isPredefMemberNamed(info.sym, nme.conforms)
+        || isView && (info.sym eq Predef_conforms)
         || shadower.isShadowed(info.name)
         || (!context.macrosEnabled && info.sym.isTermMacro)
       )
@@ -1101,13 +1104,6 @@ trait Implicits {
       }
     }
 
-    private def TagSymbols =  TagMaterializers.keySet
-    private val TagMaterializers = Map[Symbol, Symbol](
-      ClassTagClass    -> materializeClassTag,
-      WeakTypeTagClass -> materializeWeakTypeTag,
-      TypeTagClass     -> materializeTypeTag
-    )
-
     /** Creates a tree will produce a tag of the requested flavor.
       * An EmptyTree is returned if materialization fails.
       */
@@ -1168,8 +1164,6 @@ trait Implicits {
       // this is ugly but temporary, since all this code will be removed once I fix implicit macros
       else SearchFailure
     }
-
-    private val ManifestSymbols = Set[Symbol](PartialManifestClass, FullManifestClass, OptManifestClass)
 
     /** Creates a tree that calls the relevant factory method in object
       * scala.reflect.Manifest for type 'tp'. An EmptyTree is returned if

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3847,7 +3847,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         if (sameLength(tparams, args)) {
           val targs = args map (_.tpe)
           checkBounds(tree, NoPrefix, NoSymbol, tparams, targs, "")
-          if (fun.symbol == Predef_classOf)
+          if (fun.symbol == currentRun.runDefinitions.Predef_classOf)
             typedClassOf(tree, args.head, noGen = true)
           else {
             if (!isPastTyper && fun.symbol == Any_isInstanceOf && targs.nonEmpty) {
@@ -4807,7 +4807,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               typed1(This(sym.owner) setPos tree.pos, mode, pt)
           // Inferring classOf type parameter from expected type.  Otherwise an
           // actual call to the stubbed classOf method is generated, returning null.
-            else if (isPredefMemberNamed(sym, nme.classOf) && pt.typeSymbol == ClassClass && pt.typeArgs.nonEmpty)
+            else if ((sym eq currentRun.runDefinitions.Predef_classOf) && pt.typeSymbol == ClassClass && pt.typeArgs.nonEmpty)
             typedClassOf(tree, TypeTree(pt.typeArgs.head))
           else {
               val pre1  = if (sym.isTopLevel) sym.owner.thisType else if (qual == EmptyTree) NoPrefix else qual.tpe

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -359,11 +359,7 @@ trait Definitions extends api.StandardDefinitions {
       def Predef_???                 = getMemberMethod(PredefModule, nme.???)
       def Predef_implicitly          = getMemberMethod(PredefModule, nme.implicitly)
 
-    /** Is `sym` a member of Predef with the given name?
-     *  Note: DON't replace this by sym == Predef_conforms/etc, as Predef_conforms is a `def`
-     *  which does a member lookup (it can't be a lazy val because we might reload Predef
-     *  during resident compilations).
-     */
+    @deprecated("use sym = currentRun.runDefinitions.Predef_xxx", "2.11.0")
     def isPredefMemberNamed(sym: Symbol, name: Name) = (
       (sym.name == name) && (sym.owner == PredefModule.moduleClass)
     )
@@ -496,7 +492,6 @@ trait Definitions extends api.StandardDefinitions {
          def ReflectRuntimeUniverse      = ReflectRuntimePackage.map(sym => getMemberValue(sym, nme.universe))
          def ReflectRuntimeCurrentMirror = ReflectRuntimePackage.map(sym => getMemberMethod(sym, nme.currentMirror))
 
-    lazy val PartialManifestClass  = getTypeMember(ReflectPackage, tpnme.ClassManifest)
     lazy val PartialManifestModule = requiredModule[scala.reflect.ClassManifestFactory.type]
     lazy val FullManifestClass     = requiredClass[scala.reflect.Manifest[_]]
     lazy val FullManifestModule    = requiredModule[scala.reflect.ManifestFactory.type]
@@ -1412,6 +1407,21 @@ trait Definitions extends api.StandardDefinitions {
       lazy val listListTreeType = appliedType(ListClass, listTreeType)
 
       def universeMemberType(name: TypeName) = universe.tpe.memberType(getTypeMember(universe.symbol, name))
+    }
+
+    /** Efficient access to member symbols which must be looked up each run. Access via `currentRun.runRefinitions` */
+    final class RunDefinitions {
+      lazy val TagMaterializers = Map[Symbol, Symbol](
+        ClassTagClass    -> materializeClassTag,
+        WeakTypeTagClass -> materializeWeakTypeTag,
+        TypeTagClass     -> materializeTypeTag
+      )
+      lazy val TagSymbols = TagMaterializers.keySet
+      lazy val Predef_conforms = getMemberMethod(PredefModule, nme.conforms)
+      lazy val Predef_classOf  = DefinitionsClass.this.Predef_classOf
+
+      lazy val PartialManifestClass  = getTypeMember(ReflectPackage, tpnme.ClassManifest)
+      val ManifestSymbols = Set[Symbol](PartialManifestClass, FullManifestClass, OptManifestClass)
     }
   }
 }

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -304,7 +304,6 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.ReflectPackage
     definitions.ReflectApiPackage
     definitions.ReflectRuntimePackage
-    definitions.PartialManifestClass
     definitions.PartialManifestModule
     definitions.FullManifestClass
     definitions.FullManifestModule


### PR DESCRIPTION
I'm trying to submit a few of the (hopefully) uncontroversial
patches from my attempts to optimize the compiler. This pull
request focusses on implicit search.
- avoid repeated member lookup and creation of sets of symbols by
  introducing a per-run analog of Definitions. There is more
  work to be done in the name of correctness there under the
  banner of .
- implicit class symbols were never meant to be in an ImplicitInfo,
  only the factory method should be in there.
- cache 'isErroneousOrCyclic' in ImplicitInfo (which itself is
  cached per-run in Contexts (for in-scope implicits) and in
  Implicits (for companion object implicits.)

Review by @gkossakowski @adriaanm. /cc @xeno-by 
