### PR TITLE
more precise isMacroApplication check

### DIFF
--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -842,7 +842,7 @@ abstract class TreeInfo {
     })
 
   def isMacroApplication(tree: Tree): Boolean =
-    !tree.isDef && tree.symbol != null && tree.symbol.isMacro && !tree.symbol.isErroneous
+    !tree.isDef && tree.symbol != null && tree.symbol.isTermMacro && !tree.symbol.isErroneous
 
   def isMacroApplicationOrBlock(tree: Tree): Boolean = tree match {
     case Block(_, expr) => isMacroApplicationOrBlock(expr)


### PR DESCRIPTION
Replaces the `symbol.isMacro` check with `symbol.isTermMacro`.
Doesn’t make any difference to trunk but helps a lot with macro annotations.
