### PR TITLE
Support methodHandle / invokeDynamic constant pool entries in scalap

### DIFF
--- a/src/scalap/scala/tools/scalap/scalax/rules/scalasig/ClassFileParser.scala
+++ b/src/scalap/scala/tools/scalap/scalax/rules/scalasig/ClassFileParser.scala
@@ -114,6 +114,9 @@ object ClassFileParser extends ByteCodeReader {
   val methodRef = memberRef("Method")
   val interfaceMethodRef = memberRef("InterfaceMethod")
   val nameAndType = u2 ~ u2 ^^ add1 { case name ~ descriptor => pool => "NameAndType: " + pool(name) + ", " + pool(descriptor) }
+  val methodHandle = u1 ~ u2 ^^ add1 { case referenceKind ~ referenceIndex => pool => "MethodHandle: " + referenceKind + ", " + pool(referenceIndex) }
+  val methodType = u2 ^^ add1 { case descriptorIndex => pool => "MethodType: " + pool(descriptorIndex) }
+  val invokeDynamic = u2 ~ u2 ^^ add1 { case bootstrapMethodAttrIndex ~ nameAndTypeIndex => pool => "InvokeDynamic: " + "bootstrapMethodAttrIndex = " + bootstrapMethodAttrIndex + ", " + pool(nameAndTypeIndex) }
 
   val constantPoolEntry = u1 >> {
     case 1 => utf8String
@@ -127,6 +130,9 @@ object ClassFileParser extends ByteCodeReader {
     case 10 => methodRef
     case 11 => interfaceMethodRef
     case 12 => nameAndType
+    case 15 => methodHandle
+    case 16 => methodType
+    case 18 => invokeDynamic
   }
 
   val interfaces = u2 >> u2.times

--- a/test/files/run/scalapInvokedynamic.check
+++ b/test/files/run/scalapInvokedynamic.check
@@ -1,0 +1,5 @@
+class C extends scala.AnyRef {
+  def this() = { /* compiled code */ }
+  def m: java.lang.String = { /* compiled code */ }
+}
+

--- a/test/files/run/scalapInvokedynamic.scala
+++ b/test/files/run/scalapInvokedynamic.scala
@@ -1,0 +1,11 @@
+class C {
+  def m = {
+    val f = (x: String) => x.trim
+    f(" H ae i  ")
+  }
+}
+
+object Test extends App {
+  val testClassesDir = System.getProperty("partest.output")
+  scala.tools.scalap.Main.main(Array("-cp", testClassesDir, "C"))
+}


### PR DESCRIPTION
Add support in scalap to parse new constant pool entries
- MethodHandle
- MethodType
- InvokeDynamic

Spec: https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html
