### PR TITLE
use newer Redcarpet to build spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 gem "jekyll", "2.5.3"
 gem "rouge"
 # gem 's3_website'
-gem "redcarpet", "3.2.3"
+gem "redcarpet", "3.3.2"

--- a/spec/README.md
+++ b/spec/README.md
@@ -8,7 +8,7 @@ Third, we'd like to support different output formats. An html page per chapter w
 
 ## Editing
 
-We use redcarpet 3.1 and jekyll 2 to generate the html. Essentially, this is what github pages use.
+We use Jekyll 2 and [Redcarpet](https://github.com/vmg/redcarpet) to generate the html. Essentially, this is what github pages use.
 
 ## Building
 

--- a/spec/_config.yml
+++ b/spec/_config.yml
@@ -6,5 +6,3 @@ markdown: redcarpet
 encoding: utf-8
 redcarpet:
   extensions: ["no_intra_emphasis", "fenced_code_blocks", "autolink", "tables", "with_toc_data", "strikethrough", "lax_spacing", "space_after_headers", "superscript", "footnotes"]
-# with_toc_data requires redcarpet 3.1 to get
-# pretty ID attributes for Hn headers (https://github.com/vmg/redcarpet/pull/186)


### PR DESCRIPTION
now that https://github.com/vmg/redcarpet/issues/494 is fixed
we don't need to stay pinned to an outdated version anymore
