### PR TITLE
SI-9170 Fix resident compilation / specialization NPE

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1551,7 +1551,8 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
 
       if (reporter.hasErrors) {
         for ((sym, file) <- symSource.iterator) {
-          sym.reset(new loaders.SourcefileLoader(file))
+          if (file != null)
+            sym.reset(new loaders.SourcefileLoader(file))
           if (sym.isTerm)
             sym.moduleClass reset loaders.moduleClassLoader
         }

--- a/test/files/res/t9170.check
+++ b/test/files/res/t9170.check
@@ -1,0 +1,7 @@
+
+nsc> t9170/A.scala:3: error: double definition:
+def f[A](a: => A): Int at line 2 and
+def f[A](a: => Either[Exception,A]): Int at line 3
+have same type after erasure: (a: Function0)Int
+  def f[A](a: => Either[Exception, A]) = 2
+      ^

--- a/test/files/res/t9170.res
+++ b/test/files/res/t9170.res
@@ -1,0 +1,2 @@
+t9170/A.scala
+t9170/A.scala

--- a/test/files/res/t9170/A.scala
+++ b/test/files/res/t9170/A.scala
@@ -1,0 +1,4 @@
+object Y {
+  def f[A](a: =>  A) = 1
+  def f[A](a: => Either[Exception, A]) = 2
+}


### PR DESCRIPTION
The resident compiler does its best to clean the decks at
the conclusion of a compilation batch.

One part of this is as follows: if the run was erroneous,
reset the info of top level symbols defined in this run
to the initial state, that is, to a `SourceFileLoader`.

However, if the errors came late in the compilation pipeline,
the map from symbols to the source files includes the results
of the specialization transformation, which ends up with
mappings like `Function1$sp... -> null`.

This results in a `NullPointerException` on subsequent runs.

This commits filters out null source files during the reset
process.
