### PR TITLE
SI-9148: Appends companion type to link tooltips

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/HtmlPage.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/HtmlPage.scala
@@ -227,6 +227,18 @@ abstract class HtmlPage extends Page { thisPage =>
         <img src={ relativeLinkTo(List("permalink.png", "lib")) } />
       </a>
     </span>
+	
+  def docEntityKindToCompanionTitle(ety: DocTemplateEntity, baseString: String = "See companion") = 
+    ety.companion match{
+	  case Some(companion) => 
+	    s"$baseString${
+		if(companion.isObject) " object"
+		else if(companion.isTrait) " trait"
+		else if(companion.isClass) " class"
+		else ""
+		}"
+	  case None => baseString
+	}
 
   def companionAndPackage(tpl: DocTemplateEntity): Elem =
     <span class="morelinks">{
@@ -238,7 +250,7 @@ abstract class HtmlPage extends Page { thisPage =>
             else s"class ${companionTpl.name}"
           <div>
             Related Docs:
-            <a href={relativeLinkTo(tpl.companion.get)} title="See companion">{objClassTrait}</a>
+            <a href={relativeLinkTo(tpl.companion.get)} title={docEntityKindToCompanionTitle(tpl)}>{objClassTrait}</a>
             | {templateToHtml(tpl.inTemplate, s"package ${tpl.inTemplate.name}")}
           </div>
         case None =>

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
@@ -89,7 +89,7 @@ class Template(universe: doc.Universe, generator: DiagramGenerator, tpl: DocTemp
     val templateName = if (tpl.isRootPackage) "root package" else tpl.name
     val displayName = tpl.companion match {
       case Some(companion) if (companion.visibility.isPublic && companion.inSource != None) =>
-        <a href={relativeLinkTo(companion)} title="Go to companion">{ templateName }</a>
+        <a href={relativeLinkTo(companion)} title={docEntityKindToCompanionTitle(tpl)}>{ templateName }</a>
       case _ =>
         templateName
     }
@@ -105,7 +105,7 @@ class Template(universe: doc.Universe, generator: DiagramGenerator, tpl: DocTemp
         {
           tpl.companion match {
             case Some(companion) if (companion.visibility.isPublic && companion.inSource != None) =>
-              <a href={relativeLinkTo(companion)} title="Go to companion"><img src={ relativeLinkTo(List(docEntityKindToBigImage(tpl), "lib")) }/></a>
+              <a href={relativeLinkTo(companion)} title={docEntityKindToCompanionTitle(tpl)}><img src={ relativeLinkTo(List(docEntityKindToBigImage(tpl), "lib")) }/></a>
             case _ =>
               <img src={ relativeLinkTo(List(docEntityKindToBigImage(tpl), "lib")) }/>
         }}


### PR DESCRIPTION
This is a simple change to get started towards contributing more often. It simply enhances Dick's previous change of explicit companion links and appends to the tooltip the type of companion that is linked.

Review by @dickwall 
