### PR TITLE
SI-8686: scala.io.Source now implements java.io.Closeable

### DIFF
--- a/src/library/scala/io/Source.scala
+++ b/src/library/scala/io/Source.scala
@@ -10,7 +10,7 @@ package scala
 package io
 
 import scala.collection.AbstractIterator
-import java.io.{ FileInputStream, InputStream, PrintStream, File => JFile }
+import java.io.{ FileInputStream, InputStream, PrintStream, File => JFile, Closeable }
 import java.net.{ URI, URL }
 
 /** This object provides convenience methods to create an iterable
@@ -176,7 +176,7 @@ object Source {
  *  @author  Burak Emir
  *  @version 1.0
  */
-abstract class Source extends Iterator[Char] {
+abstract class Source extends Iterator[Char] with Closeable {
   /** the actual iterator */
   protected val iter: Iterator[Char]
 


### PR DESCRIPTION
allows users to write a single function for dealing with Input/Output
streams and Sources. It also allows Source to be used in
"try-with-resources" statements in Java > 7.

No tests since this is a binary and source compatible change.
