### PR TITLE
SI-8050 [Avian] Skip instrumented tests

### DIFF
--- a/test/files/instrumented/InstrumentationTest.check
+++ b/test/files/instrumented/InstrumentationTest.check
@@ -1,3 +1,4 @@
+#partest !avian
 true
 Method call statistics:
     1  Foo1.<init>()V
@@ -8,3 +9,6 @@ Method call statistics:
     1  scala/Predef$.println(Ljava/lang/Object;)V
     1  scala/io/AnsiColor$class.$init$(Lscala/io/AnsiColor;)V
     1  scala/runtime/BoxesRunTime.boxToBoolean(Z)Ljava/lang/Boolean;
+#partest avian
+!!!TEST SKIPPED!!!
+Instrumentation is not supported on Avian.

--- a/test/files/instrumented/InstrumentationTest.scala
+++ b/test/files/instrumented/InstrumentationTest.scala
@@ -15,16 +15,21 @@ package instrumented {
 /** Tests if instrumentation itself works correctly */
 object Test {
   def main(args: Array[String]) {
-    // force predef initialization before profiling
-    Predef
-    startProfiling()
-    val foo1 = new Foo1
-    foo1.someMethod
-    val foo2 = new instrumented.Foo2
-    foo2.someMethod
-    // should box the boolean
-    println(true)
-    stopProfiling()
-    printStatistics()
+    if (scala.tools.partest.utils.Properties.isAvian) {
+      println("!!!TEST SKIPPED!!!")
+      println("Instrumentation is not supported on Avian.")
+    } else {
+      // force predef initialization before profiling
+      Predef
+      startProfiling()
+      val foo1 = new Foo1
+      foo1.someMethod
+      val foo2 = new instrumented.Foo2
+      foo2.someMethod
+      // should box the boolean
+      println(true)
+      stopProfiling()
+      printStatistics()
+    }
   }
 }

--- a/test/files/instrumented/inline-in-constructors.check
+++ b/test/files/instrumented/inline-in-constructors.check
@@ -1,3 +1,7 @@
+#partest !avian
 Method call statistics:
     1  instrumented/Bar.<init>(Z)V
     1  instrumented/Foo.<init>(I)V
+#partest avian
+!!!TEST SKIPPED!!!
+Instrumentation is not supported on Avian.

--- a/test/files/instrumented/inline-in-constructors/test_3.scala
+++ b/test/files/instrumented/inline-in-constructors/test_3.scala
@@ -3,13 +3,18 @@ import instrumented._
 
 object Test {
   def main(args: Array[String]) {
-    // force predef initialization before profiling
-    Predef
-    MyPredef
-    startProfiling()
-    val a = new Foo(2)
-    val b = new Bar(true)
-    stopProfiling()
-    printStatistics()
+    if (scala.tools.partest.utils.Properties.isAvian) {
+      println("!!!TEST SKIPPED!!!")
+      println("Instrumentation is not supported on Avian.")
+    } else {
+      // force predef initialization before profiling
+      Predef
+      MyPredef
+      startProfiling()
+      val a = new Foo(2)
+      val b = new Bar(true)
+      stopProfiling()
+      printStatistics()
+    }
   }
 }


### PR DESCRIPTION
Instrumentation is (currently) not supported on Avian.
This causes
- tests instrumented/InstrumentationTest.scala and
- instrumented/inline-in-constructors
  to fail.

Let's skip these tests on Avian.
