### PR TITLE
SI-8140 Documentation references java.lang.String directly

### DIFF
--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -82,6 +82,11 @@ object Predef extends LowPriorityImplicits with DeprecatedPredef {
    */
   def classOf[T]: Class[T] = null // This is a stub method. The actual implementation is filled in by the compiler.
 
+  /** The `String` type in Scala has methods that come either from the underlying
+   *  Java String (see the documentation corresponding to your Java version, for
+   *  example [[http://docs.oracle.com/javase/8/docs/api/java/lang/String.html]]) or
+   *  are added implicitly through [[scala.collection.immutable.StringOps]].
+   */
   type String        = java.lang.String
   type Class[T]      = java.lang.Class[T]
 

--- a/src/library/scala/collection/immutable/StringOps.scala
+++ b/src/library/scala/collection/immutable/StringOps.scala
@@ -12,10 +12,9 @@ package immutable
 
 import mutable.StringBuilder
 
-/**
- *  This class serves as a wrapper providing `String`s with all the operations
- *  found in indexed sequences. Where needed, instances of `String` object
- *  are implicitly converted into this class.
+/** This class serves as a wrapper providing [[scala.Predef.String]]s with all
+ *  the operations found in indexed sequences. Where needed, `String`s are
+ *  implicitly converted into instances of this class.
  *
  *  The difference between this class and `WrappedString` is that calling transformer
  *  methods such as `filter` and `map` will yield a `String` object, whereas a


### PR DESCRIPTION
This is a documentation fix that should make it easier to get to the documentation of java.lang.String. Properly fixing this issue would require a complete redesign of the scaladoc tool to somehow add documentation for external entities.
