### PR TITLE
SI-8333 can't use modifiers if class is in a block

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -3096,10 +3096,6 @@ self =>
           stats ++= importClause()
           acceptStatSepOpt()
         }
-        else if (isExprIntro) {
-          stats += statement(InBlock)
-          if (!isCaseDefEnd) acceptStatSep()
-        }
         else if (isDefIntro || isLocalModifier || isAnnotation) {
           if (in.token == IMPLICIT) {
             val start = in.skipToken()
@@ -3109,6 +3105,10 @@ self =>
             stats ++= localDef(0)
           }
           acceptStatSepOpt()
+        }
+        else if (isExprIntro) {
+          stats += statement(InBlock)
+          if (!isCaseDefEnd) acceptStatSep()
         }
         else if (isStatSep) {
           in.nextToken()

--- a/src/compiler/scala/tools/reflect/quasiquotes/Parsers.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Parsers.scala
@@ -118,6 +118,8 @@ trait Parsers { self: Quasiquotes =>
 
       override def isTemplateIntro: Boolean = super.isTemplateIntro || (isHole && lookingAhead { isTemplateIntro })
 
+      override def isDefIntro: Boolean = super.isDefIntro || (isHole && lookingAhead { isDefIntro })
+
       override def isDclIntro: Boolean = super.isDclIntro || (isHole && lookingAhead { isDclIntro })
 
       override def isStatSep(token: Int) = token == EOF || super.isStatSep(token)

--- a/test/files/scalacheck/quasiquotes/DefinitionConstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/DefinitionConstructionProps.scala
@@ -9,7 +9,7 @@ object DefinitionConstructionProps
     with ValDefConstruction
     with PatDefConstruction
     with DefConstruction
-    with PackageConstruction 
+    with PackageConstruction
     with ImportConstruction {
 
   val x: Tree = q"val x: Int"
@@ -80,6 +80,10 @@ trait ClassConstruction { self: QuasiquoteProperties =>
     assertEqAst(q"case class C($pubx) ", "case class C(x: Int)                  ")
     assertEqAst(q"     class C($privx)", "     class C(x: Int)                  ")
     assertEqAst(q"case class C($privx)", "case class C(private[this] val x: Int)")
+  }
+
+  property("SI-8333") = test {
+    assertEqAst(q"{ $NoMods class C }", "{ class C }")
   }
 }
 


### PR DESCRIPTION
Was caused by the ordering of parser cases. Need to check for definition
first due to the fact that modifiers unquote looks like identifier from
parser point of view.

review @retronym
