### PR TITLE
SI-8224 Fix regression in f-bound aware LUBs

### DIFF
--- a/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
+++ b/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
@@ -37,6 +37,7 @@ abstract class MutableSettings extends AbsSettings {
   def XfullLubs: BooleanSetting
   def XnoPatmatAnalysis: BooleanSetting
   def Xprintpos: BooleanSetting
+  def strictInference: BooleanSetting
   def Yposdebug: BooleanSetting
   def Yrangepos: BooleanSetting
   def Yshowsymowners: BooleanSetting

--- a/src/reflect/scala/reflect/runtime/Settings.scala
+++ b/src/reflect/scala/reflect/runtime/Settings.scala
@@ -33,6 +33,7 @@ private[reflect] class Settings extends MutableSettings {
   val Xexperimental     = new BooleanSetting(false)
   val XfullLubs         = new BooleanSetting(false)
   val XnoPatmatAnalysis = new BooleanSetting(false)
+  val strictInference   = new BooleanSetting(false)
   val Xprintpos         = new BooleanSetting(false)
   val Yposdebug         = new BooleanSetting(false)
   val Yrangepos         = new BooleanSetting(false)

--- a/test/files/pos/t8224.scala
+++ b/test/files/pos/t8224.scala
@@ -1,0 +1,12 @@
+import language.higherKinds
+
+trait P  [N1, +E1[X <: N1]]
+trait PIn[N2, +E2[X <: N2]] extends P[Int,Any]
+
+trait EI extends PIn[Int, Nothing]
+trait NI extends PIn[Int, Nothing]
+
+object Test {
+  val lub = if (true) ??? : EI else ??? : NI
+  val pin: PIn[Int,Nothing] = lub
+}

--- a/test/files/run/t2251.flags
+++ b/test/files/run/t2251.flags
@@ -1,0 +1,1 @@
+-Xstrict-inference

--- a/test/files/run/t2251b.flags
+++ b/test/files/run/t2251b.flags
@@ -1,0 +1,1 @@
+-Xstrict-inference


### PR DESCRIPTION
Disable the heuristic approach to recursive bounds unless
the compiler is running under `-Dscalac.experimental.lub`.
[NOTE: the above part of the patch was authored by @adriaanm,
 the rest is by the commit's original author.]

In db46c71e88, steps were taken to avoid blowing up in the
pathological LUB calculation needed for:

```
def trav = List(List(), Stream())
```

This skipped a level in the base class sequence when f-bounds
were detected at the current level.

In that example, when `lublist` was about to:

```
mergePrefixAndArgs(
  typeOf[LinearSeqOptimized[A, List[A]]],
  typeOf[LinearSeqOptimized[A, Stream[A]]],
)
```

If it proceeded (as in 2.10.3), the LUB is invalid:

```
error: type arguments [B[_ >: D with C <: B[_ >: D with C <: A]],s.c.immutable.LinearSeq[B[_ >: D with C <: A]] with s.c.AbstractSeq[B[_ >: D with C <: A]] with s.c.LinearSeqOptimized[B[_ >: D with C <: A],s.c.immutable.LinearSeq[A] with s.c.AbstractSeq[A] with s.c.LinearSeqOptimized[A,Immutable with Equals with java.io.Serializable] with java.io.Serializable] with java.io.Serializable] do not conform to trait LinearSeqOptimized's type parameter bounds [+A,+Repr <: s.c.LinearSeqOptimized[A,Repr]]
```

To avoid this, the added code would skip to the first non-F-bounded
base type of the same arity of each element in the list. This would
get to:

```
LinearSeqLike[D, Stream[D]]
LinearSeqLike[C, List[C]]
```

which are lubbable without violating the type constraints.

I don't think this was the right remedy. For starters, as seen in
this bug report, SI-8224, if the list of types are identical we
have let a perfectly good lub slip through our fingers, and end up
calculating too general a type.

More generally, if the type arguments in f-bounded positions coincide,
we don't risk calculating a ill-bounded LUB.

Furthermore, the code was widening each of the types separately;
this isn't something we want to do within `if (isUniformFrontier)`.
AFAICT this was just wasteful and as all `ts0` start with the same
type symbol, so `typeConstructorList` should be uniform.

This commit restricts this base-class skipping to situations where
the argument inferred for an type argument that is used as an f-bound
is not:

```
a) an existential (as created by `mergePrefixAndArgs` in invariant
  positions.), or
b) equivalent to one of the corresponding input type arguments
   (this is the case that fixes the regression in pos/8224.scala)
```
