### PR TITLE
SI-8461 -Xsource:2.10 mode for macro signature checks

### DIFF
--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -490,8 +490,10 @@ trait Definitions extends api.StandardDefinitions {
     lazy val TypeCreatorClass      = getClassIfDefined("scala.reflect.api.TypeCreator") // defined in scala-reflect.jar, so we need to be careful
     lazy val TreeCreatorClass      = getClassIfDefined("scala.reflect.api.TreeCreator") // defined in scala-reflect.jar, so we need to be careful
 
-    lazy val BlackboxContextClass         = getClassIfDefined("scala.reflect.macros.blackbox.Context") // defined in scala-reflect.jar, so we need to be careful
-    lazy val WhiteboxContextClass         = getClassIfDefined("scala.reflect.macros.whitebox.Context") // defined in scala-reflect.jar, so we need to be careful
+    private def Context_210               = if (settings.isScala211) NoSymbol else getClassIfDefined("scala.reflect.macros.Context") // needed under -Xsource:2.10
+    lazy val BlackboxContextClass         = getClassIfDefined("scala.reflect.macros.blackbox.Context").orElse(Context_210) // defined in scala-reflect.jar, so we need to be careful
+
+    lazy val WhiteboxContextClass         = getClassIfDefined("scala.reflect.macros.whitebox.Context").orElse(Context_210) // defined in scala-reflect.jar, so we need to be careful
          def MacroContextPrefix           = BlackboxContextClass.map(sym => getMemberMethod(sym, nme.prefix))
          def MacroContextPrefixType       = BlackboxContextClass.map(sym => getTypeMember(sym, tpnme.PrefixType))
          def MacroContextUniverse         = BlackboxContextClass.map(sym => getMemberMethod(sym, nme.universe))


### PR DESCRIPTION
I can't get the test to fail in partest, so I've resorted to
a manual test case.

```
% qbin/scalac -nobootcp -Dscala.usejavacp=false -Xsource:2.10 -classpath $HOME/.m2/repository/org/scala-lang/scala-library/2.10.3/scala-library-2.10.3.jar:$HOME/.m2/repository/org/scala-lang/scala-reflect/2.10.3/scala-reflect-2.10.3.jar test/files/pos/t8461/Impl.scala
warning: there were 1 deprecation warning(s); re-run with -deprecation for details
one warning found

% qbin/scalac -nobootcp -Dscala.usejavacp=false -Xsource:2.11 -classpath $HOME/.m2/repository/org/scala-lang/scala-library/2.10.3/scala-library-2.10.3.jar:$HOME/.m2/repository/org/scala-lang/scala-reflect/2.10.3/scala-reflect-2.10.3.jar test/files/pos/t8461/Impl.scala
test/files/pos/t8461/Impl.scala:6: error: macro implementations cannot have implicit parameters other than WeakTypeTag evidences
  def reads[A] = macro readsImpl[A]
                       ^
one error found
```

Before this change, when using a 2.10 JAR for scala-reflect, the
macro signature validation checks failed. This was due to the fact
that `scala.reflect.macros.Context` was changed in 2.11 to be
a type alias.

To get things working again, I've had to route both
`defintions.{WhiteBoxContextClass, BlackBoxContextClass}` to the
old location. This might mean that we misclassify the boxity under
this mode. All that we can actually handle are blackbox macros, really,
as macro expansion is likely to hit binary incompatibilites very
quickly. We can refine this in subsequent releases.

Review by @huitseeker @xeno-by
