### PR TITLE
SI-7747 Added .INSTANCE accessor to classBasedWrappers in REPL.

### DIFF
--- a/test/files/run/t7747-repl.check
+++ b/test/files/run/t7747-repl.check
@@ -112,7 +112,7 @@ scala> 55 ; ((2 + 2)) ; (1, 2, 3)
 res15: (Int, Int, Int) = (1,2,3)
 
 scala> 55 ; (x: Int) => x + 1 ; () => ((5))
-<console>:8: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:9: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
               55 ; (x: Int) => x + 1 ;;
               ^
 res16: () => Int = <function0>
@@ -258,12 +258,12 @@ class $read extends Serializable {
       super.<init>;
       ()
     };
-    import $line44.$read.$iw.$iw.BippyBups;
-    import $line44.$read.$iw.$iw.BippyBups;
-    import $line45.$read.$iw.$iw.PuppyPups;
-    import $line45.$read.$iw.$iw.PuppyPups;
-    import $line46.$read.$iw.$iw.Bingo;
-    import $line46.$read.$iw.$iw.Bingo;
+    import $line44.$read.INSTANCE.$iw.$iw.BippyBups;
+    import $line44.$read.INSTANCE.$iw.$iw.BippyBups;
+    import $line45.$read.INSTANCE.$iw.$iw.PuppyPups;
+    import $line45.$read.INSTANCE.$iw.$iw.PuppyPups;
+    import $line46.$read.INSTANCE.$iw.$iw.Bingo;
+    import $line46.$read.INSTANCE.$iw.$iw.Bingo;
     class $iw extends Serializable {
       def <init>() = {
         super.<init>;
@@ -275,12 +275,23 @@ class $read extends Serializable {
   };
   val $iw = new $iw.<init>
 }
-object $read extends $read {
+object $read extends scala.AnyRef {
   def <init>() = {
     super.<init>;
     ()
-  }
+  };
+  val INSTANCE = new $read.<init>
 }
 res3: List[Product with Serializable] = List(BippyBups(), PuppyPups(), Bingo())
+
+scala> :power
+** Power User mode enabled - BEEP WHIR GYVE **
+** :phase has been set to 'typer'.          **
+** scala.tools.nsc._ has been imported      **
+** global._, definitions._ also imported    **
+** Try  :help, :vals, power.<tab>           **
+
+scala> intp.lastRequest
+res4: $r.intp.Request = Request(line=def $ires3 = intp.global, 1 trees)
 
 scala> :quit

--- a/test/files/run/t7747-repl.scala
+++ b/test/files/run/t7747-repl.scala
@@ -65,5 +65,7 @@ object Test extends ReplTest {
     |case class PuppyPups()
     |case class Bingo()
     |List(BippyBups(), PuppyPups(), Bingo()) // show
+    |:power
+    |intp.lastRequest
     |""".stripMargin
 }


### PR DESCRIPTION
This patch will free us from maintenance burden of our own port of scala repl. 

I may not have done good job in explaining things well. Specific questions can help me do better. Hopefully code comments are enough to explain the patch. I have tried with this patch - there will be no need to port the repl code in our repository(Apache Spark) again. 

I wish - it could go in for 2.11.7 :) 

review: @gkossakowski and @som-snytt
