### PR TITLE
SI-8617 Avoid rangepos crash for OptManifest materializer

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1306,7 +1306,7 @@ trait Implicits {
     }
 
     def wrapResult(tree: Tree): SearchResult =
-      if (tree == EmptyTree) SearchFailure else new SearchResult(tree, EmptyTreeTypeSubstituter, Nil)
+      if (tree == EmptyTree) SearchFailure else new SearchResult(atPos(pos.focus)(tree), EmptyTreeTypeSubstituter, Nil)
 
     /** Materializes implicits of predefined types (currently, manifests and tags).
      *  Will be replaced by implicit macros once we fix them.

--- a/test/files/pos/t8617.flags
+++ b/test/files/pos/t8617.flags
@@ -1,0 +1,1 @@
+-Yrangepos

--- a/test/files/pos/t8617.scala
+++ b/test/files/pos/t8617.scala
@@ -1,0 +1,10 @@
+object Test {
+  def foo[A] = implicitly[OptManifest[A]] // was "unpositioned tree" under -Yrangepos
+
+  // These did not crash, but testing for good measure.
+  implicitly[OptManifest[String]]
+  implicitly[Manifest[String]]
+
+  implicitly[reflect.ClassTag[String]]
+  implicitly[reflect.runtime.universe.TypeTag[String]]
+}


### PR DESCRIPTION
The tree to create a `NoManifest` was unpositioned.

Review by @lrytz

As seen in a -Yrangepos [run](https://jenkins-dbuild.typesafe.com:8499/job/Community-2.11.x-manual/26/consoleFull) of the community build.
