### PR TITLE
SI-8690 BufferedSource.mkString mistakenly skipped the first char.

### DIFF
--- a/src/library/scala/io/BufferedSource.scala
+++ b/src/library/scala/io/BufferedSource.scala
@@ -93,7 +93,7 @@ class BufferedSource(inputStream: InputStream, bufferSize: Int)(implicit val cod
     val buf = new Array[Char](bufferSize)
     var n = 0
     while (n != -1) {
-      n = charReader.read(buf)
+      n = allReader.read(buf)
       if (n>0) sb.appendAll(buf, 0, n)
     }
     sb.result

--- a/test/files/run/t8690.check
+++ b/test/files/run/t8690.check
@@ -1,0 +1,2 @@
+non-empty iterator
+abcdef

--- a/test/files/run/t8690.scala
+++ b/test/files/run/t8690.scala
@@ -1,0 +1,12 @@
+import scala.io.Source
+import java.io.ByteArrayInputStream
+
+object Test extends App {
+  val txt = "abcdef"
+
+  val in = new ByteArrayInputStream(txt.getBytes());
+  val source = Source.fromInputStream(in);
+  println(source.toString) // forces the BufferedSource to look at the head of the input
+
+  println(source.mkString) // used to return "bcdef" ...
+}


### PR DESCRIPTION
mkString is overriden in BufferedSource for performance, but the
implementation always used the wrong reader. This seems to be a typo
(`allReader` is declared 5 lines earlier but never used, `charReader`
is used in its place).
