### PR TITLE
SI-9076 REPL wrap is App

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -197,7 +197,14 @@ trait ScalaSettings extends AbsScalaSettings
   val Ymacroexpand    = ChoiceSetting     ("-Ymacro-expand", "policy", "Control expansion of macros, useful for scaladoc and presentation compiler", List(MacroExpand.Normal, MacroExpand.None, MacroExpand.Discard), MacroExpand.Normal)
   val Ymacronoexpand  = BooleanSetting    ("-Ymacro-no-expand", "Don't expand macros. Might be useful for scaladoc and presentation compiler, but will crash anything which uses macros and gets past typer.") withDeprecationMessage(s"Use ${Ymacroexpand.name}:${MacroExpand.None}") withPostSetHook(_ => Ymacroexpand.value = MacroExpand.None)
   val Yreplsync       = BooleanSetting    ("-Yrepl-sync", "Do not use asynchronous code for repl startup")
-  val Yreplclassbased = BooleanSetting    ("-Yrepl-class-based", "Use classes to wrap REPL snippets instead of objects")
+  val Yreplclassbased = BooleanSetting    ("-Yrepl-class-based", "Use classes to wrap REPL snippets instead of objects") withPostSetHook (self => if (self) YreplWrap.value = "class")
+  val YreplWrap = ChoiceSetting(
+    name    = "-YreplWrap",
+    helpArg = "template",
+    descr   = "Select REPL template",
+    choices = List("class", "object", "app"),
+    default = "app"
+  )
   val Yreploutdir     = StringSetting     ("-Yrepl-outdir", "path", "Write repl-generated classfiles to given output directory (use \"\" to generate a temporary dir)" , "")
   val YmethodInfer    = BooleanSetting    ("-Yinfer-argument-types", "Infer types for arguments of overridden methods.")
   val etaExpandKeepsStar = BooleanSetting ("-Yeta-expand-keeps-star", "Eta-expand varargs methods to T* rather than Seq[T].  This is a temporary option to ease transition.").withDeprecationMessage(removalIn212)

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -197,13 +197,13 @@ trait ScalaSettings extends AbsScalaSettings
   val Ymacroexpand    = ChoiceSetting     ("-Ymacro-expand", "policy", "Control expansion of macros, useful for scaladoc and presentation compiler", List(MacroExpand.Normal, MacroExpand.None, MacroExpand.Discard), MacroExpand.Normal)
   val Ymacronoexpand  = BooleanSetting    ("-Ymacro-no-expand", "Don't expand macros. Might be useful for scaladoc and presentation compiler, but will crash anything which uses macros and gets past typer.") withDeprecationMessage(s"Use ${Ymacroexpand.name}:${MacroExpand.None}") withPostSetHook(_ => Ymacroexpand.value = MacroExpand.None)
   val Yreplsync       = BooleanSetting    ("-Yrepl-sync", "Do not use asynchronous code for repl startup")
-  val Yreplclassbased = BooleanSetting    ("-Yrepl-class-based", "Use classes to wrap REPL snippets instead of objects") withPostSetHook (self => if (self) YreplWrap.value = "class")
+  val Yreplclassbased = BooleanSetting    ("-Yrepl-class-based", "Use classes to wrap REPL snippets instead of objects") withPostSetHook (self => YreplWrap.value = (if (self) "class" else "object"))
   val YreplWrap = ChoiceSetting(
-    name    = "-YreplWrap",
+    name    = "-Yrepl-wrap",
     helpArg = "template",
     descr   = "Select REPL template",
     choices = List("class", "object", "app"),
-    default = "app"
+    default = "object"
   )
   val Yreploutdir     = StringSetting     ("-Yrepl-outdir", "path", "Write repl-generated classfiles to given output directory (use \"\" to generate a temporary dir)" , "")
   val YmethodInfer    = BooleanSetting    ("-Yinfer-argument-types", "Infer types for arguments of overridden methods.")

--- a/test/files/jvm/interpreter.check
+++ b/test/files/jvm/interpreter.check
@@ -365,6 +365,6 @@ scala> :quit
 plusOne: (x: Int)Int
 res0: Int = 6
 res0: String = after reset
-<console>:8: error: not found: value plusOne
+<console>:7: error: not found: value plusOne
               plusOne(5) // should be undefined now
               ^

