### PR TITLE
SI-6675 deprecation warning for auto-tupling in patterns

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/ScalacPatternExpanders.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/ScalacPatternExpanders.scala
@@ -139,8 +139,8 @@ trait ScalacPatternExpanders {
       def acceptMessage   = if (extractor.isErroneous) "" else s" to hold ${extractor.offeringString}"
       val requiresTupling = isUnapply && patterns.totalArity == 1 && productArity > 1
 
-      if (settings.lint && requiresTupling && effectivePatternArity(args) == 1)
-        currentUnit.warning(sel.pos, s"${sel.symbol.owner} expects $productArity patterns$acceptMessage but crushing into $productArity-tuple to fit single pattern (SI-6675)")
+      if (requiresTupling && effectivePatternArity(args) == 1)
+        currentUnit.deprecationWarning(sel.pos, s"${sel.symbol.owner} expects $productArity patterns$acceptMessage but crushing into $productArity-tuple to fit single pattern (SI-6675)")
 
       val normalizedExtractor = if (requiresTupling) tupleExtractor(extractor) else extractor
       validateAligned(fn, Aligned(patterns, normalizedExtractor))

--- a/test/files/neg/t6675.flags
+++ b/test/files/neg/t6675.flags
@@ -1,1 +1,1 @@
--Xlint -Xfatal-warnings
+-deprecation -Xlint -Xfatal-warnings

--- a/test/files/neg/t6675b.flags
+++ b/test/files/neg/t6675b.flags
@@ -1,1 +1,1 @@
--Xlint
+-deprecation -Xlint

--- a/test/files/pos/t6675.flags
+++ b/test/files/pos/t6675.flags
@@ -1,1 +1,1 @@
--Xfatal-warnings
+-deprecation -Xfatal-warnings

--- a/test/files/run/t6111.check
+++ b/test/files/run/t6111.check
@@ -1,2 +1,3 @@
+warning: there were 2 deprecation warning(s); re-run with -deprecation for details
 (8,8)
 (x,x)

--- a/test/files/run/t6111.scala
+++ b/test/files/run/t6111.scala
@@ -1,3 +1,5 @@
+// SI-6675 DEPRECATED AUTO-TUPLING BECAUSE BAD IDEA -- MEAMAXIMACULPA
+// TODO: remove this test case in 2.12, when the deprecation will go into effect and this will no longer compile
 // slightly overkill, but a good test case for implicit resolution in extractor calls,
 // along with the real fix: an extractor pattern with 1 sub-pattern should type check for all extractors
 // that return Option[T], whatever T (even if it's a tuple)


### PR DESCRIPTION
NOTE: when the deprecation warning becomes an error,
SI-6111 must become a `won't fix`

review by @retronym
