### PR TITLE
SI-8341 Refine handoff of undet. params from implicit search

### DIFF
--- a/test/files/neg/t8431.check
+++ b/test/files/neg/t8431.check
@@ -1,0 +1,27 @@
+t8431.scala:24: error: type mismatch;
+ found   : CanBuildFrom[Invariant[Nothing]]
+ required: CanBuildFrom[Invariant[G]]
+  s.combined // fail
+  ^
+t8431.scala:24: error: value combined is not a member of Invariant[Nothing]
+  s.combined // fail
+    ^
+t8431.scala:35: error: type mismatch;
+ found   : CanBuildFrom[Invariant[Nothing]]
+ required: CanBuildFrom[Invariant[G]]
+  s.combined // was okay!
+  ^
+t8431.scala:35: error: value combined is not a member of Invariant[Nothing]
+  s.combined // was okay!
+    ^
+t8431.scala:45: error: type mismatch;
+ found   : CanBuildFrom[Invariant[Nothing]]
+ required: CanBuildFrom[Invariant[G]]
+  convert2(s).combined
+          ^
+t8431.scala:48: error: type mismatch;
+ found   : CanBuildFrom[Invariant[Nothing]]
+ required: CanBuildFrom[Invariant[G]]
+  {val c1 = convert2(s); c1.combined}
+                    ^
+6 errors found

--- a/test/files/neg/t8431.scala
+++ b/test/files/neg/t8431.scala
@@ -1,0 +1,63 @@
+trait Covariant[+A]
+trait Invariant[A] extends Covariant[A @annotation.unchecked.uncheckedVariance] 
+ 
+trait Combinable[G] {
+  def combined = 0
+}
+
+trait CanBuildFrom[+C]
+ 
+object C {
+  implicit def convert1[G, TRAVONCE[+e] <: Covariant[e]]
+    (xs: TRAVONCE[G]): Combinable[G] = ???
+ 
+  implicit def convert2[G, SET[e] <: Invariant[e]]
+    (xs: SET[_ <: G])
+    (implicit cbf: CanBuildFrom[SET[G]]): Combinable[G] = ???
+
+  implicit def cbf[A]: CanBuildFrom[Invariant[A]] = ???
+}
+
+class Test1 {
+  import C.{cbf, convert1, convert2}
+  val s: Invariant[Nothing] = ???
+  s.combined // fail
+}
+
+class Test2 {
+  import C.{cbf, convert2, convert1}
+
+  val s: Invariant[Nothing] = ???
+
+  // Non-uniformity with Test1 was due to order of typechecking implicit candidates:
+  // the last candidate typechecked was the only one that could contribute undetermined type parameters
+  // to the enclosing context, due to mutation of `Context#undetparam` in `doTypedApply`.
+  s.combined // was okay!
+}
+
+
+class TestExplicit {
+  import C.{cbf, convert2}
+
+  val s: Invariant[Nothing] = ???
+
+  // Now the implicit Test fail uniformly as per this explicit conversion
+  convert2(s).combined
+
+  // Breaking this expression down makes it work.
+  {val c1 = convert2(s); c1.combined}
+}
+
+// These ones work before and after; infering G=Null doesn't need to contribute an undetermined type param.
+class Test3 {
+   import C.{cbf, convert1, convert2}
+   val s: Invariant[Null] = ???
+   s.combined // okay
+}
+
+class Test4 {
+   import C.{cbf, convert2, convert1}
+
+   val s: Invariant[Null] = ???
+   s.combined // okay
+}


### PR DESCRIPTION
In SI-7944 / 251c2b93, we discovered that typechecking of an implicit
candidate could leave orphaned undetermined type parameters in the
implicit search context. This resulted in naked type parameters
leaking into implicit expansions. The fix seemed easy: just copy
any symbols from `implicitSearchContext.undetparams` to the enclosing
context (other than ones in `SearchResult#subst`).

However, the test case in this ticket reveals a subtle flaw in that
fix: `implicitSerachContext.undetparams` only contains the type params
from the most recently typechecked candidate!

Why? Implicit search uses the same context to typecheck all plausibly
compatible candidates.  The typechecking itself is driven by
`typedImplicit1`.

Side note, that explains the heisenbug behaviour noted in the ticket:
Not _all_ plausibly implicit candidates are typechecked. If
the current 'best' eligible candidate is more specific than the next
candidate, we can skip that altogether.Implicit search actually
exploits this for performance by ordering the candidates according to
usage statistics. This reordering, means that commenting out lines
elsewhere in the file changed the behaviour!

This commit simply stores the undet. tparams in the `SearchResult`,
where it is safe from the vaguries of typechecking other candidates.

That makes `Test1` and `Test2` with in the enclosed test case fail
uniformly, both with each other, and with an explicit call to
the view.

This is ostensibly a regression from 2.10.3. To get there,
we need an implicit search that has to infer `Nothing` in a covariant
position. In 2.10.3, we would just let the `G` out into the wild,
which did the right thing for the wrong reasons.
