### PR TITLE
List extends scala.Serializable

### DIFF
--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -85,7 +85,7 @@ sealed abstract class List[+A] extends AbstractSeq[A]
                                   with Product
                                   with GenericTraversableTemplate[A, List]
                                   with LinearSeqOptimized[A, List[A]]
-                                  with Serializable {
+                                  with scala.Serializable {
   override def companion: GenericCompanion[List] = List
 
   import scala.collection.{Iterable, Traversable, Seq, IndexedSeq}


### PR DESCRIPTION
List should extend scala.Serializable, not java.io.Serializable. Because of `import java.io._` java.io.Serializable has higher priority than scala.Serializable which is not good (Personally I found this problem not being able to pass List as an argument of type scala.Serializable). 

This is clearly a bug.
