### PR TITLE
Fix many typos

### DIFF
--- a/src/compiler/scala/reflect/quasiquotes/Reifiers.scala
+++ b/src/compiler/scala/reflect/quasiquotes/Reifiers.scala
@@ -317,7 +317,7 @@ trait Reifiers { self: Quasiquotes =>
      *  Reification of non-trivial list is done in two steps:
      *
      *  1. split the list into groups where every placeholder is always
-     *     put in a group of it's own and all subsquent non-holeMap are
+     *     put in a group of its own and all subsquent non-holeMap are
      *     grouped together; element is considered to be a placeholder if it's
      *     in the domain of the fill function;
      *

--- a/src/compiler/scala/tools/nsc/PhaseAssembly.scala
+++ b/src/compiler/scala/tools/nsc/PhaseAssembly.scala
@@ -127,7 +127,7 @@ trait PhaseAssembly {
     }
 
     /* Find all edges in the given graph that are hard links. For each hard link we
-     * need to check that its the only dependency. If not, then we will promote the
+     * need to check that it's the only dependency. If not, then we will promote the
      * other dependencies down
      */
     def validateAndEnforceHardlinks() {

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1259,7 +1259,7 @@ self =>
         atPos(start) { Apply(t3, exprsBuf.toList) }
       }
       if (inPattern) stringCheese
-      else withPlaceholders(stringCheese, isAny = true) // strinterpolator params are Any* by definition
+      else withPlaceholders(stringCheese, isAny = true) // string interpolator params are Any* by definition
     }
 
 /* ------------- NEW LINES ------------------------------------------------- */

