### PR TITLE
SI-9286 Check subclass privates for "same type after erasure"

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -814,11 +814,10 @@ abstract class Erasure extends AddInterfaces
         // specialized members have no type history before 'specialize', causing double def errors for curried defs
         override def exclude(sym: Symbol): Boolean = (
              sym.isType
-          || sym.isPrivate
           || super.exclude(sym)
           || !sym.hasTypeAt(currentRun.refchecksPhase.id)
         )
-        override def matches(lo: Symbol, high: Symbol) = true
+        override def matches(lo: Symbol, high: Symbol) = !high.isPrivate
       }
       def isErasureDoubleDef(pair: SymbolPair) = {
         import pair._

--- a/test/files/neg/t9286a.check
+++ b/test/files/neg/t9286a.check
@@ -1,0 +1,7 @@
+t9286a.scala:6: error: name clash between defined and inherited member:
+def foo(o: (String,)): Unit in class T and
+private def foo(o: (Any,)): Unit at line 6
+have same type after erasure: (o: Tuple1)Unit
+   private def foo(o: Tuple1[Any]) = ()
+               ^
+one error found

--- a/test/files/neg/t9286a.scala
+++ b/test/files/neg/t9286a.scala
@@ -1,0 +1,13 @@
+class T {
+  def foo(o: Tuple1[String]) = ()
+}
+
+class U extends T {
+   private def foo(o: Tuple1[Any]) = ()
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    new U().foo(null) // IllegalAccessError:  tried to access method U.foo(Lscala/Tuple1;)V from class Test$
+  }
+}

--- a/test/files/neg/t9286b.check
+++ b/test/files/neg/t9286b.check
@@ -1,0 +1,7 @@
+t9286b.scala:2: error: name clash between defined and inherited member:
+def foo: Int in class C and
+private def foo[A]: Int at line 2
+have same type after erasure: ()Int
+class D extends C { private def foo[A] = 0 }
+                                ^
+one error found

--- a/test/files/neg/t9286b.scala
+++ b/test/files/neg/t9286b.scala
@@ -1,0 +1,5 @@
+class C { def foo = 0 }
+class D extends C { private def foo[A] = 0 }
+
+class E { private def foo = 0 }
+class F extends E { def foo[A] = 0 } // okay

--- a/test/files/neg/t9286c.check
+++ b/test/files/neg/t9286c.check
@@ -1,0 +1,7 @@
+t9286c.scala:8: error: name clash between defined and inherited member:
+def foo(m: M[_ >: String]): Int in trait T and
+private def foo(m: M[_ >: Any]): Int at line 8
+have same type after erasure: (m: M)Int
+    def foo(m: M[_ >: Any]) = 0 // Expected: "same type after erasure"
+        ^
+one error found

--- a/test/files/neg/t9286c.scala
+++ b/test/files/neg/t9286c.scala
@@ -1,0 +1,14 @@
+class M[_]
+trait T {
+  def foo(m: M[_ >: String]) = 42
+}
+
+object Test {
+  def t: T = new T {
+    def foo(m: M[_ >: Any]) = 0 // Expected: "same type after erasure"
+  }
+  def main(args: Array[String]): Unit = {
+    val m: M[String] = null
+    t.foo(m) // VeriyError: Duplicate method name&signature
+  }
+}


### PR DESCRIPTION
The overriding pairs cursor used to detect erased signature clashes
was turning a blind eye to any pair that contained a private method.

However, this could lead to a `VerifyError` or `IllegalAccessError`.

Checking against javac's behaviour in both directions:

```
% cat sandbox/Test.java
public abstract class Test {
  class C { int foo() { return 0; } }
  class D extends C { private <A> int foo() { return 1; } }
}

% javac sandbox/Test.java
sandbox/Test.java:3: error: name clash: <A>foo() in Test.D and foo() in Test.C have the same erasure, yet neither overrides the other
  class D extends C { private <A> int foo() { return 1; } }
                                      ^
  where A is a type-variable:
    A extends Object declared in method <A>foo()
1 error
```

```
% cat sandbox/Test.java
public abstract class Test {
  class C { private int foo() { return 0; } }
  class D extends C { <A> int foo() { return 1; } }
}

% javac sandbox/Test.java
%
```

This commit only the exludes private symbols from the superclass
from the checks by moving the test from `excludes` to `matches`.

Review by @adriaanm 
