### PR TITLE
Removes exception handler inlinining from -optimize

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -39,7 +39,7 @@ trait ScalaSettings extends AbsScalaSettings
   protected def futureSettings = List[BooleanSetting]()
 
   /** Enabled under -optimise. */
-  def optimiseSettings = List[BooleanSetting](inline, inlineHandlers, Xcloselim, Xdce, YconstOptimization)
+  def optimiseSettings = List[BooleanSetting](inline, Xcloselim, Xdce, YconstOptimization)
 
   /** If any of these settings is enabled, the compiler should print a message and exit.  */
   def infoSettings = List[Setting](help, Xhelp, Yhelp, showPlugins, showPhases, genPhaseGraph)

--- a/test/files/jvm/t7006.check
+++ b/test/files/jvm/t7006.check
@@ -22,7 +22,6 @@
 [running phase delambdafy on Foo_1.scala]
 [running phase icode on Foo_1.scala]
 [running phase inliner on Foo_1.scala]
-[running phase inlinehandlers on Foo_1.scala]
 [running phase closelim on Foo_1.scala]
 [running phase constopt on Foo_1.scala]
 [running phase dce on Foo_1.scala]

--- a/test/files/neg/t6446-additional.check
+++ b/test/files/neg/t6446-additional.check
@@ -23,17 +23,10 @@ superaccessors   6  add super accessors in traits and nested classes
        cleanup  21  platform-specific cleanups, generate reflective calls
     delambdafy  22  remove lambdas
          icode  23  generate portable intermediate code
-#partest -optimise
        inliner  24  optimization: do inlining
-inlinehandlers  25  optimization: inline exception handlers
-      closelim  26  optimization: eliminate uncalled closures
-      constopt  27  optimization: optimize null and other constants
-           dce  28  optimization: eliminate dead code
-           jvm  29  generate JVM bytecode
-       ploogin  30  A sample phase that does so many things it's kind of hard...
-      terminal  31  the last phase during a compilation run
-#partest !-optimise
-           jvm  24  generate JVM bytecode
-       ploogin  25  A sample phase that does so many things it's kind of hard...
-      terminal  26  the last phase during a compilation run
-#partest
+      closelim  25  optimization: eliminate uncalled closures
+      constopt  26  optimization: optimize null and other constants
+           dce  27  optimization: eliminate dead code
+           jvm  28  generate JVM bytecode
+       ploogin  29  A sample phase that does so many things it's kind of hard...
+      terminal  30  the last phase during a compilation run

--- a/test/files/neg/t6446-missing.check
+++ b/test/files/neg/t6446-missing.check
@@ -24,15 +24,9 @@ superaccessors   6  add super accessors in traits and nested classes
        cleanup  21  platform-specific cleanups, generate reflective calls
     delambdafy  22  remove lambdas
          icode  23  generate portable intermediate code
-#partest !-optimise
-           jvm  24  generate JVM bytecode
-      terminal  25  the last phase during a compilation run
-#partest -optimise
        inliner  24  optimization: do inlining
-inlinehandlers  25  optimization: inline exception handlers
-      closelim  26  optimization: eliminate uncalled closures
-      constopt  27  optimization: optimize null and other constants
-           dce  28  optimization: eliminate dead code
-           jvm  29  generate JVM bytecode
-      terminal  30  the last phase during a compilation run
-#partest
+      closelim  25  optimization: eliminate uncalled closures
+      constopt  26  optimization: optimize null and other constants
+           dce  27  optimization: eliminate dead code
+           jvm  28  generate JVM bytecode
+      terminal  29  the last phase during a compilation run

--- a/test/files/neg/t6446-show-phases.check
+++ b/test/files/neg/t6446-show-phases.check
@@ -23,15 +23,9 @@ superaccessors   6  add super accessors in traits and nested classes
        cleanup  21  platform-specific cleanups, generate reflective calls
     delambdafy  22  remove lambdas
          icode  23  generate portable intermediate code
-#partest !-optimise
-           jvm  24  generate JVM bytecode
-      terminal  25  the last phase during a compilation run
-#partest -optimise
        inliner  24  optimization: do inlining
-inlinehandlers  25  optimization: inline exception handlers
-      closelim  26  optimization: eliminate uncalled closures
-      constopt  27  optimization: optimize null and other constants
-           dce  28  optimization: eliminate dead code
-           jvm  29  generate JVM bytecode
-      terminal  30  the last phase during a compilation run
-#partest
+      closelim  25  optimization: eliminate uncalled closures
+      constopt  26  optimization: optimize null and other constants
+           dce  27  optimization: eliminate dead code
+           jvm  28  generate JVM bytecode
+      terminal  29  the last phase during a compilation run

--- a/test/files/neg/t7494-no-options.check
+++ b/test/files/neg/t7494-no-options.check
@@ -24,17 +24,10 @@ superaccessors   6  add super accessors in traits and nested classes
        cleanup  21  platform-specific cleanups, generate reflective calls
     delambdafy  22  remove lambdas
          icode  23  generate portable intermediate code
