### PR TITLE
SI-8525 Clarify usage of -Xlint:_,flag

### DIFF
--- a/src/compiler/scala/tools/nsc/CompilerCommand.scala
+++ b/src/compiler/scala/tools/nsc/CompilerCommand.scala
@@ -107,7 +107,7 @@ class CompilerCommand(arguments: List[String], val settings: Settings) {
     else {
       val sb = new StringBuilder
       allSettings foreach {
-        case s: MultiChoiceSetting if s.isHelping => sb append s.help append "\n"
+        case s: MultiChoiceSetting if s.isHelping => sb append s.help
         case _ =>
       }
       sb.toString

--- a/src/compiler/scala/tools/nsc/CompilerCommand.scala
+++ b/src/compiler/scala/tools/nsc/CompilerCommand.scala
@@ -103,7 +103,15 @@ class CompilerCommand(arguments: List[String], val settings: Settings) {
       val components = global.phaseNames  // global.phaseDescriptors // one initializes
       s"Phase graph of ${components.size} components output to ${genPhaseGraph.value}*.dot."
     }
-    else                    ""
+    // would be nicer if we could ask all the options for their helpful messages
+    else {
+      val sb = new StringBuilder
+      allSettings foreach {
+        case s: MultiChoiceSetting if s.isHelping => sb append s.help append "\n"
+        case _ =>
+      }
+      sb.toString
+    }
   }
 
   /**

--- a/src/compiler/scala/tools/nsc/settings/AbsScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/AbsScalaSettings.scala
@@ -29,7 +29,7 @@ trait AbsScalaSettings {
   def ChoiceSetting(name: String, helpArg: String, descr: String, choices: List[String], default: String): ChoiceSetting
   def IntSetting(name: String, descr: String, default: Int, range: Option[(Int, Int)], parser: String => Option[Int]): IntSetting
   def MultiStringSetting(name: String, helpArg: String, descr: String): MultiStringSetting
-  def MultiChoiceSetting(name: String, helpArg: String, descr: String, choices: List[String], default: () => Unit): MultiChoiceSetting
+  def MultiChoiceSetting(name: String, helpArg: String, descr: String, choices: List[String], default: () => Unit)(helper: MultiChoiceSetting => String): MultiChoiceSetting
   def OutputSetting(outputDirs: OutputDirs, default: String): OutputSetting
   def PathSetting(name: String, descr: String, default: String): PathSetting
   def PhasesSetting(name: String, descr: String, default: String): PhasesSetting

--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -567,13 +567,12 @@ class MutableSettings(val errorFn: String => Unit)
     def badChoice(s: String, n: String) = errorFn(s"'$s' is not a valid choice for '$name'")
     def choosing = choices.nonEmpty
     def isChoice(s: String) = (s == "_") || (choices contains (s stripPrefix "-"))
-    def wildcards = choices // filter (!_.isSetByUser)
 
     override protected def tts(args: List[String], halting: Boolean) = {
-      val total = collection.mutable.ListBuffer.empty[String] ++ value
+      val added = collection.mutable.ListBuffer.empty[String]
       def tryArg(arg: String) = arg match {
-        case "_" if choosing               => wildcards foreach (total += _)
-        case s if !choosing || isChoice(s) => total += s
+        case "_" if choosing               => default()
+        case s if !choosing || isChoice(s) => added += s
         case s                             => badChoice(s, name)
       }
       def stoppingAt(arg: String) = (arg startsWith "-") || (choosing && !isChoice(arg))
@@ -584,7 +583,7 @@ class MutableSettings(val errorFn: String => Unit)
       }
       val rest = loop(args)
       if (rest.size == args.size) default()       // if no arg consumed, trigger default action
-      else value = total.toList                   // update once
+      else value = added.toList                   // update all new settings at once
       Some(rest)
     }
   }

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -70,8 +70,27 @@ trait ScalaSettings extends AbsScalaSettings
   // Would be nice to build this dynamically from scala.languageFeature.
   // The two requirements: delay error checking until you have symbols, and let compiler command build option-specific help.
   val language      = {
-    val features = List("dynamics", "postfixOps", "reflectiveCalls", "implicitConversions", "higherKinds", "existentials", "experimental.macros")
-    MultiChoiceSetting("-language", "feature", "Enable or disable language features", features)
+    val features = List(
+      "dynamics"            -> "Allow direct or indirect subclasses of scala.Dynamic",
+      "postfixOps"          -> "Allow postfix operator notation, such as `1 to 10 toList'",
+      "reflectiveCalls"     -> "Allow reflective access to members of structural types",
+      "implicitConversions" -> "Allow definition of implicit functions called views",
+      "higherKinds"         -> "Allow higher-kinded types",  // "Ask Adriaan, but if you have to ask..."
+      "existentials"        -> "Existential types (besides wildcard types) can be written and inferred",
+      "experimental.macros" -> "Allow macro defintion (besides implementation and application)"
+    )
+    val description = "Enable or disable language features"
+    MultiChoiceSetting(
+      name    = "-language",
+      helpArg = "feature",
+      descr   = description,
+      choices = features map (_._1)
+    ) { s =>
+      val helpline: ((String, String)) => String = {
+        case (name, text) => f"  $name%-25s $text%n"
+      }
+      features map helpline mkString (f"$description:%n", "", f"%n")
+    }
   }
 
   /*

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -44,8 +44,11 @@ trait ScalaSettings extends AbsScalaSettings
   /** If any of these settings is enabled, the compiler should print a message and exit.  */
   def infoSettings = List[Setting](version, help, Xhelp, Yhelp, showPlugins, showPhases, genPhaseGraph)
 
+  /** Any -multichoice:help? Nicer if any option could report that it had help to offer. */
+  private def multihelp = allSettings exists { case s: MultiChoiceSetting => s.isHelping case _ => false }
+
   /** Is an info setting set? */
-  def isInfo = infoSettings exists (_.isSetByUser)
+  def isInfo = (infoSettings exists (_.isSetByUser)) || multihelp
 
   /** Disable a setting */
   def disable(s: Setting) = allSettings -= s
@@ -68,7 +71,7 @@ trait ScalaSettings extends AbsScalaSettings
   // The two requirements: delay error checking until you have symbols, and let compiler command build option-specific help.
   val language      = {
     val features = List("dynamics", "postfixOps", "reflectiveCalls", "implicitConversions", "higherKinds", "existentials", "experimental.macros")
-    MultiChoiceSetting("-language", "feature", "Enable one or more language features", features)
+    MultiChoiceSetting("-language", "feature", "Enable or disable language features", features)
   }
 
   /*

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -109,18 +109,18 @@ trait Warnings {
   private val xlint = new BooleanSetting("-Zunused", "True if -Xlint or -Xlint:_")
   // On -Xlint or -Xlint:_, set xlint, otherwise set the lint warning unless already set true
   val lint = {
-    val d = "Enable or disable specific warnings"
-    val s = new MultiChoiceSetting(
+    val description = "Enable or disable specific warnings"
+    val choices     = (lintWarnings map (_.name)).sorted
+    MultiChoiceSetting(
       name    = "-Xlint",
-      arg     = "warning",
-      descr   = d,
-      choices = (lintWarnings map (_.name)).sorted,
+      helpArg = "warning",
+      descr   = description,
+      choices = choices,
       default = () => xlint.value = true
-    ) {
+    ) { s =>
       def helpline(n: String) = lintWarnings.find(_.name == n).map(w => f"  ${w.name}%-25s ${w.helpDescription}%n")
-      override def help = s"$d${ choices flatMap (helpline(_)) mkString (":\n", "", "\n") }"
-    }
-    val t = s withPostSetHook { x =>
+      choices flatMap (helpline(_)) mkString (f"$description:%n", "", f"%n")
+    } withPostSetHook { x =>
       val Neg = "-"
       def setPolitely(b: BooleanSetting, v: Boolean) = if (!b.isSetByUser || !b) b.value = v
       def set(w: String, v: Boolean) = lintWarnings find (_.name == w) foreach (setPolitely(_, v))
@@ -130,8 +130,6 @@ trait Warnings {
       }
       propagate(x.value)
     }
-    add(t)
-    t
   }
 
   // Lint warnings that are currently -Y, but deprecated in that usage

--- a/test/files/neg/t8610-arg.check
+++ b/test/files/neg/t8610-arg.check
@@ -1,18 +1,6 @@
-t8610-arg.scala:5: warning: possible missing interpolator: detected interpolated identifier `$name`
-  def x = "Hi, $name"   // missing interp
-          ^
-t8610-arg.scala:7: warning: Adapting argument list by creating a 2-tuple: this may not be what you want.
-        signature: X.f(p: (Int, Int)): Int
-  given arguments: 3, 4
- after adaptation: X.f((3, 4): (Int, Int))
-  def g = f(3, 4)       // adapted
-           ^
-t8610-arg.scala:9: warning: private[this] value name in class X shadows mutable name inherited from class Named.  Changes to name will not be visible within class X - you may want to give them distinct names.
-  override def toString = name // shadowing mutable var name
-                          ^
 t8610-arg.scala:8: warning: side-effecting nullary methods are discouraged: suggest defining as `def u()` instead
   def u: Unit = ()      // unitarian universalist
       ^
 error: No warnings can be incurred under -Xfatal-warnings.
-four warnings found
+one warning found
 one error found

--- a/test/files/neg/t8610-arg.flags
+++ b/test/files/neg/t8610-arg.flags
@@ -1,1 +1,1 @@
--Xfatal-warnings -Xlint warn-nullary-unit
+-Xfatal-warnings -Xlint nullary-unit

--- a/test/files/run/t8610.check
+++ b/test/files/run/t8610.check
@@ -1,13 +1,7 @@
-t8610.scala:4: warning: possible missing interpolator: detected interpolated identifier `$name`
-  def x = "Hi, $name"   // missing interp
-          ^
 t8610.scala:6: warning: Adapting argument list by creating a 2-tuple: this may not be what you want.
         signature: X.f(p: (Int, Int)): Int
   given arguments: 3, 4
  after adaptation: X.f((3, 4): (Int, Int))
   def g = f(3, 4)       // adapted
            ^
-t8610.scala:7: warning: side-effecting nullary methods are discouraged: suggest defining as `def u()` instead
-  def u: Unit = ()      // unitarian universalist
-      ^
 Hi, $name

--- a/test/junit/scala/tools/nsc/settings/SettingsTest.scala
+++ b/test/junit/scala/tools/nsc/settings/SettingsTest.scala
@@ -38,29 +38,23 @@ class SettingsTest {
     assertFalse(check("-Yinline:false", "-optimise").value)
   }
 
-  @Test def userSettingsHavePrecedenceOverLint() {
-    def check(args: String*): MutableSettings#BooleanSetting = {
-      val s = new MutableSettings(msg => throw new IllegalArgumentException(msg))
-      val (ok, residual) = s.processArguments(args.toList, processAll = true)
-      assert(residual.isEmpty)
-      s.warnAdaptedArgs // among Xlint
-    }
-    assertTrue(check("-Xlint").value)
-    assertFalse(check("-Xlint", "-Ywarn-adapted-args:false").value)
-    assertFalse(check("-Ywarn-adapted-args:false", "-Xlint").value)
-  }
-
-  def check(args: String*)(b: MutableSettings => MutableSettings#BooleanSetting): MutableSettings#BooleanSetting = {
+  // for the given args, select the desired setting
+  private def check(args: String*)(b: MutableSettings => MutableSettings#BooleanSetting): MutableSettings#BooleanSetting = {
     val s = new MutableSettings(msg => throw new IllegalArgumentException(msg))
     val (ok, residual) = s.processArguments(args.toList, processAll = true)
     assert(residual.isEmpty)
     b(s)
   }
+  @Test def userSettingsHavePrecedenceOverLint() {
+    assertTrue(check("-Xlint")(_.warnAdaptedArgs))
+    assertFalse(check("-Xlint", "-Ywarn-adapted-args:false")(_.warnAdaptedArgs))
+    assertFalse(check("-Ywarn-adapted-args:false", "-Xlint")(_.warnAdaptedArgs))
+  }
+
   @Test def anonymousLintersCanBeNamed() {
     assertTrue(check("-Xlint")(_.warnMissingInterpolator)) // among Xlint
     assertFalse(check("-Xlint:-missing-interpolator")(_.warnMissingInterpolator))
     assertFalse(check("-Xlint:-missing-interpolator", "-Xlint")(_.warnMissingInterpolator))
-    // two lint settings are first come etc; unlike -Y
-    assertTrue(check("-Xlint", "-Xlint:-missing-interpolator")(_.warnMissingInterpolator))
+    assertFalse(check("-Xlint", "-Xlint:-missing-interpolator")(_.warnMissingInterpolator))
   }
 }


### PR DESCRIPTION
Align more with javac -Xlint:all,-flag,flag where once a flag is
explicitly enabled it cannot be disabled, but where the wildcard
is a backstop only.

-Xlint and -Xlint:_ just set a flag which is consulted by any
unset lint warning.

Some tests are corrected. Also, option order is no longer
significant, see the unit test.
