### PR TITLE
SI-9020 Avoid spurious value discarding warning post-typer

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1039,11 +1039,11 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           // to non-continuation types.
           if (tree.tpe <:< AnyTpe) pt.dealias match {
             case TypeRef(_, UnitClass, _) => // (12)
-              if (settings.warnValueDiscard)
+              if (!isPastTyper && settings.warnValueDiscard)
                 context.warning(tree.pos, "discarded non-Unit value")
               return typedPos(tree.pos, mode, pt)(Block(List(tree), Literal(Constant(()))))
             case TypeRef(_, sym, _) if isNumericValueClass(sym) && isNumericSubType(tree.tpe, pt) =>
-              if (settings.warnNumericWiden)
+              if (!isPastTyper && settings.warnNumericWiden)
                 context.warning(tree.pos, "implicit numeric widening")
               return typedPos(tree.pos, mode, pt)(Select(tree, "to" + sym.name))
             case _ =>

--- a/test/files/pos/t9020.flags
+++ b/test/files/pos/t9020.flags
@@ -1,0 +1,1 @@
+-Ywarn-value-discard -Xfatal-warnings

--- a/test/files/pos/t9020.scala
+++ b/test/files/pos/t9020.scala
@@ -1,0 +1,10 @@
+trait ValueDiscard[@specialized U] {
+  def u: U
+}
+/* Was:
+scalac-hash v2.11.5 -Ywarn-value-discard test/files/pos/t9020.scala
+test/files/pos/t9020.scala:2: warning: discarded non-Unit value
+  def u: U
+      ^
+one warning found
+*/


### PR DESCRIPTION
Typechecking during the specialization phase was emitting a
bogus warning about value discarding. Such warnings in the
typer should be guarded by `!isPastTyper` to restrict the
analysis to the code the user originally wrote, rather than
the results of later typechecking.

I've made this change to the value discarding warning. I've also
changed a numeric widening warning in the vicinity, although I do
not have a test case for that.

Review by @adriaanm
