### PR TITLE
SI-9302 -Xdisable-assertions raises elide level

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -101,7 +101,8 @@ trait ScalaSettings extends AbsScalaSettings
   val Xhelp              = BooleanSetting      ("-X", "Print a synopsis of advanced options.")
   val checkInit          = BooleanSetting      ("-Xcheckinit", "Wrap field accessors to throw an exception on uninitialized access.")
   val developer          = BooleanSetting      ("-Xdev", "Indicates user is a developer - issue warnings about anything which seems amiss")
-  val noassertions       = BooleanSetting      ("-Xdisable-assertions", "Generate no assertions or assumptions.")
+  val noassertions       = BooleanSetting      ("-Xdisable-assertions", "Generate no assertions or assumptions.") andThen (flag =>
+                                                if (flag) elidebelow.value = elidable.ASSERTION + 1)
   val elidebelow         = IntSetting          ("-Xelide-below", "Calls to @elidable methods are omitted if method priority is lower than argument",
                                                 elidable.MINIMUM, None, elidable.byName get _)
   val noForwarders       = BooleanSetting      ("-Xno-forwarders", "Do not generate static forwarders in mirror classes.")

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -437,9 +437,7 @@ abstract class UnCurry extends InfoTransform
       def isLiftedLambdaBody(target: Tree) = target.symbol.isLocalToBlock && target.symbol.isArtifact && target.symbol.name.containsName(nme.ANON_FUN_NAME)
 
       val result = (
-        // TODO - settings.noassertions.value temporarily retained to avoid
-        // breakage until a reasonable interface is settled upon.
-        if ((sym ne null) && (sym.elisionLevel.exists (_ < settings.elidebelow.value || settings.noassertions)))
+        if ((sym ne null) && sym.elisionLevel.exists(_ < settings.elidebelow.value))
           replaceElidableTree(tree)
         else translateSynchronized(tree) match {
           case dd @ DefDef(mods, name, tparams, _, tpt, rhs) =>

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -35,9 +35,9 @@ import scala.io.StdIn
  *  === Assertions ===
  *
  *  A set of `assert` functions are provided for use as a way to document
- *  and dynamically check invariants in code. `assert` statements can be elided
- *  at compile time by providing the command line argument `-Xdisable-assertions` to
- *  the `scalac` command.
+ *  and dynamically check invariants in code. Invocations of `assert` can be elided
+ *  at compile time by providing the command line option `-Xdisable-assertions`,
+ *  which raises `-Xelide-below` above `elidable.ASSERTION`, to the `scalac` command.
  *
  *  Variants of `assert` intended for use with static analysis tools are also
  *  provided: `assume`, `require` and `ensuring`. `require` and `ensuring` are

--- a/test/files/run/disable-assertions.flags
+++ b/test/files/run/disable-assertions.flags
@@ -1,0 +1,1 @@
+-Xdisable-assertions

--- a/test/files/run/disable-assertions.scala
+++ b/test/files/run/disable-assertions.scala
@@ -1,0 +1,14 @@
+
+object Elided {
+  import annotation._, elidable._
+  @elidable(INFO) def info(): Boolean = true
+  @elidable(10000) def f(): Boolean = true
+  def g(): Boolean = { assert(false); true }
+}
+
+object Test extends App {
+  import Elided._
+  if (info()) println("Bad info.")
+  if (!f()) println("Elided f.")
+  if (!g()) println("Elided g?")   // assert should be off
+}


### PR DESCRIPTION
Previously, the flag caused any elidable to be elided.

This commit simply sets -Xelide-below to ASSERTION + 1.

The flag is useful because there's no mnemonic for specifying
the magic constant as an option argument. `-Xelide-below ASSERTION`
means asserts are enabled.

Follow-up to #4470 
