### PR TITLE
Avoid storing source file contents twice

### DIFF
--- a/src/reflect/scala/reflect/internal/util/SourceFile.scala
+++ b/src/reflect/scala/reflect/internal/util/SourceFile.scala
@@ -107,7 +107,7 @@ class ScriptSourceFile(underlying: BatchSourceFile, content: Array[Char], overri
 }
 
 /** a file whose contents do not change over time */
-class BatchSourceFile(val file : AbstractFile, val content0: Array[Char]) extends SourceFile {
+class BatchSourceFile(val file : AbstractFile, content0: Array[Char]) extends SourceFile {
   def this(_file: AbstractFile)                 = this(_file, _file.toCharArray)
   def this(sourceName: String, cs: Seq[Char])   = this(new VirtualFile(sourceName), cs.toArray)
   def this(file: AbstractFile, cs: Seq[Char])   = this(file, cs.toArray)


### PR DESCRIPTION
BatchSourceFile instances contain two almost identical character arrays,
content0 and content. What's worse, content0 is even public. Instead,
content0 should just be a constructor parameter. This seems the residual
of an incomplete refactoring.

I observed this waste of memory during debugging; after applying this
patch, I've verified by hand that the second field indeed disappears.

I don't expect a measurable difference, but this patch is not premature
optimization because it makes code more logical.

Review by @retronym .
