### PR TITLE
Disable -Ydelambdafy:method for specialized FunctionN

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -70,6 +70,14 @@ abstract class UnCurry extends InfoTransform
     private val noApply           = mutable.HashSet[Tree]()
     private val newMembers        = mutable.Map[Symbol, mutable.Buffer[Tree]]()
 
+    private lazy val forceSpecializationInfoTransformOfFunctionN: Unit = {
+      if (currentRun.specializePhase != NoPhase) { // be robust in case of -Ystop-after:uncurry
+        exitingSpecialize {
+          FunctionClass.seq.foreach(cls => cls.info)
+        }
+      }
+    }
+
     /** Add a new synthetic member for `currentOwner` */
     private def addNewMember(t: Tree): Unit =
       newMembers.getOrElseUpdate(currentOwner, mutable.Buffer()) += t
@@ -220,8 +228,16 @@ abstract class UnCurry extends InfoTransform
           def mkMethod(owner: Symbol, name: TermName, additionalFlags: FlagSet = NoFlags): DefDef =
             gen.mkMethodFromFunction(localTyper)(fun, owner, name, additionalFlags)
 
-          val canUseDelamdafyMethod = (inConstructorFlag == 0) // Avoiding synthesizing code prone to SI-6666, SI-8363 by using old-style lambda translation
+          def isSpecialized = {
+            forceSpecializationInfoTransformOfFunctionN
+            val specialized = specializeTypes.specializedType(fun.tpe)
+            !(specialized =:= fun.tpe)
+          }
 
+          def canUseDelamdafyMethod = (
+               (inConstructorFlag == 0) // Avoiding synthesizing code prone to SI-6666, SI-8363 by using old-style lambda translation
+            && !isSpecialized           // DelambdafyTransformer currently only emits generic FunctionN-s, use the old style in the meantime
+          )
           if (inlineFunctionExpansion || !canUseDelamdafyMethod) {
             val parents = addSerializable(abstractFunctionForFunctionType(fun.tpe))
             val anonClass = fun.symbol.owner newAnonymousFunctionClass(fun.pos, inConstructorFlag) addAnnotation SerialVersionUIDAnnotation

--- a/test/files/run/delambdafy-specialized.check
+++ b/test/files/run/delambdafy-specialized.check
@@ -1,0 +1,1 @@
+scala.runtime.AbstractFunction1$mcII$sp

--- a/test/files/run/delambdafy-specialized.flags
+++ b/test/files/run/delambdafy-specialized.flags
@@ -1,0 +1,1 @@
+-Ydelambdafy:method

--- a/test/files/run/delambdafy-specialized.scala
+++ b/test/files/run/delambdafy-specialized.scala
@@ -1,0 +1,6 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    val f = (x: Int) => -x
+    println(f.getClass.getSuperclass.getName)
+  }
+}

