### PR TITLE
an optimization for c.eval

### DIFF
--- a/src/compiler/scala/reflect/macros/contexts/Evals.scala
+++ b/src/compiler/scala/reflect/macros/contexts/Evals.scala
@@ -12,7 +12,12 @@ trait Evals {
   private lazy val evalImporter = ru.mkImporter(universe).asInstanceOf[ru.Importer { val from: universe.type }]
 
   def eval[T](expr: Expr[T]): T = {
-    val imported = evalImporter.importTree(expr.tree)
-    evalToolBox.eval(imported).asInstanceOf[T]
+    expr.tree match {
+      case global.Literal(global.Constant(value)) =>
+        value.asInstanceOf[T]
+      case _ =>
+        val imported = evalImporter.importTree(expr.tree)
+        evalToolBox.eval(imported).asInstanceOf[T]
+    }
   }
 }


### PR DESCRIPTION
People are very frequently using c.eval in order to obtain underlying
values of literals. Spinning up a new compiler for that modest purpose
is a gross waste of fossil fuels.
