### PR TITLE
Fixes first sentence delimiters

### DIFF
--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -102,7 +102,7 @@ trait Future[+T] extends Awaitable[T] {
 
   /* Callbacks */
 
-  /** When this future is completed successfully (i.e. with a value),
+  /** When this future is completed successfully (i&period;e&period; with a value),
    *  apply the provided partial function to the value if the partial function
    *  is defined at that value.
    *
@@ -118,7 +118,7 @@ trait Future[+T] extends Awaitable[T] {
     case _ =>
   }
 
-  /** When this future is completed with a failure (i.e. with a throwable),
+  /** When this future is completed with a failure (i&period;e&period; with a throwable),
    *  apply the provided callback to the throwable.
    *
    *  $caughtThrowables

--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -102,7 +102,7 @@ trait Future[+T] extends Awaitable[T] {
 
   /* Callbacks */
 
-  /** When this future is completed successfully (i&period;e&period; with a value),
+  /** When this future is completed successfully (i.e., with a value),
    *  apply the provided partial function to the value if the partial function
    *  is defined at that value.
    *
@@ -118,7 +118,7 @@ trait Future[+T] extends Awaitable[T] {
     case _ =>
   }
 
-  /** When this future is completed with a failure (i&period;e&period; with a throwable),
+  /** When this future is completed with a failure (i.e., with a throwable),
    *  apply the provided callback to the throwable.
    *
    *  $caughtThrowables


### PR DESCRIPTION
Scaladoc places the first sentence in the method summary table and index. The first sentence is defined as the sequence of chars up to the first period (not as in JavaDoc where the sentence ends with the first period _followed by a blank_). As a consequence, the clause starting with `i.e.` ends the first sentence at a wrong position. This request replaces `i.e.` with `i&period;e&period;`. Alghough a valid HTML code, I do not know whether this change is compatible with other tools. And I assume that this is not the only source file affected.
An alternative fix would be to reformulate the summary of methods `onSuccess` and `onFailure`.
