### PR TITLE
SI-7859 fix AnyVal.scala scaladoc.

### DIFF
--- a/src/library/scala/AnyVal.scala
+++ b/src/library/scala/AnyVal.scala
@@ -33,7 +33,7 @@ package scala
  *
  * User-defined value classes which avoid object allocation...
  *
- *   - must have a single, public `val` parameter that is the underlying runtime representation.
+ *   - must have a single `val` parameter that is the underlying runtime representation.
  *   - can define `def`s, but no `val`s, `var`s, or nested `traits`s, `class`es or `object`s.
  *   - typically extend no other trait apart from `AnyVal`.
  *   - cannot be used in type tests or pattern matching.


### PR DESCRIPTION
Value class member need not be public in 2.11+
