### PR TITLE
Fix SI-8102 (postfix abs for -0.0)

### DIFF
--- a/src/library/scala/math/Numeric.scala
+++ b/src/library/scala/math/Numeric.scala
@@ -127,6 +127,8 @@ object Numeric {
     def toLong(x: Float): Long = x.toLong
     def toFloat(x: Float): Float = x
     def toDouble(x: Float): Double = x.toDouble
+    // logic in Numeric base trait mishandles abs(-0.0f)
+    override def abs(x: Float): Float = math.abs(x)
   }
   trait FloatIsFractional extends FloatIsConflicted with Fractional[Float] {
     def div(x: Float, y: Float): Float = x / y
@@ -149,6 +151,8 @@ object Numeric {
     def toLong(x: Double): Long = x.toLong
     def toFloat(x: Double): Float = x.toFloat
     def toDouble(x: Double): Double = x
+    // logic in Numeric base trait mishandles abs(-0.0)
+    override def abs(x: Double): Double = math.abs(x)
   }
   trait DoubleIsFractional extends DoubleIsConflicted with Fractional[Double] {
     def div(x: Double, y: Double): Double = x / y

--- a/test/junit/scala/math/NumericTest.scala
+++ b/test/junit/scala/math/NumericTest.scala
@@ -1,0 +1,18 @@
+
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class NumericTest {
+
+  /* Test for SI-8102 */
+  @Test
+  def testAbs {
+    assertTrue(-0.0.abs equals 0.0)
+    assertTrue(-0.0f.abs equals 0.0f)
+  }
+}
+


### PR DESCRIPTION
SI-8102 points out that -0.0.abs returns -0.0 (in error). The same issue
exists for -0.0f. This commit fixes the issue for both by delegating to
math.abs.
