### PR TITLE
SI-7771: BitSet hashcode inefficient

### DIFF
--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -167,6 +167,15 @@ class BitSet(protected final var elems: Array[Long]) extends AbstractSet[Int]
     Array.copy(elems, 0, elems1, 0, elems.length)
     new BitSet(elems1)
   }
+
+  override def equals(that: Any): Boolean = that match {
+    case that: BitSet =>
+      that.elems.sameElements(this.elems)
+    case _ =>
+      false
+  }
+
+  override def hashCode() = scala.util.hashing.MurmurHash3.arrayHash(elems)
 }
 
 /** $factoryInfo
@@ -194,4 +203,5 @@ object BitSet extends BitSetFactory[BitSet] {
    *  array without copying.
    */
   def fromBitMaskNoCopy(elems: Array[Long]): BitSet = new BitSet(elems)
+
 }

--- a/test/junit/scala/collection/mutable/BitSetTest.scala
+++ b/test/junit/scala/collection/mutable/BitSetTest.scala
@@ -2,7 +2,7 @@ package scala.collection.mutable
 
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import org.junit.{Test, Ignore}
+import org.junit.{ Assert, Test }
 
 @RunWith(classOf[JUnit4])
 class BitSetTest {
@@ -18,5 +18,14 @@ class BitSetTest {
     assert(bitSet.toBitMask.length == size, "Capacity of bitset changed after &=")
     bitSet &~= bitSet
     assert(bitSet.toBitMask.length == size, "Capacity of bitset changed after &~=")
+  }
+
+  // Test for SI-7771
+  @Test def testEquality(): Unit = {
+    Assert.assertEquals(BitSet(1, 2, 3), BitSet(3, 2, 1))
+    Assert.assertEquals(BitSet.empty, BitSet.empty)
+    Assert.assertNotEquals(BitSet(1, 2, 3), BitSet(1, 4, 1))
+    Assert.assertEquals(BitSet(1, 1, 1), BitSet(1))
+    Assert.assertEquals(BitSet(3, 2, 3, 2), BitSet(2, 3))
   }
 }


### PR DESCRIPTION
An immutable BitSet can use Murmur3.arrayHash instead of
Murmur3.setHash, which is inherited from GenSet.
