### PR TITLE
SI-8459 fix incorrect positions for incomplete selection trees

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1059,7 +1059,7 @@ self =>
     def identOrMacro(): Name = if (isMacro) rawIdent() else ident()
 
     def selector(t: Tree): Tree = {
-      val point = in.offset
+      val point = if(isIdent) in.offset else in.lastOffset //SI-8459
       //assert(t.pos.isDefined, t)
       if (t != EmptyTree)
         Select(t, ident(skipIt = false)) setPos r2p(t.pos.start, point, in.lastOffset)

--- a/test/files/presentation/t8459.check
+++ b/test/files/presentation/t8459.check
@@ -1,0 +1,14 @@
+reload: IncompleteDynamicSelect.scala
+
+askType at IncompleteDynamicSelect.scala(12,2)
+================================================================================
+[response] askTypeAt (12,2)
+scala.AnyRef {
+  def <init>(): Foo = {
+    Foo.super.<init>();
+    ()
+  };
+  private[this] val bar: F = new F();
+  Foo.this.bar.<selectDynamic: error>("<error>")
+}
+================================================================================

--- a/test/files/presentation/t8459/Test.scala
+++ b/test/files/presentation/t8459/Test.scala
@@ -1,0 +1,3 @@
+import scala.tools.nsc.interactive.tests.InteractiveTest
+
+object Test extends InteractiveTest

--- a/test/files/presentation/t8459/src/IncompleteDynamicSelect.scala
+++ b/test/files/presentation/t8459/src/IncompleteDynamicSelect.scala
@@ -1,0 +1,14 @@
+import scala.language.dynamics
+
+class F extends Dynamic {
+  def applyDynamic(name: String)(args: Any*) =
+    s"method '$name' called with arguments ${args.mkString("'", "', '", "'")}"
+}
+
+class Foo {
+  val bar = new F
+
+  bar. //note whitespace after dot
+  /*?*/ //force typechecking
+}
+


### PR DESCRIPTION
The mentioned issue is a presentation compiler issue, but its root cause is a bug in the parser which incorrectly assigned positions to incomplete selection trees (i.e. selections that lack an indentifier after dot and have some whitespace instead).

In detail: for such incomplete selection trees, the "point" of the position should be immediately after the dot but instead was at the start of next token after the dot. For range positions, this caused a pathological situation where the "point" was greater than the "end" of the position. This position is later used by the typechecker during resolution of dynamic calls and causes it to crash. Of course, because a syntactically incorrect code is required for the bug to manifest, it only happens in the presentation compiler.
