### PR TITLE
SI-8845 Control flow pot-pourri crashes GenASM, but not -BCode

### DIFF
--- a/test/files/run/t8845.flags
+++ b/test/files/run/t8845.flags
@@ -1,0 +1,1 @@
+-Ybackend:GenBCode -Ynooptimize

--- a/test/files/run/t8845.scala
+++ b/test/files/run/t8845.scala
@@ -1,0 +1,17 @@
+// crashes compiler under GenASM, works under GenBCode.
+object Interpreter {
+  def mkDataProp(i: Int) = i
+  def break(n: Int): Unit =
+    try {
+      n match {
+        case _ =>
+          val newDesc = mkDataProp(n)
+          n match { case _ => return }
+      }
+    } catch { case e: Throwable => }
+    finally { }
+}
+
+object Test extends App {
+  Interpreter.break(0)
+}


### PR DESCRIPTION
Given that we'll switch to GenBCode in 2.12, the test case
showing the bug is fixed under that option is all I plan to
offer for this bug.
