### PR TITLE
SI-9273 Avoid unpositioned error for bare classOf

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4881,10 +4881,11 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             (// this -> Foo.this
             if (sym.isThisSym)
               typed1(This(sym.owner) setPos tree.pos, mode, pt)
-          // Inferring classOf type parameter from expected type.  Otherwise an
-          // actual call to the stubbed classOf method is generated, returning null.
-            else if (isPredefClassOf(sym) && pt.typeSymbol == ClassClass && pt.typeArgs.nonEmpty)
-            typedClassOf(tree, TypeTree(pt.typeArgs.head))
+            else if (isPredefClassOf(sym) && pt.typeSymbol == ClassClass && pt.typeArgs.nonEmpty) {
+              // Inferring classOf type parameter from expected type.  Otherwise an
+              // actual call to the stubbed classOf method is generated, returning null.
+              typedClassOf(tree, TypeTree(pt.typeArgs.head).setPos(tree.pos.focus))
+            }
           else {
               val pre1  = if (sym.isTopLevel) sym.owner.thisType else if (qual == EmptyTree) NoPrefix else qual.tpe
               val tree1 = if (qual == EmptyTree) tree else atPos(tree.pos)(Select(atPos(tree.pos.focusStart)(qual), name))

--- a/test/files/neg/t9273.check
+++ b/test/files/neg/t9273.check
@@ -1,0 +1,10 @@
+t9273.scala:2: error: class type required but ? found
+  val foo: Class[_] = classOf            // error without position, line or file
+                      ^
+t9273.scala:3: error: not found: type X
+  val foo1: Class[_] = classOf[X]        // good error, all info contained
+                               ^
+t9273.scala:7: error: not found: type X
+  val foo4: Class[_] = Predef.classOf[X] // good error, all info contained
+                                      ^
+three errors found

--- a/test/files/neg/t9273.scala
+++ b/test/files/neg/t9273.scala
@@ -1,0 +1,9 @@
+class MissingLineNumbers {
+  val foo: Class[_] = classOf            // error without position, line or file
+  val foo1: Class[_] = classOf[X]        // good error, all info contained
+  val foo2 = classOf                     // Infers  T=Nothing
+
+  val foo3: Class[_] = Predef.classOf    // Infers  T=Nothing. Irregular wrt typedIdent.
+  val foo4: Class[_] = Predef.classOf[X] // good error, all info contained
+  val foo5 = Predef.classOf              // Infers  T=Nothing
+}


### PR DESCRIPTION
A bare identifier `classOf` in a position wth an expected type of
`Class[_]` was leading to an unpositioned error.

This is due to special treatment of bare `classOf` in `typedIdent`
creating an ephemeral, but unpositioned, `TypeTree`.

This commit positions that tree and tests that the error is
issued at a sensible position.

There is still an irregularity between `classOf` and `Predef.classOf`,
but that seems esoteric enough to leave alone for now.
