### PR TITLE
SI-8219 Source compatible name for implicit any2stringadd

### DIFF
--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -264,7 +264,8 @@ object Predef extends LowPriorityImplicits with DeprecatedPredef {
     @inline def formatted(fmtstr: String): String = fmtstr format self
   }
 
-  implicit final class StringAdd[A](private val self: A) extends AnyVal {
+  // SI-8229 retaining the pre 2.11 name for source compatibility in shadowing this implicit
+  implicit final class any2stringadd[A](private val self: A) extends AnyVal {
     def +(other: String) = String.valueOf(self) + other
   }
 
@@ -410,7 +411,6 @@ private[scala] trait DeprecatedPredef {
   @deprecated("Use `ArrowAssoc`", "2.11.0") def any2ArrowAssoc[A](x: A): ArrowAssoc[A]                                      = new ArrowAssoc(x)
   @deprecated("Use `Ensuring`", "2.11.0") def any2Ensuring[A](x: A): Ensuring[A]                                            = new Ensuring(x)
   @deprecated("Use `StringFormat`", "2.11.0") def any2stringfmt(x: Any): StringFormat[Any]                                  = new StringFormat(x)
-  @deprecated("Use String interpolation", "2.11.0") def any2stringadd(x: Any): StringAdd[Any]                               = new StringAdd(x)
   @deprecated("Use `Throwable` directly", "2.11.0") def exceptionWrapper(exc: Throwable)                                    = new RichException(exc)
   @deprecated("Use `SeqCharSequence`", "2.11.0") def seqToCharSequence(xs: scala.collection.IndexedSeq[Char]): CharSequence = new SeqCharSequence(xs)
   @deprecated("Use `ArrayCharSequence`", "2.11.0") def arrayToCharSequence(xs: Array[Char]): CharSequence                   = new ArrayCharSequence(xs)

--- a/test/files/neg/logImplicits.check
+++ b/test/files/neg/logImplicits.check
@@ -10,7 +10,7 @@ logImplicits.scala:15: inferred view from String("abc") to Int = C.this.convert:
 logImplicits.scala:19: applied implicit conversion from Int(1) to ?{def ->: ?} = implicit def ArrowAssoc[A](self: A): ArrowAssoc[A]
   def f = (1 -> 2) + "c"
            ^
-logImplicits.scala:19: applied implicit conversion from (Int, Int) to ?{def +: ?} = implicit def StringAdd[A](self: A): StringAdd[A]
+logImplicits.scala:19: applied implicit conversion from (Int, Int) to ?{def +: ?} = implicit def any2stringadd[A](self: A): any2stringadd[A]
   def f = (1 -> 2) + "c"
              ^
 logImplicits.scala:22: error: class Un needs to be abstract, since method unimplemented is not defined

--- a/test/files/neg/predef-masking.scala
+++ b/test/files/neg/predef-masking.scala
@@ -1,5 +1,5 @@
 // Testing predef masking
-import Predef.{ StringAdd => _, _ }
+import Predef.{ any2stringadd => _, _ }
 
 object StringPlusConfusion {
   // Would love to do something about this error message, but by the

--- a/test/files/neg/t8219.check
+++ b/test/files/neg/t8219.check
@@ -1,0 +1,4 @@
+t8219.scala:5: error: value + is not a member of Object
+  o + ""
+    ^
+one error found

--- a/test/files/neg/t8219.scala
+++ b/test/files/neg/t8219.scala
@@ -1,0 +1,6 @@
+import Predef.{any2stringadd => _, _}
+
+object Test {
+  val o = new Object()
+  o + ""
+}


### PR DESCRIPTION
To support the established pattern for disabling it for
an compilation unit.

Review by @adriaanm
