### PR TITLE
SI-6632 ListBuffer's updated accepts negative positions

### DIFF
--- a/src/library/scala/collection/SeqLike.scala
+++ b/src/library/scala/collection/SeqLike.scala
@@ -509,11 +509,14 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
   }
 
   def updated[B >: A, That](index: Int, elem: B)(implicit bf: CanBuildFrom[Repr, B, That]): That = {
+    if (index < 0) throw new IndexOutOfBoundsException(index.toString)
     val b = bf(repr)
     val (prefix, rest) = this.splitAt(index)
+    val restColl = toCollection(rest)
+    if (restColl.isEmpty) throw new IndexOutOfBoundsException(index.toString)
     b ++= toCollection(prefix)
     b += elem
-    b ++= toCollection(rest).view.tail
+    b ++= restColl.view.tail
     b.result()
   }
 

--- a/test/files/run/t6632.check
+++ b/test/files/run/t6632.check
@@ -1,3 +1,5 @@
 java.lang.IndexOutOfBoundsException: -1
 java.lang.IndexOutOfBoundsException: -2
 java.lang.IndexOutOfBoundsException: -3
+java.lang.IndexOutOfBoundsException: -1
+java.lang.IndexOutOfBoundsException: 5

--- a/test/files/run/t6632.scala
+++ b/test/files/run/t6632.scala
@@ -3,27 +3,20 @@ object Test extends App {
 
   def newLB = ListBuffer('a, 'b, 'c, 'd, 'e)
 
-  val lb0 = newLB
+  def iiobe[A](f: => A) =
+    try { f }
+    catch { case ex: IndexOutOfBoundsException => println(ex) }
 
-  try {
-    lb0.insert(-1, 'x)
-  } catch {
-    case ex: IndexOutOfBoundsException => println(ex)
-  }
+  val lb0 = newLB
+  iiobe( lb0.insert(-1, 'x) )
 
   val lb1 = newLB
-
-  try {
-    lb1.insertAll(-2, Array('x, 'y, 'z))
-  } catch {
-    case ex: IndexOutOfBoundsException => println(ex)
-  }
+  iiobe( lb1.insertAll(-2, Array('x, 'y, 'z)) )
 
   val lb2 = newLB
+  iiobe( lb2.update(-3, 'u) )
 
-  try {
-    lb2.update(-3, 'u)
-  } catch {
-    case ex: IndexOutOfBoundsException => println(ex)
-  }
+  val lb3 = newLB
+  iiobe( lb3.updated(-1, 'u) )
+  iiobe( lb3.updated(5, 'u) )
 }


### PR DESCRIPTION
Changed the behavior in SeqLike.updated (which would silently accept negatives and throw on empty.tail) to throw IndexOutOfBoundException.

Updated tests to verify the behavior in ListBuffer.  Everything else SeqLike will come along for the ride.
