### PR TITLE
SI-9095 Memory leak in LinkedHasMap and LinkedHashSet

### DIFF
--- a/src/library/scala/collection/mutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/mutable/LinkedHashMap.scala
@@ -160,6 +160,7 @@ class LinkedHashMap[A, B] extends AbstractMap[A, B]
   override def clear() {
     clearTable()
     firstEntry = null
+    lastEntry = null
   }
 
   private def writeObject(out: java.io.ObjectOutputStream) {

--- a/src/library/scala/collection/mutable/LinkedHashSet.scala
+++ b/src/library/scala/collection/mutable/LinkedHashSet.scala
@@ -112,6 +112,7 @@ class LinkedHashSet[A] extends AbstractSet[A]
   override def clear() {
     clearTable()
     firstEntry = null
+    lastEntry = null
   }
 
   private def writeObject(out: java.io.ObjectOutputStream) {

--- a/test/junit/scala/collection/mutable/LinkedHashMapTest.scala
+++ b/test/junit/scala/collection/mutable/LinkedHashMapTest.scala
@@ -1,0 +1,25 @@
+package scala.collection.mutable
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.{ Assert, Test }
+
+import scala.collection.mutable
+
+/* Test for SI-9095 */
+@RunWith(classOf[JUnit4])
+class LinkedHashMapTest {
+  class TestClass extends mutable.LinkedHashMap[String, Int] {
+    def lastItemRef = lastEntry
+  }
+  
+  @Test
+  def testClear: Unit = {
+    val lhm = new TestClass
+    Seq("a" -> 8, "b" -> 9).foreach(kv => lhm.put(kv._1, kv._2))
+    
+    Assert.assertNotNull(lhm.lastItemRef)
+    lhm.clear()
+    Assert.assertNull(lhm.lastItemRef)
+  }
+}

--- a/test/junit/scala/collection/mutable/LinkedHashSetTest.scala
+++ b/test/junit/scala/collection/mutable/LinkedHashSetTest.scala
@@ -1,0 +1,25 @@
+package scala.collection.mutable
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.{ Assert, Test }
+
+import scala.collection.mutable
+
+/* Test for SI-9095 */
+@RunWith(classOf[JUnit4])
+class LinkedHashSetTest {
+  class TestClass extends mutable.LinkedHashSet[String] {
+    def lastItemRef = lastEntry
+  }
+  
+  @Test
+  def testClear: Unit = {
+    val lhs = new TestClass
+    Seq("a", "b").foreach(k => lhs.add(k))
+    
+    Assert.assertNotNull(lhs.lastItemRef)
+    lhs.clear()
+    Assert.assertNull(lhs.lastItemRef)
+  }
+}


### PR DESCRIPTION
The clear() method in scala.collection.mutable.LinkedHashSet and
scala.collection.mutable.LinkedHashMap does not set lastEntry to null.

In result it holds a reference to an object that was removed from the
collection.
