### PR TITLE
SI-9319 Avoid "filename too long" errors for anon functions

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
+++ b/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
@@ -284,9 +284,9 @@ abstract class Delambdafy extends Transform with TypingTransformers with ast.Tre
         //      - reinstate the assertion in `Erasure.resolveAnonymousBridgeClash`
         val suffix = nme.DELAMBDAFY_LAMBDA_CLASS_NAME + "$" + (
           if (funOwner.isPrimaryConstructor) ""
-          else "$" + funOwner.name + "$"
+          else "$" + funOwner.unexpandedName + "$"
         )
-        val oldClassPart = oldClass.name.decode
+        val oldClassPart = oldClass.unexpandedName.decode
         // make sure the class name doesn't contain $anon, otherwise isAnonymousClass/Function may be true
         val name = unit.freshTypeName(s"$oldClassPart$suffix".replace("$anon", "$nestedInAnon"))
 

--- a/test/files/jvm/innerClassAttribute.check
+++ b/test/files/jvm/innerClassAttribute.check
@@ -14,27 +14,27 @@ A19 / null / null
 A19 / null / null
 A19 / null / null
 -- A20 --
-A20$$anonfun$6 / null / null / 17
+A20$$anonfun$4 / null / null / 17
 fun1: attribute for itself and the two child closures `() => ()` and `() => () => 1`
-A20$$anonfun$6 / null / null / 17
-A20$$anonfun$6$$anonfun$apply$1 / null / null / 17
-A20$$anonfun$6$$anonfun$apply$3 / null / null / 17
+A20$$anonfun$4 / null / null / 17
+A20$$anonfun$4$$anonfun$apply$1 / null / null / 17
+A20$$anonfun$4$$anonfun$apply$2 / null / null / 17
 fun2 () => (): itself and the outer closure
-A20$$anonfun$6 / null / null / 17
-A20$$anonfun$6$$anonfun$apply$1 / null / null / 17
+A20$$anonfun$4 / null / null / 17
+A20$$anonfun$4$$anonfun$apply$1 / null / null / 17
 fun3 () => () => (): itself, the outer closure and its child closure
-A20$$anonfun$6 / null / null / 17
-A20$$anonfun$6$$anonfun$apply$3 / null / null / 17
-A20$$anonfun$6$$anonfun$apply$3$$anonfun$apply$2 / null / null / 17
+A20$$anonfun$4 / null / null / 17
+A20$$anonfun$4$$anonfun$apply$2 / null / null / 17
+A20$$anonfun$4$$anonfun$apply$2$$anonfun$apply$3 / null / null / 17
 fun4: () => 1: itself and the two outer closures
-A20$$anonfun$6 / null / null / 17
-A20$$anonfun$6$$anonfun$apply$3 / null / null / 17
-A20$$anonfun$6$$anonfun$apply$3$$anonfun$apply$2 / null / null / 17
+A20$$anonfun$4 / null / null / 17
+A20$$anonfun$4$$anonfun$apply$2 / null / null / 17
+A20$$anonfun$4$$anonfun$apply$2$$anonfun$apply$3 / null / null / 17
 enclosing: nested closures have outer class defined, but no outer method
 A20 / null / null
-A20$$anonfun$6 / null / null
-A20$$anonfun$6 / null / null
-A20$$anonfun$6$$anonfun$apply$3 / null / null
+A20$$anonfun$4 / null / null
+A20$$anonfun$4 / null / null
+A20$$anonfun$4$$anonfun$apply$2 / null / null
 #partest -Ydelambdafy:method
 -- A4 --
 null / null / null

