### PR TITLE
Handle TypeApply(fun, ...) for symbol-less funs

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5051,7 +5051,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
         // @M: fun is typed in TAPPmode because it is being applied to its actual type parameters
         val fun1 = typed(fun, mode.forFunMode | TAPPmode)
-        val tparams = fun1.symbol.typeParams
+        val tparams = if (fun1.symbol == null) Nil else fun1.symbol.typeParams
 
         //@M TODO: val undets_fun = context.undetparams  ?
         // "do args first" (by restoring the context.undetparams) in order to maintain context.undetparams on the function side.

--- a/test/files/neg/class-of-double-targs.check
+++ b/test/files/neg/class-of-double-targs.check
@@ -1,0 +1,4 @@
+class-of-double-targs.scala:2: error: expression of type Class[Int](classOf[scala.Int]) does not take type parameters.
+  classOf[Int][Int]
+              ^
+one error found

--- a/test/files/neg/class-of-double-targs.scala
+++ b/test/files/neg/class-of-double-targs.scala
@@ -1,0 +1,3 @@
+object Test {
+  classOf[Int][Int]
+}


### PR DESCRIPTION
Such as class literals, as one could conjure in `classOf[Int][Int]`

Before, this would crash with a `NullPointerException`
