### PR TITLE
Make parameters to implicit value classes private

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -286,9 +286,12 @@ TODO:
           -->
         <!-- <artifact:remoteRepository refid="extra-repo"/> -->
         <dependency groupId="org.scala-lang.modules" artifactId="scala-partest_${scala.binary.version}" version="${partest.version.number}" />
-        <dependency groupId="org.scalacheck"         artifactId="scalacheck_${scala.binary.version}"    version="${scalacheck.version.number}" />
       </artifact:dependencies>
       <copy-deps project="partest"/>
+
+      <artifact:dependencies pathId="scalacheck.classpath" filesetId="scalacheck.fileset" versionsId="scalacheck.versions">
+        <dependency groupId="org.scalacheck"         artifactId="scalacheck_${scala.binary.version}"    version="${scalacheck.version.number}" />
+      </artifact:dependencies>
 
       <artifact:dependencies pathId="repl.deps.classpath" filesetId="repl.fileset" versionsId="repl.deps.versions">
         <dependency groupId="jline" artifactId="jline" version="${jline.version}"/>
@@ -894,11 +897,30 @@ TODO:
       <pathelement location="${actors.jar}"/>
 
       <!-- partest's dependencies, which marks most of its dependencies as provided,
+           (but not scala-library, so we filter that one out...)
            so we provide them: scala-[library/reflect/compiler], scalap built here,
            scala-xml, scala-parser-combinators via external-modules-nocore,
            scalacheck as part of `partest.classpath` -->
-      <path refid="partest.classpath"/>
-      <path refid="external-modules-nocore"/> <!-- xml, parsers -->
+      <restrict>
+        <path refid="partest.classpath"/>
+        <rsel:not><rsel:or>
+          <rsel:name name="scala-library*.jar"/>
+        </rsel:or></rsel:not>
+      </restrict>
+      <pathelement location="${scala-xml}"/>
+      <pathelement location="${scala-parser-combinators}"/>
+
+      <restrict>
+        <path refid="scalacheck.classpath"/>
+        <rsel:not><rsel:or>
+          <rsel:name name="scala-library*.jar"/>
+          <rsel:name name="scala-compiler*.jar"/>
+          <rsel:name name="scala-reflect*.jar"/>
+          <rsel:name name="scala-actors*.jar"/>
+          <rsel:name name="scala-parser-combinators*.jar"/>
+          <rsel:name name="scala-xml*.jar"/>
+        </rsel:or></rsel:not>
+      </restrict>
 
       <!-- partest classes specific to the core compiler build -->
       <pathelement location="${partest-extras.jar}"/>

--- a/src/compiler/scala/tools/nsc/util/package.scala
+++ b/src/compiler/scala/tools/nsc/util/package.scala
@@ -75,7 +75,7 @@ package object util {
     s"$clazz$msg @ $frame"
   }
 
