### PR TITLE
Improve PartialFunction/Function1 docs

### DIFF
--- a/src/library/scala/Function1.scala
+++ b/src/library/scala/Function1.scala
@@ -10,7 +10,7 @@
 package scala
 
 
-/** A function of 1 parameter.
+/** A partial function of 1 parameter.
  *  
  *  In the following example, the definition of succ is a
  *  shorthand for the anonymous class definition anonfun1:
@@ -25,11 +25,10 @@ package scala
  * }
  *  }}}
  *
- *  Note that `Function1` does not define a total function, as might
+ *  `Function1` does not define a total function, as might
  *  be suggested by the existence of [[scala.PartialFunction]]. The only
  *  distinction between `Function1` and `PartialFunction` is that the
  *  latter can specify inputs which it will not handle.
-
  */
 @annotation.implicitNotFound(msg = "No implicit view available from ${T1} => ${R}.")
 trait Function1[@specialized(scala.Int, scala.Long, scala.Float, scala.Double) -T1, @specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double) +R] extends AnyRef { self =>

--- a/src/library/scala/PartialFunction.scala
+++ b/src/library/scala/PartialFunction.scala
@@ -9,22 +9,23 @@
 package scala
 
 
-/** A partial function of type `PartialFunction[A, B]` is a unary function
- *  where the domain does not necessarily include all values of type `A`.
- *  The function `isDefinedAt` allows to test dynamically if a value is in
- *  the domain of the function.
+/** A partial function `pf` of type `PartialFunction[A, B]` is a unary function
+ *  that allows testing dynamically which values belong to its domain, through
+ *  the `isDefinedAt` method.
  *
- *  Even if `isDefinedAt` returns true for an `a: A`, calling `apply(a)` may
+ *  If `pf.isDefinedAt(a)` for an `a: A`, calling `pf.apply(a)` may
  *  still throw an exception, so the following code is legal:
  *
  *  {{{
  *  val f: PartialFunction[Int, Any] = { case _ => 1/0 }
  *  }}}
- * 
- *  It is the responsibility of the caller to call `isDefinedAt` before
- *  calling `apply`, because if `isDefinedAt` is false, it is not guaranteed
- *  `apply` will throw an exception to indicate an error condition. If an
- *  exception is not thrown, evaluation may result in an arbitrary value.
+
+ *  If `pf.isDefinedAt(a) = false` for an `a: A`, calling `pf.apply(a)` is not
+ *  required to throw an exception. However, evaluation might produce an
+ *  arbitrary value. Hence, it is the responsibility of the caller to call
+ *  `isDefinedAt` before calling `apply`, because if `isDefinedAt` is false, it
+ *  is not guaranteed `apply` will throw an exception to indicate an error
+ *  condition.
  *
  *  The main distinction between `PartialFunction` and [[scala.Function1]] is
  *  that the user of a `PartialFunction` may choose to do something different


### PR DESCRIPTION
TODO: if this is what we want, all FunctionX should be documented as "_partial_ function of X arguments" like I did for `Function1`.

Prompted by https://groups.google.com/d/msg/scala-language/QuYtWldPNi8/hW2FjM0x96QJ. Apparently https://issues.scala-lang.org/browse/SI-5370's earlier doc fix wasn't enough (EDIT: I misattributed the fix to myself, while I just reported a bug).

A question on the API: I get why isDefinedAt = true still allows for exceptions (changing that would require solving the halting problem, for compiler-generated partial functions), but I don't get why isDefinedAt = false does not require exceptions. The new doc explains this, and I don't assume this could be changed, but I'm still curious about the rationale.

Review by @phaller (for the library) & @heathermiller (for the docs).
