### PR TITLE
Optimize the pickler phase

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1596,6 +1596,10 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
       }
     }
 
+    private def checkUnexpandedMacro(t: Tree) =
+      if (!t.isDef && t.hasSymbolField && t.symbol.isTermMacro)
+        unit.error(t.pos, "macro has not been expanded")
+
     override def transform(tree: Tree): Tree = {
       val savedLocalTyper = localTyper
       val savedCurrentApplication = currentApplication
@@ -1755,6 +1759,9 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
             varianceValidator.traverse(tt.original) // See SI-7872
           case _ =>
         }
+
+        checkUnexpandedMacro(result)
+
         result
       } catch {
         case ex: TypeError =>


### PR DESCRIPTION
- move "erroneous type" diagnostic into a crash recovery handler,
  rather than running it proactively
  - move the "unexpanded macros" check into refchecks.

Cuts this phase in half, from about 1% of compile time to 0.5%.

Review by @adriaanm
