### PR TITLE
Upgrade Ruby / Jekyll versions used to build the spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 # based on http://www.paperplanes.de/2013/8/13/deploying-your-jekyll-blog-to-s3-with-travis-ci.html
 language: ruby
 rvm:
-  - 1.9.3
+  - 2.2
 script: bundle exec jekyll build -s spec/ -d build/spec
 install: bundle install
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # To build the spec on Travis CI
 source "https://rubygems.org"
 
-gem "jekyll", "2.0.0.alpha.2"
+gem "jekyll", "2.5.3"
 gem "rouge"
 # gem 's3_website'
 # gem 'redcarpet'


### PR DESCRIPTION
I've given this a dry-run in a separate repository:

   https://travis-ci.org/retronym/scala-spec/builds/57744110

I haven't verified that the output is the same, though.

Review by @adriaanm
