### PR TITLE
SI-9377 ScalaVersion init no longer fails if versionless

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaVersion.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaVersion.scala
@@ -77,10 +77,7 @@ object ScalaVersion {
 
   def apply(versionString: String, errorHandler: String => Unit): ScalaVersion = {
     def error() = errorHandler(
-      s"There was a problem parsing ${versionString}. " +
-      "Versions should be in the form major[.minor[.revision]] " +
-      "where each part is a positive number, as in 2.10.1. " +
-      "The minor and revision parts are optional."
+      s"Bad version (${versionString}) not major[.minor[.revision[-suffix]]]"
     )
 
     def toInt(s: String) = s match {

--- a/src/compiler/scala/tools/nsc/settings/ScalaVersion.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaVersion.scala
@@ -97,6 +97,7 @@ object ScalaVersion {
 
     versionString match {
       case "none" => NoScalaVersion
+      case ""     => NoScalaVersion
       case "any"  => AnyScalaVersion
       case vpat(majorS, minorS, revS, buildS) =>
         SpecificScalaVersion(toInt(majorS), toInt(minorS), toInt(revS), toBuild(buildS))

--- a/test/junit/scala/tools/nsc/settings/ScalaVersionTest.scala
+++ b/test/junit/scala/tools/nsc/settings/ScalaVersionTest.scala
@@ -57,4 +57,9 @@ class ScalaVersionTest {
     assertThrows[NumberFormatException] { ScalaVersion("2-.") } // scalacheck territory
     assertThrows[NumberFormatException] { ScalaVersion("any.7") }
   }
+
+  // SI-9377
+  @Test def `missing version is as good as none`() {
+    assertEquals(NoScalaVersion, ScalaVersion(""))
+  }
 }

--- a/test/junit/scala/tools/nsc/settings/ScalaVersionTest.scala
+++ b/test/junit/scala/tools/nsc/settings/ScalaVersionTest.scala
@@ -56,6 +56,10 @@ class ScalaVersionTest {
     assertThrows[NumberFormatException] { ScalaVersion("2-") }
     assertThrows[NumberFormatException] { ScalaVersion("2-.") } // scalacheck territory
     assertThrows[NumberFormatException] { ScalaVersion("any.7") }
+
+    assertThrows[NumberFormatException] ( ScalaVersion("2.11-ok"), _ ==
+      "Bad version (2.11-ok) not major[.minor[.revision[-suffix]]]" )
+
   }
 
   // SI-9377

--- a/test/junit/scala/tools/nsc/settings/SettingsTest.scala
+++ b/test/junit/scala/tools/nsc/settings/SettingsTest.scala
@@ -178,6 +178,6 @@ class SettingsTest {
     check(expected = "2.12",   "-Xsource:2.12")
     assertThrows[IllegalArgumentException](check(expected = "2.11", "-Xsource"), _ == "-Xsource requires an argument, the syntax is -Xsource:<version>")
     assertThrows[IllegalArgumentException](check(expected = "2.11", "-Xsource", "2.11"), _ == "-Xsource requires an argument, the syntax is -Xsource:<version>")
-    assertThrows[IllegalArgumentException](check(expected = "2.11", "-Xsource:2.invalid"), _ contains "There was a problem parsing 2.invalid")
+    assertThrows[IllegalArgumentException](check(expected = "2.11", "-Xsource:2.invalid"), _ contains "Bad version (2.invalid)")
   }
 }


### PR DESCRIPTION
If the version string was empty, ScalaVersion would
indignantly refuse to initialize. Now it takes a missing
property as "none".
