### PR TITLE
Rename ClassPath.findSourceFile and delete Platform.doLoad

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -352,7 +352,7 @@ abstract class ClassfileParser {
   }
 
   private def loadClassSymbol(name: Name): Symbol = {
-    val file = classPath findSourceFile ("" +name) getOrElse {
+    val file = classPath findClassFile ("" +name) getOrElse {
       // SI-5593 Scaladoc's current strategy is to visit all packages in search of user code that can be documented
       // therefore, it will rummage through the classpath triggering errors whenever it encounters package objects
       // that are not in their correct place (see bug for details)
@@ -1047,7 +1047,7 @@ abstract class ClassfileParser {
     for (entry <- innerClasses.entries) {
       // create a new class member for immediate inner classes
       if (entry.outerName == currentClass) {
-        val file = classPath.findSourceFile(entry.externalName.toString) getOrElse {
+        val file = classPath.findClassFile(entry.externalName.toString) getOrElse {
           throw new AssertionError(entry.externalName)
         }
         enterClassAndModule(entry, file)

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ICodeReader.scala
@@ -130,7 +130,7 @@ abstract class ICodeReader extends ClassfileParser {
     log("ICodeReader reading " + cls)
     val name = cls.javaClassName
 
-    classPath.findSourceFile(name) match {
+    classPath.findClassFile(name) match {
       case Some(classFile) => parse(classFile, cls)
       case _               => MissingRequirementError.notFound("Could not find bytecode for " + cls)
     }

--- a/src/compiler/scala/tools/nsc/util/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/util/ClassPath.scala
@@ -231,7 +231,7 @@ abstract class ClassPath[T] {
         classes find (_.name == name)
     }
 
-  def findSourceFile(name: String): Option[AbstractFile] =
+  def findClassFile(name: String): Option[AbstractFile] =
     findClass(name) match {
       case Some(ClassRep(Some(x: AbstractFile), _)) => Some(x)
       case _                                        => None

--- a/test/junit/scala/tools/nsc/symtab/SymbolTableForUnitTesting.scala
+++ b/test/junit/scala/tools/nsc/symtab/SymbolTableForUnitTesting.scala
@@ -33,7 +33,6 @@ class SymbolTableForUnitTesting extends SymbolTable {
     lazy val loaders: SymbolTableForUnitTesting.this.loaders.type = SymbolTableForUnitTesting.this.loaders
     def platformPhases: List[SubComponent] = Nil
     val classPath: ClassPath[AbstractFile] = new PathResolver(settings).result
-    def doLoad(cls: ClassPath[AbstractFile]#ClassRep): Boolean = true
     def isMaybeBoxed(sym: Symbol): Boolean = ???
     def needCompile(bin: AbstractFile, src: AbstractFile): Boolean = ???
     def externalEquals: Symbol = ???


### PR DESCRIPTION
This is a change cherry-picked from a branch with new classpath implementation as
it's something independent which doesn't affect anything and so that it should be safe to merge it.

If you look at the implementation of ClassPath.findSourceFile method and its usage
it's clear that it should have been named `findClassFile` from the
beginning because that's what it does: find a class file and not a source file.

We don't need Platform.doLoad - .NET backend has been removed so method is a no-op.
