### PR TITLE
Expose seq field for variable arity definitions

### DIFF
--- a/src/reflect/scala/reflect/api/StandardDefinitions.scala
+++ b/src/reflect/scala/reflect/api/StandardDefinitions.scala
@@ -214,6 +214,14 @@ trait StandardDefinitions {
     /** The module symbol of module `scala.Some`. */
     def SomeModule: ModuleSymbol
 
+    /** Function-like api that lets you acess symbol
+     *  of the definition with given arity and also look
+     *  through all known symbols via `seq`.
+     */
+    abstract class VarArityClassApi extends (Int => Symbol) {
+      def seq: Seq[ClassSymbol]
+    }
+
     /** Function-like object that maps arity to symbols for classes `scala.ProductX`.
      *   -  0th element is `Unit`
      *   -  1st element is `Product1`
@@ -222,7 +230,7 @@ trait StandardDefinitions {
      *   - 23nd element is `NoSymbol`
      *   - ...
      */
-    def ProductClass: Int => Symbol
+    def ProductClass: VarArityClassApi
 
     /** Function-like object that maps arity to symbols for classes `scala.FunctionX`.
      *   -  0th element is `Function0`
@@ -232,17 +240,17 @@ trait StandardDefinitions {
      *   - 23nd element is `NoSymbol`
      *   - ...
      */
-    def FunctionClass: Int => Symbol
+    def FunctionClass: VarArityClassApi
 
     /** Function-like object that maps arity to symbols for classes `scala.TupleX`.
      *   -  0th element is `NoSymbol`
-     *   -  1st element is `Product1`
+     *   -  1st element is `Tuple1`
      *   -  ...
-     *   - 22nd element is `Product22`
+     *   - 22nd element is `Tuple22`
      *   - 23nd element is `NoSymbol`
      *   - ...
      */
-    def TupleClass: Int => Symbol
+    def TupleClass: VarArityClassApi
 
     /** Contains Scala primitive value classes:
      *   - Byte

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -522,7 +522,7 @@ trait Definitions extends api.StandardDefinitions {
     def hasJavaMainMethod(sym: Symbol): Boolean =
       (sym.tpe member nme.main).alternatives exists isJavaMainMethod
 
-    class VarArityClass(name: String, maxArity: Int, countFrom: Int = 0, init: Option[ClassSymbol] = None) extends (Int => Symbol) {
+    class VarArityClass(name: String, maxArity: Int, countFrom: Int = 0, init: Option[ClassSymbol] = None) extends VarArityClassApi {
       private val offset = countFrom - init.size
       private def isDefinedAt(i: Int) = i < seq.length + offset && i >= offset
       val seq: IndexedSeq[ClassSymbol] = (init ++: countFrom.to(maxArity).map { i => getRequiredClass("scala." + name + i) }).toVector

--- a/test/files/run/var-arity-class-symbol.scala
+++ b/test/files/run/var-arity-class-symbol.scala
@@ -1,0 +1,19 @@
+import scala.reflect.runtime.universe._, definitions._
+object Test extends App {
+  // Tuples
+  assert(TupleClass.seq.size == 22)
+  assert(TupleClass(0) == NoSymbol)
+  assert(TupleClass(23) == NoSymbol)
+  assert((1 to 22).forall { i => TupleClass(i).name.toString == s"Tuple$i" })
+  // Functions
+  assert(FunctionClass.seq.size == 23)
+  assert(FunctionClass(-1) == NoSymbol)
+  assert(FunctionClass(23) == NoSymbol)
+  assert((0 to 22).forall { i => FunctionClass(i).name.toString == s"Function$i" })
+  // Products
+  assert(ProductClass.seq.size == 23)
+  assert(ProductClass(-1) == NoSymbol)
+  assert(ProductClass(0) == UnitClass)
+  assert(ProductClass(23) == NoSymbol)
+  assert((1 to 22).forall { i => ProductClass(i).name.toString == s"Product$i" })
+}


### PR DESCRIPTION
In 2.11 we've changed TupleClass, ProductClass and FunctionClass
endpoints to be exposed as (Int => Symbol) functions that never throw
exceptions but rather return NoSymbol instead of previous error-prone
indexed access on array that could explode.

While simplifying one use case (indexed access) it complicated
ability to check if symbol at hand is in fact a tuple, product or
function:

``` scala
  (1 to 22).map(TupleClass).toList.contains(symbol)
```

To cover this extra use case we add a seq method to the variable arity
class definitions that exposes a corresponding sequence of class symbols:

``` scala
  TupleClass.seq.contains(symbol)
```

review @retronym 
