### PR TITLE
SI-7459 Handle pattern binders used as prefixes in TypeTrees.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
@@ -248,7 +248,10 @@ trait MatchTranslation {
       if (caseDefs forall treeInfo.isCatchCase) caseDefs
       else {
         val swatches = { // switch-catches
-          val bindersAndCases = caseDefs map { caseDef =>
+          // SI-7459 must duplicate here as we haven't commited to switch emission, and just figuring out
+          //         if we can ends up mutating `caseDefs` down in the use of `substituteSymbols` in
+          //         `TypedSubstitution#Substitution`. That is called indirectly by `emitTypeSwitch`.
+          val bindersAndCases = caseDefs.map(_.duplicate) map { caseDef =>
             // generate a fresh symbol for each case, hoping we'll end up emitting a type-switch (we don't have a global scrut there)
             // if we fail to emit a fine-grained switch, have to do translateCase again with a single scrutSym (TODO: uniformize substitution on treemakers so we can avoid this)
             val caseScrutSym = freshSym(pos, pureType(ThrowableTpe))

--- a/test/files/pos/t7459a.scala
+++ b/test/files/pos/t7459a.scala
@@ -1,0 +1,18 @@
+trait SpecialException extends Throwable
+
+object Test {
+  def run() {
+    try {
+      ???
+    } catch {
+      case e: SpecialException => e.isInstanceOf[SpecialException]
+      case e =>
+    }
+
+    // OKAY
+    // (null: Throwable) match {
+    //   case e: SpecialException => e.isInstanceOf[SpecialException]
+    //   case e =>
+    // }
+  }
+}

--- a/test/files/pos/t7459b.scala
+++ b/test/files/pos/t7459b.scala
@@ -1,0 +1,12 @@
+import scala.concurrent._
+import scala.util._
+
+
+class Test {
+  (null: Any) match {
+    case s @ Some(_) => ???
+    case f @ _ => 
+      () => f
+      ???
+  }
+}

--- a/test/files/pos/t7459c.scala
+++ b/test/files/pos/t7459c.scala
@@ -1,0 +1,18 @@
+object Test {
+  trait Universe {
+    type Type
+    type TypeTag[A] >: Null <: TypeTagApi[A]
+    trait TypeTagApi[A] { def tpe: Type }
+  }
+  trait JavaUniverse extends Universe
+
+  trait Mirror[U <: Universe] {
+    def universe: U
+  }
+  (null: Mirror[_]).universe match {
+    case ju: JavaUniverse => 
+      val ju1 = ju
+      val f = {() => (null: ju.TypeTag[Nothing]).tpe }
+  }
+  trait M[A]
+}

--- a/test/files/pos/t7704.scala
+++ b/test/files/pos/t7704.scala
@@ -1,0 +1,10 @@
+class Attr { type V ; class Val }
+class StrAttr extends Attr { type V = String }
+class BoolAttr extends Attr { type V = Boolean }
+ 
+object Main {
+  def f(x: Attr) = x match {
+    case v: StrAttr  => new v.Val
+    case v: BoolAttr => new v.Val
+  }
+}

--- a/test/files/run/t7459a.scala
+++ b/test/files/run/t7459a.scala
@@ -1,0 +1,14 @@
+class LM {
+  class Node[B1]
+  case class CC(n: LM)
+
+  // crash
+  val f: (LM => Any) = {
+    case tttt =>
+      new tttt.Node[Any]()
+  }
+}
+
+object Test extends App {
+  new LM().f(new LM())
+}

--- a/test/files/run/t7459b.scala
+++ b/test/files/run/t7459b.scala
@@ -1,0 +1,16 @@
+class LM {
+  class Node[B1]
+
+  // crash
+  val g: (CC => Any) = {
+    case CC(tttt) =>
+      //tttt.##
+      new tttt.Node[Any]()
+  }
+}
+
+object Test extends App {
+  new LM().g(new CC(new LM()))
+}
+case class CC(n: LM)
+

--- a/test/files/run/t7459c.scala
+++ b/test/files/run/t7459c.scala
@@ -1,0 +1,16 @@
+class LM {
+  class Node[B1]
+
+  // crash
+  val g: (CC => Any) = {
+    case CC(tttt) =>
+      tttt.## // no crash
+      new tttt.Node[Any]()
+  }
+}
+
+object Test extends App {
+  new LM().g(new CC(new LM()))
+}
+case class CC(n: LM)
+

--- a/test/files/run/t7459d.scala
+++ b/test/files/run/t7459d.scala
@@ -1,0 +1,15 @@
+class LM {
+  class Node[B1]
+  case class CC(n: LM)
+
+  // crash
+  val f: (LM => Any) = {
+    case tttt =>
+      val uuuu: (tttt.type, Any) = (tttt, 0)
+      new uuuu._1.Node[Any]()
+  }
+}
+
+object Test extends App {
+  new LM().f(new LM())
+}

--- a/test/files/run/t7459f.scala
+++ b/test/files/run/t7459f.scala
@@ -1,0 +1,12 @@
+object Test extends App {
+  class C
+
+  case class FooSeq(x: Int, y: String, z: C*)
+
+  FooSeq(1, "a", new C()) match {
+    case FooSeq(1, "a", x@_* ) =>
+      //println(x.toList)
+      x.asInstanceOf[x.type]
+      assert(x.isInstanceOf[x.type])
+  }
+}


### PR DESCRIPTION
Match translation was incorrect for:

```
case t => new t.C
case D(t) => new d.C
```

We would end up with Types in TypeTrees referring to the wrong symbols, e.g:

```
// t7459a.scala
((x0$1: this.LM) => {
  case <synthetic> val x1: this.LM = x0$1;
  case4(){
   matchEnd3(new tttt.Node[Any]())
  };
  matchEnd3(x: Any){
    x
}
```

Or:
    // t7459b.scala
     ((x0$1: CC) => {
       case <synthetic> val x1: CC = x0$1;
       case4(){
         if (x1.ne(null))
           matchEnd3(new tttt.Node[Any]())
         else
           case5()
       };

This commit:
- Changes `bindSubPats` to traverse types, as well as terms,
  in search of references to bound symbols
- Changes `Substitution` to reuse `Tree#substituteSymbols` rather
  than the home-brew substitution from `Tree`s to `Tree`s, if the
  `to` trees are all `Ident`s

I had to dance around the awkward handling of "swatches" (exception
handlers that can be implemented with JVM native type switches) by
duplicating trees to avoid seeing the results of `substituteSymbols`
in `caseDefs` after we abandon that approach if we detect the
patterns are too complex late in the game.
