### PR TITLE
Fix scaladoc of Try#failed

### DIFF
--- a/src/library/scala/util/Try.scala
+++ b/src/library/scala/util/Try.scala
@@ -164,8 +164,8 @@ sealed abstract class Try[+T] {
   def flatten[U](implicit ev: T <:< Try[U]): Try[U]
 
   /**
-   * Completes this `Try` with an exception wrapped in a `Success`. The exception is either the exception that the
-   * `Try` failed with (if a `Failure`) or an `UnsupportedOperationException`.
+   * Inverts this `Try`. If this is a `Failure`, returns its exception wrapped in a `Success`.
+   * If this is a `Success`, returns a `Failure` containing an `UnsupportedOperationException`.
    */
   def failed: Try[Throwable]
 


### PR DESCRIPTION
The documentation stated that it returns a Success[Throwable] regardless, either containing the failure or an UnsupportedOperationException. However only Failure#failed returns a success; Success#failed returns a Failure.

Also the phrasing of "Completes this `Try`" and "that `Try` failed with" sounds like it was copy-pasted from Future? Trys don't complete, nor fail, they are immutable.
