### PR TITLE
spec: Add a link to the sources from the main page

### DIFF
--- a/spec/index.md
+++ b/spec/index.md
@@ -6,6 +6,8 @@ layout: toc
 # The Scala Language Specification
 # Version 2.11
 
+### Maintained online at [https://github.com/scala/scala/tree/2.11.x/spec](https://github.com/scala/scala/tree/2.11.x/spec)
+
 ### Martin Odersky, Philippe Altherr, Vincent Cremet, Gilles Dubochet, Burak Emir, Philipp Haller, Stéphane Micheloud, Nikolay Mihaylov, Adriaan Moors, Lukas Rytz, Michel Schinz, Erik Stenman, Matthias Zenger
 
 ### Markdown Conversion by Iain McGinniss.


### PR DESCRIPTION
Alternatively, the link could be added to the header of each page, but this requires messing with the CSS which hardcodes the height of the header for some reason.
