### PR TITLE
macro args now correctly preserve range positions

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -417,9 +417,10 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
 
             val wrappedArgs = mapWithIndex(args)((arg, j) => {
               val fingerprint = implParams(min(j, implParams.length - 1))
+              val duplicatedArg = duplicateAndKeepPositions(arg)
               fingerprint match {
-                case LiftedTyped => context.Expr[Nothing](arg.duplicate)(TypeTag.Nothing) // TODO: SI-5752
-                case LiftedUntyped => arg.duplicate
+                case LiftedTyped => context.Expr[Nothing](duplicatedArg)(TypeTag.Nothing) // TODO: SI-5752
+                case LiftedUntyped => duplicatedArg
                 case _ => abort(s"unexpected fingerprint $fingerprint in $binding with paramss being $paramss " +
                                 s"corresponding to arg $arg in $argss")
               }

--- a/test/files/run/macro-rangepos-args.check
+++ b/test/files/run/macro-rangepos-args.check
@@ -1,0 +1,1 @@
+Line: 3. Width: 5.

--- a/test/files/run/macro-rangepos-args.flags
+++ b/test/files/run/macro-rangepos-args.flags
@@ -1,0 +1,1 @@
+-Yrangepos

--- a/test/files/run/macro-rangepos-args/Macros_1.scala
+++ b/test/files/run/macro-rangepos-args/Macros_1.scala
@@ -1,0 +1,10 @@
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox.Context
+
+object Macros {
+  def impl(c: Context)(x: c.Tree): c.Tree = {
+    import c.universe._
+    Literal(Constant(s"Line: ${x.pos.line}. Width: ${x.pos.end - x.pos.start}."))
+  }
+  def pos(x: Any): String = macro impl
+}

--- a/test/files/run/macro-rangepos-args/Test_2.scala
+++ b/test/files/run/macro-rangepos-args/Test_2.scala
@@ -1,0 +1,4 @@
+object Test extends App {
+  val x = 2
+  println(Macros.pos(x + 2))
+}


### PR DESCRIPTION
Somewhen in the 2.11.0 development cycle we started duplicating macro arguments
for increased robustness. What wasn't taken into account though is that
Tree.duplicate destroys range positions. This commit fixes the problem.

2.10.x is unaffected by this bug, because it doesn't duplicate the args yet.
