### PR TITLE
SI-8188 NPE during deserialization of TrieMap

### DIFF
--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -655,8 +655,8 @@ extends scala.collection.concurrent.Map[K, V]
   /* internal methods */
 
   private def writeObject(out: java.io.ObjectOutputStream) {
-    out.writeObject(hashf)
-    out.writeObject(ef)
+    out.writeObject(hashingobj)
+    out.writeObject(equalityobj)
 
     val it = iterator
     while (it.hasNext) {

--- a/test/files/run/t8188.scala
+++ b/test/files/run/t8188.scala
@@ -1,0 +1,25 @@
+object Test {
+  def main(args: Array[String]) {
+    import java.io.ByteArrayInputStream
+    import java.io.ByteArrayOutputStream
+    import java.io.ObjectInputStream
+    import java.io.ObjectOutputStream
+    import scala.collection.concurrent.TrieMap
+   
+    def ser[T](o: T): Array[Byte] = {
+      val baos = new ByteArrayOutputStream()
+      new ObjectOutputStream(baos).writeObject(o)
+      baos.toByteArray()
+    }
+
+    def deser[T](bs: Array[Byte]): T =
+      new ObjectInputStream(new ByteArrayInputStream(bs)).readObject().asInstanceOf[T]
+   
+    def cloneViaSerialization[T](t: T): T = deser(ser(t))
+   
+    val f = cloneViaSerialization(_: TrieMap[Int, Int])
+    val tm = TrieMap(1 -> 2)
+    assert( f(f(tm)) == tm )
+    assert( ser(tm).length == ser(f(tm)).length )
+  }
+}


### PR DESCRIPTION
The writer was using the constructor headf and ef instead of the internal vars hashingobj and equalityobj.
