### PR TITLE
SI-8627 Two-argument indexOf does not work for Iterator

### DIFF
--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -852,8 +852,25 @@ trait Iterator[+A] extends TraversableOnce[A] {
    *           or -1 if such an element does not exist until the end of the iterator is reached.
    *  @note    Reuse: $consumesIterator
    */
-  def indexWhere(p: A => Boolean): Int = {
+  def indexWhere(p: A => Boolean): Int = indexWhere(p, 0)
+
+  /** Returns the index of the first produced value satisfying a predicate, or -1, after or at
+   *  some start index.
+   *  $mayNotTerminateInf
+   *
+   *  @param p the predicate to test values
+   *  @param from the start index
+   *  @return the index `>= from` of the first produced value satisfying `p`,
+   *          or -1 if such an element does not exist until the end of the iterator is reached.
+   *  @note   Reuse: $consumesIterator
+   */
+  def indexWhere(p: A => Boolean, from: Int): Int = {
     var i = 0
+    while (i < from && hasNext) {
+      next()
+      i += 1
+    }
+
     var found = false
     while (!found && hasNext) {
       if (p(next())) {
@@ -874,8 +891,26 @@ trait Iterator[+A] extends TraversableOnce[A] {
    *          or -1 if such an element does not exist until the end of the iterator is reached.
    *  @note   Reuse: $consumesIterator
    */
-  def indexOf[B >: A](elem: B): Int = {
+  def indexOf[B >: A](elem: B): Int = indexOf(elem, 0)
+
+  /** Returns the index of the first occurrence of the specified object in this iterable object
+   *  after or at some start index.
+   *  $mayNotTerminateInf
+   *
+   *  @param elem element to search for.
+   *  @param from the start index
+   *  @return the index `>= from` of the first occurrence of `elem` in the values produced by this
+   *          iterator, or -1 if such an element does not exist until the end of the iterator is
+   *          reached.
+   *  @note   Reuse: $consumesIterator
+   */
+  def indexOf[B >: A](elem: B, from: Int): Int = {
     var i = 0
+    while (i < from && hasNext) {
+      next()
+      i += 1
+    }
+
     var found = false
     while (!found && hasNext) {
       if (next() == elem) {

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -135,6 +135,20 @@ class IteratorTest {
     assertEquals(3, List(1, 2, 3, 4, 5).iterator.indexWhere { x: Int => x >= 4 })
     assertEquals(-1, List(1, 2, 3, 4, 5).iterator.indexWhere { x: Int => x >= 16 })
   }
+  @Test def indexOfFrom(): Unit = {
+    assertEquals(1, List(1, 2, 3, 4, 5).iterator.indexOf(2, 0))
+    assertEquals(1, List(1, 2, 3, 4, 5).iterator.indexOf(2, 1))
+    assertEquals(-1, List(1, 2, 3, 4, 5).iterator.indexOf(2, 2))
+    assertEquals(4, List(1, 2, 3, 2, 1).iterator.indexOf(1, 1))
+    assertEquals(1, List(1, 2, 3, 2, 1).iterator.indexOf(2, 1))
+  }
+  @Test def indexWhereFrom(): Unit = {
+    assertEquals(1, List(1, 2, 3, 4, 5).iterator.indexWhere(_ == 2, 0))
+    assertEquals(1, List(1, 2, 3, 4, 5).iterator.indexWhere(_ == 2, 1))
+    assertEquals(-1, List(1, 2, 3, 4, 5).iterator.indexWhere(_ == 2, 2))
+    assertEquals(4, List(1, 2, 3, 2, 1).iterator.indexWhere(_ < 2, 1))
+    assertEquals(1, List(1, 2, 3, 2, 1).iterator.indexWhere(_ <= 2, 1))
+  }
   // iterator-iterate-lazy.scala
   // was java.lang.UnsupportedOperationException: tail of empty list
   @Test def iterateIsSufficientlyLazy(): Unit = {
@@ -153,5 +167,13 @@ class IteratorTest {
     // back and forth without slipping into nontermination.
     results += (Stream from 1).toIterator.drop(10).toStream.drop(10).toIterator.next()
     assertSameElements(List(1,1,21), results)
+  }
+  // SI-8552
+  @Test def indexOfShouldWorkForTwoParams(): Unit = {
+    assertEquals(1, List(1, 2, 3).iterator.indexOf(2, 0))
+    assertEquals(-1, List(5 -> 0).iterator.indexOf(5, 0))
+    assertEquals(0, List(5 -> 0).iterator.indexOf((5, 0)))
+    assertEquals(-1, List(5 -> 0, 9 -> 2, 0 -> 3).iterator.indexOf(9, 2))
+    assertEquals(1, List(5 -> 0, 9 -> 2, 0 -> 3).iterator.indexOf(9 -> 2))
   }
 }


### PR DESCRIPTION
Adds two new methods to `Iterator`, overloading `indexOf` and `indexWhere` with a two-arg version whose second argument indicates the index where to start the search. These methods were already present in instances of `GenSeqLike` but not on iterators, leading to strange behavior when two arguments were passed to `indexOf`.
