### PR TITLE
SI-8266 Deprecate octal escapes in f-interpolator

### DIFF
--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -172,8 +172,8 @@ object StringContext {
    *  @param  str   The offending string
    *  @param  idx   The index of the offending backslash character in `str`.
    */
-  class InvalidEscapeException(str: String, idx: Int)
-    extends IllegalArgumentException("invalid escape character at index "+idx+" in \""+str+"\"")
+  class InvalidEscapeException(str: String, @deprecatedName('idx) val index: Int)
+    extends IllegalArgumentException("invalid escape character at index "+index+" in \""+str+"\"")
 
   /** Expands standard Scala escape sequences in a string.
    *  Escape sequences are:
@@ -184,7 +184,11 @@ object StringContext {
    *  @param  str  A string that may contain escape sequences
    *  @return The string with all escape sequences expanded.
    */
-  def treatEscapes(str: String): String = {
+  def treatEscapes(str: String): String = treatEscapes0(str, strict = false)
+
+  def processEscapes(str: String): String = treatEscapes0(str, strict = true)
+
+  private def treatEscapes0(str: String, strict: Boolean): String = {
     lazy val bldr = new java.lang.StringBuilder
     val len = str.length
     var start = 0
@@ -201,6 +205,7 @@ object StringContext {
         idx += 1
         if (idx >= len) throw new InvalidEscapeException(str, cur)
         if ('0' <= str(idx) && str(idx) <= '7') {
+          if (strict) throw new InvalidEscapeException(str, cur)
           val leadch = str(idx)
           var oct = leadch - '0'
           idx += 1

--- a/test/files/neg/t8266-invalid-interp.check
+++ b/test/files/neg/t8266-invalid-interp.check
@@ -1,0 +1,10 @@
+t8266-invalid-interp.scala:4: error: Trailing '\' escapes nothing.
+    f"a\",
+       ^
+t8266-invalid-interp.scala:5: error: invalid escape character at index 1 in "a\xc"
+    f"a\xc",
+       ^
+t8266-invalid-interp.scala:7: error: invalid escape character at index 1 in "a\vc"
+    f"a\vc"
+       ^
+three errors found

--- a/test/files/neg/t8266-invalid-interp.scala
+++ b/test/files/neg/t8266-invalid-interp.scala
@@ -1,0 +1,9 @@
+
+trait X {
+  def f = Seq(
+    f"a\",
+    f"a\xc",
+    // following could suggest \u000b for vertical tab, similar for \a alert
+    f"a\vc"
+  )
+}

--- a/test/files/run/t8266-octal-interp.check
+++ b/test/files/run/t8266-octal-interp.check
@@ -1,0 +1,30 @@
+t8266-octal-interp.scala:4: warning: Octal escape literals are deprecated, use \b instead.
+    f"a\10c",
+       ^
+t8266-octal-interp.scala:5: warning: Octal escape literals are deprecated, use \t instead.
+    f"a\11c",
+       ^
+t8266-octal-interp.scala:6: warning: Octal escape literals are deprecated, use \n instead.
+    f"a\12c",
+       ^
+t8266-octal-interp.scala:7: warning: Octal escape literals are deprecated, use \r instead.
+    f"a\15c",
+       ^
+t8266-octal-interp.scala:8: warning: Octal escape literals are deprecated, use \u0022 instead.
+    f"a\42c",
+       ^
+t8266-octal-interp.scala:9: warning: Octal escape literals are deprecated, use \\ instead.
+    f"a\134c",
+       ^
+t8266-octal-interp.scala:10: warning: Octal escape literals are deprecated, use \u0069 instead.
+    f"a\15151515c"
+       ^
+ac
+a	c
+a
+c
+a
+c
+a"c
+a\c
+ai51515c

--- a/test/files/run/t8266-octal-interp.flags
+++ b/test/files/run/t8266-octal-interp.flags
@@ -1,0 +1,1 @@
+-deprecation

--- a/test/files/run/t8266-octal-interp.scala
+++ b/test/files/run/t8266-octal-interp.scala
@@ -1,0 +1,16 @@
+
+trait X {
+  def f = Seq(
+    f"a\10c",
+    f"a\11c",
+    f"a\12c",
+    f"a\15c",
+    f"a\42c",
+    f"a\134c",
+    f"a\15151515c"
+  )
+}
+
+object Test extends App with X {
+  f foreach println
+}


### PR DESCRIPTION
Also turns the f-interpolator into a migration
assistant by suggesting alternatives for the
standard escapes.

Just a little brown-bagged exercise, in case it is useful.

It would have been more fun if it could have recommended replacing `\042` with '$"`.
