### PR TITLE
SI-6546 InnerClasses attribute refers to absent class

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
@@ -104,6 +104,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
       if (settings.Xdce)
         for ((sym, cls) <- icodes.classes if inliner.isClosureClass(sym) && !deadCode.liveClosures(sym)) {
           log(s"Optimizer eliminated ${sym.fullNameString}")
+          deadCode.elidedClosures += sym
           icodes.classes -= sym
         }
 
@@ -639,7 +640,8 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
           innerClassBuffer += m
       }
 
-      val allInners: List[Symbol] = innerClassBuffer.toList
+      val allInners: List[Symbol] = innerClassBuffer.toList filterNot deadCode.elidedClosures
+
       if (allInners.nonEmpty) {
         debuglog(csym.fullName('.') + " contains " + allInners.size + " inner classes.")
 

--- a/test/files/run/t6546.flags
+++ b/test/files/run/t6546.flags
@@ -1,0 +1,1 @@
+-optimise

--- a/test/files/run/t6546/A_1.scala
+++ b/test/files/run/t6546/A_1.scala
@@ -1,0 +1,6 @@
+final class Opt {
+  @inline def getOrElse(x: => String): String = ""
+}
+class A_1 {
+  def f(x: Opt): String = x getOrElse null
+}

--- a/test/files/run/t6546/B_2.scala
+++ b/test/files/run/t6546/B_2.scala
@@ -1,0 +1,8 @@
+import scala.tools.partest.BytecodeTest
+
+object Test extends BytecodeTest {
+  def show: Unit = {
+    val node = loadClassNode("A_1")
+    assert(node.innerClasses.isEmpty, node.innerClasses)
+  }
+}


### PR DESCRIPTION
At issue is that the optimizer would eliminate closure classes
completely, then neglect to eliminate those classes from the
container's InnerClasses attribute. This breaks tooling which
expects those entries to correspond to real classes.

The code changes are by mgarcia - I only added the test case,
which verifies that after being compiled under -optimise, there
are no inner classes. Before/after:

``` diff
  7,8d6
  <   InnerClasses:
  <        public final #22; //class A_1$$anonfun$f$1
  37,45c35,40
  <   #21 = Utf8               A_1$$anonfun$f$1
  <   #22 = Class              #21            //  A_1$$anonfun$f$1
  <   #23 = Utf8               Code
  ---
  >   #21 = Utf8               Code
```
