### PR TITLE
SI-6502 Reenables loading jars into the running REPL (regression in 2.10)

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -845,7 +845,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
 
   /** Is given package class a system package class that cannot be invalidated?
    */
-  private def isSystemPackageClass(pkg: Symbol) = 
+  private def isSystemPackageClass(pkg: Symbol) =
     pkg == RootClass || (pkg.hasTransOwner(definitions.ScalaPackageClass) && !pkg.hasTransOwner(this.rootMirror.staticPackage("scala.tools").moduleClass.asClass))
 
   /** Invalidates packages that contain classes defined in a classpath entry, and

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -846,34 +846,10 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
 
   /** Extend classpath of `platform` and rescan updated packages. */
   def extendCompilerClassPath(urls: URL*): Unit = {
-    val newClassPath = mergeUrlsIntoClassPath(platform, urls: _*)
+    val newClassPath = platform.classPath.mergeUrlsIntoClassPath(urls: _*)
     platform.currentClassPath = Some(newClassPath)
     // Reload all specified jars into this compiler instance
     invalidateClassPathEntries(urls.map(_.getPath): _*)
-  }
-
-  /** Merge classpath of `platform` and `urls` into merged classpath */
-  def mergeUrlsIntoClassPath(platform: JavaPlatform, urls: URL*): MergedClassPath[AbstractFile] = {
-    // Collect our new jars/directories and add them to the existing set of classpaths
-    val prevEntries = platform.classPath match {
-      case mcp: MergedClassPath[AbstractFile] => mcp.entries
-      case cp:  ClassPath[AbstractFile]       => List(cp)
-    }
-    val allEntries = (prevEntries ++
-      urls.map(url => platform.classPath.context.newClassPath(
-          if (url.getProtocol == "file") {
-            val f = new File(url.getPath)
-            if (f.isDirectory) io.AbstractFile.getDirectory(f)
-            else io.AbstractFile.getFile(f)
-          } else {
-            io.AbstractFile.getURL(url)
-          }
-        )
-      )
-    ).distinct
-
-    // Combine all of our classpaths (old and new) into one merged classpath
-    new MergedClassPath(allEntries, platform.classPath.context)
   }
 
   // ------------ Invalidations ---------------------------------

