### PR TITLE
Update ScalaDoc code examples not to use deprecated constructs

### DIFF
--- a/src/reflect/scala/reflect/api/Constants.scala
+++ b/src/reflect/scala/reflect/api/Constants.scala
@@ -60,7 +60,7 @@ package api
  *
  *  object Test extends App {
  *    val jann = typeOf[JavaAnnottee].typeSymbol.annotations(0).javaArgs
- *    def jarg(name: String) = jann(newTermName(name)).asInstanceOf[LiteralArgument].value
+ *    def jarg(name: String) = jann(TermName(name)).asInstanceOf[LiteralArgument].value
  *
  *    val classRef = jarg("classRef").typeValue
  *    println(showRaw(classRef))             // TypeRef(ThisType(<empty>), JavaAnnottee, List())
@@ -150,7 +150,7 @@ trait Constants {
    *
    *  object Test extends App {
    *    val jann = typeOf[JavaAnnottee].typeSymbol.annotations(0).javaArgs
-   *    def jarg(name: String) = jann(newTermName(name)) match {
+   *    def jarg(name: String) = jann(TermName(name)) match {
    *      // Constant is always wrapped into a Literal or LiteralArgument tree node
    *      case LiteralArgument(ct: Constant) => value
    *      case _ => sys.error("Not a constant")

--- a/src/reflect/scala/reflect/api/Exprs.scala
+++ b/src/reflect/scala/reflect/api/Exprs.scala
@@ -84,7 +84,7 @@ trait Exprs { self: Universe =>
      *
      * It is equivalent to
      * {{{
-     *   Select( expr.tree, newTermName("foo") )
+     *   Select( expr.tree, TermName("foo") )
      * }}}
      *
      * The following example code however does not compile

--- a/src/reflect/scala/reflect/api/FlagSets.scala
+++ b/src/reflect/scala/reflect/api/FlagSets.scala
@@ -20,20 +20,20 @@ import scala.language.implicitConversions
  *
  * For example, to create a class named `C` one would write something like:
  * {{{
- *  ClassDef(Modifiers(NoFlags), newTypeName("C"), Nil, ...)
+ *  ClassDef(Modifiers(NoFlags), TypeName("C"), Nil, ...)
  * }}}
  *
  * Here, the flag set is empty.
  *
  * To make `C` private, one would write something like:
  * {{{
- *  ClassDef(Modifiers(PRIVATE), newTypeName("C"), Nil, ...)
+ *  ClassDef(Modifiers(PRIVATE), TypeName("C"), Nil, ...)
  * }}}
  *
  * Flags can also be combined with the vertical bar operator (`|`).
  * For example, a private final class is written something like:
  * {{{
- *  ClassDef(Modifiers(PRIVATE | FINAL), newTypeName("C"), Nil, ...)
+ *  ClassDef(Modifiers(PRIVATE | FINAL), TypeName("C"), Nil, ...)
  * }}}
  *
  * The list of all available flags is defined in [[scala.reflect.api.FlagSets#FlagValues]], available via

--- a/src/reflect/scala/reflect/api/Mirror.scala
+++ b/src/reflect/scala/reflect/api/Mirror.scala
@@ -58,7 +58,7 @@ abstract class Mirror[U <: Universe with Singleton] {
    *    scala> cm.staticPackage("scala")
    *    res2: scala.reflect.runtime.universe.ModuleSymbol = package scala
    *
-   *    scala> res2.moduleClass.info member newTypeName("List")
+   *    scala> res2.moduleClass.info member TypeName("List")
    *    res3: scala.reflect.runtime.universe.Symbol = type List
    *
    *    scala> res3.fullName

--- a/src/reflect/scala/reflect/api/Mirrors.scala
+++ b/src/reflect/scala/reflect/api/Mirrors.scala
@@ -292,7 +292,7 @@ trait Mirrors { self: Universe =>
      *  that can be used to create instances of the class, inspect its companion object or perform further reflections.
      *
      *  To get a class symbol by the name of the class you would like to reflect,
-     *  use `<this mirror>.symbol.info.member(newTypeName(<name of the class>)).asClass`.
+     *  use `<this mirror>.symbol.info.member(TypeName(<name of the class>)).asClass`.
      *  For further information about member lookup refer to `Symbol.info`.
      *
      *  The input symbol can be either private or non-private (Scala reflection transparently deals with visibility).

--- a/src/reflect/scala/reflect/api/Names.scala
+++ b/src/reflect/scala/reflect/api/Names.scala
@@ -17,11 +17,11 @@ import scala.language.implicitConversions
  *  To search for the `map` method (which is a term) declared in the `List` class, one can do:
  *
  * {{{
- *   scala> typeOf[List[_]].member(newTermName("map"))
+ *   scala> typeOf[List[_]].member(TermName("map"))
  *   res0: reflect.runtime.universe.Symbol = method map
  * }}}
  *
- *  To search for a type member, one can follow the same procedure, using `newTypeName` instead.
+ *  To search for a type member, one can follow the same procedure, using `TypeName` instead.
  *
  *  For more information about creating and using `Name`s, see the [[http://docs.scala-lang.org/overviews/reflection/annotations-names-scopes.html Reflection Guide: Annotations, Names, Scopes, and More]]
  *
@@ -30,14 +30,14 @@ import scala.language.implicitConversions
  */
 trait Names {
   /** An implicit conversion from String to TermName.
-   *  Enables an alternative notation `"map": TermName` as opposed to `newTermName("map")`.
+   *  Enables an alternative notation `"map": TermName` as opposed to `TermName("map")`.
    *  @group Names
    */
   @deprecated("Use explicit `TermName(s)` instead", "2.11.0")
   implicit def stringToTermName(s: String): TermName = TermName(s)
 
   /** An implicit conversion from String to TypeName.
-   *  Enables an alternative notation `"List": TypeName` as opposed to `newTypeName("List")`.
+   *  Enables an alternative notation `"List": TypeName` as opposed to `TypeName("List")`.
    *  @group Names
    */
   @deprecated("Use explicit `TypeName(s)` instead", "2.11.0")

--- a/src/reflect/scala/reflect/api/Printers.scala
+++ b/src/reflect/scala/reflect/api/Printers.scala
@@ -46,15 +46,15 @@ import java.io.{ PrintWriter, StringWriter }
  * {{{
  *  scala> showRaw(tree)
  *  res1: String = Block(List(
- *    ClassDef(Modifiers(FINAL), newTypeName("C"), List(), Template(
- *      List(Ident(newTypeName("AnyRef"))),
+ *    ClassDef(Modifiers(FINAL), TypeName("C"), List(), Template(
+ *      List(Ident(TypeName("AnyRef"))),
  *      noSelfType,
  *      List(
  *        DefDef(Modifiers(), nme.CONSTRUCTOR, List(), List(List()), TypeTree(),
  *          Block(List(
  *            Apply(Select(Super(This(tpnme.EMPTY), tpnme.EMPTY), nme.CONSTRUCTOR), List())),
  *            Literal(Constant(())))),
- *        DefDef(Modifiers(), newTermName("x"), List(), List(), TypeTree(),
+ *        DefDef(Modifiers(), TermName("x"), List(), List(), TypeTree(),
  *          Literal(Constant(2))))))),
  *    Literal(Constant(())))
  * }}}
@@ -70,23 +70,23 @@ import java.io.{ PrintWriter, StringWriter }
  *
  *  scala> showRaw(cm.mkToolBox().typecheck(tree), printTypes = true)
  *  res2: String = Block[1](List(
- *    ClassDef[2](Modifiers(FINAL), newTypeName("C"), List(), Template[3](
- *      List(Ident[4](newTypeName("AnyRef"))),
+ *    ClassDef[2](Modifiers(FINAL), TypeName("C"), List(), Template[3](
+ *      List(Ident[4](TypeName("AnyRef"))),
  *      noSelfType,
  *      List(
  *        DefDef[2](Modifiers(), nme.CONSTRUCTOR, List(), List(List()), TypeTree[3](),
  *          Block[1](List(
- *            Apply[4](Select[5](Super[6](This[3](newTypeName("C")), tpnme.EMPTY), ...))),
+ *            Apply[4](Select[5](Super[6](This[3](TypeName("C")), tpnme.EMPTY), ...))),
  *            Literal[1](Constant(())))),
- *        DefDef[2](Modifiers(), newTermName("x"), List(), List(), TypeTree[7](),
+ *        DefDef[2](Modifiers(), TermName("x"), List(), List(), TypeTree[7](),
  *          Literal[8](Constant(2))))))),
  *    Literal[1](Constant(())))
  *  [1] TypeRef(ThisType(scala), scala.Unit, List())
  *  [2] NoType
- *  [3] TypeRef(NoPrefix, newTypeName("C"), List())
+ *  [3] TypeRef(NoPrefix, TypeName("C"), List())
  *  [4] TypeRef(ThisType(java.lang), java.lang.Object, List())
  *  [5] MethodType(List(), TypeRef(ThisType(java.lang), java.lang.Object, List()))
- *  [6] SuperType(ThisType(newTypeName("C")), TypeRef(... java.lang.Object ...))
+ *  [6] SuperType(ThisType(TypeName("C")), TypeRef(... java.lang.Object ...))
  *  [7] TypeRef(ThisType(scala), scala.Int, List())
  *  [8] ConstantType(Constant(2))
  *  }}}
@@ -112,10 +112,10 @@ import java.io.{ PrintWriter, StringWriter }
  *  // showRaw has already been discussed above
  *  scala> showRaw(tpe)
  *  res1: String = RefinedType(
- *    List(TypeRef(ThisType(scala), newTypeName("AnyRef"), List())),
+ *    List(TypeRef(ThisType(scala), TypeName("AnyRef"), List())),
  *    Scope(
- *      newTermName("x"),
- *      newTermName("y")))
+ *      TermName("x"),
+ *      TermName("y")))
  * }}}
  *
  * `printIds` and/or `printKinds` can additionally be supplied as arguments in a call to
@@ -124,10 +124,10 @@ import java.io.{ PrintWriter, StringWriter }
  * {{{
  *  scala> showRaw(tpe, printIds = true, printKinds = true)
  *  res2: String = RefinedType(
- *    List(TypeRef(ThisType(scala#2043#PK), newTypeName("AnyRef")#691#TPE, List())),
+ *    List(TypeRef(ThisType(scala#2043#PK), TypeName("AnyRef")#691#TPE, List())),
  *    Scope(
- *      newTermName("x")#2540#METH,
- *      newTermName("y")#2541#GET))
+ *      TermName("x")#2540#METH,
+ *      TermName("y")#2541#GET))
  * }}}
  *
  * For more details about `Printer`s and other aspects of Scala reflection, see the

--- a/src/reflect/scala/reflect/api/StandardDefinitions.scala
+++ b/src/reflect/scala/reflect/api/StandardDefinitions.scala
@@ -128,7 +128,7 @@ trait StandardDefinitions {
      *  scala> import scala.reflect.runtime.universe._
      *  import scala.reflect.runtime.universe._
      *
-     *  scala> val m = typeOf[C].member(newTermName("m")).asMethod
+     *  scala> val m = typeOf[C].member(TermName("m")).asMethod
      *  m: reflect.runtime.universe.MethodSymbol = method m
      *
      *  scala> m.params(0)(0).info
@@ -156,7 +156,7 @@ trait StandardDefinitions {
      *  scala> import scala.reflect.runtime.universe._
      *  import scala.reflect.runtime.universe._
      *
-     *  scala> val m = typeOf[C].member(newTermName("m")).asMethod
+     *  scala> val m = typeOf[C].member(TermName("m")).asMethod
      *  m: reflect.runtime.universe.MethodSymbol = method m
      *
      *  scala> m.params(0)(0).info
@@ -181,7 +181,7 @@ trait StandardDefinitions {
      *  scala> import scala.reflect.runtime.universe._
      *  import scala.reflect.runtime.universe._
      *
-     *  scala> val m = typeOf[C].member(newTermName("m")).asMethod
+     *  scala> val m = typeOf[C].member(TermName("m")).asMethod
      *  m: reflect.runtime.universe.MethodSymbol = method m
      *
      *  scala> m.params(0)(0).info

--- a/src/reflect/scala/reflect/api/Symbols.scala
+++ b/src/reflect/scala/reflect/api/Symbols.scala
@@ -27,7 +27,7 @@ package api
  *    scala> class C[T] { def test[U](x: T)(y: U): Int = ??? }
  *    defined class C
  *
- *    scala> val test = typeOf[C[Int]].member(newTermName("test")).asMethod
+ *    scala> val test = typeOf[C[Int]].member(TermName("test")).asMethod
  *    test: reflect.runtime.universe.MethodSymbol = method test
  *
  *    scala> test.info

--- a/src/reflect/scala/reflect/api/Trees.scala
+++ b/src/reflect/scala/reflect/api/Trees.scala
@@ -33,7 +33,7 @@ package api
  *
  *  The following creates an AST representing `print("Hello World")`:
  *  {{{
- *    Apply(Select(Select(This(newTypeName("scala")), newTermName("Predef")), newTermName("print")), List(Literal(Constant("Hello World"))))
+ *    Apply(Select(Select(This(TypeName("scala")), TermName("Predef")), TermName("print")), List(Literal(Constant("Hello World"))))
  *  }}}
  *
  *  The following creates an AST from a literal 5, and then uses `showRaw` to print it in a readable format.
@@ -1098,11 +1098,11 @@ trait Trees { self: Universe =>
    *            // a dummy node that carries the type of unapplication to patmat
    *            // the <unapply-selector> here doesn't have an underlying symbol
    *            // it only has a type assigned, therefore after `untypecheck` this tree is no longer typeable
-   *            Apply(Select(Ident(Foo), newTermName("unapply")), List(Ident(newTermName("<unapply-selector>")))),
+   *            Apply(Select(Ident(Foo), TermName("unapply")), List(Ident(TermName("<unapply-selector>")))),
    *            // arguments of the unapply => nothing synthetic here
-   *            List(Bind(newTermName("x"), Ident(nme.WILDCARD)))),
+   *            List(Bind(TermName("x"), Ident(nme.WILDCARD)))),
    *          EmptyTree,
-   *          Ident(newTermName("x")))))
+   *          Ident(TermName("x")))))
    *  }}}
    *
    * Introduced by typer. Eliminated by compiler phases patmat (in the new pattern matcher of 2.10) or explicitouter (in the old pre-2.10 pattern matcher).


### PR DESCRIPTION
- Replace newTermName in favour of TermName
- Replace newTypeName in favour of TypeName

Review by @heathermiller 
