### PR TITLE
SI-8291 Fix implicitNotFound message with type aliases

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1478,8 +1478,10 @@ trait Implicits {
         })
 
       private lazy val typeParamNames: List[String] = sym.typeParams.map(_.decodedName)
+      private def typeArgsAtSym(paramTp: Type) = paramTp.baseType(sym).typeArgs
 
-      def format(paramName: Name, paramTp: Type): String = format(paramTp.typeArgs map (_.toString))
+      def format(paramName: Name, paramTp: Type): String = format(typeArgsAtSym(paramTp) map (_.toString))
+
       def format(typeArgs: List[String]): String =
         interpolate(msg, Map((typeParamNames zip typeArgs): _*)) // TODO: give access to the name and type of the implicit argument, etc?
 

--- a/test/files/neg/t8291.check
+++ b/test/files/neg/t8291.check
@@ -1,0 +1,7 @@
+t8291.scala:5: error: Could not find implicit for Int or String
+  implicitly[X[Int, String]]
+            ^
+t8291.scala:6: error: Could not find implicit for Int or String
+  implicitly[Z[String]]
+            ^
+two errors found

--- a/test/files/neg/t8291.scala
+++ b/test/files/neg/t8291.scala
@@ -1,0 +1,7 @@
+@scala.annotation.implicitNotFound("Could not find implicit for ${T} or ${U}") trait X[T, U]
+
+object Test {
+  type Z[U] = X[Int, U]
+  implicitly[X[Int, String]]
+  implicitly[Z[String]]
+}


### PR DESCRIPTION
This pattern of code is typically a bug:

```
if (f(tp.typeSymbol)) {
   g(tp.typeArgs)
}
```

Intead, one needs to take the base type of `tp` wrt `tp.typeSymbol`.

This commit does exactly that when formatting the `@implicitNotFound`
custom error message.

Patch found on the back of an envelope in the handwriting of @adriaanm

Review by @som-snytt
