### PR TITLE
SI-8213 AnyRefMap.getOrElseUpdate is faulty

### DIFF
--- a/test/junit/scala/collection/SetMapConsistencyTest.scala
+++ b/test/junit/scala/collection/SetMapConsistencyTest.scala
@@ -476,4 +476,16 @@ class SetMapConsistencyTest {
     }
     assert(test)
   }
+  
+  @Test
+  def si8213() {
+    val am = new scala.collection.mutable.AnyRefMap[String, Int]
+    for (i <- 0 until 1024) am += i.toString -> i
+    am.getOrElseUpdate("1024", { am.clear; -1 })
+    assert(am == scala.collection.mutable.AnyRefMap("1024" -> -1))
+    val lm = new scala.collection.mutable.LongMap[Int]
+    for (i <- 0 until 1024) lm += i.toLong -> i
+    lm.getOrElseUpdate(1024, { lm.clear; -1 })
+    assert(lm == scala.collection.mutable.LongMap(1024L -> -1))
+  }
 }


### PR DESCRIPTION
Altered getOrElseUpdate to be robust to the map changing out from under it as a result of calling the default value method.  Side-effects FTW!

Made a comparable change in LongMap also, as it was also affected.  And added a test to SetMapConsistencyTest.

scala/bug#8213