### PR TITLE
SI-8197 clarify overloading resolution with default args

### DIFF
--- a/test/files/run/t8197.scala
+++ b/test/files/run/t8197.scala
@@ -1,7 +1,7 @@
-// NOTE: according to SI-4728, this shouldn't even compile...
+// SI-8197, see also SI-4592 and SI-4728
 class A
 class B
-// default arguments do not participate in overload resolution
+
 class Foo(val x: A = null) {
   def this(bla: B*) {
     this(new A)
@@ -9,5 +9,8 @@ class Foo(val x: A = null) {
 }
 
 object Test extends App {
+  // both constructors of `Foo` are applicable. Overloading resolution
+  // will eliminate the alternative that uses a default argument, therefore
+  // the vararg constructor is chosen.
   assert((new Foo).x != null)
 }


### PR DESCRIPTION
If there are multiple applicable alternatives, drop those
that use default arguments. This is done indirectly by
checking applicability based on arity
(disallowing tupling to ensure exact arity matching!).
If defaults are required in the application, the arities
won't match up exactly.

TODO this `namesMatch` business is not spec'ed, and is
the wrong fix for SI-4592. We should instead clarify what
the spec means by "typing each argument with an undefined expected type".

What does typing a named argument entail when we don't know what
the valid parameter names are? (Since we're doing overload resolution,
there are multiple alternatives that can define different names.)

Luckily, the next step checks applicability to the individual alternatives,
so it knows whether an assignment is:
- a valid named argument
- a well-typed assignment
- an error (e.g., rhs does not refer to a variable)

I propose the following solution (as a TODO):
check whether a named argument (when typing it in `doTypedApply`)
could be interpreted as an assign; `infer.checkNames` must not use
`UnitType` for its type unless it's a legal assignment
