### PR TITLE
introduces Mirror.typeOf

### DIFF
--- a/bincompat-backward.whitelist.conf
+++ b/bincompat-backward.whitelist.conf
@@ -132,6 +132,18 @@ filter {
     {
         matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticPartialFunction"
         problemName=MissingMethodProblem
+    },
+    {
+        matchName="scala.reflect.api.Mirror.symbolOf"
+        problemName=MissingMethodProblem
+    },
+    {
+        matchName="scala.reflect.api.Mirror.typeOf"
+        problemName=MissingMethodProblem
+    },
+    {
+        matchName="scala.reflect.api.Mirror.weakTypeOf"
+        problemName=MissingMethodProblem
     }
   ]
 }

--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -111,7 +111,7 @@ filter {
         matchName="scala.reflect.api.StandardLiftables#StandardLiftableInstances.liftTree"
         problemName=MissingMethodProblem
     },
-    // see SI-8331 
+    // see SI-8331
     {
         matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticSelectType"
         problemName=MissingMethodProblem
@@ -151,6 +151,18 @@ filter {
     },
     {
         matchName="scala.collection.Iterator#ConcatIterator.this"
+        problemName=MissingMethodProblem
+    },
+    {
+        matchName="scala.reflect.api.Mirror.symbolOf"
+        problemName=MissingMethodProblem
+    },
+    {
+        matchName="scala.reflect.api.Mirror.typeOf"
+        problemName=MissingMethodProblem
+    },
+    {
+        matchName="scala.reflect.api.Mirror.weakTypeOf"
         problemName=MissingMethodProblem
     }
   ]

--- a/src/reflect/scala/reflect/api/Mirror.scala
+++ b/src/reflect/scala/reflect/api/Mirror.scala
@@ -118,4 +118,22 @@ abstract class Mirror[U <: Universe with Singleton] {
    *  @group Mirror
    */
   def staticPackage(fullName: String): U#ModuleSymbol
+
+  /**
+   * Shortcut for `implicitly[WeakTypeTag[T]].tpe`
+   * @group TypeTags
+   */
+  def weakTypeOf[T: universe.WeakTypeTag]: U#Type = universe.weakTypeTag[T].in(this).tpe
+
+  /**
+   * Shortcut for `implicitly[TypeTag[T]].tpe`
+   * @group TypeTags
+   */
+  def typeOf[T: universe.TypeTag]: U#Type = universe.typeTag[T].in(this).tpe
+
+  /**
+   * Type symbol of `x` as derived from a type tag.
+   * @group TypeTags
+   */
+  def symbolOf[T: universe.WeakTypeTag]: U#TypeSymbol
 }

--- a/src/reflect/scala/reflect/internal/Mirrors.scala
+++ b/src/reflect/scala/reflect/internal/Mirrors.scala
@@ -30,6 +30,8 @@ trait Mirrors extends api.Mirrors {
     val EmptyPackageClass: ClassSymbol
     val EmptyPackage: ModuleSymbol
 
+    def symbolOf[T: universe.WeakTypeTag]: universe.TypeSymbol = universe.weakTypeTag[T].in(this).tpe.typeSymbolDirect.asType
+
     def findMemberFromRoot(fullName: Name): Symbol = {
       val segs = nme.segments(fullName.toString, fullName.isTermName)
       if (segs.isEmpty) NoSymbol

--- a/test/files/run/mirror_symbolof_x.check
+++ b/test/files/run/mirror_symbolof_x.check
@@ -1,0 +1,13 @@
+class Int
+object C
+type T
+type Id
+class Nothing
+class Null
+class Int
+object C
+type T
+type Id
+class Nothing
+class Null
+exception: class C not found.

--- a/test/files/run/mirror_symbolof_x.scala
+++ b/test/files/run/mirror_symbolof_x.scala
@@ -1,0 +1,43 @@
+import scala.reflect.runtime.universe._
+import scala.reflect.runtime.{universe => ru}
+import scala.reflect.runtime.{currentMirror => cm}
+import scala.reflect.api.Mirror
+
+class C
+object C
+
+object Test extends App {
+  object test1 {
+    val m = cm
+    type T = Int
+    type Id[X] = X
+    println(m.symbolOf[Int]: ru.TypeSymbol)
+    println(m.symbolOf[C.type]: ru.TypeSymbol)
+    println(m.symbolOf[T]: ru.TypeSymbol)
+    println(m.symbolOf[Id[_]]: ru.TypeSymbol)
+    println(m.symbolOf[Nothing]: ru.TypeSymbol)
+    println(m.symbolOf[Null]: ru.TypeSymbol)
+  }
+
+  object test2 {
+    val m: Mirror[ru.type] = cm
+    type T = Int
+    type Id[X] = X
+    println(m.symbolOf[Int]: ru.TypeSymbol)
+    println(m.symbolOf[C.type]: ru.TypeSymbol)
+    println(m.symbolOf[T]: ru.TypeSymbol)
+    println(m.symbolOf[Id[_]]: ru.TypeSymbol)
+    println(m.symbolOf[Nothing]: ru.TypeSymbol)
+    println(m.symbolOf[Null]: ru.TypeSymbol)
+  }
+
+  object test3 {
+    val m = ru.runtimeMirror(classOf[Int].getClass.getClassLoader)
+    try println(m.symbolOf[C])
+    catch { case ex: ScalaReflectionException => println(s"exception: ${ex.getMessage}") }
+  }
+
+  test1
+  test2
+  test3
+}


### PR DESCRIPTION
I just realized that our tag-based shortcuts were incomplete, because
they only work with root mirrors (doing just u.typeTag[T].tpe means that
the type is going to be resolved in u.rootMirror because that's the default).

This commit fixes this oversight. I'm hoping for 2.11.0-RC3, but also feel
free to reschedule to 2.12.0-M1 if it becomes clear that RC3 isn't happening.
