### PR TITLE
SI-7548 askTypeAt returns the same type whether the file was fully type-checked or targeted type-checked

### DIFF
--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -336,16 +336,21 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
           println("something's wrong: no "+context.unit+" in "+result+result.pos)
           located = result
         }
-        throw new TyperResult(located)
+        located.tpe match {
+          case _: OverloadedType => ()
+          case _ => throw new TyperResult(located) 
+        }
       }
-      try {
-        checkForMoreWork(old.pos)
-      } catch {
-        case ex: ValidateException => // Ignore, this will have been reported elsewhere
-          debugLog("validate exception caught: "+ex)
-        case ex: Throwable =>
-          log.flush()
-          throw ex
+      else {
+        try {
+          checkForMoreWork(old.pos)
+        } catch {
+          case ex: ValidateException => // Ignore, this will have been reported elsewhere
+            debugLog("validate exception caught: "+ex)
+          case ex: Throwable =>
+            log.flush()
+            throw ex
+        }
       }
     }
   }

--- a/test/files/presentation/t7548.check
+++ b/test/files/presentation/t7548.check
@@ -1,0 +1,1 @@
+(x: Int)Unit

--- a/test/files/presentation/t7548/Test.scala
+++ b/test/files/presentation/t7548/Test.scala
@@ -1,0 +1,17 @@
+import scala.tools.nsc.interactive.tests.InteractiveTest
+
+object Test extends InteractiveTest {
+  override protected def loadSources() { /* don't parse or typecheck sources */ }
+
+  import compiler._
+
+  override def runDefaultTests() {
+    val res = new Response[Tree]
+    val pos = compiler.rangePos(sourceFiles.head, 102,102,102)
+    compiler.askTypeAt(pos, res)
+    res.get match {
+      case Left(tree) => compiler.ask(() => reporter.println(tree.tpe))
+      case Right(ex) => reporter.println(ex)
+    }
+  }
+}

--- a/test/files/presentation/t7548/src/Foo.scala
+++ b/test/files/presentation/t7548/src/Foo.scala
@@ -1,0 +1,7 @@
+object Foo {
+  def foo(x: Int) = {}
+  def foo(x: String) = {}
+  def foo(x: Int, y: String) = {}
+  
+  foo(2)
+}


### PR DESCRIPTION
When asking for targeted typecheck, the located tree may have overloaded types
is the source isn't yet fully typechecked (e.g., a select tree for an
overloaded method). This is problematic as it can lead to unknown 'hovers',
broken hyperlinking that suddenly starts working, unresolved ScalaDoc comments,
and similar, in the Scala IDE.

With this commit we are hardening the contract of `askTypeAt` to return the
same type whether the file was fully type-checked or targeted type-checked.
This is done by preventing the typechecker to stop too early if the `located`
tree has an overloaded type.

Unfortunately, there is no easy way to provide a test together with this fix.
The faulty behavior is hard to consistently reproduce, as it depends on timing.
However, I've manually tested this by inserting a `Thread.sleep` just before
typechecking in `Global.backgroundCompile`, and checked that an `askTypeAt` on
an select tree for an overloaded method now does return a fully resolved symbol.

review by @dragos

Is this too risky to backport?
