### PR TITLE
SI-8267 Avoid existentials after polymorphic overload resolution

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1100,7 +1100,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           adaptConstant(value)
         case OverloadedType(pre, alts) if !mode.inFunMode => // (1)
           inferExprAlternative(tree, pt)
-          adapt(tree, mode, pt, original)
+          adaptAfterOverloadResolution(tree, mode, pt, original)
         case NullaryMethodType(restpe) => // (2)
           adapt(tree setType restpe, mode, pt, original)
         case TypeRef(_, ByNameParamClass, arg :: Nil) if mode.inExprMode => // (2)
@@ -1131,6 +1131,12 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         case _ =>
           vanillaAdapt(tree)
       }
+    }
+
+    // This just exists to help keep track of the spots where we have to adapt a tree after
+    // overload resolution. These proved hard to find during the fix for SI-8267.
+    def adaptAfterOverloadResolution(tree: Tree, mode: Mode, pt: Type = WildcardType, original: Tree = EmptyTree): Tree = {
+      adapt(tree, mode, pt, original)
     }
 
     def instantiate(tree: Tree, mode: Mode, pt: Type): Tree = {
@@ -3171,7 +3177,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             if (sym1 != NoSymbol) sym = sym1
           }
           if (sym == NoSymbol) fun
-          else adapt(fun setSymbol sym setType pre.memberType(sym), mode.forFunMode, WildcardType)
+          else adaptAfterOverloadResolution(fun setSymbol sym setType pre.memberType(sym), mode.forFunMode)
         } else fun
       }
 
@@ -3216,7 +3222,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               setError(tree)
             else {
               inferMethodAlternative(fun, undetparams, argTpes, pt)
-              doTypedApply(tree, adapt(fun, mode.forFunMode, WildcardType), args1, mode, pt)
+              doTypedApply(tree, adaptAfterOverloadResolution(fun, mode.forFunMode, WildcardType), args1, mode, pt)
             }
           }
           handleOverloaded
