### PR TITLE
SI-7999 s.u.c.NonFatal: StackOverflowError is fatal

### DIFF
--- a/src/library/scala/util/control/NonFatal.scala
+++ b/src/library/scala/util/control/NonFatal.scala
@@ -11,9 +11,8 @@ package util.control
 
 /**
  * Extractor of non-fatal Throwables. Will not match fatal errors like `VirtualMachineError`
- * (for example, `OutOfMemoryError`, a subclass of `VirtualMachineError`), `ThreadDeath`,
+ * (for example, `OutOfMemoryError` and `StackOverflowError`, subclasses of `VirtualMachineError`), `ThreadDeath`,
  * `LinkageError`, `InterruptedException`, `ControlThrowable`.
- * However, `StackOverflowError` is matched, i.e. considered non-fatal.
  *
  * Note that [[scala.util.control.ControlThrowable]], an internal Throwable, is not matched by
  * `NonFatal` (and would therefore be thrown).
@@ -34,7 +33,6 @@ object NonFatal {
     * Returns true if the provided `Throwable` is to be considered non-fatal, or false if it is to be considered fatal
     */
    def apply(t: Throwable): Boolean = t match {
-     case _: StackOverflowError => true // StackOverflowError ok even though it is a VirtualMachineError
      // VirtualMachineError includes OutOfMemoryError and other fatal errors
      case _: VirtualMachineError | _: ThreadDeath | _: InterruptedException | _: LinkageError | _: ControlThrowable => false
      case _ => true

--- a/test/files/jvm/non-fatal-tests.scala
+++ b/test/files/jvm/non-fatal-tests.scala
@@ -4,8 +4,7 @@ trait NonFatalTests {
 
 	//NonFatals
     val nonFatals: Seq[Throwable] =
-      Seq(new StackOverflowError,
-          new RuntimeException,
+      Seq(new RuntimeException,
           new Exception,
           new Throwable,
           new NotImplementedError)
@@ -13,6 +12,7 @@ trait NonFatalTests {
     //Fatals
     val fatals: Seq[Throwable] =
       Seq(new InterruptedException,
+          new StackOverflowError,
           new OutOfMemoryError,
           new LinkageError,
           new VirtualMachineError {},


### PR DESCRIPTION
As demonstrated in
https://groups.google.com/d/topic/scala-language/eC9dqTTBYHg, SOEs
should be considered fatal, because all popular JVM implementations
seem to run into inconsistent state (ignoring finally blocks leading
to not running monitorExit, leading to locks not being unlocked, ...)
if one just pushes them enough.
