### PR TITLE
Bump version for 2.12.x

### DIFF
--- a/build.number
+++ b/build.number
@@ -1,7 +1,7 @@
 #Tue Sep 11 19:21:09 CEST 2007
 version.major=2
-version.minor=11
-version.patch=1
+version.minor=12
+version.patch=0
 # This is the -N part of a version.  if it's 0, it's dropped from maven versions.
 version.bnum=0
 


### PR DESCRIPTION
For this step, we still depend on _2.11 libraries (partest, xml,
parser-combinators).

After we release the first milestone of 2.12, we will update
versions.property to bootstrap to 2.12 dependencies.
