### PR TITLE
To have effect, @deprecated needs to be an annotation.

### DIFF
--- a/src/library/scala/concurrent/Lock.scala
+++ b/src/library/scala/concurrent/Lock.scala
@@ -14,8 +14,8 @@ package scala.concurrent
  *
  *  @author  Martin Odersky
  *  @version 1.0, 10/03/2003
- *  @deprecated("Use java.util.concurrent.locks.Lock", "2.11.0")
  */
+@deprecated("Use java.util.concurrent.locks.Lock", "2.11.0")
 class Lock {
   var available = true
 


### PR DESCRIPTION
This was intended to be deprecated in 2.11.0 based on the commit and text, but apparently wasn't.

I don't know whether this can still be pulled into the 2.11 branch or not, but if this was the intent, it should be pulled there as well as 2.12.x; otherwise, I'll resubmit with 2.12.0 as the deprecation version.
