### PR TITLE
Fix illegal inlining of instructions accessing protected members

### DIFF
--- a/test/files/run/kmpSliceSearch.flags
+++ b/test/files/run/kmpSliceSearch.flags
@@ -1,0 +1,1 @@
+-Ydelambdafy:inline

--- a/test/files/run/t2106.check
+++ b/test/files/run/t2106.check
@@ -1,3 +1,10 @@
+#partest -Ybackend:GenBCode
+t2106.scala:7: warning: A::foo()Ljava/lang/Object; is annotated @inline but could not be inlined:
+The callee A::foo()Ljava/lang/Object; contains the instruction INVOKEVIRTUAL java/lang/Object.clone ()Ljava/lang/Object;
+that would cause an IllegalAccessError when inlined into class Test$.
+  def main(args: Array[String]): Unit = x.foo
+                                          ^
+#partest !-Ybackend:GenBCode
 t2106.scala:7: warning: Could not inline required method foo because access level required by callee not matched by caller.
   def main(args: Array[String]): Unit = x.foo
                                           ^

--- a/test/files/run/t2106.flags
+++ b/test/files/run/t2106.flags
@@ -1,1 +1,1 @@
--optimise -Yinline-warnings
+-optimise -Yinline-warnings -Yopt:l:classpath


### PR DESCRIPTION
There were two issues in the new inliner that would cause a
VerifyError and an IllegalAccessError.

First, an access to a public member of package protected class C can
only be inlined if the destination class can access C. This is tested
by t7582b.

Second, an access to a protected member requires the receiver object
to be a subtype of the class where the instruction is located. So
when inlining such an access, we need to know the type of the receiver
object - which we don't have. Therefore we don't inline in this case
for now. This can be fixed once we have a type propagation analyis.
https://github.com/scala-opt/scala/issues/13.
This case is tested by t2106.
