### PR TITLE
Corrects positions for Dynamic calls

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3999,9 +3999,14 @@ trait Typers extends Modes with Adaptations with Tags {
 
       def typedNamedApply(orig: Tree, fun: Tree, args: List[Tree], mode: Int, pt: Type): Tree = {
         def argToBinding(arg: Tree): Tree = arg match {
-          case AssignOrNamedArg(Ident(name), rhs) => gen.mkTuple(List(CODE.LIT(name.toString), rhs))
-          case _ => gen.mkTuple(List(CODE.LIT(""), arg))
+          case AssignOrNamedArg(i @ Ident(name), rhs) =>
+            atPos(i.pos.withEnd(rhs.pos.endOrPoint)) {
+              gen.mkTuple(List(atPos(i.pos)(CODE.LIT(name.toString)), rhs))
+            }
+          case _ =>
+            gen.mkTuple(List(CODE.LIT(""), arg))
         }
+
         val t = treeCopy.Apply(orig, fun, args map argToBinding)
         wrapErrors(t, _.typed(t, mode, pt))
       }

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4273,7 +4273,9 @@ trait Typers extends Modes with Adaptations with Tags {
         }
         else if(dyna.isDynamicallyUpdatable(lhs1)) {
           val rhs1 = typed(rhs, EXPRmode | BYVALmode, WildcardType)
-          val t = Apply(lhs1, List(rhs1))
+          val t = atPos(lhs1.pos.withEnd(rhs1.pos.endOrPoint)) {
+            Apply(lhs1, List(rhs1))
+          }
           dyna.wrapErrors(t, _.typed1(t, mode, pt))
         }
         else fail()

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4061,7 +4061,10 @@ trait Typers extends Modes with Adaptations with Tags {
             case Some((opName, treeInfo.Applied(_, targs, _))) =>
               val fun = gen.mkTypeApply(Select(qual, opName), targs)
               if (opName == nme.updateDynamic) suppressMacroExpansion(fun) // SI-7617
-              atPos(qual.pos)(Apply(fun, Literal(Constant(name.decode)) :: Nil))
+              val nameStringLit = atPos(treeSelection.pos.withStart(treeSelection.pos.point).makeTransparent) {
+                Literal(Constant(name.decode))
+              }
+              atPos(qual.pos)(Apply(fun, List(nameStringLit)))
             case _ =>
               setError(tree)
           }

--- a/test/files/neg/applydynamic_sip.check
+++ b/test/files/neg/applydynamic_sip.check
@@ -13,28 +13,28 @@ applydynamic_sip.scala:18: error: type mismatch;
 error after rewriting to Test.this.bad1.selectDynamic("sel")
 possible cause: maybe a wrong Dynamic method signature?
   bad1.sel
-  ^
+       ^
 applydynamic_sip.scala:19: error: type mismatch;
  found   : String("sel")
  required: Int
 error after rewriting to Test.this.bad1.applyDynamic("sel")
 possible cause: maybe a wrong Dynamic method signature?
   bad1.sel(1)
-  ^
+       ^
 applydynamic_sip.scala:20: error: type mismatch;
  found   : String("sel")
  required: Int
 error after rewriting to Test.this.bad1.applyDynamicNamed("sel")
 possible cause: maybe a wrong Dynamic method signature?
   bad1.sel(a = 1)
-  ^
+       ^
 applydynamic_sip.scala:21: error: type mismatch;
  found   : String("sel")
  required: Int
 error after rewriting to Test.this.bad1.updateDynamic("sel")
 possible cause: maybe a wrong Dynamic method signature?
   bad1.sel = 1
-  ^
+       ^
 applydynamic_sip.scala:29: error: Int does not take parameters
 error after rewriting to Test.this.bad2.selectDynamic("sel")
 possible cause: maybe a wrong Dynamic method signature?

--- a/test/files/run/dynamic-applyDynamic.check
+++ b/test/files/run/dynamic-applyDynamic.check
@@ -1,0 +1,14 @@
+[[syntax trees at end of                     typer]] // newSource1.scala
+[0:67]package [0:0]<empty> {
+  [0:67]object X extends [9:67][67]scala.AnyRef {
+    [9]def <init>(): [9]X.type = [9]{
+      [9][9][9]X.super.<init>();
+      [9]()
+    };
+    [17:30]private[this] val d: [21]D = [25:30][25:30][25:30]new [29:30]D();
+    [21]<stable> <accessor> def d: [21]D = [21][21]X.this.d;
+    [37:49][37:38][37:38][37]X.this.d.applyDynamic(<39:45>"method")([46:48]10);
+    [56:61]<56:57><56:57>[56]X.this.d.applyDynamic(<56:57>"apply")([58:60]10)
+  }
+}
+

--- a/test/files/run/dynamic-applyDynamic.scala
+++ b/test/files/run/dynamic-applyDynamic.scala
@@ -1,0 +1,26 @@
+import scala.tools.partest.DirectTest
+
+object Test extends DirectTest {
+
+  override def extraSettings: String =
+    s"-usejavacp -Xprint-pos -Xprint:typer -Yrangepos -Ystop-after:typer -d ${testOutput.path}"
+
+  override def code = """
+    object X {
+      val d = new D
+      d.method(10)
+      d(10)
+    }
+  """.trim
+
+  override def show(): Unit = {
+    Console.withErr(System.out) {
+      compile()
+    }
+  }
+}
+
+import language.dynamics
+class D extends Dynamic {
+  def applyDynamic(name: String)(value: Any) = ???
+}

--- a/test/files/run/dynamic-applyDynamicNamed.check
+++ b/test/files/run/dynamic-applyDynamicNamed.check
@@ -1,0 +1,14 @@
+[[syntax trees at end of                     typer]] // newSource1.scala
+[0:97]package [0:0]<empty> {
+  [0:97]object X extends [9:97][97]scala.AnyRef {
+    [9]def <init>(): [9]X.type = [9]{
+      [9][9][9]X.super.<init>();
+      [9]()
+    };
+    [17:30]private[this] val d: [21]D = [25:30][25:30][25:30]new [29:30]D();
+    [21]<stable> <accessor> def d: [21]D = [21][21]X.this.d;
+    [37:70][37:38][37:38][37]X.this.d.applyDynamicNamed(<39:43>"meth")([44:55][44][44][44]scala.this.Tuple2.apply[[44]String, [44]Int]([44:50]"value1", [53:55]10), [57:69][57][57][57]scala.this.Tuple2.apply[[57]String, [57]Int]([57:63]"value2", [66:69]100));
+    [77:91]<77:78><77:78>[77]X.this.d.applyDynamicNamed(<77:78>"apply")([79:90][79][79][79]scala.this.Tuple2.apply[[79]String, [79]Int]([79:85]"value1", [88:90]10))
+  }
+}
+

--- a/test/files/run/dynamic-applyDynamicNamed.scala
+++ b/test/files/run/dynamic-applyDynamicNamed.scala
@@ -1,0 +1,26 @@
+import scala.tools.partest.DirectTest
+
+object Test extends DirectTest {
+
+  override def extraSettings: String =
+    s"-usejavacp -Xprint-pos -Xprint:typer -Yrangepos -Ystop-after:typer -d ${testOutput.path}"
+
+  override def code = """
+    object X {
+      val d = new D
+      d.meth(value1 = 10, value2 = 100)
+      d(value1 = 10)
+    }
+  """.trim
+
+  override def show(): Unit = {
+    Console.withErr(System.out) {
+      compile()
+    }
+  }
+}
+
+import language.dynamics
+class D extends Dynamic {
+  def applyDynamicNamed(name: String)(value: (String, Any)*) = ???
+}

--- a/test/files/run/dynamic-selectDynamic.check
+++ b/test/files/run/dynamic-selectDynamic.check
@@ -1,0 +1,13 @@
+[[syntax trees at end of                     typer]] // newSource1.scala
+[0:50]package [0:0]<empty> {
+  [0:50]object X extends [9:50][50]scala.AnyRef {
+    [9]def <init>(): [9]X.type = [9]{
+      [9][9][9]X.super.<init>();
+      [9]()
+    };
+    [17:30]private[this] val d: [21]D = [25:30][25:30][25:30]new [29:30]D();
+    [21]<stable> <accessor> def d: [21]D = [21][21]X.this.d;
+    [37:38][37:38][37]X.this.d.selectDynamic(<39:44>"field")
+  }
+}
+

--- a/test/files/run/dynamic-selectDynamic.scala
+++ b/test/files/run/dynamic-selectDynamic.scala
@@ -1,0 +1,25 @@
+import scala.tools.partest.DirectTest
+
+object Test extends DirectTest {
+
+  override def extraSettings: String =
+    s"-usejavacp -Xprint-pos -Xprint:typer -Yrangepos -Ystop-after:typer -d ${testOutput.path}"
+
+  override def code = """
+    object X {
+      val d = new D
+      d.field
+    }
+  """.trim
+
+  override def show(): Unit = {
+    Console.withErr(System.out) {
+      compile()
+    }
+  }
+}
+
+import language.dynamics
+class D extends Dynamic {
+  def selectDynamic(name: String) = ???
+}

--- a/test/files/run/dynamic-updateDynamic.check
+++ b/test/files/run/dynamic-updateDynamic.check
@@ -1,0 +1,14 @@
+[[syntax trees at end of                     typer]] // newSource1.scala
+[0:69]package [0:0]<empty> {
+  [0:69]object X extends [9:69][69]scala.AnyRef {
+    [9]def <init>(): [9]X.type = [9]{
+      [9][9][9]X.super.<init>();
+      [9]()
+    };
+    [17:30]private[this] val d: [21]D = [25:30][25:30][25:30]new [29:30]D();
+    [21]<stable> <accessor> def d: [21]D = [21][21]X.this.d;
+    [37:49][37:38][37:38][37]X.this.d.updateDynamic(<39:44>"field")([47:49]10);
+    [56:57][56:57][56]X.this.d.selectDynamic(<58:63>"field")
+  }
+}
+

--- a/test/files/run/dynamic-updateDynamic.scala
+++ b/test/files/run/dynamic-updateDynamic.scala
@@ -1,0 +1,28 @@
+import scala.tools.partest.DirectTest
+
+object Test extends DirectTest {
+
+  override def extraSettings: String =
+    s"-usejavacp -Xprint-pos -Xprint:typer -Yrangepos -Ystop-after:typer -d ${testOutput.path}"
+
+  override def code = """
+    object X {
+      val d = new D
+      d.field = 10
+      d.field
+    }
+  """.trim
+
+  override def show(): Unit = {
+    Console.withErr(System.out) {
+      compile()
+    }
+  }
+}
+
+import language.dynamics
+class D extends Dynamic {
+  def selectDynamic(name: String): Any = ???
+  def updateDynamic(name: String)(value: Any): Unit = ???
+}
+


### PR DESCRIPTION
Rebase of #3190 to make it work with 2.10.x
- update `pointOrEnd` to work with both `Range`\- and `OffsetPosition`s
- update checkfiles for unrelated position differences between master and 2.10.x

We'll have to update the checkfiles when we merge to master. We can
also switch back to using `point`.

Review by @sschaef
