### PR TITLE
SI-9332 Iterator.span exhausts leading iterator

### DIFF
--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -154,4 +154,14 @@ class IteratorTest {
     results += (Stream from 1).toIterator.drop(10).toStream.drop(10).toIterator.next()
     assertSameElements(List(1,1,21), results)
   }
+  // SI-9332
+  @Test def spanExhaustsLeadingIterator(): Unit = {
+    def it = Iterator.iterate(0)(_ + 1).take(6)
+    val (x, y) = it.span(_ != 1)
+    val z = x.toList
+    assertEquals(1, z.size)
+    assertFalse(x.hasNext)
+    assertEquals(1, y.next)
+    assertFalse(x.hasNext)   // was true, after advancing underlying iterator
+  }
 }


### PR DESCRIPTION
Since the leading and trailing iterators returned by span
share the underlying iterator, the leading iterator must
flag when it is exhausted (when the span predicate fails)
since the trailing iterator will advance the underlying
iterator.

It would also be possible to leave the failing element in
the leading lookahead buffer, where it would forever fail
the predicate, but that entails evaluating the predicate
twice, on both enqueue and dequeue.
