### PR TITLE
SI-8475 Fix off by one in GroupedIterator when Streaming

### DIFF
--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -926,7 +926,9 @@ trait Iterator[+A] extends TraversableOnce[A] {
     private def takeDestructively(size: Int): Seq[A] = {
       val buf = new ArrayBuffer[A]
       var i = 0
-      while (self.hasNext && i < size) {
+      // The order of terms in the following condition is important
+      // here as self.hasNext could be blocking
+      while (i < size && self.hasNext) {
         buf += self.next
         i += 1
       }

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -1,0 +1,20 @@
+
+package scala.collection
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class IteratorTest {
+
+  @Test
+  def groupedIteratorShouldNotAskForUnneededElement(): Unit = {
+    var counter = 0
+    val it = new Iterator[Int] { var i = 0 ; def hasNext = { counter = i; true } ; def next = { i += 1; i } }
+    val slidingIt = it sliding 2
+    slidingIt.next
+    assertEquals("Counter should be one, that means we didn't look further than needed", 1, counter)
+  }
+}


### PR DESCRIPTION
This also affected sliding and grouped since they defer to GroupedIterator
