### PR TITLE
SI-7985 Allow qualified type argument in patterns

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1774,10 +1774,12 @@ self =>
             in.nextToken()
             if (in.token == SUBTYPE || in.token == SUPERTYPE) wildcardType(start)
             else atPos(start) { Bind(tpnme.WILDCARD, EmptyTree) }
-          case IDENTIFIER if nme.isVariableName(in.name) && lookingAhead(in.token != DOT && in.token != HASH) =>
-            atPos(start) { Bind(identForType(), EmptyTree) }
           case _ =>
-            typ()
+            typ() match {
+              case Ident(name: TypeName) if nme.isVariableName(name) =>
+                atPos(start) { Bind(name, EmptyTree) }
+              case t => t
+            }
         }
       }
 

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1774,7 +1774,7 @@ self =>
             in.nextToken()
             if (in.token == SUBTYPE || in.token == SUPERTYPE) wildcardType(start)
             else atPos(start) { Bind(tpnme.WILDCARD, EmptyTree) }
-          case IDENTIFIER if nme.isVariableName(in.name) && lookingAhead(in.token != DOT) =>
+          case IDENTIFIER if nme.isVariableName(in.name) && lookingAhead(in.token != DOT && in.token != HASH) =>
             atPos(start) { Bind(identForType(), EmptyTree) }
           case _ =>
             typ()

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1774,7 +1774,7 @@ self =>
             in.nextToken()
             if (in.token == SUBTYPE || in.token == SUPERTYPE) wildcardType(start)
             else atPos(start) { Bind(tpnme.WILDCARD, EmptyTree) }
-          case IDENTIFIER if nme.isVariableName(in.name) =>
+          case IDENTIFIER if nme.isVariableName(in.name) && lookingAhead(in.token != DOT) =>
             atPos(start) { Bind(identForType(), EmptyTree) }
           case _ =>
             typ()

--- a/test/files/run/t7985.scala
+++ b/test/files/run/t7985.scala
@@ -1,0 +1,3 @@
+object Test extends App {
+  Array(1) match { case _: Array[scala.Int] => }
+}

--- a/test/files/run/t7985b.scala
+++ b/test/files/run/t7985b.scala
@@ -1,0 +1,5 @@
+class a { type X = Int }
+
+object Test extends App {
+  Array(1) match { case _: Array[a#X] => }
+}


### PR DESCRIPTION
We were considering the lower case `s` in `case _: Array[scala.Int]`
as a sign that we were dealing with a type variable pattern.

Now, we only do this if a lookahead confirms the absense of a the `.`

Review by @densh
