### PR TITLE
SI-7968 Use an intrinsic for the next power of two calculation.

### DIFF
--- a/src/library/scala/collection/mutable/OpenHashMap.scala
+++ b/src/library/scala/collection/mutable/OpenHashMap.scala
@@ -17,7 +17,6 @@ package mutable
  *  @since 2.7
  */
 object OpenHashMap {
-  import generic.BitOperations.Int.highestOneBit
 
   def apply[K, V](elems : (K, V)*) = new OpenHashMap[K, V] ++= elems
   def empty[K, V] = new OpenHashMap[K, V]
@@ -27,7 +26,7 @@ object OpenHashMap {
                                             var value: Option[Value])
                 extends HashEntry[Key, OpenEntry[Key, Value]]
 
-  private[mutable] def nextPowerOfTwo(i : Int) = highestOneBit(i) << 1
+  private[mutable] def nextPositivePowerOfTwo(i : Int) = 1 << (32 - Integer.numberOfLeadingZeros(i - 1))
 }
 
 /** A mutable hash map based on an open hashing scheme. The precise scheme is
@@ -62,7 +61,7 @@ extends AbstractMap[Key, Value]
 
   override def empty: OpenHashMap[Key, Value] = OpenHashMap.empty[Key, Value]
 
-  private[this] val actualInitialSize = OpenHashMap.nextPowerOfTwo(initialSize)
+  private[this] val actualInitialSize = OpenHashMap.nextPositivePowerOfTwo(initialSize)
 
   private var mask = actualInitialSize - 1
   private var table : Array[Entry] = new Array[Entry](actualInitialSize)


### PR DESCRIPTION
Fixes issues raised in #3126.
The nextPowerOfTwo function is replaced by nextPositivePowerOfTwo which provides the following improvements:

1) Uses the Integer.numberOfLeadingZeros intrinsic for the actual implementation.
2) If the input is already a power of two it just returns the number instead of returning the next power of two.
3) Works for negative numbers and zero as input. The output is 1 in both cases.
