### PR TITLE
remove temporary XML coalescing hack we used to build M2

### DIFF
--- a/scripts/jobs/integrate/bootstrap
+++ b/scripts/jobs/integrate/bootstrap
@@ -217,8 +217,7 @@ buildXML() {
   then echo "Found scala-xml $XML_VER; not building."
   else
     update scala scala-xml "$XML_REF" && gfxd
-    # TODO: compile under 2.12 source level once `scala.xml.XMLTest.escape` is fixed (see #4451)
-    sbtBuild 'set scalacOptions += "-Xsource:2.11"' 'set version := "'$XML_VER'-DOC"' $clean doc  'set version := "'$XML_VER'"' test "${buildTasks[@]}"
+    sbtBuild 'set version := "'$XML_VER'-DOC"' $clean doc  'set version := "'$XML_VER'"' test "${buildTasks[@]}"
     XML_BUILT="yes" # ensure the module is built and published when buildXML is invoked for the second time, see comment above
   fi
 }

--- a/versions.properties
+++ b/versions.properties
@@ -22,7 +22,7 @@ starr.version=2.12.0-M2
 scala.binary.version=2.12.0-M2
 
 # external modules shipped with distribution, as specified by scala-library-all's pom
-scala-xml.version.number=1.0.4
+scala-xml.version.number=1.0.5
 scala-parser-combinators.version.number=1.0.4
 scala-swing.version.number=2.0.0-M2
 scala-swing.version.osgi=2.0.0.M2


### PR DESCRIPTION
scala-xml 1.0.5 has the fix we need in order to run the scala-xml
tests normally during bootstrapping.

reverts 83554a3c0fb2b57efa293efcc81a947b98a19469
