### PR TITLE
SI-8689 Make a Future test case determistic

### DIFF
--- a/test/files/jvm/t8689.scala
+++ b/test/files/jvm/t8689.scala
@@ -4,10 +4,15 @@ object Test {
     import ExecutionContext.Implicits.global
     val source1 = Promise[Int]()
     val source2 = Promise[Int]()
+    val done = Promise[Unit]()
     source2.completeWith(source1.future).future.onComplete {
-      case _ => print("success")
+      case _ =>
+         print("success")
+         done.success(())
     }
     source2.tryFailure(new TimeoutException)
     source1.success(123)
+    import duration._
+    Await.result(done.future, 120.seconds)
   }
 }


### PR DESCRIPTION
As discussed:

  https://groups.google.com/forum/#!topic/scala-internals/m8I_3GQR4vQ

We need to ensure a happens-before relationship between the callback
that prints "success" and the end of the main method.

Review by @lrytz

Should be backported to 2.10.x
