### PR TITLE
SI-6913 Reapplies a lost fix by @viktorklang

### DIFF
--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -384,7 +384,10 @@ trait Future[+T] extends Awaitable[T] {
     val p = Promise[U]()
     onComplete {
       case s @ Success(_) => p complete s
-      case _ => p completeWith that
+      case f @ Failure(_) => that onComplete {
+        case s2 @ Success(_) => p complete s2
+        case _ => p complete f // Use the first failure as the failure
+      }
     }
     p.future
   }

--- a/test/files/jvm/future-spec/PromiseTests.scala
+++ b/test/files/jvm/future-spec/PromiseTests.scala
@@ -38,10 +38,10 @@ object PromiseTests extends MinimalScalaTest {
       
       Await.result(failure fallbackTo timedOut, defaultTimeout) mustBe ("Timedout")
       Await.result(timedOut fallbackTo empty, defaultTimeout) mustBe ("Timedout")
-      Await.result(failure fallbackTo failure fallbackTo timedOut, defaultTimeout) mustBe ("Timedout")
+      Await.result(otherFailure fallbackTo failure fallbackTo timedOut, defaultTimeout) mustBe ("Timedout")
       intercept[RuntimeException] {
         Await.result(failure fallbackTo otherFailure, defaultTimeout)
-      }.getMessage mustBe ("last")
+      }.getMessage mustBe ("br0ken")
     }
     
   }

--- a/test/files/jvm/scala-concurrent-tck.scala
+++ b/test/files/jvm/scala-concurrent-tck.scala
@@ -344,8 +344,8 @@ def testTransformFailure(): Unit = once {
   def testFallbackToFailure(): Unit = once {
     done =>
     val cause = new Exception
-    val f = future { sys.error("failed") }
-    val g = future { throw cause }
+    val f = future { throw cause }
+    val g = future { sys.error("failed") }
     val h = f fallbackTo g
 
     h onSuccess { case _ => done(false) }


### PR DESCRIPTION
https://issues.scala-lang.org/browse/SI-6913

This somehow got lost. Thanks to @rkuhn for pointing it out. 
https://groups.google.com/forum/#!topic/scala-internals/X1bgCpINb60
