### PR TITLE
SI-5919 TypeTags and Exprs should be serializable

### DIFF
--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -254,6 +254,23 @@ filter {
     {
        matchName="scala.reflect.runtime.JavaUniverse.PerRunReporting"
        problemName=MissingMethodProblem
+    },
+    // see SI-5919
+    {
+        matchName="scala.reflect.api.TypeTags$PredefTypeCreator"
+        problemName=MissingTypesProblem
+    },
+    {
+        matchName="scala.reflect.api.TreeCreator"
+        problemName=MissingTypesProblem
+    },
+    {
+        matchName="scala.reflect.api.TypeCreator"
+        problemName=MissingTypesProblem
+    },
+    {
+        matchName="scala.reflect.api.PredefTypeCreator"
+        problemName=MissingClassProblem
     }
   ]
 }

--- a/src/reflect/scala/reflect/api/Exprs.scala
+++ b/src/reflect/scala/reflect/api/Exprs.scala
@@ -9,6 +9,7 @@ package api
 
 import scala.reflect.runtime.{universe => ru}
 import scala.annotation.compileTimeOnly
+import java.io.ObjectStreamException
 
 /**
  * <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>
@@ -157,23 +158,22 @@ trait Exprs { self: Universe =>
       |if you want to get a value of the underlying expression, add scala-compiler.jar to the classpath,
       |import `scala.tools.reflect.Eval` and call `<your expr>.eval` instead.""".trim.stripMargin)
 
+    @throws(classOf[ObjectStreamException])
     private def writeReplace(): AnyRef = new SerializedExpr(treec, implicitly[WeakTypeTag[T]].in(ru.rootMirror))
   }
 }
 
 private[scala] class SerializedExpr(var treec: TreeCreator, var tag: ru.WeakTypeTag[_]) extends Serializable {
-  private def writeObject(out: java.io.ObjectOutputStream): Unit = {
-    out.writeObject(treec)
-    out.writeObject(tag)
-  }
+  import scala.reflect.runtime.universe.{Expr, runtimeMirror}
 
-  private def readObject(in: java.io.ObjectInputStream): Unit = {
-    treec = in.readObject().asInstanceOf[TreeCreator]
-    tag = in.readObject().asInstanceOf[ru.WeakTypeTag[_]]
-  }
-
+  @throws(classOf[ObjectStreamException])
   private def readResolve(): AnyRef = {
-    import ru._
-    Expr(rootMirror, treec)(tag)
+    val loader: ClassLoader = try {
+      Thread.currentThread().getContextClassLoader()
+    } catch {
+      case se: SecurityException => null
+    }
+    val m = runtimeMirror(loader)
+    Expr(m, treec)(tag.in(m))
   }
 }

--- a/src/reflect/scala/reflect/api/Exprs.scala
+++ b/src/reflect/scala/reflect/api/Exprs.scala
@@ -163,6 +163,7 @@ trait Exprs { self: Universe =>
   }
 }
 
+@SerialVersionUID(1L)
 private[scala] class SerializedExpr(var treec: TreeCreator, var tag: ru.WeakTypeTag[_]) extends Serializable {
   import scala.reflect.runtime.universe.{Expr, runtimeMirror}
 

--- a/src/reflect/scala/reflect/api/TreeCreator.scala
+++ b/src/reflect/scala/reflect/api/TreeCreator.scala
@@ -2,12 +2,12 @@ package scala
 package reflect
 package api
 
-/** This is an internal implementation class.
+/** A mirror-aware factory for trees.
  *
  * This class is used internally by Scala Reflection, and is not recommended for use in client code.
  *
- *  @group ReflectionAPI
+ * @group ReflectionAPI
  */
