### PR TITLE
Resolves SI-7837, failure in quickSort.

### DIFF
--- a/src/library/scala/util/Sorting.scala
+++ b/src/library/scala/util/Sorting.scala
@@ -141,14 +141,14 @@ object Sorting {
         var done = false
         while (!done) {
           while (b <= c && x(b) <= v) {
-            if (x(b) == v) {
+            if (x(b) equiv v) {
               swap(a, b)
               a += 1
             }
             b += 1
           }
           while (c >= b && x(c) >= v) {
-            if (x(c) == v) {
+            if (x(c) equiv v) {
               swap(c, d)
               d -= 1
             }

--- a/test/junit/scala/collection/ArraySortingTest.scala
+++ b/test/junit/scala/collection/ArraySortingTest.scala
@@ -1,0 +1,29 @@
+package scala.collection.mutable
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Test
+
+/* Tests various maps by making sure they all agree on the same answers. */
+@RunWith(classOf[JUnit4])
+class ArraySortingTest {
+  
+  class CantSortMe(val i: Int) {
+    override def equals(a: Any) = throw new IllegalArgumentException("I cannot be equalled!")
+  }
+  
+  object CanOrder extends Ordering[CantSortMe] {
+    def compare(a: CantSortMe, b: CantSortMe) = a.i compare b.i
+  }
+  
+  // Tests SI-7837
+  @Test
+  def sortByTest() {
+    val test = Array(1,2,3,4,1,3,5,7,1,4,8,1,1,1,1)
+    val cant = test.map(i => new CantSortMe(i))
+    java.util.Arrays.sort(test)
+    scala.util.Sorting.quickSort(cant)(CanOrder)
+    assert( test(6) == 1 )
+    assert( (test,cant).zipped.forall(_ == _.i) )
+  }
+}


### PR DESCRIPTION
== instead of equiv (from Ordering) was used by mistake.  No tests; this is unlikely to revert.  (The problem with using == when one means equiv is likely to arise in other contexts, however.)
