### PR TITLE
Align noTraceSuppression val names to system property name

### DIFF
--- a/src/library/scala/sys/SystemProperties.scala
+++ b/src/library/scala/sys/SystemProperties.scala
@@ -86,6 +86,8 @@ object SystemProperties {
   lazy val headless            = bool("java.awt.headless", "system should not utilize a display device")
   lazy val preferIPv4Stack     = bool("java.net.preferIPv4Stack", "system should prefer IPv4 sockets")
   lazy val preferIPv6Addresses = bool("java.net.preferIPv6Addresses", "system should prefer IPv6 addresses")
-  lazy val noTraceSupression   = bool("scala.control.noTraceSuppression", "scala should not suppress any stack trace creation")
+  lazy val noTraceSuppression  = bool("scala.control.noTraceSuppression", "scala should not suppress any stack trace creation")
+  @deprecated("Use noTraceSuppression", "2.12.0")
+  def noTraceSupression        = noTraceSuppression
 }
 

--- a/src/library/scala/util/control/NoStackTrace.scala
+++ b/src/library/scala/util/control/NoStackTrace.scala
@@ -26,7 +26,7 @@ trait NoStackTrace extends Throwable {
 object NoStackTrace {
   final def noSuppression = _noSuppression
 
-  // two-stage init to make checkinit happy, since sys.SystemProperties.noTraceSupression.value calls back into NoStackTrace.noSuppression
+  // two-stage init to make checkinit happy, since sys.SystemProperties.noTraceSuppression.value calls back into NoStackTrace.noSuppression
   final private var _noSuppression = false
-  _noSuppression = sys.SystemProperties.noTraceSupression.value
+  _noSuppression = sys.SystemProperties.noTraceSuppression.value
 }

--- a/test/disabled/run/applet-prop.scala
+++ b/test/disabled/run/applet-prop.scala
@@ -8,7 +8,7 @@ class S extends javax.swing.JApplet {
 
 object Test extends SecurityTest {
   val s = new S
-  // lazy val TestKey = sys.SystemProperties.noTraceSupression.key
+  // lazy val TestKey = sys.SystemProperties.noTraceSuppression.key
   // def hitPerm() = new Throwable with scala.util.control.ControlThrowable { }
   // 
   // var throwing = false


### PR DESCRIPTION
For vals based on the scala.control.noTraceSuppression system property
align the val name to the property name.
