### PR TITLE
SI-8731 warning if @switch is ignored

### DIFF
--- a/test/files/neg/t6902.scala
+++ b/test/files/neg/t6902.scala
@@ -16,7 +16,7 @@ object Test {
   // at scala.reflect.internal.SymbolTable.abort(SymbolTable.scala:50)
   // at scala.tools.nsc.Global.abort(Global.scala:249)
   // at scala.tools.nsc.backend.jvm.GenASM$JPlainBuilder$jcode$.emitSWITCH(GenASM.scala:1850)
-  ((1: Byte): @unchecked @annotation.switch) match {
+  ((1: Byte): @unchecked) match {
     case 1 => 2
     case 1 => 3 // crash
   }

--- a/test/files/neg/t8731.check
+++ b/test/files/neg/t8731.check
@@ -1,0 +1,9 @@
+t8731.scala:5: warning: matches with two cases or fewer are emitted using if-then-else instead of switch
+  def f(x: Int) = (x: @annotation.switch) match {
+                       ^
+t8731.scala:10: warning: could not emit switch for @switch annotated match
+  def g(x: Int) = (x: @annotation.switch) match {
+                       ^
+error: No warnings can be incurred under -Xfatal-warnings.
+two warnings found
+one error found

--- a/test/files/neg/t8731.flags
+++ b/test/files/neg/t8731.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/t8731.scala
+++ b/test/files/neg/t8731.scala
@@ -1,0 +1,15 @@
+class C {
+  // not a compile-time constant due to return type
+  final val K: Int = 20
+
+  def f(x: Int) = (x: @annotation.switch) match {
+    case K => 0
+    case 2 => 1
+  }
+
+  def g(x: Int) = (x: @annotation.switch) match {
+    case K => 0
+    case 2 => 1
+    case 3 => 2
+  }
+}

--- a/test/files/pos/switch-small.flags
+++ b/test/files/pos/switch-small.flags
@@ -1,1 +1,0 @@
--Xfatal-warnings

--- a/test/files/pos/switch-small.scala
+++ b/test/files/pos/switch-small.scala
@@ -1,8 +1,0 @@
-import annotation._
-
-object Test {
-  def f(x: Int) = (x: @switch) match {
-    case 1 => 1
-    case _ => 2
-  }
-}

--- a/test/files/run/t5830.check
+++ b/test/files/run/t5830.check
@@ -1,5 +1,6 @@
 a with oef
 a with oef
+a with oef
 a
 def with oef
 def

--- a/test/files/run/t5830.scala
+++ b/test/files/run/t5830.scala
@@ -1,12 +1,11 @@
 import scala.annotation.switch
 
 object Test extends App {
-  // TODO: should not emit a switch
-  // def noSwitch(ch: Char, eof: Boolean) = (ch: @switch) match {
-  //   case 'a' if eof => println("a with oef") // then branch
-  // }
+  def noSwitch(ch: Char, eof: Boolean) = ch match {
+    case 'a' if eof => println("a with oef") // then branch
+  }
 
-  def onlyThen(ch: Char, eof: Boolean) = (ch: @switch) match {
+  def onlyThen(ch: Char, eof: Boolean) = ch match {
     case 'a' if eof => println("a with oef") // then branch
     case 'c' =>
   }
@@ -18,7 +17,7 @@ object Test extends App {
     case 'c' =>
   }
 
-  def defaultUnguarded(ch: Char, eof: Boolean) = (ch: @switch) match {
+  def defaultUnguarded(ch: Char, eof: Boolean) = ch match {
     case ' ' if eof => println("spacey oef")
     case _ => println("default")
   }
@@ -44,7 +43,7 @@ object Test extends App {
   //   case 'c' =>
   // }
 
-  // noSwitch('a', true)
+  noSwitch('a', true)
   onlyThen('a', true)       // 'a with oef'
   ifThenElse('a', true)     // 'a with oef'
   ifThenElse('a', false)    // 'a'

--- a/test/files/run/t6011c.scala
+++ b/test/files/run/t6011c.scala
@@ -6,7 +6,7 @@ object Test extends App {
   // at scala.reflect.internal.SymbolTable.abort(SymbolTable.scala:50)
   // at scala.tools.nsc.Global.abort(Global.scala:249)
   // at scala.tools.nsc.backend.jvm.GenASM$JPlainBuilder$jcode$.emitSWITCH(GenASM.scala:1850)
-  ((1: Byte): @unchecked @annotation.switch) match {
+  ((1: Byte): @unchecked) match {
     case 1 => 2
     case 1 => 3 // crash
   }

--- a/test/junit/scala/issues/BytecodeTests.scala
+++ b/test/junit/scala/issues/BytecodeTests.scala
@@ -1,0 +1,39 @@
+package scala.issues
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Test
+import scala.tools.asm.Opcodes
+import scala.tools.nsc.backend.jvm.CodeGenTools._
+import org.junit.Assert._
+import scala.collection.JavaConverters._
+import scala.tools.partest.ASMConverters._
+
+@RunWith(classOf[JUnit4])
+class BytecodeTests {
+  val compiler = newCompiler()
+
+  @Test
+  def t8731(): Unit = {
+    val code =
+      """class C {
+        |  def f(x: Int) = (x: @annotation.switch) match {
+        |    case 1 => 0
+        |    case 2 => 1
+        |    case 3 => 2
+        |  }
+        |  final val K = 10
+        |  def g(x: Int) = (x: @annotation.switch) match {
+        |    case K => 0
+        |    case 1 => 10
+        |    case 2 => 20
+        |  }
+        |}
+      """.stripMargin
+
+    val List(c) = compileClasses(compiler)(code)
+
+    assertTrue(getSingleMethod(c, "f").instructions.count(_.isInstanceOf[TableSwitch]) == 1)
+    assertTrue(getSingleMethod(c, "g").instructions.count(_.isInstanceOf[LookupSwitch]) == 1)
+  }
+}

--- a/test/junit/scala/tools/nsc/backend/jvm/CodeGenTools.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/CodeGenTools.scala
@@ -76,4 +76,7 @@ object CodeGenTools {
   def assertSameCode(actual: List[Instruction], expected: List[Instruction]): Unit = {
     assertTrue(s"\nExpected: $expected\nActual  : $actual", actual === expected)
   }
+
+  def getSingleMethod(classNode: ClassNode, name: String): Method =
+    convertMethod(classNode.methods.asScala.toList.find(_.name == name).get)
 }


### PR DESCRIPTION
For matches with two or fewer cases, @switch is ignored. This should
not happen silently.
