### PR TITLE
typecheck(q"class C") no longer crashes

### DIFF
--- a/src/compiler/scala/reflect/macros/contexts/Typers.scala
+++ b/src/compiler/scala/reflect/macros/contexts/Typers.scala
@@ -16,15 +16,11 @@ trait Typers {
   def typecheck(tree: Tree, pt: Type = universe.WildcardType, silent: Boolean = false, withImplicitViewsDisabled: Boolean = false, withMacrosDisabled: Boolean = false): Tree = {
     macroLogVerbose("typechecking %s with expected type %s, implicit views = %s, macros = %s".format(tree, pt, !withImplicitViewsDisabled, !withMacrosDisabled))
     val context = callsiteTyper.context
-    val wrapper1 = if (!withImplicitViewsDisabled) (context.withImplicitsEnabled[Tree] _) else (context.withImplicitsDisabled[Tree] _)
-    val wrapper2 = if (!withMacrosDisabled) (context.withMacrosEnabled[Tree] _) else (context.withMacrosDisabled[Tree] _)
-    def wrapper (tree: => Tree) = wrapper1(wrapper2(tree))
-    // if you get a "silent mode is not available past typer" here
-    // don't rush to change the typecheck not to use the silent method when the silent parameter is false
-    // typechecking uses silent anyways (e.g. in typedSelect), so you'll only waste your time
-    // I'd advise fixing the root cause: finding why the context is not set to report errors
-    // (also see reflect.runtime.ToolBoxes.typeCheckExpr for a workaround that might work for you)
-    wrapper(callsiteTyper.silent(_.typed(universe.duplicateAndKeepPositions(tree), pt), reportAmbiguousErrors = false) match {
+    val withImplicitFlag = if (!withImplicitViewsDisabled) (context.withImplicitsEnabled[Tree] _) else (context.withImplicitsDisabled[Tree] _)
+    val withMacroFlag = if (!withMacrosDisabled) (context.withMacrosEnabled[Tree] _) else (context.withMacrosDisabled[Tree] _)
+    def withContext(tree: => Tree) = withImplicitFlag(withMacroFlag(tree))
+    def typecheckInternal(tree: Tree) = callsiteTyper.silent(_.typed(universe.duplicateAndKeepPositions(tree), pt), reportAmbiguousErrors = false)
+    universe.wrappingIntoTerm(tree)(wrappedTree => withContext(typecheckInternal(wrappedTree) match {
       case universe.analyzer.SilentResultValue(result) =>
         macroLogVerbose(result)
         result
@@ -32,7 +28,7 @@ trait Typers {
         macroLogVerbose(error.err.errMsg)
         if (!silent) throw new TypecheckException(error.err.errPos, error.err.errMsg)
         universe.EmptyTree
-    })
+    }))
   }
 
   def inferImplicitValue(pt: Type, silent: Boolean = true, withMacrosDisabled: Boolean = false, pos: Position = enclosingPosition): Tree = {

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -1676,6 +1676,15 @@ trait Trees extends api.Trees {
 
   def duplicateAndKeepPositions(tree: Tree) = new Duplicator(focusPositions = false) transform tree
 
+  // this is necessary to avoid crashes like https://github.com/scalamacros/paradise/issues/1
+  // when someone tries to c.typecheck a naked MemberDef
+  def wrappingIntoTerm(tree: Tree)(op: Tree => Tree): Tree = {
+    op(build.SyntacticBlock(tree :: Nil)) match {
+      case build.SyntacticBlock(tree :: Nil) => tree
+      case tree => tree
+    }
+  }
+
   // ------ copiers -------------------------------------------
 
   def copyDefDef(tree: Tree)(

--- a/test/files/run/t7185.check
+++ b/test/files/run/t7185.check
@@ -24,9 +24,7 @@ tree: reflect.runtime.universe.Apply =
 scala> {val tb = reflect.runtime.currentMirror.mkToolBox(); tb.typecheck(tree): Any}
 res0: Any =
 {
-  {
-    $read.O.apply()
-  }
+  $read.O.apply()
 }
 
 scala> 

--- a/test/files/run/typecheck/Macros_1.scala
+++ b/test/files/run/typecheck/Macros_1.scala
@@ -1,0 +1,12 @@
+import scala.reflect.macros.whitebox._
+import scala.language.experimental.macros
+
+object Macros {
+  def impl(c: Context) = {
+    import c.universe._
+    c.typecheck(q"class C")
+    q"()"
+  }
+
+  def foo: Any = macro impl
+}

--- a/test/files/run/typecheck/Test_2.scala
+++ b/test/files/run/typecheck/Test_2.scala
@@ -1,0 +1,10 @@
+import scala.reflect.runtime.universe._
+import scala.reflect.runtime.{currentMirror => cm}
+import scala.tools.reflect.ToolBox
+
+object Test extends App {
+  Macros.foo
+
+  val tb = cm.mkToolBox()
+  tb.typecheck(q"class C")
+}


### PR DESCRIPTION
MemberDefs alone can't be typechecked as is, because namer only names
contents of PackageDefs, Templates and Blocks. And, if not named, a tree
can't be typed.

This commit solves this problem by wrapping typecheckees in a trivial block
and then unwrapping the result when it returns back from the typechecker.
