### PR TITLE
Fix feature warnings in test.osgi.comp

### DIFF
--- a/test/osgi/src/BasicReflection.scala
+++ b/test/osgi/src/BasicReflection.scala
@@ -2,6 +2,8 @@ package tools.test.osgi
 package reflection
 package basic
 
+import scala.language.higherKinds
+
 import org.junit.Assert._
 import org.ops4j.pax.exam.CoreOptions._
 

--- a/test/osgi/src/ScalaOsgiHelper.scala
+++ b/test/osgi/src/ScalaOsgiHelper.scala
@@ -1,5 +1,5 @@
 package tools.test.osgi
- 
+
 import org.ops4j.pax.exam.CoreOptions._
 import org.ops4j.pax.exam
 import java.io.File
@@ -12,7 +12,7 @@ trait ScalaOsgiHelper {
   }
 
   private def filteredBundleFiles(names: String*): Array[exam.Option] =
-     for(bundle <- allBundleFiles; if names exists (bundle.getName contains))
+     for(bundle <- allBundleFiles; if names exists (bundle.getName contains _))
      yield makeBundle(bundle)
 
   private def makeBundle(file: File): exam.Option =
@@ -34,5 +34,5 @@ trait ScalaOsgiHelper {
     val bundles = filteredBundleFiles("scala-library")
     bundles ++ Array[exam.Option](felix(), equinox(), junitBundles())
   }
- 
+
 }


### PR DESCRIPTION
Reduces the amount of noise from 22 lines down to the actually
interesting 5 lines of information.
