### PR TITLE
SI-8900 Don't assert !isDelambdafyFunction, it may not be accurate

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeAsmCommon.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeAsmCommon.scala
@@ -30,10 +30,10 @@ final class BCodeAsmCommon[G <: Global](val global: G) {
    */
   def isAnonymousOrLocalClass(classSym: Symbol): Boolean = {
     assert(classSym.isClass, s"not a class: $classSym")
-    val res = (classSym.isAnonymousClass || !classSym.originalOwner.isClass)
-    // lambda classes are always top-level classes.
-    if (res) assert(!classSym.isDelambdafyFunction)
-    res
+    // Here used to be an `assert(!classSym.isDelambdafyFunction)`: delambdafy lambda classes are
+    // always top-level. However, SI-8900 shows an example where the weak name-based implementation
+    // of isDelambdafyFunction failed (for a function declared in a package named "lambda").
+    classSym.isAnonymousClass || !classSym.originalOwner.isClass
   }
 
   /**

--- a/test/files/pos/t8900.scala
+++ b/test/files/pos/t8900.scala
@@ -1,0 +1,11 @@
+package foo
+package lambdaking
+
+class Test {
+  def byname(b: => Any) = ???
+  def foo: Any = {
+    def bar: Any = {
+      byname(bar)
+    }
+  }
+}


### PR DESCRIPTION
The implementations of isAnonymousClass, isAnonymousFunction,
isDelambdafyFunction and isDefaultGetter check if a specific substring
(eg "$lambda") exists in the symbol's name.

SI-8900 shows an example where a class ends up with "$lambda" in its
name even though it's not a delambdafy lambda class. In this case the
conflict seems to be introduced by a macro. It is possible that the
compiler itself never introduces such names, but in any case, the
above methods should be implemented more robustly.

This commit is band-aid, it fixes one specific known issue, but there
are many calls to the mentioned methods across the compiler which
are potentially wrong.
