### PR TITLE
SI-8736 Restore -language to former glory

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/AbsScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/AbsScalaSettings.scala
@@ -29,7 +29,7 @@ trait AbsScalaSettings {
   def ChoiceSetting(name: String, helpArg: String, descr: String, choices: List[String], default: String): ChoiceSetting
   def IntSetting(name: String, descr: String, default: Int, range: Option[(Int, Int)], parser: String => Option[Int]): IntSetting
   def MultiStringSetting(name: String, helpArg: String, descr: String): MultiStringSetting
-  def MultiChoiceSetting(name: String, helpArg: String, descr: String, choices: List[String], default: () => Unit)(helper: MultiChoiceSetting => String): MultiChoiceSetting
+  def MultiChoiceSetting(name: String, helpArg: String, descr: String, choices: List[String], default: Option[() => Unit])(helper: MultiChoiceSetting => String): MultiChoiceSetting
   def OutputSetting(outputDirs: OutputDirs, default: String): OutputSetting
   def PathSetting(name: String, descr: String, default: String): PathSetting
   def PhasesSetting(name: String, descr: String, default: String): PhasesSetting

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -116,7 +116,7 @@ trait Warnings {
       helpArg = "warning",
       descr   = description,
       choices = choices,
-      default = () => xlint.value = true
+      default = Some(() => xlint.value = true)
     ) { s =>
       def helpline(n: String) = lintWarnings.find(_.name == n).map(w => f"  ${w.name}%-25s ${w.helpDescription}%n")
       choices flatMap (helpline(_)) mkString (f"$description:%n", "", f"%n")

--- a/test/files/neg/t8736-c.check
+++ b/test/files/neg/t8736-c.check
@@ -1,0 +1,11 @@
+t8736-c.scala:4: warning: higher-kinded type should be enabled
+by making the implicit value scala.language.higherKinds visible.
+This can be achieved by adding the import clause 'import scala.language.higherKinds'
+or by setting the compiler option -language:higherKinds.
+See the Scala docs for value scala.language.higherKinds for a discussion
+why the feature should be explicitly enabled.
+  def hk[M[_]] = ???
+         ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/t8736-c.flags
+++ b/test/files/neg/t8736-c.flags
@@ -1,0 +1,1 @@
+-feature -language:-higherKinds,_ -Xfatal-warnings

--- a/test/files/neg/t8736-c.scala
+++ b/test/files/neg/t8736-c.scala
@@ -1,0 +1,7 @@
+// scalac: -feature -language:-higherKinds,_ -Xfatal-warnings
+// showing that wildcard doesn't supersede explicit disablement
+class X {
+  def hk[M[_]] = ???
+
+  implicit def imp(x: X): Int = x.hashCode
+}

--- a/test/files/pos/t8736-b.flags
+++ b/test/files/pos/t8736-b.flags
@@ -1,0 +1,1 @@
+-feature -language:_ -Xfatal-warnings

--- a/test/files/pos/t8736-b.scala
+++ b/test/files/pos/t8736-b.scala
@@ -1,0 +1,7 @@
+// scalac: -feature -language:_ -Xfatal-warnings
+// showing that all are set
+class X {
+  def hk[M[_]] = ???
+
+  implicit def imp(x: X): Int = x.hashCode
+}

--- a/test/files/pos/t8736.flags
+++ b/test/files/pos/t8736.flags
@@ -1,0 +1,1 @@
+-feature -language:implicitConversions -language:higherKinds -language:-implicitConversions -Xfatal-warnings

--- a/test/files/pos/t8736.scala
+++ b/test/files/pos/t8736.scala
@@ -1,0 +1,7 @@
+// scalac: -feature -language:implicitConversions -language:higherKinds -language:-implicitConversions -Xfatal-warnings
+// showing that multiple settings are respected, and explicit enablement has precedence
+class X {
+  def hk[M[_]] = ???
+
+  implicit def imp(x: X): Int = x.hashCode
+}


### PR DESCRIPTION
MultiChoice allows -language to work like -Xlint.

The bug as described was that the setting value was set instead of updated
(++=) with additional flags.

The unreported bug was that `_` no longer set all settings.

The corrected behavior is that "contains" means "it was enabled, or
_ was set and it was not disabled explicitly."

That is the behavior of `-Xlint` but with a different mechanism,
since each lint option is a Setting.

A semantic difference is that -Xlint enables all the lint options,
but -language does not enable all the language features. `scalac -X` does
not explain this additional behavior of the `-Xlint` flag.

Also worth noting that `scalac -feature -language unused.scala` failed
in 2.11.1 but succeeds silently now.

note: -language as string settings and -Xlint as a group of Settings represent two
different models, so unifying them is annoying.  The contains test is convenient
for the -language check, and the individual Setting objects are convenient for
programmatic linting.