--- a/src/compiler/scala/tools/nsc/backend/JavaPlatform.scala
+++ b/src/compiler/scala/tools/nsc/backend/JavaPlatform.scala
@@ -16,7 +16,7 @@ trait JavaPlatform extends Platform {
   import global._
   import definitions._
 
-  private var currentClassPath: Option[MergedClassPath[AbstractFile]] = None
+  private[nsc] var currentClassPath: Option[MergedClassPath[AbstractFile]] = None
 
   def classPath: ClassPath[AbstractFile] = {
     if (currentClassPath.isEmpty) currentClassPath = Some(new PathResolver(settings).result)

--- a/src/reflect/scala/reflect/io/AbstractFile.scala
+++ b/src/reflect/scala/reflect/io/AbstractFile.scala
@@ -48,14 +48,16 @@ object AbstractFile {
     else null
 
   /**
-   * If the specified URL exists and is a readable zip or jar archive,
-   * returns an abstract directory backed by it. Otherwise, returns
-   * `null`.
+   * If the specified URL exists and is a regular file or a directory, returns an
+   * abstract regular file or an abstract directory, respectively, backed by it.
+   * Otherwise, returns `null`.
    */
-  def getURL(url: URL): AbstractFile = {
-    if (url == null || !Path.isExtensionJarOrZip(url.getPath)) null
-    else ZipArchive fromURL url
-  }
+  def getURL(url: URL): AbstractFile =
+    if (url.getProtocol == "file") {
+      val f = new java.io.File(url.getPath)
+      if (f.isDirectory) getDirectory(f)
+      else getFile(f)
+    } else null
 
   def getResources(url: URL): AbstractFile = ZipArchive fromManifestURL url
 }

--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -221,7 +221,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     nullary("power", "enable power user mode", powerCmd),
     nullary("quit", "exit the interpreter", () => Result(keepRunning = false, None)),
     cmd("replay", "[options]", "reset the repl and replay all previous commands", replayCommand),
-    //cmd("require", "<path>", "add a jar or directory to the classpath", require),  // TODO
+    cmd("require", "<path>", "add a jar or directory to the classpath", require),
     cmd("reset", "[options]", "reset the repl to its initial state, forgetting all session entries", resetCommand),
     cmd("save", "<path>", "save replayable session to a file", saveCommand),
     shCommand,
@@ -612,11 +612,71 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     val f = File(arg).normalize
     if (f.exists) {
       addedClasspath = ClassPath.join(addedClasspath, f.path)
-      val totalClasspath = ClassPath.join(settings.classpath.value, addedClasspath)
-      echo("Added '%s'.  Your new classpath is:\n\"%s\"".format(f.path, totalClasspath))
-      replay()
+      intp.addUrlsToClassPath(f.toURI.toURL)
+      echo("Added '%s'.  Your new classpath is:\n\"%s\"".format(f.path, intp.global.classPath.asClasspathString))
     }
     else echo("The path '" + f + "' doesn't seem to exist.")
+  }
+
+  /** Adds jar file to the current classpath. Jar will only be added if it
+   *  does not contain classes that already exist on the current classpath.
+   *
+   *  Importantly, `require` adds jars to the classpath ''without'' resetting
+   *  the state of the interpreter. This is in contrast to `replay` which can
+   *  be used to add jars to the classpath and which creates a new instance of
+   *  the interpreter and replays all interpreter expressions.
+   */
+  def require(arg: String): Unit = {
+    class InfoClassLoader extends java.lang.ClassLoader {
+      def classOf(arr: Array[Byte]): Class[_] =
+        super.defineClass(null, arr, 0, arr.length)
+    }
+
+    def readFully(is: InputStream): Array[Byte] = {
+      val dis = new java.io.DataInputStream(is)
+      val len = dis.available()
+      val arr = Array.ofDim[Byte](len)
+      dis.readFully(arr)
+      dis.close()
+      arr
+    }
+
+    val f = File(arg).normalize
+
+    if (f.isDirectory) {
+      echo("Adding directories to the classpath is not supported. Add a jar instead.")
+      return
+    }
+    val jarFile = new java.util.jar.JarFile(arg)
+    val entries = jarFile.entries
+    val cloader = new InfoClassLoader
+    var exists = false
+
+    while (entries.hasMoreElements()) {
+      val entry = entries.nextElement()
+      // skip directories and manifests
+      if (!entry.isDirectory() && !entry.getName().endsWith("MF")) {
+        // for each entry get InputStream
+        val is = jarFile.getInputStream(entry)
+        // read InputStream into Array[Byte]
+        val arr = readFully(is)
+        val clazz = cloader.classOf(arr)
+        try {
+          Class.forName(clazz.getName(), false, intp.classLoader)
+          exists = true
+        } catch {
+          case _: ClassNotFoundException => /* do nothing */
+        }
+      }
+    }
+
+    if (f.exists && !exists) {
+      addedClasspath = ClassPath.join(addedClasspath, f.path)
+      intp.addUrlsToClassPath(f.toURI.toURL)
+      echo("Added '%s'.  Your new classpath is:\n\"%s\"".format(f.path, intp.global.classPath.asClasspathString))
+    } else if (exists) {
+      echo("The path '" + f + "' cannot be loaded, because existing classpath entries conflict.")
+    } else echo("The path '" + f + "' doesn't seem to exist.")
   }
 
   def powerCmd(): Result = {

--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -652,8 +652,8 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
 
     val jarFile = AbstractFile.getDirectory(new java.io.File(arg))
 
-    def flatten(f: AbstractFile): Iterator[AbstractFile] = 
-      if (f.isClassContainer) f.iterator.flatMap(flatten) 
+    def flatten(f: AbstractFile): Iterator[AbstractFile] =
+      if (f.isClassContainer) f.iterator.flatMap(flatten)
       else Iterator(f)
 
     val entries = flatten(jarFile)
@@ -669,13 +669,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
         // read InputStream into Array[Byte]
         val arr = readFully(is)
         val clazz = cloader.classOf(arr)
-        try {
-          // pass initialize = false because we don't want to execute class initializers:
-          Class.forName(clazz.getName(), false, intp.classLoader)
-          exists = true
-        } catch {
-          case _: ClassNotFoundException => /* do nothing */
-        }
+        if ((intp.classLoader tryToLoadClass clazz.getName).isDefined) exists = true
       }
     }
 

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -86,8 +86,7 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
   private var _classLoader: util.AbstractFileClassLoader = null                              // active classloader
   private val _compiler: ReplGlobal                 = newCompiler(settings, reporter)   // our private compiler
 
