### PR TITLE
[indylambda] Improve test coverage

### DIFF
--- a/test/files/run/indylambda-specialization.scala
+++ b/test/files/run/indylambda-specialization.scala
@@ -1,0 +1,15 @@
+object Test {
+  def assertApply(expected: Boolean) = {
+    val frames = Thread.currentThread.getStackTrace.takeWhile(_.getMethodName != "main")
+    val usesObjectApply = frames.exists(_.getMethodName == "apply")
+    assert(expected == usesObjectApply, frames.mkString("\n"))
+  }
+  def assertSpecialized() = assertApply(false)
+  def assertUnspecialized() = assertApply(true)
+  def main(args: Array[String]): Unit = {
+    ((i: String)      => {assertUnspecialized(); i}).apply("")
+    (()               => {assertSpecialized(); 0}).apply()
+    ((i: Int)         => {assertSpecialized(); i}).apply(0)
+    ((i: Int, j: Int) => {assertSpecialized(); i + j}).apply(0, 0)
+  }
+}

--- a/test/junit/scala/tools/nsc/backend/jvm/IndyLambdaTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/IndyLambdaTest.scala
@@ -18,7 +18,8 @@ object IndyLambdaTest extends ClearAfterClass.Clearable {
   }
 }
 
-class IndyLambdaTest {
+class IndyLambdaTest extends ClearAfterClass {
+  ClearAfterClass.stateToClear = IndyLambdaTest
   val compiler = IndyLambdaTest.compiler
 
   @Test def boxingBridgeMethodUsedSelectively(): Unit = {
@@ -35,7 +36,7 @@ class IndyLambdaTest {
     // This is because Scala's unboxing of null values gives zero, whereas Java's throw a NPE.
 
     // 1. Here we show that we are calling the boxing bridge (the lambda bodies here are compiled into
-    //    methods of `(I)java/lang/Object;` / `(I)java/lang/Object;` respectively.)
+    //    methods of `(I)Ljava/lang/Object;` / `(I)Ljava/lang/Object;` respectively.)
     assertEquals("(Ljava/lang/Object;)Ljava/lang/Object;", implMethodDescriptorFor("(x: Int) => new Object"))
     assertEquals("(Ljava/lang/Object;)Ljava/lang/Object;", implMethodDescriptorFor("(x: Object) => 0"))
 

--- a/test/junit/scala/tools/nsc/backend/jvm/IndyLambdaTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/IndyLambdaTest.scala
@@ -1,0 +1,54 @@
+package scala.tools.nsc.backend.jvm
+
+import org.junit.Assert._
+import org.junit.{Assert, Test}
+
+import scala.tools.asm.{Handle, Opcodes}
+import scala.tools.asm.tree.InvokeDynamicInsnNode
+import scala.tools.nsc.backend.jvm.AsmUtils._
+import scala.tools.nsc.backend.jvm.CodeGenTools._
+import scala.tools.testing.ClearAfterClass
+import scala.collection.JavaConverters._
+
+object IndyLambdaTest extends ClearAfterClass.Clearable {
+  var compiler = newCompiler(extraArgs = "-Ybackend:GenBCode")
+
+  def clear(): Unit = {
+    compiler = null
+  }
+}
+
+class IndyLambdaTest {
+  val compiler = IndyLambdaTest.compiler
+
+  @Test def boxingBridgeMethodUsedSelectively(): Unit = {
+    def implMethodDescriptorFor(code: String): String = {
+      val method = compileMethods(compiler)(s"""def f = $code """).find(_.name == "f").get
+      val x = method.instructions.iterator.asScala.toList
+      x.flatMap {
+        case insn : InvokeDynamicInsnNode => insn.bsmArgs.collect { case h : Handle => h.getDesc }
+        case _ => Nil
+      }.head
+    }
+    // unspecialized functions that have a primitive in parameter or return position
+    // give rise to a "boxing bridge" method (which has the suffix `$adapted`).
+    // This is because Scala's unboxing of null values gives zero, whereas Java's throw a NPE.
+
+    // 1. Here we show that we are calling the boxing bridge (the lambda bodies here are compiled into
+    //    methods of `(I)java/lang/Object;` / `(I)java/lang/Object;` respectively.)
+    assertEquals("(Ljava/lang/Object;)Ljava/lang/Object;", implMethodDescriptorFor("(x: Int) => new Object"))
+    assertEquals("(Ljava/lang/Object;)Ljava/lang/Object;", implMethodDescriptorFor("(x: Object) => 0"))
+
+    // 2a. We don't need such adaptations for parameters or return values with types that differ
+    // from Object due to other generic substitution, LambdaMetafactory will downcast the arguments.
+    assertEquals("(Ljava/lang/String;)Ljava/lang/String;", implMethodDescriptorFor("(x: String) => x"))
+
+    // 2b. Testing 2a. in combination with 1.
+    assertEquals("(Ljava/lang/Object;)Ljava/lang/String;", implMethodDescriptorFor("(x: Int) => \"\""))
+    assertEquals("(Ljava/lang/String;)Ljava/lang/Object;", implMethodDescriptorFor("(x: String) => 0"))
+
+    // 3. Specialized functions, don't need any of this as they implement a method like `apply$mcII$sp`,
+    //    and the (un)boxing is handled in the base class in code emitted by scalac.
+    assertEquals("(I)I", implMethodDescriptorFor("(x: Int) => x"))
+  }
+}

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineInfoTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineInfoTest.scala
@@ -27,7 +27,9 @@ object InlineInfoTest extends ClearAfterClass.Clearable {
 }
 
 @RunWith(classOf[JUnit4])
-class InlineInfoTest {
+class InlineInfoTest extends ClearAfterClass {
+  ClearAfterClass.stateToClear = InlineInfoTest
+
   val compiler = InlineInfoTest.compiler
 
   def compile(code: String) = {


### PR DESCRIPTION
Adding tests for the selective use of boxing bridge methods
and to show that specialization is not subverted by indylambda.

Other aspects of indylambda are tested by tests like:
- run/lambda-serialization.scala
- run/indylambda-boxing

When those tests were written, they only tested the old backend.
However, now that we have Java 8 and the new backend avaialble
by default to partest, they provide the intended coverage.
