### PR TITLE
SI-8124 Scaladoc package object members

### DIFF
--- a/src/scaladoc/scala/tools/nsc/ScalaDoc.scala
+++ b/src/scaladoc/scala/tools/nsc/ScalaDoc.scala
@@ -66,6 +66,11 @@ object ScalaDoc extends ScalaDoc {
     )
   }
 
+  /** System properties for turning on debug. */
+  trait DebugSettings {
+    def isDebugPruning = sys.BooleanProp keyExists "scala.doc.debug.pruning"
+  }
+
   def main(args: Array[String]): Unit = sys exit {
     if (process(args)) 0 else 1
   }

--- a/src/scaladoc/scala/tools/nsc/doc/ScaladocAnalyzer.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/ScaladocAnalyzer.scala
@@ -16,7 +16,18 @@ trait ScaladocAnalyzer extends Analyzer {
   val global : Global // generally, a ScaladocGlobal
   import global._
 
+  override def newNamer(context: Context): ScaladocNamer = new Namer(context) with ScaladocNamer
+
   override def newTyper(context: Context): ScaladocTyper = new Typer(context) with ScaladocTyper
+
+  val namedPackages = collection.mutable.Set[Symbol]()
+
+  trait ScaladocNamer extends Namer {
+    override def enterPackage(tree: PackageDef) = {
+      super.enterPackage(tree)
+      namedPackages += tree.symbol
+    }
+  }
 
   trait ScaladocTyper extends Typer {
     private def unit = context.unit

--- a/src/scaladoc/scala/tools/nsc/doc/html/HtmlPage.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/HtmlPage.scala
@@ -188,14 +188,10 @@ abstract class HtmlPage extends Page { thisPage =>
 
   /** Returns the HTML code that represents the template in `tpl` as a hyperlinked name. */
   def templateToHtml(tpl: TemplateEntity, name: String = null) = tpl match {
-    case dTpl: DocTemplateEntity =>
-      if (hasPage(dTpl)) {
-        <a href={ relativeLinkTo(dTpl) } class="extype" name={ dTpl.qualifiedName }>{ if (name eq null) dTpl.name else name }</a>
-      } else {
-        scala.xml.Text(if (name eq null) dTpl.name else name)
-      }
-    case ndTpl: NoDocTemplate =>
-      scala.xml.Text(if (name eq null) ndTpl.name else name)
+    case dTpl: DocTemplateEntity if hasPage(dTpl) =>
+      <a href={ relativeLinkTo(dTpl) } class="extype" name={ dTpl.qualifiedName }>{ if (name eq null) dTpl.name else name }</a>
+    case dTpl: DocTemplateEntity => scala.xml.Text(if (name eq null) dTpl.name else name)
+    case ndTpl: NoDocTemplate    => scala.xml.Text(if (name eq null) ndTpl.name else name)
   }
 
   /** Returns the HTML code that represents the templates in `tpls` as a list of hyperlinked names. */

--- a/src/scaladoc/scala/tools/nsc/doc/package.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/package.scala
@@ -1,0 +1,5 @@
+
+package scala.tools.nsc
+package object doc extends ScalaDoc.DebugSettings {
+  //
+}

--- a/src/scaladoc/scala/tools/partest/ScaladocModelTest.scala
+++ b/src/scaladoc/scala/tools/partest/ScaladocModelTest.scala
@@ -69,7 +69,7 @@ abstract class ScaladocModelTest extends DirectTest {
       val universe = model.getOrElse({sys.error("Scaladoc Model Test ERROR: No universe generated!")})
       // 2 - check the model generated
       testModel(universe.rootPackage)
-      println("Done.")
+      done()
     } catch {
       case e: Exception =>
         println(e)
@@ -77,6 +77,9 @@ abstract class ScaladocModelTest extends DirectTest {
     }
     // set err back to the real err handler
     System.setErr(prevErr)
+  }
+  protected def done(): Unit = {
+    println("Done.")
   }
 
   private[this] var settings: doc.Settings = null

--- a/test/files/presentation/memory-leaks/MemoryLeaksTest.scala
+++ b/test/files/presentation/memory-leaks/MemoryLeaksTest.scala
@@ -29,6 +29,8 @@ object Test extends InteractiveTest {
   import interactive.Global
   trait InteractiveScaladocAnalyzer extends interactive.InteractiveAnalyzer with doc.ScaladocAnalyzer {
     val global : Global
+    override def newNamer(context: Context) = new Namer(context) with InteractiveNamer with ScaladocNamer
+
     override def newTyper(context: Context) = new Typer(context) with InteractiveTyper with ScaladocTyper {
       override def canAdaptConstantTypeToLiteral = false
     }

--- a/test/scaladoc/run/t8124.scala
+++ b/test/scaladoc/run/t8124.scala
@@ -1,0 +1,29 @@
+import scala.tools.nsc.doc.model._
+import scala.tools.nsc.doc.model.diagram._
+import scala.tools.partest.ScaladocModelTest
+
+object Test extends ScaladocModelTest {
+
+  def comment = "Do an amazing feat of computation."
+
+  override def code = s"""
+    //package funcs { object `package` { }}  // also fails
+    package object funcs {
+      /** $comment */
+      def f(): Int = ???
+    }
+    //package funcs { class Foo }            // ok this way
+  """
+
+  def scaladocSettings = ""
+
+  def testModel(rootPackage: Package) = {
+    import access._
+
+    val f = rootPackage._package("funcs")._method("f")
+    assert(f.resultType.name == "Int", s"${f.resultType.name} == Int")
+    assert(extractCommentText(f.comment.get) contains comment, "Bad comment")
+  }
+
+  override protected def done(): Unit = ()
+}

--- a/test/scaladoc/scalacheck/CommentFactoryTest.scala
+++ b/test/scaladoc/scalacheck/CommentFactoryTest.scala
@@ -1,20 +1,24 @@
+
+object Test extends org.scalacheck.Properties("CommentFactory") with scala.tools.nsc.doc.Test
+
+package scala.tools.nsc.doc {
+
 import org.scalacheck._
 import org.scalacheck.Prop._
 
 import scala.tools.nsc.Global
-import scala.tools.nsc.doc
 import scala.tools.nsc.doc.base.comment._
 import scala.tools.nsc.doc.model._
 import scala.tools.nsc.doc.model.diagram._
 
-class Factory(val g: Global, val s: doc.Settings)
-  extends doc.model.ModelFactory(g, s) {
+class Factory(val g: ScaladocGlobal, val s: Settings)
+  extends ModelFactory(g, s) {
   thisFactory: Factory
   with ModelFactoryImplicitSupport
   with ModelFactoryTypeSupport
   with DiagramFactory
   with CommentFactory
-  with doc.model.TreeFactory
+  with TreeFactory
   with MemberLookup =>
 
   def strip(c: Comment): Option[Inline] = {
@@ -31,17 +35,17 @@ class Factory(val g: Global, val s: doc.Settings)
     parse(s, "", scala.tools.nsc.util.NoPosition, null).body
 }
 
-object Test extends Properties("CommentFactory") {
+trait Test { _: Properties =>
   val factory = {
-    val settings = new doc.Settings((str: String) => {})
+    val settings = new Settings((str: String) => {})
     val reporter = new scala.tools.nsc.reporters.ConsoleReporter(settings)
-    val g = new Global(settings, reporter)
+    val g = new ScaladocGlobal(settings, reporter)
     (new Factory(g, settings)
       with ModelFactoryImplicitSupport
       with ModelFactoryTypeSupport
       with DiagramFactory
       with CommentFactory
-      with doc.model.TreeFactory
+      with TreeFactory
       with MemberLookup)
   }
 
@@ -166,4 +170,5 @@ object Test extends Properties("CommentFactory") {
     }
   }
 
+}
 }


### PR DESCRIPTION
Modifies the package pruning test to check whether the
package was first seen during namer.  Scaladoc gets a
custom namer that remembers package symbols.

A nicer mechanism may have been to turn on symbol
tracking and then query the tracker after namer, but
there are no hooks presently for that.
