### PR TITLE
Jarlister utility with ant task and man page

### DIFF
--- a/build-ant-macros.xml
+++ b/build-ant-macros.xml
@@ -330,6 +330,7 @@
               <mk-bin file="${build-@{stage}.dir}/bin/scalac" class="scala.tools.nsc.Main" javaFlags="${java.flags}"/>
               <mk-bin file="${build-@{stage}.dir}/bin/scaladoc" class="scala.tools.nsc.ScalaDoc" javaFlags="${java.flags}"/>
               <mk-bin file="${build-@{stage}.dir}/bin/fsc" class="scala.tools.nsc.CompileClient" javaFlags="${java.flags}"/>
+              <mk-bin file="${build-@{stage}.dir}/bin/jarlister" class="scala.tools.nsc.JarLister" javaFlags="${java.flags}"/>
               <mk-bin file="${build-@{stage}.dir}/bin/scalap" class="scala.tools.scalap.Main" javaFlags="${java.flags}"/>
             </then>
             <else>
@@ -344,6 +345,7 @@
           <chmod perm="ugo+rx" file="${build-@{stage}.dir}/bin/scalac"/>
           <chmod perm="ugo+rx" file="${build-@{stage}.dir}/bin/scaladoc"/>
           <chmod perm="ugo+rx" file="${build-@{stage}.dir}/bin/fsc"/>
+          <chmod perm="ugo+rx" file="${build-@{stage}.dir}/bin/jarlister"/>
           <chmod perm="ugo+rx" file="${build-@{stage}.dir}/bin/scalap"/>
         </do>
       </staged-uptodate>

--- a/build.xml
+++ b/build.xml
@@ -1222,7 +1222,10 @@ TODO:
 <!-- ===========================================================================
                                   PACKED QUICK BUILD (PACK)
 ============================================================================ -->
-  <target name="pack.lib"    depends="quick.lib, forkjoin.done"> <staged-pack project="library"/></target>
+  <target name="pack.lib"    depends="quick.lib, forkjoin.done"> <staged-pack project="library"/>
+    <taskdef name="jarlister" classname="scala.tools.ant.JarLister" classpathref="quick.compiler.build.path"/>
+    <jarlister file="${build-pack.dir}/lib/scala-library.jar"/>
+  </target>
 
   <target name="pack.reflect" depends="quick.reflect"> <staged-pack project="reflect"/> </target>
 

--- a/build.xml
+++ b/build.xml
@@ -1754,7 +1754,7 @@ TODO:
         <taskdef name="genman"
                  classname="scala.tools.docutil.ManMaker"
                  classpathref="manual.build.path"/>
-        <genman command="fsc, scala, scalac, scaladoc, scalap"
+        <genman command="fsc, scala, scalac, scaladoc, scalap, jarlister"
                 htmlout="${build-pack.dir}/doc/tools"
                 manout="${build-manual.dir}/genman"/>
       </do>

--- a/src/compiler/scala/tools/ant/JarLister.scala
+++ b/src/compiler/scala/tools/ant/JarLister.scala
@@ -1,0 +1,58 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala Ant Tasks                      **
+**    / __/ __// _ | / /  / _ |    (c) 2005-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala.tools.ant
+
+import java.io.File
+
+/** An Ant task that lists a jar's classes into its manifest.
+ *
+ *  This task can take the following parameters as attributes:
+ *  - `file` (mandatory),
+ *  - `output`.
+ *
+ * @author  Raphael Jolly
+ * @version 1.0
+ */
+class JarLister extends ScalaMatchingTask {
+
+/*============================================================================*\
+**                             Ant user-properties                            **
+\*============================================================================*/
+
+  /** The path to the jar file. */
+  private var file: Option[File] = None
+
+  /** The path to the output file. */
+  private var output: Option[File] = None
+
+/*============================================================================*\
+**                             Properties setters                             **
+\*============================================================================*/
+
+  /** Sets the file attribute. */
+  def setFile(input: File) =
+    file = Some(input)
+
+  /** Sets the output attribute. */
+  def setOutput(input: File) =
+    output = Some(input)
+
+/*============================================================================*\
+**                           The big execute method                           **
+\*============================================================================*/
+
+  /** Performs the jar listing. */
+  override def execute() = {
+    // Tests if all mandatory attributes are set and valid.
+    if (file.isEmpty) buildError("Attribute 'file' is not set.")
+
+    scala.tools.nsc.JarLister.process(file.get.getPath, if (output.isEmpty) "" else output.get.getPath)
+  }
+
+}

