### PR TITLE
SI-8240 Consider rolling back optimizations for List

### DIFF
--- a/test/files/pos/list-optim-check.flags
+++ b/test/files/pos/list-optim-check.flags
@@ -1,0 +1,1 @@
+-optimize

--- a/test/files/pos/list-optim-check.scala
+++ b/test/files/pos/list-optim-check.scala
@@ -1,0 +1,21 @@
+// Tests a map known to crash in optimizer with faster List map in SI-8240.
+// Equivalent tests for collect and flatmap do not crash, but are provided
+// anyway.
+// See ticket SI-8334 for optimizer bug.
+// TODO - Remove this test once SI-8334 is fixed and has its own test.
+class A {
+  def f: Boolean = {
+    val xs = Nil map (_ => return false)
+    true
+  }
+
+  def g: Boolean = {
+    val xs = Nil collect { case _ => return false }
+    true
+  }
+
+  def h: Boolean = {
+    val xs = Nil flatMap { _ => return false }
+    true
+  }
+}


### PR DESCRIPTION
Some compiler-specific optimizations turn out to be very helpful for Lists in general.
- List map can be a lot faster (up to 5x!)
- List collect can be considerably faster (up to 2.5x)
- List flatMap can be a bit faster (1.5x)
- List take can be slightly faster (1.1x) and have better structural sharing

These appear to be unqualified wins (tested), even in a scenario with mixed collections.  This is expected: detecting the builder is faster than the otherwise mandatory object creation, and multiple dispatch is mostly a wash since it was already multiple dispatch in getting to the builder.
