### PR TITLE
SI-6476 Accept escaped quotes in interp strings

### DIFF
--- a/test/files/neg/t5510.check
+++ b/test/files/neg/t5510.check
@@ -1,19 +1,25 @@
-t5510.scala:2: error: unclosed string literal
+t5510.scala:2: error: unclosed string literal (\" is an escaped quote, not the end of string)
+  val sa = s"x\"y
+             ^
+t5510.scala:3: error: unclosed string literal (\" is an escaped quote, not the end of string)
+  val sb = "x\"y
+           ^
+t5510.scala:4: error: unclosed string literal
   val s1 = s"xxx
              ^
-t5510.scala:3: error: unclosed string literal
+t5510.scala:5: error: unclosed string literal
   val s2 = s"xxx $x
                    ^
-t5510.scala:4: error: unclosed string literal
+t5510.scala:6: error: unclosed string literal
   val s3 = s"xxx $$
              ^
-t5510.scala:5: error: unclosed string literal
+t5510.scala:7: error: unclosed string literal
   val s4 = ""s"
                ^
-t5510.scala:6: error: unclosed multi-line string literal
+t5510.scala:8: error: unclosed multi-line string literal
   val s5 = ""s""" $s1 $s2 s"
                          ^
-t5510.scala:7: error: unclosed multi-line string literal
+t5510.scala:9: error: unclosed multi-line string literal
 }
  ^
-6 errors found
+8 errors found

--- a/test/files/neg/t5510.scala
+++ b/test/files/neg/t5510.scala
@@ -1,4 +1,6 @@
 object Test {
+  val sa = s"x\"y
+  val sb = "x\"y
   val s1 = s"xxx
   val s2 = s"xxx $x
   val s3 = s"xxx $$

--- a/test/files/neg/t8266-invalid-interp.check
+++ b/test/files/neg/t8266-invalid-interp.check
@@ -1,7 +1,8 @@
 t8266-invalid-interp.scala:5: error: invalid escape '\x' not one of [\b, \t, \n, \f, \r, \\, \", \'] at index 1 in "a\xc". Use \\ for literal \.
     f"a\xc",
        ^
-t8266-invalid-interp.scala:7: error: invalid escape '\v' not one of [\b, \t, \n, \f, \r, \\, \", \'] at index 1 in "a\vc". Use \\ for literal \.
+t8266-invalid-interp.scala:7: error: \v is not supported, but for vertical tab use \u000b;
+invalid escape '\v' not one of [\b, \t, \n, \f, \r, \\, \", \'] at index 1 in "a\vc". Use \\ for literal \.
     f"a\vc"
        ^
 two errors found

--- a/test/files/neg/t8266-invalid-interp.check
+++ b/test/files/neg/t8266-invalid-interp.check
@@ -1,10 +1,7 @@
-t8266-invalid-interp.scala:4: error: Trailing '\' escapes nothing.
-    f"a\",
-       ^
 t8266-invalid-interp.scala:5: error: invalid escape '\x' not one of [\b, \t, \n, \f, \r, \\, \", \'] at index 1 in "a\xc". Use \\ for literal \.
     f"a\xc",
        ^
 t8266-invalid-interp.scala:7: error: invalid escape '\v' not one of [\b, \t, \n, \f, \r, \\, \", \'] at index 1 in "a\vc". Use \\ for literal \.
     f"a\vc"
        ^
-three errors found
+two errors found

--- a/test/files/neg/t8266-invalid-interp.scala
+++ b/test/files/neg/t8266-invalid-interp.scala
@@ -1,7 +1,7 @@
 
 trait X {
   def f = Seq(
-    f"a\",
+    // f"a\",    // escaped quote and unterminated string
     f"a\xc",
     // following could suggest \u000b for vertical tab, similar for \a alert
     f"a\vc"

--- a/test/junit/scala/StringContextTest.scala
+++ b/test/junit/scala/StringContextTest.scala
@@ -75,4 +75,18 @@ class StringContextTest {
     val res = f"${3.14}%.2f rounds to ${3}%d"
     assertEquals("3.14 rounds to 3", res)
   }
+
+  @Test def `SI-6476: escape quotes`(): Unit = {
+    val i = 42
+    assertEquals("""Forty-two is "42"""", s"Forty-two is \"42\"")
+    assertEquals("""dir\""", s"dir\\")
+    assertEquals("""\\""", s"\\\\")
+    // dollar is not escaped
+    assertEquals("""\\\42""", raw"\\\$i")
+    // colon separator, in case we like to escape dollar someday
+    assertEquals("""\\\:42""", raw"\\\:$i")
+    assertThrows[StringContext.InvalidEscapeException] {
+      s"\\\:$i"
+    }
+  }
 }


### PR DESCRIPTION
Everyone wants to say `s"\"hello,\" world"`.

This commit considers `\"` when looking for the end of
a string part. `\\` is permitted to enable `\\"` for
literal `\"`.

However, the interpolator still receives the source text.

The wrinkly edge case is that trailing backslash must be
escaped. For instance, an interpolator that creates `File`
objects would require `F"~\Documents\\"`.
