### PR TITLE
Emit correctly typed literal when initializing lazy val bitmaps

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Mixin.scala
+++ b/src/compiler/scala/tools/nsc/transform/Mixin.scala
@@ -725,7 +725,9 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
           }
           val init = bitmapKind match {
             case BooleanClass => ValDef(sym, FALSE)
-            case _            => ValDef(sym, ZERO)
+            case ByteClass    => ValDef(sym, LIT(0.toByte))
+            case IntClass     => ValDef(sym, ZERO)
+            case LongClass    => ValDef(sym, LIT(0L))
           }
 
           sym setFlag PrivateLocal


### PR DESCRIPTION
`Constants.tag` and `Constants.tpe` relies on the held `Any` to have the
desired type. Explicitly match on `bitmapKind` to emit correctly typed
`Literal(Constant(...))`
