### PR TITLE
SI-9252 gets rid of custom logic for jArrayClass in runtime reflection

### DIFF
--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -1285,16 +1285,12 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
       jclazz getDeclaredConstructor (effectiveParamClasses: _*)
     }
 
-    private def jArrayClass(elemClazz: jClass[_]): jClass[_] = {
-      jArray.newInstance(elemClazz, 0).getClass
-    }
-
     /** The Java class that corresponds to given Scala type.
      *  Pre: Scala type is already transformed to Java level.
      */
     def typeToJavaClass(tpe: Type): jClass[_] = tpe match {
       case ExistentialType(_, rtpe)                  => typeToJavaClass(rtpe)
-      case TypeRef(_, ArrayClass, List(elemtpe))     => jArrayClass(typeToJavaClass(elemtpe))
+      case TypeRef(_, ArrayClass, List(elemtpe))     => ScalaRunTime.arrayClass(typeToJavaClass(elemtpe))
       case TypeRef(_, sym: ClassSymbol, _)           => classToJava(sym.asClass)
       case tpe @ TypeRef(_, sym: AliasTypeSymbol, _) => typeToJavaClass(tpe.dealias)
       case SingleType(_, sym: ModuleSymbol)          => classToJava(sym.moduleClass.asClass)

--- a/test/files/run/t9252.check
+++ b/test/files/run/t9252.check
@@ -1,0 +1,1 @@
+class [Lscala.runtime.BoxedUnit;

--- a/test/files/run/t9252.scala
+++ b/test/files/run/t9252.scala
@@ -1,0 +1,5 @@
+import scala.reflect.runtime.universe._
+
+object Test extends App {
+  println(rootMirror.runtimeClass(typeOf[Array[Unit]]))
+}


### PR DESCRIPTION
Apparently, I've already fixed a very similar issue two years ago.
That was a fun surprise! (https://issues.scala-lang.org/browse/SI-5680)
