### PR TITLE
Another spot to fully cross version continuations plugin

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -304,6 +304,7 @@ TODO:
            necessary cross suffix (usually something like "_2.11.0-M6". -->
       <prepareCross name="scala-xml" />
       <prepareCross name="scala-parser-combinators" />
+      <property name="scala-continuations-plugin.cross.suffix" value="_${scala.full.version}"/>
       <prepareCross name="scala-continuations-plugin" />
       <prepareCross name="scala-continuations-library"/>
       <prepareCross name="scala-swing"/>


### PR DESCRIPTION
The continuations plugin is fully cross versioned, as it
dependes on the non-BC compiler API.

I had to make the same change externally releasing 2.11.0:

   https://github.com/scala/jenkins-scripts/pull/99/files

This fix addresses the problem in scala/scala. Without it,
we can't resolve dependencies in development.

Review by @xeno-by @adriaanm
