### PR TITLE
Make partest to depend on Scala compiler Eclipse project

### DIFF
--- a/src/eclipse/partest/.classpath
+++ b/src/eclipse/partest/.classpath
@@ -4,11 +4,11 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/asm"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/repl"/>
 	<classpathentry kind="var" path="M2_REPO/com/googlecode/java-diff-utils/diffutils/1.3.0/diffutils-1.3.0.jar"/>
-        <classpathentry kind="var" path="M2_REPO/org/scala-sbt/test-interface/1.0/test-interface-1.0.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/scala-sbt/test-interface/1.0/test-interface-1.0.jar"/>
 	<classpathentry kind="var" path="M2_REPO/org/scala-lang/modules/scala-partest_2.11.0-M7/1.0.0-RC8/scala-partest_2.11.0-M7-1.0.0-RC8.jar"/>
 	<classpathentry kind="var" path="SCALA_BASEDIR/lib/ant/ant.jar"/>
-	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
-	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_COMPILER_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/scala-compiler"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/scala-library"/>
 	<classpathentry kind="output" path="build-quick-partest-extras"/>
 </classpath>


### PR DESCRIPTION
This way changes made to Scala compiler sources are visible to partest in Eclipse.
