### PR TITLE
SI-8269 tolerates CaseDefs with empty bodies

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2419,7 +2419,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
       val guard1: Tree = if (cdef.guard == EmptyTree) EmptyTree
                          else typed(cdef.guard, BooleanTpe)
-      var body1: Tree = typed(cdef.body, pt)
+      var body1: Tree = typed(cdef.body orElse Literal(Constant(())), pt)
 
       if (context.enclosingCaseDef.savedTypeBounds.nonEmpty) {
         body1 modifyType context.enclosingCaseDef.restoreTypeBounds

--- a/test/files/pos/t8269/Macros_1.scala
+++ b/test/files/pos/t8269/Macros_1.scala
@@ -1,0 +1,21 @@
+import scala.reflect.macros.whitebox._
+import scala.language.experimental.macros
+
+object Macros {
+  def impl(c: Context) = {
+    import c.universe._
+    Try(
+      Literal(Constant(())),
+      CaseDef(
+        Bind(
+          TermName("signal"),
+          Typed(
+            Ident(nme.WILDCARD),
+            Ident(TypeName("Exception")))),
+        EmptyTree,
+        EmptyTree) :: Nil,
+      EmptyTree)
+  }
+
+  def foo: Unit = macro impl
+}

--- a/test/files/pos/t8269/Test_2.scala
+++ b/test/files/pos/t8269/Test_2.scala
@@ -1,0 +1,3 @@
+object Test extends App {
+  Macros.foo
+}


### PR DESCRIPTION
This commit proposes to make `CaseDef(_, _, EmptyTree)` behave the
same as `CaseDef(_, _, Literal(Constant(())))` with respect to typechecking.

It's not like we absolutely have to have that, but it would be definitely
useful for people who don't remember default values of tree parts by heart.
