### PR TITLE
SI-8852 Support joint compilation of Java interfaces w. statics

### DIFF
--- a/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
@@ -488,7 +488,8 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
           val vparams = formalParams()
           if (!isVoid) rtpt = optArrayBrackets(rtpt)
           optThrows()
-          val bodyOk = !inInterface || (mods hasFlag Flags.DEFAULTMETHOD)
+          val isStatic = mods hasFlag Flags.STATIC
+          val bodyOk = !inInterface || ((mods hasFlag Flags.DEFAULTMETHOD) || isStatic)
           val body =
             if (bodyOk && in.token == LBRACE) {
               methodBody()
@@ -507,7 +508,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
                 EmptyTree
               }
             }
-          if (inInterface) mods1 |= Flags.DEFERRED
+          if (inInterface && !isStatic) mods1 |= Flags.DEFERRED
           List {
             atPos(pos) {
               DefDef(mods1, name.toTermName, tparams, List(vparams), rtpt, body)

--- a/test/files/run/t8852a.scala
+++ b/test/files/run/t8852a.scala
@@ -1,0 +1,34 @@
+import scala.tools.partest._
+
+// Test that static methods in Java interfaces (new in Java 8)
+// are callable from jointly compiler Scala code.
+object Test extends CompilerTest {
+  import global._
+
+  override lazy val units: List[CompilationUnit] = {
+    // This test itself does not depend on JDK8.
+    javaCompilationUnits(global)(staticMethodInInterface) ++
+    compilationUnits(global)(scalaClient)
+  }
+
+  private def staticMethodInInterface = """
+public interface Interface {
+  public static int staticMethod() {
+    return 42;
+  }
+}
+
+  """
+
+  private def scalaClient = """
+object Test {
+  val x: Int = Interface.staticMethod()
+}
+
+class C extends Interface // expect no errors about unimplemented members.
+
+  """
+
+  // We're only checking we can compile it.
+  def check(source: String, unit: global.CompilationUnit): Unit = ()
+}


### PR DESCRIPTION
We had to change the java parser to accomodate this language
change in Java 8.

The enclosed test does not require JDK8 to run, it only tests
JavaParsers.

Here is a transcript of my manual testing using Java 8.

```
% tail test/files/run/8852b/{Interface.java,client.scala}
==> test/files/run/8852b/Interface.java <==
public interface Interface {
  public static int staticMethod() {
    return 42;
  }
}

==> test/files/run/8852b/client.scala <==
object Test extends App {
  assert(Interface.staticMethod() == 42)
}

// Under separate compilation, statics in interfaces were already working
% rm /tmp/*.class 2> /dev/null; javac -d /tmp test/files/run/8852b/Interface.java && scalac-hash v2.11.2 -classpath /tmp -d /tmp test/files/run/8852b/client.scala && scala-hash v2.11.2 -classpath /tmp -nc Test

// Under joint compilation, statics in interfaces now work.
% rm /tmp/*.class 2> /dev/null; qscalac -d /tmp test/files/run/8852b/{client.scala,Interface.java} && javac -d /tmp test/files/run/8852b/Interface.java && qscala -classpath /tmp -nc Test
```

Review by @gkossakowski
