### PR TITLE
SI-8922 REPL load -v

### DIFF
--- a/src/compiler/scala/tools/nsc/Properties.scala
+++ b/src/compiler/scala/tools/nsc/Properties.scala
@@ -14,7 +14,9 @@ object Properties extends scala.util.PropertiesTrait {
   // settings based on jar properties, falling back to System prefixed by "scala."
   def residentPromptString = scalaPropOrElse("resident.prompt", "\nnsc> ")
   def shellPromptString    = scalaPropOrElse("shell.prompt", "\nscala> ")
-  def shellInterruptedString = scalaPropOrElse("shell.interrupted", ":quit\n")
+  // message to display at EOF (which by default ends with
+  // a newline so as not to break the user's terminal)
+  def shellInterruptedString = scalaPropOrElse("shell.interrupted", f":quit$lineSeparator")
 
   // derived values
   def isEmacsShell         = propOrEmpty("env.emacs") != ""

--- a/src/repl/scala/tools/nsc/interpreter/LoopCommands.scala
+++ b/src/repl/scala/tools/nsc/interpreter/LoopCommands.scala
@@ -76,6 +76,9 @@ trait LoopCommands {
     // the default result means "keep running, and don't record that line"
     val default = Result(keepRunning = true, None)
 
+    // "keep running, and record this line"
+    def recording(line: String) = Result(keepRunning = true, Option(line))
+
     // most commands do not want to micromanage the Result, but they might want
     // to print something to the console, so we accomodate Unit and String returns.
     implicit def resultFromUnit(x: Unit): Result = default
@@ -85,4 +88,3 @@ trait LoopCommands {
     }
   }
 }
-

--- a/src/repl/scala/tools/nsc/interpreter/SimpleReader.scala
+++ b/src/repl/scala/tools/nsc/interpreter/SimpleReader.scala
@@ -22,14 +22,19 @@ extends InteractiveReader
 
   def reset() = ()
   def redrawLine() = ()
-  def readOneLine(prompt: String): String = {
-    if (interactive) {
-      out.print(prompt)
-      out.flush()
-    }
-    in.readLine()
+
+  // InteractiveReader internals
+  protected def readOneLine(prompt: String): String = {
+    echo(prompt)
+    readOneLine()
   }
-  def readOneKey(prompt: String)  = sys.error("No char-based input in SimpleReader")
+  protected def readOneKey(prompt: String) = sys.error("No char-based input in SimpleReader")
+
+  protected def readOneLine(): String = in.readLine()
+  protected def echo(s: String): Unit = if (interactive) {
+    out.print(s)
+    out.flush()
+  }
 }
 
 object SimpleReader {
@@ -38,4 +43,14 @@ object SimpleReader {
 
   def apply(in: BufferedReader = defaultIn, out: JPrintWriter = defaultOut, interactive: Boolean = true): SimpleReader =
     new SimpleReader(in, out, interactive)
+}
+
+// pretend we are a console for verbose purposes
+trait EchoReader extends SimpleReader {
+  // if there is more input, then maybe echo the prompt and the input
+  override def readOneLine(prompt: String) = {
+    val input = readOneLine()
+    if (input != null) echo(f"$prompt$input%n")
+    input
+  }
 }


### PR DESCRIPTION
Verbose mode causes the familiar prompt and
line echo so you can see what you just loaded.

The quit message is pushed up a level in the
process loop.

This has the huge payoff that if you start the
repl and immediately hit ctl-D, you don't have to
wait for the compiler to init (yawn) before you
get a shell prompt back.

Review by @gourlaysama 
