### PR TITLE
SI-7741: Be more tolerant of absent inner classfiles and non-Scala interface members

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/AddInterfaces.scala
+++ b/src/compiler/scala/tools/nsc/transform/AddInterfaces.scala
@@ -207,7 +207,7 @@ abstract class AddInterfaces extends InfoTransform { self: Erasure =>
   }
 
   def transformMixinInfo(tp: Type): Type = tp match {
-    case ClassInfoType(parents, decls, clazz) =>
+    case ClassInfoType(parents, decls, clazz) if clazz.isPackageClass || !clazz.isJavaDefined =>
       if (clazz.needsImplClass)
         implClass(clazz setFlag lateINTERFACE) // generate an impl class
 

--- a/test/files/run/t7741a/GroovyInterface$1Dump.java
+++ b/test/files/run/t7741a/GroovyInterface$1Dump.java
@@ -1,0 +1,222 @@
+import java.util.*;
+import scala.tools.asm.*;
+
+// generated with
+//    git clone alewando/scala_groovy_interop
+//    SCALA_HOME=... GROOVY_HOME=... ant
+//    cd /code/scala2
+//    java  -classpath build/asm/classes:/Users/jason/code/scala_groovy_interop/classes:/code/scala2/build/pack/lib/scala-library.jar:/usr/local/Cellar/groovy/2.4.1/libexec/embeddable/groovy-all-2.4.1.jar scala.tools.asm.util.ASMifier 'GroovyInterface$1'
+//    java  -classpath build/asm/classes:/Users/jason/code/scala_groovy_interop/classes:/code/scala2/build/pack/lib/scala-library.jar:/usr/local/Cellar/groovy/2.4.1/libexec/embeddable/groovy-all-2.4.1.jar scala.tools.asm.util.ASMifier 'GroovyInterface$1'
+public class GroovyInterface$1Dump implements Opcodes {
+
+    public static byte[] dump () throws Exception {
+
+        ClassWriter cw = new ClassWriter(0);
+        FieldVisitor fv;
+        MethodVisitor mv;
+        AnnotationVisitor av0;
+
+        cw.visit(V1_5, ACC_SUPER + ACC_SYNTHETIC, "GroovyInterface$1", null, "java/lang/Object", new String[] {});
+
+        cw.visitInnerClass("GroovyInterface$1", "GroovyInterface", "1", ACC_SYNTHETIC);
+
+        {
+            fv = cw.visitField(ACC_STATIC + ACC_SYNTHETIC, "$class$GroovyInterface", "Ljava/lang/Class;", null, null);
+            fv.visitEnd();
+        }
+        {
+            fv = cw.visitField(ACC_PRIVATE + ACC_STATIC + ACC_SYNTHETIC, "$staticClassInfo", "Lorg/codehaus/groovy/reflection/ClassInfo;", null, null);
+            fv.visitEnd();
+        }
+        {
+            fv = cw.visitField(ACC_PUBLIC + ACC_STATIC + ACC_TRANSIENT + ACC_SYNTHETIC, "__$stMC", "Z", null, null);
+            fv.visitEnd();
+        }
+        {
+            fv = cw.visitField(ACC_PRIVATE + ACC_TRANSIENT + ACC_SYNTHETIC, "metaClass", "Lgroovy/lang/MetaClass;", null, null);
+            fv.visitEnd();
+        }
+        {
+            fv = cw.visitField(ACC_PRIVATE + ACC_STATIC + ACC_SYNTHETIC, "$callSiteArray", "Ljava/lang/ref/SoftReference;", null, null);
+            fv.visitEnd();
+        }
+        {
+            mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+            mv.visitCode();
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+            mv.visitMethodInsn(INVOKESTATIC, "GroovyInterface$1", "$getCallSiteArray", "()[Lorg/codehaus/groovy/runtime/callsite/CallSite;", false);
+            mv.visitVarInsn(ASTORE, 1);
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitMethodInsn(INVOKEVIRTUAL, "GroovyInterface$1", "$getStaticMetaClass", "()Lgroovy/lang/MetaClass;", false);
+            mv.visitVarInsn(ASTORE, 2);
+            mv.visitVarInsn(ALOAD, 2);
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitInsn(SWAP);
+            mv.visitFieldInsn(PUTFIELD, "GroovyInterface$1", "metaClass", "Lgroovy/lang/MetaClass;");
+            mv.visitVarInsn(ALOAD, 2);
+            mv.visitInsn(POP);
+            mv.visitInsn(RETURN);
+            mv.visitMaxs(2, 3);
+            mv.visitEnd();
+        }
+        {
+            mv = cw.visitMethod(ACC_PROTECTED + ACC_SYNTHETIC, "$getStaticMetaClass", "()Lgroovy/lang/MetaClass;", null, null);
+            mv.visitCode();
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Object", "getClass", "()Ljava/lang/Class;", false);
+            mv.visitLdcInsn(Type.getType("LGroovyInterface$1;"));
+            Label l0 = new Label();
+            mv.visitJumpInsn(IF_ACMPEQ, l0);
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitMethodInsn(INVOKESTATIC, "org/codehaus/groovy/runtime/ScriptBytecodeAdapter", "initMetaClass", "(Ljava/lang/Object;)Lgroovy/lang/MetaClass;", false);
+            mv.visitInsn(ARETURN);
+            mv.visitLabel(l0);
+            mv.visitFieldInsn(GETSTATIC, "GroovyInterface$1", "$staticClassInfo", "Lorg/codehaus/groovy/reflection/ClassInfo;");
+            mv.visitVarInsn(ASTORE, 1);
+            mv.visitVarInsn(ALOAD, 1);
+            Label l1 = new Label();
+            mv.visitJumpInsn(IFNONNULL, l1);
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Object", "getClass", "()Ljava/lang/Class;", false);
+            mv.visitMethodInsn(INVOKESTATIC, "org/codehaus/groovy/reflection/ClassInfo", "getClassInfo", "(Ljava/lang/Class;)Lorg/codehaus/groovy/reflection/ClassInfo;", false);
+            mv.visitInsn(DUP);
+            mv.visitVarInsn(ASTORE, 1);
+            mv.visitFieldInsn(PUTSTATIC, "GroovyInterface$1", "$staticClassInfo", "Lorg/codehaus/groovy/reflection/ClassInfo;");
+            mv.visitLabel(l1);
+            mv.visitVarInsn(ALOAD, 1);
+            mv.visitMethodInsn(INVOKEVIRTUAL, "org/codehaus/groovy/reflection/ClassInfo", "getMetaClass", "()Lgroovy/lang/MetaClass;", false);
+            mv.visitInsn(ARETURN);
+            mv.visitMaxs(2, 2);
+            mv.visitEnd();
+        }
+        {
+            mv = cw.visitMethod(ACC_PUBLIC + ACC_SYNTHETIC, "getMetaClass", "()Lgroovy/lang/MetaClass;", null, null);
+            mv.visitCode();
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitFieldInsn(GETFIELD, "GroovyInterface$1", "metaClass", "Lgroovy/lang/MetaClass;");
+            mv.visitInsn(DUP);
+            Label l0 = new Label();
+            mv.visitJumpInsn(IFNULL, l0);
+            mv.visitInsn(ARETURN);
+            mv.visitLabel(l0);
+            mv.visitInsn(POP);
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitInsn(DUP);
+            mv.visitMethodInsn(INVOKEVIRTUAL, "GroovyInterface$1", "$getStaticMetaClass", "()Lgroovy/lang/MetaClass;", false);
+            mv.visitFieldInsn(PUTFIELD, "GroovyInterface$1", "metaClass", "Lgroovy/lang/MetaClass;");
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitFieldInsn(GETFIELD, "GroovyInterface$1", "metaClass", "Lgroovy/lang/MetaClass;");
+            mv.visitInsn(ARETURN);
+            mv.visitMaxs(2, 1);
+            mv.visitEnd();
+        }
+        {
+            mv = cw.visitMethod(ACC_PUBLIC + ACC_SYNTHETIC, "setMetaClass", "(Lgroovy/lang/MetaClass;)V", null, null);
+            mv.visitCode();
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitVarInsn(ALOAD, 1);
+            mv.visitFieldInsn(PUTFIELD, "GroovyInterface$1", "metaClass", "Lgroovy/lang/MetaClass;");
+            mv.visitInsn(RETURN);
+            mv.visitMaxs(2, 2);
+            mv.visitEnd();
+        }
+        {
+            mv = cw.visitMethod(ACC_PUBLIC + ACC_SYNTHETIC, "invokeMethod", "(Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;", null, null);
+            mv.visitCode();
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitMethodInsn(INVOKEVIRTUAL, "GroovyInterface$1", "getMetaClass", "()Lgroovy/lang/MetaClass;", false);
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitVarInsn(ALOAD, 1);
+            mv.visitVarInsn(ALOAD, 2);
+            mv.visitMethodInsn(INVOKEINTERFACE, "groovy/lang/MetaClass", "invokeMethod", "(Ljava/lang/Object;Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;", true);
+            mv.visitInsn(ARETURN);
+            mv.visitMaxs(4, 3);
+            mv.visitEnd();
+        }
+        {
+            mv = cw.visitMethod(ACC_PUBLIC + ACC_SYNTHETIC, "getProperty", "(Ljava/lang/String;)Ljava/lang/Object;", null, null);
+            mv.visitCode();
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitMethodInsn(INVOKEVIRTUAL, "GroovyInterface$1", "getMetaClass", "()Lgroovy/lang/MetaClass;", false);
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitVarInsn(ALOAD, 1);
+            mv.visitMethodInsn(INVOKEINTERFACE, "groovy/lang/MetaClass", "getProperty", "(Ljava/lang/Object;Ljava/lang/String;)Ljava/lang/Object;", true);
+            mv.visitInsn(ARETURN);
+            mv.visitMaxs(3, 2);
+            mv.visitEnd();
+        }
+        {
+            mv = cw.visitMethod(ACC_PUBLIC + ACC_SYNTHETIC, "setProperty", "(Ljava/lang/String;Ljava/lang/Object;)V", null, null);
+            mv.visitCode();
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitMethodInsn(INVOKEVIRTUAL, "GroovyInterface$1", "getMetaClass", "()Lgroovy/lang/MetaClass;", false);
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitVarInsn(ALOAD, 1);
+            mv.visitVarInsn(ALOAD, 2);
+            mv.visitMethodInsn(INVOKEINTERFACE, "groovy/lang/MetaClass", "setProperty", "(Ljava/lang/Object;Ljava/lang/String;Ljava/lang/Object;)V", true);
+            mv.visitInsn(RETURN);
+            mv.visitMaxs(4, 3);
+            mv.visitEnd();
+        }
+        {
+            mv = cw.visitMethod(ACC_STATIC, "<clinit>", "()V", null, null);
+            mv.visitCode();
+            mv.visitLdcInsn(Type.getType("LGroovyInterface;"));
+            mv.visitVarInsn(ASTORE, 0);
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitFieldInsn(PUTSTATIC, "GroovyInterface$1", "$class$GroovyInterface", "Ljava/lang/Class;");
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitInsn(POP);
+            mv.visitInsn(RETURN);
+            mv.visitMaxs(1, 1);
+            mv.visitEnd();
+        }
+        {
+            mv = cw.visitMethod(ACC_PRIVATE + ACC_STATIC + ACC_SYNTHETIC, "$createCallSiteArray", "()Lorg/codehaus/groovy/runtime/callsite/CallSiteArray;", null, null);
+            mv.visitCode();
+            mv.visitLdcInsn(new Integer(0));
+            mv.visitTypeInsn(ANEWARRAY, "java/lang/String");
+            mv.visitVarInsn(ASTORE, 0);
+            mv.visitTypeInsn(NEW, "org/codehaus/groovy/runtime/callsite/CallSiteArray");
+            mv.visitInsn(DUP);
+            mv.visitLdcInsn(Type.getType("LGroovyInterface$1;"));
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitMethodInsn(INVOKESPECIAL, "org/codehaus/groovy/runtime/callsite/CallSiteArray", "<init>", "(Ljava/lang/Class;[Ljava/lang/String;)V", false);
+            mv.visitInsn(ARETURN);
+            mv.visitMaxs(4, 1);
+            mv.visitEnd();
+        }
+        {
+            mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC + ACC_SYNTHETIC, "$getCallSiteArray", "()[Lorg/codehaus/groovy/runtime/callsite/CallSite;", null, null);
+            mv.visitCode();
+            mv.visitFieldInsn(GETSTATIC, "GroovyInterface$1", "$callSiteArray", "Ljava/lang/ref/SoftReference;");
+            Label l0 = new Label();
+            mv.visitJumpInsn(IFNULL, l0);
+            mv.visitFieldInsn(GETSTATIC, "GroovyInterface$1", "$callSiteArray", "Ljava/lang/ref/SoftReference;");
+            mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/ref/SoftReference", "get", "()Ljava/lang/Object;", false);
+            mv.visitTypeInsn(CHECKCAST, "org/codehaus/groovy/runtime/callsite/CallSiteArray");
+            mv.visitInsn(DUP);
+            mv.visitVarInsn(ASTORE, 0);
+            Label l1 = new Label();
+            mv.visitJumpInsn(IFNONNULL, l1);
+            mv.visitLabel(l0);
+            mv.visitMethodInsn(INVOKESTATIC, "GroovyInterface$1", "$createCallSiteArray", "()Lorg/codehaus/groovy/runtime/callsite/CallSiteArray;", false);
+            mv.visitVarInsn(ASTORE, 0);
+            mv.visitTypeInsn(NEW, "java/lang/ref/SoftReference");
+            mv.visitInsn(DUP);
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitMethodInsn(INVOKESPECIAL, "java/lang/ref/SoftReference", "<init>", "(Ljava/lang/Object;)V", false);
+            mv.visitFieldInsn(PUTSTATIC, "GroovyInterface$1", "$callSiteArray", "Ljava/lang/ref/SoftReference;");
+            mv.visitLabel(l1);
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitFieldInsn(GETFIELD, "org/codehaus/groovy/runtime/callsite/CallSiteArray", "array", "[Lorg/codehaus/groovy/runtime/callsite/CallSite;");
+            mv.visitInsn(ARETURN);
+            mv.visitMaxs(3, 1);
+            mv.visitEnd();
+        }
+        cw.visitEnd();
+
+        return cw.toByteArray();
+    }
+}

