### PR TITLE
SI-2991 No Java tupling

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -219,6 +219,9 @@ trait ScalaSettings extends AbsScalaSettings
   val YdisableUnreachablePrevention = BooleanSetting("-Ydisable-unreachable-prevention", "Disable the prevention of unreachable blocks in code generation.")
   val YnoLoadImplClass = BooleanSetting   ("-Yno-load-impl-class", "Do not load $class.class files.")
 
+  val YnoJavaTupling  = BooleanSetting    ("-Yno-java-tupling", "No autotupling of Java method applications.")
+  val YnoTupling      = BooleanSetting    ("-Yno-tupling", "No tupling conversions during applicability tests.")
+
   val exposeEmptyPackage = BooleanSetting ("-Yexpose-empty-package", "Internal only: expose the empty package.").internalOnly()
   val Ydelambdafy        = ChoiceSetting  ("-Ydelambdafy", "strategy", "Strategy used for translating lambdas into JVM code.", List("inline", "method"), "method")
 

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -687,7 +687,7 @@ trait Infer extends Checkable {
         case 2 => varargsTarget
         case _ => false
       }
-      canSendTuple && canReceiveTuple
+      context.inTuplingEnabled && canSendTuple && canReceiveTuple
     }
     def eligibleForTupleConversion(formals: List[Type], argsCount: Int): Boolean = formals match {
       case p :: Nil                                     => eligibleForTupleConversion(1, argsCount, varargsTarget = isScalaRepeatedParamType(p))
@@ -755,7 +755,7 @@ trait Infer extends Checkable {
       compareLengths(argtpes0, formals) match {
         case 0 if containsNamedType(argtpes0) => reorderedTypesCompatible      // right number of args, wrong order
         case 0                                => typesCompatible(argtpes0)     // fast track if no named arguments are used
-        case x if x > 0                       => tryWithArgs(argsTupled)       // too many args, try tupling
+        case x if x > 0                       => context.inTuplingEnabled && tryWithArgs(argsTupled) // too many args, try tupling
         case _                                => tryWithArgs(argsPlusDefaults) // too few args, try adding defaults or tupling
       }
     }
@@ -1277,8 +1277,8 @@ trait Infer extends Checkable {
      *  If no alternative matches `pt`, take the parameterless one anyway.
      */
     def inferExprAlternative(tree: Tree, pt: Type): Tree = {
-      val c = context
-      class InferTwice(pre: Type, alts: List[Symbol]) extends c.TryTwice {
+      val `context'` = context
+      class InferTwice(pre: Type, alts: List[Symbol]) extends `context'`.TryTwice {
         def tryOnce(isSecondTry: Boolean): Unit = {
           val alts0 = alts filter (alt => isWeaklyCompatible(pre memberType alt, pt))
           val alts1 = if (alts0.isEmpty) alts else alts0
@@ -1387,8 +1387,8 @@ trait Infer extends Checkable {
       // This potentially makes up to four attempts: tryOnce may execute
       // with and without views enabled, and bestForExpectedType will try again
       // with pt = WildcardType if it fails with pt != WildcardType.
-      val c = context
-      class InferMethodAlternativeTwice extends c.TryTwice {
+      val `context'` = context
+      class InferMethodAlternativeTwice extends `context'`.TryTwice {
         private[this] val OverloadedType(pre, alts) = tree.tpe
         private[this] var varargsStar = false
         private[this] val argtpes = argtpes0 mapConserve {
@@ -1402,7 +1402,13 @@ trait Infer extends Checkable {
         private def rankAlternatives(sym1: Symbol, sym2: Symbol) = isStrictlyMoreSpecific(followType(sym1), followType(sym2), sym1, sym2)
         private def bestForExpectedType(pt: Type, isLastTry: Boolean): Unit = {
           val applicable  = overloadsToConsiderBySpecificity(alts filter isAltApplicable(pt), argtpes, varargsStar)
-          val ranked      = bestAlternatives(applicable)(rankAlternatives)
+          def infected    = applicable exists (_.isJavaDefined)
+          val ranked      = (
+            if (settings.YnoTupling || (settings.YnoJavaTupling && isLastTry && infected))
+              context.withinTuplingDisabled(bestAlternatives(applicable)(rankAlternatives))
+            else
+              context.withinTuplingEnabled(bestAlternatives(applicable)(rankAlternatives))
+          )
           ranked match {
             case best :: competing :: _ => AmbiguousMethodAlternativeError(tree, pre, best, competing, argtpes, pt, isLastTry) // ambiguous
             case best :: Nil            => tree setSymbol best setType (pre memberType best)           // success

--- a/test/files/neg/t2991.check
+++ b/test/files/neg/t2991.check
@@ -1,0 +1,13 @@
+scam_2.scala:3: error: No adaptation of argument list for Java method.
+        signature: Jamb_1.k(x$1: Any): String
+  given arguments: 42, true, false
+ after adaptation: Jamb_1.k((42, true, false): (Int, Boolean, Boolean))
+  def f = new Jamb_1().k(42, true, false)
+                        ^
+scam_2.scala:4: error: No adaptation of argument list for Java method.
+        signature: Jamb_1.f(x$1: Any): String
+  given arguments: 42, true, false
+ after adaptation: Jamb_1.f((42, true, false): (Int, Boolean, Boolean))
+  def g = new Jamb_1().f(42, true, false)
+                        ^
+two errors found

--- a/test/files/neg/t2991.flags
+++ b/test/files/neg/t2991.flags
@@ -1,0 +1,1 @@
+-Yno-java-tupling

--- a/test/files/neg/t2991/Jamb_1.java
+++ b/test/files/neg/t2991/Jamb_1.java
@@ -1,0 +1,9 @@
+
+public class Jamb_1 {
+    // k(42, true, false) fails to compile without tupling.
+    // overload resolution says neither method is applicable.
+    public String k(Object a) { return "foo"; }
+    public String k(int i, boolean b) { return "bar"; }
+
+    public String f(Object x) { return "ok"; }
+}

--- a/test/files/neg/t2991/scam_2.scala
+++ b/test/files/neg/t2991/scam_2.scala
@@ -1,0 +1,5 @@
+
+trait Scam {
+  def f = new Jamb_1().k(42, true, false)
+  def g = new Jamb_1().f(42, true, false)
+}

--- a/test/files/pos/t2991.flags
+++ b/test/files/pos/t2991.flags
@@ -1,0 +1,1 @@
+-Yno-java-tupling

--- a/test/files/pos/t2991/Jamb_1.java
+++ b/test/files/pos/t2991/Jamb_1.java
@@ -1,0 +1,15 @@
+
+public class Jamb_1 {
+    // ambiguous to Scala, not to Java
+    public String f(Object a) { return "foo"; }
+    public String f(Object a, Object... as) { return "bar"; }
+
+    // ditto
+    public <T> T g(T t) { return t; }
+    public <T> T g(T t, T... ts) { return ts[0]; }
+
+    // even more ambiguous
+    public <T> T j(T t) { return t; }
+    public <T> T j(T t, T u ) { return u; }
+    public <T> T j(T t, T u, T... ts) { return ts[0]; }
+}

--- a/test/files/pos/t2991/Jamb_1.java
+++ b/test/files/pos/t2991/Jamb_1.java
@@ -12,4 +12,8 @@ public class Jamb_1 {
     public <T> T j(T t) { return t; }
     public <T> T j(T t, T u ) { return u; }
     public <T> T j(T t, T u, T... ts) { return ts[0]; }
+
+    // people want to do this, too
+    public String k(Object x) { return "foo"; }     // pick me, pick me!
+    public <T> String k(T... xs) { return "bar"; }
 }

--- a/test/files/pos/t2991/scam_2.scala
+++ b/test/files/pos/t2991/scam_2.scala
@@ -1,0 +1,9 @@
+
+// was ambiguous to Scala
+trait Scam {
+  val j = new Jamb_1
+  val o = new Object
+  def f = j.f(o)        // yes, we can
+  def g = j.g(42)       // ditto
+  def k = j.j(42)       // threesome
+}

--- a/test/files/pos/t2991/scam_2.scala
+++ b/test/files/pos/t2991/scam_2.scala
@@ -5,5 +5,10 @@ trait Scam {
   val o = new Object
   def f = j.f(o)        // yes, we can
   def g = j.g(42)       // ditto
+  def h = j.g(42, 43)   // you better
   def k = j.j(42)       // threesome
+
+  def z = j.k(o)        // picks the one-arg version
+  def y = j.k()         // just checking
+  def x = j.k(o, o)     // just checking
 }


### PR DESCRIPTION
SI-2991 No Java tupling

A compiler option `-Yno-java-tupling` ensures that
tupling is not used to make a Java method applicable.

This includes applicability tests during overload
resolution, so that Java API that was previously
ambiguous can be invoked from Scala.

For example, Java will disambiguate `f(A)` and `f(A, A*)` 
even though ambiguous in Scala. Turning off Java tupling
allows invoking the single-parameter method defined in Java.

Anticipating deprecation of the feature, which was
never specked, `-Yno-tupling` turns it off entirely.

Currently, `-Yno-adapted-args` invalidates an
adaptation only after overload resolution.

Tupling becomes a Context mode which defaults off.

Review by @retronym 
