### PR TITLE
SI-8478 Fix a performance regression in subtyping

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4113,8 +4113,8 @@ trait Types
 
   def isSubArgs(tps1: List[Type], tps2: List[Type], tparams: List[Symbol], depth: Depth): Boolean = {
     def isSubArg(t1: Type, t2: Type, variance: Variance) = (
-         (variance.isContravariant || isSubType(t1, t2, depth))
-      && (variance.isCovariant || isSubType(t2, t1, depth))
+         (variance.isCovariant || isSubType(t2, t1, depth))     // The order of these two checks can be material for performance (SI-8478)
+      && (variance.isContravariant || isSubType(t1, t2, depth))
     )
 
     corresponds3(tps1, tps2, mapList(tparams)(_.variance))(isSubArg)


### PR DESCRIPTION
When checking `M[X] <:< M[Y]` for an `M` with an invariant
parameter, we have to check that `X <:< Y && Y <:< X`. This is
done in `isSubArgs`.

The compile time of the test in the ticket jumps from 20s in
2.10.4 to too-long-to-measure in 2.11.0. This commit reverts the
a subtle change to `isSubArgs` in ea93654 that was ultimately
responsible.

The search for this was unusually circuitious, even for scalac.
It appeared in 9c09c1709 due a tiny error that has since been
reverted in 58bfa19. But 58bfa19 still exhibited abysmal performance,
due to an intervening regression that I'm targeting here.

I haven't managed to extract a performance test from Slick. Using
the test that @cvogt provided, however, with this patch:

```
% time qbin/scalac -J-Xmx4G -classpath /Users/jason/code/slick-presentation/target/scala-2.10/classes:/Users/jason/.sbt/0.13/staging/b64b71d1228cdfe7b6d8/slick/target/scala-2.10/classes:/Users/jason/.ivy2/cache/org.slf4j/slf4j-api/jars/slf4j-api-1.6.4.jar /Users/jason/code/slick-presentation/src/main/scala/SlickPresentation.scala

real    0m21.853s
user    0m33.625s
sys 0m0.878s
```

Which is back to 2.10.x style performance.
