### PR TITLE
Collection documentation fixes

### DIFF
--- a/src/library/scala/collection/BitSetLike.scala
+++ b/src/library/scala/collection/BitSetLike.scala
@@ -115,7 +115,7 @@ trait BitSetLike[+This <: BitSetLike[This] with SortedSet[Int]] extends SortedSe
       else Iterator.empty.next()
   }
 
-  override def foreach[B](f: Int => B) {
+  override def foreach[U](f: Int => U) {
     /* NOTE: while loops are significantly faster as of 2.11 and
        one major use case of bitsets is performance. Also, there
        is nothing to do when all bits are clear, so use that as

--- a/src/library/scala/collection/GenTraversableLike.scala
+++ b/src/library/scala/collection/GenTraversableLike.scala
@@ -158,20 +158,6 @@ trait GenTraversableLike[+A, +Repr] extends Any with GenTraversableOnce[A] with 
   @migration("The behavior of `scanRight` has changed. The previous behavior can be reproduced with scanRight.reverse.", "2.9.0")
   def scanRight[B, That](z: B)(op: (A, B) => B)(implicit bf: CanBuildFrom[Repr, B, That]): That
 
-  /** Applies a function `f` to all elements of this $coll.
-   *
-   *  @param  f   the function that is applied for its side-effect to every element.
-   *              The result of function `f` is discarded.
-   *
-   *  @tparam  U  the type parameter describing the result of function `f`.
-   *              This result will always be ignored. Typically `U` is `Unit`,
-   *              but this is not necessary.
-   *
-   *  @usecase def foreach(f: A => Unit): Unit
-   *    @inheritdoc
-   */
-  def foreach[U](f: A => U): Unit
-
   /** Builds a new collection by applying a function to all elements of this $coll.
    *
    *  @param f      the function to apply to each element.
@@ -269,16 +255,16 @@ trait GenTraversableLike[+A, +Repr] extends Any with GenTraversableOnce[A] with 
    *    {{{
    *      scala> val a = List(1)
    *      a: List[Int] = List(1)
-   *      
+   *
    *      scala> val b = List(2)
    *      b: List[Int] = List(2)
-   *      
+   *
    *      scala> val c = a ++ b
    *      c: List[Int] = List(1, 2)
-   *      
+   *
    *      scala> val d = List('a')
    *      d: List[Char] = List(a)
-   *      
+   *
    *      scala> val e = c ++ d
    *      e: List[AnyVal] = List(1, 2, a)
    *    }}}

--- a/src/library/scala/collection/GenTraversableOnce.scala
+++ b/src/library/scala/collection/GenTraversableOnce.scala
@@ -49,6 +49,22 @@ import scala.language.higherKinds
  */
 trait GenTraversableOnce[+A] extends Any {
 
+  /** Applies a function `f` to all elements of this $coll.
+   *
+   *  @param  f   the function that is applied for its side-effect to every element.
+   *              The result of function `f` is discarded.
+   *
+   *  @tparam  U  the type parameter describing the result of function `f`.
+   *              This result will always be ignored. Typically `U` is `Unit`,
+   *              but this is not necessary.
+   *
+   *  @usecase def foreach(f: A => Unit): Unit
+   *    @inheritdoc
+   *
+   *    Note: this method underlies the implementation of most other bulk operations.
+   *    It's important to implement this method in an efficient way.
+   *
+   */
   def foreach[U](f: A => U): Unit
 
   def hasDefiniteSize: Boolean

--- a/src/library/scala/collection/GenTraversableOnce.scala
+++ b/src/library/scala/collection/GenTraversableOnce.scala
@@ -110,13 +110,14 @@ trait GenTraversableOnce[+A] extends Any {
    *  binary operator.
    *
    *  $undefinedorder
+   *  $willNotTerminateInf
    *
    *  @tparam A1     a type parameter for the binary operator, a supertype of `A`.
    *  @param z       a neutral element for the fold operation; may be added to the result
    *                 an arbitrary number of times, and must not change the result (e.g., `Nil` for list concatenation,
-   *                 0 for addition, or 1 for multiplication.)
-   *  @param op      a binary operator that must be associative
-   *  @return        the result of applying fold operator `op` between all the elements and `z`
+   *                 0 for addition, or 1 for multiplication).
+   *  @param op      a binary operator that must be associative.
+   *  @return        the result of applying the fold operator `op` between all the elements and `z`, or `z` if this $coll is empty.
    */
   def fold[A1 >: A](z: A1)(op: (A1, A1) => A1): A1
 
@@ -205,6 +206,7 @@ trait GenTraversableOnce[+A] extends Any {
    *             op(...op(z, x_1), x_2, ..., x_n)
    *           }}}
    *           where `x,,1,,, ..., x,,n,,` are the elements of this $coll.
+   *           Returns `z` if this $coll is empty.
    */
   def foldLeft[B](z: B)(op: (B, A) => B): B
 
@@ -222,6 +224,7 @@ trait GenTraversableOnce[+A] extends Any {
    *             op(x_1, op(x_2, ... op(x_n, z)...))
    *           }}}
    *           where `x,,1,,, ..., x,,n,,` are the elements of this $coll.
+   *           Returns `z` if this $coll is empty.
    */
   def foldRight[B](z: B)(op: (A, B) => B): B
 

