### PR TITLE
Correct collections variable definitions to avoid many scaladoc warnings.

### DIFF
--- a/src/library/scala/Enumeration.scala
+++ b/src/library/scala/Enumeration.scala
@@ -239,6 +239,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
    *
    *  @param nnIds The set of ids of values (adjusted so that the lowest value does
    *    not fall below zero), organized as a `BitSet`.
+   *  @define Coll `collection.immutable.SortedSet`
    */
   class ValueSet private[ValueSet] (private[this] var nnIds: immutable.BitSet)
   extends AbstractSet[Value]

--- a/src/library/scala/collection/concurrent/Map.scala
+++ b/src/library/scala/collection/concurrent/Map.scala
@@ -20,7 +20,7 @@ package collection.concurrent
  *  @tparam A  the key type of the map
  *  @tparam B  the value type of the map
  *
- *  @define Coll `ConcurrentMap`
+ *  @define Coll `concurrent.Map`
  *  @define coll concurrent map
  *  @define concurrentmapinfo
  *  This is a base trait for all Scala concurrent map implementations. It

--- a/src/library/scala/collection/generic/GenericTraversableTemplate.scala
+++ b/src/library/scala/collection/generic/GenericTraversableTemplate.scala
@@ -25,7 +25,7 @@ import scala.language.higherKinds
  *  @author Martin Odersky
  *  @since 2.8
  *  @define coll  collection
