### PR TITLE
SI-7475 use intersection type for pattern type

### DIFF
--- a/src/reflect/scala/reflect/internal/transform/Erasure.scala
+++ b/src/reflect/scala/reflect/internal/transform/Erasure.scala
@@ -60,7 +60,9 @@ trait Erasure {
    */
   protected def unboundedGenericArrayLevel(tp: Type): Int = tp match {
     case GenericArray(level, core) if !(core <:< AnyRefTpe) => level
-    case RefinedType(ps, _) if ps.nonEmpty                  => logResult(s"Unbounded generic level for $tp is")((ps map unboundedGenericArrayLevel).max)
+    case RefinedType(ps, _) if ps.nonEmpty                  => unboundedGenericArrayLevel(intersectionDominator(ps))
+    // used to be `(ps map unboundedGenericArrayLevel).max`, but that's inconsistent with what happens during erasure
+    // consider e.g., `isInstanceOf[Array[Int] with Array[_]]` -- its outcome is decided by intersectionDominator
     case _                                                  => 0
   }
 

--- a/test/files/pos/t7475-patmat.scala
+++ b/test/files/pos/t7475-patmat.scala
@@ -1,0 +1,26 @@
+// After SI-7475 has enforced the rule that private members aren't
+// inherited, we need to make pattern typing less eager to eliinate
+// the "redundant" part of `d: D with C`. Otherwhise, `foo` is not
+// a member of `d.type`.
+class C {
+  private def foo: Any = 0
+  this match {
+    case d: D =>
+      d.foo
+  }
+}
+object C {
+  def test(c: C) = c match {
+    case d: D =>
+      d.foo
+  }
+}
+
+class D extends C
+
+object Other {
+  def test(c: C) = c match {
+    case d: D =>
+      d // here, as before, we can eliminate `C`.
+  }
+}


### PR DESCRIPTION
Usually, the type of a pattern binder is an intersection of
the scrutinee type and the pattern type.

We used to "simplify" this intersection to eliminate
"redundancies", so that `intersect(Sub, Super)` will just
be `Sub` (where `Sub` <:< `Super`).

But, if we are nested in `Super` there is an observable difference
between `Sub` and `Sub with Super`. Only the latter will allow
use to select private members of `Super`.
