### PR TITLE
Fix typo

### DIFF
--- a/src/reflect/scala/reflect/api/Mirrors.scala
+++ b/src/reflect/scala/reflect/api/Mirrors.scala
@@ -153,7 +153,7 @@ package api
  *
  * '''[[scala.reflect.api.Mirrors#ClassMirror]]'''. Used for creating invoker mirrors for constructors.
  * Entry points: for ''static classes'' `val cm1 = m.reflectClass(<class symbol>)`,
- * for ''inner classes'' `val mm2 = im.reflectClass(<module symbol>)`.
+ * for ''inner classes'' `val mm2 = im.reflectClass(<class symbol>)`.
  * Example:
  * {{{
  *   scala> case class C(x: Int)


### PR DESCRIPTION
In "for inner classes `val mm2 = im.reflectClass(<module symbol>)`", `<module symbol>` should read `<class symbol>`.

The same error is also in docs.scala-lang.org, so I sent pull request scala/scala.github.com#284.

Review by @heathermiller or @xeno-by.
