### PR TITLE
SI-8151 Remove -Yself-in-annots and associated implementation

### DIFF
--- a/src/compiler/scala/reflect/reify/codegen/GenTypes.scala
+++ b/src/compiler/scala/reflect/reify/codegen/GenTypes.scala
@@ -60,7 +60,7 @@ trait GenTypes {
         reifyProduct(tpe)
       case tpe @ NullaryMethodType(restpe) =>
         reifyProduct(tpe)
-      case tpe @ AnnotatedType(anns, underlying, selfsym) =>
+      case tpe @ AnnotatedType(anns, underlying) =>
         reifyAnnotatedType(tpe)
       case _ =>
         reifyToughType(tpe)
@@ -162,8 +162,8 @@ trait GenTypes {
 
   /** Reify an annotated type, i.e. the one that makes us deal with AnnotationInfos */
   private def reifyAnnotatedType(tpe: AnnotatedType): Tree = {
-    val AnnotatedType(anns, underlying, selfsym) = tpe
-    mirrorFactoryCall(nme.AnnotatedType, mkList(anns map reifyAnnotationInfo), reify(underlying), reify(selfsym))
+    val AnnotatedType(anns, underlying) = tpe
+    mirrorFactoryCall(nme.AnnotatedType, mkList(anns map reifyAnnotationInfo), reify(underlying))
   }
 
   /** Reify a tough type, i.e. the one that leads to creation of auxiliary symbols */

--- a/src/compiler/scala/tools/nsc/ast/TreeBrowsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeBrowsers.scala
@@ -619,7 +619,7 @@ abstract class TreeBrowsers {
                         toDocument(result) :: ")")
         )
 
-      case AnnotatedType(annots, tp, _) =>
+      case AnnotatedType(annots, tp) =>
         Document.group(
           Document.nest(4, "AnnotatedType(" :/:
                         annots.mkString("[", ",", "]") :/:

--- a/src/compiler/scala/tools/nsc/backend/icode/TypeKinds.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/TypeKinds.scala
@@ -393,7 +393,7 @@ trait TypeKinds { self: ICodes =>
     // if the first two cases exist because they do or as a defensive measure, but
     // at the time I added it, RefinedTypes were indeed reaching here.
     case ExistentialType(_, t)           => toTypeKind(t)
-    case AnnotatedType(_, t, _)          => toTypeKind(t)
+    case AnnotatedType(_, t)             => toTypeKind(t)
     case RefinedType(parents, _)         => parents map toTypeKind reduceLeft lub
     // For sure WildcardTypes shouldn't reach here either, but when
     // debugging such situations this may come in handy.

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -518,7 +518,7 @@ abstract class BCodeHelpers extends BCodeTypes with BytecodeWriters {
 
         // !!! Iulian says types which make no sense after erasure should not reach here, which includes the ExistentialType, AnnotatedType, RefinedType.
         case ExistentialType(_, t)   => toTypeKind(t) // TODO shouldn't get here but the following does: akka-actor/src/main/scala/akka/util/WildcardTree.scala
-        case AnnotatedType(_, w, _)  => toTypeKind(w) // TODO test/files/jvm/annotations.scala causes an AnnotatedType to reach here.
+        case AnnotatedType(_, w)     => toTypeKind(w) // TODO test/files/jvm/annotations.scala causes an AnnotatedType to reach here.
         case RefinedType(parents, _) => parents map toTypeKind reduceLeft jvmWiseLUB
 
         // For sure WildcardTypes shouldn't reach here either, but when debugging such situations this may come in handy.

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -154,7 +154,6 @@ trait ScalaSettings extends AbsScalaSettings
   val nopredef        = BooleanSetting    ("-Yno-predef", "Compile without importing Predef.")
   val noAdaptedArgs   = BooleanSetting    ("-Yno-adapted-args", "Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.")
   val Yrecursion      = IntSetting        ("-Yrecursion", "Set recursion depth used when locking symbols.", 0, Some((0, Int.MaxValue)), (_: String) => None)
-  val selfInAnnots    = BooleanSetting    ("-Yself-in-annots", "Include a \"self\" identifier inside of annotations.")
   val Xshowtrees      = BooleanSetting    ("-Yshow-trees", "(Requires -Xprint:) Print detailed ASTs in formatted form.")
   val XshowtreesCompact
                       = BooleanSetting    ("-Yshow-trees-compact", "(Requires -Xprint:) Print detailed ASTs in compact form.")

--- a/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
@@ -238,9 +238,8 @@ abstract class Pickler extends SubComponent {
         case ExistentialType(tparams, restpe) =>
           putType(restpe)
           putSymbols(tparams)
-        case AnnotatedType(_, underlying, selfsym) =>
+        case AnnotatedType(_, underlying) =>
           putType(underlying)
-          if (settings.selfInAnnots) putSymbol(selfsym)
           tp.staticAnnotations foreach putAnnotation
         case _ =>
           throw new FatalError("bad type: " + tp + "(" + tp.getClass + ")")
@@ -450,7 +449,7 @@ abstract class Pickler extends SubComponent {
         case PolyType(tparams, restpe)           => writeRef(restpe); writeRefs(tparams)
         case ExistentialType(tparams, restpe)    => writeRef(restpe); writeRefs(tparams)
         case StaticallyAnnotatedType(annots, tp) => writeRef(tp) ; writeRefs(annots)
-        case AnnotatedType(_, tp, _)             => writeTypeBody(tp) // write the underlying type if there are no static annotations
+        case AnnotatedType(_, tp)                => writeTypeBody(tp) // write the underlying type if there are no static annotations
         case CompoundType(parents, _, clazz)     => writeRef(clazz); writeRefs(parents)
       }
 

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -61,7 +61,7 @@ abstract class Erasure extends AddInterfaces
             parents foreach traverse
           case ClassInfoType(parents, _, _) =>
             parents foreach traverse
-          case AnnotatedType(_, atp, _) =>
+          case AnnotatedType(_, atp) =>
             traverse(atp)
           case _ =>
             mapOver(tp)
@@ -302,7 +302,7 @@ abstract class Erasure extends AddInterfaces
           boxedSig(parent)
         case ClassInfoType(parents, _, _) =>
           superSig(parents)
-        case AnnotatedType(_, atp, _) =>
+        case AnnotatedType(_, atp) =>
           jsig(atp, existentiallyBound, toplevel, primitiveOK)
         case BoundedWildcardType(bounds) =>
           println("something's wrong: "+sym0+":"+sym0.tpe+" has a bounded wildcard type")

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -438,7 +438,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
     case NullaryMethodType(resTpe)   => specializedTypeVars(resTpe)
     case MethodType(argSyms, resTpe) => specializedTypeVars(resTpe :: argSyms.map(_.tpe))
     case ExistentialType(_, res)     => specializedTypeVars(res)
-    case AnnotatedType(_, tp, _)     => specializedTypeVars(tp)
+    case AnnotatedType(_, tp)        => specializedTypeVars(tp)
     case TypeBounds(lo, hi)          => specializedTypeVars(lo :: hi :: Nil)
     case RefinedType(parents, _)     => parents flatMap specializedTypeVars toSet
     case _                           => immutable.Set.empty
@@ -1098,7 +1098,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
     case (ThisType(_), _)                             => unify(tp1.widen, tp2, env, strict)
     case (_, ThisType(_))                             => unify(tp1, tp2.widen, env, strict)
     case (RefinedType(_, _), RefinedType(_, _))       => env
-    case (AnnotatedType(_, tp1, _), tp2)              => unify(tp2, tp1, env, strict)
+    case (AnnotatedType(_, tp1), tp2)                 => unify(tp2, tp1, env, strict)
     case (ExistentialType(_, res1), _)                => unify(tp2, res1, env, strict)
     case (TypeBounds(lo1, hi1), TypeBounds(lo2, hi2)) => unify(List(lo1, hi1), List(lo2, hi2), env, strict)
     case _ =>

--- a/src/compiler/scala/tools/nsc/typechecker/DestructureTypes.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/DestructureTypes.scala
@@ -180,7 +180,7 @@ trait DestructureTypes {
       case SuperType(thistp, supertp)                => product(tp, this("this", thistp), this("super", supertp))
       case ThisType(clazz)                           => product(tp, wrapAtom(clazz))
       case TypeVar(inst, constr)                     => product(tp, this("inst", inst), typeConstraint(constr))
-      case AnnotatedType(annotations, underlying, _) => annotatedType(annotations, underlying)
+      case AnnotatedType(annotations, underlying)    => annotatedType(annotations, underlying)
       case ExistentialType(tparams, underlying)      => polyFunction(tparams, underlying)
       case PolyType(tparams, restpe)                 => polyFunction(tparams, restpe)
       case MethodType(params, restpe)                => monoFunction(params, restpe)

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -389,7 +389,7 @@ trait Implicits {
     private def dominates(dtor: Type, dted: Type): Boolean = {
       def core(tp: Type): Type = tp.dealiasWiden match {
         case RefinedType(parents, defs)         => intersectionType(parents map core, tp.typeSymbol.owner)
-        case AnnotatedType(annots, tp, selfsym) => core(tp)
+        case AnnotatedType(annots, tp)          => core(tp)
         case ExistentialType(tparams, result)   => core(result).subst(tparams, tparams map (t => core(t.info.bounds.hi)))
         case PolyType(tparams, result)          => core(result).subst(tparams, tparams map (t => core(t.info.bounds.hi)))
         case _                                  => tp
@@ -1060,7 +1060,7 @@ trait Implicits {
             getParts(restpe)
           case RefinedType(ps, _) =>
             for (p <- ps) getParts(p)
-          case AnnotatedType(_, t, _) =>
+          case AnnotatedType(_, t) =>
             getParts(t)
           case ExistentialType(_, t) =>
             getParts(t)

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1431,7 +1431,7 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
     private def checkTypeRefBounds(tp: Type, tree: Tree) = {
       var skipBounds = false
       tp match {
-        case AnnotatedType(ann :: Nil, underlying, selfSym) if ann.symbol == UncheckedBoundsClass =>
+        case AnnotatedType(ann :: Nil, underlying) if ann.symbol == UncheckedBoundsClass =>
           skipBounds = true
           underlying
         case TypeRef(pre, sym, args) =>
@@ -1474,7 +1474,7 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
           }
 
           doTypeTraversal(tree) {
-            case tp @ AnnotatedType(annots, _, _)  =>
+            case tp @ AnnotatedType(annots, _)  =>
               applyChecks(annots)
             case tp =>
           }

--- a/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
@@ -542,7 +542,7 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
       case TypeRef(pre, _, _)      => isThisType(pre)
       case SingleType(pre, _)      => isThisType(pre)
       case RefinedType(parents, _) => parents exists isThisType
-      case AnnotatedType(_, tp, _) => isThisType(tp)
+      case AnnotatedType(_, tp)    => isThisType(tp)
       case _                       => false
     }
   }

--- a/src/reflect/scala/reflect/api/Types.scala
+++ b/src/reflect/scala/reflect/api/Types.scala
@@ -707,14 +707,14 @@ trait Types {
   val AnnotatedType: AnnotatedTypeExtractor
 
   /** An extractor class to create and pattern match with syntax
-   * `AnnotatedType(annotations, underlying, selfsym)`.
+   * `AnnotatedType(annotations, underlying)`.
    *  Here, `annotations` are the annotations decorating the underlying type `underlying`.
    *  `selfSym` is a symbol representing the annotated type itself.
    *  @group Extractors
    */
   abstract class AnnotatedTypeExtractor {
-    def apply(annotations: List[Annotation], underlying: Type, selfsym: Symbol): AnnotatedType
-    def unapply(tpe: AnnotatedType): Option[(List[Annotation], Type, Symbol)]
+    def apply(annotations: List[Annotation], underlying: Type): AnnotatedType
+    def unapply(tpe: AnnotatedType): Option[(List[Annotation], Type)]
   }
 
   /** The API that all annotated types support.
@@ -727,9 +727,6 @@ trait Types {
 
     /** The annotee. */
     def underlying: Type
-
-    /** A symbol that represents the annotated type itself. */
-    def selfsym: Symbol
   }
 
   /** The `TypeBounds` type signature is used to indicate lower and upper type bounds

--- a/src/reflect/scala/reflect/internal/AnnotationInfos.scala
+++ b/src/reflect/scala/reflect/internal/AnnotationInfos.scala
@@ -290,8 +290,8 @@ trait AnnotationInfos extends api.Annotations { self: SymbolTable =>
      *  metaAnnotations = List(setter, field).
      */
     def metaAnnotations: List[AnnotationInfo] = atp match {
-      case AnnotatedType(metas, _, _) => metas
-      case _                          => Nil
+      case AnnotatedType(metas, _) => metas
+      case _                       => Nil
     }
 
     /** The default kind of members to which this annotation is attached.

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -692,7 +692,7 @@ trait Definitions extends api.StandardDefinitions {
       case TypeRef(pre, sym, _) if sym.isModuleClass    => isStable(pre)
       case TypeRef(_, _, _) if tp ne tp.dealias         => isStable(tp.dealias)
       case TypeVar(origin, _)                           => isStable(origin)
-      case AnnotatedType(_, atp, _)                     => isStable(atp)    // Really?
+      case AnnotatedType(_, atp)                        => isStable(atp)    // Really?
       case _: SimpleTypeProxy                           => isStable(tp.underlying)
       case _                                            => false
     }

--- a/src/reflect/scala/reflect/internal/Importers.scala
+++ b/src/reflect/scala/reflect/internal/Importers.scala
@@ -266,8 +266,8 @@ trait Importers extends api.Importers { to: SymbolTable =>
         val myconstr = new TypeConstraint(their.constr.loBounds map importType, their.constr.hiBounds map importType)
         myconstr.inst = importType(their.constr.inst)
         TypeVar(importType(their.origin), myconstr, their.typeArgs map importType, their.params map importSymbol)
-      case from.AnnotatedType(annots, result, selfsym) =>
-        AnnotatedType(annots map importAnnotationInfo, importType(result), importSymbol(selfsym))
+      case from.AnnotatedType(annots, result) =>
+        AnnotatedType(annots map importAnnotationInfo, importType(result))
       case from.ErrorType =>
         ErrorType
       case from.WildcardType =>

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -95,7 +95,7 @@ abstract class TreeGen extends macros.TreeBuilder {
       case ConstantType(value) =>
         Literal(value) setType tpe
 
-      case AnnotatedType(_, atp, _) =>
+      case AnnotatedType(_, atp) =>
         mkAttributedQualifier(atp)
 
       case RefinedType(parents, _) =>

--- a/src/reflect/scala/reflect/internal/Variances.scala
+++ b/src/reflect/scala/reflect/internal/Variances.scala
@@ -84,7 +84,7 @@ trait Variances {
         loop(base, Covariant)
       }
       def isUncheckedVariance(tp: Type) = tp match {
-        case AnnotatedType(annots, _, _) => annots exists (_ matches definitions.uncheckedVarianceClass)
+        case AnnotatedType(annots, _)    => annots exists (_ matches definitions.uncheckedVarianceClass)
         case _                           => false
       }
 
@@ -202,7 +202,7 @@ trait Variances {
       case MethodType(params, restpe)                   => inSyms(params).flip         & inType(restpe)
       case PolyType(tparams, restpe)                    => inSyms(tparams).flip        & inType(restpe)
       case ExistentialType(tparams, restpe)             => inSyms(tparams)             & inType(restpe)
-      case AnnotatedType(annots, tp, _)                 => inTypes(annots map (_.atp)) & inType(tp)
+      case AnnotatedType(annots, tp)                    => inTypes(annots map (_.atp)) & inType(tp)
     }
 
     inType(tp)

--- a/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
+++ b/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
@@ -362,7 +362,7 @@ abstract class UnPickler {
         case METHODtpe                 => MethodTypeRef(readTypeRef(), readSymbols())
         case POLYtpe                   => PolyOrNullaryType(readTypeRef(), readSymbols())
         case EXISTENTIALtpe            => ExistentialType(underlying = readTypeRef(), quantified = readSymbols())
-        case ANNOTATEDtpe              => AnnotatedType(underlying = readTypeRef(), annotations = readAnnots(), selfsym = NoSymbol)
+        case ANNOTATEDtpe              => AnnotatedType(underlying = readTypeRef(), annotations = readAnnots())
       }
     }
 

--- a/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
+++ b/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
@@ -316,7 +316,7 @@ private[internal] trait GlbLubs {
         NullaryMethodType(lub0(matchingRestypes(ts, Nil)))
       case ts @ TypeBounds(_, _) :: rest =>
         TypeBounds(glb(ts map (_.bounds.lo), depth), lub(ts map (_.bounds.hi), depth))
-      case ts @ AnnotatedType(annots, tpe, _) :: rest =>
+      case ts @ AnnotatedType(annots, tpe) :: rest =>
         annotationsLub(lub0(ts map (_.withoutAnnotations)), ts)
       case ts =>
         lubResults get ((depth, ts)) match {

--- a/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
@@ -403,14 +403,14 @@ trait TypeComparers {
           case _ =>
             secondTry
         }
-      case AnnotatedType(_, _, _) =>
+      case AnnotatedType(_, _) =>
         isSubType(tp1.withoutAnnotations, tp2.withoutAnnotations, depth) &&
           annotationsConform(tp1, tp2)
       case BoundedWildcardType(bounds) =>
         isSubType(tp1, bounds.hi, depth)
       case tv2 @ TypeVar(_, constr2) =>
         tp1 match {
-          case AnnotatedType(_, _, _) | BoundedWildcardType(_) =>
+          case AnnotatedType(_, _) | BoundedWildcardType(_) =>
             secondTry
           case _ =>
             tv2.registerBound(tp1, isLowerBound = true)
@@ -425,7 +425,7 @@ trait TypeComparers {
      *   - handle existential types by skolemization.
      */
     def secondTry = tp1 match {
-      case AnnotatedType(_, _, _) =>
+      case AnnotatedType(_, _) =>
         isSubType(tp1.withoutAnnotations, tp2.withoutAnnotations, depth) &&
           annotationsConform(tp1, tp2)
       case BoundedWildcardType(bounds) =>

--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -48,7 +48,7 @@ private[internal] trait TypeMaps {
       case TypeRef(_, sym, _) if sym.isAliasType    => apply(tp.dealias)
       case TypeRef(_, sym, _) if sym.isAbstractType => apply(tp.bounds.hi)
       case rtp @ RefinedType(parents, decls)        => copyRefinedType(rtp, parents mapConserve this, decls)
-      case AnnotatedType(_, _, _)                   => mapOver(tp)
+      case AnnotatedType(_, _)                      => mapOver(tp)
       case _                                        => tp             // no recursion - top level only
     }
   }
@@ -174,12 +174,12 @@ private[internal] trait TypeMaps {
       case tv@TypeVar(_, constr) =>
         if (constr.instValid) this(constr.inst)
         else tv.applyArgs(mapOverArgs(tv.typeArgs, tv.params))  //@M !args.isEmpty implies !typeParams.isEmpty
-      case AnnotatedType(annots, atp, selfsym) =>
+      case AnnotatedType(annots, atp) =>
         val annots1 = mapOverAnnotations(annots)
         val atp1 = this(atp)
         if ((annots1 eq annots) && (atp1 eq atp)) tp
         else if (annots1.isEmpty) atp1
-        else AnnotatedType(annots1, atp1, selfsym)
+        else AnnotatedType(annots1, atp1)
       /*
             case ErrorType => tp
             case WildcardType => tp
@@ -1142,7 +1142,7 @@ private[internal] trait TypeMaps {
       case SuperType(_, _) => mapOver(tp)
       case TypeBounds(_, _) => mapOver(tp)
       case TypeVar(_, _) => mapOver(tp)
-      case AnnotatedType(_,_,_) => mapOver(tp)
+      case AnnotatedType(_, _) => mapOver(tp)
       case ExistentialType(_, _) => mapOver(tp)
       case _ => tp
     }

--- a/src/reflect/scala/reflect/internal/transform/Erasure.scala
+++ b/src/reflect/scala/reflect/internal/transform/Erasure.scala
@@ -144,7 +144,7 @@ trait Erasure {
           else apply(mt.resultType(mt.paramTypes)))
       case RefinedType(parents, decls) =>
         apply(mergeParents(parents))
-      case AnnotatedType(_, atp, _) =>
+      case AnnotatedType(_, atp) =>
         apply(atp)
       case ClassInfoType(parents, decls, clazz) =>
         ClassInfoType(

--- a/test/files/run/constrained-types.check
+++ b/test/files/run/constrained-types.check
@@ -149,13 +149,3 @@ scala> val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
                                     ^
 
 scala> 
-
-scala> class Where(condition: Boolean) extends annotation.Annotation
-defined class Where
-
-scala> 
-
-scala> val x : Int @Where(self > 0 && self < 100) = 3
-x: Int @Where(self.>(0).&&(self.<(100))) = 3
-
-scala> 

--- a/test/files/run/constrained-types.scala
+++ b/test/files/run/constrained-types.scala
@@ -72,16 +72,10 @@ object A { val x = "hello" : String @ rep }
 val y = a.x // should drop the annotation
 
 val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
-
-class Where(condition: Boolean) extends annotation.Annotation
-
-val x : Int @Where(self > 0 && self < 100) = 3
-
 """
 
   override def transformSettings(s: Settings): Settings = {
     s.Xexperimental.value = true
-    s.selfInAnnots.value = true
     s.deprecation.value = true
     // when running that compiler, give it a scala-library to the classpath
     s.classpath.value = sys.props("java.class.path")


### PR DESCRIPTION
This experimental option typechecked arguments of annotations
with an injected value in scope named `self`:

```
@Foo(self.foo < 1)
```

This has been slated for removal [1] for some time.

This commit removes it in one fell swoop, without any attempt
at source compatibility with code that constructs or pattern
matches on AnnotatedType.

[1] https://groups.google.com/d/msg/scala-internals/VdZ5UJwQFGI/C6tZ493Yxx4J
