### PR TITLE
Make global-showdef a DirectTest

### DIFF
--- a/test/files/run/global-showdef.check
+++ b/test/files/run/global-showdef.check
@@ -1,14 +1,14 @@
 <<-- class foo.bar.Bippy after phase 'typer' -->>
   def showdefTestMemberClass1: Int
+<<-- object foo.bar.Bippy after phase 'typer' -->>
+  def showdefTestMemberObject2: String
 <<-- type foo.bar.Bippy.BippyType after phase 'typer' -->>
   def showdefTestMemberType1: Unit
+<<-- object foo.bar.Bippy.Boppity.Boo after phase 'typer' -->>
+  def showdefTestMemberObject1: String
 <<-- type foo.bar.Bippy.BippyType after phase 'typer' -->>
   def showdefTestMemberType2: Unit
 <<-- class foo.bar.Bippy.Boppity after phase 'typer' -->>
   def showdefTestMemberClass2: Int
 <<-- class foo.bar.Bippy.Boppity.Boo after phase 'typer' -->>
   def showdefTestMemberClass3: Int
-<<-- object foo.bar.Bippy after phase 'typer' -->>
-  def showdefTestMemberObject2: String
-<<-- object foo.bar.Bippy.Boppity.Boo after phase 'typer' -->>
-  def showdefTestMemberObject1: String

--- a/test/files/run/global-showdef.scala
+++ b/test/files/run/global-showdef.scala
@@ -2,7 +2,7 @@ import scala.tools.partest.DirectTest
 import scala.tools.nsc.util.stringFromStream
 
 object Test extends DirectTest {
-  override def extraSettings: String = "-usejavacp -Yshow:typer"
+  override def extraSettings: String = "-usejavacp -Yshow:typer -Ystop-after:typer"
 
   override def code = """
 package foo.bar
@@ -41,8 +41,10 @@ object Bippy {
 
     def run(args: String*) = slurp(args: _*).lines filter interesting foreach println
 
-    classes foreach (x => run("-Xshow-class", x))
-    objects foreach (x => run("-Xshow-object", x))
+    classes.zipAll(objects, "", "") foreach {
+      case (c, "") => run("-Xshow-class", c)
+      case (c, o)  => run("-Xshow-class", c, "-Xshow-object", o)
+    }
   }
 
   // slurp the compilation result


### PR DESCRIPTION
The test test/files/run/global-showdef.scala was outputting
to the cwd instead of the test output dir.

Good behavior is now inherited from DirectTest.

Test frameworks, of any ilk or capability, rock.

Issue was revealed by https://github.com/scala/scala/pull/4024

Review by @retronym 
