### PR TITLE
Deprecate maven deploy

### DIFF
--- a/build-ant-macros.xml
+++ b/build-ant-macros.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project name="build-support">
+<project name="build-support" xmlns:artifact="urn:maven-artifact-ant">
   <description> Macros for Scala's ant build </description>
 
   <macrodef name="optimized">
@@ -469,6 +469,128 @@
     </sequential>
   </macrodef>
 
+
+  <macrodef name="deploy-remote">
+    <attribute name="jar" default=""/>
+    <attribute name="pom"/>
+    <element name="artifacts" implicit="true" optional="true"/>
+    <sequential>
+      <artifact:deploy file="@{jar}" settingsFile="${settings.file}">
+        <artifact:remoteRepository url="${remote.repository}" id="${repository.credentials.id}" />
+        <artifact:pom refid="@{pom}" />
+        <artifacts/>
+      </artifact:deploy>
+    </sequential>
+  </macrodef>
+
+  <macrodef name="deploy-local">
+    <attribute name="jar" default=""/>
+    <attribute name="pom"/>
+    <element name="artifacts" implicit="true" optional="true"/>
+    <sequential>
+    <artifact:install file="@{jar}">
+      <artifact:localRepository path="${local.repository}"  id="${repository.credentials.id}" />
+      <artifact:pom refid="@{pom}" />
+      <artifacts/>
+    </artifact:install>
+    </sequential>
+  </macrodef>
+
+  <macrodef name="deploy-to">
+    <attribute name="jar" default=""/>
+    <attribute name="pom"/>
+    <attribute name="local"/>
+    <element name="artifacts" implicit="true" optional="true"/>
+    <sequential>
+      <if><equals arg1="@{local}" arg2="true"/><then>
+        <deploy-local jar="@{jar}" pom="@{pom}"> <artifacts/> </deploy-local>
+      </then><else>
+        <deploy-remote jar="@{jar}" pom="@{pom}"> <artifacts/> </deploy-remote>
+      </else></if>
+    </sequential>
+  </macrodef>
+
+  <macrodef name="deploy-one">
+    <attribute name="dir" default=""/>
+    <attribute name="name" />
+    <attribute name="local"  default="false"/>
+    <attribute name="signed" default="false"/>
+
+    <sequential>
+      <local name="path"/> <property name="path" value="@{dir}@{name}/@{name}"/>
+
+      <echo>Deploying ${path}-[pom.xml|src.jar|docs.jar].</echo>
+
+      <copy file="${path}-pom.xml" tofile="${path}-pom-filtered.xml" overwrite="true">
+        <filterset>
+          <filter token="VERSION"                    value="${maven.version.number}" />
+          <filter token="SCALA_BINARY_VERSION"       value="${scala.binary.version}" />
+          <filter token="XML_VERSION"                value="${scala-xml.version.number}" />
+          <filter token="PARSER_COMBINATORS_VERSION" value="${scala-parser-combinators.version.number}" />
+          <filter token="RELEASE_REPOSITORY"         value="${remote.release.repository}" />
+          <filter token="SNAPSHOT_REPOSITORY"        value="${remote.snapshot.repository}" />
+          <filter token="JLINE_VERSION"              value="${jline.version}" />
+
+          <!-- TODO modularize compiler.
+          <filter token="SCALA_COMPILER_DOC_VERSION" value="${scala-compiler-doc.version.number}" />
+          <filter token="SCALA_COMPILER_INTERACTIVE_VERSION" value="${scala-compiler-interactive.version.number}" />
+          -->
+        </filterset>
+      </copy>
+      <artifact:pom id="@{name}.pom" file="${path}-pom-filtered.xml" />
+
+      <if><equals arg1="@{signed}" arg2="false"/><then>
+        <if><isset property="docs.skip"/><then>
+          <deploy-to local="@{local}" jar="${path}.jar" pom="@{name}.pom">
+            <artifact:attach type="jar" file="${path}-src.jar"  classifier="sources" />
+          </deploy-to>
+        </then><else>
+          <deploy-to local="@{local}" jar="${path}.jar" pom="@{name}.pom">
+            <artifact:attach type="jar" file="${path}-src.jar"  classifier="sources" />
+            <artifact:attach type="jar" file="${path}-docs.jar" classifier="javadoc" />
+          </deploy-to>
+        </else></if>
+      </then><else>
+        <local name="repo"/>
+        <if><equals arg1="@{local}" arg2="false"/><then>
+          <property name="repo" value="${remote.repository}"/>
+        </then><else>
+          <property name="repo" value="${local.repository}"/>
+        </else></if>
+        <artifact:mvn failonerror="true">
+          <arg value="org.apache.maven.plugins:maven-gpg-plugin:1.3:sign-and-deploy-file" />
+          <arg value="-Durl=${repo}" />
+          <arg value="-DrepositoryId=${repository.credentials.id}" />
+          <arg value="-DpomFile=${path}-pom-filtered.xml" />
+          <arg value=   "-Dfile=${path}.jar" />
+          <arg value="-Dsources=${path}-src.jar" />
+          <arg value="-Djavadoc=${path}-docs.jar" />
+          <arg value="-Pgpg" />
+          <arg value="-Dgpg.useagent=true" />
+        </artifact:mvn>
+      </else></if>
+    </sequential>
+  </macrodef>
+
+  <macrodef name="deploy">
+    <attribute name="dir"    default=""/>
+    <attribute name="local"  default="false"/>
+    <attribute name="signed" default="false"/>
+
+    <sequential>
+      <deploy-one dir="@{dir}"          name="scala-library"     local="@{local}" signed="@{signed}"/>
+      <deploy-one dir="@{dir}"          name="scala-reflect"     local="@{local}" signed="@{signed}"/>
+      <deploy-one dir="@{dir}"          name="scala-compiler"    local="@{local}" signed="@{signed}"/>
+
+      <!-- TODO modularize compiler.
+      <deploy-one dir="@{dir}"          name="scala-compiler-doc"         local="@{local}" signed="@{signed}"/>
+      <deploy-one dir="@{dir}"          name="scala-compiler-interactive" local="@{local}" signed="@{signed}"/>
+      -->
+
+      <deploy-one dir="@{dir}"          name="scala-actors"      local="@{local}" signed="@{signed}"/>
+      <deploy-one dir="@{dir}"          name="scalap"            local="@{local}" signed="@{signed}"/>
+    </sequential>
+  </macrodef>
 
 
   <macrodef name="testSuite">

