### PR TITLE
Support def macros for constructors

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2551,13 +2551,26 @@ self =>
       in.nextToken()
       if (in.token == THIS) {
         atPos(start, in.skipToken()) {
+          var newmods = mods
           val vparamss = paramClauses(nme.CONSTRUCTOR, classContextBounds map (_.duplicate), ofCaseClass = false)
           newLineOptWhenFollowedBy(LBRACE)
           val rhs = in.token match {
-            case LBRACE   => atPos(in.offset) { constrBlock(vparamss) }
-            case _        => accept(EQUALS) ; atPos(in.offset) { constrExpr(vparamss) }
+            case LBRACE =>
+              atPos(in.offset) { constrBlock(vparamss) }
+            case EQUALS =>
+              in.nextTokenAllow(nme.MACROkw)
+              if (in.token == IDENTIFIER && in.name == nme.MACROkw) {
+                in.nextToken()
+                newmods |= Flags.MACRO
+                expr()
+              } else {
+                atPos(in.offset) { constrExpr(vparamss) }
+              }
+            case _ =>
+              accept(EQUALS)
+              atPos(in.offset) { constrExpr(vparamss) }
           }
-          DefDef(mods, nme.CONSTRUCTOR, List(), vparamss, TypeTree(), rhs)
+          DefDef(newmods, nme.CONSTRUCTOR, List(), vparamss, TypeTree(), rhs)
         }
       }
       else {

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -721,6 +721,11 @@ trait ContextErrors {
         setError(tree)
       }
 
+      def MacroSuperCtorError(tree: Tree) = {
+        issueNormalTypeError(tree, "illegal inheritance; super class constructor can't be a macro")
+        setError(tree)
+      }
+
       def MacroTooManyArgumentListsError(expandee: Tree, fun: Symbol) = {
         NormalTypeError(expandee, "too many argument lists for " + fun)
       }

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -687,6 +687,11 @@ trait Macros extends FastTrack with MacroRuntimes with Traces with Helpers {
       } else delayed
     }
     override def onFallback(fallback: Tree) = typer.typed(fallback, mode, outerPt)
