### PR TITLE
SI-7275 allow flattening of blocks with ..$ 

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -33,7 +33,7 @@ trait ParsersCommon extends ScannersCommon { self =>
   import global.{currentUnit => _, _}
 
   def newLiteral(const: Any) = Literal(Constant(const))
-  def literalUnit            = newLiteral(())
+  def literalUnit            = gen.mkSyntheticUnit()
 
   /** This is now an abstract class, only to work around the optimizer:
    *  methods in traits are never inlined.

--- a/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
@@ -189,7 +189,9 @@ trait Reifiers { self: Quasiquotes =>
         mirrorBuildCall(nme.SyntacticBlock, tree)
       case Block(Nil, other) =>
         reifyTree(other)
-      case SyntacticBlock(stats @ (_ :: _ :: _)) =>
+      // Syntactic block always matches so we have to be careful
+      // not to cause infinite recursion.
+      case block @ SyntacticBlock(stats) if block.isInstanceOf[Block] =>
         reifyBuildCall(nme.SyntacticBlock, stats)
       case Try(block, catches, finalizer) =>
         reifyBuildCall(nme.SyntacticTry, block, catches, finalizer)

--- a/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
@@ -185,9 +185,9 @@ trait Reifiers { self: Quasiquotes =>
         reifyBuildCall(nme.SyntacticFunction, args, body)
       case SyntacticIdent(name, isBackquoted) =>
         reifyBuildCall(nme.SyntacticIdent, name, isBackquoted)
-      case Block(Nil, Placeholder(Hole(tree, DotDot))) =>
+      case Q(Placeholder(Hole(tree, DotDot))) =>
         mirrorBuildCall(nme.SyntacticBlock, tree)
-      case Block(Nil, other) =>
+      case Q(other) =>
         reifyTree(other)
       // Syntactic block always matches so we have to be careful
       // not to cause infinite recursion.

--- a/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
@@ -189,7 +189,7 @@ trait Reifiers { self: Quasiquotes =>
         mirrorBuildCall(nme.SyntacticBlock, tree)
       case Block(Nil, other) =>
         reifyTree(other)
-      case SyntacticBlock(stats) if stats.size > 1 =>
+      case SyntacticBlock(stats @ (_ :: _ :: _)) =>
         reifyBuildCall(nme.SyntacticBlock, stats)
       case Try(block, catches, finalizer) =>
         reifyBuildCall(nme.SyntacticTry, block, catches, finalizer)

--- a/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
@@ -189,8 +189,8 @@ trait Reifiers { self: Quasiquotes =>
         mirrorBuildCall(nme.SyntacticBlock, tree)
       case Block(Nil, other) =>
         reifyTree(other)
-      case Block(stats, last) =>
-        reifyBuildCall(nme.SyntacticBlock, stats :+ last)
+      case SyntacticBlock(stats) if stats.size > 1 =>
+        reifyBuildCall(nme.SyntacticBlock, stats)
       case Try(block, catches, finalizer) =>
         reifyBuildCall(nme.SyntacticTry, block, catches, finalizer)
       case Match(selector, cases) =>

--- a/src/reflect/scala/reflect/api/BuildUtils.scala
+++ b/src/reflect/scala/reflect/api/BuildUtils.scala
@@ -72,6 +72,8 @@ private[reflect] trait BuildUtils { self: Universe =>
 
     def setSymbol[T <: Tree](tree: T, sym: Symbol): T
 
+    def toStats(tree: Tree): List[Tree]
+
     def mkAnnotation(tree: Tree): Tree
 
     def mkAnnotation(trees: List[Tree]): List[Tree]

--- a/src/reflect/scala/reflect/internal/BuildUtils.scala
+++ b/src/reflect/scala/reflect/internal/BuildUtils.scala
@@ -61,6 +61,8 @@ trait BuildUtils { self: SymbolTable =>
 
     def setSymbol[T <: Tree](tree: T, sym: Symbol): T = { tree.setSymbol(sym); tree }
 
+    def toStats(tree: Tree): List[Tree] = SyntacticBlock.unapply(tree).get
+
     def mkAnnotation(tree: Tree): Tree = tree match {
       case SyntacticNew(Nil, SyntacticApplied(SyntacticTypeApplied(_, _), _) :: Nil, noSelfType, Nil) =>
         tree

--- a/src/reflect/scala/reflect/internal/BuildUtils.scala
+++ b/src/reflect/scala/reflect/internal/BuildUtils.scala
@@ -385,6 +385,8 @@ trait BuildUtils { self: SymbolTable =>
       def apply(stats: List[Tree]): Tree = gen.mkBlock(stats)
 
       def unapply(tree: Tree): Option[List[Tree]] = tree match {
+        case EmptyTree => Some(Nil)
+        case self.Block(stats, expr) if expr.hasAttachment[SyntheticUnitAttachment.type] => Some(stats)
         case self.Block(stats, expr) => Some(stats :+ expr)
         case _ if tree.isTerm => Some(tree :: Nil)
         case _ => None

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -625,6 +625,7 @@ trait Definitions extends api.StandardDefinitions {
     def isBlackboxMacroBundleType(tp: Type) =
       isMacroBundleType(tp) && (macroBundleParamInfo(tp) <:< BlackboxContextClass.tpe)
 
+    def isListType(tp: Type)     = tp <:< classExistentialType(ListClass)
     def isIterableType(tp: Type) = tp <:< classExistentialType(IterableClass)
 
     // These "direct" calls perform no dealiasing. They are most needed when

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -36,6 +36,10 @@ trait StdAttachments {
    */
   case object ForAttachment extends PlainAttachment
 
+  /** Identifies unit constants which were inserted by the compiler.
+   */
+  case object SyntheticUnitAttachment extends PlainAttachment
+
   /** Untyped list of subpatterns attached to selector dummy. */
   case class SubpatternsAttachment(patterns: List[Tree])
 }

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -36,7 +36,7 @@ trait StdAttachments {
    */
   case object ForAttachment extends PlainAttachment
 
-  /** Identifies unit constants which were inserted by the compiler.
+  /** Identifies unit constants which were inserted by the compiler (e.g. gen.mkBlock)
    */
   case object SyntheticUnitAttachment extends PlainAttachment
 

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -750,6 +750,7 @@ trait StdNames {
     val toArray: NameType              = "toArray"
     val toList: NameType               = "toList"
     val toObjectArray : NameType       = "toObjectArray"
+    val toStats: NameType              = "toStats"
     val TopScope: NameType             = "TopScope"
     val toString_ : NameType           = "toString"
     val toTypeConstructor: NameType    = "toTypeConstructor"

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -447,7 +447,7 @@ abstract class TreeGen extends macros.TreeBuilder {
   /** Create block of statements `stats`  */
   def mkBlock(stats: List[Tree]): Tree =
     if (stats.isEmpty) Literal(Constant(()))
-    else if (!stats.last.isTerm) Block(stats, Literal(Constant(())))
+    else if (!stats.last.isTerm) Block(stats, Literal(Constant(())).updateAttachment(SyntheticUnitAttachment))
     else if (stats.length == 1) stats.head
     else Block(stats.init, stats.last)
 

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -342,7 +342,7 @@ abstract class TreeGen extends macros.TreeBuilder {
       }
       param
     }
-    
+
     val (edefs, rest) = body span treeInfo.isEarlyDef
     val (evdefs, etdefs) = edefs partition treeInfo.isEarlyValDef
     val gvdefs = evdefs map {
@@ -381,11 +381,11 @@ abstract class TreeGen extends macros.TreeBuilder {
     }
     constr foreach (ensureNonOverlapping(_, parents ::: gvdefs, focus = false))
     // Field definitions for the class - remove defaults.
-    
+
     val fieldDefs = vparamss.flatten map (vd => {
       val field = copyValDef(vd)(mods = vd.mods &~ DEFAULTPARAM, rhs = EmptyTree)
       // Prevent overlapping of `field` end's position with default argument's start position.
-      // This is needed for `Positions.Locator(pos).traverse` to return the correct tree when 
+      // This is needed for `Positions.Locator(pos).traverse` to return the correct tree when
       // the `pos` is a point position with all its values equal to `vd.rhs.pos.start`.
       if(field.pos.isRange && vd.rhs.pos.isRange) field.pos = field.pos.withEnd(vd.rhs.pos.start - 1)
       field
@@ -444,13 +444,23 @@ abstract class TreeGen extends macros.TreeBuilder {
   def mkFunctionTypeTree(argtpes: List[Tree], restpe: Tree): Tree =
     AppliedTypeTree(rootScalaDot(newTypeName("Function" + argtpes.length)), argtpes ::: List(restpe))
 
+  /** Create a literal unit tree that is inserted by the compiler but not
+   *  written by end user. It's important to distinguish the two so that
+   *  quasiquotes can strip synthetic ones away.
+   */
+  def mkSyntheticUnit() = Literal(Constant(())).updateAttachment(SyntheticUnitAttachment)
+
   /** Create block of statements `stats`  */
   def mkBlock(stats: List[Tree]): Tree =
     if (stats.isEmpty) Literal(Constant(()))
-    else if (!stats.last.isTerm) Block(stats, Literal(Constant(())).updateAttachment(SyntheticUnitAttachment))
+    else if (!stats.last.isTerm) Block(stats, mkSyntheticUnit())
     else if (stats.length == 1) stats.head
     else Block(stats.init, stats.last)
 
+  /** Create a block that wraps multiple statements but don't
+   *  do any wrapping if there is just one statement. Used by
+   *  quasiquotes, macro c.parse api and toolbox.
+   */
   def mkTreeOrBlock(stats: List[Tree]) = stats match {
     case Nil         => EmptyTree
     case head :: Nil => head

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -58,6 +58,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.CompoundTypeTreeOriginalAttachment
     this.BackquotedIdentifierAttachment
     this.ForAttachment
+    this.SyntheticUnitAttachment
     this.SubpatternsAttachment
     this.noPrint
     this.typeDebug

--- a/test/files/scalacheck/quasiquotes/ErrorProps.scala
+++ b/test/files/scalacheck/quasiquotes/ErrorProps.scala
@@ -52,13 +52,6 @@ object ErrorProps extends QuasiquoteProperties("errors") {
       StringContext("\"", "\"").q(x)
     """)
 
-  property("expected different cardinality") = fails(
-    "Can't splice List[reflect.runtime.universe.Tree] with ..., consider using ..",
-    """
-      val args: List[Tree] = Nil
-      q"f(...$args)"
-    """)
-
   property("non-liftable type ..") = fails(
     "Can't splice List[StringBuilder] with .., consider omitting the dots or providing an implicit instance of Liftable[StringBuilder]",
     """
@@ -88,13 +81,6 @@ object ErrorProps extends QuasiquoteProperties("errors") {
     """
       val xs = List(List(q"x", q"x"))
       q"$xs"
-    """)
-
-  property("use zero card") = fails(
-    "Can't splice reflect.runtime.universe.Tree with .., consider omitting the dots",
-    """
-      val t = EmptyTree
-      q"f(..$t)"
     """)
 
   property("not liftable or natively supported") = fails(


### PR DESCRIPTION
This commit extends current splicing rules to allow flattening of
trees into other trees.

Without such support it is impossible to correctly use vals with
patterns and use it in other location as they could expand into
multiple-statement blocks:

``` scala
    scala> q"val (a, b) = (1, 2)"
    res0: reflect.runtime.universe.Tree =
    {
      <synthetic> <artifact> private[this] val x$1 = scala.Tuple2(1, 2):
    @scala.unchecked match {
        case scala.Tuple2((a @ _), (b @ _)) => scala.Tuple2(a, b)
      };
      val a = x$1._1;
      val b = x$1._2;
      ()
    }

    scala> q"..$res0; println(a + b)"
    res1: reflect.runtime.universe.Tree =
    {
      <synthetic> <artifact> private[this] val x$1 = scala.Tuple2(1, 2):
    @scala.unchecked match {
        case scala.Tuple2((a @ _), (b @ _)) => scala.Tuple2(a, b)
      };
      val a = x$1._1;
      val b = x$1._2;
      println(a.$plus(b))
    }
```

review by @xeno-by
