### PR TITLE
SI-7995 completion imported vars and vals

### DIFF
--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -1018,7 +1018,11 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
     val enclosing = new Members[ScopeMember]
     def addScopeMember(sym: Symbol, pre: Type, viaImport: Tree) =
       locals.add(sym, pre, implicitlyAdded = false) { (s, st) =>
-        new ScopeMember(s, st, context.isAccessible(s, pre, superAccess = false), viaImport)
+        // imported val and var are always marked as inaccessible, but they could be accessed through their getters. SI-7995
+        if (s.hasGetter)
+          new ScopeMember(s, st, context.isAccessible(s.getter, pre, superAccess = false), viaImport)
+        else
+          new ScopeMember(s, st, context.isAccessible(s, pre, superAccess = false), viaImport)
       }
     def localsToEnclosing() = {
       enclosing.addNonShadowed(locals)

--- a/test/files/presentation/scope-completion-2.check
+++ b/test/files/presentation/scope-completion-2.check
@@ -1,12 +1,11 @@
 reload: Completions.scala
 
-askScopeCompletion at Completions.scala(16,4)
+askScopeCompletion at Completions.scala(15,2)
 ================================================================================
-[response] askScopeCompletion at (16,4)
-retrieved 11 members
+[response] askScopeCompletion at (15,2)
+retrieved 10 members
 class Completion1 extends AnyRef
 def <init>(): test.Completion1
-def test: Unit
 object Completion1
 private class Cc1 extends AnyRef
 private class Co1 extends AnyRef
@@ -17,19 +16,18 @@ private[this] val vc1: Int
 private[this] val vo1: Int
 ================================================================================
 
-askScopeCompletion at Completions.scala(32,4)
+askScopeCompletion at Completions.scala(29,2)
 ================================================================================
-[response] askScopeCompletion at (32,4)
-retrieved 11 members
-[inaccessible] private[this] val vc1: Int
+[response] askScopeCompletion at (29,2)
+retrieved 10 members
 class Completion1 extends AnyRef
 def <init>(): test.Completion1.type
-def test: Unit
 object Completion1
 private class Cc1 extends AnyRef
 private class Co1 extends AnyRef
 private def fc1: Int
 private def fo1: Int
 private[this] val c: test.Completion1
+private[this] val vc1: Int
 private[this] val vo1: Int
 ================================================================================

--- a/test/files/presentation/scope-completion-2/src/Completions.scala
+++ b/test/files/presentation/scope-completion-2/src/Completions.scala
@@ -9,12 +9,10 @@ class Completion1 {
   private val vc1 = 0
   private def fc1 = 0
 
-  private class Cc1
-
-  def test {
-    // needs to be done in a method, because of SI-7280
-    /*_*/
+  private class Cc1 {
   }
+
+  /*_*/
 }
 
 object Completion1 {
@@ -25,11 +23,9 @@ object Completion1 {
   private val vo1 = 0
   private def fo1 = 0
 
-  private class Co1
-
-  def test {
-    // needs to be done in a method, because of SI-7280
-    /*_*/
+  private class Co1 {
   }
+
+  /*_*/
 }
 

--- a/test/files/presentation/scope-completion-3.check
+++ b/test/files/presentation/scope-completion-3.check
@@ -12,13 +12,9 @@ retrieved 49 members
 [inaccessible] private object Ot2
 [inaccessible] private type tb2 = Completion1.this.tb2
 [inaccessible] private type tt2 = Completion1.this.tt2
-[inaccessible] private[this] val vb1: Int
 [inaccessible] private[this] val vb2: Int
-[inaccessible] private[this] val vt1: Int
 [inaccessible] private[this] val vt2: Int
-[inaccessible] private[this] var rb1: Int
 [inaccessible] private[this] var rb2: Int
-[inaccessible] private[this] var rt1: Int
 [inaccessible] private[this] var rt2: Int
 abstract class Base1 extends AnyRef
 abstract trait Trait1 extends AnyRef
@@ -42,13 +38,17 @@ private class Cc2 extends AnyRef
 private def fc2: Int
 private object Oc2
 private type tc2 = Completion1.this.tc2
+private[this] val vb1: Int
 private[this] val vb3: Int
 private[this] val vc1: Int
 private[this] val vc2: Int
+private[this] val vt1: Int
 private[this] val vt3: Int
+private[this] var rb1: Int
 private[this] var rb3: Int
 private[this] var rc1: Int
 private[this] var rc2: Int
+private[this] var rt1: Int
 private[this] var rt3: Int
 type tb1 = Completion1.this.tb1
 type tc1 = Completion1.this.tc1
@@ -67,13 +67,9 @@ retrieved 49 members
 [inaccessible] private object Ot2
 [inaccessible] private type tb2 = test.Completion2.tb2
 [inaccessible] private type tt2 = test.Completion2.tt2
-[inaccessible] private[this] val vb1: Int
 [inaccessible] private[this] val vb2: Int
-[inaccessible] private[this] val vt1: Int
 [inaccessible] private[this] val vt2: Int
-[inaccessible] private[this] var rb1: Int
 [inaccessible] private[this] var rb2: Int
-[inaccessible] private[this] var rt1: Int
 [inaccessible] private[this] var rt2: Int
 abstract class Base1 extends AnyRef
 abstract trait Trait1 extends AnyRef
@@ -97,13 +93,17 @@ private class Co2 extends AnyRef
 private def fo2: Int
 private object Oo2
 private type to2 = test.Completion2.to2
+private[this] val vb1: Int
 private[this] val vb3: Int
 private[this] val vo1: Int
 private[this] val vo2: Int
+private[this] val vt1: Int
 private[this] val vt3: Int
+private[this] var rb1: Int
 private[this] var rb3: Int
 private[this] var ro1: Int
 private[this] var ro2: Int
+private[this] var rt1: Int
 private[this] var rt3: Int
 type tb1 = test.Completion2.tb1
 type to1 = test.Completion2.to1

--- a/test/files/presentation/scope-completion-import.check
+++ b/test/files/presentation/scope-completion-import.check
@@ -1,9 +1,13 @@
 reload: Completions.scala
 
-askScopeCompletion at Completions.scala(15,4)
+askScopeCompletion at Completions.scala(23,4)
 ================================================================================
-[response] askScopeCompletion at (15,4)
-retrieved 10 members
+[response] askScopeCompletion at (23,4)
+retrieved 18 members
+[inaccessible] private[this] val pVCCC: Int
+[inaccessible] private[this] val pVOOO: Int
+[inaccessible] private[this] var pRCCC: Int
+[inaccessible] private[this] var pROOO: Int
 class C extends AnyRef
 class Foo extends AnyRef
 class Foo_1 extends AnyRef
@@ -13,13 +17,21 @@ def <init>(): test.Foo
 def fCCC: Int
 def fOOO: Int
 object O
+private[this] val vCCC: Int
+private[this] val vOOO: Int
+private[this] var rCCC: Int
+private[this] var rOOO: Int
 val o: test.O.type
 ================================================================================
 
-askScopeCompletion at Completions.scala(19,4)
+askScopeCompletion at Completions.scala(27,4)
 ================================================================================
-[response] askScopeCompletion at (19,4)
-retrieved 9 members
+[response] askScopeCompletion at (27,4)
+retrieved 17 members
+[inaccessible] private[this] val pVCCC: Int
+[inaccessible] private[this] val pVOOO: Int
+[inaccessible] private[this] var pRCCC: Int
+[inaccessible] private[this] var pROOO: Int
 class C extends AnyRef
 class Foo extends AnyRef
 class Foo_1 extends AnyRef
@@ -29,12 +41,18 @@ def <init>(): test.Foo
 def fCCC: Int
 def fOOO: Int
 object O
+private[this] val vCCC: Int
+private[this] val vOOO: Int
+private[this] var rCCC: Int
+private[this] var rOOO: Int
 ================================================================================
 
-askScopeCompletion at Completions.scala(24,4)
+askScopeCompletion at Completions.scala(32,4)
 ================================================================================
-[response] askScopeCompletion at (24,4)
-retrieved 9 members
+[response] askScopeCompletion at (32,4)
+retrieved 13 members
+[inaccessible] private[this] val pVCCC: Int
+[inaccessible] private[this] var pRCCC: Int
 class C extends AnyRef
 class Foo extends AnyRef
 class Foo_1 extends AnyRef
@@ -43,12 +61,14 @@ class Foo_3 extends AnyRef
 def <init>(): test.Foo
 def fCCC: Int
 object O
+private[this] val vCCC: Int
+private[this] var rCCC: Int
 val c: test.C
 ================================================================================
 
-askScopeCompletion at Completions.scala(27,5)
+askScopeCompletion at Completions.scala(35,5)
 ================================================================================
-[response] askScopeCompletion at (27,5)
+[response] askScopeCompletion at (35,5)
 retrieved 8 members
 class C extends AnyRef
 class Foo extends AnyRef
@@ -60,10 +80,12 @@ object O
 val c: test.C
 ================================================================================
 
-askScopeCompletion at Completions.scala(30,5)
+askScopeCompletion at Completions.scala(38,5)
 ================================================================================
-[response] askScopeCompletion at (30,5)
-retrieved 9 members
+[response] askScopeCompletion at (38,5)
+retrieved 13 members
+[inaccessible] private[this] val pVCCC: Int
+[inaccessible] private[this] var pRCCC: Int
 class C extends AnyRef
 class Foo extends AnyRef
 class Foo_1 extends AnyRef
@@ -72,13 +94,19 @@ class Foo_3 extends AnyRef
 def <init>(): test.Foo
 def fCCC: Int
 object O
+private[this] val vCCC: Int
+private[this] var rCCC: Int
 val c: test.C
 ================================================================================
 
-askScopeCompletion at Completions.scala(32,5)
+askScopeCompletion at Completions.scala(40,5)
 ================================================================================
-[response] askScopeCompletion at (32,5)
-retrieved 10 members
+[response] askScopeCompletion at (40,5)
+retrieved 18 members
+[inaccessible] private[this] val pVCCC: Int
+[inaccessible] private[this] val pVOOO: Int
+[inaccessible] private[this] var pRCCC: Int
+[inaccessible] private[this] var pROOO: Int
 class C extends AnyRef
 class Foo extends AnyRef
 class Foo_1 extends AnyRef
@@ -88,13 +116,21 @@ def <init>(): test.Foo
 def fCCC: Int
 def fOOO: Int
 object O
+private[this] val vCCC: Int
+private[this] val vOOO: Int
+private[this] var rCCC: Int
+private[this] var rOOO: Int
 val c: test.C
 ================================================================================
 
-askScopeCompletion at Completions.scala(41,4)
+askScopeCompletion at Completions.scala(49,4)
 ================================================================================
-[response] askScopeCompletion at (41,4)
-retrieved 10 members
+[response] askScopeCompletion at (49,4)
+retrieved 18 members
+[inaccessible] private[this] val pVCCC: Int
+[inaccessible] private[this] val pVOOO: Int
+[inaccessible] private[this] var pRCCC: Int
+[inaccessible] private[this] var pROOO: Int
 class C extends AnyRef
 class Foo extends AnyRef
 class Foo_1 extends AnyRef
@@ -105,12 +141,20 @@ def bar: Unit
 def fCCC: Int
 def fOOO: Int
 object O
+private[this] val vCCC: Int
+private[this] val vOOO: Int
+private[this] var rCCC: Int
+private[this] var rOOO: Int
 ================================================================================
 
-askScopeCompletion at Completions.scala(51,4)
+askScopeCompletion at Completions.scala(59,4)
 ================================================================================
-[response] askScopeCompletion at (51,4)
-retrieved 11 members
+[response] askScopeCompletion at (59,4)
+retrieved 19 members
+[inaccessible] private[this] val pVCCC: Int
+[inaccessible] private[this] val pVOOO: Int
+[inaccessible] private[this] var pRCCC: Int
+[inaccessible] private[this] var pROOO: Int
 class C extends AnyRef
 class Foo extends AnyRef
 class Foo_1 extends AnyRef
@@ -122,12 +166,18 @@ def fCCC: Int
 def fOOO: Int
 object O
 private[this] val o: test.O.type
+private[this] val vCCC: Int
+private[this] val vOOO: Int
+private[this] var rCCC: Int
+private[this] var rOOO: Int
 ================================================================================
 
-askScopeCompletion at Completions.scala(61,4)
+askScopeCompletion at Completions.scala(69,4)
 ================================================================================
-[response] askScopeCompletion at (61,4)
-retrieved 10 members
+[response] askScopeCompletion at (69,4)
+retrieved 14 members
+[inaccessible] private[this] val pVCCC: Int
+[inaccessible] private[this] var pRCCC: Int
 class C extends AnyRef
 class Foo extends AnyRef
 class Foo_1 extends AnyRef
@@ -138,4 +188,6 @@ def bar: Unit
 def fCCC: Int
 object O
 private[this] val c: test.C
+private[this] val vCCC: Int
+private[this] var rCCC: Int
 ================================================================================

--- a/test/files/presentation/scope-completion-import/src/Completions.scala
+++ b/test/files/presentation/scope-completion-import/src/Completions.scala
@@ -1,10 +1,18 @@
 package test
 
 class C {
+  val vCCC : Int = 0
+  var rCCC : Int = 0
+  private val pVCCC : Int = 0
+  private var pRCCC : Int = 0
   def fCCC : Int = 0
 }
 
 object O extends C {
+  val vOOO : Int = 0
+  var rOOO : Int = 0
+  private val pVOOO : Int = 0
+  private var pROOO : Int = 0
   def fOOO : Int = 0
 }
 


### PR DESCRIPTION
Imported member vals and vars were always marked inaccessible, even
if referencing them at the location of the completion is valid in code.
The accessible flag is now set accordingly to the accessibility of the getter.

This is the 2.11 version of #3222. The changes are the same, with the .check files in the new output format.
