### PR TITLE
Avoid test fragility to changes in Predef

### DIFF
--- a/test/files/neg/macro-invalidret.check
+++ b/test/files/neg/macro-invalidret.check
@@ -19,8 +19,7 @@ Macros_Test_2.scala:7: warning: macro defs must have explicitly specified return
   def foo6 = macro Impls.foo6
       ^
 Macros_Test_2.scala:14: error: exception during macro expansion:
-scala.NotImplementedError: an implementation is missing
-	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:225)
+java.lang.NullPointerException
 	at Impls$.foo3(Impls_1.scala:7)
 
   foo3

--- a/test/files/neg/macro-invalidret/Impls_1.scala
+++ b/test/files/neg/macro-invalidret/Impls_1.scala
@@ -4,7 +4,7 @@ import scala.reflect.runtime.{universe => ru}
 object Impls {
   def foo1(c: Context) = 2
   def foo2(c: Context) = ru.Literal(ru.Constant(42))
-  def foo3(c: Context) = ???
+  def foo3(c: Context) = throw null
   def foo5(c: Context) = c.universe.Literal(c.universe.Constant(42))
   def foo6(c: Context) = c.Expr[Int](c.universe.Literal(c.universe.Constant(42)))
 }


### PR DESCRIPTION
The check file used to contain a stack trace entry from
Predef with a line number. I've made the macro fail
in a different manner that avoids this fragility.

Review by @xeno-by
