### PR TITLE
SI-9011 Speculative fix for CCE in Scala IDE

### DIFF
--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -78,7 +78,11 @@ trait InteractiveAnalyzer extends Analyzer {
         val owningInfo = sym.owner.info
         val existingDerivedSym = owningInfo.decl(sym.name.toTermName).filter(sym => sym.isSynthetic && sym.isMethod)
         existingDerivedSym.alternatives foreach (owningInfo.decls.unlink)
-        enterImplicitWrapper(tree.asInstanceOf[ClassDef])
+        val defTree = tree match {
+          case dd: DocDef => dd.definition // See SI-9011, Scala IDE's presentation compiler incorporates ScalaDocGlobal with InterativeGlobal, so we have to unwrap DocDefs.
+          case _ => tree
+        }
+        enterImplicitWrapper(defTree.asInstanceOf[ClassDef])
       }
       super.enterExistingSym(sym, tree)
     }


### PR DESCRIPTION
Based on the reported stack trace and what I know of Scala IDE,
I've changed `InteractiveNamer#enterExistingSymbol` to be `DocDef`
aware.

I haven't provided a test as this was not minimized from Scala IDE.
