### PR TITLE
SI-8948 resurrect the scaladoc for Any/AnyRef/Nothing/Null.

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/DocParser.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/DocParser.scala
@@ -15,13 +15,14 @@ import DocParser.Parsed
  *  right after parsing so it can read `DocDefs` from source code which would
  *  otherwise cause the compiler to go haywire.
  */
-class DocParser(settings: nsc.Settings, reporter: Reporter) extends Global(settings, reporter) {
+class DocParser(settings: nsc.Settings, reporter: Reporter) extends Global(settings, reporter) with ScaladocGlobalTrait {
   def this(settings: Settings) = this(settings, new ConsoleReporter(settings))
   def this() = this(new Settings(Console println _))
 
   // the usual global initialization
   locally { new Run() }
 
+  override def forScaladoc = true
   override protected def computeInternalPhases() {
     phasesSet += syntaxAnalyzer
   }

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -313,7 +313,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
 
     /* Subclass cache */
     private lazy val subClassesCache = (
-      if (sym == AnyRefClass) null
+      if (sym == AnyRefClass || sym == AnyClass) null
       else mutable.ListBuffer[DocTemplateEntity]()
     )
     def registerSubClass(sc: DocTemplateEntity): Unit = {


### PR DESCRIPTION
They disappeared in dc1cd96 when `scala.tools.nsc.doc.DocParser` lost
its `override def forScaladoc = true`, which used to trigger whether to
parse `DocDef` nodes. This was deprecated in favor of a custom global
when scaladoc was modularized out (#2226), but `DocParser` didn't get it
since it didn't override `forScaladoc` anymore...

I added back `forScaladoc` in `DocParser` for consistency with
`ScaladocGlobal`, although it doesn't do anything anymore.
