### PR TITLE
Revise paragraph (a revised #3164)

### DIFF
--- a/src/library/scala/concurrent/impl/Promise.scala
+++ b/src/library/scala/concurrent/impl/Promise.scala
@@ -82,11 +82,11 @@ private[concurrent] object Promise {
    *  2. Complete, with a result.
    *  3. Linked to another DefaultPromise.
    *
-   *  If a DefaultPromise is linked it another DefaultPromise then it will
+   *  If a DefaultPromise is linked to another DefaultPromise, it will
    *  delegate all its operations to that other promise. This means that two
    *  DefaultPromises that are linked will appear, to external callers, to have
-   *  exactly the same state and behaviour. E.g. they will both appear to be
-   *  either complete or incomplete, and with the same values.
+   *  exactly the same state and behaviour. For instance, both will appear as
+   *  incomplete, or as complete with the same result value.
    *
    *  A DefaultPromise stores its state entirely in the AnyRef cell exposed by
    *  AbstractPromise. The type of object stored in the cell fully describes the


### PR DESCRIPTION
Revise text further, following suggestions in #3164 and part of the suggestions by @som-snytt. But I've kept "appear", since this paragraph documents the external behavior, not the implementation.

Review by @heathermiller.
