### PR TITLE
SI-8502 Improve resiliance to absent packages

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -3432,10 +3432,11 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
   trait StubSymbol extends Symbol {
     devWarning("creating stub symbol to defer error: " + missingMessage)
 
-    protected def missingMessage: String
+    def missingMessage: String
 
     /** Fail the stub by throwing a [[scala.reflect.internal.MissingRequirementError]]. */
-    override final def failIfStub() = {MissingRequirementError.signal(missingMessage)} //
+    override final def failIfStub() =
+      MissingRequirementError.signal(missingMessage)
 
     /** Fail the stub by reporting an error to the reporter, setting the IS_ERROR flag
       * on this symbol, and returning the dummy value `alt`.
@@ -3460,8 +3461,8 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     override def rawInfo         = fail(NoType)
     override def companionSymbol = fail(NoSymbol)
   }
-  class StubClassSymbol(owner0: Symbol, name0: TypeName, protected val missingMessage: String) extends ClassSymbol(owner0, owner0.pos, name0) with StubSymbol
-  class StubTermSymbol(owner0: Symbol, name0: TermName, protected val missingMessage: String) extends TermSymbol(owner0, owner0.pos, name0) with StubSymbol
+  class StubClassSymbol(owner0: Symbol, name0: TypeName, val missingMessage: String) extends ClassSymbol(owner0, owner0.pos, name0) with StubSymbol
+  class StubTermSymbol(owner0: Symbol, name0: TermName, val missingMessage: String) extends TermSymbol(owner0, owner0.pos, name0) with StubSymbol
 
   trait FreeSymbol extends Symbol {
     def origin: String

--- a/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
+++ b/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
@@ -211,7 +211,12 @@ abstract class UnPickler {
         def fromName(name: Name) = name.toTermName match {
           case nme.ROOT     => loadingMirror.RootClass
           case nme.ROOTPKG  => loadingMirror.RootPackage
-          case _            => adjust(owner.info.decl(name))
+          case _            =>
+            val decl = owner match {
+              case stub: StubSymbol => NoSymbol // SI-8502 Don't call .info and fail the stub
+              case _ => owner.info.decl(name)
+            }
+            adjust(decl)
         }
         def nestedObjectSymbol: Symbol = {
           // If the owner is overloaded (i.e. a method), it's not possible to select the
@@ -389,13 +394,23 @@ abstract class UnPickler {
         case CLASSINFOtpe => ClassInfoType(parents, symScope(clazz), clazz)
       }
 
+      def readThisType(): Type = {
+        val sym = readSymbolRef() match {
+          case stub: StubSymbol if !stub.isClass =>
+            // SI-8502 This allows us to create a stub for a unpickled reference to `missingPackage.Foo`.
+            stub.owner.newStubSymbol(stub.name.toTypeName, stub.missingMessage)
+          case sym => sym
+        }
+        ThisType(sym)
+      }
+
       // We're stuck with the order types are pickled in, but with judicious use
       // of named parameters we can recapture a declarative flavor in a few cases.
       // But it's still a rat's nest of adhockery.
       (tag: @switch) match {
         case NOtpe                     => NoType
         case NOPREFIXtpe               => NoPrefix
-        case THIStpe                   => ThisType(readSymbolRef())
+        case THIStpe                   => readThisType()
         case SINGLEtpe                 => SingleType(readTypeRef(), readSymbolRef().filter(_.isStable)) // SI-7596 account for overloading
         case SUPERtpe                  => SuperType(readTypeRef(), readTypeRef())
         case CONSTANTtpe               => ConstantType(readConstantRef())

--- a/test/files/neg/t5148.check
+++ b/test/files/neg/t5148.check
@@ -1,6 +1,11 @@
 error: missing or invalid dependency detected while loading class file 'Imports.class'.
+Could not access type Wrapper in class scala.tools.nsc.interpreter.IMain.Request,
+because it (or its dependencies) are missing. Check your build definition for
+missing or conflicting dependencies. (Re-run with `-Ylog-classpath` to see the problematic classpath.)
+A full rebuild may help if 'Imports.class' was compiled against an incompatible version of scala.tools.nsc.interpreter.IMain.Request.
+error: missing or invalid dependency detected while loading class file 'Imports.class'.
 Could not access type Request in class scala.tools.nsc.interpreter.IMain,
 because it (or its dependencies) are missing. Check your build definition for
 missing or conflicting dependencies. (Re-run with `-Ylog-classpath` to see the problematic classpath.)
 A full rebuild may help if 'Imports.class' was compiled against an incompatible version of scala.tools.nsc.interpreter.IMain.
-one error found
+two errors found

--- a/test/files/run/t6440.check
+++ b/test/files/run/t6440.check
@@ -1,5 +1,4 @@
-pos: source-newSource1.scala,line-9,offset=109 missing or invalid dependency detected while loading class file 'U.class'.
-Could not access term pack1 in package <root>,
-because it (or its dependencies) are missing. Check your build definition for
-missing or conflicting dependencies. (Re-run with `-Ylog-classpath` to see the problematic classpath.)
-A full rebuild may help if 'U.class' was compiled against an incompatible version of <root>. ERROR
+pos: source-newSource1.scala,line-9,offset=109 reference to U is ambiguous;
+it is imported twice in the same scope by
+import pack2._
+and import X._ ERROR

--- a/test/files/run/t6440.scala
+++ b/test/files/run/t6440.scala
@@ -41,7 +41,7 @@ object Test extends StoreReporterDirectTest {
     assert(tClass.delete())
     assert(pack1.delete())
 
-    // bad symbolic reference error expected (but no stack trace!)
+    // should report ambiguous import, despite the fact that a parent of pack2.U is absent
     compileCode(app)
     println(filteredInfos.mkString("\n"))
   }

--- a/test/files/run/t8502.scala
+++ b/test/files/run/t8502.scala
@@ -1,0 +1,41 @@
+import scala.tools.partest._
+import java.io.File
+
+object Test extends StoreReporterDirectTest {
+  def code = ???
+
+  def compileCode(code: String) = {
+    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
+    compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(code)
+  }
+
+  def show(): Unit = {
+    compileCode("""
+      object U {
+        def foo(log: vanishing.Vanishing) = ()
+      }
+
+      package vanishing {
+        class Vanishing
+      }
+      """)
+    assert(filteredInfos.isEmpty, filteredInfos)
+    deletePackage("vanishing")
+    compileCode("""
+      class Test {
+        U
+      }
+    """)
+    assert(storeReporter.infos.isEmpty, storeReporter.infos.mkString("\n")) // Included a MissingRequirementError before.
+  }
+
+  def deletePackage(name: String) {
+    val directory = new File(testOutput.path, name)
+    for (f <- directory.listFiles()) {
+      assert(f.getName.endsWith(".class"))
+      assert(f.delete())
+    }
+    assert(directory.listFiles().isEmpty)
+    assert(directory.delete())
+  }
+}


### PR DESCRIPTION
When unpickling a class, we create stub symbols for references
to classes absent from the current classpath. If these references
only appear in method signatures that aren't called, we can
proceed with compilation. This is in line with javac.

We're getting better at this, but there are still some gaps.
This bug is about the behaviour when a package is completely
missing, rather than just a single class within that package.

To make this work we have to add two special cases to the unpickler:
- When unpickling a `ThisType`, convert a `StubTermSymbol` into
  a `StubTypeSymbol`. We hit this when unpickling
  `ThisType(missingPackage)`.
- When unpickling a reference to `<owner>.name` where `<owner>`
  is a stub symbol, don't call info on that owner, but rather
  allow the enclosing code in `readSymbol` fall through to
  create a stub for the member.

The test case was distilled from an a problem that a Spray user
encountered when Akka was missing from the classpath.

Two existing test cases have progressed, and the checkfiles are
accordingly updated.

Review by @gkossakowski
