### PR TITLE
SI-8392 Guards QuasiquoteClass against non-availability in scala-reflect

### DIFF
--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -501,7 +501,9 @@ trait Definitions extends api.StandardDefinitions {
 
     lazy val StringContextClass           = requiredClass[scala.StringContext]
 
-    lazy val QuasiquoteClass             = if (ApiUniverseClass != NoSymbol) getMember(ApiUniverseClass, tpnme.Quasiquote) else NoSymbol
+    // SI-8392 a reflection universe on classpath may not have
+    // quasiquotes, if e.g. crosstyping with -Xsource on
+    lazy val QuasiquoteClass             = if (ApiUniverseClass != NoSymbol) getMemberIfDefined(ApiUniverseClass, tpnme.Quasiquote) else NoSymbol
     lazy val QuasiquoteClass_api         = if (QuasiquoteClass != NoSymbol) getMember(QuasiquoteClass, tpnme.api) else NoSymbol
     lazy val QuasiquoteClass_api_apply   = if (QuasiquoteClass_api != NoSymbol) getMember(QuasiquoteClass_api, nme.apply) else NoSymbol
     lazy val QuasiquoteClass_api_unapply = if (QuasiquoteClass_api != NoSymbol) getMember(QuasiquoteClass_api, nme.unapply) else NoSymbol


### PR DESCRIPTION
This assimilates behavior on Quasiquotes to the one on Reflection : if we
don't have the right resource on classpath, we do without rather than
throwing.

See the bug report for more on rationale (-Xsource flag, early quasiquote
loading in Analyzer through FastTrack, etc).

Review by @gkossakowski or @xeno-by
