### PR TITLE
SI-7322 Interpolator idents must be encoded

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1219,7 +1219,7 @@ self =>
       // Like Swiss cheese, with holes
       def stringCheese: Tree = atPos(in.offset) {
         val start = in.offset
-        val interpolator = in.name
+        val interpolator = in.name.encoded // ident() for INTERPOLATIONID
 
         val partsBuf = new ListBuffer[Tree]
         val exprBuf = new ListBuffer[Tree]

--- a/test/files/pos/t7322.scala
+++ b/test/files/pos/t7322.scala
@@ -1,0 +1,11 @@
+
+package object t7322 {
+  implicit class X(sc: StringContext) {
+    def x_?(args: Any*) = "hi there"
+  }
+}
+package t7322 {
+  trait Y {
+    x_?"junk"  // assume that if it compiles, it works
+  }
+}


### PR DESCRIPTION
Otherwise, they are not found.

This matters for term names with a differential encoding.
