### PR TITLE
SI-8965 Account for corner case in "unrelated types" warning

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1095,7 +1095,7 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
         // better to have lubbed and lost
         def warnIfLubless(): Unit = {
           val common = global.lub(List(actual.tpe, receiver.tpe))
-          if (ObjectTpe <:< common)
+          if (ObjectTpe <:< common && !(ObjectTpe <:< actual.tpe && ObjectTpe <:< receiver.tpe))
             unrelatedTypes()
         }
         // warn if actual has a case parent that is not same as receiver's;

--- a/test/files/pos/t8965.flags
+++ b/test/files/pos/t8965.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t8965.scala
+++ b/test/files/pos/t8965.scala
@@ -1,0 +1,7 @@
+class A {
+  def f(x: Any with AnyRef, y: Any with AnyRef) = x eq y
+  // a.scala:2: warning: Any and Any are unrelated: they will most likely never compare equal
+  //   def f(x: Any with AnyRef, y: Any with AnyRef) = x eq y
+  //                                                     ^
+  // one warning found
+}


### PR DESCRIPTION
It's okay for the two types to LUB to something above `Object`
if they both individially were its supertype.
