### PR TITLE
SI-8765  immutable.HashSet exposes internal updated0 method

### DIFF
--- a/src/library/scala/collection/parallel/immutable/ParHashSet.scala
+++ b/src/library/scala/collection/parallel/immutable/ParHashSet.scala
@@ -197,7 +197,7 @@ extends scala.collection.parallel.BucketCombiner[T, ParHashSet[T], Any, HashSetC
         while (i < chunksz) {
           val v = chunkarr(i).asInstanceOf[T]
           val hc = trie.computeHash(v)
-          trie = trie.updated0(v, hc, rootbits)
+          trie = trie.updated0(v, hc, rootbits)  // internal API, private[collection]
           i += 1
         }
         i = 0


### PR DESCRIPTION
Made all internal methods protected or private[immutable], as appropriate.  No deprecation, as there was no real way to sanely use these.  No test, as this is better caught by inspection than compilation failure tests.
