### PR TITLE
SI-8911  scala.collection.convert.Wrappers$MapWrapper not serializable

### DIFF
--- a/src/library/scala/collection/convert/Wrappers.scala
+++ b/src/library/scala/collection/convert/Wrappers.scala
@@ -103,7 +103,7 @@ private[collection] trait Wrappers {
   }
 
   // Note various overrides to avoid performance gotchas.
-  class SetWrapper[A](underlying: Set[A]) extends ju.AbstractSet[A] {
+  class SetWrapper[A](underlying: Set[A]) extends ju.AbstractSet[A] with Serializable {
     self =>
     override def contains(o: Object): Boolean = {
       try { underlying.contains(o.asInstanceOf[A]) }
@@ -165,7 +165,7 @@ private[collection] trait Wrappers {
       new JSetWrapper[A](new ju.LinkedHashSet[A](underlying))
   }
 
-  class MapWrapper[A, B](underlying: Map[A, B]) extends ju.AbstractMap[A, B] { self =>
+  class MapWrapper[A, B](underlying: Map[A, B]) extends ju.AbstractMap[A, B] with Serializable { self =>
     override def size = underlying.size
 
     override def get(key: AnyRef): B = try {

--- a/test/junit/scala/collection/convert/WrapperSerializationTest.scala
+++ b/test/junit/scala/collection/convert/WrapperSerializationTest.scala
@@ -1,0 +1,29 @@
+package scala.collection.convert
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class WrapperSerializationTest {
+  def ser(a: AnyRef) = {
+    val baos = new java.io.ByteArrayOutputStream
+    (new java.io.ObjectOutputStream(baos)).writeObject(a)
+    baos
+  }
+  def des(baos: java.io.ByteArrayOutputStream): AnyRef = {
+    val bais = new java.io.ByteArrayInputStream(baos.toByteArray)
+    (new java.io.ObjectInputStream(bais)).readObject()
+  }
+  def serdes(a: AnyRef): Boolean = a == des(ser(a))
+
+  @Test
+  def test_SI8911() {
+    import scala.collection.JavaConverters._
+    assert( serdes(scala.collection.mutable.ArrayBuffer(1,2).asJava) )
+    assert( serdes(Seq(1,2).asJava) )
+    assert( serdes(Set(1,2).asJava) )
+    assert( serdes(Map(1 -> "one", 2 -> "two").asJava) )
+  }
+}


### PR DESCRIPTION
`with Serializable` added to MapWrapper and SetWrapper.

Test verifies that serialziation works in the simplest case.
