### PR TITLE
SI-7700 @unspecialized, Part Deux: Now Working.

### DIFF
--- a/test/files/run/t7700.check
+++ b/test/files/run/t7700.check
@@ -1,0 +1,2 @@
+public abstract java.lang.Object C.bar(java.lang.Object)
+public abstract java.lang.Object C.foo(java.lang.Object)

--- a/test/files/run/t7700.scala
+++ b/test/files/run/t7700.scala
@@ -1,0 +1,17 @@
+import scala.annotation._
+
+trait C[@specialized U] {
+  @unspecialized
+  def foo(u: U): U
+  @unspecialized
+  def bar[A](u: U) = u
+}
+
+object Test extends App {
+  val declared = classOf[C[_]].getDeclaredMethods.sortBy(_.getName)
+  println(declared.mkString("\n"))
+  object CInt extends C[Int] { def foo(i: Int) = i }
+  object CAny extends C[Any] { def foo(a: Any) = a }
+  assert(CInt.foo(1) == 1)
+  assert(CAny.foo("") == "")
+}


### PR DESCRIPTION
This annotation was introduced to allow us to mark methods within
a specialized trait as immune from specialization. In particular,
this is desirable for `Function1.{andThen, compose}`.

However, it seems we need to check for this in two places in the
specialization code base. The feature is now backed with a test.

Review by @VladUreche

This will introduce a binary incompatibility in the library wrt
2.11.0-M8. We'll only notice this if partest or scalacheck calls
`andThen` or `compose` on `Function1`; our PR validation build
should tell us whether that's a problem or not.
