### PR TITLE
Fix the bug in the example in scala.sys.process

### DIFF
--- a/src/library/scala/sys/process/package.scala
+++ b/src/library/scala/sys/process/package.scala
@@ -157,7 +157,7 @@ package scala.sys {
     *     while(input.read() != -1) count += 1
     *     input.close()
     *   }
-    *   cat ! new ProcessIO(_.close(), byteCounter, _.close())
+    *   cat run new ProcessIO(_.close(), byteCounter, _.close())
     *   count
     * }
     *

--- a/src/library/scala/sys/process/package.scala
+++ b/src/library/scala/sys/process/package.scala
@@ -157,7 +157,8 @@ package scala.sys {
     *     while(input.read() != -1) count += 1
     *     input.close()
     *   }
-    *   cat run new ProcessIO(_.close(), byteCounter, _.close())
+    *   val p = cat run new ProcessIO(_.close(), byteCounter, _.close())
+    *   p.exitValue()
     *   count
     * }
     *


### PR DESCRIPTION
There's no `!` method with argument type `ProcessIO`. I suppose this is intended to be `run`.

Review by @heathermiller, @dickwall.
