### PR TITLE
SI-8385 make sure $quasiquote$tuple gets reified properly 

### DIFF
--- a/src/compiler/scala/tools/reflect/quasiquotes/Quasiquotes.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Quasiquotes.scala
@@ -51,7 +51,7 @@ abstract class Quasiquotes extends Parsers
     def sreified =
       reified
         .toString
-        .replace("scala.reflect.runtime.`package`.universe.build.", "")
+        .replace("scala.reflect.runtime.`package`.universe.internal.reificationSupport.", "")
         .replace("scala.reflect.runtime.`package`.universe.", "")
         .replace("scala.collection.immutable.", "")
     debug(s"reified tree:\n$sreified\n")

--- a/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
@@ -181,6 +181,10 @@ trait Reifiers { self: Quasiquotes =>
         reifyBuildCall(nme.SyntacticForYield, enums, body)
       case SyntacticAssign(lhs, rhs) =>
         reifyBuildCall(nme.SyntacticAssign, lhs, rhs)
+      // rest will always be non-empty due to the fact that every single-parens
+      // application will be reified by reifyTreePlaceholder before it gets here.
+      case SyntacticApplied(id @ Ident(nme.QUASIQUOTE_TUPLE), first :: rest) =>
+        mirrorBuildCall(nme.SyntacticApplied, reifyTreePlaceholder(Apply(id, first)), reify(rest))
       case SyntacticApplied(fun, argss) if argss.nonEmpty =>
         reifyBuildCall(nme.SyntacticApplied, fun, argss)
       case SyntacticTypeApplied(fun, targs) if targs.nonEmpty =>

--- a/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Reifiers.scala
@@ -131,6 +131,10 @@ trait Reifiers { self: Quasiquotes =>
       case Placeholder(Hole(tree, NoDot)) if isReifyingPatterns => tree
       case Placeholder(hole @ Hole(_, rank @ Dot())) => c.abort(hole.pos, s"Can't $action with $rank here")
       case TuplePlaceholder(args) => reifyTuple(args)
+      // Due to greediness of syntactic applied we need to pre-emptively peek inside.
+      // `rest` will always be non-empty due to the rule on top of this one.
+      case SyntacticApplied(id @ Ident(nme.QUASIQUOTE_TUPLE), first :: rest) =>
+        mirrorBuildCall(nme.SyntacticApplied, reifyTreePlaceholder(Apply(id, first)), reify(rest))
       case TupleTypePlaceholder(args) => reifyTupleType(args)
       case FunctionTypePlaceholder(argtpes, restpe) => reifyFunctionType(argtpes, restpe)
       case CasePlaceholder(hole) => hole.tree
@@ -181,10 +185,6 @@ trait Reifiers { self: Quasiquotes =>
         reifyBuildCall(nme.SyntacticForYield, enums, body)
       case SyntacticAssign(lhs, rhs) =>
         reifyBuildCall(nme.SyntacticAssign, lhs, rhs)
-      // rest will always be non-empty due to the fact that every single-parens
-      // application will be reified by reifyTreePlaceholder before it gets here.
-      case SyntacticApplied(id @ Ident(nme.QUASIQUOTE_TUPLE), first :: rest) =>
-        mirrorBuildCall(nme.SyntacticApplied, reifyTreePlaceholder(Apply(id, first)), reify(rest))
       case SyntacticApplied(fun, argss) if argss.nonEmpty =>
         reifyBuildCall(nme.SyntacticApplied, fun, argss)
       case SyntacticTypeApplied(fun, targs) if targs.nonEmpty =>

--- a/test/files/scalacheck/quasiquotes/TermConstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/TermConstructionProps.scala
@@ -295,4 +295,12 @@ object TermConstructionProps extends QuasiquoteProperties("term construction") {
     val q"$a = $b = $c = $d = $e = $f = $g = $h = $k = $l" = q"a = b = c = d = e = f = g = h = k = l"
     assert(a ≈ q"a" && b ≈ q"b" && c ≈ q"c" && d ≈ q"d" && e ≈ q"e" && g ≈ q"g" && h ≈ q"h" && k ≈ q"k" && l ≈ q"l")
   }
+
+  property("SI-8385 a") = test {
+    assertEqAst(q"(foo.x = 1)(2)", "(foo.x = 1)(2)")
+  }
+
+  property("SI-8385 b") = test {
+    assertEqAst(q"(() => ())()", "(() => ())()")
+  }
 }


### PR DESCRIPTION
Previously due to greediness of SyntacticApplied there was a chance that
quasiquote tuple placeholder got reified as its representation rather
than its meaning.

review @retronym
