### PR TITLE
Proper cleanup after finishing global-showdef test

### DIFF
--- a/test/files/run/global-showdef.scala
+++ b/test/files/run/global-showdef.scala
@@ -1,8 +1,6 @@
 import scala.tools.nsc._
-import scala.reflect.io.AbstractFile
 import scala.tools.nsc.util.stringFromStream
 import scala.reflect.internal.util.{ SourceFile, BatchSourceFile }
-import scala.tools.nsc.reporters.ConsoleReporter
 
 object Test {
   val src: SourceFile = new BatchSourceFile("src", """
@@ -36,7 +34,8 @@ object Bippy {
 
   def mkCompiler(args: String*) = {
     val settings             = new Settings()
-    val command              = new CompilerCommand("-usejavacp" :: args.toList, settings)
+    val testOutputPath       = sys.props("partest.output")
+    val command              = new CompilerCommand("-usejavacp" :: "-d" :: testOutputPath :: args.toList, settings)
 
     new Global(settings)
   }


### PR DESCRIPTION
The temporary foo directory with classes created by global-showdef.scala was not deleted after finishing a test. When I was running tests from Scala project root, this directory was created there and was visible when running git status.

I just forced the creation of a foo directory inside global-showdef-run.obj - so it's properly deleted after finishing the test.
