### PR TITLE
Add repl as dependency of test-junit Eclipse project.

### DIFF
--- a/src/eclipse/test-junit/.classpath
+++ b/src/eclipse/test-junit/.classpath
@@ -7,5 +7,6 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/scala-library"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scala-compiler"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/repl"/>
 	<classpathentry kind="output" path="build-test-junit"/>
 </classpath>


### PR DESCRIPTION
Since 8f20fa23dbb5b000f0889132b8c6e2acfff096b3 junit tests depend on
repl. We need to reflect that dependency in our Eclipse project files.
