### PR TITLE
SI-8497 Fix regression in pickling of AnnotatedTypes

### DIFF
--- a/src/reflect/scala/reflect/internal/pickling/Translations.scala
+++ b/src/reflect/scala/reflect/internal/pickling/Translations.scala
@@ -62,21 +62,22 @@ trait Translations {
   }
 
   def picklerTag(tpe: Type): Int = tpe match {
-    case NoType               => NOtpe
-    case NoPrefix             => NOPREFIXtpe
-    case _: ThisType          => THIStpe
-    case _: SingleType        => SINGLEtpe
-    case _: SuperType         => SUPERtpe
-    case _: ConstantType      => CONSTANTtpe
-    case _: TypeBounds        => TYPEBOUNDStpe
-    case _: TypeRef           => TYPEREFtpe
-    case _: RefinedType       => REFINEDtpe
-    case _: ClassInfoType     => CLASSINFOtpe
-    case _: MethodType        => METHODtpe
-    case _: PolyType          => POLYtpe
-    case _: NullaryMethodType => POLYtpe  // bad juju, distinct ints are not at a premium!
-    case _: ExistentialType   => EXISTENTIALtpe
-    case _: AnnotatedType     => ANNOTATEDtpe
+    case NoType                        => NOtpe
+    case NoPrefix                      => NOPREFIXtpe
+    case _: ThisType                   => THIStpe
+    case _: SingleType                 => SINGLEtpe
+    case _: SuperType                  => SUPERtpe
+    case _: ConstantType               => CONSTANTtpe
+    case _: TypeBounds                 => TYPEBOUNDStpe
+    case _: TypeRef                    => TYPEREFtpe
+    case _: RefinedType                => REFINEDtpe
+    case _: ClassInfoType              => CLASSINFOtpe
+    case _: MethodType                 => METHODtpe
+    case _: PolyType                   => POLYtpe
+    case _: NullaryMethodType          => POLYtpe  // bad juju, distinct ints are not at a premium!
+    case _: ExistentialType            => EXISTENTIALtpe
+    case StaticallyAnnotatedType(_, _) => ANNOTATEDtpe
+    case _: AnnotatedType              => picklerTag(tpe.underlying)
   }
 
   def picklerSubTag(tree: Tree): Int = tree match {

--- a/test/files/pos/t8497/A_1.scala
+++ b/test/files/pos/t8497/A_1.scala
@@ -1,0 +1,13 @@
+package p {
+  object Crash {
+    def e(s: (String @java.lang.Deprecated)): Unit = ()
+    def f(s: (String @nonStatic)): Unit = ()
+  }
+  object Ok {
+    def g(s: (String @nonStatic @static)): Unit = ()
+    def h(s: (String @static)): Unit = ()
+  }
+}
+
+class nonStatic extends scala.annotation.Annotation
+class static extends scala.annotation.StaticAnnotation

--- a/test/files/pos/t8497/B_2.scala
+++ b/test/files/pos/t8497/B_2.scala
@@ -1,0 +1,1 @@
+package p { object Test { Crash } }


### PR DESCRIPTION
Fixes an inconsistency introduced in these two spots:

  https://github.com/scala/scala/pull/3033/files#diff-6ce1a17ebee31068f41c36a8a2b3bc9aR79
  https://github.com/scala/scala/pull/3033/files#diff-c455cb229f5227b1bcaa1544478fe3acR452

The bug shows up when pickling then unpickling an AnnotatedType
that has only non-static annotations. It manifests as a crash in unpickling.
