### PR TITLE
SI-9110 Pattern `O.C` must check `$outer eq O` for a top level O

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3940,7 +3940,8 @@ trait Types
     def maybeCreateDummyClone(pre: Type, sym: Symbol): Type = pre match {
       case SingleType(pre1, sym1) =>
         if (sym1.isModule && sym1.isStatic) {
-          NoType
+          if (sym.owner == sym1 || sym.isJavaDefined || sym.owner.sourceModule.isStaticModule) NoType
+          else pre
         } else if (sym1.isModule && sym.owner == sym1.moduleClass) {
           val pre2 = maybeCreateDummyClone(pre1, sym1)
           if (pre2 eq NoType) pre2

--- a/test/files/run/t9110.scala
+++ b/test/files/run/t9110.scala
@@ -1,0 +1,27 @@
+trait Event
+
+trait Domain {
+  case class Created(name: String) extends Event
+}
+
+// declare three instances of Domain trait, one here and two
+// in an inner scope
+
+object DomainC extends Domain
+
+object Test {
+ def main(args: Array[String]) {
+   object DomainA extends Domain
+   object DomainB extends Domain
+
+   def lookingForAs(event: Event): Unit = {
+      event match {
+        case DomainB.Created(_) => throw null
+        case DomainC.Created(_) => throw null
+        case DomainA.Created(_) => // okay
+      }
+   }
+
+   lookingForAs(DomainA.Created("I am an A"))
+  }
+}


### PR DESCRIPTION
The outer check was not being generated when the prefix was a
top level module. The enclosed test shows that we in fact must
synthesize the outer check in that case.

Perhaps the bug was introduced by neglecting to consider that
a module can inherit member classes.

Review by @adriaanm. Targetting to 2.12.x to be conservative,
but let's discuss the best way to bring in this fix.
