### PR TITLE
SI-9140 Allow deprecating current parameter name

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
@@ -554,15 +554,19 @@ trait NamesDefaults { self: Analyzer =>
       arg match {
         case arg @ AssignOrNamedArg(Ident(name), rhs) =>
           def matchesName(param: Symbol) = {
-            def checkDeprecation = when(param.deprecatedParamName) { case Some(`name`) => true }
+            def checkDeprecation(anonOK: Boolean) =
+              when (param.deprecatedParamName) {
+                case Some(`name`)      => true
+                case Some(nme.NO_NAME) => anonOK
+              }
             def checkName = {
               val res = param.name == name
-              if (res && checkDeprecation)
+              if (res && checkDeprecation(true))
                 context0.deprecationWarning(arg.pos, param, s"naming parameter $name has been deprecated.")
               res
             }
             def checkAltName = {
-              val res = checkDeprecation
+              val res = checkDeprecation(false)
               if (res) context0.deprecationWarning(arg.pos, param,
                   s"the parameter name $name has been deprecated. Use ${param.name} instead.")
               res

--- a/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
@@ -538,75 +538,73 @@ trait NamesDefaults { self: Analyzer =>
     }
   }
 
-  /**
-   * Removes name assignments from args. Additionally, returns an array mapping
-   * argument indices from call-site-order to definition-site-order.
+  /** Removes name assignments from args. Additionally, returns an array mapping
+   *  argument indices from call-site-order to definition-site-order.
    *
-   * Verifies that names are not specified twice, positional args don't appear
-   * after named ones.
+   *  Verifies that names are not specified twice, and positional args don't appear after named ones.
    */
   def removeNames(typer: Typer)(args: List[Tree], params: List[Symbol]): (List[Tree], Array[Int]) = {
     implicit val context0 = typer.context
-    // maps indices from (order written by user) to (order of definition)
-    val argPos            = Array.fill(args.length)(-1)
-    var positionalAllowed = true
-    val namelessArgs = mapWithIndex(args) { (arg, argIndex) =>
-      arg match {
-        case arg @ AssignOrNamedArg(Ident(name), rhs) =>
-          def matchesName(param: Symbol) = {
-            def checkDeprecation(anonOK: Boolean) =
-              when (param.deprecatedParamName) {
-                case Some(`name`)      => true
-                case Some(nme.NO_NAME) => anonOK
-              }
-            def checkName = {
-              val res = param.name == name
-              if (res && checkDeprecation(true))
-                context0.deprecationWarning(arg.pos, param, s"naming parameter $name has been deprecated.")
-              res
-            }
-            def checkAltName = {
-              val res = checkDeprecation(false)
-              if (res) context0.deprecationWarning(arg.pos, param,
-                  s"the parameter name $name has been deprecated. Use ${param.name} instead.")
-              res
-            }
-            !param.isSynthetic && (checkName || checkAltName)
-          }
-          val paramPos = params indexWhere matchesName
-          if (paramPos == -1) {
-            if (positionalAllowed) {
-              argPos(argIndex) = argIndex
-              // prevent isNamed from being true when calling doTypedApply recursively,
-              // treat the arg as an assignment of type Unit
-              Assign(arg.lhs, rhs) setPos arg.pos
-            }
-            else UnknownParameterNameNamesDefaultError(arg, name)
-          }
-          else if (argPos contains paramPos) {
+    def matchesName(param: Symbol, name: Name, argIndex: Int) = {
+      def warn(w: String) = context0.deprecationWarning(args(argIndex).pos, param, w)
+      def checkDeprecation(anonOK: Boolean) =
+        when (param.deprecatedParamName) {
+          case Some(`name`)      => true
+          case Some(nme.NO_NAME) => anonOK
+        }
+      def checkName = {
+        val res = param.name == name
+        if (res && checkDeprecation(true)) warn(s"naming parameter $name has been deprecated.")
+        res
+      }
+      def checkAltName = {
+        val res = checkDeprecation(false)
+        if (res) warn(s"the parameter name $name has been deprecated. Use ${param.name} instead.")
+        res
+      }
+      !param.isSynthetic && (checkName || checkAltName)
+    }
+    // argPos maps indices from (order written by user) to (order of definition)
+    val argPos       = Array.fill(args.length)(-1)
+    val namelessArgs = {
+      var positionalAllowed = true
+      def stripNamedArg(arg: AssignOrNamedArg, argIndex: Int): Tree = {
+        val AssignOrNamedArg(Ident(name), rhs) = arg
+        params indexWhere (p => matchesName(p, name, argIndex)) match {
+          case -1 if positionalAllowed =>
+            // prevent isNamed from being true when calling doTypedApply recursively,
+            // treat the arg as an assignment of type Unit
+            Assign(arg.lhs, rhs) setPos arg.pos
+          case -1 =>
+            UnknownParameterNameNamesDefaultError(arg, name)
+          case paramPos if argPos contains paramPos =>
             val existingArgIndex = argPos.indexWhere(_ == paramPos)
-            val otherName = args(paramPos) match {
-              case AssignOrNamedArg(Ident(oName), rhs) if oName != name => Some(oName)
-              case _ => None
+            val otherName = Some(args(paramPos)) collect {
+              case AssignOrNamedArg(Ident(oName), _) if oName != name => oName
             }
             DoubleParamNamesDefaultError(arg, name, existingArgIndex+1, otherName)
-          } else if (isAmbiguousAssignment(typer, params(paramPos), arg))
+          case paramPos if isAmbiguousAssignment(typer, params(paramPos), arg) =>
             AmbiguousReferenceInNamesDefaultError(arg, name)
-          else {
-            // if the named argument is on the original parameter
-            // position, positional after named is allowed.
-            if (argIndex != paramPos)
-              positionalAllowed = false
-            argPos(argIndex) = paramPos
+          case paramPos if paramPos != argIndex =>
+            positionalAllowed = false    // named arg is not in original parameter order: require names after this
+            argPos(argIndex)  = paramPos // fix up the arg position
             rhs
-          }
-        case _ =>
-          argPos(argIndex) = argIndex
-          if (positionalAllowed) arg
-          else PositionalAfterNamedNamesDefaultError(arg)
+          case _ => rhs
+        }
+      }
+      mapWithIndex(args) {
+        case (arg: AssignOrNamedArg, argIndex) =>
+          val t = stripNamedArg(arg, argIndex)
+          if (!t.isErroneous && argPos(argIndex) < 0) argPos(argIndex) = argIndex
+          t
+        case (arg, argIndex) =>
+          if (positionalAllowed) {
+            argPos(argIndex) = argIndex
+            arg
+          } else
+            PositionalAfterNamedNamesDefaultError(arg)
       }
     }
-
     (namelessArgs, argPos)
   }
 }

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2214,7 +2214,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         val allParams = meth.paramss.flatten
         for (p <- allParams) {
           for (n <- p.deprecatedParamName) {
-            if (allParams.exists(p1 => p1.name == n || (p != p1 && p1.deprecatedParamName.exists(_ == n))))
+            if (allParams.exists(p1 => p != p1 && (p1.name == n || p1.deprecatedParamName.exists(_ == n))))
               DeprecatedParamNameError(p, n)
           }
         }

--- a/src/library/scala/deprecatedName.scala
+++ b/src/library/scala/deprecatedName.scala
@@ -29,4 +29,6 @@ import scala.annotation.meta._
  * @since 2.8.1
  */
 @param
-class deprecatedName(name: Symbol) extends scala.annotation.StaticAnnotation
+class deprecatedName(name: Symbol) extends scala.annotation.StaticAnnotation {
+  def this() = this(Symbol("<none>"))
+}

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -858,7 +858,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def isDeprecated        = hasAnnotation(DeprecatedAttr)
     def deprecationMessage  = getAnnotation(DeprecatedAttr) flatMap (_ stringArg 0)
     def deprecationVersion  = getAnnotation(DeprecatedAttr) flatMap (_ stringArg 1)
-    def deprecatedParamName = getAnnotation(DeprecatedNameAttr) flatMap (_ symbolArg 0)
+    def deprecatedParamName = getAnnotation(DeprecatedNameAttr) flatMap (_ symbolArg 0 orElse Some(nme.NO_NAME))
     def hasDeprecatedInheritanceAnnotation
                             = hasAnnotation(DeprecatedInheritanceAttr)
     def deprecatedInheritanceMessage

--- a/test/files/neg/names-defaults-neg.check
+++ b/test/files/neg/names-defaults-neg.check
@@ -118,68 +118,71 @@ names-defaults-neg.scala:93: warning: the parameter name y has been deprecated. 
 names-defaults-neg.scala:93: error: parameter 'b' is already specified at parameter position 1
   deprNam3(y = 10, b = 2)
                      ^
-names-defaults-neg.scala:98: error: unknown parameter name: m
+names-defaults-neg.scala:96: warning: naming parameter deprNam4Arg has been deprecated.
+  deprNam4(deprNam4Arg = null)
+                       ^
+names-defaults-neg.scala:100: error: unknown parameter name: m
   f3818(y = 1, m = 1)
                  ^
-names-defaults-neg.scala:131: error: reference to var2 is ambiguous; it is both a method parameter and a variable in scope.
+names-defaults-neg.scala:133: error: reference to var2 is ambiguous; it is both a method parameter and a variable in scope.
   delay(var2 = 40)
              ^
-names-defaults-neg.scala:134: error: missing parameter type for expanded function ((x$1) => a = x$1)
+names-defaults-neg.scala:136: error: missing parameter type for expanded function ((x$1) => a = x$1)
   val taf2: Int => Unit = testAnnFun(a = _, b = get("+"))
                                          ^
-names-defaults-neg.scala:134: error: not found: value a
+names-defaults-neg.scala:136: error: not found: value a
   val taf2: Int => Unit = testAnnFun(a = _, b = get("+"))
                                      ^
-names-defaults-neg.scala:134: error: not found: value get
+names-defaults-neg.scala:136: error: not found: value get
   val taf2: Int => Unit = testAnnFun(a = _, b = get("+"))
                                                 ^
-names-defaults-neg.scala:135: error: parameter 'a' is already specified at parameter position 1
+names-defaults-neg.scala:137: error: parameter 'a' is already specified at parameter position 1
   val taf3 = testAnnFun(b = _: String, a = get(8))
                                          ^
-names-defaults-neg.scala:136: error: missing parameter type for expanded function ((x$3) => testAnnFun(x$3, ((x$4) => b = x$4)))
+names-defaults-neg.scala:138: error: missing parameter type for expanded function ((x$3) => testAnnFun(x$3, ((x$4) => b = x$4)))
   val taf4: (Int, String) => Unit = testAnnFun(_, b = _)
                                                ^
-names-defaults-neg.scala:136: error: missing parameter type for expanded function ((x$4) => b = x$4)
+names-defaults-neg.scala:138: error: missing parameter type for expanded function ((x$4) => b = x$4)
   val taf4: (Int, String) => Unit = testAnnFun(_, b = _)
                                                       ^
-names-defaults-neg.scala:136: error: not found: value b
+names-defaults-neg.scala:138: error: not found: value b
   val taf4: (Int, String) => Unit = testAnnFun(_, b = _)
                                                   ^
-names-defaults-neg.scala:144: error: variable definition needs type because 'x' is used as a named argument in its body.
+names-defaults-neg.scala:146: error: variable definition needs type because 'x' is used as a named argument in its body.
   def t3 { var x = t.f(x = 1) }
                ^
-names-defaults-neg.scala:147: error: variable definition needs type because 'x' is used as a named argument in its body.
+names-defaults-neg.scala:149: error: variable definition needs type because 'x' is used as a named argument in its body.
   object t6 { var x = t.f(x = 1) }
                   ^
-names-defaults-neg.scala:147: warning: type-checking the invocation of method f checks if the named argument expression 'x = ...' is a valid assignment
+names-defaults-neg.scala:149: warning: type-checking the invocation of method f checks if the named argument expression 'x = ...' is a valid assignment
 in the current scope. The resulting type inference error (see above) can be fixed by providing an explicit type in the local definition for x.
   object t6 { var x = t.f(x = 1) }
                             ^
-names-defaults-neg.scala:150: error: variable definition needs type because 'x' is used as a named argument in its body.
+names-defaults-neg.scala:152: error: variable definition needs type because 'x' is used as a named argument in its body.
   class t9 { var x = t.f(x = 1) }
                  ^
-names-defaults-neg.scala:150: warning: type-checking the invocation of method f checks if the named argument expression 'x = ...' is a valid assignment
+names-defaults-neg.scala:152: warning: type-checking the invocation of method f checks if the named argument expression 'x = ...' is a valid assignment
 in the current scope. The resulting type inference error (see above) can be fixed by providing an explicit type in the local definition for x.
   class t9 { var x = t.f(x = 1) }
                            ^
-names-defaults-neg.scala:164: error: variable definition needs type because 'x' is used as a named argument in its body.
+names-defaults-neg.scala:166: error: variable definition needs type because 'x' is used as a named argument in its body.
   def u3 { var x = u.f(x = 1) }
                ^
-names-defaults-neg.scala:167: error: variable definition needs type because 'x' is used as a named argument in its body.
+names-defaults-neg.scala:169: error: variable definition needs type because 'x' is used as a named argument in its body.
   def u6 { var x = u.f(x = "32") }
                ^
-names-defaults-neg.scala:170: error: reference to x is ambiguous; it is both a method parameter and a variable in scope.
+names-defaults-neg.scala:172: error: reference to x is ambiguous; it is both a method parameter and a variable in scope.
   def u9 { var x: Int = u.f(x = 1) }
                               ^
-names-defaults-neg.scala:177: error: variable definition needs type because 'x' is used as a named argument in its body.
+names-defaults-neg.scala:179: error: variable definition needs type because 'x' is used as a named argument in its body.
   class u15 { var x = u.f(x = 1) }
                   ^
-names-defaults-neg.scala:177: warning: type-checking the invocation of method f checks if the named argument expression 'x = ...' is a valid assignment
+names-defaults-neg.scala:179: warning: type-checking the invocation of method f checks if the named argument expression 'x = ...' is a valid assignment
 in the current scope. The resulting type inference error (see above) can be fixed by providing an explicit type in the local definition for x.
   class u15 { var x = u.f(x = 1) }
                             ^
-names-defaults-neg.scala:180: error: reference to x is ambiguous; it is both a method parameter and a variable in scope.
+names-defaults-neg.scala:182: error: reference to x is ambiguous; it is both a method parameter and a variable in scope.
   class u18 { var x: Int = u.f(x = 1) }
                                  ^
-four warnings found
+5 warnings found
 46 errors found

--- a/test/files/neg/names-defaults-neg.check
+++ b/test/files/neg/names-defaults-neg.check
@@ -121,68 +121,71 @@ names-defaults-neg.scala:93: error: parameter 'b' is already specified at parame
 names-defaults-neg.scala:96: warning: naming parameter deprNam4Arg has been deprecated.
   deprNam4(deprNam4Arg = null)
                        ^
-names-defaults-neg.scala:100: error: unknown parameter name: m
+names-defaults-neg.scala:98: warning: naming parameter deprNam5Arg has been deprecated.
+  deprNam5(deprNam5Arg = null)
+                       ^
+names-defaults-neg.scala:102: error: unknown parameter name: m
   f3818(y = 1, m = 1)
                  ^
-names-defaults-neg.scala:133: error: reference to var2 is ambiguous; it is both a method parameter and a variable in scope.
+names-defaults-neg.scala:135: error: reference to var2 is ambiguous; it is both a method parameter and a variable in scope.
   delay(var2 = 40)
              ^
-names-defaults-neg.scala:136: error: missing parameter type for expanded function ((x$1) => a = x$1)
+names-defaults-neg.scala:138: error: missing parameter type for expanded function ((x$1) => a = x$1)
   val taf2: Int => Unit = testAnnFun(a = _, b = get("+"))
                                          ^
-names-defaults-neg.scala:136: error: not found: value a
+names-defaults-neg.scala:138: error: not found: value a
   val taf2: Int => Unit = testAnnFun(a = _, b = get("+"))
                                      ^
-names-defaults-neg.scala:136: error: not found: value get
+names-defaults-neg.scala:138: error: not found: value get
   val taf2: Int => Unit = testAnnFun(a = _, b = get("+"))
                                                 ^
-names-defaults-neg.scala:137: error: parameter 'a' is already specified at parameter position 1
+names-defaults-neg.scala:139: error: parameter 'a' is already specified at parameter position 1
   val taf3 = testAnnFun(b = _: String, a = get(8))
                                          ^
-names-defaults-neg.scala:138: error: missing parameter type for expanded function ((x$3) => testAnnFun(x$3, ((x$4) => b = x$4)))
+names-defaults-neg.scala:140: error: missing parameter type for expanded function ((x$3) => testAnnFun(x$3, ((x$4) => b = x$4)))
   val taf4: (Int, String) => Unit = testAnnFun(_, b = _)
                                                ^
-names-defaults-neg.scala:138: error: missing parameter type for expanded function ((x$4) => b = x$4)
+names-defaults-neg.scala:140: error: missing parameter type for expanded function ((x$4) => b = x$4)
   val taf4: (Int, String) => Unit = testAnnFun(_, b = _)
                                                       ^
-names-defaults-neg.scala:138: error: not found: value b
+names-defaults-neg.scala:140: error: not found: value b
   val taf4: (Int, String) => Unit = testAnnFun(_, b = _)
                                                   ^
-names-defaults-neg.scala:146: error: variable definition needs type because 'x' is used as a named argument in its body.
+names-defaults-neg.scala:148: error: variable definition needs type because 'x' is used as a named argument in its body.
   def t3 { var x = t.f(x = 1) }
                ^
-names-defaults-neg.scala:149: error: variable definition needs type because 'x' is used as a named argument in its body.
+names-defaults-neg.scala:151: error: variable definition needs type because 'x' is used as a named argument in its body.
   object t6 { var x = t.f(x = 1) }
                   ^
-names-defaults-neg.scala:149: warning: type-checking the invocation of method f checks if the named argument expression 'x = ...' is a valid assignment
+names-defaults-neg.scala:151: warning: type-checking the invocation of method f checks if the named argument expression 'x = ...' is a valid assignment
 in the current scope. The resulting type inference error (see above) can be fixed by providing an explicit type in the local definition for x.
   object t6 { var x = t.f(x = 1) }
                             ^
-names-defaults-neg.scala:152: error: variable definition needs type because 'x' is used as a named argument in its body.
+names-defaults-neg.scala:154: error: variable definition needs type because 'x' is used as a named argument in its body.
   class t9 { var x = t.f(x = 1) }
                  ^
-names-defaults-neg.scala:152: warning: type-checking the invocation of method f checks if the named argument expression 'x = ...' is a valid assignment
+names-defaults-neg.scala:154: warning: type-checking the invocation of method f checks if the named argument expression 'x = ...' is a valid assignment
 in the current scope. The resulting type inference error (see above) can be fixed by providing an explicit type in the local definition for x.
   class t9 { var x = t.f(x = 1) }
                            ^
-names-defaults-neg.scala:166: error: variable definition needs type because 'x' is used as a named argument in its body.
+names-defaults-neg.scala:168: error: variable definition needs type because 'x' is used as a named argument in its body.
   def u3 { var x = u.f(x = 1) }
                ^
-names-defaults-neg.scala:169: error: variable definition needs type because 'x' is used as a named argument in its body.
+names-defaults-neg.scala:171: error: variable definition needs type because 'x' is used as a named argument in its body.
   def u6 { var x = u.f(x = "32") }
                ^
-names-defaults-neg.scala:172: error: reference to x is ambiguous; it is both a method parameter and a variable in scope.
+names-defaults-neg.scala:174: error: reference to x is ambiguous; it is both a method parameter and a variable in scope.
   def u9 { var x: Int = u.f(x = 1) }
                               ^
-names-defaults-neg.scala:179: error: variable definition needs type because 'x' is used as a named argument in its body.
+names-defaults-neg.scala:181: error: variable definition needs type because 'x' is used as a named argument in its body.
   class u15 { var x = u.f(x = 1) }
                   ^
-names-defaults-neg.scala:179: warning: type-checking the invocation of method f checks if the named argument expression 'x = ...' is a valid assignment
+names-defaults-neg.scala:181: warning: type-checking the invocation of method f checks if the named argument expression 'x = ...' is a valid assignment
 in the current scope. The resulting type inference error (see above) can be fixed by providing an explicit type in the local definition for x.
   class u15 { var x = u.f(x = 1) }
                             ^
-names-defaults-neg.scala:182: error: reference to x is ambiguous; it is both a method parameter and a variable in scope.
+names-defaults-neg.scala:184: error: reference to x is ambiguous; it is both a method parameter and a variable in scope.
   class u18 { var x: Int = u.f(x = 1) }
                                  ^
-5 warnings found
+6 warnings found
 46 errors found

--- a/test/files/neg/names-defaults-neg.scala
+++ b/test/files/neg/names-defaults-neg.scala
@@ -92,6 +92,8 @@ object Test extends App {
   def deprNam3(@deprecatedName('x) a: Int, @deprecatedName('y) b: Int) = a + b
   deprNam3(y = 10, b = 2)
 
+  def deprNam4(@deprecatedName('deprNam4Arg) deprNam4Arg: String) = 0
+  deprNam4(deprNam4Arg = null)
 
   // t3818
   def f3818(x: Int = 1, y: Int, z: Int = 1) = 0

--- a/test/files/neg/names-defaults-neg.scala
+++ b/test/files/neg/names-defaults-neg.scala
@@ -94,6 +94,8 @@ object Test extends App {
 
   def deprNam4(@deprecatedName('deprNam4Arg) deprNam4Arg: String) = 0
   deprNam4(deprNam4Arg = null)
+  def deprNam5(@deprecatedName deprNam5Arg: String) = 0
+  deprNam5(deprNam5Arg = null)
 
   // t3818
   def f3818(x: Int = 1, y: Int, z: Int = 1) = 0


### PR DESCRIPTION
Allow deprecatedName to specify the name of the parameter
it qualifies.

This tells the user, That's my name, don't wear it out.
I.e., don't use my name when calling me.

Use cases include: the name will change; normally a name
should be provided for a boolean, but not in this case
(perhaps because there is only one argument).

```
scala> def f(@deprecatedName('foo) bar: String) = bar.reverse
f: (bar: String)String

scala> f(foo = "hello")
<console>:9: warning: the parameter name foo has been deprecated. Use bar instead.
              f(foo = "hello")
                    ^
res0: String = olleh

scala> def g(@deprecatedName('foo) foo: String) = foo.reverse
g: (foo: String)String

scala> g(foo = "hello")
<console>:9: warning: naming parameter foo has been deprecated.
              g(foo = "hello")
                    ^
res1: String = olleh
```
