### PR TITLE
This fixes SI-8251: `ListBuffer.readOnly` destroys List immutability

### DIFF
--- a/src/library/scala/collection/mutable/BufferLike.scala
+++ b/src/library/scala/collection/mutable/BufferLike.scala
@@ -211,9 +211,10 @@ trait BufferLike[A, +This <: BufferLike[A, This] with Buffer[A]]
    */
   override def stringPrefix: String = "Buffer"
 
-  /** Provide a read-only view of this buffer as a sequence
+  /** Provide a read-only view over changing state of this buffer as a sequence
    *  @return  A sequence which refers to this buffer for all its operations.
    */
+  @deprecated("Result of this method will mutate when the buffer is mutated. Use toList (or whatever's appropriate) instead.", "2.11.0")
   def readOnly: scala.collection.Seq[A] = toSeq
 
   /** Creates a new collection containing both the elements of this collection and the provided

--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -13,6 +13,7 @@ package mutable
 import generic._
 import immutable.{List, Nil, ::}
 import java.io._
+import scala.annotation.migration
 
 /** A `Buffer` implementation back up by a list. It provides constant time
  *  prepend and append. Most other operations are linear.
@@ -262,7 +263,7 @@ final class ListBuffer[A]
    *  @param n         the index which refers to the first element to remove.
    *  @param count     the number of elements to remove.
    */
-  @scala.annotation.migration("Invalid input values will be rejected in future releases.", "2.11")
+  @migration("Invalid input values will be rejected in future releases.", "2.11")
   override def remove(n: Int, count: Int) {
     if (n >= len)
       return
@@ -408,8 +409,9 @@ final class ListBuffer[A]
       }
   }
 
-  /** expose the underlying list but do not mark it as exported */
-  override def readOnly: List[A] = start
+  @migration("ListBuffer.readOnly now returns a Seq, not a List.", "2.11.0")
+  @deprecated("This method is deprecated and will be removed.", "2.11.0")
+  override def readOnly: scala.collection.Seq[A] = this
 
   // Private methods
 
@@ -426,7 +428,7 @@ final class ListBuffer[A]
   }
 
   override def equals(that: Any): Boolean = that match {
-    case that: ListBuffer[_] => this.readOnly equals that.readOnly
+    case that: ListBuffer[_] => this.start equals that.start
     case _                   => super.equals(that)
   }
 

--- a/src/library/scala/collection/mutable/Map.scala
+++ b/src/library/scala/collection/mutable/Map.scala
@@ -47,18 +47,6 @@ trait Map[A, B]
    *  @return      a wrapper of the map with a default value
    */
   def withDefaultValue(d: B): mutable.Map[A, B] = new Map.WithDefault[A, B](this, x => d)
-
-  /*  Return a read-only projection of this map.  !!! or just use an (immutable) MapProxy?
-  def readOnly : scala.collection.Map[A, B] = new scala.collection.Map[A, B] {
-    override def size = self.size
-    override def update(key: A, value: B) = self.update(key, value)
-    override def - (elem: A) = self - elem
-    override def iterator = self.iterator
-    override def foreach[U](f: ((A, B)) =>  U) = self.foreach(f)
-    override def empty[C] = self.empty[C]
-    def get(key: A) = self.get(key)
-  }
-  */
 }
 
 /** $factoryInfo

--- a/test/files/run/ListBuffer-readOnly.check
+++ b/test/files/run/ListBuffer-readOnly.check
@@ -1,0 +1,3 @@
+warning: there were 1 deprecation warning(s); re-run with -deprecation for details
+List(1, 2)
+List(1, 2)

--- a/test/files/run/ListBuffer-readOnly.scala
+++ b/test/files/run/ListBuffer-readOnly.scala
@@ -1,0 +1,12 @@
+object Test {
+  def main(args: Array[String]) {
+    val buf = scala.collection.mutable.ListBuffer[Int](1, 2)
+    def f(): List[Int] = buf.readOnly.toList
+
+    val innocent = f()
+    println(innocent)
+
+    buf ++= (1 to 100)
+    println(innocent)
+  }
+}

--- a/test/files/run/t4288.scala
+++ b/test/files/run/t4288.scala
@@ -1,6 +1,6 @@
 object Test {
   def f1 = scala.collection.mutable.ListBuffer(1 to 9: _*).slice(-5, -1)
-  def f2 = scala.collection.mutable.ListBuffer(1 to 9: _*).readOnly.slice(-5, -1)
+  def f2 = List(1 to 9: _*).slice(-5, -1)
   def f3 = Vector(1 to 9: _*).slice(-5, -1)
   def f4 = Traversable(1 to 9: _*).slice(-5, -1)
   def f5 = (1 to 9).toArray.slice(-5, -1)


### PR DESCRIPTION
Method `BufferLike.readOnly` now returns a view over changing state of the buffer.

Discussion:
https://groups.google.com/d/msg/scala-internals/g_-gIWgB8Os/kWazrALbLKEJ
