### PR TITLE
SI-8764 fix return type of case class productElement under Xexperimental

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
@@ -95,7 +95,7 @@ trait SyntheticMethods extends ast.TreeDSL {
     // which they shouldn't.
     val accessorLub  = (
       if (settings.Xexperimental) {
-        global.weakLub(accessors map (_.tpe.finalResultType)) match {
+        global.lub(accessors map (_.tpe.finalResultType)) match {
           case RefinedType(parents, decls) if !decls.isEmpty => intersectionType(parents)
           case tp                                            => tp
         }

--- a/test/files/neg/t8764.check
+++ b/test/files/neg/t8764.check
@@ -1,0 +1,6 @@
+t8764.scala:8: error: type mismatch;
+ found   : AnyVal
+ required: Double
+  val d: Double = a.productElement(0)
+                                  ^
+one error found

--- a/test/files/neg/t8764.flags
+++ b/test/files/neg/t8764.flags
@@ -1,0 +1,1 @@
+-Xexperimental

--- a/test/files/neg/t8764.scala
+++ b/test/files/neg/t8764.scala
@@ -1,0 +1,9 @@
+object Main {
+
+  case class IntAndDouble(i: Int, d: Double)
+
+  // a.productElement used to be Int => Double
+  // now: Int => AnyVal
+  val a = IntAndDouble(1, 5.0)
+  val d: Double = a.productElement(0)
+}

--- a/test/files/run/t8764.check
+++ b/test/files/run/t8764.check
@@ -1,0 +1,5 @@
+IntOnly: should return an unboxed int
+Int: int
+IntAndDouble: should just box and return Anyval
+Double: class java.lang.Double
+Int: class java.lang.Integer

--- a/test/files/run/t8764.flags
+++ b/test/files/run/t8764.flags
@@ -1,0 +1,1 @@
+-Xexperimental

--- a/test/files/run/t8764.scala
+++ b/test/files/run/t8764.scala
@@ -1,0 +1,16 @@
+object Test extends App {
+case class IntOnly(i: Int, j: Int)
+
+println("IntOnly: should return an unboxed int")
+val a = IntOnly(1, 2)
+val i: Int = a.productElement(0)
+println(s"Int: ${a.productElement(0).getClass}")
+
+case class IntAndDouble(i: Int, d: Double)
+
+println("IntAndDouble: should just box and return Anyval")
+val b = IntAndDouble(1, 2.0)
+val j: AnyVal = b.productElement(0)
+println(s"Double: ${b.productElement(1).getClass}")
+println(s"Int: ${b.productElement(0).getClass}")
+}


### PR DESCRIPTION
Under `-Xexperimental`, `productElement` now returns the lub instead
of the weak lub of case class parameter types (numeric widening
shouldn't magically happen _inside_ `productElement`).
