### PR TITLE
SI-9041 Avoid unreported type error with overloading, implicits

### DIFF
--- a/test/files/neg/t9041.check
+++ b/test/files/neg/t9041.check
@@ -1,0 +1,4 @@
+t9041.scala:11: error: could not find implicit value for parameter cellSetter: CellSetter[scala.math.BigDecimal]
+      def setCell(cell: Cell, data: math.BigDecimal) { cell.setCellValue(data) }
+                                                                        ^
+one error found

--- a/test/files/neg/t9041.scala
+++ b/test/files/neg/t9041.scala
@@ -1,0 +1,17 @@
+// False negative test, requires overloading in Cell.
+
+trait Cell { def setCellValue(i: Int) = () ; def setCellValue(d: Double) = () }
+
+trait Nope {
+  def f = {
+    trait CellSetter[A] {
+      def setCell(cell: Cell, data: A): Unit
+    }
+    implicit val bigDecimalCellSetter = new CellSetter[math.BigDecimal]() {
+      def setCell(cell: Cell, data: math.BigDecimal) { cell.setCellValue(data) }
+    }
+    implicit class RichCell(cell: Cell) {
+      def setCellValue[A](data: A)(implicit cellSetter: CellSetter[A]) = cellSetter.setCell(cell, data)
+    }
+  }
+}


### PR DESCRIPTION
[rebased #4250] 

If `qual.foo(args)` fails to typecheck, we fall back to
`ImplicitView(qual).foo(args)`. However, if the original type error
stemmed from an overload ambiguity, the tree `Select(qual, 'foo')`
holds onto an error symbol. The fall back attempt just returns an
`Apply` tree containing the erroneous qualifier, as it does not
want to issue cascading type errors.

This commit replaces the error symbol with a `NoSymbol`, which
triggers the second try typechecking to perform overload resolution
again.

A more principled fix might be to more pervasively duplicate trees
before mutating their types and symbols, that this is beyond the
scope of this bug fix.
