### PR TITLE
Dist cleanup

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1663,7 +1663,7 @@ TODO:
       <fileset dir="${build-docs.dir}/library"/>
     </copy>
 
-    <copy toDir="${dist.dir}/doc/api" overwrite="true" flatten="true">
+    <copy toDir="${dist.dir}/api" overwrite="true" flatten="true">
       <file file="${scala-xml-javadoc}"/>
       <file file="${scala-parser-combinators-javadoc}"/>
       <file file="${scala-continuations-plugin-javadoc}"/>

--- a/src/build/maven/scala-actors-pom.xml
+++ b/src/build/maven/scala-actors-pom.xml
@@ -38,17 +38,6 @@
       <version>@VERSION@</version>
     </dependency>
   </dependencies>
-  <distributionManagement>
-    <repository>
-      <id>scala-tools.org</id>
-      <url>@RELEASE_REPOSITORY@</url>
-    </repository>
-    <snapshotRepository>
-      <id>scala-tools.org</id>
-      <url>@SNAPSHOT_REPOSITORY@</url>
-      <uniqueVersion>false</uniqueVersion>
-    </snapshotRepository>
-  </distributionManagement>
   <developers>
     <developer>
       <id>lamp</id>

--- a/src/build/maven/scala-compiler-doc-pom.xml
+++ b/src/build/maven/scala-compiler-doc-pom.xml
@@ -45,17 +45,6 @@
       <version>@PARSER_COMBINATORS_VERSION@</version>
     </dependency>
   </dependencies>
-  <distributionManagement>
-    <repository>
-      <id>scala-tools.org</id>
-      <url>@RELEASE_REPOSITORY@</url>
-    </repository>
-    <snapshotRepository>
-      <id>scala-tools.org</id>
-      <url>@SNAPSHOT_REPOSITORY@</url>
-      <uniqueVersion>false</uniqueVersion>
-    </snapshotRepository>
-  </distributionManagement>
   <developers>
     <developer>
       <id>lamp</id>

--- a/src/build/maven/scala-compiler-interactive-pom.xml
+++ b/src/build/maven/scala-compiler-interactive-pom.xml
@@ -35,17 +35,6 @@
       <version>@VERSION@</version>
     </dependency>
   </dependencies>
-  <distributionManagement>
-    <repository>
-      <id>scala-tools.org</id>
-      <url>@RELEASE_REPOSITORY@</url>
-    </repository>
-    <snapshotRepository>
-      <id>scala-tools.org</id>
-      <url>@SNAPSHOT_REPOSITORY@</url>
-      <uniqueVersion>false</uniqueVersion>
-    </snapshotRepository>
-  </distributionManagement>
   <developers>
     <developer>
       <id>lamp</id>

--- a/src/build/maven/scala-compiler-pom.xml
+++ b/src/build/maven/scala-compiler-pom.xml
@@ -39,7 +39,7 @@
       <artifactId>scala-reflect</artifactId>
       <version>@VERSION@</version>
     </dependency>
-    <!-- TODO modularize compiler: these dependencies will disappear then the compiler is modularized -->
+    <!-- TODO modularize compiler: these dependencies will disappear when the compiler is modularized -->
     <dependency> <!-- for scala-compiler-doc -->
       <groupId>org.scala-lang.modules</groupId>
       <artifactId>scala-xml_@SCALA_BINARY_VERSION@</artifactId>
@@ -57,17 +57,6 @@
       <optional>true</optional>
     </dependency>
   </dependencies>
-  <distributionManagement>
-    <repository>
-      <id>scala-tools.org</id>
-      <url>@RELEASE_REPOSITORY@</url>
-    </repository>
-    <snapshotRepository>
-      <id>scala-tools.org</id>
-      <url>@SNAPSHOT_REPOSITORY@</url>
-      <uniqueVersion>false</uniqueVersion>
-    </snapshotRepository>
-  </distributionManagement>
   <developers>
     <developer>
       <id>lamp</id>

