### PR TITLE
Dotless type application for infix operators.

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
@@ -55,7 +55,13 @@ abstract class TreeBuilder {
     ValDef(Modifiers(PRIVATE), name, tpt, EmptyTree)
 
   /** Create tree representing (unencoded) binary operation expression or pattern. */
-  def makeBinop(isExpr: Boolean, left: Tree, op: TermName, right: Tree, opPos: Position): Tree = {
+  def makeBinop(isExpr: Boolean, left: Tree, op: TermName, right: Tree, opPos: Position, targs: List[Tree] = Nil): Tree = {
+    require(isExpr || targs.isEmpty, s"Incompatible args to makeBinop: !isExpr but targs=$targs")
+
+    def mkSelection(t: Tree) = {
+      def sel = atPos(opPos union t.pos)(Select(stripParens(t), op.encode))
+      if (targs.isEmpty) sel else atPos(left.pos)(TypeApply(sel, targs))
+    }
     def mkNamed(args: List[Tree]) = if (isExpr) args map treeInfo.assignmentToMaybeNamedArg else args
     val arguments = right match {
       case Parens(args) => mkNamed(args)
@@ -63,12 +69,12 @@ abstract class TreeBuilder {
     }
     if (isExpr) {
       if (treeInfo.isLeftAssoc(op)) {
-        Apply(atPos(opPos union left.pos) { Select(stripParens(left), op.encode) }, arguments)
+        Apply(mkSelection(left), arguments)
       } else {
         val x = freshTermName()
         Block(
           List(ValDef(Modifiers(SYNTHETIC | ARTIFACT), x, TypeTree(), stripParens(left))),
-          Apply(atPos(opPos union right.pos) { Select(stripParens(right), op.encode) }, List(Ident(x))))
+          Apply(mkSelection(right), List(Ident(x))))
       }
     } else {
       Apply(Ident(op.encode), stripParens(left) :: arguments)

--- a/test/files/neg/dotless-targs.check
+++ b/test/files/neg/dotless-targs.check
@@ -1,0 +1,4 @@
+dotless-targs.scala:2: error: type application is not allowed for postfix operators
+  def f1 = "f1" isInstanceOf[String] // not ok
+                ^
+one error found

--- a/test/files/neg/dotless-targs.scala
+++ b/test/files/neg/dotless-targs.scala
@@ -1,0 +1,5 @@
+class A {
+  def f1 = "f1" isInstanceOf[String] // not ok
+  def f2 = "f2".isInstanceOf[String] // ok
+  def f3 = "f3" toList               // ok
+}

--- a/test/files/pos/dotless-targs.scala
+++ b/test/files/pos/dotless-targs.scala
@@ -1,0 +1,9 @@
+class A {
+  def fn1 = List apply 1
+  def fn2 = List apply[Int] 2
+
+  def g1: Char = "g1" toList 0
+  def g2: Char = "g2" apply 1
+
+  def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
+}


### PR DESCRIPTION
When you have an aesthetic expresion like

```
  def f(xs: Iterator[Int]) = (
    xs takeWhile (_ < 1000)
             map (_ * -1)
          filter (_ % 2 == 0)
         flatMap (x => List(x, x))
    reduceOption (_ + _)
           maxBy (_.toString)
  )
```

And then for whatever reason you have to perform explicit
type application in the midst of that expression, it's
aggravating in the extreme that it has (had) to be rewritten
in its entirety to accommodate that change.

So now you can perform type application in the middle of it.

For reasons not entirely clear to me postfix operators are
excluded. The discussion as well as the approval for the infix
variation of it can be found at:
  https://groups.google.com/forum/#!msg/scala-language/eJl1wnkEz9M/hR984-lqC5EJ
