### PR TITLE
Applying inverse index instead of reversing a List

### DIFF
--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -56,12 +56,12 @@ class Queue[+A] protected(protected val in: List[A], protected val out: List[A])
    *  @throws java.util.NoSuchElementException if the queue is too short.
    */
   override def apply(n: Int): A = {
-    val len = out.length
-    if (n < len) out.apply(n)
+    val olen = out.length
+    if (n < olen) out.apply(n)
     else {
-      val m = n - len
-      val l = in.length
-      if (m < l) in.apply(l - m - 1)
+      val m = n - olen
+      val ilen = in.length
+      if (m < ilen) in.apply(ilen - m - 1)
       else throw new NoSuchElementException("index out of range")
     }
   }

--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -60,7 +60,8 @@ class Queue[+A] protected(protected val in: List[A], protected val out: List[A])
     if (n < len) out.apply(n)
     else {
       val m = n - len
-      if (m < in.length) in.reverse.apply(m)
+      val l = in.length
+      if (m < l) in.apply(l - m - 1)
       else throw new NoSuchElementException("index out of range")
     }
   }


### PR DESCRIPTION
It is a very simple change. Every `Seq` is a function, also `Queue`. I changed the `Queue.appy(index)` method in the way that no intermediate objects are created any more when the index is located within the `in` List of the Queue (this is the List where elements are enqueued).

The improvement is technically accomplished by calculating the _inverse_ index instead of reversing the whole `in` List, i.e. no additional objects are created any more.
