### PR TITLE
SI-5479 deprecate DelayedInit outside of App

### DIFF
--- a/src/library/scala/App.scala
+++ b/src/library/scala/App.scala
@@ -31,6 +31,8 @@ import scala.collection.mutable.ListBuffer
  *  It should also be noted that the `main` method should not be overridden:
  *  the whole class body becomes the “main method”.
  *
+ *  Future versions of this trait will no longer extend `DelayedInit`.
+ *
  *  @author  Martin Odersky
  *  @version 2.1, 15/02/2011
  */
@@ -38,10 +40,12 @@ trait App extends DelayedInit {
 
   /** The time when the execution of this program started, in milliseconds since 1
     * January 1970 UTC. */
+  @deprecatedOverriding("executionStart should not be overridden", "2.11.0")
   val executionStart: Long = currentTime
 
   /** The command line arguments passed to the application's `main` method.
    */
+  @deprecatedOverriding("args should not be overridden", "2.11.0")
   protected def args: Array[String] = _args
 
   private var _args: Array[String] = _
@@ -55,6 +59,7 @@ trait App extends DelayedInit {
    *  themselves define a `delayedInit` method.
    *  @param body the initialization code to be stored for later execution
    */
+  @deprecated("The delayedInit mechanism will disappear.", "2.11.0")
   override def delayedInit(body: => Unit) {
     initCode += (() => body)
   }

--- a/src/library/scala/DelayedInit.scala
+++ b/src/library/scala/DelayedInit.scala
@@ -43,6 +43,7 @@ package scala
  *
  *  @author  Martin Odersky
  */
+@deprecated("DelayedInit semantics can be surprising.\n(For details and a proposed alternative, see https://issues.scala-lang.org/browse/SI-4330?jql=labels%20%3D%20delayedinit%20AND%20resolution%20%3D%20unresolved. Support for `App` will continue.)", "2.11.0")
 trait DelayedInit {
   def delayedInit(x: => Unit): Unit
 }

--- a/src/library/scala/DelayedInit.scala
+++ b/src/library/scala/DelayedInit.scala
@@ -43,7 +43,7 @@ package scala
  *
  *  @author  Martin Odersky
  */
-@deprecated("DelayedInit semantics can be surprising.\n(For details and a proposed alternative, see https://issues.scala-lang.org/browse/SI-4330?jql=labels%20%3D%20delayedinit%20AND%20resolution%20%3D%20unresolved. Support for `App` will continue.)", "2.11.0")
+@deprecated("DelayedInit semantics can be surprising. Support for `App` will continue.\nSee the release notes for more details: https://github.com/scala/scala/releases/tag/v2.11.0-RC1", "2.11.0")
 trait DelayedInit {
   def delayedInit(x: => Unit): Unit
 }

--- a/test/files/neg/delayed-init-ref.check
+++ b/test/files/neg/delayed-init-ref.check
@@ -4,8 +4,8 @@ delayed-init-ref.scala:17: warning: Selecting value vall from object O, which ex
 delayed-init-ref.scala:19: warning: Selecting value vall from object O, which extends scala.DelayedInit, is likely to yield an uninitialized value
   println(vall)       // warn
           ^
-delayed-init-ref.scala:28: warning: trait DelayedInit in package scala is deprecated: DelayedInit semantics can be surprising.
-(For details and a proposed alternative, see https://issues.scala-lang.org/browse/SI-4330?jql=labels%20%3D%20delayedinit%20AND%20resolution%20%3D%20unresolved. Support for `App` will continue.)
+delayed-init-ref.scala:28: warning: trait DelayedInit in package scala is deprecated: DelayedInit semantics can be surprising. Support for `App` will continue.
+See the release notes for more details: https://github.com/scala/scala/releases/tag/v2.11.0-RC1
 trait Before extends DelayedInit {
                      ^
 delayed-init-ref.scala:40: warning: Selecting value foo from trait UserContext, which extends scala.DelayedInit, is likely to yield an uninitialized value

--- a/test/files/neg/delayed-init-ref.check
+++ b/test/files/neg/delayed-init-ref.check
@@ -4,9 +4,13 @@ delayed-init-ref.scala:17: warning: Selecting value vall from object O, which ex
 delayed-init-ref.scala:19: warning: Selecting value vall from object O, which extends scala.DelayedInit, is likely to yield an uninitialized value
   println(vall)       // warn
           ^
+delayed-init-ref.scala:28: warning: trait DelayedInit in package scala is deprecated: DelayedInit semantics can be surprising.
+(For details and a proposed alternative, see https://issues.scala-lang.org/browse/SI-4330?jql=labels%20%3D%20delayedinit%20AND%20resolution%20%3D%20unresolved. Support for `App` will continue.)
+trait Before extends DelayedInit {
+                     ^
 delayed-init-ref.scala:40: warning: Selecting value foo from trait UserContext, which extends scala.DelayedInit, is likely to yield an uninitialized value
     println({locally(()); this}.foo)  // warn (spurious, but we can't discriminate)
                                 ^
 error: No warnings can be incurred under -Xfatal-warnings.
-three warnings found
+four warnings found
 one error found

--- a/test/files/neg/delayed-init-ref.flags
+++ b/test/files/neg/delayed-init-ref.flags
@@ -1,1 +1,1 @@
--Xlint -Xfatal-warnings
+-deprecation -Xlint -Xfatal-warnings

--- a/test/files/run/delay-bad.check
+++ b/test/files/run/delay-bad.check
@@ -4,6 +4,7 @@ delay-bad.scala:53: warning: a pure expression does nothing in statement positio
 delay-bad.scala:73: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
     f(new { val x = 5 } with E() { 5 })
                                    ^
+warning: there were 1 deprecation warning(s); re-run with -deprecation for details
 
 
 // new C { }

--- a/test/files/run/t4396.check
+++ b/test/files/run/t4396.check
@@ -1,3 +1,4 @@
+warning: there were 1 deprecation warning(s); re-run with -deprecation for details
 hallo
 constructor
 out:22

--- a/test/files/run/t4680.check
+++ b/test/files/run/t4680.check
@@ -4,6 +4,7 @@ t4680.scala:51: warning: a pure expression does nothing in statement position; y
 t4680.scala:69: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
     new { val x = 5 } with E() { 5 }
                                  ^
+warning: there were 1 deprecation warning(s); re-run with -deprecation for details
 
 
 // new C { }

--- a/test/files/run/t6481.check
+++ b/test/files/run/t6481.check
@@ -1,3 +1,4 @@
+warning: there were 1 deprecation warning(s); re-run with -deprecation for details
 delayed init
 new foo(1, 2)
 delayed init


### PR DESCRIPTION
DelayedInit's semantics are way too surprising.

For example, it delays initialization of fields,
so that fields on objects that extend `App`
(which `extends DelayedInit`) are not initialized
until the `main` method is called.

For more details and a proposed alternative,
see https://issues.scala-lang.org/browse/SI-4330?jql=labels%20%3D%20delayedinit%20AND%20resolution%20%3D%20unresolved.

Support for `App` will continue -- we'll special case it.

review by @gkossakowski
