### PR TITLE
SI-5887: Can try any expression

### DIFF
--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -11,7 +11,7 @@ Expr         ::=  (Bindings | id | `_') `=>' Expr
                |  Expr1
 Expr1        ::=  `if' `(' Expr `)' {nl} Expr [[semi] `else' Expr]
                |  `while' `(' Expr `)' {nl} Expr
-               |  `try' (`{' Block `}' | Expr) [`catch' `{' CaseClauses `}'] [`finally' Expr]
+               |  `try' Expr [`catch' Expr] [`finally' Expr]
                |  `do' Expr [semi] `while' `(' Expr ')'
                |  `for' (`(' Enumerators `)' | `{' Enumerators `}') {nl} [`yield'] Expr
                |  `throw' Expr
@@ -1122,7 +1122,7 @@ is `scala.Nothing`.
 ## Try Expressions
 
 ```ebnf
-Expr1 ::=  `try' `{' Block `}' [`catch' `{' CaseClauses `}']
+Expr1 ::=  `try'  Expr  [`catch' Expr]
            [`finally' Expr]
 ```
 

--- a/spec/13-syntax-summary.md
+++ b/spec/13-syntax-summary.md
@@ -126,7 +126,7 @@ grammar.
                       |  Expr1
   Expr1             ::=  `if' `(' Expr `)' {nl} Expr [[semi] `else' Expr]
                       |  `while' `(' Expr `)' {nl} Expr
-                      |  `try' (`{' Block `}' | Expr) [`catch' `{' CaseClauses `}'] [`finally' Expr]
+                      |  `try' Expr [`catch' Expr] [`finally' Expr]
                       |  `do' Expr [semi] `while' `(' Expr ')'
                       |  `for' (`(' Enumerators `)' | `{' Enumerators `}') {nl} [`yield'] Expr
                       |  `throw' Expr

--- a/test/files/neg/t5887.check
+++ b/test/files/neg/t5887.check
@@ -1,0 +1,21 @@
+t5887.scala:6: error: type mismatch;
+ found   : Int(22)
+ required: PartialFunction[Throwable,?]
+  def f = try ??? catch 22
+                        ^
+t5887.scala:8: warning: A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.
+  def g = try 42
+          ^
+t5887.scala:10: error: missing parameter type for expanded function
+The argument types of an anonymous function must be fully known. (SLS 8.5)
+Expected type was: ?
+  def h = List("x") map (s => try { case _ => 7 })
+                                  ^
+t5887.scala:10: warning: A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.
+  def h = List("x") map (s => try { case _ => 7 })
+                              ^
+t5887.scala:10: error: Cannot construct a collection of type That with elements of type <error> => Int based on a collection of type List[String].
+  def h = List("x") map (s => try { case _ => 7 })
+                    ^
+two warnings found
+three errors found

--- a/test/files/neg/t5887.scala
+++ b/test/files/neg/t5887.scala
@@ -1,0 +1,11 @@
+
+trait TheOldCollegeTry {
+
+  // was: value isDefinedAt is not a member of Int
+  // now: required: PartialFunction[Throwable,?]
+  def f = try ??? catch 22
+
+  def g = try 42
+
+  def h = List("x") map (s => try { case _ => 7 })
+}

--- a/test/files/pos/t5887.scala
+++ b/test/files/pos/t5887.scala
@@ -1,0 +1,17 @@
+
+trait TheOldCollegeTry {
+  def f = try (1) + 1 finally ()
+
+  def g = try { 1 } + 1 finally ()
+
+  type H[A] = PartialFunction[Throwable, A]
+
+  val myh: H[Int] = { case _: NullPointerException => ??? ; case t => 42 }
+  def h = try ??? catch myh finally ()
+
+  // a little weird
+  def pf: H[Nothing] = try { case _: Throwable => ??? } finally ()
+
+  // but not weirder than
+  def tf = try (t: Throwable) => throw t finally ()
+}


### PR DESCRIPTION
Previously, parsing `try` was special-cased for expressions
beginning with paren or brace. Perhaps that was to avoid odd
sights such as `try (1,2,3)` or `try { case _ => }`, but it
also broke `try { 1 } + 1 finally ()`.

This commit takes an arbitrary expression to `try`.

It also takes an arbitrary expression for `catch`. But for
improved type safety, the expression is required to conform
to `PartialFunction[Throwable, ?]`. The previous transform
was named-based. In addition, this commit invokes `applyOrElse`.

Previously:

```
scala> try 42 catch new {
     | def isDefinedAt(x: Any) = false
     | def apply(x: Any) = ()
     | }
warning: there was one feature warning; re-run with -feature for details
res0: AnyVal = 42

scala> try 42 catch 22
<console>:8: error: value isDefinedAt is not a member of Int
              try 42 catch 22
                           ^
```

Now:

```
scala> try 42 catch new {
     | def isDefinedAt(x: Any) = false
     | def apply(x: Any) = ()
     | }
<console>:8: error: type mismatch;
 found   : AnyRef{}
 required: PartialFunction[Throwable,?]
              try 42 catch new {
                           ^

scala> try 42 catch 22
<console>:8: error: type mismatch;
 found   : Int(22)
 required: PartialFunction[Throwable,?]
              try 42 catch 22
                           ^
```
