### PR TITLE
Preliminary support for building and testing with Java 8

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -411,8 +411,12 @@ TODO:
     <condition property="has.java7">
         <equals arg1="${ant.java.version}" arg2="1.7"/>
     </condition>
+    <condition property="has.java8">
+        <equals arg1="${ant.java.version}" arg2="1.8"/>
+    </condition>
     <condition property="has.unsupported.jdk">
        <not><or>
+         <isset property="has.java8" />
          <isset property="has.java7" />
          <isset property="has.java6" />
        </or></not>

--- a/test/files/filters
+++ b/test/files/filters
@@ -4,3 +4,5 @@ Java HotSpot\(TM\) .* warning:
 # Hotspot receiving VM options through the $_JAVA_OPTIONS
 # env variable outputs them on stderr
 Picked up _JAVA_OPTIONS:
+# Filter out a message caused by this bug: http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=8021205
+objc\[\d+\]: Class JavaLaunchHelper is implemented in both .* and .*\. One of the two will be used\. Which one is undefined\.

--- a/test/files/neg/abstract-report2.check
+++ b/test/files/neg/abstract-report2.check
@@ -61,7 +61,7 @@ it has 13 unimplemented members.
 
 class Baz[T] extends Collection[T]
       ^
-abstract-report2.scala:11: error: class Dingus needs to be abstract, since:
+abstract-report2.scala:15: error: class Dingus needs to be abstract, since:
 it has 24 unimplemented members.
 /** As seen from class Dingus, the missing signatures are as follows.
  *  For convenience, these are usable as stub implementations.
@@ -84,9 +84,6 @@ it has 24 unimplemented members.
   def toIterator: Iterator[(Set[Int], String)] = ???
   def toStream: Stream[(Set[Int], String)] = ???
 
-  // Members declared in scala.math.Ordering
-  def compare(x: List[Int],y: List[Int]): Int = ???
-
   // Members declared in scala.collection.TraversableOnce
   def copyToArray[B >: (Set[Int], String)](xs: Array[B],start: Int,len: Int): Unit = ???
   def exists(p: ((Set[Int], String)) => Boolean): Boolean = ???
@@ -97,6 +94,9 @@ it has 24 unimplemented members.
   def isEmpty: Boolean = ???
   def seq: scala.collection.TraversableOnce[(Set[Int], String)] = ???
   def toTraversable: Traversable[(Set[Int], String)] = ???
+
+  // Members declared in Xyz
+  def foo(x: List[Int]): Boolean = ???
 
 class Dingus extends Bippy[String, Set[Int], List[Int]]
       ^

--- a/test/files/neg/abstract-report2.scala
+++ b/test/files/neg/abstract-report2.scala
@@ -6,6 +6,10 @@ class Bar extends Collection[List[_ <: String]]
 
 class Baz[T] extends Collection[T]
 
-trait Bippy[T1, T2, T3] extends Collection[T1] with TraversableOnce[(T2, String)] with Ordering[T3]
+trait Xyz[T] {
+  def foo(x: T): Boolean
+}
+
+trait Bippy[T1, T2, T3] extends Collection[T1] with TraversableOnce[(T2, String)] with Xyz[T3]
 
 class Dingus extends Bippy[String, Set[Int], List[Int]]


### PR DESCRIPTION
A few straightforward fixes of problems that arise when we try to build and test master with Java 8.

There are more test failures that are Java 8-specific but we need a release of partest that includes scala/scala-partest#14 first.
