### PR TITLE
SI-8843 AbsFileCL acts like a CL

### DIFF
--- a/src/reflect/scala/reflect/internal/util/AbstractFileClassLoader.scala
+++ b/src/reflect/scala/reflect/internal/util/AbstractFileClassLoader.scala
@@ -5,16 +5,16 @@
 package scala
 package reflect.internal.util
 
-import scala.reflect.io.AbstractFile
+import scala.collection.{ mutable, immutable }
+import scala.reflect.io.{ AbstractFile, Streamable }
+import java.net.{ URL, URLConnection, URLStreamHandler }
 import java.security.cert.Certificate
 import java.security.{ ProtectionDomain, CodeSource }
-import java.net.{ URL, URLConnection, URLStreamHandler }
-import scala.collection.{ mutable, immutable }
+import java.util.{ Collections => JCollections, Enumeration => JEnumeration }
 
-/**
- * A class loader that loads files from a {@link scala.tools.nsc.io.AbstractFile}.
+/** A class loader that loads files from a {@link scala.tools.nsc.io.AbstractFile}.
  *
- * @author Lex Spoon
+ *  @author Lex Spoon
  */
 class AbstractFileClassLoader(val root: AbstractFile, parent: ClassLoader)
     extends ClassLoader(parent)
@@ -22,7 +22,7 @@ class AbstractFileClassLoader(val root: AbstractFile, parent: ClassLoader)
 {
   protected def classNameToPath(name: String): String =
     if (name endsWith ".class") name
-    else name.replace('.', '/') + ".class"
+    else s"${name.replace('.', '/')}.class"
 
   protected def findAbstractFile(name: String): AbstractFile = {
     var file: AbstractFile = root
@@ -56,35 +56,25 @@ class AbstractFileClassLoader(val root: AbstractFile, parent: ClassLoader)
     file
   }
 
-  // parent delegation in JCL uses getResource; so either add parent.getResAsStream
-  // or implement findResource, which we do here as a study in scarlet (my complexion
-  // after looking at CLs and URLs)
-  override def findResource(name: String): URL = findAbstractFile(name) match {
-    case null => null
-    case file => new URL(null, "repldir:" + file.path, new URLStreamHandler {
-      override def openConnection(url: URL): URLConnection = new URLConnection(url) {
-        override def connect() { }
-        override def getInputStream = file.input
-      }
-    })
-  }
-
-  // this inverts delegation order: super.getResAsStr calls parent.getRes if we fail
-  override def getResourceAsStream(name: String) = findAbstractFile(name) match {
-    case null => super.getResourceAsStream(name)
-    case file => file.input
-  }
-  // ScalaClassLoader.classBytes uses getResAsStream, so we'll try again before delegating
-  override def classBytes(name: String): Array[Byte] = findAbstractFile(classNameToPath(name)) match {
-    case null => super.classBytes(name)
-    case file => file.toByteArray
-  }
-  override def findClass(name: String): Class[_] = {
+  override protected def findClass(name: String): Class[_] = {
     val bytes = classBytes(name)
     if (bytes.length == 0)
       throw new ClassNotFoundException(name)
     else
       defineClass(name, bytes, 0, bytes.length, protectionDomain)
+  }
+  override protected def findResource(name: String): URL = findAbstractFile(name) match {
+    case null => null
+    case file => new URL(null, s"memory:${file.path}", new URLStreamHandler {
+      override def openConnection(url: URL): URLConnection = new URLConnection(url) {
+        override def connect() = ()
+        override def getInputStream = file.input
+      }
+    })
+  }
+  override protected def findResources(name: String): JEnumeration[URL] = findResource(name) match {
+    case null => JCollections.enumeration(JCollections.emptyList[URL])  //JCollections.emptyEnumeration[URL]
+    case url  => JCollections.enumeration(JCollections.singleton(url))
   }
 
   lazy val protectionDomain = {
@@ -106,15 +96,13 @@ class AbstractFileClassLoader(val root: AbstractFile, parent: ClassLoader)
     throw new UnsupportedOperationException()
   }
 
-  override def getPackage(name: String): Package = {
-    findAbstractDir(name) match {
-      case null => super.getPackage(name)
-      case file => packages.getOrElseUpdate(name, {
-        val ctor = classOf[Package].getDeclaredConstructor(classOf[String], classOf[String], classOf[String], classOf[String], classOf[String], classOf[String], classOf[String], classOf[URL], classOf[ClassLoader])
-        ctor.setAccessible(true)
-        ctor.newInstance(name, null, null, null, null, null, null, null, this)
-      })
-    }
+  override def getPackage(name: String): Package = findAbstractDir(name) match {
+    case null => super.getPackage(name)
+    case file => packages.getOrElseUpdate(name, {
+      val ctor = classOf[Package].getDeclaredConstructor(classOf[String], classOf[String], classOf[String], classOf[String], classOf[String], classOf[String], classOf[String], classOf[URL], classOf[ClassLoader])
+      ctor.setAccessible(true)
+      ctor.newInstance(name, null, null, null, null, null, null, null, this)
+    })
   }
 
   override def getPackages(): Array[Package] =

--- a/src/reflect/scala/reflect/internal/util/ScalaClassLoader.scala
+++ b/src/reflect/scala/reflect/internal/util/ScalaClassLoader.scala
@@ -53,8 +53,10 @@ trait ScalaClassLoader extends JClassLoader {
   }
 
   /** An InputStream representing the given class name, or null if not found. */
-  def classAsStream(className: String) =
-    getResourceAsStream(className.replaceAll("""\.""", "/") + ".class")
+  def classAsStream(className: String) = getResourceAsStream {
+    if (className endsWith ".class") className
+    else s"${className.replace('.', '/')}.class"  // classNameToPath
+  }
 
   /** Run the main method of a class to be loaded by this classloader */
   def run(objectName: String, arguments: Seq[String]) {

--- a/test/files/run/t8843-repl-xlat.scala
+++ b/test/files/run/t8843-repl-xlat.scala
@@ -1,0 +1,33 @@
+
+import scala.tools.partest.SessionTest
+
+// Handy hamburger helper for repl resources
+object Test extends SessionTest {
+  def session =
+"""Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> $intp.isettings.unwrapStrings = false
+$intp.isettings.unwrapStrings: Boolean = false
+
+scala> class Bippy
+defined class Bippy
+
+scala> $intp.classLoader getResource "Bippy.class"
+res0: java.net.URL = memory:(memory)/$line4/$read$$iw$$iw$Bippy.class
+
+scala> ($intp.classLoader getResources "Bippy.class").nextElement
+res1: java.net.URL = memory:(memory)/$line4/$read$$iw$$iw$Bippy.class
+
+scala> ($intp.classLoader classBytes "Bippy").nonEmpty
+res2: Boolean = true
+
+scala> ($intp.classLoader classAsStream "Bippy") != null
+res3: Boolean = true
+
+scala> $intp.classLoader getResource "Bippy"
+res4: java.net.URL = null
+
+scala> :quit"""
+}
+

--- a/test/junit/scala/reflect/internal/PrintersTest.scala
+++ b/test/junit/scala/reflect/internal/PrintersTest.scala
@@ -24,10 +24,10 @@ object PrinterHelper {
     resultCode.lines mkString s"$LF"
 
   def assertResultCode(code: String)(parsedCode: String = "", typedCode: String = "", wrap: Boolean = false, printRoot: Boolean = false) = {
-    def toolboxTree(tree: => Tree) = try{
+    def toolboxTree(tree: => Tree) = try {
         tree
       } catch {
-        case e:scala.tools.reflect.ToolBoxError => throw new Exception(e.getMessage + ": " + code)
+        case e:scala.tools.reflect.ToolBoxError => throw new Exception(e.getMessage + ": " + code, e)
       }
 
     def wrapCode(source: String) = {

--- a/test/junit/scala/reflect/internal/util/AbstractFileClassLoaderTest.scala
+++ b/test/junit/scala/reflect/internal/util/AbstractFileClassLoaderTest.scala
@@ -1,0 +1,138 @@
+package scala.reflect.internal.util
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class AbstractFileClassLoaderTest {
+
+  import scala.reflect.io._
+  import scala.io.Source
+  import scala.io.Codec.UTF8
+  import scala.reflect.io.Streamable
+  import java.net.{ URLClassLoader, URL }
+
+  implicit def `we love utf8` = UTF8
+  implicit class `abs file ops`(f: AbstractFile) {
+    def writeContent(s: String): Unit = Streamable.closing(f.bufferedOutput)(os => os write s.getBytes(UTF8.charSet))
+  }
+  implicit class `url slurp`(url: URL) {
+    def slurp(): String = Streamable.slurp(url)
+  }
+
+  val NoClassLoader: ClassLoader = null
+
+  def fuzzBuzzBooz: (AbstractFile, AbstractFile) = {
+    val fuzz = new VirtualDirectory("fuzz", None)
+    val buzz = fuzz subdirectoryNamed "buzz"
+    val booz = buzz fileNamed "booz.class"
+    (fuzz, booz)
+  }
+
+  @Test
+  def afclGetsParent(): Unit = {
+    val p = new URLClassLoader(Array.empty[URL])
+    val d = new VirtualDirectory("vd", None)
+    val x = new AbstractFileClassLoader(d, p)
+    assertSame(p, x.getParent)
+  }
+
+  @Test
+  def afclGetsResource(): Unit = {
+    val (fuzz, booz) = fuzzBuzzBooz
+    booz writeContent "hello, world"
+    val x = new AbstractFileClassLoader(fuzz, NoClassLoader)
+    val r = x.getResource("buzz/booz.class")
+    assertNotNull(r)
+    assertEquals("hello, world", r.slurp())
+  }
+
+  @Test
+  def afclGetsResourceFromParent(): Unit = {
+    val (fuzz, booz) = fuzzBuzzBooz
+    val (fuzz_, booz_) = fuzzBuzzBooz
+    booz writeContent "hello, world"
+    booz_ writeContent "hello, world_"
+    val p = new AbstractFileClassLoader(fuzz, NoClassLoader)
+    val x = new AbstractFileClassLoader(fuzz_, p)
+    val r = x.getResource("buzz/booz.class")
+    assertNotNull(r)
+    assertEquals("hello, world", r.slurp())
+  }
+
+  @Test
+  def afclGetsResourceInDefaultPackage(): Unit = {
+    val fuzz = new VirtualDirectory("fuzz", None)
+    val booz = fuzz fileNamed "booz.class"
+    val bass = fuzz fileNamed "bass"
+    booz writeContent "hello, world"
+    bass writeContent "lo tone"
+    val x = new AbstractFileClassLoader(fuzz, NoClassLoader)
+    val r = x.getResource("booz.class")
+    assertNotNull(r)
+    assertEquals("hello, world", r.slurp())
+    assertEquals("lo tone", (x getResource "bass").slurp())
+  }
+
+  // SI-8843
+  @Test
+  def afclGetsResources(): Unit = {
+    val (fuzz, booz) = fuzzBuzzBooz
+    booz writeContent "hello, world"
+    val x = new AbstractFileClassLoader(fuzz, NoClassLoader)
+    val e = x.getResources("buzz/booz.class")
+    assertTrue(e.hasMoreElements)
+    assertEquals("hello, world", e.nextElement.slurp())
+    assertFalse(e.hasMoreElements)
+  }
+
+  @Test
+  def afclGetsResourcesFromParent(): Unit = {
+    val (fuzz, booz) = fuzzBuzzBooz
+    val (fuzz_, booz_) = fuzzBuzzBooz
+    booz writeContent "hello, world"
+    booz_ writeContent "hello, world_"
+    val p = new AbstractFileClassLoader(fuzz, NoClassLoader)
+    val x = new AbstractFileClassLoader(fuzz_, p)
+    val e = x.getResources("buzz/booz.class")
+    assertTrue(e.hasMoreElements)
+    assertEquals("hello, world", e.nextElement.slurp())
+    assertTrue(e.hasMoreElements)
+    assertEquals("hello, world_", e.nextElement.slurp())
+    assertFalse(e.hasMoreElements)
+  }
+
+  @Test
+  def afclGetsResourceAsStream(): Unit = {
+    val (fuzz, booz) = fuzzBuzzBooz
+    booz writeContent "hello, world"
+    val x = new AbstractFileClassLoader(fuzz, NoClassLoader)
+    val r = x.getResourceAsStream("buzz/booz.class")
+    assertNotNull(r)
+    assertEquals("hello, world", Streamable.closing(r)(is => Source.fromInputStream(is).mkString))
+  }
+
+  @Test
+  def afclGetsClassBytes(): Unit = {
+    val (fuzz, booz) = fuzzBuzzBooz
+    booz writeContent "hello, world"
+    val x = new AbstractFileClassLoader(fuzz, NoClassLoader)
+    val b = x.classBytes("buzz/booz.class")
+    assertEquals("hello, world", new String(b, UTF8.charSet))
+  }
+
+  @Test
+  def afclGetsClassBytesFromParent(): Unit = {
+    val (fuzz, booz) = fuzzBuzzBooz
+    val (fuzz_, booz_) = fuzzBuzzBooz
+    booz writeContent "hello, world"
+    booz_ writeContent "hello, world_"
+
+    val p = new AbstractFileClassLoader(fuzz, NoClassLoader)
+    val x = new AbstractFileClassLoader(fuzz_, p)
+    val b = x.classBytes("buzz/booz.class")
+    assertEquals("hello, world", new String(b, UTF8.charSet))
+  }
+}


### PR DESCRIPTION
Let the AbstractFileClassLoader override just the usual suspects.

Normal delegation behavior should ensue.

That's instead of overriding `getResourceAsStream`, which was intended
that "The repl classloader now works more like you'd expect a classloader to."
(Workaround for "Don't know how to construct an URL for something which exists
only in memory.")

Also override `findResources` so that `getResources` does the obvious thing,
namely, return one if `getResource` does.  (If `getResources.size > 1`, the others come
from parent/system loaders.)

The translating class loader for REPL only special-cases `foo.class`: as
a fallback, take `foo` as `$line42.$read$something$foo` and try that class file.
That's the use case for "works like you'd expect it to."

There was a previous fix to ensure `getResource` doesn't take a class name.
The convenience behavior, that `classBytes` takes either a class name or a resource
path ending in ".class", has been promoted to `ScalaClassLoader`.

Review by @retronym 
