### PR TITLE
SI-7280 Scope completion not returning members provided by imports

### DIFF
--- a/src/interactive/scala/tools/nsc/interactive/ContextTrees.scala
+++ b/src/interactive/scala/tools/nsc/interactive/ContextTrees.scala
@@ -6,6 +6,7 @@ package scala.tools.nsc
 package interactive
 
 import scala.collection.mutable.ArrayBuffer
+import scala.annotation.tailrec
 
 trait ContextTrees { self: Global =>
 
@@ -28,44 +29,59 @@ trait ContextTrees { self: Global =>
     override def toString = "ContextTree("+pos+", "+children+")"
   }
 
-  /** Optionally returns the smallest context that contains given `pos`, or None if none exists.
+  /** Returns the most precise context possible for the given `pos`.
+   *
+   *  It looks for the finest ContextTree containing `pos`, and then look inside
+   *  this ContextTree for a child ContextTree located immediately before `pos`.
+   *  If such a child exists, returns its context, otherwise returns the context of
+   *  the parent ContextTree.
+   *
+   *  This is required to always return a context which contains the all the imports
+   *  declared up to `pos` (see SI-7280 for a test case).
+   *
+   *  Can return None if `pos` is before any valid Scala code.
    */
   def locateContext(contexts: Contexts, pos: Position): Option[Context] = synchronized {
-    def locateNearestContextTree(contexts: Contexts, pos: Position, recent: Array[ContextTree]): Option[ContextTree] = {
-      locateContextTree(contexts, pos) match {
-        case Some(x) =>
-          recent(0) = x
-          locateNearestContextTree(x.children, pos, recent)
-        case None => recent(0) match {
-            case null => None
-            case x => Some(x)
-          }
+    @tailrec
+    def locateFinestContextTree(context: ContextTree): ContextTree = {
+      if (context.pos includes pos) {
+        locateContextTree(context.children, pos) match {
+          case Some(x) =>
+            locateFinestContextTree(x)
+          case None =>
+            context
+        }
+      } else {
+        context
       }
     }
-    locateNearestContextTree(contexts, pos, new Array[ContextTree](1)) map (_.context)
+    locateContextTree(contexts, pos) map locateFinestContextTree map (_.context)
   }
 
+  /** Returns the ContextTree containing `pos`, or the ContextTree positioned just before `pos`,
+   *  or None if `pos` is located before all ContextTrees.
+   */ 
   def locateContextTree(contexts: Contexts, pos: Position): Option[ContextTree] = {
     if (contexts.isEmpty) None
     else {
-      val hi = contexts.length - 1
-      if ((contexts(hi).pos properlyPrecedes pos) || (pos properlyPrecedes contexts(0).pos)) None
-      else {
-        def loop(lo: Int, hi: Int): Option[ContextTree] = {
+      @tailrec
+      def loop(lo: Int, hi: Int, previousSibling: Option[ContextTree]): Option[ContextTree] = {
+        if (pos properlyPrecedes contexts(lo).pos)
+          previousSibling
+        else if (contexts(hi).pos properlyPrecedes pos)
+          Some(contexts(hi))
+        else {
           val mid = (lo + hi) / 2
           val midpos = contexts(mid).pos
-          if ((pos precedes midpos) && (mid < hi))
-            loop(lo, mid)
-          else if ((midpos precedes pos) && (lo < mid))
-            loop(mid, hi)
-          else if (midpos includes pos)
+          if (midpos includes pos)
             Some(contexts(mid))
-          else if (contexts(mid+1).pos includes pos)
-            Some(contexts(mid+1))
-          else None
+          else if (midpos properlyPrecedes pos)
+            loop(mid + 1, hi, Some(contexts(mid)))
+          else
+            loop(lo, mid, previousSibling)
         }
-        loop(0, hi)
       }
+      loop(0, contexts.length - 1, None)
     }
   }
 

--- a/src/interactive/scala/tools/nsc/interactive/tests/InteractiveTest.scala
+++ b/src/interactive/scala/tools/nsc/interactive/tests/InteractiveTest.scala
@@ -61,7 +61,7 @@ abstract class InteractiveTest
    *  Override this member if you need to change the default set of executed test actions.
    */
   protected lazy val testActions: ListBuffer[PresentationCompilerTestDef] = {
-    ListBuffer(new CompletionAction(compiler), new TypeAction(compiler), new HyperlinkAction(compiler))
+    ListBuffer(new TypeCompletionAction(compiler), new ScopeCompletionAction(compiler), new TypeAction(compiler), new HyperlinkAction(compiler))
   }
 
   /** Add new presentation compiler actions to test. Presentation compiler's test

--- a/src/interactive/scala/tools/nsc/interactive/tests/core/AskCommand.scala
+++ b/src/interactive/scala/tools/nsc/interactive/tests/core/AskCommand.scala
@@ -42,7 +42,7 @@ trait AskParse extends AskCommand {
   import compiler.Tree
 
   /** `sources` need to be entirely parsed before running the test
-   *  (else commands such as `AskCompletionAt` may fail simply because
+   *  (else commands such as `AskTypeCompletionAt` may fail simply because
    *  the source's AST is not yet loaded).
    */
   def askParse(sources: Seq[SourceFile]) {
@@ -72,14 +72,27 @@ trait AskReload extends AskCommand {
 }
 
 /** Ask the presentation compiler for completion at a given position. */
-trait AskCompletionAt extends AskCommand {
+trait AskTypeCompletionAt extends AskCommand {
   import compiler.Member
 
-  private[tests] def askCompletionAt(pos: Position)(implicit reporter: Reporter): Response[List[Member]] = {
+  private[tests] def askTypeCompletionAt(pos: Position)(implicit reporter: Reporter): Response[List[Member]] = {
     reporter.println("\naskTypeCompletion at " + pos.source.file.name + ((pos.line, pos.column)))
 
     ask {
       compiler.askTypeCompletion(pos, _)
+    }
+  }
+}
+
+/** Ask the presentation compiler for scope completion at a given position. */
+trait AskScopeCompletionAt extends AskCommand {
+  import compiler.Member
+
+  private[tests] def askScopeCompletionAt(pos: Position)(implicit reporter: Reporter): Response[List[Member]] = {
+    reporter.println("\naskScopeCompletion at " + pos.source.file.name + ((pos.line, pos.column)))
+
+    ask {
+      compiler.askScopeCompletion(pos, _)
     }
   }
 }

--- a/src/interactive/scala/tools/nsc/interactive/tests/core/CoreTestDefs.scala
+++ b/src/interactive/scala/tools/nsc/interactive/tests/core/CoreTestDefs.scala
@@ -12,16 +12,16 @@ private[tests] trait CoreTestDefs
 
   /** Ask the presentation compiler for completion at all locations
    * (in all sources) where the defined `marker` is found. */
-  class CompletionAction(override val compiler: Global)
+  class TypeCompletionAction(override val compiler: Global)
     extends PresentationCompilerTestDef
-    with AskCompletionAt {
+    with AskTypeCompletionAt {
 
     override def runTest() {
-      askAllSources(CompletionMarker) { pos =>
-        askCompletionAt(pos)
+      askAllSources(TypeCompletionMarker) { pos =>
+        askTypeCompletionAt(pos)
       } { (pos, members) =>
         withResponseDelimiter {
-          reporter.println("[response] askCompletionAt " + format(pos))
+          reporter.println("[response] askTypeCompletion at " + format(pos))
           // we skip getClass because it changed signature between 1.5 and 1.6, so there is no
           // universal check file that we can provide for this to work
           reporter.println("retrieved %d members".format(members.size))
@@ -29,6 +29,40 @@ private[tests] trait CoreTestDefs
             val filtered = members.filterNot(member => (member.sym.name string_== "getClass") || member.sym.isConstructor)
             reporter println (filtered.map(_.forceInfoString).sorted mkString "\n")
           }
+        }
+      }
+    }
+  }
+
+  /** Ask the presentation compiler for completion at all locations
+   * (in all sources) where the defined `marker` is found. */
+  class ScopeCompletionAction(override val compiler: Global)
+    extends PresentationCompilerTestDef
+    with AskScopeCompletionAt {
+
+    def memberPrinter(member: compiler.Member): String =
+        "[accessible: %5s] ".format(member.accessible) + "`" + (member.sym.toString() + member.tpe.toString()).trim() + "`"
+
+    override def runTest() {
+      askAllSources(ScopeCompletionMarker) { pos =>
+        askScopeCompletionAt(pos)
+      } { (pos, members) =>
+        withResponseDelimiter {
+          reporter.println("[response] askScopeCompletion at " + format(pos))
+          try {
+            // exclude members not from source (don't have position), for more focused and self contained tests.
+            def eligible(sym: compiler.Symbol) = sym.pos != compiler.NoPosition
+            val filtered = members.filter(member => eligible(member.sym))
+            
+            reporter.println("retrieved %d members".format(filtered.size))
+            compiler ask { () =>
+              reporter.println(filtered.map(_.forceInfoString).sorted mkString "\n")
+            }
+          } catch {
+            case t: Throwable =>
+              t.printStackTrace()
+          }
+
         }
       }
     }
@@ -57,7 +91,7 @@ private[tests] trait CoreTestDefs
   class HyperlinkAction(override val compiler: Global)
     extends PresentationCompilerTestDef
     with AskTypeAt
-    with AskCompletionAt {
+    with AskTypeCompletionAt {
 
     override def runTest() {
       askAllSources(HyperlinkMarker) { pos =>

--- a/src/interactive/scala/tools/nsc/interactive/tests/core/TestMarker.scala
+++ b/src/interactive/scala/tools/nsc/interactive/tests/core/TestMarker.scala
@@ -20,7 +20,9 @@ abstract case class TestMarker(marker: String) {
   TestMarker.checkForDuplicate(this)
 }
 
-object CompletionMarker extends TestMarker("/*!*/")
+object TypeCompletionMarker extends TestMarker("/*!*/")
+
+object ScopeCompletionMarker extends TestMarker("/*_*/")
 
 object TypeMarker extends TestMarker("/*?*/")
 

--- a/test/files/presentation/callcc-interpreter.check
+++ b/test/files/presentation/callcc-interpreter.check
@@ -2,7 +2,7 @@ reload: CallccInterpreter.scala
 
 askTypeCompletion at CallccInterpreter.scala(51,38)
 ================================================================================
-[response] askCompletionAt (51,38)
+[response] askTypeCompletion at (51,38)
 retrieved 59 members
 abstract trait Term extends AnyRef
 abstract trait Value extends AnyRef

--- a/test/files/presentation/completion-implicit-chained.check
+++ b/test/files/presentation/completion-implicit-chained.check
@@ -2,7 +2,7 @@ reload: Completions.scala
 
 askTypeCompletion at Completions.scala(11,16)
 ================================================================================
-[response] askCompletionAt (11,16)
+[response] askTypeCompletion at (11,16)
 retrieved 24 members
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit

--- a/test/files/presentation/ide-bug-1000349.check
+++ b/test/files/presentation/ide-bug-1000349.check
@@ -2,7 +2,7 @@ reload: CompletionOnEmptyArgMethod.scala
 
 askTypeCompletion at CompletionOnEmptyArgMethod.scala(2,17)
 ================================================================================
-[response] askCompletionAt (2,17)
+[response] askTypeCompletion at (2,17)
 retrieved 32 members
 def +(other: String): String
 def ->[B](y: B): (Foo, B)

--- a/test/files/presentation/ide-bug-1000475.check
+++ b/test/files/presentation/ide-bug-1000475.check
@@ -2,7 +2,7 @@ reload: Foo.scala
 
 askTypeCompletion at Foo.scala(3,7)
 ================================================================================
-[response] askCompletionAt (3,7)
+[response] askTypeCompletion at (3,7)
 retrieved 31 members
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit
@@ -36,7 +36,7 @@ final def wait(x$1: Long,x$2: Int): Unit
 
 askTypeCompletion at Foo.scala(6,10)
 ================================================================================
-[response] askCompletionAt (6,10)
+[response] askTypeCompletion at (6,10)
 retrieved 31 members
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit
@@ -70,7 +70,7 @@ final def wait(x$1: Long,x$2: Int): Unit
 
 askTypeCompletion at Foo.scala(7,7)
 ================================================================================
-[response] askCompletionAt (7,7)
+[response] askTypeCompletion at (7,7)
 retrieved 31 members
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit

--- a/test/files/presentation/ide-bug-1000531.check
+++ b/test/files/presentation/ide-bug-1000531.check
@@ -2,7 +2,7 @@ reload: CrashOnLoad.scala
 
 askTypeCompletion at CrashOnLoad.scala(6,12)
 ================================================================================
-[response] askCompletionAt (6,12)
+[response] askTypeCompletion at (6,12)
 retrieved 120 members
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit

--- a/test/files/presentation/implicit-member.check
+++ b/test/files/presentation/implicit-member.check
@@ -2,7 +2,7 @@ reload: ImplicitMember.scala
 
 askTypeCompletion at ImplicitMember.scala(7,7)
 ================================================================================
-[response] askCompletionAt (7,7)
+[response] askTypeCompletion at (7,7)
 retrieved 34 members
 def +(other: String): String
 def ->[B](y: B): (Implicit.type, B)

--- a/test/files/presentation/ping-pong.check
+++ b/test/files/presentation/ping-pong.check
@@ -2,7 +2,7 @@ reload: PingPong.scala
 
 askTypeCompletion at PingPong.scala(10,23)
 ================================================================================
-[response] askCompletionAt (10,23)
+[response] askTypeCompletion at (10,23)
 retrieved 35 members
 [inaccessible] private[this] val ping: Ping
 [inaccessible] protected[package lang] def clone(): Object
@@ -39,7 +39,7 @@ private[this] val name: String
 
 askTypeCompletion at PingPong.scala(19,20)
 ================================================================================
-[response] askCompletionAt (19,20)
+[response] askTypeCompletion at (19,20)
 retrieved 35 members
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit

--- a/test/files/presentation/scope-completion-1.check
+++ b/test/files/presentation/scope-completion-1.check
@@ -1,0 +1,19 @@
+reload: Completions.scala
+
+askScopeCompletion at Completions.scala(6,2)
+================================================================================
+[response] askScopeCompletion at (6,2)
+retrieved 3 members
+class Completion1 extends AnyRef
+def <init>(): test.Completion1
+object Completion2
+================================================================================
+
+askScopeCompletion at Completions.scala(10,2)
+================================================================================
+[response] askScopeCompletion at (10,2)
+retrieved 3 members
+class Completion1 extends AnyRef
+def <init>(): test.Completion2.type
+object Completion2
+================================================================================

--- a/test/files/presentation/scope-completion-1/Test.scala
+++ b/test/files/presentation/scope-completion-1/Test.scala
@@ -1,0 +1,3 @@
+import scala.tools.nsc.interactive.tests.InteractiveTest
+
+object Test extends InteractiveTest

--- a/test/files/presentation/scope-completion-1/src/Completions.scala
+++ b/test/files/presentation/scope-completion-1/src/Completions.scala
@@ -1,0 +1,12 @@
+package test
+
+/* completion on empty class and object */
+
+class Completion1 {
+  /*_*/
+}
+
+object Completion2 {
+  /*_*/
+}
+

--- a/test/files/presentation/scope-completion-2.check
+++ b/test/files/presentation/scope-completion-2.check
@@ -1,0 +1,35 @@
+reload: Completions.scala
+
+askScopeCompletion at Completions.scala(16,4)
+================================================================================
+[response] askScopeCompletion at (16,4)
+retrieved 11 members
+class Completion1 extends AnyRef
+def <init>(): test.Completion1
+def test: Unit
+object Completion1
+private class Cc1 extends AnyRef
+private class Co1 extends AnyRef
+private def fc1: Int
+private def fo1: Int
+private[this] val c: test.Completion1
+private[this] val vc1: Int
+private[this] val vo1: Int
+================================================================================
+
+askScopeCompletion at Completions.scala(32,4)
+================================================================================
+[response] askScopeCompletion at (32,4)
+retrieved 11 members
+[inaccessible] private[this] val vc1: Int
+class Completion1 extends AnyRef
+def <init>(): test.Completion1.type
+def test: Unit
+object Completion1
+private class Cc1 extends AnyRef
+private class Co1 extends AnyRef
+private def fc1: Int
+private def fo1: Int
+private[this] val c: test.Completion1
+private[this] val vo1: Int
+================================================================================

--- a/test/files/presentation/scope-completion-2/Test.scala
+++ b/test/files/presentation/scope-completion-2/Test.scala
@@ -1,0 +1,3 @@
+import scala.tools.nsc.interactive.tests.InteractiveTest
+
+object Test extends InteractiveTest

--- a/test/files/presentation/scope-completion-2/src/Completions.scala
+++ b/test/files/presentation/scope-completion-2/src/Completions.scala
@@ -1,0 +1,35 @@
+package test
+
+/* private elements are visible in the companion class/object */
+
+class Completion1 {
+
+  import Completion1._
+
+  private val vc1 = 0
+  private def fc1 = 0
+
+  private class Cc1
+
+  def test {
+    // needs to be done in a method, because of SI-7280
+    /*_*/
+  }
+}
+
+object Completion1 {
+
+  val c = new Completion1()
+  import c._
+
+  private val vo1 = 0
+  private def fo1 = 0
+
+  private class Co1
+
+  def test {
+    // needs to be done in a method, because of SI-7280
+    /*_*/
+  }
+}
+

--- a/test/files/presentation/scope-completion-3.check
+++ b/test/files/presentation/scope-completion-3.check
@@ -1,0 +1,111 @@
+reload: Completions.scala
+
+askScopeCompletion at Completions.scala(75,2)
+================================================================================
+[response] askScopeCompletion at (75,2)
+retrieved 49 members
+[inaccessible] private class Cb2 extends AnyRef
+[inaccessible] private class Ct2 extends AnyRef
+[inaccessible] private def fb2: Int
+[inaccessible] private def ft2: Int
+[inaccessible] private object Ob2
+[inaccessible] private object Ot2
+[inaccessible] private type tb2 = Completion1.this.tb2
+[inaccessible] private type tt2 = Completion1.this.tt2
+[inaccessible] private[this] val vb1: Int
+[inaccessible] private[this] val vb2: Int
+[inaccessible] private[this] val vt1: Int
+[inaccessible] private[this] val vt2: Int
+[inaccessible] private[this] var rb1: Int
+[inaccessible] private[this] var rb2: Int
+[inaccessible] private[this] var rt1: Int
+[inaccessible] private[this] var rt2: Int
+abstract class Base1 extends AnyRef
+abstract trait Trait1 extends AnyRef
+class Cb1 extends AnyRef
+class Cc1 extends AnyRef
+class Completion1 extends Base1 with Trait1
+class Ct1 extends AnyRef
+def <init>(): test.Completion1
+def fb1: Int
+def fc1: Int
+def ft1: Int
+object Completion2
+object Ob1
+object Oc1
+object Ot1
+override def fb3: Int
+override def ft3: Int
+override type tb3 = Completion1.this.tb3
+override type tt3 = Completion1.this.tt3
+private class Cc2 extends AnyRef
+private def fc2: Int
+private object Oc2
+private type tc2 = Completion1.this.tc2
+private[this] val vb3: Int
+private[this] val vc1: Int
+private[this] val vc2: Int
+private[this] val vt3: Int
+private[this] var rb3: Int
+private[this] var rc1: Int
+private[this] var rc2: Int
+private[this] var rt3: Int
+type tb1 = Completion1.this.tb1
+type tc1 = Completion1.this.tc1
+type tt1 = Completion1.this.tt1
+================================================================================
+
+askScopeCompletion at Completions.scala(104,2)
+================================================================================
+[response] askScopeCompletion at (104,2)
+retrieved 49 members
+[inaccessible] private class Cb2 extends AnyRef
+[inaccessible] private class Ct2 extends AnyRef
+[inaccessible] private def fb2: Int
+[inaccessible] private def ft2: Int
+[inaccessible] private object Ob2
+[inaccessible] private object Ot2
+[inaccessible] private type tb2 = test.Completion2.tb2
+[inaccessible] private type tt2 = test.Completion2.tt2
+[inaccessible] private[this] val vb1: Int
+[inaccessible] private[this] val vb2: Int
+[inaccessible] private[this] val vt1: Int
+[inaccessible] private[this] val vt2: Int
+[inaccessible] private[this] var rb1: Int
+[inaccessible] private[this] var rb2: Int
+[inaccessible] private[this] var rt1: Int
+[inaccessible] private[this] var rt2: Int
+abstract class Base1 extends AnyRef
+abstract trait Trait1 extends AnyRef
+class Cb1 extends AnyRef
+class Co1 extends AnyRef
+class Completion1 extends Base1 with Trait1
+class Ct1 extends AnyRef
+def <init>(): test.Completion2.type
+def fb1: Int
+def fo1: Int
+def ft1: Int
+object Completion2
+object Ob1
+object Oo1
+object Ot1
+override def fb3: Int
+override def ft3: Int
+override type tb3 = test.Completion2.tb3
+override type tt3 = test.Completion2.tt3
+private class Co2 extends AnyRef
+private def fo2: Int
+private object Oo2
+private type to2 = test.Completion2.to2
+private[this] val vb3: Int
+private[this] val vo1: Int
+private[this] val vo2: Int
+private[this] val vt3: Int
+private[this] var rb3: Int
+private[this] var ro1: Int
+private[this] var ro2: Int
+private[this] var rt3: Int
+type tb1 = test.Completion2.tb1
+type to1 = test.Completion2.to1
+type tt1 = test.Completion2.tt1
+================================================================================

--- a/test/files/presentation/scope-completion-3/Test.scala
+++ b/test/files/presentation/scope-completion-3/Test.scala
@@ -1,0 +1,3 @@
+import scala.tools.nsc.interactive.tests.InteractiveTest
+
+object Test extends InteractiveTest

--- a/test/files/presentation/scope-completion-3/src/Completions.scala
+++ b/test/files/presentation/scope-completion-3/src/Completions.scala
@@ -1,0 +1,106 @@
+package test
+
+/* check availability of members defined locally and in hierachy */
+
+abstract class Base1 {
+
+  type tb1 = Int
+  val vb1 = 0
+  var rb1 = 0 
+  def fb1 = 0
+  class Cb1
+  object Ob1
+
+  private type tb2 = Int
+  private val vb2 = 0
+  private var rb2 = 0
+  private def fb2 = 0
+  private class Cb2
+  private object Ob2
+
+  type tb3
+  val vb3: Int
+  var rb3: Int
+  def fb3: Int
+}
+
+trait Trait1 {
+
+  type tt1 = Int
+  val vt1 = 0
+  var rt1 = 0
+  def ft1 = 0
+  class Ct1
+  object Ot1
+
+  private type tt2 = Int
+  private val vt2 = 0
+  private var rt2 = 0
+  private def ft2 = 0
+  private class Ct2
+  private object Ot2
+
+  type tt3
+  val vt3: Int
+  var rt3: Int
+  def ft3: Int
+}
+
+class Completion1 extends Base1 with Trait1 {
+
+  type tc1 = Int
+  val vc1 = 0
+  var rc1 = 0
+  def fc1 = 0
+  class Cc1
+  object Oc1
+
+  private type tc2 = Int
+  private val vc2 = 0
+  private var rc2 = 0
+  private def fc2 = 0
+  private class Cc2
+  private object Oc2
+
+  override type tb3 = Int
+  override val vb3 = 12
+  override var rb3 = 12
+  override def fb3 = 12
+  
+  override type tt3 = Int
+  override val vt3 = 12
+  override var rt3 = 12
+  override def ft3 = 12
+
+  /*_*/
+}
+
+object Completion2 extends Base1 with Trait1 {
+
+  type to1 = Int
+  val vo1 = 0
+  var ro1 = 0
+  def fo1 = 0
+  class Co1
+  object Oo1
+
+  private type to2 = Int
+  private val vo2 = 0
+  private var ro2 = 0
+  private def fo2 = 0
+  private class Co2
+  private object Oo2
+
+  override type tb3 = Int
+  override val vb3 = 12
+  override var rb3 = 12
+  override def fb3 = 12
+  
+  override type tt3 = Int
+  override val vt3 = 12
+  override var rt3 = 12
+  override def ft3 = 12
+  
+  /*_*/
+}
+

--- a/test/files/presentation/scope-completion-4.check
+++ b/test/files/presentation/scope-completion-4.check
@@ -1,0 +1,293 @@
+reload: Completions.scala
+
+askScopeCompletion at Completions.scala(12,8)
+================================================================================
+[response] askScopeCompletion at (12,8)
+retrieved 8 members
+class Completion1 extends AnyRef
+class c extends AnyRef
+class fc extends AnyRef
+class ffc extends AnyRef
+def <init>(): test.Completion1
+def f: Unit
+def ff: Unit
+def fff: Unit
+================================================================================
+
+askScopeCompletion at Completions.scala(15,6)
+================================================================================
+[response] askScopeCompletion at (15,6)
+retrieved 8 members
+class Completion1 extends AnyRef
+class c extends AnyRef
+class fc extends AnyRef
+class ffc extends AnyRef
+def <init>(): test.Completion1
+def f: Unit
+def ff: Unit
+def fff: Unit
+================================================================================
+
+askScopeCompletion at Completions.scala(18,8)
+================================================================================
+[response] askScopeCompletion at (18,8)
+retrieved 8 members
+class Completion1 extends AnyRef
+class c extends AnyRef
+class fc extends AnyRef
+class ffc extends AnyRef
+def <init>(): ffc
+def f: Unit
+def ff: Unit
+def fff: Unit
+================================================================================
+
+askScopeCompletion at Completions.scala(21,6)
+================================================================================
+[response] askScopeCompletion at (21,6)
+retrieved 8 members
+class Completion1 extends AnyRef
+class c extends AnyRef
+class fc extends AnyRef
+class ffc extends AnyRef
+def <init>(): test.Completion1
+def f: Unit
+def ff: Unit
+def fff: Unit
+================================================================================
+
+askScopeCompletion at Completions.scala(24,4)
+================================================================================
+[response] askScopeCompletion at (24,4)
+retrieved 6 members
+class Completion1 extends AnyRef
+class c extends AnyRef
+class fc extends AnyRef
+def <init>(): test.Completion1
+def f: Unit
+def ff: Unit
+================================================================================
+
+askScopeCompletion at Completions.scala(29,8)
+================================================================================
+[response] askScopeCompletion at (29,8)
+retrieved 8 members
+class Completion1 extends AnyRef
+class c extends AnyRef
+class fc extends AnyRef
+class fcc extends AnyRef
+def <init>(): fc
+def f: Unit
+def fcf: Unit
+def ff: Unit
+================================================================================
+
+askScopeCompletion at Completions.scala(32,6)
+================================================================================
+[response] askScopeCompletion at (32,6)
+retrieved 8 members
+class Completion1 extends AnyRef
+class c extends AnyRef
+class fc extends AnyRef
+class fcc extends AnyRef
+def <init>(): fc
+def f: Unit
+def fcf: Unit
+def ff: Unit
+================================================================================
+
+askScopeCompletion at Completions.scala(35,8)
+================================================================================
+[response] askScopeCompletion at (35,8)
+retrieved 8 members
+class Completion1 extends AnyRef
+class c extends AnyRef
+class fc extends AnyRef
+class fcc extends AnyRef
+def <init>(): fc.this.fcc
+def f: Unit
+def fcf: Unit
+def ff: Unit
+================================================================================
+
+askScopeCompletion at Completions.scala(38,6)
+================================================================================
+[response] askScopeCompletion at (38,6)
+retrieved 8 members
+class Completion1 extends AnyRef
+class c extends AnyRef
+class fc extends AnyRef
+class fcc extends AnyRef
+def <init>(): fc
+def f: Unit
+def fcf: Unit
+def ff: Unit
+================================================================================
+
+askScopeCompletion at Completions.scala(41,4)
+================================================================================
+[response] askScopeCompletion at (41,4)
+retrieved 6 members
+class Completion1 extends AnyRef
+class c extends AnyRef
+class fc extends AnyRef
+def <init>(): test.Completion1
+def f: Unit
+def ff: Unit
+================================================================================
+
+askScopeCompletion at Completions.scala(44,2)
+================================================================================
+[response] askScopeCompletion at (44,2)
+retrieved 4 members
+class Completion1 extends AnyRef
+class c extends AnyRef
+def <init>(): test.Completion1
+def f: Unit
+================================================================================
+
+askScopeCompletion at Completions.scala(51,8)
+================================================================================
+[response] askScopeCompletion at (51,8)
+retrieved 8 members
+class Completion1 extends AnyRef
+class c extends AnyRef
+class cc extends AnyRef
+class ccc extends AnyRef
+def <init>(): cc.this.ccc
+def ccf: Unit
+def cf: Unit
+def f: Unit
+================================================================================
+
+askScopeCompletion at Completions.scala(54,6)
+================================================================================
+[response] askScopeCompletion at (54,6)
+retrieved 8 members
+class Completion1 extends AnyRef
+class c extends AnyRef
+class cc extends AnyRef
+class ccc extends AnyRef
+def <init>(): c.this.cc
+def ccf: Unit
+def cf: Unit
+def f: Unit
+================================================================================
+
+askScopeCompletion at Completions.scala(57,8)
+================================================================================
+[response] askScopeCompletion at (57,8)
+retrieved 8 members
+class Completion1 extends AnyRef
+class c extends AnyRef
+class cc extends AnyRef
+class ccc extends AnyRef
+def <init>(): c.this.cc
+def ccf: Unit
+def cf: Unit
+def f: Unit
+================================================================================
+
+askScopeCompletion at Completions.scala(60,6)
+================================================================================
+[response] askScopeCompletion at (60,6)
+retrieved 8 members
+class Completion1 extends AnyRef
+class c extends AnyRef
+class cc extends AnyRef
+class ccc extends AnyRef
+def <init>(): c.this.cc
+def ccf: Unit
+def cf: Unit
+def f: Unit
+================================================================================
+
+askScopeCompletion at Completions.scala(63,4)
+================================================================================
+[response] askScopeCompletion at (63,4)
+retrieved 6 members
+class Completion1 extends AnyRef
+class c extends AnyRef
+class cc extends AnyRef
+def <init>(): Completion1.this.c
+def cf: Unit
+def f: Unit
+================================================================================
+
+askScopeCompletion at Completions.scala(68,8)
+================================================================================
+[response] askScopeCompletion at (68,8)
+retrieved 8 members
+class Completion1 extends AnyRef
+class c extends AnyRef
+class cc extends AnyRef
+class cfc extends AnyRef
+def <init>(): cfc
+def cf: Unit
+def cff: Unit
+def f: Unit
+================================================================================
+
+askScopeCompletion at Completions.scala(71,6)
+================================================================================
+[response] askScopeCompletion at (71,6)
+retrieved 8 members
+class Completion1 extends AnyRef
+class c extends AnyRef
+class cc extends AnyRef
+class cfc extends AnyRef
+def <init>(): Completion1.this.c
+def cf: Unit
+def cff: Unit
+def f: Unit
+================================================================================
+
+askScopeCompletion at Completions.scala(74,8)
+================================================================================
+[response] askScopeCompletion at (74,8)
+retrieved 8 members
+class Completion1 extends AnyRef
+class c extends AnyRef
+class cc extends AnyRef
+class cfc extends AnyRef
+def <init>(): Completion1.this.c
+def cf: Unit
+def cff: Unit
+def f: Unit
+================================================================================
+
+askScopeCompletion at Completions.scala(77,6)
+================================================================================
+[response] askScopeCompletion at (77,6)
+retrieved 8 members
+class Completion1 extends AnyRef
+class c extends AnyRef
+class cc extends AnyRef
+class cfc extends AnyRef
+def <init>(): Completion1.this.c
+def cf: Unit
+def cff: Unit
+def f: Unit
+================================================================================
+
+askScopeCompletion at Completions.scala(80,4)
+================================================================================
+[response] askScopeCompletion at (80,4)
+retrieved 6 members
+class Completion1 extends AnyRef
+class c extends AnyRef
+class cc extends AnyRef
+def <init>(): Completion1.this.c
+def cf: Unit
+def f: Unit
+================================================================================
+
+askScopeCompletion at Completions.scala(83,2)
+================================================================================
+[response] askScopeCompletion at (83,2)
+retrieved 4 members
+class Completion1 extends AnyRef
+class c extends AnyRef
+def <init>(): test.Completion1
+def f: Unit
+================================================================================

--- a/test/files/presentation/scope-completion-4/Test.scala
+++ b/test/files/presentation/scope-completion-4/Test.scala
@@ -1,0 +1,3 @@
+import scala.tools.nsc.interactive.tests.InteractiveTest
+
+object Test extends InteractiveTest

--- a/test/files/presentation/scope-completion-4/src/Completions.scala
+++ b/test/files/presentation/scope-completion-4/src/Completions.scala
@@ -1,0 +1,84 @@
+package test
+
+/* check that members defined in sub-block are not visible*/
+
+class Completion1 {
+
+  def f {
+    
+    def ff {
+      
+      def fff {
+        /*_*/
+      }
+      
+      /*_*/
+      
+      class ffc {
+        /*_*/
+      }
+      
+      /*_*/
+    }
+    
+    /*_*/
+    
+    class fc {
+      
+      def fcf {
+        /*_*/
+      } 
+      
+      /*_*/
+      
+      class fcc {
+        /*_*/
+      }
+      
+      /*_*/
+    }
+    
+    /*_*/
+  }
+  
+  /*_*/
+  
+  class c {
+    
+    class cc {
+      
+      class ccc {
+        /*_*/
+      }
+      
+      /*_*/
+      
+      def ccf {
+        /*_*/
+      }
+
+      /*_*/
+    }
+    
+    /*_*/
+    
+    def cf {
+      
+      class cfc {
+        /*_*/
+      }
+      
+      /*_*/
+      
+      def cff {
+        /*_*/
+      }
+      
+      /*_*/
+    }
+    
+    /*_*/
+  }
+
+  /*_*/
+}

--- a/test/files/presentation/scope-completion-import.check
+++ b/test/files/presentation/scope-completion-import.check
@@ -1,0 +1,141 @@
+reload: Completions.scala
+
+askScopeCompletion at Completions.scala(15,4)
+================================================================================
+[response] askScopeCompletion at (15,4)
+retrieved 10 members
+class C extends AnyRef
+class Foo extends AnyRef
+class Foo_1 extends AnyRef
+class Foo_2 extends AnyRef
+class Foo_3 extends AnyRef
+def <init>(): test.Foo
+def fCCC: Int
+def fOOO: Int
+object O
+val o: test.O.type
+================================================================================
+
+askScopeCompletion at Completions.scala(19,4)
+================================================================================
+[response] askScopeCompletion at (19,4)
+retrieved 9 members
+class C extends AnyRef
+class Foo extends AnyRef
+class Foo_1 extends AnyRef
+class Foo_2 extends AnyRef
+class Foo_3 extends AnyRef
+def <init>(): test.Foo
+def fCCC: Int
+def fOOO: Int
+object O
+================================================================================
+
+askScopeCompletion at Completions.scala(24,4)
+================================================================================
+[response] askScopeCompletion at (24,4)
+retrieved 9 members
+class C extends AnyRef
+class Foo extends AnyRef
+class Foo_1 extends AnyRef
+class Foo_2 extends AnyRef
+class Foo_3 extends AnyRef
+def <init>(): test.Foo
+def fCCC: Int
+object O
+val c: test.C
+================================================================================
+
+askScopeCompletion at Completions.scala(27,5)
+================================================================================
+[response] askScopeCompletion at (27,5)
+retrieved 8 members
+class C extends AnyRef
+class Foo extends AnyRef
+class Foo_1 extends AnyRef
+class Foo_2 extends AnyRef
+class Foo_3 extends AnyRef
+def <init>(): test.Foo
+object O
+val c: test.C
+================================================================================
+
+askScopeCompletion at Completions.scala(30,5)
+================================================================================
+[response] askScopeCompletion at (30,5)
+retrieved 9 members
+class C extends AnyRef
+class Foo extends AnyRef
+class Foo_1 extends AnyRef
+class Foo_2 extends AnyRef
+class Foo_3 extends AnyRef
+def <init>(): test.Foo
+def fCCC: Int
+object O
+val c: test.C
+================================================================================
+
+askScopeCompletion at Completions.scala(32,5)
+================================================================================
+[response] askScopeCompletion at (32,5)
+retrieved 10 members
+class C extends AnyRef
+class Foo extends AnyRef
+class Foo_1 extends AnyRef
+class Foo_2 extends AnyRef
+class Foo_3 extends AnyRef
+def <init>(): test.Foo
+def fCCC: Int
+def fOOO: Int
+object O
+val c: test.C
+================================================================================
+
+askScopeCompletion at Completions.scala(41,4)
+================================================================================
+[response] askScopeCompletion at (41,4)
+retrieved 10 members
+class C extends AnyRef
+class Foo extends AnyRef
+class Foo_1 extends AnyRef
+class Foo_2 extends AnyRef
+class Foo_3 extends AnyRef
+def <init>(): test.Foo_1
+def bar: Unit
+def fCCC: Int
+def fOOO: Int
+object O
+================================================================================
+
+askScopeCompletion at Completions.scala(51,4)
+================================================================================
+[response] askScopeCompletion at (51,4)
+retrieved 11 members
+class C extends AnyRef
+class Foo extends AnyRef
+class Foo_1 extends AnyRef
+class Foo_2 extends AnyRef
+class Foo_3 extends AnyRef
+def <init>(): test.Foo_2
+def bar: Unit
+def fCCC: Int
+def fOOO: Int
+object O
+private[this] val o: test.O.type
+================================================================================
+
+askScopeCompletion at Completions.scala(61,4)
+================================================================================
+[response] askScopeCompletion at (61,4)
+retrieved 10 members
+class C extends AnyRef
+class Foo extends AnyRef
+class Foo_1 extends AnyRef
+class Foo_2 extends AnyRef
+class Foo_3 extends AnyRef
+def <init>(): test.Foo_3
+def bar: Unit
+def fCCC: Int
+object O
+private[this] val c: test.C
+================================================================================

--- a/test/files/presentation/scope-completion-import/Test.scala
+++ b/test/files/presentation/scope-completion-import/Test.scala
@@ -1,0 +1,3 @@
+import scala.tools.nsc.interactive.tests.InteractiveTest
+
+object Test extends InteractiveTest

--- a/test/files/presentation/scope-completion-import/src/Completions.scala
+++ b/test/files/presentation/scope-completion-import/src/Completions.scala
@@ -1,0 +1,64 @@
+package test
+
+class C {
+  def fCCC : Int = 0
+}
+
+object O extends C {
+  def fOOO : Int = 0
+}
+
+class Foo {
+  {
+    val o = O
+    import o._
+    /*_*/
+  }
+  {
+    import O._
+    /*_*/
+  }
+  {
+    val c = new C
+    import c._
+    /*_*/
+  }
+  {
+    f/*_*/
+    val c = new C
+    import c._
+    f/*_*/
+    import O._
+    f/*_*/
+  }
+}
+
+class Foo_1 {
+
+  import O._
+
+  def bar {
+    /*_*/
+  }
+}
+
+class Foo_2 {
+
+  val o = O
+  import o._
+
+  def bar {
+    /*_*/
+  }
+}
+
+class Foo_3 {
+
+  val c = new C
+  import c._
+
+  def bar {
+    /*_*/
+  }
+}
+

--- a/test/files/presentation/t1207.check
+++ b/test/files/presentation/t1207.check
@@ -2,7 +2,7 @@ reload: Completions.scala
 
 askTypeCompletion at Completions.scala(10,15)
 ================================================================================
-[response] askCompletionAt (10,15)
+[response] askTypeCompletion at (10,15)
 retrieved 3 members
 final package bongo
 final package lang
@@ -11,7 +11,7 @@ final package util
 
 askTypeCompletion at Completions.scala(11,16)
 ================================================================================
-[response] askCompletionAt (11,16)
+[response] askTypeCompletion at (11,16)
 retrieved 3 members
 final package bongo
 final package lang
@@ -20,7 +20,7 @@ final package util
 
 askTypeCompletion at Completions.scala(12,19)
 ================================================================================
-[response] askCompletionAt (12,19)
+[response] askTypeCompletion at (12,19)
 retrieved 3 members
 final package bongo
 final package lang
@@ -29,7 +29,7 @@ final package util
 
 askTypeCompletion at Completions.scala(13,19)
 ================================================================================
-[response] askCompletionAt (13,19)
+[response] askTypeCompletion at (13,19)
 retrieved 3 members
 final package bongo
 final package lang
@@ -38,7 +38,7 @@ final package util
 
 askTypeCompletion at Completions.scala(14,23)
 ================================================================================
-[response] askCompletionAt (14,23)
+[response] askTypeCompletion at (14,23)
 retrieved 3 members
 final package bongo
 final package lang
@@ -47,7 +47,7 @@ final package util
 
 askTypeCompletion at Completions.scala(15,10)
 ================================================================================
-[response] askCompletionAt (15,10)
+[response] askTypeCompletion at (15,10)
 retrieved 0 members
 
 ================================================================================

--- a/test/files/presentation/t5708.check
+++ b/test/files/presentation/t5708.check
@@ -2,7 +2,7 @@ reload: Completions.scala
 
 askTypeCompletion at Completions.scala(17,9)
 ================================================================================
-[response] askCompletionAt (17,9)
+[response] askTypeCompletion at (17,9)
 retrieved 39 members
 [inaccessible] private def privateM: String
 [inaccessible] private[this] val privateV: String

--- a/test/files/presentation/visibility.check
+++ b/test/files/presentation/visibility.check
@@ -2,7 +2,7 @@ reload: Completions.scala
 
 askTypeCompletion at Completions.scala(14,12)
 ================================================================================
-[response] askCompletionAt (14,12)
+[response] askTypeCompletion at (14,12)
 retrieved 37 members
 [inaccessible] private[this] def secretPrivateThis(): Unit
 def +(other: String): String
@@ -42,7 +42,7 @@ protected[package lang] def finalize(): Unit
 
 askTypeCompletion at Completions.scala(16,11)
 ================================================================================
-[response] askCompletionAt (16,11)
+[response] askTypeCompletion at (16,11)
 retrieved 37 members
 def +(other: String): String
 def ->[B](y: B): (accessibility.Foo, B)
@@ -82,7 +82,7 @@ protected[package lang] def finalize(): Unit
 
 askTypeCompletion at Completions.scala(22,11)
 ================================================================================
-[response] askCompletionAt (22,11)
+[response] askTypeCompletion at (22,11)
 retrieved 37 members
 [inaccessible] private def secretPrivate(): Unit
 def +(other: String): String
@@ -122,7 +122,7 @@ protected[package lang] def finalize(): Unit
 
 askTypeCompletion at Completions.scala(28,10)
 ================================================================================
-[response] askCompletionAt (28,10)
+[response] askTypeCompletion at (28,10)
 retrieved 37 members
 [inaccessible] private def secretPrivate(): Unit
 [inaccessible] private[this] def secretPrivateThis(): Unit
@@ -162,7 +162,7 @@ protected[package accessibility] def secretProtectedInPackage(): Unit
 
 askTypeCompletion at Completions.scala(37,8)
 ================================================================================
-[response] askCompletionAt (37,8)
+[response] askTypeCompletion at (37,8)
 retrieved 37 members
 [inaccessible] private def secretPrivate(): Unit
 [inaccessible] private[this] def secretPrivateThis(): Unit


### PR DESCRIPTION
Scope completion was not returning members provided by import declared in the same block as the given position, if the position was inside an expression which could not be typed successfully, or outside any expression (2 normal use cases when triggering completion in an IDE).

The first commit is a port of retronym/scala@e7ebf3825b4bc63e60ea1e7fcb8c74d509f5a0c6 on the 2.11 code base, to add support to test scope completion in parttest. The second one contains some basic tests for code completion (inheritance, multilevel definition, ...). And the last commit contains the actual fix, with the associated test.

review by @retronym, @odersky
