### PR TITLE
SI-8550 fix scaladoc for the default s.c.LinearSeq.

### DIFF
--- a/src/library/scala/collection/LinearSeq.scala
+++ b/src/library/scala/collection/LinearSeq.scala
@@ -25,7 +25,7 @@ trait LinearSeq[+A] extends Seq[A]
 }
 
 /** $factoryInfo
- *  The current default implementation of a $Coll is a `Vector`.
+ *  The current default implementation of a $Coll is a `List`.
  *  @define coll linear sequence
  *  @define Coll `LinearSeq`
  */


### PR DESCRIPTION
The default LinearSeq is a List (LinearSeq.newBuilder delegates to
immutable.LinearSeq.newBuilder, whose default is List).
