### PR TITLE
SI-8157 Make overloading, defaults restriction PolyType aware

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -132,11 +132,7 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
 
       defaultMethodNames.toList.distinct foreach { name =>
         val methods      = clazz.info.findMember(name, 0L, requiredFlags = METHOD, stableOnly = false).alternatives
-        def hasDefaultParam(tpe: Type): Boolean = tpe match {
-          case MethodType(params, restpe) => (params exists (_.hasDefault)) || hasDefaultParam(restpe)
-          case _                          => false
-        }
-        val haveDefaults = methods filter (sym => hasDefaultParam(sym.info) && !nme.isProtectedAccessorName(sym.name))
+        val haveDefaults = methods filter (sym => mexists(sym.info.paramss)(_.hasDefault) && !nme.isProtectedAccessorName(sym.name))
 
         if (haveDefaults.lengthCompare(1) > 0) {
           val owners = haveDefaults map (_.owner)

--- a/test/files/neg/t8157.check
+++ b/test/files/neg/t8157.check
@@ -1,0 +1,4 @@
+t8157.scala:1: error: in object Test, multiple overloaded alternatives of method foo define default arguments.
+object Test {
+       ^
+one error found

--- a/test/files/neg/t8157.scala
+++ b/test/files/neg/t8157.scala
@@ -1,0 +1,4 @@
+object Test {
+  def foo(printer: Any, question: => String, show: Boolean = false)(op: => Any): Any = ???
+  def foo[T](question: => String, show: Boolean)(op: => Any = ()): Any = ???
+}


### PR DESCRIPTION
Named/Default args levies an implementation restriction that
only one overloaded alternative may declare defaults.

But, this restriction failed to consider polymorphic methods.

Rather than matching on MethodType, this commit uses `Type#paramms`,
which handles PolyTypes and curried MethodTypes in one fell swoop.

Review by @odersky, who found the bug.
