### PR TITLE
SI-7965 Support calls to MethodHandle.{invoke,invokeExact}

### DIFF
--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -410,6 +410,19 @@ The final result of the transformation is a block of the form
 }
 ```
 
+### Signature Polymorphic Methods
+
+For invocations of signature polymorphic methods of the target platform `$f$($e_1 , \ldots , e_m$)`,
+the invoked function has a different method type `($p_1$:$T_1 , \ldots , p_n$:$T_n$)$U$` at each call
+site. The parameter types `$T_ , \ldots , T_n$` are the types of the argument expressions
+`$e_1 , \ldots , e_m$` and `$U$` is the expected type at the call site. If the expected type is
+undefined then `$U$` is `scala.AnyRef`. The parameter names `$p_1 , \ldots , p_n$` are fresh.
+
+###### Note
+
+On the Java platform version 7 and later, the methods `invoke` and `invokeExact` in class
+`java.lang.invoke.MethodHandle` are signature polymorphic.
+
 ## Method Values
 
 ```ebnf

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -514,6 +514,8 @@ trait Definitions extends api.StandardDefinitions {
     lazy val ScalaSignatureAnnotation = requiredClass[scala.reflect.ScalaSignature]
     lazy val ScalaLongSignatureAnnotation = requiredClass[scala.reflect.ScalaLongSignature]
 
+    lazy val MethodHandle = getClassIfDefined("java.lang.invoke.MethodHandle")
+
     // Option classes
     lazy val OptionClass: ClassSymbol   = requiredClass[Option[_]]
     lazy val OptionModule: ModuleSymbol = requiredModule[scala.Option.type]
@@ -1508,6 +1510,9 @@ trait Definitions extends api.StandardDefinitions {
 
       lazy val PartialManifestClass  = getTypeMember(ReflectPackage, tpnme.ClassManifest)
       lazy val ManifestSymbols = Set[Symbol](PartialManifestClass, FullManifestClass, OptManifestClass)
+
+      def isPolymorphicSignature(sym: Symbol) = PolySigMethods(sym)
+      private lazy val PolySigMethods: Set[Symbol] = Set[Symbol](MethodHandle.info.decl(sn.Invoke), MethodHandle.info.decl(sn.InvokeExact)).filter(_.exists)
     }
   }
 }

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -1147,6 +1147,7 @@ trait StdNames {
     final val GetClassLoader: TermName   = newTermName("getClassLoader")
     final val GetMethod: TermName        = newTermName("getMethod")
     final val Invoke: TermName           = newTermName("invoke")
+    final val InvokeExact: TermName      = newTermName("invokeExact")
 
     val Boxed = immutable.Map[TypeName, TypeName](
       tpnme.Boolean -> BoxedBoolean,

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -310,6 +310,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.QuasiquoteClass_api_unapply
     definitions.ScalaSignatureAnnotation
     definitions.ScalaLongSignatureAnnotation
+    definitions.MethodHandle
     definitions.OptionClass
     definitions.OptionModule
     definitions.SomeClass

--- a/test/files/run/t7965.scala
+++ b/test/files/run/t7965.scala
@@ -1,0 +1,54 @@
+// Test that scala doesn't apply boxing or varargs conversions to the
+// @PolymorphicSignature magical methods, MethodHandle#{invoke, invokeExact}
+object Test {
+  val code = """
+
+object O {
+  private def foo = "foo"
+  private def bar(x: Int): Int = -x
+  private def baz(x: Box): Unit = x.a = "present"
+  val lookup = java.lang.invoke.MethodHandles.lookup
+}
+
+import java.lang.invoke._
+class Box(var a: Any)
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    def lookup(name: String, params: Array[Class[_]], ret: Class[_]) = {
+      val mt = MethodType.methodType(ret, params)
+      O.lookup.findVirtual(O.getClass, name, mt)
+    }
+    val fooResult = (lookup("foo", Array(), classOf[String]).invokeExact(O): Int)
+    assert(fooResult == "foo")
+
+    val barResult = (lookup("bar", Array(classOf[Int]), classOf[Int]).invokeExact(O, 42): Int)
+    assert(barResult == -42)
+
+    val box = new Box(null)
+    (lookup("baz", Array(classOf[Box]), Void.TYPE).invokeExact(O, box) : Unit)
+    assert(box.a == "present")
+
+    // Note: Application in statement position in a block in Java also infers return type of Unit,
+    // but we don't support that, ascribe the type to Unit as above.
+    // as done in Java.
+    // lookup("baz", Array(classOf[Box]), Void.TYPE).invokeExact(O, box)
+    ()
+  }
+}
+
+"""
+  def main(args: Array[String]): Unit = {
+    if (util.Properties.isJavaAtLeast("1.7")) test()
+  }
+
+  def test() {
+    import scala.reflect.runtime._
+    import scala.tools.reflect.ToolBox
+
+    val m = currentMirror
+    val tb = m.mkToolBox()
+    import tb._
+    eval(parse(code))
+  }
+}


### PR DESCRIPTION
These methods are "signature polymorphic", which means that compiler
should not:
1. adapt the arguments to `Object`
2. wrap the repeated parameters in an array
3. adapt the result type to `Object` if the enclosing expression
    is a cast or if the application appears in the statement position
    of a block.

Dispiritingly, my initial attempt to implement this touched the type
checker, uncurry, erasure, and the backend.

However, I realized we could centralize handling of this in the typer
if at each application we substituted the signature polymorphic
symbol with a clone that carried its implied signature, which is
derived from the types of the arguments (typechecked without an
expected type) and position within and enclosing cast or block.

The test case requires Java 7+ to compile so is currently embedded
in a conditionally compiled block of code in a run test.

We ought to create a partest category for modern JVMs so we can
write such tests in a more natural style.

Here's how this looks in bytecode. Note the `bipush` / `istore`
before/after the invocation of `invokeExact`, and the descriptor
`(LO$;I)I`.

```
% cat sandbox/poly-sig.scala && qscala Test && echo ':javap Test$#main' | qscala
import java.lang.invoke._

object O {
  def bar(x: Int): Int = -x
}

object Test {
  def main(args: Array[String]): Unit = {
    def lookup(name: String, params: Array[Class[_]], ret: Class[_]) = {
      val lookup = java.lang.invoke.MethodHandles.lookup
      val mt = MethodType.methodType(ret, params)
      lookup.findVirtual(O.getClass, name, mt)
    }
    def lookupBar = lookup("bar", Array(classOf[Int]), classOf[Int])

    val barResult = lookupBar.invokeExact(O, 42).asInstanceOf[Int]
    ()
  }
}

scala> :javap Test$#main
  public void main(java.lang.String[]);
    descriptor: ([Ljava/lang/String;)V
    flags: ACC_PUBLIC
    Code:
      stack=3, locals=3, args_size=2
         0: aload_0
         1: invokespecial #18                 // Method lookupBar$1:()Ljava/lang/invoke/MethodHandle;
         4: getstatic     #23                 // Field O$.MODULE$:LO$;
         7: bipush        42
         9: invokevirtual #29                 // Method java/lang/invoke/MethodHandle.invokeExact:(LO$;I)I
        12: istore_2
        13: return
      LocalVariableTable:
        Start  Length  Slot  Name   Signature
            0      14     0  this   LTest$;
            0      14     1  args   [Ljava/lang/String;
           13       0     2 barResult   I
      LineNumberTable:
        line 16: 0
}
```

I've run this test across our active JVMs:

```
% for v in 1.6 1.7 1.8; do java_use $v; pt --terse test/files/run/t7965.scala || break; done
java version "1.6.0_65"
Java(TM) SE Runtime Environment (build 1.6.0_65-b14-466.1-11M4716)
Java HotSpot(TM) 64-Bit Server VM (build 20.65-b04-466.1, mixed mode)
Selected 1 tests drawn from specified tests

.

1/1 passed (elapsed time: 00:00:02)
Test Run PASSED
java version "1.7.0_71"
Java(TM) SE Runtime Environment (build 1.7.0_71-b14)
Java HotSpot(TM) 64-Bit Server VM (build 24.71-b01, mixed mode)
Selected 1 tests drawn from specified tests

.

1/1 passed (elapsed time: 00:00:07)
Test Run PASSED
java version "1.8.0_25"
Java(TM) SE Runtime Environment (build 1.8.0_25-b17)
Java HotSpot(TM) 64-Bit Server VM (build 25.25-b02, mixed mode)
Selected 1 tests drawn from specified tests

.

1/1 passed (elapsed time: 00:00:05)
Test Run PASSED
```
