### PR TITLE
SI-8001 spurious "pure expression does nothing" warning

### DIFF
--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -199,7 +199,8 @@ abstract class TreeInfo {
    *  don't reuse it for important matters like inlining
    *  decisions.
    */
-  def isPureExprForWarningPurposes(tree: Tree) = tree match {
+  def isPureExprForWarningPurposes(tree: Tree): Boolean = tree match {
+    case Typed(expr, _)                    => isPureExprForWarningPurposes(expr)
     case EmptyTree | Literal(Constant(())) => false
     case _                                 =>
       def isWarnableRefTree = tree match {

--- a/test/files/pos/t8001.flags
+++ b/test/files/pos/t8001.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t8001/Macros_1.scala
+++ b/test/files/pos/t8001/Macros_1.scala
@@ -1,0 +1,10 @@
+import scala.language.experimental.macros
+import scala.reflect.macros.BlackboxContext
+
+object Macros {
+  def foo = macro impl
+  def impl(c: BlackboxContext) = {
+    import c.universe._
+    q"()"
+  }
+}

--- a/test/files/pos/t8001/Test_2.scala
+++ b/test/files/pos/t8001/Test_2.scala
@@ -1,0 +1,4 @@
+object Test extends App {
+  Macros.foo
+  (): Unit
+}

--- a/test/files/run/macro-system-properties.check
+++ b/test/files/run/macro-system-properties.check
@@ -14,15 +14,9 @@ scala>     object GrabContext {
 defined object GrabContext
 
 scala>     object Test { class C(implicit a: Any) { GrabContext.grab } }
-<console>:12: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
-           object Test { class C(implicit a: Any) { GrabContext.grab } }
-                                                                ^
 defined object Test
 
 scala>     object Test { class C(implicit a: Any) { GrabContext.grab } }
-<console>:12: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
-           object Test { class C(implicit a: Any) { GrabContext.grab } }
-                                                                ^
 defined object Test
 
 scala> 


### PR DESCRIPTION
`isPureExprForWarningPurposes` doesn’t warn on `()`, but `(): Unit`
leaves it confused. This patch fixes the problem.

The fix is important in the context of the recent split between blackbox
and whitebox macros. Macro engines wrap expansions of blackbox macros
in type ascriptions, so a macro that expands into `()` would actually
produce `(): Unit`, which would trigger a spurious warning. Thanks
@milessabin for spotting this problem!
