### PR TITLE
SI-9226 Fix NPE in GenASM.writeIfNotTooBig

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
@@ -533,7 +533,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters { self =>
         }
         bytecodeWriter.writeClass(label, jclassName, arr, outF)
       } catch {
-        case e: java.lang.RuntimeException if e != null && (e.getMessage contains "too large!") =>
+        case e: java.lang.RuntimeException if e.getMessage != null && (e.getMessage contains "too large!") =>
           reporter.error(sym.pos,
             s"Could not write class $jclassName because it exceeds JVM code size limits. ${e.getMessage}")
       }


### PR DESCRIPTION
On 2.11.6 line 535 (as reported in the issue) points to the changed
line.

Exception.getMessage can return null. Checking for null on the matched
variable is not necessary.

No tests, because I have no idea on how to reproduce the problem.