--- a/src/compiler/scala/tools/ant/antlib.xml
+++ b/src/compiler/scala/tools/ant/antlib.xml
@@ -11,6 +11,8 @@
              classname="scala.tools.ant.Scaladoc"/>
     <taskdef name="scalatool"
              classname="scala.tools.ant.ScalaTool"/>
+    <taskdef name="jarlister"
+             classname="scala.tools.ant.JarLister"/>
     <taskdef name="pack200"
              classname="scala.tools.ant.Pack200Task"/>
 </antlib>

--- a/src/compiler/scala/tools/nsc/JarLister.scala
+++ b/src/compiler/scala/tools/nsc/JarLister.scala
@@ -1,0 +1,89 @@
+/* NSC -- new Scala compiler
+ * Copyright 2005-2013 LAMP/EPFL
+ * @author  Raphael Jolly
+ */
+
+package scala.tools.nsc
+
+import java.io.{File, FileOutputStream, IOException}
+import java.util.jar.{JarFile, JarEntry, JarOutputStream, Attributes}
+import scala.collection.convert.WrapAsScala
+import WrapAsScala.{enumerationAsScalaIterator, mapAsScalaMap}
+
+/** A class that lists a jar's classes into its manifest.
+  * Used to make libraries visible to the interpreter
+  * when run as a script engine.
+  */
+class JarLister {
+
+  def process(args: Array[String]): Boolean = {
+    if (args.length == 0 || args(0) == "-help") {
+      Console.println("""Usage: jarlister [<options>] <jar name>
+   or  jarlister -help
+
+Options:
+
+ -o <file>  specify output jar file
+""")
+      return true
+    }
+    if (args(0) == "-o") process(args(2), args(1)) else process(args(0), "")
+  }
+
+  def process(name: String, output: String): Boolean = {
+    val listedName = if (output == "") name + ".lst" else output
+    val file = new File(name);
+    val jarFile = new JarFile(file);
+    val listedFile = new File(listedName);
+
+    val manifest = jarFile.getManifest
+    val mfEntries = manifest.getEntries
+
+    for (entry <- jarFile.entries) if (entry.getName.endsWith(".class") && !mfEntries.contains(entry.getName)) {
+      mfEntries(entry.getName) = new Attributes
+    }
+
+    val fos = new FileOutputStream(listedFile)
+    val jos = new JarOutputStream(fos, manifest)
+
+    for (entry <- jarFile.entries) if (!entry.getName.equalsIgnoreCase(JarFile.MANIFEST_NAME)) {
+      jos.putNextEntry(entry)
+      writeBytes(jarFile, entry, jos)
+    }
+
+    jos.finish
+    fos.close
+    jarFile.close
+
+    if (output == "") {
+      if (!listedFile.renameTo(file)) {
+        val orig = new File(name + ".orig");
+        if (file.renameTo(orig)) {
+          if (listedFile.renameTo(file)) orig.delete
+          else return false
+        } else return false
+      }
+    }
+    return true
+  }
+
+  val buffer = new Array[Byte](8192)
+  def writeBytes(f: JarFile, e: JarEntry, os: JarOutputStream) {
+    val is = f.getInputStream(e)
+    var left = e.getSize
+    var n = 0
+    while(left > 0) {
+      n = is.read(buffer, 0, buffer.length)
+      if (n == -1) throw new IOException("read error")
+      os.write(buffer, 0, n)
+      left -= n
+    }
+  }
+}
+
+object JarLister extends JarLister {
+  def main(args: Array[String]) {
+    if (!process(args))
+      sys.exit(1)
+  }
+}

