### PR TITLE
SI-9089 Another REPL/FSC + specialization bug fix

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -894,7 +894,6 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
       }
 
       val specMember = subst(outerEnv)(specializedOverload(owner, sym, spec))
-      owner.info.decls.enter(specMember)
       typeEnv(specMember) = typeEnv(sym) ++ outerEnv ++ spec
       wasSpecializedForTypeVars(specMember) ++= spec collect { case (s, tp) if s.tpe == tp => s }
 

--- a/test/files/res/t9089.check
+++ b/test/files/res/t9089.check
@@ -1,0 +1,4 @@
+
+nsc> 
+nsc> 
+nsc> 

--- a/test/files/res/t9089.res
+++ b/test/files/res/t9089.res
@@ -1,0 +1,2 @@
+t9089/A.scala
+t9089/A.scala

--- a/test/files/res/t9089/A.scala
+++ b/test/files/res/t9089/A.scala
@@ -1,0 +1,1 @@
+object O { def f(x: => Int): Int = x }


### PR DESCRIPTION
The enclosed test case stopped working in 2.11.5 on the back of
https://github.com/scala/scala/pull/4040.

The key change was that we ran all post-typer info transformers
on each run of the compiler, rather than trying to reuse the results
of the previous run.

In that patch, I noticed [another place](https://github.com/scala/scala/pull/4040#commitcomment-8531516) in specialization that
aggressively entered specialized members into the owning scope,
rather than relying on `transformInfo` to place the new members
in the scope of the newly created element of the info history.
I made that change after noticing that this code could actually
mutated scopes of specializaed types at the parser phase, which
led to fairly obscure failures.

This bug is another one of these obscure failures, and has the
same root cause. We effectively "double specialiaze" Function0,
which trips an assertion when `method apply$mcI$sp` is found
twice in a scope.

I have found another spot that was directly manipulating the scope,
and removed the offending code.
