### PR TITLE
Fix inconsistent binding in patterns with 10+ holes

### DIFF
--- a/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
@@ -29,7 +29,7 @@ trait Reifiers { self: Quasiquotes =>
     /** Map that stores freshly generated names linked to the corresponding names in the reified tree.
      *  This information is used to reify names created by calls to freshTermName and freshTypeName.
      */
-    var nameMap = collection.mutable.HashMap.empty[Name, Set[TermName]].withDefault { _ => Set() }
+    val nameMap = collection.mutable.HashMap.empty[Name, Set[TermName]].withDefault { _ => Set() }
 
     /** Wraps expressions into:
      *    a block which starts with a sequence of vals that correspond
@@ -71,7 +71,7 @@ trait Reifiers { self: Quasiquotes =>
         // q"..$freshdefs; $tree"
         SyntacticBlock(freshdefs :+ tree)
       } else {
-        val freevars = holeMap.toList.map { case (name, _) => Ident(name) }
+        val freevars = holeMap.keysIterator.map(Ident(_)).toList
         val isVarPattern = tree match { case Bind(name, Ident(nme.WILDCARD)) => true case _ => false }
         val cases =
           if(isVarPattern) {
@@ -162,7 +162,7 @@ trait Reifiers { self: Quasiquotes =>
         reifyBuildCall(nme.SyntacticNew, earlyDefs, parents, selfdef, body)
       case SyntacticDefDef(mods, name, tparams, build.ImplicitParams(vparamss, implparams), tpt, rhs) =>
         if (implparams.nonEmpty)
-          mirrorBuildCall(nme.SyntacticDefDef, reify(mods), reify(name), reify(tparams), 
+          mirrorBuildCall(nme.SyntacticDefDef, reify(mods), reify(name), reify(tparams),
                           reifyBuildCall(nme.ImplicitParams, vparamss, implparams), reify(tpt), reify(rhs))
         else
           reifyBuildCall(nme.SyntacticDefDef, mods, name, tparams, vparamss, tpt, rhs)

--- a/test/files/scalacheck/quasiquotes/TermConstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/TermConstructionProps.scala
@@ -291,4 +291,9 @@ object TermConstructionProps extends QuasiquoteProperties("term construction") {
     val stats2 = List.empty[Tree]
     assert(q"{ ..$stats2 }" ≈ q"")
   }
+
+  property("consistent variable order") = test {
+    val q"$a = $b = $c = $d = $e = $f = $g = $h = $k = $l" = q"a = b = c = d = e = f = g = h = k = l"
+    assert(a ≈ q"a" && b ≈ q"b" && c ≈ q"c" && d ≈ q"d" && e ≈ q"e" && g ≈ q"g" && h ≈ q"h" && k ≈ q"k" && l ≈ q"l")
+  }
 }


### PR DESCRIPTION
Previously a map that was storing bindings of fresh hole variables with
their contents (tree & cardinality) used to be a SortedMap which had
issues with inconsistent key ordering:

```
   "$fresh$prefix$1" < "$fresh$prefix$2"
   ...
   "$fresh$prefix$8" < "$fresh$prefix$9"
   "$fresh$prefix$9" > "$fresh$prefix$10"
```

This issue is solved by using a LinkedHashMap instead (keys are inserted
in the proper order.)

review @retronym
