### PR TITLE
SI-7281 Add @scala.runtime.ValueType to value type classes

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -929,6 +929,7 @@ trait Namers extends MethodSynthesis {
       if (clazz.isDerivedValueClass) {
         log("Ensuring companion for derived value class " + cdef.name + " at " + cdef.pos.show)
         clazz setFlag FINAL
+        clazz.addAnnotation(AnnotationInfo(ValueTypeAnnotationClass.tpe, Nil, Nil))
         // Don't force the owner's info lest we create cycles as in SI-6357.
         enclosingNamerWithScope(clazz.owner.rawInfo.decls).ensureCompanionObject(cdef)
       }

--- a/src/library/scala/runtime/ValueType.java
+++ b/src/library/scala/runtime/ValueType.java
@@ -1,0 +1,10 @@
+package scala.runtime;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ValueType {}

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -353,6 +353,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val StringAddClass             = requiredClass[scala.runtime.StringAdd]
     lazy val ScalaNumberClass           = requiredClass[scala.math.ScalaNumber]
     lazy val TraitSetterAnnotationClass = requiredClass[scala.runtime.TraitSetter]
+    lazy val ValueTypeAnnotationClass   = requiredClass[scala.runtime.ValueType]
     lazy val DelayedInitClass           = requiredClass[scala.DelayedInit]
       def delayedInitMethod = getMemberMethod(DelayedInitClass, nme.delayedInit)
 

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -261,6 +261,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.StringAddClass
     definitions.ScalaNumberClass
     definitions.TraitSetterAnnotationClass
+    definitions.ValueTypeAnnotationClass
     definitions.DelayedInitClass
     definitions.TypeConstraintClass
     definitions.SingletonClass

--- a/test/files/run/t7281.scala
+++ b/test/files/run/t7281.scala
@@ -1,0 +1,12 @@
+import scala.runtime.ValueType
+
+object Test extends App {
+
+  // Works automatically for AnyVals ...
+  assert(classOf[RichException].isAnnotationPresent(classOf[ValueType]))
+
+  // ... but can also be added manually
+  @ValueType
+  class Complex(real: Double, imag: Double)
+  assert(classOf[Complex].isAnnotationPresent(classOf[ValueType]))
+}


### PR DESCRIPTION
Instead of preserving AnyVal as a superclass, which seems to be out of
reach for the time being, add a marker annotation which gives runtimes
an cheap and easy way to check whether a certain class is a value type
without depending on a language-specific library.
