### PR TITLE
SI-8403 Fix regression in name binding with imports in templates

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -433,8 +433,10 @@ trait Contexts { self: Analyzer =>
         case _         => false
       }
       val isImport = tree match {
-        case _: Import => true
-        case _         => false
+        // The guard is for SI-8403. It prevents adding imports again in the context created by
+        // `Namer#createInnerNamer`
+        case _: Import if tree != this.tree => true
+        case _                              => false
       }
       val sameOwner = owner == this.owner
       val prefixInChild =

--- a/test/files/pos/t8403.scala
+++ b/test/files/pos/t8403.scala
@@ -1,0 +1,9 @@
+trait Bug {
+  val u: { type Amb } = ???
+  import u._
+ 
+  class Amb { def x = 0 }
+  class C(x: Amb) { // after dbd8457e4, "reference to Amb is ambiguous"
+    x.x
+  }
+}


### PR DESCRIPTION
Regressed in dbd8457 which changed `Context#make` to automatically
include the imports from the given `Tree` if it was an `Import`
tree, rather than requiring callers to call `makeNewImport`.

However, this turns out to double up the imports for the "inner" namer
of a template that starts with imports. The inner namer has a new
scope, but the same owner and tree as its parent.

This commit detects this case by seeing if the `Import` tree used
to consruct the child context is the same as the parent context.
If that is the case, we don't augment `Context#imports`.

Review by @adriaanm
