### PR TITLE
Don't crash on dead code in ICodeReader

### DIFF
--- a/test/files/run/icode-reader-dead-code.check
+++ b/test/files/run/icode-reader-dead-code.check
@@ -1,0 +1,19 @@
+Bytecode for method f
+   L0
+    LINENUMBER 4 L0
+    ICONST_1
+    IRETURN
+   L1
+    LOCALVARIABLE this Lp/A; L0 L1 0
+    MAXSTACK = 1
+    MAXLOCALS = 1
+Bytecode for method f
+   L0
+    LINENUMBER 4 L0
+    ICONST_1
+    ATHROW
+    IRETURN
+   L1
+    LOCALVARIABLE this Lp/A; L0 L1 0
+    MAXSTACK = 1
+    MAXLOCALS = 1

--- a/test/files/run/icode-reader-dead-code.scala
+++ b/test/files/run/icode-reader-dead-code.scala
@@ -1,0 +1,82 @@
+import java.io.{FileOutputStream, FileInputStream}
+
+import scala.tools.asm.{ClassWriter, Opcodes, ClassReader}
+import scala.tools.asm.tree.{InsnNode, ClassNode}
+import scala.tools.nsc.backend.jvm.AsmUtils
+import scala.tools.partest.DirectTest
+import scala.collection.JavaConverters._
+
+/**
+ * Test that the ICodeReader does not crash if the bytecode of a method has unreachable code.
+ */
+object Test extends DirectTest {
+  def code: String = ???
+
+  def show(): Unit = {
+    // The bytecode of f will be modified using ASM by `addDeadCode`
+    val aCode =
+      """
+        |package p
+        |class A {
+        |  @inline final def f = 1
+        |}
+      """.stripMargin
+
+    val bCode =
+      """
+        |package p
+        |class B {
+        |  def g = (new A()).f
+        |}
+      """.stripMargin
+
+    compileString(newCompiler("-usejavacp"))(aCode)
+
+    addDeadCode()
+
+    // If inlining fails, the compiler will issue an inliner warning that is not present in the
+    // check file
+    compileString(newCompiler("-usejavacp", "-optimise"))(bCode)
+  }
+
+  def readClass(file: String) = {
+    val cnode = new ClassNode()
+    val is = new FileInputStream(file)
+    val reader = new ClassReader(is)
+    reader.accept(cnode, 0)
+    is.close()
+    cnode
+  }
+
+  def writeClass(file: String, cnode: ClassNode): Unit = {
+    val writer = new ClassWriter(0)
+    cnode.accept(writer)
+
+    val os = new FileOutputStream(file)
+    os.write(writer.toByteArray)
+    os.close()
+  }
+
+  def addDeadCode() {
+    val file = (testOutput / "p" / "A.class").path
+    val cnode = readClass(file)
+    val method = cnode.methods.asScala.find(_.name == "f").head
+
+    AsmUtils.traceMethod(method)
+
+    val insns = method.instructions
+    val it = insns.iterator()
+    while (it.hasNext) {
+      val in = it.next()
+      if (in.getOpcode == Opcodes.IRETURN) {
+        // Insert an ATHROW before the IRETURN. The IRETURN will then be dead code.
+        // The ICodeReader should not crash if there's dead code.
+        insns.insert(in.getPrevious, new InsnNode(Opcodes.ATHROW))
+      }
+    }
+
+    AsmUtils.traceMethod(method)
+
+    writeClass(file, cnode)
+  }
+}

--- a/test/files/run/repl-javap-app.check
+++ b/test/files/run/repl-javap-app.check
@@ -1,4 +1,5 @@
 #partest java6
+Welcome to Scala
 Type in expressions to have them evaluated.
 Type :help for more information.
 
@@ -6,9 +7,9 @@ scala> :javap -app MyApp$
 public final void delayedEndpoint$MyApp$1();
   Code:
    Stack=2, Locals=1, Args_size=1
-   0:	getstatic	#61; //Field scala/Console$.MODULE$:Lscala/Console$;
-   3:	ldc	#63; //String Hello, delayed world.
-   5:	invokevirtual	#67; //Method scala/Console$.println:(Ljava/lang/Object;)V
+   0:	getstatic	#XX; //Field scala/Console$.MODULE$:Lscala/Console$;
+   3:	ldc	#XX; //String Hello, delayed world.
+   5:	invokevirtual	#XX; //Method scala/Console$.println:(Ljava/lang/Object;)V
    8:	return
   LocalVariableTable: 
    Start  Length  Slot  Name   Signature
@@ -16,6 +17,7 @@ public final void delayedEndpoint$MyApp$1();
 
 scala> 
 #partest !java6
+Welcome to Scala
 Type in expressions to have them evaluated.
 Type :help for more information.
 
@@ -24,9 +26,9 @@ scala> :javap -app MyApp$
     flags: ACC_PUBLIC, ACC_FINAL
     Code:
       stack=2, locals=1, args_size=1
-         0: getstatic     #61                 // Field scala/Console$.MODULE$:Lscala/Console$;
-         3: ldc           #63                 // String Hello, delayed world.
-         5: invokevirtual #67                 // Method scala/Console$.println:(Ljava/lang/Object;)V
+         0: getstatic     #XX                 // Field scala/Console$.MODULE$:Lscala/Console$;
+         3: ldc           #XX                 // String Hello, delayed world.
+         5: invokevirtual #XX                 // Method scala/Console$.println:(Ljava/lang/Object;)V
          8: return        
       LocalVariableTable:
         Start  Length  Slot  Name   Signature

