### PR TITLE
SI-9093 Fix value discarding / multiple param list crasher

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1177,7 +1177,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     }
 
     def instantiatePossiblyExpectingUnit(tree: Tree, mode: Mode, pt: Type): Tree = {
-      if (mode.typingExprNotFun && pt.typeSymbol == UnitClass)
+      if (mode.typingExprNotFun && pt.typeSymbol == UnitClass && !tree.tpe.isInstanceOf[MethodType])
         instantiateExpectingUnit(tree, mode)
       else
         instantiate(tree, mode, pt)

--- a/test/files/neg/t9093.check
+++ b/test/files/neg/t9093.check
@@ -1,0 +1,6 @@
+t9093.scala:3: error: polymorphic expression cannot be instantiated to expected type;
+ found   : [C](f: C)Null
+ required: Unit
+  val x: Unit = apply2(0)/*(0)*/
+                      ^
+one error found

--- a/test/files/neg/t9093.scala
+++ b/test/files/neg/t9093.scala
@@ -1,0 +1,5 @@
+object Main {
+  def apply2[C](fa: Any)(f: C) = null
+  val x: Unit = apply2(0)/*(0)*/  
+}
+


### PR DESCRIPTION
The type error stemming from missing argument list was being
swallowed when the expected type was `Unit` and there were
undetermined type parameters in the expression.

This commit modifies `adapt` to avoid using
`instantiateExpectingUnit` when the tree is typed with `MethodType`.
