### PR TITLE
SI-8514 Remove scaladoc html inconsistencies

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
@@ -306,9 +306,6 @@ class Template(universe: doc.Universe, generator: DiagramGenerator, tpl: DocTemp
         <xml:group>
           <div id="comment" class="fullcommenttop">{ memberToCommentBodyHtml(mbr, inTpl, isSelf = true) }</div>
         </xml:group>
-      case dte: DocTemplateEntity if mbr.comment.isDefined =>
-        // comment of inner, documented class (only short comment, full comment is on the class' own page)
-        memberToInlineCommentHtml(mbr, isSelf)
       case _ =>
         // comment of non-class member or non-documentented inner class
         val commentBody = memberToCommentBodyHtml(mbr, inTpl, isSelf = false)

--- a/test/scaladoc/resources/SI-8514.scala
+++ b/test/scaladoc/resources/SI-8514.scala
@@ -1,0 +1,10 @@
+package a {
+  class DeveloperApi extends scala.annotation.StaticAnnotation
+
+  /** Some doc here */
+  @DeveloperApi
+  class A
+
+  @DeveloperApi
+  class B
+}

--- a/test/scaladoc/scalacheck/HtmlFactoryTest.scala
+++ b/test/scaladoc/scalacheck/HtmlFactoryTest.scala
@@ -740,5 +740,19 @@ object Test extends Properties("HtmlFactory") {
       case node: scala.xml.Node => true
       case _ => false
     }
+
+    property("SI-8514: No inconsistencies") =
+      checkText("SI-8514.scala")(
+        (Some("a/package"),
+         """class A extends AnyRef
+            Some doc here
+            Some doc here
+            Annotations @DeveloperApi()
+         """, true),
+        (Some("a/package"),
+         """class B extends AnyRef
+            Annotations @DeveloperApi()
+         """, true)
+      )
   }
 }


### PR DESCRIPTION
Some classes only got inline comments instead of getting the full comment.
