### PR TITLE
Improved message for missing argument list

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -550,23 +550,18 @@ trait ContextErrors {
       def ModuleUsingCompanionClassDefaultArgsErrror(tree: Tree) =
         NormalTypeError(tree, "module extending its companion class cannot use default constructor arguments")
 
-      def NotEnoughArgsError(tree: Tree, fun0: Tree, missing0: List[Symbol]) = {
-        def notEnoughArgumentsMsg(fun: Tree, missing: List[Symbol]) = {
-          val suffix = {
-            if (missing.isEmpty) ""
-            else {
-              val keep = missing take 3 map (_.name)
-              ".\nUnspecified value parameter%s %s".format(
-                if (missing.tail.isEmpty) "" else "s",
-                if ((missing drop 3).nonEmpty) (keep :+ "...").mkString(", ")
-                else keep.mkString("", ", ", ".")
-              )
-            }
+      def NotEnoughArgsError(tree: Tree, fun: Tree, missing: List[Symbol]) = {
+        val notEnoughArgumentsMsg = {
+          val suffix = if (missing.isEmpty) "" else {
+            val keep = missing take 3 map (_.name)
+            val ess  = if (missing.tail.isEmpty) "" else "s"
+            f".%nUnspecified value parameter$ess ${
+              keep.mkString("", ", ", if ((missing drop 3).nonEmpty) "..." else ".")
+            }"
           }
-
-          "not enough arguments for " + treeSymTypeMsg(fun) + suffix
+          s"not enough arguments for ${ treeSymTypeMsg(fun) }$suffix"
         }
-        NormalTypeError(tree, notEnoughArgumentsMsg(fun0, missing0))
+        NormalTypeError(tree, notEnoughArgumentsMsg)
       }
 
       //doTypedApply - patternMode
@@ -632,12 +627,16 @@ trait ContextErrors {
 
       //adapt
       def MissingArgsForMethodTpeError(tree: Tree, meth: Symbol) = {
+        val f = meth.name
+        val paf = s"$f(${ meth.asMethod.paramLists map (_ map (_ => "_") mkString ",") mkString ")(" })"
+        val advice = s"""
+          |Unapplied methods are only converted to functions when a function type is expected.
+          |You can make this conversion explicit by writing `$f _` or `$paf` instead of `$f`.""".stripMargin
         val message =
           if (meth.isMacro) MacroTooFewArgumentListsMessage
-          else "missing arguments for " + meth.fullLocationString + (
-            if (meth.isConstructor) ""
-            else ";\nfollow this method with `_' if you want to treat it as a partially applied function"
-          )
+          else s"""missing argument list for ${meth.fullLocationString}${
+            if (!meth.isConstructor) advice else ""
+          }"""
         issueNormalTypeError(tree, message)
         setError(tree)
       }

--- a/test/files/neg/macro-invalidshape.check
+++ b/test/files/neg/macro-invalidshape.check
@@ -8,8 +8,9 @@ macro [<static object>].<method name>[[<type args>]] or
 macro [<macro bundle>].<method name>[[<type args>]]
   def foo2(x: Any) = macro Impls.foo(null)(null)
                                  ^
-Macros_Test_2.scala:4: error: missing arguments for method foo in object Impls;
-follow this method with `_' if you want to treat it as a partially applied function
+Macros_Test_2.scala:4: error: missing argument list for method foo in object Impls
+Unapplied methods are only converted to functions when a function type is expected.
+You can make this conversion explicit by writing `foo _` or `foo(_)(_)` instead of `foo`.
   def foo3(x: Any) = macro {2; Impls.foo}
                                      ^
 Macros_Test_2.scala:7: error: macro implementation reference has wrong shape. required:

--- a/test/files/neg/missing-arg-list.check
+++ b/test/files/neg/missing-arg-list.check
@@ -1,0 +1,21 @@
+missing-arg-list.scala:9: error: missing argument list for method id in trait T
+Unapplied methods are only converted to functions when a function type is expected.
+You can make this conversion explicit by writing `id _` or `id(_)` instead of `id`.
+  val w = id
+          ^
+missing-arg-list.scala:10: error: missing argument list for method f in trait T
+Unapplied methods are only converted to functions when a function type is expected.
+You can make this conversion explicit by writing `f _` or `f(_)(_)` instead of `f`.
+  val x = f
+          ^
+missing-arg-list.scala:11: error: missing argument list for method g in trait T
+Unapplied methods are only converted to functions when a function type is expected.
+You can make this conversion explicit by writing `g _` or `g(_,_,_)` instead of `g`.
+  val y = g
+          ^
+missing-arg-list.scala:12: error: missing argument list for method h in trait T
+Unapplied methods are only converted to functions when a function type is expected.
+You can make this conversion explicit by writing `h _` or `h(_,_,_)(_)` instead of `h`.
+  val z = h
+          ^
+four errors found

--- a/test/files/neg/missing-arg-list.scala
+++ b/test/files/neg/missing-arg-list.scala
@@ -1,0 +1,13 @@
+
+trait T {
+
+  def id(i: Int) = i
+  def f(i: Int)(j: Int) = i+j
+  def g(i: Int, j: Int, k: Int) = i+j+k
+  def h(i: Int, j: Int, k: Int)(implicit s: String) = s*(i+j+k)
+
+  val w = id
+  val x = f
+  val y = g
+  val z = h
+}


### PR DESCRIPTION
Clarifies the language and rules for eta-expansion.

A missing argument in a list, as opposed to a missing
argument list, results in a different message.

The comical expansion in parens does not attempt to show
what was already applied, but succeeds in showing at a
glance the shape of the method in question.

```
scala> def m(i: Int, j: Int)(x: Int) = ???
m: (i: Int, j: Int)(x: Int)Nothing

scala> m
<console>:12: error: missing argument list for method m
Unapplied methods are only converted to functions when a function type is expected.
You can make this conversion explicit by writing `m _` or `m(_,_)(_)` instead of `m`.
       m
       ^
```

The original submission #4555 was due to sschaef and the wording due
to adriaanm, with a minor tweak.

Review by @adriaanm 
