### PR TITLE
Code cleanup to be more conforming to style guide.

### DIFF
--- a/src/library/scala/collection/generic/BitSetFactory.scala
+++ b/src/library/scala/collection/generic/BitSetFactory.scala
@@ -12,7 +12,6 @@ package scala
 package collection
 package generic
 
-import scala.collection._
 import mutable.Builder
 
 /** @define coll collection
@@ -36,4 +35,3 @@ trait BitSetFactory[Coll <: BitSet with BitSetLike[Coll]] {
     def apply() = newBuilder
   }
 }
-

--- a/src/library/scala/collection/generic/MapFactory.scala
+++ b/src/library/scala/collection/generic/MapFactory.scala
@@ -11,7 +11,6 @@ package collection
 package generic
 
 
-import mutable.{Builder, MapBuilder}
 import scala.language.higherKinds
 
 /** A template for companion objects of `Map` and subclasses thereof.

--- a/src/library/scala/collection/generic/ParFactory.scala
+++ b/src/library/scala/collection/generic/ParFactory.scala
@@ -11,7 +11,6 @@ package collection
 package generic
 
 import scala.collection.parallel.ParIterable
-import scala.collection.parallel.Combiner
 import scala.language.higherKinds
 
 /** A template class for companion objects of `ParIterable` and subclasses

--- a/src/library/scala/collection/generic/ParMapFactory.scala
+++ b/src/library/scala/collection/generic/ParMapFactory.scala
@@ -49,4 +49,3 @@ extends GenMapFactory[CC]
   }
 
 }
-

--- a/src/library/scala/collection/generic/ParSetFactory.scala
+++ b/src/library/scala/collection/generic/ParSetFactory.scala
@@ -10,7 +10,6 @@ package scala
 package collection
 package generic
 
-import scala.collection.mutable.Builder
 import scala.collection.parallel.Combiner
 import scala.collection.parallel.ParSet
 import scala.collection.parallel.ParSetLike
@@ -33,4 +32,3 @@ abstract class ParSetFactory[CC[X] <: ParSet[X] with ParSetLike[X, CC[X], _] wit
     override def apply() = newCombiner[A]
   }
 }
-

--- a/src/library/scala/collection/generic/SeqFactory.scala
+++ b/src/library/scala/collection/generic/SeqFactory.scala
@@ -28,4 +28,3 @@ extends GenSeqFactory[CC] with TraversableFactory[CC] {
   def unapplySeq[A](x: CC[A]): Some[CC[A]] = Some(x)
 
 }
-

--- a/src/library/scala/collection/generic/SetFactory.scala
+++ b/src/library/scala/collection/generic/SetFactory.scala
@@ -12,7 +12,6 @@ package scala
 package collection
 package generic
 
-import mutable.Builder
 import scala.language.higherKinds
 
 abstract class SetFactory[CC[X] <: Set[X] with SetLike[X, CC[X]]]

--- a/src/library/scala/collection/generic/TraversableFactory.scala
+++ b/src/library/scala/collection/generic/TraversableFactory.scala
@@ -38,4 +38,3 @@ import scala.language.higherKinds
  */
 trait TraversableFactory[CC[X] <: Traversable[X] with GenericTraversableTemplate[X, CC]]
   extends GenTraversableFactory[CC] with GenericSeqCompanion[CC]
-

--- a/src/library/scala/compat/Platform.scala
+++ b/src/library/scala/compat/Platform.scala
@@ -9,8 +9,6 @@
 package scala
 package compat
 
