### PR TITLE
SI-9197  Duration.Inf not a singleton when deserialized

### DIFF
--- a/src/library/scala/concurrent/duration/Duration.scala
+++ b/src/library/scala/concurrent/duration/Duration.scala
@@ -182,6 +182,7 @@ object Duration {
     def compare(other: Duration) = if (other eq this) 0 else 1
     def unary_- : Duration = this
     def toUnit(unit: TimeUnit): Double = Double.NaN
+    private def readResolve(): AnyRef = Undefined      // Instructs deserialization to use this same instance
   }
 
   sealed abstract class Infinite extends Duration {
@@ -230,7 +231,7 @@ object Duration {
    * but itself. This value closely corresponds to Double.PositiveInfinity,
    * matching its semantics in arithmetic operations.
    */
-  val Inf: Infinite = new Infinite {
+  val Inf: Infinite = new Infinite  {
     override def toString = "Duration.Inf"
     def compare(other: Duration) = other match {
       case x if x eq Undefined => -1 // Undefined != Undefined
@@ -239,6 +240,7 @@ object Duration {
     }
     def unary_- : Duration = MinusInf
     def toUnit(unit: TimeUnit): Double = Double.PositiveInfinity
+    private def readResolve(): AnyRef = Inf            // Instructs deserialization to use this same instance
   }
 
   /**
@@ -251,6 +253,7 @@ object Duration {
     def compare(other: Duration) = if (other eq this) 0 else -1
     def unary_- : Duration = Inf
     def toUnit(unit: TimeUnit): Double = Double.NegativeInfinity
+    private def readResolve(): AnyRef = MinusInf    // Instructs deserialization to use this same instance
   }
 
   // Java Factories

--- a/test/junit/scala/concurrent/duration/SerializationTest.scala
+++ b/test/junit/scala/concurrent/duration/SerializationTest.scala
@@ -1,0 +1,24 @@
+package scala.concurrent.duration
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Test
+
+
+@RunWith(classOf[JUnit4])
+class SerializationTest {
+  @Test
+  def test_SI9197 {
+    def ser(a: AnyRef): Array[Byte] = {
+      val bais = new java.io.ByteArrayOutputStream
+      (new java.io.ObjectOutputStream(bais)).writeObject(a)
+      bais.toByteArray
+    }
+    def des(ab: Array[Byte]): AnyRef =
+      (new java.io.ObjectInputStream(new java.io.ByteArrayInputStream(ab))).readObject
+    
+    assert(Duration.Undefined eq des(ser(Duration.Undefined)))
+    assert(Duration.Inf eq des(ser(Duration.Inf)))
+    assert(Duration.MinusInf eq des(ser(Duration.MinusInf)))
+  }
+}


### PR DESCRIPTION
Made `Duration.Undefined`, `.Inf`, and `.MinusInf` all give back the singleton instance instead of creating a new copy by overriding readResolve.

This override can be (and is) private, which at least on Sun's JDK8 doesn't mess with the auto-generated SerialVersionUIDs.

Thus, the patch should make things strictly better: if you're on 2.11.7+ on JVMs which pick the same SerialVersionUIDs, you can recover singletons.  Everywhere else you were already in trouble anyway.
