### PR TITLE
Remove "throws InvalidEscapeException" from StringContext.raw doc

### DIFF
--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -112,8 +112,6 @@ case class StringContext(parts: String*) {
    *  @throws An `IllegalArgumentException`
    *          if the number of `parts` in the enclosing `StringContext` does not exceed
    *          the number of arguments `arg` by exactly 1.
-   *  @throws A `StringContext.InvalidEscapeException` if a `parts` string contains a backslash (`\`) character
-   *          that does not start a valid escape sequence.
    */
   def raw(args: Any*): String = standardInterpolator(identity, args)
 

--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -104,7 +104,7 @@ case class StringContext(parts: String*) {
    *  ''Note:'' Even when using the raw interpolator, Scala will preprocess unicode escapes.
    *  For example:
    *  {{{
-   *    scala> raw"\u005cu0025"
+   *    scala> raw"\u005cu0023"
    *    res0: String = #
    *  }}}
    *


### PR DESCRIPTION
Since StringContext.raw doesn't escape its input, it does not call `treatEscapes` and cannot throw the InvalidEscapeException.
