### PR TITLE
SI-8634 Improve asSeenFrom handling of existentials

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -661,10 +661,7 @@ trait Types
         else {
           val m     = newAsSeenFromMap(pre.normalize, clazz)
           val tp    = m(this)
-          val tp1   = existentialAbstraction(m.capturedParams, tp)
-
-          if (m.capturedSkolems.isEmpty) tp1
-          else deriveType(m.capturedSkolems, _.cloneSymbol setFlag CAPTURED)(tp1)
+          existentialAbstraction(m.capturedParams, tp)
         }
       } finally if (Statistics.canEnable) Statistics.popTimer(typeOpsStack, start)
     }

--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -459,7 +459,6 @@ private[internal] trait TypeMaps {
     //   class Inner(lhs: T) { def f = lhs }
     // }
     def capturedParams: List[Symbol]  = _capturedParams
-    def capturedSkolems: List[Symbol] = _capturedSkolems
 
     def apply(tp: Type): Type = tp match {
       case tp @ ThisType(_)                                            => thisTypeAsSeen(tp)
@@ -468,7 +467,6 @@ private[internal] trait TypeMaps {
       case _                                                           => mapOver(tp)
     }
 
-    private var _capturedSkolems: List[Symbol] = Nil
     private var _capturedParams: List[Symbol]  = Nil
     private val isStablePrefix = seenFromPrefix.isStable
 
@@ -504,12 +502,6 @@ private[internal] trait TypeMaps {
           _capturedParams ::= qvar
           debuglog(s"Captured This(${clazz.fullNameString}) seen from $seenFromPrefix: ${qvar.defString}")
           qvar.tpe
-      }
-    }
-    protected def captureSkolems(skolems: List[Symbol]) {
-      for (p <- skolems; if !(capturedSkolems contains p)) {
-        debuglog(s"Captured $p seen from $seenFromPrefix")
-        _capturedSkolems ::= p
       }
     }
 
@@ -583,7 +575,7 @@ private[internal] trait TypeMaps {
         else nextBase match {
           case NoType                         => loop(NoType, clazz.owner) // backstop for SI-2797, must remove `SingletonType#isHigherKinded` and run pos/t2797.scala to get here.
           case applied @ TypeRef(_, _, _)     => correspondingTypeArgument(classParam, applied)
-          case ExistentialType(eparams, qtpe) => captureSkolems(eparams) ; loop(qtpe, clazz)
+          case ExistentialType(eparams, qtpe) => loop(qtpe, clazz)
           case t                              => abort(s"$tparam in ${tparam.owner} cannot be instantiated from ${seenFromPrefix.widen}")
         }
       }

--- a/test/files/run/t8634.scala
+++ b/test/files/run/t8634.scala
@@ -1,0 +1,32 @@
+trait SelfTyped {
+  type Self
+}
+ 
+sealed trait Container { self =>
+  type Child = SelfTyped { type Self <: self.ChildSelf }
+  type ChildSelf
+  def child: Child
+}
+ 
+sealed trait ExampleChild extends SelfTyped
+ 
+case class Example (child: Example#Child) extends Container {
+  type Self = Example
+  type ChildSelf = ExampleChild
+}
+ 
+sealed trait AbstractNode extends ExampleChild { }
+sealed case class ConcreteNode () extends AbstractNode { override type Self = ConcreteNode }
+ 
+object ProofOfConcept {
+  def processContainer(container: Container): Unit = {
+    val c: container.Child = container.
+    c match {
+      case n: ConcreteNode => // java.lang.ClassCastException: ConcreteNode cannot be cast to scala.runtime.Null$
+        n
+    }
+  }
+}
+object Test extends App {
+  ProofOfConcept.processContainer(Example(ConcreteNode()))
+}


### PR DESCRIPTION
Reverts the change to `asSeenFrom`, b7b81ca28. The test from that
commit remains; it must have been fixed in the right place in
the meantime.

The error that we've shed in `run/t8634.scala` also looks like
a progression.

Review by the build kitteh then by @adriaanm

If it seems like this is the right direction, I'll see about bisecting
what changed in the meantime. It is probably worth dbuilding this one,
too.
