### PR TITLE
SI-9067: Enumeration withName improvement

### DIFF
--- a/src/library/scala/Enumeration.scala
+++ b/src/library/scala/Enumeration.scala
@@ -121,7 +121,8 @@ abstract class Enumeration (initial: Int) extends Serializable {
    * @throws   NoSuchElementException if no `Value` with a matching
    *           name is in this `Enumeration`
    */
-  final def withName(s: String): Value = values.find(_.toString == s).get
+  final def withName(s: String): Value = values.find(_.toString == s).getOrElse(
+    throw new NoSuchElementException(s"No value found for '$s'"))
 
   /** Creates a fresh value, part of this enumeration. */
   protected final def Value: Value = Value(nextId)


### PR DESCRIPTION
- Enumeration#withName in case of a failed approach to resolve the
  Enumeration value fails with a meaningless NoSuchElementException.
  Would be nice to know what exactly is not found
