### PR TITLE
SI-8657 don't miss tailrec defs in more positions

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/TailCalls.scala
+++ b/src/compiler/scala/tools/nsc/transform/TailCalls.scala
@@ -328,11 +328,14 @@ abstract class TailCalls extends Transform {
           )
 
         case CaseDef(pat, guard, body) =>
+          // CaseDefs are already translated and guards were moved into the body.
+          // If this was not the case, guards would have to be transformed here as well.
+          assert(guard.isEmpty)
           deriveCaseDef(tree)(transform)
 
         case If(cond, thenp, elsep) =>
           treeCopy.If(tree,
-            cond,
+            noTailTransform(cond),
             transform(thenp),
             transform(elsep)
           )
@@ -363,7 +366,7 @@ abstract class TailCalls extends Transform {
           rewriteApply(tapply, fun, targs, vargs)
 
         case Apply(fun, args) if fun.symbol == Boolean_or || fun.symbol == Boolean_and =>
-          treeCopy.Apply(tree, fun, transformTrees(args))
+          treeCopy.Apply(tree, noTailTransform(fun), transformTrees(args))
 
         // this is to detect tailcalls in translated matches
         // it's a one-argument call to a label that is in a tailposition and that looks like label(x) {x}

--- a/test/files/neg/tailrec-4.check
+++ b/test/files/neg/tailrec-4.check
@@ -1,0 +1,16 @@
+tailrec-4.scala:6: error: could not optimize @tailrec annotated method foo: it contains a recursive call not in tail position
+      @tailrec def foo: Int = foo + 1
+                                  ^
+tailrec-4.scala:11: error: could not optimize @tailrec annotated method foo: it contains a recursive call not in tail position
+      @tailrec def foo: Int = foo + 1
+                                  ^
+tailrec-4.scala:17: error: could not optimize @tailrec annotated method foo: it contains a recursive call not in tail position
+      @tailrec def foo: Int = foo + 1
+                                  ^
+tailrec-4.scala:23: error: could not optimize @tailrec annotated method foo: it contains a recursive call not in tail position
+      @tailrec def foo: Int = foo + 1
+                                  ^
+tailrec-4.scala:31: error: could not optimize @tailrec annotated method foo: it contains a recursive call not in tail position
+          @tailrec def foo: Int = foo + 1
+                                      ^
+5 errors found

--- a/test/files/neg/tailrec-4.scala
+++ b/test/files/neg/tailrec-4.scala
@@ -1,0 +1,35 @@
+import annotation._
+
+object Tail {
+  def tcInFunc: Unit = {
+    () => {
+      @tailrec def foo: Int = foo + 1
+    }
+  }
+  def tcInBooleanExprFirstOp(x: Int, v: Int): Boolean = {
+    {
+      @tailrec def foo: Int = foo + 1
+      foo
+    } == v && true
+  }
+  def tcInBooleanExprSecondOp(x: Int, v: Int): Boolean = {
+    true && {
+      @tailrec def foo: Int = foo + 1
+      foo
+    } == v
+  }
+  def tcInIfCond(x: Int, v: Int): Boolean = {
+    if ({
+      @tailrec def foo: Int = foo + 1
+      foo
+    } == v) true else false
+  }
+  def tcInPatternGuard(x: Int, v: Int): Boolean =
+    v match {
+      case _ if
+        {
+          @tailrec def foo: Int = foo + 1
+          foo == 42
+        } => true
+    }
+}

--- a/test/files/run/tailcalls.check
+++ b/test/files/run/tailcalls.check
@@ -50,6 +50,10 @@ test NonTailCall.f2
 test TailCall.b1 was successful
 test TailCall.b2 was successful
 test FancyTailCalls.tcTryLocal was successful
+test FancyTailCalls.tcInBooleanExprFirstOp was successful
+test FancyTailCalls.tcInBooleanExprSecondOp was successful
+test FancyTailCalls.tcInIfCond was successful
+test FancyTailCalls.tcInPatternGuard was successful
 test FancyTailCalls.differentInstance was successful
 test PolyObject.tramp was successful
 #partest avian
@@ -104,5 +108,9 @@ test NonTailCall.f2
 test TailCall.b1 was successful
 test TailCall.b2 was successful
 test FancyTailCalls.tcTryLocal was successful
+test FancyTailCalls.tcInBooleanExprFirstOp was successful
+test FancyTailCalls.tcInBooleanExprSecondOp was successful
+test FancyTailCalls.tcInIfCond was successful
+test FancyTailCalls.tcInPatternGuard was successful
 test FancyTailCalls.differentInstance was successful
 test PolyObject.tramp was successful

--- a/test/files/run/tailcalls.scala
+++ b/test/files/run/tailcalls.scala
@@ -213,6 +213,33 @@ class FancyTailCalls {
     } finally {}
   }
 
+  def tcInBooleanExprFirstOp(x: Int, v: Int): Boolean = {
+    {
+      def loop(n: Int): Int = if (n == 0) v else loop(n - 1)
+      loop(x)
+    } == v && true
+  }
+  def tcInBooleanExprSecondOp(x: Int, v: Int): Boolean = {
+    true && {
+      def loop(n: Int): Int = if (n == 0) v else loop(n - 1)
+      loop(x)
+    } == v
+  }
+  def tcInIfCond(x: Int, v: Int): Boolean = {
+    if ({
+      def loop(n: Int): Int = if (n == 0) v else loop(n - 1)
+      loop(x)
+    } == v) true else false
+  }
+  def tcInPatternGuard(x: Int, v: Int): Boolean =
+    v match {
+      case _ if
+        {
+          def loop(n: Int): Int = if (n == 0) v else loop(n - 1)
+          loop(x) == v
+        } => true
+    }
+
   import FancyTailCalls._
   final def differentInstance(n: Int, v: Int): Int = {
     if (n == 0) v
@@ -376,8 +403,12 @@ object Test {
     check_success_b("TailCall.b2", TailCall.b2(max), true)
 
     val FancyTailCalls = new FancyTailCalls;
-    check_success("FancyTailCalls.tcTryLocal",   FancyTailCalls.tcTryLocal(max, max), max)
-    check_success("FancyTailCalls.differentInstance",   FancyTailCalls.differentInstance(max, 42), 42)
+    check_success("FancyTailCalls.tcTryLocal", FancyTailCalls.tcTryLocal(max, max), max)
+    check_success_b("FancyTailCalls.tcInBooleanExprFirstOp", FancyTailCalls.tcInBooleanExprFirstOp(max, max), true)
+    check_success_b("FancyTailCalls.tcInBooleanExprSecondOp", FancyTailCalls.tcInBooleanExprSecondOp(max, max), true)
+    check_success_b("FancyTailCalls.tcInIfCond", FancyTailCalls.tcInIfCond(max, max), true)
+    check_success_b("FancyTailCalls.tcInPatternGuard", FancyTailCalls.tcInPatternGuard(max, max), true)
+    check_success("FancyTailCalls.differentInstance", FancyTailCalls.differentInstance(max, 42), 42)
     check_success("PolyObject.tramp", PolyObject.tramp[Int](max), 0)
   }
 


### PR DESCRIPTION
1) First operand of boolean expression using `&&` or `||`. Second operands of those boolean exprs were already treated specially here but handling for first operands was missing.
2) Condition of `If`. Also added a test for guards.
