### PR TITLE
duplicates arguments to macro typer APIs

### DIFF
--- a/src/compiler/scala/reflect/macros/contexts/Typers.scala
+++ b/src/compiler/scala/reflect/macros/contexts/Typers.scala
@@ -24,7 +24,7 @@ trait Typers {
     // typechecking uses silent anyways (e.g. in typedSelect), so you'll only waste your time
     // I'd advise fixing the root cause: finding why the context is not set to report errors
     // (also see reflect.runtime.ToolBoxes.typeCheckExpr for a workaround that might work for you)
-    wrapper(callsiteTyper.silent(_.typed(tree, pt), reportAmbiguousErrors = false) match {
+    wrapper(callsiteTyper.silent(_.typed(universe.duplicateAndKeepPositions(tree), pt), reportAmbiguousErrors = false) match {
       case universe.analyzer.SilentResultValue(result) =>
         macroLogVerbose(result)
         result
@@ -46,7 +46,7 @@ trait Typers {
     universe.analyzer.inferImplicit(tree, viewTpe, true, callsiteTyper.context, silent, withMacrosDisabled, pos, (pos, msg) => throw TypecheckException(pos, msg))
   }
 
-  def resetAllAttrs(tree: Tree): Tree = universe.resetAllAttrs(tree)
+  def resetAllAttrs(tree: Tree): Tree = universe.resetAllAttrs(universe.duplicateAndKeepPositions(tree))
 
-  def resetLocalAttrs(tree: Tree): Tree = universe.resetLocalAttrs(tree)
+  def resetLocalAttrs(tree: Tree): Tree = universe.resetLocalAttrs(universe.duplicateAndKeepPositions(tree))
 }


### PR DESCRIPTION
This commit continues the tendency set by the parent commit to duplicate
as much as possible in order to avoid potential confusion that users
might run into when compiler internals start leaking.

Here we plumb another way that by-reference sharing of trees might bite
unsuspecting macro writers. Previously we have duplicated macro expansions,
macro arguments, c.macroApplication, and now it’s arguments to typeCheck
and resetAttrs.

There is still an unlikely situation when someone gets to c.enclosingXXX
and then starts typechecking around, but that’s left for future work,
as it’s yet unclear what to do with c.enclosingXXX APIs.