-  private trait ExposeAddUrl extends URLClassLoader { def addNewUrl(url: URL) = this.addURL(url) }
-  private var _runtimeClassLoader: URLClassLoader with ExposeAddUrl = null              // wrapper exposing addURL
+  private var _runtimeClassLoader: URLClassLoader = null              // wrapper exposing addURL
 
   def compilerClasspath: Seq[java.net.URL] = (
     if (isInitializeComplete) global.classPath.asURLs
@@ -252,7 +251,7 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
    */
   def addUrlsToClassPath(urls: URL*): Unit = {
     new Run //  force some initialization
-    urls.foreach(_runtimeClassLoader.addNewUrl) // Add jars to runtime classloader
+    urls.foreach(_runtimeClassLoader.addURL) // Add jars to runtime classloader
     extendCompilerClassPath(urls: _*)           // Add jars to compile-time classpath
   }
 
@@ -381,7 +380,7 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
   }
   private def makeClassLoader(): util.AbstractFileClassLoader =
     new TranslatingClassLoader({
-      _runtimeClassLoader = new URLClassLoader(compilerClasspath, parentClassLoader) with ExposeAddUrl
+      _runtimeClassLoader = new URLClassLoader(compilerClasspath, parentClassLoader)
       _runtimeClassLoader
     })
 

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -252,39 +252,7 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
   def addUrlsToClassPath(urls: URL*): Unit = {
     new Run //  force some initialization
     urls.foreach(_runtimeClassLoader.addURL) // Add jars to runtime classloader
-    extendCompilerClassPath(urls: _*)           // Add jars to compile-time classpath
-  }
-
-  /** Extend classpath of global.platform and force `global` to rescan updated packages. */
-  protected def extendCompilerClassPath(urls: URL*): Unit = {
-    val newClassPath = mergeUrlsIntoClassPath(global.platform, urls: _*)
-    global.platform.currentClassPath = Some(newClassPath)
-    // Reload all specified jars into the current compiler instance (global)
-    global.invalidateClassPathEntries(urls.map(_.getPath): _*)
-  }
-
-  /** Merge classpath of `platform` and `urls` into merged classpath */
-  protected def mergeUrlsIntoClassPath(platform: JavaPlatform, urls: URL*): MergedClassPath[AbstractFile] = {
-    // Collect our new jars/directories and add them to the existing set of classpaths
-    val prevEntries = platform.classPath match {
-      case mcp: MergedClassPath[AbstractFile] => mcp.entries
-      case cp:  ClassPath[AbstractFile]       => List(cp)
-    }
-    val allEntries = (prevEntries ++
-      urls.map(url => platform.classPath.context.newClassPath(
-          if (url.getProtocol == "file") {
-            val f = new File(url.getPath)
-            if (f.isDirectory) io.AbstractFile.getDirectory(f)
-            else io.AbstractFile.getFile(f)
-          } else {
-            io.AbstractFile.getURL(url)
-          }
-        )
-      )
-    ).distinct
-
-    // Combine all of our classpaths (old and new) into one merged classpath
-    new MergedClassPath(allEntries, platform.classPath.context)
+    global.extendCompilerClassPath(urls: _*) // Add jars to compile-time classpath
   }
 
   /** Parent classloader.  Overridable. */

--- a/test/files/run/t6502.check
+++ b/test/files/run/t6502.check
@@ -1,0 +1,8 @@
+test1 res1: true
+test1 res2: true
+test2 res1: true
+test2 res2: true
+test3 res1: true
+test3 res2: true
+test4 res1: true
+test4 res2: true

