### PR TITLE
SI-9133 Harden against infinite loop in NoSymbol.owner

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2054,7 +2054,11 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
      *  where it is the outer class of the enclosing class.
      */
     final def outerClass: Symbol =
-      if (owner.isClass) owner
+      if (this == NoSymbol) {
+        // ideally we shouldn't get here, but its better to harden against this than suffer the infinite loop in SI-9133
+        devWarningDumpStack("NoSymbol.outerClass", 15)
+        NoSymbol
+      } else if (owner.isClass) owner
       else if (isClassLocalToConstructor) owner.enclClass.outerClass
       else owner.outerClass
 

--- a/test/junit/scala/collection/IterableViewLikeTest.scala
+++ b/test/junit/scala/collection/IterableViewLikeTest.scala
@@ -4,6 +4,7 @@ import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import language.postfixOps
 
 @RunWith(classOf[JUnit4])
 class IterableViewLikeTest {

--- a/test/junit/scala/tools/nsc/symtab/SymbolTableTest.scala
+++ b/test/junit/scala/tools/nsc/symtab/SymbolTableTest.scala
@@ -44,4 +44,9 @@ class SymbolTableTest {
     assertFalse("Foo should be a superclass of Foo", fooSymbol.tpe <:< barSymbol.tpe)
   }
 
+  @Test
+  def noSymbolOuterClass_t9133: Unit = {
+    import symbolTable._
+    assert(NoSymbol.outerClass == NoSymbol)
+  }
 }


### PR DESCRIPTION
The available evidence gathered in an IDE hang suggests that while editing
erronenous code, a call to `Erasure#javaSig` by the IDE's structure builder
triggered the `ExplicitOuter` info transformer on a symbol with some sort
of incoherent owner chain, which led to an infinite loop in
`NoSymbol#outerClass`.

This commit hardens that method to work in the same manner as a call to
`NoSymbol.owner`: log the error under -Xdev or -Ydebug and return return
`NoSymbol` to soldier on without crashing / hanging.

I haven't formulated a theory about how we might have ended up with the
corrupt owner chain.

Review by @gkossakowski
