### PR TITLE
a few missing deprecations in proxy collections.

### DIFF
--- a/src/library/scala/collection/IterableProxy.scala
+++ b/src/library/scala/collection/IterableProxy.scala
@@ -16,4 +16,5 @@ package collection
  *  @version 2.8
  *  @since   2.8
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.3")
 trait IterableProxy[+A] extends Iterable[A] with IterableProxyLike[A, Iterable[A]]

--- a/src/library/scala/collection/MapProxy.scala
+++ b/src/library/scala/collection/MapProxy.scala
@@ -17,4 +17,5 @@ package collection
  *  @version 1.0, 21/07/2003
  *  @since   1
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.3")
 trait MapProxy[A, +B] extends Map[A, B] with MapProxyLike[A, B, Map[A, B]]

--- a/src/library/scala/collection/SetProxy.scala
+++ b/src/library/scala/collection/SetProxy.scala
@@ -17,4 +17,5 @@ package collection
  *  @author  Martin Odersky
  *  @version 2.0, 01/01/2007
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.3")
 trait SetProxy[A] extends Set[A] with SetProxyLike[A, Set[A]]

--- a/src/library/scala/collection/TraversableProxy.scala
+++ b/src/library/scala/collection/TraversableProxy.scala
@@ -21,4 +21,5 @@ package collection
  *  @version 2.8
  *  @since   2.8
  */
+@deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.3")
 trait TraversableProxy[+A] extends Traversable[A] with TraversableProxyLike[A, Traversable[A]]


### PR DESCRIPTION
SeqProxy was properly deprecated, so were the CollProxyLike classes, and
the ones in collection.immutable, but these four somehow survived
the Big Proxy Deprecation (tm).
