### PR TITLE
SI-7961 Fix false positive procedure warnings

### DIFF
--- a/test/files/neg/t7605-deprecation.check
+++ b/test/files/neg/t7605-deprecation.check
@@ -1,12 +1,15 @@
-t7605-deprecation.scala:2: warning: Procedure syntax is deprecated. Convert procedure to method by adding `: Unit =`.
-  def this(i: Int) { this() }
-                   ^
-t7605-deprecation.scala:3: warning: Procedure syntax is deprecated. Convert procedure to method by adding `: Unit =`.
+t7605-deprecation.scala:2: warning: Procedure syntax is deprecated. Convert procedure `bar` to method by adding `: Unit =`.
   def bar {}
           ^
-t7605-deprecation.scala:4: warning: Procedure syntax is deprecated. Convert procedure to method by adding `: Unit`.
+t7605-deprecation.scala:3: warning: Procedure syntax is deprecated. Convert procedure `baz` to method by adding `: Unit`.
   def baz
          ^
+t7605-deprecation.scala:4: warning: Procedure syntax is deprecated. Convert procedure `boo` to method by adding `: Unit`.
+  def boo(i: Int, l: Long)
+                          ^
+t7605-deprecation.scala:5: warning: Procedure syntax is deprecated. Convert procedure `boz` to method by adding `: Unit =`.
+  def boz(i: Int, l: Long) {}
+                           ^
 error: No warnings can be incurred under -Xfatal-warnings.
-three warnings found
+four warnings found
 one error found

--- a/test/files/neg/t7605-deprecation.scala
+++ b/test/files/neg/t7605-deprecation.scala
@@ -1,5 +1,8 @@
 abstract class Foo {
-  def this(i: Int) { this() }
   def bar {}
   def baz
+  def boo(i: Int, l: Long)
+  def boz(i: Int, l: Long) {}
+  def this(i: Int) { this() } // Don't complain here!
+  def foz: Unit               // Don't complain here!
 }


### PR DESCRIPTION
Two issues are fixed in this commit:
- `def foo: Unit` was detected as missing a return type
- The warning was emitted for constructors, but
  `def this(...): Unit = ...` is not valid Scala syntax
