### PR TITLE
Fix EOL-printing in Printers test suite

### DIFF
--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -735,7 +735,8 @@ trait Printers extends api.Printers { self: SymbolTable =>
                 println()
               };
             case _ =>
-              printPackageDef(pd, "\n")
+              val separator = scala.util.Properties.lineSeparator
+              printPackageDef(pd, separator)
           }
 
         case md @ ModuleDef(mods, name, impl) =>
@@ -944,15 +945,16 @@ trait Printers extends api.Printers { self: SymbolTable =>
           }
 
         case l @ Literal(x) =>
+          import Chars.LF
           x match {
             case Constant(v: String) if {
               val strValue = x.stringValue
-              strValue.contains("\n") && strValue.contains("\"\"\"") && strValue.size > 1
+              strValue.contains(LF) && strValue.contains("\"\"\"") && strValue.size > 1
             } =>
-              val splitValue = x.stringValue.split('\n'.toString).toList
-              val multilineStringValue = if (x.stringValue.endsWith("\n")) splitValue :+ "" else splitValue
+              val splitValue = x.stringValue.split(s"$LF").toList
+              val multilineStringValue = if (x.stringValue.endsWith(s"$LF")) splitValue :+ "" else splitValue
               val trQuotes = "\"\"\""
-              print(trQuotes); printSeq(multilineStringValue) { print(_) } { print("\n") }; print(trQuotes)
+              print(trQuotes); printSeq(multilineStringValue) { print(_) } { print(LF) }; print(trQuotes)
             case _ =>
               // processing Float constants
               val printValue = x.escapedStringValue + (if (x.value.isInstanceOf[Float]) "F" else "")

--- a/test/junit/scala/reflect/internal/PrintersTest.scala
+++ b/test/junit/scala/reflect/internal/PrintersTest.scala
@@ -19,14 +19,19 @@ class PrintersTest extends BasePrintTests
 object PrinterHelper {
   val toolbox = cm.mkToolBox()
   def assertPrintedCode(code: String, tree: Tree = EmptyTree) = {
+    def processEOL(resultCode: String) = {
+      import scala.reflect.internal.Chars._
+      resultCode.replaceAll(s"$CR$LF", s"$LF").replace(CR, LF)
+    }
+
     val toolboxTree = 
       try{
         toolbox.parse(code)
       } catch {
         case e:scala.tools.reflect.ToolBoxError => throw new Exception(e.getMessage + ": " + code)
       }
-    if (tree ne EmptyTree) assertEquals("using quasiquote or given tree"+"\n", code.trim, showCode(tree))
-    else assertEquals("using toolbox parser", code.trim, showCode(toolboxTree))
+    if (tree ne EmptyTree) assertEquals("using quasiquote or given tree"+"\n", code.trim, processEOL(showCode(tree)))
+    else assertEquals("using toolbox parser", code.trim, processEOL(showCode(toolboxTree)))
   }
   
   implicit class StrContextStripMarginOps(val stringContext: StringContext) extends util.StripMarginInterpolator


### PR DESCRIPTION
Fixes for [problem](https://gist.github.com/adriaanm/8449000) with EOL processing in Printers test suite (scala-nightly-windows tests failed).
1. EOL printing in scala.reflect.internal.Printers is modified.
2. EOL processing for tests (PrintersTest) is added.
