### PR TITLE
SI-8147 Add f"%q" escaped quote

### DIFF
--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -133,7 +133,8 @@ case class StringContext(parts: String*) {
    *  Finally, if an interpolated expression is followed by a `parts` string
    *  that starts with a formatting specifier, the expression is formatted according to that
    *  specifier. All specifiers allowed in Java format strings are handled, and in the same
-   *  way they are treated in Java.
+   *  way they are treated in Java. In addition, a `"%q"` conversion is provided that is
+   *  expanded to `'"'`.
    *
    *  For example:
    *  {{{
@@ -157,9 +158,9 @@ case class StringContext(parts: String*) {
    *      If a formatting position does not refer to a `%` character (which is assumed to
    *      start a format specifier), then the string format specifier `%s` is inserted.
    *
-   *   2. Any `%` characters not in formatting positions are left in the resulting
-   *      string literally. This is achieved by replacing each such occurrence by the
-   *      format specifier `%%`.
+   *   2. Any `%` characters not in formatting positions must begin one of the conversions
+   *      `%%` (the literal percent), `%n` (the platform-specific line separator) or
+   *      `%q` (the literal double-quote).
    */
   // The implementation is hardwired to `scala.tools.reflect.MacroImplementations.macro_StringInterpolation_f`
   // Using the mechanism implemented in `scala.tools.reflect.FastTrack`

--- a/test/files/neg/t7325.check
+++ b/test/files/neg/t7325.check
@@ -1,19 +1,19 @@
-t7325.scala:2: error: conversions must follow a splice; use %% for literal %, %n for newline
+t7325.scala:2: error: conversions must follow a splice; use %% for literal %, %n for newline, %q for quote
   println(f"%")
             ^
-t7325.scala:4: error: conversions must follow a splice; use %% for literal %, %n for newline
+t7325.scala:4: error: conversions must follow a splice; use %% for literal %, %n for newline, %q for quote
   println(f"%%%")
               ^
-t7325.scala:6: error: conversions must follow a splice; use %% for literal %, %n for newline
+t7325.scala:6: error: conversions must follow a splice; use %% for literal %, %n for newline, %q for quote
   println(f"%%%%%")
                 ^
 t7325.scala:16: error: wrong conversion string
   println(f"${0}%")
                 ^
-t7325.scala:19: error: conversions must follow a splice; use %% for literal %, %n for newline
+t7325.scala:19: error: conversions must follow a splice; use %% for literal %, %n for newline, %q for quote
   println(f"${0}%%%d")
                   ^
-t7325.scala:21: error: conversions must follow a splice; use %% for literal %, %n for newline
+t7325.scala:21: error: conversions must follow a splice; use %% for literal %, %n for newline, %q for quote
   println(f"${0}%%%%%d")
                     ^
 6 errors found

--- a/test/junit/scala/tools/reflect/FTest.scala
+++ b/test/junit/scala/tools/reflect/FTest.scala
@@ -1,0 +1,20 @@
+
+package scala.tools.reflect
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import PartialFunction._
+
+/** Unit tests for `f` interpolator.
+ */
+@RunWith(classOf[JUnit4])
+class FTest {
+  @Test def qescape(): Unit = {
+    assertEquals("\"hello, world\"", f"%qhello, world%q")
+    assertEquals("hello, \"world\"", f"hello, %qworld%q")
+    assertEquals("hello, \"world\"", f"${"hello, "}%qworld%q")
+  }
+}


### PR DESCRIPTION
When the f-interpolator processes conversions, it also
substitutes "\"" for "%q" with this commit.

This may not fly, in the face of $", but it has a pleasing uniformity; maybe it will await other compelling additions to the conversion layer.
