### PR TITLE
SI-8967 Only add JARs and dirs from $SCALA_HOME/lib to classpath

### DIFF
--- a/src/compiler/scala/tools/ant/templates/tool-unix.tmpl
+++ b/src/compiler/scala/tools/ant/templates/tool-unix.tmpl
@@ -86,10 +86,14 @@ fi
 TOOL_CLASSPATH="@classpath@"
 if [[ -z "$TOOL_CLASSPATH" ]]; then
     for ext in "$SCALA_HOME"/lib/* ; do
-        if [[ -z "$TOOL_CLASSPATH" ]]; then
-            TOOL_CLASSPATH="$ext"
-        else
-            TOOL_CLASSPATH="${TOOL_CLASSPATH}${SEP}${ext}"
+        file_extension="${ext##*.}"
+        # SI-8967 Only consider directories and files named '*.jar'
+        if [[ -d "$ext" || $file_extension == "jar" ]]; then
+          if [[ -z "$TOOL_CLASSPATH" ]]; then
+              TOOL_CLASSPATH="$ext"
+          else
+              TOOL_CLASSPATH="${TOOL_CLASSPATH}${SEP}${ext}"
+          fi
         fi
     done
 fi

--- a/src/compiler/scala/tools/ant/templates/tool-windows.tmpl
+++ b/src/compiler/scala/tools/ant/templates/tool-windows.tmpl
@@ -128,7 +128,7 @@ if defined _JAVA_PARAMS set _JAVA_OPTS=%_JAVA_OPTS% %_JAVA_PARAMS%
 
 set _TOOL_CLASSPATH=@classpath@
 if "%_TOOL_CLASSPATH%"=="" (
-  for %%f in ("!_SCALA_HOME!\lib\*") do call :add_cpath "%%f"
+  for %%f in ("!_SCALA_HOME!\lib\*.jar") do call :add_cpath "%%f"
   for /d %%f in ("!_SCALA_HOME!\lib\*") do call :add_cpath "%%f"
 )
 


### PR DESCRIPTION
That's all we ship in that directory, but it seems that some
JVMs freak out with a core dump if something else ends up
in that directory and we add it to the boot classpath.

Testing on unix:

```
    % rm ./build/pack/bin.complete; ant
    % touch /Users/jason/code/scala/build/pack/lib/foo.txt
    % mkdir /Users/jason/code/scala/build/pack/lib/dir
    % bash -x ./build/pack/bin/scala -version
    ...
    /Library/Java/JavaVirtualMachines/jdk1.8.0_20.jdk/Contents/Home/bin/java -Xmx256M -Xms32M -Xbootclasspath/a:/Users/jason/code/scala/build/pack/lib/dir:/Users/jason/code/scala/build/pack/lib/jline.jar:/Users/jason/code/scala/build/pack/lib/scala-actors.jar:/Users/jason/code/scala/build/pack/lib/scala-compiler.jar:/Users/jason/code/scala/build/pack/lib/scala-continuations-library_2.11-1.0.2.jar:/Users/jason/code/scala/build/pack/lib/scala-continuations-plugin_2.11.2-1.0.2.jar:/Users/jason/code/scala/build/pack/lib/scala-library.jar:/Users/jason/code/scala/build/pack/lib/scala-parser-combinators_2.11-1.0.2.jar:/Users/jason/code/scala/build/pack/lib/scala-partest-extras.jar:/Users/jason/code/scala/build/pack/lib/scala-partest-javaagent.jar:/Users/jason/code/scala/build/pack/lib/scala-reflect.jar:/Users/jason/code/scala/build/pack/lib/scala-swing_2.11-1.0.1.jar:/Users/jason/code/scala/build/pack/lib/scala-xml_2.11-1.0.2.jar:/Users/jason/code/scala/build/pack/lib/scalap.jar -classpath '""' -Dscala.home=/Users/jason/code/scala/build/pack -Dscala.usejavacp=true -Denv.emacs= scala.tools.nsc.MainGenericRunner -version
```

The boot classpath contains `build/pack/lib/dir` but not `foo.txt`.

I will seek a Windows test of the same during PR review.

Review by @gourlaysama
