### PR TITLE
SI-2991 No Java tupling

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -209,6 +209,8 @@ trait ScalaSettings extends AbsScalaSettings
   val YdisableUnreachablePrevention = BooleanSetting("-Ydisable-unreachable-prevention", "Disable the prevention of unreachable blocks in code generation.")
   val YnoLoadImplClass = BooleanSetting   ("-Yno-load-impl-class", "Do not load $class.class files.")
 
+  val YnoJavaTupling = BooleanSetting ("-Yno-java-tupling", "No autotupling of Java method applications.")
+
   val exposeEmptyPackage = BooleanSetting("-Yexpose-empty-package", "Internal only: expose the empty package.").internalOnly()
   // the current standard is "inline" but we are moving towards "method"
   val Ydelambdafy        = ChoiceSetting     ("-Ydelambdafy", "strategy", "Strategy used for translating lambdas into JVM code.", List("inline", "method"), "inline")

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -178,6 +178,17 @@ trait Infer extends Checkable {
     def context: Context
     import InferErrorGen._
 
+    // flag used to turn off tupling when alternatives of an overload include a Java-defined method
+    private[this] var tupleForApplicability = true
+    def withoutTuplingForApplicability[A](body: => A): A =
+      if (settings.YnoJavaTupling) {
+        val saved = tupleForApplicability
+        tupleForApplicability = false
+        try body finally tupleForApplicability = saved
+      } else {
+        body
+      }
+
     /* -- Error Messages --------------------------------------------------- */
     def setError[T <: Tree](tree: T): T = {
       // SI-7388, one can incur a cycle calling sym.toString
@@ -756,7 +767,7 @@ trait Infer extends Checkable {
       compareLengths(argtpes0, formals) match {
         case 0 if containsNamedType(argtpes0) => reorderedTypesCompatible      // right number of args, wrong order
         case 0                                => typesCompatible(argtpes0)     // fast track if no named arguments are used
-        case x if x > 0                       => tryWithArgs(argsTupled)       // too many args, try tupling
+        case x if x > 0                       => tupleForApplicability && tryWithArgs(argsTupled) // too many args, try tupling
         case _                                => tryWithArgs(argsPlusDefaults) // too few args, try adding defaults or tupling
       }
     }
@@ -1396,13 +1407,25 @@ trait Infer extends Checkable {
           case tp               => tp
         }
 
+        // if at least one retry is required, and the overload includes a Java-defined alternative
+        // proceed without tupling for applicability (if flag is enabled)
+        private[this] var retries = 0
+        private def atRetryDepth[A](cond: Boolean)(body: => A): A = {
+          val res =
+            if (cond && retries > 0) withoutTuplingForApplicability(body)
+            else body
+          retries += 1
+          res
+        }
+
         private def followType(sym: Symbol) = followApply(pre memberType sym)
         // separate method to help the inliner
         private def isAltApplicable(pt: Type)(alt: Symbol) = context inSilentMode { isApplicable(undetparams, followType(alt), argtpes, pt) && !context.reporter.hasErrors }
         private def rankAlternatives(sym1: Symbol, sym2: Symbol) = isStrictlyMoreSpecific(followType(sym1), followType(sym2), sym1, sym2)
         private def bestForExpectedType(pt: Type, isLastTry: Boolean): Unit = {
           val applicable  = overloadsToConsiderBySpecificity(alts filter isAltApplicable(pt), argtpes, varargsStar)
-          val ranked      = bestAlternatives(applicable)(rankAlternatives)
+          val infected    = applicable exists (_.isJavaDefined)
+          val ranked      = atRetryDepth(infected) { bestAlternatives(applicable)(rankAlternatives) }
           ranked match {
             case best :: competing :: _ => AmbiguousMethodAlternativeError(tree, pre, best, competing, argtpes, pt, isLastTry) // ambiguous
             case best :: Nil            => tree setSymbol best setType (pre memberType best)           // success

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3308,7 +3308,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
            * default arguments)
            */
           def tryTupleApply: Tree = {
-            if (eligibleForTupleConversion(paramTypes, argslen) && !phase.erasedTypes) {
+            if (!settings.YnoJavaTupling && eligibleForTupleConversion(paramTypes, argslen) && !phase.erasedTypes) {
               val tupleArgs = List(atPos(tree.pos.makeTransparent)(gen.mkTuple(args)))
               // expected one argument, but got 0 or >1 ==>  try applying to tuple
               // the inner "doTypedApply" does "extractUndetparams" => restore when it fails

--- a/test/files/neg/t2991.check
+++ b/test/files/neg/t2991.check
@@ -1,0 +1,4 @@
+scam_2.scala:3: error: too many arguments for method k: (x$1: Any)String
+  def f = new Jamb_1().k(42, true, false)
+                        ^
+one error found

--- a/test/files/neg/t2991.flags
+++ b/test/files/neg/t2991.flags
@@ -1,0 +1,1 @@
+-Yno-java-tupling

--- a/test/files/neg/t2991/Jamb_1.java
+++ b/test/files/neg/t2991/Jamb_1.java
@@ -1,0 +1,6 @@
+
+public class Jamb_1 {
+    // k(42, true, false) fails to compile without tupling
+    public String k(Object a) { return "foo"; }
+    public String k(int i, boolean b) { return "bar"; }
+}

--- a/test/files/neg/t2991/scam_2.scala
+++ b/test/files/neg/t2991/scam_2.scala
@@ -1,0 +1,4 @@
+
+trait Scam {
+  def f = new Jamb_1().k(42, true, false)
+}

--- a/test/files/pos/t2991.flags
+++ b/test/files/pos/t2991.flags
@@ -1,0 +1,1 @@
+-Yno-java-tupling

--- a/test/files/pos/t2991/Jamb_1.java
+++ b/test/files/pos/t2991/Jamb_1.java
@@ -1,0 +1,15 @@
+
+public class Jamb_1 {
+    // ambiguous to Scala, not to Java
+    public String f(Object a) { return "foo"; }
+    public String f(Object a, Object... as) { return "bar"; }
+
+    // ditto
+    public <T> T g(T t) { return t; }
+    public <T> T g(T t, T... ts) { return ts[0]; }
+
+    // even more ambiguous
+    public <T> T j(T t) { return t; }
+    public <T> T j(T t, T u ) { return u; }
+    public <T> T j(T t, T u, T... ts) { return ts[0]; }
+}

--- a/test/files/pos/t2991/scam_2.scala
+++ b/test/files/pos/t2991/scam_2.scala
@@ -1,0 +1,9 @@
+
+// was ambiguous to Scala
+trait Scam {
+  val j = new Jamb_1
+  val o = new Object
+  def f = j.f(o)        // yes, we can
+  def g = j.g(42)       // ditto
+  def k = j.j(42)       // threesome
+}


### PR DESCRIPTION
Don't auto-tuple arguments to a Java method.

No one writes a Java method that takes an Object
or type parameter intending the user to supply a
Scala tuple.

A compiler option `-Yno-java-tupling` ensures that
tupling does not make a Java method applicable for
any purpose.

Java will disambiguate `f(A)` and `f(A, A*)` even though
they are patently ambiguous to the Scala programmer where
A is effectively Object. Turning off Java tupling will
allow invoking the single-parameter method defined in Java.

Given `f(Object)` and `f(A, B)`, Java disallows `f(x, y, z)`.
With tupling disabled, Scala also rejects that application,
which is otherwise a source of programmer error.

The compiler option can be considered for standardization
in 2.12.
