### PR TITLE
SI-8017 Value class awareness for -Ydelamdafy:method

### DIFF
--- a/test/files/run/t8017.flags
+++ b/test/files/run/t8017.flags
@@ -1,0 +1,1 @@
+-Ydelambdafy:method

--- a/test/files/run/t8017/value-class-lambda.scala
+++ b/test/files/run/t8017/value-class-lambda.scala
@@ -1,0 +1,40 @@
+object Test {
+  def testC {
+    val f1 = (c: C) => c.value
+    val f2 = (x: Int) => new C(x)
+    val f3 = (c1: C) => (c2: C) => (c1, c2)
+    val r1 = f2(2)
+    val r2 = f2(2)
+    val r3 = f3(r1)(r2)
+    val result = f1(r3._2)
+    assert(result == 2)
+  }
+
+  def testD {
+    val f1 = (c: D) => c.value
+    val f2 = (x: String) => new D(x)
+    val f3 = (c1: D) => (c2: D) => (c1, c2)
+    val r1 = f2("2")
+    val r2 = f2("2")
+    val r3 = f3(r1)(r2)
+    val result = f1(r3._2)
+    assert(result == "2")
+  }
+
+  def testE {
+    val f1 = (c: E[Int]) => c.value
+    val f2 = (x: Int) => new E(x)
+    val f3 = (c1: E[Int]) => (c2: E[Int]) => (c1, c2)
+    val r1 = f2(2)
+    val r2 = f2(2)
+    val r3 = f3(r1)(r2)
+    val result = f1(r3._2)
+    assert(result == 2)
+  }
+
+  def main(args: Array[String]) {
+    testC
+    testD
+    testE
+  }
+}

--- a/test/files/run/t8017/value-class.scala
+++ b/test/files/run/t8017/value-class.scala
@@ -1,0 +1,3 @@
+class C(val value: Int) extends AnyVal
+class D(val value: String) extends AnyVal
+class E[A](val value: A) extends AnyVal


### PR DESCRIPTION
The delambdafy creates a bridge method which requires adaptation
of the result type to the generic `Object`, which is the erased
return type of FunctionN.

This bridge building reused some code from erasure, now refactored
into TypeAdaptingTransformer.

But, it was running into problems with:

```
class C(a: Int) extends AnyVal
(x: Any) => new C(0)
```

It created (forgive the pseudo quasiquote syntax):

```
class anonfun$ extends Function1[Any, C] {
   def apply#1(a: Object): Int = 0
   <bridge> def apply#2(a: Object): Object = {
     val result: Int = apply#1(a)
     ${adapt(Ident("result"), ObjectType)}
   }
}
```

This resulted in primitive boxing, rather than value class boxing.

Instead, we need the call to the main apply method to be typed
as `ErasedValueClass(C, Int)`, which `adapt` takes as a trigger
to perform value class boxing.

Finally, we have to run the post-erasure transformer over the adapted
tree to eliminate remnants of `ErasedValueClass` from the types of
trees.

Review by @gkossakowski / @adriaanm
