### PR TITLE
SI-8059 Override immutable.Queue#{+:,:+} for performance

### DIFF
--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -89,6 +89,16 @@ class Queue[+A] protected(protected val in: List[A], protected val out: List[A])
    */
   override def length = in.length + out.length
 
+  override def +:[B >: A, That](elem: B)(implicit bf: CanBuildFrom[Queue[A], B, That]): That = bf match {
+    case _: Queue.GenericCanBuildFrom[_] => new Queue(in, elem :: out).asInstanceOf[That]
+    case _                               => super.+:(elem)(bf)
+  }
+
+  override def :+[B >: A, That](elem: B)(implicit bf: CanBuildFrom[Queue[A], B, That]): That = bf match {
+    case _: Queue.GenericCanBuildFrom[_] => enqueue(elem).asInstanceOf[That]
+    case _                               => super.:+(elem)(bf)
+  }
+
   /** Creates a new queue with element added at the end
    *  of the old queue.
    *
@@ -118,7 +128,7 @@ class Queue[+A] protected(protected val in: List[A], protected val out: List[A])
     case x :: xs            => (x, new Queue(in, xs))
     case _                  => throw new NoSuchElementException("dequeue on empty queue")
   }
-  
+
   /** Optionally retrieves the first element and a queue of the remaining elements.
    *
    * @return A tuple of the first element of the queue, and a new queue with this element removed.

--- a/test/files/run/iq.check
+++ b/test/files/run/iq.check
@@ -1,4 +1,8 @@
 Empty
+q2: Queue(42, 0)
+qa: Queue(42, 0)
+qb: Queue(42, 0)
+qc: Queue(42, 0)
 Head: 42
 q5: Queue(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
 q5[5]: 5

--- a/test/files/run/iq.scala
+++ b/test/files/run/iq.scala
@@ -16,10 +16,21 @@ object iq {
       Console.println("Empty")
     }
 
-    /* Test infix enqueing. */
-    //val q2 = q + 42 + 0  // deprecated
+    /* Test enqueing. */
     val q2 = q.enqueue(42).enqueue(0)
+    val qa = q :+ 42 :+ 0
+    assert(q2 == qa)
+    
+    val qb = 42 +: 0 +: q
+    assert(q2 == qb)
+    val qc = 42 +: q :+ 0
+    assert(q2 == qc)
 
+    Console.println("q2: " + q2)
+    Console.println("qa: " + qa)
+    Console.println("qb: " + qb)
+    Console.println("qc: " + qc)
+    
     /* Test is empty and dequeue.
      * Expected: Head: 42
      */
@@ -37,7 +48,7 @@ object iq {
     /* Test sequence enqueing. */
     val q5: Queue[Any] = q4.enqueue(List(1,2,3,4,5,6,7,8,9))
     /* Test toString.
-     * Expected: Head: q5: Queue(0,1,2,3,4,5,6,7,8,9)
+     * Expected: q5: Queue(0,1,2,3,4,5,6,7,8,9)
      */
     Console.println("q5: " + q5)
     /* Test apply


### PR DESCRIPTION
Without those overrides, all elements are unnecessarily copied.
