### PR TITLE
SI-8325 Accept infix star type outside patterns

### DIFF
--- a/test/files/neg/t8325-b.check
+++ b/test/files/neg/t8325-b.check
@@ -1,0 +1,10 @@
+t8325-b.scala:3: error: Unmatched closing brace '}' ignored here
+  def k(is: Int*} = ???
+                ^
+t8325-b.scala:3: error: ';' expected but '=' found.
+  def k(is: Int*} = ???
+                  ^
+t8325-b.scala:4: error: eof expected but '}' found.
+}
+^
+three errors found

--- a/test/files/neg/t8325-b.scala
+++ b/test/files/neg/t8325-b.scala
@@ -1,0 +1,4 @@
+
+trait Test {
+  def k(is: Int*} = ???
+}

--- a/test/files/neg/t8325-c.check
+++ b/test/files/neg/t8325-c.check
@@ -1,0 +1,7 @@
+t8325-c.scala:3: error: identifier expected but ')' found.
+  def k(xx: Int`*`) = ???
+                  ^
+t8325-c.scala:4: error: ')' expected but '}' found.
+}
+^
+two errors found

--- a/test/files/neg/t8325-c.scala
+++ b/test/files/neg/t8325-c.scala
@@ -1,0 +1,4 @@
+
+trait Test {
+  def k(xx: Int`*`) = ???
+}

--- a/test/files/neg/t8325.check
+++ b/test/files/neg/t8325.check
@@ -1,0 +1,15 @@
+t8325.scala:5: error: *-parameter must come last
+  def f(is: Int*, s: String) = ???
+        ^
+t8325.scala:7: error: *-parameter must come last
+  def h(is: Int * String *, s: String) = ???
+        ^
+t8325.scala:10: error: type mismatch;
+ found   : Int(5)
+ required: Int*
+  def j(is: Int* = 5) = ???
+                   ^
+t8325.scala:10: error: a parameter section with a `*'-parameter is not allowed to have default arguments
+  def j(is: Int* = 5) = ???
+      ^
+four errors found

--- a/test/files/neg/t8325.scala
+++ b/test/files/neg/t8325.scala
@@ -1,0 +1,11 @@
+
+trait Test {
+  type OK[A,B] = A Tuple2 B
+  type *[A,B]  = A Tuple2 B
+  def f(is: Int*, s: String) = ???
+  def g(is: Int * String, s: String) = ???     // OK
+  def h(is: Int * String *, s: String) = ???
+  // won't recover from following
+  //def i(is: Int OK) = ???  //error: identifier expected but ')' found.
+  def j(is: Int* = 5) = ???
+}

--- a/test/files/pos/t8325.scala
+++ b/test/files/pos/t8325.scala
@@ -1,0 +1,9 @@
+
+trait Test {
+  type +[A, B] = (A, B)
+  type *[A, B] = (A, B)
+
+  type X[A, B] = A + B
+  type Y[A, B] = A * B
+  type Z[A, B] = A `*` B
+}


### PR DESCRIPTION
Also, do not take backticked star as the repeated
parameter marker in postfix position.

Note: not satisfied with the error messages yet. This is a test run for feedback.
