### PR TITLE
SI-8575 Prevent AbstractMethodError caused by type alias

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4804,7 +4804,10 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         else {
           val decls = newScope
           //Console.println("Owner: " + context.enclClass.owner + " " + context.enclClass.owner.id)
-          val self = refinedType(parents1 map (_.tpe), context.enclClass.owner, decls, templ.pos)
+          val self = refinedType(parents1 map (_.tpe match {
+            case t if t =:= AnyRefTpe => t
+            case t => t.dealias
+          }), context.enclClass.owner, decls, templ.pos)
           newTyper(context.make(templ, self.typeSymbol, decls)).typedRefinement(templ)
           templ updateAttachment CompoundTypeTreeOriginalAttachment(parents1, Nil) // stats are set elsewhere
           tree setType (if (templ.exists(_.isErroneous)) ErrorType else self) // Being conservative to avoid SI-5361

--- a/test/files/run/t8575.scala
+++ b/test/files/run/t8575.scala
@@ -1,0 +1,29 @@
+class E[F]
+class A
+class B
+class C
+
+trait TypeMember {
+  type X
+
+  // This call throws an AbstractMethodError, because it invokes the erasure of
+  // consume(X): Unit that is consume(Object): Unit. But the corresponding
+  // bridge method is not generated.
+  consume(value)
+
+  def value: X
+  def consume(x: X): Unit
+}
+
+object Test extends App with TypeMember {
+  type F = A with B
+
+  // works if replaced by type X = E[A with B with C]
+  type X = E[F with C]
+
+  val value = new E[F with C]
+
+  // This call passes, since it invokes consume(E): Unit
+  consume(value)
+  def consume(x: X) {}
+}


### PR DESCRIPTION
For some reason, erasure will not create the bridge method for consume in the situation below.

``` scala
  type F = A with B
  type X = E[F with C]
  def consume(x: X): Unit
```

When the method consume is defined in a subclass but called in the super class (using the generated bridge) an AbstractMethodError is triggered.

This appears to be only the case if `X` is aliased to an applied type constructor with the argument being a compound type as above.

Since manually deliasing `F` to `A with B` does work, the solution appears to be to dealias components of compound types. However, dealiasing must not be performed on `AnyRef`, which would result in Object and thus break tests.

This might change the binary interface of the generated code to a theoretically equivalent one. But who knows whether this is equivalent enough.

Review by @adriaanm and @dragos 
