### PR TITLE
SI-8205 Don't include CR in line

### DIFF
--- a/src/reflect/scala/reflect/internal/util/SourceFile.scala
+++ b/src/reflect/scala/reflect/internal/util/SourceFile.scala
@@ -143,7 +143,13 @@ class BatchSourceFile(val file : AbstractFile, val content0: Array[Char]) extend
 
   def isLineBreak(idx: Int) = charAtIsEOL(idx)(isLineBreakChar)
 
-  def isEndOfLine(idx: Int) = charAtIsEOL(idx) {
+  /** True if the index is included by an EOL sequence. */
+  def isEndOfLine(idx: Int) = (content isDefinedAt idx) && PartialFunction.cond(content(idx)) {
+    case CR | LF => true
+  }
+
+  /** True if the index is end of an EOL sequence. */
+  def isAtEndOfLine(idx: Int) = charAtIsEOL(idx) {
     case CR | LF => true
     case _       => false
   }
@@ -151,7 +157,7 @@ class BatchSourceFile(val file : AbstractFile, val content0: Array[Char]) extend
   def calculateLineIndices(cs: Array[Char]) = {
     val buf = new ArrayBuffer[Int]
     buf += 0
-    for (i <- 0 until cs.length) if (isEndOfLine(i)) buf += i + 1
+    for (i <- 0 until cs.length) if (isAtEndOfLine(i)) buf += i + 1
     buf += cs.length // sentinel, so that findLine below works smoother
     buf.toArray
   }

--- a/test/junit/scala/reflect/internal/util/SourceFileTest.scala
+++ b/test/junit/scala/reflect/internal/util/SourceFileTest.scala
@@ -30,4 +30,26 @@ class SourceFileTest {
     assertEquals("def", lineContentOf("abc\ndef", 6))
     assertEquals("def", lineContentOf("abc\ndef\n", 7))
   }
+
+  @Test
+  def CRisEOL(): Unit = {
+    assertEquals("", lineContentOf("\r", 0))
+    assertEquals("abc", lineContentOf("abc\rdef", 0))
+    assertEquals("abc", lineContentOf("abc\rdef", 3))
+    assertEquals("def", lineContentOf("abc\rdef", 4))
+    assertEquals("def", lineContentOf("abc\rdef", 6))
+    assertEquals("def", lineContentOf("abc\rdef\r", 7))
+  }
+
+  @Test
+  def CRNLisEOL(): Unit = {
+    assertEquals("", lineContentOf("\r\n", 0))
+    assertEquals("abc", lineContentOf("abc\r\ndef", 0))
+    assertEquals("abc", lineContentOf("abc\r\ndef", 3))
+    assertEquals("abc", lineContentOf("abc\r\ndef", 4))
+    assertEquals("def", lineContentOf("abc\r\ndef", 5))
+    assertEquals("def", lineContentOf("abc\r\ndef", 7))
+    assertEquals("def", lineContentOf("abc\r\ndef", 8))
+    assertEquals("def", lineContentOf("abc\r\ndef\r\n", 9))
+  }
 }


### PR DESCRIPTION
More penance. Extend the unit test and don't include CR
in the line text.

This is obvious, which shows how dangerous it is to refactor
without unit tests.

My very favorite bugs are off-by-one and EOL handling, followed
closely by off-by-Int.MaxValue.
