### PR TITLE
SI-8030 Restore thread safety to the parser

### DIFF
--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -281,7 +281,7 @@ abstract class TreeGen extends macros.TreeBuilder {
     case tree :: Nil if flattenUnary =>
       tree
     case _ =>
-      Apply(scalaDot(TupleClass(elems.length).companionModule.name), elems)
+      Apply(scalaDot(TupleClass(elems.length).name.toTermName), elems)
   }
 
   def mkTupleType(elems: List[Tree], flattenUnary: Boolean = true): Tree = elems match {


### PR DESCRIPTION
In addition to the invariant "parsing doesn’t enter new symbols",
which was respected and tested in 760df9843a910d6, we also must
ensure that "parsing doesn't call Symbol#info".

That happend indirectly if we call `companionModule`.

This commit just converts the name of `class TupleN` to a term
name, rather than getting the name of its companion.

No test is included. This is tested upstream in:

```
https://jenkins.scala-ide.org:8496/jenkins/view/Memory%20Leak%20Tests/job/scalac-memory-leaks-test-2.11.0/
```

Review by @densh / @dragos
