### PR TITLE
Add flag -Yignore-access-mods to ignore access modifiers

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -364,7 +364,7 @@ trait ScalaSettings extends AbsScalaSettings
   val YpresentationLog     = StringSetting("-Ypresentation-log", "file", "Log presentation compiler events into file", "")
   val YpresentationReplay  = StringSetting("-Ypresentation-replay", "file", "Replay presentation compiler events from file", "")
   val YpresentationDelay   = IntSetting("-Ypresentation-delay", "Wait number of ms after typing before starting typechecking", 0, Some((0, 999)), str => Some(str.toInt))
-
+  val YIgnoreAcessModifier = BooleanSetting("-Yignore-access-mods", "Ignore access flags in toolbox typecheck")
   /**
    * -P "Plugin" settings
    */

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -393,6 +393,8 @@ trait Contexts { self: Analyzer =>
     @inline final def withinSuperInit[T](op: => T): T                      = withMode(enabled = SuperInit)(op)
     @inline final def withinSecondTry[T](op: => T): T                      = withMode(enabled = SecondTry)(op)
     @inline final def withinPatAlternative[T](op: => T): T                 = withMode(enabled = PatternAlternative)(op)
+    @inline final def withAccessModeOff[T](op: => T): T                    = withMode(enabled = AccessModsOff)(op)
+    @inline final def withAccessModeOn[T](op: => T): T                     = withMode(disabled = AccessModsOff)(op)
 
     /** TypeConstructorAllowed is enabled when we are typing a higher-kinded type.
      *  adapt should then check kind-arity based on the prototypical type's kind
@@ -713,7 +715,7 @@ trait Contexts { self: Analyzer =>
         }
       }
 
-      (pre == NoPrefix) || {
+      contextMode.inAny(AccessModsOff) || (pre == NoPrefix) || {
         val ab = sym.accessBoundary(sym.owner)
 
         (  (ab.isTerm || ab == rootMirror.RootClass)
@@ -1535,6 +1537,9 @@ object ContextMode {
 
   /** Are unapplied type constructors allowed here? Formerly HKmode. */
   final val TypeConstructorAllowed: ContextMode   = 1 << 16
+
+  /** Are private and protected modifiers should be turn off during toolbox typecheck. */
+  final val AccessModsOff: ContextMode = 1 << 17
 
   /** TODO: The "sticky modes" are EXPRmode, PATTERNmode, TYPEmode.
    *  To mimick the sticky mode behavior, when captain stickyfingers

--- a/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
+++ b/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
@@ -136,7 +136,11 @@ abstract class ToolBoxFactory[U <: JavaUniverse](val u: U) { factorySelf =>
           val currentTyper     = analyzer.newTyper(analyzer.rootContext(NoCompilationUnit, EmptyTree).make(expr2, owner))
           val withImplicitFlag = if (!withImplicitViewsDisabled) (currentTyper.context.withImplicitsEnabled[Tree] _) else (currentTyper.context.withImplicitsDisabled[Tree] _)
           val withMacroFlag    = if (!withMacrosDisabled) (currentTyper.context.withMacrosEnabled[Tree] _) else (currentTyper.context.withMacrosDisabled[Tree] _)
-          def withContext      (tree: => Tree) = withImplicitFlag(withMacroFlag(tree))
+          val withAccessMode   =
+            if (settings.YIgnoreAcessModifier.isSetByUser) (currentTyper.context.withAccessModeOff[Tree] _)
+            else (currentTyper.context.withAccessModeOn[Tree] _)
+
+          def withContext      (tree: => Tree) = withImplicitFlag(withMacroFlag(withAccessMode(tree)))
 
           val run = new Run
           run.symSource(ownerClass) = NoAbstractFile // need to set file to something different from null, so that currentRun.defines works

--- a/test/junit/scala/reflect/internal/PrivateAccess.scala
+++ b/test/junit/scala/reflect/internal/PrivateAccess.scala
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2014 Contributor. All rights reserved.
+ */
+package scala.reflect.internal
+
+import org.junit.{ Ignore, Test }
+import scala.tools.reflect._
+import scala.reflect.runtime.{ currentMirror => cm }
+import org.junit.Assert._
+
+// For easier test result validation
+trait Stringable {
+  override def toString = getClass.getSimpleName
+}
+
+class TraitResult extends Stringable
+class ClassResult extends Stringable
+
+trait TraitDep extends Stringable {
+  private val privateTraitField = "privateTraitField"
+  protected val protectedTraitField = "protectedTraitField"
+  val publicTraitField = "publicTraitField"
+
+  private def privateTraitMethod = "traitMethod"
+
+  protected def protectedTraitMethod = "traitMethod"
+
+  def publicTraitMethod = "publicTraitMethod"
+
+  private val privateTraitProtectedClass = new TraitResult
+  protected val protectedTraitPrivateClass = new TraitResult
+  private val privateTraitPrivateClass = new TraitResult
+  val publicTraitPrivateClass = new TraitResult
+  private val privateTraitPublicClass = new TraitResult
+}
+
+class ClassDep extends Stringable {
+  private val privateClassField = "privateClassField"
+  protected val protectedClassField = "protectedClassField"
+  val publicClassField = "publicClassField"
+
+  private def privateClassMethod = "classMethod"
+
+  protected def protectedClassMethod = "classMethod"
+
+  def publicClassMethod = "publicClassMethod"
+
+  protected val privateTraitProtectedClass =new  ClassResult
+  private val protectedTraitPrivateClass = new ClassResult
+  private val privateTraitPrivateClass = new ClassResult
+  private val publicTraitPrivateClass = new ClassResult
+  val privateTraitPublicClass = new ClassResult
+}
+
+object Libs extends ClassDep with TraitDep {
+  private val privateObjectField = "privateObjectField"
+  protected val protectedObjectField = "protectedObjectField"
+  val publicObjectField = "publicObjectField"
+
+  private def privateObjectMethod = "objectMethod"
+
+  protected def protectedObjectMethod = "objectMethod"
+
+  def publicObjectMethod = "publicObjectMethod"
+}
+
+class PrivateAccess {
+
+  lazy val toolbox = cm.mkToolBox(options = "-Yignore-access-mods")
+
+  private def addImports(code: String) = s"import scala.reflect.internal._ \n $code"
+
+  def shouldOnlyTypcheck(code: String, expectedType: Option[String] = None) = {
+    val fullCode = addImports(code)
+    val parsed = toolbox.parse(fullCode)
+    val tree = toolbox.typecheck(parsed)
+
+    expectedType.foreach(expected => assertEquals(expected, tree.tpe.toString))
+
+    try {
+      val parsed2 = toolbox.parse(fullCode)
+      toolbox.compile(parsed2)
+      fail("Expression should not compile. Flag should works only in typecheck")
+    } catch {
+      case te: ToolBoxError =>
+    }
+  }
+
+  def shouldCompile(code: String, expectedType: Option[String] = None): Unit = {
+    val parsed = toolbox.parse(addImports(code))
+    val tree = toolbox.typecheck(parsed)
+
+    expectedType.foreach(expected => assertEquals(expected, tree.tpe.toString))
+
+    val parsed2 = toolbox.parse(addImports(code))
+    toolbox.compile(parsed2)
+  }
+
+  def checkResult(code: String, result: String): Unit = {
+    val parsed = toolbox.parse(addImports(code))
+    val compiled = toolbox.compile(parsed)
+
+    assertEquals("Result differs", compiled().toString, result)
+  }
+
+  @Ignore("Add support for private member from parent classes/traits")
+  @Test
+  def privateTraitField(): Unit = shouldOnlyTypcheck("Libs.privateTraitField")
+
+  @Ignore("Add support for private member from parent classes/traits")
+  @Test
+  def privateClassField(): Unit = shouldOnlyTypcheck("Libs.privateClassField")
+
+  @Test
+  def privateObjectField(): Unit = shouldOnlyTypcheck("Libs.privateObjectField")
+
+  @Ignore("Add support for private member from parent classes/traits")
+  @Test
+  def privateTraitMethod(): Unit = shouldOnlyTypcheck("Libs.privateTraitMethod")
+
+  @Ignore("Add support for private member from parent classes/traits")
+  @Test
+  def privateClassMethod(): Unit = shouldOnlyTypcheck("Libs.privateClassMethod")
+
+  @Test
+  def privateObjectMethod(): Unit = shouldOnlyTypcheck("Libs.privateObjectMethod")
+
+  @Test
+  def testProtectedMember(): Unit = shouldOnlyTypcheck("Libs.protectedTraitField")
+
+  @Test
+  def protectedClassField(): Unit = shouldOnlyTypcheck("Libs.protectedClassField")
+
+  @Test
+  def protectedObjectField(): Unit = shouldOnlyTypcheck("Libs.protectedObjectField")
+
+
+  @Test
+  def protectedTraitMethod(): Unit = shouldOnlyTypcheck("Libs.protectedTraitMethod")
+
+  @Test
+  def protectedClassMethod(): Unit = shouldOnlyTypcheck("Libs.protectedClassMethod")
+
+  @Test
+  def protectedObjectMethod(): Unit = shouldOnlyTypcheck("Libs.protectedObjectMethod")
+
+  @Test
+  def importedProtectedObjectMethod(): Unit = shouldOnlyTypcheck("import Libs._; protectedObjectMethod")
+
+  @Test
+  def publicTraitField(): Unit = checkResult("Libs.publicTraitField", "publicTraitField")
+
+  @Test
+  def publicClassField(): Unit = checkResult("Libs.publicClassField", "publicClassField")
+
+  @Test
+  def publicObjectField(): Unit = checkResult("Libs.publicObjectField", "publicObjectField")
+
+  @Test
+  def publicTraitMethod(): Unit = checkResult("Libs.publicTraitMethod", "publicTraitMethod")
+
+  @Test
+  def publicClassMethod(): Unit = checkResult("Libs.publicClassMethod", "publicClassMethod")
+
+  @Test
+  def publicObjectMethod(): Unit = checkResult("Libs.publicObjectMethod", "publicObjectMethod")
+
+  @Test
+  def privateTraitProtectedClass(): Unit =
+    shouldOnlyTypcheck("Libs.privateTraitProtectedClass", Some("scala.reflect.internal.ClassResult"))
+
+  @Test
+  def protectedTraitPrivateClass(): Unit =
+    shouldOnlyTypcheck("Libs.protectedTraitPrivateClass", Some("scala.reflect.internal.TraitResult"))
+
+  @Ignore("Add support for private member from parent classes/traits")
+  @Test
+  def privateTraitPrivateClass(): Unit =
+    shouldOnlyTypcheck("Libs.privateTraitPrivateClass", Some("scala.reflect.internal.ClassResult"))
+
+  @Test
+  def publicTraitPrivateClass(): Unit =
+    shouldCompile("Libs.publicTraitPrivateClass", Some("scala.reflect.internal.TraitResult"))
+
+  @Test
+  def privateTraitPublicClass(): Unit =
+    shouldCompile("Libs.privateTraitPublicClass", Some("scala.reflect.internal.ClassResult"))
+}


### PR DESCRIPTION
Add flag -Yignore-access-mods to ignore access modifiers (private and protected) for typecheck in toolbox.

Currently private methods from parent classes/traits are still unaccessible.
For testing in ScalaIDE version was downgrade to 2.11.6.

Lastly, the below disclaimer is required by the lawyers:

THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE:
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
ONLY THE SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE, IF ANY, THAT ARE ATTACHED TO (OR OTHERWISE ACCOMPANY) THIS SUBMISSION (AND ORDINARY COURSE CONTRIBUTIONS OF FUTURES PATCHES THERETO) ARE TO BE CONSIDERED A CONTRIBUTION. NO OTHER SOFTWARE CODE OR MATERIALS ARE A CONTRIBUTION.
