### PR TITLE
SI-9113: WrapAsScala can create exception-prone Wrappers

### DIFF
--- a/src/library/scala/collection/convert/WrapAsJava.scala
+++ b/src/library/scala/collection/convert/WrapAsJava.scala
@@ -30,8 +30,9 @@ trait WrapAsJava {
    * @return    A Java Iterator view of the argument.
    */
   implicit def asJavaIterator[A](it: Iterator[A]): ju.Iterator[A] = it match {
-    case JIteratorWrapper(wrapped) => wrapped.asInstanceOf[ju.Iterator[A]]
-    case _ => IteratorWrapper(it)
+    case null                       => null
+    case JIteratorWrapper(wrapped)  => wrapped.asInstanceOf[ju.Iterator[A]]
+    case _                          => IteratorWrapper(it)
   }
 
   /**
@@ -48,8 +49,9 @@ trait WrapAsJava {
    * @return   A Java Enumeration view of the argument.
    */
   implicit def asJavaEnumeration[A](it: Iterator[A]): ju.Enumeration[A] = it match {
+    case null                         => null
     case JEnumerationWrapper(wrapped) => wrapped.asInstanceOf[ju.Enumeration[A]]
-    case _ => IteratorWrapper(it)
+    case _                            => IteratorWrapper(it)
   }
 
   /**
@@ -66,8 +68,9 @@ trait WrapAsJava {
    * @return A Java Iterable view of the argument.
    */
   implicit def asJavaIterable[A](i: Iterable[A]): jl.Iterable[A] = i match {
-    case JIterableWrapper(wrapped) => wrapped.asInstanceOf[jl.Iterable[A]]
-    case _ => IterableWrapper(i)
+    case null                       => null
+    case JIterableWrapper(wrapped)  => wrapped.asInstanceOf[jl.Iterable[A]]
+    case _                          => IterableWrapper(i)
   }
 
   /**
@@ -82,8 +85,9 @@ trait WrapAsJava {
    * @return   A Java Collection view of the argument.
    */
   implicit def asJavaCollection[A](it: Iterable[A]): ju.Collection[A] = it match {
-    case JCollectionWrapper(wrapped) => wrapped.asInstanceOf[ju.Collection[A]]
-    case _ => new IterableWrapper(it)
+    case null                         => null
+    case JCollectionWrapper(wrapped)  => wrapped.asInstanceOf[ju.Collection[A]]
+    case _                            => new IterableWrapper(it)
   }
 
   /**
@@ -100,8 +104,9 @@ trait WrapAsJava {
    * @return A Java List view of the argument.
    */
   implicit def bufferAsJavaList[A](b: mutable.Buffer[A]): ju.List[A] = b match {
-    case JListWrapper(wrapped) => wrapped
-    case _ => new MutableBufferWrapper(b)
+    case null                   => null
+    case JListWrapper(wrapped)  => wrapped
+    case _                      => new MutableBufferWrapper(b)
   }
 
   /**
@@ -118,8 +123,9 @@ trait WrapAsJava {
    * @return    A Java List view of the argument.
    */
   implicit def mutableSeqAsJavaList[A](seq: mutable.Seq[A]): ju.List[A] = seq match {
-    case JListWrapper(wrapped) => wrapped
-    case _ => new MutableSeqWrapper(seq)
+    case null                   => null
+    case JListWrapper(wrapped)  => wrapped
+    case _                      => new MutableSeqWrapper(seq)
   }
 
   /**
@@ -136,8 +142,9 @@ trait WrapAsJava {
    * @return    A Java List view of the argument.
    */
   implicit def seqAsJavaList[A](seq: Seq[A]): ju.List[A] = seq match {
-    case JListWrapper(wrapped) => wrapped.asInstanceOf[ju.List[A]]
-    case _ => new SeqWrapper(seq)
+    case null                   => null
+    case JListWrapper(wrapped)  => wrapped.asInstanceOf[ju.List[A]]
+    case _                      => new SeqWrapper(seq)
   }
 
   /**
@@ -154,8 +161,9 @@ trait WrapAsJava {
    * @return A Java Set view of the argument.
    */
   implicit def mutableSetAsJavaSet[A](s: mutable.Set[A]): ju.Set[A] = s match {
+    case null                 => null
     case JSetWrapper(wrapped) => wrapped
-    case _ => new MutableSetWrapper(s)
+    case _                    => new MutableSetWrapper(s)
   }
 
   /**
@@ -172,8 +180,9 @@ trait WrapAsJava {
    * @return A Java Set view of the argument.
    */
   implicit def setAsJavaSet[A](s: Set[A]): ju.Set[A] = s match {
+    case null                 => null
     case JSetWrapper(wrapped) => wrapped
-    case _ => new SetWrapper(s)
+    case _                    => new SetWrapper(s)
   }
 
   /**
@@ -190,9 +199,9 @@ trait WrapAsJava {
    * @return A Java Map view of the argument.
    */
   implicit def mutableMapAsJavaMap[A, B](m: mutable.Map[A, B]): ju.Map[A, B] = m match {
-    //case JConcurrentMapWrapper(wrapped) => wrapped
+    case null                 => null
     case JMapWrapper(wrapped) => wrapped
-    case _ => new MutableMapWrapper(m)
+    case _                    => new MutableMapWrapper(m)
   }
 
   /**
@@ -210,9 +219,9 @@ trait WrapAsJava {
    * @return A Java `Dictionary` view of the argument.
    */
   implicit def asJavaDictionary[A, B](m: mutable.Map[A, B]): ju.Dictionary[A, B] = m match {
-    //case JConcurrentMapWrapper(wrapped) => wrapped
-    case JDictionaryWrapper(wrapped) => wrapped
-    case _ => new DictionaryWrapper(m)
+    case null                         => null
+    case JDictionaryWrapper(wrapped)  => wrapped
+    case _                            => new DictionaryWrapper(m)
   }
 
   /**
@@ -230,9 +239,9 @@ trait WrapAsJava {
    * @return A Java `Map` view of the argument.
    */
   implicit def mapAsJavaMap[A, B](m: Map[A, B]): ju.Map[A, B] = m match {
-    //case JConcurrentMapWrapper(wrapped) => wrapped
+    case null                 => null
     case JMapWrapper(wrapped) => wrapped.asInstanceOf[ju.Map[A, B]]
-    case _ => new MapWrapper(m)
+    case _                    => new MapWrapper(m)
   }
 
   /**
@@ -251,8 +260,9 @@ trait WrapAsJava {
    * @return A Java `ConcurrentMap` view of the argument.
    */
   implicit def mapAsJavaConcurrentMap[A, B](m: concurrent.Map[A, B]): juc.ConcurrentMap[A, B] = m match {
+    case null                           => null
     case JConcurrentMapWrapper(wrapped) => wrapped
-    case _ => new ConcurrentMapWrapper(m)
+    case _                              => new ConcurrentMapWrapper(m)
   }
 }
 

