### PR TITLE
FSC server port selected by argument

### DIFF
--- a/src/compiler/scala/tools/nsc/CompileClient.scala
+++ b/src/compiler/scala/tools/nsc/CompileClient.scala
@@ -43,8 +43,8 @@ class StandardCompileClient extends HasCompileSocket with CompileOutputCommon {
     info(vmArgs.mkString("[VM arguments: ", " ", "]"))
 
     val socket =
-      if (settings.server.value == "") compileSocket.getOrCreateSocket(vmArgs mkString " ", !shutdown)
-      else Some(compileSocket.getSocket(settings.server.value))
+      if (settings.server.value == "") compileSocket.getOrCreateSocket(vmArgs mkString " ", !shutdown, settings.port.value)
+      else compileSocket.getSocket(settings.server.value)
 
     socket match {
       case Some(sock) => compileOnServer(sock, fscArgs)

--- a/src/compiler/scala/tools/nsc/settings/FscSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/FscSettings.scala
@@ -22,13 +22,15 @@ class FscSettings(error: String => Unit) extends Settings(error) {
   val reset        = BooleanSetting("-reset",    "Reset compile server caches")
   val shutdown     = BooleanSetting("-shutdown", "Shutdown compile server")
   val server       = StringSetting ("-server",   "hostname:portnumber", "Specify compile server socket", "")
+  val port         = IntSetting    ("-port",     "Search and start compile server in given port only",
+  		                                      0, Some((0, Int.MaxValue)), (_: String) => None)
   val preferIPv4   = BooleanSetting("-ipv4",     "Use IPv4 rather than IPv6 for the server socket")
   val idleMins     = IntSetting    ("-max-idle", "Set idle timeout in minutes for fsc (use 0 for no timeout)",
                                               30, Some((0, Int.MaxValue)), (_: String) => None)
 
   // For improved help output, separating fsc options from the others.
   def fscSpecific = Set[Settings#Setting](
-    currentDir, reset, shutdown, server, preferIPv4, idleMins
+    currentDir, reset, shutdown, server, port, preferIPv4, idleMins
   )
   val isFscSpecific: String => Boolean = fscSpecific map (_.name)
 

--- a/src/compiler/scala/tools/util/SocketServer.scala
+++ b/src/compiler/scala/tools/util/SocketServer.scala
@@ -28,12 +28,12 @@ trait CompileOutputCommon {
  *  @author  Martin Odersky
  *  @version 1.0
  */
-abstract class SocketServer extends CompileOutputCommon {
+abstract class SocketServer(fixPort: Int = 0) extends CompileOutputCommon {
   def shutdown: Boolean
   def session(): Unit
   def timeout(): Unit = ()  // called after a timeout is detected for subclasses to cleanup
   // a hook for subclasses
-  protected def createServerSocket(): ServerSocket = new ServerSocket(0)
+  protected def createServerSocket(): ServerSocket = new ServerSocket(fixPort)
 
   var in: BufferedReader = _
   var out: PrintWriter   = _


### PR DESCRIPTION
Discussed for example in https://issues.scala-lang.org/browse/SI-4504

Logic is following: If the existing -server argument has form localhost:port and there is no server running, then a new server is started at the given port. Therefore fsc can be used as without the server argument but fixing the port where to connect and start. If server argument points to another host server is not started.
