### PR TITLE
SI-8950  SeqView and StreamView allow indexing out of a slice

### DIFF
--- a/src/library/scala/collection/SeqViewLike.scala
+++ b/src/library/scala/collection/SeqViewLike.scala
@@ -55,7 +55,7 @@ trait SeqViewLike[+A,
   trait Sliced extends super.Sliced with Transformed[A] {
     def length = iterator.size
     def apply(idx: Int): A =
-      if (idx + from < until) self.apply(idx + from)
+      if (idx >= 0 && idx + from < until) self.apply(idx + from)
       else throw new IndexOutOfBoundsException(idx.toString)
 
     override def foreach[U](f: A => U) = iterator foreach f

--- a/src/library/scala/collection/mutable/IndexedSeqView.scala
+++ b/src/library/scala/collection/mutable/IndexedSeqView.scala
@@ -50,7 +50,7 @@ self =>
   trait Sliced extends super.Sliced with Transformed[A] {
     override def length = endpoints.width
     def update(idx: Int, elem: A) =
-      if (idx + from < until) self.update(idx + from, elem)
+      if (idx >= 0 && idx + from < until) self.update(idx + from, elem)
       else throw new IndexOutOfBoundsException(idx.toString)
   }
 


### PR DESCRIPTION
Added `idx >= 0` tests for `SeqViewLike#Sliced` `apply` and `mutable.IndexedSeqViewLike#Sliced` `unapply`.  Now you get `IndexOutOfBoundsException`s as you should.

No tests; this was found by collections-laws and will be tested by them.  (Exact variants in bug report were tested in the REPL.)