--- a/test/files/run/kind-repl-command.check
+++ b/test/files/run/kind-repl-command.check
@@ -21,7 +21,7 @@ scala> :k new { def empty = false }
 AnyRef{def empty: Boolean}'s kind is A
 
 scala> :k Nonexisting
-<console>:8: error: not found: value Nonexisting
+<console>:7: error: not found: value Nonexisting
               Nonexisting
               ^
 

--- a/test/files/run/reify_newimpl_22.check
+++ b/test/files/run/reify_newimpl_22.check
@@ -17,7 +17,7 @@ scala> {
   }
   println(code.eval)
 }
-<console>:15: free term: Ident(TermName("x")) defined by res0  in <console>:14:21
+<console>:14: free term: Ident(TermName("x")) defined by res0  in <console>:13:21
                 val code = reify {
                                  ^
 2

--- a/test/files/run/reify_newimpl_23.check
+++ b/test/files/run/reify_newimpl_23.check
@@ -16,7 +16,7 @@ scala> def foo[T]{
   }
   println(code.eval)
 }
-<console>:13: free type: Ident(TypeName("T")) defined by foo in <console>:12:16
+<console>:12: free type: Ident(TypeName("T")) defined by foo in <console>:11:16
          val code = reify {
                           ^
 foo: [T]=> Unit

--- a/test/files/run/reify_newimpl_25.check
+++ b/test/files/run/reify_newimpl_25.check
@@ -7,7 +7,7 @@ scala> {
   val tt = implicitly[TypeTag[x.type]]
   println(tt)
 }
-<console>:11: free term: Ident(TermName("x")) defined by res0  in <console>:10:21
+<console>:10: free term: Ident(TermName("x")) defined by res0  in <console>:9:21
                 val tt = implicitly[TypeTag[x.type]]
                                    ^
 TypeTag[x.type]

--- a/test/files/run/reify_newimpl_26.check
+++ b/test/files/run/reify_newimpl_26.check
@@ -6,7 +6,7 @@ scala> def foo[T]{
   val tt = implicitly[WeakTypeTag[List[T]]]
   println(tt)
 }
-<console>:9: free type: Ident(TypeName("T")) defined by foo in <console>:7:16
+<console>:8: free type: Ident(TypeName("T")) defined by foo in <console>:6:16
          val tt = implicitly[WeakTypeTag[List[T]]]
                             ^
 foo: [T]=> Unit

--- a/test/files/run/repl-bare-expr.check
+++ b/test/files/run/repl-bare-expr.check
@@ -2,13 +2,13 @@ Type in expressions to have them evaluated.
 Type :help for more information.
 
 scala> 2 ; 3
-<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:6: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
               2 ;;
               ^
 res0: Int = 3
 
 scala> { 2 ; 3 }
-<console>:8: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
               { 2 ; 3 }
                 ^
 res1: Int = 3
@@ -17,16 +17,16 @@ scala> 5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Mooo
   1 +
   2 +
   3 } ; bippy+88+11
-<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:6: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
               5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
               ^
-<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:6: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
               5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
                   ^
-<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:6: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
               5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
                                          ^
-<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:6: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
               5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
                                                                                                 ^
 defined object Cow

--- a/test/files/run/repl-colon-type.check
+++ b/test/files/run/repl-colon-type.check
@@ -36,12 +36,12 @@ scala> :type lazy val f = 5
 Int
 
 scala> :type protected lazy val f = 5
-<console>:5: error: lazy value f cannot be accessed in object $iw
+<console>:6: error: lazy value f cannot be accessed in object $iw
  Access to protected value f not permitted because
  enclosing object $eval in package $line13 is not a subclass of
- object $iw where target is defined
-  lazy val $result = f
-                                           ^
+ object $iw in object $read where target is defined
+  lazy val $result = { compute ; f }
+                                                   ^
 
 scala> :type def f = 5
 => Int

--- a/test/files/run/repl-out-dir.check
+++ b/test/files/run/repl-out-dir.check
@@ -16,7 +16,6 @@ repl-out-dir-run.obj
         $eval$.class
         $eval.class
         $read$$iw$.class
-        $read$$iw$delayedInit$body.class
         $read$.class
         $read.class
     $line3
