### PR TITLE
Make t8960 pass under delambdafy:method

### DIFF
--- a/test/files/run/t8960.scala
+++ b/test/files/run/t8960.scala
@@ -1,6 +1,12 @@
 object Test extends App {
   def test(o: AnyRef, sp: Boolean = false) = {
-    if (sp) assert(o.getClass.getSuperclass.getName contains "$sp")
+    val isSpecialized      = o.getClass.getSuperclass.getName contains "$sp"
+    val isDelambdafyMethod = o.getClass.getName contains "$lambda$"
+    assert(
+      // delambdafy:method doesn't currently emit specialized anonymous function classes
+      if (sp) (isSpecialized || isDelambdafyMethod) else !isSpecialized,
+      o.getClass.getName)
+
     val Some(f) = o.getClass.getDeclaredFields.find(_.getName == "serialVersionUID")
     assert(f.getLong(null) == 0l)
   }


### PR DESCRIPTION
When using `delambdafy:method`, anonymous function classes are not
currently specialized, as noted here:

https://github.com/scala/scala/blob/f08e96571479552b103b15cc2d40ea5454999546/src/compiler/scala/tools/nsc/transform/Delambdafy.scala#L26

Fixes the `GenBCode` / `delambdafy:method` build (https://scala-webapps.epfl.ch/jenkins/view/2.11.x/job/scala-nightly-genbcode-2.11.x/191/console)
