### PR TITLE
SI-8954 Make @deprecated{Overriding,Inheritance} aware of @deprecated.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -543,7 +543,7 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
         }
 
         def checkOverrideDeprecated() {
-          if (other.hasDeprecatedOverridingAnnotation) {
+          if (other.hasDeprecatedOverridingAnnotation && !member.ownerChain.exists(x => x.isDeprecated || x.hasBridgeAnnotation)) {
             val suffix = other.deprecatedOverridingMessage map (": " + _) getOrElse ""
             val msg = s"overriding ${other.fullLocationString} is deprecated$suffix"
             currentRun.reporting.deprecationWarning(member.pos, other, msg)
@@ -1404,7 +1404,7 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
       if (symbol.isDeprecated) {
         val concrOvers =
           symbol.allOverriddenSymbols.filter(sym =>
-            !sym.isDeprecated && !sym.isDeferred)
+            !sym.isDeprecated && !sym.isDeferred && !sym.hasDeprecatedOverridingAnnotation && !sym.enclClass.hasDeprecatedInheritanceAnnotation)
         if(!concrOvers.isEmpty)
           currentRun.reporting.deprecationWarning(
             tree.pos,

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1657,7 +1657,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
           val sameSourceFile = context.unit.source.file == psym.sourceFile
 
-          if (!isPastTyper && psym.hasDeprecatedInheritanceAnnotation && !sameSourceFile) {
+          if (!isPastTyper && psym.hasDeprecatedInheritanceAnnotation &&
+            !sameSourceFile && !context.owner.ownerChain.exists(x => x.isDeprecated || x.hasBridgeAnnotation)) {
             val suffix = psym.deprecatedInheritanceMessage map (": " + _) getOrElse ""
             val msg = s"inheritance from ${psym.fullLocationString} is deprecated$suffix"
             context.deprecationWarning(parent.pos, psym, msg)

--- a/test/files/pos/t8954.flags
+++ b/test/files/pos/t8954.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -deprecation

--- a/test/files/pos/t8954/t1.scala
+++ b/test/files/pos/t8954/t1.scala
@@ -1,0 +1,13 @@
+package scala.foo
+
+// 1. a class about to be made final
+@deprecatedInheritance class A {
+  def foo(): Unit = ???
+}
+
+// 1.1:
+// - no inheritance warning because same file
+// - no "override non-deprecated member" because @deprecatedInheritance
+class B2 extends A {
+  @deprecated("","") override def foo(): Unit = ???
+}

--- a/test/files/pos/t8954/t2.scala
+++ b/test/files/pos/t8954/t2.scala
@@ -1,0 +1,39 @@
+package scala.foo
+
+// 1.2 deprecated children should be fine...
+@deprecated("", "") class B extends A {
+
+  // 1.3 and shouldn't trigger the
+  // "overriding non-deprecated parent" warning
+  override def foo(): Unit = ???
+}
+
+@deprecated("","") class F {
+  // 1.4 a class inside a deprecated class should work too
+  class G extends A
+}
+
+// 2. a method about to be made final
+class C {
+  @deprecatedOverriding def foo(): Unit = ???
+}
+
+// 2.1 overriding with a deprecated def should be fine
+// and also shoudln't trigger the "deprecation is useless"
+// warning
+class D extends C {
+  @deprecated("","") override def foo(): Unit = ???
+}
+
+// 2.2 overriding from a deprecated class should be fine
+@deprecated("","") class E extends C {
+  override def foo(): Unit = ???
+}
+
+// 2.3 overriding from deeper inside a deprecated class
+// should work too
+@deprecated("","") class H {
+  class I extends C {
+    override def foo(): Unit = ???
+  }
+}


### PR DESCRIPTION
This makes sure that:
- there is no warning for a `@deprecated` class inheriting a
  `@deprecatedInheritance` class
- there is no warning for a `@deprecated` method or a method of a
  `@deprecated` class overriding a `@deprecatedOverriding` method

This should remove quite a few useless deprecation warnings from the
library.
