### PR TITLE
  SI-9000 equals for immutable collections should check identity

### DIFF
--- a/src/library/scala/collection/LinearSeqOptimized.scala
+++ b/src/library/scala/collection/LinearSeqOptimized.scala
@@ -235,13 +235,16 @@ trait LinearSeqOptimized[+A, +Repr <: LinearSeqOptimized[A, Repr]] extends Linea
   override /*IterableLike*/
   def sameElements[B >: A](that: GenIterable[B]): Boolean = that match {
     case that1: LinearSeq[_] =>
-      var these = this
-      var those = that1
-      while (!these.isEmpty && !those.isEmpty && these.head == those.head) {
-        these = these.tail
-        those = those.tail
+      // Probably immutable, so check reference identity first (it's quick anyway)
+      (this eq that1) || {
+        var these = this
+        var those = that1
+        while (!these.isEmpty && !those.isEmpty && these.head == those.head) {
+          these = these.tail
+          those = those.tail
+        }
+        these.isEmpty && those.isEmpty
       }
-      these.isEmpty && those.isEmpty
     case _ =>
       super.sameElements(that)
   }


### PR DESCRIPTION
`LinearSeqOptimized` now checks reference identity on `LinearSeq`s.

No unit test; this doesn't change visible behavior (save for side-effecting equals methods).
