### PR TITLE
Remove scala-continuations-plugin from scala-library-all

### DIFF
--- a/src/build/maven/scala-dist-pom.xml
+++ b/src/build/maven/scala-dist-pom.xml
@@ -39,6 +39,11 @@
       <artifactId>scala-compiler</artifactId>
       <version>@VERSION@</version>
     </dependency>
+    <dependency>
+      <groupId>org.scala-lang.plugins</groupId>
+      <artifactId>scala-continuations-plugin_@VERSION@</artifactId> <!-- plugins are fully cross-versioned -->
+      <version>@CONTINUATIONS_PLUGIN_VERSION@</version>
+    </dependency>
     <!-- duplicated from scala-compiler, where it's optional,
     so that resolving scala-dist's transitive dependencies does not include jline,
     even though we need to include it in the dist, but macros depending on the compiler

--- a/src/build/maven/scala-library-all-pom.xml
+++ b/src/build/maven/scala-library-all-pom.xml
@@ -49,11 +49,11 @@
       <artifactId>scala-parser-combinators_@SCALA_BINARY_VERSION@</artifactId>
       <version>@PARSER_COMBINATORS_VERSION@</version>
     </dependency>
-    <dependency>
-      <groupId>org.scala-lang.plugins</groupId>
-      <artifactId>scala-continuations-plugin_@SCALA_BINARY_VERSION@</artifactId>
-      <version>@CONTINUATIONS_PLUGIN_VERSION@</version>
-    </dependency>
+    <!--
+         the continuations plugin is a dependency of scala-dist, as scala-library-all should be
+         a drop-in replacement for scala-library, and as such should not (indirectly)
+         depend on plugins/the compiler.
+    -->
     <dependency>
       <groupId>org.scala-lang.plugins</groupId>
       <artifactId>scala-continuations-library_@SCALA_BINARY_VERSION@</artifactId>


### PR DESCRIPTION
The continuations plugin should instead be a dependency of scala-dist,
as scala-library-all should be a drop-in replacement for scala-library,
and as such should not (indirectly) depend on plugins/the compiler.

Review by @retronym.
