### PR TITLE
SI-9264 An even-better diagnostic for an unexplained crash

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
@@ -883,7 +883,12 @@ abstract class GenICode extends SubComponent {
                   case None =>
                     val saved = settings.uniqid
                     settings.uniqid.value = true
-                    try abort(s"symbol $sym does not exist in ${ctx.method}, which contains locals ${ctx.method.locals.mkString(",")}")
+                    try {
+                      val methodCode = unit.body.collect { case dd: DefDef
+                        if dd.symbol == ctx.method.symbol => showCode(dd);
+                      }.headOption.getOrElse("<unknown>")
+                      abort(s"symbol $sym does not exist in ${ctx.method}, which contains locals ${ctx.method.locals.mkString(",")}. \nMethod code: $methodCode")
+                    }
                     finally settings.uniqid.value = saved
                 }
               }


### PR DESCRIPTION
We have seen an intermittent crasher in the backend for the last
month or so.

In https://github.com/scala/scala/pull/4397, I added a diagnostic
to show the actual locals in scope in the method.

This commit further expands the diagnistic to show the method's tree.

Review by @adriaanm
