### PR TITLE
Can catch any expression

### DIFF
--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -1106,7 +1106,7 @@ Expr1 ::=  ‘try’ Expr [‘catch’ Expr] [‘finally’ Expr]
 ```
 
 A _try expression_ is of the form `try { ´b´ } catch ´h´`
-where the handler ´h´ is a
+where the handler ´h´ is usually a
 [pattern matching anonymous function](08-pattern-matching.html#pattern-matching-anonymous-functions)
 
 ```scala
@@ -1120,11 +1120,12 @@ handler ´h´ is applied to the thrown exception.
 If the handler contains a case matching the thrown exception,
 the first such case is invoked. If the handler contains
 no case matching the thrown exception, the exception is
-re-thrown.
+re-thrown. More generally, if the handler is a `PartialFunction`,
+it is applied only if it is defined at the given exception.
 
 Let ´\mathit{pt}´ be the expected type of the try expression.  The block
 ´b´ is expected to conform to ´\mathit{pt}´.  The handler ´h´
-is expected conform to type `scala.PartialFunction[scala.Throwable, ´\mathit{pt}\,´]`.
+is expected conform to type `scala.Function[scala.Throwable, ´\mathit{pt}\,´]`.
 The type of the try expression is the [weak least upper bound](03-types.html#weak-conformance)
 of the type of ´b´ and the result type of ´h´.
 

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1546,22 +1546,14 @@ self =>
       case TRY =>
         def parseTry = atPos(in.skipToken()) {
           val body = expr()
-          def catchFromExpr() = List(makeCatchFromExpr(expr()))
-          val catches: List[CaseDef] =
-            if (in.token != CATCH) Nil
-            else {
-              in.nextToken()
-              if (in.token != LBRACE) catchFromExpr()
-              else inBracesOrNil {
-                if (in.token == CASE) caseClauses()
-                else catchFromExpr()
-              }
-            }
+          val handler: List[CaseDef] =
+            if (in.token == CATCH) { in.nextToken(); makeMatchFromExpr(expr()) }
+            else Nil
           val finalizer = in.token match {
             case FINALLY => in.nextToken() ; expr()
             case _       => EmptyTree
           }
-          Try(body, catches, finalizer)
+          Try(body, handler, finalizer)
         }
         parseTry
       case WHILE =>

--- a/test/files/neg/catch-all.check
+++ b/test/files/neg/catch-all.check
@@ -7,6 +7,9 @@ catch-all.scala:6: warning: This catches all Throwables. If this is really inten
 catch-all.scala:8: warning: This catches all Throwables. If this is really intended, use `case x : Throwable` to clear this warning.
   try { "warn" } catch { case _: RuntimeException => ; case x => }
                                                             ^
+catch-all.scala:36: warning: This catches all Throwables. If this is really intended, use `case _ : Throwable` to clear this warning.
+  try "okay" catch discarder   // warn total function
+                   ^
 error: No warnings can be incurred under -Werror.
-3 warnings
+4 warnings
 1 error

--- a/test/files/neg/catch-all.scala
+++ b/test/files/neg/catch-all.scala
@@ -1,4 +1,4 @@
-// scalac: -Xfatal-warnings
+// scalac: -Werror
 //
 object CatchAll {
   try { "warn" } catch { case _ => }
@@ -28,6 +28,12 @@ object CatchAll {
   try { "okay" } catch { case _ if "".isEmpty => }
 
   "okay" match { case _ => "" }
+
+  val handler: PartialFunction[Throwable, String] = { case _ => "hello, world" }
+  val discarder = (_: Throwable) => "goodbye, cruel world"
+
+  try "okay" catch handler
+  try "okay" catch discarder   // warn total function
 }
 
 object T extends Throwable

--- a/test/files/neg/t5887.check
+++ b/test/files/neg/t5887.check
@@ -1,8 +1,18 @@
+t5887.scala:6: error: type mismatch;
+ found   : Int(22)
+ required: Throwable => ?
+  def f = try ??? catch 22
+                        ^
 t5887.scala:10: error: missing parameter type for expanded function
 The argument types of an anonymous function must be fully known. (SLS 8.5)
 Expected type was: ?
   def h = List("x") map (s => try { case _ => 7 })
                                   ^
+t5887.scala:29: error: type mismatch;
+ found   : TheOldCollegeTry.this.catcher.type
+ required: Throwable => Int
+  def noLongerAllower: Int = try 42 catch catcher
+                                          ^
 t5887.scala:8: warning: A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.
   def g = try 42
           ^
@@ -10,4 +20,4 @@ t5887.scala:10: warning: A try without a catch or finally is equivalent to putti
   def h = List("x") map (s => try { case _ => 7 })
                               ^
 2 warnings
-1 error
+3 errors

--- a/test/files/neg/t5887.check
+++ b/test/files/neg/t5887.check
@@ -19,5 +19,11 @@ t5887.scala:8: warning: A try without a catch or finally is equivalent to puttin
 t5887.scala:10: warning: A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.
   def h = List("x") map (s => try { case _ => 7 })
                               ^
-2 warnings
+t5887.scala:12: warning: This catches all Throwables. If this is really intended, use `case _ : Throwable` to clear this warning.
+  def j = try ??? catch (_ => 42)
+                           ^
+t5887.scala:18: warning: This catches all Throwables. If this is really intended, use `case _ : Throwable` to clear this warning.
+  def k2 = try 27 catch recover
+                        ^
+4 warnings
 3 errors

--- a/test/files/neg/t5887.scala
+++ b/test/files/neg/t5887.scala
@@ -2,10 +2,29 @@
 trait TheOldCollegeTry {
 
   // was: value isDefinedAt is not a member of Int
-  // now: required: PartialFunction[Throwable,?]
-  //def f = try ??? catch 22
+  // now: required: Function[Throwable,?]
+  def f = try ??? catch 22
 
   def g = try 42
 
   def h = List("x") map (s => try { case _ => 7 })
+
+  def j = try ??? catch (_ => 42)
+
+  import PartialFunction.fromFunction
+
+  def recover(t: Throwable): Int = 42
+  def k  = try 27 catch fromFunction(recover)
+  def k2 = try 27 catch recover
+
+  def parseErrorHandler[T]: PartialFunction[Throwable, T] = ???
+  def pushBusy[T](body: => T): T =
+    try body
+    catch parseErrorHandler
+
+  object catcher {
+    def isDefinedAt(x: Any) = true
+    def apply(x: Any) = 27
+  }
+  def noLongerAllower: Int = try 42 catch catcher
 }

--- a/test/files/run/t5887.scala
+++ b/test/files/run/t5887.scala
@@ -1,0 +1,17 @@
+
+import scala.tools.testkit.AssertUtil.assertThrows
+
+object Test extends App {
+  def npe: Int = throw null
+  def err: Int = throw new Error()
+
+  val pf: PartialFunction[Throwable, Int] = { case _: NullPointerException => 42 }
+  val f: Throwable => Int = pf
+
+  assertThrows[NullPointerException](npe)
+
+  assert(42 == (try npe catch pf))
+  assert(42 == (try npe catch f))
+  assertThrows[Error](try err catch pf)
+  assertThrows[MatchError](try err catch f)
+}

--- a/test/files/run/t5887.scala
+++ b/test/files/run/t5887.scala
@@ -1,6 +1,8 @@
 
 import scala.tools.testkit.AssertUtil.assertThrows
+import scala.annotation.nowarn
 
+@nowarn("msg=This catches all Throwables.")
 object Test extends App {
   def npe: Int = throw null
   def err: Int = throw new Error()


### PR DESCRIPTION
`catch` accepts an arbitrary expression, which must conform
to `Function[Throwable, ?]`.

The previous transform was name-based:
```
scala> try 42 catch new {
     | def isDefinedAt(x: Any) = false
     | def apply(x: Any) = ()
     | }
warning: there was one feature warning; re-run with -feature for details
res0: AnyVal = 42

scala> try 42 catch 22
<console>:8: error: value isDefinedAt is not a member of Int
              try 42 catch 22
                           ^
```
Now:
```
scala> try 42 catch 22
                    ^
       error: type mismatch;
        found   : Int(22)
        required: Throwable => ?

scala> def npe: Int = throw null
def npe: Int

scala> val pf: PartialFunction[Throwable, Int] = { case _: NullPointerException => 42 }
val pf: PartialFunction[Throwable,Int] = <function1>

scala> try npe catch pf
val res0: Int = 42

scala> def err: Int = throw new Error()
def err: Int

scala> try err catch pf
java.lang.Error
  at err(<console>:1)
  at liftedTree1$1(<console>:1)
  ... 33 elided
```
As shown, if the handler is a `PartialFunction`, it is invoked
selectively, as though by calling:
```
pf.applyOrElse(e, (t: Throwable) => throw t)
```
Otherwise, the handler is applied to all thrown exceptions:
```
scala> def f(t: Throwable) = if (t.isInstanceOf[NullPointerException]) 27 else ???
def f(t: Throwable): Int

scala> try err catch f
scala.NotImplementedError: an implementation is missing
  at scala.Predef$.$qmark$qmark$qmark(Predef.scala:345)
  at f(<console>:1)
  at $anonfun$res6$1(<console>:1)
  at $anonfun$res6$1$adapted(<console>:1)
  at liftedTree1$1(<console>:1)
  ... 33 elided
```
Note that applying a partial function literal in the form of a pattern-matching
anonymous function will use `applyOrElse`. The following example invokes
the `apply` method because the static type of the handler is not a
`PartialFunction`:
```
scala> val g: Throwable => Int = pf
val g: Throwable => Int = <function1>

scala> try err catch g
scala.MatchError: java.lang.Error (of class java.lang.Error)
  at scala.PartialFunction$$anon$1.apply(PartialFunction.scala:344)
  at scala.PartialFunction$$anon$1.apply(PartialFunction.scala:342)
  at $anonfun$1.applyOrElse(<console>:1)
  at $anonfun$1.applyOrElse(<console>:1)
  at scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:35)
  at liftedTree1$1(<console>:1)
  ... 33 elided

```
