### PR TITLE
SI-8677 Duration: Zero - Inf should be MinusInf

### DIFF
--- a/src/library/scala/concurrent/duration/Duration.scala
+++ b/src/library/scala/concurrent/duration/Duration.scala
@@ -621,7 +621,7 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
   }
   def -(other: Duration) = other match {
     case x: FiniteDuration => add(-x.length, x.unit)
-    case _                 => other
+    case _                 => -other
   }
 
   def *(factor: Double) =

--- a/test/files/jvm/duration-tck.scala
+++ b/test/files/jvm/duration-tck.scala
@@ -61,6 +61,11 @@ object Test extends App {
   minf -  inf mustBe minf
   minf + minf mustBe minf
 
+  for (i <- Seq(zero, one, two, three)) {
+    i - inf mustBe minf
+    i - minf mustBe inf
+  }
+
   inf.compareTo(inf) mustBe 0
   inf.compareTo(one) mustBe 1
   inf.compareTo(minf) mustBe 1


### PR DESCRIPTION
Fixes #8677. Add basic tests.
This is a backport from 2.12.x of dead39dc5f21c6eac41788e93426c50ddd398c24.
