### PR TITLE
SI-8944 A more resiliant naming scheme for case accessors

### DIFF
--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -111,6 +111,7 @@ trait StdNames {
     val PACKAGE: NameType                      = "package"
     val ROOT: NameType                         = "<root>"
     val SPECIALIZED_SUFFIX: NameType           = "$sp"
+    val CASE_ACCESSOR: NameType                = "$access"
 
     // value types (and AnyRef) are all used as terms as well
     // as (at least) arguments to the @specialize annotation.

--- a/test/files/run/t8944/A_1.scala
+++ b/test/files/run/t8944/A_1.scala
@@ -1,0 +1,1 @@
+case class A(private val x: String)

--- a/test/files/run/t8944/A_2.scala
+++ b/test/files/run/t8944/A_2.scala
@@ -1,0 +1,6 @@
+case class Other(private val x: String) // consume a fresh name suffix
+ 
+// the param accessor will now be called "x$2",
+// whereas the previously compiled client expects it to be called
+// x$1
+case class A(private val x: String)

--- a/test/files/run/t8944/Test_1.scala
+++ b/test/files/run/t8944/Test_1.scala
@@ -1,0 +1,3 @@
+object Test extends App {
+  val A("") = new A("")
+}

--- a/test/files/run/t8944b.scala
+++ b/test/files/run/t8944b.scala
@@ -1,0 +1,9 @@
+case class A(private var foo: Any) {
+  def m = { def foo = 42 /*will be lamba lifted to `A#foo$1`*/ }
+}
+object Test {
+  def main(args: Array[String]): Unit = {
+    val A("") = new A("")  
+    new A("").m
+  }
+}

--- a/test/files/run/t8944c.check
+++ b/test/files/run/t8944c.check
@@ -1,0 +1,5 @@
+private java.lang.Object Foo.ant()
+public java.lang.Object Foo.ant$access$0()
+private scala.collection.Seq Foo.cat()
+public scala.collection.Seq Foo.cat$access$2()
+public java.lang.Object Foo.elk()

--- a/test/files/run/t8944c.scala
+++ b/test/files/run/t8944c.scala
@@ -1,0 +1,8 @@
+case class Foo[A](private val ant: Any, elk: Any, private val cat: A*)
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    def pred(name: String) = Set("ant", "elk", "cat").exists(name contains _)
+    println(classOf[Foo[_]].getDeclaredMethods.filter(m => pred(m.getName)).sortBy(_.getName).mkString("\n"))  
+  }
+}


### PR DESCRIPTION
Case class parameters that are less that public have an extra
accessor method created to ensure universal pattern matchability.
See #4081 for more background.

Currently, this is given a fresh name based on the parameter name.
However, this is fragile and the name can change based on unrelated
edits higher up in the source file.

This commit switches to a stable naming scheme for these methods.

A non-public case field `foo` has a corresponding accessor
`foo$access$N`, where `N` is the index of the parameter within
the constructor parameter list.

The enclosed tests show a case that used to trigger a linkage
error under separate compilation that now works; shows that by
choosing the `foo$access$1` rather than `foo$1` we don't clash with
lambda lifted methods in the class; and shows the names of the
accessor methods as seen via Java reflection.

Just submitting for a test run for now.

/cc @gkossakowski who is usually has some good insights when it
comes to accessor naming schemes. This is one of the cross
compilation unit use cases that we have to deal with that Java
doesn't.
