### PR TITLE
SI-8894 dealias when looking at tuple components

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -172,7 +172,6 @@ trait TreeAndTypeAnalysis extends Debugging {
     // a type is "uncheckable" (for exhaustivity) if we don't statically know its subtypes (i.e., it's unsealed)
     // we consider tuple types with at least one component of a checkable type as a checkable type
     def uncheckableType(tp: Type): Boolean = {
-      def tupleComponents(tp: Type) = tp.normalize.typeArgs
       val checkable = (
            (isTupleType(tp) && tupleComponents(tp).exists(tp => !uncheckableType(tp)))
         || enumerateSubtypes(tp).nonEmpty)

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -653,6 +653,7 @@ trait Definitions extends api.StandardDefinitions {
     // tends to change the course of events by forcing types.
     def isFunctionType(tp: Type)       = isFunctionTypeDirect(tp.dealiasWiden)
     def isTupleType(tp: Type)          = isTupleTypeDirect(tp.dealiasWiden)
+    def tupleComponents(tp: Type)      = tp.dealiasWiden.typeArgs
 
     lazy val ProductRootClass: ClassSymbol = requiredClass[scala.Product]
       def Product_productArity          = getMemberMethod(ProductRootClass, nme.productArity)
@@ -837,7 +838,7 @@ trait Definitions extends api.StandardDefinitions {
     def typeOfMemberNamedApply(tp: Type) = typeArgOfBaseTypeOr(tp, SeqClass)(resultOfMatchingMethod(tp, nme.apply)(IntTpe))
     def typeOfMemberNamedDrop(tp: Type)  = typeArgOfBaseTypeOr(tp, SeqClass)(resultOfMatchingMethod(tp, nme.drop)(IntTpe))
     def typesOfSelectors(tp: Type)       =
-      if (isTupleType(tp)) tp.typeArgs
+      if (isTupleType(tp)) tupleComponents(tp)
       else getterMemberTypes(tp, productSelectors(tp))
 
     // SI-8128 Still using the type argument of the base type at Seq/Option if this is an old-style (2.10 compatible)

--- a/test/files/pos/t8894.scala
+++ b/test/files/pos/t8894.scala
@@ -1,0 +1,12 @@
+class CC(val i: Int, val s: String)
+object CC extends {
+  type P = (Int, String)
+
+  //def unapply(c: CC): Option[(Int, String)] = Some((c.i, c.s)) // OK
+  def unapply(c: CC): Option[P] = Some((c.i, c.s)) // fails (because of the type alias)
+}
+
+class Test {
+  val cc = new CC(23, "foo")
+  val CC(i, s) = cc
+}


### PR DESCRIPTION
[Shooting from the hip here: did not run test suite.]

Classic bait-and-switch: `isTupleType` dealiases, but `typeArgs` does not.
When deciding with `isTupleType`, process using `tupleComponents`.
Similar for other combos. We should really enforce this using extractors,
and only decouple when performance is actually impacted.
