### PR TITLE
Tweak parser entry point for pq""

### DIFF
--- a/src/compiler/scala/tools/reflect/quasiquotes/Parsers.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Parsers.scala
@@ -200,7 +200,7 @@ trait Parsers { self: Quasiquotes =>
 
   object PatternParser extends Parser {
     def entryPoint = { parser =>
-      val pat = parser.noSeq.pattern1()
+      val pat = parser.noSeq.pattern()
       gen.patvarTransformer.transform(pat)
     }
   }

--- a/src/reflect/scala/reflect/api/StandardLiftables.scala
+++ b/src/reflect/scala/reflect/api/StandardLiftables.scala
@@ -143,7 +143,7 @@ trait StandardLiftables { self: Universe =>
       case Apply(ScalaDot(symbol), List(Literal(Constant(name: String)))) if symbol == nme.Symbol => scala.Symbol(name)
     }
 
-    implicit def unliftName[T <: Name : ClassTag]: Unliftable[T] = Unliftable[T] { case Ident(name: T) => name; case Bind(name: T, Ident(nme.WILDCARD)) => name}
+    implicit def unliftName[T <: Name : ClassTag]: Unliftable[T] = Unliftable[T] { case Ident(name: T) => name; case Bind(name: T, Ident(nme.WILDCARD)) => name }
     implicit def unliftType: Unliftable[Type]                    = Unliftable[Type] { case tt: TypeTree if tt.tpe != null => tt.tpe }
     implicit def unliftConstant: Unliftable[Constant]            = Unliftable[Constant] { case Literal(const) => const }
 

--- a/test/files/scalacheck/quasiquotes/PatternConstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/PatternConstructionProps.scala
@@ -29,4 +29,8 @@ object PatternConstructionProps extends QuasiquoteProperties("pattern constructi
   property("splice into casedef") = forAll { (pat: Tree, cond: Tree, body: Tree) =>
     cq"$pat if $cond => $body" ≈ CaseDef(pat, cond, body)
   }
+
+  property("splice into alternative") = forAll { (first: Tree, rest: List[Tree]) =>
+    pq"$first | ..$rest" ≈ Alternative(first :: rest)
+  }
 }

--- a/test/files/scalacheck/quasiquotes/PatternDeconstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/PatternDeconstructionProps.scala
@@ -36,4 +36,9 @@ object PatternDeconstructionProps extends QuasiquoteProperties("pattern deconstr
     val cq"$pat0 if $cond0 => $body0" = cq"$pat if $cond => $body"
     pat0 ≈ pat && cond0 ≈ cond && body0 ≈ body
   }
+
+  property("extract alternative") = forAll { (first: Tree, rest: List[Tree]) =>
+    val pq"$first1 | ..$rest1" = pq"$first | ..$rest"
+    first1 ≈ first && rest1 ≈ rest
+  }
 }


### PR DESCRIPTION
Previously pq"" used `pattern1` which required parens to be used in alternative pattern. This commit tweaks it to support parens-free `pq"a | b"` syntax. Also adds some tests for alternative patterns.

review @xeno-by
