### PR TITLE
SI-9339 Use the scala-jline fork

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -376,7 +376,7 @@ TODO:
       </artifact:dependencies>
 
       <artifact:dependencies pathId="repl.deps.classpath" filesetId="repl.fileset" versionsId="repl.deps.versions">
-        <dependency groupId="jline" artifactId="jline" version="${jline.version}"/>
+        <dependency groupId="org.scala-lang.modules" artifactId="scala-jline" version="${jline.version}"/>
       </artifact:dependencies>
       <copy-deps project="repl"/>
 

--- a/src/build/bnd/scala-compiler.bnd
+++ b/src/build/bnd/scala-compiler.bnd
@@ -3,7 +3,7 @@ Bundle-SymbolicName: org.scala-lang.scala-compiler
 ver: @VERSION@
 Bundle-Version: ${ver}
 Export-Package: *;version=${ver}
-Import-Package: jline.*;resolution:=optional, \
+Import-Package: scala.tools.jline.*;resolution:=optional, \
                 org.apache.tools.ant.*;resolution:=optional, \
                 scala.util.parsing.*;version="${range;[====,====];@PARSER_COMBINATORS_VERSION@}";resolution:=optional, \
                 scala.xml.*;version="${range;[====,====];@XML_VERSION@}";resolution:=optional, \

--- a/src/build/maven/scala-compiler-pom.xml
+++ b/src/build/maven/scala-compiler-pom.xml
@@ -51,8 +51,8 @@
       <version>@PARSER_COMBINATORS_VERSION@</version>
     </dependency>
     <dependency> <!-- for scala-compiler-repl; once it moves there, make it required -->
-      <groupId>jline</groupId>
-      <artifactId>jline</artifactId>
+      <groupId>org.scala-lang.modules</groupId>
+      <artifactId>scala-jline</artifactId>
       <version>@JLINE_VERSION@</version>
       <optional>true</optional>
     </dependency>

--- a/src/repl/scala/tools/nsc/interpreter/ConsoleReaderHelper.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ConsoleReaderHelper.scala
@@ -6,7 +6,7 @@
 package scala.tools.nsc
 package interpreter
 
-import jline.console.{ ConsoleReader, CursorBuffer }
+import scala.tools.jline.console.{ ConsoleReader, CursorBuffer }
 
 trait ConsoleReaderHelper { _: ConsoleReader with Tabulator =>
   def isAcross: Boolean

--- a/src/repl/scala/tools/nsc/interpreter/Delimited.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Delimited.scala
@@ -6,7 +6,7 @@
 package scala.tools.nsc
 package interpreter
 
-import jline.console.completer.ArgumentCompleter.{ ArgumentDelimiter, ArgumentList }
+import scala.tools.jline.console.completer.ArgumentCompleter.{ ArgumentDelimiter, ArgumentList }
 
 class JLineDelimiter extends ArgumentDelimiter {
   def toJLine(args: List[String], cursor: Int) = args match {

--- a/src/repl/scala/tools/nsc/interpreter/JLineReader.scala
+++ b/src/repl/scala/tools/nsc/interpreter/JLineReader.scala
@@ -6,8 +6,8 @@
 package scala.tools.nsc
 package interpreter
 
-import jline.console.ConsoleReader
-import jline.console.completer._
+import scala.tools.jline.console.ConsoleReader
+import scala.tools.jline.console.completer._
 import session._
 import Completion._
 

--- a/src/repl/scala/tools/nsc/interpreter/session/package.scala
+++ b/src/repl/scala/tools/nsc/interpreter/session/package.scala
@@ -14,10 +14,10 @@ package object session {
   type JIterator[T]       = java.util.Iterator[T]
   type JListIterator[T]   = java.util.ListIterator[T]
 
-  type JEntry             = jline.console.history.History.Entry
-  type JHistory           = jline.console.history.History
-  type JMemoryHistory     = jline.console.history.MemoryHistory
-  type JPersistentHistory = jline.console.history.PersistentHistory
+  type JEntry             = scala.tools.jline.console.history.History.Entry
+  type JHistory           = scala.tools.jline.console.history.History
+  type JMemoryHistory     = scala.tools.jline.console.history.MemoryHistory
+  type JPersistentHistory = scala.tools.jline.console.history.PersistentHistory
 
   private[interpreter] implicit def charSequenceFix(x: CharSequence): String = x.toString
 }

--- a/test/files/jvm/innerClassEnclMethodJavaReflection.scala
+++ b/test/files/jvm/innerClassEnclMethodJavaReflection.scala
@@ -9,7 +9,7 @@ object Test extends App {
     // not on the classpath. We just skip over those classes.
     // PENDING: for now we also allow missing $anonfun classes: the optimizer may eliminate some closures
     // that are refferred to in EnclosingClass attributes. SI-9136
-    val allowedMissingPackages = Set("jline", "org.apache.tools.ant", "$anonfun")
+    val allowedMissingPackages = Set("scala.tools.jline", "org.apache.tools.ant", "$anonfun")
 
     def ok(t: Throwable) = {
       allowedMissingPackages.exists(p => t.getMessage.replace('/', '.').contains(p))


### PR DESCRIPTION
The scala compiler depending on a jline release pollutes the classpath
of projects that embed the scala compiler or REPL, such as the spark
REPL. The scala-jline fork is identical to official jline, but with
the package name changed to scala.tools.jline.

For reference, the PR that removed jline from the scala repository
and introduced stock jline was #2704.

JLine fork [here](https://github.com/scala/scala-jline), I added some information to the README.
