### PR TITLE
Fix ./build/<stage>/bin/scaladoc

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -753,6 +753,7 @@ TODO:
       <path refid="quick.repl.build.path"/>
       <path refid="quick.actors.build.path"/>
       <pathelement location="${build-quick.dir}/classes/scalap"/>
+      <pathelement location="${build-quick.dir}/classes/scaladoc"/>
       <path refid="external-modules-nocore"/>
     </path>
 


### PR DESCRIPTION
Was:

```
./build/quick/bin/scaladoc -version
Exception in thread "main" java.lang.NoClassDefFoundError: scala/tools/nsc/ScalaDoc
Caused by: java.lang.ClassNotFoundException: scala.tools.nsc.ScalaDoc
```

Now:

```
% for tool in ./build/quick/bin/{fsc,scala,scalac,scaladoc,scalap}; do $tool -version; done
Fast Scala compiler version 2.11.0-20140222-144307-b0dcf79875 -- Copyright 2002-2013, LAMP/EPFL
Scala code runner version 2.11.0-20140222-144307-b0dcf79875 -- Copyright 2002-2013, LAMP/EPFL
Scala compiler version 2.11.0-20140222-144307-b0dcf79875 -- Copyright 2002-2013, LAMP/EPFL
Scaladoc version 2.11.0-20140222-144307-b0dcf79875 -- Copyright 2002-2013, LAMP/EPFL
Scala classfile decoder version 2.0.1 -- (c) 2002-2013 LAMP/EPFL
```

Review by @gkossakowski
