### PR TITLE
SI-9164 Fix thread safety of Scaladoc diagram generator

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/Universe.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/Universe.scala
@@ -5,6 +5,8 @@
 
 package scala.tools.nsc.doc
 
+import scala.tools.nsc.doc.html.page.diagram.DotRunner
+
 /**
  * Class to hold common dependencies across Scaladoc classes.
  * @author Pedro Furlanetto
@@ -13,4 +15,5 @@ package scala.tools.nsc.doc
 trait Universe {
   def settings: Settings
   def rootPackage: model.Package
+  def dotRunner: DotRunner
 }

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/diagram/DiagramGenerator.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/diagram/DiagramGenerator.scala
@@ -25,29 +25,3 @@ trait DiagramGenerator {
    */
   def generate(d: Diagram, t: DocTemplateEntity, p: HtmlPage):NodeSeq
 }
-
-object DiagramGenerator {
-
-  // TODO: This is tailored towards the dot generator, since it's the only generator. In the future it should be more
-  // general.
-
-  private[this] var dotRunner: DotRunner = null
-  private[this] var settings: doc.Settings = null
-
-  def initialize(s: doc.Settings) =
-    settings = s
-
-  def getDotRunner() = {
-    if (dotRunner == null)
-      dotRunner = new DotRunner(settings)
-    dotRunner
-  }
-
-  def cleanup() = {
-    DiagramStats.printStats(settings)
-    if (dotRunner != null) {
-      dotRunner.cleanup()
-      dotRunner = null
-    }
-  }
-}

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/diagram/DotDiagramGenerator.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/diagram/DotDiagramGenerator.scala
@@ -15,7 +15,7 @@ import scala.collection.immutable._
 import model._
 import model.diagram._
 
-class DotDiagramGenerator(settings: doc.Settings) extends DiagramGenerator {
+class DotDiagramGenerator(settings: doc.Settings, dotRunner: DotRunner) extends DiagramGenerator {
 
   // the page where the diagram will be embedded
   private var page: HtmlPage = null
@@ -317,7 +317,7 @@ class DotDiagramGenerator(settings: doc.Settings) extends DiagramGenerator {
    * Calls dot with a given dot string and returns the SVG output.
    */
   private def generateSVG(dotInput: String, template: DocTemplateEntity) = {
-    val dotOutput = DiagramGenerator.getDotRunner().feedToDot(dotInput, template)
+    val dotOutput = dotRunner.feedToDot(dotInput, template)
     var tSVG = -System.currentTimeMillis
 
     val result = if (dotOutput != null) {

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -9,8 +9,11 @@ import base.comment._
 import diagram._
 
 import scala.collection._
+import scala.tools.nsc.doc.html.HtmlPage
+import scala.tools.nsc.doc.html.page.diagram.{DotRunner}
 import scala.util.matching.Regex
 import scala.reflect.macros.internal.macroImpl
+import scala.xml.NodeSeq
 import symtab.Flags
 
 import io._
@@ -47,6 +50,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
       thisFactory.universe = thisUniverse
       val settings = thisFactory.settings
       val rootPackage = modelCreation.createRootPackage
+      lazy val dotRunner = new DotRunner(settings)
     }
     _modelFinished = true
     // complete the links between model entities, everthing that couldn't have been done before


### PR DESCRIPTION
In a bug reminiscent of SI-7603 / ab8a223, when running multiple
instances of Scaladoc in one JVM/classloader, we are exposed to
race conditions in unprotected mutable state in a top-level object.

This commit moves that state into the `Universe` object, which
corresponds to a single Scaladoc instance. It also removes a little
premature abstraction from the code.

Note: the statistics code is still not thread safe, but this is no
worse than the compiler itself, and not a real problem, as they are
only enabled begind a `-Y` option.

Review by @VladUreche