--- a/test/files/run/delambdafy_t6028.check
+++ b/test/files/run/delambdafy_t6028.check
@@ -1,35 +1,35 @@
 [[syntax trees at end of                lambdalift]] // newSource1.scala
 package <empty> {
   class T extends Object {
-    <paramaccessor> private[this] val classParam: Int = _;
-    def <init>(classParam: Int): T = {
+    <paramaccessor> private[this] val classParam: String = _;
+    def <init>(classParam: String): T = {
       T.super.<init>();
       ()
     };
-    private[this] val field: Int = 0;
-    <stable> <accessor> def field(): Int = T.this.field;
-    def foo(methodParam: Int): Function0 = {
-      val methodLocal: Int = 0;
+    private[this] val field: String = "";
+    <stable> <accessor> def field(): String = T.this.field;
+    def foo(methodParam: String): Function0 = {
+      val methodLocal: String = "";
       {
         (() => T.this.$anonfun$1(methodParam, methodLocal)).$asInstanceOf[Function0]()
       }
     };
-    def bar(barParam: Int): Object = {
+    def bar(barParam: String): Object = {
       @volatile var MethodLocalObject$module: runtime.VolatileObjectRef = scala.runtime.VolatileObjectRef.zero();
       T.this.MethodLocalObject$1(barParam, MethodLocalObject$module)
     };
-    def tryy(tryyParam: Int): Function0 = {
-      var tryyLocal: runtime.IntRef = scala.runtime.IntRef.create(0);
+    def tryy(tryyParam: String): Function0 = {
+      var tryyLocal: runtime.ObjectRef = scala.runtime.ObjectRef.create("");
       {
-        (() => T.this.$anonfun$2(tryyParam, tryyLocal)).$asInstanceOf[Function0]()
+        (new <$anon: Function0>(T.this, tryyParam, tryyLocal): Function0)
       }
     };
-    final <artifact> private[this] def $anonfun$1(methodParam$1: Int, methodLocal$1: Int): Int = T.this.classParam.+(T.this.field()).+(methodParam$1).+(methodLocal$1);
+    final <artifact> private[this] def $anonfun$1(methodParam$1: String, methodLocal$1: String): String = T.this.classParam.+(T.this.field()).+(methodParam$1).+(methodLocal$1);
     abstract trait MethodLocalTrait$1 extends Object {
       <synthetic> <stable> <artifact> def $outer(): T
     };
     object MethodLocalObject$2 extends Object with T#MethodLocalTrait$1 {
-      def <init>($outer: T, barParam$1: Int): T#MethodLocalObject$2.type = {
+      def <init>($outer: T, barParam$1: String): T#MethodLocalObject$2.type = {
         MethodLocalObject$2.super.<init>();
         MethodLocalObject$2.this.$asInstanceOf[T#MethodLocalTrait$1$class]()./*MethodLocalTrait$1$class*/$init$(barParam$1);
         ()
@@ -38,19 +38,34 @@ package <empty> {
       <synthetic> <stable> <artifact> def $outer(): T = MethodLocalObject$2.this.$outer;
       <synthetic> <stable> <artifact> def $outer(): T = MethodLocalObject$2.this.$outer
     };
-    final <stable> private[this] def MethodLocalObject$1(barParam$1: Int, MethodLocalObject$module$1: runtime.VolatileObjectRef): T#MethodLocalObject$2.type = {
+    final <stable> private[this] def MethodLocalObject$1(barParam$1: String, MethodLocalObject$module$1: runtime.VolatileObjectRef): T#MethodLocalObject$2.type = {
       MethodLocalObject$module$1.elem = new T#MethodLocalObject$2.type(T.this, barParam$1);
       MethodLocalObject$module$1.elem.$asInstanceOf[T#MethodLocalObject$2.type]()
     };
     abstract trait MethodLocalTrait$1$class extends Object with T#MethodLocalTrait$1 {
-      def /*MethodLocalTrait$1$class*/$init$(barParam$1: Int): Unit = {
+      def /*MethodLocalTrait$1$class*/$init$(barParam$1: String): Unit = {
         ()
       };
-      scala.this.Predef.print(scala.Int.box(barParam$1))
+      scala.this.Predef.print(barParam$1)
     };
-    final <artifact> private[this] def $anonfun$2(tryyParam$1: Int, tryyLocal$1: runtime.IntRef): Unit = try {
-      tryyLocal$1.elem = tryyParam$1
-    } finally ()
+    @SerialVersionUID(value = 0) final <synthetic> class $anonfun$tryy$1 extends scala.runtime.AbstractFunction0$mcV$sp with Serializable {
+      def <init>($outer: T, tryyParam$1: String, tryyLocal$1: runtime.ObjectRef): <$anon: Function0> = {
+        $anonfun$tryy$1.super.<init>();
+        ()
+      };
+      final def apply(): Unit = $anonfun$tryy$1.this.apply$mcV$sp();
+      <specialized> def apply$mcV$sp(): Unit = try {
+        $anonfun$tryy$1.this.tryyLocal$1.elem = $anonfun$tryy$1.this.tryyParam$1
+      } finally ();
+      <synthetic> <paramaccessor> <artifact> private[this] val $outer: T = _;
+      <synthetic> <stable> <artifact> def $outer(): T = $anonfun$tryy$1.this.$outer;
+      final <bridge> <artifact> def apply(): Object = {
+        $anonfun$tryy$1.this.apply();
+        scala.runtime.BoxedUnit.UNIT
+      };
+      <synthetic> <paramaccessor> private[this] val tryyParam$1: String = _;
+      <synthetic> <paramaccessor> private[this] val tryyLocal$1: runtime.ObjectRef = _
+    }
   }
 }
 

--- a/test/files/run/delambdafy_t6028.scala
+++ b/test/files/run/delambdafy_t6028.scala
@@ -5,11 +5,11 @@ object Test extends DirectTest {
 
   override def extraSettings: String = "-usejavacp -Ydelambdafy:method -Xprint:lambdalift -d " + testOutput.path
 
-  override def code = """class T(classParam: Int) {
-                        |  val field: Int = 0
-                        |  def foo(methodParam: Int) = {val methodLocal = 0 ; () => classParam + field + methodParam + methodLocal }
-                        |  def bar(barParam: Int) = { trait MethodLocalTrait { print(barParam) }; object MethodLocalObject extends MethodLocalTrait; MethodLocalObject }
-                        |  def tryy(tryyParam: Int) = { var tryyLocal = 0; () => try { tryyLocal = tryyParam } finally () }
+  override def code = """class T(classParam: String) {
+                        |  val field: String = ""
+                        |  def foo(methodParam: String) = {val methodLocal = "" ; () => classParam + field + methodParam + methodLocal }
+                        |  def bar(barParam: String) = { trait MethodLocalTrait { print(barParam) }; object MethodLocalObject extends MethodLocalTrait; MethodLocalObject }
+                        |  def tryy(tryyParam: String) = { var tryyLocal = ""; () => try { tryyLocal = tryyParam } finally () }
                         |}
                         |""".stripMargin.trim
 

--- a/test/files/run/delambdafy_t6555.check
+++ b/test/files/run/delambdafy_t6555.check
@@ -5,11 +5,11 @@ package <empty> {
       Foo.super.<init>();
       ()
     };
-    private[this] val f: Int => Int = {
-      final <artifact> def $anonfun(param: Int): Int = param;
-      ((param: Int) => $anonfun(param))
+    private[this] val f: String => String = {
+      final <artifact> def $anonfun(param: String): String = param;
+      ((param: String) => $anonfun(param))
     };
-    <stable> <accessor> def f(): Int => Int = Foo.this.f
+    <stable> <accessor> def f(): String => String = Foo.this.f
   }
 }
 

--- a/test/files/run/delambdafy_t6555.scala
+++ b/test/files/run/delambdafy_t6555.scala
@@ -5,7 +5,7 @@ object Test extends DirectTest {
 
   override def extraSettings: String = "-usejavacp -Xprint:specialize -Ydelambdafy:method -d " + testOutput.path
 
-  override def code = "class Foo { val f = (param: Int) => param } "
+  override def code = "class Foo { val f = (param: String) => param } "
 
   override def show(): Unit = {
     Console.withErr(System.out) {

--- a/test/files/run/delambdafy_uncurry_byname_method.check
+++ b/test/files/run/delambdafy_uncurry_byname_method.check
@@ -5,9 +5,9 @@ package <empty> {
       Foo.super.<init>();
       ()
     };
-    def bar(x: () => Int): Int = x.apply();
-    def foo(): Int = Foo.this.bar({
-      final <artifact> def $anonfun(): Int = 1;
+    def bar(x: () => String): String = x.apply();
+    def foo(): String = Foo.this.bar({
+      final <artifact> def $anonfun(): String = "";
       (() => $anonfun())
     })
   }

--- a/test/files/run/delambdafy_uncurry_byname_method.scala
+++ b/test/files/run/delambdafy_uncurry_byname_method.scala
@@ -6,9 +6,9 @@ object Test extends DirectTest {
   override def extraSettings: String = "-usejavacp -Xprint:uncurry -Ydelambdafy:method -Ystop-after:uncurry -d " + testOutput.path
 
   override def code = """class Foo {
-                        |  def bar(x: => Int) = x
+                        |  def bar(x: => String) = x
                         |  
-                        |  def foo = bar(1)
+                        |  def foo = bar("")
                         |}
                         |""".stripMargin.trim
 

--- a/test/files/run/repl-javap-lambdas.scala
+++ b/test/files/run/repl-javap-lambdas.scala
@@ -7,8 +7,8 @@ object Test extends JavapTest {
   def code = """
     |object Betty {
     | List(1,2,3) count (_ % 2 != 0)
-    | def f = List(1,2,3) filter (_ % 2 != 0) map (_ * 2)
-    | def g = List(1,2,3) filter (_ % 2 == 0) map (_ * 3) map (_ + 1)
+    | def f = List(1,2,3) filter ((x: Any) => true) map (x => "m1")
+    | def g = List(1,2,3) filter ((x: Any) => true) map (x => "m1") map (x => "m2")
     |}
     |:javap -fun Betty#g
   """.stripMargin

--- a/test/files/run/t9097.scala
+++ b/test/files/run/t9097.scala
@@ -15,7 +15,7 @@ object Test extends StoreReporterDirectTest {
   override def code = """package o
                         |package a {
                         |  class C {
-                        |    def hihi = List(1,2).map(_ * 2)
+                        |    def hihi = List(1,2).map(_ => "")
                         |  }
                         |}
                         |package object a {


### PR DESCRIPTION
The Delambdafy phase generates its `FunctionN` subclasses after
the specialization phase. As such, `((x: Int) => x).apply(42)` incurs
boxing.

This commit falls back to the `-Ydelambdafy:inline` in this case.

This is done by running the specialization type map over the
type of the function, and seeing if anything changes. To make this
work robustly, we first need to ensure that the specialization info
transformer has processed all the function types.

This is not a fundamental limitation; we could in principle generate
the specialized code.

A followup change will use `-Ydelambdafy:method` as the basis for
invokedymnamic lambdas. As part of that stream of
work, we will synthesize specialization-aware lambdas, and remove
the fallback to `-Ydelambdafy:inline`.

Review by @gkossakowski

I have updated some tests that indend to test the delambdafy transform
to avoid use of specialized function types.