--- a/src/library/scala/collection/convert/WrapAsScala.scala
+++ b/src/library/scala/collection/convert/WrapAsScala.scala
@@ -30,8 +30,9 @@ trait WrapAsScala {
    * @return   A Scala `Iterator` view of the argument.
    */
   implicit def asScalaIterator[A](it: ju.Iterator[A]): Iterator[A] = it match {
+    case null                     => null
     case IteratorWrapper(wrapped) => wrapped
-    case _ => JIteratorWrapper(it)
+    case _                        => JIteratorWrapper(it)
   }
 
   /**
@@ -48,8 +49,9 @@ trait WrapAsScala {
    * @return A Scala Iterator view of the argument.
    */
   implicit def enumerationAsScalaIterator[A](i: ju.Enumeration[A]): Iterator[A] = i match {
+    case null                     => null
     case IteratorWrapper(wrapped) => wrapped
-    case _ => JEnumerationWrapper(i)
+    case _                        => JEnumerationWrapper(i)
   }
 
   /**
@@ -67,8 +69,9 @@ trait WrapAsScala {
    * @return A Scala Iterable view of the argument.
    */
   implicit def iterableAsScalaIterable[A](i: jl.Iterable[A]): Iterable[A] = i match {
+    case null                     => null
     case IterableWrapper(wrapped) => wrapped
-    case _ => JIterableWrapper(i)
+    case _                        => JIterableWrapper(i)
   }
 
   /**
@@ -82,8 +85,9 @@ trait WrapAsScala {
    * @return A Scala Iterable view of the argument.
    */
   implicit def collectionAsScalaIterable[A](i: ju.Collection[A]): Iterable[A] = i match {
+    case null                     => null
     case IterableWrapper(wrapped) => wrapped
-    case _ => JCollectionWrapper(i)
+    case _                        => JCollectionWrapper(i)
   }
 
   /**
@@ -101,8 +105,9 @@ trait WrapAsScala {
    * @return A Scala mutable `Buffer` view of the argument.
    */
   implicit def asScalaBuffer[A](l: ju.List[A]): mutable.Buffer[A] = l match {
-    case MutableBufferWrapper(wrapped) => wrapped
-    case _ =>new JListWrapper(l)
+    case null                           => null
+    case MutableBufferWrapper(wrapped)  => wrapped
+    case _                              => new JListWrapper(l)
   }
 
   /**
@@ -119,8 +124,9 @@ trait WrapAsScala {
    * @return A Scala mutable Set view of the argument.
    */
   implicit def asScalaSet[A](s: ju.Set[A]): mutable.Set[A] = s match {
+    case null                       => null
     case MutableSetWrapper(wrapped) => wrapped
-    case _ =>new JSetWrapper(s)
+    case _                          => new JSetWrapper(s)
   }
 
   /**
@@ -144,9 +150,9 @@ trait WrapAsScala {
    * @return A Scala mutable Map view of the argument.
    */
   implicit def mapAsScalaMap[A, B](m: ju.Map[A, B]): mutable.Map[A, B] = m match {
-    //case ConcurrentMapWrapper(wrapped) => wrapped
+    case null                       => null
     case MutableMapWrapper(wrapped) => wrapped
-    case _ => new JMapWrapper(m)
+    case _                          => new JMapWrapper(m)
   }
 
   /**
@@ -163,8 +169,9 @@ trait WrapAsScala {
    * @return A Scala mutable ConcurrentMap view of the argument.
    */
   implicit def mapAsScalaConcurrentMap[A, B](m: juc.ConcurrentMap[A, B]): concurrent.Map[A, B] = m match {
-    case cmw: ConcurrentMapWrapper[a, b]      => cmw.underlying
-    case _                                    => new JConcurrentMapWrapper(m)
+    case null                             => null
+    case cmw: ConcurrentMapWrapper[A, B]  => cmw.underlying
+    case _                                => new JConcurrentMapWrapper(m)
   }
 
   /**
@@ -179,8 +186,9 @@ trait WrapAsScala {
    * @return  A Scala mutable Map[String, String] view of the argument.
    */
   implicit def dictionaryAsScalaMap[A, B](p: ju.Dictionary[A, B]): mutable.Map[A, B] = p match {
+    case null                       => null
     case DictionaryWrapper(wrapped) => wrapped
-    case _ => new JDictionaryWrapper(p)
+    case _                          => new JDictionaryWrapper(p)
   }
 
   /**
@@ -194,7 +202,8 @@ trait WrapAsScala {
    * @return  A Scala mutable Map[String, String] view of the argument.
    */
   implicit def propertiesAsScalaMap(p: ju.Properties): mutable.Map[String, String] = p match {
-    case _ => new JPropertiesWrapper(p)
+    case null => null
+    case _    => new JPropertiesWrapper(p)
   }
 }
 

