### PR TITLE
SI-8601 Reining back over-eager optimizations.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/opt/ClosureElimination.scala
+++ b/src/compiler/scala/tools/nsc/backend/opt/ClosureElimination.scala
@@ -56,11 +56,10 @@ abstract class ClosureElimination extends SubComponent {
       case (BOX(t1), UNBOX(t2)) if (t1 == t2) =>
         Some(Nil)
 
-      case (LOAD_FIELD(sym, isStatic), DROP(_)) if !sym.hasAnnotation(definitions.VolatileAttr) =>
-        if (isStatic)
-          Some(Nil)
-        else
-          Some(DROP(REFERENCE(definitions.ObjectClass)) :: Nil)
+      // Can't eliminate (LOAD_FIELD, DROP) without eliding side effects:
+      //  - static class initialization
+      //  - NPE if the receiver is null
+      // We could replace the LOAD/DROP with a null check to preserve semantics.
 
       case _ => None
     }

--- a/src/compiler/scala/tools/nsc/backend/opt/DeadCodeElimination.scala
+++ b/src/compiler/scala/tools/nsc/backend/opt/DeadCodeElimination.scala
@@ -169,7 +169,7 @@ abstract class DeadCodeElimination extends SubComponent {
 
             case RETURN(_) | JUMP(_) | CJUMP(_, _, _, _) | CZJUMP(_, _, _, _) | STORE_FIELD(_, _) | LOAD_FIELD(_, _) | // Why LOAD_FIELD? It can NPE!
                  THROW(_)   | LOAD_ARRAY_ITEM(_) | STORE_ARRAY_ITEM(_) | SCOPE_ENTER(_) | SCOPE_EXIT(_) | STORE_THIS(_) |
-                 LOAD_EXCEPTION(_) | SWITCH(_, _) | MONITOR_ENTER() | MONITOR_EXIT() | CHECK_CAST(_) =>
+                 LOAD_EXCEPTION(_) | SWITCH(_, _) | MONITOR_ENTER() | MONITOR_EXIT() | CHECK_CAST(_) | CREATE_ARRAY(_, _) =>
               moveToWorkList()
 
             case CALL_METHOD(m1, _) if isSideEffecting(m1) =>

--- a/src/compiler/scala/tools/nsc/backend/opt/DeadCodeElimination.scala
+++ b/src/compiler/scala/tools/nsc/backend/opt/DeadCodeElimination.scala
@@ -167,7 +167,7 @@ abstract class DeadCodeElimination extends SubComponent {
               set += idx
               localStores(key) = set
 
-            case RETURN(_) | JUMP(_) | CJUMP(_, _, _, _) | CZJUMP(_, _, _, _) | STORE_FIELD(_, _) |
+            case RETURN(_) | JUMP(_) | CJUMP(_, _, _, _) | CZJUMP(_, _, _, _) | STORE_FIELD(_, _) | LOAD_FIELD(_, _) | // Why LOAD_FIELD? It can NPE!
                  THROW(_)   | LOAD_ARRAY_ITEM(_) | STORE_ARRAY_ITEM(_) | SCOPE_ENTER(_) | SCOPE_EXIT(_) | STORE_THIS(_) |
                  LOAD_EXCEPTION(_) | SWITCH(_, _) | MONITOR_ENTER() | MONITOR_EXIT() | CHECK_CAST(_) =>
               moveToWorkList()

--- a/src/compiler/scala/tools/nsc/backend/opt/DeadCodeElimination.scala
+++ b/src/compiler/scala/tools/nsc/backend/opt/DeadCodeElimination.scala
@@ -193,6 +193,8 @@ abstract class DeadCodeElimination extends SubComponent {
               moveToWorkListIf(necessary)
             case LOAD_MODULE(sym) if isLoadNeeded(sym) =>
               moveToWorkList() // SI-4859 Module initialization might side-effect.
+            case CALL_PRIMITIVE(Arithmetic(DIV | REM, INT | LONG) | ArrayLength(_)) =>
+              moveToWorkList() // SI-8601 Might divide by zero
             case _ => ()
               moveToWorkListIf(cond = false)
           }

--- a/test/files/run/t8601.flags
+++ b/test/files/run/t8601.flags
@@ -1,0 +1,1 @@
+-optimize

--- a/test/files/run/t8601.scala
+++ b/test/files/run/t8601.scala
@@ -1,0 +1,15 @@
+object Test {
+  def idiv(x: Int): Unit = x / 0
+  def ldiv(x: Long): Unit = x / 0
+  def irem(x: Int): Unit = x % 0
+  def lrem(x: Long): Unit = x % 0
+
+  def check(x: => Any) = try { x; sys.error("failed to throw divide by zero!") } catch { case _: ArithmeticException => }
+
+  def main(args: Array[String]) {
+    check(idiv(1))
+    check(ldiv(1L))
+    check(irem(1))
+    check(lrem(1L))
+  }
+}

--- a/test/files/run/t8601b.flags
+++ b/test/files/run/t8601b.flags
@@ -1,0 +1,1 @@
+-optimize

--- a/test/files/run/t8601b.scala
+++ b/test/files/run/t8601b.scala
@@ -1,0 +1,9 @@
+object Test {
+  def len(x: Array[String]): Unit = x.length
+
+  def check(x: => Any) = try { x; sys.error("failed to throw NPE!") } catch { case _: NullPointerException => }
+
+  def main(args: Array[String]) {
+    check(len(null))
+  }
+}

--- a/test/files/run/t8601b.scala
+++ b/test/files/run/t8601b.scala
@@ -1,11 +1,14 @@
 object Test {
   def len(x: Array[String]): Unit = x.length
   def load(x: Array[String]): Unit = x(0)
+  def newarray(i: Int): Unit = new Array[Int](i)
 
   def check(x: => Any) = try { x; sys.error("failed to throw NPE!") } catch { case _: NullPointerException => }
+  def checkNegSize(x: => Any) = try { x; sys.error("failed to throw NegativeArraySizeException!") } catch { case _: NegativeArraySizeException => }
 
   def main(args: Array[String]) {
     check(len(null)) // bug: did not NPE
     check(load(null))
+    checkNegSize(newarray(-1))
   }
 }

--- a/test/files/run/t8601b.scala
+++ b/test/files/run/t8601b.scala
@@ -1,9 +1,11 @@
 object Test {
   def len(x: Array[String]): Unit = x.length
+  def load(x: Array[String]): Unit = x(0)
 
   def check(x: => Any) = try { x; sys.error("failed to throw NPE!") } catch { case _: NullPointerException => }
 
   def main(args: Array[String]) {
-    check(len(null))
+    check(len(null)) // bug: did not NPE
+    check(load(null))
   }
 }

--- a/test/files/run/t8601c.flags
+++ b/test/files/run/t8601c.flags
@@ -1,0 +1,1 @@
+-optimize

--- a/test/files/run/t8601c.scala
+++ b/test/files/run/t8601c.scala
@@ -1,0 +1,12 @@
+object Test {
+  def loadField(x: scala.runtime.IntRef): Unit = x.elem
+  def storeField(x: scala.runtime.IntRef): Unit = x.elem = 42
+
+  def check(x: => Any) = try { x; sys.error("failed to throw NPE!") } catch { case _: NullPointerException => }
+
+  def main(args: Array[String]) {
+    check(loadField(null)) // bug: did not NPE under -Ydead-code
+    check(storeField(null))
+
+  }
+}

--- a/test/files/run/t8601d.flags
+++ b/test/files/run/t8601d.flags
@@ -1,0 +1,1 @@
+-optimize

--- a/test/files/run/t8601d.scala
+++ b/test/files/run/t8601d.scala
@@ -1,0 +1,8 @@
+object Test {
+  def monitor(x: AnyRef): Unit = {x.synchronized(()); ()}
+  def check(x: => Any) = try { x; sys.error("failed to throw NPE") } catch { case _: NullPointerException => }
+
+  def main(args: Array[String]) {
+    check(monitor(null))
+  }
+}


### PR DESCRIPTION
This started when I found a failing test in a run of the
community build with `-optimize`. That test intentionally
triggered `1/x` with `x == 0` to test error handling, but
this was eliminated by `-Ydead-code`.

I then went through the rest of the JVM instruction set
and found more bugs of the same category.

The deletion of the peephole optimization of `[LOAD_FIELD, DROP]`
is worth discussion here.
