### PR TITLE
SI-8575 Avoid use of unitialized field in a test.

### DIFF
--- a/test/files/run/t8575.scala
+++ b/test/files/run/t8575.scala
@@ -21,13 +21,12 @@ object Test extends TypeMember {
   // works if replaced by type X = E[A with B with C]
   type X = E[F with C]
 
-  val value = new E[F with C]
+  def value = new E[F with C]
 
   // This call passes, since it invokes consume(E): Unit
-  consume(value)
   def consume(x: X) {}
 
   def main(args: Array[String]) {
-    
+    consume(value)
   }
 }


### PR DESCRIPTION
The checkinit build has been failing in the 2.12.x branch.

This commit modifies the errant test case to avoid using an
unitialized field.

I have verified that the new test still faithfully demonstrates the
original bug.

```
% scalac-hash v2.11.0 test/files/run/t8575.scala && scala-hash v2.11.0 Test
java.lang.AbstractMethodError: Test$.consume(Ljava/lang/Object;)V
```

Review by @adriaanm
