### PR TITLE
SI-9401 Avoid SOE with array + missing classtag

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4577,7 +4577,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           typed1(atPos(tree.pos)(Block(stats, Apply(expr, args) setPos tree.pos.makeTransparent)), mode, pt)
         case Apply(fun, args) =>
           normalTypedApply(tree, fun, args) match {
-            case ArrayInstantiation(tree1)                                           => typed(tree1, mode, pt)
+            case ArrayInstantiation(tree1)                                           => if (tree1.isErrorTyped) tree1 else typed(tree1, mode, pt)
             case Apply(Select(fun, nme.apply), _) if treeInfo.isSuperConstrCall(fun) => TooManyArgumentListsForConstructor(tree) //SI-5696
             case tree1                                                               => tree1
           }

--- a/test/files/neg/t9401.check
+++ b/test/files/neg/t9401.check
@@ -1,0 +1,4 @@
+t9401.scala:3: error: cannot find class tag for element type T
+  gencastarray = new Array[T](0)
+                 ^
+one error found

--- a/test/files/neg/t9401.scala
+++ b/test/files/neg/t9401.scala
@@ -1,0 +1,4 @@
+class Resetting[T] {
+  var gencastarray: Any = null
+  gencastarray = new Array[T](0)
+}


### PR DESCRIPTION
The implicit classtags required by the Array constructor are not
expressed in the type signature of its constructor, and instead
are summoned by a special case in the typechecker.

This special case entails replacing the `new Array` tree with
`implicitly[T].newArray(size)`, handled in `ArrayInstantiation`.
This tree is recursively typechecked.

However, if the implicit materialization/search fails, an error
is issued to the current reporter and the original tree is marked
with an error type. As above, this is recursively typechecked.

In the normal course of affairs, the recursive typecheck of the
erroneous tree would be a noop (the tree already has a type!).

However, if we are both in silent mode (in which errors are buffered)
and in retyping mode (in which the typer clears the type and symbols
of trees), we were getting into an cycle.

In the enclosed test, retyping mode was trying to recover
from:

```
Resetting.this.gencastarray_=(new Array[T](0).<ERROR>)
```

By inserting a suitable a view:

```
implicitly[Resetting => { def gencastarray_=(AT)}](
  Resetting.this
).gencastarray_=(new Array[T](0))
```

Where AT is the type found by retypechecking the argument.
It is during the argument retypechecking that we fell into cycle.

Crazily enough, in 2.11.0, the ensuing `StackOverflowError` was
being caught and treated as a failure. We would then back out of
the retyping mode, and issue the error from the the very first attempt
at the implicit search.

This fragile state of affairs was disrupted by a refactoring to
the error reporting system in 725c5c9, after which the SOE crashed
the compiler.

This commit avoids recursively typechecking error typed trees.
