### PR TITLE
SI-8407 "symbol not found" in Scaladoc use cases: warning only

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/ScaladocAnalyzer.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/ScaladocAnalyzer.scala
@@ -37,7 +37,7 @@ trait ScaladocAnalyzer extends Analyzer {
         comment.defineVariables(sym)
         val typer1 = newTyper(context.makeNewScope(docDef, context.owner))
         for (useCase <- comment.useCases) {
-          typer1.silent(_ => typer1 defineUseCases useCase) match {
+          typer1.silent(_.asInstanceOf[ScaladocTyper].defineUseCases(useCase)) match {
             case SilentTypeError(err) =>
               unit.warning(useCase.pos, err.errMsg)
             case _ =>

--- a/test/scaladoc/run/t8407.check
+++ b/test/scaladoc/run/t8407.check
@@ -1,0 +1,4 @@
+newSource:4: warning: not found: type $NotFound
+   *  @usecase def zipWithIndex: $NotFound
+               ^
+Done.

--- a/test/scaladoc/run/t8407.scala
+++ b/test/scaladoc/run/t8407.scala
@@ -1,0 +1,20 @@
+import scala.tools.nsc.doc.model._
+import scala.tools.partest.ScaladocModelTest
+
+object Test extends ScaladocModelTest {
+  override def code = """
+class C {
+  /**
+   *  @usecase def zipWithIndex: $NotFound
+   *
+   */
+  def zipWithIndex: Int = ???
+}
+  """
+
+  def scaladocSettings = ""
+
+  def testModel(root: Package) = {
+    // just testing that it doesn't error out.
+  }
+}


### PR DESCRIPTION
The refactoring in aedec1980 mistakenly used the non-silent
typer to typecheck the use cases. It temptingly had the desired
type (`ScalaDocAnalyzer`), but sadly the wrong properties (it will
report errors, rather than buffer.)

This meant that "symbol not found" errors in use cases would prevent
Scaladoc generation.

This commit introduces a little downcast on the silent typer.
A more principled approach would be to go through the rigmarole
of the virtual class pattern for `Analzyer.Typer`, but that will
have to remain work for another day.

Review by @gkossakowski
