### PR TITLE
SI-7776 post-erasure signature clashes are now macro-aware

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -866,6 +866,9 @@ abstract class Erasure extends AddInterfaces
       low setInfo ErrorType
     }
 
+    private def sameTypeAfterErasure(sym1: Symbol, sym2: Symbol) =
+      exitingPostErasure(sym1.info =:= sym2.info) && !sym1.isMacro && !sym2.isMacro
+
     /** TODO - adapt SymbolPairs so it can be used here. */
     private def checkNoDeclaredDoubleDefs(base: Symbol) {
       val decls = base.info.decls
@@ -874,7 +877,7 @@ abstract class Erasure extends AddInterfaces
         if (e.sym.isTerm) {
           var e1 = decls lookupNextEntry e
           while (e1 ne null) {
-            if (exitingPostErasure(e1.sym.info =:= e.sym.info))
+            if (sameTypeAfterErasure(e.sym, e1.sym))
               doubleDefError(new SymbolPair(base, e.sym, e1.sym))
 
             e1 = decls lookupNextEntry e1
@@ -904,12 +907,12 @@ abstract class Erasure extends AddInterfaces
         )
         override def matches(sym1: Symbol, sym2: Symbol) = true
       }
-      def sameTypeAfterErasure(pair: SymbolPair) = {
+      def isErasureDoubleDef(pair: SymbolPair) = {
         import pair._
         log(s"Considering for erasure clash:\n$pair")
-        !exitingRefchecks(lowType matches highType) && exitingPostErasure(low.tpe =:= high.tpe)
+        !exitingRefchecks(lowType matches highType) && sameTypeAfterErasure(low, high)
       }
-      opc.iterator filter sameTypeAfterErasure foreach doubleDefError
+      opc.iterator filter isErasureDoubleDef foreach doubleDefError
     }
 
     /**  Add bridge definitions to a template. This means:

--- a/test/files/pos/t7776.scala
+++ b/test/files/pos/t7776.scala
@@ -1,0 +1,20 @@
+import scala.language.experimental.macros
+import scala.reflect.macros.Context
+
+class MacroErasure {
+  def app(f: Any => Any, x: Any): Any = macro MacroErasure.appMacro
+  def app[A](f: A => Any, x: Any): Any = macro MacroErasure.appMacroA[A]
+}
+
+object MacroErasure {
+  def appMacro(c: Context)(
+    f: c.Expr[Any => Any], x: c.Expr[Any]): c.Expr[Any] = {
+    import c.universe._
+    c.Expr(q"$f($x)")
+  }
+  def appMacroA[A](c: Context)(f: c.Expr[A => Any], x: c.Expr[Any])(
+    implicit tt: c.WeakTypeTag[A]): c.Expr[Any] = {
+    import c.universe._
+    c.Expr(q"$f[${tt.tpe}]($x)")
+  }
+}


### PR DESCRIPTION
"double definition: macro this and method that have same type after erasure"
This error doesn't make sense when macros are involved, because macros
expand at compile-time, where we're not affected by erasure. Moreover,
macros produce no bytecode, which means that we're safe from VerifyErrors.
