### PR TITLE
SI-8428 Fix regression in iterator concatenation

### DIFF
--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -139,6 +139,10 @@ filter {
     {
         matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticPartialFunction"
         problemName=MissingMethodProblem
-    } 
+    },
+    {
+        matchName="scala.collection.Iterator#ConcatIterator.this"
+        problemName=MissingMethodProblem
+    }
   ]
 }

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -165,11 +165,11 @@ object Iterator {
   /** Avoid stack overflows when applying ++ to lots of iterators by
    *  flattening the unevaluated iterators out into a vector of closures.
    */
-  private[scala] final class ConcatIterator[+A](initial: Vector[() => Iterator[A]]) extends Iterator[A] {
-    // current set to null when all iterators are exhausted
-    private[this] var current: Iterator[A] = Iterator.empty
+  private[scala] final class ConcatIterator[+A](private[this] var current: Iterator[A], initial: Vector[() => Iterator[A]]) extends Iterator[A] {
+    @deprecated def this(initial: Vector[() => Iterator[A]]) = this(Iterator.empty, initial) // for binary compatibility
     private[this] var queue: Vector[() => Iterator[A]] = initial
     // Advance current to the next non-empty iterator
+    // current is set to null when all iterators are exhausted
     private[this] def advance(): Boolean = {
       if (queue.isEmpty) {
         current = null
@@ -185,7 +185,7 @@ object Iterator {
     def next()  = if (hasNext) current.next else Iterator.empty.next
 
     override def ++[B >: A](that: => GenTraversableOnce[B]): Iterator[B] =
-      new ConcatIterator((() => current) +: (queue :+ (() => that.toIterator)))
+      new ConcatIterator(current, queue :+ (() => that.toIterator))
   }
 
   private[scala] final class JoinIterator[+A](lhs: Iterator[A], that: => GenTraversableOnce[A]) extends Iterator[A] {
@@ -194,7 +194,7 @@ object Iterator {
     def next    = if (lhs.hasNext) lhs.next else rhs.next
 
     override def ++[B >: A](that: => GenTraversableOnce[B]) =
-      new ConcatIterator(Vector(() => this, () => that.toIterator))
+      new ConcatIterator(this, Vector(() => that.toIterator))
   }
 }
 

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -185,7 +185,7 @@ object Iterator {
     def next()  = if (hasNext) current.next else Iterator.empty.next
 
     override def ++[B >: A](that: => GenTraversableOnce[B]): Iterator[B] =
-      new ConcatIterator(queue :+ (() => that.toIterator))
+      new ConcatIterator((() => current) +: (queue :+ (() => that.toIterator)))
   }
 
   private[scala] final class JoinIterator[+A](lhs: Iterator[A], that: => GenTraversableOnce[A]) extends Iterator[A] {

--- a/test/files/run/t8428.scala
+++ b/test/files/run/t8428.scala
@@ -1,0 +1,12 @@
+object Test extends App {
+  val xs = List.tabulate(4)(List(_))
+  val i = xs.map(_.iterator).reduce { (a,b) =>
+    a.hasNext
+    a ++ b
+  }
+
+  val r1 = i.toList
+  val r2 = xs.flatten.toList
+
+  assert(r1 == r2, r1)
+}


### PR DESCRIPTION
Regressed in e3ddb2d7, which introduced `ConcatIterator` to
avoid super-linear runtime on chains of concatenated iterators.

`ConcatIterator` maintains a queue of thunks for the remaining
iterators. Both `next` and `hasNext` delegate to `advance`, which
evaluates the thunks and discards any empty iterators from the
start of the queue. The first non-empty iterator is stored in
the var `current`.

It also overrides `++`, and creates a new `ConcatIterator` with
the given `that` as an extra element in the queue. However, it
failed to copy `current` across, which led to data loss.
