### PR TITLE
SI-2991 Enable untupled overload res for Java

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -209,6 +209,8 @@ trait ScalaSettings extends AbsScalaSettings
   val YdisableUnreachablePrevention = BooleanSetting("-Ydisable-unreachable-prevention", "Disable the prevention of unreachable blocks in code generation.")
   val YnoLoadImplClass = BooleanSetting   ("-Yno-load-impl-class", "Do not load $class.class files.")
 
+  val YnoTupledAmbiguity = BooleanSetting ("-Yno-tupled-ambiguity", "Tupling will not make a Java API ambiguous.")
+
   val exposeEmptyPackage = BooleanSetting("-Yexpose-empty-package", "Internal only: expose the empty package.").internalOnly()
   // the current standard is "inline" but we are moving towards "method"
   val Ydelambdafy        = ChoiceSetting     ("-Ydelambdafy", "strategy", "Strategy used for translating lambdas into JVM code.", List("inline", "method"), "inline")

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -178,6 +178,17 @@ trait Infer extends Checkable {
     def context: Context
     import InferErrorGen._
 
+    // flag used to turn off tupling when alternatives of an overload include a Java-defined method
+    private[this] var tupleForApplicability = true
+    def withoutTuplingForApplicability[A](body: => A): A =
+      if (settings.YnoTupledAmbiguity) {
+        val saved = tupleForApplicability
+        tupleForApplicability = false
+        try body finally tupleForApplicability = saved
+      } else {
+        body
+      }
+
     /* -- Error Messages --------------------------------------------------- */
     def setError[T <: Tree](tree: T): T = {
       // SI-7388, one can incur a cycle calling sym.toString
@@ -756,7 +767,7 @@ trait Infer extends Checkable {
       compareLengths(argtpes0, formals) match {
         case 0 if containsNamedType(argtpes0) => reorderedTypesCompatible      // right number of args, wrong order
         case 0                                => typesCompatible(argtpes0)     // fast track if no named arguments are used
-        case x if x > 0                       => tryWithArgs(argsTupled)       // too many args, try tupling
+        case x if x > 0                       => tupleForApplicability && tryWithArgs(argsTupled) // too many args, try tupling
         case _                                => tryWithArgs(argsPlusDefaults) // too few args, try adding defaults or tupling
       }
     }
@@ -1396,13 +1407,25 @@ trait Infer extends Checkable {
           case tp               => tp
         }
 
+        // if at least one retry is required, and the overload includes a Java-defined alternative
+        // proceed without tupling for applicability (if flag is enabled)
+        private[this] var retries = 0
+        private def atRetryDepth[A](cond: Boolean)(body: => A): A = {
+          val res =
+            if (cond && retries > 0) withoutTuplingForApplicability(body)
+            else body
+          retries += 1
+          res
+        }
+
         private def followType(sym: Symbol) = followApply(pre memberType sym)
         // separate method to help the inliner
         private def isAltApplicable(pt: Type)(alt: Symbol) = context inSilentMode { isApplicable(undetparams, followType(alt), argtpes, pt) && !context.reporter.hasErrors }
         private def rankAlternatives(sym1: Symbol, sym2: Symbol) = isStrictlyMoreSpecific(followType(sym1), followType(sym2), sym1, sym2)
         private def bestForExpectedType(pt: Type, isLastTry: Boolean): Unit = {
           val applicable  = overloadsToConsiderBySpecificity(alts filter isAltApplicable(pt), argtpes, varargsStar)
-          val ranked      = bestAlternatives(applicable)(rankAlternatives)
+          val infected    = applicable exists (_.isJavaDefined)
+          val ranked      = atRetryDepth(infected) { bestAlternatives(applicable)(rankAlternatives) }
           ranked match {
             case best :: competing :: _ => AmbiguousMethodAlternativeError(tree, pre, best, competing, argtpes, pt, isLastTry) // ambiguous
             case best :: Nil            => tree setSymbol best setType (pre memberType best)           // success

--- a/test/files/pos/t2991.flags
+++ b/test/files/pos/t2991.flags
@@ -1,0 +1,1 @@
+-Yno-tupled-ambiguity

--- a/test/files/pos/t2991/Jamb_1.java
+++ b/test/files/pos/t2991/Jamb_1.java
@@ -1,0 +1,5 @@
+
+public class Jamb_1 {
+    public String f(Object a) { return "foo"; }
+    public String f(Object a, Object... as) { return "bar"; }
+}

--- a/test/files/pos/t2991/scam_2.scala
+++ b/test/files/pos/t2991/scam_2.scala
@@ -1,0 +1,7 @@
+
+// was ambiguous to Scala
+trait Scam {
+  val j = new Jamb_1
+  val o = new Object
+  def f = j.f(o)
+}


### PR DESCRIPTION
Java will disambiguate `f(A)` and `f(A, A*)` even though
they are patently ambiguous to the Scala programmer where
A is effectively Object.

This commit adds a compiler option `-Yno-tupled-ambiguity`
to mean: if an overload seems ambiguous and one of the
alternatives is a Java method, try again with tupling disabled.

Since the library author defines the intentional disambiguation
of an overload, the new option allows the library consumer to
respect the intended disambiguation, and indeed, to enable
any disambiguation at all by Scala.
