### PR TITLE
SI-7962 Scalac runner does not work within Emacs's terminal

### DIFF
--- a/src/compiler/scala/tools/ant/templates/tool-unix.tmpl
+++ b/src/compiler/scala/tools/ant/templates/tool-unix.tmpl
@@ -73,8 +73,7 @@ SEP=":"
 
 # Possible additional command line options
 WINDOWS_OPT=""
-EMACS_OPT=""
-[[ -n "$EMACS" ]] && EMACS_OPT="-Denv.emacs=$EMACS"
+EMACS_OPT="-Denv.emacs=$EMACS"
 
 # Remove spaces from SCALA_HOME on windows
 if [[ -n "$cygwin" ]]; then
@@ -201,7 +200,7 @@ execCommand \
   $(classpathArgs) \
   -Dscala.home="$SCALA_HOME" \
   -Dscala.usejavacp=true \
-  $EMACS_OPT \
+  "$EMACS_OPT" \
   $WINDOWS_OPT \
   @properties@ @class@ @toolflags@ "$@@"
 


### PR DESCRIPTION
- Always set the env.emacs system property - scalac only cares
  about whether the system property has a non-empty value, not
  whether it is set or not. Fixes 7962
