### PR TITLE
SI-7019 Fix crasher with private[this] extension methods

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
@@ -208,7 +208,7 @@ abstract class ExtensionMethods extends Transform with TypingTransformers {
           def makeExtensionMethodSymbol = {
             val extensionName = extensionNames(origMeth).head.toTermName
             val extensionMeth = (
-              companion.moduleClass.newMethod(extensionName, tree.pos.focus, origMeth.flags & ~OVERRIDE & ~PROTECTED | FINAL)
+              companion.moduleClass.newMethod(extensionName, tree.pos.focus, origMeth.flags & ~OVERRIDE & ~PROTECTED & ~LOCAL | FINAL)
                 setAnnotations origMeth.annotations
             )
             origMeth.removeAnnotation(TailrecClass) // it's on the extension method, now.

--- a/test/files/run/t7019.scala
+++ b/test/files/run/t7019.scala
@@ -1,0 +1,10 @@
+final class Foo(val i: Int) extends AnyVal {
+  def foo() = go(i)
+  private[this] def go(i: Int) = i * 2
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    assert(new Foo(1).foo() == 2)
+  }
+}


### PR DESCRIPTION
When we move the body of value class methods to the corresponding
extension method, we typecheck a forward method that remains
in the class. In order to allow access, this commit weakens the
access of `private[local]` extension methods to `private`.

Review by @lrytz
