### PR TITLE
SI-8237 Avoid cyclic constraints when inferring hk type args

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/TypeConstraints.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeConstraints.scala
@@ -257,6 +257,12 @@ private[internal] trait TypeConstraints {
 
     // println("solving "+tvars+"/"+tparams+"/"+(tparams map (_.info)))
     foreach3(tvars, tparams, variances)(solveOne)
-    tvars forall (tv => tv.instWithinBounds || util.andFalse(log(s"Inferred type for ${tv.originString} does not conform to bounds: ${tv.constr}")))
+
+    def logBounds(tv: TypeVar) = log {
+      val what = if (!tv.instValid) "is invalid" else s"does not conform to bounds: ${tv.constr}"
+      s"Inferred type for ${tv.originString} (${tv.inst}) $what"
+    }
+
+    tvars forall (tv => tv.instWithinBounds || util.andFalse(logBounds(tv)))
   }
 }

--- a/test/files/neg/names-defaults-neg.check
+++ b/test/files/neg/names-defaults-neg.check
@@ -88,7 +88,7 @@ names-defaults-neg.scala:76: error: no type parameters for method test4: (x: T[T
  --- because ---
 argument expression's type is not compatible with formal parameter type;
  found   : List[Int]
- required: ?T
+ required: ?T[?T[List[?T[X forSome { type X }]]]]
 Error occurred in an application involving default arguments.
   test4()
   ^

--- a/test/files/neg/t8237-default.check
+++ b/test/files/neg/t8237-default.check
@@ -1,0 +1,13 @@
+t8237-default.scala:5: error: no type parameters for method test4: (x: T[T[List[T[X forSome { type X }]]]])Nothing exist so that it can be applied to arguments (List[Int])
+ --- because ---
+argument expression's type is not compatible with formal parameter type;
+ found   : List[Int]
+ required: ?T[?T[List[?T[X forSome { type X }]]]]
+  test4(test4$default$1)
+  ^
+t8237-default.scala:5: error: type mismatch;
+ found   : List[Int]
+ required: T[T[List[T[X forSome { type X }]]]]
+  test4(test4$default$1)
+        ^
+two errors found

--- a/test/files/neg/t8237-default.scala
+++ b/test/files/neg/t8237-default.scala
@@ -1,0 +1,29 @@
+// This test case was extracte from `names-defaults-neg.scala`
+// It pinpoints an improvement an error message that results from
+// a type inference failure
+object Test extends App {
+  test4(test4$default$1)
+
+  def test4[T[P]](x: T[T[List[T[X forSome { type X }]]]]) = ???
+  def test4$default$1[T[P]]: List[Int] = ???
+}
+
+/*
+OLD:
+ no type parameters for method test4: (x: T[T[List[T[X forSome { type X }]]]])Nothing exist so that it can be applied to arguments (List[Int])
+ --- because ---
+argument expression's type is not compatible with formal parameter type;
+ found   : List[Int]
+ required: ?T
+  test4(test4$default$1)
+  ^
+
+NEW:
+
+no type parameters for method test4: (x: T[T[List[T[X forSome { type X }]]]])Nothing exist so that it can be applied to arguments (List[Int])
+ --- because ---
+argument expression's type is not compatible with formal parameter type;
+ found   : List[Int]
+ required: ?T[?T[List[?T[X forSome { type X }]]]
+  test4(test4$default$1)
+*/

--- a/test/files/pos/t8237.scala
+++ b/test/files/pos/t8237.scala
@@ -1,0 +1,29 @@
+import scala.language.higherKinds
+
+object TestExplicit {
+  trait TC[A]
+  def fTt[A,E[X] <: List[X]](a: A)(implicit tt: TC[E[A]]) = a
+  implicit def tc[T]: TC[T] = ???
+
+  // Typechecking results in SOE in TypeVar.isGround
+  fTt(1)(tc)
+  // fun = TestExplicit.this.fTt[Int, E](1)
+  // args = TestExplicit.this.tc[E[Int]]
+  // argTpes.head.instantiateTypeParams = TC[?E#1[Int]]
+  // formals.head.instantiateTypeParams = TC[?E#2[Int]]
+  //   (where ?E#1 and ?E#2 as distinct AppliedTypeVars that resulted
+  //    from separate applications of type args to the same HKTypeVar, ?E)
+  //
+  // As we check if the argument conforms to the formal, we would have
+  // AppliedTypeVars sharing the same TypeConstraints on the LHS and RHS,
+  // which leads to a cyclic constraint.
+}
+
+object TestImplicit    {
+  trait TC[A]
+  def fTt[A,E[X] <: List[X]](a: A)(implicit tt: TC[E[A]]) = a
+  implicit def tc[T]: TC[T] = ???
+
+  // Oddly enough, this one works.
+  fTt(1)
+}

--- a/test/files/pos/t8237b.scala
+++ b/test/files/pos/t8237b.scala
@@ -1,0 +1,10 @@
+import scala.language.higherKinds
+import scala.reflect.runtime.universe._
+object Test {
+
+  def fTt[A,E[X]<:List[X]](a: A)(implicit tt: TypeTag[E[A]]) = a
+
+  trait TC[A]
+  implicit def TCListInt[A]: TC[A] = ???
+  fTt(1)
+}

--- a/test/files/run/t7319.check
+++ b/test/files/run/t7319.check
@@ -21,7 +21,7 @@ scala> convert(Some[Int](0))
  --- because ---
 argument expression's type is not compatible with formal parameter type;
  found   : Some[Int]
- required: ?F forSome { type _$1 <: ?F forSome { type _$2 } }
+ required: ?F[_$1] forSome { type _$1 <: ?F[_$2] forSome { type _$2 } }
               convert(Some[Int](0))
               ^
 <console>:12: error: type mismatch;


### PR DESCRIPTION
An `AppliedTypeVars` spawned from `HKTypeVar#applyArgs`
(necessarily) shares the same `TypeConstraints`.

But, we can have multiple ATVs based on a single HKTV floating
around during inference, and they can appear on both sides
of type relations. An example of this is traced out in
the enclosed test.

This commit avoids registering upper/lower bound constraints
when this is detected.

In the enclosed test, we end up with an empty set of constraints
for `?E`, which results in inference of Nothing, which is what
we expect.

I have also improved the printing of ATVs (to include the args)
and sharpened the log message when `solve` leaves type variables
instantiated to `NoType`, rather than some other type that doesn't
conform to the bounds. Both of these changes helped me to get
to the bottom of this ticket.

The reported test has quite a checkered history:
- in 2.10.0 it worked, but more by good luck than good planning
- after the fix for SI-7226 / 221f52757aa6, it started crashing
- from 3bd897ba0054f (a merge from 2.10.x just before 2.11.0-M1)
  we started getting a type inference failure, rather than a crash.
  "no type parameters for method exists [...] because cyclic
  instantiation".
- It still crashes in `isGround` in 2.10.3.

Review by @adriaanm
