### PR TITLE
SI-9027 Parser no longer consumes space after multi XML elements

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/MarkupParsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/MarkupParsers.scala
@@ -346,12 +346,11 @@ trait MarkupParsers {
 
         // parse more XML ?
         if (charComingAfter(xSpaceOpt()) == '<') {
-          xSpaceOpt()
-          while (ch == '<') {
+          do {
+            xSpaceOpt()
             nextch()
             ts append element
-            xSpaceOpt()
-          }
+          } while (charComingAfter(xSpaceOpt()) == '<')
           handle.makeXMLseq(r2p(start, start, curOffset), ts)
         }
         else {

--- a/test/files/run/t9027.check
+++ b/test/files/run/t9027.check
@@ -1,0 +1,19 @@
+{
+  {
+    val $buf = new _root_.scala.xml.NodeBuffer();
+    $buf.$amp$plus(new _root_.scala.xml.Elem(null, "a", _root_.scala.xml.Null, $scope, true));
+    $buf.$amp$plus(new _root_.scala.xml.Elem(null, "b", _root_.scala.xml.Null, $scope, true));
+    $buf
+  };
+  println("hello, world.")
+}
+{
+  {
+    val $buf = new _root_.scala.xml.NodeBuffer();
+    $buf.$amp$plus(new _root_.scala.xml.Elem(null, "a", _root_.scala.xml.Null, $scope, true));
+    $buf.$amp$plus(new _root_.scala.xml.Elem(null, "b", _root_.scala.xml.Null, $scope, true));
+    $buf.$amp$plus(new _root_.scala.xml.Elem(null, "c", _root_.scala.xml.Null, $scope, true));
+    $buf
+  };
+  println("hello, world.")
+}

--- a/test/files/run/t9027.scala
+++ b/test/files/run/t9027.scala
@@ -1,0 +1,15 @@
+
+// used to be parsed as .println
+object Test extends App {
+  import reflect.runtime._, universe._
+
+  val trees = List(
+  q"""<a/><b/>
+      println("hello, world.")""",
+  q"""<a/>
+      <b/>
+      <c/>
+      println("hello, world.")"""
+  )
+  trees foreach println
+}


### PR DESCRIPTION
Once the parser starts looking for more <elements>, it should
still lookahead speculatively, leaving any remaining whitespace,
including newlines, after the last element.
