### PR TITLE
SI-9393 Temporarily disable two assertions in GenBCode

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -841,16 +841,17 @@ abstract class BTypes {
 
       assert(!ClassBType.isInternalPhantomType(internalName), s"Cannot create ClassBType for phantom type $this")
 
-      assert(
-        if (info.get.superClass.isEmpty) { isJLO(this) || (isCompilingPrimitive && ClassBType.hasNoSuper(internalName)) }
-        else if (isInterface.get) isJLO(info.get.superClass.get)
-        else !isJLO(this) && ifInit(info.get.superClass.get)(!_.isInterface.get),
-        s"Invalid superClass in $this: ${info.get.superClass}"
-      )
-      assert(
-        info.get.interfaces.forall(c => ifInit(c)(_.isInterface.get)),
-        s"Invalid interfaces in $this: ${info.get.interfaces}"
-      )
+      // TODO bring these back in a way that doesn't trip pos/t9393
+      // assert(
+      //   if (info.get.superClass.isEmpty) { isJLO(this) || (isCompilingPrimitive && ClassBType.hasNoSuper(internalName)) }
+      //   else if (isInterface.get) isJLO(info.get.superClass.get)
+      //   else !isJLO(this) && ifInit(info.get.superClass.get)(!_.isInterface.get),
+      //   s"Invalid superClass in $this: ${info.get.superClass}"
+      // )
+      // assert(
+      //   info.get.interfaces.forall(c => ifInit(c)(_.isInterface.get)),
+      //   s"Invalid interfaces in $this: ${info.get.interfaces}"
+      // )
 
       assert(info.get.nestedClasses.forall(c => ifInit(c)(_.isNestedClass.get)), info.get.nestedClasses)
     }

--- a/test/files/pos/t9393/Named.java
+++ b/test/files/pos/t9393/Named.java
@@ -1,0 +1,3 @@
+package bug;
+
+public @interface Named {}

--- a/test/files/pos/t9393/NamedImpl.java
+++ b/test/files/pos/t9393/NamedImpl.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package bug;
+
+import bug.Named;
+import java.io.Serializable;
+import java.lang.annotation.Annotation;
+
+public class NamedImpl implements Named {
+
+    public Class<? extends Annotation> annotationType() {
+        return null;
+    }
+}

--- a/test/files/pos/t9393/test.scala
+++ b/test/files/pos/t9393/test.scala
@@ -1,0 +1,3 @@
+class C {
+  new bug.NamedImpl
+}


### PR DESCRIPTION
These cause a crash in the build of Play. We should try to bring
these back once we have suitable annotation awareness. Perhaps
they should only be `devWarning`-s, though.

This is another backport candidate for 2.11.x. Submitting
to 2.12.x in case we want to include it in M2.
