### PR TITLE
prevents using reify and quasiquotes in the compiler

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -450,7 +450,7 @@ TODO:
     <property name="scalac.args"           value=""/>
     <property name="javac.args"            value=""/>
 
-    <property name="scalac.args.always"    value="-feature" />
+    <property name="scalac.args.always"    value="-feature -Yreify-debug -Yquasiquote-debug" />
     <property name="scalac.args.optimise"  value=""/> <!-- scalac.args.optimise is selectively overridden in certain antcall tasks. -->
     <property name="scalac.args.all"       value="${scalac.args.always} ${scalac.args} ${scalac.args.optimise}"/>
     <property name="scalac.args.locker"    value="${scalac.args.all}"/>


### PR DESCRIPTION
Kind of prevents us from using quasiquoting facilities in scalac,
because those depend on internal APIs that can easily diverge from starr,
creating problems similar to https://groups.google.com/forum/#!topic/scala-internals/K4EoU6q0dek.

This hack doesn't strictly prohibit those facilities from being used,
since I have no good idea about how to do that reliably, but rather
makes reification/quasiquoting print swaths of debug output that are
going to catch someone's eye.
