### PR TITLE
SI-8032 Provides an implicit macro for materialization of Liftable for case classes

### DIFF
--- a/src/reflect/scala/reflect/api/StandardLiftables.scala
+++ b/src/reflect/scala/reflect/api/StandardLiftables.scala
@@ -236,6 +236,13 @@ trait StandardLiftables { self: Universe =>
 object LiftableCaseClass {
   import scala.reflect.macros.WhiteboxContext
 
+  /* All the trees (except one that has a special comment) in this macro are hygienic
+   * (and there is a test to check that). That is, all TermNames used
+   * (specifically: Tree, Apply, Liftable, List, implicitly, reify) are fully qualified,
+   * and will not bind to terms with same names, declared in the expansion context.
+   * Each tree is commented with a simplified, unhygienic quasiquote, that explains
+   * what that tree is supposed to do.
+   */
   def impl[T: c.WeakTypeTag](c: WhiteboxContext): c.Tree = {
     import c.universe._
     val Select(prefix, _) = c.prefix.tree
@@ -252,37 +259,51 @@ object LiftableCaseClass {
       val typeSign = tpe.declaration(name).typeSignature
       name → typeSign
     }
+    /* Tree produced by the following quasiquote:
+     * q"reify(${c.mirror.staticModule(symbol.fullName)}).tree"
+     */
     val constructor = Select(Apply(
                                Select(prefix, TermName("reify")),
                                List(Ident(c.mirror.staticModule(symbol.fullName)))),
                         TermName("tree"))
+    val value = "value"
     val arguments = fields(T).map { case (name, typeSign) ⇒
-      // Tree produced by the following quasiquote:
-      // q"implicitly[Liftable[$typeSign]].apply(value.$name)"
+      /* Tree produced by the following quasiquote:
+       * q"implicitly[Liftable[$typeSign]].apply(value.$name)"
+       * Another way to do this would be:
+       * q"""
+       *   val v : $typeSign = value.$name
+       *   q"$$v"
+       * """
+       *
+       * This tree is not hygienic: TermName(value) will bind to value from
+       * enclosing context, which is the tree being returned from the macro.
+       * To ensure that its name does not change in one place, but stays
+       * unchanged in another, it is placed in a dedicated val.
+       */
       Apply(Select(
               TypeApply(Select(Ident(definitions.PredefModule), TermName("implicitly")),
                         List(AppliedTypeTree(Select(prefix, TypeName("Liftable")),
                              List(TypeTree(typeSign))))),
               TermName("apply")),
-           List(Select(Ident(TermName("value")), name)))
-      // Another way to do this would be:
-      /*q"""
-        val v : $typeSign = value.$name
-        q"$$v"
-       """*/
+           List(Select(Ident(TermName(value)), name)))
     }
+    /* Tree produced by the following quasiquote:
+     * q"Apply($constructor, List(..$arguments))"
+     */
     val reflect = Apply(Select(prefix, TermName("Apply")),
                         List(constructor,
                           Apply(Ident(definitions.ListModule),
-                        arguments))) // q"Apply($constructor, List(..$arguments))"
+                        arguments)))
     val implicitName = TermName(symbol.name.encoded ++ "Liftable")
-    // Tree produced by the following quasiquote:
-    /*q"""
-      implicit object $implicitName extends Liftable[$T] {
-        def apply(value: $T): Tree = $reflect
-      }
-      $implicitName
-    """*/
+    /* Tree produced by the following quasiquote:
+     * q"""
+     *   implicit object $implicitName extends Liftable[$T] {
+     *     def apply(value: $T): Tree = $reflect
+     *   }
+     *   $implicitName
+     * """
+     */
     import Flag._
     Block(List(ModuleDef(Modifiers(IMPLICIT),
                 implicitName,
@@ -301,7 +322,7 @@ object LiftableCaseClass {
                                TermName("apply"),
                                List(),
                                List(List(ValDef(Modifiers(PARAM),
-                                         TermName("value"), TypeTree(T), EmptyTree))),
+                                         TermName(value), TypeTree(T), EmptyTree))),
                                Select(prefix, TypeName("Tree")), reflect))))),
           Ident(implicitName))
   }

--- a/test/files/scalacheck/quasiquotes/LiftableCaseClassProps.scala
+++ b/test/files/scalacheck/quasiquotes/LiftableCaseClassProps.scala
@@ -14,6 +14,11 @@ package inside.a {
   case class Package(pkg: String)
 }
 
