### PR TITLE
Don't crash GenBCode for value classes with a self declaration

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeAsmCommon.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeAsmCommon.scala
@@ -329,10 +329,12 @@ final class BCodeAsmCommon[G <: Global](val global: G) {
    * Build the [[InlineInfo]] for a class symbol.
    */
   def buildInlineInfoFromClassSymbol(classSym: Symbol, classSymToInternalName: Symbol => InternalName, methodSymToDescriptor: Symbol => String): InlineInfo = {
-    val selfType = {
+    val traitSelfType = if (classSym.isTrait && !classSym.isImplClass) {
       // The mixin phase uses typeOfThis for the self parameter in implementation class methods.
       val selfSym = classSym.typeOfThis.typeSymbol
       if (selfSym != classSym) Some(classSymToInternalName(selfSym)) else None
+    } else {
+      None
     }
 
     val isEffectivelyFinal = classSym.isEffectivelyFinal
@@ -394,6 +396,6 @@ final class BCodeAsmCommon[G <: Global](val global: G) {
         }
     }).toMap
 
-    InlineInfo(selfType, isEffectivelyFinal, methodInlineInfos, warning)
+    InlineInfo(traitSelfType, isEffectivelyFinal, methodInlineInfos, warning)
   }
 }

--- a/test/files/run/valueClassSelfType.scala
+++ b/test/files/run/valueClassSelfType.scala
@@ -1,0 +1,52 @@
+trait T
+
+class V1(val l: Long) extends AnyVal { self: T =>
+  def foo: V1 = self
+  def bar: T  = self
+}
+
+class V2(val l: Long) extends AnyVal { self =>
+  def foo: V2 = self
+}
+
+class V3(val l: Long) extends AnyVal { self: Long =>
+  def foo: V3   = self
+  def bar: Long = self
+}
+
+// non-value classes
+
+class C1(val l: Long) { self: T =>
+  def foo: C1 = self
+  def bar: T  = self
+}
+
+class C2(val l: Long) { self =>
+  def foo: C2 = self
+}
+
+class C3(val l: Long) { self: Long =>
+  def foo: C3   = self
+  def bar: Long = self
+}
+
+object Test extends App {
+  // Rejected: superclass V1 is not a subclass of the superclass Object of the mixin trait T
+  // new V1(1l) with T
+
+  assert(new V2(1l).foo.l == 1l)
+
+  // Rejected: V3 does not conform to its self-type V3 with Long
+  // new V3(1l)
+
+  val c2 = new C1(2l) with T
+  assert(c2.foo.l + c2.bar.asInstanceOf[C1].l == 4l)
+
+  assert(new C2(3l).foo.l == 3l)
+
+  // Rejected: C3 does not conform to its self-type C3 with Long
+  // new C3(4l)
+
+  // Rejected: class Long needs to be a trait to be mixed in
+  // new C3(4l) with Long
+}


### PR DESCRIPTION
If a value class has a self declaration

  class V(x: Long) extends AnyVal { self => /\* ... */ }

`vClassSymbol.typeOfThis.typeSymbol` is `class Long` in the backend.

The InlineInfo for traits contains a field for the self type of the
trait. This is required for re-writing calls to final trait methods
to the static implementation method: the self type appears in the
impl method signature.

By mistake, the backend was recording the self type of all classes,
not only of traits. In the case of a value class with a self
declaration, this broke the assumption that the self type is always
a class type (not a primitive type).

The simple fix: only record the self type for traits.