-#partest !-optimise
-           jvm  24  generate JVM bytecode
-       ploogin  25  A sample phase that does so many things it's kind of hard...
-      terminal  26  the last phase during a compilation run
-#partest -optimise
        inliner  24  optimization: do inlining
-inlinehandlers  25  optimization: inline exception handlers
-      closelim  26  optimization: eliminate uncalled closures
-      constopt  27  optimization: optimize null and other constants
-           dce  28  optimization: eliminate dead code
-           jvm  29  generate JVM bytecode
-       ploogin  30  A sample phase that does so many things it's kind of hard...
-      terminal  31  the last phase during a compilation run
-#partest
+      closelim  25  optimization: eliminate uncalled closures
+      constopt  26  optimization: optimize null and other constants
+           dce  27  optimization: eliminate dead code
+           jvm  28  generate JVM bytecode
+       ploogin  29  A sample phase that does so many things it's kind of hard...
+      terminal  30  the last phase during a compilation run

--- a/test/files/run/inline-ex-handlers.check
+++ b/test/files/run/inline-ex-handlers.check
@@ -9,28 +9,28 @@
 +  blocks: [1,3,4]
    
 @@ -186,2 +186,4 @@
-     92	LOAD_LOCAL(value x$1)
-+    92	STORE_LOCAL(variable boxed1)
-+    92	LOAD_LOCAL(variable boxed1)
-     92	BOX INT
+     94	LOAD_LOCAL(value x$1)
++    94	STORE_LOCAL(variable boxed1)
++    94	LOAD_LOCAL(variable boxed1)
+     94	BOX INT
 @@ -194,5 +196,2 @@
-     92	CALL_METHOD MyException.message (dynamic)
--    92	JUMP 2
+     94	CALL_METHOD MyException.message (dynamic)
+-    94	JUMP 2
 -    
 -  2: 
-     92	RETURN(REF(class Object))
+     94	RETURN(REF(class Object))
 @@ -246,3 +245,3 @@
    startBlock: 1
 -  blocks: [1,2,3,4,5,6,7,8,11,12,13,14,15,16,17,18]
 +  blocks: [1,2,3,4,5,6,8,11,12,13,14,15,16,17,18]
    
 @@ -257,5 +256,2 @@
-     92	SCOPE_ENTER value x1
--    92	JUMP 7
+     94	SCOPE_ENTER value x1
+-    94	JUMP 7
 -    
 -  7: 
