### PR TITLE
SI-8951  SeqView and StreamView stack-overflow on index < 0 when flatMapped

### DIFF
--- a/src/library/scala/collection/SeqViewLike.scala
+++ b/src/library/scala/collection/SeqViewLike.scala
@@ -83,6 +83,7 @@ trait SeqViewLike[+A,
     }
     def length = index(self.length)
     def apply(idx: Int) = {
+      if (idx < 0 || idx >= self.length) throw new IndexOutOfBoundsException(idx.toString)
       val row = findRow(idx, 0, self.length - 1)
       mapping(self(row)).seq.toSeq(idx - index(row))
     }


### PR DESCRIPTION
Checks and throws IndexOutOfBounds now.

No test, caught and checked by scala-collections-laws (line 405 presently).
