### PR TITLE
Bump jline version to 2.12 (Re: SI-8535)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -187,8 +187,6 @@ TODO:
 
   <property name="copyright.string"        value="Copyright 2002-2013, LAMP/EPFL"/>
 
-  <property name="jline.version"           value="2.11"/>
-
   <!-- These are NOT the flags used to run SuperSabbus, but the ones written
        into the script runners created with scala.tools.ant.ScalaTool -->
   <property name="java.flags"              value="-Xmx256M -Xms32M"/>

--- a/versions.properties
+++ b/versions.properties
@@ -24,6 +24,7 @@ scala-continuations-library.version.number=1.0.2
 scala-swing.version.number=1.0.1
 akka-actor.version.number=2.3.3
 actors-migration.version.number=1.1.0
+jline.version=2.12
 
 # external modules, used internally (not shipped)
 partest.version.number=1.0.0


### PR DESCRIPTION
Move version info where it belongs: versions.properties

I skimmed https://github.com/jline/jline2/compare/jline-2.11...jline-2.12 -- looks like all bug fixes to me.

This should fix SI-8535, but I don't have a repro to verify.
