### PR TITLE
SI-8546 Pattern matcher analysis foiled by over-widening

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -149,14 +149,15 @@ trait TreeAndTypeAnalysis extends Debugging {
       object typeArgsToWildcardsExceptArray extends TypeMap {
         // SI-6771 dealias would be enough today, but future proofing with the dealiasWiden.
         // See neg/t6771b.scala for elaboration
-        def apply(tp: Type): Type = tp.dealiasWiden match {
+        def apply(tp: Type): Type = tp.dealias match {
           case TypeRef(pre, sym, args) if args.nonEmpty && (sym ne ArrayClass) =>
             TypeRef(pre, sym, args map (_ => WildcardType))
           case _ =>
             mapOver(tp)
         }
       }
-      debug.patmatResult(s"checkableType($tp)")(typeArgsToWildcardsExceptArray(tp))
+      val result = typeArgsToWildcardsExceptArray(tp)
+      debug.patmatResult(s"checkableType($tp)")(result)
     }
 
     // a type is "uncheckable" (for exhaustivity) if we don't statically know its subtypes (i.e., it's unsealed)

--- a/test/files/neg/t6771b.scala
+++ b/test/files/neg/t6771b.scala
@@ -6,8 +6,6 @@
 // But, to the intrepid hacker who works on this, a few notes:
 // You'll have to look into places in the pattern matcher that
 // call `dealias`, and see if they need to be `dealiasWiden`.
-// For example, if `checkableType` used only `dealias`, `pos/t6671.scala`
-// would fail.
 object Test {
   val a = ""; var b: a.type = a
 

--- a/test/files/pos/t8546.flags
+++ b/test/files/pos/t8546.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t8546.scala
+++ b/test/files/pos/t8546.scala
@@ -1,0 +1,49 @@
+package test
+ 
+class F1() {
+  private sealed abstract class T
+  private case class A(m: Int) extends T
+  private case class B() extends T
+  private case object C extends T
+ 
+  // No warnings here
+  private def foo(t: T) = t match {
+    case A(m) => println("A:" + m)
+    case B() => println("B")
+    case C => println("C")
+  }
+ 
+  def test(m: Int): Unit = {
+    foo(A(m))
+    foo(B())
+    foo(C)
+  }
+}
+ 
+class F2[M]() {
+  private sealed abstract class T
+  private case class A(m: M) extends T
+  private case class B() extends T
+  private case object C extends T
+ 
+  // match may not be exhaustive. It would fail on the following input: C
+  private def foo(t: T) = t match {
+    case A(m) => println("A:" + m)
+    case B() => println("B")
+    case C => println("C")
+  }
+ 
+  def test(m: M): Unit = {
+    foo(A(m))
+    foo(B())
+    foo(C)
+  }
+ 
+}
+ 
+object Test {
+  def main(args: Array[String]): Unit = {
+    new F1().test(1)
+    new F2[Int]().test(1)
+  }
+}


### PR DESCRIPTION
In the enclosed test, the prefix checkable type
`ModuleTypeRef(F2.this, C)` was being inadvertently widened to
`ModuleTypeRef(F2[?], C)`. This started after some misguided
future-proofing in SI-6771 / 3009916.

This commit changes the `dealiasWiden` to a `delias`.
