### PR TITLE
[backport] SI-7439 Avoid NPE in `isMonomorphicType` with stub symbols.

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -709,7 +709,9 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     final def isMonomorphicType =
       isType && {
         val info = originalInfo
-        info.isComplete && !info.isHigherKinded
+        (    (info eq null)
+          || (info.isComplete && !info.isHigherKinded)
+        )
       }
 
     def isStrictFP          = hasAnnotation(ScalaStrictFPAttr) || (enclClass hasAnnotation ScalaStrictFPAttr)

--- a/test/files/run/t7439.check
+++ b/test/files/run/t7439.check
@@ -1,0 +1,1 @@
+pos: NoPosition Class A_1 not found - continuing with a stub. WARNING

--- a/test/files/run/t7439/A_1.java
+++ b/test/files/run/t7439/A_1.java
@@ -1,0 +1,3 @@
+public class A_1 {
+
+}

--- a/test/files/run/t7439/B_1.java
+++ b/test/files/run/t7439/B_1.java
@@ -1,0 +1,3 @@
+public class B_1 {
+	public void b(A_1[] a) {}
+}

--- a/test/files/run/t7439/Test_2.scala
+++ b/test/files/run/t7439/Test_2.scala
@@ -1,0 +1,31 @@
+import scala.tools.partest._
+import java.io.File
+
+object Test extends StoreReporterDirectTest {
+  def code = ???
+
+  def compileCode(code: String) = {
+    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
+    compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(code)
+  }
+
+  def C = """
+    class C {
+      new B_1
+    }
+  """
+
+  def show(): Unit = {
+    //compileCode(C)
+    assert(filteredInfos.isEmpty, filteredInfos)
+
+    // blow away the entire package
+    val a1Class = new File(testOutput.path, "A_1.class")
+    assert(a1Class.exists)
+    assert(a1Class.delete())
+
+    // bad symbolic reference error expected (but no stack trace!)
+    compileCode(C)
+    println(storeReporter.infos.mkString("\n")) // Included a NullPointerException before.
+  }
+}


### PR DESCRIPTION
`originalInfo` can return null for stub symbols; deal with that
as we used to before a regression in 016bc3db.

After this change, we can once again delete A_1.class and still compile
code instantiating B_1. (A_1 is only referred to in a method signature
of B_1 which is not called from our code.)

```
scala> new B_1
warning: Class A_1 not found - continuing with a stub.
res0: B_1 = B_1@5284b8f9
```

In practice, this situation arises when someone uses a third
party class that was compiled against other libraries not avaialable
on the current compilation classpath.

(cherry picked from commit a95432168204964e4f6c4571e781559c1640f2d8)
