### PR TITLE
Scala doc update (sliding method)

### DIFF
--- a/src/library/scala/collection/IterableLike.scala
+++ b/src/library/scala/collection/IterableLike.scala
@@ -195,7 +195,7 @@ self =>
    *
    *  @param size the number of elements per group
    *  @param step the distance between the first elements of successive
-   *         groups (defaults to 1)
+   *         groups
    *  @return An iterator producing ${coll}s of size `size`, except the
    *          last and the only element will be truncated if there are
    *          fewer elements than size.

--- a/src/library/scala/collection/IterableLike.scala
+++ b/src/library/scala/collection/IterableLike.scala
@@ -179,6 +179,7 @@ self =>
 
   /** Groups elements in fixed size blocks by passing a "sliding window"
    *  over them (as opposed to partitioning them, as is done in grouped.)
+   *  "Sliding window" step is 1 by default.
    *  @see [[scala.collection.Iterator]], method `sliding`
    *
    *  @param size the number of elements per group


### PR DESCRIPTION
Added info about default step set to 1. Reading this doc (having no code) can be ambiguous.
