### PR TITLE
SI-7711 Do not emit extra argv in script body

### DIFF
--- a/src/compiler/scala/tools/nsc/ScriptRunner.scala
+++ b/src/compiler/scala/tools/nsc/ScriptRunner.scala
@@ -19,7 +19,7 @@ import util.Exceptional.unwrap
  *    exec scala "$0" "$@"
  *    !#
  *    Console.println("Hello, world!")
- *    argv.toList foreach Console.println
+ *    args.toList foreach Console.println
  *  </pre>
  *  <p>And here is a batch file example on Windows XP:</p>
  *  <pre>
@@ -29,7 +29,7 @@ import util.Exceptional.unwrap
  *    goto :eof
  *    ::!#
  *    Console.println("Hello, world!")
- *    argv.toList foreach Console.println
+ *    args.toList foreach Console.println
  *  </pre>
  *
  *  @author  Lex Spoon

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -413,12 +413,10 @@ self =>
        *
        *  {{{
        *  object moduleName {
-       *    def main(argv: Array[String]): Unit = {
-       *      val args = argv
+       *    def main(args: Array[String]): Unit =
        *      new AnyRef {
        *        stmts
        *      }
-       *    }
        *  }
        *  }}}
        */
@@ -433,9 +431,8 @@ self =>
 
       // def main
       def mainParamType = AppliedTypeTree(Ident(tpnme.Array), List(Ident(tpnme.String)))
-      def mainParameter = List(ValDef(Modifiers(Flags.PARAM), nme.argv, mainParamType, EmptyTree))
-      def mainSetArgv   = List(ValDef(NoMods, nme.args, TypeTree(), Ident(nme.argv)))
-      def mainDef       = DefDef(NoMods, nme.main, Nil, List(mainParameter), scalaDot(tpnme.Unit), Block(mainSetArgv, gen.mkAnonymousNew(stmts)))
+      def mainParameter = List(ValDef(Modifiers(Flags.PARAM), nme.args, mainParamType, EmptyTree))
+      def mainDef       = DefDef(NoMods, nme.main, Nil, List(mainParameter), scalaDot(tpnme.Unit), gen.mkAnonymousNew(stmts))
 
       // object Main
       def moduleName  = newTermName(ScriptRunner scriptMain settings)

--- a/src/manual/scala/man1/scala.scala
+++ b/src/manual/scala/man1/scala.scala
@@ -215,7 +215,7 @@ object scala extends Command {
       "exec scala \"$0\" \"$@\"\n" +
       "!#\n" +
       "Console.println(\"Hello, world!\")\n" +
-      "argv.toList foreach Console.println"),
+      "args.toList foreach Console.println"),
 
     "Here is a complete Scala script for MS Windows: ",
 
@@ -226,7 +226,7 @@ object scala extends Command {
       "goto :eof\n" +
       "::!#\n" +
       "Console.println(\"Hello, world!\")\n" +
-      "argv.toList foreach Console.println"),
+      "args.toList foreach Console.println"),
 
     "If you want to use the compilation cache to speed up multiple executions " +
     "of the script, then add " & Mono("-savecompiled") & " to the scala " +
@@ -237,7 +237,7 @@ object scala extends Command {
       "exec scala -savecompiled \"$0\" \"$@\"\n" +
       "!#\n" +
       "Console.println(\"Hello, world!\")\n" +
-      "argv.toList foreach Console.println"))
+      "args.toList foreach Console.println"))
 
   val exitStatus = Section("EXIT STATUS",
 

--- a/src/partest-extras/scala/tools/partest/ScriptTest.scala
+++ b/src/partest-extras/scala/tools/partest/ScriptTest.scala
@@ -14,8 +14,9 @@ abstract class ScriptTest extends DirectTest {
   override def extraSettings = s"-usejavacp -Xscript $testmain"
   def scriptPath = testPath changeExtension "script"
   def code = scriptPath.toFile.slurp
+  def argv = Seq.empty[String]
   def show() = {
     compile()
-    ScalaClassLoader(getClass.getClassLoader).run(testmain, Seq.empty[String])
+    ScalaClassLoader(getClass.getClassLoader).run(testmain, argv)
   }
 }

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -640,7 +640,6 @@ trait StdNames {
     val applyDynamicNamed: NameType    = "applyDynamicNamed"
     val applyOrElse: NameType          = "applyOrElse"
     val args : NameType                = "args"
-    val argv : NameType                = "argv"
     val arrayClass: NameType           = "arrayClass"
     val array_apply : NameType         = "array_apply"
     val array_clone : NameType         = "array_clone"

--- a/test/files/run/t7711-script-args.check
+++ b/test/files/run/t7711-script-args.check
@@ -1,0 +1,2 @@
+Hello, scripted test!
+What good news have you for me today?

--- a/test/files/run/t7711-script-args.scala
+++ b/test/files/run/t7711-script-args.scala
@@ -1,0 +1,7 @@
+
+import scala.tools.partest.ScriptTest
+
+object Test extends ScriptTest {
+  override def extraSettings = s"${super.extraSettings} -Xlint"
+  override def argv          = Seq("good", "news")
+}

--- a/test/files/run/t7711-script-args.script
+++ b/test/files/run/t7711-script-args.script
@@ -1,0 +1,12 @@
+#!/bin/bash
+exec ${SCALA_HOME}/bin/scala "$0" "$@" 2>&1
+!#
+
+Console println s"Hello, scripted test!"
+Console println s"What ${args mkString " "} have you for me today?"
+
+//def unused = 88
+//newSource1.scala:8: warning: private method in <$anon: AnyRef> is never used
+//Console println s"Hello, $argv, are you still here?"
+//newSource1.scala:9: error: not found: value argv
+


### PR DESCRIPTION
Take away `argv` and make `args` the standard parameter name.

This is a quick fix to avoid "unused local" lint error.  All
the examples use `args`; in particular, "Step 4. Write some
Scala scripts" in "Programming in Scala" uses `args`.

I see the footnote there is also where Odersky concatenation is
specified, `"Hello, "+ args(0) +"!"` with no space next to the
literals.
