### PR TITLE
SI-9248 Lint warning when inferring ?F[_] = Any/Nothing

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -574,6 +574,13 @@ trait Infer extends Checkable {
           }
         )
       }
+      if (settings.warnInferAny) {
+        foreachWithIndex(targs){ (targ, idx) =>
+          val tparam = tparams(idx)
+          if (!tparam.isMonomorphicType && !targ.isHigherKinded)
+            reporter.warning(argumentPosition(idx), s"type inference relied on kind-polymorphic nature of inferred type `$targ` to conform to type parameter ${tparam.defString}")
+        }
+      }
       adjustTypeArgs(tparams, tvars, targs, restpe)
     }
 

--- a/test/files/neg/t9248.check
+++ b/test/files/neg/t9248.check
@@ -1,0 +1,4 @@
+warning: there were two feature warnings; re-run with -feature for details
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/t9248.flags
+++ b/test/files/neg/t9248.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/t9248.scala
+++ b/test/files/neg/t9248.scala
@@ -1,0 +1,39 @@
+object Test {
+  trait Binary[A, B]
+
+  type Unary[A] = Binary[A, A]
+
+  def f[F[A], A](f: F[A]) = ???
+  def test1(u: Unary[Any]) = f(u)
+
+  // reports inference error, cannot unifiy Binary[Any, Any] with ?F[?A]
+  // commented out as we can't have errors in a test for warnings.
+  // def test2(u: Binary[Any, Any]) = f(u)
+
+  def test3 = {
+    implicit def b2u[A, B](b: Binary[A, B]): List[Int] = ???
+    val b: Binary[Any, Any] = null
+    f(b) // inference fails initially, but then we try to coerse the arguments 
+    //
+    // Under -Ytyper-debug, we see:
+    //
+    //    searching for adaptation to pt=Test.Binary[Any,Any] => ?F[?A] (silent: method test3 in Test) implicits disabled
+    // |    |    |    |    5 eligible for pt=Test.Binary[Any,Any] => ?F[?A] at (silent: method test3 in Test) implicits disabled
+    // |    |    |    |    [search #5] considering b2u
+    // |    |    |    |    |-- b2u BYVALmode-EXPRmode-FUNmode-POLYmode (silent: method test3 in Test) implicits disabled
+    // |    |    |    |    |    [adapt] [A, B](b: Test.Binary[A,B])List[Int] adapted to [A, B](b: Test.Binary[A,B])List[Int]
+    // |    |    |    |    |    \-> (b: Test.Binary[A,B])List[Int]
+    // |    |    |    |    solving for (A: ?A, B: ?B)
+    // |    |    |    |    [adapt] [A, B](b: Test.Binary[A,B])List[Int] adapted to [A, B](b: Test.Binary[A,B])List[Int] based on pt Test.Binary[Any,Any] => ?F[?A]
+    // |    |    |    |    [search #5] success inferred value of type Test.Binary[Any,Any] => ?F[?A] is SearchResult(b2u[Any, Any], )
+    //
+    // This leads to inference of ?F=Any, ?A=Nothing (this is kind-correct because Any/Nothing are kind polymorphic)
+    // 
+    // When we instantatiate the method type of `f` with this, the formal parameter type is now just Any[Nothing]
+    // which is just Any.
+    //
+    // The provided argument of type `Binary[A, B]` now unifies with this, no implicit coercion required.
+  }
+
+  f[Any, Nothing]("") // explicit type application incurs no warning.
+}


### PR DESCRIPTION
Any and Nothing are kind polymorphic, meaning the following is valid:

```
def f[F[A]] = 0; f[Any]; f[Nothing]
```

This commit warns, under -Xlint:infer-any, when we infer such
type appliations.