--- a/test/junit/scala/collection/convert/NullSafetyTest.scala
+++ b/test/junit/scala/collection/convert/NullSafetyTest.scala
@@ -1,0 +1,279 @@
+package scala.collection.convert
+
+import java.{util => ju, lang => jl}
+import ju.{concurrent => juc}
+
+import org.junit.Test
+import org.junit.experimental.runners.Enclosed
+import org.junit.runner.RunWith
+
+import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
+import scala.collection.{mutable, concurrent}
+
+@RunWith(classOf[Enclosed])
+object NullSafetyTest {
+
+    /*
+     * Pertinent: SI-9113
+     * Tests to insure that wrappers return null instead of wrapping it as a collection
+     */
+
+    class ToScala {
+
+        @Test def testIteratorWrapping(): Unit = {
+            val nullJIterator: ju.Iterator[AnyRef] = null
+            val iterator: Iterator[AnyRef] = nullJIterator
+
+            assert(iterator == null)
+        }
+
+        @Test def testEnumerationWrapping(): Unit = {
+            val nullJEnumeration: ju.Enumeration[AnyRef] = null
+            val enumeration: Iterator[AnyRef] = nullJEnumeration
+
+            assert(enumeration == null)
+        }
+
+        @Test def testIterableWrapping(): Unit = {
+            val nullJIterable: jl.Iterable[AnyRef] = null
+            val iterable: Iterable[AnyRef] = nullJIterable
+
+            assert(iterable == null)
+        }
+
+        @Test def testCollectionWrapping(): Unit = {
+            val nullJCollection: ju.Collection[AnyRef] = null
+            val collection: Iterable[AnyRef] = nullJCollection
+
+            assert(collection == null)
+        }
+
+        @Test def testBufferWrapping(): Unit = {
+            val nullJList: ju.List[AnyRef] = null
+            val buffer: mutable.Buffer[AnyRef] = nullJList
+
+            assert(buffer == null)
+        }
+
+        @Test def testSetWrapping(): Unit = {
+            val nullJSet: ju.Set[AnyRef] = null
+            val set: mutable.Set[AnyRef] = nullJSet
+
+            assert(set == null)
+        }
+
+        @Test def testMapWrapping(): Unit = {
+            val nullJMap: ju.Map[AnyRef, AnyRef] = null
+            val map: mutable.Map[AnyRef, AnyRef] = nullJMap
+
+            assert(map == null)
+        }
+
+        @Test def testConcurrentMapWrapping(): Unit = {
+            val nullJConMap: juc.ConcurrentMap[AnyRef, AnyRef] = null
+            val conMap: concurrent.Map[AnyRef, AnyRef] = nullJConMap
+
+            assert(conMap == null)
+        }
+
+        @Test def testDictionaryWrapping(): Unit = {
+            val nullJDict: ju.Dictionary[AnyRef, AnyRef] = null
+            val dict: mutable.Map[AnyRef, AnyRef] = nullJDict
+
+            assert(dict == null)
+        }
+
+
+        @Test def testPropertyWrapping(): Unit = {
+            val nullJProps: ju.Properties = null
+            val props: mutable.Map[String, String] = nullJProps
+
+            assert(props == null)
+        }
+
+        @Test def testIteratorDecoration(): Unit = {
+            val nullJIterator: ju.Iterator[AnyRef] = null
+
+            assert(nullJIterator.asScala == null)
+        }
+
+        @Test def testEnumerationDecoration(): Unit = {
+            val nullJEnumeration: ju.Enumeration[AnyRef] = null
+
+            assert(nullJEnumeration.asScala == null)
+        }
+
+        @Test def testIterableDecoration(): Unit = {
+            val nullJIterable: jl.Iterable[AnyRef] = null
+
+            assert(nullJIterable.asScala == null)
+        }
+
+        @Test def testCollectionDecoration(): Unit = {
+            val nullJCollection: ju.Collection[AnyRef] = null
+
+            assert(nullJCollection.asScala == null)
+        }
+
+        @Test def testBufferDecoration(): Unit = {
+            val nullJBuffer: ju.List[AnyRef] = null
+
+            assert(nullJBuffer.asScala == null)
+        }
+
+        @Test def testSetDecoration(): Unit = {
+            val nullJSet: ju.Set[AnyRef] = null
+
+            assert(nullJSet.asScala == null)
+        }
+
+        @Test def testMapDecoration(): Unit = {
+            val nullJMap: ju.Map[AnyRef, AnyRef] = null
+
+            assert(nullJMap.asScala == null)
+        }
+
+        @Test def testConcurrentMapDecoration(): Unit = {
+            val nullJConMap: juc.ConcurrentMap[AnyRef, AnyRef] = null
+
+            assert(nullJConMap.asScala == null)
+        }
+
+        @Test def testDictionaryDecoration(): Unit = {
+            val nullJDict: ju.Dictionary[AnyRef, AnyRef] = null
+
+            assert(nullJDict.asScala == null)
+        }
+
+        @Test def testPropertiesDecoration(): Unit = {
+            val nullJProperties: ju.Properties = null
+
+            assert(nullJProperties.asScala == null)
+        }
+    }
+
+    class ToJava {
+
+        @Test def testIteratorWrapping(): Unit = {
+            val nullIterator: Iterator[AnyRef] = null
+            val jIterator: ju.Iterator[AnyRef] = nullIterator
+
+            assert(jIterator == null)
+        }
+
+        @Test def testEnumerationWrapping(): Unit = {
+            val nullEnumeration: Iterator[AnyRef] = null
+            val enumeration: ju.Iterator[AnyRef] = nullEnumeration
+
+            assert(enumeration == null)
+        }
+
+        @Test def testIterableWrapping(): Unit = {
+            val nullIterable: Iterable[AnyRef] = null
+            val iterable: jl.Iterable[AnyRef] = asJavaIterable(nullIterable)
+
+            assert(iterable == null)
+        }
+
+        @Test def testCollectionWrapping(): Unit = {
+            val nullCollection: Iterable[AnyRef] = null
+            val collection: ju.Collection[AnyRef] = nullCollection
+
+            assert(collection == null)
+        }
+
+        @Test def testBufferWrapping(): Unit = {
+            val nullList: mutable.Buffer[AnyRef] = null
+            val buffer: ju.List[AnyRef] = nullList
+
+            assert(buffer == null)
+        }
+
+        @Test def testSetWrapping(): Unit = {
+            val nullSet: mutable.Set[AnyRef] = null
+            val set: ju.Set[AnyRef] = nullSet
+
+            assert(set == null)
+        }
+
+        @Test def testMapWrapping(): Unit = {
+            val nullMap: mutable.Map[AnyRef, AnyRef] = null
+            val map: ju.Map[AnyRef, AnyRef] = nullMap
+
+            assert(map == null)
+        }
+
+        @Test def testConcurrentMapWrapping(): Unit = {
+            val nullConMap: concurrent.Map[AnyRef, AnyRef] = null
+            val conMap: juc.ConcurrentMap[AnyRef, AnyRef] = nullConMap
+
+            assert(conMap == null)
+        }
+
+        @Test def testDictionaryWrapping(): Unit = {
+            val nullDict: mutable.Map[AnyRef, AnyRef] = null
+            val dict: ju.Dictionary[AnyRef, AnyRef] = nullDict
+
+            assert(dict == null)
+        }
+
+        // Implicit conversion to ju.Properties is not available
+
+        @Test def testIteratorDecoration(): Unit = {
+            val nullIterator: Iterator[AnyRef] = null
+
+            assert(nullIterator.asJava == null)
+        }
+
+        @Test def testEnumerationDecoration(): Unit = {
+            val nullEnumeration: Iterator[AnyRef] = null
+
+            assert(nullEnumeration.asJavaEnumeration == null)
+        }
+
+        @Test def testIterableDecoration(): Unit = {
+            val nullIterable: Iterable[AnyRef] = null
+
+            assert(nullIterable.asJava == null)
+        }
+
+        @Test def testCollectionDecoration(): Unit = {
+            val nullCollection: Iterable[AnyRef] = null
+
+            assert(nullCollection.asJavaCollection == null)
+        }
+
+        @Test def testBufferDecoration(): Unit = {
+            val nullBuffer: mutable.Buffer[AnyRef] = null
+
+            assert(nullBuffer.asJava == null)
+        }
+
+        @Test def testSetDecoration(): Unit = {
+            val nullSet: Set[AnyRef] = null
+
+            assert(nullSet.asJava == null)
+        }
+
+        @Test def testMapDecoration(): Unit = {
+            val nullMap: mutable.Map[AnyRef, AnyRef] = null
+
+            assert(nullMap.asJava == null)
+        }
+
+        @Test def testConcurrentMapDecoration(): Unit = {
+            val nullConMap: concurrent.Map[AnyRef, AnyRef] = null
+
+            assert(nullConMap.asJava == null)
+        }
+
+        @Test def testDictionaryDecoration(): Unit = {
+            val nullDict: mutable.Map[AnyRef, AnyRef] = null
+
+            assert(nullDict.asJavaDictionary == null)
+        }
+
+        // Decorator conversion to ju.Properties is not available
+    }
+}


### PR DESCRIPTION
Review by @axel22 @phaller .

Fixes issue SI-9113 by checking for and returning null values instead of passing them to a wrapper as an underlying collection, which can in turn lead to unexpected behaviour.

This is a follow-up to #4266, in which I neglected to squash commits.
