### PR TITLE
SI-8927 Update OSGi stuff to get rid of bndlib warning

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -272,28 +272,36 @@ TODO:
       </artifact:dependencies>
 
       <!-- JUnit -->
-      <property name="junit.version" value="4.10"/>
+      <property name="junit.version" value="4.11"/>
       <artifact:dependencies pathId="junit.classpath" filesetId="junit.fileset">
         <dependency groupId="junit" artifactId="junit" version="${junit.version}"/>
       </artifact:dependencies>
       <copy-deps project="junit"/>
 
       <!-- Pax runner -->
-      <property name="pax.exam.version" value="2.6.0"/>
+      <property name="pax.exam.version" value="3.5.0"/><!-- Last version which supports Java 6 -->
+      <property name="osgi.felix.version" value="4.0.3"/>
+      <property name="osgi.equinox.version" value="3.7.1"/>
       <artifact:dependencies pathId="pax.exam.classpath" filesetId="pax.exam.fileset">
-        <dependency groupId="org.ops4j.pax.exam" artifactId="pax-exam-container-native" version="${pax.exam.version}"/>
+        <dependency groupId="org.ops4j.pax.exam" artifactId="pax-exam-container-native" version="${pax.exam.version}">
+          <exclusion groupId="org.osgi" artifactId="org.osgi.core"/><!-- Avoid dragging in a dependency which requires Java >6 -->
+        </dependency>
         <dependency groupId="org.ops4j.pax.exam" artifactId="pax-exam-junit4" version="${pax.exam.version}"/>
         <dependency groupId="org.ops4j.pax.exam" artifactId="pax-exam-link-assembly" version="${pax.exam.version}"/>
-        <!-- upgraded to 1.6.0 to get fix for https://ops4j1.jira.com/browse/PAXURL-217
-      https://ops4j1.jira.com/browse/PAXURL-138 is still unresolved... -->
-        <dependency groupId="org.ops4j.pax.url" artifactId="pax-url-aether" version="1.6.0"/>
-        <dependency groupId="org.ops4j.pax.swissbox" artifactId="pax-swissbox-framework" version="1.5.1"/>
-        <dependency groupId="ch.qos.logback" artifactId="logback-core" version="0.9.20"/>
-        <dependency groupId="ch.qos.logback" artifactId="logback-classic" version="0.9.20"/>
+        <dependency groupId="org.ops4j.pax.url" artifactId="pax-url-aether" version="2.2.0"/>
+        <dependency groupId="org.ops4j.pax.swissbox" artifactId="pax-swissbox-tracker" version="1.8.0"/>
+        <dependency groupId="ch.qos.logback" artifactId="logback-core" version="1.1.2"/>
+        <dependency groupId="ch.qos.logback" artifactId="logback-classic" version="1.1.2"/>
         <dependency groupId="junit" artifactId="junit" version="${junit.version}"/>
-        <dependency groupId="org.apache.felix" artifactId="org.apache.felix.framework" version="3.2.2"/>
       </artifact:dependencies>
 
+      <artifact:dependencies pathId="osgi.framework.felix">
+        <dependency groupId="org.apache.felix" artifactId="org.apache.felix.framework" version="${osgi.felix.version}"/>
+      </artifact:dependencies>
+
+      <artifact:dependencies pathId="osgi.framework.equinox">
+        <dependency groupId="org.eclipse.osgi" artifactId="org.eclipse.osgi" version="${osgi.equinox.version}"/>
+      </artifact:dependencies>
 
       <artifact:remoteRepository id="sonatype-release" url="https://oss.sonatype.org/content/repositories/releases"/>
       <artifact:remoteRepository id="extra-repo" url="${extra.repo.url}"/>
@@ -984,6 +992,16 @@ TODO:
       <path refid="forkjoin.classpath"/>
     </path>
 
+    <path id="test.osgi.compiler.build.path.felix">
+      <path refid="test.osgi.compiler.build.path"/>
+      <path refid="osgi.framework.felix"/>
+    </path>
+
+    <path id="test.osgi.compiler.build.path.equinox">
+      <path refid="test.osgi.compiler.build.path"/>
+      <path refid="osgi.framework.equinox"/>
+    </path>
+
     <path id="test.positions.sub.build.path" path="${build-quick.dir}/classes/library"/>
 
     <!-- TODO: consolidate *.includes -->
