### PR TITLE
SI-9231 Don't attempt implicit search for erroneous parameter

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -151,7 +151,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           for(ar <- argResultsBuff)
             paramTp = paramTp.subst(ar.subst.from, ar.subst.to)
 
-          val res = if (paramFailed || (paramTp.isError && {paramFailed = true; true})) SearchFailure else inferImplicit(fun, paramTp, context.reportErrors, isView = false, context)
+          val res = if (paramFailed || (paramTp.isErroneous && {paramFailed = true; true})) SearchFailure else inferImplicit(fun, paramTp, context.reportErrors, isView = false, context)
           argResultsBuff += res
 
           if (res.isSuccess) {

--- a/test/files/neg/t9231.check
+++ b/test/files/neg/t9231.check
@@ -1,0 +1,4 @@
+t9231.scala:8: error: not found: type DoesNotExist
+  foo[DoesNotExist]
+      ^
+one error found

--- a/test/files/neg/t9231.scala
+++ b/test/files/neg/t9231.scala
@@ -1,0 +1,9 @@
+class M[A]
+class C {
+  implicit def M1: M[Int] = null
+  implicit def M2: M[String] = null
+
+  def foo[A](implicit M: M[A]) = null
+
+  foo[DoesNotExist]
+}


### PR DESCRIPTION
If the instantiated type of an implicit parameter is erroneous,
we should not attempt the implicit search. This avoids the following
useless error message in the enclosed test:

```
error: ambiguous implicit values: ... match expected type M[<error>]
```
