### PR TITLE
SI-7784 Allow a singleton type over a constant value defn.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5193,7 +5193,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         if (refTyped.isErrorTyped) {
           setError(tree)
         } else {
-          tree setType refTyped.tpe.resultType
+          tree setType refTyped.tpe.resultType.deconst
           if (refTyped.isErrorTyped || treeInfo.admitsTypeSelection(refTyped)) tree
           else UnstableTreeError(tree)
         }

--- a/test/files/neg/logImplicits.check
+++ b/test/files/neg/logImplicits.check
@@ -4,7 +4,7 @@ logImplicits.scala:2: applied implicit conversion from xs.type to ?{def size: ?}
 logImplicits.scala:7: applied implicit conversion from String("abc") to ?{def map: ?} = implicit def augmentString(x: String): scala.collection.immutable.StringOps
   def f = "abc" map (_ + 1)
           ^
-logImplicits.scala:15: inferred view from String("abc") to Int = C.this.convert:(p: String("abc"))Int
+logImplicits.scala:15: inferred view from String("abc") to Int = C.this.convert:(p: String)Int
   math.max(122, x: Int)
                 ^
 logImplicits.scala:19: applied implicit conversion from Int(1) to ?{def ->: ?} = implicit def ArrowAssoc[A](self: A): ArrowAssoc[A]

--- a/test/files/pos/t7784.scala
+++ b/test/files/pos/t7784.scala
@@ -1,0 +1,9 @@
+object Test {
+  final val a = ""
+  var b: a.type = a
+  b = a
+
+  final val x = classOf[Object]
+  var y: x.type = x
+  y = x
+}

--- a/test/files/pos/t7784.scala
+++ b/test/files/pos/t7784.scala
@@ -6,4 +6,8 @@ object Test {
   final val x = classOf[Object]
   var y: x.type = x
   y = x
+
+  final val e = Thread.State.NEW
+  var e1: e.type = e
+  e1 = e
 }


### PR DESCRIPTION
Rebased https://github.com/scala/scala/pull/4107

When typechecking a SingletonTypeTree, we must deconst
the type of the typechecked reference tree to avoid collapsing
a.type into a constant type if a is a constant value definition.

Review by @adriaanm

Thought this might be worth consideration in light of your SIP-23
work.
