### PR TITLE
Cleanup a few compiler flags in test/files/

### DIFF
--- a/test/files/pos/five-dot-f.flags
+++ b/test/files/pos/five-dot-f.flags
@@ -1,1 +1,0 @@
--Xfuture

--- a/test/files/run/t5530.flags
+++ b/test/files/run/t5530.flags
@@ -1,1 +1,0 @@
--Xexperimental

--- a/test/files/run/t5532.flags
+++ b/test/files/run/t5532.flags
@@ -1,1 +1,0 @@
--Xexperimental

--- a/test/files/run/t5614.flags
+++ b/test/files/run/t5614.flags
@@ -1,1 +1,0 @@
--Xexperimental


### PR DESCRIPTION
- String interpolation isn't Xexperimental anymore
  
  A few useless Xexperimental flags in tests were left behind by 6917cca,
  after string interpolation was made non-experimental in 983f414.
- Things added under -Xfuture in 2.10 are very much Xpresent now, the
  flag isn't needed anymore.
