### PR TITLE
Prefer scala.Serializable to j.io.Serializable

### DIFF
--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -13,7 +13,7 @@ package immutable
 import generic._
 import mutable.{Builder, ListBuffer}
 import scala.annotation.tailrec
-import java.io._
+import java.io.{ObjectOutputStream, ObjectInputStream}
 
 /** A class for immutable linked lists representing ordered collections
  *  of elements of type.
@@ -85,7 +85,7 @@ sealed abstract class List[+A] extends AbstractSeq[A]
                                   with Product
                                   with GenericTraversableTemplate[A, List]
                                   with LinearSeqOptimized[A, List[A]]
-                                  with Serializable {
+                                  with scala.Serializable {
   override def companion: GenericCompanion[List] = List
 
   import scala.collection.{Iterable, Traversable, Seq, IndexedSeq}

--- a/src/library/scala/collection/immutable/PagedSeq.scala
+++ b/src/library/scala/collection/immutable/PagedSeq.scala
@@ -12,7 +12,7 @@ package scala
 package collection
 package immutable
 
-import java.io._
+import java.io.{File, FileReader, Reader}
 import scala.util.matching.Regex
 import scala.reflect.ClassTag
 

--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -12,7 +12,7 @@ package mutable
 
 import generic._
 import immutable.{List, Nil, ::}
-import java.io._
+import java.io.{ObjectOutputStream, ObjectInputStream}
 import scala.annotation.migration
 
 /** A `Buffer` implementation back up by a list. It provides constant time

--- a/test/files/run/lub-visibility.check
+++ b/test/files/run/lub-visibility.check
@@ -6,6 +6,6 @@ scala> // should infer List[scala.collection.immutable.Seq[Nothing]]
 scala> // but reverted that for SI-5534.
 
 scala> val x = List(List(), Vector())
-x: List[scala.collection.immutable.Seq[Nothing] with scala.collection.AbstractSeq[Nothing] with java.io.Serializable] = List(List(), Vector())
+x: List[scala.collection.immutable.Seq[Nothing] with scala.collection.AbstractSeq[Nothing] with Serializable] = List(List(), Vector())
 
 scala> :quit

--- a/test/files/run/t2251b.check
+++ b/test/files/run/t2251b.check
@@ -1,4 +1,4 @@
-TypeTag[List[scala.collection.immutable.LinearSeq[B[_ >: D with C <: B[_ >: D with C <: A]]] with scala.collection.AbstractSeq[B[_ >: D with C <: B[_ >: D with C <: A]]] with java.io.Serializable]]
+TypeTag[List[scala.collection.immutable.LinearSeq[B[_ >: D with C <: B[_ >: D with C <: A]]] with scala.collection.AbstractSeq[B[_ >: D with C <: B[_ >: D with C <: A]]] with Serializable]]
 TypeTag[List[scala.collection.immutable.Iterable[B[_ >: F with E with D with C <: B[_ >: F with E with D with C <: A]]] with F with Int => Any]]
 TypeTag[List[scala.collection.immutable.Seq[B[_ >: D with C <: B[_ >: D with C <: A]]] with scala.collection.AbstractSeq[B[_ >: D with C <: B[_ >: D with C <: A]]] with Serializable]]
 TypeTag[List[scala.collection.Set[_ >: G with F <: B[_ >: G with F <: B[_ >: G with F <: A]]]]]
@@ -6,6 +6,6 @@ TypeTag[List[scala.collection.Set[_ >: G with F <: B[_ >: G with F <: B[_ >: G w
 TypeTag[List[scala.collection.Set[_ >: G with F <: B[_ >: G with F <: B[_ >: G with F <: A]]]]]
 TypeTag[List[Seq[B[_ >: G with F <: B[_ >: G with F <: A]]]]]
 TypeTag[List[scala.collection.Map[_ >: F with C <: B[_ >: F with C <: B[_ >: F with C <: A]], B[_ >: G with D <: B[_ >: G with D <: A]]]]]
-TypeTag[List[scala.collection.AbstractSeq[B[_ >: G with F <: B[_ >: G with F <: A]]] with scala.collection.LinearSeq[B[_ >: G with F <: B[_ >: G with F <: A]]] with java.io.Serializable]]
+TypeTag[List[scala.collection.AbstractSeq[B[_ >: G with F <: B[_ >: G with F <: A]]] with scala.collection.LinearSeq[B[_ >: G with F <: B[_ >: G with F <: A]]] with Serializable]]
 TypeTag[List[Seq[B[_ >: G with F <: B[_ >: G with F <: A]]]]]
 TypeTag[List[Seq[B[_ >: G with F <: B[_ >: G with F <: A]]]]]


### PR DESCRIPTION
The former extends the latter, and exists as a platorm agnostic
serialization marker trait. It is of less value now that we
have jettisoned the MSIL backend, but while it still exists
we ought ought to use it.

I achieved this by replacing wildcard import of `java.io._`
with selective imports, leaving `Serializable` to bind to
`scala.Serializable`.
