### PR TITLE
Use LambdaMetafactory where possible for lambda creation.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -266,6 +266,11 @@ TODO:
     -->
     <if><not><isset property="maven-deps-done"></isset></not><then>
       <mkdir dir="${user.home}/.m2/repository"/>
+
+      <artifact:remoteRepository id="sonatype-release" url="https://oss.sonatype.org/content/repositories/releases"/>
+      <artifact:remoteRepository id="sonatype-snapshots" url="https://oss.sonatype.org/content/repositories/snapshots"/>
+      <artifact:remoteRepository id="extra-repo" url="${extra.repo.url}"/>
+
       <!-- This task has an issue where if the user directory does not exist, so we create it above. UGH. -->
       <artifact:dependencies pathId="extra.tasks.classpath" filesetId="extra.tasks.fileset">
         <dependency groupId="biz.aQute" artifactId="bnd" version="1.50.0"/>
@@ -306,6 +311,36 @@ TODO:
 
       <artifact:remoteRepository id="sonatype-release" url="https://oss.sonatype.org/content/repositories/releases"/>
       <artifact:remoteRepository id="extra-repo" url="${extra.repo.url}"/>
+
+      <!-- scala-java8-compat, used by the experimental -target jvm-1.8 support. -->
+      <if><isset property="scala-java8-compat.package"/><then>
+        <property name="scala-java8-compat.version" value="0.2.0"/>
+        <property name="scala-java8-compat.binary.version" value="2.11"/>
+        <artifact:dependencies pathId="scala-java8-compat.classpath" filesetId="scala-java8-compat.fileset">
+          <dependency groupId="org.scala-lang.modules" artifactId="scala-java8-compat_${scala-java8-compat.binary.version}" version="${scala-java8-compat.version}">
+            <exclusion groupId="org.scala-lang" artifactId="scala-library"/>
+          </dependency>
+        </artifact:dependencies>
+        <property name="scala-java8-compat-classes" value="${build-quick.dir}/scala-java8-compat"/>
+        <delete dir="${scala-java8-compat-classes}"/>
+        <unzip dest="${scala-java8-compat-classes}">
+          <fileset refid="scala-java8-compat.fileset"/>
+          <patternset>
+            <include name="**/*.class"/>
+          </patternset>
+        </unzip>
+        <path id="scala-java8-compat.libs">
+          <pathelement location="${scala-java8-compat-classes}"/>
+        </path>
+        <fileset id="scala-java8-compat.fileset" dir="${scala-java8-compat-classes}">
+          <include name="**/*"/>
+        </fileset>
+      </then>
+        <else>
+          <path id="scala-java8-compat.libs"/>
+          <fileset id="scala-java8-compat.fileset" dir="." excludes="**"/>
+        </else>
+      </if>
 
       <!-- prepare, for each of the names below, the property "@{name}.cross", set to the
            necessary cross suffix (usually something like "_2.11.0-M6". -->
@@ -718,6 +753,7 @@ TODO:
       <pathelement location="${build-locker.dir}/classes/library"/>
       <path refid="forkjoin.classpath"/>
       <path refid="aux.libs"/>
+      <path refid="scala-java8-compat.libs"/>
     </path>
 
     <path id="locker.reflect.build.path">
@@ -739,6 +775,7 @@ TODO:
       <pathelement location="${build-quick.dir}/classes/library"/>
       <path refid="forkjoin.classpath"/>
       <path refid="aux.libs"/>
+      <path refid="scala-java8-compat.libs"/>
     </path>
 
     <path id="quick.actors.build.path">
@@ -827,6 +864,7 @@ TODO:
     <path id="pack.library.files">
       <fileset dir="${build-quick.dir}/classes/library"/>
       <fileset dir="${forkjoin-classes}"/>
+      <fileset refid="scala-java8-compat.fileset"/>
     </path>
 
     <path id="pack.actors.files">

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeIdiomatic.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeIdiomatic.scala
@@ -412,6 +412,9 @@ abstract class BCodeIdiomatic extends SubComponent {
       jmethod.instructions.add(node)
       if (settings.YoptInlinerEnabled) callsitePositions(node) = pos
     }
+    final def invokedynamic(owner: String, name: String, desc: String) {
+      jmethod.visitMethodInsn(Opcodes.INVOKEDYNAMIC, owner, name, desc)
+    }
 
     // can-multi-thread
     final def goTo(label: asm.Label) { jmethod.visitJumpInsn(Opcodes.GOTO, label) }

--- a/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
+++ b/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
@@ -79,6 +79,7 @@ abstract class Delambdafy extends Transform with TypingTransformers with ast.Tre
     sealed abstract class TransformedFunction
     // A class definition for the lambda, an expression insantiating the lambda class
     case class DelambdafyAnonClass(lambdaClassDef: ClassDef, newExpr: Tree) extends TransformedFunction
+    case class InvokeDynamicLambda(tree: Apply) extends TransformedFunction
 
     // here's the main entry point of the transform
     override def transform(tree: Tree): Tree = tree match {
@@ -93,6 +94,9 @@ abstract class Delambdafy extends Transform with TypingTransformers with ast.Tre
             lambdaClassDefs(pkg) = lambdaClassDef :: lambdaClassDefs(pkg)
 
             super.transform(newExpr)
+          case InvokeDynamicLambda(apply) =>
+            // ... or an invokedynamic call
+            super.transform(apply)
         }
       case _ => super.transform(tree)
     }
