### PR TITLE
SI-8924 No outer ref in LinearSeq iterator

### DIFF
--- a/src/library/scala/collection/LinearSeqLike.scala
+++ b/src/library/scala/collection/LinearSeqLike.scala
@@ -58,12 +58,11 @@ trait LinearSeqLike[+A, +Repr <: LinearSeqLike[A, Repr]] extends SeqLike[A, Repr
         val result = these.head; these = these.tail; result
       } else Iterator.empty.next()
 
-    /** Have to clear `these` so the iterator is exhausted like
-     *  it would be without the optimization.
-     */
     override def toList: List[A] = {
       val xs = these.toList
-      these = newBuilder.result()
+      // exhaust the iterator. Also, don't hold outer ref to self (SI-8924). This gets an empty Repr.
+      // TODO in 2.12, move this anon class to private member of companion, for extra protection from ourselves.
+      these = these take 0
       xs
     }
   }

--- a/test/junit/scala/collection/IterableViewLikeTest.scala
+++ b/test/junit/scala/collection/IterableViewLikeTest.scala
@@ -1,5 +1,7 @@
 package scala.collection
 
+import language.postfixOps
+
 import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/test/junit/scala/collection/LinearSeqLikeTest.scala
+++ b/test/junit/scala/collection/LinearSeqLikeTest.scala
@@ -1,0 +1,85 @@
+package scala.collection
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import java.lang.ref._
+
+@RunWith(classOf[JUnit4])
+class LinearSeqLikeTest {
+
+  // Wait for the list ref to go stale.
+  // A helper thread allocates to goose collection.
+  // The allocation delta must be small enough to create
+  // pressure without failing outright.
+  // In failure mode, the OOME causes the test thread
+  // to fail with InterruptedException.
+  // The test completes quickly.
+  @Test
+  def exhaustedIteratorMustNotReferenceUnderlyingSeq(): Unit = {
+    //import java.lang.management._
+    //Console println ManagementFactory.getMemoryMXBean.getHeapMemoryUsage
+
+    exhaustedIteratorTestFor(List(1, 2, 3), 2)
+
+    exhaustedIteratorTestFor(mutable.MutableList(1, 2, 3), 2)
+
+    //Console println ManagementFactory.getMemoryMXBean.getHeapMemoryUsage
+  }
+
+  private def exhaustedIteratorTestFor[A, Repr <: LinearSeqLike[A, Repr]](gen: => Repr, two: A): Unit = {
+    val refq = new ReferenceQueue[Repr]
+
+    // a list's iterator and a weak ref to the list
+    def data = {
+      var list = gen
+      val ref  = new WeakReference(list, refq)
+      val res  = (ref, list.iterator)
+      list     = null.asInstanceOf[Repr]     // paranoia
+      res
+    }
+
+    val (ref, it) = data
+
+    //assertNotNull(ref.get)                 // likely
+    it.next()                                // exercise
+    val rest = it.toList                     // must exhaust iterator
+
+    assertTrue(it.isEmpty)
+    assertEquals(two, rest.head)
+
+    // apply gentle pressure
+    class Alloc(val parent: Thread) extends Runnable {
+      @volatile var done  = false
+      @volatile var count = 0
+
+      var allocated  = List.empty[Array[Byte]]
+      val allocation = 1 * 1024 * 1024
+
+      override def run(): Unit = {
+        while (!done) {
+          try {
+            allocated = Array.ofDim[Byte](allocation) :: allocated
+          } catch {
+            case _: OutOfMemoryError => parent.interrupt() ; done = true
+          }
+          count += 1
+          Thread.`yield`()
+        }
+      }
+    }
+    val alloc   = new Alloc(Thread.currentThread)
+    val t       = new Thread(alloc)
+    val timeout = 60 * 1000L                 // wait a minute
+    val got =
+      try {
+        t.start()
+        refq.remove(timeout)
+      } finally alloc.done = true
+    assertEquals(ref, got)
+    assertNull(ref.get)
+    //Console println s"Done after ${alloc.count}"
+  }
+}

