### PR TITLE
SI-8970  hashCode of BigDecimal and Double do not match

### DIFF
--- a/src/library/scala/math/BigDecimal.scala
+++ b/src/library/scala/math/BigDecimal.scala
@@ -417,7 +417,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable {
   private final def computeHashCode(): Unit = {
     computedHashCode =
       if (isWhole && (precision - scale) < BigDecimal.maximumHashScale) toBigInt.hashCode
-      else if (isValidDouble) doubleValue.##
+      else if (isDecimalDouble) doubleValue.##
       else {
         val temp = bigDecimal.stripTrailingZeros
         scala.util.hashing.MurmurHash3.mixLast( temp.scaleByPowerOfTen(temp.scale).toBigInteger.hashCode, temp.scale )
@@ -477,7 +477,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable {
     * `isExactDouble`, `isBinaryDouble`, or `isDecimalDouble`, depending on the intended meaning.
     * By default, `decimal` creation is used, so `isDecimalDouble` is probably what you want.
     */
-  @deprecated("Validity has two distinct meanings.  Use `isExactBinaryDouble` or `equivalentToDouble` instead.", "2.11")
+  @deprecated("Validity has distinct meanings.  Use `isExactDouble`, `isBinaryDouble`, or `isDecimalDouble` instead.", "2.11")
   def isValidDouble = {
     val d = toDouble
     !d.isInfinity && bigDecimal.compareTo(new BigDec(d)) == 0

--- a/test/junit/scala/math/BigDecimalTest.scala
+++ b/test/junit/scala/math/BigDecimalTest.scala
@@ -222,4 +222,10 @@ class BigDecimalTest {
     for (a <- different; b <- different if (a ne b))
       assert(a != b, "BigDecimal representations of Double mistakenly conflated")
   }
+
+  // Make sure hash code agrees with decimal representation of Double
+  @Test
+  def test_SI8970() {
+    assert((0.1).## == BigDecimal(0.1).##)
+  }
 }


### PR DESCRIPTION
Switched isValidDouble (binary equivalence) to isDecimalDouble (decimal expansion equivalence), as people generally do not care about the slew of extra decimal digits off the end of the binary approximation to a decimal fraction (decimal equivalence is the standard now).

Added minimal unit test to verify behavior.
