### PR TITLE
SI-8271 ignore free term values if we can't see them

### DIFF
--- a/test/files/pos/t8271.scala
+++ b/test/files/pos/t8271.scala
@@ -1,0 +1,7 @@
+import scala.language.higherKinds
+import scala.reflect.macros.blackbox.Context
+
+object Macros {
+  def foo(c: Context) = bar[List](c)
+  def bar[M[X]](d: Context)(implicit tcon: d.WeakTypeTag[M[_]]) = ???
+}


### PR DESCRIPTION
Migration of reification from resetAllAttrs to resetLocalAttrs uncovered
a serious bug with reifications of free terms that could emit references
to symbols that don't belong to current lexical scopes. Such symbols can
arise when recursively reifying owners of existentials that can come from
arbitrary places in the program.

This commit ignores values of such free terms (reifying them as ???)
in order to plug an issue that would otherwise be a non-workaroundable
regression in 2.11.0-RC1.

I don't have a very good understanding of this thing, but intuitively
we shouldn't even think of reifying existentials that originate elsewhere.
From what I can see from my brief excursion into typer, a typical approach
of dealing with this is skolemizing existentials that come from elsewhere
and then packing them up by calling existentialAbstraction on created skolems.
Theoretically we could apply the same approach to reified types, but
that will have to remain future work, as that would be too risky for RC1.
