### PR TITLE
SI-9143 Avoid edge case in BigDecimal factory

### DIFF
--- a/src/library/scala/math/BigDecimal.scala
+++ b/src/library/scala/math/BigDecimal.scala
@@ -122,7 +122,18 @@ object BigDecimal {
   /** Constructs a `BigDecimal` that exactly represents the number
    *  specified in a `String`.
    */
-  def exact(s: String): BigDecimal = exact(new BigDec(s))
+  def exact(s: String): BigDecimal =
+    try exact(new BigDec(s))
+    catch {
+      // if it fails because exp is MinValue, construct by hand.
+      // BigDec throws for reasons of backward compatibility.
+      case e: NumberFormatException if s endsWith "+2147483648" =>
+        val r = """(\+|-)?(\d+)(\.\d+)?(e|E)\+2147483648""".r
+        s match {
+          case r(_*) => exact(new BigDec(s.init + "7").scaleByPowerOfTen(1))
+          case _     => throw e
+        }
+    }
   
   /** Constructs a 'BigDecimal` that exactly represents the number
    *  specified in base 10 in a character array.

--- a/test/junit/scala/math/BigDecimalTest.scala
+++ b/test/junit/scala/math/BigDecimalTest.scala
@@ -3,7 +3,8 @@ package scala.math
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.junit.Test
-import java.math.{BigDecimal => BD, MathContext => MC}
+import org.junit.Assert._
+import java.math.{BigDecimal => BD, BigInteger => BI, MathContext => MC}
 
 /* Tests various maps by making sure they all agree on the same answers. */
 @RunWith(classOf[JUnit4])
@@ -227,5 +228,9 @@ class BigDecimalTest {
   @Test
   def test_SI8970() {
     assert((0.1).## == BigDecimal(0.1).##)
+  }
+  @Test def `string factory accepts exp at MinValue`(): Unit = {
+    assertEquals(new math.BigDecimal(new BD(BI.ZERO, Int.MinValue, MC.UNLIMITED)), math.BigDecimal("0E+2147483648"))
+    assertEquals(new math.BigDecimal(new BD(BI.ZERO, Int.MinValue, MC.UNLIMITED)).toString, math.BigDecimal("0E+2147483648").toString)
   }
 }


### PR DESCRIPTION
The Java factory fails on MinValue exponent, as defined,

```
"0E+2147483648"
```

The JDK source says

```
// Next test is required for backwards compatibility
```

which suggests that Scala could handle it gracefully.

Where grace == I don't give a flying backwards compatibility.

The issue was whether ScalaCheck is free to generate values
that can't be reconstituted via the string factory.

http://stackoverflow.com/questions/28461403/scala-bigdecimal-fails-to-translate-a-decimal-string-representation-created-by-i/28461644

Review by @Ichoran 
