### PR TITLE
[nomaster] SI-8114 Binary compat. workaround for erasure bug SI-7120

### DIFF
--- a/test/files/run/t8114.scala
+++ b/test/files/run/t8114.scala
@@ -1,0 +1,15 @@
+class AbstractTable[T] { type TableElementType }
+class Table[T] extends AbstractTable[T] { type TableElementType = T }
+ 
+class Query[E, U]
+class TableQuery[E <: AbstractTable[_]] extends Query[E, E#TableElementType]
+ 
+object Test extends App {
+  object MyTable extends TableQuery[Table[Long]]
+ 
+  def list[R](q: Query[_, R]): List[R] = Nil
+  list/*[Long]*/(MyTable) collect { case x => x }
+
+  // Generates a redundant bridge method (double definition error)
+  // in 2.10.x due to (at least) the bug in erasure fixed in SI-7120
+}


### PR DESCRIPTION
We can't backport SI-7120 to 2.10.x as it changes erased signatures,
which can lead to interop problems between 2.10.3 and 2.10.4.

But, we can detect one of the nasty symptoms -- a bridge method
with the same signature as its target -- and treat that.

This commit detects duplicate bridges in the ASM (only) backend
and removes them.

Review by @adriaanm @magarcia
