### PR TITLE
SI-9057 - fix `showCode` to put backticks around names including dots

### DIFF
--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -546,10 +546,11 @@ trait Printers extends api.Printers { self: SymbolTable =>
       import Chars._
       val decName = name.decoded
       val bslash = '\\'
+      val isDot = (x: Char) => x == '.'
       val brackets = List('[',']','(',')','{','}')
 
       def addBackquotes(s: String) =
-        if (decoded && (decName.exists(ch => brackets.contains(ch) || isWhitespace(ch)) ||
+        if (decoded && (decName.exists(ch => brackets.contains(ch) || isWhitespace(ch) || isDot(ch)) ||
           (name.isOperatorName && decName.exists(isOperatorPart) && decName.exists(isScalaLetter) && !decName.contains(bslash))))
           s"`$s`" else s
 

--- a/test/junit/scala/reflect/internal/PrintersTest.scala
+++ b/test/junit/scala/reflect/internal/PrintersTest.scala
@@ -125,6 +125,8 @@ trait BasePrintTests {
   @Test def testName19 = assertPrintedCode("""class `class`""")
 
   @Test def testName20 = assertPrintedCode("""class `test name`""")
+  
+  @Test def testName21 = assertPrintedCode("""class `test.name`""")
 
   @Test def testIfExpr1 = assertResultCode(code = sm"""
     |val a = 1


### PR DESCRIPTION
Missing backticks cause the parser to treat names as paths, which is obviously invalid.

A unit test is included.