--- a/src/compiler/scala/tools/nsc/backend/icode/ICodeCheckers.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/ICodeCheckers.scala
@@ -109,7 +109,7 @@ abstract class ICodeCheckers {
 
     /** Only called when m1 < m2, so already known that (m1 ne m2).
      */
-    private def isConfict(m1: IMember, m2: IMember, canOverload: Boolean) = (
+    private def isConflict(m1: IMember, m2: IMember, canOverload: Boolean) = (
       (m1.symbol.name == m2.symbol.name) &&
       (!canOverload || (m1.symbol.tpe =:= m2.symbol.tpe))
     )
@@ -119,11 +119,11 @@ abstract class ICodeCheckers {
       clasz = cls
 
       for (f1 <- cls.fields ; f2 <- cls.fields ; if f1 < f2)
-        if (isConfict(f1, f2, canOverload = false))
+        if (isConflict(f1, f2, canOverload = false))
           icodeError("Repetitive field name: " + f1.symbol.fullName)
 
       for (m1 <- cls.methods ; m2 <- cls.methods ; if m1 < m2)
-        if (isConfict(m1, m2, canOverload = true))
+        if (isConflict(m1, m2, canOverload = true))
           icodeError("Repetitive method: " + m1.symbol.fullName)
 
       clasz.methods foreach check
@@ -471,7 +471,7 @@ abstract class ICodeCheckers {
            pushStack(local.kind)
 
          case LOAD_FIELD(field, isStatic) =>
-           // the symbol's owner should contain it's field, but
+           // the symbol's owner should contain its field, but
            // this is already checked by the type checker, no need
            // to redo that here
            if (isStatic) ()

--- a/src/compiler/scala/tools/nsc/backend/icode/analysis/TypeFlowAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/analysis/TypeFlowAnalysis.scala
@@ -572,7 +572,7 @@ abstract class TypeFlowAnalysis {
 
         - `inlined` : These blocks were spliced into the method's CFG as part of inlining. Being new blocks, they haven't been visited yet by the typeflow analysis.
 
-        - `staleIn` : These blocks are what `doInline()` calls `afterBlock`s, ie the new home for instructions that previously appearead
+        - `staleIn` : These blocks are what `doInline()` calls `afterBlock`s, ie the new home for instructions that previously appeared
                       after a callsite in a `staleOut` block.
 
       Based on the above information, we have to bring up-to-date the caches that `forwardAnalysis` and `blockTransfer` use to skip blocks and instructions.

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -315,7 +315,7 @@ abstract class BTypes {
         case ArrayBType(component) =>
           if (other == ObjectReference || other == jlCloneableReference || other == jioSerializableReference) true
           else other match {
-            case ArrayBType(otherComponoent) => component.conformsTo(otherComponoent).orThrow
+            case ArrayBType(otherComponent) => component.conformsTo(otherComponent).orThrow
             case _ => false
           }
 

--- a/src/compiler/scala/tools/nsc/backend/opt/DeadCodeElimination.scala
+++ b/src/compiler/scala/tools/nsc/backend/opt/DeadCodeElimination.scala
@@ -173,7 +173,7 @@ abstract class DeadCodeElimination extends SubComponent {
               moveToWorkList()
 
             case LOAD_FIELD(sym, isStatic) if isStatic || !inliner.isClosureClass(sym.owner) =>
-              // static load may trigger static initization.
+              // static load may trigger static initialization.
               // non-static load can throw NPE (but we know closure fields can't be accessed via a
               // null reference.
               moveToWorkList()
@@ -191,7 +191,7 @@ abstract class DeadCodeElimination extends SubComponent {
                   case LOAD_EXCEPTION(_) | DUP(_) | LOAD_MODULE(_) => true
                   case _ =>
                     dropOf((bb1, idx1)) = (bb,idx) :: dropOf.getOrElse((bb1, idx1), Nil)
-                    debuglog("DROP is innessential: " + i + " because of: " + bb1(idx1) + " at " + bb1 + ":" + idx1)
+                    debuglog("DROP is inessential: " + i + " because of: " + bb1(idx1) + " at " + bb1 + ":" + idx1)
                     false
                 }
               }

--- a/src/compiler/scala/tools/nsc/transform/Constructors.scala
+++ b/src/compiler/scala/tools/nsc/transform/Constructors.scala
@@ -315,7 +315,7 @@ abstract class Constructors extends Statics with Transform with ast.TreeDSL {
     }
 
     def rewriteDelayedInit() {
-      /* XXX This is not corect: remainingConstrStats.nonEmpty excludes too much,
+      /* XXX This is not correct: remainingConstrStats.nonEmpty excludes too much,
        * but excluding it includes too much.  The constructor sequence being mimicked
        * needs to be reproduced with total fidelity.
        *

--- a/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
+++ b/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
@@ -77,7 +77,7 @@ abstract class Delambdafy extends Transform with TypingTransformers with ast.Tre
 
     // the result of the transformFunction method.
     sealed abstract class TransformedFunction
-    // A class definition for the lambda, an expression insantiating the lambda class
+    // A class definition for the lambda, an expression instantiating the lambda class
     case class DelambdafyAnonClass(lambdaClassDef: ClassDef, newExpr: Tree) extends TransformedFunction
 
     // here's the main entry point of the transform
@@ -86,7 +86,7 @@ abstract class Delambdafy extends Transform with TypingTransformers with ast.Tre
       case fun @ Function(_, _) =>
         transformFunction(fun) match {
           case DelambdafyAnonClass(lambdaClassDef, newExpr) =>
-            // a lambda beccomes a new class, an instantiation expression
+            // a lambda becomes a new class, an instantiation expression
             val pkg = lambdaClassDef.symbol.owner
 
             // we'll add the lambda class to the package later

--- a/src/compiler/scala/tools/nsc/transform/LazyVals.scala
+++ b/src/compiler/scala/tools/nsc/transform/LazyVals.scala
@@ -219,7 +219,7 @@ abstract class LazyVals extends Transform with TypingTransformers with ast.TreeD
      *    l$
      *  } or
      *  <rhs> when the lazy value has type Unit (for which there is no field
-     *  to cache it's value.
+     *  to cache its value.
      *
      *  Similarly as for normal lazy val members (see Mixin), the result will be a tree of the form
      *  { if ((bitmap&n & MASK) == 0) this.l$compute()

--- a/src/compiler/scala/tools/nsc/transform/Mixin.scala
+++ b/src/compiler/scala/tools/nsc/transform/Mixin.scala
@@ -26,7 +26,7 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
    */
   private val treatedClassInfos = perRunCaches.newMap[Symbol, Type]() withDefaultValue NoType
 
-  /** Map a lazy, mixedin field accessor to it's trait member accessor */
+  /** Map a lazy, mixedin field accessor to its trait member accessor */
   private val initializer = perRunCaches.newMap[Symbol, Symbol]()
 
 // --------- helper functions -----------------------------------------------
@@ -886,7 +886,7 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
       }
 
       /* Complete lazy field accessors. Applies only to classes,
-       * for it's own (non inherited) lazy fields. If 'checkinit'
+       * for its own (non inherited) lazy fields. If 'checkinit'
        * is enabled, getters that check for the initialized bit are
        * generated, and the class constructor is changed to set the
        * initialized bits.

--- a/src/compiler/scala/tools/nsc/transform/SampleTransform.scala
+++ b/src/compiler/scala/tools/nsc/transform/SampleTransform.scala
@@ -27,7 +27,7 @@ abstract class SampleTransform extends Transform {
       tree1 match {
         case Block(List(), expr) =>           // a simple optimization
           expr
-        case Block(defs, sup @ Super(qual, mix)) => // A hypthothetic transformation, which replaces
+        case Block(defs, sup @ Super(qual, mix)) => // A hypothetical transformation, which replaces
                                                     // {super} by {super.sample}
           treeCopy.Block(                           // `copy` is the usual lazy tree copier
             tree1, defs,

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -610,7 +610,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
       exitingSpecialize(sClass setInfo specializedInfoType)
       val fullEnv = outerEnv ++ env
 
-      /* Enter 'sym' in the scope of the current specialized class. It's type is
+      /* Enter 'sym' in the scope of the current specialized class. Its type is
        * mapped through the active environment, binding type variables to concrete
        * types. The existing typeEnv for `sym` is composed with the current active
        * environment
@@ -1368,7 +1368,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
   )
 
   def specializeCalls(unit: CompilationUnit) = new TypingTransformer(unit) {
-    /** Map a specializable method to it's rhs, when not deferred. */
+    /** Map a specializable method to its rhs, when not deferred. */
     val body = perRunCaches.newMap[Symbol, Tree]()
 
     /** Map a specializable method to its value parameter symbols. */

--- a/src/compiler/scala/tools/nsc/typechecker/AnalyzerPlugins.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/AnalyzerPlugins.scala
@@ -57,7 +57,7 @@ trait AnalyzerPlugins { self: Analyzer =>
      * `analyzer.transformed` hash map, indexed by the definition's rhs tree.
      *
      * NOTE: Invoking the type checker can lead to cyclic reference errors. For instance, if this
-     * method is called from the type completer of a recursive method, type checking the mehtod
+     * method is called from the type completer of a recursive method, type checking the method
      * rhs will invoke the same completer again. It might be possible to avoid this situation by
      * assigning `tpe` to `defTree.symbol` (untested) - the final type computed by this method
      * will then be assigned to the definition's symbol by monoTypeCompleter (in Namers).

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -167,7 +167,7 @@ trait Contexts { self: Analyzer =>
    *     afterwards errors are thrown. This is configured in `rootContext`. Additionally, more
    *     fine grained control is needed based on the kind of error; ambiguity errors are often
    *     suppressed during exploratory typing, such as determining whether `a == b` in an argument
-   *     position is an assignment or a named argument, when `Infererencer#isApplicableSafe` type checks
+   *     position is an assignment or a named argument, when `Inferencer#isApplicableSafe` type checks
    *     applications with and without an expected type, or whtn `Typer#tryTypedApply` tries to fit arguments to
    *     a function type with/without implicit views.
    *
@@ -1108,10 +1108,10 @@ trait Contexts { self: Analyzer =>
       //
       // A type-import-on-demand declaration never causes any other declaration to be shadowed.
       //
-      // Scala: Bindings of different kinds have a precedence deﬁned on them:
+      // Scala: Bindings of different kinds have a precedence defined on them:
       //
-      //  1) Deﬁnitions and declarations that are local, inherited, or made available by a
-      //     package clause in the same compilation unit where the deﬁnition occurs have
+      //  1) Definitions and declarations that are local, inherited, or made available by a
+      //     package clause in the same compilation unit where the definition occurs have
       //     highest precedence.
       //  2) Explicit imports have next highest precedence.
       def depthOk(imp: ImportInfo) = (

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -376,7 +376,7 @@ trait Infer extends Checkable {
     }
     /** Overload which allocates fresh type vars.
      *  The other one exists because apparently inferExprInstance needs access to the typevars
-     *  after the call, and its wasteful to return a tuple and throw it away almost every time.
+     *  after the call, and it's wasteful to return a tuple and throw it away almost every time.
      */
     private def exprTypeArgs(tparams: List[Symbol], restpe: Type, pt: Type, useWeaklyCompatible: Boolean): List[Type] =
       exprTypeArgs(tparams map freshVar, tparams, restpe, pt, useWeaklyCompatible)

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1125,7 +1125,7 @@ trait Namers extends MethodSynthesis {
             for (vparam <- vparams) {
               if (vparam.tpt.isEmpty) {
                 val overriddenParamTp = overriddenParams.head.tpe
-                // references to type parameteres in overriddenParamTp link to the type skolems, so the
+                // references to type parameters in overriddenParamTp link to the type skolems, so the
                 // assigned type is consistent with the other / existing parameter types in vparamSymss.
                 vparam.symbol setInfo overriddenParamTp
                 vparam.tpt defineType overriddenParamTp setPos vparam.pos.focus

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -584,7 +584,7 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
             !other.isDeferred && other.isJavaDefined && !sym.enclClass.isSubClass(other.enclClass) && {
               // #3622: erasure operates on uncurried types --
               // note on passing sym in both cases: only sym.isType is relevant for uncurry.transformInfo
-              // !!! erasure.erasure(sym, uncurry.transformInfo(sym, tp)) gives erreneous of inaccessible type - check whether that's still the case!
+              // !!! erasure.erasure(sym, uncurry.transformInfo(sym, tp)) gives erroneous or inaccessible type - check whether that's still the case!
               def uncurryAndErase(tp: Type) = erasure.erasure(sym)(uncurry.transformInfo(sym, tp))
               val tp1 = uncurryAndErase(clazz.thisType.memberType(sym))
               val tp2 = uncurryAndErase(clazz.thisType.memberType(other))

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4301,7 +4301,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             val selector1 = atPos(tree.pos.focusStart) { if (arity == 1) ids.head else gen.mkTuple(ids) }
             // SI-8120 If we don't duplicate the cases, the original Match node will share trees with ones that
             //         receive symbols owned by this function. However if, after a silent mode session, we discard
-            //         this Function and try a different approach (e.g. applying a view to the reciever) we end up
+            //         this Function and try a different approach (e.g. applying a view to the receiver) we end up
             //         with orphaned symbols which blows up far down the pipeline (or can be detected with -Ycheck:typer).
             val body = treeCopy.Match(tree, selector1, (cases map duplicateAndKeepPositions).asInstanceOf[List[CaseDef]])
             typed1(atPos(tree.pos) { Function(params, body) }, mode, pt)

--- a/src/interactive/scala/tools/nsc/interactive/CompilerControl.scala
+++ b/src/interactive/scala/tools/nsc/interactive/CompilerControl.scala
@@ -302,7 +302,7 @@ trait CompilerControl { self: Global =>
   abstract class WorkItem extends (() => Unit) {
     val onCompilerThread = self.onCompilerThread
 
-    /** Raise a MissingReponse, if the work item carries a response. */
+    /** Raise a MissingResponse, if the work item carries a response. */
     def raiseMissing(): Unit
   }
 

--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -315,7 +315,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
   private val NoResponse: Response[_] = new Response[Any]
 
   /** The response that is currently pending, i.e. the compiler
-   *  is working on providing an asnwer for it.
+   *  is working on providing an answer for it.
    */
   private var pendingResponse: Response[_] = NoResponse
 

--- a/src/interactive/scala/tools/nsc/interactive/Lexer.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Lexer.scala
@@ -195,7 +195,7 @@ class Lexer(rd: Reader) {
       case 'n' => putAcceptString("null"); token = NullLit
       case '"' => getString()
       case '-' | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' => getNumber()
-      case _ => error("unrecoginezed start of token: '"+ch+"'")
+      case _ => error("unrecognized start of token: '"+ch+"'")
     }
     //println("["+token+"]")
   }

--- a/src/library/scala/Mutable.scala
+++ b/src/library/scala/Mutable.scala
@@ -11,7 +11,7 @@
 package scala
 
 /**
- * A marker trait for mutable datatructures such as mutable collections
+ * A marker trait for mutable data structures such as mutable collections
  *
  * @since 2.8
  */

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -58,7 +58,7 @@ import scala.io.StdIn
  *  condition fails, then the caller of the function is to blame rather than a
  *  logical error having been made within `addNaturals` itself. `ensures` is a
  *  form of `assert` that declares the guarantee the function is providing with
- *  regards to it's return value.
+ *  regards to its return value.
  *
  *  === Implicit Conversions ===
  *  A number of commonly applied implicit conversions are also defined here, and
@@ -85,7 +85,7 @@ object Predef extends LowPriorityImplicits with DeprecatedPredef {
   type String        = java.lang.String
   type Class[T]      = java.lang.Class[T]
 
-  // miscelleaneous -----------------------------------------------------
+  // miscellaneous -----------------------------------------------------
   scala.`package`                         // to force scala package object to be seen.
   scala.collection.immutable.List         // to force Nil, :: to be seen.
 

--- a/src/library/scala/collection/SeqLike.scala
+++ b/src/library/scala/collection/SeqLike.scala
@@ -413,7 +413,7 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
    *    @inheritdoc
    *
    *    Another way to express this
-   *    is that `xs union ys` computes the order-presevring multi-set union of `xs` and `ys`.
+   *    is that `xs union ys` computes the order-preserving multi-set union of `xs` and `ys`.
    *    `union` is hence a counter-part of `diff` and `intersect` which also work on multi-sets.
    *
    *    $willNotTerminateInf

--- a/src/library/scala/collection/concurrent/Map.scala
+++ b/src/library/scala/collection/concurrent/Map.scala
@@ -49,7 +49,7 @@ trait Map[A, B] extends scala.collection.mutable.Map[A, B] {
   def putIfAbsent(k: A, v: B): Option[B]
 
   /**
-   * Removes the entry for the specified key if its currently mapped to the
+   * Removes the entry for the specified key if it's currently mapped to the
    * specified value.
    *
    * $atomicop

--- a/src/library/scala/collection/immutable/Stream.scala
+++ b/src/library/scala/collection/immutable/Stream.scala
@@ -360,7 +360,7 @@ self =>
    * `List(BigInt(12)) ++ fibs`.
    *
    * @tparam B The element type of the returned collection.'''That'''
-   * @param that The [[scala.collection.GenTraversableOnce]] the be contatenated
+   * @param that The [[scala.collection.GenTraversableOnce]] the be concatenated
    * to this `Stream`.
    * @return A new collection containing the result of concatenating `this` with
    * `that`.

--- a/src/library/scala/collection/mutable/AVLTree.scala
+++ b/src/library/scala/collection/mutable/AVLTree.scala
@@ -27,7 +27,7 @@ private[mutable] sealed trait AVLTree[+A] extends Serializable {
 
   /**
    * Returns a new tree containing the given element.
-   * Thows an IllegalArgumentException if element is already present.
+   * Throws an IllegalArgumentException if element is already present.
    *
    */
   def insert[B >: A](value: B, ordering: Ordering[B]): AVLTree[B] = Node(value, Leaf, Leaf)
@@ -95,7 +95,7 @@ private case class Node[A](data: A, left: AVLTree[A], right: AVLTree[A]) extends
 
   /**
    * Returns a new tree containing the given element.
-   * Thows an IllegalArgumentException if element is already present.
+   * Throws an IllegalArgumentException if element is already present.
    *
    */
   override def insert[B >: A](value: B, ordering: Ordering[B]) = {

--- a/src/library/scala/collection/mutable/HashTable.scala
+++ b/src/library/scala/collection/mutable/HashTable.scala
@@ -449,7 +449,7 @@ private[collection] object HashTable {
       // h
 
       /* OLD VERSION
-       * quick, but bad for sequence 0-10000 - little enthropy in higher bits
+       * quick, but bad for sequence 0-10000 - little entropy in higher bits
        * since 2003 */
       // var h: Int = hcode + ~(hcode << 9)
       // h = h ^ (h >>> 14)

--- a/src/library/scala/collection/mutable/UnrolledBuffer.scala
+++ b/src/library/scala/collection/mutable/UnrolledBuffer.scala
@@ -85,7 +85,7 @@ extends scala.collection.mutable.AbstractBuffer[T]
 
   def classTagCompanion = UnrolledBuffer
 
-  /** Concatenates the targer unrolled buffer to this unrolled buffer.
+  /** Concatenates the target unrolled buffer to this unrolled buffer.
    *
    *  The specified buffer `that` is cleared after this operation. This is
    *  an O(1) operation.

--- a/src/library/scala/collection/mutable/WrappedArray.scala
+++ b/src/library/scala/collection/mutable/WrappedArray.scala
@@ -93,7 +93,7 @@ object WrappedArray {
   def empty[T <: AnyRef]: WrappedArray[T] = EmptyWrappedArray.asInstanceOf[WrappedArray[T]]
 
   // If make is called explicitly we use whatever we're given, even if it's
-  // empty.  This may be unnecesssary (if WrappedArray is to honor the collections
+  // empty.  This may be unnecessary (if WrappedArray is to honor the collections
   // contract all empty ones must be equal, so discriminating based on the reference
   // equality of an empty array should not come up) but we may as well be
   // conservative since wrapRefArray contributes most of the unnecessary allocations.

--- a/src/library/scala/concurrent/JavaConversions.scala
+++ b/src/library/scala/concurrent/JavaConversions.scala
@@ -11,7 +11,7 @@ package scala.concurrent
 import java.util.concurrent.{ExecutorService, Executor}
 import scala.language.implicitConversions
 
-/** The `JavaConversions` object provides implicit converstions supporting
+/** The `JavaConversions` object provides implicit conversions supporting
  *  interoperability between Scala and Java concurrency classes.
  *
  *  @author Philipp Haller

--- a/src/library/scala/math/BigDecimal.scala
+++ b/src/library/scala/math/BigDecimal.scala
@@ -431,7 +431,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable {
    *  with unequal `hashCode`s.  These hash codes agree with `BigInt`
    *  for whole numbers up ~4934 digits (the range of IEEE 128 bit floating
    *  point).  Beyond this, hash codes will disagree; this prevents the
-   *  explicit represention of the `BigInt` form for `BigDecimal` values
+   *  explicit representation of the `BigInt` form for `BigDecimal` values
    *  with large exponents.
    */
   override def hashCode(): Int = {

--- a/src/library/scala/sys/process/BasicIO.scala
+++ b/src/library/scala/sys/process/BasicIO.scala
@@ -203,7 +203,7 @@ object BasicIO {
   /** Returns a `ProcessIO` connected to stdout and stderr, and, optionally, stdin. */
   def standard(connectInput: Boolean): ProcessIO = standard(input(connectInput))
 
-  /** Retruns a `ProcessIO` connected to stdout, stderr and the provided `in` */
+  /** Returns a `ProcessIO` connected to stdout, stderr and the provided `in` */
   def standard(in: OutputStream => Unit): ProcessIO = new ProcessIO(in, toStdOut, toStdErr)
 
   /** Send all the input from the stream to stderr, and closes the input stream

--- a/src/library/scala/sys/process/ProcessLogger.scala
+++ b/src/library/scala/sys/process/ProcessLogger.scala
@@ -88,7 +88,7 @@ object ProcessLogger {
   /** Creates a [[scala.sys.process.ProcessLogger]] that sends all output to the corresponding
    *  function.
    *
-   *  @param fout  This function will receive standard outpout.
+   *  @param fout  This function will receive standard output.
    *
    *  @param ferr  This function will receive standard error.
    */

--- a/src/library/scala/util/control/Exception.scala
+++ b/src/library/scala/util/control/Exception.scala
@@ -155,7 +155,7 @@ object Exception {
   /** A `Catch` object which catches everything. */
   final def allCatch[T]: Catch[T] = new Catch(allCatcher[T]) withDesc "<everything>"
 
-  /** A `Catch` object witch catches non-fatal exceptions. */
+  /** A `Catch` object which catches non-fatal exceptions. */
   final def nonFatalCatch[T]: Catch[T] = new Catch(nonFatalCatcher[T]) withDesc "<non-fatal>"
 
   /** Creates a `Catch` object which will catch any of the supplied exceptions.

--- a/src/library/scala/util/hashing/MurmurHash3.scala
+++ b/src/library/scala/util/hashing/MurmurHash3.scala
@@ -191,7 +191,7 @@ private[hashing] class MurmurHash3 {
  * This is based on the earlier MurmurHash3 code by Rex Kerr, but the
  * MurmurHash3 algorithm was since changed by its creator Austin Appleby
  * to remedy some weaknesses and improve performance. This represents the
- * latest and supposedly final version of the algortihm (revision 136).
+ * latest and supposedly final version of the algorithm (revision 136).
  *
  * @see [[http://code.google.com/p/smhasher]]
  */

--- a/src/library/scala/util/matching/Regex.scala
+++ b/src/library/scala/util/matching/Regex.scala
@@ -477,7 +477,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
   /**
    * Replaces some of the matches using a replacer function that returns an [[scala.Option]].
    * The replacer function takes a [[scala.util.matching.Regex.Match]] so that extra
-   * information can be btained from the match. For example:
+   * information can be obtained from the match. For example:
    *
    * {{{
    * import scala.util.matching.Regex._

--- a/src/partest-extras/scala/tools/partest/ASMConverters.scala
+++ b/src/partest-extras/scala/tools/partest/ASMConverters.scala
@@ -89,7 +89,7 @@ object ASMConverters {
 
     private def lst[T](xs: java.util.List[T]): List[T] = if (xs == null) Nil else xs.asScala.toList
 
-    // Heterogenous List[Any] is used in FrameNode: type information about locals / stack values
+    // Heterogeneous List[Any] is used in FrameNode: type information about locals / stack values
     // are stored in a List[Any] (Integer, String or LabelNode), see Javadoc of MethodNode#visitFrame.
     // Opcodes (eg Opcodes.INTEGER) and Reference types (eg "java/lang/Object") are returned unchanged,
     // LabelNodes are mapped to their LabelEntry.

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -936,7 +936,7 @@ trait Definitions extends api.StandardDefinitions {
     // TODO these aren't final! They are now overridden in AnyRef/Object. Prior to the fix
     //      for SI-8129, they were actually *overloaded* by the members in AnyRef/Object.
     //      We should unfinalize these, override in AnyValClass, and make the overrides final.
-    //      Refchecks never actually looks at these, so its just for consistency.
+    //      Refchecks never actually looks at these, so it's just for consistency.
     lazy val Any_==       = enterNewMethod(AnyClass, nme.EQ, AnyTpe :: Nil, BooleanTpe, FINAL)
     lazy val Any_!=       = enterNewMethod(AnyClass, nme.NE, AnyTpe :: Nil, BooleanTpe, FINAL)
 

--- a/src/reflect/scala/reflect/internal/ReificationSupport.scala
+++ b/src/reflect/scala/reflect/internal/ReificationSupport.scala
@@ -292,7 +292,7 @@ trait ReificationSupport { self: SymbolTable =>
           if (ctorMods.isTrait)
             result(ctorMods, Nil, edefs, body)
           else {
-            // undo conversion from (implicit ... ) to ()(implicit ... ) when its the only parameter section
+            // undo conversion from (implicit ... ) to ()(implicit ... ) when it's the only parameter section
             val vparamssRestoredImplicits = ctorVparamss match {
               case Nil :: (tail @ ((head :: _) :: _)) if head.mods.isImplicit => tail
               case other => other

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2061,7 +2061,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
      */
     final def outerClass: Symbol =
       if (this == NoSymbol) {
-        // ideally we shouldn't get here, but its better to harden against this than suffer the infinite loop in SI-9133
+        // ideally we shouldn't get here, but it's better to harden against this than suffer the infinite loop in SI-9133
         devWarningDumpStack("NoSymbol.outerClass", 15)
         NoSymbol
       } else if (owner.isClass) owner

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -365,7 +365,7 @@ abstract class TreeGen {
             DefDef(NoMods, nme.MIXIN_CONSTRUCTOR, Nil, ListOfNil, TypeTree(), Block(lvdefs, Literal(Constant(()))))))
       }
       else {
-        // convert (implicit ... ) to ()(implicit ... ) if its the only parameter section
+        // convert (implicit ... ) to ()(implicit ... ) if it's the only parameter section
         if (vparamss1.isEmpty || !vparamss1.head.isEmpty && vparamss1.head.head.mods.isImplicit)
           vparamss1 = List() :: vparamss1
         val superCall = pendingSuperCall // we can't know in advance which of the parents will end up as a superclass

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3658,7 +3658,7 @@ trait Types
       // JZ: We used to register this as a perRunCache so it would be cleared eagerly at
       // the end of the compilation run. But, that facility didn't actually clear this map (SI-8129)!
       // When i fixed that bug, run/tpeCache-tyconCache.scala started failing. Why was that?
-      // I've removed the registration for now. I don't think its particularly harmful anymore
+      // I've removed the registration for now. I don't think it's particularly harmful anymore
       // as a) this is now a weak set, and b) it is discarded completely before the next run.
       uniqueRunId = currentRunId
     }
@@ -4535,7 +4535,7 @@ trait Types
 
   /** Adds the @uncheckedBound annotation if the given `tp` has type arguments */
   final def uncheckedBounds(tp: Type): Type = {
-    if (tp.typeArgs.isEmpty || UncheckedBoundsClass == NoSymbol) tp // second condition for backwards compatibilty with older scala-reflect.jar
+    if (tp.typeArgs.isEmpty || UncheckedBoundsClass == NoSymbol) tp // second condition for backwards compatibility with older scala-reflect.jar
     else tp.withAnnotation(AnnotationInfo marker UncheckedBoundsClass.tpe)
   }
 

--- a/src/reflect/scala/reflect/internal/tpe/FindMembers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/FindMembers.scala
@@ -155,7 +155,7 @@ trait FindMembers {
         && (    (member.owner eq other.owner)                         // same owner, therefore overload
              || (member.flags & PRIVATE) != 0                         // (unqualified) private members never participate in overriding
              || (other.flags & PRIVATE) != 0                          // ... as overrider or overridee.
-             || !(memberTypeLow(member) matches memberTypeHi(other))  // do the member types match? If so, its an override. Otherwise it's an overload.
+             || !(memberTypeLow(member) matches memberTypeHi(other))  // do the member types match? If so, it's an override. Otherwise it's an overload.
            )
       )
 

--- a/test/files/jvm/inner.scala
+++ b/test/files/jvm/inner.scala
@@ -77,7 +77,7 @@ object Scalatest {
   def java(cname: String) =
     exec(javacmd, "-cp", classpath, cname)
 
-  /** Execute cmd, wait for the process to end and pipe it's output to stdout */
+  /** Execute cmd, wait for the process to end and pipe its output to stdout */
   private def exec(args: String*) {
     val proc = Runtime.getRuntime().exec(args.toArray)
     val inp = new BufferedReader(new InputStreamReader(proc.getInputStream))

--- a/test/files/jvm/javaReflection/Test.scala
+++ b/test/files/jvm/javaReflection/Test.scala
@@ -124,8 +124,8 @@ object Test {
       // exclude files from Test.scala, just take those from Classes_1.scala
       case s if !s.startsWith("Test") && s.endsWith(".class") => s.substring(0, s.length - 6)
     }).sortWith((a, b) => {
-      // sort such that first there are all anonymous funcitions, then all other classes.
-      // within those cathegories, sort lexically.
+      // sort such that first there are all anonymous functions, then all other classes.
+      // within those categories, sort lexically.
       // this makes the check file smaller: it differs for anonymous functions between -Ydelambdafy:inline/method.
       // the other classes are the same.
       if (isAnonFunClassName(a)) !isAnonFunClassName(b) || a < b

--- a/test/files/pos/t7815.scala
+++ b/test/files/pos/t7815.scala
@@ -21,7 +21,7 @@ object Foo {
 object Main extends App {
   def mapWithFoo[A <: AnyRef, B](as: List[A])(implicit foo: Foo.Aux[A, B]) = {
     // Should be Eta expandable because the result type of `f` is not
-    // dependant on the value, it is just `B`.
+    // dependent on the value, it is just `B`.
     as map foo.f
     as map foo.g
     as map foo.m

--- a/test/files/run/classfile-format-51.scala
+++ b/test/files/run/classfile-format-51.scala
@@ -12,7 +12,7 @@ import Opcodes._
 // it runs a normal compile on the source in the 'code' field that refers to
 // DynamicInvoker. Any failure will be dumped to std out.
 //
-// By it's nature the test can only work on JDK 7+ because under JDK 6 some of the
+// By its nature the test can only work on JDK 7+ because under JDK 6 some of the
 // classes referred to by DynamicInvoker won't be available and DynamicInvoker won't
 // verify. So the test includes a version check that short-circuites the whole test
 // on JDK 6

--- a/test/files/run/classfile-format-52.scala
+++ b/test/files/run/classfile-format-52.scala
@@ -11,7 +11,7 @@ import Opcodes._
 // HasDefaultMethod. Then it runs a normal compile on Scala source that extends that
 // interface. Any failure will be dumped to std out.
 //
-// By it's nature the test can only work on JDK 8+ because under JDK 7- the
+// By its nature the test can only work on JDK 8+ because under JDK 7- the
 // interface won't verify.
 object Test extends DirectTest {
   override def extraSettings: String = "-optimise -usejavacp -d " + testOutput.path + " -cp " + testOutput.path

--- a/test/files/run/t7741a/Test.scala
+++ b/test/files/run/t7741a/Test.scala
@@ -25,7 +25,7 @@ object Test extends DirectTest {
     // interface GroovyInterface {
     //
     //   // This is the line that causes scalac to choke.
-    //   // It results in a GroovyInterface$1 class, which is a non-static inner class but it's constructor does not
+    //   // It results in a GroovyInterface$1 class, which is a non-static inner class but its constructor does not
     //   // include the implicit parameter that is the immediate enclosing instance.
     //   // See http://jira.codehaus.org/browse/GROOVY-7312
     //   //

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
@@ -720,7 +720,7 @@ class InlinerTest extends ClearAfterClass {
         |final class D extends C
         |object E extends C
         |class T {
-        |  def t1(d: D) = d.f + d.g + E.f + E.g // d.f can be inlined because the reciever type is D, which is final.
+        |  def t1(d: D) = d.f + d.g + E.f + E.g // d.f can be inlined because the receiver type is D, which is final.
         |}                                      // so d.f can be resolved statically. same for E.f
       """.stripMargin
     val List(c, d, e, eModule, t) = compile(code)

--- a/test/pending/jvm/javasigs.scala
+++ b/test/pending/jvm/javasigs.scala
@@ -32,7 +32,7 @@ object Scalatest {
   }
     
 
-  /** Execute cmd, wait for the process to end and pipe it's output to stdout */
+  /** Execute cmd, wait for the process to end and pipe its output to stdout */
   def exec(cmd: String) {
     val proc = Runtime.getRuntime().exec(cmd)
     val inp = new BufferedReader(new InputStreamReader(proc.getInputStream))

--- a/test/scaladoc/resources/Trac4420.scala
+++ b/test/scaladoc/resources/Trac4420.scala
@@ -1,7 +1,7 @@
 import java.io.File
 
 /**
- * @define PP This class is an instance of XXX so it's members are not called directly.
+ * @define PP This class is an instance of XXX so its members are not called directly.
  * Instead these classes are instantiated via a driver's ''process''. See YYY for more details. */
 abstract class test
 

--- a/tools/scaladoc-compare
+++ b/tools/scaladoc-compare
@@ -7,7 +7,7 @@ if [ $# -ne 2 ]
 then
   echo
   echo "scaladoc-compare will compare the scaladoc-generated pages in two different locations and output the diff"
-  echo "it's main purpose is to track changes to scaladoc and prevent updates that break things."
+  echo "its main purpose is to track changes to scaladoc and prevent updates that break things."
   echo
   echo "This script is meant to be used with the scaladoc -raw-output option, as it compares .html.raw files "
   echo "instead of markup-heavy .html files."


### PR DESCRIPTION
This commit corrects many typos found in scaladocs and comments. There's
also fixed the name of a private method in ICodeCheckers.
