### PR TITLE
SI-9394 Fix pattern infererence with class tparams in pt

### DIFF
--- a/spec/08-pattern-matching.md
+++ b/spec/08-pattern-matching.md
@@ -151,13 +151,14 @@ A constructor pattern is of the form $c(p_1 , \ldots , p_n)$ where $n
 \geq 0$. It consists of a stable identifier $c$, followed by element
 patterns $p_1 , \ldots , p_n$. The constructor $c$ is a simple or
 qualified name which denotes a [case class](05-classes-and-objects.html#case-classes).
-If the case class is monomorphic, then it
-must conform to the expected type of the pattern, and the formal
-parameter types of $x$'s [primary constructor](05-classes-and-objects.html#class-definitions)
-are taken as the expected types of the element patterns $p_1, \ldots ,
-p_n$.  If the case class is polymorphic, then its type parameters are
-instantiated so that the instantiation of $c$ conforms to the expected
-type of the pattern. The instantiated formal parameter types of $c$'s
+
+For the purposes of type checking patterns, monomorphic and polymorphic
+case classes are treated uniformly: the former is seen as having an
+empty type parameter list.
+
+The type parameters of the case class are
+[instantiated](#type-parameter-inference-in-patterns), which may fail with a static
+error if no instantiation exists. The instantiated formal parameter types of $c$'s
 primary constructor are then taken as the expected types of the
 component patterns $p_1, \ldots , p_n$.  The pattern matches all
 objects created from constructor invocations $c(v_1 , \ldots , v_n)$

--- a/test/files/pos/t9394a.scala
+++ b/test/files/pos/t9394a.scala
@@ -1,0 +1,14 @@
+sealed trait Base
+case class Up() extends Base
+case class Down() extends Base
+ 
+sealed trait Tracker[B <: Base] {
+ 
+  def bar = this match {
+    case UpTracker() => ???
+    case DownTracker() => ???
+  }
+ 
+}
+case class UpTracker() extends Tracker[Up]
+case class DownTracker() extends Tracker[Down]

--- a/test/files/pos/t9394b.scala
+++ b/test/files/pos/t9394b.scala
@@ -1,0 +1,14 @@
+sealed trait Base
+case class Up() extends Base
+case class Down() extends Base
+ 
+sealed trait Tracker[B <: Base] {
+ 
+  def bar = (this: Tracker[_ <: B]) match {
+    case UpTracker() => ???
+    case DownTracker() => ???
+  }
+ 
+}
+case class UpTracker() extends Tracker[Up]
+case class DownTracker() extends Tracker[Down]


### PR DESCRIPTION
Constructor patterns must be compatible with the expected type of
the pattern (ie, the scrutinee type). The spec doesn't cover the
whole story here:

http://www.scala-lang.org/files/archive/spec/2.11/08-pattern-matching.html#constructor-patterns

> If the case class is monomorphic, then it must conform to the
> expected type of the pattern. [...]
> If the case class is polymorphic, then its type parameters are
> instantiated so that the instantiation of c conforms to the expected
> type of the pattern

The implementation actually treats monomorphic case classes, like
those in the test case, according the rules for polymorphic case
classes, albeit with an empty type parameter list. As such, we need
to consider another part of the spec that elaborates on type parameter
inference within patterns, and the subsequent static check for
the pattern conforming to the expected type:

http://www.scala-lang.org/files/archive/spec/2.11/08-pattern-matching.html#type-parameter-inference-in-patterns

> Otherwise, if T can not be made to conform to pt by instantiating
> its type variables, one determines all type variables in pt which
> are defined as type parameters of a method enclosing the pattern
> ...
> let C2 be the weakest set of subtype constraints over the type
> variables a1,…,an and b1,…,bm such that C0∧C′0∧C2 implies that
> it is possible to construct a type T′ which conforms to both
> T and pt. It is a static error if there is no satisfiable set of
> constraints C2 with this property.

This "otherwise" corresponds to `inferForApproxPt` within:

https://github.com/scala/scala/blob/v2.11.6/src/compiler/scala/tools/nsc/typechecker/Infer.scala#L1063-L1085

This substitutes free type parameters within the expected type
with wildcard types. However, class type parameters were being
excluded from this due to the line of code that this commit removes.

I traced the `owner.isTerm` condition back to f9e5afd36a8.
I don't understand the intent; and the tests are still passing.

I have also updated the spec to replace the too-narrow description
of pattern inference in the "constructor patterns" section with a link
to the more up-to-date description in the "pattern inference"
section, and to explain that mono- and polymorphic case classes
are treated uniformly when it comes to checking conformance to the
expected type.
