### PR TITLE
SI-7932 Exclude PolyTypes from Java generic signatures

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -238,8 +238,11 @@ abstract class Erasure extends AddInterfaces
               if (!(AnyRefTpe <:< bounds.hi)) "+" + boxedSig(bounds.hi)
               else if (!(bounds.lo <:< NullTpe)) "-" + boxedSig(bounds.lo)
               else "*"
-            } else {
-              boxedSig(tp)
+            } else tp match {
+              case PolyType(_, res) =>
+                "*" // SI-7932
+              case _ =>
+                boxedSig(tp)
             }
           def classSig = {
             val preRebound = pre.baseType(sym.owner) // #2585

--- a/test/files/run/t7932.check
+++ b/test/files/run/t7932.check
@@ -1,0 +1,3 @@
+warning: there were 1 feature warning(s); re-run with -feature for details
+public Category<?> C.category()
+public Category<scala.Tuple2> C.category1()

--- a/test/files/run/t7932.scala
+++ b/test/files/run/t7932.scala
@@ -1,0 +1,11 @@
+class Category[M[_, _]]
+trait M[F] {
+  type X[a, b] = F
+  def category: Category[X] = null
+  def category1: Category[Tuple2] = null
+}
+abstract class C extends M[Float]
+object Test extends App {
+  val ms = classOf[C].getMethods.filter(_.getName.startsWith("category"))
+  println(ms.map(_.toGenericString).sorted.mkString("\n"))
+}


### PR DESCRIPTION
In the enclosed test case, we were emitting just the result type of
`[a, b]Float` in the Java generic signature.

This resulted in a `GenericSignatureFormatError`.

This commit changes `argSig` to project such type functions to `*`
instead.

The test case shows that we still emit the class when we use
its type constructor directly as the type argument.

Review by @adriaanm
