### PR TITLE
SI-8793 Fix patmat regression with extractors, existentials

### DIFF
--- a/test/files/pos/t8793.scala
+++ b/test/files/pos/t8793.scala
@@ -1,0 +1,15 @@
+package regr 
+ 
+trait F[A]
+ 
+class G(val a: F[_], val b: F[_])
+ 
+object G {
+  def unapply(g: G) = Option((g.a, g.b))
+}
+ 
+object H {
+  def unapply(g: G) = g match {
+    case G(a, _) => Option(a)
+  }
+}


### PR DESCRIPTION
In the same vein as SI-8128 / 3e9e2c65a, revert to the 2.10.x style
of determining the types of the product elements of an extractor
when using `TupleN`.

I believe we can discard the special casing for Option/Tuple/Seq
altogether with judicious application of `repackExistential` in
`unapplyMethodTypes`. That ought to also fix fix SI-8149. But I'll
target that work at 2.12.x.
