### PR TITLE
moves the impl of quasiquotes to scala.reflect

### DIFF
--- a/src/compiler/scala/reflect/quasiquotes/Holes.scala
+++ b/src/compiler/scala/reflect/quasiquotes/Holes.scala
@@ -1,4 +1,4 @@
-package scala.tools.reflect
+package scala.reflect
 package quasiquotes
 
 import scala.collection.{immutable, mutable}

--- a/src/compiler/scala/reflect/quasiquotes/Parsers.scala
+++ b/src/compiler/scala/reflect/quasiquotes/Parsers.scala
@@ -1,4 +1,4 @@
-package scala.tools.reflect
+package scala.reflect
 package quasiquotes
 
 import scala.tools.nsc.ast.parser.{Parsers => ScalaParser}

--- a/src/compiler/scala/reflect/quasiquotes/Placeholders.scala
+++ b/src/compiler/scala/reflect/quasiquotes/Placeholders.scala
@@ -1,4 +1,4 @@
-package scala.tools.reflect
+package scala.reflect
 package quasiquotes
 
 import java.util.UUID.randomUUID

--- a/src/compiler/scala/reflect/quasiquotes/Quasiquotes.scala
+++ b/src/compiler/scala/reflect/quasiquotes/Quasiquotes.scala
@@ -1,4 +1,4 @@
-package scala.tools.reflect
+package scala.reflect
 package quasiquotes
 
 import scala.reflect.macros.runtime.Context

--- a/src/compiler/scala/reflect/quasiquotes/Reifiers.scala
+++ b/src/compiler/scala/reflect/quasiquotes/Reifiers.scala
@@ -1,4 +1,4 @@
-package scala.tools.reflect
+package scala.reflect
 package quasiquotes
 
 import java.lang.UnsupportedOperationException

--- a/src/compiler/scala/tools/reflect/FastTrack.scala
+++ b/src/compiler/scala/tools/reflect/FastTrack.scala
@@ -5,7 +5,7 @@ import scala.reflect.reify.Taggers
 import scala.tools.nsc.typechecker.{ Analyzer, Macros }
 import scala.reflect.runtime.Macros.currentMirror
 import scala.reflect.api.Universe
-import scala.tools.reflect.quasiquotes.{ Quasiquotes => QuasiquoteImpls }
+import scala.reflect.quasiquotes.{ Quasiquotes => QuasiquoteImpls }
 
 /** Optimizes system macro expansions by hardwiring them directly to their implementations
  *  bypassing standard reflective load and invoke to avoid the overhead of Java/Scala reflection.


### PR DESCRIPTION
This brings consistency with scala.reflect.reify and scala.reflect.macros
already existing in scala-compiler. To the contrast, scala.tools.reflect,
the previous home of quasiquotes, is a grab bag of various stuff without
any central theme.
