### PR TITLE
SI-8534 Avoid crash in erroneous SelectFromTypeTree

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5134,16 +5134,19 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             typed(tree.ref, MonoQualifierModes | mode.onlyTypePat, AnyRefTpe)
           }
 
-        if (!refTyped.isErrorTyped)
+        if (refTyped.isErrorTyped) {
+          setError(tree)
+        } else {
           tree setType refTyped.tpe.resultType
-
-        if (treeInfo.admitsTypeSelection(refTyped)) tree
-        else UnstableTreeError(refTyped)
+          if (refTyped.isErrorTyped || treeInfo.admitsTypeSelection(refTyped)) tree
+          else UnstableTreeError(tree)
+        }
       }
 
       def typedSelectFromTypeTree(tree: SelectFromTypeTree) = {
         val qual1 = typedType(tree.qualifier, mode)
-        if (qual1.tpe.isVolatile) TypeSelectionFromVolatileTypeError(tree, qual1)
+        if (qual1.isErrorTyped) setError(treeCopy.SelectFromTypeTree(tree, qual1, tree.name))
+        else if (qual1.tpe.isVolatile) TypeSelectionFromVolatileTypeError(tree, qual1)
         else typedSelect(tree, qual1, tree.name)
       }
 

--- a/test/files/neg/t8534.check
+++ b/test/files/neg/t8534.check
@@ -1,0 +1,4 @@
+t8534.scala:6: error: MyTrait is not an enclosing class
+  class BugTest {def isTheBugHere(in: MyTrait.this.type#SomeData) = false}
+                                      ^
+one error found

--- a/test/files/neg/t8534.scala
+++ b/test/files/neg/t8534.scala
@@ -1,0 +1,7 @@
+object line1 {
+  trait MyTrait
+}
+object line2 {
+  import line2._
+  class BugTest {def isTheBugHere(in: MyTrait.this.type#SomeData) = false}
+}

--- a/test/files/neg/t8534b.check
+++ b/test/files/neg/t8534b.check
@@ -1,0 +1,4 @@
+t8534b.scala:3: error: stable identifier required, but foo.type found.
+  type T = foo.type#Foo
+              ^
+one error found

--- a/test/files/neg/t8534b.scala
+++ b/test/files/neg/t8534b.scala
@@ -1,0 +1,4 @@
+object Test {
+  def foo = ""
+  type T = foo.type#Foo
+}

--- a/test/files/neg/t963.check
+++ b/test/files/neg/t963.check
@@ -1,9 +1,9 @@
-t963.scala:14: error: stable identifier required, but Test.this.y3.x found.
+t963.scala:14: error: stable identifier required, but y3.x.type found.
   val w3 : y3.x.type = y3.x
-              ^
-t963.scala:17: error: stable identifier required, but Test.this.y4.x found.
+               ^
+t963.scala:17: error: stable identifier required, but y4.x.type found.
   val w4 : y4.x.type = y4.x
-              ^
+               ^
 t963.scala:10: error: type mismatch;
  found   : AnyRef{def x: Integer}
  required: AnyRef{val x: Integer}


### PR DESCRIPTION
PR #2374 changed the behaviour of `typedSingletonTypeTree` in the
presence of an error typed reference tree. It incorrectly
returns the reference tree in case on an error. However, this is
a term tree, which is an inconsistent result with the input type
tree. Consequently, a `typedSelectInternal` later fails when
using this as the qualifier of a `SelectFromTypeTree`.

Both test cases enclosed show this symptom.

This commit:
- Returns `tree` rather than `refTyped` when `refTyped` is
  error typed or when it isn't suitable as a stable prefix.
- Avoids issuing a cascading "not a stable prefix" error if the
  `refTyped` is error typed.
- Adds an extra layer of defense in `typedSelectFromTypeTree`
  to bail out quickly if the qualifier is error typed.

The last measure is not necessary to fix this bug.

Review by @adriaanm
