### PR TITLE
Render scala.full.version to versions.properties.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -550,6 +550,7 @@ TODO:
       <echo message="Updating `versions.properties`:"/>
       <echo message="starr.version                              = ${starr.version}"/>
       <echo message="scala.binary.version                       = ${scala.binary.version}"/>
+      <echo message="scala.full.version                         = ${scala.full.version}"/>
       <echo message="scala-xml.version.number                   = ${scala-xml.version.number}"/>
       <echo message="scala-parser-combinators.version.number    = ${scala-parser-combinators.version.number}"/>
       <echo message="scala-continuations-plugin.version.number  = ${scala-continuations-plugin.version.number}"/>
@@ -563,6 +564,7 @@ TODO:
       <propertyfile file="versions.properties">
         <entry key="starr.version"                              value="${starr.version}"/>
         <entry key="scala.binary.version"                       value="${scala.binary.version}"/>
+        <entry key="scala.full.version"                         value="${scala.full.version}"/>
         <entry key="scala-xml.version.number"                   value="${scala-xml.version.number}"/>
         <entry key="scala-parser-combinators.version.number"    value="${scala-parser-combinators.version.number}"/>
         <entry key="scala-continuations-plugin.version.number"  value="${scala-continuations-plugin.version.number}"/>

--- a/versions.properties
+++ b/versions.properties
@@ -1,4 +1,9 @@
 #Wed, 19 Mar 2014 03:05:28 +0100
+# NOTE: this file determines the content of the scala-distribution
+# via scala-dist-pom.xml and scala-library-all-pom.xml
+# when adding new properties that influence a release,
+# also add them to the update.versions mechanism in build.xml,
+# which is used by scala-release-2.11.x in scala/jenkins-scripts
 starr.version=2.11.0-RC3
 starr.use.released=1
 
@@ -8,16 +13,15 @@ starr.use.released=1
 # e.g. 2.11.0-RC1, 2.11
 scala.binary.version=2.11.0-RC3
 # e.g. 2.11.0-RC1, 2.11.0, 2.11.1-RC1, 2.11.1
+# this defines the dependency on scala-continuations-plugin in scala-dist's pom
 scala.full.version=2.11.0-RC3
 
-# external modules shipped with distribution:
+# external modules shipped with distribution, as specified by scala-library-all's pom
 scala-xml.version.number=1.0.1
 scala-parser-combinators.version.number=1.0.1
 scala-continuations-plugin.version.number=1.0.1
 scala-continuations-library.version.number=1.0.1
 scala-swing.version.number=1.0.1
-
-# these ship with distribution (and scala-library-all depends on them)
 akka-actor.version.number=2.3.0
 actors-migration.version.number=1.1.0
 


### PR DESCRIPTION
When called with -Dupdate.versions, the build will render its current
set of versions to versions properties. This is used during releases,
when bootstrapping to a consistent set of modules that constitute
a release.

Particularly, scala.full.version is the non-SNAPSHOT full version
of scala that's closed to maven.version.number. It's similar in
spirit to the module build's snapshotScalaBinaryVersion,
except that it's always the full version, so, e.g., 2.11.1 rather than 2.11.

This version is so far only used to determine the dependency on
scala-continuations-plugin in scala-dist.

Review by @retronym. See also https://github.com/scala/jenkins-scripts/pull/91
