### PR TITLE
SI-8199 Account for module class suffix in -Xmax-classfile-name

### DIFF
--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -53,14 +53,17 @@ trait StdNames {
      *
      * We obtain the formula:
      *
-     *   FileNameLength = 2*(MaxNameLength / 4) + 2.marker.length + 32 + 6
+     *   FileNameLength = 2*(MaxNameLength / 4) + 2.marker.length + 32 + suffixLength
      *
-     * (+6 for ".class"). MaxNameLength can therefore be computed as follows:
+     * (+suffixLength for ".class" and potential module class suffix that is added *after* this transform).
+     *
+     * MaxNameLength can therefore be computed as follows:
      */
     val marker = "$$$$"
+    val maxSuffixLength = "$.class".length + 1 // potential module class suffix and file extension
     val MaxNameLength = math.min(
-      settings.maxClassfileName.value - 6,
-      2 * (settings.maxClassfileName.value - 6 - 2*marker.length - 32)
+      settings.maxClassfileName.value - maxSuffixLength,
+      2 * (settings.maxClassfileName.value - maxSuffixLength - 2*marker.length - 32)
     )
     def toMD5(s: String, edge: Int): String = {
       val prefix = s take edge

--- a/test/files/run/t8199.scala
+++ b/test/files/run/t8199.scala
@@ -1,0 +1,105 @@
+class reallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongname {
+object obj0
+object obj01
+object obj012
+object obj0123
+object obj01234
+object obj012345
+object obj0123456
+object obj01234567
+object obj012345678
+object obj0123456789
+object obj01234567890
+class cls0
+class cls01
+class cls012
+class cls0123
+class cls01234
+class cls012345
+class cls0123456
+class cls01234567
+class cls012345678
+class cls0123456789
+class cls01234567890
+trait trt0 { def x = Test.checkCallerImplClassName() }
+trait trt01 { def x = Test.checkCallerImplClassName() }
+trait trt012 { def x = Test.checkCallerImplClassName() }
+trait trt0123 { def x = Test.checkCallerImplClassName() }
+trait trt01234 { def x = Test.checkCallerImplClassName() }
+trait trt012345 { def x = Test.checkCallerImplClassName() }
+trait trt0123456 { def x = Test.checkCallerImplClassName() }
+trait trt01234567 { def x = Test.checkCallerImplClassName() }
+trait trt012345678 { def x = Test.checkCallerImplClassName() }
+trait trt0123456789 { def x = Test.checkCallerImplClassName() }
+trait trt01234567890 { def x = Test.checkCallerImplClassName() }
+}
+
+object Test extends App {
+  def check(c: Class[_]) {
+    checkClassName(c.getName)
+  }
+  def checkClassName(name: String) {
+    val defaultMaxClassFileLength = 255
+    assert((name + ".class").length <= defaultMaxClassFileLength, name)
+  }
+  def checkCallerImplClassName() {
+    val name = Thread.currentThread.getStackTrace.apply(2).getClassName
+    assert(name.contains("$class"))
+    Test.checkClassName(name)
+  }
+
+  val c = new reallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongname
+  import c._
+
+  check(obj0.getClass)
+  check(obj01.getClass)
+  check(obj012.getClass)
+  check(obj0123.getClass)
+  check(obj01234.getClass)
+  check(obj012345.getClass)
+  check(obj0123456.getClass)
+  check(obj01234567.getClass)
+  check(obj012345678.getClass)
+  check(obj0123456789.getClass)
+  check(obj01234567890.getClass)
+
+  check(classOf[cls0])
+  check(classOf[cls01])
+  check(classOf[cls012])
+  check(classOf[cls0123])
+  check(classOf[cls01234])
+  check(classOf[cls012345])
+  check(classOf[cls0123456])
+  check(classOf[cls01234567])
+  check(classOf[cls012345678])
+  check(classOf[cls0123456789])
+  check(classOf[cls01234567890])
+
+  // interface facets
+  check(classOf[trt0])
+  check(classOf[trt01])
+  check(classOf[trt012])
+  check(classOf[trt0123])
+  check(classOf[trt01234])
+  check(classOf[trt012345])
+  check(classOf[trt0123456])
+  check(classOf[trt01234567])
+  check(classOf[trt012345678])
+  check(classOf[trt0123456789])
+  check(classOf[trt01234567890])
+
+  // impl classes are harder to find the names of to test!
+  (new trt0 {}).x
+  (new trt01 {}).x
+  (new trt012 {}).x
+  (new trt0123 {}).x
+  (new trt01234 {}).x
+  (new trt012345 {}).x
+  (new trt0123456 {}).x
+  (new trt01234567 {}).x
+  (new trt012345678 {}).x
+  (new trt0123456789 {}).x
+  (new trt01234567890 {}).x
+}
+
+// filename too long: reallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongname$obj012345$.class


### PR DESCRIPTION
The class file name of an inner class is based on the flattened
name of its owner chain.

But, if this is going to be unreasonably long, it is shortened
with the help of a MD5 hash.

However, after this shortening takes place, we sneakily add one
more character (the infamous '$') to the name when it is used
for the module class. It is thus possible to exceed the limit
by one.

The enclosed test failed on Mac with "filename too long" because
of this. I have also tested for trait implementatation classes,
but these seem to be suffixed with "$class" before the name
compactification runs, so they weren't actually a problem.

This change is binary incompatible as separately compiled
defintions and usages of named, inner classes need to agree
on this setting. Most typically, however, these long names
crop up for inner anonymous classes / functions, which are
not prone to the binary incompatiblity, assuming that their
creation hasn't be inlined to a separately compiled client.

Review by @gkossakowski
