### PR TITLE
SI-8425 don't create double-dollar names in c.freshName

### DIFF
--- a/src/compiler/scala/reflect/macros/contexts/Names.scala
+++ b/src/compiler/scala/reflect/macros/contexts/Names.scala
@@ -33,8 +33,9 @@ trait Names {
     //
     // TODO: hopefully SI-7823 will provide an ultimate answer to this problem.
     // In the meanwhile I will also keep open the original issue: SI-6879 "c.freshName is broken".
+    val prefix = if (name.endsWith("$")) name else name + "$" // SI-8425
     val sortOfUniqueSuffix = freshNameCreator.newName(nme.FRESH_SUFFIX)
-    name + "$" + sortOfUniqueSuffix
+    prefix + sortOfUniqueSuffix
   }
 
   def freshName[NameType <: Name](name: NameType): NameType =

--- a/test/files/run/t8425.check
+++ b/test/files/run/t8425.check
@@ -1,0 +1,1 @@
+List(fresh$macro$1, $macro$2)

--- a/test/files/run/t8425/Macros_1.scala
+++ b/test/files/run/t8425/Macros_1.scala
@@ -1,0 +1,12 @@
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox.Context
+
+object Macros {
+  def foo: Unit = macro impl
+  def impl(c: Context) = {
+    import c.universe._
+    val test1 = c.freshName()
+    val test2 = c.freshName("$")
+    q"println(List($test1, $test2))"
+  }
+}

--- a/test/files/run/t8425/Test_2.scala
+++ b/test/files/run/t8425/Test_2.scala
@@ -1,0 +1,3 @@
+object Test extends App {
+  Macros.foo
+}


### PR DESCRIPTION
If we append a dollar to a user-provided prefix that ends in a dollar,
we create a potential for confusion for backend phases. That's why
this commit prevents such situations from happening.
