### PR TITLE
SI-9135 Fix NPE, a regression in the pattern matcher

### DIFF
--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -1622,7 +1622,7 @@ trait Trees extends api.Trees {
     }
     private def invalidateSingleTypeCaches(tree: Tree): Unit = {
       if (mutatedSymbols.nonEmpty)
-        for (t <- tree)
+        for (t <- tree if t.tpe != null)
           for (tp <- t.tpe) {
             tp match {
               case s: SingleType if mutatedSymbols contains s.sym =>

--- a/test/files/pos/t9135.scala
+++ b/test/files/pos/t9135.scala
@@ -1,0 +1,16 @@
+
+class Free[A] {
+  
+
+  this match {
+    case a @ Gosub() => gosub(a.a)(x => gosub(???)(???))
+  }
+  def gosub[A, B](a0: Free[A])(f0: A => Any): Free[B] = ???
+}
+
+  
+
+  case class Gosub[B]() extends Free[B] {
+    type C
+    def a: Free[C] = ???
+  }


### PR DESCRIPTION
The community build discovered that #4252 introduced the possibility
for a NullPointerException. The tree with a null type was a synthetic
`Apply(<<matchEnd>>)` created by the pattern matcher.

This commit adds a null check.

Review by @gkossakowski
