### PR TITLE
Simpler & Scala.js-friendly `ClassTag.unapply`

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1445,15 +1445,7 @@ TODO:
     <stopwatch name="quick.sbt-interface.timer" action="total"/>
   </target>
 
-  <target name="test.junit.init" depends="quick.done">
-    <uptodate property="test.junit.available" targetfile="${build-junit.dir}/test-compile.complete">
-      <srcfiles dir="${test.junit.src}">
-        <include name="**/*.scala"/>
-      </srcfiles>
-    </uptodate>
-  </target>
-
-  <target name="test.junit.comp" depends="test.junit.init, quick.done" unless="test.junit.available">
+  <target name="test.junit.comp" depends="pack.done">
     <stopwatch name="test.junit.compiler.timer"/>
     <mkdir dir="${test.junit.classes}"/>
     <scalacfork
@@ -1469,7 +1461,7 @@ TODO:
     <stopwatch name="test.junit.compiler.timer" action="total"/>
   </target>
 
-  <target name="test.junit" depends="test.junit.comp, test.junit.init">
+  <target name="test.junit" depends="test.junit.comp">
     <stopwatch name="test.junit.timer"/>
     <mkdir dir="${test.junit.classes}"/>
     <echo message="Note: details of failed tests will be output to ${build-junit.dir}"/>

--- a/src/library/scala/reflect/ClassTag.scala
+++ b/src/library/scala/reflect/ClassTag.scala
@@ -94,9 +94,9 @@ trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serial
   def unapply(x: Double)  : Option[T] = unapplyImpl(x, classOf[Double])
   def unapply(x: Boolean) : Option[T] = unapplyImpl(x, classOf[Boolean])
   def unapply(x: Unit)    : Option[T] = unapplyImpl(x, classOf[Unit])
-  
+
   private[this] def unapplyImpl(x: Any, alternative: jClass[_] = null): Option[T] = {
-    val conforms = runtimeClass.isAssignableFrom(x.getClass) || (alternative != null && runtimeClass.isAssignableFrom(alternative))
+    val conforms = runtimeClass.isInstance(x) || (alternative != null && runtimeClass.isAssignableFrom(alternative))
     if (conforms) Some(x.asInstanceOf[T]) else None
   }
 

--- a/src/library/scala/reflect/ClassTag.scala
+++ b/src/library/scala/reflect/ClassTag.scala
@@ -69,21 +69,20 @@ trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serial
    * `SomeExtractor(...)` is turned into `ct(SomeExtractor(...))` if `T` in `SomeExtractor.unapply(x: T)`
    * is uncheckable, but we have an instance of `ClassTag[T]`.
    */
-  def unapply(x: Any): Option[T] = x match {
-    case null       => None
-    case x: Byte    => unapplyImpl(x, classOf[Byte]) // erases to: if (x instanceof Byte) unapplyImpl(BoxesRunTime.boxToByte(BoxesRunTime.unboxToByte(x)), Byte.TYPE)
-    case x: Short   => unapplyImpl(x, classOf[Short])
-    case x: Char    => unapplyImpl(x, classOf[Char])
-    case x: Int     => unapplyImpl(x, classOf[Int])
-    case x: Long    => unapplyImpl(x, classOf[Long])
-    case x: Float   => unapplyImpl(x, classOf[Float])
-    case x: Double  => unapplyImpl(x, classOf[Double])
-    case x: Boolean => unapplyImpl(x, classOf[Boolean])
-    case x: Unit    => unapplyImpl(x, classOf[Unit])
-    // TODO: move this next case up and remove the redundant check in unapplyImpl?
-    case _ if runtimeClass isInstance x => Some(x.asInstanceOf[T])
-    case _ => None
-  }
+  def unapply(x: Any): Option[T] =
+    if (null != x && (
+            (runtimeClass.isInstance(x))
+         || (x.isInstanceOf[Byte]    && runtimeClass.isAssignableFrom(classOf[Byte]))
+         || (x.isInstanceOf[Short]   && runtimeClass.isAssignableFrom(classOf[Short]))
+         || (x.isInstanceOf[Char]    && runtimeClass.isAssignableFrom(classOf[Char]))
+         || (x.isInstanceOf[Int]     && runtimeClass.isAssignableFrom(classOf[Int]))
+         || (x.isInstanceOf[Long]    && runtimeClass.isAssignableFrom(classOf[Long]))
+         || (x.isInstanceOf[Float]   && runtimeClass.isAssignableFrom(classOf[Float]))
+         || (x.isInstanceOf[Double]  && runtimeClass.isAssignableFrom(classOf[Double]))
+         || (x.isInstanceOf[Boolean] && runtimeClass.isAssignableFrom(classOf[Boolean]))
+         || (x.isInstanceOf[Unit]    && runtimeClass.isAssignableFrom(classOf[Unit])))
+       ) Some(x.asInstanceOf[T])
+    else None
 
   // TODO: deprecate overloads in 2.12.0, remove in 2.13.0
   def unapply(x: Byte)    : Option[T] = unapplyImpl(x, classOf[Byte])

--- a/test/junit/scala/reflect/ClassTag.scala
+++ b/test/junit/scala/reflect/ClassTag.scala
@@ -1,0 +1,29 @@
+package scala.reflect
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.tools.testing.AssertUtil._
+
+class Misc
+
+@RunWith(classOf[JUnit4])
+class ClassTagTest {
+  def checkNotString[A: ClassTag](a: Any)  = a match { case x: String  => false case x: A => true case _ => false }
+  def checkNotInt[A: ClassTag](a: Any)  = a match { case x: Int  => false case x: A => true case _ => false }
+  def checkNotLong[A: ClassTag](a: Any) = a match { case x: Long => false case x: A => true case _ => false }
+
+  @Test def checkMisc    = assertTrue(checkNotString[Misc](new Misc))
+  @Test def checkString  = assertTrue(checkNotInt[String] ("woele"))
+  @Test def checkByte    = assertTrue(checkNotInt[Byte]   (0.toByte))
+  @Test def checkShort   = assertTrue(checkNotInt[Short]  (0.toShort))
+  @Test def checkChar    = assertTrue(checkNotInt[Char]   (0.toChar))
+  @Test def checkInt     = assertTrue(checkNotLong[Int]   (0.toInt))
+  @Test def checkLong    = assertTrue(checkNotInt[Long]   (0.toLong))
+  @Test def checkFloat   = assertTrue(checkNotInt[Float]  (0.toFloat))
+  @Test def checkDouble  = assertTrue(checkNotInt[Double] (0.toDouble))
+  @Test def checkBoolean = assertTrue(checkNotInt[Boolean](false))
+  @Test def checkUnit    = assertTrue(checkNotInt[Unit]   ({}))
+}


### PR DESCRIPTION
Follow up to #4235
- use `j.l.Class.isInstance` for Scala.js, so that `unapply`
  works correctly when referencing raw JavaScript classes (patch by @sjrd)
- inline overloaded calls to `unapply`, so we can get rid of them in 2.13

Review by @retronym, @som-snytt (lunch break permitting)
