### PR TITLE
Fix toolbox with varargs constructors

### DIFF
--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -1184,6 +1184,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
       constr setInfo GenPolyType(tparams, MethodType(clazz.newSyntheticValueParams(paramtpes), clazz.tpe))
       propagatePackageBoundary(jconstr.javaFlags, constr)
       copyAnnotations(constr, jconstr)
+      if (jconstr.javaFlags.isVarargs) constr modifyInfo arrayToRepeated
       markAllCompleted(constr)
       constr
     }

--- a/test/files/run/toolbox-varargs/Test.scala
+++ b/test/files/run/toolbox-varargs/Test.scala
@@ -1,0 +1,13 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+     import scala.tools.reflect.ToolBox
+     val m = reflect.runtime.currentMirror
+     val u = m.universe
+     import u._
+     val tb = m.mkToolBox();
+     tb.compile(q"new p.Varargs(null, null)")
+     tb.compile(q"p.Varargs.staticMethod(null, null)")
+     tb.compile(q"(null: p.Varargs).instanceMethod(null, null)")
+  }
+}
+

--- a/test/files/run/toolbox-varargs/Varargs.java
+++ b/test/files/run/toolbox-varargs/Varargs.java
@@ -1,0 +1,8 @@
+package p;
+
+public class Varargs {
+	public Varargs(String... args) {}
+	public static void staticMethod(String... args) {}
+
+	public void instanceMethod(String... args) {}
+}


### PR DESCRIPTION
It was already working for methods, but not for constructors.

Review by @xeno-by
