### PR TITLE
SI-8376 Fix overload resolution with Java varargs

### DIFF
--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -410,7 +410,8 @@ trait Definitions extends api.StandardDefinitions {
       else if (isScalaRepeatedParamType(tp)) elementExtract(RepeatedParamClass, tp) orElse tp
       else tp
     )
-    def repeatedToSingle(tp: Type): Type                     = elementExtract(RepeatedParamClass, tp) orElse tp
+    def repeatedToSingle(tp: Type): Type                     = elementExtract(RepeatedParamClass, tp) orElse elementExtract(JavaRepeatedParamClass, tp) orElse tp
+     // We don't need to deal with JavaRepeatedParamClass here, as `repeatedToSeq` is only called in the patmat translation for Scala sources.
     def repeatedToSeq(tp: Type): Type                        = elementTransform(RepeatedParamClass, tp)(seqType) orElse tp
     def seqToRepeated(tp: Type): Type                        = elementTransform(SeqClass, tp)(scalaRepeatedType) orElse tp
     def isReferenceArray(tp: Type)                           = elementTest(ArrayClass, tp)(_ <:< AnyRefTpe)

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2271,7 +2271,7 @@ trait Types
       case _          => args.mkString("(", ", ", ")")
     }
     private def customToString = sym match {
-      case RepeatedParamClass => args.head + "*"
+      case RepeatedParamClass | JavaRepeatedParamClass => args.head + "*"
       case ByNameParamClass   => "=> " + args.head
       case _                  =>
         if (isFunctionTypeDirect(this)) {

--- a/test/files/neg/t8376.check
+++ b/test/files/neg/t8376.check
@@ -1,0 +1,7 @@
+S.scala:2: error: overloaded method value m with alternatives:
+  (a: J*)Unit <and>
+  (a: String*)Unit
+ cannot be applied to (Int)
+  J.m(0)
+    ^
+one error found

--- a/test/files/neg/t8376/J.java
+++ b/test/files/neg/t8376/J.java
@@ -1,0 +1,4 @@
+class J {
+  public static void m(String... a) { }
+  public static void m(J... a) { }
+}

--- a/test/files/neg/t8376/S.scala
+++ b/test/files/neg/t8376/S.scala
@@ -1,0 +1,4 @@
+object S {
+  J.m(0)
+  // the error message should show `T*` in the method signatures rather than `<repeated>[T]`
+}

--- a/test/files/pos/t8376/BindingsX.java
+++ b/test/files/pos/t8376/BindingsX.java
@@ -1,0 +1,13 @@
+/**
+ * A simple Java class implementing methods similar to new JavaFX `Bindings`.
+ */
+public final class BindingsX {
+
+    public static void select(String root, String... steps) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    public static void select(Object root, String... steps) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+}

--- a/test/files/pos/t8376/Test.scala
+++ b/test/files/pos/t8376/Test.scala
@@ -1,0 +1,10 @@
+class Test {
+  BindingsX.select("", "") // okay in 2.10, fails in 2.11
+
+  BindingsY.select1("", "") // okay in both
+}
+
+object BindingsY {
+  def select1(root: String, steps: String*) = ()  
+  def select1(root: Any, steps: String*) = ()
+}


### PR DESCRIPTION
When comparing specificity of two vararg `MethodTypes`, `isAsSpecific`
gets to:

```
  case mt @ MethodType(_, _) if bothAreVarargs =>
    checkIsApplicable(mt.paramTypes mapConserve repeatedToSingle)
```

The formal parameter type of a Java varargs parameter is represented
as `tq"${defintions.JavaRepeatedParamClass}[$elemTp]"`. For a Scala
repeated parameter, we instead use `defintions.RepeatedParamClass`.

`bothAreVarargs` detects `JavaRepeatedParamClass`, by virtue of:

```
def isRepeatedParamType(tp: Type)      = isScalaRepeatedParamType(tp) || isJavaRepeatedParamType(tp)
```

But, `repeatedToSingle` only considers `RepeatedParamClass`.

This bug was ostensibly masked in 2.10.3, but became apparent after
a not-quite-refactoring in 0fe56b9770. It would be good to pin that
change down to a particular line, but I haven't managed that yet.

Review by @adriaanm / @gkossakowski.

I'll look at 0fe56b9770 a bit more tomorrow to try to explain why this
ever worked in to 2.10.3.
