### PR TITLE
Simplify ClassTag.unapply using j.l.Class.isInstance.

### DIFF
--- a/src/library/scala/reflect/ClassTag.scala
+++ b/src/library/scala/reflect/ClassTag.scala
@@ -94,9 +94,9 @@ trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serial
   def unapply(x: Double)  : Option[T] = unapplyImpl(x, classOf[Double])
   def unapply(x: Boolean) : Option[T] = unapplyImpl(x, classOf[Boolean])
   def unapply(x: Unit)    : Option[T] = unapplyImpl(x, classOf[Unit])
-  
+
   private[this] def unapplyImpl(x: Any, alternative: jClass[_] = null): Option[T] = {
-    val conforms = runtimeClass.isAssignableFrom(x.getClass) || (alternative != null && runtimeClass.isAssignableFrom(alternative))
+    val conforms = runtimeClass.isInstance(x) || (alternative != null && runtimeClass.isAssignableFrom(alternative))
     if (conforms) Some(x.asInstanceOf[T]) else None
   }
 


### PR DESCRIPTION
On the JVM, this doesn't change anything, since `cls.isAssignableFrom(x.getClass)` is always equivalent to `cls.isInstance(x)`, except the latter does not fail brutally if `x == null`.

In Scala.js, this change allows `unapply` for `ClassTag`s referencing raw JavaScript classes to work correctly.

In Scala.js, I'm going to override the source of `ClassTag.scala` with this change for past versions of the Scala library. But I figured it might as well be sent upstream for future versions, if you think the change is valid.
