### PR TITLE
Avoid inefficient specialized lambdas w. delambdafy jvm-1.8, GenASM

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -237,7 +237,7 @@ abstract class UnCurry extends InfoTransform
 
           def canUseDelamdafyMethod = (
                (inConstructorFlag == 0) // Avoiding synthesizing code prone to SI-6666, SI-8363 by using old-style lambda translation
-            && (!isSpecialized || (settings.target.value == "jvm-1.8")) // DelambdafyTransformer currently only emits generic FunctionN-s, use the old style in the meantime
+            && (!isSpecialized || (settings.isBCodeActive && settings.target.value == "jvm-1.8")) // DelambdafyTransformer currently only emits generic FunctionN-s, use the old style in the meantime
           )
           if (inlineFunctionExpansion || !canUseDelamdafyMethod) {
             val parents = addSerializable(abstractFunctionForFunctionType(fun.tpe))


### PR DESCRIPTION
A previous change disabled -Ydelambdafy:method for specialized
lambdas, as `DelambdafyTransformer` made no attempt to emit
the requisite machinery to avoid boxing.

This was loosened to allow them under `-target:jvm-1.8`, in the
knowledge that `indylambda` would do the right thing.

However, this wasn't quite right: indylambda is only supported
in `GenBCode`, so we should consider that setting as well.