--- a/build.xml
+++ b/build.xml
@@ -4,17 +4,14 @@
   xmlns:artifact="urn:maven-artifact-ant"
   xmlns:rsel="antlib:org.apache.tools.ant.types.resources.selectors">
   <include file="build-ant-macros.xml" as="macros"/>
-  <include file="src/build/maven/maven-deploy.xml" as="maven-deploy"/>
 
   <description>
 SuperSabbus for Scala core, builds the scala library and compiler. It can also package it as a simple distribution, tests it for stable bootstrapping and against the Scala test suite.
   </description>
 
 <!-- HINTS
-
  - for faster builds, have a build.properties in the same directory as build.xml that says:
       locker.skip=1
-
 -->
 
 <!-- USAGE FROM JENKINS SCRIPTS IS (CURRENTLY) AS FOLLOWS:
@@ -27,11 +24,14 @@ antArgs tend to be:
 scalacArgs examples:
   "-Dscalac.args=\"-Yrangepos\" -Dpartest.scalac_opts=\"-Yrangepos\""
 
-targets exercised:
-  deploy-core.snapshot publish-opt-nodocs distpack-maven-opt nightly locker.done build build-opt test.suite test.continuations.suite test.scaladoc
+supported/exercised targets
+  to publish: nightly publish-opt-nodocs
+  to build: build build-opt locker.done
+  to run tests: test.suite test.scaladoc
 
