### PR TITLE
Add support for running a specific Junit test/method.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1440,9 +1440,13 @@ TODO:
     <stopwatch name="test.junit.timer"/>
     <mkdir dir="${test.junit.classes}"/>
     <echo message="Note: details of failed tests will be output to ${build-junit.dir}"/>
+
+    <if><isset property="test.method" /><then><property name="test.methods" value="${test.method}" /></then></if>
     <junit fork="yes" haltonfailure="yes" printsummary="on">
       <classpath refid="test.junit.compiler.build.path"/>
-      <batchtest fork="yes" todir="${build-junit.dir}">
+      <test fork="yes" todir="${build-junit.dir}" if="test.class" unless="test.methods" name="${test.class}" />
+      <test fork="yes" todir="${build-junit.dir}" if="test.methods" name="${test.class}" methods="${test.methods}" />
+      <batchtest fork="yes" todir="${build-junit.dir}" unless="test.class">
         <fileset dir="${test.junit.classes}">
           <include name="**/*Test.class"/>
         </fileset>


### PR DESCRIPTION
Unless I really missed something, there is currently no way to run a
specific Junit test (class or method). Running the whole thing is going
to get worse and worse since Junit is supposed to be the preferred way,
so here it goes:

``` sh
# will run all methods in a test file
ant test.junit -Dtest.class=scala.WhateverTest

# will run a specific method (just an alias for the one below)
ant test.junit -Dtest.class=scala.WhateverTest -Dtest.method=mymethod

# will run several methods (comma separated)
ant test.junit -Dtest.class=scala.WhateverTest -Dtest.methods="foo,bar"
```

`test.method(s)` without `test.class` is just ignored (all tests are
run).
