### PR TITLE
SI-9006 Scaladoc: explicit companion and package links

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/HtmlPage.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/HtmlPage.scala
@@ -228,6 +228,26 @@ abstract class HtmlPage extends Page { thisPage =>
       </a>
     </span>
 
+  def companionAndPackage(tpl: DocTemplateEntity): Elem =
+    <span class="morelinks">{
+      tpl.companion match {
+        case Some(companionTpl) =>
+          val objClassTrait =
+            if (companionTpl.isObject) s"object ${tpl.name}"
+            else if (companionTpl.isTrait) s"trait ${companionTpl.name}"
+            else s"class ${companionTpl.name}"
+          <div>
+            Related Docs:
+            <a href={relativeLinkTo(tpl.companion.get)} title="See companion">{objClassTrait}</a>
+            | {templateToHtml(tpl.inTemplate, s"package ${tpl.inTemplate.name}")}
+          </div>
+        case None =>
+          <div>Related Doc:
+            {templateToHtml(tpl.inTemplate, s"package ${tpl.inTemplate.name}")}
+          </div>
+      }
+    }</span>
+
   def memberToUrl(template: Entity, isSelf: Boolean = true): String = {
     val (signature: Option[String], containingTemplate: TemplateEntity) = template match {
       case dte: DocTemplateEntity if (!isSelf) => (Some(dte.signature), dte.inTemplate)

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
@@ -110,7 +110,9 @@ class Template(universe: doc.Universe, generator: DiagramGenerator, tpl: DocTemp
               <img src={ relativeLinkTo(List(docEntityKindToBigImage(tpl), "lib")) }/>
         }}
         { owner }
-        <h1>{ displayName }</h1> { permalink(tpl) }
+        <h1>{ displayName }</h1>{
+          if (tpl.isPackage) NodeSeq.Empty else <h3>{companionAndPackage(tpl)}</h3>
+        }{ permalink(tpl) }
       </div>
 
       { signature(tpl, isSelf = true) }

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.css
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.css
@@ -397,6 +397,18 @@ div.members > ol > li:last-child {
   margin-bottom: 5px;
 }
 
+#definition .morelinks {
+  text-align: right;
+  position: absolute;
+  top: 40px;
+  right: 10px;
+  width: 450px;
+}
+
+#definition .morelinks a {
+  color: #EBEBEB;
+}
+
 #template .members li .permalink {
   position: absolute;
   top: 5px;


### PR DESCRIPTION
The existing navigation mechanisms have proved hard to discover for newcomers
to Scaladoc.

This commit adds textual links in the navigation bar to the docs of the
companion (if defined) and to those of the enclosing package.
