### PR TITLE
SI-8788 Add generic signature to Parcelable static field special case.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
@@ -1046,7 +1046,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
         PublicStaticFinal,
         androidFieldName.toString,
         tdesc_creator,
-        null, // no java-generic-signature
+        "%s<L%s;>;".format(tdesc_creator.dropRight(1), thisName),
         null  // no initial value
       ).visitEnd()
 


### PR DESCRIPTION
Android's AIDL generates Java code that assumes the presence of generic
annotations for Parcelable classes, which previously were not being
generated. This patch adds a generic signature to the generated CREATOR
field, resolving the issue.
