### PR TITLE
SI-8715 Include versions.properties in scala-compiler.jar.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -827,6 +827,11 @@ TODO:
     <path id="pack.compiler.files">
       <fileset dir="${build-quick.dir}/classes/compiler"/>
 
+      <!-- include versions.properties in scala-compiler.jar
+           versions.properties determines scala-library-all's pom and could thus be reconstructed from it,
+           but the property file is easier to digest by ivy-based tools -->
+      <pathelement location="${basedir}/versions.properties"/>
+
       <!-- TODO modularize compiler. Remove the other class dirs as soon as they become modules -->
       <fileset dir="${build-quick.dir}/classes/scaladoc"/>
       <fileset dir="${build-quick.dir}/classes/interactive"/>


### PR DESCRIPTION
So that it can be consumed in builds that cannot use scala-library-all's pom.

Review by @dragos, cc @skyluc
