### PR TITLE
SI-3235 math.round() returns wrong results for Int and Long

### DIFF
--- a/src/library/scala/math/package.scala
+++ b/src/library/scala/math/package.scala
@@ -64,11 +64,11 @@ package object math {
 
   def ceil(x: Double): Double  = java.lang.Math.ceil(x)
   def floor(x: Double): Double = java.lang.Math.floor(x)
-
-  /** Returns the `double` value that is closest in value to the
+  
+  /** Returns the `Double` value that is closest in value to the
    *  argument and is equal to a mathematical integer.
    *
-   *  @param  x a `double` value
+   *  @param  x a `Double` value
    *  @return the closest floating-point value to a that is equal to a
    *          mathematical integer.
    */
@@ -93,12 +93,34 @@ package object math {
    */
   def pow(x: Double, y: Double): Double = java.lang.Math.pow(x, y)
 
-  /** Returns the closest `long` to the argument.
+  /** Returns the closest `Int` to the argument, which is just the argument.
+   *  This method exists primarily to help catch errors where a floating-point number is expected but
+   *  the type is `Int` instead.
+   */
+  @deprecated("An Int is already rounded.  Convert to a floating-point type in an earlier step.", "2.11.0")
+  def round(x: Int): Int = x
+
+  /** Returns the closest `Long` to the argument, which is just the argument.
+   *  This method exists primarily to help catch errors where a floating-point number is expected but
+   *  the type is `Int` instead.
+   */
+  @deprecated("A Long is already rounded.  Convert to a floating-point type in an earlier step.", "2.11.0")
+  def round(x: Long): Long = x
+
+  /** Returns the closest `Int` to the argument.  Consider using `rint(x).toInt` instead to make
+   *  explicit the desired return type; `round` can also return a `Long` if applied to a `Double`.
    *
-   *  @param  x a floating-point value to be rounded to a `long`.
-   *  @return the value of the argument rounded to the nearest`long` value.
+   *  @param  x a `Float` floating-point value to be rounded to an `Int`.
+   *  @return the value of the argument rounded to the nearest `Int` value.
    */
   def round(x: Float): Int = java.lang.Math.round(x)
+  
+  /** Returns the closest `Long` to the argument.  Consider using `rint(x).toLong` instead to make
+   *  explicit the desired return type; `round` can also return an `Int` if applied to a `Float`.
+   *
+   *  @param  x a `Double` floating-point value to be rounded to a `Long`.
+   *  @return the value of the argument rounded to the nearest `Long` value.
+   */
   def round(x: Double): Long = java.lang.Math.round(x)
 
   def abs(x: Int): Int       = java.lang.Math.abs(x)

--- a/src/library/scala/runtime/RichDouble.scala
+++ b/src/library/scala/runtime/RichDouble.scala
@@ -43,7 +43,12 @@ final class RichDouble(val self: Double) extends AnyVal with FractionalProxy[Dou
   override def min(that: Double): Double = math.min(self, that)
   override def signum: Int               = math.signum(self).toInt  // !!! NaN
 
+  /** Rounds to the nearest Long.  Consider using `.rint.toLong` instead to make the desired return type explicit. */
   def round: Long   = math.round(self)
+  
+  /** Rounds to the nearest whole number that can still be represented as a `Double`. */
+  def rint: Double  = math.rint(self)
+
   def ceil: Double  = math.ceil(self)
   def floor: Double = math.floor(self)
 

--- a/src/library/scala/runtime/RichFloat.scala
+++ b/src/library/scala/runtime/RichFloat.scala
@@ -43,7 +43,12 @@ final class RichFloat(val self: Float) extends AnyVal with FractionalProxy[Float
   override def min(that: Float): Float = math.min(self, that)
   override def signum: Int             = math.signum(self).toInt  // !!! NaN
 
+  /** Rounds to the nearest Int.  Consider using `.rint.toInt` instead to make the desired return type explicit. */
   def round: Int   = math.round(self)
+  
+  /** Rounds to the nearest whole number that can still be represented as a `Float`. */
+  def rint: Float  = math.rint(self.toDouble).toFloat
+  
   def ceil: Float  = math.ceil(self.toDouble).toFloat
   def floor: Float = math.floor(self.toDouble).toFloat
 

--- a/src/library/scala/runtime/RichInt.scala
+++ b/src/library/scala/runtime/RichInt.scala
@@ -36,7 +36,11 @@ final class RichInt(val self: Int) extends AnyVal with ScalaNumberProxy[Int] wit
   override def max(that: Int): Int = math.max(self, that)
   override def min(that: Int): Int = math.min(self, that)
   override def signum: Int         = math.signum(self)
-
+  
+  /** Utility method to warn when a floating-point operation is applied that has no use on an integer value. */
+  @deprecated("Integers are already rounded.  Did you mean to convert to a floating-point type in an earlier step?  Also consider using .rint.toInt instead of .round to make the desired return type explicit.", "2.11.0")
+  def round: Int = self
+  
   def toBinaryString: String = java.lang.Integer.toBinaryString(self)
   def toHexString: String    = java.lang.Integer.toHexString(self)
   def toOctalString: String  = java.lang.Integer.toOctalString(self)

--- a/src/library/scala/runtime/RichLong.scala
+++ b/src/library/scala/runtime/RichLong.scala
@@ -33,6 +33,22 @@ final class RichLong(val self: Long) extends AnyVal with IntegralProxy[Long] {
   override def min(that: Long): Long = math.min(self, that)
   override def signum: Int           = math.signum(self).toInt
 
+  /** Utility method to warn when a floating-point operation is applied that has no use on an integer value. */
+  @deprecated("Long integers are already rounded.  Did you mean to convert to a floating-point type in an earlier step?  Also consider using .rint.toLong instead of .round to make the desired return type explicit.", "2.11.0")
+  def round: Long = self
+  
+  /** Utility method to warn when a floating-point operation is applied that has no use on an integer value. */
+  @deprecated("Long integers are already rounded to the nearest integer.  Did you mean to convert to a floating-point type earlier?", "2.11.0")
+  def rint: Long = self
+  
+  /** Utility method to warn when a floating-point operation is applied that has no use on an integer value. */
+  @deprecated("Long integers are already rounded up to an integer.  Did you mean to convert to a floating-point type earlier?", "2.11.0")
+  def ceil: Long = self
+  
+  /** Utility method to warn when a floating-point operation is applied that has no use on an integer value. */
+  @deprecated("Long integers are already rounded down to an integer.  Did you mean to convert to a floating-point type earlier?", "2.11.0")
+  def floor: Long = self
+  
   def toBinaryString: String = java.lang.Long.toBinaryString(self)
   def toHexString: String    = java.lang.Long.toHexString(self)
   def toOctalString: String  = java.lang.Long.toOctalString(self)

--- a/test/junit/scala/math/NumericTest.scala
+++ b/test/junit/scala/math/NumericTest.scala
@@ -14,5 +14,21 @@ class NumericTest {
     assertTrue(-0.0.abs equals 0.0)
     assertTrue(-0.0f.abs equals 0.0f)
   }
+  
+  def iAmA(i: Int) = "Int"
+  def iAmA(l: Long) = "Long"
+  def iAmA(f: Float) = "Float"
+  def iAmA(d: Double) = "Double"
+  
+  @Test
+  def testSI3235 {
+    assert(123456789.round == 123456789)
+    assert(1234567890123456789L.round == 1234567890123456789L)
+    assert(iAmA((2.4f).rint) == "Float")
+    assert(iAmA((2.4).rint) == "Double")
+    assert(math.round(123456789) == 123456789)
+    assert(math.round(1234567890123456789L) == 1234567890123456789L)
+    assert(iAmA(math.rint(2.4)) == "Double")
+  }
 }
 


### PR DESCRIPTION
Near-minimal fix for math.round() issue.  (Based on a more extensive fix proposed by soc.)

RichLong intercepts calls to the four floating-point-only methods of .math: round, rint, ceil, and floor.

Also catches round on Int/Long in scala.math.
