### PR TITLE
Refactoring. Optimizing dependency graph. `HasMember` and `memberWildcardType` 

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -254,25 +254,6 @@ trait Implicits {
     override def hashCode = 1
   }
 
-  /** A constructor for types ?{ def/type name: tp }, used in infer view to member
-   *  searches.
-   */
-  def memberWildcardType(name: Name, tp: Type) = {
-    val result = refinedType(List(WildcardType), NoSymbol)
-    name match {
-      case x: TermName => result.typeSymbol.newMethod(x) setInfoAndEnter tp
-      case x: TypeName => result.typeSymbol.newAbstractType(x) setInfoAndEnter tp
-    }
-    result
-  }
-
-  /** An extractor for types of the form ? { name: ? }
-   */
-  object HasMember {
-    private val hasMemberCache = perRunCaches.newMap[Name, Type]()
-    def apply(name: Name): Type = hasMemberCache.getOrElseUpdate(name, memberWildcardType(name, WildcardType))
-    }
-
   /** An extractor for types of the form ? { name: (? >: argtpe <: Any*)restp }
    */
   object HasMethodMatching {

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1244,6 +1244,13 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       )
     }
 
+   /** An extractor for types of the form ? { name: ? }
+     */
+    private object HasMember {
+      private val hasMemberCache = perRunCaches.newMap[Name, Type]()
+      def apply(name: Name): Type = hasMemberCache.getOrElseUpdate(name, memberWildcardType(name, WildcardType))
+    }
+    
     /** Try to apply an implicit conversion to `qual` so that it contains
      *  a method `name`. If that's ambiguous try taking arguments into
      *  account using `adaptToArguments`.

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3447,6 +3447,18 @@ trait Types
       result
     }
 
+  /** A constructor for types ?{ def/type name: tp }, used in infer view to member
+   *  searches.
+   */
+  def memberWildcardType(name: Name, tp: Type) = {
+    val result = refinedType(List(WildcardType), NoSymbol)
+    name match {
+      case x: TermName => result.typeSymbol.newMethod(x) setInfoAndEnter tp
+      case x: TypeName => result.typeSymbol.newAbstractType(x) setInfoAndEnter tp
+    }
+    result
+  }
+  
   /** The canonical creator for typerefs
    *  todo: see how we can clean this up a bit
    */


### PR DESCRIPTION
`HasMember` was only used by `Typers` yet it was located in `Implicits`. The method `memberWildcardType` seemed out of place at `Implicits`. While it's used by `Implicits` it is a utility method not specialized for `Implicits`.
- Moved object `HasMember` from `Implicits` to `Typers` (the only call site) and made it private.
- Moved method `memberWildcardType` to `Types` which contains similar methods and is available to both `Typer` and `Implicits`.
