### PR TITLE
SI-8129 Plug a leak in perRunCaches

### DIFF
--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -344,16 +344,18 @@ abstract class SymbolTable extends macros.Universe
 
     // Weak references so the garbage collector will take care of
     // letting us know when a cache is really out of commission.
-    private val caches = WeakHashSet[Clearable]()
+    import java.lang.ref.WeakReference
+    private var caches = List[WeakReference[Clearable]]()
 
     def recordCache[T <: Clearable](cache: T): T = {
-      caches += cache
+      caches ::= new WeakReference(cache)
       cache
     }
 
     def clearAll() = {
       debuglog("Clearing " + caches.size + " caches.")
-      caches foreach (_.clear)
+      caches foreach (ref => Option(ref.get).foreach(_.clear))
+      caches = caches.filterNot(_.get == null)
     }
 
     def newWeakMap[K, V]()        = recordCache(mutable.WeakHashMap[K, V]())
@@ -364,9 +366,9 @@ abstract class SymbolTable extends macros.Universe
       val NoCached: T = null.asInstanceOf[T]
       var cached: T = NoCached
       var cachedRunId = NoRunId
-      caches += new Clearable {
+      recordCache(new Clearable {
         def clear(): Unit = cached = NoCached
-      }
+      })
       () => {
         if (currentRunId != cachedRunId || cached == NoCached) {
           cached = f


### PR DESCRIPTION
I guess we've never leaned to heavily on these, because the
registry of caches was forgetting about most of them
immediately if they compared == at the point of creation.

Consequently, maps like `treatedInfos` in Mixin were holding
onto old types and symbols and leaking memory.

You can reproduce the leak with:

```
(for i in {1..200}; do echo src/library/scala/collection/*.scala; done; printf "\n") | scalac-hash v2.11.0-M7 -J-Xmx256M -Xresident

nsc> warning: there were 6 deprecation warning(s); re-run with -deprecation for details

(... 15 times)

nsc> java.lang.OutOfMemoryError: GC overhead limit exceeded
Dumping heap to java_pid90362.hprof ...
Heap dump file created [340635728 bytes in 7.993 secs]
^CException in thread "main" java.lang.OutOfMemoryError: GC overhead limit exceeded
```

Review by @gkossakowski
