### PR TITLE
SI-8032 Provides an implicit macro for materialization of Liftable for case classes

### DIFF
--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -226,6 +226,14 @@ filter {
     {
         matchName="scala.reflect.api.Internals$ReificationSupportApi$SyntacticTypeProjectionExtractor"
         problemName=MissingClassProblem
+    },
+    {
+        matchName="scala.reflect.api.LiftableCaseClass"
+        problemName=MissingClassProblem
+    },
+    {
+        matchName="scala.reflect.api.LiftableCaseClass$"
+        problemName=MissingClassProblem
     }
   ]
 }

--- a/src/reflect/scala/reflect/api/StandardLiftables.scala
+++ b/src/reflect/scala/reflect/api/StandardLiftables.scala
@@ -1,6 +1,8 @@
 package scala.reflect
 package api
 
+import scala.language.experimental.macros
+
 trait StandardLiftables { self: Universe =>
   import internal._
   import reificationSupport.{SyntacticTuple, ScalaDot}
@@ -54,6 +56,8 @@ trait StandardLiftables { self: Universe =>
       case left: Left[L, R]   => lift(left)
       case right: Right[L, R] => lift(right)
     }
+
+    implicit def liftCaseClass[T]: Liftable[T] = macro LiftableCaseClass.impl[T]
 
     implicit def liftTuple2[T1, T2](implicit liftT1: Liftable[T1], liftT2: Liftable[T2]): Liftable[Tuple2[T1, T2]] = Liftable { t =>
       SyntacticTuple(liftT1(t._1) :: liftT2(t._2) :: Nil)
@@ -231,5 +235,100 @@ trait StandardLiftables { self: Universe =>
     val util       = TermName("util")
     val Vector     = TermName("Vector")
     val WILDCARD   = self.nme.WILDCARD
+  }
+}
+
+object LiftableCaseClass {
+  import scala.reflect.macros.whitebox.Context
+
+  /* All the trees (except one that has a special comment) in this macro are hygienic
+   * (and there is a test to check that). That is, all TermNames used
+   * (specifically: Tree, Apply, Liftable, List, implicitly, reify) are fully qualified,
+   * and will not bind to terms with same names, declared in the expansion context.
+   * Each tree is commented with a simplified, unhygienic quasiquote, that explains
+   * what that tree is supposed to do.
+   */
+  def impl[T: c.WeakTypeTag](c: Context): c.Tree = {
+    import c.universe._
+    val Select(prefix, _) = c.prefix.tree
+    val T = weakTypeOf[T]
+    val symbol = T.typeSymbol
+    if (!symbol.asClass.isCaseClass)
+      c.abort(c.enclosingPosition, s"$symbol is not a case class")
+    if (!symbol.isStatic)
+      c.abort(c.enclosingPosition, s"$symbol is not static")
+    def fields(tpe: Type) = tpe.declarations.collectFirst {
+      case m: MethodSymbol if m.isPrimaryConstructor ⇒ m
+    }.get.paramss.head.map { field ⇒
+      val name = field.name
+      val typeSign = tpe.declaration(name).typeSignature
+      name → typeSign
+    }
+    /* Tree produced by the following quasiquote:
+     * q"reify(${c.mirror.staticModule(symbol.fullName)}).tree"
+     */
+    val constructor = Select(Apply(
+                               Select(prefix, TermName("reify")),
+                               List(Ident(c.mirror.staticModule(symbol.fullName)))),
+                        TermName("tree"))
+    val value = "value"
+    val arguments = fields(T).map { case (name, typeSign) ⇒
+      /* Tree produced by the following quasiquote:
+       * q"implicitly[Liftable[$typeSign]].apply(value.$name)"
+       * Another way to do this would be:
+       * q"""
+       *   val v : $typeSign = value.$name
+       *   q"$$v"
+       * """
+       *
+       * This tree is not hygienic: TermName(value) will bind to value from
+       * enclosing context, which is the tree being returned from the macro.
+       * To ensure that its name does not change in one place, but stays
+       * unchanged in another, it is placed in a dedicated val.
+       */
+      Apply(Select(
+              TypeApply(Select(Ident(definitions.PredefModule), TermName("implicitly")),
+                        List(AppliedTypeTree(Select(prefix, TypeName("Liftable")),
+                             List(TypeTree(typeSign))))),
+              TermName("apply")),
+           List(Select(Ident(TermName(value)), name)))
+    }
+    /* Tree produced by the following quasiquote:
+     * q"Apply($constructor, List(..$arguments))"
+     */
+    val reflect = Apply(Select(prefix, TermName("Apply")),
+                        List(constructor,
+                          Apply(Ident(definitions.ListModule),
+                        arguments)))
+    val implicitName = TermName(symbol.name.encoded ++ "Liftable")
+    /* Tree produced by the following quasiquote:
+     * q"""
+     *   implicit object $implicitName extends Liftable[$T] {
+     *     def apply(value: $T): Tree = $reflect
+     *   }
+     *   $implicitName
+     * """
+     */
+    import Flag._
+    Block(List(ModuleDef(Modifiers(IMPLICIT),
+                implicitName,
+                Template(
+                  List(AppliedTypeTree(Select(prefix, TypeName("Liftable")),
+                       List(TypeTree(T)))),
+                  noSelfType,
+                  List(DefDef(Modifiers(),
+                        nme.CONSTRUCTOR,
+                        List(), List(List()),
+                        TypeTree(),
+                        Block(
+                          List(pendingSuperCall),
+                          Literal(Constant(())))),
+                        DefDef(Modifiers(),
+                               TermName("apply"),
+                               List(),
+                               List(List(ValDef(Modifiers(PARAM),
+                                         TermName(value), TypeTree(T), EmptyTree))),
+                               Select(prefix, TypeName("Tree")), reflect))))),
+          Ident(implicitName))
   }
 }

--- a/test/files/scalacheck/quasiquotes/LiftableCaseClassProps.scala
+++ b/test/files/scalacheck/quasiquotes/LiftableCaseClassProps.scala
@@ -1,0 +1,62 @@
+import org.scalacheck._
+import scala.reflect.runtime.universe._
+
+case class Simple(s: String, i: Int)
+case class Nested(d: Double, s: String, simple: Simple)
+case class `Simple.With.Dot`(d: Double)
+
+case class Recursive(recursive: Recursive)
+
+case class Mutually(rec: Rec)
+case class Rec(mutually: Mutually)
+
+package inside.a {
+  case class Package(pkg: String)
+}
+
+package a {
+  case class B()
+}
+
+
+object LiftableCaseClassProps extends QuasiquoteProperties("liftable case class") {
+  property("lift simple case class") = test {
+    val simple = Simple("simple", 42)
+    assert(q"$simple" ≈ Apply(Ident(TermName("Simple")), List(Literal(Constant("simple")), Literal(Constant(42)))))
+  }
+
+  property("lift nested case class") = test {
+    val simple = Simple("simple", 42)
+    val nested = Nested(2.0, "nested", simple)
+    assert(q"$nested" ≈ Apply(Ident(TermName("Nested")), List(Literal(Constant(2.0)), Literal(Constant("nested")), Apply(Ident(TermName("Simple")), List(Literal(Constant("simple")), Literal(Constant(42)))))))
+  }
+
+  property("lift case class with dots in name") = test {
+    val dotted = `Simple.With.Dot`(3.0)
+    assert(q"$dotted" ≈ Apply(Ident(TermName("Simple$u002EWith$u002EDot")), List(Literal(Constant(3.0)))))
+  }
+
+  property("lift case class inside a package") = test {
+    val packaged = inside.a.Package("package")
+    assert(q"$packaged" ≈ Apply(Ident(TermName("Package")), List(Literal(Constant("package")))))
+  }
+
+  property("materialize liftable instances for recursive and mutually recursive case classes") = test {
+    implicitly[Liftable[Recursive]]
+    implicitly[Liftable[Mutually]]
+    implicitly[Liftable[Rec]]
+    assert(true)
+  }
+
+  property("hygiene") = test {
+    val a = ""
+    val b = _root_.a.B()
+    val reify = ""
+    val implicitly = ""
+    case class Liftable()
+    case class Tree()
+    case class Apply()
+    case class List()
+    assert(q"$b" ≈ scala.reflect.runtime.universe.Apply(Ident(TermName("B")), scala.List()))
+  }
+}

--- a/test/files/scalacheck/quasiquotes/Test.scala
+++ b/test/files/scalacheck/quasiquotes/Test.scala
@@ -8,6 +8,7 @@ object Test extends Properties("quasiquotes") {
   include(PatternConstructionProps)
   include(PatternDeconstructionProps)
   include(LiftableProps)
+  include(LiftableCaseClassProps)
   include(UnliftableProps)
   include(ErrorProps)
   include(RuntimeErrorProps)


### PR DESCRIPTION
Now that development of 2.12 has started, reopening this PR.

Case classes can now be used in quasiquotes.

``` scala
Welcome to Scala version 2.11.1-20140505-184318-2e6e13ff25 (Java HotSpot(TM) 64-Bit Server VM, Java 1.7.0_51).
Type in expressions to have them evaluated.
Type :help for more information.

scala> import scala.reflect.runtime.{universe => u}
import scala.reflect.runtime.{universe=>u}

scala>  import u._
import u._

scala> case class Test(str: String, i: Int, lst: List[Double])
defined class Test

scala> val test = Test("test", 1, List(2.0, 3.5))
test: Test = Test(test,1,List(2.0, 3.5))

scala> showRaw(q"$test")
res0: String = Apply(Ident(Test), List(Literal(Constant("test")), Literal(Constant(1)), Apply(Select(Select(Select(Ident(scala), TermName("collection")), TermName("immutable")), TermName("List")), List(Literal(Constant(2.0)), Literal(Constant(3.5))))))

scala> val cm = runtimeMirror(getClass.getClassLoader)
cm: reflect.runtime.universe.Mirror = JavaMirror with scala.tools.nsc.interpreter.IMain$TranslatingClassLoader@75293656 of type class scala.tools.nsc.interpreter.IMain$TranslatingClassLoader with classpath [(memory)] and parent being scala.reflect.internal.util.ScalaClassLoader$URLClassLoader@64ae8431 of type class scala.reflect.internal.util.ScalaClassLoader$URLClassLoader with classpath [file:/Library/Java/JavaVirtualMachines/jdk1.7.0_51.jdk/Contents/Home/jre/lib/resources.jar,file:/Library/Java/JavaVirtualMachines/jdk1.7.0_51.jdk/Contents/Home/jre/lib/rt.jar,file:/Library/Java/JavaVirtualMachines/jdk1.7.0_51.jdk/Contents/Home/jre/lib/jsse.jar,file:/Library/Java/JavaVirtualMachines/jdk1.7.0_51.jdk/Contents/Home/jre/lib/jce.jar,file:/Library/Java/JavaVirtualMachines/jdk1.7.0_51.jdk/Con...
scala> import scala.tools.reflect.ToolBox
import scala.tools.reflect.ToolBox

scala> val tb = cm.mkToolBox()
tb: scala.tools.reflect.ToolBox[reflect.runtime.universe.type] = scala.tools.reflect.ToolBoxFactory$ToolBoxImpl@641c66ff

scala> tb.eval(q"$test")
res1: Any = Test(test,1,List(2.0, 3.5))

scala> .asInstanceOf[Test]
res2: Test = Test(test,1,List(2.0, 3.5))
```

Review by @xeno-by, @densh, and @retronym please.
