### PR TITLE
fix BigDecimal losing MathContext

### DIFF
--- a/src/library/scala/math/BigDecimal.scala
+++ b/src/library/scala/math/BigDecimal.scala
@@ -49,7 +49,7 @@ object BigDecimal {
   
   /** Constructs a `BigDecimal` using the decimal text representation of `Double` value `d`, rounding if necessary. */
   def decimal(d: Double, mc: MathContext): BigDecimal =
-    new BigDecimal(new BigDec(java.lang.Double.toString(d), mc))
+    new BigDecimal(new BigDec(java.lang.Double.toString(d), mc), mc)
 
   /** Constructs a `BigDecimal` using the decimal text representation of `Double` value `d`. */
   def decimal(d: Double): BigDecimal = decimal(d, defaultMathContext)
@@ -59,7 +59,7 @@ object BigDecimal {
    *  `0.1 != 0.1f`.
    */
   def decimal(f: Float, mc: MathContext): BigDecimal =
-    new BigDecimal(new BigDec(java.lang.Float.toString(f), mc))
+    new BigDecimal(new BigDec(java.lang.Float.toString(f), mc), mc)
 
   /** Constructs a `BigDecimal` using the decimal text representation of `Float` value `f`.
    *  Note that `BigDecimal.decimal(0.1f) != 0.1f` since equality agrees with the `Double` representation, and

--- a/test/junit/scala/math/BigDecimalTest.scala
+++ b/test/junit/scala/math/BigDecimalTest.scala
@@ -228,4 +228,11 @@ class BigDecimalTest {
   def test_SI8970() {
     assert((0.1).## == BigDecimal(0.1).##)
   }
+
+  // Motivated by the problem of MathContext lost
+  @Test
+  def testMathContext() {
+    assert(BigDecimal(1.1d, MC.UNLIMITED).pow(1000) == BigDecimal("1.1", MC.UNLIMITED).pow(1000))
+    assert((BigDecimal(1.23d, new MC(3)) + BigDecimal("0.005")).rounded == BigDecimal("1.24"))
+  }
 }

--- a/test/junit/scala/math/BigDecimalTest.scala
+++ b/test/junit/scala/math/BigDecimalTest.scala
@@ -233,27 +233,28 @@ class BigDecimalTest {
   @Test
   def testMathContext() {
     def testPrecision() {
-      val e = 1000
+      val p = 1000
+      val n = BigDecimal("1.1", MC.UNLIMITED).pow(p)
 
-      val n = BigDecimal("1.1", MC.UNLIMITED).pow(e)
-      assert(BigDecimal(1.1d, MC.UNLIMITED).pow(e) == n)
-      assert(BigDecimal.decimal(1.1d, MC.UNLIMITED).pow(e) == n)
-      assert(BigDecimal.decimal(1.1f, MC.UNLIMITED).pow(e) == n)
-      assert(BigDecimal.decimal(new BD("1.1"), MC.UNLIMITED).pow(e) == n)
+      // BigDecimal(x: Float, mc: MC), which may not do what you want, is deprecated
+      assert(BigDecimal(1.1f, MC.UNLIMITED).pow(p) == BigDecimal(java.lang.Double.toString(1.1f.toDouble), MC.UNLIMITED).pow(p))
+      assert(BigDecimal(1.1d, MC.UNLIMITED).pow(p) == n)
+      assert(BigDecimal(new BD("1.1"), MC.UNLIMITED).pow(p) == n)
 
-      val m = BigDecimal(java.lang.Double.toString(1.1f.toDouble), MC.UNLIMITED).pow(e)
-      assert(BigDecimal(1.1f, MC.UNLIMITED).pow(e) == m) // deprecated
+      assert(BigDecimal.decimal(1.1f, MC.UNLIMITED).pow(p) == n)
+      assert(BigDecimal.decimal(1.1d, MC.UNLIMITED).pow(p) == n)
+      assert(BigDecimal.decimal(new BD("1.1"), MC.UNLIMITED).pow(p) == n)
 
-      val l = BigDecimal("11", MC.UNLIMITED).pow(e)
-      assert(BigDecimal(11, MC.UNLIMITED).pow(e) == l)
-      assert(BigDecimal.decimal(11, MC.UNLIMITED).pow(e) == l)
+      assert((BigDecimal(11, MC.UNLIMITED) / 10).pow(p) == n)
+      assert((BigDecimal.decimal(11, MC.UNLIMITED) / 10).pow(p) == n)
     }
 
     def testRounded() {
+      // the default rounding mode is HALF_UP
+      assert((BigDecimal(1.23f, new MC(3)) + BigDecimal("0.005")).rounded == BigDecimal("1.24")) // deprecated api
       assert((BigDecimal(1.23d, new MC(3)) + BigDecimal("0.005")).rounded == BigDecimal("1.24"))
-      assert((BigDecimal(1.23f, new MC(3)) + BigDecimal("0.005")).rounded == BigDecimal("1.24")) // deprecated
-      assert((BigDecimal.decimal(1.23d, new MC(3)) + BigDecimal("0.005")).rounded == BigDecimal("1.24"))
       assert((BigDecimal.decimal(1.23f, new MC(3)) + BigDecimal("0.005")).rounded == BigDecimal("1.24"))
+      assert((BigDecimal.decimal(1.23d, new MC(3)) + BigDecimal("0.005")).rounded == BigDecimal("1.24"))
     }
 
     testPrecision()

--- a/test/junit/scala/math/BigDecimalTest.scala
+++ b/test/junit/scala/math/BigDecimalTest.scala
@@ -232,7 +232,31 @@ class BigDecimalTest {
   // Motivated by the problem of MathContext lost
   @Test
   def testMathContext() {
-    assert(BigDecimal(1.1d, MC.UNLIMITED).pow(1000) == BigDecimal("1.1", MC.UNLIMITED).pow(1000))
-    assert((BigDecimal(1.23d, new MC(3)) + BigDecimal("0.005")).rounded == BigDecimal("1.24"))
+    def testPrecision() {
+      val e = 1000
+
+      val n = BigDecimal("1.1", MC.UNLIMITED).pow(e)
+      assert(BigDecimal(1.1d, MC.UNLIMITED).pow(e) == n)
+      assert(BigDecimal.decimal(1.1d, MC.UNLIMITED).pow(e) == n)
+      assert(BigDecimal.decimal(1.1f, MC.UNLIMITED).pow(e) == n)
+      assert(BigDecimal.decimal(new BD("1.1"), MC.UNLIMITED).pow(e) == n)
+
+      val m = BigDecimal(java.lang.Double.toString(1.1f.toDouble), MC.UNLIMITED).pow(e)
+      assert(BigDecimal(1.1f, MC.UNLIMITED).pow(e) == m) // deprecated
+
+      val l = BigDecimal("11", MC.UNLIMITED).pow(e)
+      assert(BigDecimal(11, MC.UNLIMITED).pow(e) == l)
+      assert(BigDecimal.decimal(11, MC.UNLIMITED).pow(e) == l)
+    }
+
+    def testRounded() {
+      assert((BigDecimal(1.23d, new MC(3)) + BigDecimal("0.005")).rounded == BigDecimal("1.24"))
+      assert((BigDecimal(1.23f, new MC(3)) + BigDecimal("0.005")).rounded == BigDecimal("1.24")) // deprecated
+      assert((BigDecimal.decimal(1.23d, new MC(3)) + BigDecimal("0.005")).rounded == BigDecimal("1.24"))
+      assert((BigDecimal.decimal(1.23f, new MC(3)) + BigDecimal("0.005")).rounded == BigDecimal("1.24"))
+    }
+
+    testPrecision()
+    testRounded()
   }
 }


### PR DESCRIPTION
The MathContext would be lost in the following statement:
`val d = BigDecimal(0.123, java.math.MathContext.UNLIMITED)`
due to the incorrect implement of
`BigDecimal.decimal(d: Double, mc: MathContext)`
as well as
`BigDecimal.decimal(f: Float, mc: MathContext)`
