### PR TITLE
Particular formatting improvement in the spec

### DIFF
--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -1336,7 +1336,7 @@ The following five implicit conversions can be applied to an
 expression $e$ which has some value type $T$ and which is type-checked with
 some expected type $\mathit{pt}$.
 
-#### Overloading Resolution
+###### Static Overloading Resolution
 If an expression denotes several possible members of a class,
 [overloading resolution](#overloading-resolution)
 is applied to pick a unique member.


### PR DESCRIPTION
Fixes the titularity of the "Overloading resolution" header
under 6.26.1 "Value conversions" to match "Type instantiation."

Hopefully this makes the link to the actual 6.26.3 overloading
resolution section work without further renaming.

Possibly that is the oftenest-cited section of the entire document.

At least on Stack Overflow, if not in Proceedings of the ACM.

Review by @gourlaysama
