### PR TITLE
Enable #4285: switch to partest 1.0.6

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -27,7 +27,7 @@ actors-migration.version.number=1.1.0
 jline.version=2.12.1
 
 # external modules, used internally (not shipped)
-partest.version.number=1.0.5
+partest.version.number=1.0.6
 scalacheck.version.number=1.11.4
 
 # TODO: modularize the compiler


### PR DESCRIPTION
To enable #4285, see also https://github.com/scala/scala-partest/pull/31.
