### PR TITLE
Implements specialized subsetOf for HashSet

### DIFF
--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -237,6 +237,42 @@ object HashSet extends ImmutableSetFactory[HashSet] {
 
   }
 
+  /**
+   * A branch node of the HashTrieSet with at least one and up to 32 children.
+   *
+   * @param bitmap encodes which element corresponds to which child
+   * @param elems the up to 32 children of this node.
+   *              the number of children must be identical to the number of 1 bits in bitmap
+   * @param size0 the total number of elements. This is stored just for performance reasons.
+   * @tparam A      the type of the elements contained in this hash set.
+   *
+   * How levels work:
+   *
+   * When looking up or adding elements, the part of the hashcode that is used to address the children array depends
+   * on how deep we are in the tree. This is accomplished by having a level parameter in all internal methods
+   * that starts at 0 and increases by 5 (32 = 2^5) every time we go deeper into the tree.
+   *
+   * hashcode (binary): 00000000000000000000000000000000
+   * level=0 (depth=0)                             ^^^^^
+   * level=5 (depth=1)                        ^^^^^
+   * level=10 (depth=2)                  ^^^^^
+   * ...
+   *
+   * Be careful: a non-toplevel HashTrieSet is not a self-contained set, so e.g. calling contains on it will not work!
+   * It relies on its depth in the Trie for which part of a hash to use to address the children, but this information
+   * (the level) is not stored due to storage efficiency reasons but has to be passed explicitly!
+   *
+   * How bitmap and elems correspond:
+   *
+   * A naive implementation of a HashTrieSet would always have an array of size 32 for children and leave the unused
+   * children empty (null). But that would be very wasteful regarding memory. Instead, only non-empty children are
+   * stored in elems, and the bitmap is used to encode which elem corresponds to which child bucket. The lowest 1 bit
+   * corresponds to the first element, the second-lowest to the second, etc.
+   *
+   * bitmap (binary): 00010000000000000000100000000000
+   * elems: [a,b]
+   * children:        ---b----------------a-----------
+   */
   class HashTrieSet[A](private val bitmap: Int, private[collection] val elems: Array[HashSet[A]], private val size0: Int)
         extends HashSet[A] {
     assert(Integer.bitCount(bitmap) == elems.length)

--- a/test/files/run/t7326.scala
+++ b/test/files/run/t7326.scala
@@ -1,0 +1,64 @@
+import scala.collection.immutable.ListSet
+import scala.collection.immutable.HashSet
+
+object Test extends App {
+
+  def testCorrectness() {
+    // a key that has many hashCode collisions
+    case class Collision(i: Int) { override def hashCode = i / 5 }
+
+    def subsetTest[T](emptyA:Set[T], emptyB:Set[T], mkKey:Int => T, n:Int) {
+      val outside = mkKey(n + 1)
+      for(i <- 0 to n) {
+        val a = emptyA ++ (0 until i).map(mkKey)
+        // every set must be a subset of itself
+        require(a.subsetOf(a), "A set must be the subset of itself")
+        for(k <- 0 to i) {
+          // k <= i, so b is definitely a subset
+          val b = emptyB ++ (0 until k).map(mkKey)
+          // c has less elements than a, but contains a value that is not in a
+          // so it is not a subset, but that is not immediately obvious due to size
+          val c = b + outside
+          require(b.subsetOf(a), s"$b must be a subset of $a")
+          require(!c.subsetOf(a), s"$c must not be a subset of $a")
+        }
+      }
+    }
+
+    // test the HashSet/HashSet case
+    subsetTest(HashSet.empty[Int], HashSet.empty[Int], identity, 100)
+
+    // test the HashSet/other set case
+    subsetTest(HashSet.empty[Int], ListSet.empty[Int], identity, 100)
+
+    // test the HashSet/HashSet case for Collision keys
+    subsetTest(HashSet.empty[Collision], HashSet.empty[Collision], Collision, 100)
+
+    // test the HashSet/other set case for Collision keys
+    subsetTest(HashSet.empty[Collision], ListSet.empty[Collision], Collision, 100)
+  }
+
+  /**
+   * A main performance benefit of the new subsetOf is that we do not have to call hashCode during subsetOf
+   * since we already have the hash codes in the HashSet1 nodes.
+   */
+  def testNoHashCodeInvocationsDuringSubsetOf() = {
+    var count = 0
+
+    case class HashCodeCounter(i:Int) {
+      override def hashCode = {
+        count += 1
+        i
+      }
+    }
+
+    val a = HashSet.empty ++ (0 until 100).map(HashCodeCounter)
+    val b = HashSet.empty ++ (0 until 50).map(HashCodeCounter)
+    val count0 = count
+    val result = b.subsetOf(a)
+    require(count == count0, "key.hashCode must not be called during subsetOf of two HashSets")
+    result
+  }
+  testCorrectness()
+  testNoHashCodeInvocationsDuringSubsetOf()
+}


### PR DESCRIPTION
Fixes SI-7326. This also adds a basic test for subsetOf that was missing before.

Review by @Ichoran, @soc

@Ichoran: feel free to integrate the subsetOf test into your collection comparison test suite and remove the testCorrectness part of t7326.scala
