### PR TITLE
Bump versions for Scala 2.11.2

### DIFF
--- a/build.number
+++ b/build.number
@@ -1,7 +1,7 @@
 #Tue Sep 11 19:21:09 CEST 2007
 version.major=2
 version.minor=11
-version.patch=2
+version.patch=3
 # This is the -N part of a version.  if it's 0, it's dropped from maven versions.
 version.bnum=0
 

--- a/versions.properties
+++ b/versions.properties
@@ -1,10 +1,10 @@
-#Tue, 20 May 2014 10:01:37 +0200
+#Wed, 23 Jul 2014 08:37:26 +0200
 # NOTE: this file determines the content of the scala-distribution
 # via scala-dist-pom.xml and scala-library-all-pom.xml
 # when adding new properties that influence a release,
 # also add them to the update.versions mechanism in build.xml,
 # which is used by scala-release-2.11.x in scala/jenkins-scripts
-starr.version=2.11.1
+starr.version=2.11.2
 starr.use.released=1
 
 # These are the versions of the modules that go with this release.
@@ -14,21 +14,21 @@ starr.use.released=1
 scala.binary.version=2.11
 # e.g. 2.11.0-RC1, 2.11.0, 2.11.1-RC1, 2.11.1
 # this defines the dependency on scala-continuations-plugin in scala-dist's pom
-scala.full.version=2.11.1
+scala.full.version=2.11.2
 
 # external modules shipped with distribution, as specified by scala-library-all's pom
 scala-xml.version.number=1.0.2
-scala-parser-combinators.version.number=1.0.1
+scala-parser-combinators.version.number=1.0.2
 scala-continuations-plugin.version.number=1.0.2
 scala-continuations-library.version.number=1.0.2
 scala-swing.version.number=1.0.1
-akka-actor.version.number=2.3.3
+akka-actor.version.number=2.3.4
 actors-migration.version.number=1.1.0
 jline.version=2.12
 
 # external modules, used internally (not shipped)
 partest.version.number=1.0.0
-scalacheck.version.number=1.11.3
+scalacheck.version.number=1.11.4
 
 # TODO: modularize the compiler
 #scala-compiler-doc.version.number=1.0.0-RC1


### PR DESCRIPTION
`versions.properties` from https://scala-webapps.epfl.ch/jenkins/view/scala-release-2.11.x/job/scala-release-2.11.x/133/
