### PR TITLE
SI-8609 Fix flattening of definitions and imports in quasiquotes 

### DIFF
--- a/src/reflect/scala/reflect/internal/ReificationSupport.scala
+++ b/src/reflect/scala/reflect/internal/ReificationSupport.scala
@@ -97,6 +97,8 @@ trait ReificationSupport { self: SymbolTable =>
     def toStats(tree: Tree): List[Tree] = tree match {
       case EmptyTree             => Nil
       case SyntacticBlock(stats) => stats
+      case defn if defn.isDef    => defn :: Nil
+      case imp: Import           => imp :: Nil
       case _                     => throw new IllegalArgumentException(s"can't flatten $tree")
     }
 

--- a/test/files/scalacheck/quasiquotes/TermConstructionProps.scala
+++ b/test/files/scalacheck/quasiquotes/TermConstructionProps.scala
@@ -310,4 +310,16 @@ object TermConstructionProps extends QuasiquoteProperties("term construction") {
     val cases = List(cq"a => b", cq"c => d")
     assertEqAst(q"{ case ..$cases }", "{ case a => b case c => d }")
   }
+
+  property("SI-8609 a") = test {
+    val q1 = q"val x = 1"
+    val q2 = q"..$q1; val y = 2"
+    assert(q2 ≈ q"{ val x = 1; val y = 2 }")
+  }
+
+  property("SI-8609 b") = test {
+    val q1 = q"import foo.bar"
+    val q2 = q"..$q1; val y = 2"
+    assert(q2 ≈ q"{ import foo.bar; val y = 2 }")
+  }
 }


### PR DESCRIPTION
Quasiquotes allow to unquote trees with ..$ with block flattening
semantics to simplify composition:

```
  val onetwo = q"1; 2"
  val onetwothree = q"..$onetwo; 3" // same as q"1; 2; 3"
```

If there is no block it will be equivalent to $ unquoting:

```
  val one = q"1"
  val onetwo = q"..$one; 2" // same as q"1; 2"
```

But the inconsistency here is that currently only terms support
this single-element semantics. This commit extends this functionality
to also support definitions and imports. So that following code works:

```
  val q1 = q"val x = 1"
  val q2 = q"..$q1; val y = 2" // same as q"val x = 1; val y = 2"
```

review @retronym @xeno-by
