### PR TITLE
SI-8132 Fix false "overrides nothing" for case class protected param

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
@@ -380,7 +380,7 @@ trait SyntheticMethods extends ast.TreeDSL {
         val original = ddef.symbol
         val newAcc = deriveMethod(ddef.symbol, name => context.unit.freshTermName(name + "$")) { newAcc =>
           newAcc.makePublic
-          newAcc resetFlag (ACCESSOR | PARAMACCESSOR)
+          newAcc resetFlag (ACCESSOR | PARAMACCESSOR | OVERRIDE)
           ddef.rhs.duplicate
         }
         // TODO: shouldn't the next line be: `original resetFlag CASEACCESSOR`?

--- a/test/files/pos/t8132.scala
+++ b/test/files/pos/t8132.scala
@@ -1,0 +1,5 @@
+trait T {
+  protected def s: String
+}
+
+case class G(override protected val s: String) extends T


### PR DESCRIPTION
Case class parameters that are less-than-public have an accessor
method created. In the enclosed test, we saw:

```
case class G extends AnyRef with T with Product with Serializable {
  override <synthetic> <stable> <caseaccessor> def s$1: String = G.this.s;
  <caseaccessor> <paramaccessor> private[this] val s: String = _;
  override <stable> <accessor> <paramaccessor> protected def s: String = G.this.s;
  ...
}
```

This commit removes the OVERRIDE flag from the accessor method,
which avoids the spurious "overrides nothing" error.

Review by @gkossakowski
