### PR TITLE
SI-8814  mutable.LongMap loses its LongMapness when adding with +

### DIFF
--- a/src/library/scala/collection/mutable/AnyRefMap.scala
+++ b/src/library/scala/collection/mutable/AnyRefMap.scala
@@ -335,6 +335,24 @@ extends AbstractMap[K, V]
     arm
   }
   
+  override def +[V1 >: V](kv: (K, V1)): AnyRefMap[K, V1] = {
+    val arm = clone().asInstanceOf[AnyRefMap[K, V1]]
+    arm += kv
+    arm
+  }
+  
+  override def ++[V1 >: V](xs: GenTraversableOnce[(K, V1)]): AnyRefMap[K, V1] = {
+    val arm = clone().asInstanceOf[AnyRefMap[K, V1]]
+    xs.foreach(kv => arm += kv)
+    arm
+  }
+  
+  override def updated[V1 >: V](key: K, value: V1): AnyRefMap[K, V1] = {
+    val arm = clone().asInstanceOf[AnyRefMap[K, V1]]
+    arm += (key, value)
+    arm
+  }
+  
   private[this] def foreachElement[A,B](elems: Array[AnyRef], f: A => B) {
     var i,j = 0
     while (i < _hashes.length & j < _size) {

--- a/src/library/scala/collection/mutable/LongMap.scala
+++ b/src/library/scala/collection/mutable/LongMap.scala
@@ -415,6 +415,24 @@ extends AbstractMap[Long, V]
     lm
   }
   
+  override def +[V1 >: V](kv: (Long, V1)): LongMap[V1] = {
+    val lm = clone().asInstanceOf[LongMap[V1]]
+    lm += kv
+    lm
+  }
+  
+  override def ++[V1 >: V](xs: GenTraversableOnce[(Long, V1)]): LongMap[V1] = {
+    val lm = clone().asInstanceOf[LongMap[V1]]
+    xs.foreach(kv => lm += kv)
+    lm
+  }
+  
+  override def updated[V1 >: V](key: Long, value: V1): LongMap[V1] = {
+    val lm = clone().asInstanceOf[LongMap[V1]]
+    lm += (key, value)
+    lm
+  }
+
   /** Applies a function to all keys of this map. */
   def foreachKey[A](f: Long => A) {
     if ((extraKeys & 1) == 1) f(0L)


### PR DESCRIPTION
Added overrides for +, ++, and updated to both LongMap and AnyRefMap.

No tests; this was caught by scala-collections-laws.
