### PR TITLE
Declare FiniteDuration.toCoarsest to return a FiniteDuration

### DIFF
--- a/src/library/scala/concurrent/duration/Duration.scala
+++ b/src/library/scala/concurrent/duration/Duration.scala
@@ -705,7 +705,7 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
 
   final def isFinite() = true
 
-  final def toCoarsest: Duration = {
+  final override def toCoarsest: FiniteDuration = {
     def loop(length: Long, unit: TimeUnit): FiniteDuration = {
       def coarserOrThis(coarser: TimeUnit, divider: Int) =
         if (length % divider == 0) loop(length / divider, coarser)

--- a/test/files/run/duration-coarsest.scala
+++ b/test/files/run/duration-coarsest.scala
@@ -25,4 +25,7 @@ object Test extends App {
     23 hours,
     40 days
   ) foreach (x => assert(x == x.toCoarsest, x))
+
+  // toCoarsest on a FiniteDuration should return a FiniteDuration
+  val finite: FiniteDuration = 1.second.toCoarsest
 }


### PR DESCRIPTION
FiniteDuration.toCoarsest is declared with a return type of Duration
even though it can only ever return a FiniteDuration. Change the
declaration to return a FiniteDuration so that using this method
doesn't require a cast or pattern match on the result in cases where
a FiniteDuration is required.

review by @phaller (or @adriaanm ?)
