### PR TITLE
SI-7750 Test case for fixed spurious existential feature warning

### DIFF
--- a/test/files/pos/t7750.flags
+++ b/test/files/pos/t7750.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -feature

--- a/test/files/pos/t7750.scala
+++ b/test/files/pos/t7750.scala
@@ -1,0 +1,8 @@
+trait LazyCombiner[Elem, +To, Buff <: Growable[Elem] with Sizing]
+trait Growable[T]
+trait Sizing
+
+
+object Test {
+  null.isInstanceOf[LazyCombiner[_, _, _]] // issued an existential feature warning
+}


### PR DESCRIPTION
In 2.11.0-M8, the enclosed test issued the following feature
warning:

```
sandbox/t7750.scala:7: warning: the existential type LazyCombiner[_$1,_$2,_$3] forSome { type _$1; type _$2; type _$3 <: Growable[_$1] with Sizing }, which cannot be expressed by wildcards,
```

This went way in 2.11.0-RC1 after we turned off the problematic
attempt to infer existential bounds based on the bounds of the
corresponding type parameters.

Review by @soc