-NOTE: after distpack-maven-opt, it is expected there's a build file in dists/maven/latest that defines targets deploy and deploy.local
-TODO: get rid of this separate step
+DO NOT RELY ON ANY OTHER TARGETS (ok, you're probably ok assuming the ones defined in the first 100 lines of this file remain)
+
+NOTE: dists/maven/latest/build.xml will soon disappear; call `publish` in this build instead
 -->
 
 <!-- To use Zinc with the ant build:
@@ -70,7 +70,6 @@ TODO:
   <!-- packaging -->
   <target name="distpack" depends="pack-archives.done, pack-maven.done"/>
   <target name="distpack-maven" depends="pack-maven.done"/>
-
   <target name="distpack-opt" description="Builds an optimised distribution."> <optimized name="distpack"/></target>
   <target name="distpack-maven-opt" description="Builds an optimised maven distribution."><optimized name="distpack-maven"/></target>
 
@@ -81,7 +80,6 @@ TODO:
       <param name="scalac.args.optimise" value="-optimise"/>
     </antcall>
   </target>
-
   <target name="publish-core-opt-nodocs" description="Builds an untested, undocumented optimised core (library/reflect/compiler) and publishes to maven.">
     <antcall target="publish-core">
       <param name="docs.skip" value="1"/>
@@ -93,12 +91,9 @@ TODO:
       <param name="docs.skip" value="1"/>
     </antcall>
   </target>
-
   <target name="all.done" depends="test.done, distpack"/>
-
-  <target name="nightly-nopt" depends="all.done"/>
+  <target name="nightly-nopt" depends="all.done, publish"/>
   <target name="nightly"><optimized name="nightly-nopt"/></target>
-
   <target name="nightly.checkall">
     <antcall target="nightly-nopt"> <param name="partest.scalac_opts" value="-Ycheck:all"/></antcall></target>
 
@@ -1792,6 +1787,7 @@ MAIN DISTRIBUTION PACKAGING
                resource="${version.number}"
                overwrite="true"/>
     </else></if>
+    <!-- TODO: remove the remainder of this target and delete src/build/maven-deploy.xml -->
     <!-- copy build file and its dependencies -->
     <copy todir="${maven-base}"
           file="${lib-ant.dir}/ant-contrib.jar" overwrite="true"/>
@@ -1827,7 +1823,6 @@ MAIN DISTRIBUTION PACKAGING
 <!-- ===========================================================================
                                   MAVEN PUBLISHING
 ============================================================================ -->
-  <!-- TODO: inline maven-deploy.xml here and remove it, once jenkins jobs no longer rely on it -->
   <target name="publish"        depends="pack-maven.base, init.maven" description="Publishes unsigned artifacts to the maven repo.">       <deploy dir="${maven-base}/"/> </target>
   <target name="publish.local"  depends="pack-maven.base, init.maven" description="Publishes unsigned artifacts to the local maven repo."> <deploy dir="${maven-base}/" local="true"/> </target>
   <target name="publish.signed" depends="pack-maven.base, init.maven" description="Publishes signed artifacts to the remote maven repo.">  <deploy dir="${maven-base}/" signed="true"/> </target>

--- a/build.xml
+++ b/build.xml
@@ -107,10 +107,6 @@ TODO:
   <target name="distclean"   depends="dist.clean"   description="Removes all distributions. Binaries and documentation are untouched."/>
 
 
-  <target name="test.continuations.suite">
-    <echo message="DEPRECATED: the continuations have moved to https://github.com/scala/scala-continuations"/>
-  </target>
-
 <!-- ===========================================================================
                                   PROPERTIES
 ============================================================================ -->

--- a/src/build/maven/maven-deploy.xml
+++ b/src/build/maven/maven-deploy.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--
+THIS FILE WILL SOON SELF DESTRUCT; DO NOT USE
+see publish.* targets in /build.xml
+-->
 <project name="sabbus-maven-deploy" xmlns:artifact="urn:maven-artifact-ant">
 
   <description>
@@ -162,7 +166,18 @@
     </echo>
   </target>
 
-  <target name="deploy"        depends="init.maven" description="Deploys unsigned artifacts to the maven repo.">       <deploy/> </target>
-  <target name="deploy.local"  depends="init.maven" description="Deploys unsigned artifacts to the local maven repo."> <deploy local="true"/> </target>
-  <target name="deploy.signed" depends="init.maven" description="Deploys signed artifacts to the remote maven repo.">  <deploy signed="true"/> </target>
+  <target name="deploy"        depends="init.maven" description="Deploys unsigned artifacts to the maven repo.">
+    <echo message="WARNING!1! THIS TARGET HAS BEEN DEPRECATED -- CALL `ant publish` FROM /build.xml"
+    <deploy/>
+  </target>
+
+  <target name="deploy.local"  depends="init.maven" description="Deploys unsigned artifacts to the local maven repo.">
+    <echo message="WARNING!1! THIS TARGET HAS BEEN DEPRECATED -- CALL `ant publish.local` FROM /build.xml"
+    <deploy local="true"/>
+  </target>
+
+  <target name="deploy.signed" depends="init.maven" description="Deploys signed artifacts to the remote maven repo.">
+    <echo message="WARNING!1! THIS TARGET HAS BEEN DEPRECATED -- CALL `ant publish.signed` FROM /build.xml"
+    <deploy signed="true"/>
+  </target>
 </project>


### PR DESCRIPTION
Set the scene for `src/build/maven-deploy.xml` aka `dists/maven/latest/build.xml`'s timely demise.

For a while now, you can just call `ant publish` to publish a build (or `ant build-opt publish` for an optimized build).

From now on, `ant nightly` also publishes, so that our jenkins set up is vastly simplified.

/cc @cunei as dbuild relies on this
/cc @huitseeker / @skyluc for the impact on uber-build

as soon as these two dependencies are removed, the duplicated maven-deploy.xml will be removed.

review by @soc please (See, I promised test.continuations.suite would be gone soon :-))