-     92	LOAD_LOCAL(value x1)
-@@ -390,5 +386,5 @@
+     94	LOAD_LOCAL(value x1)
+@@ -408,5 +404,5 @@
    def main(args: Array[String] (ARRAY[REF(class String)])): Unit {
 -  locals: value args, variable result, value ex6, value x4, value x5, value message, value x
 +  locals: value args, variable result, value ex6, value x4, value x5, value x
@@ -38,90 +38,90 @@
 -  blocks: [1,2,3,4,5,8,10,11,13]
 +  blocks: [1,2,3,5,8,10,11,13,14]
    
-@@ -416,4 +412,13 @@
-     103	CALL_METHOD MyException.<init> (static-instance)
--    103	THROW(MyException)
+@@ -434,4 +430,13 @@
+     105	CALL_METHOD MyException.<init> (static-instance)
+-    105	THROW(MyException)
 +    ?	STORE_LOCAL(value ex6)
 +    ?	JUMP 14
      
 +  14: 
-+    101	LOAD_LOCAL(value ex6)
-+    101	STORE_LOCAL(value x4)
-+    101	SCOPE_ENTER value x4
-+    106	LOAD_LOCAL(value x4)
-+    106	IS_INSTANCE REF(class MyException)
-+    106	CZJUMP (BOOL)NE ? 5 : 8
++    103	LOAD_LOCAL(value ex6)
++    103	STORE_LOCAL(value x4)
++    103	SCOPE_ENTER value x4
++    108	LOAD_LOCAL(value x4)
++    108	IS_INSTANCE REF(class MyException)
++    108	CZJUMP (BOOL)NE ? 5 : 8
 +    
    13: 
-@@ -429,5 +434,2 @@
-     101	SCOPE_ENTER value x4
--    101	JUMP 4
+@@ -447,5 +452,2 @@
+     103	SCOPE_ENTER value x4
+-    103	JUMP 4
 -    
 -  4: 
-     106	LOAD_LOCAL(value x4)
-@@ -441,8 +443,5 @@
-     106	SCOPE_ENTER value x5
--    106	LOAD_LOCAL(value x5)
--    106	CALL_METHOD MyException.message (dynamic)
--    106	STORE_LOCAL(value message)
--    106	SCOPE_ENTER value message
-     106	LOAD_MODULE object Predef
--    106	LOAD_LOCAL(value message)
+     108	LOAD_LOCAL(value x4)
+@@ -459,8 +461,5 @@
+     108	SCOPE_ENTER value x5
+-    108	LOAD_LOCAL(value x5)
+-    108	CALL_METHOD MyException.message (dynamic)
+-    108	STORE_LOCAL(value message)
+-    108	SCOPE_ENTER value message
+     108	LOAD_MODULE object Predef
+-    108	LOAD_LOCAL(value message)
 +    ?	LOAD_LOCAL(value x5)
-+    106	CALL_METHOD MyException.message (dynamic)
-     106	CALL_METHOD scala.Predef.println (dynamic)
-@@ -518,3 +517,3 @@
++    108	CALL_METHOD MyException.message (dynamic)
+     108	CALL_METHOD scala.Predef.println (dynamic)
+@@ -536,3 +535,3 @@
    startBlock: 1
 -  blocks: [1,2,3,4,6,7,9,10]
 +  blocks: [1,3,4,6,7,9,10,11,12,13]
    
-@@ -547,4 +546,9 @@
-     306	CALL_METHOD MyException.<init> (static-instance)
--    306	THROW(MyException)
+@@ -565,4 +564,9 @@
+     308	CALL_METHOD MyException.<init> (static-instance)
+-    308	THROW(MyException)
 +    ?	JUMP 11
      
 +  11: 
 +    ?	LOAD_LOCAL(variable monitor4)
-+    305	MONITOR_EXIT
++    307	MONITOR_EXIT
 +    ?	JUMP 12
 +    
    9: 
-@@ -553,3 +557,3 @@
-     305	MONITOR_EXIT
+@@ -571,3 +575,3 @@
+     307	MONITOR_EXIT
 -    ?	THROW(Throwable)
 +    ?	JUMP 12
      
-@@ -559,4 +563,11 @@
-     304	MONITOR_EXIT
+@@ -577,4 +581,11 @@
+     306	MONITOR_EXIT
 -    ?	THROW(Throwable)
 +    ?	STORE_LOCAL(value t)
 +    ?	JUMP 13
      
 +  12: 
 +    ?	LOAD_LOCAL(variable monitor3)
-+    304	MONITOR_EXIT
++    306	MONITOR_EXIT
 +    ?	STORE_LOCAL(value t)
 +    ?	JUMP 13
 +    
    3: 
-@@ -573,5 +584,14 @@
-     310	CALL_METHOD scala.Predef.println (dynamic)
--    310	JUMP 2
-+    300	RETURN(UNIT)
+@@ -591,5 +602,14 @@
+     312	CALL_METHOD scala.Predef.println (dynamic)
+-    312	JUMP 2
++    302	RETURN(UNIT)
      
 -  2: 
 +  13: 
-+    310	LOAD_MODULE object Predef
-+    310	CALL_PRIMITIVE(StartConcat)
-+    310	CONSTANT("Caught crash: ")
-+    310	CALL_PRIMITIVE(StringConcat(REF(class String)))
-+    310	LOAD_LOCAL(value t)
-+    310	CALL_METHOD java.lang.Throwable.toString (dynamic)
-+    310	CALL_PRIMITIVE(StringConcat(REF(class String)))
-+    310	CALL_PRIMITIVE(EndConcat)
-+    310	CALL_METHOD scala.Predef.println (dynamic)
-     300	RETURN(UNIT)
-@@ -583,6 +603,6 @@
++    312	LOAD_MODULE object Predef
++    312	CALL_PRIMITIVE(StartConcat)
++    312	CONSTANT("Caught crash: ")
++    312	CALL_PRIMITIVE(StringConcat(REF(class String)))
++    312	LOAD_LOCAL(value t)
++    312	CALL_METHOD java.lang.Throwable.toString (dynamic)
++    312	CALL_PRIMITIVE(StringConcat(REF(class String)))
++    312	CALL_PRIMITIVE(EndConcat)
++    312	CALL_METHOD scala.Predef.println (dynamic)
+     302	RETURN(UNIT)
+@@ -601,6 +621,6 @@
        with finalizer: null
 -    catch (Throwable) in ArrayBuffer(7, 9, 10) starting at: 6
 +    catch (Throwable) in ArrayBuffer(7, 9, 10, 11) starting at: 6
@@ -130,51 +130,51 @@
 -    catch (Throwable) in ArrayBuffer(4, 6, 7, 9, 10) starting at: 3
 +    catch (Throwable) in ArrayBuffer(4, 6, 7, 9, 10, 11, 12) starting at: 3
        consisting of blocks: List(3)
-@@ -618,3 +638,3 @@
+@@ -636,3 +656,3 @@
    startBlock: 1
 -  blocks: [1,3,4,5,6,8,9]
 +  blocks: [1,3,4,5,6,8,9,10,11]
    
-@@ -642,4 +662,10 @@
-     78	CALL_METHOD java.lang.IllegalArgumentException.<init> (static-instance)
--    78	THROW(IllegalArgumentException)
+@@ -660,4 +680,10 @@
+     80	CALL_METHOD java.lang.IllegalArgumentException.<init> (static-instance)
+-    80	THROW(IllegalArgumentException)
 +    ?	STORE_LOCAL(value e)
 +    ?	JUMP 10
      
 +  10: 
-+    81	LOAD_LOCAL(value e)
++    83	LOAD_LOCAL(value e)
 +    ?	STORE_LOCAL(variable exc1)
 +    ?	JUMP 11
 +    
    8: 
-@@ -668,3 +694,4 @@
-     81	LOAD_LOCAL(value e)
--    81	THROW(Exception)
+@@ -686,3 +712,4 @@
+     83	LOAD_LOCAL(value e)
+-    83	THROW(Exception)
 +    ?	STORE_LOCAL(variable exc1)
 +    ?	JUMP 11
      
-@@ -685,2 +712,15 @@
+@@ -703,2 +730,15 @@
      
 +  11: 
-+    83	LOAD_MODULE object Predef
-+    83	CONSTANT("finally")
-+    83	CALL_METHOD scala.Predef.println (dynamic)
-+    84	LOAD_LOCAL(variable result)
-+    84	CONSTANT(1)
-+    84	CALL_PRIMITIVE(Arithmetic(SUB,INT))
-+    84	CONSTANT(2)
-+    84	CALL_PRIMITIVE(Arithmetic(DIV,INT))
-+    84	STORE_LOCAL(variable result)
-+    84	LOAD_LOCAL(variable exc1)
-+    84	THROW(Throwable)
++    85	LOAD_MODULE object Predef
++    85	CONSTANT("finally")
++    85	CALL_METHOD scala.Predef.println (dynamic)
++    86	LOAD_LOCAL(variable result)
++    86	CONSTANT(1)
++    86	CALL_PRIMITIVE(Arithmetic(SUB,INT))
++    86	CONSTANT(2)
++    86	CALL_PRIMITIVE(Arithmetic(DIV,INT))
++    86	STORE_LOCAL(variable result)
++    86	LOAD_LOCAL(variable exc1)
++    86	THROW(Throwable)
 +    
    }
