### PR TITLE
add method dequeueOption to immutable.Queue

### DIFF
--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -118,6 +118,13 @@ class Queue[+A] protected(protected val in: List[A], protected val out: List[A])
     case x :: xs            => (x, new Queue(in, xs))
     case _                  => throw new NoSuchElementException("dequeue on empty queue")
   }
+  
+  /** Optionally retrieves the first element and a queue of the remaining elements.
+   *
+   * @return A tuple of the first element of the queue, and a new queue with this element removed.
+   *         If the queue is empty, `None` is returned.
+   */
+  def dequeueOption: Option[(A, Queue[A])] = if(isEmpty) None else Some(dequeue)
 
   /** Returns the first element in the queue, or throws an error if there
    *  is no element contained in the queue.

--- a/test/junit/scala/collection/QueueTest.scala
+++ b/test/junit/scala/collection/QueueTest.scala
@@ -1,0 +1,28 @@
+package scala.collection.immutable
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Test
+
+@RunWith(classOf[JUnit4])
+/* Tests for collection.immutable.Queue  */
+class QueueTest {
+  val emptyQueue = Queue.empty[Int]
+  val oneAdded = emptyQueue.enqueue(1)
+  val threeAdded = emptyQueue.enqueue(1 to 3)
+
+  @Test
+  def dequeueOptionOnEmpty() {
+    assert( emptyQueue.dequeueOption == None )
+  }
+
+  @Test
+  def dequeueOptionOneAdded() {
+    assert( oneAdded.dequeueOption == Some((1,emptyQueue)) )
+  }
+
+  @Test
+  def dequeueOptionThreeAdded() {
+    assert( threeAdded.dequeueOption == Some((1,Queue(2 to 3:_*))) )
+  }
+}


### PR DESCRIPTION
This allows immutable.Queue to be used conveniently in functional code.
Method is in the spirit of `headOption` on seqs or `get` on maps. Also
adds a unit test for immutable.Queue.

---

Somehow I messed the old pull-request (I'm new to this, so sorry). I decided that it would be easiest to open a new one.

Note that I changed the implementation of `dequeueOption` to use `dequeue`. It is a bit more overhead, but I thought this overhead is dwarfed by the object creations that will happen anyway. So I decided for less code duplication.
