### PR TITLE
SI-8637 fixes toolbox phase corruption

### DIFF
--- a/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
+++ b/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
@@ -141,6 +141,7 @@ abstract class ToolBoxFactory[U <: JavaUniverse](val u: U) { factorySelf =>
           val run = new Run
           run.symSource(ownerClass) = NoAbstractFile // need to set file to something different from null, so that currentRun.defines works
           phase = run.typerPhase // need to set a phase to something <= typerPhase, otherwise implicits in typedSelect will be disabled
+          globalPhase = run.typerPhase // amazing... looks like phase and globalPhase are different things, so we need to set them separately
           currentTyper.context.setReportErrors() // need to manually set context mode, otherwise typer.silent will throw exceptions
           reporter.reset()
 

--- a/test/files/run/t8637.scala
+++ b/test/files/run/t8637.scala
@@ -1,0 +1,9 @@
+import scala.reflect.runtime.universe._
+import scala.reflect.runtime.currentMirror
+import scala.tools.reflect.ToolBox
+
+object Test extends App {
+  val tb = currentMirror.mkToolBox()
+  tb.compile(q"true > true")
+  tb.typecheck(q"true > true")
+}


### PR DESCRIPTION
It turns out, Toolbox.typecheck hasn't been properly re-initializing its state
between requests.

In particular, globalPhase was left untouched, which made the compiler
think that it's past typer, and that in turn disabled implicits.

This commit applies a symptomatic fix to this problem.
