### PR TITLE
Backport of SI-7280

### DIFF
--- a/src/compiler/scala/tools/nsc/interactive/tests/InteractiveTest.scala
+++ b/src/compiler/scala/tools/nsc/interactive/tests/InteractiveTest.scala
@@ -69,7 +69,7 @@ abstract class InteractiveTest
    *  Override this member if you need to change the default set of executed test actions.
    */
   protected lazy val testActions: ListBuffer[PresentationCompilerTestDef] = {
-    ListBuffer(new CompletionAction(compiler), new TypeAction(compiler), new HyperlinkAction(compiler))
+    ListBuffer(new TypeCompletionAction(compiler), new ScopeCompletionAction(compiler), new TypeAction(compiler), new HyperlinkAction(compiler))
   }
 
   /** Add new presentation compiler actions to test. Presentation compiler's test

--- a/src/compiler/scala/tools/nsc/interactive/tests/core/AskCommand.scala
+++ b/src/compiler/scala/tools/nsc/interactive/tests/core/AskCommand.scala
@@ -42,7 +42,7 @@ trait AskParse extends AskCommand {
   import compiler.Tree
 
   /** `sources` need to be entirely parsed before running the test
-   *  (else commands such as `AskCompletionAt` may fail simply because
+   *  (else commands such as `AskTypeCompletionAt` may fail simply because
    *  the source's AST is not yet loaded).
    */
   def askParse(sources: Seq[SourceFile]) {
@@ -72,14 +72,27 @@ trait AskReload extends AskCommand {
 }
 
 /** Ask the presentation compiler for completion at a given position. */
-trait AskCompletionAt extends AskCommand {
+trait AskTypeCompletionAt extends AskCommand {
   import compiler.Member
 
-  private[tests] def askCompletionAt(pos: Position)(implicit reporter: Reporter): Response[List[Member]] = {
+  private[tests] def askTypeCompletionAt(pos: Position)(implicit reporter: Reporter): Response[List[Member]] = {
     reporter.println("\naskTypeCompletion at " + pos.source.file.name + ((pos.line, pos.column)))
 
     ask {
       compiler.askTypeCompletion(pos, _)
+    }
+  }
+}
+
+/** Ask the presentation compiler for scope completion at a given position. */
+trait AskScopeCompletionAt extends AskCommand {
+  import compiler.Member
+
+  private[tests] def askScopeCompletionAt(pos: Position)(implicit reporter: Reporter): Response[List[Member]] = {
+    reporter.println("\naskScopeCompletion at " + pos.source.file.name + ((pos.line, pos.column)))
+
+    ask {
+      compiler.askScopeCompletion(pos, _)
     }
   }
 }

--- a/src/compiler/scala/tools/nsc/interactive/tests/core/CoreTestDefs.scala
+++ b/src/compiler/scala/tools/nsc/interactive/tests/core/CoreTestDefs.scala
@@ -13,19 +13,19 @@ private[tests] trait CoreTestDefs
 
   /** Ask the presentation compiler for completion at all locations
    * (in all sources) where the defined `marker` is found. */
-  class CompletionAction(override val compiler: Global)
+  class TypeCompletionAction(override val compiler: Global)
     extends PresentationCompilerTestDef
-    with AskCompletionAt {
+    with AskTypeCompletionAt {
 
     def memberPrinter(member: compiler.Member): String =
         "[accessible: %5s] ".format(member.accessible) + "`" + (member.sym.toString() + member.tpe.toString()).trim() + "`"
 
     override def runTest() {
-      askAllSources(CompletionMarker) { pos =>
-        askCompletionAt(pos)
+      askAllSources(TypeCompletionMarker) { pos =>
+        askTypeCompletionAt(pos)
       } { (pos, members) =>
         withResponseDelimiter {
-          reporter.println("[response] aksTypeCompletion at " + format(pos))
+          reporter.println("[response] askTypeCompletion at " + format(pos))
           // we skip getClass because it changed signature between 1.5 and 1.6, so there is no
           // universal check file that we can provide for this to work
           reporter.println("retrieved %d members".format(members.size))
@@ -33,6 +33,39 @@ private[tests] trait CoreTestDefs
             val filtered = members.filterNot(member => member.sym.name.toString == "getClass" || member.sym.isConstructor)
             reporter.println(filtered.map(memberPrinter).sortBy(_.toString()).mkString("\n"))
           }
+        }
+      }
+    }
+  }
+
+  /** Ask the presentation compiler for completion at all locations
+   * (in all sources) where the defined `marker` is found. */
+  class ScopeCompletionAction(override val compiler: Global)
+    extends PresentationCompilerTestDef
+    with AskScopeCompletionAt {
+
+    def memberPrinter(member: compiler.Member): String =
+        "[accessible: %5s] ".format(member.accessible) + "`" + (member.sym.toString() + member.tpe.toString()).trim() + "`"
+
+    override def runTest() {
+      askAllSources(ScopeCompletionMarker) { pos =>
+        askScopeCompletionAt(pos)
+      } { (pos, members) =>
+        withResponseDelimiter {
+          reporter.println("[response] askScopeCompletion at " + format(pos))
+          try {
+            // exclude members not from source (don't have position), for more focussed and self contained tests.
+            def eligible(sym: compiler.Symbol) = sym.pos != compiler.NoPosition
+            val filtered = members.filter(member => eligible(member.sym))
+            reporter.println("retrieved %d members".format(filtered.size))
+            compiler ask { () =>
+              reporter.println(filtered.map(memberPrinter).sortBy(_.toString()).mkString("\n"))
+            }
+          } catch {
+            case t: Throwable =>
+              t.printStackTrace()
+          }
+
         }
       }
     }
@@ -61,7 +94,7 @@ private[tests] trait CoreTestDefs
   class HyperlinkAction(override val compiler: Global)
     extends PresentationCompilerTestDef
     with AskTypeAt
-    with AskCompletionAt {
+    with AskTypeCompletionAt {
 
     override def runTest() {
       askAllSources(HyperlinkMarker) { pos =>

--- a/src/compiler/scala/tools/nsc/interactive/tests/core/TestMarker.scala
+++ b/src/compiler/scala/tools/nsc/interactive/tests/core/TestMarker.scala
@@ -20,7 +20,9 @@ abstract case class TestMarker(val marker: String) {
   TestMarker.checkForDuplicate(this)
 }
 
-object CompletionMarker extends TestMarker("/*!*/")
+object TypeCompletionMarker extends TestMarker("/*!*/")
+
+object ScopeCompletionMarker extends TestMarker("/*_*/")
 
 object TypeMarker extends TestMarker("/*?*/")
 

--- a/test/files/presentation/callcc-interpreter.check
+++ b/test/files/presentation/callcc-interpreter.check
@@ -2,7 +2,7 @@ reload: CallccInterpreter.scala
 
 askTypeCompletion at CallccInterpreter.scala(51,38)
 ================================================================================
-[response] aksTypeCompletion at (51,38)
+[response] askTypeCompletion at (51,38)
 retrieved 64 members
 [accessible:  true] `class AddcallccInterpreter.Add`
 [accessible:  true] `class AppcallccInterpreter.App`

--- a/test/files/presentation/completion-implicit-chained.check
+++ b/test/files/presentation/completion-implicit-chained.check
@@ -2,7 +2,7 @@ reload: Completions.scala
 
 askTypeCompletion at Completions.scala(11,16)
 ================================================================================
-[response] aksTypeCompletion at (11,16)
+[response] askTypeCompletion at (11,16)
 retrieved 24 members
 [accessible:  true] `method !=(x$1: Any)Boolean`
 [accessible:  true] `method !=(x$1: AnyRef)Boolean`

--- a/test/files/presentation/ide-bug-1000349.check
+++ b/test/files/presentation/ide-bug-1000349.check
@@ -2,7 +2,7 @@ reload: CompletionOnEmptyArgMethod.scala
 
 askTypeCompletion at CompletionOnEmptyArgMethod.scala(2,17)
 ================================================================================
-[response] aksTypeCompletion at (2,17)
+[response] askTypeCompletion at (2,17)
 retrieved 37 members
 [accessible:  true] `method !=(x$1: Any)Boolean`
 [accessible:  true] `method !=(x$1: AnyRef)Boolean`

--- a/test/files/presentation/ide-bug-1000475.check
+++ b/test/files/presentation/ide-bug-1000475.check
@@ -2,7 +2,7 @@ reload: Foo.scala
 
 askTypeCompletion at Foo.scala(3,7)
 ================================================================================
-[response] aksTypeCompletion at (3,7)
+[response] askTypeCompletion at (3,7)
 retrieved 36 members
 [accessible:  true] `method !=(x$1: Any)Boolean`
 [accessible:  true] `method !=(x$1: AnyRef)Boolean`
@@ -40,7 +40,7 @@ retrieved 36 members
 
 askTypeCompletion at Foo.scala(6,10)
 ================================================================================
-[response] aksTypeCompletion at (6,10)
+[response] askTypeCompletion at (6,10)
 retrieved 36 members
 [accessible:  true] `method !=(x$1: Any)Boolean`
 [accessible:  true] `method !=(x$1: AnyRef)Boolean`
@@ -78,7 +78,7 @@ retrieved 36 members
 
 askTypeCompletion at Foo.scala(7,7)
 ================================================================================
-[response] aksTypeCompletion at (7,7)
+[response] askTypeCompletion at (7,7)
 retrieved 36 members
 [accessible:  true] `method !=(x$1: Any)Boolean`
 [accessible:  true] `method !=(x$1: AnyRef)Boolean`

--- a/test/files/presentation/ide-bug-1000531.check
+++ b/test/files/presentation/ide-bug-1000531.check
@@ -2,7 +2,7 @@ reload: CrashOnLoad.scala
 
 askTypeCompletion at CrashOnLoad.scala(6,12)
 ================================================================================
-[response] aksTypeCompletion at (6,12)
+[response] askTypeCompletion at (6,12)
 retrieved 126 members
 [accessible:  true] `class GroupedIteratorIterator[B]#GroupedIterator`
 [accessible:  true] `method !=(x$1: Any)Boolean`

--- a/test/files/presentation/implicit-member.check
+++ b/test/files/presentation/implicit-member.check
@@ -2,7 +2,7 @@ reload: ImplicitMember.scala
 
 askTypeCompletion at ImplicitMember.scala(7,7)
 ================================================================================
-[response] aksTypeCompletion at (7,7)
+[response] askTypeCompletion at (7,7)
 retrieved 39 members
 [accessible:  true] `class AppliedImplicitImplicit.AppliedImplicit`
 [accessible:  true] `method !=(x$1: Any)Boolean`

--- a/test/files/presentation/ping-pong.check
+++ b/test/files/presentation/ping-pong.check
@@ -2,7 +2,7 @@ reload: PingPong.scala
 
 askTypeCompletion at PingPong.scala(10,23)
 ================================================================================
-[response] aksTypeCompletion at (10,23)
+[response] askTypeCompletion at (10,23)
 retrieved 40 members
 [accessible:  true] `method !=(x$1: Any)Boolean`
 [accessible:  true] `method !=(x$1: AnyRef)Boolean`
@@ -43,7 +43,7 @@ retrieved 40 members
 
 askTypeCompletion at PingPong.scala(19,20)
 ================================================================================
-[response] aksTypeCompletion at (19,20)
+[response] askTypeCompletion at (19,20)
 retrieved 40 members
 [accessible:  true] `method !=(x$1: Any)Boolean`
 [accessible:  true] `method !=(x$1: AnyRef)Boolean`

--- a/test/files/presentation/scope-completion-1.check
+++ b/test/files/presentation/scope-completion-1.check
@@ -1,0 +1,19 @@
+reload: Completions.scala
+
+askScopeCompletion at Completions.scala(6,2)
+================================================================================
+[response] askScopeCompletion at (6,2)
+retrieved 3 members
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `constructor Completion1()test.Completion1`
+[accessible:  true] `object Completion2test.Completion2.type`
+================================================================================
+
+askScopeCompletion at Completions.scala(10,2)
+================================================================================
+[response] askScopeCompletion at (10,2)
+retrieved 3 members
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `constructor Completion2()test.Completion2.type`
+[accessible:  true] `object Completion2test.Completion2.type`
+================================================================================

--- a/test/files/presentation/scope-completion-1/Test.scala
+++ b/test/files/presentation/scope-completion-1/Test.scala
@@ -1,0 +1,3 @@
+import scala.tools.nsc.interactive.tests.InteractiveTest
+
+object Test extends InteractiveTest

--- a/test/files/presentation/scope-completion-1/src/Completions.scala
+++ b/test/files/presentation/scope-completion-1/src/Completions.scala
@@ -1,0 +1,12 @@
+package test
+
+/* completion on empty class and object */
+
+class Completion1 {
+  /*_*/
+}
+
+object Completion2 {
+  /*_*/
+}
+

--- a/test/files/presentation/scope-completion-2.check
+++ b/test/files/presentation/scope-completion-2.check
@@ -1,0 +1,35 @@
+reload: Completions.scala
+
+askScopeCompletion at Completions.scala(16,4)
+================================================================================
+[response] askScopeCompletion at (16,4)
+retrieved 11 members
+[accessible:  true] `class Cc1Completion1.this.Cc1`
+[accessible:  true] `class Co1test.Completion1.Co1`
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `constructor Completion1()test.Completion1`
+[accessible:  true] `method fc1=> Int`
+[accessible:  true] `method fo1=> Int`
+[accessible:  true] `method test=> Unit`
+[accessible:  true] `object Completion1test.Completion1.type`
+[accessible:  true] `value ctest.Completion1`
+[accessible:  true] `value vc1Int`
+[accessible:  true] `value vo1Int`
+================================================================================
+
+askScopeCompletion at Completions.scala(32,4)
+================================================================================
+[response] askScopeCompletion at (32,4)
+retrieved 11 members
+[accessible:  true] `class Cc1test.Completion1.c.Cc1`
+[accessible:  true] `class Co1test.Completion1.Co1`
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `constructor Completion1()test.Completion1.type`
+[accessible:  true] `method fc1=> Int`
+[accessible:  true] `method fo1=> Int`
+[accessible:  true] `method test=> Unit`
+[accessible:  true] `object Completion1test.Completion1.type`
+[accessible:  true] `value ctest.Completion1`
+[accessible:  true] `value vo1Int`
+[accessible: false] `value vc1Int`
+================================================================================

--- a/test/files/presentation/scope-completion-2/Test.scala
+++ b/test/files/presentation/scope-completion-2/Test.scala
@@ -1,0 +1,3 @@
+import scala.tools.nsc.interactive.tests.InteractiveTest
+
+object Test extends InteractiveTest

--- a/test/files/presentation/scope-completion-2/src/Completions.scala
+++ b/test/files/presentation/scope-completion-2/src/Completions.scala
@@ -1,0 +1,35 @@
+package test
+
+/* private elements are visible in the companion class/object */
+
+class Completion1 {
+
+  import Completion1._
+
+  private val vc1 = 0
+  private def fc1 = 0
+
+  private class Cc1
+
+  def test {
+    // needs to be done in a method, because of SI-7280
+    /*_*/
+  }
+}
+
+object Completion1 {
+
+  val c = new Completion1()
+  import c._
+
+  private val vo1 = 0
+  private def fo1 = 0
+
+  private class Co1
+
+  def test {
+    // needs to be done in a method, because of SI-7280
+    /*_*/
+  }
+}
+

--- a/test/files/presentation/scope-completion-3.check
+++ b/test/files/presentation/scope-completion-3.check
@@ -1,0 +1,111 @@
+reload: Completions.scala
+
+askScopeCompletion at Completions.scala(75,2)
+================================================================================
+[response] askScopeCompletion at (75,2)
+retrieved 49 members
+[accessible:  true] `class Base1test.Base1`
+[accessible:  true] `class Cb1Completion1.this.Cb1`
+[accessible:  true] `class Cc1Completion1.this.Cc1`
+[accessible:  true] `class Cc2Completion1.this.Cc2`
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `class Ct1Completion1.this.Ct1`
+[accessible:  true] `constructor Completion1()test.Completion1`
+[accessible:  true] `method fb1=> Int`
+[accessible:  true] `method fb3=> Int`
+[accessible:  true] `method fc1=> Int`
+[accessible:  true] `method fc2=> Int`
+[accessible:  true] `method ft1=> Int`
+[accessible:  true] `method ft3=> Int`
+[accessible:  true] `object Completion2test.Completion2.type`
+[accessible:  true] `object Ob1Completion1.this.Ob1.type`
+[accessible:  true] `object Oc1Completion1.this.Oc1.type`
+[accessible:  true] `object Oc2Completion1.this.Oc2.type`
+[accessible:  true] `object Ot1Completion1.this.Ot1.type`
+[accessible:  true] `trait Trait1test.Trait1`
+[accessible:  true] `type tb1Completion1.this.tb1`
+[accessible:  true] `type tb3Completion1.this.tb3`
+[accessible:  true] `type tc1Completion1.this.tc1`
+[accessible:  true] `type tc2Completion1.this.tc2`
+[accessible:  true] `type tt1Completion1.this.tt1`
+[accessible:  true] `type tt3Completion1.this.tt3`
+[accessible:  true] `value vb3Int`
+[accessible:  true] `value vc1Int`
+[accessible:  true] `value vc2Int`
+[accessible:  true] `value vt3Int`
+[accessible:  true] `variable rb3Int`
+[accessible:  true] `variable rc1Int`
+[accessible:  true] `variable rc2Int`
+[accessible:  true] `variable rt3Int`
+[accessible: false] `class Cb2Completion1.this.Cb2`
+[accessible: false] `class Ct2Completion1.this.Ct2`
+[accessible: false] `method fb2=> Int`
+[accessible: false] `method ft2=> Int`
+[accessible: false] `object Ob2Completion1.this.Ob2.type`
+[accessible: false] `object Ot2Completion1.this.Ot2.type`
+[accessible: false] `type tb2Completion1.this.tb2`
+[accessible: false] `type tt2Completion1.this.tt2`
+[accessible: false] `value vb1Int`
+[accessible: false] `value vb2Int`
+[accessible: false] `value vt1Int`
+[accessible: false] `value vt2Int`
+[accessible: false] `variable rb1Int`
+[accessible: false] `variable rb2Int`
+[accessible: false] `variable rt1Int`
+[accessible: false] `variable rt2Int`
+================================================================================
+
+askScopeCompletion at Completions.scala(104,2)
+================================================================================
+[response] askScopeCompletion at (104,2)
+retrieved 49 members
+[accessible:  true] `class Base1test.Base1`
+[accessible:  true] `class Cb1test.Completion2.Cb1`
+[accessible:  true] `class Co1test.Completion2.Co1`
+[accessible:  true] `class Co2test.Completion2.Co2`
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `class Ct1test.Completion2.Ct1`
+[accessible:  true] `constructor Completion2()test.Completion2.type`
+[accessible:  true] `method fb1=> Int`
+[accessible:  true] `method fb3=> Int`
+[accessible:  true] `method fo1=> Int`
+[accessible:  true] `method fo2=> Int`
+[accessible:  true] `method ft1=> Int`
+[accessible:  true] `method ft3=> Int`
+[accessible:  true] `object Completion2test.Completion2.type`
+[accessible:  true] `object Ob1test.Completion2.Ob1.type`
+[accessible:  true] `object Oo1test.Completion2.Oo1.type`
+[accessible:  true] `object Oo2test.Completion2.Oo2.type`
+[accessible:  true] `object Ot1test.Completion2.Ot1.type`
+[accessible:  true] `trait Trait1test.Trait1`
+[accessible:  true] `type tb1test.Completion2.tb1`
+[accessible:  true] `type tb3test.Completion2.tb3`
+[accessible:  true] `type to1test.Completion2.to1`
+[accessible:  true] `type to2test.Completion2.to2`
+[accessible:  true] `type tt1test.Completion2.tt1`
+[accessible:  true] `type tt3test.Completion2.tt3`
+[accessible:  true] `value vb3Int`
+[accessible:  true] `value vo1Int`
+[accessible:  true] `value vo2Int`
+[accessible:  true] `value vt3Int`
+[accessible:  true] `variable rb3Int`
+[accessible:  true] `variable ro1Int`
+[accessible:  true] `variable ro2Int`
+[accessible:  true] `variable rt3Int`
+[accessible: false] `class Cb2test.Completion2.Cb2`
+[accessible: false] `class Ct2test.Completion2.Ct2`
+[accessible: false] `method fb2=> Int`
+[accessible: false] `method ft2=> Int`
+[accessible: false] `object Ob2test.Completion2.Ob2.type`
+[accessible: false] `object Ot2test.Completion2.Ot2.type`
+[accessible: false] `type tb2test.Completion2.tb2`
+[accessible: false] `type tt2test.Completion2.tt2`
+[accessible: false] `value vb1Int`
+[accessible: false] `value vb2Int`
+[accessible: false] `value vt1Int`
+[accessible: false] `value vt2Int`
+[accessible: false] `variable rb1Int`
+[accessible: false] `variable rb2Int`
+[accessible: false] `variable rt1Int`
+[accessible: false] `variable rt2Int`
+================================================================================

--- a/test/files/presentation/scope-completion-3/Test.scala
+++ b/test/files/presentation/scope-completion-3/Test.scala
@@ -1,0 +1,3 @@
+import scala.tools.nsc.interactive.tests.InteractiveTest
+
+object Test extends InteractiveTest

--- a/test/files/presentation/scope-completion-3/src/Completions.scala
+++ b/test/files/presentation/scope-completion-3/src/Completions.scala
@@ -1,0 +1,106 @@
+package test
+
+/* check availability of members defined locally and in hierachy */
+
+abstract class Base1 {
+
+  type tb1 = Int
+  val vb1 = 0
+  var rb1 = 0 
+  def fb1 = 0
+  class Cb1
+  object Ob1
+
+  private type tb2 = Int
+  private val vb2 = 0
+  private var rb2 = 0
+  private def fb2 = 0
+  private class Cb2
+  private object Ob2
+
+  type tb3
+  val vb3: Int
+  var rb3: Int
+  def fb3: Int
+}
+
+trait Trait1 {
+
+  type tt1 = Int
+  val vt1 = 0
+  var rt1 = 0
+  def ft1 = 0
+  class Ct1
+  object Ot1
+
+  private type tt2 = Int
+  private val vt2 = 0
+  private var rt2 = 0
+  private def ft2 = 0
+  private class Ct2
+  private object Ot2
+
+  type tt3
+  val vt3: Int
+  var rt3: Int
+  def ft3: Int
+}
+
+class Completion1 extends Base1 with Trait1 {
+
+  type tc1 = Int
+  val vc1 = 0
+  var rc1 = 0
+  def fc1 = 0
+  class Cc1
+  object Oc1
+
+  private type tc2 = Int
+  private val vc2 = 0
+  private var rc2 = 0
+  private def fc2 = 0
+  private class Cc2
+  private object Oc2
+
+  override type tb3 = Int
+  override val vb3 = 12
+  override var rb3 = 12
+  override def fb3 = 12
+  
+  override type tt3 = Int
+  override val vt3 = 12
+  override var rt3 = 12
+  override def ft3 = 12
+
+  /*_*/
+}
+
+object Completion2 extends Base1 with Trait1 {
+
+  type to1 = Int
+  val vo1 = 0
+  var ro1 = 0
+  def fo1 = 0
+  class Co1
+  object Oo1
+
+  private type to2 = Int
+  private val vo2 = 0
+  private var ro2 = 0
+  private def fo2 = 0
+  private class Co2
+  private object Oo2
+
+  override type tb3 = Int
+  override val vb3 = 12
+  override var rb3 = 12
+  override def fb3 = 12
+  
+  override type tt3 = Int
+  override val vt3 = 12
+  override var rt3 = 12
+  override def ft3 = 12
+  
+  /*_*/
+}
+

--- a/test/files/presentation/scope-completion-4.check
+++ b/test/files/presentation/scope-completion-4.check
@@ -1,0 +1,293 @@
+reload: Completions.scala
+
+askScopeCompletion at Completions.scala(12,8)
+================================================================================
+[response] askScopeCompletion at (12,8)
+retrieved 8 members
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `class cCompletion1.this.c`
+[accessible:  true] `class fcfc`
+[accessible:  true] `class ffcffc`
+[accessible:  true] `constructor Completion1()test.Completion1`
+[accessible:  true] `method f=> Unit`
+[accessible:  true] `method ff=> Unit`
+[accessible:  true] `method fff=> Unit`
+================================================================================
+
+askScopeCompletion at Completions.scala(15,6)
+================================================================================
+[response] askScopeCompletion at (15,6)
+retrieved 8 members
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `class cCompletion1.this.c`
+[accessible:  true] `class fcfc`
+[accessible:  true] `class ffcffc`
+[accessible:  true] `constructor Completion1()test.Completion1`
+[accessible:  true] `method f=> Unit`
+[accessible:  true] `method ff=> Unit`
+[accessible:  true] `method fff=> Unit`
+================================================================================
+
+askScopeCompletion at Completions.scala(18,8)
+================================================================================
+[response] askScopeCompletion at (18,8)
+retrieved 8 members
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `class cCompletion1.this.c`
+[accessible:  true] `class fcfc`
+[accessible:  true] `class ffcffc`
+[accessible:  true] `constructor ffc()ffc`
+[accessible:  true] `method f=> Unit`
+[accessible:  true] `method ff=> Unit`
+[accessible:  true] `method fff=> Unit`
+================================================================================
+
+askScopeCompletion at Completions.scala(21,6)
+================================================================================
+[response] askScopeCompletion at (21,6)
+retrieved 8 members
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `class cCompletion1.this.c`
+[accessible:  true] `class fcfc`
+[accessible:  true] `class ffcffc`
+[accessible:  true] `constructor Completion1()test.Completion1`
+[accessible:  true] `method f=> Unit`
+[accessible:  true] `method ff=> Unit`
+[accessible:  true] `method fff=> Unit`
+================================================================================
+
+askScopeCompletion at Completions.scala(24,4)
+================================================================================
+[response] askScopeCompletion at (24,4)
+retrieved 6 members
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `class cCompletion1.this.c`
+[accessible:  true] `class fcfc`
+[accessible:  true] `constructor Completion1()test.Completion1`
+[accessible:  true] `method f=> Unit`
+[accessible:  true] `method ff=> Unit`
+================================================================================
+
+askScopeCompletion at Completions.scala(29,8)
+================================================================================
+[response] askScopeCompletion at (29,8)
+retrieved 8 members
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `class cCompletion1.this.c`
+[accessible:  true] `class fccfc.this.fcc`
+[accessible:  true] `class fcfc`
+[accessible:  true] `constructor fc()fc`
+[accessible:  true] `method f=> Unit`
+[accessible:  true] `method fcf=> Unit`
+[accessible:  true] `method ff=> Unit`
+================================================================================
+
+askScopeCompletion at Completions.scala(32,6)
+================================================================================
+[response] askScopeCompletion at (32,6)
+retrieved 8 members
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `class cCompletion1.this.c`
+[accessible:  true] `class fccfc.this.fcc`
+[accessible:  true] `class fcfc`
+[accessible:  true] `constructor fc()fc`
+[accessible:  true] `method f=> Unit`
+[accessible:  true] `method fcf=> Unit`
+[accessible:  true] `method ff=> Unit`
+================================================================================
+
+askScopeCompletion at Completions.scala(35,8)
+================================================================================
+[response] askScopeCompletion at (35,8)
+retrieved 8 members
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `class cCompletion1.this.c`
+[accessible:  true] `class fccfc.this.fcc`
+[accessible:  true] `class fcfc`
+[accessible:  true] `constructor fcc()fc.this.fcc`
+[accessible:  true] `method f=> Unit`
+[accessible:  true] `method fcf=> Unit`
+[accessible:  true] `method ff=> Unit`
+================================================================================
+
+askScopeCompletion at Completions.scala(38,6)
+================================================================================
+[response] askScopeCompletion at (38,6)
+retrieved 8 members
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `class cCompletion1.this.c`
+[accessible:  true] `class fccfc.this.fcc`
+[accessible:  true] `class fcfc`
+[accessible:  true] `constructor fc()fc`
+[accessible:  true] `method f=> Unit`
+[accessible:  true] `method fcf=> Unit`
+[accessible:  true] `method ff=> Unit`
+================================================================================
+
+askScopeCompletion at Completions.scala(41,4)
+================================================================================
+[response] askScopeCompletion at (41,4)
+retrieved 6 members
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `class cCompletion1.this.c`
+[accessible:  true] `class fcfc`
+[accessible:  true] `constructor Completion1()test.Completion1`
+[accessible:  true] `method f=> Unit`
+[accessible:  true] `method ff=> Unit`
+================================================================================
+
+askScopeCompletion at Completions.scala(44,2)
+================================================================================
+[response] askScopeCompletion at (44,2)
+retrieved 4 members
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `class cCompletion1.this.c`
+[accessible:  true] `constructor Completion1()test.Completion1`
+[accessible:  true] `method f=> Unit`
+================================================================================
+
+askScopeCompletion at Completions.scala(51,8)
+================================================================================
+[response] askScopeCompletion at (51,8)
+retrieved 8 members
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `class cCompletion1.this.c`
+[accessible:  true] `class ccc.this.cc`
+[accessible:  true] `class ccccc.this.ccc`
+[accessible:  true] `constructor ccc()cc.this.ccc`
+[accessible:  true] `method ccf=> Unit`
+[accessible:  true] `method cf=> Unit`
+[accessible:  true] `method f=> Unit`
+================================================================================
+
+askScopeCompletion at Completions.scala(54,6)
+================================================================================
+[response] askScopeCompletion at (54,6)
+retrieved 8 members
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `class cCompletion1.this.c`
+[accessible:  true] `class ccc.this.cc`
+[accessible:  true] `class ccccc.this.ccc`
+[accessible:  true] `constructor cc()c.this.cc`
+[accessible:  true] `method ccf=> Unit`
+[accessible:  true] `method cf=> Unit`
+[accessible:  true] `method f=> Unit`
+================================================================================
+
+askScopeCompletion at Completions.scala(57,8)
+================================================================================
+[response] askScopeCompletion at (57,8)
+retrieved 8 members
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `class cCompletion1.this.c`
+[accessible:  true] `class ccc.this.cc`
+[accessible:  true] `class ccccc.this.ccc`
+[accessible:  true] `constructor cc()c.this.cc`
+[accessible:  true] `method ccf=> Unit`
+[accessible:  true] `method cf=> Unit`
+[accessible:  true] `method f=> Unit`
+================================================================================
+
+askScopeCompletion at Completions.scala(60,6)
+================================================================================
+[response] askScopeCompletion at (60,6)
+retrieved 8 members
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `class cCompletion1.this.c`
+[accessible:  true] `class ccc.this.cc`
+[accessible:  true] `class ccccc.this.ccc`
+[accessible:  true] `constructor cc()c.this.cc`
+[accessible:  true] `method ccf=> Unit`
+[accessible:  true] `method cf=> Unit`
+[accessible:  true] `method f=> Unit`
+================================================================================
+
+askScopeCompletion at Completions.scala(63,4)
+================================================================================
+[response] askScopeCompletion at (63,4)
+retrieved 6 members
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `class cCompletion1.this.c`
+[accessible:  true] `class ccc.this.cc`
+[accessible:  true] `constructor c()Completion1.this.c`
+[accessible:  true] `method cf=> Unit`
+[accessible:  true] `method f=> Unit`
+================================================================================
+
+askScopeCompletion at Completions.scala(68,8)
+================================================================================
+[response] askScopeCompletion at (68,8)
+retrieved 8 members
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `class cCompletion1.this.c`
+[accessible:  true] `class ccc.this.cc`
+[accessible:  true] `class cfccfc`
+[accessible:  true] `constructor cfc()cfc`
+[accessible:  true] `method cf=> Unit`
+[accessible:  true] `method cff=> Unit`
+[accessible:  true] `method f=> Unit`
+================================================================================
+
+askScopeCompletion at Completions.scala(71,6)
+================================================================================
+[response] askScopeCompletion at (71,6)
+retrieved 8 members
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `class cCompletion1.this.c`
+[accessible:  true] `class ccc.this.cc`
+[accessible:  true] `class cfccfc`
+[accessible:  true] `constructor c()Completion1.this.c`
+[accessible:  true] `method cf=> Unit`
+[accessible:  true] `method cff=> Unit`
+[accessible:  true] `method f=> Unit`
+================================================================================
+
+askScopeCompletion at Completions.scala(74,8)
+================================================================================
+[response] askScopeCompletion at (74,8)
+retrieved 8 members
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `class cCompletion1.this.c`
+[accessible:  true] `class ccc.this.cc`
+[accessible:  true] `class cfccfc`
+[accessible:  true] `constructor c()Completion1.this.c`
+[accessible:  true] `method cf=> Unit`
+[accessible:  true] `method cff=> Unit`
+[accessible:  true] `method f=> Unit`
+================================================================================
+
+askScopeCompletion at Completions.scala(77,6)
+================================================================================
+[response] askScopeCompletion at (77,6)
+retrieved 8 members
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `class cCompletion1.this.c`
+[accessible:  true] `class ccc.this.cc`
+[accessible:  true] `class cfccfc`
+[accessible:  true] `constructor c()Completion1.this.c`
+[accessible:  true] `method cf=> Unit`
+[accessible:  true] `method cff=> Unit`
+[accessible:  true] `method f=> Unit`
+================================================================================
+
+askScopeCompletion at Completions.scala(80,4)
+================================================================================
+[response] askScopeCompletion at (80,4)
+retrieved 6 members
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `class cCompletion1.this.c`
+[accessible:  true] `class ccc.this.cc`
+[accessible:  true] `constructor c()Completion1.this.c`
+[accessible:  true] `method cf=> Unit`
+[accessible:  true] `method f=> Unit`
+================================================================================
+
+askScopeCompletion at Completions.scala(83,2)
+================================================================================
+[response] askScopeCompletion at (83,2)
+retrieved 4 members
+[accessible:  true] `class Completion1test.Completion1`
+[accessible:  true] `class cCompletion1.this.c`
+[accessible:  true] `constructor Completion1()test.Completion1`
+[accessible:  true] `method f=> Unit`
+================================================================================

--- a/test/files/presentation/scope-completion-4/Test.scala
+++ b/test/files/presentation/scope-completion-4/Test.scala
@@ -1,0 +1,3 @@
+import scala.tools.nsc.interactive.tests.InteractiveTest
+
+object Test extends InteractiveTest

--- a/test/files/presentation/scope-completion-4/src/Completions.scala
+++ b/test/files/presentation/scope-completion-4/src/Completions.scala
@@ -1,0 +1,84 @@
+package test
+
+/* check that members defined in sub-block are not visible*/
+
+class Completion1 {
+
+  def f {
+    
+    def ff {
+      
+      def fff {
+        /*_*/
+      }
+      
+      /*_*/
+      
+      class ffc {
+        /*_*/
+      }
+      
+      /*_*/
+    }
+    
+    /*_*/
+    
+    class fc {
+      
+      def fcf {
+        /*_*/
+      } 
+      
+      /*_*/
+      
+      class fcc {
+        /*_*/
+      }
+      
+      /*_*/
+    }
+    
+    /*_*/
+  }
+  
+  /*_*/
+  
+  class c {
+    
+    class cc {
+      
+      class ccc {
+        /*_*/
+      }
+      
+      /*_*/
+      
+      def ccf {
+        /*_*/
+      }
+
+      /*_*/
+    }
+    
+    /*_*/
+    
+    def cf {
+      
+      class cfc {
+        /*_*/
+      }
+      
+      /*_*/
+      
+      def cff {
+        /*_*/
+      }
+      
+      /*_*/
+    }
+    
+    /*_*/
+  }
+
+  /*_*/
+}

--- a/test/files/presentation/scope-completion-import.check
+++ b/test/files/presentation/scope-completion-import.check
@@ -1,0 +1,141 @@
+reload: Completions.scala
+
+askScopeCompletion at Completions.scala(15,4)
+================================================================================
+[response] askScopeCompletion at (15,4)
+retrieved 10 members
+[accessible:  true] `class Ctest.C`
+[accessible:  true] `class Foo_1test.Foo_1`
+[accessible:  true] `class Foo_2test.Foo_2`
+[accessible:  true] `class Foo_3test.Foo_3`
+[accessible:  true] `class Footest.Foo`
+[accessible:  true] `constructor Foo()test.Foo`
+[accessible:  true] `method fCCC=> Int`
+[accessible:  true] `method fOOO=> Int`
+[accessible:  true] `object Otest.O.type`
+[accessible:  true] `value otest.O.type`
+================================================================================
+
+askScopeCompletion at Completions.scala(19,4)
+================================================================================
+[response] askScopeCompletion at (19,4)
+retrieved 9 members
+[accessible:  true] `class Ctest.C`
+[accessible:  true] `class Foo_1test.Foo_1`
+[accessible:  true] `class Foo_2test.Foo_2`
+[accessible:  true] `class Foo_3test.Foo_3`
+[accessible:  true] `class Footest.Foo`
+[accessible:  true] `constructor Foo()test.Foo`
+[accessible:  true] `method fCCC=> Int`
+[accessible:  true] `method fOOO=> Int`
+[accessible:  true] `object Otest.O.type`
+================================================================================
+
+askScopeCompletion at Completions.scala(24,4)
+================================================================================
+[response] askScopeCompletion at (24,4)
+retrieved 9 members
+[accessible:  true] `class Ctest.C`
+[accessible:  true] `class Foo_1test.Foo_1`
+[accessible:  true] `class Foo_2test.Foo_2`
+[accessible:  true] `class Foo_3test.Foo_3`
+[accessible:  true] `class Footest.Foo`
+[accessible:  true] `constructor Foo()test.Foo`
+[accessible:  true] `method fCCC=> Int`
+[accessible:  true] `object Otest.O.type`
+[accessible:  true] `value ctest.C`
+================================================================================
+
+askScopeCompletion at Completions.scala(27,5)
+================================================================================
+[response] askScopeCompletion at (27,5)
+retrieved 8 members
+[accessible:  true] `class Ctest.C`
+[accessible:  true] `class Foo_1test.Foo_1`
+[accessible:  true] `class Foo_2test.Foo_2`
+[accessible:  true] `class Foo_3test.Foo_3`
+[accessible:  true] `class Footest.Foo`
+[accessible:  true] `constructor Foo()test.Foo`
+[accessible:  true] `object Otest.O.type`
+[accessible:  true] `value ctest.C`
+================================================================================
+
+askScopeCompletion at Completions.scala(30,5)
+================================================================================
+[response] askScopeCompletion at (30,5)
+retrieved 9 members
+[accessible:  true] `class Ctest.C`
+[accessible:  true] `class Foo_1test.Foo_1`
+[accessible:  true] `class Foo_2test.Foo_2`
+[accessible:  true] `class Foo_3test.Foo_3`
+[accessible:  true] `class Footest.Foo`
+[accessible:  true] `constructor Foo()test.Foo`
+[accessible:  true] `method fCCC=> Int`
+[accessible:  true] `object Otest.O.type`
+[accessible:  true] `value ctest.C`
+================================================================================
+
+askScopeCompletion at Completions.scala(32,5)
+================================================================================
+[response] askScopeCompletion at (32,5)
+retrieved 10 members
+[accessible:  true] `class Ctest.C`
+[accessible:  true] `class Foo_1test.Foo_1`
+[accessible:  true] `class Foo_2test.Foo_2`
+[accessible:  true] `class Foo_3test.Foo_3`
+[accessible:  true] `class Footest.Foo`
+[accessible:  true] `constructor Foo()test.Foo`
+[accessible:  true] `method fCCC=> Int`
+[accessible:  true] `method fOOO=> Int`
+[accessible:  true] `object Otest.O.type`
+[accessible:  true] `value ctest.C`
+================================================================================
+
+askScopeCompletion at Completions.scala(41,4)
+================================================================================
+[response] askScopeCompletion at (41,4)
+retrieved 10 members
+[accessible:  true] `class Ctest.C`
+[accessible:  true] `class Foo_1test.Foo_1`
+[accessible:  true] `class Foo_2test.Foo_2`
+[accessible:  true] `class Foo_3test.Foo_3`
+[accessible:  true] `class Footest.Foo`
+[accessible:  true] `constructor Foo_1()test.Foo_1`
+[accessible:  true] `method bar=> Unit`
+[accessible:  true] `method fCCC=> Int`
+[accessible:  true] `method fOOO=> Int`
+[accessible:  true] `object Otest.O.type`
+================================================================================
+
+askScopeCompletion at Completions.scala(51,4)
+================================================================================
+[response] askScopeCompletion at (51,4)
+retrieved 11 members
+[accessible:  true] `class Ctest.C`
+[accessible:  true] `class Foo_1test.Foo_1`
+[accessible:  true] `class Foo_2test.Foo_2`
+[accessible:  true] `class Foo_3test.Foo_3`
+[accessible:  true] `class Footest.Foo`
+[accessible:  true] `constructor Foo_2()test.Foo_2`
+[accessible:  true] `method bar=> Unit`
+[accessible:  true] `method fCCC=> Int`
+[accessible:  true] `method fOOO=> Int`
+[accessible:  true] `object Otest.O.type`
+[accessible:  true] `value otest.O.type`
+================================================================================
+
+askScopeCompletion at Completions.scala(61,4)
+================================================================================
+[response] askScopeCompletion at (61,4)
+retrieved 10 members
+[accessible:  true] `class Ctest.C`
+[accessible:  true] `class Foo_1test.Foo_1`
+[accessible:  true] `class Foo_2test.Foo_2`
+[accessible:  true] `class Foo_3test.Foo_3`
+[accessible:  true] `class Footest.Foo`
+[accessible:  true] `constructor Foo_3()test.Foo_3`
+[accessible:  true] `method bar=> Unit`
+[accessible:  true] `method fCCC=> Int`
+[accessible:  true] `object Otest.O.type`
+[accessible:  true] `value ctest.C`
+================================================================================

--- a/test/files/presentation/scope-completion-import/Test.scala
+++ b/test/files/presentation/scope-completion-import/Test.scala
@@ -1,0 +1,3 @@
+import scala.tools.nsc.interactive.tests.InteractiveTest
+
+object Test extends InteractiveTest

--- a/test/files/presentation/scope-completion-import/src/Completions.scala
+++ b/test/files/presentation/scope-completion-import/src/Completions.scala
@@ -1,0 +1,64 @@
+package test
+
+class C {
+  def fCCC : Int = 0
+}
+
+object O extends C {
+  def fOOO : Int = 0
+}
+
+class Foo {
+  {
+    val o = O
+    import o._
+    /*_*/
+  }
+  {
+    import O._
+    /*_*/
+  }
+  {
+    val c = new C
+    import c._
+    /*_*/
+  }
+  {
+    f/*_*/
+    val c = new C
+    import c._
+    f/*_*/
+    import O._
+    f/*_*/
+  }
+}
+
+class Foo_1 {
+
+  import O._
+
+  def bar {
+    /*_*/
+  }
+}
+
+class Foo_2 {
+
+  val o = O
+  import o._
+
+  def bar {
+    /*_*/
+  }
+}
+
+class Foo_3 {
+
+  val c = new C
+  import c._
+
+  def bar {
+    /*_*/
+  }
+}
+

--- a/test/files/presentation/t5708.check
+++ b/test/files/presentation/t5708.check
@@ -2,7 +2,7 @@ reload: Completions.scala
 
 askTypeCompletion at Completions.scala(17,9)
 ================================================================================
-[response] aksTypeCompletion at (17,9)
+[response] askTypeCompletion at (17,9)
 retrieved 44 members
 [accessible:  true] `lazy value fooInt`
 [accessible:  true] `method !=(x$1: Any)Boolean`

--- a/test/files/presentation/visibility.check
+++ b/test/files/presentation/visibility.check
@@ -2,7 +2,7 @@ reload: Completions.scala
 
 askTypeCompletion at Completions.scala(14,12)
 ================================================================================
-[response] aksTypeCompletion at (14,12)
+[response] askTypeCompletion at (14,12)
 retrieved 42 members
 [accessible:  true] `method !=(x$1: Any)Boolean`
 [accessible:  true] `method !=(x$1: AnyRef)Boolean`
@@ -46,7 +46,7 @@ retrieved 42 members
 
 askTypeCompletion at Completions.scala(16,11)
 ================================================================================
-[response] aksTypeCompletion at (16,11)
+[response] askTypeCompletion at (16,11)
 retrieved 42 members
 [accessible:  true] `method !=(x$1: Any)Boolean`
 [accessible:  true] `method !=(x$1: AnyRef)Boolean`
@@ -90,7 +90,7 @@ retrieved 42 members
 
 askTypeCompletion at Completions.scala(22,11)
 ================================================================================
-[response] aksTypeCompletion at (22,11)
+[response] askTypeCompletion at (22,11)
 retrieved 42 members
 [accessible:  true] `method !=(x$1: Any)Boolean`
 [accessible:  true] `method !=(x$1: AnyRef)Boolean`
@@ -134,7 +134,7 @@ retrieved 42 members
 
 askTypeCompletion at Completions.scala(28,10)
 ================================================================================
-[response] aksTypeCompletion at (28,10)
+[response] askTypeCompletion at (28,10)
 retrieved 42 members
 [accessible:  true] `method !=(x$1: Any)Boolean`
 [accessible:  true] `method !=(x$1: AnyRef)Boolean`
@@ -178,7 +178,7 @@ retrieved 42 members
 
 askTypeCompletion at Completions.scala(37,8)
 ================================================================================
-[response] aksTypeCompletion at (37,8)
+[response] askTypeCompletion at (37,8)
 retrieved 42 members
 [accessible:  true] `method !=(x$1: Any)Boolean`
 [accessible:  true] `method !=(x$1: AnyRef)Boolean`


### PR DESCRIPTION
The pretty print in the test support code is slightly different than in the 2.11 pull request (scala/scala#3140), so the text of the `.check` files is not the same. The elements are the same, but the representation is different.
