### PR TITLE
better errors for macro applications with wrong number of arguments

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3387,7 +3387,6 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               // defaults are needed. they are added to the argument list in named style as
               // calls to the default getters. Example:
               //  foo[Int](a)()  ==>  foo[Int](a)(b = foo$qual.foo$default$2[Int](a))
-              checkNotMacro()
 
               // SI-8111 transformNamedApplication eagerly shuffles around the application to preserve
               //         evaluation order. During this process, it calls `changeOwner` on symbols that
@@ -3434,6 +3433,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                   duplErrTree
                 } else if (lencmp2 == 0) {
                   // useful when a default doesn't match parameter type, e.g. def f[T](x:T="a"); f[Int]()
+                  checkNotMacro()
                   context.diagUsedDefaults = true
                   doTypedApply(tree, if (blockIsEmpty) fun else fun1, allArgs, mode, pt)
                 } else {

--- a/test/files/neg/macro-invalidusage-badargs.check
+++ b/test/files/neg/macro-invalidusage-badargs.check
@@ -9,7 +9,8 @@ Macros_Test_2.scala:6: error: too few argument lists for macro invocation
 Macros_Test_2.scala:7: error: Int does not take parameters
   foo(4)(2)
         ^
-Macros_Test_2.scala:8: error: macro applications do not support named and/or default arguments
+Macros_Test_2.scala:8: error: not enough arguments for macro method foo: (x: Int)Int.
+Unspecified value parameter x.
   foo()
      ^
 Macros_Test_2.scala:9: error: too many arguments for macro method foo: (x: Int)Int

--- a/test/files/neg/t7157.check
+++ b/test/files/neg/t7157.check
@@ -7,7 +7,8 @@ Test_2.scala:6: error: too many arguments for macro method m1_0_0: ()Unit
 Test_2.scala:7: error: too many arguments for macro method m1_0_0: ()Unit
   m1_0_0(1, 2, 3)
         ^
-Test_2.scala:9: error: macro applications do not support named and/or default arguments
+Test_2.scala:9: error: not enough arguments for macro method m1_1_1: (x: Int)Unit.
+Unspecified value parameter x.
   m1_1_1()
         ^
 Test_2.scala:11: error: too many arguments for macro method m1_1_1: (x: Int)Unit
@@ -16,22 +17,27 @@ Test_2.scala:11: error: too many arguments for macro method m1_1_1: (x: Int)Unit
 Test_2.scala:12: error: too many arguments for macro method m1_1_1: (x: Int)Unit
   m1_1_1(1, 2, 3)
         ^
-Test_2.scala:14: error: macro applications do not support named and/or default arguments
+Test_2.scala:14: error: not enough arguments for macro method m1_2_2: (x: Int, y: Int)Unit.
+Unspecified value parameters x, y.
   m1_2_2()
         ^
-Test_2.scala:15: error: macro applications do not support named and/or default arguments
+Test_2.scala:15: error: not enough arguments for macro method m1_2_2: (x: Int, y: Int)Unit.
+Unspecified value parameter y.
   m1_2_2(1)
         ^
 Test_2.scala:17: error: too many arguments for macro method m1_2_2: (x: Int, y: Int)Unit
   m1_2_2(1, 2, 3)
         ^
-Test_2.scala:24: error: macro applications do not support named and/or default arguments
+Test_2.scala:24: error: not enough arguments for macro method m1_1_inf: (x: Int, y: Int*)Unit.
+Unspecified value parameters x, y.
   m1_1_inf()
           ^
-Test_2.scala:29: error: macro applications do not support named and/or default arguments
+Test_2.scala:29: error: not enough arguments for macro method m1_2_inf: (x: Int, y: Int, z: Int*)Unit.
+Unspecified value parameters x, y, z.
   m1_2_inf()
           ^
-Test_2.scala:30: error: macro applications do not support named and/or default arguments
+Test_2.scala:30: error: not enough arguments for macro method m1_2_inf: (x: Int, y: Int, z: Int*)Unit.
+Unspecified value parameters y, z.
   m1_2_inf(1)
           ^
 Test_2.scala:35: error: too many arguments for macro method m2_0_0: ()Unit
@@ -43,7 +49,8 @@ Test_2.scala:36: error: too many arguments for macro method m2_0_0: ()Unit
 Test_2.scala:37: error: too many arguments for macro method m2_0_0: ()Unit
   m2_0_0()(1, 2, 3)
           ^
-Test_2.scala:39: error: macro applications do not support named and/or default arguments
+Test_2.scala:39: error: not enough arguments for macro method m2_1_1: (x: Int)Unit.
+Unspecified value parameter x.
   m2_1_1()()
           ^
 Test_2.scala:41: error: too many arguments for macro method m2_1_1: (x: Int)Unit
@@ -52,22 +59,27 @@ Test_2.scala:41: error: too many arguments for macro method m2_1_1: (x: Int)Unit
 Test_2.scala:42: error: too many arguments for macro method m2_1_1: (x: Int)Unit
   m2_1_1()(1, 2, 3)
           ^
-Test_2.scala:44: error: macro applications do not support named and/or default arguments
+Test_2.scala:44: error: not enough arguments for macro method m2_2_2: (x: Int, y: Int)Unit.
+Unspecified value parameters x, y.
   m2_2_2()()
           ^
-Test_2.scala:45: error: macro applications do not support named and/or default arguments
+Test_2.scala:45: error: not enough arguments for macro method m2_2_2: (x: Int, y: Int)Unit.
+Unspecified value parameter y.
   m2_2_2()(1)
           ^
 Test_2.scala:47: error: too many arguments for macro method m2_2_2: (x: Int, y: Int)Unit
   m2_2_2()(1, 2, 3)
           ^
-Test_2.scala:54: error: macro applications do not support named and/or default arguments
+Test_2.scala:54: error: not enough arguments for macro method m2_1_inf: (x: Int, y: Int*)Unit.
+Unspecified value parameters x, y.
   m2_1_inf()()
             ^
-Test_2.scala:59: error: macro applications do not support named and/or default arguments
+Test_2.scala:59: error: not enough arguments for macro method m2_2_inf: (x: Int, y: Int, z: Int*)Unit.
+Unspecified value parameters x, y, z.
   m2_2_inf()()
             ^
-Test_2.scala:60: error: macro applications do not support named and/or default arguments
+Test_2.scala:60: error: not enough arguments for macro method m2_2_inf: (x: Int, y: Int, z: Int*)Unit.
+Unspecified value parameters y, z.
   m2_2_inf()(1)
             ^
 24 errors found


### PR DESCRIPTION
The tryNamesDefaults branch of application typechecking contains the
checkNotMacro check, which errors out when we try to do named/default arguments
for macros (that's not supported yet, see SI-5920 for discussion).

Unfortunately, the check activates too early, because it turns out that
we can also enter tryNamesDefaults when the user just provides insufficient
number of arguments to a method by mistake, without expecting any default
arguments at all.

This leads to really confusing errors, which can luckily be fixed in a
very simple way by moving the checkNotMacro check down the happy path
of named/default typechecking.
