### PR TITLE
SI-8087 keep annotations on mixed-in private[this] fields

### DIFF
--- a/test/files/run/t8087.scala
+++ b/test/files/run/t8087.scala
@@ -1,0 +1,12 @@
+trait Foo {
+  @volatile private[this] var x: String = ""
+  @volatile private var y: String = ""
+}
+
+class Bar extends Foo
+
+object Test extends App {
+  classOf[Bar].getDeclaredFields.foreach(f => {
+    assert(java.lang.reflect.Modifier.isVolatile(f.getModifiers), f.getName)
+  })
+}


### PR DESCRIPTION
Related to SI-2511 / eea7956, which fixed the same issue for non
`private[this]` fields.

If you have

```
trait T { private[this] val f = 0 }
class C extends T
```

Mixin geneartes an accessor method `T.f` with owner `T`. When
generating the field in `C`, the Mixin.mixinTraitMembers calls
`fAccessor.accessed`. The implementation of `accessed` does a lookup
for a member named `"f "` (note the space). The bug is that
`private[this]` fields are not renamed to have space
(`LOCAL_SUFFIX_STRING`) in their name, so the accessed was not found,
and no annotations were copied from it.
