### PR TITLE
SI-7872 Plug a variance exploit in refinement types

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1762,6 +1762,8 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
              | TypeDef(_, _, _, _) =>
             if (result.symbol.isLocal || result.symbol.isTopLevel)
               varianceValidator.traverse(result)
+          case tt @ TypeTree() if tt.original != null =>
+            varianceValidator.traverse(tt.original) // See SI-7872
           case _ =>
         }
         result

--- a/src/reflect/scala/reflect/internal/Variances.scala
+++ b/src/reflect/scala/reflect/internal/Variances.scala
@@ -162,6 +162,16 @@ trait Variances {
           traverseTreess(vparamss)
         case Template(_, _, _) =>
           super.traverse(tree)
+        case CompoundTypeTree(templ) =>
+          super.traverse(tree)
+
+        // SI-7872 These two cases make sure we don't miss variance exploits
+        // in originals, e.g. in `foo[({type l[+a] = List[a]})#l]`
+        case tt @ TypeTree() if tt.original != null =>
+          super.traverse(tt.original)
+        case tt : TypTree =>
+          super.traverse(tt)
+
         case _ =>
       }
     }

--- a/test/files/neg/t7872.check
+++ b/test/files/neg/t7872.check
@@ -1,0 +1,10 @@
+t7872.scala:6: error: contravariant type a occurs in covariant position in type [-a]Cov[a] of type l
+  type x = {type l[-a] = Cov[a]}
+                 ^
+t7872.scala:8: error: covariant type a occurs in contravariant position in type [+a]Inv[a] of type l
+  foo[({type l[+a] = Inv[a]})#l]
+             ^
+t7872.scala:5: error: contravariant type a occurs in covariant position in type [-a]Cov[a] of type l
+  type l[-a] = Cov[a]
+       ^
+three errors found

--- a/test/files/neg/t7872.scala
+++ b/test/files/neg/t7872.scala
@@ -1,0 +1,9 @@
+trait Cov[+A]
+trait Inv[-A]
+
+object varianceExploit {  
+  type l[-a] = Cov[a]
+  type x = {type l[-a] = Cov[a]}
+  def foo[M[_]] = ()
+  foo[({type l[+a] = Inv[a]})#l]
+}

--- a/test/files/neg/t7872b.check
+++ b/test/files/neg/t7872b.check
@@ -1,0 +1,7 @@
+t7872b.scala:8: error: contravariant type a occurs in covariant position in type [-a]List[a] of type l
+  def oops1 = down[({type l[-a] = List[a]})#l](List('whatever: Object)).head + "oops"
+                          ^
+t7872b.scala:19: error: covariant type a occurs in contravariant position in type [+a]coinv.Stringer[a] of type l
+  def oops2 = up[({type l[+a] = Stringer[a]})#l]("printed: " + _)
+                        ^
+two errors found

--- a/test/files/neg/t7872b.scala
+++ b/test/files/neg/t7872b.scala
@@ -1,0 +1,23 @@
+object coinv {
+  def up[F[+_]](fa: F[String]): F[Object] = fa
+  def down[F[-_]](fa: F[Object]): F[String] = fa
+ 
+  up(List("hi"))
+ 
+  // should not compile; `l' is unsound
+  def oops1 = down[({type l[-a] = List[a]})#l](List('whatever: Object)).head + "oops"
+  // scala> oops1
+  // java.lang.ClassCastException: scala.Symbol cannot be cast to java.lang.String
+  //         at com.nocandysw.coinv$.oops1(coinv.scala:12)
+ 
+  type Stringer[-A] = A => String
+  down[Stringer](_.toString)
+  // [error] type A is contravariant, but type _ is declared covariant
+  // up[Stringer]("printed: " + _)
+ 
+  // should not compile; `l' is unsound
+  def oops2 = up[({type l[+a] = Stringer[a]})#l]("printed: " + _)
+  // scala> oops2(Some(33))
+  // java.lang.ClassCastException: scala.Some cannot be cast to java.lang.String
+  //         at com.nocandysw.coinv$$anonfun$oops2$1.apply(coinv.scala:20)
+}

--- a/test/files/neg/t7872c.check
+++ b/test/files/neg/t7872c.check
@@ -1,0 +1,11 @@
+t7872c.scala:7: error: inferred kinds of the type arguments (List) do not conform to the expected kinds of the type parameters (type F).
+List's type parameters do not match type F's expected parameters:
+type A is covariant, but type _ is declared contravariant
+  down(List('whatever: Object))
+  ^
+t7872c.scala:7: error: type mismatch;
+ found   : List[Object]
+ required: F[Object]
+  down(List('whatever: Object))
+           ^
+two errors found

--- a/test/files/neg/t7872c.scala
+++ b/test/files/neg/t7872c.scala
@@ -1,0 +1,8 @@
+object coinv {
+  def up[F[+_]](fa: F[String]): F[Object] = fa
+  def down[F[-_]](fa: F[Object]): F[String] = fa
+ 
+  up(List("hi"))
+  // [error] type A is covariant, but type _ is declared contravariant
+  down(List('whatever: Object))
+}

--- a/test/files/neg/variances.check
+++ b/test/files/neg/variances.check
@@ -1,6 +1,9 @@
 variances.scala:4: error: covariant type A occurs in contravariant position in type test.Vector[A] of value x
   def append(x: Vector[A]): Vector[A]
              ^
+variances.scala:75: error: covariant type A occurs in contravariant position in type => A => A of value m
+      val m: A => A
+          ^
 variances.scala:18: error: covariant type A occurs in contravariant position in type A of value a
     private def setA3(a : A) = this.a = a
                       ^
@@ -19,4 +22,4 @@ variances.scala:89: error: covariant type T occurs in invariant position in type
 variances.scala:90: error: covariant type T occurs in contravariant position in type => test.TestAlias.B[C.this.A] of method foo
     def foo: B[A]
         ^
-7 errors found
+8 errors found


### PR DESCRIPTION
Refinement types are collapsed to a TypeTree with an original
during type checking; this was enough to evade variance validation
in refchecks.

This commit:
- validates the original of `TypeTree`s in refchecks
- changes VarianceValidator to recurse into:
  - the originals of `TypeTree`s
  - `TypTree` (to cover, e.g. `CompoundTypeTree` / `SelectFromTypeTree`)
