### PR TITLE
SI-4959 - UNIX bin scripts now work for paths with spaces

### DIFF
--- a/src/compiler/scala/tools/ant/templates/tool-unix.tmpl
+++ b/src/compiler/scala/tools/ant/templates/tool-unix.tmpl
@@ -109,9 +109,6 @@ if [[ -n "$cygwin" ]]; then
         JAVA_HOME="$(cygpath --$format "$JAVA_HOME")"
     fi
     TOOL_CLASSPATH="$(cygpath --path --$format "$TOOL_CLASSPATH")"
-elif [[ -n "$mingw" ]]; then
-    SCALA_HOME="$(cmd //c echo "$SCALA_HOME")"
-    TOOL_CLASSPATH="$(cmd //c echo "$TOOL_CLASSPATH")"
 fi
 
 if [[ -n "$cygwin$mingw" ]]; then
@@ -130,23 +127,6 @@ fi
 # -D options will be available as system properties.
 declare -a java_args
 declare -a scala_args
-
-# default to the boot classpath for speed, except on cygwin/mingw because
-# JLine on Windows requires a custom DLL to be loaded.
-unset usebootcp
-if [[ -z "$cygwin$mingw" ]]; then
-  usebootcp="true"
-fi
-
-# If using the boot classpath, also pass an empty classpath
-# to java to suppress "." from materializing.
-classpathArgs () {
-  if [[ -n $usebootcp ]]; then
-    echo "-Xbootclasspath/a:$TOOL_CLASSPATH -classpath \"\""
-  else
-    echo "-classpath $TOOL_CLASSPATH"
-  fi
-}
 
 # SI-8358, SI-8368 -- the default should really be false,
 # but I don't want to flip the default during 2.11's RC cycle
@@ -200,6 +180,23 @@ if [[ -z "$JAVACMD" && -n "$JAVA_HOME" && -x "$JAVA_HOME/bin/java" ]]; then
     JAVACMD="$JAVA_HOME/bin/java"
 fi
 
+declare -a classpath_args
+
+# default to the boot classpath for speed, except on cygwin/mingw because
+# JLine on Windows requires a custom DLL to be loaded.
+unset usebootcp
+if [[ -z "$cygwin$mingw" ]]; then
+  usebootcp="true"
+fi
+
+# If using the boot classpath, also pass an empty classpath
+# to java to suppress "." from materializing.
+if [[ -n $usebootcp ]]; then
+  classpath_args=("-Xbootclasspath/a:$TOOL_CLASSPATH" -classpath "\"\"")
+else
+  classpath_args=(-classpath "$TOOL_CLASSPATH")
+fi
+
 # note that variables which may intentionally be empty must not
 # be quoted: otherwise an empty string will appear as a command line
 # argument, and java will think that is the program to run.
@@ -207,7 +204,7 @@ execCommand \
   "${JAVACMD:=java}" \
   $JAVA_OPTS \
   "${java_args[@@]}" \
-  $(classpathArgs) \
+  "${classpath_args[@@]}" \
   -Dscala.home="$SCALA_HOME" \
   $OVERRIDE_USEJAVACP \
   "$EMACS_OPT" \


### PR DESCRIPTION
The bin scripts fsc, scala, scalac, scaladoc, and scalap were not
working when spaces were in the true path of the file (after symbolic
links were resolved). This is now fixed.

The problem affected OS X, Linux, and mingw on Windows. It did not
affect cygwin, because the code was special-cased for cygwin to use
cygpath to convert to short filenames, which eliminates spaces.
It did not affect the Windows command prompt, because that uses a
separate batch file.

The problem was that there was a shell function, classpathArgs, used
to generate the arguments for the classpath. Shell functions can only
return status codes, and emit text which can be captured in a command
substitution. Thus, they can contain strings, but not distinguish
which spaces should be part of a word, and which ones should separate
words.

The solution was to switch to using a bash array, as java_args and
scala_args were already doing. In this way, each element of the array
can contain spaces, but the elements are kept distinct.

There was an additional problem with mingw. There was some code that
used 'cmd //c' to convert the path to Windows format (drive letters
with colons, backslashes and semicolons instead the UNIX-style slashes
with colon separators). It turns out that when there are spaces in the
path, 'cmd //c' adds quotes around the result to protect it. This was
superfluous and actually caused a problem with parsing the first and
last paths in the classpath, leading to trouble in finding jars.
