### PR TITLE
SI-8727  Map.filterKeys result's contains and get are inconsistent

### DIFF
--- a/src/library/scala/collection/MapLike.scala
+++ b/src/library/scala/collection/MapLike.scala
@@ -230,11 +230,15 @@ self =>
   protected class FilteredKeys(p: A => Boolean) extends AbstractMap[A, B] with DefaultMap[A, B] {
     override def foreach[C](f: ((A, B)) => C): Unit = for (kv <- self) if (p(kv._1)) f(kv)
     def iterator = self.iterator.filter(kv => p(kv._1))
-    override def contains(key: A) = self.contains(key) && p(key)
+    override def contains(key: A) = p(key) && self.contains(key)
     def get(key: A) = if (!p(key)) None else self.get(key)
   }
 
   /** Filters this map by retaining only keys satisfying a predicate.
+   *
+   *  '''Note''': the predicate must accept any key of type `A`, not just those already
+   *  present in the map, as the predicate is tested before the underlying map is queried.
+   *
    *  @param  p   the predicate used to test keys
    *  @return an immutable map consisting only of those key value pairs of this map where the key satisfies
    *          the predicate `p`. The resulting map wraps the original map without copying any elements.

--- a/test/junit/scala/collection/SetMapConsistencyTest.scala
+++ b/test/junit/scala/collection/SetMapConsistencyTest.scala
@@ -529,4 +529,15 @@ class SetMapConsistencyTest {
     assert(nit == 4)
     assert(nfe == 4)
   }
+
+  @Test
+  def test_SI8727() {
+    import scala.tools.testing.AssertUtil._
+    type NSEE = NoSuchElementException
+    val map = Map(0 -> "zero", 1 -> "one")
+    val m = map.filterKeys(i => if (map contains i) true else throw new NSEE)
+    assert{ (m contains 0) && (m get 0).nonEmpty }
+    assertThrows[NSEE]{ m contains 2 }
+    assertThrows[NSEE]{ m get 2 }
+  }
 }


### PR DESCRIPTION
Changed documentation and code so that predicate for filterKeys is always applied before the map is queried.
