### PR TITLE
SI-8835 Lazier slice for Iterator

### DIFF
--- a/src/library/scala/collection/parallel/RemainsIterator.scala
+++ b/src/library/scala/collection/parallel/RemainsIterator.scala
@@ -456,6 +456,15 @@ self =>
     }
     it
   }
+  /** Drop implemented as simple eager consumption. */
+  override def drop(n: Int): IterableSplitter[T] = {
+    var i = 0
+    while (i < n && hasNext) {
+      next()
+      i += 1
+    }
+    this
+  }
   override def take(n: Int): IterableSplitter[T] = newTaken(n)
   override def slice(from1: Int, until1: Int): IterableSplitter[T] = newSliceInternal(newTaken(until1), from1)
 

--- a/src/library/scala/runtime/ScalaRunTime.scala
+++ b/src/library/scala/runtime/ScalaRunTime.scala
@@ -13,6 +13,7 @@ import scala.collection.{ Seq, IndexedSeq, TraversableView, AbstractIterator }
 import scala.collection.mutable.WrappedArray
 import scala.collection.immutable.{ StringLike, NumericRange, List, Stream, Nil, :: }
 import scala.collection.generic.{ Sorted, IsTraversableLike }
+import scala.collection.parallel.ParIterable
 import scala.reflect.{ ClassTag, classTag }
 import scala.util.control.ControlThrowable
 import java.lang.{ Class => jClass }
@@ -326,6 +327,7 @@ object ScalaRunTime {
       case x: AnyRef if isArray(x)      => arrayToString(x)
       case x: scala.collection.Map[_, _]      => x.iterator take maxElements map mapInner mkString (x.stringPrefix + "(", ", ", ")")
       case x: Iterable[_]               => x.iterator take maxElements map inner mkString (x.stringPrefix + "(", ", ", ")")
+      case x: ParIterable[_]            => x.iterator take maxElements map inner mkString (x.stringPrefix + "(", ", ", ")")
       case x: Traversable[_]            => x take maxElements map inner mkString (x.stringPrefix + "(", ", ", ")")
       case x: Product1[_] if isTuple(x) => "(" + inner(x._1) + ",)" // that special trailing comma
       case x: Product if isTuple(x)     => x.productIterator map inner mkString ("(", ",", ")")


### PR DESCRIPTION
An iterator for slicing that does not drop eagerly.

A series of `take m drop n` that results in nothing taken
will not call the underlying iterator.

Chained invocations do not create intermediate iterators.

Adds eager `drop` to `IterableSplitter`, which overrides `take` and `slice`.

Let `stringOf` handle `ParIterable` so your ScalaCheck labels can be shown truncated, at least during debug.

This PR against 2.12 (because of the change to laziness)
includes the expanded unit test from #4075, but does not
delete the redundant test files.

This is similar to a proposal at #3963: just track drop and take numbers (skip and limit counters) until forced.

There may be a question whether this is worth it, in the space between deprecated views and the collections getting rewritten by multiple parties.

The other question is, if `take` and `drop` and `slice` are defined in terms of a template method, should they be final?

Review by @Ichoran 
