### PR TITLE
@inline Predef.identity[A].

### DIFF
--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -126,7 +126,7 @@ object Predef extends LowPriorityImplicits with DeprecatedPredef {
   def optManifest[T](implicit m: OptManifest[T])     = m
 
   // Minor variations on identity functions
-  def identity[A](x: A): A         = x    // @see `conforms` for the implicit version
+  @inline def identity[A](x: A): A         = x    // @see `conforms` for the implicit version
   @inline def implicitly[T](implicit e: T) = e    // for summoning implicit values from the nether world -- TODO: when dependent method types are on by default, give this result type `e.type`, so that inliner has better chance of knowing which method to inline in calls like `implicitly[MatchingStrategy[Option]].zero`
   @inline def locally[T](x: T): T  = x    // to communicate intent and avoid unmoored statements
 


### PR DESCRIPTION
This is a bytecode micro-optimization, but I don't see any issues with including it.

It helps in the case of something like:

def foo(a: (A)=>A): ...

foo(identity[A] _)
# Commit text:

Since identity[A] is often used as a function directly supplied to
methods requiring (A)=>A, there's no need to have the generated
Function1 object contain an explicit call to identity[A].

This implementation isn't going to change, so let the synthetic
Function1 elide the extra call, generating just "aload_1; areturn".
