### PR TITLE
SI-9127 Xlint doesn't think spaces are significant

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5181,13 +5181,10 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           def suspiciousExpr                = InterpolatorCodeRegex findFirstIn s
           def suspiciousIdents              = InterpolatorIdentRegex findAllIn s map (s => suspiciousSym(s drop 1))
 
-          // heuristics - no warning on e.g. a string with only "$asInstanceOf"
-          if (s contains ' ') (
-            if (suspiciousExpr.nonEmpty)
-              warn("detected an interpolated expression") // "${...}"
-            else
-              suspiciousIdents find isPlausible foreach (sym => warn(s"detected interpolated identifier `$$${sym.name}`")) // "$id"
-          )
+          if (suspiciousExpr.nonEmpty)
+            warn("detected an interpolated expression") // "${...}"
+          else
+            suspiciousIdents find isPlausible foreach (sym => warn(s"detected interpolated identifier `$$${sym.name}`")) // "$id"
         }
         lit match {
           case Literal(Constant(s: String)) if !isRecognizablyNotForInterpolation => maybeWarn(s)

--- a/test/files/neg/t9127.check
+++ b/test/files/neg/t9127.check
@@ -1,0 +1,12 @@
+t9127.scala:4: warning: possible missing interpolator: detected interpolated identifier `$s`
+  val t = "$s"
+          ^
+t9127.scala:5: warning: possible missing interpolator: detected an interpolated expression
+  val u = "a${s}b"
+          ^
+t9127.scala:6: warning: possible missing interpolator: detected interpolated identifier `$s`
+  val v = "a$s b"
+          ^
+error: No warnings can be incurred under -Xfatal-warnings.
+three warnings found
+one error found

--- a/test/files/neg/t9127.flags
+++ b/test/files/neg/t9127.flags
@@ -1,0 +1,1 @@
+-Xlint:missing-interpolator -Xfatal-warnings

--- a/test/files/neg/t9127.scala
+++ b/test/files/neg/t9127.scala
@@ -1,0 +1,7 @@
+
+trait X {
+  val s = "hello"
+  val t = "$s"
+  val u = "a${s}b"
+  val v = "a$s b"
+}

--- a/test/files/pos/t9097.flags
+++ b/test/files/pos/t9097.flags
@@ -1,0 +1,1 @@
+-Ydelambdafy:method -Ybackend:GenBCode -Xfatal-warnings

--- a/test/files/pos/t9097.scala
+++ b/test/files/pos/t9097.scala
@@ -1,0 +1,9 @@
+package o
+package a {
+  class C {
+    def hihi = List(1,2).map(_ * 2)
+  }
+}
+package object a {
+  def f = 1
+}


### PR DESCRIPTION
For purposes of warning about missing interpolators,
such as `"$greeting"` when the intended code was `s"$greeting"`,
spaces are no longer significant.

The heuristic was previously intended to allow compileresque
strings, where the dollar sign is a common prefix.

Currently, the Xlint warning can be selectively disabled.
