### PR TITLE
Further tweak version of continuations plugin in scala-dist.pom

### DIFF
--- a/build-ant-macros.xml
+++ b/build-ant-macros.xml
@@ -432,6 +432,7 @@
         <filterset>
           <filter token="VERSION" value="${osgi.version.number}"/>
           <filter token="SCALA_BINARY_VERSION" value="${scala.binary.version}"/>
+          <filter token="SCALA_FULL_VERSION" value="${scala.full.version}"/>
           <filter token="SCALA_COMPILER_DOC_VERSION" value="${scala-compiler-doc.version.number}"/>
           <filter token="SCALA_COMPILER_INTERACTIVE_VERSION" value="${scala-compiler-interactive.version.number}"/>
         </filterset>
@@ -554,6 +555,7 @@
         <filterset>
           <filter token="VERSION"                    value="${maven.version.number}" />
           <filter token="SCALA_BINARY_VERSION"       value="${scala.binary.version}" />
+          <filter token="SCALA_FULL_VERSION"         value="${scala.full.version}" />
           <filter token="XML_VERSION"                value="${scala-xml.version.number}" />
           <filter token="PARSER_COMBINATORS_VERSION" value="${scala-parser-combinators.version.number}" />
           <filter token="CONTINUATIONS_PLUGIN_VERSION"  value="${scala-continuations-plugin.version.number}" />

--- a/src/build/maven/scala-dist-pom.xml
+++ b/src/build/maven/scala-dist-pom.xml
@@ -41,7 +41,8 @@
     </dependency>
     <dependency>
       <groupId>org.scala-lang.plugins</groupId>
-      <artifactId>scala-continuations-plugin_@VERSION@</artifactId> <!-- plugins are fully cross-versioned -->
+      <!-- plugins are fully cross-versioned. But, we don't publish with 2.11.0-SNAPSHOT, instead use full version of the last non-snapshot version -->
+      <artifactId>scala-continuations-plugin_@SCALA_FULL_VERSION@</artifactId>
       <version>@CONTINUATIONS_PLUGIN_VERSION@</version>
     </dependency>
     <!-- duplicated from scala-compiler, where it's optional,

--- a/versions.properties
+++ b/versions.properties
@@ -4,7 +4,11 @@ starr.use.released=1
 
 # These are the versions of the modules that go with this release.
 # These properties are used during PR validation and in dbuild builds.
+
+# e.g. 2.11.0-RC1, 2.11
 scala.binary.version=2.11.0-RC3
+# e.g. 2.11.0-RC1, 2.11.0, 2.11.1-RC1, 2.11.1
+scala.full.version=2.11.0-RC3
 
 # external modules shipped with distribution:
 scala-xml.version.number=1.0.1


### PR DESCRIPTION
While we must use full version, rather than the cross version
(12720e699), we need to use latest non-snapshot version.

This should avoid failures like:

  https://jenkins.scala-ide.org:8496/jenkins/view/Scala%20Xsource%20flag%20nightlies/job/Akka/63/console

Such as:

```
[warn] ::::::::::::::::::::::::::::::::::::::::::::::
[warn] ::          UNRESOLVED DEPENDENCIES         ::
[warn] ::::::::::::::::::::::::::::::::::::::::::::::
[warn] :: org.scala-lang.plugins#scala-continuations-plugin_2.11.0-SNAPSHOT;1.0.1:
not found
[warn] ::::::::::::::::::::::::::::::::::::::::::::::
sbt.ResolveException: unresolved dependency:
org.scala-lang.plugins#scala-continuations-plugin_2.11.0-SNAPSHOT;1.0.1:
```

Review by @gkossakowski / @huitseeker
