### PR TITLE
fix a few string interpolation typos

### DIFF
--- a/src/reflect/scala/reflect/internal/AnnotationInfos.scala
+++ b/src/reflect/scala/reflect/internal/AnnotationInfos.scala
@@ -388,11 +388,11 @@ trait AnnotationInfos extends api.Annotations { self: SymbolTable =>
         case Literal(const) => LiteralAnnotArg(const)
         case Apply(ArrayModule, args) => ArrayAnnotArg(args map encodeJavaArg toArray)
         case Apply(Select(New(tpt), nme.CONSTRUCTOR), args) => NestedAnnotArg(treeToAnnotation(arg))
-        case _ => throw new Exception("unexpected java argument shape $arg: literals, arrays and nested annotations are supported")
+        case _ => throw new Exception(s"unexpected java argument shape $arg: literals, arrays and nested annotations are supported")
       }
       def encodeJavaArgs(args: List[Tree]): List[(Name, ClassfileAnnotArg)] = args match {
         case AssignOrNamedArg(Ident(name), arg) :: rest => (name, encodeJavaArg(arg)) :: encodeJavaArgs(rest)
-        case arg :: rest => throw new Exception("unexpected java argument shape $arg: only AssignOrNamedArg trees are supported")
+        case arg :: rest => throw new Exception(s"unexpected java argument shape $arg: only AssignOrNamedArg trees are supported")
         case Nil => Nil
       }
       val atp = tpt.tpe

--- a/src/reflect/scala/reflect/internal/ReificationSupport.scala
+++ b/src/reflect/scala/reflect/internal/ReificationSupport.scala
@@ -866,7 +866,7 @@ trait ReificationSupport { self: SymbolTable =>
 
     protected def mkCases(cases: List[Tree]): List[CaseDef] = cases.map {
       case c: CaseDef => c
-      case tree => throw new IllegalArgumentException("$tree is not valid representation of pattern match case")
+      case tree => throw new IllegalArgumentException(s"$tree is not valid representation of pattern match case")
     }
 
     object SyntacticPartialFunction extends SyntacticPartialFunctionExtractor {

--- a/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
+++ b/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
@@ -116,7 +116,7 @@ trait MemberHandlers {
           else any2stringOf(path, maxStringElements)
 
         val vidString =
-          if (replProps.vids) s"""" + " @ " + "%%8x".format(System.identityHashCode($path)) + " """.trim
+          if (replProps.vids) s"""" + f"@$${System.identityHashCode($path)}%8x" + """"
           else ""
 
         """ + "%s%s: %s = " + %s""".format(string2code(prettyName), vidString, string2code(req typeOf name), resultString)


### PR DESCRIPTION
The ones in scala-reflect were caught by Xlint (who knew building with
Xlint was actually useful...), the other was just luck.

That nice little `-Dscala.repl.vids` feature regressed in f56f9a3c, but
there was no test to catch that. So there is one now.
