### PR TITLE
SI-6844  SI-8076 improve handling of function parameters in quasiquotes

### DIFF
--- a/src/compiler/scala/tools/reflect/quasiquotes/Placeholders.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Placeholders.scala
@@ -95,7 +95,6 @@ trait Placeholders { self: Quasiquotes =>
       case Ident(name) => name
       case Bind(name, Ident(nme.WILDCARD)) => name
       case TypeDef(_, name, List(), TypeBoundsTree(EmptyTree, EmptyTree)) => name
-      case ValDef(_, name, TypeTree(), EmptyTree) => name
     }
   }
 
@@ -108,6 +107,12 @@ trait Placeholders { self: Quasiquotes =>
   object AnnotPlaceholder extends HolePlaceholder {
     def matching = {
       case Apply(Select(New(Ident(name)), nme.CONSTRUCTOR), Nil) => name
+    }
+  }
+
+  object ParamPlaceholder extends HolePlaceholder {
+    def matching = {
+      case ValDef(_, name, Ident(tpnme.QUASIQUOTE_PARAM), EmptyTree) => name
     }
   }
 

--- a/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
@@ -137,6 +137,7 @@ trait Reifiers { self: Quasiquotes =>
       case RefineStatPlaceholder(hole) => reifyRefineStat(hole)
       case EarlyDefPlaceholder(hole) => reifyEarlyDef(hole)
       case PackageStatPlaceholder(hole) => reifyPackageStat(hole)
+      case ParamPlaceholder(hole) => hole.tree
       // for enumerators are checked not during splicing but during
       // desugaring of the for loop in SyntacticFor & SyntacticForYield
       case ForEnumPlaceholder(hole) => hole.tree
@@ -311,6 +312,8 @@ trait Reifiers { self: Quasiquotes =>
       case EarlyDefPlaceholder(h @ Hole(_, DotDot)) => reifyEarlyDef(h)
       case PackageStatPlaceholder(h @ Hole(_, DotDot)) => reifyPackageStat(h)
       case ForEnumPlaceholder(Hole(tree, DotDot)) => tree
+      case ParamPlaceholder(Hole(tree, DotDot)) => tree
+      case List(ParamPlaceholder(Hole(tree, DotDotDot))) => tree
       case List(Placeholder(Hole(tree, DotDotDot))) => tree
     } {
       reify(_)

--- a/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
@@ -160,8 +160,12 @@ trait Reifiers { self: Quasiquotes =>
         reifyBuildCall(nme.SyntacticObjectDef, mods, name, earlyDefs, parents, selfdef, body)
       case SyntacticNew(earlyDefs, parents, selfdef, body) =>
         reifyBuildCall(nme.SyntacticNew, earlyDefs, parents, selfdef, body)
-      case SyntacticDefDef(mods, name, tparams, vparamss, tpt, rhs) =>
-        reifyBuildCall(nme.SyntacticDefDef, mods, name, tparams, vparamss, tpt, rhs)
+      case SyntacticDefDef(mods, name, tparams, build.ImplicitParams(vparamss, implparams), tpt, rhs) =>
+        if (implparams.nonEmpty)
+          mirrorBuildCall(nme.SyntacticDefDef, reify(mods), reify(name), reify(tparams), 
+                          reifyBuildCall(nme.ImplicitParams, vparamss, implparams), reify(tpt), reify(rhs))
+        else
+          reifyBuildCall(nme.SyntacticDefDef, mods, name, tparams, vparamss, tpt, rhs)
       case SyntacticValDef(mods, name, tpt, rhs) if tree != noSelfType =>
         reifyBuildCall(nme.SyntacticValDef, mods, name, tpt, rhs)
       case SyntacticVarDef(mods, name, tpt, rhs) =>

--- a/src/reflect/scala/reflect/api/BuildUtils.scala
+++ b/src/reflect/scala/reflect/api/BuildUtils.scala
@@ -126,8 +126,8 @@ private[reflect] trait BuildUtils { self: Universe =>
 
     trait SyntacticClassDefExtractor {
       def apply(mods: Modifiers, name: TypeName, tparams: List[Tree],
-                constrMods: Modifiers, vparamss: List[List[Tree]], earlyDefs: List[Tree],
-                parents: List[Tree], selfType: Tree, body: List[Tree]): ClassDef
+                constrMods: Modifiers, vparamss: List[List[Tree]],
+                earlyDefs: List[Tree], parents: List[Tree], selfType: Tree, body: List[Tree]): ClassDef
       def unapply(tree: Tree): Option[(Modifiers, TypeName, List[TypeDef], Modifiers, List[List[ValDef]],
                                        List[Tree], List[Tree], ValDef, List[Tree])]
     }
@@ -197,9 +197,10 @@ private[reflect] trait BuildUtils { self: Universe =>
     val SyntacticDefDef: SyntacticDefDefExtractor
 
     trait SyntacticDefDefExtractor {
-      def apply(mods: Modifiers, name: TermName, tparams: List[Tree], vparamss: List[List[Tree]], tpt: Tree, rhs: Tree): DefDef
+      def apply(mods: Modifiers, name: TermName, tparams: List[Tree],
+                vparamss: List[List[Tree]], tpt: Tree, rhs: Tree): DefDef
 
-      def unapply(tree: Tree): Option[(Modifiers, TermName, List[Tree], List[List[ValDef]], Tree, Tree)]
+      def unapply(tree: Tree): Option[(Modifiers, TermName, List[TypeDef], List[List[ValDef]], Tree, Tree)]
     }
 
     val SyntacticValDef: SyntacticValDefExtractor

--- a/src/reflect/scala/reflect/api/BuildUtils.scala
+++ b/src/reflect/scala/reflect/api/BuildUtils.scala
@@ -94,6 +94,13 @@ private[reflect] trait BuildUtils { self: Universe =>
 
     def freshTypeName(prefix: String): TypeName
 
+    val ImplicitParams: ImplicitParamsExtractor
+
+    trait ImplicitParamsExtractor {
+      def apply(paramss: List[List[ValDef]], implparams: List[ValDef]): List[List[ValDef]]
+      def unapply(vparamss: List[List[ValDef]]): Some[(List[List[ValDef]], List[ValDef])]
+    }
+
     val ScalaDot: ScalaDotExtractor
 
     trait ScalaDotExtractor {

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -576,6 +576,7 @@ trait StdNames {
     val Flag : NameType                = "Flag"
     val FlagsRepr: NameType            = "FlagsRepr"
     val Ident: NameType                = "Ident"
+    val ImplicitParams: NameType       = "ImplicitParams"
     val Import: NameType               = "Import"
     val Literal: NameType              = "Literal"
     val LiteralAnnotArg: NameType      = "LiteralAnnotArg"

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -250,12 +250,13 @@ trait StdNames {
     final val Quasiquote: NameType          = "Quasiquote"
 
     // quasiquote-specific names
-    final val QUASIQUOTE_MODS: NameType         = "$quasiquote$mods$"
-    final val QUASIQUOTE_TUPLE: NameType        = "$quasiquote$tuple$"
-    final val QUASIQUOTE_FUNCTION: NameType     = "$quasiquote$function$"
-    final val QUASIQUOTE_REFINE_STAT: NameType  = "$quasiquote$refine$stat$"
     final val QUASIQUOTE_EARLY_DEF: NameType    = "$quasiquote$early$def$"
+    final val QUASIQUOTE_FUNCTION: NameType     = "$quasiquote$function$"
+    final val QUASIQUOTE_MODS: NameType         = "$quasiquote$mods$"
     final val QUASIQUOTE_PACKAGE_STAT: NameType = "$quasiquote$package$stat$"
+    final val QUASIQUOTE_PARAM: NameType        = "$quasiquote$param$"
+    final val QUASIQUOTE_REFINE_STAT: NameType  = "$quasiquote$refine$stat$"
+    final val QUASIQUOTE_TUPLE: NameType        = "$quasiquote$tuple$"
 
     // Annotation simple names, used in Namer
     final val BeanPropertyAnnot: NameType = "BeanProperty"
@@ -703,9 +704,9 @@ trait StdNames {
     val materializeTypeTag: NameType   = "materializeTypeTag"
     val moduleClass : NameType         = "moduleClass"
     val mkAnnotation: NameType         = "mkAnnotation"
-    val mkRefineStat: NameType         = "mkRefineStat"
     val mkEarlyDef: NameType           = "mkEarlyDef"
     val mkPackageStat: NameType        = "mkPackageStat"
+    val mkRefineStat: NameType         = "mkRefineStat"
     val ne: NameType                   = "ne"
     val newArray: NameType             = "newArray"
     val newFreeTerm: NameType          = "newFreeTerm"

--- a/test/files/neg/quasiquotes-syntax-error-position.check
+++ b/test/files/neg/quasiquotes-syntax-error-position.check
@@ -29,4 +29,7 @@ quasiquotes-syntax-error-position.scala:13: error: end of quote expected but 'ca
 quasiquotes-syntax-error-position.scala:14: error: ')' expected but end of quote found.
   pq"$a(bar"
            ^
-10 errors found
+quasiquotes-syntax-error-position.scala:15: error: ':' expected but ')' found.
+  q"def foo(x)"
+             ^
+11 errors found

--- a/test/files/neg/quasiquotes-syntax-error-position.scala
+++ b/test/files/neg/quasiquotes-syntax-error-position.scala
@@ -12,4 +12,5 @@ object test extends App {
   tq"$t => $t $t]"
   cq"pattern => body ; case pattern2 =>"
   pq"$a(bar"
+  q"def foo(x)"
 }

--- a/test/files/neg/t6844.check
+++ b/test/files/neg/t6844.check
@@ -1,0 +1,6 @@
+t6844.scala:4: error: type mismatch;
+ found   : reflect.runtime.universe.TermName
+ required: reflect.runtime.universe.Tree
+  q"def foo($x)"
+             ^
+one error found

--- a/test/files/neg/t6844.scala
+++ b/test/files/neg/t6844.scala
@@ -1,0 +1,5 @@
+import scala.reflect.runtime.universe._
+object Test extends App {
+  val x = TermName("x")
+  q"def foo($x)"
+}

--- a/test/files/scalacheck/quasiquotes/DefinitionConstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/DefinitionConstructionProps.scala
@@ -7,6 +7,7 @@ object DefinitionConstructionProps
     with TraitConstruction
     with TypeDefConstruction
     with ValDefConstruction
+    with DefConstruction
     with PackageConstruction {
   property("SI-6842") = test {
     val x: Tree = q"val x: Int"
@@ -348,5 +349,17 @@ trait PackageConstruction { self: QuasiquoteProperties =>
     val edefs = q"val x = 1" :: q"type I = Int" :: Nil
     assertEqAst(q"package object foo extends { ..$edefs } with Any",
                  "package object foo extends { val x = 1; type I = Int } with Any")
+  }
+}
+
+trait DefConstruction { self: QuasiquoteProperties =>
+  property("construct implicit args (1)") = test {
+    val x = q"val x: Int"
+    assertEqAst(q"def foo(implicit $x) = x", "def foo(implicit x: Int) = x")
+  }
+
+  property("construct implicit args (2)") = test {
+    val xs = q"val x1: Int" :: q"val x2: Long" :: Nil
+    assertEqAst(q"def foo(implicit ..$xs) = x1 + x2", "def foo(implicit x1: Int, x2: Long) = x1 + x2")
   }
 }


### PR DESCRIPTION
Fixes two bugs related to handling of function parameters:
- [SI-6844](https://issues.scala-lang.org/browse/SI-6844) restrict splicing in parameter position
- [SI-8076](https://issues.scala-lang.org/browse/SI-8076) improve support for implicit argument list

Best viewed per commit. 

review @retronym
