### PR TITLE
[ SI-7514 ] Introduce Source.fromClassPath(resource) method

### DIFF
--- a/src/library/scala/io/Source.scala
+++ b/src/library/scala/io/Source.scala
@@ -167,6 +167,12 @@ object Source {
 
   def fromInputStream(is: InputStream)(implicit codec: Codec): BufferedSource =
     createBufferedSource(is, reset = () => fromInputStream(is)(codec), close = () => is.close())(codec)
+
+  def fromClassPath(resource: String, classLdr: ClassLoader = ClassLoader.getSystemClassLoader)(implicit codec: Codec): BufferedSource = {
+    val is = classLdr.getResourceAsStream(resource)
+    createBufferedSource(is, reset = () => fromInputStream(is)(codec), close = () => is.close())(codec)
+  }
+
 }
 
 /** An iterable representation of source data.

--- a/test/junit/scala/io/SourceTest.scala
+++ b/test/junit/scala/io/SourceTest.scala
@@ -28,6 +28,10 @@ class SourceTest {
   @Test def canIterateLines() = {
     assertEquals(sampler.lines.size, (Source fromString sampler).getLines.size)
   }
+  @Test def loadFromClassPath() = {
+    val res = Source.fromClassPath("rootdoc.txt")
+    assertTrue("No classpath resource found", res.getLines().size > 5)
+  }
   @Test def canCustomizeReporting() = {
     class CapitalReporting(is: InputStream) extends BufferedSource(is) {
       override def report(pos: Int, msg: String, out: PrintStream): Unit = {


### PR DESCRIPTION
Returns Source from named classpath resource
Simplifies

 val src = io.Source.fromInputStream(classOf[ClassInst].getResourceAsStream("/name"))

to

 val src = io.Source.fromClassPath("/name")
