### PR TITLE
Improve diagnostic error on failed genLoadIdent

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
@@ -876,13 +876,15 @@ abstract class GenICode extends SubComponent {
                 genLoadModule(ctx, tree)
                 generatedType = toTypeKind(sym.info)
               } else {
-                try {
-                  val Some(l) = ctx.method.lookupLocal(sym)
-                  ctx.bb.emit(LOAD_LOCAL(l), tree.pos)
-                  generatedType = l.kind
-                } catch {
-                  case ex: MatchError =>
-                    abort("symbol " + sym + " does not exist in " + ctx.method)
+                ctx.method.lookupLocal(sym) match {
+                  case Some(l) =>
+                    ctx.bb.emit(LOAD_LOCAL(l), tree.pos)
+                    generatedType = l.kind
+                  case None =>
+                    val saved = settings.uniqid
+                    settings.uniqid.value = true
+                    try abort(s"symbol $sym does not exist in ${ctx.method}, which contains locals ${ctx.method.locals.mkString(",")}")
+                    finally settings.uniqid.value = saved
                 }
               }
             }


### PR DESCRIPTION
This error has been haunting us recently, firstly on Greg's machine
when compiling the compiler using the new SBT build, and more recently
during PR validation in #4316.

This commit will output an error like:

  symbol value c#16812 does not exist in Macro.impl, which contains locals value a#16810, value b#16811

I've included symbol IDs in the hope that they will prove useful.

It seems that synthetic identifiers generated by the pattern matcher
are often seen in the vicinity of this bug.

Review by the haunted: @gkossakowski / @som-snytt
