### PR TITLE
Upgrade pax-url-aether to 1.6.0.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -219,12 +219,14 @@ TODO:
       </artifact:dependencies>
 
       <!-- Pax runner -->
-      <property name="pax.exam.version" value="2.5.0"/>
+      <property name="pax.exam.version" value="2.6.0"/>
       <artifact:dependencies pathId="pax.exam.classpath" filesetId="pax.exam.fileset">
         <dependency groupId="org.ops4j.pax.exam" artifactId="pax-exam-container-native" version="${pax.exam.version}"/>
         <dependency groupId="org.ops4j.pax.exam" artifactId="pax-exam-junit4" version="${pax.exam.version}"/>
         <dependency groupId="org.ops4j.pax.exam" artifactId="pax-exam-link-assembly" version="${pax.exam.version}"/>
-        <dependency groupId="org.ops4j.pax.url" artifactId="pax-url-aether" version="1.4.0"/>
+        <!-- upgraded to 1.6.0 to get fix for https://ops4j1.jira.com/browse/PAXURL-217
+      https://ops4j1.jira.com/browse/PAXURL-138 is still unresolved... -->
+        <dependency groupId="org.ops4j.pax.url" artifactId="pax-url-aether" version="1.6.0"/>
         <dependency groupId="org.ops4j.pax.swissbox" artifactId="pax-swissbox-framework" version="1.5.1"/>
         <dependency groupId="ch.qos.logback" artifactId="logback-core" version="0.9.20"/>
         <dependency groupId="ch.qos.logback" artifactId="logback-classic" version="0.9.20"/>

--- a/starr.number
+++ b/starr.number
@@ -1,1 +1,2 @@
-starr.version=2.10.1
+starr.version=2.10.3
+starr.use.released=1


### PR DESCRIPTION
Since our jenkins uses mirrors with passwords,
we needed a fix for https://ops4j1.jira.com/browse/PAXURL-217
in order to run osgi.test on jenkins, now that we use maven more.
We didn't hit this bug before because we were using a standard
location for the maven local repository, but that causes problems
with concurrent jenkins jobs accessing it.
