### PR TITLE
Possible fix for SI-8782

### DIFF
--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -472,22 +472,15 @@ object Range {
       NumericRange.inclusive(start, end, step)
   }
 
-  // Double works by using a BigDecimal under the hood for precise
-  // stepping, but mapping the sequence values back to doubles with
-  // .doubleValue.  This constructs the BigDecimals by way of the
-  // String constructor (valueOf) instead of the Double one, which
-  // is necessary to keep 0.3d at 0.3 as opposed to
-  // 0.299999999999999988897769753748434595763683319091796875 or so.
   object Double {
-    implicit val bigDecAsIntegral = scala.math.Numeric.BigDecimalAsIfIntegral
     implicit val doubleAsIntegral = scala.math.Numeric.DoubleAsIfIntegral
     def toBD(x: Double): BigDecimal = scala.math.BigDecimal valueOf x
 
     def apply(start: Double, end: Double, step: Double) =
-      BigDecimal(toBD(start), toBD(end), toBD(step)) mapRange (_.doubleValue)
+      NumericRange(start, end, step)
 
     def inclusive(start: Double, end: Double, step: Double) =
-      BigDecimal.inclusive(toBD(start), toBD(end), toBD(step)) mapRange (_.doubleValue)
+      NumericRange.inclusive(start, end, step)
   }
 
   // As there is no appealing default step size for not-really-integral ranges,


### PR DESCRIPTION
Modified Range.Double to use NumericRange of Double instead of using BigDecimal internally and then converting it to Double.

Same change can be made on the other branches 2.9.x, 2.10.x and 2.11.x
