### PR TITLE
SI-8207 Allow import qualified by self reference

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1407,8 +1407,14 @@ trait Namers extends MethodSynthesis {
       if (expr1.isErrorTyped)
         ErrorType
       else {
-        if (!treeInfo.isStableIdentifierPattern(expr1))
-          typer.TyperErrorGen.UnstableTreeError(expr1)
+        expr1 match {
+          case This(_) =>
+            // SI-8207 okay, typedIdent expands Ident(self) to C.this which doesn't satisfy the next case
+            // TODO should we change `typedIdent` not to expand to the `Ident` to a `This`?
+          case _ if treeInfo.isStableIdentifierPattern(expr1) =>
+          case _ =>
+            typer.TyperErrorGen.UnstableTreeError(expr1)
+        }
 
         val newImport = treeCopy.Import(imp, expr1, selectors).asInstanceOf[Import]
         checkSelectors(newImport)

--- a/test/files/neg/t8207.check
+++ b/test/files/neg/t8207.check
@@ -1,0 +1,7 @@
+t8207.scala:1: error: '.' expected but '}' found.
+class C { import C.this.toString }
+                                 ^
+t8207.scala:3: error: '.' expected but '}' found.
+class D { import D.this.toString }
+                                 ^
+two errors found

--- a/test/files/neg/t8207.scala
+++ b/test/files/neg/t8207.scala
@@ -1,0 +1,3 @@
+class C { import C.this.toString }
+
+class D { import D.this.toString }

--- a/test/files/pos/t8207.scala
+++ b/test/files/pos/t8207.scala
@@ -1,0 +1,6 @@
+class C { me =>
+  import me.{toString => ts}
+  locally(this: me.type)
+  trait T
+  type X = me.T
+}


### PR DESCRIPTION
This regressed in SI-6815 / #2374. We check if the result of
`typedQualifier(Ident(selfReference))` is a stable identifier
pattern. But we actually see the expansion to `C.this`, which
doesn't qualify.

This commit adds a special cases to `importSig` to compensate.
This is safe enough, because the syntax prevents the following:

```
scala> class C { import C.this.toString }
<console>:1: error: '.' expected but '}' found.
       class C { import C.this.toString }
                                        ^
```

So loosening the check here doesn't admit invalid programs.
I've backed this up with a `neg` test.

The enclosed test also checks that we can use the self
reference in a singleton type. (That wasn't broken.)

Maybe it would be more principled to avoid expanding the self
reference in `typedIdent`. I can imagine that the current situation
is a pain for refactoring tools that try to implement a rename
refactoring, for example.

Seems a bit risky at the minute, but I've noted the idea
in a comment.

Review by @adriaanm. 

/cc @misto for discussion about the expansion of the `Ident` to a `This` in the IDE context.
