### PR TITLE
[SI-8990] Attempt fix with same types for 2.11 binary compatibility

### DIFF
--- a/src/library/scala/collection/immutable/Stream.scala
+++ b/src/library/scala/collection/immutable/Stream.scala
@@ -527,6 +527,8 @@ self =>
   /** A lazier implementation of WithFilter than TraversableLike's.
    */
   final class StreamWithFilter(p: A => Boolean) extends WithFilter(p) {
+    private[this] var original = self
+    private[this] def refOnce() = { val s = original; original = null; s }
 
     override def map[B, That](f: A => B)(implicit bf: CanBuildFrom[Stream[A], B, That]): That = {
       def tailMap(coll: Stream[A]): Stream[B] = {
@@ -566,9 +568,7 @@ self =>
       else super.flatMap(f)(bf)
     }
 
-    override def foreach[B](f: A => B) =
-      for (x <- self)
-        if (p(x)) f(x)
+    override def foreach[B](f: A => B) = refOnce().filter(p).foreach(f)
 
     override def withFilter(q: A => Boolean): StreamWithFilter =
       new StreamWithFilter(x => p(x) && q(x))

--- a/test/junit/scala/collection/immutable/StreamTest.scala
+++ b/test/junit/scala/collection/immutable/StreamTest.scala
@@ -1,0 +1,38 @@
+package scala.collection.immutable
+
+import org.junit.{Ignore, Test}
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.ref.WeakReference
+import scala.util.Try
+
+@RunWith(classOf[JUnit4])
+/* Tests for collection.immutable.Stream  */
+class StreamTest {
+  val ref = WeakReference( Stream.continually(42).take(100) )
+
+  def gcAndThrowIfCollected(d: Any): Unit = {
+    System.gc()
+    Thread.sleep(100)
+    if (ref.get.isEmpty) throw new RuntimeException("GC succeeded")
+  }
+
+  @Test
+  def foreachAllowsGC() {
+    // NOTE: Uncomment to demonstrate that StreamWithFilter closes over head of stream,
+    //   preventing garbage collection below.
+    //val wf = ref().withFilter(_ => true)
+    Try { ref().foreach(gcAndThrowIfCollected) }
+    assert( ref.get.isEmpty )
+  }
+
+  /** SI-8990: Fix lazy evaluation of StreamWithFilter#foreach */
+  @Ignore("Pending a fix for SI-8990")
+  @Test
+  def withFilterForeachAllowsGC() {
+    Try { ref().withFilter(_ => true).foreach(gcAndThrowIfCollected) }
+    assert( ref.get.isEmpty )
+  }
+
+}

--- a/test/junit/scala/collection/immutable/StreamTest.scala
+++ b/test/junit/scala/collection/immutable/StreamTest.scala
@@ -20,15 +20,11 @@ class StreamTest {
 
   @Test
   def foreachAllowsGC() {
-    // NOTE: Uncomment to demonstrate that StreamWithFilter closes over head of stream,
-    //   preventing garbage collection below.
-    //val wf = ref().withFilter(_ => true)
     Try { ref().foreach(gcAndThrowIfCollected) }
     assert( ref.get.isEmpty )
   }
 
-  /** SI-8990: Fix lazy evaluation of StreamWithFilter#foreach */
-  @Ignore("Pending a fix for SI-8990")
+  /** SI-8990: Fix StreamWithFilter#foreach to allow GC of head as tail is processed */
   @Test
   def withFilterForeachAllowsGC() {
     Try { ref().withFilter(_ => true).foreach(gcAndThrowIfCollected) }


### PR DESCRIPTION
This PR is to try to get a fix that is 2.11.x binary compatible, which I now understand is defined to mean that the return type of the method cannot change. However, as I mention on the google group, I fear this may be impossible.

@Ichoran please see commits below for (what I think is) evidence that simply using and nulling a private reference to the original Stream is not sufficient...
