### PR TITLE
IntelliJ IDEA files for version 14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,9 +39,9 @@
 # eclipse, intellij
 /.classpath
 /.project
-/src/intellij/*.iml
-/src/intellij/*.ipr
-/src/intellij/*.iws
+/src/intellij*/*.iml
+/src/intellij*/*.ipr
+/src/intellij*/*.iws
 **/.cache
 /.idea
 /.settings

--- a/src/intellij-14/README
+++ b/src/intellij-14/README
@@ -1,0 +1,12 @@
+Use the latest IntelliJ IDEA release and install the Scala plugin from within the IDE.
+
+Compilation withing IDEA is performed in "-Dlocker.skip=1" mode: the sources are built
+directly using the STARR compiler.
+
+The following steps are required to use IntelliJ IDEA on Scala trunk
+ - Run "ant init". This will download some JARs from to ./build/deps, which are
+   included in IntelliJ's classpath.
+ - Run src/intellij-14/setup.sh
+ - Open ./src/intellij-14/scala.ipr in IntelliJ
+ - File, Project Settings, Project, SDK. Create an SDK entry named "1.6" containing the
+   Java 1.6 SDK

--- a/src/intellij-14/actors.iml.SAMPLE
+++ b/src/intellij-14/actors.iml.SAMPLE
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../actors">
+      <sourceFolder url="file://$MODULE_DIR$/../actors" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="forkjoin" />
+    <orderEntry type="module" module-name="library" />
+    <orderEntry type="library" name="starr-no-deps" level="project" />
+  </component>
+</module>

--- a/src/intellij-14/asm.iml.SAMPLE
+++ b/src/intellij-14/asm.iml.SAMPLE
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../asm">
+      <sourceFolder url="file://$MODULE_DIR$/../asm/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../asm" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/src/intellij-14/compiler.iml.SAMPLE
+++ b/src/intellij-14/compiler.iml.SAMPLE
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../compiler">
+      <sourceFolder url="file://$MODULE_DIR$/../compiler" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="asm" />
+    <orderEntry type="module" module-name="library" />
+    <orderEntry type="module" module-name="reflect" />
+    <orderEntry type="library" name="ant" level="project" />
+    <orderEntry type="library" name="starr-no-deps" level="project" />
+  </component>
+</module>

