### PR TITLE
SI-8514 NumericRange[Double] take and drop are broken

### DIFF
--- a/test/junit/scala/math/NumericTest.scala
+++ b/test/junit/scala/math/NumericTest.scala
@@ -14,5 +14,14 @@ class NumericTest {
     assertTrue(-0.0.abs equals 0.0)
     assertTrue(-0.0f.abs equals 0.0f)
   }
+  
+  /* Tests for SI-8518 and SI-4370 regressions */
+  @Test
+  def testDoubleRangeAccuracy {
+    assertTrue((0.0 to 1.0 by 0.1).drop(3).take(3).length == 3)
+    assertTrue((0.0 to 0.5 by 0.1).map(_.toString) == (0 to 5).map(x => s"0.$x"))
+    assertFalse((0.0 until 0.2 by 0.5).isEmpty)
+    assertTrue((0.0 until 0.3 by 0.1).length == 3)
+  }
 }
 


### PR DESCRIPTION
Fixes SI-8514, plus regressions associated with fix of SI-4370, plus other regressions from earlier commits regarding floating-point ranges.  This fixes only Double; Float is still broken.  Jumped through all sorts of hoops to (try to) preserve binary compatibility--this should be redone for 2.12.
