### PR TITLE
SI-7937 No nested if after val def in for

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1738,7 +1738,7 @@ self =>
 
     def enumerator(isFirst: Boolean, allowNestedIf: Boolean = true): List[Tree] =
       if (in.token == IF && !isFirst) makeFilter(in.offset, guard()) :: Nil
-      else generator(!isFirst, allowNestedIf)
+      else generator(eqOK = !isFirst, allowNestedIf)
 
     /** {{{
      *  Generator ::= Pattern1 (`<-' | `=') Expr [Guard]
@@ -1765,7 +1765,11 @@ self =>
 
       def loop(): List[Tree] =
         if (in.token != IF) Nil
-        else makeFilter(in.offset, guard()) :: loop()
+        else {
+          if (hasEq) deprecationWarning(in.offset,
+            "nested guard (missing semicolon before if) in for comprehension must follow a generator, not a value definition")
+          makeFilter(in.offset, guard()) :: loop()
+        }
 
       val tail =
         if (allowNestedIf) loop()

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1767,7 +1767,7 @@ self =>
         if (in.token != IF) Nil
         else {
           if (hasEq) deprecationWarning(in.offset,
-            "nested guard (missing semicolon before if) in for comprehension must follow a generator, not a value definition")
+            "guard (if expression) in for comprehension should follow a semicolon when it comes after a value definition")
           makeFilter(in.offset, guard()) :: loop()
         }
 

--- a/test/files/neg/t7937-for-semi.check
+++ b/test/files/neg/t7937-for-semi.check
@@ -1,0 +1,9 @@
+t7937-for-semi.scala:7: warning: guard (if expression) in for comprehension should follow a semicolon when it comes after a value definition
+  def f2() = for (i <- 1 to 5 ; j = 2 * i if j > 4) yield j    // no, that's confusing
+                                          ^
+t7937-for-semi.scala:12: warning: guard (if expression) in for comprehension should follow a semicolon when it comes after a value definition
+    k = 2 * j if k > 4      // no, that's super confusing
+              ^
+error: No warnings can be incurred under -Xfatal-warnings.
+two warnings found
+one error found

--- a/test/files/neg/t7937-for-semi.flags
+++ b/test/files/neg/t7937-for-semi.flags
@@ -1,0 +1,1 @@
+-deprecation -Xfatal-warnings

--- a/test/files/neg/t7937-for-semi.scala
+++ b/test/files/neg/t7937-for-semi.scala
@@ -1,0 +1,14 @@
+
+trait X {
+  def f0() = for (i <- 1 to 5 ; j = 2 * i ; if j > 4) yield j  // ok, all semis
+
+  def f1() = for (i <- 1 to 5 if i > 3; j = 2 * i) yield j     // ok, all semis
+
+  def f2() = for (i <- 1 to 5 ; j = 2 * i if j > 4) yield j    // no, that's confusing
+
+  def f3() = for {
+    i <- 1 to 5
+    j = 2 * i
+    k = 2 * j if k > 4      // no, that's super confusing
+  } yield k
+}

--- a/test/files/run/fors.scala
+++ b/test/files/run/fors.scala
@@ -66,7 +66,7 @@ object Test extends App {
     for {x <- it
          if x % 2 == 0} print(x + " "); println
     for (x <- it;
-         y = 2
+         y = 2;
          if x % y == 0) print(x + " "); println
     for {x <- it
          y = 2


### PR DESCRIPTION
scala/bug#7937

Deprecate nested if after a value definition in
a for comprehension. (That is per spec.)

The difference is between

```
for (i <- is if i > 0)
```

and

```
for (i <- is ; j = 2 * i if i > 0)
```

where, in the second form, the guard seems to
control perlesquely the val def. That is confusing
to the human eye.

The first form, where the guard directly follows
a generator, is OK because a generator doesn't
look like an expression that would be guarded
by the if condition.

Review by @densh
