### PR TITLE
Fix bytecode stability when running the closure optimizer

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/ClosureOptimizer.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/ClosureOptimizer.scala
@@ -70,10 +70,10 @@ class ClosureOptimizer[BT <: BTypes](val btypes: BT) {
       }
     }
 
-    // Group the closure instantiations by method allows running the ProdConsAnalyzer only once per method.
-    // Also sort the instantiations: If there are multiple closure instantiations in a method, closure
-    // invocations need to be re-written in a consistent order for bytecode stability. The local variable
-    // slots for storing captured values depends on the order of rewriting.
+    // Grouping the closure instantiations by method allows running the ProdConsAnalyzer only once per
+    // method. Also sort the instantiations: If there are multiple closure instantiations in a method,
+    // closure invocations need to be re-written in a consistent order for bytecode stability. The local
+    // variable slots for storing captured values depends on the order of rewriting.
     val closureInstantiationsByMethod: Map[MethodNode, immutable.TreeSet[ClosureInstantiation]] = {
       closureInstantiations.values.groupBy(_.ownerMethod).mapValues(immutable.TreeSet.empty ++ _)
     }
@@ -81,13 +81,13 @@ class ClosureOptimizer[BT <: BTypes](val btypes: BT) {
     // For each closure instantiation, a list of callsites of the closure that can be re-written
     // If a callsite cannot be rewritten, for example because the lambda body method is not accessible,
     // a warning is returned instead.
-    val callsitesToRewrite: Map[ClosureInstantiation, List[Either[RewriteClosureApplyToClosureBodyFailed, (MethodInsnNode, Int)]]] = {
-      closureInstantiationsByMethod flatMap {
+    val callsitesToRewrite: List[(ClosureInstantiation, List[Either[RewriteClosureApplyToClosureBodyFailed, (MethodInsnNode, Int)]])] = {
+      closureInstantiationsByMethod.iterator.flatMap({
         case (methodNode, closureInits) =>
           // A lazy val to ensure the analysis only runs if necessary (the value is passed by name to `closureCallsites`)
           lazy val prodCons = new ProdConsAnalyzer(methodNode, closureInits.head.ownerClass.internalName)
-          closureInits.map(init => (init, closureCallsites(init, prodCons)))
-      }
+          closureInits.iterator.map(init => (init, closureCallsites(init, prodCons)))
+      }).toList // mapping to a list (not a map) to keep the sorting of closureInstantiationsByMethod
     }
 
     // Rewrite all closure callsites (or issue inliner warnings for those that cannot be rewritten)


### PR DESCRIPTION
Fixes the stability regression introduced by #4619.

Tested locally with `ant test-stab-opt` (PR validation doesn't test stability).
