### PR TITLE
SI-9383 Improved unused import warning

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1408,7 +1408,7 @@ trait Implicits {
       }
 
       if (result.isFailure && settings.debug) // debuglog is not inlined for some reason
-        log("no implicits found for "+pt+" "+pt.typeSymbol.info.baseClasses+" "+implicitsOfExpectedType)
+        log(s"no implicits found for ${pt} ${pt.typeSymbol.info.baseClasses} ${implicitsOfExpectedType}")
 
       result
     }

--- a/test/files/neg/warn-unused-imports.check
+++ b/test/files/neg/warn-unused-imports.check
@@ -1,33 +1,55 @@
-warn-unused-imports.scala:57: warning: Unused import
+warn-unused-imports_2.scala:133: error: type mismatch;
+ found   : Int(42)
+ required: Sample.X
+    f(42)                       // error
+      ^
+warn-unused-imports_2.scala:57: warning: Unused import
     import p1.A // warn
               ^
-warn-unused-imports.scala:62: warning: Unused import
+warn-unused-imports_2.scala:62: warning: Unused import
     import p1.{ A, B } // warn on A
                 ^
-warn-unused-imports.scala:67: warning: Unused import
+warn-unused-imports_2.scala:67: warning: Unused import
     import p1.{ A, B } // warn on both
                 ^
-warn-unused-imports.scala:67: warning: Unused import
+warn-unused-imports_2.scala:67: warning: Unused import
     import p1.{ A, B } // warn on both
                    ^
-warn-unused-imports.scala:73: warning: Unused import
+warn-unused-imports_2.scala:73: warning: Unused import
     import c._  // warn
              ^
-warn-unused-imports.scala:78: warning: Unused import
+warn-unused-imports_2.scala:78: warning: Unused import
     import p1._ // warn
               ^
-warn-unused-imports.scala:85: warning: Unused import
+warn-unused-imports_2.scala:85: warning: Unused import
     import c._  // warn
              ^
-warn-unused-imports.scala:91: warning: Unused import
+warn-unused-imports_2.scala:91: warning: Unused import
     import p1.c._  // warn
                 ^
-warn-unused-imports.scala:98: warning: Unused import
+warn-unused-imports_2.scala:98: warning: Unused import
     import p1._   // warn
               ^
-warn-unused-imports.scala:118: warning: Unused import
+warn-unused-imports_2.scala:118: warning: Unused import
     import p1.A   // warn
               ^
-error: No warnings can be incurred under -Xfatal-warnings.
-10 warnings found
+warn-unused-imports_2.scala:132: warning: Unused import
+    import Sample.Implicits._   // warn
+                            ^
+warn-unused-imports_2.scala:143: warning: Unused import
+    import Sample.Implicits.useless     // warn
+                            ^
+warn-unused-imports_2.scala:147: warning: Unused import
+    import java.io.File                 // warn
+                   ^
+warn-unused-imports_2.scala:148: warning: Unused import
+    import scala.concurrent.Future      // warn
+                            ^
+warn-unused-imports_2.scala:149: warning: Unused import
+    import scala.concurrent.ExecutionContext.Implicits.global // warn
+                                                       ^
+warn-unused-imports_2.scala:150: warning: Unused import
+    import p1.A                         // warn
+              ^
+16 warnings found
 one error found

--- a/test/files/neg/warn-unused-imports/sample_1.scala
+++ b/test/files/neg/warn-unused-imports/sample_1.scala
@@ -1,0 +1,17 @@
+
+import language._
+
+object Sample {
+  trait X
+  trait Y
+
+  // import of the non-implicit should be unused
+  object Implicits {
+    def `int to X`(i: Int): X = null
+    implicit def `int to Y`(i: Int): Y = null
+    implicit def useless(i: Int): String = null
+  }
+
+  def f(x: X) = ???
+  def g(y: Y) = ???
+}

--- a/test/files/neg/warn-unused-imports/warn-unused-imports_2.scala
+++ b/test/files/neg/warn-unused-imports/warn-unused-imports_2.scala
@@ -123,3 +123,33 @@ trait Nested {
     println(new Warn { })
   }
 }
+
+// test unusage of imports from other compilation units after implicit search
+trait Outsiders {
+  {
+    //implicit search should not disable warning
+    import Sample._
+    import Sample.Implicits._   // warn
+    f(42)                       // error
+  }
+  {
+    import Sample._
+    import Sample.Implicits._   // nowarn
+    g(42)                       // ok
+  }
+  {
+    import Sample._
+    import Sample.Implicits.`int to Y`  // nowarn
+    import Sample.Implicits.useless     // warn
+    g(42)                       // ok
+  }
+  {
+    import java.io.File                 // warn
+    import scala.concurrent.Future      // warn
+    import scala.concurrent.ExecutionContext.Implicits.global // warn
+    import p1.A                         // warn
+    import p1.B                         // no warn
+    println("abc".bippy)
+    //Future("abc".bippy)
+  }
+}


### PR DESCRIPTION
Previously, implicit search would mark every import
it touched as a lookup.

Instead, let subsequent type check perform the lookup.
