### PR TITLE
SI-7992 Fix super-accessor generation after a local class

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
@@ -346,12 +346,14 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
      *  performance hit for the compiler as a whole.
      */
     override def atOwner[A](tree: Tree, owner: Symbol)(trans: => A): A = {
+      val savedValid = validCurrentOwner
       if (owner.isClass) validCurrentOwner = true
       val savedLocalTyper = localTyper
       localTyper = localTyper.atOwner(tree, if (owner.isModule) owner.moduleClass else owner)
       typers = typers updated (owner, localTyper)
       val result = super.atOwner(tree, owner)(trans)
       localTyper = savedLocalTyper
+      validCurrentOwner = savedValid
       typers -= owner
       result
     }

--- a/test/files/run/t7992.scala
+++ b/test/files/run/t7992.scala
@@ -1,0 +1,20 @@
+class C {
+  def foo: Int = 0
+}
+
+class D extends C {
+  override def foo: Int = {
+    val f = () => {
+      class C     // comment this line to fix.
+      D.super.foo // no super accessor generated here!
+      // java.lang.VerifyError: (class: D$$anonfun$1, method: apply$mcI$sp signature: ()I) Illegal use of nonvirtual function call
+    }
+    f()
+  }
+}
+
+object Test {
+  def main(args: Array[String]) {
+    new D().foo
+  }
+}

--- a/test/files/run/t7992b.scala
+++ b/test/files/run/t7992b.scala
@@ -1,0 +1,18 @@
+class C {
+  def foo: Int = 0
+}
+
+class E extends C {
+  override def foo: Int = {
+    (None: Option[Int]).getOrElse {
+      class C
+      E.super.foo 
+    }
+  }
+}
+
+object Test {
+  def main(args: Array[String]) {
+    new E().foo
+  }
+}


### PR DESCRIPTION
The transformer in the superaccessors phase uses the var
`validCurrentOwner` to track whether we're in a part of the
code that won't end up in the host method, and as such, will
need to access super-method via a super-accessor.

But, this bit of bookkeeping was not correctly reset after traversing
out of a local class. A `VerifyError` ensued.

This commit changes `atOwner` to save and restore that flag, rather
than leaving it set to `true`.

I've also added a test variation using a by-name argument.

Review by @gkossakowski. For 2.11.1
