### PR TITLE
SI-8022 Backwards compatibility for Regex#unapplySeq

### DIFF
--- a/src/library/scala/util/matching/Regex.scala
+++ b/src/library/scala/util/matching/Regex.scala
@@ -188,9 +188,9 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *  @param  s     The string to match
    *  @return       The matches
    */
-  def unapplySeq(s: CharSequence): Option[Seq[String]] = {
+  def unapplySeq(s: CharSequence): Option[List[String]] = {
     val m = pattern matcher s
-    if (runMatcher(m)) Some(1 to m.groupCount map m.group)
+    if (runMatcher(m)) Some((1 to m.groupCount).toList map m.group)
     else None
   }
 
@@ -225,10 +225,10 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *  @param  c     The Char to match
    *  @return       The match
    */
-  def unapplySeq(c: Char): Option[Seq[Char]] = {
+  def unapplySeq(c: Char): Option[List[Char]] = {
     val m = pattern matcher c.toString
     if (runMatcher(m)) {
-      if (m.groupCount > 0) Some(m group 1) else Some(Nil)
+      if (m.groupCount > 0) Some((m group 1).toList) else Some(Nil)
     } else None
   }
 
@@ -238,9 +238,9 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *  Otherwise, this Regex is applied to the previously matched input,
    *  and the result of that match is used.
    */
-  def unapplySeq(m: Match): Option[Seq[String]] =
+  def unapplySeq(m: Match): Option[List[String]] =
     if (m.matched == null) None
-    else if (m.matcher.pattern == this.pattern) Some(1 to m.groupCount map m.group)
+    else if (m.matcher.pattern == this.pattern) Some((1 to m.groupCount).toList map m.group)
     else unapplySeq(m.matched)
 
   /** Tries to match target.

--- a/test/junit/scala/util/matching/RegexTest.scala
+++ b/test/junit/scala/util/matching/RegexTest.scala
@@ -1,0 +1,30 @@
+
+package scala.util.matching
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class RegexTest {
+  @Test def t8022CharSequence(): Unit = {
+    val full = """.*: (.)$""".r
+    val text = "   When I use this operator: *"
+    // Testing 2.10.x compatibility of the return types of unapplySeq
+    val x :: Nil = full.unapplySeq(text: Any).get
+    val y :: Nil = full.unapplySeq(text: CharSequence).get
+    assertEquals("*", x)
+    assertEquals("*", y)
+  }
+
+  @Test def t8022Match(): Unit = {
+    val R = """(\d)""".r
+    val matchh = R.findFirstMatchIn("a1").get
+    // Testing 2.10.x compatibility of the return types of unapplySeq
+    val x :: Nil = R.unapplySeq(matchh: Any).get
+    val y :: Nil = R.unapplySeq(matchh).get
+    assertEquals("1", x)
+    assertEquals("1", y)
+  }
+}


### PR DESCRIPTION
The change in ce1bbfe / SI-6406 introduced overloades of
`unapplySeq` with wider static and dynmaic result types
than the now-deprecated alternative that accepted `Any`.

This is subtly source incompatible and the change was noticed
in Specs2.

This commit uses `List` as the static and runtime type for
the new overloads.

For consistency, the same is done for the new method added
in SI-7737 / 93e9623.

Review by @som-snytt