--- a/test/files/run/repl-javap-app.scala
+++ b/test/files/run/repl-javap-app.scala
@@ -7,4 +7,15 @@ object MyApp extends App {
 
 object Test extends ReplTest {
   def code = ":javap -app MyApp$"
+
+  override def welcoming = true
+
+  // The constant pool indices are not the same for GenASM / GenBCode, so
+  // replacing the exact numbers by XX.
+  lazy val hasConstantPoolRef = """(.*)(#\d\d)(.*)""".r
+
+  override def normalize(s: String) = s match {
+    case hasConstantPoolRef(start, ref, end) => start + "#XX" + end
+    case _ => super.normalize(s)
+  }
 }

--- a/test/files/run/t7974.check
+++ b/test/files/run/t7974.check
@@ -1,6 +1,5 @@
 public class Symbols {
 
-  // compiled from: Symbols.scala
 
 
 
@@ -18,20 +17,14 @@ public class Symbols {
 
   // access flags 0x9
   public static <clinit>()V
-   L0
-    LINENUMBER 2 L0
     GETSTATIC scala/Symbol$.MODULE$ : Lscala/Symbol$;
     LDC "Symbolic1"
     INVOKEVIRTUAL scala/Symbol$.apply (Ljava/lang/String;)Lscala/Symbol;
     PUTSTATIC Symbols.symbol$1 : Lscala/Symbol;
-   L1
-    LINENUMBER 3 L1
     GETSTATIC scala/Symbol$.MODULE$ : Lscala/Symbol$;
     LDC "Symbolic2"
     INVOKEVIRTUAL scala/Symbol$.apply (Ljava/lang/String;)Lscala/Symbol;
     PUTSTATIC Symbols.symbol$2 : Lscala/Symbol;
-   L2
-    LINENUMBER 5 L2
     GETSTATIC scala/Symbol$.MODULE$ : Lscala/Symbol$;
     LDC "Symbolic3"
     INVOKEVIRTUAL scala/Symbol$.apply (Ljava/lang/String;)Lscala/Symbol;
@@ -42,63 +35,41 @@ public class Symbols {
 
   // access flags 0x1
   public someSymbol1()Lscala/Symbol;
-   L0
-    LINENUMBER 2 L0
     GETSTATIC Symbols.symbol$1 : Lscala/Symbol;
     ARETURN
-   L1
-    LOCALVARIABLE this LSymbols; L0 L1 0
     MAXSTACK = 1
     MAXLOCALS = 1
 
   // access flags 0x1
   public someSymbol2()Lscala/Symbol;
-   L0
-    LINENUMBER 3 L0
     GETSTATIC Symbols.symbol$2 : Lscala/Symbol;
     ARETURN
-   L1
-    LOCALVARIABLE this LSymbols; L0 L1 0
     MAXSTACK = 1
     MAXLOCALS = 1
 
   // access flags 0x1
   public sameSymbol1()Lscala/Symbol;
-   L0
-    LINENUMBER 4 L0
     GETSTATIC Symbols.symbol$1 : Lscala/Symbol;
     ARETURN
-   L1
-    LOCALVARIABLE this LSymbols; L0 L1 0
     MAXSTACK = 1
     MAXLOCALS = 1
 
   // access flags 0x1
   public someSymbol3()Lscala/Symbol;
-   L0
-    LINENUMBER 5 L0
     ALOAD 0
     GETFIELD Symbols.someSymbol3 : Lscala/Symbol;
     ARETURN
-   L1
-    LOCALVARIABLE this LSymbols; L0 L1 0
     MAXSTACK = 1
     MAXLOCALS = 1
 
   // access flags 0x1
   public <init>()V
-   L0
-    LINENUMBER 6 L0
     ALOAD 0
     INVOKESPECIAL java/lang/Object.<init> ()V
-   L1
-    LINENUMBER 5 L1
     ALOAD 0
     GETSTATIC Symbols.symbol$3 : Lscala/Symbol;
     PUTFIELD Symbols.someSymbol3 : Lscala/Symbol;
     RETURN
-   L2
-    LOCALVARIABLE this LSymbols; L0 L2 0
     MAXSTACK = 2
     MAXLOCALS = 1
 }

--- a/test/files/run/t7974/Test.scala
+++ b/test/files/run/t7974/Test.scala
@@ -6,7 +6,7 @@ import scala.tools.nsc.util.stringFromWriter
 
 object Test extends BytecodeTest {
   def show {
-    val classNode = loadClassNode("Symbols", skipDebugInfo = false)
+    val classNode = loadClassNode("Symbols", skipDebugInfo = true)
     val textifier = new Textifier
     classNode.accept(new TraceClassVisitor(null, textifier, null))
 


### PR DESCRIPTION
Under `-Ybackend:GenBCode`, the scala compiler occasionally emits dead code, see discussion on PR #3726 for example.

Such a class file crashes ICodeReader. This was uncovered because under `-optimise`, the compiler switches to the ICode-GenASM pipeline, even if the `-Ybackend:GenBCode` flag is present.

There are multiple [tests that fail before](https://scala-webapps.epfl.ch/jenkins/job/scala-checkin-manual/1227/consoleFull) basically because the compiler emits inliner warnings ("could not inline") when the ICodeReader failed.
