### PR TITLE
spec: Remove obsolete rules related to scala.NotNull

### DIFF
--- a/spec/03-types.md
+++ b/spec/03-types.md
@@ -835,8 +835,7 @@ transitive relation that satisfies the following conditions.
 - For every type constructor $T$ (with any number of type parameters),
   `scala.Nothing <: $T$ <: scala.Any`.
 
-- For every class type $T$ such that `$T$ <: scala.AnyRef` and not
-  `$T$ <: scala.NotNull` one has `scala.Null <: $T$`.
+- For every class type $T$ such that `$T$ <: scala.AnyRef` one has `scala.Null <: $T$`.
 - A type variable or abstract type $t$ conforms to its upper bound and
   its lower bound conforms to $t$.
 - A class type or parameterized type conforms to any of its base-types.

--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -148,10 +148,6 @@ The selection $e.x$ is evaluated by first evaluating the qualifier
 expression $e$, which yields an object $r$, say. The selection's
 result is then the member of $r$ that is either defined by $m$ or defined
 by a definition overriding $m$.
-If that member has a type which
-conforms to `scala.NotNull`, the member's value must be initialized
-to a value different from `null`, otherwise a `scala.UnitializedError`
-is thrown.
 
 ## This and Super
 


### PR DESCRIPTION
These rules were removed in #2244 and scala.NotNull itself was
deprecated.
