### PR TITLE
 SI-6502 Repl reset/replay take settings args

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/AbsSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/AbsSettings.scala
@@ -35,7 +35,11 @@ trait AbsSettings extends scala.reflect.internal.settings.AbsSettings {
     case s: AbsSettings => this.userSetSettings == s.userSetSettings
     case _              => false
   }
-  override def toString() = "Settings {\n%s}\n" format (userSetSettings map ("  " + _ + "\n")).mkString
+  override def toString() = {
+    val uss    = userSetSettings
+    val indent = if (uss.nonEmpty) " " * 2 else ""
+    uss.mkString(f"Settings {%n$indent", f"%n$indent", f"%n}%n")
+  }
   def toConciseString = userSetSettings.mkString("(", " ", ")")
 
   def checkDependencies =

--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -75,6 +75,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
   def history = in.history
 
   // classpath entries added via :cp
+  @deprecated("Use reset, replay or require to update class path", since = "2.11")
   var addedClasspath: String = ""
 
   /** A reverse list of commands to replay if the user requests a :replay */
@@ -207,7 +208,6 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
 
   /** Standard commands **/
   lazy val standardCommands = List(
-    cmd("cp", "<path>", "add a jar or directory to the classpath", addClasspath),
     cmd("edit", "<id>|<line>", "edit history", editCommand),
     cmd("help", "[command]", "print this summary or command-specific help", helpCommand),
     historyCommand,
@@ -221,6 +221,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     nullary("power", "enable power user mode", powerCmd),
     nullary("quit", "exit the interpreter", () => Result(keepRunning = false, None)),
     nullary("replay", "reset execution and replay all previous commands", replay),
+    //cmd("require", "<path>", "add a jar or directory to the classpath", require),  // TODO
     nullary("reset", "reset the repl to its initial state, forgetting all session entries", resetCommand),
     cmd("save", "<path>", "save replayable session to a file", saveCommand),
     shCommand,
@@ -482,6 +483,8 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
       echo("")
     }
   }
+  /** `reset` the interpreter in an attempt to start fresh.
+   */
   def resetCommand() {
     echo("Resetting interpreter state.")
     if (replayCommandStack.nonEmpty) {
@@ -619,6 +622,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     else File(filename).printlnAll(replayCommands: _*)
   )
 
+  @deprecated("Use reset, replay or require to update class path", since = "2.11")
   def addClasspath(arg: String): Unit = {
     val f = File(arg).normalize
     if (f.exists) {

--- a/src/repl/scala/tools/nsc/interpreter/ReplStrings.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplStrings.scala
@@ -28,5 +28,8 @@ trait ReplStrings {
   def any2stringOf(x: Any, maxlen: Int) =
     "scala.runtime.ScalaRunTime.replStringOf(%s, %s)".format(x, maxlen)
 
-  def words(s: String) = (s.trim split "\\s+" filterNot (_ == "")).toList
+  // no escaped or nested quotes
+  private[this] val inquotes = """(['"])(.*?)\1""".r
+  def unquoted(s: String) = s match { case inquotes(_, w) => w ; case _ => s }
+  def words(s: String) = (s.trim split "\\s+" filterNot (_ == "") map unquoted).toList
 }

--- a/test/files/run/t4594-repl-settings.scala
+++ b/test/files/run/t4594-repl-settings.scala
@@ -14,7 +14,7 @@ object Test extends SessionTest {
     |warning: there was one deprecation warning; re-run with -deprecation for details
     |a: String
     |
-    |scala> :settings +deprecation
+    |scala> :settings -deprecation
     |
     |scala> def b = depp
     |<console>:8: warning: method depp is deprecated: Please don't do that.


### PR DESCRIPTION
The reset and replay commands take arbitrary command line args.
When settings args are supplied, the compiler is recreated.

For uniformity, the settings command performs only the usual
arg parsing: use `-flag:true` or `-flag` instead of `+flag`, and clearing a
setting is promoted to the command line, so that -Xlint: is not
an error but clears the flags.

```
scala> maqicode.Test main null
<console>:8: error: not found: value maqicode
              maqicode.Test main null
              ^

scala> :reset -classpath/a target/scala-2.11/sample_2.11-1.0.jar
Resetting interpreter state.
Forgetting all expression results and named terms: $intp

scala> maqicode.Test main null
Hello, world.

scala> val i = 42
i: Int = 42

scala> s"$i is the loneliest numbah."
res1: String = 42 is the loneliest numbah.

scala> :replay -classpath ""
Replaying: maqicode.Test main null
Hello, world.

Replaying: val i = 42
i: Int = 42

Replaying: s"$i is the loneliest numbah."
res1: String = 42 is the loneliest numbah.

scala> :replay -classpath/a ""
Replaying: maqicode.Test main null
<console>:8: error: not found: value maqicode
              maqicode.Test main null
              ^

Replaying: val i = 42
i: Int = 42

Replaying: s"$i is the loneliest numbah."
res1: String = 42 is the loneliest numbah.
```

Clearing a clearable setting:

```
scala> :reset -Xlint:missing-interpolator
Resetting interpreter state.

scala> { val i = 42 ; "$i is the loneliest numbah." }
<console>:8: warning: possible missing interpolator: detected interpolated identifier `$i`
              { val i = 42 ; "$i is the loneliest numbah." }
                             ^
res0: String = $i is the loneliest numbah.

scala> :reset -Xlint:
Resetting interpreter state.
Forgetting this session history:

{ val i = 42 ; "$i is the loneliest numbah." }

scala> { val i = 42 ; "$i is the loneliest numbah." }
res0: String = $i is the loneliest numbah.

scala> :replay -Xlint:missing-interpolator
Replaying: { val i = 42 ; "$i is the loneliest numbah." }
<console>:8: warning: possible missing interpolator: detected interpolated identifier `$i`
              { val i = 42 ; "$i is the loneliest numbah." }
                             ^
res0: String = $i is the loneliest numbah.
```

Review by @gkossakowski 
