### PR TITLE
Prepare upgrade to scalacheck 1.11.

### DIFF
--- a/test/files/scalacheck/CheckCollections.scala
+++ b/test/files/scalacheck/CheckCollections.scala
@@ -1,4 +1,4 @@
-import org.scalacheck.{ ConsoleReporter, Properties }
+import org.scalacheck.Properties
 import org.scalacheck.Prop._
 
 import scala.reflect.internal.util.Collections._
@@ -49,11 +49,4 @@ object Test extends Properties("reflect.internal.util.Collections") {
   for {
     (label, prop) <- tests
   } property(label) = prop
-
-  import org.scalacheck.{ Test => STest }
-
-  def runTests() =
-    STest.checkProperties(
-      STest.Params(testCallback = ConsoleReporter(0)), this)
-
 }

--- a/test/files/scalacheck/CheckEither.scala
+++ b/test/files/scalacheck/CheckEither.scala
@@ -1,10 +1,8 @@
-import org.scalacheck.{ Arbitrary, ConsoleReporter, Prop, Properties }
+import org.scalacheck.{ Arbitrary, Prop, Properties }
 import org.scalacheck.Arbitrary.{arbitrary, arbThrowable}
 import org.scalacheck.Gen.oneOf
-import org.scalacheck.util.StdRand
 import org.scalacheck.Prop._
-import org.scalacheck.Test.{Params, check}
-import org.scalacheck.ConsoleReporter.testStatsEx
+import org.scalacheck.Test.check
 import Function.tupled
 
 object Test extends Properties("Either") {
@@ -177,11 +175,5 @@ object Test extends Properties("Either") {
 
   for ((label, prop) <- tests) {
     property(label) = prop
-  }
-
-  import org.scalacheck.{ Test => STest }
-
-  def runTests() = {
-    STest.checkProperties(STest.Params(testCallback = ConsoleReporter(0)), this)
   }
 }

--- a/test/files/scalacheck/array-new.scala
+++ b/test/files/scalacheck/array-new.scala
@@ -1,4 +1,4 @@
-import scala.reflect.{ClassTag, classTag}
+import scala.reflect.ClassTag // new style: use ClassTag
 import org.scalacheck._
 import Prop._
 import Gen._

--- a/test/files/scalacheck/quasiquotes/ArbitraryTreesAndNames.scala
+++ b/test/files/scalacheck/quasiquotes/ArbitraryTreesAndNames.scala
@@ -222,7 +222,7 @@ trait ArbitraryTreesAndNames {
       yield ValDef(mods, name, tpt, rhs)
 
   def genTree(size: Int): Gen[Tree] =
-    if (size <= 1) oneOf(EmptyTree, genTreeIsTerm(size), genTreeIsType(size))
+    if (size <= 1) oneOf(EmptyTree: Gen[Tree], genTreeIsTerm(size), genTreeIsType(size))
     else oneOf(genTree(1),
                // these trees are neither terms nor types
                genPackageDef(size - 1), genModuleDef(size - 1),
@@ -273,8 +273,8 @@ trait ArbitraryTreesAndNames {
     def apply(universe: Universe, value: TreeIsType): universe.Tree =
       value.tree.asInstanceOf[universe.Tree]
   }
-  implicit def treeIsTerm2tree(tit: TreeIsTerm) = tit.tree
-  implicit def treeIsType2tree(tit: TreeIsType) = tit.tree
+  implicit def treeIsTerm2tree(tit: TreeIsTerm): Tree = tit.tree
+  implicit def treeIsType2tree(tit: TreeIsType): Tree = tit.tree
 
   implicit val arbConstant: Arbitrary[Constant] = Arbitrary(genConstant)
   implicit val arbModifiers: Arbitrary[Modifiers] = Arbitrary(genModifiers)

--- a/test/files/scalacheck/si4147.scala
+++ b/test/files/scalacheck/si4147.scala
@@ -1,8 +1,6 @@
 import org.scalacheck.Prop.{forAll, throws}
 import org.scalacheck.Properties
-import org.scalacheck.ConsoleReporter.testStatsEx
 import org.scalacheck.Gen
-import org.scalacheck.ConsoleReporter
 
 
 import collection.mutable
@@ -66,5 +64,5 @@ object Test extends Properties("Mutable TreeSet") {
   }
 
   property("ordering must not be null") =
-    throws(mutable.TreeSet.empty[Int](null), classOf[NullPointerException])
+    throws(classOf[NullPointerException])(mutable.TreeSet.empty[Int](null))
 }

--- a/test/files/scalacheck/t2460.scala
+++ b/test/files/scalacheck/t2460.scala
@@ -1,6 +1,5 @@
 import org.scalacheck.Prop.forAll
 import org.scalacheck.Properties
-import org.scalacheck.ConsoleReporter.testStatsEx
 import org.scalacheck.{Test => SCTest}
 import org.scalacheck.Gen
 
@@ -25,8 +24,4 @@ object Test extends Properties("Regex : Ticket 2460") {
     ("numberOfGroup", numberOfGroup),
     ("nameOfGroup", nameOfGroup)
   )
-
-  /*tests foreach {
-    case (name, p) => testStatsEx(name, SCTest.check(p))
-  }*/
 }

--- a/test/files/scalacheck/treeset.scala
+++ b/test/files/scalacheck/treeset.scala
@@ -151,5 +151,5 @@ object Test extends Properties("TreeSet") {
   }
 
   property("ordering must not be null") =
-    throws(TreeSet.empty[Int](null), classOf[NullPointerException])
+    throws(classOf[NullPointerException])(TreeSet.empty[Int](null))
 }


### PR DESCRIPTION
Our scalacheck tests now compile against 1.10.1 and 1.11.0.
They pass on 1.10.1, but fail on 1.11.0.

Once (that)[https://github.com/rickynils/scalacheck/issues/79]'s fixed,
and 1.11.1 released, we should be able to upgrade to it by simply
changing scalacheck.version.number in versions.properties.

The changes are mostly removing dead code (e.g., consolereporter business).

Of interest: the type ascription for `oneOf`. I haven't quite investigated,
but something seems to have changed between 1.10.1 and 1.11.0 that caused
a different overload to be picked without the type ascription.
Probably not a scalac bug, just a scalacheck api change.

Review by @gkossakowski.
