### PR TITLE
SI-8966 Allow use of jvm-1.8 via the Ant scalac task

### DIFF
--- a/src/compiler/scala/tools/ant/Scalac.scala
+++ b/src/compiler/scala/tools/ant/Scalac.scala
@@ -97,7 +97,7 @@ class Scalac extends ScalaMatchingTask with ScalacShared {
 
   /** Defines valid values for the `target` property. */
   object Target extends PermissibleValue {
-    val values = List("jvm-1.5", "jvm-1.6", "jvm-1.7")
+    val values = List("jvm-1.5", "jvm-1.6", "jvm-1.7", "jvm-1.8")
   }
 
   /** Defines valid values for the `deprecation` and `unchecked` properties. */


### PR DESCRIPTION
This option has been allowed by the command line compiler since
ee706b873a28.

This commit allows use of this via Ant.

Note: we still don't exploit the features of classfile version 52,
but watch this space as we roll out method handle based closures
soon!
