### PR TITLE
SI-5905 Clarify test case

### DIFF
--- a/test/files/run/t5905-features.scala
+++ b/test/files/run/t5905-features.scala
@@ -3,13 +3,13 @@ import tools.partest.DirectTest
 
 // verify that all languageFeature names are accepted by -language
 object Test extends DirectTest {
-  override def code = "class Code { def f = (1 to 10) size }" // exercise a feature
+  override def code = "class Code { def f = (1 to 10) size }" // exercise a feature to sanity-check coverage of -language options
 
   override def extraSettings = s"-usejavacp -d ${testOutput.path}"
 
   override def show() = {
-    val global = newCompiler("-language:postfixOps", "-Ystop-after:typer")
-    compileString(global)(code)
+    val global = newCompiler("-Ystop-after:typer")
+    compileString(global)("")   // warm me up, scotty
     import global._
     exitingTyper {
       //def isFeature(s: Symbol) = s.annotations.exists((a: AnnotationInfo) => a.tpe <:< typeOf[scala.annotation.meta.languageFeature])
@@ -20,6 +20,8 @@ object Test extends DirectTest {
       val all    = (feats ++ xmen) mkString ","
 
       assert(feats.nonEmpty, "Test must find feature flags.")
+
+      //compile("junk")   // tragically, does not fail the test, i.e., arg must not be totally borked
 
       //dynamics,postfixOps,reflectiveCalls,implicitConversions,higherKinds,existentials,experimental.macros
       compile(s"-language:$all")


### PR DESCRIPTION
The language feature options are discovered reflectively, but it
is nice to enforce that expected options are supplied.

Short of that, the code string includes a rowdy postfix operator.

It still does enforce that at least one option was discovered.

(Resubmittal.)

Review by @retronym since this is in response to previous minor feedback from him.
