### PR TITLE
SI-8215: Correcting typo and splitting a long sentence in MatchIterator doc

### DIFF
--- a/src/library/scala/util/matching/Regex.scala
+++ b/src/library/scala/util/matching/Regex.scala
@@ -647,9 +647,10 @@ object Regex {
   /** A class to step through a sequence of regex matches.
    *
    *  All methods inherited from [[scala.util.matching.Regex.MatchData]] will throw
-   *  an [[java.lang.IllegalStateException]] until the matcher is initialized by
-   *  calling `hasNext` or `next()` or causing these methods to be called, such as
-   *  by invoking `toString` or iterating through the iterator's elements.
+   *  a [[java.lang.IllegalStateException]] until the matcher is initialized. The
+   *  matcher can be initialized by calling `hasNext` or `next()` or causing these
+   *  methods to be called, such as by invoking `toString` or iterating through
+   *  the iterator's elements.
    *
    *  @see [[java.util.regex.Matcher]]
    */


### PR DESCRIPTION
Follow-up to 9c0ca62. The typo comes from the fact that I didn't take into account the full rendering of exception names:

![image](https://f.cloud.github.com/assets/223702/2091023/ed0ff260-8e9b-11e3-88f3-b6a1465e096c.png)

Also taken the opportunity to split a sentence that seems a bit long into two.

Review by @adriaanm @heathermiller

Sorry that we need this fixup!
