### PR TITLE
Unifying -Ydelambdafy:{inline, method}

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/TreeGen.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeGen.scala
@@ -256,4 +256,44 @@ abstract class TreeGen extends scala.reflect.internal.TreeGen with TreeDSL {
     val stats1 = if (stats.isEmpty) List(Literal(Constant(()))) else stats
     mkNew(Nil, noSelfType, stats1, NoPosition, NoPosition)
   }
+
+  /**
+   * Create a method based on a Function
+   *
+   * Used both to under `-Ydelambdafy:method` create a lifted function and
+   * under `-Ydelamdafy:inline` to create the apply method on the anonymous
+   * class.
+   *
+   * It creates a method definition with value params cloned from the
+   * original lambda. Then it calls a supplied function to create
+   * the body and types the result. Finally
+   * everything is wrapped up in a DefDef
+   *
+   * @param owner The owner for the new method
+   * @param name name for the new method
+   * @param additionalFlags flags to be put on the method in addition to FINAL
+   */
+  def mkMethodFromFunction(localTyper: analyzer.Typer)
+                          (fun: Function, owner: Symbol, name: TermName, additionalFlags: FlagSet = NoFlags) = {
+    val funParams = fun.vparams map (_.symbol)
+    val formals :+ restpe = fun.tpe.typeArgs
+
+    val methSym = owner.newMethod(name, fun.pos, FINAL | additionalFlags)
+
+    val paramSyms = map2(formals, fun.vparams) {
+      (tp, vparam) => methSym.newSyntheticValueParam(tp, vparam.name)
+    }
+
+    methSym setInfo MethodType(paramSyms, restpe.deconst)
+
+    fun.body.substituteSymbols(funParams, paramSyms)
+    fun.body changeOwner (fun.symbol -> methSym)
+
+    val methDef = DefDef(methSym, fun.body)
+
+    // Have to repack the type to avoid mismatches when existentials
+    // appear in the result - see SI-4869.
+    methDef.tpt setType localTyper.packedType(fun.body, methSym).deconst
+    methDef
+  }
 }

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -232,11 +232,11 @@ abstract class UnCurry extends InfoTransform
               }
               methSym setInfoAndEnter MethodType(paramSyms, restpe)
 
-              fun.vparams foreach  (_.symbol.owner =  methSym)
-              fun.body changeOwner (fun.symbol     -> methSym)
+              fun.body changeOwner (fun.symbol -> methSym)
+              fun.body substituteSymbols (fun.vparams.map(_.symbol), paramSyms)
 
               val body    = typedFunPos(fun.body)
-              val methDef = DefDef(methSym, List(fun.vparams), body)
+              val methDef = DefDef(methSym, body)
 
               // Have to repack the type to avoid mismatches when existentials
               // appear in the result - see SI-4869.

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -217,14 +217,14 @@ abstract class UnCurry extends InfoTransform
         // nullary or parameterless
         case fun1 if fun1 ne fun => fun1
         case _ =>
-          val parents = addSerializable(abstractFunctionForFunctionType(fun.tpe))
-          val anonClass = fun.symbol.owner newAnonymousFunctionClass(fun.pos, inConstructorFlag) addAnnotation SerialVersionUIDAnnotation
-          anonClass setInfo ClassInfoType(parents, newScope, anonClass)
+          val formals :+ restpe = fun.tpe.typeArgs
 
