### PR TITLE
Removes TODO comments that are no longer applicable

### DIFF
--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -59,7 +59,6 @@ class HashMap[A, +B] extends AbstractMap[A, B]
 
   override def + [B1 >: B] (elem1: (A, B1), elem2: (A, B1), elems: (A, B1) *): HashMap[A, B1] =
     this + elem1 + elem2 ++ elems
-    // TODO: optimize (might be able to use mutable updates)
 
   def - (key: A): HashMap[A, B] =
     removed0(key, computeHash(key), 0)
@@ -168,8 +167,6 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
     }
   }
 
-  // TODO: add HashMap2, HashMap3, ...
-
   class HashMap1[A,+B](private[collection] val key: A, private[collection] val hash: Int, private[collection] val value: (B @uV), private[collection] var kv: (A,B @uV)) extends HashMap[A,B] {
     override def size = 1
 
@@ -277,7 +274,6 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
         elems(index & 0x1f).get0(key, hash, level + 5)
       } else if ((bitmap & mask) != 0) {
         val offset = Integer.bitCount(bitmap & (mask-1))
-        // TODO: might be worth checking if sub is HashTrieMap (-> monomorphic call site)
         elems(offset).get0(key, hash, level + 5)
       } else
         None
@@ -289,7 +285,6 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
       val offset = Integer.bitCount(bitmap & (mask-1))
       if ((bitmap & mask) != 0) {
         val sub = elems(offset)
-        // TODO: might be worth checking if sub is HashTrieMap (-> monomorphic call site)
         val subNew = sub.updated0(key, hash, level + 5, value, kv, merger)
         if(subNew eq sub) this else {
           val elemsNew = new Array[HashMap[A,B1]](elems.length)
@@ -312,7 +307,6 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
       val offset = Integer.bitCount(bitmap & (mask-1))
       if ((bitmap & mask) != 0) {
         val sub = elems(offset)
-        // TODO: might be worth checking if sub is HashTrieMap (-> monomorphic call site)
         val subNew = sub.removed0(key, hash, level + 5)
         if (subNew eq sub) this
         else if (subNew.isEmpty) {

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -58,7 +58,6 @@ class HashSet[A] extends AbstractSet[A]
 
   override def + (elem1: A, elem2: A, elems: A*): HashSet[A] =
     this + elem1 + elem2 ++ elems
-    // TODO: optimize (might be able to use mutable updates)
 
   def - (e: A): HashSet[A] =
     removed0(e, computeHash(e), 0)
@@ -127,8 +126,6 @@ object HashSet extends ImmutableSetFactory[HashSet] {
       new HashTrieSet[A](bitmap, elems, child.size)
     }
   }
-
-  // TODO: add HashSet2, HashSet3, ...
 
   class HashSet1[A](private[HashSet] val key: A, private[HashSet] val hash: Int) extends HashSet[A] {
     override def size = 1
@@ -212,7 +209,6 @@ object HashSet extends ImmutableSetFactory[HashSet] {
         elems(index & 0x1f).get0(key, hash, level + 5)
       } else if ((bitmap & mask) != 0) {
         val offset = Integer.bitCount(bitmap & (mask-1))
-        // TODO: might be worth checking if sub is HashTrieSet (-> monomorphic call site)
         elems(offset).get0(key, hash, level + 5)
       } else
         false
@@ -223,7 +219,6 @@ object HashSet extends ImmutableSetFactory[HashSet] {
       val mask = (1 << index)
       val offset = Integer.bitCount(bitmap & (mask-1))
       if ((bitmap & mask) != 0) {
-        // TODO: might be worth checking if sub is HashTrieSet (-> monomorphic call site)
         val sub = elems(offset)
         val subNew = sub.updated0(key, hash, level + 5)
         if (sub eq subNew) this
@@ -249,7 +244,6 @@ object HashSet extends ImmutableSetFactory[HashSet] {
       val offset = Integer.bitCount(bitmap & (mask-1))
       if ((bitmap & mask) != 0) {
         val sub = elems(offset)
-        // TODO: might be worth checking if sub is HashTrieMap (-> monomorphic call site)
         val subNew = sub.removed0(key, hash, level + 5)
         if (sub eq subNew) this
         else if (subNew.isEmpty) {


### PR DESCRIPTION
- we do not want to use mutable updates because that would mean making vals
  vars, losing various guarantees for final fields of the java memory model
- we do not want to add more subcasses of HashSet, because that would make
  callsites megamorphic. If anything, we should try to reduce the number of
  subclasses
- checking for monomorphic call site is not worth it for a single virtual
  method call.

Review by @Ichoran
