### PR TITLE
SI-8138 Fix bug with super-accessors / dependent types

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -878,11 +878,13 @@ abstract class UnCurry extends InfoTransform
           case Packed(param, tempVal) => (param, tempVal)
         }.unzip
 
-        val rhs1 = localTyper.typedPos(rhs.pos) {
-          // Patch the method body to refer to the temp vals
-          val rhsSubstituted = rhs.substituteSymbols(packedParams map (_.symbol), tempVals map (_.symbol))
-          // The new method body: { val p$1 = p.asInstanceOf[<dependent type>]; ...; <rhsSubstituted> }
-          Block(tempVals, rhsSubstituted)
+        val rhs1 = if (tempVals.isEmpty) rhs else {
+          localTyper.typedPos(rhs.pos) {
+            // Patch the method body to refer to the temp vals
+            val rhsSubstituted = rhs.substituteSymbols(packedParams map (_.symbol), tempVals map (_.symbol))
+            // The new method body: { val p$1 = p.asInstanceOf[<dependent type>]; ...; <rhsSubstituted> }
+            Block(tempVals, rhsSubstituted)
+          }
         }
 
         (allParams :: Nil, rhs1)

--- a/test/files/pos/t8138.scala
+++ b/test/files/pos/t8138.scala
@@ -1,0 +1,24 @@
+
+class U {
+  trait Transformer {
+    def transform(a: Tree): Tree = ???
+  }
+  trait Tree
+}
+
+object Test {
+  def m(u: U) = {
+    class C extends u.Transformer {
+      override def transform(t: u.Tree): u.Tree = {
+        null match {
+          case _ =>
+            // crashes in GenICode:
+            // error: Unknown type: <notype>, <notype> [class scala.reflect.internal.Types$NoType$, class scala.reflect.internal.Types$NoType$] TypeRef? false
+            (y: Any) => super.transform(???)
+            null
+        }
+        ???
+      }
+    }
+  }
+}


### PR DESCRIPTION
Super-accessors are generated as `DefDef`'s with `EmptyTree` as a
placeholder for the RHS. This is filled in later in `Mixin` in
`completeSuperAccessor`.

A change in `Uncurry` ( / 493197f), however, converted this
to a `{ EmptyTree }`, which evaded the pattern match in mixin.

This commit adds a special case to the dependent method treatment
in Uncurry to avoid generating redundant blocks.
