### PR TITLE
SI-9044 Fix order of interfaces in classfiles

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -185,22 +185,22 @@ abstract class Erasure extends AddInterfaces
 
   private def isErasedValueType(tpe: Type) = tpe.isInstanceOf[ErasedValueType]
 
-  /* Drop redundant interfaces (ones which are implemented by some other parent) from the immediate parents.
+  /* Drop redundant types (ones which are implemented by some other parent) from the immediate parents.
    * This is important on Android because there is otherwise an interface explosion.
    */
-  def minimizeInterfaces(lstIfaces: List[Type]): List[Type] = {
-    var rest   = lstIfaces
-    var leaves = List.empty[Type]
-    while(!rest.isEmpty) {
+  def minimizeParents(parents: List[Type]): List[Type] = {
+    var rest   = parents
+    var leaves = collection.mutable.ListBuffer.empty[Type]
+    while(rest.nonEmpty) {
       val candidate = rest.head
       val nonLeaf = leaves exists { t => t.typeSymbol isSubClass candidate.typeSymbol }
       if(!nonLeaf) {
-        leaves = candidate :: (leaves filterNot { t => candidate.typeSymbol isSubClass t.typeSymbol })
+        leaves = leaves filterNot { t => candidate.typeSymbol isSubClass t.typeSymbol }
+        leaves += candidate
       }
       rest = rest.tail
     }
-
-    leaves.reverse
+    leaves.toList
   }
 
 
@@ -220,7 +220,7 @@ abstract class Erasure extends AddInterfaces
         case _ => tps
       }
 
-      val minParents = minimizeInterfaces(parents)
+      val minParents = minimizeParents(parents)
       val validParents =
         if (isTraitSignature)
           // java is unthrilled about seeing interfaces inherit from classes

--- a/test/files/jvm/t9044.scala
+++ b/test/files/jvm/t9044.scala
@@ -1,0 +1,6 @@
+trait A
+trait B
+object Test extends A with B with App {
+  val is = Test.getClass.getInterfaces.mkString(", ")
+  assert(is == "interface A, interface B, interface scala.App", is)
+}


### PR DESCRIPTION
It was reversed since ced3ca8. The reason is that the backend used
`mixinClasses` to obtain the parents of a class, which returns them in
linearization order.

`mixinClasses` als returns all ancestors (not only direct parents),
which means more work for `minimizeInterfaces`. This was introduced
in cd62f52 for unclear reasons. So we switch back to using `parents`.

To verify, I created a git repo with the library classfiles of 2.11.4, 2.11.x and this fix (classfile diffing by https://github.com/retronym/libscala/tree/master/git-java)

```
lucmac:t9044 luc$ git lg
* 02a3531 - (HEAD, master) 9044 fix 2 (37 minutes ago) <Lukas Rytz>
* 68b55fe - current 2.11.x (17 hours ago) <Lukas Rytz>
* 405c74d - 2.11.4 (17 hours ago) <Lukas Rytz>
```

the result of diffing 2.11.4 versus this fix (`git diff 405c74d..02a3531 > diff`) is here: https://gist.github.com/lrytz/3fcb0547849cf7b7ef36. The different diff in signatures (`+  Signature: J`) is due to the fix ced3ca8, which minimized the interfaces - the signature diff is not correctly displayed. Here's the diff for List.class (obtained with asm):

``` diff
@@ -1,11 +1,11 @@
 // class version 50.0 (50)
 // access flags 0x421
-// signature <A:Ljava/lang/Object;>Lscala/collection/AbstractSeq<TA;>;Lscala/collection/immutable/LinearSeq<TA;>;Lscala/Product;Lscala/collection/LinearSeqOptimized<TA;Lscala/collection/immutable/List<TA;>;>;Ljava/io/Serializable;
-// declaration: scala/collection/immutable/List<A> extends scala.collection.AbstractSeq<A> implements scala.collection.immutable.LinearSeq<A>, scala.Product, scala.collection.LinearSeqOptimized<A, scala.collection.immutable.List<A>>, java.io.Serializable
+// signature <A:Ljava/lang/Object;>Lscala/collection/AbstractSeq<TA;>;Lscala/collection/immutable/LinearSeq<TA;>;Lscala/Product;Lscala/collection/generic/GenericTraversableTemplate<TA;Lscala/collection/immutable/List;>;Lscala/collection/LinearSeqOptimized<TA;Lscala/collection/immutable/List<TA;>;>;Ljava/io/Serializable;
+// declaration: scala/collection/immutable/List<A> extends scala.collection.AbstractSeq<A> implements scala.collection.immutable.LinearSeq<A>, scala.Product, scala.collection.generic.GenericTraversableTemplate<A, scala.collection.immutable.List>, scala.collection.LinearSeqOptimized<A, scala.collection.immutable.List<A>>, java.io.Serializable
 public abstract class scala/collection/immutable/List extends scala/collection/AbstractSeq  implements scala/collection/immutable/LinearSeq scala/Product scala/collection/LinearSeqOptimized java/io/Serializable  {
```

The gist shows that the list of implemented interfaces is the same for all classes in the library:

```
lucmac:t9044 luc$ cat diff | grep implements | grep +
lucmac:t9044 luc$ 
```
