### PR TITLE
SI-8071 Allow unification for prefixes of form ThisType(refinement)

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3977,6 +3977,7 @@ trait Types
     case SingleType(pre, sym)  => !(sym hasFlag PACKAGE) && isEligibleForPrefixUnification(pre)
     case tv@TypeVar(_, constr) => !tv.instValid || isEligibleForPrefixUnification(constr.inst)
     case RefinedType(_, _)     => true
+    case ThisType(sym)         => sym.isRefinementClass // See SI-8071
     case _                     => false
   }
 

--- a/test/files/pos/t8071.scala
+++ b/test/files/pos/t8071.scala
@@ -1,0 +1,15 @@
+class ann extends annotation.StaticAnnotation
+
+object Use {
+  def ??? = sys.error("!!!")
+  val field = new AnyRef {     // <---- error reported here
+    class Mem { def x: (Int @ann) = ??? }
+    type Memory = Mem
+  }
+}
+
+/**
+error: type mismatch;
+ found   : AnyRef{type Mem(in <refinement of AnyRef>)(in <refinement of AnyRef>)(in <refinement of AnyRef>)(in <refinement of AnyRef>) <: AnyRef{def x: Int}; type Memory = this.Mem(in <refinement of AnyRef>)(in <refinement of AnyRef>)(in <refinement of AnyRef>)(in <refinement of AnyRef>)}
+ required: AnyRef{type Mem(in <refinement of AnyRef>)(in <refinement of AnyRef>)(in <refinement of AnyRef>)(in <refinement of AnyRef>) <: AnyRef{def x: Int @ann}; type Memory = this.Mem(in <refinement of AnyRef>)(in <refinement of AnyRef>)(in <refinement of AnyRef>)(in <refinement of AnyRef>)}
+ */

--- a/test/files/pos/t8071b.scala
+++ b/test/files/pos/t8071b.scala
@@ -1,0 +1,6 @@
+class ann extends annotation.StaticAnnotation
+
+class Use {
+  def foo: (Int @ann) = ???
+  def bar: (Int @ann) = (new Use{}).foo
+}

--- a/test/files/pos/t8071c.scala
+++ b/test/files/pos/t8071c.scala
@@ -1,0 +1,17 @@
+trait DataSetup {
+  type Memory <: AnyRef with Serializable
+  def run(): Memory
+}
+
+object Use {
+
+  val dataSetup = new DataSetup {     // <---- error reported here
+    case class Mem(ids: List[Int])
+    type Memory = Mem
+    def run(): Memory = {
+      val ids = List(1,2,3)
+      Mem(ids)
+    }
+  }
+
+}


### PR DESCRIPTION
In the enclosed test, we ended up relating the following types:

```
tp1 = AnyRef{type Mem <: AnyRef{def x: Int}; type Memory#3 = this.Mem}" // #1
tp2 = AnyRef{type Mem <: AnyRef{def x: Int @ann}; type Memory#4 = this.Mem}" // #2
```

The first was the result of `Use.field`, in which the `asSeenFrom`
had stripped the annotation. (`AsSeenFromMap` extends
`KeepOnlyTypeConstraints`).

The second type was the declared return type of the accessor method.

Usually, `=:=` and `<:<` are annotation agnostic, and unless a plugin
says otherwise, just compare the underlying types.

But, when refinements are thrown into the mix, one has to wade
through `specializesSym`.

On the way, we get to:

```
tp1 = Use.<refinement#1>.type
tp2 = Use.<refinement#2>.type
sym1 = type Memory#3
sym2 = type Memory#4
tp2.memberType(sym2).substThis(tp2.typeSymbol, tp1) =:= tp1.memberType(sym1)
```

And finally down to business in `equalSymsAndPrefixes`.

Here, we allow loose matching, based on symbol names, if the prefixes
are =:= and represent a refined type (or a singleton type or type
variable over a refined type.) But none of these cases covered what
we encounter here: a this type over a refinement class.

This commit adds that case to `isEligibleForPrefixUnification`.

Review by @adriaanm
