### PR TITLE
Avoid throwing exceptions in macro context.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -750,7 +750,7 @@ trait ContextErrors {
       protected def macroExpansionError(expandee: Tree, msg: String, pos: Position = NoPosition) = {
         def msgForLog = if (msg != null && (msg contains "exception during macro expansion")) msg.split(EOL).drop(1).headOption.getOrElse("?") else msg
         macroLogLite("macro expansion has failed: %s".format(msgForLog))
-        if (msg != null) context.error(if (pos.isDefined) pos else expandee.pos, msg) // issueTypeError(PosAndMsgTypeError(..)) won't work => swallows positions
+        if (msg != null) issueTypeError(PosAndMsgTypeError(if (pos.isDefined) pos else expandee.pos, msg))
         setError(expandee)
         throw MacroExpansionException
       }

--- a/test/files/neg/macro-basic-mamdmi.check
+++ b/test/files/neg/macro-basic-mamdmi.check
@@ -1,5 +1,13 @@
+Impls_Macros_Test_1.scala:33: error: macro implementation not found: foo
+(the most common reason for that is that you cannot use macro implementations in the same compilation run that defines them)
+  println(foo(2) + Macros.bar(2) * new Macros().quux(4))
+             ^
+Impls_Macros_Test_1.scala:33: error: macro implementation not found: bar
+(the most common reason for that is that you cannot use macro implementations in the same compilation run that defines them)
+  println(foo(2) + Macros.bar(2) * new Macros().quux(4))
+                             ^
 Impls_Macros_Test_1.scala:33: error: macro implementation not found: quux
 (the most common reason for that is that you cannot use macro implementations in the same compilation run that defines them)
   println(foo(2) + Macros.bar(2) * new Macros().quux(4))
                                                     ^
-one error found
+three errors found


### PR DESCRIPTION
This eliminates probably the last place where type errors are thrown
in an obvious way - reporting errors is off for whitebox macros, which
makes it pretty annoying if you are trying to understand the decision
process of implicit search (any c.abort will throw a type error rather
than simply buffering an error like in every other normal case).

As a bonus we get more messages that are reported during (failed) macro
expansion (see updated test case).
