### PR TITLE
SI-8475 GroupedIterator is also lazy when padded

### DIFF
--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -17,4 +17,12 @@ class IteratorTest {
     slidingIt.next
     assertEquals("Counter should be one, that means we didn't look further than needed", 1, counter)
   }
+
+  @Test def groupedIteratorIsLazyWhenPadded(): Unit = {
+    var counter = 0
+    def it = new Iterator[Int] { var i = 0 ; def hasNext = { counter = i; true } ; def next = { i += 1; i } }
+    val slidingIt = it sliding 2 withPadding -1
+    slidingIt.next
+    assertEquals("Counter should be one, that means we didn't look further than needed", 1, counter)
+  }
 }


### PR DESCRIPTION
This is the related case which dnlgtm in the previous fix.

The old code seems to be tilting for laziness, but we have
to fill the buffer with the current group anyway, so there
is no reason to be coy about calling ArrayBuffer.length.
