### PR TITLE
SI-9350 Command option -Xreporter for custom error reporter

### DIFF
--- a/src/compiler/scala/tools/nsc/Driver.scala
+++ b/src/compiler/scala/tools/nsc/Driver.scala
@@ -1,7 +1,7 @@
 package scala
 package tools.nsc
 
-import scala.tools.nsc.reporters.ConsoleReporter
+import scala.tools.nsc.reporters.{ ConsoleReporter, Reporter }
 import Properties.{ versionMsg, residentPromptString }
 import scala.reflect.internal.util.FakePos
 
@@ -9,39 +9,43 @@ abstract class Driver {
 
   val prompt = residentPromptString
 
-  var reporter: ConsoleReporter = _
+  var reporter: Reporter = _
   protected var command: CompilerCommand = _
   protected var settings: Settings = _
 
+  /** Forward errors to the (current) reporter. */
   protected def scalacError(msg: String): Unit = {
     reporter.error(FakePos("scalac"), msg + "\n  scalac -help  gives more information")
   }
 
+  /** True to continue compilation. */
   protected def processSettingsHook(): Boolean = {
-    if (settings.version) { reporter echo versionMsg ; false } else true
+    if (settings.version) { reporter echo versionMsg ; false }
+    else !reporter.hasErrors
   }
 
   protected def newCompiler(): Global
 
-  protected def doCompile(compiler: Global) {
+  protected def doCompile(compiler: Global): Unit = {
     if (command.files.isEmpty) {
       reporter.echo(command.usageMsg)
       reporter.echo(compiler.pluginOptionsHelp)
     } else {
       val run = new compiler.Run()
       run compile command.files
-      reporter.printSummary()
+      reporter.finish()
     }
   }
 
-  def process(args: Array[String]) {
+  def process(args: Array[String]): Boolean = {
     val ss   = new Settings(scalacError)
-    reporter = new ConsoleReporter(ss)
+    reporter = new ConsoleReporter(ss)    // for reporting early config errors, before compiler is constructed
     command  = new CompilerCommand(args.toList, ss)
     settings = command.settings
 
     if (processSettingsHook()) {
       val compiler = newCompiler()
+      reporter     = compiler.reporter    // adopt the configured reporter
       try {
         if (reporter.hasErrors)
           reporter.flush()
@@ -57,11 +61,9 @@ abstract class Driver {
             case _                => throw ex // unexpected error, tell the outside world.
           }
       }
-    }
+    } else if (reporter.hasErrors) reporter.flush()
+    !reporter.hasErrors
   }
 
-  def main(args: Array[String]) {
-    process(args)
-    sys.exit(if (reporter.hasErrors) 1 else 0)
-  }
+  def main(args: Array[String]): Unit = sys.exit(if (process(args)) 0 else 1)
 }

--- a/src/compiler/scala/tools/nsc/Main.scala
+++ b/src/compiler/scala/tools/nsc/Main.scala
@@ -17,7 +17,8 @@ class MainClass extends Driver with EvalLoop {
     new compiler.Run() compile command.files
   }
 
-  override def newCompiler(): Global = Global(settings, reporter)
+  override def newCompiler(): Global = Global(settings)
+
   override def doCompile(compiler: Global) {
     if (settings.resident) resident(compiler)
     else super.doCompile(compiler)

--- a/src/compiler/scala/tools/nsc/reporters/ConsoleReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/ConsoleReporter.scala
@@ -11,8 +11,7 @@ import java.io.{ BufferedReader, IOException, PrintWriter }
 import scala.reflect.internal.util._
 import StringOps._
 
-/**
- * This class implements a Reporter that displays messages on a text console.
+/** This class implements a Reporter that displays messages on a text console.
  */
 class ConsoleReporter(val settings: Settings, reader: BufferedReader, writer: PrintWriter) extends AbstractReporter {
   def this(settings: Settings) = this(settings, Console.in, new PrintWriter(Console.err, true))
@@ -85,5 +84,7 @@ class ConsoleReporter(val settings: Settings, reader: BufferedReader, writer: Pr
     }
   }
 
-  override def flush() { writer.flush() }
+  override def flush() = writer.flush()
+
+  override def finish() = printSummary()
 }

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -134,6 +134,7 @@ trait ScalaSettings extends AbsScalaSettings
   val Xshowobj           = StringSetting       ("-Xshow-object", "object", "Show internal representation of object.", "")
   val showPhases         = BooleanSetting      ("-Xshow-phases", "Print a synopsis of compiler phases.")
   val sourceReader       = StringSetting       ("-Xsource-reader", "classname", "Specify a custom method for reading source files.", "")
+  val reporter           = StringSetting       ("-Xreporter", "classname", "Specify a custom reporter for compiler messages.", "scala.tools.nsc.reporters.ConsoleReporter")
   val strictInference    = BooleanSetting      ("-Xstrict-inference", "Don't infer known-unsound types")
   val source             = ScalaVersionSetting ("-Xsource", "version", "Treat compiler input as Scala source for the specified version, see SI-8126.", initial = ScalaVersion("2.11"))
 

--- a/src/reflect/scala/reflect/internal/Reporting.scala
+++ b/src/reflect/scala/reflect/internal/Reporting.scala
@@ -8,11 +8,11 @@ package reflect
 package internal
 
 /** Provides delegates to the reporter doing the actual work.
- * All forwarding methods should be marked final,
- * but some subclasses out of our reach stil override them.
+ *  All forwarding methods should be marked final,
+ *  but some subclasses out of our reach stil override them.
  *
- * Eventually, this interface should be reduced to one method: `reporter`,
- * and clients should indirect themselves (reduce duplication of forwarders).
+ *  Eventually, this interface should be reduced to one method: `reporter`,
+ *  and clients should indirect themselves (reduce duplication of forwarders).
  */
 trait Reporting { self : Positions =>
   def reporter: Reporter
@@ -71,8 +71,8 @@ import util.Position
 
 /** Report information, warnings and errors.
  *
- * This describes the (future) external interface for issuing information, warnings and errors.
- * Currently, scala.tools.nsc.Reporter is used by sbt/ide/partest.
+ *  This describes the (future) external interface for issuing information, warnings and errors.
+ *  Currently, scala.tools.nsc.Reporter is used by sbt/ide/partest.
  */
 abstract class Reporter {
   protected def info0(pos: Position, msg: String, severity: Severity, force: Boolean): Unit
@@ -101,7 +101,10 @@ abstract class Reporter {
     resetCount(ERROR)
   }
 
-  def flush(): Unit = { }
+  def flush(): Unit = ()
+
+  /** Finish reporting: print summaries, release resources. */
+  def finish(): Unit = ()
 }
 
 // TODO: move into superclass once partest cuts tie on Severity

--- a/src/reflect/scala/reflect/internal/util/ScalaClassLoader.scala
+++ b/src/reflect/scala/reflect/internal/util/ScalaClassLoader.scala
@@ -11,7 +11,8 @@ import java.lang.reflect.{ Constructor, Modifier, Method }
 import java.io.{ File => JFile }
 import java.net.{ URLClassLoader => JURLClassLoader }
 import java.net.URL
-import scala.reflect.runtime.ReflectionUtils.unwrapHandler
+import scala.reflect.internal.FatalError
+import scala.reflect.runtime.ReflectionUtils.{ show, unwrapHandler }
 import ScalaClassLoader._
 import scala.util.control.Exception.{ catching }
 import scala.language.implicitConversions
@@ -45,6 +46,35 @@ trait ScalaClassLoader extends JClassLoader {
   /** Create an instance of a class with this classloader */
   def create(path: String): AnyRef =
     tryToInitializeClass[AnyRef](path).map(_.newInstance()).orNull
+
+  /** Create an instance with ctor args, or invoke errorFn before throwing FatalError. */
+  def create[T <: AnyRef : ClassTag](path: String, errorFn: String => Unit)(args: AnyRef*): T = {
+    def fail(msg: String) = {
+      errorFn(msg)
+      throw FatalError(msg)
+    }
+    try {
+      val clazz = Class.forName(path, /*initialize =*/ true, /*loader =*/ this)
+      if (classTag[T].runtimeClass isAssignableFrom clazz) {
+        val ctor = {
+          val maybes = clazz.getConstructors filter (c => c.getParameterCount == args.size &&
+            (c.getParameterTypes zip args).forall { case (k, a) => k isAssignableFrom a.getClass })
+          if (maybes.size == 1) maybes.head
+          else fail(s"Constructor must accept arg list (${args map (_.getClass.getName) mkString ", "}): ${path}")
+        }
+        (ctor.newInstance(args: _*)).asInstanceOf[T]
+      } else {
+        errorFn(s"""Loader for ${classTag[T]}:   [${show(classTag[T].runtimeClass.getClassLoader)}]
+                   |Loader for ${clazz.getName}: [${show(clazz.getClassLoader)}]""".stripMargin)
+        fail(s"Not a ${classTag[T]}: ${path}")
+      }
+    } catch {
+      case _: ClassNotFoundException =>
+        fail(s"Class not found: ${path}")
+      case e @ (_: LinkageError | _: ReflectiveOperationException) =>
+        fail(s"Unable to create instance: ${path}: ${e.toString}")
+    }
+  }
 
   /** The actual bytes for a class file, or an empty array if it can't be found. */
   def classBytes(className: String): Array[Byte] = classAsStream(className) match {


### PR DESCRIPTION
Add a setting to take a custom Reporter.

Basic usage works:

```
import scala.tools.nsc.Settings
import scala.tools.nsc.reporters.ConsoleReporter

import scala.reflect.internal.util._

class MyReporter(ss: Settings) extends ConsoleReporter(ss) {
  var deprecationCount = 0
  override def warning(pos: Position, msg: String): Unit = {
    if (msg contains "is deprecated") deprecationCount += 1
    super.warning(pos, msg)
  }
  override def hasWarnings: Boolean = count(WARNING) - deprecationCount > 0
  override def reset() = { deprecationCount = 0 ; super.reset() }
}
```

and

```
$ scalac -toolcp . -Xreporter myrep.MyReporter -Xfatal-warnings -deprecation test.scala
test.scala:8: warning: class C in package tester is deprecated: Don't use me
  Console println s"${new C}"
                          ^
one warning found
```

Review by @adriaanm 
