### PR TITLE
Run dead code elimination by default in GenBCode

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/LocalOpt.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/LocalOpt.scala
@@ -55,7 +55,7 @@ class LocalOpt(settings: ScalaSettings) {
    * @return      `true` if unreachable code was elminated in some method, `false` otherwise.
    */
   def methodOptimizations(clazz: ClassNode): Boolean = {
-    settings.Yopt.value.nonEmpty && clazz.methods.asScala.foldLeft(false) {
+    !settings.YoptNone && clazz.methods.asScala.foldLeft(false) {
       case (changed, method) => methodOptimizations(method, clazz.name) || changed
     }
   }

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -242,6 +242,7 @@ trait ScalaSettings extends AbsScalaSettings
     descr = "Enable optimizations",
     domain = YoptChoices)
 
+  def YoptNone                    = Yopt.isSetByUser && Yopt.value.isEmpty
   def YoptUnreachableCode         = !Yopt.isSetByUser || Yopt.contains(YoptChoices.unreachableCode)
   def YoptSimplifyJumps           = Yopt.contains(YoptChoices.simplifyJumps)
   def YoptRecurseUnreachableJumps = Yopt.contains(YoptChoices.recurseUnreachableJumps)


### PR DESCRIPTION
This was disabled by mistake. Settings are still a challenge.
This fixes the bcode-delambdafy-method build
(https://scala-webapps.epfl.ch/jenkins/view/2.11.x/job/scala-nightly-genbcode-2.11.x/)
