### PR TITLE
Fixed two grammar mistakes.

### DIFF
--- a/src/library/scala/concurrent/impl/Promise.scala
+++ b/src/library/scala/concurrent/impl/Promise.scala
@@ -82,10 +82,10 @@ private[concurrent] object Promise {
    *  2. Complete, with a result.
    *  3. Linked to another DefaultPromise.
    *
-   *  If a DefaultPromise is linked it another DefaultPromise then it will
+   *  If a DefaultPromise is linked to another DefaultPromise then it will
    *  delegate all its operations to that other promise. This means that two
    *  DefaultPromises that are linked will appear, to external callers, to have
-   *  exactly the same state and behaviour. E.g. they will both appear to be
+   *  exactly the same state and behaviour. I.e. they will both appear to be
    *  either complete or incomplete, and with the same values.
    *
    *  A DefaultPromise stores its state entirely in the AnyRef cell exposed by


### PR DESCRIPTION
First was clearly just a typo, second was using e.g. ("exepli gratia" or "for example) when it should be using i.e. ("id est" or "that is")
