### PR TITLE
SI-9343 Xlint less strict on pattern sequences

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/ScalacPatternExpanders.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/ScalacPatternExpanders.scala
@@ -112,8 +112,10 @@ trait ScalacPatternExpanders {
         arityError("not enough")
       else if (elementArity > 0 && !isSeq)
         arityError("too many")
-      else if (settings.warnStarsAlign && isSeq && productArity > 0 && (elementArity > 0 || !isStar))
-        warn("A repeated case parameter or extracted sequence should be matched only by a sequence wildcard (_*).")
+      else if (settings.warnStarsAlign && isSeq && productArity > 0 && elementArity > 0) warn {
+        if (isStar) "Sequence wildcard (_*) does not align with repeated case parameter or extracted sequence; the result may be unexpected."
+        else "A repeated case parameter or extracted sequence is not matched by a sequence wildcard (_*), and may fail at runtime."
+      }
 
       aligned
     }

--- a/test/files/neg/t7623.check
+++ b/test/files/neg/t7623.check
@@ -1,21 +1,15 @@
-t7623.scala:19: warning: A repeated case parameter or extracted sequence should be matched only by a sequence wildcard (_*).
-  def f = "" match { case X(s) => }
+t7623.scala:21: warning: A repeated case parameter or extracted sequence is not matched by a sequence wildcard (_*), and may fail at runtime.
+  def g = "" match { case X(s, t) => }               // warn
                           ^
-t7623.scala:21: warning: A repeated case parameter or extracted sequence should be matched only by a sequence wildcard (_*).
-  def g = "" match { case X(s, t) => }
+t7623.scala:23: warning: Sequence wildcard (_*) does not align with repeated case parameter or extracted sequence; the result may be unexpected.
+  def h = "" match { case X(s, t, u @ _*) => }       // warn
                           ^
-t7623.scala:23: warning: A repeated case parameter or extracted sequence should be matched only by a sequence wildcard (_*).
-  def h = "" match { case X(s, t, u @ _*) => }
-                          ^
-t7623.scala:9: warning: A repeated case parameter or extracted sequence should be matched only by a sequence wildcard (_*).
-  def f = C("") match { case C(s) => }
+t7623.scala:11: warning: A repeated case parameter or extracted sequence is not matched by a sequence wildcard (_*), and may fail at runtime.
+  def g = C("") match { case C(s, t) => }            // warn
                              ^
-t7623.scala:11: warning: A repeated case parameter or extracted sequence should be matched only by a sequence wildcard (_*).
-  def g = C("") match { case C(s, t) => }
-                             ^
-t7623.scala:13: warning: A repeated case parameter or extracted sequence should be matched only by a sequence wildcard (_*).
-  def h = C("") match { case C(s, t, u @ _*) => }
+t7623.scala:13: warning: Sequence wildcard (_*) does not align with repeated case parameter or extracted sequence; the result may be unexpected.
+  def h = C("") match { case C(s, t, u @ _*) => }    // warn
                              ^
 error: No warnings can be incurred under -Xfatal-warnings.
-6 warnings found
+four warnings found
 one error found

--- a/test/files/neg/t7623.scala
+++ b/test/files/neg/t7623.scala
@@ -8,9 +8,9 @@ object X { def unapplySeq(a: Any): Option[(String, Seq[Int])] = Some("", List(1,
 trait Ctest {
   def f = C("") match { case C(s) => }
 
-  def g = C("") match { case C(s, t) => }
+  def g = C("") match { case C(s, t) => }            // warn
 
-  def h = C("") match { case C(s, t, u @ _*) => }
+  def h = C("") match { case C(s, t, u @ _*) => }    // warn
 
   def ok = C("") match { case C(s, u @ _*) => }
 }
@@ -18,9 +18,9 @@ trait Ctest {
 trait Xtest {
   def f = "" match { case X(s) => }
 
-  def g = "" match { case X(s, t) => }
+  def g = "" match { case X(s, t) => }               // warn
 
-  def h = "" match { case X(s, t, u @ _*) => }
+  def h = "" match { case X(s, t, u @ _*) => }       // warn
 
   def ok = "" match { case X(s, u @ _*) => }
 }


### PR DESCRIPTION
-Xlint:stars-align warns only if elementarity > 0, that is,
if an extracted sequence is not matched entirely by a pattern
sequence, that is, in SLS 8.1.9 on pattern sequences, n = 1
and that pattern is a pattern sequence.

This is still only triggered if productarity > 0, that is,
a non-pattern-sequence pattern is required for the match.

This is a sensitive area because it borders on exhaustiveness
checking: it would be preferable to verify just that the match
is exhaustive, and to emit this warning only if it is not.