--- a/test/files/run/t7741a/GroovyInterfaceDump.java
+++ b/test/files/run/t7741a/GroovyInterfaceDump.java
@@ -1,0 +1,51 @@
+import java.util.*;
+import scala.tools.asm.*;
+
+// generated with
+//    git clone alewando/scala_groovy_interop
+//    SCALA_HOME=... GROOVY_HOME=... ant
+//    cd /code/scala2
+//    java  -classpath build/asm/classes:/Users/jason/code/scala_groovy_interop/classes:/code/scala2/build/pack/lib/scala-library.jar:/usr/local/Cellar/groovy/2.4.1/libexec/embeddable/groovy-all-2.4.1.jar scala.tools.asm.util.ASMifier 'GroovyInterface$1'
+//    java  -classpath build/asm/classes:/Users/jason/code/scala_groovy_interop/classes:/code/scala2/build/pack/lib/scala-library.jar:/usr/local/Cellar/groovy/2.4.1/libexec/embeddable/groovy-all-2.4.1.jar scala.tools.asm.util.ASMifier 'GroovyInterface$1'
+public class GroovyInterfaceDump implements Opcodes {
+
+    public static byte[] dump () throws Exception {
+
+        ClassWriter cw = new ClassWriter(0);
+        FieldVisitor fv;
+        MethodVisitor mv;
+        AnnotationVisitor av0;
+
+        cw.visit(V1_5, ACC_PUBLIC + ACC_ABSTRACT + ACC_INTERFACE, "GroovyInterface", null, "java/lang/Object", null);
+
+        cw.visitInnerClass("GroovyInterface$1", "GroovyInterface", "1", ACC_SYNTHETIC);
+
+        cw.visitInnerClass("GroovyInterface$__clinit__closure1", null, null, 0);
+
+        {
+            fv = cw.visitField(ACC_PUBLIC + ACC_FINAL + ACC_STATIC, "closure", "Ljava/lang/Object;", null, null);
+            fv.visitEnd();
+        }
+        {
+            mv = cw.visitMethod(ACC_STATIC, "<clinit>", "()V", null, null);
+            mv.visitCode();
+            mv.visitTypeInsn(NEW, "GroovyInterface$__clinit__closure1");
+            mv.visitInsn(DUP);
+            mv.visitFieldInsn(GETSTATIC, "GroovyInterface$1", "$class$GroovyInterface", "Ljava/lang/Class;");
+            mv.visitFieldInsn(GETSTATIC, "GroovyInterface$1", "$class$GroovyInterface", "Ljava/lang/Class;");
+            mv.visitMethodInsn(INVOKESPECIAL, "GroovyInterface$__clinit__closure1", "<init>", "(Ljava/lang/Object;Ljava/lang/Object;)V", false);
+            mv.visitVarInsn(ASTORE, 0);
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitFieldInsn(PUTSTATIC, "GroovyInterface", "closure", "Ljava/lang/Object;");
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitInsn(POP);
+            mv.visitInsn(RETURN);
+            mv.visitMaxs(4, 1);
+            mv.visitEnd();
+        }
+        cw.visitEnd();
+
+        return cw.toByteArray();
+    }
+}
+