-  implicit class StackTraceOps(val e: Throwable) extends AnyVal with StackTracing {
+  implicit class StackTraceOps(private val e: Throwable) extends AnyVal with StackTracing {
     /** Format the stack trace, returning the prefix consisting of frames that satisfy
      *  a given predicate.
      *  The format is similar to the typical case described in the JavaDoc

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -244,33 +244,33 @@ object Predef extends LowPriorityImplicits with DeprecatedPredef {
 
   // implicit classes -----------------------------------------------------
 
-  implicit final class ArrowAssoc[A](val __leftOfArrow: A) extends AnyVal {
-    @inline def -> [B](y: B): Tuple2[A, B] = Tuple2(__leftOfArrow, y)
+  implicit final class ArrowAssoc[A](private val self: A) extends AnyVal {
+    @inline def -> [B](y: B): Tuple2[A, B] = Tuple2(self, y)
     def →[B](y: B): Tuple2[A, B] = ->(y)
   }
 
-  implicit final class Ensuring[A](val __resultOfEnsuring: A) extends AnyVal {
-    def ensuring(cond: Boolean): A = { assert(cond); __resultOfEnsuring }
-    def ensuring(cond: Boolean, msg: => Any): A = { assert(cond, msg); __resultOfEnsuring }
-    def ensuring(cond: A => Boolean): A = { assert(cond(__resultOfEnsuring)); __resultOfEnsuring }
-    def ensuring(cond: A => Boolean, msg: => Any): A = { assert(cond(__resultOfEnsuring), msg); __resultOfEnsuring }
+  implicit final class Ensuring[A](private val self: A) extends AnyVal {
+    def ensuring(cond: Boolean): A = { assert(cond); self }
+    def ensuring(cond: Boolean, msg: => Any): A = { assert(cond, msg); self }
+    def ensuring(cond: A => Boolean): A = { assert(cond(self)); self }
+    def ensuring(cond: A => Boolean, msg: => Any): A = { assert(cond(self), msg); self }
   }
 
-  implicit final class StringFormat[A](val __stringToFormat: A) extends AnyVal {
+  implicit final class StringFormat[A](private val self: A) extends AnyVal {
     /** Returns string formatted according to given `format` string.
      *  Format strings are as for `String.format`
      *  (@see java.lang.String.format).
      */
-    @inline def formatted(fmtstr: String): String = fmtstr format __stringToFormat
+    @inline def formatted(fmtstr: String): String = fmtstr format self
   }
 
-  implicit final class StringAdd[A](val __thingToAdd: A) extends AnyVal {
-    def +(other: String) = String.valueOf(__thingToAdd) + other
+  implicit final class StringAdd[A](private val self: A) extends AnyVal {
+    def +(other: String) = String.valueOf(self) + other
   }
 
-  implicit final class RichException(val __throwableToEnrich: Throwable) extends AnyVal {
+  implicit final class RichException(private val self: Throwable) extends AnyVal {
     import scala.compat.Platform.EOL
-    @deprecated("Use Throwable#getStackTrace", "2.11.0") def getStackTraceString = __throwableToEnrich.getStackTrace().mkString("", EOL, EOL)
+    @deprecated("Use Throwable#getStackTrace", "2.11.0") def getStackTraceString = self.getStackTrace().mkString("", EOL, EOL)
   }
 
   implicit final class SeqCharSequence(val __sequenceOfChars: scala.collection.IndexedSeq[Char]) extends CharSequence {

--- a/src/library/scala/concurrent/duration/package.scala
+++ b/src/library/scala/concurrent/duration/package.scala
@@ -40,15 +40,15 @@ package object duration {
   implicit def pairLongToDuration(p: (Long, TimeUnit)): FiniteDuration = Duration(p._1, p._2)
   implicit def durationToPair(d: Duration): (Long, TimeUnit)           = (d.length, d.unit)
 
-  implicit final class DurationInt(val n: Int) extends AnyVal with DurationConversions {
+  implicit final class DurationInt(private val n: Int) extends AnyVal with DurationConversions {
     override protected def durationIn(unit: TimeUnit): FiniteDuration = Duration(n.toLong, unit)
   }
 
-  implicit final class DurationLong(val n: Long) extends AnyVal with DurationConversions {
+  implicit final class DurationLong(private val n: Long) extends AnyVal with DurationConversions {
     override protected def durationIn(unit: TimeUnit): FiniteDuration = Duration(n, unit)
   }
 
-  implicit final class DurationDouble(val d: Double) extends AnyVal with DurationConversions {
+  implicit final class DurationDouble(private val d: Double) extends AnyVal with DurationConversions {
     override protected def durationIn(unit: TimeUnit): FiniteDuration =
       Duration(d, unit) match {
         case f: FiniteDuration => f
@@ -59,17 +59,17 @@ package object duration {
   /*
    * Avoid reflection based invocation by using non-duck type
    */
-  implicit final class IntMult(val i: Int) extends AnyVal {
+  implicit final class IntMult(private val i: Int) extends AnyVal {
     def *(d: Duration) = d * i.toDouble
     def *(d: FiniteDuration) = d * i.toLong
   }
 
-  implicit final class LongMult(val i: Long) extends AnyVal {
+  implicit final class LongMult(private val i: Long) extends AnyVal {
     def *(d: Duration) = d * i.toDouble
     def *(d: FiniteDuration) = d * i.toLong
   }
 
-  implicit final class DoubleMult(val f: Double) extends AnyVal {
+  implicit final class DoubleMult(private val f: Double) extends AnyVal {
     def *(d: Duration) = d * f.toDouble
   }
 }

--- a/src/library/scala/util/Either.scala
+++ b/src/library/scala/util/Either.scala
@@ -216,7 +216,7 @@ object Either {
    * r.merge: Seq[Int] // Vector(1)
    * }}}
    */
-  implicit class MergeableEither[A](val x: Either[A, A]) extends AnyVal {
+  implicit class MergeableEither[A](private val x: Either[A, A]) extends AnyVal {
     def merge: A = x match {
       case Left(a)  => a
       case Right(a) => a

--- a/test/files/neg/logImplicits.check
+++ b/test/files/neg/logImplicits.check
@@ -7,10 +7,10 @@ logImplicits.scala:7: applied implicit conversion from String("abc") to ?{def ma
 logImplicits.scala:15: inferred view from String("abc") to Int = C.this.convert:(p: String("abc"))Int
   math.max(122, x: Int)
                 ^
-logImplicits.scala:19: applied implicit conversion from Int(1) to ?{def ->: ?} = implicit def ArrowAssoc[A](__leftOfArrow: A): ArrowAssoc[A]
+logImplicits.scala:19: applied implicit conversion from Int(1) to ?{def ->: ?} = implicit def ArrowAssoc[A](self: A): ArrowAssoc[A]
   def f = (1 -> 2) + "c"
            ^
-logImplicits.scala:19: applied implicit conversion from (Int, Int) to ?{def +: ?} = implicit def StringAdd[A](__thingToAdd: A): StringAdd[A]
+logImplicits.scala:19: applied implicit conversion from (Int, Int) to ?{def +: ?} = implicit def StringAdd[A](self: A): StringAdd[A]
   def f = (1 -> 2) + "c"
              ^
 logImplicits.scala:22: error: class Un needs to be abstract, since method unimplemented is not defined

--- a/test/files/presentation/callcc-interpreter.check
+++ b/test/files/presentation/callcc-interpreter.check
@@ -3,7 +3,7 @@ reload: CallccInterpreter.scala
 askTypeCompletion at CallccInterpreter.scala(51,38)
 ================================================================================
 [response] askCompletionAt (51,38)
-retrieved 63 members
+retrieved 59 members
 abstract trait Term extends AnyRef
 abstract trait Value extends AnyRef
 case class Add extends callccInterpreter.Term with Product with Serializable
@@ -52,10 +52,6 @@ final def synchronized[T0](x$1: T0): T0
 final def wait(): Unit
 final def wait(x$1: Long): Unit
 final def wait(x$1: Long,x$2: Int): Unit
-private[this] val __leftOfArrow: callccInterpreter.type
-private[this] val __resultOfEnsuring: callccInterpreter.type
-private[this] val __stringToFormat: callccInterpreter.type
-private[this] val __thingToAdd: callccInterpreter.type
 private[this] val term0: callccInterpreter.App
 private[this] val term1: callccInterpreter.App
 private[this] val term2: callccInterpreter.Add

--- a/test/files/presentation/ide-bug-1000349.check
+++ b/test/files/presentation/ide-bug-1000349.check
@@ -3,7 +3,7 @@ reload: CompletionOnEmptyArgMethod.scala
 askTypeCompletion at CompletionOnEmptyArgMethod.scala(2,17)
 ================================================================================
 [response] askCompletionAt (2,17)
-retrieved 36 members
+retrieved 32 members
 def +(other: String): String
 def ->[B](y: B): (Foo, B)
 def ensuring(cond: Boolean): Foo
@@ -31,10 +31,6 @@ final def synchronized[T0](x$1: T0): T0
 final def wait(): Unit
 final def wait(x$1: Long): Unit
 final def wait(x$1: Long,x$2: Int): Unit
-private[this] val __leftOfArrow: Foo
-private[this] val __resultOfEnsuring: Foo
-private[this] val __stringToFormat: Foo
-private[this] val __thingToAdd: Foo
 protected[package lang] def clone(): Object
 protected[package lang] def finalize(): Unit
 ================================================================================

--- a/test/files/presentation/ide-bug-1000475.check
+++ b/test/files/presentation/ide-bug-1000475.check
@@ -3,7 +3,7 @@ reload: Foo.scala
 askTypeCompletion at Foo.scala(3,7)
 ================================================================================
 [response] askCompletionAt (3,7)
-retrieved 35 members
+retrieved 31 members
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit
 def +(other: String): String
@@ -32,16 +32,12 @@ final def synchronized[T0](x$1: T0): T0
 final def wait(): Unit
 final def wait(x$1: Long): Unit
 final def wait(x$1: Long,x$2: Int): Unit
-private[this] val __leftOfArrow: Object
-private[this] val __resultOfEnsuring: Object
-private[this] val __stringToFormat: Object
-private[this] val __thingToAdd: Object
 ================================================================================
 
 askTypeCompletion at Foo.scala(6,10)
 ================================================================================
 [response] askCompletionAt (6,10)
-retrieved 35 members
+retrieved 31 members
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit
 def +(other: String): String
@@ -70,16 +66,12 @@ final def synchronized[T0](x$1: T0): T0
 final def wait(): Unit
 final def wait(x$1: Long): Unit
 final def wait(x$1: Long,x$2: Int): Unit
-private[this] val __leftOfArrow: Object
-private[this] val __resultOfEnsuring: Object
-private[this] val __stringToFormat: Object
-private[this] val __thingToAdd: Object
 ================================================================================
 
 askTypeCompletion at Foo.scala(7,7)
 ================================================================================
 [response] askCompletionAt (7,7)
-retrieved 35 members
+retrieved 31 members
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit
 def +(other: String): String
@@ -108,8 +100,4 @@ final def synchronized[T0](x$1: T0): T0
 final def wait(): Unit
 final def wait(x$1: Long): Unit
 final def wait(x$1: Long,x$2: Int): Unit
-private[this] val __leftOfArrow: Object
-private[this] val __resultOfEnsuring: Object
-private[this] val __stringToFormat: Object
-private[this] val __thingToAdd: Object
 ================================================================================

--- a/test/files/presentation/ide-bug-1000531.check
+++ b/test/files/presentation/ide-bug-1000531.check
@@ -3,7 +3,7 @@ reload: CrashOnLoad.scala
 askTypeCompletion at CrashOnLoad.scala(6,12)
 ================================================================================
 [response] askCompletionAt (6,12)
-retrieved 124 members
+retrieved 120 members
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit
 [inaccessible] protected[this] def reversed: List[B]
@@ -121,8 +121,4 @@ final def synchronized[T0](x$1: T0): T0
 final def wait(): Unit
 final def wait(x$1: Long): Unit
 final def wait(x$1: Long,x$2: Int): Unit
-private[this] val __leftOfArrow: java.util.Iterator[B]
-private[this] val __resultOfEnsuring: java.util.Iterator[B]
-private[this] val __stringToFormat: java.util.Iterator[B]
-private[this] val __thingToAdd: java.util.Iterator[B]
 ================================================================================

--- a/test/files/presentation/implicit-member.check
+++ b/test/files/presentation/implicit-member.check
@@ -3,7 +3,7 @@ reload: ImplicitMember.scala
 askTypeCompletion at ImplicitMember.scala(7,7)
 ================================================================================
 [response] askCompletionAt (7,7)
-retrieved 38 members
+retrieved 34 members
 def +(other: String): String
 def ->[B](y: B): (Implicit.type, B)
 def ensuring(cond: Boolean): Implicit.type
@@ -32,10 +32,6 @@ final def wait(): Unit
 final def wait(x$1: Long): Unit
 final def wait(x$1: Long,x$2: Int): Unit
 implicit def AppliedImplicit[A](x: A): Implicit.AppliedImplicit[A]
-private[this] val __leftOfArrow: Implicit.type
-private[this] val __resultOfEnsuring: Implicit.type
-private[this] val __stringToFormat: Implicit.type
-private[this] val __thingToAdd: Implicit.type
 private[this] val x: Implicit.type
 protected[package lang] def clone(): Object
 protected[package lang] def finalize(): Unit

--- a/test/files/presentation/ping-pong.check
+++ b/test/files/presentation/ping-pong.check
@@ -3,7 +3,7 @@ reload: PingPong.scala
 askTypeCompletion at PingPong.scala(10,23)
 ================================================================================
 [response] askCompletionAt (10,23)
-retrieved 39 members
+retrieved 35 members
 [inaccessible] private[this] val ping: Ping
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit
@@ -34,17 +34,13 @@ final def wait(): Unit
 final def wait(x$1: Long): Unit
 final def wait(x$1: Long,x$2: Int): Unit
 override def toString(): String
-private[this] val __leftOfArrow: Pong
-private[this] val __resultOfEnsuring: Pong
-private[this] val __stringToFormat: Pong
-private[this] val __thingToAdd: Pong
 private[this] val name: String
 ================================================================================
 
 askTypeCompletion at PingPong.scala(19,20)
 ================================================================================
 [response] askCompletionAt (19,20)
-retrieved 39 members
+retrieved 35 members
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit
 def +(other: String): String
@@ -76,10 +72,6 @@ final def wait(): Unit
 final def wait(x$1: Long): Unit
 final def wait(x$1: Long,x$2: Int): Unit
 override def toString(): String
-private[this] val __leftOfArrow: Ping
-private[this] val __resultOfEnsuring: Ping
-private[this] val __stringToFormat: Ping
-private[this] val __thingToAdd: Ping
 private[this] val pong: Pong
 ================================================================================
 

--- a/test/files/presentation/t5708.check
+++ b/test/files/presentation/t5708.check
@@ -3,7 +3,7 @@ reload: Completions.scala
 askTypeCompletion at Completions.scala(17,9)
 ================================================================================
 [response] askCompletionAt (17,9)
-retrieved 43 members
+retrieved 39 members
 [inaccessible] private def privateM: String
 [inaccessible] private[this] val privateV: String
 [inaccessible] private[this] val protectedV: String
@@ -39,9 +39,5 @@ final def wait(x$1: Long,x$2: Int): Unit
 final private[this] val CONST_STRING: String("constant")
 lazy private[this] var foo: Int
 private[package test] def pkgPrivateM: String
-private[this] val __leftOfArrow: test.Compat.type
-private[this] val __resultOfEnsuring: test.Compat.type
-private[this] val __stringToFormat: test.Compat.type
-private[this] val __thingToAdd: test.Compat.type
 private[this] val pkgPrivateV: String
 ================================================================================

--- a/test/files/presentation/visibility.check
+++ b/test/files/presentation/visibility.check
@@ -3,7 +3,7 @@ reload: Completions.scala
 askTypeCompletion at Completions.scala(14,12)
 ================================================================================
 [response] askCompletionAt (14,12)
-retrieved 41 members
+retrieved 37 members
 [inaccessible] private[this] def secretPrivateThis(): Unit
 def +(other: String): String
 def ->[B](y: B): (accessibility.Foo, B)
@@ -34,10 +34,6 @@ final def wait(): Unit
 final def wait(x$1: Long): Unit
 final def wait(x$1: Long,x$2: Int): Unit
 private def secretPrivate(): Unit
-private[this] val __leftOfArrow: accessibility.Foo
-private[this] val __resultOfEnsuring: accessibility.Foo
-private[this] val __stringToFormat: accessibility.Foo
-private[this] val __thingToAdd: accessibility.Foo
 protected def secretProtected(): Unit
 protected[package accessibility] def secretProtectedInPackage(): Unit
 protected[package lang] def clone(): Object
@@ -47,7 +43,7 @@ protected[package lang] def finalize(): Unit
 askTypeCompletion at Completions.scala(16,11)
 ================================================================================
 [response] askCompletionAt (16,11)
-retrieved 41 members
+retrieved 37 members
 def +(other: String): String
 def ->[B](y: B): (accessibility.Foo, B)
 def ensuring(cond: Boolean): accessibility.Foo
@@ -78,10 +74,6 @@ final def wait(x$1: Long): Unit
 final def wait(x$1: Long,x$2: Int): Unit
 private def secretPrivate(): Unit
 private[this] def secretPrivateThis(): Unit
-private[this] val __leftOfArrow: accessibility.Foo
-private[this] val __resultOfEnsuring: accessibility.Foo
-private[this] val __stringToFormat: accessibility.Foo
-private[this] val __thingToAdd: accessibility.Foo
 protected def secretProtected(): Unit
 protected[package accessibility] def secretProtectedInPackage(): Unit
 protected[package lang] def clone(): Object
@@ -91,7 +83,7 @@ protected[package lang] def finalize(): Unit
 askTypeCompletion at Completions.scala(22,11)
 ================================================================================
 [response] askCompletionAt (22,11)
-retrieved 41 members
+retrieved 37 members
 [inaccessible] private def secretPrivate(): Unit
 def +(other: String): String
 def ->[B](y: B): (accessibility.AccessibilityChecks, B)
@@ -122,10 +114,6 @@ final def synchronized[T0](x$1: T0): T0
 final def wait(): Unit
 final def wait(x$1: Long): Unit
 final def wait(x$1: Long,x$2: Int): Unit
-private[this] val __leftOfArrow: accessibility.AccessibilityChecks
-private[this] val __resultOfEnsuring: accessibility.AccessibilityChecks
-private[this] val __stringToFormat: accessibility.AccessibilityChecks
-private[this] val __thingToAdd: accessibility.AccessibilityChecks
 protected def secretProtected(): Unit
 protected[package accessibility] def secretProtectedInPackage(): Unit
 protected[package lang] def clone(): Object
@@ -135,7 +123,7 @@ protected[package lang] def finalize(): Unit
 askTypeCompletion at Completions.scala(28,10)
 ================================================================================
 [response] askCompletionAt (28,10)
-retrieved 41 members
+retrieved 37 members
 [inaccessible] private def secretPrivate(): Unit
 [inaccessible] private[this] def secretPrivateThis(): Unit
 [inaccessible] protected def secretProtected(): Unit
@@ -169,17 +157,13 @@ final def synchronized[T0](x$1: T0): T0
 final def wait(): Unit
 final def wait(x$1: Long): Unit
 final def wait(x$1: Long,x$2: Int): Unit
-private[this] val __leftOfArrow: accessibility.Foo
-private[this] val __resultOfEnsuring: accessibility.Foo
-private[this] val __stringToFormat: accessibility.Foo
-private[this] val __thingToAdd: accessibility.Foo
 protected[package accessibility] def secretProtectedInPackage(): Unit
 ================================================================================
 
 askTypeCompletion at Completions.scala(37,8)
 ================================================================================
 [response] askCompletionAt (37,8)
-retrieved 41 members
+retrieved 37 members
 [inaccessible] private def secretPrivate(): Unit
 [inaccessible] private[this] def secretPrivateThis(): Unit
 [inaccessible] protected def secretProtected(): Unit
@@ -214,8 +198,4 @@ final def synchronized[T0](x$1: T0): T0
 final def wait(): Unit
 final def wait(x$1: Long): Unit
 final def wait(x$1: Long,x$2: Int): Unit
-private[this] val __leftOfArrow: accessibility.Foo
-private[this] val __resultOfEnsuring: accessibility.Foo
-private[this] val __stringToFormat: accessibility.Foo
-private[this] val __thingToAdd: accessibility.Foo
 ================================================================================


### PR DESCRIPTION
Rebase of #3046, first bumping starr to M6
(Left other versions as-is, as something seems wrong with partest.
Looking into that now.)

Old description:
So that they aren't offered as an autocomplete suggestion:

```
implicit class Shouty(string: String) extends AnyVal {
 def SHOUT_! = string.toUpperCase + "!"
}
"". // autocompletion offers `.string` here.
```

The original incarnation of value classes didn't allow this sort of
encapsulation, so we either invented goofy names like
`__thingToAdd` or just picked `x` or `self`. But  has delivered us the
freedom to keep the accessor private.

Should we keep any of these accessors around in a deprecated form?

The implicit classes in Predef were added in 2.11.0-M2
(c26a8db067e4f), so they are okay.

I think we can make reason that these APIs were both accidental and unlikely
to be interpreted as public, so we can break them immediately.

```
scala> Left(1).x
res0: scala.util.Either[Int,Int] = Left(1)

scala> import concurrent.duration._
import concurrent.duration._

scala> 1.n
res1: Int = 1
```
