### PR TITLE
Scala parser cuts last bracket

### DIFF
--- a/src/reflect/scala/reflect/internal/Positions.scala
+++ b/src/reflect/scala/reflect/internal/Positions.scala
@@ -304,12 +304,18 @@ trait Positions extends api.Positions { self: SymbolTable =>
       tree
     }
     else {
-      if (!tree.isEmpty && tree.canHaveAttrs && tree.pos == NoPosition) {
-        tree.setPos(pos)
-        val children = tree.children
-        if (children.nonEmpty) {
-          if (children.tail.isEmpty) atPos(pos)(children.head)
-          else setChildrenPos(pos, children)
+      if (!tree.isEmpty && tree.canHaveAttrs) {
+        if (tree.pos == NoPosition) {
+          tree.setPos(pos)
+          val children = tree.children
+          if (children.nonEmpty) {
+            if (children.tail.isEmpty) atPos(pos)(children.head)
+            else setChildrenPos(pos, children)
+          }
+        } else if (settings.Yrangepos) {
+          val currPos = tree.pos
+          val position = new RangePosition(currPos.source, currPos.start, currPos.point, pos.end)
+          tree.setPos(position)
         }
       }
       tree


### PR DESCRIPTION
In scenario [mirror.mkToolBox(options = "-Yrangepos")](http://stackoverflow.com/q/25547149/651140):

``` scala
libraryDependencies ++= Seq("org.scala-lang" % "scala-compiler" % "2.10.4") map {
    (dependency) =>{
        dependency
    }
}
```

Scala parser create tree with wrong RangePosition. In method: `scala.reflect.internal.Positions` `def atPos[T <: Tree](pos: Position)(tree: T): T` if the tree.pos is assigned - `pos` with correct `end` is ignored. So for the same tree method now check - if flag Yrangepos is set - and then replace `end` position of statement.
I compiled some projects with this version of scala - and code works,  but I think - acceptance tests are needed.

For scala 2.11 the trait Positions was rewritten. For scala 2.10 I do not have fix. It is needed for https://github.com/sbt/sbt/issues/1606
