### PR TITLE
SI-7775 Exclude nulls when iterating sys props

### DIFF
--- a/src/compiler/scala/tools/cmd/Property.scala
+++ b/src/compiler/scala/tools/cmd/Property.scala
@@ -9,6 +9,7 @@ package cmd
 import nsc.io._
 import java.util.Properties
 import java.io.FileInputStream
+import scala.sys.SystemProperties
 
 /** Contains logic for translating a property key/value pair into
  *  equivalent command line arguments.  The default settings will
@@ -58,7 +59,7 @@ trait Property extends Reference {
     returning(new Properties)(_ load new FileInputStream(file.path))
 
   def systemPropertiesToOptions: List[String] =
-    propertiesToOptions(System.getProperties)
+    propertiesToOptions(new SystemProperties().toList)
 
   def propertiesToOptions(file: File): List[String] =
     propertiesToOptions(loadProperties(file))

--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -52,7 +52,7 @@ object PathResolver {
    */
   object Environment {
     private def searchForBootClasspath =
-      systemProperties find (_._1 endsWith ".boot.class.path") map (_._2) getOrElse ""
+      systemProperties collectFirst { case (k, v) if k endsWith ".boot.class.path" => v } getOrElse ""
 
     /** Environment variables which java pays attention to so it
      *  seems we do as well.

--- a/src/library/scala/sys/SystemProperties.scala
+++ b/src/library/scala/sys/SystemProperties.scala
@@ -35,8 +35,15 @@ extends mutable.AbstractMap[String, String]
   override def empty = new SystemProperties
   override def default(key: String): String = null
 
-  def iterator: Iterator[(String, String)] =
-    wrapAccess(System.getProperties().asScala.iterator) getOrElse Iterator.empty
+  def iterator: Iterator[(String, String)] = wrapAccess {
+    val ps = System.getProperties()
+    names map (k => (k, ps getProperty k)) filter (_._2 ne null)
+  } getOrElse Iterator.empty
+
+  def names: Iterator[String] = wrapAccess (
+    System.getProperties().stringPropertyNames().asScala.iterator
+  ) getOrElse Iterator.empty
+
   def get(key: String) =
     wrapAccess(Option(System.getProperty(key))) flatMap (x => x)
   override def contains(key: String) =


### PR DESCRIPTION
The previous fix to deal with concurrent modification of system
properties doesn't handle null results introduced when a property
is removed.

This commit filters nulls for safety, and also adds a `names`
method to `sys.SystemProperties`.

The test is upgraded.

Motivated by the same bug at sbt
https://github.com/sbt/sbt/pull/1893#issuecomment-76635038
and this impending change that would make the test stop testing
https://github.com/scala/scala/pull/4285#issuecomment-76721772

It's too late to help sbt.
