### PR TITLE
Resurrect a test for type inference

### DIFF
--- a/test/files/pos/jesper.scala
+++ b/test/files/pos/jesper.scala
@@ -1,0 +1,30 @@
+object Pair {
+ sealed trait Pair {
+   type First
+   type Second <: Pair
+ }
+
+ case class End() extends Pair {
+   type First = Nothing
+   type Second = End
+
+   def ::[T](v : T) : Cons[T, End] = Cons(v, this)
+ }
+
+ object End extends End()
+
+ final case class Cons[T1, T2 <: Pair](_1 : T1, _2 : T2) extends Pair {
+   type First = T1
+   type Second = T2
+
+   def ::[T](v : T) : Cons[T, Cons[T1, T2]] = Cons(v, this)
+   def find[T](implicit finder : Cons[T1, T2] => T) = finder(this)
+ }
+
+ implicit def findFirst[T1, T2 <: Pair] : Cons[T1, T2] => T1 = (p : Cons[T1, T2]) => p._1
+ implicit def findSecond[T, T1, T2 <: Pair](implicit finder : T2 => T) : Cons[T1, T2] => T = (p : Cons[T1, T2]) => finder(p._2)
+
+ val p : Cons[Int, Cons[Boolean, End]] = 10 :: false :: End
+// val x : Boolean = p.find[Boolean](findSecond(findFirst))
+ val x2 : Boolean = p.find[Boolean]  // Doesn't compile
+}


### PR DESCRIPTION
This test was removed in ... when case class extension was disallowed.
But the intent of the test was actually to exercise a path through
type inference, described in `Infer#exprTypeArgs`.

When I remove that special case, the test still fails:

```
test/files/pos/jesper.scala:29: error: No implicit view available from Pair.Cons[Int,Pair.Cons[Boolean,Pair.End]] => Boolean.
 val x2 : Boolean = p.find[Boolean]  // Doesn't compile
                          ^
one error found
```

This special case is important to understand when deciphering
the inference in this program:

```
object Test {

  trait Cov[+A]
  def cov[A](implicit ev: Cov[A]): A = ???
  implicit def covImp[A]: Cov[A] = ???

  trait Inv[A]
  def inv[A](implicit ev: Inv[A]): A = ???
  implicit def invImp[A]: Inv[A] = ???

  trait Con[-A]
  def con[A](implicit ev: Con[A]): A = ???
  implicit def conImp[A]: Con[A] = ???

  cov : String // (Test.this.cov[String](Test.this.covImp[Nothing]): String);
               // (Test.this.cov[Nothing](Test.this.covImp[Nothing]): String) (or, without the special case in exprTypeArgs)
  inv : String // (Test.this.inv[Nothing](Test.this.invImp[Nothing]): String);
  con : String // (Test.this.con[Any](Test.this.conImp[Any]): String)
}
```

Review by @propensive
