### PR TITLE
SI-1994 Test case for fixed overriding problem

### DIFF
--- a/test/files/run/t1994.scala
+++ b/test/files/run/t1994.scala
@@ -1,0 +1,20 @@
+class A {
+  protected def x = 0
+  protected[A] def y = 0
+}
+ 
+class B extends A {
+  override def x = 1
+  def superY = super[A].y
+  override def y = 1
+}
+
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val b = new B
+    assert(b.x == 1)
+    assert(b.y == 1)
+    assert(b.superY == 0)
+  }
+}


### PR DESCRIPTION
The test case passes since Scala 2.9.2.

Prior, it failed with:

```
~/scala/2.9.1/bin/scalac sandbox/t1994.scala
sandbox/t1994.scala:9: error: method y overrides nothing
  override def y = 1
               ^
one error found
```

Review by @gourlaysama
