### PR TITLE
SI-5994 battling implicits for String.lines

### DIFF
--- a/src/library/scala/sys/process/ProcessBuilder.scala
+++ b/src/library/scala/sys/process/ProcessBuilder.scala
@@ -30,9 +30,7 @@ import ProcessBuilder._
   * "ls".!
   *
   * // Execute "ls" and assign a `Stream[String]` of its output to "contents".
-  * // Because [[scala.Predef]] already defines a `lines` method for `String`,
-  * // we use [[scala.sys.process.Process]]'s object companion to create it.
-  * val contents = Process("ls").lines
+  * val contents = Process("ls").lineStream
   *
   * // Here we use a `Seq` to make the parameter whitespace-safe
   * def contentsOf(dir: String): String = Seq("ls", dir).!!
@@ -82,11 +80,11 @@ import ProcessBuilder._
   *     of the last one in the chain of execution.
   *   - `!!`: blocks until all external commands exit, and returns a `String`
   *     with the output generated.
-  *   - `lines`: returns immediately like `run`, and the output being generared
+  *   - `lineStream`: returns immediately like `run`, and the output being generated
   *     is provided through a `Stream[String]`. Getting the next element of that
   *     `Stream` may block until it becomes available. This method will throw an
   *     exception if the return code is different than zero -- if this is not
-  *     desired, use the `lines_!` method.
+  *     desired, use the `lineStream_!` method.
   *
   * ==Handling Input and Output==
   *
@@ -131,6 +129,14 @@ import ProcessBuilder._
   *
   * Note: though it is not shown above, the equivalent of a shell's `;` would be
   * `###`. The reason for this name is that `;` is a reserved token in Scala.
+  *
+  * Note: the `lines` method, though deprecated, may conflict with the `StringLike`
+  * method of the same name.  To avoid this, one may wish to call the builders in
+  * `Process` instead of importing `scala.sys.process._`.  The example above would be
+  * {{{
+  * import scala.sys.process.Process
+  * Process("find src -name *.scala -exec grep null {} ;") #| Process("xargs test -z") #&& Process("echo null-free") #|| Process("echo null detected") !
+  * }}}
   */
 trait ProcessBuilder extends Source with Sink {
   /** Starts the process represented by this builder, blocks until it exits, and
@@ -165,7 +171,11 @@ trait ProcessBuilder extends Source with Sink {
     * with a non-zero value, the Stream will provide all lines up to termination
     * and then throw an exception.
     */
-  def lines: Stream[String]
+  def lineStream: Stream[String]
+  
+  /** Deprecated (renamed). Use `lineStream` instead. */
+  @deprecated("Use lineStream instead.", "2.11.0")
+  def lines: Stream[String] = lineStream
 
   /** Starts the process represented by this builder.  The output is returned as
     * a Stream that blocks when lines are not available but the process has not
@@ -173,7 +183,11 @@ trait ProcessBuilder extends Source with Sink {
     * process exits with a non-zero value, the Stream will provide all lines up
     * to termination and then throw an exception.
     */
-  def lines(log: ProcessLogger): Stream[String]
+  def lineStream(log: ProcessLogger): Stream[String]
+  
+  /** Deprecated (renamed).  Use `lineStream(log: ProcessLogger)` instead. */
+  @deprecated("Use stream instead.", "2.11.0")
+  def lines(log: ProcessLogger): Stream[String] = lineStream(log)
 
   /** Starts the process represented by this builder.  The output is returned as
     * a Stream that blocks when lines are not available but the process has not
@@ -181,7 +195,11 @@ trait ProcessBuilder extends Source with Sink {
     * with a non-zero value, the Stream will provide all lines up to termination
     * but will not throw an exception.
     */
-  def lines_! : Stream[String]
+  def lineStream_! : Stream[String]
+  
+  /** Deprecated (renamed).  Use `lineStream_!` instead. */
+  @deprecated("Use lineStream_! instead.", "2.11.0")  
+  def lines_! : Stream[String] = lineStream_!
 
   /** Starts the process represented by this builder.  The output is returned as
     * a Stream that blocks when lines are not available but the process has not
@@ -189,7 +207,11 @@ trait ProcessBuilder extends Source with Sink {
     * process exits with a non-zero value, the Stream will provide all lines up
     * to termination but will not throw an exception.
     */
-  def lines_!(log: ProcessLogger): Stream[String]
+  def lineStream_!(log: ProcessLogger): Stream[String]
+  
+  /** Deprecated (renamed).  Use `lineStream_!(log: ProcessLogger)` instead. */
+  @deprecated("Use stream_! instead.", "2.11.0")
+  def lines_!(log: ProcessLogger): Stream[String] = lineStream_!(log)
 
   /** Starts the process represented by this builder, blocks until it exits, and
     * returns the exit code.  Standard output and error are sent to the console.

--- a/src/library/scala/sys/process/ProcessBuilderImpl.scala
+++ b/src/library/scala/sys/process/ProcessBuilderImpl.scala
@@ -104,10 +104,10 @@ private[process] trait ProcessBuilderImpl {
     def !!<                     = slurp(None, withIn = true)
     def !!<(log: ProcessLogger) = slurp(Some(log), withIn = true)
 
-    def lines: Stream[String]                       = lines(withInput = false, nonZeroException = true, None)
-    def lines(log: ProcessLogger): Stream[String]   = lines(withInput = false, nonZeroException = true, Some(log))
-    def lines_! : Stream[String]                    = lines(withInput = false, nonZeroException = false, None)
-    def lines_!(log: ProcessLogger): Stream[String] = lines(withInput = false, nonZeroException = false, Some(log))
+    def lineStream: Stream[String]                       = lineStream(withInput = false, nonZeroException = true, None)
+    def lineStream(log: ProcessLogger): Stream[String]   = lineStream(withInput = false, nonZeroException = true, Some(log))
+    def lineStream_! : Stream[String]                    = lineStream(withInput = false, nonZeroException = false, None)
+    def lineStream_!(log: ProcessLogger): Stream[String] = lineStream(withInput = false, nonZeroException = false, Some(log))
 
     def !                      = run(connectInput = false).exitValue()
     def !(io: ProcessIO)       = run(io).exitValue()
@@ -132,7 +132,7 @@ private[process] trait ProcessBuilderImpl {
       else scala.sys.error("Nonzero exit value: " + code)
     }
 
-    private[this] def lines(
+    private[this] def lineStream(
       withInput: Boolean,
       nonZeroException: Boolean,
       log: Option[ProcessLogger]


### PR DESCRIPTION
Deprecated ProcessBuilder's lines method and renamed it streaming.

stream was another possibility, but that seemed more likely to cause conflicts.

Also updated tutorial in ProcessBuilder.

I am sure this will break some tests, but because of the name conflict it's hard to be sure where they are.  So Jenkins gets to find the problems for me.
