### PR TITLE
SI-8680 Avoid Stream evaluation when it is cyclic

### DIFF
--- a/test/files/run/stream-check-cycles.check
+++ b/test/files/run/stream-check-cycles.check
@@ -1,0 +1,19 @@
+Stream()
+Stream(1)
+Stream(1, 2)
+Stream(1, 2, 3)
+
+false
+Stream(1, 2, ?)
+
+true
+Stream(1, 2)
+
+false
+Stream(1, 2, 3, ?)
+
+false
+Stream(4, 5, 1, 2, 3, ?)
+false
+Stream(1, 2, 3, 4, 5, ?)
+

--- a/test/files/run/stream-check-cycles.scala
+++ b/test/files/run/stream-check-cycles.scala
@@ -1,0 +1,41 @@
+object Test extends App {
+  println(Stream().force)
+  println(Stream(1).force)
+  println(Stream(1, 2).force)
+  println(Stream(1, 2, 3).force)
+  println
+
+  val sFinite: Stream[Int] = 1 #:: 2 #:: Stream.empty
+  sFinite(1)
+
+  // end not yet reached
+  println(sFinite.hasDefiniteSize)
+  println(sFinite)
+  println
+
+  // end reached
+  try sFinite(2) catch { case _: IndexOutOfBoundsException => /* expected */ }
+  println(sFinite.hasDefiniteSize)
+  println(sFinite)
+  println
+
+  val sInfinite: Stream[Int] = 1 #:: 2 #:: 3 #:: sInfinite
+  sInfinite(10)
+
+  // always infinite
+  println(sInfinite.hasDefiniteSize)
+  println(sInfinite)
+  println
+
+  lazy val sInf1: Stream[Int] = 4 #:: 5 #:: sInf2
+  lazy val sInf2: Stream[Int] = 1 #:: 2 #:: 3 #:: sInf1
+  sInf1(10)
+  sInf2(10)
+
+  // always infinite
+  println(sInf1.hasDefiniteSize)
+  println(sInf1)
+  println(sInf2.hasDefiniteSize)
+  println(sInf2)
+  println
+}


### PR DESCRIPTION
The methods `addString` and `hasDefiniteSize` were too eagerly
implemented in case the Stream references itself and therefore contains
a cycle.

One example of such a Stream is

```
val s: Stream[Int] = 1 #:: 2 #:: 3 #:: s
```

The cycle detection is very simple. A reference to the head of the
Stream is stored and in the iteration to reach the end it is checked
if this reference occurs again. If yes further evaluation is aborted.

Review by @ichoran

scala/bug#8680