### PR TITLE
Diminished Tuple Confusion

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
@@ -233,9 +233,6 @@ trait MatchOptimization extends MatchTreeMaking with MatchAnalysis {
       def defaultBody: Tree
       def defaultCase(scrutSym: Symbol = defaultSym, guard: Tree = EmptyTree, body: Tree = defaultBody): CaseDef
 
-      private def sequence[T](xs: List[Option[T]]): Option[List[T]] =
-        if (xs exists (_.isEmpty)) None else Some(xs.flatten)
-
       object GuardAndBodyTreeMakers {
           def unapply(tms: List[TreeMaker]): Option[(Tree, Tree)] = {
             tms match {

--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -109,6 +109,22 @@ trait TypeDiagnostics {
     case x                                    => x.toString
   }
 
+  /**
+   * [a, b, c] => "(a, b, c)"
+   * [a, B]    => "(param1, param2)"
+   * [a, B, c] => "(param1, ..., param2)"
+   */
+  final def exampleTuplePattern(names: List[Name]): String = {
+    val arity = names.length
+    val varPatterNames: Option[List[String]] = sequence(names map {
+      case name if nme.isVariableName(name) => Some(name.decode)
+      case _                                => None
+    })
+    def parenthesize(a: String) = s"($a)"
+    def genericParams = (Seq("param1") ++ (if (arity > 2) Seq("...") else Nil) ++ Seq(s"param$arity"))
+    parenthesize(varPatterNames.getOrElse(genericParams).mkString(", "))
+  }
+
   def alternatives(tree: Tree): List[Type] = tree.tpe match {
     case OverloadedType(pre, alternatives)  => alternatives map pre.memberType
     case _                                  => Nil

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2906,6 +2906,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       else if (argpts.lengthCompare(numVparams) != 0)
         WrongNumberOfParametersError(fun, argpts)
       else {
+        var issuedMissingParameterTypeError = false
         foreach2(fun.vparams, argpts) { (vparam, argpt) =>
           if (vparam.tpt.isEmpty) {
             vparam.tpt.tpe =
@@ -2923,7 +2924,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                     }
                   case _ =>
                 }
-                MissingParameterTypeError(fun, vparam, pt)
+                MissingParameterTypeError(fun, vparam, pt, withTupleAddendum = !issuedMissingParameterTypeError)
+                issuedMissingParameterTypeError = true
                 ErrorType
               }
             if (!vparam.tpt.pos.isDefined) vparam.tpt setPos vparam.pos.focus

--- a/src/reflect/scala/reflect/internal/util/Collections.scala
+++ b/src/reflect/scala/reflect/internal/util/Collections.scala
@@ -244,6 +244,11 @@ trait Collections {
     true
   }
 
+  final def sequence[A](as: List[Option[A]]): Option[List[A]] = {
+    if (as.exists (_.isEmpty)) None
+    else Some(as.flatten)
+  }
+
   final def transposeSafe[A](ass: List[List[A]]): Option[List[List[A]]] = try {
     Some(ass.transpose)
   } catch {

--- a/test/files/neg/missing-param-type-tuple.check
+++ b/test/files/neg/missing-param-type-tuple.check
@@ -1,0 +1,31 @@
+missing-param-type-tuple.scala:3: error: missing parameter type
+Note: The expected type requires a one-argument function accepting a 2-Tuple.
+      Consider a pattern matching anoynmous function, `{ case (a, b) =>  ... }`
+  val x: ((Int, Int)) => Int = (a, b) => 0
+                                ^
+missing-param-type-tuple.scala:3: error: missing parameter type
+  val x: ((Int, Int)) => Int = (a, b) => 0
+                                   ^
+missing-param-type-tuple.scala:5: error: missing parameter type
+Note: The expected type requires a one-argument function accepting a 3-Tuple.
+      Consider a pattern matching anoynmous function, `{ case (param1, ..., param3) =>  ... }`
+  val y: ((Int, Int, Int)) => Int = (a, b, !!) => 0
+                                     ^
+missing-param-type-tuple.scala:5: error: missing parameter type
+  val y: ((Int, Int, Int)) => Int = (a, b, !!) => 0
+                                        ^
+missing-param-type-tuple.scala:5: error: missing parameter type
+  val y: ((Int, Int, Int)) => Int = (a, b, !!) => 0
+                                           ^
+missing-param-type-tuple.scala:7: error: missing parameter type
+Note: The expected type requires a one-argument function accepting a 3-Tuple.
+      Consider a pattern matching anoynmous function, `{ case (param1, ..., param3) =>  ... }`
+  val z: ((Int, Int, Int)) => Int = (a, NotAVariablePatternName, c) => 0
+                                     ^
+missing-param-type-tuple.scala:7: error: missing parameter type
+  val z: ((Int, Int, Int)) => Int = (a, NotAVariablePatternName, c) => 0
+                                        ^
+missing-param-type-tuple.scala:7: error: missing parameter type
+  val z: ((Int, Int, Int)) => Int = (a, NotAVariablePatternName, c) => 0
+                                                                 ^
+8 errors found

--- a/test/files/neg/missing-param-type-tuple.scala
+++ b/test/files/neg/missing-param-type-tuple.scala
@@ -1,0 +1,8 @@
+class C {
+
+  val x: ((Int, Int)) => Int = (a, b) => 0
+
+  val y: ((Int, Int, Int)) => Int = (a, b, !!) => 0
+
+  val z: ((Int, Int, Int)) => Int = (a, NotAVariablePatternName, c) => 0
+}

--- a/test/files/neg/not-a-legal-formal-parameter-tuple.check
+++ b/test/files/neg/not-a-legal-formal-parameter-tuple.check
@@ -1,0 +1,19 @@
+not-a-legal-formal-parameter-tuple.scala:2: error: not a legal formal parameter.
+Note: Tuples cannot be directly destructured in method or function parameters.
+      Either create a single parameter accepting the Tuple2,
+      or consider a pattern matching anonymous function: `{ case (a, b) => ... }
+  val x: ((Int, Int) => Int) = (((a, b)) => a)
+                                 ^
+not-a-legal-formal-parameter-tuple.scala:3: error: not a legal formal parameter.
+Note: Tuples cannot be directly destructured in method or function parameters.
+      Either create a single parameter accepting the Tuple2,
+      or consider a pattern matching anonymous function: `{ case (param1, param2) => ... }
+  val y: ((Int, Int, Int) => Int) = (((a, !!)) => a)
+                                      ^
+not-a-legal-formal-parameter-tuple.scala:4: error: not a legal formal parameter.
+Note: Tuples cannot be directly destructured in method or function parameters.
+      Either create a single parameter accepting the Tuple3,
+      or consider a pattern matching anonymous function: `{ case (param1, ..., param3) => ... }
+  val z: ((Int, Int, Int) => Int) = (((a, NotAPatternVariableName, c)) => a)
+                                      ^
+three errors found

--- a/test/files/neg/not-a-legal-formal-parameter-tuple.scala
+++ b/test/files/neg/not-a-legal-formal-parameter-tuple.scala
@@ -1,0 +1,5 @@
+class C {
+  val x: ((Int, Int) => Int) = (((a, b)) => a)
+  val y: ((Int, Int, Int) => Int) = (((a, !!)) => a)
+  val z: ((Int, Int, Int) => Int) = (((a, NotAPatternVariableName, c)) => a)
+}


### PR DESCRIPTION
- Better error message for ((a, b) => c): (Tuple2[A, B] => C)
- Better error message for (((a, b)) => c)

Review by @densh @soc
