### PR TITLE
Respect -Dpartest.scalac_opts when running the test suite through ANT

### DIFF
--- a/build-ant-macros.xml
+++ b/build-ant-macros.xml
@@ -745,7 +745,7 @@
     <attribute name="dir" default="${partest.dir}"/>
     <attribute name="srcdir" default="files"/> <!-- TODO: make targets for `pending` and other subdirs -->
     <attribute name="colors" default="${partest.colors}"/>
-    <attribute name="scalacOpts" default="${scalac.args.optimise}"/>
+    <attribute name="scalacOpts" default="${partest.scalac_opts} ${scalac.args.optimise}"/>
     <attribute name="pcp" default="${toString:partest.compilation.path}"/>
     <attribute name="kinds"/>
     <sequential>

--- a/src/partest-extras/scala/tools/partest/BytecodeTest.scala
+++ b/src/partest-extras/scala/tools/partest/BytecodeTest.scala
@@ -34,7 +34,7 @@ abstract class BytecodeTest extends ASMConverters {
   /** produce the output to be compared against a checkfile */
   protected def show(): Unit
 
-  def main(args: Array[String]): Unit = show
+  def main(args: Array[String]): Unit = show()
 
   // asserts
   def sameBytecode(methA: MethodNode, methB: MethodNode) = {

--- a/test/files/pos/dotless-targs.flags
+++ b/test/files/pos/dotless-targs.flags
@@ -1,2 +1,1 @@
 -Yrangepos:false
--Xexperimental

--- a/test/files/run/applydynamic_sip.flags
+++ b/test/files/run/applydynamic_sip.flags
@@ -1,1 +1,2 @@
+-Yrangepos:false
 -language:dynamics

--- a/test/files/run/interop_typetags_are_manifests.flags
+++ b/test/files/run/interop_typetags_are_manifests.flags
@@ -1,2 +1,1 @@
 -Yrangepos:false
--Xexperimental

--- a/test/files/run/macro-openmacros.flags
+++ b/test/files/run/macro-openmacros.flags
@@ -1,1 +1,2 @@
+-Yrangepos:false
 -language:experimental.macros

--- a/test/files/run/macro-parse-position.flags
+++ b/test/files/run/macro-parse-position.flags
@@ -1,2 +1,1 @@
 -Yrangepos:false
--Xexperimental

--- a/test/files/run/macroPlugins-macroExpand.flags
+++ b/test/files/run/macroPlugins-macroExpand.flags
@@ -1,2 +1,1 @@
 -Yrangepos:false
--Xexperimental

--- a/test/files/run/macroPlugins-typedMacroBody.flags
+++ b/test/files/run/macroPlugins-typedMacroBody.flags
@@ -1,2 +1,1 @@
 -Yrangepos:false
--Xexperimental

--- a/test/files/run/t6327.flags
+++ b/test/files/run/t6327.flags
@@ -1,2 +1,1 @@
 -Yrangepos:false
--Xexperimental

--- a/test/files/run/t6663.flags
+++ b/test/files/run/t6663.flags
@@ -1,2 +1,1 @@
 -Yrangepos:false
--Xexperimental

--- a/test/files/run/t6731.flags
+++ b/test/files/run/t6731.flags
@@ -1,2 +1,1 @@
 -Yrangepos:false
--Xexperimental


### PR DESCRIPTION
Used to enable `-Xcheckinit` (now also `-Ybackend:GenBCode`) when
compiling tests in the respective jenkins builds. This is currently
broken, as you can see in [recent build logs](https://scala-webapps.epfl.ch/jenkins/view/nightlies/job/scala-nightly-checkinit/2058/consoleFull), `-Xcheckinit` is
missing:

```
[partest] Scalac options are:  -optimise
```

Adds `.flags` files for macro tests (correct range positions not
enforced) and for tests failing due to SI-8560 or SI-8562.

Resubmission of #3709 (against 2.11 branch).
