### PR TITLE
Bump swing version to 2.0.0-M2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -24,7 +24,7 @@ scala.binary.version=2.12.0-M1
 # external modules shipped with distribution, as specified by scala-library-all's pom
 scala-xml.version.number=1.0.4
 scala-parser-combinators.version.number=1.0.4
-scala-swing.version.number=1.0.2
+scala-swing.version.number=2.0.0-M2
 jline.version=2.12.1
 scala-asm.version=5.0.3-scala-3
 


### PR DESCRIPTION
This will unbreak the nightly release, and allow building 2.12.0-M2
without overriding SWING_VER.
