### PR TITLE
SI-8868 Fix unpickling of local dummy symbols

### DIFF
--- a/test/files/pos/t8868a/Sub_2.scala
+++ b/test/files/pos/t8868a/Sub_2.scala
@@ -1,0 +1,1 @@
+class Sub extends T

--- a/test/files/pos/t8868a/T_1.scala
+++ b/test/files/pos/t8868a/T_1.scala
@@ -1,0 +1,6 @@
+class C
+
+trait T {
+  @deprecated(since = "", message = "")
+  class X
+}

--- a/test/files/pos/t8868b/Sub_2.scala
+++ b/test/files/pos/t8868b/Sub_2.scala
@@ -1,0 +1,2 @@
+class Sub extends T
+

--- a/test/files/pos/t8868b/T_1.scala
+++ b/test/files/pos/t8868b/T_1.scala
@@ -1,0 +1,4 @@
+@deprecated(since = "2.4.0", message = "")
+trait T {
+  class X
+}

--- a/test/files/pos/t8868c/Sub_2.scala
+++ b/test/files/pos/t8868c/Sub_2.scala
@@ -1,0 +1,2 @@
+class Sub extends T
+

--- a/test/files/pos/t8868c/T_1.scala
+++ b/test/files/pos/t8868c/T_1.scala
@@ -1,0 +1,9 @@
+class C(a: Any) extends annotation.StaticAnnotation
+
+@C({val x = 0; x})
+trait T {
+  class X
+
+  @C({val x = 0; x})
+  def foo = 42
+}


### PR DESCRIPTION
These pop up as the owner of symbols in annotation arguments,
such as the ones introduced by the names/defaults desugaring.

The first two test cases here motivate the two patches to Unpicker.

The third requires both fixes, but exploits the problem directly,
without using `@deprecated` and named arguments.

See also 14fa7be / SI-8708 for a recently remedied kindred bug.

Review by `scala.annotation.`@lrytz
