### PR TITLE
SI-9267: Constructor properties are not properly copied

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Constructors.scala
+++ b/src/compiler/scala/tools/nsc/transform/Constructors.scala
@@ -499,11 +499,13 @@ abstract class Constructors extends Statics with Transform with ast.TreeDSL {
     // The constructor parameter with given name. This means the parameter
     // has given name, or starts with given name, and continues with a `$` afterwards.
     def parameterNamed(name: Name): Symbol = {
-      def matchesName(param: Symbol) = param.name == name || param.name.startsWith(name + nme.NAME_JOIN_STRING)
+      val nameWithSuffix = name.append(nme.NAME_JOIN_STRING)
+      def matchesName(param: Symbol) = param.name == name || param.name == nameWithSuffix
 
       (constrParams filter matchesName) match {
-        case Nil    => abort(name + " not in " + constrParams)
-        case p :: _ => p
+        case Nil      => abort(name + " not in " + constrParams)
+        case p :: Nil => p
+        case _        => abort(name + " matched multiple parameters in " + constrParams)
       }
     }
 

--- a/test/junit/scala/tools/nsc/transform/ParamMatchTest.scala
+++ b/test/junit/scala/tools/nsc/transform/ParamMatchTest.scala
@@ -1,0 +1,19 @@
+package scala.tools.nsc.transform
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class ParamMatchTest {
+  // order of parameters is important for a failing test, as the parameter matcher for "total" takes the first
+  // constructor parameter that was either "total" or started with "total$"
+  class Invoice(val `total tax`: Int, val total: Int)
+
+  @Test
+  def testMatch: Unit = {
+    val invoice = new Invoice(20, 120)
+    assertEquals("invalid parameter copy in constructor", 120, invoice.total)
+  }
+}


### PR DESCRIPTION
The parameterNamed(name: Name) method in Constructors currently
selects the first result from a list of matches, which allows
for an invalid assignment.

A fix proposal is to use an exact match instead of the startsWith
method, while also adding a sanity check in case of multiple
matched constructor parameters.
