### PR TITLE
SI-8466 fix quasiquote crash on recursively iterable unlifting

### DIFF
--- a/test/files/scalacheck/quasiquotes/LiftableProps.scala
+++ b/test/files/scalacheck/quasiquotes/LiftableProps.scala
@@ -164,4 +164,11 @@ object LiftableProps extends QuasiquoteProperties("liftable") {
     val right3: Either[Int, Int] = Right(1)
     assert(q"$right3" ≈ q"scala.util.Right(1)")
   }
+
+  property("lift xml comment") = test {
+    implicit val liftXmlComment = Liftable[xml.Comment] { comment =>
+      q"new _root_.scala.xml.Comment(${comment.commentText})"
+    }
+    assert(q"${xml.Comment("foo")}" ≈ q"<!--foo-->")
+  }
 }

--- a/test/files/scalacheck/quasiquotes/UnliftableProps.scala
+++ b/test/files/scalacheck/quasiquotes/UnliftableProps.scala
@@ -155,4 +155,12 @@ object UnliftableProps extends QuasiquoteProperties("unliftable") {
     assert(t21 == (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21))
     assert(t22 == (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22))
   }
+
+  property("unlift xml comment") = test {
+    implicit val unliftXmlComment = Unliftable[xml.Comment] {
+      case q"new _root_.scala.xml.Comment(${value: String})" => xml.Comment(value)
+    }
+    val q"${comment: xml.Comment}" = q"<!--foo-->"
+    assert(comment.commentText == "foo")
+  }
 }


### PR DESCRIPTION
In order to handle unquoting quasiquotes needs to know if type is
iterable and whats the depth of the iterable nesting which is called
rank. (e.g. List[List[Tree]] is rank 2 iterable of Tree)

The logic that checks depth of iterable nesting didn't take a situation
where T is in fact Iterable[T] which caused infinite recursion in
stripIterable function.

In order to fix it stripIterable now always recurs no more than
non-optional limit times.

review @retronym
