### PR TITLE
Remove deprecated constructor from the migration annotation

### DIFF
--- a/src/library/scala/annotation/migration.scala
+++ b/src/library/scala/annotation/migration.scala
@@ -25,7 +25,4 @@ package scala.annotation
  *
  * @since 2.8
  */
- private[scala] final class migration(message: String, changedIn: String) extends scala.annotation.StaticAnnotation {
-   @deprecated("Use the constructor taking two Strings instead.", "2.10.0")
-   def this(majorVersion: Int, minorVersion: Int, message: String) = this(message, majorVersion + "." + minorVersion)
- }
+ private[scala] final class migration(message: String, changedIn: String) extends scala.annotation.StaticAnnotation


### PR DESCRIPTION
The migration annotation had a deprecated 2 arg constructor that was
deprecated in 2.10.0. This commit removes that constructor. Because
migration is private to the scala package this change shouldn’t affect
the rest of the community.
