### PR TITLE
SI-6120 Suppress extra warnings

### DIFF
--- a/test/files/neg/checksensible.check
+++ b/test/files/neg/checksensible.check
@@ -28,9 +28,6 @@ checksensible.scala:27: warning: comparing values of types Int and Unit using `=
 checksensible.scala:29: warning: comparing values of types Int and String using `==' will always yield false
   1 == "abc"
     ^
-checksensible.scala:29: warning: Int and String are unrelated: they will most likely never compare equal
-  1 == "abc"
-    ^
 checksensible.scala:33: warning: comparing values of types Some[Int] and Int using `==' will always yield false
   Some(1) == 1      // as above
           ^
@@ -64,16 +61,10 @@ checksensible.scala:51: warning: comparing values of types Int and Unit using `!
 checksensible.scala:52: warning: comparing values of types Int and Symbol using `!=' will always yield true
   (1 != 'sym)
      ^
-checksensible.scala:52: warning: Int and Symbol are unrelated: they will most likely always compare unequal
-  (1 != 'sym)
-     ^
 checksensible.scala:58: warning: comparing a fresh object using `==' will always yield false
   ((x: Int) => x + 1) == null
                       ^
 checksensible.scala:59: warning: comparing a fresh object using `==' will always yield false
-  Bep == ((_: Int) + 1)
-      ^
-checksensible.scala:59: warning: Bep.type and Int => Int are unrelated: they will most likely never compare equal
   Bep == ((_: Int) + 1)
       ^
 checksensible.scala:61: warning: comparing a fresh object using `==' will always yield false
@@ -91,9 +82,6 @@ checksensible.scala:66: warning: comparing values of types Int and Null using `=
 checksensible.scala:71: warning: comparing values of types Bip and Bop using `==' will always yield false
   (x1 == x2)
       ^
-checksensible.scala:71: warning: Bip and Bop are unrelated: they will most likely never compare equal
-  (x1 == x2)
-      ^
 checksensible.scala:81: warning: comparing values of types EqEqRefTest.this.C3 and EqEqRefTest.this.Z1 using `==' will always yield false
   c3 == z1
      ^
@@ -106,12 +94,9 @@ checksensible.scala:83: warning: comparing values of types EqEqRefTest.this.Z1 a
 checksensible.scala:84: warning: comparing values of types EqEqRefTest.this.C3 and String using `!=' will always yield true
   c3 != "abc"
      ^
-checksensible.scala:84: warning: EqEqRefTest.this.C3 and String are unrelated: they will most likely always compare unequal
-  c3 != "abc"
-     ^
 checksensible.scala:95: warning: comparing values of types Unit and Int using `!=' will always yield true
     while ((c = in.read) != -1)
                          ^
 error: No warnings can be incurred under -Xfatal-warnings.
-38 warnings found
+33 warnings found
 one error found

--- a/test/files/neg/t5426.check
+++ b/test/files/neg/t5426.check
@@ -4,18 +4,12 @@ t5426.scala:2: warning: comparing values of types Some[Int] and Int using `==' w
 t5426.scala:3: warning: comparing values of types Int and Some[Int] using `==' will always yield false
   def f2 = 5 == Some(5)
              ^
-t5426.scala:3: warning: Int and Some[Int] are unrelated: they will most likely never compare equal
-  def f2 = 5 == Some(5)
-             ^
 t5426.scala:8: warning: comparing values of types Int and Some[Int] using `==' will always yield false
-  (x1 == x2)
-      ^
-t5426.scala:8: warning: Int and Some[Int] are unrelated: they will most likely never compare equal
   (x1 == x2)
       ^
 t5426.scala:9: warning: comparing values of types Some[Int] and Int using `==' will always yield false
   (x2 == x1)
       ^
 error: No warnings can be incurred under -Xfatal-warnings.
-6 warnings found
+four warnings found
 one error found

--- a/test/files/neg/t5663-badwarneq.check
+++ b/test/files/neg/t5663-badwarneq.check
@@ -25,9 +25,6 @@ t5663-badwarneq.scala:72: warning: ValueClass1 and Int are unrelated: they will 
 t5663-badwarneq.scala:74: warning: comparing values of types Int and ValueClass1 using `==' will always yield false
     println(5 == new ValueClass1(5)) // bad
               ^
-t5663-badwarneq.scala:74: warning: Int and ValueClass1 are unrelated: they will never compare equal
-    println(5 == new ValueClass1(5)) // bad
-              ^
 t5663-badwarneq.scala:78: warning: ValueClass2[String] and String are unrelated: they will never compare equal
     println(new ValueClass2("abc") == "abc") // bad
                                    ^
@@ -41,5 +38,5 @@ t5663-badwarneq.scala:82: warning: comparing values of types ValueClass3 and Int
     println(ValueClass3(5) == 5) // bad
                            ^
 error: No warnings can be incurred under -Xfatal-warnings.
-14 warnings found
+13 warnings found
 one error found

--- a/test/files/neg/t7756b.check
+++ b/test/files/neg/t7756b.check
@@ -1,9 +1,6 @@
 t7756b.scala:3: warning: comparing values of types Int and String using `==' will always yield false
     case _ => 0 == ""
                 ^
-t7756b.scala:3: warning: Int and String are unrelated: they will most likely never compare equal
-    case _ => 0 == ""
-                ^
 error: No warnings can be incurred under -Xfatal-warnings.
-two warnings found
+one warning found
 one error found


### PR DESCRIPTION
Sensibility checks in refchecks were shown to be redundant.

This commit includes a mild refactor to reduce tabbage, and
uses a local var to flag that a warning has already been emitted.

The flag is used at line 1020 to 1040.

It would be better to have the checks return true if warned,
to facilitate `nonSensically || unrelatedly`, etc. But that's a lot
of elses.

Review by? @retronym ?  I bet @paulp would rise from the grave for this one.
