### PR TITLE
Test case for recently improved unchecked warning

### DIFF
--- a/test/files/neg/patmat-classtag-compound.check
+++ b/test/files/neg/patmat-classtag-compound.check
@@ -1,0 +1,6 @@
+patmat-classtag-compound.scala:12: warning: abstract type pattern A is unchecked since it is eliminated by erasure
+    case b: A with Bar => true
+            ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/patmat-classtag-compound.flags
+++ b/test/files/neg/patmat-classtag-compound.flags
@@ -1,0 +1,1 @@
+-unchecked -Xfatal-warnings

--- a/test/files/neg/patmat-classtag-compound.scala
+++ b/test/files/neg/patmat-classtag-compound.scala
@@ -1,0 +1,17 @@
+object Test extends App{
+  trait Bar
+  trait Foo
+  // Failed to give an unchecked warning pre: https://github.com/scala/scala/pull/2848
+  //
+  // Features interacting:
+  //   - implicit class tags to enable type patterns on abstract types
+  //   - type tests on compound types.
+  //
+  // We could try make these work together, but an unchecked warning is okay for now.
+  def x[A: reflect.ClassTag](a: Any): Boolean = a match{
+    case b: A with Bar => true
+    case _ => false
+  }
+  println(x[Foo](new Bar{}))
+  println(x[String](""))
+}


### PR DESCRIPTION
Prior to https://github.com/scala/scala/pull/2848, the enclosed
test compiled without warning and printed:

```
true
false
```

Features interacting:
- implicit class tags to enable type patterns on abstract types
- type tests on compound types.

I think the unchecked warning is acceptable for now.
