### PR TITLE
OSGi: Restrict Import-Package for scala.*

### DIFF
--- a/build-ant-macros.xml
+++ b/build-ant-macros.xml
@@ -435,6 +435,11 @@
           <filter token="SCALA_FULL_VERSION" value="${scala.full.version}"/>
           <filter token="SCALA_COMPILER_DOC_VERSION" value="${scala-compiler-doc.version.number}"/>
           <filter token="SCALA_COMPILER_INTERACTIVE_VERSION" value="${scala-compiler-interactive.version.number}"/>
+          <filter token="XML_VERSION"                value="${scala-xml.version.number}" />
+          <filter token="PARSER_COMBINATORS_VERSION" value="${scala-parser-combinators.version.number}" />
+          <filter token="CONTINUATIONS_PLUGIN_VERSION"  value="${scala-continuations-plugin.version.number}" />
+          <filter token="CONTINUATIONS_LIBRARY_VERSION" value="${scala-continuations-library.version.number}" />
+          <filter token="SCALA_SWING_VERSION"           value="${scala-swing.version.number}" />
         </filterset>
       </copy>
       <bnd classpath="${@{project}.jar}" eclipse="false" failok="false" exceptions="true" files="${build-osgi.dir}/${@{project}.name}.bnd" output="${build-osgi.dir}"/>

--- a/src/build/bnd/scala-actors.bnd
+++ b/src/build/bnd/scala-actors.bnd
@@ -3,3 +3,5 @@ Bundle-SymbolicName: org.scala-lang.scala-actors
 ver: @VERSION@
 Bundle-Version: ${ver}
 Export-Package: *;version=${ver}
+Import-Package: scala.*;version="${range;[==,=+);${ver}}",*
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/src/build/bnd/scala-actors.bnd
+++ b/src/build/bnd/scala-actors.bnd
@@ -4,4 +4,4 @@ ver: @VERSION@
 Bundle-Version: ${ver}
 Export-Package: *;version=${ver}
 Import-Package: scala.*;version="${range;[==,=+);${ver}}",*
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6, JavaSE-1.7

--- a/src/build/bnd/scala-compiler-doc.bnd
+++ b/src/build/bnd/scala-compiler-doc.bnd
@@ -3,4 +3,6 @@ Bundle-SymbolicName: org.scala-lang.modules.scala-compiler-doc_@SCALA_BINARY_VER
 ver: @SCALA_COMPILER_DOC_VERSION@
 Bundle-Version: ${ver}
 Export-Package: *;version=${ver}
-Import-Package: *
+Import-Package: scala.*;version="${range;[==,=+);@VERSION@}",*
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+

--- a/src/build/bnd/scala-compiler-doc.bnd
+++ b/src/build/bnd/scala-compiler-doc.bnd
@@ -4,5 +4,4 @@ ver: @SCALA_COMPILER_DOC_VERSION@
 Bundle-Version: ${ver}
 Export-Package: *;version=${ver}
 Import-Package: scala.*;version="${range;[==,=+);@VERSION@}",*
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6, JavaSE-1.7

--- a/src/build/bnd/scala-compiler-interactive.bnd
+++ b/src/build/bnd/scala-compiler-interactive.bnd
@@ -3,4 +3,6 @@ Bundle-SymbolicName: org.scala-lang.modules.scala-compiler-interactive_@SCALA_BI
 ver: @SCALA_COMPILER_INTERACTIVE_VERSION@
 Bundle-Version: ${ver}
 Export-Package: *;version=${ver}
-Import-Package: *
+Import-Package: scala.*;version="${range;[==,=+);@VERSION@}",*
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+

--- a/src/build/bnd/scala-compiler-interactive.bnd
+++ b/src/build/bnd/scala-compiler-interactive.bnd
@@ -4,5 +4,4 @@ ver: @SCALA_COMPILER_INTERACTIVE_VERSION@
 Bundle-Version: ${ver}
 Export-Package: *;version=${ver}
 Import-Package: scala.*;version="${range;[==,=+);@VERSION@}",*
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6, JavaSE-1.7

--- a/src/build/bnd/scala-compiler.bnd
+++ b/src/build/bnd/scala-compiler.bnd
@@ -5,7 +5,7 @@ Bundle-Version: ${ver}
 Export-Package: *;version=${ver}
 Import-Package: jline.*;resolution:=optional, \
                 org.apache.tools.ant.*;resolution:=optional, \
