### PR TITLE
SI-9144 Scaladoc: Make generated HTML files POSIX-compatible text files

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/HtmlPage.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/HtmlPage.scala
@@ -59,6 +59,7 @@ abstract class HtmlPage extends Page { thisPage =>
     writeFile(site) { (w: Writer) =>
       w.write(doctype.toString + "\n")
       w.write(xml.Xhtml.toXhtml(html))
+      w.write('\n')
     }
 
     if (site.universe.settings.docRawOutput)


### PR DESCRIPTION
According POSIX, every text file contains characters organized into
zero or more lines [1], and every line must be terminated by "\n" [2].

This change makes Scaladoc's HTML files POSIX-compatible text files.

[1] http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_397
[2] http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206
