### PR TITLE
SI-8574 Copy @SerialVersionUID, etc, to specialized subclasses

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -538,6 +538,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
       bytecodeClazz.info
 
       val sClass = clazz.owner.newClass(clazzName, clazz.pos, (clazz.flags | SPECIALIZED) & ~CASE)
+      sClass.setAnnotations(clazz.annotations) // SI-8574 important that the subclass picks up @SerialVersionUID, @strictfp, etc.
 
       def cloneInSpecializedClass(member: Symbol, flagFn: Long => Long, newName: Name = null) =
         member.cloneSymbol(sClass, flagFn(member.flags | SPECIALIZED), newName)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1687,7 +1687,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
           val sameSourceFile = context.unit.source.file == psym.sourceFile
 
-          if (psym.hasDeprecatedInheritanceAnnotation && !sameSourceFile) {
+          if (!isPastTyper && psym.hasDeprecatedInheritanceAnnotation && !sameSourceFile) {
             val suffix = psym.deprecatedInheritanceMessage map (": " + _) getOrElse ""
             val msg = s"inheritance from ${psym.fullLocationString} is deprecated$suffix"
             unit.deprecationWarning(parent.pos, msg)

--- a/test/files/neg/t6162-inheritance.check
+++ b/test/files/neg/t6162-inheritance.check
@@ -7,12 +7,6 @@ object SubT extends T
 usage.scala:8: warning: inheritance from trait S in package t6126 is deprecated
   new S {
       ^
-usage.scala:3: warning: inheritance from class Foo in package t6126 is deprecated: `Foo` will be made final in a future version.
-class SubFoo extends Foo
-             ^
-usage.scala:5: warning: inheritance from trait T in package t6126 is deprecated
-object SubT extends T
-            ^
 error: No warnings can be incurred under -Xfatal-warnings.
-5 warnings found
+three warnings found
 one error found

--- a/test/files/run/t8574.scala
+++ b/test/files/run/t8574.scala
@@ -1,0 +1,27 @@
+import annotation._
+
+@SerialVersionUID(42) @strictfp class Foo[@specialized(Int) T] extends Serializable {
+  def foo(t: T) = t
+}
+
+object Test extends App {
+  def checkUID(cls: Class[_], expected: Long) = {
+    val actual = java.io.ObjectStreamClass.lookup(cls).getSerialVersionUID
+    assert(actual == expected, s"$actual != expected for ${cls}")
+  }
+  def checkStrictFp(cls: Class[_]) = {
+    import java.lang.reflect._
+    for (m <- cls.getDeclaredMethods) {
+      val isStrict = Modifier.isStrict(m.getModifiers)
+      assert(isStrict, cls)
+    }
+  }
+  def check(x: AnyRef) {
+    checkUID(x.getClass, 42)
+    checkStrictFp(x.getClass)
+  }
+
+  check(new Foo[String])
+  check(new Foo[Int])
+}
+


### PR DESCRIPTION
The test case demonstrates that this is important for serialization
and for strictfp. (Although the latter is still pretty broken,
see SI-7954.)
