### PR TITLE
SI-7974 Fix broken 'Symbol-handling code in CleanUp

### DIFF
--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -244,6 +244,18 @@ abstract class SymbolTable extends macros.Universe
     finally popPhase(saved)
   }
 
+  final def findPhaseWithName(phaseName: String): Phase = {
+    var ph = phase
+    while (ph != NoPhase && ph.name != phaseName) {
+      ph = ph.prev
+    }
+    if (ph eq NoPhase) phase else ph
+  }
+  final def enteringPhaseWithName[T](phaseName: String)(body: => T): T = {
+    val phase = findPhaseWithName(phaseName)
+    enteringPhase(phase)(body)
+  }
+
   def slowButSafeEnteringPhase[T](ph: Phase)(op: => T): T = {
     if (isCompilerUniverse) enteringPhase(ph)(op)
     else op

--- a/src/reflect/scala/reflect/internal/util/TraceSymbolActivity.scala
+++ b/src/reflect/scala/reflect/internal/util/TraceSymbolActivity.scala
@@ -41,7 +41,8 @@ trait TraceSymbolActivity {
     }
   }
 
-  private def signature(id: Int) = runBeforeErasure(allSymbols(id).defString)
+  private lazy val erasurePhase = findPhaseWithName("erasure")
+  private def signature(id: Int) = enteringPhase(erasurePhase)(allSymbols(id).defString)
 
   private def dashes(s: Any): String = ("" + s) map (_ => '-')
   private def show(s1: Any, ss: Any*) {
@@ -87,14 +88,6 @@ trait TraceSymbolActivity {
   private def showFreq[T, U](xs: Traversable[T])(groupFn: T => U, showFn: U => String) = {
     showMapFreq(xs.toList groupBy groupFn)(showFn)
   }
-  private lazy val findErasurePhase: Phase = {
-    var ph = phase
-    while (ph != NoPhase && ph.name != "erasure") {
-      ph = ph.prev
-    }
-    if (ph eq NoPhase) phase else ph
-  }
-  private def runBeforeErasure[T](body: => T): T = enteringPhase(findErasurePhase)(body)
 
   def showAllSymbols() {
     if (!enabled) return

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -425,6 +425,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.languageFeatureModule
     definitions.metaAnnotations
     definitions.AnnotationDefaultAttr
+    // inaccessible: definitions.erasurePhase
     definitions.isPhantomClass
     definitions.syntheticCoreClasses
     definitions.syntheticCoreMethods

--- a/test/files/run/t7974.check
+++ b/test/files/run/t7974.check
@@ -1,0 +1,104 @@
+public class Symbols {
+
+  // compiled from: Symbols.scala
+
+
+
+  // access flags 0x12
+  private final Lscala/Symbol; someSymbol3
+
+  // access flags 0xA
+  private static Lscala/Symbol; symbol$1
+
+  // access flags 0xA
+  private static Lscala/Symbol; symbol$2
+
+  // access flags 0xA
+  private static Lscala/Symbol; symbol$3
+
+  // access flags 0x9
+  public static <clinit>()V
+   L0
+    LINENUMBER 2 L0
+    GETSTATIC scala/Symbol$.MODULE$ : Lscala/Symbol$;
+    LDC "Symbolic1"
+    INVOKEVIRTUAL scala/Symbol$.apply (Ljava/lang/String;)Lscala/Symbol;
+    PUTSTATIC Symbols.symbol$1 : Lscala/Symbol;
+   L1
+    LINENUMBER 3 L1
+    GETSTATIC scala/Symbol$.MODULE$ : Lscala/Symbol$;
+    LDC "Symbolic2"
+    INVOKEVIRTUAL scala/Symbol$.apply (Ljava/lang/String;)Lscala/Symbol;
+    PUTSTATIC Symbols.symbol$2 : Lscala/Symbol;
+   L2
+    LINENUMBER 5 L2
+    GETSTATIC scala/Symbol$.MODULE$ : Lscala/Symbol$;
+    LDC "Symbolic3"
+    INVOKEVIRTUAL scala/Symbol$.apply (Ljava/lang/String;)Lscala/Symbol;
+    PUTSTATIC Symbols.symbol$3 : Lscala/Symbol;
+    RETURN
+    MAXSTACK = 2
+    MAXLOCALS = 0
+
+  // access flags 0x1
+  public someSymbol1()Lscala/Symbol;
+   L0
+    LINENUMBER 2 L0
+    GETSTATIC Symbols.symbol$1 : Lscala/Symbol;
+    ARETURN
+   L1
+    LOCALVARIABLE this LSymbols; L0 L1 0
+    MAXSTACK = 1
+    MAXLOCALS = 1
+
+  // access flags 0x1
+  public someSymbol2()Lscala/Symbol;
+   L0
+    LINENUMBER 3 L0
+    GETSTATIC Symbols.symbol$2 : Lscala/Symbol;
+    ARETURN
+   L1
+    LOCALVARIABLE this LSymbols; L0 L1 0
+    MAXSTACK = 1
+    MAXLOCALS = 1
+
+  // access flags 0x1
+  public sameSymbol1()Lscala/Symbol;
+   L0
+    LINENUMBER 4 L0
+    GETSTATIC Symbols.symbol$1 : Lscala/Symbol;
+    ARETURN
+   L1
+    LOCALVARIABLE this LSymbols; L0 L1 0
+    MAXSTACK = 1
+    MAXLOCALS = 1
+
+  // access flags 0x1
+  public someSymbol3()Lscala/Symbol;
+   L0
+    LINENUMBER 5 L0
+    ALOAD 0
+    GETFIELD Symbols.someSymbol3 : Lscala/Symbol;
+    ARETURN
+   L1
+    LOCALVARIABLE this LSymbols; L0 L1 0
+    MAXSTACK = 1
+    MAXLOCALS = 1
+
+  // access flags 0x1
+  public <init>()V
+   L0
+    LINENUMBER 6 L0
+    ALOAD 0
+    INVOKESPECIAL java/lang/Object.<init> ()V
+   L1
+    LINENUMBER 5 L1
+    ALOAD 0
+    GETSTATIC Symbols.symbol$3 : Lscala/Symbol;
+    PUTFIELD Symbols.someSymbol3 : Lscala/Symbol;
+    RETURN
+   L2
+    LOCALVARIABLE this LSymbols; L0 L2 0
+    MAXSTACK = 2
+    MAXLOCALS = 1
+}

--- a/test/files/run/t7974/Symbols.scala
+++ b/test/files/run/t7974/Symbols.scala
@@ -1,0 +1,6 @@
+class Symbols {
+  def someSymbol1 = 'Symbolic1
+  def someSymbol2 = 'Symbolic2
+  def sameSymbol1 = 'Symbolic1
+  val someSymbol3 = 'Symbolic3
+}

--- a/test/files/run/t7974/Test.scala
+++ b/test/files/run/t7974/Test.scala
@@ -1,0 +1,20 @@
+import java.io.PrintWriter;
+
+import scala.tools.partest.BytecodeTest
+import scala.tools.asm.util._
+import scala.tools.nsc.util.stringFromWriter
+
+object Test extends BytecodeTest {
+  def show {
+    val classNode = loadClassNode("Symbols", skipDebugInfo = false)
+    val textifier = new Textifier
+    classNode.accept(new TraceClassVisitor(null, textifier, null))
+    
+    val classString = stringFromWriter(w => textifier.print(w))
+    val result =
+      classString.split('\n')
+        .dropWhile(elem => elem != "public class Symbols {")
+        .filterNot(elem => elem.startsWith("  @Lscala/reflect/ScalaSignature") || elem.startsWith("  ATTRIBUTE ScalaSig"))
+    result foreach println
+  }
+}


### PR DESCRIPTION
The transformation did never happen because the pattern
failed to match. Why did the pattern fail to match? Because
Symbol_apply turned into an overloaded Symbol after erasure.
