### PR TITLE
Update stripPrefix documentation to talk about no op case

### DIFF
--- a/src/library/scala/collection/immutable/StringLike.scala
+++ b/src/library/scala/collection/immutable/StringLike.scala
@@ -135,7 +135,9 @@ self =>
   def linesIterator: Iterator[String] =
     linesWithSeparators map (line => new WrappedString(line).stripLineEnd)
 
-  /** Returns this string with first character converted to upper case. */
+  /** Returns this string with first character converted to upper case. If the first character 
+   *  is of the caller is capitalized, it is returned unchanged.
+   */
   def capitalize: String =
     if (toString == null) null
     else if (toString.length == 0) ""

--- a/src/library/scala/collection/immutable/StringLike.scala
+++ b/src/library/scala/collection/immutable/StringLike.scala
@@ -135,7 +135,7 @@ self =>
   def linesIterator: Iterator[String] =
     linesWithSeparators map (line => new WrappedString(line).stripLineEnd)
 
-  /** Returns this string with first character converted to upper case */
+  /** Returns this string with first character converted to upper case. */
   def capitalize: String =
     if (toString == null) null
     else if (toString.length == 0) ""
@@ -145,13 +145,16 @@ self =>
       new String(chars)
     }
 
-  /** Returns this string with the given `prefix` stripped. */
+  /** Returns this string with the given `prefix` stripped. If this string does not
+   *  end with `prefix`, it is returned unchanged.
+   */
   def stripPrefix(prefix: String) =
     if (toString.startsWith(prefix)) toString.substring(prefix.length)
     else toString
 
   /** Returns this string with the given `suffix` stripped. If this string does not
-    * end with `suffix`, it is returned unchanged. */
+   *  end with `suffix`, it is returned unchanged.
+   */
   def stripSuffix(suffix: String) =
     if (toString.endsWith(suffix)) toString.substring(0, toString.length() - suffix.length)
     else toString

--- a/src/library/scala/collection/immutable/StringLike.scala
+++ b/src/library/scala/collection/immutable/StringLike.scala
@@ -146,7 +146,7 @@ self =>
     }
 
   /** Returns this string with the given `prefix` stripped. If this string does not
-   *  end with `prefix`, it is returned unchanged.
+   *  start with `prefix`, it is returned unchanged.
    */
   def stripPrefix(prefix: String) =
     if (toString.startsWith(prefix)) toString.substring(prefix.length)


### PR DESCRIPTION
Update StringLike Documentation to indicate what happens when you remove a prefix from a string, and the string doesn't have that prefix.
