### PR TITLE
Fix the Scaladoc tests under Java 8

### DIFF
--- a/test/scaladoc/filters
+++ b/test/scaladoc/filters
@@ -1,0 +1,8 @@
+#
+#Java HotSpot(TM) 64-Bit Server VM warning: Failed to reserve shared memory (errno = 28).
+Java HotSpot\(TM\) .* warning:
+# Hotspot receiving VM options through the $_JAVA_OPTIONS
+# env variable outputs them on stderr
+Picked up _JAVA_OPTIONS:
+# Filter out a message caused by this bug: http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=8021205
+objc\[\d+\]: Class JavaLaunchHelper is implemented in both .* and .*\. One of the two will be used\. Which one is undefined\.


### PR DESCRIPTION
Partest seems to require a second copy of the `filters` find
in the root of the Scaladoc tests.

This file ignores JVM-specific console output, like everone's
favourite nag:

```
Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=256M; support was removed in 8.0
```

Not sure what changed to make this necessary, maybe a partest
upgrade? The first failing build was on Feb 14:

  https://scala-webapps.epfl.ch/jenkins/view/2.N.x/job/scala-nightly-auxjvm-2.11.x/287/

Thanks to @som-snytt for diagnosing this. Review by, drumroll, @som-snytt.
