### PR TITLE
Fix problems with a locale-dependent decimal mark in StringContextTest

### DIFF
--- a/test/junit/scala/StringContextTest.scala
+++ b/test/junit/scala/StringContextTest.scala
@@ -65,14 +65,23 @@ class StringContextTest {
 
   @Test def fIf() = {
     val res = f"${if (true) 2.5 else 2.5}%.2f"
-    assertEquals("2.50", res)
+    val expected = formatUsingCurrentLocale(2.50)
+    assertEquals(expected, res)
   }
+
   @Test def fIfNot() = {
     val res = f"${if (false) 2.5 else 3.5}%.2f"
-    assertEquals("3.50", res)
+    val expected = formatUsingCurrentLocale(3.50)
+    assertEquals(expected, res)
   }
+
   @Test def fHeteroArgs() = {
     val res = f"${3.14}%.2f rounds to ${3}%d"
-    assertEquals("3.14 rounds to 3", res)
+    val expected = formatUsingCurrentLocale(3.14) + " rounds to 3"
+    assertEquals(expected, res)
   }
+
+  // Use this method to avoid problems with a locale-dependent decimal mark.
+  // The string interpolation is not used here intentionally as this method is used to test string interpolation.
+  private def formatUsingCurrentLocale(number: Double, decimalPlaces: Int = 2) = ("%." + decimalPlaces + "f").format(number)
 }


### PR DESCRIPTION
This commit corrects three tests which were failing for certain locale
due to the different decimal marks in the expected value and the
result (e.g. 2.50 and 2,50).

From now also the expected value is formatted in accordance with the
current locale.

I reported this issue some time ago (see
https://groups.google.com/forum/#!topic/scala-internals/P7mv3wmTSfs )
but nothing changed so far. That's why I made these changes.
