### PR TITLE
Added .ant-targets-build.xml to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@
 /out/
 /bin/
 /sandbox/
+/.ant-targets-build.xml
 
 # eclipse, intellij
 /.classpath


### PR DESCRIPTION
Something generates this repo-dirtying file during ant replacestarr.
