### PR TITLE
fix Stream#flatten example

### DIFF
--- a/src/library/scala/collection/immutable/Stream.scala
+++ b/src/library/scala/collection/immutable/Stream.scala
@@ -955,7 +955,7 @@ self =>
    * `Stream`.
    * @example {{{
    * val sov: Stream[Vector[Int]] = Vector(0) #:: Vector(0, 0) #:: sov.zip(sov.tail).map { n => n._1 ++ n._2 }
-   * sov flatten take 10 mkString ", "
+   * sov.flatten take 10 mkString ", "
    * // produces: "0, 0, 0, 0, 0, 0, 0, 0, 0, 0"
    * }}}
    */


### PR DESCRIPTION
```
Welcome to Scala version 2.10.3 (Java HotSpot(TM) 64-Bit Server VM, Java 1.7.0_45).
Type in expressions to have them evaluated.
Type :help for more information.

scala> val sov: Stream[Vector[Int]] = Vector(0) #:: Vector(0, 0) #:: sov.zip(sov.tail).map { n => n._1 ++ n._2 }
sov: Stream[Vector[Int]] = Stream(Vector(0), ?)

scala> sov flatten take 10 mkString ", "
<console>:1: error: ';' expected but integer literal found.
       sov flatten take 10 mkString ", "
                        ^

scala> sov.flatten take 10 mkString ", "
res0: String = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
```
