### PR TITLE
SI-9172  FlatMapped views throw exception on filter

### DIFF
--- a/src/library/scala/collection/SeqViewLike.scala
+++ b/src/library/scala/collection/SeqViewLike.scala
@@ -83,7 +83,7 @@ trait SeqViewLike[+A,
     }
     def length = index(self.length)
     def apply(idx: Int) = {
-      if (idx < 0 || idx >= self.length) throw new IndexOutOfBoundsException(idx.toString)
+      if (idx < 0 || idx >= length) throw new IndexOutOfBoundsException(idx.toString)
       val row = findRow(idx, 0, self.length - 1)
       mapping(self(row)).seq.toSeq(idx - index(row))
     }


### PR DESCRIPTION
Errant `self.length` changed to `length`.  (Some sort of complex interaction with other changes caused this to become a problem.)

No tests; found and tested by collections-laws.