--- a/test/files/run/t6502.scala
+++ b/test/files/run/t6502.scala
@@ -1,0 +1,101 @@
+import scala.tools.partest._
+import java.io.File
+import scala.tools.nsc.interpreter.ILoop
+
+object Test extends StoreReporterDirectTest {
+  def code = ???
+
+  def compileCode(code: String, jarFileName: String) = {
+    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
+    compileString(newCompiler("-cp", classpath, "-d", s"${testOutput.path}/$jarFileName"))(code)
+  }
+
+  def app1 = """
+    package test
+
+    object Test extends App {
+      def test(): Unit = {
+        println("testing...")
+      }
+    }"""
+
+  def app2 = """
+    package test
+
+    object Test extends App {
+      def test(): Unit = {
+        println("testing differently...")
+      }
+    }"""
+
+  def app3 = """
+    package test
+
+    object Test3 extends App {
+      def test(): Unit = {
+        println("new object in existing package")
+      }
+    }"""
+
+  def test1(): Unit = {
+    val jar = "test1.jar"
+    compileCode(app1, jar)
+
+    val output = ILoop.run(List(s":require ${testOutput.path}/$jar", "test.Test.test()"))
+    val lines  = output.split("\n")
+    val res1   = lines(4).contains("Added") && lines(4).contains("test1.jar")
+    val res2   = lines(lines.length-3).contains("testing...")
+
+    println(s"test1 res1: $res1")
+    println(s"test1 res2: $res2")
+  }
+
+  def test2(): Unit = {
+    // should reject jars with conflicting entries
+    val jar1 = "test1.jar"
+    val jar2 = "test2.jar"
+    compileCode(app2, jar2)
+
+    val output = ILoop.run(List(s":require ${testOutput.path}/$jar1", s":require ${testOutput.path}/$jar2"))
+    val lines  = output.split("\n")
+    val res1   = lines(4).contains("Added") && lines(4).contains("test1.jar")
+    val res2   = lines(lines.length-3).contains("test2.jar") && lines(lines.length-3).contains("existing classpath entries conflict")
+
+    println(s"test2 res1: $res1")
+    println(s"test2 res2: $res2")
+  }
+
+  def test3(): Unit = {
+    // should accept jars with overlapping packages, but no conflicts
+    val jar1 = "test1.jar"
+    val jar3 = "test3.jar"
+    compileCode(app3, jar3)
+
+    val output = ILoop.run(List(s":require ${testOutput.path}/$jar1", s":require ${testOutput.path}/$jar3", "test.Test3.test()"))
+    val lines  = output.split("\n")
+    val res1   = lines(4).contains("Added") && lines(4).contains("test1.jar")
+    val res2   = lines(lines.length-3).contains("new object in existing package")
+
+    println(s"test3 res1: $res1")
+    println(s"test3 res2: $res2")
+  }
+
+  def test4(): Unit = {
+    // twice the same jar should be rejected
+    val jar1   = "test1.jar"
+    val output = ILoop.run(List(s":require ${testOutput.path}/$jar1", s":require ${testOutput.path}/$jar1"))
+    val lines  = output.split("\n")
+    val res1   = lines(4).contains("Added") && lines(4).contains("test1.jar")
+    val res2   = lines(lines.length-3).contains("test1.jar") && lines(lines.length-3).contains("existing classpath entries conflict")
+
+    println(s"test4 res1: $res1")
+    println(s"test4 res2: $res2")
+  }
+
+  def show(): Unit = {
+    test1()
+    test2()
+    test3()
+    test4()
+  }
+}


### PR DESCRIPTION
Fixes [SI-6502](https://issues.scala-lang.org/browse/SI-6502), reenables loading jars into the running REPL (regression in 2.10). This PR allows adding a jar to the compile and runtime classpaths without resetting the REPL state (crucial for Spark [SPARK-3257](issues.apache.org/jira/browse/SPARK-3257)).

This follows the lead taken by @som-snytt in PR [#3986](https://github.com/scala/scala/pull/3986), which differentiates two jar-loading behaviors (muddled by `cp`):
- adding jars and replaying REPL expressions (using `replay`)
- adding jars without resetting the REPL (deprecated `cp`, introduced `require`)
  This PR implements `require` (left unimplemented in [#3986](https://github.com/scala/scala/pull/3986))

This PR is a simplification of a similar approach taken by @gkossakowski in #3884. In this attempt, we check first to make sure that a jar is only added if it only contains _new_ classes/traits/objects, otherwise we emit an error. This differs from the old invalidation approach which also tracked deleted classpath entries.
