### PR TITLE
SI-8030 force symbols on presentation compiler initialization

### DIFF
--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -1234,6 +1234,18 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
     }
   }
 
+  // We need to force a number of symbols that might be touched by a parser.
+  // Otherwise thread safety property of parseTree method would be violated.
+  protected def forceSymbolsUsedByParser(): Unit = {
+    val symbols =
+      Set(UnitClass, BooleanClass, ByteClass,
+          ShortClass, IntClass, LongClass, FloatClass,
+          DoubleClass, NilModule, ListClass) ++ TupleClass.seq
+    symbols.foreach(_.initialize)
+  }
+
+  forceSymbolsUsedByParser()
+
   /** The compiler has been initialized. Constructors are evaluated in textual order,
    *  so this is set to true only after all super constructors and the primary constructor
    *  have been executed.

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -16,8 +16,7 @@ abstract class TreeGen extends macros.TreeBuilder {
   def rootScalaDot(name: Name)       = Select(rootId(nme.scala_) setSymbol ScalaPackage, name)
   def scalaDot(name: Name)           = Select(Ident(nme.scala_) setSymbol ScalaPackage, name)
   def scalaAnnotationDot(name: Name) = Select(scalaDot(nme.annotation), name)
-  def scalaAnyRefConstrRaw           = scalaDot(tpnme.AnyRef)
-  def scalaAnyRefConstr              = scalaAnyRefConstrRaw setSymbol AnyRefClass // used in ide
+  def scalaAnyRefConstr              = scalaDot(tpnme.AnyRef) // used in ide
 
   def scalaFunctionConstr(argtpes: List[Tree], restpe: Tree, abstractFun: Boolean = false): Tree = {
     val cls = if (abstractFun)
@@ -393,7 +392,7 @@ abstract class TreeGen extends macros.TreeBuilder {
 
   def mkParents(ownerMods: Modifiers, parents: List[Tree], parentPos: Position = NoPosition) =
     if (ownerMods.isCase) parents ::: List(scalaDot(tpnme.Product), scalaDot(tpnme.Serializable))
-    else if (parents.isEmpty) atPos(parentPos)(scalaAnyRefConstrRaw) :: Nil
+    else if (parents.isEmpty) atPos(parentPos)(scalaAnyRefConstr) :: Nil
     else parents
 
   def mkClassDef(mods: Modifiers, name: TypeName, tparams: List[TypeDef], templ: Template): ClassDef = {

--- a/test/files/presentation/ide-t1001326.check
+++ b/test/files/presentation/ide-t1001326.check
@@ -1,4 +1,0 @@
-Unique OK
-Unattributed OK
-NeverModify OK
-AlwaysParseTree OK

--- a/test/files/presentation/ide-t1001326/src/a/A.scala
+++ b/test/files/presentation/ide-t1001326/src/a/A.scala
@@ -1,5 +1,0 @@
-package a
-
-class A {
-  def foo(s: String) = s + s
-}

--- a/test/files/presentation/parse-invariants.check
+++ b/test/files/presentation/parse-invariants.check
@@ -1,0 +1,5 @@
+NoNewSymbolsEntered OK
+Unique OK
+Unattributed OK
+NeverModify OK
+AlwaysParseTree OK

--- a/test/files/presentation/parse-invariants/Test.scala
+++ b/test/files/presentation/parse-invariants/Test.scala
@@ -6,16 +6,32 @@ object Test extends InteractiveTest {
 
   override def execute(): Unit = {
     val sf = sourceFiles.find(_.file.name == "A.scala").head
-    uniqueParseTree_t1001326(sf)
-    unattributedParseTree_t1001326(sf)
-    neverModifyParseTree_t1001326(sf)
-    shouldAlwaysReturnParseTree_t1001326(sf)
+    noNewSymbols(sf)
+    uniqueParseTree(sf)
+    unattributedParseTree(sf)
+    neverModifyParseTree(sf)
+    shouldAlwaysReturnParseTree(sf)
+  }
+
+  /**
+   * Asking for a parseTree should not enter any new symbols.
+   */
+  private def noNewSymbols(sf: SourceFile) {
+    def nextId() = compiler.NoSymbol.newTermSymbol(compiler.TermName("dummy"), compiler.NoPosition, compiler.NoFlags).id
+    val id = nextId()
+    val tree = compiler.parseTree(sf)
+    val id2 = nextId()
+    if (id2 == id + 1) {
+      reporter.println("NoNewSymbolsEntered OK")
+    } else {
+      reporter.println("NoNewSymbolsEntered FAILED")
+    }
   }
 
   /**
    * Asking twice for a parseTree on the same source should always return a new tree
    */
