### PR TITLE
add -Xsource:version to scalac man page

### DIFF
--- a/src/manual/scala/man1/scalac.scala
+++ b/src/manual/scala/man1/scalac.scala
@@ -309,6 +309,9 @@ object scalac extends Command {
           CmdOption("Xshow-phases"),
           "Print a synopsis of compiler phases."),
         Definition(
+          CmdOptionBound("Xsource:", Argument("version")),
+          "Treat compiler input as Scala source for the specified version, see SI-8126."),
+	Definition(
           CmdOption("Xsource-reader", Argument("classname")),
           "Specify a custom method for reading source files."),
 	Definition(


### PR DESCRIPTION
The flag was added in d43618a (PR #3340) by @huitseeker.
