### PR TITLE
SI-8786 disable part of thest that's failing the jdk8 build

### DIFF
--- a/test/files/jvm/varargs/VaClass.scala
+++ b/test/files/jvm/varargs/VaClass.scala
@@ -9,5 +9,7 @@ class VaClass {
   @varargs def vs(a: Int, b: String*) = println(a + b.length)
   @varargs def vi(a: Int, b: Int*) = println(a + b.sum)
   @varargs def vt[T](a: Int, b: T*) = println(a + b.length)
-  @varargs def vt1[T](a: Int, b: T*): T = b.head
+
+  // TODO remove type bound after fixing SI-8786, see also https://github.com/scala/scala/pull/3961
+  @varargs def vt1[T <: String](a: Int, b: T*): T = b.head
 }


### PR DESCRIPTION
As noted in SI-8786, this test currently fails the [jdk 8 build](https://scala-webapps.epfl.ch/jenkins/view/2.11.x/job/scala-nightly-auxjvm-2.11.x/jdk=jdk8,label=auxjvm/122/console).
