### PR TITLE
SI-8738  Regression in range equality

### DIFF
--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -364,15 +364,16 @@ extends scala.collection.AbstractSeq[Int]
   override def equals(other: Any) = other match {
     case x: Range =>
       // Note: this must succeed for overfull ranges (length > Int.MaxValue)
-      (x canEqual this) && (
-        isEmpty ||                              // all empty sequences are equal
-        (start == x.start && {                  // Otherwise, must have same start
-          val l0 = last
-          (l0 == x.last && (                    // And same end
-            start == l0 || step == x.step       // And either the same step, or not take any steps
-          ))
-        })
-      )
+      (x canEqual this) && {
+        if (isEmpty) x.isEmpty                  // empty sequences are equal
+        else                                    // this is non-empty...
+          x.nonEmpty && start == x.start && {   // ...so other must contain something and have same start
+            val l0 = last
+            (l0 == x.last && (                    // And same end
+              start == l0 || step == x.step       // And either the same step, or not take any steps
+            ))
+          }
+      }
     case _ =>
       super.equals(other)
   }

--- a/test/files/run/t8738.scala
+++ b/test/files/run/t8738.scala
@@ -1,0 +1,16 @@
+object Test {
+  def check(a: Range, b: Range) = (a == b) == (a.toList == b.toList)
+  def main(args: Array[String]) {
+    val lo = -2 to 2
+    val hi = lo
+    val step = List(-6,-2,-1,1,2,6)
+    for (i <- lo; j <- hi; n <- step; k <- lo; l <- hi; m <- step) {
+      assert(
+        check(i until j by n, k until l by m) &&
+        check(i until j by n, k to l by m) &&
+        check(i to j by n, k until l by m) &&
+        check(i to j by n, k to l by m)
+      )
+    }
+  }
+}


### PR DESCRIPTION
Missed the case of comparing a non-empty range to an empty one.  Fixed by checking nonEmpty/isEmpty on other collection.

Added a test to verify the behavior.
