### PR TITLE
[backport] SI-7902 Fix spurious kind error due to an unitialized symbol

### DIFF
--- a/src/reflect/scala/reflect/internal/Kinds.scala
+++ b/src/reflect/scala/reflect/internal/Kinds.scala
@@ -184,6 +184,7 @@ trait Kinds {
           )
         }
         else {
+          hkarg.initialize // SI-7902 otherwise hkarg.typeParams yields List(NoSymbol)!
           debuglog("checkKindBoundsHK recursing to compare params of "+ hkparam +" with "+ hkarg)
           kindErrors ++= checkKindBoundsHK(
             hkarg.typeParams,

--- a/test/files/pos/t7902.scala
+++ b/test/files/pos/t7902.scala
@@ -1,0 +1,17 @@
+import scala.language.higherKinds
+
+object Bug {
+  class Tag[W[M1[X1]]]
+
+  def ofType[W[M2[X2]]]: Tag[W] = ???
+  type InSeq  [M3[X3]] = Some[M3[Any]]
+
+  // fail
+  val x = ofType[InSeq]
+
+  // okay
+  val y: Any = ofType[InSeq]
+  object T {
+    val z = ofType[InSeq]
+  }
+}


### PR DESCRIPTION
Tracked down this error:

```
<none> is invariant, but type Y2 is declared covariant
<none>'s bounds<notype> are stricter than type X2's declared bounds >: Nothing <: Any, <none>'s bounds<notype> are stricter than type Y2's declared bounds >: Nothing <: Any
```

to `Symbol#typeParams` returning `List(NoSymbol)` if the symbol
was not initialized.

This happends in the enclosed test for:

```
// checkKindBoundsHK()
hkArgs   = List(type M3)
hkParams = List(type M2)
```

This commit forces the symbol of the higher-kinded type argument
before checking kind conformance.

A little backstory:

The `List(NoSymbol)` arises from:

```
class PolyTypeCompleter... {
  // @M. If `owner` is an abstract type member, `typeParams` are all NoSymbol (see comment in `completerOf`),
  // otherwise, the non-skolemized (external) type parameter symbols
  override val typeParams = tparams map (_.symbol)
```

The variation that triggers this problem gets into the kind
conformance checks quite early on, during naming of:

```
private[this] val x = ofType[InSeq]
```

The inferred type of which is forced during:

```
def addDerivedTrees(typer: Typer, stat: Tree): List[Tree] = stat match {
  case vd @ ValDef(mods, name, tpt, rhs) if !noFinishGetterSetter(vd) =>
    // If we don't save the annotations, they seem to wander off.
    val annotations = stat.symbol.initialize.annotations
```

(cherry picked from commit 03a06e02483eaf442158339c2edd6bcfd99847a3)

Review by @gkossakowski. This problem hit some more people yesterday.
The fix in master has had four months of battle testing, I think its
suitable for the backport for RC3.
