### PR TITLE
SI-9008 Fix regression with higher kinded existentials

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -480,7 +480,8 @@ trait Contexts { self: Analyzer =>
       // SI-8245 `isLazy` need to skip lazy getters to ensure `return` binds to the right place
       c.enclMethod         = if (isDefDef && !owner.isLazy) c else enclMethod
 
-      if (tree != outer.tree) c(TypeConstructorAllowed) = false
+      if (tree != outer.tree)
+        c(TypeConstructorAllowed) = false
 
       registerContext(c.asInstanceOf[analyzer.Context])
       debuglog("[context] ++ " + c.unit + " / " + tree.summaryString)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5207,7 +5207,11 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
       def typedExistentialTypeTree(tree: ExistentialTypeTree) = {
         val tree1 = typerWithLocalContext(context.makeNewScope(tree, context.owner)){
-          _.typedExistentialTypeTree(tree, mode)
+          typer =>
+            if (context.inTypeConstructorAllowed)
+              typer.context.withinTypeConstructorAllowed(typer.typedExistentialTypeTree(tree, mode))
+            else
+              typer.typedExistentialTypeTree(tree, mode)
         }
         checkExistentialsFeature(tree1.pos, tree1.tpe, "the existential type")
         tree1

--- a/test/files/neg/t9008.check
+++ b/test/files/neg/t9008.check
@@ -1,0 +1,4 @@
+t9008.scala:2: error: type M takes type parameters
+  def x: List[M forSome { type M[_] }] = ???
+              ^
+one error found

--- a/test/files/neg/t9008.scala
+++ b/test/files/neg/t9008.scala
@@ -1,0 +1,3 @@
+object Test {
+  def x: List[M forSome { type M[_] }] = ???
+}

--- a/test/files/neg/t9008b.check
+++ b/test/files/neg/t9008b.check
@@ -1,0 +1,4 @@
+t9008b.scala:2: error: type M takes type parameters
+  type T = M forSome { type M[_] }
+           ^
+one error found

--- a/test/files/neg/t9008b.scala
+++ b/test/files/neg/t9008b.scala
@@ -1,0 +1,3 @@
+object Test {
+  type T = M forSome { type M[_] }
+}

--- a/test/files/pos/t9008.scala
+++ b/test/files/pos/t9008.scala
@@ -1,0 +1,5 @@
+trait Monad[M[_]]
+
+object Test {
+  def x: Monad[M forSome { type M[_] }] = ???
+}


### PR DESCRIPTION
Allow a naked type constructor in an existential type if
we are directly within a type application.

Recently, 84d4671 changed nested context creation to avoid passing
down the `TypeConstructorAllowed`, which led to missing kind errors
in code like `type T[({type M = List})#M]`.

However, when typechecking `T forSome { quantifiers }`, we create
a nested context to represent the nested scope introduced for the
quantifiers. But we need to propagate the `TypeConstructorAllowed`
bit to the nested context to allow for higher kinded existentials.

The enclosed tests show:
- pos/t9008  well kinded application of an hk existential
- neg/t9008  hk existential forbidden outside of type application
- neg/t9008b kind error reported for hk existential

Regressed in 84d4671.

Review by @adriaanm
