### PR TITLE
SI-8394 Add zip method to Option.

### DIFF
--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -8,6 +8,8 @@
 
 package scala
 
+import scala.collection.GenIterable
+
 object Option {
 
   import scala.language.implicitConversions
@@ -321,6 +323,40 @@ sealed abstract class Option[+A] extends Product with Serializable {
    */
   @inline final def toLeft[X](right: => X) =
     if (isEmpty) Right(right) else Left(this.get)
+
+
+  /** Returns an `Option[Tuple2[A,B]]` formed from this `option` and another iterable collection
+    *  by combining value of this `option` and first element of incoming iterable.
+    *  If iterable has more than one value, its remaining elements are ignored.
+    *  If `option` is `None`, returns `None`.
+    *
+    *  @param   that  The iterable providing the second half of the pair
+    *  @tparam  A1    The type of the first half of the returned pair (this is always a supertype
+    *                 of the collection's element type `A`).
+    *  @tparam  B     the type of the second half of the returned pair
+    *  @return        A new `option` contains a tuple consisting of
+    *                 value of this `option` and first element of `that`.
+    *
+    */
+  final def zip[A1 >: A, B](that: GenIterable[B]): Option[Tuple2[A,B]] =
+    if (isEmpty || that.isEmpty) None else Some((this.get, that.head))
+
+  /** Returns an `Option[Tuple2[A,B]]` formed from this `option` and another `option` by combining the values.
+    *  If any of the `options` is `None`, returns `None`.
+    *
+    *  @param   that  The option providing the second half of the pair
+    *  @tparam  A1    The type of the first half of the returned pair (this is always a supertype
+    *                 of the collection's element type `A`).
+    *  @tparam  B     the type of the second half of the returned pair
+    *  @return        A new `option` contains a tuple consisting of
+    *                 value of this `option` and `that` `option`.
+    *
+    */
+  final def zip[A1 >: A, B](that: Option[B]): Option[Tuple2[A,B]] =
+    for {
+      a <- this
+      b <- that
+    } yield (a,b)
 }
 
 /** Class `Some[A]` represents existing values of type

--- a/test/junit/scala/OptionTest.scala
+++ b/test/junit/scala/OptionTest.scala
@@ -1,0 +1,84 @@
+package scala
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class OptionTest {
+  import Option._
+
+  @Test def someZipSome() = {
+    val some = Some("a")
+    val other = Some("b")
+
+    val res = some.zip(other)
+    assertEquals(res, Some(("a", "b")))
+  }
+
+  @Test def someZipNone() = {
+    val some = Some("a")
+    val none = None
+
+    val res = some.zip(none)
+    assertEquals(res, None)
+  }
+
+  @Test def noneZipSome() = {
+    val some = Some("a")
+    val none = None
+
+    val res = none.zip(some)
+    assertEquals(res, None)
+  }
+
+  @Test def someZipList0() = {
+    val some = Some("a")
+    val list = List()
+
+    val res = some.zip(list)
+    assertEquals(res, None)
+  }
+
+  @Test def someZipList1() = {
+    val some = Some("a")
+    val list = List("a")
+
+    val res = some.zip(list)
+    assertEquals(res, Some(("a", "a")))
+  }
+
+  @Test def someZipList2() = {
+    val some = Some("a")
+    val list = List("a", "b")
+
+    val res = some.zip(list)
+    assertEquals(res, Some(("a", "a")))
+  }
+
+  @Test def noneZipList0() = {
+    val none = None
+    val list = List()
+
+    val res = none.zip(list)
+    assertEquals(res, None)
+  }
+
+  @Test def noneZipList1() = {
+    val none = None
+    val list = List("a")
+
+    val res = none.zip(list)
+    assertEquals(res, None)
+  }
+
+  @Test def noneZipList2() = {
+    val none = None
+    val list = List("a", "b")
+
+    val res = none.zip(list)
+    assertEquals(res, None)
+  }
+
+}


### PR DESCRIPTION
SI-8394 Option zip should return Option

It looks like duplicate implementation for zip methond in IterableLike. 
But based on the note that I found in source code, I think it's feasible considering the outcome.

@note Many of the methods in here are duplicative with those
in the Traversable hierarchy, but they are duplicated for a reason:
the implicit conversion tends to leave one with an Iterable in
situations where one could have retained an Option.
Behavior

> val some = Some("text")
> val none = None
> val list0 = List()
> val list1 = List("text")
> val list2 = List("text", "text2")
> Option values with each other:
> 
> some zip some
> res6: Option[(String, String)] = Some((text,text))
> 
> some zip none
> res7: Option[(String, Nothing)] = None
> 
> none zip some
> res8: Option[(Nothing, String)] = None
> Option values with other Iterables:
> 
> some zip list0
> res9: Option[(String, Nothing)] = None
> 
> some zip list1
> res10: Option[(String, String)] = Some((text,text))
> 
> some zip list2
> res11: Option[(String, String)] = Some((text,text))
> 
> none zip list0
> res12: Option[(Nothing, Nothing)] = None
> 
> none zip list1
> res13: Option[(Nothing, String)] = None
> 
> none zip list2
> res14: Option[(Nothing, String)] = None
> I'm aware there are some comments about that current behaviour is as intended.
> There is even a closed ticket that points the same issue for zipWithIndex. Comment there says:

Zipping with an index is a pretty non-Option-like thing to do (it's equivalent to x.map(y => (y,0)))
But in my opinion, unlike zipWithIndex, zip might be useful in some cases.
