### PR TITLE
Better error message when method needs to be applied as partial function

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -636,7 +636,7 @@ trait ContextErrors {
           if (meth.isMacro) MacroTooFewArgumentListsMessage
           else "missing arguments for " + meth.fullLocationString + (
             if (meth.isConstructor) ""
-            else ";\nfollow this method with `_' if you want to treat it as a partially applied function"
+            else s";\nIf you want to treat it as a partially applied function write `${meth.name} _' instead, i.e. follow the method by an underscore."
           )
         issueNormalTypeError(tree, message)
         setError(tree)

--- a/test/files/neg/eta-expansion-for-method-expected.check
+++ b/test/files/neg/eta-expansion-for-method-expected.check
@@ -1,0 +1,5 @@
+eta-expansion-for-method-expected.scala:4: error: missing arguments for method meth in object Test;
+If you want to treat it as a partially applied function write `meth _' instead, i.e. follow the method by an underscore.
+  val func = meth
+             ^
+one error found

--- a/test/files/neg/eta-expansion-for-method-expected.scala
+++ b/test/files/neg/eta-expansion-for-method-expected.scala
@@ -1,0 +1,5 @@
+object Test {
+  def meth(i: Int) = i
+
+  val func = meth
+}

--- a/test/files/neg/macro-invalidshape.check
+++ b/test/files/neg/macro-invalidshape.check
@@ -9,7 +9,7 @@ macro [<macro bundle>].<method name>[[<type args>]]
   def foo2(x: Any) = macro Impls.foo(null)(null)
                                  ^
 Macros_Test_2.scala:4: error: missing arguments for method foo in object Impls;
-follow this method with `_' if you want to treat it as a partially applied function
+If you want to treat it as a partially applied function write `foo _' instead, i.e. follow the method by an underscore.
   def foo3(x: Any) = macro {2; Impls.foo}
                                      ^
 Macros_Test_2.scala:7: error: macro implementation reference has wrong shape. required:


### PR DESCRIPTION
The idea for a better error message occurred to me when I read the
following question on StackOverflow:

```
http://stackoverflow.com/questions/30846760
```

In short, the user did this:

```
scala> def yyy(c: Char) = {
     |     c.toUpper
     | }
    yyy: (c: Char)Char

scala> yyy('a')
res5: Char = A

scala> yyy
<console>:9: error: missing arguments for method yyy;
follow this method with `_' if you want to treat it as a partially
applied function
          yyy
          ^

scala> yyy_
<console>:8: error: not found: value yyy_
          yyy_
          ^
```

The current error message is clearly misleading, therefore a better one
is provided.
