### PR TITLE
SI-8977 remove duplicate decoder.properties from scalap

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -848,8 +848,7 @@ TODO:
     -->
 
     <path id="pack.reflect.files">    <fileset dir="${build-quick.dir}/classes/reflect"/> </path>
-    <path id="pack.scalap.files">     <fileset dir="${build-quick.dir}/classes/scalap"/>
-                                      <fileset file="${src.dir}/scalap/decoder.properties"/> </path>
+    <path id="pack.scalap.files">     <fileset dir="${build-quick.dir}/classes/scalap"/>  </path>
 
     <path id="pack.partest-extras.files"> <fileset dir="${build-quick.dir}/classes/partest-extras"/> </path>
     <path id="pack.partest-javaagent.files"> <fileset dir="${build-quick.dir}/classes/partest-javaagent"/> </path>


### PR DESCRIPTION
All .properties files in sources folder are already included in the
packed jar (see [line 1028](https://github.com/scala/scala/blob/3a949a18cee6b4197a981892f305a9890e402f12/build.xml#L1028)), so there is no need to add it again.
