### PR TITLE
SI-7984 Issue unchecked warning for type aliases

### DIFF
--- a/test/files/neg/t3692-new.check
+++ b/test/files/neg/t3692-new.check
@@ -1,10 +1,10 @@
-t3692-new.scala:14: warning: non-variable type argument Int in type pattern Map[Int,Int] is unchecked since it is eliminated by erasure
+t3692-new.scala:14: warning: non-variable type argument Int in type pattern scala.collection.immutable.Map[Int,Int] (the underlying of Map[Int,Int]) is unchecked since it is eliminated by erasure
       case m0: Map[Int, Int] => new java.util.HashMap[Integer, Integer]
                ^
-t3692-new.scala:15: warning: non-variable type argument Int in type pattern Map[Int,V] is unchecked since it is eliminated by erasure
+t3692-new.scala:15: warning: non-variable type argument Int in type pattern scala.collection.immutable.Map[Int,V] (the underlying of Map[Int,V]) is unchecked since it is eliminated by erasure
       case m1: Map[Int, V] => new java.util.HashMap[Integer, V]
                ^
-t3692-new.scala:16: warning: non-variable type argument Int in type pattern Map[T,Int] is unchecked since it is eliminated by erasure
+t3692-new.scala:16: warning: non-variable type argument Int in type pattern scala.collection.immutable.Map[T,Int] (the underlying of Map[T,Int]) is unchecked since it is eliminated by erasure
       case m2: Map[T, Int] => new java.util.HashMap[T, Integer]
                ^
 t3692-new.scala:15: warning: unreachable code

--- a/test/files/neg/t7984.check
+++ b/test/files/neg/t7984.check
@@ -1,0 +1,6 @@
+t7984.scala:4: warning: non-variable type argument Int in type pattern List[Int] (the underlying of Test.this.ListInt) is unchecked since it is eliminated by erasure
+    case is: ListInt => is.head
+             ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/t7984.flags
+++ b/test/files/neg/t7984.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/t7984.scala
+++ b/test/files/neg/t7984.scala
@@ -1,0 +1,7 @@
+class Test {
+  type ListInt = List[Int]
+  List[Any]("") match {
+    case is: ListInt => is.head
+    case _ =>
+  }
+}

--- a/test/files/neg/unchecked-suppress.check
+++ b/test/files/neg/unchecked-suppress.check
@@ -1,7 +1,7 @@
-unchecked-suppress.scala:4: warning: non-variable type argument Int in type pattern Set[Int] is unchecked since it is eliminated by erasure
+unchecked-suppress.scala:4: warning: non-variable type argument Int in type pattern scala.collection.immutable.Set[Int] (the underlying of Set[Int]) is unchecked since it is eliminated by erasure
     case xs: Set[Int]                              => xs.head   // unchecked
              ^
-unchecked-suppress.scala:5: warning: non-variable type argument String in type pattern Map[String @unchecked,String] is unchecked since it is eliminated by erasure
+unchecked-suppress.scala:5: warning: non-variable type argument String in type pattern scala.collection.immutable.Map[String @unchecked,String] (the underlying of Map[String @unchecked,String]) is unchecked since it is eliminated by erasure
     case xs: Map[String @unchecked, String]        => xs.head   // one unchecked, one okay
              ^
 unchecked-suppress.scala:7: warning: non-variable type argument Int in type pattern (Int, Int) => Int is unchecked since it is eliminated by erasure

--- a/test/files/neg/unchecked.check
+++ b/test/files/neg/unchecked.check
@@ -1,10 +1,10 @@
-unchecked.scala:18: warning: non-variable type argument String in type pattern Iterable[String] is unchecked since it is eliminated by erasure
+unchecked.scala:18: warning: non-variable type argument String in type pattern Iterable[String] (the underlying of Iterable[String]) is unchecked since it is eliminated by erasure
     case xs: Iterable[String] => xs.head // unchecked
              ^
-unchecked.scala:22: warning: non-variable type argument Any in type pattern Set[Any] is unchecked since it is eliminated by erasure
+unchecked.scala:22: warning: non-variable type argument Any in type pattern scala.collection.immutable.Set[Any] (the underlying of Set[Any]) is unchecked since it is eliminated by erasure
     case xs: Set[Any] => xs.head // unchecked
              ^
-unchecked.scala:26: warning: non-variable type argument Any in type pattern Map[Any,Any] is unchecked since it is eliminated by erasure
+unchecked.scala:26: warning: non-variable type argument Any in type pattern scala.collection.immutable.Map[Any,Any] (the underlying of Map[Any,Any]) is unchecked since it is eliminated by erasure
     case xs: Map[Any, Any] => xs.head // unchecked
              ^
 unchecked.scala:35: warning: non-variable type argument List[Nothing] in type pattern Test.Contra[List[Nothing]] is unchecked since it is eliminated by erasure

--- a/test/files/neg/unchecked3.check
+++ b/test/files/neg/unchecked3.check
@@ -31,7 +31,7 @@ unchecked3.scala:62: warning: non-variable type argument Array[String] in type p
 unchecked3.scala:63: warning: non-variable type argument String in type pattern Array[Array[List[String]]] is unchecked since it is eliminated by erasure
     /*   warn */ case _: Array[Array[List[String]]] => ()
                          ^
-unchecked3.scala:75: warning: abstract type A in type pattern Set[Q.this.A] is unchecked since it is eliminated by erasure
+unchecked3.scala:75: warning: abstract type A in type pattern scala.collection.immutable.Set[Q.this.A] (the underlying of Set[Q.this.A]) is unchecked since it is eliminated by erasure
       /*   warn */ case xs: Set[A]  => xs.head
                             ^
 unchecked3.scala:62: warning: unreachable code


### PR DESCRIPTION
The unchecked nature of the type test was already noticed,
but because the type alias tripped up in rendering a sensible
message `CheckabilityChecker` chose to remain silent, other
than under `-Xdev.`

This commit:
- Dealiases pattern types before launching the CheckabilityChecker
- Sharpens the error messages to explain that the dealiased type
  is the expansion of the alias.
