### PR TITLE
SI-8861 Handle alias when probing for Any

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -553,9 +553,8 @@ trait Infer extends Checkable {
       // ...or lower bound of a type param, since they're asking for it.
       def canWarnAboutAny = {
         val loBounds = tparams map (_.info.bounds.lo)
-        val hasAny = pt :: restpe :: formals ::: argtpes ::: loBounds exists (t =>
-          (t contains AnyClass) || (t contains AnyValClass)
-        )
+        def containsAny(t: Type) = (t contains AnyClass) || (t contains AnyValClass)
+        val hasAny = pt :: restpe :: formals ::: argtpes ::: loBounds exists (_.dealiasWidenChain exists containsAny)
         !hasAny
       }
       def argumentPosition(idx: Int): Position = context.tree match {

--- a/test/files/pos/t8861.flags
+++ b/test/files/pos/t8861.flags
@@ -1,0 +1,1 @@
+-Xlint:infer-any -Xfatal-warnings

--- a/test/files/pos/t8861.scala
+++ b/test/files/pos/t8861.scala
@@ -1,0 +1,11 @@
+
+trait Test {
+  type R = PartialFunction[Any, Unit]
+
+  val x: R = { case "" => }
+  val y: R = { case "" => }
+
+  val z: R = x orElse y
+  val zz   = x orElse y
+}
+


### PR DESCRIPTION
If args to a method are alias types, dealias to see if they
contain Any before warning about inferring it. Similarly for
return and expected types.

Rebase of #4004 an incremental stopgap which @retronym considered bookable FWIW.
