### PR TITLE
SI-9159 allow usejavacp be set to false in presentation compiler

### DIFF
--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -236,7 +236,7 @@ abstract class PathResolverBase[BaseClassPathType <: ClassFileLookup[AbstractFil
    */
   object Calculated {
     def scalaHome           = Defaults.scalaHome
-    def useJavaClassPath    = settings.usejavacp.value || Defaults.useJavaClassPath
+    def useJavaClassPath    = if (settings.usejavacp.isSetByUser) settings.usejavacp.value else Defaults.useJavaClassPath
     def useManifestClassPath= settings.usemanifestcp.value
     def javaBootClassPath   = cmdLineOrElse("javabootclasspath", Defaults.javaBootClassPath)
     def javaExtDirs         = cmdLineOrElse("javaextdirs", Defaults.javaExtDirs)


### PR DESCRIPTION
If the environment has this property set to true, the value passed to Global is being ignored. Shouldn't it be the other way around?
