### PR TITLE
SI-8498 @compileTimeOnly should be aware of bridge methods.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1287,6 +1287,7 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
     private def checkUndesiredProperties(sym: Symbol, pos: Position) {
       // If symbol is deprecated, and the point of reference is not enclosed
       // in either a deprecated member or a scala bridge method, issue a warning.
+      // TODO: x.hasBridgeAnnotation doesn't seem to be needed here...
       if (sym.isDeprecated && !currentOwner.ownerChain.exists(x => x.isDeprecated || x.hasBridgeAnnotation))
         currentRun.reporting.deprecationWarning(pos, sym)
 
@@ -1305,7 +1306,7 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
           reporter.warning(pos, s"${sym.fullLocationString} has changed semantics in version ${sym.migrationVersion.get}:\n${sym.migrationMessage.get}")
       }
       // See an explanation of compileTimeOnly in its scaladoc at scala.annotation.compileTimeOnly.
-      if (sym.isCompileTimeOnly) {
+      if (sym.isCompileTimeOnly && !currentOwner.ownerChain.exists(x => x.isCompileTimeOnly)) {
         def defaultMsg =
           sm"""Reference to ${sym.fullLocationString} should not have survived past type checking,
               |it should have been processed and eliminated during expansion of an enclosing macro."""

--- a/test/files/neg/compile-time-only-a.check
+++ b/test/files/neg/compile-time-only-a.check
@@ -4,9 +4,6 @@ compile-time-only-a.scala:10: error: C3
 compile-time-only-a.scala:12: error: C4
 @compileTimeOnly("C4") case class C4(x: Int)
                                   ^
-compile-time-only-a.scala:17: error: C5
-  implicit class C5(val x: Int) {
-                 ^
 compile-time-only-a.scala:32: error: C1
   new C1()
       ^
@@ -76,4 +73,4 @@ compile-time-only-a.scala:75: error: placebo
 compile-time-only-a.scala:75: error: placebo
   @placebo def x = (2: @placebo)
                         ^
-26 errors found
+25 errors found

--- a/test/files/pos/t8498.scala
+++ b/test/files/pos/t8498.scala
@@ -1,0 +1,6 @@
+import scala.annotation.compileTimeOnly
+
+class C(val s: String) extends AnyVal {
+  @compileTimeOnly("error")
+  def error = ???
+}


### PR DESCRIPTION
Values classes, for example, will create bridges to a `@compileTimeOnly`
method (the bridge is also marked `@compileTimeOnly`), which should not
throw an error. Calling the bridge or the method will anyway.
