### PR TITLE
Minor fixes in test. The equals method always returned true.

### DIFF
--- a/test/files/run/t6196.scala
+++ b/test/files/run/t6196.scala
@@ -43,7 +43,7 @@ object Test extends App {
 
       override def equals(that:Any) = {
         equalsCount += 1
-        this match {
+        that match {
           case HashCounter(value) => this.value == value
           case _ => false
         }

--- a/test/files/run/t6200.scala
+++ b/test/files/run/t6200.scala
@@ -43,7 +43,7 @@ object Test extends App {
 
       override def equals(that: Any) = {
         equalsCount += 1
-        this match {
+        that match {
           case HashCounter(value) => this.value == value
           case _ => false
         }


### PR DESCRIPTION
This commit ensures that the classes we use to test HashMaps and
HashSets in t6196 and t6200 have proper equals and hashCode
methods. (The old equals method returned always true and therefore
hashCode violated its contract).
