### PR TITLE
SI-9279 Improve performance of bash runner script

### DIFF
--- a/src/compiler/scala/tools/ant/templates/tool-unix.tmpl
+++ b/src/compiler/scala/tools/ant/templates/tool-unix.tmpl
@@ -137,8 +137,8 @@ while [[ $# -gt 0 ]]; do
     -D*)
       # pass to scala as well: otherwise we lose it sometimes when we
       # need it, e.g. communicating with a server compiler.
-      java_args=("${java_args[@@]}" "$1")
-      scala_args=("${scala_args[@@]}" "$1")
+      java_args+=("$1")
+      scala_args+=("$1")
       # respect user-supplied -Dscala.usejavacp
       case "$1" in -Dscala.usejavacp*) OVERRIDE_USEJAVACP="";; esac
       shift
@@ -146,8 +146,8 @@ while [[ $# -gt 0 ]]; do
     -J*)
       # as with -D, pass to scala even though it will almost
       # never be used.
-      java_args=("${java_args[@@]}" "${1:2}")
-      scala_args=("${scala_args[@@]}" "$1")
+      java_args+=("${1:2}")
+      scala_args+=("$1")
       shift
       ;;
     -toolcp)
@@ -167,7 +167,7 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     *)
-      scala_args=("${scala_args[@@]}" "$1")
+      scala_args+=("$1")
       shift
       ;;
   esac


### PR DESCRIPTION
In fbe897d, the template for bash scripts (scala/scalac/etc) was
modified to fix processing of `-J`, `-bootcp`.

This involved looping through the argument array and filtering out
options like `-bootcp` that only influence the script, and shouldn't
be passed to the JVM.

However, the mechanism to do this uses an inefficient, erm,
"CanBuildFrom", and under the load of even a few hundred source
files takes half a second before the JVM starts. Throw 2000 files
at it, and you have to wait ten seconds!

This commit uses a more efficient array append operator. This requires
Bash 3 or above. Hopefully it is safe to presume this version these
days, it's been around for a decade.

Results:

```
% time ~/scala/2.11.6/bin/scalac -J-NOJVM abcdedfghijklmnopqrtsuvwxyv{1..2000} 2>&1
Unrecognized option: -NOJVM
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.

real    0m7.765s
user    0m7.734s
sys 0m0.028s

% time ./build/quick/bin/scalac -J-NOJVM abcdedfghijklmnopqrtsuvwxyv{1..2000} 2>&1
Unrecognized option: -NOJVM
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.

real    0m0.144s
user    0m0.124s
sys 0m0.022s

```

Thanks to Stephan Schmidt for pointing out the performance gulf.
