### PR TITLE
Fix SI-8938: Future is not completed with anything if it throws InterruptedException

### DIFF
--- a/src/library/scala/concurrent/impl/Future.scala
+++ b/src/library/scala/concurrent/impl/Future.scala
@@ -21,7 +21,13 @@ private[concurrent] object Future {
 
     override def run() = {
       promise complete {
-        try Success(body) catch { case NonFatal(e) => Failure(e) }
+        try Success(body) catch {
+          // Catch all throwables here, so they can be communicated back to the
+          // calling thread. Throwables that aren't handled here are invisible
+          // to the caller, so it doesn't make sense to let any leak, even if
+          // they're fatal.
+          case t: Throwable => Failure(t)
+        }
       }
     }
   }

--- a/test/files/jvm/future-spec/FutureTests.scala
+++ b/test/files/jvm/future-spec/FutureTests.scala
@@ -93,8 +93,14 @@ class FutureTests extends MinimalScalaTest {
       val logThrowable: Throwable => Unit = p.trySuccess(_)
       val ec: ExecutionContext = ExecutionContext.fromExecutor(null, logThrowable)
 
-      val t = new InterruptedException()
-      val f = Future(throw t)(ec)
+      // Future now handles all exceptions, so this test must directly use a
+      // Runnable.
+      val t = new Exception()
+      ec.prepare.execute(new Runnable {
+        override def run() = {
+          throw t
+        }
+      })
       Await.result(p.future, 2.seconds) mustBe t
     }
   }

--- a/test/files/jvm/future-spec/PromiseTests.scala
+++ b/test/files/jvm/future-spec/PromiseTests.scala
@@ -12,7 +12,13 @@ import scala.util.{Try,Success,Failure}
 class PromiseTests extends MinimalScalaTest {
   import ExecutionContext.Implicits._
 
-  val defaultTimeout = Inf
+  // There's a tradeoff between setting the timeout high to avoid false
+  // positives, or setting it low to improve test execution time in cases where
+  // a timeout occurs. The tests in PromiseTests only wait on computations that
+  // are trivially short, so it should be safe to pick a short timeout. If this
+  // assumption is wrong, it will result in false positive test failures due to
+  // timeouts, which should be easy to diagnose from the log output.
+  val defaultTimeout = 0.25 seconds
 
   /* promise specification */
 


### PR DESCRIPTION
Last week, I decided to pick an arbitrary Scala bug and fix it, so I could gain some real experience with the language, while producing something that I wasn't going to throw away after. I wasn't sure how far I'd get, so I didn't bring this up on the mailing list or bug before working on it (sorry!). However, I now have a fix for this issue, as well as fixes for a gap in the tests that allowed the bug to remain unnoticed. I developed on the 2.11.x branch, because that happened to be where Scala's HEAD reference points to.

The hacker guide includes the following quote:

> Keeping Scala’s git history clean is also important. Therefore we won’t accept pull requests for bug fixes that have more than one commit.

This pull request currently has two commits, which I've kept separate because I think there's a case for doing that. If the reviewer disagrees, I can squash the changes, put the other commit in its own PR, or omit the second change, to bring the PR into compliance.

While preparing to submit the pull request, I looked at the 2.12.x branch. It looks like the bug affects that branch as well, and I'm in the process of porting the fix to it.
