### PR TITLE
SI-3235 math.round() returns wrong results for Int and Long

### DIFF
--- a/src/library/scala/math/package.scala
+++ b/src/library/scala/math/package.scala
@@ -93,12 +93,22 @@ package object math {
    */
   def pow(x: Double, y: Double): Double = java.lang.Math.pow(x, y)
 
-  /** Returns the closest `long` to the argument.
+  /** There is no reason to round a `Long`, but this method prevents unintended conversion to `Float` followed by rounding to `Int`. */
+  @deprecated("This is an integer type; there is no reason to round it.  Perhaps you meant to call this with a floating-point value?", "2.11.0")
+  def round(x: Long): Long = x
+
+  /** Returns the closest `Int` to the argument.
    *
-   *  @param  x a floating-point value to be rounded to a `long`.
-   *  @return the value of the argument rounded to the nearest`long` value.
+   *  @param  x a floating-point value to be rounded to a `Int`.
+   *  @return the value of the argument rounded to the nearest `Int` value.
    */
   def round(x: Float): Int = java.lang.Math.round(x)
+  
+  /** Returns the closest `Long` to the argument.
+   *
+   *  @param  x a floating-point value to be rounded to a `Long`.
+   *  @return the value of the argument rounded to the nearest`long` value.
+   */
   def round(x: Double): Long = java.lang.Math.round(x)
 
   def abs(x: Int): Int       = java.lang.Math.abs(x)

--- a/src/library/scala/runtime/RichInt.scala
+++ b/src/library/scala/runtime/RichInt.scala
@@ -36,6 +36,10 @@ final class RichInt(val self: Int) extends AnyVal with ScalaNumberProxy[Int] wit
   override def max(that: Int): Int = math.max(self, that)
   override def min(that: Int): Int = math.min(self, that)
   override def signum: Int         = math.signum(self)
+  
+  /** There is no reason to round an `Int`, but this method is provided to avoid accidental loss of precision from a detour through `Float`. */
+  @deprecated("This is an integer type; there is no reason to round it.  Perhaps you meant to call this on a floating-point value?", "2.11.0")
+  def round: Int = self
 
   def toBinaryString: String = java.lang.Integer.toBinaryString(self)
   def toHexString: String    = java.lang.Integer.toHexString(self)

--- a/src/library/scala/runtime/RichLong.scala
+++ b/src/library/scala/runtime/RichLong.scala
@@ -32,6 +32,10 @@ final class RichLong(val self: Long) extends AnyVal with IntegralProxy[Long] {
   override def max(that: Long): Long = math.max(self, that)
   override def min(that: Long): Long = math.min(self, that)
   override def signum: Int           = math.signum(self).toInt
+  
+  /** There is no reason to round a `Long`, but this method is provided to avoid accidental conversion to `Int` through `Float`. */
+  @deprecated("This is an integer type; there is no reason to round it.  Perhaps you meant to call this on a floating-point value?", "2.11.0")
+  def round: Long = self
 
   def toBinaryString: String = java.lang.Long.toBinaryString(self)
   def toHexString: String    = java.lang.Long.toHexString(self)

--- a/test/files/run/t3235-minimal.check
+++ b/test/files/run/t3235-minimal.check
@@ -1,0 +1,12 @@
+t3235-minimal.scala:3: warning: method round in class RichInt is deprecated: This is an integer type; there is no reason to round it.  Perhaps you meant to call this on a floating-point value?
+    assert(123456789.round == 123456789)
+                     ^
+t3235-minimal.scala:4: warning: method round in package math is deprecated: This is an integer type; there is no reason to round it.  Perhaps you meant to call this with a floating-point value?
+    assert(math.round(123456789) == 123456789)
+                ^
+t3235-minimal.scala:5: warning: method round in class RichLong is deprecated: This is an integer type; there is no reason to round it.  Perhaps you meant to call this on a floating-point value?
+    assert(1234567890123456789L.round == 1234567890123456789L)
+                                ^
+t3235-minimal.scala:6: warning: method round in package math is deprecated: This is an integer type; there is no reason to round it.  Perhaps you meant to call this with a floating-point value?
+    assert(math.round(1234567890123456789L) == 1234567890123456789L)
+                ^

--- a/test/files/run/t3235-minimal.flags
+++ b/test/files/run/t3235-minimal.flags
@@ -1,0 +1,1 @@
+-deprecation

--- a/test/files/run/t3235-minimal.scala
+++ b/test/files/run/t3235-minimal.scala
@@ -1,0 +1,8 @@
+object Test {
+  def main(args: Array[String]) {
+    assert(123456789.round == 123456789)
+    assert(math.round(123456789) == 123456789)
+    assert(1234567890123456789L.round == 1234567890123456789L)
+    assert(math.round(1234567890123456789L) == 1234567890123456789L)
+  }
+}


### PR DESCRIPTION
Minimal fix for SI-3235.

No deprecation or migration messages; if anyone used this to clip Long into Int (with rounding errors from Float), they will observe altered behavior.

Test verifies behavior.
