### PR TITLE
SI-9116 Set.subsets has a param list

### DIFF
--- a/src/library/scala/collection/SetLike.scala
+++ b/src/library/scala/collection/SetLike.scala
@@ -171,7 +171,7 @@ self =>
    *
    *  @return     the iterator.
    */
-  def subsets: Iterator[This] = new AbstractIterator[This] {
+  def subsets(): Iterator[This] = new AbstractIterator[This] {
     private val elms = self.toIndexedSeq
     private var len = 0
     private var itr: Iterator[This] = Iterator.empty

--- a/test/files/pos/t9116.scala
+++ b/test/files/pos/t9116.scala
@@ -1,0 +1,7 @@
+
+trait X {
+  List(1, 2, 3).toSet.subsets.map(_.toList)     // ok now
+
+  List(1, 2, 3).toSet.subsets().map(_.toList)   // now also
+  List(1, 2, 3).toSet.subsets(2).map(_.toList)  // still ok
+}

--- a/test/files/run/settings-parse.scala
+++ b/test/files/run/settings-parse.scala
@@ -3,9 +3,8 @@ import scala.language.postfixOps
 import scala.tools.nsc._
 
 object Test {
-  val tokens        = List("", "-deprecation", "foo.scala")
-  val subsets       = tokens.toSet.subsets.toList
-  val permutations0 = subsets.flatMap(_.toList.permutations).distinct
+  val tokens        = "" :: "-deprecation" :: "foo.scala" :: Nil
+  val permutations0 = tokens.toSet.subsets.flatMap(_.toList.permutations).toList.distinct
 
   def runWithCp(cp: String) = {
     val permutations = permutations0 flatMap ("-cp CPTOKEN" :: _ permutations)


### PR DESCRIPTION
Now both of the overloaded variants have a parameter list.
This seems to make type inference happier. Or it makes someone
happier.

The user is unaware whether `subsets()` takes a default arg.
But happily, empty application still kicks in.
