### PR TITLE
SI-1264 SI-5227 fsc isn't very good at returning error messages

### DIFF
--- a/src/compiler/scala/tools/nsc/CompileServer.scala
+++ b/src/compiler/scala/tools/nsc/CompileServer.scala
@@ -152,6 +152,7 @@ class StandardCompileServer extends SocketServer {
           clearCompiler()
         case ex: Throwable =>
           warn("Compile server encountered fatal condition: " + ex)
+          reporter.error(null, "Compile server encountered fatal condition: " + ex.getMessage)
           shutdown = true
           throw ex
       }

--- a/src/compiler/scala/tools/nsc/CompileSocket.scala
+++ b/src/compiler/scala/tools/nsc/CompileSocket.scala
@@ -32,7 +32,8 @@ trait HasCompileSocket {
           if (isErrorMessage(line))
             noErrors = false
 
-          compileSocket.echo(line)
+          // be consistent with scalac: everything goes to stderr
+          compileSocket.warn(line)
           loop()
       }
       try loop()


### PR DESCRIPTION
Two little error-message-related fsc fixes:

**SI-1264 fsc compiler output should go to stderr, like scalac**

This properly sends the compiler output of `scala -e`, scala worksheets,
... to sdterr, just like scalac does.

Before:

``` sh
% scala -e 'foo' > /dev/null
%
```

After:

``` sh
% scala -e 'foo' > /dev/null
/tmp/scalacmd8514641341855028538.scala:1: error: not found: value foo
foo
^
one error found
%
```

---

**SI-5227 make fsc notify its client upon compiler crash**

Fsc shoudln't just write to its own stderr when a major compiler crash
happens, it should also send an error to the client (`scala -e` for
example).

Otherwise the client thinks everything went fine (silence == success)
and tries to run something, crashes too, and displays only its own
error, not the original one.