- *  @define Coll  CC
+ *  @define Coll  Traversable
  */
 trait GenericTraversableTemplate[+A, +CC[X] <: GenTraversable[X]] extends HasNewBuilder[A, CC[A] @uncheckedVariance] {
 

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -30,8 +30,8 @@ import parallel.mutable.ParArray
  *
  *  @tparam A    the type of this arraybuffer's elements.
  *
- *  @define Coll `ArrayBuffer`
- *  @define coll arraybuffer
+ *  @define Coll `mutable.ArrayBuffer`
+ *  @define coll array buffer
  *  @define thatinfo the class of the returned collection. In the standard library configuration,
  *    `That` is always `ArrayBuffer[B]` because an implicit of type `CanBuildFrom[ArrayBuffer, B, ArrayBuffer[B]]`
  *    is defined in object `ArrayBuffer`.

--- a/src/library/scala/collection/mutable/MapLike.scala
+++ b/src/library/scala/collection/mutable/MapLike.scala
@@ -18,6 +18,8 @@ import scala.collection.parallel.mutable.ParMap
 /** A template trait for mutable maps.
  *  $mapNote
  *  $mapTags
+ *  @define Coll `mutable.Map`
+ *  @define coll mutable map
  *  @since   2.8
  *
  * @define mapNote

--- a/src/library/scala/collection/mutable/MutableList.scala
+++ b/src/library/scala/collection/mutable/MutableList.scala
@@ -22,6 +22,8 @@ import immutable.{List, Nil}
  *  @author  Martin Odersky
  *  @version 2.8
  *  @since   1
+ *  @define Coll `mutable.MutableList`
+ *  @define coll mutable list
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#mutable_lists "Scala's Collection Library overview"]]
  *  section on `Mutable Lists` for more information.
  */

--- a/src/library/scala/collection/mutable/StringBuilder.scala
+++ b/src/library/scala/collection/mutable/StringBuilder.scala
@@ -22,6 +22,8 @@ import immutable.StringLike
  *  @author Martin Odersky
  *  @version 2.8
  *  @since   2.7
+ *  @define Coll `mutable.IndexedSeq`
+ *  @define coll string builder
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html# "Scala's Collection Library overview"]]
  *  section on `StringBuilders` for more information.
  */

--- a/src/library/scala/collection/parallel/ParIterable.scala
+++ b/src/library/scala/collection/parallel/ParIterable.scala
@@ -23,9 +23,6 @@ import scala.collection.parallel.mutable.ParArrayCombiner
  *
  *  @author Aleksandar Prokopec
  *  @since 2.9
- *
- *  @define Coll `ParIterable`
- *  @define coll parallel iterable
  */
 trait ParIterable[+T]
 extends GenIterable[T]

--- a/src/library/scala/collection/parallel/ParIterableLike.scala
+++ b/src/library/scala/collection/parallel/ParIterableLike.scala
@@ -150,7 +150,8 @@ import scala.collection.parallel.ParallelCollectionImplicits._
  *  @define indexsignalling
  *  This method will use `indexFlag` signalling capabilities. This means
  *  that splitters may set and read the `indexFlag` state.
- *
+ *  @define Coll `ParIterable`
+ *  @define coll parallel iterable
  */
 trait ParIterableLike[+T, +Repr <: ParIterable[T], +Sequential <: Iterable[T] with IterableLike[T, Sequential]]
 extends GenIterableLike[T, Repr]

--- a/src/library/scala/collection/parallel/ParMapLike.scala
+++ b/src/library/scala/collection/parallel/ParMapLike.scala
@@ -24,6 +24,8 @@ import scala.collection.generic.Signalling
  *
  *  @tparam K    the key type of the map
  *  @tparam V    the value type of the map
+ *  @define Coll `ParMap`
+ *  @define coll parallel map
  *
  *  @author Aleksandar Prokopec
  *  @since 2.9

--- a/src/library/scala/collection/parallel/ParSetLike.scala
+++ b/src/library/scala/collection/parallel/ParSetLike.scala
@@ -20,6 +20,8 @@ import scala.collection.Set
  *  $sideeffects
  *
  *  @tparam T    the element type of the set
+ *  @define Coll `ParSet`
+ *  @define coll parallel set
  *
  *  @author Aleksandar Prokopec
  *  @since 2.9

--- a/src/library/scala/collection/parallel/mutable/ParMapLike.scala
+++ b/src/library/scala/collection/parallel/mutable/ParMapLike.scala
@@ -22,6 +22,8 @@ import scala.collection.generic.Shrinkable
  *
  *  @tparam K    the key type of the map
  *  @tparam V    the value type of the map
+ *  @define Coll `ParMap`
+ *  @define coll parallel map
  *
  *  @author Aleksandar Prokopec
  *  @since 2.9

--- a/src/library/scala/collection/parallel/mutable/ParSet.scala
+++ b/src/library/scala/collection/parallel/mutable/ParSet.scala
@@ -14,9 +14,6 @@ import scala.collection.parallel.Combiner
 
 /** A mutable variant of `ParSet`.
  *
- *  @define Coll `mutable.ParSet`
- *  @define coll mutable parallel set
- *
  *  @author Aleksandar Prokopec
  */
 trait ParSet[T]

--- a/src/library/scala/collection/parallel/mutable/ParSetLike.scala
+++ b/src/library/scala/collection/parallel/mutable/ParSetLike.scala
@@ -21,6 +21,8 @@ import scala.collection.generic.Shrinkable
  *  $sideeffects
  *
  *  @tparam T    the element type of the set
+ *  @define Coll `mutable.ParSet`
+ *  @define coll mutable parallel set
  *
  *  @author Aleksandar Prokopec
  *  @since 2.9

--- a/src/library/scala/runtime/Tuple2Zipped.scala
+++ b/src/library/scala/runtime/Tuple2Zipped.scala
@@ -17,6 +17,10 @@ import scala.language.{ higherKinds, implicitConversions }
 /** This interface is intended as a minimal interface, not complicated
  *  by the requirement to resolve type constructors, for implicit search (which only
  *  needs to find an implicit conversion to Traversable for our purposes.)
+ *  @define Coll `ZippedTraversable2`
+ *  @define coll collection
+ *  @define collectExample
+ *  @define willNotTerminateInf
  */
 trait ZippedTraversable2[+El1, +El2] extends Any {
   def foreach[U](f: (El1, El2) => U): Unit

--- a/src/library/scala/runtime/Tuple3Zipped.scala
+++ b/src/library/scala/runtime/Tuple3Zipped.scala
@@ -14,7 +14,12 @@ import scala.collection.{ TraversableLike, IterableLike }
 import scala.collection.generic.{ CanBuildFrom => CBF }
 import scala.language.{ higherKinds, implicitConversions }
 
-/** See comment on ZippedTraversable2. */
+/** See comment on ZippedTraversable2
+ *  @define Coll `ZippedTraversable3`
+ *  @define coll collection
+ *  @define collectExample
+ *  @define willNotTerminateInf
+ */
 trait ZippedTraversable3[+El1, +El2, +El3] extends Any {
   def foreach[U](f: (El1, El2, El3) => U): Unit
 }

--- a/src/library/scala/sys/SystemProperties.scala
+++ b/src/library/scala/sys/SystemProperties.scala
@@ -21,6 +21,8 @@ import scala.language.implicitConversions
  *  System properties.  If a security manager is in place which prevents
  *  the properties from being read or written, the AccessControlException
  *  will be caught and discarded.
+ *  @define Coll `collection.mutable.Map`
+ *  @define coll mutable map
  *
  *  @author Paul Phillips
  *  @version 2.9


### PR DESCRIPTION
Running 'ant docs.lib' produces such a long warning list that nobody seems to care. Consequently the documentation for stdlib contains many errorneous signatures.

This PR addresses most of the "Unresolved $Coll when documenting XXX" warnings and reduces scaladoc output from 1600 to 400 lines. Since this is a pure documentation change, it is safe to merge in 2.11.x
