### PR TITLE
SI-9370 Xplugin scans plugin path for descriptor

### DIFF
--- a/src/compiler/scala/tools/nsc/plugins/Plugin.scala
+++ b/src/compiler/scala/tools/nsc/plugins/Plugin.scala
@@ -158,8 +158,8 @@ object Plugin {
       def loop(qs: List[Path]): Try[PluginDescription] = qs match {
         case Nil       => Failure(new MissingPluginException(ps))
         case p :: rest =>
-          if (p.isDirectory) loadDescriptionFromFile(p.toDirectory / PluginXML)
-          else if (p.isFile) loadDescriptionFromJar(p.toFile)
+          if (p.isDirectory) loadDescriptionFromFile(p.toDirectory / PluginXML) orElse loop(rest)
+          else if (p.isFile) loadDescriptionFromJar(p.toFile) orElse loop(rest)
           else loop(rest)
       }
       loop(ps)

--- a/test/files/pos/t9370/ThePlugin.scala
+++ b/test/files/pos/t9370/ThePlugin.scala
@@ -1,0 +1,31 @@
+package scala.test.plugins
+
+import scala.tools.nsc
+import nsc.Global
+import nsc.Phase
+import nsc.plugins.Plugin
+import nsc.plugins.PluginComponent
+
+class ThePlugin(val global: Global) extends Plugin {
+  import global._
+
+  val name = "timebomb"
+  val description = "Explodes if run. Maybe I haven't implemented it yet."
+  val components = List[PluginComponent](thePhase1)
+
+  private object thePhase1 extends PluginComponent {
+    val global = ThePlugin.this.global
+
+    val runsAfter = List[String]("parser")
+    override val runsBefore = List[String]("namer")
+    val phaseName = ThePlugin.this.name
+
+    def newPhase(prev: Phase) = new ThePhase(prev)
+  }
+
+  private class ThePhase(prev: Phase) extends Phase(prev) {
+    override def name = ThePlugin.this.name
+    override def run  = ???
+  }
+}
+

--- a/test/files/pos/t9370/sample_2.flags
+++ b/test/files/pos/t9370/sample_2.flags
@@ -1,0 +1,1 @@
+-Xplugin:/tmp:. -Xplugin-require:timebomb -Ystop-after:parser

--- a/test/files/pos/t9370/sample_2.scala
+++ b/test/files/pos/t9370/sample_2.scala
@@ -1,0 +1,6 @@
+
+package sample
+
+// just a sample that is compiled with the explosive plugin disabled
+object Sample extends App {
+}

--- a/test/files/pos/t9370/scalac-plugin.xml
+++ b/test/files/pos/t9370/scalac-plugin.xml
@@ -1,0 +1,5 @@
+<plugin>
+  <name>ignored</name>
+  <classname>scala.test.plugins.ThePlugin</classname>
+</plugin>
+


### PR DESCRIPTION
Keep on scanning if the first entry doesn't yield
a plugin.xml descriptor.
