### PR TITLE
SI-8363 Disable -Ydelambdafy:method in constructor position

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -221,7 +221,9 @@ abstract class UnCurry extends InfoTransform
           def mkMethod(owner: Symbol, name: TermName, additionalFlags: FlagSet = NoFlags): DefDef =
             gen.mkMethodFromFunction(localTyper)(fun, owner, name, additionalFlags)
 
-          if (inlineFunctionExpansion) {
+          val canUseDelamdafyMethod = (inConstructorFlag == 0) // Avoiding synthesizing code prone to SI-6666, SI-8363 by using old-style lambda translation
+
+          if (inlineFunctionExpansion || !canUseDelamdafyMethod) {
             val parents = addSerializable(abstractFunctionForFunctionType(fun.tpe))
             val anonClass = fun.symbol.owner newAnonymousFunctionClass(fun.pos, inConstructorFlag) addAnnotation SerialVersionUIDAnnotation
             anonClass setInfo ClassInfoType(parents, newScope, anonClass)

--- a/test/files/pos/t8363.flags
+++ b/test/files/pos/t8363.flags
@@ -1,0 +1,1 @@
+-Ydelambdafy:method

--- a/test/files/pos/t8363.scala
+++ b/test/files/pos/t8363.scala
@@ -1,0 +1,7 @@
+class C(a: Any)
+class Test {  
+  def foo: Any = {
+    def form = 0
+    class C1 extends C(() => form)
+  }
+}

--- a/test/pending/pos/t8363b.scala
+++ b/test/pending/pos/t8363b.scala
@@ -1,0 +1,7 @@
+class C(a: Any)
+class Test {  
+  def foo: Any = {
+    def form = 0
+    class C1 extends C({def x = form; ()})
+  }
+}


### PR DESCRIPTION
As @magarciaEPFL has done in his experimental optimizer [1], we can
avoid running into limitations of lambdalift (either `VerifyError`s,
ala scala/bug#6666, or compiler crashes, such as this bug), by using the
old style of "inline" lambda translation when in a super- or self-
construtor call.

We might be able to get these working later on, but for now we
shouldn't block adoption of `-Ydelamndafy:method` for this corner
case.

[1] https://github.com/magarciaEPFL/scala/blob/GenRefactored99sZ/src/compiler/scala/tools/nsc/transform/UnCurry.scala#L227

Review by @gkossakowski
