### PR TITLE
Closure elimination for new backend

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -140,7 +140,7 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
       if (AsmUtils.traceClassEnabled && cnode.name.contains(AsmUtils.traceClassPattern))
         AsmUtils.traceClass(cnode)
 
-      if (settings.YoptInlinerEnabled) {
+      if (settings.YoptAddToBytecodeRepository) {
         // The inliner needs to find all classes in the code repo, also those being compiled
         byteCodeRepository.add(cnode, ByteCodeRepository.CompilationUnit)
       }

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -44,6 +44,8 @@ abstract class BTypes {
 
   val inliner: Inliner[this.type]
 
+  val closureOptimizer: ClosureOptimizer[this.type]
+
   val callGraph: CallGraph[this.type]
 
   val backendReporting: BackendReporting

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -7,7 +7,7 @@ package scala.tools.nsc
 package backend.jvm
 
 import scala.tools.asm
-import scala.tools.nsc.backend.jvm.opt.{LocalOpt, CallGraph, Inliner, ByteCodeRepository}
+import scala.tools.nsc.backend.jvm.opt._
 import scala.tools.nsc.backend.jvm.BTypes.{InlineInfo, MethodInlineInfo, InternalName}
 import BackendReporting._
 import scala.tools.nsc.settings.ScalaSettings
@@ -41,6 +41,8 @@ class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
   val localOpt: LocalOpt[this.type] = new LocalOpt(this)
 
   val inliner: Inliner[this.type] = new Inliner(this)
+
+  val closureOptimizer: ClosureOptimizer[this.type] = new ClosureOptimizer(this)
 
   val callGraph: CallGraph[this.type] = new CallGraph(this)
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BackendReporting.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BackendReporting.scala
@@ -247,6 +247,28 @@ object BackendReporting {
                                      callsiteClass: InternalName, callsiteName: String, callsiteDesc: String) extends CannotInlineWarning
 
   /**
+   * Used in `rewriteClosureApplyInvocations` when a closure apply callsite cannot be rewritten
+   * to the closure body method.
+   */
+  trait RewriteClosureApplyToClosureBodyFailed extends OptimizerWarning {
+    def pos: Position
+
+    override def emitWarning(settings: ScalaSettings): Boolean = this match {
+      case RewriteClosureAccessCheckFailed(_, cause) => cause.emitWarning(settings)
+      case RewriteClosureIllegalAccess(_, _)         => settings.YoptWarningEmitAtInlineFailed
+    }
+
+    override def toString: String = this match {
+      case RewriteClosureAccessCheckFailed(_, cause) =>
+        s"Failed to rewrite the closure invocation to its implementation method:\n" + cause
+      case RewriteClosureIllegalAccess(_, callsiteClass) =>
+        s"The closure body invocation cannot be rewritten because the target method is not accessible in class $callsiteClass."
+    }
+  }
+  case class RewriteClosureAccessCheckFailed(pos: Position, cause: OptimizerWarning) extends RewriteClosureApplyToClosureBodyFailed
+  case class RewriteClosureIllegalAccess(pos: Position, callsiteClass: InternalName) extends RewriteClosureApplyToClosureBodyFailed
+
+  /**
    * Used in the InlineInfo of a ClassBType, when some issue occurred obtaining the inline information.
    */
   sealed trait ClassInlineInfoWarning extends OptimizerWarning {

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/InstructionStackEffect.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/InstructionStackEffect.scala
@@ -94,7 +94,7 @@ object InstructionStackEffect {
         val isSize2 = peekStack(0).getSize == 2
         if (isSize2) t(1, 0) else t(2, 0)
 
-      case DUP => t(0, 1)
+      case DUP => t(1, 2)
 
       case DUP_X1 => t(2, 3)
 
@@ -104,7 +104,7 @@ object InstructionStackEffect {
 
       case DUP2 =>
         val isSize2 = peekStack(0).getSize == 2
-        if (isSize2) t(0, 1) else t(0, 2)
+        if (isSize2) t(1, 2) else t(2, 4)
 
       case DUP2_X1 =>
         val isSize2 = peekStack(0).getSize == 2

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/ProdConsAnalyzer.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/ProdConsAnalyzer.scala
@@ -1,0 +1,450 @@
+/* NSC -- new Scala compiler
+ * Copyright 2005-2015 LAMP/EPFL
+ * @author Martin Odersky
+ */
+
+package scala.tools.nsc
+package backend.jvm
+package analysis
+
+import java.util
+
+import scala.annotation.switch
+import scala.collection.mutable
+import scala.tools.asm.{Type, MethodVisitor}
+import scala.tools.asm.Opcodes._
+import scala.tools.asm.tree._
+import scala.tools.asm.tree.analysis._
+import scala.tools.nsc.backend.jvm.BTypes.InternalName
+
+import opt.BytecodeUtils._
+
+import scala.collection.convert.decorateAsScala._
+
+/**
+ * This class provides additional queries over ASM's built-in `SourceValue` analysis.
+ *
+ * The analysis computes for each value in a frame a set of source instructions, which are the
+ * potential producers. Most instructions produce either nothing or a stack value. For example,
+ * a `LOAD` instruction is the producer of the value pushed onto the stack. The exception are
+ * `STORE` instructions, which produce a new value for a local variable slot, so they are used
+ * as producers for the value they stored.
+ *
+ * Note that pseudo-instructions are used as initial producers for parameters and local variables.
+ * See the documentation on class InitialProducer.
+ *
+ * This class implements the following queries over the data computed by the SourceValue analysis:
+ *
+ *   - producersForValueAt(insn, slot)
+ *   - consumersOfValueAt(insn, slot)
+ *
+ *   - producersForInputsOf(insn)
+ *   - consumersOfOutputsFrom(insn)
+ *
+ *   - initialProducersForValueAt(insn, slot)
+ *   - ultimateConsumersOfValueAt(insn, slot)
+ *
+ *   - initialProducersForInputsOf(insn)
+ *   - ultimateConsumersOfOutputsFrom(insn)
+ *
+ * The following operations are considered as copying operations:
+ *   - xLOAD, xSTORE
+ *   - DUP, DUP2, DUP_X1, DUP_X2, DUP2_X1, DUP2_X2
+ *   - SWAP
+ *   - CHECKCAST
+ *
+ * If ever needed, we could introduce a mode where primitive conversions (l2i) are considered as
+ * copying operations.
+ */
+class ProdConsAnalyzer(methodNode: MethodNode, classInternalName: InternalName) {
+  val analyzer = new Analyzer(new InitialProducerSourceInterpreter)
+  analyzer.analyze(classInternalName, methodNode)
+
+  def frameAt(insn: AbstractInsnNode) = analyzer.frameAt(insn, methodNode)
+
+  /**
+   * Returns the potential producer instructions of a (local or stack) value in the frame of `insn`.
+   * This method simply returns the producer information computed by the SourceValue analysis.
+   */
+  def producersForValueAt(insn: AbstractInsnNode, slot: Int): Set[AbstractInsnNode] = {
+    frameAt(insn).getValue(slot).insns.asScala.toSet
+  }
+
+  /**
+   * Returns the potential consumer instructions of a (local or stack) value in the frame of `insn`.
+   * This is the counterpart of `producersForValueAt`.
+   */
+  def consumersOfValueAt(insn: AbstractInsnNode, slot: Int): Set[AbstractInsnNode] = {
+    producersForValueAt(insn, slot).flatMap(prod => {
+      val outputNumber = outputValueSlots(prod).indexOf(slot)
+      _consumersOfOutputsFrom.get(prod).map(v => {
+        v(outputNumber)
+      }).getOrElse(Set.empty)
+    })
+  }
+
+  /**
+   * Returns the potential producer instructions of any of the values consumed by `insn`.
+   */
+  def producersForInputsOf(insn: AbstractInsnNode): Set[AbstractInsnNode] = {
+    inputValues(insn).iterator.flatMap(v => v.insns.asScala).toSet
+  }
+
+  def consumersOfOutputsFrom(insn: AbstractInsnNode): Set[AbstractInsnNode] =
+    _consumersOfOutputsFrom.get(insn).map(v => v.indices.flatMap(v.apply)(collection.breakOut): Set[AbstractInsnNode]).getOrElse(Set.empty)
+
+  /**
+   * Returns the potential initial producer instructions of a value in the frame of `insn`.
+   *
+   * Unlike `producersForValueAt`, producers are tracked through copying instructions such as STORE
+   * and LOAD. If the producer of the value is a LOAD, then the producers of the stored value(s) are
+   * returned instead.
+   */
+  def initialProducersForValueAt(insn: AbstractInsnNode, slot: Int): Set[AbstractInsnNode] = {
+    def initialProducers(insn: AbstractInsnNode, producedSlot: Int): Set[AbstractInsnNode] = {
+      if (isCopyOperation(insn)) {
+        _initialProducersCache.getOrElseUpdate((insn, producedSlot), {
+          val (sourceValue, sourceValueSlot) = copyOperationSourceValue(insn, producedSlot)
+          sourceValue.insns.iterator.asScala.flatMap(initialProducers(_, sourceValueSlot)).toSet
+        })
+      } else {
+        Set(insn)
+      }
+    }
+    producersForValueAt(insn, slot).flatMap(initialProducers(_, slot))
+  }
+
+  /**
+   * Returns the potential ultimate consumers of a value in the frame of `insn`. Consumers are
+   * tracked through copying operations such as SOTRE and LOAD.
+   */
+  def ultimateConsumersOfValueAt(insn: AbstractInsnNode, slot: Int): Set[AbstractInsnNode] = {
+    def ultimateConsumers(insn: AbstractInsnNode, consumedSlot: Int): Set[AbstractInsnNode] = {
+      if (isCopyOperation(insn)) {
+        _ultimateConsumersCache.getOrElseUpdate((insn, consumedSlot), {
+          for {
+            producedSlot     <- copyOperationProducedValueSlots(insn, consumedSlot)
+            consumer         <- consumersOfValueAt(insn.getNext, producedSlot)
+            ultimateConsumer <- ultimateConsumers(consumer, producedSlot)
+          } yield ultimateConsumer
+        })
+      } else {
+        Set(insn)
+      }
+    }
+    consumersOfValueAt(insn, slot).flatMap(ultimateConsumers(_, slot))
+  }
+
+  def initialProducersForInputsOf(insn: AbstractInsnNode): Set[AbstractInsnNode] = {
+    inputValueSlots(insn).flatMap(slot => initialProducersForValueAt(insn, slot)).toSet
+  }
+
+  def ultimateConsumersOfOutputsFrom(insn: AbstractInsnNode): Set[AbstractInsnNode] = {
+    lazy val next = insn.getNext
+    outputValueSlots(insn).flatMap(slot => ultimateConsumersOfValueAt(next, slot)).toSet
+  }
+
+  private def isCopyOperation(insn: AbstractInsnNode): Boolean = {
+    isVarInstruction(insn) || {
+      (insn.getOpcode: @switch) match {
+        case DUP | DUP_X1 | DUP_X2 | DUP2 | DUP2_X1 | DUP2_X2 | SWAP | CHECKCAST => true
+        case _ => false
+      }
+    }
+  }
+
+  /**
+   * Returns the value and its frame slot that `copyOp` copies into `producedSlot`.
+   *
+   * Example:
+   *   - copyOp = DUP_X1, assume it produces slots 2,3,4
+   *   - producedSlot = 3
+   *   - the result is the value at slot 2 in the frame of `copyOp`
+   */
+  private def copyOperationSourceValue(copyOp: AbstractInsnNode, producedSlot: Int): (SourceValue, Int) = {
+    val frame = frameAt(copyOp)
+
+    // Index of the produced value. Example: DUP_X1 produces 3 values, so producedIndex is 0, 1 or 2,
+    // where 0 corresponds to the lowest value on the stack.
+    def producedIndex(numConsumed: Int) = {
+      val numUsedSlotsBeforeCopy = frame.stackTop + 1
+      producedSlot - (numUsedSlotsBeforeCopy - numConsumed)
+    }
+
+    def stackValue(n: Int) = (frame.peekStack(n), frame.stackTop - n)
+
+    def dupX1Case = (producedIndex(2): @switch) match {
+      case 0 | 2 => stackValue(0)
+      case 1     => stackValue(1)
+    }
+
+    // Form 1 of dup_x2
+    def dupX2Case = (producedIndex(3): @switch) match {
+      case 0 | 3 => stackValue(0)
+      case 1     => stackValue(2)
+      case 2     => stackValue(1)
+    }
+
+    // Form 1 of dup2_x1
+    def dup2X1Case = (producedIndex(3): @switch) match {
+      case 0 | 3 => stackValue(1)
+      case 1 | 4 => stackValue(0)
+      case 2     => stackValue(2)
+    }
+
+    if (isLoad(copyOp)) {
+      val slot = copyOp.asInstanceOf[VarInsnNode].`var`
+      (frame.getLocal(slot), slot)
+    } else if (isStore(copyOp)) {
+      stackValue(0)
+    } else (copyOp.getOpcode: @switch) match {
+      case DUP =>
+        stackValue(0) // the current stack top is the source of both produced values
+
+      case DUP_X1 =>
+        dupX1Case
+
+      case DUP_X2 =>
+        if (frame.peekStack(1).getSize == 2) dupX1Case
+        else dupX2Case
+
+      case DUP2 =>
+        if (frame.peekStack(0).getSize == 2) stackValue(0)
+        else {
+          (producedIndex(2): @switch) match {
+            case 0 | 2 => stackValue(1)
+            case 1 | 3 => stackValue(0)
+          }
+        }
+
+      case DUP2_X1 =>
+        if (frame.peekStack(0).getSize == 2) dupX1Case
+        else dup2X1Case
+
+      case DUP2_X2 =>
+        val v1isSize2 = frame.peekStack(0).getSize == 2
+        if (v1isSize2) {
+          val v2isSize2 = frame.peekStack(1).getSize == 2
+          if (v2isSize2) dupX1Case // Form 4
+          else dupX2Case // Form 2
+        } else {
+          val v3isSize2 = frame.peekStack(2).getSize == 2
+          if (v3isSize2) dup2X1Case // Form 3
+          else {
+            // Form 1
+            (producedIndex(4): @switch) match {
+              case 0 | 4 => stackValue(1)
+              case 1 | 5 => stackValue(0)
+              case 2     => stackValue(3)
+              case 3     => stackValue(2)
+            }
+          }
+        }
+
+      case SWAP =>
+        if (producedIndex(2) == 0) stackValue(0)
+        else stackValue(1)
+
+      case CHECKCAST =>
+        stackValue(0)
+    }
+  }
+
+  /**
+   * Returns the value slots into which `copyOp` copies the value at `consumedSlot`.
+   *
+   * Example:
+   *   - copyOp = DUP_X1, assume it consumes slots 2,3 and produces 2,3,4
+   *   - if consumedSlot == 2, the result is Set(3)
+   *   - if consumedSlot == 3, the result is Set(2, 4)
+   */
+  private def copyOperationProducedValueSlots(copyOp: AbstractInsnNode, consumedSlot: Int): Set[Int] = {
+    if (isStore(copyOp)) Set(copyOp.asInstanceOf[VarInsnNode].`var`)
+    else {
+      val nextFrame = frameAt(copyOp.getNext)
+      val top = nextFrame.stackTop
+
+      // Index of the consumed value. Example: DUP_X1 consumes two values, so consumedIndex is
+      // 0 or 1, where 0 corresponds to the lower value on the stack.
+      def consumedIndex(numProduced: Int) = {
+        val numUsedSlotsAfterCopy = top + 1
+        consumedSlot - (numUsedSlotsAfterCopy - numProduced)
+      }
+
+      def dupX1Case = (consumedIndex(3): @switch) match {
+        case 0 => Set(top - 1)
+        case 1 => Set(top - 2, top)
+      }
+
+      def dupX2Case = (consumedIndex(4): @switch) match {
+        case 0 => Set(top - 2)
+        case 1 => Set(top - 1)
+        case 2 => Set(top - 3, top)
+      }
+
+      def dup2X1Case = (consumedIndex(5): @switch) match {
+        case 0 => Set(top - 2)
+        case 1 => Set(top - 4, top - 1)
+        case 2 => Set(top - 3, top)
+      }
+
+      if (isLoad(copyOp)) Set(top)
+      else (copyOp.getOpcode: @switch) match {
+        case DUP =>
+          Set(top - 1, top)
+
+        case DUP_X1 =>
+          dupX1Case
+
+        case DUP_X2 =>
+          if (nextFrame.peekStack(1).getSize == 2) dupX1Case
+          else dupX2Case
+
+        case DUP2 =>
+          if (nextFrame.peekStack(0).getSize == 2) Set(top - 1, top)
+          else (consumedIndex(4): @switch) match {
+            case 0 => Set(top - 3, top - 1)
+            case 1 => Set(top - 2, top)
+          }
+
+        case DUP2_X1 =>
+          if (nextFrame.peekStack(0).getSize == 2) dupX1Case
+          else dup2X1Case
+
+        case DUP2_X2 =>
+          val v1isSize2 = nextFrame.peekStack(0).getSize == 2
+          if (v1isSize2) {
+            val v2isSize2 = nextFrame.peekStack(1).getSize == 2
+            if (v2isSize2) dupX1Case // Form 4
+            else dupX2Case // Form 2
+          } else {
+            val v3isSize2 = nextFrame.peekStack(2).getSize == 2
+            if (v3isSize2) dup2X1Case // Form 3
+            else {
+              // Form 1
+              (consumedIndex(6): @switch) match {
+                case 0 => Set(top - 3)
+                case 1 => Set(top - 2)
+                case 2 => Set(top - 5, top - 1)
+                case 3 => Set(top - 4, top)
+              }
+            }
+          }
+
+        case SWAP =>
+          if (consumedIndex(2) == 0) Set(top)
+          else Set(top - 1)
+
+        case CHECKCAST =>
+          Set(top)
+      }
+    }
+  }
+
+  /** Returns the frame values consumed by executing `insn`. */
+  private def inputValues(insn: AbstractInsnNode): Seq[SourceValue] = {
+    lazy val frame = frameAt(insn)
+    inputValueSlots(insn) map frame.getValue
+  }
+
+  /** Returns the frame slots holding the values consumed by executing `insn`. */
+  private def inputValueSlots(insn: AbstractInsnNode): Seq[Int] = {
+    if (insn.getOpcode == -1) return Seq.empty
+    if (isLoad(insn)) {
+      Seq(insn.asInstanceOf[VarInsnNode].`var`)
+    } else if (insn.getOpcode == IINC) {
+      Seq(insn.asInstanceOf[IincInsnNode].`var`)
+    } else {
+      val frame = frameAt(insn)
+      val stackEffect = InstructionStackEffect(insn, frame)
+      val stackSize = frame.getLocals + frame.getStackSize
+      (stackSize - stackEffect._1) until stackSize
+    }
+  }
+
+  /** Returns the frame slots holding the values produced by executing `insn`. */
+  private def outputValueSlots(insn: AbstractInsnNode): Seq[Int] = insn match {
+    case ParameterProducer(local)          => Seq(local)
+    case UninitializedLocalProducer(local) => Seq(local)
+    case ExceptionProducer(frame)          => Seq(frame.stackTop)
+    case _ =>
+      if (insn.getOpcode == -1) return Seq.empty
+      if (isStore(insn)) {
+        Seq(insn.asInstanceOf[VarInsnNode].`var`)
+      } else if (insn.getOpcode == IINC) {
+        Seq(insn.asInstanceOf[IincInsnNode].`var`)
+      } else {
+        val frame = frameAt(insn)
+        val stackEffect = InstructionStackEffect(insn, frame)
+        val nextFrame = frameAt(insn.getNext)
+        val stackSize = nextFrame.getLocals + nextFrame.getStackSize
+        (stackSize - stackEffect._2) until stackSize
+      }
+  }
+
+  /** For each instruction, a set of potential consumers of the produced values. */
+  private lazy val _consumersOfOutputsFrom: Map[AbstractInsnNode, Vector[Set[AbstractInsnNode]]] = {
+    var res = Map.empty[AbstractInsnNode, Vector[Set[AbstractInsnNode]]]
+    for {
+      insn <- methodNode.instructions.iterator.asScala
+      frame = frameAt(insn)
+      i <- inputValueSlots(insn)
+      producer <- frame.getValue(i).insns.asScala
+    } {
+      val producedSlots = outputValueSlots(producer)
+      val currentConsumers = res.getOrElse(producer, Vector.fill(producedSlots.size)(Set.empty[AbstractInsnNode]))
+      val outputIndex = producedSlots.indexOf(i)
+      res = res.updated(producer, currentConsumers.updated(outputIndex, currentConsumers(outputIndex) + insn))
+    }
+    res
+  }
+
+  private val _initialProducersCache:  mutable.AnyRefMap[(AbstractInsnNode, Int), Set[AbstractInsnNode]] = mutable.AnyRefMap.empty
+  private val _ultimateConsumersCache: mutable.AnyRefMap[(AbstractInsnNode, Int), Set[AbstractInsnNode]] = mutable.AnyRefMap.empty
+}
+
+/**
+ * A class for pseudo-instructions representing the initial producers of local values that have
+ * no producer instruction in the method:
+ *   - parameters, including `this`
+ *   - uninitialized local variables
+ *   - exception values in handlers
+ *
+ * The ASM built-in SourceValue analysis yields an empty producers set for such values. This leads
+ * to ambiguities. Example (in Java one can re-assign parameter):
+ *
+ *   void foo(int a) {
+ *     if (a == 0) a = 1;
+ *     return a;
+ *   }
+ *
+ * In the first frame of the method, the SoruceValue for parameter `a` gives an empty set of
+ * producer instructions.
+ *
+ * In the frame of the `IRETURN` instruction, the SoruceValue for parameter `a` lists a single
+ * producer instruction: the `ISTORE 1`. This makes it look as if there was a single producer for
+ * `a`, where in fact it might still hold the parameter's initial value.
+ */
+abstract class InitialProducer extends AbstractInsnNode(-1) {
+  override def getType: Int = throw new UnsupportedOperationException
+  override def clone(labels: util.Map[LabelNode, LabelNode]): AbstractInsnNode = throw new UnsupportedOperationException
+  override def accept(cv: MethodVisitor): Unit = throw new UnsupportedOperationException
+}
+
+case class ParameterProducer(local: Int)                      extends InitialProducer
+case class UninitializedLocalProducer(local: Int)             extends InitialProducer
+case class ExceptionProducer(handlerFrame: Frame[_ <: Value]) extends InitialProducer
+
+class InitialProducerSourceInterpreter extends SourceInterpreter {
+  override def newParameterValue(isInstanceMethod: Boolean, local: Int, tp: Type): SourceValue = {
+    new SourceValue(tp.getSize, ParameterProducer(local))
+  }
+
+  override def newEmptyNonParameterLocalValue(local: Int): SourceValue = {
+    new SourceValue(1, UninitializedLocalProducer(local))
+  }
+
+  override def newExceptionValue(tryCatchBlockNode: TryCatchBlockNode, handlerFrame: Frame[_ <: Value], exceptionType: Type): SourceValue = {
+    new SourceValue(1, ExceptionProducer(handlerFrame))
+  }
+}

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/ByteCodeRepository.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/ByteCodeRepository.scala
@@ -102,7 +102,7 @@ class ByteCodeRepository(val classPath: ClassFileLookup[AbstractFile], val isJav
   }
 
   /**
-   * The method node for a method matching `name` and `descriptor`, accessed in class `classInternalName`.
+   * The method node for a method matching `name` and `descriptor`, accessed in class `ownerInternalNameOrArrayDescriptor`.
    * The declaration of the method may be in one of the parents.
    *
    * @return The [[MethodNode]] of the requested method and the [[InternalName]] of its declaring

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
@@ -14,7 +14,6 @@ import scala.tools.asm.commons.CodeSizeEvaluator
 import scala.tools.asm.tree.analysis._
 import scala.tools.asm.{MethodWriter, ClassWriter, Label, Opcodes}
 import scala.tools.asm.tree._
-import scala.collection.convert.decorateAsScala._
 import GenBCode._
 import scala.collection.convert.decorateAsScala._
 import scala.collection.convert.decorateAsJava._
@@ -73,10 +72,17 @@ object BytecodeUtils {
     op >= Opcodes.IRETURN && op <= Opcodes.RETURN
   }
 
-  def isVarInstruction(instruction: AbstractInsnNode): Boolean = {
+  def isLoad(instruction: AbstractInsnNode): Boolean = {
     val op = instruction.getOpcode
-    (op >= Opcodes.ILOAD  && op <= Opcodes.ALOAD) || (op >= Opcodes.ISTORE && op <= Opcodes.ASTORE)
+    op >= Opcodes.ILOAD  && op <= Opcodes.ALOAD
   }
+
+  def isStore(instruction: AbstractInsnNode): Boolean = {
+    val op = instruction.getOpcode
+    op >= Opcodes.ISTORE && op <= Opcodes.ASTORE
+  }
+
+  def isVarInstruction(instruction: AbstractInsnNode): Boolean = isLoad(instruction) || isStore(instruction)
 
   def isExecutable(instruction: AbstractInsnNode): Boolean = instruction.getOpcode >= 0
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/ClosureOptimizer.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/ClosureOptimizer.scala
@@ -1,0 +1,314 @@
+/* NSC -- new Scala compiler
+ * Copyright 2005-2015 LAMP/EPFL
+ * @author  Martin Odersky
+ */
+
+package scala.tools.nsc
+package backend.jvm
+package opt
+
+import scala.annotation.switch
+import scala.reflect.internal.util.NoPosition
+import scala.tools.asm.{Handle, Type, Opcodes}
+import scala.tools.asm.tree._
+import scala.tools.nsc.backend.jvm.BTypes.InternalName
+import scala.tools.nsc.backend.jvm.analysis.ProdConsAnalyzer
+import BytecodeUtils._
+import BackendReporting._
+import Opcodes._
+import scala.tools.nsc.backend.jvm.opt.ByteCodeRepository.CompilationUnit
+import scala.collection.convert.decorateAsScala._
+
+class ClosureOptimizer[BT <: BTypes](val btypes: BT) {
+  import btypes._
+  import callGraph._
+
+  def rewriteClosureApplyInvocations(): Unit = {
+    closureInstantiations foreach {
+      case (indy, (methodNode, ownerClass)) =>
+        val warnings = rewriteClosureApplyInvocations(indy, methodNode, ownerClass)
+        warnings.foreach(w => backendReporting.inlinerWarning(w.pos, w.toString))
+    }
+  }
+
+  private val lambdaMetaFactoryInternalName: InternalName = "java/lang/invoke/LambdaMetafactory"
+
+  private val metafactoryHandle = {
+    val metafactoryMethodName: String = "metafactory"
+    val metafactoryDesc: String       = "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;"
+    new Handle(H_INVOKESTATIC, lambdaMetaFactoryInternalName, metafactoryMethodName, metafactoryDesc)
+  }
+
+  private val altMetafactoryHandle = {
+    val altMetafactoryMethodName: String = "altMetafactory"
+    val altMetafactoryDesc: String       = "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;[Ljava/lang/Object;)Ljava/lang/invoke/CallSite;"
+    new Handle(H_INVOKESTATIC, lambdaMetaFactoryInternalName, altMetafactoryMethodName, altMetafactoryDesc)
+  }
+
+  def isClosureInstantiation(indy: InvokeDynamicInsnNode): Boolean = {
+    (indy.bsm == metafactoryHandle || indy.bsm == altMetafactoryHandle) &&
+    {
+      indy.bsmArgs match {
+        case Array(samMethodType: Type, implMethod: Handle, instantiatedMethodType: Type, xs @ _*) =>
+          // LambdaMetaFactory performs a number of automatic adaptations when invoking the lambda
+          // implementation method (casting, boxing, unboxing, and primitive widening, see Javadoc).
+          // The closure optimizer (rewriteClosureApplyInvocations) does not currently support these
+          // adaptations, so we don't consider indy calls that need adaptations for rewriting.
+          // Indy calls emitted by scalac never rely on adaptation, they are implemented explicitly
+          // in the implMethod.
+          //
+          // Note that we don't check all the invariants requried for a metafactory indy call, only
+          // those required not to crash the compiler.
+
+          val implMethodType = Type.getType(implMethod.getDesc)
+          val numCaptures = implMethodType.getArgumentTypes.length - instantiatedMethodType.getArgumentTypes.length
+          val implMethodTypeWithoutCaputres = Type.getMethodType(implMethodType.getReturnType, implMethodType.getArgumentTypes.drop(numCaptures): _*)
+          implMethodTypeWithoutCaputres == instantiatedMethodType
+
+        case _ =>
+          false
+      }
+    }
+  }
+
+  def isSamInvocation(invocation: MethodInsnNode, indy: InvokeDynamicInsnNode, prodCons: => ProdConsAnalyzer): Boolean = {
+    if (invocation.getOpcode == INVOKESTATIC) false
+    else {
+      def closureIsReceiver = {
+        val invocationFrame = prodCons.frameAt(invocation)
+        val receiverSlot = {
+          val numArgs = Type.getArgumentTypes(invocation.desc).length
+          invocationFrame.stackTop - numArgs
+        }
+        val receiverProducers = prodCons.initialProducersForValueAt(invocation, receiverSlot)
+        receiverProducers.size == 1 && receiverProducers.head == indy
+      }
+
+      invocation.name == indy.name && {
+        val indySamMethodDesc = indy.bsmArgs(0).asInstanceOf[Type].getDescriptor // safe, checked in isClosureInstantiation
+        indySamMethodDesc == invocation.desc
+      } &&
+      closureIsReceiver // most expensive check last
+    }
+  }
+
+  /**
+   * Stores the values captured by a closure creation into fresh local variables.
+   * Returns the list of locals holding the captured values.
+   */
+  private def storeCaptures(indy: InvokeDynamicInsnNode, methodNode: MethodNode): LocalsList = {
+    val capturedTypes = Type.getArgumentTypes(indy.desc)
+    val firstCaptureLocal = methodNode.maxLocals
+
+    // This could be optimized: in many cases the captured values are produced by LOAD instructions.
+    // If the variable is not modified within the method, we could avoid introducing yet another
+    // local. On the other hand, further optimizations (copy propagation, remove unused locals) will
+    // clean it up.
+    val localsForCaptures = LocalsList.fromTypes(firstCaptureLocal, capturedTypes)
+    methodNode.maxLocals = firstCaptureLocal + localsForCaptures.size
+
+    insertStoreOps(indy, methodNode, localsForCaptures)
+    insertLoadOps(indy, methodNode, localsForCaptures)
+
+    localsForCaptures
+  }
+
+  /**
+   * Insert store operations in front of the `before` instruction to copy stack values into the
+   * locals denoted by `localsList`.
+   *
+   * The lowest stack value is stored in the head of the locals list, so the last local is stored first.
+   */
+  private def insertStoreOps(before: AbstractInsnNode, methodNode: MethodNode, localsList: LocalsList) =
+    insertLocalValueOps(before, methodNode, localsList, store = true)
+
+  /**
+   * Insert load operations in front of the `before` instruction to copy the local values denoted
+   * by `localsList` onto the stack.
+   *
+   * The head of the locals list will be the lowest value on the stack, so the first local is loaded first.
+   */
+  private def insertLoadOps(before: AbstractInsnNode, methodNode: MethodNode, localsList: LocalsList) =
+    insertLocalValueOps(before, methodNode, localsList, store = false)
+
+  private def insertLocalValueOps(before: AbstractInsnNode, methodNode: MethodNode, localsList: LocalsList, store: Boolean): Unit = {
+    // If `store` is true, the first instruction needs to store into the last local of the `localsList`.
+    // Load instructions on the other hand are emitted in the order of the list.
+    // To avoid reversing the list, we use `insert(previousInstr)` for stores and `insertBefore(before)` for loads.
+    lazy val previous = before.getPrevious
+    for (l <- localsList.locals) {
+      val varOp = new VarInsnNode(if (store) l.storeOpcode else l.loadOpcode, l.local)
+      if (store) methodNode.instructions.insert(previous, varOp)
+      else methodNode.instructions.insertBefore(before, varOp)
+    }
+  }
+
+  def rewriteClosureApplyInvocations(indy: InvokeDynamicInsnNode, methodNode: MethodNode, ownerClass: ClassBType): List[RewriteClosureApplyToClosureBodyFailed] = {
+    val lambdaBodyHandle = indy.bsmArgs(1).asInstanceOf[Handle] // safe, checked in isClosureInstantiation
+
+    // Kept as a lazy val to make sure the analysis is only computed if it's actually needed.
+    // ProdCons is used to identify closure body invocations (see isSamInvocation), but only if the
+    // callsite has the right name and signature. If the method has no invcation instruction with
+    // the right name and signature, the analysis is not executed.
+    lazy val prodCons = new ProdConsAnalyzer(methodNode, ownerClass.internalName)
+
+    // First collect all callsites without modifying the instructions list yet.
+    // Once we start modifying the instruction list, prodCons becomes unusable.
+
+    // A list of callsites and stack heights. If the invocation cannot be rewritten, a warning
+    // message is stored in the stack height value.
+    val invocationsToRewrite: List[(MethodInsnNode, Either[RewriteClosureApplyToClosureBodyFailed, Int])] = methodNode.instructions.iterator.asScala.collect({
+      case invocation: MethodInsnNode if isSamInvocation(invocation, indy, prodCons) =>
+        val bodyAccessible: Either[OptimizerWarning, Boolean] = for {
+          (bodyMethodNode, declClass) <- byteCodeRepository.methodNode(lambdaBodyHandle.getOwner, lambdaBodyHandle.getName, lambdaBodyHandle.getDesc): Either[OptimizerWarning, (MethodNode, InternalName)]
+          isAccessible                <- inliner.memberIsAccessible(bodyMethodNode.access, classBTypeFromParsedClassfile(declClass), classBTypeFromParsedClassfile(lambdaBodyHandle.getOwner), ownerClass)
+        } yield {
+          isAccessible
+        }
+
+        def pos = callGraph.callsites.get(invocation).map(_.callsitePosition).getOrElse(NoPosition)
+        val stackSize: Either[RewriteClosureApplyToClosureBodyFailed, Int] = bodyAccessible match {
+          case Left(w)      => Left(RewriteClosureAccessCheckFailed(pos, w))
+          case Right(false) => Left(RewriteClosureIllegalAccess(pos, ownerClass.internalName))
+          case _            => Right(prodCons.frameAt(invocation).getStackSize)
+        }
+
+        (invocation, stackSize)
+    }).toList
+
+    if (invocationsToRewrite.isEmpty) Nil
+    else {
+      // lazy val to make sure locals for captures and arguments are only allocated if there's
+      // effectively a callsite to rewrite.
+      lazy val (localsForCapturedValues, argumentLocalsList) = {
+        val captureLocals = storeCaptures(indy, methodNode)
+
+        // allocate locals for storing the arguments of the closure apply callsites.
+        // if there are multiple callsites, the same locals are re-used.
+        val argTypes = indy.bsmArgs(0).asInstanceOf[Type].getArgumentTypes // safe, checked in isClosureInstantiation
+        val firstArgLocal = methodNode.maxLocals
+        val argLocals = LocalsList.fromTypes(firstArgLocal, argTypes)
+        methodNode.maxLocals = firstArgLocal + argLocals.size
+
+        (captureLocals, argLocals)
+      }
+
+      val warnings = invocationsToRewrite flatMap {
+        case (invocation, Left(warning)) => Some(warning)
+
+        case (invocation, Right(stackHeight)) =>
+          // store arguments
+          insertStoreOps(invocation, methodNode, argumentLocalsList)
+
+          // drop the closure from the stack
+          methodNode.instructions.insertBefore(invocation, new InsnNode(POP))
+
+          // load captured values and arguments
+          insertLoadOps(invocation, methodNode, localsForCapturedValues)
+          insertLoadOps(invocation, methodNode, argumentLocalsList)
+
+          // update maxStack
+          val capturesStackSize = localsForCapturedValues.size
+          val invocationStackHeight = stackHeight + capturesStackSize - 1 // -1 because the closure is gone
+          if (invocationStackHeight > methodNode.maxStack)
+            methodNode.maxStack = invocationStackHeight
+
+          // replace the callsite with a new call to the body method
+          val bodyOpcode = (lambdaBodyHandle.getTag: @switch) match {
+            case H_INVOKEVIRTUAL    => INVOKEVIRTUAL
+            case H_INVOKESTATIC     => INVOKESTATIC
+            case H_INVOKESPECIAL    => INVOKESPECIAL
+            case H_INVOKEINTERFACE  => INVOKEINTERFACE
+            case H_NEWINVOKESPECIAL =>
+              val insns = methodNode.instructions
+              insns.insertBefore(invocation, new TypeInsnNode(NEW, lambdaBodyHandle.getOwner))
+              insns.insertBefore(invocation, new InsnNode(DUP))
+              INVOKESPECIAL
+          }
+          val isInterface = bodyOpcode == INVOKEINTERFACE
+          val bodyInvocation = new MethodInsnNode(bodyOpcode, lambdaBodyHandle.getOwner, lambdaBodyHandle.getName, lambdaBodyHandle.getDesc, isInterface)
+          methodNode.instructions.insertBefore(invocation, bodyInvocation)
+          methodNode.instructions.remove(invocation)
+
+          // update the call graph
+          val originalCallsite = callGraph.callsites.remove(invocation)
+
+          // the method node is needed for building the call graph entry
+          val bodyMethod = byteCodeRepository.methodNode(lambdaBodyHandle.getOwner, lambdaBodyHandle.getName, lambdaBodyHandle.getDesc)
+          def bodyMethodIsBeingCompiled = byteCodeRepository.classNodeAndSource(lambdaBodyHandle.getOwner).map(_._2 == CompilationUnit).getOrElse(false)
+          val bodyMethodCallsite = Callsite(
+            callsiteInstruction = bodyInvocation,
+            callsiteMethod = methodNode,
+            callsiteClass = ownerClass,
+            callee = bodyMethod.map({
+              case (bodyMethodNode, bodyMethodDeclClass) => Callee(
+                callee = bodyMethodNode,
+                calleeDeclarationClass = classBTypeFromParsedClassfile(bodyMethodDeclClass),
+                safeToInline = compilerSettings.YoptInlineGlobal || bodyMethodIsBeingCompiled,
+                safeToRewrite = false, // the lambda body method is not a trait interface method
+                annotatedInline = false,
+                annotatedNoInline = false,
+                calleeInfoWarning = None)
+            }),
+            argInfos = Nil,
+            callsiteStackHeight = invocationStackHeight,
+            receiverKnownNotNull = true, // see below (*)
+            callsitePosition = originalCallsite.map(_.callsitePosition).getOrElse(NoPosition)
+          )
+          // (*) The documentation in class LambdaMetafactory says:
+          //     "if implMethod corresponds to an instance method, the first capture argument
+          //     (corresponding to the receiver) must be non-null"
+          // Explanation: If the lambda body method is non-static, the receiver is a captured
+          // value. It can only be captured within some instance method, so we know it's non-null.
+          callGraph.callsites(bodyInvocation) = bodyMethodCallsite
+          None
+      }
+
+      warnings.toList
+    }
+  }
+
+  /**
+   * A list of local variables. Each local stores information about its type, see class [[Local]].
+   */
+  case class LocalsList(locals: List[Local]) {
+    val size = locals.iterator.map(_.size).sum
+  }
+
+  object LocalsList {
+    /**
+     * A list of local variables starting at `firstLocal` that can hold values of the types in the
+     * `types` parameter.
+     *
+     * For example, `fromTypes(3, Array(Int, Long, String))` returns
+     *   Local(3, intOpOffset)  ::
+     *   Local(4, longOpOffset) ::  // note that this local occupies two slots, the next is at 6
+     *   Local(6, refOpOffset)  ::
+     *   Nil
+     */
+    def fromTypes(firstLocal: Int, types: Array[Type]): LocalsList = {
+      var sizeTwoOffset = 0
+      val locals: List[Local] = types.indices.map(i => {
+        // The ASM method `type.getOpcode` returns the opcode for operating on a value of `type`.
+        val offset = types(i).getOpcode(ILOAD) - ILOAD
+        val local = Local(firstLocal + i + sizeTwoOffset, offset)
+        if (local.size == 2) sizeTwoOffset += 1
+        local
+      })(collection.breakOut)
+      LocalsList(locals)
+    }
+  }
+
+  /**
+   * Stores a local varaible index the opcode offset required for operating on that variable.
+   *
+   * The xLOAD / xSTORE opcodes are in the following sequence: I, L, F, D, A, so the offset for
+   * a local variable holding a reference (`A`) is 4. See also method `getOpcode` in [[scala.tools.asm.Type]].
+   */
+  case class Local(local: Int, opcodeOffset: Int) {
+    def size = if (loadOpcode == LLOAD || loadOpcode == DLOAD) 2  else 1
+
+    def loadOpcode = ILOAD + opcodeOffset
+    def storeOpcode = ISTORE + opcodeOffset
+  }
+}

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -235,6 +235,7 @@ trait ScalaSettings extends AbsScalaSettings
     val emptyLabels             = Choice("empty-labels",              "Eliminate and collapse redundant labels in the bytecode.")
     val compactLocals           = Choice("compact-locals",            "Eliminate empty slots in the sequence of local variables.")
     val nullnessTracking        = Choice("nullness-tracking",         "Track nullness / non-nullness of local variables and apply optimizations.")
+    val closureElimination      = Choice("closure-elimination" ,      "Rewrite closure invocations to the implementation method and eliminate closures.")
     val inlineProject           = Choice("inline-project",            "Inline only methods defined in the files being compiled.")
     val inlineGlobal            = Choice("inline-global",             "Inline methods from any source, including classfiles on the compile classpath.")
 
@@ -243,7 +244,7 @@ trait ScalaSettings extends AbsScalaSettings
     private val defaultChoices = List(unreachableCode)
     val lDefault        = Choice("l:default",   "Enable default optimizations: "+ defaultChoices.mkString(","),                                    expandsTo = defaultChoices)
 
-    private val methodChoices = List(unreachableCode, simplifyJumps, emptyLineNumbers, emptyLabels, compactLocals, nullnessTracking)
+    private val methodChoices = List(unreachableCode, simplifyJumps, emptyLineNumbers, emptyLabels, compactLocals, nullnessTracking, closureElimination)
     val lMethod         = Choice("l:method",    "Enable intra-method optimizations: "+ methodChoices.mkString(","),                                expandsTo = methodChoices)
 
     private val projectChoices = List(lMethod, inlineProject)
@@ -266,10 +267,14 @@ trait ScalaSettings extends AbsScalaSettings
   def YoptEmptyLabels             = Yopt.contains(YoptChoices.emptyLabels)
   def YoptCompactLocals           = Yopt.contains(YoptChoices.compactLocals)
   def YoptNullnessTracking        = Yopt.contains(YoptChoices.nullnessTracking)
+  def YoptClosureElimination      = Yopt.contains(YoptChoices.closureElimination)
 
   def YoptInlineProject           = Yopt.contains(YoptChoices.inlineProject)
   def YoptInlineGlobal            = Yopt.contains(YoptChoices.inlineGlobal)
   def YoptInlinerEnabled          = YoptInlineProject || YoptInlineGlobal
+
+  def YoptBuildCallGraph          = YoptInlinerEnabled || YoptClosureElimination
+  def YoptAddToBytecodeRepository = YoptInlinerEnabled || YoptClosureElimination
 
   val YoptInlineHeuristics = ChoiceSetting(
     name = "-Yopt-inline-heuristics",

--- a/test/junit/scala/tools/nsc/backend/jvm/analysis/NullnessAnalyzerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/analysis/NullnessAnalyzerTest.scala
@@ -38,17 +38,6 @@ class NullnessAnalyzerTest extends ClearAfterClass {
     nullnessAnalyzer
   }
 
-  /**
-   * Instructions that match `query` when textified.
-   * If `query` starts with a `+`, the next instruction is returned.
-   */
-  def findInstr(method: MethodNode, query: String): List[AbstractInsnNode] = {
-    val useNext = query(0) == '+'
-    val instrPart = if (useNext) query.drop(1) else query
-    val insns = method.instructions.iterator.asScala.find(i => textify(i) contains instrPart).toList
-    if (useNext) insns.map(_.getNext) else insns
-  }
-
   def testNullness(analyzer: NullnessAnalyzer, method: MethodNode, query: String, index: Int, nullness: Nullness): Unit = {
     for (i <- findInstr(method, query)) {
       val r = analyzer.frameAt(i, method).getValue(index).nullness

--- a/test/junit/scala/tools/nsc/backend/jvm/analysis/ProdConsAnalyzerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/analysis/ProdConsAnalyzerTest.scala
@@ -1,0 +1,249 @@
+package scala.tools.nsc
+package backend.jvm
+package analysis
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Assert._
+
+import scala.tools.asm.Opcodes
+import scala.tools.asm.tree.AbstractInsnNode
+import scala.tools.partest.ASMConverters._
+import scala.tools.testing.ClearAfterClass
+import CodeGenTools._
+import AsmUtils._
+
+object ProdConsAnalyzerTest extends ClearAfterClass.Clearable {
+  var noOptCompiler = newCompiler(extraArgs = "-Ybackend:GenBCode -Yopt:l:none")
+
+  def clear(): Unit = {
+    noOptCompiler = null
+  }
+}
+
+@RunWith(classOf[JUnit4])
+class ProdConsAnalyzerTest extends ClearAfterClass {
+  ClearAfterClass.stateToClear = ProdConsAnalyzerTest
+  val noOptCompiler = ProdConsAnalyzerTest.noOptCompiler
+
+  def prodToString(producer: AbstractInsnNode) = producer match {
+    case p: InitialProducer => p.toString
+    case p => textify(p)
+  }
+
+  def testSingleInsn(singletonInsns: Traversable[AbstractInsnNode], expected: String): Unit = {
+    testInsn(single(singletonInsns), expected)
+  }
+
+  def testMultiInsns(insns: Traversable[AbstractInsnNode], expected: Traversable[String]): Unit = {
+    assertTrue(s"Sizes don't match: ${insns.size} vs ${expected.size}", insns.size == expected.size)
+    for (insn <- insns) {
+      val txt = prodToString(insn)
+      assertTrue(s"Instruction $txt not found in ${expected mkString ", "}", expected.exists(txt.contains))
+    }
+  }
+
+  def testInsn(insn: AbstractInsnNode, expected: String): Unit = {
+    val txt = prodToString(insn)
+    assertTrue(s"Expected $expected, found $txt", txt contains expected)
+  }
+
+  def single[T](c: Traversable[T]): T = {
+    assertTrue(s"Expected singleton collection, got $c", c.size == 1)
+    c.head
+  }
+
+  @Test
+  def parameters(): Unit = {
+    val List(m) = compileMethods(noOptCompiler)("def f = this.toString")
+    val a = new ProdConsAnalyzer(m, "C")
+    val call = findInstr(m, "INVOKEVIRTUAL").head
+
+    testSingleInsn(a.producersForValueAt(call, 1), "ALOAD 0") // producer of stack value
+    testSingleInsn(a.producersForInputsOf(call), "ALOAD 0")
+
+    testSingleInsn(a.consumersOfValueAt(call.getNext, 1), "ARETURN")  // consumer of `toString` result
+    testSingleInsn(a.consumersOfOutputsFrom(call), "ARETURN")
+
+    testSingleInsn(a.ultimateConsumersOfValueAt(call.getNext, 1), "ARETURN")
+
+    testSingleInsn(a.initialProducersForValueAt(call, 1), "ParameterProducer")
+    testSingleInsn(a.producersForValueAt(call, 0), "ParameterProducer")
+  }
+
+  @Test
+  def parametersInitialProducer(): Unit = {
+    // mutates a parameter local (not possible in scala, but in bytecode)
+    import Opcodes._
+    val m = genMethod(descriptor = "(I)I")(
+      Label(0),
+      VarOp(ILOAD, 1),
+      Jump(IFNE, Label(1)),
+      Op(ICONST_1),
+      VarOp(ISTORE, 1),
+      Label(1),
+      VarOp(ILOAD, 1),
+      Op(IRETURN),
+      Label(2)
+    )
+    m.maxLocals = 2
+    m.maxStack = 1
+    val a = new ProdConsAnalyzer(m, "C")
+
+    val ifne = findInstr(m, "IFNE").head
+    testSingleInsn(a.producersForValueAt(ifne, 1), "ParameterProducer")
+
+    val ret = findInstr(m, "IRETURN").head
+    testMultiInsns(a.producersForValueAt(ret, 1), List("ParameterProducer", "ISTORE 1"))
+  }
+
+  @Test
+  def branching(): Unit = {
+    val List(m) = compileMethods(noOptCompiler)("def f(x: Int) = { var a = x; if (a == 0) a = 12; a }")
+    val a = new ProdConsAnalyzer(m, "C")
+
+    val List(ret) = findInstr(m, "IRETURN")
+    testMultiInsns(a.producersForValueAt(ret, 2), List("ISTORE 2", "ISTORE 2"))
+    testMultiInsns(a.initialProducersForValueAt(ret, 2), List("BIPUSH 12", "ParameterProducer"))
+
+    val List(bipush) = findInstr(m, "BIPUSH 12")
+    testSingleInsn(a.consumersOfOutputsFrom(bipush), "ISTORE 2")
+    testSingleInsn(a.ultimateConsumersOfValueAt(bipush.getNext, 3), "IRETURN")
+  }
+
+  @Test
+  def checkCast(): Unit = {
+    val List(m) = compileMethods(noOptCompiler)("def f(o: Object) = o.asInstanceOf[String]")
+    val a = new ProdConsAnalyzer(m, "C")
+    assert(findInstr(m, "CHECKCAST java/lang/String").length == 1)
+
+    val List(ret) = findInstr(m, "ARETURN")
+    testSingleInsn(a.initialProducersForInputsOf(ret), "ParameterProducer(1)")
+  }
+
+  @Test
+  def instanceOf(): Unit = {
+    val List(m) = compileMethods(noOptCompiler)("def f(o: Object) = o.isInstanceOf[String]")
+    val a = new ProdConsAnalyzer(m, "C")
+    assert(findInstr(m, "INSTANCEOF java/lang/String").length == 1)
+
+    val List(ret) = findInstr(m, "IRETURN")
+    testSingleInsn(a.initialProducersForInputsOf(ret), "INSTANCEOF")
+  }
+
+  @Test
+  def unInitLocal(): Unit = {
+    val List(m) = compileMethods(noOptCompiler)("def f(b: Boolean) = { if (b) { var a = 0; println(a) }; 1 }")
+    val a = new ProdConsAnalyzer(m, "C")
+
+    val List(store) = findInstr(m, "ISTORE")
+    val List(call)  = findInstr(m, "INVOKEVIRTUAL")
+    val List(ret)   = findInstr(m, "IRETURN")
+
+    testSingleInsn(a.producersForValueAt(store, 2), "UninitializedLocalProducer(2)")
+    testSingleInsn(a.producersForValueAt(call, 2), "ISTORE")
+    testMultiInsns(a.producersForValueAt(ret, 2), List("UninitializedLocalProducer", "ISTORE"))
+  }
+
+  @Test
+  def dupCopying(): Unit = {
+    val List(m) = compileMethods(noOptCompiler)("def f = new Object")
+    val a = new ProdConsAnalyzer(m, "C")
+
+    val List(newO)   = findInstr(m, "NEW")
+    val List(constr) = findInstr(m, "INVOKESPECIAL")
+
+    testSingleInsn(a.producersForInputsOf(constr), "DUP")
+    testSingleInsn(a.initialProducersForInputsOf(constr), "NEW")
+
+    testSingleInsn(a.consumersOfOutputsFrom(newO), "DUP")
+    testMultiInsns(a.ultimateConsumersOfOutputsFrom(newO), List("INVOKESPECIAL", "ARETURN"))
+  }
+
+  @Test
+  def multiProducer(): Unit = {
+    import Opcodes._
+    val m = genMethod(descriptor = "(I)I")(
+      VarOp(ILOAD, 1),
+      VarOp(ILOAD, 1),
+      Op(DUP2),
+      Op(IADD),
+      Op(SWAP),
+      VarOp(ISTORE, 1),
+      Op(IRETURN)
+    )
+    m.maxLocals = 2
+    m.maxStack = 4
+    val a = new ProdConsAnalyzer(m, "C")
+
+    val List(dup2)  = findInstr(m, "DUP2")
+    val List(add)   = findInstr(m, "IADD")
+    val List(swap)  = findInstr(m, "SWAP")
+    val List(store) = findInstr(m, "ISTORE")
+    val List(ret)   = findInstr(m, "IRETURN")
+
+    testMultiInsns(a.producersForInputsOf(dup2), List("ILOAD", "ILOAD"))
+    testSingleInsn(a.consumersOfValueAt(dup2.getNext, 4), "IADD")
+    testSingleInsn(a.consumersOfValueAt(dup2.getNext, 5), "IADD")
+    testMultiInsns(a.consumersOfOutputsFrom(dup2), List("IADD", "SWAP"))
+
+    testSingleInsn(a.ultimateConsumersOfOutputsFrom(dup2), "IADD") // the 'store' is not here: it's a copying instr, so not an ultimate consumer.
+    testMultiInsns(a.consumersOfOutputsFrom(swap), List("IRETURN", "ISTORE"))
+    testSingleInsn(a.ultimateConsumersOfOutputsFrom(swap), "IRETURN") // again, no store
+    testSingleInsn(a.initialProducersForInputsOf(add), "ParameterProducer(1)")
+
+    testMultiInsns(a.producersForInputsOf(swap), List("IADD", "DUP2"))
+    testSingleInsn(a.consumersOfValueAt(swap.getNext, 4), "ISTORE")
+    testSingleInsn(a.consumersOfValueAt(swap.getNext, 3), "IRETURN")
+    testSingleInsn(a.initialProducersForInputsOf(store), "ParameterProducer(1)")
+    testSingleInsn(a.initialProducersForInputsOf(ret), "IADD")
+  }
+
+  @Test
+  def iincProdCons(): Unit = {
+    import Opcodes._
+    val m = genMethod(descriptor = "(I)I")(
+      Incr(IINC, 1, 1), // producer and cosumer of local variable 1
+      VarOp(ILOAD, 1),
+      Op(IRETURN)
+    )
+    m.maxLocals = 2
+    m.maxStack = 1
+    val a = new ProdConsAnalyzer(m, "C")
+
+    val List(inc) = findInstr(m, "IINC")
+    val List(load) = findInstr(m, "ILOAD")
+    val List(ret) = findInstr(m, "IRETURN")
+
+    testSingleInsn(a.producersForInputsOf(inc), "ParameterProducer(1)")
+    testSingleInsn(a.consumersOfOutputsFrom(inc), "ILOAD")
+    testSingleInsn(a.ultimateConsumersOfOutputsFrom(inc), "IRETURN")
+    testSingleInsn(a.consumersOfValueAt(inc, 1), "IINC") // parameter value has a single consumer, the IINC
+    testSingleInsn(a.ultimateConsumersOfValueAt(inc, 1), "IINC")
+
+    testSingleInsn(a.producersForInputsOf(load), "IINC")
+    testSingleInsn(a.producersForValueAt(load, 1), "IINC")
+
+    testSingleInsn(a.initialProducersForInputsOf(ret), "IINC")
+  }
+
+  @Test
+  def copyingInsns(): Unit = {
+    val List(m) = compileMethods(noOptCompiler)("def f = 0l.asInstanceOf[Int]")
+    val a = new ProdConsAnalyzer(m, "C")
+
+    val List(cnst) = findInstr(m, "LCONST_0")
+    val List(l2i)  = findInstr(m, "L2I") // l2i is not a copying instruction
+    val List(ret)  = findInstr(m, "IRETURN")
+
+    testSingleInsn(a.consumersOfOutputsFrom(cnst), "L2I")
+    testSingleInsn(a.ultimateConsumersOfOutputsFrom(cnst), "L2I")
+
+    testSingleInsn(a.producersForInputsOf(l2i), "LCONST_0")
+    testSingleInsn(a.initialProducersForInputsOf(l2i), "LCONST_0")
+
+    testSingleInsn(a.consumersOfOutputsFrom(l2i), "IRETURN")
+    testSingleInsn(a.producersForInputsOf(ret), "L2I")
+  }
+}

--- a/versions.properties
+++ b/versions.properties
@@ -33,7 +33,7 @@ scala-swing.version.number=1.0.2
 akka-actor.version.number=2.3.10
 actors-migration.version.number=1.1.0
 jline.version=2.12.1
-scala-asm.version=5.0.4-scala-1
+scala-asm.version=5.0.4-scala-2
 
 # external modules, used internally (not shipped)
 partest.version.number=1.0.7


### PR DESCRIPTION
When an indylambda closure is allocated and invoked within the same method, rewrite the invocation to the implementation method.
