### PR TITLE
Bump versions after release of 2.11.0-final

### DIFF
--- a/build.number
+++ b/build.number
@@ -1,7 +1,7 @@
 #Tue Sep 11 19:21:09 CEST 2007
 version.major=2
 version.minor=11
-version.patch=0
+version.patch=1
 # This is the -N part of a version.  if it's 0, it's dropped from maven versions.
 version.bnum=0
 

--- a/versions.properties
+++ b/versions.properties
@@ -1,20 +1,20 @@
-#Fri, 04 Apr 2014 23:11:56 +0200
+#Wed, 16 Apr 2014 11:13:08 +0200
 # NOTE: this file determines the content of the scala-distribution
 # via scala-dist-pom.xml and scala-library-all-pom.xml
 # when adding new properties that influence a release,
 # also add them to the update.versions mechanism in build.xml,
 # which is used by scala-release-2.11.x in scala/jenkins-scripts
-starr.version=2.11.0-RC4
+starr.version=2.11.0
 starr.use.released=1
 
 # These are the versions of the modules that go with this release.
 # These properties are used during PR validation and in dbuild builds.
 
 # e.g. 2.11.0-RC1, 2.11
-scala.binary.version=2.11.0-RC4
+scala.binary.version=2.11
 # e.g. 2.11.0-RC1, 2.11.0, 2.11.1-RC1, 2.11.1
 # this defines the dependency on scala-continuations-plugin in scala-dist's pom
-scala.full.version=2.11.0-RC4
+scala.full.version=2.11.0
 
 # external modules shipped with distribution, as specified by scala-library-all's pom
 scala-xml.version.number=1.0.1


### PR DESCRIPTION
New versions.properties generated by:

   https://scala-webapps.epfl.ch/jenkins/view/scala-release-2.11.x/job/scala-release-2.11.x/57/

Review by @gkossakowski

For merge on Friday (after artifacts for 2.11.0 have propagated to Maven central)
