### PR TITLE
[nomaster] SI-8152 Backport variance validator performance fix

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -909,11 +909,13 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
           // case DeBruijnIndex(_, _) =>
           case SingleType(pre, sym) =>
             validateVariance(pre, variance)
+          case TypeRef(_, sym, _) if sym.isAliasType =>
+            // okay to ignore pre/args here. In 2.10.3 we used to check them in addition to checking
+            // the normalized type, which led to exponential time type checking, see pos/t8152-performance.scala
+            validateVariance(tp.normalize, variance)
           case TypeRef(pre, sym, args) =>
 //            println("validate "+sym+" at "+relativeVariance(sym))
-            if (sym.isAliasType/* && relativeVariance(sym) == AnyVariance*/)
-              validateVariance(tp.normalize, variance)
-            else if (sym.variance != NoVariance) {
+            if (sym.variance != NoVariance) {
               val v = relativeVariance(sym)
               if (v != AnyVariance && sym.variance != v * variance) {
                 //Console.println("relativeVariance(" + base + "," + sym + ") = " + v);//DEBUG

--- a/test/files/pos/t8152-performance.scala
+++ b/test/files/pos/t8152-performance.scala
@@ -1,0 +1,13 @@
+class HListBench {
+
+  class A[H, T]
+
+  type B[H, T] = A[H, T]
+
+  // was okay
+  type T1 = A[Int, A[Int, A[Int, A[Int, A[Int, A[Int, A[Int, A[Int, A[Int, A[Int, A[Int, A[Int, A[Int, A[Int, A[Int, A[Int, A[Int, A[Int, A[Int, A[Int, A[Int, A[Int, A[Int, A[Int, A[Int, A[Int, A[Int, A[Int, Nothing]]]]]]]]]]]]]]]]]]]]]]]]]]]]
+
+  // Took over a minute to validate variance in 2.10.3!
+  type T2 = B[Int, B[Int, B[Int, B[Int, B[Int, B[Int, B[Int, B[Int, B[Int, B[Int, B[Int, B[Int, B[Int, B[Int, B[Int, B[Int, B[Int, B[Int, B[Int, B[Int, B[Int, B[Int, B[Int, B[Int, B[Int, B[Int, B[Int, B[Int, Nothing]]]]]]]]]]]]]]]]]]]]]]]]]]]]
+
+}


### PR DESCRIPTION
```
% time qbin/scalac test/files/pos/t8146-performance.scala

real    0m2.015s
user    0m2.892s
sys 0m0.215s

% time scalac-hash v2.10.3 test/files/pos/t8146-performance.scala

real    1m13.652s
user    1m14.245s
sys 0m0.508s
```

Cherry-picks one hunk from 882f8e64.

Affects Slick, so I'm considering for 2.10.4. Review by @adriaanm
