### PR TITLE
SI-8554 Two-arg remove throws exception on large count

### DIFF
--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -145,18 +145,21 @@ class ArrayBuffer[A](override protected val initialSize: Int)
     size0 += len
   }
 
-  /** Removes the element on a given index position. It takes time linear in
+  /** Removes zero or more elements at a given index position. It takes time linear in
    *  the buffer size.
    *
    *  @param n       the index which refers to the first element to delete.
    *  @param count   the number of elements to delete
-   *  @throws Predef.IndexOutOfBoundsException if `n` is out of bounds.
+   *  @throws Predef.IndexOutOfBoundsException if any of `n` to `n+count-1`, inclusive, are out of bounds
+   *  @throws   IllegalArgumentException if `count < 0`.
    */
   override def remove(n: Int, count: Int) {
-    require(count >= 0, "removing negative number of elements")
-    if (n < 0 || n > size0 - count) throw new IndexOutOfBoundsException(n.toString)
-    copy(n + count, n, size0 - (n + count))
-    reduceToSize(size0 - count)
+    if (count != 0) {
+      require(count >= 0, "removing negative number of elements")
+      if (n < 0 || n+count > size0) throw new IndexOutOfBoundsException((n+count-1).toString)
+      if (n+count < size0) copy(n + count, n, size0 - (n + count))
+      reduceToSize(size0 - count)
+    }
   }
 
   /** Removes the element at a given index position.

--- a/src/library/scala/collection/mutable/BufferLike.scala
+++ b/src/library/scala/collection/mutable/BufferLike.scala
@@ -109,12 +109,17 @@ trait BufferLike[A, +This <: BufferLike[A, This] with Buffer[A]]
    *
    *  @param n  the index which refers to the first element to remove.
    *  @param count  the number of elements to remove.
-   *  @throws   IndexOutOfBoundsException if the index `n` is not in the valid range
-   *            `0 <= n <= length - count`.
+   *  @throws   IndexOutOfBoundsException if any of the indices `n` to `n+count-1` (inclusive) are not in the valid range
+   *            `0 <= i < length`.
    *  @throws   IllegalArgumentException if `count < 0`.
    */
   def remove(n: Int, count: Int) {
-    for (i <- 0 until count) remove(n)
+    if (count != 0) {
+      require(count >= 0, "removing negative number of elements")
+      if (lengthCompare(n + count) < 0) throw new IndexOutOfBoundsException((n + count - 1).toString)
+      var k = count
+      while (k > 0) { k -=1; remove(n) }
+    }
   }
 
   /** Removes a single element from this buffer, at its first occurrence.


### PR DESCRIPTION
SI-8554  Two-arg remove throws exception on large count

Made ArrayBuffer and BufferLike have same behavior, which is also consistent with single-arg remove.
