### PR TITLE
SI-8366 make partial function and match trees disjoint

### DIFF
--- a/bincompat-backward.whitelist.conf
+++ b/bincompat-backward.whitelist.conf
@@ -122,6 +122,11 @@ filter {
     {
         matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticSelectTerm"
         problemName=MissingMethodProblem
+    },
+    // see SI-8366
+    {
+        matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticPartialFunction"
+        problemName=MissingMethodProblem
     }
   ]
 }

--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -130,6 +130,15 @@ filter {
     {
         matchName="scala.reflect.api.Internals$ReificationSupportApi$SyntacticSelectTypeExtractor"
         problemName=MissingClassProblem
-    }
+    },
+    // see SI-8366
+    {
+        matchName="scala.reflect.api.Internals$ReificationSupportApi$SyntacticPartialFunctionExtractor"
+        problemName=MissingClassProblem
+    },
+    {
+        matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticPartialFunction"
+        problemName=MissingMethodProblem
+    } 
   ]
 }

--- a/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
@@ -199,6 +199,10 @@ trait Reifiers { self: Quasiquotes =>
         reifyBuildCall(nme.SyntacticEmptyTypeTree)
       case SyntacticImport(expr, selectors) =>
         reifyBuildCall(nme.SyntacticImport, expr, selectors)
+      case SyntacticPartialFunction(cases) =>
+        reifyBuildCall(nme.SyntacticPartialFunction, cases)
+      case SyntacticMatch(scrutinee, cases) =>
+        reifyBuildCall(nme.SyntacticMatch, scrutinee, cases)
       case Q(tree) if fillListHole.isDefinedAt(tree) =>
         mirrorBuildCall(nme.SyntacticBlock, fillListHole(tree))
       case Q(other) =>
@@ -211,8 +215,6 @@ trait Reifiers { self: Quasiquotes =>
         reifyBuildCall(nme.SyntacticBlock, Nil)
       case Try(block, catches, finalizer) =>
         reifyBuildCall(nme.SyntacticTry, block, catches, finalizer)
-      case Match(selector, cases) =>
-        reifyBuildCall(nme.SyntacticMatch, selector, cases)
       case CaseDef(pat, guard, body) if fillListHole.isDefinedAt(body) =>
         mirrorCall(nme.CaseDef, reify(pat), reify(guard), mirrorBuildCall(nme.SyntacticBlock, fillListHole(body)))
       // parser emits trees with scala package symbol to ensure

--- a/src/reflect/scala/reflect/api/Internals.scala
+++ b/src/reflect/scala/reflect/api/Internals.scala
@@ -762,9 +762,15 @@ trait Internals { self: Universe =>
       def unapply(lst: List[List[Tree]]): Option[List[List[T]]]
     }
 
+    val SyntacticPartialFunction: SyntacticPartialFunctionExtractor
+    trait SyntacticPartialFunctionExtractor {
+      def apply(cases: List[Tree]): Match
+      def unapply(tree: Match): Option[List[CaseDef]]
+    }
+
     val SyntacticMatch: SyntacticMatchExtractor
     trait SyntacticMatchExtractor {
-      def apply(selector: Tree, cases: List[Tree]): Match
+      def apply(scrutinee: Tree, cases: List[Tree]): Match
       def unapply(tree: Match): Option[(Tree, List[CaseDef])]
     }
 

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -630,6 +630,7 @@ trait StdNames {
     val SyntacticNew: NameType         = "SyntacticNew"
     val SyntacticObjectDef: NameType   = "SyntacticObjectDef"
     val SyntacticPackageObjectDef: NameType = "SyntacticPackageObjectDef"
+    val SyntacticPartialFunction: NameType = "SyntacticPartialFunction"
     val SyntacticPatDef: NameType      = "SyntacticPatDef"
     val SyntacticSelectType: NameType  = "SyntacticSelectType"
     val SyntacticSelectTerm: NameType  = "SyntacticSelectTerm"

--- a/test/files/scalacheck/quasiquotes/TermConstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/TermConstructionProps.scala
@@ -95,12 +95,6 @@ object TermConstructionProps extends QuasiquoteProperties("term construction") {
     body1 ≈ body && cond1 ≈ cond
   }
 
-  property("unquote trees into alternative") = forAll { (c: Tree, A: Tree, B: Tree) =>
-    q"$c match { case $A | $B => }" ≈
-      Match(c, List(
-        CaseDef(Alternative(List(A, B)), EmptyTree, Literal(Constant(())))))
-  }
-
   def blockInvariant(quote: Tree, trees: List[Tree]) =
     quote ≈ (trees match {
       case Nil => q"{}"
@@ -302,5 +296,13 @@ object TermConstructionProps extends QuasiquoteProperties("term construction") {
 
   property("SI-8385 b") = test {
     assertEqAst(q"(() => ())()", "(() => ())()")
+  }
+
+  property("match scrutinee may not be empty") = test {
+    assertThrows[IllegalArgumentException] {
+      val scrutinee = q""
+      val cases = List(cq"_ =>")
+      q"$scrutinee match { case ..$cases }"
+    }
   }
 }

--- a/test/files/scalacheck/quasiquotes/TermConstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/TermConstructionProps.scala
@@ -305,4 +305,9 @@ object TermConstructionProps extends QuasiquoteProperties("term construction") {
       q"$scrutinee match { case ..$cases }"
     }
   }
+
+  property("construct partial function") = test {
+    val cases = List(cq"a => b", cq"c => d")
+    assertEqAst(q"{ case ..$cases }", "{ case a => b case c => d }")
+  }
 }

--- a/test/files/scalacheck/quasiquotes/TermDeconstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/TermDeconstructionProps.scala
@@ -217,4 +217,9 @@ object TermDeconstructionProps extends QuasiquoteProperties("term deconstruction
       val q"$_ match { case ..$_ }" = q"{ case _ => }"
     }
   }
+
+  property("deconstruct partial function") = test {
+    val q"{ case ..$cases }" = q"{ case a => b case c => d }"
+    val List(cq"a => b", cq"c => d") = cases
+  }
 }

--- a/test/files/scalacheck/quasiquotes/TermDeconstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/TermDeconstructionProps.scala
@@ -211,4 +211,10 @@ object TermDeconstructionProps extends QuasiquoteProperties("term deconstruction
       val q"$f[..$targs]" = tq"foo[bar]"
     }
   }
+
+  property("match doesn't match partial function") = test {
+    assertThrows[MatchError] {
+      val q"$_ match { case ..$_ }" = q"{ case _ => }"
+    }
+  }
 }


### PR DESCRIPTION
Previously one could match a partial function with match quasiquote:

```
scala> val q"$scrutinee match { case ..$cases }" = q"{ case Foo => Bar
}"
scrutinee: universe.Tree = <empty>
cases: List[universe.CaseDef] = List(case Foo => Bar)
```

This was quite annoying as it leaked encoding of partial functions as
Match trees with empty tree in place of scrutinee.

This commit make sure that matches and partial functions are disjoint
and don't match one another (while preserving original encoding under
the hood out of sight of the end user.)

review @retronym
