### PR TITLE
SI-8504 fix NPE in the Java wrapper for a Scala Map.

### DIFF
--- a/src/library/scala/collection/convert/Wrappers.scala
+++ b/src/library/scala/collection/convert/Wrappers.scala
@@ -194,7 +194,7 @@ private[collection] trait Wrappers {
             def getKey = k
             def getValue = v
             def setValue(v1 : B) = self.put(k, v1)
-            override def hashCode = byteswap32(k.hashCode) + (byteswap32(v.hashCode) << 16)
+            override def hashCode = byteswap32(k.##) + (byteswap32(v.##) << 16)
             override def equals(other: Any) = other match {
               case e: ju.Map.Entry[_, _] => k == e.getKey && v == e.getValue
               case _ => false

--- a/test/junit/scala/collection/convert/MapWrapperTest.scala
+++ b/test/junit/scala/collection/convert/MapWrapperTest.scala
@@ -46,4 +46,14 @@ class MapWrapperTest {
     assertFalse(javaMap.containsKey(null))       // negative test, null key
     assertEquals(4, scalaMap.containsCounter)
   }
+
+  // test for SI-8504
+  @Test
+  def testHashCode() {
+    import scala.collection.JavaConverters._
+    val javaMap = Map(1 -> null).asJava
+
+    // Before the fix for SI-8504, this throws a NPE
+    javaMap.hashCode
+  }
 }


### PR DESCRIPTION
MapWrapper blindly calls .hashCode on keys that can very well be null.
