### PR TITLE
Bump starr to M7, along with module versions.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -285,12 +285,13 @@ TODO:
         <!-- so we don't have to wait for artifacts to synch to maven central
             (we don't distribute partest with Scala, so the risk of sonatype and maven being out of synch is irrelevant):
           -->
-        <!-- <artifact:remoteRepository refid="extra-repo"/> -->
+        <artifact:remoteRepository refid="extra-repo"/>
         <dependency groupId="org.scala-lang.modules" artifactId="scala-partest_${scala.binary.version}" version="${partest.version.number}" />
       </artifact:dependencies>
       <copy-deps project="partest"/>
 
       <artifact:dependencies pathId="scalacheck.classpath" filesetId="scalacheck.fileset" versionsId="scalacheck.versions">
+        <artifact:remoteRepository refid="extra-repo"/>
         <dependency groupId="org.scalacheck"         artifactId="scalacheck_${scala.binary.version}"    version="${scalacheck.version.number}" />
       </artifact:dependencies>
 
@@ -302,7 +303,7 @@ TODO:
       <!-- used by the test.osgi target to create osgi bundles for the xml, parser-combinator jars
            must specify sourcesFilesetId, javadocFilesetId to download these types of artifacts -->
       <artifact:dependencies pathId="external-modules.deps.classpath" sourcesFilesetId="external-modules.sources.fileset" javadocFilesetId="external-modules.javadoc.fileset">
-        <!-- <artifact:remoteRepository refid="extra-repo"/> -->
+        <artifact:remoteRepository refid="extra-repo"/>
         <dependency groupId="org.scala-lang.modules" artifactId="scala-xml_${scala.binary.version}" version="${scala-xml.version.number}"/>
         <dependency groupId="org.scala-lang.modules" artifactId="scala-parser-combinators_${scala.binary.version}" version="${scala-parser-combinators.version.number}"/>
       </artifact:dependencies>

--- a/versions.properties
+++ b/versions.properties
@@ -1,13 +1,13 @@
-starr.version=2.11.0-M6
+starr.version=2.11.0-M7
 starr.use.released=1
 
 # These are the versions of the modules that go with this release.
 # These properties are used during PR validation and in dbuild builds.
-scala.binary.version=2.11.0-M6
-partest.version.number=1.0.0-RC7
-scala-xml.version.number=1.0.0-RC6
-scala-parser-combinators.version.number=1.0.0-RC4
-scalacheck.version.number=1.10.1
+scala.binary.version=2.11.0-M7
+partest.version.number=1.0.0-RC8
+scala-xml.version.number=1.0.0-RC7
+scala-parser-combinators.version.number=1.0.0-RC5
+scalacheck.version.number=1.11.1
 
 # TODO: modularize the compiler
 #scala-compiler-doc.version.number=1.0.0-RC1


### PR DESCRIPTION
Allow extra-repo to make it easier to test e.g.,
a staged scalacheck while releasing modules.

TODO: replace desired.sha1's with jars for M7 starr so it's consistent
alternatively, we could just remove them -- no intention of allowing unreleased starr again

what say you, @gkossakowski, @retronym, @jamesiry et al?