+    import typer.TyperErrorGen._
+    expandee match {
+      case Applied(RefTree(Super(_, _), nme.CONSTRUCTOR), _, _) => MacroSuperCtorError(expandee)
+      case _ => expandee
+    }
   }
 
   /** Expands a term macro used in apply role as `M(2)(3)` in `val x = M(2)(3)`.

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2174,17 +2174,17 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       ddef.tpt.setType(tpt1.tpe)
       val typedMods = typedModifiers(ddef.mods)
       var rhs1 =
-        if (ddef.name == nme.CONSTRUCTOR && !ddef.symbol.hasStaticFlag) { // need this to make it possible to generate static ctors
+        if (meth.isMacro) {
+          // typechecking macro bodies is sort of unconventional
+          // that's why we employ our custom typing scheme orchestrated outside of the typer
+          transformedOr(ddef.rhs, typedMacroBody(this, ddef))
+        } else if (ddef.name == nme.CONSTRUCTOR && !ddef.symbol.hasStaticFlag) { // need this to make it possible to generate static ctors
           if (!meth.isPrimaryConstructor &&
               (!meth.owner.isClass ||
                meth.owner.isModuleClass ||
                meth.owner.isAnonOrRefinementClass))
             InvalidConstructorDefError(ddef)
           typed(ddef.rhs)
-        } else if (meth.isMacro) {
-          // typechecking macro bodies is sort of unconventional
-          // that's why we employ our custom typing scheme orchestrated outside of the typer
-          transformedOr(ddef.rhs, typedMacroBody(this, ddef))
         } else {
           transformedOrTyped(ddef.rhs, EXPRmode, tpt1.tpe)
         }

--- a/test/files/neg/macro-constructor-badret.check
+++ b/test/files/neg/macro-constructor-badret.check
@@ -1,0 +1,8 @@
+Test_2.scala:4: error: macro implementation has incompatible shape:
+ required: (c: scala.reflect.macros.whitebox.Context)(x: c.Expr[Int]): c.Expr[C]
+ or      : (c: scala.reflect.macros.whitebox.Context)(x: c.Tree): c.Tree
+ found   : (c: reflect.macros.Context)(x: c.Tree): c.Expr[X]
+type mismatch for return type: c.Expr[X] does not conform to c.Expr[C]
+  def this(x: Int) = macro Macros.ctor
+                                  ^
+one error found

--- a/test/files/neg/macro-constructor-badret/Macros_1.scala
+++ b/test/files/neg/macro-constructor-badret/Macros_1.scala
@@ -1,0 +1,11 @@
+import scala.reflect.macros.Context
+import scala.language.experimental.macros
+
+class X
+
+object Macros {
+  def ctor(c: Context)(x: c.Tree): c.Expr[X] = {
+    import c.universe._
+    c.Expr[X](q"C($x)")
+  }
+}

--- a/test/files/neg/macro-constructor-badret/Test_2.scala
+++ b/test/files/neg/macro-constructor-badret/Test_2.scala
@@ -1,0 +1,5 @@
+import scala.language.experimental.macros
+
+class C private () {
+  def this(x: Int) = macro Macros.ctor
+}

--- a/test/files/neg/macro-constructor-super.check
+++ b/test/files/neg/macro-constructor-super.check
@@ -1,0 +1,4 @@
+Test_2.scala:1: error: illegal inheritance; super class constructor can't be a macro
+class D extends C(42)
+                ^
+one error found

--- a/test/files/neg/macro-constructor-super/Macros_1.scala
+++ b/test/files/neg/macro-constructor-super/Macros_1.scala
@@ -1,0 +1,17 @@
+import scala.reflect.macros.Context
+import scala.language.experimental.macros
+
+object Macros {
+  def ctor(c: Context)(x: c.Tree): c.Tree = {
+    import c.universe._
+    q"C($x)"
+  }
+}
+
+class CState(val x: Int) extends AnyVal
+
+class C private (state: CState) {
+  def this(x: Int) = macro Macros.ctor
+  def x = state.x
+  override def toString = s"C($x)"
+}

--- a/test/files/neg/macro-constructor-super/Test_2.scala
+++ b/test/files/neg/macro-constructor-super/Test_2.scala
@@ -1,0 +1,1 @@
+class D extends C(42)

--- a/test/files/run/macro-constructor.check
+++ b/test/files/run/macro-constructor.check
@@ -1,0 +1,2 @@
+intercepted new C(2)
+C(2)

--- a/test/files/run/macro-constructor/Macros_1.scala
+++ b/test/files/run/macro-constructor/Macros_1.scala
@@ -1,0 +1,9 @@
+import scala.reflect.macros.Context
+import scala.language.experimental.macros
+
+object Macros {
+  def ctor(c: Context)(x: c.Tree): c.Tree = {
+    import c.universe._
+    q"C($x)"
+  }
+}

--- a/test/files/run/macro-constructor/Test_2.scala
+++ b/test/files/run/macro-constructor/Test_2.scala
@@ -1,0 +1,20 @@
+import scala.language.experimental.macros
+
+class CState(val x: Int) extends AnyVal
+
+class C private (state: CState) {
+  def this(x: Int) = macro Macros.ctor
+  def x = state.x
+  override def toString = s"C($x)"
+}
+
+object C {
+  def apply(x: Int) = {
+    println(s"intercepted new C($x)")
+    new C(new CState(x))
+  }
+}
+
+object Test extends App {
+  println(new C(2))
+}


### PR DESCRIPTION
Fixes an oversight that lasted from the times of 2.10.0-M3. Back then we
allowed defs to be a macro, but didn't think of constructors. Of course,
primary constructors can't be macros, because a class ought to have at
least one JVM-compatible ctor, but secondary constructors - why not?!

You might ask what's the point of turning constructors into macros.
After all, constructors have to expand into something that calls into
other constructors. Therefore even if one wants to hide a certain
constructor from the user by making that constructor private or protected,
it won't help because a public macro constructor would eventually have
to call that hidden constructor, producing a compilation error.

So we're stuck, right? Not really! Indeed, we can't expand into
a direct call to the hidden ctor, but what we can do is call a companion's
method and companions can see private constructors:

  class C private (x: Int) {
    def this(x: Int) = macro ??? // expands into `C(x)`
  }

  object C {
    def apply(x: Int) = new C(x)
  }

Now, you might point out that the signatures of the hidden ctor
and of the macro ctor are the same. So how do we disambiguate? Easy!
Let's wrap our state in a zero-overhead value class!

  class CState(val x: Int) extends AnyVal

  class C private (x: CState) {
    def this(x: Int) = macro ??? // expands into `C(x)`
  }

  object C {
    def apply(x: Int) = new C(new CState(x))
  }
