### PR TITLE
SI-8630 lineToString no longer long by one at eof

### DIFF
--- a/src/reflect/scala/reflect/internal/util/SourceFile.scala
+++ b/src/reflect/scala/reflect/internal/util/SourceFile.scala
@@ -40,7 +40,7 @@ abstract class SourceFile {
   def lineToString(index: Int): String = {
     val start = lineToOffset(index)
     var end = start
-    while (!isEndOfLine(end) && end <= length) end += 1
+    while (end < length && !isEndOfLine(end)) end += 1
     new String(content, start, end - start)
   }
 

--- a/test/files/neg/t8630.check
+++ b/test/files/neg/t8630.check
@@ -1,0 +1,7 @@
+t8630.scala:1: error: '{' expected but 'abstract' found.
+package bobsdelights  abstract class Fruit(  val name: String,  val color: String  )  object Fruits {  object Apple extends Fruit("apple", "red")  object Orange extends Fruit("orange", "orange")  object Pear extends Fruit("pear", "yellowish")  val menu = List(Apple, Orange, Pear)  }
+                      ^
+t8630.scala:1: error: '}' expected but eof found.
+package bobsdelights  abstract class Fruit(  val name: String,  val color: String  )  object Fruits {  object Apple extends Fruit("apple", "red")  object Orange extends Fruit("orange", "orange")  object Pear extends Fruit("pear", "yellowish")  val menu = List(Apple, Orange, Pear)  }
+                                                                                                                                                                                                                                                                                           ^
+two errors found

--- a/test/files/neg/t8630.scala
+++ b/test/files/neg/t8630.scala
@@ -1,0 +1,1 @@
+package bobsdelights  abstract class Fruit(  val name: String,  val color: String  )  object Fruits {  object Apple extends Fruit("apple", "red")  object Orange extends Fruit("orange", "orange")  object Pear extends Fruit("pear", "yellowish")  val menu = List(Apple, Orange, Pear)  } 

--- a/test/junit/scala/reflect/internal/util/SourceFileTest.scala
+++ b/test/junit/scala/reflect/internal/util/SourceFileTest.scala
@@ -17,6 +17,11 @@ class SourceFileTest {
     assertFalse(file.isEndOfLine(Int.MaxValue))
   }
 
+  @Test def si8630_lineToString(): Unit = {
+    val code = "abc "
+    assertEquals(code, new BatchSourceFile("", code).lineToString(0))
+  }
+
   @Test
   def si8205_lineToString(): Unit = {
     assertEquals("", lineContentOf("", 0))


### PR DESCRIPTION
One more EOL crasher, or lack-of-EOL crasher, when the text
is at EOF.

It was not caught by the last round of excellent and
thorough tests because

```
// If non-whitespace tokens run all the way up to EOF,
// positions go wrong because the correct end of the last
// token cannot be used as an index into the char array.
// The least painful way to address this was to add a
// newline to the array.
```

Review by @retronym
