### PR TITLE
Add documentation to parts of scala.concurrent.

### DIFF
--- a/src/library/scala/concurrent/Channel.scala
+++ b/src/library/scala/concurrent/Channel.scala
@@ -10,8 +10,10 @@
 
 package scala.concurrent
 
-/** This class ...
+/** This class provides a simple FIFO stream of data objects,
+ *  which are read by one or more reader threads.
  *
+ *  @tparam A type of data exchanged
  *  @author  Martin Odersky
  *  @version 1.0, 10/03/2003
  */
@@ -24,7 +26,10 @@ class Channel[A] {
   private var lastWritten = written       // aliasing of a linked list
   private var nreaders = 0
 
-  /**
+  /** Append a value to the FIFO to be read by `read`.
+   *  This operation is nonblocking and can be executed by any thread.
+   *
+   * @param x object to enqueue to this channel
    */
   def write(x: A) = synchronized {
     lastWritten.elem = x
@@ -33,6 +38,11 @@ class Channel[A] {
     if (nreaders > 0) notify()
   }
 
+  /** Retrieve the next waiting object from the FIFO, blocking if necessary
+   *  until an object is available.
+   *
+   * @return next object dequeued from this channel
+   */
   def read: A = synchronized {
     while (written.next == null) {
       try {

--- a/src/library/scala/concurrent/ExecutionContext.scala
+++ b/src/library/scala/concurrent/ExecutionContext.scala
@@ -77,12 +77,12 @@ trait ExecutionContext {
 }
 
 /**
- * Union interface since Java does not support union types
+ * An `ExecutionContext` that is also a Java `Executor`.
  */
 trait ExecutionContextExecutor extends ExecutionContext with Executor
 
 /**
- * Union interface since Java does not support union types
+ * An `ExecutionContext` that is also a Java `ExecutorService`.
  */
 trait ExecutionContextExecutorService extends ExecutionContextExecutor with ExecutorService
 

--- a/src/library/scala/concurrent/SyncVar.scala
+++ b/src/library/scala/concurrent/SyncVar.scala
@@ -20,6 +20,8 @@ class SyncVar[A] {
   private var isDefined: Boolean = false
   private var value: Option[A] = None
 
+  /** Waits for this SyncVar to become defined and returns
+    *  the result, without unsetting the stored value. */
   def get: A = synchronized {
     while (!isDefined) wait()
     value.get
@@ -58,7 +60,7 @@ class SyncVar[A] {
   }
 
   /** Waits for this SyncVar to become defined and returns
-   *  the result */
+   *  the result, unsetting the stored value before returning. */
   def take(): A = synchronized {
     try get
     finally unsetVal()

--- a/src/library/scala/concurrent/package.scala
+++ b/src/library/scala/concurrent/package.scala
@@ -55,6 +55,10 @@ package object concurrent {
 }
 
 package concurrent {
+  /**
+   * This marker trait is used by `Await` to ensure that `Awaitable.ready` and `Awaitable.result`
+   * are only called from the global `Await` methods, not directly by user code.
+   */
   @implicitNotFound("Don't call `Awaitable` methods directly, use the `Await` object.")
   sealed trait CanAwait
 


### PR DESCRIPTION
Small doc nits for stuff historically not documented. If you'd like this in 2.11.x, I'll cherry-pick and submit a pull for that too.
