### PR TITLE
SI-6493 more robust symbol handling in existentialTransform

### DIFF
--- a/src/reflect/scala/reflect/internal/ExistentialsAndSkolems.scala
+++ b/src/reflect/scala/reflect/internal/ExistentialsAndSkolems.scala
@@ -43,31 +43,6 @@ trait ExistentialsAndSkolems {
   def isRawParameter(sym: Symbol) = // is it a type parameter leaked by a raw type?
     sym.isTypeParameter && sym.owner.isJavaDefined
 
-  /** If we map a set of hidden symbols to their existential bounds, we
-   *  have a problem: the bounds may themselves contain references to the
-   *  hidden symbols.  So this recursively calls existentialBound until
-   *  the typeSymbol is not amongst the symbols being hidden.
-   */
-  private def existentialBoundsExcludingHidden(hidden: List[Symbol]): Map[Symbol, Type] = {
-    def safeBound(t: Type): Type =
-      if (hidden contains t.typeSymbol) safeBound(t.typeSymbol.existentialBound.bounds.hi) else t
-
-    def hiBound(s: Symbol): Type = safeBound(s.existentialBound.bounds.hi) match {
-      case tp @ RefinedType(parents, decls) =>
-        val parents1 = parents mapConserve safeBound
-        if (parents eq parents1) tp
-        else copyRefinedType(tp, parents1, decls)
-      case tp => tp
-    }
-
-    // Hanging onto lower bound in case anything interesting
-    // happens with it.
-    mapFrom(hidden)(s => s.existentialBound match {
-      case TypeBounds(lo, hi) => TypeBounds(lo, hiBound(s))
-      case _                  => hiBound(s)
-    })
-  }
-
   /** Given a set `rawSyms` of term- and type-symbols, and a type
    *  `tp`, produce a set of fresh type parameters and a type so that
    *  it can be abstracted to an existential type. Every type symbol
@@ -85,26 +60,87 @@ trait ExistentialsAndSkolems {
    *  only the type of the Ident is changed.
    */
   final def existentialTransform[T](rawSyms: List[Symbol], tp: Type, rawOwner: Symbol = NoSymbol)(creator: (List[Symbol], Type) => T): T = {
-    val allBounds = existentialBoundsExcludingHidden(rawSyms)
-    val typeParams: List[Symbol] = rawSyms map { sym =>
+    /** If we map a set of hidden symbols to their existential bounds, we
+     *  have a problem: the bounds may themselves contain references to the
+     *  hidden symbols.  So this recursively calls existentialBound until
+     *  the typeSymbol is not amongst the symbols being hidden.
+     */
+    def safeBound(t: Type): Type = {
+      val sym = t.typeSymbol
+      if (rawSyms contains sym) safeBound(sym.existentialBound.bounds.hi)
+      else t
+    }
+
+    // TODO: get rid of this, but then we'll have to fix SI-2071 for sure
+    def deepBound(hi: Type): Type = safeBound(hi) match {
+      case tp @ RefinedType(parents, decls) =>
+        val parents1 = parents mapConserve safeBound
+        if (parents eq parents1) tp
+        else RefinedType(parents1, decls)
+      case tp => tp
+    }
+
+    // this turns term symbols into type symbols, which is a problem for annotations (see run/constrained-types.scala)
+    val quantifiers = rawSyms map { sym =>
       val name = sym.name match {
         case x: TypeName  => x
         case x            => tpnme.singletonName(x)
       }
-      def rawOwner0  = rawOwner orElse abort(s"no owner provided for existential transform over raw parameter: $sym")
-      val bound      = allBounds(sym)
-      val sowner     = if (isRawParameter(sym)) rawOwner0 else sym.owner
-      val quantified = sowner.newExistential(name, sym.pos)
+      def rawOwner0 = rawOwner orElse abort(s"no owner provided for existential transform over raw parameter: $sym")
+      val sowner    = if (isRawParameter(sym)) rawOwner0 else sym.owner
+      val quant     = sowner.newExistential(name, sym.pos)
+      val bound     = sym.existentialBound match {
+        // Hanging onto lower bound in case anything interesting happens with it.
+        case TypeBounds(lo, hi) => TypeBounds(lo, deepBound(hi))
+        case tp                 => deepBound(tp.bounds.hi)
+      }
 
-      quantified setInfo bound.cloneInfo(quantified)
+      quant setInfo bound.cloneInfo(quant)
     }
+
     // Higher-kinded existentials are not yet supported, but this is
     // tpeHK for when they are: "if a type constructor is expected/allowed,
     // tpeHK must be called instead of tpe."
-    val typeParamTypes = typeParams map (_.tpeHK)
-    def doSubst(info: Type) = info.subst(rawSyms, typeParamTypes)
+    val quantifierTypes = quantifiers map (_.tpeHK)
 
-    creator(typeParams map (_ modifyInfo doSubst), doSubst(tp))
+    def doSubst(info: Type) = info.subst(rawSyms, quantifierTypes)
+
+    /* Abandon all hope for symbol consistency, ye who enter here:
+     * For example, from SI-6493, let's compute a result type for
+     *   `def foo = { class Foo { class Bar { val b = 2 }}; val f = new Foo; new f.Bar }`:
+     *
+     * Note the inconsistent symbol ids in:
+     *
+     * rawSyms     = List(value f#49740, class Foo#49739, class Bar#49742)
+     * quantifiers + their infos =
+     *       type f.type#49774 <: AnyRef{type Bar#49762 <: AnyRef{val b#49764: Int}} with Singleton,
+     *       type Foo#49775    <: AnyRef{type Bar#49770 <: AnyRef{val b#49772: Int}},
+     *                                   type Bar#49773 <: AnyRef{val b#49758: Int}
+     *
+     *
+     * It makes sense to subst the symbols in tp, but the modifyInfo will have little effect on quantifiers.
+     * Luckily, coevolveSym will fix up some of the inconsistencies, so that we get
+     * `f.type#49774.Bar#49762`, which is extrapolated to `AnyRef{type Bar#49868 <: AnyRef{val b: Int}}#Bar#49868`.
+     *
+     * TODO: The intermediate type `f.type#49774.Bar#49762` motivates the need for the `.substSym` below,
+     * as `.subst` does not touch the `Bar#49742` in the `f#49740.Bar#49742` that we start out with.
+     *
+     * The remaining problem is that ExistentialExtrapolation will not consider type Bar#49868 as existentially bound.
+     * Instead, it's looking for the stale version in quantifiers, Bar#49773.
+     * If it was looking for Bar#49868, the result type would simply be `AnyRef{val b: Int}`
+     *
+     * TODO: figure out how to compute the full set of quantifiers for extrapolation
+     *       the `doSubst(tp)` will clone more symbols, so we'll probably need to traverse its result and
+     *       somehow correlate the contained symbols to those in `quantifiers`...
+     */
+
+    // SI-6493 requires the full substitution, but unless we fix SI-2071, run/existentials3-new.scala breaks
+    // also, annotations break since we're replacing term symbols by type symbols (albeit singleton-bounded)
+    val underlyingSubst =
+      if (settings.Xexperimental) doSubst(tp).substSym(rawSyms, quantifiers)
+      else doSubst(tp)
+
+    creator(quantifiers map (_ modifyInfo doSubst), underlyingSubst)
   }
 
   /**

--- a/test/files/run/t6493.flags
+++ b/test/files/run/t6493.flags
@@ -1,0 +1,1 @@
+-Xexperimental

--- a/test/files/run/t6493/A_1.scala
+++ b/test/files/run/t6493/A_1.scala
@@ -1,0 +1,8 @@
+// SI-6493: existential abstraction misplaces some symbols,
+// while hiding the class symbols in foo()'s inferred result type,
+// it doesn't replace them by the corresponding existential quantifiers,
+// which lead to a NoSuchMethodError in calling foo() because its signature was messed up
+object one {
+  def foo() = { object Foo { class Bar } ; new Foo.Bar }
+  def module() = { trait T { object Bar } ; (new T {}).Bar }
+}

--- a/test/files/run/t6493/B_2.scala
+++ b/test/files/run/t6493/B_2.scala
@@ -1,0 +1,6 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    one.foo // should not fail...
+    one.module
+  }
+}


### PR DESCRIPTION
The fix is only enabled under -Xexperimental, because the
full fix is blocked by SI-2071.

To illustrate the problem, let's compute the result type for

```
def foo = { class Foo { class Bar { val b = 2 }}; val f = new Foo; new f.Bar }
```

Note the inconsistent symbol ids in:

rawSyms     = List(value f#49740, class Foo#49739, class Bar#49742)
quantifiers + their infos =
  type f.type#49774 <: AnyRef{type Bar#49762 <: AnyRef{val b#49764: Int}} with Singleton,
  type Foo#49775    <: AnyRef{type Bar#49770 <: AnyRef{val b#49772: Int}},
                              type Bar#49773 <: AnyRef{val b#49758: Int}

It makes sense to subst the symbols in tp, but the modifyInfo will have
little effect on quantifiers. Luckily, coevolveSym will fix up some of
the inconsistencies, so that we get `f.type#49774.Bar#49762`, which is
extrapolated to `AnyRef{type Bar#49868 <: AnyRef{val b: Int}}#Bar#49868`.

The intermediate type `f.type#49774.Bar#49762` motivates the need for
the `.substSym` above, as `.subst` does not touch the `Bar#49742` in
the `f#49740.Bar#49742` that we start out with.

The remaining problem is that ExistentialExtrapolation will not consider
type Bar#49868 as existentially bound. Instead, it's looking for the
stale version in quantifiers, Bar#49773. If it was looking for Bar#49868,
the result type would simply be `AnyRef{val b: Int}`

TODO: figure out how to compute the full set of quantifiers for extrapolation
      the `doSubst(tp)` will clone more symbols, so we'll probably need to
      traverse its result and somehow correlate the contained symbols to
      those in `quantifiers`...
