### PR TITLE
Implicit enrichment as alternative to broken Either projection APIs

### DIFF
--- a/src/library/scala/util/Either.scala
+++ b/src/library/scala/util/Either.scala
@@ -636,7 +636,14 @@ object Either {
       implicit final class Ops[A,B]( src : Either[A,B] )( implicit opsTypeClass : Either.RightBias.withEmptyToken.Generic[A] ) extends AbstractOps( src )( opsTypeClass );
 
       trait Generic[+E] extends Either.WithEmpty[E]{
-        protected def leftEmpty : Left[E,Nothing] = Left(empty);
+        /*
+         * In order to meet the contract of withFilter(...) [from which this method is called],
+         * no object allocation should occur on each non-Exception-raising call of this method.
+         * Raising an exception is "fine" (in that it represents a hackish violation of the contract
+         * anyway), as is overriding this with a val. But no new Left should be created on each
+         * invocation.
+         */ 
+        protected def leftEmpty : Left[E,Nothing];
 
         // monad ops
         def flatMap[A>:E,AA>:A,B,Z]( src : Either[A,B] )( f : B => Either[AA,Z] ) : Either[AA,Z] = {
@@ -710,6 +717,8 @@ object Either {
         def apply( throwableBuilder : =>java.lang.Throwable ) : Throwing = new Throwing( throwableBuilder );
       }
       final class Throwing private( throwableBuilder : =>java.lang.Throwable ) extends withEmptyToken.Generic[Nothing] {
+        override protected def leftEmpty : Nothing = empty;
+
         override def empty : Nothing = throw throwableBuilder;
       }
     }
@@ -968,7 +977,14 @@ object Either {
       implicit final class Ops[A,B]( src : Either[A,B] )( implicit opsTypeClass : Either.LeftBias.withEmptyToken.Generic[B] ) extends AbstractOps( src )( opsTypeClass );
 
       trait Generic[+E] extends Either.WithEmpty[E]{
-        protected def rightEmpty : Right[Nothing,E] = Right(empty);
+        /*
+         * In order to meet the contract of withFilter(...) [from which this method is called],
+         * no object allocation should occur on each non-Exception-raising call of this method.
+         * Raising an exception is "fine" (in that it represents a hackish violation of the contract
+         * anyway), as is overriding this with a val. But no new Right should be created on each
+         * invocation.
+         */ 
+        protected def rightEmpty : Right[Nothing,E]; 
 
         // monad ops
         def flatMap[A, B>:E, BB>:B ,Z]( src : Either[A,B] )( f : A => Either[Z,BB] ) : Either[Z,BB] = {
@@ -1064,6 +1080,8 @@ object Either {
         * For more, please see [[LeftBias$ LeftBias]].
         */
       final class Throwing private( throwableBuilder : =>java.lang.Throwable ) extends withEmptyToken.Generic[Nothing] {
+        override protected def rightEmpty : Nothing = empty;
+
         override def empty : Nothing = throw throwableBuilder;
       }
     }

--- a/src/library/scala/util/Either.scala
+++ b/src/library/scala/util/Either.scala
@@ -596,7 +596,7 @@ object Either {
   }
   final object RightBiased {
 
-    private[Either] final val DefaultThrowingOps = WithEmptyToken.Throwing( throw new MatchError( matchErrorMessage( true ) ) );
+    private[Either] final val DefaultThrowingOps = WithEmptyToken.Throwing( throw new NoSuchElementException( noSuchElementMessage( true ) ) );
 
     implicit class Ops[A,B]( val src : Either[A,B] ) extends AnyVal { // alas, we don't define a trait, but write all these ops twice, so we can avoid boxing here
 
@@ -734,7 +734,7 @@ object Either {
   }
   final object LeftBiased {
 
-    private[Either] final val DefaultThrowingOps = WithEmptyToken.Throwing( throw new MatchError( matchErrorMessage( false ) ) );
+    private[Either] final val DefaultThrowingOps = WithEmptyToken.Throwing( throw new NoSuchElementException( noSuchElementMessage( false ) ) );
 
     implicit class Ops[A,B]( val src : Either[A,B] ) extends AnyVal { // alas, we don't define a trait, but write all these ops twice, so we can avoid boxing here
 
@@ -871,7 +871,7 @@ object Either {
     implicit def toLeftBiasedEtherOps[A]( src : Either[A,B] ) : LeftBiased.WithEmptyToken.AbstractOps[A,B] = new LeftBiased.WithEmptyToken.Ops[A,B]( src )( EmptyTokenDefinition );
   }
 
-  private def matchErrorMessage[A,B]( rightBiased : Boolean, mbEither : Option[Either[A,B]] = None ) = {
+  private def noSuchElementMessage[A,B]( rightBiased : Boolean, mbEither : Option[Either[A,B]] = None ) = {
     val bias = if ( rightBiased ) "Right-biased" else "Left-biased";
     val withToken = if ( rightBiased ) "RightBiased.WithEmptyToken" else "LeftBiased.WithEmptyToken";
     val eitherRep = mbEither.fold(" ")( either => s" '${either}' " );

--- a/src/library/scala/util/Either.scala
+++ b/src/library/scala/util/Either.scala
@@ -274,7 +274,7 @@ object Either {
    */
   final case class LeftProjection[+A, +B](e: Either[A, B]) {
     /**
-     * Returns the value from this `Left` or throws `java.util.NoSuchElementException`
+     * Returns the value from this `Left`. Throws `java.util.NoSuchElementException`
      * if this is a `Right`.
      *
      * {{{
@@ -439,7 +439,7 @@ object Either {
   final case class RightProjection[+A, +B](e: Either[A, B]) {
 
     /**
-     * Returns the value from this `Right` or throws
+     * Returns the value from this `Right`. Throws
      * `java.util.NoSuchElementException` if this is a `Left`.
      *
      * {{{
@@ -604,10 +604,204 @@ object Either {
       }
     }
   }
+  /**
+    *  This object contains utilities for defining an environment in which `Either` instances are "right-biased".
+    * 
+    *  Right-biased means instances of `Either[A,B]` can be operated upon via methods that render thme 
+    *  quite analogous to an `Option[A]`, except that failures are represented by a `Left` containing information about
+    *  the problem rathar than by uninformative `None`. In particular,
+    *  a right-biased `Either` can be used directly in a for comprehension. Unlike a [[scala.util.Either.RightProjection]],
+    *  a right-biased `Either` supports all features of a for comprehension, including pattern matching, filtering,
+    *  and variable assignment.
+    * 
+    *  Right-biasing decorates vanilla `Either[A,B]` with the following API.
+    * {{{
+    *   def flatMap[AA >: A, Z]( f : B => Either[AA,Z] ) : Either[AA,Z]
+    *   def map[Z]( f : B => Z )                         : Either[A,Z]
+    *   def withFilter( p : B => Boolean )               : Either[A,B]
+    *   def exists( f : B => Boolean )                   : Boolean     
+    *   def forall( f : B => Boolean )                   : Boolean     
+    *   def foreach[U]( f : B => U )                     : Any         
+    *   def get                                          : B           
+    *   def getOrElse[BB>:B]( or : =>BB )                : BB          
+    *   def toOption                                     : Option[B]   
+    *   def toSeq                                        : collection.Seq[B]
+    *   def xget                                         : A                
+    *   def xgetOrElse[AA>:A]( or : =>AA )               : AA               
+    *   def xmap[Z]( f : A => Z )                        : Either[Z,B]      
+    *   def replaceIfEmpty[AA>:A]( replacement : =>AA )  : Either[AA,B]     
+    *   def isEmpty                                      : Boolean          
+    *   def isLeftBiased                                 : Boolean          
+    *   def isRightBiased                                : Boolean          
+    *   def conformsToBias                               : Boolean          
+    * }}}
+    * 
+    *  For the full documentation, plase see [[RightBias.withEmptyToken.Ops Ops]].
+    * 
+    *  To enable right-biasing, you first define a bias, typically via the [[Either.RightBias.withEmptyToken$ Either.RightBias.withEmptyToken]]
+    *  factory.
+    * {{{
+    *     // will impart a right-bias suitable to Either[A,String]
+    *     val RightBias = Either.RightBias.withEmptyToken("EMPTY")
+    *     import RightBias._
+    * }}}
+    *  The specified "empty token" will define the value in the `Left` object that will be used to indicate
+    *  when a filter or pattern-match of a right-side object fails.
+    * 
+    *  If you don't wish to specify an empty token, you may use the more convenient
+    * {{{
+    *     import Either.RightBias._
+    * }}}
+    *  However, if you do not specify an empty token, filter operations or pattern match failures that would leave the right-side
+    *  empty will result in the raising of a `java.util.NoSuchElementException`.
+    * 
+    *  You may also create a right-biased environment within a trait, class, object, or package by
+    *  having the entity extend the trait [[RightBias! RightBias]] or the abstract base class
+    *  [[RightBias.Base]].
+    * 
+    *  '''A Detailed example'''
+    * 
+    *  Consider a hypothetical process that must read some binary data from a URL, parse the data into
+    *  a `Record`, ensure that record's year is no older than 2011, and then operate upon
+    *  the data via one of several external services, depending on the `opCode`, ultimately producing a `Result`. 
+    *  Things that can go wrong include network errors on loading, 
+    *  parsing problems, failure of the timestamp condition, and failures with the external service.
+    * 
+    *  With `Option`, one might define a process like:
+    * {{{
+    *     case class Record( opCode : Int, data : Seq[Byte], year : Int )
+    *     trait Result
+    * 
+    *     def loadURL( url : String ) : Option[Seq[Byte]] = ???
+    *     def parseRecord( bytes : Seq[Byte] ) : Option[Record] = ???
+    *     def process( opCode : Int, data : Seq[Byte] ) : Option[Result] = ???
+    * 
+    *     def processURL( url : String ) : Option[Result] = {
+    *       for {
+    *         rawBytes                     <- loadURL( url )
+    *         Record( opCode, data, year ) <- parseRecord( rawBytes )
+    *         result                       <- process( opCode, data ) if year >= 2011
+    *       } yield result
+    *     }
+    * }}}
+    *  That's fine, but if anything goes wrong, clients will receive a value `None`, and have no specific information
+    *  about what the problem was. Instead of option, we might try to use Either, defining error codes
+    *  for things that can go wrong. (We'll let our error codes be `Int` for this example, but ''errors should 
+    *  be represented by descriptive kinds of object in real applications.'') Conventionally,
+    *  we'll let good values arrive as `Right` values and embed our error codes in `Left` objects.
+    * {{{
+    *     val ErrIO               = 1
+    *     val ErrNoParse          = 2
+    *     val ErrBadYear          = 3
+    *     val ErrProcessorFailure = 4
+    * 
+    *     case class Record( opCode : Int, data : Seq[Byte], year : Int )
+    *     trait Result
+    * 
+    *     def loadURL( url : String ) : Either[Int,Seq[Byte]] = ???                // fails w/ErrIO
+    *     def parseRecord( bytes : Seq[Byte] ) : Either[Int,Record] = ???          // fails w/ErrNoParse
+    *     def process( opCode : Int, data : Seq[Byte] ) : Either[Int,Result] = ??? // fails w/ErrProcessorFailure
+    * 
+    *     // we try to use the right projection but the
+    *     // for comprehension fails to compile
+    *     def processURL( url : String ) : Either[Int,Result] = {
+    *       for {
+    *         rawBytes                     <- loadURL( url ).right
+    *         Record( opCode, data, year ) <- parseRecord( rawBytes ).right
+    *         result                       <- process( opCode, data ).right if year >= 2011
+    *       } yield result
+    *     }
+    * }}}
+    *   Unfortunately, this fails to compile, because [[scala.util.Either.RightProjection]] does not support
+    *   pattern-matching (used to extract `opCode`, `data`, and `year`) or filtering (which we perform based on `year`).
+    * 
+    *   Instead, we can right-bias the `Either`:
+    * {{{
+    *     val ErrEmpty            = -1
+    *     val ErrIO               =  1
+    *     val ErrNoParse          =  2
+    *     val ErrBadYear          =  3
+    *     val ErrProcessorFailure =  4
+    * 
+    *     // right-bias Either 
+    *     val RightBias = Either.RightBias.withEmptyToken( ErrEmpty ) 
+    *     import RightBias._
+    * 
+    *     case class Record( opCode : Int, data : Seq[Byte], year : Int )
+    *     trait Result
+    * 
+    *     def loadURL( url : String ) : Either[Int,Seq[Byte]] = ???                // fails w/ErrIO
+    *     def parseRecord( bytes : Seq[Byte] ) : Either[Int,Record] = ???          // fails w/ErrNoParse
+    *     def process( opCode : Int, data : Seq[Byte] ) : Either[Int,Result] = ??? // fails w/ErrProcessorFailure
+    * 
+    *     // use Either directly, rather than a projection, in the for comprehension
+    *     def processURL( url : String ) : Either[Int,Result] = {
+    *       for {
+    *         rawBytes                     <- loadURL( url )
+    *         Record( opCode, data, year ) <- parseRecord( rawBytes )
+    *         result                       <- process( opCode, data ) if year >= 2011
+    *       } yield result
+    *     }
+    * }}}
+    * 
+    *   There is a problem: `ErrEmpty`, would be the result of the year filter failing, 
+    *   when it should be `ErrBadYear`. 
+    * 
+    *   The most general and straightforward wat to fix this is to replace empty
+    *   tokens as they arrive with more informative errors. For this purpose,
+    *   biased `Either` offers a method called [[RightBias.Ops.replaceIfEmpty]]: 
+    * 
+    * {{{
+    *     // use Either directly, rather than a projection, in the for comprehension
+    *     def processURL( url : String ) : Either[Int,Result] = {
+    *       val processed = {
+    *         for {
+    *           rawBytes                     <- loadURL( url )
+    *           Record( opCode, data, year ) <- parseRecord( rawBytes )
+    *           result                       <- process( opCode, data ) if year >= 2011
+    *         } yield result
+    *       }
+    *       processed.replaceIfEmpty( ErrBadYear )
+    *     }
+    * }}}
+    * 
+    *   The scope of the right-bias is the scope of the import. An alternative way to
+    *   ensure empty tokens yield meaningful information is to define separate biases
+    *   for separate contexts.
+    * 
+    * {{{
+    *     val ProcessURLBias       = Either.RightBias.withEmptyToken( ErrBadYear ) 
+    *     val EnableHyperdriveBias = Either.RightBias.withEmptyToken( ErrSpaceTimeRupture )
+    *     ...
+    * 
+    *     def processURL( url : String ) : Either[Int,Result] = {
+    *       import ProcessURLBias._
+    *       for {
+    *         rawBytes                     <- loadURL( url )
+    *         Record( opCode, data, year ) <- parseRecord( rawBytes )
+    *         result                       <- process( opCode, data ) if year >= 2011
+    *       } yield result
+    *     }
+    * }}}
+    */ 
   final object RightBias {
 
     private[Either] final val DefaultThrowingOps = withEmptyToken.Throwing( throw new NoSuchElementException( noSuchElementMessage( true ) ) );
 
+    /**
+      * A value class implementing the operations of a [[RightBias$ right-biased]] `Either`,
+      * which throws a `java.util.NoSuchElementException` if a filter operation
+      * or pattern match results in empty.
+      * 
+      * Typical use
+      * {{{
+      *   import Either.RightBias._
+      * }}}
+      * 
+      * For documentation of the operations, please see [[RightBias.withEmptyToken.Ops]]
+      * 
+      * For more, please see [[RightBias$ RightBias]].
+      */
     implicit class Ops[A,B]( val target : Either[A,B] ) extends AnyVal { // alas, we don't define a trait, but write all these ops twice, so we can avoid boxing here
 
       // monad ops
@@ -627,34 +821,243 @@ object Either {
       def xgetOrElse[AA>:A]( or : =>AA )              : AA                = DefaultThrowingOps.xgetOrElse[A,AA,B]( target )( or );
       def xmap[Z]( f : A => Z )                       : Either[Z,B]       = DefaultThrowingOps.xmap( target )( f );
       def replaceIfEmpty[AA>:A]( replacement : =>AA ) : Either[AA,B]      = DefaultThrowingOps.replaceIfEmpty[A,AA,B]( target )( replacement );
+      def isEmpty                                     : Boolean           = DefaultThrowingOps.isEmpty( target );
       def isLeftBiased                                : Boolean           = DefaultThrowingOps.isLeftBias;
       def isRightBiased                               : Boolean           = DefaultThrowingOps.isRightBias;
       def conformsToBias                              : Boolean           = DefaultThrowingOps.conformsToBias( target );
     }
 
+    /**
+      * A factory for a typeclass instance which implements the operations of a right-biased `Either`. 
+      * An unsuccessful filter or pattern match will result in a Right containing a specified empty token of type `E`.
+      * 
+      * Typical use
+      * {{{
+      *   val RightBias = Either.RightBias.withEmptyToken(-1); //suitable for Either[Int,A]
+      *   import RightBias._
+      * }}}
+      * For more, please see [[RightBias$ RightBias]].
+      */
     object withEmptyToken {
+      /**
+        * Implements the operations of a right-biased `Either`, whose specific behavior -- especially with respect
+        * to handling of an empty value resulting from a filter or failed pattern match -- is defined by
+        * constructor argument `opsTypeClass`.
+        * 
+        * Clients can extend this is they wish to defined specialized right-biased `Either` instances
+        * that define extra operations.
+        * {{{
+        *   val EmptyThrowable = {
+        *     // the stack-trace on construction has no relevance to operations that return this token
+        *     // so we clear that stack trace
+        *     val tmp = new NoSuchElementException("EMPTY -- A value was right empty after a failed filter or pattern match operation.");
+        *     tmp.setStackTrace( Array.empty[StackTraceElement] ); 
+        *     tmp
+        *   }
+        *   val RightBias = Either.RightBias.withEmptyToken[Throwable]( EmptyThrowable );
+        *   implicit class RightBiasOps[B]( target : Either[Throwable,B] ) extends Either.RightBias.withEmptyToken.AbstractOps( target )( RightBias ) {
+        *      def raise : Unit = {
+        *        target match {
+        *          case Left( t ) => throw t;
+        *          case Right( _ ) => ();
+        *        }
+        *      }
+        *   }
+        * }}}
+        * 
+        * For more, see [[RightBias$ RightBias]].
+        */ 
       abstract class AbstractOps[A,B]( target : Either[A,B] )( opsTypeClass : Either.RightBias.withEmptyToken.Generic[A] ) {
 
         // monad ops
+        /**
+          * Binds the given function across `Right` of athe target right-biased `Either`.
+          *
+          * {{{
+          * Left(12).flatMap(x => Left("scala"))  // Left(12)
+          * Right(12).flatMap(x => Right("scala") // Right("scala")
+          * }}}
+          * @param f The function to bind across `Left`.
+          */
         def flatMap[AA >: A, Z]( f : B => Either[AA,Z] ) : Either[AA,Z] = opsTypeClass.flatMap[A,AA,B,Z]( target )( f );
+        /**
+          * Maps the function argument through `Right` of the target right-biased `Either`.
+          *
+          * {{{
+          * Left(12).map(_ + 2)  // Left(12)
+          * Right(12).map(_ + 2) // Right(14)
+          * }}}
+          */
         def map[Z]( f : B => Z )                         : Either[A,Z]  = opsTypeClass.map( target )( f );
+        /**
+          * Returns the target right-biased `Either` unchanged if it is a `Right` ''and'' the predicate `p`
+          * holds for its value, or if it is any `Left`.
+          * 
+          * Returns a `Left` containing the empty token if the target is a `Right` but predicate `p`
+          * fails to hold. If no empty token has been set, a `java.util.NoSuchElementException` will
+          * be thrown.
+          *
+          * {{{
+          * val RightBias = RightBias.withEmptyToken[Int](-1);
+          * import RightBias._
+          * 
+          * Left(7).withFilter(_ > 10)   // Left(7)
+          * Right(7).withFilter(_ > 10)  // Left(-1)
+          * Right(12).withFilter(_ > 10) // Right(12)
+          * }}}
+          */
         def withFilter( p : B => Boolean )               : Either[A,B]  = opsTypeClass.withFilter( target )( p );
 
         // extra ops
+        /**
+          * Returns `false` if the target right-biased `Either` is a `Left` or returns the result of the application of
+          * the given function to the `Right` value.
+          *
+          * {{{
+          * Right(12).exists(_ > 10) // true
+          * Right(7).exists(_ > 10)  // false
+          * Left(12).exists(_ > 10)  // false
+          * }}}
+          *
+          */
         def exists( f : B => Boolean )                  : Boolean           = opsTypeClass.exists( target )( f );
+        /**
+          * Returns `true` if the target right-biased `Either` is `Left` or returns 
+          * the result of the application of the given function to the `Right` value.
+          *
+          * {{{
+          * Right(12).forall(_ > 10) // true
+          * Right(7).forall(_ > 10)  // false
+          * Left(12).forall(_ > 10)  // true
+          * }}}
+          *
+          */
         def forall( f : B => Boolean )                  : Boolean           = opsTypeClass.forall( target )( f );
+        /**
+          * Executes the given side-effecting function if the target right-biased `Either` is a `Right`.
+          *
+          * {{{
+          * Left(12).foreach(x => println(x))  // doesn't print
+          * Right(12).foreach(x => println(x)) // prints "12"
+          * }}}
+          * 
+          * @param f The side-effecting function to execute.
+          */
         def foreach[U]( f : B => U )                    : Any               = opsTypeClass.foreach( target )( f );
+        /**
+          * Returns the value if the target right-biased `Either` is a `Right` or 
+          * throws `java.util.NoSuchElementException` if the target is a `Left`.
+          *
+          * {{{
+          * Left(12).get  // NoSuchElementException
+          * Right(12).get // 12
+          * }}}
+          *
+          * @throws java.util.NoSuchElementException if the target is [[scala.util.Left]]
+          */
         def get                                         : B                 = opsTypeClass.get( target );
+        /**
+          * Returns the value from the target right-biased `Either` if it is a `Right`,
+          * or the argument `or` if it is a `Left`.
+          *
+          * {{{
+          * Left(12).getOrElse(17)  // 12
+          * Right(12).getOrElse(17) // 17
+          * }}}
+          *
+          */
         def getOrElse[BB>:B]( or : =>BB )               : BB                = opsTypeClass.getOrElse[A,B,BB]( target )( or );
+        /**
+          * Returns a `Some` containing the `Right` value of the target right-biased `Either` if it exists or a
+          * `None` if the target is a `Left`.
+          *
+          * {{{
+          * Left(12).toOption  // None
+          * Right(12).toOption // Some(12)
+          * }}}
+          */
         def toOption                                    : Option[B]         = opsTypeClass.toOption( target );
+        /**
+          * Returns a `Seq` containing the `Right` value if it exists or an empty
+          * `Seq` if the target right-biased `Either` is a `Left`.
+          *
+          * {{{
+          * Left(12).toSeq  // Seq()
+          * Right(12).toSeq // Seq(12)
+          * }}}
+          */
         def toSeq                                       : collection.Seq[B] = opsTypeClass.toSeq( target );
+        /**
+          *  Returns `true` if this right-biased `Either` is a `Left`
+          *  that contains the empty token, signifying empty. Returns `false`
+          *  for any other error or value.
+          */ 
         def isEmpty                                     : Boolean           = opsTypeClass.isEmpty( target );
+        /**
+          * "cross-get" -- Returns the value if the target right-biased `Either` 
+          * does ''not'' conform to its bias, that is, if it is a `Left`.
+          * Throws `java.util.NoSuchElementException` if the target is a `Right`.
+          *
+          * {{{
+          * Left(12).xget  // 12
+          * Right(12).xget // NoSuchElementException
+          * }}}
+          *
+          * @throws java.util.NoSuchElementException if the target is [[scala.util.Right]]
+          */
         def xget                                        : A                 = opsTypeClass.xget( target );
+        /**
+          * "cross-getOrElse" -- Returns the value from the target right-biased `Either` 
+          * if it does ''not'' conform to its bias and is a `Left`.
+          * Returns the argument `or` if it is a `Right`.
+          *
+          * {{{
+          * Right(12).xgetOrElse(17) // 17
+          * Left(12).xgetOrElse(17)  // 12
+          * }}}
+          *
+          */
         def xgetOrElse[AA>:A]( or : =>AA )              : AA                = opsTypeClass.xgetOrElse[A,AA,B]( target )( or );
+        /**
+          * "cross-map" -- Maps the function argument through `Left` ''against'' the bias the target right-biased `Either`.
+          *
+          * {{{
+          * Left(12).map(_ + 2)  // Left(14)
+          * Right(12).map(_ + 2) // Right(12)
+          * }}}
+          */
         def xmap[Z]( f : A => Z )                       : Either[Z,B]       = opsTypeClass.xmap( target )( f );
+        /**
+          * If the target right-biased `Either` is a `Left` containing the empty token,
+          * returns a `Left` containing `replacement`. Otherwise returns the target `Either` unchanged.
+          *
+          * {{{
+          * // with empty token Int -1
+          * 
+          * Left(12).replaceIfEmpty(99)  // Left(12)
+          * Left(-1).replaceIfEmpty(99)  // Left(99)
+          * Right(12).replaceIfEmpty(99) // Right(12)
+          * Right(-1).replaceIfEmpty(99) // Right(-1)
+          * }}}
+          */
         def replaceIfEmpty[AA>:A]( replacement : =>AA ) : Either[AA,B]      = opsTypeClass.replaceIfEmpty[A,AA,B]( target )( replacement );
+        /**
+          * Returns `true` when called on a wrapper representing a left-biased `Either`, `false` otherwise.
+          */
         def isLeftBiased                                : Boolean           = opsTypeClass.isLeftBias;
+        /**
+          * Returns `true` when called on a wrapper representing a right-biased `Either`, `false` otherwise.
+          */
         def isRightBiased                               : Boolean           = opsTypeClass.isRightBias;
+        /**
+          * Returns `true` if this wrapper represents a left-biased `Either` wrapping a `Left` or a 
+          * right-biased `Either` wrapping a `Right`. Returns false if the bias of this wrapper is not
+          * consistent with the type of the target `Either`.
+          * 
+          * It is safe to call [[get]] on a biased `Either` for which `conformsToBias` is `true`.
+          * 
+          * It is safe to call [[xget]] on a biased `Either` for which `conformsToBias` is `false`.
+          */
         def conformsToBias                              : Boolean           = opsTypeClass.conformsToBias( target );
       }
 
@@ -765,6 +1168,17 @@ object Either {
       object Throwing {
         def apply( throwableBuilder : =>java.lang.Throwable ) : Throwing = new Throwing( throwableBuilder );
       }
+      /**
+        * A typeclass instance which implements the operations of a right-biased `Either` 
+        * that signals empty by throwing some Throwable as specified in a by-name parameter.
+        * 
+        * Typical use
+        * {{{
+        *   val RightBias = Either.RightBias.withEmptyToken.Throwing( new NoValueAvailableException ); 
+        *   import RightBias._
+        * }}}
+        * For more, please see [[RightBias$ RightBias]].
+        */
       final class Throwing private( throwableBuilder : =>java.lang.Throwable ) extends withEmptyToken.Generic[Nothing] {
         override protected def leftEmpty : Nothing = empty;
 
@@ -773,18 +1187,145 @@ object Either {
         override def isEmpty[A,B]( target : Either[A,B] ) : Boolean = false; // no state represents empty, empties cannot be formed as an Exception is thrown when it is tried
       }
     }
+    /**
+      * A typeclass instance which implements the operations of a right-biased `Either`. 
+      * An unsuccessful filter or pattern match will result in a Right containing a specified empty token of type `E`.
+      * 
+      * Typical use
+      * {{{
+      *   val RightBias = Either.RightBias.withEmptyToken(-1); //suitable for Either[Int,A]
+      *   import RightBias._
+      * }}}
+      * For more, please see [[RightBias$ RightBias]].
+      */
     final class withEmptyToken[+E] private( override val empty : E ) extends withEmptyToken.Generic[E] {
       override protected val leftEmpty : Left[E,Nothing] = Left(empty);
 
       override def isEmpty[A>:E,B]( target : Either[A,B] ) : Boolean = (target == leftEmpty);
     }
+    /**
+      * May be extended by classes, objects, traits, and packages (via package objects).
+      * 
+      * Within entities that extend this class
+      * values of type `Either` will be right-biased, and have
+      * the full-suite of right-biased operations (including operations suitable to for
+      * comprehensions) automatically made available.
+      * 
+      * Empty `Either` values will be represented by Left values containing the token 
+      * of type `L` passed to the superclass constructor.
+      * 
+      * '''If you are using polymorphic error types, be sure to specify the type
+      *  argument to Base, as too narrow a type may be inferred from a token
+      *  of a derived type.'''
+      * (More simply, use `extends Either.RightBias.Base[Err]( ErrEmptyToken )` rather than
+      * `extends Either.RightBias.Base( ErrEmptyToken )` without the `[Err]`.)
+      * 
+      * ''Note: Entities that do not need to extend another class can extend the abstract
+      * class [[Either.RightBias.Base]], which allows definition of the Empty token in the
+      * superclass constructor rather than overriding [[EmptyTokenDefinition]].''
+      * 
+      * For more information, please see [[RightBias$ RightBias]]
+      * 
+      * {{{
+      * class Clown extends Either.RightBias.Base[Clown.Error]( Clown.Error.Empty ) {
+      *   import Clown.{Cash,Laugh,Error};
+      * 
+      *   // use Either values directly in for comprehensions
+      *   def perform : Either[Error,Cash] = {
+      *      for {
+      *        laugh <- makeFunny
+      *        money <- begForCash( laugh ) if laugh.loudness > 2
+      *      } yield money
+      *   }
+      * 
+      *   def makeFunny : Either[Error,Laugh] = ???
+      *   def begForCash( laugh : Laugh )  : Either[Error,Cash] = ???
+      * }
+      * object Clown {
+      *   final object Error {
+      *     case object Empty extends Error;
+      *     case object JokeBombed extends Error;
+      *     case object NoAudience extends Error;
+      *     case object Cheapskates extends Error;
+      *   }
+      *   sealed trait Error;
+      * 
+      *   case class Laugh( loudness : Int );
+      *   case class Cash( quantity : Int, currencyCode : String );
+      * }
+      * }}}
+      * 
+      */ 
     abstract class Base[L]( emptyToken : L ) extends RightBias[L] {
       override val EmptyTokenDefinition = RightBias.withEmptyToken[L]( emptyToken )
     }
   }
+  /**
+    * Right-biasing trait that may be extended by classes, objects, traits, and packages (via package objects).
+    * 
+    * Within entities that extend this trait
+    * values of type `Either` will be right-biased, and have
+    * the full-suite of right-biased operations (including operations suitable to for
+    * comprehensions) automatically made available.
+    * 
+    * By default, transformation of a right-biased `Either` to empty by a failed pattern
+    * match or filter operation will provoke a `java.util.NoSuchElementException`. 
+    * Override [[EmptyTokenDefinition]] to prevent this and have emptiness
+    * represented by an error token of type `L`.
+    * 
+    * ''Note: Entities that do not need to extend another class can extend the abstract
+    * class [[Either.RightBias.Base]], which allows definition of the Empty token in the
+    * superclass constructor rather than overriding [[EmptyTokenDefinition]].''
+    * 
+    * For more information, please see [[RightBias$ RightBias]]
+    * 
+    * {{{
+    * class Clown extends Either.RightBias[Clown.Error] {
+    *   import Clown.{Cash,Laugh,Error};
+    * 
+    *   // override to specify an empty token
+    *   override val EmptyTokenDefinition = Either.RightBias.withEmptyToken(Error.Empty);
+    * 
+    *   // use Either values directly in for comprehensions
+    *   def perform : Either[Error,Cash] = {
+    *      for {
+    *        laugh <- makeFunny
+    *        money <- begForCash( laugh ) if laugh.loudness > 2
+    *      } yield money
+    *   }
+    * 
+    *   def makeFunny : Either[Error,Laugh] = ???
+    *   def begForCash( laugh : Laugh )  : Either[Error,Cash] = ???
+    * }
+    * object Clown {
+    *   final object Error {
+    *     case object Empty extends Error;
+    *     case object JokeBombed extends Error;
+    *     case object NoAudience extends Error;
+    *     case object Cheapskates extends Error;
+    *   }
+    *   sealed trait Error;
+    * 
+    *   case class Laugh( loudness : Int );
+    *   case class Cash( quantity : Int, currencyCode : String );
+    * }
+    * }}}
+    * 
+    */ 
   trait RightBias[L] {
     val EmptyTokenDefinition : Either.RightBias.withEmptyToken.Generic[L] = RightBias.DefaultThrowingOps;
 
+    /**
+      * Override this value to specify an empty token of type `L`. A Left object with this
+      * value will be returned by a failed filter or pattern match operation. If this
+      * value is not overridden, the default behavior will be to throw a `java.util.NoSuchElementException`
+      * on an unmatched pattern or filter. 
+      * {{{
+      *   // suppose errors on right-biased Either values are represented with Int codes
+      *   // with -1 representing "empty"
+      *   override val EmptyTokenDefinition = Either.RightBias.withEmptyToken(-1);
+      * }}}
+      */ 
     implicit def toRightBiasEtherOps[R]( target : Either[L,R] ) : RightBias.withEmptyToken.AbstractOps[L,R] = new RightBias.withEmptyToken.Ops[L,R]( target )( EmptyTokenDefinition );
   }
   /**
@@ -797,6 +1338,30 @@ object Either {
     *  a left-biased `Either` supports all features of a for comprehension, including pattern matching, filtering,
     *  and variable assignment.
     * 
+    *  Left-biasing decorates vanilla `Either[A,B]` with the following API.
+    * {{{
+    *   def flatMap[BB >: B, Z]( f : A => Either[Z,BB] ) : Either[Z,BB]
+    *   def map[Z]( f : A => Z )                         : Either[Z,B]
+    *   def withFilter( p : A => Boolean )               : Either[A,B]
+    *   def exists( f : A => Boolean )                   : Boolean
+    *   def forall( f : A => Boolean )                   : Boolean
+    *   def foreach[U]( f : A => U )                     : Any
+    *   def get                                          : A
+    *   def getOrElse[AA >: A ]( or : =>AA )             : AA
+    *   def toOption                                     : Option[A]
+    *   def toSeq                                        : collection.Seq[A]
+    *   def xget                                         : B
+    *   def xgetOrElse[BB>:B]( or : =>BB )               : BB
+    *   def xmap[Z]( f : B => Z )                        : Either[A,Z]
+    *   def replaceIfEmpty[BB>:B]( replacement : =>BB )  : Either[A,BB]
+    *   def isEmpty                                      : Boolean          
+    *   def isLeftBiased                                 : Boolean
+    *   def isRightBiased                                : Boolean
+    *   def conformsToBias                               : Boolean
+    * }}}
+    * 
+    *  For the full documentation, plase see [[LeftBias.withEmptyToken.Ops Ops]].
+    * 
     *  To enable left-biasing, you first define a bias, typically via the [[Either.LeftBias.withEmptyToken$ Either.LeftBias.withEmptyToken]]
     *  factory.
     * {{{
@@ -804,19 +1369,21 @@ object Either {
     *     val LeftBias = Either.LeftBias.withEmptyToken("EMPTY")
     *     import LeftBias._
     * }}}
-    *  The specified "empty token" will define the value in the `Right` object that will be used to
+    *  The specified "empty token" will define the value in the `Right` object that will be used to indicate
     *  when a filter or pattern-match of a left-side object fails.
     * 
     *  If you don't wish to specify an empty token, you may use the more convenient
     * {{{
     *     import Either.LeftBias._
     * }}}
-    *  However, filter operations or pattern match failures that would leave the left-side
+    *  However, if you do not specify an empty token, filter operations or pattern match failures that would leave the left-side
     *  empty will result in the raising of a `java.util.NoSuchElementException`.
     * 
-    *  For the full list of operations defined on a left-biased Either, see [[LeftBias.Ops]].
+    *  You may also create a left-biased environment within a trait, class, object, or package by
+    *  having the entity extend the trait [[LeftBias! LeftBias]] or the abstract base class
+    *  [[LeftBias.Base]].
     * 
-    *  '''A Detailed example:'''
+    *  '''A Detailed example'''
     * 
     *  Consider a hypothetical process that must read some binary data from a URL, parse the data into
     *  a `Record`, ensure that record's year is no older than 2011, and then operate upon
@@ -946,7 +1513,7 @@ object Either {
     private[Either] final val DefaultThrowingOps = withEmptyToken.Throwing( throw new NoSuchElementException( noSuchElementMessage( false ) ) );
 
     /**
-      * A value class implementing the operations of a left-biased `Either`,
+      * A value class implementing the operations of a [[LeftBias$ left-biased]] `Either`,
       * which throws a `java.util.NoSuchElementException` if a filter operation
       * or pattern match results in empty.
       * 
@@ -954,190 +1521,34 @@ object Either {
       * {{{
       *   import Either.LeftBias._
       * }}}
+      * 
+      * For documentation of the operations, please see [[LeftBias.withEmptyToken.Ops]]
+      * 
       * For more, please see [[LeftBias$ LeftBias]].
       */
     implicit class Ops[A,B]( val target : Either[A,B] ) extends AnyVal { // alas, we don't define a trait, but write all these ops twice, so we can avoid boxing here
 
       // monad ops
-      /**
-        * Binds the given function across `Left` of a left-biased `Either`.
-        *
-        * {{{
-        * Left(12).flatMap(x => Left("scala")) // Left("scala")
-        * Right(12).flatMap(x => Left("scala") // Right(12)
-        * }}}
-        * @param f The function to bind across `Left`.
-        */
       def flatMap[BB >: B, Z]( f : A => Either[Z,BB] ) : Either[Z,BB] = DefaultThrowingOps.flatMap[A,B,BB,Z]( target )( f );
-      /**
-        * Maps the function argument through `Left` of a left-biased `Either`.
-        *
-        * {{{
-        * Left(12).map(_ + 2) // Left(14)
-        * Right[Int, Int](12).map(_ + 2) // Right(12)
-        * }}}
-        */
-      def map[Z]( f : A => Z ) : Either[Z,B] = DefaultThrowingOps.map( target )( f );
-      /**
-        * Returns the target left-biased `Either` unchanged if it is a `Left` and the predicate `p`
-        * holds for its value, or if it is any `Right`.
-        * 
-        * Returns a `Right` containing the empty token if the target is a `Left` but predicate `p`
-        * fails to hold. If no empty token has been set, a `java.util.NoSuchElementException` will
-        * be thrown.
-        *
-        * {{{
-        * val LeftBias = LeftBias.withEmptyToken[Int](-1);
-        * import LeftBias._
-        * 
-        * Left(12).withFilter(_ > 10)  // Left(12)
-        * Left(7).withFilter(_ > 10)   // Right(-1)
-        * Right(12).withFilter(_ > 10) // Right(12)
-        * }}}
-        */
-      def withFilter( p : A => Boolean ) : Either[A,B] = DefaultThrowingOps.withFilter( target )( p );
+      def map[Z]( f : A => Z )                         : Either[Z,B]  = DefaultThrowingOps.map( target )( f );
+      def withFilter( p : A => Boolean )               : Either[A,B]  = DefaultThrowingOps.withFilter( target )( p );
 
       // extra ops
-      /**
-        * Returns `false` if the target left-biased `Either` is a `Right` or returns the result of the application of
-        * the given function to the `Left` value.
-        *
-        * {{{
-        * Left(12).exists(_ > 10)  // true
-        * Left(7).exists(_ > 10)   // false
-        * Right(12).left.exists(_ > 10) // false
-        * }}}
-        *
-        */
-      def exists( f : A => Boolean ) : Boolean = DefaultThrowingOps.exists( target )( f );
-      /**
-        * Returns `true` if the target left-biased `Either` is `Right` or returns 
-        * the result of the application of the given function to the `Left` value.
-        *
-        * {{{
-        * Left(12).forall(_ > 10)  // true
-        * Left(7).forall(_ > 10)   // false
-        * Right(12).forall(_ > 10) // true
-        * }}}
-        *
-        */
-      def forall( f : A => Boolean ) : Boolean = DefaultThrowingOps.forall( target )( f );
-      /**
-        * Executes the given side-effecting function if the target left-biased `Either` is a `Left`.
-        *
-        * {{{
-        * Left(12).foreach(x => println(x))  // prints "12"
-        * Right(12).foreach(x => println(x)) // doesn't print
-        * }}}
-        * 
-        * @param f The side-effecting function to execute.
-        */
-      def foreach[U]( f : A => U ) : Any = DefaultThrowingOps.foreach( target )( f );
-      /**
-        * Returns the value if the target left-biased `Either` is a `Left` or 
-        * throws `java.util.NoSuchElementException` if the target is a `Right`.
-        *
-        * {{{
-        * Left(12).get // 12
-        * Right(12).get // NoSuchElementException
-        * }}}
-        *
-        * @throws java.util.NoSuchElementException if the target is [[scala.util.Right]]
-        */
-      def get : A = DefaultThrowingOps.get( target );
-      /**
-        * Returns the value from the target left-biased `Either` if `Left`,
-        * or the given argument if it is a `Right`.
-        *
-        * {{{
-        * Left(12).getOrElse(17)  // 12
-        * Right(12).getOrElse(17) // 17
-        * }}}
-        *
-        */
-      def getOrElse[AA >: A ]( or : =>AA ) : AA = DefaultThrowingOps.getOrElse[A,AA,B]( target )( or );
-      /**
-        * Returns a `Some` containing the `Left` value of the target left-biased `Either` if it exists or a
-        * `None` if the target is a `Right`.
-        *
-        * {{{
-        * Left(12).toOption  // Some(12)
-        * Right(12).toOption // None
-        * }}}
-        */
-      def toOption : Option[A] = DefaultThrowingOps.toOption( target );
-      /**
-        * Returns a `Seq` containing the `Left` value if it exists or an empty
-        * `Seq` if the target left-biased `Either` is a `Right`.
-        *
-        * {{{
-        * Left(12).toSeq // Seq(12)
-        * Right(12).toSeq // Seq()
-        * }}}
-        */
-      def toSeq : collection.Seq[A] = DefaultThrowingOps.toSeq( target );
-      /**
-        * "cross-get" -- Returns the value if the target left-biased `Either` 
-        * does ''not'' conform to its bias, if it is a `Right`.
-        * Throws `java.util.NoSuchElementException` if the target is a `Left`.
-        *
-        * {{{
-        * Left(12).xget // NoSuchElementException
-        * Right(12).xget // 12
-        * }}}
-        *
-        * @throws java.util.NoSuchElementException if the target is [[scala.util.Left]]
-        */
-      def xget : B = DefaultThrowingOps.xget( target );
-      /**
-        * "cross-getOrElse" -- Returns the value from the target left-biased `Either` 
-        * if it does ''not'' conform to its bias and is a `Right`.
-        * Returns the given argument if it is a `Left`.
-        *
-        * {{{
-        * Right(12).xgetOrElse(17) // 12
-        * Right(12).xgetOrElse(17) // 17
-        * }}}
-        *
-        */
-      def xgetOrElse[BB>:B]( or : =>BB ) : BB = DefaultThrowingOps.xgetOrElse[A,B,BB]( target )( or );
-      /**
-        * "cross-map" -- Maps the function argument through `Right` ''against'' the bias the target left-biased `Either`.
-        *
-        * {{{
-        * Left(12).map(_ + 2) // Left(12)
-        * Right(12).map(_ + 2) // Right(14)
-        * }}}
-        */
-      def xmap[Z]( f : B => Z ) : Either[A,Z] = DefaultThrowingOps.xmap( target )( f );
-      /**
-        * If the target left-biased `Either` is a `Right` containing the empty token,
-        * returns a right containing `repleacement`. Otherwise returns the target `Either` unchanged.
-        *
-        * {{{
-        * // with empty token Int -1
-        * 
-        * Left(12).replaceIfEmpty(99) // Left(12)
-        * Left(-1).replaceIfEmpty(99) // Left(-1)
-        * Right(12).replaceIfEmpty(99) // Right(12)
-        * Right(-1).replaceIfEmpty(99) // Right(99)
-        * }}}
-        */
-      def replaceIfEmpty[BB>:B]( replacement : =>BB ) : Either[A,BB] = DefaultThrowingOps.replaceIfEmpty[A,B,BB]( target )( replacement )
-      /**
-        * Returns `true` when called on a wrapper representing a left-biased `Either`, `false` otherwise.
-        */
-      def isLeftBiased : Boolean = DefaultThrowingOps.isLeftBias;
-      /**
-        * Returns `true` when called on a wrapper representing a right-biased `Either`, `false` otherwise.
-        */
-      def isRightBiased : Boolean = DefaultThrowingOps.isRightBias;
-      /**
-        * Returns `true` if this wrapper represents a left-biased `Either` wrapping a `Left` or a 
-        * right-biased `Either` wrapping a `Right`. Returns `false` if this represents a left-biased
-        * `Either` wrapping a `Right` or a right-biased `Either` wrapping a left.
-        */
-      def conformsToBias : Boolean = DefaultThrowingOps.conformsToBias( target );
+      def exists( f : A => Boolean )                  : Boolean           = DefaultThrowingOps.exists( target )( f );
+      def forall( f : A => Boolean )                  : Boolean           = DefaultThrowingOps.forall( target )( f );
+      def foreach[U]( f : A => U )                    : Any               = DefaultThrowingOps.foreach( target )( f );
+      def get                                         : A                 = DefaultThrowingOps.get( target );
+      def getOrElse[AA >: A ]( or : =>AA )            : AA                = DefaultThrowingOps.getOrElse[A,AA,B]( target )( or );
+      def toOption                                    : Option[A]         = DefaultThrowingOps.toOption( target );
+      def toSeq                                       : collection.Seq[A] = DefaultThrowingOps.toSeq( target );
+      def isEmpty                                     : Boolean           = DefaultThrowingOps.isEmpty( target );
+      def xget                                        : B                 = DefaultThrowingOps.xget( target );
+      def xgetOrElse[BB>:B]( or : =>BB )              : BB                = DefaultThrowingOps.xgetOrElse[A,B,BB]( target )( or );
+      def xmap[Z]( f : B => Z )                       : Either[A,Z]       = DefaultThrowingOps.xmap( target )( f );
+      def replaceIfEmpty[BB>:B]( replacement : =>BB ) : Either[A,BB]      = DefaultThrowingOps.replaceIfEmpty[A,B,BB]( target )( replacement )
+      def isLeftBiased                                : Boolean           = DefaultThrowingOps.isLeftBias;
+      def isRightBiased                               : Boolean           = DefaultThrowingOps.isRightBias;
+      def conformsToBias                              : Boolean           = DefaultThrowingOps.conformsToBias( target );
     }
 
     /**
@@ -1168,7 +1579,7 @@ object Either {
         *     tmp
         *   }
         *   val LeftBias = Either.LeftBias.withEmptyToken[Throwable]( EmptyThrowable );
-        *   implicit class LeftBiasOps( target : Either[A,Throwable] ) extends Either.LeftBias.withEmptyToken.AbstractOps( target )( LeftBias ) {
+        *   implicit class LeftBiasOps[A]( target : Either[A,Throwable] ) extends Either.LeftBias.withEmptyToken.AbstractOps( target )( LeftBias ) {
         *      def raise : Unit = {
         *        target match {
         *          case Left(_) => ();
@@ -1177,31 +1588,33 @@ object Either {
         *      }
         *   }
         * }}}
+        * 
+        * For more, see [[LeftBias$ LeftBias]].
         */ 
       abstract class AbstractOps[A,B]( target : Either[A,B] )( opsTypeClass : Either.LeftBias.withEmptyToken.Generic[B] ) {
 
         // monad ops
         /**
-          * Binds the given function across `Left` of a left-biased `Either`.
+          * Binds the given function across `Left` of the target left-biased `Either`.
           *
           * {{{
-          * Left(12).flatMap(x => Left("scala")) // Left("scala")
-          * Right(12).flatMap(x => Left("scala") // Right(12)
+          * Left(12).flatMap(x => Left("scala"))  // Left("scala")
+          * Right(12).flatMap(x => Right("scala") // Right(12)
           * }}}
           * @param f The function to bind across `Left`.
           */
         def flatMap[BB >: B, Z]( f : A => Either[Z,BB] ) : Either[Z,BB] = opsTypeClass.flatMap[A,B,BB,Z]( target )( f );
         /**
-          * Maps the function argument through `Left` of a left-biased `Either`.
+          * Maps the function argument through `Left` of the target left-biased `Either`.
           *
           * {{{
-          * Left(12).map(_ + 2) // Left(14)
-          * Right[Int, Int](12).map(_ + 2) // Right(12)
+          * Left(12).map(_ + 2)  // Left(14)
+          * Right(12).map(_ + 2) // Right(12)
           * }}}
           */
         def map[Z]( f : A => Z ) : Either[Z,B] = opsTypeClass.map( target )( f );
         /**
-          * Returns the target left-biased `Either` unchanged if it is a `Left` and the predicate `p`
+          * Returns the target left-biased `Either` unchanged if it is a `Left` ''and'' the predicate `p`
           * holds for its value, or if it is any `Right`.
           * 
           * Returns a `Right` containing the empty token if the target is a `Left` but predicate `p`
@@ -1227,7 +1640,7 @@ object Either {
           * {{{
           * Left(12).exists(_ > 10)  // true
           * Left(7).exists(_ > 10)   // false
-          * Right(12).left.exists(_ > 10) // false
+          * Right(12).exists(_ > 10) // false
           * }}}
           *
           */
@@ -1260,7 +1673,7 @@ object Either {
           * throws `java.util.NoSuchElementException` if the target is a `Right`.
           *
           * {{{
-          * Left(12).get // 12
+          * Left(12).get  // 12
           * Right(12).get // NoSuchElementException
           * }}}
           *
@@ -1268,8 +1681,8 @@ object Either {
           */
         def get : A = opsTypeClass.get( target );
         /**
-          * Returns the value from the target left-biased `Either` if `Left`,
-          * or the given argument if it is a `Right`.
+          * Returns the value from the target left-biased `Either` if it is a `Left`,
+          * or the argument `or` if it is a `Right`.
           *
           * {{{
           * Left(12).getOrElse(17)  // 12
@@ -1293,18 +1706,24 @@ object Either {
           * `Seq` if the target left-biased `Either` is a `Right`.
           *
           * {{{
-          * Left(12).toSeq // Seq(12)
+          * Left(12).toSeq  // Seq(12)
           * Right(12).toSeq // Seq()
           * }}}
           */
         def toSeq : collection.Seq[A] = opsTypeClass.toSeq( target );
         /**
+          *  Returns `true` if this left-biased `Either` is a `Right`
+          *  that contains the empty token, signifying empty. Returns `false`
+          *  for any other error or value.
+          */ 
+        def isEmpty : Boolean = opsTypeClass.isEmpty( target );
+        /**
           * "cross-get" -- Returns the value if the target left-biased `Either` 
-          * does ''not'' conform to its bias, if it is a `Right`.
+          * does ''not'' conform to its bias, that is, if it is a `Right`.
           * Throws `java.util.NoSuchElementException` if the target is a `Left`.
           *
           * {{{
-          * Left(12).xget // NoSuchElementException
+          * Left(12).xget  // NoSuchElementException
           * Right(12).xget // 12
           * }}}
           *
@@ -1314,11 +1733,11 @@ object Either {
         /**
           * "cross-getOrElse" -- Returns the value from the target left-biased `Either` 
           * if it does ''not'' conform to its bias and is a `Right`.
-          * Returns the given argument if it is a `Left`.
+          * Returns the argument `or` if it is a `Left`.
           *
           * {{{
           * Right(12).xgetOrElse(17) // 12
-          * Right(12).xgetOrElse(17) // 17
+          * Left(12).xgetOrElse(17)  // 17
           * }}}
           *
           */
@@ -1327,20 +1746,20 @@ object Either {
           * "cross-map" -- Maps the function argument through `Right` ''against'' the bias the target left-biased `Either`.
           *
           * {{{
-          * Left(12).map(_ + 2) // Left(12)
+          * Left(12).map(_ + 2)  // Left(12)
           * Right(12).map(_ + 2) // Right(14)
           * }}}
           */
         def xmap[Z]( f : B => Z ) : Either[A,Z] = opsTypeClass.xmap( target )( f );
         /**
           * If the target left-biased `Either` is a `Right` containing the empty token,
-          * returns a right containing `repleacement`. Otherwise returns the target `Either` unchanged.
+          * returns a `Right` containing `replacement`. Otherwise returns the target `Either` unchanged.
           *
           * {{{
           * // with empty token Int -1
           * 
-          * Left(12).replaceIfEmpty(99) // Left(12)
-          * Left(-1).replaceIfEmpty(99) // Left(-1)
+          * Left(12).replaceIfEmpty(99)  // Left(12)
+          * Left(-1).replaceIfEmpty(99)  // Left(-1)
           * Right(12).replaceIfEmpty(99) // Right(12)
           * Right(-1).replaceIfEmpty(99) // Right(99)
           * }}}
@@ -1356,8 +1775,12 @@ object Either {
         def isRightBiased : Boolean = opsTypeClass.isRightBias;
         /**
           * Returns `true` if this wrapper represents a left-biased `Either` wrapping a `Left` or a 
-          * right-biased `Either` wrapping a `Right`. Returns `false` if this represents a left-biased
-          * `Either` wrapping a `Right` or a right-biased `Either` wrapping a left.
+          * right-biased `Either` wrapping a `Right`. Returns false if the bias of this wrapper is not
+          * consistent with the type of the target `Either`.
+          * 
+          * It is safe to call [[get]] on a biased `Either` for which `conformsToBias` is `true`.
+          * 
+          * It is safe to call [[xget]] on a biased `Either` for which `conformsToBias` is `false`.
           */
         def conformsToBias : Boolean = opsTypeClass.conformsToBias( target );
       }
@@ -1366,9 +1789,16 @@ object Either {
         * Implements the operations of a left-biased `Either`, whose specific behavior -- especially with respect
         * to handling of an empty value resulting from a filter or failed pattern match -- is defined by
         * constructor argument `opsTypeClass`.
+        * 
+        * Please see [[LeftBias$ LeftBias]]
         */ 
       implicit final class Ops[A,B]( target : Either[A,B] )( implicit opsTypeClass : Either.LeftBias.withEmptyToken.Generic[B] ) extends AbstractOps( target )( opsTypeClass );
 
+      /**
+        * A typeclass that defines the implementation of a left-biased `Either`
+        * 
+        * For more, see [[LeftBias$ LeftBias]]
+        */
       trait Generic[+E] extends Either.Bias[E] {
         /*
          * In order to meet the contract of withFilter(...) [from which this method is called],
@@ -1528,16 +1958,20 @@ object Either {
       * the full-suite of left-biased operations (including operations suitable to for
       * comprehensions) automatically made available.
       * 
-      * Empty `Either` values will be represented by Right values including the token 
+      * Empty `Either` values will be represented by Right values containing the token 
       * of type `R` passed to the superclass constructor.
       * 
       * '''If you are using polymorphic error types, be sure to specify the type
       *  argument to Base, as too narrow a type may be inferred from a token
-      *  of a derived type.'''
+      *  of a derived type.''' 
+      * (More simply, use `extends Either.LeftBias.Base[Err]( ErrEmptyToken )` rather than
+      * `extends Either.LeftBias.Base( ErrEmptyToken )` without the `[Err]`.)
       * 
       * ''Note: Entities that do not need to extend another class can extend the abstract
       * class [[Either.LeftBias.Base]], which allows defining the Empty token in the
       * superclass constructor rather than overriding [[EmptyTokenDefinition]].''
+      * 
+      * For more information, please see [[RightBias$ RightBias]]
       * 
       * {{{
       * class Clown extends Either.LeftBias.Base[Clown.Error]( Clown.Error.Empty ) {
@@ -1574,7 +2008,7 @@ object Either {
     }
   }
   /**
-    * May be extended by classes, objects, traits, and packages (via package objects).
+    * Left-biasing trait that may be extended by classes, objects, traits, and packages (via package objects).
     * 
     * Within entities that extend this trait
     * objects of type `Either` will be left-biased, and have
@@ -1589,6 +2023,8 @@ object Either {
     * ''Note: Entities that do not need to extend another class can extend the abstract
     * class [[Either.LeftBias.Base]], which allows defining the Empty token in the
     * superclass constructor rather than overriding [[EmptyTokenDefinition]].''
+    * 
+    * For more information, please see [[LeftBias$ LeftBias]]
     * 
     * {{{
     * class Clown extends Either.LeftBias[Clown.Error] {

--- a/src/library/scala/util/Either.scala
+++ b/src/library/scala/util/Either.scala
@@ -594,9 +594,9 @@ object Either {
   trait WithEmpty[+E] {
     def empty : E;
   }
-  final object RightBiased {
+  final object RightBias {
 
-    private[Either] final val DefaultThrowingOps = WithEmptyToken.Throwing( throw new NoSuchElementException( noSuchElementMessage( true ) ) );
+    private[Either] final val DefaultThrowingOps = withEmptyToken.Throwing( throw new NoSuchElementException( noSuchElementMessage( true ) ) );
 
     implicit class Ops[A,B]( val src : Either[A,B] ) extends AnyVal { // alas, we don't define a trait, but write all these ops twice, so we can avoid boxing here
 
@@ -617,8 +617,8 @@ object Either {
       def fold[Z]( ifLeft : A => Z )( ifRight : B => Z ) : Z = DefaultThrowingOps.fold( src )( ifLeft )( ifRight )
     }
 
-    object WithEmptyToken {
-      abstract class AbstractOps[A,B]( src : Either[A,B] )( opsTypeClass : Either.RightBiased.WithEmptyToken.Generic[A] ) {
+    object withEmptyToken {
+      abstract class AbstractOps[A,B]( src : Either[A,B] )( opsTypeClass : Either.RightBias.withEmptyToken.Generic[A] ) {
 
         // monad ops
         def flatMap[AA >: A, Z]( f : B => Either[AA,Z] ) : Either[AA,Z] = opsTypeClass.flatMap[A,AA,B,Z]( src )( f );
@@ -637,7 +637,7 @@ object Either {
         def fold[Z]( ifLeft : A => Z )( ifRight : B => Z ) : Z = opsTypeClass.fold( src )( ifLeft )( ifRight )
       }
 
-      implicit final class Ops[A,B]( src : Either[A,B] )( implicit opsTypeClass : Either.RightBiased.WithEmptyToken.Generic[A] ) extends AbstractOps( src )( opsTypeClass );
+      implicit final class Ops[A,B]( src : Either[A,B] )( implicit opsTypeClass : Either.RightBias.withEmptyToken.Generic[A] ) extends AbstractOps( src )( opsTypeClass );
 
       trait Generic[+E] extends Either.WithEmpty[E]{
         protected def leftEmpty : Left[E,Nothing] = Left(empty);
@@ -712,29 +712,29 @@ object Either {
           }
         }
 
-        implicit def toOps[A>:E,B]( src : Either[A,B] ) : RightBiased.WithEmptyToken.Ops[A,B] = new RightBiased.WithEmptyToken.Ops[A,B]( src )( this )
+        implicit def toOps[A>:E,B]( src : Either[A,B] ) : RightBias.withEmptyToken.Ops[A,B] = new RightBias.withEmptyToken.Ops[A,B]( src )( this )
       }
-      def apply[E]( token : E ) : WithEmptyToken[E] = new WithEmptyToken( token );
+      def apply[E]( token : E ) : withEmptyToken[E] = new withEmptyToken( token );
 
       object Throwing {
         def apply( throwableBuilder : =>java.lang.Throwable ) : Throwing = new Throwing( throwableBuilder );
       }
-      final class Throwing private( throwableBuilder : =>java.lang.Throwable ) extends WithEmptyToken.Generic[Nothing] {
+      final class Throwing private( throwableBuilder : =>java.lang.Throwable ) extends withEmptyToken.Generic[Nothing] {
         override def empty : Nothing = throw throwableBuilder;
       }
     }
-    final class WithEmptyToken[+E] private( override val empty : E ) extends WithEmptyToken.Generic[E] {
+    final class withEmptyToken[+E] private( override val empty : E ) extends withEmptyToken.Generic[E] {
       override protected val leftEmpty : Left[E,Nothing] = Left(empty);
     }
   }
-  trait RightBiased[A] {
-    val EmptyTokenDefinition : Either.RightBiased.WithEmptyToken.Generic[A] = RightBiased.DefaultThrowingOps;
+  trait RightBias[A] {
+    val EmptyTokenDefinition : Either.RightBias.withEmptyToken.Generic[A] = RightBias.DefaultThrowingOps;
 
-    implicit def toRightBiasedEtherOps[B]( src : Either[A,B] ) : RightBiased.WithEmptyToken.AbstractOps[A,B] = new RightBiased.WithEmptyToken.Ops[A,B]( src )( EmptyTokenDefinition );
+    implicit def toRightBiasEtherOps[B]( src : Either[A,B] ) : RightBias.withEmptyToken.AbstractOps[A,B] = new RightBias.withEmptyToken.Ops[A,B]( src )( EmptyTokenDefinition );
   }
-  final object LeftBiased {
+  final object LeftBias {
 
-    private[Either] final val DefaultThrowingOps = WithEmptyToken.Throwing( throw new NoSuchElementException( noSuchElementMessage( false ) ) );
+    private[Either] final val DefaultThrowingOps = withEmptyToken.Throwing( throw new NoSuchElementException( noSuchElementMessage( false ) ) );
 
     implicit class Ops[A,B]( val src : Either[A,B] ) extends AnyVal { // alas, we don't define a trait, but write all these ops twice, so we can avoid boxing here
 
@@ -755,8 +755,8 @@ object Either {
       def fold[Z]( ifLeft : A => Z )( ifRight : B => Z ) : Z = DefaultThrowingOps.fold( src )( ifLeft )( ifRight )
     }
 
-    object WithEmptyToken {
-      abstract class AbstractOps[A,B]( src : Either[A,B] )( opsTypeClass : Either.LeftBiased.WithEmptyToken.Generic[B] ) {
+    object withEmptyToken {
+      abstract class AbstractOps[A,B]( src : Either[A,B] )( opsTypeClass : Either.LeftBias.withEmptyToken.Generic[B] ) {
 
         // monad ops
         def flatMap[BB >: B, Z]( f : A => Either[Z,BB] ) : Either[Z,BB] = opsTypeClass.flatMap[A,B,BB,Z]( src )( f );
@@ -775,7 +775,7 @@ object Either {
         def fold[Z]( ifLeft : A => Z )( ifRight : B => Z ) : Z = opsTypeClass.fold( src )( ifLeft )( ifRight )
       }
 
-      implicit final class Ops[A,B]( src : Either[A,B] )( implicit opsTypeClass : Either.LeftBiased.WithEmptyToken.Generic[B] ) extends AbstractOps( src )( opsTypeClass );
+      implicit final class Ops[A,B]( src : Either[A,B] )( implicit opsTypeClass : Either.LeftBias.withEmptyToken.Generic[B] ) extends AbstractOps( src )( opsTypeClass );
 
       trait Generic[+E] extends Either.WithEmpty[E]{
         protected def rightEmpty : Right[Nothing,E] = Right(empty);
@@ -850,34 +850,34 @@ object Either {
           }
         }
 
-        implicit def toOps[A,B>:E]( src : Either[A,B] ) : LeftBiased.WithEmptyToken.Ops[A,B] = new LeftBiased.WithEmptyToken.Ops[A,B]( src )( this )
+        implicit def toOps[A,B>:E]( src : Either[A,B] ) : LeftBias.withEmptyToken.Ops[A,B] = new LeftBias.withEmptyToken.Ops[A,B]( src )( this )
       }
-      def apply[E]( token : E ) : WithEmptyToken[E] = new WithEmptyToken( token );
+      def apply[E]( token : E ) : withEmptyToken[E] = new withEmptyToken( token );
 
       object Throwing {
         def apply( throwableBuilder : =>java.lang.Throwable ) : Throwing = new Throwing( throwableBuilder );
       }
-      final class Throwing private( throwableBuilder : =>java.lang.Throwable ) extends WithEmptyToken.Generic[Nothing] {
+      final class Throwing private( throwableBuilder : =>java.lang.Throwable ) extends withEmptyToken.Generic[Nothing] {
         override def empty : Nothing = throw throwableBuilder;
       }
     }
-    final class WithEmptyToken[+E] private( override val empty : E ) extends WithEmptyToken.Generic[E] {
+    final class withEmptyToken[+E] private( override val empty : E ) extends withEmptyToken.Generic[E] {
       override protected val rightEmpty : Right[Nothing,E] = Right(empty);
     }
   } 
-  trait LeftBiased[B] {
-    val EmptyTokenDefinition : Either.LeftBiased.WithEmptyToken.Generic[B] = LeftBiased.DefaultThrowingOps;
+  trait LeftBias[B] {
+    val EmptyTokenDefinition : Either.LeftBias.withEmptyToken.Generic[B] = LeftBias.DefaultThrowingOps;
 
-    implicit def toLeftBiasedEtherOps[A]( src : Either[A,B] ) : LeftBiased.WithEmptyToken.AbstractOps[A,B] = new LeftBiased.WithEmptyToken.Ops[A,B]( src )( EmptyTokenDefinition );
+    implicit def toLeftBiasEtherOps[A]( src : Either[A,B] ) : LeftBias.withEmptyToken.AbstractOps[A,B] = new LeftBias.withEmptyToken.Ops[A,B]( src )( EmptyTokenDefinition );
   }
 
-  private def noSuchElementMessage[A,B]( rightBiased : Boolean, mbEither : Option[Either[A,B]] = None ) = {
-    val bias = if ( rightBiased ) "Right-biased" else "Left-biased";
-    val withToken = if ( rightBiased ) "RightBiased.WithEmptyToken" else "LeftBiased.WithEmptyToken";
+  private def noSuchElementMessage[A,B]( rightBias : Boolean, mbEither : Option[Either[A,B]] = None ) = {
+    val bias = if ( rightBias ) "Right-biased" else "Left-biased";
+    val withToken = if ( rightBias ) "RightBias.withEmptyToken" else "LeftBias.withEmptyToken";
     val eitherRep = mbEither.fold(" ")( either => s" '${either}' " );
-    s"${bias} Either${eitherRep}filtered to empty or failed to match a pattern. Consider implementing ${withToken}"
+    s"${bias} Either${eitherRep}filtered to empty or failed to match a pattern. Consider using ${withToken}"
   }
 
-  private val NoSuchLeftMessage = "Can't get a value from a LeftBiased Either which is in fact a Right.";
-  private val NoSuchRightMessage = "Can't get a value from a RightBiased Either which is in fact a Left.";
+  private val NoSuchLeftMessage = "Can't get a value from a left-biased Either which is in fact a Right.";
+  private val NoSuchRightMessage = "Can't get a value from a right-biased Either which is in fact a Left.";
 }

--- a/src/library/scala/util/Either.scala
+++ b/src/library/scala/util/Either.scala
@@ -103,7 +103,7 @@ import scala.language.implicitConversions
  *  For very extensive documentation of biased `Either`, please see [[Either.RightBias$ RightBias]]
  *  (or, if you wish to defy convention, [[Either.LeftBias$ LeftBias]]).
  * 
- *  For documentation of operations supported by biased `Either` values, see [[Either.RightBias.withEmptyToken.Ops right-biased]] / [[Either.RightBias.withEmptyToken.Ops left-biased]].
+ *  For documentation of operations supported by biased `Either` values, see [[Either.RightBias.withEmptyToken.Ops right-biased ops]] / [[Either.RightBias.withEmptyToken.Ops left-biased ops]].
  * 
  *  @author <a href="mailto:research@workingmouse.com">Tony Morris</a>, Workingmouse
  *  @version 1.0, 11/10/2008

--- a/src/library/scala/util/Either.scala
+++ b/src/library/scala/util/Either.scala
@@ -590,4 +590,294 @@ object Either {
    */
   def cond[A, B](test: Boolean, right: => B, left: => A): Either[A, B] =
     if (test) Right(right) else Left(left)
+
+  trait WithEmpty[+E] {
+    def empty : E;
+  }
+  final object RightBiased {
+
+    private[Either] final val DefaultThrowingOps = WithEmptyToken.Throwing( throw new MatchError( matchErrorMessage( true ) ) );
+
+    implicit class Ops[A,B]( val src : Either[A,B] ) extends AnyVal { // alas, we don't define a trait, but write all these ops twice, so we can avoid boxing here
+
+      // monad ops
+      def flatMap[AA >: A, Z]( f : B => Either[AA,Z] ) : Either[AA,Z] = DefaultThrowingOps.flatMap[A,AA,B,Z]( src )( f );
+      def map[Z]( f : B => Z )                         : Either[A,Z]  = DefaultThrowingOps.map( src )( f );
+      def withFilter( p : B => Boolean )               : Either[A,B]  = DefaultThrowingOps.withFilter( src )( p );
+
+      // extra ops
+      def exists( f : B => Boolean )        : Boolean           = DefaultThrowingOps.exists( src )( f );
+      def forall( f : B => Boolean )        : Boolean           = DefaultThrowingOps.forall( src )( f );
+      def foreach[U]( f : B => U )          : Any               = DefaultThrowingOps.foreach( src )( f );
+      def get                               : B                 = DefaultThrowingOps.get( src );
+      def getOrElse[ BB >: B ]( or : =>BB ) : BB                = DefaultThrowingOps.getOrElse[A,B,BB]( src )( or );
+      def toOption                          : Option[B]         = DefaultThrowingOps.toOption( src );
+      def toSeq                             : collection.Seq[B] = DefaultThrowingOps.toSeq( src );
+
+      def fold[Z]( ifLeft : A => Z )( ifRight : B => Z ) : Z = DefaultThrowingOps.fold( src )( ifLeft )( ifRight )
+    }
+
+    object WithEmptyToken {
+      abstract class AbstractOps[A,B]( src : Either[A,B] )( opsTypeClass : Either.RightBiased.WithEmptyToken.Generic[A] ) {
+
+        // monad ops
+        def flatMap[AA >: A, Z]( f : B => Either[AA,Z] ) : Either[AA,Z] = opsTypeClass.flatMap[A,AA,B,Z]( src )( f );
+        def map[Z]( f : B => Z )                         : Either[A,Z]  = opsTypeClass.map( src )( f );
+        def withFilter( p : B => Boolean )               : Either[A,B]  = opsTypeClass.withFilter( src )( p );
+
+        // extra ops
+        def exists( f : B => Boolean )        : Boolean           = opsTypeClass.exists( src )( f );
+        def forall( f : B => Boolean )        : Boolean           = opsTypeClass.forall( src )( f );
+        def foreach[U]( f : B => U )          : Any               = opsTypeClass.foreach( src )( f );
+        def get                               : B                 = opsTypeClass.get( src );
+        def getOrElse[ BB >: B ]( or : =>BB ) : BB                = opsTypeClass.getOrElse[A,B,BB]( src )( or );
+        def toOption                          : Option[B]         = opsTypeClass.toOption( src );
+        def toSeq                             : collection.Seq[B] = opsTypeClass.toSeq( src );
+
+        def fold[Z]( ifLeft : A => Z )( ifRight : B => Z ) : Z = opsTypeClass.fold( src )( ifLeft )( ifRight )
+      }
+
+      implicit final class Ops[A,B]( src : Either[A,B] )( implicit opsTypeClass : Either.RightBiased.WithEmptyToken.Generic[A] ) extends AbstractOps( src )( opsTypeClass );
+
+      trait Generic[+E] extends Either.WithEmpty[E]{
+        protected def leftEmpty : Left[E,Nothing] = Left(empty);
+
+        // monad ops
+        def flatMap[A>:E,AA>:A,B,Z]( src : Either[A,B] )( f : B => Either[AA,Z] ) : Either[AA,Z] = {
+          src match {
+            case Left( _ )  => src.asInstanceOf[Left[A,Z]]
+            case Right( b ) => f( b )
+          }
+        }
+        def map[A>:E,B,Z]( src : Either[A,B] )( f : B => Z ) : Either[A,Z] = {
+          src match {
+            case Left( _ )  => src.asInstanceOf[Left[A,Z]]
+            case Right( b ) => Right( f( b ) )
+          }
+        }
+        def withFilter[A>:E,B]( src : Either[A,B] )( p : B => Boolean ) : Either[A,B] = {
+          src match {
+            case      Left( _ ) => src;
+            case r @ Right( b ) => if ( p(b) ) r else leftEmpty;
+          }
+        }
+
+        // extra ops
+        def exists[A>:E,B]( src : Either[A,B] )( f : B => Boolean ) : Boolean = {
+          src match {
+            case Left( _ )  => false;
+            case Right( b ) => f( b );
+          }
+        }
+        def forall[A>:E,B]( src : Either[A,B] )( f : B => Boolean ) : Boolean = {
+          src match {
+            case Left( _ )  => true;
+            case Right( b ) => f( b );
+          }
+        }
+        def foreach[A>:E,B,U]( src : Either[A,B] )( f : B => U ) : Any = {
+          src match {
+            case Left( _ )  => ();
+            case Right( b ) => f( b );
+          }
+        }
+        def get[A>:E,B]( src : Either[A,B] ) : B = {
+          src match {
+            case Left( _ )  => throw new NoSuchElementException( NoSuchRightMessage );
+            case Right( b ) => b;
+          }
+        }
+        def getOrElse[A>:E,B,BB>:B]( src : Either[A,B] )( or : =>BB ) : BB = {
+          src match {
+            case Left( _ )  => or;
+            case Right( b ) => b;
+          }
+        }
+        def toOption[A>:E,B]( src : Either[A,B] ) : Option[B] = {
+          src match {
+            case Left( _ )  => None;
+            case Right( b ) => Some( b );
+          }
+        }
+        def toSeq[A>:E,B]( src : Either[A,B] ) : collection.Seq[B] = {
+          src match {
+            case Left( _ )  => collection.Seq.empty[B];
+            case Right( b ) => collection.Seq( b );
+          }
+        }
+        def fold[A>:E,B,Z]( src : Either[A,B] )( ifLeft : A => Z )( ifRight : B => Z ) : Z = {
+          src match {
+            case Left( a ) => ifLeft( a );
+            case Right( b ) => ifRight( b );
+          }
+        }
+
+        implicit def toOps[A>:E,B]( src : Either[A,B] ) : RightBiased.WithEmptyToken.Ops[A,B] = new RightBiased.WithEmptyToken.Ops[A,B]( src )( this )
+      }
+      def apply[E]( token : E ) : WithEmptyToken[E] = new WithEmptyToken( token );
+
+      object Throwing {
+        def apply( throwableBuilder : =>java.lang.Throwable ) : Throwing = new Throwing( throwableBuilder );
+      }
+      final class Throwing private( throwableBuilder : =>java.lang.Throwable ) extends WithEmptyToken.Generic[Nothing] {
+        override def empty : Nothing = throw throwableBuilder;
+      }
+    }
+    final class WithEmptyToken[+E] private( override val empty : E ) extends WithEmptyToken.Generic[E] {
+      override protected val leftEmpty : Left[E,Nothing] = Left(empty);
+    }
+  }
+  trait RightBiased[A] {
+    val EmptyTokenDefinition : Either.RightBiased.WithEmptyToken.Generic[A] = RightBiased.DefaultThrowingOps;
+
+    implicit def toRightBiasedEtherOps[B]( src : Either[A,B] ) : RightBiased.WithEmptyToken.AbstractOps[A,B] = new RightBiased.WithEmptyToken.Ops[A,B]( src )( EmptyTokenDefinition );
+  }
+  final object LeftBiased {
+
+    private[Either] final val DefaultThrowingOps = WithEmptyToken.Throwing( throw new MatchError( matchErrorMessage( false ) ) );
+
+    implicit class Ops[A,B]( val src : Either[A,B] ) extends AnyVal { // alas, we don't define a trait, but write all these ops twice, so we can avoid boxing here
+
+      // monad ops
+      def flatMap[BB >: B, Z]( f : A => Either[Z,BB] ) : Either[Z,BB] = DefaultThrowingOps.flatMap[A,B,BB,Z]( src )( f );
+      def map[Z]( f : A => Z )                         : Either[Z,B]  = DefaultThrowingOps.map( src )( f );
+      def withFilter( p : A => Boolean )               : Either[A,B]  = DefaultThrowingOps.withFilter( src )( p );
+
+      // extra ops
+      def exists( f : A => Boolean )       : Boolean           = DefaultThrowingOps.exists( src )( f );
+      def forall( f : A => Boolean )       : Boolean           = DefaultThrowingOps.forall( src )( f );
+      def foreach[U]( f : A => U )         : Any               = DefaultThrowingOps.foreach( src )( f );
+      def get                              : A                 = DefaultThrowingOps.get( src );
+      def getOrElse[AA >: A ]( or : =>AA ) : AA                = DefaultThrowingOps.getOrElse[A,AA,B]( src )( or );
+      def toOption                         : Option[A]         = DefaultThrowingOps.toOption( src );
+      def toSeq                            : collection.Seq[A] = DefaultThrowingOps.toSeq( src );
+   
+      def fold[Z]( ifLeft : A => Z )( ifRight : B => Z ) : Z = DefaultThrowingOps.fold( src )( ifLeft )( ifRight )
+    }
+
+    object WithEmptyToken {
+      abstract class AbstractOps[A,B]( src : Either[A,B] )( opsTypeClass : Either.LeftBiased.WithEmptyToken.Generic[B] ) {
+
+        // monad ops
+        def flatMap[BB >: B, Z]( f : A => Either[Z,BB] ) : Either[Z,BB] = opsTypeClass.flatMap[A,B,BB,Z]( src )( f );
+        def map[Z]( f : A => Z )                         : Either[Z,B]  = opsTypeClass.map( src )( f );
+        def withFilter( p : A => Boolean )               : Either[A,B]  = opsTypeClass.withFilter( src )( p );
+
+        // extra ops
+        def exists( f : A => Boolean )       : Boolean           = opsTypeClass.exists( src )( f );
+        def forall( f : A => Boolean )       : Boolean           = opsTypeClass.forall( src )( f );
+        def foreach[U]( f : A => U )         : Any               = opsTypeClass.foreach( src )( f );
+        def get                              : A                 = opsTypeClass.get( src );
+        def getOrElse[AA >: A ]( or : =>AA ) : AA                = opsTypeClass.getOrElse[A,AA,B]( src )( or );
+        def toOption                         : Option[A]         = opsTypeClass.toOption( src );
+        def toSeq                            : collection.Seq[A] = opsTypeClass.toSeq( src );
+
+        def fold[Z]( ifLeft : A => Z )( ifRight : B => Z ) : Z = opsTypeClass.fold( src )( ifLeft )( ifRight )
+      }
+
+      implicit final class Ops[A,B]( src : Either[A,B] )( implicit opsTypeClass : Either.LeftBiased.WithEmptyToken.Generic[B] ) extends AbstractOps( src )( opsTypeClass );
+
+      trait Generic[+E] extends Either.WithEmpty[E]{
+        protected def rightEmpty : Right[Nothing,E] = Right(empty);
+
+        // monad ops
+        def flatMap[A, B>:E, BB>:B ,Z]( src : Either[A,B] )( f : A => Either[Z,BB] ) : Either[Z,BB] = {
+          src match {
+            case Left( a )  => f( a )
+            case Right( _ ) => src.asInstanceOf[Right[Z,B]]
+          }
+        }
+        def map[A, B>:E, Z]( src : Either[A,B] )( f : A => Z ) : Either[Z,B] = {
+          src match {
+            case Left( a )  => Left( f( a ) )
+            case Right( _ ) => src.asInstanceOf[Right[Z,B]]
+          }
+        }
+        def withFilter[A,B>:E]( src : Either[A,B] )( p : A => Boolean ) : Either[A,B] = {
+          src match {
+            case l @  Left( a ) => if ( p(a) ) l else rightEmpty;
+            case     Right( _ ) => src;
+          }
+        }
+
+        // extra ops
+        def exists[A,B>:E]( src : Either[A,B] )( f : A => Boolean ) : Boolean = {
+          src match {
+            case Left( a )  => f(a);
+            case Right( _ ) => false;
+          }
+        }
+        def forall[A,B>:E]( src : Either[A,B] )( f : A => Boolean ) : Boolean = {
+          src match {
+            case Left( a )  => f(a)
+            case Right( _ ) => true;
+          }
+        }
+        def foreach[A,B>:E,U]( src : Either[A,B] )( f : A => U ) : Any = {
+          src match {
+            case Left( a )  => f(a);
+            case Right( _ ) => ();
+          }
+        }
+        def get[A,B>:E]( src : Either[A,B] ) : A = {
+          src match {
+            case Left( a )  => a;
+            case Right( _ ) => throw new NoSuchElementException( NoSuchLeftMessage );
+          }
+        }
+        def getOrElse[A, AA>:A, B>:E]( src : Either[A,B] )( or : =>AA ) : AA = {
+          src match {
+            case Left( a )  => a;
+            case Right( _ ) => or;
+          }
+        }
+        def toOption[A,B>:E]( src : Either[A,B] ) : Option[A] = {
+          src match {
+            case Left( a )  => Some( a );
+            case Right( _ ) => None; 
+          }
+        }
+        def toSeq[A,B>:E]( src : Either[A,B] ) : collection.Seq[A] = {
+          src match {
+            case Left( a )  => collection.Seq( a );
+            case Right( _ ) => collection.Seq.empty[A];
+          }
+        }
+        def fold[A,B>:E,Z]( src : Either[A,B] )( ifLeft : A => Z )( ifRight : B => Z ) : Z = {
+          src match {
+            case Left( a ) => ifLeft( a );
+            case Right( b ) => ifRight( b );
+          }
+        }
+
+        implicit def toOps[A,B>:E]( src : Either[A,B] ) : LeftBiased.WithEmptyToken.Ops[A,B] = new LeftBiased.WithEmptyToken.Ops[A,B]( src )( this )
+      }
+      def apply[E]( token : E ) : WithEmptyToken[E] = new WithEmptyToken( token );
+
+      object Throwing {
+        def apply( throwableBuilder : =>java.lang.Throwable ) : Throwing = new Throwing( throwableBuilder );
+      }
+      final class Throwing private( throwableBuilder : =>java.lang.Throwable ) extends WithEmptyToken.Generic[Nothing] {
+        override def empty : Nothing = throw throwableBuilder;
+      }
+    }
+    final class WithEmptyToken[+E] private( override val empty : E ) extends WithEmptyToken.Generic[E] {
+      override protected val rightEmpty : Right[Nothing,E] = Right(empty);
+    }
+  } 
+  trait LeftBiased[B] {
+    val EmptyTokenDefinition : Either.LeftBiased.WithEmptyToken.Generic[B] = LeftBiased.DefaultThrowingOps;
+
+    implicit def toLeftBiasedEtherOps[A]( src : Either[A,B] ) : LeftBiased.WithEmptyToken.AbstractOps[A,B] = new LeftBiased.WithEmptyToken.Ops[A,B]( src )( EmptyTokenDefinition );
+  }
+
+  private def matchErrorMessage[A,B]( rightBiased : Boolean, mbEither : Option[Either[A,B]] = None ) = {
+    val bias = if ( rightBiased ) "Right-biased" else "Left-biased";
+    val withToken = if ( rightBiased ) "RightBiased.WithEmptyToken" else "LeftBiased.WithEmptyToken";
+    val eitherRep = mbEither.fold(" ")( either => s" '${either}' " );
+    s"${bias} Either${eitherRep}filtered to empty or failed to match a pattern. Consider implementing ${withToken}"
+  }
+
+  private val NoSuchLeftMessage = "Can't get a value from a LeftBiased Either which is in fact a Right.";
+  private val NoSuchRightMessage = "Can't get a value from a RightBiased Either which is in fact a Left.";
 }

--- a/src/library/scala/util/Either.scala
+++ b/src/library/scala/util/Either.scala
@@ -597,8 +597,8 @@ object Either {
 
     def isLeftBias  : Boolean;
     def isRightBias : Boolean = !isLeftBias;
-    def conformsToBias[A,B]( src : Either[A,B] ) : Boolean = {
-      src match {
+    def conformsToBias[A,B]( target : Either[A,B] ) : Boolean = {
+      target match {
         case Left( _ )  => isLeftBias;
         case Right( _ ) => isRightBias;
       }
@@ -608,57 +608,57 @@ object Either {
 
     private[Either] final val DefaultThrowingOps = withEmptyToken.Throwing( throw new NoSuchElementException( noSuchElementMessage( true ) ) );
 
-    implicit class Ops[A,B]( val src : Either[A,B] ) extends AnyVal { // alas, we don't define a trait, but write all these ops twice, so we can avoid boxing here
+    implicit class Ops[A,B]( val target : Either[A,B] ) extends AnyVal { // alas, we don't define a trait, but write all these ops twice, so we can avoid boxing here
 
       // monad ops
-      def flatMap[AA >: A, Z]( f : B => Either[AA,Z] ) : Either[AA,Z] = DefaultThrowingOps.flatMap[A,AA,B,Z]( src )( f );
-      def map[Z]( f : B => Z )                         : Either[A,Z]  = DefaultThrowingOps.map( src )( f );
-      def withFilter( p : B => Boolean )               : Either[A,B]  = DefaultThrowingOps.withFilter( src )( p );
+      def flatMap[AA >: A, Z]( f : B => Either[AA,Z] ) : Either[AA,Z] = DefaultThrowingOps.flatMap[A,AA,B,Z]( target )( f );
+      def map[Z]( f : B => Z )                         : Either[A,Z]  = DefaultThrowingOps.map( target )( f );
+      def withFilter( p : B => Boolean )               : Either[A,B]  = DefaultThrowingOps.withFilter( target )( p );
 
       // extra ops
-      def exists( f : B => Boolean )                  : Boolean           = DefaultThrowingOps.exists( src )( f );
-      def forall( f : B => Boolean )                  : Boolean           = DefaultThrowingOps.forall( src )( f );
-      def foreach[U]( f : B => U )                    : Any               = DefaultThrowingOps.foreach( src )( f );
-      def get                                         : B                 = DefaultThrowingOps.get( src );
-      def getOrElse[ BB >: B ]( or : =>BB )           : BB                = DefaultThrowingOps.getOrElse[A,B,BB]( src )( or );
-      def toOption                                    : Option[B]         = DefaultThrowingOps.toOption( src );
-      def toSeq                                       : collection.Seq[B] = DefaultThrowingOps.toSeq( src );
-      def xget                                        : A                 = DefaultThrowingOps.xget( src );
-      def xgetOrElse[AA>:A]( or : =>AA )              : AA                = DefaultThrowingOps.xgetOrElse[A,AA,B]( src )( or );
-      def xmap[Z]( f : A => Z )                       : Either[Z,B]       = DefaultThrowingOps.xmap( src )( f );
-      def replaceIfEmpty[AA>:A]( replacement : =>AA ) : Either[AA,B]      = DefaultThrowingOps.replaceIfEmpty[A,AA,B]( src )( replacement );
+      def exists( f : B => Boolean )                  : Boolean           = DefaultThrowingOps.exists( target )( f );
+      def forall( f : B => Boolean )                  : Boolean           = DefaultThrowingOps.forall( target )( f );
+      def foreach[U]( f : B => U )                    : Any               = DefaultThrowingOps.foreach( target )( f );
+      def get                                         : B                 = DefaultThrowingOps.get( target );
+      def getOrElse[ BB >: B ]( or : =>BB )           : BB                = DefaultThrowingOps.getOrElse[A,B,BB]( target )( or );
+      def toOption                                    : Option[B]         = DefaultThrowingOps.toOption( target );
+      def toSeq                                       : collection.Seq[B] = DefaultThrowingOps.toSeq( target );
+      def xget                                        : A                 = DefaultThrowingOps.xget( target );
+      def xgetOrElse[AA>:A]( or : =>AA )              : AA                = DefaultThrowingOps.xgetOrElse[A,AA,B]( target )( or );
+      def xmap[Z]( f : A => Z )                       : Either[Z,B]       = DefaultThrowingOps.xmap( target )( f );
+      def replaceIfEmpty[AA>:A]( replacement : =>AA ) : Either[AA,B]      = DefaultThrowingOps.replaceIfEmpty[A,AA,B]( target )( replacement );
       def isLeftBiased                                : Boolean           = DefaultThrowingOps.isLeftBias;
       def isRightBiased                               : Boolean           = DefaultThrowingOps.isRightBias;
-      def conformsToBias                              : Boolean           = DefaultThrowingOps.conformsToBias( src );
+      def conformsToBias                              : Boolean           = DefaultThrowingOps.conformsToBias( target );
     }
 
     object withEmptyToken {
-      abstract class AbstractOps[A,B]( src : Either[A,B] )( opsTypeClass : Either.RightBias.withEmptyToken.Generic[A] ) {
+      abstract class AbstractOps[A,B]( target : Either[A,B] )( opsTypeClass : Either.RightBias.withEmptyToken.Generic[A] ) {
 
         // monad ops
-        def flatMap[AA >: A, Z]( f : B => Either[AA,Z] ) : Either[AA,Z] = opsTypeClass.flatMap[A,AA,B,Z]( src )( f );
-        def map[Z]( f : B => Z )                         : Either[A,Z]  = opsTypeClass.map( src )( f );
-        def withFilter( p : B => Boolean )               : Either[A,B]  = opsTypeClass.withFilter( src )( p );
+        def flatMap[AA >: A, Z]( f : B => Either[AA,Z] ) : Either[AA,Z] = opsTypeClass.flatMap[A,AA,B,Z]( target )( f );
+        def map[Z]( f : B => Z )                         : Either[A,Z]  = opsTypeClass.map( target )( f );
+        def withFilter( p : B => Boolean )               : Either[A,B]  = opsTypeClass.withFilter( target )( p );
 
         // extra ops
-        def exists( f : B => Boolean )                  : Boolean           = opsTypeClass.exists( src )( f );
-        def forall( f : B => Boolean )                  : Boolean           = opsTypeClass.forall( src )( f );
-        def foreach[U]( f : B => U )                    : Any               = opsTypeClass.foreach( src )( f );
-        def get                                         : B                 = opsTypeClass.get( src );
-        def getOrElse[BB>:B]( or : =>BB )               : BB                = opsTypeClass.getOrElse[A,B,BB]( src )( or );
-        def toOption                                    : Option[B]         = opsTypeClass.toOption( src );
-        def toSeq                                       : collection.Seq[B] = opsTypeClass.toSeq( src );
-        def isEmpty                                     : Boolean           = opsTypeClass.isEmpty( src );
-        def xget                                        : A                 = opsTypeClass.xget( src );
-        def xgetOrElse[AA>:A]( or : =>AA )              : AA                = opsTypeClass.xgetOrElse[A,AA,B]( src )( or );
-        def xmap[Z]( f : A => Z )                       : Either[Z,B]       = opsTypeClass.xmap( src )( f );
-        def replaceIfEmpty[AA>:A]( replacement : =>AA ) : Either[AA,B]      = opsTypeClass.replaceIfEmpty[A,AA,B]( src )( replacement );
+        def exists( f : B => Boolean )                  : Boolean           = opsTypeClass.exists( target )( f );
+        def forall( f : B => Boolean )                  : Boolean           = opsTypeClass.forall( target )( f );
+        def foreach[U]( f : B => U )                    : Any               = opsTypeClass.foreach( target )( f );
+        def get                                         : B                 = opsTypeClass.get( target );
+        def getOrElse[BB>:B]( or : =>BB )               : BB                = opsTypeClass.getOrElse[A,B,BB]( target )( or );
+        def toOption                                    : Option[B]         = opsTypeClass.toOption( target );
+        def toSeq                                       : collection.Seq[B] = opsTypeClass.toSeq( target );
+        def isEmpty                                     : Boolean           = opsTypeClass.isEmpty( target );
+        def xget                                        : A                 = opsTypeClass.xget( target );
+        def xgetOrElse[AA>:A]( or : =>AA )              : AA                = opsTypeClass.xgetOrElse[A,AA,B]( target )( or );
+        def xmap[Z]( f : A => Z )                       : Either[Z,B]       = opsTypeClass.xmap( target )( f );
+        def replaceIfEmpty[AA>:A]( replacement : =>AA ) : Either[AA,B]      = opsTypeClass.replaceIfEmpty[A,AA,B]( target )( replacement );
         def isLeftBiased                                : Boolean           = opsTypeClass.isLeftBias;
         def isRightBiased                               : Boolean           = opsTypeClass.isRightBias;
-        def conformsToBias                              : Boolean           = opsTypeClass.conformsToBias( src );
+        def conformsToBias                              : Boolean           = opsTypeClass.conformsToBias( target );
       }
 
-      implicit final class Ops[A,B]( src : Either[A,B] )( implicit opsTypeClass : Either.RightBias.withEmptyToken.Generic[A] ) extends AbstractOps( src )( opsTypeClass );
+      implicit final class Ops[A,B]( target : Either[A,B] )( implicit opsTypeClass : Either.RightBias.withEmptyToken.Generic[A] ) extends AbstractOps( target )( opsTypeClass );
 
       trait Generic[+E] extends Either.Bias[E] {
         /*
@@ -670,95 +670,95 @@ object Either {
          */ 
         protected def leftEmpty : Left[E,Nothing];
 
-        def isEmpty[A>:E,B]( src : Either[A,B] ) : Boolean;
+        def isEmpty[A>:E,B]( target : Either[A,B] ) : Boolean;
 
         // monad ops
-        def flatMap[A>:E,AA>:A,B,Z]( src : Either[A,B] )( f : B => Either[AA,Z] ) : Either[AA,Z] = {
-          src match {
-            case Left( _ )  => src.asInstanceOf[Left[A,Z]]
+        def flatMap[A>:E,AA>:A,B,Z]( target : Either[A,B] )( f : B => Either[AA,Z] ) : Either[AA,Z] = {
+          target match {
+            case Left( _ )  => target.asInstanceOf[Left[A,Z]]
             case Right( b ) => f( b )
           }
         }
-        def map[A>:E,B,Z]( src : Either[A,B] )( f : B => Z ) : Either[A,Z] = {
-          src match {
-            case Left( _ )  => src.asInstanceOf[Left[A,Z]]
+        def map[A>:E,B,Z]( target : Either[A,B] )( f : B => Z ) : Either[A,Z] = {
+          target match {
+            case Left( _ )  => target.asInstanceOf[Left[A,Z]]
             case Right( b ) => Right( f( b ) )
           }
         }
-        def withFilter[A>:E,B]( src : Either[A,B] )( p : B => Boolean ) : Either[A,B] = {
-          src match {
-            case      Left( _ ) => src;
+        def withFilter[A>:E,B]( target : Either[A,B] )( p : B => Boolean ) : Either[A,B] = {
+          target match {
+            case      Left( _ ) => target;
             case r @ Right( b ) => if ( p(b) ) r else leftEmpty;
           }
         }
 
         // extra ops
-        def exists[A>:E,B]( src : Either[A,B] )( f : B => Boolean ) : Boolean = {
-          src match {
+        def exists[A>:E,B]( target : Either[A,B] )( f : B => Boolean ) : Boolean = {
+          target match {
             case Left( _ )  => false;
             case Right( b ) => f( b );
           }
         }
-        def forall[A>:E,B]( src : Either[A,B] )( f : B => Boolean ) : Boolean = {
-          src match {
+        def forall[A>:E,B]( target : Either[A,B] )( f : B => Boolean ) : Boolean = {
+          target match {
             case Left( _ )  => true;
             case Right( b ) => f( b );
           }
         }
-        def foreach[A>:E,B,U]( src : Either[A,B] )( f : B => U ) : Any = {
-          src match {
+        def foreach[A>:E,B,U]( target : Either[A,B] )( f : B => U ) : Any = {
+          target match {
             case Left( _ )  => ();
             case Right( b ) => f( b );
           }
         }
-        def get[A>:E,B]( src : Either[A,B] ) : B = {
-          src match {
+        def get[A>:E,B]( target : Either[A,B] ) : B = {
+          target match {
             case Left( _ )  => throw new NoSuchElementException( NoSuchRightMessage );
             case Right( b ) => b;
           }
         }
-        def getOrElse[A>:E,B,BB>:B]( src : Either[A,B] )( or : =>BB ) : BB = {
-          src match {
+        def getOrElse[A>:E,B,BB>:B]( target : Either[A,B] )( or : =>BB ) : BB = {
+          target match {
             case Left( _ )  => or;
             case Right( b ) => b;
           }
         }
-        def toOption[A>:E,B]( src : Either[A,B] ) : Option[B] = {
-          src match {
+        def toOption[A>:E,B]( target : Either[A,B] ) : Option[B] = {
+          target match {
             case Left( _ )  => None;
             case Right( b ) => Some( b );
           }
         }
-        def toSeq[A>:E,B]( src : Either[A,B] ) : collection.Seq[B] = {
-          src match {
+        def toSeq[A>:E,B]( target : Either[A,B] ) : collection.Seq[B] = {
+          target match {
             case Left( _ )  => collection.Seq.empty[B];
             case Right( b ) => collection.Seq( b );
           }
         }
-        def xget[A>:E,B]( src : Either[A,B] ) : A = {
-          src match {
+        def xget[A>:E,B]( target : Either[A,B] ) : A = {
+          target match {
             case Left( a )  => a;
             case Right( _ ) => throw new NoSuchElementException( NoSuchXLeftMessage );
           }
         }
-        def xgetOrElse[A>:E,AA>:A,B]( src : Either[A,B] )( or : =>AA ) : AA = {
-          src match {
+        def xgetOrElse[A>:E,AA>:A,B]( target : Either[A,B] )( or : =>AA ) : AA = {
+          target match {
             case Left( a )  => a;
             case Right( _ ) => or;
           }
         }
-        def xmap[A>:E,B,Z]( src : Either[A,B] )( f : A => Z ) : Either[Z,B] = {
-          src match {
+        def xmap[A>:E,B,Z]( target : Either[A,B] )( f : A => Z ) : Either[Z,B] = {
+          target match {
             case Left( a )  => Left( f( a ) )
-            case Right( _ ) => src.asInstanceOf[Right[Z,B]]
+            case Right( _ ) => target.asInstanceOf[Right[Z,B]]
           }
         }
-        def replaceIfEmpty[A>:E,AA>:A,B]( src : Either[A,B] )( replacement : =>AA ) : Either[AA,B] = {
-          if (isEmpty( src )) Left( replacement ) else src;
+        def replaceIfEmpty[A>:E,AA>:A,B]( target : Either[A,B] )( replacement : =>AA ) : Either[AA,B] = {
+          if (isEmpty( target )) Left( replacement ) else target;
         }
         def isLeftBias  : Boolean = false;
 
-        implicit def toOps[A>:E,B]( src : Either[A,B] ) : RightBias.withEmptyToken.Ops[A,B] = new RightBias.withEmptyToken.Ops[A,B]( src )( this )
+        implicit def toOps[A>:E,B]( target : Either[A,B] ) : RightBias.withEmptyToken.Ops[A,B] = new RightBias.withEmptyToken.Ops[A,B]( target )( this )
       }
       def apply[E]( token : E ) : withEmptyToken[E] = new withEmptyToken( token );
 
@@ -770,19 +770,22 @@ object Either {
 
         override def empty : Nothing = throw throwableBuilder;
 
-        override def isEmpty[A,B]( src : Either[A,B] ) : Boolean = false; // no state represents empty, empties cannot be formed as an Exception is thrown when it is tried
+        override def isEmpty[A,B]( target : Either[A,B] ) : Boolean = false; // no state represents empty, empties cannot be formed as an Exception is thrown when it is tried
       }
     }
     final class withEmptyToken[+E] private( override val empty : E ) extends withEmptyToken.Generic[E] {
       override protected val leftEmpty : Left[E,Nothing] = Left(empty);
 
-      override def isEmpty[A>:E,B]( src : Either[A,B] ) : Boolean = (src == leftEmpty);
+      override def isEmpty[A>:E,B]( target : Either[A,B] ) : Boolean = (target == leftEmpty);
+    }
+    abstract class Base[L]( emptyToken : L ) extends RightBias[L] {
+      override val EmptyTokenDefinition = RightBias.withEmptyToken[L]( emptyToken )
     }
   }
-  trait RightBias[A] {
-    val EmptyTokenDefinition : Either.RightBias.withEmptyToken.Generic[A] = RightBias.DefaultThrowingOps;
+  trait RightBias[L] {
+    val EmptyTokenDefinition : Either.RightBias.withEmptyToken.Generic[L] = RightBias.DefaultThrowingOps;
 
-    implicit def toRightBiasEtherOps[B]( src : Either[A,B] ) : RightBias.withEmptyToken.AbstractOps[A,B] = new RightBias.withEmptyToken.Ops[A,B]( src )( EmptyTokenDefinition );
+    implicit def toRightBiasEtherOps[R]( target : Either[L,R] ) : RightBias.withEmptyToken.AbstractOps[L,R] = new RightBias.withEmptyToken.Ops[L,R]( target )( EmptyTokenDefinition );
   }
   /**
     *  This object contains utilities for defining an environment in which `Either` instances are "left-biased".
@@ -840,21 +843,21 @@ object Either {
     * }}}
     *  That's fine, but if anything goes wrong, clients will receive a value `None`, and have no specific information
     *  about what the problem was. Instead of option, we might try to use Either, defining error codes
-    *  for things that can go wrong. (We'll let our error codes be `Int` for this example, but should probably 
-    *  more descriptive kinds of object in real life.) Unconventionally (since we are considering left-biased
+    *  for things that can go wrong. (We'll let our error codes be `Int` for this example, but ''errors should 
+    *  be represented by descriptive kinds of object in real applications.'') Unconventionally (since we are considering left-biased
     *  `Either` here), we'll let good values arrive as `Left` values and embed our error codes in `Right` objects.
     * {{{
-    *     val ErrIO              = 1
-    *     val ErrNoParse         = 2
-    *     val ErrBadYear         = 3
-    *     val ErrProcessorFailed = 4
+    *     val ErrIO               = 1
+    *     val ErrNoParse          = 2
+    *     val ErrBadYear          = 3
+    *     val ErrProcessorFailure = 4
     * 
     *     case class Record( opCode : Int, data : Seq[Byte], year : Int )
     *     trait Result
     * 
-    *     def loadURL( url : String ) : Either[Seq[Byte],Int] = ???
-    *     def parseRecord( bytes : Seq[Byte] ) : Either[Record,Int] = ???
-    *     def process( opCode : Int, data : Seq[Byte] ) : Either[Result,Int] = ???
+    *     def loadURL( url : String ) : Either[Seq[Byte],Int] = ???                // fails w/ErrIO
+    *     def parseRecord( bytes : Seq[Byte] ) : Either[Record,Int] = ???          // fails w/ErrNoParse
+    *     def process( opCode : Int, data : Seq[Byte] ) : Either[Result,Int] = ??? // fails w/ErrProcessorFailure
     * 
     *     // we try to use the left projection but the
     *     // for comprehension fails to compile
@@ -867,25 +870,26 @@ object Either {
     *     }
     * }}}
     *   Unfortunately, this fails to compile, because [[scala.util.Either.LeftProjection]] does not support
-    *   pattern-matching (required to extract `opCode`, `data`, and `year`) or filtering (which we perform based on `year`).
+    *   pattern-matching (used to extract `opCode`, `data`, and `year`) or filtering (which we perform based on `year`).
     * 
     *   Instead, we can left-bias the `Either`:
     * {{{
-    *     val ErrIO              = 1
-    *     val ErrNoParse         = 2
-    *     val ErrBadYear         = 3
-    *     val ErrProcessorFailed = 4
+    *     val ErrEmpty            = -1
+    *     val ErrIO               =  1
+    *     val ErrNoParse          =  2
+    *     val ErrBadYear          =  3
+    *     val ErrProcessorFailure =  4
     * 
     *     // left-bias Either 
-    *     val LeftBias = Either.LeftBias.withEmptyToken( ErrBadYear ) 
+    *     val LeftBias = Either.LeftBias.withEmptyToken( ErrEmpty ) 
     *     import LeftBias._
     * 
     *     case class Record( opCode : Int, data : Seq[Byte], year : Int )
     *     trait Result
     * 
-    *     def loadURL( url : String ) : Either[Seq[Byte],Int] = ???
-    *     def parseRecord( bytes : Seq[Byte] ) : Either[Record,Int] = ???
-    *     def process( opCode : Int, data : Seq[Byte] ) : Either[Result,Int] = ???
+    *     def loadURL( url : String ) : Either[Seq[Byte],Int] = ???                // fails w/ErrIO
+    *     def parseRecord( bytes : Seq[Byte] ) : Either[Record,Int] = ???          // fails w/ErrNoParse
+    *     def process( opCode : Int, data : Seq[Byte] ) : Either[Result,Int] = ??? // fails w/ErrProcessorFailure
     * 
     *     // use Either directly, rather than a projection, in the for comprehension
     *     def processURL( url : String ) : Either[Result,Int] = {
@@ -896,42 +900,44 @@ object Either {
     *       } yield result
     *     }
     * }}}
-    *   An "empty" `Either` here could only result from the failure of the year filter,
-    *   so we set `ErrBadYear` to be the token supplied when the filtering fail. Note that
-    *   once the left-biased operations have been imported, a sequence `Either` yielding
-    *   values can be used directly in the for comprehension, without extractions of a projection
-    *   with `.left`.
     * 
-    *   The scope of the left-biasing is the scope of the import. In our example above, our choice
-    *   of error token was very specific to this definition. In fact, it might have been better
-    *   to narrow the scope of the bias to within the `processURL(...)` function.
+    *   There is a problem: `ErrEmpty`, would be the result of the year filter failing, 
+    *   when it should be `ErrBadYear`. 
+    * 
+    *   The most general and straightforward wat to fix this is to replace empty
+    *   tokens as they arrive with more informative errors. For this purpose,
+    *   biased `Either` offers a method called [[LeftBias.Ops.replaceIfEmpty]]: 
+    * 
     * {{{
-    *     // same definitions as above
-    *     // except the import statement sits within the method
+    *     // use Either directly, rather than a projection, in the for comprehension
     *     def processURL( url : String ) : Either[Result,Int] = {
-    *       import LeftBias._
+    *       val processed = {
+    *         for {
+    *           rawBytes                     <- loadURL( url )
+    *           Record( opCode, data, year ) <- parseRecord( rawBytes )
+    *           result                       <- process( opCode, data ) if year >= 2011
+    *         } yield result
+    *       }
+    *       processed.replaceIfEmpty( ErrBadYear )
+    *     }
+    * }}}
+    * 
+    *   The scope of the left-bias is the scope of the import. An alternative way to
+    *   ensure empty tokens yield meaningful information is to define separate biases
+    *   for separate contexts.
+    * 
+    * {{{
+    *     val ProcessURLBias       = Either.LeftBias.withEmptyToken( ErrBadYear ) 
+    *     val EnableHyperdriveBias = Either.LeftBias.withEmptyToken( ErrSpaceTimeRupture )
+    *     ...
+    * 
+    *     def processURL( url : String ) : Either[Result,Int] = {
+    *       import ProcessURLBias._
     *       for {
     *         rawBytes                     <- loadURL( url )
     *         Record( opCode, data, year ) <- parseRecord( rawBytes )
     *         result                       <- process( opCode, data ) if year >= 2011
     *       } yield result
-    *     }
-    * }}}
-    *   Other times, we might define a convention suitable for use within an entire
-    *   package, in which case we can extend the trait [[Either.LeftBias! Either.LeftBias]]:
-    * {{{
-    *     package util {
-    *       object Err {
-    *         case object Empty extends Err( -1, "A series of operations yielded no suitable value." );
-    *         case object Explosion extends Err( Int.MaxValue, "Boom!");
-    *       }
-    *       class Err( val code : Int, val description : String )
-    *     }
-    * 
-    *     // `Either` will be left-biased in all traits, classes, and objects 
-    *     // belonging package `mypkg`
-    *     package object mypkg extends Either.LeftBias[util.Err] {
-    *       override val EmptyTokenDefinition = Either.LeftBias.withEmptyToken(util.Err.Empty);
     *     }
     * }}}
     */ 
@@ -950,28 +956,188 @@ object Either {
       * }}}
       * For more, please see [[LeftBias$ LeftBias]].
       */
-    implicit class Ops[A,B]( val src : Either[A,B] ) extends AnyVal { // alas, we don't define a trait, but write all these ops twice, so we can avoid boxing here
+    implicit class Ops[A,B]( val target : Either[A,B] ) extends AnyVal { // alas, we don't define a trait, but write all these ops twice, so we can avoid boxing here
 
       // monad ops
-      def flatMap[BB >: B, Z]( f : A => Either[Z,BB] ) : Either[Z,BB] = DefaultThrowingOps.flatMap[A,B,BB,Z]( src )( f );
-      def map[Z]( f : A => Z )                         : Either[Z,B]  = DefaultThrowingOps.map( src )( f );
-      def withFilter( p : A => Boolean )               : Either[A,B]  = DefaultThrowingOps.withFilter( src )( p );
+      /**
+        * Binds the given function across `Left` of a left-biased `Either`.
+        *
+        * {{{
+        * Left(12).flatMap(x => Left("scala")) // Left("scala")
+        * Right(12).flatMap(x => Left("scala") // Right(12)
+        * }}}
+        * @param f The function to bind across `Left`.
+        */
+      def flatMap[BB >: B, Z]( f : A => Either[Z,BB] ) : Either[Z,BB] = DefaultThrowingOps.flatMap[A,B,BB,Z]( target )( f );
+      /**
+        * Maps the function argument through `Left` of a left-biased `Either`.
+        *
+        * {{{
+        * Left(12).map(_ + 2) // Left(14)
+        * Right[Int, Int](12).map(_ + 2) // Right(12)
+        * }}}
+        */
+      def map[Z]( f : A => Z ) : Either[Z,B] = DefaultThrowingOps.map( target )( f );
+      /**
+        * Returns the target left-biased `Either` unchanged if it is a `Left` and the predicate `p`
+        * holds for its value, or if it is any `Right`.
+        * 
+        * Returns a `Right` containing the empty token if the target is a `Left` but predicate `p`
+        * fails to hold. If no empty token has been set, a `java.util.NoSuchElementException` will
+        * be thrown.
+        *
+        * {{{
+        * val LeftBias = LeftBias.withEmptyToken[Int](-1);
+        * import LeftBias._
+        * 
+        * Left(12).withFilter(_ > 10)  // Left(12)
+        * Left(7).withFilter(_ > 10)   // Right(-1)
+        * Right(12).withFilter(_ > 10) // Right(12)
+        * }}}
+        */
+      def withFilter( p : A => Boolean ) : Either[A,B] = DefaultThrowingOps.withFilter( target )( p );
 
       // extra ops
-      def exists( f : A => Boolean )          : Boolean              = DefaultThrowingOps.exists( src )( f );
-      def forall( f : A => Boolean )          : Boolean              = DefaultThrowingOps.forall( src )( f );
-      def foreach[U]( f : A => U )            : Any                  = DefaultThrowingOps.foreach( src )( f );
-      def get                                 : A                    = DefaultThrowingOps.get( src );
-      def getOrElse[AA >: A ]( or : =>AA )    : AA                   = DefaultThrowingOps.getOrElse[A,AA,B]( src )( or );
-      def toOption                            : Option[A]            = DefaultThrowingOps.toOption( src );
-      def toSeq                               : collection.Seq[A]    = DefaultThrowingOps.toSeq( src );
-      def xget                                : B                    = DefaultThrowingOps.xget( src );
-      def xgetOrElse[BB>:B]( or : =>BB )      : BB                   = DefaultThrowingOps.xgetOrElse[A,B,BB]( src )( or );
-      def xmap[Z]( f : B => Z )               : Either[A,Z]          = DefaultThrowingOps.xmap( src )( f );
-      def replaceIfEmpty[BB>:B]( replacement : =>BB ) : Either[A,BB] = DefaultThrowingOps.replaceIfEmpty[A,B,BB]( src )( replacement )
-      def isLeftBiased                        : Boolean              = DefaultThrowingOps.isLeftBias;
-      def isRightBiased                       : Boolean              = DefaultThrowingOps.isRightBias;
-      def conformsToBias                      : Boolean              = DefaultThrowingOps.conformsToBias( src );
+      /**
+        * Returns `false` if the target left-biased `Either` is a `Right` or returns the result of the application of
+        * the given function to the `Left` value.
+        *
+        * {{{
+        * Left(12).exists(_ > 10)  // true
+        * Left(7).exists(_ > 10)   // false
+        * Right(12).left.exists(_ > 10) // false
+        * }}}
+        *
+        */
+      def exists( f : A => Boolean ) : Boolean = DefaultThrowingOps.exists( target )( f );
+      /**
+        * Returns `true` if the target left-biased `Either` is `Right` or returns 
+        * the result of the application of the given function to the `Left` value.
+        *
+        * {{{
+        * Left(12).forall(_ > 10)  // true
+        * Left(7).forall(_ > 10)   // false
+        * Right(12).forall(_ > 10) // true
+        * }}}
+        *
+        */
+      def forall( f : A => Boolean ) : Boolean = DefaultThrowingOps.forall( target )( f );
+      /**
+        * Executes the given side-effecting function if the target left-biased `Either` is a `Left`.
+        *
+        * {{{
+        * Left(12).foreach(x => println(x))  // prints "12"
+        * Right(12).foreach(x => println(x)) // doesn't print
+        * }}}
+        * 
+        * @param f The side-effecting function to execute.
+        */
+      def foreach[U]( f : A => U ) : Any = DefaultThrowingOps.foreach( target )( f );
+      /**
+        * Returns the value if the target left-biased `Either` is a `Left` or 
+        * throws `java.util.NoSuchElementException` if the target is a `Right`.
+        *
+        * {{{
+        * Left(12).get // 12
+        * Right(12).get // NoSuchElementException
+        * }}}
+        *
+        * @throws java.util.NoSuchElementException if the target is [[scala.util.Right]]
+        */
+      def get : A = DefaultThrowingOps.get( target );
+      /**
+        * Returns the value from the target left-biased `Either` if `Left`,
+        * or the given argument if it is a `Right`.
+        *
+        * {{{
+        * Left(12).getOrElse(17)  // 12
+        * Right(12).getOrElse(17) // 17
+        * }}}
+        *
+        */
+      def getOrElse[AA >: A ]( or : =>AA ) : AA = DefaultThrowingOps.getOrElse[A,AA,B]( target )( or );
+      /**
+        * Returns a `Some` containing the `Left` value of the target left-biased `Either` if it exists or a
+        * `None` if the target is a `Right`.
+        *
+        * {{{
+        * Left(12).toOption  // Some(12)
+        * Right(12).toOption // None
+        * }}}
+        */
+      def toOption : Option[A] = DefaultThrowingOps.toOption( target );
+      /**
+        * Returns a `Seq` containing the `Left` value if it exists or an empty
+        * `Seq` if the target left-biased `Either` is a `Right`.
+        *
+        * {{{
+        * Left(12).toSeq // Seq(12)
+        * Right(12).toSeq // Seq()
+        * }}}
+        */
+      def toSeq : collection.Seq[A] = DefaultThrowingOps.toSeq( target );
+      /**
+        * "cross-get" -- Returns the value if the target left-biased `Either` 
+        * does ''not'' conform to its bias, if it is a `Right`.
+        * Throws `java.util.NoSuchElementException` if the target is a `Left`.
+        *
+        * {{{
+        * Left(12).xget // NoSuchElementException
+        * Right(12).xget // 12
+        * }}}
+        *
+        * @throws java.util.NoSuchElementException if the target is [[scala.util.Left]]
+        */
+      def xget : B = DefaultThrowingOps.xget( target );
+      /**
+        * "cross-getOrElse" -- Returns the value from the target left-biased `Either` 
+        * if it does ''not'' conform to its bias and is a `Right`.
+        * Returns the given argument if it is a `Left`.
+        *
+        * {{{
+        * Right(12).xgetOrElse(17) // 12
+        * Right(12).xgetOrElse(17) // 17
+        * }}}
+        *
+        */
+      def xgetOrElse[BB>:B]( or : =>BB ) : BB = DefaultThrowingOps.xgetOrElse[A,B,BB]( target )( or );
+      /**
+        * "cross-map" -- Maps the function argument through `Right` ''against'' the bias the target left-biased `Either`.
+        *
+        * {{{
+        * Left(12).map(_ + 2) // Left(12)
+        * Right(12).map(_ + 2) // Right(14)
+        * }}}
+        */
+      def xmap[Z]( f : B => Z ) : Either[A,Z] = DefaultThrowingOps.xmap( target )( f );
+      /**
+        * If the target left-biased `Either` is a `Right` containing the empty token,
+        * returns a right containing `repleacement`. Otherwise returns the target `Either` unchanged.
+        *
+        * {{{
+        * // with empty token Int -1
+        * 
+        * Left(12).replaceIfEmpty(99) // Left(12)
+        * Left(-1).replaceIfEmpty(99) // Left(-1)
+        * Right(12).replaceIfEmpty(99) // Right(12)
+        * Right(-1).replaceIfEmpty(99) // Right(99)
+        * }}}
+        */
+      def replaceIfEmpty[BB>:B]( replacement : =>BB ) : Either[A,BB] = DefaultThrowingOps.replaceIfEmpty[A,B,BB]( target )( replacement )
+      /**
+        * Returns `true` when called on a wrapper representing a left-biased `Either`, `false` otherwise.
+        */
+      def isLeftBiased : Boolean = DefaultThrowingOps.isLeftBias;
+      /**
+        * Returns `true` when called on a wrapper representing a right-biased `Either`, `false` otherwise.
+        */
+      def isRightBiased : Boolean = DefaultThrowingOps.isRightBias;
+      /**
+        * Returns `true` if this wrapper represents a left-biased `Either` wrapping a `Left` or a 
+        * right-biased `Either` wrapping a `Right`. Returns `false` if this represents a left-biased
+        * `Either` wrapping a `Right` or a right-biased `Either` wrapping a left.
+        */
+      def conformsToBias : Boolean = DefaultThrowingOps.conformsToBias( target );
     }
 
     /**
@@ -1002,9 +1168,9 @@ object Either {
         *     tmp
         *   }
         *   val LeftBias = Either.LeftBias.withEmptyToken[Throwable]( EmptyThrowable );
-        *   implicit class LeftBiasOps( src : Either[A,Throwable] ) extends Either.LeftBias.withEmptyToken.AbstractOps( src )( LeftBias ) {
+        *   implicit class LeftBiasOps( target : Either[A,Throwable] ) extends Either.LeftBias.withEmptyToken.AbstractOps( target )( LeftBias ) {
         *      def raise : Unit = {
-        *        src match {
+        *        target match {
         *          case Left(_) => ();
         *          case Right( t ) => throw t;
         *        }
@@ -1012,28 +1178,188 @@ object Either {
         *   }
         * }}}
         */ 
-      abstract class AbstractOps[A,B]( src : Either[A,B] )( opsTypeClass : Either.LeftBias.withEmptyToken.Generic[B] ) {
+      abstract class AbstractOps[A,B]( target : Either[A,B] )( opsTypeClass : Either.LeftBias.withEmptyToken.Generic[B] ) {
 
         // monad ops
-        def flatMap[BB >: B, Z]( f : A => Either[Z,BB] ) : Either[Z,BB] = opsTypeClass.flatMap[A,B,BB,Z]( src )( f );
-        def map[Z]( f : A => Z )                         : Either[Z,B]  = opsTypeClass.map( src )( f );
-        def withFilter( p : A => Boolean )               : Either[A,B]  = opsTypeClass.withFilter( src )( p );
+        /**
+          * Binds the given function across `Left` of a left-biased `Either`.
+          *
+          * {{{
+          * Left(12).flatMap(x => Left("scala")) // Left("scala")
+          * Right(12).flatMap(x => Left("scala") // Right(12)
+          * }}}
+          * @param f The function to bind across `Left`.
+          */
+        def flatMap[BB >: B, Z]( f : A => Either[Z,BB] ) : Either[Z,BB] = opsTypeClass.flatMap[A,B,BB,Z]( target )( f );
+        /**
+          * Maps the function argument through `Left` of a left-biased `Either`.
+          *
+          * {{{
+          * Left(12).map(_ + 2) // Left(14)
+          * Right[Int, Int](12).map(_ + 2) // Right(12)
+          * }}}
+          */
+        def map[Z]( f : A => Z ) : Either[Z,B] = opsTypeClass.map( target )( f );
+        /**
+          * Returns the target left-biased `Either` unchanged if it is a `Left` and the predicate `p`
+          * holds for its value, or if it is any `Right`.
+          * 
+          * Returns a `Right` containing the empty token if the target is a `Left` but predicate `p`
+          * fails to hold. If no empty token has been set, a `java.util.NoSuchElementException` will
+          * be thrown.
+          *
+          * {{{
+          * val LeftBias = LeftBias.withEmptyToken[Int](-1);
+          * import LeftBias._
+          * 
+          * Left(12).withFilter(_ > 10)  // Left(12)
+          * Left(7).withFilter(_ > 10)   // Right(-1)
+          * Right(12).withFilter(_ > 10) // Right(12)
+          * }}}
+          */
+        def withFilter( p : A => Boolean ) : Either[A,B] = opsTypeClass.withFilter( target )( p );
 
         // extra ops
-        def exists( f : A => Boolean )                  : Boolean           = opsTypeClass.exists( src )( f );
-        def forall( f : A => Boolean )                  : Boolean           = opsTypeClass.forall( src )( f );
-        def foreach[U]( f : A => U )                    : Any               = opsTypeClass.foreach( src )( f );
-        def get                                         : A                 = opsTypeClass.get( src );
-        def getOrElse[AA >: A ]( or : =>AA )            : AA                = opsTypeClass.getOrElse[A,AA,B]( src )( or );
-        def toOption                                    : Option[A]         = opsTypeClass.toOption( src );
-        def toSeq                                       : collection.Seq[A] = opsTypeClass.toSeq( src );
-        def xget                                        : B                 = opsTypeClass.xget( src );
-        def xgetOrElse[BB>:B]( or : =>BB )              : BB                = opsTypeClass.xgetOrElse[A,B,BB]( src )( or );
-        def xmap[Z]( f : B => Z )                       : Either[A,Z]       = opsTypeClass.xmap( src )( f );
-        def replaceIfEmpty[BB>:B]( replacement : =>BB ) : Either[A,BB]      = opsTypeClass.replaceIfEmpty[A,B,BB]( src )( replacement )
-        def isLeftBiased                                : Boolean           = opsTypeClass.isLeftBias;
-        def isRightBiased                               : Boolean           = opsTypeClass.isRightBias;
-        def conformsToBias                              : Boolean           = opsTypeClass.conformsToBias( src );
+        /**
+          * Returns `false` if the target left-biased `Either` is a `Right` or returns the result of the application of
+          * the given function to the `Left` value.
+          *
+          * {{{
+          * Left(12).exists(_ > 10)  // true
+          * Left(7).exists(_ > 10)   // false
+          * Right(12).left.exists(_ > 10) // false
+          * }}}
+          *
+          */
+        def exists( f : A => Boolean ) : Boolean = opsTypeClass.exists( target )( f );
+        /**
+          * Returns `true` if the target left-biased `Either` is `Right` or returns 
+          * the result of the application of the given function to the `Left` value.
+          *
+          * {{{
+          * Left(12).forall(_ > 10)  // true
+          * Left(7).forall(_ > 10)   // false
+          * Right(12).forall(_ > 10) // true
+          * }}}
+          *
+          */
+        def forall( f : A => Boolean ) : Boolean = opsTypeClass.forall( target )( f );
+        /**
+          * Executes the given side-effecting function if the target left-biased `Either` is a `Left`.
+          *
+          * {{{
+          * Left(12).foreach(x => println(x))  // prints "12"
+          * Right(12).foreach(x => println(x)) // doesn't print
+          * }}}
+          * 
+          * @param f The side-effecting function to execute.
+          */
+        def foreach[U]( f : A => U ) : Any = opsTypeClass.foreach( target )( f );
+        /**
+          * Returns the value if the target left-biased `Either` is a `Left` or 
+          * throws `java.util.NoSuchElementException` if the target is a `Right`.
+          *
+          * {{{
+          * Left(12).get // 12
+          * Right(12).get // NoSuchElementException
+          * }}}
+          *
+          * @throws java.util.NoSuchElementException if the target is [[scala.util.Right]]
+          */
+        def get : A = opsTypeClass.get( target );
+        /**
+          * Returns the value from the target left-biased `Either` if `Left`,
+          * or the given argument if it is a `Right`.
+          *
+          * {{{
+          * Left(12).getOrElse(17)  // 12
+          * Right(12).getOrElse(17) // 17
+          * }}}
+          *
+          */
+        def getOrElse[AA >: A ]( or : =>AA ) : AA = opsTypeClass.getOrElse[A,AA,B]( target )( or );
+        /**
+          * Returns a `Some` containing the `Left` value of the target left-biased `Either` if it exists or a
+          * `None` if the target is a `Right`.
+          *
+          * {{{
+          * Left(12).toOption  // Some(12)
+          * Right(12).toOption // None
+          * }}}
+          */
+        def toOption : Option[A] = opsTypeClass.toOption( target );
+        /**
+          * Returns a `Seq` containing the `Left` value if it exists or an empty
+          * `Seq` if the target left-biased `Either` is a `Right`.
+          *
+          * {{{
+          * Left(12).toSeq // Seq(12)
+          * Right(12).toSeq // Seq()
+          * }}}
+          */
+        def toSeq : collection.Seq[A] = opsTypeClass.toSeq( target );
+        /**
+          * "cross-get" -- Returns the value if the target left-biased `Either` 
+          * does ''not'' conform to its bias, if it is a `Right`.
+          * Throws `java.util.NoSuchElementException` if the target is a `Left`.
+          *
+          * {{{
+          * Left(12).xget // NoSuchElementException
+          * Right(12).xget // 12
+          * }}}
+          *
+          * @throws java.util.NoSuchElementException if the target is [[scala.util.Left]]
+          */
+        def xget : B = opsTypeClass.xget( target );
+        /**
+          * "cross-getOrElse" -- Returns the value from the target left-biased `Either` 
+          * if it does ''not'' conform to its bias and is a `Right`.
+          * Returns the given argument if it is a `Left`.
+          *
+          * {{{
+          * Right(12).xgetOrElse(17) // 12
+          * Right(12).xgetOrElse(17) // 17
+          * }}}
+          *
+          */
+        def xgetOrElse[BB>:B]( or : =>BB ) : BB = opsTypeClass.xgetOrElse[A,B,BB]( target )( or );
+        /**
+          * "cross-map" -- Maps the function argument through `Right` ''against'' the bias the target left-biased `Either`.
+          *
+          * {{{
+          * Left(12).map(_ + 2) // Left(12)
+          * Right(12).map(_ + 2) // Right(14)
+          * }}}
+          */
+        def xmap[Z]( f : B => Z ) : Either[A,Z] = opsTypeClass.xmap( target )( f );
+        /**
+          * If the target left-biased `Either` is a `Right` containing the empty token,
+          * returns a right containing `repleacement`. Otherwise returns the target `Either` unchanged.
+          *
+          * {{{
+          * // with empty token Int -1
+          * 
+          * Left(12).replaceIfEmpty(99) // Left(12)
+          * Left(-1).replaceIfEmpty(99) // Left(-1)
+          * Right(12).replaceIfEmpty(99) // Right(12)
+          * Right(-1).replaceIfEmpty(99) // Right(99)
+          * }}}
+          */
+        def replaceIfEmpty[BB>:B]( replacement : =>BB ) : Either[A,BB] = opsTypeClass.replaceIfEmpty[A,B,BB]( target )( replacement )
+        /**
+          * Returns `true` when called on a wrapper representing a left-biased `Either`, `false` otherwise.
+          */
+        def isLeftBiased : Boolean = opsTypeClass.isLeftBias;
+        /**
+          * Returns `true` when called on a wrapper representing a right-biased `Either`, `false` otherwise.
+          */
+        def isRightBiased : Boolean = opsTypeClass.isRightBias;
+        /**
+          * Returns `true` if this wrapper represents a left-biased `Either` wrapping a `Left` or a 
+          * right-biased `Either` wrapping a `Right`. Returns `false` if this represents a left-biased
+          * `Either` wrapping a `Right` or a right-biased `Either` wrapping a left.
+          */
+        def conformsToBias : Boolean = opsTypeClass.conformsToBias( target );
       }
 
       /**
@@ -1041,7 +1367,7 @@ object Either {
         * to handling of an empty value resulting from a filter or failed pattern match -- is defined by
         * constructor argument `opsTypeClass`.
         */ 
-      implicit final class Ops[A,B]( src : Either[A,B] )( implicit opsTypeClass : Either.LeftBias.withEmptyToken.Generic[B] ) extends AbstractOps( src )( opsTypeClass );
+      implicit final class Ops[A,B]( target : Either[A,B] )( implicit opsTypeClass : Either.LeftBias.withEmptyToken.Generic[B] ) extends AbstractOps( target )( opsTypeClass );
 
       trait Generic[+E] extends Either.Bias[E] {
         /*
@@ -1053,95 +1379,95 @@ object Either {
          */ 
         protected def rightEmpty : Right[Nothing,E]; 
 
-        def isEmpty[A>:E,B]( src : Either[A,B] ) : Boolean;
+        def isEmpty[A>:E,B]( target : Either[A,B] ) : Boolean;
 
         // monad ops
-        def flatMap[A, B>:E, BB>:B ,Z]( src : Either[A,B] )( f : A => Either[Z,BB] ) : Either[Z,BB] = {
-          src match {
+        def flatMap[A, B>:E, BB>:B ,Z]( target : Either[A,B] )( f : A => Either[Z,BB] ) : Either[Z,BB] = {
+          target match {
             case Left( a )  => f( a )
-            case Right( _ ) => src.asInstanceOf[Right[Z,B]]
+            case Right( _ ) => target.asInstanceOf[Right[Z,B]]
           }
         }
-        def map[A, B>:E, Z]( src : Either[A,B] )( f : A => Z ) : Either[Z,B] = {
-          src match {
+        def map[A, B>:E, Z]( target : Either[A,B] )( f : A => Z ) : Either[Z,B] = {
+          target match {
             case Left( a )  => Left( f( a ) )
-            case Right( _ ) => src.asInstanceOf[Right[Z,B]]
+            case Right( _ ) => target.asInstanceOf[Right[Z,B]]
           }
         }
-        def withFilter[A,B>:E]( src : Either[A,B] )( p : A => Boolean ) : Either[A,B] = {
-          src match {
+        def withFilter[A,B>:E]( target : Either[A,B] )( p : A => Boolean ) : Either[A,B] = {
+          target match {
             case l @  Left( a ) => if ( p(a) ) l else rightEmpty;
-            case     Right( _ ) => src;
+            case     Right( _ ) => target;
           }
         }
 
         // extra ops
-        def exists[A,B>:E]( src : Either[A,B] )( f : A => Boolean ) : Boolean = {
-          src match {
+        def exists[A,B>:E]( target : Either[A,B] )( f : A => Boolean ) : Boolean = {
+          target match {
             case Left( a )  => f(a);
             case Right( _ ) => false;
           }
         }
-        def forall[A,B>:E]( src : Either[A,B] )( f : A => Boolean ) : Boolean = {
-          src match {
+        def forall[A,B>:E]( target : Either[A,B] )( f : A => Boolean ) : Boolean = {
+          target match {
             case Left( a )  => f(a)
             case Right( _ ) => true;
           }
         }
-        def foreach[A,B>:E,U]( src : Either[A,B] )( f : A => U ) : Any = {
-          src match {
+        def foreach[A,B>:E,U]( target : Either[A,B] )( f : A => U ) : Any = {
+          target match {
             case Left( a )  => f(a);
             case Right( _ ) => ();
           }
         }
-        def get[A,B>:E]( src : Either[A,B] ) : A = {
-          src match {
+        def get[A,B>:E]( target : Either[A,B] ) : A = {
+          target match {
             case Left( a )  => a;
             case Right( _ ) => throw new NoSuchElementException( NoSuchLeftMessage );
           }
         }
-        def getOrElse[A, AA>:A, B>:E]( src : Either[A,B] )( or : =>AA ) : AA = {
-          src match {
+        def getOrElse[A, AA>:A, B>:E]( target : Either[A,B] )( or : =>AA ) : AA = {
+          target match {
             case Left( a )  => a;
             case Right( _ ) => or;
           }
         }
-        def toOption[A,B>:E]( src : Either[A,B] ) : Option[A] = {
-          src match {
+        def toOption[A,B>:E]( target : Either[A,B] ) : Option[A] = {
+          target match {
             case Left( a )  => Some( a );
             case Right( _ ) => None; 
           }
         }
-        def toSeq[A,B>:E]( src : Either[A,B] ) : collection.Seq[A] = {
-          src match {
+        def toSeq[A,B>:E]( target : Either[A,B] ) : collection.Seq[A] = {
+          target match {
             case Left( a )  => collection.Seq( a );
             case Right( _ ) => collection.Seq.empty[A];
           }
         }
-        def xget[A,B>:E]( src : Either[A,B] ) : B = {
-          src match {
+        def xget[A,B>:E]( target : Either[A,B] ) : B = {
+          target match {
             case Left( _ )  => throw new NoSuchElementException( NoSuchXRightMessage );
             case Right( b ) => b;
           }
         }
-        def xgetOrElse[A,B>:E,BB>:B]( src : Either[A,B] )( or : =>BB ) : BB = {
-          src match {
+        def xgetOrElse[A,B>:E,BB>:B]( target : Either[A,B] )( or : =>BB ) : BB = {
+          target match {
             case Left( _ )  => or;
             case Right( b ) => b;
           }
         }
-        def xmap[A,B>:E,Z]( src : Either[A,B] )( f : B => Z ) : Either[A,Z] = {
-          src match {
-            case Left( _ )  => src.asInstanceOf[Left[A,Z]]
+        def xmap[A,B>:E,Z]( target : Either[A,B] )( f : B => Z ) : Either[A,Z] = {
+          target match {
+            case Left( _ )  => target.asInstanceOf[Left[A,Z]]
             case Right( b ) => Right( f(b) )
           }
         }
-        def replaceIfEmpty[A,B>:E,BB>:B]( src : Either[A,B] )( replacement : =>BB ) : Either[A,BB] = {
-          if (isEmpty( src )) Right( replacement ) else src;
+        def replaceIfEmpty[A,B>:E,BB>:B]( target : Either[A,B] )( replacement : =>BB ) : Either[A,BB] = {
+          if (isEmpty( target )) Right( replacement ) else target;
         }
         def isLeftBias  : Boolean = true;
 
-        implicit def toOps[A,B>:E]( src : Either[A,B] ) : LeftBias.withEmptyToken.Ops[A,B] = new LeftBias.withEmptyToken.Ops[A,B]( src )( this )
+        implicit def toOps[A,B>:E]( target : Either[A,B] ) : LeftBias.withEmptyToken.Ops[A,B] = new LeftBias.withEmptyToken.Ops[A,B]( target )( this )
       }
       def apply[E]( token : E ) : withEmptyToken[E] = new withEmptyToken( token );
 
@@ -1175,7 +1501,7 @@ object Either {
 
         override def empty : Nothing = throw throwableBuilder;
 
-        override def isEmpty[A,B]( src : Either[A,B] ) : Boolean = false; // no state represents empty, empties cannot be formed as an Exception is thrown when it is tried
+        override def isEmpty[A,B]( target : Either[A,B] ) : Boolean = false; // no state represents empty, empties cannot be formed as an Exception is thrown when it is tried
       }
     }
     /**
@@ -1192,11 +1518,63 @@ object Either {
     final class withEmptyToken[+E] private( override val empty : E ) extends withEmptyToken.Generic[E] {
       override protected val rightEmpty : Right[Nothing,E] = Right(empty);
 
-      override def isEmpty[A>:E,B]( src : Either[A,B] ) : Boolean = (src == rightEmpty);
+      override def isEmpty[A>:E,B]( target : Either[A,B] ) : Boolean = (target == rightEmpty);
+    }
+    /**
+      * May be extended by classes, objects, traits, and packages (via package objects).
+      * 
+      * Within entities that extend this class
+      * objects of type `Either` will be left-biased, and have
+      * the full-suite of left-biased operations (including operations suitable to for
+      * comprehensions) automatically made available.
+      * 
+      * Empty `Either` values will be represented by Right values including the token 
+      * of type `R` passed to the superclass constructor.
+      * 
+      * '''If you are using polymorphic error types, be sure to specify the type
+      *  argument to Base, as too narrow a type may be inferred from a token
+      *  of a derived type.'''
+      * 
+      * ''Note: Entities that do not need to extend another class can extend the abstract
+      * class [[Either.LeftBias.Base]], which allows defining the Empty token in the
+      * superclass constructor rather than overriding [[EmptyTokenDefinition]].''
+      * 
+      * {{{
+      * class Clown extends Either.LeftBias.Base[Clown.Error]( Clown.Error.Empty ) {
+      *   import Clown.{Cash,Laugh,Error};
+      * 
+      *   // use Either values directly in for comprehensions
+      *   def perform : Either[Cash,Error] = {
+      *      for {
+      *        laugh <- makeFunny
+      *        money <- begForCash( laugh ) if laugh.loudness > 2
+      *      } yield money
+      *   }
+      * 
+      *   def makeFunny : Either[Laugh,Error] = ???
+      *   def begForCash( laugh : Laugh )  : Either[Cash,Error] = ???
+      * }
+      * object Clown {
+      *   final object Error {
+      *     case object Empty extends Error;
+      *     case object JokeBombed extends Error;
+      *     case object NoAudience extends Error;
+      *     case object Cheapskates extends Error;
+      *   }
+      *   sealed trait Error;
+      * 
+      *   case class Laugh( loudness : Int );
+      *   case class Cash( quantity : Int, currencyCode : String );
+      * }
+      * }}}
+      * 
+      */ 
+    abstract class Base[R]( emptyToken : R ) extends LeftBias[R] {
+      override val EmptyTokenDefinition = LeftBias.withEmptyToken[R]( emptyToken )
     }
   }
   /**
-    * May be extends by classes, objects, traits, and packages (via package objects).
+    * May be extended by classes, objects, traits, and packages (via package objects).
     * 
     * Within entities that extend this trait
     * objects of type `Either` will be left-biased, and have
@@ -1207,6 +1585,10 @@ object Either {
     * match or filter operation will provoke a `java.util.NoSuchElementException`. 
     * Override [[EmptyTokenDefinition]] to prevent this and have emptiness
     * represented by an error token of type `R`.
+    * 
+    * ''Note: Entities that do not need to extend another class can extend the abstract
+    * class [[Either.LeftBias.Base]], which allows defining the Empty token in the
+    * superclass constructor rather than overriding [[EmptyTokenDefinition]].''
     * 
     * {{{
     * class Clown extends Either.LeftBias[Clown.Error] {
@@ -1255,7 +1637,7 @@ object Either {
       */ 
     val EmptyTokenDefinition : Either.LeftBias.withEmptyToken.Generic[R] = LeftBias.DefaultThrowingOps;
 
-    implicit def toLeftBiasEtherOps[A]( src : Either[A,R] ) : LeftBias.withEmptyToken.AbstractOps[A,R] = new LeftBias.withEmptyToken.Ops[A,R]( src )( EmptyTokenDefinition );
+    implicit def toLeftBiasEtherOps[L]( target : Either[L,R] ) : LeftBias.withEmptyToken.AbstractOps[L,R] = new LeftBias.withEmptyToken.Ops[L,R]( target )( EmptyTokenDefinition );
   }
 
   private def noSuchElementMessage[A,B]( rightBias : Boolean, mbEither : Option[Either[A,B]] = None ) = {

--- a/src/library/scala/util/Either.scala
+++ b/src/library/scala/util/Either.scala
@@ -613,8 +613,6 @@ object Either {
       def getOrElse[ BB >: B ]( or : =>BB ) : BB                = DefaultThrowingOps.getOrElse[A,B,BB]( src )( or );
       def toOption                          : Option[B]         = DefaultThrowingOps.toOption( src );
       def toSeq                             : collection.Seq[B] = DefaultThrowingOps.toSeq( src );
-
-      def fold[Z]( ifLeft : A => Z )( ifRight : B => Z ) : Z = DefaultThrowingOps.fold( src )( ifLeft )( ifRight )
     }
 
     object withEmptyToken {
@@ -633,8 +631,6 @@ object Either {
         def getOrElse[ BB >: B ]( or : =>BB ) : BB                = opsTypeClass.getOrElse[A,B,BB]( src )( or );
         def toOption                          : Option[B]         = opsTypeClass.toOption( src );
         def toSeq                             : collection.Seq[B] = opsTypeClass.toSeq( src );
-
-        def fold[Z]( ifLeft : A => Z )( ifRight : B => Z ) : Z = opsTypeClass.fold( src )( ifLeft )( ifRight )
       }
 
       implicit final class Ops[A,B]( src : Either[A,B] )( implicit opsTypeClass : Either.RightBias.withEmptyToken.Generic[A] ) extends AbstractOps( src )( opsTypeClass );
@@ -705,12 +701,6 @@ object Either {
             case Right( b ) => collection.Seq( b );
           }
         }
-        def fold[A>:E,B,Z]( src : Either[A,B] )( ifLeft : A => Z )( ifRight : B => Z ) : Z = {
-          src match {
-            case Left( a ) => ifLeft( a );
-            case Right( b ) => ifRight( b );
-          }
-        }
 
         implicit def toOps[A>:E,B]( src : Either[A,B] ) : RightBias.withEmptyToken.Ops[A,B] = new RightBias.withEmptyToken.Ops[A,B]( src )( this )
       }
@@ -751,8 +741,6 @@ object Either {
       def getOrElse[AA >: A ]( or : =>AA ) : AA                = DefaultThrowingOps.getOrElse[A,AA,B]( src )( or );
       def toOption                         : Option[A]         = DefaultThrowingOps.toOption( src );
       def toSeq                            : collection.Seq[A] = DefaultThrowingOps.toSeq( src );
-   
-      def fold[Z]( ifLeft : A => Z )( ifRight : B => Z ) : Z = DefaultThrowingOps.fold( src )( ifLeft )( ifRight )
     }
 
     object withEmptyToken {
@@ -771,8 +759,6 @@ object Either {
         def getOrElse[AA >: A ]( or : =>AA ) : AA                = opsTypeClass.getOrElse[A,AA,B]( src )( or );
         def toOption                         : Option[A]         = opsTypeClass.toOption( src );
         def toSeq                            : collection.Seq[A] = opsTypeClass.toSeq( src );
-
-        def fold[Z]( ifLeft : A => Z )( ifRight : B => Z ) : Z = opsTypeClass.fold( src )( ifLeft )( ifRight )
       }
 
       implicit final class Ops[A,B]( src : Either[A,B] )( implicit opsTypeClass : Either.LeftBias.withEmptyToken.Generic[B] ) extends AbstractOps( src )( opsTypeClass );
@@ -841,12 +827,6 @@ object Either {
           src match {
             case Left( a )  => collection.Seq( a );
             case Right( _ ) => collection.Seq.empty[A];
-          }
-        }
-        def fold[A,B>:E,Z]( src : Either[A,B] )( ifLeft : A => Z )( ifRight : B => Z ) : Z = {
-          src match {
-            case Left( a ) => ifLeft( a );
-            case Right( b ) => ifRight( b );
           }
         }
 

--- a/src/library/scala/util/Either.scala
+++ b/src/library/scala/util/Either.scala
@@ -616,20 +616,20 @@ object Either {
       def withFilter( p : B => Boolean )               : Either[A,B]  = DefaultThrowingOps.withFilter( src )( p );
 
       // extra ops
-      def exists( f : B => Boolean )          : Boolean           = DefaultThrowingOps.exists( src )( f );
-      def forall( f : B => Boolean )          : Boolean           = DefaultThrowingOps.forall( src )( f );
-      def foreach[U]( f : B => U )            : Any               = DefaultThrowingOps.foreach( src )( f );
-      def get                                 : B                 = DefaultThrowingOps.get( src );
-      def getOrElse[ BB >: B ]( or : =>BB )   : BB                = DefaultThrowingOps.getOrElse[A,B,BB]( src )( or );
-      def toOption                            : Option[B]         = DefaultThrowingOps.toOption( src );
-      def toSeq                               : collection.Seq[B] = DefaultThrowingOps.toSeq( src );
-      def xget                                : A                 = DefaultThrowingOps.xget( src );
-      def xgetOrElse[AA>:A]( or : =>AA )      : AA                = DefaultThrowingOps.xgetOrElse[A,AA,B]( src )( or );
-      def xmap[Z]( f : A => Z )               : Either[Z,B]       = DefaultThrowingOps.xmap( src )( f );
-      def replaceIfEmpty( replacement : =>A ) : Either[A,B]       = DefaultThrowingOps.replaceIfEmpty( src )( replacement );
-      def isLeftBiased                        : Boolean           = DefaultThrowingOps.isLeftBias;
-      def isRightBiased                       : Boolean           = DefaultThrowingOps.isRightBias;
-      def conformsToBias                      : Boolean           = DefaultThrowingOps.conformsToBias( src );
+      def exists( f : B => Boolean )                  : Boolean           = DefaultThrowingOps.exists( src )( f );
+      def forall( f : B => Boolean )                  : Boolean           = DefaultThrowingOps.forall( src )( f );
+      def foreach[U]( f : B => U )                    : Any               = DefaultThrowingOps.foreach( src )( f );
+      def get                                         : B                 = DefaultThrowingOps.get( src );
+      def getOrElse[ BB >: B ]( or : =>BB )           : BB                = DefaultThrowingOps.getOrElse[A,B,BB]( src )( or );
+      def toOption                                    : Option[B]         = DefaultThrowingOps.toOption( src );
+      def toSeq                                       : collection.Seq[B] = DefaultThrowingOps.toSeq( src );
+      def xget                                        : A                 = DefaultThrowingOps.xget( src );
+      def xgetOrElse[AA>:A]( or : =>AA )              : AA                = DefaultThrowingOps.xgetOrElse[A,AA,B]( src )( or );
+      def xmap[Z]( f : A => Z )                       : Either[Z,B]       = DefaultThrowingOps.xmap( src )( f );
+      def replaceIfEmpty[AA>:A]( replacement : =>AA ) : Either[AA,B]      = DefaultThrowingOps.replaceIfEmpty[A,AA,B]( src )( replacement );
+      def isLeftBiased                                : Boolean           = DefaultThrowingOps.isLeftBias;
+      def isRightBiased                               : Boolean           = DefaultThrowingOps.isRightBias;
+      def conformsToBias                              : Boolean           = DefaultThrowingOps.conformsToBias( src );
     }
 
     object withEmptyToken {
@@ -641,21 +641,21 @@ object Either {
         def withFilter( p : B => Boolean )               : Either[A,B]  = opsTypeClass.withFilter( src )( p );
 
         // extra ops
-        def exists( f : B => Boolean )          : Boolean           = opsTypeClass.exists( src )( f );
-        def forall( f : B => Boolean )          : Boolean           = opsTypeClass.forall( src )( f );
-        def foreach[U]( f : B => U )            : Any               = opsTypeClass.foreach( src )( f );
-        def get                                 : B                 = opsTypeClass.get( src );
-        def getOrElse[BB>:B]( or : =>BB )       : BB                = opsTypeClass.getOrElse[A,B,BB]( src )( or );
-        def toOption                            : Option[B]         = opsTypeClass.toOption( src );
-        def toSeq                               : collection.Seq[B] = opsTypeClass.toSeq( src );
-        def isEmpty                             : Boolean           = opsTypeClass.isEmpty( src );
-        def xget                                : A                 = opsTypeClass.xget( src );
-        def xgetOrElse[AA>:A]( or : =>AA )      : AA                = opsTypeClass.xgetOrElse[A,AA,B]( src )( or );
-        def xmap[Z]( f : A => Z )               : Either[Z,B]       = opsTypeClass.xmap( src )( f );
-        def replaceIfEmpty( replacement : =>A ) : Either[A,B]       = opsTypeClass.replaceIfEmpty( src )( replacement );
-        def isLeftBiased                        : Boolean           = opsTypeClass.isLeftBias;
-        def isRightBiased                       : Boolean           = opsTypeClass.isRightBias;
-        def conformsToBias                      : Boolean           = opsTypeClass.conformsToBias( src );
+        def exists( f : B => Boolean )                  : Boolean           = opsTypeClass.exists( src )( f );
+        def forall( f : B => Boolean )                  : Boolean           = opsTypeClass.forall( src )( f );
+        def foreach[U]( f : B => U )                    : Any               = opsTypeClass.foreach( src )( f );
+        def get                                         : B                 = opsTypeClass.get( src );
+        def getOrElse[BB>:B]( or : =>BB )               : BB                = opsTypeClass.getOrElse[A,B,BB]( src )( or );
+        def toOption                                    : Option[B]         = opsTypeClass.toOption( src );
+        def toSeq                                       : collection.Seq[B] = opsTypeClass.toSeq( src );
+        def isEmpty                                     : Boolean           = opsTypeClass.isEmpty( src );
+        def xget                                        : A                 = opsTypeClass.xget( src );
+        def xgetOrElse[AA>:A]( or : =>AA )              : AA                = opsTypeClass.xgetOrElse[A,AA,B]( src )( or );
+        def xmap[Z]( f : A => Z )                       : Either[Z,B]       = opsTypeClass.xmap( src )( f );
+        def replaceIfEmpty[AA>:A]( replacement : =>AA ) : Either[AA,B]      = opsTypeClass.replaceIfEmpty[A,AA,B]( src )( replacement );
+        def isLeftBiased                                : Boolean           = opsTypeClass.isLeftBias;
+        def isRightBiased                               : Boolean           = opsTypeClass.isRightBias;
+        def conformsToBias                              : Boolean           = opsTypeClass.conformsToBias( src );
       }
 
       implicit final class Ops[A,B]( src : Either[A,B] )( implicit opsTypeClass : Either.RightBias.withEmptyToken.Generic[A] ) extends AbstractOps( src )( opsTypeClass );
@@ -753,7 +753,7 @@ object Either {
             case Right( _ ) => src.asInstanceOf[Right[Z,B]]
           }
         }
-        def replaceIfEmpty[A>:E,B]( src : Either[A,B] )( replacement : =>A) : Either[A,B] = {
+        def replaceIfEmpty[A>:E,AA>:A,B]( src : Either[A,B] )( replacement : =>AA ) : Either[AA,B] = {
           if (isEmpty( src )) Left( replacement ) else src;
         }
         def isLeftBias  : Boolean = false;
@@ -958,20 +958,20 @@ object Either {
       def withFilter( p : A => Boolean )               : Either[A,B]  = DefaultThrowingOps.withFilter( src )( p );
 
       // extra ops
-      def exists( f : A => Boolean )          : Boolean           = DefaultThrowingOps.exists( src )( f );
-      def forall( f : A => Boolean )          : Boolean           = DefaultThrowingOps.forall( src )( f );
-      def foreach[U]( f : A => U )            : Any               = DefaultThrowingOps.foreach( src )( f );
-      def get                                 : A                 = DefaultThrowingOps.get( src );
-      def getOrElse[AA >: A ]( or : =>AA )    : AA                = DefaultThrowingOps.getOrElse[A,AA,B]( src )( or );
-      def toOption                            : Option[A]         = DefaultThrowingOps.toOption( src );
-      def toSeq                               : collection.Seq[A] = DefaultThrowingOps.toSeq( src );
-      def xget                                : B                 = DefaultThrowingOps.xget( src );
-      def xgetOrElse[BB>:B]( or : =>BB )      : BB                = DefaultThrowingOps.xgetOrElse[A,B,BB]( src )( or );
-      def xmap[Z]( f : B => Z )               : Either[A,Z]       = DefaultThrowingOps.xmap( src )( f );
-      def replaceIfEmpty( replacement : =>B ) : Either[A,B]       = DefaultThrowingOps.replaceIfEmpty( src )( replacement )
-      def isLeftBiased                        : Boolean           = DefaultThrowingOps.isLeftBias;
-      def isRightBiased                       : Boolean           = DefaultThrowingOps.isRightBias;
-      def conformsToBias                      : Boolean           = DefaultThrowingOps.conformsToBias( src );
+      def exists( f : A => Boolean )          : Boolean              = DefaultThrowingOps.exists( src )( f );
+      def forall( f : A => Boolean )          : Boolean              = DefaultThrowingOps.forall( src )( f );
+      def foreach[U]( f : A => U )            : Any                  = DefaultThrowingOps.foreach( src )( f );
+      def get                                 : A                    = DefaultThrowingOps.get( src );
+      def getOrElse[AA >: A ]( or : =>AA )    : AA                   = DefaultThrowingOps.getOrElse[A,AA,B]( src )( or );
+      def toOption                            : Option[A]            = DefaultThrowingOps.toOption( src );
+      def toSeq                               : collection.Seq[A]    = DefaultThrowingOps.toSeq( src );
+      def xget                                : B                    = DefaultThrowingOps.xget( src );
+      def xgetOrElse[BB>:B]( or : =>BB )      : BB                   = DefaultThrowingOps.xgetOrElse[A,B,BB]( src )( or );
+      def xmap[Z]( f : B => Z )               : Either[A,Z]          = DefaultThrowingOps.xmap( src )( f );
+      def replaceIfEmpty[BB>:B]( replacement : =>BB ) : Either[A,BB] = DefaultThrowingOps.replaceIfEmpty[A,B,BB]( src )( replacement )
+      def isLeftBiased                        : Boolean              = DefaultThrowingOps.isLeftBias;
+      def isRightBiased                       : Boolean              = DefaultThrowingOps.isRightBias;
+      def conformsToBias                      : Boolean              = DefaultThrowingOps.conformsToBias( src );
     }
 
     /**
@@ -1020,20 +1020,20 @@ object Either {
         def withFilter( p : A => Boolean )               : Either[A,B]  = opsTypeClass.withFilter( src )( p );
 
         // extra ops
-        def exists( f : A => Boolean )          : Boolean           = opsTypeClass.exists( src )( f );
-        def forall( f : A => Boolean )          : Boolean           = opsTypeClass.forall( src )( f );
-        def foreach[U]( f : A => U )            : Any               = opsTypeClass.foreach( src )( f );
-        def get                                 : A                 = opsTypeClass.get( src );
-        def getOrElse[AA >: A ]( or : =>AA )    : AA                = opsTypeClass.getOrElse[A,AA,B]( src )( or );
-        def toOption                            : Option[A]         = opsTypeClass.toOption( src );
-        def toSeq                               : collection.Seq[A] = opsTypeClass.toSeq( src );
-        def xget                                : B                 = opsTypeClass.xget( src );
-        def xgetOrElse[BB>:B]( or : =>BB )      : BB                = opsTypeClass.xgetOrElse[A,B,BB]( src )( or );
-        def xmap[Z]( f : B => Z )               : Either[A,Z]       = opsTypeClass.xmap( src )( f );
-        def replaceIfEmpty( replacement : =>B ) : Either[A,B]       = opsTypeClass.replaceIfEmpty( src )( replacement )
-        def isLeftBiased                        : Boolean           = opsTypeClass.isLeftBias;
-        def isRightBiased                       : Boolean           = opsTypeClass.isRightBias;
-        def conformsToBias                      : Boolean           = opsTypeClass.conformsToBias( src );
+        def exists( f : A => Boolean )                  : Boolean           = opsTypeClass.exists( src )( f );
+        def forall( f : A => Boolean )                  : Boolean           = opsTypeClass.forall( src )( f );
+        def foreach[U]( f : A => U )                    : Any               = opsTypeClass.foreach( src )( f );
+        def get                                         : A                 = opsTypeClass.get( src );
+        def getOrElse[AA >: A ]( or : =>AA )            : AA                = opsTypeClass.getOrElse[A,AA,B]( src )( or );
+        def toOption                                    : Option[A]         = opsTypeClass.toOption( src );
+        def toSeq                                       : collection.Seq[A] = opsTypeClass.toSeq( src );
+        def xget                                        : B                 = opsTypeClass.xget( src );
+        def xgetOrElse[BB>:B]( or : =>BB )              : BB                = opsTypeClass.xgetOrElse[A,B,BB]( src )( or );
+        def xmap[Z]( f : B => Z )                       : Either[A,Z]       = opsTypeClass.xmap( src )( f );
+        def replaceIfEmpty[BB>:B]( replacement : =>BB ) : Either[A,BB]      = opsTypeClass.replaceIfEmpty[A,B,BB]( src )( replacement )
+        def isLeftBiased                                : Boolean           = opsTypeClass.isLeftBias;
+        def isRightBiased                               : Boolean           = opsTypeClass.isRightBias;
+        def conformsToBias                              : Boolean           = opsTypeClass.conformsToBias( src );
       }
 
       /**
@@ -1136,7 +1136,7 @@ object Either {
             case Right( b ) => Right( f(b) )
           }
         }
-        def replaceIfEmpty[A,B>:E]( src : Either[A,B] )( replacement : =>B ) : Either[A,B] = {
+        def replaceIfEmpty[A,B>:E,BB>:B]( src : Either[A,B] )( replacement : =>BB ) : Either[A,BB] = {
           if (isEmpty( src )) Right( replacement ) else src;
         }
         def isLeftBias  : Boolean = true;

--- a/test/files/scalacheck/CheckEither.scala
+++ b/test/files/scalacheck/CheckEither.scala
@@ -113,8 +113,8 @@ object Test extends Properties("Either") {
   }
 
 
-  object CheckLeftBiased {
-    import Either.LeftBiased._
+  object CheckLeftBias {
+    import Either.LeftBias._
 
     val prop_value = forAll((n: Int) => Left(n).get == n)
 
@@ -197,8 +197,8 @@ object Test extends Properties("Either") {
     })
   }
 
-  object CheckLeftBiasedWithEmptyToken {
-    val Bias = Either.LeftBiased.WithEmptyToken(-1);
+  object CheckLeftBiasWithEmptyToken {
+    val Bias = Either.LeftBias.withEmptyToken(-1);
     import Bias._;
 
     val prop_withFilter = forAll((e: Either[Int, Int] ) => {
@@ -221,8 +221,8 @@ object Test extends Properties("Either") {
     })
   }
 
-  object CheckRightBiased {
-    import Either.RightBiased._
+  object CheckRightBias {
+    import Either.RightBias._
 
     val prop_value = forAll((n: Int) => Right(n).get == n)
 
@@ -305,8 +305,8 @@ object Test extends Properties("Either") {
     })
   }
 
-  object CheckRightBiasedWithEmptyToken {
-    val Bias = Either.RightBiased.WithEmptyToken(-1);
+  object CheckRightBiasWithEmptyToken {
+    val Bias = Either.RightBias.withEmptyToken(-1);
     import Bias._;
 
     val prop_withFilter = forAll((e: Either[Int, Int] ) => {
@@ -383,43 +383,43 @@ object Test extends Properties("Either") {
       ("Right.prop_seq", CheckRightProjection.prop_seq),
       ("Right.prop_option", CheckRightProjection.prop_option),
 
-      ("LeftBiased.prop_value", CheckLeftBiased.prop_value),
-      ("LeftBiased.prop_getOrElse", CheckLeftBiased.prop_getOrElse),
-      ("LeftBiased.prop_forall", CheckLeftBiased.prop_forall),
-      ("LeftBiased.prop_exists", CheckLeftBiased.prop_exists),
-      ("LeftBiased.prop_flatMapLeftIdentity", CheckLeftBiased.prop_flatMapLeftIdentity),
-      ("LeftBiased.prop_flatMapRightIdentity", CheckLeftBiased.prop_flatMapRightIdentity),
-      ("LeftBiased.prop_flatMapComposition", CheckLeftBiased.prop_flatMapComposition),
-      ("LeftBiased.prop_mapIdentity", CheckLeftBiased.prop_mapIdentity),
-      ("LeftBiased.prop_mapComposition", CheckLeftBiased.prop_mapComposition),
-      ("LeftBiased.prop_seq", CheckLeftBiased.prop_seq),
-      ("LeftBiased.prop_option", CheckLeftBiased.prop_option),
-      ("LeftBiased.prop_withFilter", CheckLeftBiased.prop_withFilter),
-      ("LeftBiased.prop_extractTuple", CheckLeftBiased.prop_extractTuple),
-      ("LeftBiased.prop_assignVariable", CheckLeftBiased.prop_assignVariable),
-      ("LeftBiased.prop_filterInFor", CheckLeftBiased.prop_filterInFor),
+      ("LeftBias.prop_value", CheckLeftBias.prop_value),
+      ("LeftBias.prop_getOrElse", CheckLeftBias.prop_getOrElse),
+      ("LeftBias.prop_forall", CheckLeftBias.prop_forall),
+      ("LeftBias.prop_exists", CheckLeftBias.prop_exists),
+      ("LeftBias.prop_flatMapLeftIdentity", CheckLeftBias.prop_flatMapLeftIdentity),
+      ("LeftBias.prop_flatMapRightIdentity", CheckLeftBias.prop_flatMapRightIdentity),
+      ("LeftBias.prop_flatMapComposition", CheckLeftBias.prop_flatMapComposition),
+      ("LeftBias.prop_mapIdentity", CheckLeftBias.prop_mapIdentity),
+      ("LeftBias.prop_mapComposition", CheckLeftBias.prop_mapComposition),
+      ("LeftBias.prop_seq", CheckLeftBias.prop_seq),
+      ("LeftBias.prop_option", CheckLeftBias.prop_option),
+      ("LeftBias.prop_withFilter", CheckLeftBias.prop_withFilter),
+      ("LeftBias.prop_extractTuple", CheckLeftBias.prop_extractTuple),
+      ("LeftBias.prop_assignVariable", CheckLeftBias.prop_assignVariable),
+      ("LeftBias.prop_filterInFor", CheckLeftBias.prop_filterInFor),
 
-      ("LeftBiasedWithEmptyToken.prop_withFilter", CheckLeftBiasedWithEmptyToken.prop_withFilter),
-      ("LeftBiasedWithEmptyToken.prop_filterInFor", CheckLeftBiasedWithEmptyToken.prop_filterInFor),
+      ("LeftBiasWithEmptyToken.prop_withFilter", CheckLeftBiasWithEmptyToken.prop_withFilter),
+      ("LeftBiasWithEmptyToken.prop_filterInFor", CheckLeftBiasWithEmptyToken.prop_filterInFor),
 
-      ("RightBiased.prop_value", CheckRightBiased.prop_value),
-      ("RightBiased.prop_getOrElse", CheckRightBiased.prop_getOrElse),
-      ("RightBiased.prop_forall", CheckRightBiased.prop_forall),
-      ("RightBiased.prop_exists", CheckRightBiased.prop_exists),
-      ("RightBiased.prop_flatMapLeftIdentity", CheckRightBiased.prop_flatMapLeftIdentity),
-      ("RightBiased.prop_flatMapRightIdentity", CheckRightBiased.prop_flatMapRightIdentity),
-      ("RightBiased.prop_flatMapComposition", CheckRightBiased.prop_flatMapComposition),
-      ("RightBiased.prop_mapIdentity", CheckRightBiased.prop_mapIdentity),
-      ("RightBiased.prop_mapComposition", CheckRightBiased.prop_mapComposition),
-      ("RightBiased.prop_seq", CheckRightBiased.prop_seq),
-      ("RightBiased.prop_option", CheckRightBiased.prop_option),
-      ("RightBiased.prop_withFilter", CheckRightBiased.prop_withFilter),
-      ("RightBiased.prop_extractTuple", CheckRightBiased.prop_extractTuple),
-      ("RightBiased.prop_assignVariable", CheckRightBiased.prop_assignVariable),
-      ("RightBiased.prop_filterInFor", CheckRightBiased.prop_filterInFor),
+      ("RightBias.prop_value", CheckRightBias.prop_value),
+      ("RightBias.prop_getOrElse", CheckRightBias.prop_getOrElse),
+      ("RightBias.prop_forall", CheckRightBias.prop_forall),
+      ("RightBias.prop_exists", CheckRightBias.prop_exists),
+      ("RightBias.prop_flatMapLeftIdentity", CheckRightBias.prop_flatMapLeftIdentity),
+      ("RightBias.prop_flatMapRightIdentity", CheckRightBias.prop_flatMapRightIdentity),
+      ("RightBias.prop_flatMapComposition", CheckRightBias.prop_flatMapComposition),
+      ("RightBias.prop_mapIdentity", CheckRightBias.prop_mapIdentity),
+      ("RightBias.prop_mapComposition", CheckRightBias.prop_mapComposition),
+      ("RightBias.prop_seq", CheckRightBias.prop_seq),
+      ("RightBias.prop_option", CheckRightBias.prop_option),
+      ("RightBias.prop_withFilter", CheckRightBias.prop_withFilter),
+      ("RightBias.prop_extractTuple", CheckRightBias.prop_extractTuple),
+      ("RightBias.prop_assignVariable", CheckRightBias.prop_assignVariable),
+      ("RightBias.prop_filterInFor", CheckRightBias.prop_filterInFor),
 
-      ("RightBiasedWithEmptyToken.prop_withFilter", CheckRightBiasedWithEmptyToken.prop_withFilter),
-      ("RightBiasedWithEmptyToken.prop_filterInFor", CheckRightBiasedWithEmptyToken.prop_filterInFor),
+      ("RightBiasWithEmptyToken.prop_withFilter", CheckRightBiasWithEmptyToken.prop_withFilter),
+      ("RightBiasWithEmptyToken.prop_filterInFor", CheckRightBiasWithEmptyToken.prop_filterInFor),
 
       ("prop_Either_left", prop_Either_left),
       ("prop_Either_right", prop_Either_right),

--- a/test/files/scalacheck/CheckEither.scala
+++ b/test/files/scalacheck/CheckEither.scala
@@ -195,6 +195,32 @@ object Test extends Properties("Either") {
         e == (for ( x <- e ) yield x) // right should be unchanged
       }
     })
+
+    val prop_xget = forAll((n: Int) => Right(n).xget == n)
+
+    val prop_xgetOrElse = forAll((e: Either[Int, Int], or: Int) => e.xgetOrElse(or) == (e match {
+      case Left(_)  => or
+      case Right(b) => b
+    }))
+
+    val prop_xmapIdentity = forAll((e: Either[Int, Int]) => e.xmap(x => x) == e)
+
+    val prop_xmapComposition = forAll((e: Either[Int, String]) => {
+      def f(s: String) = s.toLowerCase
+      def g(s: String) = s.reverse
+      e.xmap(x => f(g(x))) == e.xmap(x => g(x)).xmap(f(_))
+    })
+
+    val prop_isLeftBiased = forAll((e: Either[Int, String]) => e.isLeftBiased)
+
+    val prop_isRightBiased = forAll((e: Either[Int, String]) => !e.isRightBiased)
+
+    val prop_conformsToBias = forAll((e: Either[Int, String]) => {
+      e match {
+        case Left(_)  => e.conformsToBias == true
+        case Right(_) => e.conformsToBias == false
+      }
+    })
   }
 
   object CheckLeftBiasWithEmptyToken {
@@ -217,6 +243,16 @@ object Test extends Properties("Either") {
         (for ( x <- e if passThru ) yield x) == Right[Int,Int](-1)
       } else {
         e == (for ( x <- e ) yield x) // right should be unchanged
+      }
+    })
+
+    val prop_replaceIfEmpty = forAll((e: Either[String, Int], condition : Boolean) => {
+      if ( e.isLeft ) {
+        val filtered = for( v <- e if condition ) yield v
+        val check = filtered.replaceIfEmpty(99);
+        check == (if ( condition ) e else Right(99))
+      } else {
+        true
       }
     })
   }
@@ -303,6 +339,32 @@ object Test extends Properties("Either") {
         e == (for ( x <- e ) yield x) // left should be unchanged
       }
     })
+
+    val prop_xget = forAll((n: Int) => Left(n).xget == n)
+
+    val prop_xgetOrElse = forAll((e: Either[Int, Int], or: Int) => e.xgetOrElse(or) == (e match {
+      case Left(a)  => a
+      case Right(_) => or
+    }))
+
+    val prop_xmapIdentity = forAll((e: Either[Int, Int]) => e.xmap(x => x) == e)
+
+    val prop_xmapComposition = forAll((e: Either[String, Int]) => {
+      def f(s: String) = s.toLowerCase
+      def g(s: String) = s.reverse
+      e.xmap(x => f(g(x))) == e.xmap(x => g(x)).xmap(f(_))
+    })
+
+    val prop_isLeftBiased = forAll((e: Either[Int, String]) => !e.isLeftBiased)
+
+    val prop_isRightBiased = forAll((e: Either[Int, String]) => e.isRightBiased)
+
+    val prop_conformsToBias = forAll((e: Either[Int, String]) => {
+      e match {
+        case Left(_)  => e.conformsToBias == false
+        case Right(_) => e.conformsToBias == true
+      }
+    })
   }
 
   object CheckRightBiasWithEmptyToken {
@@ -325,6 +387,16 @@ object Test extends Properties("Either") {
         (for ( x <- e if passThru ) yield x) == Left[Int,Int](-1)
       } else {
         e == (for ( x <- e ) yield x) // left should be unchanged
+      }
+    })
+
+    val prop_replaceIfEmpty = forAll((e: Either[Int, String], condition : Boolean) => {
+      if (e.isRight) {
+        val filtered = for( v <- e if condition ) yield v
+        val check = filtered.replaceIfEmpty(99);
+        check == (if ( condition ) e else Left(99))
+      } else {
+        true
       }
     })
   }
@@ -398,9 +470,17 @@ object Test extends Properties("Either") {
       ("LeftBias.prop_extractTuple", CheckLeftBias.prop_extractTuple),
       ("LeftBias.prop_assignVariable", CheckLeftBias.prop_assignVariable),
       ("LeftBias.prop_filterInFor", CheckLeftBias.prop_filterInFor),
+      ("LeftBias.prop_xget", CheckLeftBias.prop_xget),
+      ("LeftBias.prop_xgetOrElse", CheckLeftBias.prop_xgetOrElse),
+      ("LeftBias.prop_xmapIdentity", CheckLeftBias.prop_xmapIdentity),
+      ("LeftBias.prop_xmapComposition", CheckLeftBias.prop_xmapComposition),
+      ("LeftBias.prop_isLeftBiased", CheckLeftBias.prop_isLeftBiased),
+      ("LeftBias.prop_isRightBiased", CheckLeftBias.prop_isRightBiased),
+      ("LeftBias.prop_conformsToBias", CheckLeftBias.prop_conformsToBias),
 
       ("LeftBiasWithEmptyToken.prop_withFilter", CheckLeftBiasWithEmptyToken.prop_withFilter),
       ("LeftBiasWithEmptyToken.prop_filterInFor", CheckLeftBiasWithEmptyToken.prop_filterInFor),
+      ("LeftBiasWithEmptyToken.prop_replaceIfEmpty", CheckLeftBiasWithEmptyToken.prop_replaceIfEmpty),
 
       ("RightBias.prop_value", CheckRightBias.prop_value),
       ("RightBias.prop_getOrElse", CheckRightBias.prop_getOrElse),
@@ -417,9 +497,17 @@ object Test extends Properties("Either") {
       ("RightBias.prop_extractTuple", CheckRightBias.prop_extractTuple),
       ("RightBias.prop_assignVariable", CheckRightBias.prop_assignVariable),
       ("RightBias.prop_filterInFor", CheckRightBias.prop_filterInFor),
+      ("RightBias.prop_xget", CheckRightBias.prop_xget),
+      ("RightBias.prop_xgetOrElse", CheckRightBias.prop_xgetOrElse),
+      ("RightBias.prop_xmapIdentity", CheckRightBias.prop_xmapIdentity),
+      ("RightBias.prop_xmapComposition", CheckRightBias.prop_xmapComposition),
+      ("RightBias.prop_isLeftBiased", CheckRightBias.prop_isLeftBiased),
+      ("RightBias.prop_isRightBiased", CheckRightBias.prop_isRightBiased),
+      ("RightBias.prop_conformsToBias", CheckRightBias.prop_conformsToBias),
 
       ("RightBiasWithEmptyToken.prop_withFilter", CheckRightBiasWithEmptyToken.prop_withFilter),
       ("RightBiasWithEmptyToken.prop_filterInFor", CheckRightBiasWithEmptyToken.prop_filterInFor),
+      ("RightBiasWithEmptyToken.prop_replaceIfEmpty", CheckRightBiasWithEmptyToken.prop_replaceIfEmpty),
 
       ("prop_Either_left", prop_Either_left),
       ("prop_Either_right", prop_Either_right),

--- a/test/files/scalacheck/CheckEither.scala
+++ b/test/files/scalacheck/CheckEither.scala
@@ -112,6 +112,223 @@ object Test extends Properties("Either") {
     }))
   }
 
+
+  object CheckLeftBiased {
+    import Either.LeftBiased._
+
+    val prop_value = forAll((n: Int) => Left(n).get == n)
+
+    val prop_getOrElse = forAll((e: Either[Int, Int], or: Int) => e.getOrElse(or) == (e match {
+      case Left(a) => a
+      case Right(_) => or
+    }))
+
+    val prop_forall = forAll((e: Either[Int, Int]) =>
+      e.forall(_ % 2 == 0) == (e.isRight || e.get % 2 == 0))
+
+    val prop_exists = forAll((e: Either[Int, Int]) =>
+      e.exists(_ % 2 == 0) == (e.isLeft && e.get % 2 == 0))
+
+    val prop_flatMapLeftIdentity = forAll((e: Either[Int, Int], n: Int, s: String) => {
+      def f(x: Int) = if(x % 2 == 0) Left(s) else Right(s)
+      Left(n).flatMap(f(_)) == f(n)})
+
+    val prop_flatMapRightIdentity = forAll((e: Either[Int, Int]) => e.flatMap(Left(_)) == e)
+
+    val prop_flatMapComposition = forAll((e: Either[Int, Int]) => {
+      def f(x: Int) = if(x % 2 == 0) Left(x) else Right(x)
+      def g(x: Int) = if(x % 7 == 0) Right(x) else Left(x)
+      e.flatMap(f(_)).flatMap(g(_)) == e.flatMap(f(_).flatMap(g(_)))})
+
+    val prop_mapIdentity = forAll((e: Either[Int, Int]) => e.map(x => x) == e)
+
+    val prop_mapComposition = forAll((e: Either[String, Int]) => {
+      def f(s: String) = s.toLowerCase
+      def g(s: String) = s.reverse
+      e.map(x => f(g(x))) == e.map(x => g(x)).map(f(_))})
+
+    val prop_seq = forAll((e: Either[Int, Int]) => e.toSeq == (e match {
+      case Left(a) => Seq(a)
+      case Right(_) => Seq.empty
+    }))
+
+    val prop_option = forAll((e: Either[Int, Int]) => e.toOption == (e match {
+      case Left(a) => Some(a)
+      case Right(_) => None
+    }))
+
+    val prop_withFilter = forAll((e: Either[Int, Int] ) => {
+      if ( e.isLeft ) {
+        if (e.get % 2 == 0) e.withFilter( _ % 2 == 0 ) == e;
+        else {
+          try { e.withFilter( _ % 2 == 0 ); false }
+          catch { case _ : NoSuchElementException => true }
+        }
+      } else {
+        e.withFilter(_ % 2 == 0) == e // right should be unchanged
+      }
+    })
+
+    val prop_extractTuple = forAll((e: Either[(Int,Int,Int),Int]) => {
+      if ( e.isLeft ) {
+      e.get._1 == (for ( ( a, b, c ) <- e ) yield a).get
+      } else {
+        e == (for ( ( a, b, c ) <- e ) yield a) // right should be unchanged
+      }
+    })
+
+    val prop_assignVariable = forAll((e: Either[(Int,Int,Int),Int]) => {
+      if ( e.isLeft ) {
+        e.get._2 == (for ( tup <- e; b = tup._2 ) yield b).get
+      } else {
+        e == (for ( tup <- e; b = tup._2 ) yield b) // right should be unchanged
+      }
+    })
+
+    val prop_filterInFor = forAll((e: Either[Int,Int], mul : Int, passThru: Boolean) => {
+      if ( e.isLeft && passThru) {
+        e.map(_ * mul) == (for ( x <- e if passThru ) yield (mul * x))
+      } else if ( e.isLeft && !passThru ) {
+        try { for ( x <- e if passThru ) yield x; false }
+        catch { case nse : NoSuchElementException => true; }
+      } else {
+        e == (for ( x <- e ) yield x) // right should be unchanged
+      }
+    })
+  }
+
+  object CheckLeftBiasedWithEmptyToken {
+    val Bias = Either.LeftBiased.WithEmptyToken(-1);
+    import Bias._;
+
+    val prop_withFilter = forAll((e: Either[Int, Int] ) => {
+      if ( e.isLeft ) {
+        if (e.get % 2 == 0) e.withFilter( _ % 2 == 0 ) == e;
+        else e.withFilter( _ % 2 == 0 ) == Right[Int,Int](-1)
+      } else {
+        e.withFilter(_ % 2 == 0) == e // right should be unchanged
+      }
+    })
+
+    val prop_filterInFor = forAll((e: Either[Int,Int], mul : Int, passThru: Boolean) => {
+      if ( e.isLeft && passThru) {
+        e.map(_ * mul) == (for ( x <- e if passThru ) yield (mul * x))
+      } else if ( e.isLeft && !passThru ) {
+        (for ( x <- e if passThru ) yield x) == Right[Int,Int](-1)
+      } else {
+        e == (for ( x <- e ) yield x) // right should be unchanged
+      }
+    })
+  }
+
+  object CheckRightBiased {
+    import Either.RightBiased._
+
+    val prop_value = forAll((n: Int) => Right(n).get == n)
+
+    val prop_getOrElse = forAll((e: Either[Int, Int], or: Int) => e.getOrElse(or) == (e match {
+      case Left(_) => or
+      case Right(b) => b
+    }))
+
+    val prop_forall = forAll((e: Either[Int, Int]) =>
+      e.forall(_ % 2 == 0) == (e.isLeft || e.get % 2 == 0))
+
+    val prop_exists = forAll((e: Either[Int, Int]) =>
+      e.exists(_ % 2 == 0) == (e.isRight && e.get % 2 == 0))
+
+    val prop_flatMapLeftIdentity = forAll((e: Either[Int, Int], n: Int, s: String) => {
+      def f(x: Int) = if(x % 2 == 0) Left(s) else Right(s)
+      Right(n).flatMap(f(_)) == f(n)})
+
+    val prop_flatMapRightIdentity = forAll((e: Either[Int, Int]) => e.flatMap(Right(_)) == e)
+
+    val prop_flatMapComposition = forAll((e: Either[Int, Int]) => {
+      def f(x: Int) = if(x % 2 == 0) Left(x) else Right(x)
+      def g(x: Int) = if(x % 7 == 0) Right(x) else Left(x)
+      e.flatMap(f(_)).flatMap(g(_)) == e.flatMap(f(_).flatMap(g(_)))})
+
+    val prop_mapIdentity = forAll((e: Either[Int, Int]) => e.map(x => x) == e)
+
+    val prop_mapComposition = forAll((e: Either[Int, String]) => {
+      def f(s: String) = s.toLowerCase
+      def g(s: String) = s.reverse
+      e.map(x => f(g(x))) == e.map(x => g(x)).map(f(_))})
+
+    val prop_seq = forAll((e: Either[Int, Int]) => e.toSeq == (e match {
+      case Left(_) => Seq.empty
+      case Right(b) => Seq(b)
+    }))
+
+    val prop_option = forAll((e: Either[Int, Int]) => e.toOption == (e match {
+      case Left(_) => None
+      case Right(b) => Some(b)
+    }))
+
+    val prop_withFilter = forAll((e: Either[Int, Int] ) => {
+      if ( e.isRight ) {
+        if (e.get % 2 == 0) e.withFilter( _ % 2 == 0 ) == e;
+        else {
+          try { e.withFilter( _ % 2 == 0 ); false }
+          catch { case _ : NoSuchElementException => true }
+        }
+      } else {
+        e.withFilter(_ % 2 == 0) == e // left should be unchanged
+      }
+    })
+
+    val prop_extractTuple = forAll((e: Either[Int,(Int,Int,Int)]) => {
+      if ( e.isRight ) {
+        e.get._1 == (for ( ( a, b, c ) <- e ) yield a).get
+      } else {
+        e == (for ( ( a, b, c ) <- e ) yield a) // left should be unchanged
+      }
+    })
+
+    val prop_assignVariable = forAll((e: Either[Int,(Int,Int,Int)]) => {
+      if ( e.isRight ) {
+        e.get._2 == (for ( tup <- e; b = tup._2 ) yield b).get
+      } else {
+        e == (for ( tup <- e; b = tup._2 ) yield b) // left should be unchanged
+      }
+    })
+
+    val prop_filterInFor = forAll((e: Either[Int,Int], mul : Int, passThru: Boolean) => {
+      if ( e.isRight && passThru) {
+        e.map(_ * mul) == (for ( x <- e if passThru ) yield (mul * x))
+      } else if ( e.isRight && !passThru ) {
+        try { for ( x <- e if passThru ) yield x; false }
+        catch { case nse : NoSuchElementException => true; }
+      } else {
+        e == (for ( x <- e ) yield x) // left should be unchanged
+      }
+    })
+  }
+
+  object CheckRightBiasedWithEmptyToken {
+    val Bias = Either.RightBiased.WithEmptyToken(-1);
+    import Bias._;
+
+    val prop_withFilter = forAll((e: Either[Int, Int] ) => {
+      if ( e.isRight ) {
+        if (e.get % 2 == 0) e.withFilter( _ % 2 == 0 ) == e;
+        else e.withFilter( _ % 2 == 0 ) == Left[Int,Int](-1)
+      } else {
+        e.withFilter(_ % 2 == 0) == e // left should be unchanged
+      }
+    })
+
+    val prop_filterInFor = forAll((e: Either[Int,Int], mul : Int, passThru: Boolean) => {
+      if ( e.isRight && passThru) {
+        e.map(_ * mul) == (for ( x <- e if passThru ) yield (mul * x))
+      } else if ( e.isRight && !passThru ) {
+        (for ( x <- e if passThru ) yield x) == Left[Int,Int](-1)
+      } else {
+        e == (for ( x <- e ) yield x) // left should be unchanged
+      }
+    })
+  }
+
   val prop_Either_left = forAll((n: Int) => Left(n).left.get == n)
 
   val prop_Either_right = forAll((n: Int) => Right(n).right.get == n)
@@ -165,6 +382,45 @@ object Test extends Properties("Either") {
       ("Right.prop_filter", CheckRightProjection.prop_filter),
       ("Right.prop_seq", CheckRightProjection.prop_seq),
       ("Right.prop_option", CheckRightProjection.prop_option),
+
+      ("LeftBiased.prop_value", CheckLeftBiased.prop_value),
+      ("LeftBiased.prop_getOrElse", CheckLeftBiased.prop_getOrElse),
+      ("LeftBiased.prop_forall", CheckLeftBiased.prop_forall),
+      ("LeftBiased.prop_exists", CheckLeftBiased.prop_exists),
+      ("LeftBiased.prop_flatMapLeftIdentity", CheckLeftBiased.prop_flatMapLeftIdentity),
+      ("LeftBiased.prop_flatMapRightIdentity", CheckLeftBiased.prop_flatMapRightIdentity),
+      ("LeftBiased.prop_flatMapComposition", CheckLeftBiased.prop_flatMapComposition),
+      ("LeftBiased.prop_mapIdentity", CheckLeftBiased.prop_mapIdentity),
+      ("LeftBiased.prop_mapComposition", CheckLeftBiased.prop_mapComposition),
+      ("LeftBiased.prop_seq", CheckLeftBiased.prop_seq),
+      ("LeftBiased.prop_option", CheckLeftBiased.prop_option),
+      ("LeftBiased.prop_withFilter", CheckLeftBiased.prop_withFilter),
+      ("LeftBiased.prop_extractTuple", CheckLeftBiased.prop_extractTuple),
+      ("LeftBiased.prop_assignVariable", CheckLeftBiased.prop_assignVariable),
+      ("LeftBiased.prop_filterInFor", CheckLeftBiased.prop_filterInFor),
+
+      ("LeftBiasedWithEmptyToken.prop_withFilter", CheckLeftBiasedWithEmptyToken.prop_withFilter),
+      ("LeftBiasedWithEmptyToken.prop_filterInFor", CheckLeftBiasedWithEmptyToken.prop_filterInFor),
+
+      ("RightBiased.prop_value", CheckRightBiased.prop_value),
+      ("RightBiased.prop_getOrElse", CheckRightBiased.prop_getOrElse),
+      ("RightBiased.prop_forall", CheckRightBiased.prop_forall),
+      ("RightBiased.prop_exists", CheckRightBiased.prop_exists),
+      ("RightBiased.prop_flatMapLeftIdentity", CheckRightBiased.prop_flatMapLeftIdentity),
+      ("RightBiased.prop_flatMapRightIdentity", CheckRightBiased.prop_flatMapRightIdentity),
+      ("RightBiased.prop_flatMapComposition", CheckRightBiased.prop_flatMapComposition),
+      ("RightBiased.prop_mapIdentity", CheckRightBiased.prop_mapIdentity),
+      ("RightBiased.prop_mapComposition", CheckRightBiased.prop_mapComposition),
+      ("RightBiased.prop_seq", CheckRightBiased.prop_seq),
+      ("RightBiased.prop_option", CheckRightBiased.prop_option),
+      ("RightBiased.prop_withFilter", CheckRightBiased.prop_withFilter),
+      ("RightBiased.prop_extractTuple", CheckRightBiased.prop_extractTuple),
+      ("RightBiased.prop_assignVariable", CheckRightBiased.prop_assignVariable),
+      ("RightBiased.prop_filterInFor", CheckRightBiased.prop_filterInFor),
+
+      ("RightBiasedWithEmptyToken.prop_withFilter", CheckRightBiasedWithEmptyToken.prop_withFilter),
+      ("RightBiasedWithEmptyToken.prop_filterInFor", CheckRightBiasedWithEmptyToken.prop_filterInFor),
+
       ("prop_Either_left", prop_Either_left),
       ("prop_Either_right", prop_Either_right),
       ("prop_Either_joinLeft", prop_Either_joinLeft),


### PR DESCRIPTION
[Note: I've updated this to reflect the [latest, slightly tweaked API](https://github.com/scala/scala/pull/4547#issuecomment-111682931).]

---

Hi. This is my first nontrivial attempt to contribute. I'm sorry if I'm doing it wrong!

This PR suggests a workaround of issues discussed in [SI-7222](https://issues.scala-lang.org/browse/SI-7222) and [SI-5589](https://issues.scala-lang.org/browse/SI-5589).

The basic problem is simple. Ideally, Either should be a convenient, more informative alternative to Option for managing a series of potentially failable operations. Successful operations get carried on one side of the Either (by convention as Right) while information about a Failure is stored on the other side.

In order for Either to fill that role, it should be an idiomatic Scala monad that plays well in for comprehensions. To make that happen without baking the convention-as-right into an asymmetrical API, Either offers both left and right projections, which are usable in for comprehensions. Unfortunately, their functionality is limited, because left- and right- projections offer a nonstandard `filter(...)` method. The projections fail in for comprehensions that try to destructure patterns, assign variables, or explicitly filter:

``` scala
Welcome to Scala version 2.12.0-20150609-002559-962064235e (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_31).
Type in expressions to have them evaluated.
Type :help for more information.

scala> def locationForName( name : String ) : Either[String,(Int,Int)] = Right( (name.##, name.##) )
locationForName: (name: String)Either[String,(Int, Int)]

scala> for( tup <- locationForName("Steve").right ) yield s"Location: ${tup}"
res0: scala.util.Either[String,String] = Right(Location: (80208819,80208819))

scala> for( (lat,long) <- locationForName("Steve").right ) yield s"Lattitude: ${lat}"
<console>:9: error: constructor cannot be instantiated to expected type;
 found   : (T1, T2)
 required: scala.util.Either[Nothing,(Int, Int)]
              for( (lat,long) <- locationForName("Steve").right ) yield s"Lattitude: ${lat}"
                   ^
```

The cause of the issue, the nonstandard filter method in projections, can't be undone, because it's a longstanding element of widely used API. Plus, it's not clear exactly what a filter/withFilter method _should_ do when the value of a non-error Either is filtered away. In analogy with option, a token meaning "empty" or "not available" should be returned, but the appropriate value of any token would depend upon types and conventions of error-side values, which each developer may choose differently. Alternatively, an Exception could be thrown when a filter or pattern match fails. Unlike the empty token, a standard Throwable can be chosen to signal these failures. But using a Throwable violates the purpose of embedding error values in Either in the first place, to keep the control flow within well-defined pure functions.

This PR offers an alternative monadic API for Either that breaks nothing (it is an enrichment that must be explicitly imported) and fully supports for-comprehension conventions. To deal with the unknown token / unwanted Throwable issue, it offers convenient API for users to designate their own token for empty values, or else defaults to having a NoSuchElementException thrown. Clients need not repeatedly dereference a projection in a for comprehensions, as with the current API. Instead, they import an enrichment that right- or left-biases Either, as they wish. Here's how it works.

``` scala
scala> val RightBias = Either.RightBias.withEmptyToken("EMPTY")
RightBias: Either.RightBias.withEmptyToken[String] = scala.util.Either$RightBias$withEmptyToken@e8ea697

scala> import RightBias._
import RightBias._

scala> def locationForName( name : String ) : Either[String,(Int,Int)] = Right( (name.##, name.##) )
locationForName: (name: String)Either[String,(Int, Int)]

scala> for( (lat,long) <- locationForName("Steve") ) yield s"Lattitude: ${lat}"
res8: scala.util.Either[String,String] = Right(Lattitude: 80208819)

scala> for( (lat,long) <- locationForName("Steve") if false ) yield s"Lattitude: ${lat}"
res9: scala.util.Either[String,String] = Left(EMPTY)
```

Alternatively

``` scala
scala> import Either.RightBias._
import Either.RightBias._

scala> for( (lat,long) <- locationForName("Steve") ) yield s"Lattitude: ${lat}"
res0: scala.util.Either[String,String] = Right(Lattitude: 80208819)

scala> for( (lat,long) <- locationForName("Steve") if false ) yield s"Lattitude: ${lat}"
java.util.NoSuchElementException: Right-biased Either filtered to empty or failed to match a pattern. Consider implementing RightBias.withEmptyToken
  at scala.util.Either$RightBias$$anonfun$1.apply(Either.scala:599)
  ... 
```

That's basically it. Some additional bells and whistles are RightBiased and LeftBiased traits that can be extended rather than imported to enable a package-scoped or avoid the "import tax".

The code is overlong. It violates the DRY principle, for two reasons:
1. I can't figure out a way to abstract over Left/Right that doesn't seem more complicated than its worth;
2. For the default Exception throwing case, I wanted to extend AnyVal and avoid boxing. So for each bias (left/right), I implement a typeclass to which two enrichment classes delegate, one whose Exception-throwing implementation is statically reachable and so available to a value class, another which accepts a user-specified implementation that might specify the empty token. The three classes could be condensed to one if avoiding boxing isn't worth the maintenance hassle.
