### PR TITLE
SI-8788 Add generic signature to Parcelable static field special case.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
@@ -1046,7 +1046,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters with GenJVMASM {
         PublicStaticFinal,
         androidFieldName.toString,
         tdesc_creator,
-        null, // no java-generic-signature
+        "%s<L%s;>;".format(tdesc_creator.dropRight(1), thisName),
         null  // no initial value
       ).visitEnd()
 

--- a/test/files/run/t8788.check
+++ b/test/files/run/t8788.check
@@ -1,0 +1,2 @@
+public static final android.os.Parcelable$Creator C.CREATOR
+public static final android.os.Parcelable.android.os.Parcelable$Creator<C> C.CREATOR

--- a/test/files/run/t8788.scala
+++ b/test/files/run/t8788.scala
@@ -1,0 +1,15 @@
+package android {
+  package os {
+    trait Parcelable {
+      trait Creator[T]
+    }
+  }
+}
+
+class C extends android.os.Parcelable
+
+object Test extends App {
+  val field = classOf[C].getField("CREATOR")
+  println(field)
+  println(field.toGenericString)
+}


### PR DESCRIPTION
Android's AIDL generates Java code that assumes the presence of generic
annotations for Parcelable classes, which previously were not being
generated. This patch adds a generic signature to the generated CREATOR
field, resolving the issue.

Same as https://github.com/scala/scala/pull/3922 except into 2.11.x instead of 2.12.x.
