### PR TITLE
SI-8502 create PackageClass instead of Class symbol stubs for pkgs

### DIFF
--- a/src/intellij/interactive.iml.SAMPLE
+++ b/src/intellij/interactive.iml.SAMPLE
@@ -11,5 +11,6 @@
     <orderEntry type="module" module-name="library" />
     <orderEntry type="module" module-name="reflect" />
     <orderEntry type="library" name="starr" level="project" />
+    <orderEntry type="library" name="asm" level="project" />
   </component>
 </module>

--- a/src/intellij/repl.iml.SAMPLE
+++ b/src/intellij/repl.iml.SAMPLE
@@ -10,6 +10,7 @@
     <orderEntry type="module" module-name="compiler" />
     <orderEntry type="module" module-name="library" />
     <orderEntry type="module" module-name="reflect" />
+    <orderEntry type="module" module-name="interactive" />
     <orderEntry type="library" name="starr" level="project" />
     <orderEntry type="library" name="repl-deps" level="project" />
     <orderEntry type="library" name="asm" level="project" />

--- a/src/intellij/scaladoc.iml.SAMPLE
+++ b/src/intellij/scaladoc.iml.SAMPLE
@@ -14,5 +14,6 @@
     <orderEntry type="library" name="scaladoc-deps" level="project" />
     <orderEntry type="library" name="ant" level="project" />
     <orderEntry type="library" name="partest" level="project" />
+    <orderEntry type="library" name="asm" level="project" />
   </component>
 </module>

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -495,8 +495,8 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
      *  failure to the point when that name is used for something, which is
      *  often to the point of never.
      */
-    def newStubSymbol(name: Name, missingMessage: String): Symbol = name match {
-      case n: TypeName  => new StubClassSymbol(this, n, missingMessage)
+    def newStubSymbol(name: Name, missingMessage: String, isPackage: Boolean = false): Symbol = name match {
+      case n: TypeName  => if (isPackage) new StubPackageClassSymbol(this, n, missingMessage) else new StubClassSymbol(this, n, missingMessage)
       case _            => new StubTermSymbol(this, name.toTermName, missingMessage)
     }
 
@@ -3469,6 +3469,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     override def companionSymbol = fail(NoSymbol)
   }
   class StubClassSymbol(owner0: Symbol, name0: TypeName, val missingMessage: String) extends ClassSymbol(owner0, owner0.pos, name0) with StubSymbol
+  class StubPackageClassSymbol(owner0: Symbol, name0: TypeName, val missingMessage: String) extends PackageClassSymbol(owner0, owner0.pos, name0) with StubSymbol
   class StubTermSymbol(owner0: Symbol, name0: TermName, val missingMessage: String) extends TermSymbol(owner0, owner0.pos, name0) with StubSymbol
 
   trait FreeSymbol extends Symbol {

--- a/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
+++ b/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
@@ -398,7 +398,7 @@ abstract class UnPickler {
         val sym = readSymbolRef() match {
           case stub: StubSymbol if !stub.isClass =>
             // SI-8502 This allows us to create a stub for a unpickled reference to `missingPackage.Foo`.
-            stub.owner.newStubSymbol(stub.name.toTypeName, stub.missingMessage)
+            stub.owner.newStubSymbol(stub.name.toTypeName, stub.missingMessage, isPackage = true)
           case sym => sym
         }
         ThisType(sym)

--- a/test/files/run/t8502b.scala
+++ b/test/files/run/t8502b.scala
@@ -1,0 +1,46 @@
+import scala.tools.partest._
+import java.io.File
+
+// used to crash with an assertion failure in flatten because the type symbol created for the missing
+// package was a ClassSymbol, not a PackageClassSymbol
+//   - isFlattenablePrefix(vanishingPackage) was true (wrongly)
+//   - therefore flatten tried to flatten the class defined in the package, but the class is
+//     top-level, vanishingClass.enclosingTopLevelClass is NoSymbol
+object Test extends StoreReporterDirectTest {
+  def code = ???
+
+  def compileCode(code: String) = {
+    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
+    compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(code)
+  }
+
+  def show(): Unit = {
+    compileCode("""
+      class Outer {
+        class Nested extends vanishing.Vanishing
+      }
+
+      package vanishing {
+        class Vanishing
+      }
+      """)
+    assert(filteredInfos.isEmpty, filteredInfos)
+    deletePackage("vanishing")
+    compileCode("""
+      class Test {
+        def f(o: Outer): Outer = o
+      }
+    """)
+    assert(storeReporter.infos.isEmpty, storeReporter.infos.mkString("\n")) // Included a MissingRequirementError before.
+  }
+
+  def deletePackage(name: String) {
+    val directory = new File(testOutput.path, name)
+    for (f <- directory.listFiles()) {
+      assert(f.getName.endsWith(".class"))
+      assert(f.delete())
+    }
+    assert(directory.listFiles().isEmpty)
+    assert(directory.delete())
+  }
+}


### PR DESCRIPTION
https://github.com/scala/scala/pull/4111 creates a stub type symbol
for missing packages, deferring (or avoiding) a crash if a package
is missing.

The symbol created was a ClassSymbol, which could lead to an assertion
failure in flattten:

```
case TypeRef(pre, sym, args) if isFlattenablePrefix(pre) =>
  assert(args.isEmpty && sym.enclosingTopLevelClass != NoSymbol, sym.ownerChain)
```

`pre` is the stub ClassSymbol, so `isFlattenablePrefix` is true (but
it should be false). The assertion then fails because the enclosing
class of a top-level class defined in a missing package is NoSymbol.

This failed only with GenBCode, which traverses more of the symbol
graph while building ClassBTypes: it looks collects the nested classes
of `Outer` into a `NestedInfo`.