@@ -1351,7 +1369,7 @@ TODO:
       srcdir="${test.osgi.src}"
       jvmargs="${scalacfork.jvmargs}">
       <include name="**/*.scala"/>
-      <compilationpath refid="test.osgi.compiler.build.path"/>
+      <compilationpath refid="test.osgi.compiler.build.path.felix"/>
     </scalacfork>
     <touch file="${build-osgi.dir}/test-compile.complete" verbose="no"/>
     <stopwatch name="test.osgi.compiler.timer" action="total"/>
@@ -1365,8 +1383,20 @@ TODO:
       <stopwatch name="test.osgi.timer"/>
       <mkdir dir="${test.osgi.classes}"/>
 
+      <echo message="Test pass 1 of 2 using Apache Felix ${osgi.felix.version}"/>
       <junit fork="yes" haltonfailure="yes">
-        <classpath refid="test.osgi.compiler.build.path"/>
+        <classpath refid="test.osgi.compiler.build.path.felix"/>
+        <batchtest fork="yes" todir="${build-osgi.dir}">
+          <fileset dir="${test.osgi.classes}">
+            <include name="**/*Test.class"/>
+          </fileset>
+        </batchtest>
+        <formatter type="xml" />
+      </junit>
+
+      <echo message="Test pass 2 of 2 using Eclipse Equinox ${osgi.equinox.version}"/>
+      <junit fork="yes" haltonfailure="yes">
+        <classpath refid="test.osgi.compiler.build.path.equinox"/>
         <batchtest fork="yes" todir="${build-osgi.dir}">
           <fileset dir="${test.osgi.classes}">
             <include name="**/*Test.class"/>

--- a/test/osgi/src/BasicLibrary.scala
+++ b/test/osgi/src/BasicLibrary.scala
@@ -7,19 +7,16 @@ import org.ops4j.pax.exam.CoreOptions._
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.ops4j.pax.exam
-import org.ops4j.pax.exam.junit.{
-  Configuration,
-  ExamReactorStrategy,
-  JUnit4TestRunner
-}
-import org.ops4j.pax.exam.spi.reactors.AllConfinedStagedReactorFactory
-import org.ops4j.pax.swissbox.framework.ServiceLookup
+import org.ops4j.pax.exam.Configuration
+import org.ops4j.pax.exam.junit.PaxExam
+import org.ops4j.pax.exam.spi.reactors.{ ExamReactorStrategy, PerMethod }
+import org.ops4j.pax.swissbox.tracker.ServiceLookup
 import org.osgi.framework.BundleContext
 
 
 
