### PR TITLE
SI-8450 no "implicit numeric widening" in silent mode

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1041,11 +1041,11 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           if (tree.tpe <:< AnyTpe) pt.dealias match {
             case TypeRef(_, UnitClass, _) => // (12)
               if (settings.warnValueDiscard)
-                context.unit.warning(tree.pos, "discarded non-Unit value")
+                context.warning(tree.pos, "discarded non-Unit value")
               return typedPos(tree.pos, mode, pt)(Block(List(tree), Literal(Constant(()))))
             case TypeRef(_, sym, _) if isNumericValueClass(sym) && isNumericSubType(tree.tpe, pt) =>
               if (settings.warnNumericWiden)
-                context.unit.warning(tree.pos, "implicit numeric widening")
+                context.warning(tree.pos, "implicit numeric widening")
               return typedPos(tree.pos, mode, pt)(Select(tree, "to" + sym.name))
             case _ =>
           }
@@ -5109,7 +5109,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         def isPlausible(m: Symbol) = m.alternatives exists (m => requiresNoArgs(m.info))
 
         def maybeWarn(s: String): Unit = {
-          def warn(message: String)         = context.unit.warning(lit.pos, s"$message Did you forget the interpolator?")
+          def warn(message: String)         = context.warning(lit.pos, s"$message Did you forget the interpolator?")
           def suspiciousSym(name: TermName) = context.lookupSymbol(name, _ => true).symbol
           def suspiciousExpr                = InterpolatorCodeRegex findFirstIn s
           def suspiciousIdents              = InterpolatorIdentRegex findAllIn s map (s => suspiciousSym(s drop 1))

--- a/test/files/neg/t8450.check
+++ b/test/files/neg/t8450.check
@@ -1,0 +1,6 @@
+t8450.scala:5: warning: implicit numeric widening
+  def elapsed: Foo = (System.nanoTime - 100L).foo
+                                      ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/t8450.flags
+++ b/test/files/neg/t8450.flags
@@ -1,0 +1,1 @@
+-Ywarn-numeric-widen -Xfatal-warnings

--- a/test/files/neg/t8450.scala
+++ b/test/files/neg/t8450.scala
@@ -1,0 +1,12 @@
+trait Foo
+
+class WarnWidening {
+  implicit class FooDouble(d: Double) { def foo = new Foo {} }
+  def elapsed: Foo = (System.nanoTime - 100L).foo
+}
+
+class NoWarnWidening {
+  implicit class FooLong(l: Long) { def foo = new Foo {} }
+  implicit class FooDouble(d: Double) { def foo = new Foo {} }
+  def elapsed: Foo = (System.nanoTime - 100L).foo
+}


### PR DESCRIPTION
Before this fix, we get a second, spurious warning.

```
t8450.scala:5: warning: implicit numeric widening
  def elapsed: Foo = (System.nanoTime - 100L).foo
                                      ^
t8450.scala:11: warning: implicit numeric widening
  def elapsed: Foo = (System.nanoTime - 100L).foo
                                      ^
error: No warnings can be incurred under -Xfatal-warnings.
two warnings found
one error found
```

By respecting silent contexts, we now get only one.

I sneakily fixed similar occurrences without adding a test.
