### PR TITLE
SI-8705   Added example to Option.contains method.

### DIFF
--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -211,16 +211,16 @@ sealed abstract class Option[+A] extends Product with Serializable {
 
   /** Tests whether the option contains a given value as an element.
    *
-   * @example {{{
-   * // Returns true because Some instance contains string "something" which equals "something".
-   * Some("something") contains "something"
+   *  @example {{{
+   *  // Returns true because Some instance contains string "something" which equals "something".
+   *  Some("something") contains "something"
    *
-   * // Returns false because "something" != "anything".
-   * Some("something") contains "anything"
+   *  // Returns false because "something" != "anything".
+   *  Some("something") contains "anything"
    *
-   * // Returns false when method called on None.
-   * None contains "anything"
-   * }}}
+   *  // Returns false when method called on None.
+   *  None contains "anything"
+   *  }}}
    *
    *  @param elem the element to test.
    *  @return `true` if the option has an element that is equal (as
@@ -262,16 +262,16 @@ sealed abstract class Option[+A] extends Product with Serializable {
    * nonempty '''and''' `pf` is defined for that value.
    * Returns $none otherwise.
    *
-   * @example {{{
-   * // Returns Some(HTTP) because the partial function covers the case.
-   * Some("http").collect({case "http" => "HTTP"})
+   *  @example {{{
+   *  // Returns Some(HTTP) because the partial function covers the case.
+   *  Some("http").collect({case "http" => "HTTP"})
    *
-   * // Returns None because the partial function doesn't cover the case.
-   * Some("ftp").collect({case "http" => "HTTP"})
+   *  // Returns None because the partial function doesn't cover the case.
+   *  Some("ftp").collect({case "http" => "HTTP"})
    *
-   * // Returns None because None is passed to the collect method.
-   * None.collect({case value => value})
-   * }}}
+   *  // Returns None because None is passed to the collect method.
+   *  None.collect({case value => value})
+   *  }}}
    *
    *  @param  pf   the partial function.
    *  @return the result of applying `pf` to this $option's

--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -211,6 +211,17 @@ sealed abstract class Option[+A] extends Product with Serializable {
 
   /** Tests whether the option contains a given value as an element.
    *
+   * @example {{{
+   * // Returns true because Some instance contains string "something" which equals "something".
+   * Some("something") contains "something"
+   *
+   * // Returns false because "something" != "anything".
+   * Some("something") contains "anything"
+   *
+   * // Returns false when method called on None.
+   * None contains "anything"
+   * }}}
+   *
    *  @param elem the element to test.
    *  @return `true` if the option has an element that is equal (as
    *  determined by `==`) to `elem`, `false` otherwise.


### PR DESCRIPTION
I added code which described how to **Option.contains** method works.

``` scala
// Returns true because Some instance contains string "something" which equals "something".
Some("something") contains "something"

// Returns false because "something" != "anything".
Some("something") contains "anything"

// Returns false when method called on None.
None contains "anything"
```

[SI-8705](https://issues.scala-lang.org/browse/SI-8705)
