### PR TITLE
SI-8359 Adjust parameter order of accessor method in Delambdafy

### DIFF
--- a/test/pending/run/delambdafy-lambdametafactory.scala
+++ b/test/pending/run/delambdafy-lambdametafactory.scala
@@ -1,0 +1,50 @@
+//
+// Tests that the static accessor method for lambda bodies
+// (generated under -Ydelambdafy:method) are compatible with
+// Java 8's LambdaMetafactory.
+//
+import java.lang.invoke._
+
+class C {
+  def test1: Unit = {
+    (x: String) => x.reverse
+  }
+  def test2: Unit = {
+    val capture1 = "capture1"
+    (x: String) => capture1 + " " + x.reverse
+  }
+  def test3: Unit = {
+    (x: String) => C.this + " " + x.reverse
+  }
+}
+trait T {
+  def test4: Unit = {
+    (x: String) => x.reverse
+  }
+}
+
+// A functional interface. Function1 contains abstract methods that are filled in by mixin 
+trait Function1ish[A, B] {
+  def apply(a: A): B
+}
+
+object Test {
+  def lambdaFactory[A, B](hostClass: Class[_], instantiatedParam: Class[A], instantiatedRet: Class[B], accessorName: String,
+                          capturedParams: Array[(Class[_], AnyRef)] = Array()) = {
+    val caller = MethodHandles.lookup
+    val methodType = MethodType.methodType(classOf[AnyRef], Array[Class[_]](classOf[AnyRef]))
+    val instantiatedMethodType = MethodType.methodType(instantiatedRet, Array[Class[_]](instantiatedParam))
+    val (capturedParamTypes, captured) = capturedParams.unzip
+    val targetMethodType = MethodType.methodType(instantiatedRet, capturedParamTypes :+ instantiatedParam)
+    val invokedType = MethodType.methodType(classOf[Function1ish[_, _]], capturedParamTypes)
+    val target = caller.findStatic(hostClass, accessorName, targetMethodType)
+    val site = LambdaMetafactory.metafactory(caller, "apply", invokedType, methodType, target, instantiatedMethodType)
+    site.getTarget.invokeWithArguments(captured: _*).asInstanceOf[Function1ish[A, B]]
+  }
+  def main(args: Array[String]) {
+    println(lambdaFactory(classOf[C], classOf[String], classOf[String], "accessor$1").apply("abc"))
+    println(lambdaFactory(classOf[C], classOf[String], classOf[String], "accessor$2", Array(classOf[String] -> "capture1")).apply("abc"))
+    println(lambdaFactory(classOf[C], classOf[String], classOf[String], "accessor$3", Array(classOf[C] -> new C)).apply("abc"))
+    println(lambdaFactory(Class.forName("T$class"), classOf[String], classOf[String], "accessor$4", Array(classOf[T] -> new T{})).apply("abc"))
+  }
+}


### PR DESCRIPTION
Under `-Ydelambdafy:method`, a public, static accessor method is
created to expose the private method containing the body of the
lambda.

Currently this accessor method has its parameters in the same order
structure as those of the lambda body method.

What is this order? There are three categories of parameters:
1. lambda parameters
2. captured parameters (added by lambdalift)
3. self parameters (added to lambda bodies that end up in trait
    impl classes by mixin, and added unconditionally to the static
    accessor method.)

These are currently emitted in order #3, #1, #2.

Here are examples of the current behaviour:

BEFORE (trait):

```
% cat sandbox/test.scala && scalac-hash v2.11.5 -Ydelambdafy:method sandbox/test.scala && javap -private -classpath . 'Test$class'
trait Member; class Capture; trait LambdaParam
trait Test {
  def member: Member
  def foo {
    val local = new Capture
    (arg: LambdaParam) => "" + arg + member + local
  }
}
Compiled from "test.scala"
public abstract class Test$class {
  public static void foo(Test);
  private static final java.lang.String $anonfun$1(Test, LambdaParam, Capture);
  public static void $init$(Test);
  public static final java.lang.String accessor$1(Test, LambdaParam, Capture);
}
```

BEFORE (class):

```
% cat sandbox/test.scala && scalac-hash v2.11.5 -Ydelambdafy:method sandbox/test.scala && javap -private -classpath . Test
trait Member; class Capture; trait LambdaParam
abstract class Test {
  def member: Member
  def foo {
    val local = new Capture
    (arg: LambdaParam) => "" + arg + member + local
  }
}
Compiled from "test.scala"
public abstract class Test {
  public abstract Member member();
  public void foo();
  private final java.lang.String $anonfun$1(LambdaParam, Capture);
  public Test();
  public static final java.lang.String accessor$1(Test, LambdaParam, Capture);
}
```

Contrasting the class case with Java:

```
% cat sandbox/Test.java && javac -d . sandbox/Test.java && javap -private -classpath . Test
public abstract class Test {
  public static class Member {};
  public static class Capture {};
  public static class LambaParam {};
  public static interface I {
    public abstract Object c(LambaParam arg);
  }
  public abstract Member member();
  public void test() {
    Capture local = new Capture();
    I i1 = (LambaParam arg) -> "" + member() + local;
  }
}

Compiled from "Test.java"
public abstract class Test {
  public Test();
  public abstract Test$Member member();
  public void test();
  private java.lang.Object lambda$test$0(Test$Capture, Test$LambaParam);
}
```

We can see that in Java 8 lambda parameters come after captures. If we
want to use Java's LambdaMetafactory to spin up our anoymous FunctionN
subclasses on the fly, our ordering must change.

I can see three options for change:
1. Adjust `LambdaLift` to always prepend captured parameters,
    rather than appending them. I think we could leave `Mixin` as
    it is, it already prepends the self parameter. This would result
    a parameter ordering, in terms of the list above: #3, #2, #1.
2. More conservatively, do this just for methods known to hold
    lambda bodies. This might avoid needlessly breaking code that
    has come to depend on our binary encoding.
3. Adjust the parameters of the accessor method only. The body
    of this method can permute params before calling the lambda
    body method.

This commit implements option #3. This is the lowest risk / impact
to pave the way for experimentation with indy lambdas. But it isn't
ideal as a long term solution, as indy lambdas actually don't need
the accessor method at all, private methods can be used directly
by LambdaMetaFactory, saving a little indirection.

Option #1 might be worth a shot on the 2.12.x branch. Option #2 might
even be feasible on 2.11.x.

I've included a test that shows this in all in action. However, that
is currently disabled, as we don't have a partest category for tests
that require Java 8.
