### PR TITLE
relaxes attachment-matching rules

### DIFF
--- a/src/reflect/scala/reflect/macros/Attachments.scala
+++ b/src/reflect/scala/reflect/macros/Attachments.scala
@@ -35,7 +35,7 @@ abstract class Attachments { self =>
   def all: Set[Any] = Set.empty
 
   private def matchesTag[T: ClassTag](datum: Any) =
-    classTag[T].runtimeClass == datum.getClass
+    classTag[T].runtimeClass.isInstance(datum)
 
   /** An underlying payload of the given class type `T`. */
   def get[T: ClassTag]: Option[T] =

--- a/test/files/pos/macro-attachments/Macros_1.scala
+++ b/test/files/pos/macro-attachments/Macros_1.scala
@@ -1,0 +1,19 @@
+import scala.language.experimental.macros
+import scala.reflect.macros.whitebox.Context
+
+trait Base
+class Att extends Base
+
+object Macros {
+  def impl(c: Context) = {
+    import c.universe._
+    import c.internal._
+    import decorators._
+    val dummy = q"x"
+    dummy.updateAttachment(new Att)
+    if (dummy.attachments.get[Base].isEmpty) c.abort(c.enclosingPosition, "that's not good")
+    q"()"
+  }
+
+  def foo: Any = macro impl
+}

--- a/test/files/pos/macro-attachments/Test_2.scala
+++ b/test/files/pos/macro-attachments/Test_2.scala
@@ -1,0 +1,3 @@
+object Test extends App {
+  Macros.foo
+}


### PR DESCRIPTION
It came as a surprise recently, but attachments.contains/get/update/remove
require the class of the payload to match the provided tag exactly, not
taking subclassing into account. This commit fixes the oversight.
