### PR TITLE
SI-7967 Account for type aliases in self-type checks

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1698,15 +1698,16 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               psym addChild context.owner
             else
               pending += ParentSealedInheritanceError(parent, psym)
+          val parentTypeOfThis = parent.tpe.dealias.typeOfThis
 
-          if (!(selfType <:< parent.tpe.typeOfThis) &&
+          if (!(selfType <:< parentTypeOfThis) &&
               !phase.erasedTypes &&
               !context.owner.isSynthetic &&   // don't check synthetic concrete classes for virtuals (part of DEVIRTUALIZE)
               !selfType.isErroneous &&
               !parent.tpe.isErroneous)
           {
             pending += ParentSelfTypeConformanceError(parent, selfType)
-            if (settings.explaintypes) explainTypes(selfType, parent.tpe.typeOfThis)
+            if (settings.explaintypes) explainTypes(selfType, parentTypeOfThis)
           }
 
           if (parents exists (p => p != parent && p.tpe.typeSymbol == psym && !psym.isError))

--- a/test/files/neg/t7967.check
+++ b/test/files/neg/t7967.check
@@ -1,0 +1,9 @@
+t7967.scala:6: error: illegal inheritance;
+ self-type C does not conform to C's selftype C with B
+  new C {} // fails
+      ^
+t7967.scala:8: error: illegal inheritance;
+ self-type Test.CC does not conform to Test.CC's selftype Test.CC
+  new CC {} // should fail, doesn't
+      ^
+two errors found

--- a/test/files/neg/t7967.scala
+++ b/test/files/neg/t7967.scala
@@ -1,0 +1,9 @@
+
+trait B
+trait C {self: B =>}
+
+object Test {
+  new C {} // fails
+  type CC = C
+  new CC {} // should fail, doesn't
+}


### PR DESCRIPTION
These eluded the check for "illegal inheritance; self-type does not
conform" as AliasTypeRef doesn't forward `typeOfThis`.

This commit dealiases before calling `typeOfThis`. That seems to be
the most localised change.

Without the dealias, we had:

```
parent.tpe            = TypeRef(pre, sym = AliasTypeSymbol("CC"), Nil)
parent.tpe.typeOfThis = parent.tpe.transform(sym.typeOfThis) = CC
```

After:

```
parent.tpe.dealias            = TypeRef(pre, sym = ClassSymbol("C"), Nil)
parent.tpe.dealias.typeOfThis = C with B
```

Review by @adriaanm
