### PR TITLE
SI-8719 pattern expander errors and warnings now go through context

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -460,7 +460,7 @@ abstract class UnCurry extends InfoTransform
           case UnApply(fn, args) =>
             val fn1   = transform(fn)
             val args1 = fn.symbol.name match {
-              case nme.unapplySeq => transformArgs(tree.pos, fn.symbol, args, patmat.alignPatterns(tree).expectedTypes)
+              case nme.unapplySeq => transformArgs(tree.pos, fn.symbol, args, patmat.alignPatterns(global.typer.context, tree).expectedTypes)
               case _              => args
             }
             treeCopy.UnApply(tree, fn1, args1)

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
@@ -377,8 +377,8 @@ trait MatchTranslation {
     object ExtractorCall {
       // TODO: check unargs == args
       def apply(tree: Tree): ExtractorCall = tree match {
-        case UnApply(unfun, args) => new ExtractorCallRegular(alignPatterns(tree), unfun, args) // extractor
-        case Apply(fun, args)     => new ExtractorCallProd(alignPatterns(tree), fun, args)      // case class
+        case UnApply(unfun, args) => new ExtractorCallRegular(alignPatterns(context, tree), unfun, args) // extractor
+        case Apply(fun, args)     => new ExtractorCallProd(alignPatterns(context, tree), fun, args)      // case class
       }
     }
 

--- a/src/compiler/scala/tools/nsc/transform/patmat/ScalacPatternExpanders.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/ScalacPatternExpanders.scala
@@ -18,6 +18,7 @@ trait ScalacPatternExpanders {
   import global._
   import definitions._
   import treeInfo._
+  import analyzer._
 
   type PatternAligned = ScalacPatternExpander#Aligned
 
@@ -94,7 +95,7 @@ trait ScalacPatternExpanders {
     def tupleExtractor(extractor: Extractor): Extractor =
       extractor.copy(fixed = tupleType(extractor.fixed) :: Nil)
 
-    private def validateAligned(tree: Tree, aligned: Aligned): Aligned = {
+    private def validateAligned(context: Context, tree: Tree, aligned: Aligned): Aligned = {
       import aligned._
 
       def owner         = tree.symbol.owner
@@ -103,8 +104,8 @@ trait ScalacPatternExpanders {
       def offerString   = if (extractor.isErroneous) "" else s" offering $offering"
       def arityExpected = ( if (extractor.hasSeq) "at least " else "" ) + productArity
 
-      def err(msg: String)         = reporter.error(tree.pos, msg)
-      def warn(msg: String)        = reporter.warning(tree.pos, msg)
+      def err(msg: String)         = context.issue(PosAndMsgTypeError(tree.pos, msg))
+      def warn(msg: String)        = context.warning(tree.pos, msg)
       def arityError(what: String) = err(s"$what patterns for $owner$offerString: expected $arityExpected, found $totalArity")
 
       if (isStar && !isSeq)
@@ -117,7 +118,7 @@ trait ScalacPatternExpanders {
       aligned
     }
 
-    def apply(sel: Tree, args: List[Tree]): Aligned = {
+    def apply(context: Context, sel: Tree, args: List[Tree]): Aligned = {
       val fn = sel match {
         case Unapplied(fn) => fn
         case _             => sel
@@ -145,12 +146,12 @@ trait ScalacPatternExpanders {
       }
 
       val normalizedExtractor = if (requiresTupling) tupleExtractor(extractor) else extractor
-      validateAligned(fn, Aligned(patterns, normalizedExtractor))
+      validateAligned(context, fn, Aligned(patterns, normalizedExtractor))
     }
 
-    def apply(tree: Tree): Aligned = tree match {
-      case Apply(fn, args)   => apply(fn, args)
-      case UnApply(fn, args) => apply(fn, args)
+    def apply(context: Context, tree: Tree): Aligned = tree match {
+      case Apply(fn, args)   => apply(context, fn, args)
+      case UnApply(fn, args) => apply(context, fn, args)
     }
   }
 }

--- a/src/compiler/scala/tools/nsc/typechecker/PatternTypers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternTypers.scala
@@ -309,7 +309,7 @@ trait PatternTypers {
         // the union of the expected type and the inferred type of the argument to unapply
         val glbType        = glb(ensureFullyDefined(pt) :: unapplyArg.tpe_* :: Nil)
         val wrapInTypeTest = canRemedy && !(fun1.symbol.owner isNonBottomSubClass ClassTagClass)
-        val formals        = patmat.alignPatterns(fun1, args).unexpandedFormals
+        val formals        = patmat.alignPatterns(context.asInstanceOf[analyzer.Context], fun1, args).unexpandedFormals
         val args1          = typedArgsForFormals(args, formals, mode)
         val result         = UnApply(fun1, args1) setPos tree.pos setType glbType
 

--- a/test/files/pos/t8719/Macros_1.scala
+++ b/test/files/pos/t8719/Macros_1.scala
@@ -1,0 +1,21 @@
+import scala.language.experimental.macros
+import scala.reflect.macros.TypecheckException
+import scala.reflect.macros.whitebox.Context
+
+object Macros {
+  def typecheck_impl(c: Context)(code: c.Expr[String]): c.Expr[Option[String]] = {
+    import c.universe._
+
+    val Expr(Literal(Constant(codeStr: String))) = code
+
+    try {
+      c.typecheck(c.parse(codeStr))
+      c.Expr(q"None: Option[String]")
+    } catch {
+      case e: TypecheckException =>
+        c.Expr(q"Some(${ e.toString }): Option[String]")
+    }
+  }
+
+  def typecheck(code: String): Option[String] = macro typecheck_impl
+}

--- a/test/files/pos/t8719/Test_2.scala
+++ b/test/files/pos/t8719/Test_2.scala
@@ -1,0 +1,10 @@
+case class Foo(i: Int, c: Char)
+
+object Bar {
+  def unapply(foo: Foo): Option[(Int, Char)] = Some((foo.i, foo.c))
+}
+
+object Test extends App {
+  println(Macros.typecheck("val Foo(x, y, z) = Foo(1, 'a')"))
+  println(Macros.typecheck("val Bar(x, y, z) = Foo(1, 'a')"))
+}


### PR DESCRIPTION
This ensures that typechecking custom unapplications in silent mode
doesn't leak uncatchable errors. Interestingly enough, the problem
only manifested itself for custom unapply methods, not for synthetic
ones generated for case classes.
