### PR TITLE
Update to scala-java8-compat 0.5.0

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -313,7 +313,7 @@ TODO:
 
       <!-- scala-java8-compat, used by the experimental -target jvm-1.8 support. -->
       <if><isset property="scala-java8-compat.package"/><then>
-        <property name="scala-java8-compat.version" value="0.4.0"/>
+        <property name="scala-java8-compat.version" value="0.5.0"/>
         <property name="scala-java8-compat.binary.version" value="2.11"/>
         <artifact:dependencies pathId="scala-java8-compat.classpath" filesetId="scala-java8-compat.fileset">
           <dependency groupId="org.scala-lang.modules" artifactId="scala-java8-compat_${scala-java8-compat.binary.version}" version="${scala-java8-compat.version}">


### PR DESCRIPTION
This contains LambdaDeserializer, which we refer to in our
synthetic `$deserializeLambda$` method under -target:jvm-1.8.

Note: this library is only reference in the Ant build under a
non-standard build flag that includes that library into
scala-library.jar. This is only for our internal use in running
partest for indylambda. The SBT build doesn't have the same
option at the moment.

Review by @lrytz or @adriaanm
