### PR TITLE
Use 2.11.0 as the MiMa baseline for 2.11.x

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1505,7 +1505,7 @@ TODO:
                                   BINARY COMPATIBILITY TESTING
 ============================================================================ -->
   <target name="bc.init" depends="init" unless="maven-deps-done-mima">
-    <property name="bc-reference-version" value="2.11.0-RC1"/>
+    <property name="bc-reference-version" value="2.11.0"/>
 
     <property name="bc-build.dir" value="${build.dir}/bc"/>
     <!-- Obtain mima -->


### PR DESCRIPTION
Rather than 2.11.0-RC3.