+package a {
+  case class B()
+}
+
+
 object LiftableCaseClassProps extends QuasiquoteProperties("liftable case class") {
   property("lift simple case class") = test {
     val simple = Simple("simple", 42)
@@ -41,5 +46,17 @@ object LiftableCaseClassProps extends QuasiquoteProperties("liftable case class"
     implicitly[Liftable[Mutually]]
     implicitly[Liftable[Rec]]
     assert(true)
+  }
+
+  property("hygiene") = test {
+    val a = ""
+    val b = _root_.a.B()
+    val reify = ""
+    val implicitly = ""
+    case class Liftable()
+    case class Tree()
+    case class Apply()
+    case class List()
+    assert(q"$b" ≈ scala.reflect.runtime.universe.Apply(Ident(TermName("B")), scala.List()))
   }
 }

--- a/test/files/scalacheck/quasiquotes/LiftableCaseClassProps.scala
+++ b/test/files/scalacheck/quasiquotes/LiftableCaseClassProps.scala
@@ -1,0 +1,45 @@
+import org.scalacheck._
+import scala.reflect.runtime.universe._
+
+case class Simple(s: String, i: Int)
+case class Nested(d: Double, s: String, simple: Simple)
+case class `Simple.With.Dot`(d: Double)
+
+case class Recursive(recursive: Recursive)
+
+case class Mutually(rec: Rec)
+case class Rec(mutually: Mutually)
+
+package inside.a {
+  case class Package(pkg: String)
+}
+
+object LiftableCaseClassProps extends QuasiquoteProperties("liftable case class") {
+  property("lift simple case class") = test {
+    val simple = Simple("simple", 42)
+    assert(q"$simple" ≈ Apply(Ident(TermName("Simple")), List(Literal(Constant("simple")), Literal(Constant(42)))))
+  }
+
+  property("lift nested case class") = test {
+    val simple = Simple("simple", 42)
+    val nested = Nested(2.0, "nested", simple)
+    assert(q"$nested" ≈ Apply(Ident(TermName("Nested")), List(Literal(Constant(2.0)), Literal(Constant("nested")), Apply(Ident(TermName("Simple")), List(Literal(Constant("simple")), Literal(Constant(42)))))))
+  }
+
+  property("lift case class with dots in name") = test {
+    val dotted = `Simple.With.Dot`(3.0)
+    assert(q"$dotted" ≈ Apply(Ident(TermName("Simple$u002EWith$u002EDot")), List(Literal(Constant(3.0)))))
+  }
+
+  property("lift case class inside a package") = test {
+    val packaged = inside.a.Package("package")
+    assert(q"$packaged" ≈ Apply(Ident(TermName("Package")), List(Literal(Constant("package")))))
+  }
+
+  property("materialize liftable instances for recursive and mutually recursive case classes") = test {
+    implicitly[Liftable[Recursive]]
+    implicitly[Liftable[Mutually]]
+    implicitly[Liftable[Rec]]
+    assert(true)
+  }
+}

--- a/test/files/scalacheck/quasiquotes/Test.scala
+++ b/test/files/scalacheck/quasiquotes/Test.scala
@@ -8,6 +8,7 @@ object Test extends Properties("quasiquotes") {
   include(PatternConstructionProps)
   include(PatternDeconstructionProps)
   include(LiftableProps)
+  include(LiftableCaseClassProps)
   include(UnliftableProps)
   include(ErrorProps)
   include(RuntimeErrorProps)


### PR DESCRIPTION
Now case classes can be used in quasiquotes.

``` scala
Welcome to Scala version 2.11.0-20140105-195053-c1b3d94af9 (OpenJDK 64-Bit Server VM, Java 1.7.0_45).
Type in expressions to have them evaluated.
Type :help for more information.

scala> import scala.reflect.runtime.{universe => u}
import scala.reflect.runtime.{universe=>u}

scala> import u._
import u._

scala> case class Test(str: String, i: Int, lst: List[Double])
defined class Test

scala> val test = Test("test", 1, List(2.0, 3.5))
test: Test = Test(test,1,List(2.0, 3.5))

scala> showRaw(q"$test")
res0: String = Apply(Select(Select(Select(Select(Select(Ident($line8.$read), TermName("$iw")), TermName("$iw")), TermName("$iw")), TermName("$iw")), TermName("Test")), List(Literal(Constant("test")), Literal(Constant(1)), Apply(Select(Select(Select(Ident(scala), TermName("collection")), TermName("immutable")), TermName("List")), List(Literal(Constant(2.0)), Literal(Constant(3.5))))))

scala> val cm = runtimeMirror(getClass.getClassLoader)
cm: reflect.runtime.universe.Mirror = JavaMirror with scala.tools.nsc.interpreter.IMain$TranslatingClassLoader@74a2ccbd of type class scala.tools.nsc.interpreter.IMain$TranslatingClassLoader with classpath [(memory)] and parent being scala.reflect.internal.util.ScalaClassLoader$URLClassLoader@6c2fc81d of type class scala.reflect.internal.util.ScalaClassLoader$URLClassLoader with classpath [file:/usr/lib/jvm/java-7-openjdk/jre/lib/resources.jar,file:/usr/lib/jvm/java-7-openjdk/jre/lib/rt.jar,file:/usr/lib/jvm/java-7-openjdk/jre/lib/jsse.jar,file:/usr/lib/jvm/java-7-openjdk/jre/lib/jce.jar,file:/usr/lib/jvm/java-7-openjdk/jre/lib/charsets.jar,file:/usr/lib/jvm/java-7-openjdk/jre/lib/rhino.jar,file:/home/folone/workspace/scala/build/quick/classes/library/,file:/home/folone/workspace/scala/...
scala> import scala.tools.reflect.ToolBox
import scala.tools.reflect.ToolBox

scala> val tb = cm.mkToolBox()
tb: scala.tools.reflect.ToolBox[reflect.runtime.universe.type] = scala.tools.reflect.ToolBoxFactory$ToolBoxImpl@e01afa1

scala> tb.eval(q"$test")
res1: Any = Test(test,1,List(2.0, 3.5))

scala> .asInstanceOf[Test]
res2: Test = Test(test,1,List(2.0, 3.5))
```

Review by @xeno-by, @densh, and @retronym please.
