### PR TITLE
SI-6723 Don't count `@inline` methods when computing the inline budget

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/opt/Inliners.scala
+++ b/src/compiler/scala/tools/nsc/backend/opt/Inliners.scala
@@ -420,6 +420,7 @@ abstract class Inliners extends SubComponent {
           || isApply
           || isMonadicMethod(concreteMethod)
           || receiver.enclosingPackage == definitions.RuntimePackage
+          || concreteMethod.hasAnnotation(ScalaInlineClass)
         )   // only count non-closures
 
         debuglog("Treating " + i

--- a/test/files/pos/t6723.flags
+++ b/test/files/pos/t6723.flags
@@ -1,0 +1,1 @@
+-optimize -Xfatal-warnings -Yinline-warnings

--- a/test/files/pos/t6723.scala
+++ b/test/files/pos/t6723.scala
@@ -1,0 +1,47 @@
+object O {
+  @inline def f(a: Int, b: Int) = a + b
+
+  // this test should not generate any inliner warnings
+
+  def g(a: Int, b: Int) =
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b) +
+    f(a, b)
+
+  def h = Map(
+    "a" -> 0, "b" -> 1, "c" -> 2, "d" -> 3, "e" -> 4,
+    "a" -> 0, "b" -> 1, "c" -> 2, "d" -> 3, "e" -> 4,
+    "a" -> 0, "b" -> 1, "c" -> 2, "d" -> 3, "e" -> 4,
+    "a" -> 0, "b" -> 1, "c" -> 2, "d" -> 3, "e" -> 4,
+    "a" -> 0, "b" -> 1, "c" -> 2, "d" -> 3, "e" -> 4,
+    "a" -> 0, "b" -> 1, "c" -> 2, "d" -> 3, "e" -> 4,
+    "f" -> 5, "g" -> 6, "h" -> 7, "i" -> 8)
+}


### PR DESCRIPTION
Otherwise the inlining budged exceeds when many `@inline` methods are
invoked. This triggers inline warnings for those that aren't inlined
anymore.
