### PR TITLE
SI-8362: Support for Future without sun.misc.Unsafe.

### DIFF
--- a/bincompat-backward.whitelist.conf
+++ b/bincompat-backward.whitelist.conf
@@ -208,6 +208,11 @@ filter {
     {
         matchName="scala.reflect.io.ZipArchive.scala$reflect$io$ZipArchive$$walkIterator"
         problemName=MissingMethodProblem
-    }
+    },
+    // SI-8362 - package-protected class in an impl package
+    {
+        matchName="scala.concurrent.impl.Promise$DefaultPromise"
+        problemName=MissingTypesProblem
+    } 
   ]
 }

--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -314,6 +314,11 @@ filter {
     {
         matchName="scala.reflect.runtime.Settings#IntSetting.valueSetByUser"
         problemName=MissingMethodProblem
-    }
+    },
+    // see SI-8362 - package-protected class in an impl package
+    {
+        matchName="scala.concurrent.impl.Promise$DefaultPromise"
+        problemName=MissingTypesProblem
+    } 
   ]
 }

--- a/src/library/scala/concurrent/impl/AbstractPromise.java
+++ b/src/library/scala/concurrent/impl/AbstractPromise.java
@@ -9,51 +9,17 @@
 package scala.concurrent.impl;
 
 
-import scala.concurrent.util.Unsafe;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.concurrent.atomic.AtomicReference;
 
 
 
-abstract class AbstractPromise {
-    private volatile Object _ref;
-
-    final static long _refoffset;
-    /*
-     * In a runtime with a security manager installed, or a non-Oracle runtime,
-     * the Unsafe class may be unavailable. In this case, _refoffset will be
-     * set to -1.
-     *
-     * We assume that a valid field offset will be non-negative, and likely a
-     * multiple of 4.
-     */
-    static {
-    	long refoffset = -1;
-	try {
-	    refoffset = Unsafe.instance.objectFieldOffset(AbstractPromise.class.getDeclaredField("_ref"));
-	} catch (Throwable t) {
-	    /* Unsafe object instance access failed */
-	}
-	_refoffset = refoffset;
-    }
+abstract class AbstractPromise extends AtomicReference<Object> {
     
-    /*
-     * The Hotspot compiler can identify that the value of _refoffset never
-     * changes, and compile only the branch below that is used. When the Unsafe
-     * object is available, the compare-and-swap operation will be inlined
-     * directly into *this* method's caller.
-     */
     protected final boolean updateState(Object oldState, Object newState) {
-    	if (_refoffset == -1) {
-	    return updater.compareAndSet(this, oldState, newState);
-	} else {
-	    return Unsafe.instance.compareAndSwapObject(this, _refoffset, oldState, newState);
-	}
+        return compareAndSet(oldState, newState);
     }
 
     protected final Object getState() {
-	return _ref;
+        return get();
     }
-
-    protected final static AtomicReferenceFieldUpdater<AbstractPromise, Object> updater =
-	AtomicReferenceFieldUpdater.newUpdater(AbstractPromise.class, Object.class, "_ref");
 }


### PR DESCRIPTION
Since the  [work](https://github.com/scala/scala/pull/454/files) on `Future` performances, `AbstractPromise` is using `Unsafe` breaking the ability for `Future` to be executed on GAE.
At that time, @viktorklang [suggested to implement a fallback](https://github.com/scala/scala/pull/454#issuecomment-36927964) in case `Unsafe` is not available.
@carey [proposed an implementation](https://github.com/carey/scala/commit/72e1927793c6dc808d9896e5571a97f136fd1a4e), but as far as I know he never created a pull request for it, so there it is.

Please comment if some improvement or changes are needed, so I could try to improve. 

See [SI-8362](https://issues.scala-lang.org/browse/SI-8362) for more details.
