### PR TITLE
SI-6455 no longer rewrite .withFilter to .filter

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4714,7 +4714,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               UnstableTreeError(qualTyped)
           )
           val tree1 = name match {
-            case nme.withFilter => tryWithFilterAndFilter(tree, qualStableOrError)
+            case nme.withFilter if !settings.future => tryWithFilterAndFilter(tree, qualStableOrError)
             case _              => typedSelect(tree, qualStableOrError, name)
           }
           def sym = tree1.symbol

--- a/test/files/neg/t6455.check
+++ b/test/files/neg/t6455.check
@@ -1,0 +1,4 @@
+t6455.scala:5: error: value withFilter is not a member of object O
+  O.withFilter(f => true)
+    ^
+one error found

--- a/test/files/neg/t6455.flags
+++ b/test/files/neg/t6455.flags
@@ -1,0 +1,1 @@
+-Xfuture

--- a/test/files/neg/t6455.scala
+++ b/test/files/neg/t6455.scala
@@ -1,0 +1,6 @@
+object O { def filter(p: Int => Boolean): O.type = this }
+
+class Test {
+  // should not compile because we no longer rewrite withFilter => filter under -Xfuture
+  O.withFilter(f => true)
+}

--- a/test/files/scalacheck/quasiquotes/TypecheckedProps.scala
+++ b/test/files/scalacheck/quasiquotes/TypecheckedProps.scala
@@ -44,7 +44,7 @@ object TypecheckedProps extends QuasiquoteProperties("typechecked") {
     val enums = fq"foo <- new Foo" :: fq"if foo != null" :: Nil
     val body = q"foo"
     val q"$_; for(..$enums1) yield $body1" = typecheck(q"""
-      class Foo { def map(f: Any => Any) = this; def filter(cond: Any => Boolean) = this }
+      class Foo { def map(f: Any => Any) = this; def withFilter(cond: Any => Boolean) = this }
       for(..$enums) yield $body
     """)
     assert(enums1 ≈ enums)

--- a/test/junit/scala/util/TryTest.scala
+++ b/test/junit/scala/util/TryTest.scala
@@ -1,0 +1,35 @@
+package scala.util
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Test
+import org.junit.Assert._
+
+/* Test Try's withFilter method, which was added along with the -Xfuture fix for SI-6455  */
+@RunWith(classOf[JUnit4])
+class TryTest {
+  @Test
+  def withFilterFail(): Unit = {
+    val fail = for (x <- util.Try(1) if x > 1) yield x
+    assert(fail.isFailure)
+  }
+
+  @Test
+  def withFilterSuccess(): Unit = {
+    val success1 = for (x <- util.Try(1) if x >= 1) yield x
+    assertEquals(success1, util.Success(1))
+  }
+
+  @Test
+  def withFilterFlatMap(): Unit = {
+    val successFlatMap = for (x <- util.Try(1) if x >= 1; y <- util.Try(2) if x < y) yield x
+    assertEquals(successFlatMap, util.Success(1))
+  }
+
+  @Test
+  def withFilterForeach(): Unit = {
+    var ok = false
+    for (x <- util.Try(1) if x == 1) ok = x == 1
+    assert(ok)
+  }
+}


### PR DESCRIPTION
This has been deprecated for two major releases now,
and during that time caused plenty of harm (see also SI-7239).

Time to retire, rewrite.

What say ye, @gkossakowski, @Ichoran & @retronym?
