### PR TITLE
SI-3600 Allow annotations on package objects

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2664,8 +2664,7 @@ self =>
     }
 
     /** Hook for IDE, for top-level classes/objects. */
-    def topLevelTmplDef: Tree = {
-      val annots = annotations(skipNewLines = true)
+    def topLevelTmplDef(annots: List[Tree]): Tree = {
       val pos    = caseAwareTokenOffset
       val mods   = modifiers() withAnnotations annots
       tmplDef(pos, mods)
@@ -2764,8 +2763,8 @@ self =>
      *    }
      *  }}}
      */
-    def packageObjectDef(start: Offset): PackageDef = {
-      val defn   = objectDef(in.offset, NoMods)
+    def packageObjectDef(start: Offset, annots: List[Tree] = Nil): PackageDef = {
+      val defn   = objectDef(in.offset, NoMods withAnnotations annots)
       val pidPos = o2p(defn.pos.startOrPoint)
       val pkgPos = r2p(start, pidPos.point)
       gen.mkPackageObject(defn, pidPos, pkgPos)
@@ -2942,7 +2941,7 @@ self =>
      *  TopStatSeq ::= TopStat {semi TopStat}
      *  TopStat ::= Annotations Modifiers TmplDef
      *            | Packaging
-     *            | package object objectDef
+     *            | Annotations package object objectDef
      *            | Import
      *            |
      *  }}}
@@ -2954,8 +2953,16 @@ self =>
       case IMPORT =>
         in.flushDoc
         importClause()
-      case _ if isAnnotation || isTemplateIntro || isModifier =>
-        joinComment(topLevelTmplDef :: Nil)
+      case _ if isAnnotation =>
+        val annots = annotations(skipNewLines = true)
+        in.token match {
+          case PACKAGE =>
+            joinComment(packageObjectDef(in.skipToken(), annots) :: Nil)
+          case _ =>
+            joinComment(topLevelTmplDef(annots) :: Nil)
+        }
+      case _ if isTemplateIntro || isModifier =>
+        joinComment(topLevelTmplDef(Nil) :: Nil)
     }
 
     /** {{{

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -311,6 +311,8 @@ abstract class SymbolTable extends macros.Universe
         openPackageModule(p, dest)
       }
     }
+    // copy annotations from package object symbol to package module symbol
+    dest.sourceModule withAnnotations container.annotations
   }
 
   /** Convert array parameters denoting a repeated parameter of a Java method

--- a/test/files/neg/t3209.check
+++ b/test/files/neg/t3209.check
@@ -1,4 +1,4 @@
-t3209.scala:2: error: expected start of definition
+t3209.scala:2: error: identifier expected but eof found.
 package test
-^
+            ^
 one error found

--- a/test/files/run/package-annot-compiler.scala
+++ b/test/files/run/package-annot-compiler.scala
@@ -1,0 +1,46 @@
+import scala.tools.partest.CompilerTest
+
+object Test extends CompilerTest {
+
+  override def extraSettings: String = "-usejavacp -nowarn -Ystop-after:typer"
+
+  override def code =
+    // A package object with an annotation. We will check that both
+    // symbols have the annotations set
+    """
+    package foo
+
+    import scala.annotation.StaticAnnotation
+    class annot extends StaticAnnotation
+
+    @annot
+    package object bar {
+      def value = 1
+    }
+    """.trim
+
+  def check(source: String, unit: global.CompilationUnit): Unit = {
+    import global._
+
+    // Package symbol
+    val packageSym = rootMirror.staticPackage("foo.bar")
+    // Package object symbol
+    val poSym = rootMirror.staticModule("foo.bar.package")
+
+    // Type of annotation
+    val annotTpe = rootMirror.staticClass("foo.annot").tpe
+
+    // Check annotation is on package object
+    assert(poSym.annotations match {
+      case List(Annotation(`annotTpe`, _, _)) => true
+      case _ => false
+    })
+
+    // Check annotation is on package
+    assert(packageSym.annotations match {
+      case List(Annotation(`annotTpe`, _, _)) => true
+      case _ => false
+    })
+  }
+
+}

--- a/test/files/run/package-annot-loaded/package_1.scala
+++ b/test/files/run/package-annot-loaded/package_1.scala
@@ -1,0 +1,11 @@
+package foo {
+
+  import scala.annotation.StaticAnnotation
+  class annot extends StaticAnnotation
+
+  @annot
+  package object bar {
+    def one = 1
+  }
+
+}

--- a/test/files/run/package-annot-loaded/test_2.scala
+++ b/test/files/run/package-annot-loaded/test_2.scala
@@ -1,0 +1,35 @@
+import scala.tools.partest.CompilerTest
+
+object Test extends CompilerTest {
+
+  override def extraSettings: String = "-usejavacp -nowarn -Ystop-after:typer"
+
+  // Compiler doesn't compile anything. We just check that package
+  // symbol contains annotations when loaded from class files
+  override def code = ""
+
+  def check(source: String, unit: global.CompilationUnit): Unit = {
+    import global._
+
+    // Package symbol
+    val packageSym = rootMirror.staticPackage("foo.bar")
+    // Package object symbol
+    val poSym = rootMirror.staticModule("foo.bar.package")
+
+    // Type of annotation
+    val annotTpe = rootMirror.staticClass("foo.annot").tpe
+
+    // Check annotation is on package object
+    assert(poSym.annotations match {
+      case List(Annotation(`annotTpe`, _, _)) => true
+      case _ => false
+    })
+
+    // Check annotation is on package
+    assert(packageSym.annotations match {
+      case List(Annotation(`annotTpe`, _, _)) => true
+      case _ => false
+    })
+  }
+
+}

--- a/test/files/run/package-annot-refl.scala
+++ b/test/files/run/package-annot-refl.scala
@@ -1,0 +1,37 @@
+package foo {
+
+  import scala.annotation.StaticAnnotation
+  class annot(val x: Any) extends StaticAnnotation
+
+  @annot("hello world")
+  package object bar {
+    def one = 1
+  }
+
+}
+
+object Test extends App {
+  import scala.reflect.runtime.universe._
+  import scala.reflect.runtime.{ currentMirror => mirror }
+
+  // Package symbol
+  val packageSym = mirror.staticPackage("foo.bar")
+  // Package object symbol
+  val poSym = mirror.staticModule("foo.bar.package")
+
+  // Type of annotation
+  val annotTpe = typeOf[foo.annot]
+
+  // Check annotation is on package object
+  assert(poSym.annotations match {
+    case List(Annotation(`annotTpe`, _, _)) => true
+    case _ => false
+  })
+
+  // Check annotation is on package
+  assert(packageSym.annotations match {
+    case List(Annotation(`annotTpe`, _, _)) => true
+    case _ => false
+  })
+
+}


### PR DESCRIPTION
This will desugar annotations on package objects to the object `package` which is generated. Further, it will add the annotations to the package symbol.
