### PR TITLE
SI-8462: Int shift Long result corrected

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ConstantFolder.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ConstantFolder.scala
@@ -75,7 +75,7 @@ abstract class ConstantFolder {
     case nme.AND  => Constant(x.booleanValue & y.booleanValue)
     case nme.EQ   => Constant(x.booleanValue == y.booleanValue)
     case nme.NE   => Constant(x.booleanValue != y.booleanValue)
-    case _ => null
+    case _        => null
   }
   private def foldSubrangeOp(op: Name, x: Constant, y: Constant): Constant = op match {
     case nme.OR  => Constant(x.intValue | y.intValue)
@@ -95,14 +95,20 @@ abstract class ConstantFolder {
     case nme.MUL => Constant(x.intValue * y.intValue)
     case nme.DIV => Constant(x.intValue / y.intValue)
     case nme.MOD => Constant(x.intValue % y.intValue)
-    case _ => null
+    case _       => null
   }
   private def foldLongOp(op: Name, x: Constant, y: Constant): Constant = op match {
     case nme.OR  => Constant(x.longValue | y.longValue)
     case nme.XOR => Constant(x.longValue ^ y.longValue)
     case nme.AND => Constant(x.longValue & y.longValue)
-    case nme.LSL => Constant(x.longValue << y.longValue)
+    case nme.LSL if x.tag <= IntTag
+                 => Constant(x.intValue << y.longValue)
+    case nme.LSL => Constant(x.longValue <<  y.longValue)
+    case nme.LSR if x.tag <= IntTag
+                 => Constant(x.intValue >>> y.longValue)
     case nme.LSR => Constant(x.longValue >>> y.longValue)
+    case nme.ASR if x.tag <= IntTag
+                 => Constant(x.intValue >> y.longValue)
     case nme.ASR => Constant(x.longValue >> y.longValue)
     case nme.EQ  => Constant(x.longValue == y.longValue)
     case nme.NE  => Constant(x.longValue != y.longValue)
@@ -115,7 +121,7 @@ abstract class ConstantFolder {
     case nme.MUL => Constant(x.longValue * y.longValue)
     case nme.DIV => Constant(x.longValue / y.longValue)
     case nme.MOD => Constant(x.longValue % y.longValue)
-    case _ => null
+    case _       => null
   }
   private def foldFloatOp(op: Name, x: Constant, y: Constant): Constant = op match {
     case nme.EQ  => Constant(x.floatValue == y.floatValue)
@@ -129,7 +135,7 @@ abstract class ConstantFolder {
     case nme.MUL => Constant(x.floatValue * y.floatValue)
     case nme.DIV => Constant(x.floatValue / y.floatValue)
     case nme.MOD => Constant(x.floatValue % y.floatValue)
-    case _ => null
+    case _       => null
   }
   private def foldDoubleOp(op: Name, x: Constant, y: Constant): Constant = op match {
     case nme.EQ  => Constant(x.doubleValue == y.doubleValue)
@@ -143,7 +149,7 @@ abstract class ConstantFolder {
     case nme.MUL => Constant(x.doubleValue * y.doubleValue)
     case nme.DIV => Constant(x.doubleValue / y.doubleValue)
     case nme.MOD => Constant(x.doubleValue % y.doubleValue)
-    case _ => null
+    case _       => null
   }
 
   private def foldBinop(op: Name, x: Constant, y: Constant): Constant = {
@@ -162,7 +168,7 @@ abstract class ConstantFolder {
       case _                                        => null
     }
     catch {
-      case ex: ArithmeticException => null
+      case _: ArithmeticException => null
     }
   }
 }

--- a/test/files/pos/t8462.scala
+++ b/test/files/pos/t8462.scala
@@ -1,0 +1,11 @@
+
+trait ConstantOps {
+  def exprs = (
+    1   << 2L : Int,  // was: error: type mismatch; found   : Long(4L)
+    64  >> 2L : Int,  // was: error: type mismatch; found   : Long(4L)
+    64 >>> 2L : Int,  // was: error: type mismatch; found   : Long(4L)
+    'a' << 2L : Int,
+    'a' >> 2L : Int,
+    'a'>>> 2L : Int
+  )
+}


### PR DESCRIPTION
Constant folding was incorrectly promoting to Long when the
operand was Long, as with other binary ops, but the result
type depends on the receiver.

Per SLS 12.2.1.

This fixes ((1 << 2L): Int) and the other shift ops.
