### PR TITLE
SI-8346 Rebuild invariant sets in #toSet, avoiding CCE

### DIFF
--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -162,6 +162,13 @@ class HashSet[A] extends AbstractSet[A]
   def - (e: A): HashSet[A] =
     nullToEmpty(removed0(e, computeHash(e), 0))
 
+  /** Returns this $coll as an immutable set.
+   *  
+   *  A new set will not be built; lazy collections will stay lazy.
+   */
+  @deprecatedOverriding("Immutable sets should do nothing on toSet but return themselves cast as a Set.", "2.11.0")
+  override def toSet[B >: A]: Set[B] = this.asInstanceOf[Set[B]]
+
   override def filter(p: A => Boolean) = {
     val buffer = new Array[HashSet[A]](bufferSize(size))
     nullToEmpty(filter0(p, false, 0, buffer, 0))

--- a/src/library/scala/collection/immutable/ListSet.scala
+++ b/src/library/scala/collection/immutable/ListSet.scala
@@ -138,6 +138,13 @@ class ListSet[A] extends AbstractSet[A]
 
   override def stringPrefix = "ListSet"
 
+  /** Returns this $coll as an immutable set.
+   *  
+   *  A new set will not be built; lazy collections will stay lazy.
+   */
+  @deprecatedOverriding("Immutable sets should do nothing on toSet but return themselves cast as a Set.", "2.11.0")
+  override def toSet[B >: A]: Set[B] = this.asInstanceOf[Set[B]]
+
   /** Represents an entry in the `ListSet`.
    */
   protected class Node(override val head: A) extends ListSet[A] with Serializable {

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -35,12 +35,7 @@ trait Set[A] extends Iterable[A]
   override def companion: GenericCompanion[Set] = Set
   
   
-  /** Returns this $coll as an immutable map.
-   *  
-   *  A new map will not be built; lazy collections will stay lazy.
-   */
-  @deprecatedOverriding("Immutable sets should do nothing on toSet but return themselves cast as a Set.", "2.11.0")
-  override def toSet[B >: A]: Set[B] = this.asInstanceOf[Set[B]]
+  override def toSet[B >: A]: Set[B] = to[({type l[a] = immutable.Set[B]})#l] // for bincompat; remove in dev
   
   override def seq: Set[A] = this
   protected override def parCombiner = ParSet.newCombiner[A] // if `immutable.SetLike` gets introduced, please move this there!
@@ -62,6 +57,7 @@ object Set extends ImmutableSetFactory[Set] {
     def - (elem: Any): Set[Any] = this
     def iterator: Iterator[Any] = Iterator.empty
     override def foreach[U](f: Any =>  U): Unit = {}
+    override def toSet[B >: Any]: Set[B] = this.asInstanceOf[Set[B]]
   }
   private[collection] def emptyInstance: Set[Any] = EmptySet
 
@@ -92,6 +88,8 @@ object Set extends ImmutableSetFactory[Set] {
       if (f(elem1)) Some(elem1)
       else None
     }
+    @deprecatedOverriding("Immutable sets should do nothing on toSet but return themselves cast as a Set.", "2.11.0")
+    override def toSet[B >: A]: Set[B] = this.asInstanceOf[Set[B]]
   }
 
   /** An optimized representation for immutable sets of size 2 */
@@ -123,6 +121,8 @@ object Set extends ImmutableSetFactory[Set] {
       else if (f(elem2)) Some(elem2)
       else None
     }
+    @deprecatedOverriding("Immutable sets should do nothing on toSet but return themselves cast as a Set.", "2.11.0")
+    override def toSet[B >: A]: Set[B] = this.asInstanceOf[Set[B]]
   }
 
   /** An optimized representation for immutable sets of size 3 */
@@ -156,6 +156,8 @@ object Set extends ImmutableSetFactory[Set] {
       else if (f(elem3)) Some(elem3)
       else None
     }
+    @deprecatedOverriding("Immutable sets should do nothing on toSet but return themselves cast as a Set.", "2.11.0")
+    override def toSet[B >: A]: Set[B] = this.asInstanceOf[Set[B]]
   }
 
   /** An optimized representation for immutable sets of size 4 */
@@ -191,6 +193,8 @@ object Set extends ImmutableSetFactory[Set] {
       else if (f(elem4)) Some(elem4)
       else None
     }
+    @deprecatedOverriding("Immutable sets should do nothing on toSet but return themselves cast as a Set.", "2.11.0")
+    override def toSet[B >: A]: Set[B] = this.asInstanceOf[Set[B]]
   }
 }
 

--- a/test/files/run/t8346.check
+++ b/test/files/run/t8346.check
@@ -1,0 +1,6 @@
+BitSet: List(invariant, invariant, invariant, invariant)
+HashSet: List(covariant (true), covariant (true), covariant (true), covariant (true))
+ListSet: List(covariant (true), covariant (true), covariant (true), covariant (true))
+SortedSet: List(invariant, invariant, invariant, invariant)
+TreeSet: List(invariant, invariant, invariant, invariant)
+ValueSet: invariant

--- a/test/files/run/t8346.scala
+++ b/test/files/run/t8346.scala
@@ -1,0 +1,34 @@
+object Test extends App {
+  import reflect.ClassTag
+
+  object SomeEnum extends Enumeration {
+    val one, two, three, four = Value
+  }
+
+  def sctor[A <: Set[Int]](f: Int => A)(implicit A: ClassTag[A])
+      : (String, Int => Set[Int]) =
+    (A.runtimeClass.getSimpleName, f)
+
+  val inits: Seq[(String, Int => Set[Int])] = {
+    import collection.immutable.{Seq => _, _}
+    Seq(sctor(BitSet(_)),
+        sctor(HashSet(_)),
+        sctor(ListSet(_)),
+        sctor(SortedSet(_)),
+        sctor(TreeSet(_)))
+  }
+
+  def sVarInfo[A](sa: Set[A]): String = {
+    val saa = sa.toSet[Any]
+    if (sa eq saa) s"""covariant (${(saa + "hi") contains "hi"})"""
+    else "invariant"
+  }
+
+  inits foreach {case (name, singleton) =>
+    print(s"${name}: ")
+    val one = singleton(1)
+    println(Seq(2,3,4).scanLeft(one)(_ + _) map sVarInfo toList)
+  }
+
+  println(s"ValueSet: ${sVarInfo(SomeEnum.values)}")
+}


### PR DESCRIPTION
SI-3953 caused several types of sets' operations to trivially throw `ClassCastException` after using inherited covariant #toSet method, by doing an unchecked cast that is only safe for intrinsically covariant set data structures like `HashSet`, but totally unsafe for others like `TreeSet` or `Enumeration.ValueSet`.

This change moves the cast to the leaves of the class hierarchy where that is safe, and incidentally undeprecates overriding Set#toSet.