-          val targs     = fun.tpe.typeArgs
-          val (formals, restpe) = (targs.init, targs.last)
+          def typedFunPos(t: Tree) = localTyper.typedPos(fun.pos)(t)
 
           if (inlineFunctionExpansion) {
+            val parents = addSerializable(abstractFunctionForFunctionType(fun.tpe))
+            val anonClass = fun.symbol.owner newAnonymousFunctionClass(fun.pos, inConstructorFlag) addAnnotation SerialVersionUIDAnnotation
+            anonClass setInfo ClassInfoType(parents, newScope, anonClass)
             val applyMethodDef = {
               val methSym = anonClass.newMethod(nme.apply, fun.pos, FINAL)
               val paramSyms = map2(formals, fun.vparams) {
@@ -235,7 +235,7 @@ abstract class UnCurry extends InfoTransform
               fun.vparams foreach  (_.symbol.owner =  methSym)
               fun.body changeOwner (fun.symbol     -> methSym)
 
-              val body    = localTyper.typedPos(fun.pos)(fun.body)
+              val body    = typedFunPos(fun.body)
               val methDef = DefDef(methSym, List(fun.vparams), body)
 
               // Have to repack the type to avoid mismatches when existentials
@@ -244,7 +244,7 @@ abstract class UnCurry extends InfoTransform
               methDef
             }
 
-            localTyper.typedPos(fun.pos) {
+            typedFunPos {
               Block(
                 List(ClassDef(anonClass, NoMods, ListOfNil, List(applyMethodDef), fun.pos)),
                 Typed(New(anonClass.tpe), TypeTree(fun.tpe)))
@@ -270,23 +270,17 @@ abstract class UnCurry extends InfoTransform
              * @bodyF function that turns the method symbol and list of value params
              *        into a body for the method
              */
-            def createMethod(owner: Symbol, name: TermName, additionalFlags: Long)(bodyF: (Symbol, List[ValDef]) => Tree) = {
+            def createMethod(owner: Symbol, name: TermName, additionalFlags: Long)(bodyF: Symbol => Tree) = {
               val methSym = owner.newMethod(name, fun.pos, FINAL | additionalFlags)
-              val vparams = fun.vparams map (_.duplicate)
 
-              val paramSyms = map2(formals, vparams) {
+              val paramSyms = map2(formals, fun.vparams) {
                 (tp, vparam) => methSym.newSyntheticValueParam(tp, vparam.name)
               }
-              foreach2(vparams, paramSyms){(valdef, sym) => valdef.symbol = sym}
-              vparams foreach (_.symbol.owner = methSym)
 
-              val methodType = MethodType(paramSyms, restpe.deconst)
-              methSym setInfo methodType
+              methSym setInfo MethodType(paramSyms, restpe.deconst)
 
-              // TODO this is probably cleaner if bodyF only works with symbols rather than parameter ValDefs
-              val tempBody = bodyF(methSym, vparams)
-              val body = localTyper.typedPos(fun.pos)(tempBody)
-              val methDef = DefDef(methSym, List(vparams), body)
+              val body = typedFunPos(bodyF(methSym))
+              val methDef = DefDef(methSym, body)
 
               // Have to repack the type to avoid mismatches when existentials
               // appear in the result - see SI-4869.
@@ -294,35 +288,19 @@ abstract class UnCurry extends InfoTransform
               methDef
             }
 
-            val methodFlags = ARTIFACT
+            val funParams = fun.vparams map (_.symbol)
             // method definition with the same arguments, return type, and body as the original lambda
-            val liftedMethod = createMethod(fun.symbol.owner, tpnme.ANON_FUN_NAME.toTermName, methodFlags){
-              case(methSym, vparams) =>
-                fun.body.substituteSymbols(fun.vparams map (_.symbol), vparams map (_.symbol))
+            val liftedMethod = createMethod(fun.symbol.owner, nme.ANON_FUN_NAME, additionalFlags = ARTIFACT) {
+              methSym =>
+                fun.body.substituteSymbols(funParams, methSym.paramss.head)
                 fun.body changeOwner (fun.symbol -> methSym)
             }
 
-            // callsite for the lifted method
-            val args = fun.vparams map { vparam =>
-              val ident = Ident(vparam.symbol)
-              // if -Yeta-expand-keeps-star is turned on then T* types can get through. In order
-              // to forward them we need to forward x: T* ascribed as "x:_*"
-              if (settings.etaExpandKeepsStar && definitions.isRepeatedParamType(vparam.tpt.tpe))
-                gen.wildcardStar(ident)
-              else
-                ident
-            }
-
-            val funTyper = localTyper.typedPos(fun.pos) _
-
-            val liftedMethodCall = funTyper(Apply(liftedMethod.symbol, args:_*))
-
             // new function whose body is just a call to the lifted method
-            val newFun = treeCopy.Function(fun, fun.vparams, liftedMethodCall)
-            funTyper(Block(
-             List(funTyper(liftedMethod)),
-               super.transform(newFun)
-             ))
+            val newFun = deriveFunction(fun)(_ => typedFunPos(
+              gen.mkForwarder(gen.mkAttributedRef(liftedMethod.symbol), funParams :: Nil)
+            ))
+            typedFunPos(Block(liftedMethod, super.transform(newFun)))
           }
         }
     }

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -590,7 +590,7 @@ trait Trees extends api.Trees {
   def TypeTree(tp: Type): TypeTree = TypeTree() setType tp
   private def TypeTreeMemberType(sym: Symbol): TypeTree = {
     // Needed for pos/t4970*.scala. See SI-7853
-    val resType = (sym.owner.thisType memberType sym).finalResultType
+    val resType = (if (sym.isLocal) sym.tpe else (sym.owner.thisType memberType sym)).finalResultType
     atPos(sym.pos.focus)(TypeTree(resType))
   }
 

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -1804,6 +1804,12 @@ trait Trees extends api.Trees {
     case t =>
       sys.error("Not a LabelDef: " + t + "/" + t.getClass)
   }
+  def deriveFunction(func: Tree)(applyToRhs: Tree => Tree): Function = func match {
+    case Function(params0, rhs0) =>
+      treeCopy.Function(func, params0, applyToRhs(rhs0))
+    case t =>
+      sys.error("Not a Function: " + t + "/" + t.getClass)
+  }
 
 // -------------- Classtags --------------------------------------------------------
 

--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -717,6 +717,12 @@ private[internal] trait TypeMaps {
           else appliedType(tcon.typeConstructor, args)
         case SingleType(NoPrefix, sym) =>
           substFor(sym)
+        case ClassInfoType(parents, decls, sym) =>
+          val parents1 = parents mapConserve this
+          // We don't touch decls here; they will be touched when an enclosing TreeSubstitutor
+          // transforms the tree that defines them.
+          if (parents1 eq parents) tp
+          else ClassInfoType(parents1, decls, sym)
         case _ =>
           tp
       }

--- a/test/files/run/delambdafy-dependent-on-param-subst-2.scala
+++ b/test/files/run/delambdafy-dependent-on-param-subst-2.scala
@@ -1,0 +1,20 @@
+trait M[-X] {
+  def m(x: X): Boolean
+}
+
+class C
+class A { class C }
+
+object Test {
+  def main(args: Array[String]) {
+    val a = new A
+
+    // class O extends M[a.C] { def m(x: a.C) = true }
+    // (new O: M[Null]).m(null) // Okay
+
+    ((a: A) => {
+      class N extends M[a.C] { def m(x: a.C) = true }
+      new N: M[Null]
+    }).apply(a).m(null) // NPE, missing bridge
+  }
+}

--- a/test/files/run/delambdafy-dependent-on-param-subst.flags
+++ b/test/files/run/delambdafy-dependent-on-param-subst.flags
@@ -1,0 +1,1 @@
+-Ydelambdafy:method

--- a/test/files/run/delambdafy-dependent-on-param-subst.scala
+++ b/test/files/run/delambdafy-dependent-on-param-subst.scala
@@ -1,0 +1,20 @@
+trait M[-X] {
+  def m(x: X): Boolean
+}
+
+class C
+class A { class C }
+
+object Test {
+  def main(args: Array[String]) {
+    val a = new A
+
+    // class O extends M[a.C] { def m(x: a.C) = true }
+    // (new O: M[Null]).m(null) // Okay
+
+    ((a: A) => {
+      class N extends M[a.C] { def m(x: a.C) = true }
+      new N: M[Null]
+    }).apply(a).m(null) // NPE, missing bridge
+  }
+}

--- a/test/files/run/value-class-partial-func-depmet.scala
+++ b/test/files/run/value-class-partial-func-depmet.scala
@@ -1,0 +1,24 @@
+class C
+class A { class C }
+
+object Test {
+  def main(args: Array[String]) {
+    val a = new A
+
+    new VC("").foo(a)
+  }
+}
+
+class VC(val a: Any) extends AnyVal {
+   def foo(a: A) = {
+     val pf: PartialFunction[a.C, Any] = { case x => x }
+     (pf: PartialFunction[Null, Any]).isDefinedAt(null)
+   }
+}
+
+// 2.11.0-M6
+// test/files/run/value-class-partial-func-depmet.scala:14: error: overriding method applyOrElse in trait PartialFunction of type [A1 <: a.C, B1 >: Any](x: A1, default: A1 => B1)B1;
+//  method applyOrElse has incompatible type
+//      val pf: PartialFunction[a.C, Any] = { case x => x }
+//                                          ^
+// one error found


### PR DESCRIPTION
Avoid code duplication and use a common approach for
symbol substituion.

I asked Martin "why did the apply method just reuse the parameter symbols
of the lambda verbatim", to which he suggested at the time substitution
wasn't up to scratch to risk anything more principled.

Turns out it still isn't, but I've taken steps to remedy that
in this incarnation of the pull request.
