### PR TITLE
SI-9356 more careful assertion in back-end

### DIFF
--- a/test/files/pos/t9356/Foo_2.scala
+++ b/test/files/pos/t9356/Foo_2.scala
@@ -1,0 +1,6 @@
+class C
+
+trait Foo {
+  @annot.MyAnnotation(cls = classOf[C])
+  def function: Any = ???
+}

--- a/test/files/pos/t9356/MyAnnotation.java
+++ b/test/files/pos/t9356/MyAnnotation.java
@@ -1,0 +1,12 @@
+package annot;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MyAnnotation {
+    Class<?> cls();
+}

--- a/test/files/pos/t9356/Test_3.scala
+++ b/test/files/pos/t9356/Test_3.scala
@@ -1,0 +1,3 @@
+class Foo1 extends Foo
+
+class Foo2 extends Foo


### PR DESCRIPTION
Calling `exists` on a `Symbol` triggers unpickling,
which failed for reasons I did not investigate.

Replaced `sym.exists` by `sym != NoSymbol`, which is good enough here.
Also replaced assertion by a `devWarning`, since the
logic seems too ad-hoc to actually crash the compiler when it's invalidated.

Partially reverts b45a91fe22. See also #1532.
