### PR TITLE
(2.10.4) backports https://github.com/scala/scala/pull/3236

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -715,8 +715,8 @@ trait Macros extends scala.tools.reflect.FastTrack with Traces {
             if (isNullaryInvocation(expandee)) expectedTpe = expectedTpe.finalResultType
             // also see http://groups.google.com/group/scala-internals/browse_thread/thread/492560d941b315cc
             val expanded0 = duplicateAndKeepPositions(expanded)
-            val expanded1 = typecheck("macro def return type", expanded0, expectedTpe)
-            val expanded2 = typecheck("expected type", expanded1, pt)
+            val expanded1 = typecheck("expected type", expanded0, pt)
+            val expanded2 = typecheck("macro def return type", expanded1, expectedTpe)
             expanded2
           } finally {
             popMacroContext()


### PR DESCRIPTION
Even though whitebox macros are supposed to be used to produce expansions
that refine advertised return types of their macro definitions, sometimes
those more precise types aren’t picked up by the typechecker.

It all started with Travis generating structural types with macros
and noticing that typer needs an extra nudge in order to make generated
members accessible to the outside world. I didn’t understand the mechanism
of the phenomenon back then, and after some time I just gave up.

Afterwards, when this issue had been brought up again in a different
StackOverflow question, we discussed it at reflection meeting, figured out
that typedBlock provides some special treatment to anonymous classes,
and it became clear that the first macro typecheck (the one that types
the expansion against the return type of the corresponding macro def)
is at fault here.

The thing is that if we have a block that stands for a desugard anonymous
class instantiation, and we typecheck it with expected type different from
WildcardType, then typer isn’t going to include decls of the anonymous class
in the resulting structural type: https://github.com/scala/scala/blob/master/src/compiler/scala/tools/nsc/typechecker/Typers.scala#L2350.
I tried to figure it out at https://groups.google.com/forum/#!topic/scala-internals/eXQt-BPm4i8,
but couldn’t dispel the mystery, so again I just gave up.

But today I had a profound WAT experience that finally tipped the scales.
It turns out that if we typecheck an if, providing a suitable pt, then
the resulting type of an if is going to be that pt, even though the lub
of the branch types might be more precise. I’m sure that reasons for this
behavior are also beyond my understanding, so I decided to sidestep this problem.

upd. Here’s Jason’s clarification: Doing thing differently would require
us to believe that "'Tis better to have lubbed and lost than never to have
lubbed at all." But the desire for efficiency trumps such sentimentality.

Now expansions of whitebox macros are first typechecked against pt,
the expected type that comes from the enclosing context, before being
typechecked against expectedTpe, the expected type that comes from the return
type of the macro def. This means that now pt provides the correct
expected type for the initial, most important typecheck, which makes
types more precise.
