### PR TITLE
[sammy] eta-expansion, overloading, existentials

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -295,11 +295,17 @@ trait Infer extends Checkable {
         && !isByNameParamType(tp)
         && isCompatible(tp, dropByName(pt))
       )
+      def isCompatibleSam(tp: Type, pt: Type): Boolean = {
+        val samFun = typer.samToFunctionType(pt)
+        (samFun ne NoType) && isCompatible(tp, samFun)
+      }
+
       val tp1 = normalize(tp)
 
       (    (tp1 weak_<:< pt)
         || isCoercible(tp1, pt)
         || isCompatibleByName(tp, pt)
+        || isCompatibleSam(tp, pt)
       )
     }
     def isCompatibleArgs(tps: List[Type], pts: List[Type]) = (tps corresponds pts)(isCompatible)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2726,7 +2726,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
      * which must be fully defined. Would be nice to have some kind of mechanism to insert type vars in a block of code,
      * and have the instantiation of the first occurrence propagate to the rest of the block.
      *
-     * TODO: repeated and by-name params
+     * TODO: by-name params
      *  scala> trait LazySink { def accept(a: => Any): Unit }
      *  defined trait LazySink
      *
@@ -2741,19 +2741,6 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
      *  scala> f.accept(println("!"))
      *  !
      *  !