-@@ -690,3 +730,3 @@
+@@ -708,3 +748,3 @@
        with finalizer: null
 -    catch (<none>) in ArrayBuffer(4, 5, 6, 8) starting at: 3
 +    catch (<none>) in ArrayBuffer(4, 5, 6, 8, 10) starting at: 3
        consisting of blocks: List(3)
-@@ -714,5 +754,5 @@
+@@ -732,5 +772,5 @@
    def main(args: Array[String] (ARRAY[REF(class String)])): Unit {
 -  locals: value args, variable result, value ex6, variable exc2, value x4, value x5, value message, value x, value ex6, value x4, value x5, value message, value x
 +  locals: value args, variable result, value ex6, variable exc2, value x4, value x5, value x, value ex6, value x4, value x5, value x
@@ -182,99 +182,99 @@
 -  blocks: [1,3,4,5,6,9,13,14,15,18,20,21,23,24]
 +  blocks: [1,3,4,5,6,9,13,14,15,18,20,21,23,24,25,26,27]
    
-@@ -740,4 +780,11 @@
-     172	CALL_METHOD MyException.<init> (static-instance)
--    172	THROW(MyException)
+@@ -758,4 +798,11 @@
+     174	CALL_METHOD MyException.<init> (static-instance)
+-    174	THROW(MyException)
 +    ?	STORE_LOCAL(value ex6)
 +    ?	JUMP 25
      
 +  25: 
-+    170	LOAD_LOCAL(value ex6)
-+    170	STORE_LOCAL(value x4)
-+    170	SCOPE_ENTER value x4
-+    170	JUMP 14
++    172	LOAD_LOCAL(value ex6)
++    172	STORE_LOCAL(value x4)
++    172	SCOPE_ENTER value x4
++    172	JUMP 14
 +    
    23: 
-@@ -780,8 +827,5 @@
-     175	SCOPE_ENTER value x5
--    175	LOAD_LOCAL(value x5)
--    175	CALL_METHOD MyException.message (dynamic)
--    175	STORE_LOCAL(value message)
--    175	SCOPE_ENTER value message
-     176	LOAD_MODULE object Predef
--    176	LOAD_LOCAL(value message)
+@@ -798,8 +845,5 @@
+     177	SCOPE_ENTER value x5
+-    177	LOAD_LOCAL(value x5)
+-    177	CALL_METHOD MyException.message (dynamic)
+-    177	STORE_LOCAL(value message)
+-    177	SCOPE_ENTER value message
+     178	LOAD_MODULE object Predef
+-    178	LOAD_LOCAL(value message)
 +    ?	LOAD_LOCAL(value x5)
-+    176	CALL_METHOD MyException.message (dynamic)
-     176	CALL_METHOD scala.Predef.println (dynamic)
-@@ -789,5 +833,7 @@
-     177	DUP(REF(class MyException))
--    177	LOAD_LOCAL(value message)
++    178	CALL_METHOD MyException.message (dynamic)
+     178	CALL_METHOD scala.Predef.println (dynamic)
+@@ -807,5 +851,7 @@
+     179	DUP(REF(class MyException))
+-    179	LOAD_LOCAL(value message)
 +    ?	LOAD_LOCAL(value x5)
-+    177	CALL_METHOD MyException.message (dynamic)
-     177	CALL_METHOD MyException.<init> (static-instance)
--    177	THROW(MyException)
++    179	CALL_METHOD MyException.message (dynamic)
+     179	CALL_METHOD MyException.<init> (static-instance)
+-    179	THROW(MyException)
 +    ?	STORE_LOCAL(value ex6)
 +    ?	JUMP 26
      
-@@ -795,3 +841,4 @@
-     170	LOAD_LOCAL(value ex6)
--    170	THROW(Throwable)
+@@ -813,3 +859,4 @@
+     172	LOAD_LOCAL(value ex6)
+-    172	THROW(Throwable)
 +    ?	STORE_LOCAL(value ex6)
 +    ?	JUMP 26
      
-@@ -805,2 +852,8 @@
+@@ -823,2 +870,8 @@
      
 +  26: 
-+    169	LOAD_LOCAL(value ex6)
-+    169	STORE_LOCAL(value x4)
-+    169	SCOPE_ENTER value x4
-+    169	JUMP 5
++    171	LOAD_LOCAL(value ex6)
++    171	STORE_LOCAL(value x4)
++    171	SCOPE_ENTER value x4
++    171	JUMP 5
 +    
    5: 
-@@ -815,8 +868,5 @@
-     180	SCOPE_ENTER value x5
--    180	LOAD_LOCAL(value x5)
--    180	CALL_METHOD MyException.message (dynamic)
--    180	STORE_LOCAL(value message)
--    180	SCOPE_ENTER value message
-     181	LOAD_MODULE object Predef
--    181	LOAD_LOCAL(value message)
+@@ -833,8 +886,5 @@
+     182	SCOPE_ENTER value x5
+-    182	LOAD_LOCAL(value x5)
+-    182	CALL_METHOD MyException.message (dynamic)
+-    182	STORE_LOCAL(value message)
+-    182	SCOPE_ENTER value message
+     183	LOAD_MODULE object Predef
+-    183	LOAD_LOCAL(value message)
 +    ?	LOAD_LOCAL(value x5)
-+    181	CALL_METHOD MyException.message (dynamic)
-     181	CALL_METHOD scala.Predef.println (dynamic)
-@@ -824,5 +874,7 @@
-     182	DUP(REF(class MyException))
--    182	LOAD_LOCAL(value message)
++    183	CALL_METHOD MyException.message (dynamic)
+     183	CALL_METHOD scala.Predef.println (dynamic)
+@@ -842,5 +892,7 @@
+     184	DUP(REF(class MyException))
+-    184	LOAD_LOCAL(value message)
 +    ?	LOAD_LOCAL(value x5)
-+    182	CALL_METHOD MyException.message (dynamic)
-     182	CALL_METHOD MyException.<init> (static-instance)
--    182	THROW(MyException)
++    184	CALL_METHOD MyException.message (dynamic)
+     184	CALL_METHOD MyException.<init> (static-instance)
+-    184	THROW(MyException)
 +    ?	STORE_LOCAL(variable exc2)
 +    ?	JUMP 27
      
-@@ -830,3 +882,4 @@
-     169	LOAD_LOCAL(value ex6)
--    169	THROW(Throwable)
+@@ -848,3 +900,4 @@
+     171	LOAD_LOCAL(value ex6)
+-    171	THROW(Throwable)
 +    ?	STORE_LOCAL(variable exc2)
 +    ?	JUMP 27
      
-@@ -847,2 +900,15 @@
+@@ -865,2 +918,15 @@
      
 +  27: 
-+    184	LOAD_MODULE object Predef
-+    184	CONSTANT("finally")
-+    184	CALL_METHOD scala.Predef.println (dynamic)
-+    185	LOAD_LOCAL(variable result)
-+    185	CONSTANT(1)
-+    185	CALL_PRIMITIVE(Arithmetic(SUB,INT))
-+    185	CONSTANT(2)
-+    185	CALL_PRIMITIVE(Arithmetic(DIV,INT))
-+    185	STORE_LOCAL(variable result)
-+    185	LOAD_LOCAL(variable exc2)
-+    185	THROW(Throwable)
++    186	LOAD_MODULE object Predef
++    186	CONSTANT("finally")
++    186	CALL_METHOD scala.Predef.println (dynamic)
++    187	LOAD_LOCAL(variable result)
++    187	CONSTANT(1)
++    187	CALL_PRIMITIVE(Arithmetic(SUB,INT))
++    187	CONSTANT(2)
++    187	CALL_PRIMITIVE(Arithmetic(DIV,INT))
++    187	STORE_LOCAL(variable result)
++    187	LOAD_LOCAL(variable exc2)
++    187	THROW(Throwable)
 +    
    }
