### PR TITLE
Move check for undefined members in objects from Typer to RefCheck

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -1035,7 +1035,7 @@ trait ContextErrors {
         val ImplicitConstr, ImplicitNotTermOrClass, ImplicitAtToplevel,
           OverrideClass, SealedNonClass, AbstractNonClass,
           OverrideConstr, AbstractOverride, AbstractOverrideOnTypeMember, LazyAndEarlyInit,
-          ByNameParameter, AbstractVar = Value
+          ByNameParameter = Value
       }
 
       object DuplicatesErrorKinds extends Enumeration {
@@ -1138,9 +1138,6 @@ trait ContextErrors {
 
           case ByNameParameter =>
             "pass-by-name arguments not allowed for case class parameters"
-
-          case AbstractVar =>
-            "only classes can have declared but undefined members" + abstractVarMessage(sym)
 
         }
         issueSymbolTypeError(sym, msg)

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1613,22 +1613,8 @@ trait Namers extends MethodSynthesis {
         checkNoConflict(ABSTRACT, FINAL)
 
       if (sym.isDeferred) {
-        // Is this symbol type always allowed the deferred flag?
-        def symbolAllowsDeferred = (
-             sym.isValueParameter
-          || sym.isTypeParameterOrSkolem
-          || context.tree.isInstanceOf[ExistentialTypeTree]
-        )
-        // Does the symbol owner require no undefined members?
-        def ownerRequiresConcrete = (
-             !sym.owner.isClass
-          ||  sym.owner.isModuleClass
-          ||  sym.owner.isAnonymousClass
-        )
         if (sym hasAnnotation NativeAttr)
           sym resetFlag DEFERRED
-        else if (!symbolAllowsDeferred && ownerRequiresConcrete)
-          fail(AbstractVar)
 
         checkWithDeferred(PRIVATE)
         checkWithDeferred(FINAL)

--- a/test/files/neg/nested-fn-print.check
+++ b/test/files/neg/nested-fn-print.check
@@ -1,7 +1,3 @@
-nested-fn-print.scala:4: error: only classes can have declared but undefined members
-(Note that variables need to be initialized to be defined)
-  var x3: Int => Double
-      ^
 nested-fn-print.scala:7: error: type mismatch;
  found   : String("a")
  required: Int => (Float => Double)
@@ -17,4 +13,4 @@ nested-fn-print.scala:9: error: type mismatch;
  required: Int => Double
     x3 = "c"
          ^
-four errors found
+three errors found

--- a/test/files/neg/t565.check
+++ b/test/files/neg/t565.check
@@ -1,5 +1,9 @@
+t565.scala:1: error: object creation impossible, since variable s0 is not defined
+(Note that variables need to be initialized to be defined)
+object test {
+       ^
 t565.scala:2: error: only classes can have declared but undefined members
 (Note that variables need to be initialized to be defined)
   var s0: String
       ^
-one error found
+two errors found


### PR DESCRIPTION
Alternative PR: #3407 

When writing an object (or an anonymous class) with declared but undefined members, the compiler complains specifically about the method which is not allowed:

```
object Foo {
  def x: Int  // will cause an error message
}
```

will emit

```
test.scala:16: error: only classes can have declared but undefined members
  def x: Int
      ^
```

This check has been performed by the Typer, unlike other checks for completeness of classes that are performed in the RefCheck phase. There are two issues with that:
1. The test in the typer is conceptually wrong and only shallow (it
   e.g. does not check for unimplemented inherited abstract methods)
2. This does not allow compiler plugins to generate such code in a
   post-Typer but pre-RefCheck phase.

This commit moves the check to the RefCheck phase. Error messages remain the same, except for the additional "object creation impossible" message emitted from the RefCheck phase. The example code above will now emit the following errors:

```
test.scala:15: error: object creation impossible, since method x is not defined
object Foo {
       ^
test.scala:16: error: only classes can have declared but undefined members
  def x: Int
      ^
```

There is no need for additional tests since `neg/nested-fn-print` and `neg/t565` already verify this behavior.
