### PR TITLE
SI-9188 Issue a missing unchecked warning for class type param

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Checkable.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Checkable.scala
@@ -108,7 +108,7 @@ trait Checkable {
   }
 
   private def isUnwarnableTypeArgSymbol(sym: Symbol) = (
-       sym.isTypeParameter                     // dummy
+       isDummyOf(sym.tpeHK)(sym)               // dummy
     || (sym.name.toTermName == nme.WILDCARD)   // _
     || nme.isVariableName(sym.name)            // type variable
   )

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3732,12 +3732,11 @@ trait Types
   def containsExistential(tpe: Type) = tpe exists typeIsExistentiallyBound
   def existentialsInType(tpe: Type) = tpe withFilter typeIsExistentiallyBound map (_.typeSymbol)
 
-  private def isDummyOf(tpe: Type)(targ: Type) = {
-    val sym = targ.typeSymbol
-    sym.isTypeParameter && sym.owner == tpe.typeSymbol
-  }
+  def isDummyOf(tpe: Type)(targ: Symbol) =
+    targ.isTypeParameter && targ.owner == tpe.typeSymbol
+
   def isDummyAppliedType(tp: Type) = tp.dealias match {
-    case tr @ TypeRef(_, _, args) => args exists isDummyOf(tr)
+    case tr @ TypeRef(_, _, args) => args exists (a => isDummyOf(tr)(a.typeSymbol))
     case _                        => false
   }
 

--- a/test/files/neg/t9188.check
+++ b/test/files/neg/t9188.check
@@ -1,0 +1,12 @@
+t9188.scala:3: warning: non-variable type argument Double in type pattern List[Double] (the underlying of List[Double]) is unchecked since it is eliminated by erasure
+    case ds: List[Double] =>  // unchecked warning
+             ^
+t9188.scala:5: warning: abstract type K in type pattern scala.collection.immutable.Vector[K] (the underlying of Vector[K]) is unchecked since it is eliminated by erasure
+    case kx: Vector[K] =>      // no unchecked warning
+             ^
+t9188.scala:7: warning: abstract type K in type pattern A[K] is unchecked since it is eliminated by erasure
+    case ak: A[K] =>
+             ^
+error: No warnings can be incurred under -Xfatal-warnings.
+three warnings found
+one error found

--- a/test/files/neg/t9188.flags
+++ b/test/files/neg/t9188.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/t9188.scala
+++ b/test/files/neg/t9188.scala
@@ -1,0 +1,10 @@
+class A[K] {
+  def receive: PartialFunction[Any, Unit] = {
+    case ds: List[Double] =>  // unchecked warning
+      println("* List[Double]")
+    case kx: Vector[K] =>      // no unchecked warning
+      println("* Vector[K]")
+    case ak: A[K] => 
+      println("* A[K]")
+  }
+}


### PR DESCRIPTION
CheckabilityChecker determined that the match was unsound, but
stumbled when trying to report which part of the type was to blame.
When this happens, the warning is debug logged, but not issued.

It failed to report that the reference to the enclosing class's
type paramter was to blame because of some code that sought to
avoid spurious warnings for dummy arguments (the kind that result
from calling `tpe_*` on a type constructor.)

I tightened up the check to re-use some existing code that does
a better job at identifying dummies. Now unchecked warnings
are issued for the last two patterns in the enclosed test.

Review by @adriaanm
