### PR TITLE
Scaladoc js location synch more robust

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.js
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.js
@@ -94,7 +94,7 @@ function setFrameSrcFromUrlFragment() {
         if (memberSig) {
             locWithMemeberSig += "#" + memberSig;
         }
-        frames["template"].location.replace(locWithMemeberSig);
+        frames["template"].location.replace(location.protocol + locWithMemeberSig);
     } else {
         console.log("empty fragment detected");
         frames["template"].location.replace("package.html");


### PR DESCRIPTION
Fix the cross-site scripting vulnerability in Scaladoc’s JavaScript that was brought to our attention by @todesking -- thank you!

This vulnerability could be used to access sensitive information on sites hosted on the same domain as Scaladoc-generated documentation. We do recommend, as a general precaution, to host Scaladoc documentation on its own domain.
