### PR TITLE
SI-9200 Fix Java generic signatures for refined types

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -339,8 +339,8 @@ abstract class Erasure extends AddInterfaces
           buf append (if (restpe.typeSymbol == UnitClass || sym0.isConstructor) VOID_TAG.toString else jsig(restpe))
           buf.toString
 
-        case RefinedType(parent :: _, decls) =>
-          boxedSig(parent)
+        case RefinedType(parents, decls) =>
+          boxedSig(intersectionDominator(parents))
         case ClassInfoType(parents, _, _) =>
           superSig(parents)
         case AnnotatedType(_, atp) =>

--- a/test/files/run/t9200/Test.java
+++ b/test/files/run/t9200/Test.java
@@ -1,0 +1,6 @@
+public class Test {
+    public static void main(String[] args) {
+        new C1(new C2()); // Was NoSuchMethodError
+    }
+}
+

--- a/test/files/run/t9200/test.scala
+++ b/test/files/run/t9200/test.scala
@@ -1,0 +1,12 @@
+trait W
+
+trait T1
+trait T2 extends T1
+
+object O1 {
+    type t = T1 with T2
+}
+
+class C1[w<:W](o: O1.t)
+
+class C2 extends T1 with T2


### PR DESCRIPTION
The erasure of a refined type `T1 with T2 ... Tn` is the
erasure of the intersection dominator of the elements.

In addition to erased method signatures, the compiler also emits
Java generic signatures, included information about generic types,
up to the point that it is possible to express in the language of
Java 5 generics.

Java generic signatures must be consistent with erasued signatures,
that is, the Java compiler must erase that generic signature to the
same erased signature. If this does not hold, linkage errors will
occur.

The compiler implements erasure in `ErasureMap` and java generic
signatures in `Erasure#javaSig`. Regrettably, these don't share
any implementation; e.g `javaSig` only takes the first parent of
a refinement type, rather than using `intersectionDominator`.

This commit fixes that discrepency.

Review by @lrytz