-import java.lang.System
-
 object Platform {
 
   /** Thrown when a stack overflow occurs because a method or function recurses too deeply.
@@ -41,13 +39,13 @@ object Platform {
     * @throws java.lang.ArrayStoreException If either `src` or `dest` are not of type
     *                [java.lang.Array]; or if the element type of `src` is not
     *                compatible with that of `dest`.
-    * @throws java.lang.IndexOutOfBoundsException If either srcPos` or `destPos` are
+    * @throws java.lang.IndexOutOfBoundsException If either `srcPos` or `destPos` are
     *                outside of the bounds of their respective arrays; or if `length`
     *                is negative; or if there are less than `length` elements available
     *                after `srcPos` or `destPos` in `src` and `dest` respectively.
     */
   @inline
-  def arraycopy(src: AnyRef, srcPos: Int, dest: AnyRef, destPos: Int, length: Int) {
+  def arraycopy(src: AnyRef, srcPos: Int, dest: AnyRef, destPos: Int, length: Int): Unit = {
     System.arraycopy(src, srcPos, dest, destPos, length)
   }
 
@@ -83,7 +81,7 @@ object Platform {
     * @throws `java.lang.NullPointerException` If `arr` is `null`.
     */
   @inline
-  def arrayclear(arr: Array[Int]) { java.util.Arrays.fill(arr, 0) }
+  def arrayclear(arr: Array[Int]): Unit = { java.util.Arrays.fill(arr, 0) }
 
   /** Returns the `Class` object associated with the class or interface with the given string name using the current `ClassLoader`.
    *  On the JVM, invoking this method is equivalent to: `java.lang.Class.forName(name)`

--- a/src/library/scala/concurrent/ExecutionContext.scala
+++ b/src/library/scala/concurrent/ExecutionContext.scala
@@ -11,7 +11,6 @@ package scala.concurrent
 
 import java.util.concurrent.{ ExecutorService, Executor }
 import scala.annotation.implicitNotFound
-import scala.util.Try
 
 /**
  * An `ExecutionContext` can execute program logic asynchronously,

--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -10,18 +10,11 @@ package scala.concurrent
 
 import scala.language.higherKinds
 
-import java.util.concurrent.{ ConcurrentLinkedQueue, TimeUnit, Callable }
-import java.util.concurrent.TimeUnit.{ NANOSECONDS => NANOS, MILLISECONDS ⇒ MILLIS }
-import java.lang.{ Iterable => JIterable }
-import java.util.{ LinkedList => JLinkedList }
-import java.util.concurrent.atomic.{ AtomicReferenceFieldUpdater, AtomicInteger, AtomicLong, AtomicBoolean }
+import java.util.concurrent.atomic.AtomicInteger
 
 import scala.util.control.NonFatal
-import scala.Option
 import scala.util.{Try, Success, Failure}
 
-import scala.annotation.tailrec
-import scala.collection.mutable.Builder
 import scala.collection.generic.CanBuildFrom
 import scala.reflect.ClassTag
 
@@ -341,7 +334,7 @@ trait Future[+T] extends Awaitable[T] {
   def recoverWith[U >: T](pf: PartialFunction[Throwable, Future[U]])(implicit executor: ExecutionContext): Future[U] = {
     val p = Promise[U]()
     onComplete {
-      case Failure(t) => try pf.applyOrElse(t, (_: Throwable) => this).onComplete(p.complete)(internalExecutor) catch { case NonFatal(t) => p failure t }
+      case Failure(t) => try pf.applyOrElse(t, (_: Throwable) => this).onComplete(p.complete)(internalExecutor) catch { case NonFatal(tt) => p failure tt }
       case other => p complete other
     }
     p.future

--- a/src/library/scala/concurrent/duration/Duration.scala
+++ b/src/library/scala/concurrent/duration/Duration.scala
@@ -104,7 +104,7 @@ object Duration {
    * Extract length and time unit out of a duration, if it is finite.
    */
   def unapply(d: Duration): Option[(Long, TimeUnit)] =
-    if (d.isFinite()) Some((d.length, d.unit)) else None
+    if (d.isFinite) Some((d.length, d.unit)) else None
 
   /**
    * Construct a possibly infinite or undefined Duration from the given number of nanoseconds.
@@ -638,7 +638,7 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
   // if this is made a constant, then scalac will elide the conditional and always return +0.0, SI-6331
   private[this] def minusZero = -0d
   def /(divisor: Duration): Double =
-    if (divisor.isFinite()) toNanos.toDouble / divisor.toNanos
+    if (divisor.isFinite) toNanos.toDouble / divisor.toNanos
     else if (divisor eq Undefined) Double.NaN
     else if ((length < 0) ^ (divisor > Zero)) 0d
     else minusZero
@@ -703,9 +703,9 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
 
   def unary_- = Duration(-length, unit)
 
-  final def isFinite() = true
+  def isFinite() = true
 
-  final def toCoarsest: Duration = {
+  def toCoarsest: Duration = {
     def loop(length: Long, unit: TimeUnit): FiniteDuration = {
       def coarserOrThis(coarser: TimeUnit, divider: Int) =
         if (length % divider == 0) loop(length / divider, coarser)

--- a/src/library/scala/io/Position.scala
+++ b/src/library/scala/io/Position.scala
@@ -69,7 +69,7 @@ private[scala] abstract class Position {
 }
 
 private[scala] object Position extends Position {
-  def checkInput(line: Int, column: Int) {
+  def checkInput(line: Int, column: Int): Unit = {
     if (line < 0)
       throw new IllegalArgumentException(line + " < 0")
     if ((line == 0) && (column != 0))

--- a/src/library/scala/io/Source.scala
+++ b/src/library/scala/io/Source.scala
@@ -282,8 +282,7 @@ abstract class Source extends Iterator[Char] with Closeable {
   def reportError(
     pos: Int,
     msg: String,
-    out: PrintStream = Console.err)
-  {
+    out: PrintStream = Console.err): Unit = {
     nerrors += 1
     report(pos, msg, out)
   }
@@ -294,7 +293,7 @@ abstract class Source extends Iterator[Char] with Closeable {
    *  @param msg the error message to report
    *  @param out PrintStream to use
    */
-  def report(pos: Int, msg: String, out: PrintStream) {
+  def report(pos: Int, msg: String, out: PrintStream): Unit = {
     val line  = Position line pos
     val col   = Position column pos
 
@@ -309,8 +308,7 @@ abstract class Source extends Iterator[Char] with Closeable {
   def reportWarning(
     pos: Int,
     msg: String,
-    out: PrintStream = Console.out)
-  {
+    out: PrintStream = Console.out): Unit = {
     nwarnings += 1
     report(pos, "warning! " + msg, out)
   }
@@ -342,7 +340,7 @@ abstract class Source extends Iterator[Char] with Closeable {
   }
 
   /** The close() method closes the underlying resource. */
-  def close() {
+  def close(): Unit = {
     if (closeFunction != null) closeFunction()
   }
 

--- a/src/library/scala/math/BigDecimal.scala
+++ b/src/library/scala/math/BigDecimal.scala
@@ -10,7 +10,6 @@
 package scala
 package math
 
-import java.{ lang => jl }
 import java.math.{ MathContext, BigDecimal => BigDec }
 import scala.collection.immutable.NumericRange
 import scala.language.implicitConversions
@@ -124,7 +123,7 @@ object BigDecimal {
    */
   def exact(s: String): BigDecimal = exact(new BigDec(s))
   
-  /** Constructs a 'BigDecimal` that exactly represents the number
+  /** Constructs a `BigDecimal` that exactly represents the number
    *  specified in base 10 in a character array.
    */
  def exact(cs: Array[Char]): BigDecimal = exact(new BigDec(cs))
@@ -435,7 +434,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable {
    *  with large exponents.
    */
   override def hashCode(): Int = {
-    if (computedHashCode == BigDecimal.hashCodeNotComputed) computeHashCode
+    if (computedHashCode == BigDecimal.hashCodeNotComputed) computeHashCode()
     computedHashCode
   }
 
@@ -525,9 +524,9 @@ extends ScalaNumber with ScalaNumericConversions with Serializable {
     catch { case _: ArithmeticException => false }
   }
 
-  def isWhole() = scale <= 0 || bigDecimal.stripTrailingZeros.scale <= 0
+  def isWhole: Boolean = scale <= 0 || bigDecimal.stripTrailingZeros.scale <= 0
   
-  def underlying = bigDecimal
+  def underlying: BigDec = bigDecimal
   
 
   /** Compares this BigDecimal with the specified BigDecimal for equality.
@@ -670,21 +669,21 @@ extends ScalaNumber with ScalaNumericConversions with Serializable {
    *  Note that this conversion can lose information about the overall magnitude of the
    *  BigDecimal value as well as return a result with the opposite sign.
    */
-  override def byteValue   = intValue.toByte
+  override def byteValue: Byte = intValue.toByte
 
   /** Converts this BigDecimal to a Short.
    *  If the BigDecimal is too big to fit in a Short, only the low-order 16 bits are returned.
    *  Note that this conversion can lose information about the overall magnitude of the
    *  BigDecimal value as well as return a result with the opposite sign.
    */
-  override def shortValue  = intValue.toShort
+  override def shortValue: Short = intValue.toShort
 
   /** Converts this BigDecimal to a Char.
    *  If the BigDecimal is too big to fit in a Char, only the low-order 16 bits are returned.
    *  Note that this conversion can lose information about the overall magnitude of the
    *  BigDecimal value and that it always returns a positive result.
    */
-  def charValue   = intValue.toChar
+  def charValue: Char = intValue.toChar
 
   /** Converts this BigDecimal to an Int.
    *  If the BigDecimal is too big to fit in an Int, only the low-order 32 bits
@@ -692,7 +691,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable {
    *  overall magnitude of the BigDecimal value as well as return a result with
    *  the opposite sign.
    */
-  def intValue    = this.bigDecimal.intValue
+  def intValue: Int = this.bigDecimal.intValue
 
   /** Converts this BigDecimal to a Long.
    *  If the BigDecimal is too big to fit in a Long, only the low-order 64 bits
@@ -700,49 +699,49 @@ extends ScalaNumber with ScalaNumericConversions with Serializable {
    *  overall magnitude of the BigDecimal value as well as return a result with
    *  the opposite sign.
    */
-  def longValue   = this.bigDecimal.longValue
+  def longValue: Long = this.bigDecimal.longValue
 
   /** Converts this BigDecimal to a Float.
    *  if this BigDecimal has too great a magnitude to represent as a float,
    *  it will be converted to `Float.NEGATIVE_INFINITY` or
    *  `Float.POSITIVE_INFINITY` as appropriate.
    */
-  def floatValue  = this.bigDecimal.floatValue
+  def floatValue: Float = this.bigDecimal.floatValue
 
   /** Converts this BigDecimal to a Double.
    *  if this BigDecimal has too great a magnitude to represent as a double,
    *  it will be converted to `Double.NEGATIVE_INFINITY` or
    *  `Double.POSITIVE_INFINITY` as appropriate.
    */
-  def doubleValue = this.bigDecimal.doubleValue
+  def doubleValue: Double = this.bigDecimal.doubleValue
 
   /** Converts this `BigDecimal` to a [[scala.Byte]], checking for lost information.
     * If this `BigDecimal` has a nonzero fractional part, or is out of the possible
     * range for a [[scala.Byte]] result, then a `java.lang.ArithmeticException` is
     * thrown.
     */
-  def toByteExact = bigDecimal.byteValueExact
+  def toByteExact: Byte = bigDecimal.byteValueExact
 
   /** Converts this `BigDecimal` to a [[scala.Short]], checking for lost information.
     * If this `BigDecimal` has a nonzero fractional part, or is out of the possible
     * range for a [[scala.Short]] result, then a `java.lang.ArithmeticException` is
     * thrown.
     */
-  def toShortExact = bigDecimal.shortValueExact
+  def toShortExact: Short = bigDecimal.shortValueExact
 
   /** Converts this `BigDecimal` to a [[scala.Int]], checking for lost information.
     * If this `BigDecimal` has a nonzero fractional part, or is out of the possible
     * range for an [[scala.Int]] result, then a `java.lang.ArithmeticException` is
     * thrown.
     */
-  def toIntExact = bigDecimal.intValueExact
+  def toIntExact: Int = bigDecimal.intValueExact
 
   /** Converts this `BigDecimal` to a [[scala.Long]], checking for lost information.
     * If this `BigDecimal` has a nonzero fractional part, or is out of the possible
     * range for a [[scala.Long]] result, then a `java.lang.ArithmeticException` is
     * thrown.
     */
-  def toLongExact = bigDecimal.longValueExact
+  def toLongExact: Long = bigDecimal.longValueExact
 
   /** Creates a partially constructed NumericRange[BigDecimal] in range
    *  `[start;end)`, where start is the target BigDecimal.  The step
@@ -772,20 +771,19 @@ extends ScalaNumber with ScalaNumericConversions with Serializable {
 
   /** Converts this `BigDecimal` to a scala.BigInt.
    */
-  def toBigInt(): BigInt = new BigInt(this.bigDecimal.toBigInteger())
+  def toBigInt(): BigInt = new BigInt(this.bigDecimal.toBigInteger)
 
   /** Converts this `BigDecimal` to a scala.BigInt if it
    *  can be done losslessly, returning Some(BigInt) or None.
    */
-  def toBigIntExact(): Option[BigInt] =
-    if (isWhole()) {
-      try Some(new BigInt(this.bigDecimal.toBigIntegerExact()))
+  def toBigIntExact: Option[BigInt] =
+    if (isWhole) {
+      try Some(new BigInt(this.bigDecimal.toBigIntegerExact))
       catch { case _: ArithmeticException => None }
     }
     else None
 
   /** Returns the decimal String representation of this BigDecimal.
    */
-  override def toString(): String = this.bigDecimal.toString()
-
+  override def toString: String = this.bigDecimal.toString
 }

--- a/src/library/scala/math/BigInt.scala
+++ b/src/library/scala/math/BigInt.scala
@@ -399,7 +399,7 @@ final class BigInt(val bigInteger: BigInteger) extends ScalaNumber with ScalaNum
 
   /** Returns the decimal String representation of this BigInt.
    */
-  override def toString(): String = this.bigInteger.toString()
+  override def toString(): String = this.bigInteger.toString
 
   /** Returns the String representation in the specified radix of this BigInt.
    */
@@ -411,5 +411,5 @@ final class BigInt(val bigInteger: BigInteger) extends ScalaNumber with ScalaNum
    *  minimum number of bytes required to represent this BigInt, including at
    *  least one sign bit.
    */
-  def toByteArray: Array[Byte] = this.bigInteger.toByteArray()
+  def toByteArray: Array[Byte] = this.bigInteger.toByteArray
 }

--- a/src/library/scala/math/Numeric.scala
+++ b/src/library/scala/math/Numeric.scala
@@ -218,10 +218,10 @@ trait Numeric[T] extends Ordering[T] {
     def unary_-() = negate(lhs)
     def abs(): T = Numeric.this.abs(lhs)
     def signum(): Int = Numeric.this.signum(lhs)
-    def toInt(): Int = Numeric.this.toInt(lhs)
-    def toLong(): Long = Numeric.this.toLong(lhs)
-    def toFloat(): Float = Numeric.this.toFloat(lhs)
-    def toDouble(): Double = Numeric.this.toDouble(lhs)
+    def toInt: Int = Numeric.this.toInt(lhs)
+    def toLong: Long = Numeric.this.toLong(lhs)
+    def toFloat: Float = Numeric.this.toFloat(lhs)
+    def toDouble: Double = Numeric.this.toDouble(lhs)
   }
   implicit def mkNumericOps(lhs: T): Ops = new Ops(lhs)
 }

--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -334,7 +334,7 @@ object Ordering extends LowPriorityOrderingImplicits {
       case (None, None)       => 0
       case (None, _)          => -1
       case (_, None)          => 1
-      case (Some(x), Some(y)) => optionOrdering.compare(x, y)
+      case (Some(xx), Some(yy)) => optionOrdering.compare(xx, yy)
     }
   }
   implicit def Option[T](implicit ord: Ordering[T]): Ordering[Option[T]] =
@@ -396,7 +396,7 @@ object Ordering extends LowPriorityOrderingImplicits {
 
   implicit def Tuple5[T1, T2, T3, T4, T5](implicit ord1: Ordering[T1], ord2: Ordering[T2], ord3: Ordering[T3], ord4: Ordering[T4], ord5: Ordering[T5]): Ordering[(T1, T2, T3, T4, T5)] =
     new Ordering[(T1, T2, T3, T4, T5)]{
-      def compare(x: (T1, T2, T3, T4, T5), y: Tuple5[T1, T2, T3, T4, T5]): Int = {
+      def compare(x: (T1, T2, T3, T4, T5), y: (T1, T2, T3, T4, T5)): Int = {
         val compare1 = ord1.compare(x._1, y._1)
         if (compare1 != 0) return compare1
         val compare2 = ord2.compare(x._2, y._2)

--- a/src/library/scala/math/ScalaNumericConversions.scala
+++ b/src/library/scala/math/ScalaNumericConversions.scala
@@ -34,59 +34,59 @@ trait ScalaNumericAnyConversions extends Any {
   /** Returns the value of this as a [[scala.Char]]. This may involve
     * rounding or truncation.
     */
-  def toChar = intValue().toChar
+  def toChar: Char = intValue.toChar
 
   /** Returns the value of this as a [[scala.Byte]]. This may involve
     * rounding or truncation.
     */
-  def toByte = byteValue()
+  def toByte: Byte = byteValue
 
   /** Returns the value of this as a [[scala.Short]]. This may involve
     * rounding or truncation.
     */
-  def toShort = shortValue()
+  def toShort: Short = shortValue
 
   /** Returns the value of this as an [[scala.Int]]. This may involve
     * rounding or truncation.
     */
-  def toInt = intValue()
+  def toInt: Int = intValue
 
   /** Returns the value of this as a [[scala.Long]]. This may involve
     * rounding or truncation.
     */
-  def toLong = longValue()
+  def toLong: Long = longValue
 
   /** Returns the value of this as a [[scala.Float]]. This may involve
     * rounding or truncation.
     */
-  def toFloat = floatValue()
+  def toFloat: Float = floatValue
 
   /** Returns the value of this as a [[scala.Double]]. This may involve
     * rounding or truncation.
     */
-  def toDouble = doubleValue()
+  def toDouble: Double = doubleValue
 
   /** Returns `true` iff this has a zero fractional part, and is within the
     * range of [[scala.Byte]] MinValue and MaxValue; otherwise returns `false`.
     */
-  def isValidByte  = isWhole && (toInt == toByte)
+  def isValidByte: Boolean = isWhole && (toInt == toByte)
 
   /** Returns `true` iff this has a zero fractional part, and is within the
     * range of [[scala.Short]] MinValue and MaxValue; otherwise returns `false`.
     */
-  def isValidShort = isWhole && (toInt == toShort)
+  def isValidShort: Boolean = isWhole && (toInt == toShort)
 
   /** Returns `true` iff this has a zero fractional part, and is within the
     * range of [[scala.Int]] MinValue and MaxValue; otherwise returns `false`.
     */
-  def isValidInt   = isWhole && (toLong == toInt)
+  def isValidInt: Boolean = isWhole && (toLong == toInt)
 
   /** Returns `true` iff this has a zero fractional part, and is within the
     * range of [[scala.Char]] MinValue and MaxValue; otherwise returns `false`.
     */
-  def isValidChar  = isWhole && (toInt >= Char.MinValue && toInt <= Char.MaxValue)
+  def isValidChar: Boolean = isWhole && (toInt >= Char.MinValue && toInt <= Char.MaxValue)
 
-  protected def unifiedPrimitiveHashcode() = {
+  protected def unifiedPrimitiveHashcode(): Int = {
     val lv = toLong
     if (lv >= Int.MinValue && lv <= Int.MaxValue) lv.toInt
     else lv.##

--- a/src/library/scala/util/Random.scala
+++ b/src/library/scala/util/Random.scala
@@ -36,7 +36,7 @@ class Random(val self: java.util.Random) extends AnyRef with Serializable {
   /** Generates random bytes and places them into a user-supplied byte
    *  array.
    */
-  def nextBytes(bytes: Array[Byte]) { self.nextBytes(bytes) }
+  def nextBytes(bytes: Array[Byte]): Unit = { self.nextBytes(bytes) }
 
   /** Returns the next pseudorandom, uniformly distributed double value
    *  between 0.0 and 1.0 from this random number generator's sequence.
@@ -98,7 +98,7 @@ class Random(val self: java.util.Random) extends AnyRef with Serializable {
     (self.nextInt(high - low) + low).toChar
   }
 
-  def setSeed(seed: Long) { self.setSeed(seed) }
+  def setSeed(seed: Long): Unit = { self.setSeed(seed) }
 
   /** Returns a new collection of the same type in a randomly chosen order.
    *
@@ -107,7 +107,7 @@ class Random(val self: java.util.Random) extends AnyRef with Serializable {
   def shuffle[T, CC[X] <: TraversableOnce[X]](xs: CC[T])(implicit bf: CanBuildFrom[CC[T], T, CC[T]]): CC[T] = {
     val buf = new ArrayBuffer[T] ++= xs
 
-    def swap(i1: Int, i2: Int) {
+    def swap(i1: Int, i2: Int): Unit = {
       val tmp = buf(i1)
       buf(i1) = buf(i2)
       buf(i2) = tmp

--- a/src/library/scala/util/Sorting.scala
+++ b/src/library/scala/util/Sorting.scala
@@ -9,8 +9,8 @@
 package scala
 package util
 
-import scala.reflect.{ ClassTag, classTag }
-import scala.math.{ Ordering, max, min }
+import scala.reflect.ClassTag
+import scala.math.Ordering
 
 /** The Sorting object provides functions that can sort various kinds of
   * objects. You can provide a comparison function, or you can request a sort
@@ -27,27 +27,27 @@ import scala.math.{ Ordering, max, min }
   */
 object Sorting {
   /** Quickly sort an array of Doubles. */
-  def quickSort(a: Array[Double]) { sort1(a, 0, a.length) }
+  def quickSort(a: Array[Double]): Unit = { sort1(a, 0, a.length) }
 
   /** Quickly sort an array of items with an implicit Ordering. */
-  def quickSort[K: Ordering](a: Array[K]) { sort1(a, 0, a.length) }
+  def quickSort[K: Ordering](a: Array[K]): Unit = { sort1(a, 0, a.length) }
 
   /** Quickly sort an array of Ints. */
-  def quickSort(a: Array[Int]) { sort1(a, 0, a.length) }
+  def quickSort(a: Array[Int]): Unit = { sort1(a, 0, a.length) }
 
   /** Quickly sort an array of Floats. */
-  def quickSort(a: Array[Float]) { sort1(a, 0, a.length) }
+  def quickSort(a: Array[Float]): Unit = { sort1(a, 0, a.length) }
 
   /** Sort an array of K where K is Ordered, preserving the existing order
     * where the values are equal. */
-  def stableSort[K: ClassTag: Ordering](a: Array[K]) {
-    stableSort(a, 0, a.length-1, new Array[K](a.length), Ordering[K].lt _)
+  def stableSort[K: ClassTag: Ordering](a: Array[K]): Unit = {
+    stableSort(a, 0, a.length-1, new Array[K](a.length), Ordering[K].lt)
   }
 
   /** Sorts an array of `K` given an ordering function `f`.
    *  `f` should return `true` iff its first parameter is strictly less than its second parameter.
    */
-  def stableSort[K: ClassTag](a: Array[K], f: (K, K) => Boolean) {
+  def stableSort[K: ClassTag](a: Array[K], f: (K, K) => Boolean): Unit = {
     stableSort(a, 0, a.length-1, new Array[K](a.length), f)
   }
 

--- a/src/repl/scala/tools/nsc/MainGenericRunner.scala
+++ b/src/repl/scala/tools/nsc/MainGenericRunner.scala
@@ -6,8 +6,8 @@
 package scala
 package tools.nsc
 
-import io.{ File }
-import util.{ ClassPath, ScalaClassLoader }
+import io.File
+import util.ClassPath
 import GenericRunnerCommand._
 
 object JarRunner extends CommonRunner {


### PR DESCRIPTION
- Return `Unit` instead of using procedure syntax.
- Explicitly listed return type for `def`s.
- Added/removed `()` for arity-0 methods depending on whether or not they have side-effects.
- Removed unused imports.
- Fixed missing "`" in doc strings.
- Removed redundant `final` qualifier.
- Renamed values to prevent shadowing.
