### PR TITLE
SI-7124 make macro definitions prettier in scaladoc

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -10,6 +10,7 @@ import diagram._
 
 import scala.collection._
 import scala.util.matching.Regex
+import scala.reflect.macros.internal.macroImpl
 import symtab.Flags
 
 import io._
@@ -80,7 +81,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
     def inTemplate: TemplateImpl = inTpl
     def toRoot: List[EntityImpl] = this :: inTpl.toRoot
     def qualifiedName = name
-    def annotations = sym.annotations.map(makeAnnotation)
+    def annotations = sym.annotations.filterNot(_.tpe =:= typeOf[macroImpl]).map(makeAnnotation)
     def inPackageObject: Boolean = sym.owner.isModuleClass && sym.owner.sourceModule.isPackageObject
     def isType = sym.name.isTypeName
   }
@@ -145,6 +146,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
        * any abstract terms, otherwise it would fail compilation. So we reset the DEFERRED flag. */
       if (!sym.isTrait && (sym hasFlag Flags.DEFERRED) && (!isImplicitlyInherited)) fgs += Paragraph(Text("abstract"))
       if (!sym.isModule && (sym hasFlag Flags.FINAL)) fgs += Paragraph(Text("final"))
+      if (sym.isMacro) fgs += Paragraph(Text("macro"))
       fgs.toList
     }
     def deprecation =

--- a/test/scaladoc/run/t7124.check
+++ b/test/scaladoc/run/t7124.check
@@ -1,0 +1,3 @@
+List()
+List(Paragraph(Text(macro)))
+Done.

--- a/test/scaladoc/run/t7124.scala
+++ b/test/scaladoc/run/t7124.scala
@@ -1,0 +1,22 @@
+import scala.tools.nsc.doc.model._
+import scala.tools.partest.ScaladocModelTest
+
+object Test extends ScaladocModelTest {
+
+  override def code = """
+  import scala.language.experimental.macros
+  class Test {
+     def print(): Unit = macro ???
+  }
+                      """
+
+  def scaladocSettings = ""
+
+  def testModel(root: Package) = {
+    import access._
+    val p = root._class("Test")._method("print")
+
+    println(p.annotations) // no annotations
+    println(p.flags) // a 'macro' flag
+  }
+}


### PR DESCRIPTION
Macros are now prettier in scaladoc, by
- hiding the `macroImpl` annotation
- showing the `macro` modifier in front

---

review by @VladUreche
