### PR TITLE
Revert "SI-6426, importable _."

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -980,8 +980,11 @@ self =>
 
     /** Assumed (provisionally) to be TermNames. */
     def ident(skipIt: Boolean): Name =
-      if (isIdent) rawIdent().encode
-      else {
+      if (isIdent) {
+        val name = in.name.encode
+        in.nextToken()
+        name
+      } else {
         syntaxErrorOrIncomplete(expectedMsg(IDENTIFIER), skipIt)
         nme.ERROR
       }

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -611,10 +611,7 @@ trait Scanners extends ScannersCommon {
       if (ch == '`') {
         nextChar()
         finishNamed(BACKQUOTED_IDENT)
-        if (name.length == 0)
-          syntaxError("empty quoted identifier")
-        else if (name == nme.WILDCARD)
-          syntaxError("wildcard invalid as backquoted identifier")
+        if (name.length == 0) syntaxError("empty quoted identifier")
       }
       else syntaxError("unclosed quoted identifier")
     }

--- a/test/files/neg/t6426.check
+++ b/test/files/neg/t6426.check
@@ -1,7 +1,0 @@
-t6426.scala:4: error: wildcard invalid as backquoted identifier
-  println(`_`.Buffer(0))
-          ^
-t6426.scala:5: error: ')' expected but '}' found.
-}
-^
-two errors found

--- a/test/files/neg/t6426.scala
+++ b/test/files/neg/t6426.scala
@@ -1,5 +1,0 @@
-class A {
-  import collection.{mutable => _, _}
-
-  println(`_`.Buffer(0))
-}


### PR DESCRIPTION
This reverts commit d2316df920ffa4804fe51e8f8780240c46efa982.

We can't make `_` an illegal identifier -- it's legal in Java,
so we must be able to name these Java underscores.

review by @retronym