--- a/test/junit/scala/collection/LinearSeqLikeTest.scala
+++ b/test/junit/scala/collection/LinearSeqLikeTest.scala
@@ -6,27 +6,31 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import java.lang.ref._
+import java.lang.management._
+import java.lang.Thread.{ `yield` => share }
 
 @RunWith(classOf[JUnit4])
 class LinearSeqLikeTest {
 
-  // Wait for the list ref to go stale.
-  // A helper thread allocates to goose collection.
-  // The allocation delta must be small enough to create
-  // pressure without failing outright.
-  // In failure mode, the OOME causes the test thread
-  // to fail with InterruptedException.
-  // The test completes quickly.
+  /** Exhaust iterator and wait for ref to underlying list to go stale.
+   *
+   *  A helper thread allocates to goose collection.
+   *  The allocation delta must be small enough to create
+   *  pressure without failing outright.
+   *
+   *  In failure mode, the heap bump (or OOME) causes the test thread
+   *  to fail with InterruptedException.
+   *
+   *  To avoid false negatives on heap bump, the reference queue is checked
+   *  a second time, so in that case the timeout period is always incurred.
+   *  The long timeout accommodates loaded test servers.
+   *
+   *  Otherwise, the test completes quickly.
+   */
   @Test
   def exhaustedIteratorMustNotReferenceUnderlyingSeq(): Unit = {
-    //import java.lang.management._
-    //Console println ManagementFactory.getMemoryMXBean.getHeapMemoryUsage
-
     exhaustedIteratorTestFor(List(1, 2, 3), 2)
-
     exhaustedIteratorTestFor(mutable.MutableList(1, 2, 3), 2)
-
-    //Console println ManagementFactory.getMemoryMXBean.getHeapMemoryUsage
   }
 
   private def exhaustedIteratorTestFor[A, Repr <: LinearSeqLike[A, Repr]](gen: => Repr, two: A): Unit = {
@@ -47,39 +51,76 @@ class LinearSeqLikeTest {
     it.next()                                // exercise
     val rest = it.toList                     // must exhaust iterator
 
-    assertTrue(it.isEmpty)
-    assertEquals(two, rest.head)
+    assertTrue(it.isEmpty)                   // exhausted
+    assertEquals(two, rest.head)             // sanity check
 
-    // apply gentle pressure
-    class Alloc(val parent: Thread) extends Runnable {
-      @volatile var done  = false
-      @volatile var count = 0
-
-      var allocated  = List.empty[Array[Byte]]
-      val allocation = 1 * 1024 * 1024
-
-      override def run(): Unit = {
-        while (!done) {
-          try {
-            allocated = Array.ofDim[Byte](allocation) :: allocated
-          } catch {
-            case _: OutOfMemoryError => parent.interrupt() ; done = true
-          }
-          count += 1
-          Thread.`yield`()
-        }
-      }
-    }
     val alloc   = new Alloc(Thread.currentThread)
     val t       = new Thread(alloc)
     val timeout = 60 * 1000L                 // wait a minute
+
+    // in case alloc failed spuriously (maybe due to other activity in the JVM)
+    // give gc another chance to do the right thing
+    def retry() = {
+      assertTrue(alloc.fault)
+      val retry = refq.remove(timeout)
+      if (retry == null) fail(s"Memory exhaustion (${alloc.cause})")
+      else retry
+    }
     val got =
       try {
         t.start()
         refq.remove(timeout)
-      } finally alloc.done = true
-    assertEquals(ref, got)
-    assertNull(ref.get)
+      } catch {
+        case _: InterruptedException if alloc.fault => retry()
+        case e: InterruptedException                => throw e
+      } finally {
+        try {
+          alloc.done = true
+          t.join(timeout)
+        } catch {
+          // ignore error after refq.remove completes
+          case e: InterruptedException => if (!alloc.fault) throw e
+        }
+      }
+    assertEquals("Timeout remove", ref, got) // null on timeout
+    assertNull("Not collectable", ref.get)   // collection was collectable
     //Console println s"Done after ${alloc.count}"
+  }
+
+  // apply gentle pressure
+  private class Alloc(val parent: Thread) extends Runnable {
+    @volatile var done  = false
+    @volatile var fault = false
+    @volatile var cause = "NONE"
+    @volatile var count = 0
+
+    var allocated  = Array.empty[Byte]
+    val allocation = 1 * 1024 * 1024
+
+    // allocate until heap grows or OOM, then interrupt parent.
+    override def run(): Unit = {
+      val mxb = ManagementFactory.getMemoryMXBean
+      val mem = mxb.getHeapMemoryUsage
+      //Console println mem
+      def fail(what: String) =
+        if (!done) {
+          done  = true
+          fault = true
+          cause = what
+          parent.interrupt()
+          //Console println mxb.getHeapMemoryUsage
+        }
+      while (!done) {
+        try {
+          allocated = Array.ofDim[Byte](allocation)
+          count += 1
+          if (mxb.getHeapMemoryUsage.getCommitted > mem.getCommitted) fail("BUMP")
+        } catch {
+          case _: OutOfMemoryError => fail("OOME")
+        }
+        assertEquals(allocation, allocated.length)
+        share()                              // share the CPU
+      }
+    }
   }
 }


### PR DESCRIPTION
The iterator for `LinearSeqLike` holds an outer pointer via
the call to `newBuilder`, which is used to empty the underlying
sequence on `toList`.

A better strategy is to use `these take 0` to create the empty
`Seq`.  We can rely on `take 0` to mean the empty `Repr`.

The unit test confirms that a weak reference to the sequence
is collectable after `seq.iterator.toList`.
