### PR TITLE
Bump version to 2.10.5 for nightly builds.

### DIFF
--- a/build.number
+++ b/build.number
@@ -1,7 +1,7 @@
 #Tue Sep 11 19:21:09 CEST 2007
 version.major=2
 version.minor=10
-version.patch=4
+version.patch=5
 # This is the -N part of a version.  if it's 0, it's dropped from maven versions.
 version.bnum=0
 


### PR DESCRIPTION
The 2.10.4 final has been tagged so we should start publishing nightlies as 2.10.5.
