### PR TITLE
SI-7969 REPL -C columnar output

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -933,6 +933,7 @@ TODO:
     <path id="test.junit.compiler.build.path">
       <pathelement location="${test.junit.classes}"/>
       <path refid="quick.compiler.build.path"/>
+      <path refid="quick.repl.build.path"/>
       <path refid="junit.classpath"/>
     </path>
 

--- a/src/repl/scala/tools/nsc/interpreter/ConsoleReaderHelper.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ConsoleReaderHelper.scala
@@ -8,7 +8,7 @@ package interpreter
 
 import jline.console.{ ConsoleReader, CursorBuffer }
 
-trait ConsoleReaderHelper { _: ConsoleReader =>
+trait ConsoleReaderHelper { _: ConsoleReader with Tabulator =>
   def isAcross: Boolean
 
   def terminal    = getTerminal()
@@ -18,7 +18,8 @@ trait ConsoleReaderHelper { _: ConsoleReader =>
   def readOneKey(prompt: String): Int
   def eraseLine(): Unit
 
-  private val marginSize = 3
+  val marginSize = 3
+
   private def morePrompt = "--More--"
   private def emulateMore(): Int = {
     val key = readOneKey(morePrompt)
@@ -42,38 +43,8 @@ trait ConsoleReaderHelper { _: ConsoleReader =>
   override def printColumns(items: JCollection[_ <: CharSequence]): Unit =
     printColumns_(items: List[String])
 
-  private def fits(items: List[String], width: Int): Boolean = (
-    (items map (_.length)).sum + (items.length - 1) * marginSize < width
-  )
   private def printColumns_(items: List[String]): Unit = if (items exists (_ != "")) {
-    if (fits(items, width)) println(items mkString " " * marginSize)
-    else printMultiLineColumns(items)
-  }
-  private def printMultiLineColumns(items: List[String]): Unit = {
-    import SimpleMath._
-    val longest     = (items map (_.length)).max
-    //val shortest   = (items map (_.length)).min
-    val columnWidth = longest + marginSize
-    val maxcols = {
-      if (isPaginationEnabled) 1
-      else if (columnWidth >= width) 1
-      else 1 max (width / columnWidth)   // make sure it doesn't divide to 0
-    }
-    val nrows       = items.size /% maxcols
-    val ncols       = items.size /% nrows
-    val groupSize   = ncols
-    val padded      = items map (s"%-${columnWidth}s" format _)
-    val xwise       = isAcross || ncols > items.length
-    val grouped: Seq[Seq[String]]    =
-      if (xwise) (padded grouped groupSize).toSeq
-      else {
-        val h       = 1 max padded.size /% groupSize
-        val cols    = (padded grouped h).toList
-        for (i <- 0 until h) yield
-          for (j <- 0 until groupSize) yield
-            if (i < cols(j).size) cols(j)(i) else ""
-      }
-
+    val grouped = tabulate(items)
     var linesLeft  = if (isPaginationEnabled()) height - 1 else Int.MaxValue
     grouped foreach { xs =>
       println(xs.mkString)
@@ -84,6 +55,46 @@ trait ConsoleReaderHelper { _: ConsoleReader =>
           return
       }
     }
+  }
+}
+
+trait Tabulator {
+  def isAcross: Boolean
+  def width: Int
+  def marginSize: Int
+
+  private def fits(items: List[String], width: Int): Boolean = (
+    (items map (_.length)).sum + (items.length - 1) * marginSize < width
+  )
+  def tabulate(items: List[String]): Seq[Seq[String]] = {
+    if (fits(items, width)) Seq(Seq(items mkString " " * marginSize))
+    else printMultiLineColumns(items)
+  }
+  private def printMultiLineColumns(items: List[String]): Seq[Seq[String]] = {
+    import SimpleMath._
+    val longest     = (items map (_.length)).max
+    //val shortest   = (items map (_.length)).min
+    val columnWidth = longest + marginSize
+    val maxcols = {
+      if (columnWidth >= width) 1
+      else 1 max (width / columnWidth)   // make sure it doesn't divide to 0
+    }
+    val nrows       = items.size /% maxcols
+    val ncols       = items.size /% nrows
+    val groupSize   = ncols
+    val padded      = items map (s"%-${columnWidth}s" format _)
+    val xwise       = isAcross || ncols > items.length
+    val grouped: Seq[Seq[String]]    =
+      if (groupSize == 1) Seq(items)
+      else if (xwise) (padded grouped groupSize).toSeq
+      else {
+        val h       = 1 max padded.size /% groupSize
+        val cols    = (padded grouped h).toList
+        for (i <- 0 until h) yield
+          for (j <- 0 until groupSize) yield
+            if (i < cols(j).size) cols(j)(i) else ""
+      }
+    grouped
   }
 }
 

--- a/src/repl/scala/tools/nsc/interpreter/ConsoleReaderHelper.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ConsoleReaderHelper.scala
@@ -8,7 +8,9 @@ package interpreter
 
 import jline.console.{ ConsoleReader, CursorBuffer }
 
-trait ConsoleReaderHelper extends ConsoleReader {
+trait ConsoleReaderHelper { _: ConsoleReader =>
+  def isAcross: Boolean
+
   def terminal    = getTerminal()
   def width       = terminal.getWidth()
   def height      = terminal.getHeight()
@@ -38,19 +40,42 @@ trait ConsoleReaderHelper extends ConsoleReader {
   }
 
   override def printColumns(items: JCollection[_ <: CharSequence]): Unit =
-    printColumns(items: List[String])
+    printColumns_(items: List[String])
 
-  def printColumns(items: List[String]): Unit = {
-    if (items forall (_ == ""))
-      return
+  private def fits(items: List[String], width: Int): Boolean = (
+    (items map (_.length)).sum + (items.length - 1) * marginSize < width
+  )
+  private def printColumns_(items: List[String]): Unit = if (items exists (_ != "")) {
+    if (fits(items, width)) println(items mkString " " * marginSize)
+    else printMultiLineColumns(items)
+  }
+  private def printMultiLineColumns(items: List[String]): Unit = {
+    import SimpleMath._
+    val longest     = (items map (_.length)).max
+    //val shortest   = (items map (_.length)).min
+    val columnWidth = longest + marginSize
+    val maxcols = {
+      if (isPaginationEnabled) 1
+      else if (columnWidth >= width) 1
+      else 1 max (width / columnWidth)   // make sure it doesn't divide to 0
+    }
+    val nrows       = items.size /% maxcols
+    val ncols       = items.size /% nrows
+    val groupSize   = ncols
+    val padded      = items map (s"%-${columnWidth}s" format _)
+    val xwise       = isAcross || ncols > items.length
+    val grouped: Seq[Seq[String]]    =
+      if (xwise) (padded grouped groupSize).toSeq
+      else {
+        val h       = 1 max padded.size /% groupSize
+        val cols    = (padded grouped h).toList
+        for (i <- 0 until h) yield
+          for (j <- 0 until groupSize) yield
+            if (i < cols(j).size) cols(j)(i) else ""
+      }
 
-    val longest    = items map (_.length) max
     var linesLeft  = if (isPaginationEnabled()) height - 1 else Int.MaxValue
-    val columnSize = longest + marginSize
-    val padded     = items map ("%-" + columnSize + "s" format _)
-    val groupSize  = 1 max (width / columnSize)   // make sure it doesn't divide to 0
-
-    padded grouped groupSize foreach { xs =>
+    grouped foreach { xs =>
       println(xs.mkString)
       linesLeft -= 1
       if (linesLeft <= 0) {
@@ -59,5 +84,12 @@ trait ConsoleReaderHelper extends ConsoleReader {
           return
       }
     }
+  }
+}
+
+private[interpreter] object SimpleMath {
+  implicit class DivRem(private val i: Int) extends AnyVal {
+    /** i/n + if (i % n != 0) 1 else 0 */
+    def /%(n: Int): Int = (i + n - 1) / n
   }
 }

--- a/src/repl/scala/tools/nsc/interpreter/JLineReader.scala
+++ b/src/repl/scala/tools/nsc/interpreter/JLineReader.scala
@@ -34,6 +34,10 @@ class JLineReader(_completion: => Completion) extends InteractiveReader {
   }
 
   class JLineConsoleReader extends ConsoleReader with ConsoleReaderHelper {
+    val isAcross = interpreter.`package`.isAcross
+
+    this setPaginationEnabled interpreter.`package`.isPaged
+
     // ASAP
     this setExpandEvents false
 

--- a/src/repl/scala/tools/nsc/interpreter/JLineReader.scala
+++ b/src/repl/scala/tools/nsc/interpreter/JLineReader.scala
@@ -33,7 +33,7 @@ class JLineReader(_completion: => Completion) extends InteractiveReader {
     }
   }
 
-  class JLineConsoleReader extends ConsoleReader with ConsoleReaderHelper with Tabulator {
+  class JLineConsoleReader extends ConsoleReader with ConsoleReaderHelper with VariColumnTabulator {
     val isAcross = interpreter.`package`.isAcross
 
     this setPaginationEnabled interpreter.`package`.isPaged

--- a/src/repl/scala/tools/nsc/interpreter/JLineReader.scala
+++ b/src/repl/scala/tools/nsc/interpreter/JLineReader.scala
@@ -33,7 +33,7 @@ class JLineReader(_completion: => Completion) extends InteractiveReader {
     }
   }
 
-  class JLineConsoleReader extends ConsoleReader with ConsoleReaderHelper {
+  class JLineConsoleReader extends ConsoleReader with ConsoleReaderHelper with Tabulator {
     val isAcross = interpreter.`package`.isAcross
 
     this setPaginationEnabled interpreter.`package`.isPaged

--- a/src/repl/scala/tools/nsc/interpreter/ReplConfig.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplConfig.scala
@@ -46,4 +46,8 @@ trait ReplConfig {
   def isReplDebug: Boolean = replProps.debug || isReplTrace
   def isReplInfo: Boolean  = replProps.info || isReplDebug
   def isReplPower: Boolean = replProps.power
+
+  private def csv(p: String, v: String) = p split "," contains v
+  def isPaged: Boolean     = replProps.format.isSet && csv(replProps.format.get, "paged")
+  def isAcross: Boolean    = replProps.format.isSet && csv(replProps.format.get, "across")
 }

--- a/src/repl/scala/tools/nsc/interpreter/ReplProps.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplProps.scala
@@ -18,6 +18,13 @@ class ReplProps {
   val trace = bool("scala.repl.trace")
   val power = bool("scala.repl.power")
 
+  /** CSV of paged,across to enable pagination or `-x` style
+   *  columns, "across" instead of down the column.  Since
+   *  pagination turns off columnar output, these flags are
+   *  currently mutually exclusive.
+   */
+  val format = Prop[String]("scala.repl.format")
+
   val replAutorunCode = Prop[JFile]("scala.repl.autoruncode")
   val powerInitCode   = Prop[JFile]("scala.repl.power.initcode")
   val powerBanner     = Prop[JFile]("scala.repl.power.banner")

--- a/test/junit/scala/tools/nsc/interpreter/TabulatorTest.scala
+++ b/test/junit/scala/tools/nsc/interpreter/TabulatorTest.scala
@@ -7,6 +7,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 case class Tabby(width: Int = 80, isAcross: Boolean = false, marginSize: Int = 3) extends Tabulator
+case class VTabby(width: Int = 80, isAcross: Boolean = false, marginSize: Int = 3) extends VariColumnTabulator
 
 @RunWith(classOf[JUnit4])
 class TabulatorTest {
@@ -37,5 +38,48 @@ class TabulatorTest {
     assert(res(0).size == 2)
     assert(res(1).size == 1)          // no trailing empty strings
     assert(res(1)(0) startsWith "c")
+  }
+  // before, two 9-width cols don't fit in 20
+  // but now, 5-col and 9-col do fit.
+  @Test def twolinerVariable() = {
+    val sut   = VTabby(width = 20)
+    val items = (1 to 9) map (i => i.toString * i)
+    val rows  = sut tabulate items
+    assert(rows.size == 5)
+    assert(rows(0).size == 2)
+    assert(rows(0)(0).size == 8) // width is 55555 plus margin of 3
+  }
+  @Test def sys() = {
+    val sut   = VTabby(width = 40)
+    val items = List("BooleanProp", "PropImpl", "addShutdownHook", "error",
+                    "process", "CreatorImpl", "ShutdownHookThread", "allThreads",
+                    "exit", "props", "Prop", "SystemProperties",
+                    "env", "package", "runtime")
+    val rows  = sut tabulate items
+    assert(rows.size == 8)
+    assert(rows(0).size == 2)
+    assert(rows(0)(0).size == "ShutdownHookThread".length + sut.marginSize)   // 21
+  }
+  @Test def syswide() = {
+    val sut   = VTabby(width = 120)
+    val items = List("BooleanProp", "PropImpl", "addShutdownHook", "error",
+                    "process", "CreatorImpl", "ShutdownHookThread", "allThreads",
+                    "exit", "props", "Prop", "SystemProperties",
+                    "env", "package", "runtime")
+    val rows  = sut tabulate items
+    assert(rows.size == 2)
+    assert(rows(0).size == 8)
+    assert(rows(0)(0).size == "BooleanProp".length + sut.marginSize)  // 14
+  }
+  @Test def resultFits() = {
+    val sut   = VTabby(width = 10)
+    // each of two lines would fit, but layout is two cols of width six > 10
+    // therefore, should choose ncols = 1
+    val items = List("a", "bcd",
+                    "efg", "h")
+    val rows  = sut tabulate items
+    assert(rows.size == 4)
+    assert(rows(0).size == 1)
+    assert(rows(0)(0).size == "efg".length + sut.marginSize)  // 6
   }
 }

--- a/test/junit/scala/tools/nsc/interpreter/TabulatorTest.scala
+++ b/test/junit/scala/tools/nsc/interpreter/TabulatorTest.scala
@@ -1,0 +1,41 @@
+package scala.tools.nsc
+package interpreter
+
+//import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+case class Tabby(width: Int = 80, isAcross: Boolean = false, marginSize: Int = 3) extends Tabulator
+
+@RunWith(classOf[JUnit4])
+class TabulatorTest {
+
+  @Test def oneliner() = {
+    val sut   = Tabby()
+    val items = List("a", "b", "c")
+    val res   = sut tabulate items
+    assert(res.size == 1)
+    assert(res(0).size == 1)
+    assert(res(0)(0) startsWith "a")
+    assert(res(0)(0) endsWith "c")
+  }
+  @Test def twoliner() = {
+    val sut   = Tabby(width = 40)
+    val items = List("a" * 15, "b" * 15, "c" * 15)
+    val res   = sut tabulate items
+    assert(res.size == 2)
+    assert(res(0).size == 2)
+    assert(res(1).size == 2)          // trailing empty strings
+    assert(res(1)(0) startsWith "b")
+  }
+  @Test def twolinerx() = {
+    val sut   = Tabby(width = 40, isAcross = true)
+    val items = List("a" * 15, "b" * 15, "c" * 15)
+    val res   = sut tabulate items
+    assert(res.size == 2)
+    assert(res(0).size == 2)
+    assert(res(1).size == 1)          // no trailing empty strings
+    assert(res(1)(0) startsWith "c")
+  }
+}


### PR DESCRIPTION
Let `ConsoleReaderHelper.printColumns` print in a vertical
orientation (similar to `ls -C`) instead of horizontally (`ls -x`).

To support the old behavior, add a property `-Dscala.repl.format=across`
where "across" is the presumptive mnemonic for `-x`.

Extend column formatting to make columns only as wide as
their widest element. 

Example that really benefits, witness the skinny columns:

```
scala> math.

BigDecimal                     PartiallyOrdered             cosh      rint
BigInt                         Pi                           exp       round
E                              ScalaNumber                  expm1     signum
Equiv                          ScalaNumericAnyConversions   floor     sin
Fractional                     ScalaNumericConversions      hypot     sinh
IEEEremainder                  abs                          log       sqrt
Integral                       acos                         log10     tan
LowPriorityEquiv               asin                         log1p     tanh
LowPriorityOrderingImplicits   atan                         max       toDegrees
Numeric                        atan2                        min       toRadians
Ordered                        cbrt                         package   ulp
Ordering                       ceil                         pow
PartialOrdering                cos                          random

```
