### PR TITLE
SI-9246 *OrElse should have a by-name parameter

### DIFF
--- a/src/compiler/scala/tools/reflect/WrappedProperties.scala
+++ b/src/compiler/scala/tools/reflect/WrappedProperties.scala
@@ -19,13 +19,13 @@ trait WrappedProperties extends PropertiesTrait {
   protected def propCategory   = "wrapped"
   protected def pickJarBasedOn = this.getClass
 
-  override def propIsSet(name: String)               = wrap(super.propIsSet(name)) exists (x => x)
-  override def propOrElse(name: String, alt: String) = wrap(super.propOrElse(name, alt)) getOrElse alt
-  override def setProp(name: String, value: String)  = wrap(super.setProp(name, value)).orNull
-  override def clearProp(name: String)               = wrap(super.clearProp(name)).orNull
-  override def envOrElse(name: String, alt: String)  = wrap(super.envOrElse(name, alt)) getOrElse alt
-  override def envOrNone(name: String)               = wrap(super.envOrNone(name)).flatten
-  override def envOrSome(name: String, alt: Option[String]) = wrap(super.envOrNone(name)).flatten orElse alt
+  override def propIsSet(name: String)                  = wrap(super.propIsSet(name)) exists (x => x)
+  override def propOrElse(name: String, alt: => String) = wrap(super.propOrElse(name, alt)) getOrElse alt
+  override def setProp(name: String, value: String)     = wrap(super.setProp(name, value)).orNull
+  override def clearProp(name: String)                  = wrap(super.clearProp(name)).orNull
+  override def envOrElse(name: String, alt: => String)  = wrap(super.envOrElse(name, alt)) getOrElse alt
+  override def envOrNone(name: String)                  = wrap(super.envOrNone(name)).flatten
+  override def envOrSome(name: String, alt: => Option[String]) = wrap(super.envOrNone(name)).flatten orElse alt
 
   def systemProperties: List[(String, String)] = {
     import scala.collection.JavaConverters._

--- a/src/library/scala/util/Properties.scala
+++ b/src/library/scala/util/Properties.scala
@@ -49,7 +49,7 @@ private[scala] trait PropertiesTrait {
 
   def propIsSet(name: String)                   = System.getProperty(name) != null
   def propIsSetTo(name: String, value: String)  = propOrNull(name) == value
-  def propOrElse(name: String, alt: String)     = System.getProperty(name, alt)
+  def propOrElse(name: String, alt: => String)  = Option(System getProperty name) getOrElse alt
   def propOrEmpty(name: String)                 = propOrElse(name, "")
   def propOrNull(name: String)                  = propOrElse(name, null)
   def propOrNone(name: String)                  = Option(propOrNull(name))
@@ -57,15 +57,15 @@ private[scala] trait PropertiesTrait {
   def setProp(name: String, value: String)      = System.setProperty(name, value)
   def clearProp(name: String)                   = System.clearProperty(name)
 
-  def envOrElse(name: String, alt: String)      = Option(System getenv name) getOrElse alt
+  def envOrElse(name: String, alt: => String)   = envOrNone(name) getOrElse alt
   def envOrNone(name: String)                   = Option(System getenv name)
 
-  def envOrSome(name: String, alt: Option[String])       = envOrNone(name) orElse alt
+  def envOrSome(name: String, alt: => Option[String])       = envOrNone(name) orElse alt
 
   // for values based on propFilename, falling back to System properties
-  def scalaPropOrElse(name: String, alt: String): String = scalaPropOrNone(name).getOrElse(alt)
-  def scalaPropOrEmpty(name: String): String             = scalaPropOrElse(name, "")
-  def scalaPropOrNone(name: String): Option[String]      = Option(scalaProps.getProperty(name)).orElse(propOrNone("scala." + name))
+  def scalaPropOrElse(name: String, alt: => String): String = scalaPropOrNone(name) getOrElse alt
+  def scalaPropOrEmpty(name: String): String                = scalaPropOrElse(name, "")
+  def scalaPropOrNone(name: String): Option[String]         = Option(scalaProps.getProperty(name)).orElse(propOrNone("scala." + name))
 
   /** The numeric portion of the runtime Scala version, if this is a final
    *  release.  If for instance the versionString says "version 2.9.0.final",


### PR DESCRIPTION
reopen #4279 :gem: 
Sorry for the trouble.
