### PR TITLE
correctly fails implicit search for invalid implicit macros

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -664,6 +664,8 @@ trait Implicits {
 
         if (context.hasErrors)
           fail("hasMatchingSymbol reported error: " + context.firstError.get.errMsg)
+        else if (itree3.isErroneous)
+          fail("error typechecking implicit candidate")
         else if (isLocal && !hasMatchingSymbol(itree2))
           fail("candidate implicit %s is shadowed by %s".format(
             info.sym.fullLocationString, itree2.symbol.fullLocationString))

--- a/test/files/pos/macro-implicit-invalidate-on-error.scala
+++ b/test/files/pos/macro-implicit-invalidate-on-error.scala
@@ -1,0 +1,28 @@
+package scala.reflect
+package api
+
+import scala.language.experimental.macros
+import scala.reflect.macros.Context
+
+trait Liftable[T] {
+  def apply(universe: api.Universe, value: T): universe.Tree
+}
+
+object Liftable {
+  implicit def liftCaseClass[T <: Product]: Liftable[T] = macro liftCaseClassImpl[T]
+
+  def liftCaseClassImpl[T: c.WeakTypeTag](c: Context): c.Expr[Liftable[T]] = {
+    import c.universe._
+    val tpe = weakTypeOf[T]
+    if (!tpe.typeSymbol.asClass.isCaseClass) c.abort(c.enclosingPosition, "denied")
+    val p = List(q"Literal(Constant(1))")
+    c.Expr[Liftable[T]] { q"""
+      new scala.reflect.api.Liftable[$tpe] {
+        def apply(universe: scala.reflect.api.Universe, value: $tpe): universe.Tree = {
+          import universe._
+          Apply(Select(Ident(TermName("C")), TermName("apply")), List(..$p))
+        }
+      }
+    """ }
+  }
+}


### PR DESCRIPTION
There was a rare corner case when implicit search wouldn’t discard
an invalid implicit macro (e.g. the one with mismatching macro impl or
the one with macro impl defined in the same compilation run) during
typechecking the corresponding candidate in typedImplicit1. This is now fixed.
