### PR TITLE
SI-1931 Hide Predef.any2stringadd in REPL

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -888,7 +888,7 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
     /** Code to import bound names from previous lines - accessPath is code to
       * append to objectName to access anything bound by request.
       */
-    lazy val ComputedImports(importsPreamble, importsTrailer, accessPath) =
+    lazy val ComputedImports(headerPreamble, importsPreamble, importsTrailer, accessPath) =
       exitingTyper(importsCode(referencedNames.toSet, ObjectSourceCode, definesClass))
 
     /** the line of code to compute */
@@ -908,6 +908,7 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
         else List("def %s = %s".format("$line", tquoted(originalLine)), "def %s = Nil".format("$trees"))
       }
       def preamble = s"""
+        |$headerPreamble
         |${preambleHeader format lineRep.readName}
         |${envLines mkString ("  ", ";\n  ", ";\n")}
         |$importsPreamble

--- a/src/repl/scala/tools/nsc/interpreter/Imports.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Imports.scala
@@ -70,7 +70,10 @@ trait Imports {
 
   /** Compute imports that allow definitions from previous
    *  requests to be visible in a new request.  Returns
-   *  three pieces of related code:
+   *  three or four pieces of related code:
+   *
+   *  0. Header code fragment that should go at the beginning
+   *  of the compilation unit, specifically, import Predef.
    *
    *  1. An initial code fragment that should go before
    *  the code of the new request.
@@ -91,30 +94,34 @@ trait Imports {
    * (3) It imports multiple same-named implicits, but only the
    * last one imported is actually usable.
    */
-  case class ComputedImports(prepend: String, append: String, access: String)
+  case class ComputedImports(header: String, prepend: String, append: String, access: String)
   protected def importsCode(wanted: Set[Name], wrapper: Request#Wrapper, definesClass: Boolean): ComputedImports = {
+    val header, code, trailingBraces, accessPath = new StringBuilder
+    val currentImps = mutable.HashSet[Name]()
+    var predefEscapes = false      // only emit predef import header if name not resolved in history, loosely
+
     /** Narrow down the list of requests from which imports
      *  should be taken.  Removes requests which cannot contribute
      *  useful imports for the specified set of wanted names.
      */
-    case class ReqAndHandler(req: Request, handler: MemberHandler) { }
+    case class ReqAndHandler(req: Request, handler: MemberHandler)
 
     def reqsToUse: List[ReqAndHandler] = {
       /** Loop through a list of MemberHandlers and select which ones to keep.
-        * 'wanted' is the set of names that need to be imported.
+       *  'wanted' is the set of names that need to be imported.
        */
       def select(reqs: List[ReqAndHandler], wanted: Set[Name]): List[ReqAndHandler] = {
         // Single symbol imports might be implicits! See bug #1752.  Rather than
         // try to finesse this, we will mimic all imports for now.
         def keepHandler(handler: MemberHandler) = handler match {
-        /* While defining classes in class based mode - implicits are not needed. */
+          // While defining classes in class based mode - implicits are not needed.
           case h: ImportHandler if isClassBased && definesClass => h.importedNames.exists(x => wanted.contains(x))
           case _: ImportHandler => true
           case x                => x.definesImplicit || (x.definedNames exists wanted)
         }
 
         reqs match {
-          case Nil                                    => Nil
+          case Nil                                    => predefEscapes = wanted contains PredefModule.name ; Nil
           case rh :: rest if !keepHandler(rh.handler) => select(rest, wanted)
           case rh :: rest                             =>
             import rh.handler._
@@ -126,9 +133,6 @@ trait Imports {
       /** Flatten the handlers out and pair each with the original request */
       select(allReqAndHandlers reverseMap { case (r, h) => ReqAndHandler(r, h) }, wanted).reverse
     }
-
-    val code, trailingBraces, accessPath = new StringBuilder
-    val currentImps = mutable.HashSet[Name]()
 
     // add code for a new object to hold some imports
     def addWrapper() {
@@ -146,6 +150,9 @@ trait Imports {
       try op finally addWrapper()
     }
 
+    // imports from Predef are relocated to the template header to allow hiding.
+    def checkHeader(h: ImportHandler) = h.referencedNames contains PredefModule.name
+
     // loop through previous requests, adding imports for each one
     wrapBeforeAndAfter {
       // Reusing a single temporary value when import from a line with multiple definitions.
@@ -153,6 +160,9 @@ trait Imports {
       for (ReqAndHandler(req, handler) <- reqsToUse) {
         val objName = req.lineRep.readPathInstance
         handler match {
+          case h: ImportHandler if checkHeader(h) =>
+            header.clear()
+            header append f"${h.member}%n"
           // If the user entered an import, then just use it; add an import wrapping
           // level if the import might conflict with some other import
           case x: ImportHandler if x.importsWildcard =>
@@ -194,7 +204,8 @@ trait Imports {
       }
     }
 
-    ComputedImports(code.toString, trailingBraces.toString, accessPath.toString)
+    val computedHeader = if (predefEscapes) header.toString else ""
+    ComputedImports(computedHeader, code.toString, trailingBraces.toString, accessPath.toString)
   }
 
   private def allReqAndHandlers =

--- a/test/files/jvm/interpreter.check
+++ b/test/files/jvm/interpreter.check
@@ -30,7 +30,7 @@ scala> val four: anotherint = 4
 four: anotherint = 4
 
 scala> val bogus: anotherint = "hello"
-<console>:11: error: type mismatch;
+<console>:12: error: type mismatch;
  found   : String("hello")
  required: anotherint
     (which expands to)  Int
@@ -353,7 +353,7 @@ defined class Term
 scala> def f(e: Exp) = e match {  // non-exhaustive warning here
   case _:Fact => 3
 }
-<console>:21: warning: match may not be exhaustive.
+<console>:22: warning: match may not be exhaustive.
 It would fail on the following inputs: Exp(), Term()
        def f(e: Exp) = e match {  // non-exhaustive warning here
                        ^
@@ -363,6 +363,6 @@ scala> :quit
 plusOne: (x: Int)Int
 res0: Int = 6
 res0: String = after reset
-<console>:11: error: not found: value plusOne
+<console>:12: error: not found: value plusOne
        plusOne(5) // should be undefined now
        ^

--- a/test/files/run/constrained-types.check
+++ b/test/files/run/constrained-types.check
@@ -133,16 +133,16 @@ y: String = hello
 scala> 
 
 scala> val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
-<console>:11: error: not found: value e
+<console>:12: error: not found: value e
        val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
                               ^
-<console>:11: error: not found: value f
+<console>:12: error: not found: value f
        val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
                                 ^
-<console>:11: error: not found: value g
+<console>:12: error: not found: value g
        val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
                                   ^
-<console>:11: error: not found: value h
+<console>:12: error: not found: value h
        val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
                                     ^
 

--- a/test/files/run/kind-repl-command.check
+++ b/test/files/run/kind-repl-command.check
@@ -19,7 +19,7 @@ scala> :k new { def empty = false }
 AnyRef{def empty: Boolean}'s kind is A
 
 scala> :k Nonexisting
-<console>:11: error: not found: value Nonexisting
+<console>:12: error: not found: value Nonexisting
        Nonexisting
        ^
 

--- a/test/files/run/reify-repl-fail-gracefully.check
+++ b/test/files/run/reify-repl-fail-gracefully.check
@@ -8,7 +8,7 @@ import scala.reflect.runtime.universe._
 scala> 
 
 scala> reify
-<console>:15: error: too few argument lists for macro invocation
+<console>:16: error: too few argument lists for macro invocation
        reify
        ^
 

--- a/test/files/run/reify_newimpl_22.check
+++ b/test/files/run/reify_newimpl_22.check
@@ -15,7 +15,7 @@ scala> {
   }
   println(code.eval)
 }
-<console>:18: free term: Ident(TermName("x")) defined by res0  in <console>:17:14
+<console>:19: free term: Ident(TermName("x")) defined by res0  in <console>:18:14
          val code = reify {
                           ^
 2

--- a/test/files/run/reify_newimpl_23.check
+++ b/test/files/run/reify_newimpl_23.check
@@ -14,7 +14,7 @@ scala> def foo[T]{
   }
   println(code.eval)
 }
-<console>:16: free type: Ident(TypeName("T")) defined by foo in <console>:15:16
+<console>:17: free type: Ident(TypeName("T")) defined by foo in <console>:16:16
          val code = reify {
                           ^
 foo: [T]=> Unit

--- a/test/files/run/reify_newimpl_25.check
+++ b/test/files/run/reify_newimpl_25.check
@@ -5,7 +5,7 @@ scala> {
   val tt = implicitly[TypeTag[x.type]]
   println(tt)
 }
-<console>:14: free term: Ident(TermName("x")) defined by res0  in <console>:13:14
+<console>:15: free term: Ident(TermName("x")) defined by res0  in <console>:14:14
          val tt = implicitly[TypeTag[x.type]]
                             ^
 TypeTag[x.type]

--- a/test/files/run/reify_newimpl_26.check
+++ b/test/files/run/reify_newimpl_26.check
@@ -4,7 +4,7 @@ scala> def foo[T]{
   val tt = implicitly[WeakTypeTag[List[T]]]
   println(tt)
 }
-<console>:12: free type: Ident(TypeName("T")) defined by foo in <console>:10:16
+<console>:13: free type: Ident(TypeName("T")) defined by foo in <console>:11:16
          val tt = implicitly[WeakTypeTag[List[T]]]
                             ^
 foo: [T]=> Unit

--- a/test/files/run/repl-bare-expr.check
+++ b/test/files/run/repl-bare-expr.check
@@ -1,12 +1,12 @@
 
 scala> 2 ; 3
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        2 ;;
        ^
 res0: Int = 3
 
 scala> { 2 ; 3 }
-<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:12: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        { 2 ; 3 }
          ^
 res1: Int = 3
@@ -15,16 +15,16 @@ scala> 5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Mooo
   1 +
   2 +
   3 } ; bippy+88+11
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
        ^
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
            ^
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
                                   ^
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
                                                                                          ^
 defined object Cow

--- a/test/files/run/repl-parens.check
+++ b/test/files/run/repl-parens.check
@@ -18,10 +18,10 @@ scala>   (  (2 + 2 )  )
 res5: Int = 4
 
 scala> 5 ;   (  (2 + 2 )  ) ; ((5))
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        5 ;   (  (2 + 2 )  ) ;;
        ^
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        5 ;   (  (2 + 2 )  ) ;;
                    ^
 res6: Int = 5
@@ -38,16 +38,16 @@ res9: String = 4423
 scala> 
 
 scala> 55 ; ((2 + 2)) ; (1, 2, 3)
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        55 ; ((2 + 2)) ;;
        ^
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        55 ; ((2 + 2)) ;;
                 ^
 res10: (Int, Int, Int) = (1,2,3)
 
 scala> 55 ; (x: Int) => x + 1 ; () => ((5))
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        55 ; (x: Int) => x + 1 ;;
        ^
 res11: () => Int = <function0>
@@ -58,7 +58,7 @@ scala> () => 5
 res12: () => Int = <function0>
 
 scala> 55 ; () => 5
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        55 ;;
        ^
 res13: () => Int = <function0>

--- a/test/files/run/repl-paste-2.check
+++ b/test/files/run/repl-paste-2.check
@@ -42,7 +42,7 @@ scala> res5 + res6
 res1: Int = 690
 
 scala> val x = dingus
-<console>:10: error: not found: value dingus
+<console>:11: error: not found: value dingus
        val x = dingus
                ^
 

--- a/test/files/run/repl-reset.check
+++ b/test/files/run/repl-reset.check
@@ -28,13 +28,13 @@ Forgetting all expression results and named terms: $intp, BippyBungus, x1, x2, x
 Forgetting defined types: BippyBungus
 
 scala> x1 + x2 + x3
-<console>:11: error: not found: value x1
+<console>:12: error: not found: value x1
        x1 + x2 + x3
        ^
-<console>:11: error: not found: value x2
+<console>:12: error: not found: value x2
        x1 + x2 + x3
             ^
-<console>:11: error: not found: value x3
+<console>:12: error: not found: value x3
        x1 + x2 + x3
                  ^
 
@@ -42,7 +42,7 @@ scala> val x1 = 4
 x1: Int = 4
 
 scala> new BippyBungus
-<console>:11: error: not found: type BippyBungus
+<console>:12: error: not found: type BippyBungus
        new BippyBungus
            ^
 

--- a/test/files/run/repl-trim-stack-trace.scala
+++ b/test/files/run/repl-trim-stack-trace.scala
@@ -12,7 +12,7 @@ f: Nothing
 
 scala> f
 java.lang.Exception: Uh-oh
-  at .f(<console>:10)
+  at .f(<console>:11)
   ... 69 elided
 
 scala> def f = throw new Exception("")
@@ -20,7 +20,7 @@ f: Nothing
 
 scala> f
 java.lang.Exception:
-  at .f(<console>:10)
+  at .f(<console>:11)
   ... 69 elided
 
 scala> def f = throw new Exception
@@ -28,7 +28,7 @@ f: Nothing
 
 scala> f
 java.lang.Exception
-  at .f(<console>:10)
+  at .f(<console>:11)
   ... 69 elided
 
 scala> :quit"""

