### PR TITLE
Ignore OpenJDK warnings in partest filters

### DIFF
--- a/test/files/filters
+++ b/test/files/filters
@@ -1,6 +1,7 @@
 #
 #Java HotSpot(TM) 64-Bit Server VM warning: Failed to reserve shared memory (errno = 28).
 Java HotSpot\(TM\) .* warning:
+OpenJDK .* warning:
 # Hotspot receiving VM options through the $_JAVA_OPTIONS
 # env variable outputs them on stderr
 Picked up _JAVA_OPTIONS:

--- a/test/scaladoc/filters
+++ b/test/scaladoc/filters
@@ -1,6 +1,7 @@
 #
 #Java HotSpot(TM) 64-Bit Server VM warning: Failed to reserve shared memory (errno = 28).
 Java HotSpot\(TM\) .* warning:
+OpenJDK .* warning:
 # Hotspot receiving VM options through the $_JAVA_OPTIONS
 # env variable outputs them on stderr
 Picked up _JAVA_OPTIONS:


### PR DESCRIPTION
When running a 2.11.x validation on JDK 8, there are OpenJDK
warnings that fail tests. Backports a part of 8d2d3c70 to 2.11.x.

The missing filter causes merge commits to fail in PRs that merge
2.11 to 2.12, e.g., https://github.com/scala/scala/pull/4655.

In the future we probably want to trigger an integration build for
merge commits, but this doesn't happen yet AFAICT.
