### PR TITLE
Fix several tests under GenBCode

### DIFF
--- a/test/files/instrumented/inline-in-constructors.flags
+++ b/test/files/instrumented/inline-in-constructors.flags
@@ -1,1 +1,1 @@
--optimise -Ydelambdafy:inline
+-optimise -Ydelambdafy:inline -Ybackend:GenASM

--- a/test/files/jvm/constant-optimization/Foo_1.flags
+++ b/test/files/jvm/constant-optimization/Foo_1.flags
@@ -1,1 +1,1 @@
--Ynooptimise -Yconst-opt
+-Ynooptimise -Yconst-opt -Ybackend:GenASM

--- a/test/files/jvm/innerClassAttribute.check
+++ b/test/files/jvm/innerClassAttribute.check
@@ -14,27 +14,27 @@ A19 / null / null
 A19 / null / null
 A19 / null / null
 -- A20 --
-A20$$anonfun$6 / null / null / 17
+A20$$anonfun$4 / null / null / 17
 fun1: attribute for itself and the two child closures `() => ()` and `() => () => 1`
-A20$$anonfun$6 / null / null / 17
-A20$$anonfun$6$$anonfun$apply$1 / null / null / 17
-A20$$anonfun$6$$anonfun$apply$3 / null / null / 17
+A20$$anonfun$4 / null / null / 17
+A20$$anonfun$4$$anonfun$apply$1 / null / null / 17
+A20$$anonfun$4$$anonfun$apply$2 / null / null / 17
 fun2 () => (): itself and the outer closure
-A20$$anonfun$6 / null / null / 17
-A20$$anonfun$6$$anonfun$apply$1 / null / null / 17
+A20$$anonfun$4 / null / null / 17
+A20$$anonfun$4$$anonfun$apply$1 / null / null / 17
 fun3 () => () => (): itself, the outer closure and its child closure
-A20$$anonfun$6 / null / null / 17
-A20$$anonfun$6$$anonfun$apply$3 / null / null / 17
-A20$$anonfun$6$$anonfun$apply$3$$anonfun$apply$2 / null / null / 17
+A20$$anonfun$4 / null / null / 17
+A20$$anonfun$4$$anonfun$apply$2 / null / null / 17
+A20$$anonfun$4$$anonfun$apply$2$$anonfun$apply$3 / null / null / 17
 fun4: () => 1: itself and the two outer closures
-A20$$anonfun$6 / null / null / 17
-A20$$anonfun$6$$anonfun$apply$3 / null / null / 17
-A20$$anonfun$6$$anonfun$apply$3$$anonfun$apply$2 / null / null / 17
+A20$$anonfun$4 / null / null / 17
+A20$$anonfun$4$$anonfun$apply$2 / null / null / 17
+A20$$anonfun$4$$anonfun$apply$2$$anonfun$apply$3 / null / null / 17
 enclosing: nested closures have outer class defined, but no outer method
 A20 / null / null
-A20$$anonfun$6 / null / null
-A20$$anonfun$6 / null / null
-A20$$anonfun$6$$anonfun$apply$3 / null / null
+A20$$anonfun$4 / null / null
+A20$$anonfun$4 / null / null
+A20$$anonfun$4$$anonfun$apply$2 / null / null
 #partest -Ydelambdafy:method
 -- A4 --
 null / null / null