@@ -124,6 +128,7 @@ abstract class Delambdafy extends Transform with TypingTransformers with ast.Tre
       if (!thisReferringMethods.contains(target))
         target setFlag STATIC
 
+      val isStatic = target.hasFlag(STATIC)
 
       /**
        * Creates the apply method for the anonymous subclass of FunctionN
@@ -199,7 +204,7 @@ abstract class Delambdafy extends Transform with TypingTransformers with ast.Tre
       val abstractFunctionErasedType = AbstractFunctionClass(formals.length).tpe
 
       // anonymous subclass of FunctionN with an apply method
-      def makeAnonymousClass = {
+      def makeAnonymousClass: ClassDef = {
         val parents = addSerializable(abstractFunctionErasedType)
         val funOwner = originalFunction.symbol.owner
 
@@ -232,7 +237,7 @@ abstract class Delambdafy extends Transform with TypingTransformers with ast.Tre
         // the Optional proxy that will hold a reference to the 'this'
         // object used by the lambda, if any. NoSymbol if there is no this proxy
         val thisProxy = {
-          if (target.hasFlag(STATIC))
+          if (isStatic)
             NoSymbol
           else {
             val sym = lambdaClass.newVariable(nme.FAKE_LOCAL_THIS, originalFunction.pos, SYNTHETIC)
@@ -271,22 +276,58 @@ abstract class Delambdafy extends Transform with TypingTransformers with ast.Tre
         val body = members ++ List(constr, applyMethodDef) ++ bridgeMethod
 
         // TODO if member fields are private this complains that they're not accessible
-        (localTyper.typedPos(decapturedFunction.pos)(ClassDef(lambdaClass, body)).asInstanceOf[ClassDef], thisProxy)
+        localTyper.typedPos(decapturedFunction.pos)(ClassDef(lambdaClass, body)).asInstanceOf[ClassDef]
       }
 
-      val (anonymousClassDef, thisProxy) = makeAnonymousClass
+      val useLambdaMetafactory = {
+        val hasValueClass = exitingErasure {
+          val methodType: Type = targetMethod(originalFunction).info
+          methodType.exists(_.isInstanceOf[ErasedValueType])
+        }
+        val isTarget18 = settings.target.value.contains("jvm-1.8")
+        settings.isBCodeActive && isTarget18 && !hasValueClass
+      }
 
-      pkg.info.decls enter anonymousClassDef.symbol
+      val thisArg = if (isStatic) Nil else (gen.mkAttributedThis(oldClass) setPos originalFunction.pos) :: Nil
 
-      val thisArg = optionSymbol(thisProxy) map (_ => gen.mkAttributedThis(oldClass) setPos originalFunction.pos)
-      val captureArgs = captures map (capture => Ident(capture) setPos originalFunction.pos)
+      def anonClass: TransformedFunction = {
+        val anonymousClassDef = makeAnonymousClass
+        pkg.info.decls enter anonymousClassDef.symbol
+        val captureArgs = captures map (capture => Ident(capture) setPos originalFunction.pos)
 
-      val newStat =
-          Typed(New(anonymousClassDef.symbol, (thisArg.toList ++ captureArgs): _*), TypeTree(abstractFunctionErasedType))
+        val newStat =
+          Typed(New(anonymousClassDef.symbol, thisArg ++ captureArgs: _*), TypeTree(abstractFunctionErasedType))
 
-      val typedNewStat = localTyper.typedPos(originalFunction.pos)(newStat)
+        val typedNewStat = localTyper.typedPos(originalFunction.pos)(newStat)
 
-      DelambdafyAnonClass(anonymousClassDef, typedNewStat)
+        DelambdafyAnonClass(anonymousClassDef, typedNewStat)
+      }
+
+      if (useLambdaMetafactory) {
+        val arity = originalFunction.vparams.length
+        val functionalInterface: Symbol = {
+          val sym = originalFunction.tpe.typeSymbol
+          val pack = currentRun.runDefinitions.Scala_Java8_CompatPackage
+          val returnUnit = restpe.typeSymbol == UnitClass
+          val functionInterfaceArray =
+            if (returnUnit) currentRun.runDefinitions.Scala_Java8_CompatPackage_JProcedure
+            else currentRun.runDefinitions.Scala_Java8_CompatPackage_JFunction
+          functionInterfaceArray.apply(arity)
+        }
+        if (functionalInterface.exists) {
+          val captureArgs = captures.iterator.map(capture => gen.mkAttributedRef(capture) setPos originalFunction.pos).toList
+          val allCaptureArgs = thisArg ++: captureArgs
+
+          val msym   = currentOwner.newMethod(nme.ANON_FUN_NAME, originalFunction.pos, ARTIFACT)
+          val argTypes: List[Type] = allCaptureArgs.map(_.tpe)
+          val params = msym.newSyntheticValueParams(argTypes)
+          msym.setInfo(MethodType(params, originalFunction.tpe))
+          
+          val tree = localTyper.typedPos(originalFunction.pos)(Apply(Ident(msym), allCaptureArgs)).asInstanceOf[Apply]
+          tree.updateAttachment(LambdaMetaFactoryCapable(targetMethod(originalFunction), arity, functionalInterface))
+          InvokeDynamicLambda(tree)
+        } else anonClass
+      } else anonClass
     }
 
     /**
@@ -436,4 +477,6 @@ abstract class Delambdafy extends Transform with TypingTransformers with ast.Tre
         super.traverse(tree)
     }
   }
+
+  final case class LambdaMetaFactoryCapable(target: Symbol, arity: Int, functionalInterface: Symbol)
 }

--- a/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
+++ b/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
@@ -308,11 +308,16 @@ abstract class Delambdafy extends Transform with TypingTransformers with ast.Tre
         val functionalInterface: Symbol = {
           val sym = originalFunction.tpe.typeSymbol
           val pack = currentRun.runDefinitions.Scala_Java8_CompatPackage
-          val returnUnit = restpe.typeSymbol == UnitClass
-          val functionInterfaceArray =
-            if (returnUnit) currentRun.runDefinitions.Scala_Java8_CompatPackage_JProcedure
-            else currentRun.runDefinitions.Scala_Java8_CompatPackage_JFunction
-          functionInterfaceArray.apply(arity)
+          val name1 = specializeTypes.specializedFunctionName(sym, originalFunction.tpe.typeArgs)
+          if (name1.toTypeName == sym.name) {
+            val returnUnit = restpe.typeSymbol == UnitClass
+            val functionInterfaceArray =
+              if (returnUnit) currentRun.runDefinitions.Scala_Java8_CompatPackage_JProcedure
+              else currentRun.runDefinitions.Scala_Java8_CompatPackage_JFunction
+            functionInterfaceArray.apply(arity)
+          } else {
+            pack.info.decl(name1.toTypeName.prepend("J"))
+          }
         }
         if (functionalInterface.exists) {
           val captureArgs = captures.iterator.map(capture => gen.mkAttributedRef(capture) setPos originalFunction.pos).toList

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -303,6 +303,17 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
     }
   }
 
+  def specializedFunctionName(sym: Symbol, args: List[Type]) = exitingSpecialize {
+    require(isFunctionSymbol(sym), sym)
+    val env: TypeEnv = TypeEnv.fromSpecialization(sym, args)
+    specializedClass.get((sym, env)) match {
+      case Some(x) =>
+        x.name
+      case None =>
+        sym.name
+    }
+  }
+
   /** Return the specialized name of 'sym' in the given environment. It
    *  guarantees the same result regardless of the map order by sorting
    *  type variables alphabetically.
@@ -315,10 +326,14 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
       if (sym.isClass) env.keySet
       else specializedTypeVars(sym).intersect(env.keySet)
     )
+    specializedName(sym.name, tvars, env)
+  }
+
+  private def specializedName(name: Name, tvars: immutable.Set[Symbol], env: TypeEnv): TermName = {
     val (methparams, others) = tvars.toList sortBy ("" + _.name) partition (_.owner.isMethod)
     // debuglog("specName(" + sym + ") env: " + env + " tvars: " + tvars)
 
-    specializedName(sym.name, methparams map env, others map env)
+    specializedName(name, methparams map env, others map env)
   }
 
   /** Specialize name for the two list of types. The first one denotes

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -237,7 +237,7 @@ abstract class UnCurry extends InfoTransform
 
           def canUseDelamdafyMethod = (
                (inConstructorFlag == 0) // Avoiding synthesizing code prone to SI-6666, SI-8363 by using old-style lambda translation
-            && !isSpecialized           // DelambdafyTransformer currently only emits generic FunctionN-s, use the old style in the meantime
+            && (!isSpecialized || (settings.target.value == "jvm-1.8")) // DelambdafyTransformer currently only emits generic FunctionN-s, use the old style in the meantime
           )
           if (inlineFunctionExpansion || !canUseDelamdafyMethod) {
             val parents = addSerializable(abstractFunctionForFunctionType(fun.tpe))

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1513,6 +1513,10 @@ trait Definitions extends api.StandardDefinitions {
 
       def isPolymorphicSignature(sym: Symbol) = PolySigMethods(sym)
       private lazy val PolySigMethods: Set[Symbol] = Set[Symbol](MethodHandle.info.decl(sn.Invoke), MethodHandle.info.decl(sn.InvokeExact)).filter(_.exists)
+
+      lazy val Scala_Java8_CompatPackage = rootMirror.getPackageIfDefined("scala.compat.java8")
+      lazy val Scala_Java8_CompatPackage_JFunction = (0 to MaxTupleArity).toArray map (i => getMemberIfDefined(Scala_Java8_CompatPackage.moduleClass, TypeName("JFunction" + i)))
+      lazy val Scala_Java8_CompatPackage_JProcedure = (0 to MaxTupleArity).toArray map (i => getMemberIfDefined(Scala_Java8_CompatPackage.moduleClass, TypeName("JProcedure" + i)))
     }
   }
 }

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -794,7 +794,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
 
     final def isAnonymousFunction = isSynthetic && (name containsName tpnme.ANON_FUN_NAME)
     final def isDelambdafyFunction = isSynthetic && (name containsName tpnme.DELAMBDAFY_LAMBDA_CLASS_NAME)
-    final def isDelambdafyTarget  = isSynthetic && isMethod && (name containsName tpnme.ANON_FUN_NAME)
+    final def isDelambdafyTarget  = isArtifact && isMethod && (name containsName tpnme.ANON_FUN_NAME)
     final def isDefinedInPackage  = effectiveOwner.isPackageClass
     final def needsFlatClasses    = phase.flatClasses && rawowner != NoSymbol && !rawowner.isPackageClass
 

--- a/test/files/run/t2318.scala
+++ b/test/files/run/t2318.scala
@@ -11,6 +11,7 @@ object Test {
       case _: java.io.FilePermission                                                        => ()
       case x: java.security.SecurityPermission if x.getName contains ".networkaddress."     => () // generality ftw
       case x: java.util.PropertyPermission if x.getName == "sun.net.inetaddr.ttl"           => ()
+      case _: java.lang.reflect.ReflectPermission                                           => () // needed for LambdaMetaFactory
       case _                                                                                => super.checkPermission(perm)
     }
   }


### PR DESCRIPTION
My design notes: https://gist.github.com/retronym/0178c212e4bacffed568

This is all locked behind:

```
-Ydelambdafy:method -Ybackend:GenBCode -target:jvm-1.8
```

We require scala-java8-compat to be present on the compilation and runtime classpath. This provides a set of functional interfaces.

These are automatically downloaded and added to `scala-library.jar` if the property `scala-java8-compat.package` is set during the Ant build. This option is only intended to facilitate testing, we don't plan to ship those classes in any Scala release.

We can bootstrap with this enabled:

```
% cat build.properties
starr.use.released=1
% ant all.clean
% ant -Dscala-java8-compat.package="" locker.done
% ant -Dscalac.args=\"-Ydelambdafy:method -target:jvm-1.8\" -Dscala-java8-compat.package="" clean build-opt
% ./build/quick/bin/scala -target:jvm-1.8 -Ydelambdafy:method -Ybackend:GenBCode -e 'println((() => "").getClass)'
class Main$$anon$1$$Lambda$1/495053715
```
## Limitations
- Under this mode, lambdas are not serializable. This will be remedied in a followup PR.
- The inliner needs to be updated with an understanding of `LambdaMetafactory`'s
  semantics in order to be able to perform closure elimination.
- We are not able to mixin an the implementation of `toString` in to functions. So rather than printing as `<function>`, we instead get a rather ugly toString of: `$$Lambda$1/914374969@10289886`. We would require an extension point in `LambdaMetafactory`, or ship our own `ScalaLambdaMetafactory` to do better here.

We cannot yet run the full test suite under this mode, but we are getting close.

```
SCALAC_OPTS="-target:jvm-1.8 -Ydelambdafy:method -Ybackend:GenBCode" ./test/partest --run --pos --neg --terse
Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=128M; support was removed in 8.0
Selected 3889 tests drawn from 3 named test categories

........................................................................
........................................................................
........................................................................
........................................................................
........................................................................
........................................................................
........................................................................
........................................................................
........................................................................
........................................................................
........................................................................
........................................................................
........................................................................
........................................................................
........................................................................
........................................................................
........................................................................
........................................................................
.....................

........................................................................
........................................................................
........................................................................
........................................................................
.........................................................
!!   1 - neg/t3234.scala                           [expected compilation failure]
........................................................................
........................................................................
........................................................................
........................................................................
........................................................................
........................................................................
........................................................................
.....................................

........................................................................
..................
!!    1 - run/delambdafy-specialized.scala          [output differs]
.
!!    2 - run/delambdafyLambdaClassNames            [non-zero exit code]
........................................................................
..............................
!!    3 - run/lambda-test.scala                     [output differs]     
// this was a canary that I added, expecting a failure if we used LambdaMetafactory
// It prints `(() = "").getClass`.
// 
// % diff /Users/jason/code/scala2/test/files/run/lambda-test-run.log /Users/jason/code/scala2/test/files/run/lambda-test.check--- empty
// +++ lambda-test-run.log
// @@ -1,0 +1,1 @@
// +class Test$$$Lambda$1/402115881

........................................................................
........................................................................
..........................................................
!!    4 - run/private-inline.scala                  [output differs]
........................................................................
........................................................................
...........................................
!!    5 - run/repl-javap-app.scala                  [output differs]
........................................................................
......
!!    6 - run/synchronized.scala                    [output differs]
........................................................................
..
!!    7 - run/t2106.scala                           [output differs]
.....................................................................
!!    8 - run/t3158.scala                           [output differs]
........................................................................
........................................................................
.........................................................
!!    9 - run/t5018.scala                           [non-zero exit code]
........................................................................
........................................................................
.........................................
!!   10 - run/t6102.scala                           [output differs]
........................................................................
........................................................................
........................................................................
.................................
!!   11 - run/t7582                                 [output differs]
..
!!   12 - run/t7582b                                [output differs]
!!   13 - run/t7584b.scala                          [non-zero exit code]
........................................................................
..............
!!   14 - run/t8601-closure-elim.scala              [non-zero exit code]
................................
!!   15 - run/t8960.scala                           [non-zero exit code]
........................................................................
......................................
```

Review by @adriaanm @lrytz
