### PR TITLE
SI-7553 Propagate type of unstable args through dependent methods

### DIFF
--- a/test/files/pos/t7553.scala
+++ b/test/files/pos/t7553.scala
@@ -1,0 +1,36 @@
+import scala.language.{ higherKinds, implicitConversions }
+  
+trait Foo { type Out }
+  
+trait SI {
+  val instance: Foo
+  type Out
+}
+ 
+object Test {
+  def test {
+    def indirect(si: SI)(v: si.instance.Out) = v
+    
+    val foo: Foo { type Out = Int } = ???
+    def conv(i: Foo): SI { type Out = i.Out; val instance: i.type } = ???
+     
+    val converted = conv(foo)
+ 
+    val v1: Int = indirect(converted)(23)  // Okay (after refining the return type `instance` in the return type of `conv`)
+    /*
+    indirect(converted){(v: converted.instance.Out)converted.instance.Out}(
+      23{Int(23)}
+    ){converted.instance.Out};
+    */
+ 
+    val v2: Int = indirect(conv(foo))(23)  // Fails.
+    /*
+    indirect(
+        conv(foo){si.SI{type Out = foo.Out; val instance: si.Test.<refinement>.type}}
+    ){(v: si.instance.Out)si.instance.Out}(
+      23{<error>}
+    ){<error>};
+    */
+ 
+  }
+}

--- a/test/files/pos/t8223.scala
+++ b/test/files/pos/t8223.scala
@@ -1,0 +1,29 @@
+package p {
+  class ViewEnv[AIn] {
+    type A = AIn
+    class SubView { def has(x: A): Boolean = ??? }
+    def get: SubView = new SubView
+  }
+ 
+  trait HasA { type A }
+  trait Indexable[R] extends HasA
+  class ArrayTC[AIn] extends Indexable[Array[AIn]] { type A = AIn }
+}
+ 
+package object p {
+  implicit def arrayTypeClass[A] : ArrayTC[A] = new ArrayTC[A]
+  object intArrayTC extends ArrayTC[Int]
+ 
+  type EnvAlias[W <: HasA] = ViewEnv[W#A]
+  type SubAlias[W <: HasA] = ViewEnv[W#A]#SubView
+ 
+  def f0[R](xs: R)(implicit tc: Indexable[R]): ViewEnv[tc.A]#SubView     = new ViewEnv[tc.A]() get
+  def f1[R](xs: R)(implicit tc: Indexable[R]): EnvAlias[tc.type]#SubView = new ViewEnv[tc.A]() get
+  def f2[R](xs: R)(implicit tc: Indexable[R]): SubAlias[tc.type]         = new ViewEnv[tc.A]() get
+ 
+  def g0 = f0(Array(1)) has 2                   // ok
+  def g1 = f1(Array(1)) has 2                   // ok
+  def g2 = f2(Array(1)) has 2                   // "found: Int(2), required: tc.A"
+  def g3 = f2(Array(1))(new ArrayTC[Int]) has 2 // "found: Int(2), required: tc.A"
+  def g4 = f2(Array(1))(intArrayTC) has 2       // ok
+}


### PR DESCRIPTION
After a soundness fix in , instantiation of dependent
method type results behaved differently for if the argument
from which we were propagating information had a stable type
or not. This is particular to substutition into singleton types
over the parameter in question.

If the argument was stable, it was substituted into singleton
types, such as the one below in the prefix in `a.type#B`
(which is the longhand version of `a.B`)

```
scala> class A { type B >: Null <: AnyRef }
defined class A

scala> object AA extends A { type B = String }
defined object AA

scala> def foo(a: A): a.B = null
foo: (a: A)a.B

scala> foo(AA)
res0: AA.B = null
```

But what if it isn't stable?

```
scala> foo({def a = AA; a: A { type B <: String}})
res3: a.B = null
```

This commit changes that to:

```
scala> foo({def a = AA; a: A { type B <: String}})
res1: a.type with A{type B <: String}#B = null
```

That oddly printed type is missing parens: it should be:

```
(a.type with A{type B <: String})#B
```

It is is a projection from refinement that combines:
  a) the singleton type on the parameter
  b) the type of the argument

Review by @adriaanm
