### PR TITLE
SI-8395 Regression in pattern matching with nested binds

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
@@ -81,14 +81,14 @@ trait MatchTranslation {
 
       object SymbolAndTypeBound {
         def unapply(tree: Tree): Option[(Symbol, Type)] = tree match {
-          case SymbolBound(sym, SymbolAndTypeBound(_, tpe)) => Some(sym -> tpe)
-          case TypeBound(tpe)                               => Some(binder -> tpe)
-          case _                                            => None
+          case SymbolBound(sym, TypeBound(tpe)) => Some(sym -> tpe)
+          case TypeBound(tpe)                   => Some(binder -> tpe)
+          case _                                => None
         }
       }
 
       object TypeBound {
-        def unapply(tree: Tree): Option[Type] = unbind(tree) match {
+        def unapply(tree: Tree): Option[Type] = tree match {
           case Typed(Ident(_), _) if tree.tpe != null => Some(tree.tpe)
           case _                                      => None
         }

--- a/test/files/run/t8395.scala
+++ b/test/files/run/t8395.scala
@@ -1,0 +1,9 @@
+ object Test {
+  def baz(x: Object) = {
+    val s @ (_s: String) = x
+    x
+  }
+  def main(args: Array[String]) {
+    assert(baz("1") == "1")
+  }
+}


### PR DESCRIPTION
Regressed in https://github.com/scala/scala/pull/2848. In particular,
see 0cf47bdb5b and 017460e63c.

Because of the regression, this pattern:

```
(s @ (_s @ (_: String)))
```

was translated into `typeTestStep`, rather than a `bindingStep`. This
came down the the use of `unbind` in the `TypeBound` extractor.

My first step was to remove the `unbind`. That led to another
problem: the tree now matches `SymbolAndTypeBound`, which extracted
`symbol = s, tpe = String`, ignoring the `_s`. I changed that
extractor to no longer recursively apply to the sub-pattern tree,
which is what `MaybeTypedBound` used to do.

I also checked for other uses of `unbind` in the match translation.
The only place I found it is in `BoundTree#pt`. I believe that this
usage is correct, or at least, not obviously incorrect.
