### PR TITLE
(2.10.x) codifies the state of the art wrt SI-8104

### DIFF
--- a/test/files/neg/t8104a.check
+++ b/test/files/neg/t8104a.check
@@ -1,0 +1,4 @@
+Test_2.scala:19: error: could not find implicit value for parameter e: Generic.Aux[Test.C,(Int, Int)]
+  implicitly[Generic.Aux[C, (Int, Int)]]
+            ^
+one error found

--- a/test/files/neg/t8104a/Macros_1.scala
+++ b/test/files/neg/t8104a/Macros_1.scala
@@ -1,0 +1,23 @@
+import scala.reflect.macros.Context
+
+object Macros {
+  def impl[T](c: Context)(implicit T: c.WeakTypeTag[T]) = {
+    import c.universe._
+    import Flag._
+    import definitions._
+    val fields = T.tpe.declarations.toList.collect{ case x: TermSymbol if x.isVal && x.isCaseAccessor => x }
+    val Repr = appliedType(TupleClass(fields.length).asType.toType, fields.map(_.typeSignature))
+    c.Expr(Block(
+      List(ClassDef(
+        Modifiers(FINAL),
+        newTypeName("$anon"),
+        List(),
+        Template(
+          List(AppliedTypeTree(Ident(newTypeName("Generic")), List(TypeTree(T.tpe)))),
+          emptyValDef,
+          List(
+            DefDef(Modifiers(), nme.CONSTRUCTOR, List(), List(List()), TypeTree(), Block(List(Apply(Select(Super(This(tpnme.EMPTY), tpnme.EMPTY), nme.CONSTRUCTOR), List())), Literal(Constant(())))),
+            TypeDef(Modifiers(), newTypeName("Repr"), List(), TypeTree(Repr)))))),
+      Apply(Select(New(Ident(newTypeName("$anon"))), nme.CONSTRUCTOR), List())))
+  }
+}

--- a/test/files/neg/t8104a/Test_2.scala
+++ b/test/files/neg/t8104a/Test_2.scala
@@ -1,0 +1,20 @@
+trait Generic[T] { type Repr }
+object Generic {
+  type Aux[T, Repr0] = Generic[T] { type Repr = Repr0 }
+  import scala.language.experimental.macros
+  implicit def materializeGeneric[T]: Generic[T] = macro Macros.impl[T]
+}
+
+object Test extends App {
+  case class C(x: Int, y: Int)
+
+  def reprify[T, Repr](x: T)(implicit generic: Generic.Aux[T, Repr]) = ???
+  reprify(C(40, 2))
+
+  // this is a compilation error at the moment as explained in SI-8104
+  // because matchesPt in implicit search says that depoly(<type of materializeGeneric>) isn't a subtype of Generic.Aux[C, (Int, Int)]
+  // which is rightfully so, because depoly only replaces type parameters, not type members with wildcard types
+  // however in the future we might want to relax the matchesPt check, so this might start compiling
+  // therefore, if you've broken this test, then you should be happy, because most likely you've just enabled an interesting use case!
+  implicitly[Generic.Aux[C, (Int, Int)]]
+}

--- a/test/files/neg/t8104b.check
+++ b/test/files/neg/t8104b.check
@@ -1,0 +1,4 @@
+Test_2.scala:16: error: could not find implicit value for parameter generic: Generic.Aux[Test.C,Repr]
+  reprify(C(40, 2))
+         ^
+one error found

--- a/test/files/neg/t8104b/Macros_1.scala
+++ b/test/files/neg/t8104b/Macros_1.scala
@@ -1,0 +1,23 @@
+import scala.reflect.macros.Context
+
+object Macros {
+  def impl[T](c: Context)(implicit T: c.WeakTypeTag[T]) = {
+    import c.universe._
+    import Flag._
+    import definitions._
+    val fields = T.tpe.declarations.toList.collect{ case x: TermSymbol if x.isVal && x.isCaseAccessor => x }
+    val Repr = appliedType(TupleClass(fields.length).asType.toType, fields.map(_.typeSignature))
+    c.Expr(Block(
+      List(ClassDef(
+        Modifiers(FINAL),
+        newTypeName("$anon"),
+        List(),
+        Template(
+          List(AppliedTypeTree(Ident(newTypeName("Generic")), List(TypeTree(T.tpe)))),
+          emptyValDef,
+          List(
+            DefDef(Modifiers(), nme.CONSTRUCTOR, List(), List(List()), TypeTree(), Block(List(Apply(Select(Super(This(tpnme.EMPTY), tpnme.EMPTY), nme.CONSTRUCTOR), List())), Literal(Constant(())))),
+            TypeDef(Modifiers(), newTypeName("Repr"), List(), TypeTree(Repr)))))),
+      Apply(Select(New(Ident(newTypeName("$anon"))), nme.CONSTRUCTOR), List())))
+  }
+}

--- a/test/files/neg/t8104b/Test_2.scala
+++ b/test/files/neg/t8104b/Test_2.scala
@@ -1,0 +1,24 @@
+trait Generic[T] { type Repr }
+object Generic {
+  type Aux[T, Repr0] = Generic[T] { type Repr = Repr0 }
+  import scala.language.experimental.macros
+  implicit def materializeGeneric[T, Repr]: Generic.Aux[T, Repr] = macro Macros.impl[T]
+}
+
+object Test extends App {
+  case class C(x: Int, y: Int)
+
+  // this doesn't work because of SI-7470
+  // well, in fact SI-7470 has been fixed: https://github.com/scala/scala/pull/2499
+  // it's just that the fix hasn't been backported to 2.10.x
+  // if you've made this compile, consider taking a look at the aforementioned pull request
+  def reprify[T, Repr](x: T)(implicit generic: Generic.Aux[T, Repr]) = ???
+  reprify(C(40, 2))
+
+  // this is a compilation error at the moment as explained in SI-8104
+  // because matchesPt in implicit search says that depoly(<type of materializeGeneric>) isn't a subtype of Generic.Aux[C, (Int, Int)]
+  // which is rightfully so, because depoly only replaces type parameters, not type members with wildcard types
+  // however in the future we might want to relax the matchesPt check, so this might start compiling
+  // therefore, if you've broken this test, then you should be happy, because most likely you've just enabled an interesting use case!
+  implicitly[Generic.Aux[C, (Int, Int)]]
+}


### PR DESCRIPTION
As it was discovered in SI-8104, whiteboxity doesn’t apply equally to
type parameters and type members of materialized type classes.

During implicit search and subsequent type inference, whitebox type parameters
are consistently erased to wildcards, whereas whitebox type members sometimes
remain as is and get in the way of signature conformance checks.

Unfortunately, 2.10.x can’t make use of type parameter whiteboxity, because
it requires fundep materializers that were only merged into 2.11:
https://github.com/scala/scala/pull/2499, and therefore Si-8104 seems to be
a hard blocker for 2.10.x at the moment. Stay tuned for updates.
