### PR TITLE
SI-5938 Test for a FSC bug with mixin, duplicate static forwarders

### DIFF
--- a/test/files/run/t5938.scala
+++ b/test/files/run/t5938.scala
@@ -1,0 +1,35 @@
+import scala.tools.partest.DirectTest
+
+object Test extends DirectTest {
+
+  override def extraSettings: String =
+    s"-usejavacp -d ${testOutput.path}"
+
+  override def code = """
+object O extends C {
+  def main(args: Array[String]): Unit = {
+  }
+  // Static forwarder for foo and setter_foo_= added more once in a multi-run compile.
+}
+  """.trim
+
+  override def show(): Unit = {
+    val global = newCompiler()
+    Console.withErr(System.out) {
+      compileString(global)(code)
+      compileString(global)(code)
+      loadClass // was "duplicate name and signature in class X"
+    }
+  }
+
+  def loadClass: Class[_] = {
+    val cl = new java.net.URLClassLoader(Array(testOutput.toFile.toURL));
+    cl.loadClass("O")
+  }
+}
+
+trait T {
+  val foo: String = ""
+}
+class C extends T
+


### PR DESCRIPTION
Under resident compilation, we were getting multiple copies of static
forwarders created for mixed in methods. It seems like the bug was
fixed as a by-product of #4040.

This commit adds a test to show this. I've confirmed that the test
fails appropriately with 2.11.4.

For future reference, before I figured out how to write the test
for this one (test/resident doesn't seem to let you run the code
after compiling it), I was using bash to test as follows:

```
(export V=2.11.x; (scalac-hash $V sandbox/t5938_1.scala; (for i in 1 2; do echo sandbox/t5938.scala; done; printf '\n') | scalac-hash $V  -Xresident); stty echo; scala-hash $V X ; echo ':javap -public X' | scala-hash $V);
```

Review by @gkossakowski
