### PR TITLE
SI-8072 rationalize public implicits in scala parallel collections

### DIFF
--- a/src/library/scala/collection/parallel/ParIterableLike.scala
+++ b/src/library/scala/collection/parallel/ParIterableLike.scala
@@ -29,6 +29,8 @@ import scala.annotation.unchecked.uncheckedVariance
 import scala.annotation.unchecked.uncheckedStable
 import scala.language.{ higherKinds, implicitConversions }
 
+import scala.collection.parallel.ParallelCollectionImplicits._
+
 
 /** A template trait for parallel collections of type `ParIterable[T]`.
  *

--- a/src/library/scala/collection/parallel/ParSeqLike.scala
+++ b/src/library/scala/collection/parallel/ParSeqLike.scala
@@ -16,6 +16,7 @@ import scala.collection.generic.CanBuildFrom
 import scala.collection.generic.CanCombineFrom
 import scala.collection.generic.VolatileAbort
 
+import scala.collection.parallel.ParallelCollectionImplicits._
 
 /** A template trait for sequences of type `ParSeq[T]`, representing
  *  parallel sequences with element type `T`.

--- a/test/files/neg/t8072.check
+++ b/test/files/neg/t8072.check
@@ -1,0 +1,4 @@
+t8072.scala:4: error: value ifParSeq is not a member of List[Int]
+  val y = x.ifParSeq[Int](throw new Exception).otherwise(0)  // Shouldn't compile
+            ^
+one error found

--- a/test/files/neg/t8072.scala
+++ b/test/files/neg/t8072.scala
@@ -1,0 +1,6 @@
+class NoIfParSeq {
+  import collection.parallel._
+  val x = List(1,2)
+  val y = x.ifParSeq[Int](throw new Exception).otherwise(0)  // Shouldn't compile
+  val z = x.toParArray
+}


### PR DESCRIPTION
Pretty much everything seems like it's intended for internal use, so I wrapped it in a (deprecated) object.

Split toParArray out and put it in an implicit class.
