### PR TITLE
SI-8597 Issue an elusive unchecked warning

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -781,6 +781,10 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     final def isDefinedInPackage  = effectiveOwner.isPackageClass
     final def needsFlatClasses    = phase.flatClasses && rawowner != NoSymbol && !rawowner.isPackageClass
 
+    // TODO introduce a flag for these?
+    final def isPatternTypeVariable: Boolean =
+      isAbstractType && !isExistential && !isTypeParameterOrSkolem && isLocalToBlock
+
     /** change name by appending $$<fully-qualified-name-of-class `base`>
      *  Do the same for any accessed symbols or setters/getters.
      *  Implementation in TermSymbol.

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -780,6 +780,7 @@ trait Types
       }
     }
 
+
     /** Is this type a subtype of that type in a pattern context?
      *  Dummy type arguments on the right hand side are replaced with
      *  fresh existentials, except for Arrays.
@@ -793,8 +794,9 @@ trait Types
           case ArrayTypeRef(elem1) => elem1 matchesPattern elem2
           case _                   => false
         }
-      case TypeRef(_, sym, args) =>
+      case TypeRef(pre, sym, args) =>
         val that1 = existentialAbstraction(args map (_.typeSymbol), that)
+
         (that ne that1) && (this <:< that1) && {
           debuglog(s"$this.matchesPattern($that) depended on discarding args and testing <:< $that1")
           true
@@ -2750,6 +2752,7 @@ trait Types
   }
 
   object ArrayTypeRef {
+    def apply(arg: Type): Type = TypeRef(NoPrefix, ArrayClass, arg :: Nil)
     def unapply(tp: Type) = tp match {
       case TypeRef(_, ArrayClass, arg :: Nil) => Some(arg)
       case _                                  => None

--- a/test/files/neg/t8597.check
+++ b/test/files/neg/t8597.check
@@ -1,0 +1,21 @@
+t8597.scala:2: warning: abstract type T in type pattern Some[T] is unchecked since it is eliminated by erasure
+  def nowarn[T] = (null: Any) match { case _: Some[T]      => }  // SI-8597 no unchecked warning here
+                                              ^
+t8597.scala:5: warning: abstract type pattern T is unchecked since it is eliminated by erasure
+  def warn1[T]  = (null: Any) match { case _: T            => }
+                                              ^
+t8597.scala:6: warning: non-variable type argument String in type pattern Some[String] is unchecked since it is eliminated by erasure
+  def warn2     = (null: Any) match { case _: Some[String] => }
+                                              ^
+t8597.scala:7: warning: non-variable type argument Unchecked.this.C in type pattern Some[Unchecked.this.C] is unchecked since it is eliminated by erasure
+                  (null: Any) match { case _: Some[C]      => }
+                                              ^
+t8597.scala:18: warning: abstract type T in type pattern Array[T] is unchecked since it is eliminated by erasure
+  def nowarnArray[T] = (null: Any) match { case _: Array[T] => } // did not warn
+                                                   ^
+t8597.scala:26: warning: non-variable type argument String in type pattern Array[Array[List[String]]] is unchecked since it is eliminated by erasure
+  def warnArrayErasure2   = (null: Any) match {case Some(_: Array[Array[List[String]]]) => }
+                                                            ^
+error: No warnings can be incurred under -Xfatal-warnings.
+6 warnings found
+one error found

--- a/test/files/neg/t8597.flags
+++ b/test/files/neg/t8597.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/t8597.scala
+++ b/test/files/neg/t8597.scala
@@ -1,0 +1,27 @@
+class Unchecked[C] {
+  def nowarn[T] = (null: Any) match { case _: Some[T]      => }  // SI-8597 no unchecked warning here
+
+  // These warned before.
+  def warn1[T]  = (null: Any) match { case _: T            => }
+  def warn2     = (null: Any) match { case _: Some[String] => }
+                  (null: Any) match { case _: Some[C]      => }
+
+  // These must remain without warnings. These are excerpts from
+  // related tests that are more exhauative.
+  class C; class D extends C
+  def okay      = (List(new D) : Seq[D]) match { case _: List[C] => case _ => }
+  class B2[A, B]
+  class A2[X] extends B2[X, String]
+  def okay2(x: A2[Int]) = x match { case _: B2[Int, _] => true }
+  def okay3(x: A2[Int]) = x match { case _: B2[Int, typeVar] => true }
+
+  def nowarnArray[T] = (null: Any) match { case _: Array[T] => } // did not warn
+  def nowarnArrayC   = (null: Any) match { case _: Array[C] => } // did not warn
+
+  def nowarnArrayTypeVar[T] = (null: Any) match { case _: Array[t] => } // should not warn
+
+  def noWarnArrayErasure1 = (null: Any) match {case Some(_: Array[String]) => }
+  def noWarnArrayErasure2 = (null: Any) match {case Some(_: Array[List[_]]) => }
+  def noWarnArrayErasure3 = (null: Any) match {case Some(_: Array[Array[List[_]]]) => }
+  def warnArrayErasure2   = (null: Any) match {case Some(_: Array[Array[List[String]]]) => }
+}

--- a/test/files/neg/t8597b.check
+++ b/test/files/neg/t8597b.check
@@ -1,0 +1,6 @@
+t8597b.scala:18: warning: non-variable type argument T in type pattern Some[T] is unchecked since it is eliminated by erasure
+        case _: Some[T] =>
+                ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/t8597b.flags
+++ b/test/files/neg/t8597b.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/t8597b.scala
+++ b/test/files/neg/t8597b.scala
@@ -1,0 +1,21 @@
+object Unchecked {
+  (null: Any) match {
+    case _: Some[t] =>
+
+      // t is a fresh pattern type variable, despite our attempts to
+      // backtick our way to the enclosing `t`. Under this interpretation,
+      // the absense of an uchecked warning is expected.
+      (null: Any) match {
+        case _: Some[t] =>
+      }
+      (null: Any) match {
+        case _: Some[`t`] =>
+      }
+
+      // here we correctly issue an unchecked warning
+      type T = t
+      (null: Any) match {
+        case _: Some[T] =>
+      }
+  }
+}

--- a/test/files/neg/unchecked-abstract.check
+++ b/test/files/neg/unchecked-abstract.check
@@ -4,6 +4,9 @@ unchecked-abstract.scala:16: warning: abstract type H in type Contravariant[M.th
 unchecked-abstract.scala:21: warning: abstract type H in type Contravariant[M.this.H] is unchecked since it is eliminated by erasure
     /*   warn */ println(x.isInstanceOf[Contravariant[H]])
                                        ^
