### PR TITLE
SI-7548 askTypeAt returns the same type for full/ targeted typecheck (2.10.x)

### DIFF
--- a/src/compiler/scala/tools/nsc/interactive/Global.scala
+++ b/src/compiler/scala/tools/nsc/interactive/Global.scala
@@ -247,16 +247,21 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
           println("something's wrong: no "+context.unit+" in "+result+result.pos)
           located = result
         }
-        throw new TyperResult(located)
+        located.tpe match {
+          case _: OverloadedType => ()
+          case _ => throw new TyperResult(located)
+        }
       }
-      try {
-        checkForMoreWork(old.pos)
-      } catch {
-        case ex: ValidateException => // Ignore, this will have been reported elsewhere
-          debugLog("validate exception caught: "+ex)
-        case ex: Throwable =>
-          log.flush()
-          throw ex
+      else {
+        try {
+          checkForMoreWork(old.pos)
+        } catch {
+          case ex: ValidateException => // Ignore, this will have been reported elsewhere
+            debugLog("validate exception caught: "+ex)
+          case ex: Throwable =>
+            log.flush()
+            throw ex
+        }
       }
     }
   }

--- a/test/files/presentation/t7548.check
+++ b/test/files/presentation/t7548.check
@@ -1,0 +1,1 @@
+(x: Int)Unit

--- a/test/files/presentation/t7548/Test.scala
+++ b/test/files/presentation/t7548/Test.scala
@@ -1,0 +1,17 @@
+import scala.tools.nsc.interactive.tests.InteractiveTest
+
+object Test extends InteractiveTest {
+  override protected def loadSources() { /* don't parse or typecheck sources */ }
+
+  import compiler._
+
+  override def runDefaultTests() {
+    val res = new Response[Tree]
+    val pos = compiler.rangePos(sourceFiles.head, 102,102,102)
+    compiler.askTypeAt(pos, res)
+    res.get match {
+      case Left(tree) => compiler.ask(() => reporter.println(tree.tpe))
+      case Right(ex) => reporter.println(ex)
+    }
+  }
+}

--- a/test/files/presentation/t7548/src/Foo.scala
+++ b/test/files/presentation/t7548/src/Foo.scala
@@ -1,0 +1,7 @@
+object Foo {
+  def foo(x: Int) = {}
+  def foo(x: String) = {}
+  def foo(x: Int, y: String) = {}
+  
+  foo(2)
+}

--- a/test/files/presentation/t7548b.check
+++ b/test/files/presentation/t7548b.check
@@ -1,1 +1,1 @@
-Foo.this.I.+: (other: Foo.I.type)Unit
+Foo.this.I2BI(Foo.this.I).+: (other: Foo.BI.type)Unit

--- a/test/files/presentation/t7548b.check
+++ b/test/files/presentation/t7548b.check
@@ -1,0 +1,1 @@
+Foo.this.I.+: (other: Foo.I.type)Unit

--- a/test/files/presentation/t7548b/Test.scala
+++ b/test/files/presentation/t7548b/Test.scala
@@ -1,0 +1,17 @@
+import scala.tools.nsc.interactive.tests.InteractiveTest
+
+object Test extends InteractiveTest {
+  override protected def loadSources() { /* don't parse or typecheck sources */ }
+
+  import compiler._
+
+  override def runDefaultTests() {
+    val res = new Response[Tree]
+    val pos = compiler.rangePos(sourceFiles.head, 191, 191, 191) // +
+    compiler.askTypeAt(pos, res)
+    res.get match {
+      case Left(tree) => compiler.ask(() => reporter.println(s"$tree: ${tree.tpe}"))
+      case Right(ex) => reporter.println(ex)
+    }
+  }
+}

--- a/test/files/presentation/t7548b/src/Foo.scala
+++ b/test/files/presentation/t7548b/src/Foo.scala
@@ -1,0 +1,12 @@
+import language._
+
+object Foo {
+  object I { 
+    def +(other: I.type) : Unit = ()
+  }
+  object BI {
+    def +(other: BI.type): Unit = ()
+  }
+  implicit def I2BI(i: I.type): BI.type = BI
+  I.+(BI)
+}


### PR DESCRIPTION
Re-opened https://github.com/scala/scala/pull/3177 to target 2.10.x

review by @retronym

~~P.S. This commit https://github.com/dotta/scala/commit/652b3b4b9dcbf990e7ace409e050cc4ba4e83b16 will fail the build because the commit is intended to show the issue. I expect this won't be a problem for merging the PR.~~ not true, see comment https://github.com/scala/scala/pull/3208#issuecomment-29605967
