### PR TITLE
SI-8332 implicit class param unquoting in quasiquotes

### DIFF
--- a/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
@@ -151,21 +151,20 @@ trait Reifiers { self: Quasiquotes =>
         mirrorCall(nme.This, tree)
       case SyntacticTraitDef(mods, name, tparams, earlyDefs, parents, selfdef, body) =>
         reifyBuildCall(nme.SyntacticTraitDef, mods, name, tparams, earlyDefs, parents, selfdef, body)
-      case SyntacticClassDef(mods, name, tparams, constrmods, vparamss, earlyDefs, parents, selfdef, body) =>
-        reifyBuildCall(nme.SyntacticClassDef, mods, name, tparams, constrmods, vparamss,
-                                              earlyDefs, parents, selfdef, body)
+      case SyntacticClassDef(mods, name, tparams, constrmods, vparamss,
+                             earlyDefs, parents, selfdef, body) =>
+        mirrorBuildCall(nme.SyntacticClassDef, reify(mods), reify(name), reify(tparams), reify(constrmods),
+                                               reifyVparamss(vparamss), reify(earlyDefs), reify(parents),
+                                               reify(selfdef), reify(body))
       case SyntacticPackageObjectDef(name, earlyDefs, parents, selfdef, body) =>
         reifyBuildCall(nme.SyntacticPackageObjectDef, name, earlyDefs, parents, selfdef, body)
       case SyntacticObjectDef(mods, name, earlyDefs, parents, selfdef, body) =>
         reifyBuildCall(nme.SyntacticObjectDef, mods, name, earlyDefs, parents, selfdef, body)
       case SyntacticNew(earlyDefs, parents, selfdef, body) =>
         reifyBuildCall(nme.SyntacticNew, earlyDefs, parents, selfdef, body)
-      case SyntacticDefDef(mods, name, tparams, build.ImplicitParams(vparamss, implparams), tpt, rhs) =>
-        if (implparams.nonEmpty)
-          mirrorBuildCall(nme.SyntacticDefDef, reify(mods), reify(name), reify(tparams),
-                          reifyBuildCall(nme.ImplicitParams, vparamss, implparams), reify(tpt), reify(rhs))
-        else
-          reifyBuildCall(nme.SyntacticDefDef, mods, name, tparams, vparamss, tpt, rhs)
+      case SyntacticDefDef(mods, name, tparams, vparamss, tpt, rhs) =>
+        mirrorBuildCall(nme.SyntacticDefDef, reify(mods), reify(name), reify(tparams),
+                                             reifyVparamss(vparamss), reify(tpt), reify(rhs))
       case SyntacticValDef(mods, name, tpt, rhs) if tree != noSelfType =>
         reifyBuildCall(nme.SyntacticValDef, mods, name, tpt, rhs)
       case SyntacticVarDef(mods, name, tpt, rhs) =>
@@ -269,6 +268,12 @@ trait Reifiers { self: Quasiquotes =>
     def reifyAnnotation(hole: Hole) = reifyConstructionCheck(nme.mkAnnotation, hole)
 
     def reifyPackageStat(hole: Hole) = reifyConstructionCheck(nme.mkPackageStat, hole)
+
+    def reifyVparamss(vparamss: List[List[ValDef]]) = {
+      val build.ImplicitParams(paramss, implparams) = vparamss
+      if (implparams.isEmpty) reify(paramss)
+      else reifyBuildCall(nme.ImplicitParams, paramss, implparams)
+    }
 
     /** Splits list into a list of groups where subsequent elements are considered
      *  similar by the corresponding function.

--- a/src/reflect/scala/reflect/api/Internals.scala
+++ b/src/reflect/scala/reflect/api/Internals.scala
@@ -581,7 +581,7 @@ trait Internals { self: Universe =>
     val ImplicitParams: ImplicitParamsExtractor
 
     trait ImplicitParamsExtractor {
-      def apply(paramss: List[List[ValDef]], implparams: List[ValDef]): List[List[ValDef]]
+      def apply(paramss: List[List[Tree]], implparams: List[Tree]): List[List[Tree]]
       def unapply(vparamss: List[List[ValDef]]): Some[(List[List[ValDef]], List[ValDef])]
     }
 

--- a/test/files/scalacheck/quasiquotes/DefinitionConstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/DefinitionConstructionProps.scala
@@ -85,6 +85,11 @@ trait ClassConstruction { self: QuasiquoteProperties =>
   property("SI-8333") = test {
     assertEqAst(q"{ $NoMods class C }", "{ class C }")
   }
+
+  property("SI-8332") = test {
+    val args = q"val a: Int; val b: Int"
+    assertEqAst(q"class C(implicit ..$args)", "class C(implicit val a: Int, val b: Int)")
+  }
 }
 
 trait TraitConstruction { self: QuasiquoteProperties =>

--- a/test/files/scalacheck/quasiquotes/DefinitionDeconstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/DefinitionDeconstructionProps.scala
@@ -73,8 +73,11 @@ trait ClassDeconstruction { self: QuasiquoteProperties =>
 
   property("exhaustive class matcher") = test {
     def matches(line: String) {
-      val q"""$classMods class $name[..$targs] $ctorMods(...$argss)
-              extends { ..$early } with ..$parents { $self => ..$body }""" = parse(line)
+      val tree = parse(line)
+      val q"""$classMods0 class $name0[..$targs0] $ctorMods0(...$argss0)
+              extends { ..$early0 } with ..$parents0 { $self0 => ..$body0 }""" = tree
+      val q"""$classMods1 class $name1[..$targs1] $ctorMods1(...$argss1)(implicit ..$impl)
+              extends { ..$early1 } with ..$parents1 { $self1 => ..$body1 }""" = tree
     }
     matches("class Foo")
     matches("class Foo[T]")
@@ -105,6 +108,13 @@ trait ClassDeconstruction { self: QuasiquoteProperties =>
               DefDef(Modifiers(), termNames.CONSTRUCTOR, List(), List(List(ValDef(Modifiers(PARAM | PARAMACCESSOR), TermName("x"),
                 Ident(TypeName("Int")), EmptyTree))), TypeTree(), Block(List(pendingSuperCall), Literal(Constant(())))))))
     }
+  }
+
+  property("SI-8332") = test {
+    val q"class C(implicit ..$args)" = q"class C(implicit i: I, j: J)"
+    val q"$imods val i: I" :: q"$jmods val j: J" :: Nil = args
+    assert(imods.hasFlag(IMPLICIT))
+    assert(jmods.hasFlag(IMPLICIT))
   }
 }
 


### PR DESCRIPTION
A new api that simplifies handling of implicit parameters has been
mistakingly supporting just methods parameters. This commit adds
support for class parameters too.

review @retronym
