### PR TITLE
SI-8330: Mismatch in stack heights

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
@@ -1011,9 +1011,10 @@ abstract class GenICode extends SubComponent  {
       // emit conversion
       if (generatedType != expectedType) {
         tree match {
-          case Literal(Constant(null)) if generatedType == NullReference =>
+          case Literal(Constant(null)) if generatedType == NullReference && expectedType != UNIT =>
             // literal null on the stack (as opposed to a boxed null, see SI-8233),
             // we can bypass `adapt` which would otherwise emitt a redundant [DROP, CONSTANT(null)]
+            // except one case: when expected type is UNIT (unboxed) where we need to emit just a DROP
           case _ =>
             adapt(generatedType, expectedType, resCtx, tree.pos)
         }

--- a/test/files/run/t8233-bcode.scala
+++ b/test/files/run/t8233-bcode.scala
@@ -11,8 +11,21 @@ object Test {
     bar(a)
   }
 
-  def main(args: Array[String]) = {
+  /** Check SI-8330 for details */
+  def expectedUnitInABranch(b: Boolean): Boolean = {
+    if (b) {
+      val x = 12
+      ()
+    } else {
+      // here expected type is (unboxed) Unit
+      null
+    }
+    true
+  }
+
+  def main(args: Array[String]): Unit = {
     try { nullReference } catch { case _: NoSuchElementException => }
     literal
+    expectedUnitInABranch(true)
   }
 }

--- a/test/files/run/t8233.scala
+++ b/test/files/run/t8233.scala
@@ -11,8 +11,21 @@ object Test {
     bar(a)
   }
 
-  def main(args: Array[String]) = {
+  /** Check SI-8330 for details */
+  def expectedUnitInABranch(b: Boolean): Boolean = {
+    if (b) {
+      val x = 12
+      ()
+    } else {
+      // here expected type is (unboxed) Unit
+      null
+    }
+    true
+  }
+
+  def main(args: Array[String]): Unit = {
     try { nullReference } catch { case _: NoSuchElementException => }
     literal
+    expectedUnitInABranch(true) // Was: VerifyError under GenICode
   }
 }


### PR DESCRIPTION
The SI-8233 / 9506d52 missed one case when we need to DROP a null from
a stack: when unboxed Unit is an expected type. If we forgot to do that
in a context where two branches were involved we could end up with
unbalanced stack sizes.

Let's fix that omission and a test covering that specific case to the
original test for SI-8233.

Fixes SI-8330.
