### PR TITLE
Add zip method to Option.

### DIFF
--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -8,6 +8,8 @@
 
 package scala
 
+import scala.collection.GenIterable
+
 object Option {
 
   import scala.language.implicitConversions
@@ -321,6 +323,15 @@ sealed abstract class Option[+A] extends Product with Serializable {
    */
   @inline final def toLeft[X](right: => X) =
     if (isEmpty) Right(right) else Left(this.get)
+
+  /** Returns an `Option[Tuple(A,B)]`,
+    * or None if this $option's value is None.
+    *
+    * @param that the value which is going to be zipped
+    * @see zip
+    */
+  @inline final def zip[A1 >: A, B, That](that: GenIterable[B]) =
+    if (isEmpty || that.isEmpty) None else Some(this.get, that.head)
 }
 
 /** Class `Some[A]` represents existing values of type


### PR DESCRIPTION
[SI-8394](https://issues.scala-lang.org/browse/SI-8394) Option zip should return Option

It looks like duplicate implementation for `zip` methond in `IterableLike`. 
But based on the [note](https://github.com/scala/scala/blob/2.11.x/src/library/scala/Option.scala#L72-L75) that I found in source code, I think it's feasible considering the outcome.

> @note Many of the methods in here are duplicative with those
> in the Traversable hierarchy, but they are duplicated for a reason:
> the implicit conversion tends to leave one with an Iterable in
> situations where one could have retained an Option.
### Behavior

``` scala
> val some = Some("text")
> val none = None
> val list0 = List()
> val list1 = List("text")
> val list2 = List("text", "text2")
```

**Option values with each other:**

``` scala
> some zip some
res6: Option[(String, String)] = Some((text,text))

> some zip none
res7: Option[(String, Nothing)] = None

> none zip some
res8: Option[(Nothing, String)] = None
```

**Option values with other Iterables:**

``` scala
> some zip list0
res9: Option[(String, Nothing)] = None

> some zip list1
res10: Option[(String, String)] = Some((text,text))

> some zip list2
res11: Option[(String, String)] = Some((text,text))

> none zip list0
res12: Option[(Nothing, Nothing)] = None

> none zip list1
res13: Option[(Nothing, String)] = None

> none zip list2
res14: Option[(Nothing, String)] = None
```

I'm aware there are some comments about that current behaviour is as intended.
There is even a closed [ticket](https://issues.scala-lang.org/browse/SI-8391) that points the same issue for `zipWithIndex`. Comment there says:

> Zipping with an index is a pretty non-Option-like thing to do (it's equivalent to x.map(y => (y,0)))

But in my opinion, unlike `zipWithIndex`, `zip` might be useful in some cases.
