### PR TITLE
mutable.LongMap.fromZip takes collection.Iterable

### DIFF
--- a/src/library/scala/collection/mutable/LongMap.scala
+++ b/src/library/scala/collection/mutable/LongMap.scala
@@ -557,7 +557,7 @@ object LongMap {
   /** Creates a new `LongMap` from keys and values. 
    *  Equivalent to but more efficient than `LongMap((keys zip values): _*)`.
    */
-  def fromZip[V](keys: Iterable[Long], values: Iterable[V]): LongMap[V] = {
+  def fromZip[V](keys: collection.Iterable[Long], values: collection.Iterable[V]): LongMap[V] = {
     val sz = math.min(keys.size, values.size)
     val lm = new LongMap[V](sz * 2)
     val ki = keys.iterator


### PR DESCRIPTION
The type should be qualified as collection.Iterable, because Iterable is that context is mutable.Iterable.

The fix can probably be backported to 2.11.x if generalizing final method arguments does not break binary compatibility (the companion object of `LongMap` cannot be subclassed).
