### PR TITLE
SI-6856 Fix incorrect EBNF in comment in Parsers

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1559,7 +1559,7 @@ self =>
     }
 
     /** {{{
-     *  PrefixExpr   ::= [`-' | `+' | `~' | `!' | `&'] SimpleExpr
+     *  PrefixExpr   ::= [`-' | `+' | `~' | `!'] SimpleExpr
      *  }}}
      */
     def prefixExpr(): Tree = {


### PR DESCRIPTION
'&' isn't a prefix operator, perhaps to the chagrin of the C crowd.
