### PR TITLE
SI-8197 Overload resolution should not consider default arguments

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1328,7 +1328,7 @@ trait Infer extends Checkable {
         eligible
       else
         eligible filter (alt =>
-          !alt.hasDefault && isApplicableBasedOnArity(alt.tpe, argtpes.length, varargsStar, tuplingAllowed = true)
+          !mexists(alt.info.paramss)(_.hasDefault) && isApplicableBasedOnArity(alt.tpe, argtpes.length, varargsStar, tuplingAllowed = true)
       )
     }
 

--- a/test/files/run/t8197.scala
+++ b/test/files/run/t8197.scala
@@ -1,0 +1,13 @@
+// NOTE: according to SI-4728, this shouldn't even compile...
+class A
+class B
+// default arguments do not participate in overload resolution
+class Foo(val x: A = null) {
+  def this(bla: B*) {
+    this(new A)
+  }
+}
+
+object Test extends App {
+  assert((new Foo).x != null)
+}


### PR DESCRIPTION
The spec says

> Let B be the set of alternatives in A that are applicable (§6.6)
> [...] It is an error if none of the members in B is applicable. If
> there is one single applicable alternative, that alternative is
> chosen. Otherwise, let C be the set of applicable alternatives which
> don’t employ any default argument in the application to e1, ..., em.
> It is again an error if C is empty. Otherwise, one chooses the most
> specific alternative among the alternatives in C [...].

There are many ways to interpret this, but none of them involves
excluding default getters, which is what the old code was doing.
We now exclude all alternatives that define any default arguments.

NOTE: according to SI-4728, this should fail to compile with an
ambiguity error. The compiler has been accepting this program
for all of 2.10.x, as far as I can tell, so let's not change that
for 2.11.0-RC1...
