### PR TITLE
Faster build 2.10

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -416,6 +416,17 @@ TODO:
     <echo message="     OSGi version: ${osgi.version.number}" />
     <echo message="canonical version: ${version.number}" />
 
+    <echoproperties destfile="buildcharacter.properties">
+      <propertyset>
+        <propertyref regex="time.*" />
+        <propertyref regex="git.*" />
+        <propertyref name="java.vm.name" />
+        <propertyref regex=".*version.*" />
+        <propertyref regex="scalac.args.*" />
+        <propertyref name="scalacfork.jvmargs" />
+      </propertyset>
+    </echoproperties>
+
     <!-- validate version suffixes -->
     <if><equals arg1="${maven.version.suffix}" arg2="-SNAPSHOT"/><then>
       <condition property="version.suffixes.consistent"><and>

--- a/build.xml
+++ b/build.xml
@@ -240,12 +240,15 @@ TODO:
       <!-- BND support -->
       <typedef resource="aQute/bnd/ant/taskdef.properties" classpathref="extra.tasks.classpath" />
 
+      <artifact:remoteRepository id="extra-repo" url="${extra.repo.url}"/>
+
       <!-- Download STARR via maven if `starr.use.released` is set,
            and `starr.version` is specified (see the starr.number properties file).
            Want to slow down STARR changes, using only released versions. -->
       <if><isset property="starr.use.released"/><then>
         <echo message="Using Scala ${starr.version} for STARR."/>
         <artifact:dependencies pathId="starr.core.path">
+          <artifact:remoteRepository refid="extra-repo"/>
           <dependency groupId="org.scala-lang" artifactId="scala-library" version="${starr.version}"/>
           <dependency groupId="org.scala-lang" artifactId="scala-reflect" version="${starr.version}"/>
           <dependency groupId="org.scala-lang" artifactId="scala-compiler" version="${starr.version}"/>

--- a/src/build/maven/maven-deploy.xml
+++ b/src/build/maven/maven-deploy.xml
@@ -176,6 +176,7 @@
       </sequential>
     </macrodef>
 
+    <!-- IDE needs swing/actors/continuations -->
     <macrodef name="deploy-remote-core">
       <attribute name="repository" />
       <attribute name="version" />
@@ -183,6 +184,10 @@
         <deploy-remote name="scala-library" version="@{version}" repository="@{repository}"/>
         <deploy-remote name="scala-reflect" version="@{version}" repository="@{repository}"/>
         <deploy-remote name="scala-compiler" version="@{version}" repository="@{repository}" />
+        <deploy-remote name="jline" version="@{version}" repository="@{repository}"/>
+        <deploy-remote name="scala-swing" version="@{version}" repository="@{repository}"/>
+        <deploy-remote name="scala-actors" version="@{version}" repository="@{repository}"/>
+        <deploy-remote-plugin name="continuations" version="@{version}" repository="@{repository}"/>
       </sequential>
     </macrodef>
 

--- a/src/build/maven/maven-deploy.xml
+++ b/src/build/maven/maven-deploy.xml
@@ -176,6 +176,16 @@
       </sequential>
     </macrodef>
 
+    <macrodef name="deploy-remote-core">
+      <attribute name="repository" />
+      <attribute name="version" />
+      <sequential>
+        <deploy-remote name="scala-library" version="@{version}" repository="@{repository}"/>
+        <deploy-remote name="scala-reflect" version="@{version}" repository="@{repository}"/>
+        <deploy-remote name="scala-compiler" version="@{version}" repository="@{repository}" />
+      </sequential>
+    </macrodef>
+
     <!-- PGP Signed deployment -->
     <macrodef name="deploy-remote-signed-single">
       <attribute name="pom" />
@@ -266,6 +276,11 @@
   <!-- Remote unsigned targets -->
   <target name="deploy.snapshot" depends="deploy.remote.init" if="version.is.snapshot" description="Deploys the bundled files as a snapshot into the desired remote Maven repository">
       <deploy-remote-all version="${maven.version.number}" repository="${remote.snapshot.repository}" />
+  </target>
+
+  <!-- for PR validation -->
+  <target name="deploy-core.snapshot" depends="deploy.remote.init">
+      <deploy-remote-core version="${maven.version.number}" repository="${remote.snapshot.repository}" />
   </target>
 
   <target name="deploy.release" depends="deploy.remote.init" unless="version.is.snapshot" description="Deploys the bundled files as a release into the desired remote Maven repository">


### PR DESCRIPTION
Backport of #3108 -- provide hooks for jenkins jobs to specify which repository to publish to.
Also, publish only what's needed during PR validation to save time.
Finally, we're standardizing on putting all our java properties in versions.properties and passing that around between the jenkins pr validation jobs, having them consumed by the scripts and dbuild. This way we can keep all module versions in synch and don't need to change infrastructure (much) when new properties are needed.
