### PR TITLE
SI-8370 fixes an infinite loop in repl init

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -306,7 +306,7 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
      */
     override protected def findAbstractFile(name: String): AbstractFile =
       super.findAbstractFile(name) match {
-        case null => translatePath(name) map (super.findAbstractFile(_)) orNull
+        case null if _initializeComplete => translatePath(name) map (super.findAbstractFile(_)) orNull
         case file => file
       }
   }


### PR DESCRIPTION
Under a weird coincidence of circumstances provided by `sbt console-quick`,
new XML parsing logic in compiler plugin initialization could lead to stack
overflow errors.

Here's the abridged sequence events that led to this unfortunate problem
(full description can be found on the JIRA issue page):

1) Initialization of the compiler underlying the REPL would kick off
plugin initialization.

2) PluginDescription.fromXML would call into DocumentBuilderFactory, i.e.
DocumentBuilderFactory.newInstance.newDocumentBuilder.parse(xml).

3) That thing would call into javax.xml.parsers.SecuritySupport.getResourceAsStream,
requesting META-INF/services/javax.xml.parsers.DocumentBuilderFactory.

4) That request would get serviced by TranslatingClassLoader provided
by the REPL to expose dynamically compiled code.

5) TranslatingClassLoader would call translatePath that would call into
IMain.symbolOfIdent trying to map the requested resource onto one of the
classes defined by the REPL (which don't exist yet, because REPL hasn't
yet finished initializing).

6) IMain.symbolOfIdent would request IMain.global, which is exactly the
instance of the compiler that underlies the REPL, and that's currently
being initialized.

7..inf) Repeat until a StackOverflowError.
