### PR TITLE
SI-6476 Accept escaped quotes in interp strings

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -688,13 +688,10 @@ trait Scanners extends ScannersCommon {
       } else unclosedStringLit()
     }
 
-    private def unclosedStringLit(): Unit = {
+    private def unclosedStringLit(): Unit = syntaxError {
       val message    = "unclosed string literal"
       val supplement = """ (\" is an escaped quote, not the end of string)"""
-      syntaxError {
-        if (cbuf contains '"') message + supplement
-        else message
-      }
+      if (cbuf contains '"') message + supplement else message
     }
 
     private def getRawStringLit(): Unit = {
@@ -733,22 +730,20 @@ trait Scanners extends ScannersCommon {
             token = STRINGLIT
           } else
             loop(escaped = false)
+        case '"' | '$' if escaped =>
+          putChar(ch)
+          nextRawChar()
+          loop(escaped = false)
         case '"' =>
-          if (escaped) {
-            putChar(ch)
-            nextRawChar()
-            loop(escaped = false)
-          } else {
-            nextChar()
-            setStrVal()
-            token = STRINGLIT
-          }
+          nextChar()
+          setStrVal()
+          token = STRINGLIT
         case '$' =>
           nextRawChar()
           if (ch == '$') {
             putChar(ch)
             nextRawChar()
-            loop(escaped = false) // ignore escape of dollar?
+            loop(escaped = false)
           } else if (ch == '{') {
             finishStringPart()
             nextRawChar()

--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -186,7 +186,7 @@ object StringContext {
   /** Expands standard Scala escape sequences in a string.
    *  Escape sequences are:
    *   control: `\b`, `\t`, `\n`, `\f`, `\r`
-   *   escape:  `\\`, `\"`, `\'`
+   *   escape:  `\\`, `\"`, `\'`, `\$`
    *   octal:   `\d` `\dd` `\ddd` where `d` is an octal digit between `0` and `7`.
    *
    *  @param  str  A string that may contain escape sequences
@@ -218,6 +218,7 @@ object StringContext {
             case '"'  => '"'
             case '\'' => '\''
             case '\\' => '\\'
+            case '$'  => '$'
             case o if '0' <= o && o <= '7' =>
               if (strict) throw new InvalidEscapeException(str, next)
               val leadch = str(idx)

--- a/test/files/neg/t5510.check
+++ b/test/files/neg/t5510.check
@@ -1,19 +1,25 @@
-t5510.scala:2: error: unclosed string literal
+t5510.scala:2: error: unclosed string literal (\" is an escaped quote, not the end of string)
+  val sa = s"x\"y
+             ^
+t5510.scala:3: error: unclosed string literal (\" is an escaped quote, not the end of string)
+  val sb = "x\"y
+           ^
+t5510.scala:4: error: unclosed string literal
   val s1 = s"xxx
              ^
-t5510.scala:3: error: unclosed string literal
+t5510.scala:5: error: unclosed string literal
   val s2 = s"xxx $x
                    ^
-t5510.scala:4: error: unclosed string literal
+t5510.scala:6: error: unclosed string literal
   val s3 = s"xxx $$
              ^
-t5510.scala:5: error: unclosed string literal
+t5510.scala:7: error: unclosed string literal
   val s4 = ""s"
                ^
-t5510.scala:6: error: unclosed multi-line string literal
+t5510.scala:8: error: unclosed multi-line string literal
   val s5 = ""s""" $s1 $s2 s"
                          ^
-t5510.scala:7: error: unclosed multi-line string literal
+t5510.scala:9: error: unclosed multi-line string literal
 }
  ^
-6 errors found
+8 errors found

--- a/test/files/neg/t5510.check
+++ b/test/files/neg/t5510.check
@@ -1,25 +1,22 @@
-t5510.scala:2: error: unclosed string literal (\" is an escaped quote, not the end of string)
-  val sa = s"x\"y
-             ^
-t5510.scala:3: error: unclosed string literal (\" is an escaped quote, not the end of string)
+t5510.scala:5: error: unclosed string literal (\" is an escaped quote, not the end of string)
   val sb = "x\"y
            ^
-t5510.scala:4: error: unclosed string literal
+t5510.scala:6: error: unclosed string literal
   val s1 = s"xxx
              ^
-t5510.scala:5: error: unclosed string literal
+t5510.scala:7: error: unclosed string literal
   val s2 = s"xxx $x
                    ^
-t5510.scala:6: error: unclosed string literal
+t5510.scala:8: error: unclosed string literal
   val s3 = s"xxx $$
              ^
-t5510.scala:7: error: unclosed string literal
+t5510.scala:9: error: unclosed string literal
   val s4 = ""s"
                ^
-t5510.scala:8: error: unclosed multi-line string literal
+t5510.scala:10: error: unclosed multi-line string literal
   val s5 = ""s""" $s1 $s2 s"
                          ^
-t5510.scala:9: error: unclosed multi-line string literal
+t5510.scala:11: error: unclosed multi-line string literal
 }
  ^
-8 errors found
+7 errors found

--- a/test/files/neg/t5510.scala
+++ b/test/files/neg/t5510.scala
@@ -1,5 +1,7 @@
-object Test {
-  val sa = s"x\"y
+trait TypeErrors {
+  val sa = s"x\"y  // see t6476.scala
+}
+trait ParseErrors {
   val sb = "x\"y
   val s1 = s"xxx
   val s2 = s"xxx $x

--- a/test/files/neg/t5510.scala
+++ b/test/files/neg/t5510.scala
@@ -1,4 +1,6 @@
 object Test {
+  val sa = s"x\"y
+  val sb = "x\"y
   val s1 = s"xxx
   val s2 = s"xxx $x
   val s3 = s"xxx $$

--- a/test/files/neg/t6476.check
+++ b/test/files/neg/t6476.check
@@ -1,0 +1,4 @@
+t6476.scala:2: error: value y is not a member of String
+  val sa = s"x\"y
+                ^
+one error found

--- a/test/files/neg/t6476.scala
+++ b/test/files/neg/t6476.scala
@@ -1,0 +1,3 @@
+trait TypeErrors {
+  val sa = s"x\"y
+}

--- a/test/files/neg/t8266-invalid-interp.check
+++ b/test/files/neg/t8266-invalid-interp.check
@@ -1,10 +1,7 @@
-t8266-invalid-interp.scala:4: error: Trailing '\' escapes nothing.
-    f"a\",
-       ^
 t8266-invalid-interp.scala:5: error: invalid escape '\x' not one of [\b, \t, \n, \f, \r, \\, \", \'] at index 1 in "a\xc". Use \\ for literal \.
     f"a\xc",
        ^
 t8266-invalid-interp.scala:7: error: invalid escape '\v' not one of [\b, \t, \n, \f, \r, \\, \", \'] at index 1 in "a\vc". Use \\ for literal \.
     f"a\vc"
        ^
-three errors found
+two errors found

--- a/test/files/neg/t8266-invalid-interp.check
+++ b/test/files/neg/t8266-invalid-interp.check
@@ -1,7 +1,7 @@
-t8266-invalid-interp.scala:5: error: invalid escape '\x' not one of [\b, \t, \n, \f, \r, \\, \", \'] at index 1 in "a\xc". Use \\ for literal \.
+t8266-invalid-interp.scala:5: error: invalid escape '\x' not one of [\b, \t, \n, \f, \r, \\, \$, \", \'] at index 1 in "a\xc". Use \\ for literal \.
     f"a\xc",
        ^
-t8266-invalid-interp.scala:7: error: invalid escape '\v' not one of [\b, \t, \n, \f, \r, \\, \", \'] at index 1 in "a\vc". Use \\ for literal \.
+t8266-invalid-interp.scala:7: error: invalid escape '\v' not one of [\b, \t, \n, \f, \r, \\, \$, \", \'] at index 1 in "a\vc". Use \\ for literal \.
     f"a\vc"
        ^
 two errors found

--- a/test/files/neg/t8266-invalid-interp.scala
+++ b/test/files/neg/t8266-invalid-interp.scala
@@ -1,7 +1,7 @@
 
 trait X {
   def f = Seq(
-    f"a\",
+    // f"a\",    // escaped quote and unterminated string
     f"a\xc",
     // following could suggest \u000b for vertical tab, similar for \a alert
     f"a\vc"

--- a/test/junit/scala/StringContextTest.scala
+++ b/test/junit/scala/StringContextTest.scala
@@ -86,13 +86,20 @@ class StringContextTest {
     assertEquals("""Forty-two is "42"""", s"Forty-two is \"42\"")
     assertEquals("""dir\""", s"dir\\")
     assertEquals("""\\""", s"\\\\")
-    // dollar is not escaped
-    assertEquals("""\\\42""", raw"\\\$i")
     // colon separator, in case we like to escape dollar someday
     assertEquals("""\\\:42""", raw"\\\:$i")
     assertThrows[StringContext.InvalidEscapeException] {
       s"\\\:$i"
     }
+  }
+
+  @Test def `SI-6476: escape dollar`(): Unit = {
+    val name = "world"
+    assertEquals("Hello, world.", s"Hello, $name.")
+    assertEquals("Hello, $name.", s"Hello, $$name.")
+    assertEquals("Hello, $name.", s"Hello, \$name.")
+    assertEquals("Hello, $world$.", s"Hello, \$$name\$.")
+    assertEquals("Hello, $world$.", s"Hello, \$$name$$.")
   }
 
   // Use this method to avoid problems with a locale-dependent decimal mark.

--- a/test/junit/scala/StringContextTest.scala
+++ b/test/junit/scala/StringContextTest.scala
@@ -85,6 +85,9 @@ class StringContextTest {
     val i = 42
     assertEquals("""Forty-two is "42"""", s"Forty-two is \"42\"")
     assertEquals("""dir\""", s"dir\\")
+    assertEquals("""dir\""", raw"dir\")
+    assertEquals("""1 \ 42""", raw"1 \ $i")
+    assertEquals("""1 \ 42 \""", raw"1 \ $i \")
     assertEquals("""\\""", s"\\\\")
     // colon separator, in case we like to escape dollar someday
     assertEquals("""\\\:42""", raw"\\\:$i")

--- a/test/junit/scala/StringContextTest.scala
+++ b/test/junit/scala/StringContextTest.scala
@@ -81,6 +81,20 @@ class StringContextTest {
     assertEquals(expected, res)
   }
 
+  @Test def `SI-6476: escape quotes`(): Unit = {
+    val i = 42
+    assertEquals("""Forty-two is "42"""", s"Forty-two is \"42\"")
+    assertEquals("""dir\""", s"dir\\")
+    assertEquals("""\\""", s"\\\\")
+    // dollar is not escaped
+    assertEquals("""\\\42""", raw"\\\$i")
+    // colon separator, in case we like to escape dollar someday
+    assertEquals("""\\\:42""", raw"\\\:$i")
+    assertThrows[StringContext.InvalidEscapeException] {
+      s"\\\:$i"
+    }
+  }
+
   // Use this method to avoid problems with a locale-dependent decimal mark.
   // The string interpolation is not used here intentionally as this method is used to test string interpolation.
   private def formatUsingCurrentLocale(number: Double, decimalPlaces: Int = 2) = ("%." + decimalPlaces + "f").format(number)


### PR DESCRIPTION
Everyone wants to say `s"\"hello,\" world"`.

This commit considers `\"` when looking for the end of
a string part.

However, the interpolator still receives the source text.

Also adds a commit for escaped dollar.

```
scala> s"^hi$$".r     // sip style
res0: scala.util.matching.Regex = ^hi$

scala> s"^hi\$".r      // proposed
res1: scala.util.matching.Regex = ^hi$

scala> raw"\text\"    // interpretation of escapes is still up to the interpolator
res2: String = \text\

scala> raw"\"text\""
res3: String = \"text\"

scala> s"\"text\""
res4: String = "text"

```
