### PR TITLE
[indylambda] Support lambda {de}serialization

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -685,24 +685,50 @@ abstract class BCodeHelpers extends BCodeIdiomatic with BytecodeWriters {
 
     /**
      * Add:
-     *
+     * private static java.util.Map $deserializeLambdaCache$ = null
      * private static Object $deserializeLambda$(SerializedLambda l) {
-     *   return scala.compat.java8.runtime.LambdaDeserializer.deserializeLambda(MethodHandles.lookup(), null, l);
+     *   var cache = $deserializeLambdaCache$
+     *   if (cache eq null) {
+     *     cache = new java.util.HashMap()
+     *     $deserializeLambdaCache$ = cache
+     *   }
+     *   return scala.compat.java8.runtime.LambdaDeserializer.deserializeLambda(MethodHandles.lookup(), cache, l);
      * }
-     * @param jclass
      */
-    // TODO add a static cache field to the class, and pass that as the second argument to `deserializeLambda`.
-    // This will make the test at run/lambda-serialization.scala:15 work
-    def addLambdaDeserialize(jclass: asm.ClassVisitor): Unit = {
+    def addLambdaDeserialize(clazz: Symbol, jclass: asm.ClassVisitor): Unit = {
       val cw = jclass
       import scala.tools.asm.Opcodes._
+
+      // Need to force creation of BTypes for these as `getCommonSuperClass` is called on
+      // automatically computing the max stack size (`visitMaxs`) during method writing.
+      javaUtilHashMapReference
+      javaUtilMapReference
+
       cw.visitInnerClass("java/lang/invoke/MethodHandles$Lookup", "java/lang/invoke/MethodHandles", "Lookup", ACC_PUBLIC + ACC_FINAL + ACC_STATIC)
+
+      {
+        val fv = cw.visitField(ACC_PRIVATE + ACC_STATIC + ACC_SYNTHETIC, "$deserializeLambdaCache$", "Ljava/util/Map;", null, null)
+        fv.visitEnd()
+      }
 
       {
         val mv = cw.visitMethod(ACC_PRIVATE + ACC_STATIC + ACC_SYNTHETIC, "$deserializeLambda$", "(Ljava/lang/invoke/SerializedLambda;)Ljava/lang/Object;", null, null)
         mv.visitCode()
+        mv.visitFieldInsn(GETSTATIC, clazz.javaBinaryName.encoded, "$deserializeLambdaCache$", "Ljava/util/Map;")
+        mv.visitVarInsn(ASTORE, 1)
+        mv.visitVarInsn(ALOAD, 1)
+        val l0 = new asm.Label()
+        mv.visitJumpInsn(IFNONNULL, l0)
+        mv.visitTypeInsn(NEW, "java/util/HashMap")
+        mv.visitInsn(DUP)
+        mv.visitMethodInsn(INVOKESPECIAL, "java/util/HashMap", "<init>", "()V", false)
+        mv.visitVarInsn(ASTORE, 1)
+        mv.visitVarInsn(ALOAD, 1)
+        mv.visitFieldInsn(PUTSTATIC, clazz.javaBinaryName.encoded, "$deserializeLambdaCache$", "Ljava/util/Map;")
+        mv.visitLabel(l0)
+        mv.visitFrame(asm.Opcodes.F_APPEND,1, Array("java/util/Map"), 0, null)
         mv.visitMethodInsn(INVOKESTATIC, "java/lang/invoke/MethodHandles", "lookup", "()Ljava/lang/invoke/MethodHandles$Lookup;", false)
-        mv.visitInsn(asm.Opcodes.ACONST_NULL)
+        mv.visitVarInsn(ALOAD, 1)
         mv.visitVarInsn(ALOAD, 0)
         mv.visitMethodInsn(INVOKESTATIC, "scala/compat/java8/runtime/LambdaDeserializer", "deserializeLambda", "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/util/Map;Ljava/lang/invoke/SerializedLambda;)Ljava/lang/Object;", false)
         mv.visitInsn(ARETURN)

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -131,7 +131,7 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
           && indyLambdaHosts.contains(claszSymbol))
 
       if (shouldAddLambdaDeserialize)
-        addLambdaDeserialize(cnode)
+        addLambdaDeserialize(claszSymbol, cnode)
 
       addInnerClassesASM(cnode, innerClassBufferASM.toList)
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -68,6 +68,8 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
     var isCZStaticModule           = false
     var isCZRemote                 = false
 
+    protected val indyLambdaHosts = collection.mutable.Set[Symbol]()
+
     /* ---------------- idiomatic way to ask questions to typer ---------------- */
 
     def paramTKs(app: Apply): List[BType] = {
@@ -121,6 +123,16 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
 
       innerClassBufferASM ++= classBType.info.get.nestedClasses
       gen(cd.impl)
+
+
+      val shouldAddLambdaDeserialize = (
+        settings.target.value == "jvm-1.8"
+          && settings.Ydelambdafy.value == "method"
+          && indyLambdaHosts.contains(claszSymbol))
+
+      if (shouldAddLambdaDeserialize)
+        addLambdaDeserialize(cnode)
+
       addInnerClassesASM(cnode, innerClassBufferASM.toList)
 
       cnode.visitAttribute(classBType.inlineInfoAttribute.get)

--- a/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
@@ -114,6 +114,8 @@ class CoreBTypes[BTFS <: BTypesFromSymbols[_ <: Global]](val bTypes: BTFS) {
   lazy val jioSerializableReference    : ClassBType = classBTypeFromSymbol(JavaSerializableClass)     // java/io/Serializable
   lazy val scalaSerializableReference  : ClassBType = classBTypeFromSymbol(SerializableClass)         // scala/Serializable
   lazy val classCastExceptionReference : ClassBType = classBTypeFromSymbol(ClassCastExceptionClass)   // java/lang/ClassCastException
+  lazy val javaUtilMapReference        : ClassBType = classBTypeFromSymbol(JavaUtilMap)               // java/util/Map
+  lazy val javaUtilHashMapReference    : ClassBType = classBTypeFromSymbol(JavaUtilHashMap)           // java/util/HashMap
 
   lazy val srBooleanRef : ClassBType = classBTypeFromSymbol(requiredClass[scala.runtime.BooleanRef])
   lazy val srByteRef    : ClassBType = classBTypeFromSymbol(requiredClass[scala.runtime.ByteRef])
@@ -258,6 +260,8 @@ final class CoreBTypesProxy[BTFS <: BTypesFromSymbols[_ <: Global]](val bTypes: 
   def jioSerializableReference    : ClassBType = _coreBTypes.jioSerializableReference
   def scalaSerializableReference  : ClassBType = _coreBTypes.scalaSerializableReference
   def classCastExceptionReference : ClassBType = _coreBTypes.classCastExceptionReference
+  def javaUtilMapReference        : ClassBType = _coreBTypes.javaUtilMapReference
+  def javaUtilHashMapReference    : ClassBType = _coreBTypes.javaUtilHashMapReference
 
   def srBooleanRef : ClassBType = _coreBTypes.srBooleanRef
   def srByteRef    : ClassBType = _coreBTypes.srByteRef

--- a/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
+++ b/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
@@ -146,6 +146,9 @@ abstract class Delambdafy extends Transform with TypingTransformers with ast.Tre
       val isStatic = target.hasFlag(STATIC)
 
       def createBoxingBridgeMethod(functionParamTypes: List[Type], functionResultType: Type): Tree = {
+        // Note: we bail out of this method and return EmptyTree if we find there is no adaptation required.
+        // If we need to improve performance, we could check the types first before creating the
+        // method and parameter symbols.
         val methSym = oldClass.newMethod(target.name.append("$adapted").toTermName, target.pos, target.flags | FINAL | ARTIFACT)
         var neededAdaptation = false
         def boxedType(tpe: Type): Type = {

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -369,6 +369,8 @@ trait Definitions extends api.StandardDefinitions {
     lazy val JavaEnumClass         = requiredClass[java.lang.Enum[_]]
     lazy val RemoteInterfaceClass  = requiredClass[java.rmi.Remote]
     lazy val RemoteExceptionClass  = requiredClass[java.rmi.RemoteException]
+    lazy val JavaUtilMap           = requiredClass[java.util.Map[_, _]]
+    lazy val JavaUtilHashMap       = requiredClass[java.util.HashMap[_, _]]
 
     lazy val ByNameParamClass       = specialPolyClass(tpnme.BYNAME_PARAM_CLASS_NAME, COVARIANT)(_ => AnyTpe)
     lazy val JavaRepeatedParamClass = specialPolyClass(tpnme.JAVA_REPEATED_PARAM_CLASS_NAME, COVARIANT)(tparam => arrayType(tparam.tpe))

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -514,6 +514,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val ScalaSignatureAnnotation = requiredClass[scala.reflect.ScalaSignature]
     lazy val ScalaLongSignatureAnnotation = requiredClass[scala.reflect.ScalaLongSignature]
 
+    lazy val LambdaMetaFactory = getClassIfDefined("java.lang.invoke.LambdaMetafactory")
     lazy val MethodHandle = getClassIfDefined("java.lang.invoke.MethodHandle")
 
     // Option classes

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -1167,6 +1167,8 @@ trait StdNames {
     final val Invoke: TermName           = newTermName("invoke")
     final val InvokeExact: TermName      = newTermName("invokeExact")
 
+    final val AltMetafactory: TermName      = newTermName("altMetafactory")
+
     val Boxed = immutable.Map[TypeName, TypeName](
       tpnme.Boolean -> BoxedBoolean,
       tpnme.Byte    -> BoxedByte,

--- a/src/reflect/scala/reflect/internal/transform/PostErasure.scala
+++ b/src/reflect/scala/reflect/internal/transform/PostErasure.scala
@@ -9,8 +9,7 @@ trait PostErasure {
   object elimErasedValueType extends TypeMap {
     def apply(tp: Type) = tp match {
       case ConstantType(Constant(tp: Type)) => ConstantType(Constant(apply(tp)))
-      case ErasedValueType(_, underlying)   =>
-        underlying
+      case ErasedValueType(_, underlying)   => underlying
       case _                                => mapOver(tp)
     }
   }

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -310,6 +310,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.QuasiquoteClass_api_unapply
     definitions.ScalaSignatureAnnotation
     definitions.ScalaLongSignatureAnnotation
+    definitions.LambdaMetaFactory
     definitions.MethodHandle
     definitions.OptionClass
     definitions.OptionModule

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -255,6 +255,8 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.JavaEnumClass
     definitions.RemoteInterfaceClass
     definitions.RemoteExceptionClass
+    definitions.JavaUtilMap
+    definitions.JavaUtilHashMap
     definitions.ByNameParamClass
     definitions.JavaRepeatedParamClass
     definitions.RepeatedParamClass

--- a/test/files/run/lambda-serialization-gc.scala
+++ b/test/files/run/lambda-serialization-gc.scala
@@ -1,0 +1,40 @@
+import java.io._
+
+import java.net.URLClassLoader
+
+class C {
+  def serializeDeserialize[T <: AnyRef](obj: T) = {
+    val buffer = new ByteArrayOutputStream
+    val out = new ObjectOutputStream(buffer)
+    out.writeObject(obj)
+    val in = new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray))
+    in.readObject.asInstanceOf[T]
+  }
+
+  serializeDeserialize((c: String) => c.length)
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    test()
+  }
+
+  def test(): Unit = {
+    val loader = getClass.getClassLoader.asInstanceOf[URLClassLoader]
+    val loaderCClass = classOf[C]
+    def deserializedInThrowawayClassloader = {
+      val throwawayLoader: java.net.URLClassLoader = new java.net.URLClassLoader(loader.getURLs, ClassLoader.getSystemClassLoader) {
+        val maxMemory = Runtime.getRuntime.maxMemory()
+        val junk = new Array[Byte]((maxMemory / 2).toInt)
+      }
+      val clazz = throwawayLoader.loadClass("C")
+      assert(clazz != loaderCClass)
+      clazz.newInstance()
+    }
+    (1 to 4) foreach { i =>
+      // This would OOM by the third iteration if we leaked `throwawayLoader` during
+      // deserialization.
+      deserializedInThrowawayClassloader
+    }
+  }
+}

--- a/test/files/run/lambda-serialization.scala
+++ b/test/files/run/lambda-serialization.scala
@@ -1,0 +1,35 @@
+import java.io.{ByteArrayInputStream, ObjectInputStream, ObjectOutputStream, ByteArrayOutputStream}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    roundTrip
+  }
+
+  def roundTrip(): Unit = {
+    val c = new Capture("Capture")
+    val lambda = (p: Param) => ("a", p, c)
+    val reconstituted1 = serializeDeserialize(lambda).asInstanceOf[Object => Any]
+    val p = new Param
+    assert(reconstituted1.apply(p) == ("a", p, c))
+    val reconstituted2 = serializeDeserialize(lambda).asInstanceOf[Object => Any]
+    assert(reconstituted1.getClass == reconstituted2.getClass)
+
+    val reconstituted3 = serializeDeserialize(reconstituted1)
+    assert(reconstituted3.apply(p) == ("a", p, c))
+
+    val specializedLambda = (p: Int) => List(p, c).length
+    assert(serializeDeserialize(specializedLambda).apply(42) == 2)
+    assert(serializeDeserialize(serializeDeserialize(specializedLambda)).apply(42) == 2)
+  }
+
+  def serializeDeserialize[T <: AnyRef](obj: T) = {
+    val buffer = new ByteArrayOutputStream
+    val out = new ObjectOutputStream(buffer)
+    out.writeObject(obj)
+    val in = new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray))
+    in.readObject.asInstanceOf[T]
+  }
+}
+
+case class Capture(s: String) extends Serializable
+class Param


### PR DESCRIPTION
To support serialization, we use the alternative lambda metafactory that
lets us specify that our anonymous functions should extend the marker
interface `scala.Serializable`. They will also have a
`writeObject` method added that implements the serialization proxy pattern
using `j.l.invoke.SerializedLamba`.

To support deserialization, we synthesize a `$deserializeLamba$` method in
each class. This will be called reflectively by
`SerializedLambda#readResolve`. This method in turn delegates to
`LambdaDeserializer`, currently defined [1] in `scala-java8-compat`, that
uses `LambdaMetafactory` to spin up the anonymous class and instantiate it
with the deserialized environment.

Note: `LambdaDeserializer` reuses the anonymous class on subsequent
deserializations of a given lambda, in the same spirit as an invokedynamic
call site only spins up the class on the first time it is run.

`LambdaDeserializer` will be moved into our standard library in the 2.12.x
branch, where we can introduce dependencies on the Java 8 standard library.

The enclosed test cases must be manually run with indylambda enabled. Once
we enable indylambda by default on 2.12.x, the test will actually test the
new feature.

```
% echo $INDYLAMBDA
-Ydelambdafy:method -Ybackend:GenBCode -target:jvm-1.8 -classpath
.:scala-java8-compat_2.11-0.5.0-SNAPSHOT.jar
% $INDYLAMBDA -e "println((() => 42).getClass)" class
Main$$anon$1$$Lambda$1/1183231938
% qscala $INDYLAMBDA -e "assert(classOf[scala.Serializable].isInstance(()
=> 42))"
% qscalac $INDYLAMBDA test/files/run/lambda-serialization.scala && qscala
$INDYLAMBDA Test
```

This commit contains a few minor refactorings to the code that generates
the invokedynamic instruction to use more meaningful names and to reuse
Java signature generation code in ASM rather than the DIY approach.

[1] https://github.com/scala/scala-java8-compat/pull/37
