### PR TITLE
SI-8960 Bring back the SerialVersionUID to anonymous function classes

### DIFF
--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1118,7 +1118,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val ScalaInlineClass           = requiredClass[scala.inline]
     lazy val ScalaNoInlineClass         = requiredClass[scala.noinline]
     lazy val SerialVersionUIDAttr       = requiredClass[scala.SerialVersionUID]
-    lazy val SerialVersionUIDAnnotation = AnnotationInfo(SerialVersionUIDAttr.tpe, List(Literal(Constant(0))), List())
+    lazy val SerialVersionUIDAnnotation = AnnotationInfo(SerialVersionUIDAttr.tpe, List(), List(nme.value -> LiteralAnnotArg(Constant(0))))
     lazy val SpecializedClass           = requiredClass[scala.specialized]
     lazy val ThrowsClass                = requiredClass[scala.throws[_]]
     lazy val TransientAttr              = requiredClass[scala.transient]

--- a/test/files/run/delambdafy_uncurry_byname_inline.check
+++ b/test/files/run/delambdafy_uncurry_byname_inline.check
@@ -7,7 +7,7 @@ package <empty> {
     };
     def bar(x: () => Int): Int = x.apply();
     def foo(): Int = Foo.this.bar({
-      @SerialVersionUID(0) final <synthetic> class $anonfun extends scala.runtime.AbstractFunction0[Int] with Serializable {
+      @SerialVersionUID(value = 0) final <synthetic> class $anonfun extends scala.runtime.AbstractFunction0[Int] with Serializable {
         def <init>(): <$anon: () => Int> = {
           $anonfun.super.<init>();
           ()

--- a/test/files/run/delambdafy_uncurry_inline.check
+++ b/test/files/run/delambdafy_uncurry_inline.check
@@ -7,7 +7,7 @@ package <empty> {
     };
     def bar(): Unit = {
       val f: Int => Int = {
-        @SerialVersionUID(0) final <synthetic> class $anonfun extends scala.runtime.AbstractFunction1[Int,Int] with Serializable {
+        @SerialVersionUID(value = 0) final <synthetic> class $anonfun extends scala.runtime.AbstractFunction1[Int,Int] with Serializable {
           def <init>(): <$anon: Int => Int> = {
             $anonfun.super.<init>();
             ()

--- a/test/files/run/t6028.check
+++ b/test/files/run/t6028.check
@@ -24,7 +24,7 @@ package <empty> {
         (new <$anon: Function0>(T.this, tryyParam, tryyLocal): Function0)
       }
     };
-    @SerialVersionUID(0) final <synthetic> class $anonfun$foo$1 extends scala.runtime.AbstractFunction0$mcI$sp with Serializable {
+    @SerialVersionUID(value = 0) final <synthetic> class $anonfun$foo$1 extends scala.runtime.AbstractFunction0$mcI$sp with Serializable {
       def <init>($outer: T, methodParam$1: Int, methodLocal$1: Int): <$anon: Function0> = {
         $anonfun$foo$1.super.<init>();
         ()
@@ -60,7 +60,7 @@ package <empty> {
       };
       scala.this.Predef.print(scala.Int.box(barParam$1))
     };
-    @SerialVersionUID(0) final <synthetic> class $anonfun$tryy$1 extends scala.runtime.AbstractFunction0$mcV$sp with Serializable {
+    @SerialVersionUID(value = 0) final <synthetic> class $anonfun$tryy$1 extends scala.runtime.AbstractFunction0$mcV$sp with Serializable {
       def <init>($outer: T, tryyParam$1: Int, tryyLocal$1: runtime.IntRef): <$anon: Function0> = {
         $anonfun$tryy$1.super.<init>();
         ()

--- a/test/files/run/t6555.check
+++ b/test/files/run/t6555.check
@@ -6,7 +6,7 @@ package <empty> {
       ()
     };
     private[this] val f: Int => Int = {
-      @SerialVersionUID(0) final <synthetic> class $anonfun extends scala.runtime.AbstractFunction1$mcII$sp with Serializable {
+      @SerialVersionUID(value = 0) final <synthetic> class $anonfun extends scala.runtime.AbstractFunction1$mcII$sp with Serializable {
         def <init>(): <$anon: Int => Int> = {
           $anonfun.super.<init>();
           ()

--- a/test/files/run/t8960.scala
+++ b/test/files/run/t8960.scala
@@ -1,0 +1,66 @@
+object Test extends App {
+  def test(o: AnyRef, sp: Boolean = false) = {
+    if (sp) assert(o.getClass.getSuperclass.getName contains "$sp")
+    val Some(f) = o.getClass.getDeclaredFields.find(_.getName == "serialVersionUID")
+    assert(f.getLong(null) == 0l)
+  }
+
+  test(() => (), sp = true)
+  test(() => 1,  sp = true)
+  test(() => "")
+
+  test((x: Int) => x, sp = true)
+  test((x: Boolean) => x)
+  test((x: Int) => "")
+
+  test((x1: Int, x2: Int) => 0d, sp = true)
+  test((x1: Int, x2: AnyRef) => 0d)
+  test((x1: Any, x2: Any) => x1)
+
+  // scala> println((for (i <- 3 to 22) yield (for (j <- 1 to i) yield s"x$j: Int").mkString("  test((", ", ", ") => x1)")).mkString("\n"))
+
+  test((x1: Int, x2: Int, x3: Int) => x1)
+  test((x1: Int, x2: Int, x3: Int, x4: Int) => x1)
+  test((x1: Int, x2: Int, x3: Int, x4: Int, x5: Int) => x1)
+  test((x1: Int, x2: Int, x3: Int, x4: Int, x5: Int, x6: Int) => x1)
+  test((x1: Int, x2: Int, x3: Int, x4: Int, x5: Int, x6: Int, x7: Int) => x1)
+  test((x1: Int, x2: Int, x3: Int, x4: Int, x5: Int, x6: Int, x7: Int, x8: Int) => x1)
+  test((x1: Int, x2: Int, x3: Int, x4: Int, x5: Int, x6: Int, x7: Int, x8: Int, x9: Int) => x1)
+  test((x1: Int, x2: Int, x3: Int, x4: Int, x5: Int, x6: Int, x7: Int, x8: Int, x9: Int, x10: Int) => x1)
+  test((x1: Int, x2: Int, x3: Int, x4: Int, x5: Int, x6: Int, x7: Int, x8: Int, x9: Int, x10: Int, x11: Int) => x1)
+  test((x1: Int, x2: Int, x3: Int, x4: Int, x5: Int, x6: Int, x7: Int, x8: Int, x9: Int, x10: Int, x11: Int, x12: Int) => x1)
+  test((x1: Int, x2: Int, x3: Int, x4: Int, x5: Int, x6: Int, x7: Int, x8: Int, x9: Int, x10: Int, x11: Int, x12: Int, x13: Int) => x1)
+  test((x1: Int, x2: Int, x3: Int, x4: Int, x5: Int, x6: Int, x7: Int, x8: Int, x9: Int, x10: Int, x11: Int, x12: Int, x13: Int, x14: Int) => x1)
+  test((x1: Int, x2: Int, x3: Int, x4: Int, x5: Int, x6: Int, x7: Int, x8: Int, x9: Int, x10: Int, x11: Int, x12: Int, x13: Int, x14: Int, x15: Int) => x1)
+  test((x1: Int, x2: Int, x3: Int, x4: Int, x5: Int, x6: Int, x7: Int, x8: Int, x9: Int, x10: Int, x11: Int, x12: Int, x13: Int, x14: Int, x15: Int, x16: Int) => x1)
+  test((x1: Int, x2: Int, x3: Int, x4: Int, x5: Int, x6: Int, x7: Int, x8: Int, x9: Int, x10: Int, x11: Int, x12: Int, x13: Int, x14: Int, x15: Int, x16: Int, x17: Int) => x1)
+  test((x1: Int, x2: Int, x3: Int, x4: Int, x5: Int, x6: Int, x7: Int, x8: Int, x9: Int, x10: Int, x11: Int, x12: Int, x13: Int, x14: Int, x15: Int, x16: Int, x17: Int, x18: Int) => x1)
+  test((x1: Int, x2: Int, x3: Int, x4: Int, x5: Int, x6: Int, x7: Int, x8: Int, x9: Int, x10: Int, x11: Int, x12: Int, x13: Int, x14: Int, x15: Int, x16: Int, x17: Int, x18: Int, x19: Int) => x1)
+  test((x1: Int, x2: Int, x3: Int, x4: Int, x5: Int, x6: Int, x7: Int, x8: Int, x9: Int, x10: Int, x11: Int, x12: Int, x13: Int, x14: Int, x15: Int, x16: Int, x17: Int, x18: Int, x19: Int, x20: Int) => x1)
+  test((x1: Int, x2: Int, x3: Int, x4: Int, x5: Int, x6: Int, x7: Int, x8: Int, x9: Int, x10: Int, x11: Int, x12: Int, x13: Int, x14: Int, x15: Int, x16: Int, x17: Int, x18: Int, x19: Int, x20: Int, x21: Int) => x1)
+  test((x1: Int, x2: Int, x3: Int, x4: Int, x5: Int, x6: Int, x7: Int, x8: Int, x9: Int, x10: Int, x11: Int, x12: Int, x13: Int, x14: Int, x15: Int, x16: Int, x17: Int, x18: Int, x19: Int, x20: Int, x21: Int, x22: Int) => x1)
+
+  test({
+    case x: Int => x
+  }: PartialFunction[Int, Int], sp = true)
+
+  test({
+    case x: Int => x
+  }: PartialFunction[Any, Any])
+
+  test({
+    case x: Int => ()
+  }: PartialFunction[Int, Unit], sp = true)
+
+  test({
+    case x: String => 1
+  }: PartialFunction[String, Int])
+
+  test({
+    case x: String => ()
+  }: PartialFunction[String, Unit])
+
+  test({
+    case x: String => x
+  }: PartialFunction[String, String])
+}


### PR DESCRIPTION
In PR #1673 / 4267444, the annotation `SerialVersionId` was changed
from a `StaticAnnotation` to `ClassFileAnnotation` in order to enforce
annotation arguments to be constants. That was 2.11.0.

The ID value in the AnnotationInfo moved from `args` to `assocs`, but
the backend was not adjusted. This was fixed in PR #3711 / ecbc9d0 for
2.11.1.

Unfortunately, the synthetic AnnotationInfo that is added to anonymous
function classes still used the old constructor (`args` instead of
`assocs`), so extracting the value failed, and no field was added to
the classfile.
