### PR TITLE
SI-8052 Disallow `macro` as an identifier

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -671,6 +671,7 @@ self =>
     def isRawBar  = isIdent && in.name == raw.BAR
 
     def isIdent = in.token == IDENTIFIER || in.token == BACKQUOTED_IDENT
+    def isMacro = in.token == IDENTIFIER && in.name == nme.MACROkw
 
     def isLiteralToken(token: Token) = token match {
       case CHARLIT | INTLIT | LONGLIT | FLOATLIT | DOUBLELIT |
@@ -1037,6 +1038,8 @@ self =>
     /** For when it's known already to be a type name. */
     def identForType(): TypeName = ident().toTypeName
     def identForType(skipIt: Boolean): TypeName = ident(skipIt).toTypeName
+
+    def identOrMacro(): Name = if (isMacro) rawIdent() else ident()
 
     def selector(t: Tree): Tree = {
       val point = in.offset
@@ -2551,7 +2554,7 @@ self =>
       }
       else {
         val nameOffset = in.offset
-        val name = ident()
+        val name = identOrMacro()
         funDefRest(start, nameOffset, mods, name)
       }
     }
@@ -2584,7 +2587,7 @@ self =>
           } else {
             if (in.token == EQUALS) {
               in.nextTokenAllow(nme.MACROkw)
-              if (in.token == IDENTIFIER && in.name == nme.MACROkw) {
+              if (isMacro) {
                 in.nextToken()
                 newmods |= Flags.MACRO
               }

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -204,8 +204,12 @@ trait Scanners extends ScannersCommon {
         val idx = name.start - kwOffset
         if (idx >= 0 && idx < kwArray.length) {
           token = kwArray(idx)
-          if (token == IDENTIFIER && allowIdent != name && emitIdentifierDeprecationWarnings)
-            deprecationWarning(name+" is now a reserved word; usage as an identifier is deprecated")
+          if (token == IDENTIFIER && allowIdent != name) {
+            if (name == nme.MACROkw)
+              syntaxError(name+" is now a reserved word; usage as an identifier is disallowed")
+            else if (emitIdentifierDeprecationWarnings)
+              deprecationWarning(name+" is now a reserved word; usage as an identifier is deprecated")
+          }
         }
       }
     }

--- a/test/files/neg/macro-deprecate-idents.check
+++ b/test/files/neg/macro-deprecate-idents.check
@@ -1,54 +1,67 @@
-macro-deprecate-idents.scala:2: warning: macro is now a reserved word; usage as an identifier is deprecated
+macro-deprecate-idents.scala:2: error: macro is now a reserved word; usage as an identifier is disallowed
   val macro = ???
       ^
-macro-deprecate-idents.scala:6: warning: macro is now a reserved word; usage as an identifier is deprecated
+macro-deprecate-idents.scala:6: error: macro is now a reserved word; usage as an identifier is disallowed
   var macro = ???
       ^
-macro-deprecate-idents.scala:10: warning: macro is now a reserved word; usage as an identifier is deprecated
+macro-deprecate-idents.scala:10: error: macro is now a reserved word; usage as an identifier is disallowed
   type macro = Int
        ^
-macro-deprecate-idents.scala:14: warning: macro is now a reserved word; usage as an identifier is deprecated
+macro-deprecate-idents.scala:14: error: macro is now a reserved word; usage as an identifier is disallowed
   class macro
         ^
-macro-deprecate-idents.scala:18: warning: macro is now a reserved word; usage as an identifier is deprecated
+macro-deprecate-idents.scala:18: error: macro is now a reserved word; usage as an identifier is disallowed
   class macro
         ^
-macro-deprecate-idents.scala:22: warning: macro is now a reserved word; usage as an identifier is deprecated
+macro-deprecate-idents.scala:22: error: macro is now a reserved word; usage as an identifier is disallowed
   object macro
          ^
-macro-deprecate-idents.scala:26: warning: macro is now a reserved word; usage as an identifier is deprecated
+macro-deprecate-idents.scala:26: error: macro is now a reserved word; usage as an identifier is disallowed
   object macro
          ^
-macro-deprecate-idents.scala:30: warning: macro is now a reserved word; usage as an identifier is deprecated
+macro-deprecate-idents.scala:30: error: macro is now a reserved word; usage as an identifier is disallowed
   trait macro
         ^
-macro-deprecate-idents.scala:34: warning: macro is now a reserved word; usage as an identifier is deprecated
+macro-deprecate-idents.scala:34: error: macro is now a reserved word; usage as an identifier is disallowed
   trait macro
         ^
-macro-deprecate-idents.scala:37: warning: macro is now a reserved word; usage as an identifier is deprecated
+macro-deprecate-idents.scala:37: error: macro is now a reserved word; usage as an identifier is disallowed
 package macro {
         ^
-macro-deprecate-idents.scala:38: warning: macro is now a reserved word; usage as an identifier is deprecated
+macro-deprecate-idents.scala:38: error: macro is now a reserved word; usage as an identifier is disallowed
   package macro.bar {
           ^
-macro-deprecate-idents.scala:43: warning: macro is now a reserved word; usage as an identifier is deprecated
+macro-deprecate-idents.scala:43: error: macro is now a reserved word; usage as an identifier is disallowed
   package macro.foo {
           ^
-macro-deprecate-idents.scala:48: warning: macro is now a reserved word; usage as an identifier is deprecated
+macro-deprecate-idents.scala:48: error: macro is now a reserved word; usage as an identifier is disallowed
   val Some(macro) = Some(42)
            ^
-macro-deprecate-idents.scala:49: warning: macro is now a reserved word; usage as an identifier is deprecated
+macro-deprecate-idents.scala:49: error: macro is now a reserved word; usage as an identifier is disallowed
   macro match {
   ^
-macro-deprecate-idents.scala:50: warning: macro is now a reserved word; usage as an identifier is deprecated
+macro-deprecate-idents.scala:50: error: macro is now a reserved word; usage as an identifier is disallowed
     case macro => println(macro)
          ^
-macro-deprecate-idents.scala:50: warning: macro is now a reserved word; usage as an identifier is deprecated
+macro-deprecate-idents.scala:50: error: macro is now a reserved word; usage as an identifier is disallowed
     case macro => println(macro)
                           ^
-macro-deprecate-idents.scala:55: warning: macro is now a reserved word; usage as an identifier is deprecated
+macro-deprecate-idents.scala:55: error: macro is now a reserved word; usage as an identifier is disallowed
   def macro = 2
       ^
-error: No warnings can be incurred under -Xfatal-warnings.
-17 warnings found
-one error found
+macro-deprecate-idents.scala:3: error: '=' expected but '}' found.
+}
+^
+macro-deprecate-idents.scala:7: error: '=' expected but '}' found.
+}
+^
+macro-deprecate-idents.scala:42: error: '{' expected but ';' found.
+package foo {
+^
+macro-deprecate-idents.scala:45: error: '{' expected but '}' found.
+}
+^
+macro-deprecate-idents.scala:52: error: ')' expected but '}' found.
+}
+^
+22 errors found


### PR DESCRIPTION
Note that the change could look a lot cleaner, at the cost of returning
more generic error messages. I decided that at least for 2.11 I'll keep
scalac remembering that macro was a standard identifier name once, so
that we can point out more precisely what's wrong with users' code.
