### PR TITLE
SI-8803 generate super accessor for super[A], if A is outer superclass

### DIFF
--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -473,7 +473,7 @@ trait StdNames {
     )
 
     def localDummyName(clazz: Symbol): TermName = newTermName(LOCALDUMMY_PREFIX + clazz.name + ">")
-    def superName(name: Name): TermName         = newTermName(SUPER_PREFIX_STRING + name)
+    def superName(name: Name, mix: Name = EMPTY): TermName = newTermName(SUPER_PREFIX_STRING + name + (if (mix.isEmpty) "" else "$" + mix))
 
     /** The name of an accessor for protected symbols. */
     def protName(name: Name): TermName = newTermName(PROTECTED_PREFIX + name)

--- a/test/files/run/t8803.check
+++ b/test/files/run/t8803.check
@@ -1,0 +1,16 @@
+a
+b
+b
+c
+a
+b
+b
+c
+a
+b
+b
+c
+a
+b
+b
+c

--- a/test/files/run/t8803.scala
+++ b/test/files/run/t8803.scala
@@ -1,0 +1,57 @@
+class A {
+  def m = "a"
+  protected def n = "a"
+}
+
+trait B {
+  def m = "b"
+  protected def n = "b"
+}
+
+class C extends A with B {
+  override def m = "c"
+  override protected def n = "c"
+
+  val f1 = () => super[A].m
+  val f2 = () => super[B].m
+  val f3 = () => super.m
+  val f4 = () => this.m
+
+  val g1 = new runtime.AbstractFunction0[String] { def apply() = C.super[A].m }
+  val g2 = new runtime.AbstractFunction0[String] { def apply() = C.super[B].m }
+  val g3 = new runtime.AbstractFunction0[String] { def apply() = C.super.m }
+  val g4 = new runtime.AbstractFunction0[String] { def apply() = C.this.m }
+
+  val h1 = () => super[A].n
+  val h2 = () => super[B].n
+  val h3 = () => super.n
+  val h4 = () => this.n
+
+  val i1 = new runtime.AbstractFunction0[String] { def apply() = C.super[A].n }
+  val i2 = new runtime.AbstractFunction0[String] { def apply() = C.super[B].n }
+  val i3 = new runtime.AbstractFunction0[String] { def apply() = C.super.n }
+  val i4 = new runtime.AbstractFunction0[String] { def apply() = C.this.n }
+}
+
+object Test extends App {
+  val c = new C
+  println(c.f1())
+  println(c.f2())
+  println(c.f3())
+  println(c.f4())
+
+  println(c.g1())
+  println(c.g2())
+  println(c.g3())
+  println(c.g4())
+
+  println(c.h1())
+  println(c.h2())
+  println(c.h3())
+  println(c.h4())
+
+  println(c.i1())
+  println(c.i2())
+  println(c.i3())
+  println(c.i4())
+}


### PR DESCRIPTION
```
class C extends A with T {
  class I {
    C.super[T]
    C.super[A]
  }
}
```

A super call in a nested class of the form super[T] where T is a
parent trait of the outer class doesn't need an accessor: mixin can
directly re-route the call to the correct implementation class - it's
statically known to be T$class.

However, if a nested class accesses super[A] and A is the superclass
of the outer class (not a trait), then we need a super accessor in the
outer class.

We need to add the mixin name to the super accessor name, otherwise
it clashes with non-qualified super accessors.
