### PR TITLE
Fix size update on `mutable.TreeMap#clear()`

### DIFF
--- a/src/library/scala/collection/mutable/RedBlackTree.scala
+++ b/src/library/scala/collection/mutable/RedBlackTree.scala
@@ -55,7 +55,9 @@ private[collection] object RedBlackTree {
   // ---- size ----
 
   def size(node: Node[_, _]): Int = if (node eq null) 0 else 1 + size(node.left) + size(node.right)
+  def size(tree: Tree[_, _]): Int = tree.size
   def isEmpty(tree: Tree[_, _]) = tree.root eq null
+  def clear(tree: Tree[_, _]): Unit = { tree.root = null; tree.size = 0 }
 
   // ---- search ----
 

--- a/src/library/scala/collection/mutable/TreeMap.scala
+++ b/src/library/scala/collection/mutable/TreeMap.scala
@@ -64,7 +64,7 @@ sealed class TreeMap[A, B] private (tree: RB.Tree[A, B])(implicit val ordering: 
   def keysIteratorFrom(start: A) = RB.keysIterator(tree, Some(start))
   def valuesIteratorFrom(start: A) = RB.valuesIterator(tree, Some(start))
 
-  override def size = tree.size
+  override def size = RB.size(tree)
   override def isEmpty = RB.isEmpty(tree)
   override def contains(key: A) = RB.contains(tree, key)
 
@@ -78,7 +78,7 @@ sealed class TreeMap[A, B] private (tree: RB.Tree[A, B])(implicit val ordering: 
 
   override def foreach[U](f: ((A, B)) => U): Unit = RB.foreach(tree, f)
   override def transform(f: (A, B) => B) = { RB.transform(tree, f); this }
-  override def clear(): Unit = tree.root = null
+  override def clear(): Unit = RB.clear(tree)
 
   override def stringPrefix = "TreeMap"
 

--- a/test/files/scalacheck/MutableTreeMap.scala
+++ b/test/files/scalacheck/MutableTreeMap.scala
@@ -163,7 +163,7 @@ package scala.collection.mutable {
 
     property("clear") = forAll { (map: mutable.TreeMap[K, V]) =>
       map.clear()
-      map.isEmpty
+      map.isEmpty && map.size == 0
     }
 
     property("serializable") = forAll { (map: mutable.TreeMap[K, V]) =>
@@ -303,7 +303,7 @@ package scala.collection.mutable {
     property("clear") = forAll { (map: mutable.TreeMap[K, V], from: Option[K], until: Option[K]) =>
       val mapView = map.rangeImpl(from, until)
       mapView.clear()
-      map.isEmpty && mapView.isEmpty
+      map.isEmpty && mapView.isEmpty && map.size == 0 && mapView.size == 0
     }
 
     property("serializable") = forAll { (map: mutable.TreeMap[K, V], from: Option[K], until: Option[K]) =>


### PR DESCRIPTION
The previous implementation has a major bug - although `clear()` sets the root node to `null`, the `size` attribute of the `Tree` was not updated. This effectively meant that even after a `map.clear()`, a call to `map.size` would still yield the old size of the map.

The scalacheck test suite was updated to contemplate this issue.
