### PR TITLE
SI-6493 more robust symbol handling in existentialTransform

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -470,6 +470,8 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
           // Important: first check the pair has the same kind, since the substitution
           // carries high's type parameter's bounds over to low, so that
           // type equality doesn't consider potentially different bounds on low/high's type params.
+          // In b781e25afe this went from using memberInfo to memberType (now lowType/highType), tested by neg/override.scala.
+          // TODO: was that the right fix? it seems type alias's RHS should be checked by looking at the symbol's info
           if (pair.sameKind && lowType.substSym(low.typeParams, high.typeParams) =:= highType) ()
           else overrideTypeError() // (1.6)
         }

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -305,8 +305,6 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
         import pair._
         val member   = low
         val other    = high
-        def memberTp = lowType
-        def otherTp  = highType
 
         debuglog("Checking validity of %s overriding %s".format(member.fullLocationString, other.fullLocationString))
 
@@ -471,7 +469,9 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
           // carries high's type parameter's bounds over to low, so that
           // type equality doesn't consider potentially different bounds on low/high's type params.
           // In b781e25afe this went from using memberInfo to memberType (now lowType/highType), tested by neg/override.scala.
-          // TODO: was that the right fix? it seems type alias's RHS should be checked by looking at the symbol's info
+          // It seems type alias's RHS should be checked by looking at the symbol's info...
+          // TODO: think this through some more and s/lowType/lowInfo/, s/highType/highInfo/
+          // a more liberal coevolveSym will probably break neg/t4137, unless this is fixed
           if (pair.sameKind && lowType.substSym(low.typeParams, high.typeParams) =:= highType) ()
           else overrideTypeError() // (1.6)
         }

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -467,6 +467,9 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
         //  overrideError("may not override parameterized type");
         // @M: substSym
         def checkOverrideAlias() {
+          // Important: first check the pair has the same kind, since the substitution
+          // carries high's type parameter's bounds over to low, so that
+          // type equality doesn't consider potentially different bounds on low/high's type params.
           if (pair.sameKind && lowType.substSym(low.typeParams, high.typeParams) =:= highType) ()
           else overrideTypeError() // (1.6)
         }

--- a/src/reflect/scala/reflect/internal/SymbolPairs.scala
+++ b/src/reflect/scala/reflect/internal/SymbolPairs.scala
@@ -65,6 +65,7 @@ abstract class SymbolPairs {
     def rootType: Type      = base.thisType
 
     def lowType: Type       = self memberType low
+    def lowInfo: Type       = self memberInfo low
     def lowErased: Type     = erasure.specialErasure(base)(low.tpe)
     def lowClassBound: Type = classBoundAsSeen(low.tpe.typeSymbol)
 

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2203,6 +2203,8 @@ trait Types
      *  have created a new symbol for the one the original sym referred to)
      */
     override def coevolveSym(newPre: Type): Symbol =
+      // the `embeddedSymbol(pre, sym.name) == sym` condition isn't strictly needed,
+      // but I prefer to keep this hack as conservative as possible
       if ((pre ne newPre) && embeddedSymbol(pre, sym.name) == sym) {
         val newSym = embeddedSymbol(newPre, sym.name)
         debuglog(s"co-evolve: ${pre} -> ${newPre}, $sym : ${sym.info} -> $newSym : ${newSym.info}")

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2182,20 +2182,43 @@ trait Types
     // appliedType(sym.info, typeArgs).asSeenFrom(pre, sym.owner)
     override def betaReduce = transform(sym.info.resultType)
 
-    // #3731: return sym1 for which holds: pre bound sym.name to sym and
-    // pre1 now binds sym.name to sym1, conceptually exactly the same
-    // symbol as sym.  The selection of sym on pre must be updated to the
-    // selection of sym1 on pre1, since sym's info was probably updated
-    // by the TypeMap to yield a new symbol, sym1 with transformed info.
-    // @returns sym1
-    override def coevolveSym(pre1: Type): Symbol =
-      if (pre eq pre1) sym else (pre, pre1) match {
-        // don't look at parents -- it would be an error to override alias types anyway
-        case (RefinedType(_, _), RefinedType(_, decls1)) => decls1 lookup sym.name
-        // TODO: is there another way a typeref's symbol can refer to a symbol defined in its pre?
-        case _                                           => sym
-      }
+    /** SI-3731, SI-8177: when prefix is changed to `newPre`, maintain consistency of prefix and sym
+     *  (where the symbol refers to a declaration "embedded" in the prefix).
+     *
+     *  @returns newSym so that `newPre` binds `sym.name` to `newSym`,
+     *                  to remain consistent with `pre` previously binding `sym.name` to `sym`.
+     *
+     *  `newSym` and `sym` are conceptually the same symbols, but some change to our `prefix`
+     *  got them out of whack. (Usually triggered by substitution or `asSeenFrom`.)
+     *  The only kind of "binds" we consider is where `prefix` (or its underlying type)
+     *  is a refined type that declares `sym` (since the old prefix was discarded,
+     *  the old symbol is now stale and we should update it, like in `def rebind`,
+     *  except this is not for overriding symbols -- a vertical move -- but a "lateral" change.)
+     *
+     *  The reason for this hack is that substitution and asSeenFrom clone RefinedTypes and
+     *  their members, without updating the potential references to those members -- here, we aim to patch
+     *  this up, so that: when changing a TypeRef(pre, sym, args) to a TypeRef(pre', sym', args'), and pre
+     *  embeds a symbol sym (pre is a RefinedType(_, Scope(..., sym,...)) or a SingleType with such an
+     *  underlying type), make sure that we update sym' to compensate for the change of pre -> pre' (which may
+     *  have created a new symbol for the one the original sym referred to)
+     */
+    override def coevolveSym(newPre: Type): Symbol =
+      if ((pre ne newPre) && embeddedSymbol(pre, sym.name) == sym) {
+        val newSym = embeddedSymbol(newPre, sym.name)
+        debuglog(s"co-evolve: ${pre} -> ${newPre}, $sym : ${sym.info} -> $newSym : ${newSym.info}")
+        // To deal with erroneous `preNew`, fallback via `orElse sym`, in case `preNew` does not have a decl named `sym.name`.
+        newSym orElse sym
+      } else sym
+
     override def kind = "AliasTypeRef"
+  }
+
+  // Return the symbol named `name` that's "embedded" in tp
+  // This is the case if `tp` is a `T{...; type/val $name ; ...}`,
+  // or a singleton type with such an underlying type.
+  private def embeddedSymbol(tp: Type, name: Name): Symbol = tp.widen match {
+    case RefinedType(_, decls) => decls lookup name
+    case _ => NoSymbol
   }
 
   trait AbstractTypeRef extends NonClassTypeRef {

--- a/test/files/neg/t0764.scala
+++ b/test/files/neg/t0764.scala
@@ -12,3 +12,15 @@ class Main[NextType <: Node](value: Node { type T = NextType })
 
 	new Main[AType]( (value: AType).prepend )
 }
