### PR TITLE
Follow HTTP redirects when downloading bootstrap binaries

### DIFF
--- a/tools/binary-repo-lib.sh
+++ b/tools/binary-repo-lib.sh
@@ -56,7 +56,7 @@ curlDownload() {
   if [[ "$OSTYPE" == *Cygwin* || "$OSTYPE" == *cygwin* ]]; then
     jar=$(cygpath -m $1)
   fi
-  http_code=$(curl --write-out '%{http_code}' --silent --fail --output "$jar" "$url")
+  http_code=$(curl --write-out '%{http_code}' --silent --fail -L --output "$jar" "$url")
   if (( $? != 0 )); then
     echo "Error downloading $jar: response code: $http_code"
     echo "$url"


### PR DESCRIPTION
After a recent change to the repository that hosts these JARs,
we now get a HTTP redirect to the new destination. We need to
explicitly instruct curl to follow this.
