### PR TITLE
Remove actors from dbuild meta descriptor.

### DIFF
--- a/dbuild-meta.json
+++ b/dbuild-meta.json
@@ -64,24 +64,6 @@
             "artifacts": [
                 {
                     "extension": "jar",
-                    "name": "scala-actors",
-                    "organization": "org.scala-lang"
-                }
-            ],
-            "dependencies": [
-                {
-                    "extension": "jar",
-                    "name": "scala-library",
-                    "organization": "org.scala-lang"
-                }
-            ],
-            "name": "scala-actors",
-            "organization": "org.scala-lang"
-        },
-        {
-            "artifacts": [
-                {
-                    "extension": "jar",
                     "name": "scalap",
                     "organization": "org.scala-lang"
                 }


### PR DESCRIPTION
This change aligns again the "dbuild-meta.json" file with the ant build script.
