### PR TITLE
A test case for a name binding progression

### DIFF
--- a/test/files/neg/name-lookup-stable.check
+++ b/test/files/neg/name-lookup-stable.check
@@ -1,0 +1,11 @@
+name-lookup-stable.scala:15: error: reference to PrimaryKey is ambiguous;
+it is both defined in class A and imported subsequently by
+import ColumnOption._
+    (null: Any) match { case PrimaryKey => }
+                             ^
+name-lookup-stable.scala:17: error: reference to PrimaryKey is ambiguous;
+it is both defined in class A and imported subsequently by
+import ColumnOption._
+    PrimaryKey // was already ambigious in 2.10.3
+    ^
+two errors found

--- a/test/files/neg/name-lookup-stable.scala
+++ b/test/files/neg/name-lookup-stable.scala
@@ -1,0 +1,20 @@
+// This used to compile under 2.10.3 but the ambiguity is now noticed
+// in 2.11.x (after a70c8219). I think the new behaviour is correct;
+// we shouldn't discard names based on "expected stability" before
+// evaluating ambiguity.
+object ColumnOption {
+  object PrimaryKey
+}
+
+class A {
+  def PrimaryKey: Any = ???
+
+  {
+    import ColumnOption._
+
+    (null: Any) match { case PrimaryKey => }
+
+    PrimaryKey // was already ambigious in 2.10.3
+  }
+}
+


### PR DESCRIPTION
I noticed the change when adapting Slick to work with
Scala 2.11 in `AbstractSourceCodeGenerator.scala`.
The behaviour changed in a70c8219.

This commit locks down the new, correct behaviour with a test.

Review by @gkossakowski

/cc @szeiger, @cvogt
