### PR TITLE
[SI-8990] Test and potential fix (please review)

### DIFF
--- a/test/junit/scala/collection/immutable/StreamTest.scala
+++ b/test/junit/scala/collection/immutable/StreamTest.scala
@@ -1,0 +1,38 @@
+package scala.collection.immutable
+
+import org.junit.{Ignore, Test}
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.ref.WeakReference
+import scala.util.Try
+
+@RunWith(classOf[JUnit4])
+/* Tests for collection.immutable.Stream  */
+class StreamTest {
+  val ref = WeakReference( Stream.continually(42).take(100) )
+
+  def gcAndThrowIfCollected(d: Any): Unit = {
+    System.gc()
+    Thread.sleep(100)
+    if (ref.get.isEmpty) throw new RuntimeException("GC succeeded")
+  }
+
+  @Test
+  def foreachAllowsGC() {
+    // NOTE: Uncomment to demonstrate that StreamWithFilter closes over head of stream,
+    //   preventing garbage collection below.
+    //val wf = ref().withFilter(_ => true)
+    Try { ref().foreach(gcAndThrowIfCollected) }
+    assert( ref.get.isEmpty )
+  }
+
+  /** SI-8990: Fix lazy evaluation of StreamWithFilter#foreach */
+  @Ignore("Pending a fix for SI-8990")
+  @Test
+  def withFilterForeachAllowsGC() {
+    Try { ref().withFilter(_ => true).foreach(gcAndThrowIfCollected) }
+    assert( ref.get.isEmpty )
+  }
+
+}

--- a/test/junit/scala/collection/immutable/StreamTest.scala
+++ b/test/junit/scala/collection/immutable/StreamTest.scala
@@ -20,15 +20,11 @@ class StreamTest {
 
   @Test
   def foreachAllowsGC() {
-    // NOTE: Uncomment to demonstrate that StreamWithFilter closes over head of stream,
-    //   preventing garbage collection below.
-    //val wf = ref().withFilter(_ => true)
     Try { ref().foreach(gcAndThrowIfCollected) }
     assert( ref.get.isEmpty )
   }
 
-  /** SI-8990: Fix lazy evaluation of StreamWithFilter#foreach */
-  @Ignore("Pending a fix for SI-8990")
+  /** SI-8990: Fix StreamWithFilter#foreach to allow GC of head as tail is processed */
   @Test
   def withFilterForeachAllowsGC() {
     Try { ref().withFilter(_ => true).foreach(gcAndThrowIfCollected) }


### PR DESCRIPTION
Hi Scala folks! I'm looking for advice on how to proceed here. 

I've added a junit file StreamTest with two tests:
1. Passes unless you uncomment line 25
2. Fails due to SI-8990

Uncomment StreamTest.scala line 25 to demonstrate
that simply having a StreamWithFilter present is
enough to prevent the garbage collection of a
Stream as it is processed.

To fix the pending test of SI-8990, it will be
necessary to find a solution to that, since the issue
is with using withFilter.

As mentioned on scala-internals, the heritage of 
Stream#StreamWithFilter to TraversableLike#WithFilter
means that there is a fairly baked-in assumption of
closing over a reference to the original instance, and
this is the cause of the inability to GC the stream as
it is processed.

Any suggestions?
