### PR TITLE
SI-9019  TraversableLike stringPrefix broken for inner classes

### DIFF
--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -651,12 +651,25 @@ trait TraversableLike[+A, +Repr] extends Any
    *           simple name of the collection class $coll.
    */
   def stringPrefix : String = {
-    var string = repr.getClass.getName
-    val idx1 = string.lastIndexOf('.' : Int)
-    if (idx1 != -1) string = string.substring(idx1 + 1)
-    val idx2 = string.indexOf('$')
-    if (idx2 != -1) string = string.substring(0, idx2)
-    string
+    val string = repr.getClass.getName
+    val idx1 = 1 + string.lastIndexOf('.' : Int)
+    val idx2 = string.indexOf('$', math.max(0, idx1))
+    if (idx2 == -1) {
+      // No $, just take the last name
+      if (idx1 > 0) string.substring(idx1) else string
+    }
+    else {
+      // We found a $.  Maybe we can find something that looks like a class name?
+      // None of the $-stuff the compiler inserts seems to be upper case in the first character.
+      var end = string.length
+      while (end > idx2+1) {
+        val idx = string.lastIndexOf('$', end-1)
+        // If we found something good, snip it out and return
+        if (idx >= idx2 && idx+1 < end && java.lang.Character.isUpperCase(string.charAt(idx+1))) return string.substring(idx+1, end)
+        end = idx
+      }
+      if (idx2 > idx1) string.substring(idx1, idx2) else string.substring(idx1)
+    }
   }
 
   /** Creates a non-strict view of this $coll.

--- a/test/junit/scala/collection/TraversableLikeTest.scala
+++ b/test/junit/scala/collection/TraversableLikeTest.scala
@@ -1,0 +1,33 @@
+package scala.collection
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class TraversableLikeTest {
+  // For test_SI9019; out here because as of test writing, putting this in a method would crash compiler
+  class Baz[@specialized(Int) A]() extends IndexedSeq[A] {
+    def apply(i: Int) = ???
+    def length: Int = 0
+  }
+  
+  @Test
+  def test_SI9019 {
+    object Foo {
+      def mkBar = () => {
+        class Bar extends IndexedSeq[Int] {
+          def apply(i: Int) = ???
+          def length: Int = 0
+        }
+        new Bar
+      }
+    }
+    val bar = Foo.mkBar()
+    assertEquals(bar.stringPrefix, "Bar")  // Previously would have been outermost class, TraversableLikeTest
+    
+    val baz = new Baz[Int]()
+    assertEquals(baz.stringPrefix, "Baz")  // Make sure we don't see specialization $mcI$sp stuff
+  }
+}


### PR DESCRIPTION
Added a simple heuristic to detect inner class names: it starts with a capital.  This allows most inner class collections to automatically get their name instead of some other random thing, but avoids being confused by specialization.

Test added to verify behavior.
