### PR TITLE
SI-8264 scala.collection.immutable.HashSet#- returns broken Set

### DIFF
--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -350,6 +350,8 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
             Array.copy(elems, 0, elemsNew, 0, offset)
             Array.copy(elems, offset + 1, elemsNew, offset, elems.length - offset - 1)
             val sizeNew = size - sub.size
+            // if we have only one child, which is not a HashTrieSet but a self-contained set like
+            // HashSet1 or HashSetCollision1, return the child instead
             if (elemsNew.length == 1 && !elemsNew(0).isInstanceOf[HashTrieMap[_,_]])
               elemsNew(0)
             else

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -431,15 +431,12 @@ object HashSet extends ImmutableSetFactory[HashSet] {
           case 0 =>
             // the empty set
             null
-          case size if size == ks.size =>
-            // We do this check first since even if the result is of size 1 since
-            // it is preferable to return the existing set for better structural sharing
-            // we can not rely on ks.- returning the same instance if we subtract an element that is not in it
-            // so we need to do the size check
-            this
           case 1 =>
             // create a new HashSet1 with the hash we already know
             new HashSet1(ks1.head, hash)
+          case size if size == ks.size =>
+            // Should only have HSC1 if size > 1
+            this
           case _ =>
             // create a new HashSetCollison with the hash we already know and the new keys
             new HashSetCollision1(hash, ks1)
@@ -861,6 +858,8 @@ object HashSet extends ImmutableSetFactory[HashSet] {
               new HashTrieSet(bitmapNew, elemsNew, sizeNew)
           } else
             null
+        } else if(elems.length == 1 && !subNew.isInstanceOf[HashTrieSet[_]]) {
+          subNew
         } else {
           val elemsNew = new Array[HashSet[A]](elems.length)
           Array.copy(elems, 0, elemsNew, 0, elems.length)

--- a/test/junit/scala/collection/SetMapConsistencyTest.scala
+++ b/test/junit/scala/collection/SetMapConsistencyTest.scala
@@ -507,4 +507,11 @@ class SetMapConsistencyTest {
       case _ => true
     })
   }
+  
+  @Test
+  def testSI8264() {
+    val hs = Set(-2147483648, 1, -45023380, -1, 1971207058, -54312241, -234243394) - -1
+    assert( hs.toList.toSet == hs )
+    assert( hs == hs.toList.toSet )
+  }
 }


### PR DESCRIPTION
Was an error in HashSet's handling of removal of an element when a HashTrieSet should turn into a HashSet1.

Also slightly modified HashMap's filter0 to more closely match HashSet (by adding the same comment).
