### PR TITLE
Don't define the wiki syntax in multiple places

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/DocComments.scala
+++ b/src/compiler/scala/tools/nsc/ast/DocComments.scala
@@ -129,25 +129,6 @@ trait DocComments { self: Global =>
     getDocComment(sym) map getUseCases getOrElse List()
   }
 
-  private val wikiReplacements = List(
-    ("""(\n\s*\*?)(\s*\n)"""    .r, """$1 <p>$2"""),
-    ("""<([^\w/])"""            .r, """&lt;$1"""),
-    ("""([^\w/])>"""            .r, """$1&gt;"""),
-    ("""\{\{\{(.*(?:\n.*)*)\}\}\}""".r, """<pre>$1</pre>"""),
-    ("""`([^`]*)`"""            .r, """<code>$1</code>"""),
-    ("""__([^_]*)__"""          .r, """<u>$1</u>"""),
-    ("""''([^']*)''"""          .r, """<i>$1</i>"""),
-    ("""'''([^']*)'''"""        .r, """<b>$1</b>"""),
-    ("""\^([^^]*)\^"""          .r, """<sup>$1</sup>"""),
-    (""",,([^,]*),,"""          .r, """<sub>$1</sub>"""))
-
-  /** Returns just the wiki expansion (this would correspond to
-   *  a comment in the input format of the JavaDoc tool, modulo differences
-   *  in tags.)
-   */
-  def expandWiki(str: String): String =
-    (str /: wikiReplacements) { (str1, regexRepl) => regexRepl._1 replaceAllIn(str1, regexRepl._2) }
-
   private def getDocComment(sym: Symbol): Option[DocComment] =
     mapFind(sym :: allInheritedOverriddenSymbols(sym))(docComments get _)
 


### PR DESCRIPTION
DocComments#expandWiki() had been used by DocComments#toJavaDoc before,
but the latter was removed by #3004.

Based on GitHub (yeah, it's wild guess), we don't have any external
cosumers other than that.
https://github.com/search?l=scala&q=expandWiki+-filename%3ADocComments&ref=searchresults&type=Code&utf8=%E2%9C%93
