### PR TITLE
SI-6169 Refine java wildcard bounds using corresponding tparam

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2675,7 +2675,7 @@ trait Types
       def rawToExistentialCreatedMe = (quantified corresponds underlying.typeArgs){ (q, a) => q.tpe =:= a }
 
       if (underlying.typeSymbol.isJavaDefined && rawToExistentialCreatedMe) {
-        val tpars = underlying.typeSymbol.typeParams
+        val tpars = underlying.typeSymbol.initialize.typeParams // TODO: is initialize needed?
         debuglog(s"sharpen bounds: $this | ${underlying.typeArgs.map(_.typeSymbol)} <-- ${tpars.map(_.info)}")
 
         foreach2(quantified, tpars) { (quant, tparam) =>

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2668,7 +2668,13 @@ trait Types
      *   but that causes cyclic errors because it happens too early.)
      */
     private def sharpenQuantifierBounds(): Unit = {
-      if (underlying.typeSymbol.isJavaDefined && quantified == underlying.typeArgs.map(_.typeSymbol)) {
+      /* Check that we're looking at rawToExistential's handiwork
+       * (`existentialAbstraction(eparams, typeRef(apply(pre), sym, eparams map (_.tpe)))`).
+       * We can't do this sharpening there because we'll run into cycles.
+       */
+      def rawToExistentialCreatedMe = (quantified corresponds underlying.typeArgs){ (q, a) => q.tpe =:= a }
+
+      if (underlying.typeSymbol.isJavaDefined && rawToExistentialCreatedMe) {
         val tpars = underlying.typeSymbol.typeParams
         debuglog(s"sharpen bounds: $this | ${underlying.typeArgs.map(_.typeSymbol)} <-- ${tpars.map(_.info)}")
 

--- a/test/files/pos/t6169/Exist.java
+++ b/test/files/pos/t6169/Exist.java
@@ -1,0 +1,4 @@
+public class Exist<T extends String> {
+  // java helpfully re-interprets Exist<?> as Exist<? extends String>
+  public Exist<?> foo() { throw new RuntimeException(); }
+}

--- a/test/files/pos/t6169/ExistF.java
+++ b/test/files/pos/t6169/ExistF.java
@@ -1,0 +1,4 @@
+public class ExistF<T extends ExistF<T>> {
+  // java helpfully re-interprets ExistF<?> as ExistF<?0 extends ExistF<?0>>
+  public ExistF<?> foo() { throw new RuntimeException(); }
+}

--- a/test/files/pos/t6169/ExistIndir.java
+++ b/test/files/pos/t6169/ExistIndir.java
@@ -1,0 +1,4 @@
+public class ExistIndir<T extends String, U extends T> {
+  // java helpfully re-interprets ExistIndir<?> as ExistIndir<? extends String>
+  public ExistIndir<?, ?> foo() { throw new RuntimeException(); }
+}

--- a/test/files/pos/t6169/OP.java
+++ b/test/files/pos/t6169/OP.java
@@ -1,0 +1,1 @@
+public abstract class OP<T> { }

--- a/test/files/pos/t6169/Skin.java
+++ b/test/files/pos/t6169/Skin.java
@@ -1,0 +1,1 @@
+public interface Skin<C extends Skinnable> { }

--- a/test/files/pos/t6169/Skinnable.java
+++ b/test/files/pos/t6169/Skinnable.java
@@ -1,0 +1,3 @@
+public interface Skinnable {
+  OP<Skin<?>>	skinProperty();
+}

--- a/test/files/pos/t6169/skinnable.scala
+++ b/test/files/pos/t6169/skinnable.scala
@@ -1,0 +1,14 @@
+object ObjectProperty {
+  implicit def jfxObjectProperty2sfx[T](p: OP[T]) = new ObjectProperty[T](p)
+}
+
+class ObjectProperty[T](val delegate: OP[T])
+
+trait TestWildcardBoundInference {
+  def delegate: Skinnable
+  def skin: ObjectProperty[Skin[_ /* inferred: <: Skinnable */]] = ObjectProperty.jfxObjectProperty2sfx(delegate.skinProperty)
+  skin: ObjectProperty[Skin[_  <: Skinnable]]
+
+  def skinCheckInference = delegate.skinProperty
+  skinCheckInference: ObjectProperty[Skin[_  <: Skinnable]]
+}

--- a/test/files/pos/t6169/t6169.scala
+++ b/test/files/pos/t6169/t6169.scala
@@ -1,0 +1,7 @@
+class Test {
+  class MyExist extends ExistF[MyExist]
+  // SI-8197, SI-6169: java infers the bounds of existentials, so we have to as well now that SI-1786 is fixed...
+  def stringy: Exist[_ <: String] = (new Exist[String]).foo
+  def fbounded: (ExistF[t] forSome {type t <: ExistF[t] }) = (new MyExist).foo
+  def indir: ExistIndir[_ <: String, _ <: String] = (new ExistIndir[String, String]).foo
+}


### PR DESCRIPTION
Also fixes part of SI-8197. Necessary complement to SI-1786, because we now infer tighter bounds for RHSs to conform to.

When opening an existential, Java puts constraints in the context that are derived
from the bounds on the type parameters of the existentially quantified type,
so let's do the same for existentials over java-defined classes...

Example:

```
public class Exist<T extends String> {
  // java helpfully re-interprets Exist<?> as Exist<? extends String>
  public Exist<?> foo() { throw new RuntimeException(); }
}
```

review by @retronym
