### PR TITLE
SI-8410 Don't warn fatally on disabled flag

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -32,14 +32,17 @@ trait Reporting extends scala.reflect.internal.Reporting { self: ast.Positions w
       def warn(pos: Position, msg: String) =
         if (option) reporter.warning(pos, msg)
         else if (!(warnings contains pos)) warnings += ((pos, msg))
-      def summarize() =
-        if (warnings.nonEmpty && (option.isDefault || settings.fatalWarnings)) {
+      def summarize() = {
+        def turnedOff = option.isSetByUser && !option
+        def moreInfos = option.isDefault || settings.fatalWarnings
+        if (warnings.nonEmpty && !turnedOff && moreInfos) {
           val numWarnings  = warnings.size
           val warningVerb  = if (numWarnings == 1) "was" else "were"
           val warningCount = countElementsAsString(numWarnings, s"$what warning")
 
           reporter.warning(NoPosition, s"there $warningVerb $warningCount; re-run with ${option.name} for details")
         }
+      }
     }
 
     // This change broke sbt; I gave it the thrilling name of uncheckedWarnings0 so

--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -32,17 +32,14 @@ trait Reporting extends scala.reflect.internal.Reporting { self: ast.Positions w
       def warn(pos: Position, msg: String) =
         if (option) reporter.warning(pos, msg)
         else if (!(warnings contains pos)) warnings += ((pos, msg))
-      def summarize() = {
-        def turnedOff = option.isSetByUser && !option
-        def moreInfos = option.isDefault || settings.fatalWarnings
-        if (warnings.nonEmpty && !turnedOff && moreInfos) {
+      def summarize() =
+        if (warnings.nonEmpty && (option.isDefault || option)) {
           val numWarnings  = warnings.size
           val warningVerb  = if (numWarnings == 1) "was" else "were"
           val warningCount = countElementsAsString(numWarnings, s"$what warning")
 
           reporter.warning(NoPosition, s"there $warningVerb $warningCount; re-run with ${option.name} for details")
         }
-      }
     }
 
     // This change broke sbt; I gave it the thrilling name of uncheckedWarnings0 so

--- a/test/files/pos/t8410.flags
+++ b/test/files/pos/t8410.flags
@@ -1,0 +1,1 @@
+-optimise -Xfatal-warnings -deprecation:false -Yinline-warnings:false

--- a/test/files/pos/t8410.scala
+++ b/test/files/pos/t8410.scala
@@ -1,0 +1,15 @@
+
+object Test extends App {
+  @deprecated("","") def f = 42
+  @deprecated("","") def z = f
+  def g = { @deprecated("","") def _f = f ; _f }                   // warns in 2.11.0-M8
+  def x = { @deprecated("","") class X { def x = f } ; new X().x } // warns in 2.11.0-M8
+  Console println g
+  Console println f  // warns
+
+  @deprecated("","") trait T
+  object T extends T { def t = f }
+  Console println T.t
+
+  def k = List(0).dropWhile(_ < 1)   // inlining warns doubly
+}


### PR DESCRIPTION
Since boolean settings can now be set false by user,
summary warnings should not be issued when the flag
is explicitly off (as opposed to unset, default).

In particular, `-Xfatal-warnings` should not fail
if there were no warnings otherwise.

```
$ ~/scala-2.11.2/bin/scalac -d /tmp -deprecation:false test/files/pos/t8410.scala
$ ~/scala-2.11.2/bin/scalac -d /tmp -deprecation:false -Xfatal-warnings test/files/pos/t8410.scala
warning: there were three deprecation warnings; re-run with -deprecation for details
error: No warnings can be incurred under -Xfatal-warnings.
one warning found
one error found

```

After this commit:

```
$ skalac -d /tmp -Xfatal-warnings test/files/pos/t8410.scala
warning: there were three deprecation warnings; re-run with -deprecation for details
error: No warnings can be incurred under -Xfatal-warnings.
one warning found
one error found
$ skalac -d /tmp -deprecation:false -Xfatal-warnings test/files/pos/t8410.scala
```

Similarly for other collecting flags:

```
$ skalac -d /tmp -optimise -Yinline-warnings -deprecation:false -Xfatal-warnings test/files/pos/t8410.scala
test/files/pos/t8410.scala:14: warning: Could not inline required method dropWhile because access level required by callee not matched by caller.
  def k = List(0).dropWhile(_ < 1)   // inlining warns doubly
                           ^
test/files/pos/t8410.scala:14: warning: At the end of the day, could not inline @inline-marked method dropWhile
  def k = List(0).dropWhile(_ < 1)   // inlining warns doubly
                           ^
error: No warnings can be incurred under -Xfatal-warnings.
two warnings found
one error found
$ skalac -d /tmp -optimise -Yinline-warnings:false -deprecation:false -Xfatal-warnings test/files/pos/t8410.scala

```

Footnote: handling of deprecated locals also changed in 2014:

```
$ ~/scala-2.11.0-M7/bin/scalac -d /tmp -deprecation -Xfatal-warnings test/files/pos/t8410.scala
test/files/pos/t8410.scala:8: warning: method f in object Test is deprecated:
  Console println f  // warns
                  ^
error: No warnings can be incurred under -Xfatal-warnings.
one warning found
one error found
$ ~/scala-2.11.0-M8/bin/scalac -d /tmp -deprecation -Xfatal-warnings test/files/pos/t8410.scala
test/files/pos/t8410.scala:5: warning: method _f is deprecated:
  def g = { @deprecated("","") def _f = f ; _f }                   // warns in 2.11.0-M8
                                            ^
test/files/pos/t8410.scala:6: warning: class X is deprecated:
  def x = { @deprecated("","") class X { def x = f } ; new X().x } // warns in 2.11.0-M8
                                                           ^
test/files/pos/t8410.scala:8: warning: method f in object Test is deprecated:
  Console println f  // warns
                  ^
error: No warnings can be incurred under -Xfatal-warnings.
three warnings found
one error found

```
