### PR TITLE
SI-8801 Another test for fixed exponential-time compilation

### DIFF
--- a/test/files/pos/t8801.scala
+++ b/test/files/pos/t8801.scala
@@ -1,0 +1,21 @@
+sealed trait Nat {
+  type Prev <: Nat { type Succ = Nat.this.type }
+  type Succ <: Nat { type Prev = Nat.this.type }
+}
+ 
+object Nat {
+  object Zero extends Nat {
+    type Prev = Nothing
+  }
+ 
+  type _0 = Zero.type
+  type _1 = _0#Succ
+  type _2 = _1#Succ
+  type _3 = _2#Succ
+  type _4 = _3#Succ
+  type _5 = _4#Succ
+  type _6 = _5#Succ
+  type _7 = _6#Succ
+  type _8 = _7#Succ
+  type _9 = _8#Succ
+}


### PR DESCRIPTION
Turns out that SI-9157 was a duplicate of SI-8801. This commit
adds Paul's test, whose compile time is now back in the troposphere.

```
% time qscalac test/files/pos/t8801.scala

real    0m1.294s
user    0m3.978s
sys 0m0.240s
```
