### PR TITLE
makes bundles friendly to -Ywarn-dead-code

### DIFF
--- a/src/compiler/scala/reflect/macros/compiler/DefaultMacroCompiler.scala
+++ b/src/compiler/scala/reflect/macros/compiler/DefaultMacroCompiler.scala
@@ -53,7 +53,7 @@ abstract class DefaultMacroCompiler extends Resolvers
         (EmptyTree, TermName(""), Nil)
     }
     val bundleImplRef = MacroImplRefCompiler(
-      atPos(macroDdef.rhs.pos)(gen.mkTypeApply(Select(New(maybeBundleRef, List(List(Ident(Predef_???)))), methName), targs)),
+      atPos(macroDdef.rhs.pos)(gen.mkTypeApply(Select(New(maybeBundleRef, List(List(Literal(Constant(null))))), methName), targs)),
       isImplBundle = true
     )
     val vanillaResult = tryCompile(vanillaImplRef)

--- a/test/files/pos/t8523.flags
+++ b/test/files/pos/t8523.flags
@@ -1,0 +1,1 @@
+-Ywarn-dead-code -Xfatal-warnings

--- a/test/files/pos/t8523.scala
+++ b/test/files/pos/t8523.scala
@@ -1,0 +1,10 @@
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox.Context
+
+class Impl(val c: Context) {
+  def impl: c.Tree = ???
+}
+
+object Macros {
+  def foo: Any = macro Impl.impl
+}


### PR DESCRIPTION
Apparently, the `new Bundle(???).impl` synthetic tree generated as a
macro impl ref for bundles evokes -Ywarn-dead-code warnings.

This pull requests changes `???` to `null` in order not to stress out
the checker. What's in the argument doesn't actually make any difference
anyway.
