### PR TITLE
SI-8672 Better end-of-sentence detection for Scaladoc

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
@@ -666,7 +666,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
     }
 
     def summary(): Inline = {
-      val i = inline(check("."))
+      val i = inline(checkSentenceEnded())
       Summary(
         if (jump("."))
           Chain(List(i, Text(".")))
@@ -783,6 +783,16 @@ trait CommentFactoryBase { this: MemberLookupBase =>
         offset = poff
         ok
       })
+    }
+
+    def checkSentenceEnded(): Boolean = {
+      (char == '.') && {
+        val poff = offset
+        nextChar() // read '.'
+        val ok = char == endOfText || char == endOfLine || isWhitespace(char)
+        offset = poff
+        ok
+      }
     }
 
     def reportError(pos: Position, message: String) {

--- a/test/scaladoc/run/t8672.check
+++ b/test/scaladoc/run/t8672.check
@@ -1,0 +1,4 @@
+Some(Chain(List(Text(New in release 1.2.3.4, it works), Text(.))))
+Some(Text(Sentence no period))
+Some(Chain(List(Text(Sentence period at end), Text(.))))
+Done.

--- a/test/scaladoc/run/t8672.scala
+++ b/test/scaladoc/run/t8672.scala
@@ -1,0 +1,32 @@
+import scala.tools.nsc.doc.model._
+import scala.tools.partest.ScaladocModelTest
+
+object Test extends ScaladocModelTest {
+  override def code = """
+  class C {
+    
+    /**
+     * New in release 1.2.3.4, it works. Next sentence.
+     * Next Line.
+     */
+    def method1 = 0
+
+    /** Sentence no period */
+    def method2 = 0
+
+    /** Sentence period at end.*/
+    def method3 = 0
+  }
+  """
+
+  def scaladocSettings = ""
+
+  def testModel(root: Package) = {
+    import access._
+    val ms = List("method1", "method2", "method3")
+    for (m <- ms) {
+      val method = root._class("C")._method(m)
+      println(method.comment.get.body.summary)  
+    }
+  }
+}


### PR DESCRIPTION
The first sentence of a Scaladoc comment is parsed as the summary.
However, this was breaking of the sentence at the first `.`, even
if that was immediately followed by another character.

This commit only considers a period followed by whitespace, EOL or
EOF as the end of a sentence.

Review by @vladureche