@@ -31,7 +30,6 @@ repl-out-dir-run.obj
         $eval$.class
         $eval.class
         $read$$iw$$iw$.class
-        $read$$iw$$iw$delayedInit$body.class
         $read$$iw$.class
         $read$.class
         $read.class
@@ -39,7 +37,6 @@ repl-out-dir-run.obj
         $eval$.class
         $eval.class
         $read$$iw$$iw$.class
-        $read$$iw$$iw$delayedInit$body.class
         $read$$iw$.class
         $read$.class
         $read.class

--- a/test/files/run/repl-out-dir.check
+++ b/test/files/run/repl-out-dir.check
@@ -15,23 +15,23 @@ repl-out-dir-run.obj
     $line2
         $eval$.class
         $eval.class
-        $read$$iw$$iw$.class
         $read$$iw$.class
+        $read$$iw$delayedInit$body.class
         $read$.class
         $read.class
     $line3
         $eval$.class
         $eval.class
-        $read$$iw$$iw$.class
-        $read$$iw$$iw$Bippy$.class
-        $read$$iw$$iw$Bippy.class
         $read$$iw$.class
+        $read$$iw$Bippy$.class
+        $read$$iw$Bippy.class
         $read$.class
         $read.class
     $line4
         $eval$.class
         $eval.class
         $read$$iw$$iw$.class
+        $read$$iw$$iw$delayedInit$body.class
         $read$$iw$.class
         $read$.class
         $read.class
@@ -39,6 +39,7 @@ repl-out-dir-run.obj
         $eval$.class
         $eval.class
         $read$$iw$$iw$.class
+        $read$$iw$$iw$delayedInit$body.class
         $read$$iw$.class
         $read$.class
         $read.class

--- a/test/files/run/repl-parens.check
+++ b/test/files/run/repl-parens.check
@@ -20,10 +20,10 @@ scala>   (  (2 + 2 )  )
 res5: Int = 4
 
 scala> 5 ;   (  (2 + 2 )  ) ; ((5))
-<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:6: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
               5 ;   (  (2 + 2 )  ) ;;
               ^
-<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:6: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
               5 ;   (  (2 + 2 )  ) ;;
                           ^
 res6: Int = 5
@@ -40,16 +40,16 @@ res9: String = 4423
 scala> 
 
 scala> 55 ; ((2 + 2)) ; (1, 2, 3)
-<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:6: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
               55 ; ((2 + 2)) ;;
               ^
-<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:6: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
               55 ; ((2 + 2)) ;;
                        ^
 res10: (Int, Int, Int) = (1,2,3)
 
 scala> 55 ; (x: Int) => x + 1 ; () => ((5))
-<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:6: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
               55 ; (x: Int) => x + 1 ;;
               ^
 res11: () => Int = <function0>
@@ -60,7 +60,7 @@ scala> () => 5
 res12: () => Int = <function0>
 
 scala> 55 ; () => 5
-<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:6: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
               55 ;;
               ^
 res13: () => Int = <function0>

--- a/test/files/run/repl-paste-2.check
+++ b/test/files/run/repl-paste-2.check
@@ -44,7 +44,7 @@ scala> res5 + res6
 res1: Int = 690
 
 scala> val x = dingus
-<console>:7: error: not found: value dingus
+<console>:6: error: not found: value dingus
        val x = dingus
                ^
 

--- a/test/files/run/repl-reset.check
+++ b/test/files/run/repl-reset.check
@@ -30,13 +30,13 @@ Forgetting all expression results and named terms: $intp, BippyBungus, x1, x2, x
 Forgetting defined types: BippyBungus
 
 scala> x1 + x2 + x3
-<console>:8: error: not found: value x1
+<console>:7: error: not found: value x1
               x1 + x2 + x3
               ^
-<console>:8: error: not found: value x2
+<console>:7: error: not found: value x2
               x1 + x2 + x3
                    ^
-<console>:8: error: not found: value x3
+<console>:7: error: not found: value x3
               x1 + x2 + x3
                         ^
 
@@ -44,7 +44,7 @@ scala> val x1 = 4
 x1: Int = 4
 
 scala> new BippyBungus
-<console>:8: error: not found: type BippyBungus
+<console>:7: error: not found: type BippyBungus
               new BippyBungus
                   ^
 