--- a/test/files/jvm/innerClassAttribute/Classes_1.scala
+++ b/test/files/jvm/innerClassAttribute/Classes_1.scala
@@ -12,8 +12,8 @@ object A3 {
 }
 
 class A4 {
-  def f(l: List[Int]): List[Int] = {
-    l map (_ + 1)
+  def f(l: List[String]): List[String] = {
+    l map (_ + "1")
   }
 }
 
@@ -114,21 +114,21 @@ class A18 {
 }
 
 class A19 {
-  ((x: Int) => x + 3)
+  ((x: String) => x + "3")
 
   val x = {
-    ((x: Int) => x + 1)
+    ((x: String) => x + "1")
   }
 
   {
-    ((x: Int) => x + 2)
+    ((x: String) => x + "2")
   }
 }
 
 class A20 {
-  () => {
-    {() => ()}
-    {() => () => 1}
+  (s: String) => {
+    {(s: String) => ()}
+    {(s: String) => (s: String) => 1}
   }
 }
 
@@ -189,13 +189,13 @@ trait A24 extends A24Base {
 class SI_9105 {    
   // the EnclosingMethod attributes depend on the delambdafy strategy (inline vs method)
 
-                                       //  outerClass-inline   enclMeth-inline   outerClass-method   enclMeth-method                    
-  val fun = () => {
+                                       //  outerClass-inline   enclMeth-inline   outerClass-method   enclMeth-method
+  val fun = (s: String) => {
     class A                            //     closure             null (*)            SI_9105           null
     def m: Object = { class B; new B } //     closure              m$1                SI_9105            m$1
     val f: Object = { class C; new C } //     closure             null (*)            SI_9105           null
   }
-  def met = () => {
+  def met = (s: String) => {
     class D                            //     closure             null (*)            SI_9105            met
     def m: Object = { class E; new E } //     closure              m$1                SI_9105            m$1
     val f: Object = { class F; new F } //     closure             null (*)            SI_9105            met
@@ -210,17 +210,19 @@ class SI_9105 {
   //     So using `null` looks more like the situation in the source code: C / F are nested classes of the anon-fun, and
   //     there's no method in between.
 
-  def byName[T](op: => T) = 0
+  def byName(op: => Any) = 0
 
   val bnV = byName {
     class G                            //     closure             null (*)            SI_9105           null
     def m: Object = { class H; new H } //     closure              m$1                SI_9105            m$1
     val f: Object = { class I; new I } //     closure             null (*)            SI_9105           null
+    ""
   }
   def bnM = byName {
     class J                            //     closure             null (*)            SI_9105            bnM
     def m: Object = { class K; new K } //     closure              m$1                SI_9105            m$1
     val f: Object = { class L; new L } //     closure             null (*)            SI_9105            bnM
+    ""
   }
 }
 
@@ -283,8 +285,8 @@ object NestedInValueClass {
   class A(val arg: String) extends AnyVal {
     // A has InnerClass entries for the two closures (and for A and A$). not for B / C
     def f = {
-      def g = List().map(x => (() => x)) // outer class A, no outer method (g is moved to the companion, doesn't exist in A)
-      g.map(x => (() => x))              // outer class A, outer method f
+      def g = List().map(x => ((s: String) => x)) // outer class A, no outer method (g is moved to the companion, doesn't exist in A)
+      g.map(x => ((s: String) => x))              // outer class A, outer method f
     }
     // statements and field declarations are not allowed in value classes
   }

--- a/test/files/jvm/innerClassAttribute/Test.scala
+++ b/test/files/jvm/innerClassAttribute/Test.scala
@@ -5,6 +5,9 @@ import asm.{Opcodes => Flags}
 import scala.collection.JavaConverters._
 
 object Test extends BytecodeTest {
+  // Helpful for debugging the test:
+  // println(new java.io.File(classpath.asURLs.head.toURI).list().sorted.mkString("\n"))
+
   def assertSame(a: Any, b: Any) = {
     assert(a == b, s"\na: $a\nb: $b")
   }
@@ -266,10 +269,10 @@ object Test extends BytecodeTest {
 
     printInnerClassNodes("A20")
 
-    val fun1 = lambdaClass("A20$$anonfun$6", "A20$lambda$1")
-    val fun2 = lambdaClass("A20$$anonfun$6$$anonfun$apply$1", "A20$lambda$$$nestedInAnonfun$5$1")
-    val fun3 = lambdaClass("A20$$anonfun$6$$anonfun$apply$3", "A20$lambda$$$nestedInAnonfun$5$2")
-    val fun4 = lambdaClass("A20$$anonfun$6$$anonfun$apply$3$$anonfun$apply$2", "A20$lambda$$$nestedInAnonfun$7$1")
+    val fun1 = lambdaClass("A20$$anonfun$4", "A20$lambda$1")
+    val fun2 = lambdaClass("A20$$anonfun$4$$anonfun$apply$1", "A20$lambda$$$nestedInAnonfun$5$1")
+    val fun3 = lambdaClass("A20$$anonfun$4$$anonfun$apply$2", "A20$lambda$$$nestedInAnonfun$5$2")
+    val fun4 = lambdaClass("A20$$anonfun$4$$anonfun$apply$2$$anonfun$apply$3", "A20$lambda$$$nestedInAnonfun$7$1")
 
     println("fun1: attribute for itself and the two child closures `() => ()` and `() => () => 1`")
     printInnerClassNodes(fun1)
@@ -339,9 +342,9 @@ object Test extends BytecodeTest {
       assertEnclosingMethod  ("SI_9105$A$3"          , "SI_9105", null , null)
       assertEnclosingMethod  ("SI_9105$B$5"          , "SI_9105", "m$1", "()Ljava/lang/Object;")
       assertEnclosingMethod  ("SI_9105$C$1"          , "SI_9105", null , null)
-      assertEnclosingMethod  ("SI_9105$D$1"          , "SI_9105", "met", "()Lscala/Function0;")
+      assertEnclosingMethod  ("SI_9105$D$1"          , "SI_9105", "met", "()Lscala/Function1;")
       assertEnclosingMethod  ("SI_9105$E$1"          , "SI_9105", "m$3", "()Ljava/lang/Object;")
-      assertEnclosingMethod  ("SI_9105$F$1"          , "SI_9105", "met", "()Lscala/Function0;")
+      assertEnclosingMethod  ("SI_9105$F$1"          , "SI_9105", "met", "()Lscala/Function1;")
       assertNoEnclosingMethod("SI_9105$lambda$$met$1")
       assertNoEnclosingMethod("SI_9105$lambda$1")
       assertNoEnclosingMethod("SI_9105")
@@ -366,35 +369,35 @@ object Test extends BytecodeTest {
       assert(innerClassNodes("SI_9105").length == 12) // the 12 local classes
     } else {
       // comment in innerClassAttribute/Classes_1.scala explains the difference between A / C and D / F.
-      assertEnclosingMethod  ("SI_9105$$anonfun$4$A$3"    , "SI_9105$$anonfun$4"    , null          , null)
-      assertEnclosingMethod  ("SI_9105$$anonfun$4$B$5"    , "SI_9105$$anonfun$4"    , "m$1"         , "()Ljava/lang/Object;")
-      assertEnclosingMethod  ("SI_9105$$anonfun$4$C$1"    , "SI_9105$$anonfun$4"    , null          , null)
+      assertEnclosingMethod  ("SI_9105$$anonfun$5$A$3"    , "SI_9105$$anonfun$5"    , null          , null)
+      assertEnclosingMethod  ("SI_9105$$anonfun$5$B$5"    , "SI_9105$$anonfun$5"    , "m$1"         , "()Ljava/lang/Object;")
+      assertEnclosingMethod  ("SI_9105$$anonfun$5$C$1"    , "SI_9105$$anonfun$5"    , null          , null)
       assertEnclosingMethod  ("SI_9105$$anonfun$met$1$D$1", "SI_9105$$anonfun$met$1", null          , null)
       assertEnclosingMethod  ("SI_9105$$anonfun$met$1$E$1", "SI_9105$$anonfun$met$1", "m$3"         , "()Ljava/lang/Object;")
       assertEnclosingMethod  ("SI_9105$$anonfun$met$1$F$1", "SI_9105$$anonfun$met$1", null          , null)
-      assertEnclosingMethod  ("SI_9105$$anonfun$4"        , "SI_9105"               , null          , null)
-      assertEnclosingMethod  ("SI_9105$$anonfun$met$1"    , "SI_9105"               , "met"         , "()Lscala/Function0;")
+      assertEnclosingMethod  ("SI_9105$$anonfun$5"        , "SI_9105"               , null          , null)
+      assertEnclosingMethod  ("SI_9105$$anonfun$met$1"    , "SI_9105"               , "met"         , "()Lscala/Function1;")
       assertNoEnclosingMethod("SI_9105")
 
-      assertLocal(ownInnerClassNode("SI_9105$$anonfun$4$A$3"),     "SI_9105$$anonfun$4$A$3"    , "A$3")
-      assertLocal(ownInnerClassNode("SI_9105$$anonfun$4$B$5"),     "SI_9105$$anonfun$4$B$5"    , "B$5")
-      assertLocal(ownInnerClassNode("SI_9105$$anonfun$4$C$1"),     "SI_9105$$anonfun$4$C$1"    , "C$1")
+      assertLocal(ownInnerClassNode("SI_9105$$anonfun$5$A$3"),     "SI_9105$$anonfun$5$A$3"    , "A$3")
+      assertLocal(ownInnerClassNode("SI_9105$$anonfun$5$B$5"),     "SI_9105$$anonfun$5$B$5"    , "B$5")
+      assertLocal(ownInnerClassNode("SI_9105$$anonfun$5$C$1"),     "SI_9105$$anonfun$5$C$1"    , "C$1")
       assertLocal(ownInnerClassNode("SI_9105$$anonfun$met$1$D$1"), "SI_9105$$anonfun$met$1$D$1", "D$1")
       assertLocal(ownInnerClassNode("SI_9105$$anonfun$met$1$E$1"), "SI_9105$$anonfun$met$1$E$1", "E$1")
       assertLocal(ownInnerClassNode("SI_9105$$anonfun$met$1$F$1"), "SI_9105$$anonfun$met$1$F$1", "F$1")
 
       // by-name
-      assertEnclosingMethod("SI_9105$$anonfun$5$G$1", "SI_9105$$anonfun$5", null, null)
-      assertEnclosingMethod("SI_9105$$anonfun$5$H$1", "SI_9105$$anonfun$5", "m$2", "()Ljava/lang/Object;")
-      assertEnclosingMethod("SI_9105$$anonfun$5$I$1", "SI_9105$$anonfun$5", null, null)
+      assertEnclosingMethod("SI_9105$$anonfun$6$G$1", "SI_9105$$anonfun$6", null, null)
+      assertEnclosingMethod("SI_9105$$anonfun$6$H$1", "SI_9105$$anonfun$6", "m$2", "()Ljava/lang/Object;")
+      assertEnclosingMethod("SI_9105$$anonfun$6$I$1", "SI_9105$$anonfun$6", null, null)
       assertEnclosingMethod("SI_9105$$anonfun$bnM$1$J$1", "SI_9105$$anonfun$bnM$1", null, null)
       assertEnclosingMethod("SI_9105$$anonfun$bnM$1$K$2", "SI_9105$$anonfun$bnM$1", "m$4", "()Ljava/lang/Object;")
       assertEnclosingMethod("SI_9105$$anonfun$bnM$1$L$1", "SI_9105$$anonfun$bnM$1", null, null)
 
-      assertAnonymous(ownInnerClassNode("SI_9105$$anonfun$4"), "SI_9105$$anonfun$4")
+      assertAnonymous(ownInnerClassNode("SI_9105$$anonfun$5"), "SI_9105$$anonfun$5")
       assertAnonymous(ownInnerClassNode("SI_9105$$anonfun$met$1"), "SI_9105$$anonfun$met$1")
 
-      assert(innerClassNodes("SI_9105$$anonfun$4").length == 4)     // itself and three of the local classes
+      assert(innerClassNodes("SI_9105$$anonfun$5").length == 4)     // itself and three of the local classes
       assert(innerClassNodes("SI_9105$$anonfun$met$1").length == 4) // itself and three of the local classes
       assert(innerClassNodes("SI_9105").length == 4)                // the four anon funs
     }

--- a/test/files/jvm/javaReflection/Classes_1.scala
+++ b/test/files/jvm/javaReflection/Classes_1.scala
@@ -13,7 +13,7 @@ class A {
     trait C
     object D
     new T { }
-    (() => -1)
+    (() => "-1")
     def f = { class KB }
   }
 
@@ -21,21 +21,21 @@ class A {
   new T { }
 
   // anonymous function, not a member
-  (() => 1)
+  (() => "1")
 
   def f = {
     class E
     trait F
     object G
     new T { }
-    (() => 2)
+    (() => "2")
 
     if (new Object().hashCode == 1) {
       class H
       trait I
       object J
       new T { }
-      (() => 3)
+      (() => "3")
     } else {
       ()
     }
@@ -46,7 +46,7 @@ class A {
     trait L
     object M
     new T { }
-    (() => 4)
+    (() => "4")
   }
 
   val x = {
@@ -54,7 +54,7 @@ class A {
     trait O
     object P
     new T { }
-    (() => 5)
+    (() => "5")
   }
 
   def this(x: Int) {
@@ -63,7 +63,7 @@ class A {
     trait R
     object S
     new T { }
-    (() => () => 5)
+    (() => () => "5")
   }
 }
 
@@ -72,7 +72,7 @@ object AO {
   trait C
   object D
   new T { }
-  (() => 1)
+  (() => "1")
 }
 
 trait AT {
@@ -80,5 +80,5 @@ trait AT {
   trait C
   object D
   new T { }
-  (() => 1)
+  (() => "1")
 }

--- a/test/files/pos/t9319.flags
+++ b/test/files/pos/t9319.flags
@@ -1,0 +1,1 @@
+-Ydelambdafy:method

--- a/test/files/pos/t9319.scala
+++ b/test/files/pos/t9319.scala
@@ -1,0 +1,35 @@
+object Test {
+
+  // was causing "filename too long" errors under -Ydelambdafy:method
+  def main(args: Array[String]) {
+    val x = List(1)
+    (i: Int) => {
+      (i: Int) => {
+        (i: Int) => {
+          (i: Int) => {
+            (i: Int) => {
+              (i: Int) => {
+                (i: Int) => {
+                  (i: Int) => {
+                    (i: Int) => {
+                      ()
+                    }
+
+                    ""
+                  }
+                  ()
+                }
+                ()
+              }
+              ()
+            }
+            ()
+          }
+          ()
+        }
+        ()
+      }
+      ()
+    }
+  }
+}

--- a/test/files/run/delambdafyLambdaClassNames/A_1.scala
+++ b/test/files/run/delambdafyLambdaClassNames/A_1.scala
@@ -1,5 +1,5 @@
 class A {
   def f = new Runnable {
-    def run(): Unit = List(1,2).foreach(println)
+    def run(): Unit = List("1","2").foreach(println)
   }
 }

--- a/test/files/run/delambdafyLambdaClassNames/Test.scala
+++ b/test/files/run/delambdafyLambdaClassNames/Test.scala
@@ -1,4 +1,4 @@
 object Test extends App {
-  val c = Class.forName("A$$nestedInAnon$1$lambda$$run$1")
+  val c = Class.forName("anon$1$lambda$$run$1.class")
   println(c.getName)
 }


### PR DESCRIPTION
Under -Ydelambdafy:method, the name of the anonymous class is
derived from the names of the original enclosing class and
term of the function.

However no effort is made to conform to the `-Xmaxclassname` setting
when constructing the class name from the components.

Recently, in 029cce7, I changed uncurry to selectively fallback
to the old method of emitting lambdas when we detect that
`-Ydelambdafy:method` would subvert specialization.

As a result of this, we could now have a delambdafy translated
function enclosed in an anonymous class representing an old-style
function. If that function, in turn, is heavily nested, its long
name now contributes a long suffix to the delambdafy class's name.

This led to a "filename too long" error in `run/kmpSliceSearch.scala`.
I have extract the essence of the failure in `pos/t9319.scala`.

I then changed delambdafy to use the unexpanded names of the owner
in the suffix, rather than the full name. This makes things work
as expected.

I haven't further protected against pathological cases, given
that in 2.12.x and indylambda, we won't ever emit these classes.
