### PR TITLE
SI-8445, SI-6622 test cases, already fixed

### DIFF
--- a/test/files/run/t6622.check
+++ b/test/files/run/t6622.check
@@ -1,0 +1,10 @@
+ O1.resultVal isMemberClass = false, null
+class A$1
+ O1.resultDef isMemberClass = false, public void O1$.resultDef()
+class A$2
+ C2.resultVal isMemberClass = false, null
+class $B$1
+ O3.resultDef isMemberClass = false, public void O3$.resultDef()
+class C$1
+ O4.resultDefDefault isMemberClass = false, public java.lang.Object O4$.resultDefDefault$default$1()
+class C$2

--- a/test/files/run/t6622.scala
+++ b/test/files/run/t6622.scala
@@ -1,0 +1,50 @@
+import Test.check
+
+object O1 {
+  lazy val resultVal = {
+    class A
+    check("O1.resultVal", classOf[A])
+  }
+
+  def resultDef = {
+    class A
+    check("O1.resultDef", classOf[A])
+  }
+}
+
+class C2 {
+  val resultVal = {
+    val tmp = {
+      class B
+      check("C2.resultVal", classOf[B])
+    }
+  }
+}
+
+object O3 {
+  def resultDef = {
+    class C
+    check("O3.resultDef", classOf[C])
+  }
+}
+
+object O4 {
+  def resultDefDefault(a: Any = {
+    class C
+    check("O4.resultDefDefault", classOf[C])
+  }) = ();
+}
+
+
+object Test extends App {
+  def check(desc: String, clazz: Class[_]) {
+    println(s" $desc isMemberClass = ${clazz.isMemberClass}, ${clazz.getEnclosingMethod}")
+    println(reflect.runtime.currentMirror.classSymbol(clazz))
+  }
+
+  O1.resultVal
+  O1.resultDef
+  new C2().resultVal
+  O3.resultDef
+  O4.resultDefDefault()
+}

--- a/test/files/run/t8445.check
+++ b/test/files/run/t8445.check
@@ -1,0 +1,1 @@
+warning: there was one feature warning; re-run with -feature for details

--- a/test/files/run/t8445.scala
+++ b/test/files/run/t8445.scala
@@ -1,0 +1,11 @@
+object X {
+  class Y
+  def y = new Y {
+    class Z
+    def z = classOf[Z]
+  }
+}
+
+object Test extends App {
+  assert(X.y.z.getEnclosingClass.getName == "X$$anon$1")
+}


### PR DESCRIPTION
They were most likely fixed in #3931 / e3107465c3.

The test case for SI-6622 is taken from Jason's PR #2654. I adjusted
the EnclosingMethod to be `null` in two places in the check file, for
the classes that are owned by fields (not methods).
