### PR TITLE
SI-8931 make generic signature consistent with interface list in classfiles

### DIFF
--- a/test/files/run/t8931.check
+++ b/test/files/run/t8931.check
@@ -1,0 +1,1 @@
+List(interface B)

--- a/test/files/run/t8931.scala
+++ b/test/files/run/t8931.scala
@@ -1,0 +1,15 @@
+
+trait A
+
+trait B extends A
+
+class C extends A with B
+
+object Test extends App {
+  val c = classOf[C]
+
+  println(c.getGenericInterfaces.toList)
+
+  assert(c.getGenericInterfaces.length == c.getInterfaces.length,
+    s"mismatch between ${c.getGenericInterfaces} and ${c.getInterfaces}")
+}


### PR DESCRIPTION
An optimization was introduced in 7a99c03 ([SI-5278](https://issues.scala-lang.org/browse/SI-5278)) to remove redundant
interfaces from the list of implemented interfaces in the bytecode.
However the same change was not propagated to the generic signature
of a class, which also contains a list of direct parent classes and
interfaces.

The JVM does not check the well-formedness of signatures at class
loading or linking (see §4.3.4 of jdk7 jvms), but other tools might
assume the number of implemented interfaces is the same whether one
asked for generic or erased interfaces.

It doesn't break reflection so nobody complained, but it does show:

``` scala
scala> val c = classOf[Tuple1[String]]
c: Class[(String,)] = class scala.Tuple1

scala> c.getInterfaces // Product is gone
res0: Array[Class[_]] = Array(interface scala.Product1, interface
scala.Serializable)

scala> c.getGenericInterfaces // Product is back!
res1: Array[java.lang.reflect.Type] = Array(scala.Product1<T1>,
interface scala.Product, interface scala.Serializable)
```

This moves the optimization to erasure, for use in emitting the generic
signature, and the backend calls into it later for the list of
interfaces.
