### PR TITLE
SI-9206 REPL custom bits

### DIFF
--- a/src/compiler/scala/tools/nsc/Properties.scala
+++ b/src/compiler/scala/tools/nsc/Properties.scala
@@ -18,8 +18,7 @@ object Properties extends scala.util.PropertiesTrait {
   def residentPromptString = scalaPropOrElse("resident.prompt", "\nnsc> ")
   def shellPromptString    = scalaPropOrElse("shell.prompt", "%nscala> ")
   def shellWelcomeString   = scalaPropOrElse("shell.welcome",
-    """Welcome to Scala!
-      |%1$s (%3$s, Java %2$s).
+    """Welcome to Scala %1$#s (%3$s, Java %2$s).
       |Type in expressions for evaluation. Or try :help.""".stripMargin
   )
 

--- a/src/compiler/scala/tools/nsc/Properties.scala
+++ b/src/compiler/scala/tools/nsc/Properties.scala
@@ -18,9 +18,9 @@ object Properties extends scala.util.PropertiesTrait {
   def residentPromptString = scalaPropOrElse("resident.prompt", "\nnsc> ")
   def shellPromptString    = scalaPropOrElse("shell.prompt", "%nscala> ")
   def shellWelcomeString   = scalaPropOrElse("shell.welcome",
-    """Welcome to Scala %1$s (%3$s, Java %2$s).
-      |Type in expressions to have them evaluated.
-      |Type :help for more information.""".stripMargin
+    """Welcome to Scala!
+      |%1$s (%3$s, Java %2$s).
+      |Type in expressions for evaluation. Or try :help.""".stripMargin
   )
 
   // message to display at EOF (which by default ends with

--- a/src/compiler/scala/tools/nsc/Properties.scala
+++ b/src/compiler/scala/tools/nsc/Properties.scala
@@ -12,8 +12,17 @@ object Properties extends scala.util.PropertiesTrait {
   protected def pickJarBasedOn = classOf[Global]
 
   // settings based on jar properties, falling back to System prefixed by "scala."
+
+  // messages to display at startup or prompt, format string with string parameters
+  // Scala version, Java version, JVM name
   def residentPromptString = scalaPropOrElse("resident.prompt", "\nnsc> ")
   def shellPromptString    = scalaPropOrElse("shell.prompt", "%nscala> ")
+  def shellWelcomeString   = scalaPropOrElse("shell.welcome",
+    """Welcome to Scala %1$s (%3$s, Java %2$s).
+      |Type in expressions to have them evaluated.
+      |Type :help for more information.""".stripMargin
+  )
+
   // message to display at EOF (which by default ends with
   // a newline so as not to break the user's terminal)
   def shellInterruptedString = scalaPropOrElse("shell.interrupted", f":quit$lineSeparator")

--- a/src/library/scala/sys/BooleanProp.scala
+++ b/src/library/scala/sys/BooleanProp.scala
@@ -50,6 +50,7 @@ object BooleanProp {
     def get: String = "" + value
     val clear, enable, disable, toggle = ()
     def option = if (isSet) Some(value) else None
+    //def or[T1 >: Boolean](alt: => T1): T1 = if (value) true else alt
 
     protected def zero = false
   }

--- a/src/library/scala/sys/Prop.scala
+++ b/src/library/scala/sys/Prop.scala
@@ -58,6 +58,10 @@ trait Prop[+T] {
    */
   def option: Option[T]
 
+  // Do not open until 2.12.
+  //** This value if the property is set, an alternative value otherwise. */
+  //def or[T1 >: T](alt: => T1): T1
+
   /** Removes the property from the underlying map.
    */
   def clear(): Unit

--- a/src/partest-extras/scala/tools/partest/ReplTest.scala
+++ b/src/partest-extras/scala/tools/partest/ReplTest.scala
@@ -6,8 +6,9 @@
 package scala.tools.partest
 
 import scala.tools.nsc.Settings
-import scala.tools.nsc.interpreter.ILoop
+import scala.tools.nsc.interpreter.{ ILoop, replProps }
 import java.lang.reflect.{ Method => JMethod, Field => JField }
+import scala.util.matching.Regex
 import scala.util.matching.Regex.Match
 
 /** A class for testing repl code.
@@ -19,30 +20,31 @@ abstract class ReplTest extends DirectTest {
   // final because we need to enforce the existence of a couple settings.
   final override def settings: Settings = {
     val s = super.settings
-    // s.Yreplsync.value = true
     s.Xnojline.value = true
     transformSettings(s)
   }
+  def normalize(s: String) = s
   /** True for SessionTest to preserve session text. */
   def inSession: Boolean = false
-  /** True to preserve welcome text. */
+  /** True to preserve welcome header, eliding version number. */
   def welcoming: Boolean = false
-  lazy val welcome = "(Welcome to Scala) version .*".r
-  def normalize(s: String) = s match {
-    case welcome(w) => w
-    case s          => s
-  }
-  def unwelcoming(s: String) = s match {
-    case welcome(w) => false
-    case _          => true
-  }
+  lazy val header = replProps.welcome
   def eval() = {
     val s = settings
     log("eval(): settings = " + s)
-    //ILoop.runForTranscript(code, s).lines drop 1  // not always first line
     val lines = ILoop.runForTranscript(code, s, inSession = inSession).lines
-    if (welcoming) lines map normalize
-    else lines filter unwelcoming
+    (if (welcoming) {
+      val welcome = Regex.quote(header.lines.next).r
+      val version = "(.*version).*".r
+      var inHead  = false
+      lines map {
+        case s @ welcome()        => inHead = true  ; s
+        case version(s) if inHead => inHead = false ; s
+        case s                    => s
+      }
+    } else {
+      lines drop header.lines.size
+    }) map normalize
   }
   def show() = eval() foreach println
 }

--- a/src/partest-extras/scala/tools/partest/ReplTest.scala
+++ b/src/partest-extras/scala/tools/partest/ReplTest.scala
@@ -34,13 +34,15 @@ abstract class ReplTest extends DirectTest {
     log("eval(): settings = " + s)
     val lines = ILoop.runForTranscript(code, s, inSession = inSession).lines
     (if (welcoming) {
-      val welcome = Regex.quote(header.lines.next).r
-      val version = "(.*version).*".r
-      var inHead  = false
+      val welcome = "(Welcome to Scala).*".r
+      //val welcome = Regex.quote(header.lines.next).r
+      //val version = "(.*version).*".r   // version on separate line?
+      //var inHead  = false
       lines map {
-        case s @ welcome()        => inHead = true  ; s
-        case version(s) if inHead => inHead = false ; s
-        case s                    => s
+        //case s @ welcome()        => inHead = true  ; s
+        //case version(s) if inHead => inHead = false ; s
+        case welcome(s) => s
+        case s          => s
       }
     } else {
       lines drop header.lines.size

--- a/src/repl-jline/scala/tools/nsc/interpreter/jline/FileBackedHistory.scala
+++ b/src/repl-jline/scala/tools/nsc/interpreter/jline/FileBackedHistory.scala
@@ -7,9 +7,9 @@ package scala.tools.nsc.interpreter.jline
 
 import _root_.jline.console.history.PersistentHistory
 
-
 import scala.tools.nsc.interpreter
-import scala.tools.nsc.io.{File, Path}
+import scala.reflect.io.{ File, Path }
+import scala.tools.nsc.Properties.{ propOrNone, userHome }
 
 /** TODO: file locking.
   */
@@ -85,9 +85,9 @@ object FileBackedHistory {
   //   val ContinuationChar = '\003'
   //   val ContinuationNL: String = Array('\003', '\n').mkString
 
-  import scala.tools.nsc.Properties.userHome
+  final val defaultFileName = ".scala_history"
 
-  def defaultFileName = ".scala_history"
-
-  def defaultFile: File = File(Path(userHome) / defaultFileName)
+  def defaultFile: File = File(
+    propOrNone("scala.shell.histfile") map (Path.apply) getOrElse (Path(userHome) / defaultFileName)
+  )
 }

--- a/src/repl/scala/tools/nsc/interpreter/Formatting.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Formatting.scala
@@ -30,3 +30,6 @@ class Formatting(indent: Int) {
     }
   )
 }
+object Formatting {
+  def forPrompt(prompt: String) = new Formatting(prompt.lines.toList.last.length)
+}

--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -56,13 +56,9 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
 
   private var globalFuture: Future[Boolean] = _
 
-  /** Print a welcome message */
-  def printWelcome() {
-    echo(s"""
-      |Welcome to Scala $versionString ($javaVmName, Java $javaVersion).
-      |Type in expressions to have them evaluated.
-      |Type :help for more information.""".trim.stripMargin
-    )
+  /** Print a welcome message! */
+  def printWelcome(): Unit = {
+    Option(replProps.welcome) filter (!_.isEmpty) foreach echo
     replinfo("[info] started at " + new java.util.Date)
   }
 
@@ -111,10 +107,6 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
   }
 
   class ILoopInterpreter extends IMain(settings, out) {
-    // the expanded prompt but without color escapes and without leading newline, for purposes of indenting
-    override lazy val formatting: Formatting = new Formatting(
-      (replProps.promptString format Properties.versionNumberString).lines.toList.last.length
-    )
     override protected def parentClassLoader =
       settings.explicitParentLoader.getOrElse( classOf[ILoop].getClassLoader )
   }

--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -680,9 +680,8 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
   }
 
   def verbosity() = {
-    val old = intp.printResults
-    intp.printResults = !old
-    echo("Switched " + (if (old) "off" else "on") + " result printing.")
+    intp.printResults = !intp.printResults
+    replinfo(s"Result printing is ${ if (intp.printResults) "on" else "off" }.")
   }
 
   /** Run one command submitted by the user.  Two values are returned:

--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -753,7 +753,8 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
 
   private object paste extends Pasted {
     import scala.util.matching.Regex.quote
-    val ContinueString = "     | "
+    val ContinuePrompt = replProps.continuePrompt
+    val ContinueString = replProps.continueText     // "     | "
     val PromptString   = prompt.lines.toList.last
     val anyPrompt = s"""\\s*(?:${quote(PromptString.trim)}|${quote(AltPromptString.trim)})\\s*""".r
 
@@ -797,7 +798,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
         echo("You typed two blank lines.  Starting a new command.")
         None
       case IR.Incomplete =>
-        in.readLine(paste.ContinueString) match {
+        in.readLine(paste.ContinuePrompt) match {
           case null =>
             // we know compilation is going to fail since we're at EOF and the
             // parser thinks the input is still incomplete, but since this is
@@ -940,8 +941,9 @@ object ILoop {
       Console.withOut(ostream) {
         val output = new JPrintWriter(new OutputStreamWriter(ostream), true) {
           // skip margin prefix for continuation lines, unless preserving session text for test
+          // should test for repl.paste.ContinueString or replProps.continueText.contains(ch)
           override def write(str: String) =
-            if (!inSession && (str forall (ch => ch.isWhitespace || ch == '|'))) ()  // repl.paste.ContinueString
+            if (!inSession && (str forall (ch => ch.isWhitespace || ch == '|'))) ()
             else super.write(str)
         }
         val input = new BufferedReader(new StringReader(code.trim + "\n")) {

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -113,9 +113,7 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
   def this() = this(new Settings())
 
   // the expanded prompt but without color escapes and without leading newline, for purposes of indenting
-  lazy val formatting: Formatting = new Formatting(
-    (replProps.promptString format Properties.versionNumberString).lines.toList.last.length
-  )
+  lazy val formatting = Formatting.forPrompt(replProps.promptText)
   lazy val reporter: ReplReporter = new ReplReporter(this)
 
   import formatting.indentCode

--- a/src/repl/scala/tools/nsc/interpreter/ReplProps.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplProps.scala
@@ -45,11 +45,17 @@ class ReplProps {
 
   // Handy system prop for shell prompt, or else pick it up from compiler.properties
   val promptString = Prop[String]("scala.repl.prompt").option getOrElse (if (info) "%nscala %s> " else shellPromptString)
-  def promptText   = enversion(promptString)
-  val prompt = {
-    import scala.io.AnsiColor.{ MAGENTA, RESET }
-    if (colorOk) s"$MAGENTA$promptText$RESET" else promptText
+  val promptText   = enversion(promptString)
+  val prompt       = encolor(promptText)
+
+  // Prompt for continued input, will be right-adjusted to width of the primary prompt
+  val continueString = Prop[String]("scala.repl.continue").option getOrElse "| "
+  val continueText   = {
+    val text   = enversion(continueString)
+    val margin = promptText.lines.toList.last.length - text.length
+    if (margin > 0) " " * margin + text else text
   }
+  val continuePrompt = encolor(continueText)
 
   //def welcome = enversion(Prop[String]("scala.repl.welcome") or shellWelcomeString)
   def welcome = enversion {

--- a/src/repl/scala/tools/nsc/interpreter/ReplProps.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplProps.scala
@@ -44,7 +44,7 @@ class ReplProps {
   }
 
   // Handy system prop for shell prompt, or else pick it up from compiler.properties
-  val promptString = Prop[String]("scala.repl.prompt").option getOrElse (if (info) "%nscala %s> " else shellPromptString)
+  val promptString = Prop[String]("scala.repl.prompt").option getOrElse (if (info) "%nscala %#s> " else shellPromptString)
   val promptText   = enversion(promptString)
   val prompt       = encolor(promptText)
 
@@ -57,10 +57,11 @@ class ReplProps {
   }
   val continuePrompt = encolor(continueText)
 
+  // Next time.
   //def welcome = enversion(Prop[String]("scala.repl.welcome") or shellWelcomeString)
   def welcome = enversion {
     val p = Prop[String]("scala.repl.welcome")
-    if (p.isSet) p.value else shellWelcomeString
+    if (p.isSet) p.get else shellWelcomeString
   }
 
   /** CSV of paged,across to enable pagination or `-x` style

--- a/test/files/jvm/interpreter.check
+++ b/test/files/jvm/interpreter.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> // basics
 

--- a/test/files/jvm/throws-annot-from-java.check
+++ b/test/files/jvm/throws-annot-from-java.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> :power
 ** Power User mode enabled - BEEP WHIR GYVE **

--- a/test/files/jvm/xml05.check
+++ b/test/files/jvm/xml05.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> <city name="San Jos&eacute;"/>
 res0: scala.xml.Elem = <city name="San Jos&eacute;"/>

--- a/test/files/run/class-symbol-contravariant.check
+++ b/test/files/run/class-symbol-contravariant.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> :power
 ** Power User mode enabled - BEEP WHIR GYVE **

--- a/test/files/run/constant-type.check
+++ b/test/files/run/constant-type.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> :power
 ** Power User mode enabled - BEEP WHIR GYVE **

--- a/test/files/run/constrained-types.check
+++ b/test/files/run/constrained-types.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> class Annot(obj: Any) extends annotation.Annotation with annotation.TypeConstraint
 defined class Annot

--- a/test/files/run/kind-repl-command.check
+++ b/test/files/run/kind-repl-command.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> :kind scala.Option
 scala.Option's kind is F[+A]

--- a/test/files/run/lub-visibility.check
+++ b/test/files/run/lub-visibility.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> // should infer List[scala.collection.immutable.Seq[Nothing]]
 

--- a/test/files/run/macro-bundle-repl.check
+++ b/test/files/run/macro-bundle-repl.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> import scala.language.experimental.macros
 import scala.language.experimental.macros

--- a/test/files/run/macro-repl-basic.check
+++ b/test/files/run/macro-repl-basic.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> import language.experimental.macros
 import language.experimental.macros

--- a/test/files/run/macro-repl-dontexpand.check
+++ b/test/files/run/macro-repl-dontexpand.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> def bar1(c: scala.reflect.macros.blackbox.Context) = ???
 bar1: (c: scala.reflect.macros.blackbox.Context)Nothing

--- a/test/files/run/macro-system-properties.check
+++ b/test/files/run/macro-system-properties.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> import scala.language.experimental._, scala.reflect.macros.blackbox.Context
 import scala.language.experimental._

--- a/test/files/run/reflection-equality.check
+++ b/test/files/run/reflection-equality.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> class X {
    def methodIntIntInt(x: Int, y: Int) = x+y

--- a/test/files/run/reflection-magicsymbols-repl.check
+++ b/test/files/run/reflection-magicsymbols-repl.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> import scala.reflect.runtime.universe._
 import scala.reflect.runtime.universe._

--- a/test/files/run/reflection-repl-classes.check
+++ b/test/files/run/reflection-repl-classes.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> class A
 defined class A

--- a/test/files/run/reflection-repl-elementary.check
+++ b/test/files/run/reflection-repl-elementary.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> scala.reflect.runtime.universe.typeOf[List[Nothing]]
 res0: reflect.runtime.universe.Type = scala.List[Nothing]

--- a/test/files/run/reify-repl-fail-gracefully.check
+++ b/test/files/run/reify-repl-fail-gracefully.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> import language.experimental.macros
 import language.experimental.macros

--- a/test/files/run/reify_newimpl_22.check
+++ b/test/files/run/reify_newimpl_22.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> import scala.reflect.runtime.universe._
 import scala.reflect.runtime.universe._

--- a/test/files/run/reify_newimpl_23.check
+++ b/test/files/run/reify_newimpl_23.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> import scala.reflect.runtime.universe._
 import scala.reflect.runtime.universe._

--- a/test/files/run/reify_newimpl_25.check
+++ b/test/files/run/reify_newimpl_25.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> {
   import scala.reflect.runtime.universe._

--- a/test/files/run/reify_newimpl_26.check
+++ b/test/files/run/reify_newimpl_26.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> def foo[T]{
   import scala.reflect.runtime.universe._

--- a/test/files/run/reify_newimpl_35.check
+++ b/test/files/run/reify_newimpl_35.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> import scala.reflect.runtime.universe._
 import scala.reflect.runtime.universe._

--- a/test/files/run/repl-assign.check
+++ b/test/files/run/repl-assign.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> var x = 10
 x: Int = 10

--- a/test/files/run/repl-bare-expr.check
+++ b/test/files/run/repl-bare-expr.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> 2 ; 3
 <console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses

--- a/test/files/run/repl-colon-type.check
+++ b/test/files/run/repl-colon-type.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> :type List[1, 2, 3]
 <console>:1: error: identifier expected but integer literal found.

--- a/test/files/run/repl-empty-package.check
+++ b/test/files/run/repl-empty-package.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> println(Bippy.bippy)
 bippy!

--- a/test/files/run/repl-javap-app.check
+++ b/test/files/run/repl-javap-app.check
@@ -1,6 +1,5 @@
 #partest java6
-Welcome to Scala!
-version
+Welcome to Scala
 Type in expressions for evaluation. Or try :help.
 
 scala> :javap -app MyApp$
@@ -17,8 +16,7 @@ public final void delayedEndpoint$MyApp$1();
 
 scala> :quit
 #partest java7
-Welcome to Scala!
-version
+Welcome to Scala
 Type in expressions for evaluation. Or try :help.
 
 scala> :javap -app MyApp$
@@ -39,8 +37,7 @@ scala> :javap -app MyApp$
 
 scala> :quit
 #partest java8
-Welcome to Scala!
-version
+Welcome to Scala
 Type in expressions for evaluation. Or try :help.
 
 scala> :javap -app MyApp$

--- a/test/files/run/repl-javap-app.check
+++ b/test/files/run/repl-javap-app.check
@@ -1,7 +1,7 @@
 #partest java6
-Welcome to Scala
-Type in expressions to have them evaluated.
-Type :help for more information.
+Welcome to Scala!
+version
+Type in expressions for evaluation. Or try :help.
 
 scala> :javap -app MyApp$
 public final void delayedEndpoint$MyApp$1();
@@ -17,9 +17,9 @@ public final void delayedEndpoint$MyApp$1();
 
 scala> :quit
 #partest java7
-Welcome to Scala
-Type in expressions to have them evaluated.
-Type :help for more information.
+Welcome to Scala!
+version
+Type in expressions for evaluation. Or try :help.
 
 scala> :javap -app MyApp$
   public final void delayedEndpoint$MyApp$1();
@@ -39,9 +39,9 @@ scala> :javap -app MyApp$
 
 scala> :quit
 #partest java8
-Welcome to Scala
-Type in expressions to have them evaluated.
-Type :help for more information.
+Welcome to Scala!
+version
+Type in expressions for evaluation. Or try :help.
 
 scala> :javap -app MyApp$
   public final void delayedEndpoint$MyApp$1();

--- a/test/files/run/repl-out-dir.check
+++ b/test/files/run/repl-out-dir.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> case class Bippy(x: Int)
 defined class Bippy

--- a/test/files/run/repl-parens.check
+++ b/test/files/run/repl-parens.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> (2)
 res0: Int = 2

--- a/test/files/run/repl-paste-2.check
+++ b/test/files/run/repl-paste-2.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> scala> 999l
 

--- a/test/files/run/repl-paste-3.check
+++ b/test/files/run/repl-paste-3.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> println(3)
 3

--- a/test/files/run/repl-paste-4.scala
+++ b/test/files/run/repl-paste-4.scala
@@ -3,9 +3,7 @@ import scala.tools.partest.SessionTest
 
 object Test extends SessionTest {
   def session =
-s"""|Type in expressions to have them evaluated.
-    |Type :help for more information.
-    |
+s"""|
     |scala> :paste $pastie
     |Pasting file $pastie...
     |defined class Foo

--- a/test/files/run/repl-paste-raw.scala
+++ b/test/files/run/repl-paste-raw.scala
@@ -3,9 +3,7 @@ import scala.tools.partest.SessionTest
 
 object Test extends SessionTest {
   def session =
-s"""|Type in expressions to have them evaluated.
-    |Type :help for more information.
-    |
+s"""|
     |scala> :paste -raw $pastie
     |Pasting file $pastie...
     |

--- a/test/files/run/repl-paste.check
+++ b/test/files/run/repl-paste.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> :paste
 // Entering paste mode (ctrl-D to finish)

--- a/test/files/run/repl-power.check
+++ b/test/files/run/repl-power.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> :power
 ** Power User mode enabled - BEEP WHIR GYVE **

--- a/test/files/run/repl-reset.check
+++ b/test/files/run/repl-reset.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> val x1 = 1
 x1: Int = 1

--- a/test/files/run/repl-save.scala
+++ b/test/files/run/repl-save.scala
@@ -2,9 +2,7 @@ import scala.tools.partest.SessionTest
 
 object Test extends SessionTest {
   def session =
-s"""|Type in expressions to have them evaluated.
-    |Type :help for more information.
-    |
+s"""|
     |scala> val i = 7
     |i: Int = 7
     |

--- a/test/files/run/repl-term-macros.check
+++ b/test/files/run/repl-term-macros.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> import scala.reflect.macros.blackbox.Context
 import scala.reflect.macros.blackbox.Context

--- a/test/files/run/repl-transcript.check
+++ b/test/files/run/repl-transcript.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> scala> class Bippity
 

--- a/test/files/run/repl-trim-stack-trace.scala
+++ b/test/files/run/repl-trim-stack-trace.scala
@@ -4,9 +4,9 @@ import scala.tools.partest.{ SessionTest, Welcoming }
 // SI-7740
 object Test extends SessionTest with Welcoming {
   def session =
-"""Welcome to Scala
-Type in expressions to have them evaluated.
-Type :help for more information.
+"""Welcome to Scala!
+version
+Type in expressions for evaluation. Or try :help.
 
 scala> def f = throw new Exception("Uh-oh")
 f: Nothing
@@ -37,7 +37,6 @@ scala> :quit"""
   // normalize the "elided" lines because the frame count depends on test context
   lazy val elided = """(\s+\.{3} )\d+( elided)""".r
   override def normalize(line: String) = line match {
-    case welcome(w)               => w
     case elided(ellipsis, suffix) => s"$ellipsis???$suffix"
     case s                        => s
   }

--- a/test/files/run/repl-trim-stack-trace.scala
+++ b/test/files/run/repl-trim-stack-trace.scala
@@ -4,8 +4,7 @@ import scala.tools.partest.{ SessionTest, Welcoming }
 // SI-7740
 object Test extends SessionTest with Welcoming {
   def session =
-"""Welcome to Scala!
-version
+"""Welcome to Scala
 Type in expressions for evaluation. Or try :help.
 
 scala> def f = throw new Exception("Uh-oh")

--- a/test/files/run/repl-type-verbose.check
+++ b/test/files/run/repl-type-verbose.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> // verbose!
 

--- a/test/files/run/t3376.check
+++ b/test/files/run/t3376.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> class M[@specialized T] { override def toString = "mmm" }
 defined class M

--- a/test/files/run/t4025.check
+++ b/test/files/run/t4025.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> class Color(val red: Int)
 defined class Color

--- a/test/files/run/t4172.check
+++ b/test/files/run/t4172.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> val c = { class C { override def toString = "C" }; ((new C, new C { def f = 2 })) }
 warning: there was one feature warning; re-run with -feature for details

--- a/test/files/run/t4216.check
+++ b/test/files/run/t4216.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> import scala.reflect.ClassTag
 import scala.reflect.ClassTag

--- a/test/files/run/t4285.check
+++ b/test/files/run/t4285.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> val x = Array(1,2,3,4,5,6,7)
 x: Array[Int] = Array(1, 2, 3, 4, 5, 6, 7)

--- a/test/files/run/t4542.check
+++ b/test/files/run/t4542.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> @deprecated("foooo", "ReplTest version 1.0-FINAL") class Foo() {
   override def toString = "Bippy"

--- a/test/files/run/t4594-repl-settings.scala
+++ b/test/files/run/t4594-repl-settings.scala
@@ -4,23 +4,21 @@ import scala.tools.partest.SessionTest
 // Detected repl transcript paste: ctrl-D to finish.
 object Test extends SessionTest {
   def session =
-""" |Type in expressions to have them evaluated.
-    |Type :help for more information.
-    |
-    |scala> @deprecated(message="Please don't do that.", since="Time began.") def depp = "john"
-    |depp: String
-    |
-    |scala> def a = depp
-    |warning: there was one deprecation warning; re-run with -deprecation for details
-    |a: String
-    |
-    |scala> :settings -deprecation
-    |
-    |scala> def b = depp
-    |<console>:11: warning: method depp is deprecated: Please don't do that.
-    |       def b = depp
-    |               ^
-    |b: String
-    |
-    |scala> :quit"""
+"""|
+   |scala> @deprecated(message="Please don't do that.", since="Time began.") def depp = "john"
+   |depp: String
+   |
+   |scala> def a = depp
+   |warning: there was one deprecation warning; re-run with -deprecation for details
+   |a: String
+   |
+   |scala> :settings -deprecation
+   |
+   |scala> def b = depp
+   |<console>:11: warning: method depp is deprecated: Please don't do that.
+   |       def b = depp
+   |               ^
+   |b: String
+   |
+   |scala> :quit"""
 }

--- a/test/files/run/t4671.check
+++ b/test/files/run/t4671.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> object o { val file = sys.props("partest.cwd") + "/t4671.scala" }
 defined object o

--- a/test/files/run/t4710.check
+++ b/test/files/run/t4710.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> def method : String = { implicit def f(s: Symbol) = "" ; 'symbol }
 warning: there was one feature warning; re-run with -feature for details

--- a/test/files/run/t4950.check
+++ b/test/files/run/t4950.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> val 1 = 2
 scala.MatchError: 2 (of class java.lang.Integer)

--- a/test/files/run/t5072.check
+++ b/test/files/run/t5072.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> class C
 defined class C

--- a/test/files/run/t5256d.check
+++ b/test/files/run/t5256d.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> import scala.reflect.runtime.universe._
 import scala.reflect.runtime.universe._

--- a/test/files/run/t5535.check
+++ b/test/files/run/t5535.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> def h()(i: Int) = 1 + i
 h: ()(i: Int)Int

--- a/test/files/run/t5537.check
+++ b/test/files/run/t5537.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> List[Predef.type]()
 res0: List[scala.Predef.type] = List()

--- a/test/files/run/t5583.check
+++ b/test/files/run/t5583.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> var s = 0
 s: Int = 0

--- a/test/files/run/t5655.check
+++ b/test/files/run/t5655.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> object x { def x={} }
 defined object x

--- a/test/files/run/t5789.check
+++ b/test/files/run/t5789.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> val n = 2
 n: Int = 2

--- a/test/files/run/t6086-repl.check
+++ b/test/files/run/t6086-repl.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> case class X(s: String)
 defined class X

--- a/test/files/run/t6146b.check
+++ b/test/files/run/t6146b.check
@@ -2,8 +2,6 @@ t6146b.scala:15: warning: match may not be exhaustive.
 It would fail on the following inputs: S2(), S3()
   def foo(f: F[Int]) = f match { case X.S1 => }
                        ^
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> :power
 ** Power User mode enabled - BEEP WHIR GYVE **

--- a/test/files/run/t6187.check
+++ b/test/files/run/t6187.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> import scala.language.experimental.macros, scala.reflect.macros.blackbox.Context
 import scala.language.experimental.macros

--- a/test/files/run/t6273.check
+++ b/test/files/run/t6273.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> val y = 55
 y: Int = 55

--- a/test/files/run/t6320.check
+++ b/test/files/run/t6320.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> import scala.language.dynamics
 import scala.language.dynamics

--- a/test/files/run/t6329_repl.check
+++ b/test/files/run/t6329_repl.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> import scala.reflect.classTag
 import scala.reflect.classTag

--- a/test/files/run/t6329_repl_bug.check
+++ b/test/files/run/t6329_repl_bug.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> import scala.reflect.runtime.universe._
 import scala.reflect.runtime.universe._

--- a/test/files/run/t6381.check
+++ b/test/files/run/t6381.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> import scala.language.experimental.macros
 import scala.language.experimental.macros

--- a/test/files/run/t6434.check
+++ b/test/files/run/t6434.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> def f(x: => Int): Int = x
 f: (x: => Int)Int

--- a/test/files/run/t6439.check
+++ b/test/files/run/t6439.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> class A
 defined class A

--- a/test/files/run/t6507.check
+++ b/test/files/run/t6507.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> :silent
 

--- a/test/files/run/t6507.check
+++ b/test/files/run/t6507.check
@@ -2,7 +2,6 @@ Type in expressions to have them evaluated.
 Type :help for more information.
 
 scala> :silent
-Switched off result printing.
 
 scala> class A { override def toString() = { println("!"); "A" } }
 
@@ -15,7 +14,6 @@ scala> b = new A
 scala> new A
 
 scala> :silent
-Switched on result printing.
 
 scala> res0
 !

--- a/test/files/run/t6549.check
+++ b/test/files/run/t6549.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> case class `X"`(var xxx: Any)
 defined class X$u0022

--- a/test/files/run/t6937.check
+++ b/test/files/run/t6937.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> import scala.reflect.runtime.{universe => ru}
 import scala.reflect.runtime.{universe=>ru}

--- a/test/files/run/t7185.check
+++ b/test/files/run/t7185.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> import scala.tools.reflect.ToolBox
 import scala.tools.reflect.ToolBox

--- a/test/files/run/t7319.check
+++ b/test/files/run/t7319.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> class M[A]
 defined class M

--- a/test/files/run/t7482a.check
+++ b/test/files/run/t7482a.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> val v: java.util.ArrayList[String] = new java.util.ArrayList[String](5)
 v: java.util.ArrayList[String] = []

--- a/test/files/run/t7634.check
+++ b/test/files/run/t7634.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 
 scala> .lines

--- a/test/files/run/t7747-repl.check
+++ b/test/files/run/t7747-repl.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> var x = 10
 x: Int = 10

--- a/test/files/run/t7801.check
+++ b/test/files/run/t7801.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> val g: scala.reflect.internal.SymbolTable = null; import g.abort
 g: scala.reflect.internal.SymbolTable = null

--- a/test/files/run/t7805-repl-i.check
+++ b/test/files/run/t7805-repl-i.check
@@ -1,9 +1,9 @@
 Loading t7805-repl-i.script...
 import util._
 
-Welcome to Scala
-Type in expressions to have them evaluated.
-Type :help for more information.
+Welcome to Scala!
+version
+Type in expressions for evaluation. Or try :help.
 
 scala> Console println Try(8)
 Success(8)

--- a/test/files/run/t7805-repl-i.check
+++ b/test/files/run/t7805-repl-i.check
@@ -1,8 +1,7 @@
 Loading t7805-repl-i.script...
 import util._
 
-Welcome to Scala!
-version
+Welcome to Scala
 Type in expressions for evaluation. Or try :help.
 
 scala> Console println Try(8)

--- a/test/files/run/t8843-repl-xlat.scala
+++ b/test/files/run/t8843-repl-xlat.scala
@@ -4,9 +4,7 @@ import scala.tools.partest.SessionTest
 // Handy hamburger helper for repl resources
 object Test extends SessionTest {
   def session =
-"""Type in expressions to have them evaluated.
-Type :help for more information.
-
+"""
 scala> $intp.isettings.unwrapStrings = false
 $intp.isettings.unwrapStrings: Boolean = false
 

--- a/test/files/run/t9170.scala
+++ b/test/files/run/t9170.scala
@@ -6,9 +6,7 @@ object Test extends SessionTest {
   override def stripMargins = false
 
   def session =
-"""Type in expressions to have them evaluated.
-Type :help for more information.
-
+"""
 scala> object Y { def f[A](a: => A) = 1 ; def f[A](a: => Either[Exception, A]) = 2 }
 <console>:10: error: double definition:
 def f[A](a: => A): Int at line 10 and

--- a/test/files/run/t9206.scala
+++ b/test/files/run/t9206.scala
@@ -5,9 +5,7 @@ object Test extends SessionTest {
   //override def prompt = "XXX> "
 //Welcome to Scala version 2.11.6 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_40).
   def session =
-    s"""|Type in expressions to have them evaluated.
-        |Type :help for more information.
-        |
+    s"""|
         |scala> val i: Int = "foo"
         |<console>:10: error: type mismatch;
         | found   : String("foo")

--- a/test/files/run/tpeCache-tyconCache.check
+++ b/test/files/run/tpeCache-tyconCache.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> :power
 ** Power User mode enabled - BEEP WHIR GYVE **

--- a/test/files/run/xMigration.check
+++ b/test/files/run/xMigration.check
@@ -1,5 +1,3 @@
-Type in expressions to have them evaluated.
-Type :help for more information.
 
 scala> Map(1 -> "eis").values    // no warn
 res0: Iterable[String] = MapLike(eis)


### PR DESCRIPTION
This supersedes #4447 and considers https://github.com/scala/scala/compare/2.11.x...iracic:topic/repl-customization--2nd-try

Introduces `scala.repl.continue` for continuation prompt, `scala.shell.histfile` for history file location, and `scala.repl.welcome` for its first impression, which is also available as a properties file entry, `shell.welcome`.

The welcome banner is turned off by setting it empty.

Review by @adriaanm the gaatkeeper.
