### PR TITLE
SI-8060 Avoid infinite loop with higher kinded type alias

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3826,7 +3826,7 @@ trait Typers extends Modes with Adaptations with Tags {
       val normalizeLocals = new TypeMap {
         def apply(tp: Type): Type = tp match {
           case TypeRef(pre, sym, args) =>
-            if (sym.isAliasType && containsLocal(tp)) apply(tp.dealias)
+            if (sym.isAliasType && containsLocal(tp) && (tp.dealias ne tp)) apply(tp.dealias)
             else {
               if (pre.isVolatile)
                 InferTypeWithVolatileTypeSelectionError(tree, pre)

--- a/test/files/pos/t8060.scala
+++ b/test/files/pos/t8060.scala
@@ -1,0 +1,11 @@
+trait M[F[_]]
+ 
+trait P[A] {
+  type CC[X] = P[X]
+  def f(p: A => Boolean): M[CC]
+}
+ 
+trait Other {
+  // was infinite loop trying to dealias `x$1.CC`
+  def g[A](p: A => Boolean): P[A] => M[P] = _ f p
+}


### PR DESCRIPTION
The `dealiasLocals` map was assuming that:

```
tp.isAliasType implies (tp.dealias ne tp)
```

This isn't true if `!typeParamsMatchArgs`.

This commit avoids the infinite loop by checking whether or not
dealiasing progresses.
