### PR TITLE
Optimization: remove assertion from SubstMap constructor

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -667,7 +667,8 @@ private[internal] trait TypeMaps {
 
   /** A base class to compute all substitutions */
   abstract class SubstMap[T](from: List[Symbol], to: List[T]) extends TypeMap {
-    assert(sameLength(from, to), "Unsound substitution from "+ from +" to "+ to)
+    // OPT this check was 2-3% of some profiles, demoted to -Xdev
+    if (isDeveloper) assert(sameLength(from, to), "Unsound substitution from "+ from +" to "+ to)
 
     /** Are `sym` and `sym1` the same? Can be tuned by subclasses. */
     protected def matches(sym: Symbol, sym1: Symbol): Boolean = sym eq sym1


### PR DESCRIPTION
A profile [1] reported 3% of a compile run was spent here.

This commit demotes the eager check to -Xdev.

This assertion was added in e557acb9a7.

[1] https://dl.dropboxusercontent.com/u/106552/perf/rudder-nailgun-2014-02-18-1.snapshot

Review by @adriaanm. I was reminded of this inefficiency
while profiling compilation of @fanf's code base.
