### PR TITLE
SI-7618 Remove octal number literals

### DIFF
--- a/test/files/run/literals.check
+++ b/test/files/run/literals.check
@@ -1,4 +1,4 @@
-warning: there were 18 deprecation warning(s); re-run with -deprecation for details
+warning: there were 5 deprecation warning(s); re-run with -deprecation for details
 test '\u0024' == '$' was successful
 test '\u005f' == '_' was successful
 test 65.asInstanceOf[Char] == 'A' was successful
@@ -7,28 +7,19 @@ test "\0x61\0x62".trim() == "x61\0x62" was successful
 
 test (65 : Byte) == 'A' was successful
 
-test 01 == 1 was successful
-test 010 == 8 was successful
 test 0X01 == 1 was successful
 test 0x01 == 1 was successful
 test 0x10 == 16 was successful
 test 0xa == 10 was successful
 test 0x0a == 10 was successful
-test +01 == 1 was successful
-test +010 == 8 was successful
 test +0x01 == 1 was successful
 test +0x10 == 16 was successful
 test +0xa == 10 was successful
 test +0x0a == 10 was successful
-test -01 == -1 was successful
-test -010 == -8 was successful
 test -0x01 == -1 was successful
 test -0x10 == -16 was successful
 test -0xa == -10 was successful
 test -0x0a == -10 was successful
-test 017777777777 == 2147483647 was successful
-test 020000000000 == -2147483648 was successful
-test 037777777777 == -1 was successful
 test 0x7fffffff == 2147483647 was successful
 test 0x80000000 == -2147483648 was successful
 test 0xffffffff == -1 was successful
@@ -36,9 +27,6 @@ test 0xffffffff == -1 was successful
 test 1l == 1L was successful
 test 1L == 1l was successful
 test 1.asInstanceOf[Long] == 1l was successful
-test 0777777777777777777777L == 9223372036854775807L was successful
-test 01000000000000000000000L == -9223372036854775808L was successful
-test 01777777777777777777777L == -1L was successful
 test 0x7fffffffffffffffL == 9223372036854775807L was successful
 test 0x8000000000000000L == -9223372036854775808L was successful
 test 0xffffffffffffffffL == -1L was successful
@@ -46,6 +34,7 @@ test 0xffffffffffffffffL == -1L was successful
 test 1e1f == 10.0f was successful
 test .3f == 0.3f was successful
 test 0f == 0.0f was successful
+test 01.23f == 1.23f was successful
 test 3.14f == 3.14f was successful
 test 6.022e23f == 6.022e23f was successful
 test 09f == 9.0f was successful
@@ -56,6 +45,8 @@ test 1e1 == 10.0 was successful
 test .3 == 0.3 was successful
 test 0.0 == 0.0 was successful
 test 0d == 0.0 was successful
+test 01.23 == 1.23 was successful
+test 01.23d == 1.23d was successful
 test 3.14 == 3.14 was successful
 test 1e-9d == 1.0e-9 was successful
 test 1e137 == 1.0e137 was successful

--- a/test/files/run/literals.scala
+++ b/test/files/run/literals.scala
@@ -47,31 +47,21 @@ object Test {
     println
 
     // int
-    check_success("01 == 1", 01, 1)
-    check_success("010 == 8", 010, 8)
     check_success("0X01 == 1", 0X01, 1)
     check_success("0x01 == 1", 0x01, 1)
     check_success("0x10 == 16", 0x10, 16)
     check_success("0xa == 10", 0xa, 10)
     check_success("0x0a == 10", 0x0a, 10)
 
-    check_success("+01 == 1", +01, 1)
-    check_success("+010 == 8", +010, 8)
     check_success("+0x01 == 1", +0x01, 1)
     check_success("+0x10 == 16", +0x10, 16)
     check_success("+0xa == 10", +0xa, 10)
     check_success("+0x0a == 10", +0x0a, 10)
 
-    check_success("-01 == -1", -01, -1)
-    check_success("-010 == -8", -010, -8)
     check_success("-0x01 == -1", -0x01, -1)
     check_success("-0x10 == -16", -0x10, -16)
     check_success("-0xa == -10", -0xa, -10)
     check_success("-0x0a == -10", -0x0a, -10)
-
-    check_success("017777777777 == 2147483647", 017777777777, 2147483647)
-    check_success("020000000000 == -2147483648", 020000000000, -2147483648)
-    check_success("037777777777 == -1", 037777777777, -1)
 
     check_success("0x7fffffff == 2147483647", 0x7fffffff, 2147483647)
     check_success("0x80000000 == -2147483648", 0x80000000, -2147483648)
@@ -83,13 +73,6 @@ object Test {
     check_success("1l == 1L", 1l, 1L)
     check_success("1L == 1l", 1L, 1l)
     check_success("1.asInstanceOf[Long] == 1l", 1.asInstanceOf[Long], 1l)
-
-    check_success("0777777777777777777777L == 9223372036854775807L",
-      0777777777777777777777L, 9223372036854775807L)
-    check_success("01000000000000000000000L == -9223372036854775808L",
-      01000000000000000000000L, -9223372036854775808L)
-    check_success("01777777777777777777777L == -1L",
-      01777777777777777777777L, -1L)
 
     check_success("0x7fffffffffffffffL == 9223372036854775807L",
       0x7fffffffffffffffL, 9223372036854775807L)
@@ -105,9 +88,9 @@ object Test {
 
     // float
     check_success("1e1f == 10.0f", 1e1f, 10.0f)
-    //check_success("2.f == 2.0f", 2.f, 2.0f)
     check_success(".3f == 0.3f", .3f, 0.3f)
     check_success("0f == 0.0f", 0f, 0.0f)
+    check_success("01.23f == 1.23f", 01.23f, 1.23f)
     check_success("3.14f == 3.14f", 3.14f, 3.14f)
     check_success("6.022e23f == 6.022e23f", 6.022e23f, 6.022e23f)
     check_success("09f == 9.0f", 09f, 9.0f)
@@ -118,11 +101,11 @@ object Test {
 
     // double
     check_success("1e1 == 10.0", 1e1, 10.0)
-    //check_success("2. == 2.0", 2., 2.0)
-    //check_success("2.d == 2.0", 2.d, 2.0)
     check_success(".3 == 0.3", .3, 0.3)
     check_success("0.0 == 0.0", 0.0, 0.0)
     check_success("0d == 0.0", 0d, 0.0)
+    check_success("01.23 == 1.23", 01.23, 1.23)
+    check_success("01.23d == 1.23d", 01.23d, 1.23d)
     check_success("3.14 == 3.14", 3.14, 3.14)
     check_success("1e-9d == 1.0e-9", 1e-9d, 1.0e-9)
     check_success("1e137 == 1.0e137", 1e137, 1.0e137)


### PR DESCRIPTION
This also fixes a spurious detection of octal literals in floating
point literals: Literals like 01.23 are neither deprecated nor planned
for removal.
