### PR TITLE
SI-9154 scalac offers extra help on bad option

### DIFF
--- a/src/compiler/scala/tools/nsc/Driver.scala
+++ b/src/compiler/scala/tools/nsc/Driver.scala
@@ -14,7 +14,8 @@ abstract class Driver {
   protected var settings: Settings = _
 
   protected def scalacError(msg: String): Unit = {
-    reporter.error(FakePos("scalac"), msg + "\n  scalac -help  gives more information")
+    val indent = "\u0020" * 2
+    reporter.error(FakePos("scalac"), f"${msg}%n${indent}`scalac -help` gives more information")
   }
 
   protected def processSettingsHook(): Boolean = {


### PR DESCRIPTION
If one of the help settings is on (-help, -X, -Y), then
on a bad option, scalac reports similar options.

For example, I know there's an option for showing things:

```
$ skalac -help -show
scalac error: bad option: '-show'
  Similar options:
  -Xshow-class
  -Xshow-object
  -Xshow-phases
  -Yshow
  -Yshow-member-pos
  -Yshow-symkinds
  -Yshow-symowners
  -Yshow-syms
  -Yshow-trees
  -Yshow-trees-compact
  -Yshow-trees-stringified
  `scalac -help` gives more information
```

The `-debug` option is a little whacky, unfortunately, but this
incantation works:

```
$ skalac -X -Xdebug
scalac error: bad option: '-Xdebug'
  Similar options:
  -Ydebug
  -Ydoc-debug
  -Yide-debug
  -Yinfer-debug
  -Yissue-debug
  -Ymacro-debug-lite
  -Ymacro-debug-verbose
  -Ypatmat-debug
  -Ypos-debug
  -Ypresentation-debug
  -Yquasiquote-debug
  -Yreify-debug
  -Ytyper-debug
  `scalac -help` gives more information
```

This is more mnemonic assistance than help for newbies.
