### PR TITLE
SI-8910 BitSet sometimes uses exponential memory.

### DIFF
--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -110,7 +110,7 @@ class BitSet(protected final var elems: Array[Long]) extends AbstractSet[Int]
    *  @return  the bitset itself.
    */
   def |= (other: BitSet): this.type = {
-    ensureCapacity(other.nwords)
+    ensureCapacity(other.nwords - 1)
     for (i <- 0 until other.nwords)
       elems(i) = elems(i) | other.word(i)
     this
@@ -121,7 +121,7 @@ class BitSet(protected final var elems: Array[Long]) extends AbstractSet[Int]
    *  @return  the bitset itself.
    */
   def &= (other: BitSet): this.type = {
-    ensureCapacity(other.nwords)
+    ensureCapacity(other.nwords - 1)
     for (i <- 0 until other.nwords)
       elems(i) = elems(i) & other.word(i)
     this
@@ -132,7 +132,7 @@ class BitSet(protected final var elems: Array[Long]) extends AbstractSet[Int]
    *  @return  the bitset itself.
    */
   def ^= (other: BitSet): this.type = {
-    ensureCapacity(other.nwords)
+    ensureCapacity(other.nwords - 1)
     for (i <- 0 until other.nwords)
       elems(i) = elems(i) ^ other.word(i)
     this
@@ -143,7 +143,7 @@ class BitSet(protected final var elems: Array[Long]) extends AbstractSet[Int]
    *  @return  the bitset itself.
    */
   def &~= (other: BitSet): this.type = {
-    ensureCapacity(other.nwords)
+    ensureCapacity(other.nwords - 1)
     for (i <- 0 until other.nwords)
       elems(i) = elems(i) & ~other.word(i)
     this

--- a/test/files/run/t8910.scala
+++ b/test/files/run/t8910.scala
@@ -1,0 +1,13 @@
+object Test extends App {
+  val bitset = new scala.collection.mutable.BitSet()
+  val size   = bitset.toBitMask.length
+  // Ensure the size of the BitSet doesn't change after certain operations.
+  bitset ^= bitset
+  assert(bitset.toBitMask.length == size, "Size of bitset changed after ^=")
+  bitset |= bitset
+  assert(bitset.toBitMask.length == size, "Size of bitset changed after |=")
+  bitset &= bitset
+  assert(bitset.toBitMask.length == size, "Size of bitset changed after &=")
+  bitset &~= bitset
+  assert(bitset.toBitMask.length == size, "Size of bitset changed after &~=")
+}


### PR DESCRIPTION
Because of an off-by-one error in scala.collection.mutable.BitSet, where a function (ensureCapacity) is passed a length list instead of an index, when ^=, &=, |=, or &~= are passed BitSets with the same internal capacity as the set the method is being invoked on, the size of the first BitSet is needlessly doubled.

This patch simply changes the ensureCapacity calls to pass the last index of the list, instead of the raw length.