--- a/test/files/run/repl-trim-stack-trace.scala
+++ b/test/files/run/repl-trim-stack-trace.scala
@@ -13,24 +13,24 @@ f: Nothing
 
 scala> f
 java.lang.Exception: Uh-oh
-  at .f(<console>:7)
-  ... 69 elided
+  at .f(<console>:6)
+  ... 42 elided
 
 scala> def f = throw new Exception("")
 f: Nothing
 
 scala> f
 java.lang.Exception:
-  at .f(<console>:7)
-  ... 69 elided
+  at .f(<console>:6)
+  ... 42 elided
 
 scala> def f = throw new Exception
 f: Nothing
 
 scala> f
 java.lang.Exception
-  at .f(<console>:7)
-  ... 69 elided
+  at .f(<console>:6)
+  ... 42 elided
 
 scala> :quit"""
 

--- a/test/files/run/t5256d.check
+++ b/test/files/run/t5256d.check
@@ -17,7 +17,7 @@ scala> println(c)
 class A
 
 scala> println(c.fullName)
-$line8.$read.$iw.$iw.$iw.$iw.A
+$line8.$read.$iw.$iw.$iw.A
 
 scala> println(c.info)
 scala.AnyRef {

--- a/test/files/run/t7747-repl.check
+++ b/test/files/run/t7747-repl.check
@@ -17,13 +17,13 @@ scala> val z = x * y
 z: Int = 156
 
 scala> 2 ; 3
-<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:6: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
               2 ;;
               ^
 res0: Int = 3
 
 scala> { 2 ; 3 }
-<console>:8: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
               { 2 ; 3 }
                 ^
 res1: Int = 3
@@ -32,16 +32,16 @@ scala> 5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Mooo
   1 +
   2 +
   3 } ; bippy+88+11
-<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:6: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
               5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
               ^
-<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:6: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
               5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
                   ^
-<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:6: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
               5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
                                          ^
-<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:6: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
               5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
                                                                                                 ^
 defined object Cow
@@ -83,10 +83,10 @@ scala>   (  (2 + 2 )  )
 res10: Int = 4
 
 scala> 5 ;   (  (2 + 2 )  ) ; ((5))
-<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:6: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
               5 ;   (  (2 + 2 )  ) ;;
               ^
-<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:6: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
               5 ;   (  (2 + 2 )  ) ;;
                           ^
 res11: Int = 5
@@ -103,10 +103,10 @@ res14: String = 4423
 scala> 
 
 scala> 55 ; ((2 + 2)) ; (1, 2, 3)
-<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:6: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
               55 ; ((2 + 2)) ;;
               ^
-<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:6: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
               55 ; ((2 + 2)) ;;
                        ^
 res15: (Int, Int, Int) = (1,2,3)
@@ -123,7 +123,7 @@ scala> () => 5
 res17: () => Int = <function0>
 
 scala> 55 ; () => 5
-<console>:7: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:6: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
               55 ;;
               ^
 res18: () => Int = <function0>
@@ -211,13 +211,13 @@ Forgetting all expression results and named terms: $intp, BippyBungus, Bovine, C
 Forgetting defined types: BippyBungus, Moo, Ruminant
 
 scala> x1 + x2 + x3
-<console>:8: error: not found: value x1
+<console>:7: error: not found: value x1
               x1 + x2 + x3
               ^
-<console>:8: error: not found: value x2
+<console>:7: error: not found: value x2
               x1 + x2 + x3
                    ^
-<console>:8: error: not found: value x3
+<console>:7: error: not found: value x3
               x1 + x2 + x3
                         ^
 
@@ -225,7 +225,7 @@ scala> val x1 = 4
 x1: Int = 4
 
 scala> new BippyBungus
-<console>:8: error: not found: type BippyBungus
+<console>:7: error: not found: type BippyBungus
               new BippyBungus
                   ^
 
@@ -258,12 +258,12 @@ class $read extends Serializable {
       super.<init>;
       ()
     };
-    import $line44.$read.$iw.$iw.BippyBups;
-    import $line44.$read.$iw.$iw.BippyBups;
-    import $line45.$read.$iw.$iw.PuppyPups;
-    import $line45.$read.$iw.$iw.PuppyPups;
-    import $line46.$read.$iw.$iw.Bingo;
-    import $line46.$read.$iw.$iw.Bingo;
+    import $line44.$read.$iw.BippyBups;
+    import $line44.$read.$iw.BippyBups;
+    import $line45.$read.$iw.PuppyPups;
+    import $line45.$read.$iw.PuppyPups;
+    import $line46.$read.$iw.Bingo;
+    import $line46.$read.$iw.Bingo;
     class $iw extends Serializable {
       def <init>() = {
         super.<init>;

--- a/test/files/run/t8843-repl-xlat.scala
+++ b/test/files/run/t8843-repl-xlat.scala
@@ -14,10 +14,10 @@ scala> class Bippy
 defined class Bippy
 
 scala> $intp.classLoader getResource "Bippy.class"
-res0: java.net.URL = memory:(memory)/$line4/$read$$iw$$iw$Bippy.class
+res0: java.net.URL = memory:(memory)/$line4/$read$$iw$Bippy.class
 
 scala> ($intp.classLoader getResources "Bippy.class").nextElement
-res1: java.net.URL = memory:(memory)/$line4/$read$$iw$$iw$Bippy.class
+res1: java.net.URL = memory:(memory)/$line4/$read$$iw$Bippy.class
 
 scala> ($intp.classLoader classBytes "Bippy").nonEmpty
 res2: Boolean = true

--- a/test/files/run/t8935-app.scala
+++ b/test/files/run/t8935-app.scala
@@ -1,0 +1,32 @@
+import scala.tools.partest.SessionTest
+
+import scala.tools.nsc.Settings
+
+object Test extends SessionTest {
+  override def transformSettings(s: Settings): Settings = {
+    s.YreplWrap.value = "app"
+    s
+  }
+  def session =
+ """|Type in expressions to have them evaluated.
+    |Type :help for more information.
+    |
+    |scala> 42
+    |res0: Int = 42
+    |
+    |scala> $intp.valueOfTerm($intp.mostRecentVar)
+    |res1: Option[Any] = Some(42)
+    |
+    |scala> val i = 17 ; 64
+    |i: Int = 17
+    |res2: Int = 64
+    |
+    |scala> $intp.valueOfTerm($intp.mostRecentVar)
+    |res3: Option[Any] = Some(64)
+    |
+    |scala> $intp.valueOfTerm("i")
+    |res4: Option[Any] = Some(17)
+    |
+    |scala> :quit
+ """.stripMargin.trim
+}

--- a/test/files/run/t8935-object.scala
+++ b/test/files/run/t8935-object.scala
@@ -1,0 +1,32 @@
+import scala.tools.partest.SessionTest
+
+import scala.tools.nsc.Settings
+
+object Test extends SessionTest {
+  override def transformSettings(s: Settings): Settings = {
+    s.YreplWrap.value = "object"
+    s
+  }
+  def session =
+ """|Type in expressions to have them evaluated.
+    |Type :help for more information.
+    |
+    |scala> 42
+    |res0: Int = 42
+    |
+    |scala> $intp.valueOfTerm($intp.mostRecentVar)
+    |res1: Option[Any] = Some(42)
+    |
+    |scala> val i = 17 ; 64
+    |i: Int = 17
+    |res2: Int = 64
+    |
+    |scala> $intp.valueOfTerm($intp.mostRecentVar)
+    |res3: Option[Any] = Some(64)
+    |
+    |scala> $intp.valueOfTerm("i")
+    |res4: Option[Any] = Some(17)
+    |
+    |scala> :quit
+ """.stripMargin.trim
+}

--- a/test/files/run/t9076.scala
+++ b/test/files/run/t9076.scala
@@ -1,5 +1,7 @@
 import scala.tools.partest.SessionTest
 
+import scala.tools.nsc.Settings
+
 object Test extends SessionTest {
   /* avoid objects that don't override toString
   // was: timeout
@@ -8,6 +10,10 @@ object Test extends SessionTest {
     |val y = Future { 9 } ; val z = Future { 7 } ; val r = Await.result(for (a <- y; b <- z) yield (a+b), 5.seconds)
   """.stripMargin
   */
