### PR TITLE
SI-8196 Runtime reflection robustness for STATIC impl details

### DIFF
--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -173,6 +173,11 @@ filter {
         {
             matchName="scala.reflect.runtime.SymbolLoaders.isInvalidClassName"
             problemName=MissingMethodProblem
+        },
+        {
+            matchName="scala.reflect.runtime.JavaMirrors#JavaMirror.scala$reflect$runtime$JavaMirrors$JavaMirror$$followStatic"
+            problemName=MissingMethodProblem
         }
+
     ]
 }

--- a/test/files/run/t8196.check
+++ b/test/files/run/t8196.check
@@ -1,0 +1,3 @@
+Scope{
+  final private val f1: Int
+}

--- a/test/files/run/t8196.scala
+++ b/test/files/run/t8196.scala
@@ -1,0 +1,30 @@
+object Test extends App {
+ 
+  trait FormTrait {
+    import scala.reflect.runtime.{ universe => ru }
+
+    val runtimeMirror = ru.runtimeMirror(this.getClass.getClassLoader)
+    val instanceMirror = runtimeMirror.reflect(this)
+    val members = instanceMirror.symbol.typeSignature.members
+    def fields = members.filter(_.typeSignature <:< ru.typeOf[Int])
+  }
+ 
+  val f = () => {
+ 
+    class Form1 extends FormTrait {
+      val f1 = 5
+    }
+    val form1 = new Form1
+ 
+    println(form1.fields)
+ 
+    val form2 = new FormTrait {
+      val g1 = new Form1
+    }
+ 
+    form2.g1 // comment this line in order to make the test pass
+    ()
+  }
+
+  f()  
+}

--- a/test/files/run/t8196.scala
+++ b/test/files/run/t8196.scala
@@ -1,7 +1,8 @@
+import scala.reflect.runtime.{ universe => ru }
+
 object Test extends App {
  
   trait FormTrait {
-    import scala.reflect.runtime.{ universe => ru }
 
     val runtimeMirror = ru.runtimeMirror(this.getClass.getClassLoader)
     val instanceMirror = runtimeMirror.reflect(this)
@@ -26,5 +27,25 @@ object Test extends App {
     ()
   }
 
-  f()  
+  val g = () => {
+    // Reported as SI-8195, same root cause
+    trait Form {
+ 
+      private val runtimeMirror = ru.runtimeMirror(this.getClass.getClassLoader)
+      private val instanceMirror = runtimeMirror.reflect(this)
+      private val members = instanceMirror.symbol.typeSignature.members
+ 
+    }
+ 
+    val f1 = new Form {
+      val a = 1
+    }
+ 
+    val f2 = new Form {
+      val b = f1.a
+    }
+  }
+
+  f() 
+  g() 
 }


### PR DESCRIPTION
Scala's runtime reflection works in few modes. The primary mode reads
reads out the pickled signatures from ScalaSig annotations, if
avaialable. However, these aren't available for Java-defined classes
(obviously) nor for local Scala-defined classes (less obviously.),
and the Scala `Symbol`s and `Types` must be reconstructed from
the Java generic reflection metadata.

This bug occurs in the last case, and is centered in
`FromJavaClassCompleter`.

In that completer, member fields and methods are given an owner
based on the STATIC modifier. That makes sense for Java defined
classes. I'm not 100% if it makes sense for Scala defined classes;
maybe we should just skip them entirely?

This patch still includes them, but makes the ownership-assignment
more robust in the face of STATIC members emitted by the Scala
compiler backend, such as the cache fields for structural calls.
(It's reflection all the way down!). We might not have a companion
module at all, so before we ended up owning those by `NoSymbol`,
and before too long hit the dreaded NSDHNAO crash.

That crash doesn't exist any more on 2.11 (it is demoted to a
-Xdev warning), but this patch still makes sense on that branch.

This commit makes `followStatic` and `enter` more robust when
finding a suitable owner for static members. I've also factored
out the duplicated logic between the two.

Review by @xeno-by

I think this fix should be targetted at 2.10.5 and 2.11.1