@@ -3799,7 +3805,18 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     protected def typedTypeApply(tree: Tree, mode: Mode, fun: Tree, args: List[Tree]): Tree = fun.tpe match {
       case OverloadedType(pre, alts) =>
         inferPolyAlternatives(fun, mapList(args)(treeTpe))
-        val tparams = fun.symbol.typeParams //@M TODO: fun.symbol.info.typeParams ? (as in typedAppliedTypeTree)
+
+        // SI-8267 `memberType` can introduce existentials *around* a PolyType/MethodType, see AsSeenFromMap#captureThis.
+        //         If we had selected a non-overloaded symbol, `memberType` would have been called in `makeAccessible`
+        //         and the resulting existential type would have been skolemized in `adapt` *before* we typechecked
+        //         the enclosing type-/ value- application.
+        //
+        //         However, if the selection is overloaded, we defer calling `memberType` until we can select a single
+        //         alternative here. It is therefore necessary to skolemize the existential here.
+        //
+        val fun1 = adaptAfterOverloadResolution(fun, mode.forFunMode | TAPPmode)
+
+        val tparams = fun1.symbol.typeParams //@M TODO: fun.symbol.info.typeParams ? (as in typedAppliedTypeTree)
         val args1 = if (sameLength(args, tparams)) {
           //@M: in case TypeApply we can't check the kind-arities of the type arguments,
           // as we don't know which alternative to choose... here we do
@@ -3813,7 +3830,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
          // ...actually this was looping anyway, see bug #278.
           return TypedApplyWrongNumberOfTpeParametersError(fun, fun)
 
-        typedTypeApply(tree, mode, fun, args1)
+        typedTypeApply(tree, mode, fun1, args1)
       case SingleType(_, _) =>
         typedTypeApply(tree, mode, fun setType fun.tpe.widen, args)
       case PolyType(tparams, restpe) if tparams.nonEmpty =>

--- a/test/files/pos/t8267.scala
+++ b/test/files/pos/t8267.scala
@@ -1,0 +1,33 @@
+class Bippy { trait Foo[A] }
+
+final class RichBippy[C <: Bippy with Singleton](val c1: C) {
+  def f: Int = 1
+  def f[A](x: A)(ev: c1.Foo[A]): Int = 2
+
+  def g[A <: Nothing](x: A): Int = 1
+  def g[A](x: A)(ev: c1.Foo[A]): Int = 2
+
+  def h[A](x: A)(ev: c1.Foo[A]): Int = 1
+
+  def i(x: Nothing): Int = 1
+  def i(x: AnyRef)(ev: c1.Foo[x.type]): Int = 2
+}
+
+object p {
+
+  val c  = new Bippy
+  val d0 = new RichBippy[c.type](c)
+  def d1 = new RichBippy[c.type](c)
+ 
+  d0.f[Int](5)(null: c.Foo[Int])  // ok
+  d1.f[Int](5)(null: c.Foo[Int])  // fails
+
+  d0.g[Int](5)(null: c.Foo[Int])  // ok
+  d1.g[Int](5)(null: c.Foo[Int])  // fails
+
+  d0.h[Int](5)(null: c.Foo[Int])  // ok
+  d1.h[Int](5)(null: c.Foo[Int])  // ok
+
+  d0.i("")(null)  // ok
+  d1.i("")(null)  // ok
+}


### PR DESCRIPTION
... which can be introduced by `memberType` for methods
with methods dependent on class type parameters.

Usually these are skolemized out of existence, but when
we carry through multiple overloaded alternatives and deferred
the call to `memberType`, this wasn't happening.

This commit calls `adapt` on function tree after polymorphic
overload resolution has run. This is analagous to `doTypedApply`:

``` scala
inferMethodAlternative(fun, undetparams, argTpes, pt)
doTypedApply(tree, adapt(fun, mode.forFunMode, WildcardType), args1, mode, pt)
```

This REPL transcript might further illustrate the problem.

```
scala> class Bippy { trait Foo[A] }
defined class Bippy

scala> final class RichBippy[C <: Bippy with Singleton](val c1: C) {
     |   def g[A](x: A)(ev: c1.Foo[A]): Int = 2
     | }
defined class RichBippy

scala> :power
** Power User mode enabled - BEEP WHIR GYVE **
** :phase has been set to 'typer'.          **
** scala.tools.nsc._ has been imported      **
** global._, definitions._ also imported    **
** Try  :help, :vals, power.<tab>           **

scala> val g = typeOf[RichBippy[_]].member(TermName("g"))
g: $r.intp.global.Symbol = method g

scala> val c = new Bippy
c: Bippy = Bippy@92e2c93

scala> val memberType = typeOf[RichBippy[c.type]].memberType(g)
memberType: $r.intp.global.Type = ([A](x: A)(ev: _7.c1.Foo[A])Int) forSome { val _7: RichBippy[c.type] }

scala> val tree = Ident(TermName("dummy")).setType(memberType)
tree: $r.intp.global.Ident = dummy

scala> def adaptExprWildcard(t: Tree) = {
     |   type HasAdapt = { def adapt(t: Tree, mode: Int, pt: Type, original: Tree) }
     |   typer.asInstanceOf[HasAdapt].adapt(t, Mode.EXPRmode.bits, WildcardType, EmptyTree)
     | }
warning: there was one feature warning; re-run with -feature for details
adaptExprWildcard: (t: $r.intp.global.Tree)Unit

scala> adaptExprWildcard(tree)

scala> tree.tpe
res1: $r.intp.global.Type = [A](x: A)(ev: _7.c1.Foo[A])Int

scala> memberType.skolemizeExistential
res2: $r.intp.global.Type = [A](x: A)(ev: _7.c1.Foo[A])Int
```

Review by @lrytz / @adriaanm
