### PR TITLE
SI-7995 completion imported vars and vals

### DIFF
--- a/src/compiler/scala/tools/nsc/interactive/Global.scala
+++ b/src/compiler/scala/tools/nsc/interactive/Global.scala
@@ -955,7 +955,11 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
     val enclosing = new Members[ScopeMember]
     def addScopeMember(sym: Symbol, pre: Type, viaImport: Tree) =
       locals.add(sym, pre, false) { (s, st) =>
-        new ScopeMember(s, st, context.isAccessible(s, pre, false), viaImport)
+        // imported val and var are always marked as inaccessible, but they could be accessed through their getters. SI-7995
+        if (s.hasGetter) 
+          new ScopeMember(s, st, context.isAccessible(s.getter, pre, superAccess = false), viaImport)
+        else
+          new ScopeMember(s, st, context.isAccessible(s, pre, superAccess = false), viaImport)
       }
     def localsToEnclosing() = {
       enclosing.addNonShadowed(locals)

--- a/test/files/presentation/scope-completion-2.check
+++ b/test/files/presentation/scope-completion-2.check
@@ -1,35 +1,33 @@
 reload: Completions.scala
 
-askScopeCompletion at Completions.scala(16,4)
+askScopeCompletion at Completions.scala(15,2)
 ================================================================================
-[response] askScopeCompletion at (16,4)
-retrieved 11 members
+[response] askScopeCompletion at (15,2)
+retrieved 10 members
 [accessible:  true] `class Cc1Completion1.this.Cc1`
 [accessible:  true] `class Co1test.Completion1.Co1`
 [accessible:  true] `class Completion1test.Completion1`
 [accessible:  true] `constructor Completion1()test.Completion1`
 [accessible:  true] `method fc1=> Int`
 [accessible:  true] `method fo1=> Int`
-[accessible:  true] `method test=> Unit`
 [accessible:  true] `object Completion1test.Completion1.type`
 [accessible:  true] `value ctest.Completion1`
 [accessible:  true] `value vc1Int`
 [accessible:  true] `value vo1Int`
 ================================================================================
 
-askScopeCompletion at Completions.scala(32,4)
+askScopeCompletion at Completions.scala(29,2)
 ================================================================================
-[response] askScopeCompletion at (32,4)
-retrieved 11 members
+[response] askScopeCompletion at (29,2)
+retrieved 10 members
 [accessible:  true] `class Cc1test.Completion1.c.Cc1`
 [accessible:  true] `class Co1test.Completion1.Co1`
 [accessible:  true] `class Completion1test.Completion1`
 [accessible:  true] `constructor Completion1()test.Completion1.type`
 [accessible:  true] `method fc1=> Int`
 [accessible:  true] `method fo1=> Int`
-[accessible:  true] `method test=> Unit`
 [accessible:  true] `object Completion1test.Completion1.type`
 [accessible:  true] `value ctest.Completion1`
+[accessible:  true] `value vc1Int`
 [accessible:  true] `value vo1Int`
-[accessible: false] `value vc1Int`
 ================================================================================

--- a/test/files/presentation/scope-completion-2/src/Completions.scala
+++ b/test/files/presentation/scope-completion-2/src/Completions.scala
@@ -9,12 +9,10 @@ class Completion1 {
   private val vc1 = 0
   private def fc1 = 0
 
-  private class Cc1
-
-  def test {
-    // needs to be done in a method, because of SI-7280
-    /*_*/
+  private class Cc1 {
   }
+
+  /*_*/
 }
 
 object Completion1 {
@@ -25,11 +23,9 @@ object Completion1 {
   private val vo1 = 0
   private def fo1 = 0
 
-  private class Co1
-
-  def test {
-    // needs to be done in a method, because of SI-7280
-    /*_*/
+  private class Co1 {
   }
+
+  /*_*/
 }
 

--- a/test/files/presentation/scope-completion-3.check
+++ b/test/files/presentation/scope-completion-3.check
@@ -29,13 +29,17 @@ retrieved 49 members
 [accessible:  true] `type tc2Completion1.this.tc2`
 [accessible:  true] `type tt1Completion1.this.tt1`
 [accessible:  true] `type tt3Completion1.this.tt3`
+[accessible:  true] `value vb1Int`
 [accessible:  true] `value vb3Int`
 [accessible:  true] `value vc1Int`
 [accessible:  true] `value vc2Int`
+[accessible:  true] `value vt1Int`
 [accessible:  true] `value vt3Int`
+[accessible:  true] `variable rb1Int`
 [accessible:  true] `variable rb3Int`
 [accessible:  true] `variable rc1Int`
 [accessible:  true] `variable rc2Int`
+[accessible:  true] `variable rt1Int`
 [accessible:  true] `variable rt3Int`
 [accessible: false] `class Cb2Completion1.this.Cb2`
 [accessible: false] `class Ct2Completion1.this.Ct2`
@@ -45,13 +49,9 @@ retrieved 49 members
 [accessible: false] `object Ot2Completion1.this.Ot2.type`
 [accessible: false] `type tb2Completion1.this.tb2`
 [accessible: false] `type tt2Completion1.this.tt2`
-[accessible: false] `value vb1Int`
 [accessible: false] `value vb2Int`
-[accessible: false] `value vt1Int`
 [accessible: false] `value vt2Int`
-[accessible: false] `variable rb1Int`
 [accessible: false] `variable rb2Int`
-[accessible: false] `variable rt1Int`
 [accessible: false] `variable rt2Int`
 ================================================================================
 
@@ -84,13 +84,17 @@ retrieved 49 members
 [accessible:  true] `type to2test.Completion2.to2`
 [accessible:  true] `type tt1test.Completion2.tt1`
 [accessible:  true] `type tt3test.Completion2.tt3`
+[accessible:  true] `value vb1Int`
 [accessible:  true] `value vb3Int`
 [accessible:  true] `value vo1Int`
 [accessible:  true] `value vo2Int`
+[accessible:  true] `value vt1Int`
 [accessible:  true] `value vt3Int`
+[accessible:  true] `variable rb1Int`
 [accessible:  true] `variable rb3Int`
 [accessible:  true] `variable ro1Int`
 [accessible:  true] `variable ro2Int`
+[accessible:  true] `variable rt1Int`
 [accessible:  true] `variable rt3Int`
 [accessible: false] `class Cb2test.Completion2.Cb2`
 [accessible: false] `class Ct2test.Completion2.Ct2`
@@ -100,12 +104,8 @@ retrieved 49 members
 [accessible: false] `object Ot2test.Completion2.Ot2.type`
 [accessible: false] `type tb2test.Completion2.tb2`
 [accessible: false] `type tt2test.Completion2.tt2`
-[accessible: false] `value vb1Int`
 [accessible: false] `value vb2Int`
-[accessible: false] `value vt1Int`
 [accessible: false] `value vt2Int`
-[accessible: false] `variable rb1Int`
 [accessible: false] `variable rb2Int`
-[accessible: false] `variable rt1Int`
 [accessible: false] `variable rt2Int`
 ================================================================================

--- a/test/files/presentation/scope-completion-import.check
+++ b/test/files/presentation/scope-completion-import.check
@@ -1,9 +1,9 @@
 reload: Completions.scala
 
-askScopeCompletion at Completions.scala(15,4)
+askScopeCompletion at Completions.scala(23,4)
 ================================================================================
-[response] askScopeCompletion at (15,4)
-retrieved 10 members
+[response] askScopeCompletion at (23,4)
+retrieved 18 members
 [accessible:  true] `class Ctest.C`
 [accessible:  true] `class Foo_1test.Foo_1`
 [accessible:  true] `class Foo_2test.Foo_2`
@@ -14,12 +14,20 @@ retrieved 10 members
 [accessible:  true] `method fOOO=> Int`
 [accessible:  true] `object Otest.O.type`
 [accessible:  true] `value otest.O.type`
+[accessible:  true] `value vCCCInt`
+[accessible:  true] `value vOOOInt`
+[accessible:  true] `variable rCCCInt`
+[accessible:  true] `variable rOOOInt`
+[accessible: false] `value pVCCCInt`
+[accessible: false] `value pVOOOInt`
+[accessible: false] `variable pRCCCInt`
+[accessible: false] `variable pROOOInt`
 ================================================================================
 
-askScopeCompletion at Completions.scala(19,4)
+askScopeCompletion at Completions.scala(27,4)
 ================================================================================
-[response] askScopeCompletion at (19,4)
-retrieved 9 members
+[response] askScopeCompletion at (27,4)
+retrieved 17 members
 [accessible:  true] `class Ctest.C`
 [accessible:  true] `class Foo_1test.Foo_1`
 [accessible:  true] `class Foo_2test.Foo_2`
@@ -29,12 +37,20 @@ retrieved 9 members
 [accessible:  true] `method fCCC=> Int`
 [accessible:  true] `method fOOO=> Int`
 [accessible:  true] `object Otest.O.type`
+[accessible:  true] `value vCCCInt`
+[accessible:  true] `value vOOOInt`
+[accessible:  true] `variable rCCCInt`
+[accessible:  true] `variable rOOOInt`
+[accessible: false] `value pVCCCInt`
+[accessible: false] `value pVOOOInt`
+[accessible: false] `variable pRCCCInt`
+[accessible: false] `variable pROOOInt`
 ================================================================================
 
-askScopeCompletion at Completions.scala(24,4)
+askScopeCompletion at Completions.scala(32,4)
 ================================================================================
-[response] askScopeCompletion at (24,4)
-retrieved 9 members
+[response] askScopeCompletion at (32,4)
+retrieved 13 members
 [accessible:  true] `class Ctest.C`
 [accessible:  true] `class Foo_1test.Foo_1`
 [accessible:  true] `class Foo_2test.Foo_2`
@@ -44,11 +60,15 @@ retrieved 9 members
 [accessible:  true] `method fCCC=> Int`
 [accessible:  true] `object Otest.O.type`
 [accessible:  true] `value ctest.C`
+[accessible:  true] `value vCCCInt`
+[accessible:  true] `variable rCCCInt`
+[accessible: false] `value pVCCCInt`
+[accessible: false] `variable pRCCCInt`
 ================================================================================
 
-askScopeCompletion at Completions.scala(27,5)
+askScopeCompletion at Completions.scala(35,5)
 ================================================================================
-[response] askScopeCompletion at (27,5)
+[response] askScopeCompletion at (35,5)
 retrieved 8 members
 [accessible:  true] `class Ctest.C`
 [accessible:  true] `class Foo_1test.Foo_1`
@@ -60,10 +80,10 @@ retrieved 8 members
 [accessible:  true] `value ctest.C`
 ================================================================================
 
-askScopeCompletion at Completions.scala(30,5)
+askScopeCompletion at Completions.scala(38,5)
 ================================================================================
-[response] askScopeCompletion at (30,5)
-retrieved 9 members
+[response] askScopeCompletion at (38,5)
+retrieved 13 members
 [accessible:  true] `class Ctest.C`
 [accessible:  true] `class Foo_1test.Foo_1`
 [accessible:  true] `class Foo_2test.Foo_2`
@@ -73,12 +93,16 @@ retrieved 9 members
 [accessible:  true] `method fCCC=> Int`
 [accessible:  true] `object Otest.O.type`
 [accessible:  true] `value ctest.C`
+[accessible:  true] `value vCCCInt`
+[accessible:  true] `variable rCCCInt`
+[accessible: false] `value pVCCCInt`
+[accessible: false] `variable pRCCCInt`
 ================================================================================
 
-askScopeCompletion at Completions.scala(32,5)
+askScopeCompletion at Completions.scala(40,5)
 ================================================================================
-[response] askScopeCompletion at (32,5)
-retrieved 10 members
+[response] askScopeCompletion at (40,5)
+retrieved 18 members
 [accessible:  true] `class Ctest.C`
 [accessible:  true] `class Foo_1test.Foo_1`
 [accessible:  true] `class Foo_2test.Foo_2`
@@ -89,12 +113,20 @@ retrieved 10 members
 [accessible:  true] `method fOOO=> Int`
 [accessible:  true] `object Otest.O.type`
 [accessible:  true] `value ctest.C`
+[accessible:  true] `value vCCCInt`
+[accessible:  true] `value vOOOInt`
+[accessible:  true] `variable rCCCInt`
+[accessible:  true] `variable rOOOInt`
+[accessible: false] `value pVCCCInt`
+[accessible: false] `value pVOOOInt`
+[accessible: false] `variable pRCCCInt`
+[accessible: false] `variable pROOOInt`
 ================================================================================
 
-askScopeCompletion at Completions.scala(41,4)
+askScopeCompletion at Completions.scala(49,4)
 ================================================================================
-[response] askScopeCompletion at (41,4)
-retrieved 10 members
+[response] askScopeCompletion at (49,4)
+retrieved 18 members
 [accessible:  true] `class Ctest.C`
 [accessible:  true] `class Foo_1test.Foo_1`
 [accessible:  true] `class Foo_2test.Foo_2`
@@ -105,12 +137,20 @@ retrieved 10 members
 [accessible:  true] `method fCCC=> Int`
 [accessible:  true] `method fOOO=> Int`
 [accessible:  true] `object Otest.O.type`
+[accessible:  true] `value vCCCInt`
+[accessible:  true] `value vOOOInt`
+[accessible:  true] `variable rCCCInt`
+[accessible:  true] `variable rOOOInt`
+[accessible: false] `value pVCCCInt`
+[accessible: false] `value pVOOOInt`
+[accessible: false] `variable pRCCCInt`
+[accessible: false] `variable pROOOInt`
 ================================================================================
 
-askScopeCompletion at Completions.scala(51,4)
+askScopeCompletion at Completions.scala(59,4)
 ================================================================================
-[response] askScopeCompletion at (51,4)
-retrieved 11 members
+[response] askScopeCompletion at (59,4)
+retrieved 19 members
 [accessible:  true] `class Ctest.C`
 [accessible:  true] `class Foo_1test.Foo_1`
 [accessible:  true] `class Foo_2test.Foo_2`
@@ -122,12 +162,20 @@ retrieved 11 members
 [accessible:  true] `method fOOO=> Int`
 [accessible:  true] `object Otest.O.type`
 [accessible:  true] `value otest.O.type`
+[accessible:  true] `value vCCCInt`
+[accessible:  true] `value vOOOInt`
+[accessible:  true] `variable rCCCInt`
+[accessible:  true] `variable rOOOInt`
+[accessible: false] `value pVCCCInt`
+[accessible: false] `value pVOOOInt`
+[accessible: false] `variable pRCCCInt`
+[accessible: false] `variable pROOOInt`
 ================================================================================
 
-askScopeCompletion at Completions.scala(61,4)
+askScopeCompletion at Completions.scala(69,4)
 ================================================================================
-[response] askScopeCompletion at (61,4)
-retrieved 10 members
+[response] askScopeCompletion at (69,4)
+retrieved 14 members
 [accessible:  true] `class Ctest.C`
 [accessible:  true] `class Foo_1test.Foo_1`
 [accessible:  true] `class Foo_2test.Foo_2`
@@ -138,4 +186,8 @@ retrieved 10 members
 [accessible:  true] `method fCCC=> Int`
 [accessible:  true] `object Otest.O.type`
 [accessible:  true] `value ctest.C`
+[accessible:  true] `value vCCCInt`
+[accessible:  true] `variable rCCCInt`
+[accessible: false] `value pVCCCInt`
+[accessible: false] `variable pRCCCInt`
 ================================================================================

--- a/test/files/presentation/scope-completion-import/src/Completions.scala
+++ b/test/files/presentation/scope-completion-import/src/Completions.scala
@@ -1,10 +1,18 @@
 package test
 
 class C {
+  val vCCC : Int = 0
+  var rCCC : Int = 0
+  private val pVCCC : Int = 0
+  private var pRCCC : Int = 0
   def fCCC : Int = 0
 }
 
 object O extends C {
+  val vOOO : Int = 0
+  var rOOO : Int = 0
+  private val pVOOO : Int = 0
+  private var pROOO : Int = 0
   def fOOO : Int = 0
 }
 


### PR DESCRIPTION
Imported member vals and vars were always marked inaccessible, even
if referencing them at the location of the completion is valid in code.
The accessible flag is now set accordingly to the accessibility of the getter.

I am working on an equivalent PR for 2.11. The changes are fairly different, as the code has been modularized, and the format of the oracle is different. I'll submit it after this PR is merged.
