### PR TITLE
Remove "will not terminate" from toStream doc

### DIFF
--- a/src/library/scala/collection/GenTraversableOnce.scala
+++ b/src/library/scala/collection/GenTraversableOnce.scala
@@ -506,7 +506,6 @@ trait GenTraversableOnce[+A] extends Any {
   def toIndexedSeq: immutable.IndexedSeq[A]
 
   /** Converts this $coll to a stream.
-   *  $willNotTerminateInf
    *  @return a stream containing all elements of this $coll.
    */
   def toStream: Stream[A]


### PR DESCRIPTION
It's at least not always true:

```
scala> val example = Iterator.continually(1).toStream
example: scala.collection.immutable.Stream[Int] = Stream(1, ?)
```
