### PR TITLE
SI-8610 -Xlint is multichoice option

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/AbsScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/AbsScalaSettings.scala
@@ -29,7 +29,7 @@ trait AbsScalaSettings {
   def ChoiceSetting(name: String, helpArg: String, descr: String, choices: List[String], default: String): ChoiceSetting
   def IntSetting(name: String, descr: String, default: Int, range: Option[(Int, Int)], parser: String => Option[Int]): IntSetting
   def MultiStringSetting(name: String, helpArg: String, descr: String): MultiStringSetting
-  def MultiChoiceSetting(name: String, helpArg: String, descr: String, choices: List[String]): MultiChoiceSetting
+  def MultiChoiceSetting(name: String, helpArg: String, descr: String, choices: List[String], default: () => Unit): MultiChoiceSetting
   def OutputSetting(outputDirs: OutputDirs, default: String): OutputSetting
   def PathSetting(name: String, descr: String, default: String): PathSetting
   def PhasesSetting(name: String, descr: String, default: String): PhasesSetting

--- a/test/files/neg/t8610-arg.check
+++ b/test/files/neg/t8610-arg.check
@@ -1,0 +1,9 @@
+t8610-arg.scala:3: warning: `$name` looks like an interpolated identifier! Did you forget the interpolator?
+  def x = "Hi, $name"   // missing interp
+          ^
+t8610-arg.scala:6: warning: side-effecting nullary methods are discouraged: suggest defining as `def u()` instead
+  def u: Unit = ()      // unitarian universalist
+      ^
+error: No warnings can be incurred under -Xfatal-warnings.
+two warnings found
+one error found

--- a/test/files/neg/t8610-arg.flags
+++ b/test/files/neg/t8610-arg.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -Xlint warn-nullary-unit

--- a/test/files/neg/t8610-arg.scala
+++ b/test/files/neg/t8610-arg.scala
@@ -1,0 +1,7 @@
+
+case class X(name: String) {
+  def x = "Hi, $name"   // missing interp
+  def f(p: (Int, Int)): Int = p._1 * p._2
+  def g = f(3, 4)       // adapted
+  def u: Unit = ()      // unitarian universalist
+}

--- a/test/files/neg/t8610.check
+++ b/test/files/neg/t8610.check
@@ -1,0 +1,15 @@
+t8610.scala:3: warning: `$name` looks like an interpolated identifier! Did you forget the interpolator?
+  def x = "Hi, $name"   // missing interp
+          ^
+t8610.scala:5: warning: Adapting argument list by creating a 2-tuple: this may not be what you want.
+        signature: X.f(p: (Int, Int)): Int
+  given arguments: 3, 4
+ after adaptation: X.f((3, 4): (Int, Int))
+  def g = f(3, 4)       // adapted
+           ^
+t8610.scala:6: warning: side-effecting nullary methods are discouraged: suggest defining as `def u()` instead
+  def u: Unit = ()      // unitarian universalist
+      ^
+error: No warnings can be incurred under -Xfatal-warnings.
+three warnings found
+one error found

--- a/test/files/neg/t8610.flags
+++ b/test/files/neg/t8610.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -Xlint

--- a/test/files/neg/t8610.scala
+++ b/test/files/neg/t8610.scala
@@ -1,0 +1,7 @@
+
+case class X(name: String) {
+  def x = "Hi, $name"   // missing interp
+  def f(p: (Int, Int)): Int = p._1 * p._2
+  def g = f(3, 4)       // adapted
+  def u: Unit = ()      // unitarian universalist
+}

--- a/test/files/run/t8610.check
+++ b/test/files/run/t8610.check
@@ -1,0 +1,10 @@
+t8610.scala:4: warning: `$name` looks like an interpolated identifier! Did you forget the interpolator?
+  def x = "Hi, $name"   // missing interp
+          ^
+t8610.scala:6: warning: Adapting argument list by creating a 2-tuple: this may not be what you want.
+        signature: X.f(p: (Int, Int)): Int
+  given arguments: 3, 4
+ after adaptation: X.f((3, 4): (Int, Int))
+  def g = f(3, 4)       // adapted
+           ^
+Hi, $name

--- a/test/files/run/t8610.flags
+++ b/test/files/run/t8610.flags
@@ -1,0 +1,1 @@
+-Xlint:warn-adapted-args

--- a/test/files/run/t8610.scala
+++ b/test/files/run/t8610.scala
@@ -1,0 +1,13 @@
+
+// flags don't warn on u
+case class X(name: String) {
+  def x = "Hi, $name"   // missing interp
+  def f(p: (Int, Int)): Int = p._1 * p._2
+  def g = f(3, 4)       // adapted
+  def u: Unit = ()      // unitarian universalist
+}
+
+object Test extends App {
+  // poignant demonstration
+  Console println X("Bob").x
+}


### PR DESCRIPTION
Make -Xlint a "multichoice" option for purposes of option parsing.

This allows turning on "lint with these warnings" instead of only
"turn off these warnings but enable other lint warnings".

```
$ scalac -Xlint:warn-adapted-args linty.scala  # lint plus a warning
$ scalac -Xlint warn-adapted-args linty.scala  # same
$ scalac -Xlint linty.scala                    # same as now
$ scalac -Xlint -- linty.scala                 # ok, not necessary
$ scalac -Xlint _ -- linty.scala               # another funky underscore
```

This would also enable Xlint options that are not standalone options,
although that is not implemented in this commit.  For example,
`-Xlint:no-missing-interpolator` could be used to disable that
warning. (There is no `-Xoption:flavor=off` syntax.) (`no-` switches
would not be enabled by `_`.)

Review by @retronym who has expressed opinions about the warning group conundrum
