### PR TITLE
SI-8627 Override filterNot in Stream

### DIFF
--- a/src/library/scala/collection/immutable/Stream.scala
+++ b/src/library/scala/collection/immutable/Stream.scala
@@ -491,6 +491,8 @@ self =>
     else Stream.Empty
   }
 
+  override def filterNot(p: A => Boolean): Stream[A] = filter(!p(_))
+
   override final def withFilter(p: A => Boolean): StreamWithFilter = new StreamWithFilter(p)
 
   /** A lazier implementation of WithFilter than TraversableLike's.

--- a/test/junit/scala/collection/StreamTest.scala
+++ b/test/junit/scala/collection/StreamTest.scala
@@ -1,0 +1,16 @@
+package scala.collection
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class StreamTest {
+
+  @Test(timeout=10000)
+  def filterNotWorks() {
+    assertEquals(Seq(6, 7, 8), Stream.from(1).filterNot(_ <= 5).take(3))
+    assertEquals(Seq((), ()), Stream.continually(()).filterNot(_ => false).take(2))
+  }
+}


### PR DESCRIPTION
Fixes a bug in which `Stream#filterNot` performs an eager evaluation of
the `Stream` it is called on. Also adds an additional unit test that
exposes the bug.

Previously, commit 7a6905dc15 fixed this method, but commit 3059e3a0c03
broke it again. In my opinion, `Stream` should not rely on the fact
that `TraversableLike`’s implementation of `filterNot` uses `filter`,
as it is not mandatory in the method’s contract. Instead, the method
should be overriden in `Stream` - that way, `Stream` will be more
resilient to changes in its underlying traits.