-abstract class TreeCreator {
+abstract class TreeCreator extends Serializable {
   def apply[U <: Universe with Singleton](m: scala.reflect.api.Mirror[U]): U # Tree
 }

--- a/src/reflect/scala/reflect/api/TypeCreator.scala
+++ b/src/reflect/scala/reflect/api/TypeCreator.scala
@@ -8,6 +8,6 @@ package api
  *
  * @group ReflectionAPI
  */
-abstract class TypeCreator {
+abstract class TypeCreator extends Serializable {
   def apply[U <: Universe with Singleton](m: scala.reflect.api.Mirror[U]): U # Type
 }

--- a/src/reflect/scala/reflect/api/TypeTags.scala
+++ b/src/reflect/scala/reflect/api/TypeTags.scala
@@ -349,8 +349,7 @@ trait TypeTags { self: Universe =>
 
 // This class should be final, but we can't do that in Scala 2.11.x without breaking
 // binary incompatibility.
-// Since instances of this class are serialized, this class should have a
-// SerialVersionUID annotation.
+@SerialVersionUID(1L)
 private[scala] class SerializedTypeTag(var tpec: TypeCreator, var concrete: Boolean) extends Serializable {
   import scala.reflect.runtime.universe.{TypeTag, WeakTypeTag, runtimeMirror}
   @throws(classOf[ObjectStreamException])

--- a/src/reflect/scala/reflect/api/TypeTags.scala
+++ b/src/reflect/scala/reflect/api/TypeTags.scala
@@ -9,6 +9,7 @@ package api
 
 import java.lang.{ Class => jClass }
 import scala.language.implicitConversions
+import java.io.ObjectStreamException
 
 /**
  * A `TypeTag[T]` encapsulates the runtime type representation of some type `T`.
@@ -233,6 +234,7 @@ trait TypeTags { self: Universe =>
       val otherMirror1 = otherMirror.asInstanceOf[scala.reflect.api.Mirror[otherMirror.universe.type]]
       otherMirror.universe.WeakTypeTag[T](otherMirror1, tpec)
     }
+    @throws(classOf[ObjectStreamException])
     private def writeReplace(): AnyRef = new SerializedTypeTag(tpec, concrete = false)
   }
 
@@ -293,10 +295,13 @@ trait TypeTags { self: Universe =>
       val otherMirror1 = otherMirror.asInstanceOf[scala.reflect.api.Mirror[otherMirror.universe.type]]
       otherMirror.universe.TypeTag[T](otherMirror1, tpec)
     }
+    @throws(classOf[ObjectStreamException])
     private def writeReplace(): AnyRef = new SerializedTypeTag(tpec, concrete = true)
   }
 
   /* @group TypeTags */
+  // This class only exists to silence MIMA complaining about a binary incompatibility.
+  // Only the top-level class (api.PredefTypeCreator) should be used.
   private class PredefTypeCreator[T](copyIn: Universe => Universe#TypeTag[T]) extends TypeCreator {
     def apply[U <: Universe with Singleton](m: scala.reflect.api.Mirror[U]): U # Type = {
       copyIn(m.universe).asInstanceOf[U # TypeTag[T]].tpe
@@ -304,8 +309,9 @@ trait TypeTags { self: Universe =>
   }
 
   /* @group TypeTags */
-  private class PredefTypeTag[T](_tpe: Type, copyIn: Universe => Universe#TypeTag[T]) extends TypeTagImpl[T](rootMirror, new PredefTypeCreator(copyIn)) {
+  private class PredefTypeTag[T](_tpe: Type, copyIn: Universe => Universe#TypeTag[T]) extends TypeTagImpl[T](rootMirror, new api.PredefTypeCreator(copyIn)) {
     override lazy val tpe: Type = _tpe
+    @throws(classOf[ObjectStreamException])
     private def writeReplace(): AnyRef = new SerializedTypeTag(tpec, concrete = true)
   }
 
@@ -341,20 +347,28 @@ trait TypeTags { self: Universe =>
   def symbolOf[T: WeakTypeTag]: TypeSymbol
 }
 
+// This class should be final, but we can't do that in Scala 2.11.x without breaking
+// binary incompatibility.
+// Since instances of this class are serialized, this class should have a
+// SerialVersionUID annotation.
 private[scala] class SerializedTypeTag(var tpec: TypeCreator, var concrete: Boolean) extends Serializable {
-  private def writeObject(out: java.io.ObjectOutputStream): Unit = {
-    out.writeObject(tpec)
-    out.writeBoolean(concrete)
-  }
-
-  private def readObject(in: java.io.ObjectInputStream): Unit = {
-    tpec = in.readObject().asInstanceOf[TypeCreator]
-    concrete = in.readBoolean()
-  }
-
+  import scala.reflect.runtime.universe.{TypeTag, WeakTypeTag, runtimeMirror}
+  @throws(classOf[ObjectStreamException])
   private def readResolve(): AnyRef = {
-    import scala.reflect.runtime.universe._
-    if (concrete) TypeTag(rootMirror, tpec)
-    else WeakTypeTag(rootMirror, tpec)
+    val loader: ClassLoader = try {
+      Thread.currentThread().getContextClassLoader()
+    } catch {
+      case se: SecurityException => null
+    }
+    val m = runtimeMirror(loader)
+    if (concrete) TypeTag(m, tpec)
+    else WeakTypeTag(m, tpec)
+  }
+}
+
+/* @group TypeTags */
+private class PredefTypeCreator[T](copyIn: Universe => Universe#TypeTag[T]) extends TypeCreator {
+  def apply[U <: Universe with Singleton](m: scala.reflect.api.Mirror[U]): U # Type = {
+    copyIn(m.universe).asInstanceOf[U # TypeTag[T]].tpe
   }
 }

--- a/test/files/run/abstypetags_serialize.check
+++ b/test/files/run/abstypetags_serialize.check
@@ -1,2 +1,2 @@
-java.io.NotSerializableException: Test$$typecreator1$1
-java.io.NotSerializableException: Test$$typecreator2$1
+WeakTypeTag[T]
+WeakTypeTag[U[String]]

--- a/test/files/run/exprs_serialize.check
+++ b/test/files/run/exprs_serialize.check
@@ -1,2 +1,19 @@
-java.io.NotSerializableException: Test$$treecreator1$1
-java.io.NotSerializableException: Test$$treecreator2$1
+Expr[Int(2)](2)
+Expr[java.lang.String]({
+  def foo = "hello";
+  foo.$plus("world!")
+})
+Expr[Boolean]({
+  def foo(x: Int) = {
+    class Local extends AnyRef {
+      def <init>() = {
+        super.<init>();
+        ()
+      };
+      val f = 2
+    };
+    val obj = new Local();
+    x.$percent(obj.f).$eq$eq(0)
+  };
+  foo(5)
+})

--- a/test/files/run/exprs_serialize.scala
+++ b/test/files/run/exprs_serialize.scala
@@ -26,4 +26,14 @@ object Test extends App {
 
   test(reify(2))
   test(reify{def foo = "hello"; foo + "world!"})
+  test(reify {
+    def foo(x: Int) = {
+      class Local {
+        val f = 2
+      }
+      val obj = new Local
+      x % obj.f == 0
+    }
+    foo(5)
+  })
 }

--- a/test/files/run/typetags_serialize.check
+++ b/test/files/run/typetags_serialize.check
@@ -1,2 +1,3 @@
-java.io.NotSerializableException: scala.reflect.api.TypeTags$PredefTypeCreator
-java.io.NotSerializableException: Test$$typecreator1$1
+TypeTag[Int]
+TypeTag[String]
+TypeTag[Test.C[Double]]

--- a/test/files/run/typetags_serialize.scala
+++ b/test/files/run/typetags_serialize.scala
@@ -4,6 +4,10 @@ import scala.reflect.runtime.{universe => ru}
 import scala.reflect.runtime.{currentMirror => cm}
 
 object Test extends App {
+  class C[A] {
+    def m(a: A): Int = 5
+  }
+
   def test(tag: TypeTag[_]) =
     try {
       val fout = new ByteArrayOutputStream()
@@ -26,4 +30,5 @@ object Test extends App {
 
   test(implicitly[TypeTag[Int]])
   test(implicitly[TypeTag[String]])
+  test(implicitly[TypeTag[C[Double]]])
 }


### PR DESCRIPTION
- Make TypeCreator and TreeCreator extend Serializable.
- When replacing a SerializedTypeTag with a TypeTag or WeakTypeTag,
  do not use scala.reflect.runtime.universe.rootMirror, since
  it is unlikely to find user classes; instead, create a runtime
  mirror using the context ClassLoader of the current thread.
  Use the same logic for SerializedExpr.
- Remove writeObject/readObject methods from SerializedTypeTag
  and SerializedExpr since they are unused.
- Add @throws annotation on writeReplace and readResolve methods.
- Handle SecurityException if the current thread cannot access the
  context ClassLoader.
- To make type tags of primitive value classes serializable, make
  PredefTypeCreator a top-level class. Otherwise, it would
  retain a reference to the enclosing Universe,
  rendering the TypeCreator non-serializable.
