### PR TITLE
SI-8790 detuplify match under -Xexperimental

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -207,12 +207,12 @@ trait MatchApproximation extends TreeAndTypeAnalysis with ScalaLogic with MatchT
       override def toString = s"T${id}C($prop)"
     }
 
-    class TreeMakersToPropsIgnoreNullChecks(root: Symbol) extends TreeMakersToProps(root) {
+    class TreeMakersToPropsIgnoreNullChecks(scrutinee: Scrutinee) extends TreeMakersToProps(scrutinee) {
       override def uniqueNonNullProp(p: Tree): Prop = True
     }
 
     // returns (tree, tests), where `tree` will be used to refer to `root` in `tests`
-    class TreeMakersToProps(val root: Symbol) {
+    class TreeMakersToProps(val scrutinee: Scrutinee) {
       prepareNewAnalysis() // reset hash consing for Var and Const
 
       private[this] val uniqueEqualityProps = new mutable.HashMap[(Tree, Tree), Eq]
@@ -230,7 +230,7 @@ trait MatchApproximation extends TreeAndTypeAnalysis with ScalaLogic with MatchT
         uniqueTypeProps getOrElseUpdate((testedPath, pt), Eq(Var(testedPath), TypeConst(checkableType(pt))))
 
       // a variable in this set should never be replaced by a tree that "does not consist of a selection on a variable in this set" (intuitively)
-      private val pointsToBound = mutable.HashSet(root)
+      private val pointsToBound = mutable.HashSet(scrutinee.sym)
       private val trees         = mutable.HashSet.empty[Tree]
 
       // the substitution that renames variables to variables in pointsToBound
@@ -377,8 +377,8 @@ trait MatchApproximation extends TreeAndTypeAnalysis with ScalaLogic with MatchT
       }
     }
 
-    def approximateMatchConservative(root: Symbol, cases: List[List[TreeMaker]]): List[List[Test]] =
-      (new TreeMakersToProps(root)).approximateMatch(cases)
+    def approximateMatchConservative(scrutinee: Scrutinee, cases: List[List[TreeMaker]]): List[List[Test]] =
+      (new TreeMakersToProps(scrutinee)).approximateMatch(cases)
 
     // turns a case (represented as a list of abstract tests)
     // into a proposition that is satisfiable if the case may match
@@ -416,13 +416,13 @@ trait MatchAnalysis extends MatchApproximation {
     // the case is reachable if there is a model for -P /\ C,
     // thus, the case is unreachable if there is no model for -(-P /\ C),
     // or, equivalently, P \/ -C, or C => P
-    def unreachableCase(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type): Option[Int] = {
+    def unreachableCase(scrutinee: Scrutinee, cases: List[List[TreeMaker]], pt: Type): Option[Int] = {
       val start = if (Statistics.canEnable) Statistics.startTimer(patmatAnaReach) else null
 
       // use the same approximator so we share variables,
       // but need different conditions depending on whether we're conservatively looking for failure or success
       // don't rewrite List-like patterns, as List() and Nil need to distinguished for unreachability
-      val approx = new TreeMakersToProps(prevBinder)
+      val approx = new TreeMakersToProps(scrutinee)
       def approximate(default: Prop) = approx.approximateMatch(cases, approx.onUnknown { tm =>
         approx.refutableRewrite.applyOrElse(tm, (_: TreeMaker) => default )
       })
@@ -471,14 +471,14 @@ trait MatchAnalysis extends MatchApproximation {
         if (reachable) None else Some(caseIndex)
       } catch {
         case ex: AnalysisBudget.Exception =>
-          warn(prevBinder.pos, ex, "unreachability")
+          warn(scrutinee.pos, ex, "unreachability")
           None // CNF budget exceeded
       }
     }
 
     // exhaustivity
 
-    def exhaustive(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type): List[String] = if (uncheckableType(prevBinder.info)) Nil else {
+    def exhaustive(scrutinee: Scrutinee, cases: List[List[TreeMaker]], pt: Type): List[String] = if (uncheckableType(scrutinee.info)) Nil else {
       // customize TreeMakersToProps (which turns a tree of tree makers into a more abstract DAG of tests)
       // - approximate the pattern `List()` (unapplySeq on List with empty length) as `Nil`,
       //   otherwise the common (xs: List[Any]) match { case List() => case x :: xs => } is deemed unexhaustive
@@ -488,7 +488,7 @@ trait MatchAnalysis extends MatchApproximation {
       val start = if (Statistics.canEnable) Statistics.startTimer(patmatAnaExhaust) else null
       var backoff = false
 
-      val approx = new TreeMakersToPropsIgnoreNullChecks(prevBinder)
+      val approx = new TreeMakersToPropsIgnoreNullChecks(scrutinee)
       val symbolicCases = approx.approximateMatch(cases, approx.onUnknown { tm =>
         approx.fullRewrite.applyOrElse[TreeMaker, Prop](tm, {
           case BodyTreeMaker(_, _) => True // irrelevant -- will be discarded by symbolCase later
@@ -499,8 +499,6 @@ trait MatchAnalysis extends MatchApproximation {
       }) map caseWithoutBodyToProp
 
       if (backoff) Nil else {
-        val prevBinderTree = approx.binderToUniqueTree(prevBinder)
-
         // TODO: null tests generate too much noise, so disabled them -- is there any way to bring them back?
         // assuming we're matching on a non-null scrutinee (prevBinder), when does the match fail?
         // val nonNullScrutineeCond =
@@ -523,8 +521,9 @@ trait MatchAnalysis extends MatchApproximation {
 
         try {
           // find the models (under which the match fails)
-          val matchFailModels = findAllModelsFor(propToSolvable(matchFails), prevBinder.pos)
+          val matchFailModels = findAllModelsFor(propToSolvable(matchFails), scrutinee.pos)
 
+          val prevBinderTree = approx.binderToUniqueTree(scrutinee.sym)
           val scrutVar = Var(prevBinderTree)
           val counterExamples = {
             matchFailModels.flatMap {
@@ -543,7 +542,7 @@ trait MatchAnalysis extends MatchApproximation {
           pruned
         } catch {
           case ex: AnalysisBudget.Exception =>
-            warn(prevBinder.pos, ex, "exhaustivity")
+            warn(scrutinee.pos, ex, "exhaustivity")
             Nil // CNF budget exceeded
         }
       }
@@ -875,16 +874,16 @@ trait MatchAnalysis extends MatchApproximation {
       VariableAssignment(scrutVar).toCounterExample()
     }
 
-    def analyzeCases(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type, suppression: Suppression): Unit = {
+    def analyzeCases(scrutinee: Scrutinee, cases: List[List[TreeMaker]], pt: Type, suppression: Suppression): Unit = {
       if (!suppression.suppressUnreachable) {
-        unreachableCase(prevBinder, cases, pt) foreach { caseIndex =>
+        unreachableCase(scrutinee, cases, pt) foreach { caseIndex =>
           reportUnreachable(cases(caseIndex).last.pos)
         }
       }
       if (!suppression.suppressExhaustive) {
-        val counterExamples = exhaustive(prevBinder, cases, pt)
+        val counterExamples = exhaustive(scrutinee, cases, pt)
         if (counterExamples.nonEmpty)
-          reportMissingCases(prevBinder.pos, counterExamples)
+          reportMissingCases(scrutinee.pos, counterExamples)
       }
     }
   }

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchCodeGen.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchCodeGen.scala
@@ -36,7 +36,7 @@ trait MatchCodeGen extends Interface {
 
     // codegen relevant to the structure of the translation (how extractors are combined)
     trait AbsCodegen {
-      def matcher(scrut: Tree, scrutSym: Symbol, restpe: Type)(cases: List[Casegen => Tree], matchFailGen: Option[Tree => Tree]): Tree
+      def matcher(scrut: Tree, scrutSym: Symbol, restpe: Type)(cases: List[Casegen => Tree], defaultCase: Option[Tree]): Tree
 
       // local / context-free
       def _asInstanceOf(b: Symbol, tp: Type): Tree
@@ -109,7 +109,7 @@ trait MatchCodeGen extends Interface {
       //// methods in MatchingStrategy (the monad companion) -- used directly in translation
       // __match.runOrElse(`scrut`)(`scrutSym` => `matcher`)
       // TODO: consider catchAll, or virtualized matching will break in exception handlers
-      def matcher(scrut: Tree, scrutSym: Symbol, restpe: Type)(cases: List[Casegen => Tree], matchFailGen: Option[Tree => Tree]): Tree =
+      def matcher(scrut: Tree, scrutSym: Symbol, restpe: Type)(cases: List[Casegen => Tree], defaultCase: Option[Tree]): Tree =
         _match(vpmName.runOrElse) APPLY (scrut) APPLY (fun(scrutSym, cases map (f => f(this)) reduceLeft typedOrElse))
 
       // __match.one(`res`)
@@ -146,7 +146,7 @@ trait MatchCodeGen extends Interface {
        * the matcher's optional result is encoded as a flag, keepGoing, where keepGoing == true encodes result.isEmpty,
        * if keepGoing is false, the result Some(x) of the naive translation is encoded as matchRes == x
        */
-      def matcher(scrut: Tree, scrutSym: Symbol, restpe: Type)(cases: List[Casegen => Tree], matchFailGen: Option[Tree => Tree]): Tree = {
+      def matcher(scrut: Tree, scrutSym: Symbol, restpe: Type)(cases: List[Casegen => Tree], defaultCase: Option[Tree]): Tree = {
         val matchRes = NoSymbol.newValueParameter(newTermName("x"), NoPosition, newFlags = SYNTHETIC) setInfo restpe.withoutAnnotations
         val matchEnd = newSynthCaseLabel("matchEnd") setInfo MethodType(List(matchRes), restpe)
 
@@ -163,10 +163,10 @@ trait MatchCodeGen extends Interface {
         // must compute catchAll after caseLabels (side-effects nextCase)
         // catchAll.isEmpty iff no synthetic default case needed (the (last) user-defined case is a default)
         // if the last user-defined case is a default, it will never jump to the next case; it will go immediately to matchEnd
-        val catchAllDef = matchFailGen map { matchFailGen =>
+        val catchAllDef = defaultCase map { defaultCase =>
           val scrutRef = scrutSym.fold(EmptyTree: Tree)(REF) // for alternatives
 
-          LabelDef(_currCase, Nil, matchEnd APPLY (matchFailGen(scrutRef)))
+          LabelDef(_currCase, Nil, matchEnd APPLY (defaultCase))
         } toList // at most 1 element
 
         // scrutSym == NoSymbol when generating an alternatives matcher
@@ -183,8 +183,8 @@ trait MatchCodeGen extends Interface {
       }
 
       class OptimizedCasegen(matchEnd: Symbol, nextCase: Symbol) extends CommonCodegen with Casegen {
-        def matcher(scrut: Tree, scrutSym: Symbol, restpe: Type)(cases: List[Casegen => Tree], matchFailGen: Option[Tree => Tree]): Tree =
-          optimizedCodegen.matcher(scrut, scrutSym, restpe)(cases, matchFailGen)
+        def matcher(scrut: Tree, scrutSym: Symbol, restpe: Type)(cases: List[Casegen => Tree], defaultCase: Option[Tree]): Tree =
+          optimizedCodegen.matcher(scrut, scrutSym, restpe)(cases, defaultCase)
 
         // only used to wrap the RHS of a body
         // res: T

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
@@ -31,11 +31,11 @@ trait MatchOptimization extends MatchTreeMaking with MatchAnalysis {
      * the variable is floated up so that its scope includes all of the program that shares it
      * we generalize sharing to implication, where b reuses a if a => b and priors(a) => priors(b) (the priors of a sub expression form the path through the decision tree)
      */
-    def doCSE(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type): List[List[TreeMaker]] = {
+    def doCSE(scrutinee: Scrutinee, cases: List[List[TreeMaker]], pt: Type): List[List[TreeMaker]] = {
       debug.patmat("before CSE:")
       showTreeMakers(cases)
 
-      val testss = approximateMatchConservative(prevBinder, cases)
+      val testss = approximateMatchConservative(scrutinee, cases)
 
       // interpret:
       val dependencies = new mutable.LinkedHashMap[Test, Set[Prop]]
@@ -491,7 +491,7 @@ trait MatchOptimization extends MatchTreeMaking with MatchAnalysis {
         }
     }
 
-    class RegularSwitchMaker(scrutSym: Symbol, defaultCaseOverride: Option[Tree], val unchecked: Boolean) extends SwitchMaker {
+    class RegularSwitchMaker(scrutinee: Scrutinee, defaultCaseOverride: Option[Tree], val unchecked: Boolean) extends SwitchMaker {
       val switchableTpe = Set(ByteTpe, ShortTpe, IntTpe, CharTpe)
       val alternativesSupported = true
       val canJump = true
@@ -516,26 +516,26 @@ trait MatchOptimization extends MatchTreeMaking with MatchAnalysis {
         case _ => false
       }
 
-      def defaultSym: Symbol = scrutSym
-      def defaultBody: Tree  = { import CODE._; defaultCaseOverride getOrElse Throw(MatchErrorClass.tpe, REF(scrutSym)) }
+      def defaultSym: Symbol = scrutinee.sym
+      def defaultBody: Tree  = { import CODE._; defaultCaseOverride getOrElse Throw(MatchErrorClass.tpe, scrutinee.ref) }
       def defaultCase(scrutSym: Symbol = defaultSym, guard: Tree = EmptyTree, body: Tree = defaultBody): CaseDef = { import CODE._; atPos(body.pos) {
         (DEFAULT IF guard) ==> body
       }}
     }
 
-    override def emitSwitch(scrut: Tree, scrutSym: Symbol, cases: List[List[TreeMaker]], pt: Type, defaultCaseOverride: Option[Tree], unchecked: Boolean): Option[Tree] = { import CODE._
-      val regularSwitchMaker = new RegularSwitchMaker(scrutSym, defaultCaseOverride, unchecked)
+    override def emitSwitch(scrutinee: Scrutinee, cases: List[List[TreeMaker]], pt: Type, defaultCaseOverride: Option[Tree], unchecked: Boolean): Option[Tree] = { import CODE._
+      val regularSwitchMaker = new RegularSwitchMaker(scrutinee, defaultCaseOverride, unchecked)
       // TODO: if patterns allow switch but the type of the scrutinee doesn't, cast (type-test) the scrutinee to the corresponding switchable type and switch on the result
-      if (regularSwitchMaker.switchableTpe(dealiasWiden(scrutSym.tpe))) {
-        val caseDefsWithDefault = regularSwitchMaker(cases map {c => (scrutSym, c)}, pt)
+      if (regularSwitchMaker.switchableTpe(dealiasWiden(scrutinee.info))) {
+        val caseDefsWithDefault = regularSwitchMaker(cases map {c => (scrutinee.sym, c)}, pt)
         if (caseDefsWithDefault isEmpty) None // not worth emitting a switch.
         else {
-          // match on scrutSym -- converted to an int if necessary -- not on scrut directly (to avoid duplicating scrut)
+          // match on scrutinee.sym -- converted to an int if necessary -- not on scrut directly (to avoid duplicating scrut)
           val scrutToInt: Tree =
-            if (scrutSym.tpe =:= IntTpe) REF(scrutSym)
-            else (REF(scrutSym) DOT (nme.toInt))
-          Some(BLOCK(
-            ValDef(scrutSym, scrut),
+            if (scrutinee.info =:= IntTpe) scrutinee.ref
+            else (scrutinee.ref DOT (nme.toInt))
+          Some(Block(
+            scrutinee.defs,
             Match(scrutToInt, caseDefsWithDefault) // a switch
           ))
         }
@@ -584,9 +584,9 @@ trait MatchOptimization extends MatchTreeMaking with MatchAnalysis {
   trait MatchOptimizer extends OptimizedCodegen
                           with SwitchEmission
                           with CommonSubconditionElimination {
-    override def optimizeCases(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type): (List[List[TreeMaker]], List[Tree]) = {
+    override def optimizeCases(scrutinee: Scrutinee, cases: List[List[TreeMaker]], pt: Type): (List[List[TreeMaker]], List[Tree]) = {
       // TODO: do CSE on result of doDCE(prevBinder, cases, pt)
-      val optCases = doCSE(prevBinder, cases, pt)
+      val optCases = doCSE(scrutinee, cases, pt)
       val toHoist = (
         for (treeMakers <- optCases)
           yield treeMakers.collect{case tm: ReusedCondTreeMaker => tm.treesToHoist}

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
@@ -204,7 +204,7 @@ trait MatchTranslation {
       val Match(selector, cases) = match_
 
       val (nonSyntheticCases, defaultOverride) = cases match {
-        case init :+ last if treeInfo isSyntheticDefaultCase last => (init, Some(((scrut: Tree) => last.body)))
+        case init :+ last if treeInfo isSyntheticDefaultCase last => (init, Some(last.body))
         case _                                                    => (cases, None)
       }
 
@@ -268,13 +268,14 @@ trait MatchTranslation {
           val casesNoSubstOnly = caseDefs map { caseDef => (propagateSubstitution(translateCase(scrutSym, pt)(caseDef), EmptySubstitution))}
 
           val exSym = freshSym(pos, pureType(ThrowableTpe), "ex")
+          val selector = REF(exSym)
 
           List(
               atPos(pos) {
                 CaseDef(
                   Bind(exSym, Ident(nme.WILDCARD)), // TODO: does this need fixing upping?
                   EmptyTree,
-                  combineCasesNoSubstOnly(REF(exSym), scrutSym, casesNoSubstOnly, pt, matchOwner, Some(scrut => Throw(REF(exSym))))
+                  combineCasesNoSubstOnly(selector, scrutSym, casesNoSubstOnly, pt, matchOwner, Some(Throw(selector)))
                 )
               })
         }

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
@@ -98,10 +98,13 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
       override def toString = "B"+((body, matchPt))
     }
 
-    case class SubstOnlyTreeMaker(prevBinder: Symbol, nextBinder: Symbol) extends TreeMaker {
+    object SubstOnlyTreeMaker {
+      def apply(prevBinder: Symbol, nextBinder: Symbol) = new SubstOnlyTreeMaker(List(prevBinder), List(CODE.REF(nextBinder)))
+    }
+    case class SubstOnlyTreeMaker(binders: List[Symbol], refs: List[Tree]) extends TreeMaker {
       val pos = NoPosition
 
-      val localSubstitution = Substitution(prevBinder, CODE.REF(nextBinder))
+      val localSubstitution = Substitution(binders, refs)
       def chainBefore(next: Tree)(casegen: Casegen): Tree = substitution(next)
       override def toString = "S"+ localSubstitution
     }

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
@@ -31,10 +31,10 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
 // the making of the trees
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   trait TreeMakers extends TypedSubstitution with CodegenCore {
-    def optimizeCases(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type): (List[List[TreeMaker]], List[Tree])
-    def analyzeCases(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type, suppression: Suppression): Unit
+    def optimizeCases(scrutinee: Scrutinee, cases: List[List[TreeMaker]], pt: Type): (List[List[TreeMaker]], List[Tree])
+    def analyzeCases(scrutinee: Scrutinee, cases: List[List[TreeMaker]], pt: Type, suppression: Suppression): Unit
 
-    def emitSwitch(scrut: Tree, scrutSym: Symbol, cases: List[List[TreeMaker]], pt: Type, defaultCaseOverride: Option[Tree], unchecked: Boolean): Option[Tree] =
+    def emitSwitch(scrutinee: Scrutinee, cases: List[List[TreeMaker]], pt: Type, defaultCaseOverride: Option[Tree], unchecked: Boolean): Option[Tree] =
       None
 
     // for catch (no need to customize match failure)
@@ -505,7 +505,7 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
             ((casegen: Casegen) => combineExtractors(altTreeMakers :+ TrivialTreeMaker(casegen.one(mkTRUE)))(casegen))
           )
 
-          val findAltMatcher = codegenAlt.matcher(EmptyTree, NoSymbol, BooleanTpe)(combinedAlts, Some(mkFALSE))
+          val findAltMatcher = codegenAlt.matcher(NoScrutinee, BooleanTpe)(combinedAlts, Some(mkFALSE))
           codegenAlt.ifThenElseZero(findAltMatcher, substitution(next))
         }
       }
@@ -538,74 +538,67 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
     }
 
     // calls propagateSubstitution on the treemakers
-    def combineCases(scrut: Tree, scrutSym: Symbol, casesRaw: List[List[TreeMaker]], pt: Type, owner: Symbol, defaultCaseOverride: Option[Tree]): Tree = {
+    def combineCases(scrutinee: MatchScrutinee, casesRaw: List[List[TreeMaker]], pt: Type, owner: Symbol, defaultCaseOverride: Option[Tree]): Tree = {
       // drops SubstOnlyTreeMakers, since their effect is now contained in the TreeMakers that follow them
       val casesNoSubstOnly = casesRaw map (propagateSubstitution(_, EmptySubstitution))
-      combineCasesNoSubstOnly(scrut, scrutSym, casesNoSubstOnly, pt, owner, defaultCaseOverride)
+      combineCasesNoSubstOnly(scrutinee, casesNoSubstOnly, pt, owner, defaultCaseOverride)
     }
 
     // pt is the fully defined type of the cases (either pt or the lub of the types of the cases)
-    def combineCasesNoSubstOnly(scrut: Tree, scrutSym: Symbol, casesNoSubstOnly: List[List[TreeMaker]], pt: Type, owner: Symbol, defaultCaseOverride: Option[Tree]): Tree =
-      fixerUpper(owner, scrut.pos) {
+    def combineCasesNoSubstOnly(scrutinee: MatchScrutinee, casesNoSubstOnly: List[List[TreeMaker]], pt: Type, owner: Symbol, defaultCaseOverride: Option[Tree]): Tree =
+      fixerUpper(owner, scrutinee.pos) {
         debug.patmat("combining cases: "+ (casesNoSubstOnly.map(_.mkString(" >> ")).mkString("{", "\n", "}")))
 
         val (suppression, requireSwitch): (Suppression, Boolean) =
           if (settings.XnoPatmatAnalysis) (Suppression.FullSuppression, false)
-          else scrut match {
-            case Typed(tree, tpt) =>
-              val suppressExhaustive = tpt.tpe hasAnnotation UncheckedClass
-              val supressUnreachable = tree match {
-                case Ident(name) if name startsWith nme.CHECK_IF_REFUTABLE_STRING => true // SI-7183 don't warn for withFilter's that turn out to be irrefutable.
-                case _ => false
+          else if (scrutinee.typeAscribed.nonEmpty) {
+            val suppression = Suppression(scrutinee.suppressExhaustive, scrutinee.supressUnreachable)
+            // matches with two or fewer cases need not apply for switchiness (if-then-else will do)
+            // `case 1 | 2` is considered as two cases.
+            def exceedsTwoCasesOrAlts = {
+              // avoids traversing the entire list if there are more than 3 elements
+              def lengthMax3[T](l: List[T]): Int = l match {
+                case a :: b :: c :: _ => 3
+                case cases            =>
+                  cases.map({
+                    case AlternativesTreeMaker(_, alts, _) :: _ => lengthMax3(alts)
+                    case c                                      => 1
+                  }).sum
               }
-              val suppression = Suppression(suppressExhaustive, supressUnreachable)
-              val hasSwitchAnnotation = treeInfo.isSwitchAnnotation(tpt.tpe)
-              // matches with two or fewer cases need not apply for switchiness (if-then-else will do)
-              // `case 1 | 2` is considered as two cases.
-              def exceedsTwoCasesOrAlts = {
-                // avoids traversing the entire list if there are more than 3 elements
-                def lengthMax3[T](l: List[T]): Int = l match {
-                  case a :: b :: c :: _ => 3
-                  case cases =>
-                    cases.map({
-                      case AlternativesTreeMaker(_, alts, _) :: _ => lengthMax3(alts)
-                      case c => 1
-                    }).sum
-                }
-                lengthMax3(casesNoSubstOnly) > 2
-              }
-              val requireSwitch = hasSwitchAnnotation && exceedsTwoCasesOrAlts
-              (suppression, requireSwitch)
-            case _ =>
-              (Suppression.NoSuppression, false)
-          }
 
-        emitSwitch(scrut, scrutSym, casesNoSubstOnly, pt, defaultCaseOverride, unchecked = suppression.suppressExhaustive).getOrElse{
-          if (requireSwitch) reporter.warning(scrut.pos, "could not emit switch for @switch annotated match")
+              lengthMax3(casesNoSubstOnly) > 2
+            }
+            val requireSwitch = scrutinee.hasSwitchAnnotation && exceedsTwoCasesOrAlts
 
-          def defaultCase = defaultCaseOverride orElse Some(Throw(MatchErrorClass.tpe, CODE.REF(scrutSym)))
+            (suppression, requireSwitch)
+          } else (Suppression.NoSuppression, false)
+
+        emitSwitch(scrutinee, casesNoSubstOnly, pt, defaultCaseOverride, unchecked = suppression.suppressExhaustive).getOrElse{
+          if (requireSwitch) reporter.warning(scrutinee.pos, "could not emit switch for @switch annotated match")
+
+          def defaultCase = defaultCaseOverride orElse Some(Throw(MatchErrorClass.tpe, scrutinee.ref))
 
           if (casesNoSubstOnly nonEmpty) {
             // before optimizing, check casesNoSubstOnly for presence of a default case,
             // since DCE will eliminate trivial cases like `case _ =>`, even if they're the last one
             // exhaustivity and reachability must be checked before optimization as well
             // TODO: improve notion of trivial/irrefutable -- a trivial type test before the body still makes for a default case
-            //   ("trivial" depends on whether we're emitting a straight match or an exception, or more generally, any supertype of scrutSym.tpe is a no-op)
+            //   ("trivial" depends on whether we're emitting a straight match or an exception, or more generally, any supertype of scrutinee.info is a no-op)
             //   irrefutability checking should use the approximation framework also used for CSE, unreachability and exhaustivity checking
             val nonTrivLast            = casesNoSubstOnly.last
             val hasUserSuppliedDefault = nonTrivLast.nonEmpty && nonTrivLast.head.isInstanceOf[BodyTreeMaker]
 
-            analyzeCases(scrutSym, casesNoSubstOnly, pt, suppression)
+            analyzeCases(scrutinee, casesNoSubstOnly, pt, suppression)
 
-            val (cases, toHoist) = optimizeCases(scrutSym, casesNoSubstOnly, pt)
+            val (cases, toHoist) = optimizeCases(scrutinee, casesNoSubstOnly, pt)
 
             val defaultCaseUnlessUserSupplied = if (hasUserSuppliedDefault) None else defaultCase
 
-            val matchRes = codegen.matcher(scrut, scrutSym, pt)(cases map combineExtractors, defaultCaseUnlessUserSupplied)
+            val matchRes = codegen.matcher(scrutinee, pt)(cases map combineExtractors, defaultCaseUnlessUserSupplied)
 
             if (toHoist isEmpty) matchRes else Block(toHoist, matchRes)
           } else {
-            codegen.matcher(scrut, scrutSym, pt)(Nil, defaultCase)
+            codegen.matcher(scrutinee, pt)(Nil, defaultCase)
           }
         }
       }

--- a/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
@@ -140,6 +140,9 @@ trait Interface extends ast.TreeDSL {
     // if there's a single symbol to represent this scrutinee, otherwise NoSymbol
     def sym: Symbol
 
+    // empty (if sym == NoSymbol), List(sym) (sym != NoSymbol), or multiple symbols (for tuple scrutinee)
+    def syms: List[Symbol] = if (sym.exists) List(sym) else Nil
+
     // a way to refer to the scrutinee definition
     def ref: Tree
 

--- a/src/compiler/scala/tools/nsc/typechecker/Checkable.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Checkable.scala
@@ -116,7 +116,7 @@ trait Checkable {
        uncheckedOk(arg)                                 // @unchecked T
     || isUnwarnableTypeArgSymbol(arg.typeSymbolDirect)  // has to be direct: see pos/t1439
   )
-  private def uncheckedOk(tp: Type) = tp hasAnnotation UncheckedClass
+  private def uncheckedOk(tp: Type) = treeInfo isUncheckedAnnotation tp
 
   private def typeArgsInTopLevelType(tp: Type): List[Type] = {
     val tps = tp match {

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -581,6 +581,11 @@ trait Definitions extends api.StandardDefinitions {
     def isFunctionSymbol(sym: Symbol) = FunctionClass.seq contains unspecializedSymbol(sym)
     def isProductNSymbol(sym: Symbol) = ProductClass.seq contains unspecializedSymbol(sym)
 
+    def isTupleFactory(sym: Symbol, arity: Int): Boolean =
+      arity > 0 && sym.exists && ( // using unspecializedSymbol for future-proofing -- currently the apply method/constructor aren't specialized
+           unspecializedSymbol(sym) == TupleClass(arity).companionModule.info.nonPrivateMember(nme.apply)
+        || unspecializedSymbol(sym) == TupleClass(arity).primaryConstructor)
+
     def unspecializedSymbol(sym: Symbol): Symbol = {
       if (sym hasFlag SPECIALIZED) {
         // add initialization from its generic class constructor

--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -530,6 +530,8 @@ abstract class TreeInfo {
   /** a Match(Typed(_, tpt), _) must be translated into a switch if isSwitchAnnotation(tpt.tpe) */
   def isSwitchAnnotation(tpe: Type) = tpe hasAnnotation definitions.SwitchClass
 
+  def isUncheckedAnnotation(tpe: Type) = tpe hasAnnotation definitions.UncheckedClass
+
   /** can this type be a type pattern */
   def mayBeTypePat(tree: Tree): Boolean = tree match {
     case CompoundTypeTree(Template(tps, _, Nil)) => tps exists mayBeTypePat

--- a/test/files/jvm/patmat_opt_tuple_scrut.check
+++ b/test/files/jvm/patmat_opt_tuple_scrut.check
@@ -1,0 +1,4 @@
+bytecode identical
+bytecode identical
+bytecode identical
+bytecode identical

--- a/test/files/jvm/patmat_opt_tuple_scrut.flags
+++ b/test/files/jvm/patmat_opt_tuple_scrut.flags
@@ -1,0 +1,1 @@
+-optimize -Xexperimental

--- a/test/files/jvm/patmat_opt_tuple_scrut/Analyzed_1.scala
+++ b/test/files/jvm/patmat_opt_tuple_scrut/Analyzed_1.scala
@@ -1,0 +1,63 @@
+// method a's bytecode should be identical to method b's bytecode under -optimize
+final class Simple { // also covers calling the apply method on Tuple2, as that's what this desugars to
+  def a(x1: Any, x2: Any): Int = (x1, x2) match {
+    case (s1: String, s2: String) => return 1
+    case (i1: Int, s2)            => return 2
+    case (s1, s2: String)         => return 3
+    case _                        => return 4
+  }
+
+  def b(x1: Any, x2: Any): Int = {
+    if (x1.isInstanceOf[String] && x2.isInstanceOf[String]) return 1
+    else if (x1.isInstanceOf[Int])                          return 2
+    else if (x2.isInstanceOf[String])                       return 3
+    else                                                    return 4
+  }
+}
+
+
+final class Constructor {
+  def a(x1: Any, x2: Any): Int = ((new Tuple2(x1, x2))) match {
+    case (s1: String, s2: String) => return 1
+    case (i1: Int, s2)            => return 2
+    case (s1, s2: String)         => return 3
+    case _                        => return 4
+  }
+
+  def b(x1: Any, x2: Any): Int = {
+    if (x1.isInstanceOf[String] && x2.isInstanceOf[String]) return 1
+    else if (x1.isInstanceOf[Int])                          return 2
+    else if (x2.isInstanceOf[String])                       return 3
+    else                                                    return 4
+  }
+}
+
+// should not optimize
+final class Referenced {
+  def a(x1: Any, x2: Any): Boolean = (x1, x2) match {
+    case t@(s1, s2) => t.isInstanceOf[Tuple2[_, _]]
+  }
+
+  def b(x1: Any, x2: Any): Boolean = {
+    val scrut = (x1, x2)
+    scrut.isInstanceOf[Tuple2[_, _]]
+  }
+}
+
+// should not optimize
+final class Sneaky {
+  def a(x1: Any, x2: Any): Int = {???; Tuple2}.apply(x1, x2) match {
+    case (s1: String, s2: String) => return 1
+    case (i1: Int, s2)            => return 2
+    case (s1, s2: String)         => return 3
+    case _                        => return 4
+  }
+
+  def b(x1: Any, x2: Any): Int = {
+    val scrut = {???; Tuple2}.apply(x1, x2) // should not elide the ??? call
+    if (scrut._1.isInstanceOf[String] && scrut._2.isInstanceOf[String]) return 1
+    else if (scrut._1.isInstanceOf[Int])                          return 2
+    else if (scrut._2.isInstanceOf[String])                       return 3
+    else                                                    return 4
+  }
+}

--- a/test/files/jvm/patmat_opt_tuple_scrut/test.scala
+++ b/test/files/jvm/patmat_opt_tuple_scrut/test.scala
@@ -1,0 +1,14 @@
+import scala.tools.partest.BytecodeTest
+
+import scala.tools.nsc.util.JavaClassPath
+import java.io.InputStream
+import scala.tools.asm
+import asm.ClassReader
+import asm.tree.{ClassNode, InsnList}
+import scala.collection.JavaConverters._
+
+object Test extends BytecodeTest {
+  def show: Unit = List("Simple", "Constructor", "Referenced", "Sneaky") map (loadClassNode(_)) foreach { classNode =>
+    sameBytecode(getMethod(classNode, "a"), getMethod(classNode, "b"))
+  }
+}

--- a/test/files/neg/patmat_tuple_opt_exhaust.check
+++ b/test/files/neg/patmat_tuple_opt_exhaust.check
@@ -1,0 +1,7 @@
+patmat_tuple_opt_exhaust.scala:7: warning: match may not be exhaustive.
+It would fail on the following inputs: (C(_, _), C(_, _)), (C(_, _), N()), (N(), C(_, _)), (N(), N())
+    (a1, a2) match {
+    ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/patmat_tuple_opt_exhaust.flags
+++ b/test/files/neg/patmat_tuple_opt_exhaust.flags
@@ -1,0 +1,1 @@
+-Xexperimental -Xfatal-warnings

--- a/test/files/neg/patmat_tuple_opt_exhaust.scala
+++ b/test/files/neg/patmat_tuple_opt_exhaust.scala
@@ -1,0 +1,14 @@
+sealed abstract class L[A]
+final case class N[A]() extends L[A]
+final case class C[A](head: A, tail: L[A]) extends L[A]
+
+object Test {
+  def exhaust[A](a1: L[A], a2: L[A]): Unit =
+    (a1, a2) match {
+      // case (N(), N())         =>
+      // case (N(), C(_, _))     =>
+      // case (C(_, _), N())     =>
+      // case (C(_, _), C(_, _)) =>
+      case (null, null)          =>
+    }
+}

--- a/test/files/pos/patmat_tuple_opt_erasure.flags
+++ b/test/files/pos/patmat_tuple_opt_erasure.flags
@@ -1,0 +1,1 @@
+-Xexperimental

--- a/test/files/pos/patmat_tuple_opt_erasure.scala
+++ b/test/files/pos/patmat_tuple_opt_erasure.scala
@@ -1,0 +1,9 @@
+object T {
+  def layoutFromParent(x: Option[String], y: Option[String]): (String, String) = (x, y) match {
+    case (_,          None  )  => ???
+    case (None,       Some(_)) => ???
+    case (None,       Some(_)) => ???
+    case (Some(_), Some(_))    => ???
+    case (Some(_), Some(_))    => ???
+  }
+}

--- a/test/files/pos/patmat_tuple_opt_tailrec.flags
+++ b/test/files/pos/patmat_tuple_opt_tailrec.flags
@@ -1,0 +1,1 @@
+-Xexperimental

--- a/test/files/pos/patmat_tuple_opt_tailrec.scala
+++ b/test/files/pos/patmat_tuple_opt_tailrec.scala
@@ -1,0 +1,11 @@
+import scala.annotation.tailrec
+
+object Test {
+  @tailrec final def rec(a: Any, b: Any): Unit =
+    (a, b) match {
+      case (_, _) =>
+        null match {
+          case _ => rec(a, b)
+        }
+    }
+}

--- a/test/files/run/inline-ex-handlers.check
+++ b/test/files/run/inline-ex-handlers.check
@@ -32,8 +32,8 @@
      92	LOAD_LOCAL(value x1)
 @@ -390,5 +386,5 @@
    def main(args: Array[String] (ARRAY[REF(class String)])): Unit {
--  locals: value args, variable result, value ex6, value x4, value x5, value message, value x
-+  locals: value args, variable result, value ex6, value x4, value x5, value x
+-  locals: value args, variable result, value ex4, value x5, value x6, value message, value x
++  locals: value args, variable result, value ex4, value x5, value x6, value x
    startBlock: 1
 -  blocks: [1,2,3,4,5,8,10,11,13]
 +  blocks: [1,2,3,5,8,10,11,13,14]
@@ -41,33 +41,33 @@
 @@ -416,4 +412,13 @@
      103	CALL_METHOD MyException.<init> (static-instance)
 -    103	THROW(MyException)
-+    ?	STORE_LOCAL(value ex6)
++    ?	STORE_LOCAL(value ex4)
 +    ?	JUMP 14
      
 +  14: 
-+    101	LOAD_LOCAL(value ex6)
-+    101	STORE_LOCAL(value x4)
-+    101	SCOPE_ENTER value x4
-+    106	LOAD_LOCAL(value x4)
++    101	LOAD_LOCAL(value ex4)
++    101	STORE_LOCAL(value x5)
++    101	SCOPE_ENTER value x5
++    106	LOAD_LOCAL(value x5)
 +    106	IS_INSTANCE REF(class MyException)
 +    106	CZJUMP (BOOL)NE ? 5 : 8
 +    
    13: 
 @@ -429,5 +434,2 @@
-     101	SCOPE_ENTER value x4
+     101	SCOPE_ENTER value x5
 -    101	JUMP 4
 -    
 -  4: 
-     106	LOAD_LOCAL(value x4)
+     106	LOAD_LOCAL(value x5)
 @@ -441,8 +443,5 @@
-     106	SCOPE_ENTER value x5
--    106	LOAD_LOCAL(value x5)
+     106	SCOPE_ENTER value x6
+-    106	LOAD_LOCAL(value x6)
 -    106	CALL_METHOD MyException.message (dynamic)
 -    106	STORE_LOCAL(value message)
 -    106	SCOPE_ENTER value message
      106	LOAD_MODULE object Predef
 -    106	LOAD_LOCAL(value message)
-+    ?	LOAD_LOCAL(value x5)
++    101	LOAD_LOCAL(value x6)
 +    106	CALL_METHOD MyException.message (dynamic)
      106	CALL_METHOD scala.Predef.println (dynamic)
 @@ -518,3 +517,3 @@
@@ -176,8 +176,8 @@
        consisting of blocks: List(3)
 @@ -714,5 +754,5 @@
    def main(args: Array[String] (ARRAY[REF(class String)])): Unit {
--  locals: value args, variable result, value ex6, variable exc2, value x4, value x5, value message, value x, value ex6, value x4, value x5, value message, value x
-+  locals: value args, variable result, value ex6, variable exc2, value x4, value x5, value x, value ex6, value x4, value x5, value x
+-  locals: value args, variable result, value ex4, variable exc2, value x5, value x6, value message, value x, value ex4, value x5, value x6, value message, value x
++  locals: value args, variable result, value ex4, variable exc2, value x5, value x6, value x, value ex4, value x5, value x6, value x
    startBlock: 1
 -  blocks: [1,3,4,5,6,9,13,14,15,18,20,21,23,24]
 +  blocks: [1,3,4,5,6,9,13,14,15,18,20,21,23,24,25,26,27]
@@ -185,67 +185,67 @@
 @@ -740,4 +780,11 @@
      172	CALL_METHOD MyException.<init> (static-instance)
 -    172	THROW(MyException)
-+    ?	STORE_LOCAL(value ex6)
++    ?	STORE_LOCAL(value ex4)
 +    ?	JUMP 25
      
 +  25: 
-+    170	LOAD_LOCAL(value ex6)
-+    170	STORE_LOCAL(value x4)
-+    170	SCOPE_ENTER value x4
++    170	LOAD_LOCAL(value ex4)
++    170	STORE_LOCAL(value x5)
++    170	SCOPE_ENTER value x5
 +    170	JUMP 14
 +    
    23: 
 @@ -780,8 +827,5 @@
-     175	SCOPE_ENTER value x5
--    175	LOAD_LOCAL(value x5)
+     175	SCOPE_ENTER value x6
+-    175	LOAD_LOCAL(value x6)
 -    175	CALL_METHOD MyException.message (dynamic)
 -    175	STORE_LOCAL(value message)
 -    175	SCOPE_ENTER value message
      176	LOAD_MODULE object Predef
 -    176	LOAD_LOCAL(value message)
-+    ?	LOAD_LOCAL(value x5)
++    170	LOAD_LOCAL(value x6)
 +    176	CALL_METHOD MyException.message (dynamic)
      176	CALL_METHOD scala.Predef.println (dynamic)
 @@ -789,5 +833,7 @@
      177	DUP(REF(class MyException))
 -    177	LOAD_LOCAL(value message)
-+    ?	LOAD_LOCAL(value x5)
++    170	LOAD_LOCAL(value x6)
 +    177	CALL_METHOD MyException.message (dynamic)
      177	CALL_METHOD MyException.<init> (static-instance)
 -    177	THROW(MyException)
-+    ?	STORE_LOCAL(value ex6)
++    ?	STORE_LOCAL(value ex4)
 +    ?	JUMP 26
      
 @@ -795,3 +841,4 @@
-     170	LOAD_LOCAL(value ex6)
+     170	LOAD_LOCAL(value ex4)
 -    170	THROW(Throwable)
-+    ?	STORE_LOCAL(value ex6)
++    ?	STORE_LOCAL(value ex4)
 +    ?	JUMP 26
      
 @@ -805,2 +852,8 @@
      
 +  26: 
-+    169	LOAD_LOCAL(value ex6)
-+    169	STORE_LOCAL(value x4)
-+    169	SCOPE_ENTER value x4
++    169	LOAD_LOCAL(value ex4)
++    169	STORE_LOCAL(value x5)
++    169	SCOPE_ENTER value x5
 +    169	JUMP 5
 +    
    5: 
 @@ -815,8 +868,5 @@
-     180	SCOPE_ENTER value x5
--    180	LOAD_LOCAL(value x5)
+     180	SCOPE_ENTER value x6
+-    180	LOAD_LOCAL(value x6)
 -    180	CALL_METHOD MyException.message (dynamic)
 -    180	STORE_LOCAL(value message)
 -    180	SCOPE_ENTER value message
      181	LOAD_MODULE object Predef
 -    181	LOAD_LOCAL(value message)
-+    ?	LOAD_LOCAL(value x5)
++    169	LOAD_LOCAL(value x6)
 +    181	CALL_METHOD MyException.message (dynamic)
      181	CALL_METHOD scala.Predef.println (dynamic)
 @@ -824,5 +874,7 @@
      182	DUP(REF(class MyException))
 -    182	LOAD_LOCAL(value message)
-+    ?	LOAD_LOCAL(value x5)
++    169	LOAD_LOCAL(value x6)
 +    182	CALL_METHOD MyException.message (dynamic)
      182	CALL_METHOD MyException.<init> (static-instance)
 -    182	THROW(MyException)
@@ -253,7 +253,7 @@
 +    ?	JUMP 27
      
 @@ -830,3 +882,4 @@
-     169	LOAD_LOCAL(value ex6)
+     169	LOAD_LOCAL(value ex4)
 -    169	THROW(Throwable)
 +    ?	STORE_LOCAL(variable exc2)
 +    ?	JUMP 27
@@ -285,8 +285,8 @@
        consisting of blocks: List(3)
 @@ -879,5 +945,5 @@
    def main(args: Array[String] (ARRAY[REF(class String)])): Unit {
--  locals: value args, variable result, value e, value ex6, value x4, value x5, value message, value x
-+  locals: value args, variable result, value e, value ex6, value x4, value x5, value x
+-  locals: value args, variable result, value e, value ex4, value x5, value x6, value message, value x
++  locals: value args, variable result, value e, value ex4, value x5, value x6, value x
    startBlock: 1
 -  blocks: [1,2,3,6,7,8,11,13,14,16]
 +  blocks: [1,2,3,6,7,8,11,13,14,16,17]
@@ -294,25 +294,25 @@
 @@ -905,4 +971,11 @@
      124	CALL_METHOD MyException.<init> (static-instance)
 -    124	THROW(MyException)
-+    ?	STORE_LOCAL(value ex6)
++    ?	STORE_LOCAL(value ex4)
 +    ?	JUMP 17
      
 +  17: 
-+    122	LOAD_LOCAL(value ex6)
-+    122	STORE_LOCAL(value x4)
-+    122	SCOPE_ENTER value x4
++    122	LOAD_LOCAL(value ex4)
++    122	STORE_LOCAL(value x5)
++    122	SCOPE_ENTER value x5
 +    122	JUMP 7
 +    
    16: 
 @@ -930,8 +1003,5 @@
-     127	SCOPE_ENTER value x5
--    127	LOAD_LOCAL(value x5)
+     127	SCOPE_ENTER value x6
+-    127	LOAD_LOCAL(value x6)
 -    127	CALL_METHOD MyException.message (dynamic)
 -    127	STORE_LOCAL(value message)
 -    127	SCOPE_ENTER value message
      127	LOAD_MODULE object Predef
 -    127	LOAD_LOCAL(value message)
-+    ?	LOAD_LOCAL(value x5)
++    122	LOAD_LOCAL(value x6)
 +    127	CALL_METHOD MyException.message (dynamic)
      127	CALL_METHOD scala.Predef.println (dynamic)
 @@ -964,3 +1034,3 @@
@@ -322,8 +322,8 @@
        consisting of blocks: List(3)
 @@ -988,5 +1058,5 @@
    def main(args: Array[String] (ARRAY[REF(class String)])): Unit {
--  locals: value args, variable result, value ex6, value x4, value x5, value message, value x, value e
-+  locals: value args, variable result, value ex6, value x4, value x5, value x, value e
+-  locals: value args, variable result, value ex4, value x5, value x6, value message, value x, value e
++  locals: value args, variable result, value ex4, value x5, value x6, value x, value e
    startBlock: 1
 -  blocks: [1,2,3,4,5,8,12,13,14,16]
 +  blocks: [1,2,3,5,8,12,13,14,16,17]
@@ -331,33 +331,33 @@
 @@ -1014,4 +1084,13 @@
      148	CALL_METHOD MyException.<init> (static-instance)
 -    148	THROW(MyException)
-+    ?	STORE_LOCAL(value ex6)
++    ?	STORE_LOCAL(value ex4)
 +    ?	JUMP 17
      
 +  17: 
-+    145	LOAD_LOCAL(value ex6)
-+    145	STORE_LOCAL(value x4)
-+    145	SCOPE_ENTER value x4
-+    154	LOAD_LOCAL(value x4)
++    145	LOAD_LOCAL(value ex4)
++    145	STORE_LOCAL(value x5)
++    145	SCOPE_ENTER value x5
++    154	LOAD_LOCAL(value x5)
 +    154	IS_INSTANCE REF(class MyException)
 +    154	CZJUMP (BOOL)NE ? 5 : 8
 +    
    16: 
 @@ -1035,5 +1114,2 @@
-     145	SCOPE_ENTER value x4
+     145	SCOPE_ENTER value x5
 -    145	JUMP 4
 -    
 -  4: 
-     154	LOAD_LOCAL(value x4)
+     154	LOAD_LOCAL(value x5)
 @@ -1047,8 +1123,5 @@
-     154	SCOPE_ENTER value x5
--    154	LOAD_LOCAL(value x5)
+     154	SCOPE_ENTER value x6
+-    154	LOAD_LOCAL(value x6)
 -    154	CALL_METHOD MyException.message (dynamic)
 -    154	STORE_LOCAL(value message)
 -    154	SCOPE_ENTER value message
      154	LOAD_MODULE object Predef
 -    154	LOAD_LOCAL(value message)
-+    ?	LOAD_LOCAL(value x5)
++    145	LOAD_LOCAL(value x6)
 +    154	CALL_METHOD MyException.message (dynamic)
      154	CALL_METHOD scala.Predef.println (dynamic)
 @@ -1269,3 +1342,3 @@
@@ -380,8 +380,8 @@
    7: 
 @@ -1340,5 +1420,5 @@
    def main(args: Array[String] (ARRAY[REF(class String)])): Unit {
--  locals: value args, variable result, value ex6, value x4, value x5, value message, value x
-+  locals: value args, variable result, value ex6, value x4, value x5, value x
+-  locals: value args, variable result, value ex4, value x5, value x6, value message, value x
++  locals: value args, variable result, value ex4, value x5, value x6, value x
    startBlock: 1
 -  blocks: [1,2,3,4,5,8,10,11,13,14,16]
 +  blocks: [1,2,3,5,8,10,11,13,14,16,17]
@@ -389,39 +389,39 @@
 @@ -1366,3 +1446,4 @@
      203	CALL_METHOD MyException.<init> (static-instance)
 -    203	THROW(MyException)
-+    ?	STORE_LOCAL(value ex6)
++    ?	STORE_LOCAL(value ex4)
 +    ?	JUMP 17
      
 @@ -1386,4 +1467,13 @@
      209	CALL_METHOD MyException.<init> (static-instance)
 -    209	THROW(MyException)
-+    ?	STORE_LOCAL(value ex6)
++    ?	STORE_LOCAL(value ex4)
 +    ?	JUMP 17
      
 +  17: 
-+    200	LOAD_LOCAL(value ex6)
-+    200	STORE_LOCAL(value x4)
-+    200	SCOPE_ENTER value x4
-+    212	LOAD_LOCAL(value x4)
++    200	LOAD_LOCAL(value ex4)
++    200	STORE_LOCAL(value x5)
++    200	SCOPE_ENTER value x5
++    212	LOAD_LOCAL(value x5)
 +    212	IS_INSTANCE REF(class MyException)
 +    212	CZJUMP (BOOL)NE ? 5 : 8
 +    
    16: 
 @@ -1399,5 +1489,2 @@
-     200	SCOPE_ENTER value x4
+     200	SCOPE_ENTER value x5
 -    200	JUMP 4
 -    
 -  4: 
-     212	LOAD_LOCAL(value x4)
+     212	LOAD_LOCAL(value x5)
 @@ -1411,8 +1498,5 @@
-     212	SCOPE_ENTER value x5
--    212	LOAD_LOCAL(value x5)
+     212	SCOPE_ENTER value x6
+-    212	LOAD_LOCAL(value x6)
 -    212	CALL_METHOD MyException.message (dynamic)
 -    212	STORE_LOCAL(value message)
 -    212	SCOPE_ENTER value message
      213	LOAD_MODULE object Predef
 -    213	LOAD_LOCAL(value message)
-+    ?	LOAD_LOCAL(value x5)
++    200	LOAD_LOCAL(value x6)
 +    213	CALL_METHOD MyException.message (dynamic)
      213	CALL_METHOD scala.Predef.println (dynamic)
 @@ -1460,3 +1544,3 @@


### PR DESCRIPTION
Optimize

```
(e1,..., eN) match {
case (p1, ..., pN) if G => B
...
case _ if G => B
}
```

to

```
val t1 = e1
... val tN = eN

t1 | ... | TN match {
case p1 | ... | pN if G => B
...
case _ if G => B
}
```

Where `|` is like magic: its constructor is a no-op, and its accessors are
local variable accesses (the `ti`).

The optimization supports scrutinees of the shape:
- `new TupleN(e1,...,eN)`
- `TupleN.apply(e1,...,eN)`

This is not allowed (can't omit the effect of the `???`)
- `{???; TupleN}.apply(e1,...,eN)` // !isQualifierSafeToElide(fun)

Built on top of a bunch of refactorings:
- SubstOnlyTreeMaker can subst >1 binders
- peel off a few Layers of Abstraction
- simplify `BoundTree`
- move `makers` to ExtractorCall
- pull out scrutineeFor
- Scrutinee encapsulates its sym & tree
- Simplify generation of default case

Already incorporates over-the-shoulder review by @retronym. Review by @retronym.
