### PR TITLE
Compiler optimizations for Scopes, checkDoubleDefs, Namer

### DIFF
--- a/bincompat-backward.whitelist.conf
+++ b/bincompat-backward.whitelist.conf
@@ -181,6 +181,10 @@ filter {
     {
         matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticExistentialType"
         problemName=MissingMethodProblem
+    },
+    {
+        matchName="scala.reflect.runtime.SynchronizedOps.newNestedScope"
+        problemName=MissingMethodProblem
     }
   ]
 }

--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -230,6 +230,10 @@ filter {
     {
         matchName="scala.reflect.runtime.JavaMirrors#JavaMirror.scala$reflect$runtime$JavaMirrors$JavaMirror$$followStatic"
         problemName=MissingMethodProblem
+    },
+    {
+        matchName="scala.reflect.runtime.SynchronizedOps.newNestedScope"
+        problemName=MissingMethodProblem
     }
   ]
 }

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1040,10 +1040,10 @@ trait Namers extends MethodSynthesis {
        * so the resulting type is a valid external method type, it does not contain (references to) skolems.
        */
       def thisMethodType(restpe: Type) = {
-        val checkDependencies = new DependentTypeChecker(context)(this)
-        checkDependencies check vparamSymss
-        // DEPMETTODO: check not needed when they become on by default
-        checkDependencies(restpe)
+        if (vparamSymss.lengthCompare(0) > 0) { // OPT fast path for methods of 0-1 parameter lists
+          val checkDependencies = new DependentTypeChecker(context)(this)
+          checkDependencies check vparamSymss
+        }
 
         val makeMethodType = (vparams: List[Symbol], restpe: Type) => {
           // TODODEPMET: check that we actually don't need to do anything here
@@ -1750,7 +1750,6 @@ trait Namers extends MethodSynthesis {
         for (p <- vps)
           this(p.info)
         // can only refer to symbols in earlier parameter sections
-        // (if the extension is enabled)
         okParams ++= vps
       }
     }

--- a/src/reflect/scala/reflect/internal/Scopes.scala
+++ b/src/reflect/scala/reflect/internal/Scopes.scala
@@ -48,22 +48,17 @@ trait Scopes extends api.Scopes { self: SymbolTable =>
    *  This is necessary because when run from reflection every scope needs to have a
    *  SynchronizedScope as mixin.
    */
-  class Scope protected[Scopes] (initElems: ScopeEntry = null, initFingerPrints: Long = 0L) extends ScopeApi with MemberScopeApi {
+  class Scope protected[Scopes]() extends ScopeApi with MemberScopeApi {
 
-    protected[Scopes] def this(base: Scope) = {
-      this(base.elems)
-      nestinglevel = base.nestinglevel + 1
-    }
-
-    private[scala] var elems: ScopeEntry = initElems
+    private[scala] var elems: ScopeEntry = _
 
     /** The number of times this scope is nested in another
      */
-    private var nestinglevel = 0
+    private[Scopes] var nestinglevel = 0
 
     /** the hash table
      */
-    private var hashtable: Array[ScopeEntry] = null
+    private[Scopes] var hashtable: Array[ScopeEntry] = null
 
     /** a cache for all elements, to be used by symbol iterator.
      */
@@ -83,8 +78,6 @@ trait Scopes extends api.Scopes { self: SymbolTable =>
     /** the threshold number of entries from which a hashtable is constructed.
      */
     private val MIN_HASH = 8
-
-    if (size >= MIN_HASH) createHash()
 
     /** Returns a new scope with the same content as this one. */
     def cloneScope: Scope = newScopeWith(this.toList: _*)
@@ -435,7 +428,14 @@ trait Scopes extends api.Scopes { self: SymbolTable =>
   }
 
   /** Create a new scope nested in another one with which it shares its elements */
-  def newNestedScope(outer: Scope): Scope = new Scope(outer)
+  final def newNestedScope(outer: Scope): Scope = {
+    val nested = newScope // not `new Scope`, we must allow the runtime reflection universe to mixin SynchronizedScopes!
+    nested.elems = outer.elems
+    nested.nestinglevel = outer.nestinglevel + 1
+    if (outer.hashtable ne null)
+      nested.hashtable = java.util.Arrays.copyOf(outer.hashtable, outer.hashtable.length)
+    nested
+  }
 
   /** Create a new scope with given initial elements */
   def newScopeWith(elems: Symbol*): Scope = {

--- a/src/reflect/scala/reflect/runtime/SymbolLoaders.scala
+++ b/src/reflect/scala/reflect/runtime/SymbolLoaders.scala
@@ -91,7 +91,7 @@ private[reflect] trait SymbolLoaders { self: SymbolTable =>
   //
   // Short of significantly changing SymbolLoaders I see no other way than just
   // to slap a global lock on materialization in runtime reflection.
-  class PackageScope(pkgClass: Symbol) extends Scope(initFingerPrints = -1L) // disable fingerprinting as we do not know entries beforehand
+  class PackageScope(pkgClass: Symbol) extends Scope
       with SynchronizedScope {
     assert(pkgClass.isType)
 

--- a/src/reflect/scala/reflect/runtime/SynchronizedOps.scala
+++ b/src/reflect/scala/reflect/runtime/SynchronizedOps.scala
@@ -37,8 +37,7 @@ private[reflect] trait SynchronizedOps extends internal.SymbolTable
 
 // Scopes
 
-  override def newScope = new Scope() with SynchronizedScope
-  override def newNestedScope(outer: Scope): Scope = new Scope(outer) with SynchronizedScope
+  override def newScope = new Scope with SynchronizedScope
 
   trait SynchronizedScope extends Scope {
     // we can keep this lock fine-grained, because methods of Scope don't do anything extraordinary, which makes deadlocks impossible

--- a/test/files/neg/double-def-top-level.check
+++ b/test/files/neg/double-def-top-level.check
@@ -1,0 +1,7 @@
+D_3.scala:1: error: C is already defined as class C
+class C
+      ^
+D_3.scala:2: error: O is already defined as object O
+object O
+       ^
+two errors found

--- a/test/files/neg/double-def-top-level/A_1.scala
+++ b/test/files/neg/double-def-top-level/A_1.scala
@@ -1,0 +1,4 @@
+package p
+
+class C
+object O

--- a/test/files/neg/double-def-top-level/B_2.scala
+++ b/test/files/neg/double-def-top-level/B_2.scala
@@ -1,0 +1,2 @@
+class C /* noerror */
+object O /* noerror */

--- a/test/files/neg/double-def-top-level/C_3.scala
+++ b/test/files/neg/double-def-top-level/C_3.scala
@@ -1,0 +1,2 @@
+class C
+object O

--- a/test/files/neg/double-def-top-level/D_3.scala
+++ b/test/files/neg/double-def-top-level/D_3.scala
@@ -1,0 +1,2 @@
+class C
+object O

--- a/test/junit/scala/reflect/internal/ScopeTest.scala
+++ b/test/junit/scala/reflect/internal/ScopeTest.scala
@@ -1,0 +1,54 @@
+package symtab
+
+import scala.tools.nsc.symtab
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.tools.testing.AssertUtil.assertThrows
+import scala.tools.nsc.symtab.SymbolTableForUnitTesting
+
+@RunWith(classOf[JUnit4])
+class ScopeTest {
+  object symbolTable extends SymbolTableForUnitTesting
+
+  import symbolTable._
+
+  @Test
+  def testNestedScopeSmall(): Unit = testNestedScope(0)
+  @Test
+  def testNestedScopeLarge(): Unit = testNestedScope(64) // exceeding MIN_HASH
+
+  private def testNestedScope(initSize: Int) {
+    def sym(termName: String): Symbol = NoSymbol.newValue(TermName(termName))
+    val foo = sym("foo")
+    val bar = sym("bar")
+
+    val outerElems = List.tabulate(initSize)(i => sym(i.toString))
+    val outer = newScopeWith(outerElems ++ List(foo, bar) : _*)
+    assertTrue(outer.containsName(foo.name))
+    assertTrue(outer.containsName(bar.name))
+
+    val baz = sym("baz")
+    val nested = newNestedScope(outer)
+
+    // Entries from the outer scope are entered in the nested.
+    assertTrue(outer.containsName(foo.name))
+    assertTrue(outer.containsName(bar.name))
+
+    // Nested scopes structurally share ScopeEntry-s with the outer.
+    assertSame(outer.lookupEntry(foo.name), nested.lookupEntry(foo.name))
+    nested.enter(baz)
+
+    // Symbols entered in the nested scope aren't visible in the outer.
+    assertTrue(nested.containsName(baz.name))
+    assertTrue(!outer.containsName(baz.name))
+
+    // Unlinking a symbol in the inner scope doesn't modify the outer
+    nested.unlink(bar)
+    assert(!nested.containsName(bar.name))
+    assert(outer.containsName(bar.name))
+  }
+}


### PR DESCRIPTION
Resubmission of #3771, adds a unit test for Scope and
fixes the boostrap error from the previous attempt.

Review by @gkossakowski 
