### PR TITLE
SI-8420 don't crash on unquoting of non-liftable native type

### DIFF
--- a/src/compiler/scala/tools/reflect/quasiquotes/Holes.scala
+++ b/src/compiler/scala/tools/reflect/quasiquotes/Holes.scala
@@ -78,8 +78,10 @@ trait Holes { self: Quasiquotes =>
     val (strippedTpe, tpe): (Type, Type) = {
       val (strippedRank, strippedTpe) = stripIterable(unquotee.tpe, limit = Some(annotatedRank))
       if (isBottomType(strippedTpe)) cantSplice()
-      else if (isNativeType(strippedTpe)) (strippedTpe, iterableTypeFromRank(annotatedRank, strippedTpe))
-      else if (isLiftableType(strippedTpe)) (strippedTpe, iterableTypeFromRank(annotatedRank, treeType))
+      else if (isNativeType(strippedTpe)) {
+        if (strippedRank != NoDot && !(strippedTpe <:< treeType) && !isLiftableType(strippedTpe)) cantSplice()
+        else (strippedTpe, iterableTypeFromRank(annotatedRank, strippedTpe))
+      } else if (isLiftableType(strippedTpe)) (strippedTpe, iterableTypeFromRank(annotatedRank, treeType))
       else cantSplice()
     }
 

--- a/test/files/scalacheck/quasiquotes/ErrorProps.scala
+++ b/test/files/scalacheck/quasiquotes/ErrorProps.scala
@@ -172,6 +172,27 @@ object ErrorProps extends QuasiquoteProperties("errors") {
       tq"_"
     """)
 
+  property("SI-8420: don't crash on splicing of non-unliftable native type (1)") = fails(
+    "Can't unquote List[reflect.runtime.universe.Symbol] with .., consider omitting the dots or providing an implicit instance of Liftable[reflect.runtime.universe.Symbol]",
+    """
+      val l: List[Symbol] = Nil
+      q"f(..$l)"
+    """)
+
+  property("SI-8420: don't crash on splicing of non-unliftable native type (2)") = fails(
+    "Can't unquote List[reflect.runtime.universe.FlagSet] with .., consider omitting the dots or providing an implicit instance of Liftable[reflect.runtime.universe.FlagSet]",
+    """
+      val l: List[FlagSet] = Nil
+      q"f(..$l)"
+    """)
+
+  property("SI-8420: don't crash on splicing of non-unliftable native type (3)") = fails(
+    "Can't unquote List[reflect.runtime.universe.Modifiers] with .., consider omitting the dots or providing an implicit instance of Liftable[reflect.runtime.universe.Modifiers]",
+    """
+      val l: List[Modifiers] = Nil
+      q"f(..$l)"
+    """)
+
   // // Make sure a nice error is reported in this case
   // { import Flag._; val mods = NoMods; q"lazy $mods val x: Int" }
 }


### PR DESCRIPTION
Previously quasiquote's type-based dispatch failed to handle situation
where unquotee's type is native but non-liftable and was used to splice
with non-zero cardinality.

review @retronym
