### PR TITLE
SI-9015 Reject 0x and minor parser cleanup 

### DIFF
--- a/test/files/neg/literals.check
+++ b/test/files/neg/literals.check
@@ -1,0 +1,40 @@
+literals.scala:6: error: missing integer number
+  def missingHex: Int    = { 0x }        // line 4: was: not reported, taken as zero
+                             ^
+literals.scala:8: error: Decimal integer literals may not have a leading zero. (Octal syntax is obsolete.)
+  def leadingZeros: Int  = { 01 }        // line 6: no leading zero
+                             ^
+literals.scala:10: error: Decimal integer literals may not have a leading zero. (Octal syntax is obsolete.)
+  def tooManyZeros: Int  = { 00 }        // line 8: no leading zero
+                             ^
+literals.scala:12: error: Decimal integer literals may not have a leading zero. (Octal syntax is obsolete.)
+  def zeroOfNine: Int    = { 09 }        // line 10: no leading zero
+                             ^
+literals.scala:16: error: Decimal integer literals may not have a leading zero. (Octal syntax is obsolete.)
+  def zeroOfNineDot: Int = { 09. }       // line 14: malformed integer, ident expected
+                             ^
+literals.scala:23: error: missing integer number
+  def missingHex: Int    = 0x            // line 22: was: not reported, taken as zero
+                           ^
+literals.scala:27: error: Decimal integer literals may not have a leading zero. (Octal syntax is obsolete.)
+  def tooManyZeros: Int  = 00            // line 26: no leading zero
+                           ^
+literals.scala:14: error: identifier expected but '}' found.
+  def orphanDot: Int     = { 9. }        // line 12: ident expected
+                                ^
+literals.scala:16: error: identifier expected but '}' found.
+  def zeroOfNineDot: Int = { 09. }       // line 14: malformed integer, ident expected
+                                 ^
+literals.scala:18: error: ';' expected but double literal found.
+  def noHexFloat: Double = { 0x1.2 }     // line 16: ';' expected but double literal found.
+                                ^
+literals.scala:25: error: ';' expected but 'def' found.
+  def leadingZeros: Int  = 01            // line 24: no leading zero
+  ^
+literals.scala:29: error: ';' expected but 'def' found.
+  def zeroOfNine: Int    = 09            // line 28: no leading zero
+  ^
+literals.scala:33: error: identifier expected but 'def' found.
+  def zeroOfNineDot: Int = 09.           // line 32: malformed integer, ident expected
+  ^
+13 errors found

--- a/test/files/neg/literals.scala
+++ b/test/files/neg/literals.scala
@@ -1,0 +1,36 @@
+
+/* This took me literally all day.
+*/
+trait RejectedLiterals {
+
+  def missingHex: Int    = { 0x }        // line 4: was: not reported, taken as zero
+
+  def leadingZeros: Int  = { 01 }        // line 6: no leading zero
+
+  def tooManyZeros: Int  = { 00 }        // line 8: no leading zero
+
+  def zeroOfNine: Int    = { 09 }        // line 10: no leading zero
+
+  def orphanDot: Int     = { 9. }        // line 12: ident expected
+
+  def zeroOfNineDot: Int = { 09. }       // line 14: malformed integer, ident expected
+
+  def noHexFloat: Double = { 0x1.2 }     // line 16: ';' expected but double literal found.
+}
+
+trait Braceless {
+
+  def missingHex: Int    = 0x            // line 22: was: not reported, taken as zero
+
+  def leadingZeros: Int  = 01            // line 24: no leading zero
+
+  def tooManyZeros: Int  = 00            // line 26: no leading zero
+
+  def zeroOfNine: Int    = 09            // line 28: no leading zero
+
+  def orphanDot: Int     = 9.            // line 30: ident expected
+
+  def zeroOfNineDot: Int = 09.           // line 32: malformed integer, ident expected
+
+  def noHexFloat: Double = 0x1.2         // line 34: ';' expected but double literal found.
+}

