### PR TITLE
SI-8120 Avoid tree sharing when typechecking patmat anon functions

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4250,7 +4250,11 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               }
             val ids = for (p <- params) yield Ident(p.name)
             val selector1 = atPos(tree.pos.focusStart) { if (arity == 1) ids.head else gen.mkTuple(ids) }
-            val body = treeCopy.Match(tree, selector1, cases)
+            // SI-8120 If we don't duplicate the cases, the original Match node will share trees with ones that
+            //         receive symbols owned by this function. However if, after a silent mode session, we discard
+            //         this Function and try a different approach (e.g. applying a view to the reciever) we end up
+            //         with orphaned symbols which blows up far down the pipeline (or can be detected with -Ycheck:typer).
+            val body = treeCopy.Match(tree, selector1, (cases map duplicateAndKeepPositions).asInstanceOf[List[CaseDef]])
             typed1(atPos(tree.pos) { Function(params, body) }, mode, pt)
           }
         } else

--- a/test/files/pos/t8120.scala
+++ b/test/files/pos/t8120.scala
@@ -1,0 +1,9 @@
+object A {
+  class C {
+    def m(a: Nothing): Int = 0
+  }
+  implicit class RichAny(a: Any) {
+    def m(a: Any): Int = 0
+  }
+  (new C).m({ case (x, y) => x } : Any => Any)
+}


### PR DESCRIPTION
When typechecking an empty selector `Match` corresponding to:

```
{ case ... => ... }: (A => B)
```

We wrap it in a `Function` and typecheck:

```
(x$1 => x$1 match { case ... => ... })
```

Local symbols in this expression (representing values bound by
the pattern, or just definitions in the body or guard) are then
owned by the anonymous function's symbol.

However, if we ever discard this `Function` and start anew with
the empty selector match, as happens during the fallback to
use a view on the receiver in `tryTypedApply`, we found that we
had mutated the cases of the original tree, and allowed orphaned
local symbols to escape into the compiler pipeline.

This commit uses duplicated trees for the the cases in the synthetic
`Match` to avoid this problem.

Review by @adriaanm @xeno-by