-@RunWith(classOf[JUnit4TestRunner])
-@ExamReactorStrategy(Array(classOf[AllConfinedStagedReactorFactory]))
+@RunWith(classOf[PaxExam])
+@ExamReactorStrategy(Array(classOf[PerMethod]))
 class BasicLibraryTest extends ScalaOsgiHelper {
   @Configuration
   def config(): Array[exam.Option] =

--- a/test/osgi/src/BasicReflection.scala
+++ b/test/osgi/src/BasicReflection.scala
@@ -10,13 +10,10 @@ import org.ops4j.pax.exam.CoreOptions._
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.ops4j.pax.exam
-import org.ops4j.pax.exam.junit.{
-  Configuration,
-  ExamReactorStrategy,
-  JUnit4TestRunner
-}
-import org.ops4j.pax.exam.spi.reactors.AllConfinedStagedReactorFactory
-import org.ops4j.pax.swissbox.framework.ServiceLookup
+import org.ops4j.pax.exam.Configuration
+import org.ops4j.pax.exam.junit.PaxExam
+import org.ops4j.pax.exam.spi.reactors.{ ExamReactorStrategy, PerMethod }
+import org.ops4j.pax.swissbox.tracker.ServiceLookup
 import org.osgi.framework.BundleContext
 
 
@@ -38,8 +35,8 @@ class C {
 object M
 
 
-@RunWith(classOf[JUnit4TestRunner])
-@ExamReactorStrategy(Array(classOf[AllConfinedStagedReactorFactory]))
+@RunWith(classOf[PaxExam])
+@ExamReactorStrategy(Array(classOf[PerMethod]))
 class BasicReflectionTest extends ScalaOsgiHelper {
 
   @Configuration

--- a/test/osgi/src/BasicTest.scala
+++ b/test/osgi/src/BasicTest.scala
@@ -6,21 +6,18 @@ import org.ops4j.pax.exam.CoreOptions._
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.ops4j.pax.exam
-import org.ops4j.pax.exam.junit.{
-  Configuration,
-  ExamReactorStrategy,
-  JUnit4TestRunner
-}
-import org.ops4j.pax.exam.spi.reactors.AllConfinedStagedReactorFactory
-import org.ops4j.pax.swissbox.framework.ServiceLookup
+import org.ops4j.pax.exam.Configuration
+import org.ops4j.pax.exam.junit.PaxExam
+import org.ops4j.pax.exam.spi.reactors.{ ExamReactorStrategy, PerMethod }
+import org.ops4j.pax.swissbox.tracker.ServiceLookup
 import org.osgi.framework.BundleContext
 
 
 
 
 
-@RunWith(classOf[JUnit4TestRunner])
-@ExamReactorStrategy(Array(classOf[AllConfinedStagedReactorFactory]))
+@RunWith(classOf[PaxExam])
+@ExamReactorStrategy(Array(classOf[PerMethod]))
 class BasicTest extends ScalaOsgiHelper {
   @Configuration
   def config(): Array[exam.Option] = {

--- a/test/osgi/src/ReflectionToolboxTest.scala
+++ b/test/osgi/src/ReflectionToolboxTest.scala
@@ -8,13 +8,10 @@ import org.ops4j.pax.exam.CoreOptions._
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.ops4j.pax.exam
-import org.ops4j.pax.exam.junit.{
-  Configuration,
-  ExamReactorStrategy,
-  JUnit4TestRunner
-}
-import org.ops4j.pax.exam.spi.reactors.AllConfinedStagedReactorFactory
-import org.ops4j.pax.swissbox.framework.ServiceLookup
+import org.ops4j.pax.exam.Configuration
+import org.ops4j.pax.exam.junit.PaxExam
+import org.ops4j.pax.exam.spi.reactors.{ ExamReactorStrategy, PerMethod }
+import org.ops4j.pax.swissbox.tracker.ServiceLookup
 import org.osgi.framework.BundleContext
 
 
@@ -22,8 +19,8 @@ class C {
   val f1 = 2
 }
 
-@RunWith(classOf[JUnit4TestRunner])
-@ExamReactorStrategy(Array(classOf[AllConfinedStagedReactorFactory]))
+@RunWith(classOf[PaxExam])
+@ExamReactorStrategy(Array(classOf[PerMethod]))
 class ReflectionToolBoxTest extends ScalaOsgiHelper {
 
   @Configuration

--- a/test/osgi/src/ScalaOsgiHelper.scala
+++ b/test/osgi/src/ScalaOsgiHelper.scala
@@ -20,19 +20,19 @@ trait ScalaOsgiHelper {
 
   def standardOptions: Array[exam.Option]  = {
     val bundles = (allBundleFiles map makeBundle)
-    bundles ++ Array[exam.Option](felix(), equinox(), junitBundles())
+    bundles ++ Array[exam.Option](junitBundles())
     // to change the local repo used (for some operations, but not all -- which is why I didn't bother):
     // systemProperty("org.ops4j.pax.url.mvn.localRepository").value(sys.props("maven.repo.local")))
   }
 
   def justReflectionOptions: Array[exam.Option]  = {
     val bundles = filteredBundleFiles("scala-library", "scala-reflect")
-    bundles ++ Array[exam.Option](felix(), equinox(), junitBundles())
+    bundles ++ Array[exam.Option](junitBundles())
   }
 
   def justCoreLibraryOptions: Array[exam.Option]  = {
     val bundles = filteredBundleFiles("scala-library")
-    bundles ++ Array[exam.Option](felix(), equinox(), junitBundles())
+    bundles ++ Array[exam.Option](junitBundles())
   }
 
 }


### PR DESCRIPTION
The way the desired OSGi frameworks are chosen has changed between
Pax Exam versions:

On earlier versions, specifying it in code was fine, but PAX Exam 4.x
runs the tests on the first OSGi framework it finds on classpath.

An exclusion for the transitive dependency org.osgi.core was added,
because it seems that artifact has broken dependecies (which would
have brought us back to square one).
Good thing is that it isn't needed here, because the OSGi framework JARs
contain all necessary classes.
