### PR TITLE
SI-8015 Count lines by EOLs

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -206,9 +206,9 @@ trait Scanners extends ScannersCommon {
           token = kwArray(idx)
           if (token == IDENTIFIER && allowIdent != name) {
             if (name == nme.MACROkw)
-              syntaxError(name+" is now a reserved word; usage as an identifier is disallowed")
+              syntaxError(s"$name is now a reserved word; usage as an identifier is disallowed")
             else if (emitIdentifierDeprecationWarnings)
-              deprecationWarning(name+" is now a reserved word; usage as an identifier is deprecated")
+              deprecationWarning(s"$name is now a reserved word; usage as an identifier is deprecated")
           }
         }
       }
@@ -389,7 +389,7 @@ trait Scanners extends ScannersCommon {
 //              println("blank line found at "+lastOffset+":"+(lastOffset to idx).map(buf(_)).toList)
               return true
             }
-	    if (idx == end) return false
+            if (idx == end) return false
           } while (ch <= ' ')
         }
         idx += 1; ch = buf(idx)

--- a/src/reflect/scala/reflect/internal/util/Position.scala
+++ b/src/reflect/scala/reflect/internal/util/Position.scala
@@ -202,12 +202,14 @@ private[util] trait InternalPositionImpl {
   def line: Int           = if (hasSource) source.offsetToLine(point) + 1 else 0
   def column: Int         = if (hasSource) calculateColumn() else 0
   def lineContent: String = if (hasSource) source.lineToString(line - 1) else ""
-  def lineCarat: String   = if (hasSource) " " * (column - 1) + "^" else ""
+  def lineCaret: String   = if (hasSource) " " * (column - 1) + "^" else ""
+  @deprecated("use `lineCaret`", since="2.11.0")
+  def lineCarat: String   = lineCaret
 
   def showError(msg: String): String = finalPosition match {
     case FakePos(fmsg) => s"$fmsg $msg"
     case NoPosition    => msg
-    case pos           => f"${pos.line}: $msg%n${u(pos.lineContent)}%n${pos.lineCarat}"
+    case pos           => f"${pos.line}: $msg%n${u(pos.lineContent)}%n${pos.lineCaret}"
   }
   private def u(s: String) = {
     def uu(c: Int) = f"\\u$c%04x"
@@ -263,7 +265,7 @@ private[util] trait DeprecatedPosition {
   @deprecated("use `finalPosition`", "2.11.0")
   def inUltimateSource(source: SourceFile): Position = source positionInUltimateSource this
 
-  @deprecated("use `lineCarat`", "2.11.0")
+  @deprecated("use `lineCaret`", since="2.11.0")
   def lineWithCarat(maxWidth: Int): (String, String) = ("", "")
 
   @deprecated("Use `withSource(source)` and `withShift`", "2.11.0")

--- a/src/reflect/scala/reflect/internal/util/Position.scala
+++ b/src/reflect/scala/reflect/internal/util/Position.scala
@@ -207,7 +207,16 @@ private[util] trait InternalPositionImpl {
   def showError(msg: String): String = finalPosition match {
     case FakePos(fmsg) => s"$fmsg $msg"
     case NoPosition    => msg
-    case pos           => s"${pos.line}: $msg\n${pos.lineContent}\n${pos.lineCarat}"
+    case pos           => f"${pos.line}: $msg%n${u(pos.lineContent)}%n${pos.lineCarat}"
+  }
+  private def u(s: String) = {
+    def uu(c: Int) = f"\\u$c%04x"
+    def uable(c: Int) = (c < 0x20 && c != '\t') || c == 0x7F
+    if (s exists (c => uable(c))) {
+      val sb = new StringBuilder
+      s foreach (c => sb append (if (uable(c)) uu(c) else c))
+      sb.toString
+    } else s
   }
   def showDebug: String = toString
   def show = (

--- a/src/reflect/scala/reflect/internal/util/SourceFile.scala
+++ b/src/reflect/scala/reflect/internal/util/SourceFile.scala
@@ -37,8 +37,12 @@ abstract class SourceFile {
   override def toString() = file.name
   def path = file.path
 
-  def lineToString(index: Int): String =
-    content drop lineToOffset(index) takeWhile (c => !isLineBreakChar(c.toChar)) mkString ""
+  def lineToString(index: Int): String = {
+    val start = lineToOffset(index)
+    var end = start
+    while (!isEndOfLine(end)) end += 1
+    content.slice(start, end) mkString ""
+  }
 
   @tailrec
   final def skipWhitespace(offset: Int): Int =

--- a/test/files/neg/t8015-ffa.check
+++ b/test/files/neg/t8015-ffa.check
@@ -1,0 +1,6 @@
+t8015-ffa.scala:7: error: type mismatch;
+ found   : String("3")
+ required: Int
+  val i: Int = "3"      // error line 7 (was 8)
+               ^
+one error found

--- a/test/files/neg/t8015-ffa.scala
+++ b/test/files/neg/t8015-ffa.scala
@@ -1,0 +1,8 @@
+
+package foo
+
+//-------object Next
+
+trait F {
+  val i: Int = "3"      // error line 7 (was 8)
+}

--- a/test/files/neg/t8015-ffb.check
+++ b/test/files/neg/t8015-ffb.check
@@ -1,0 +1,6 @@
+t8015-ffb.scala:10: warning: side-effecting nullary methods are discouraged: suggest defining as `def w()` instead
+  def w = { x
+      ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/t8015-ffb.check
+++ b/test/files/neg/t8015-ffb.check
@@ -1,5 +1,5 @@
 t8015-ffb.scala:10: warning: side-effecting nullary methods are discouraged: suggest defining as `def w()` instead
-  def w = { x
+  def w = { x\u000c() }       // ^L is colored blue on this screen, hardly visible
       ^
 error: No warnings can be incurred under -Xfatal-warnings.
 one warning found

--- a/test/files/neg/t8015-ffb.flags
+++ b/test/files/neg/t8015-ffb.flags
@@ -1,0 +1,1 @@
+-Xlint -Xfatal-warnings

--- a/test/files/neg/t8015-ffb.scala
+++ b/test/files/neg/t8015-ffb.scala
@@ -1,0 +1,11 @@
+
+trait G {
+  val c: Char = '\u000a'   // disallowed!
+  def x\u000d\u000a = 9    // as nl
+  def y() = x
+  def z() = {
+    y()\u000a()           // was Int does not take parameters
+  }
+  def v = y()\u000c()     // was Int does not take parameters
+  def w = { x() }       // ^L is colored blue on this screen, hardly visible
+}

--- a/test/files/run/t8015-ffc.scala
+++ b/test/files/run/t8015-ffc.scala
@@ -1,0 +1,7 @@
+
+object Test extends App {
+  val ms = """This is a long multiline string
+  with \u000d\u000a CRLF embedded."""
+  assert(ms.lines.size == 3, s"lines.size ${ms.lines.size}")
+  assert(ms contains "\r\n CRLF", "no CRLF")
+}


### PR DESCRIPTION
Source lines were counted by "line break chars", including FF.
Clients of `pos.line` seem to all expect the ordinary line num,
so that is what they get.

Unicode processing now precedes line ending processing.

Review by @adriaanm who is going to come across it anyway in the final hours of clean-up before cutting a milestone
