### PR TITLE
SI-8589 Performance improvement for ArrayCharSequence.toString

### DIFF
--- a/src/library/scala/runtime/SeqCharSequence.scala
+++ b/src/library/scala/runtime/SeqCharSequence.scala
@@ -41,5 +41,10 @@ final class ArrayCharSequence(val xs: Array[Char], start: Int, end: Int) extends
       new ArrayCharSequence(xs, start1, start1 + newlen)
     }
   }
-  override def toString = xs drop start take length mkString ""
+  override def toString = {
+    val start = math.max(this.start, 0)
+    val end = math.min(xs.length, start + length)
+
+    if (start >= end) "" else new String(xs, start, end - start)
+  }
 }


### PR DESCRIPTION
While using a csv parser to process large char arrays i ran into the problem that the toString method of ArrayCharSequence was very slow on large buffers (and, as it appears, also on small buffers)
The problematic method:
override def toString = xs drop start take length mkString ""

I created a faster version which is already almost 50% faster on an empty charsequence and only becomes relatively faster when the array gets bigger.

See https://issues.scala-lang.org/browse/SI-8589
