### PR TITLE
Test in quick mode for ant build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -920,9 +920,15 @@ TODO:
         Why, the compiler we're testing, of course, and partest with all its dependencies.
     -->
     <path id="partest.compilation.path">
+      <path refid="partest.compilation.path.core"/>
+      <path refid="partest.compilation.path.noncore"/>
+    </path>
+    <path id="partest.compilation.path.core">
       <pathelement location="${library.jar}"/>
       <pathelement location="${reflect.jar}"/>
       <pathelement location="${compiler.jar}"/>
+    </path>
+    <path id="partest.compilation.path.noncore">
 
       <!-- TODO modularize compiler
       <pathelement location="${scaladoc.jar}"/>
@@ -1890,6 +1896,17 @@ TODO:
 
   <target name="test.suite.color" depends="test.suite.init">
     <testSuite colors="8" kinds="pos neg run jvm res scalap scalacheck specialized instrumented"/>
+  </target>
+
+  <target name="test.suite.quick" depends="init, quick.done">
+    <path id="test.suite.path">
+      <path refid="quick.bin.tool.path"/>
+      <path refid="quick.interactive.build.path"/>
+      <path refid="partest.compilation.path.noncore"/>
+    </path>
+    <property name="pcp" value="${toString:test.suite.path}"/>
+    <taskdef classpathref="test.suite.path" resource="scala/tools/partest/antlib.xml"/>
+    <testSuite colors="8" kinds="pos neg run jvm res scalap scalacheck specialized instrumented" pcp="${pcp}"/>
   </target>
 
   <target name="test.run" depends="test.suite.init">

--- a/test/build-partest.xml
+++ b/test/build-partest.xml
@@ -7,6 +7,7 @@
     <attribute name="srcdir" default="files"/> <!-- TODO: make targets for `pending` and other subdirs -->
     <attribute name="colors" default="${partest.colors}"/>
     <attribute name="scalacOpts" default="${scalac.args.optimise}"/>
+    <attribute name="pcp" default="${toString:partest.compilation.path}"/>
     <attribute name="kinds"/>
     <sequential>
       <property name="partest.dir" value="@{dir}" />
@@ -14,7 +15,7 @@
                    kinds="@{kinds}"
                   colors="@{colors}"
               scalacOpts="@{scalacOpts}"
-      compilationpathref="partest.compilation.path"/>
+         compilationpath="@{pcp}"/>
     </sequential>
   </macrodef>
 </project>


### PR DESCRIPTION
Add a target `test.suite.quick`.

Let test.quick depend only on init and quick.done,
and load the task using the quick path (with non-core deps).

As mentioned on the ML.  This would be more useful if
partest task had a failed attribute to ask ant runner to run
failed tests.  We'll have to ask the partest guys for that.

Review by @adriaanm in case it is useful.