--- a/src/library/scala/collection/GenTraversableOnce.scala
+++ b/src/library/scala/collection/GenTraversableOnce.scala
@@ -397,7 +397,15 @@ trait GenTraversableOnce[+A] extends Any {
    */
   def minBy[B](f: A => B)(implicit cmp: Ordering[B]): A
 
-  def forall(pred: A => Boolean): Boolean
+  /** Tests whether a predicate holds for all elements of this $coll.
+   *
+   *  $mayNotTerminateInf
+   *
+   *  @param   p     the predicate used to test elements.
+   *  @return        `true` if this $coll is empty or the given predicate `p`
+   *                 holds for all elements of this $coll, otherwise `false`.
+   */
+  def forall(p: A => Boolean): Boolean
 
   /** Tests whether a predicate holds for some of the elements of this $coll.
    *

--- a/src/library/scala/collection/GenTraversableOnce.scala
+++ b/src/library/scala/collection/GenTraversableOnce.scala
@@ -410,11 +410,11 @@ trait GenTraversableOnce[+A] extends Any {
    *  $mayNotTerminateInf
    *  $orderDependent
    *
-   *  @param pred    the predicate used to test elements.
+   *  @param p       the predicate used to test elements.
    *  @return        an option value containing the first element in the $coll
-   *                 that satisfies `p`, or `None` if none exists.
+   *                 for which `p` returns `true`, or `None` if none exists.
    */
-  def find(pred: A => Boolean): Option[A]
+  def find(p: A => Boolean): Option[A]
 
   /** Copies the elements of this $coll to an array.
    *  Fills the given array `xs` with values of this $coll.

--- a/src/library/scala/collection/GenTraversableOnce.scala
+++ b/src/library/scala/collection/GenTraversableOnce.scala
@@ -396,7 +396,14 @@ trait GenTraversableOnce[+A] extends Any {
 
   def forall(pred: A => Boolean): Boolean
 
-  def exists(pred: A => Boolean): Boolean
+  /** Tests whether a predicate holds for some of the elements of this $coll.
+   *
+   *  $mayNotTerminateInf
+   *
+   *  @param   p     the predicate used to test elements.
+   *  @return        `true` if the given predicate `p` returns `true` for at least one element of this $coll, otherwise `false`
+   */
+  def exists(p: A => Boolean): Boolean
 
   /** Finds the first element of the $coll satisfying a predicate, if any.
    *

--- a/src/library/scala/collection/GenTraversableOnce.scala
+++ b/src/library/scala/collection/GenTraversableOnce.scala
@@ -409,13 +409,13 @@ trait GenTraversableOnce[+A] extends Any {
    */
   def find(pred: A => Boolean): Option[A]
 
-  /** Copies values of this $coll to an array.
+  /** Copies the elements of this $coll to an array.
    *  Fills the given array `xs` with values of this $coll.
    *  Copying will stop once either the end of the current $coll is reached,
-   *  or the end of the array is reached.
+   *  or the end of the target array is reached.
    *
    *  @param  xs     the array to fill.
-   *  @tparam B      the type of the elements of the array.
+   *  @tparam B      the type of the elements of the target array.
    *
    *  @usecase def copyToArray(xs: Array[A]): Unit
    *    @inheritdoc
@@ -424,14 +424,14 @@ trait GenTraversableOnce[+A] extends Any {
    */
   def copyToArray[B >: A](xs: Array[B]): Unit
 
-  /** Copies values of this $coll to an array.
+  /** Copies the elements of this $coll to an array.
    *  Fills the given array `xs` with values of this $coll, beginning at index `start`.
    *  Copying will stop once either the end of the current $coll is reached,
-   *  or the end of the array is reached.
+   *  or the end of the target array is reached.
    *
    *  @param  xs     the array to fill.
    *  @param  start  the starting index.
-   *  @tparam B      the type of the elements of the array.
+   *  @tparam B      the type of the elements of the target array.
    *
    *  @usecase def copyToArray(xs: Array[A], start: Int): Unit
    *    @inheritdoc
@@ -440,6 +440,22 @@ trait GenTraversableOnce[+A] extends Any {
    */
   def copyToArray[B >: A](xs: Array[B], start: Int): Unit
 
+  /** Copies the elements of this $coll to an array.
+   *  Fills the given array `xs` with at most `len` elements of
+   *  this $coll, starting at position `start`.
+   *  Copying will stop once either the end of the current $coll is reached,
+   *  or the end of the target array is reached, or `len` elements have been copied.
+   *
+   *  @param  xs     the array to fill.
+   *  @param  start  the starting index.
+   *  @param  len    the maximal number of elements to copy.
+   *  @tparam B      the type of the elements of the target array.
+   *
+   *  @usecase def copyToArray(xs: Array[A], start: Int, len: Int): Unit
+   *    @inheritdoc
+   *
+   *    $willNotTerminateInf
+   */
   def copyToArray[B >: A](xs: Array[B], start: Int, len: Int): Unit
 
   /** Displays all elements of this $coll in a string using start, end, and

--- a/src/library/scala/collection/LinearSeqOptimized.scala
+++ b/src/library/scala/collection/LinearSeqOptimized.scala
@@ -117,20 +117,20 @@ trait LinearSeqOptimized[+A, +Repr <: LinearSeqOptimized[A, Repr]] extends Linea
   }
 
   override /*TraversableLike*/
-  def foldLeft[B](z: B)(f: (B, A) => B): B = {
+  def foldLeft[B](z: B)(op: (B, A) => B): B = {
     var acc = z
     var these = this
     while (!these.isEmpty) {
-      acc = f(acc, these.head)
+      acc = op(acc, these.head)
       these = these.tail
     }
     acc
   }
 
   override /*IterableLike*/
-  def foldRight[B](z: B)(f: (A, B) => B): B =
+  def foldRight[B](z: B)(op: (A, B) => B): B =
     if (this.isEmpty) z
-    else f(head, tail.foldRight(z)(f))
+    else op(head, tail.foldRight(z)(op))
 
   override /*TraversableLike*/
   def reduceLeft[B >: A](f: (B, A) => B): B =

--- a/src/library/scala/collection/LinearSeqOptimized.scala
+++ b/src/library/scala/collection/LinearSeqOptimized.scala
@@ -67,7 +67,7 @@ trait LinearSeqOptimized[+A, +Repr <: LinearSeqOptimized[A, Repr]] extends Linea
   }
 
   override /*IterableLike*/
-  def foreach[B](f: A => B) {
+  def foreach[U](f: A => U) {
     var these = this
     while (!these.isEmpty) {
       f(these.head)

--- a/src/library/scala/collection/MapLike.scala
+++ b/src/library/scala/collection/MapLike.scala
@@ -171,7 +171,7 @@ self =>
     def + (elem: A): Set[A] = (Set[A]() ++ this + elem).asInstanceOf[Set[A]] // !!! concrete overrides abstract problem
     def - (elem: A): Set[A] = (Set[A]() ++ this - elem).asInstanceOf[Set[A]] // !!! concrete overrides abstract problem
     override def size = self.size
-    override def foreach[C](f: A => C) = self.keysIterator foreach f
+    override def foreach[U](f: A => U) = self.keysIterator foreach f
   }
 
   /** Creates an iterator for all keys.
@@ -203,7 +203,7 @@ self =>
   protected class DefaultValuesIterable extends AbstractIterable[B] with Iterable[B] with Serializable {
     def iterator = valuesIterator
     override def size = self.size
-    override def foreach[C](f: B => C) = self.valuesIterator foreach f
+    override def foreach[U](f: B => U) = self.valuesIterator foreach f
   }
 
   /** Creates an iterator for all values in this map.
@@ -228,7 +228,7 @@ self =>
     throw new NoSuchElementException("key not found: " + key)
 
   protected class FilteredKeys(p: A => Boolean) extends AbstractMap[A, B] with DefaultMap[A, B] {
-    override def foreach[C](f: ((A, B)) => C): Unit = for (kv <- self) if (p(kv._1)) f(kv)
+    override def foreach[U](f: ((A, B)) => U): Unit = for (kv <- self) if (p(kv._1)) f(kv)
     def iterator = self.iterator.filter(kv => p(kv._1))
     override def contains(key: A) = self.contains(key) && p(key)
     def get(key: A) = if (!p(key)) None else self.get(key)
@@ -242,7 +242,7 @@ self =>
   def filterKeys(p: A => Boolean): Map[A, B] = new FilteredKeys(p)
 
   protected class MappedValues[C](f: B => C) extends AbstractMap[A, C] with DefaultMap[A, C] {
-    override def foreach[D](g: ((A, C)) => D): Unit = for ((k, v) <- self) g((k, f(v)))
+    override def foreach[U](g: ((A, C)) => U): Unit = for ((k, v) <- self) g((k, f(v)))
     def iterator = for ((k, v) <- self.iterator) yield (k, f(v))
     override def size = self.size
     override def contains(key: A) = self.contains(key)

--- a/src/library/scala/collection/Traversable.scala
+++ b/src/library/scala/collection/Traversable.scala
@@ -38,7 +38,7 @@ trait Traversable[+A] extends TraversableLike[A, Traversable[A]]
   override def remove(p: A => Boolean): Traversable[A]
   override def partition(p: A => Boolean): (Traversable[A], Traversable[A])
   override def groupBy[K](f: A => K): Map[K, Traversable[A]]
-  override def foreach[U](f: A =>  U): Unit
+  override def foreach[U](f: A => U): Unit
   override def forall(p: A => Boolean): Boolean
   override def exists(p: A => Boolean): Boolean
   override def count(p: A => Boolean): Int

--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -366,15 +366,6 @@ trait TraversableLike[+A, +Repr] extends Any
     result
   }
 
-  /** Finds the first element of the $coll satisfying a predicate, if any.
-   *
-   *  $mayNotTerminateInf
-   *  $orderDependent
-   *
-   *  @param p    the predicate used to test elements.
-   *  @return     an option value containing the first element in the $coll
-   *              that satisfies `p`, or `None` if none exists.
-   */
   def find(p: A => Boolean): Option[A] = {
     var result: Option[A] = None
     breakable {

--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -594,23 +594,6 @@ trait TraversableLike[+A, +Repr] extends Any
    */
   def inits: Iterator[Repr] = iterateUntilEmpty(_.init)
 
-  /** Copies elements of this $coll to an array.
-   *  Fills the given array `xs` with at most `len` elements of
-   *  this $coll, starting at position `start`.
-   *  Copying will stop once either the end of the current $coll is reached,
-   *  or the end of the array is reached, or `len` elements have been copied.
-   *
-   *  @param  xs     the array to fill.
-   *  @param  start  the starting index.
-   *  @param  len    the maximal number of elements to copy.
-   *  @tparam B      the type of the elements of the array.
-   *
-   *
-   *  @usecase def copyToArray(xs: Array[A], start: Int, len: Int): Unit
-   *    @inheritdoc
-   *
-   *    $willNotTerminateInf
-   */
   def copyToArray[B >: A](xs: Array[B], start: Int, len: Int) {
     var i = start
     val end = (start + len) min xs.length
@@ -625,7 +608,7 @@ trait TraversableLike[+A, +Repr] extends Any
 
   @deprecatedOverriding("Enforce contract of toTraversable that if it is Traversable it returns itself.", "2.11.0")
   def toTraversable: Traversable[A] = thisCollection
-  
+
   def toIterator: Iterator[A] = toStream.iterator
   def toStream: Stream[A] = toBuffer.toStream
   // Override to provide size hint.

--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -357,14 +357,6 @@ trait TraversableLike[+A, +Repr] extends Any
     result
   }
 
-  /** Tests whether a predicate holds for some of the elements of this $coll.
-   *
-   *  $mayNotTerminateInf
-   *
-   *  @param   p     the predicate used to test elements.
-   *  @return        `false` if this $coll is empty, otherwise `true` if the given predicate `p`
-    *                holds for some of the elements of this $coll, otherwise `false`
-   */
   def exists(p: A => Boolean): Boolean = {
     var result = false
     breakable {

--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -340,14 +340,6 @@ trait TraversableLike[+A, +Repr] extends Any
     b.result
   }
 
-  /** Tests whether a predicate holds for all elements of this $coll.
-   *
-   *  $mayNotTerminateInf
-   *
-   *  @param   p     the predicate used to test elements.
-   *  @return        `true`  if this $coll is empty, otherwise `true` if the given predicate `p`
-    *                holds for all elements of this $coll, otherwise `false`.
-   */
   def forall(p: A => Boolean): Boolean = {
     var result = true
     breakable {

--- a/src/library/scala/collection/TraversableOnce.scala
+++ b/src/library/scala/collection/TraversableOnce.scala
@@ -61,7 +61,8 @@ import scala.reflect.ClassTag
 trait TraversableOnce[+A] extends Any with GenTraversableOnce[A] {
   self =>
 
-  /** Self-documenting abstract methods. */
+  /* Self-documenting abstract methods. */
+
   def foreach[U](f: A => U): Unit
   def isEmpty: Boolean
   def hasDefiniteSize: Boolean
@@ -334,10 +335,10 @@ trait TraversableOnce[+A] extends Any with GenTraversableOnce[A] {
    * {{{
    *      scala> val a = List(1,2,3,4)
    *      a: List[Int] = List(1, 2, 3, 4)
-   *      
+   *
    *      scala> val b = new StringBuilder()
-   *      b: StringBuilder = 
-   *      
+   *      b: StringBuilder =
+   *
    *      scala> a.addString(b , "List(" , ", " , ")")
    *      res5: StringBuilder = List(1, 2, 3, 4)
    * }}}
@@ -376,7 +377,7 @@ trait TraversableOnce[+A] extends Any with GenTraversableOnce[A] {
    * {{{
    *      scala> val a = List(1,2,3,4)
    *      a: List[Int] = List(1, 2, 3, 4)
-   *      
+   *
    *      scala> val b = new StringBuilder()
    *      b: StringBuilder =
    *
@@ -399,7 +400,7 @@ trait TraversableOnce[+A] extends Any with GenTraversableOnce[A] {
    * {{{
    *      scala> val a = List(1,2,3,4)
    *      a: List[Int] = List(1, 2, 3, 4)
-   *      
+   *
    *      scala> val b = new StringBuilder()
    *      b: StringBuilder =
    *

--- a/src/library/scala/collection/TraversableProxyLike.scala
+++ b/src/library/scala/collection/TraversableProxyLike.scala
@@ -28,7 +28,7 @@ import scala.reflect.ClassTag
 trait TraversableProxyLike[+A, +Repr <: TraversableLike[A, Repr] with Traversable[A]] extends TraversableLike[A, Repr] with Proxy {
   def self: Repr
 
-  override def foreach[B](f: A => B): Unit = self.foreach(f)
+  override def foreach[U](f: A => U): Unit = self.foreach(f)
   override def isEmpty: Boolean = self.isEmpty
   override def nonEmpty: Boolean = self.nonEmpty
   override def size: Int = self.size

--- a/src/library/scala/collection/generic/TraversableForwarder.scala
+++ b/src/library/scala/collection/generic/TraversableForwarder.scala
@@ -32,7 +32,7 @@ trait TraversableForwarder[+A] extends Traversable[A] {
   /** The traversable object to which calls are forwarded. */
   protected def underlying: Traversable[A]
 
-  override def foreach[B](f: A => B): Unit = underlying foreach f
+  override def foreach[U](f: A => U): Unit = underlying foreach f
   override def isEmpty: Boolean = underlying.isEmpty
   override def nonEmpty: Boolean = underlying.nonEmpty
   override def size: Int = underlying.size

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -48,7 +48,7 @@ class HashMap[A, +B] extends AbstractMap[A, B]
 
   def iterator: Iterator[(A,B)] = Iterator.empty
 
-  override def foreach[U](f: ((A, B)) =>  U): Unit = { }
+  override def foreach[U](f: ((A, B)) => U): Unit = { }
 
   def get(key: A): Option[B] =
     get0(key, computeHash(key), 0)
@@ -422,7 +422,7 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
       final override def getElem(cc: AnyRef): (A, B) = cc.asInstanceOf[HashMap1[A, B]].ensurePair
     }
 
-    override def foreach[U](f: ((A, B)) =>  U): Unit = {
+    override def foreach[U](f: ((A, B)) => U): Unit = {
       var i = 0
       while (i < elems.length) {
         elems(i).foreach(f)

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -53,7 +53,7 @@ class HashSet[A] extends AbstractSet[A]
 
   def iterator: Iterator[A] = Iterator.empty
 
-  override def foreach[U](f: A =>  U): Unit = { }
+  override def foreach[U](f: A => U): Unit = { }
 
   def contains(e: A): Boolean = get0(e, computeHash(e), 0)
 
@@ -163,7 +163,7 @@ class HashSet[A] extends AbstractSet[A]
     nullToEmpty(removed0(e, computeHash(e), 0))
 
   /** Returns this $coll as an immutable set.
-   *  
+   *
    *  A new set will not be built; lazy collections will stay lazy.
    */
   @deprecatedOverriding("Immutable sets should do nothing on toSet but return themselves cast as a Set.", "2.11.0")
@@ -221,7 +221,7 @@ object HashSet extends ImmutableSetFactory[HashSet] {
 
   private object EmptyHashSet extends HashSet[Any] { }
   private[collection] def emptyInstance: HashSet[Any] = EmptyHashSet
-  
+
   // utility method to create a HashTrieSet from two leaf HashSets (HashSet1 or HashSetCollision1) with non-colliding hash code)
   private def makeHashTrieSet[A](hash0:Int, elem0:HashSet[A], hash1:Int, elem1:HashSet[A], level:Int) : HashTrieSet[A] = {
     val index0 = (hash0 >>> level) & 0x1f
@@ -972,7 +972,7 @@ object HashSet extends ImmutableSetFactory[HashSet] {
       final override def getElem(cc: AnyRef): A = cc.asInstanceOf[HashSet1[A]].key
     }
 
-    override def foreach[U](f: A =>  U): Unit = {
+    override def foreach[U](f: A => U): Unit = {
       var i = 0
       while (i < elems.length) {
         elems(i).foreach(f)

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -112,7 +112,7 @@ object Map extends ImmutableMapFactory[Map] {
     def + [B1 >: B](kv: (A, B1)): Map[A, B1] = updated(kv._1, kv._2)
     def - (key: A): Map[A, B] =
       if (key == key1) Map.empty else this
-    override def foreach[U](f: ((A, B)) =>  U): Unit = {
+    override def foreach[U](f: ((A, B)) => U): Unit = {
       f((key1, value1))
     }
   }
@@ -133,7 +133,7 @@ object Map extends ImmutableMapFactory[Map] {
       if (key == key1) new Map1(key2, value2)
       else if (key == key2) new Map1(key1, value1)
       else this
-    override def foreach[U](f: ((A, B)) =>  U): Unit = {
+    override def foreach[U](f: ((A, B)) => U): Unit = {
       f((key1, value1)); f((key2, value2))
     }
   }
@@ -157,7 +157,7 @@ object Map extends ImmutableMapFactory[Map] {
       else if (key == key2) new Map2(key1, value1, key3, value3)
       else if (key == key3) new Map2(key1, value1, key2, value2)
       else this
-    override def foreach[U](f: ((A, B)) =>  U): Unit = {
+    override def foreach[U](f: ((A, B)) => U): Unit = {
       f((key1, value1)); f((key2, value2)); f((key3, value3))
     }
   }
@@ -184,7 +184,7 @@ object Map extends ImmutableMapFactory[Map] {
       else if (key == key3) new Map3(key1, value1, key2, value2, key4, value4)
       else if (key == key4) new Map3(key1, value1, key2, value2, key3, value3)
       else this
-    override def foreach[U](f: ((A, B)) =>  U): Unit = {
+    override def foreach[U](f: ((A, B)) => U): Unit = {
       f((key1, value1)); f((key2, value2)); f((key3, value3)); f((key4, value4))
     }
   }

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -81,8 +81,8 @@ object Set extends ImmutableSetFactory[Set] {
     override def exists(p: A => Boolean): Boolean = {
       p(elem1)
     }
-    override def forall(f: A => Boolean): Boolean = {
-      f(elem1)
+    override def forall(p: A => Boolean): Boolean = {
+      p(elem1)
     }
     override def find(p: A => Boolean): Option[A] = {
       if (p(elem1)) Some(elem1)
@@ -113,8 +113,8 @@ object Set extends ImmutableSetFactory[Set] {
     override def exists(p: A => Boolean): Boolean = {
       p(elem1) || p(elem2)
     }
-    override def forall(f: A => Boolean): Boolean = {
-      f(elem1) && f(elem2)
+    override def forall(p: A => Boolean): Boolean = {
+      p(elem1) && p(elem2)
     }
     override def find(p: A => Boolean): Option[A] = {
       if (p(elem1)) Some(elem1)
@@ -147,8 +147,8 @@ object Set extends ImmutableSetFactory[Set] {
     override def exists(p: A => Boolean): Boolean = {
       p(elem1) || p(elem2) || p(elem3)
     }
-    override def forall(f: A => Boolean): Boolean = {
-      f(elem1) && f(elem2) && f(elem3)
+    override def forall(p: A => Boolean): Boolean = {
+      p(elem1) && p(elem2) && p(elem3)
     }
     override def find(p: A => Boolean): Option[A] = {
       if (p(elem1)) Some(elem1)
@@ -183,8 +183,8 @@ object Set extends ImmutableSetFactory[Set] {
     override def exists(p: A => Boolean): Boolean = {
       p(elem1) || p(elem2) || p(elem3) || p(elem4)
     }
-    override def forall(f: A => Boolean): Boolean = {
-      f(elem1) && f(elem2) && f(elem3) && f(elem4)
+    override def forall(p: A => Boolean): Boolean = {
+      p(elem1) && p(elem2) && p(elem3) && p(elem4)
     }
     override def find(p: A => Boolean): Option[A] = {
       if (p(elem1)) Some(elem1)

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -84,8 +84,8 @@ object Set extends ImmutableSetFactory[Set] {
     override def forall(f: A => Boolean): Boolean = {
       f(elem1)
     }
-    override def find(f: A => Boolean): Option[A] = {
-      if (f(elem1)) Some(elem1)
+    override def find(p: A => Boolean): Option[A] = {
+      if (p(elem1)) Some(elem1)
       else None
     }
     @deprecatedOverriding("Immutable sets should do nothing on toSet but return themselves cast as a Set.", "2.11.0")
@@ -116,9 +116,9 @@ object Set extends ImmutableSetFactory[Set] {
     override def forall(f: A => Boolean): Boolean = {
       f(elem1) && f(elem2)
     }
-    override def find(f: A => Boolean): Option[A] = {
-      if (f(elem1)) Some(elem1)
-      else if (f(elem2)) Some(elem2)
+    override def find(p: A => Boolean): Option[A] = {
+      if (p(elem1)) Some(elem1)
+      else if (p(elem2)) Some(elem2)
       else None
     }
     @deprecatedOverriding("Immutable sets should do nothing on toSet but return themselves cast as a Set.", "2.11.0")
@@ -150,10 +150,10 @@ object Set extends ImmutableSetFactory[Set] {
     override def forall(f: A => Boolean): Boolean = {
       f(elem1) && f(elem2) && f(elem3)
     }
-    override def find(f: A => Boolean): Option[A] = {
-      if (f(elem1)) Some(elem1)
-      else if (f(elem2)) Some(elem2)
-      else if (f(elem3)) Some(elem3)
+    override def find(p: A => Boolean): Option[A] = {
+      if (p(elem1)) Some(elem1)
+      else if (p(elem2)) Some(elem2)
+      else if (p(elem3)) Some(elem3)
       else None
     }
     @deprecatedOverriding("Immutable sets should do nothing on toSet but return themselves cast as a Set.", "2.11.0")
@@ -186,11 +186,11 @@ object Set extends ImmutableSetFactory[Set] {
     override def forall(f: A => Boolean): Boolean = {
       f(elem1) && f(elem2) && f(elem3) && f(elem4)
     }
-    override def find(f: A => Boolean): Option[A] = {
-      if (f(elem1)) Some(elem1)
-      else if (f(elem2)) Some(elem2)
-      else if (f(elem3)) Some(elem3)
-      else if (f(elem4)) Some(elem4)
+    override def find(p: A => Boolean): Option[A] = {
+      if (p(elem1)) Some(elem1)
+      else if (p(elem2)) Some(elem2)
+      else if (p(elem3)) Some(elem3)
+      else if (p(elem4)) Some(elem4)
       else None
     }
     @deprecatedOverriding("Immutable sets should do nothing on toSet but return themselves cast as a Set.", "2.11.0")

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -56,7 +56,7 @@ object Set extends ImmutableSetFactory[Set] {
     def + (elem: Any): Set[Any] = new Set1(elem)
     def - (elem: Any): Set[Any] = this
     def iterator: Iterator[Any] = Iterator.empty
-    override def foreach[U](f: Any =>  U): Unit = {}
+    override def foreach[U](f: Any => U): Unit = {}
     override def toSet[B >: Any]: Set[B] = this.asInstanceOf[Set[B]]
   }
   private[collection] def emptyInstance: Set[Any] = EmptySet
@@ -75,7 +75,7 @@ object Set extends ImmutableSetFactory[Set] {
       else this
     def iterator: Iterator[A] =
       Iterator(elem1)
-    override def foreach[U](f: A =>  U): Unit = {
+    override def foreach[U](f: A => U): Unit = {
       f(elem1)
     }
     override def exists(p: A => Boolean): Boolean = {
@@ -107,7 +107,7 @@ object Set extends ImmutableSetFactory[Set] {
       else this
     def iterator: Iterator[A] =
       Iterator(elem1, elem2)
-    override def foreach[U](f: A =>  U): Unit = {
+    override def foreach[U](f: A => U): Unit = {
       f(elem1); f(elem2)
     }
     override def exists(p: A => Boolean): Boolean = {
@@ -141,7 +141,7 @@ object Set extends ImmutableSetFactory[Set] {
       else this
     def iterator: Iterator[A] =
       Iterator(elem1, elem2, elem3)
-    override def foreach[U](f: A =>  U): Unit = {
+    override def foreach[U](f: A => U): Unit = {
       f(elem1); f(elem2); f(elem3)
     }
     override def exists(p: A => Boolean): Boolean = {
@@ -177,7 +177,7 @@ object Set extends ImmutableSetFactory[Set] {
       else this
     def iterator: Iterator[A] =
       Iterator(elem1, elem2, elem3, elem4)
-    override def foreach[U](f: A =>  U): Unit = {
+    override def foreach[U](f: A => U): Unit = {
       f(elem1); f(elem2); f(elem3); f(elem4)
     }
     override def exists(p: A => Boolean): Boolean = {

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -33,10 +33,10 @@ trait Set[A] extends Iterable[A]
                 with Parallelizable[A, ParSet[A]]
 {
   override def companion: GenericCompanion[Set] = Set
-  
-  
+
+
   override def toSet[B >: A]: Set[B] = to[({type l[a] = immutable.Set[B]})#l] // for bincompat; remove in dev
-  
+
   override def seq: Set[A] = this
   protected override def parCombiner = ParSet.newCombiner[A] // if `immutable.SetLike` gets introduced, please move this there!
 }
@@ -48,7 +48,7 @@ trait Set[A] extends Iterable[A]
 object Set extends ImmutableSetFactory[Set] {
   /** $setCanBuildFromInfo */
   implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Set[A]] = setCanBuildFrom[A]
-  
+
   /** An optimized representation for immutable empty sets */
   private object EmptySet extends AbstractSet[Any] with Set[Any] with Serializable {
     override def size: Int = 0
@@ -78,8 +78,8 @@ object Set extends ImmutableSetFactory[Set] {
     override def foreach[U](f: A =>  U): Unit = {
       f(elem1)
     }
-    override def exists(f: A => Boolean): Boolean = {
-      f(elem1)
+    override def exists(p: A => Boolean): Boolean = {
+      p(elem1)
     }
     override def forall(f: A => Boolean): Boolean = {
       f(elem1)
@@ -110,8 +110,8 @@ object Set extends ImmutableSetFactory[Set] {
     override def foreach[U](f: A =>  U): Unit = {
       f(elem1); f(elem2)
     }
-    override def exists(f: A => Boolean): Boolean = {
-      f(elem1) || f(elem2)
+    override def exists(p: A => Boolean): Boolean = {
+      p(elem1) || p(elem2)
     }
     override def forall(f: A => Boolean): Boolean = {
       f(elem1) && f(elem2)
@@ -144,8 +144,8 @@ object Set extends ImmutableSetFactory[Set] {
     override def foreach[U](f: A =>  U): Unit = {
       f(elem1); f(elem2); f(elem3)
     }
-    override def exists(f: A => Boolean): Boolean = {
-      f(elem1) || f(elem2) || f(elem3)
+    override def exists(p: A => Boolean): Boolean = {
+      p(elem1) || p(elem2) || p(elem3)
     }
     override def forall(f: A => Boolean): Boolean = {
       f(elem1) && f(elem2) && f(elem3)
@@ -180,8 +180,8 @@ object Set extends ImmutableSetFactory[Set] {
     override def foreach[U](f: A =>  U): Unit = {
       f(elem1); f(elem2); f(elem3); f(elem4)
     }
-    override def exists(f: A => Boolean): Boolean = {
-      f(elem1) || f(elem2) || f(elem3) || f(elem4)
+    override def exists(p: A => Boolean): Boolean = {
+      p(elem1) || p(elem2) || p(elem3) || p(elem4)
     }
     override def forall(f: A => Boolean): Boolean = {
       f(elem1) && f(elem2) && f(elem3) && f(elem4)

--- a/src/library/scala/collection/immutable/Stream.scala
+++ b/src/library/scala/collection/immutable/Stream.scala
@@ -176,9 +176,9 @@ import scala.language.implicitConversions
  *    loop(1, 1)
  *  }
  *  }}}
- * 
+ *
  *  Note that `mkString` forces evaluation of a `Stream`, but `addString` does
- *  not.  In both cases, a `Stream` that is or ends in a cycle 
+ *  not.  In both cases, a `Stream` that is or ends in a cycle
  *  (e.g. `lazy val s: Stream[Int] = 0 #:: s`) will convert additional trips
  *  through the cycle to `...`.  Additionally, `addString` will display an
  *  un-memoized tail as `?`.
@@ -566,7 +566,7 @@ self =>
       else super.flatMap(f)(bf)
     }
 
-    override def foreach[B](f: A => B) =
+    override def foreach[U](f: A => U) =
       for (x <- self)
         if (p(x)) f(x)
 
@@ -589,7 +589,7 @@ self =>
    *  unless the `f` throws an exception.
    */
   @tailrec
-  override final def foreach[B](f: A => B) {
+  override final def foreach[U](f: A => U) {
     if (!this.isEmpty) {
       f(head)
       tail.foreach(f)

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -151,7 +151,7 @@ class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: Orderin
   def iterator: Iterator[A] = RB.keysIterator(tree)
   override def keysIteratorFrom(start: A): Iterator[A] = RB.keysIterator(tree, Some(start))
 
-  override def foreach[U](f: A =>  U) = RB.foreachKey(tree, f)
+  override def foreach[U](f: A => U) = RB.foreachKey(tree, f)
 
   override def rangeImpl(from: Option[A], until: Option[A]): TreeSet[A] = newSet(RB.rangeImpl(tree, from, until))
   override def range(from: A, until: A): TreeSet[A] = newSet(RB.range(tree, from, until))

--- a/src/library/scala/collection/mutable/AnyRefMap.scala
+++ b/src/library/scala/collection/mutable/AnyRefMap.scala
@@ -5,23 +5,23 @@ package mutable
 import generic.CanBuildFrom
 
 /** This class implements mutable maps with `AnyRef` keys based on a hash table with open addressing.
- * 
- *  Basic map operations on single entries, including `contains` and `get`, 
+ *
+ *  Basic map operations on single entries, including `contains` and `get`,
  *  are typically significantly faster with `AnyRefMap` than [[HashMap]].
  *  Note that numbers and characters are not handled specially in AnyRefMap;
  *  only plain `equals` and `hashCode` are used in comparisons.
- * 
+ *
  *  Methods that traverse or regenerate the map, including `foreach` and `map`,
  *  are not in general faster than with `HashMap`.  The methods `foreachKey`,
  *  `foreachValue`, `mapValuesNow`, and `transformValues` are, however, faster
  *  than alternative ways to achieve the same functionality.
- * 
+ *
  *  Maps with open addressing may become less efficient at lookup after
  *  repeated addition/removal of elements.  Although `AnyRefMap` makes a
  *  decent attempt to remain efficient regardless,  calling `repack`
  *  on a map that will no longer have elements removed but will be
  *  used heavily may save both time and storage space.
- * 
+ *
  *  This map is not intended to contain more than 2^29^ entries (approximately
  *  500 million).  The maximum capacity is 2^30^, but performance will degrade
  *  rapidly as 2^30^ is approached.
@@ -34,50 +34,50 @@ extends AbstractMap[K, V]
 {
   import AnyRefMap._
   def this() = this(AnyRefMap.exceptionDefault, 16, true)
-  
+
   /** Creates a new `AnyRefMap` that returns default values according to a supplied key-value mapping. */
   def this(defaultEntry: K => V) = this(defaultEntry, 16, true)
 
   /** Creates a new `AnyRefMap` with an initial buffer of specified size.
-   * 
+   *
    *  An `AnyRefMap` can typically contain half as many elements as its buffer size
    *  before it requires resizing.
    */
   def this(initialBufferSize: Int) = this(AnyRefMap.exceptionDefault, initialBufferSize, true)
-  
+
   /** Creates a new `AnyRefMap` with specified default values and initial buffer size. */
   def this(defaultEntry: K => V, initialBufferSize: Int) = this(defaultEntry, initialBufferSize, true)
-  
+
   private[this] var mask = 0
   private[this] var _size = 0
   private[this] var _vacant = 0
   private[this] var _hashes: Array[Int] = null
   private[this] var _keys: Array[AnyRef] = null
   private[this] var _values: Array[AnyRef] = null
-    
+
   if (initBlank) defaultInitialize(initialBufferSize)
-  
+
   private[this] def defaultInitialize(n: Int) {
-    mask = 
+    mask =
       if (n<0) 0x7
       else (((1 << (32 - java.lang.Integer.numberOfLeadingZeros(n-1))) - 1) & 0x3FFFFFFF) | 0x7
     _hashes = new Array[Int](mask+1)
     _keys = new Array[AnyRef](mask+1)
     _values = new Array[AnyRef](mask+1)
   }
-  
+
   private[collection] def initializeTo(
     m: Int, sz: Int, vc: Int, hz: Array[Int], kz: Array[AnyRef], vz: Array[AnyRef]
   ) {
     mask = m; _size = sz; _vacant = vc; _hashes = hz; _keys = kz; _values = vz
   }
-  
+
   override def size: Int = _size
   override def empty: AnyRefMap[K,V] = new AnyRefMap(defaultEntry)
-  
-  private def imbalanced: Boolean = 
+
+  private def imbalanced: Boolean =
     (_size + _vacant) > 0.5*mask || _vacant > _size
-  
+
   private def hashOf(key: K): Int = {
     if (key eq null) 0x41081989
     else {
@@ -88,7 +88,7 @@ extends AbstractMap[K, V]
       if (j==0) 0x41081989 else j & 0x7FFFFFFF
     }
   }
-  
+
   private def seekEntry(h: Int, k: AnyRef): Int = {
     var e = h & mask
     var x = 0
@@ -100,7 +100,7 @@ extends AbstractMap[K, V]
     }
     e | MissingBit
   }
-  
+
   private def seekEntryOrOpen(h: Int, k: AnyRef): Int = {
     var e = h & mask
     var x = 0
@@ -114,19 +114,19 @@ extends AbstractMap[K, V]
     }
     if (o >= 0) o | MissVacant else e | MissingBit
   }
-  
+
   override def contains(key: K): Boolean = seekEntry(hashOf(key), key) >= 0
-  
+
   override def get(key: K): Option[V] = {
     val i = seekEntry(hashOf(key), key)
     if (i < 0) None else Some(_values(i).asInstanceOf[V])
   }
-  
+
   override def getOrElse[V1 >: V](key: K, default: => V1): V1 = {
     val i = seekEntry(hashOf(key), key)
     if (i < 0) default else _values(i).asInstanceOf[V]
   }
-  
+
   override def getOrElseUpdate(key: K, defaultValue: => V): V = {
     val h = hashOf(key)
     var i = seekEntryOrOpen(h, key)
@@ -154,10 +154,10 @@ extends AbstractMap[K, V]
     }
     else _values(i).asInstanceOf[V]
   }
-  
+
   /** Retrieves the value associated with a key, or the default for that type if none exists
    *  (null for AnyRef, 0 for floats and integers).
-   * 
+   *
    *  Note: this is the fastest way to retrieve a value that may or
    *  may not exist, if the default null/zero is acceptable.  For key/value
    *  pairs that do exist, `apply` (i.e. `map(key)`) is equally fast.
@@ -166,22 +166,22 @@ extends AbstractMap[K, V]
     val i = seekEntry(hashOf(key), key)
     (if (i < 0) null else _values(i)).asInstanceOf[V]
   }
-  
-  /** Retrieves the value associated with a key. 
+
+  /** Retrieves the value associated with a key.
    *  If the key does not exist in the map, the `defaultEntry` for that key
-   *  will be returned instead; an exception will be thrown if no 
+   *  will be returned instead; an exception will be thrown if no
    *  `defaultEntry` was supplied.
    */
   override def apply(key: K): V = {
     val i = seekEntry(hashOf(key), key)
     if (i < 0) defaultEntry(key) else _values(i).asInstanceOf[V]
   }
-  
+
   /** Defers to defaultEntry to find a default value for the key.  Throws an
    *  exception if no other default behavior was specified.
    */
   override def default(key: K) = defaultEntry(key)
-  
+
   private def repack(newMask: Int) {
     val oh = _hashes
     val ok = _keys
@@ -205,9 +205,9 @@ extends AbstractMap[K, V]
       i += 1
     }
   }
-  
+
   /** Repacks the contents of this `AnyRefMap` for maximum efficiency of lookup.
-   * 
+   *
    *  For maps that undergo a complex creation process with both addition and
    *  removal of keys, and then are used heavily with no further removal of
    *  elements, calling `repack` after the end of the creation can result in
@@ -220,7 +220,7 @@ extends AbstractMap[K, V]
     while (m > 8 && 8*_size < m) m = m >>> 1
     repack(m)
   }
-  
+
   override def put(key: K, value: V): Option[V] = {
     val h = hashOf(key)
     val k = key
@@ -243,9 +243,9 @@ extends AbstractMap[K, V]
       ans
     }
   }
-  
+
   /** Updates the map to include a new key-value pair.
-   * 
+   *
    *  This is the fastest way to add an entry to an `AnyRefMap`.
    */
   override def update(key: K, value: V): Unit = {
@@ -267,12 +267,12 @@ extends AbstractMap[K, V]
       _values(i) = value.asInstanceOf[AnyRef]
     }
   }
-  
+
   /** Adds a new key/value pair to this map and returns the map. */
   def +=(key: K, value: V): this.type = { update(key, value); this }
 
   def +=(kv: (K, V)): this.type = { update(kv._1, kv._2); this }
-  
+
   def -=(key: K): this.type = {
     val i = seekEntry(hashOf(key), key)
     if (i >= 0) {
@@ -284,14 +284,14 @@ extends AbstractMap[K, V]
     }
     this
   }
-  
+
   def iterator: Iterator[(K, V)] = new Iterator[(K, V)] {
     private[this] val hz = _hashes
     private[this] val kz = _keys
     private[this] val vz = _values
-    
+
     private[this] var index = 0
-    
+
     def hasNext: Boolean = index<hz.length && {
       var h = hz(index)
       while (h+h == 0) {
@@ -301,7 +301,7 @@ extends AbstractMap[K, V]
       }
       true
     }
-    
+
     def next: (K, V) = {
       if (hasNext) {
         val ans = (kz(index).asInstanceOf[K], vz(index).asInstanceOf[V])
@@ -311,8 +311,8 @@ extends AbstractMap[K, V]
       else throw new NoSuchElementException("next")
     }
   }
-  
-  override def foreach[A](f: ((K,V)) => A) {
+
+  override def foreach[U](f: ((K,V)) => U) {
     var i = 0
     var e = _size
     while (e > 0) {
@@ -325,7 +325,7 @@ extends AbstractMap[K, V]
       else return
     }
   }
-    
+
   override def clone(): AnyRefMap[K, V] = {
     val hz = java.util.Arrays.copyOf(_hashes, _hashes.length)
     val kz = java.util.Arrays.copyOf(_keys, _keys.length)
@@ -334,7 +334,7 @@ extends AbstractMap[K, V]
     arm.initializeTo(mask, _size, _vacant, hz, kz,  vz)
     arm
   }
-  
+
   private[this] def foreachElement[A,B](elems: Array[AnyRef], f: A => B) {
     var i,j = 0
     while (i < _hashes.length & j < _size) {
@@ -346,13 +346,13 @@ extends AbstractMap[K, V]
       i += 1
     }
   }
-  
+
   /** Applies a function to all keys of this map. */
   def foreachKey[A](f: K => A) { foreachElement[K,A](_keys, f) }
 
   /** Applies a function to all values of this map. */
   def foreachValue[A](f: V => A) { foreachElement[V,A](_values, f) }
-  
+
   /** Creates a new `AnyRefMap` with different values.
    *  Unlike `mapValues`, this method generates a new
    *  collection immediately.
@@ -374,8 +374,8 @@ extends AbstractMap[K, V]
     arm.initializeTo(mask, _size, _vacant, hz, kz, vz)
     arm
   }
-  
-  /** Applies a transformation function to all values stored in this map. 
+
+  /** Applies a transformation function to all values stored in this map.
    *  Note: the default, if any,  is not transformed.
    */
   def transformValues(f: V => V): this.type = {
@@ -398,15 +398,15 @@ object AnyRefMap {
   private final val MissingBit = 0x80000000
   private final val VacantBit  = 0x40000000
   private final val MissVacant = 0xC0000000
-  
+
   private val exceptionDefault = (k: Any) => throw new NoSuchElementException(if (k == null) "(null)" else k.toString)
-  
+
   implicit def canBuildFrom[K <: AnyRef, V, J <: AnyRef, U]: CanBuildFrom[AnyRefMap[K,V], (J, U), AnyRefMap[J,U]] =
     new CanBuildFrom[AnyRefMap[K,V], (J, U), AnyRefMap[J,U]] {
       def apply(from: AnyRefMap[K,V]): AnyRefMapBuilder[J, U] = apply()
       def apply(): AnyRefMapBuilder[J, U] = new AnyRefMapBuilder[J, U]
     }
-  
+
   final class AnyRefMapBuilder[K <: AnyRef, V] extends Builder[(K, V), AnyRefMap[K, V]] {
     private[collection] var elems: AnyRefMap[K, V] = new AnyRefMap[K, V]
     def +=(entry: (K, V)): this.type = {
@@ -425,14 +425,14 @@ object AnyRefMap {
     if (arm.size < (sz>>3)) arm.repack()
     arm
   }
-  
+
   /** Creates a new empty `AnyRefMap`. */
   def empty[K <: AnyRef, V]: AnyRefMap[K, V] = new AnyRefMap[K, V]
-  
+
   /** Creates a new empty `AnyRefMap` with the supplied default */
   def withDefault[K <: AnyRef, V](default: K => V): AnyRefMap[K, V] = new AnyRefMap[K, V](default)
-  
-  /** Creates a new `AnyRefMap` from arrays of keys and values. 
+
+  /** Creates a new `AnyRefMap` from arrays of keys and values.
    *  Equivalent to but more efficient than `AnyRefMap((keys zip values): _*)`.
    */
   def fromZip[K <: AnyRef, V](keys: Array[K], values: Array[V]): AnyRefMap[K, V] = {
@@ -443,8 +443,8 @@ object AnyRefMap {
     if (arm.size < (sz>>3)) arm.repack()
     arm
   }
-  
-  /** Creates a new `AnyRefMap` from keys and values. 
+
+  /** Creates a new `AnyRefMap` from keys and values.
    *  Equivalent to but more efficient than `AnyRefMap((keys zip values): _*)`.
    */
   def fromZip[K <: AnyRef, V](keys: Iterable[K], values: Iterable[V]): AnyRefMap[K, V] = {

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -68,7 +68,7 @@ extends AbstractSeq[A]
     array(idx) = elem.asInstanceOf[AnyRef]
   }
 
-  override def foreach[U](f: A =>  U) {
+  override def foreach[U](f: A => U) {
     var i = 0
     while (i < length) {
       f(array(i).asInstanceOf[A])

--- a/src/library/scala/collection/mutable/ArrayStack.scala
+++ b/src/library/scala/collection/mutable/ArrayStack.scala
@@ -233,7 +233,7 @@ extends AbstractSeq[T]
     }
   }
 
-  override def foreach[U](f: T =>  U) {
+  override def foreach[U](f: T => U) {
     var currentIndex = index
     while (currentIndex > 0) {
       currentIndex -= 1

--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -96,16 +96,16 @@ extends AbstractMap[A, B]
 
   def iterator = entriesIterator map (e => ((e.key, e.value)))
 
-  override def foreach[C](f: ((A, B)) => C): Unit = foreachEntry(e => f((e.key, e.value)))
+  override def foreach[U](f: ((A, B)) => U): Unit = foreachEntry(e => f((e.key, e.value)))
 
   /* Override to avoid tuple allocation in foreach */
   override def keySet: scala.collection.Set[A] = new DefaultKeySet {
-    override def foreach[C](f: A => C) = foreachEntry(e => f(e.key))
+    override def foreach[U](f: A => U) = foreachEntry(e => f(e.key))
   }
 
   /* Override to avoid tuple allocation in foreach */
   override def values: scala.collection.Iterable[B] = new DefaultValuesIterable {
-    override def foreach[C](f: B => C) = foreachEntry(e => f(e.value))
+    override def foreach[U](f: B => U) = foreachEntry(e => f(e.value))
   }
 
   /* Override to avoid tuple allocation */

--- a/src/library/scala/collection/mutable/HashSet.scala
+++ b/src/library/scala/collection/mutable/HashSet.scala
@@ -70,7 +70,7 @@ extends AbstractSet[A]
 
   override def iterator: Iterator[A] = super[FlatHashTable].iterator
 
-  override def foreach[U](f: A =>  U) {
+  override def foreach[U](f: A => U) {
     var i = 0
     val len = table.length
     while (i < len) {

--- a/src/library/scala/collection/mutable/ImmutableSetAdaptor.scala
+++ b/src/library/scala/collection/mutable/ImmutableSetAdaptor.scala
@@ -32,7 +32,7 @@ extends AbstractSet[A]
 
   def contains(elem: A): Boolean = set.contains(elem)
 
-  override def foreach[U](f: A =>  U): Unit = set.foreach(f)
+  override def foreach[U](f: A => U): Unit = set.foreach(f)
 
   override def exists(p: A => Boolean): Boolean = set.exists(p)
 

--- a/src/library/scala/collection/mutable/LinkedListLike.scala
+++ b/src/library/scala/collection/mutable/LinkedListLike.scala
@@ -172,7 +172,7 @@ trait LinkedListLike[A, This <: Seq[A] with LinkedListLike[A, This]] extends Seq
     }
   }
 
-  override def foreach[B](f: A => B) {
+  override def foreach[U](f: A => U) {
     var these = this
     while (these.nonEmpty) {
       f(these.elem)

--- a/src/library/scala/collection/mutable/SynchronizedSet.scala
+++ b/src/library/scala/collection/mutable/SynchronizedSet.scala
@@ -78,7 +78,7 @@ trait SynchronizedSet[A] extends Set[A] {
     super.subsetOf(that)
   }
 
-  override def foreach[U](f: A =>  U) = synchronized {
+  override def foreach[U](f: A => U) = synchronized {
     super.foreach(f)
   }
 

--- a/src/library/scala/collection/package.scala
+++ b/src/library/scala/collection/package.scala
@@ -13,8 +13,11 @@ package scala
  *
  * == Guide ==
  *
- * A detailed guide for the collections library is available
+ * A detailed guide for using the collections library is available
  * at [[http://docs.scala-lang.org/overviews/collections/introduction.html]].
+ * Developers looking to extend the collections library can find a description
+ * of its architecture at
+ * [[http://docs.scala-lang.org/overviews/core/architecture-of-scala-collections.html]].
  *
  * == Using Collections ==
  *
@@ -31,24 +34,25 @@ package scala
  * array: Array[Int] = Array(1, 2, 3, 4, 5, 6)
  *
  * scala> array map { _.toString }
- * res0: Array[java.lang.String] = Array(1, 2, 3, 4, 5, 6)
+ * res0: Array[String] = Array(1, 2, 3, 4, 5, 6)
  *
  * scala> val list = List(1,2,3,4,5,6)
  * list: List[Int] = List(1, 2, 3, 4, 5, 6)
  *
  * scala> list map { _.toString }
- * res1: List[java.lang.String] = List(1, 2, 3, 4, 5, 6)
+ * res1: List[String] = List(1, 2, 3, 4, 5, 6)
  *
  * }}}
  *
  * == Creating Collections ==
  *
- * The most common way to create a collection is to use the companion objects as factories.
- * Of these, the three most common
- * are [[scala.collection.Seq]], [[scala.collection.immutable.Set]], and [[scala.collection.immutable.Map]].  Their
- * companion objects are all available
- * as type aliases the either the [[scala]] package or in `scala.Predef`, and can be used
- * like so:
+ * The most common way to create a collection is to use its companion object as
+ * a factory. The three most commonly used collections are
+ * [[scala.collection.Seq]], [[scala.collection.immutable.Set]], and
+ * [[scala.collection.immutable.Map]].
+ * They can be used directly as shown below since their companion objects are
+ * all available as type aliases in either the [[scala]] package or in
+ * `scala.Predef`. New collections are created like this:
  * {{{
  * scala> val seq = Seq(1,2,3,4,1)
  * seq: Seq[Int] = List(1, 2, 3, 4, 1)
@@ -56,12 +60,12 @@ package scala
  * scala> val set = Set(1,2,3,4,1)
  * set: scala.collection.immutable.Set[Int] = Set(1, 2, 3, 4)
  *
- * scala> val map = Map(1 -> "one",2 -> "two", 3 -> "three",2 -> "too")
- * map: scala.collection.immutable.Map[Int,java.lang.String] = Map((1,one), (2,too), (3,three))
+ * scala> val map = Map(1 -> "one", 2 -> "two", 3 -> "three", 2 -> "too")
+ * map: scala.collection.immutable.Map[Int,String] = Map(1 -> one, 2 -> too, 3 -> three)
  * }}}
  *
- * It is also typical to use the [[scala.collection.immutable]] collections over those
- * in [[scala.collection.mutable]]; The types aliased in
+ * It is also typical to prefer the [[scala.collection.immutable]] collections
+ * over those in [[scala.collection.mutable]]; the types aliased in
  * the `scala.Predef` object are the immutable versions.
  *
  * Also note that the collections library was carefully designed to include several implementations of
@@ -71,9 +75,9 @@ package scala
  *
  * === Converting between Java Collections ===
  *
- * The `JavaConversions` object provides implicit defs that will allow mostly seamless integration
- * between Java Collections-based APIs and the Scala collections library.
- *
+ * The [[scala.collection.JavaConversions]] object provides implicit defs that
+ * will allow mostly seamless integration between APIs using Java Collections
+ * and the Scala collections library.
  */
 package object collection {
   import scala.collection.generic.CanBuildFrom

--- a/src/library/scala/collection/parallel/ParIterableLike.scala
+++ b/src/library/scala/collection/parallel/ParIterableLike.scala
@@ -531,11 +531,11 @@ self: ParIterableLike[T, Repr, Sequential] =>
    *
    *  $abortsignalling
    *
-   *  @param pred    a predicate used to test elements
+   *  @param p       a predicate used to test elements
    *  @return        true if `p` holds for some element, false otherwise
    */
-  def exists(pred: T => Boolean): Boolean = {
-    tasksupport.executeAndWaitResult(new Exists(pred, splitter assign new DefaultSignalling with VolatileAbort))
+  def exists(p: T => Boolean): Boolean = {
+    tasksupport.executeAndWaitResult(new Exists(p, splitter assign new DefaultSignalling with VolatileAbort))
   }
 
   /** Finds some element in the collection for which the predicate holds, if such

--- a/src/library/scala/collection/parallel/ParIterableLike.scala
+++ b/src/library/scala/collection/parallel/ParIterableLike.scala
@@ -546,11 +546,11 @@ self: ParIterableLike[T, Repr, Sequential] =>
    *
    *  $abortsignalling
    *
-   *  @param pred     predicate used to test the elements
+   *  @param p        predicate used to test the elements
    *  @return         an option value with the element if such an element exists, or `None` otherwise
    */
-  def find(pred: T => Boolean): Option[T] = {
-    tasksupport.executeAndWaitResult(new Find(pred, splitter assign new DefaultSignalling with VolatileAbort))
+  def find(p: T => Boolean): Option[T] = {
+    tasksupport.executeAndWaitResult(new Find(p, splitter assign new DefaultSignalling with VolatileAbort))
   }
 
   /** Creates a combiner factory. Each combiner factory instance is used

--- a/src/library/scala/collection/parallel/ParIterableLike.scala
+++ b/src/library/scala/collection/parallel/ParIterableLike.scala
@@ -520,11 +520,11 @@ self: ParIterableLike[T, Repr, Sequential] =>
    *
    *  $abortsignalling
    *
-   *  @param pred    a predicate used to test elements
+   *  @param p       a predicate used to test elements
    *  @return        true if `p` holds for all elements, false otherwise
    */
-  def forall(pred: T => Boolean): Boolean = {
-    tasksupport.executeAndWaitResult(new Forall(pred, splitter assign new DefaultSignalling with VolatileAbort))
+  def forall(p: T => Boolean): Boolean = {
+    tasksupport.executeAndWaitResult(new Forall(p, splitter assign new DefaultSignalling with VolatileAbort))
   }
 
   /** Tests whether a predicate holds for some element of this $coll.

--- a/src/library/scala/collection/parallel/ParMapLike.scala
+++ b/src/library/scala/collection/parallel/ParMapLike.scala
@@ -99,14 +99,14 @@ self =>
     def - (elem: K): ParSet[K] =
       (ParSet[K]() ++ this - elem).asInstanceOf[ParSet[K]] // !!! concrete overrides abstract problem
     override def size = self.size
-    override def foreach[S](f: K => S) = for ((k, v) <- self) f(k)
+    override def foreach[U](f: K => U) = for ((k, v) <- self) f(k)
     override def seq = self.seq.keySet
   }
 
   protected class DefaultValuesIterable extends ParIterable[V] {
     def splitter = valuesIterator(self.splitter)
     override def size = self.size
-    override def foreach[S](f: V => S) = for ((k, v) <- self) f(v)
+    override def foreach[U](f: V => U) = for ((k, v) <- self) f(v)
     def seq = self.seq.values
   }
 
@@ -118,7 +118,7 @@ self =>
 
   def filterKeys(p: K => Boolean): ParMap[K, V] = new ParMap[K, V] {
     lazy val filtered = self.filter(kv => p(kv._1))
-    override def foreach[S](f: ((K, V)) => S): Unit = for (kv <- self) if (p(kv._1)) f(kv)
+    override def foreach[U](f: ((K, V)) => U): Unit = for (kv <- self) if (p(kv._1)) f(kv)
     def splitter = filtered.splitter
     override def contains(key: K) = self.contains(key) && p(key)
     def get(key: K) = if (!p(key)) None else self.get(key)
@@ -129,7 +129,7 @@ self =>
   }
 
   def mapValues[S](f: V => S): ParMap[K, S] = new ParMap[K, S] {
-    override def foreach[Q](g: ((K, S)) => Q): Unit = for ((k, v) <- self) g((k, f(v)))
+    override def foreach[U](g: ((K, S)) => U): Unit = for ((k, v) <- self) g((k, f(v)))
     def splitter = self.splitter.map(kv => (kv._1, f(kv._2)))
     override def size = self.size
     override def contains(key: K) = self.contains(key)

--- a/src/library/scala/collection/parallel/mutable/ParArray.scala
+++ b/src/library/scala/collection/parallel/mutable/ParArray.scala
@@ -179,7 +179,7 @@ self =>
 
     override def fold[U >: T](z: U)(op: (U, U) => U): U = foldLeft[U](z)(op)
 
-    override def aggregate[S](z: =>S)(seqop: (S, T) => S, combop: (S, S) => S): S = foldLeft[S](z)(seqop)
+    override def aggregate[B](z: =>B)(seqop: (B, T) => B, combop: (B, B) => B): B = foldLeft[B](z)(seqop)
 
     override def sum[U >: T](implicit num: Numeric[U]): U = {
       val s = sum_quick(num, arr, until, i, num.zero)

--- a/tools/scaladoc-diff
+++ b/tools/scaladoc-diff
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Script to compare the scaladoc of the current commit with the scaladoc
+# of the parent commit. No arguments.
+#
+
+
+oldsha=$(git log -1 --format="%H" HEAD^)
+oldsha=${oldsha#g}
+oldsha=${oldsha:0:10}
+
+sha=`sh tools/get-scala-commit-sha`
+echo "parent commit sha: $oldsha. current commit sha: $sha"
+
+# create scaladoc for parent commit if not done already
+if [ ! -f "build/scaladoc-output-$oldsha.txt" ]
+then
+  echo "making scaladoc for parent commit ($oldsha)"
+  git checkout HEAD^
+  ant docs.lib -Dscaladoc.raw.output='yes' > build/scaladoc-output-$oldsha.txt
+  cp -r build/scaladoc/ build/scaladoc-${oldsha}
+  git checkout $sha
+fi
+
+# create scaladoc for current commit
+echo "making scaladoc for current commit ($sha)"
+ant docs.lib -Dscaladoc.raw.output='yes' > build/scaladoc-output-$sha.txt
+cp -r build/scaladoc/ build/scaladoc-${sha}
+echo "opendiff build/scaladoc-output-$oldsha.txt build/scaladoc-output-$sha.txt"
+opendiff build/scaladoc-output-$oldsha.txt build/scaladoc-output-$sha.txt
+
+echo "Comparing files..."
+
+difffile=build/scaladoc-diff-${sha}-$oldsha.txt
+sh tools/scaladoc-compare build/scaladoc-${sha}/ build/scaladoc-$oldsha/ &> $difffile
+open $difffile &
+
+# Adapted from tools/scaladoc-compare
+echo "Comparing versions with difftool: build/scaladoc-${sha}/ build/scaladoc-$oldsha/"
+NEW_PATH=build/scaladoc-${sha}/
+OLD_PATH=build/scaladoc-$oldsha/
+
+FILES=`find $NEW_PATH -name '*.html.raw'`
+if [ "$FILES" == "" ]
+then
+  echo "No .html.raw files found in $NEW_PATH!"
+  exit 1
+fi
+
+for NEW_FILE in $FILES
+do
+  OLD_FILE=${NEW_FILE/$NEW_PATH/$OLD_PATH}
+  if [ -f $OLD_FILE ]
+  then
+    DIFF=`diff -q -w $NEW_FILE $OLD_FILE 2>&1`
+    if [ "$DIFF" != "" ]
+    then
+      opendiff $OLD_FILE $NEW_FILE > /dev/null
+      echo "next [y\N]? "
+      read -n 1 -s input
+
+      if [ "$input" == "N" ]
+      then exit 0
+      fi
+    fi
+  else
+    echo -e "$NEW_FILE: No corresponding file (expecting $OLD_FILE)\n\n"
+  fi
+done
+
+echo "Done."


### PR DESCRIPTION
Some doc fixes for GenTraversableOnce, methods from aggregate to foreach in alphabetical order. I'm leaving EPFL, so somebody else will have to do the rest of the alphabet ;)

Types of corrections:
- rewordings, (hopefully) better explanations
- fixing type params and parameter names so doc gets inherited properly
- adjusting REPL output to what I get with 2.11
- moving documentation up to GenTraversableOnce (e.g. copyToArray was defined in GTO, but had no documentation there, only in TraversableLike)
- squashed some whitespace along the lines
