### PR TITLE
Reword javap filtering options

### DIFF
--- a/2.11/index.markdown
+++ b/2.11/index.markdown
@@ -179,13 +179,13 @@ scala> :history
 
 ### `:javap` ([#1880](https://github.com/scala/scala/pull/1880))
 
-The command to dissasemble Java output got some bugfixes and new features. It is now possible to filter out members of classes:
+The command to dissasemble Java output got some bugfixes and new features. It is now possible to selectively display members of classes:
 
-- `Bar#foo` filters out all `foo` members
-- `Bar#` filters out all `apply` members
-- `-fun Bar#foo` filters out all anonfuns of `foo` members
-- `-fun Bar#` filters out all anonfuns of `apply` members
-- `-app Bar` filters out `Bar.delayedInit`
+- `Bar#foo` displays all `foo` members
+- `Bar#` displays all `apply` members
+- `-fun Bar#foo` displays all anonfuns of `foo` members
+- `-fun Bar#` displays all anonfuns of `apply` members
+- `-app Bar` displays `Bar.delayedInit`
 
 Example usage:
 


### PR DESCRIPTION
"To filter out" means remove, and, therefore, has the exact opposite meaning of what the example shows. But "filter" is kind of an ambiguous word when it comes to what's removed and what's left, not to mention which you are interested in (if you filter water to drink that's one thing, if you filter water to mine gold, that's another), so I'm avoiding it altogether and going for some unambiguous.
