### PR TITLE
SI-5508 Fix crasher with private[this] in nested traits

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Flatten.scala
+++ b/src/compiler/scala/tools/nsc/transform/Flatten.scala
@@ -134,7 +134,10 @@ abstract class Flatten extends InfoTransform {
     /** Transform statements and add lifted definitions to them. */
     override def transformStats(stats: List[Tree], exprOwner: Symbol): List[Tree] = {
       val stats1 = super.transformStats(stats, exprOwner)
-      if (currentOwner.isPackageClass) stats1 ::: liftedDefs(currentOwner).toList
+      // SI-5508 Ordering important as mixin needs a chance to create accessors for private[this] trait
+      //         fields before it transforms inner classes that refer to them.
+      def lifted = liftedDefs(currentOwner).toList.sortBy(_.pos.start)
+      if (currentOwner.isPackageClass) stats1 ::: lifted
       else stats1
     }
   }

--- a/test/files/pos/t5508-min-okay.scala
+++ b/test/files/pos/t5508-min-okay.scala
@@ -1,0 +1,6 @@
+object Test {
+  trait NestedTrait { // must be nested and a trait
+    private val _st : Int = 0 // crashes if changed to private[this]
+    val escape = { () => _st }
+  }
+}

--- a/test/files/pos/t5508-min-okay2.scala
+++ b/test/files/pos/t5508-min-okay2.scala
@@ -1,0 +1,4 @@
+trait TopTrait { // must be nested and a trait
+  private[this] val _st : Int = 0 // crashes if TopTrait is not top level
+  val escape = { () => _st }
+}

--- a/test/files/pos/t5508-min.scala
+++ b/test/files/pos/t5508-min.scala
@@ -1,0 +1,6 @@
+object Test {
+  trait NestedTrait { // must be nested and a trait
+    private[this] val _st : Int = 0 // must be private[this]
+    val escape = { () => _st }
+  }
+}

--- a/test/files/pos/t5508.scala
+++ b/test/files/pos/t5508.scala
@@ -1,0 +1,83 @@
+package TestTestters
+
+trait Test1 {
+  private[this] var _st : Int = 0
+  def close : PartialFunction[Any,Any] = {
+    case x : Int =>
+      _st = identity(_st)
+  }
+}
+
+object Base1 {
+  trait Test2 {
+    private[this] var _st : Int = 0
+    def close : PartialFunction[Any,Any] = {
+      case x : Int =>
+  _st = identity(_st)
+    }
+  }
+}
+
+class Test3 {
+  private[this] var _st : Int = 0
+  def close : PartialFunction[Any,Any] = {
+    case x : Int =>
+      _st = 1
+  }
+}
+
+object Base2 {
+  class Test4 {
+    private[this] var _st : Int = 0
+    def close : PartialFunction[Any,Any] = {
+      case x : Int =>
+  _st = 1
+    }
+  }
+}
+
+class Base3 {
+  trait Test5 {
+    private[this] var _st : Int = 0
+    def close : PartialFunction[Any,Any] = {
+      case x : Int =>
+  _st = 1
+    }
+  }
+}
+
+object Base4 {
+  trait Test6 {
+    private[this] var _st : Int = 0
+    def close : PartialFunction[Any,Any] = {
+      case x : Int => ()
+    }
+  }
+}
+
+object Base5 {
+  trait Test7 {
+    private[this] var _st : Int = 0
+    def close = () => {
+      _st = 1
+    }
+  }
+}
+
+object Base6 {
+  class Test8 {
+    private[this] var _st : Int = 0
+    def close = () => {
+      _st = 1
+    }
+  }
+}
+
+object Base7 {
+  trait Test9 {
+    var st : Int = 0
+    def close = () => {
+      st = 1
+    }
+  }
+}


### PR DESCRIPTION
Currently, this is done late in the game as the Mixin tree transformer
treats the trait.

```
// Mixin#addLateInterfaceMembers
val getter = member.getter(clazz)
if (getter == NoSymbol) addMember(clazz, newGetter(member))
```

`addMember` mutates the type of the interface to add the getter.

However, if an inner class or anonymous function of the trait
has been flattened to a spot where it precedes the trait in the
enclosing packages info, this code hasn't had a chance to run,
and the lookup of the getter crashes as mixins postTransform
runs over a selection of the not-yet-materialized getter.

```
// Mixin#postTransform
case Select(qual, name) if sym.owner.isImplClass && !isStaticOnly(sym) =>
  val iface  = toInterface(sym.owner.tpe).typeSymbol
  val ifaceGetter = sym getter iface
```

This commit removes ensures that Flatten lifts inner classes to
a position _after_ the enclosing class in the stats of the
enclosing package.
