### PR TITLE
add 'constantly' function to complement 'identity'

### DIFF
--- a/src/library/scala/Function.scala
+++ b/src/library/scala/Function.scala
@@ -24,6 +24,7 @@ object Function {
   def chain[a](fs: Seq[a => a]): a => a = { x => (x /: fs) ((x, f) => f(x)) }
 
   /** The constant function */
+  @deprecated("Use `scala.Predef.constantly` instead", "2.12.0")
   def const[T, U](x: T)(y: U): T = x
 
   /** Turns a function `A => Option[B]` into a `PartialFunction[A, B]`.

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -130,6 +130,8 @@ object Predef extends LowPriorityImplicits with DeprecatedPredef {
   @inline def implicitly[T](implicit e: T) = e    // for summoning implicit values from the nether world -- TODO: when dependent method types are on by default, give this result type `e.type`, so that inliner has better chance of knowing which method to inline in calls like `implicitly[MatchingStrategy[Option]].zero`
   @inline def locally[T](x: T): T  = x    // to communicate intent and avoid unmoored statements
 
+  @inline def constantly[A, B](x: A)(y: B) = x    // always return constant value
+
   // errors and asserts -------------------------------------------------
 
   // !!! Remove this when possible - ideally for 2.11.


### PR DESCRIPTION
Proposing to move const (renamed as constantly) and identity together to improve language consistency.
Little conversation about: https://groups.google.com/forum/#!topic/scala-language/IgMLwK3ztjk
