### PR TITLE
SI-7128  copyToArray(xs, 0, 0) should not fail

### DIFF
--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -1130,9 +1130,8 @@ trait Iterator[+A] extends TraversableOnce[A] {
    *    $willNotTerminateInf
    */
   def copyToArray[B >: A](xs: Array[B], start: Int, len: Int): Unit = {
-    require(start >= 0 && (start < xs.length || xs.length == 0), s"start $start out of range ${xs.length}")
     var i = start
-    val end = start + math.min(len, xs.length - start)
+    val end = math.min(start + len, xs.length)
     while (i < end && hasNext) {
       xs(i) = next()
       i += 1

--- a/src/library/scala/collection/mutable/ArrayOps.scala
+++ b/src/library/scala/collection/mutable/ArrayOps.scala
@@ -40,9 +40,8 @@ trait ArrayOps[T] extends Any with ArrayLike[T, Array[T]] with CustomParalleliza
     arrayElementClass(repr.getClass)
 
   override def copyToArray[U >: T](xs: Array[U], start: Int, len: Int) {
-    var l = math.min(len, repr.length)
-    if (xs.length - start < l) l = xs.length - start max 0
-    Array.copy(repr, 0, xs, start, l)
+    val l = len min repr.length min (xs.length - start)
+    if (l > 0) Array.copy(repr, 0, xs, start, l)
   }
 
   override def toArray[U >: T : ClassTag]: Array[U] = {

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -87,7 +87,7 @@ extends AbstractSeq[A]
    */
   override def copyToArray[B >: A](xs: Array[B], start: Int, len: Int) {
     val len1 = len min (xs.length - start) min length
-    Array.copy(array, 0, xs, start, len1)
+    if (len1 > 0) Array.copy(array, 0, xs, start, len1)
   }
 
   override def clone(): ArraySeq[A] = {

--- a/src/library/scala/collection/mutable/ResizableArray.scala
+++ b/src/library/scala/collection/mutable/ResizableArray.scala
@@ -74,7 +74,7 @@ trait ResizableArray[A] extends IndexedSeq[A]
    */
    override def copyToArray[B >: A](xs: Array[B], start: Int, len: Int) {
      val len1 = len min (xs.length - start) min length
-     Array.copy(array, 0, xs, start, len1)
+     if (len1 > 0) Array.copy(array, 0, xs, start, len1)
    }
 
   //##########################################################################


### PR DESCRIPTION
Fixed all copyToArray methods to do exactly what the docs say they do, with the least-suprise behavior of not throwing an exception if you ask to copy nothing (but would have copied out of range).

Iterator had an undocumented requirement for the target index to be in range regardless if anything happened; this has been removed.
