### PR TITLE
SI-7623 Trailing sequence wildcard warning

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -28,10 +28,11 @@ trait Warnings {
   val warnUnusedImport     = BooleanSetting("-Ywarn-unused-import", "Warn when imports are unused.")
 
   // Experimental lint warnings that are turned off, but which could be turned on programmatically.
-  // These warnings are said to blind those who dare enable them.
-  // They are not activated by -Xlint and can't be enabled on the command line.
-  val warnValueOverrides = { // Currently turned off as experimental. Created using constructor (new BS), so not available on the command line.
-  val flag = new BooleanSetting("value-overrides", "Generated value class method overrides an implementation")
+  // They are not activated by -Xlint and can't be enabled on the command line because they are not
+  // created using the standard factory methods.
+
+  val warnValueOverrides = {
+    val flag = new BooleanSetting("value-overrides", "Generated value class method overrides an implementation.")
     flag.value = false
     flag
   }
@@ -53,10 +54,11 @@ trait Warnings {
     val TypeParameterShadow    = LintWarning("type-parameter-shadow",     "A local type parameter shadows a type already in scope.")
     val PolyImplicitOverload   = LintWarning("poly-implicit-overload",    "Parameterized overloaded implicit methods are not visible as view bounds.")
     val OptionImplicit         = LintWarning("option-implicit",           "Option.apply used implicit view.")
-    val DelayedInitSelect      = LintWarning("delayedinit-select",        "Selecting member of DelayedInit")
+    val DelayedInitSelect      = LintWarning("delayedinit-select",        "Selecting member of DelayedInit.")
     val ByNameRightAssociative = LintWarning("by-name-right-associative", "By-name parameter of right associative operator.")
     val PackageObjectClasses   = LintWarning("package-object-classes",    "Class or object defined in package object.")
     val UnsoundMatch           = LintWarning("unsound-match",             "Pattern match may not be typesafe.")
+    val StarsAlign             = LintWarning("stars-align",               "Pattern sequence wildcard must align with sequence component.")
 
     def allLintWarnings = values.toSeq.asInstanceOf[Seq[LintWarning]]
   }
@@ -77,6 +79,7 @@ trait Warnings {
   def warnByNameRightAssociative = lint contains ByNameRightAssociative
   def warnPackageObjectClasses   = lint contains PackageObjectClasses
   def warnUnsoundMatch           = lint contains UnsoundMatch
+  def warnStarsAlign             = lint contains StarsAlign
 
   // Lint warnings that are currently -Y, but deprecated in that usage
   @deprecated("Use warnAdaptedArgs", since="2.11.2")

--- a/src/compiler/scala/tools/nsc/transform/patmat/ScalacPatternExpanders.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/ScalacPatternExpanders.scala
@@ -110,8 +110,10 @@ trait ScalacPatternExpanders {
         err("Star pattern must correspond with varargs or unapplySeq")
       else if (elementArity < 0)
         arityError("not enough")
-      else if (elementArity > 0 && !extractor.hasSeq)
+      else if (elementArity > 0 && !isSeq)
         arityError("too many")
+      else if (settings.warnStarsAlign && isSeq && productArity > 0 && (elementArity > 0 || !isStar))
+        warn("A repeated case parameter or extracted sequence should be matched only by a sequence wildcard (_*).")
 
       aligned
     }

--- a/test/files/neg/t7623.check
+++ b/test/files/neg/t7623.check
@@ -1,0 +1,21 @@
+t7623.scala:19: warning: A repeated case parameter or extracted sequence should be matched only by a sequence wildcard (_*).
+  def f = "" match { case X(s) => }
+                          ^
+t7623.scala:21: warning: A repeated case parameter or extracted sequence should be matched only by a sequence wildcard (_*).
+  def g = "" match { case X(s, t) => }
+                          ^
+t7623.scala:23: warning: A repeated case parameter or extracted sequence should be matched only by a sequence wildcard (_*).
+  def h = "" match { case X(s, t, u @ _*) => }
+                          ^
+t7623.scala:9: warning: A repeated case parameter or extracted sequence should be matched only by a sequence wildcard (_*).
+  def f = C("") match { case C(s) => }
+                             ^
+t7623.scala:11: warning: A repeated case parameter or extracted sequence should be matched only by a sequence wildcard (_*).
+  def g = C("") match { case C(s, t) => }
+                             ^
+t7623.scala:13: warning: A repeated case parameter or extracted sequence should be matched only by a sequence wildcard (_*).
+  def h = C("") match { case C(s, t, u @ _*) => }
+                             ^
+error: No warnings can be incurred under -Xfatal-warnings.
+6 warnings found
+one error found

--- a/test/files/neg/t7623.flags
+++ b/test/files/neg/t7623.flags
@@ -1,0 +1,1 @@
+-Xlint:stars-align -Xfatal-warnings

--- a/test/files/neg/t7623.scala
+++ b/test/files/neg/t7623.scala
@@ -1,0 +1,38 @@
+
+
+case class C(s: String, xs: Int*)
+
+object X { def unapplySeq(a: Any): Option[(String, Seq[Int])] = Some("", List(1,2,3)) }
+
+// for case classes with varargs, avoid misaligned patterns
+trait Ctest {
+  def f = C("") match { case C(s) => }
+
+  def g = C("") match { case C(s, t) => }
+
+  def h = C("") match { case C(s, t, u @ _*) => }
+
+  def ok = C("") match { case C(s, u @ _*) => }
+}
+// for extractors that unapplySeq: Option[(Something, Seq[_])], avoid misaligned patterns
+trait Xtest {
+  def f = "" match { case X(s) => }
+
+  def g = "" match { case X(s, t) => }
+
+  def h = "" match { case X(s, t, u @ _*) => }
+
+  def ok = "" match { case X(s, u @ _*) => }
+}
+// for extractors that unapplySeq: Option[Seq[_]], anything goes
+trait Rtest {
+  val r = "(a+)".r
+
+  def f = "" match { case r(s) => }
+
+  def g = "" match { case r(s, t) => }
+
+  def h = "" match { case r(s, t, u @ _*) => }
+
+  def whatever = "" match { case r(u @ _*) => }
+}


### PR DESCRIPTION
An -Xlint:stars-align warning for the case of patterns
with at least one "fixed" component and a varargs component.

Warn if the fixed patterns don't exactly align with the fixed
value components, such that a sequence wildcard aligns exactly
with the varargs component (either a T\* parameter in a case class
or a Seq[T] in an extractor result).

This addresses the case of the xml.Elem extractor, which does
not correspond to the Elem class constructor. One can be fooled
into supplying an extra field for extraction.

Vanilla extractors of type `Option[Seq[_]]` are unaffected by
this flag. It's OK to ask for `case X(a, b, c)` in the expectation
that three results are forthcoming. There is no semantic confusion
over where the varargs begin.

JIRA: https://issues.scala-lang.org/browse/SI-7623