### PR TITLE
SI-9086 More coherent trees with patmat, dependent types

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
@@ -239,6 +239,11 @@ trait Interface extends ast.TreeDSL {
               case Ident(_) => subst(from, to)
               case _        => super.transform(tree)
             }
+            tree1 match {
+              case _: DefTree =>
+                tree1.symbol.modifyInfo(_.substituteTypes(from, toTypes))
+              case _ =>
+            }
             tree1.modifyType(_.substituteTypes(from, toTypes))
           }
         }

--- a/test/files/pos/t9086.flags
+++ b/test/files/pos/t9086.flags
@@ -1,0 +1,1 @@
+-optimize -Ydelambdafy:method

--- a/test/files/pos/t9086.scala
+++ b/test/files/pos/t9086.scala
@@ -1,0 +1,10 @@
+trait Setting {
+  type T
+  def value: T
+}
+
+object Test {
+  def test(x: Some[Setting]) = x match {
+    case Some(dep) => Some(dep.value) map (_ => true)
+  }
+}


### PR DESCRIPTION
The pattern matcher needs to substitute references to bound
variables with references to either a) synthetic temporary vals,
or to b) selections. The latter occurs under -optimize to avoid
to be frugal with local variable slots.

For instance:

```
def test(s: Some[String]) = s match {
  case Some(elem) => elem.length
}
```

Is translated to:

```
def test(s: Some[String]): Int = {
  case <synthetic> val x1: Some[String] = s;
  case4(){
    if (x1.ne(null))
      matchEnd3(x1.x.length())
    else
      case5()
  };
  case5(){
    matchEnd3(throw new MatchError(x1))
  };
  matchEnd3(x: Int){
    x
  }
}
```

However, for a long time this translation failed to consider
references to the binder in types. #4122 tried to address this
by either using standard substitution facilities where available
(references to temp vals), and by expanding the patmat's
home grown substitution to handle the more complex case of
referencing a selection.

However, this left the tree in an incoherent state; while it
patched up the `.tpe` field of `Tree`s, it failed to modify the
info of `Symbol`-s.

This led to a crash in the later uncurry phase under
`-Ydelambdafy:method`.

This commit modifies the info of such symbols to get rid of stray
refeferences to the pattern binder symbols.
