### PR TITLE
[backport] SI-7776 post-erasure signature clashes are now macro-aware

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -895,6 +895,9 @@ abstract class Erasure extends AddInterfaces
      *    but their erased types are the same.
      */
     private def checkNoDoubleDefs(root: Symbol) {
+      def sameTypeAfterErasure(sym1: Symbol, sym2: Symbol) =
+        afterPostErasure(sym1.info =:= sym2.info) && !sym1.isMacro && !sym2.isMacro
+
       def doubleDefError(sym1: Symbol, sym2: Symbol) {
         // the .toString must also be computed at the earlier phase
         val tpe1 = afterRefchecks(root.thisType.memberType(sym1))
@@ -920,7 +923,7 @@ abstract class Erasure extends AddInterfaces
         if (e.sym.isTerm) {
           var e1 = decls.lookupNextEntry(e)
           while (e1 ne null) {
-            if (afterPostErasure(e1.sym.info =:= e.sym.info)) doubleDefError(e.sym, e1.sym)
+            if (sameTypeAfterErasure(e1.sym, e.sym)) doubleDefError(e.sym, e1.sym)
             e1 = decls.lookupNextEntry(e1)
           }
         }
@@ -939,7 +942,8 @@ abstract class Erasure extends AddInterfaces
       while (opc.hasNext) {
         if (!afterRefchecks(
               root.thisType.memberType(opc.overriding) matches
-              root.thisType.memberType(opc.overridden))) {
+              root.thisType.memberType(opc.overridden)) &&
+            sameTypeAfterErasure(opc.overriding, opc.overridden)) {
           debuglog("" + opc.overriding.locationString + " " +
                      opc.overriding.infosString +
                      opc.overridden.locationString + " " +

--- a/test/files/pos/t7776.scala
+++ b/test/files/pos/t7776.scala
@@ -1,0 +1,12 @@
+import scala.language.experimental.macros
+import scala.reflect.macros.Context
+
+class MacroErasure {
+  def app(f: Any => Any, x: Any): Any = macro MacroErasure.appMacro
+  def app[A](f: A => Any, x: Any): Any = macro MacroErasure.appMacroA[A]
+}
+
+object MacroErasure {
+  def appMacro(c: Context)(f: c.Expr[Any => Any], x: c.Expr[Any]): c.Expr[Any] = ???
+  def appMacroA[A](c: Context)(f: c.Expr[A => Any], x: c.Expr[Any])(implicit tt: c.WeakTypeTag[A]): c.Expr[Any] = ???
+}


### PR DESCRIPTION
"double definition: macro this and method that have same type after erasure"
This error doesn't make sense when macros are involved, because macros
expand at compile-time, where we're not affected by erasure. Moreover,
macros produce no bytecode, which means that we're safe from VerifyErrors.
