### PR TITLE
SI-6626 make @throws tags create links to exceptions

### DIFF
--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -107,7 +107,7 @@ sealed abstract class Option[+A] extends Product with Serializable {
 
   /** Returns the option's value.
    *  @note The option must be nonEmpty.
-   *  @throws Predef.NoSuchElementException if the option is empty.
+   *  @throws java.util.NoSuchElementException if the option is empty.
    */
   def get: A
 

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -220,7 +220,7 @@ object Predef extends LowPriorityImplicits with DeprecatedPredef {
   }
 
   /** `???` can be used for marking methods that remain to be implemented.
-   *  @throws  A `NotImplementedError`
+   *  @throws NotImplementedError
    */
   def ??? : Nothing = throw new NotImplementedError
 

--- a/src/library/scala/Product.scala
+++ b/src/library/scala/Product.scala
@@ -22,7 +22,7 @@ trait Product extends Any with Equals {
    *  product `A(x,,1,,, ..., x,,k,,)`, returns `x,,(n+1),,` where `0 < n < k`.
    *
    *  @param    n   the index of the element to return
-   *  @throws       `IndexOutOfBoundsException`
+   *  @throws       IndexOutOfBoundsException
    *  @return       the element `n` elements after the first element
    */
   def productElement(n: Int): Any

--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -58,7 +58,7 @@ case class StringContext(parts: String*) {
   /** Checks that the length of the given argument `args` is one less than the number
    *  of `parts` supplied to the enclosing `StringContext`.
    *  @param `args` The arguments to be checked.
-   *  @throws An `IllegalArgumentException` if this is not the case.
+   *  @throws IllegalArgumentException  if this is not the case.
    */
   def checkLengths(args: Seq[Any]): Unit =
     if (parts.length != args.length + 1)
@@ -85,10 +85,11 @@ case class StringContext(parts: String*) {
    *  will print the string `1 + 1 = 2`.
    *
    *  @param `args` The arguments to be inserted into the resulting string.
-   *  @throws An `IllegalArgumentException`
+   *  @throws IllegalArgumentException
    *          if the number of `parts` in the enclosing `StringContext` does not exceed
    *          the number of arguments `arg` by exactly 1.
-   *  @throws A `StringContext.InvalidEscapeException` if a `parts` string contains a backslash (`\`) character
+   *  @throws StringContext.InvalidEscapeException
+   *          if a `parts` string contains a backslash (`\`) character
    *          that does not start a valid escape sequence.
    */
   def s(args: Any*): String = standardInterpolator(treatEscapes, args)
@@ -109,7 +110,7 @@ case class StringContext(parts: String*) {
    *  }}}
    *
    *  @param `args` The arguments to be inserted into the resulting string.
-   *  @throws An `IllegalArgumentException`
+   *  @throws IllegalArgumentException
    *          if the number of `parts` in the enclosing `StringContext` does not exceed
    *          the number of arguments `arg` by exactly 1.
    */
@@ -144,10 +145,11 @@ case class StringContext(parts: String*) {
    *  }}}
    *
    *  @param `args` The arguments to be inserted into the resulting string.
-   *  @throws An `IllegalArgumentException`
+   *  @throws IllegalArgumentException
    *          if the number of `parts` in the enclosing `StringContext` does not exceed
    *          the number of arguments `arg` by exactly 1.
-   *  @throws A `StringContext.InvalidEscapeException` if a `parts` string contains a backslash (`\`) character
+   *  @throws StringContext.InvalidEscapeException
+   *          if a `parts` string contains a backslash (`\`) character
    *          that does not start a valid escape sequence.
    *
    *  Note: The `f` method works by assembling a format string from all the `parts` strings and using

--- a/src/library/scala/collection/GenSeqLike.scala
+++ b/src/library/scala/collection/GenSeqLike.scala
@@ -47,7 +47,7 @@ trait GenSeqLike[+A, +Repr] extends Any with GenIterableLike[A, Repr] with Equal
    *
    *  @param  idx  The index to select.
    *  @return the element of this $coll at index `idx`, where `0` indicates the first element.
-   *  @throws `IndexOutOfBoundsException` if `idx` does not satisfy `0 <= idx < length`.
+   *  @throws IndexOutOfBoundsException if `idx` does not satisfy `0 <= idx < length`.
    */
   def apply(idx: Int): A
 

--- a/src/library/scala/collection/GenTraversableLike.scala
+++ b/src/library/scala/collection/GenTraversableLike.scala
@@ -63,7 +63,7 @@ trait GenTraversableLike[+A, +Repr] extends Any with GenTraversableOnce[A] with 
   /** Selects the first element of this $coll.
    *  $orderDependent
    *  @return  the first element of this $coll.
-   *  @throws `NoSuchElementException` if the $coll is empty.
+   *  @throws NoSuchElementException if the $coll is empty.
    */
   def head: A
 
@@ -83,7 +83,7 @@ trait GenTraversableLike[+A, +Repr] extends Any with GenTraversableOnce[A] with 
    *  $orderDependent
    *  @return  a $coll consisting of all elements of this $coll
    *           except the first one.
-   *  @throws `UnsupportedOperationException` if the $coll is empty.
+   *  @throws UnsupportedOperationException if the $coll is empty.
    */
   def tail: Repr
 
@@ -105,7 +105,7 @@ trait GenTraversableLike[+A, +Repr] extends Any with GenTraversableOnce[A] with 
    *  $orderDependent
    *  @return  a $coll consisting of all elements of this $coll
    *           except the last one.
-   *  @throws `UnsupportedOperationException` if the $coll is empty.
+   *  @throws UnsupportedOperationException if the $coll is empty.
    */
   def init: Repr
 

--- a/src/library/scala/collection/GenTraversableOnce.scala
+++ b/src/library/scala/collection/GenTraversableOnce.scala
@@ -268,7 +268,7 @@ trait GenTraversableOnce[+A] extends Any {
    *             op(x_1, op(x_2, ..., op(x_{n-1}, x_n)...))
    *           }}}
    *           where `x,,1,,, ..., x,,n,,` are the elements of this $coll.
-   *  @throws `UnsupportedOperationException` if this $coll is empty.
+   *  @throws UnsupportedOperationException if this $coll is empty.
    */
   def reduceRight[B >: A](op: (A, B) => B): B
 

--- a/src/library/scala/collection/LinearSeqOptimized.scala
+++ b/src/library/scala/collection/LinearSeqOptimized.scala
@@ -44,7 +44,7 @@ trait LinearSeqOptimized[+A, +Repr <: LinearSeqOptimized[A, Repr]] extends Linea
 
   /** Selects an element by its index in the $coll.
    *  Note: the execution of `apply` may take time proportial to the index value.
-   *  @throws `IndexOutOfBoundsException` if `idx` does not satisfy `0 <= idx < length`.
+   *  @throws IndexOutOfBoundsException if `idx` does not satisfy `0 <= idx < length`.
    */
   def apply(n: Int): A = {
     val rest = drop(n)

--- a/src/library/scala/collection/MapLike.scala
+++ b/src/library/scala/collection/MapLike.scala
@@ -222,7 +222,7 @@ self =>
    *  but it might be overridden in subclasses.
    *
    *  @param key the given key value for which a binding is missing.
-   *  @throws `NoSuchElementException`
+   *  @throws NoSuchElementException
    */
   def default(key: A): B =
     throw new NoSuchElementException("key not found: " + key)

--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -419,7 +419,7 @@ trait TraversableLike[+A, +Repr] extends Any
   /** Selects the first element of this $coll.
    *  $orderDependent
    *  @return  the first element of this $coll.
-   *  @throws `NoSuchElementException` if the $coll is empty.
+   *  @throws NoSuchElementException if the $coll is empty.
    */
   def head: A = {
     var result: () => A = () => throw new NoSuchElementException
@@ -473,7 +473,7 @@ trait TraversableLike[+A, +Repr] extends Any
    *  $orderDependent
    *  @return  a $coll consisting of all elements of this $coll
    *           except the last one.
-   *  @throws `UnsupportedOperationException` if the $coll is empty.
+   *  @throws UnsupportedOperationException if the $coll is empty.
    */
   def init: Repr = {
     if (isEmpty) throw new UnsupportedOperationException("empty.init")

--- a/src/library/scala/collection/TraversableOnce.scala
+++ b/src/library/scala/collection/TraversableOnce.scala
@@ -159,7 +159,7 @@ trait TraversableOnce[+A] extends Any with GenTraversableOnce[A] {
    *             op( op( ... op(x_1, x_2) ..., x_{n-1}), x_n)
    *           }}}
    *           where `x,,1,,, ..., x,,n,,` are the elements of this $coll.
-   *  @throws `UnsupportedOperationException` if this $coll is empty.   */
+   *  @throws UnsupportedOperationException if this $coll is empty.   */
   def reduceLeft[B >: A](op: (B, A) => B): B = {
     if (isEmpty)
       throw new UnsupportedOperationException("empty.reduceLeft")

--- a/src/library/scala/collection/generic/GenericTraversableTemplate.scala
+++ b/src/library/scala/collection/generic/GenericTraversableTemplate.scala
@@ -45,7 +45,7 @@ trait GenericTraversableTemplate[+A, +CC[X] <: GenTraversable[X]] extends HasNew
   /** Selects the first element of this $coll.
    *
    *  @return  the first element of this $coll.
-   *  @throws `NoSuchElementException` if the $coll is empty.
+   *  @throws NoSuchElementException if the $coll is empty.
    */
   def head: A
 
@@ -202,7 +202,7 @@ trait GenericTraversableTemplate[+A, +CC[X] <: GenTraversable[X]] extends HasNew
    *          element type of this $coll is a `Traversable`.
    *  @return a two-dimensional $coll of ${coll}s which has as ''n''th row
    *          the ''n''th column of this $coll.
-   *  @throws `IllegalArgumentException` if all collections in this $coll
+   *  @throws IllegalArgumentException if all collections in this $coll
    *          are not of the same size.
    */
   @migration("`transpose` throws an `IllegalArgumentException` if collections are not uniformly sized.", "2.9.0")

--- a/src/library/scala/collection/immutable/ListSet.scala
+++ b/src/library/scala/collection/immutable/ListSet.scala
@@ -111,7 +111,7 @@ class ListSet[A] extends AbstractSet[A]
 
   /** Creates a new iterator over all elements contained in this set.
    *
-   *  @throws Predef.NoSuchElementException
+   *  @throws java.util.NoSuchElementException
    *  @return the new iterator
    */
   def iterator: Iterator[A] = new AbstractIterator[A] {
@@ -127,12 +127,12 @@ class ListSet[A] extends AbstractSet[A]
   }
 
   /**
-   *  @throws Predef.NoSuchElementException
+   *  @throws java.util.NoSuchElementException
    */
   override def head: A = throw new NoSuchElementException("Set has no elements")
 
   /**
-   *  @throws Predef.NoSuchElementException
+   *  @throws java.util.NoSuchElementException
    */
   override def tail: ListSet[A] = throw new NoSuchElementException("Next of an empty set")
 

--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -53,7 +53,7 @@ class Queue[+A] protected(protected val in: List[A], protected val out: List[A])
    *
    *  @param  n index of the element to return
    *  @return   the element at position `n` in this queue.
-   *  @throws Predef.NoSuchElementException if the queue is too short.
+   *  @throws java.util.NoSuchElementException if the queue is too short.
    */
   override def apply(n: Int): A = {
     val len = out.length
@@ -120,7 +120,7 @@ class Queue[+A] protected(protected val in: List[A], protected val out: List[A])
   /** Returns a tuple with the first element in the queue,
    *  and a new queue with this element removed.
    *
-   *  @throws Predef.NoSuchElementException
+   *  @throws java.util.NoSuchElementException
    *  @return the first element of the queue.
    */
   def dequeue: (A, Queue[A]) = out match {
@@ -139,7 +139,7 @@ class Queue[+A] protected(protected val in: List[A], protected val out: List[A])
   /** Returns the first element in the queue, or throws an error if there
    *  is no element contained in the queue.
    *
-   *  @throws Predef.NoSuchElementException
+   *  @throws java.util.NoSuchElementException
    *  @return the first element.
    */
   def front: A = head

--- a/src/library/scala/collection/immutable/Stack.scala
+++ b/src/library/scala/collection/immutable/Stack.scala
@@ -95,7 +95,7 @@ class Stack[+A] protected (protected val elems: List[A])
   /** Returns the top element of the stack. An error is signaled if
    *  there is no element on the stack.
    *
-   *  @throws Predef.NoSuchElementException
+   *  @throws java.util.NoSuchElementException
    *  @return the top element.
    */
   def top: A =
@@ -105,7 +105,7 @@ class Stack[+A] protected (protected val elems: List[A])
   /** Removes the top element from the stack.
    *  Note: should return `(A, Stack[A])` as for queues (mics)
    *
-   *  @throws Predef.NoSuchElementException
+   *  @throws java.util.NoSuchElementException
    *  @return the new stack without the former top element.
    */
   def pop: Stack[A] =

--- a/src/library/scala/collection/immutable/Stream.scala
+++ b/src/library/scala/collection/immutable/Stream.scala
@@ -225,7 +225,7 @@ self =>
    * }}}
    *
    *  @return The first element of the `Stream`.
-   *  @throws Predef.NoSuchElementException if the stream is empty.
+   *  @throws java.util.NoSuchElementException if the stream is empty.
    */
   def head: A
 
@@ -236,7 +236,7 @@ self =>
    *  returns the lazy result.
    *
    *  @return The tail of the `Stream`.
-   *  @throws Predef.UnsupportedOperationException if the stream is empty.
+   *  @throws UnsupportedOperationException if the stream is empty.
    */
   def tail: Stream[A]
 
@@ -876,7 +876,7 @@ self =>
    * @return A new `Stream` containing everything but the last element.  If your
    * `Stream` represents an infinite series, this method will not return.
    *
-   *  @throws `Predef.UnsupportedOperationException` if the stream is empty.
+   *  @throws UnsupportedOperationException if the stream is empty.
    */
   override def init: Stream[A] =
     if (isEmpty) super.init

--- a/src/library/scala/collection/immutable/StringLike.scala
+++ b/src/library/scala/collection/immutable/StringLike.scala
@@ -230,31 +230,31 @@ self =>
   def r(groupNames: String*): Regex = new Regex(toString, groupNames: _*)
 
   /**
-   * @throws `java.lang.IllegalArgumentException` - If the string does not contain a parsable boolean.
+   * @throws java.lang.IllegalArgumentException - If the string does not contain a parsable boolean.
    */
   def toBoolean: Boolean = parseBoolean(toString)
   /**
-   * @throws `java.lang.NumberFormatException` - If the string does not contain a parsable byte.
+   * @throws java.lang.NumberFormatException - If the string does not contain a parsable byte.
    */
   def toByte: Byte       = java.lang.Byte.parseByte(toString)
   /**
-   * @throws `java.lang.NumberFormatException` - If the string does not contain a parsable short.
+   * @throws java.lang.NumberFormatException - If the string does not contain a parsable short.
    */
   def toShort: Short     = java.lang.Short.parseShort(toString)
   /**
-   * @throws `java.lang.NumberFormatException`  - If the string does not contain a parsable int.
+   * @throws java.lang.NumberFormatException  - If the string does not contain a parsable int.
    */
   def toInt: Int         = java.lang.Integer.parseInt(toString)
   /**
-   * @throws `java.lang.NumberFormatException`  - If the string does not contain a parsable long.
+   * @throws java.lang.NumberFormatException  - If the string does not contain a parsable long.
    */
   def toLong: Long       = java.lang.Long.parseLong(toString)
   /**
-   * @throws `java.lang.NumberFormatException` - If the string does not contain a parsable float.
+   * @throws java.lang.NumberFormatException - If the string does not contain a parsable float.
    */
   def toFloat: Float     = java.lang.Float.parseFloat(toString)
   /**
-   * @throws `java.lang.NumberFormatException` - If the string does not contain a parsable double.
+   * @throws java.lang.NumberFormatException - If the string does not contain a parsable double.
    */
   def toDouble: Double   = java.lang.Double.parseDouble(toString)
 
@@ -287,7 +287,7 @@ self =>
    *    understands.
    *
    *  @param args the arguments used to instantiating the pattern.
-   *  @throws `java.lang.IllegalArgumentException`
+   *  @throws java.lang.IllegalArgumentException
    */
   def format(args : Any*): String =
     java.lang.String.format(toString, args map unwrapArg: _*)
@@ -304,7 +304,7 @@ self =>
    *
    *  @param l    an instance of `java.util.Locale`
    *  @param args the arguments used to instantiating the pattern.
-   *  @throws `java.lang.IllegalArgumentException`
+   *  @throws java.lang.IllegalArgumentException
    */
   def formatLocal(l: java.util.Locale, args: Any*): String =
     java.lang.String.format(l, toString, args map unwrapArg: _*)

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -133,7 +133,7 @@ class ArrayBuffer[A](override protected val initialSize: Int)
    *
    *  @param n     the index where a new element will be inserted.
    *  @param seq   the traversable object providing all elements to insert.
-   *  @throws Predef.IndexOutOfBoundsException if `n` is out of bounds.
+   *  @throws IndexOutOfBoundsException if `n` is out of bounds.
    */
   def insertAll(n: Int, seq: Traversable[A]) {
     if (n < 0 || n > size0) throw new IndexOutOfBoundsException(n.toString)
@@ -150,7 +150,7 @@ class ArrayBuffer[A](override protected val initialSize: Int)
    *
    *  @param n       the index which refers to the first element to delete.
    *  @param count   the number of elements to delete
-   *  @throws Predef.IndexOutOfBoundsException if `n` is out of bounds.
+   *  @throws IndexOutOfBoundsException if `n` is out of bounds.
    */
   override def remove(n: Int, count: Int) {
     require(count >= 0, "removing negative number of elements")

--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -132,7 +132,7 @@ final class ListBuffer[A]
    *
    *  @param n  the index of the element to replace.
    *  @param x  the new element.
-   *  @throws Predef.IndexOutOfBoundsException if `n` is out of bounds.
+   *  @throws IndexOutOfBoundsException if `n` is out of bounds.
    */
   def update(n: Int, x: A) {
     // We check the bounds early, so that we don't trigger copying.
@@ -217,7 +217,7 @@ final class ListBuffer[A]
    *
    *  @param  n     the index where a new element will be inserted.
    *  @param  seq   the iterable object providing all elements to insert.
-   *  @throws Predef.IndexOutOfBoundsException if `n` is out of bounds.
+   *  @throws IndexOutOfBoundsException if `n` is out of bounds.
    */
   def insertAll(n: Int, seq: Traversable[A]) {
     // We check the bounds early, so that we don't trigger copying.
@@ -330,7 +330,7 @@ final class ListBuffer[A]
    *  @param  n  the index which refers to the element to delete.
    *  @return n  the element that was formerly at position `n`.
    *  @note      an element must exists at position `n`.
-   *  @throws Predef.IndexOutOfBoundsException if `n` is out of bounds.
+   *  @throws IndexOutOfBoundsException if `n` is out of bounds.
    */
   def remove(n: Int): A = {
     if (n < 0 || n >= len) throw new IndexOutOfBoundsException(n.toString())

--- a/src/library/scala/collection/mutable/PriorityQueue.scala
+++ b/src/library/scala/collection/mutable/PriorityQueue.scala
@@ -126,7 +126,7 @@ class PriorityQueue[A](implicit val ord: Ordering[A])
   /** Returns the element with the highest priority in the queue,
    *  and removes this element from the queue.
    *
-   *  @throws Predef.NoSuchElementException
+   *  @throws java.util.NoSuchElementException
    *  @return   the element with the highest priority.
    */
   def dequeue(): A =

--- a/src/library/scala/collection/mutable/Queue.scala
+++ b/src/library/scala/collection/mutable/Queue.scala
@@ -58,7 +58,7 @@ extends MutableList[A]
   /** Returns the first element in the queue, and removes this element
    *  from the queue.
    *
-   *  @throws Predef.NoSuchElementException
+   *  @throws java.util.NoSuchElementException
    *  @return the first element of the queue.
    */
   def dequeue(): A =

--- a/src/library/scala/collection/mutable/SetLike.scala
+++ b/src/library/scala/collection/mutable/SetLike.scala
@@ -208,7 +208,7 @@ trait SetLike[A, +This <: SetLike[A, This] with Set[A]]
   /** Send a message to this scriptable object.
    *
    *  @param cmd  the message to send.
-   *  @throws `Predef.UnsupportedOperationException`
+   *  @throws UnsupportedOperationException
    *  if the message was not understood.
    */
   @deprecated("Scripting is deprecated.", "2.11.0")

--- a/src/library/scala/collection/mutable/Stack.scala
+++ b/src/library/scala/collection/mutable/Stack.scala
@@ -125,7 +125,7 @@ extends AbstractSeq[A]
    *  the element from the stack. An error is signaled if there is no
    *  element on the stack.
    *
-   *  @throws Predef.NoSuchElementException
+   *  @throws java.util.NoSuchElementException
    *  @return the top element
    */
   def top: A =
@@ -133,7 +133,7 @@ extends AbstractSeq[A]
 
   /** Removes the top element from the stack.
    *
-   *  @throws Predef.NoSuchElementException
+   *  @throws java.util.NoSuchElementException
    *  @return the top element
    */
   def pop(): A = {

--- a/src/library/scala/compat/Platform.scala
+++ b/src/library/scala/compat/Platform.scala
@@ -70,9 +70,9 @@ object Platform {
    *  @param elemClass the `Class` object of the component type of the array
    *  @param length    the length of the new array.
    *  @return          an array of the given component type as an `AnyRef`.
-   *  @throws `java.lang.NullPointerException` If `elemClass` is `null`.
-   *  @throws `java.lang.IllegalArgumentException` if componentType is [[scala.Unit]] or `java.lang.Void.TYPE`
-   *  @throws `java.lang.NegativeArraySizeException` if the specified length is negative
+   *  @throws java.lang.NullPointerException If `elemClass` is `null`.
+   *  @throws java.lang.IllegalArgumentException if componentType is [[scala.Unit]] or `java.lang.Void.TYPE`
+   *  @throws java.lang.NegativeArraySizeException if the specified length is negative
    */
   @inline
   def createArray(elemClass: Class[_], length: Int): AnyRef =
@@ -80,7 +80,7 @@ object Platform {
 
   /** Assigns the value of 0 to each element in the array.
     * @param arr     A non-null Array[Int].
-    * @throws `java.lang.NullPointerException` If `arr` is `null`.
+    * @throws java.lang.NullPointerException If `arr` is `null`.
     */
   @inline
   def arrayclear(arr: Array[Int]) { java.util.Arrays.fill(arr, 0) }
@@ -92,9 +92,9 @@ object Platform {
    *
    * @param    name the fully qualified name of the desired class.
    * @return   the `Class` object for the class with the specified name.
-   * @throws `java.lang.LinkageError` if the linkage fails
-   * @throws `java.lang.ExceptionInInitializerError` if the initialization provoked by this method fails
-   * @throws `java.lang.ClassNotFoundException` if the class cannot be located
+   * @throws java.lang.LinkageError if the linkage fails
+   * @throws java.lang.ExceptionInInitializerError if the initialization provoked by this method fails
+   * @throws java.lang.ClassNotFoundException if the class cannot be located
    *  @example {{{
    *  val a = scala.compat.Platform.getClassForName("java.lang.Integer")  // returns the Class[_] for java.lang.Integer
    *  }}}

--- a/src/library/scala/concurrent/package.scala
+++ b/src/library/scala/concurrent/package.scala
@@ -47,8 +47,8 @@ package object concurrent {
    *  Blocking on an [[Awaitable]] should be done using [[Await.result]] instead of `blocking`.
    *
    *  @param body         A piece of code which contains potentially blocking or long running calls.
-   *  @throws `CancellationException` if the computation was cancelled
-   *  @throws `InterruptedException` in the case that a wait within the blocking `body` was interrupted
+   *  @throws CancellationException if the computation was cancelled
+   *  @throws InterruptedException in the case that a wait within the blocking `body` was interrupted
    */
   @throws(classOf[Exception])
   def blocking[T](body: =>T): T = BlockContext.current.blockOn(body)(scala.concurrent.AwaitPermission)

--- a/src/library/scala/util/Either.scala
+++ b/src/library/scala/util/Either.scala
@@ -274,7 +274,7 @@ object Either {
    */
   final case class LeftProjection[+A, +B](e: Either[A, B]) {
     /**
-     * Returns the value from this `Left` or throws `Predef.NoSuchElementException`
+     * Returns the value from this `Left` or throws `java.util.NoSuchElementException`
      * if this is a `Right`.
      *
      * {{{
@@ -282,7 +282,7 @@ object Either {
      * Right(12).left.get // NoSuchElementException
      * }}}
      *
-     * @throws Predef.NoSuchElementException if the projection is [[scala.util.Right]]
+     * @throws java.util.NoSuchElementException if the projection is [[scala.util.Right]]
      */
     def get = e match {
       case Left(a) => a
@@ -440,14 +440,14 @@ object Either {
 
     /**
      * Returns the value from this `Right` or throws
-     * `Predef.NoSuchElementException` if this is a `Left`.
+     * `java.util.NoSuchElementException` if this is a `Left`.
      *
      * {{{
      * Right(12).right.get // 12
      * Left(12).right.get // NoSuchElementException
      * }}}
      *
-     * @throws Predef.NoSuchElementException if the projection is `Left`.
+     * @throws java.util.NoSuchElementException if the projection is `Left`.
      */
     def get = e match {
       case Left(_) =>  throw new NoSuchElementException("Either.right.value on Left")

--- a/src/reflect/scala/reflect/macros/Parsers.scala
+++ b/src/reflect/scala/reflect/macros/Parsers.scala
@@ -13,7 +13,7 @@ trait Parsers {
 
   /** Parses a string with a Scala expression into an abstract syntax tree.
    *  Only works for expressions, i.e. parsing a package declaration will fail.
-   *  @throws [[scala.reflect.macros.ParseException]]
+   *  @throws scala.reflect.macros.ParseException
    */
   def parse(code: String): Tree
 }

--- a/src/reflect/scala/reflect/macros/Typers.scala
+++ b/src/reflect/scala/reflect/macros/Typers.scala
@@ -72,7 +72,7 @@ trait Typers {
    *    `withImplicitViewsDisabled` recursively prohibits implicit views (though, implicit vals will still be looked up and filled in), default value is false
    *    `withMacrosDisabled` recursively prohibits macro expansions and macro-based implicits, default value is false
    *
-   *  @throws [[scala.reflect.macros.TypecheckException]]
+   *  @throws scala.reflect.macros.TypecheckException
    */
   def typecheck(tree: Tree, mode: TypecheckMode = TERMmode, pt: Type = universe.WildcardType, silent: Boolean = false, withImplicitViewsDisabled: Boolean = false, withMacrosDisabled: Boolean = false): Tree
 
@@ -84,7 +84,7 @@ trait Typers {
    *  Such errors don't vanish and can be inspected by turning on -Xlog-implicits.
    *  Unlike in `typecheck`, `silent` is true by default.
    *
-   *  @throws [[scala.reflect.macros.TypecheckException]]
+   *  @throws scala.reflect.macros.TypecheckException
    */
   def inferImplicitValue(pt: Type, silent: Boolean = true, withMacrosDisabled: Boolean = false, pos: Position = enclosingPosition): Tree
 
@@ -96,7 +96,7 @@ trait Typers {
    *  Such errors don't vanish and can be inspected by turning on -Xlog-implicits.
    *  Unlike in `typecheck`, `silent` is true by default.
    *
-   *  @throws [[scala.reflect.macros.TypecheckException]]
+   *  @throws scala.reflect.macros.TypecheckException
    */
   def inferImplicitView(tree: Tree, from: Type, to: Type, silent: Boolean = true, withMacrosDisabled: Boolean = false, pos: Position = enclosingPosition): Tree
 

--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -1191,7 +1191,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
      *   - top-level classes
      *   - Scala classes that were generated via jclassToScala
      *   - classes that have a class owner that has a corresponding Java class
-     *  @throws A `ClassNotFoundException` for all Scala classes not in one of these categories.
+     *  @throws ClassNotFoundException for all Scala classes not in one of these categories.
      */
     @throws(classOf[ClassNotFoundException])
     def classToJava(clazz: ClassSymbol): jClass[_] = classCache.toJava(clazz) {

--- a/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
@@ -345,12 +345,28 @@ trait CommentFactoryBase { this: MemberLookupBase =>
           Map.empty[String, Body] ++ pairs
         }
 
+        def linkedExceptions: Map[String, Body] = {
+          val m = allSymsOneTag(SimpleTagKey("throws"))
+
+          m.map { case (name,body) =>
+            val link = memberLookup(pos, name, site)
+            val newBody = body match {
+              case Body(List(Paragraph(Chain(content)))) =>
+                val descr = Text(" ") +: content
+                val entityLink = EntityLink(Monospace(Text(name)), link)
+                Body(List(Paragraph(Chain(entityLink +: descr))))
+              case _ => body
+            }
+            (name, newBody)
+          }
+        }
+
         val com = createComment (
           body0           = Some(parseWikiAtSymbol(docBody.toString, pos, site)),
           authors0        = allTags(SimpleTagKey("author")),
           see0            = allTags(SimpleTagKey("see")),
           result0         = oneTag(SimpleTagKey("return")),
-          throws0         = allSymsOneTag(SimpleTagKey("throws")),
+          throws0         = linkedExceptions,
           valueParams0    = allSymsOneTag(SimpleTagKey("param")),
           typeParams0     = allSymsOneTag(SimpleTagKey("tparam")),
           version0        = oneTag(SimpleTagKey("version")),

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
@@ -605,7 +605,7 @@ class Template(universe: doc.Universe, generator: DiagramGenerator, tpl: DocTemp
             <dd>{
               val exceptionsXml: List[NodeSeq] =
                 for((name, body) <- comment.throws.toList.sortBy(_._1) ) yield
-                  <span class="cmt">{Text(name) ++ bodyToHtml(body)}</span>
+                  <span class="cmt">{bodyToHtml(body)}</span>
               exceptionsXml.reduceLeft(_ ++ Text("") ++ _)
             }</dd>
           }

--- a/src/scaladoc/scala/tools/partest/ScaladocModelTest.scala
+++ b/src/scaladoc/scala/tools/partest/ScaladocModelTest.scala
@@ -182,14 +182,16 @@ abstract class ScaladocModelTest extends DirectTest {
       }
     }
 
-    def countLinks(c: Comment, p: EntityLink => Boolean) = {
-      def countLinks(body: Any): Int = body match {
+    def countLinks(c: Comment, p: EntityLink => Boolean): Int = countLinksInBody(c.body, p)
+
+    def countLinksInBody(body: Body, p: EntityLink => Boolean): Int = {
+      def countLinks(b: Any): Int = b match {
         case el: EntityLink if p(el) => 1
         case s: Seq[_]  => s.toList.map(countLinks(_)).sum
         case p: Product => p.productIterator.toList.map(countLinks(_)).sum
         case _          => 0
       }
-      countLinks(c.body)
+      countLinks(body)
     }
 
     def testDiagram(doc: DocTemplateEntity, diag: Option[Diagram], nodes: Int, edges: Int) = {

--- a/test/scaladoc/run/t6626.check
+++ b/test/scaladoc/run/t6626.check
@@ -1,0 +1,7 @@
+newSource:10: warning: Could not find any member to link for "SomeUnknownException".
+  /**
+  ^
+newSource:10: warning: Could not find any member to link for "IOException".
+  /**
+  ^
+Done.

--- a/test/scaladoc/run/t6626.scala
+++ b/test/scaladoc/run/t6626.scala
@@ -1,0 +1,42 @@
+import scala.tools.nsc.doc.base._
+import scala.tools.nsc.doc.base.comment._
+import scala.tools.nsc.doc.model._
+import scala.tools.partest.ScaladocModelTest
+
+object Test extends ScaladocModelTest {
+
+  override def code = """
+
+package org.foo
+
+class MyException extends Exception
+
+class MyOtherException extends Exception
+
+object Foo {
+  /**
+    * Test exception linking
+    *
+    * @throws org.foo.MyException linked with a fully-qualified name
+    * @throws MyOtherException linked with a relative name
+    * @throws SomeUnknownException not linked at all (but with some text)
+    * @throws IOException
+    */
+  def test(): Unit = ???
+}
+    """
+
+  def scaladocSettings = ""
+
+  def testModel(rootPackage: Package) = {
+    // get the quick access implicit defs in scope (_package(s), _class(es), _trait(s), object(s) _method(s), _value(s))
+    import access._
+
+    val a = rootPackage._package("org")._package("foo")._object("Foo")._method("test")
+    val throws = a.comment.get.throws
+    val allbodies = Body(throws.values.flatMap(_.blocks).toSeq)
+
+    val links = countLinksInBody(allbodies, _.link.isInstanceOf[LinkToTpl[_]])
+    assert(links == 2, links + " ==  2 (links to MyException and MyOtherException)")
+  }
+}


### PR DESCRIPTION
In scaladoc, this turns exceptions in `@throws` tags into links
(when it can find the target exception), instead of just showing
the name.

Review by @VladUreche :)
