### PR TITLE
Increase REPL startup timeout to avoid test failures

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -428,7 +428,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
   // return false if repl should exit
   def processLine(line: String): Boolean = {
     import scala.concurrent.duration._
-    Await.ready(globalFuture, 60.seconds)
+    Await.ready(globalFuture, 10.minutes) // Long timeout here to avoid test failures under heavy load.
 
     if (line eq null) {
       // SI-4563: this means the console was properly interrupted (Ctrl+D usually)


### PR DESCRIPTION
Under load on Jenkins, we've been seeing:

```
% diff /localhome/jenkins/a/workspace/scala-nightly-auxjvm-2.12.x/jdk/jdk7/label/auxjvm/test/files/run/t4542-run.log /localhome/jenkins/a/workspace/scala-nightly-auxjvm-2.12.x/jdk/jdk7/label/auxjvm/test/files/run/t4542.check
@@ -2,75 +2,14 @@ Type in expressions to have them evaluated.
 Type :help for more information.

 scala> @deprecated("foooo", "ReplTest version 1.0-FINAL") class Foo() {
 java.util.concurrent.TimeoutException: Futures timed out after [60 seconds]
    at scala.concurrent.impl.Promise$DefaultPromise.ready(Promise.scala:219)
    at scala.concurrent.impl.Promise$DefaultPromise.ready(Promise.scala:153)
    at scala.concurrent.Await$$anonfun$ready$1.apply(package.scala:95)
    at scala.concurrent.Await$$anonfun$ready$1.apply(package.scala:95)
    at scala.concurrent.BlockContext$DefaultBlockContext$.blockOn(BlockContext.scala:53)
    at scala.concurrent.Await$.ready(package.scala:95)
    at scala.tools.nsc.interpreter.ILoop.processLine(ILoop.scala:431)
    at scala.tools.nsc.interpreter.ILoop.loop(ILoop.scala:457)
    at scala.tools.nsc.interpreter.ILoop$$anonfun$process$1.apply$mcZ$sp(ILoop.scala:875)
```

This commit bumps the timeout up be a factor of ten to try to
restore that comforting green glow to https://scala-webapps.epfl.ch/jenkins/view/2.N.x

Review by @gkossakowski
