### PR TITLE
SI-8316 SI-8318 SI-8248 reintroduces resetAllAttrs

### DIFF
--- a/src/compiler/scala/reflect/reify/Reifier.scala
+++ b/src/compiler/scala/reflect/reify/Reifier.scala
@@ -110,10 +110,18 @@ abstract class Reifier extends States
       // todo. this is a common problem with non-trivial macros in our current macro system
       // needs to be solved some day
       // upd. a new hope: https://groups.google.com/forum/#!topic/scala-internals/TtCTPlj_qcQ
-      val untyped = resetAttrs(result, leaveAlone = {
+      var importantSymbols = Set[Symbol](
+        NothingClass, AnyClass, SingletonClass, PredefModule, ScalaRunTimeModule, TypeCreatorClass, TreeCreatorClass, MirrorClass,
+        ApiUniverseClass, JavaUniverseClass, ReflectRuntimePackage, runDefinitions.ReflectRuntimeCurrentMirror)
+      importantSymbols ++= importantSymbols map (_.companionSymbol)
+      importantSymbols ++= importantSymbols map (_.moduleClass)
+      importantSymbols ++= importantSymbols map (_.linkedClassOfClass)
+      def isImportantSymbol(sym: Symbol): Boolean = sym != null && sym != NoSymbol && importantSymbols(sym)
+      val untyped = brutallyResetAttrs(result, leaveAlone = {
         case ValDef(_, u, _, _) if u == nme.UNIVERSE_SHORT => true
         case ValDef(_, m, _, _) if m == nme.MIRROR_SHORT => true
         case tree if symtab.syms contains tree.symbol => true
+        case tree if isImportantSymbol(tree.symbol) => true
         case _ => false
       })
 

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2288,7 +2288,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           val sym2 = namer.enterInScope(
             context.owner.newLabel(ldef.name, ldef.pos) setInfo MethodType(List(), restpe))
           val LabelDef(_, _, rhs1) = resetAttrs(ldef)
-          val rhs2 = typed(rhs1, restpe)
+          val rhs2 = typed(brutallyResetAttrs(rhs1), restpe)
           ldef.params foreach (param => param setType param.symbol.tpe)
           deriveLabelDef(ldef)(_ => rhs2) setSymbol sym2 setType restpe
         }

--- a/test/files/run/macro-reify-chained1/Impls_Macros_1.scala
+++ b/test/files/run/macro-reify-chained1/Impls_Macros_1.scala
@@ -1,6 +1,7 @@
 import scala.reflect.runtime.universe._
 import scala.reflect.runtime.{universe => ru}
 import scala.reflect.macros.blackbox.Context
+import scala.language.experimental.macros
 
 case class Utils[C <: Context]( c:C ) {
   import c.universe._
@@ -34,7 +35,7 @@ object QueryableMacros{
     c.universe.reify{ Queryable.factory[S]( foo.splice )}
   }
   def map[T:c.WeakTypeTag, S:c.WeakTypeTag]
-               (c: scala.reflect.macros.blackbox.Context)
+               (c: Context)
                (projection: c.Expr[T => S]): c.Expr[Queryable[S]] = _helper[c.type,S]( c )( "_map", projection )
 }
 class Queryable[T]{

--- a/test/files/run/macro-reify-chained1/Test_2.scala
+++ b/test/files/run/macro-reify-chained1/Test_2.scala
@@ -1,0 +1,9 @@
+object Test extends App{
+  val q : Queryable[Any] = new Queryable[Any]
+  q.map(x => x).map(x => x)
+
+  locally {
+    val q : Queryable[Any] = new Queryable[Any]
+    q.map(x => x).map(x => x)
+  }
+}

--- a/test/files/run/macro-reify-chained2/Impls_Macros_1.scala
+++ b/test/files/run/macro-reify-chained2/Impls_Macros_1.scala
@@ -1,0 +1,47 @@
+import scala.reflect.runtime.universe._
+import scala.reflect.runtime.{universe => ru}
+import scala.reflect.macros.whitebox.Context
+import scala.language.experimental.macros
+
+case class Utils[C <: Context]( c:C ) {
+  import c.universe._
+  import c.{Tree=>_}
+  object removeDoubleReify extends c.universe.Transformer {
+    def apply( tree:Tree ) = transform(tree)
+    override def transform(tree: Tree): Tree = {
+      super.transform {
+        tree match {
+          case  Apply(TypeApply(Select(_this, termname), _), reification::Nil )
+                if termname.toString == "factory" => c.unreifyTree(reification)
+          case Apply(Select(_this, termname), reification::Nil )
+               if termname.toString == "factory" => c.unreifyTree(reification)
+          case _ => tree
+        }
+      }
+    }
+  }
+}
+object QueryableMacros{
+  def _helper[C <: Context,S:c.WeakTypeTag]( c:C )( name:String, projection:c.Expr[_] ) = {
+    import c.universe._
+    import internal._
+    val element_type = implicitly[c.WeakTypeTag[S]].tpe
+    val foo = c.Expr[ru.Expr[Queryable[S]]](
+    c.reifyTree( gen.mkRuntimeUniverseRef, EmptyTree, c.typecheck(
+      Utils[c.type](c).removeDoubleReify(
+        Apply(Select(c.prefix.tree, TermName( name )), List( projection.tree ))
+       ).asInstanceOf[Tree]
+      )))
+    c.universe.reify{ Queryable.factory[S]( foo.splice )}
+  }
+  def map[T:c.WeakTypeTag, S:c.WeakTypeTag]
+               (c: Context)
+               (projection: c.Expr[T => S]): c.Expr[Queryable[S]] = _helper[c.type,S]( c )( "_map", projection )
+}
+class Queryable[T]{
+  def _map[S]( projection: T => S ) : Queryable[S] = ???
+  def map[S]( projection: T => S ) : Queryable[S] = macro QueryableMacros.map[T,S]
+}
+object Queryable{
+  def factory[S]( projection:ru.Expr[Queryable[S]] ) : Queryable[S] = null
+}

--- a/test/files/run/macro-reify-chained2/Test_2.scala
+++ b/test/files/run/macro-reify-chained2/Test_2.scala
@@ -1,0 +1,9 @@
+object Test extends App{
+  val q : Queryable[Any] = new Queryable[Any]
+  q.map(x => x).map(x => x)
+
+  locally {
+    val q : Queryable[Any] = new Queryable[Any]
+    q.map(x => x).map(x => x)
+  }
+}

--- a/test/files/run/macro-reify-nested-a.flags
+++ b/test/files/run/macro-reify-nested-a.flags
@@ -1,1 +1,0 @@
--language:experimental.macros

--- a/test/files/run/macro-reify-nested-a1/Impls_Macros_1.scala
+++ b/test/files/run/macro-reify-nested-a1/Impls_Macros_1.scala
@@ -1,6 +1,7 @@
 import scala.reflect.runtime.universe._
 import scala.reflect.runtime.{universe => ru}
 import scala.reflect.macros.blackbox.Context
+import scala.language.experimental.macros
 
 case class Utils[C <: Context]( c:C ) {
   import c.universe._
@@ -34,7 +35,7 @@ object QueryableMacros{
     c.universe.reify{ Queryable.factory[S]( foo.splice )}
   }
   def map[T:c.WeakTypeTag, S:c.WeakTypeTag]
-               (c: scala.reflect.macros.blackbox.Context)
+               (c: Context)
                (projection: c.Expr[T => S]): c.Expr[Queryable[S]] = _helper[c.type,S]( c )( "_map", projection )
 }
 class Queryable[T]{

--- a/test/files/run/macro-reify-nested-a1/Test_2.scala
+++ b/test/files/run/macro-reify-nested-a1/Test_2.scala
@@ -1,4 +1,9 @@
 object Test extends App{
   val q : Queryable[Any] = new Queryable[Any]
   q.map(e1 => q.map(e2=>e1))
+
+  locally {
+    val q : Queryable[Any] = new Queryable[Any]
+    q.map(e1 => q.map(e2=>e1))
+  }
 }

--- a/test/files/run/macro-reify-nested-a2/Impls_Macros_1.scala
+++ b/test/files/run/macro-reify-nested-a2/Impls_Macros_1.scala
@@ -1,0 +1,47 @@
+import scala.reflect.runtime.universe._
+import scala.reflect.runtime.{universe => ru}
+import scala.reflect.macros.whitebox.Context
+import scala.language.experimental.macros
+
+case class Utils[C <: Context]( c:C ) {
+  import c.universe._
+  import c.{Tree=>_}
+  object removeDoubleReify extends c.universe.Transformer {
+    def apply( tree:Tree ) = transform(tree)
+    override def transform(tree: Tree): Tree = {
+      super.transform {
+        tree match {
+          case  Apply(TypeApply(Select(_this, termname), _), reification::Nil )
+                if termname.toString == "factory" => c.unreifyTree(reification)
+          case Apply(Select(_this, termname), reification::Nil )
+               if termname.toString == "factory" => c.unreifyTree(reification)
+          case _ => tree
+        }
+      }
+    }
+  }
+}
+object QueryableMacros{
+  def _helper[C <: Context,S:c.WeakTypeTag]( c:C )( name:String, projection:c.Expr[_] ) = {
+    import c.universe._
+    import internal._
+    val element_type = implicitly[c.WeakTypeTag[S]].tpe
+    val foo = c.Expr[ru.Expr[Queryable[S]]](
+    c.reifyTree( gen.mkRuntimeUniverseRef, EmptyTree, c.typecheck(
+      Utils[c.type](c).removeDoubleReify(
+        Apply(Select(c.prefix.tree, TermName( name )), List( projection.tree ))
+       ).asInstanceOf[Tree]
+      )))
+    c.universe.reify{ Queryable.factory[S]( foo.splice )}
+  }
+  def map[T:c.WeakTypeTag, S:c.WeakTypeTag]
+               (c: Context)
+               (projection: c.Expr[T => S]): c.Expr[Queryable[S]] = _helper[c.type,S]( c )( "_map", projection )
+}
+class Queryable[T]{
+  def _map[S]( projection: T => S ) : Queryable[S] = ???
+  def map[S]( projection: T => S ) : Queryable[S] = macro QueryableMacros.map[T,S]
+}
+object Queryable{
+  def factory[S]( projection:ru.Expr[Queryable[S]] ) : Queryable[S] = null
+}

--- a/test/files/run/macro-reify-nested-a2/Test_2.scala
+++ b/test/files/run/macro-reify-nested-a2/Test_2.scala
@@ -1,0 +1,9 @@
+object Test extends App{
+  val q : Queryable[Any] = new Queryable[Any]
+  q.map(e1 => q.map(e2=>e1))
+
+  locally {
+    val q : Queryable[Any] = new Queryable[Any]
+    q.map(e1 => q.map(e2=>e1))
+  }
+}

--- a/test/files/run/macro-reify-nested-b.flags
+++ b/test/files/run/macro-reify-nested-b.flags
@@ -1,1 +1,0 @@
--language:experimental.macros

--- a/test/files/run/macro-reify-nested-b1/Impls_Macros_1.scala
+++ b/test/files/run/macro-reify-nested-b1/Impls_Macros_1.scala
@@ -1,0 +1,47 @@
+import scala.reflect.runtime.universe._
+import scala.reflect.runtime.{universe => ru}
+import scala.reflect.macros.blackbox.Context
+import scala.language.experimental.macros
+
+case class Utils[C <: Context]( c:C ) {
+  import c.universe._
+  import c.{Tree=>_}
+  object removeDoubleReify extends c.universe.Transformer {
+    def apply( tree:Tree ) = transform(tree)
+    override def transform(tree: Tree): Tree = {
+      super.transform {
+        tree match {
+          case  Apply(TypeApply(Select(_this, termname), _), reification::Nil )
+                if termname.toString == "factory" => c.unreifyTree(reification)
+          case Apply(Select(_this, termname), reification::Nil )
+               if termname.toString == "factory" => c.unreifyTree(reification)
+          case _ => tree
+        }
+      }
+    }
+  }
+}
+object QueryableMacros{
+  def _helper[C <: Context,S:c.WeakTypeTag]( c:C )( name:String, projection:c.Expr[_] ) = {
+    import c.universe._
+    import internal._
+    val element_type = implicitly[c.WeakTypeTag[S]].tpe
+    val foo = c.Expr[ru.Expr[Queryable[S]]](
+    c.reifyTree( gen.mkRuntimeUniverseRef, EmptyTree, c.typecheck(
+      Utils[c.type](c).removeDoubleReify(
+        Apply(Select(c.prefix.tree, TermName( name )), List( projection.tree ))
+       ).asInstanceOf[Tree]
+      )))
+    c.universe.reify{ Queryable.factory[S]( foo.splice )}
+  }
+  def map[T:c.WeakTypeTag, S:c.WeakTypeTag]
+               (c: Context)
+               (projection: c.Expr[T => S]): c.Expr[Queryable[S]] = _helper[c.type,S]( c )( "_map", projection )
+}
+class Queryable[T]{
+  def _map[S]( projection: T => S ) : Queryable[S] = ???
+  def map[S]( projection: T => S ) : Queryable[S] = macro QueryableMacros.map[T,S]
+}
+object Queryable{
+  def factory[S]( projection:ru.Expr[Queryable[S]] ) : Queryable[S] = null
+}

--- a/test/files/run/macro-reify-nested-b1/Test_2.scala
+++ b/test/files/run/macro-reify-nested-b1/Test_2.scala
@@ -1,4 +1,9 @@
 object Test extends App{
   val q : Queryable[Any] = new Queryable[Any]
   q.map(e1 => q.map(e2=>e1).map(e2=>e1))
+
+  locally {
+    val q : Queryable[Any] = new Queryable[Any]
+    q.map(e1 => q.map(e2=>e1).map(e2=>e1))
+  }
 }

--- a/test/files/run/macro-reify-nested-b2/Impls_Macros_1.scala
+++ b/test/files/run/macro-reify-nested-b2/Impls_Macros_1.scala
@@ -1,0 +1,47 @@
+import scala.reflect.runtime.universe._
+import scala.reflect.runtime.{universe => ru}
+import scala.reflect.macros.whitebox.Context
+import scala.language.experimental.macros
+
+case class Utils[C <: Context]( c:C ) {
+  import c.universe._
+  import c.{Tree=>_}
+  object removeDoubleReify extends c.universe.Transformer {
+    def apply( tree:Tree ) = transform(tree)
+    override def transform(tree: Tree): Tree = {
+      super.transform {
+        tree match {
+          case  Apply(TypeApply(Select(_this, termname), _), reification::Nil )
+                if termname.toString == "factory" => c.unreifyTree(reification)
+          case Apply(Select(_this, termname), reification::Nil )
+               if termname.toString == "factory" => c.unreifyTree(reification)
+          case _ => tree
+        }
+      }
+    }
+  }
+}
+object QueryableMacros{
+  def _helper[C <: Context,S:c.WeakTypeTag]( c:C )( name:String, projection:c.Expr[_] ) = {
+    import c.universe._
+    import internal._
+    val element_type = implicitly[c.WeakTypeTag[S]].tpe
+    val foo = c.Expr[ru.Expr[Queryable[S]]](
+    c.reifyTree( gen.mkRuntimeUniverseRef, EmptyTree, c.typecheck(
+      Utils[c.type](c).removeDoubleReify(
+        Apply(Select(c.prefix.tree, TermName( name )), List( projection.tree ))
+       ).asInstanceOf[Tree]
+      )))
+    c.universe.reify{ Queryable.factory[S]( foo.splice )}
+  }
+  def map[T:c.WeakTypeTag, S:c.WeakTypeTag]
+               (c: Context)
+               (projection: c.Expr[T => S]): c.Expr[Queryable[S]] = _helper[c.type,S]( c )( "_map", projection )
+}
+class Queryable[T]{
+  def _map[S]( projection: T => S ) : Queryable[S] = ???
+  def map[S]( projection: T => S ) : Queryable[S] = macro QueryableMacros.map[T,S]
+}
+object Queryable{
+  def factory[S]( projection:ru.Expr[Queryable[S]] ) : Queryable[S] = null
+}

--- a/test/files/run/macro-reify-nested-b2/Test_2.scala
+++ b/test/files/run/macro-reify-nested-b2/Test_2.scala
@@ -1,0 +1,9 @@
+object Test extends App{
+  val q : Queryable[Any] = new Queryable[Any]
+  q.map(e1 => q.map(e2=>e1).map(e2=>e1))
+
+  locally {
+    val q : Queryable[Any] = new Queryable[Any]
+    q.map(e1 => q.map(e2=>e1).map(e2=>e1))
+  }
+}


### PR DESCRIPTION
Unfortunately, due to the aforementioned bugs we have to delay our triumph
over resetAllAttrs.

Therefore, I'm rolling back the internal changes to scalac introduced in
https://github.com/scala/scala/pull/3485. Our public reflection API interface
in Scala 2.11 is still going to contain only resetLocalAttrs, but both
the reifier and the label typechecker are too heavily addicted to resetAllAttrs
to do away with it right now.
