### PR TITLE
SI-7746 fix unspecifc non-exhaustiveness warnings and non-determinism in pattern matcher

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
@@ -88,6 +88,9 @@ trait Logic extends Debugging  {
       // compute the domain and return it (call registerNull first!)
       def domainSyms: Option[mutable.LinkedHashSet[Sym]]
 
+      // contains (pairs of) domain symbols that are not in a subtype relation
+      def mutuallyExclusiveDomainSyms: Option[Seq[Seq[Sym]]]
+
       // the symbol for this variable being equal to its statically known type
       // (only available if registerEquality has been called for that type before)
       def symForStaticTp: Option[Sym]
@@ -238,6 +241,15 @@ trait Logic extends Debugging  {
         // consider X ::= A | B | C, and A => B
         // coverage is formulated as: A \/ B \/ C and the implications are
         v.domainSyms foreach { dsyms => addAxiom(\/(dsyms)) }
+
+        // restrict solutions to only one of the possible subtypes of a domain
+        for {
+          dsyms <- v.mutuallyExclusiveDomainSyms
+          mutuallyExclusiveSyms <- dsyms
+        } {
+          val negated = mutuallyExclusiveSyms.map(Not)
+          addAxiom(\/(negated))
+        }
 
         // when this variable cannot be null the equality corresponding to the type test `(x: T)`, where T is x's static type,
         // is always true; when the variable may be null we use the implication `(x != null) => (x: T)` for the axiom
@@ -487,6 +499,14 @@ trait ScalaLogic extends Interface with Logic with TreeAndTypeAnalysis {
 
       // accessing after calling registerNull will result in inconsistencies
       lazy val domainSyms: Option[collection.mutable.LinkedHashSet[Sym]] = domain map { _ map symForEqualsTo }
+
+      lazy val mutuallyExclusiveDomainSyms: Option[Seq[Seq[Sym]]] = domainSyms map {
+        _.toSeq.combinations(2).toIndexedSeq.filterNot { case Seq(a, b) =>
+            val aIsSubTypeOfb = a.const.tp <:< b.const.tp
+            val bIsSubTypeOfa = b.const.tp <:< a.const.tp
+            aIsSubTypeOfb || bIsSubTypeOfa
+          }
+      }
 
       lazy val symForStaticTp: Option[Sym]  = symForEqualsTo.get(TypeConst(staticTpCheckable))
 

--- a/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
@@ -86,7 +86,7 @@ trait Logic extends Debugging  {
       def mayBeNull: Boolean
 
       // compute the domain and return it (call registerNull first!)
-      def domainSyms: Option[mutable.LinkedHashSet[Sym]]
+      def domainSyms: Option[Set[Sym]]
 
       // contains (pairs of) domain symbols that are not in a subtype relation
       def mutuallyExclusiveDomainSyms: Option[Seq[Seq[Sym]]]
@@ -207,7 +207,7 @@ trait Logic extends Debugging  {
     def removeVarEq(props: List[Prop], modelNull: Boolean = false): (Formula, List[Formula]) = {
       val start = if (Statistics.canEnable) Statistics.startTimer(patmatAnaVarEq) else null
 
-      val vars = mutable.LinkedHashSet[Var]()
+      val vars = new scala.collection.mutable.HashSet[Var]
 
       object gatherEqualities extends PropTraverser {
         override def apply(p: Prop) = p match {
@@ -303,7 +303,7 @@ trait Logic extends Debugging  {
     def eqFreePropToSolvable(p: Prop): Formula
     def cnfString(f: Formula): String
 
-    type Model = collection.immutable.SortedMap[Sym, Boolean]
+    type Model = Map[Sym, Boolean]
     val EmptyModel: Model
     val NoModel: Model
 
@@ -353,9 +353,9 @@ trait ScalaLogic extends Interface with Logic with TreeAndTypeAnalysis {
       // we enumerate the subtypes of the full type, as that allows us to filter out more types statically,
       // once we go to run-time checks (on Const's), convert them to checkable types
       // TODO: there seems to be bug for singleton domains (variable does not show up in model)
-      lazy val domain: Option[mutable.LinkedHashSet[Const]] = {
-        val subConsts: Option[mutable.LinkedHashSet[Const]] = enumerateSubtypes(staticTp).map { tps =>
-          mutable.LinkedHashSet(tps: _*).map{ tp =>
+      lazy val domain: Option[Set[Const]] = {
+        val subConsts = enumerateSubtypes(staticTp).map{ tps =>
+          tps.toSet[Type].map{ tp =>
             val domainC = TypeConst(tp)
             registerEquality(domainC)
             domainC
@@ -498,7 +498,7 @@ trait ScalaLogic extends Interface with Logic with TreeAndTypeAnalysis {
       }
 
       // accessing after calling registerNull will result in inconsistencies
-      lazy val domainSyms: Option[collection.mutable.LinkedHashSet[Sym]] = domain map { _ map symForEqualsTo }
+      lazy val domainSyms: Option[Set[Sym]] = domain map { _ map symForEqualsTo }
 
       lazy val mutuallyExclusiveDomainSyms: Option[Seq[Seq[Sym]]] = domainSyms map {
         _.toSeq.combinations(2).toIndexedSeq.filterNot { case Seq(a, b) =>

--- a/src/compiler/scala/tools/nsc/transform/patmat/Solving.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Solving.scala
@@ -26,16 +26,9 @@ trait Solving extends Logic {
     type Formula = FormulaBuilder
     def formula(c: Clause*): Formula = ArrayBuffer(c: _*)
 
-    type Clause  = collection.Set[Lit]
+    type Clause  = Set[Lit]
     // a clause is a disjunction of distinct literals
-    def clause(l: Lit*): Clause = (
-      if (l.lengthCompare(1) <= 0) {
-        l.toSet // SI-8531 Avoid LinkedHashSet's bulk for 0 and 1 element clauses
-      } else {
-        // neg/t7020.scala changes output 1% of the time, the non-determinism is quelled with this linked set
-        mutable.LinkedHashSet(l: _*)
-      }
-    )
+    def clause(l: Lit*): Clause = l.toSet
 
     type Lit
     def Lit(sym: Sym, pos: Boolean = true): Lit
@@ -141,7 +134,7 @@ trait Solving extends Logic {
     def cnfString(f: Formula) = alignAcrossRows(f map (_.toList) toList, "\\/", " /\\\n")
 
     // adapted from http://lara.epfl.ch/w/sav10:simple_sat_solver (original by Hossein Hojjat)
-    val EmptyModel = collection.immutable.SortedMap.empty[Sym, Boolean]
+    val EmptyModel = Map.empty[Sym, Boolean]
     val NoModel: Model = null
 
     // returns all solutions, if any (TODO: better infinite recursion backstop -- detect fixpoint??)
@@ -242,15 +235,14 @@ trait Solving extends Logic {
             withLit(findModelFor(dropUnit(f, unitLit)), unitLit)
           case _ =>
             // partition symbols according to whether they appear in positive and/or negative literals
-            // SI-7020 Linked- for deterministic counter examples.
-            val pos = new mutable.LinkedHashSet[Sym]()
-            val neg = new mutable.LinkedHashSet[Sym]()
+            val pos = new mutable.HashSet[Sym]()
+            val neg = new mutable.HashSet[Sym]()
             mforeach(f)(lit => if (lit.pos) pos += lit.sym else neg += lit.sym)
 
             // appearing in both positive and negative
-            val impures: mutable.LinkedHashSet[Sym] = pos intersect neg
+            val impures = pos intersect neg
             // appearing only in either positive/negative positions
-            val pures: mutable.LinkedHashSet[Sym] = (pos ++ neg) -- impures
+            val pures = (pos ++ neg) -- impures
 
             if (pures nonEmpty) {
               val pureSym = pures.head

--- a/test/files/neg/patmatexhaust.check
+++ b/test/files/neg/patmatexhaust.check
@@ -12,7 +12,7 @@ It would fail on the following inputs: (Kult(_), Kult(_)), (Qult(), Qult())
                       ^
 patmatexhaust.scala:49: warning: match may not be exhaustive.
 It would fail on the following inputs: Gp(), Gu
-    def ma4(x:Deep) = x match { // missing cases: Gu, Gp
+    def ma4(x:Deep) = x match { // missing cases: Gu, Gp which is not abstract so must be included
                       ^
 patmatexhaust.scala:55: warning: unreachable code
       case _ if 1 == 0 =>

--- a/test/files/neg/patmatexhaust.scala
+++ b/test/files/neg/patmatexhaust.scala
@@ -46,7 +46,7 @@ class TestSealedExhaustive { // compile only
       case _ =>
     }
 
-    def ma4(x:Deep) = x match { // missing cases: Gu, Gp
+    def ma4(x:Deep) = x match { // missing cases: Gu, Gp which is not abstract so must be included
       case Ga =>
     }
 

--- a/test/files/neg/t7020.check
+++ b/test/files/neg/t7020.check
@@ -1,17 +1,17 @@
 t7020.scala:3: warning: match may not be exhaustive.
-It would fail on the following inputs: List((x: Int forSome x not in (1, 2, 4, 5, 6, 7))), List((x: Int forSome x not in (1, 2, 4, 5, 6, 7)), _), List(1, _), List(2, _), List(4, _), List(5, _), List(6, _), List(7, _), List(_, _)
+It would fail on the following inputs: List((x: Int forSome x not in (1, 2, 4, 5, 6, 7))), List((x: Int forSome x not in (1, 2, 4, 5, 6, 7)), _), List(1, _), List(2, _), List(4, _), List(5, _), List(6, _), List(7, _), List(??, _)
   List(5) match {
       ^
 t7020.scala:10: warning: match may not be exhaustive.
-It would fail on the following inputs: List((x: Int forSome x not in (1, 2, 4, 5, 6, 7))), List((x: Int forSome x not in (1, 2, 4, 5, 6, 7)), _), List(1, _), List(2, _), List(4, _), List(5, _), List(6, _), List(7, _), List(_, _)
+It would fail on the following inputs: List((x: Int forSome x not in (1, 2, 4, 5, 6, 7))), List((x: Int forSome x not in (1, 2, 4, 5, 6, 7)), _), List(1, _), List(2, _), List(4, _), List(5, _), List(6, _), List(7, _), List(??, _)
   List(5) match {
       ^
 t7020.scala:17: warning: match may not be exhaustive.
-It would fail on the following inputs: List((x: Int forSome x not in (1, 2, 4, 5, 6, 7))), List((x: Int forSome x not in (1, 2, 4, 5, 6, 7)), _), List(1, _), List(2, _), List(4, _), List(5, _), List(6, _), List(7, _), List(_, _)
+It would fail on the following inputs: List((x: Int forSome x not in (1, 2, 4, 5, 6, 7))), List((x: Int forSome x not in (1, 2, 4, 5, 6, 7)), _), List(1, _), List(2, _), List(4, _), List(5, _), List(6, _), List(7, _), List(??, _)
   List(5) match {
       ^
 t7020.scala:24: warning: match may not be exhaustive.
-It would fail on the following inputs: List((x: Int forSome x not in (1, 2, 4, 5, 6, 7))), List((x: Int forSome x not in (1, 2, 4, 5, 6, 7)), _), List(1, _), List(2, _), List(4, _), List(5, _), List(6, _), List(7, _), List(_, _)
+It would fail on the following inputs: List((x: Int forSome x not in (1, 2, 4, 5, 6, 7))), List((x: Int forSome x not in (1, 2, 4, 5, 6, 7)), _), List(1, _), List(2, _), List(4, _), List(5, _), List(6, _), List(7, _), List(??, _)
   List(5) match {
       ^
 error: No warnings can be incurred under -Xfatal-warnings.

--- a/test/files/neg/t8430.check
+++ b/test/files/neg/t8430.check
@@ -1,25 +1,25 @@
 t8430.scala:15: warning: match may not be exhaustive.
-It would fail on the following inputs: ??, LetC, LetF, LetL(IntLit), LetP
+It would fail on the following inputs: LetC, LetF, LetL(BooleanLit), LetL(IntLit), LetL(UnitLit), LetP
   (tree: Tree) => tree match {case LetL(CharLit) => ??? }
                   ^
 t8430.scala:16: warning: match may not be exhaustive.
-It would fail on the following inputs: ??, LetC, LetF, LetL(IntLit), LetP
+It would fail on the following inputs: LetC, LetF, LetL(BooleanLit), LetL(IntLit), LetL(UnitLit), LetP
   (tree: Tree) => tree match {case LetL(CharLit) => ??? }
                   ^
 t8430.scala:17: warning: match may not be exhaustive.
-It would fail on the following inputs: ??, LetC, LetF, LetL(IntLit), LetP
+It would fail on the following inputs: LetC, LetF, LetL(BooleanLit), LetL(IntLit), LetL(UnitLit), LetP
   (tree: Tree) => tree match {case LetL(CharLit) => ??? }
                   ^
 t8430.scala:18: warning: match may not be exhaustive.
-It would fail on the following inputs: ??, LetC, LetF, LetL(IntLit), LetP
+It would fail on the following inputs: LetC, LetF, LetL(BooleanLit), LetL(IntLit), LetL(UnitLit), LetP
   (tree: Tree) => tree match {case LetL(CharLit) => ??? }
                   ^
 t8430.scala:19: warning: match may not be exhaustive.
-It would fail on the following inputs: ??, LetC, LetF, LetL(IntLit), LetP
+It would fail on the following inputs: LetC, LetF, LetL(BooleanLit), LetL(IntLit), LetL(UnitLit), LetP
   (tree: Tree) => tree match {case LetL(CharLit) => ??? }
                   ^
 t8430.scala:20: warning: match may not be exhaustive.
-It would fail on the following inputs: ??, LetC, LetF, LetL(IntLit), LetP
+It would fail on the following inputs: LetC, LetF, LetL(BooleanLit), LetL(IntLit), LetL(UnitLit), LetP
   (tree: Tree) => tree match {case LetL(CharLit) => ??? }
                   ^
 error: No warnings can be incurred under -Xfatal-warnings.

--- a/test/files/run/virtpatmat_nested_lists.check
+++ b/test/files/run/virtpatmat_nested_lists.check
@@ -1,3 +1,4 @@
+warning: DPLL reached max recursion depth, not all missing cases are reported.
 virtpatmat_nested_lists.scala:5: warning: match may not be exhaustive.
   List(List(1), List(2)) match { case x :: (y :: Nil) :: Nil => println(y) }
       ^

--- a/test/files/run/virtpatmat_opt_sharing.check
+++ b/test/files/run/virtpatmat_opt_sharing.check
@@ -1,3 +1,4 @@
+warning: DPLL reached max recursion depth, not all missing cases are reported.
 virtpatmat_opt_sharing.scala:7: warning: match may not be exhaustive.
     List(1, 3, 4, 7) match {
         ^


### PR DESCRIPTION
This pull request should resolve all remaining non-determinisms regarding exhaustiveness warnings in the pattern matcher. It was buried deep in the machinery and thus not easy to find. The non-determinism is also the reason behind SI-7746.

@adriaanm / @retronym

1) The implementation of the DPLL algorithm was flawed and did not return all solutions. Depending on the ordering of the symbols, more or less solutions were found.
You can find a test project that compares the results of the implementation with Sat4j here:
https://github.com/gbasler/dpll
2) The formulas that were passed to the solver resulted in counter examples that were invalid and removed in a following filtering step. That led to the weird situation where the fixed algorithm returned less counter examples than the buggy one. The recursion goes now deeper than before and also this led to less counter examples reported, since it was stopped too early before.
3) I also cleaned up the `LinkedHashSet` workarounds. They should not be needed anymore. I've repeated Jason's checks (see below) and could not find any problems.

I'm working on another PR that will get rid of the "analysis budget" error but this one is a prerequisite to make it work.

Check 1:

```
  ~/Documents/scala-fix-nondet-patmat:ticket/7746$ (f=test/files/neg/t8430.scala; (for i in {1..20}; do echo $f; done; printf "\n") | qbin/scalac -Xresident) 2>&1 | grep "fail" | sort | uniq | wc -l
      1
```

Check 2:

```
 for i in {1..100}; do cp test/files/neg/t7020.scala test/files/neg/t7020-$i.scala; cp test/files/neg/t7020.flags test/files/neg/t7020-$i.flags; cat test/files/neg/t7020.check | sed "s/t7020/t7020-$i/" > test/files/neg/t7020-$i.check; done

~/Documents/scala-fix-nondet-patmat:ticket/7746$ test/partest --terse --srcpath disabled test/files/neg/t7020*.scala

Selected 101 tests drawn from specified tests


# starting 101 tests in neg

........................................................................

.............................


101/101 passed (elapsed time: 00:00:32)

Test Run PASSED
```