-@@ -852,6 +918,6 @@
+@@ -870,6 +936,6 @@
        with finalizer: null
 -    catch (Throwable) in ArrayBuffer(13, 14, 15, 18, 20, 21, 23) starting at: 4
 +    catch (Throwable) in ArrayBuffer(13, 14, 15, 18, 20, 21, 23, 25) starting at: 4
@@ -283,7 +283,7 @@
 -    catch (<none>) in ArrayBuffer(4, 5, 6, 9, 13, 14, 15, 18, 20, 21, 23) starting at: 3
 +    catch (<none>) in ArrayBuffer(4, 5, 6, 9, 13, 14, 15, 18, 20, 21, 23, 25, 26) starting at: 3
        consisting of blocks: List(3)
-@@ -879,5 +945,5 @@
+@@ -897,5 +963,5 @@
    def main(args: Array[String] (ARRAY[REF(class String)])): Unit {
 -  locals: value args, variable result, value e, value ex6, value x4, value x5, value message, value x
 +  locals: value args, variable result, value e, value ex6, value x4, value x5, value x
@@ -291,36 +291,36 @@
 -  blocks: [1,2,3,6,7,8,11,13,14,16]
 +  blocks: [1,2,3,6,7,8,11,13,14,16,17]
    
-@@ -905,4 +971,11 @@
-     124	CALL_METHOD MyException.<init> (static-instance)
--    124	THROW(MyException)
+@@ -923,4 +989,11 @@
+     126	CALL_METHOD MyException.<init> (static-instance)
+-    126	THROW(MyException)
 +    ?	STORE_LOCAL(value ex6)
 +    ?	JUMP 17
      
 +  17: 
-+    122	LOAD_LOCAL(value ex6)
-+    122	STORE_LOCAL(value x4)
-+    122	SCOPE_ENTER value x4
-+    122	JUMP 7
++    124	LOAD_LOCAL(value ex6)
++    124	STORE_LOCAL(value x4)
++    124	SCOPE_ENTER value x4
++    124	JUMP 7
 +    
    16: 
-@@ -930,8 +1003,5 @@
-     127	SCOPE_ENTER value x5
--    127	LOAD_LOCAL(value x5)
--    127	CALL_METHOD MyException.message (dynamic)
--    127	STORE_LOCAL(value message)
--    127	SCOPE_ENTER value message
-     127	LOAD_MODULE object Predef
--    127	LOAD_LOCAL(value message)
+@@ -948,8 +1021,5 @@
+     129	SCOPE_ENTER value x5
+-    129	LOAD_LOCAL(value x5)
+-    129	CALL_METHOD MyException.message (dynamic)
+-    129	STORE_LOCAL(value message)
+-    129	SCOPE_ENTER value message
+     129	LOAD_MODULE object Predef
+-    129	LOAD_LOCAL(value message)
 +    ?	LOAD_LOCAL(value x5)
-+    127	CALL_METHOD MyException.message (dynamic)
-     127	CALL_METHOD scala.Predef.println (dynamic)
-@@ -964,3 +1034,3 @@
++    129	CALL_METHOD MyException.message (dynamic)
+     129	CALL_METHOD scala.Predef.println (dynamic)
+@@ -982,3 +1052,3 @@
        with finalizer: null
 -    catch (IllegalArgumentException) in ArrayBuffer(6, 7, 8, 11, 13, 14, 16) starting at: 3
 +    catch (IllegalArgumentException) in ArrayBuffer(6, 7, 8, 11, 13, 14, 16, 17) starting at: 3
        consisting of blocks: List(3)
-@@ -988,5 +1058,5 @@
+@@ -1006,5 +1076,5 @@
    def main(args: Array[String] (ARRAY[REF(class String)])): Unit {
 -  locals: value args, variable result, value ex6, value x4, value x5, value message, value x, value e
 +  locals: value args, variable result, value ex6, value x4, value x5, value x, value e
@@ -328,57 +328,57 @@
 -  blocks: [1,2,3,4,5,8,12,13,14,16]
 +  blocks: [1,2,3,5,8,12,13,14,16,17]
    
-@@ -1014,4 +1084,13 @@
-     148	CALL_METHOD MyException.<init> (static-instance)
--    148	THROW(MyException)
+@@ -1032,4 +1102,13 @@
+     150	CALL_METHOD MyException.<init> (static-instance)
+-    150	THROW(MyException)
 +    ?	STORE_LOCAL(value ex6)
 +    ?	JUMP 17
      
 +  17: 
-+    145	LOAD_LOCAL(value ex6)
-+    145	STORE_LOCAL(value x4)
-+    145	SCOPE_ENTER value x4
-+    154	LOAD_LOCAL(value x4)
-+    154	IS_INSTANCE REF(class MyException)
-+    154	CZJUMP (BOOL)NE ? 5 : 8
++    147	LOAD_LOCAL(value ex6)
++    147	STORE_LOCAL(value x4)
++    147	SCOPE_ENTER value x4
++    156	LOAD_LOCAL(value x4)
++    156	IS_INSTANCE REF(class MyException)
++    156	CZJUMP (BOOL)NE ? 5 : 8
 +    
    16: 
-@@ -1035,5 +1114,2 @@
-     145	SCOPE_ENTER value x4
--    145	JUMP 4
+@@ -1053,5 +1132,2 @@
+     147	SCOPE_ENTER value x4
+-    147	JUMP 4
 -    
 -  4: 
-     154	LOAD_LOCAL(value x4)
-@@ -1047,8 +1123,5 @@
-     154	SCOPE_ENTER value x5
--    154	LOAD_LOCAL(value x5)
--    154	CALL_METHOD MyException.message (dynamic)
--    154	STORE_LOCAL(value message)
--    154	SCOPE_ENTER value message
-     154	LOAD_MODULE object Predef
--    154	LOAD_LOCAL(value message)
+     156	LOAD_LOCAL(value x4)
+@@ -1065,8 +1141,5 @@
+     156	SCOPE_ENTER value x5
+-    156	LOAD_LOCAL(value x5)
+-    156	CALL_METHOD MyException.message (dynamic)
+-    156	STORE_LOCAL(value message)
+-    156	SCOPE_ENTER value message
+     156	LOAD_MODULE object Predef
+-    156	LOAD_LOCAL(value message)
 +    ?	LOAD_LOCAL(value x5)
-+    154	CALL_METHOD MyException.message (dynamic)
-     154	CALL_METHOD scala.Predef.println (dynamic)
-@@ -1269,3 +1342,3 @@
++    156	CALL_METHOD MyException.message (dynamic)
+     156	CALL_METHOD scala.Predef.println (dynamic)
+@@ -1287,3 +1360,3 @@
    startBlock: 1
 -  blocks: [1,2,3,4,5,7]
 +  blocks: [1,2,3,4,5,7,8]
    
-@@ -1293,4 +1366,11 @@
-     38	CALL_METHOD java.lang.IllegalArgumentException.<init> (static-instance)
--    38	THROW(IllegalArgumentException)
+@@ -1311,4 +1384,11 @@
+     40	CALL_METHOD java.lang.IllegalArgumentException.<init> (static-instance)
+-    40	THROW(IllegalArgumentException)
 +    ?	STORE_LOCAL(value e)
 +    ?	JUMP 8
      
 +  8: 
-+    42	LOAD_MODULE object Predef
-+    42	CONSTANT("IllegalArgumentException")
-+    42	CALL_METHOD scala.Predef.println (dynamic)
-+    42	JUMP 2
++    44	LOAD_MODULE object Predef
++    44	CONSTANT("IllegalArgumentException")
++    44	CALL_METHOD scala.Predef.println (dynamic)
++    44	JUMP 2
 +    
    7: 
-@@ -1340,5 +1420,5 @@
+@@ -1358,5 +1438,5 @@
    def main(args: Array[String] (ARRAY[REF(class String)])): Unit {
 -  locals: value args, variable result, value ex6, value x4, value x5, value message, value x
 +  locals: value args, variable result, value ex6, value x4, value x5, value x
@@ -386,84 +386,84 @@
 -  blocks: [1,2,3,4,5,8,10,11,13,14,16]
 +  blocks: [1,2,3,5,8,10,11,13,14,16,17]
    
-@@ -1366,3 +1446,4 @@
-     203	CALL_METHOD MyException.<init> (static-instance)
--    203	THROW(MyException)
+@@ -1384,3 +1464,4 @@
+     205	CALL_METHOD MyException.<init> (static-instance)
+-    205	THROW(MyException)
 +    ?	STORE_LOCAL(value ex6)
 +    ?	JUMP 17
      
-@@ -1386,4 +1467,13 @@
-     209	CALL_METHOD MyException.<init> (static-instance)
--    209	THROW(MyException)
+@@ -1404,4 +1485,13 @@
+     211	CALL_METHOD MyException.<init> (static-instance)
+-    211	THROW(MyException)
 +    ?	STORE_LOCAL(value ex6)
 +    ?	JUMP 17
      
 +  17: 
-+    200	LOAD_LOCAL(value ex6)
-+    200	STORE_LOCAL(value x4)
-+    200	SCOPE_ENTER value x4
-+    212	LOAD_LOCAL(value x4)
-+    212	IS_INSTANCE REF(class MyException)
-+    212	CZJUMP (BOOL)NE ? 5 : 8
++    202	LOAD_LOCAL(value ex6)
++    202	STORE_LOCAL(value x4)
++    202	SCOPE_ENTER value x4
++    214	LOAD_LOCAL(value x4)
++    214	IS_INSTANCE REF(class MyException)
++    214	CZJUMP (BOOL)NE ? 5 : 8
 +    
    16: 
-@@ -1399,5 +1489,2 @@
-     200	SCOPE_ENTER value x4
--    200	JUMP 4
+@@ -1417,5 +1507,2 @@
+     202	SCOPE_ENTER value x4
+-    202	JUMP 4
 -    
 -  4: 
-     212	LOAD_LOCAL(value x4)
-@@ -1411,8 +1498,5 @@
-     212	SCOPE_ENTER value x5
--    212	LOAD_LOCAL(value x5)
--    212	CALL_METHOD MyException.message (dynamic)
--    212	STORE_LOCAL(value message)
--    212	SCOPE_ENTER value message
-     213	LOAD_MODULE object Predef
--    213	LOAD_LOCAL(value message)
+     214	LOAD_LOCAL(value x4)
+@@ -1429,8 +1516,5 @@
+     214	SCOPE_ENTER value x5
+-    214	LOAD_LOCAL(value x5)
+-    214	CALL_METHOD MyException.message (dynamic)
+-    214	STORE_LOCAL(value message)
+-    214	SCOPE_ENTER value message
+     215	LOAD_MODULE object Predef
+-    215	LOAD_LOCAL(value message)
 +    ?	LOAD_LOCAL(value x5)
-+    213	CALL_METHOD MyException.message (dynamic)
-     213	CALL_METHOD scala.Predef.println (dynamic)
-@@ -1460,3 +1544,3 @@
++    215	CALL_METHOD MyException.message (dynamic)
+     215	CALL_METHOD scala.Predef.println (dynamic)
+@@ -1478,3 +1562,3 @@
    startBlock: 1
 -  blocks: [1,2,3,4,5,7]
 +  blocks: [1,2,3,4,5,7,8]
    
-@@ -1484,4 +1568,11 @@
-     58	CALL_METHOD java.lang.IllegalArgumentException.<init> (static-instance)
--    58	THROW(IllegalArgumentException)
+@@ -1502,4 +1586,11 @@
+     60	CALL_METHOD java.lang.IllegalArgumentException.<init> (static-instance)
+-    60	THROW(IllegalArgumentException)
 +    ?	STORE_LOCAL(value e)
 +    ?	JUMP 8
      
 +  8: 
-+    62	LOAD_MODULE object Predef
-+    62	CONSTANT("RuntimeException")
-+    62	CALL_METHOD scala.Predef.println (dynamic)
-+    62	JUMP 2
++    64	LOAD_MODULE object Predef
++    64	CONSTANT("RuntimeException")
++    64	CALL_METHOD scala.Predef.println (dynamic)
++    64	JUMP 2
 +    
    7: 
-@@ -1533,3 +1624,3 @@
+@@ -1551,3 +1642,3 @@
    startBlock: 1
 -  blocks: [1,3,4]
 +  blocks: [1,3,4,5]
    
-@@ -1553,4 +1644,9 @@
-     229	CALL_METHOD MyException.<init> (static-instance)
--    229	THROW(MyException)
+@@ -1571,4 +1662,9 @@
+     231	CALL_METHOD MyException.<init> (static-instance)
+-    231	THROW(MyException)
 +    ?	JUMP 5
      
 +  5: 
 +    ?	LOAD_LOCAL(variable monitor1)
-+    228	MONITOR_EXIT
-+    228	THROW(Throwable)
++    230	MONITOR_EXIT
++    230	THROW(Throwable)
 +    
    3: 
-@@ -1559,3 +1655,3 @@
-     228	MONITOR_EXIT
+@@ -1577,3 +1673,3 @@
+     230	MONITOR_EXIT
 -    ?	THROW(Throwable)
-+    228	THROW(Throwable)
++    230	THROW(Throwable)
      
-@@ -1587,5 +1683,5 @@
+@@ -1605,5 +1701,5 @@
    def main(args: Array[String] (ARRAY[REF(class String)])): Unit {
 -  locals: value args, variable result, variable monitor2, variable monitorResult1
 +  locals: value exception$1, value args, variable result, variable monitor2, variable monitorResult1
@@ -471,9 +471,9 @@
 -  blocks: [1,3,4]
 +  blocks: [1,3,4,5]
    
-@@ -1612,4 +1708,12 @@
-     245	CALL_METHOD MyException.<init> (static-instance)
--    245	THROW(MyException)
+@@ -1630,4 +1726,12 @@
+     247	CALL_METHOD MyException.<init> (static-instance)
+-    247	THROW(MyException)
 +    ?	STORE_LOCAL(value exception$1)
 +    ?	DROP ConcatClass
 +    ?	LOAD_LOCAL(value exception$1)
@@ -481,12 +481,12 @@
      
 +  5: 
 +    ?	LOAD_LOCAL(variable monitor2)
-+    244	MONITOR_EXIT
-+    244	THROW(Throwable)
++    246	MONITOR_EXIT
++    246	THROW(Throwable)
 +    
    3: 
-@@ -1618,3 +1722,3 @@
-     244	MONITOR_EXIT
+@@ -1636,3 +1740,3 @@
+     246	MONITOR_EXIT
 -    ?	THROW(Throwable)
-+    244	THROW(Throwable)
++    246	THROW(Throwable)
      

--- a/test/files/run/inline-ex-handlers.scala
+++ b/test/files/run/inline-ex-handlers.scala
@@ -2,6 +2,8 @@ import scala.tools.partest.IcodeComparison
 
 object Test extends IcodeComparison {
   override def printIcodeAfterPhase = "inlinehandlers"
+
+  override def extraSettings = super.extraSettings + " -Yinline-handlers"
 }
 
 import scala.util.Random._

--- a/test/files/run/t6102.check
+++ b/test/files/run/t6102.check
@@ -21,12 +21,9 @@
 [running phase cleanup on t6102.scala]
 [running phase delambdafy on t6102.scala]
 [running phase icode on t6102.scala]
-#partest -optimise
 [running phase inliner on t6102.scala]
-[running phase inlinehandlers on t6102.scala]
 [running phase closelim on t6102.scala]
 [running phase constopt on t6102.scala]
-#partest
 [running phase dce on t6102.scala]
 [running phase jvm on icode]
 hello


### PR DESCRIPTION
Exception handler inlining is an optimization that’s hard to get right
(and in fact has open bugs) but that has questionable benefits. This
commit removes -inlineHandlers from being included under -optimize. If
there are no serious repercussions then the optimization may be entirely
removed later.
