### PR TITLE
SI-8507 Avoid lazy val in StringContext

### DIFF
--- a/test/junit/scala/StringContextTest.scala
+++ b/test/junit/scala/StringContextTest.scala
@@ -1,0 +1,51 @@
+
+package scala
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.tools.testing.AssertUtil._
+
+@RunWith(classOf[JUnit4])
+class StringContextTest {
+
+  import StringContext._
+
+  @Test def noEscape() = {
+    val s = "string"
+    val res = processEscapes(s)
+    assertEquals(s, res)
+  }
+  @Test def tabbed() = {
+    val s = """a\tb"""
+    val res = processEscapes(s)
+    assertEquals("a\tb", res)
+  }
+  @Test def quoted() = {
+    val s = """hello, \"world\""""
+    val res = processEscapes(s)
+    assertEquals("""hello, "world"""", res)
+  }
+  @Test def octal() = {
+    val s = """\123cala"""
+    val res = treatEscapes(s)
+    assertEquals("Scala", res)
+  }
+  @Test def doubled() = {
+    val s = """\123cala\123yntax"""
+    val res = treatEscapes(s)
+    assertEquals("ScalaSyntax", res)
+  }
+  @Test def badly() = assertThrows[InvalidEscapeException] {
+    val s = """Scala\"""
+    val res = treatEscapes(s)
+    assertEquals("Scala", res)
+  }
+  @Test def noOctal() = assertThrows[InvalidEscapeException] {
+    val s = """\123cala"""
+    val res = processEscapes(s)
+    assertEquals("Scala", res)
+  }
+}


### PR DESCRIPTION
This mild refactor eliminates the lazy val StringBuilder
and arguably makes the code easier to read.

There is a small unit test but no benchmark to prove
anything useful about performance. The ticket notes
contention due to lazy implementation.

This is the first commit from #3695. 

Review by @retronym 
