### PR TITLE
SI-9170 More flexible SessionTest

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1551,7 +1551,8 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
 
       if (reporter.hasErrors) {
         for ((sym, file) <- symSource.iterator) {
-          sym.reset(new loaders.SourcefileLoader(file))
+          if (file != null)
+            sym.reset(new loaders.SourcefileLoader(file))
           if (sym.isTerm)
             sym.moduleClass reset loaders.moduleClassLoader
         }

--- a/test/files/run/t9170.scala
+++ b/test/files/run/t9170.scala
@@ -1,0 +1,58 @@
+
+import scala.tools.partest.SessionTest
+
+object Test extends SessionTest {
+
+  override def stripMargins = false
+
+  def session =
+"""Type in expressions to have them evaluated.
+Type :help for more information.
+
+scala> object Y { def f[A](a: => A) = 1 ; def f[A](a: => Either[Exception, A]) = 2 }
+<console>:7: error: double definition:
+def f[A](a: => A): Int at line 7 and
+def f[A](a: => Either[Exception,A]): Int at line 7
+have same type after erasure: (a: Function0)Int
+       object Y { def f[A](a: => A) = 1 ; def f[A](a: => Either[Exception, A]) = 2 }
+                                              ^
+
+scala> object Y { def f[A](a: => A) = 1 ; def f[A](a: => Either[Exception, A]) = 2 }
+<console>:7: error: double definition:
+def f[A](a: => A): Int at line 7 and
+def f[A](a: => Either[Exception,A]): Int at line 7
+have same type after erasure: (a: Function0)Int
+       object Y { def f[A](a: => A) = 1 ; def f[A](a: => Either[Exception, A]) = 2 }
+                                              ^
+
+scala> object Y {
+     |   def f[A](a: =>  A) = 1
+     |   def f[A](a: => Either[Exception, A]) = 2
+     | }
+<console>:9: error: double definition:
+def f[A](a: => A): Int at line 8 and
+def f[A](a: => Either[Exception,A]): Int at line 9
+have same type after erasure: (a: Function0)Int
+         def f[A](a: => Either[Exception, A]) = 2
+             ^
+
+scala> :pa
+// Entering paste mode (ctrl-D to finish)
+
+object Y {
+  def f[A](a: =>  A) = 1
+  def f[A](a: => Either[Exception, A]) = 2
+}
+
+// Exiting paste mode, now interpreting.
+
+<console>:9: error: double definition:
+def f[A](a: => A): Int at line 8 and
+def f[A](a: => Either[Exception,A]): Int at line 9
+have same type after erasure: (a: Function0)Int
+         def f[A](a: => Either[Exception, A]) = 2
+             ^
+
+scala> :quit"""
+}
+


### PR DESCRIPTION
SessionTest session text can include line continuations
and pasted text. Pasted script (which looks like a
double prompt) probably doesn't work.

This commit includes @retronym's SI-9170 one-liner.
