### PR TITLE
SI-8503 -version is info setting 

### DIFF
--- a/src/compiler/scala/tools/nsc/CompilerCommand.scala
+++ b/src/compiler/scala/tools/nsc/CompilerCommand.scala
@@ -20,8 +20,11 @@ class CompilerCommand(arguments: List[String], val settings: Settings) {
   def ok    = processArgumentsResult._1
   def files = processArgumentsResult._2
 
-  /** The name of the command */
+  /** The name of the command. */
   def cmdName = "scalac"
+
+  /** A descriptive alias for version and help messages. */
+  def cmdDesc = "compiler"
 
   private def explainAdvanced = "\n" + """
     |-- Notes on option parsing --
@@ -85,7 +88,11 @@ class CompilerCommand(arguments: List[String], val settings: Settings) {
 
   def getInfoMessage(global: Global): String = {
     import settings._
-    if (help)               usageMsg + global.pluginOptionsHelp
+    import Properties.{ versionString, copyrightString } //versionFor
+    def versionFor(command: String) = f"Scala $command $versionString -- $copyrightString"
+
+    if (version)            versionFor(cmdDesc)
+    else if (help)          usageMsg + global.pluginOptionsHelp
     else if (Xhelp)         xusageMsg
     else if (Yhelp)         yusageMsg
     else if (showPlugins)   global.pluginDescriptions

--- a/src/compiler/scala/tools/nsc/GenericRunnerCommand.scala
+++ b/src/compiler/scala/tools/nsc/GenericRunnerCommand.scala
@@ -50,17 +50,16 @@ extends CompilerCommand(args, settings) {
     case Nil      => AsRepl
     case hd :: _  => waysToRun find (_.name == settings.howtorun.value) getOrElse guessHowToRun(hd)
   }
-  private def interpolate(s: String) = s.trim.replaceAll("@cmd@", cmdName).replaceAll("@compileCmd@", compCmdName) + "\n"
 
-  def shortUsageMsg = interpolate("""
-Usage: @cmd@ <options> [<script|class|object|jar> <arguments>]
-   or  @cmd@ -help
+  def shortUsageMsg =
+s"""|Usage: $cmdName <options> [<script|class|object|jar> <arguments>]
+    |   or  $cmdName -help
+    |
+    |All options to $compCmdName (see $compCmdName -help) are also allowed.
+""".stripMargin
 
-All options to @compileCmd@ (see @compileCmd@ -help) are also allowed.
-""")
-
-  override def usageMsg = shortUsageMsg + interpolate("""
-The first given argument other than options to @cmd@ designates
+  override def usageMsg = f"""$shortUsageMsg
+The first given argument other than options to $cmdName designates
 what to run.  Runnable targets are:
 
   - a file containing scala source
@@ -68,7 +67,7 @@ what to run.  Runnable targets are:
   - a runnable jar file with a valid Main-Class attribute
   - or if no argument is given, the repl (interactive shell) is started
 
-Options to @cmd@ which reach the java runtime:
+Options to $cmdName which reach the java runtime:
 
  -Dname=prop  passed directly to java to set system properties
  -J<arg>      -J is stripped and <arg> passed to java as-is
@@ -86,8 +85,7 @@ A file argument will be run as a scala script unless it contains only
 self-contained compilation units (classes and objects) and exactly one
 runnable main method.  In that case the file will be compiled and the
 main method invoked.  This provides a bridge between scripts and standard
-scala source.
-  """) + "\n"
+scala source.%n"""
 }
 
 object GenericRunnerCommand {

--- a/src/compiler/scala/tools/nsc/GenericRunnerCommand.scala
+++ b/src/compiler/scala/tools/nsc/GenericRunnerCommand.scala
@@ -19,9 +19,10 @@ extends CompilerCommand(args, settings) {
   def this(args: List[String]) =
     this(args, str => Console.println("Error: " + str))
 
-  /** name of the associated compiler command */
   override def cmdName = "scala"
-  def compCmdName = "scalac"
+  override def cmdDesc = "code runner"
+
+  def compCmdName = "scalac"  // super.cmdName
 
   // change CompilerCommand behavior
   override def shouldProcessArguments: Boolean = false

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -42,7 +42,7 @@ trait ScalaSettings extends AbsScalaSettings
   def optimiseSettings = List[BooleanSetting](inline, inlineHandlers, Xcloselim, Xdce, YconstOptimization)
 
   /** If any of these settings is enabled, the compiler should print a message and exit.  */
-  def infoSettings = List[Setting](help, Xhelp, Yhelp, showPlugins, showPhases, genPhaseGraph)
+  def infoSettings = List[Setting](version, help, Xhelp, Yhelp, showPlugins, showPhases, genPhaseGraph)
 
   /** Is an info setting set? */
   def isInfo = infoSettings exists (_.isSetByUser)

--- a/src/interactive/scala/tools/nsc/interactive/Main.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Main.scala
@@ -12,7 +12,7 @@ package interactive
  */
 object Main extends nsc.MainClass {
   override def processSettingsHook(): Boolean = {
-    if (this.settings.Yidedebug) {
+    def run(): Unit = {
       this.settings.Xprintpos.value = true
       this.settings.Yrangepos.value = true
       val compiler = new interactive.Global(this.settings, this.reporter)
@@ -27,8 +27,9 @@ object Main extends nsc.MainClass {
         case None => reporter.reset() // Causes other compiler errors to be ignored
       }
       askShutdown
-      false
     }
-    else true
+    super.processSettingsHook() && (
+      if (this.settings.Yidedebug) { run() ; false } else true
+    )
   }
 }

--- a/src/library/scala/util/Properties.scala
+++ b/src/library/scala/util/Properties.scala
@@ -155,9 +155,12 @@ private[scala] trait PropertiesTrait {
   // This is looking for javac, tools.jar, etc.
   // Tries JDK_HOME first, then the more common but likely jre JAVA_HOME,
   // and finally the system property based javaHome.
-  def jdkHome              = envOrElse("JDK_HOME", envOrElse("JAVA_HOME", javaHome))
+  def jdkHome               = envOrElse("JDK_HOME", envOrElse("JAVA_HOME", javaHome))
 
-  def versionMsg            = "Scala %s %s -- %s".format(propCategory, versionString, copyrightString)
+  // private[scala] for 2.12
+  private[this] def versionFor(command: String) = f"Scala $command $versionString -- $copyrightString"
+
+  def versionMsg            = versionFor(propCategory)
   def scalaCmd              = if (isWin) "scala.bat" else "scala"
   def scalacCmd             = if (isWin) "scalac.bat" else "scalac"
 

--- a/src/repl/scala/tools/nsc/MainGenericRunner.scala
+++ b/src/repl/scala/tools/nsc/MainGenericRunner.scala
@@ -8,7 +8,6 @@ package tools.nsc
 
 import io.{ File }
 import util.{ ClassPath, ScalaClassLoader }
-import Properties.{ versionString, copyrightString }
 import GenericRunnerCommand._
 
 object JarRunner extends CommonRunner {
@@ -28,79 +27,78 @@ object JarRunner extends CommonRunner {
 }
 
 /** An object that runs Scala code.  It has three possible
-  * sources for the code to run: pre-compiled code, a script file,
-  * or interactive entry.
-  */
+ *  sources for the code to run: pre-compiled code, a script file,
+ *  or interactive entry.
+ */
 class MainGenericRunner {
-  def errorFn(ex: Throwable): Boolean = {
-    ex.printStackTrace()
-    false
-  }
-  def errorFn(str: String): Boolean = {
-    Console.err println str
-    false
+  def errorFn(str: String, e: Option[Throwable] = None, isFailure: Boolean = true): Boolean = {
+    if (str.nonEmpty) Console.err println str
+    e foreach (_.printStackTrace())
+    !isFailure
   }
 
   def process(args: Array[String]): Boolean = {
     val command = new GenericRunnerCommand(args.toList, (x: String) => errorFn(x))
-    import command.{ settings, howToRun, thingToRun }
-    def sampleCompiler = new Global(settings)   // def so its not created unless needed
+    import command.{ settings, howToRun, thingToRun, shortUsageMsg, shouldStopWithInfo }
+    def sampleCompiler = new Global(settings)   // def so it's not created unless needed
 
-    if (!command.ok)                      return errorFn("\n" + command.shortUsageMsg)
-    else if (settings.version)            return errorFn("Scala code runner %s -- %s".format(versionString, copyrightString))
-    else if (command.shouldStopWithInfo)  return errorFn(command getInfoMessage sampleCompiler)
+    def run(): Boolean = {
+      def isE   = !settings.execute.isDefault
+      def dashe = settings.execute.value
 
-    def isE   = !settings.execute.isDefault
-    def dashe = settings.execute.value
+      def isI   = !settings.loadfiles.isDefault
+      def dashi = settings.loadfiles.value
 
-    def isI   = !settings.loadfiles.isDefault
-    def dashi = settings.loadfiles.value
+      // Deadlocks on startup under -i unless we disable async.
+      if (isI)
+        settings.Yreplsync.value = true
 
-    // Deadlocks on startup under -i unless we disable async.
-    if (isI)
-      settings.Yreplsync.value = true
+      def combinedCode  = {
+        val files   = if (isI) dashi map (file => File(file).slurp()) else Nil
+        val str     = if (isE) List(dashe) else Nil
 
-    def combinedCode  = {
-      val files   = if (isI) dashi map (file => File(file).slurp()) else Nil
-      val str     = if (isE) List(dashe) else Nil
+        files ++ str mkString "\n\n"
+      }
 
-      files ++ str mkString "\n\n"
+      def runTarget(): Either[Throwable, Boolean] = howToRun match {
+        case AsObject =>
+          ObjectRunner.runAndCatch(settings.classpathURLs, thingToRun, command.arguments)
+        case AsScript =>
+          ScriptRunner.runScriptAndCatch(settings, thingToRun, command.arguments)
+        case AsJar    =>
+          JarRunner.runJar(settings, thingToRun, command.arguments)
+        case Error =>
+          Right(false)
+        case _  =>
+          // We start the repl when no arguments are given.
+          Right(new interpreter.ILoop process settings)
+      }
+
+      /** If -e and -i were both given, we want to execute the -e code after the
+       *  -i files have been included, so they are read into strings and prepended to
+       *  the code given in -e.  The -i option is documented to only make sense
+       *  interactively so this is a pretty reasonable assumption.
+       *
+       *  This all needs a rewrite though.
+       */
+      if (isE) {
+        ScriptRunner.runCommand(settings, combinedCode, thingToRun +: command.arguments)
+      }
+      else runTarget() match {
+        case Left(ex) => errorFn("", Some(ex))  // there must be a useful message of hope to offer here
+        case Right(b) => b
+      }
     }
 
-    def runTarget(): Either[Throwable, Boolean] = howToRun match {
-      case AsObject =>
-        ObjectRunner.runAndCatch(settings.classpathURLs, thingToRun, command.arguments)
-      case AsScript =>
-        ScriptRunner.runScriptAndCatch(settings, thingToRun, command.arguments)
-      case AsJar    =>
-        JarRunner.runJar(settings, thingToRun, command.arguments)
-      case Error =>
-        Right(false)
-      case _  =>
-        // We start the repl when no arguments are given.
-        Right(new interpreter.ILoop process settings)
-    }
-
-    /** If -e and -i were both given, we want to execute the -e code after the
-     *  -i files have been included, so they are read into strings and prepended to
-     *  the code given in -e.  The -i option is documented to only make sense
-     *  interactively so this is a pretty reasonable assumption.
-     *
-     *  This all needs a rewrite though.
-     */
-    if (isE) {
-      ScriptRunner.runCommand(settings, combinedCode, thingToRun +: command.arguments)
-    }
-    else runTarget() match {
-      case Left(ex) => errorFn(ex)
-      case Right(b) => b
-    }
+    if (!command.ok)
+      errorFn(f"%n$shortUsageMsg")
+    else if (shouldStopWithInfo)
+      errorFn(command getInfoMessage sampleCompiler, isFailure = false)
+    else
+      run()
   }
 }
 
 object MainGenericRunner extends MainGenericRunner {
-  def main(args: Array[String]) {
-    if (!process(args))
-      sys.exit(1)
-  }
+  def main(args: Array[String]): Unit = if (!process(args)) sys.exit(1)
 }


### PR DESCRIPTION
And the Scala runner exits with 0 for info settings.

```
apm@mara:~$ javac -version 2> /dev/null
apm@mara:~$ echo $?
0
apm@mara:~$ java -version 2> /dev/null
apm@mara:~$ echo $?
0
apm@mara:~$ java -help 2> /dev/null
apm@mara:~$ echo $?
0
apm@mara:~$ java -junk 2> /dev/null
apm@mara:~$ echo $?
1
apm@mara:~$ skala -version
Scala code runner version 2.11.2-20140528-130424-c8f8782f6a -- Copyright 2002-2013, LAMP/EPFL
apm@mara:~$ echo $?
0
apm@mara:~$ skalac -version
Scala compiler version 2.11.2-20140528-130424-c8f8782f6a -- Copyright 2002-2013, LAMP/EPFL
apm@mara:~$ echo $?
0
apm@mara:~$ skalac -junk 2> /dev/null
apm@mara:~$ echo $?
1
```

Review by @adriaanm in case this breaks one of his scripts
