### PR TITLE
SI-8002 private access for local companions

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -657,7 +657,10 @@ trait Contexts { self: Analyzer =>
       // Console.println("isAccessible(%s, %s, %s)".format(sym, pre, superAccess))
 
       // don't have access if there is no linked class (so exclude linkedClass=NoSymbol)
-      def accessWithinLinked(ab: Symbol) = ab.linkedClassOfClass.fold(false)(accessWithin)
+      def accessWithinLinked(ab: Symbol) = {
+        val linked = linkedClassOfClassOf(ab, this)
+        linked.fold(false)(accessWithin)
+      }
 
       /* Are we inside definition of `ab`? */
       def accessWithin(ab: Symbol) = {

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1695,4 +1695,11 @@ trait Namers extends MethodSynthesis {
       )
     }
   }
+
+  /** A version of `Symbol#linkedClassOfClass` that works with local companions, ala `companionSymbolOf`. */
+  final def linkedClassOfClassOf(original: Symbol, ctx: Context): Symbol =
+    if (original.isModuleClass)
+      companionSymbolOf(original.sourceModule, ctx)
+    else
+      companionSymbolOf(original, ctx).moduleClass
 }

--- a/test/files/pos/t8002-nested-scope.scala
+++ b/test/files/pos/t8002-nested-scope.scala
@@ -1,0 +1,20 @@
+//  This test serves to capture the status quo, but should really
+// emit an accessibiltiy error.
+
+// `Namers#companionSymbolOf` seems too lenient, and currently doesn't
+// implement the same-scope checks mentioned:
+//
+// https://github.com/scala/scala/pull/2816#issuecomment-22555206
+//
+class C {
+  def foo = {
+    class C { private def x = 0 }
+
+    {
+      val a = 0
+      object C {
+        new C().x
+      }
+    }
+  }
+}

--- a/test/files/run/t8002.scala
+++ b/test/files/run/t8002.scala
@@ -1,0 +1,19 @@
+object Test extends App {
+  val a: Any = {
+    class A private () { private def x = 0; A.y };
+    object A {
+      def a = new A().x
+      private def y = 0
+    }
+    A.a
+  }
+  def b: Any = {
+    object A {
+      def a = new A().x
+      private def y = 0
+    }
+    class A private () { private def x = 0; A.y };
+    A.a
+  }
+  b
+}


### PR DESCRIPTION
We go through similar gymnastics to make companion implicits
work for local class/object pairings, so we ought to be consistent
when it comes to access

Review by @xeno-by @lrytz
