### PR TITLE
streamlines refchecking undesired symbol properties

### DIFF
--- a/test/files/neg/compile-time-only-a.check
+++ b/test/files/neg/compile-time-only-a.check
@@ -1,49 +1,79 @@
-compile-time-only-a.scala:9: error: C3
+compile-time-only-a.scala:10: error: C3
 @compileTimeOnly("C3") case class C3(x: Int)
                                   ^
-compile-time-only-a.scala:11: error: C4
+compile-time-only-a.scala:12: error: C4
 @compileTimeOnly("C4") case class C4(x: Int)
                                   ^
-compile-time-only-a.scala:16: error: C5
+compile-time-only-a.scala:17: error: C5
   implicit class C5(val x: Int) {
                  ^
-compile-time-only-a.scala:28: error: C1
+compile-time-only-a.scala:32: error: C1
   new C1()
       ^
-compile-time-only-a.scala:32: error: C2
+compile-time-only-a.scala:36: error: C2
   C2
   ^
-compile-time-only-a.scala:34: error: C3
+compile-time-only-a.scala:38: error: C3
   new C3(2)
       ^
-compile-time-only-a.scala:37: error: C4
+compile-time-only-a.scala:41: error: C4
   new C4(2)
       ^
-compile-time-only-a.scala:41: error: C5
+compile-time-only-a.scala:45: error: C5
   2.ext
   ^
-compile-time-only-a.scala:42: error: C5
+compile-time-only-a.scala:46: error: C5
   C5(2)
   ^
-compile-time-only-a.scala:45: error: C6.x
+compile-time-only-a.scala:49: error: C6.x
   val _ = c6.x
              ^
-compile-time-only-a.scala:46: error: C6.foo
+compile-time-only-a.scala:50: error: C6.foo
   c6.foo
      ^
-compile-time-only-a.scala:48: error: C6.y
+compile-time-only-a.scala:51: error: C6.Foo
+  type Foo = c6.Foo
+                ^
+compile-time-only-a.scala:52: error: C6.y
   c6.y = c6.y
      ^
-compile-time-only-a.scala:48: error: C6.y
+compile-time-only-a.scala:52: error: C6.y
   c6.y = c6.y
             ^
-compile-time-only-a.scala:54: error: placebo
-@placebo
- ^
-compile-time-only-a.scala:56: error: placebo
+compile-time-only-a.scala:54: error: C7
+  val c701: (C7, C7) = ???
+            ^
+compile-time-only-a.scala:55: error: C7
+  val c702: (C7 => C7) = ???
+                ^
+compile-time-only-a.scala:56: error: C7
+  val c703: { val x: C7 } = ???
+            ^
+compile-time-only-a.scala:57: error: C7
+  val c704: AnyRef with C7 = ???
+            ^
+compile-time-only-a.scala:60: error: C7
+  val c706: C7 Either C7 = ???
+               ^
+compile-time-only-a.scala:61: error: C7
+  val c707a: List[C7] = ???
+             ^
+compile-time-only-a.scala:63: error: C7
+  val c708a: T forSome { type T <: C7 } = ???
+               ^
+compile-time-only-a.scala:66: error: C8
+  val c709: (C8[Int], C8[C7]) = ???
+            ^
+compile-time-only-a.scala:67: error: C8
+  val c710: (C8[_] => C8[_]) = ???
+                   ^
+compile-time-only-a.scala:74: error: placebo
+class Test {
+      ^
+compile-time-only-a.scala:75: error: placebo
   @placebo def x = (2: @placebo)
-   ^
-compile-time-only-a.scala:56: error: placebo
+               ^
+compile-time-only-a.scala:75: error: placebo
   @placebo def x = (2: @placebo)
                         ^
-16 errors found
+26 errors found

--- a/test/files/neg/compile-time-only-a.scala
+++ b/test/files/neg/compile-time-only-a.scala
@@ -1,4 +1,5 @@
 import scala.annotation.compileTimeOnly
+import scala.language.existentials
 
 @compileTimeOnly("C1") class C1
 object C1
@@ -24,6 +25,9 @@ class C6(@compileTimeOnly("C6.x") val x: Int) {
   @compileTimeOnly("C6.y") var y = 3
 }
 
+@compileTimeOnly("C7") class C7
+@compileTimeOnly("C8") class C8[T]
+
 object Test extends App {
   new C1()
   C1
@@ -46,6 +50,21 @@ object Test extends App {
   c6.foo
   type Foo = c6.Foo
   c6.y = c6.y
+
+  val c701: (C7, C7) = ???
+  val c702: (C7 => C7) = ???
+  val c703: { val x: C7 } = ???
+  val c704: AnyRef with C7 = ???
+  // https://groups.google.com/forum/#!topic/scala-internals/5n07TiCnBZU
+  // val c705: ({ @compileTimeOnly("C7") type C7[T] = List[T] })#C7[_] = ???
+  val c706: C7 Either C7 = ???
+  val c707a: List[C7] = ???
+  val c707b = List[C7]()
+  val c708a: T forSome { type T <: C7 } = ???
+  // https://groups.google.com/forum/#!topic/scala-internals/5n07TiCnBZU
+  // val c708b: T forSome { @compileTimeOnly("C7") type T } = ???
+  val c709: (C8[Int], C8[C7]) = ???
+  val c710: (C8[_] => C8[_]) = ???
 }
 
 @compileTimeOnly("placebo")


### PR DESCRIPTION
Unifies `checkDeprecated`, `checkMigration` and `checkCompileTimeOnly`
into a single centralized point of reference that is now consistently
called from `checkTypeRef`, `transformIdent` and `transformSelect`.
