### PR TITLE
cosmetic changes to liftables

### DIFF
--- a/src/reflect/scala/reflect/api/Liftables.scala
+++ b/src/reflect/scala/reflect/api/Liftables.scala
@@ -1,0 +1,30 @@
+package scala
+package reflect
+package api
+
+// TODO: needs a Scaladoc
+trait Liftables { self: Universe =>
+
+  // TODO: needs a Scaladoc
+  trait Liftable[T] {
+    def apply(value: T): Tree
+  }
+
+  // TODO: needs a Scaladoc
+  object Liftable extends StandardLiftableInstances {
+    def apply[T](f: T => Tree): Liftable[T] =
+      new Liftable[T] { def apply(value: T): Tree = f(value) }
+  }
+
+  // TODO: needs a Scaladoc
+  trait Unliftable[T] {
+    def unapply(tree: Tree): Option[T]
+  }
+
+  // TODO: needs a Scaladoc
+  object Unliftable extends StandardUnliftableInstances {
+    def apply[T](pf: PartialFunction[Tree, T]): Unliftable[T] = new Unliftable[T] {
+      def unapply(value: Tree): Option[T] = pf.lift(value)
+    }
+  }
+}

--- a/src/reflect/scala/reflect/api/StandardNames.scala
+++ b/src/reflect/scala/reflect/api/StandardNames.scala
@@ -96,20 +96,6 @@ trait StandardNames {
      *  of non-private vals and vars are renamed using `LOCAL_SUFFIX_STRING`.
      */
     val LOCAL_SUFFIX_STRING: String
-
-    protected[reflect] val Array: NameType
-    protected[reflect] val collection: NameType
-    protected[reflect] val immutable: NameType
-    protected[reflect] val Left: NameType
-    protected[reflect] val List: NameType
-    protected[reflect] val Map: NameType
-    protected[reflect] val None: NameType
-    protected[reflect] val Right: NameType
-    protected[reflect] val Set: NameType
-    protected[reflect] val Some: NameType
-    protected[reflect] val Symbol: NameType
-    protected[reflect] val util: NameType
-    protected[reflect] val Vector: NameType
   }
 
   /** Defines standard type names that can be accessed via the [[tpnme]] member.

--- a/src/reflect/scala/reflect/api/Universe.scala
+++ b/src/reflect/scala/reflect/api/Universe.scala
@@ -78,6 +78,7 @@ abstract class Universe extends Symbols
                            with Mirrors
                            with Printers
                            with Importers
+                           with Liftables
                            with Quasiquotes
 {
   /** Use `refiy` to produce the abstract syntax tree representing a given Scala expression.

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -124,15 +124,8 @@ trait StdNames {
     final val AnyRef: NameType        = "AnyRef"
     final val Array: NameType         = "Array"
     final val List: NameType          = "List"
-    final val Left: NameType          = "Left"
-    final val Right: NameType         = "Right"
-    final val Vector: NameType        = "Vector"
     final val Seq: NameType           = "Seq"
-    final val Set: NameType           = "Set"
-    final val Some: NameType          = "Some"
     final val Symbol: NameType        = "Symbol"
-    final val Map: NameType           = "Map"
-    final val None: NameType          = "None"
     final val WeakTypeTag: NameType   = "WeakTypeTag"
     final val TypeTag : NameType      = "TypeTag"
     final val Expr: NameType          = "Expr"
@@ -763,7 +756,6 @@ trait StdNames {
     val typedProductIterator: NameType = "typedProductIterator"
     val TypeName: NameType             = "TypeName"
     val typeTagToManifest: NameType    = "typeTagToManifest"
-    val util: NameType                 = "util"
     val unapply: NameType              = "unapply"
     val unapplySeq: NameType           = "unapplySeq"
     val unbox: NameType                = "unbox"
@@ -799,7 +791,7 @@ trait StdNames {
       final val STAR : NameType  = "*"
       final val TILDE: NameType  = "~"
 
-      final val isUnary: Set[Name] = scala.collection.immutable.Set(MINUS, PLUS, TILDE, BANG)
+      final val isUnary: Set[Name] = Set(MINUS, PLUS, TILDE, BANG)
     }
 
     // value-conversion methods
@@ -852,8 +844,8 @@ trait StdNames {
     val UNARY_! = encode("unary_!")
 
     // Grouped here so Cleanup knows what tests to perform.
-    val CommonOpNames   = scala.collection.immutable.Set[Name](OR, XOR, AND, EQ, NE)
-    val BooleanOpNames  = scala.collection.immutable.Set[Name](ZOR, ZAND, UNARY_!) ++ CommonOpNames
+    val CommonOpNames   = Set[Name](OR, XOR, AND, EQ, NE)
+    val BooleanOpNames  = Set[Name](ZOR, ZAND, UNARY_!) ++ CommonOpNames
 
     val add: NameType                    = "add"
     val complement: NameType             = "complement"

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -204,9 +204,10 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     // inaccessible: this.TypeHistory
     this.TermName
     this.TypeName
-    this.BooleanFlag
     this.Liftable
     this.Unliftable
+    this.BooleanFlag
+    // inaccessible: this.CachedNames
     this.WeakTypeTag
     this.TypeTag
     this.Expr


### PR DESCRIPTION
Namely:
1) Moved definitions of Liftable and Unliftable into a separate file.
2) Inlined internal names that were only used in StandardLiftables.
