### PR TITLE
SI-8285 use correct kind of map for quasiquote positions

### DIFF
--- a/src/compiler/scala/tools/reflect/quasiquotes/Placeholders.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Placeholders.scala
@@ -17,7 +17,7 @@ trait Placeholders { self: Quasiquotes =>
 
   // Step 1: Transform Scala source with holes into vanilla Scala source
 
-  lazy val posMap = mutable.ListMap[Position, (Int, Int)]()
+  lazy val posMap = mutable.LinkedHashMap[Position, (Int, Int)]()
   lazy val code = {
     val sb = new StringBuilder()
     val sessionSuffix = randomUUID().toString.replace("-", "").substring(0, 8) + "$"
@@ -40,9 +40,7 @@ trait Placeholders { self: Quasiquotes =>
 
     val iargs = method match {
       case nme.apply   => args
-      case nme.unapply =>
-        val (dummy @ Ident(nme.SELECTOR_DUMMY)) :: Nil = args
-        internal.subpatterns(dummy).get
+      case nme.unapply => internal.subpatterns(args.head).get
       case _           => global.abort("unreachable")
     }
 

--- a/test/files/neg/quasiquotes-syntax-error-position.check
+++ b/test/files/neg/quasiquotes-syntax-error-position.check
@@ -32,4 +32,16 @@ quasiquotes-syntax-error-position.scala:14: error: ')' expected but end of quote
 quasiquotes-syntax-error-position.scala:15: error: ':' expected but ')' found.
   q"def foo(x)"
              ^
-11 errors found
+quasiquotes-syntax-error-position.scala:16: error: illegal start of simple expression
+  q"$a(])"
+       ^
+quasiquotes-syntax-error-position.scala:17: error: in XML literal: '>' expected instead of '$'
+  q"foo bar <xml$a>"
+                ^
+quasiquotes-syntax-error-position.scala:19: error: ';' expected but '<:' found.
+  q"val $x: $x <: $x"
+               ^
+quasiquotes-syntax-error-position.scala:20: error: '=' expected but '.' found.
+  q"def f ( $x  ) . $x"
+                  ^
+15 errors found

--- a/test/files/neg/quasiquotes-syntax-error-position.scala
+++ b/test/files/neg/quasiquotes-syntax-error-position.scala
@@ -13,4 +13,9 @@ object test extends App {
   cq"pattern => body ; case pattern2 =>"
   pq"$a(bar"
   q"def foo(x)"
+  q"$a(])"
+  q"foo bar <xml$a>"
+  val x = q"x"
+  q"val $x: $x <: $x"
+  q"def f ( $x  ) . $x"
 }


### PR DESCRIPTION
Previously mutable.ListMap was used with assumption that it preserved
order of inserted elements (but it doesn't). Surprisingly logic that
assumed ordered elements worked mosly fine on unordered ones. I guess
two bugs can cancel each other out.

review @retronym
