### PR TITLE
SI-9354 ScalaDoc members added via by-name view

### DIFF
--- a/src/library/scala/collection/immutable/Stream.scala
+++ b/src/library/scala/collection/immutable/Stream.scala
@@ -1180,7 +1180,13 @@ object Stream extends SeqFactory[Stream] {
    *  to streams.
    */
   class ConsWrapper[A](tl: => Stream[A]) {
+    /** Construct a stream consisting of a given first element followed by elements
+     *  from a lazily evaluated Stream.
+     */
     def #::(hd: A): Stream[A] = cons(hd, tl)
+    /** Construct a stream consisting of the concatenation of the given stream and
+     *  a lazily evaluated Stream.
+     */
     def #:::(prefix: Stream[A]): Stream[A] = prefix append tl
   }
 

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryImplicitSupport.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryImplicitSupport.scala
@@ -90,8 +90,12 @@ trait ModelFactoryImplicitSupport {
     else {
       val context: global.analyzer.Context = global.analyzer.rootContext(NoCompilationUnit)
 
-      val results = global.analyzer.allViewsFrom(sym.tpe_*, context, sym.typeParams)
+      val results = global.analyzer.allViewsFrom(sym.tpe_*, context, sym.typeParams) ++
+        global.analyzer.allViewsFrom(byNameType(sym.tpe_*), context, sym.typeParams)
       var conversions = results.flatMap(result => makeImplicitConversion(sym, result._1, result._2, context, inTpl))
+      //debug(results.mkString("All views\n  ", "\n  ", "\n"))
+      //debug(conversions.mkString("Conversions\n  ", "\n  ", "\n"))
+
       // also keep empty conversions, so they appear in diagrams
       // conversions = conversions.filter(!_.members.isEmpty)
 
@@ -193,7 +197,7 @@ trait ModelFactoryImplicitSupport {
         List(new ImplicitConversionImpl(sym, result.tree.symbol, toType, constraints, inTpl))
       } catch {
         case i: ImplicitNotFound =>
-          //println("  Eliminating: " + toType)
+          //debug(s"  Eliminating: $toType")
           Nil
       }
     }


### PR DESCRIPTION
Eligible views were looked up by exact from type without
including the by-name dodge.

By-name views are now included without consideration whether
ScalaDoc processes possible duplicates correctly.

Review by @SethTisue 
