### PR TITLE
Subst repo.typesafe -> dl.bintray, use jcenter cache

### DIFF
--- a/scripts/jobs/integrate/bootstrap
+++ b/scripts/jobs/integrate/bootstrap
@@ -114,6 +114,7 @@ mkdir -p $baseDir/resolutionScratch_
 # repo used to publish "locker" scala to (to start the bootstrap)
 releaseTempRepoCred="private-repo"
 releaseTempRepoUrl=${releaseTempRepoUrl-"https://scala-ci.typesafe.com/artifactory/scala-release-temp/"}
+jcenterCacheUrl=${jcenterCacheUrl-"https://scala-ci.typesafe.com/artifactory/jcenter/"}
 
 # Used below in sbtArgs since we use a dedicated repository to share artifcacts between jobs,
 # so we need to configure SBT to use these rather than its default, Maven Central.
@@ -121,10 +122,10 @@ releaseTempRepoUrl=${releaseTempRepoUrl-"https://scala-ci.typesafe.com/artifacto
 sbtRepositoryConfig="$scriptsDir/repositories-scala-release"
 cat > "$sbtRepositoryConfig" << EOF
 [repositories]
-  plugins: http://dl.bintray.com/sbt/sbt-plugin-releases/, [organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
   private-repo: $releaseTempRepoUrl
-  typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
-  sbt-plugin-releases: http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
+  jcenter-cache: $jcenterCacheUrl
+  typesafe-ivy-releases: https://dl.bintray.com/typesafe/ivy-releases/, [organisation]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
+  sbt-plugin-releases: https://dl.bintray.com/sbt/sbt-plugin-releases/, [organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
   maven-central
   local
 EOF

--- a/tools/binary-repo-lib.sh
+++ b/tools/binary-repo-lib.sh
@@ -2,8 +2,8 @@
 #
 # Library to push and pull binary artifacts from a remote repository using CURL.
 
-remote_urlget="http://repo.typesafe.com/typesafe/scala-sha-bootstrap/org/scala-lang/bootstrap"
-remote_urlpush="http://dl.bintray.com/typesafe/scala-sha-bootstrap/org/scala-lang/bootstrap"
+remote_urlget="https://dl.bintray.com/typesafe/scala-sha-bootstrap/org/scala-lang/bootstrap"
+remote_urlpush="https://dl.bintray.com/typesafe/scala-sha-bootstrap/org/scala-lang/bootstrap"
 libraryJar="$(pwd)/lib/scala-library.jar"
 desired_ext=".desired.sha1"
 push_jar="$(pwd)/tools/push.jar"


### PR DESCRIPTION
Switch to https while we're at it,
and remove duplicate entry for sbt-plugin-releases
(NOTE: 'organization' <-> 'organisation',
 see http://ant.apache.org/ivy/history/latest-milestone/concept.html#patterns)

review by @lrytz 
