### PR TITLE
SI-8197 Only consider immediate params for defaults, overloading

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1328,7 +1328,8 @@ trait Infer extends Checkable {
         eligible
       else
         eligible filter (alt =>
-          !mexists(alt.info.paramss)(_.hasDefault) && isApplicableBasedOnArity(alt.tpe, argtpes.length, varargsStar, tuplingAllowed = true)
+             !alt.info.params.exists(_.hasDefault) // run/t8197b first parameter list only!
+          && isApplicableBasedOnArity(alt.tpe, argtpes.length, varargsStar, tuplingAllowed = true)
       )
     }
 

--- a/test/files/run/t8197b.scala
+++ b/test/files/run/t8197b.scala
@@ -1,0 +1,8 @@
+object O {
+  def foo[T](t: T) = 0
+  def foo(s: String)(implicit i: DummyImplicit = null) = 1
+}
+
+object Test extends App {
+  assert(O.foo("") == 1)
+}


### PR DESCRIPTION
A recent commit fixed the behaviour of overloading with regards
to discarding candiates that include default arguments. The old
check was checking the wrong flag.

But, the new code is actually checking all parameter lists for
defaults, which led to a regression in scala-io, which is distilled
in the enclosed test case. Applications are typechecked one
parameter list at a time, so a holistic check for defaults doesn't
seem to make sense; only defaults in the first parameter list
ought to count.

Review (and adoption if needed!) by @adriaanm
