### PR TITLE
Bump versions after release of Scala 2.11.0-RC4

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -1,20 +1,20 @@
-#Wed, 19 Mar 2014 03:05:28 +0100
+#Fri, 04 Apr 2014 23:11:56 +0200
 # NOTE: this file determines the content of the scala-distribution
 # via scala-dist-pom.xml and scala-library-all-pom.xml
 # when adding new properties that influence a release,
 # also add them to the update.versions mechanism in build.xml,
 # which is used by scala-release-2.11.x in scala/jenkins-scripts
-starr.version=2.11.0-RC3
+starr.version=2.11.0-RC4
 starr.use.released=1
 
 # These are the versions of the modules that go with this release.
 # These properties are used during PR validation and in dbuild builds.
 
 # e.g. 2.11.0-RC1, 2.11
-scala.binary.version=2.11.0-RC3
+scala.binary.version=2.11.0-RC4
 # e.g. 2.11.0-RC1, 2.11.0, 2.11.1-RC1, 2.11.1
 # this defines the dependency on scala-continuations-plugin in scala-dist's pom
-scala.full.version=2.11.0-RC3
+scala.full.version=2.11.0-RC4
 
 # external modules shipped with distribution, as specified by scala-library-all's pom
 scala-xml.version.number=1.0.1

--- a/versions.properties
+++ b/versions.properties
@@ -22,7 +22,7 @@ scala-parser-combinators.version.number=1.0.1
 scala-continuations-plugin.version.number=1.0.1
 scala-continuations-library.version.number=1.0.1
 scala-swing.version.number=1.0.1
-akka-actor.version.number=2.3.0
+akka-actor.version.number=2.3.2
 actors-migration.version.number=1.1.0
 
 # external modules, used internally (not shipped)


### PR DESCRIPTION
Based on:

   https://scala-webapps.epfl.ch/jenkins/view/scala-release-2.11.x/job/scala-release-2.11.x/52/artifact/scala/versions.properties

With a manual edit of the new property, scala.full.version, which
was not written out by `ant -Dupdate.versions`. That has since
been remedied.

Review by @adriaanm