+  override def transformSettings(s: Settings): Settings = {
+    s.YreplWrap.value = "app"
+    s
+  }
   // was: hang
   def session =
 s"""|Type in expressions to have them evaluated.

--- a/test/files/run/t9076.scala
+++ b/test/files/run/t9076.scala
@@ -1,0 +1,22 @@
+import scala.tools.partest.SessionTest
+
+object Test extends SessionTest {
+  /* avoid objects that don't override toString
+  // was: timeout
+  def code = """
+    |import concurrent._,duration._,ExecutionContext.Implicits._
+    |val y = Future { 9 } ; val z = Future { 7 } ; val r = Await.result(for (a <- y; b <- z) yield (a+b), 5.seconds)
+  """.stripMargin
+  */
+  // was: hang
+  def session =
+s"""|Type in expressions to have them evaluated.
+    |Type :help for more information.
+    |
+    |scala> def i = 42 ; List(1, 2, 3).par.map(x => x + i)
+    |i: Int
+    |res0: scala.collection.parallel.immutable.ParSeq[Int] = ParVector(43, 44, 45)
+    |
+    |scala> :quit
+ """.stripMargin.trim
+}

--- a/test/files/run/xMigration.check
+++ b/test/files/run/xMigration.check
@@ -12,7 +12,7 @@ res1: Iterable[String] = MapLike(eis)
 scala> :setting -Xmigration:any
 
 scala> Map(1 -> "eis").values    // warn
-<console>:8: warning: method values in trait MapLike has changed semantics in version 2.8.0:
+<console>:7: warning: method values in trait MapLike has changed semantics in version 2.8.0:
 `values` returns `Iterable[B]` rather than `Iterator[B]`.
               Map(1 -> "eis").values    // warn
                               ^
@@ -26,7 +26,7 @@ res3: Iterable[String] = MapLike(eis)
 scala> :setting -Xmigration:2.7
 
 scala> Map(1 -> "eis").values    // warn
-<console>:8: warning: method values in trait MapLike has changed semantics in version 2.8.0:
+<console>:7: warning: method values in trait MapLike has changed semantics in version 2.8.0:
 `values` returns `Iterable[B]` rather than `Iterator[B]`.
               Map(1 -> "eis").values    // warn
                               ^
@@ -40,7 +40,7 @@ res5: Iterable[String] = MapLike(eis)
 scala> :setting -Xmigration      // same as :any
 
 scala> Map(1 -> "eis").values    // warn
-<console>:8: warning: method values in trait MapLike has changed semantics in version 2.8.0:
+<console>:7: warning: method values in trait MapLike has changed semantics in version 2.8.0:
 `values` returns `Iterable[B]` rather than `Iterator[B]`.
               Map(1 -> "eis").values    // warn
                               ^


### PR DESCRIPTION
Avoid class initialization traps in the object wrapper by
extending App.

The App object is initialized in the usual place, namely
the print method of the eval object, by invoking main.

```
scala> 42 // show
object $read extends scala.AnyRef {
  def <init>() = {
    super.<init>;
    ()
  };
  object $iw extends App {
    def <init>() = {
      super.<init>;
      ()
    };
    val res0 = 42
  };
}
[[syntax trees at end of                     typer]] // <console>
package $line3 {
  object $read extends scala.AnyRef {
    def <init>(): $line3.$read.type = {
      $read.super.<init>();
      ()
    };
    object $iw extends AnyRef with App {
      def <init>(): type = {
        $iw.super.<init>();
        ()
      };
      private[this] val res0: Int = 42;
      <stable> <accessor> def res0: Int = $iw.this.res0
    }
  }
}

[[syntax trees at end of                     typer]] // <console>
package $line3 {
  object $eval extends scala.AnyRef {
    def <init>(): $line3.$eval.type = {
      $eval.super.<init>();
      ()
    };
    lazy private[this] var $result: Int = _;
    <stable> <accessor> lazy def $result: Int = {
      $eval.this.$result = $line3.$read.$iw.res0;
      $eval.this.$result
    };
    lazy private[this] var $print: String = _;
    <stable> <accessor> lazy def $print: String = {
      $eval.this.$print = {
        $line3.$read.$iw.main(null);
        "res0: Int = ".+(scala.runtime.ScalaRunTime.replStringOf($line3.$read.$iw.res0, 1000))
      };
      $eval.this.$print
    }
  }
}

res0: Int = 42

```
