### PR TITLE
SI-8731 don't issue a @switch warning for two-case matches

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
@@ -577,8 +577,6 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
                 lengthMax3(casesNoSubstOnly) > 2
               }
               val requireSwitch = hasSwitchAnnotation && exceedsTwoCasesOrAlts
-              if (hasSwitchAnnotation && !requireSwitch)
-                reporter.warning(scrut.pos, "matches with two cases or fewer are emitted using if-then-else instead of switch")
               (suppression, requireSwitch)
             case _ =>
               (Suppression.NoSuppression, false)

--- a/src/library/scala/annotation/switch.scala
+++ b/src/library/scala/annotation/switch.scala
@@ -22,6 +22,9 @@ package scala.annotation
   }
 }}}
  *
+ *  Note: for pattern matches with one or two cases, the compiler generates jump instructions.
+ *  Annotating such a match with `@switch` does not issue any warning.
+ *
  *  @author   Paul Phillips
  *  @since    2.8
  */

--- a/test/files/neg/t8731.check
+++ b/test/files/neg/t8731.check
@@ -1,9 +1,6 @@
-t8731.scala:5: warning: matches with two cases or fewer are emitted using if-then-else instead of switch
-  def f(x: Int) = (x: @annotation.switch) match {
-                       ^
 t8731.scala:10: warning: could not emit switch for @switch annotated match
   def g(x: Int) = (x: @annotation.switch) match {
                        ^
 error: No warnings can be incurred under -Xfatal-warnings.
-two warnings found
+one warning found
 one error found


### PR DESCRIPTION
This allows annotating small pattern matches with `@switch` without
getting any warnings. There's no reason to warn, the performance of
the generated bytecode is good.
