### PR TITLE
SI-1503 don't assume unsound type for ident/literal patterns

### DIFF
--- a/src/compiler/scala/reflect/reify/codegen/GenTypes.scala
+++ b/src/compiler/scala/reflect/reify/codegen/GenTypes.scala
@@ -34,9 +34,9 @@ trait GenTypes {
     if (tsym.isClass && tpe == tsym.typeConstructor && tsym.isStatic)
       Select(Select(reify(tsym), nme.asType), nme.toTypeConstructor)
     else tpe match {
-      case tpe @ NoType =>
+      case tpe : NoType.type =>
         reifyMirrorObject(tpe)
-      case tpe @ NoPrefix =>
+      case tpe : NoPrefix.type =>
         reifyMirrorObject(tpe)
       case tpe @ ThisType(root) if root.isRoot =>
         mirrorBuildCall(nme.thisPrefix, mirrorMirrorSelect(nme.RootClass))

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -16,6 +16,53 @@ trait TreeAndTypeAnalysis extends Debugging {
   import definitions._
   import analyzer.Typer
 
+  /** Compute the type T implied for a value `v` matched by a pattern `pat` (with expected type `pt`).
+   *
+   * Usually, this is the pattern's type because pattern matching implies instance-of checks.
+   *
+   * However, Stable Identifier and Literal patterns are matched using `==`,
+   * which does not imply a type for the binder that binds the matched value.
+   *
+   * See SI-1503, SI-5024: don't cast binders to types we're not sure they have
+   *
+   * TODO: update spec as follows (deviation between `**`):
+   *
+   *   A pattern binder x@p consists of a pattern variable x and a pattern p.
+   *   The type of the variable x is the static type T **IMPLIED BY** the pattern p.
+   *   This pattern matches any value v matched by the pattern p
+   *     **Deleted: , provided the run-time type of v is also an instance of T, **
+   *   and it binds the variable name to that value.
+   *
+   *   Addition:
+   *     A pattern `p` _implies_ a type `T` if the pattern matches only values of the type `T`.
+   */
+  def binderTypeImpliedByPattern(pat: Tree, pt: Type, binder: Symbol): Type =
+    pat match {
+      // because `==` decides whether these patterns match, stable identifier patterns (ident or selection)
+      // do not contribute any type information (beyond the pattern's expected type)
+      // e.g., in case x@Nil => x --> all we know about `x` is that it satisfies Nil == x, which could be anything
+      case Ident(_) | Select(_, _) =>
+        if (settings.future) pt
+        else {
+          // TODO: don't warn unless this unsound assumption is actually used in a cast
+          // I tried annotating the type returned here with an internal annotation,
+          // and catching it in the patmat backend when used in a cast,
+          // but the annotation didn't bubble up --> delaying
+          if (!(pt <:< pat.tpe))
+            global.currentUnit.deprecationWarning(pat.pos,
+              sm"""Typing of identifier patterns will become more conservative (see SI-1503).
+                  |Value ${binder.name} (the value matched by $pat) is wrongly assumed to have type ${pat.tpe},
+                  |whereas we can only safely count on it having type $pt, as the pattern is matched using ==.""")
+          pat.tpe // TODO: withAnnotation UnsoundAssumptionAnnotation
+        }
+
+
+      // the other patterns imply type tests, so we can safely assume the binder has the pattern's type when the pattern matches
+      // concretely, a literal, type pattern, a case class (the constructor's result type) or extractor (the unapply's argument type) all imply type tests
+      // (and, inductively, an alternative)
+      case _ => pat.tpe
+    }
+
   // we use subtyping as a model for implication between instanceof tests
   // i.e., when S <:< T we assume x.isInstanceOf[S] implies x.isInstanceOf[T]
   // unfortunately this is not true in general:

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4098,9 +4098,10 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             }
 
             val body1 = typed(body, mode, pt)
+            val impliedType = patmat.binderTypeImpliedByPattern(body1, pt, sym) // SI-1503, SI-5204
             val symTp =
-              if (treeInfo.isSequenceValued(body)) seqType(body1.tpe)
-              else body1.tpe
+              if (treeInfo.isSequenceValued(body)) seqType(impliedType)
+              else impliedType
             sym setInfo symTp
 
             // have to imperatively set the symbol for this bind to keep it in sync with the symbols used in the body of a case

--- a/test/files/neg/t1503.check
+++ b/test/files/neg/t1503.check
@@ -1,0 +1,8 @@
+t1503.scala:7: warning: Typing of identifier patterns will become more conservative (see SI-1503).
+Value n (the value matched by Whatever) is wrongly assumed to have type Whatever.type,
+whereas we can only safely count on it having type Any, as the pattern is matched using ==.
+  def matchWhateverCCE(x: Any) = x match { case n @ Whatever => n }
+                                                    ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/t1503.flags
+++ b/test/files/neg/t1503.flags
@@ -1,0 +1,1 @@
+-deprecation -Xfatal-warnings

--- a/test/files/neg/t1503.scala
+++ b/test/files/neg/t1503.scala
@@ -1,0 +1,8 @@
+object Whatever {
+  override def equals(x: Any) = true
+}
+
+class Test {
+  // when left to its own devices, and not under -Xfuture, the return type is Whatever.type
+  def matchWhateverCCE(x: Any) = x match { case n @ Whatever => n }
+}

--- a/test/files/run/t1503.check
+++ b/test/files/run/t1503.check
@@ -1,0 +1,2 @@
+warning: there were 2 deprecation warning(s); re-run with -deprecation for details
+whoops

--- a/test/files/run/t1503.scala
+++ b/test/files/run/t1503.scala
@@ -1,0 +1,20 @@
+object Whatever {
+  override def equals(x: Any) = true
+}
+
+object Test extends App {
+  // this should make it abundantly clear Any is the best return type we can guarantee
+  def matchWhatever(x: Any): Any = x match { case n @ Whatever => n }
+  // when left to its own devices, and not under -Xfuture, the return type is Whatever.type
+  def matchWhateverCCE(x: Any) = x match { case n @ Whatever => n }
+
+  // just to exercise it a bit
+  assert(matchWhatever(1) == 1)
+  assert(matchWhatever("1") == "1")
+
+  try {
+    matchWhateverCCE("1"): Whatever.type
+  } catch {
+    case _: ClassCastException => println("whoops")
+  }
+}

--- a/test/files/run/t1503_future.flags
+++ b/test/files/run/t1503_future.flags
@@ -1,0 +1,1 @@
+-Xfuture

--- a/test/files/run/t1503_future.scala
+++ b/test/files/run/t1503_future.scala
@@ -1,0 +1,17 @@
+object Whatever {
+  override def equals(x: Any) = true
+}
+
+object Test extends App {
+  // this should make it abundantly clear Any is the best return type we can guarantee
+  def matchWhatever(x: Any): Any = x match { case n @ Whatever => n }
+  // when left to its own devices, and not under -Xfuture, the return type is Whatever.type
+  def matchWhateverCCE(x: Any) = x match { case n @ Whatever => n }
+
+  // just to exercise it a bit
+  assert(matchWhatever(1) == 1)
+  assert(matchWhatever("1") == "1")
+
+  assert(matchWhateverCCE(1) == 1)
+  assert(matchWhateverCCE("1") == "1")
+}


### PR DESCRIPTION
What type should a variable bound to the value matched by a pattern have?
To avoid CCEs, it should be a type that's implied by the matching
semantics of the pattern.

Usually, the type implied by a pattern matching a certain value
is the pattern's type, because pattern matching implies instance-of checks.

However, Stable Identifier and Literal patterns are matched using `==`,
which does not imply a type for the binder that binds the matched value.

The change in type checking due to this fix is that programs that used to crash with a CCE
(because we blindly cast to the type of the pattern, which a `==` check does not imply)
now get a weaker type instead (and no cast). They may still type check, or they may not.

To compensate for this fix, change `case x@Foo => x` to `case x: Foo.type => x`,
if it's important that `x` have type `Foo.type`.

NOTE: once  is fixed, matching of singleton type patterns will use `eq`,
not `==` (so that the types are not a lie).

See also: 

Review by @retronym
