### PR TITLE
SI-9268 Be robust against absent classfiles during signature parsing

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -1141,16 +1141,12 @@ abstract class ClassfileParser {
     private def innerSymbol(entry: InnerClassEntry): Symbol = {
       val name      = entry.originalName.toTypeName
       val enclosing = entry.enclosing
-      def getMember = (
+      val member = (
         if (enclosing == clazz) entry.scope lookup name
         else lookupMemberAtTyperPhaseIfPossible(enclosing, name)
       )
-      getMember
-      /*  There used to be an assertion that this result is not NoSymbol; changing it to an error
-       *  revealed it had been going off all the time, but has been swallowed by a catch t: Throwable
-       *  in Repository.scala. Since it has been accomplishing nothing except misleading anyone who
-       *  thought it wasn't triggering, I removed it entirely.
-       */
+      def newStub = enclosing.newStubSymbol(name, s"Unable to locate class corresponding to inner class entry for $name in owner ${entry.outerName}")
+      member.orElse(newStub)
     }
   }
 

--- a/test/files/run/t9268.check
+++ b/test/files/run/t9268.check
@@ -1,0 +1,5 @@
+Compiling Client1
+pos: NoPosition Class Waiter not found - continuing with a stub. WARNING
+Compiling Client2
+pos: NoPosition Class Waiter not found - continuing with a stub. WARNING
+pos: NoPosition Unable to locate class corresponding to inner class entry for Predicate in owner Waiter ERROR

--- a/test/files/run/t9268/Java.java
+++ b/test/files/run/t9268/Java.java
@@ -1,0 +1,12 @@
+public class Java {
+}
+
+class Partial {
+	public <E extends java.lang.Exception> long waitFor(long l, Waiter.Predicate<E> pred) throws E {
+		return 0L;
+	}
+}
+
+class Waiter {
+	interface Predicate<E> {}
+}

--- a/test/files/run/t9268/Test.scala
+++ b/test/files/run/t9268/Test.scala
@@ -1,0 +1,40 @@
+import scala.tools.partest._
+import java.io.File
+
+object Test extends StoreReporterDirectTest {
+  def code = ???
+
+  def compileCode(code: String) = {
+    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
+    compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(code)
+  }
+
+  def client1 = """
+    class Client1 { def p(p: Partial) = p.toString }
+  """
+
+  def client2 = """
+    class Client2 { def p(p: Partial) = p.waitFor() }
+  """
+
+  def deleteClass(s: String) = {
+    val f = new File(testOutput.path, s + ".class")
+    assert(f.exists)
+    f.delete()
+  }
+
+  def show(): Unit = {
+    deleteClass("Waiter")
+    deleteClass("Waiter$Predicate")
+
+    // Used to crash in Java Generic Signature parsing
+    println("Compiling Client1")
+    compileCode(client1)
+    println(storeReporter.infos.mkString("\n"))
+    storeReporter.reset()
+    println("Compiling Client2")
+    compileCode(client2)
+    println(storeReporter.infos.mkString("\n"))
+  }
+}
+


### PR DESCRIPTION
When parsing a Java generic signature that references an inner
class `A$B`, we were tripping an assertion if the enclosing class
`A` was absent.

This commit creates a stub symbol for `B` when this happens, rather
than continuing on with `NoSymbol`.

The enclosed test shows that we can instantiate a class containing
a method referring to such an inner class with only a warning
about the absent classfile, and that an error is issued only upon
a subsequent attempt to call the method.

Review by @lrytz
