### PR TITLE
Correct init order between Pasted and ILoop#pasted

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/Pasted.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Pasted.scala
@@ -21,7 +21,13 @@ abstract class Pasted {
   def PromptString: String
   def AltPromptString: String = "scala> "
 
-  private val testBoth = PromptString != AltPromptString
+  /* `testBoth` cannot be a val, as `Pasted` is inherited by `object paste` in ILoop,
+    which would cause `val testBoth` to be initialized before `val PromptString` was.
+
+      object paste extends Pasted {
+        val PromptString   = prompt.lines.toList.last
+  */
+  private def testBoth = PromptString != AltPromptString
   private val spacey   = " \t".toSet
 
   def matchesPrompt(line: String) = matchesString(line, PromptString) || testBoth && matchesString(line, AltPromptString)


### PR DESCRIPTION
`testBoth` cannot be a val in `Pasted`, as `Pasted` is inherited
by `object paste` in ILoop, which would cause `val testBoth` to
be initialized before `val PromptString` was:

```
object paste extends Pasted {
  val PromptString   = prompt.lines.toList.last
```

See https://scala-webapps.epfl.ch/jenkins/job/scala-nightly-checkinit-2.11.x/417.
Introduced by #4564.
