### PR TITLE
(2.10.4) duplicates macro arguments before expansion

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -575,7 +575,7 @@ trait Macros extends scala.tools.reflect.FastTrack with Traces {
     def collectMacroArgs(tree: Tree): Unit = tree match {
       case Apply(fn, args) =>
         // todo. infer precise typetag for this Expr, namely the declared type of the corresponding macro impl argument
-        exprArgs.prepend(args map (arg => context.Expr[Nothing](arg)(TypeTag.Nothing)))
+        exprArgs.prepend(args map (arg => context.Expr[Nothing](arg.duplicate)(TypeTag.Nothing)))
         collectMacroArgs(fn)
       case TypeApply(fn, args) =>
         typeArgs = args


### PR DESCRIPTION
As discussed with Jason, this is an important dimension of defenses that
we can build to ensure robustness of the macro engine.

This commit is important in the context of the upcoming patch to the
presentation compiler that will throw away expansions and keep original
macro applications (only when run in presentation compiler mode) so that
hyperlinking in macro arguments starts working in the IDE.

Duplication of macro arguments will make sure that macro arguments, which
are going to become exposed to the IDE, can’t become corrupted by possibly
misbehaving or misguided macros.
