### PR TITLE
Fixes SI-8689 by delegating Promise.completeWith to Promise.tryCompleteW...

### DIFF
--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -808,8 +808,7 @@ object Future {
   // doesn't need to create defaultExecutionContext as
   // a side effect.
   private[concurrent] object InternalCallbackExecutor extends ExecutionContext with BatchingExecutor {
-    override protected def unbatchedExecute(r: Runnable): Unit =
-      r.run()
+    override protected def unbatchedExecute(r: Runnable): Unit = r.run()
     override def reportFailure(t: Throwable): Unit =
       throw new IllegalStateException("problem in scala.concurrent internal callback", t)
   }

--- a/src/library/scala/concurrent/Promise.scala
+++ b/src/library/scala/concurrent/Promise.scala
@@ -60,12 +60,7 @@ trait Promise[T] {
    *
    *  @return   This promise
    */
-  final def completeWith(other: Future[T]): this.type = {
-    if (other ne this.future) { // this completeWith this doesn't make much sense
-      other.onComplete(this complete _)(Future.InternalCallbackExecutor)
-    }
-    this
-  }
+  final def completeWith(other: Future[T]): this.type = tryCompleteWith(other)
 
   /** Attempts to complete this promise with the specified future, once that future is completed.
    *

--- a/test/files/jvm/t8689.check
+++ b/test/files/jvm/t8689.check
@@ -1,0 +1,2 @@
+warning: there was one deprecation warning; re-run with -deprecation for details
+success

--- a/test/files/jvm/t8689.scala
+++ b/test/files/jvm/t8689.scala
@@ -1,0 +1,13 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    import scala.concurrent._
+    import ExecutionContext.Implicits.global
+    val source1 = Promise[Int]()
+    val source2 = Promise[Int]()
+    source2.completeWith(source1.future).future.onComplete {
+      case _ => print("success")
+    }
+    source2.tryFailure(new TimeoutException)
+    source1.success(123)
+  }
+}


### PR DESCRIPTION
...ith

as well as deprecates `Promise.completeWith` since it is now redundant.

Backport to 2.11.x and 2.10.x without the deprecation