-                !scala.util.parsing.*, \
+                scala.util.parsing.*;version="${range;[====,====];@PARSER_COMBINATORS_VERSION@}";resolution:=optional, \
                 scala.xml.*;version="${range;[====,====];@XML_VERSION@}";resolution:=optional, \
                 scala.*;version="${range;[==,=+);${ver}}", \
                 *

--- a/src/build/bnd/scala-compiler.bnd
+++ b/src/build/bnd/scala-compiler.bnd
@@ -9,5 +9,4 @@ Import-Package: jline.*;resolution:=optional, \
                 scala.xml.*;version="${range;[===,=+);@XML_VERSION@}", \
                 scala.*;version="${range;[==,=+);${ver}}", \
                 *
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6, JavaSE-1.7

--- a/src/build/bnd/scala-compiler.bnd
+++ b/src/build/bnd/scala-compiler.bnd
@@ -5,8 +5,8 @@ Bundle-Version: ${ver}
 Export-Package: *;version=${ver}
 Import-Package: jline.*;resolution:=optional, \
                 org.apache.tools.ant.*;resolution:=optional, \
-                scala.util.parsing.*;version="${range;[===,=+);@PARSER_COMBINATORS_VERSION@}", \
-                scala.xml.*;version="${range;[===,=+);@XML_VERSION@}", \
+                !scala.util.parsing.*, \
+                scala.xml.*;version="${range;[====,====];@XML_VERSION@}";resolution:=optional, \
                 scala.*;version="${range;[==,=+);${ver}}", \
                 *
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6, JavaSE-1.7

--- a/src/build/bnd/scala-compiler.bnd
+++ b/src/build/bnd/scala-compiler.bnd
@@ -5,4 +5,9 @@ Bundle-Version: ${ver}
 Export-Package: *;version=${ver}
 Import-Package: jline.*;resolution:=optional, \
                 org.apache.tools.ant.*;resolution:=optional, \
+                scala.util.parsing.*;version="${range;[===,=+);@PARSER_COMBINATORS_VERSION@}", \
+                scala.xml.*;version="${range;[===,=+);@XML_VERSION@}", \
+                scala.*;version="${range;[==,=+);${ver}}", \
                 *
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+

--- a/src/build/bnd/scala-continuations-library.bnd
+++ b/src/build/bnd/scala-continuations-library.bnd
@@ -1,5 +1,8 @@
 Bundle-Name: Scala Delimited Continuations Library
 Bundle-SymbolicName: org.scala-lang.plugins.scala-continuations-library
-ver: @VERSION@
+ver: @CONTINUATIONS_LIBRARY_VERSION@
 Bundle-Version: ${ver}
 Export-Package: *;version=${ver}
+Import-Package: scala.*;version="${range;[==,=+);@VERSION@}",*
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+

--- a/src/build/bnd/scala-continuations-library.bnd
+++ b/src/build/bnd/scala-continuations-library.bnd
@@ -4,5 +4,4 @@ ver: @CONTINUATIONS_LIBRARY_VERSION@
 Bundle-Version: ${ver}
 Export-Package: *;version=${ver}
 Import-Package: scala.*;version="${range;[==,=+);@VERSION@}",*
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6, JavaSE-1.7

--- a/src/build/bnd/scala-continuations-plugin.bnd
+++ b/src/build/bnd/scala-continuations-plugin.bnd
@@ -4,5 +4,4 @@ ver: @CONTINUATIONS_PLUGIN_VERSION@
 Bundle-Version: ${ver}
 Export-Package: *;version=${ver}
 Import-Package: scala.*;version="${range;[==,=+);@VERSION@}",*
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6, JavaSE-1.7

--- a/src/build/bnd/scala-continuations-plugin.bnd
+++ b/src/build/bnd/scala-continuations-plugin.bnd
@@ -1,5 +1,8 @@
 Bundle-Name: Scala Delimited Continuations Compiler Plugin
 Bundle-SymbolicName: org.scala-lang.plugins.scala-continuations-plugin
-ver: @VERSION@
+ver: @CONTINUATIONS_PLUGIN_VERSION@
 Bundle-Version: ${ver}
 Export-Package: *;version=${ver}
+Import-Package: scala.*;version="${range;[==,=+);@VERSION@}",*
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+

--- a/src/build/bnd/scala-library.bnd
+++ b/src/build/bnd/scala-library.bnd
@@ -4,5 +4,4 @@ ver: @VERSION@
 Bundle-Version: ${ver}
 Export-Package: *;version=${ver}
 Import-Package: sun.misc;resolution:=optional, *
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6, JavaSE-1.7

