### PR TITLE
SI-1264 scala -e now outputs compilation messages to stderr

### DIFF
--- a/src/compiler/scala/tools/nsc/CompileSocket.scala
+++ b/src/compiler/scala/tools/nsc/CompileSocket.scala
@@ -32,7 +32,11 @@ trait HasCompileSocket {
           if (isErrorMessage(line))
             noErrors = false
 
-          compileSocket.echo(line)
+          // There is currently no way to separate full messages (not justs individual lines)
+          // intended for stdout from those for stderr, even on the sender side (ConsoleReporter).
+          // Even scalac doesn't try and sends everything to stderr, so let's at least
+          // be consistent and do the same here
+          compileSocket.warn(line)
           loop()
       }
       try loop()


### PR DESCRIPTION
This makes `scala -e` send the compilation output from fsc to stderr, just
lile `scala -nc -e`, and like `scalac` itself, instead of stdout.

Note that this only aligns fsc with the rest, but it doesn't fix the
actual issue that, currently, a line can be printed without the error
severity and yet be part of an error message, so the severity is useless
for the purpose of discriminating stdout vs. stderr. This ended up with
fsc picking stdout for (mostly) everything and the others stderr. Even
`scalac -help` sends its output to stderr...
