### PR TITLE
SI-8657 don't miss tailrec defs in more positions

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/TailCalls.scala
+++ b/src/compiler/scala/tools/nsc/transform/TailCalls.scala
@@ -332,7 +332,7 @@ abstract class TailCalls extends Transform {
 
         case If(cond, thenp, elsep) =>
           treeCopy.If(tree,
-            cond,
+            noTailTransform(cond),
             transform(thenp),
             transform(elsep)
           )
@@ -363,7 +363,7 @@ abstract class TailCalls extends Transform {
           rewriteApply(tapply, fun, targs, vargs)
 
         case Apply(fun, args) if fun.symbol == Boolean_or || fun.symbol == Boolean_and =>
-          treeCopy.Apply(tree, fun, transformTrees(args))
+          treeCopy.Apply(tree, noTailTransform(fun), transformTrees(args))
 
         // this is to detect tailcalls in translated matches
         // it's a one-argument call to a label that is in a tailposition and that looks like label(x) {x}

--- a/test/files/run/tailcalls.check
+++ b/test/files/run/tailcalls.check
@@ -50,6 +50,9 @@ test NonTailCall.f2
 test TailCall.b1 was successful
 test TailCall.b2 was successful
 test FancyTailCalls.tcTryLocal was successful
+test FancyTailCalls.tcInBooleanExprFirstOp was successful
+test FancyTailCalls.tcInBooleanExprSecondOp was successful
+test FancyTailCalls.tcInIfCond was successful
 test FancyTailCalls.differentInstance was successful
 test PolyObject.tramp was successful
 #partest avian
@@ -104,5 +107,8 @@ test NonTailCall.f2
 test TailCall.b1 was successful
 test TailCall.b2 was successful
 test FancyTailCalls.tcTryLocal was successful
+test FancyTailCalls.tcInBooleanExprFirstOp was successful
+test FancyTailCalls.tcInBooleanExprSecondOp was successful
+test FancyTailCalls.tcInIfCond was successful
 test FancyTailCalls.differentInstance was successful
 test PolyObject.tramp was successful

--- a/test/files/run/tailcalls.scala
+++ b/test/files/run/tailcalls.scala
@@ -213,6 +213,31 @@ class FancyTailCalls {
     } finally {}
   }
 
+  def tcInBooleanExprFirstOp(x: Int, v: Int): Boolean = {
+    {
+      def loop(n: Int): Int = {
+        if (n == 0) v else loop(n - 1)
+      }
+      loop(x)
+    } == v && true
+  }
+  def tcInBooleanExprSecondOp(x: Int, v: Int): Boolean = {
+    true && {
+      def loop(n: Int): Int = {
+        if (n == 0) v else loop(n - 1)
+      }
+      loop(x)
+    } == v
+  }
+  def tcInIfCond(x: Int, v: Int): Boolean = {
+    if ({
+      def loop(n: Int): Int = {
+        if (n == 0) v else loop(n - 1)
+      }
+      loop(x)
+    } == v) true else false
+  }
+
   import FancyTailCalls._
   final def differentInstance(n: Int, v: Int): Int = {
     if (n == 0) v
@@ -376,8 +401,11 @@ object Test {
     check_success_b("TailCall.b2", TailCall.b2(max), true)
 
     val FancyTailCalls = new FancyTailCalls;
-    check_success("FancyTailCalls.tcTryLocal",   FancyTailCalls.tcTryLocal(max, max), max)
-    check_success("FancyTailCalls.differentInstance",   FancyTailCalls.differentInstance(max, 42), 42)
+    check_success("FancyTailCalls.tcTryLocal", FancyTailCalls.tcTryLocal(max, max), max)
+    check_success_b("FancyTailCalls.tcInBooleanExprFirstOp", FancyTailCalls.tcInBooleanExprFirstOp(max, max), true)
+    check_success_b("FancyTailCalls.tcInBooleanExprSecondOp", FancyTailCalls.tcInBooleanExprSecondOp(max, max), true)
+    check_success_b("FancyTailCalls.tcInIfCond", FancyTailCalls.tcInIfCond(max, max), true)
+    check_success("FancyTailCalls.differentInstance", FancyTailCalls.differentInstance(max, 42), 42)
     check_success("PolyObject.tramp", PolyObject.tramp[Int](max), 0)
   }
 


### PR DESCRIPTION
1) First operand of boolean expression using `&&` or `||`. Second operands of
   those boolean exprs were already treated specially here but handling for first
   operands was missing.
2) Condition of `If`.

This may be a candidate for backporting as well.
