### PR TITLE
SI-8512 Infer a type for f"$args"

### DIFF
--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -163,7 +163,7 @@ case class StringContext(parts: String*) {
    */
   // The implementation is hardwired to `scala.tools.reflect.MacroImplementations.macro_StringInterpolation_f`
   // Using the mechanism implemented in `scala.tools.reflect.FastTrack`
-  def f(args: Any*): String = macro ???
+  def f[A >: Any](args: A*): String = macro ???
 }
 
 object StringContext {

--- a/src/reflect/scala/reflect/api/Quasiquotes.scala
+++ b/src/reflect/scala/reflect/api/Quasiquotes.scala
@@ -13,7 +13,7 @@ trait Quasiquotes { self: Universe =>
     protected trait api {
       // implementation is hardwired to `dispatch` method of `scala.tools.reflect.quasiquotes.Quasiquotes`
       // using the mechanism implemented in `scala.tools.reflect.FastTrack`
-      def apply[T](args: T*): Tree = macro ???
+      def apply[A >: Any](args: A*): Tree = macro ???
       def unapply(scrutinee: Any): Any = macro ???
     }
     object q extends api

--- a/test/files/neg/t7848-interp-warn.flags
+++ b/test/files/neg/t7848-interp-warn.flags
@@ -1,1 +1,1 @@
--Xlint -Xfatal-warnings
+-Xlint:missing-interpolator -Xfatal-warnings

--- a/test/files/pos/t8013.flags
+++ b/test/files/pos/t8013.flags
@@ -1,1 +1,1 @@
--Xfatal-warnings -Xlint
+-Xfatal-warnings -Xlint:-infer-any,_

--- a/test/junit/scala/StringContextTest.scala
+++ b/test/junit/scala/StringContextTest.scala
@@ -62,4 +62,17 @@ class StringContextTest {
     //assertEquals("????", s"????")
     assertEquals("!!!!", s"????") // OK to hijack core interpolator ids
   }
+
+  @Test def fIf() = {
+    val res = f"${if (true) 2.5 else 2.5}%.2f"
+    assertEquals("2.50", res)
+  }
+  @Test def fIfNot() = {
+    val res = f"${if (false) 2.5 else 3.5}%.2f"
+    assertEquals("3.50", res)
+  }
+  @Test def fHeteroArgs() = {
+    val res = f"${3.14}%.2f rounds to ${3}%d"
+    assertEquals("3.14 rounds to 3", res)
+  }
 }

--- a/test/junit/scala/reflect/QTest.scala
+++ b/test/junit/scala/reflect/QTest.scala
@@ -1,0 +1,23 @@
+
+package scala.reflect
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.tools.testing.AssertUtil._
+
+@RunWith(classOf[JUnit4])
+class QTest {
+
+  import reflect.runtime._
+  import universe._
+  @Test def qConstantsNotHomogenized() = {
+    //Apply(Select(Literal(Constant(1.0)), TermName("$plus")), List(Literal(Constant(1.0))))
+    val t = q"${1} + ${1.0}"
+    val Apply(Select(Literal(Constant(i)), TermName("$plus")), List(Literal(Constant(j)))) = t
+    assertEquals(1, i)
+    assertEquals(1.0, j)
+  }
+}


### PR DESCRIPTION
The f-interpolator gets a type param that better be Any to avoid
unfortunate widenings.

Hey, it worked!

@densh 's comments on the ticket are longer than the fix and the test.

Review by @densh
