### PR TITLE
add `dequeueOption` to immutable.Queue

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -561,6 +561,27 @@ TODO:
     <echo message="canonical suffix: ${version.suffix}" /> -->
     <fail unless="version.suffixes.consistent" message="Version suffixes inconsistent!"/>
 
+
+    <!-- used during releases to bump versions in versions.properties -->
+    <if><isset property="update.versions"/><then>
+      <echo message="Updating `versions.properties`:"/>
+      <echo message="  starr.version                           = ${starr.version}"/>
+      <echo message="  scala.binary.version                    = ${scala.binary.version}"/>
+      <echo message="  partest.version.number                  = ${partest.version.number}"/>
+      <echo message="  scala-xml.version.number                = ${scala-xml.version.number}"/>
+      <echo message="  scala-parser-combinators.version.number = ${scala-parser-combinators.version.number}"/>
+      <echo message="  scalacheck.version.number               = ${scalacheck.version.number}"/>
+
+      <propertyfile file="versions.properties">
+        <entry key="starr.version"                           value="${starr.version}"/>
+        <entry key="scala.binary.version"                    value="${scala.binary.version}"/>
+        <entry key="partest.version.number"                  value="${partest.version.number}"/>
+        <entry key="scala-xml.version.number"                value="${scala-xml.version.number}"/>
+        <entry key="scala-parser-combinators.version.number" value="${scala-parser-combinators.version.number}"/>
+        <entry key="scalacheck.version.number"               value="${scalacheck.version.number}"/>
+      </propertyfile>
+    </then></if>
+
     <path id="forkjoin.classpath" path="${build-libs.dir}/classes/forkjoin"/>
     <path id="asm.classpath"      path="${build-asm.dir}/classes"/>
     <property name="forkjoin-classes" refid="forkjoin.classpath"/>

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
@@ -233,9 +233,6 @@ trait MatchOptimization extends MatchTreeMaking with MatchAnalysis {
       def defaultBody: Tree
       def defaultCase(scrutSym: Symbol = defaultSym, guard: Tree = EmptyTree, body: Tree = defaultBody): CaseDef
 
-      private def sequence[T](xs: List[Option[T]]): Option[List[T]] =
-        if (xs exists (_.isEmpty)) None else Some(xs.flatten)
-
       object GuardAndBodyTreeMakers {
           def unapply(tms: List[TreeMaker]): Option[(Tree, Tree)] = {
             tms match {

--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -109,6 +109,22 @@ trait TypeDiagnostics {
     case x                                    => x.toString
   }
 
+  /**
+   * [a, b, c] => "(a, b, c)"
+   * [a, B]    => "(param1, param2)"
+   * [a, B, c] => "(param1, ..., param2)"
+   */
+  final def exampleTuplePattern(names: List[Name]): String = {
+    val arity = names.length
+    val varPatterNames: Option[List[String]] = sequence(names map {
+      case name if nme.isVariableName(name) => Some(name.decode)
+      case _                                => None
+    })
+    def parenthesize(a: String) = s"($a)"
+    def genericParams = (Seq("param1") ++ (if (arity > 2) Seq("...") else Nil) ++ Seq(s"param$arity"))
+    parenthesize(varPatterNames.getOrElse(genericParams).mkString(", "))
+  }
+
   def alternatives(tree: Tree): List[Type] = tree.tpe match {
     case OverloadedType(pre, alternatives)  => alternatives map pre.memberType
     case _                                  => Nil

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3835,7 +3835,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           // as we don't know which alternative to choose... here we do
           map2Conserve(args, tparams) {
             //@M! the polytype denotes the expected kind
-            (arg, tparam) => typedHigherKindedType(arg, mode, GenPolyType(tparam.typeParams, AnyTpe))
+            (arg, tparam) => typedHigherKindedType(arg, mode, Kind.FromParams(tparam.typeParams))
           }
         } else // @M: there's probably something wrong when args.length != tparams.length... (triggered by bug #320)
          // Martin, I'm using fake trees, because, if you use args or arg.map(typedType),
@@ -4880,20 +4880,17 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           if (sameLength(tparams, args)) {
             // @M: kind-arity checking is done here and in adapt, full kind-checking is in checkKindBounds (in Infer)
             val args1 = map2Conserve(args, tparams) { (arg, tparam) =>
-              //@M! the polytype denotes the expected kind
-              def pt = GenPolyType(tparam.typeParams, AnyTpe)
+              def ptParams = Kind.FromParams(tparam.typeParams)
 
-              // if symbol hasn't been fully loaded, can't check kind-arity
-              // ... except, if we're in a pattern, where we can and must (SI-8023)
-              if (mode.typingPatternOrTypePat) {
-                tparam.initialize
-                typedHigherKindedType(arg, mode, pt)
+              // if symbol hasn't been fully loaded, can't check kind-arity except when we're in a pattern,
+              // where we can (we can't take part in F-Bounds) and must (SI-8023)
+              val pt = if (mode.typingPatternOrTypePat) {
+                tparam.initialize; ptParams
               }
-              else if (isComplete)
-                typedHigherKindedType(arg, mode, pt)
-              else
-                // This overload (without pt) allows type constructors, as we don't don't know the allowed kind.
-                typedHigherKindedType(arg, mode)
+              else if (isComplete) ptParams
+              else Kind.Wildcard
+
+              typedHigherKindedType(arg, mode, pt)
             }
             val argtypes = args1 map (_.tpe)
 
@@ -5080,8 +5077,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
         // @M maybe the well-kindedness check should be done when checking the type arguments conform to the type parameters' bounds?
         val args1 = if (sameLength(args, tparams)) map2Conserve(args, tparams) {
-          //@M! the polytype denotes the expected kind
-          (arg, tparam) => typedHigherKindedType(arg, mode, GenPolyType(tparam.typeParams, AnyTpe))
+          (arg, tparam) => typedHigherKindedType(arg, mode, Kind.FromParams(tparam.typeParams))
         }
         else {
           //@M  this branch is correctly hit for an overloaded polymorphic type. It also has to handle erroneous cases.
@@ -5451,9 +5447,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     /** Types a (fully parameterized) type tree */
     def typedType(tree: Tree): Tree = typedType(tree, NOmode)
 
-    /** Types a higher-kinded type tree -- pt denotes the expected kind*/
+    /** Types a higher-kinded type tree -- pt denotes the expected kind and must be one of `Kind.WildCard` and `Kind.FromParams` */
     def typedHigherKindedType(tree: Tree, mode: Mode, pt: Type): Tree =
-      if (pt.typeParams.isEmpty) typedType(tree, mode) // kind is known and it's *
+      if (pt != Kind.Wildcard && pt.typeParams.isEmpty) typedType(tree, mode) // kind is known and it's *
       else context withinTypeConstructorAllowed typed(tree, NOmode, pt)
 
     def typedHigherKindedType(tree: Tree, mode: Mode): Tree =

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2906,6 +2906,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       else if (argpts.lengthCompare(numVparams) != 0)
         WrongNumberOfParametersError(fun, argpts)
       else {
+        var issuedMissingParameterTypeError = false
         foreach2(fun.vparams, argpts) { (vparam, argpt) =>
           if (vparam.tpt.isEmpty) {
             vparam.tpt.tpe =
@@ -2923,7 +2924,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                     }
                   case _ =>
                 }
-                MissingParameterTypeError(fun, vparam, pt)
+                MissingParameterTypeError(fun, vparam, pt, withTupleAddendum = !issuedMissingParameterTypeError)
+                issuedMissingParameterTypeError = true
                 ErrorType
               }
             if (!vparam.tpt.pos.isDefined) vparam.tpt setPos vparam.pos.focus

--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -118,6 +118,13 @@ class Queue[+A] protected(protected val in: List[A], protected val out: List[A])
     case x :: xs            => (x, new Queue(in, xs))
     case _                  => throw new NoSuchElementException("dequeue on empty queue")
   }
+  
+  /** Optionally retrieves the first element and a queue of the remaining elements.
+   *
+   * @return A tuple of the first element of the queue, and a new queue with this element removed.
+   *         If the queue is empty, `None` is returned.
+   */
+  def dequeueOption: Option[(A, Queue[A])] = if(isEmpty) None else Some(dequeue)
 
   /** Returns the first element in the queue, or throws an error if there
    *  is no element contained in the queue.

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -227,7 +227,7 @@ override def companion: GenericCompanion[Vector] = Vector
             val ri = this.reverseIterator
             while (ri.hasNext) v = ri.next +: v
             v.asInstanceOf[That]
-          case _ => super.++(that)
+          case _ => super.++(again)
         }
       }
     }

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -59,7 +59,7 @@ object Vector extends IndexedSeqFactory[Vector] {
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  */
-final class Vector[+A](private[collection] val startIndex: Int, private[collection] val endIndex: Int, focus: Int)
+final class Vector[+A] private[immutable] (private[collection] val startIndex: Int, private[collection] val endIndex: Int, focus: Int)
 extends AbstractSeq[A]
    with IndexedSeq[A]
    with GenericTraversableTemplate[A, Vector]

--- a/src/library/scala/util/matching/Regex.scala
+++ b/src/library/scala/util/matching/Regex.scala
@@ -188,9 +188,9 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *  @param  s     The string to match
    *  @return       The matches
    */
-  def unapplySeq(s: CharSequence): Option[Seq[String]] = {
+  def unapplySeq(s: CharSequence): Option[List[String]] = {
     val m = pattern matcher s
-    if (runMatcher(m)) Some(1 to m.groupCount map m.group)
+    if (runMatcher(m)) Some((1 to m.groupCount).toList map m.group)
     else None
   }
 
@@ -225,10 +225,10 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *  @param  c     The Char to match
    *  @return       The match
    */
-  def unapplySeq(c: Char): Option[Seq[Char]] = {
+  def unapplySeq(c: Char): Option[List[Char]] = {
     val m = pattern matcher c.toString
     if (runMatcher(m)) {
-      if (m.groupCount > 0) Some(m group 1) else Some(Nil)
+      if (m.groupCount > 0) Some((m group 1).toList) else Some(Nil)
     } else None
   }
 
@@ -238,9 +238,9 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *  Otherwise, this Regex is applied to the previously matched input,
    *  and the result of that match is used.
    */
-  def unapplySeq(m: Match): Option[Seq[String]] =
+  def unapplySeq(m: Match): Option[List[String]] =
     if (m.matched == null) None
-    else if (m.matcher.pattern == this.pattern) Some(1 to m.groupCount map m.group)
+    else if (m.matcher.pattern == this.pattern) Some((1 to m.groupCount).toList map m.group)
     else unapplySeq(m.matched)
 
   /** Tries to match target.

--- a/src/reflect/scala/reflect/internal/Kinds.scala
+++ b/src/reflect/scala/reflect/internal/Kinds.scala
@@ -326,6 +326,8 @@ trait Kinds {
     private[internal] object StringState {
       def empty: StringState = StringState(Seq())
     }
+    def FromParams(tparams: List[Symbol]): Type = GenPolyType(tparams, AnyTpe)
+    def Wildcard: Type                          = WildcardType
   }
   class ProperTypeKind(val bounds: TypeBounds) extends Kind {
     import Kind.StringState

--- a/src/reflect/scala/reflect/internal/util/Collections.scala
+++ b/src/reflect/scala/reflect/internal/util/Collections.scala
@@ -244,6 +244,11 @@ trait Collections {
     true
   }
 
+  final def sequence[A](as: List[Option[A]]): Option[List[A]] = {
+    if (as.exists (_.isEmpty)) None
+    else Some(as.flatten)
+  }
+
   final def transposeSafe[A](ass: List[List[A]]): Option[List[List[A]]] = try {
     Some(ass.transpose)
   } catch {

--- a/test/files/neg/missing-param-type-tuple.check
+++ b/test/files/neg/missing-param-type-tuple.check
@@ -1,0 +1,31 @@
+missing-param-type-tuple.scala:3: error: missing parameter type
+Note: The expected type requires a one-argument function accepting a 2-Tuple.
+      Consider a pattern matching anoynmous function, `{ case (a, b) =>  ... }`
+  val x: ((Int, Int)) => Int = (a, b) => 0
+                                ^
+missing-param-type-tuple.scala:3: error: missing parameter type
+  val x: ((Int, Int)) => Int = (a, b) => 0
+                                   ^
+missing-param-type-tuple.scala:5: error: missing parameter type
+Note: The expected type requires a one-argument function accepting a 3-Tuple.
+      Consider a pattern matching anoynmous function, `{ case (param1, ..., param3) =>  ... }`
+  val y: ((Int, Int, Int)) => Int = (a, b, !!) => 0
+                                     ^
+missing-param-type-tuple.scala:5: error: missing parameter type
+  val y: ((Int, Int, Int)) => Int = (a, b, !!) => 0
+                                        ^
+missing-param-type-tuple.scala:5: error: missing parameter type
+  val y: ((Int, Int, Int)) => Int = (a, b, !!) => 0
+                                           ^
+missing-param-type-tuple.scala:7: error: missing parameter type
+Note: The expected type requires a one-argument function accepting a 3-Tuple.
+      Consider a pattern matching anoynmous function, `{ case (param1, ..., param3) =>  ... }`
+  val z: ((Int, Int, Int)) => Int = (a, NotAVariablePatternName, c) => 0
+                                     ^
+missing-param-type-tuple.scala:7: error: missing parameter type
+  val z: ((Int, Int, Int)) => Int = (a, NotAVariablePatternName, c) => 0
+                                        ^
+missing-param-type-tuple.scala:7: error: missing parameter type
+  val z: ((Int, Int, Int)) => Int = (a, NotAVariablePatternName, c) => 0
+                                                                 ^
+8 errors found

--- a/test/files/neg/missing-param-type-tuple.scala
+++ b/test/files/neg/missing-param-type-tuple.scala
@@ -1,0 +1,8 @@
+class C {
+
+  val x: ((Int, Int)) => Int = (a, b) => 0
+
+  val y: ((Int, Int, Int)) => Int = (a, b, !!) => 0
+
+  val z: ((Int, Int, Int)) => Int = (a, NotAVariablePatternName, c) => 0
+}

--- a/test/files/neg/not-a-legal-formal-parameter-tuple.check
+++ b/test/files/neg/not-a-legal-formal-parameter-tuple.check
@@ -1,0 +1,19 @@
+not-a-legal-formal-parameter-tuple.scala:2: error: not a legal formal parameter.
+Note: Tuples cannot be directly destructured in method or function parameters.
+      Either create a single parameter accepting the Tuple2,
+      or consider a pattern matching anonymous function: `{ case (a, b) => ... }
+  val x: ((Int, Int) => Int) = (((a, b)) => a)
+                                 ^
+not-a-legal-formal-parameter-tuple.scala:3: error: not a legal formal parameter.
+Note: Tuples cannot be directly destructured in method or function parameters.
+      Either create a single parameter accepting the Tuple2,
+      or consider a pattern matching anonymous function: `{ case (param1, param2) => ... }
+  val y: ((Int, Int, Int) => Int) = (((a, !!)) => a)
+                                      ^
+not-a-legal-formal-parameter-tuple.scala:4: error: not a legal formal parameter.
+Note: Tuples cannot be directly destructured in method or function parameters.
+      Either create a single parameter accepting the Tuple3,
+      or consider a pattern matching anonymous function: `{ case (param1, ..., param3) => ... }
+  val z: ((Int, Int, Int) => Int) = (((a, NotAPatternVariableName, c)) => a)
+                                      ^
+three errors found

--- a/test/files/neg/not-a-legal-formal-parameter-tuple.scala
+++ b/test/files/neg/not-a-legal-formal-parameter-tuple.scala
@@ -1,0 +1,5 @@
+class C {
+  val x: ((Int, Int) => Int) = (((a, b)) => a)
+  val y: ((Int, Int, Int) => Int) = (((a, !!)) => a)
+  val z: ((Int, Int, Int) => Int) = (((a, NotAPatternVariableName, c)) => a)
+}

--- a/test/files/pos/t8023.scala
+++ b/test/files/pos/t8023.scala
@@ -1,0 +1,22 @@
+import language._
+
+
+object Test {
+  def foo = (null: Any) match {
+    case a: A[k] =>
+      // error: kinds of the type arguments (k) do not conform to the 
+      // expected kinds of the type parameters (type K) in class B.
+      new B[k]()
+  }
+}
+
+class A[K[L[_]]]
+
+class B[K[M[_]]]
+
+
+object Test2 {
+  def foo = (null: Any) match {
+    case a: A[k] => new B[k]() // this one worked before as the info of `A` was complete
+  }
+}

--- a/test/files/pos/t8023b.scala
+++ b/test/files/pos/t8023b.scala
@@ -1,0 +1,2 @@
+// this fails with naive attempts to fix SI-8023
+trait T[A <: T[A]]

--- a/test/junit/scala/collection/QueueTest.scala
+++ b/test/junit/scala/collection/QueueTest.scala
@@ -1,0 +1,28 @@
+package scala.collection.immutable
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Test
+
+@RunWith(classOf[JUnit4])
+/* Tests for collection.immutable.Queue  */
+class QueueTest {
+  val emptyQueue = Queue.empty[Int]
+  val oneAdded = emptyQueue.enqueue(1)
+  val threeAdded = emptyQueue.enqueue(1 to 3)
+
+  @Test
+  def dequeueOptionOnEmpty() {
+    assert( emptyQueue.dequeueOption == None )
+  }
+
+  @Test
+  def dequeueOptionOneAdded() {
+    assert( oneAdded.dequeueOption == Some((1,emptyQueue)) )
+  }
+
+  @Test
+  def dequeueOptionThreeAdded() {
+    assert( threeAdded.dequeueOption == Some((1,Queue(2 to 3:_*))) )
+  }
+}

--- a/test/junit/scala/collection/VectorTest.scala
+++ b/test/junit/scala/collection/VectorTest.scala
@@ -1,0 +1,51 @@
+package scala.collection.mutable
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Test
+import scala.collection.mutable
+
+@RunWith(classOf[JUnit4])
+/* Test for SI-8014 and ++ in general  */
+class VectorTest {
+  val noVec = Vector.empty[Int]
+  val smallVec = Vector.range(0,3)
+  val bigVec = Vector.range(0,64)
+  val smsm = Vector.tabulate(2 * smallVec.length)(i => (i % smallVec.length))
+  val smbig = Vector.tabulate(smallVec.length + bigVec.length)(i => 
+    if (i < smallVec.length) i else i - smallVec.length
+  )
+  val bigsm = Vector.tabulate(smallVec.length + bigVec.length)(i => 
+    if (i < bigVec.length) i else i - bigVec.length
+  )
+  val bigbig = Vector.tabulate(2 * bigVec.length)(i => (i % bigVec.length))
+
+
+  val vecs = List(noVec, smallVec, bigVec)
+  val ans = List(
+    vecs,
+    List(smallVec, smsm, smbig),
+    List(bigVec, bigsm, bigbig)
+  )
+
+  @Test
+  def vectorCat() {
+    val cats = vecs.map(a => vecs.map(a ++ _))
+    assert( cats == ans )
+  }
+
+  @Test
+  def iteratorCat() {
+    def its = vecs.map(_.toList.toIterator)
+    val cats = vecs.map(a => its.map(a ++ _))
+    println(cats)
+    assert( cats == ans )
+  }
+
+  @Test
+  def arrayCat() {
+    val ars = vecs.map(_.toArray)
+    val cats = vecs.map(a => ars.map(a ++ _))
+    assert( cats == ans )
+  }
+}

--- a/test/junit/scala/util/matching/RegexTest.scala
+++ b/test/junit/scala/util/matching/RegexTest.scala
@@ -1,0 +1,30 @@
+
+package scala.util.matching
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class RegexTest {
+  @Test def t8022CharSequence(): Unit = {
+    val full = """.*: (.)$""".r
+    val text = "   When I use this operator: *"
+    // Testing 2.10.x compatibility of the return types of unapplySeq
+    val x :: Nil = full.unapplySeq(text: Any).get
+    val y :: Nil = full.unapplySeq(text: CharSequence).get
+    assertEquals("*", x)
+    assertEquals("*", y)
+  }
+
+  @Test def t8022Match(): Unit = {
+    val R = """(\d)""".r
+    val matchh = R.findFirstMatchIn("a1").get
+    // Testing 2.10.x compatibility of the return types of unapplySeq
+    val x :: Nil = R.unapplySeq(matchh: Any).get
+    val y :: Nil = R.unapplySeq(matchh).get
+    assertEquals("1", x)
+    assertEquals("1", y)
+  }
+}


### PR DESCRIPTION
Currently it's not possible to use `immutable.Queue` easily in a functional way, since the essential method `deque` throws an exception in a common situation (dequeue on an empty Queue). Of course you can convert the exception into an Option on the user-side, but this is awkward to code, and simply annoying.

This pull-request implements `dequeueOption` in the spirit of `headOption` for `Seq`, yielding `Option[(A,Queue[A])]`, with `None` in case of empty queue. 

A possible different type signature might have been `(Option[A],Queue[A])`, though this appears a bit strange, since `q.dequeueOption._2` would return `q` for the empty case and `q` with first element removed, else. 
