### PR TITLE
SI-8228 Avoid infinite loop with erroneous code, overloading

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -595,6 +595,7 @@ trait Infer extends Checkable {
     }
 
     private[typechecker] def followApply(tp: Type): Type = tp match {
+      case _ if tp.isError => tp // SI-8228, `ErrorType nonPrivateMember nme.apply` returns an member with an erroneous type!
       case NullaryMethodType(restp) =>
         val restp1 = followApply(restp)
         if (restp1 eq restp) tp else restp1

--- a/test/files/neg/t8228.check
+++ b/test/files/neg/t8228.check
@@ -1,0 +1,4 @@
+t8228.scala:4: error: recursive value foo needs type
+    val foo = foo(null)
+                 ^
+one error found

--- a/test/files/neg/t8228.scala
+++ b/test/files/neg/t8228.scala
@@ -1,0 +1,7 @@
+object X {
+  def bar = {
+    def foo(x: Any) = ""
+    val foo = foo(null)
+    foo(null) // cycle in isApplicableBasedOnArity
+  }
+}


### PR DESCRIPTION
SI-8228 Avoid infinite loop with erroneous code, overloading …
`isApplicableBasedOnArity` couldn't get of the ferris wheel after
as `followApply` kept insisting on another spin.

```
scala> ErrorType nonPrivateMember nme.apply
res0: $r.intp.global.Symbol = value apply

scala> res0.info
res1: $r.intp.global.Type = <error>
```

This commit makes `followApply` consider that an `ErrorType`
does not contain an `apply` member.

I also considered whether to do a deep check on the type
(`isErroneous`), but I can't motivate this with a test.
I tend to think we _shouldn't_ do that: `List[${ErrorType}]`
still has an `apply` member that we should follow, right?

Review by @adriaanm 
