### PR TITLE
Scaladoc js location synch more robust

### DIFF
--- a/src/compiler/scala/tools/nsc/doc/html/resource/lib/index.js
+++ b/src/compiler/scala/tools/nsc/doc/html/resource/lib/index.js
@@ -70,7 +70,7 @@ function setFrameSrcFromUrlFragment() {
     var loc = fragment.split("@")[0].replace(/\./g, "/");
     if(loc.indexOf(".html") < 0) loc += ".html";
     if(fragment.indexOf('@') > 0) loc += ("#" + fragment.split("@", 2)[1]);
-    frames["template"].location.replace(loc);
+    frames["template"].location.replace(location.protocol + loc);
   }
   else
     frames["template"].location.replace("package.html");


### PR DESCRIPTION
Fix the cross-site scripting vulnerability in Scaladoc’s JavaScript that was brought to our attention by @todesking -- thank you!

This vulnerability could be used to access sensitive information on sites hosted on the same domain as Scaladoc-generated documentation. We do recommend, as a general precaution, to host Scaladoc documentation on its own domain.

Tested on:
- Mac: FF35/Safari 8/Chrome 41
- Win: IE11
