### PR TITLE
SI-5294 Use bounds of abstract prefix in asSeenFrom

### DIFF
--- a/src/reflect/scala/reflect/internal/BaseTypeSeqs.scala
+++ b/src/reflect/scala/reflect/internal/BaseTypeSeqs.scala
@@ -58,7 +58,7 @@ trait BaseTypeSeqs {
         pending.clear()
         throw CyclicInheritance
       } else
-        elems(i) match {
+        elems(i).underlying match {
           case rtp @ RefinedType(variants, decls) =>
             // can't assert decls.isEmpty; see t0764
             //if (!decls.isEmpty) abort("computing closure of "+this+":"+this.isInstanceOf[RefinedType]+"/"+closureCache(j))
@@ -88,7 +88,7 @@ trait BaseTypeSeqs {
      *  no evaluation needed.
      */
     def typeSymbol(i: Int): Symbol = {
-      elems(i) match {
+      elems(i).underlying match {
         case RefinedType(v :: vs, _) => v.typeSymbol
         case tp => tp.typeSymbol
       }

--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -610,11 +610,8 @@ private[internal] trait TypeMaps {
     }
 
     // Does the candidate symbol match the given prefix and class?
-    // Since pre may be something like ThisType(A) where trait A { self: B => },
-    // we have to test the typeSymbol of the widened type, not pre.typeSymbol, or
-    // B will not be considered.
     private def matchesPrefixAndClass(pre: Type, clazz: Symbol)(candidate: Symbol) =
-      (clazz == candidate) && (pre.widen.typeSymbol isSubClass clazz)
+      (clazz == candidate) && (pre.baseTypeIndex(clazz) != -1)
 
     // Whether the annotation tree currently being mapped over has had a This(_) node rewritten.
     private[this] var wroteAnnotation = false

--- a/test/files/pos/t5294b.scala
+++ b/test/files/pos/t5294b.scala
@@ -1,0 +1,36 @@
+class Test {
+  def test = {
+
+    val l1 = null: Int #: String #: Boolean #: String #: HNil.type
+
+    type _2 = Succ[Succ[Zero.type]]
+
+    val t1: Boolean = null.asInstanceOf[ l1.type#Drop[_2]#Head ]
+
+    val t2: Boolean = null.asInstanceOf[ l1.type#Apply[_2] ]
+  }
+}
+
+
+sealed trait Nat {
+  type Fold[U, F[_ <: U] <: U, Z <: U] <: U
+}
+
+final object Zero extends Nat {
+  type Fold[U, F[_ <: U] <: U, Z <: U] = Z
+}
+
+final class Succ[N <: Nat] extends Nat {
+  type Fold[U, F[_ <: U] <: U, Z <: U] = F[N#Fold[U, F, Z]]
+}
+
+trait HList {
+  type Head
+  type Tail <: HList
+  type Drop[N <: Nat] = N#Fold[HList, ({ type L[X <: HList] = X#Tail })#L, this.type]
+  type Apply[N <: Nat] = Drop[N]#Head
+}
+
+class #: [H, T <: HList] extends HList { type Head = H; type Tail = T }
+
+object HNil extends HList { type Head = Nothing;  type Tail = Nothing }

--- a/test/files/pos/t5294c.scala
+++ b/test/files/pos/t5294c.scala
@@ -1,0 +1,30 @@
+sealed trait Nat {
+  type IsZero[U, A <: U, B <: U] <: U
+}
+
+final object Zero extends Nat {
+  type IsZero[U, T <: U, F <: U] = T
+}
+
+final class Succ[N <: Nat] extends Nat {
+  type IsZero[U, T <: U, F <: U] = F
+}
+
+trait HList {
+  type Head
+  type Tail <: HList
+  type Drop[N <: Nat] = N#IsZero[HList, this.type, Tail]
+  type Apply[N <: Nat] = Drop[N]#Head // typechecks as HList.this.Head
+}
+
+object Test {
+  type ::[H, T <: HList] = HList { type Head = H; type Tail = T}
+  type HNil <: HList
+  type T = Int :: String :: HNil
+
+  type U = T#Drop[Succ[Zero.type]]#Head
+  type V = T#Apply[Succ[Zero.type]]
+  var u: U = ???
+  var v: V = ???
+  u = v
+}

--- a/test/files/run/t5294.scala
+++ b/test/files/run/t5294.scala
@@ -1,0 +1,22 @@
+import scala.language.higherKinds
+
+package p {
+  trait T[+A, +CC] {
+    def t: CC
+  }
+  class C {
+    def test[CC[X] <: T[X,String] with T[X,Int]](from: CC[_]): Unit = ()
+  }
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val symtab = reflect.runtime.universe.asInstanceOf[reflect.internal.SymbolTable]
+    val CTpe = reflect.runtime.universe.typeOf[p.C].asInstanceOf[symtab.Type]
+    val TClass = reflect.runtime.universe.symbolOf[p.T[_, _]].asInstanceOf[symtab.Symbol]
+    import symtab._
+    val from = CTpe.member(TermName("test")).paramss.head.head
+    assert(from.baseClasses contains TClass)
+    assert(from.info.baseTypeIndex(TClass) != -1) // was failing!
+  }
+}


### PR DESCRIPTION
ASF was failing to recognize the correspondence between a
prefix if it has an abstract type symbol, even if it is bounded by
the currently considered class.

Distilling the test cases, this led to incorrect typechecking of the
RHS of `G` in:

```
trait T {
  type A
  trait HasH { type H[U] <: U }
  type F[N <: HasH] = N#H[T]
  type G[N <: HasH] = F[N]#A // RHS was incorrectly reduced to T.this.A
}
```

In the fuller examples (included as test cases), this meant that
type level functions written as members of `HList` could not be
implemented in terms of each other, e.g. defining `Apply[N]` as
`Drop[N]#Head` had the wrong semantics.

This commit checks checks if the prefix has the candidate class
as a base type, rather than checking if its type symbol has this
as a base class. The latter formulation discarded information about
the instantation of the abstract type.

Using the example above:

```
scala> val F = typeOf[T].member(TypeName("F")).info
F: $r.intp.global.Type = [N <: T.this.HasH]N#H[T]

scala> F.resultType.typeSymbol.baseClasses // old approach
res14: List[$r.intp.global.Symbol] = List(class Any)

scala> F.resultType.baseClasses // new approach
res13: List[$r.intp.global.Symbol] = List(trait T, class Object, class Any)
```

It is worth noting that dotty rejects some of these programs,
as it introduces the rule that:

> // A type T is a legal prefix in a type selection T#A if
> // T is stable or T contains no abstract types except possibly A.
> final def isLegalPrefixFor(selector: Name)(implicit ctx: Context)

However, typechecking the program above in this comment in dotty
yields:

```
<trait> trait T() extends Object {
  type A
  <trait> trait HasH() extends Object {
    type H <: [HK$0] =>  <: HK$0
  }
  type F = [HK$0] => HK$0#H{HK$0 = T}#Apply
  type G = [HK$0] => HK$0#H{HK$0 = T}#Apply#A
}
```

As the equivalent code [1] in dotc's `asSeenFrom` already looks for a base type
of the prefix, rather than looking for a superclass of the prefix's
type symbol.

[1] https://github.com/lampepfl/dotty/blob/d2c96d02fccef3a82b88ee1ff31253b6ef17f900/src/dotty/tools/dotc/core/TypeOps.scala#L62

Review by @adriaanm @odersky
