### PR TITLE
Bump version number in build.number to 2.11.4

### DIFF
--- a/build.number
+++ b/build.number
@@ -1,7 +1,7 @@
 #Tue Sep 11 19:21:09 CEST 2007
 version.major=2
 version.minor=11
-version.patch=3
+version.patch=4
 # This is the -N part of a version.  if it's 0, it's dropped from maven versions.
 version.bnum=0
 


### PR DESCRIPTION
This should happen every time we cut a new release. We don't touch
versions.properties files because that file specifies dependencies and
we don't want to depend on broken Scala 2.11.3 release.
