### PR TITLE
SI-9182 Fix runtime reflection with package object, overloads

### DIFF
--- a/src/reflect/scala/reflect/runtime/SymbolLoaders.scala
+++ b/src/reflect/scala/reflect/runtime/SymbolLoaders.scala
@@ -107,7 +107,8 @@ private[reflect] trait SymbolLoaders { self: SymbolTable =>
       if (isCompilerUniverse) super.enter(sym)
       else {
         val existing = super.lookupEntry(sym.name)
-        assert(existing == null || existing.sym.isMethod, s"pkgClass = $pkgClass, sym = $sym, existing = $existing")
+        def eitherIsMethod(sym1: Symbol, sym2: Symbol) = sym1.isMethod || sym2.isMethod
+        assert(existing == null || eitherIsMethod(existing.sym, sym), s"pkgClass = $pkgClass, sym = $sym, existing = $existing")
         super.enter(sym)
       }
     }

--- a/test/files/run/t9182.check
+++ b/test/files/run/t9182.check
@@ -1,0 +1,3 @@
+constructor package
+method A
+object A

--- a/test/files/run/t9182.scala
+++ b/test/files/run/t9182.scala
@@ -1,0 +1,12 @@
+// Main.scala
+package object ops {
+  object A
+  def A(a: Any) = ()
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val pack = scala.reflect.runtime.currentMirror.staticModule("ops.package")
+    println(pack.info.decls.toList.map(_.toString).sorted.mkString("\n"))
+  }
+}


### PR DESCRIPTION
Eponymous modules and methods should be allowed to live in the
same package scope. This can happen when using a module and
and implicit class, or when defining the overloads manually.

This commit tones back an assertion that was added for sanity checking
runtime reflection thread safety to only fire when we are sure that
neither the existing and current symbol of the given name are methods.

Review by @xeno-by
