### PR TITLE
Implement `distinctBy` for SeqLike and Stream

### DIFF
--- a/src/library/scala/collection/SeqLike.scala
+++ b/src/library/scala/collection/SeqLike.scala
@@ -499,13 +499,27 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
    *
    *  @return  A new $coll which contains the first occurrence of every element of this $coll.
    */
-  def distinct: Repr = {
+  def distinct: Repr = distinctBy(identity)
+
+  /** Builds a new $coll from this $coll where output elements have distinct
+   *  results by `f`.
+   *  $willNotTerminateInf
+   *
+   *  @return  A new $coll which contains the first occurence of each element
+   *    `x` with a unique `y = f(x)`.
+   *  @example {{{
+   *    List("Steve", "Barbara", "Stephanie", "Bob", "Frank").distinctBy(_.head) =
+   *    List("Steve", "Barbara", "Frank")
+   *  }}}
+   */
+  def distinctBy[B](f: A => B): Repr = {
     val b = newBuilder
-    val seen = mutable.HashSet[A]()
+    val seen = mutable.HashSet[B]()
     for (x <- this) {
-      if (!seen(x)) {
+      val y = f(x)
+      if (!seen(y)) {
         b += x
-        seen += x
+        seen += y
       }
     }
     b.result()

--- a/src/library/scala/collection/immutable/Stream.scala
+++ b/src/library/scala/collection/immutable/Stream.scala
@@ -933,13 +933,34 @@ self =>
    * // produces: "1, 2, 3, 4, 5, 6"
    * }}}
    */
-  override def distinct: Stream[A] = {
+  override def distinct: Stream[A] = distinctBy(identity)
+
+  /** Builds a new stream from this stream in which elements with duplicate
+   * outputs by `f` are removed. Among elements with the same result by `f`,
+   * only the first one is retained in the resulting `Stream`.
+   *
+   * @return  A new `Stream` which contains the first occurrence of each
+   * element `x` with a unique `y = f(x)`.
+   * @example {{{
+   * // Creates a Stream where every element is followed by its negation
+   * def naturalsFrom(i: Int): Stream[Int] = i #:: { -i #:: naturalsFrom(i + 1) }
+   * naturalsFrom(1) take 6 mkString ", "
+   * // produces: "1, -1, 2, -2, 3, -3"
+   * (naturalsFrom(1) distinctBy (x => math.abs(x))) take 6 mkString ", "
+   * // produces: "1, 2, 3, 4, 5, 6"
+   * }}}
+   */
+  override def distinctBy[B](f: A => B): Stream[A] = {
     // This should use max memory proportional to N, whereas
     // recursively calling distinct on the tail is N^2.
-    def loop(seen: Set[A], rest: Stream[A]): Stream[A] = {
-      if (rest.isEmpty) rest
-      else if (seen(rest.head)) loop(seen, rest.tail)
-      else cons(rest.head, loop(seen + rest.head, rest.tail))
+    def loop(seen: Set[B], rest: Stream[A]): Stream[A] = rest match {
+      case Stream.Empty => rest
+      case cons(x, xs) =>
+        val y = f(x)
+        if (seen(y))
+          loop(seen, xs)
+        else
+          x #:: loop(seen + y, xs)
     }
     loop(Set(), this)
   }


### PR DESCRIPTION
Opening against 2.12.x as requested from #4612.

> Hi all! I wasn't sure what the right order to do things in for a PR would be, but the readme seemed to indicate it'd be fine to open a PR first and figure things out later. :)
> - I have not yet implemented tests, but I wasn't sure where those should go. Any guidance on that?
> - ~~"The current maintenance release (2.11.x) cannot break source/binary compatibility, which means public APIs cannot change." Does adding a method break compatibility?~~
> 
> @Ichoran and @axel22, the readme and PR policy doc mentioned you're the people to ping on the collections library (I think). Any thoughts?
> 
> Thanks for reading!
