### PR TITLE
SI-5795 empty scaladoc tags should be omitted from output

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
@@ -281,13 +281,16 @@ trait CommentFactoryBase { this: MemberLookupBase =>
         parse0(docBody, tags + (key -> value), Some(key), ls, inCodeBlock)
 
       case line :: ls if (lastTagKey.isDefined) =>
-        val key = lastTagKey.get
-        val value =
-          ((tags get key): @unchecked) match {
-            case Some(b :: bs) => (b + endOfLine + line) :: bs
-            case None => oops("lastTagKey set when no tag exists for key")
-          }
-        parse0(docBody, tags + (key -> value), lastTagKey, ls, inCodeBlock)
+        val newtags = if (!line.isEmpty) {
+          val key = lastTagKey.get
+          val value =
+            ((tags get key): @unchecked) match {
+              case Some(b :: bs) => (b + endOfLine + line) :: bs
+              case None => oops("lastTagKey set when no tag exists for key")
+            }
+          tags + (key -> value)
+        } else tags
+        parse0(docBody, newtags, lastTagKey, ls, inCodeBlock)
 
       case line :: ls =>
         if (docBody.length > 0) docBody append endOfLine

--- a/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
@@ -318,18 +318,18 @@ trait CommentFactoryBase { this: MemberLookupBase =>
         val bodyTags: mutable.Map[TagKey, List[Body]] =
           mutable.Map(tagsWithoutDiagram mapValues {tag => tag map (parseWikiAtSymbol(_, pos, site))} toSeq: _*)
 
-        def oneTag(key: SimpleTagKey): Option[Body] =
+        def oneTag(key: SimpleTagKey, filterEmpty: Boolean = true): Option[Body] =
           ((bodyTags remove key): @unchecked) match {
-            case Some(r :: rs) =>
+            case Some(r :: rs) if !(filterEmpty && r.blocks.isEmpty) =>
               if (!rs.isEmpty) reporter.warning(pos, "Only one '@" + key.name + "' tag is allowed")
               Some(r)
-            case None => None
+            case _ => None
           }
 
         def allTags(key: SimpleTagKey): List[Body] =
-          (bodyTags remove key) getOrElse Nil
+          (bodyTags remove key).getOrElse(Nil).filterNot(_.blocks.isEmpty)
 
-        def allSymsOneTag(key: TagKey): Map[String, Body] = {
+        def allSymsOneTag(key: TagKey, filterEmpty: Boolean = true): Map[String, Body] = {
           val keys: Seq[SymbolTagKey] =
             bodyTags.keys.toSeq flatMap {
               case stk: SymbolTagKey if (stk.name == key.name) => Some(stk)
@@ -345,11 +345,11 @@ trait CommentFactoryBase { this: MemberLookupBase =>
                 reporter.warning(pos, "Only one '@" + key.name + "' tag for symbol " + key.symbol + " is allowed")
               (key.symbol, bs.head)
             }
-          Map.empty[String, Body] ++ pairs
+          Map.empty[String, Body] ++ (if (filterEmpty) pairs.filterNot(_._2.blocks.isEmpty) else pairs)
         }
 
         def linkedExceptions: Map[String, Body] = {
-          val m = allSymsOneTag(SimpleTagKey("throws"))
+          val m = allSymsOneTag(SimpleTagKey("throws"), filterEmpty = false)
 
           m.map { case (name,body) =>
             val link = memberLookup(pos, name, site)
@@ -375,7 +375,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
           version0        = oneTag(SimpleTagKey("version")),
           since0          = oneTag(SimpleTagKey("since")),
           todo0           = allTags(SimpleTagKey("todo")),
-          deprecated0     = oneTag(SimpleTagKey("deprecated")),
+          deprecated0     = oneTag(SimpleTagKey("deprecated"), filterEmpty = false),
           note0           = allTags(SimpleTagKey("note")),
           example0        = allTags(SimpleTagKey("example")),
           constructor0    = oneTag(SimpleTagKey("constructor")),

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.css
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.css
@@ -210,6 +210,7 @@ dl.attributes > dd {
   display: block;
   padding-left: 10em;
   margin-bottom: 5px;
+  min-height: 15px;
 }
 
 #template .values > h3 {
@@ -669,6 +670,7 @@ div.fullcomment dl.paramcmts > dd {
   padding-left: 10px;
   margin-bottom: 5px;
   margin-left: 70px;
+  min-height: 15px;
 }
 
 /* Members filter tool */

--- a/test/scaladoc/run/t5795.check
+++ b/test/scaladoc/run/t5795.check
@@ -1,0 +1,4 @@
+newSource:16: warning: Could not find any member to link for "Exception".
+  /**
+  ^
+Done.

--- a/test/scaladoc/run/t5795.scala
+++ b/test/scaladoc/run/t5795.scala
@@ -1,0 +1,63 @@
+import scala.tools.nsc.doc.model._
+import scala.tools.partest.ScaladocModelTest
+
+object Test extends ScaladocModelTest {
+
+  override def code = """
+/**
+  * Only the 'deprecated' tag should stay.
+  *
+  * @author
+  * @since
+  * @todo
+  * @note
+  * @see
+  * @version
+  * @deprecated
+  * @example
+  * @constructor
+  */
+object Test {
+  /**
+    * Only the 'throws' tag should stay.
+    * @param foo
+    * @param bar
+    * @param baz
+    * @return
+    * @throws Exception
+    * @tparam T
+    */
+  def foo[T](foo: Any, bar: Any, baz: Any): Int = 1
+}
+  """
+
+  def scaladocSettings = ""
+
+  def test(b: Boolean, text: => String): Unit = if (!b) println(text)
+
+  def testModel(root: Package) = {
+    import access._
+    val obj = root._object("Test")
+    val c = obj.comment.get
+
+    test(c.authors.isEmpty, s"expected no authors, found: ${c.authors}")
+    test(!c.since.isDefined, s"expected no since tag, found: ${c.since}")
+    test(c.todo.isEmpty, s"expected no todos, found: ${c.todo}")
+    test(c.note.isEmpty, s"expected no note, found: ${c.note}")
+    test(c.see.isEmpty, s"expected no see, found: ${c.see}")
+    test(!c.version.isDefined, s"expected no version tag, found: ${c.version}")
+    // deprecated stays
+    test(c.deprecated.isDefined, s"expected deprecated tag, found none")
+    test(c.example.isEmpty, s"expected no example, found: ${c.example}")
+    test(!c.constructor.isDefined, s"expected no constructor tag, found: ${c.constructor}")
+
+    val method = obj._method("foo")
+    val mc = method.comment.get
+
+    test(mc.valueParams.isEmpty, s"expected empty value params, found: ${mc.valueParams}")
+    test(mc.typeParams.isEmpty, s"expected empty type params, found: ${mc.typeParams}")
+    test(!mc.result.isDefined, s"expected no result tag, found: ${mc.result}")
+    // throws stay
+    test(!mc.throws.isEmpty, s"expected an exception tag, found: ${mc.throws}")
+  }
+}

--- a/test/scaladoc/scalacheck/CommentFactoryTest.scala
+++ b/test/scaladoc/scalacheck/CommentFactoryTest.scala
@@ -24,8 +24,11 @@ class Factory(val g: Global, val s: doc.Settings)
     }
   }
 
+  def getComment(s: String): Comment =
+    parse(s, "", scala.tools.nsc.util.NoPosition, null)
+
   def parseComment(s: String): Option[Inline] =
-    strip(parse(s, "", scala.tools.nsc.util.NoPosition, null))
+    strip(getComment(s))
 
   def createBody(s: String) =
     parse(s, "", scala.tools.nsc.util.NoPosition, null).body
@@ -166,4 +169,19 @@ object Test extends Properties("CommentFactory") {
     }
   }
 
+  property("Empty parameter text should be empty") = {
+    // used to fail with
+    // body == Body(List(Paragraph(Chain(List(Summary(Text('\n')))))))
+    factory.getComment(
+      """
+/**
+  * @deprecated
+  */
+      """).deprecated match {
+      case Some(Body(l)) if l.isEmpty => true
+      case other =>
+        println(other)
+        false
+    }
+  }
 }

--- a/test/scaladoc/scalacheck/HtmlFactoryTest.scala
+++ b/test/scaladoc/scalacheck/HtmlFactoryTest.scala
@@ -685,7 +685,7 @@ object Test extends Properties("HtmlFactory") {
       case node: scala.xml.Node => {
         val s = node.toString
         s.contains("<h6>Author:</h6>") &&
-        s.contains("<p>The Only Author\n</p>")
+        s.contains("<p>The Only Author</p>")
       }
       case _ => false
     }
@@ -699,7 +699,7 @@ object Test extends Properties("HtmlFactory") {
         val s = node.toString
         s.contains("<h6>Authors:</h6>") &&
         s.contains("<p>The First Author</p>") &&
-        s.contains("<p>The Second Author\n</p>")
+        s.contains("<p>The Second Author</p>")
       }
       case _ => false
     }


### PR DESCRIPTION
Empty scaladoc tags, like `@param`, `@return`, `@version`, etc. should
be omitted from the output when they have no meaning by themselves.

They are still parsed, for validation (warning that a tag doesn't
exist and so on), but are removed, if empty, when building the Comment.

The only one that stays even when empty is `@deprecated`, so that the
class name can be striked-through. "Deprecated" also appears in the
header, even if there is no message with it.

---

The first two commits fix two other tag-related bugs in scaladoc, found while fixing this one. See individual commit messages.
