### PR TITLE
SI-8553 WrappedArray throws exception on lastIndexWhere when index out of range

### DIFF
--- a/src/library/scala/collection/IndexedSeqOptimized.scala
+++ b/src/library/scala/collection/IndexedSeqOptimized.scala
@@ -206,7 +206,7 @@ trait IndexedSeqOptimized[+A, +Repr] extends Any with IndexedSeqLike[A, Repr] { 
 
   override /*SeqLike*/
   def lastIndexWhere(p: A => Boolean, end: Int): Int = {
-    var i = end
+    var i = math.min(end, length - 1)
     while (i >= 0 && !p(this(i))) i -= 1
     i
   }

--- a/test/junit/scala/collection/IndexedSeqOptimizedTest.scala
+++ b/test/junit/scala/collection/IndexedSeqOptimizedTest.scala
@@ -1,0 +1,16 @@
+package scala.collection
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Assert._
+import org.junit.Test
+
+@RunWith(classOf[JUnit4])
+class IndexedSeqOptimizedTest {
+
+  @Test
+  def notThrowsAnExceptionInLastIndexOf() {
+    assertEquals(0, (Array(2): collection.mutable.WrappedArray[Int]).lastIndexWhere(_ => true, 1))
+    assertEquals(2, "abc123".lastIndexWhere(_.isLetter, 6))
+  }
+}


### PR DESCRIPTION
Adds a check in `IndexedSeqOptimized#lastIndexWhere(A => Boolean, Int)` to begin searching in the end of the collection if `end` is greater than the collection's length.

Discussed in https://groups.google.com/d/topic/scala-internals/-MacXivbY0Q/discussion.