--- a/test/files/run/t1931.scala
+++ b/test/files/run/t1931.scala
@@ -1,0 +1,43 @@
+
+import scala.tools.partest.SessionTest
+
+object Test extends SessionTest {
+
+  def session =
+"""
+scala> val x: Any = 42
+x: Any = 42
+
+scala> x + " works"
+res0: String = 42 works
+
+scala> import Predef.{ any2stringadd => _, _ }
+import Predef.{any2stringadd=>_, _}
+
+scala> x + " works"
+<console>:14: error: value + is not a member of Any
+       x + " works"
+         ^
+
+scala> import Predef._
+import Predef._
+
+scala> x + " works"
+res2: String = 42 works
+
+scala> object Predef { def f = 42 }
+defined object Predef
+
+scala> import Predef._
+import Predef._
+
+scala> f
+<console>:14: error: not found: value f
+       f
+       ^
+
+scala> Predef.f
+res4: Int = 42
+
+scala> :quit"""
+}

--- a/test/files/run/t4542.check
+++ b/test/files/run/t4542.check
@@ -5,7 +5,7 @@ scala> @deprecated("foooo", "ReplTest version 1.0-FINAL") class Foo() {
 defined class Foo
 
 scala> val f = new Foo
-<console>:11: warning: class Foo is deprecated: foooo
+<console>:12: warning: class Foo is deprecated: foooo
        val f = new Foo
                    ^
 f: Foo = Bippy

--- a/test/files/run/t4594-repl-settings.scala
+++ b/test/files/run/t4594-repl-settings.scala
@@ -15,7 +15,7 @@ object Test extends SessionTest {
    |scala> :settings -deprecation
    |
    |scala> def b = depp
-   |<console>:11: warning: method depp is deprecated: Please don't do that.
+   |<console>:12: warning: method depp is deprecated: Please don't do that.
    |       def b = depp
    |               ^
    |b: String

--- a/test/files/run/t5655.check
+++ b/test/files/run/t5655.check
@@ -6,7 +6,7 @@ scala> import x._
 import x._
 
 scala> x
-<console>:15: error: reference to x is ambiguous;
+<console>:16: error: reference to x is ambiguous;
 it is imported twice in the same scope by
 import x._
 and import x
@@ -14,7 +14,7 @@ and import x
        ^
 
 scala> x
-<console>:15: error: reference to x is ambiguous;
+<console>:16: error: reference to x is ambiguous;
 it is imported twice in the same scope by
 import x._
 and import x

--- a/test/files/run/t7319.check
+++ b/test/files/run/t7319.check
@@ -15,21 +15,21 @@ warning: there was one feature warning; re-run with -feature for details
 convert: [F[X <: F[X]]](builder: F[_ <: F[_]])Int
 
 scala> convert(Some[Int](0))
-<console>:15: error: no type parameters for method convert: (builder: F[_ <: F[_]])Int exist so that it can be applied to arguments (Some[Int])
+<console>:16: error: no type parameters for method convert: (builder: F[_ <: F[_]])Int exist so that it can be applied to arguments (Some[Int])
  --- because ---
 argument expression's type is not compatible with formal parameter type;
  found   : Some[Int]
  required: ?F[_$1] forSome { type _$1 <: ?F[_$2] forSome { type _$2 } }
        convert(Some[Int](0))
        ^
-<console>:15: error: type mismatch;
+<console>:16: error: type mismatch;
  found   : Some[Int]
  required: F[_ <: F[_]]
        convert(Some[Int](0))
                         ^
 
 scala> Range(1,2).toArray: Seq[_]
-<console>:14: error: polymorphic expression cannot be instantiated to expected type;
+<console>:15: error: polymorphic expression cannot be instantiated to expected type;
  found   : [B >: Int]Array[B]
  required: Seq[_]
        Range(1,2).toArray: Seq[_]

--- a/test/files/run/t7747-repl.check
+++ b/test/files/run/t7747-repl.check
@@ -15,13 +15,13 @@ scala> val z = x * y
 z: Int = 156
 
 scala> 2 ; 3
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        2 ;;
        ^
 res0: Int = 3
 
 scala> { 2 ; 3 }
-<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:12: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        { 2 ; 3 }
          ^
 res1: Int = 3
@@ -30,16 +30,16 @@ scala> 5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Mooo
   1 +
   2 +
   3 } ; bippy+88+11
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
        ^
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
            ^
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
                                   ^
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
                                                                                          ^
 defined object Cow
@@ -81,10 +81,10 @@ scala>   (  (2 + 2 )  )
 res10: Int = 4
 
 scala> 5 ;   (  (2 + 2 )  ) ; ((5))
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        5 ;   (  (2 + 2 )  ) ;;
        ^
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        5 ;   (  (2 + 2 )  ) ;;
                    ^
 res11: Int = 5
@@ -101,16 +101,16 @@ res14: String = 4423
 scala> 
 
 scala> 55 ; ((2 + 2)) ; (1, 2, 3)
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        55 ; ((2 + 2)) ;;
        ^
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        55 ; ((2 + 2)) ;;
                 ^
 res15: (Int, Int, Int) = (1,2,3)
 
 scala> 55 ; (x: Int) => x + 1 ; () => ((5))
-<console>:12: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:13: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        55 ; (x: Int) => x + 1 ;;
        ^
 res16: () => Int = <function0>
@@ -121,7 +121,7 @@ scala> () => 5
 res17: () => Int = <function0>
 
 scala> 55 ; () => 5
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        55 ;;
        ^
 res18: () => Int = <function0>
@@ -209,13 +209,13 @@ Forgetting all expression results and named terms: $intp, BippyBungus, Bovine, C
 Forgetting defined types: BippyBungus, Moo, Ruminant
 
 scala> x1 + x2 + x3
-<console>:11: error: not found: value x1
+<console>:12: error: not found: value x1
        x1 + x2 + x3
        ^
-<console>:11: error: not found: value x2
+<console>:12: error: not found: value x2
        x1 + x2 + x3
             ^
-<console>:11: error: not found: value x3
+<console>:12: error: not found: value x3
        x1 + x2 + x3
                  ^
 
@@ -223,7 +223,7 @@ scala> val x1 = 4
 x1: Int = 4
 
 scala> new BippyBungus
-<console>:11: error: not found: type BippyBungus
+<console>:12: error: not found: type BippyBungus
        new BippyBungus
            ^
 

--- a/test/files/run/t9170.scala
+++ b/test/files/run/t9170.scala
@@ -8,17 +8,17 @@ object Test extends SessionTest {
   def session =
 """
 scala> object Y { def f[A](a: => A) = 1 ; def f[A](a: => Either[Exception, A]) = 2 }
-<console>:10: error: double definition:
-def f[A](a: => A): Int at line 10 and
-def f[A](a: => Either[Exception,A]): Int at line 10
+<console>:11: error: double definition:
+def f[A](a: => A): Int at line 11 and
+def f[A](a: => Either[Exception,A]): Int at line 11
 have same type after erasure: (a: Function0)Int
        object Y { def f[A](a: => A) = 1 ; def f[A](a: => Either[Exception, A]) = 2 }
                                               ^
 
 scala> object Y { def f[A](a: => A) = 1 ; def f[A](a: => Either[Exception, A]) = 2 }
-<console>:10: error: double definition:
-def f[A](a: => A): Int at line 10 and
-def f[A](a: => Either[Exception,A]): Int at line 10
+<console>:11: error: double definition:
+def f[A](a: => A): Int at line 11 and
+def f[A](a: => Either[Exception,A]): Int at line 11
 have same type after erasure: (a: Function0)Int
        object Y { def f[A](a: => A) = 1 ; def f[A](a: => Either[Exception, A]) = 2 }
                                               ^
@@ -27,9 +27,9 @@ scala> object Y {
      |   def f[A](a: =>  A) = 1
      |   def f[A](a: => Either[Exception, A]) = 2
      | }
-<console>:12: error: double definition:
-def f[A](a: => A): Int at line 11 and
-def f[A](a: => Either[Exception,A]): Int at line 12
+<console>:13: error: double definition:
+def f[A](a: => A): Int at line 12 and
+def f[A](a: => Either[Exception,A]): Int at line 13
 have same type after erasure: (a: Function0)Int
          def f[A](a: => Either[Exception, A]) = 2
              ^
@@ -44,9 +44,9 @@ object Y {
 
 // Exiting paste mode, now interpreting.
 
-<console>:12: error: double definition:
-def f[A](a: => A): Int at line 11 and
-def f[A](a: => Either[Exception,A]): Int at line 12
+<console>:13: error: double definition:
+def f[A](a: => A): Int at line 12 and
+def f[A](a: => Either[Exception,A]): Int at line 13
 have same type after erasure: (a: Function0)Int
          def f[A](a: => Either[Exception, A]) = 2
              ^

--- a/test/files/run/t9206.scala
+++ b/test/files/run/t9206.scala
@@ -7,14 +7,14 @@ object Test extends SessionTest {
   def session =
     s"""|
         |scala> val i: Int = "foo"
-        |<console>:10: error: type mismatch;
+        |<console>:11: error: type mismatch;
         | found   : String("foo")
         | required: Int
         |       val i: Int = "foo"
         |                    ^
         |
         |scala> { val j = 42 ; val i: Int = "foo" + j }
-        |<console>:11: error: type mismatch;
+        |<console>:12: error: type mismatch;
         | found   : String
         | required: Int
         |       { val j = 42 ; val i: Int = "foo" + j }

--- a/test/files/run/xMigration.check
+++ b/test/files/run/xMigration.check
@@ -10,7 +10,7 @@ res1: Iterable[String] = MapLike(eis)
 scala> :setting -Xmigration:any
 
 scala> Map(1 -> "eis").values    // warn
-<console>:11: warning: method values in trait MapLike has changed semantics in version 2.8.0:
+<console>:12: warning: method values in trait MapLike has changed semantics in version 2.8.0:
 `values` returns `Iterable[B]` rather than `Iterator[B]`.
        Map(1 -> "eis").values    // warn
                        ^
@@ -24,7 +24,7 @@ res3: Iterable[String] = MapLike(eis)
 scala> :setting -Xmigration:2.7
 
 scala> Map(1 -> "eis").values    // warn
-<console>:11: warning: method values in trait MapLike has changed semantics in version 2.8.0:
+<console>:12: warning: method values in trait MapLike has changed semantics in version 2.8.0:
 `values` returns `Iterable[B]` rather than `Iterator[B]`.
        Map(1 -> "eis").values    // warn
                        ^
@@ -38,7 +38,7 @@ res5: Iterable[String] = MapLike(eis)
 scala> :setting -Xmigration      // same as :any
 
 scala> Map(1 -> "eis").values    // warn
-<console>:11: warning: method values in trait MapLike has changed semantics in version 2.8.0:
+<console>:12: warning: method values in trait MapLike has changed semantics in version 2.8.0:
 `values` returns `Iterable[B]` rather than `Iterator[B]`.
        Map(1 -> "eis").values    // warn
                        ^


### PR DESCRIPTION
User imports that reference Predef are moved to the top of
the wrapping template so that they can hide implicits defined
in Predef.

Only the last import from Predef gets the special treatment.

```
scala> val x: Any = 42
x: Any = 42

scala> x + " works"
res0: String = 42 works

scala> import Predef.{ any2stringadd => _, _ }
import Predef.{any2stringadd=>_, _}

scala> x + " works"
<console>:14: error: value + is not a member of Any
       x + " works"
         ^

scala> import Predef._
import Predef._

scala> x + " works"
res2: String = 42 works

```
