### PR TITLE
Improve naming of ReadStdin

### DIFF
--- a/src/library/scala/Console.scala
+++ b/src/library/scala/Console.scala
@@ -9,7 +9,7 @@
 package scala
 
 import java.io.{ BufferedReader, InputStream, InputStreamReader, OutputStream, PrintStream, Reader }
-import scala.io.{ AnsiColor, ReadStdin }
+import scala.io.{ AnsiColor, StdIn }
 import scala.util.DynamicVariable
 
 /** Implements functionality for
@@ -169,20 +169,20 @@ private[scala] abstract class DeprecatedConsole {
   protected def setErrDirect(err: PrintStream): Unit
   protected def setInDirect(in: BufferedReader): Unit
 
-  @deprecated("Use the method in scala.io.ReadStdin", "2.11.0") def readBoolean(): Boolean                     = ReadStdin.readBoolean()
-  @deprecated("Use the method in scala.io.ReadStdin", "2.11.0") def readByte(): Byte                           = ReadStdin.readByte()
-  @deprecated("Use the method in scala.io.ReadStdin", "2.11.0") def readChar(): Char                           = ReadStdin.readChar()
-  @deprecated("Use the method in scala.io.ReadStdin", "2.11.0") def readDouble(): Double                       = ReadStdin.readDouble()
-  @deprecated("Use the method in scala.io.ReadStdin", "2.11.0") def readFloat(): Float                         = ReadStdin.readFloat()
-  @deprecated("Use the method in scala.io.ReadStdin", "2.11.0") def readInt(): Int                             = ReadStdin.readInt()
-  @deprecated("Use the method in scala.io.ReadStdin", "2.11.0") def readLine(): String                         = ReadStdin.readLine()
-  @deprecated("Use the method in scala.io.ReadStdin", "2.11.0") def readLine(text: String, args: Any*): String = ReadStdin.readLine(text, args: _*)
-  @deprecated("Use the method in scala.io.ReadStdin", "2.11.0") def readLong(): Long                           = ReadStdin.readLong()
-  @deprecated("Use the method in scala.io.ReadStdin", "2.11.0") def readShort(): Short                         = ReadStdin.readShort()
-  @deprecated("Use the method in scala.io.ReadStdin", "2.11.0") def readf(format: String): List[Any]           = ReadStdin.readf(format)
-  @deprecated("Use the method in scala.io.ReadStdin", "2.11.0") def readf1(format: String): Any                = ReadStdin.readf1(format)
-  @deprecated("Use the method in scala.io.ReadStdin", "2.11.0") def readf2(format: String): (Any, Any)         = ReadStdin.readf2(format)
-  @deprecated("Use the method in scala.io.ReadStdin", "2.11.0") def readf3(format: String): (Any, Any, Any)    = ReadStdin.readf3(format)
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readBoolean(): Boolean                     = StdIn.readBoolean()
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readByte(): Byte                           = StdIn.readByte()
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readChar(): Char                           = StdIn.readChar()
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readDouble(): Double                       = StdIn.readDouble()
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readFloat(): Float                         = StdIn.readFloat()
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readInt(): Int                             = StdIn.readInt()
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readLine(): String                         = StdIn.readLine()
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readLine(text: String, args: Any*): String = StdIn.readLine(text, args: _*)
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readLong(): Long                           = StdIn.readLong()
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readShort(): Short                         = StdIn.readShort()
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readf(format: String): List[Any]           = StdIn.readf(format)
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readf1(format: String): Any                = StdIn.readf1(format)
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readf2(format: String): (Any, Any)         = StdIn.readf2(format)
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readf3(format: String): (Any, Any, Any)    = StdIn.readf3(format)
 
   /** Sets the default output stream.
    *

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -15,7 +15,7 @@ import generic.CanBuildFrom
 import scala.annotation.{ elidable, implicitNotFound }
 import scala.annotation.elidable.ASSERTION
 import scala.language.{implicitConversions, existentials}
-import scala.io.ReadStdin
+import scala.io.StdIn
 
 /** The `Predef` object provides definitions that are accessible in all Scala
  *  compilation units without explicit qualification.
@@ -415,20 +415,20 @@ private[scala] trait DeprecatedPredef {
   @deprecated("Use `SeqCharSequence`", "2.11.0") def seqToCharSequence(xs: scala.collection.IndexedSeq[Char]): CharSequence = new SeqCharSequence(xs)
   @deprecated("Use `ArrayCharSequence`", "2.11.0") def arrayToCharSequence(xs: Array[Char]): CharSequence                   = new ArrayCharSequence(xs)
 
-  @deprecated("Use the method in `scala.io.ReadStdin`", "2.11.0") def readLine(): String                 = ReadStdin.readLine()
-  @deprecated("Use the method in `scala.io.ReadStdin`", "2.11.0") def readLine(text: String, args: Any*) = ReadStdin.readLine(text, args: _*)
-  @deprecated("Use the method in `scala.io.ReadStdin`", "2.11.0") def readBoolean()                      = ReadStdin.readBoolean()
-  @deprecated("Use the method in `scala.io.ReadStdin`", "2.11.0") def readByte()                         = ReadStdin.readByte()
-  @deprecated("Use the method in `scala.io.ReadStdin`", "2.11.0") def readShort()                        = ReadStdin.readShort()
-  @deprecated("Use the method in `scala.io.ReadStdin`", "2.11.0") def readChar()                         = ReadStdin.readChar()
-  @deprecated("Use the method in `scala.io.ReadStdin`", "2.11.0") def readInt()                          = ReadStdin.readInt()
-  @deprecated("Use the method in `scala.io.ReadStdin`", "2.11.0") def readLong()                         = ReadStdin.readLong()
-  @deprecated("Use the method in `scala.io.ReadStdin`", "2.11.0") def readFloat()                        = ReadStdin.readFloat()
-  @deprecated("Use the method in `scala.io.ReadStdin`", "2.11.0") def readDouble()                       = ReadStdin.readDouble()
-  @deprecated("Use the method in `scala.io.ReadStdin`", "2.11.0") def readf(format: String)              = ReadStdin.readf(format)
-  @deprecated("Use the method in `scala.io.ReadStdin`", "2.11.0") def readf1(format: String)             = ReadStdin.readf1(format)
-  @deprecated("Use the method in `scala.io.ReadStdin`", "2.11.0") def readf2(format: String)             = ReadStdin.readf2(format)
-  @deprecated("Use the method in `scala.io.ReadStdin`", "2.11.0") def readf3(format: String)             = ReadStdin.readf3(format)
+  @deprecated("Use the method in `scala.io.StdIn`", "2.11.0") def readLine(): String                 = StdIn.readLine()
+  @deprecated("Use the method in `scala.io.StdIn`", "2.11.0") def readLine(text: String, args: Any*) = StdIn.readLine(text, args: _*)
+  @deprecated("Use the method in `scala.io.StdIn`", "2.11.0") def readBoolean()                      = StdIn.readBoolean()
+  @deprecated("Use the method in `scala.io.StdIn`", "2.11.0") def readByte()                         = StdIn.readByte()
+  @deprecated("Use the method in `scala.io.StdIn`", "2.11.0") def readShort()                        = StdIn.readShort()
+  @deprecated("Use the method in `scala.io.StdIn`", "2.11.0") def readChar()                         = StdIn.readChar()
+  @deprecated("Use the method in `scala.io.StdIn`", "2.11.0") def readInt()                          = StdIn.readInt()
+  @deprecated("Use the method in `scala.io.StdIn`", "2.11.0") def readLong()                         = StdIn.readLong()
+  @deprecated("Use the method in `scala.io.StdIn`", "2.11.0") def readFloat()                        = StdIn.readFloat()
+  @deprecated("Use the method in `scala.io.StdIn`", "2.11.0") def readDouble()                       = StdIn.readDouble()
+  @deprecated("Use the method in `scala.io.StdIn`", "2.11.0") def readf(format: String)              = StdIn.readf(format)
+  @deprecated("Use the method in `scala.io.StdIn`", "2.11.0") def readf1(format: String)             = StdIn.readf1(format)
+  @deprecated("Use the method in `scala.io.StdIn`", "2.11.0") def readf2(format: String)             = StdIn.readf2(format)
+  @deprecated("Use the method in `scala.io.StdIn`", "2.11.0") def readf3(format: String)             = StdIn.readf3(format)
 }
 
 /** The `LowPriorityImplicits` class provides implicit values that

--- a/src/library/scala/io/StdIn.scala
+++ b/src/library/scala/io/StdIn.scala
@@ -7,7 +7,7 @@ import java.text.MessageFormat
  *  in the standard library, at least not in this idiosyncractic form.
  *  Factored into trait because it is better code structure regardless.
  */
-private[scala] trait ReadStdin {
+private[scala] trait StdIn {
   import scala.Console._
 
   /** Read a full line from the default input.  Returns `null` if the end of the
@@ -225,4 +225,4 @@ private[scala] trait ReadStdin {
   }
 }
 
-object ReadStdin extends ReadStdin { }
+object StdIn extends StdIn

--- a/test/files/run/Predef.readLine.scala
+++ b/test/files/run/Predef.readLine.scala
@@ -1,5 +1,5 @@
 import java.io.StringReader
-import scala.io.ReadStdin.readLine
+import scala.io.StdIn.readLine
 
 object Test extends App {
   Console.withIn(new StringReader("")) {


### PR DESCRIPTION
We don't need to say everything twice, methods are already prefixed
with “read”.
