### PR TITLE
fixes run/macroPlugins-namerHooks.scala

### DIFF
--- a/test/files/run/macroPlugins-namerHooks.scala
+++ b/test/files/run/macroPlugins-namerHooks.scala
@@ -14,19 +14,20 @@ object Test extends DirectTest {
     import analyzer._
 
     val output = collection.mutable.ListBuffer[String]()
+    def log(what: String) = output += what.replace(String.format("%n"), " ")
 
     object macroPlugin extends MacroPlugin {
       override def pluginsEnterSym(namer: Namer, tree: Tree): Boolean = {
-        output += s"enterSym(${tree.toString.replace('\n', ' ')})"
+        log(s"enterSym($tree)")
         namer.standardEnterSym(tree)
         true
       }
       override def pluginsEnsureCompanionObject(namer: Namer, cdef: ClassDef, creator: ClassDef => Tree = companionModuleDef(_)): Option[Symbol] = {
-        output += s"ensureCompanionObject(${cdef.toString.replace('\n', ' ')}, ...)"
+        log(s"ensureCompanionObject($cdef, ...)")
         Some(namer.standardEnsureCompanionObject(cdef, creator))
       }
       override def pluginsEnterStats(typer: Typer, stats: List[Tree]): List[Tree] = {
-        stats.foreach(stat => output += s"enterStat(${stat.toString.replace('\n', ' ')})")
+        stats.foreach(stat => log(s"enterStat($stat)"))
         stats
       }
     }


### PR DESCRIPTION
Makes run/macroPlugins-namerHooks.scala work equally well on both
Unix and Windows machines.
