### PR TITLE
SI-9322 Elapsed times in compiler calculated with System.currentTimeMillis and System.nanoTime

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -10,7 +10,6 @@ package nsc
 import java.io.{ File, FileOutputStream, PrintWriter, IOException, FileNotFoundException }
 import java.net.URL
 import java.nio.charset.{ Charset, CharsetDecoder, IllegalCharsetNameException, UnsupportedCharsetException }
-import scala.compat.Platform.currentTime
 import scala.collection.{ mutable, immutable }
 import io.{ SourceReader, AbstractFile, Path }
 import reporters.{ Reporter, ConsoleReporter }
@@ -1487,6 +1486,8 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
       compileUnitsInternal(units, fromPhase)
 
     private def compileUnitsInternal(units: List[CompilationUnit], fromPhase: Phase) {
+      def currentTime = java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(System.nanoTime())
+
       units foreach addUnit
       val startTime = currentTime
 

--- a/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
@@ -8,7 +8,6 @@ package symtab
 
 import classfile.ClassfileParser
 import java.io.IOException
-import scala.compat.Platform.currentTime
 import scala.reflect.internal.MissingRequirementError
 import scala.reflect.internal.util.Statistics
 import scala.reflect.io.{ AbstractFile, NoAbstractFile }
@@ -207,7 +206,7 @@ abstract class SymbolLoaders {
 
     override def complete(root: Symbol) {
       try {
-        val start = currentTime
+        val start = java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(System.nanoTime())
         val currentphase = phase
         doComplete(root)
         phase = currentphase


### PR DESCRIPTION
Changing this bit of code back seemed to fix the negative timestamps I was seeing in scalac's verbose output:

> [loaded package loader resources.jar in 440ms]
> [loaded package loader java in 5ms]
> [loaded package loader lang in 62ms]

It looks like it was originally changed to improve performance by eliminating a possible system call, but since this is wrapping steps in the compiler, I wouldn't think this would be too expensive to add back.
