### PR TITLE
SI-8917  collection.mutable.BitSet's &= operator doesn't clear end

### DIFF
--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -121,8 +121,10 @@ class BitSet(protected final var elems: Array[Long]) extends AbstractSet[Int]
    *  @return  the bitset itself.
    */
   def &= (other: BitSet): this.type = {
-    ensureCapacity(other.nwords - 1)
-    for (i <- 0 until other.nwords)
+    // Different from other operations: no need to ensure capacity because
+    // anything beyond the capacity is 0.  Since we use other.word which is 0
+    // off the end, we also don't need to make sure we stay in bounds there.
+    for (i <- 0 until nwords)
       elems(i) = elems(i) & other.word(i)
     this
   }

--- a/test/junit/scala/collection/mutable/BitSetTest.scala
+++ b/test/junit/scala/collection/mutable/BitSetTest.scala
@@ -19,4 +19,13 @@ class BitSetTest {
     bitSet &~= bitSet
     assert(bitSet.toBitMask.length == size, "Capacity of bitset changed after &~=")
   }
+  
+  @Test def test_SI8917() {
+    val bigBitSet = BitSet(1, 100, 10000)
+    val littleBitSet = BitSet(100)
+    bigBitSet &= littleBitSet
+    assert(!(bigBitSet contains 10000), "&= not applied to the full bitset")
+    littleBitSet &= bigBitSet
+    assert(littleBitSet.toBitMask.length < bigBitSet.toBitMask.length, "Needlessly extended the size of bitset on &=")
+  }
 }


### PR DESCRIPTION
Made &= run to the end of its own bitset, ignoring the size of what it's &-ing with (which is exactly what you want for &=).