--- a/test/files/run/t7741a/Test.scala
+++ b/test/files/run/t7741a/Test.scala
@@ -1,0 +1,47 @@
+import java.io.{ByteArrayInputStream, FileOutputStream, BufferedOutputStream}
+import java.util
+
+import java.io.File
+
+import scala.tools.partest.DirectTest
+
+object Test extends DirectTest {
+
+  def code = ""
+
+  override def show(): Unit = {
+
+    val class1: Array[Byte] = GroovyInterfaceDump.dump()
+    val class2: Array[Byte] = GroovyInterface$1Dump.dump()
+    def writeFile(contents: Array[Byte], f: java.io.File): Unit = {
+      val out = new BufferedOutputStream(new FileOutputStream(f))
+      try {
+        out.write(contents)
+      } finally out.close()
+    }
+
+    val outdir = testOutput.jfile
+
+    // interface GroovyInterface {
+    //
+    //   // This is the line that causes scalac to choke.
+    //   // It results in a GroovyInterface$1 class, which is a non-static inner class but it's constructor does not
+    //   // include the implicit parameter that is the immediate enclosing instance.
+    //   // See http://jira.codehaus.org/browse/GROOVY-7312
+    //   //
+    //   // Scalac error:
+    //   //   [scalac] error: error while loading 1, class file '..../scala_groovy_interop/classes/com/example/groovy/GroovyInterface$1.class' is broken
+    //   //   [scalac] (class java.util.NoSuchElementException/head of empty list)
+    //   final static def closure = { x -> "banana" }
+    //
+    // }
+    writeFile(GroovyInterfaceDump.dump(), new File(outdir, "GroovyInterface.class"))
+    writeFile(GroovyInterface$1Dump.dump(), new File(outdir, "GroovyInterface$1.class"))
+    compileCode("object Test { def foo(g: GroovyInterface) = g.toString }")
+  }
+
+  def compileCode(code: String) = {
+    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
+    compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(code)
+  }
+}

