### PR TITLE
SI-7730 Fix scoping in pattern typing

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -244,7 +244,7 @@ trait ContextErrors {
       def AmbiguousIdentError(tree: Tree, name: Name, msg: String) =
         NormalTypeError(tree, "reference to " + name + " is ambiguous;\n" + msg)
 
-      def SymbolNotFoundError(tree: Tree, name: Name, owner: Symbol, startingIdentCx: Context) = {
+      def SymbolNotFoundError(tree: Tree, name: Name, owner: Symbol) = {
         NormalTypeError(tree, "not found: "+decodeWithKind(name, owner))
       }
 

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -265,6 +265,8 @@ trait Contexts { self: Analyzer =>
     def inSecondTry_=(value: Boolean)         = this(SecondTry) = value
     def inReturnExpr                          = this(ReturnExpr)
     def inTypeConstructorAllowed              = this(TypeConstructorAllowed)
+    def pattern                               = this(Pattern)
+    def pattern_=(value: Boolean)             = this(Pattern) = value
 
     def defaultModeForTyped: Mode = if (inTypeConstructorAllowed) Mode.NOmode else Mode.EXPRmode
 
@@ -282,6 +284,7 @@ trait Contexts { self: Analyzer =>
 
     /** The next enclosing context (potentially `this`) that has a `CaseDef` as a tree */
     def enclosingCaseDef = nextEnclosing(_.tree.isInstanceOf[CaseDef])
+    def enclosingPattern = nextEnclosing(_.pattern)
 
     /** ...or an Apply. */
     def enclosingApply = nextEnclosing(_.tree.isInstanceOf[Apply])
@@ -482,6 +485,7 @@ trait Contexts { self: Analyzer =>
 
       if (tree != outer.tree)
         c(TypeConstructorAllowed) = false
+      c.pattern = false
 
       registerContext(c.asInstanceOf[analyzer.Context])
       debuglog("[context] ++ " + c.unit + " / " + tree.summaryString)
@@ -1009,6 +1013,9 @@ trait Contexts { self: Analyzer =>
      *  the search continuing as long as no qualifying name is found.
      */
     def lookupSymbol(name: Name, qualifies: Symbol => Boolean): NameLookup = {
+      // ignore current variable scope in patterns to enforce linearity
+      val enclosingPatternCx = enclosingPattern
+
       var lookupError: NameLookup  = null       // set to non-null if a definite error is encountered
       var inaccessible: NameLookup = null       // records inaccessible symbol for error reporting in case none is found
       var defSym: Symbol           = NoSymbol   // the directly found symbol
@@ -1079,10 +1086,13 @@ trait Contexts { self: Analyzer =>
         defSym = lookupInScope(cx.scope) match {
           case Nil                  => searchPrefix
           case entries @ (hd :: tl) =>
-            // we have a winner: record the symbol depth
-            symbolDepth = (cx.depth - cx.scope.nestingLevel) + hd.depth
-            if (tl.isEmpty) hd.sym
-            else newOverloaded(cx.owner, pre, entries)
+            if (hd.owner eq enclosingPatternCx.scope) NoSymbol
+            else {
+              // we have a winner: record the symbol depth
+              symbolDepth = (cx.depth - cx.scope.nestingLevel) + hd.depth
+              if (tl.isEmpty) hd.sym
+              else newOverloaded(cx.owner, pre, entries)
+            }
         }
         if (!defSym.exists)
           cx = cx.outer // push further outward
@@ -1536,6 +1546,9 @@ object ContextMode {
   /** Are unapplied type constructors allowed here? Formerly HKmode. */
   final val TypeConstructorAllowed: ContextMode   = 1 << 16
 
+  /** Are we typechecking the pattern of the `CaseDef` associated with this context? */
+  final val Pattern: ContextMode                = 1 << 17
+
   /** TODO: The "sticky modes" are EXPRmode, PATTERNmode, TYPEmode.
    *  To mimick the sticky mode behavior, when captain stickyfingers
    *  comes around we need to propagate those modes but forget the other
@@ -1559,7 +1572,8 @@ object ContextMode {
     StarPatterns           -> "StarPatterns",
     SuperInit              -> "SuperInit",
     SecondTry              -> "SecondTry",
-    TypeConstructorAllowed -> "TypeConstructorAllowed"
+    TypeConstructorAllowed -> "TypeConstructorAllowed",
+    Pattern                -> "Pattern"
   )
 }
 

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2397,7 +2397,11 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       // withoutAnnotations - see continuations-run/z1673.scala
       // This adjustment is awfully specific to continuations, but AFAICS the
       // whole AnnotationChecker framework is.
-      val pat1 = typedPattern(cdef.pat, pattpe.withoutAnnotations)
+      val pat1 = {
+        context.pattern = true
+        try typedPattern(cdef.pat, pattpe.withoutAnnotations)
+        finally context.pattern = false
+      }
       // When case classes have more than two parameter lists, the pattern ends
       // up typed as a method.  We only pattern match on the first parameter
       // list, so substitute the final result type of the method, i.e. the type
@@ -4861,10 +4865,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
           setError(tree)
         }
-          // ignore current variable scope in patterns to enforce linearity
-        val startContext = if (mode.typingPatternOrTypePat) context.outer else context
         val nameLookup   = tree.symbol match {
-          case NoSymbol   => startContext.lookupSymbol(name, qualifies)
+          case NoSymbol   => context.lookupSymbol(name, qualifies)
           case sym        => LookupSucceeded(EmptyTree, sym)
         }
         import InferErrorGen._
@@ -4873,7 +4875,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           case LookupInaccessible(sym, msg) => issue(AccessError(tree, sym, context, msg))
           case LookupNotFound               =>
             inEmptyPackage orElse lookupInRoot(name) match {
-              case NoSymbol => issue(SymbolNotFoundError(tree, name, context.owner, startContext))
+              case NoSymbol => issue(SymbolNotFoundError(tree, name, context.owner))
               case sym      => typed1(tree setSymbol sym, mode, pt)
                 }
           case LookupSucceeded(qual, sym)   =>

--- a/test/files/neg/t7730.check
+++ b/test/files/neg/t7730.check
@@ -1,0 +1,10 @@
+t7730.scala:2: error: not found: value a
+  def f(x: Any) = x match { case (a: AnyRef, b: (a.type forSome { type T })) => () }
+                                                 ^
+t7730.scala:3: error: not found: value a
+  def g(x: Any) = x match { case (a: AnyRef, b: Array[a.type]) => () }
+                                                      ^
+t7730.scala:6: error: not found: value a
+  def h(x: Any) = x match { case (a: AnyRef, b: ({type L = a.type})#L) => () }
+                                                           ^
+three errors found

--- a/test/files/neg/t7730.scala
+++ b/test/files/neg/t7730.scala
@@ -1,0 +1,7 @@
+class Foo {
+  def f(x: Any) = x match { case (a: AnyRef, b: (a.type forSome { type T })) => () }
+  def g(x: Any) = x match { case (a: AnyRef, b: Array[a.type]) => () }
+
+  // TODO this is harder to prevent
+  def h(x: Any) = x match { case (a: AnyRef, b: ({type L = a.type})#L) => () }
+}

--- a/test/files/pos/t7730.scala
+++ b/test/files/pos/t7730.scala
@@ -1,0 +1,7 @@
+// Fails
+class Foo {
+  def f(x: Any) = x match { case x: (T forSome { type T }) => x }
+  // a.scala:2: error: not found: type T
+  //   def f(x: Any) = x match { case x: (T forSome { type T }) => x }
+  //                                      ^
+}


### PR DESCRIPTION
Pattern binders introduced by a `CaseDef` may not be referred to by
terms or types in other patterns in the same case. The implementation
of this was too simplistic, To enforce this, `typedIdent` simply
skipped the first enclosing context when in a `PATTERNmode` or
`TYPEPATmode`.

However this was too simplistic. If the type pattern included an
existential type, the nested context containing the quantified
types was dropped, rather than that of the CaseDef. This results in
a "symbol not found" error in the enclosed pos test. The enclosed
neg tests show the related symptom: we can actually subvert the
restriction and refer to binders from within an existential
type, or from within a refined type.

The commit enforces the unusual scoping rules faithfully by:
- introduces ContextMode.Pattern, and mark the `CaseDef`-s
  context with this while typechecking its patterns
- within `Context.lookupSymbol`, search for the closest enclosing
  context so-marked, and ignore any definitions owned by its scope.

We can't predicate this logic on typing `Mode`-s alone. I tried
that as my first attempt, but found that in the body of a refined
type (e.g in the third part of the neg test), we have switched out
of the TYPEPATmode. Using a `ContextMode` instead lets us simply
walk the context chain and find the scope to ignore.

Review by @adriaanm. We might want to push this to 2.12.x, but
let's review it here to start with.
