### PR TITLE
SI-8869 Prevent ill-kindedness in type lambdas

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -480,6 +480,8 @@ trait Contexts { self: Analyzer =>
       // SI-8245 `isLazy` need to skip lazy getters to ensure `return` binds to the right place
       c.enclMethod         = if (isDefDef && !owner.isLazy) c else enclMethod
 
+      if (tree != outer.tree) c(TypeConstructorAllowed) = false
+
       registerContext(c.asInstanceOf[analyzer.Context])
       debuglog("[context] ++ " + c.unit + " / " + tree.summaryString)
       c

--- a/test/files/neg/t8869.check
+++ b/test/files/neg/t8869.check
@@ -1,0 +1,7 @@
+t8869.scala:5: error: class Option takes type parameters
+  def value: TC[({type l1[x] = Option})#l1] = ??? // error not reported!
+                               ^
+t8869.scala:7: error: class Option takes type parameters
+  type l2[x] = Option // error correctly reported
+               ^
+two errors found

--- a/test/files/neg/t8869.scala
+++ b/test/files/neg/t8869.scala
@@ -1,0 +1,10 @@
+class TC[T[_]] {
+  def identity[A](a: T[A]): T[A] = a
+}
+object Test {
+  def value: TC[({type l1[x] = Option})#l1] = ??? // error not reported!
+
+  type l2[x] = Option // error correctly reported
+  def value1: TC[l2] = ???
+}
+


### PR DESCRIPTION
When type checking an type application, the arguments are allowed
to be of kinds other than *. This leniency is controlled by the
`ContextMode` bit `TypeConstructorAllowed`.

(More fine grained checking of matching arity a bounds of type
constructors is deferred until the refchecks phase to avoid
cycles during typechecking.)

However, this bit is propagated to child contexts, which means
that we fail to report this error in the lexical context marked
here:

```
T[({type x = Option}#x)]
    `-------------'
```

This commit resets this bit to false in any child context
relates to a different tree from its parent.

Review by @adriaanm
