### PR TITLE
Resolves SI-6364, O(n) performance of wrapped set contains.

### DIFF
--- a/src/library/scala/collection/convert/Wrappers.scala
+++ b/src/library/scala/collection/convert/Wrappers.scala
@@ -102,8 +102,14 @@ private[collection] trait Wrappers {
     override def clone(): JListWrapper[A] = JListWrapper(new ju.ArrayList[A](underlying))
   }
 
+  // Note various overrides to avoid performance gotchas.
   class SetWrapper[A](underlying: Set[A]) extends ju.AbstractSet[A] {
     self =>
+    override def contains(o: Object): Boolean = {
+      try { underlying.contains(o.asInstanceOf[A]) }
+      catch { case cce: ClassCastException => false }
+    }
+    override def isEmpty = underlying.isEmpty
     def size = underlying.size
     def iterator = new ju.Iterator[A] {
       val ui = underlying.iterator


### PR DESCRIPTION
Added overrides for contains and isEmpty to SetWrapper.  Note that sets are
invariant in Scala, while the Java signature is for any Object, so we trap
a ClassCastException if one occurs.  (Is this everything that could possibly
go wrong?  I think so, but am not as confident as I would like.)
