### PR TITLE
undeprecates c.parse

### DIFF
--- a/src/reflect/scala/reflect/macros/Parsers.scala
+++ b/src/reflect/scala/reflect/macros/Parsers.scala
@@ -8,7 +8,6 @@ package macros
  *  A slice of [[scala.reflect.macros.BlackboxContext the Scala macros context]] that
  *  exposes functions to parse strings with Scala code into trees.
  */
-@deprecated("Use quasiquotes instead", "2.11.0")
 trait Parsers {
   self: BlackboxContext =>
 
@@ -16,11 +15,9 @@ trait Parsers {
    *  Only works for expressions, i.e. parsing a package declaration will fail.
    *  @throws [[scala.reflect.macros.ParseException]]
    */
-  @deprecated("Use quasiquotes instead", "2.11.0")
   def parse(code: String): Tree
 }
 
 /** Indicates an error during [[scala.reflect.macros.Parsers#parse]].
  */
-  @deprecated("Use quasiquotes instead", "2.11.0")
 case class ParseException(pos: scala.reflect.api.Position, msg: String) extends Exception(msg)


### PR DESCRIPTION
We never thought that c.parse is going to be completely subsumed by
quasiquotes, but hoped that the use cases that are going to be lost
aren’t going to be noticed by anyone.

Unfortunately, this isn’t the case, so I’m undeprecating c.parse until
we get a better story for those for whom quasiquotes are not enough.
