### PR TITLE
SI-8092 Try to verify f-interpolator format

### DIFF
--- a/test/files/neg/t8092.check
+++ b/test/files/neg/t8092.check
@@ -1,0 +1,4 @@
+t8092.scala:3: error: Bad format: java.util.IllegalFormatPrecisionException: 2
+  def k = f"${0x1234}%.2x"  // DNC
+          ^
+one error found

--- a/test/files/neg/t8092.scala
+++ b/test/files/neg/t8092.scala
@@ -1,0 +1,5 @@
+
+trait S {
+  def k = f"${0x1234}%.2x"  // DNC
+  //FlueTest.scala:15: Bad format: java.util.IllegalFormatPrecisionException: 2
+}


### PR DESCRIPTION
There is a private parse routine on Formatter in OpenJDK,
so use it if it's there to verify the format string.

Otherwise, try performing the format with dummy arguments.
