### PR TITLE
SI-9223 By-name constructor params should not be aliased

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2053,7 +2053,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                 case acc                                           => acc
               }
               ownAcc match {
-                case acc: TermSymbol if !acc.isVariable =>
+                case acc: TermSymbol if !acc.isVariable && !isByNameParamType(acc.info) =>
                   debuglog(s"$acc has alias ${alias.fullLocationString}")
                   acc setAlias alias
                 case _ =>

--- a/test/files/run/t9223.scala
+++ b/test/files/run/t9223.scala
@@ -1,0 +1,8 @@
+class X(val x: String)
+class Y(y: => String) extends X(y) { def f = y }
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    assert(new Y("hi").f == "hi")
+  }
+}

--- a/test/files/run/t9223b.scala
+++ b/test/files/run/t9223b.scala
@@ -1,0 +1,8 @@
+class X(x: => String) { def xx = x }
+class Y(y: String) extends X(y) { def f = y }
+
+object Test {
+  def main(args: Array[String]): Unit = {
+     assert(new Y("hi").f == "hi")
+  }
+}


### PR DESCRIPTION
Usually, the compiler tries avoids creating a field in a subclass
for a constructor parameter that is known to be stored in a field
in one of its superclasses.

However, in the enclosed test `run/t9223.scala`, this mechanism
confuses `=> A` with `A`, which results in a runtime
`ClassCastException`.

This commit avoids using param aliases for by-name parameters.

I have also added a test for something close the opposite case, where
the subclass has a strict parameter and the superclass has a by-name
parameter. This was working correctly before this patch.
