### PR TITLE
SI-1448 Deprecate conversion of numeric values types by casts

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -827,9 +827,12 @@ abstract class Erasure extends AddInterfaces
             case TypeApply(Select(qual, _), List(targ)) =>
               if (qual.tpe <:< targ.tpe)
                 atPos(tree.pos) { Typed(qual, TypeTree(targ.tpe)) }
-              else if (isNumericValueClass(qual.tpe.typeSymbol) && isNumericValueClass(targ.tpe.typeSymbol))
+              else if (isNumericValueClass(qual.tpe.typeSymbol) && isNumericValueClass(targ.tpe.typeSymbol)) {
+                // todo: make this fail 2.12
+                unit.deprecationWarning(qual.pos, "using asInstanceOf to convert numeric value types is deprecated. " +
+                                        s"Use to${targ.tpe.typeSymbol.name} instead")
                 atPos(tree.pos)(numericConversion(qual, targ.tpe.typeSymbol))
-              else
+              } else
                 tree
           }
           // todo: also handle the case where the singleton type is buried in a compound

--- a/test/files/run/literals.check
+++ b/test/files/run/literals.check
@@ -1,4 +1,4 @@
-warning: there were 5 deprecation warning(s); re-run with -deprecation for details
+warning: there were 11 deprecation warning(s); re-run with -deprecation for details
 test '\u0024' == '$' was successful
 test '\u005f' == '_' was successful
 test 65.asInstanceOf[Char] == 'A' was successful

--- a/test/files/run/literals.scala
+++ b/test/files/run/literals.scala
@@ -35,6 +35,7 @@ object Test {
     // char
     check_success("'\\u0024' == '$'", '\u0024', '$')
     check_success("'\\u005f' == '_'", '\u005f', '_')
+    // this cast is deprecated
     check_success("65.asInstanceOf[Char] == 'A'", 65.asInstanceOf[Char], 'A')
     check_success("\"\\141\\142\" == \"ab\"", "\141\142", "ab")
     check_success("\"\\0x61\\0x62\".trim() == \"x61\\0x62\"", "\0x61\0x62".substring(1), "x61\0x62")
@@ -72,6 +73,7 @@ object Test {
     // long
     check_success("1l == 1L", 1l, 1L)
     check_success("1L == 1l", 1L, 1l)
+    // this cast is deprecated
     check_success("1.asInstanceOf[Long] == 1l", 1.asInstanceOf[Long], 1l)
 
     check_success("0x7fffffffffffffffL == 9223372036854775807L",
@@ -94,6 +96,7 @@ object Test {
     check_success("3.14f == 3.14f", 3.14f, 3.14f)
     check_success("6.022e23f == 6.022e23f", 6.022e23f, 6.022e23f)
     check_success("09f == 9.0f", 09f, 9.0f)
+    // these casts are deprecated
     check_success("1.asInstanceOf[Float] == 1.0", 1.asInstanceOf[Float], 1.0f)
     check_success("1l.asInstanceOf[Float] == 1.0", 1l.asInstanceOf[Float], 1.0f)
 
@@ -109,6 +112,7 @@ object Test {
     check_success("3.14 == 3.14", 3.14, 3.14)
     check_success("1e-9d == 1.0e-9", 1e-9d, 1.0e-9)
     check_success("1e137 == 1.0e137", 1e137, 1.0e137)
+    // these casts are deprecated
     check_success("1.asInstanceOf[Double] == 1.0", 1.asInstanceOf[Double], 1.0)
     check_success("1l.asInstanceOf[Double] == 1.0", 1l.asInstanceOf[Double], 1.0)
 

--- a/test/files/run/t7868.check
+++ b/test/files/run/t7868.check
@@ -1,0 +1,1 @@
+warning: there were 1 deprecation warning(s); re-run with -deprecation for details

--- a/test/files/run/unboxingBug.check
+++ b/test/files/run/unboxingBug.check
@@ -1,3 +1,4 @@
+warning: there were 2 deprecation warning(s); re-run with -deprecation for details
 97
 97
 97

--- a/test/files/run/unboxingBug.scala
+++ b/test/files/run/unboxingBug.scala
@@ -1,6 +1,7 @@
 object Test extends App {
   println(identity('a').toInt)
   println('a'.toInt)
+  // deprecated casts (char -> int)
   println(identity('a').asInstanceOf[Int])
   println('a'.asInstanceOf[Int])
   println(identity(1).asInstanceOf[Int])


### PR DESCRIPTION
**Attention**: This is an alternative PR to #3294. Do **NOT** merge both.

Casts of AnyVals had inconsitent behavior depending on whether they were boxed:

```
1L.asInstanceOf[Int]        // -> 1
(1L: Any).asInstanceOf[Int] // -> ClassCastException
```

This PR fixes this by deprecating casts for conversion. I.e. in future scala versions, both calls will fail (although the first at compile time).

PR #3294 contains some discussion why this version might be desirable above the other.

After checkfile update to accomodate deprecation warnings, all partests succeed. However, run/t7868 does now emit a deprecation warning due to the code generated by the pattern matcher (no difference in matching behaviour is observed). If we proceed with this option, this warning will have to be fixed in the pattern matcher.

**UPDATE** This does not deprecate casts from `null` to a value type.
