### PR TITLE
Optimization: use AnyRef map for Namer -> Typer tree handoff

### DIFF
--- a/src/compiler/scala/tools/nsc/CompilationUnits.scala
+++ b/src/compiler/scala/tools/nsc/CompilationUnits.scala
@@ -98,6 +98,11 @@ trait CompilationUnits { global: Global =>
       override def toString = map.toString
     }
 
+    // namer calls typer.computeType(rhs) on DefDef / ValDef when tpt is empty. the result
+    // is cached here and re-used in typedDefDef / typedValDef
+    // Also used to cache imports type-checked by namer.
+    val transformed = new mutable.AnyRefMap[Tree, Tree]
+
     /** things to check at end of compilation unit */
     val toCheck = new ListBuffer[() => Unit]
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
@@ -171,10 +171,10 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
 
   var pickledBytes = 0 // statistics
 
-  val javaNameCache = perRunCaches.newMap[Symbol, Name]()
+  val javaNameCache = perRunCaches.newAnyRefMap[Symbol, Name]()
 
   // unlike javaNameCache, reverseJavaName contains entries only for class symbols and their internal names.
-  val reverseJavaName = perRunCaches.newMap[String, Symbol]()
+  val reverseJavaName = perRunCaches.newAnyRefMap[String, Symbol]()
 
   private def mkFlags(args: Int*)         = args.foldLeft(0)(_ | _)
   private def hasPublicBitSet(flags: Int) = (flags & asm.Opcodes.ACC_PUBLIC) != 0

--- a/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
@@ -427,7 +427,7 @@ trait MethodSynthesis {
       override def derivedSym = basisSym.lazyAccessor
       override def derivedTree: DefDef = {
         val ValDef(_, _, tpt0, rhs0) = tree
-        val rhs1 = transformed.getOrElse(rhs0, rhs0)
+        val rhs1 = context.unit.transformed.getOrElse(rhs0, rhs0)
         val body = (
           if (tree.symbol.owner.isTrait || hasUnitType(basisSym)) rhs1
           else gen.mkAssignAndReturn(basisSym, rhs1)

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1413,7 +1413,7 @@ trait Namers extends MethodSynthesis {
 
         val newImport = treeCopy.Import(imp, expr1, selectors).asInstanceOf[Import]
         checkSelectors(newImport)
-        transformed(imp) = newImport
+        context.unit.transformed(imp) = newImport
         // copy symbol and type attributes back into old expression
         // so that the structure builder will find it.
         expr setSymbol expr1.symbol setType expr1.tpe

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -13,7 +13,7 @@ package scala
 package tools.nsc
 package typechecker
 
-import scala.collection.{ mutable, immutable }
+import scala.collection.{mutable, immutable}
 import scala.reflect.internal.util.{ BatchSourceFile, Statistics, shortClassOfInstance }
 import mutable.ListBuffer
 import symtab.Flags._
@@ -39,7 +39,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
   // namer calls typer.computeType(rhs) on DefDef / ValDef when tpt is empty. the result
   // is cached here and re-used in typedDefDef / typedValDef
   // Also used to cache imports type-checked by namer.
-  val transformed = new mutable.HashMap[Tree, Tree]
+  val transformed = new mutable.AnyRefMap[Tree, Tree]
 
   final val shortenImports = false
 
@@ -52,7 +52,6 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     //println("resetTyper called")
     resetContexts()
     resetImplicits()
-    transformed.clear()
     resetDocComments()
   }
 
@@ -107,6 +106,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     import TyperErrorGen._
     val runDefinitions = currentRun.runDefinitions
     import runDefinitions._
+
+    private val transformed: mutable.Map[Tree, Tree] = unit.transformed
 
     val infer = new Inferencer(context0) {
       // See SI-3281 re undoLog

--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -638,6 +638,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
     unit.problems.clear()
     unit.body = EmptyTree
     unit.status = NotLoaded
+    unit.transformed.clear()
   }
 
   /** Parse unit and create a name index, unless this has already been done before */

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -371,6 +371,8 @@ abstract class SymbolTable extends macros.Universe
     def newMap[K, V]()            = recordCache(mutable.HashMap[K, V]())
     def newSet[K]()               = recordCache(mutable.HashSet[K]())
     def newWeakSet[K <: AnyRef]() = recordCache(new WeakHashSet[K]())
+
+    def newAnyRefMap[K <: AnyRef, V]() = recordCache(mutable.AnyRefMap[K, V]())
     def newGeneric[T](f: => T): () => T = {
       val NoCached: T = null.asInstanceOf[T]
       var cached: T = NoCached


### PR DESCRIPTION
And uses a map per-compilation unit, rather than one per Typer.

No need to cleanup in `reset()`, this way.

Review by @gkossakowski

In my topic/opt2 branch, I used tree attachments as an alternative
to using a map at all. But when I submitted a PR with that change,
the test suite picked up a subtle change in behaviour that I didn't
have time to investigate. Switching to `AnyRefMap` is a lower-risk
patch, but still worthwhile for performance.
