### PR TITLE
Disable 'unreachable' test for GenBCode

### DIFF
--- a/test/files/jvm/unreachable.flags
+++ b/test/files/jvm/unreachable.flags
@@ -1,0 +1,1 @@
+-Ybackend:GenASM


### PR DESCRIPTION
GenICode has some logic to eliminate some dead code directly at code
gen (introduced in b50a0d811f for SI-7006). This has not been ported
over to GenBCode.

GenBCode with the new optimizer (in Miguel's branch) also eliminates
such dead code. Before adding such functionality to GenBCode I'd like
to investigate the cost of running DCE. Maybe we can keep the code
generator simple.

I created SI-8568 to keep track of this.
