### PR TITLE
Fix broken URL for MathJAX Javascript dependency.

### DIFF
--- a/spec/_layouts/default.yml
+++ b/spec/_layouts/default.yml
@@ -11,7 +11,7 @@
     }
   });
   </script>
-  <script type="text/javascript" src="https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+  <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/2.3-latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
 
   <!-- need to use include to see value of page.chapter variable -->


### PR DESCRIPTION
Loaded using an DNS alias for the CDN, as per the
[instructions](http://docs.mathjax.org/en/latest/configuration.html)

I also switched from `latest` to `2.3-latest`, so that we don't
automatically perform major upgrades.

Review by @lrytz