+
+/* TODO: this should compile with a proper fix for SI-8177
+
+Behold the equivalent program which already type checks.
+(Expand type alias, convert type member to type param;
+note the covariance to encode subtyping on type members.)
+
+class Node[+T <: Node[_]] { def prepend = new Node[this.type] }
+class Main[NextType <: Node[_]](value: Node[NextType]) {
+  new Main(value.prepend)
+}
+*/

--- a/test/files/pos/t8177.scala
+++ b/test/files/pos/t8177.scala
@@ -1,0 +1,11 @@
+trait Thing { type A }
+object IntThing extends Thing { type A = Int }
+
+// The following erroneously failed with  error: method f overrides nothing.
+// because asSeenFrom produced a typeref of the shape T'#A where A referred to a symbol defined in a T of times past
+// More precisely, the TypeRef case of TypeMap's mapOver correctly modified prefix
+// from having an underlying type of { type A = Ain } to { type A = Int }, with a new symbol for A (now with info Int),
+// but the symbol in the outer type ref wasn't co-evolved (so it still referred to the { type A = AIn } underlying the old prefix)
+// coEvolveSym used to only look at prefixes that were directly RefinedTypes, but they could also be SingleTypes with an underlying RefinedType
+class View[AIn](val in: Thing { type A = AIn }) {          def f(p: in.A): in.A = p }
+class SubView extends View[Int](IntThing)       { override def f(p: in.A): in.A = p }

--- a/test/files/run/t6493/A_1.scala
+++ b/test/files/run/t6493/A_1.scala
@@ -1,0 +1,8 @@
+// SI-6493: existential abstraction misplaces some symbols,
+// while hiding the class symbols in foo()'s inferred result type,
+// it doesn't replace them by the corresponding existential quantifiers,
+// which lead to a NoSuchMethodError in calling foo() because its signature was messed up
+object one {
+  def foo() = { object Foo { class Bar } ; new Foo.Bar }
+  def module() = { trait T { object Bar } ; (new T {}).Bar }
+}

--- a/test/files/run/t6493/B_2.scala
+++ b/test/files/run/t6493/B_2.scala
@@ -1,0 +1,6 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    one.foo // should not fail...
+    one.module
+  }
+}


### PR DESCRIPTION
To illustrate the problem, let's compute the result type for

```
def foo = { class Foo { class Bar { val b = 2 }}; val f = new Foo; new f.Bar }
```

Note the inconsistent symbol ids in:

```
rawSyms     = List(value f#49740, class Foo#49739, class Bar#49742)
quantifiers + their infos =
  type f.type#49774 <: AnyRef{type Bar#49762 <: AnyRef{val b#49764: Int}} with Singleton,
  type Foo#49775    <: AnyRef{type Bar#49770 <: AnyRef{val b#49772: Int}},
                              type Bar#49773 <: AnyRef{val b#49758: Int}
```

It makes sense to subst the symbols in tp, but the modifyInfo will have
little effect on quantifiers. Luckily, coevolveSym will fix up some of
the inconsistencies, so that we get `f.type#49774.Bar#49762`, which is
extrapolated to `AnyRef{type Bar#49868 <: AnyRef{val b: Int}}#Bar#49868`.

The intermediate type `f.type#49774.Bar#49762` motivates the need for
the `.substSym` above, as `.subst` does not touch the `Bar#49742` in
the `f#49740.Bar#49742` that we start out with.

The remaining problem is that ExistentialExtrapolation will not consider
type Bar#49868 as existentially bound. Instead, it's looking for the
stale version in quantifiers, Bar#49773. If it was looking for Bar#49868,
the result type would simply be `AnyRef{val b: Int}`

TODO: figure out how to compute the full set of quantifiers for extrapolation
      the `doSubst(tp)` will clone more symbols, so we'll probably need to
      traverse its result and somehow correlate the contained symbols to
      those in `quantifiers`...

review by @retronym
