### PR TITLE
SI-4339 Backpatch event errors and attr fix

### DIFF
--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -187,6 +187,14 @@ filter {
         {
             matchName="scala.xml.dtd.ElementValidator.scala$xml$dtd$ElementValidator$$find$2"
             problemName=IncompatibleMethTypeProblem
+        },
+        {
+            matchName="scala.xml.pull.ExceptionEvent"
+            problemName=MissingClassProblem
+        },
+        {
+            matchName="scala.xml.pull.ExceptionEvent$"
+            problemName=MissingClassProblem
         }
     ]
 }

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -367,7 +367,9 @@ trait Scanners extends ScannersCommon {
             val last = if (charOffset >= 2) buf(charOffset - 2) else ' '
             nextChar()
             last match {
-              case ' ' | '\t' | '\n' | '{' | '(' | '>' if isNameStart(ch) || ch == '!' || ch == '?' =>
+              // exclude valid xml names that happen to be Scala operator chars
+              case ' ' | '\t' | '\n' | '{' | '(' | '>' if (isNameStart(ch) && ch != ':' && !isSpecial(ch))
+                  || ch == '!' || ch == '?' =>
                 token = XMLSTART
               case _ =>
                 // Console.println("found '<', but last is '"+in.last+"'"); // DEBUG

--- a/src/library/scala/xml/parsing/MarkupParserCommon.scala
+++ b/src/library/scala/xml/parsing/MarkupParserCommon.scala
@@ -58,8 +58,9 @@ private[scala] trait MarkupParserCommon extends TokenTests {
    @param endCh either `'` or `"`
    */
   def xAttributeValue(endCh: Char): String = {
+    require(endCh == '\'' || endCh == '"', s"Expected single or double quote, found $endCh")
     val buf = new StringBuilder
-    while (ch != endCh) {
+    while (ch != endCh && !eof) {
       // well-formedness constraint
       if (ch == '<') return errorAndResult("'<' not allowed in attrib value", "")
       else if (ch == SU) truncatedError("")

--- a/test/files/jvm/unittest_xml.scala
+++ b/test/files/jvm/unittest_xml.scala
@@ -62,7 +62,9 @@ object Test {
   object UtilityTest {
     def run() {
       assert(Utility.isNameStart('b'))
-      assert(!Utility.isNameStart(':'))
+
+      // no longer: this was a convenience for the implementation, not to spec.
+      //assert(!Utility.isNameStart(':'))
 
       val x = <foo>
                  <toomuchws/>

--- a/test/files/run/t4339.check
+++ b/test/files/run/t4339.check
@@ -1,0 +1,3 @@
+Saw failure: scala.xml.parsing.FatalError: expected closing tag of foo
+EvElemStart(null,foo, bar="baz/&gt;",)
+Saw failure: scala.xml.parsing.FatalError: expected closing tag of foo

--- a/test/files/run/t4339.scala
+++ b/test/files/run/t4339.scala
@@ -1,0 +1,35 @@
+
+import scala.util.{ Try, Success, Failure }
+import xml._
+import scala.io.Source.fromString
+import java.io.PrintStream
+
+object Test extends App {
+
+  def quietSource(text: String) = new io.Source {
+    override protected val iter = io.Source fromString text
+    override def report(pos: Int, msg: String, out: PrintStream) = ()
+  }
+  def reading(text: String)(f: pull.XMLEventReader => Unit): Unit = {
+    val r = new pull.XMLEventReader(quietSource(text))
+    try f(r)
+    finally r.stop()
+  }
+  def trying(body: => Unit): Unit =
+    Try (body) match {
+      case Success(_) => Console println "Expected failure"
+      case Failure(e) => Console println s"Saw failure: $e"
+    }
+
+  val problematic = """<foo bar="baz/>"""
+
+  trying (
+    parsing.ConstructingParser.fromSource(quietSource(problematic), false).document.docElem
+  )
+
+  trying (
+    reading(problematic) { r =>
+      while (r.hasNext) println(r.next())
+    }
+  )
+}


### PR DESCRIPTION
Improve attribute parsing and propagate errors
across event thread. Otherwise tests just hang.
