### PR TITLE
Issue/8553

### DIFF
--- a/src/library/scala/collection/IndexedSeqOptimized.scala
+++ b/src/library/scala/collection/IndexedSeqOptimized.scala
@@ -206,7 +206,7 @@ trait IndexedSeqOptimized[+A, +Repr] extends Any with IndexedSeqLike[A, Repr] { 
 
   override /*SeqLike*/
   def lastIndexWhere(p: A => Boolean, end: Int): Int = {
-    var i = end
+    var i = math.min(end, length-1)
     while (i >= 0 && !p(this(i))) i -= 1
     i
   }


### PR DESCRIPTION
 SI-8553 WrappedArray throws exception on lastIndexWhere

Actually affected all of IndexedSeqOptimized: if the end (start?) index was at or beyond the length it'd try to index into it anyway.  No tests; this will be covered by quasi-comprehensive collections tests.
