### PR TITLE
SI-7602 Avoid crash in LUBs with erroneous code

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
+++ b/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
@@ -347,7 +347,9 @@ private[internal] trait GlbLubs {
           def lubsym(proto: Symbol): Symbol = {
             val prototp = lubThisType.memberInfo(proto)
             val syms = narrowts map (t =>
-              t.nonPrivateMember(proto.name).suchThat(sym =>
+              // SI-7602 With erroneous code, we could end up with overloaded symbols after filtering
+              //         so `suchThat` unsuitable.
+              t.nonPrivateMember(proto.name).filter(sym =>
                 sym.tpe matches prototp.substThis(lubThisType.typeSymbol, t)))
 
             if (syms contains NoSymbol) NoSymbol

--- a/test/files/neg/t7602.check
+++ b/test/files/neg/t7602.check
@@ -1,0 +1,5 @@
+t7602.scala:16: error: method foo is defined twice
+  conflicting symbols both originated in file 't7602.scala'
+  def foo : Device
+      ^
+one error found

--- a/test/files/neg/t7602.scala
+++ b/test/files/neg/t7602.scala
@@ -1,0 +1,26 @@
+trait Table[T]{
+  def foo : T
+}
+trait Computer
+trait Device
+ 
+object schema{
+  def lub[T]( a:T, b:T ) = ???
+  lub(null:Computers,null:Devices)
+}
+trait Computers extends Table[Computer]{
+  def foo : Computer
+}
+trait Devices extends Table[Device]{
+  def foo : Device
+  def foo : Device
+}
+/* Was:
+Exception in thread "main" java.lang.AssertionError: assertion failed: List(method foo, method foo)
+        at scala.Predef$.assert(Predef.scala:165)
+        at scala.reflect.internal.Symbols$Symbol.suchThat(Symbols.scala:1916)
+        at scala.reflect.internal.tpe.GlbLubs$$anonfun$23.apply(GlbLubs.scala:350)
+        at scala.reflect.internal.tpe.GlbLubs$$anonfun$23.apply(GlbLubs.scala:349)
+        at scala.collection.immutable.List.map(List.scala:272)
+        at scala.reflect.internal.tpe.GlbLubs$class.lubsym$1(GlbLubs.scala:349)
+*/


### PR DESCRIPTION
If a class contains a double defintion of a method that overrides
an interface method, LUBs could run into a spot where filtering
overloaded alternatives to those that match the interface method
fails to resolve to a single overload, which crashes the compiler.

This commit uses `filter` rather than `suchThat` to avoid the crash.
