### PR TITLE
Update versions.properites

### DIFF
--- a/test/files/scalacheck/redblacktree.scala
+++ b/test/files/scalacheck/redblacktree.scala
@@ -33,7 +33,7 @@ package scala.collection.immutable.redblacktree {
 
     def mkTree(level: Int, parentIsBlack: Boolean = false, label: String = ""): Gen[Tree[String, Int]] =
       if (level == 0) {
-        value(null)
+        const(null)
       } else {
         for {
           oddOrEven <- choose(0, 2)

--- a/versions.properties
+++ b/versions.properties
@@ -13,21 +13,24 @@ starr.version=2.11.6
 # These are the versions of the modules that go with this release.
 # These properties are used during PR validation and in dbuild builds.
 
-# The scala.binary.version determines how modules are resolved. After 2.x.0 is released,
-# the binary version is 2.x. For milestones and RCs, modules are cross-built against the
-# full version, so the value, so the value is the full version (e.g. 2.12.0-M1).
+# The scala.binary.version determines how modules are resolved. For example, it
+# determines which partest artifact is being used for running the tests.
+# It has to be set in the following way:
+#  - After 2.x.0 is released, the binary version is 2.x.
+#  - During milestones and RCs, modules are cross-built against the full version.
+#    So the value is the full version (e.g. 2.12.0-M1).
 scala.binary.version=2.11
 
 # external modules shipped with distribution, as specified by scala-library-all's pom
-scala-xml.version.number=1.0.3
-scala-parser-combinators.version.number=1.0.3
-scala-swing.version.number=1.0.1
-akka-actor.version.number=2.3.4
+scala-xml.version.number=1.0.4
+scala-parser-combinators.version.number=1.0.4
+scala-swing.version.number=1.0.2
+akka-actor.version.number=2.3.10
 jline.version=2.12.1
 
 # external modules, used internally (not shipped)
-partest.version.number=1.0.6
-scalacheck.version.number=1.11.4
+partest.version.number=1.0.7
+scalacheck.version.number=1.12.2
 
 # TODO: modularize the compiler
 #scala-compiler-doc.version.number=1.0.0-RC1


### PR DESCRIPTION
The tagged revisions of the modules integrate the latest release of
the sbt-scala-modules sbt plugin. This enables building with a new
scala binary version (e.g. 2.12.0-M1) without failinig MiMa.

Also updates the other external dependencies.
