### PR TITLE
SI-8301 fix regression with refinement subtyping, wildcard type.

### DIFF
--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -98,7 +98,7 @@ abstract class TreeInfo {
    */
   def isStableIdentifier(tree: Tree, allowVolatile: Boolean): Boolean =
     tree match {
-      case i @ Ident(_)    => isStableIdent(i)
+      case i @ Ident(_)    => isStableIdent(i, allowVolatile)
       case Select(qual, _) => isStableMemberOf(tree.symbol, qual, allowVolatile) && isPath(qual, allowVolatile)
       case Apply(Select(free @ Ident(_), nme.apply), _) if free.symbol.name endsWith nme.REIFY_FREE_VALUE_SUFFIX =>
         // see a detailed explanation of this trick in `GenSymbols.reifyFreeTerm`
@@ -119,11 +119,11 @@ abstract class TreeInfo {
     typeOk(tree.tpe) && (allowVolatile || !hasVolatileType(tree)) && !definitions.isByNameParamType(tree.tpe)
   )
 
-  private def isStableIdent(tree: Ident): Boolean = (
+  private def isStableIdent(tree: Ident, allowVolatile: Boolean): Boolean = (
        symOk(tree.symbol)
     && tree.symbol.isStable
     && !definitions.isByNameParamType(tree.tpe)
-    && !tree.symbol.hasVolatileType // TODO SPEC: not required by spec
+    && (allowVolatile || !tree.symbol.hasVolatileType) // TODO SPEC: not required by spec
   )
 
   /** Is `tree`'s type volatile? (Ignored if its symbol has the @uncheckedStable annotation.)

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4133,8 +4133,8 @@ trait Types
 
       if (symHi.isTerm)
         (isSubType(tpLo, tpHi, depth)        &&
-         (!symHi.isStable || symLo.isStable) &&                // sub-member must remain stable
-         (!symLo.hasVolatileType || symHi.hasVolatileType))    // sub-member must not introduce volatility
+         (!symHi.isStable || symLo.isStable) &&                                // sub-member must remain stable
+         (!symLo.hasVolatileType || symHi.hasVolatileType || tpHi.isWildcard)) // sub-member must not introduce volatility
       else if (symHi.isAbstractType)
         ((tpHi.bounds containsType tpLo) &&
          kindsConform(symHi :: Nil, tpLo :: Nil, preLo, symLo.owner))

--- a/test/files/pos/t8301.scala
+++ b/test/files/pos/t8301.scala
@@ -1,0 +1,19 @@
+trait Universe {
+  type Symbol >: Null <: AnyRef with SymbolApi
+  trait SymbolApi
+
+  type TypeSymbol >: Null <: TypeSymbolApi with Symbol
+  trait TypeSymbolApi
+
+  implicit class CompatibleSymbol(sym: Symbol) {
+    def asFreeType: TypeSymbol = ???
+  }
+}
+
+object Test extends App {
+  val u: Universe = ???
+  import u._
+
+  val sym: Symbol = ???
+  sym.asFreeType
+}

--- a/test/files/pos/t8301b.scala
+++ b/test/files/pos/t8301b.scala
@@ -1,0 +1,36 @@
+// cf. pos/t8300-patmat.scala
+trait Universe {
+  type Name >: Null <: AnyRef with NameApi
+  trait NameApi
+ 
+  type TermName >: Null <: TermNameApi with Name
+  trait TermNameApi extends NameApi
+}
+ 
+object Test extends App {
+  val u: Universe = ???
+  import u._
+ 
+  val ScalaName: TermName = ???
+  locally {
+    
+    ??? match {
+      case Test.ScalaName => ???
+    }
+    import Test.ScalaName._
+
+    ??? match {
+      case ScalaName => ???
+    }
+    import ScalaName._
+
+    // both the pattern and import led to
+    // stable identifier required, but SN found. Note that value SN 
+    // is not stable because its type, Test.u.TermName, is volatile.
+    val SN = ScalaName
+    ??? match {
+      case SN => ???
+    }
+    import SN._
+  }
+}


### PR DESCRIPTION
In the enclosed test case, the list of candidate implicit is
checked for eligibility with the view by:

```
pt = Test.sym.type => ?{def asFreeType: ?}
tp = (sym: Test.u.Symbol)Test.u.CompatibleSymbol
matchesPt(tp, pt)
```

This ends up in `TypeComparers#specializesSym`, which compares:

   symLo = asFreeType: => Universe.this.TypeSymbol
   symHi = asFreeType: ?

Before the regression in fada1ef6, that method called `isStable`
on both of these to make sure that `symLo` was as least as stable
as `symHi`. Both returned `false`, and, they matched.

After that refactoring, two calls were made. `isStable` _only_
checked for stability, and gave the same results as before.
But, the new check for volatility believes that the low symbol
was more volatile than the high, because `WildCardType` is treated
as non-volatile.

Really, it should have the same volatility as whatever it is
being compared to, so that these sort of comparisons yield true.

This commit ammends `specializesSym` to special case `symHi: ?`,
and ignore the volatilty gap in that case.

Review by @adriaanm, /cc @xeno-by
