### PR TITLE
Add curly brace (zero-or-more) in grammar for Bindings

### DIFF
--- a/spec/13-syntax-summary.md
+++ b/spec/13-syntax-summary.md
@@ -210,7 +210,7 @@ grammar.
   ClassParams       ::=  ClassParam {‘,’ ClassParam}
   ClassParam        ::=  {Annotation} {Modifier} [(`val' | `var')]
                          id ‘:’ ParamType [‘=’ Expr]
-  Bindings          ::=  ‘(’ Binding {‘,’ Binding ‘)’
+  Bindings          ::=  ‘(’ Binding {‘,’ Binding} ‘)’
   Binding           ::=  (id | ‘_’) [‘:’ Type]
 
   Modifier          ::=  LocalModifier


### PR DESCRIPTION
Missing closing curly brace as reported by Andre at https://groups.google.com/forum/#!topic/scala-language/4Zb6dc6EEFM.
