### PR TITLE
SI-4492 More informative error when class not found on classpath

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -359,6 +359,14 @@ trait ContextErrors {
         //setError(sel)
       }
 
+      def SelectWithUnderlyingError(sel: Tree, err: AbsTypeError) = {
+        // if there's no position, this is likely the result of a MissingRequirementError
+        // use the position of the selection we failed to type check to report the original message
+        if (err.errPos == NoPosition) issueNormalTypeError(sel, err.errMsg)
+        else issueTypeError(err)
+        setError(sel)
+      }
+
       //typedNew
       def IsAbstractError(tree: Tree, sym: Symbol) = {
         issueNormalTypeError(tree, sym + " is abstract; cannot be instantiated")

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -103,7 +103,7 @@ trait Contexts { self: Analyzer =>
 
     // there must be a scala.xml package when xml literals were parsed in this unit
     if (unit.hasXml && ScalaXmlPackage == NoSymbol)
-      unit.error(unit.firstXmlPos, "To compile XML syntax, the scala.xml package must be on the classpath.\nPlease see https://github.com/scala/scala/wiki/Scala-2.11#xml.")
+      unit.error(unit.firstXmlPos, "To compile XML syntax, the scala.xml package must be on the classpath.\nPlease see http://docs.scala-lang.org/overviews/core/scala-2.11.html#scala-xml.")
 
     // scala-xml needs `scala.xml.TopScope` to be in scope globally as `$scope`
     // We detect `scala-xml` by looking for `scala.xml.TopScope` and
@@ -544,6 +544,8 @@ trait Contexts { self: Analyzer =>
       if (checking) onTreeCheckerError(pos, msg) else unit.error(pos, msg)
 
     @inline private def issueCommon(err: AbsTypeError)(pf: PartialFunction[AbsTypeError, Unit]) {
+      // TODO: are errors allowed to have pos == NoPosition??
+      // if not, Jason suggests doing: val pos = err.errPos.orElse( { devWarning("Que?"); context.tree.pos })
       if (settings.Yissuedebug) {
         log("issue error: " + err.errMsg)
         (new Exception).printStackTrace()

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4670,8 +4670,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             case SilentTypeError(err: AccessTypeError) =>
               (tree1, Some(err))
             case SilentTypeError(err) =>
-              context issue err
-              return setError(tree)
+              SelectWithUnderlyingError(tree, err)
+              return tree
             case SilentResultValue(treeAndPre) =>
               (stabilize(treeAndPre._1, treeAndPre._2, mode, pt), None)
           }

--- a/test/files/neg/t5148.check
+++ b/test/files/neg/t5148.check
@@ -1,5 +1,5 @@
-error: bad symbolic reference. A signature in Imports.class refers to type Request
-in class scala.tools.nsc.interpreter.IMain which is not available.
-It may be completely missing from the current classpath, or the version on
-the classpath might be incompatible with the version used when compiling Imports.class.
+error: bad symbolic reference to scala.tools.nsc.interpreter.IMain.Request encountered in class file 'Imports.class'.
+Cannot access type Request in class scala.tools.nsc.interpreter.IMain. The current classpath may be
+missing a definition for scala.tools.nsc.interpreter.IMain.Request, or Imports.class may have been compiled against a version that's
+incompatible with the one found on the current classpath.
 one error found

--- a/test/files/run/t6440.check
+++ b/test/files/run/t6440.check
@@ -1,4 +1,4 @@
-pos: source-newSource1.scala,line-9,offset=109 bad symbolic reference. A signature in U.class refers to term pack1
-in package <root> which is not available.
-It may be completely missing from the current classpath, or the version on
-the classpath might be incompatible with the version used when compiling U.class. ERROR
+pos: source-newSource1.scala,line-9,offset=109 bad symbolic reference to <root>.pack1 encountered in class file 'U.class'.
+Cannot access term pack1 in package <root>. The current classpath may be
+missing a definition for <root>.pack1, or U.class may have been compiled against a version that's
+incompatible with the one found on the current classpath. ERROR

--- a/test/files/run/t6440b.check
+++ b/test/files/run/t6440b.check
@@ -1,4 +1,4 @@
-pos: NoPosition bad symbolic reference. A signature in U.class refers to type T
-in package pack1 which is not available.
-It may be completely missing from the current classpath, or the version on
-the classpath might be incompatible with the version used when compiling U.class. ERROR
+pos: NoPosition bad symbolic reference to pack1.T encountered in class file 'U.class'.
+Cannot access type T in package pack1. The current classpath may be
+missing a definition for pack1.T, or U.class may have been compiled against a version that's
+incompatible with the one found on the current classpath. ERROR


### PR DESCRIPTION
Sorry, I don't have time to add a test for the module advice part of the error message.
Our classpath handling needs to be fixed to do this reliably anyway.

I discovered another bug in our launcher script (#3630) while testing it manually...
