### PR TITLE
Traits mistakenly set as 'Case Classes' subsection

### DIFF
--- a/spec/05-classes-and-objects.md
+++ b/spec/05-classes-and-objects.md
@@ -966,7 +966,7 @@ This form of extensibility can be excluded by declaring the base class
 directly extend `Expr` must be in the same source file as
 `Expr`.
 
-### Traits
+## Traits
 
 ```ebnf
 TmplDef          ::=  `trait' TraitDef


### PR DESCRIPTION
Instead of being its own section, a minor formatting issue causes 'Traits' to be rendered and numbered as a subsection of the section 'Case Classes'.

This patch changes the numbering on both 'Traits' and 'Object Definitions' sections.
