### PR TITLE
SI-8148 fix anonymous functions with placeholders in quasiquotes

### DIFF
--- a/src/compiler/scala/tools/reflect/quasiquotes/Parsers.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Parsers.scala
@@ -55,7 +55,7 @@ trait Parsers { self: Quasiquotes =>
 
       def isHole(name: Name): Boolean = holeMap.contains(name)
 
-      override implicit def fresh: FreshNameCreator = new FreshNameCreator(nme.QUASIQUOTE_PREFIX)
+      override implicit lazy val fresh: FreshNameCreator = new FreshNameCreator(nme.QUASIQUOTE_PREFIX)
 
       override val treeBuilder = new ParserTreeBuilder {
         override implicit def fresh: FreshNameCreator = parser.fresh

--- a/test/files/scalacheck/quasiquotes/TermConstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/TermConstructionProps.scala
@@ -224,4 +224,9 @@ object TermConstructionProps extends QuasiquoteProperties("term construction") {
   property("SI-8009") = test {
     q"`foo`".asInstanceOf[reflect.internal.SymbolTable#Ident].isBackquoted
   }
+
+  property("SI-8148") = test {
+    val q"($a, $b) => $_" = q"_ + _"
+    assert(a.name != b.name)
+  }
 }


### PR DESCRIPTION
Quasiquotes used to fail to generate proper fresh identifiers for
anonymous functions like:

```
  q"_ + _" // used to be parsed as q"(x$1, x$1) => x$1 + x$1"
```

Due to improper initialization of FreshNameCreator in quasiquote
parser which was erroneously not preserved throughout parsing of
the code snippet but re-created on every invocation.

review @retronym
