### PR TITLE
SI-9050 Fix crasher with value classes, recursion

### DIFF
--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -1576,6 +1576,7 @@ trait Trees extends api.Trees {
    */
   class TreeSymSubstituter(from: List[Symbol], to: List[Symbol]) extends Transformer {
     val symSubst = new SubstSymMap(from, to)
+    private var mutatedSymbols: List[Symbol] = Nil
     override def transform(tree: Tree): Tree = {
       def subst(from: List[Symbol], to: List[Symbol]) {
         if (!from.isEmpty)
@@ -1594,6 +1595,7 @@ trait Trees extends api.Trees {
                 |TreeSymSubstituter: updated info of symbol ${tree.symbol}
                 |  Old: ${showRaw(tree.symbol.info, printTypes = true, printIds = true)}
                 |  New: ${showRaw(newInfo, printTypes = true, printIds = true)}""")
+              mutatedSymbols ::= tree.symbol
               tree.symbol updateInfo newInfo
             }
           case _          =>
@@ -1613,7 +1615,23 @@ trait Trees extends api.Trees {
       } else
         super.transform(tree)
     }
-    def apply[T <: Tree](tree: T): T = transform(tree).asInstanceOf[T]
+    def apply[T <: Tree](tree: T): T = {
+      val tree1 = transform(tree)
+      invalidateSingleTypeCaches(tree1)
+      tree1.asInstanceOf[T]
+    }
+    private def invalidateSingleTypeCaches(tree: Tree): Unit = {
+      if (mutatedSymbols.nonEmpty)
+        for (t <- tree)
+          for (tp <- t.tpe) {
+            tp match {
+              case s: SingleType if mutatedSymbols contains s.sym =>
+                s.underlyingPeriod = NoPeriod
+                s.underlyingCache = NoType
+              case _ =>
+            }
+          }
+    }
     override def toString() = "TreeSymSubstituter/" + substituterString("Symbol", "Symbol", from, to)
   }
 

--- a/test/files/pos/t9050.scala
+++ b/test/files/pos/t9050.scala
@@ -1,0 +1,13 @@
+final class Mu[F](val value: Any) extends AnyVal {
+  def cata(f: F) {
+    // crash
+    ((y: Mu[F]) => y.cata(f))
+    // crash
+    def foo(x : Mu[F]) = x.cata(f)
+
+    // // okay
+    def x: Mu[F] = ???
+    (() => x.cata(f))
+    assert(true, cata(f))
+  }
+}


### PR DESCRIPTION
From the "Substitution is hard to do" department.

In 7babdab9a, TreeSymSubstitutor was modified to mutate the info
of symbols defined in the tree, if that symbol's info referred to
one of the `from` symbols in the substitution.

It would have been more principled to create a cloned symbol
with the updated info, and add that to the substitution. But I
wasn't able implement that correctly (let alone efficiently.)

The in-place mutation of the info of a symbol led to the crasher
in this bug: a singleton type over that symbol ends up with a stale
cached value of 'underlying'. In the enclosed test case, this leads
to a type error in the `SubstituteRecursion` of the extension
methods phase.

This commit performs a cleanup job at the end of `substituteSymbols`
by invalidating the cache of any `SingleType`-s in the tree that
refer to one of the mutated symbols.
