### PR TITLE
SI-8711 ScalaVersion.unparse doesn't produce valid versions

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaVersion.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaVersion.scala
@@ -34,7 +34,7 @@ case object NoScalaVersion extends ScalaVersion {
  * to segregate builds
  */
 case class SpecificScalaVersion(major: Int, minor: Int, rev: Int, build: ScalaBuild) extends ScalaVersion {
-  def unparse = s"${major}.${minor}.${rev}.${build.unparse}"
+  def unparse = s"${major}.${minor}.${rev}${build.unparse}"
 
   def compare(that: ScalaVersion): Int =  that match {
     case SpecificScalaVersion(thatMajor, thatMinor, thatRev, thatBuild) =>

--- a/test/junit/scala/tools/nsc/settings/ScalaVersionTest.scala
+++ b/test/junit/scala/tools/nsc/settings/ScalaVersionTest.scala
@@ -1,0 +1,18 @@
+package scala.tools.nsc
+package settings
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import scala.tools.testing.AssertUtil.assertThrows
+
+@RunWith(classOf[JUnit4])
+class ScalaVersionTest {
+  // SI-8711
+  @Test def versionUnparse() {
+    val v = "2.11.3"
+
+    assertEquals(ScalaVersion(v).unparse, v)
+  }
+}


### PR DESCRIPTION
There is no dot between `major.minor.rev` and `-build` in a scala
version, yet that's what unparse returns for:

```
// was "2.11.3.-SNAPSHOT"
ScalaVersion("2.11.3-SNAPSHOT").unparse
```
