### PR TITLE
makes well-known packages and package classes consistent with each other

### DIFF
--- a/src/reflect/scala/reflect/internal/Mirrors.scala
+++ b/src/reflect/scala/reflect/internal/Mirrors.scala
@@ -281,7 +281,6 @@ trait Mirrors extends api.Mirrors {
 
     class RootPackage extends ModuleSymbol(rootOwner, NoPosition, nme.ROOTPKG) with RootSymbol {
       this setInfo NullaryMethodType(RootClass.tpe)
-      RootClass.sourceModule = this
 
       override def isRootPackage = true
     }
@@ -296,6 +295,7 @@ trait Mirrors extends api.Mirrors {
       override def isRoot            = true
       override def isEffectiveRoot   = true
       override def isNestedClass     = false
+      override def sourceModule      = RootPackage
     }
 
     // This is <root>, the actual root of everything except the package _root_.
@@ -316,6 +316,7 @@ trait Mirrors extends api.Mirrors {
     class EmptyPackageClass extends PackageClassSymbol(RootClass, NoPosition, tpnme.EMPTY_PACKAGE_NAME) with WellKnownSymbol {
       override def isEffectiveRoot     = true
       override def isEmptyPackageClass = true
+      override def sourceModule        = EmptyPackage
     }
 
     lazy val EmptyPackageClass = new EmptyPackageClass

--- a/test/junit/scala/reflect/internal/MirrorsTest.scala
+++ b/test/junit/scala/reflect/internal/MirrorsTest.scala
@@ -1,0 +1,18 @@
+package scala.reflect.internal
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class MirrorsTest {
+  @Test def rootCompanionsAreConnected(): Unit = {
+    val cm = scala.reflect.runtime.currentMirror
+    import cm._
+    assertEquals("RootPackage.moduleClass == RootClass", RootClass, RootPackage.moduleClass)
+    assertEquals("RootClass.module == RootPackage", RootPackage, RootClass.module)
+    assertEquals("EmptyPackage.moduleClass == EmptyPackageClass", EmptyPackageClass, EmptyPackage.moduleClass)
+    assertEquals("EmptyPackageClass.module == EmptyPackage", EmptyPackage, EmptyPackageClass.module)
+  }
+}


### PR DESCRIPTION
As discovered in https://groups.google.com/forum/#!topic/scala-user/RckXE90LoXo,
RootClass.sourceModule and EmptyPackageClass.sourceModule used to incorrectly
return NoSymbol instead of RootModule and EmptyPackage. This is now fixed.
