### PR TITLE
SI-8263 Avoid SOE in logicallyEnclosingMember

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2047,9 +2047,10 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
      *  (or, for traits: `$init`) of `C`.
      *
      */
-    def logicallyEnclosingMember: Symbol =
+    final def logicallyEnclosingMember: Symbol =
       if (isLocalDummy) enclClass.primaryConstructor
-      else if (isMethod || isClass) this
+      else if (isMethod || isClass || this == NoSymbol) this
+      else if (this == NoSymbol) { devWarningDumpStack("NoSymbol.logicallyEnclosingMember", 15); this }
       else owner.logicallyEnclosingMember
 
     /** The top-level class containing this symbol. */


### PR DESCRIPTION
Not sure when the regression hit, but we're seeing this in the
SBT build. It's probably a mistake to be calling this method
on somthing that isn't owned by a method, but let's not SOE
in that case.

This is analagous with the way the `NoSymbol#owner` doesnt throw
and exception anymore.

Review by @gkossakowski
