### PR TITLE
Topic/tidy collections

### DIFF
--- a/src/library/scala/collection/GenTraversableOnce.scala
+++ b/src/library/scala/collection/GenTraversableOnce.scala
@@ -518,7 +518,7 @@ trait GenTraversableOnce[+A] extends Any {
    */
   def toIterator: Iterator[A]
 
-  /** Converts this $coll to a mutable buffer.
+  /** Uses the contents of this $coll to create a new mutable buffer.
    *  $willNotTerminateInf
    *  @return a buffer containing all elements of this $coll.
    */

--- a/src/library/scala/collection/IterableLike.scala
+++ b/src/library/scala/collection/IterableLike.scala
@@ -83,10 +83,26 @@ self =>
     iterator.foldRight(z)(op)
   override /*TraversableLike*/ def reduceRight[B >: A](op: (A, B) => B): B =
     iterator.reduceRight(op)
+    
+  
+  /** Returns this $coll as an iterable collection.
+   *
+   *  A new collection will not be built; lazy collections will stay lazy.
+   *
+   *  $willNotTerminateInf
+   *  @return an `Iterable` containing all elements of this $coll.
+   */
   override /*TraversableLike*/ def toIterable: Iterable[A] =
     thisCollection
-  override /*TraversableLike*/ def toIterator: Iterator[A] =
-    iterator
+  
+  /** Returns an Iterator over the elements in this $coll.  Produces the same
+   *  result as `iterator`.
+   *  $willNotTerminateInf
+   *  @return an Iterator containing all elements of this $coll.
+   */
+  @deprecatedOverriding("toIterator should stay consistent with iterator for all Iterables: override iterator instead.", "2.11.0")
+  override def toIterator: Iterator[A] = iterator
+  
   override /*TraversableLike*/ def head: A =
     iterator.next()
 

--- a/src/library/scala/collection/IterableProxyLike.scala
+++ b/src/library/scala/collection/IterableProxyLike.scala
@@ -23,6 +23,7 @@ import mutable.Buffer
  *  @version 2.8
  *  @since   2.8
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 trait IterableProxyLike[+A, +Repr <: IterableLike[A, Repr] with Iterable[A]]
     extends IterableLike[A, Repr]
     with TraversableProxyLike[A, Repr] {

--- a/src/library/scala/collection/MapProxyLike.scala
+++ b/src/library/scala/collection/MapProxyLike.scala
@@ -18,6 +18,7 @@ package collection
  *  @version 2.8
  *  @since   2.8
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 trait MapProxyLike[A, +B, +This <: MapLike[A, B, This] with Map[A, B]]
       extends MapLike[A, B, This]
       with IterableProxyLike[(A, B), This]

--- a/src/library/scala/collection/SeqLike.scala
+++ b/src/library/scala/collection/SeqLike.scala
@@ -622,7 +622,7 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
   /** Converts this $coll to a sequence.
    *  $willNotTerminateInf
    *
-   *  Overridden for efficiency.
+   *  A new collection will not be built; in particular, lazy sequences will stay lazy.
    */
   override def toSeq: Seq[A] = thisCollection
 

--- a/src/library/scala/collection/SeqProxy.scala
+++ b/src/library/scala/collection/SeqProxy.scala
@@ -18,4 +18,5 @@ package collection
  *  @version 2.8
  *  @since   2.8
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 trait SeqProxy[+A] extends Seq[A] with SeqProxyLike[A, Seq[A]]

--- a/src/library/scala/collection/SeqProxyLike.scala
+++ b/src/library/scala/collection/SeqProxyLike.scala
@@ -23,6 +23,7 @@ import generic._
  *  @version 2.8
  *  @since   2.8
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 trait SeqProxyLike[+A, +Repr <: SeqLike[A, Repr] with Seq[A]] extends SeqLike[A, Repr] with IterableProxyLike[A, Repr] {
   override def size = self.size
   override def toSeq: Seq[A] = self.toSeq

--- a/src/library/scala/collection/SetProxyLike.scala
+++ b/src/library/scala/collection/SetProxyLike.scala
@@ -17,6 +17,7 @@ package collection
  *  @author  Martin Odersky
  *  @version 2.8
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 trait SetProxyLike[A, +This <: SetLike[A, This] with Set[A]] extends SetLike[A, This] with IterableProxyLike[A, This] {
   def empty: This
   override def contains(elem: A): Boolean = self.contains(elem)

--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -623,7 +623,9 @@ trait TraversableLike[+A, +Repr] extends Any
     }
   }
 
+  @deprecatedOverriding("Enforce contract of toTraversable that if it is Traversable it returns itself.", "2.11.0")
   def toTraversable: Traversable[A] = thisCollection
+  
   def toIterator: Iterator[A] = toStream.iterator
   def toStream: Stream[A] = toBuffer.toStream
   // Override to provide size hint.

--- a/src/library/scala/collection/TraversableProxyLike.scala
+++ b/src/library/scala/collection/TraversableProxyLike.scala
@@ -24,6 +24,7 @@ import scala.reflect.ClassTag
  *  @version 2.8
  *  @since   2.8
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 trait TraversableProxyLike[+A, +Repr <: TraversableLike[A, Repr] with Traversable[A]] extends TraversableLike[A, Repr] with Proxy {
   def self: Repr
 

--- a/src/library/scala/collection/generic/IterableForwarder.scala
+++ b/src/library/scala/collection/generic/IterableForwarder.scala
@@ -26,6 +26,7 @@ import scala.collection._
  *  @version 2.8
  *  @since   2.8
  */
+@deprecated("Forwarding is inherently unreliable since it is not automated and methods can be forgotten.", "2.11.0")
 trait IterableForwarder[+A] extends Iterable[A] with TraversableForwarder[A] {
 
   /** The iterable object to which calls are forwarded */

--- a/src/library/scala/collection/generic/SeqForwarder.scala
+++ b/src/library/scala/collection/generic/SeqForwarder.scala
@@ -25,6 +25,7 @@ import scala.collection.immutable.Range
  *  @version 2.8
  *  @since   2.8
  */
+@deprecated("Forwarding is inherently unreliable since it is not automated and new methods can be forgotten.", "2.11.0")
 trait SeqForwarder[+A] extends Seq[A] with IterableForwarder[A] {
 
   protected override def underlying: Seq[A]

--- a/src/library/scala/collection/generic/TraversableForwarder.scala
+++ b/src/library/scala/collection/generic/TraversableForwarder.scala
@@ -27,6 +27,7 @@ import scala.reflect.ClassTag
  *  @version 2.8
  *  @since   2.8
  */
+@deprecated("Forwarding is inherently unreliable since it is not automated and new methods can be forgotten.", "2.11.0")
 trait TraversableForwarder[+A] extends Traversable[A] {
   /** The traversable object to which calls are forwarded. */
   protected def underlying: Traversable[A]

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -33,6 +33,7 @@ import parallel.immutable.ParHashMap
  *  @define willNotTerminateInf
  */
 @SerialVersionUID(2L)
+@deprecatedInheritance("The implementation details of immutable hash maps make inheriting from them unwise.", "2.11.0")
 class HashMap[A, +B] extends AbstractMap[A, B]
                         with Map[A, B]
                         with MapLike[A, B, HashMap[A, B]]

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -30,6 +30,7 @@ import scala.collection.parallel.immutable.ParHashSet
  *  @define coll immutable hash set
  */
 @SerialVersionUID(2L)
+@deprecatedInheritance("The implementation details of immutable hash sets make inheriting from them unwise.", "2.11.0")
 class HashSet[A] extends AbstractSet[A]
                     with Set[A]
                     with GenericSetTemplate[A, HashSet]

--- a/src/library/scala/collection/immutable/IndexedSeq.scala
+++ b/src/library/scala/collection/immutable/IndexedSeq.scala
@@ -23,6 +23,12 @@ trait IndexedSeq[+A] extends Seq[A]
                     with GenericTraversableTemplate[A, IndexedSeq]
                     with IndexedSeqLike[A, IndexedSeq[A]] {
   override def companion: GenericCompanion[IndexedSeq] = IndexedSeq
+  
+  /** Returns this $coll as an indexed sequence.
+   *  
+   *  A new indexed sequence will not be built; lazy collections will stay lazy.
+   */
+  @deprecatedOverriding("Immutable indexed sequences should do nothing on toIndexedSeq except cast themselves as an indexed sequence.", "2.11.0")
   override def toIndexedSeq: IndexedSeq[A] = this
   override def seq: IndexedSeq[A] = this
 }

--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -49,6 +49,7 @@ object ListMap extends ImmutableMapFactory[ListMap] {
  *  @define willNotTerminateInf
  */
 @SerialVersionUID(301002838095710379L)
+@deprecatedInheritance("The semantics of immutable collections makes inheriting from ListMap error-prone.", "2.11.0")
 class ListMap[A, +B]
 extends AbstractMap[A, B]
    with Map[A, B]

--- a/src/library/scala/collection/immutable/ListSet.scala
+++ b/src/library/scala/collection/immutable/ListSet.scala
@@ -64,6 +64,7 @@ object ListSet extends ImmutableSetFactory[ListSet] {
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  */
+@deprecatedInheritance("The semantics of immutable collections makes inheriting from ListSet error-prone.", "2.11.0")
 class ListSet[A] extends AbstractSet[A]
                     with Set[A]
                     with GenericSetTemplate[A, ListSet]

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -32,6 +32,12 @@ trait Map[A, +B] extends Iterable[(A, B)]
                     with MapLike[A, B, Map[A, B]] { self =>
 
   override def empty: Map[A, B] = Map.empty
+  
+  /** Returns this $coll as an immutable map.
+   *  
+   *  A new map will not be built; lazy collections will stay lazy.
+   */
+  @deprecatedOverriding("Immutable maps should do nothing on toMap except return themselves cast as a map.",  "2.11.0")
   override def toMap[T, U](implicit ev: (A, B) <:< (T, U)): immutable.Map[T, U] =
     self.asInstanceOf[immutable.Map[T, U]]
 

--- a/src/library/scala/collection/immutable/MapProxy.scala
+++ b/src/library/scala/collection/immutable/MapProxy.scala
@@ -23,6 +23,7 @@ package immutable
  *  @version 2.0, 31/12/2006
  *  @since   2.8
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 trait MapProxy[A, +B] extends Map[A, B] with MapProxyLike[A, B, Map[A, B]] {
   override def repr = this
   private def newProxy[B1 >: B](newSelf: Map[A, B1]): MapProxy[A, B1] =

--- a/src/library/scala/collection/immutable/PagedSeq.scala
+++ b/src/library/scala/collection/immutable/PagedSeq.scala
@@ -126,6 +126,7 @@ import PagedSeq._
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  */
+@deprecatedInheritance("The implementation details of paged sequences make inheriting from them unwise.", "2.11.0")
 class PagedSeq[T: ClassTag] protected(
   more: (Array[T], Int, Int) => Int,
   first1: Page[T],

--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -38,6 +38,7 @@ import scala.annotation.tailrec
  */
 
 @SerialVersionUID(-7622936493364270175L)
+@deprecatedInheritance("The implementation details of immutable queues make inheriting from them unwise.", "2.11.0")
 class Queue[+A] protected(protected val in: List[A], protected val out: List[A])
          extends AbstractSeq[A]
             with LinearSeq[A]

--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -42,6 +42,7 @@ import scala.collection.parallel.immutable.ParRange
  *         and its complexity is O(1).
  */
 @SerialVersionUID(7618862778670199309L)
+@deprecatedInheritance("The implementation details of Range makes inheriting from it unwise.", "2.11.0")
 class Range(val start: Int, val end: Int, val step: Int)
 extends scala.collection.AbstractSeq[Int]
    with IndexedSeq[Int]

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -33,7 +33,15 @@ trait Set[A] extends Iterable[A]
                 with Parallelizable[A, ParSet[A]]
 {
   override def companion: GenericCompanion[Set] = Set
+  
+  
+  /** Returns this $coll as an immutable map.
+   *  
+   *  A new map will not be built; lazy collections will stay lazy.
+   */
+  @deprecatedOverriding("Immutable sets should do nothing on toSet but return themselves cast as a Set.", "2.11.0")
   override def toSet[B >: A]: Set[B] = this.asInstanceOf[Set[B]]
+  
   override def seq: Set[A] = this
   protected override def parCombiner = ParSet.newCombiner[A] // if `immutable.SetLike` gets introduced, please move this there!
 }

--- a/src/library/scala/collection/immutable/SetProxy.scala
+++ b/src/library/scala/collection/immutable/SetProxy.scala
@@ -22,6 +22,7 @@ package immutable
  *
  *  @since 2.8
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 trait SetProxy[A] extends Set[A] with SetProxyLike[A, Set[A]] {
   override def repr = this
   private def newProxy[B >: A](newSelf: Set[B]): SetProxy[B] =

--- a/src/library/scala/collection/immutable/Stack.scala
+++ b/src/library/scala/collection/immutable/Stack.scala
@@ -46,6 +46,7 @@ object Stack extends SeqFactory[Stack] {
  *  @define willNotTerminateInf
  */
 @SerialVersionUID(1976480595012942526L)
+@deprecated("Stack is an inelegant and potentially poorly-performing wrapper around List.  Use List instead: stack push x becomes x :: list; stack.pop is list.tail.", "2.11.0")
 class Stack[+A] protected (protected val elems: List[A])
                  extends AbstractSeq[A]
                     with LinearSeq[A]

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -44,6 +44,7 @@ object TreeMap extends ImmutableSortedMapFactory[TreeMap] {
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  */
+@deprecatedInheritance("The implementation details of immutable tree maps make inheriting from them unwise.", "2.11.0")
 class TreeMap[A, +B] private (tree: RB.Tree[A, B])(implicit val ordering: Ordering[A])
   extends SortedMap[A, B]
      with SortedMapLike[A, B, TreeMap[A, B]]

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -49,6 +49,7 @@ object TreeSet extends ImmutableSortedSetFactory[TreeSet] {
  *  @define willNotTerminateInf
  */
 @SerialVersionUID(-5685982407650748405L)
+@deprecatedInheritance("The implementation details of immutable tree sets make inheriting from them unwise.", "2.11.0")
 class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: Ordering[A])
   extends SortedSet[A] with SortedSetLike[A, TreeSet[A]] with Serializable {
 

--- a/src/library/scala/collection/immutable/WrappedString.scala
+++ b/src/library/scala/collection/immutable/WrappedString.scala
@@ -29,6 +29,7 @@ import mutable.{Builder, StringBuilder}
  *  @define Coll `WrappedString`
  *  @define coll wrapped string
  */
+@deprecatedInheritance("Inherit from StringLike instead of WrappedString.", "2.11.0")
 class WrappedString(val self: String) extends AbstractSeq[Char] with IndexedSeq[Char] with StringLike[WrappedString] {
 
   override protected[this] def thisCollection: WrappedString = this

--- a/src/library/scala/collection/mutable/ArrayBuilder.scala
+++ b/src/library/scala/collection/mutable/ArrayBuilder.scala
@@ -52,6 +52,7 @@ object ArrayBuilder {
    *
    *  @tparam T     type of elements for the array builder, subtype of `AnyRef` with a `ClassTag` context bound.
    */
+  @deprecatedInheritance("ArrayBuilder.ofRef is an internal implementation not intended for subclassing.", "2.11.0")
   class ofRef[T <: AnyRef : ClassTag] extends ArrayBuilder[T] {
 
     private var elems: Array[T] = _
@@ -116,6 +117,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `byte`s. */
+  @deprecatedInheritance("ArrayBuilder.ofByte is an internal implementation not intended for subclassing.", "2.11.0")
   class ofByte extends ArrayBuilder[Byte] {
 
     private var elems: Array[Byte] = _
@@ -180,6 +182,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `short`s. */
+  @deprecatedInheritance("ArrayBuilder.ofShort is an internal implementation not intended for subclassing.", "2.11.0")
   class ofShort extends ArrayBuilder[Short] {
 
     private var elems: Array[Short] = _
@@ -244,6 +247,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `char`s. */
+  @deprecatedInheritance("ArrayBuilder.ofChar is an internal implementation not intended for subclassing.", "2.11.0")
   class ofChar extends ArrayBuilder[Char] {
 
     private var elems: Array[Char] = _
@@ -308,6 +312,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `int`s. */
+  @deprecatedInheritance("ArrayBuilder.ofInt is an internal implementation not intended for subclassing.", "2.11.0")
   class ofInt extends ArrayBuilder[Int] {
 
     private var elems: Array[Int] = _
@@ -372,6 +377,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `long`s. */
+  @deprecatedInheritance("ArrayBuilder.ofLong is an internal implementation not intended for subclassing.", "2.11.0")
   class ofLong extends ArrayBuilder[Long] {
 
     private var elems: Array[Long] = _
@@ -436,6 +442,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `float`s. */
+  @deprecatedInheritance("ArrayBuilder.ofFloat is an internal implementation not intended for subclassing.", "2.11.0")
   class ofFloat extends ArrayBuilder[Float] {
 
     private var elems: Array[Float] = _
@@ -500,6 +507,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `double`s. */
+  @deprecatedInheritance("ArrayBuilder.ofDouble is an internal implementation not intended for subclassing.", "2.11.0")
   class ofDouble extends ArrayBuilder[Double] {
 
     private var elems: Array[Double] = _
@@ -628,6 +636,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `Unit` type. */
+  @deprecatedInheritance("ArrayBuilder.ofUnit is an internal implementation not intended for subclassing.", "2.11.0")
   class ofUnit extends ArrayBuilder[Unit] {
 
     private var elems: Array[Unit] = _

--- a/src/library/scala/collection/mutable/ArrayLike.scala
+++ b/src/library/scala/collection/mutable/ArrayLike.scala
@@ -10,8 +10,9 @@ package scala
 package collection
 package mutable
 
-/** A common supertrait of `ArrayOps` and `WrappedArray` that factors out most
- *  operations on arrays and wrapped arrays.
+/** A common supertrait of `ArrayOps` and `WrappedArray` that factors out the 
+ * `deep` method for arrays and wrapped arrays and serves as a marker trait
+ * for array wrappers.
  *
  *  @tparam A     type of the elements contained in the array like object.
  *  @tparam Repr  the type of the actual collection containing the elements.

--- a/src/library/scala/collection/mutable/ArrayOps.scala
+++ b/src/library/scala/collection/mutable/ArrayOps.scala
@@ -33,6 +33,7 @@ import parallel.mutable.ParArray
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  */
+@deprecatedInheritance("ArrayOps will be sealed to facilitate greater flexibility with array/collections integration in future releases.", "2.11.0")
 trait ArrayOps[T] extends Any with ArrayLike[T, Array[T]] with CustomParallelizable[T, ParArray[T]] {
 
   private def elementClass: Class[_] =

--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -37,7 +37,7 @@ import BitSetLike.{LogWL, MaxSize, updateArray}
  *  @define willNotTerminateInf
  */
 @SerialVersionUID(8483111450368547763L)
-class BitSet(protected var elems: Array[Long]) extends AbstractSet[Int]
+class BitSet(protected final var elems: Array[Long]) extends AbstractSet[Int]
                                                   with SortedSet[Int]
                                                   with scala.collection.BitSet
                                                   with BitSetLike[BitSet]
@@ -54,16 +54,19 @@ class BitSet(protected var elems: Array[Long]) extends AbstractSet[Int]
 
   def this() = this(0)
 
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def nwords = elems.length
+  
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def word(idx: Int): Long =
     if (idx < nwords) elems(idx) else 0L
 
-  private def updateWord(idx: Int, w: Long) {
+  protected final def updateWord(idx: Int, w: Long) {
     ensureCapacity(idx)
     elems(idx) = w
   }
 
-  private def ensureCapacity(idx: Int) {
+  protected final def ensureCapacity(idx: Int) {
     require(idx < MaxSize)
     if (idx >= nwords) {
       var newlen = nwords
@@ -95,7 +98,10 @@ class BitSet(protected var elems: Array[Long]) extends AbstractSet[Int]
     } else false
   }
 
+  @deprecatedOverriding("Override add to prevent += and add from exhibiting different behavior.", "2.11.0")
   def += (elem: Int): this.type = { add(elem); this }
+  
+  @deprecatedOverriding("Override add to prevent += and add from exhibiting different behavior.", "2.11.0")
   def -= (elem: Int): this.type = { remove(elem); this }
 
   /** Updates this bitset to the union with another bitset by performing a bitwise "or".

--- a/src/library/scala/collection/mutable/BufferLike.scala
+++ b/src/library/scala/collection/mutable/BufferLike.scala
@@ -184,6 +184,7 @@ trait BufferLike[A, +This <: BufferLike[A, This] with Buffer[A]]
    *
    *  @param cmd  the message to send.
    */
+  @deprecated("Scripting is deprecated.", "2.11.0")
   def <<(cmd: Message[A]): Unit = cmd match {
     case Include(Start, x)      => prepend(x)
     case Include(End, x)        => append(x)

--- a/src/library/scala/collection/mutable/BufferProxy.scala
+++ b/src/library/scala/collection/mutable/BufferProxy.scala
@@ -26,6 +26,7 @@ import script._
  *  @define Coll `BufferProxy`
  *  @define coll buffer proxy
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 trait BufferProxy[A] extends Buffer[A] with Proxy {
 
   def self: Buffer[A]
@@ -131,6 +132,7 @@ trait BufferProxy[A] extends Buffer[A] with Proxy {
    *
    *  @param cmd  the message to send.
    */
+  @deprecated("Scripting is deprecated.", "2.11.0")
   override def <<(cmd: Message[A]) { self << cmd }
 
   /** Return a clone of this buffer.

--- a/src/library/scala/collection/mutable/DoubleLinkedList.scala
+++ b/src/library/scala/collection/mutable/DoubleLinkedList.scala
@@ -41,6 +41,7 @@ import generic._
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  */
+@deprecated("Low-level linked lists are deprecated due to idiosyncracies in interface and incomplete features.", "2.11.0")
 @SerialVersionUID(-8144992287952814767L)
 class DoubleLinkedList[A]() extends AbstractSeq[A]
                             with LinearSeq[A]
@@ -77,6 +78,7 @@ class DoubleLinkedList[A]() extends AbstractSeq[A]
  *  @define coll double linked list
  *  @define Coll `DoubleLinkedList`
  */
+@deprecated("Low-level linked lists are deprecated.", "2.11.0")
 object DoubleLinkedList extends SeqFactory[DoubleLinkedList] {
   /** $genericCanBuildFromInfo */
   implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, DoubleLinkedList[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]

--- a/src/library/scala/collection/mutable/DoubleLinkedListLike.scala
+++ b/src/library/scala/collection/mutable/DoubleLinkedListLike.scala
@@ -56,6 +56,7 @@ import scala.annotation.migration
  *  @define Coll `DoubleLinkedList`
  *  @define coll double linked list
  */
+@deprecated("Low-level linked lists are deprecated due to idiosyncracies in interface and incomplete features.", "2.11.0")
 trait DoubleLinkedListLike[A, This <: Seq[A] with DoubleLinkedListLike[A, This]] extends SeqLike[A, This] with LinkedListLike[A, This] { self =>
 
   /** A reference to the node in the linked list preceeding the current node. */

--- a/src/library/scala/collection/mutable/FlatHashTable.scala
+++ b/src/library/scala/collection/mutable/FlatHashTable.scala
@@ -107,6 +107,7 @@ trait FlatHashTable[A] extends FlatHashTable.HashUtils[A] {
   }
 
   /** Finds an entry in the hash table if such an element exists. */
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def findEntry(elem: A): Option[A] =
     findElemImpl(elem) match {
       case null => None
@@ -115,6 +116,7 @@ trait FlatHashTable[A] extends FlatHashTable.HashUtils[A] {
 
 
   /** Checks whether an element is contained in the hash table. */
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def containsElem(elem: A): Boolean = {
     null != findElemImpl(elem)
   }
@@ -248,15 +250,18 @@ trait FlatHashTable[A] extends FlatHashTable.HashUtils[A] {
    * where sizeMapBucketSize == 4.
    *
    */
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def nnSizeMapAdd(h: Int) = if (sizemap ne null) {
     val p = h >> sizeMapBucketBitSize
     sizemap(p) += 1
   }
 
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def nnSizeMapRemove(h: Int) = if (sizemap ne null) {
     sizemap(h >> sizeMapBucketBitSize) -= 1
   }
 
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def nnSizeMapReset(tableLength: Int) = if (sizemap ne null) {
     val nsize = calcSizeMapSize(tableLength)
     if (sizemap.length != nsize) sizemap = new Array[Int](nsize)
@@ -265,14 +270,17 @@ trait FlatHashTable[A] extends FlatHashTable.HashUtils[A] {
 
   private[collection] final def totalSizeMapBuckets = (table.length - 1) / sizeMapBucketSize + 1
 
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def calcSizeMapSize(tableLength: Int) = (tableLength >> sizeMapBucketBitSize) + 1
 
   // discards the previous sizemap and only allocates a new one
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def sizeMapInit(tableLength: Int) {
     sizemap = new Array[Int](calcSizeMapSize(tableLength))
   }
 
   // discards the previous sizemap and populates the new one
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def sizeMapInitAndRebuild() {
     // first allocate
     sizeMapInit(table.length)

--- a/src/library/scala/collection/mutable/HashTable.scala
+++ b/src/library/scala/collection/mutable/HashTable.scala
@@ -127,6 +127,7 @@ trait HashTable[A, Entry >: Null <: HashEntry[A, Entry]] extends HashTable.HashU
 
   /** Find entry with given key in table, null if not found.
    */
+  @deprecatedOverriding("No sensible way to override findEntry as private findEntry0 is used in multiple places internally.", "2.11.0")
   protected def findEntry(key: A): Entry =
     findEntry0(key, index(elemHashCode(key)))
 
@@ -139,6 +140,7 @@ trait HashTable[A, Entry >: Null <: HashEntry[A, Entry]] extends HashTable.HashU
   /** Add entry to table
    *  pre: no entry with same key exists
    */
+  @deprecatedOverriding("No sensible way to override addEntry as private addEntry0 is used in multiple places internally.", "2.11.0")
   protected def addEntry(e: Entry) {
     addEntry0(e, index(elemHashCode(e.key)))
   }
@@ -172,6 +174,7 @@ trait HashTable[A, Entry >: Null <: HashEntry[A, Entry]] extends HashTable.HashU
 
   /** Remove entry from table if present.
    */
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def removeEntry(key: A) : Entry = {
     val h = index(elemHashCode(key))
     var e = table(h).asInstanceOf[Entry]
@@ -282,14 +285,17 @@ trait HashTable[A, Entry >: Null <: HashEntry[A, Entry]] extends HashTable.HashU
    * is converted into a parallel hash table, the size map is initialized, as it will be needed
    * there.
    */
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def nnSizeMapAdd(h: Int) = if (sizemap ne null) {
     sizemap(h >> sizeMapBucketBitSize) += 1
   }
 
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def nnSizeMapRemove(h: Int) = if (sizemap ne null) {
     sizemap(h >> sizeMapBucketBitSize) -= 1
   }
 
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def nnSizeMapReset(tableLength: Int) = if (sizemap ne null) {
     val nsize = calcSizeMapSize(tableLength)
     if (sizemap.length != nsize) sizemap = new Array[Int](nsize)
@@ -298,6 +304,7 @@ trait HashTable[A, Entry >: Null <: HashEntry[A, Entry]] extends HashTable.HashU
 
   private[collection] final def totalSizeMapBuckets = if (sizeMapBucketSize < table.length) 1 else table.length / sizeMapBucketSize
 
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def calcSizeMapSize(tableLength: Int) = (tableLength >> sizeMapBucketBitSize) + 1
 
   // discards the previous sizemap and only allocates a new one
@@ -306,6 +313,7 @@ trait HashTable[A, Entry >: Null <: HashEntry[A, Entry]] extends HashTable.HashU
   }
 
   // discards the previous sizemap and populates the new one
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def sizeMapInitAndRebuild() {
     sizeMapInit(table.length)
 
@@ -336,8 +344,10 @@ trait HashTable[A, Entry >: Null <: HashEntry[A, Entry]] extends HashTable.HashU
     println(sizemap.toList)
   }
 
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def sizeMapDisable() = sizemap = null
 
+  @deprecatedOverriding("Internal implementation does not admit sensible overriding of this method.", "2.11.0")
   protected def isSizeMapDefined = sizemap ne null
 
   // override to automatically initialize the size map

--- a/src/library/scala/collection/mutable/ImmutableMapAdaptor.scala
+++ b/src/library/scala/collection/mutable/ImmutableMapAdaptor.scala
@@ -25,6 +25,7 @@ import scala.annotation.migration
  *  @version 2.0, 01/01/2007
  *  @since   1
  */
+@deprecated("Adaptors are inherently unreliable and prone to performance problems.", "2.11.0")
 class ImmutableMapAdaptor[A, B](protected var imap: immutable.Map[A, B])
 extends AbstractMap[A, B]
    with Map[A, B]

--- a/src/library/scala/collection/mutable/ImmutableSetAdaptor.scala
+++ b/src/library/scala/collection/mutable/ImmutableSetAdaptor.scala
@@ -20,6 +20,7 @@ package mutable
  *  @version 1.0, 21/07/2003
  *  @since   1
  */
+@deprecated("Adaptors are inherently unreliable and prone to performance problems.", "2.11.0")
 class ImmutableSetAdaptor[A](protected var set: immutable.Set[A])
 extends AbstractSet[A]
    with Set[A]

--- a/src/library/scala/collection/mutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/mutable/LinkedHashMap.scala
@@ -85,7 +85,10 @@ class LinkedHashMap[A, B] extends AbstractMap[A, B]
     }
   }
 
+  @deprecatedOverriding("+= should not be overridden so it stays consistent with put.", "2.11.0")
   def += (kv: (A, B)): this.type = { put(kv._1, kv._2); this }
+
+  @deprecatedOverriding("-= should not be overridden so it stays consistent with remove.", "2.11.0")
   def -=(key: A): this.type = { remove(key); this }
 
   def iterator: Iterator[(A, B)] = new AbstractIterator[(A, B)] {

--- a/src/library/scala/collection/mutable/LinkedHashSet.scala
+++ b/src/library/scala/collection/mutable/LinkedHashSet.scala
@@ -57,7 +57,10 @@ class LinkedHashSet[A] extends AbstractSet[A]
 
   def contains(elem: A): Boolean = findEntry(elem) ne null
 
+  @deprecatedOverriding("+= should not be overridden so it stays consistent with add.", "2.11.0")
   def += (elem: A): this.type = { add(elem); this }
+
+  @deprecatedOverriding("-= should not be overridden so it stays consistent with remove.", "2.11.0")
   def -= (elem: A): this.type = { remove(elem); this }
 
   override def add(elem: A): Boolean = findOrAddEntry(elem, null) eq null

--- a/src/library/scala/collection/mutable/LinkedList.scala
+++ b/src/library/scala/collection/mutable/LinkedList.scala
@@ -76,6 +76,7 @@ import generic._
   *  }}}
   */
 @SerialVersionUID(-7308240733518833071L)
+@deprecated("Low-level linked lists are deprecated due to idiosyncracies in interface and incomplete features.", "2.11.0")
 class LinkedList[A]() extends AbstractSeq[A]
                          with LinearSeq[A]
                          with GenericTraversableTemplate[A, LinkedList]
@@ -113,6 +114,7 @@ class LinkedList[A]() extends AbstractSeq[A]
  *  @define Coll `LinkedList`
  *  @define coll linked list
  */
+@deprecated("Low-level linked lists are deprecated.", "2.11.0")
 object LinkedList extends SeqFactory[LinkedList] {
   override def empty[A]: LinkedList[A] = new LinkedList[A]
   implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, LinkedList[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]

--- a/src/library/scala/collection/mutable/LinkedListLike.scala
+++ b/src/library/scala/collection/mutable/LinkedListLike.scala
@@ -55,6 +55,7 @@ import scala.annotation.tailrec
  *
  *  }}}
  */
+@deprecated("Low-level linked lists are deprecated due to idiosyncracies in interface and incomplete features.", "2.11.0")
 trait LinkedListLike[A, This <: Seq[A] with LinkedListLike[A, This]] extends SeqLike[A, This] { self =>
 
   var elem: A = _

--- a/src/library/scala/collection/mutable/ListMap.scala
+++ b/src/library/scala/collection/mutable/ListMap.scala
@@ -50,7 +50,10 @@ extends AbstractMap[A, B]
   def get(key: A): Option[B] = elems find (_._1 == key) map (_._2)
   def iterator: Iterator[(A, B)] = elems.iterator
 
+  @deprecatedOverriding("No sensible way to override += as private remove is used in multiple places internally.", "2.11.0")
   def += (kv: (A, B)) = { elems = remove(kv._1, elems, List()); elems = kv :: elems; siz += 1; this }
+
+  @deprecatedOverriding("No sensible way to override -= as private remove is used in multiple places internally.", "2.11.0")
   def -= (key: A) = { elems = remove(key, elems, List()); this }
 
   @tailrec
@@ -61,7 +64,10 @@ extends AbstractMap[A, B]
   }
 
 
+  @deprecatedOverriding("No sensible way to override as this functionality relies upon access to private methods.", "2.11.0")
   override def clear() = { elems = List(); siz = 0 }
+
+  @deprecatedOverriding("No sensible way to override as this functionality relies upon access to private methods.", "2.11.0")
   override def size: Int = siz
 }
 

--- a/src/library/scala/collection/mutable/MapProxy.scala
+++ b/src/library/scala/collection/mutable/MapProxy.scala
@@ -20,6 +20,7 @@ package mutable
  *  @version 2.0, 31/12/2006
  *  @since   1
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 trait MapProxy[A, B] extends Map[A, B] with MapProxyLike[A, B, Map[A, B]] {
   private def newProxy[B1 >: B](newSelf: Map[A, B1]): MapProxy[A, B1] =
     new MapProxy[A, B1] { val self = newSelf }

--- a/src/library/scala/collection/mutable/ObservableBuffer.scala
+++ b/src/library/scala/collection/mutable/ObservableBuffer.scala
@@ -23,6 +23,7 @@ import script._
  *  @version 1.0, 08/07/2003
  *  @since   1
  */
+@deprecated("Observables are deprecated because scripting is deprecated.", "2.11.0")
 trait ObservableBuffer[A] extends Buffer[A] with Publisher[Message[A] with Undoable]
 {
   type Pub <: ObservableBuffer[A]

--- a/src/library/scala/collection/mutable/ObservableMap.scala
+++ b/src/library/scala/collection/mutable/ObservableMap.scala
@@ -25,6 +25,7 @@ import script._
  *  @version 2.0, 31/12/2006
  *  @since   1
  */
+@deprecated("Observables are deprecated because scripting is deprecated.", "2.11.0")
 trait ObservableMap[A, B] extends Map[A, B] with Publisher[Message[(A, B)] with Undoable]
 {
 

--- a/src/library/scala/collection/mutable/ObservableSet.scala
+++ b/src/library/scala/collection/mutable/ObservableSet.scala
@@ -23,6 +23,7 @@ import script._
  *  @version 1.0, 08/07/2003
  *  @since   1
  */
+@deprecated("Observables are deprecated because scripting is deprecated.", "2.11.0")
 trait ObservableSet[A] extends Set[A] with Publisher[Message[A] with Undoable]
 {
 

--- a/src/library/scala/collection/mutable/OpenHashMap.scala
+++ b/src/library/scala/collection/mutable/OpenHashMap.scala
@@ -117,7 +117,10 @@ extends AbstractMap[Key, Value]
     put(key, hashOf(key), value)
   }
 
+  @deprecatedOverriding("+= should not be overridden in order to maintain consistency with put.", "2.11.0")
   def += (kv: (Key, Value)): this.type = { put(kv._1, kv._2); this }
+  
+  @deprecatedOverriding("-= should not be overridden in order to maintain consistency with remove.", "2.11.0")
   def -= (key: Key): this.type = { remove(key); this }
 
   override def put(key: Key, value: Value): Option[Value] =

--- a/src/library/scala/collection/mutable/PriorityQueue.scala
+++ b/src/library/scala/collection/mutable/PriorityQueue.scala
@@ -30,6 +30,7 @@ import generic._
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  */
+@deprecatedInheritance("PriorityQueue is not intended to be subclassed due to extensive private implementation details.", "2.11.0")
 class PriorityQueue[A](implicit val ord: Ordering[A])
    extends AbstractIterable[A]
       with Iterable[A]

--- a/src/library/scala/collection/mutable/PriorityQueueProxy.scala
+++ b/src/library/scala/collection/mutable/PriorityQueueProxy.scala
@@ -19,6 +19,7 @@ package mutable
  *  @version 1.0, 03/05/2004
  *  @since   1
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 abstract class PriorityQueueProxy[A](implicit ord: Ordering[A]) extends PriorityQueue[A]
          with Proxy
 {

--- a/src/library/scala/collection/mutable/Queue.scala
+++ b/src/library/scala/collection/mutable/Queue.scala
@@ -143,6 +143,7 @@ extends MutableList[A]
   /** Return the proper suffix of this list which starts with the first element that satisfies `p`.
    *  That element is unlinked from the list. If no element satisfies `p`, return None.
    */
+  @deprecated("extractFirst inappropriately exposes implementation details.  Use dequeue or dequeueAll.", "2.11.0")
   def extractFirst(start: LinkedList[A], p: A => Boolean): Option[LinkedList[A]] = {
     if (isEmpty) None
     else {

--- a/src/library/scala/collection/mutable/QueueProxy.scala
+++ b/src/library/scala/collection/mutable/QueueProxy.scala
@@ -21,6 +21,7 @@ package mutable
  *  @version 1.1, 03/05/2004
  *  @since   1
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 trait QueueProxy[A] extends Queue[A] with Proxy {
 
   def self: Queue[A]

--- a/src/library/scala/collection/mutable/SetLike.scala
+++ b/src/library/scala/collection/mutable/SetLike.scala
@@ -210,11 +210,12 @@ trait SetLike[A, +This <: SetLike[A, This] with Set[A]]
    *  @throws `Predef.UnsupportedOperationException`
    *  if the message was not understood.
    */
-   def <<(cmd: Message[A]): Unit = cmd match {
-     case Include(_, x)     => this += x
-     case Remove(_, x)      => this -= x
-     case Reset()           => clear()
-     case s: Script[_]      => s.iterator foreach <<
-     case _                 => throw new UnsupportedOperationException("message " + cmd + " not understood")
-   }
+  @deprecated("Scripting is deprecated.", "2.11.0")
+  def <<(cmd: Message[A]): Unit = cmd match {
+    case Include(_, x)     => this += x
+    case Remove(_, x)      => this -= x
+    case Reset()           => clear()
+    case s: Script[_]      => s.iterator foreach <<
+    case _                 => throw new UnsupportedOperationException("message " + cmd + " not understood")
+  }
 }

--- a/src/library/scala/collection/mutable/SetProxy.scala
+++ b/src/library/scala/collection/mutable/SetProxy.scala
@@ -18,6 +18,7 @@ package mutable
  *  @version 1.1, 09/05/2004
  *  @since   1
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 trait SetProxy[A] extends Set[A] with SetProxyLike[A, Set[A]] {
   override def repr = this
   override def empty = new SetProxy[A] { val self = SetProxy.this.self.empty }

--- a/src/library/scala/collection/mutable/StackProxy.scala
+++ b/src/library/scala/collection/mutable/StackProxy.scala
@@ -19,6 +19,7 @@ package mutable
  *  @version 1.0, 10/05/2004
  *  @since   1
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 trait StackProxy[A] extends Stack[A] with Proxy {
 
   def self: Stack[A]

--- a/src/library/scala/collection/mutable/SynchronizedBuffer.scala
+++ b/src/library/scala/collection/mutable/SynchronizedBuffer.scala
@@ -25,6 +25,7 @@ import script._
  *  @define Coll `SynchronizedBuffer`
  *  @define coll synchronized buffer
  */
+@deprecated("Synchronization via traits is deprecated as it is inherently unreliable.  Consider java.util.concurrent.ConcurrentLinkedQueue as an alternative.", "2.11.0")
 trait SynchronizedBuffer[A] extends Buffer[A] {
 
   import scala.collection.Traversable
@@ -161,6 +162,7 @@ trait SynchronizedBuffer[A] extends Buffer[A] {
     super.clear()
   }
 
+  @deprecated("Scripting is deprecated.", "2.11.0")
   override def <<(cmd: Message[A]): Unit = synchronized {
     super.<<(cmd)
   }

--- a/src/library/scala/collection/mutable/SynchronizedMap.scala
+++ b/src/library/scala/collection/mutable/SynchronizedMap.scala
@@ -24,6 +24,7 @@ import scala.annotation.migration
  *  @define Coll `SynchronizedMap`
  *  @define coll synchronized map
  */
+@deprecated("Synchronization via traits is deprecated as it is inherently unreliable.  Consider java.util.concurrent.ConcurrentHashMap as an alternative.", "2.11.0")
 trait SynchronizedMap[A, B] extends Map[A, B] {
 
   abstract override def get(key: A): Option[B] = synchronized { super.get(key) }

--- a/src/library/scala/collection/mutable/SynchronizedPriorityQueue.scala
+++ b/src/library/scala/collection/mutable/SynchronizedPriorityQueue.scala
@@ -24,6 +24,7 @@ package mutable
  *  @define Coll `SynchronizedPriorityQueue`
  *  @define coll synchronized priority queue
  */
+@deprecated("Comprehensive synchronization via selective overriding of methods is inherently unreliable.  Consider java.util.concurrent.ConcurrentSkipListSet as an alternative.", "2.11.0")
 class SynchronizedPriorityQueue[A](implicit ord: Ordering[A]) extends PriorityQueue[A] {
 
   /** Checks if the queue is empty.

--- a/src/library/scala/collection/mutable/SynchronizedQueue.scala
+++ b/src/library/scala/collection/mutable/SynchronizedQueue.scala
@@ -25,6 +25,7 @@ package mutable
  *  @define Coll `SynchronizedQueue`
  *  @define coll synchronized queue
  */
+@deprecated("Synchronization via selective overriding of methods is inherently unreliable.  Consider java.util.concurrent.ConcurrentLinkedQueue as an alternative.", "2.11.0")
 class SynchronizedQueue[A] extends Queue[A] {
   /** Checks if the queue is empty.
    *

--- a/src/library/scala/collection/mutable/SynchronizedSet.scala
+++ b/src/library/scala/collection/mutable/SynchronizedSet.scala
@@ -24,6 +24,7 @@ import script._
  *  @define Coll `SynchronizedSet`
  *  @define coll synchronized set
  */
+@deprecated("Synchronization via traits is deprecated as it is inherently unreliable.  Consider java.util.concurrent.ConcurrentHashMap[A,Unit] as an alternative.", "2.11.0")
 trait SynchronizedSet[A] extends Set[A] {
   abstract override def size: Int = synchronized {
     super.size
@@ -93,6 +94,7 @@ trait SynchronizedSet[A] extends Set[A] {
     super.toString
   }
 
+  @deprecated("Scripting is deprecated.", "2.11.0")
   override def <<(cmd: Message[A]): Unit = synchronized {
     super.<<(cmd)
   }

--- a/src/library/scala/collection/mutable/SynchronizedStack.scala
+++ b/src/library/scala/collection/mutable/SynchronizedStack.scala
@@ -25,6 +25,7 @@ package mutable
  *  @define Coll `SynchronizedStack`
  *  @define coll synchronized stack
  */
+@deprecated("Synchronization via selective overriding of methods is inherently unreliable.  Consider java.util.concurrent.LinkedBlockingDequeue instead.", "2.11.0")
 class SynchronizedStack[A] extends Stack[A] {
   import scala.collection.Traversable
 

--- a/src/library/scala/collection/mutable/TreeSet.scala
+++ b/src/library/scala/collection/mutable/TreeSet.scala
@@ -37,6 +37,7 @@ object TreeSet extends MutableSortedSetFactory[TreeSet] {
  * @author Lucien Pereira
  *
  */
+@deprecatedInheritance("TreeSet is not designed to enable meaningful subclassing.", "2.11.0")
 class TreeSet[A] private (treeRef: ObjectRef[RB.Tree[A, Null]], from: Option[A], until: Option[A])(implicit val ordering: Ordering[A])
   extends SortedSet[A] with SetLike[A, TreeSet[A]]
   with SortedSetLike[A, TreeSet[A]] with Set[A] with Serializable {

--- a/src/library/scala/collection/mutable/UnrolledBuffer.scala
+++ b/src/library/scala/collection/mutable/UnrolledBuffer.scala
@@ -43,6 +43,7 @@ import scala.reflect.ClassTag
  *
  */
 @SerialVersionUID(1L)
+@deprecatedInheritance("UnrolledBuffer is not designed to enable meaningful subclassing.", "2.11.0")
 class UnrolledBuffer[T](implicit val tag: ClassTag[T])
 extends scala.collection.mutable.AbstractBuffer[T]
    with scala.collection.mutable.Buffer[T]
@@ -67,7 +68,20 @@ extends scala.collection.mutable.AbstractBuffer[T]
 
   protected def newUnrolled = new Unrolled[T](this)
 
-  private[collection] def calcNextLength(sz: Int) = sz
+  // The below would allow more flexible behavior without requiring inheritance
+  // that is risky because all the important internals are private.
+  // private var myLengthPolicy: Int => Int = x => x
+  // 
+  // /** Specifies how the array lengths should vary.
+  //   * 
+  //   *  By default,  `UnrolledBuffer` uses arrays of a fixed size.  A length
+  //   *  policy can be given that changes this scheme to, for instance, an
+  //   *  exponential growth.
+  //   * 
+  //   *  @param nextLength   computes the length of the next array from the length of the latest one
+  //   */
+  // def setLengthPolicy(nextLength: Int => Int): Unit = { myLengthPolicy = nextLength }
+  private[collection] def calcNextLength(sz: Int) = sz // myLengthPolicy(sz)
 
   def classTagCompanion = UnrolledBuffer
 

--- a/src/library/scala/collection/parallel/mutable/UnrolledParArrayCombiner.scala
+++ b/src/library/scala/collection/parallel/mutable/UnrolledParArrayCombiner.scala
@@ -20,6 +20,7 @@ import scala.collection.parallel.Combiner
 import scala.collection.parallel.Task
 import scala.reflect.ClassTag
 
+// Todo -- revisit whether inheritance is the best way to achieve this functionality
 private[mutable] class DoublingUnrolledBuffer[T](implicit t: ClassTag[T]) extends UnrolledBuffer[T]()(t) {
   override def calcNextLength(sz: Int) = if (sz < 10000) sz * 2 else sz
   protected override def newUnrolled = new Unrolled[T](0, new Array[T](4), null, this)

--- a/src/library/scala/collection/script/Location.scala
+++ b/src/library/scala/collection/script/Location.scala
@@ -18,8 +18,17 @@ package script
  *  @since   2.8
  */
 
+@deprecated("Scripting is deprecated.", "2.11.0")
 sealed abstract class Location
+
+@deprecated("Scripting is deprecated.", "2.11.0")
 case object Start extends Location
+
+@deprecated("Scripting is deprecated.", "2.11.0")
 case object End extends Location
+
+@deprecated("Scripting is deprecated.", "2.11.0")
 case object NoLo extends Location
+
+@deprecated("Scripting is deprecated.", "2.11.0")
 case class Index(n: Int) extends Location

--- a/src/library/scala/collection/script/Message.scala
+++ b/src/library/scala/collection/script/Message.scala
@@ -21,6 +21,7 @@ import mutable.ArrayBuffer
  *  @version 1.0, 08/07/2003
  *  @since   2.8
  */
+@deprecated("Scripting is deprecated.", "2.11.0")
 trait Message[+A]
 
 /** This observable update refers to inclusion operations that add new elements
@@ -29,6 +30,7 @@ trait Message[+A]
  *  @author  Matthias Zenger
  *  @version 1.0, 08/07/2003
  */
+@deprecated("Scripting is deprecated.", "2.11.0")
 case class Include[+A](location: Location, elem: A) extends Message[A] {
   def this(elem: A) = this(NoLo, elem)
 }
@@ -39,6 +41,7 @@ case class Include[+A](location: Location, elem: A) extends Message[A] {
  *  @author  Matthias Zenger
  *  @version 1.0, 08/07/2003
  */
+@deprecated("Scripting is deprecated.", "2.11.0")
 case class Update[+A](location: Location, elem: A) extends Message[A] {
   def this(elem: A) = this(NoLo, elem)
 }
@@ -49,6 +52,7 @@ case class Update[+A](location: Location, elem: A) extends Message[A] {
  *  @author  Matthias Zenger
  *  @version 1.0, 08/07/2003
  */
+@deprecated("Scripting is deprecated.", "2.11.0")
 case class Remove[+A](location: Location, elem: A) extends Message[A] {
   def this(elem: A) = this(NoLo, elem)
 }
@@ -58,6 +62,7 @@ case class Remove[+A](location: Location, elem: A) extends Message[A] {
  *  @author  Matthias Zenger
  *  @version 1.0, 08/07/2003
  */
+@deprecated("Scripting is deprecated.", "2.11.0")
 case class Reset[+A]() extends Message[A]
 
 /** Objects of this class represent compound messages consisting
@@ -66,6 +71,7 @@ case class Reset[+A]() extends Message[A]
  *  @author  Matthias Zenger
  *  @version 1.0, 10/05/2004
  */
+@deprecated("Scripting is deprecated.", "2.11.0")
 class Script[A] extends ArrayBuffer[Message[A]] with Message[A] {
 
   override def toString(): String = {

--- a/src/library/scala/collection/script/Scriptable.scala
+++ b/src/library/scala/collection/script/Scriptable.scala
@@ -17,6 +17,7 @@ package script
  *  @version 1.0, 09/05/2004
  *  @since   2.8
  */
+@deprecated("Scripting is deprecated.", "2.11.0")
 trait Scriptable[A] {
   /** Send a message to this scriptable object.
    */

--- a/src/swing/scala/swing/ListView.scala
+++ b/src/swing/scala/swing/ListView.scala
@@ -200,9 +200,7 @@ class ListView[A] extends Component {
     /**
      * The currently selected items.
      */
-    object items extends scala.collection.SeqProxy[A] {
-      def self = peer.getSelectedValues.map(_.asInstanceOf[A])
-    }
+    lazy val items = peer.getSelectedValues.map(_.asInstanceOf[A])
 
     def intervalMode: IntervalMode.Value = IntervalMode(peer.getSelectionModel.getSelectionMode)
     def intervalMode_=(m: IntervalMode.Value) { peer.getSelectionModel.setSelectionMode(m.id) }

--- a/test/files/jvm/future-spec.check
+++ b/test/files/jvm/future-spec.check
@@ -1,2 +1,1 @@
 warning: there were 1 deprecation warning(s); re-run with -deprecation for details
-Stack(8, 7, 6, 5, 4, 3)

--- a/test/files/jvm/serialization-new.check
+++ b/test/files/jvm/serialization-new.check
@@ -1,3 +1,4 @@
+warning: there were 2 deprecation warning(s); re-run with -deprecation for details
 a1 = Array[1,2,3]
 _a1 = Array[1,2,3]
 arrayEquals(a1, _a1): true

--- a/test/files/jvm/serialization.check
+++ b/test/files/jvm/serialization.check
@@ -1,3 +1,4 @@
+warning: there were 2 deprecation warning(s); re-run with -deprecation for details
 a1 = Array[1,2,3]
 _a1 = Array[1,2,3]
 arrayEquals(a1, _a1): true

--- a/test/files/run/collection-stacks.check
+++ b/test/files/run/collection-stacks.check
@@ -1,3 +1,4 @@
+warning: there were 1 deprecation warning(s); re-run with -deprecation for details
 3-2-1: true
 3-2-1: true
 apply

--- a/test/files/run/colltest.check
+++ b/test/files/run/colltest.check
@@ -1,3 +1,4 @@
+warning: there were 2 deprecation warning(s); re-run with -deprecation for details
 true
 false
 true

--- a/test/files/run/t3361.check
+++ b/test/files/run/t3361.check
@@ -1,0 +1,1 @@
+warning: there were 16 deprecation warning(s); re-run with -deprecation for details

--- a/test/files/run/t3970.check
+++ b/test/files/run/t3970.check
@@ -1,0 +1,1 @@
+warning: there were 5 deprecation warning(s); re-run with -deprecation for details

--- a/test/files/run/t3996.check
+++ b/test/files/run/t3996.check
@@ -1,4 +1,1 @@
 warning: there were 2 deprecation warning(s); re-run with -deprecation for details
-LinkedList(1)
-LinkedList(1)
-true

--- a/test/files/run/t4080.check
+++ b/test/files/run/t4080.check
@@ -1,1 +1,2 @@
+warning: there were 3 deprecation warning(s); re-run with -deprecation for details
 LinkedList(1, 0, 2, 3)

--- a/test/files/run/t4461.check
+++ b/test/files/run/t4461.check
@@ -1,3 +1,4 @@
+warning: there were 4 deprecation warning(s); re-run with -deprecation for details
 Include(End,1)
 Include(End,2)
 Include(End,3)

--- a/test/files/run/t4813.check
+++ b/test/files/run/t4813.check
@@ -1,4 +1,1 @@
 warning: there were 2 deprecation warning(s); re-run with -deprecation for details
-LinkedList(1)
-LinkedList(1)
-true

--- a/test/files/run/t6292.check
+++ b/test/files/run/t6292.check
@@ -1,0 +1,1 @@
+warning: there were 7 deprecation warning(s); re-run with -deprecation for details

--- a/test/files/run/t6690.check
+++ b/test/files/run/t6690.check
@@ -1,4 +1,1 @@
 warning: there were 2 deprecation warning(s); re-run with -deprecation for details
-LinkedList(1)
-LinkedList(1)
-true

--- a/test/files/run/unittest_collection.check
+++ b/test/files/run/unittest_collection.check
@@ -1,2 +1,1 @@
 warning: there were 1 deprecation warning(s); re-run with -deprecation for details
-Stack(8, 7, 6, 5, 4, 3)


### PR DESCRIPTION
This set of commits significantly cleans up the interface of the collections library.  In particular, it deprecates collections that are either broken or will continually break due to needing too much manual attention to keep them consistent: SynchronizedColl, CollProxy, CollForwarder, and ImmutableCollAdaptor.  It also attempts to deprecate inheritance and/or overriding where these things do not make sense so that there is more flexibility to alter internal representations and/or less danger of inadvertently introducing inconsistent behavior.  In particular, many immutable classes that implement nontrivial collections have deprecated inheritance (in many cases they should become sealed not final); certain methods have deprecated overriding (including CollLike toColl almost always returning self, += forwarding to put or add in maps).  Finally, a few scarcely-used classes or traits and/or those with idiosyncratic APIs have been deprecated, including all of collection.script and all the low-level mutable buffers (LinkedListLike and friends).
