### PR TITLE
SI-9275 Fix row-first display in REPL

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/ConsoleReaderHelper.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ConsoleReaderHelper.scala
@@ -112,8 +112,12 @@ trait VariColumnTabulator extends Tabulator {
     def layout(ncols: Int): Option[(Int, Seq[Int], Seq[Seq[String]])] = {
       val nrows = items.size /% ncols
       val xwise = isAcross || ncols >= items.length
-      def maxima(sss: Seq[Seq[String]]) =
-        (0 until (ncols min items.size)) map (i => (sss map (ss => ss(i).length)).max)
+      // max width item in each column
+      def maxima(rows: Seq[Seq[String]]) =
+        (0 until (ncols min items.size)) map { col =>
+          val widths = for (r <- rows if r.size > col) yield r(col).length
+          widths.max
+        }
       def resulting(rows: Seq[Seq[String]]) = {
         val columnWidths = maxima(rows) map (_ + marginSize)
         val linelen      = columnWidths.sum
@@ -124,9 +128,10 @@ trait VariColumnTabulator extends Tabulator {
       else if (xwise) resulting((items grouped ncols).toSeq)
       else {
         val cols = (items grouped nrows).toList
-        val rows = for (i <- 0 until nrows) yield
-          for (j <- 0 until ncols) yield
-            if (j < cols.size && i < cols(j).size) cols(j)(i) else ""
+        val rows =
+          for (i <- 0 until nrows) yield
+            for (j <- 0 until ncols) yield
+              if (j < cols.size && i < cols(j).size) cols(j)(i) else ""
         resulting(rows)
       }
     }

--- a/test/junit/scala/tools/nsc/interpreter/TabulatorTest.scala
+++ b/test/junit/scala/tools/nsc/interpreter/TabulatorTest.scala
@@ -82,4 +82,24 @@ class TabulatorTest {
     assert(rows(0).size == 1)
     assert(rows(0)(0).size == "efg".length + sut.marginSize)  // 6
   }
+  @Test def badFit() = {
+    val sut = VTabby(isAcross = true)
+    val items = ('a' until 'z').map(_.toString).toList
+    val rows = sut tabulate items
+    assert(rows.size == 2)
+    assert(rows(0).size == 20)   // 20 * 4 = 80
+    assert(rows(1)(0).dropRight(sut.marginSize) == "u")
+  }
+  @Test def badFitter() = {
+    val sut = VTabby(isAcross = true)
+    val items = List (
+      "%", "&", "*", "+", "-", "/", ">", ">=", ">>", ">>>", "^",
+      "asInstanceOf", "isInstanceOf", "toByte", "toChar", "toDouble", "toFloat",
+      "toInt", "toLong", "toShort", "toString", "unary_+", "unary_-", "unary_~", "|"
+    )
+    val rows = sut tabulate items
+    assert(rows.size == 4)
+    assert(rows(3).size == 4)   // 7 cols
+    assert(rows(3)(0).dropRight(sut.marginSize) == "unary_+")
+  }
 }


### PR DESCRIPTION
A missing range check in case anyone ever wants to use

```
-Dscala.repl.format=across
```

which was observed only because of competition from Ammonite.
