### PR TITLE
SI-8451 makes uncurry more forgiving

### DIFF
--- a/test/files/scalacheck/quasiquotes/DefinitionConstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/DefinitionConstructionProps.scala
@@ -90,6 +90,15 @@ trait ClassConstruction { self: QuasiquoteProperties =>
     val args = q"val a: Int; val b: Int"
     assertEqAst(q"class C(implicit ..$args)", "class C(implicit val a: Int, val b: Int)")
   }
+
+  property("SI-8451: inline secondary constructors") = test {
+    assertEqAst(q"class C(x: Int) { def this() = this(0) }", "class C(x: Int) { def this() = this(0) }")
+  }
+
+  property("SI-8451: unquoted secondary constructors") = test {
+    val secondaryCtor = q"def this() = this(0)"
+    assertEqAst(q"class C(x: Int) { $secondaryCtor }", "class C(x: Int) { def this() = this(0) }")
+  }
 }
 
 trait TraitConstruction { self: QuasiquoteProperties =>

--- a/test/files/scalacheck/quasiquotes/DefinitionDeconstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/DefinitionDeconstructionProps.scala
@@ -229,6 +229,12 @@ trait DefDeconstruction { self: QuasiquoteProperties =>
     val q"def foo(...$argss)(implicit ..$impl)" = q"def foo(x: Int)"
     assert(impl.isEmpty)
   }
+
+  property("SI-8451") = test {
+    val q"def this(..$params) = this(..$args)" = q"def this(x: Int) = this(0)"
+    assert(params ≈ List(q"${Modifiers(PARAM)} val x: Int"))
+    assert(args ≈ List(q"0"))
+  }
 }
 
 trait ImportDeconstruction { self: QuasiquoteProperties =>

--- a/test/files/scalacheck/quasiquotes/ErrorProps.scala
+++ b/test/files/scalacheck/quasiquotes/ErrorProps.scala
@@ -195,6 +195,19 @@ object ErrorProps extends QuasiquoteProperties("errors") {
       q"f(..$l)"
     """)
 
+  property("SI-8451 construction: disallow everything except for constructor calls in secondary constructor bodies") = fails(
+    "'this' expected but unquotee found",
+    """
+      val rhs1 = q"this(0)"
+      val ctor1 = q"def this(x: Int) = $rhs1"
+    """)
+
+  property("SI-8451 deconstruction: disallow everything except for constructor calls in secondary constructor bodies") = fails(
+    "'this' expected but unquotee found",
+    """
+      val q"def this(..$params) = $rhs2" = q"def this(x: Int) = this(0)"
+    """)
+
   // // Make sure a nice error is reported in this case
   // { import Flag._; val mods = NoMods; q"lazy $mods val x: Int" }
 }


### PR DESCRIPTION
Apparently even though the rhs of a secondary constructor looks like an expr,
it always gets wrapped in a block by the parser. This works just fine with
the typer, but crashes in uncurry. This commit brings quasiquotes in line with the parser.
