### PR TITLE
Fix compilation errors

### DIFF
--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -362,7 +362,7 @@ abstract class TreeGen extends macros.TreeBuilder {
         if (body forall treeInfo.isInterfaceMember) None
         else Some(
           atPos(wrappingPos(superPos, lvdefs)) (
-            DefDef(NoMods, nme.MIXIN_CONSTRUCTOR, Nil, ListOfNil, TypeTree(), Block(lvdefs, Literal(Constant())))))
+            DefDef(NoMods, nme.MIXIN_CONSTRUCTOR, Nil, ListOfNil, TypeTree(), Block(lvdefs, Literal(Constant(()))))))
       }
       else {
         // convert (implicit ... ) to ()(implicit ... ) if its the only parameter section
@@ -376,7 +376,7 @@ abstract class TreeGen extends macros.TreeBuilder {
                                          // therefore here we emit a dummy which gets populated when the template is named and typechecked
         Some(
           atPos(wrappingPos(superPos, lvdefs ::: vparamss1.flatten).makeTransparent) (
-            DefDef(constrMods, nme.CONSTRUCTOR, List(), vparamss1, TypeTree(), Block(lvdefs ::: List(superCall), Literal(Constant())))))
+            DefDef(constrMods, nme.CONSTRUCTOR, List(), vparamss1, TypeTree(), Block(lvdefs ::: List(superCall), Literal(Constant(()))))))
       }
     }
     constr foreach (ensureNonOverlapping(_, parents ::: gvdefs, focus = false))

--- a/src/repl/scala/tools/nsc/interpreter/session/SimpleHistory.scala
+++ b/src/repl/scala/tools/nsc/interpreter/session/SimpleHistory.scala
@@ -26,7 +26,7 @@ class SimpleHistory extends JLineHistory {
   }
 
   case class Entry(index: Int, value: CharSequence) extends JEntry {
-    override def toString = value
+    override def toString = value.toString()
   }
 
   def maxSize: Int = 2500


### PR DESCRIPTION
This fixes compilation errors about adapted argument lists and
a type error between CharSequence and String

---

I have no idea how the type error between CharSequence and String happened. Compiling it in the IDE doesn't work whereas on the command line everything is ok.
