### PR TITLE
SI-8823 Exclude specialized methods from extension method rewrite

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -795,7 +795,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       info.firstParent.typeSymbol == AnyValClass && !isPrimitiveValueClass
 
     final def isMethodWithExtension =
-      isMethod && owner.isDerivedValueClass && !isParamAccessor && !isConstructor && !hasFlag(SUPERACCESSOR) && !isMacro
+      isMethod && owner.isDerivedValueClass && !isParamAccessor && !isConstructor && !hasFlag(SUPERACCESSOR) && !isMacro && !isSpecialized
 
     final def isAnonymousFunction = isSynthetic && (name containsName tpnme.ANON_FUN_NAME)
     final def isDefinedInPackage  = effectiveOwner.isPackageClass

--- a/test/files/run/t8823.scala
+++ b/test/files/run/t8823.scala
@@ -1,0 +1,10 @@
+class Tuple2Int(val encoding: Long) extends AnyVal with Product2[Int, Int] {
+  def canEqual(that: Any) = false
+  def _1: Int = 1
+  def _2: Int = 2
+}
+
+object Test extends App {
+  assert(new Tuple2Int(0)._1 == 1)
+  assert(new Tuple2Int(0)._2 == 2)
+}


### PR DESCRIPTION
If a value class extends a specialized class, it can sprout
specialized members after the specialization info transformer has run.
However, we only install extension methods for class members we know
about at the extmethods phase.

This commit simply disables rewiring calls to these methods in
erasure to an extention method. This follows the approach taken
from super accessors.

Note: value class type parameters themselves currently are not
allowed to be specialized.

Review by @gkossakowski
