### PR TITLE
SI-4997 deprecate StringLike.linesIterator for StringLike.lines

### DIFF
--- a/src/library/scala/collection/immutable/StringLike.scala
+++ b/src/library/scala/collection/immutable/StringLike.scala
@@ -131,6 +131,7 @@ self =>
    *  end characters, i.e. apply `.stripLineEnd` to all lines
    *  returned by `linesWithSeparators`.
    */
+  @deprecated("Use `lines` instead.","2.11.0")
   def linesIterator: Iterator[String] =
     linesWithSeparators map (line => new WrappedString(line).stripLineEnd)
 

--- a/test/files/run/global-showdef.scala
+++ b/test/files/run/global-showdef.scala
@@ -54,7 +54,7 @@ object Bippy {
       val run = new compiler.Run()
       run.compileSources(List(src))
     }
-    output.linesIterator.toList
+    output.lines.toList
   }
   def showClass(name: String) = lines("-Yshow:typer", "-Xshow-class", name)
   def showObject(name: String) = lines("-Yshow:typer", "-Xshow-object", name)


### PR DESCRIPTION
Deprecated.  lines is by far more consistent with the rest of the naming in the library.
