### PR TITLE
Bump akka-actor version to 2.3.3 (ref SI-8549)

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -22,7 +22,7 @@ scala-parser-combinators.version.number=1.0.1
 scala-continuations-plugin.version.number=1.0.1
 scala-continuations-library.version.number=1.0.1
 scala-swing.version.number=1.0.1
-akka-actor.version.number=2.3.2
+akka-actor.version.number=2.3.3
 actors-migration.version.number=1.1.0
 
 # external modules, used internally (not shipped)


### PR DESCRIPTION
Because serialization affected akka, we're upgrading the included
akka-actor to 2.3.3, which is built with Scala 2.11.1.

Review by @retronym
