### PR TITLE
Spec: Implicit parameters with context/view bound is allowed since 2.10

### DIFF
--- a/spec/07-implicits.md
+++ b/spec/07-implicits.md
@@ -358,6 +358,16 @@ in one implicit parameter section.  Since traits do not take
 constructor parameters, this translation does not work for them.
 Consequently, type-parameters in traits may not be view- or context-bounded.
 
+Evidence parameters are prepended to the existing implicit parameter section, if one exists.
+
+For example:
+
+```scala
+def foo[A: M](implicit b: B): C
+// expands to:
+// def foo[A](implicit evidence$1: M[A], b: B): C
+```
+
 ###### Example
 The `<=` method from the [`Ordered` example](#example-ordered) can be declared
 more concisely as follows:

--- a/spec/07-implicits.md
+++ b/spec/07-implicits.md
@@ -357,8 +357,6 @@ they appear and all the resulting evidence parameters are concatenated
 in one implicit parameter section.  Since traits do not take
 constructor parameters, this translation does not work for them.
 Consequently, type-parameters in traits may not be view- or context-bounded.
-Also, a method or class with view- or context bounds may not define any
-additional implicit parameters.
 
 ###### Example
 The `<=` method from the [`Ordered` example](#example-ordered) can be declared


### PR DESCRIPTION
Obsolete description is removed.

I know additional document for parameter order(both *-bound and additional implicits are used) is needed, but I can't describe it :(
