### PR TITLE
Mlbileschi update partial function documentation

### DIFF
--- a/src/library/scala/PartialFunction.scala
+++ b/src/library/scala/PartialFunction.scala
@@ -12,7 +12,7 @@ package scala
 /** A partial function of type `PartialFunction[A, B]` is a unary function
  *  where the domain does not necessarily include all values of type `A`.
  *  The function `isDefinedAt` allows to test dynamically if a value is in
- *  the domain of the function.
+ *  the domain of the function. 
  *
  *  Even if `isDefinedAt` returns true for an `a: A`, calling `apply(a)` may
  *  still throw an exception, so the following code is legal:
@@ -20,6 +20,12 @@ package scala
  *  {{{
  *  val f: PartialFunction[Int, Any] = { case _ => 1/0 }
  *  }}}
+ * 
+ *  It is the responsibility of the caller of `apply` to check for membership
+ *  in the domain by calling `isDefinedAt`, to ensure sanity of return values. 
+ *  A notable exception to this rule is `PartialFunction`s created with curly 
+ *  braces and case statements; In this case, a [[scala.MatchError]] is 
+ *  thrown if `isDefinedAt` (i.e. pattern matching) fails.
  *
  *  The main distinction between `PartialFunction` and [[scala.Function1]] is
  *  that the user of a `PartialFunction` may choose to do something different

--- a/src/library/scala/PartialFunction.scala
+++ b/src/library/scala/PartialFunction.scala
@@ -12,7 +12,7 @@ package scala
 /** A partial function of type `PartialFunction[A, B]` is a unary function
  *  where the domain does not necessarily include all values of type `A`.
  *  The function `isDefinedAt` allows to test dynamically if a value is in
- *  the domain of the function. 
+ *  the domain of the function.
  *
  *  Even if `isDefinedAt` returns true for an `a: A`, calling `apply(a)` may
  *  still throw an exception, so the following code is legal:

--- a/src/library/scala/PartialFunction.scala
+++ b/src/library/scala/PartialFunction.scala
@@ -21,11 +21,10 @@ package scala
  *  val f: PartialFunction[Int, Any] = { case _ => 1/0 }
  *  }}}
  * 
- *  It is the responsibility of the caller of `apply` to check for membership
- *  in the domain by calling `isDefinedAt`, to ensure sanity of return values. 
- *  A notable exception to this rule is `PartialFunction`s created with curly 
- *  braces and case statements; In this case, a [[scala.MatchError]] is 
- *  thrown if `isDefinedAt` (i.e. pattern matching) fails.
+ *  It is the responsibility of the caller to call `isDefinedAt` before
+ *  before calling `apply`, because if `isDefinedAt` is false, an exception
+ *  may or may not be thrown. In the case that an exception is not thrown,
+ *  an insane value may be returned. 
  *
  *  The main distinction between `PartialFunction` and [[scala.Function1]] is
  *  that the user of a `PartialFunction` may choose to do something different

--- a/src/library/scala/PartialFunction.scala
+++ b/src/library/scala/PartialFunction.scala
@@ -22,9 +22,9 @@ package scala
  *  }}}
  * 
  *  It is the responsibility of the caller to call `isDefinedAt` before
- *  before calling `apply`, because if `isDefinedAt` is false, an exception
- *  may or may not be thrown. In the case that an exception is not thrown,
- *  an insane value may be returned. 
+ *  calling `apply`, because if `isDefinedAt` is false, it is not guaranteed
+ *  `apply` will throw an exception to indicate an error condition. If an
+ *  exception is not thrown, evaluation may result in an arbitrary value.
  *
  *  The main distinction between `PartialFunction` and [[scala.Function1]] is
  *  that the user of a `PartialFunction` may choose to do something different


### PR DESCRIPTION
To include the fact that the caller is responsible for checking 'isDefinedAt', except when using partial functions defined using {} and case statements.
