### PR TITLE
SI-8275 allow to directly extract block contents of the case def

### DIFF
--- a/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
@@ -206,6 +206,8 @@ trait Reifiers { self: Quasiquotes =>
         reifyBuildCall(nme.SyntacticTry, block, catches, finalizer)
       case Match(selector, cases) =>
         reifyBuildCall(nme.SyntacticMatch, selector, cases)
+      case CaseDef(pat, guard, body) if fillListHole.isDefinedAt(body) =>
+        mirrorCall(nme.CaseDef, reify(pat), reify(guard), mirrorBuildCall(nme.SyntacticBlock, fillListHole(body)))
       // parser emits trees with scala package symbol to ensure
       // that some names hygienically point to various scala package
       // members; we need to preserve this symbol to preserve

--- a/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
@@ -202,6 +202,8 @@ trait Reifiers { self: Quasiquotes =>
       // not to cause infinite recursion.
       case block @ SyntacticBlock(stats) if block.isInstanceOf[Block] =>
         reifyBuildCall(nme.SyntacticBlock, stats)
+      case SyntheticUnit() =>
+        reifyBuildCall(nme.SyntacticBlock, Nil)
       case Try(block, catches, finalizer) =>
         reifyBuildCall(nme.SyntacticTry, block, catches, finalizer)
       case Match(selector, cases) =>

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -580,6 +580,7 @@ trait StdNames {
     val AnyVal: NameType               = "AnyVal"
     val Apply: NameType                = "Apply"
     val ArrayAnnotArg: NameType        = "ArrayAnnotArg"
+    val CaseDef: NameType              = "CaseDef"
     val ClassInfoType: NameType        = "ClassInfoType"
     val ConstantType: NameType         = "ConstantType"
     val EmptyPackage: NameType         = "EmptyPackage"

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -452,7 +452,7 @@ abstract class TreeGen {
 
   /** Create block of statements `stats`  */
   def mkBlock(stats: List[Tree]): Tree =
-    if (stats.isEmpty) Literal(Constant(()))
+    if (stats.isEmpty) mkSyntheticUnit()
     else if (!stats.last.isTerm) Block(stats, mkSyntheticUnit())
     else if (stats.length == 1) stats.head
     else Block(stats.init, stats.last)

--- a/test/files/scalacheck/quasiquotes/TermConstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/TermConstructionProps.scala
@@ -103,7 +103,7 @@ object TermConstructionProps extends QuasiquoteProperties("term construction") {
 
   def blockInvariant(quote: Tree, trees: List[Tree]) =
     quote ≈ (trees match {
-      case Nil => q""
+      case Nil => q"{}"
       case _ :+ last if !last.isTerm => Block(trees, q"()")
       case head :: Nil => head
       case init :+ last => Block(init, last)
@@ -277,11 +277,18 @@ object TermConstructionProps extends QuasiquoteProperties("term construction") {
     assert(stats ≈ List(q"def x = 2", q"()"))
   }
 
-  property("empty-tree as block") = test {
-    val q"{ ..$stats1 }" = q" "
-    assert(stats1.isEmpty)
-    val stats2 = List.empty[Tree]
-    assert(q"{ ..$stats2 }" ≈ q"")
+  property("empty-tree is not a block") = test {
+    assertThrows[MatchError] {
+      val q"{ ..$stats1 }" = q" "
+    }
+  }
+
+  property("empty block is synthetic unit") = test {
+    val q"()" = q"{}"
+    val q"{..$stats}" = q"{}"
+    assert(stats.isEmpty)
+    assertEqAst(q"{..$stats}", "{}")
+    assertEqAst(q"{..$stats}", "()")
   }
 
   property("consistent variable order") = test {

--- a/test/files/scalacheck/quasiquotes/TermDeconstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/TermDeconstructionProps.scala
@@ -175,4 +175,15 @@ object TermDeconstructionProps extends QuasiquoteProperties("term deconstruction
     assert(x ≈ q"x")
     val q"{ _ * _ }" = q"{ _ * _ }"
   }
+
+  property("si-8275 a") = test {
+    val cq"_ => ..$stats" = cq"_ => foo; bar"
+    assert(stats ≈ List(q"foo", q"bar"))
+  }
+
+  property("si-8275 b") = test {
+    val cq"_ => ..$init; $last" = cq"_ => a; b; c"
+    assert(init ≈ List(q"a", q"b"))
+    assert(last ≈ q"c")
+  }
 }

--- a/test/files/scalacheck/quasiquotes/TermDeconstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/TermDeconstructionProps.scala
@@ -186,4 +186,17 @@ object TermDeconstructionProps extends QuasiquoteProperties("term deconstruction
     assert(init ≈ List(q"a", q"b"))
     assert(last ≈ q"c")
   }
+
+  property("si-8275 c") = test {
+    val cq"_ => ..$stats" = cq"_ =>"
+    assert(stats.isEmpty)
+    assertEqAst(q"{ case _ => ..$stats }", "{ case _ => }")
+  }
+
+  property("can't flatten type into block") = test {
+    assertThrows[IllegalArgumentException] {
+      val tpt = tq"List[Int]"
+      q"..$tpt; ()"
+    }
+  }
 }


### PR DESCRIPTION
Due to the fact that blocks in cases are implicit one might expect to be
able to extract its contents with `..$`.

review @xeno-by 
