### PR TITLE
SI-7958 Deprecate methods `future` and `promise` in the `scala.concurren...

### DIFF
--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -29,11 +29,11 @@ import scala.reflect.ClassTag
 
 /** The trait that represents futures.
  *
- *  Asynchronous computations that yield futures are created with the `future` call:
+ *  Asynchronous computations that yield futures are created with the `Future` call:
  *
  *  {{{
  *  val s = "Hello"
- *  val f: Future[String] = future {
+ *  val f: Future[String] = Future {
  *    s + " future!"
  *  }
  *  f onSuccess {
@@ -67,8 +67,8 @@ import scala.reflect.ClassTag
  *  Example:
  *
  *  {{{
- *  val f = future { 5 }
- *  val g = future { 3 }
+ *  val f = Future { 5 }
+ *  val g = Future { 3 }
  *  val h = for {
  *    x: Int <- f // returns Future(5)
  *    y: Int <- g // returns Future(3)
@@ -266,7 +266,7 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  Example:
    *  {{{
-   *  val f = future { 5 }
+   *  val f = Future { 5 }
    *  val g = f filter { _ % 2 == 1 }
    *  val h = f filter { _ % 2 == 0 }
    *  Await.result(g, Duration.Zero) // evaluates to 5
@@ -291,7 +291,7 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  Example:
    *  {{{
-   *  val f = future { -5 }
+   *  val f = Future { -5 }
    *  val g = f collect {
    *    case x if x < 0 => -x
    *  }
@@ -314,9 +314,9 @@ trait Future[+T] extends Awaitable[T] {
    *  Example:
    *
    *  {{{
-   *  future (6 / 0) recover { case e: ArithmeticException => 0 } // result: 0
-   *  future (6 / 0) recover { case e: NotFoundException   => 0 } // result: exception
-   *  future (6 / 2) recover { case e: ArithmeticException => 0 } // result: 3
+   *  Future (6 / 0) recover { case e: ArithmeticException => 0 } // result: 0
+   *  Future (6 / 0) recover { case e: NotFoundException   => 0 } // result: exception
+   *  Future (6 / 2) recover { case e: ArithmeticException => 0 } // result: 3
    *  }}}
    */
   def recover[U >: T](pf: PartialFunction[Throwable, U])(implicit executor: ExecutionContext): Future[U] = {
@@ -334,8 +334,8 @@ trait Future[+T] extends Awaitable[T] {
    *  Example:
    *
    *  {{{
-   *  val f = future { Int.MaxValue }
-   *  future (6 / 0) recoverWith { case e: ArithmeticException => f } // result: Int.MaxValue
+   *  val f = Future { Int.MaxValue }
+   *  Future (6 / 0) recoverWith { case e: ArithmeticException => f } // result: Int.MaxValue
    *  }}}
    */
   def recoverWith[U >: T](pf: PartialFunction[Throwable, Future[U]])(implicit executor: ExecutionContext): Future[U] = {
@@ -373,8 +373,8 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  Example:
    *  {{{
-   *  val f = future { sys.error("failed") }
-   *  val g = future { 5 }
+   *  val f = Future { sys.error("failed") }
+   *  val g = Future { 5 }
    *  val h = f fallbackTo g
    *  Await.result(h, Duration.Zero) // evaluates to 5
    *  }}}
@@ -416,7 +416,7 @@ trait Future[+T] extends Awaitable[T] {
    *  The following example prints out `5`:
    *
    *  {{{
-   *  val f = future { 5 }
+   *  val f = Future { 5 }
    *  f andThen {
    *    case r => sys.error("runtime exception")
    *  } andThen {

--- a/src/library/scala/concurrent/package.scala
+++ b/src/library/scala/concurrent/package.scala
@@ -27,6 +27,8 @@ package object concurrent {
    *  @param executor the execution context on which the future is run
    *  @return         the `Future` holding the result of the computation
    */
+  @deprecated("Use `Future { ... }` instead.", "2.11.0")
+  // removal planned for 2.13.0
   def future[T](body: =>T)(implicit @deprecatedName('execctx) executor: ExecutionContext): Future[T] = Future[T](body)
 
   /** Creates a promise object which can be completed with a value or an exception.
@@ -34,6 +36,8 @@ package object concurrent {
    *  @tparam T       the type of the value in the promise
    *  @return         the newly created `Promise` object
    */
+  @deprecated("Use `Promise[T]()` instead.", "2.11.0")
+  // removal planned for 2.13.0
   def promise[T](): Promise[T] = Promise[T]()
 
   /** Used to designate a piece of code which potentially blocks, allowing the current [[BlockContext]] to adjust

--- a/test/files/jvm/future-spec/FutureTests.scala
+++ b/test/files/jvm/future-spec/FutureTests.scala
@@ -15,7 +15,7 @@ class FutureTests extends MinimalScalaTest {
   /* some utils */
 
   def testAsync(s: String)(implicit ec: ExecutionContext): Future[String] = s match {
-    case "Hello"   => future { "World" }
+    case "Hello"   => Future { "World" }
     case "Failure" => Future.failed(new RuntimeException("Expected exception; to test fault-tolerance"))
     case "NoReply" => Promise[String]().future
   }
@@ -34,7 +34,7 @@ class FutureTests extends MinimalScalaTest {
 
       class ThrowableTest(m: String) extends Throwable(m)
 
-      val f1 = future[Any] {
+      val f1 = Future[Any] {
         throw new ThrowableTest("test")
       }
 
@@ -43,7 +43,7 @@ class FutureTests extends MinimalScalaTest {
       }
 
       val latch = new TestLatch
-      val f2 = future {
+      val f2 = Future {
         Await.ready(latch, 5 seconds)
         "success"
       }
@@ -61,7 +61,7 @@ class FutureTests extends MinimalScalaTest {
 
       Await.result(f3, defaultTimeout) mustBe ("SUCCESS")
 
-      val waiting = future {
+      val waiting = Future {
         Thread.sleep(1000)
       }
       Await.ready(waiting, 2000 millis)
@@ -106,8 +106,8 @@ class FutureTests extends MinimalScalaTest {
     import ExecutionContext.Implicits._
 
     "compose with for-comprehensions" in {
-      def async(x: Int) = future { (x * 2).toString }
-      val future0 = future[Any] {
+      def async(x: Int) = Future { (x * 2).toString }
+      val future0 = Future[Any] {
         "five!".length
       }
 
@@ -119,8 +119,8 @@ class FutureTests extends MinimalScalaTest {
 
       val future2 = for {
         a <- future0.mapTo[Int]
-        b <- (future { (a * 2).toString }).mapTo[Int]
-        c <- future { (7 * 2).toString }
+        b <- (Future { (a * 2).toString }).mapTo[Int]
+        c <- Future { (7 * 2).toString }
       } yield b + "-" + c
 
       Await.result(future1, defaultTimeout) mustBe ("10-14")
@@ -132,8 +132,8 @@ class FutureTests extends MinimalScalaTest {
       case class Req[T](req: T)
       case class Res[T](res: T)
       def async[T](req: Req[T]) = req match {
-        case Req(s: String) => future { Res(s.length) }
-        case Req(i: Int)    => future { Res((i * 2).toString) }
+        case Req(s: String) => Future { Res(s.length) }
+        case Req(i: Int)    => Future { Res((i * 2).toString) }
       }
 
       val future1 = for {
@@ -224,7 +224,7 @@ class FutureTests extends MinimalScalaTest {
     "andThen like a boss" in {
       val q = new java.util.concurrent.LinkedBlockingQueue[Int]
       for (i <- 1 to 1000) {
-        val chained = future {
+        val chained = Future {
           q.add(1); 3
         } andThen {
           case _ => q.add(2)
@@ -251,7 +251,7 @@ class FutureTests extends MinimalScalaTest {
     }
 
     "find" in {
-      val futures = for (i <- 1 to 10) yield future {
+      val futures = for (i <- 1 to 10) yield Future {
         i
       }
 
@@ -286,7 +286,7 @@ class FutureTests extends MinimalScalaTest {
 
     "fold" in {
       val timeout = 10000 millis
-      def async(add: Int, wait: Int) = future {
+      def async(add: Int, wait: Int) = Future {
         Thread.sleep(wait)
         add
       }
@@ -306,7 +306,7 @@ class FutureTests extends MinimalScalaTest {
 
     "fold by composing" in {
       val timeout = 10000 millis
-      def async(add: Int, wait: Int) = future {
+      def async(add: Int, wait: Int) = Future {
         Thread.sleep(wait)
         add
       }
@@ -321,7 +321,7 @@ class FutureTests extends MinimalScalaTest {
 
     "fold with an exception" in {
       val timeout = 10000 millis
-      def async(add: Int, wait: Int) = future {
+      def async(add: Int, wait: Int) = Future {
         Thread.sleep(wait)
         if (add == 6) throw new IllegalArgumentException("shouldFoldResultsWithException: expected")
         add
@@ -357,7 +357,7 @@ class FutureTests extends MinimalScalaTest {
     }
 
     "shouldReduceResults" in {
-      def async(idx: Int) = future {
+      def async(idx: Int) = Future {
         Thread.sleep(idx * 20)
         idx
       }
@@ -373,7 +373,7 @@ class FutureTests extends MinimalScalaTest {
     }
 
     "shouldReduceResultsWithException" in {
-      def async(add: Int, wait: Int) = future {
+      def async(add: Int, wait: Int) = Future {
         Thread.sleep(wait)
         if (add == 6) throw new IllegalArgumentException("shouldFoldResultsWithException: expected")
         else add
@@ -404,7 +404,7 @@ class FutureTests extends MinimalScalaTest {
         }
       }
 
-      val oddFutures = List.fill(100)(future { counter.incAndGet() }).iterator
+      val oddFutures = List.fill(100)(Future { counter.incAndGet() }).iterator
       val traversed = Future.sequence(oddFutures)
       Await.result(traversed, defaultTimeout).sum mustBe (10000)
 
@@ -420,11 +420,11 @@ class FutureTests extends MinimalScalaTest {
     "shouldBlockUntilResult" in {
       val latch = new TestLatch
 
-      val f = future {
+      val f = Future {
         Await.ready(latch, 5 seconds)
         5
       }
-      val f2 = future {
+      val f2 = Future {
         val res = Await.result(f, Inf)
         res + 9
       }
@@ -437,7 +437,7 @@ class FutureTests extends MinimalScalaTest {
 
       Await.result(f2, defaultTimeout) mustBe (14)
 
-      val f3 = future {
+      val f3 = Future {
         Thread.sleep(100)
         5
       }
@@ -450,7 +450,7 @@ class FutureTests extends MinimalScalaTest {
     "run callbacks async" in {
       val latch = Vector.fill(10)(new TestLatch)
 
-      val f1 = future {
+      val f1 = Future {
         latch(0).open()
         Await.ready(latch(1), TestLatch.DefaultTimeout)
         "Hello"
@@ -542,7 +542,7 @@ class FutureTests extends MinimalScalaTest {
 
     "should not throw when Await.ready" in {
       val expected = try Success(5 / 0) catch { case a: ArithmeticException => Failure(a) }
-      val f = future(5).map(_ / 0)
+      val f = Future(5).map(_ / 0)
       Await.ready(f, defaultTimeout).value.get.toString mustBe expected.toString
     }
 

--- a/test/files/pos/t2484.scala
+++ b/test/files/pos/t2484.scala
@@ -3,7 +3,7 @@ import concurrent.ExecutionContext.Implicits.global
 class Admin extends javax.swing.JApplet {
   val jScrollPane = new javax.swing.JScrollPane (null, 0, 0)
   def t2484: Unit = {
-    scala.concurrent.future {jScrollPane.synchronized {
+    scala.concurrent.Future {jScrollPane.synchronized {
       def someFunction () = {}
       //scala.concurrent.ops.spawn {someFunction ()}
       jScrollPane.addComponentListener (new java.awt.event.ComponentAdapter {override def componentShown (e: java.awt.event.ComponentEvent) = {

--- a/test/files/run/macro-duplicate/Impls_Macros_1.scala
+++ b/test/files/run/macro-duplicate/Impls_Macros_1.scala
@@ -10,7 +10,7 @@ object Macros {
           case Template(_, _, ctor :: defs) =>
             val defs1 = defs collect {
               case ddef @ DefDef(mods, name, tparams, vparamss, tpt, body) =>
-                val future = Select(Select(Select(Ident(TermName("scala")), TermName("concurrent")), TermName("package")), TermName("future"))
+                val future = Select(Select(Ident(TermName("scala")), TermName("concurrent")), TermName("Future"))
                 val Future = Select(Select(Ident(TermName("scala")), TermName("concurrent")), TypeName("Future"))
                 val tpt1 = if (tpt.isEmpty) tpt else AppliedTypeTree(Future, List(tpt))
                 val body1 = Apply(future, List(body))

--- a/test/files/run/t6448.scala
+++ b/test/files/run/t6448.scala
@@ -50,7 +50,7 @@ object Test {
         import concurrent.ExecutionContext.Implicits.global
         import concurrent.Await
         import concurrent.duration.Duration
-        val result = concurrent.future(1) collect { case x if f(x) => x}
+        val result = concurrent.Future(1) collect { case x if f(x) => x}
         Await.result(result, Duration.Inf)
       }
 

--- a/test/files/run/t7775.scala
+++ b/test/files/run/t7775.scala
@@ -1,4 +1,4 @@
-import scala.concurrent.{duration, future, Await, ExecutionContext}
+import scala.concurrent.{duration, Future, Await, ExecutionContext}
 import scala.tools.nsc.Settings
 import ExecutionContext.Implicits.global
 
@@ -8,7 +8,7 @@ import ExecutionContext.Implicits.global
 object Test {
   def main(args: Array[String]) {
     val tries = 1000 // YMMV
-    val compiler = future {
+    val compiler = Future {
       for(_ <- 1 to tries) new Settings(_ => {})
     }
     for(i <- 1 to tries * 10) System.setProperty(s"foo$i", i.toString)

--- a/test/files/run/t7805-repl-i.scala
+++ b/test/files/run/t7805-repl-i.scala
@@ -35,7 +35,7 @@ trait HangingRepl extends ReplTest {
   import ExecutionContext.Implicits._
   import Resulting._
   def timeout = 120 seconds
-  def hanging[A](a: =>A): A = future(a) resultWithin timeout
+  def hanging[A](a: =>A): A = Future(a) resultWithin timeout
   override def show() = Try(hanging(super.show())) recover {
     case e => e.printStackTrace()
   }


### PR DESCRIPTION
...t` package object

The corresponding `apply` methods in the `Future` and `Promise` objects
should be used instead.
