### PR TITLE
SI-8306: handle SWITCH nodes with just default case

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/opt/ConstantOptimization.scala
+++ b/src/compiler/scala/tools/nsc/backend/opt/ConstantOptimization.scala
@@ -492,7 +492,10 @@ abstract class ConstantOptimization extends SubComponent {
         case SWITCH(tags, labels) =>
           val in1 = in peek 0
           val reachableNormalLabels = tags zip labels collect { case (tagSet, label) if canSwitch(in1, tagSet) => label }
-          val reachableLabels = if (labels.lengthCompare(tags.length) > 0) {
+          val reachableLabels = if (tags.isEmpty) {
+            assert(labels.size == 1, s"When SWITCH node has empty array of tags it should have just one (default) label: $labels")
+            labels
+          } else if (labels.lengthCompare(tags.length) > 0) {
             // if we've got an extra label then it's the default
             val defaultLabel = labels.last
             // see if the default is reachable by seeing if the input might be out of the set

--- a/test/files/pos/t8306.flags
+++ b/test/files/pos/t8306.flags
@@ -1,0 +1,1 @@
+-optimize

--- a/test/files/pos/t8306.scala
+++ b/test/files/pos/t8306.scala
@@ -1,0 +1,8 @@
+class Si8306 {
+  def foo: Int = 123
+  lazy val extension: Int =
+      foo match {
+          case idx if idx != -1 => 15
+          case _ => 17
+      }
+}


### PR DESCRIPTION
Handle properly SWITCH nodes that contain just a default case in optimizer
(ConstantOptimization). SWITCH with just default case is expressed as a
node with empty tags and exactly one label. We can handle such nodes
easily by introducing a shortcut in logic that computes reachableLabels.

Add a test case which triggers patmat to generate SWITCH node with just
a default case.

Fixes SI-8306.
