### PR TITLE
SI-5154 Parse leading literal brace in XML pattern

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/MarkupParsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/MarkupParsers.scala
@@ -425,11 +425,10 @@ trait MarkupParsers {
               if (ch != '/') ts append xPattern   // child
               else return false                   // terminate
 
-            case '{'  => // embedded Scala patterns
-              while (ch == '{') {
-                nextch()
+            case '{' if xCheckEmbeddedBlock => // embedded Scala patterns, if not double brace
+              do {
                 ts ++= xScalaPatterns
-              }
+              } while (xCheckEmbeddedBlock)
               assert(!xEmbeddedBlock, "problem with embedded block")
 
             case SU   =>

--- a/test/files/pos/t5154.scala
+++ b/test/files/pos/t5154.scala
@@ -1,0 +1,9 @@
+
+trait Z {
+  // extra space made the pattern OK
+  def f = <z> {{3}}</z> match { case <z> {{3}}</z> => }
+
+  // lack of space: error: illegal start of simple pattern
+  def g = <z>{{3}}</z> match { case <z>{{3}}</z> => }
+}
+


### PR DESCRIPTION
Don't consume literal brace as Scala pattern.

Previously, leading space would let the text parser `xText`
handle it correctly instead.
