### PR TITLE
SI-7987 Test case for "macro not expanded" error with implicits

### DIFF
--- a/test/files/pos/t7987/Macro_1.scala
+++ b/test/files/pos/t7987/Macro_1.scala
@@ -1,0 +1,6 @@
+import scala.language.experimental._
+
+object Macro {
+  def apply[A](a: A): A = macro impl[A]
+  def impl[A](c: reflect.macros.Context)(a: c.Expr[A]): c.Expr[A] = a
+}

--- a/test/files/pos/t7987/Test_2.scala
+++ b/test/files/pos/t7987/Test_2.scala
@@ -1,0 +1,12 @@
+class C[T] {                                     
+  def foo = 0                                    
+}                                                
+
+object Test {
+  implicit def AnyToC[T](a: Any): C[T] = new C[T] 
+  // was: "macro not expanded"
+  Macro {                                         
+    "".foo                                         
+     ()                                            
+  }
+}


### PR DESCRIPTION
Fixed, serendipitously, a handful of commits ago in 4a6882e772,
"SI-7944 FOUND: stray undetermined type params in vicinity of
implicits".