-     *  This looks like a bug:
-     *
-     *  scala> trait RepeatedSink { def accept(a: Any*): Unit }
-     *  defined trait RepeatedSink
-     *
-     *  scala> val f: RepeatedSink = (a) => println(a)
-     *  f: RepeatedSink = $anonfun$1@4799abc2
-     *
-     *  scala> f.accept(1)
-     *  WrappedArray(WrappedArray(1))
-     *
-     *  scala> f.accept(1, 2)
-     *  WrappedArray(WrappedArray(1, 2))
      */
     def synthesizeSAMFunction(sam: Symbol, fun: Function, resPt: Type, samClassTp: Type, mode: Mode): Tree = {
       // assert(fun.vparams forall (vp => isFullyDefined(vp.tpt.tpe))) -- by construction, as we take them from sam's info
@@ -2848,7 +2835,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           Nil,
           List(fun.vparams),
           TypeTree(samMethTp.finalResultType) setPos sampos.focus,
-          Apply(Ident(bodyName), fun.vparams map (p => Ident(p.name)))
+          Apply(Ident(bodyName), fun.vparams map gen.paramToArg)
         )
 
       val serializableParentAddendum =

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -790,7 +790,7 @@ trait Definitions extends api.StandardDefinitions {
      * The class defining the method is a supertype of `tp` that
      * has a public no-arg primary constructor.
      */
-    def samOf(tp: Type): Symbol = {
+    def samOf(tp: Type): Symbol = if (!settings.Xexperimental) NoSymbol else {
       // if tp has a constructor, it must be public and must not take any arguments
       // (not even an implicit argument list -- to keep it simple for now)
       val tpSym  = tp.typeSymbol

--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -432,7 +432,7 @@ private[internal] trait TypeMaps {
   object wildcardExtrapolation extends TypeMap(trackVariance = true) {
     def apply(tp: Type): Type =
       tp match {
-        case BoundedWildcardType(TypeBounds(lo, AnyTpe))  if variance.isContravariant =>lo
+        case BoundedWildcardType(TypeBounds(lo, AnyTpe)) if variance.isContravariant => lo
         case BoundedWildcardType(TypeBounds(NothingTpe, hi)) if variance.isCovariant => hi
         case tp => mapOver(tp)
       }

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -170,6 +170,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.dropSingletonType
     this.abstractTypesToBounds
     this.dropIllegalStarTypes
+    this.wildcardExtrapolation
     this.IsDependentCollector
     this.ApproximateDependentMap
     this.wildcardToTypeVarMap

--- a/test/files/neg/sammy_error_exist_no_crash.check
+++ b/test/files/neg/sammy_error_exist_no_crash.check
@@ -1,0 +1,6 @@
+sammy_error_exist_no_crash.scala:5: error: Could not derive subclass of F[? >: String]
+ (with SAM `def method apply(s: String)Int`)
+ based on: ((x$1: String) => x$1.<parseInt: error>).
+  bar(_.parseInt)
+        ^
+one error found

--- a/test/files/neg/sammy_error_exist_no_crash.flags
+++ b/test/files/neg/sammy_error_exist_no_crash.flags
@@ -1,0 +1,1 @@
+-Xexperimental

--- a/test/files/neg/sammy_error_exist_no_crash.scala
+++ b/test/files/neg/sammy_error_exist_no_crash.scala
@@ -1,0 +1,6 @@
+abstract class F[T] { def apply(s: T): Int }
+
+object NeedsNiceError {
+  def bar(x: F[_ >: String]) = ???
+  bar(_.parseInt)
+}

--- a/test/files/neg/sammy_restrictions.scala
+++ b/test/files/neg/sammy_restrictions.scala
@@ -1,28 +1,28 @@
-class NoAbstract
+abstract class NoAbstract
 
-class TwoAbstract { def ap(a: Int): Int; def pa(a: Int): Int }
+abstract class TwoAbstract { def ap(a: Int): Int; def pa(a: Int): Int }
 
-class Base // check that the super class constructor isn't considered.
-class NoEmptyConstructor(a: Int) extends Base { def this(a: String) = this(0); def ap(a: Int): Int }
+abstract class Base // check that the super class constructor isn't considered.
+abstract class NoEmptyConstructor(a: Int) extends Base { def this(a: String) = this(0); def ap(a: Int): Int }
 
-class OneEmptyConstructor() { def this(a: Int) = this(); def ap(a: Int): Int }
+abstract class OneEmptyConstructor() { def this(a: Int) = this(); def ap(a: Int): Int }
 
-class OneEmptySecondaryConstructor(a: Int) { def this() = this(0); def ap(a: Int): Int }
+abstract class OneEmptySecondaryConstructor(a: Int) { def this() = this(0); def ap(a: Int): Int }
 
-class MultipleConstructorLists()() { def ap(a: Int): Int }
+abstract class MultipleConstructorLists()() { def ap(a: Int): Int }
 
-class MultipleMethodLists()() { def ap(a: Int)(): Int }
+abstract class MultipleMethodLists()() { def ap(a: Int)(): Int }
 
-class ImplicitConstructorParam()(implicit a: String) { def ap(a: Int): Int }
+abstract class ImplicitConstructorParam()(implicit a: String) { def ap(a: Int): Int }
 
-class ImplicitMethodParam() { def ap(a: Int)(implicit b: String): Int }
+abstract class ImplicitMethodParam() { def ap(a: Int)(implicit b: String): Int }
 
-class PolyClass[T] { def ap(a: T): T }
+abstract class PolyClass[T] { def ap(a: T): T }
 
-class PolyMethod { def ap[T](a: T): T }
+abstract class PolyMethod { def ap[T](a: T): T }
 
-class OneAbstract { def ap(a: Any): Any }
-class DerivedOneAbstract extends OneAbstract
+abstract class OneAbstract { def ap(a: Int): Any }
+abstract class DerivedOneAbstract extends OneAbstract
 
 object Test {
   implicit val s: String = ""

--- a/test/files/pos/sammy_exist.flags
+++ b/test/files/pos/sammy_exist.flags
@@ -1,0 +1,1 @@
+-Xexperimental

--- a/test/files/pos/sammy_exist.scala
+++ b/test/files/pos/sammy_exist.scala
@@ -1,0 +1,24 @@
+// scala> typeOf[java.util.stream.Stream[_]].nonPrivateMember(TermName("map")).info
+// [R](x$1: java.util.function.Function[_ >: T, _ <: R])java.util.stream.Stream[R]
+
+// java.util.function.Function
+trait Fun[A, B] { def apply(x: A): B }
+
+// java.util.stream.Stream
+class S[T](x: T) { def map[R](f: Fun[_ >: T, _ <: R]): R = f(x) }
+
+class Bla { def foo: Bla = this }
+
+object T {
+  val aBlaSAM = (new S(new Bla)).map(_.foo) // : Bla should be inferred, when running under -Xexperimental [TODO]
+  val fun: Fun[Bla, Bla] = (x: Bla) => x
+  val aBlaSAMX = (new S(new Bla)).map(fun) // : Bla should be inferred, when running under -Xexperimental [TODO]
+}
+//
+// // or, maybe by variance-cast?
+// import annotation.unchecked.{uncheckedVariance => uv}
+// type SFun[-A, +B] = Fun[_ >: A, _ <: B @uv]
+//
+// def jf[T, R](f: T => R): SFun[T, R] = (x: T) => f(x): R
+//
+// val aBlaSAM = (new S(new Bla)).map(jf(_.foo)) // : Bla should be inferred [type checks, but existential inferred]

--- a/test/files/pos/sammy_exist.scala
+++ b/test/files/pos/sammy_exist.scala
@@ -9,16 +9,9 @@ class S[T](x: T) { def map[R](f: Fun[_ >: T, _ <: R]): R = f(x) }
 
 class Bla { def foo: Bla = this }
 
+// NOTE: inferred types show unmoored skolems, should pack them to display properly as bounded wildcards
 object T {
-  val aBlaSAM = (new S(new Bla)).map(_.foo) // : Bla should be inferred, when running under -Xexperimental [TODO]
+  val aBlaSAM = (new S(new Bla)).map(_.foo)
   val fun: Fun[Bla, Bla] = (x: Bla) => x
-  val aBlaSAMX = (new S(new Bla)).map(fun) // : Bla should be inferred, when running under -Xexperimental [TODO]
+  val aBlaSAMX = (new S(new Bla)).map(fun)
 }
-//
-// // or, maybe by variance-cast?
-// import annotation.unchecked.{uncheckedVariance => uv}
-// type SFun[-A, +B] = Fun[_ >: A, _ <: B @uv]
-//
-// def jf[T, R](f: T => R): SFun[T, R] = (x: T) => f(x): R
-//
-// val aBlaSAM = (new S(new Bla)).map(jf(_.foo)) // : Bla should be inferred [type checks, but existential inferred]

--- a/test/files/pos/sammy_overload.flags
+++ b/test/files/pos/sammy_overload.flags
@@ -1,0 +1,1 @@
+-Xexperimental

--- a/test/files/pos/sammy_overload.scala
+++ b/test/files/pos/sammy_overload.scala
@@ -1,0 +1,9 @@
+trait Consumer[T] {
+  def consume(x: T): Unit
+}
+
+object Test {
+  def foo(x: String): Unit = ???
+  def foo(): Unit = ???
+  val f: Consumer[_ >: String] = foo
+}

--- a/test/files/pos/sammy_override.flags
+++ b/test/files/pos/sammy_override.flags
@@ -1,0 +1,1 @@
+-Xexperimental

--- a/test/files/pos/sammy_override.scala
+++ b/test/files/pos/sammy_override.scala
@@ -1,0 +1,8 @@
+trait IntConsumer {
+  def consume(x: Int): Unit
+}
+
+object Test {
+  def anyConsumer(x: Any): Unit = ???
+  val f: IntConsumer = anyConsumer
+}

--- a/test/files/pos/t8310.flags
+++ b/test/files/pos/t8310.flags
@@ -1,0 +1,1 @@
+-Xexperimental

--- a/test/files/pos/t8310.scala
+++ b/test/files/pos/t8310.scala
@@ -1,0 +1,22 @@
+trait Comparinator[T] { def compare(a: T, b: T): Int }
+
+object TestOkay {
+  def sort(x: Comparinator[_ >: String]) = ()
+  sort((a: String, b: String) => a.compareToIgnoreCase(b))
+}
+
+object TestOkay2 {
+  def sort[T](x: Comparinator[_ >: T]) = ()
+  sort((a: String, b: String) => a.compareToIgnoreCase(b))
+}
+
+object TestOkay3 {
+  def sort[T](xs: Option[T], x: Comparinator[_ >: T]) = ()
+  sort(Some(""), (a: String, b: String) => a.compareToIgnoreCase(b))
+}
+
+object TestKoOverloaded {
+  def sort[T](xs: Option[T]) = ()
+  def sort[T](xs: Option[T], x: Comparinator[_ >: T]) = ()
+  sort(Some(""), (a: String, b: String) => a.compareToIgnoreCase(b))
+}

--- a/test/files/run/sammy_repeated.check
+++ b/test/files/run/sammy_repeated.check
@@ -1,0 +1,1 @@
+WrappedArray(1)

--- a/test/files/run/sammy_repeated.flags
+++ b/test/files/run/sammy_repeated.flags
@@ -1,0 +1,1 @@
+-Xexperimental

--- a/test/files/run/sammy_repeated.scala
+++ b/test/files/run/sammy_repeated.scala
@@ -1,0 +1,8 @@
+trait RepeatedSink { def accept(a: Any*): Unit }
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val f: RepeatedSink = (a) => println(a)
+    f.accept(1)
+  }
+}


### PR DESCRIPTION
Review by @retronym, please.

While playing with Java 8 Streams from the repl,
I realized we weren't eta-expanding,
nor resolving overloading properly for SAMs.

Also, the way Java uses wildcards to represent use-site variance
stresses type inference (since it results in existentials).

Introduce `wildcardExtrapolation` to simplify the resulting types
(without losing precision): `wildcardExtrapolation(tp) =:= tp`.

For example, the `MethodType` given by `def bla(x: (_ >: String)): (_ <: Int)`
is both a subtype and a supertype of `def bla(x: String): Int`.

Translating http://winterbe.com/posts/2014/07/31/java8-stream-tutorial-examples/ into Scala:

```
scala> import java.util.Arrays
scala> import java.util.stream.Stream
scala> import java.util.stream.IntStream
scala> val myList = Arrays.asList("a1", "a2", "b1", "c2", "c1")
myList: java.util.List[String] = [a1, a2, b1, c2, c1]

scala> myList.stream.filter(_.startsWith("c")).map(_.toUpperCase).sorted.forEach(println)
C1
C2

scala> myList.stream.filter(_.startsWith("c")).map(_.toUpperCase).sorted
res8: java.util.stream.Stream[?0] = java.util.stream.SortedOps$OfRef@133e7789

scala> Arrays.asList("a1", "a2", "a3").stream.findFirst.ifPresent(println)
a1

scala> Stream.of("a1", "a2", "a3").findFirst.ifPresent(println)
a1

scala> IntStream.range(1, 4).forEach(println)
<console>:37: error: object creation impossible, since method accept in trait IntConsumer of type (x$1: Int)Unit is not defined
(Note that Int does not match Any: class Int in package scala is a subclass of class Any in package scala, but method parameter types must match exactly.)
              IntStream.range(1, 4).forEach(println)
                                            ^

scala> IntStream.range(1, 4).forEach(println(_: Int)) // TODO: can we avoid this annotation?
1
2
3

scala> Arrays.stream(Array(1, 2, 3)).map(n => 2 * n + 1).average.ifPresent(println(_: Double))
5.0

scala> Stream.of("a1", "a2", "a3").map(_.substring(1)).mapToInt(_.parseInt).max.ifPresent(println(_: Int)) // whoops!
ReplGlobal.abort: Unknown type: <error>, <error> [class scala.reflect.internal.Types$ErrorType$, class scala.reflect.internal.Types$ErrorType$] TypeRef? false
error: Unknown type: <error>, <error> [class scala.reflect.internal.Types$ErrorType$, class scala.reflect.internal.Types$ErrorType$] TypeRef? false
scala.reflect.internal.FatalError: Unknown type: <error>, <error> [class scala.reflect.internal.Types$ErrorType$, class scala.reflect.internal.Types$ErrorType$] TypeRef? false
    at scala.reflect.internal.Reporting$class.abort(Reporting.scala:59)

scala> IntStream.range(1, 4).mapToObj(i => "a" + i).forEach(println)
a1
a2
a3

```
