### PR TITLE
Prevent creation of Some(null) with Option.map function

### DIFF
--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -143,7 +143,7 @@ sealed abstract class Option[+A] extends Product with Serializable {
    *  @see foreach
    */
   @inline final def map[B](f: A => B): Option[B] =
-    if (isEmpty) None else Some(f(this.get))
+    if (isEmpty) None else Option(f(this.get))
 
   /** Returns the result of applying $f to this $option's
    *  value if the $option is nonempty.  Otherwise, evaluates


### PR DESCRIPTION
Current implementation of Option.map don't allow to simplify checks for nulls.

If I have something like `project.getUser.getAccount.getName` and need to prevent nullpointer exceptions I would write something like

``` scala
Option(project).map(_.getUser).map(_.getAccount).map(_.getName).orElse("Default name")
```

But the function is implemented in a way that lead to null pointer exceptions in this case.
