### PR TITLE
Make compiler.properties fall back to prefixed

### DIFF
--- a/src/compiler/scala/tools/nsc/Properties.scala
+++ b/src/compiler/scala/tools/nsc/Properties.scala
@@ -11,7 +11,7 @@ object Properties extends scala.util.PropertiesTrait {
   protected def propCategory   = "compiler"
   protected def pickJarBasedOn = classOf[Global]
 
-  // settings based on jar properties
+  // settings based on jar properties, falling back to System prefixed by "scala."
   def residentPromptString = scalaPropOrElse("resident.prompt", "\nnsc> ")
   def shellPromptString    = scalaPropOrElse("shell.prompt", "\nscala> ")
   def shellInterruptedString = scalaPropOrElse("shell.interrupted", ":quit\n")

--- a/src/library/scala/util/Properties.scala
+++ b/src/library/scala/util/Properties.scala
@@ -62,10 +62,10 @@ private[scala] trait PropertiesTrait {
 
   def envOrSome(name: String, alt: Option[String])       = envOrNone(name) orElse alt
 
-  // for values based on propFilename
-  def scalaPropOrElse(name: String, alt: String): String = scalaProps.getProperty(name, alt)
+  // for values based on propFilename, falling back to System properties
+  def scalaPropOrElse(name: String, alt: String): String = scalaPropOrNone(name).getOrElse(alt)
   def scalaPropOrEmpty(name: String): String             = scalaPropOrElse(name, "")
-  def scalaPropOrNone(name: String): Option[String]      = Option(scalaProps.getProperty(name))
+  def scalaPropOrNone(name: String): Option[String]      = Option(scalaProps.getProperty(name)).orElse(propOrNone("scala." + name))
 
   /** The numeric portion of the runtime Scala version, if this is a final
    *  release.  If for instance the versionString says "version 2.9.0.final",


### PR DESCRIPTION
Previously, if we wanted to override the shell.prompt property, we had
to modify compiler.properties in the jar. This change lets us do the
following, instead:

```
scala -Dscala.shell.prompt="$(echo -e "\npuffnfresh> ")"
```

All properties previously loaded from compiler.properties now fall back
to "scala." in the system properties when not found.