--- a/test/files/jvm/innerClassAttribute/Classes_1.scala
+++ b/test/files/jvm/innerClassAttribute/Classes_1.scala
@@ -12,8 +12,8 @@ object A3 {
 }
 
 class A4 {
-  def f(l: List[Int]): List[Int] = {
-    l map (_ + 1)
+  def f(l: List[String]): List[String] = {
+    l map (_ + "1")
   }
 }
 
@@ -114,21 +114,21 @@ class A18 {
 }
 
 class A19 {
-  ((x: Int) => x + 3)
+  ((x: String) => x + "3")
 
   val x = {
-    ((x: Int) => x + 1)
+    ((x: String) => x + "1")
   }
 
   {
-    ((x: Int) => x + 2)
+    ((x: String) => x + "2")
   }
 }
 
 class A20 {
-  () => {
-    {() => ()}
-    {() => () => 1}
+  (s: String) => {
+    {(s: String) => ()}
+    {(s: String) => (s: String) => 1}
   }
 }
 
@@ -189,13 +189,13 @@ trait A24 extends A24Base {
 class SI_9105 {    
   // the EnclosingMethod attributes depend on the delambdafy strategy (inline vs method)
 
-                                       //  outerClass-inline   enclMeth-inline   outerClass-method   enclMeth-method                    
-  val fun = () => {
+                                       //  outerClass-inline   enclMeth-inline   outerClass-method   enclMeth-method
+  val fun = (s: String) => {
     class A                            //     closure             null (*)            SI_9105           null
     def m: Object = { class B; new B } //     closure              m$1                SI_9105            m$1
     val f: Object = { class C; new C } //     closure             null (*)            SI_9105           null
   }
-  def met = () => {
+  def met = (s: String) => {
     class D                            //     closure             null (*)            SI_9105            met
     def m: Object = { class E; new E } //     closure              m$1                SI_9105            m$1
     val f: Object = { class F; new F } //     closure             null (*)            SI_9105            met
@@ -210,17 +210,19 @@ class SI_9105 {
   //     So using `null` looks more like the situation in the source code: C / F are nested classes of the anon-fun, and
   //     there's no method in between.
 
-  def byName[T](op: => T) = 0
+  def byName(op: => Any) = 0
 
   val bnV = byName {
     class G                            //     closure             null (*)            SI_9105           null
     def m: Object = { class H; new H } //     closure              m$1                SI_9105            m$1
     val f: Object = { class I; new I } //     closure             null (*)            SI_9105           null
+    ""
   }
   def bnM = byName {
     class J                            //     closure             null (*)            SI_9105            bnM
     def m: Object = { class K; new K } //     closure              m$1                SI_9105            m$1
     val f: Object = { class L; new L } //     closure             null (*)            SI_9105            bnM
+    ""
   }
 }
 
@@ -283,8 +285,8 @@ object NestedInValueClass {
   class A(val arg: String) extends AnyVal {
     // A has InnerClass entries for the two closures (and for A and A$). not for B / C
     def f = {
-      def g = List().map(x => (() => x)) // outer class A, no outer method (g is moved to the companion, doesn't exist in A)
-      g.map(x => (() => x))              // outer class A, outer method f
+      def g = List().map(x => ((s: String) => x)) // outer class A, no outer method (g is moved to the companion, doesn't exist in A)
+      g.map(x => ((s: String) => x))              // outer class A, outer method f
     }
     // statements and field declarations are not allowed in value classes
   }

--- a/test/files/jvm/innerClassAttribute/Test.scala
+++ b/test/files/jvm/innerClassAttribute/Test.scala
@@ -5,11 +5,14 @@ import asm.{Opcodes => Flags}
 import scala.collection.JavaConverters._
 
 object Test extends BytecodeTest {
+  // Helpful for debugging the test:
+  // println(new java.io.File(classpath.asURLs.head.toURI).list().sorted.mkString("\n"))
+
   def assertSame(a: Any, b: Any) = {
     assert(a == b, s"\na: $a\nb: $b")
   }
 
-  val publicStatic = Flags.ACC_PUBLIC | Flags.ACC_STATIC 
+  val publicStatic = Flags.ACC_PUBLIC | Flags.ACC_STATIC
   val publicAbstractInterface = Flags.ACC_PUBLIC | Flags.ACC_ABSTRACT | Flags.ACC_INTERFACE
 
   def innerClassNodes(className: String): List[InnerClassNode] = {
@@ -266,10 +269,10 @@ object Test extends BytecodeTest {
 
     printInnerClassNodes("A20")
 
-    val fun1 = lambdaClass("A20$$anonfun$6", "A20$lambda$1")
-    val fun2 = lambdaClass("A20$$anonfun$6$$anonfun$apply$1", "A20$lambda$$$nestedInAnonfun$5$1")
-    val fun3 = lambdaClass("A20$$anonfun$6$$anonfun$apply$3", "A20$lambda$$$nestedInAnonfun$5$2")
-    val fun4 = lambdaClass("A20$$anonfun$6$$anonfun$apply$3$$anonfun$apply$2", "A20$lambda$$$nestedInAnonfun$7$1")
+    val fun1 = lambdaClass("A20$$anonfun$4", "A20$lambda$1")
+    val fun2 = lambdaClass("A20$$anonfun$4$$anonfun$apply$1", "A20$lambda$$$nestedInAnonfun$5$1")
+    val fun3 = lambdaClass("A20$$anonfun$4$$anonfun$apply$2", "A20$lambda$$$nestedInAnonfun$5$2")
+    val fun4 = lambdaClass("A20$$anonfun$4$$anonfun$apply$2$$anonfun$apply$3", "A20$lambda$$$nestedInAnonfun$7$1")
 
     println("fun1: attribute for itself and the two child closures `() => ()` and `() => () => 1`")
     printInnerClassNodes(fun1)
@@ -339,9 +342,9 @@ object Test extends BytecodeTest {
       assertEnclosingMethod  ("SI_9105$A$3"          , "SI_9105", null , null)
       assertEnclosingMethod  ("SI_9105$B$5"          , "SI_9105", "m$1", "()Ljava/lang/Object;")
       assertEnclosingMethod  ("SI_9105$C$1"          , "SI_9105", null , null)
-      assertEnclosingMethod  ("SI_9105$D$1"          , "SI_9105", "met", "()Lscala/Function0;")
+      assertEnclosingMethod  ("SI_9105$D$1"          , "SI_9105", "met", "()Lscala/Function1;")
       assertEnclosingMethod  ("SI_9105$E$1"          , "SI_9105", "m$3", "()Ljava/lang/Object;")
-      assertEnclosingMethod  ("SI_9105$F$1"          , "SI_9105", "met", "()Lscala/Function0;")
+      assertEnclosingMethod  ("SI_9105$F$1"          , "SI_9105", "met", "()Lscala/Function1;")
       assertNoEnclosingMethod("SI_9105$lambda$$met$1")
       assertNoEnclosingMethod("SI_9105$lambda$1")
       assertNoEnclosingMethod("SI_9105")
@@ -366,35 +369,35 @@ object Test extends BytecodeTest {
       assert(innerClassNodes("SI_9105").length == 12) // the 12 local classes
     } else {
       // comment in innerClassAttribute/Classes_1.scala explains the difference between A / C and D / F.
-      assertEnclosingMethod  ("SI_9105$$anonfun$4$A$3"    , "SI_9105$$anonfun$4"    , null          , null)
-      assertEnclosingMethod  ("SI_9105$$anonfun$4$B$5"    , "SI_9105$$anonfun$4"    , "m$1"         , "()Ljava/lang/Object;")
-      assertEnclosingMethod  ("SI_9105$$anonfun$4$C$1"    , "SI_9105$$anonfun$4"    , null          , null)
+      assertEnclosingMethod  ("SI_9105$$anonfun$5$A$3"    , "SI_9105$$anonfun$5"    , null          , null)
+      assertEnclosingMethod  ("SI_9105$$anonfun$5$B$5"    , "SI_9105$$anonfun$5"    , "m$1"         , "()Ljava/lang/Object;")
+      assertEnclosingMethod  ("SI_9105$$anonfun$5$C$1"    , "SI_9105$$anonfun$5"    , null          , null)
       assertEnclosingMethod  ("SI_9105$$anonfun$met$1$D$1", "SI_9105$$anonfun$met$1", null          , null)
       assertEnclosingMethod  ("SI_9105$$anonfun$met$1$E$1", "SI_9105$$anonfun$met$1", "m$3"         , "()Ljava/lang/Object;")
       assertEnclosingMethod  ("SI_9105$$anonfun$met$1$F$1", "SI_9105$$anonfun$met$1", null          , null)
-      assertEnclosingMethod  ("SI_9105$$anonfun$4"        , "SI_9105"               , null          , null)
-      assertEnclosingMethod  ("SI_9105$$anonfun$met$1"    , "SI_9105"               , "met"         , "()Lscala/Function0;")
+      assertEnclosingMethod  ("SI_9105$$anonfun$5"        , "SI_9105"               , null          , null)
+      assertEnclosingMethod  ("SI_9105$$anonfun$met$1"    , "SI_9105"               , "met"         , "()Lscala/Function1;")
       assertNoEnclosingMethod("SI_9105")
 
-      assertLocal(ownInnerClassNode("SI_9105$$anonfun$4$A$3"),     "SI_9105$$anonfun$4$A$3"    , "A$3")
-      assertLocal(ownInnerClassNode("SI_9105$$anonfun$4$B$5"),     "SI_9105$$anonfun$4$B$5"    , "B$5")
-      assertLocal(ownInnerClassNode("SI_9105$$anonfun$4$C$1"),     "SI_9105$$anonfun$4$C$1"    , "C$1")
+      assertLocal(ownInnerClassNode("SI_9105$$anonfun$5$A$3"),     "SI_9105$$anonfun$5$A$3"    , "A$3")
+      assertLocal(ownInnerClassNode("SI_9105$$anonfun$5$B$5"),     "SI_9105$$anonfun$5$B$5"    , "B$5")
+      assertLocal(ownInnerClassNode("SI_9105$$anonfun$5$C$1"),     "SI_9105$$anonfun$5$C$1"    , "C$1")
       assertLocal(ownInnerClassNode("SI_9105$$anonfun$met$1$D$1"), "SI_9105$$anonfun$met$1$D$1", "D$1")
       assertLocal(ownInnerClassNode("SI_9105$$anonfun$met$1$E$1"), "SI_9105$$anonfun$met$1$E$1", "E$1")
       assertLocal(ownInnerClassNode("SI_9105$$anonfun$met$1$F$1"), "SI_9105$$anonfun$met$1$F$1", "F$1")
 
       // by-name
-      assertEnclosingMethod("SI_9105$$anonfun$5$G$1", "SI_9105$$anonfun$5", null, null)
-      assertEnclosingMethod("SI_9105$$anonfun$5$H$1", "SI_9105$$anonfun$5", "m$2", "()Ljava/lang/Object;")
-      assertEnclosingMethod("SI_9105$$anonfun$5$I$1", "SI_9105$$anonfun$5", null, null)
+      assertEnclosingMethod("SI_9105$$anonfun$6$G$1", "SI_9105$$anonfun$6", null, null)
+      assertEnclosingMethod("SI_9105$$anonfun$6$H$1", "SI_9105$$anonfun$6", "m$2", "()Ljava/lang/Object;")
+      assertEnclosingMethod("SI_9105$$anonfun$6$I$1", "SI_9105$$anonfun$6", null, null)
       assertEnclosingMethod("SI_9105$$anonfun$bnM$1$J$1", "SI_9105$$anonfun$bnM$1", null, null)
       assertEnclosingMethod("SI_9105$$anonfun$bnM$1$K$2", "SI_9105$$anonfun$bnM$1", "m$4", "()Ljava/lang/Object;")
       assertEnclosingMethod("SI_9105$$anonfun$bnM$1$L$1", "SI_9105$$anonfun$bnM$1", null, null)
 
-      assertAnonymous(ownInnerClassNode("SI_9105$$anonfun$4"), "SI_9105$$anonfun$4")
+      assertAnonymous(ownInnerClassNode("SI_9105$$anonfun$5"), "SI_9105$$anonfun$5")
       assertAnonymous(ownInnerClassNode("SI_9105$$anonfun$met$1"), "SI_9105$$anonfun$met$1")
 
-      assert(innerClassNodes("SI_9105$$anonfun$4").length == 4)     // itself and three of the local classes
+      assert(innerClassNodes("SI_9105$$anonfun$5").length == 4)     // itself and three of the local classes
       assert(innerClassNodes("SI_9105$$anonfun$met$1").length == 4) // itself and three of the local classes
       assert(innerClassNodes("SI_9105").length == 4)                // the four anon funs
     }
@@ -474,7 +477,7 @@ object Test extends BytecodeTest {
     testInner("ImplClassesAreTopLevel$B2$1$class", b2)
     testInner("ImplClassesAreTopLevel$B3$1$class", b3)
     testInner("ImplClassesAreTopLevel$B4$class", b4)
- 
+
     testInner("ImplClassesAreTopLevel$B1", b1)
     testInner("ImplClassesAreTopLevel$B2$1", b2)
     testInner("ImplClassesAreTopLevel$B3$1", b3)
@@ -533,13 +536,13 @@ object Test extends BytecodeTest {
         "NestedInValueClass$A$lambda$$g$2$1",
         "NestedInValueClass$A$lambda$$f$extension$1",
         "NestedInValueClass$A$lambda$$$nestedInAnonfun$13$1",
-        "NestedInValueClass$A$lambda$$$nestedInAnonfun$15$1").foreach(assertNoEnclosingMethod)
+        "NestedInValueClass$A$lambda$$NestedInValueClass$A$$$nestedInAnonfun$15$1").foreach(assertNoEnclosingMethod)
       testInner("NestedInValueClass$A", a, am)
       testInner("NestedInValueClass$A$", a, am, b, c)
       testInner("NestedInValueClass$A$lambda$$g$2$1", am)
       testInner("NestedInValueClass$A$lambda$$f$extension$1", am)
       testInner("NestedInValueClass$A$lambda$$$nestedInAnonfun$13$1", am)
-      testInner("NestedInValueClass$A$lambda$$$nestedInAnonfun$15$1", am)
+      testInner("NestedInValueClass$A$lambda$$NestedInValueClass$A$$$nestedInAnonfun$15$1", am)
     } else {
       assertEnclosingMethod("NestedInValueClass$A$$anonfun$g$2$1"                         , "NestedInValueClass$A"                       , null, null)
       assertEnclosingMethod("NestedInValueClass$A$$anonfun$g$2$1$$anonfun$apply$4"        , "NestedInValueClass$A$$anonfun$g$2$1"        , null, null)

--- a/test/files/jvm/javaReflection/Classes_1.scala
+++ b/test/files/jvm/javaReflection/Classes_1.scala
@@ -13,7 +13,7 @@ class A {
     trait C
     object D
     new T { }
-    (() => -1)
+    (() => "-1")
     def f = { class KB }
   }
 
@@ -21,21 +21,21 @@ class A {
   new T { }
 
   // anonymous function, not a member
-  (() => 1)
+  (() => "1")
 
   def f = {
     class E
     trait F
     object G
     new T { }
-    (() => 2)
+    (() => "2")
 
     if (new Object().hashCode == 1) {
       class H
       trait I
       object J
       new T { }
-      (() => 3)
+      (() => "3")
     } else {
       ()
     }
@@ -46,7 +46,7 @@ class A {
     trait L
     object M
     new T { }
-    (() => 4)
+    (() => "4")
   }
 
   val x = {
@@ -54,7 +54,7 @@ class A {
     trait O
     object P
     new T { }
-    (() => 5)
+    (() => "5")
   }
 
   def this(x: Int) {
@@ -63,7 +63,7 @@ class A {
     trait R
     object S
     new T { }
-    (() => () => 5)
+    (() => () => "5")
   }
 }
 
@@ -72,7 +72,7 @@ object AO {
   trait C
   object D
   new T { }
-  (() => 1)
+  (() => "1")
 }
 
 trait AT {
@@ -80,5 +80,5 @@ trait AT {
   trait C
   object D
   new T { }
-  (() => 1)
+  (() => "1")
 }

--- a/test/files/jvm/patmat_opt_ignore_underscore.flags
+++ b/test/files/jvm/patmat_opt_ignore_underscore.flags
@@ -1,1 +1,1 @@
--optimize
+-optimize -Ybackend:GenASM

--- a/test/files/jvm/patmat_opt_no_nullcheck.flags
+++ b/test/files/jvm/patmat_opt_no_nullcheck.flags
@@ -1,1 +1,1 @@
--optimize
+-optimize -Ybackend:GenASM

--- a/test/files/jvm/patmat_opt_primitive_typetest.flags
+++ b/test/files/jvm/patmat_opt_primitive_typetest.flags
@@ -1,1 +1,1 @@
--optimize
+-optimize -Ybackend:GenASM

--- a/test/files/jvm/t7006/Foo_1.flags
+++ b/test/files/jvm/t7006/Foo_1.flags
@@ -1,1 +1,1 @@
--optimise -Ydebug -Xfatal-warnings
+-optimise -Ydebug -Xfatal-warnings -Ybackend:GenASM

--- a/test/files/neg/t3234.flags
+++ b/test/files/neg/t3234.flags
@@ -1,1 +1,1 @@
--Yinline -Yinline-warnings -Xfatal-warnings
+-Yinline -Yinline-warnings -Xfatal-warnings -Ybackend:GenASM

--- a/test/files/run/private-inline.flags
+++ b/test/files/run/private-inline.flags
@@ -1,1 +1,1 @@
--optimise -Yinline-warnings
+-optimise -Yinline-warnings -Ybackend:GenASM

--- a/test/files/run/synchronized.check
+++ b/test/files/run/synchronized.check
@@ -1,8 +1,3 @@
-#partest !-Ybackend:GenBCode
-warning: there were 14 inliner warnings; re-run with -Yinline-warnings for details
-#partest -Ybackend:GenBCode
-warning: there were 14 inliner warnings; re-run with -Yopt-warnings for details
-#partest
     .|.               c1.f1:     OK
     .|.               c1.fi:     OK
     .|...             c1.fv:     OK

--- a/test/files/run/synchronized.scala
+++ b/test/files/run/synchronized.scala
@@ -1,3 +1,6 @@
+/*
+ * filter: inliner warnings; re-run with
+ */
 import java.lang.Thread.holdsLock
 import scala.collection.mutable.StringBuilder
 

--- a/test/files/run/t6102.check
+++ b/test/files/run/t6102.check
@@ -28,5 +28,10 @@
 [running phase constopt on t6102.scala]
 #partest
 [running phase dce on t6102.scala]
+#partest !-Ybackend:GenBCode
 [running phase jvm on icode]
+#partest -Ybackend:GenBCode
+[running phase jvm on t6102.scala]
+[running phase jvm on t6102.scala]
+#partest
 hello

--- a/test/files/run/t8601-closure-elim.flags
+++ b/test/files/run/t8601-closure-elim.flags
@@ -1,1 +1,1 @@
--optimize -Ydelambdafy:inline
+-optimize -Ydelambdafy:inline -Ybackend:GenASM


### PR DESCRIPTION
- private-inline, t8601-closure-elim, inline-in-constructors
  - test closure inlining / elimination, which is not yet implemented
    in GenBCode. noted in https://github.com/scala-opt/scala/issues/14.
- constant-optimization, t7006
  - no constant folding in GenBCode yet.
    noted in https://github.com/scala-opt/scala/issues/29.
- patmat_opt_ignore_underscore, patmat_opt_no_nullcheck, patmat_opt_primitive_typetest
  - not all optimizations in GenBCode yet.
    noted in https://github.com/scala-opt/scala/issues/30.
- t3234
  - tests a warning of trait inlining - trait inlining works in
    GenBCode
- synchronized
  - ignore inliner warnings (they changed a bit)
- t6102
  - account for the changed outputo of -Ydebug has under GenBCode
