### PR TITLE
SI-4563 friendlier behavior for Ctrl+D in the REPL

### DIFF
--- a/src/compiler/scala/tools/nsc/Properties.scala
+++ b/src/compiler/scala/tools/nsc/Properties.scala
@@ -14,6 +14,7 @@ object Properties extends scala.util.PropertiesTrait {
   // settings based on jar properties
   def residentPromptString = scalaPropOrElse("resident.prompt", "\nnsc> ")
   def shellPromptString    = scalaPropOrElse("shell.prompt", "\nscala> ")
+  def shellInterruptedString = scalaPropOrElse("shell.interrupted", ":quit\n")
 
   // derived values
   def isEmacsShell         = propOrEmpty("env.emacs") != ""

--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -430,7 +430,14 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     import scala.concurrent.duration._
     Await.ready(globalFuture, 60.seconds)
 
-    (line ne null) && (command(line) match {
+    if (line eq null) {
+      // SI-4563: this means the console was properly interrupted (Ctrl+D usually)
+      // so we display the output message (which by default ends with
+      // a newline so as not to break the user's terminal)
+      if (in.interactive) out.print(Properties.shellInterruptedString)
+
+      false
+    } else (command(line) match {
       case Result(false, _)      => false
       case Result(_, Some(line)) => addReplay(line) ; true
       case _                     => true

--- a/test/files/jvm/interpreter.check
+++ b/test/files/jvm/interpreter.check
@@ -361,7 +361,7 @@ It would fail on the following inputs: Exp(), Term()
                        ^
 f: (e: Exp)Int
 
-scala> 
+scala> :quit
 plusOne: (x: Int)Int
 res0: Int = 6
 res0: String = after reset

--- a/test/files/jvm/throws-annot-from-java.check
+++ b/test/files/jvm/throws-annot-from-java.check
@@ -44,4 +44,4 @@ bar
 tp.typeParams.isEmpty: true
 throws[test.PolymorphicException[_]](classOf[test.PolymorphicException])
 
-scala> 
+scala> :quit

--- a/test/files/jvm/xml05.check
+++ b/test/files/jvm/xml05.check
@@ -4,4 +4,4 @@ Type :help for more information.
 scala> <city name="San Jos&eacute;"/>
 res0: scala.xml.Elem = <city name="San Jos&eacute;"/>
 
-scala> 
+scala> :quit

--- a/test/files/run/class-symbol-contravariant.check
+++ b/test/files/run/class-symbol-contravariant.check
@@ -33,4 +33,4 @@ res2: Boolean = true
 scala> sym.isContravariant // was true
 res3: Boolean = false
 
-scala> 
+scala> :quit

--- a/test/files/run/constant-type.check
+++ b/test/files/run/constant-type.check
@@ -23,4 +23,4 @@ Class[String](classOf[java.lang.String])
 scala> { ConstantType(Constant(s)); exitingPhase(currentRun.erasurePhase)(println(ConstantType(Constant(s)))); }
 Class(classOf[java.lang.String])
 
-scala> 
+scala> :quit

--- a/test/files/run/constrained-types.check
+++ b/test/files/run/constrained-types.check
@@ -148,4 +148,4 @@ scala> val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
        val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
                                     ^
 
-scala> 
+scala> :quit

--- a/test/files/run/kind-repl-command.check
+++ b/test/files/run/kind-repl-command.check
@@ -25,4 +25,4 @@ scala> :k Nonexisting
               Nonexisting
               ^
 
-scala> 
+scala> :quit

--- a/test/files/run/lub-visibility.check
+++ b/test/files/run/lub-visibility.check
@@ -8,4 +8,4 @@ scala> // but reverted that for SI-5534.
 scala> val x = List(List(), Vector())
 x: List[scala.collection.immutable.Seq[Nothing] with scala.collection.AbstractSeq[Nothing] with java.io.Serializable] = List(List(), Vector())
 
-scala> 
+scala> :quit

--- a/test/files/run/macro-bundle-repl.check
+++ b/test/files/run/macro-bundle-repl.check
@@ -21,4 +21,4 @@ defined term macro foo: Unit
 
 scala> foo
 
-scala> 
+scala> :quit

--- a/test/files/run/macro-repl-basic.check
+++ b/test/files/run/macro-repl-basic.check
@@ -49,4 +49,4 @@ import Macros.Shmacros._
 scala> println(foo(2) + Macros.bar(2) * new Macros().quux(4))
 31
 
-scala> 
+scala> :quit

--- a/test/files/run/macro-repl-dontexpand.check
+++ b/test/files/run/macro-repl-dontexpand.check
@@ -13,4 +13,4 @@ bar2: (c: scala.reflect.macros.whitebox.Context)Nothing
 scala> def foo2 = macro bar2
 defined term macro foo2: Nothing
 
-scala> 
+scala> :quit

--- a/test/files/run/macro-system-properties.check
+++ b/test/files/run/macro-system-properties.check
@@ -19,4 +19,4 @@ defined object Test
 scala>     object Test { class C(implicit a: Any) { GrabContext.grab } }
 defined object Test
 
-scala> 
+scala> :quit

--- a/test/files/run/reflection-equality.check
+++ b/test/files/run/reflection-equality.check
@@ -48,4 +48,4 @@ res2: Boolean = true
 scala> t2 <:< t1
 res3: Boolean = true
 
-scala> 
+scala> :quit

--- a/test/files/run/reflection-magicsymbols-repl.check
+++ b/test/files/run/reflection-magicsymbols-repl.check
@@ -34,4 +34,4 @@ scala.Null
 scala.Nothing
 scala.Singleton
 
-scala> 
+scala> :quit

--- a/test/files/run/reflection-repl-classes.check
+++ b/test/files/run/reflection-repl-classes.check
@@ -30,4 +30,4 @@ scala>
 scala> mm(new A)
 res0: Any = 1
 
-scala> 
+scala> :quit

--- a/test/files/run/reflection-repl-elementary.check
+++ b/test/files/run/reflection-repl-elementary.check
@@ -4,4 +4,4 @@ Type :help for more information.
 scala> scala.reflect.runtime.universe.typeOf[List[Nothing]]
 res0: reflect.runtime.universe.Type = scala.List[Nothing]
 
-scala> 
+scala> :quit

--- a/test/files/run/reify-repl-fail-gracefully.check
+++ b/test/files/run/reify-repl-fail-gracefully.check
@@ -14,4 +14,4 @@ scala> reify
               reify
               ^
 
-scala> 
+scala> :quit

--- a/test/files/run/reify_newimpl_22.check
+++ b/test/files/run/reify_newimpl_22.check
@@ -22,4 +22,4 @@ scala> {
                                  ^
 2
 
-scala> 
+scala> :quit

--- a/test/files/run/reify_newimpl_23.check
+++ b/test/files/run/reify_newimpl_23.check
@@ -21,4 +21,4 @@ scala> def foo[T]{
                           ^
 foo: [T]=> Unit
 
-scala> 
+scala> :quit

--- a/test/files/run/reify_newimpl_25.check
+++ b/test/files/run/reify_newimpl_25.check
@@ -12,4 +12,4 @@ scala> {
                                    ^
 TypeTag[x.type]
 
-scala> 
+scala> :quit

--- a/test/files/run/reify_newimpl_26.check
+++ b/test/files/run/reify_newimpl_26.check
@@ -14,4 +14,4 @@ foo: [T]=> Unit
 scala> foo[Int]
 WeakTypeTag[scala.List[T]]
 
-scala> 
+scala> :quit

--- a/test/files/run/reify_newimpl_35.check
+++ b/test/files/run/reify_newimpl_35.check
@@ -10,4 +10,4 @@ foo: [T](implicit evidence$1: reflect.runtime.universe.TypeTag[T])reflect.runtim
 scala> println(foo)
 Expr[List[Nothing]](Nil)
 
-scala> 
+scala> :quit

--- a/test/files/run/repl-assign.check
+++ b/test/files/run/repl-assign.check
@@ -13,4 +13,4 @@ x: Int = 12
 scala> y = 13
 y: Int = 13
 
-scala> 
+scala> :quit

--- a/test/files/run/repl-bare-expr.check
+++ b/test/files/run/repl-bare-expr.check
@@ -47,4 +47,4 @@ Bovine.x: List[Any] = List(Ruminant(5), Cow, Moooooo)
 scala> Bovine.x
 res4: List[Any] = List(Ruminant(5), Cow, Moooooo)
 
-scala> 
+scala> :quit

--- a/test/files/run/repl-colon-type.check
+++ b/test/files/run/repl-colon-type.check
@@ -218,4 +218,4 @@ Unit
 scala> :type println("side effect!")
 Unit
 
-scala> 
+scala> :quit

--- a/test/files/run/repl-empty-package.check
+++ b/test/files/run/repl-empty-package.check
@@ -4,4 +4,4 @@ Type :help for more information.
 scala> println(Bippy.bippy)
 bippy!
 
-scala> 
+scala> :quit

--- a/test/files/run/repl-javap-app.check
+++ b/test/files/run/repl-javap-app.check
@@ -15,7 +15,7 @@ public final void delayedEndpoint$MyApp$1();
    Start  Length  Slot  Name   Signature
    0      9      0    this       LMyApp$;
 
-scala> 
+scala> :quit
 #partest java7
 Welcome to Scala
 Type in expressions to have them evaluated.
@@ -37,7 +37,7 @@ scala> :javap -app MyApp$
         line 5: 0
 }
 
-scala> 
+scala> :quit
 #partest java8
 Welcome to Scala
 Type in expressions to have them evaluated.
@@ -60,4 +60,4 @@ scala> :javap -app MyApp$
         line 5: 0
 }
 
-scala> 
+scala> :quit

--- a/test/files/run/repl-out-dir.check
+++ b/test/files/run/repl-out-dir.check
@@ -46,4 +46,4 @@ repl-out-dir-run.obj
     Test$.class
     Test.class
 
-scala> 
+scala> :quit

--- a/test/files/run/repl-parens.check
+++ b/test/files/run/repl-parens.check
@@ -81,4 +81,4 @@ scala>
 scala> List(1) ++ List('a')
 res16: List[AnyVal] = List(1, a)
 
-scala> 
+scala> :quit

--- a/test/files/run/repl-paste-2.check
+++ b/test/files/run/repl-paste-2.check
@@ -58,4 +58,4 @@ scala> x.length + res5
 res3: Int = 129
 
 
-scala> 
+scala> :quit

--- a/test/files/run/repl-paste-3.check
+++ b/test/files/run/repl-paste-3.check
@@ -7,4 +7,4 @@ scala> println(3)
 scala>   List(1,2)
 res1: List[Int] = List(1, 2)
 
-scala> 
+scala> :quit

--- a/test/files/run/repl-paste-4.scala
+++ b/test/files/run/repl-paste-4.scala
@@ -14,7 +14,7 @@ s"""|Type in expressions to have them evaluated.
     |scala> Foo(new Foo)
     |res0: Int = 7
     |
-    |scala> """
+    |scala> :quit"""
   def pastie = testPath changeExtension "pastie"
 }
 

--- a/test/files/run/repl-paste-raw.scala
+++ b/test/files/run/repl-paste-raw.scala
@@ -15,6 +15,6 @@ s"""|Type in expressions to have them evaluated.
     |scala> favoriteThing.hasString
     |res0: Boolean = true
     |
-    |scala> """
+    |scala> :quit"""
   def pastie = testPath changeExtension "pastie"
 }

--- a/test/files/run/repl-paste.check
+++ b/test/files/run/repl-paste.check
@@ -23,4 +23,4 @@ defined class Dingus
 defined object Dingus
 x: Int = 110
 
-scala> 
+scala> :quit

--- a/test/files/run/repl-power.check
+++ b/test/files/run/repl-power.check
@@ -27,4 +27,4 @@ m: $r.treedsl.global.Literal = 10
 scala> typed(m).tpe                              // typed is in scope
 res2: $r.treedsl.global.Type = Int(10)
 
-scala> 
+scala> :quit

--- a/test/files/run/repl-reset.check
+++ b/test/files/run/repl-reset.check
@@ -54,4 +54,4 @@ defined class BippyBungus
 scala> { new BippyBungus ; x1 }
 res2: Int = 4
 
-scala> 
+scala> :quit

--- a/test/files/run/repl-save.scala
+++ b/test/files/run/repl-save.scala
@@ -16,7 +16,7 @@ s"""|Type in expressions to have them evaluated.
     |
     |scala> :save $saveto
     |
-    |scala> """
+    |scala> :quit"""
   def saveto = testOutput / "session.repl"
   override def show() = {
     super.show()

--- a/test/files/run/repl-term-macros.check
+++ b/test/files/run/repl-term-macros.check
@@ -37,4 +37,4 @@ defined term macro foo3: (x: Int)(y: Int)Unit
 
 scala> foo3(2)(3)
 
-scala> 
+scala> :quit

--- a/test/files/run/repl-transcript.check
+++ b/test/files/run/repl-transcript.check
@@ -35,4 +35,4 @@ scala> res6.sum + res5
 res0: Int = 5273
 
 
-scala> 
+scala> :quit

--- a/test/files/run/repl-trim-stack-trace.scala
+++ b/test/files/run/repl-trim-stack-trace.scala
@@ -32,7 +32,7 @@ java.lang.Exception
   at .f(<console>:7)
   ... 69 elided
 
-scala> """
+scala> :quit"""
 
   // normalize the "elided" lines because the frame count depends on test context
   lazy val elided = """(\s+\.{3} )\d+( elided)""".r

--- a/test/files/run/repl-type-verbose.check
+++ b/test/files/run/repl-type-verbose.check
@@ -187,4 +187,4 @@ PolyType(
   )
 )
 
-scala> 
+scala> :quit

--- a/test/files/run/t3376.check
+++ b/test/files/run/t3376.check
@@ -13,4 +13,4 @@ m2: M[Float] = mmm
 scala> val m3 = new M[String]()
 m3: M[String] = mmm
 
-scala> 
+scala> :quit

--- a/test/files/run/t4025.check
+++ b/test/files/run/t4025.check
@@ -14,4 +14,4 @@ scala>
 scala> def f(c: Any) = c match { case Red(_) => () }
 f: (c: Any)Unit
 
-scala> 
+scala> :quit

--- a/test/files/run/t4172.check
+++ b/test/files/run/t4172.check
@@ -5,4 +5,4 @@ scala> val c = { class C { override def toString = "C" }; ((new C, new C { def f
 warning: there was one feature warning; re-run with -feature for details
 c: (C, C{def f: Int}) forSome { type C <: AnyRef } = (C,C)
 
-scala> 
+scala> :quit

--- a/test/files/run/t4216.check
+++ b/test/files/run/t4216.check
@@ -34,4 +34,4 @@ res4: java.util.List[V] = [V@0]
 scala> o(new V(0))
 res5: java.util.List[Any] = [V@0]
 
-scala> 
+scala> :quit

--- a/test/files/run/t4285.check
+++ b/test/files/run/t4285.check
@@ -10,4 +10,4 @@ y: scala.collection.mutable.WrappedArray[Int] = WrappedArray(2, 4, 6, 8, 10, 12,
 scala> println(y.sum)
 56
 
-scala> 
+scala> :quit

--- a/test/files/run/t4542.check
+++ b/test/files/run/t4542.check
@@ -12,4 +12,4 @@ scala> val f = new Foo
                    ^
 f: Foo = Bippy
 
-scala> 
+scala> :quit

--- a/test/files/run/t4594-repl-settings.scala
+++ b/test/files/run/t4594-repl-settings.scala
@@ -22,5 +22,5 @@ object Test extends SessionTest {
     |               ^
     |b: String
     |
-    |scala> """
+    |scala> :quit"""
 }

--- a/test/files/run/t4671.check
+++ b/test/files/run/t4671.check
@@ -43,4 +43,4 @@ println(s.mkString(""))
 }
 
 
-scala> 
+scala> :quit

--- a/test/files/run/t4710.check
+++ b/test/files/run/t4710.check
@@ -5,4 +5,4 @@ scala> def method : String = { implicit def f(s: Symbol) = "" ; 'symbol }
 warning: there was one feature warning; re-run with -feature for details
 method: String
 
-scala> 
+scala> :quit

--- a/test/files/run/t5072.check
+++ b/test/files/run/t5072.check
@@ -7,4 +7,4 @@ defined class C
 scala> Thread.currentThread.getContextClassLoader.loadClass(classOf[C].getName)
 res0: Class[_] = class C
 
-scala> 
+scala> :quit

--- a/test/files/run/t5256d.check
+++ b/test/files/run/t5256d.check
@@ -25,4 +25,4 @@ scala.AnyRef {
   def foo: scala.Nothing
 }
 
-scala> 
+scala> :quit

--- a/test/files/run/t5535.check
+++ b/test/files/run/t5535.check
@@ -13,4 +13,4 @@ f: Int => Int = <function1>
 scala> println(f(10))
 11
 
-scala> 
+scala> :quit

--- a/test/files/run/t5537.check
+++ b/test/files/run/t5537.check
@@ -13,4 +13,4 @@ res2: List[scala.collection.immutable.List.type] = List()
 scala> List[Set.type]()
 res3: List[Set.type] = List()
 
-scala> 
+scala> :quit

--- a/test/files/run/t5583.check
+++ b/test/files/run/t5583.check
@@ -13,4 +13,4 @@ scala> for (i <- 1 to 10) {s += i}
 scala> println(s)
 165
 
-scala> 
+scala> :quit

--- a/test/files/run/t5655.check
+++ b/test/files/run/t5655.check
@@ -23,4 +23,4 @@ and import x
               x
               ^
 
-scala> 
+scala> :quit

--- a/test/files/run/t5789.check
+++ b/test/files/run/t5789.check
@@ -7,4 +7,4 @@ n: Int = 2
 scala>     () => n
 res0: () => Int = <function0>
 
-scala> 
+scala> :quit

--- a/test/files/run/t6086-repl.check
+++ b/test/files/run/t6086-repl.check
@@ -7,4 +7,4 @@ defined class X
 scala> scala.reflect.runtime.universe.typeOf[X]
 res0: reflect.runtime.universe.Type = X
 
-scala> 
+scala> :quit

--- a/test/files/run/t6146b.check
+++ b/test/files/run/t6146b.check
@@ -60,4 +60,4 @@ res2: u.Type = O.S3
 scala> memType(S4, fTpe)
 res3: u.Type = S4
 
-scala> 
+scala> :quit

--- a/test/files/run/t6187.check
+++ b/test/files/run/t6187.check
@@ -29,4 +29,4 @@ res1: List[Int] = List(1)
 scala> List("") collect { case x => x }
 res2: List[String] = List("")
 
-scala> 
+scala> :quit

--- a/test/files/run/t6273.check
+++ b/test/files/run/t6273.check
@@ -12,4 +12,4 @@ x: String =
   y = 55
 "
 
-scala> 
+scala> :quit

--- a/test/files/run/t6320.check
+++ b/test/files/run/t6320.check
@@ -10,4 +10,4 @@ defined class Dyn
 scala> new Dyn(Map("foo" -> 10)).foo[Int]
 res0: Int = 10
 
-scala> 
+scala> :quit

--- a/test/files/run/t6329_repl.check
+++ b/test/files/run/t6329_repl.check
@@ -32,4 +32,4 @@ res6: scala.reflect.ClassTag[scala.collection.immutable.Set[_]] = scala.collecti
 scala> classTag[scala.collection.immutable.Set[_]]
 res7: scala.reflect.ClassTag[scala.collection.immutable.Set[_]] = scala.collection.immutable.Set
 
-scala> 
+scala> :quit

--- a/test/files/run/t6329_repl_bug.check
+++ b/test/files/run/t6329_repl_bug.check
@@ -14,4 +14,4 @@ res0: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List[<?>]
 scala> scala.reflect.classTag[List[_]]
 res1: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List
 
-scala> 
+scala> :quit

--- a/test/files/run/t6381.check
+++ b/test/files/run/t6381.check
@@ -16,4 +16,4 @@ defined term macro pos: String
 scala> pos
 res0: String = class scala.reflect.internal.util.RangePosition
 
-scala> 
+scala> :quit

--- a/test/files/run/t6434.check
+++ b/test/files/run/t6434.check
@@ -7,4 +7,4 @@ f: (x: => Int)Int
 scala> f _
 res0: (=> Int) => Int = <function1>
 
-scala> 
+scala> :quit

--- a/test/files/run/t6439.check
+++ b/test/files/run/t6439.check
@@ -70,4 +70,4 @@ defined object lookup
 scala> lookup("F") // this now works as a result of changing .typeSymbol to .typeSymbolDirect in IMain#Request#definedSymbols
 res0: $r.intp.global.Symbol = type F
 
-scala> 
+scala> :quit

--- a/test/files/run/t6507.check
+++ b/test/files/run/t6507.check
@@ -21,4 +21,4 @@ scala> res0
 !
 res1: A = A
 
-scala> 
+scala> :quit

--- a/test/files/run/t6549.check
+++ b/test/files/run/t6549.check
@@ -25,4 +25,4 @@ m(scala.Symbol("s")).xxx: Any = 's
 scala> val `"` = 0
 ": Int = 0
 
-scala> 
+scala> :quit

--- a/test/files/run/t6937.check
+++ b/test/files/run/t6937.check
@@ -19,4 +19,4 @@ apiru: scala.reflect.api.Universe = <lazy>
 scala>     apiru.typeTag[A].in(cm)
 res0: reflect.runtime.universe.TypeTag[A] = TypeTag[A]
 
-scala> 
+scala> :quit

--- a/test/files/run/t7185.check
+++ b/test/files/run/t7185.check
@@ -29,4 +29,4 @@ res0: Any =
   }
 }
 
-scala> 
+scala> :quit

--- a/test/files/run/t7319.check
+++ b/test/files/run/t7319.check
@@ -40,4 +40,4 @@ scala> Range(1,2).toArray: Seq[_]
 scala> 0
 res2: Int = 0
 
-scala> 
+scala> :quit

--- a/test/files/run/t7482a.check
+++ b/test/files/run/t7482a.check
@@ -7,4 +7,4 @@ v: java.util.ArrayList[String] = []
 scala>   val v: java.util.ArrayList[String] = new java.util.ArrayList[String](5)
 v: java.util.ArrayList[String] = []
 
-scala> 
+scala> :quit

--- a/test/files/run/t7634.check
+++ b/test/files/run/t7634.check
@@ -5,4 +5,4 @@ Type :help for more information.
 scala> .lines
 res1: List[String] = List(shello, world.)
 
-scala> 
+scala> :quit

--- a/test/files/run/t7747-repl.check
+++ b/test/files/run/t7747-repl.check
@@ -283,4 +283,4 @@ object $read extends $read {
 }
 res3: List[Product with Serializable] = List(BippyBups(), PuppyPups(), Bingo())
 
-scala> 
+scala> :quit

--- a/test/files/run/t7801.check
+++ b/test/files/run/t7801.check
@@ -8,4 +8,4 @@ import g.abort
 scala> class C(val a: Any) extends AnyVal
 defined class C
 
-scala> 
+scala> :quit

--- a/test/files/run/t7805-repl-i.check
+++ b/test/files/run/t7805-repl-i.check
@@ -8,4 +8,4 @@ Type :help for more information.
 scala> Console println Try(8)
 Success(8)
 
-scala> 
+scala> :quit

--- a/test/files/run/tpeCache-tyconCache.check
+++ b/test/files/run/tpeCache-tyconCache.check
@@ -16,4 +16,4 @@ res0: Boolean = true
 scala> AnyRefClass.tpe eq AnyRefClass.typeConstructor
 res1: Boolean = true
 
-scala> 
+scala> :quit


### PR DESCRIPTION
Closing the REPL with Ctrl+D does not issue a newline, so the user's
prompt displays on the same line as the `scala>` prompt. This is bad.
We now force a newline before closing the interpreter, and display
`:quit` while we're at it so that people know how to exit the REPL
(since `exit` doesn't exist anymore).

The tricky part was to only add a newline when the console is
interrupted, and _not_ when it is closed by a command (like `:quit`),
since commands are processed after their text (including newline) has
been sent to the console.
