### PR TITLE
SI-7521 Fix erasure of parametric value classes.

### DIFF
--- a/src/reflect/scala/reflect/internal/transform/Erasure.scala
+++ b/src/reflect/scala/reflect/internal/transform/Erasure.scala
@@ -280,8 +280,17 @@ trait Erasure {
   }
 
   object boxingErasure extends ScalaErasureMap {
+    private var boxPrimitives = true
+
+    override def applyInArray(tp: Type): Type = {
+      val saved = boxPrimitives
+      boxPrimitives = false
+      try super.applyInArray(tp)
+      finally boxPrimitives = saved
+    }
+
     override def eraseNormalClassRef(tref: TypeRef) =
-      if (isPrimitiveValueClass(tref.sym)) boxedClass(tref.sym).tpe
+      if (boxPrimitives && isPrimitiveValueClass(tref.sym)) boxedClass(tref.sym).tpe
       else super.eraseNormalClassRef(tref)
     override def eraseDerivedValueClassRef(tref: TypeRef) =
       super.eraseNormalClassRef(tref)

--- a/test/files/run/t7521/Test.scala
+++ b/test/files/run/t7521/Test.scala
@@ -1,0 +1,5 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    new Wrapper(new Array[Int](1))
+  }
+}

--- a/test/files/run/t7521/Wrapper.scala
+++ b/test/files/run/t7521/Wrapper.scala
@@ -1,0 +1,1 @@
+class Wrapper[Repr](val xs: Repr) extends AnyVal

--- a/test/files/run/t7521b.check
+++ b/test/files/run/t7521b.check
@@ -1,0 +1,7 @@
+= Java Erased Signatures =
+public int C.a(Wrapper)
+public int C.b(Wrapper)
+
+= Java Generic Signatures =
+public int C.a(Wrapper<int[]>)
+public int C.b(Wrapper<java.lang.Object>)

--- a/test/files/run/t7521b.scala
+++ b/test/files/run/t7521b.scala
@@ -1,0 +1,20 @@
+class Wrapper[X](x: X)
+
+class C {
+  def a(w: Wrapper[Array[Int]]) = 0
+  def b(w: Wrapper[Int]) = 0
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val c = new C
+    c.a(new Wrapper(Array(1, 2)))
+    c.b(new Wrapper(1))
+
+    val methods = classOf[C].getDeclaredMethods.sortBy(_.getName)
+    println("= Java Erased Signatures =")
+    println(methods.mkString("\n"))
+    println("\n= Java Generic Signatures =")
+    println(methods.map(_.toGenericString).mkString("\n"))
+  }
+}


### PR DESCRIPTION
`Erasure.boxingErasure` exists to ensure that we use boxed primitives
to represent the value, if the value class has type parameters
referred to by its element type.

However, this is implenented with a type map that runs deeply
across the type. In the enclosed test case, we have
`Repr=Array[Int]`, which should be erased to `Array[Int]`, _not_
to `Array[Integer]`.

This commit ensures that the `boxingErasure` map only applies
boxing at the top level, and not within array arguments. (Other
type arguments will be erased, so we don't have to deal with them.)

Review by @gkossakowski
