### PR TITLE
SI-8233 Fix regression in backend with boxed nulls

### DIFF
--- a/test/files/run/t8233-bcode.flags
+++ b/test/files/run/t8233-bcode.flags
@@ -1,0 +1,1 @@
+-Ybackend:GenBCode

--- a/test/files/run/t8233-bcode.scala
+++ b/test/files/run/t8233-bcode.scala
@@ -1,0 +1,18 @@
+object Test {
+  def bar(s: String) = s;
+  val o: Option[Null] = None
+  def nullReference {
+    val a: Null = o.get
+    bar(a) // Was: VerifyError under GenICode
+  }
+
+  def literal {
+    val a: Null = null
+    bar(a)
+  }
+
+  def main(args: Array[String]) = {
+    try { nullReference } catch { case _: NoSuchElementException => }
+    literal
+  }
+}

--- a/test/files/run/t8233.scala
+++ b/test/files/run/t8233.scala
@@ -1,0 +1,18 @@
+object Test {
+  def bar(s: String) = s;
+  val o: Option[Null] = None
+  def nullReference {
+    val a: Null = o.get
+    bar(a) // Was: VerifyError under GenICode
+  }
+
+  def literal {
+    val a: Null = null
+    bar(a)
+  }
+
+  def main(args: Array[String]) = {
+    try { nullReference } catch { case _: NoSuchElementException => }
+    literal
+  }
+}


### PR DESCRIPTION
Regressed in SI-7015 / 1b6661b8.

We do need to "unbox" the null (ie, drop a stack from and load
a null) in general. The only time we can avoid this is if the
tree we are adapting is a `Constant(Literal(null))`.

I've added a test for both backends. Only GenICode exhibited
the problem.

Review by @gkossakowski, /cc @JamesIry