--- a/test/files/run/literals.check
+++ b/test/files/run/literals.check
@@ -1,57 +1,12 @@
-warning: there were 5 deprecation warnings; re-run with -deprecation for details
-test '\u0024' == '$' was successful
-test '\u005f' == '_' was successful
-test 65.asInstanceOf[Char] == 'A' was successful
-test "\141\142" == "ab" was successful
-test "\0x61\0x62".trim() == "x61\0x62" was successful
-
-test (65 : Byte) == 'A' was successful
-
-test 0X01 == 1 was successful
-test 0x01 == 1 was successful
-test 0x10 == 16 was successful
-test 0xa == 10 was successful
-test 0x0a == 10 was successful
-test +0x01 == 1 was successful
-test +0x10 == 16 was successful
-test +0xa == 10 was successful
-test +0x0a == 10 was successful
-test -0x01 == -1 was successful
-test -0x10 == -16 was successful
-test -0xa == -10 was successful
-test -0x0a == -10 was successful
-test 0x7fffffff == 2147483647 was successful
-test 0x80000000 == -2147483648 was successful
-test 0xffffffff == -1 was successful
-
-test 1l == 1L was successful
-test 1L == 1l was successful
-test 1.asInstanceOf[Long] == 1l was successful
-test 0x7fffffffffffffffL == 9223372036854775807L was successful
-test 0x8000000000000000L == -9223372036854775808L was successful
-test 0xffffffffffffffffL == -1L was successful
-
-test 1e1f == 10.0f was successful
-test .3f == 0.3f was successful
-test 0f == 0.0f was successful
-test 01.23f == 1.23f was successful
-test 3.14f == 3.14f was successful
-test 6.022e23f == 6.022e23f was successful
-test 09f == 9.0f was successful
-test 1.asInstanceOf[Float] == 1.0 was successful
-test 1l.asInstanceOf[Float] == 1.0 was successful
-
-test 1e1 == 10.0 was successful
-test .3 == 0.3 was successful
-test 0.0 == 0.0 was successful
-test 0d == 0.0 was successful
-test 01.23 == 1.23 was successful
-test 01.23d == 1.23d was successful
-test 3.14 == 3.14 was successful
-test 1e-9d == 1.0e-9 was successful
-test 1e137 == 1.0e137 was successful
-test 1.asInstanceOf[Double] == 1.0 was successful
-test 1l.asInstanceOf[Double] == 1.0 was successful
-
-test "".length() was successful
-test ggg == 3 was successful
+literals.scala:34: warning: Octal escape literals are deprecated, use \u0061 instead.
+    check_success("\"\\141\\142\" == \"ab\"", "\141\142", "ab")
+                                               ^
+literals.scala:34: warning: Octal escape literals are deprecated, use \u0062 instead.
+    check_success("\"\\141\\142\" == \"ab\"", "\141\142", "ab")
+                                                   ^
+literals.scala:37: warning: Octal escape literals are deprecated, use \u0000 instead.
+      "\0x61\0x62".getBytes(io.Codec.UTF8.charSet) sameElements Array[Byte](0, 120, 54, 49, 0, 120, 54, 50),
+       ^
+literals.scala:37: warning: Octal escape literals are deprecated, use \u0000 instead.
+      "\0x61\0x62".getBytes(io.Codec.UTF8.charSet) sameElements Array[Byte](0, 120, 54, 49, 0, 120, 54, 50),
+            ^

--- a/test/files/run/literals.flags
+++ b/test/files/run/literals.flags
@@ -1,0 +1,1 @@
+-deprecation

--- a/test/files/run/literals.scala
+++ b/test/files/run/literals.scala
@@ -14,21 +14,16 @@ object Test {
     def \u03b1\u03b1(that: GGG) = i + that.i
   }
 
