### PR TITLE
SI-8362: AbstractPromise extends AtomicReference, avoids sun.misc.Unsafe

### DIFF
--- a/bincompat-backward.whitelist.conf
+++ b/bincompat-backward.whitelist.conf
@@ -208,6 +208,15 @@ filter {
     {
         matchName="scala.reflect.io.ZipArchive.scala$reflect$io$ZipArchive$$walkIterator"
         problemName=MissingMethodProblem
+    },
+    // SI-8362: AbstractPromise extends AtomicReference
+    // It's ok to change a package-protected class in an impl package,
+    // even though it's not clear why it changed -- bug in generic signature generation?
+    // -public class scala.concurrent.impl.Promise$DefaultPromise<T>                          extends scala.concurrent.impl.AbstractPromise implements scala.concurrent.impl.Promise<T>
+    // +public class scala.concurrent.impl.Promise$DefaultPromise<T extends java.lang.Object> extends scala.concurrent.impl.AbstractPromise implements scala.concurrent.impl.Promise<T>
+    {
+        matchName="scala.concurrent.impl.Promise$DefaultPromise"
+        problemName=MissingTypesProblem
     }
   ]
 }

--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -372,6 +372,15 @@ filter {
     {
         matchName="scala.util.Sorting.scala$util$Sorting$$booleanSort"
         problemName=MissingMethodProblem
+    },
+    // SI-8362: AbstractPromise extends AtomicReference
+    // It's ok to change a package-protected class in an impl package,
+    // even though it's not clear why it changed -- bug in generic signature generation?
+    // -public class scala.concurrent.impl.Promise$DefaultPromise<T>                          extends scala.concurrent.impl.AbstractPromise implements scala.concurrent.impl.Promise<T>
+    // +public class scala.concurrent.impl.Promise$DefaultPromise<T extends java.lang.Object> extends scala.concurrent.impl.AbstractPromise implements scala.concurrent.impl.Promise<T>
+    {
+        matchName="scala.concurrent.impl.Promise$DefaultPromise"
+        problemName=MissingTypesProblem
     }
   ]
 }

--- a/src/library/scala/concurrent/impl/AbstractPromise.java
+++ b/src/library/scala/concurrent/impl/AbstractPromise.java
@@ -1,6 +1,6 @@
 /*                     __                                               *\
 **     ________ ___   / /  ___     Scala API                            **
-**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
+**    / __/ __// _ | / /  / _ |    (c) 2003-2015, LAMP/EPFL             **
 **  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
 ** /____/\___/_/ |_/____/_/ | |                                         **
 **                          |/                                          **
@@ -8,33 +8,10 @@
 
 package scala.concurrent.impl;
 
+import java.util.concurrent.atomic.AtomicReference;
 
-import scala.concurrent.util.Unsafe;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-
-
-
-abstract class AbstractPromise {
-    private volatile Object _ref;
-
-    final static long _refoffset;
-
-    static {
-	try {
-	    _refoffset = Unsafe.instance.objectFieldOffset(AbstractPromise.class.getDeclaredField("_ref"));
-	} catch (Throwable t) {
-	    throw new ExceptionInInitializerError(t);
-	}
-    }
-
-    protected final boolean updateState(Object oldState, Object newState) {
-	return Unsafe.instance.compareAndSwapObject(this, _refoffset, oldState, newState);
-    }
-
-    protected final Object getState() {
-	return _ref;
-    }
-
-    protected final static AtomicReferenceFieldUpdater<AbstractPromise, Object> updater =
-	AtomicReferenceFieldUpdater.newUpdater(AbstractPromise.class, Object.class, "_ref");
+@Deprecated // Since 2.11.8. Extend java.util.concurrent.atomic.AtomicReference instead.
+abstract class AbstractPromise extends AtomicReference<Object> {
+  protected final boolean updateState(Object oldState, Object newState) { return compareAndSet(oldState, newState); }
+  protected final Object getState() { return get(); }
 }


### PR DESCRIPTION
Rebases and slightly reworks #4313.