--- a/test/files/run/t7741b.check
+++ b/test/files/run/t7741b.check
@@ -1,0 +1,3 @@
+1. Don't refer to Inner
+2. Refering to Inner
+pos: NoPosition Class file for HasInner$Inner not found ERROR

--- a/test/files/run/t7741b/HasInner.java
+++ b/test/files/run/t7741b/HasInner.java
@@ -1,0 +1,3 @@
+class HasInner {
+    class Inner {}
+}

--- a/test/files/run/t7741b/Test.scala
+++ b/test/files/run/t7741b/Test.scala
@@ -1,0 +1,29 @@
+import java.io.File
+
+import scala.tools.partest.StoreReporterDirectTest
+
+object Test extends StoreReporterDirectTest {
+
+  def code = ""
+
+  override def show(): Unit = {
+    deleteClass("HasInner$Inner")
+    println("1. Don't refer to Inner")
+    compileCode("class Test { def test(x: HasInner) = x }")
+    assert(filteredInfos.isEmpty, filteredInfos)
+    println("2. Refering to Inner")
+    compileCode("class Test { def test(x: HasInner#Inner) = x }")
+    println(filteredInfos.mkString("\n"))
+  }
+
+  def deleteClass(name: String) {
+    val classFile = new File(testOutput.path, name + ".class")
+    assert(classFile.exists)
+    assert(classFile.delete())
+  }
+
+  def compileCode(code: String) = {
+    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
+    compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(code)
+  }
+}


### PR DESCRIPTION
Modifies ClassfileParser to avoid forcing the type information of members of non-Scala defined interfaces unnecessarily, and defers failures due to completely absent inner classes. Although these classes may not conform to expectations for javac-compiled classes, they are still valid JVM class files (in this case produced by the Groovy compiler) and should be supported by scalac. In addition to discussion on [SI-7741](https://issues.scala-lang.org/browse/SI-7741) see also https://groups.google.com/d/msg/scala-internals/lGE15Ly6xHU/q1LLfS3w9R0J.
