### PR TITLE
SI-8844 Fix regression with existentials + type aliases

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2605,7 +2605,7 @@ trait Types
       // derived from the existentially quantified type into the typing environment
       // (aka \Gamma, which tracks types for variables and constraints/kinds for types)
       // as a nice bonus, delaying this until we need it avoids cyclic errors
-      def tpars = underlying.typeSymbol.initialize.typeParams
+      def tpars = underlying.typeSymbolDirect.initialize.typeParams
 
       def newSkolem(quant: Symbol) = owner.newExistentialSkolem(quant, origin)
       def newSharpenedSkolem(quant: Symbol, tparam: Symbol): Symbol = {

--- a/test/files/pos/t8844.scala
+++ b/test/files/pos/t8844.scala
@@ -1,0 +1,4 @@
+object Example {
+  type S[A] = String
+  def foo(s: S[_]): String = s
+}


### PR DESCRIPTION
Regressed in 2a1b15e / SI-8283. Another specimen of an archetypal
bug: unwanted dealising by using `typeSymbol`, rather than
`typeSymbolDirect`.

Review by @lrytz
