### PR TITLE
SI-8890 handle reference to overload with error

### DIFF
--- a/test/files/neg/t8890.check
+++ b/test/files/neg/t8890.check
@@ -1,0 +1,4 @@
+t8890.scala:6: error: not found: type Str
+  def bar(x: Str): Unit = ???
+             ^
+one error found

--- a/test/files/neg/t8890.scala
+++ b/test/files/neg/t8890.scala
@@ -1,0 +1,11 @@
+package foo
+
+class A {
+  /** The other */
+  def bar(x: Int): Unit = ???
+  def bar(x: Str): Unit = ???
+}
+
+class B {
+  (new A).bar(0)
+}


### PR DESCRIPTION
We must report the ambiguity error to avoid a stack overflow.

TODO: should we simply always report? The test suite passes,
with the added test file reporting a valid second error.

review by @lrytz, cc @dragos 
