### PR TITLE
FSC / REPL Bug Bonanza

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -1499,20 +1499,13 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
         val residualTargs = symbol.info.typeParams zip baseTargs collect {
           case (tvar, targ) if !env.contains(tvar) || !isPrimitiveValueClass(env(tvar).typeSymbol) => targ
         }
-        // See SI-5583.  Don't know why it happens now if it didn't before.
-        if (specMember.info.typeParams.isEmpty && residualTargs.nonEmpty) {
-          devWarning("Type args to be applied, but symbol says no parameters: " + ((specMember.defString, residualTargs)))
-          baseTree
-        }
-        else {
-          ifDebug(assert(residualTargs.length == specMember.info.typeParams.length,
-            "residual: %s, tparams: %s, env: %s".format(residualTargs, specMember.info.typeParams, env))
-          )
+        ifDebug(assert(residualTargs.length == specMember.info.typeParams.length,
+          "residual: %s, tparams: %s, env: %s".format(residualTargs, specMember.info.typeParams, env))
+        )
 
-          val tree1 = gen.mkTypeApply(specTree, residualTargs)
-          debuglog("rewrote " + tree + " to " + tree1)
-          localTyper.typedOperator(atPos(tree.pos)(tree1)) // being polymorphic, it must be a method
-        }
+        val tree1 = gen.mkTypeApply(specTree, residualTargs)
+        debuglog("rewrote " + tree + " to " + tree1)
+        localTyper.typedOperator(atPos(tree.pos)(tree1)) // being polymorphic, it must be a method
       }
 
       curTree = tree

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -861,11 +861,6 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
           debuglog("%s expands to %s in %s".format(sym, specMember.name.decode, pp(env)))
           info(specMember) = NormalizedMember(sym)
           newOverload(sym, specMember, env)
-          // if this is a class, we insert the normalized member in scope,
-          // if this is a method, there's no attached scope for it (EmptyScope)
-          val decls = owner.info.decls
-          if (decls != EmptyScope)
-            decls.enter(specMember)
           specMember
         }
       }

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -904,12 +904,14 @@ trait Definitions extends api.StandardDefinitions {
         )
     }
 
-    def EnumType(sym: Symbol) =
+    def EnumType(sym: Symbol) = {
       // given (in java): "class A { enum E { VAL1 } }"
       //  - sym: the symbol of the actual enumeration value (VAL1)
       //  - .owner: the ModuleClassSymbol of the enumeration (object E)
       //  - .linkedClassOfClass: the ClassSymbol of the enumeration (class E)
-      sym.owner.linkedClassOfClass.tpe
+      // SI-6613 Subsequent runs of the resident compiler demand the phase discipline here.
+      enteringPhaseNotLaterThan(picklerPhase)(sym.owner.linkedClassOfClass).tpe
+    }
 
     /** Given a class symbol C with type parameters T1, T2, ... Tn
      *  which have upper/lower bounds LB1/UB1, LB1/UB2, ..., LBn/UBn,

--- a/test/files/res/t6613.check
+++ b/test/files/res/t6613.check
@@ -1,0 +1,5 @@
+
+nsc> 
+nsc> 
+nsc> 
+nsc> 

--- a/test/files/res/t6613.res
+++ b/test/files/res/t6613.res
@@ -1,0 +1,3 @@
+t6613/Enummy.java
+t6613/Broken.scala
+t6613/Broken.scala

--- a/test/files/res/t6613/Broken.scala
+++ b/test/files/res/t6613/Broken.scala
@@ -1,0 +1,1 @@
+class Broken() { def broken() = Enummy.Broke.CHIP }

--- a/test/files/res/t6613/Enummy.java
+++ b/test/files/res/t6613/Enummy.java
@@ -1,0 +1,1 @@
+public class Enummy { public enum Broke { SHARD, CHIP } }

--- a/test/files/res/t8871.check
+++ b/test/files/res/t8871.check
@@ -1,0 +1,5 @@
+
+nsc> 
+nsc> 
+nsc> 
+nsc> 

--- a/test/files/res/t8871.res
+++ b/test/files/res/t8871.res
@@ -1,0 +1,4 @@
+t8871/tag.scala
+t8871/usetag.scala
+t8871/usetag.scala
+

--- a/test/files/res/t8871/tag.scala
+++ b/test/files/res/t8871/tag.scala
@@ -1,0 +1,3 @@
+class Tag {
+  @inline def apply[@specialized A, T](a: A): A = a
+}

--- a/test/files/res/t8871/usetag.scala
+++ b/test/files/res/t8871/usetag.scala
@@ -1,0 +1,6 @@
+trait Foo
+
+object Test {
+  val y = new Tag().apply[Double, Foo](3.3)
+  // under FSC, this gave t8871/usetag.scala:4: error: wrong number of type parameters for method apply$mDc$sp: [T](a: Double)Double
+}


### PR DESCRIPTION
The big contribution here is to change `adaptInfos` to
start with a clean slate (a one element type history)
on subsequent runs. I did the same a while back for package
classes, this is an generalization of that idea. This ensures
that all info transformers are run, importantly the side-effecty
ones.

This fixes a regression in specialization in the REPL, which
was a latent bug uncovered by our recent fix to `perRunCaches`.

The other changes are similarly themed, being more disciplined
when reading or mutating the type history.

Submitting for a test run and initial review by @lrytz. The commit
messages might need some fleshing out as I've been a little bit
hand wavy in a few of my explanations where I wasn't able to
precisely explain _why_ the fix works.
