### PR TITLE
SI-8888 Avoid ClassFormatError under -Ydelambdafy:method

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
+++ b/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
@@ -260,7 +260,7 @@ abstract class Delambdafy extends Transform with TypingTransformers with ast.Tre
 
         val captureProxies2 = new LinkedHashMap[Symbol, TermSymbol]
         captures foreach {capture =>
-          val sym = lambdaClass.newVariable(capture.name.toTermName, capture.pos, SYNTHETIC)
+          val sym = lambdaClass.newVariable(unit.freshTermName(capture.name.toString + "$"), capture.pos, SYNTHETIC)
           sym setInfo capture.info
           captureProxies2 += ((capture, sym))
         }

--- a/test/files/run/t8888.flags
+++ b/test/files/run/t8888.flags
@@ -1,0 +1,1 @@
+-Ydelambdafy:method

--- a/test/files/run/t8888.scala
+++ b/test/files/run/t8888.scala
@@ -1,0 +1,12 @@
+class C {
+  final def resume: Unit = (this: Any) match {
+    case x : C => (x: Any) match {
+      case y : C =>
+        () => (x, y) // used to trigger a ClassFormatError under -Ydelambdafy:method
+    }
+  }
+}
+
+object Test extends App {
+  new C().resume
+}


### PR DESCRIPTION
The pattern matcher phase (conceivably, among others) can generate
code that binds local `Ident`s symbolically, rather than according
to the lexical scope. This means that a lambda can capture more than
one local of the same name.

In the enclosed test case, this ends up creating the following
tree after delambdafy

```
[[syntax trees at end of                delambdafy]] // delambday-patmat-path-dep.scala
matchEnd4({
  case <synthetic> val x1: Object = (x2: Object);
  case5(){
    if (x1.$isInstanceOf[C]())
      {
        <synthetic> val x2#19598: C = (x1.$asInstanceOf[C](): C);
        matchEnd4({
          {
            (new resume$1(x2#19598, x2#19639): runtime.AbstractFunction0)
          };
          scala.runtime.BoxedUnit.UNIT
        })
      }
    else
      case6()
  };
  ...
})
...
<synthetic> class resume$1 extends AbstractFunction0 {
  <synthetic> var x2: C = null;
  <synthetic> var x2: C = null;
  ...
}
```

After this commit, the var members of `resume$1` are given fresh
names, rather than directly using the name of the captured var:

```
<synthetic> var x2$3: C = null;
<synthetic> var x2$4: C = null;
```

Review by @lrytz or @gkossakowski
