### PR TITLE
SI-9348 Fix missing last element in exclusive floating point ranges

### DIFF
--- a/src/library/scala/math/Numeric.scala
+++ b/src/library/scala/math/Numeric.scala
@@ -134,7 +134,7 @@ object Numeric {
     def div(x: Float, y: Float): Float = x / y
   }
   trait FloatAsIfIntegral extends FloatIsConflicted with Integral[Float] {
-    def quot(x: Float, y: Float): Float = (BigDecimal(x) / BigDecimal(y)).floatValue
+    def quot(x: Float, y: Float): Float = (BigDecimal(x) quot BigDecimal(y)).floatValue
     def rem(x: Float, y: Float): Float = (BigDecimal(x) remainder BigDecimal(y)).floatValue
   }
   implicit object FloatIsFractional extends FloatIsFractional with Ordering.FloatOrdering
@@ -158,7 +158,7 @@ object Numeric {
     def div(x: Double, y: Double): Double = x / y
   }
   trait DoubleAsIfIntegral extends DoubleIsConflicted with Integral[Double] {
-    def quot(x: Double, y: Double): Double = (BigDecimal(x) / BigDecimal(y)).doubleValue
+    def quot(x: Double, y: Double): Double = (BigDecimal(x) quot BigDecimal(y)).doubleValue
     def rem(x: Double, y: Double): Double = (BigDecimal(x) remainder BigDecimal(y)).doubleValue
   }
 
@@ -178,7 +178,7 @@ object Numeric {
     def div(x: BigDecimal, y: BigDecimal): BigDecimal = x / y
   }
   trait BigDecimalAsIfIntegral extends BigDecimalIsConflicted with Integral[BigDecimal] {
-    def quot(x: BigDecimal, y: BigDecimal): BigDecimal = x / y
+    def quot(x: BigDecimal, y: BigDecimal): BigDecimal = x quot y
     def rem(x: BigDecimal, y: BigDecimal): BigDecimal = x remainder y
   }
 

--- a/test/files/run/range.scala
+++ b/test/files/run/range.scala
@@ -36,16 +36,19 @@ object Test {
 
     def gr1 = NumericRange(x, x, x)
     def gr2 = NumericRange.inclusive(x, x, x)
-    def gr3 = NumericRange(x, x * fromInt(10), x)
-    def gr4 = NumericRange.inclusive(x, x * fromInt(10), x)
-    def gr5 = gr3.toList ::: negated.gr3.toList
+    def gr3 = NumericRange(x, x * fromInt(4), x * fromInt(2))  // SI-9348
+    def gr4 = NumericRange(x, x * fromInt(-2), x * fromInt(-2))
+    def gr5 = NumericRange(x, x * fromInt(10), x)
+    def gr6 = NumericRange.inclusive(x, x * fromInt(10), x)
+    def gr7 = gr3.toList ::: negated.gr3.toList
 
     def check = {
       assert(gr1.isEmpty && !gr2.isEmpty)
-      assert(gr3.size == 9 && gr4.size == 10)
-      assert(gr5.sum == num.zero, gr5.toString)
-      assert(!(gr3 contains (x * fromInt(10))))
-      assert((gr4 contains (x * fromInt(10))))
+      assert(gr3.size == 2 && gr4.size == 2)
+      assert(gr5.size == 9 && gr6.size == 10)
+      assert(gr7.sum == num.zero, gr7.toString)
+      assert(!(gr5 contains (x * fromInt(10))))
+      assert(gr6 contains (x * fromInt(10)))
     }
   }
 
@@ -55,6 +58,7 @@ object Test {
 
     val _grs = List[GR[_]](
       GR(BigDecimal(5.0)),
+      GR(BigDecimal(0.25)),  // SI-9348
       GR(BigInt(5)),
       GR(5L),
       GR(5.0d),

--- a/test/junit/scala/collection/immutable/RangeConsistencyTest.scala
+++ b/test/junit/scala/collection/immutable/RangeConsistencyTest.scala
@@ -137,4 +137,15 @@ class RangeConsistencyTest {
     assert( (-3 to Int.MaxValue).dropWhile(_ <= 0).length == Int.MaxValue )
     assert( (-3 to Int.MaxValue).span(_ <= 0) match { case (a,b) => a.length == 4 && b.length == Int.MaxValue } )
   }
+  
+  @Test
+  def testSI9348() {
+    // Test exclusive range with (end-start) != 0 (mod step)
+    assert( (0.0f until 0.4f by 0.25f) sameElements List(0.0f, 0.25f) )
+    assert( (1.0 until 2.2 by 0.5) sameElements List(1.0, 1.5, 2.0) )
+    
+    def bd(d: Double) = BigDecimal(d)
+    val bdRange = bd(-10.0) until bd(0.0) by bd(4.5)
+    assert( bdRange sameElements List(bd(-10.0), bd(-5.5), bd(-1.0)) )
+  }
 }

--- a/test/junit/scala/math/NumericTest.scala
+++ b/test/junit/scala/math/NumericTest.scala
@@ -5,6 +5,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
+
 @RunWith(classOf[JUnit4])
 class NumericTest {
 
@@ -14,5 +15,28 @@ class NumericTest {
     assertTrue(-0.0.abs equals 0.0)
     assertTrue(-0.0f.abs equals 0.0f)
   }
-}
+  
+  /* Test for SI-9348 */
+  @Test
+  def testFloatAsIfIntegral {
+    val num = scala.math.Numeric.FloatAsIfIntegral
+    assertTrue(num.quot(1.0f, 0.5f) equals 2.0f)
+    assertTrue(num.quot(1.0f, 0.3f) equals 3.0f)
+  }
+
+  /* Test for SI-9348 */
+  @Test
+  def testDoubleAsIfIntegral {
+    val num = scala.math.Numeric.DoubleAsIfIntegral
+    assertTrue(num.quot(1.0, 0.25) equals 4.0)
+    assertTrue(num.quot(0.5, 0.15) equals 3.0)
+  }
+
+  /* Test for SI-9348 */
+  @Test
+  def testBigDecimalAsIfIntegral {
+    val num = scala.math.Numeric.BigDecimalAsIfIntegral
+    assertTrue(num.quot(BigDecimal(2.5), BigDecimal(0.5)) equals BigDecimal(5.0))
+    assertTrue(num.quot(BigDecimal(5.0), BigDecimal(2.0)) equals BigDecimal(2.0))
+  }}
 


### PR DESCRIPTION
Fix exclusive floating point ranges to contain also the last element
when the end-start difference is not an integer multiple of step.

Review by @axel22

(Note: the hash is different here since I removed one unused import that got in. Otherwise identical cherry-pick.)
