### PR TITLE
Scaladoc explicit companion and package links in title bar

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/HtmlPage.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/HtmlPage.scala
@@ -228,6 +228,17 @@ abstract class HtmlPage extends Page { thisPage =>
       </a>
     </span>
 
+  def companionAndPackage(tpl: DocTemplateEntity): Elem =
+    <span class="morelinks">{
+      if (tpl.companion.isDefined)
+        <div>
+          Go to <a href={relativeLinkTo(tpl.companion.get)} title="Flip between class/trait and companion object">companion</a>
+          or {templateToHtml(tpl.inTemplate, "package")} docs
+        </div>
+      else
+        <div>Go to {templateToHtml(tpl.inTemplate, "package")} docs</div>
+    }</span>
+
   def memberToUrl(template: Entity, isSelf: Boolean = true): String = {
     val (signature: Option[String], containingTemplate: TemplateEntity) = template match {
       case dte: DocTemplateEntity if (!isSelf) => (Some(dte.signature), dte.inTemplate)

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
@@ -110,7 +110,9 @@ class Template(universe: doc.Universe, generator: DiagramGenerator, tpl: DocTemp
               <img src={ relativeLinkTo(List(docEntityKindToBigImage(tpl), "lib")) }/>
         }}
         { owner }
-        <h1>{ displayName }</h1> { permalink(tpl) }
+        <h1>{ displayName }</h1>{
+          if (tpl.isPackage) NodeSeq.Empty else <h3>{companionAndPackage(tpl)}</h3>
+        }{ permalink(tpl) }
       </div>
 
       { signature(tpl, isSelf = true) }

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.css
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.css
@@ -397,6 +397,18 @@ div.members > ol > li:last-child {
   margin-bottom: 5px;
 }
 
+#definition .morelinks {
+  text-align: right;
+  position: absolute;
+  top: 40px;
+  right: 10px;
+  width: 300px;
+}
+
+#definition .morelinks a {
+  color: #EBEBEB;
+}
+
 #template .members li .permalink {
   position: absolute;
   top: 5px;


### PR DESCRIPTION
Against issue #4161

Added context sensitive links for the companion toggle and package documentation on the right side of the title bar to make it more obvious that further documentation may exist related to this class. See attached screenshots for effect on each documentation type.

![screenshot from 2014-11-25 07 25 34](https://cloud.githubusercontent.com/assets/56453/5185430/5e001bc6-7474-11e4-9bca-d4bbf454d530.png)
![screenshot from 2014-11-25 07 01 29](https://cloud.githubusercontent.com/assets/56453/5185429/5dff90b6-7474-11e4-9500-edda42b0f955.png)
![screenshot from 2014-11-25 07 00 49](https://cloud.githubusercontent.com/assets/56453/5185432/5e010644-7474-11e4-9ffc-30fd4aeb71e4.png)
![screenshot from 2014-11-25 06 59 52](https://cloud.githubusercontent.com/assets/56453/5185431/5e009ac4-7474-11e4-8278-ddb3ab9e7c78.png)
