### PR TITLE
SI-8167 readLine shold flush output before reading input

### DIFF
--- a/src/library/scala/io/ReadStdin.scala
+++ b/src/library/scala/io/ReadStdin.scala
@@ -17,7 +17,7 @@ private[scala] trait ReadStdin {
    */
   def readLine(): String = in.readLine()
 
-  /** Print formatted text to the default output and read a full line from the default input.
+  /** Print and flush formatted text to the default output, and read a full line from the default input.
    *  Returns `null` if the end of the input stream has been reached.
    *
    *  @param text the format of the text to print out, as in `printf`.
@@ -26,6 +26,7 @@ private[scala] trait ReadStdin {
    */
   def readLine(text: String, args: Any*): String = {
     printf(text, args: _*)
+    out.flush()
     readLine()
   }
 


### PR DESCRIPTION
As reported on scala-user:

> Using `scala.Predef.readLine(text: String, args: Any*)`
> on Windows causes strange behavior. If I am leaving some
> part of `text` unforced to be flushed (say, "---\nEnter new
>  expression >") then "Enter new expression >" flushed only
> after Enter press. Still, it works fine on Ubuntu and (seems like)
> on MacOS.
> 
> My workaround is to force `java.lang.System.out` (that readLine
> depends on to write welcome string) to flush output like
> "---\nEnter new expression >\n".

Review by @ichoran