--- a/src/manual/scala/man1/jarlister.scala
+++ b/src/manual/scala/man1/jarlister.scala
@@ -1,0 +1,92 @@
+package scala.man1
+
+/**
+ *  @author Raphael Jolly
+ *  @version 1.0
+ */
+object jarlister extends Command {
+  import _root_.scala.tools.docutil.ManPage._
+
+  protected def cn = new Error().getStackTrace()(0).getClassName()
+
+  val name = Section("NAME",
+
+    MBold(command) & " " & NDash & " Jar file lister for the " &
+    Link("Scala 2", "http://scala-lang.org/") & " language")
+
+  val synopsis = Section("SYNOPSIS",
+
+    CmdLine(" [ " & Argument("options") & " ] " & Argument("jar name")))
+
+  val parameters = Section("PARAMETERS",
+
+    DefinitionList(
+      Definition(
+        Mono(Argument("options")),
+        "Command line options. See " & Link(Bold("OPTIONS"), "#options") &
+        " below."),
+      Definition(
+        Mono(Argument("jar name")),
+        "Name of a jar to be listed (such as " &
+        Mono("thirdpartylib.jar") & ").")))
+
+  val description = Section("DESCRIPTION",
+
+    "The " & MBold(command) & " tool lists a jar file's classes " &
+    "into its manifest.")
+
+  val options = Section("OPTIONS",
+
+    "The jar lister has the following options.",
+
+    Section("Standard Options",
+      DefinitionList(
+        Definition(
+          CmdOption("help"),
+          "Display this usage message."),
+        Definition(
+          CmdOption("o"),
+          "Specify output jar file."))))
+
+  val examples = Section("EXAMPLES",
+
+    DefinitionList(
+      Definition(
+        "List jar's classes into manifest",
+        CmdLine("thirdpartylib.jar"))))
+
+  val exitStatus = Section("EXIT STATUS",
+
+    MBold(command) & " returns a zero exist status if it succeeds to process " &
+    "the specified input file. Non zero is returned in case of failure.")
+
+  override val authors = Section("AUTHOR",
+
+    "Written by Raphael Jolly.")
+
+  val seeAlso = Section("SEE ALSO",
+
+    Link(Bold("fsc") & "(1)", "fsc.html") & ", " &
+    Link(Bold("scala") & "(1)", "scala.html") & ", " &
+    Link(Bold("scalac") & "(1)", "scalac.html") & ", " &
+    Link(Bold("scaladoc") & "(1)", "scaladoc.html"))
+
+  def manpage = new Document {
+    title = command
+    date = "February 2013"
+    author = "Raphael Jolly"
+    version = "1.0"
+    sections = List(
+      name,
+      synopsis,
+      parameters,
+      description,
+      options,
+      examples,
+      exitStatus,
+      authors,
+      bugs,
+      copyright,
+      seeAlso)
+  }
+}

--- a/src/manual/scala/tools/docutil/resources/index.html
+++ b/src/manual/scala/tools/docutil/resources/index.html
@@ -46,7 +46,7 @@
   <li>
     <a href="#basic"><b class="SansSerif">Basic Tools</b></a> (<code>fsc</code>, 
     <code>scala</code>, <code>scalac</code>, <code>scaladoc</code>,
-    <code>scalap</code>)
+    <code>scalap</code>, <code>jarlister</code>)
   </li>
 </ul>
 </div>
@@ -173,6 +173,17 @@
     </td>
     <td width="17%" valign="top" class="links">
       [<a href="scalap.html">Solaris, Linux and Windows</a>]
+    </td>
+  </tr>
+  <tr>
+    <td width="13%" valign="top">
+      <span class="tool">jarlister</span>
+    </td>
+    <td width="70%" valign="top">
+      The jar file lister.
+    </td>
+    <td width="17%" valign="top" class="links">
+      [<a href="jarlister.html">Solaris, Linux and Windows</a>]
     </td>
   </tr>
 </table>

--- a/test/files/run/t7843-jsr223-service.scala
+++ b/test/files/run/t7843-jsr223-service.scala
@@ -1,8 +1,6 @@
-import scala.tools.nsc.interpreter.IMain
-
 object Test extends App {
-  val engine = new IMain.Factory getScriptEngine()
-  engine.asInstanceOf[IMain].settings.usejavacp.value = true
+  val m = new javax.script.ScriptEngineManager()
+  val engine = m.getEngineByName("scala")
   engine put ("n", 10)
   engine eval "1 to n.asInstanceOf[Int] foreach print"
 }

--- a/test/files/run/t7933.scala
+++ b/test/files/run/t7933.scala
@@ -1,8 +1,6 @@
-import scala.tools.nsc.interpreter.IMain
-
 object Test extends App {
-  val engine = new IMain.Factory getScriptEngine()
-  engine.asInstanceOf[IMain].settings.usejavacp.value = true
+  val m = new javax.script.ScriptEngineManager()
+  val engine = m.getEngineByName("scala")
   val res2 = engine.asInstanceOf[javax.script.Compilable]
   res2 compile "8" eval()
   val res5 = res2 compile """println("hello") ; 8"""


### PR DESCRIPTION
To take full advantage of JSR-223 compatibility, added in 2.11, one must
list a jar's classes into its manifest, to make the library visible from
the interpreter when run with jrunscript. This is necessary for
scala-library.jar, but also any third party library. This commit provides
a jarlister utility, together with ant task and documentation. I made an
independent jarlister project available on github, but users are afraid of
using it, as it is not official, see the comments in
https://github.com/scala/scala/pull/2238
