### PR TITLE
SI-8449 Fix spurious error with Java raw type over a Scala class

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -850,13 +850,13 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
       def adaptType(): Tree = {
         // @M When not typing a type constructor (!context.inTypeConstructorAllowed)
-        // or raw type (tree.symbol.isJavaDefined && context.unit.isJava), types must be of kind *,
+        // or raw type, types must be of kind *,
         // and thus parameterized types must be applied to their type arguments
         // @M TODO: why do kind-* tree's have symbols, while higher-kinded ones don't?
         def properTypeRequired = (
              tree.hasSymbolField
           && !context.inTypeConstructorAllowed
-          && !(tree.symbol.isJavaDefined && context.unit.isJava)
+          && !context.unit.isJava
         )
         // @M: don't check tree.tpe.symbol.typeParams. check tree.tpe.typeParams!!!
         // (e.g., m[Int] --> tree.tpe.symbol.typeParams.length == 1, tree.tpe.typeParams.length == 0!)

--- a/test/files/t8449/Client.scala
+++ b/test/files/t8449/Client.scala
@@ -1,0 +1,3 @@
+object Client {
+  def foo: Any = new Test().foo
+}

--- a/test/files/t8449/Test.java
+++ b/test/files/t8449/Test.java
@@ -1,0 +1,10 @@
+public class Test {
+	// Raw type over a Scala type constructor
+	public scala.Function1 foo() { return null; }
+	// scalac reported:
+	// % scalac-hash v2.11.2 -d /tmp sandbox/{Test.java,Client.scala}
+	// sandbox/Test.java:2: error: trait Function1 takes type parameters
+	// 	public scala.Function1 foo() { return null; }
+	//                      ^
+	// one error found
+}


### PR DESCRIPTION
When the Scala typechecker typechecks signatures in Java sources,
it must enable use of a type constructor without applied type
arguments (a raw type).

However, the check in `adaptType::properTypeRequired` was too
restricive: it only allows raw types given a) we are typechecking a
Java source file and b) the type constructor itself is Java defined.

The second check does not make sense; it is perfectly legal to define
a Java raw type for over a Scala defined type constructor. This commit
removes it.

The bug was noticed in the Scaladoc context, as it explores the
signatures of all Java sources so it can document them. But the
enclosed test demonstrates the underlying bug under normal
compilation.

Review by @adriaanm
