### PR TITLE
SI-8940 Scaladoc: Fix "Order by Alphabetical" button

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.js
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.js
@@ -179,7 +179,7 @@ $(document).ready(function(){
 
         filter();
     });
-    $("#visbl > ol > li.public").click(function() {
+    $("#order > ol > li.alpha").click(function() {
         if ($(this).hasClass("out")) {
             orderAlpha();
         }


### PR DESCRIPTION
The selector has been wrong since 0c2614e.
