### PR TITLE
SI-7773 Restore phase id to icode filename

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1675,23 +1675,25 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
   def getFile(clazz: Symbol, suffix: String): File = getFile(clazz.sourceFile, clazz.fullName split '.', suffix)
 
   private def writeICode() {
-    val printer = new icodes.TextPrinter(null, icodes.linearizer)
-    icodes.classes.values.foreach((cls) => {
-      val moduleSfx = if (cls.symbol.hasModuleFlag) "$" else ""
-      val phaseSfx  = if (settings.debug) phase else "" // only for debugging, appending the full phasename breaks windows build
-      val file      = getFile(cls.symbol, s"$moduleSfx$phaseSfx.icode")
+    val printer = new icodes.TextPrinter(writer = null, icodes.linearizer)
+    icodes.classes.values foreach { cls =>
+      val file = {
+        val module = if (cls.symbol.hasModuleFlag) "$" else ""
+        val faze   = if (settings.debug) phase.name else f"${phase.id}%02d" // avoid breaking windows build with long filename
+        getFile(cls.symbol, s"$module-$faze.icode")
+      }
 
       try {
         val stream = new FileOutputStream(file)
         printer.setWriter(new PrintWriter(stream, true))
         printer.printClass(cls)
-        informProgress("wrote " + file)
+        informProgress(s"wrote $file")
       } catch {
-        case ex: IOException =>
-          if (settings.debug) ex.printStackTrace()
-        globalError("could not write file " + file)
+        case e: IOException =>
+          if (settings.debug) e.printStackTrace()
+          globalError(s"could not write file $file")
       }
-    })
+    }
   }
   def createJavadoc    = false
 }


### PR DESCRIPTION
Having icode output files of the form `X-24.icode` went in and
out of style using the long-form phase name because it broke
the windows nightly build somehow. Here's hoping using just the
phase id works on this year's infrastructure.

As previously, the long name is still available under `-Ydebug`,
because why not debug.
