### PR TITLE
SI-8608 f interpolator emits plain old strings

### DIFF
--- a/src/compiler/scala/tools/reflect/FormatInterpolator.scala
+++ b/src/compiler/scala/tools/reflect/FormatInterpolator.scala
@@ -183,11 +183,13 @@ abstract class FormatInterpolator {
     }
 
     //q"{..$evals; ${fstring.toString}.format(..$ids)}"
-    locally {
+    val format = fstring.toString
+    if (ids.isEmpty && !format.contains("%")) Literal(Constant(format))
+    else {
       val expr =
         Apply(
           Select(
-            Literal(Constant(fstring.toString)),
+            Literal(Constant(format)),
             newTermName("format")),
           ids.toList
         )

--- a/test/files/run/stringinterpolation_macro-run.check
+++ b/test/files/run/stringinterpolation_macro-run.check
@@ -63,5 +63,9 @@ She is 4 feet tall.
 05/26/12
 05/26/12
 %
+ mind
+------
+matter
+
 7 7 9
 7 9 9

--- a/test/files/run/stringinterpolation_macro-run.scala
+++ b/test/files/run/stringinterpolation_macro-run.scala
@@ -115,6 +115,7 @@ println(f"""${"1234"}%TD""")
 
 // literals and arg indexes
 println(f"%%")
+println(f" mind%n------%nmatter%n")
 println(f"${7}%d %<d ${9}%d")
 println(f"${7}%d %2$$d ${9}%d")
 

--- a/test/files/run/t8608-no-format.scala
+++ b/test/files/run/t8608-no-format.scala
@@ -1,0 +1,15 @@
+
+import scala.tools.partest.JavapTest
+
+object Test extends JavapTest {
+  def code = """
+    |f"hello, world"
+    |:javap -prv -
+  """.stripMargin
+
+  // no format
+  override def yah(res: Seq[String]) = {
+    // note: avoid the word "information"
+    res forall (!_.contains("StringOps.format"))
+  }
+}


### PR DESCRIPTION
When invoking `format` is obviated by a lack of
formatting fields, then just degenerate to an
unenhanced string.

This means it doesn't cost anything to use
f"$$ordinary" in place of "$ordinary", which
may cause warnings under -Xlint.

Note that certain format literals, in particular
for line separator %n, are not actually literals and
can't be replaced at compile time.

Review by @xeno-by for macro expertise
