### PR TITLE
SI-6780 Better handling of cycles in in-scope implicit search

### DIFF
--- a/test/files/neg/t712.check
+++ b/test/files/neg/t712.check
@@ -1,4 +1,5 @@
 t712.scala:10: error: value self is not a member of B.this.ParentImpl
+ Note: implicit method coerce is not applicable here because it comes after the application point and it lacks an explicit result type
   implicit def coerce(p : ParentImpl) = p.self;
                                           ^
 one error found

--- a/test/files/pos/t6780.scala
+++ b/test/files/pos/t6780.scala
@@ -1,0 +1,20 @@
+object O {
+  implicit def i: Int = 0
+}
+
+import O._
+
+trait Foo {
+  implicit val v1: Any
+  implicit def d1: Any
+           val v2: Any
+  implicit val v3: Any
+}
+
+trait Bar1 extends Foo {
+  implicit val v1      = {implicitly[Int]; ()} // failed due to cycle in Context#implicits being broken with Nil.
+           def d1      = {implicitly[Int]; ()} // okay
+  implicit val v2      = {implicitly[Int]; ()} // okay
+  implicit val v3: Any = {implicitly[Int]; ()} // okay
+
+}


### PR DESCRIPTION
Implicit searches in the body of implicit members with inferred
types were leading to cycles. Before we used to resolve that
by saying there were no implicits in scope at all; now we just
skip the current context and still include the enclosing implicits.
Care is taken not to cache results under these circumstances.
