### PR TITLE
SI-9409 Scaladoc: remove link to nonexistent diagram doc

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
@@ -676,7 +676,6 @@ class Template(universe: doc.Universe, generator: DiagramGenerator, tpl: DocTemp
             if (diagramSvg != NodeSeq.Empty) {
               <div class="toggleContainer block diagram-container" id={ id + "-container"}>
                 <span class="toggle diagram-link">{ description }</span>
-                <a href="http://docs.scala-lang.org/overviews/scaladoc/usage.html#diagrams" target="_blank" class="diagram-help">Learn more about scaladoc diagrams</a>
                 <div class="diagram" id={ id }>{
                   diagramSvg
                 }</div>


### PR DESCRIPTION
tried to test this locally but ran into problems with dot/graphviz
crashing.  I did check that doing the same edit manually to a sample
page didn't mess up the layout.