-  def check_success[a](name: String, closure: => a, expected: a) {
-    print("test " + name)
-    try {
-      val actual: a = closure
-      if (actual == expected) {
-        print(" was successful");
-      } else {
-        print(" failed: expected "+ expected +", found "+ actual);
+  def check_success[A](name: String, closure: => A, expected: A) {
+    val res: Option[String] =
+      try {
+        val actual: A = closure
+        if (actual == expected) None  //print(" was successful")
+        else Some(s" failed: expected $expected, found $actual")
+      } catch {
+        case exception: Throwable => Some(s" raised exception $exception")
       }
-    } catch {
-      case exception: Throwable => {
-        print(" raised exception " + exception);
-      }
-    }
-    println
+    for (e <- res) println(s"test $name $e")
   }
 
   def main(args: Array[String]) {
@@ -37,14 +32,13 @@ object Test {
     check_success("'\\u005f' == '_'", '\u005f', '_')
     check_success("65.asInstanceOf[Char] == 'A'", 65.asInstanceOf[Char], 'A')
     check_success("\"\\141\\142\" == \"ab\"", "\141\142", "ab")
-    check_success("\"\\0x61\\0x62\".trim() == \"x61\\0x62\"", "\0x61\0x62".substring(1), "x61\0x62")
-
-    println
+    //check_success("\"\\0x61\\0x62\".trim() == \"x61\\0x62\"", "\0x61\0x62".substring(1), "x61\0x62")
+    check_success(""""\0x61\0x62".getBytes == Array(0, 120, ...)""",
+      "\0x61\0x62".getBytes(io.Codec.UTF8.charSet) sameElements Array[Byte](0, 120, 54, 49, 0, 120, 54, 50),
+      true)
 
     // boolean
     check_success("(65 : Byte) == 'A'", (65: Byte) == 'A', true) // contrib #176
-
-    println
 
     // int
     check_success("0X01 == 1", 0X01, 1)
@@ -67,8 +61,6 @@ object Test {
     check_success("0x80000000 == -2147483648", 0x80000000, -2147483648)
     check_success("0xffffffff == -1", 0xffffffff, -1)
 
-    println
-
     // long
     check_success("1l == 1L", 1l, 1L)
     check_success("1L == 1l", 1L, 1l)
@@ -80,8 +72,6 @@ object Test {
       0x8000000000000000L, -9223372036854775808L)
     check_success("0xffffffffffffffffL == -1L",
       0xffffffffffffffffL, -1L)
-
-    println
 
     // see JLS at address:
     // http://java.sun.com/docs/books/jls/second_edition/html/lexical.doc.html#230798
@@ -97,8 +87,6 @@ object Test {
     check_success("1.asInstanceOf[Float] == 1.0", 1.asInstanceOf[Float], 1.0f)
     check_success("1l.asInstanceOf[Float] == 1.0", 1l.asInstanceOf[Float], 1.0f)
 
-    println
-
     // double
     check_success("1e1 == 10.0", 1e1, 10.0)
     check_success(".3 == 0.3", .3, 0.3)
@@ -112,7 +100,6 @@ object Test {
     check_success("1.asInstanceOf[Double] == 1.0", 1.asInstanceOf[Double], 1.0)
     check_success("1l.asInstanceOf[Double] == 1.0", 1l.asInstanceOf[Double], 1.0)
 
-    println
     check_success("\"\".length()", "\u001a".length(), 1)
 
     val ggg = GGG(1) \u03b1\u03b1 GGG(2)


### PR DESCRIPTION
There was no negative test for what constitutes a legal literal.

The ultimate goal is for the test to report all errors in
one compilation.

This commit follows up the removal of "1." syntax to simplify
number parsing.  It removes previous paulp code to contain the
erstwhile complexity.

Leading zero is not immediately put to the buffer.  Instead,
the empty buffer is handled on evaluation.  In particular, an
empty buffer due to `0x` is a syntax error.

The message for obsolete octal syntax is nuanced and deferred
until evaluation by the parser, which is slightly simpler to
reason about.
