### PR TITLE
SI-6908 FlatHashTable and things that depend on it can't store nulls

### DIFF
--- a/src/library/scala/collection/parallel/mutable/ParFlatHashTable.scala
+++ b/src/library/scala/collection/parallel/mutable/ParFlatHashTable.scala
@@ -28,12 +28,12 @@ trait ParFlatHashTable[T] extends scala.collection.mutable.FlatHashTable[T] {
   extends IterableSplitter[T] with SizeMapUtils {
     import scala.collection.DebugUtils._
 
-    private var traversed = 0
-    private val itertable = table
+    private[this] var traversed = 0
+    private[this] val itertable = table
 
     if (hasNext) scan()
 
-    private def scan() {
+    private[this] def scan() {
       while (itertable(idx) eq null) {
         idx += 1
       }

--- a/src/library/scala/collection/parallel/mutable/ParFlatHashTable.scala
+++ b/src/library/scala/collection/parallel/mutable/ParFlatHashTable.scala
@@ -44,7 +44,7 @@ trait ParFlatHashTable[T] extends scala.collection.mutable.FlatHashTable[T] {
     def remaining = totalsize - traversed
     def hasNext = traversed < totalsize
     def next() = if (hasNext) {
-      val r = itertable(idx).asInstanceOf[T]
+      val r = entryToElem(itertable(idx))
       traversed += 1
       idx += 1
       if (hasNext) scan()

--- a/test/files/run/t6908.scala
+++ b/test/files/run/t6908.scala
@@ -1,0 +1,6 @@
+object Test {
+  def main(args: Array[String]) {
+    val set = collection.mutable.Set("1", null, "3").par
+    assert( set exists (_ eq null) )
+  }
+}


### PR DESCRIPTION
Fixed ParFlatHashTable to use entryToElem which correctly converts sentinels to nulls.
