### PR TITLE
SI-7568 Adding Serializable to ResizableArrayAccess inner class

### DIFF
--- a/src/library/scala/collection/mutable/PriorityQueue.scala
+++ b/src/library/scala/collection/mutable/PriorityQueue.scala
@@ -43,7 +43,7 @@ class PriorityQueue[A](implicit val ord: Ordering[A])
 {
   import ord._
 
-  private class ResizableArrayAccess[A] extends AbstractSeq[A] with ResizableArray[A] {
+  private class ResizableArrayAccess[A] extends AbstractSeq[A] with ResizableArray[A] with Serializable {
     def p_size0 = size0
     def p_size0_=(s: Int) = size0 = s
     def p_array = array

--- a/test/junit/scala/collection/PriorityQueueTest.scala
+++ b/test/junit/scala/collection/PriorityQueueTest.scala
@@ -1,0 +1,32 @@
+package scala.collection.mutable
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Test
+import scala.collection.mutable
+import java.io.{ObjectInputStream, ByteArrayInputStream, ByteArrayOutputStream, ObjectOutputStream}
+
+@RunWith(classOf[JUnit4])
+/* Test for SI-7568  */
+class PriorityQueueTest {
+  val priorityQueue = new mutable.PriorityQueue[Int]()
+  val elements = List.fill(1000)(scala.util.Random.nextInt(Int.MaxValue))
+  priorityQueue.enqueue(elements :_*)
+
+  @Test
+  def canSerialize() {
+    val outputStream = new ByteArrayOutputStream()
+    new ObjectOutputStream(outputStream).writeObject(priorityQueue)
+  }
+
+  @Test
+  def maintainsStateWhenDeserialized() {
+    val outputStream = new ByteArrayOutputStream()
+    new ObjectOutputStream(outputStream).writeObject(priorityQueue)
+    val bytes = outputStream.toByteArray
+
+    val objectInputStream = new ObjectInputStream(new ByteArrayInputStream(bytes))
+    val deserializedPriorityQueue = objectInputStream.readObject().asInstanceOf[PriorityQueue[Int]]
+    assert(deserializedPriorityQueue.dequeueAll == elements.sorted.reverse)
+  }
+}


### PR DESCRIPTION
Serialization troubles were caused by an inner class not being Serializable. 

I'd like to include a test for this, some guidance would be appreciated.
