### PR TITLE
SI-8828 fix regression in Xlint visibility warning for sealed classes

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1633,7 +1633,7 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
             if (settings.warnNullaryUnit)
               checkNullaryMethodReturnType(sym)
             if (settings.warnInaccessible) {
-              if (!sym.isConstructor && !sym.isEffectivelyFinal && !sym.isSynthetic)
+              if (!sym.isConstructor && !sym.isEffectivelyFinalOrNotOverridden && !sym.isSynthetic)
                 checkAccessibilityOfReferencedTypes(tree)
             }
             tree match {

--- a/test/files/pos/t8828.flags
+++ b/test/files/pos/t8828.flags
@@ -1,0 +1,1 @@
+-Xlint:inaccessible -Xfatal-warnings

--- a/test/files/pos/t8828.scala
+++ b/test/files/pos/t8828.scala
@@ -1,0 +1,20 @@
+
+package outer
+
+package inner {
+
+  private[inner] class A
+
+  // the class is final: no warning
+  private[outer] final class B {
+    def doWork(a: A): A = a
+  }
+
+  // the trait is sealed and doWork is not 
+  // and cannot be overriden: no warning
+  private[outer] sealed trait C {
+    def doWork(a: A): A = a
+  }
+
+  private[outer] final class D extends C
+}


### PR DESCRIPTION
5dfcf5e reverted a change to `Symbol#isEffectivelyFinal` (made in
adeffda) that broke overriding checks, and moved the new enhanced
version to a new method.

However, the test for inaccessible type access still uses the old one,
so it lost the ability to see that the owner of some method is either
final or sealed and not overridden.

This just makes it use the new `isEffectivelyFinalOrNotOverriden`.
