### PR TITLE
SI-8266 Amend advice for deprecated octal 042

### DIFF
--- a/src/compiler/scala/tools/reflect/FormatInterpolator.scala
+++ b/src/compiler/scala/tools/reflect/FormatInterpolator.scala
@@ -93,7 +93,8 @@ abstract class FormatInterpolator {
               case '\n' => "\\n"
               case '\f' => "\\f"
               case '\r' => "\\r"
-              case '\"' => "\\u0022"  // $" in future
+              case '\"' => "${'\"'}" /* avoid lint warn */ +
+                " or a triple-quoted literal \"\"\"with embedded \" or \\u0022\"\"\""  // $" in future
               case '\'' => "'"
               case '\\' => """\\"""
               case x    => "\\u%04x" format x

--- a/test/files/run/t8266-octal-interp.check
+++ b/test/files/run/t8266-octal-interp.check
@@ -10,7 +10,7 @@ t8266-octal-interp.scala:6: warning: Octal escape literals are deprecated, use \
 t8266-octal-interp.scala:7: warning: Octal escape literals are deprecated, use \r instead.
     f"a\15c",
        ^
-t8266-octal-interp.scala:8: warning: Octal escape literals are deprecated, use \u0022 instead.
+t8266-octal-interp.scala:8: warning: Octal escape literals are deprecated, use ${'"'} or a triple-quoted literal """with embedded " or \u0022""" instead.
     f"a\42c",
        ^
 t8266-octal-interp.scala:9: warning: Octal escape literals are deprecated, use \\ instead.


### PR DESCRIPTION
Improve the advice for `f"\042"` to read:

```
use ${'"'} or a triple-quoted literal """with embedded " or \u0022""" instead.
```

as per the discussion on SI-6476.

Knuth says that Charles XII came close to introducing octal arithmetic to Sweden,
and Wikipedia doesn't deny it.

I imagine an alternative history in which octal literals are deprecated in Scala
but required by legislation in Akka. #octal-fan-fiction
