### PR TITLE
Revert "SI-8315 Better debugging facility for ICode"

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1798,8 +1798,10 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
   private def writeICode() {
     val printer = new icodes.TextPrinter(null, icodes.linearizer)
     icodes.classes.values.foreach((cls) => {
-      val suffix = s"${if (cls.symbol.hasModuleFlag) "$" else ""}_${phase}.icode"
-      val file = getFile(cls.symbol, suffix)
+      val moduleSfx = if (cls.symbol.hasModuleFlag) "$" else ""
+      val phaseSfx  = if (settings.debug) phase else "" // only for debugging, appending the full phasename breaks windows build
+      val file      = getFile(cls.symbol, s"$moduleSfx$phaseSfx.icode")
+
       try {
         val stream = new FileOutputStream(file)
         printer.setWriter(new PrintWriter(stream, true))


### PR DESCRIPTION
This reverts commit 0561dd084b5f3c2678eb032a40b85cb25bb6d589.

When the windows nightly broke, git bisect pointed its unwavering finger at this poor soul.

Build passes again after the revert: https://scala-webapps.epfl.ch/jenkins/job/scala-checkin-manual-windows/39/console

I have no idea why, but the machines don't lie (and I don't have time right now to dig deeper).
Ok, if I had to guess, I'd say the longer filenames for the .icode files confused windows somehow.
