### PR TITLE
SI-8200 provide an identity liftable for trees

### DIFF
--- a/bincompat-backward.whitelist.conf
+++ b/bincompat-backward.whitelist.conf
@@ -102,6 +102,11 @@ filter {
         matchName="scala.collection.mutable.ArrayOps#ofDouble.unzip3"
         problemName=IncompatibleMethTypeProblem
     },
+    // see SI-8200
+    {
+        matchName="scala.reflect.api.StandardLiftables#StandardLiftableInstances.liftTree"
+        problemName=MissingMethodProblem
+    },
     // see SI-8331
     {
         matchName="scala.reflect.api.Internals#ReificationSupportApi#SyntacticTypeAppliedExtractor.unapply"

--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -102,6 +102,15 @@ filter {
         matchName="scala.collection.mutable.ArrayOps#ofDouble.unzip3"
         problemName=IncompatibleMethTypeProblem
     },
+    // see SI-8200
+    {
+        matchName="scala.reflect.api.Liftables#Liftable.liftTree"
+        problemName=MissingMethodProblem
+    },
+    {
+        matchName="scala.reflect.api.StandardLiftables#StandardLiftableInstances.liftTree"
+        problemName=MissingMethodProblem
+    },
     // see SI-8331 
     {
         matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticSelectType"

--- a/src/reflect/scala/reflect/api/StandardLiftables.scala
+++ b/src/reflect/scala/reflect/api/StandardLiftables.scala
@@ -27,6 +27,7 @@ trait StandardLiftables { self: Universe =>
       callScala(stdnme.Symbol)(Literal(Constant(v.name)) :: Nil)
     }
 
+    implicit def liftTree[T <: Tree]: Liftable[T]              = Liftable { identity }
     implicit def liftName[T <: Name]: Liftable[T]              = Liftable { name => Ident(name) }
     implicit def liftExpr[T <: Expr[_]]: Liftable[T]           = Liftable { expr => expr.tree }
     implicit def liftType[T <: Type]: Liftable[T]              = Liftable { tpe => TypeTree(tpe) }

--- a/test/files/scalacheck/quasiquotes/ErrorProps.scala
+++ b/test/files/scalacheck/quasiquotes/ErrorProps.scala
@@ -9,9 +9,10 @@ object ErrorProps extends QuasiquoteProperties("errors") {
     """)
 
   property("can't unquote with given rank") = fails(
-    "Can't unquote List[reflect.runtime.universe.Ident], consider using ..",
+    "Can't unquote List[StringBuilder], consider using .. or providing an implicit instance of Liftable[List[StringBuilder]]",
     """
-      val xs = List(q"x", q"x")
+      import java.lang.StringBuilder
+      val xs: List[StringBuilder] = Nil
       q"$xs"
     """)
 
@@ -71,9 +72,10 @@ object ErrorProps extends QuasiquoteProperties("errors") {
     """)
 
   property("use ... rank or provide liftable") = fails(
-    "Can't unquote List[List[reflect.runtime.universe.Ident]], consider using ...",
+    "Can't unquote List[List[StringBuilder]], consider using ... or providing an implicit instance of Liftable[List[List[StringBuilder]]]",
     """
-      val xs = List(List(q"x", q"x"))
+      import java.lang.StringBuilder
+      val xs: List[List[StringBuilder]] = Nil
       q"$xs"
     """)
 

--- a/test/files/scalacheck/quasiquotes/LiftableProps.scala
+++ b/test/files/scalacheck/quasiquotes/LiftableProps.scala
@@ -88,14 +88,20 @@ object LiftableProps extends QuasiquoteProperties("liftable") {
     assert(q"$const" ≈ q"0")
   }
 
+  val immutable = q"$scalapkg.collection.immutable"
+
   property("lift list variants") = test {
     val lst = List(1, 2)
-    val immutable = q"$scalapkg.collection.immutable"
     assert(q"$lst" ≈ q"$immutable.List(1, 2)")
     assert(q"f(..$lst)" ≈ q"f(1, 2)")
     val llst = List(List(1), List(2))
     assert(q"f(..$llst)" ≈ q"f($immutable.List(1), $immutable.List(2))")
     assert(q"f(...$llst)" ≈ q"f(1)(2)")
+  }
+
+  property("lift list of tree") = test {
+    val lst = List(q"a", q"b")
+    assert(q"$lst" ≈ q"$immutable.List(a, b)")
   }
 
   property("lift tuple") = test {


### PR DESCRIPTION
This liftable hasn't been originally included in the set of standard
liftables due to following contradiction:
1. On one hand we can have identity lifting that seems to be quite
   consistent with regular unquoting and splicing:
   
   ``` scala
   q"..${List(1,2)}"        <==> q"1; 2"
   q"${List(1,2)}"          <==> q"s.c.i.List(1, 2)"
   q"..${List(q"a", q"b")}” <==> q"a; b"
   q"${List(q"a", q"b")}"   <==> q"s.c.i.List(a, b)" // introduced by this pr, currently fails
   ```
   
   This is also consistent with how lisp unquoting works although they
   get lifting for free thanks to homoiconicity:
   
   ``` scala
   // scala
   scala> val x = List(q"a", q"b"); q"f($x)"
   q"f(s.c.i.List(a, b))"
   ```
   
   ``` scheme
   ;; scheme
   > (let [(x (list a b))] `(f ,x))
   '(f (list a b))
   ```
2. On the other hand lifting is an operation that converts a value into
   a code that when evaluated turns into the same value. In this sense
   `Liftable[Tree]` means reification of a tree into a tree that
   represents it, i.e.:
   
   ``` scala
   q"${List(q"a", q"b")}"
   <==>
   q"""s.c.i.List(Ident(TermName("a")), Ident(TermName("b")))"""
   ```
   
   But I belive that such lifting will be very confusing for everyone
   other than a few very advanced users.

This commit introduces the first option as a default Liftable for trees.

review @xeno-by @retronym
