### PR TITLE
Bootstrap scala-xml using `-Xsource:2.11`

### DIFF
--- a/scripts/jobs/integrate/bootstrap
+++ b/scripts/jobs/integrate/bootstrap
@@ -217,7 +217,8 @@ buildXML() {
   then echo "Found scala-xml $XML_VER; not building."
   else
     update scala scala-xml "$XML_REF" && gfxd
-    sbtBuild 'set version := "'$XML_VER'-DOC"' $clean doc  'set version := "'$XML_VER'"' test "${buildTasks[@]}"
+    # TODO: compile under 2.12 source level once `scala.xml.XMLTest.escape` is fixed (see #4451)
+    sbtBuild 'set scalacOptions += "-Xsource:2.11"' 'set version := "'$XML_VER'-DOC"' $clean doc  'set version := "'$XML_VER'"' test "${buildTasks[@]}"
     XML_BUILT="yes" # ensure the module is built and published when buildXML is invoked for the second time, see comment above
   fi
 }


### PR DESCRIPTION
Under 2.12 source level, `scala.xml.XMLTest.escape` fails (see #4451)

https://scala-ci.typesafe.com/job/scala-2.12.x-integrate-bootstrap/60/artifact/logs/builds/*view*/
