### PR TITLE
[nomaster] backports https://github.com/scala/scala/pull/3236

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1837,6 +1837,7 @@ TODO:
     <copy toDir="${dist.dir}/lib">
       <fileset dir="${build-pack.dir}/lib">
         <include name="jline.jar"/>
+        <include name="scala-partest.jar"/> <!-- needed for maven publish -->
         <include name="scalap.jar"/>
       </fileset>
     </copy>

--- a/src/asm/scala/tools/asm/MethodWriter.java
+++ b/src/asm/scala/tools/asm/MethodWriter.java
@@ -1853,7 +1853,12 @@ class MethodWriter extends MethodVisitor {
         int size = 8;
         if (code.length > 0) {
             if (code.length > 65536) {
-                throw new RuntimeException("Method code too large!");
+                String nameString = "";
+                int i = 0;
+                // find item that corresponds to the index of our name
+                while (i < cw.items.length && (cw.items[i] == null || cw.items[i].index != name)) i++;
+                if (cw.items[i] != null) nameString = cw.items[i].strVal1 +"'s ";
+                throw new RuntimeException("Method "+ nameString +"code too large!");
             }
             cw.newUTF8("Code");
             size += 18 + code.length + 8 * handlerCount;

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -980,8 +980,11 @@ self =>
 
     /** Assumed (provisionally) to be TermNames. */
     def ident(skipIt: Boolean): Name =
-      if (isIdent) rawIdent().encode
-      else {
+      if (isIdent) {
+        val name = in.name.encode
+        in.nextToken()
+        name
+      } else {
         syntaxErrorOrIncomplete(expectedMsg(IDENTIFIER), skipIt)
         nme.ERROR
       }

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -611,10 +611,7 @@ trait Scanners extends ScannersCommon {
       if (ch == '`') {
         nextChar()
         finishNamed(BACKQUOTED_IDENT)
-        if (name.length == 0)
-          syntaxError("empty quoted identifier")
-        else if (name == nme.WILDCARD)
-          syntaxError("wildcard invalid as backquoted identifier")
+        if (name.length == 0) syntaxError("empty quoted identifier")
       }
       else syntaxError("unclosed quoted identifier")
     }

--- a/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
@@ -954,10 +954,7 @@ abstract class GenICode extends SubComponent  {
                 case _ =>
               }
               ctx1.bb.emit(cm, tree.pos)
-
-              if (sym == ctx1.method.symbol) {
-                ctx1.method.recursive = true
-              }
+              ctx1.method.updateRecursive(sym)
               generatedType =
                 if (sym.isClassConstructor) UNIT
                 else toTypeKind(sym.info.resultType);

--- a/src/compiler/scala/tools/nsc/backend/icode/Members.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/Members.scala
@@ -185,6 +185,10 @@ trait Members {
       this
     }
 
+    final def updateRecursive(called: Symbol): Unit = {
+      recursive ||= (called == symbol)
+    }
+
     def addLocal(l: Local): Local = findOrElse(locals)(_ == l) { locals ::= l ; l }
 
     def addParam(p: Local): Unit =

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
@@ -450,7 +450,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
     }
 
     // -----------------------------------------------------------------------------------------
-    // utitilies useful when emitting plain, mirror, and beaninfo classes.
+    // utilities useful when emitting plain, mirror, and beaninfo classes.
     // -----------------------------------------------------------------------------------------
 
     def writeIfNotTooBig(label: String, jclassName: String, jclass: asm.ClassWriter, sym: Symbol) {
@@ -458,9 +458,9 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
         val arr = jclass.toByteArray()
         bytecodeWriter.writeClass(label, jclassName, arr, sym)
       } catch {
-        case e: java.lang.RuntimeException if(e.getMessage() == "Class file too large!") =>
-          // TODO check where ASM throws the equivalent of CodeSizeTooBigException
-          log("Skipped class "+jclassName+" because it exceeds JVM limits (it's too big or has methods that are too long).")
+        case e: java.lang.RuntimeException if e != null && (e.getMessage contains "too large!") =>
+          reporter.error(sym.pos,
+            s"Could not write class $jclassName because it exceeds JVM code size limits. ${e.getMessage}")
       }
     }
 
@@ -1402,7 +1402,6 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
       addInnerClasses(clasz.symbol, jclass)
       jclass.visitEnd()
       writeIfNotTooBig("" + c.symbol.name, thisName, jclass, c.symbol)
-
     }
 
     /**

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -715,8 +715,8 @@ trait Macros extends scala.tools.reflect.FastTrack with Traces {
             if (isNullaryInvocation(expandee)) expectedTpe = expectedTpe.finalResultType
             // also see http://groups.google.com/group/scala-internals/browse_thread/thread/492560d941b315cc
             val expanded0 = duplicateAndKeepPositions(expanded)
-            val expanded1 = typecheck("macro def return type", expanded0, expectedTpe)
-            val expanded2 = typecheck("expected type", expanded1, pt)
+            val expanded1 = typecheck("expected type", expanded0, pt)
+            val expanded2 = typecheck("macro def return type", expanded1, expectedTpe)
             expanded2
           } finally {
             popMacroContext()

--- a/test/files/neg/t6426.check
+++ b/test/files/neg/t6426.check
@@ -1,7 +1,0 @@
-t6426.scala:4: error: wildcard invalid as backquoted identifier
-  println(`_`.Buffer(0))
-          ^
-t6426.scala:5: error: ')' expected but '}' found.
-}
-^
-two errors found

--- a/test/files/neg/t6426.scala
+++ b/test/files/neg/t6426.scala
@@ -1,5 +1,0 @@
-class A {
-  import collection.{mutable => _, _}
-
-  println(`_`.Buffer(0))
-}

--- a/test/files/pos/t8062.flags
+++ b/test/files/pos/t8062.flags
@@ -1,0 +1,1 @@
+-optimize

--- a/test/files/pos/t8062/A_1.scala
+++ b/test/files/pos/t8062/A_1.scala
@@ -1,0 +1,5 @@
+package warmup
+
+object Warmup {
+  def filter[A](p: Any => Boolean): Any = filter[Any](p)
+}

--- a/test/files/pos/t8062/B_2.scala
+++ b/test/files/pos/t8062/B_2.scala
@@ -1,0 +1,3 @@
+object Test {
+  warmup.Warmup.filter[Any](x => false)
+}

--- a/test/files/run/large_code.check
+++ b/test/files/run/large_code.check
@@ -1,0 +1,3 @@
+newSource1.scala:1: error: Could not write class BigEnoughToFail because it exceeds JVM code size limits. Method tooLong's code too large!
+class BigEnoughToFail {
+      ^

--- a/test/files/run/large_code.scala
+++ b/test/files/run/large_code.scala
@@ -1,0 +1,24 @@
+import scala.tools.partest._
+import java.io.{Console => _, _}
+
+// a cold run of partest takes about 15s for this test on my laptop
+object Test extends DirectTest {
+  override def extraSettings: String = "-usejavacp -d " + testOutput.path
+
+  // test that we hit the code size limit and error out gracefully
+  // 5958 is the magic number (2^16/11 -- each `a(1,2,3,4,5,6)` is 11 bytes of bytecode)
+  override def code
+    = s"""
+      |class BigEnoughToFail {
+      |  def a(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int): Unit = {}
+      |  def tooLong: Unit = {
+      |    ${(1 to 5958) map (_ => "a(1,2,3,4,5,6)") mkString(";")}
+      |  }
+      |}""".stripMargin.trim
+
+  override def show(): Unit = {
+    Console.withErr(System.out) {
+      compile()
+    }
+  }
+}


### PR DESCRIPTION
Even though whitebox macros are supposed to be used to produce expansions
that refine advertised return types of their macro definitions, sometimes
those more precise types aren’t picked up by the typechecker.

It all started with Travis generating structural types with macros
and noticing that typer needs an extra nudge in order to make generated
members accessible to the outside world. I didn’t understand the mechanism
of the phenomenon back then, and after some time I just gave up.

Afterwards, when this issue had been brought up again in a different
StackOverflow question, we discussed it at reflection meeting, figured out
that typedBlock provides some special treatment to anonymous classes,
and it became clear that the first macro typecheck (the one that types
the expansion against the return type of the corresponding macro def)
is at fault here.

The thing is that if we have a block that stands for a desugard anonymous
class instantiation, and we typecheck it with expected type different from
WildcardType, then typer isn’t going to include decls of the anonymous class
in the resulting structural type: https://github.com/scala/scala/blob/master/src/compiler/scala/tools/nsc/typechecker/Typers.scala#L2350.
I tried to figure it out at https://groups.google.com/forum/#!topic/scala-internals/eXQt-BPm4i8,
but couldn’t dispel the mystery, so again I just gave up.

But today I had a profound WAT experience that finally tipped the scales.
It turns out that if we typecheck an if, providing a suitable pt, then
the resulting type of an if is going to be that pt, even though the lub
of the branch types might be more precise. I’m sure that reasons for this
behavior are also beyond my understanding, so I decided to sidestep this problem.

upd. Here’s Jason’s clarification: Doing thing differently would require
us to believe that "'Tis better to have lubbed and lost than never to have
lubbed at all." But the desire for efficiency trumps such sentimentality.

Now expansions of whitebox macros are first typechecked against pt,
the expected type that comes from the enclosing context, before being
typechecked against expectedTpe, the expected type that comes from the return
type of the macro def. This means that now pt provides the correct
expected type for the initial, most important typecheck, which makes
types more precise.