--- a/src/intellij-14/diff.sh
+++ b/src/intellij-14/diff.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#
+# Diffs the SAMPLE files against the working project config.
+#
+export SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+for f in "$SCRIPT_DIR"/*.{iml,ipr}; do
+	echo $f; diff -u $f.SAMPLE $f;
+done

--- a/src/intellij-14/forkjoin.iml.SAMPLE
+++ b/src/intellij-14/forkjoin.iml.SAMPLE
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../forkjoin">
+      <sourceFolder url="file://$MODULE_DIR$/../forkjoin" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/src/intellij-14/interactive.iml.SAMPLE
+++ b/src/intellij-14/interactive.iml.SAMPLE
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../interactive">
+      <sourceFolder url="file://$MODULE_DIR$/../interactive" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="compiler" />
+    <orderEntry type="module" module-name="library" />
+    <orderEntry type="module" module-name="reflect" />
+    <orderEntry type="module" module-name="scaladoc" />
+    <orderEntry type="library" name="starr-no-deps" level="project" />
+  </component>
+</module>

--- a/src/intellij-14/library.iml.SAMPLE
+++ b/src/intellij-14/library.iml.SAMPLE
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../library">
+      <sourceFolder url="file://$MODULE_DIR$/../library" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="forkjoin" />
+    <orderEntry type="library" name="starr-no-deps" level="project" />
+  </component>
+</module>

--- a/src/intellij-14/manual.iml.SAMPLE
+++ b/src/intellij-14/manual.iml.SAMPLE
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../manual">
+      <sourceFolder url="file://$MODULE_DIR$/../manual" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="library" />
+    <orderEntry type="library" name="ant" level="project" />
+    <orderEntry type="library" name="scaladoc-deps" level="project" />
+    <orderEntry type="library" name="starr-no-deps" level="project" />
+  </component>
+</module>

--- a/src/intellij-14/partest-extras.iml.SAMPLE
+++ b/src/intellij-14/partest-extras.iml.SAMPLE
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../partest-extras">
+      <sourceFolder url="file://$MODULE_DIR$/../partest-extras" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="asm" />
+    <orderEntry type="module" module-name="compiler" />
+    <orderEntry type="module" module-name="library" />
+    <orderEntry type="module" module-name="reflect" />
+    <orderEntry type="module" module-name="repl" />
+    <orderEntry type="library" name="partest" level="project" />
+    <orderEntry type="library" name="starr-no-deps" level="project" />
+  </component>
+</module>

--- a/src/intellij-14/partest-javaagent.iml.SAMPLE
+++ b/src/intellij-14/partest-javaagent.iml.SAMPLE
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../partest-javaagent">
+      <sourceFolder url="file://$MODULE_DIR$/../partest-javaagent" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="asm" />
+    <orderEntry type="library" name="starr-no-deps" level="project" />
+  </component>
+</module>

--- a/src/intellij-14/reflect.iml.SAMPLE
+++ b/src/intellij-14/reflect.iml.SAMPLE
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../reflect">
+      <sourceFolder url="file://$MODULE_DIR$/../reflect" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="library" />
+    <orderEntry type="library" name="starr-no-deps" level="project" />
+  </component>
+</module>

--- a/src/intellij-14/repl.iml.SAMPLE
+++ b/src/intellij-14/repl.iml.SAMPLE
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../repl">
+      <sourceFolder url="file://$MODULE_DIR$/../repl" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="library" />
+    <orderEntry type="module" module-name="compiler" />
+    <orderEntry type="module" module-name="reflect" />
+    <orderEntry type="library" name="repl-deps" level="project" />
+    <orderEntry type="library" name="starr-no-deps" level="project" />
+  </component>
+</module>

--- a/src/intellij-14/scala.iml.SAMPLE
+++ b/src/intellij-14/scala.iml.SAMPLE
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../..">
+      <excludeFolder url="file://$MODULE_DIR$/../../build" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/src/intellij-14/scala.ipr.SAMPLE
+++ b/src/intellij-14/scala.ipr.SAMPLE
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <option name="DEFAULT_COMPILER" value="Javac" />
+    <resourceExtensions />
+    <wildcardResourcePatterns>
+      <entry name="!?*.java" />
+      <entry name="!?*.form" />
+      <entry name="!?*.class" />
+      <entry name="!?*.groovy" />
+      <entry name="!?*.scala" />
+      <entry name="!?*.flex" />
+      <entry name="!?*.kt" />
+      <entry name="!?*.clj" />
+    </wildcardResourcePatterns>
+    <annotationProcessing>
+      <profile default="true" name="Default" enabled="false">
+        <processorPath useClasspath="true" />
+      </profile>
+    </annotationProcessing>
+  </component>
+  <component name="CopyrightManager" default="" />
+  <component name="DaemonCodeAnalyzer">
+    <disable_hints />
+  </component>
+  <component name="DependencyValidationManager">
+    <option name="SKIP_IMPORT_STATEMENTS" value="false" />
+  </component>
+  <component name="Encoding" useUTFGuessing="true" native2AsciiForPropertiesFiles="false" />
+  <component name="EntryPointsManager">
+    <entry_points version="2.0" />
+  </component>
+  <component name="ProjectLevelVcsManager" settingsEditedManually="false">
+    <OptionsSetting value="true" id="Add" />
+    <OptionsSetting value="true" id="Remove" />
+    <OptionsSetting value="true" id="Checkout" />
+    <OptionsSetting value="true" id="Update" />
+    <OptionsSetting value="true" id="Status" />
+    <OptionsSetting value="true" id="Edit" />
+    <ConfirmationsSetting value="0" id="Add" />
+    <ConfirmationsSetting value="0" id="Remove" />
+  </component>
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/actors.iml" filepath="$PROJECT_DIR$/actors.iml" />
+      <module fileurl="file://$PROJECT_DIR$/asm.iml" filepath="$PROJECT_DIR$/asm.iml" />
+      <module fileurl="file://$PROJECT_DIR$/compiler.iml" filepath="$PROJECT_DIR$/compiler.iml" />
+      <module fileurl="file://$PROJECT_DIR$/forkjoin.iml" filepath="$PROJECT_DIR$/forkjoin.iml" />
+      <module fileurl="file://$PROJECT_DIR$/interactive.iml" filepath="$PROJECT_DIR$/interactive.iml" />
+      <module fileurl="file://$PROJECT_DIR$/library.iml" filepath="$PROJECT_DIR$/library.iml" />
+      <module fileurl="file://$PROJECT_DIR$/manual.iml" filepath="$PROJECT_DIR$/manual.iml" />
+      <module fileurl="file://$PROJECT_DIR$/partest-extras.iml" filepath="$PROJECT_DIR$/partest-extras.iml" />
+      <module fileurl="file://$PROJECT_DIR$/partest-javaagent.iml" filepath="$PROJECT_DIR$/partest-javaagent.iml" />
+      <module fileurl="file://$PROJECT_DIR$/reflect.iml" filepath="$PROJECT_DIR$/reflect.iml" />
+      <module fileurl="file://$PROJECT_DIR$/repl.iml" filepath="$PROJECT_DIR$/repl.iml" />
+      <module fileurl="file://$PROJECT_DIR$/scala.iml" filepath="$PROJECT_DIR$/scala.iml" />
+      <module fileurl="file://$PROJECT_DIR$/scaladoc.iml" filepath="$PROJECT_DIR$/scaladoc.iml" />
+      <module fileurl="file://$PROJECT_DIR$/scalap.iml" filepath="$PROJECT_DIR$/scalap.iml" />
+      <module fileurl="file://$PROJECT_DIR$/test.iml" filepath="$PROJECT_DIR$/test.iml" />
+      <module fileurl="file://$PROJECT_DIR$/test-junit.iml" filepath="$PROJECT_DIR$/test-junit.iml" />
+    </modules>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" assert-keyword="true" jdk-15="true" project-jdk-name="1.6" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/../../out" />
+  </component>
+  <component name="PropertiesComponent">
+    <property name="GoToClass.includeLibraries" value="false" />
+    <property name="GoToClass.toSaveIncludeLibraries" value="false" />
+    <property name="GoToFile.includeJavaFiles" value="false" />
+    <property name="MemberChooser.sorted" value="false" />
+    <property name="MemberChooser.showClasses" value="true" />
+    <property name="MemberChooser.copyJavadoc" value="false" />
+    <property name="options.lastSelected" value="configurable.group.appearance" />
+    <property name="options.splitter.main.proportions" value="0.3" />
+    <property name="options.splitter.details.proportions" value="0.2" />
+    <property name="options.searchVisible" value="true" />
+  </component>
+  <component name="RunManager">
+    <configuration default="true" type="#org.jetbrains.idea.devkit.run.PluginConfigurationType" factoryName="Plugin">
+      <module name="" />
+      <option name="VM_PARAMETERS" value="-Xmx512m -Xms256m -XX:MaxPermSize=250m -ea" />
+      <option name="PROGRAM_PARAMETERS" />
+      <method />
+    </configuration>
+    <configuration default="true" type="Remote" factoryName="Remote">
+      <option name="USE_SOCKET_TRANSPORT" value="true" />
+      <option name="SERVER_MODE" value="false" />
+      <option name="SHMEM_ADDRESS" value="javadebug" />
+      <option name="HOST" value="localhost" />
+      <option name="PORT" value="5005" />
+      <method />
+    </configuration>
+    <configuration default="true" type="Applet" factoryName="Applet">
+      <module name="" />
+      <option name="MAIN_CLASS_NAME" />
+      <option name="HTML_FILE_NAME" />
+      <option name="HTML_USED" value="false" />
+      <option name="WIDTH" value="400" />
+      <option name="HEIGHT" value="300" />
+      <option name="POLICY_FILE" value="$CARDEA_HOME$/bin/appletviewer.policy" />
+      <option name="VM_PARAMETERS" />
+      <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+      <option name="ALTERNATIVE_JRE_PATH" />
+      <method />
+    </configuration>
+    <configuration default="true" type="TestNG" factoryName="TestNG">
+      <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea" />
+      <module name="" />
+      <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+      <option name="ALTERNATIVE_JRE_PATH" />
+      <option name="SUITE_NAME" />
+      <option name="PACKAGE_NAME" />
+      <option name="MAIN_CLASS_NAME" />
+      <option name="METHOD_NAME" />
+      <option name="GROUP_NAME" />
+      <option name="TEST_OBJECT" value="CLASS" />
+      <option name="VM_PARAMETERS" value="-ea" />
+      <option name="PARAMETERS" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+      <option name="OUTPUT_DIRECTORY" />
+      <option name="ANNOTATION_TYPE" />
+      <option name="ENV_VARIABLES" />
+      <option name="PASS_PARENT_ENVS" value="true" />
+      <option name="TEST_SEARCH_SCOPE">
+        <value defaultName="moduleWithDependencies" />
+      </option>
+      <option name="USE_DEFAULT_REPORTERS" value="false" />
+      <option name="PROPERTIES_FILE" />
+      <envs />
+      <properties />
+      <listeners />
+      <method />
+    </configuration>
+    <configuration default="true" type="Application" factoryName="Application">
+      <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea" />
+      <option name="MAIN_CLASS_NAME" />
+      <option name="VM_PARAMETERS" />
+      <option name="PROGRAM_PARAMETERS" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+      <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+      <option name="ALTERNATIVE_JRE_PATH" />
+      <option name="ENABLE_SWING_INSPECTOR" value="false" />
+      <option name="ENV_VARIABLES" />
+      <option name="PASS_PARENT_ENVS" value="true" />
+      <module name="" />
+      <envs />
+      <method />
+    </configuration>
+    <configuration default="true" type="JUnit" factoryName="JUnit">
+      <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea" />
+      <module name="" />
+      <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+      <option name="ALTERNATIVE_JRE_PATH" />
+      <option name="PACKAGE_NAME" />
+      <option name="MAIN_CLASS_NAME" />
+      <option name="METHOD_NAME" />
+      <option name="TEST_OBJECT" value="class" />
+      <option name="VM_PARAMETERS" value="-ea" />
+      <option name="PARAMETERS" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+      <option name="ENV_VARIABLES" />
+      <option name="PASS_PARENT_ENVS" value="true" />
+      <option name="TEST_SEARCH_SCOPE">
+        <value defaultName="moduleWithDependencies" />
+      </option>
+      <envs />
+      <patterns />
+      <method />
+    </configuration>
+    <list size="0" />
+    <configuration name="&lt;template&gt;" type="WebApp" default="true" selected="false">
+      <Host>localhost</Host>
+      <Port>5050</Port>
+    </configuration>
+  </component>
+  <component name="ScalaCompilerConfiguration">
+    <parameters>
+      <parameter value="-sourcepath" />
+      <parameter value="$PROJECT_DIR$/../library" />
+    </parameters>
+  </component>
+  <component name="VcsContentAnnotationSettings">
+    <option name="myLimit" value="2678400000" />
+  </component>
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
+  </component>
+  <component name="VcsManagerConfiguration">
+    <option name="myTodoPanelSettings">
+      <TodoPanelSettings />
+    </option>
+  </component>
+  <component name="libraryTable">
+    <library name="ant">
+      <CLASSES>
+        <root url="jar://$PROJECT_DIR$/../../lib/ant/ant.jar!/" />
+      </CLASSES>
+      <JAVADOC />
+      <SOURCES />
+    </library>
+    <library name="junit">
+      <CLASSES>
+        <root url="file://$PROJECT_DIR$/../../build/deps/junit" />
+      </CLASSES>
+      <JAVADOC />
+      <SOURCES />
+      <jarDirectory url="file://$PROJECT_DIR$/../../build/deps/junit" recursive="false" />
+    </library>
+    <library name="partest">
+      <CLASSES>
+        <root url="file://$PROJECT_DIR$/../../build/deps/partest" />
+      </CLASSES>
+      <JAVADOC />
+      <SOURCES />
+      <jarDirectory url="file://$PROJECT_DIR$/../../build/deps/partest" recursive="false" />
+    </library>
+    <library name="repl-deps">
+      <CLASSES>
+        <root url="file://$PROJECT_DIR$/../../build/deps/repl" />
+      </CLASSES>
+      <JAVADOC />
+      <SOURCES />
+      <jarDirectory url="file://$PROJECT_DIR$/../../build/deps/repl" recursive="false" />
+    </library>
+    <library name="scaladoc-deps">
+      <CLASSES>
+        <root url="file://$PROJECT_DIR$/../../build/deps/scaladoc" />
+      </CLASSES>
+      <JAVADOC />
+      <SOURCES />
+      <jarDirectory url="file://$PROJECT_DIR$/../../build/deps/scaladoc" recursive="false" />
+    </library>
+    <library name="starr" type="Scala">
+      <properties>
+        <compiler-classpath>
+          <root url="file://$PROJECT_DIR$/../../build/deps/starr/scala-compiler-2.11.2.jar" />
+          <root url="file://$PROJECT_DIR$/../../build/deps/starr/scala-library-2.11.2.jar" />
+          <root url="file://$PROJECT_DIR$/../../build/deps/starr/scala-reflect-2.11.2.jar" />
+        </compiler-classpath>
+      </properties>
+      <CLASSES>
+        <root url="jar://$PROJECT_DIR$/../../build/deps/starr/scala-library-2.11.2.jar!/" />
+        <root url="jar://$PROJECT_DIR$/../../build/deps/starr/scala-reflect-2.11.2.jar!/" />
+      </CLASSES>
+      <JAVADOC />
+      <SOURCES />
+    </library>
+    <library name="starr-no-deps" type="Scala">
+      <properties>
+        <compiler-classpath>
+          <root url="file://$PROJECT_DIR$/../../build/deps/starr/scala-compiler-2.11.2.jar" />
+          <root url="file://$PROJECT_DIR$/../../build/deps/starr/scala-library-2.11.2.jar" />
+          <root url="file://$PROJECT_DIR$/../../build/deps/starr/scala-reflect-2.11.2.jar" />
+        </compiler-classpath>
+      </properties>
+      <CLASSES />
+      <JAVADOC />
+      <SOURCES />
+    </library>
+  </component>
+</project>

--- a/src/intellij-14/scaladoc.iml.SAMPLE
+++ b/src/intellij-14/scaladoc.iml.SAMPLE
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../scaladoc">
+      <sourceFolder url="file://$MODULE_DIR$/../scaladoc" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="compiler" />
+    <orderEntry type="module" module-name="library" />
+    <orderEntry type="module" module-name="reflect" />
+    <orderEntry type="library" name="scaladoc-deps" level="project" />
+    <orderEntry type="library" name="partest" level="project" />
+    <orderEntry type="library" name="starr-no-deps" level="project" />
+  </component>
+</module>

--- a/src/intellij-14/scalap.iml.SAMPLE
+++ b/src/intellij-14/scalap.iml.SAMPLE
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../scalap">
+      <sourceFolder url="file://$MODULE_DIR$/../scalap" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="compiler" />
+    <orderEntry type="module" module-name="library" />
+    <orderEntry type="module" module-name="reflect" />
+    <orderEntry type="library" name="starr-no-deps" level="project" />
+  </component>
+</module>

--- a/src/intellij-14/setup.sh
+++ b/src/intellij-14/setup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Generates IntelliJ IDEA project files based on the checked-in samples.
+#
+
+set -e
+export SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+echo "About to delete .ipr and .iml files and replace with the .SAMPLE files. Press enter to continue or CTRL-C to cancel."
+read
+
+for f in "$SCRIPT_DIR"/*.SAMPLE; do
+  g=${f%.SAMPLE}
+  cp $f $g
+done

--- a/src/intellij-14/test-junit.iml.SAMPLE
+++ b/src/intellij-14/test-junit.iml.SAMPLE
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../../test/junit">
+      <sourceFolder url="file://$MODULE_DIR$/../../test/junit" isTestSource="true" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="junit" level="project" />
+    <orderEntry type="library" name="scaladoc-deps" level="project" />
+    <orderEntry type="module" module-name="actors" />
+    <orderEntry type="module" module-name="asm" />
+    <orderEntry type="module" module-name="compiler" />
+    <orderEntry type="module" module-name="forkjoin" />
+    <orderEntry type="module" module-name="library" />
+    <orderEntry type="module" module-name="partest-extras" />
+    <orderEntry type="module" module-name="reflect" />
+    <orderEntry type="module" module-name="repl" />
+    <orderEntry type="library" name="starr-no-deps" level="project" />
+  </component>
+</module>

--- a/src/intellij-14/test.iml.SAMPLE
+++ b/src/intellij-14/test.iml.SAMPLE
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../../test">
+      <excludeFolder url="file://$MODULE_DIR$/../../test/junit" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="actors" />
+    <orderEntry type="module" module-name="asm" />
+    <orderEntry type="module" module-name="compiler" />
+    <orderEntry type="module" module-name="forkjoin" />
+    <orderEntry type="module" module-name="library" />
+    <orderEntry type="module" module-name="partest-extras" />
+    <orderEntry type="module" module-name="reflect" />
+    <orderEntry type="module" module-name="repl" />
+    <orderEntry type="library" name="partest" level="project" />
+    <orderEntry type="library" name="scaladoc-deps" level="project" />
+    <orderEntry type="library" name="starr-no-deps" level="project" />
+  </component>
+</module>

--- a/src/intellij-14/update.sh
+++ b/src/intellij-14/update.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Updates the .SAMPLE files with the current project files.
+#
+
+set -e
+export SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+
+echo "About to create overwrite the .ipr.SAMPLE and .iml.SAMPLE files with the current project files. Press enter to continue or CTRL-C to cancel."
+read
+
+for f in "$SCRIPT_DIR"/*.{iml,ipr}; do
+  cp $f $f.SAMPLE
+done
+
+for f in "$SCRIPT_DIR"/*.SAMPLE; do
+  g=${f%.SAMPLE}
+  if [[ ! -f $g ]]; then
+    echo "Stale sample file, deleting $f"
+    rm $f
+  fi
+done


### PR DESCRIPTION
The latest version of the Scala plugin for IntelliJ IDEA introduces
a new project structure

http://blog.jetbrains.com/scala/2014/10/30/scala-plugin-update-for-intellij-idea-14-rc-is-out/

Due to a bug (https://youtrack.jetbrains.com/issue/SCL-7753), you
currently need to install the latest nightly build from here:
http://confluence.jetbrains.com/display/SCA/Scala+Plugin+Nightly+Builds+for+Cassiopeia

The new format doesn't allow scala compiler options per-module, so
the `-sourcepath src/libarary` is used for all modules.
