### PR TITLE
SI-4577 singleton type pattern test should use `eq`, not `==`

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -261,7 +261,8 @@ trait MatchApproximation extends TreeAndTypeAnalysis with ScalaLogic with MatchT
                 }
                 def nonNullTest(testedBinder: Symbol)                 = uniqueNonNullProp(binderToUniqueTree(testedBinder))
                 def equalsTest(pat: Tree, testedBinder: Symbol)       = uniqueEqualityProp(binderToUniqueTree(testedBinder), unique(pat))
-                def eqTest(pat: Tree, testedBinder: Symbol)           = uniqueEqualityProp(binderToUniqueTree(testedBinder), unique(pat)) // TODO: eq, not ==
+                // rewrite eq test to type test against the singleton type `pat.tpe`; unrelated to == (uniqueEqualityProp), could be null
+                def eqTest(pat: Tree, testedBinder: Symbol)           = uniqueTypeProp(binderToUniqueTree(testedBinder), uniqueTp(pat.tpe))
                 def tru                                               = True
               }
               ttm.renderCondition(condStrategy)

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
@@ -447,8 +447,7 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
         //  - Scala's arrays are invariant (so we don't drop type tests unsoundly)
         if (extractorArgTypeTest) mkDefault
         else expectedTp match {
-          // TODO: [SPEC] the spec requires `eq` instead of `==` for singleton types - this implies sym.isStable
-          case SingleType(_, sym)                       => and(mkEqualsTest(gen.mkAttributedQualifier(expectedTp)), mkTypeTest)
+          case SingleType(_, sym)                       => mkEqTest(gen.mkAttributedQualifier(expectedTp)) // SI-4577, SI-4897
           case ThisType(sym) if sym.isModule            => and(mkEqualsTest(CODE.REF(sym)), mkTypeTest) // must use == to support e.g. List() == Nil
           case ConstantType(Constant(null)) if isAnyRef => mkEqTest(expTp(CODE.NULL))
           case ConstantType(const)                      => mkEqualsTest(expTp(Literal(const)))

--- a/test/files/run/t4577.scala
+++ b/test/files/run/t4577.scala
@@ -1,0 +1,38 @@
+object Test {
+  val bippy    = new Symbol("bippy")
+  val imposter = new Symbol("bippy")
+  val notBippy = new Symbol("not-bippy")
+  val syms = List(bippy, imposter, notBippy)
+
+  // the equals method should only be used for case `bippy`,
+  // for the singleton type pattern, case _: bippy.type, the spec mandates `bippy eq _` as the test
+  class Symbol(val name: String) {
+    override def equals(other: Any) = other match {
+      case x: Symbol  => name == x.name
+      case _          => false
+    }
+    override def toString = name
+  }
+
+  // TODO: test bytecode equality for f and fDirect (and g and gDirect),
+  // for now the optimizer doesn't quite get from `f` to `fDirect`
+  def f(s: Symbol) = s match {
+    case _: bippy.type  => true
+    case _              => false
+  }
+  def fDirect(s: Symbol) = bippy eq s
+
+  def g(s: Symbol) = s match {
+    case _: bippy.type => 1
+    case `bippy`       => 2
+    case _             => 3
+  }
+  def gDirect(s: Symbol) = if (bippy eq s) 1 else if (bippy == s) 2 else 3
+  
+  def main(args: Array[String]): Unit = {
+    // `syms map f` should be: true false false
+    assert(syms forall (s => f(s) == fDirect(s)))
+    // `syms map g` should be: 1 2 3
+    assert(syms forall (s => g(s) == gDirect(s)))
+  }
+}


### PR DESCRIPTION
I find it hard to imagine anyone is relying on `case x: foo.type =>`
erroneously being compiled to `foo == x` instead of the spec'ed `foo eq x`,
so let's finally fix this.

Maybe my imagination is lacking, so feel free to veto this, @retronym and @gkossakowski.
