### PR TITLE
Fix completion after application with implicit arguments

### DIFF
--- a/src/compiler/scala/tools/nsc/interactive/Global.scala
+++ b/src/compiler/scala/tools/nsc/interactive/Global.scala
@@ -999,7 +999,13 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
 
     val context = doLocateContext(pos)
 
-    if (tree.tpe == null)
+    val shouldTypeQualifier = tree.tpe match {
+      case null           => true
+      case mt: MethodType => mt.isImplicit
+      case _              => false
+    }
+
+    if (shouldTypeQualifier)
       // TODO: guard with try/catch to deal with ill-typed qualifiers.
       tree = analyzer.newTyper(context).typedQualifier(tree)
 
@@ -1192,4 +1198,3 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
 }
 
 object CancelException extends Exception
-

--- a/test/files/presentation/completion-implicit-chained.check
+++ b/test/files/presentation/completion-implicit-chained.check
@@ -1,0 +1,29 @@
+reload: Completions.scala
+
+askTypeCompletion at Completions.scala(11,16)
+================================================================================
+[response] aksTypeCompletion at (11,16)
+retrieved 24 members
+[accessible:  true] `method !=(x$1: Any)Boolean`
+[accessible:  true] `method !=(x$1: AnyRef)Boolean`
+[accessible:  true] `method ##()Int`
+[accessible:  true] `method ==(x$1: Any)Boolean`
+[accessible:  true] `method ==(x$1: AnyRef)Boolean`
+[accessible:  true] `method asInstanceOf[T0]=> T0`
+[accessible:  true] `method eq(x$1: AnyRef)Boolean`
+[accessible:  true] `method equals(x$1: Any)Boolean`
+[accessible:  true] `method hashCode()Int`
+[accessible:  true] `method isInstanceOf[T0]=> Boolean`
+[accessible:  true] `method map(x: Int => Int)(implicit a: DummyImplicit)test.O.type`
+[accessible:  true] `method ne(x$1: AnyRef)Boolean`
+[accessible:  true] `method notify()Unit`
+[accessible:  true] `method notifyAll()Unit`
+[accessible:  true] `method synchronized[T0](x$1: T0)T0`
+[accessible:  true] `method toString()String`
+[accessible:  true] `method wait()Unit`
+[accessible:  true] `method wait(x$1: Long)Unit`
+[accessible:  true] `method wait(x$1: Long, x$2: Int)Unit`
+[accessible:  true] `value prefix123Int`
+[accessible: false] `method clone()Object`
+[accessible: false] `method finalize()Unit`
+================================================================================

--- a/test/files/presentation/completion-implicit-chained/Test.scala
+++ b/test/files/presentation/completion-implicit-chained/Test.scala
@@ -1,0 +1,3 @@
+import scala.tools.nsc.interactive.tests.InteractiveTest
+
+object Test extends InteractiveTest

--- a/test/files/presentation/completion-implicit-chained/src/Completions.scala
+++ b/test/files/presentation/completion-implicit-chained/src/Completions.scala
@@ -1,0 +1,12 @@
+package test
+
+import scala.Predef.DummyImplicit // turn off other predef implicits for a cleaner .check file.
+
+object O {
+  def map(x: Int => Int)(implicit a: DummyImplicit): O.type = this
+  val prefix123 : Int = 0
+}
+
+class Foo {
+  O.map(x => x)./*!*/ // we want the presentation compiler to apply the implicit argument list.
+}


### PR DESCRIPTION
`List(1, 2, 3).map(f).<ctrl-space>` now works; before
the tree had the type `(bf: CanBuildFrom[...]):...` and
did not contribute completions from the result type.

This commit checks if the tree has an implicit method
type, and typechecks it as a qualifier. That is enough
to get to `adaptToImplicitMethod` in the type checker,
infer the implicit arguments, and compute the final result
type accordingly.