--- a/src/build/maven/scala-dist-pom.xml
+++ b/src/build/maven/scala-dist-pom.xml
@@ -51,17 +51,6 @@
       <version>@JLINE_VERSION@</version>
     </dependency>
   </dependencies>
-  <distributionManagement>
-    <repository>
-      <id>scala-tools.org</id>
-      <url>@RELEASE_REPOSITORY@</url>
-    </repository>
-    <snapshotRepository>
-      <id>scala-tools.org</id>
-      <url>@SNAPSHOT_REPOSITORY@</url>
-      <uniqueVersion>false</uniqueVersion>
-    </snapshotRepository>
-  </distributionManagement>
   <developers>
     <developer>
       <id>lamp</id>

--- a/src/build/maven/scala-library-all-pom.xml
+++ b/src/build/maven/scala-library-all-pom.xml
@@ -75,17 +75,6 @@
       <version>@ACTORS_MIGRATION_VERSION@</version>
     </dependency>
   </dependencies>
-  <distributionManagement>
-    <repository>
-      <id>scala-tools.org</id>
-      <url>@RELEASE_REPOSITORY@</url>
-    </repository>
-    <snapshotRepository>
-      <id>scala-tools.org</id>
-      <url>@SNAPSHOT_REPOSITORY@</url>
-      <uniqueVersion>false</uniqueVersion>
-    </snapshotRepository>
-  </distributionManagement>
   <developers>
     <developer>
       <id>lamp</id>

--- a/src/build/maven/scala-library-pom.xml
+++ b/src/build/maven/scala-library-pom.xml
@@ -33,17 +33,6 @@
   </properties>
   <dependencies>
    </dependencies>
-  <distributionManagement>
-    <repository>
-      <id>scala-tools.org</id>
-      <url>@RELEASE_REPOSITORY@</url>
-    </repository>
-    <snapshotRepository>
-      <id>scala-tools.org</id>
-      <url>@SNAPSHOT_REPOSITORY@</url>
-      <uniqueVersion>false</uniqueVersion>
-    </snapshotRepository>
-  </distributionManagement>
   <developers>
     <developer>
       <id>lamp</id>

--- a/src/build/maven/scala-reflect-pom.xml
+++ b/src/build/maven/scala-reflect-pom.xml
@@ -38,17 +38,6 @@
       <version>@VERSION@</version>
     </dependency>
   </dependencies>
-  <distributionManagement>
-    <repository>
-      <id>scala-tools.org</id>
-      <url>@RELEASE_REPOSITORY@</url>
-    </repository>
-    <snapshotRepository>
-      <id>scala-tools.org</id>
-      <url>@SNAPSHOT_REPOSITORY@</url>
-      <uniqueVersion>false</uniqueVersion>
-    </snapshotRepository>
-  </distributionManagement>
   <developers>
     <developer>
       <id>lamp</id>

--- a/src/build/maven/scalap-pom.xml
+++ b/src/build/maven/scalap-pom.xml
@@ -35,17 +35,6 @@
       <version>@VERSION@</version>
     </dependency>
   </dependencies>
-  <distributionManagement>
-    <repository>
-      <id>scala-tools.org</id>
-      <url>@RELEASE_REPOSITORY@</url>
-    </repository>
-    <snapshotRepository>
-      <id>scala-tools.org</id>
-      <url>@SNAPSHOT_REPOSITORY@</url>
-      <uniqueVersion>false</uniqueVersion>
-    </snapshotRepository>
-  </distributionManagement>
   <developers>
     <developer>
       <id>lamp</id>


### PR DESCRIPTION
1. Figured out why we were packaging extraneous jars.
2. Removed <distributionManagement> from POMs. I could close the staged repo without the distributionManagement tag, and all the docs I've seen indicate it's a maven-publishing-client kind of thing (not necessary for publishing to maven central).

Review by @jsuereth (not urgent)
