### PR TITLE
SI-9285 Don't warn about non-sensible equals in synthetic methods

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1122,7 +1122,7 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
     }
     /** Sensibility check examines flavors of equals. */
     def checkSensible(pos: Position, fn: Tree, args: List[Tree]) = fn match {
-      case Select(qual, name @ (nme.EQ | nme.NE | nme.eq | nme.ne)) if args.length == 1 && isObjectOrAnyComparisonMethod(fn.symbol) =>
+      case Select(qual, name @ (nme.EQ | nme.NE | nme.eq | nme.ne)) if args.length == 1 && isObjectOrAnyComparisonMethod(fn.symbol) && !currentOwner.isSynthetic =>
         checkSensibleEquals(pos, qual, name, fn.symbol, args.head)
       case _ =>
     }

--- a/test/files/pos/t9285.flags
+++ b/test/files/pos/t9285.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t9285.scala
+++ b/test/files/pos/t9285.scala
@@ -1,0 +1,1 @@
+case class C(placeholder: Unit)


### PR DESCRIPTION
Notably, in the synthetic equals method of a case class. Otherwise,
we get an unsuppressable warning when defining a case class with a
`Unit`-typed parameter, which some folks use a placeholder for
real type while evolving a design.
