### PR TITLE
SI-7596 Curtail overloaded symbols during unpickling

### DIFF
--- a/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
+++ b/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
@@ -396,7 +396,7 @@ abstract class UnPickler {
         case NOtpe                     => NoType
         case NOPREFIXtpe               => NoPrefix
         case THIStpe                   => ThisType(readSymbolRef())
-        case SINGLEtpe                 => SingleType(readTypeRef(), readSymbolRef())
+        case SINGLEtpe                 => SingleType(readTypeRef(), readSymbolRef().filter(_.isStable)) // SI-7596 account for overloading
         case SUPERtpe                  => SuperType(readTypeRef(), readTypeRef())
         case CONSTANTtpe               => ConstantType(readConstantRef())
         case TYPEREFtpe                => TypeRef(readTypeRef(), readSymbolRef(), readTypes())

--- a/test/files/pos/t7596/A_1.scala
+++ b/test/files/pos/t7596/A_1.scala
@@ -1,0 +1,10 @@
+trait Driver {
+  abstract class Table
+}
+
+object Config {
+  val driver : Driver = ???
+  def driver(a: Any) = ???
+}
+
+object Sites extends Config.driver.Table

--- a/test/files/pos/t7596/B_2.scala
+++ b/test/files/pos/t7596/B_2.scala
@@ -1,0 +1,19 @@
+object Test {
+  locally {
+    Sites: Config.driver.Table
+  }
+}
+
+// Under separate compilation, the pickler is foiled by the 
+// overloaded term `Config.driver`, and results in:
+
+// qbin/scalac test/files/pos/t7596/A_1.scala && qbin/scalac -explaintypes test/files/pos/t7596/B_2.scala
+// test/files/pos/t7596/B_2.scala:3: error: type mismatch;
+//  found   : Sites.type
+//  required: Config.driver.Table
+//     Sites: Config.driver.Table
+//     ^
+// Sites.type <: Config.driver.Table?
+//   Driver.this.type = Config.driver.type?
+//   false
+// false

--- a/test/files/pos/t7596b/A.scala
+++ b/test/files/pos/t7596b/A.scala
@@ -1,0 +1,10 @@
+trait H2Driver{
+    abstract class Table[T]
+}
+
+object Config {
+  val driver : H2Driver = ???
+  def driver(app: Any): H2Driver = ???
+}
+
+class Sites extends Config.driver.Table[String]

--- a/test/files/pos/t7596b/B.scala
+++ b/test/files/pos/t7596b/B.scala
@@ -1,0 +1,6 @@
+class DAOBase[E]{
+  type TableType <: Config.driver.Table[E]
+}
+class SitesDAO extends DAOBase[String]{
+  type TableType = Sites
+}

--- a/test/files/pos/t7596c/A_1.scala
+++ b/test/files/pos/t7596c/A_1.scala
@@ -1,0 +1,11 @@
+trait Driver {
+  abstract class Table
+}
+
+object Config {
+  val driver : Driver = ???
+  val driverUniqueName: driver.type = driver
+  def driver(a: Any) = ???
+}
+
+object Sites extends Config.driver.Table

--- a/test/files/pos/t7596c/B_2.scala
+++ b/test/files/pos/t7596c/B_2.scala
@@ -1,0 +1,9 @@
+object Test {
+  locally {
+    Sites: Config.driver.Table
+  }
+}
+
+// This variation worked by avoiding referring to the
+// overloaded term `Config.driver` in the parent type of
+// Sites


### PR DESCRIPTION
In code like:

```
object O { val x = A; def x(a: Any) = ... }
object P extends O.x.A
```

The unpickler was using an overloaded symbol for `x` in the
parent type of `P`. This led to compilation failures under
separate compilation.

The code that leads to this is in `Unpicklers`:

```
def fromName(name: Name) = name.toTermName match {
  case nme.ROOT     => loadingMirror.RootClass
  case nme.ROOTPKG  => loadingMirror.RootPackage
  case _            => adjust(owner.info.decl(name))
}
```

This commit filters the overloaded symbol based its stability
unpickling a singleton type. That seemed a slightly safer place
than in `fromName`.

Resubmission of #2664 incorporating review from @gkossakowski.

Review by @gkossakowski :)
