### PR TITLE
Bump timeout in interactive tests from 10s -> 30s.

### DIFF
--- a/src/interactive/scala/tools/nsc/interactive/tests/core/TestSettings.scala
+++ b/src/interactive/scala/tools/nsc/interactive/tests/core/TestSettings.scala
@@ -4,7 +4,7 @@ import scala.tools.nsc.io.Path
 
 /** Common settings for the test. */
 private[tests] trait TestSettings {
-  protected final val TIMEOUT = 10000 // timeout in milliseconds
+  protected final val TIMEOUT = 30000 // timeout in milliseconds
 
   /** The root directory for this test suite, usually the test kind ("test/files/presentation"). */
   protected val outDir = Path(Option(System.getProperty("partest.cwd")).getOrElse("."))


### PR DESCRIPTION
Seeing too many of these failures on our build servers.

https://scala-webapps.epfl.ch/jenkins/view/2.N.x/job/scala-nightly-auxjvm-2.11.x/148/jdk=jdk8,label=auxjvm/console

This is most likely due to load on the machines.
