### PR TITLE
SI-8575 Fix subtyping transitivity with aliases, compound types

### DIFF
--- a/test/files/run/t8575.scala
+++ b/test/files/run/t8575.scala
@@ -1,0 +1,33 @@
+class E[F]
+class A
+class B
+class C
+
+trait TypeMember {
+  type X
+
+  // This call throws an AbstractMethodError, because it invokes the erasure of
+  // consume(X): Unit that is consume(Object): Unit. But the corresponding
+  // bridge method is not generated.
+  consume(value)
+
+  def value: X
+  def consume(x: X): Unit
+}
+
+object Test extends TypeMember {
+  type F = A with B
+
+  // works if replaced by type X = E[A with B with C]
+  type X = E[F with C]
+
+  val value = new E[F with C]
+
+  // This call passes, since it invokes consume(E): Unit
+  consume(value)
+  def consume(x: X) {}
+
+  def main(args: Array[String]) {
+    
+  }
+}

--- a/test/files/run/t8575b.scala
+++ b/test/files/run/t8575b.scala
@@ -1,0 +1,17 @@
+class A
+class B
+class C
+
+object Test {
+  type F = A with B
+
+  def main(args: Array[String]) {
+    import reflect.runtime.universe._
+    val t1 = typeOf[F with C]
+    val t2 = typeOf[(A with B) with C]
+    val t3 = typeOf[A with B with C]
+    assert(t1 =:= t2)
+    assert(t2 =:= t3)
+    assert(t3 =:= t1)
+  }
+}

--- a/test/files/run/t8575c.scala
+++ b/test/files/run/t8575c.scala
@@ -1,0 +1,23 @@
+class C
+
+trait TypeMember {
+  type X
+  type Y
+  type Z
+}
+
+object Test extends TypeMember {
+  type A = X with Y
+  type B = Z with A
+  type F = A with B
+
+  def main(args: Array[String]) {
+    import reflect.runtime.universe._
+    val t1 = typeOf[F with C]
+    val t2 = typeOf[(A with B) with C]
+    val t3 = typeOf[A with B with C]
+    assert(t1 =:= t2)
+    assert(t2 =:= t3)
+    assert(t3 =:= t1)
+  }
+}


### PR DESCRIPTION
Thanks to @b-studios and @Blaisorblade for investigation into this
bug.

`RefinedType#normalize` is responsible for flattening nested
compound types to a flat representation.

Types are normalized during `=:=` in search of a successful
result.

This means that `((A with B) with C) =:= (A with B with C)`.

However, if we introduce a type alias for `A with B` on the LHS,
the attempt at flattening is thwarted.

This commit dealiases parents of refined types during normalization.

Two tests are included. The first demonstrates a symptom of this
problem: failure to install a bridge method resulted in a linkage
error.

The second test uses the reflection API to directly show transitivity
of subtyping now holds.

Targetting at 2.12, as bug fixes in subtyping usually can be shown
to lead to binary incompatibilities between code using the old and
new compilers.