+unchecked-abstract.scala:22: warning: abstract type T in type Contravariant[M.this.T] is unchecked since it is eliminated by erasure
+    /*   warn */ println(x.isInstanceOf[Contravariant[T]])
+                                       ^
 unchecked-abstract.scala:27: warning: abstract type T in type Invariant[M.this.T] is unchecked since it is eliminated by erasure
     /*   warn */ println(x.isInstanceOf[Invariant[T]])
                                        ^
@@ -22,6 +25,15 @@ unchecked-abstract.scala:36: warning: abstract type H in type Invariant[M.this.H
 unchecked-abstract.scala:37: warning: abstract type T in type Invariant[M.this.T] is unchecked since it is eliminated by erasure
     /*   warn */ println(x.isInstanceOf[Invariant[T]])
                                        ^
+unchecked-abstract.scala:42: warning: abstract type T in type Covariant[M.this.T] is unchecked since it is eliminated by erasure
+    /*   warn */ println(x.isInstanceOf[Covariant[T]])
+                                       ^
+unchecked-abstract.scala:43: warning: abstract type L in type Covariant[M.this.L] is unchecked since it is eliminated by erasure
+    /*   warn */ println(x.isInstanceOf[Covariant[L]])
+                                       ^
+unchecked-abstract.scala:48: warning: abstract type L in type Covariant[M.this.L] is unchecked since it is eliminated by erasure
+    /*   warn */ println(x.isInstanceOf[Covariant[L]])
+                                       ^
 error: No warnings can be incurred under -Xfatal-warnings.
-8 warnings found
+12 warnings found
 one error found


### PR DESCRIPTION
For:

``` scala
def nowarn[T] = (null: Any) match { case _: Some[T] => }
```

Review by @adriaanm. I'll be out your way on Wedsneday, let's
run through this together then.

See also a followup issue that I lodged as SI-8604.
