### PR TITLE
SI-8019 Make Publisher check 'Reaction' partial-function is defined for an Event

### DIFF
--- a/src/swing/scala/swing/Publisher.scala
+++ b/src/swing/scala/swing/Publisher.scala
@@ -44,7 +44,7 @@ trait Publisher extends Reactor {
   /**
    * Notify all registered reactions.
    */
-  def publish(e: Event) { for (l <- listeners) l(e) }
+  def publish(e: Event) { for (l <- listeners) if (l.isDefinedAt(e)) l(e) }
 
   listenTo(this)
 }


### PR DESCRIPTION
Reactions are PartialFunctions, so if events come through indiscriminately that the listener is not defined for, errors occur. Eg:

```
Exception in thread "AWT-EventQueue-0" scala.MatchError: FocusGained(scala.swing wrapper scala.swing.TextField
```

A Coursera thread with people affected by this issue: https://class.coursera.org/reactive-001/forum/thread?thread_id=1315

_I've signed the Scala CLA._
