### PR TITLE
PR #3233 cleanup

### DIFF
--- a/test/files/jvm/t6941/Analyzed_1.scala
+++ b/test/files/jvm/t6941/Analyzed_1.scala
@@ -6,6 +6,6 @@ class SameBytecode {
   }
 
   def b(xs: List[Int]) = xs match {
-    case xs: ::[Int] => xs.hd$1
+    case xs: ::[Int] => xs.head
   }
 }


### PR DESCRIPTION
- `::.head` became a `val`; excessive accessor removed
- SerializationProxy moved to `object List`
