### PR TITLE
SI-7770 mutable.BitSet.toImmutable isn't immutable

### DIFF
--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -160,6 +160,9 @@ class BitSet(protected final var elems: Array[Long]) extends AbstractSet[Int]
    *
    *  @return an immutable set containing all the elements of this set.
    */
+  @deprecated("If this BitSet contains a value that is 128 or greater, the result of this method is an 'immutable' " +
+    "BitSet that shares state with this mutable BitSet. Thus, if the mutable BitSet is modified, it will violate the " +
+    "immutability of the result.", "2.11.6")
   def toImmutable = immutable.BitSet.fromBitMaskNoCopy(elems)
 
   override def clone(): BitSet = {

--- a/test/files/jvm/serialization-new.check
+++ b/test/files/jvm/serialization-new.check
@@ -1,4 +1,4 @@
-warning: there were two deprecation warnings; re-run with -deprecation for details
+warning: there were three deprecation warnings; re-run with -deprecation for details
 a1 = Array[1,2,3]
 _a1 = Array[1,2,3]
 arrayEquals(a1, _a1): true

--- a/test/files/jvm/serialization.check
+++ b/test/files/jvm/serialization.check
@@ -1,4 +1,4 @@
-warning: there were two deprecation warnings; re-run with -deprecation for details
+warning: there were three deprecation warnings; re-run with -deprecation for details
 a1 = Array[1,2,3]
 _a1 = Array[1,2,3]
 arrayEquals(a1, _a1): true

--- a/test/files/run/bitsets.check
+++ b/test/files/run/bitsets.check
@@ -1,3 +1,4 @@
+warning: there were three deprecation warnings; re-run with -deprecation for details
 ms0 = BitSet(2)
 ms1 = BitSet(2)
 ms2 = BitSet(2)


### PR DESCRIPTION
Mark method as deprecated due to it not providing the expected result,
while fixing it will break existing code.
