### PR TITLE
SI-8350 SI-8387 tweak handling of new trees

### DIFF
--- a/src/reflect/scala/reflect/internal/ReificationSupport.scala
+++ b/src/reflect/scala/reflect/internal/ReificationSupport.scala
@@ -510,7 +510,9 @@ trait ReificationSupport { self: SymbolTable =>
         gen.mkNew(parents, mkSelfType(selfType), earlyDefs ::: body, NoPosition, NoPosition)
 
       def unapply(tree: Tree): Option[(List[Tree], List[Tree], ValDef, List[Tree])] = tree match {
-        case SyntacticApplied(Select(New(SyntacticAppliedType(ident, targs)), nme.CONSTRUCTOR), argss) =>
+        case treeInfo.Applied(Select(New(SyntacticAppliedType(ident, targs)), nme.CONSTRUCTOR), Nil, List(Nil)) =>
+          Some((Nil, SyntacticAppliedType(ident, targs) :: Nil, noSelfType, Nil))
+        case treeInfo.Applied(Select(New(SyntacticAppliedType(ident, targs)), nme.CONSTRUCTOR), Nil, argss) =>
           Some((Nil, SyntacticApplied(SyntacticAppliedType(ident, targs), argss) :: Nil, noSelfType, Nil))
         case SyntacticBlock(SyntacticClassDef(_, tpnme.ANON_CLASS_NAME, Nil, _, ListOfNil, earlyDefs, parents, selfType, body) ::
                             Apply(Select(New(Ident(tpnme.ANON_CLASS_NAME)), nme.CONSTRUCTOR), Nil) :: Nil) =>
@@ -829,10 +831,10 @@ trait ReificationSupport { self: SymbolTable =>
     // drop potential @scala.unchecked annotation
     protected object MaybeUnchecked {
       def unapply(tree: Tree): Some[Tree] = tree match {
-        case Annotated(SyntacticNew(Nil, Apply(ScalaDot(tpnme.unchecked), Nil) :: Nil, noSelfType, Nil), annottee) =>
+        case Annotated(SyntacticNew(Nil, ScalaDot(tpnme.unchecked) :: Nil, noSelfType, Nil), annottee) =>
           Some(annottee)
         case Typed(annottee, MaybeTypeTreeOriginal(
-          Annotated(SyntacticNew(Nil, Apply(ScalaDot(tpnme.unchecked), Nil) :: Nil, noSelfType, Nil), _))) =>
+          Annotated(SyntacticNew(Nil, ScalaDot(tpnme.unchecked) :: Nil, noSelfType, Nil), _))) =>
           Some(annottee)
         case annottee => Some(annottee)
       }

--- a/src/reflect/scala/reflect/internal/ReificationSupport.scala
+++ b/src/reflect/scala/reflect/internal/ReificationSupport.scala
@@ -241,10 +241,15 @@ trait ReificationSupport { self: SymbolTable =>
         case UnApply(treeInfo.Unapplied(Select(fun, nme.unapply)), pats) =>
           Some((fun, pats :: Nil))
         case treeInfo.Applied(fun, targs, argss) =>
-          val callee =
-            if (fun.isTerm) SyntacticTypeApplied(fun, targs)
-            else SyntacticAppliedType(fun, targs)
-          Some((callee, argss))
+          fun match {
+            case Select(_: New, nme.CONSTRUCTOR) =>
+              Some((tree, Nil))
+            case _ =>
+              val callee =
+                if (fun.isTerm) SyntacticTypeApplied(fun, targs)
+                else SyntacticAppliedType(fun, targs)
+              Some((callee, argss))
+          }
       }
     }
 

--- a/test/files/scalacheck/quasiquotes/TermDeconstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/TermDeconstructionProps.scala
@@ -222,4 +222,21 @@ object TermDeconstructionProps extends QuasiquoteProperties("term deconstruction
     val q"{ case ..$cases }" = q"{ case a => b case c => d }"
     val List(cq"a => b", cq"c => d") = cases
   }
+
+  property("SI-8350 `new C` and `new C()` are equivalent") = test {
+    val q"new C" = q"new C()"
+    val q"new C()" = q"new C"
+  }
+
+  property("SI-8350 new applications extracted only for non-empty ctor calls") = test{
+    val q"new $c1" = q"new C()"
+    assert(c1 ≈ tq"C")
+    val q"new $c2" = q"new C(x)"
+    assert(c2 ≈ q"${tq"C"}(x)")
+  }
+
+  property("SI-8350 original test case") = test {
+    val q"new ..$parents" = q"new Foo with Bar"
+    assert(parents ≈ List(tq"Foo", tq"Bar"))
+  }
 }

--- a/test/files/scalacheck/quasiquotes/TermDeconstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/TermDeconstructionProps.scala
@@ -239,4 +239,11 @@ object TermDeconstructionProps extends QuasiquoteProperties("term deconstruction
     val q"new ..$parents" = q"new Foo with Bar"
     assert(parents ≈ List(tq"Foo", tq"Bar"))
   }
+
+  property("SI-8387 new is not an application") = test {
+    val `new` = q"new F(x)"
+    val q"$f(...$argss)" = `new`
+    assert(f ≈ `new`)
+    assert(argss.isEmpty)
+  }
 }


### PR DESCRIPTION
Adds two tweaks to the handling of `q"new ..."` trees:
1. Makes `q"$f(...$argss)"` not match `q"new Foo(x)"` as function with arguments 
2. Makes `q"new Foo"` and `q"new Foo()"` match one another

review @xeno-by @retronym
