### PR TITLE
SI-8599 Improve type variable inference in nested matches

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1121,17 +1121,14 @@ trait Infer extends Checkable {
              |      saved  ${enclCase.savedTypeBounds}
              |     tparam  ${tparam.shortSymbolClass} ${tparam.defString}
              |}""")
-      val lo2 = if (lo1 <:< lo0) lo1 else lo0
-      val hi2 = if (hi0 <:< hi1) hi0 else hi1
-      val tb2 = TypeBounds(lo2, hi2)
-
+      val tb2 = tb0 union tb
       if (tb2 =:= tb0) // bounds unimproved
-        log(s"redundant bounds: discarding TypeBounds($lo1, $hi1) for $tparam, no improvement on TypeBounds($lo0, $hi0)")
-      else if (tparam == lo1.typeSymbolDirect || tparam == hi1.typeSymbolDirect)
+        log(s"redundant bounds: discarding TypeBounds($lo2, $hi2) for $tparam, no improvement on TypeBounds($lo0, $hi0)")
+      else if (tparam == lo2.typeSymbolDirect || tparam == hi2.typeSymbolDirect)
         log(s"cyclical bounds: discarding TypeBounds($lo1, $hi1) for $tparam because $tparam appears as bounds")
       else {
         enclCase pushTypeBounds tparam
-        tparam setInfo logResult(s"updated bounds: $tparam from ${tparam.info} to")(tb)
+        tparam setInfo logResult(s"updated bounds: $tparam from ${tparam.info} to")(tb2)
       }
     }
 

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1109,11 +1109,11 @@ trait Infer extends Checkable {
     // (see #3692, where the type param T's bounds were set to > : T <: T, so that parts looped)
     // the changes are rolled back by restoreTypeBounds, but might be unintentially observed in the mean time
     def instantiateTypeVar(tvar: TypeVar) {
-      val tparam                    = tvar.origin.typeSymbol
-      val TypeBounds(lo0, hi0)      = tparam.info.bounds
-      val tb @ TypeBounds(lo1, hi1) = instBounds(tvar)
-      val enclCase                  = context.enclosingCaseDef
-      def enclCase_s                = enclCase.toString.replaceAll("\\n", " ").take(60)
+      val tparam                     = tvar.origin.typeSymbol
+      val tb0 @ TypeBounds(lo0, hi0) = tparam.info.bounds
+      val tb @ TypeBounds(lo1, hi1)  = instBounds(tvar)
+      val enclCase                   = context.enclosingCaseDef
+      def enclCase_s                 = enclCase.toString.replaceAll("\\n", " ").take(60)
 
       if (enclCase.savedTypeBounds.nonEmpty) log(
         sm"""|instantiateTypeVar with nonEmpty saved type bounds {
@@ -1121,18 +1121,18 @@ trait Infer extends Checkable {
              |      saved  ${enclCase.savedTypeBounds}
              |     tparam  ${tparam.shortSymbolClass} ${tparam.defString}
              |}""")
+      val lo2 = if (lo1 <:< lo0) lo1 else lo0
+      val hi2 = if (hi0 <:< hi1) hi0 else hi1
+      val tb2 = TypeBounds(lo2, hi2)
 
-      if (lo1 <:< hi1) {
-        if (lo1 <:< lo0 && hi0 <:< hi1) // bounds unimproved
-          log(s"redundant bounds: discarding TypeBounds($lo1, $hi1) for $tparam, no improvement on TypeBounds($lo0, $hi0)")
-        else if (tparam == lo1.typeSymbolDirect || tparam == hi1.typeSymbolDirect)
-          log(s"cyclical bounds: discarding TypeBounds($lo1, $hi1) for $tparam because $tparam appears as bounds")
-        else {
-          enclCase pushTypeBounds tparam
-          tparam setInfo logResult(s"updated bounds: $tparam from ${tparam.info} to")(tb)
-        }
+      if (tb2 =:= tb0) // bounds unimproved
+        log(s"redundant bounds: discarding TypeBounds($lo1, $hi1) for $tparam, no improvement on TypeBounds($lo0, $hi0)")
+      else if (tparam == lo1.typeSymbolDirect || tparam == hi1.typeSymbolDirect)
+        log(s"cyclical bounds: discarding TypeBounds($lo1, $hi1) for $tparam because $tparam appears as bounds")
+      else {
+        enclCase pushTypeBounds tparam
+        tparam setInfo logResult(s"updated bounds: $tparam from ${tparam.info} to")(tb)
       }
-      else log(s"inconsistent bounds: discarding TypeBounds($lo1, $hi1)")
     }
 
     /** Type intersection of simple type tp1 with general type tp2.

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1299,6 +1299,11 @@ trait Types
     private def emptyLowerBound = typeIsNothing(lo) || lo.isWildcard
     private def emptyUpperBound = typeIsAny(hi) || hi.isWildcard
     def isEmptyBounds = emptyLowerBound && emptyUpperBound
+    def union(other: TypeBounds) =
+      TypeBounds(
+        if (other.lo <:< lo) other.lo else lo,
+        if (hi <:< other.hi) other.hi else hi
+      )
 
     override def safeToString = scalaNotation(_.toString)
 

--- a/test/files/pos/t8599.scala
+++ b/test/files/pos/t8599.scala
@@ -1,0 +1,25 @@
+object RefinementTest {
+  sealed trait Grandparent[A]
+  sealed trait Parent[A] extends Grandparent[A]
+  case class Child[C](c: (C, C)) extends Parent[(C, C)]
+
+  def extractParent[A](parent: Parent[A]): A = parent match {
+    case child: Child[c] => child.c
+  }
+
+  // Fails
+  def extractGrandparent1[A](grandparent: Grandparent[A]): A = grandparent match {
+    case parent: Parent[a] =>
+      parent match {
+        //     Error: type mismatch;
+        //     found   : (c, c)
+        //     required: a
+        case child: Child[c] => child.c: a
+      }
+  }
+
+  // Works
+  def extractGrandparent2[A](grandparent: Grandparent[A]): A = grandparent match {
+    case parent: Parent[a] => extractParent(parent)
+  }
+}


### PR DESCRIPTION
Refine the upper and lower bounds independentally, rather than
bailing out if `!(lo1 <:< hi1)`.

Before, the enclosed test case traced out as follows:

```
inferTypedPattern
-----------------------------------
pattpt   = RefinementTest.Child[c]
pt       = RefinementTest.Parent[a]
ptparams = [type a]
ptvars   = [=?(?c, ?c)]
ptvars foreach instantiateTypeVar

  instantiateTypeVar
  -----------------------------------
  tvar  = =?(?c, ?c)
  tb0   =  >: A <: A
  instBounds(tvar)

    instBounds
    -----------------------------------
    loBounds   = [(c, c)]
    hiBounds   = [(c, c)]
    tparam     = type a
    val TypeBounds(lo, hi) = tparam.info.bounds
    lo         = A
    hi         = A
    lub(A :: (c, c) :: Nil) = Any
    glb(A :: (c, c) :: Nil) = A with (c, c)
    result = >: Any <: A with (c, c)

  lo1   = Any
  hi1   = A with (c, c)
  if (! (lo1 <:< hi1) )
   log(s"inconsistent bounds: discarding TypeBounds($lo1, $hi1)")
```

So because we haven't yet refined the info of `a`, it still appears
distinct from `(c, c)`, and the LUB is `Any`. Based on this, we
don't proceed to refine the type.

This commit changes the process to individually retain or discard
the low and high bounds, which is enough to tie the knot here.
