### PR TITLE
SI-7280 Remove unneccesary method

### DIFF
--- a/src/interactive/scala/tools/nsc/interactive/tests/core/CoreTestDefs.scala
+++ b/src/interactive/scala/tools/nsc/interactive/tests/core/CoreTestDefs.scala
@@ -40,9 +40,6 @@ private[tests] trait CoreTestDefs
     extends PresentationCompilerTestDef
     with AskScopeCompletionAt {
 
-    def memberPrinter(member: compiler.Member): String =
-        "[accessible: %5s] ".format(member.accessible) + "`" + (member.sym.toString() + member.tpe.toString()).trim() + "`"
-
     override def runTest() {
       askAllSources(ScopeCompletionMarker) { pos =>
         askScopeCompletionAt(pos)


### PR DESCRIPTION
I noticed when preparing the backport of #3140 that it added an unused method.
