### PR TITLE
SI-8062 Fix inliner cycle with recursion, separate compilation

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
@@ -954,10 +954,7 @@ abstract class GenICode extends SubComponent  {
                 case _ =>
               }
               ctx1.bb.emit(cm, tree.pos)
-
-              if (sym == ctx1.method.symbol) {
-                ctx1.method.recursive = true
-              }
+              ctx1.method.updateRecursive(sym)
               generatedType =
                 if (sym.isClassConstructor) UNIT
                 else toTypeKind(sym.info.resultType);

--- a/src/compiler/scala/tools/nsc/backend/icode/Members.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/Members.scala
@@ -185,6 +185,10 @@ trait Members {
       this
     }
 
+    final def updateRecursive(called: Symbol): Unit = {
+      recursive ||= (called == symbol)
+    }
+
     def addLocal(l: Local): Local = findOrElse(locals)(_ == l) { locals ::= l ; l }
 
     def addParam(p: Local): Unit =

--- a/test/files/pos/t8062.flags
+++ b/test/files/pos/t8062.flags
@@ -1,0 +1,1 @@
+-optimize

--- a/test/files/pos/t8062/A_1.scala
+++ b/test/files/pos/t8062/A_1.scala
@@ -1,0 +1,5 @@
+package warmup
+
+object Warmup {
+  def filter[A](p: Any => Boolean): Any = filter[Any](p)
+}

--- a/test/files/pos/t8062/B_2.scala
+++ b/test/files/pos/t8062/B_2.scala
@@ -1,0 +1,3 @@
+object Test {
+  warmup.Warmup.filter[Any](x => false)
+}


### PR DESCRIPTION
ICodeReaders, which decompiles JVM bytecode to ICode, was not
setting the `recursive` attribute of `IMethod`. This meant that
the inliner got into a cycle, repeatedly inlining the recursive
call.

The method name `filter` was needed to trigger this as the inliner
heuristically treats that as a more attractive inlining candidate,
based on `isMonadicMethod`.

This commit:
- refactors the checking / setting of `virtual`
- adds this to ICodeReaders
- tests the case involving `invokevirtual`

I'm not sure how to setup a test that fails without the other changes
to `ICodeReader` (for invokestatic and invokespecial).
