### PR TITLE
SI-9127 Xlint doesn't think spaces are significant

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5200,13 +5200,10 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           def suspiciousExpr                = InterpolatorCodeRegex findFirstIn s
           def suspiciousIdents              = InterpolatorIdentRegex findAllIn s map (s => suspiciousSym(s drop 1))
 
-          // heuristics - no warning on e.g. a string with only "$asInstanceOf"
-          if (s contains ' ') (
-            if (suspiciousExpr.nonEmpty)
-              warn("detected an interpolated expression") // "${...}"
-            else
-              suspiciousIdents find isPlausible foreach (sym => warn(s"detected interpolated identifier `$$${sym.name}`")) // "$id"
-          )
+          if (suspiciousExpr.nonEmpty)
+            warn("detected an interpolated expression") // "${...}"
+          else
+            suspiciousIdents find isPlausible foreach (sym => warn(s"detected interpolated identifier `$$${sym.name}`")) // "$id"
         }
         lit match {
           case Literal(Constant(s: String)) if !isRecognizablyNotForInterpolation => maybeWarn(s)

--- a/test/files/neg/t7848-interp-warn.check
+++ b/test/files/neg/t7848-interp-warn.check
@@ -4,9 +4,12 @@ t7848-interp-warn.scala:8: warning: possible missing interpolator: detected inte
 t7848-interp-warn.scala:12: warning: possible missing interpolator: detected an interpolated expression
     "A doubly important ${foo * 2} message!"
     ^
+t7848-interp-warn.scala:15: warning: possible missing interpolator: detected interpolated identifier `$bar`
+  def i = s"Try using '${ "$bar" }' instead."  // was: no warn on space test
+                          ^
 t7848-interp-warn.scala:16: warning: possible missing interpolator: detected interpolated identifier `$bar`
   def j = s"Try using '${ "something like $bar" }' instead."  // warn
                           ^
 error: No warnings can be incurred under -Xfatal-warnings.
-three warnings found
+four warnings found
 one error found

--- a/test/files/neg/t7848-interp-warn.scala
+++ b/test/files/neg/t7848-interp-warn.scala
@@ -12,7 +12,7 @@ object Test {
     "A doubly important ${foo * 2} message!"
   }
   def h = s"Try using '$$bar' instead."  // no warn
-  def i = s"Try using '${ "$bar" }' instead."  // no warn on space test
+  def i = s"Try using '${ "$bar" }' instead."  // was: no warn on space test
   def j = s"Try using '${ "something like $bar" }' instead."  // warn
   def k = f"Try using '$bar' instead."  // no warn on other std interps
 }

--- a/test/files/neg/t9127.check
+++ b/test/files/neg/t9127.check
@@ -1,0 +1,12 @@
+t9127.scala:4: warning: possible missing interpolator: detected interpolated identifier `$s`
+  val t = "$s"
+          ^
+t9127.scala:5: warning: possible missing interpolator: detected an interpolated expression
+  val u = "a${s}b"
+          ^
+t9127.scala:6: warning: possible missing interpolator: detected interpolated identifier `$s`
+  val v = "a$s b"
+          ^
+error: No warnings can be incurred under -Xfatal-warnings.
+three warnings found
+one error found

--- a/test/files/neg/t9127.flags
+++ b/test/files/neg/t9127.flags
@@ -1,0 +1,1 @@
+-Xlint:missing-interpolator -Xfatal-warnings

--- a/test/files/neg/t9127.scala
+++ b/test/files/neg/t9127.scala
@@ -1,0 +1,7 @@
+
+trait X {
+  val s = "hello"
+  val t = "$s"
+  val u = "a${s}b"
+  val v = "a$s b"
+}


### PR DESCRIPTION
For purposes of warning about missing interpolators,
such as `"$greeting"` when the intended code was `s"$greeting"`,
spaces are no longer significant.

The heuristic was previously intended to allow compileresque
strings, where the dollar sign is a common prefix.

Currently, the Xlint warning can be selectively disabled.
