### PR TITLE
Disable more of the Travis spec build for PR validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,4 @@ after_success:
   - openssl aes-256-cbc -pass "pass:$PRIV_KEY_SECRET" -in spec/id_dsa_travis.enc -out spec/id_dsa_travis -d -a
   - chmod 600 spec/id_dsa_travis
   - eval "$(ssh-agent)"
-  - ssh-add -D
-  - ssh-add spec/id_dsa_travis
-  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && rsync -e "ssh -o StrictHostKeyChecking=no" -rzv build/spec/ scalatest@chara.epfl.ch:/home/linuxsoft/archives/scala/spec/2.11/'
+  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && ssh-add -D && ssh-add spec/id_dsa_travis && rsync -e "ssh -o StrictHostKeyChecking=no" -rzv build/spec/ scalatest@chara.epfl.ch:/home/linuxsoft/archives/scala/spec/2.11/'


### PR DESCRIPTION
So as to avoid:

```
$ ssh-add -D
All identities removed.
$ ssh-add spec/id_dsa_travis
Enter passphrase for spec/id_dsa_travis:
No output has been received in the last 10 minutes, this potentially indicates a stalled build or something wrong with the build itself.
```

Review by @adriaanm
