### PR TITLE
Refactor FastTrack to use composition instead of inheritance.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -42,13 +42,15 @@ import Fingerprint._
  *    (Expr(elems))
  *    (TypeTag(Int))
  */
-trait Macros extends FastTrack with MacroRuntimes with Traces with Helpers {
+trait Macros extends MacroRuntimes with Traces with Helpers {
   self: Analyzer =>
 
   import global._
   import definitions._
   import treeInfo.{isRepeatedParamType => _, _}
   import MacrosStats._
+
+  lazy val fastTrack = new FastTrack[self.type](self)
 
   def globalSettings = global.settings
 


### PR DESCRIPTION
Instead of mixing in FastTrack into Macros trait just have a member
with an instance of FastTrack. The motivation for this change is to reduce
the overall use of inheritance is Scala compiler and FastTrack seems like
a nice target for first step. It's an implementation detail of Scala
compiler that we are free to modify.

Previously, `fastTrack` method would be inherited from FastTrack trait and
called from clients (sub classes). The `fastTrack` method returned Map.
Now, the `fastTrack` viariable is of type `FastTrack`. In order for clients
to continue to work we had to implement three operations called by
clients: contains, apply, get.

Alternatively, we could keep the `fastTrack` method and import it in
clients. This approach is likely to be more common in the future when
bigger pieces of code get refactored.
