### PR TITLE
SI-5691 lint warning when a type parameter shadows an existing type.

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -38,6 +38,7 @@ trait Warnings {
     warnMissingInterpolator,
     warnDocDetached,
     warnPrivateShadow,
+    warnTypeParameterShadow,
     warnPolyImplicitOverload,
     warnOptionImplicit,
     warnDelayedInit,
@@ -83,6 +84,8 @@ trait Warnings {
                                 "A ScalaDoc comment appears to be detached from its element.")
   val warnPrivateShadow        = lintflag("private-shadow",
                                 "A private field (or class parameter) shadows a superclass field.")
+  val warnTypeParameterShadow  = lintflag("type-parameter-shadow",
+                                "A local type parameter shadows a type already in scope.")
   val warnPolyImplicitOverload = lintflag("poly-implicit-overload",
                                 "Parameterized overloaded implicit methods are not visible as view bounds")
   val warnOptionImplicit       = lintflag("option-implicit",

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1749,6 +1749,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
              |you want, you must write the annotation class in Java.""".stripMargin)
       }
 
+      warnTypeParameterShadow(tparams1, clazz)
+
       if (!isPastTyper) {
         for (ann <- clazz.getAnnotation(DeprecatedAttr)) {
           val m = companionSymbolOf(clazz, context)
@@ -2151,6 +2153,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       val tparams1 = ddef.tparams mapConserve typedTypeDef
       val vparamss1 = ddef.vparamss mapConserve (_ mapConserve typedValDef)
 
+      warnTypeParameterShadow(tparams1, meth)
+
       meth.annotations.map(_.completeInfo())
 
       for (vparams1 <- vparamss1; vparam1 <- vparams1 dropRight 1)
@@ -2226,6 +2230,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       val tparams1 = tdef.tparams mapConserve typedTypeDef
       val typedMods = typedModifiers(tdef.mods)
       tdef.symbol.annotations.map(_.completeInfo())
+
+      warnTypeParameterShadow(tparams1, tdef.symbol)
 
       // @specialized should not be pickled when compiling with -no-specialize
       if (settings.nospecialization && currentRun.compiles(tdef.symbol)) {

--- a/test/files/neg/forgot-interpolator.scala
+++ b/test/files/neg/forgot-interpolator.scala
@@ -54,8 +54,8 @@ package test {
     }
   }
   import annotation._
-  @implicitNotFound("No Z in ${A}")   // no warn
-  class Z[A]
+  @implicitNotFound("No Z in ${T}")   // no warn
+  class Z[T]
 }
 
 

--- a/test/files/neg/t4851.check
+++ b/test/files/neg/t4851.check
@@ -29,13 +29,13 @@ S.scala:7: warning: Adapting argument list by creating a 3-tuple: this may not b
   val y2 = new Some(1, 2, 3)
            ^
 S.scala:9: warning: Adaptation of argument list by inserting () has been deprecated: this is unlikely to be what you want.
-        signature: J2[T](x: T): J2[T]
+        signature: J2(x: T): J2[T]
   given arguments: <none>
  after adaptation: new J2((): Unit)
   val z1 = new J2
            ^
 S.scala:10: warning: Adaptation of argument list by inserting () has been deprecated: this is unlikely to be what you want.
-        signature: J2[T](x: T): J2[T]
+        signature: J2(x: T): J2[T]
   given arguments: <none>
  after adaptation: new J2((): Unit)
   val z2 = new J2()

--- a/test/files/neg/t4851/J2.java
+++ b/test/files/neg/t4851/J2.java
@@ -1,7 +1,7 @@
 public class J2<T> {
   T x;
 
-  public <T> J(T x) {
+  public J2(T x) {
     this.x = x;
   }
 

--- a/test/files/neg/t5691.check
+++ b/test/files/neg/t5691.check
@@ -1,0 +1,24 @@
+t5691.scala:7: warning: type parameter D defined in method foobar shadows trait D defined in class B. You may want to rename your type parameter, or possibly remove it.
+  def foobar[D](in: D) = in.toString
+             ^
+t5691.scala:10: warning: type parameter D defined in type MySeq shadows trait D defined in class B. You may want to rename your type parameter, or possibly remove it.
+  type MySeq[D] = Seq[D]
+             ^
+t5691.scala:15: warning: type parameter T defined in method bar shadows type T defined in class Foo. You may want to rename your type parameter, or possibly remove it.
+    def bar[T](w: T) = w.toString
+            ^
+t5691.scala:13: warning: type parameter T defined in class Foo shadows type T defined in class B. You may want to rename your type parameter, or possibly remove it.
+  class Foo[T](t: T) {
+            ^
+t5691.scala:19: warning: type parameter List defined in type M shadows type List defined in package object scala. You may want to rename your type parameter, or possibly remove it.
+  class C[M[List[_]]]
+            ^
+t5691.scala:20: warning: type parameter List defined in type M shadows type List defined in package object scala. You may want to rename your type parameter, or possibly remove it.
+  type E[M[List[_]]] = Int
+           ^
+t5691.scala:21: warning: type parameter List defined in type M shadows type List defined in package object scala. You may want to rename your type parameter, or possibly remove it.
+  def foo[N[M[List[_]]]] = ???
+              ^
+error: No warnings can be incurred under -Xfatal-warnings.
+7 warnings found
+one error found

--- a/test/files/neg/t5691.flags
+++ b/test/files/neg/t5691.flags
@@ -1,0 +1,1 @@
+-Xlint:type-parameter-shadow -language:higherKinds -Xfatal-warnings

--- a/test/files/neg/t5691.scala
+++ b/test/files/neg/t5691.scala
@@ -1,0 +1,27 @@
+class B {
+
+  type T = Int
+  trait D
+
+  // method parameter shadows some other type
+  def foobar[D](in: D) = in.toString
+
+  // type member's parameter shadows some other type
+  type MySeq[D] = Seq[D]
+
+  // class parameter shadows some other type
+  class Foo[T](t: T) {
+    // a type parameter shadows another type parameter
+    def bar[T](w: T) = w.toString
+  }
+
+  // even deeply nested...
+  class C[M[List[_]]]
+  type E[M[List[_]]] = Int
+  def foo[N[M[List[_]]]] = ???
+
+  // ...but not between type parameters in the same list
+  class F[A, M[L[A]]]         // no warning!
+  type G[A, M[L[A]]] = Int    // no warning!
+  def bar[A, N[M[L[A]]]] = ??? // no warning!
+}

--- a/test/files/neg/t6675b.scala
+++ b/test/files/neg/t6675b.scala
@@ -13,7 +13,7 @@ object NativelyTwo {
 }
 
 
-class A {
+class E {
   def f1 = (Left((0, 0)): Either[(Int, Int), (Int, Int)]) match { case LeftOrRight(a) => a  }          // warn
   def f2 = (Left((0, 0)): Either[(Int, Int), (Int, Int)]) match { case LeftOrRight((a, b)) => a  }     // no warn
   def f3 = (Left((0, 0)): Either[(Int, Int), (Int, Int)]) match { case LeftOrRight((a, b, c)) => a  }  // fail


### PR DESCRIPTION
This adds a new lint warning for when a class/method/type-member's
type parameter shadows an existing type: `-Xlint:type-parameter-shadow`.

It excludes type parameters of synthetic methods (the user can't
rename or remove those anyway), otherwise, for example, every case class
triggers the warning.

Also fixes a test that contained wrong java sources (that didn't even
compile...), discovered thanks to the warning.

---

This kind of errors shows up every now and then on the mailing-list, on
stackoverflow, etc. so maybe a warning would be useful.
I was afraid this would yield too many warnings for libraries that are
heavy on type parameters, but no: running this on scalaz and shapeless
HEAD (`v7.1.0-RC1-41-g1cc0a96` and `v2.0.0-M1-225-g78426a0` respectively)
yields 44 warnings. None of them are false positives; they usually come
from:
- scalaz loving using `A` as type parameter, even several levels deep
  of parametrized classes/methods
- or calling a type parameter that will hold a map `Map`, or similar,
  thus shadowing an existing type
