### PR TITLE
SI-8875 showCode should print all class constructor modifiers.

### DIFF
--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -761,7 +761,7 @@ trait Printers extends api.Printers { self: SymbolTable =>
             val build.SyntacticClassDef(_, _, _, ctorMods, vparamss, earlyDefs, parents, selfType, body) = cl
 
             // constructor's modifier
-            if (ctorMods.hasFlag(AccessFlags)) {
+            if (ctorMods.hasFlag(AccessFlags) || ctorMods.hasAccessBoundary) {
               print(" ")
               printModifiers(ctorMods, primaryCtorParam = false)
             }

--- a/test/junit/scala/reflect/internal/PrintersTest.scala
+++ b/test/junit/scala/reflect/internal/PrintersTest.scala
@@ -354,6 +354,13 @@ trait ClassPrintTests {
     |  def y = "test"
     |}""")
 
+  @Test def testClassConstructorModifiers = assertPrintedCode("class X private (x: scala.Int)")
+
+  @Test def testClassConstructorModifierVisibility = assertPrintedCode(sm"""
+    |object A {
+    |  class X protected[A] (x: scala.Int)
+    |}""")
+
   @Test def testClassWithPublicParams = assertPrintedCode("class X(val x: scala.Int, val s: scala.Predef.String)")
 
   @Test def testClassWithParams1 = assertPrintedCode("class X(x: scala.Int, s: scala.Predef.String)")


### PR DESCRIPTION
showCode used to print nothing when the only modifier was a change in
visibility scope (i.e. no flags but privateWithin is set).
