### PR TITLE
Update versions.properties for building 2.11.2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -14,21 +14,21 @@ starr.use.released=1
 scala.binary.version=2.11
 # e.g. 2.11.0-RC1, 2.11.0, 2.11.1-RC1, 2.11.1
 # this defines the dependency on scala-continuations-plugin in scala-dist's pom
-scala.full.version=2.11.1
+scala.full.version=2.11.2
 
 # external modules shipped with distribution, as specified by scala-library-all's pom
 scala-xml.version.number=1.0.2
-scala-parser-combinators.version.number=1.0.1
+scala-parser-combinators.version.number=1.0.2
 scala-continuations-plugin.version.number=1.0.2
 scala-continuations-library.version.number=1.0.2
 scala-swing.version.number=1.0.1
-akka-actor.version.number=2.3.3
+akka-actor.version.number=2.3.4
 actors-migration.version.number=1.1.0
 jline.version=2.12
 
 # external modules, used internally (not shipped)
 partest.version.number=1.0.0
-scalacheck.version.number=1.11.3
+scalacheck.version.number=1.11.4
 
 # TODO: modularize the compiler
 #scala-compiler-doc.version.number=1.0.0-RC1


### PR DESCRIPTION
parser combinators: current tag
https://github.com/scala/scala-parser-combinators/releases

akka: current release http://akka.io/downloads/

scalacheck: current tag
https://github.com/rickynils/scalacheck/releases

Review by @adriaanm.

With this change, I can push a tag and run the [release job](https://scala-webapps.epfl.ch/jenkins/view/scala-release-2.11.x/job/scala-release-2.11.x/build) with the default parameters.
