### PR TITLE
SI-7459 Handle pattern binders used as prefixes in TypeTrees.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -266,7 +266,7 @@ trait MatchApproximation extends TreeAndTypeAnalysis with ScalaLogic with MatchT
       // the type of the binder passed to the first invocation
       // determines the type of the tree that'll be returned for that binder as of then
       final def binderToUniqueTree(b: Symbol) =
-        unique(accumSubst(normalize(CODE.REF(b))), b.tpe)
+        unique(accumSubst(normalize(gen.mkAttributedStableRef(b))), b.tpe)
 
       // note that the sequencing of operations is important: must visit in same order as match execution
       // binderToUniqueTree uses the type of the first symbol that was encountered as the type for all future binders

--- a/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
@@ -12,7 +12,7 @@ import scala.language.postfixOps
 import scala.tools.nsc.transform.TypingTransformers
 import scala.tools.nsc.transform.Transform
 import scala.reflect.internal.util.Statistics
-import scala.reflect.internal.Types
+import scala.reflect.internal.{Mode, Types}
 import scala.reflect.internal.util.Position
 
 /** Translate pattern matching.
@@ -198,33 +198,57 @@ trait Interface extends ast.TreeDSL {
     }
 
     class Substitution(val from: List[Symbol], val to: List[Tree]) {
-      import global.{Transformer, Ident, NoType}
+      import global.{Transformer, Ident, NoType, TypeTree, SingleType}
 
       // We must explicitly type the trees that we replace inside some other tree, since the latter may already have been typed,
       // and will thus not be retyped. This means we might end up with untyped subtrees inside bigger, typed trees.
       def apply(tree: Tree): Tree = {
         // according to -Ystatistics 10% of translateMatch's time is spent in this method...
         // since about half of the typedSubst's end up being no-ops, the check below shaves off 5% of the time spent in typedSubst
-        if (!tree.exists { case i@Ident(_) => from contains i.symbol case _ => false}) tree
-        else (new Transformer {
+        val toIdents = to.forall(_.isInstanceOf[Ident])
+        val containsSym = tree.exists {
+          case i@Ident(_) => from contains i.symbol
+          case tt: TypeTree => tt.tpe.exists {
+            case SingleType(_, sym) =>
+              (from contains sym) && {
+                if (!toIdents) global.devWarning(s"Unexpected substitution of non-Ident into TypeTree `$tt`, subst= $this")
+                true
+              }
+            case _ => false
+          }
+          case _          => false
+        }
+        val toSyms = to.map(_.symbol)
+        object substIdentsForTrees extends Transformer {
           private def typedIfOrigTyped(to: Tree, origTp: Type): Tree =
             if (origTp == null || origTp == NoType) to
             // important: only type when actually substing and when original tree was typed
             // (don't need to use origTp as the expected type, though, and can't always do this anyway due to unknown type params stemming from polymorphic extractors)
             else typer.typed(to)
 
+          def typedStable(t: Tree) = typer.typed(t.shallowDuplicate, Mode.MonoQualifierModes | Mode.TYPEPATmode)
+          lazy val toTypes: List[Type] = to map (tree => typedStable(tree).tpe)
+
           override def transform(tree: Tree): Tree = {
             def subst(from: List[Symbol], to: List[Tree]): Tree =
               if (from.isEmpty) tree
-              else if (tree.symbol == from.head) typedIfOrigTyped(to.head.shallowDuplicate.setPos(tree.pos), tree.tpe)
+              else if (tree.symbol == from.head) typedIfOrigTyped(typedStable(to.head).setPos(tree.pos), tree.tpe)
               else subst(from.tail, to.tail)
 
-            tree match {
+            val tree1 = tree match {
               case Ident(_) => subst(from, to)
               case _        => super.transform(tree)
             }
+            tree1.modifyType(_.substituteTypes(from, toTypes))
           }
-        }).transform(tree)
+        }
+        if (containsSym) {
+          if (to.forall(_.isInstanceOf[Ident]))
+            tree.duplicate.substituteSymbols(from, to.map(_.symbol)) // SI-7459 catches `case t => new t.Foo`
+          else
+            substIdentsForTrees.transform(tree)
+        }
+        else tree
       }
 
 

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3727,8 +3727,12 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           case TypeRef(pre, sym, args) =>
             if (sym.isAliasType && containsLocal(tp) && (tp.dealias ne tp)) apply(tp.dealias)
             else {
-              if (pre.isVolatile)
-                InferTypeWithVolatileTypeSelectionError(tree, pre)
+              if (pre.isVolatile) pre match {
+                case SingleType(_, sym) if sym.isSynthetic && isPastTyper =>
+                  debuglog(s"ignoring volatility of prefix in pattern matcher generated inferred type: $tp") // See pos/t7459c.scala
+                case _ =>
+                  InferTypeWithVolatileTypeSelectionError(tree, pre)
+              }
               mapOver(tp)
             }
           case _ =>

--- a/test/files/pos/t7459a.scala
+++ b/test/files/pos/t7459a.scala
@@ -1,0 +1,18 @@
+trait SpecialException extends Throwable
+
+object Test {
+  def run() {
+    try {
+      ???
+    } catch {
+      case e: SpecialException => e.isInstanceOf[SpecialException]
+      case e =>
+    }
+
+    // OKAY
+    // (null: Throwable) match {
+    //   case e: SpecialException => e.isInstanceOf[SpecialException]
+    //   case e =>
+    // }
+  }
+}

--- a/test/files/pos/t7459b.scala
+++ b/test/files/pos/t7459b.scala
@@ -1,0 +1,12 @@
+import scala.concurrent._
+import scala.util._
+
+
+class Test {
+  (null: Any) match {
+    case s @ Some(_) => ???
+    case f @ _ => 
+      () => f
+      ???
+  }
+}

--- a/test/files/pos/t7459c.scala
+++ b/test/files/pos/t7459c.scala
@@ -1,0 +1,18 @@
+object Test {
+  trait Universe {
+    type Type
+    type TypeTag[A] >: Null <: TypeTagApi[A]
+    trait TypeTagApi[A] { def tpe: Type }
+  }
+  trait JavaUniverse extends Universe
+
+  trait Mirror[U <: Universe] {
+    def universe: U
+  }
+  (null: Mirror[_]).universe match {
+    case ju: JavaUniverse => 
+      val ju1 = ju
+      val f = {() => (null: ju.TypeTag[Nothing]).tpe }
+  }
+  trait M[A]
+}

--- a/test/files/pos/t7459d.scala
+++ b/test/files/pos/t7459d.scala
@@ -1,0 +1,8 @@
+class Test {
+  (null: Any) match {
+    case s @ Some(_) => ???
+    case f @ _ => 
+      () => f
+      ???
+  }
+}

--- a/test/files/pos/t7704.scala
+++ b/test/files/pos/t7704.scala
@@ -1,0 +1,10 @@
+class Attr { type V ; class Val }
+class StrAttr extends Attr { type V = String }
+class BoolAttr extends Attr { type V = Boolean }
+ 
+object Main {
+  def f(x: Attr) = x match {
+    case v: StrAttr  => new v.Val
+    case v: BoolAttr => new v.Val
+  }
+}

--- a/test/files/run/t7459a.scala
+++ b/test/files/run/t7459a.scala
@@ -1,0 +1,14 @@
+class LM {
+  class Node[B1]
+  case class CC(n: LM)
+
+  // crash
+  val f: (LM => Any) = {
+    case tttt =>
+      new tttt.Node[Any]()
+  }
+}
+
+object Test extends App {
+  new LM().f(new LM())
+}

--- a/test/files/run/t7459b-optimize.flags
+++ b/test/files/run/t7459b-optimize.flags
@@ -1,0 +1,1 @@
+-optimize

--- a/test/files/run/t7459b-optimize.scala
+++ b/test/files/run/t7459b-optimize.scala
@@ -1,0 +1,21 @@
+class LM {
+  class Node[B1]
+
+  // crash
+  val g: (CC => Any) = {
+    case CC(tttt) =>
+      new tttt.Node[Any]()
+  }
+
+  val h: (Some[CC] => Any) = {
+    case Some(CC(tttt)) =>
+      new tttt.Node[Any]()
+  }
+}
+
+object Test extends App {
+  new LM().g(new CC(new LM()))
+  new LM().h(Some(new CC(new LM())))
+}
+case class CC(n: LM)
+

--- a/test/files/run/t7459b.scala
+++ b/test/files/run/t7459b.scala
@@ -1,0 +1,21 @@
+class LM {
+  class Node[B1]
+
+  // crash
+  val g: (CC => Any) = {
+    case CC(tttt) =>
+      new tttt.Node[Any]()
+  }
+
+  val h: (Some[CC] => Any) = {
+    case Some(CC(tttt)) =>
+      new tttt.Node[Any]()
+  }
+}
+
+object Test extends App {
+  new LM().g(new CC(new LM()))
+  new LM().h(Some(new CC(new LM())))
+}
+case class CC(n: LM)
+

--- a/test/files/run/t7459c.scala
+++ b/test/files/run/t7459c.scala
@@ -1,0 +1,16 @@
+class LM {
+  class Node[B1]
+
+  // crash
+  val g: (CC => Any) = {
+    case CC(tttt) =>
+      tttt.## // no crash
+      new tttt.Node[Any]()
+  }
+}
+
+object Test extends App {
+  new LM().g(new CC(new LM()))
+}
+case class CC(n: LM)
+

--- a/test/files/run/t7459d.scala
+++ b/test/files/run/t7459d.scala
@@ -1,0 +1,15 @@
+class LM {
+  class Node[B1]
+  case class CC(n: LM)
+
+  // crash
+  val f: (LM => Any) = {
+    case tttt =>
+      val uuuu: (tttt.type, Any) = (tttt, 0)
+      new uuuu._1.Node[Any]()
+  }
+}
+
+object Test extends App {
+  new LM().f(new LM())
+}

--- a/test/files/run/t7459f.scala
+++ b/test/files/run/t7459f.scala
@@ -1,0 +1,12 @@
+object Test extends App {
+  class C
+
+  case class FooSeq(x: Int, y: String, z: C*)
+
+  FooSeq(1, "a", new C()) match {
+    case FooSeq(1, "a", x@_* ) =>
+      //println(x.toList)
+      x.asInstanceOf[x.type]
+      assert(x.isInstanceOf[x.type])
+  }
+}


### PR DESCRIPTION
Match translation was incorrect for:

```
case t => new t.C
case D(t) => new d.C
```

We would end up with Types in TypeTrees referring to the wrong
symbols, e.g:

```
// t7459a.scala
((x0$1: this.LM) => {
  case <synthetic> val x1: this.LM = x0$1;
  case4(){
   matchEnd3(new tttt.Node[Any]())
  };
  matchEnd3(x: Any){
    x
}
```

Or:
    // t7459b.scala
     ((x0$1: CC) => {
       case <synthetic> val x1: CC = x0$1;
       case4(){
         if (x1.ne(null))
           matchEnd3(new tttt.Node[Any]())
         else
           case5()
       };

This commit:
- Changes `bindSubPats` to traverse types, as well as terms,
  in search of references to bound symbols
- Changes `Substitution` to reuse `Tree#substituteSymbols` rather
  than the home-brew substitution from `Tree`s to `Tree`s, if the
  `to` trees are all `Ident`s

I had to dance around the awkward handling of "swatches" (exception
handlers that can be implemented with JVM native type switches) by
duplicating trees to avoid seeing the results of `substituteSymbols`
in `caseDefs` after we abandon that approach if we detect the
patterns are too complex late in the game.

I also had to add an escape hatch for the "type selection from
volatile type" check in the type checker. Without this, the
translation of `pos/t7459c.scala`:

```
case <synthetic> val x1: _$1 = (null: Test.Mirror[_]).universe;
case5(){
  if (x1.isInstanceOf[Test.JavaUniverse])
    {
      <synthetic> val x2: _$1 with Test.JavaUniverse = (x1.asInstanceOf[_$1 with Test.JavaUniverse]: _$1 with Test.JavaUniverse);
      matchEnd4({
        val ju1: Test.JavaUniverse = x2;
        val f: () => x2.Type = (() => (null: x2.TypeTag[Nothing]).tpe);
```

.. triggers that error at `x2.TypeTag`.

Review by @adriaanm. I think we can do better for 2.12 as we discussed in #3490.
But we should consider booking this progress.
