### PR TITLE
SI-7266 Stream leaks memory

### DIFF
--- a/src/library/scala/collection/immutable/Stream.scala
+++ b/src/library/scala/collection/immutable/Stream.scala
@@ -1108,11 +1108,15 @@ object Stream extends SeqFactory[Stream] {
     override def isEmpty = false
     override def head = hd
     @volatile private[this] var tlVal: Stream[A] = _
-    def tailDefined: Boolean = tlVal ne null
+    @volatile private[this] var tlGen = tl _
+    def tailDefined: Boolean = tlGen eq null
     override def tail: Stream[A] = {
       if (!tailDefined)
         synchronized {
-          if (!tailDefined) tlVal = tl
+          if (!tailDefined) {
+            tlVal = tlGen()
+            tlGen = null
+          }
         }
 
       tlVal


### PR DESCRIPTION
Changed tail-generation function to mutable and clear it after it's used to allow any captured memory to be freed once the tail has been generated.

(This is a case where a by-name parameter was used when a lazy val parameter was wanted instead.  If we ever get lazy val parameters, we should switch to that.)
