### PR TITLE
Bump version to 2.11.5 in build.number file.

### DIFF
--- a/build.number
+++ b/build.number
@@ -1,7 +1,7 @@
 #Tue Sep 11 19:21:09 CEST 2007
 version.major=2
 version.minor=11
-version.patch=4
+version.patch=5
 # This is the -N part of a version.  if it's 0, it's dropped from maven versions.
 version.bnum=0
 


### PR DESCRIPTION
Scala 2.11.4 release has been staged, we should start publishing snapshots
for Scala 2.11.5 now.
