### PR TITLE
Let users specify a different location for build repos than user home

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1386,6 +1386,7 @@ TODO:
       <echo message="Test pass 1 of 2 using Apache Felix ${osgi.felix.version}"/>
       <junit fork="yes" haltonfailure="yes">
         <classpath refid="test.osgi.compiler.build.path.felix"/>
+        <jvmarg value="-Duser.home=${user.home}"/>
         <batchtest fork="yes" todir="${build-osgi.dir}">
           <fileset dir="${test.osgi.classes}">
             <include name="**/*Test.class"/>
@@ -1397,6 +1398,7 @@ TODO:
       <echo message="Test pass 2 of 2 using Eclipse Equinox ${osgi.equinox.version}"/>
       <junit fork="yes" haltonfailure="yes">
         <classpath refid="test.osgi.compiler.build.path.equinox"/>
+        <jvmarg value="-Duser.home=${user.home}"/>
         <batchtest fork="yes" todir="${build-osgi.dir}">
           <fileset dir="${test.osgi.classes}">
             <include name="**/*Test.class"/>

--- a/tools/binary-repo-lib.sh
+++ b/tools/binary-repo-lib.sh
@@ -2,15 +2,16 @@
 #
 # Library to push and pull binary artifacts from a remote repository using CURL.
 
-
 remote_urlget="http://repo.typesafe.com/typesafe/scala-sha-bootstrap/org/scala-lang/bootstrap"
 remote_urlpush="http://private-repo.typesafe.com/typesafe/scala-sha-bootstrap/org/scala-lang/bootstrap"
 libraryJar="$(pwd)/lib/scala-library.jar"
 desired_ext=".desired.sha1"
 push_jar="$(pwd)/tools/push.jar"
+
 if [[ "$OSTYPE" == *Cygwin* || "$OSTYPE" == *cygwin* ]]; then push_jar="$(cygpath -m "$push_jar")"; fi
 # Cache dir has .sbt in it to line up with SBT build.
-cache_dir="${HOME}/.sbt/cache/scala"
+SCALA_BUILD_REPOS_HOME=${SCALA_BUILD_REPOS_HOME:=$HOME}
+cache_dir="${SCALA_BUILD_REPOS_HOME}/.sbt/cache/scala"
 
 # Checks whether or not curl is installed and issues a warning on failure.
 checkCurl() {


### PR DESCRIPTION
This change is helpful e.g. when setting up CI for Scala and it's important which directories are used by a build.

By default it uses .m2, .pax and .sbt/cache from user home (in general $HOME). Sometimes it's not possible to use this location and also changing a value of $HOME is not an option.

The required location should be specified both for ant's build.xml and used scripts.
In the first case specifying -Duser.home is all, what we need. But we can't just set _JAVA_OPTIONS
as then partest tests fail due to the unexpected output (an additional 'Picked up java options (...)' messages). We can set ANT_OPTS instead of this. The only problem was that OSGi JUnit tests (only they) were using $HOME anyway. I forced them to use -Duser.home by propagating this option in build.xml.

binary-repo-lib.sh is changed to use a special env variable or $HOME, when this variable is not set. Then we can do:

export SCALA_BUILD_REPOS_HOME=<some_dir>
export ANT_OPTS="$ANT_OPTS -Duser.home=$SCALA_BUILD_REPOS_HOME"
ant dist

and it will create all directories .m2, .pax and .sbt/cache in a specified $SCALA_BUILD_REPOS_HOME directory.

Note: maven's settings.xml should be located in this used $SCALA_BUILD_REPOS_HOME/.m2 and point to the repository like e.g. <some_dir>/.m2/repository
