### PR TITLE
README.md: Add link to CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ This is the repository for the [Scala Programming Language](http://www.scala-lan
   - [Read about the development of the compiler and the standard library](http://docs.scala-lang.org/scala/);
   - [Check our Jenkins status](https://scala-webapps.epfl.ch/jenkins/);
   - [Download the latest nightly](https://scala-webapps.epfl.ch/jenkins/job/scala-nightly-main-master/ws/dists/latest/*zip*/latest.zip);
-  - ... and contribute right here! Please, first read our [policy](http://docs.scala-lang.org/scala/pull-request-policy.html),
+  - ... and contribute right here! Please, first read our [policy](http://docs.scala-lang.org/scala/pull-request-policy.html), our [development guidelines](CONTRIBUTING.md),
 and [sign the contributor's license agreement](http://typesafe.com/contribute/cla/scala).


### PR DESCRIPTION
I think this link also appears when opening pull requests, but one needs to read this document before pushing the branch.

BTW:
- there's also another version of the pull request policy [here](https://github.com/scala/scala/wiki/Pull-Request-Policy) on the wiki, which is more up-to-date. @heathermiller, I guess this needs consolidation?
- @paulp is listed as the only reviewer for "repl, compiler performance", which seems to place on him a possibly unwanted load. I suspect listing a second reviewer is appropriate. (I don't propose removing him unless he asks to be removed).
