### PR TITLE
SI-8054 Fix regression in TypeRef rebind with val overriding object

### DIFF
--- a/test/files/pos/t8054.scala
+++ b/test/files/pos/t8054.scala
@@ -1,0 +1,31 @@
+trait D {
+  trait Manifest {
+    class Entry
+  }
+
+  val M: Manifest
+
+  def m: M.Entry = ???
+}
+
+object D1 extends D {
+  object M extends Manifest
+}
+
+object D2 extends D {
+  val M: Manifest = ???
+}
+
+object Hello {
+
+  def main(args: Array[String]) {
+    // 2.10.3 - ok
+    // 2.11.0-M7 - type mismatch; found : Seq[DB1.MANIFEST.Entry]
+    // required: Seq[DB1.MANIFEST.Entry]
+    val t1: D1.M.Entry = D1.m
+
+    // 2.10.3 - ok
+    // 2.11.0-M7 - ok
+    val t2: D2.M.Entry = D2.m
+  }
+}


### PR DESCRIPTION
Regressed in 80767383fd / SI-7928

The condition added in that commit are necessary after refchecks but
poisonous before.

This still seems rather fragile: I wonder if `eliminateModuleDefs`
in `RefChecks` ought to flag the module symbol as `ARTIFACT` after
creating the accessor, so as to signal that it shouldn't be bound
anymore?
