### PR TITLE
SI-8918 Unary ids are plain ids

### DIFF
--- a/test/files/run/t8918-unary-ids.scala
+++ b/test/files/run/t8918-unary-ids.scala
@@ -1,0 +1,49 @@
+
+
+import scala.tools.partest.SessionTest
+
+// Taking unary ids as plain
+object Test extends SessionTest {
+  def session =
+"""Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> val - = 42
+-: Int = 42
+
+scala> val i = -
+i: Int = 42
+
+scala> - { 42 }
+res0: Int = -42
+
+scala> - if (true) 1 else 2
+<console>:1: error: illegal start of simple expression
+       - if (true) 1 else 2
+         ^
+
+scala> - - 1
+<console>:1: error: ';' expected but integer literal found.
+       - - 1
+           ^
+
+scala> -.-(1)
+res1: Int = 41
+
+scala> -
+res2: Int = 42
+
+scala> - -
+res3: Int = -42
+
+scala> + -
+res4: Int = 42
+
+scala> object X { def -(i: Int) = 42 - i ; def f(g: Int => Int) = g(7) ; def j = f(-) }
+defined object X
+
+scala> X.j
+res5: Int = 35
+
+scala> :quit"""
+}


### PR DESCRIPTION
Allow +,-,!,~ to be used as unprefixed identifiers.

As prefix operators, they must be followed by
a simple expression, so otherwise, consume the
id itself as the start of a simple expression.

Moved https://github.com/scala/scala/pull/4059 to 2.12.x.
