### PR TITLE
SI-8781 Avoid double-expansion under -Ymacro-expand:discard

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -576,7 +576,10 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
                 // also see http://groups.google.com/group/scala-internals/browse_thread/thread/492560d941b315cc
                 val expanded1 = try onSuccess(duplicateAndKeepPositions(expanded)) finally popMacroContext()
                 if (!hasMacroExpansionAttachment(expanded1)) linkExpandeeAndExpanded(expandee, expanded1)
-                if (settings.Ymacroexpand.value == settings.MacroExpand.Discard) expandee.setType(expanded1.tpe)
+                if (settings.Ymacroexpand.value == settings.MacroExpand.Discard) {
+                  suppressMacroExpansion(expandee)
+                  expandee.setType(expanded1.tpe)
+                }
                 else expanded1
               case Fallback(fallback) => onFallback(fallback)
               case Delayed(delayed) => onDelayed(delayed)

--- a/test/files/pos/t8781/Macro_1.scala
+++ b/test/files/pos/t8781/Macro_1.scala
@@ -1,0 +1,13 @@
+import scala.reflect.macros.whitebox.Context
+import language.experimental.macros
+
+object Macros {
+  def impl(c: Context) = {
+    import c.universe._
+    val name = TypeName(c.freshName())
+    q"class $name extends T; new $name"
+  }
+  def fresh: Any = macro impl
+}
+
+trait T

--- a/test/files/pos/t8781/Test_2.flags
+++ b/test/files/pos/t8781/Test_2.flags
@@ -1,0 +1,1 @@
+-Ymacro-expand:discard -Ystop-after:typer

--- a/test/files/pos/t8781/Test_2.scala
+++ b/test/files/pos/t8781/Test_2.scala
@@ -1,0 +1,5 @@
+object Test {
+  implicit class RichT(t: T) { def augmented = "" }
+
+  Macros.fresh.augmented
+}


### PR DESCRIPTION
This mode of macro expansion is used by the presentation compiler to
leave the original macro applications ("expandees") in the type
checked trees, annotated with the types of the expansions.

However, under some circumstances involving implicits, we would
re-expand the macro. If the macro wasn't stable, this could lead
to a type mismatch.

The originally reported problem was with the shapeless
`mkSingletonOps` macro. Its expansion had the type of a freshly-named
class local to the expansion. Upon the re-expansion, a new class
was generated, which lead to errors like:

```
client/Client.scala:4: error: type mismatch;
 found   : fresh$macro$2
 required: fresh$macro$1
```

This commit suppressed re-expansion of the expandee by use of
the existing, tree attachment driven mechanism.

Review by @xeno-by. /cc @dragos
