### PR TITLE
SI-7912 Be defensive calling `toString` in `MatchError#getMessage`

### DIFF
--- a/src/library/scala/MatchError.scala
+++ b/src/library/scala/MatchError.scala
@@ -23,9 +23,15 @@ final class MatchError(obj: Any) extends RuntimeException {
   /** There's no reason we need to call toString eagerly,
    *  so defer it until getMessage is called.
    */
-  private lazy val objString =
+  private lazy val objString = {
+    def ofClass = "of class " + obj.getClass.getName
     if (obj == null) "null"
-    else obj.toString() + " (of class " + obj.getClass.getName + ")"
+    else try {
+      obj.toString() + " (" + ofClass + ")"
+    } catch {
+      case _: Throwable => "an instance " + ofClass
+    }
+  }
 
   override def getMessage() = objString
 }

--- a/test/files/run/t7912.scala
+++ b/test/files/run/t7912.scala
@@ -1,0 +1,16 @@
+case object A { override def toString = ??? }
+
+object Test {
+  def foo: Int = (A: Any) match {
+    case 0 => 0
+  }
+  def main(args: Array[String]): Unit = {
+    try {
+      foo
+      sys.error("no exception")
+    } catch {
+      case me: MatchError => assert(me.getMessage == "an instance of class A$", me.getMessage)
+      case ex: Throwable => sys.error("not a match error: " + ex.getClass)
+    }
+  }
+}


### PR DESCRIPTION
Otherwise, objects with exception-throwing `toString` lead to a
cascading error far removed from the originally failed match.
