### PR TITLE
SI-7852 for GenBCode

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
@@ -13,13 +13,12 @@ import scala.collection.{ mutable, immutable }
 import scala.collection.mutable.{ ListBuffer, Buffer }
 import scala.tools.nsc.symtab._
 import scala.annotation.switch
-import PartialFunction._
 
 /**
  *  @author  Iulian Dragos
  *  @version 1.0
  */
-abstract class GenICode extends SubComponent  {
+abstract class GenICode extends SubComponent with jvm.BCodeICodeCommon {
   import global._
   import icodes._
   import icodes.opcodes._
@@ -1325,15 +1324,6 @@ abstract class GenICode extends SubComponent  {
       case _ =>
         List(tree)
     }
-
-    /** Some useful equality helpers.
-     */
-    def isNull(t: Tree) = cond(t) { case Literal(Constant(null)) => true }
-    def isLiteral(t: Tree) = cond(t) { case Literal(_) => true }
-    def isNonNullExpr(t: Tree) = isLiteral(t) || ((t.symbol ne null) && t.symbol.isModule)
-
-    /* If l or r is constant null, returns the other ; otherwise null */
-    def ifOneIsNull(l: Tree, r: Tree) = if (isNull(l)) r else if (isNull(r)) l else null
 
     /**
      * Find the label denoted by `lsym` and enter it in context `ctx`.

--- a/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
@@ -18,7 +18,7 @@ import scala.annotation.switch
  *  @author  Iulian Dragos
  *  @version 1.0
  */
-abstract class GenICode extends SubComponent with jvm.BCodeICodeCommon {
+abstract class GenICode extends SubComponent {
   import global._
   import icodes._
   import icodes.opcodes._
@@ -28,6 +28,9 @@ abstract class GenICode extends SubComponent with jvm.BCodeICodeCommon {
     isUniversalEqualityOp, isReferenceEqualityOp
   }
   import platform.isMaybeBoxed
+
+  private val bCodeICodeCommon: jvm.BCodeICodeCommon[global.type] = new jvm.BCodeICodeCommon(global)
+  import bCodeICodeCommon._
 
   val phaseName = "icode"
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -23,6 +23,7 @@ import scala.tools.asm
 abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
   import global._
   import definitions._
+  import bCodeICodeCommon._
 
   /*
    * Functionality to build the body of ASM MethodNode, except for `synchronized` and `try` expressions.

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeGlue.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeGlue.scala
@@ -18,9 +18,11 @@ import scala.collection.{ immutable, mutable }
  *  @version 1.0
  *
  */
-abstract class BCodeGlue extends SubComponent with BCodeICodeCommon {
+abstract class BCodeGlue extends SubComponent {
 
   import global._
+
+  protected val bCodeICodeCommon: BCodeICodeCommon[global.type] = new BCodeICodeCommon(global)
 
   object BType {
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeGlue.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeGlue.scala
@@ -18,7 +18,7 @@ import scala.collection.{ immutable, mutable }
  *  @version 1.0
  *
  */
-abstract class BCodeGlue extends SubComponent {
+abstract class BCodeGlue extends SubComponent with BCodeICodeCommon {
 
   import global._
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeICodeCommon.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeICodeCommon.scala
@@ -1,0 +1,26 @@
+/* NSC -- new Scala compiler
+ * Copyright 2005-2014 LAMP/EPFL
+ * @author  Martin Odersky
+ */
+
+package scala.tools.nsc.backend.jvm
+
+import scala.tools.nsc.Global
+import PartialFunction._
+
+/**
+ * This trait contains code shared between GenBCode and GenICode that depends on types defined in
+ * the compiler cake (Global).
+ */
+trait BCodeICodeCommon {
+  val global: Global
+  import global._
+
+  /** Some useful equality helpers. */
+  def isNull(t: Tree) = cond(t) { case Literal(Constant(null)) => true }
+  def isLiteral(t: Tree) = cond(t) { case Literal(_) => true }
+  def isNonNullExpr(t: Tree) = isLiteral(t) || ((t.symbol ne null) && t.symbol.isModule)
+
+  /** If l or r is constant null, returns the other ; otherwise null */
+  def ifOneIsNull(l: Tree, r: Tree) = if (isNull(l)) r else if (isNull(r)) l else null
+}

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeICodeCommon.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeICodeCommon.scala
@@ -12,8 +12,7 @@ import PartialFunction._
  * This trait contains code shared between GenBCode and GenICode that depends on types defined in
  * the compiler cake (Global).
  */
-trait BCodeICodeCommon {
-  val global: Global
+final class BCodeICodeCommon[G <: Global](val global: G) {
   import global._
 
   /** Some useful equality helpers. */

--- a/test/files/run/t7852.scala
+++ b/test/files/run/t7852.scala
@@ -12,7 +12,7 @@ object Test extends BytecodeTest {
       val classNode = loadClassNode("Lean")
       val methodNode = getMethod(classNode, methodName)
       val got = countNullChecks(methodNode.instructions)
-      assert(got == expected, s"expected $expected but got $got comparisons")
+      assert(got == expected, s"$methodName: expected $expected but got $got comparisons")
     }
     test("string", expected = 0)
     test("module", expected = 0)


### PR DESCRIPTION
Avoid null checks for "someLiteral".== and SomeModule.==. This has
been implemented in GenICode in #2954.

Introduces a trait to share code between GenICode and GenBCode. This
is just a start, more such refactorings will come quite certainly.

Test already exists. The new `scala-nightly-genbcode-2.1X.x` nightly build
runs all tests on the new backend (that's how the difference was found).