-   private def uniqueParseTree_t1001326(sf: SourceFile) {
+  private def uniqueParseTree(sf: SourceFile) {
     val parseTree1 = compiler.parseTree(sf)
     val parseTree2 = compiler.parseTree(sf)
     if (parseTree1 != parseTree2) {
@@ -28,7 +44,7 @@ object Test extends InteractiveTest {
   /**
    * A parseTree should never contain any symbols or types
    */
-  private def unattributedParseTree_t1001326(sf: SourceFile) {
+  private def unattributedParseTree(sf: SourceFile) {
     if (noSymbolsOrTypes(compiler.parseTree(sf))) {
       reporter.println("Unattributed OK")
     } else {
@@ -39,7 +55,7 @@ object Test extends InteractiveTest {
   /**
    * Once you have obtained a parseTree it should never change
    */
-  private def neverModifyParseTree_t1001326(sf: SourceFile) {
+  private def neverModifyParseTree(sf: SourceFile) {
     val parsedTree = compiler.parseTree(sf)
     loadSourceAndWaitUntilTypechecked(sf)
     if (noSymbolsOrTypes(parsedTree)) {
@@ -52,7 +68,7 @@ object Test extends InteractiveTest {
   /**
    * Should always return a parse tree
    */
-   private def shouldAlwaysReturnParseTree_t1001326(sf: SourceFile) {
+   private def shouldAlwaysReturnParseTree(sf: SourceFile) {
      loadSourceAndWaitUntilTypechecked(sf)
      if (noSymbolsOrTypes(compiler.parseTree(sf))) {
        reporter.println("AlwaysParseTree OK")

--- a/test/files/presentation/parse-invariants/src/a/A.scala
+++ b/test/files/presentation/parse-invariants/src/a/A.scala
@@ -1,0 +1,138 @@
+package syntax
+
+object Terms {
+  object Literals {
+    0
+    0l
+    0f
+    0d
+    0xb33f
+    'c'
+    "string"
+    """
+      multi-line
+      string
+    """
+    'symbol
+    true
+    false
+    null
+    ()
+  }
+
+  object Patterns {
+    0             match { case 0                               =>               }
+    1             match { case (0 | 1)                         =>               }
+    2             match { case _: Int                          =>               }
+    3             match { case _                               =>               }
+    Some(0)       match { case Some(0)                         =>               }
+    Some(0)       match { case name @ Some(_)                  =>               }
+    Some(Some(0)) match { case nested @ Some(deeper @ Some(_)) =>               }
+    List(1, 2, 3) match { case unapplySeq @ List(1, 2, _*)     =>               }
+    0             match { case i if i > 0                      =>               }
+    List(1)       match { case _: List[t]                      => List.empty[t] }
+  }
+
+  object New {
+    class Foo
+    trait Bar
+    new Foo
+    new Foo { selfie => }
+    new Foo with Bar
+    new { val early = 1 } with Bar
+    new { val name = "anon "}
+  }
+
+  def tuple         = (1, 'two, "three")
+  def lambda        = (x: Int, y: Int) => x + y
+  def lambda2       = (_: Int) + (_: Int)
+  def blocks        = { { {}; {} }; {} }
+  def ascription    = (1: Int)
+  def select        = Nil.size
+  def method1       = "s".replace("foo", "bar")
+  def method2       = "s" + "s"
+  def method3       = Nil.foreach { e => }
+  def method4       = 1 :: 2 :: 3 :: Nil
+  def if1           = if (true) true else false
+  def if2           = if (true) true
+  def `return`: Int = { return 0 }
+  def `throw`       = throw new Exception
+  def `match`       = 0 match { case 0 => case _ => }
+  def `try`         = try 0 catch { case _ => } finally 0
+  def `while`       = while(true) 0
+  def `do while`    = do 0 while(true)
+  def `for`         = for (i <- 1 to 10; if i % 2 == 0; j = i + 1) j
+  def `for yield`   = for (a <- List(List(1)); b <- a; c = b * 2) yield b
+  def interpolation = s"$tuple and maybe also $blocks"
+  def assign        = { var x = 1; x = 2 }
+  def assign2       = { object o { var x = 1 }; o.x = 2 }
+  def update        = { val v = collection.mutable.Seq(1); v(0) = 2 }
+  def `this`        = this
+}
+
+object Types {
+  type Reference    = scala.App
+  type Tuple        = (Int, String, Double)
+  type Function     = (Int, String) => Double
+  type Refined      = Int { val meta: Any }
+  type Lambda       = ({ type F[T] = List[T] })#F[_]
+  type Infix        = Int Either String
+  type Application  = List[Int]
+  type Existential  = List[T] forSome { type T }
+  object O { type T = Int }
+  type Dependent    = O.T
+  class O { type T  = Int }
+  type Selection    = O#T
+}
+
+object Definitions {
+  private val x1 = 0
+  private[this] val x2 = 0
+  private[Definitions] val x3 = 0
+  protected val x4 = 0
+  protected[AcessManagement] val x5 = 0
+  val x1 = 1
+  val x2: Int = 1
+  val x3, y3 = 1
+  lazy val x4 = 1
+  implicit val x5 = 1
+  final val x6 = 1
+  lazy final val x7 = 1
+  val Some(x8) = Some(0)
+  var x9 = 1
+  var x10, y10 = 1
+  var x11: Int = 1
+
+  implicit def implicitView: Option[Int] = None
+  def implicitArg1(implicit i: Int) = i + 2
+  def implicitArg2[T: Fooable] = implicitly[Fooable[T]]
+  def bound1[T <: Int](x: T): T = x
+  def bound2[T >: Any](x: T): T = x
+  def bound3[T <% Int](x: T): Int = x
+  def vararg(args: Int*) = args.toList
+  def sum(x: Int, y: Int) = x + y
+  def multipleArgLists(x: Int)(y: Int) = x + y
+
+  type _0 = Int
+  type _1[T] = List[T]
+  type _2[A, B] = Either[A, B]
+
+  class Val(value: Int) extends AnyVal
+  implicit class Impl(value: Int) { def foo = "foo" }
+  abstract class Abs
+  sealed class Sealed
+  class Child extends Sealed
+  case class Point(x: Int, y: Int)
+
+  trait Fooable[T]
+  trait Barable with Fooable[Barable]
+
+  object Foo
+  object Foo with Fooable[Foo]
+  case object Zero
+}
+
+package Packages {
+  package object PackageObject
+  package Nested { package Deeper { } }
+}


### PR DESCRIPTION
This pull request forces a number of built-in symbols in presentation compiler to prevent them from being entered during parsing.

The property “parsing doesn’t enter new symbols” is tested on a rich source file that contains significant number of variations of Scala syntax.

review @retronym
