### PR TITLE
SI-8107 Add Regex.quoted

### DIFF
--- a/test/junit/scala/util/matching/t8107.scala
+++ b/test/junit/scala/util/matching/t8107.scala
@@ -1,0 +1,47 @@
+
+package scala.util.matching
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class QuotedRegexTest {
+  import PartialFunction.cond
+
+  def aver[A](x: A)(pf: PartialFunction[A, Boolean]): Unit = assertTrue(cond(x)(pf))
+  def deny[A](x: A)(pf: PartialFunction[A, Boolean]): Unit = assertFalse(cond(x)(pf))
+
+  @Test def t8107_quoted(): Unit = {
+    val r = "a*c".r.quoted
+    deny("abc") { case r() => true }
+    aver("a*c") { case r() => true }
+    val u = "a*b".r.quoted.unanchored
+    aver("aaa*bbb") { case u() => true }
+    val v = "a*b".r.quoted.unanchored.unanchored
+    aver("aaa*bbb") { case v() => true }
+    val q = "a*b".r.unanchored.quoted
+    aver("aaa*bbb") { case q() => true }
+    val z = "a*c".r.quoted.quoted
+    aver("a*c") { case z() => true }
+    val y = "a*b".r.unanchored.quoted.quoted
+    aver("aaa*bbb") { case y() => true }
+  }
+
+  @Test def anchorage(): Unit = {
+    val v = "a*b".r.quoted.unanchored.anchored
+    aver("a*b") { case v() => true }
+    deny("aaa*bbb") { case v() => true }
+  }
+
+  /** Pattern is compiled lazily.
+   *
+   *  Pattern compile "[]" throws.
+   */
+  @Test def t8107_lazily(): Unit = {
+    val q = "[]".r.quoted
+    val r = s"Array$q".r
+    aver("Array[]") { case r() => true }
+  }
+}


### PR DESCRIPTION
Add `quoted` as an instance method of Regex.

Change `pattern` to a lazy val to defer compilation.

This makes the regex string the primary representation,
reverting a previous change that preferred the compiled
pattern.

This is complementary to https://github.com/scala/scala/pull/3317.
