### PR TITLE
SI-6967 Fix ClassTag unapply for primitives

### DIFF
--- a/test/files/run/t6318_primitives.check
+++ b/test/files/run/t6318_primitives.check
@@ -1,36 +1,54 @@
-true
+Checking if byte matches byte
 Some(1)
-false
+Checking if byte matches short
 None
-true
+Checking if class java.lang.Byte matches byte
 Some(1)
-false
+Checking if short matches short
+Some(1)
+Checking if short matches char
 None
-true
+Checking if class java.lang.Short matches short
+Some(1)
+Checking if char matches char
 Some()
-false
+Checking if char matches int
 None
-true
+Checking if class java.lang.Character matches char
+Some()
+Checking if int matches int
 Some(1)
-false
+Checking if int matches long
 None
-true
+Checking if class java.lang.Integer matches int
 Some(1)
-false
+Checking if long matches long
+Some(1)
+Checking if long matches float
 None
-true
+Checking if class java.lang.Long matches long
+Some(1)
+Checking if float matches float
 Some(1.0)
-false
+Checking if float matches double
 None
-true
+Checking if class java.lang.Float matches float
 Some(1.0)
-false
+Checking if double matches double
+Some(1.0)
+Checking if double matches boolean
 None
-true
+Checking if class java.lang.Double matches double
+Some(1.0)
+Checking if boolean matches boolean
 Some(true)
-false
+Checking if boolean matches void
 None
-true
+Checking if class java.lang.Boolean matches boolean
+Some(true)
+Checking if void matches void
 Some(())
-false
+Checking if void matches byte
 None
+Checking if class scala.runtime.BoxedUnit matches void
+Some(())

--- a/test/files/run/t6318_primitives.scala
+++ b/test/files/run/t6318_primitives.scala
@@ -2,70 +2,88 @@ import scala.reflect.{ClassTag, classTag}
 
 object Test extends App {
   def test[T: ClassTag](x: T) {
-    println(classTag[T].runtimeClass.isAssignableFrom(x.getClass))
+    println(s"Checking if ${x.getClass} matches ${classTag[T].runtimeClass}")
     println(classTag[T].unapply(x))
   }
 
   {
     val x = 1.toByte
-    println(ClassTag.Byte.runtimeClass.isAssignableFrom(x.getClass))
+    println(s"Checking if ${x.getClass} matches ${classTag[Byte].runtimeClass}")
     println(ClassTag.Byte.unapply(x))
-    test(x)
-  }
-
-  {
-    val x = 1.toShort
-    println(ClassTag.Short.runtimeClass.isAssignableFrom(x.getClass))
+    println(s"Checking if ${x.getClass} matches ${classTag[Short].runtimeClass}")
     println(ClassTag.Short.unapply(x))
     test(x)
   }
 
   {
-    val x = 1.toChar
-    println(ClassTag.Char.runtimeClass.isAssignableFrom(x.getClass))
+    val x = 1.toShort
+    println(s"Checking if ${x.getClass} matches ${classTag[Short].runtimeClass}")
+    println(ClassTag.Short.unapply(x))
+    println(s"Checking if ${x.getClass} matches ${classTag[Char].runtimeClass}")
     println(ClassTag.Char.unapply(x))
     test(x)
   }
 
   {
-    val x = 1.toInt
-    println(ClassTag.Int.runtimeClass.isAssignableFrom(x.getClass))
+    val x = 1.toChar
+    println(s"Checking if ${x.getClass} matches ${classTag[Char].runtimeClass}")
+    println(ClassTag.Char.unapply(x))
+    println(s"Checking if ${x.getClass} matches ${classTag[Int].runtimeClass}")
     println(ClassTag.Int.unapply(x))
     test(x)
   }
 
   {
-    val x = 1.toLong
-    println(ClassTag.Long.runtimeClass.isAssignableFrom(x.getClass))
+    val x = 1.toInt
+    println(s"Checking if ${x.getClass} matches ${classTag[Int].runtimeClass}")
+    println(ClassTag.Int.unapply(x))
+    println(s"Checking if ${x.getClass} matches ${classTag[Long].runtimeClass}")
     println(ClassTag.Long.unapply(x))
     test(x)
   }
 
   {
-    val x = 1.toFloat
-    println(ClassTag.Float.runtimeClass.isAssignableFrom(x.getClass))
+    val x = 1.toLong
+    println(s"Checking if ${x.getClass} matches ${classTag[Long].runtimeClass}")
+    println(ClassTag.Long.unapply(x))
+    println(s"Checking if ${x.getClass} matches ${classTag[Float].runtimeClass}")
     println(ClassTag.Float.unapply(x))
     test(x)
   }
 
   {
-    val x = 1.toDouble
-    println(ClassTag.Double.runtimeClass.isAssignableFrom(x.getClass))
+    val x = 1.toFloat
+    println(s"Checking if ${x.getClass} matches ${classTag[Float].runtimeClass}")
+    println(ClassTag.Float.unapply(x))
+    println(s"Checking if ${x.getClass} matches ${classTag[Double].runtimeClass}")
     println(ClassTag.Double.unapply(x))
     test(x)
   }
 
   {
-    val x = true
-    println(ClassTag.Boolean.runtimeClass.isAssignableFrom(x.getClass))
+    val x = 1.toDouble
+    println(s"Checking if ${x.getClass} matches ${classTag[Double].runtimeClass}")
+    println(ClassTag.Double.unapply(x))
+    println(s"Checking if ${x.getClass} matches ${classTag[Boolean].runtimeClass}")
     println(ClassTag.Boolean.unapply(x))
     test(x)
   }
 
   {
-    val x = ()
-    println(ClassTag.Unit.runtimeClass.isAssignableFrom(x.getClass))
+    val x = true
+    println(s"Checking if ${x.getClass} matches ${classTag[Boolean].runtimeClass}")
+    println(ClassTag.Boolean.unapply(x))
+    println(s"Checking if ${x.getClass} matches ${classTag[Unit].runtimeClass}")
     println(ClassTag.Unit.unapply(x))
+    test(x)
+  }
+
+  {
+    val x = ()
+    println(s"Checking if ${x.getClass} matches ${classTag[Unit].runtimeClass}")
+    println(ClassTag.Unit.unapply(x))
+    println(s"Checking if ${x.getClass} matches ${classTag[Byte].runtimeClass}")
+    println(ClassTag.Byte.unapply(x))
     test(x)
   }
 }

--- a/test/files/run/virtpatmat_typetag.check
+++ b/test/files/run/virtpatmat_typetag.check
@@ -1,9 +1,9 @@
-1 is not a Int; it's a class java.lang.Integer
+1 is a Int
 1 is a java.lang.Integer
 1 is not a java.lang.String; it's a class java.lang.Integer
 true is a Any
 woele is a java.lang.String
-1 is not a Int; it's a class java.lang.Integer
+1 is a Int
 1 is a java.lang.Integer
 1 is not a java.lang.String; it's a class java.lang.Integer
 true is a Any


### PR DESCRIPTION
This pull request should make the unapply method on ClassTag work much better for primitives; It makes reflect.ClassTag.Int unapply (2: Any) work.
