### PR TITLE
SI-9059 Random.alphanumeric is inefficient

### DIFF
--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -314,6 +314,11 @@ filter {
     {
         matchName="scala.reflect.runtime.Settings#IntSetting.valueSetByUser"
         problemName=MissingMethodProblem
+    },
+    // SI-9059
+    {
+        matchName="scala.util.Random.scala$util$Random$$nextAlphaNum$1"
+        problemName=MissingMethodProblem
     }
   ]
 }

--- a/src/library/scala/util/Random.scala
+++ b/src/library/scala/util/Random.scala
@@ -121,15 +121,21 @@ class Random(val self: java.util.Random) extends AnyRef with Serializable {
     (bf(xs) ++= buf).result()
   }
 
+  @deprecated("Preserved for backwards binary compatibility. To remove in 2.12.x.", "2.11.6")
+  final def `scala$util$Random$$isAlphaNum$1`(c: Char) = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')
+
   /** Returns a Stream of pseudorandomly chosen alphanumeric characters,
    *  equally chosen from A-Z, a-z, and 0-9.
    *
    *  @since 2.8
    */
   def alphanumeric: Stream[Char] = {
-    def isAlphaNum(c: Char) = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')
+    def nextAlphaNum: Char = {
+      val chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+      chars charAt (self nextInt chars.length)
+    }
 
-    Stream continually nextPrintableChar filter isAlphaNum
+    Stream continually nextAlphaNum
   }
 
 }

--- a/test/junit/scala/util/RandomTest.scala
+++ b/test/junit/scala/util/RandomTest.scala
@@ -1,0 +1,15 @@
+package scala.util
+
+import org.junit.{ Assert, Test }
+
+class RandomTest {
+  // Test for SI-9059
+  @Test def testAlphanumeric: Unit = {
+    def isAlphaNum(c: Char) = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')
+
+    val items = Random.alphanumeric.take(100000)
+    for (c <- items) {
+      Assert.assertTrue(s"$c should be alphanumeric", isAlphaNum(c))
+    }
+  }
+}


### PR DESCRIPTION
[Rework of #4230 to preserve backwards compatibility.]

Generate alphanumeric values by taking random element of string
containing all alphanumerics.

Instead of generating nextPrintableChar then filtering for
alphanumerics, we can just take from a string containing all
alphanumerics. This provides a significant performance improvement.

Original implementation by: Keith Wansbrough
I just timed it and tested it.

Thyme results to generate 1 million chars:
Benchmark comparison (in 41.99 s): alphanumeric, nextPrintableChar vs const with nextInt
Significantly different (p ~= 0)
Time ratio: 0.36143 95% CI 0.33998 - 0.38288 (n=20)
First 253.6 ms 95% CI 248.5 ms - 258.7 ms
Second 91.67 ms 95% CI 86.55 ms - 96.78 ms
