### PR TITLE
SI-8463 Avoid unpositioned errors from search for views

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -197,7 +197,10 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
          !from.isError
       && !to.isError
       && context.implicitsEnabled
-      && (inferView(EmptyTree, from, to, reportAmbiguous = false) != EmptyTree)
+      && (inferView(context.tree, from, to, reportAmbiguous = false, saveErrors = true) != EmptyTree)
+      // SI-8230 / SI-8463 We'd like to change this to `saveErrors = false`, but can't.
+      // For now, we can at least pass in `context.tree` rather then `EmptyTree` so as
+      // to avoid unpositioned type errors.
     )
 
     def inferView(tree: Tree, from: Type, to: Type, reportAmbiguous: Boolean): Tree =

--- a/test/files/neg/t8463.check
+++ b/test/files/neg/t8463.check
@@ -1,0 +1,10 @@
+t8463.scala:5: error: type mismatch;
+ found   : Long
+ required: ?T[Long]
+Note that implicit conversions are not applicable because they are ambiguous:
+ both method longWrapper in class LowPriorityImplicits of type (x: Long)scala.runtime.RichLong
+ and method ArrowAssoc in object Predef of type [A](self: A)ArrowAssoc[A]
+ are possible conversion functions from Long to ?T[Long]
+  insertCell(Foo(5))
+            ^
+one error found

--- a/test/files/neg/t8463.scala
+++ b/test/files/neg/t8463.scala
@@ -1,0 +1,38 @@
+object Test {
+  case class Foo[+T[_]](activity:T[Long])
+  type Cell[T] = T
+  def insertCell(u:Foo[Cell]) = ???
+  insertCell(Foo(5))
+}
+
+/* If SI-8230 is fixed, and `viewExists` is changed to no longer leak
+   ambiguity errors, you might expect the check file for this test to
+   change as folloes:
+
+@@ -1,18 +1,10 @@
+-t8463.scala:5: error: no type parameters for method apply: (activity:
+- --- because ---
+-argument expression's type is not compatible with formal parameter ty
++t8463.scala:5: error: type mismatch;
+  found   : Long
+  required: ?T[Long]
++Note that implicit conversions are not applicable because they are am
++ both method longWrapper in class LowPriorityImplicits of type (x: Lo
++ and method ArrowAssoc in object Predef of type [A](self: A)ArrowAsso
++ are possible conversion functions from Long to ?T[Long]
+   insertCell(Foo(5))
+-             ^
+-t8463.scala:5: error: type mismatch;
+- found   : Long(5L)
+- required: T[Long]
+-  insertCell(Foo(5))
+-                 ^
+-t8463.scala:5: error: type mismatch;
+- found   : Test.Foo[T]
+- required: Test.Foo[Test.Cell]
+-  insertCell(Foo(5))
+-                ^
+-three errors found
++            ^
++one error found
+*/


### PR DESCRIPTION
Ideally, I'd like to fix this using `saveErrors = false` here to
firewall the enclosing context from the ambiguiouty error encountered
during implicit search.

I originally proposed that patch as a fix for SI-8419 in
https://github.com/scala/scala/pull/3460 but withdrew from
that approach as I uncovered a deeper bug that meant that
we actually shouldn't have even been looking for views in
that case.

But, this runs into SI-8230 and these failures:

```
test/partest --update-check \
  /Users/jason/code/scala/test/files/pos/t2504.scala \
  /Users/jason/code/scala/test/files/pos/t4457_1.scala \
  /Users/jason/code/scala/test/files/neg/t4457_2.scala
```

Turns out that typechecking the ostensible straight forward
application, `Array("abc")`, hinges on us leaking an ambiguity
error from `viewExists` to find a path through overload resolution!

This commit takes a tiny step forward by using `context.tree`
rather than `EmptyTree` as the argument to `inferImplicit`.
This avoids unpositioned type errors.

Review by @adriaanm