--- a/src/build/bnd/scala-library.bnd
+++ b/src/build/bnd/scala-library.bnd
@@ -4,3 +4,5 @@ ver: @VERSION@
 Bundle-Version: ${ver}
 Export-Package: *;version=${ver}
 Import-Package: sun.misc;resolution:=optional, *
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+

--- a/src/build/bnd/scala-parser-combinators.bnd
+++ b/src/build/bnd/scala-parser-combinators.bnd
@@ -4,5 +4,4 @@ ver: @PARSER_COMBINATORS_VERSION@
 Bundle-Version: ${ver}
 Export-Package: *;version=${ver}
 Import-Package: scala.*;version="${range;[==,=+);@VERSION@}",*
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6, JavaSE-1.7

--- a/src/build/bnd/scala-parser-combinators.bnd
+++ b/src/build/bnd/scala-parser-combinators.bnd
@@ -1,5 +1,8 @@
 Bundle-Name: Scala Parser Combinators Library
 Bundle-SymbolicName: org.scala-lang.modules.scala-parser-combinators
-ver: @VERSION@
+ver: @PARSER_COMBINATORS_VERSION@
 Bundle-Version: ${ver}
 Export-Package: *;version=${ver}
+Import-Package: scala.*;version="${range;[==,=+);@VERSION@}",*
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+

--- a/src/build/bnd/scala-reflect.bnd
+++ b/src/build/bnd/scala-reflect.bnd
@@ -6,5 +6,4 @@ Export-Package: *;version=${ver}
 Import-Package: scala.*;version="${range;[==,=+);${ver}}", \
                 scala.tools.nsc;resolution:=optional;version="${range;[==,=+);${ver}}", \
                 *
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6, JavaSE-1.7

--- a/src/build/bnd/scala-reflect.bnd
+++ b/src/build/bnd/scala-reflect.bnd
@@ -3,4 +3,8 @@ Bundle-SymbolicName: org.scala-lang.scala-reflect
 ver: @VERSION@
 Bundle-Version: ${ver}
 Export-Package: *;version=${ver}
-Import-Package: scala.tools.nsc;resolution:=optional, *
+Import-Package: scala.*;version="${range;[==,=+);${ver}}", \
+                scala.tools.nsc;resolution:=optional;version="${range;[==,=+);${ver}}", \
+                *
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+

--- a/src/build/bnd/scala-swing.bnd
+++ b/src/build/bnd/scala-swing.bnd
@@ -4,5 +4,4 @@ ver: @SCALA_SWING_VERSION@
 Bundle-Version: ${ver}
 Export-Package: *;version=${ver}
 Import-Package: scala.*;version="${range;[==,=+);@VERSION@}",*
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6,JavaSE-1.7

--- a/src/build/bnd/scala-swing.bnd
+++ b/src/build/bnd/scala-swing.bnd
@@ -1,5 +1,8 @@
 Bundle-Name: Scala Swing
 Bundle-SymbolicName: org.scala-lang.modules.scala-swing
-ver: @VERSION@
+ver: @SCALA_SWING_VERSION@
 Bundle-Version: ${ver}
 Export-Package: *;version=${ver}
+Import-Package: scala.*;version="${range;[==,=+);@VERSION@}",*
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+

--- a/src/build/bnd/scala-xml.bnd
+++ b/src/build/bnd/scala-xml.bnd
@@ -1,5 +1,8 @@
 Bundle-Name: Scala XML Library
 Bundle-SymbolicName: org.scala-lang.modules.scala-xml
-ver: @VERSION@
+ver: @XML_VERSION@
 Bundle-Version: ${ver}
 Export-Package: *;version=${ver}
+Import-Package: scala.*;version="${range;[==,=+);@VERSION@}",*
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+

--- a/src/build/bnd/scala-xml.bnd
+++ b/src/build/bnd/scala-xml.bnd
@@ -4,5 +4,4 @@ ver: @XML_VERSION@
 Bundle-Version: ${ver}
 Export-Package: *;version=${ver}
 Import-Package: scala.*;version="${range;[==,=+);@VERSION@}",*
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6, JavaSE-1.7


### PR DESCRIPTION
Restrict the Import-Package OSGi manifest entry to match only binary compatible scala.\* packages. This is necessary, because the Scala OSGi versions do not match the OSGi semantic versioning policy and are not binary compatible between their OSGi minor versions. This means that e.g. the scala-compiler-2.11 bundle will never work if it imports a scala.\* package from 2.10 or 2.12. Thus this patch enforces a tight version range, only accepting versions within the same minor version. E.g. Applied to version 2.11.1 the range would expand to "[2.11,2.12)".

This PR also enforces a Java 6/7 execution environment for the bundles.

This PR has already a discussion history as #3697
