### PR TITLE
Merge ChangeOwner{AndModuleClass}Traversers

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
@@ -410,17 +410,6 @@ trait MethodSynthesis {
      *      { z = <rhs>; z } where z can be an identifier or a field.
      */
     case class LazyValGetter(tree: ValDef) extends BaseGetter(tree) {
-      class ChangeOwnerAndModuleClassTraverser(oldowner: Symbol, newowner: Symbol)
-        extends ChangeOwnerTraverser(oldowner, newowner) {
-
-        override def traverse(tree: Tree) {
-          tree match {
-            case _: DefTree => change(tree.symbol.moduleClass)
-            case _          =>
-          }
-          super.traverse(tree)
-        }
-      }
 
       // todo: in future this should be enabled but now other phases still depend on the flag for various reasons
       //override def flagsMask = (super.flagsMask & ~LAZY)
@@ -433,7 +422,7 @@ trait MethodSynthesis {
           else gen.mkAssignAndReturn(basisSym, rhs1)
         )
         derivedSym setPos tree.pos // cannot set it at createAndEnterSymbol because basisSym can possible stil have NoPosition
-        val ddefRes = DefDef(derivedSym, new ChangeOwnerAndModuleClassTraverser(basisSym, derivedSym)(body))
+        val ddefRes = DefDef(derivedSym, body.changeOwner(basisSym -> derivedSym))
         // ValDef will have its position focused whereas DefDef will have original correct rangepos
         // ideally positions would be correct at the creation time but lazy vals are really a special case
         // here so for the sake of keeping api clean we fix positions manually in LazyValGetter

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -1471,6 +1471,7 @@ trait Trees extends api.Trees {
           }
         case _: DefTree | _: Function =>
           change(tree.symbol)
+          change(tree.symbol.moduleClass)
         case _ =>
       }
       super.traverse(tree)


### PR DESCRIPTION
I found while implementing scala-async that I needed the
equivalent functionality of `ChangeOwnerAndModuleClassTraverser`,
which I found squirrelled away in part of the lazy vals
implementation.

This functionality was at briefly (starting in 981424b376)
in the regular `ChangeOwnerTraverser` but was moved to a subclass
in a15969a6963 in response to code review [1].

But that review was actually about exposing a boolean
parameter "followModuleClass", rather than a criticism of
centralizing this pattern.

This commit speculates that "followModuleClass = true" is
_always_ what you want.

Review by @gkossakowski

[1] https://github.com/scala/scala/pull/1406#discussion_r1703370
