### PR TITLE
SI-9030 make BoxesRunTime.equalsNumChar public

### DIFF
--- a/src/library/scala/runtime/BoxesRunTime.java
+++ b/src/library/scala/runtime/BoxesRunTime.java
@@ -183,7 +183,7 @@ public final class BoxesRunTime
         return xc.equals(y);
     }
 
-    private static boolean equalsNumChar(java.lang.Number xn, java.lang.Character yc) {
+    public static boolean equalsNumChar(java.lang.Number xn, java.lang.Character yc) {
         if (yc == null)
             return xn == null;
 

--- a/test/files/run/t9030.scala
+++ b/test/files/run/t9030.scala
@@ -1,0 +1,19 @@
+object Test extends App {
+
+  // For these methods, the compiler emits calls to BoxesRuntime.equalsNumNum/equalsNumChar/equalsNumObject directly
+
+  def numNum(a: java.lang.Number, b: java.lang.Number) = assert(a == b)
+  def numChar(a: java.lang.Number, b: java.lang.Character) = assert(a == b)
+  def numObject(a: java.lang.Number, b: java.lang.Object) = assert(a == b)
+
+  // The compiler doesn't use equalsCharObject directly, but still adding an example for completeness
+
+  def charObject(a: java.lang.Character, b: java.lang.Object) = assert(a == b)
+
+  numNum(new Integer(1), new Integer(1))
+  numChar(new Integer(97), new Character('a'))
+  numObject(new Integer(1), new Integer(1))
+  numObject(new Integer(97), new Character('a'))
+
+  charObject(new Character('a'), new Integer(97))
+}


### PR DESCRIPTION
When comparing a Number and a Character, the backend directly emits a
call to this method.
