### PR TITLE
isAnonymousClass/Function for delambdafy classes is not true

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1512,7 +1512,12 @@ TODO:
 <!-- ===========================================================================
                                   BINARY COMPATIBILITY TESTING
 ============================================================================ -->
-  <target name="bc.init" depends="init" unless="maven-deps-done-mima">
+  <target name="bc.init" depends="init" if="test.bc.skip">
+    <!-- if test.bc.skip is set, make sure that pc.prepare is not executed either -->
+    <property name="maven-deps-done-mima" value="true"/>
+  </target>
+
+  <target name="bc.prepare" depends="bc.init" unless="maven-deps-done-mima">
     <property name="bc-reference-version" value="2.11.0"/>
 
     <property name="bc-build.dir" value="${build.dir}/bc"/>
@@ -1530,7 +1535,7 @@ TODO:
   </target>
 
   <target name="test.bc-opt" description="Optimized version of test.bc."> <optimized name="test.bc"/></target>
-  <target name="test.bc" depends="bc.init, pack.lib, pack.reflect">
+  <target name="test.bc" depends="bc.prepare, pack.lib, pack.reflect" unless="test.bc.skip">
     <bc.check project="library"/>
     <bc.check project="reflect"/>
   </target>

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeAsmCommon.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeAsmCommon.scala
@@ -22,14 +22,11 @@ final class BCodeAsmCommon[G <: Global](val global: G) {
    * null.
    */
   def isAnonymousOrLocalClass(classSym: Symbol): Boolean = {
-    def isDelambdafyLambdaClass(classSym: Symbol): Boolean = {
-      classSym.isAnonymousFunction && (settings.Ydelambdafy.value == "method")
-    }
-
     assert(classSym.isClass, s"not a class: $classSym")
-
-    !isDelambdafyLambdaClass(classSym) &&
-      (classSym.isAnonymousClass || !classSym.originalOwner.isClass)
+    val res = (classSym.isAnonymousClass || !classSym.originalOwner.isClass)
+    // lambda classes are always top-level classes.
+    if (res) assert(!classSym.isDelambdafyFunction)
+    res
   }
 
   /**
@@ -81,7 +78,7 @@ final class BCodeAsmCommon[G <: Global](val global: G) {
   final case class EnclosingMethodEntry(owner: String, name: String, methodDescriptor: String)
 
   /**
-   * If data for emitting an EnclosingMethod attribute. None if `classSym` is a member class (not
+   * Data for emitting an EnclosingMethod attribute. None if `classSym` is a member class (not
    * an anonymous or local class). See doc in BTypes.
    *
    * The class is parametrized by two functions to obtain a bytecode class descriptor for a class

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -99,17 +99,18 @@ trait StdNames {
 
     val SINGLETON_SUFFIX: String     = ".type"
 
-    val ANON_CLASS_NAME: NameType    = "$anon"
-    val ANON_FUN_NAME: NameType      = "$anonfun"
-    val EMPTY: NameType              = ""
-    val EMPTY_PACKAGE_NAME: NameType = "<empty>"
-    val IMPL_CLASS_SUFFIX            = "$class"
-    val IMPORT: NameType             = "<import>"
-    val MODULE_SUFFIX_NAME: NameType = MODULE_SUFFIX_STRING
-    val MODULE_VAR_SUFFIX: NameType  = "$module"
-    val PACKAGE: NameType            = "package"
-    val ROOT: NameType               = "<root>"
-    val SPECIALIZED_SUFFIX: NameType = "$sp"
+    val ANON_CLASS_NAME: NameType              = "$anon"
+    val DELAMBDAFY_LAMBDA_CLASS_NAME: NameType = "$lambda"
+    val ANON_FUN_NAME: NameType                = "$anonfun"
+    val EMPTY: NameType                        = ""
+    val EMPTY_PACKAGE_NAME: NameType           = "<empty>"
+    val IMPL_CLASS_SUFFIX                      = "$class"
+    val IMPORT: NameType                       = "<import>"
+    val MODULE_SUFFIX_NAME: NameType           = MODULE_SUFFIX_STRING
+    val MODULE_VAR_SUFFIX: NameType            = "$module"
+    val PACKAGE: NameType                      = "package"
+    val ROOT: NameType                         = "<root>"
+    val SPECIALIZED_SUFFIX: NameType           = "$sp"
 
     // value types (and AnyRef) are all used as terms as well
     // as (at least) arguments to the @specialize annotation.

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -789,6 +789,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       isMethod && owner.isDerivedValueClass && !isParamAccessor && !isConstructor && !hasFlag(SUPERACCESSOR) && !isMacro && !isSpecialized
 
     final def isAnonymousFunction = isSynthetic && (name containsName tpnme.ANON_FUN_NAME)
+    final def isDelambdafyFunction = isSynthetic && (name containsName tpnme.DELAMBDAFY_LAMBDA_CLASS_NAME)
     final def isDefinedInPackage  = effectiveOwner.isPackageClass
     final def needsFlatClasses    = phase.flatClasses && rawowner != NoSymbol && !rawowner.isPackageClass
 

--- a/test/files/run/delambdafyLambdaClassNames.check
+++ b/test/files/run/delambdafyLambdaClassNames.check
@@ -1,0 +1,1 @@
+A$$nestedInAnon$1$lambda$$run$1

--- a/test/files/run/delambdafyLambdaClassNames.flags
+++ b/test/files/run/delambdafyLambdaClassNames.flags
@@ -1,0 +1,1 @@
+-Ybackend:GenBCode -Ydelambdafy:method

--- a/test/files/run/delambdafyLambdaClassNames/A_1.scala
+++ b/test/files/run/delambdafyLambdaClassNames/A_1.scala
@@ -1,0 +1,5 @@
+class A {
+  def f = new Runnable {
+    def run(): Unit = List(1,2).foreach(println)
+  }
+}

--- a/test/files/run/delambdafyLambdaClassNames/Test.scala
+++ b/test/files/run/delambdafyLambdaClassNames/Test.scala
@@ -1,0 +1,4 @@
+object Test extends App {
+  val c = Class.forName("A$$nestedInAnon$1$lambda$$run$1")
+  println(c.getName)
+}


### PR DESCRIPTION
Ydelambdafy:method lambda classes are not anonymous classes, and not
anonymous function classes either. They are somethig new, so there's
a new predicate isDelambdafyFunction.

They are not anonymous classes (or functions) because anonymous
classes in Java speak are nested. Delambdafy classes are always
top-level, they are just synthetic.

Before this patch, isAnonymous was sometimes accidentailly true: if
the lambda is nested in an anonymous class. Now it's always false.

This should fix the [BCode-Delambdafy community build](https://jenkins-dbuild.typesafe.com:8499/job/Community-2.11.x-BCode-Delambdafy/125/console). An assertion in BCode failed because it was trying to emit an EnclosingMethod attribute for a delambdafy class - this should only happen for inner classes.
