### PR TITLE
Use -Dupdate.versions to update versions.properties

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -561,6 +561,27 @@ TODO:
     <echo message="canonical suffix: ${version.suffix}" /> -->
     <fail unless="version.suffixes.consistent" message="Version suffixes inconsistent!"/>
 
+
+    <!-- used during releases to bump versions in versions.properties -->
+    <if><isset property="update.versions"/><then>
+      <echo message="Updating `versions.properties`:"/>
+      <echo message="  starr.version                           = ${starr.version}"/>
+      <echo message="  scala.binary.version                    = ${scala.binary.version}"/>
+      <echo message="  partest.version.number                  = ${partest.version.number}"/>
+      <echo message="  scala-xml.version.number                = ${scala-xml.version.number}"/>
+      <echo message="  scala-parser-combinators.version.number = ${scala-parser-combinators.version.number}"/>
+      <echo message="  scalacheck.version.number               = ${scalacheck.version.number}"/>
+
+      <propertyfile file="versions.properties">
+        <entry key="starr.version"                           value="${starr.version}"/>
+        <entry key="scala.binary.version"                    value="${scala.binary.version}"/>
+        <entry key="partest.version.number"                  value="${partest.version.number}"/>
+        <entry key="scala-xml.version.number"                value="${scala-xml.version.number}"/>
+        <entry key="scala-parser-combinators.version.number" value="${scala-parser-combinators.version.number}"/>
+        <entry key="scalacheck.version.number"               value="${scalacheck.version.number}"/>
+      </propertyfile>
+    </then></if>
+
     <path id="forkjoin.classpath" path="${build-libs.dir}/classes/forkjoin"/>
     <path id="asm.classpath"      path="${build-asm.dir}/classes"/>
     <property name="forkjoin-classes" refid="forkjoin.classpath"/>


### PR DESCRIPTION
To allow automating the release process (which involves bumping the versions in versions.properties),
this serializes the relevant ant properties (set on the command line by the release script) to versions.properties.

See build.sh in https://github.com/scala/scala-modules-build for the WIP on the release script.

review by @retronym 
