### PR TITLE
SI-8675 Avoid unreported error after second try using implicit view

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4399,7 +4399,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           if (retry) {
             val Select(qual, name) = fun
             tryTypedArgs(args, forArgMode(fun, mode)) match {
-              case Some(args1) =>
+              case Some(args1) if !args1.exists(arg => arg.exists(_.isErroneous)) =>
                 val qual1 =
                   if (!pt.isError) adaptToArguments(qual, name, args1, pt, reportAmbiguous = true, saveErrors = true)
                   else qual

--- a/test/files/neg/t8675.check
+++ b/test/files/neg/t8675.check
@@ -1,0 +1,11 @@
+t8675.scala:13: error: type mismatch;
+ found   : Boolean(true)
+ required: String
+    a.update(0, x[A]({new isString(true)})) // !!! allowed
+                                   ^
+t8675.scala:22: error: type mismatch;
+ found   : Boolean(true)
+ required: String
+    new X().m(x[A]({new isString(true)})) // !!! allowed
+                                 ^
+two errors found

--- a/test/files/neg/t8675.scala
+++ b/test/files/neg/t8675.scala
@@ -1,0 +1,24 @@
+class A(s: String) {
+  def foo(x: A) = x
+}
+
+class isString(s: String)
+
+class Test {
+
+  def x[A](a: Any): A = ???
+
+  def test {
+    val a = Array[A]()
+    a.update(0, x[A]({new isString(true)})) // !!! allowed
+
+    // boils down to
+    class X {
+      def m(p: Any) {}
+    }
+    implicit class XOps(x: X) {
+      def m(p: Any) {}
+    }
+    new X().m(x[A]({new isString(true)})) // !!! allowed
+  }
+}

--- a/test/files/neg/t8675b.check
+++ b/test/files/neg/t8675b.check
@@ -1,0 +1,6 @@
+t8675b.scala:19: error: missing parameter type for expanded function
+The argument types of an anonymous function must be fully known. (SLS 8.5)
+Expected type was: List[Test.Reportable1[?,?]] => Boolean
+  for (path: List[Any] <- (null : Engine1).asRequirement.pathsIncludingSelf.toList) {
+                                                                            ^
+one error found

--- a/test/files/neg/t8675b.scala
+++ b/test/files/neg/t8675b.scala
@@ -1,0 +1,22 @@
+object Test {
+  trait Engine1
+
+  implicit class EngineTools1[Params, R](e: Engine1) {
+    def asRequirement: Requirement1[Params, R] = ???
+  }
+  trait Requirement1[Params, R] {
+    def pathsIncludingSelf: Traversable[List[Reportable1[Params, R]]]
+  }
+  trait Reportable1[Params, R]
+
+  // "missing paramater type" error was swallowed in 2.11.0 leading to a crash
+  // in the backend.
+  //
+  // This error is itself a regression (or at least a change) in 2.11.0-M7,
+  // specifically in SI-7944. The type paramaters to the implicit view
+  // `EngineTools1` are undetermined, and are now treated as type variables
+  // in the expected type of the closure argument to `withFilter`.
+  for (path: List[Any] <- (null : Engine1).asRequirement.pathsIncludingSelf.toList) {
+    ???
+  }
+}


### PR DESCRIPTION
This is specific to situations in which we first typecheck an
application `qual.m(arg)` against the method `m` directly provided
by `qual`, and then fall back to `implicitView(qual).m(arg)`.

Regressed in SI-3971 / 7fa77af, in which error reports were moved
to the innermost `Apply`, and the check for `errorInResult` was
accordingly changed to recurse through `Apply` trees.

Before that change, we did not fall back to using a view. After the
change, we do try a view. We retypecheck the arguments under the
`retyping` mode (see `tryTypedArgs`), but this doesn't seem to
be enough to avoid leaking the error typed nested trees from the
first try.

Here's an example from the enclosed test case:

```
a.update(0, x[A]({new isString(true)}))
                               `-- error typed

refArrayOps(a).update(0, x[A]({new isString(true)}))
                         `                  `-- error type persists
                          `-- this tree is retypecked by tryTypedArgs
```

This commit changes `onError` to only proceed with the second
try if the retyped argument trees are error free.
