### PR TITLE
SI-7981 override toSeq in immutable.MapLike and immutable.Set

### DIFF
--- a/src/library/scala/collection/immutable/MapLike.scala
+++ b/src/library/scala/collection/immutable/MapLike.scala
@@ -126,5 +126,11 @@ self =>
     for ((key, value) <- this) b += ((key, f(key, value)))
     b.result()
   }
+
+  /**
+   * Converts this $coll to an immutable sequence.
+   * @return an immutable sequence containing all elements of this $coll.
+   */
+  override def toSeq: scala.collection.Seq[(A, B)] = Seq(toBuffer[(A, B)]:_*)
 }
 

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -36,6 +36,12 @@ trait Set[A] extends Iterable[A]
   
   
   override def toSet[B >: A]: Set[B] = to[({type l[a] = immutable.Set[B]})#l] // for bincompat; remove in dev
+
+  /**
+   * Converts this $coll to an immutable sequence.
+   * @return an immutable sequence containing all elements of this $coll.
+   */
+  override def toSeq: scala.collection.Seq[A] = Seq(toBuffer[A]:_*)
   
   override def seq: Set[A] = this
   protected override def parCombiner = ParSet.newCombiner[A] // if `immutable.SetLike` gets introduced, please move this there!


### PR DESCRIPTION
https://issues.scala-lang.org/browse/SI-7981
This pull request is a way to pay attention to the issue. I'm not sure that it is the best implementation. There are may be faster way.
