### PR TITLE
SI-8962 Fix regression with skolems in pattern translation

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -330,7 +330,7 @@ trait Contexts { self: Analyzer =>
 
     // if set, errors will not be reporter/thrown
     def bufferErrors = reporter.isBuffering
-    def reportErrors = !bufferErrors
+    def reportErrors = !(bufferErrors || reporter.isThrowing)
 
     // whether to *report* (which is separate from buffering/throwing) ambiguity errors
     def ambiguousErrors = this(AmbiguousErrors)
@@ -1247,6 +1247,7 @@ trait Contexts { self: Analyzer =>
     def makeImmediate: ContextReporter = this
     def makeBuffering: ContextReporter = this
     def isBuffering: Boolean           = false
+    def isThrowing: Boolean            = false
 
     /** Emit an ambiguous error according to context.ambiguousErrors
      *
@@ -1384,6 +1385,7 @@ trait Contexts { self: Analyzer =>
    * TODO: get rid of it, use ImmediateReporter and a check for reporter.hasErrors where necessary
    */
   private[typechecker] class ThrowingReporter extends ContextReporter {
+    override def isThrowing = true
     protected def handleError(pos: Position, msg: String): Unit = throw new TypeError(pos, msg)
   }
 

--- a/test/files/pos/t8962.scala
+++ b/test/files/pos/t8962.scala
@@ -1,0 +1,31 @@
+package test.nestedcov
+
+sealed abstract class Outer[+A]
+case class Let[+A](expr: Outer[Inner[A]]) extends Outer[A]
+
+sealed abstract class Inner[+A]
+
+sealed abstract class Outer2[+A, +B]
+case class Let2[+A](expr: Outer2[Inner2[A], A]) extends Outer2[A, A]
+
+sealed abstract class Inner2[+A]
+
+sealed abstract class Outer3[+A, +B]
+case class Let3[+A](expr: Outer3[A, A]) extends Outer3[A, A]
+
+object NestedCov {
+  def run[A](nc: Outer[A]) = nc match {
+    case Let(expr) =>
+      expr : Outer[Inner[A]]
+  }
+
+  def run2[A](nc: Outer2[A, A]) = nc match {
+    case Let2(expr) =>
+      expr : Outer2[Inner2[A], A]
+  }
+
+  def run3[A](nc: Outer3[A, A]) = nc match {
+    case Let3(expr) =>
+      expr : Outer3[A, A]
+  }
+}


### PR DESCRIPTION
During the refactoring of error reporting in 258d95c7b15, the result
of `Context#reportError` was changed once we had switched to
using a `ThrowingReporter`, which is still the case in post
typer phase typechecking

This was enough to provoke a type error in the enclosed test.
Here's a diff of the typer log:

```
%  scalac-hash 258d95~1 -Ytyper-debug sandbox/test.scala 2>&1 | tee sandbox/good.log
%  scalac-hash 258d95 -Ytyper-debug sandbox/test.scala 2>&1 | tee sandbox/bad.log
%  diff -U100 sandbox/{good,bad}.log | gist --filename=SI-8962-typer-log.diff
https://gist.github.com/retronym/3ccbe7e0791447d272a6
```

The test `Context#reportError` happens to be used when deciding
whether the type checker should be lenient when it hits a type error.
In lenient mode (see `adaptMismatchedSkolems`), it `adapt` retries
with after slackening the expected type by replacing GADT and
existential skolems with wildcard types. This is to accomodate
known type-incorrect trees generated by the pattern matcher.

This commit restores the old semantics of `reportError`, which means
it is `false` when a `ThrowingReporter` is being used.

Review by @adriaanm
