### PR TITLE
make ConsoleReporter handle both stdout and stderr

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/ReplReporter.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplReporter.scala
@@ -10,6 +10,7 @@ import reporters._
 import IMain._
 
 import scala.reflect.internal.util.Position
+import java.io.PrintWriter
 
 /** Like ReplGlobal, a layer for ensuring extra functionality.
  */
@@ -32,15 +33,16 @@ class ReplReporter(intp: IMain) extends ConsoleReporter(intp.settings, Console.i
   override def warning(pos: Position, msg: String): Unit = withoutTruncating(super.warning(pos, msg))
   override def error(pos: Position, msg: String): Unit   = withoutTruncating(super.error(pos, msg))
 
-  override def printMessage(msg: String) {
+  // intercepts all output to support total silencing
+  override protected def writeImpl(msg: String, writer: PrintWriter) {
     // Avoiding deadlock if the compiler starts logging before
     // the lazy val is complete.
     if (intp.isInitializeComplete) {
       if (intp.totalSilence) {
         if (isReplTrace)
-          super.printMessage("[silent] " + msg)
+          super.writeImpl("[silent] " + msg, writer)
       }
-      else super.printMessage(msg)
+      else super.writeImpl(msg, writer)
     }
     else Console.println("[init] " + msg)
   }


### PR DESCRIPTION
`scala` and `scalac` always had a problem with deciding where to send
messages in the console and just sent everything to stderr, so it is
time to improve that:

`ConsoleReporter` now takes two `PrintWriter`, one for errors/warnings and
one for normal messages. The short constructor sets them to stderr and
stdout, respectively.

This finally makes scala(c) ouput like any normal program. For example:

``` sh
$ scalac -help > /dev/null # will now print nothing

$ scala -nc -e "val" > /dev/null # will print an error message

$ scala -nc -e "println(1)" > /dev/null # but this won't
```

People calling the old constructor (with a single writer) get no change
in behavior: everything goes to the writer.

---

The second commit uses that to fix a 6-year-old issue, [SI-1264](https://issues.scala-lang.org/browse/SI-1264).
