### PR TITLE
SI-8841 report named arg / assignment ambiguity also in silent mode.

### DIFF
--- a/test/files/neg/names-defaults-neg.check
+++ b/test/files/neg/names-defaults-neg.check
@@ -151,15 +151,15 @@ names-defaults-neg.scala:144: error: variable definition needs type because 'x' 
 names-defaults-neg.scala:147: error: variable definition needs type because 'x' is used as a named argument in its body.
   object t6 { var x = t.f(x = 1) }
                   ^
-names-defaults-neg.scala:147: warning: type-checking the invocation of method f checks if the named argument expression 'x = ...' is a valid assignment
-in the current scope. The resulting type inference error (see above) can be fixed by providing an explicit type in the local definition for x.
+names-defaults-neg.scala:147: warning: failed to determine if 'x = ...' is a named argument or an assignment expression.
+an explicit type is required for the definition mentioned in the error message above.
   object t6 { var x = t.f(x = 1) }
                             ^
 names-defaults-neg.scala:150: error: variable definition needs type because 'x' is used as a named argument in its body.
   class t9 { var x = t.f(x = 1) }
                  ^
-names-defaults-neg.scala:150: warning: type-checking the invocation of method f checks if the named argument expression 'x = ...' is a valid assignment
-in the current scope. The resulting type inference error (see above) can be fixed by providing an explicit type in the local definition for x.
+names-defaults-neg.scala:150: warning: failed to determine if 'x = ...' is a named argument or an assignment expression.
+an explicit type is required for the definition mentioned in the error message above.
   class t9 { var x = t.f(x = 1) }
                            ^
 names-defaults-neg.scala:164: error: variable definition needs type because 'x' is used as a named argument in its body.
@@ -174,8 +174,8 @@ names-defaults-neg.scala:170: error: reference to x is ambiguous; it is both a m
 names-defaults-neg.scala:177: error: variable definition needs type because 'x' is used as a named argument in its body.
   class u15 { var x = u.f(x = 1) }
                   ^
-names-defaults-neg.scala:177: warning: type-checking the invocation of method f checks if the named argument expression 'x = ...' is a valid assignment
-in the current scope. The resulting type inference error (see above) can be fixed by providing an explicit type in the local definition for x.
+names-defaults-neg.scala:177: warning: failed to determine if 'x = ...' is a named argument or an assignment expression.
+an explicit type is required for the definition mentioned in the error message above.
   class u15 { var x = u.f(x = 1) }
                             ^
 names-defaults-neg.scala:180: error: reference to x is ambiguous; it is both a method parameter and a variable in scope.

--- a/test/files/neg/t5044.check
+++ b/test/files/neg/t5044.check
@@ -1,8 +1,8 @@
 t5044.scala:7: error: recursive value a needs type
     val id = m(a)
                ^
-t5044.scala:6: warning: type-checking the invocation of method foo checks if the named argument expression 'id = ...' is a valid assignment
-in the current scope. The resulting type inference error (see above) can be fixed by providing an explicit type in the local definition for id.
+t5044.scala:6: warning: failed to determine if 'id = ...' is a named argument or an assignment expression.
+an explicit type is required for the definition mentioned in the error message above.
     val a = foo(id = 1)
                    ^
 one warning found

--- a/test/files/neg/t5091.check
+++ b/test/files/neg/t5091.check
@@ -1,8 +1,8 @@
 t5091.scala:8: error: recursive value xxx needs type
     val param = bar(xxx)
                     ^
-t5091.scala:7: warning: type-checking the invocation of method foo checks if the named argument expression 'param = ...' is a valid assignment
-in the current scope. The resulting type inference error (see above) can be fixed by providing an explicit type in the local definition for param.
+t5091.scala:7: warning: failed to determine if 'param = ...' is a named argument or an assignment expression.
+an explicit type is required for the definition mentioned in the error message above.
     val xxx = foo(param = null)
                         ^
 one warning found

--- a/test/files/neg/t8463.check
+++ b/test/files/neg/t8463.check
@@ -7,4 +7,21 @@ Note that implicit conversions are not applicable because they are ambiguous:
  are possible conversion functions from Long to ?T[Long]
   insertCell(Foo(5))
             ^
-one error found
+t8463.scala:5: error: no type parameters for method apply: (activity: T[Long])Test.Foo[T] in object Foo exist so that it can be applied to arguments (Long)
+ --- because ---
+argument expression's type is not compatible with formal parameter type;
+ found   : Long
+ required: ?T[Long]
+  insertCell(Foo(5))
+             ^
+t8463.scala:5: error: type mismatch;
+ found   : Long(5L)
+ required: T[Long]
+  insertCell(Foo(5))
+                 ^
+t8463.scala:5: error: type mismatch;
+ found   : Test.Foo[T]
+ required: Test.Foo[Test.Cell]
+  insertCell(Foo(5))
+                ^
+four errors found

--- a/test/files/neg/t8841.check
+++ b/test/files/neg/t8841.check
@@ -1,0 +1,9 @@
+t8841.scala:13: error: recursive value c needs type
+    val ambiguousName = c.ambiguousName
+        ^
+t8841.scala:12: warning: failed to determine if 'ambiguousName = ...' is a named argument or an assignment expression.
+an explicit type is required for the definition mentioned in the error message above.
+    val c = new Cell(ambiguousName = Some("bla"))
+                                   ^
+one warning found
+one error found

--- a/test/files/neg/t8841.scala
+++ b/test/files/neg/t8841.scala
@@ -1,0 +1,15 @@
+class Cell(val ambiguousName: Option[String])
+ 
+class Test {
+  def wrap(f: Any): Nothing = ???
+ 
+  wrap {
+    // the namer for these two ValDefs is created when typing the argument expression
+    // of wrap. This happens to be in a silent context (tryTypedApply). Therefore, the
+    // cyclic reference will not be thrown, but transformed into a NormalTypeError by
+    // `silent`. This requires different handling in NamesDefaults.
+
+    val c = new Cell(ambiguousName = Some("bla"))
+    val ambiguousName = c.ambiguousName
+  }
+}


### PR DESCRIPTION
For local definitions (eg. in a block that is an argument of a method
call), the type completer may have a silent context. A CyclicReference
is then not thrown but transformed into a NormalTypeError. When
deciding if 'x = e' is an assignment or a named arg, we need to report
cyclic references, but not other type errors. In the above case, the
cyclic reference was not reported.

Also makes sure that warnings are printed after typing argument
expressions.
