### PR TITLE
Add cross suffix customizability for modules

### DIFF
--- a/build-ant-macros.xml
+++ b/build-ant-macros.xml
@@ -23,15 +23,35 @@
     </sequential>
   </macrodef>
 
+  <!-- Set a property @{name}.cross to the actual cross suffix that should be
+	used when resolving the module "@{name}". If the (user-supplied)
+	@{name}.cross.suffix property exists then use that value, otherwise use
+	"_${scala.binary.version}". -->
+  <macrodef name="prepareCross">
+    <attribute name="name" />
+    <sequential>
+      <if>
+        <isset property="@{name}.cross.suffix" />
+        <then>
+          <property name="@{name}.cross" value="${@{name}.cross.suffix}" />
+        </then>
+        <else>
+          <property name="@{name}.cross" value="_${scala.binary.version}" />
+        </else>
+      </if>
+    </sequential>
+  </macrodef>
+
   <!-- Set property named @{name} to the jar resolved as @{jar}_${scala.binary.version}:jar.
            @{jar}_${scala.binary.version} must be a maven dependency. -->
   <macrodef name="propertyForCrossedArtifact">
     <attribute name="name"/>
     <attribute name="jar"/>
+    <attribute name="suffix" default="${@{name}.cross}"/>
     <sequential>
-      <readProperty name="@{name}" property="@{jar}_${scala.binary.version}:jar"/>
-      <readProperty name="@{name}-sources" property="@{jar}_${scala.binary.version}:java-source:sources"/>
-      <readProperty name="@{name}-javadoc" property="@{jar}_${scala.binary.version}:java-source:javadoc"/>
+      <readProperty name="@{name}" property="@{jar}@{suffix}:jar"/>
+      <readProperty name="@{name}-sources" property="@{jar}@{suffix}:java-source:sources"/>
+      <readProperty name="@{name}-javadoc" property="@{jar}@{suffix}:java-source:javadoc"/>
     </sequential>
   </macrodef>
 

--- a/build.xml
+++ b/build.xml
@@ -276,6 +276,16 @@ TODO:
 
       <artifact:remoteRepository id="extra-repo" url="${extra.repo.url}"/>
 
+      <!-- prepare, for each of the names below, the property "@{name}.cross", set to the
+           necessary cross suffix (usually something like "_2.11.0-M6". -->
+      <prepareCross name="scala-xml" />
+      <prepareCross name="scala-parser-combinators" />
+      <prepareCross name="scala-continuations-plugin" />
+      <prepareCross name="scala-continuations-library"/>
+      <prepareCross name="scala-swing"/>
+      <prepareCross name="scala-partest"/>
+      <prepareCross name="scalacheck"/>
+
       <!-- TODO: delay until absolutely necessary to allow minimal build, also move out partest dependency from scaladoc -->
       <artifact:dependencies pathId="partest.classpath" filesetId="partest.fileset" versionsId="partest.versions">
         <!-- uncomment the following if you're deploying your own partest locally -->
@@ -284,13 +294,13 @@ TODO:
             (we don't distribute partest with Scala, so the risk of sonatype and maven being out of synch is irrelevant):
           -->
         <artifact:remoteRepository refid="extra-repo"/>
-        <dependency groupId="org.scala-lang.modules" artifactId="scala-partest_${scala.binary.version}" version="${partest.version.number}" />
+        <dependency groupId="org.scala-lang.modules" artifactId="scala-partest${scala-partest.cross}" version="${partest.version.number}" />
       </artifact:dependencies>
       <copy-deps project="partest"/>
 
       <artifact:dependencies pathId="scalacheck.classpath" filesetId="scalacheck.fileset" versionsId="scalacheck.versions">
         <artifact:remoteRepository refid="extra-repo"/>
-        <dependency groupId="org.scalacheck"         artifactId="scalacheck_${scala.binary.version}"    version="${scalacheck.version.number}" />
+        <dependency groupId="org.scalacheck"         artifactId="scalacheck${scalacheck.cross}"    version="${scalacheck.version.number}" />
       </artifact:dependencies>
 
       <artifact:dependencies pathId="repl.deps.classpath" filesetId="repl.fileset" versionsId="repl.deps.versions">
@@ -302,11 +312,11 @@ TODO:
            must specify sourcesFilesetId, javadocFilesetId to download these types of artifacts -->
       <artifact:dependencies pathId="external-modules.deps.classpath" sourcesFilesetId="external-modules.sources.fileset" javadocFilesetId="external-modules.javadoc.fileset">
         <artifact:remoteRepository refid="extra-repo"/>
-        <dependency groupId="org.scala-lang.modules" artifactId="scala-xml_${scala.binary.version}" version="${scala-xml.version.number}"/>
-        <dependency groupId="org.scala-lang.modules" artifactId="scala-parser-combinators_${scala.binary.version}" version="${scala-parser-combinators.version.number}"/>
-        <dependency groupId="org.scala-lang.plugins" artifactId="scala-continuations-plugin_${scala.binary.version}"  version="${scala-continuations-plugin.version.number}"/>
-        <dependency groupId="org.scala-lang.plugins" artifactId="scala-continuations-library_${scala.binary.version}" version="${scala-continuations-library.version.number}"/>
-        <dependency groupId="org.scala-lang.modules" artifactId="scala-swing_${scala.binary.version}" version="${scala-swing.version.number}"/>
+        <dependency groupId="org.scala-lang.modules" artifactId="scala-xml${scala-xml.cross}" version="${scala-xml.version.number}"/>
+        <dependency groupId="org.scala-lang.modules" artifactId="scala-parser-combinators${scala-parser-combinators.cross}" version="${scala-parser-combinators.version.number}"/>
+        <dependency groupId="org.scala-lang.plugins" artifactId="scala-continuations-plugin${scala-continuations-plugin.cross}"  version="${scala-continuations-plugin.version.number}"/>
+        <dependency groupId="org.scala-lang.plugins" artifactId="scala-continuations-library${scala-continuations-library.cross}" version="${scala-continuations-library.version.number}"/>
+        <dependency groupId="org.scala-lang.modules" artifactId="scala-swing${scala-swing.cross}" version="${scala-swing.version.number}"/>
       </artifact:dependencies>
 
       <!-- External modules, excluding the core -->

--- a/build.xml
+++ b/build.xml
@@ -283,7 +283,7 @@ TODO:
       <prepareCross name="scala-continuations-plugin" />
       <prepareCross name="scala-continuations-library"/>
       <prepareCross name="scala-swing"/>
-      <prepareCross name="scala-partest"/>
+      <prepareCross name="partest"/>
       <prepareCross name="scalacheck"/>
 
       <!-- TODO: delay until absolutely necessary to allow minimal build, also move out partest dependency from scaladoc -->
@@ -294,7 +294,7 @@ TODO:
             (we don't distribute partest with Scala, so the risk of sonatype and maven being out of synch is irrelevant):
           -->
         <artifact:remoteRepository refid="extra-repo"/>
-        <dependency groupId="org.scala-lang.modules" artifactId="scala-partest${scala-partest.cross}" version="${partest.version.number}" />
+        <dependency groupId="org.scala-lang.modules" artifactId="scala-partest${partest.cross}" version="${partest.version.number}" />
       </artifact:dependencies>
       <copy-deps project="partest"/>
 


### PR DESCRIPTION
For each module whose version can be specified using
the property "xxx.version.number", it is now possible
to specify its cross version suffix by using an
optional property "xxx.cross.suffix".

If such a property is not defined, then continue to
use the string "_${scala.binary.version}", as before.

Review by @adriaanm
