### PR TITLE
update to scala-parser-combinators 1.0.3

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -18,7 +18,7 @@ scala.full.version=2.11.2
 
 # external modules shipped with distribution, as specified by scala-library-all's pom
 scala-xml.version.number=1.0.3
-scala-parser-combinators.version.number=1.0.2
+scala-parser-combinators.version.number=1.0.3
 scala-continuations-plugin.version.number=1.0.2
 scala-continuations-library.version.number=1.0.2
 scala-swing.version.number=1.0.1


### PR DESCRIPTION
Just [released](https://github.com/scala/scala-parser-combinators/releases/tag/v1.0.3) yesterday. If it is not too late, it would be nice to have it in 2.11.5.

---

@adriaanm 
