### PR TITLE
SI-9298 Fix erasure of value classes in Java

### DIFF
--- a/src/reflect/scala/reflect/internal/transform/Erasure.scala
+++ b/src/reflect/scala/reflect/internal/transform/Erasure.scala
@@ -254,6 +254,8 @@ trait Erasure {
     def mergeParents(parents: List[Type]): Type =
       if (parents.isEmpty) ObjectTpe
       else parents.head
+
+    override protected def eraseDerivedValueClassRef(tref: TypeRef): Type = eraseNormalClassRef(tref)
   }
 
   object scalaErasure extends ScalaErasureMap

--- a/test/files/run/t9298/Test.java
+++ b/test/files/run/t9298/Test.java
@@ -1,0 +1,7 @@
+public class Test {
+	public void consume(VC vc) {}
+
+	public static void main(String[] args) {
+		new Client().test();
+	}
+}

--- a/test/files/run/t9298/VC.scala
+++ b/test/files/run/t9298/VC.scala
@@ -1,0 +1,5 @@
+class VC(val s: String) extends AnyVal
+
+class Client {
+  def test = new Test().consume(new VC(""))
+}

--- a/test/files/run/t9298b/Test.java
+++ b/test/files/run/t9298b/Test.java
@@ -1,0 +1,7 @@
+public class Test {
+	public VC identity(VC vc) { return vc; }
+
+	public static void main(String[] args) {
+		new Client().test();
+	}
+}

--- a/test/files/run/t9298b/VC.scala
+++ b/test/files/run/t9298b/VC.scala
@@ -1,0 +1,8 @@
+class VC(val s: Int) extends AnyVal
+
+class Client {
+  def test = {
+    val vc: VC = new Test().identity(new VC(42))
+    assert(vc.s == 42)
+  }
+}


### PR DESCRIPTION
Value classes that appear in signatures of Java defined methods
should not be erased to the underlying type.

Before this change, we'd get a `ClassCastException`, as the Scala
call site would unbox the value class despite the fact the Java
recipient would expect the boxed representation.

I've tested this for primitive and object wrapped types in parameter
and return position.

Review by @smarter @lrytz 
