### PR TITLE
SI-7683 Enable -Ystop-before:typer

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1590,10 +1590,9 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
       }
     }
 
-    /** Reset package class to state at typer (not sure what this
-     *  is needed for?)
+    /** Reset package class to state at typer (not sure what this is needed for?)
      */
-    private def resetPackageClass(pclazz: Symbol) {
+    private def resetPackageClass(pclazz: Symbol): Unit = if (typerPhase != NoPhase) {
       enteringPhase(firstPhase) {
         pclazz.setInfo(enteringPhase(typerPhase)(pclazz.info))
       }

--- a/test/files/pos/t7683-stop-after-parser/ThePlugin.scala
+++ b/test/files/pos/t7683-stop-after-parser/ThePlugin.scala
@@ -1,0 +1,31 @@
+package scala.test.plugins
+
+import scala.tools.nsc
+import nsc.Global
+import nsc.Phase
+import nsc.plugins.Plugin
+import nsc.plugins.PluginComponent
+
+class ThePlugin(val global: Global) extends Plugin {
+  import global._
+
+  val name = "timebomb"
+  val description = "Explodes if run. Maybe I haven't implemented it yet."
+  val components = List[PluginComponent](thePhase1)
+
+  private object thePhase1 extends PluginComponent {
+    val global = ThePlugin.this.global
+
+    val runsAfter = List[String]("parser")
+    override val runsBefore = List[String]("namer")
+    val phaseName = ThePlugin.this.name
+
+    def newPhase(prev: Phase) = new ThePhase(prev)
+  }
+
+  private class ThePhase(prev: Phase) extends Phase(prev) {
+    override def name = ThePlugin.this.name
+    override def run  = ???
+  }
+}
+

--- a/test/files/pos/t7683-stop-after-parser/sample_2.flags
+++ b/test/files/pos/t7683-stop-after-parser/sample_2.flags
@@ -1,0 +1,1 @@
+-Xplugin:. -Xplugin-require:timebomb -Ystop-after:parser

--- a/test/files/pos/t7683-stop-after-parser/sample_2.scala
+++ b/test/files/pos/t7683-stop-after-parser/sample_2.scala
@@ -1,0 +1,6 @@
+
+package sample
+
+// just a sample that is compiled with the explosive plugin disabled
+object Sample extends App {
+}

--- a/test/files/pos/t7683-stop-after-parser/scalac-plugin.xml
+++ b/test/files/pos/t7683-stop-after-parser/scalac-plugin.xml
@@ -1,0 +1,5 @@
+<plugin>
+  <name>ignored</name>
+  <classname>scala.test.plugins.ThePlugin</classname>
+</plugin>
+


### PR DESCRIPTION
Allows a plugin to run before typer without incurring typechecking.

The test is that a plugin doesn't run when stopping after parser,
and that the truncated compilation run also succeeds, since
updating check files for the output of -Xshow-phases is tedious.
