### PR TITLE
SI-5508 Eagerly create accessors for private[this] in traits

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
@@ -143,7 +143,7 @@ trait MethodSynthesis {
           val lazyValGetter = LazyValGetter(tree).createAndEnterSymbol()
           enterLazyVal(tree, lazyValGetter)
         } else {
-          if (mods.isPrivateLocal)
+          if (mods.isPrivateLocal && owner.isCaseClass)
             PrivateThisCaseClassParameterError(tree)
           val getter = Getter(tree).createAndEnterSymbol()
           // Create the setter if necessary.

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -119,12 +119,12 @@ trait Namers extends MethodSynthesis {
     // Neither gets accessors so the code is as far as I know still correct.
     def noEnterGetterSetter(vd: ValDef) = !vd.mods.isLazy && (
          !owner.isClass
-      || (vd.mods.isPrivateLocal && !vd.mods.isCaseAccessor)
+      || (vd.mods.isPrivateLocal && !vd.mods.isCaseAccessor && !owner.isTrait) // SI-5508 eagerly create accessor for private[this] trait fields
       || (vd.name startsWith nme.OUTER)
       || (context.unit.isJava)
     )
     def noFinishGetterSetter(vd: ValDef) = (
-         (vd.mods.isPrivateLocal && !vd.mods.isLazy) // all lazy vals need accessors, even private[this]
+         (vd.mods.isPrivateLocal && !vd.mods.isLazy && !owner.isTrait) // all lazy vals need accessors, even private[this]
       || vd.symbol.isModuleVar)
 
     def setPrivateWithin[T <: Symbol](tree: Tree, sym: T, mods: Modifiers): T =

--- a/test/files/pos/t5508-min-okay.scala
+++ b/test/files/pos/t5508-min-okay.scala
@@ -1,0 +1,6 @@
+object Test {
+  trait NestedTrait { // must be nested and a trait
+    private val _st : Int = 0 // crashes if changed to private[this]
+    val escape = { () => _st }
+  }
+}

--- a/test/files/pos/t5508-min-okay2.scala
+++ b/test/files/pos/t5508-min-okay2.scala
@@ -1,0 +1,4 @@
+trait TopTrait { // must be nested and a trait
+  private[this] val _st : Int = 0 // crashes if TopTrait is not top level
+  val escape = { () => _st }
+}

--- a/test/files/pos/t5508-min.scala
+++ b/test/files/pos/t5508-min.scala
@@ -1,0 +1,6 @@
+object Test {
+  trait NestedTrait { // must be nested and a trait
+    private[this] val _st : Int = 0 // must be private[this]
+    val escape = { () => _st }
+  }
+}

--- a/test/files/pos/t5508.scala
+++ b/test/files/pos/t5508.scala
@@ -1,0 +1,83 @@
+package TestTestters
+
+trait Test1 {
+  private[this] var _st : Int = 0
+  def close : PartialFunction[Any,Any] = {
+    case x : Int =>
+      _st = identity(_st)
+  }
+}
+
+object Base1 {
+  trait Test2 {
+    private[this] var _st : Int = 0
+    def close : PartialFunction[Any,Any] = {
+      case x : Int =>
+  _st = identity(_st)
+    }
+  }
+}
+
+class Test3 {
+  private[this] var _st : Int = 0
+  def close : PartialFunction[Any,Any] = {
+    case x : Int =>
+      _st = 1
+  }
+}
+
+object Base2 {
+  class Test4 {
+    private[this] var _st : Int = 0
+    def close : PartialFunction[Any,Any] = {
+      case x : Int =>
+  _st = 1
+    }
+  }
+}
+
+class Base3 {
+  trait Test5 {
+    private[this] var _st : Int = 0
+    def close : PartialFunction[Any,Any] = {
+      case x : Int =>
+  _st = 1
+    }
+  }
+}
+
+object Base4 {
+  trait Test6 {
+    private[this] var _st : Int = 0
+    def close : PartialFunction[Any,Any] = {
+      case x : Int => ()
+    }
+  }
+}
+
+object Base5 {
+  trait Test7 {
+    private[this] var _st : Int = 0
+    def close = () => {
+      _st = 1
+    }
+  }
+}
+
+object Base6 {
+  class Test8 {
+    private[this] var _st : Int = 0
+    def close = () => {
+      _st = 1
+    }
+  }
+}
+
+object Base7 {
+  trait Test9 {
+    var st : Int = 0
+    def close = () => {
+      st = 1
+    }
+  }
+}


### PR DESCRIPTION
Currently, this is done late in the game as the Mixin tree transformer
treats the trait.

```
// Mixin#addLateInterfaceMembers
val getter = member.getter(clazz)
if (getter == NoSymbol) addMember(clazz, newGetter(member))
```

`addMember` mutates the type of the interface to add the getter.

However, if an inner class or anonymous function of the trait
has been flattened to a spot where it precedes the trait in the
enclosing packages info, this code hasn't had a chance to run,
and the lookup of the getter crashes as mixins postTransform
runs over a selection of the not-yet-materialized getter.

```
// Mixin#postTransform
case Select(qual, name) if sym.owner.isImplClass && !isStaticOnly(sym) =>
  val iface  = toInterface(sym.owner.tpe).typeSymbol
  val ifaceGetter = sym getter iface
```

This commit removes the optimization to avoid creating accessors
in Namers for private[this] if the owner is a trait.

I can't spot a difference in the end result:

```
% cat sandbox/test.scala
trait T {
  private       val x: Int = 0
  private[this] val y: Int = 0
}

% scalac-hash v2.10.3  sandbox/test.scala && javap -classpath . T
Compiled from "test.scala"
public interface T{
    public abstract void T$_setter_$T$$x_$eq(int);
    public abstract int T$$y();
    public abstract void T$_setter_$T$$y_$eq(int);
    public abstract int T$$x();
}

% qbin/scala  sandbox/test.scala && javap -classpath . T
Compiled from "test.scala"
public interface T{
    public abstract void T$_setter_$T$$x_$eq(int);
    public abstract int T$$y();
    public abstract void T$_setter_$T$$y_$eq(int);
    public abstract int T$$x();
}
```

But we need to explore the history a little to figure out what
this change might break.
