### PR TITLE
SI-9396 Runner computes path only once

### DIFF
--- a/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
+++ b/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
@@ -9,7 +9,7 @@ import java.net.URL
 import scala.tools.util.PathResolverFactory
 
 class GenericRunnerSettings(error: String => Unit) extends Settings(error) {
-  def classpathURLs: Seq[URL] = PathResolverFactory.create(this).resultAsURLs
+  lazy val classpathURLs: Seq[URL] = PathResolverFactory.create(this).resultAsURLs
 
   val howtorun =
     ChoiceSetting(

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -22,13 +22,9 @@ trait ScalaSettings extends AbsScalaSettings
   /** Set of settings */
   protected[scala] lazy val allSettings = mutable.HashSet[Setting]()
 
-  /** Against my better judgment, giving in to martin here and allowing
-   *  CLASSPATH to be used automatically.  So for the user-specified part
-   *  of the classpath:
-   *
-   *  - If -classpath or -cp is given, it is that
-   *  - Otherwise, if CLASSPATH is set, it is that
-   *  - If neither of those, then "." is used.
+  /** The user class path, specified by `-classpath` or `-cp`,
+   *  defaults to the value of CLASSPATH env var if it is set, as in Java,
+   *  or else to `"."` for the current user directory.
    */
   protected def defaultClasspath = sys.env.getOrElse("CLASSPATH", ".")
 

--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -254,17 +254,7 @@ abstract class PathResolverBase[BaseClassPathType <: ClassFileLookup[AbstractFil
      * TODO: we should refactor this as a separate -bootstrap option to have a clean implementation, no? */
     def sourcePath          = if (!settings.isScaladoc) cmdLineOrElse("sourcepath", Defaults.scalaSourcePath) else ""
 
-    /** Against my better judgment, giving in to martin here and allowing
-     *  CLASSPATH to be used automatically.  So for the user-specified part
-     *  of the classpath:
-     *
-     *  - If -classpath or -cp is given, it is that
-     *  - Otherwise, if CLASSPATH is set, it is that
-     *  - If neither of those, then "." is used.
-     */
-    def userClassPath =
-      if (!settings.classpath.isDefault) settings.classpath.value
-      else sys.env.getOrElse("CLASSPATH", ".")
+    def userClassPath = settings.classpath.value  // default is specified by settings and can be overridden there
 
     import classPathFactory._
 


### PR DESCRIPTION
Change the classpath URL list in the runner settings to a lazy val.

Also clean up PathResolver's use of settings.classpath so
that the default is defined in one place, namely in settings,
where it can also be overridden.

The previous definition in both places was the same, namely,
`sys.env.getOrElse("CLASSPATH", ".")`, but the history of the
code path is fraught.
