### PR TITLE
Color REPL under -Dscala.color

### DIFF
--- a/src/compiler/scala/tools/nsc/reporters/ConsoleReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/ConsoleReporter.scala
@@ -29,7 +29,7 @@ class ConsoleReporter(val settings: Settings, reader: BufferedReader, writer: Pr
     case INFO    => null
   }
 
-  private def clabel(severity: Severity): String = {
+  protected def clabel(severity: Severity): String = {
     val label0 = label(severity)
     if (label0 eq null) "" else label0 + ": "
   }

--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -445,8 +445,14 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
   }
 
   private def readOneLine() = {
+    import scala.io.AnsiColor.{ MAGENTA, RESET }
     out.flush()
-    in readLine prompt
+    in readLine (
+      if (replProps.colorOk)
+        MAGENTA + prompt + RESET
+      else
+        prompt
+    )
   }
 
   /** The main read-eval-print loop for the repl.  It calls

--- a/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
+++ b/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
@@ -119,7 +119,15 @@ trait MemberHandlers {
           if (replProps.vids) s"""" + f"@$${System.identityHashCode($path)}%8x" + """"
           else ""
 
-        """ + "%s%s: %s = " + %s""".format(string2code(prettyName), vidString, string2code(req typeOf name), resultString)
+        import scala.io.AnsiColor.{ BOLD, BLUE, GREEN, RESET }
+
+        def color(c: String, s: String) =
+          if (replProps.colorOk) string2code(BOLD) + string2code(c) + s + string2code(RESET)
+          else s
+
+        val nameString = color(BLUE, string2code(prettyName)) + vidString
+        val typeString = color(GREEN, string2code(req typeOf name))
+        s""" + "$nameString: $typeString = " + $resultString"""
       }
     }
   }

--- a/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
+++ b/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
@@ -102,6 +102,18 @@ trait MemberHandlers {
 
   class GenericHandler(member: Tree) extends MemberHandler(member)
 
+  import scala.io.AnsiColor.{ BOLD, BLUE, GREEN, RESET }
+
+  def color(c: String, s: String) =
+    if (replProps.colorOk) string2code(BOLD) + string2code(c) + s + string2code(RESET)
+    else s
+
+  def colorName(s: String) =
+    color(BLUE, string2code(s))
+
+  def colorType(s: String) =
+    color(GREEN, string2code(s))
+
   class ValHandler(member: ValDef) extends MemberDefHandler(member) {
     val maxStringElements = 1000  // no need to mkString billions of elements
     override def definesValue = true
@@ -119,14 +131,8 @@ trait MemberHandlers {
           if (replProps.vids) s"""" + f"@$${System.identityHashCode($path)}%8x" + """"
           else ""
 
-        import scala.io.AnsiColor.{ BOLD, BLUE, GREEN, RESET }
-
-        def color(c: String, s: String) =
-          if (replProps.colorOk) string2code(BOLD) + string2code(c) + s + string2code(RESET)
-          else s
-
-        val nameString = color(BLUE, string2code(prettyName)) + vidString
-        val typeString = color(GREEN, string2code(req typeOf name))
+        val nameString = colorName(prettyName) + vidString
+        val typeString = colorType(req typeOf name)
         s""" + "$nameString: $typeString = " + $resultString"""
       }
     }
@@ -134,8 +140,11 @@ trait MemberHandlers {
 
   class DefHandler(member: DefDef) extends MemberDefHandler(member) {
     override def definesValue = flattensToEmpty(member.vparamss) // true if 0-arity
-    override def resultExtractionCode(req: Request) =
-      if (mods.isPublic) codegenln(name, ": ", req.typeOf(name)) else ""
+    override def resultExtractionCode(req: Request) = {
+      val nameString = colorName(name)
+      val typeString = colorType(req typeOf name)
+      if (mods.isPublic) s""" + "$nameString: $typeString\\n"""" else ""
+    }
   }
 
   abstract class MacroHandler(member: DefDef) extends MemberDefHandler(member) {

--- a/src/repl/scala/tools/nsc/interpreter/ReplProps.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplProps.scala
@@ -13,6 +13,9 @@ class ReplProps {
   private def bool(name: String) = BooleanProp.keyExists(name)
   private def int(name: String) = IntProp(name)
 
+  // This property is used in TypeDebugging. Let's recycle it.
+  val colorOk = bool("scala.color")
+
   val info  = bool("scala.repl.info")
   val debug = bool("scala.repl.debug")
   val trace = bool("scala.repl.trace")

--- a/src/repl/scala/tools/nsc/interpreter/ReplReporter.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplReporter.scala
@@ -32,6 +32,24 @@ class ReplReporter(intp: IMain) extends ConsoleReporter(intp.settings, Console.i
   override def warning(pos: Position, msg: String): Unit = withoutTruncating(super.warning(pos, msg))
   override def error(pos: Position, msg: String): Unit   = withoutTruncating(super.error(pos, msg))
 
+  import scala.io.AnsiColor.{ RED, YELLOW, RESET }
+
+  def severityColor(severity: Severity): String = severity match {
+    case ERROR   => RED
+    case WARNING => YELLOW
+    case INFO    => RESET
+  }
+
+  override def print(pos: Position, msg: String, severity: Severity) {
+    val prefix = (
+      if (replProps.colorOk)
+        severityColor(severity) + clabel(severity) + RESET
+      else
+        clabel(severity)
+    )
+    printMessage(pos, prefix + msg)
+  }
+
   override def printMessage(msg: String) {
     // Avoiding deadlock if the compiler starts logging before
     // the lazy val is complete.


### PR DESCRIPTION
We already use -Dscala.color when using -Ytyper-debug

This tries to reuse the colors chosen from the debug flag:
- Bold blue for vals (e.g. "res0")
- Bold green for types (e.g. "Int")
- Magenta for the shell prompt (e.g. "scala>")
