### PR TITLE
SI-8631 Treat `A with Sealed` as enumerable for pattern matching

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -115,7 +115,7 @@ trait TreeAndTypeAnalysis extends Debugging {
             )
           else None
         // make sure it's not a primitive, else (5: Byte) match { case 5 => ... } sees no Byte
-        case sym if sym.isSealed && !isPrimitiveValueClass(sym) =>
+        case sym if sym.isSealed =>
           val subclasses = debug.patmatResult(s"enum $sym sealed, subclasses")(
             // symbols which are both sealed and abstract need not be covered themselves, because
             // all of their children must be and they cannot otherwise be created.

--- a/test/files/neg/virtpatmat_exhaust_compound.check
+++ b/test/files/neg/virtpatmat_exhaust_compound.check
@@ -1,0 +1,15 @@
+virtpatmat_exhaust_compound.scala:14: warning: match may not be exhaustive.
+It would fail on the following inputs: O1, O2, O4
+  a match {
+  ^
+virtpatmat_exhaust_compound.scala:18: warning: match may not be exhaustive.
+It would fail on the following input: O4
+  def t1(a: Product with Base with Base2) = a match {
+                                            ^
+virtpatmat_exhaust_compound.scala:22: warning: match may not be exhaustive.
+It would fail on the following input: O2
+  def t2(a: Product with Base { def foo: Int }) = a match {
+                                                  ^
+error: No warnings can be incurred under -Xfatal-warnings.
+three warnings found
+one error found

--- a/test/files/neg/virtpatmat_exhaust_compound.flags
+++ b/test/files/neg/virtpatmat_exhaust_compound.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/virtpatmat_exhaust_compound.scala
+++ b/test/files/neg/virtpatmat_exhaust_compound.scala
@@ -1,0 +1,29 @@
+sealed trait Base
+case object O1 extends Base
+case object O2 extends Base {
+  def foo: Int = 0
+}
+
+sealed trait Base2
+case object O3 extends Base2
+
+case object O4 extends Base with Base2
+
+object Test {
+  val a /*: Product with Serialiable with Base */ = if (true) O1 else O2
+  a match {
+    case null =>
+  }
+
+  def t1(a: Product with Base with Base2) = a match {
+    case null => // O1..O3 should *not* be possible here
+  }
+
+  def t2(a: Product with Base { def foo: Int }) = a match {
+    case null => // O2 in the domain
+  }
+
+  def t3(a: Product with Base { def bar: Int }) = a match {
+    case null => // nothing in the domain
+  }
+}


### PR DESCRIPTION
Enumerate the subtypes of sealed parent types of refinement
types, and filter those that conform to the refinement type.

Such types can crop up easily when LUB-bing case classes which
add `Product with Serializable` to the mix.
