### PR TITLE
SI-1448 Unify casting behavior for AnyVals

### DIFF
--- a/src/library/scala/runtime/BoxesRunTime.java
+++ b/src/library/scala/runtime/BoxesRunTime.java
@@ -90,31 +90,66 @@ public final class BoxesRunTime
     }
 
     public static char unboxToChar(Object c) {
-        return c == null ? 0 : ((java.lang.Character)c).charValue();
+        if (c == null)
+            return 0;
+        else if (c instanceof java.lang.Number)
+            return (char)((java.lang.Number)c).shortValue();
+        else
+            return ((java.lang.Character)c).charValue();
     }
 
     public static byte unboxToByte(Object b) {
-        return b == null ? 0 : ((java.lang.Byte)b).byteValue();
+        if (b == null)
+            return 0;
+        else if (b instanceof java.lang.Character)
+            return (byte)((java.lang.Character)b).charValue();
+        else
+            return ((java.lang.Number)b).byteValue();
     }
 
     public static short unboxToShort(Object s) {
-        return s == null ? 0 : ((java.lang.Short)s).shortValue();
+        if (s == null)
+            return 0;
+        else if (s instanceof java.lang.Character)
+            return (short)((java.lang.Character)s).charValue();
+        else
+            return ((java.lang.Number)s).shortValue();
     }
 
     public static int unboxToInt(Object i) {
-        return i == null ? 0 : ((java.lang.Integer)i).intValue();
+        if (i == null)
+            return 0;
+        else if (i instanceof java.lang.Character)
+            return (int)((java.lang.Character)i).charValue();
+        else
+            return ((java.lang.Number)i).intValue();
     }
 
     public static long unboxToLong(Object l) {
-        return l == null ? 0 : ((java.lang.Long)l).longValue();
+        if (l == null)
+            return 0L;
+        else if (l instanceof java.lang.Character)
+            return (long)((java.lang.Character)l).charValue();
+        else
+            return ((java.lang.Number)l).longValue();
     }
 
     public static float unboxToFloat(Object f) {
-        return f == null ? 0.0f : ((java.lang.Float)f).floatValue();
+        if (f == null)
+            return 0.0f;
+        else if (f instanceof java.lang.Character)
+            return (float)((java.lang.Character)f).charValue();
+        else
+            return ((java.lang.Number)f).floatValue();
     }
 
     public static double unboxToDouble(Object d) {
-        return d == null ? 0.0d : ((java.lang.Double)d).doubleValue();
+        if (d == null)
+            return 0.0d;
+        else if (d instanceof java.lang.Character)
+            return (double)((java.lang.Character)d).charValue();
+        else
+            return ((java.lang.Number)d).doubleValue();
     }
 
     /* COMPARISON ... COMPARISON ... COMPARISON ... COMPARISON ... COMPARISON ... COMPARISON */

--- a/src/library/scala/runtime/BoxesRunTime.java
+++ b/src/library/scala/runtime/BoxesRunTime.java
@@ -114,7 +114,6 @@ public final class BoxesRunTime
     }
 
     public static double unboxToDouble(Object d) {
-        //        System.out.println("unbox " + d);
         return d == null ? 0.0d : ((java.lang.Double)d).doubleValue();
     }
 


### PR DESCRIPTION
**Attention**: This is an alternative PR to #3295. Do **NOT** merge both.

Casts of AnyVals had inconsitent behavior depending on whether they were boxed:

```
1L.asInstanceOf[Int]        // -> 1
(1L: Any).asInstanceOf[Int] // -> ClassCastException
```

This PR fixes this by adapting the unboxing helpers in `BoxesRunTime`. A couple of caveats:
- Unboxing requires an additional instanceof check. (Reason: Casting of Character, which is not subtype of Number).
- A wrong ClassCastException is raised on a failed cast to a primitive numeric value. It says "cannot cast to Number" instead of Integer etc.

Where the latter issue can easily be fixed by adding another `instanceof` check, the former is inherent to the fact that `java.lang.Character` does not extend `java.lang.Number` but conversion must be performed. It can only be fixed by integrating (part) of this behaviour in the compiler.

Maybe we should reconsider changing the behaviour the other way around. It is easy to emit a deprecation warning in 2.11 for casts that convert (implemented in PR #3295) and put the behaviour behind a flag in 2.12.

All partests ~~except for the instrumentation tests~~ succeed on this PR.
