### PR TITLE
SI-9003 Eagerly capture more potentially mutable binders

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
@@ -192,13 +192,14 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
     case class ExtractorTreeMaker(extractor: Tree, extraCond: Option[Tree], nextBinder: Symbol)(
           val subPatBinders: List[Symbol],
           val subPatRefs: List[Tree],
+          val potentiallyMutableBinders: Set[Symbol],
           extractorReturnsBoolean: Boolean,
           val checkedLength: Option[Int],
           val prevBinder: Symbol,
           val ignoredSubPatBinders: Set[Symbol]
           ) extends FunTreeMaker with PreserveSubPatBinders {
 
-      def extraStoredBinders: Set[Symbol] = Set()
+      def extraStoredBinders: Set[Symbol] = potentiallyMutableBinders
 
       debug.patmat(s"""
         |ExtractorTreeMaker($extractor, $extraCond, $nextBinder) {

--- a/test/files/run/t9003.flags
+++ b/test/files/run/t9003.flags
@@ -1,0 +1,1 @@
+-optimize

--- a/test/files/run/t9003.scala
+++ b/test/files/run/t9003.scala
@@ -1,0 +1,71 @@
+object Single {
+  var i = 0
+  def isEmpty = false
+  def get = i
+  def unapply(a: Single.type) = this
+}
+
+object Product {
+  var i = 0
+  def _1: Int = i
+  def _2: String = ???
+  def productArity = 2
+  def unapply(a: Product.type) = this
+  def isEmpty = false
+  def get: this.type = this
+}
+
+object Sequence {
+  var i = 0
+  def apply(n: Int): Int = i
+  def length = 2
+  def unapplySeq(a: Sequence.type) = this
+  def isEmpty = false
+  def get = this
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    def assertZero(i: Int) = assert(i == 0)
+
+    Single match {
+      case Single(i) =>
+        Single.i = 1
+        assertZero(i) // fails under -optimize
+    }
+
+    Product match {
+      case Product(i, _) =>
+        Product.i = 1
+        assertZero(i) // fails under -optimize
+    }
+
+    Sequence match {
+      case Sequence(i, _ @ _*) =>
+        Sequence.i = 1
+        assertZero(i) // okay
+    }
+
+    Sequence.i = 0
+    Sequence match {
+      case Sequence(_, i) =>
+        Sequence.i = 1
+        assertZero(i) // okay
+    }
+
+    val buffer = collection.mutable.Buffer(0, 0)
+    buffer match {
+      case Seq(_, i) =>
+        buffer(1) = 1
+        assertZero(i) // failed
+    }
+
+    case class CaseSequence(as: Int*)
+    val buffer1 = collection.mutable.Buffer(0, 0)
+    CaseSequence(buffer1: _*) match {
+      case CaseSequence(_, i) =>
+        buffer1(1) = 1
+        assertZero(i) // failed
+    }
+  }
+}


### PR DESCRIPTION
This is a re-run of SI-5158 in two different contexts.

As reported, the result of `unapply[Seq]` under name based pattern
matching might not guarantee stability of results of calls to
`_1`, `apply(i)`, etc, so we call these eagerly, and call them
once only.

I also found a case in regular pattern matching that we hadn't
accounted for: extracting elements of sequences (either from
a case class or from an `unapplySeq`) may also be unstable.

This commit changes `ExtractorTreeMaker` to force storage
of such binders, even under `-optimize`. This parallels the change
to `ProductExtractorTreeMaker` in 8ebe8e3e8.

I have added a special case for traditional `unapply` methods
returning `Option`. This avoids a change for:

```
% cat test/files/run/t9003b.scala
object Single {
  def unapply(a: Any) = Some("")
}

object Test {
  def main(args: Array[String]): Unit = {
    "" match {
      case Single(x) =>
        (x, x)
    }
  }
}
% qscalac -optimize -Xprint:patmat test/files/run/t9003b.scala 2>&1 | grep --context=5 get
      case <synthetic> val x1: Any = "";
      case5(){
        <synthetic> val o7: Some[String] = Single.unapply(x1);
        if (o7.isEmpty.unary_!)
          matchEnd4({
            scala.Tuple2.apply[String, String](o7.get, o7.get);
            ()
          })
        else
          case6()
      };
% scalac-hash v2.11.4 -optimize -Xprint:patmat test/files/run/t9003b.scala 2>&1 | grep --context=5 get
      case <synthetic> val x1: Any = "";
      case5(){
        <synthetic> val o7: Some[String] = Single.unapply(x1);
        if (o7.isEmpty.unary_!)
          matchEnd4({
            scala.Tuple2.apply[String, String](o7.get, o7.get);
            ()
          })
        else
          case6()
      };
```

Review by @adriaanm
