### PR TITLE
[nomerge] SI-9030 don't call private BoxesRunTime.equalsNumChar

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
@@ -1495,7 +1495,7 @@ abstract class GenICode extends SubComponent {
           if (!settings.optimise) {
             if (l.tpe <:< BoxedNumberClass.tpe) {
               if (r.tpe <:< BoxedNumberClass.tpe) platform.externalEqualsNumNum
-              else if (r.tpe <:< BoxedCharacterClass.tpe) platform.externalEqualsNumChar
+              else if (r.tpe <:< BoxedCharacterClass.tpe) platform.externalEqualsNumObject // will be externalEqualsNumChar in 2.12, SI-9030
               else platform.externalEqualsNumObject
             } else platform.externalEquals
           } else {

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -1225,7 +1225,7 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
         val equalsMethod: Symbol = {
           if (l.tpe <:< BoxedNumberClass.tpe) {
             if (r.tpe <:< BoxedNumberClass.tpe) platform.externalEqualsNumNum
-            else if (r.tpe <:< BoxedCharacterClass.tpe) platform.externalEqualsNumChar
+            else if (r.tpe <:< BoxedCharacterClass.tpe) platform.externalEqualsNumObject // will be externalEqualsNumChar in 2.12, SI-9030
             else platform.externalEqualsNumObject
           } else platform.externalEquals
         }

--- a/test/files/run/t9030.scala
+++ b/test/files/run/t9030.scala
@@ -1,0 +1,19 @@
+object Test extends App {
+
+  // For these methods, the compiler emits calls to BoxesRuntime.equalsNumNum/equalsNumChar/equalsNumObject directly
+
+  def numNum(a: java.lang.Number, b: java.lang.Number) = assert(a == b)
+  def numChar(a: java.lang.Number, b: java.lang.Character) = assert(a == b)
+  def numObject(a: java.lang.Number, b: java.lang.Object) = assert(a == b)
+
+  // The compiler doesn't use equalsCharObject directly, but still adding an example for completeness
+
+  def charObject(a: java.lang.Character, b: java.lang.Object) = assert(a == b)
+
+  numNum(new Integer(1), new Integer(1))
+  numChar(new Integer(97), new Character('a'))
+  numObject(new Integer(1), new Integer(1))
+  numObject(new Integer(97), new Character('a'))
+
+  charObject(new Character('a'), new Integer(97))
+}


### PR DESCRIPTION
When comparing a Number and a Character, the would emit a call to the
private method. For binary compatibility, this method remains private
in 2.11, so we just use equalsNumObject instead.
