### PR TITLE
SI-4438 PC Completer, SI-1931 Hide any+str in REPL, SI-5408 Post paste prompt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -200,7 +200,7 @@ lazy val repl = configureAsSubproject(project)
     run <<= (run in Compile).partialInput(" -usejavacp") // Automatically add this so that `repl/run` works without additional arguments.
   )
   .settings(disableDocsAndPublishingTasks: _*)
-  .dependsOn(compiler)
+  .dependsOn(compiler, interactive)
 
 lazy val scaladoc = configureAsSubproject(project)
   .settings(

--- a/build.xml
+++ b/build.xml
@@ -802,6 +802,7 @@ TODO:
 
     <path id="quick.repl.build.path">
       <path refid="quick.compiler.build.path"/>
+      <path refid="quick.interactive.build.path"/>
       <pathelement location="${build-quick.dir}/classes/repl"/>
     </path>
 
@@ -1168,7 +1169,7 @@ TODO:
   <target name="quick.comp"       depends="quick.reflect">
     <staged-build with="locker"   stage="quick" project="compiler"/> </target>
 
-  <target name="quick.repl"       depends="quick.comp">
+  <target name="quick.repl"       depends="quick.comp, quick.interactive">
     <staged-build with="locker"   stage="quick" project="repl"/>
     <staged-build with="locker"   stage="quick" project="repl-jline"/>
 

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -175,6 +175,7 @@ trait ScalaSettings extends AbsScalaSettings
   val YconstOptimization  = BooleanSetting    ("-Yconst-opt", "Perform optimization with constant values.")
   val Ycompacttrees   = BooleanSetting    ("-Ycompact-trees", "Use compact tree printer when displaying trees.")
   val noCompletion    = BooleanSetting    ("-Yno-completion", "Disable tab-completion in the REPL.")
+  val completion      = ChoiceSetting     ("-Ycompletion", "provider", "Select tab-completion in the REPL.", List("pc","adhoc","none"), "pc")
   val Xdce            = BooleanSetting    ("-Ydead-code", "Perform dead code elimination.")
   val debug           = BooleanSetting    ("-Ydebug", "Increase the quantity of debugging output.")
   //val doc           = BooleanSetting    ("-Ydoc", "Generate documentation")

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -242,11 +242,10 @@ trait ContextErrors {
 
       // typedIdent
       def AmbiguousIdentError(tree: Tree, name: Name, msg: String) =
-        NormalTypeError(tree, "reference to " + name + " is ambiguous;\n" + msg)
+        NormalTypeError(tree, s"reference to $name is ambiguous;\n$msg")
 
-      def SymbolNotFoundError(tree: Tree, name: Name, owner: Symbol, startingIdentCx: Context) = {
-        NormalTypeError(tree, "not found: "+decodeWithKind(name, owner))
-      }
+      def SymbolNotFoundError(tree: Tree, name: Name, owner: Symbol, startingIdentCx: Context) =
+        NormalTypeError(tree, s"not found: ${ decodeWithKind(name, owner) }")
 
       // typedAppliedTypeTree
       def AppliedTypeNoParametersError(tree: Tree, errTpe: Type) = {

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -918,7 +918,7 @@ trait Implicits {
 
       /** Returns all eligible ImplicitInfos and their SearchResults in a map.
        */
-      def findAll() = linkedMapFrom(eligible)(typedImplicit(_, ptChecked = false, isLocalToCallsite))
+      def findAll() = linkedMapFrom(eligible)(x => try typedImplicit(x, ptChecked = false, isLocalToCallsite) finally context.reporter.clearAll())
 
       /** Returns the SearchResult of the best match.
        */

--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -661,7 +661,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
 
   /** Make sure unit is typechecked
    */
-  private def typeCheck(unit: RichCompilationUnit) {
+  private[scala] def typeCheck(unit: RichCompilationUnit) {
     debugLog("type checking: "+unit)
     parseAndEnter(unit)
     unit.status = PartiallyChecked
@@ -792,7 +792,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
   }
 
   /** A fully attributed tree located at position `pos` */
-  private[interactive] def typedTreeAt(pos: Position): Tree = getUnit(pos.source) match {
+  private[scala] def typedTreeAt(pos: Position): Tree = getUnit(pos.source) match {
     case None =>
       reloadSources(List(pos.source))
       try typedTreeAt(pos)
@@ -1022,7 +1022,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
   }
 
   /** Return all members visible without prefix in context enclosing `pos`. */
-  private def scopeMembers(pos: Position): List[ScopeMember] = {
+  private[scala] def scopeMembers(pos: Position): List[ScopeMember] = {
     typedTreeAt(pos) // to make sure context is entered
     val context = doLocateContext(pos)
     val locals = new Members[ScopeMember]
@@ -1072,7 +1072,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
     //if (debugIDE) typeMembers(pos)
   }
 
-  private def typeMembers(pos: Position): Stream[List[TypeMember]] = {
+  def typeMembers(pos: Position): Stream[List[TypeMember]] = {
     // Choosing which tree will tell us the type members at the given position:
     //   If pos leads to an Import, type the expr
     //   If pos leads to a Select, type the qualifier as long as it is not erroneous

--- a/src/repl-jline/scala/tools/nsc/interpreter/jline/JLineDelimiter.scala
+++ b/src/repl-jline/scala/tools/nsc/interpreter/jline/JLineDelimiter.scala
@@ -11,7 +11,7 @@ import _root_.jline.console.completer.ArgumentCompleter.{ ArgumentDelimiter, Arg
 
 // implements a jline interface
 class JLineDelimiter extends ArgumentDelimiter {
-  def toJLine(args: List[String], cursor: Int) = args match {
+  def toJLine(args: List[String], cursor: Int): ArgumentList = args match {
     case Nil => new ArgumentList(new Array[String](0), 0, 0, cursor)
     case xs => new ArgumentList(xs.toArray, xs.size - 1, xs.last.length, cursor)
   }

--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -657,12 +657,9 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     unleashAndSetPhase()
     asyncEcho(isDuringInit, power.banner)
   }
-  private def unleashAndSetPhase() {
-    if (isReplPower) {
-      power.unleash()
-      // Set the phase to "typer"
-      intp beSilentDuring phaseCommand("typer")
-    }
+  private def unleashAndSetPhase() = if (isReplPower) {
+    power.unleash()
+    intp beSilentDuring phaseCommand("typer") // Set the phase to "typer"
   }
 
   def asyncEcho(async: Boolean, msg: => String) {

--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -863,7 +863,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
           case _ if settings.noCompletion => NoCompletion
           case "none"   => NoCompletion
           case "adhoc"  => new JLineCompletion(intp) // JLineCompletion is a misnomer; it's not tied to jline
-          case "pc" | _ => new PresentationCompilerCompletionProvider(intp)
+          case "pc" | _ => new PresentationCompilerCompleter(intp)
         }
       }
 

--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -23,9 +23,9 @@ import io.AbstractFile
 import scala.collection.generic.Clearable
 import scala.concurrent.{ ExecutionContext, Await, Future, future }
 import ExecutionContext.Implicits._
-import java.io.{ BufferedReader, FileReader }
+import java.io.{ BufferedReader, FileReader, StringReader }
 
-import scala.util.{Try, Success, Failure}
+import scala.util.{ Try, Success, Failure }
 
 /** The Scala interactive shell.  It provides a read-eval-print loop
  *  around the Interpreter class.
@@ -747,28 +747,9 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     result
   }
 
-  private object paste extends Pasted {
-    import scala.util.matching.Regex.quote
-    val ContinuePrompt = replProps.continuePrompt
-    val ContinueString = replProps.continueText     // "     | "
-    val PromptString   = prompt.lines.toList.last
-    val anyPrompt = s"""\\s*(?:${quote(PromptString.trim)}|${quote(AltPromptString.trim)})\\s*""".r
-
-    def isPrompted(line: String)   = matchesPrompt(line)
-    def isPromptOnly(line: String) = line match { case anyPrompt() => true ; case _ => false }
-
-    def interpret(line: String): Unit = {
-      echo(line.trim)
-      intp interpret line
-      echo("")
-    }
-
-    def transcript(start: String) = {
-      echo("\n// Detected repl transcript paste: ctrl-D to finish.\n")
-      apply(Iterator(start) ++ readWhile(!isPromptOnly(_)))
-    }
-
-    def unapply(line: String): Boolean = isPrompted(line)
+  private object paste extends Pasted(prompt) {
+    def interpret(line: String) = intp interpret line
+    def echo(message: String)   = ILoop.this echo message
   }
 
   private object invocation {
@@ -783,29 +764,9 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     * read, go ahead and interpret it.  Return the full string
     * to be recorded for replay, if any.
     */
-  def interpretStartingWith(code: String): Option[String] = {
+  @tailrec final def interpretStartingWith(code: String): Option[String] = {
     // signal completion non-completion input has been received
     in.completion.resetVerbosity()
-
-    def reallyInterpret = intp.interpret(code) match {
-      case IR.Error      => None
-      case IR.Success    => Some(code)
-      case IR.Incomplete if in.interactive && code.endsWith("\n\n") =>
-        echo("You typed two blank lines.  Starting a new command.")
-        None
-      case IR.Incomplete =>
-        in.readLine(paste.ContinuePrompt) match {
-          case null =>
-            // we know compilation is going to fail since we're at EOF and the
-            // parser thinks the input is still incomplete, but since this is
-            // a file being read non-interactively we want to fail.  So we send
-            // it straight to the compiler for the nice error message.
-            intp.compileString(code)
-            None
-
-          case line => interpretStartingWith(code + "\n" + line)
-        }
-    }
 
     /* Here we place ourselves between the user and the interpreter and examine
      * the input they are ostensibly submitting.  We intervene in several cases:
@@ -819,9 +780,29 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     code match {
       case ""                                       => None
       case lineComment()                            => None                 // line comment, do nothing
-      case paste() if !paste.running                => paste.transcript(code) ; None
+      case paste() if !paste.running                => paste.transcript(Iterator(code) ++ readWhile(!paste.isPromptOnly(_))) match {
+                                                         case Some(s) => interpretStartingWith(s)
+                                                         case _       => None
+                                                       }
       case invocation() if intp.mostRecentVar != "" => interpretStartingWith(intp.mostRecentVar + code)
-      case _                                        => reallyInterpret
+      case _                                        => intp.interpret(code) match {
+        case IR.Error      => None
+        case IR.Success    => Some(code)
+        case IR.Incomplete if in.interactive && code.endsWith("\n\n") =>
+          echo("You typed two blank lines.  Starting a new command.")
+          None
+        case IR.Incomplete => in.readLine(paste.ContinuePrompt) match {
+          case null =>
+            // we know compilation is going to fail since we're at EOF and the
+            // parser thinks the input is still incomplete, but since this is
+            // a file being read non-interactively we want to fail.  So we send
+            // it straight to the compiler for the nice error message.
+            intp.compileString(code)
+            None
+
+          case line => interpretStartingWith(s"$code\n$line")
+        }
+      }
     }
   }
 

--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -1,8 +1,7 @@
 /* NSC -- new Scala compiler
- * Copyright 2005-2013 LAMP/EPFL
+ * Copyright 2005-2015 LAMP/EPFL
  * @author Alexander Spoon
  */
-
 package scala
 package tools.nsc
 package interpreter
@@ -841,9 +840,10 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     case _ =>
   }
 
-  /** Tries to create a JLineReader, falling back to SimpleReader:
-   *  unless settings or properties are such that it should start
-   *  with SimpleReader.
+  /** Tries to create a JLineReader, falling back to SimpleReader,
+   *  unless settings or properties are such that it should start with SimpleReader.
+   *  The constructor of the InteractiveReader must take a Completion strategy,
+   *  supplied as a `() => Completion`; the Completion object provides a concrete Completer.
    */
   def chooseReader(settings: Settings): InteractiveReader = {
     if (settings.Xnojline || Properties.isEmacsShell) SimpleReader()
@@ -851,20 +851,25 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
       type Completer = () => Completion
       type ReaderMaker = Completer => InteractiveReader
 
-      def instantiate(className: String): ReaderMaker = completer => {
-        if (settings.debug) Console.println(s"Trying to instantiate a InteractiveReader from $className")
+      def instantiater(className: String): ReaderMaker = completer => {
+        if (settings.debug) Console.println(s"Trying to instantiate an InteractiveReader from $className")
         Class.forName(className).getConstructor(classOf[Completer]).
           newInstance(completer).
           asInstanceOf[InteractiveReader]
       }
 
-      def mkReader(maker: ReaderMaker) =
-        if (settings.noCompletion) maker(() => NoCompletion)
-        else maker(() => new JLineCompletion(intp)) // JLineCompletion is a misnomer -- it's not tied to jline
+      def mkReader(maker: ReaderMaker) = maker { () =>
+        settings.completion.value match {
+          case _ if settings.noCompletion => NoCompletion
+          case "none"   => NoCompletion
+          case "adhoc"  => new JLineCompletion(intp) // JLineCompletion is a misnomer; it's not tied to jline
+          case "pc" | _ => new PresentationCompilerCompletionProvider(intp)
+        }
+      }
 
       def internalClass(kind: String) = s"scala.tools.nsc.interpreter.$kind.InteractiveReader"
       val readerClasses = sys.props.get("scala.repl.reader").toStream ++ Stream(internalClass("jline"), internalClass("jline_embedded"))
-      val readers = readerClasses map (cls => Try { mkReader(instantiate(cls)) })
+      val readers = readerClasses map (cls => Try { mkReader(instantiater(cls)) })
 
       val reader = (readers collect { case Success(reader) => reader } headOption) getOrElse SimpleReader()
 

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -15,10 +15,13 @@ import scala.concurrent.{ Future, ExecutionContext }
 import scala.reflect.runtime.{ universe => ru }
 import scala.reflect.{ ClassTag, classTag }
 import scala.reflect.internal.util.{ BatchSourceFile, SourceFile }
+import scala.tools.nsc.interactive
+import scala.tools.nsc.reporters.StoreReporter
+import scala.tools.nsc.util.ClassPath.DefaultJavaContext
 import scala.tools.util.PathResolverFactory
 import scala.tools.nsc.io.AbstractFile
 import scala.tools.nsc.typechecker.{ TypeStrings, StructuredTypeStrings }
-import scala.tools.nsc.util.{ ScalaClassLoader, stringFromReader, stringFromWriter, StackTraceOps, ClassPath, MergedClassPath }
+import scala.tools.nsc.util._
 import ScalaClassLoader.URLClassLoader
 import scala.tools.nsc.util.Exceptional.unwrap
 import scala.tools.nsc.backend.JavaPlatform
@@ -58,8 +61,10 @@ import java.io.File
  *  @author Moez A. Abdel-Gawad
  *  @author Lex Spoon
  */
-class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Settings, protected val out: JPrintWriter) extends AbstractScriptEngine with Compilable with Imports {
+class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Settings, protected val out: JPrintWriter) extends AbstractScriptEngine with Compilable with Imports with PresentationCompilation {
   imain =>
+
+  val api = new PresentationCompilerAPI(this)
 
   setBindings(createBindings, ScriptContext.ENGINE_SCOPE)
   object replOutput extends ReplOutput(settings.Yreploutdir) { }
@@ -447,7 +452,7 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
 
   /** Build a request from the user. `trees` is `line` after being parsed.
    */
-  private def buildRequest(line: String, trees: List[Tree]): Request = {
+  private[interpreter] def buildRequest(line: String, trees: List[Tree]): Request = {
     executingRequest = new Request(line, trees)
     executingRequest
   }
@@ -466,11 +471,12 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
     pos
   }
 
-  private def requestFromLine(line: String, synthetic: Boolean): Either[IR.Result, Request] = {
-    val content = line  //indentCode(line)
-    val trees = parse(content) match {
-      case parse.Incomplete     => return Left(IR.Incomplete)
-      case parse.Error          => return Left(IR.Error)
+  private[interpreter] def requestFromLine(line: String, synthetic: Boolean): Either[IR.Result, Request] = {
+    val content = line
+
+    val trees: List[global.Tree] = parse(content) match {
+      case parse.Incomplete(_)     => return Left(IR.Incomplete)
+      case parse.Error(_)          => return Left(IR.Error)
       case parse.Success(trees) => trees
     }
     repltrace(
@@ -855,7 +861,7 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
   }
 
   /** One line of code submitted by the user for interpretation */
-  class Request(val line: String, val trees: List[Tree]) {
+  class Request(val line: String, val trees: List[Tree], generousImports: Boolean = false) {
     def defines    = defHandlers flatMap (_.definedSymbols)
     def imports    = importedSymbols
     def value      = Some(handlers.last) filter (h => h.definesValue) map (h => definedSymbols(h.definesTerm.get)) getOrElse NoSymbol
@@ -889,7 +895,7 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
       * append to objectName to access anything bound by request.
       */
     lazy val ComputedImports(headerPreamble, importsPreamble, importsTrailer, accessPath) =
-      exitingTyper(importsCode(referencedNames.toSet, ObjectSourceCode, definesClass))
+      exitingTyper(importsCode(referencedNames.toSet, ObjectSourceCode, definesClass, generousImports))
 
     /** the line of code to compute */
     def toCompute = line
@@ -913,6 +919,7 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
         |${envLines mkString ("  ", ";\n  ", ";\n")}
         |$importsPreamble
         |${indentCode(toCompute)}""".stripMargin
+      def preambleLength = preamble.length - toCompute.length - 1
 
       val generate = (m: MemberHandler) => m extraCodeToEvaluate Request.this
 
@@ -952,7 +959,7 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
       def postwrap = s"}\nval $iw = new $iw\n"
     }
 
-    private lazy val ObjectSourceCode: Wrapper =
+    private[interpreter] lazy val ObjectSourceCode: Wrapper =
       if (isClassBased) new ClassBasedWrapper else new ObjectBasedWrapper
 
     private object ResultObjectSourceCode extends IMain.CodeAssembler[MemberHandler] {
@@ -1013,6 +1020,7 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
     }
 
     lazy val resultSymbol = lineRep.resolvePathToSymbol(fullAccessPath)
+
     def applyToResultMember[T](name: Name, f: Symbol => T) = exitingTyper(f(resultSymbol.info.nonPrivateDecl(name)))
 
     /* typeOf lookup with encoding */
@@ -1166,20 +1174,22 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
 
   /** Parse a line into and return parsing result (error, incomplete or success with list of trees) */
   object parse {
-    abstract sealed class Result
-    case object Error extends Result
-    case object Incomplete extends Result
+    abstract sealed class Result { def trees: List[Tree] }
+    case class Error(trees: List[Tree]) extends Result
+    case class Incomplete(trees: List[Tree]) extends Result
     case class Success(trees: List[Tree]) extends Result
 
-    def apply(line: String): Result = debugging(s"""parse("$line")""")  {
+    def apply(line: String, forPresentation: Boolean = false): Result = debugging(s"""parse("$line")""")  {
       var isIncomplete = false
-      currentRun.parsing.withIncompleteHandler((_, _) => isIncomplete = true) {
+      def parse = {
         reporter.reset()
         val trees = newUnitParser(line).parseStats()
-        if (reporter.hasErrors) Error
-        else if (isIncomplete) Incomplete
+        if (reporter.hasErrors) Error(trees)
+        else if (isIncomplete) Incomplete(trees)
         else Success(trees)
       }
+      currentRun.parsing.withIncompleteHandler((_, _) => isIncomplete = true) {parse}
+
     }
   }
 
@@ -1359,3 +1369,4 @@ object IMain {
     def stripImpl(str: String): String = naming.unmangle(str)
   }
 }
+

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -888,7 +888,7 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
     /** Code to import bound names from previous lines - accessPath is code to
       * append to objectName to access anything bound by request.
       */
-    lazy val ComputedImports(importsPreamble, importsTrailer, accessPath) =
+    lazy val ComputedImports(headerPreamble, importsPreamble, importsTrailer, accessPath) =
       exitingTyper(importsCode(referencedNames.toSet, ObjectSourceCode, definesClass))
 
     /** the line of code to compute */
@@ -908,6 +908,7 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
         else List("def %s = %s".format("$line", tquoted(originalLine)), "def %s = Nil".format("$trees"))
       }
       def preamble = s"""
+        |$headerPreamble
         |${preambleHeader format lineRep.readName}
         |${envLines mkString ("  ", ";\n  ", ";\n")}
         |$importsPreamble

--- a/src/repl/scala/tools/nsc/interpreter/Imports.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Imports.scala
@@ -70,7 +70,10 @@ trait Imports {
 
   /** Compute imports that allow definitions from previous
    *  requests to be visible in a new request.  Returns
-   *  three pieces of related code:
+   *  three or four pieces of related code:
+   *
+   *  0. Header code fragment that should go at the beginning
+   *  of the compilation unit, specifically, import Predef.
    *
    *  1. An initial code fragment that should go before
    *  the code of the new request.
@@ -91,30 +94,34 @@ trait Imports {
    * (3) It imports multiple same-named implicits, but only the
    * last one imported is actually usable.
    */
-  case class ComputedImports(prepend: String, append: String, access: String)
+  case class ComputedImports(header: String, prepend: String, append: String, access: String)
   protected def importsCode(wanted: Set[Name], wrapper: Request#Wrapper, definesClass: Boolean): ComputedImports = {
+    val header, code, trailingBraces, accessPath = new StringBuilder
+    val currentImps = mutable.HashSet[Name]()
+    var predefEscapes = false      // only emit predef import header if name not resolved in history, loosely
+
     /** Narrow down the list of requests from which imports
      *  should be taken.  Removes requests which cannot contribute
      *  useful imports for the specified set of wanted names.
      */
-    case class ReqAndHandler(req: Request, handler: MemberHandler) { }
+    case class ReqAndHandler(req: Request, handler: MemberHandler)
 
     def reqsToUse: List[ReqAndHandler] = {
       /** Loop through a list of MemberHandlers and select which ones to keep.
-        * 'wanted' is the set of names that need to be imported.
+       *  'wanted' is the set of names that need to be imported.
        */
       def select(reqs: List[ReqAndHandler], wanted: Set[Name]): List[ReqAndHandler] = {
         // Single symbol imports might be implicits! See bug #1752.  Rather than
         // try to finesse this, we will mimic all imports for now.
         def keepHandler(handler: MemberHandler) = handler match {
-        /* While defining classes in class based mode - implicits are not needed. */
+          // While defining classes in class based mode - implicits are not needed.
           case h: ImportHandler if isClassBased && definesClass => h.importedNames.exists(x => wanted.contains(x))
           case _: ImportHandler => true
           case x                => x.definesImplicit || (x.definedNames exists wanted)
         }
 
         reqs match {
-          case Nil                                    => Nil
+          case Nil                                    => predefEscapes = wanted contains PredefModule.name ; Nil
           case rh :: rest if !keepHandler(rh.handler) => select(rest, wanted)
           case rh :: rest                             =>
             import rh.handler._
@@ -126,9 +133,6 @@ trait Imports {
       /** Flatten the handlers out and pair each with the original request */
       select(allReqAndHandlers reverseMap { case (r, h) => ReqAndHandler(r, h) }, wanted).reverse
     }
-
-    val code, trailingBraces, accessPath = new StringBuilder
-    val currentImps = mutable.HashSet[Name]()
 
     // add code for a new object to hold some imports
     def addWrapper() {
@@ -146,6 +150,9 @@ trait Imports {
       try op finally addWrapper()
     }
 
+    // imports from Predef are relocated to the template header to allow hiding.
+    def checkHeader(h: ImportHandler) = h.referencedNames contains PredefModule.name
+
     // loop through previous requests, adding imports for each one
     wrapBeforeAndAfter {
       // Reusing a single temporary value when import from a line with multiple definitions.
@@ -153,6 +160,9 @@ trait Imports {
       for (ReqAndHandler(req, handler) <- reqsToUse) {
         val objName = req.lineRep.readPathInstance
         handler match {
+          case h: ImportHandler if checkHeader(h) =>
+            header.clear()
+            header append f"${h.member}%n"
           // If the user entered an import, then just use it; add an import wrapping
           // level if the import might conflict with some other import
           case x: ImportHandler if x.importsWildcard =>
@@ -194,7 +204,8 @@ trait Imports {
       }
     }
 
-    ComputedImports(code.toString, trailingBraces.toString, accessPath.toString)
+    val computedHeader = if (predefEscapes) header.toString else ""
+    ComputedImports(computedHeader, code.toString, trailingBraces.toString, accessPath.toString)
   }
 
   private def allReqAndHandlers =

--- a/src/repl/scala/tools/nsc/interpreter/JLineCompletion.scala
+++ b/src/repl/scala/tools/nsc/interpreter/JLineCompletion.scala
@@ -9,6 +9,7 @@ package interpreter
 import Completion._
 import scala.collection.mutable.ListBuffer
 import scala.reflect.internal.util.StringOps.longestCommonPrefix
+import scala.tools.nsc.interactive.Global
 
 // REPL completor - queries supplied interpreter for valid
 // completions based on current contents of buffer.
@@ -296,7 +297,6 @@ class JLineCompletion(val intp: IMain) extends Completion with CompletionOutput 
     override def complete(buf: String, cursor: Int): Candidates = {
       verbosity = if (isConsecutiveTabs(buf, cursor)) verbosity + 1 else 0
       repldbg(f"%ncomplete($buf, $cursor%d) last = ($lastBuf, $lastCursor%d), verbosity: $verbosity")
-
       // we don't try lower priority completions unless higher ones return no results.
       def tryCompletion(p: Parsed, completionFunction: Parsed => List[String]): Option[Candidates] = {
         val winners = completionFunction(p)

--- a/src/repl/scala/tools/nsc/interpreter/Power.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Power.scala
@@ -112,10 +112,13 @@ class Power[ReplValsImpl <: ReplVals : ru.TypeTag: ClassTag](val intp: IMain, re
     }
   }
 
-  private def customBanner = replProps.powerBanner.option flatMap (f => io.File(f).safeSlurp())
+  private def customBanner = replProps.powerBanner.option flatMap {
+    case f if f.getName == "classic" => Some(classic)
+    case f => io.File(f).safeSlurp()
+  }
   private def customInit   = replProps.powerInitCode.option flatMap (f => io.File(f).safeSlurp())
 
-  def banner = customBanner getOrElse """
+  def classic = """
     |** Power User mode enabled - BEEP WHIR GYVE **
     |** :phase has been set to 'typer'.          **
     |** scala.tools.nsc._ has been imported      **
@@ -123,28 +126,30 @@ class Power[ReplValsImpl <: ReplVals : ru.TypeTag: ClassTag](val intp: IMain, re
     |** Try  :help, :vals, power.<tab>           **
   """.stripMargin.trim
 
-  private def initImports = List(
-    "scala.tools.nsc._",
-    "scala.collection.JavaConverters._",
-    "intp.global.{ error => _, _ }",
-    "definitions.{ getClass => _, _ }",
-    "power.rutil._",
-    "replImplicits._",
-    "treedsl.CODE._"
-  )
+  def banner = customBanner getOrElse """
+    |Power mode enabled. :phase is at typer.
+    |import scala.tools.nsc._, intp.global._, definitions._
+    |Try :help or completions for vals._ and power._
+  """.stripMargin.trim
 
-  def init = customInit match {
-    case Some(x)  => x
-    case _        => initImports.mkString("import ", ", ", "")
-  }
+  private def initImports =
+  """scala.tools.nsc._
+    |scala.collection.JavaConverters._
+    |intp.global.{ error => _, _ }
+    |definitions.{ getClass => _, _ }
+    |power.rutil._
+    |replImplicits._
+    |treedsl.CODE._""".stripMargin.lines
 
-  /** Starts up power mode and runs whatever is in init.
+  def init = customInit getOrElse initImports.mkString("import ", ", ", "")
+
+  /** Quietly starts up power mode and runs whatever is in init.
    */
   def unleash(): Unit = beQuietDuring {
     // First we create the ReplVals instance and bind it to $r
     intp.bind("$r", replVals)
     // Then we import everything from $r.
-    intp interpret ("import " + intp.originalPath("$r") + "._")
+    intp interpret s"import ${ intp.originalPath("$r") }._"
     // And whatever else there is to do.
     init.lines foreach (intp interpret _)
   }

--- a/src/repl/scala/tools/nsc/interpreter/Power.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Power.scala
@@ -1,8 +1,7 @@
 /* NSC -- new Scala compiler
- * Copyright 2005-2013 LAMP/EPFL
- * @author  Paul Phillips
+ * Copyright 2005-2015 LAMP/EPFL
+ * @author Paul Phillips
  */
-
 package scala.tools.nsc
 package interpreter
 

--- a/src/repl/scala/tools/nsc/interpreter/PresentationCompilation.scala
+++ b/src/repl/scala/tools/nsc/interpreter/PresentationCompilation.scala
@@ -1,0 +1,113 @@
+/* NSC -- new Scala compiler
+ * Copyright 2005-2015 LAMP/EPFL
+ * @author Martin Odersky
+ */
+package scala.tools.nsc.interpreter
+
+import scala.tools.nsc.backend.JavaPlatform
+import scala.tools.nsc.{interactive, Settings}
+import scala.tools.nsc.io._
+import scala.tools.nsc.reporters.StoreReporter
+import scala.tools.nsc.util.ClassPath.DefaultJavaContext
+import scala.tools.nsc.util.{DirectoryClassPath, MergedClassPath}
+
+trait PresentationCompilation {
+  self: IMain =>
+
+  private[scala] def presentationCompile(line: String): Either[IR.Result, PresentationCompileResult] = {
+    if (global == null) Left(IR.Error)
+    else {
+      val compiler = newPresentationCompiler()
+      val trees = compiler.newUnitParser(line).parseStats()
+      val importer = global.mkImporter(compiler)
+      val request = new Request(line, trees map (t => importer.importTree(t)), generousImports = true)
+      val wrappedCode: String = request.ObjectSourceCode(request.handlers)
+      import compiler._
+      val unit = new RichCompilationUnit(newCompilationUnit(wrappedCode).source)
+      unitOfFile(unit.source.file) = unit
+      typeCheck(unit)
+      val result = PresentationCompileResult(request, compiler)(unit, request.ObjectSourceCode.preambleLength)
+      Right(result)
+    }
+  }
+
+  private def newPresentationCompiler(): interactive.Global = {
+    val storeReporter: StoreReporter = new StoreReporter
+    val replOutClasspath: DirectoryClassPath = new DirectoryClassPath(replOutput.dir, DefaultJavaContext)
+    val claspath = new MergedClassPath[AbstractFile](replOutClasspath :: global.platform.classPath :: Nil, DefaultJavaContext)
+    def copySettings: Settings = {
+      val s = new Settings(_ => () /* ignores "bad option -nc" errors, etc */)
+      s.processArguments(global.settings.recreateArgs, processAll = false)
+      s
+    }
+    val interactiveGlobal = new interactive.Global(copySettings, storeReporter) { self =>
+      override def assertCorrectThread(): Unit = ()
+      override lazy val platform: ThisPlatform = new JavaPlatform {
+        val global: self.type = self
+
+        override def classPath: PlatformClassPath = claspath
+      }
+    }
+    import interactiveGlobal._
+    val run = new TyperRun()
+    interactiveGlobal
+  }
+
+  abstract class PresentationCompileResult {
+    def request: Request
+    val compiler: scala.tools.nsc.interactive.Global
+    def unit: compiler.RichCompilationUnit
+    def preambleLength: Int
+    def cleanup(): Unit = {
+      compiler.askShutdown()
+    }
+    sealed abstract class CompletionResult {
+      def results: List[compiler.Member]
+    }
+    object CompletionResult {
+      final case class ScopeMembers(newCursor: Int, results: List[compiler.ScopeMember]) extends CompletionResult
+      final case class TypeMembers(newCursor: Int, tree: compiler.Select, results: List[compiler.TypeMember]) extends CompletionResult
+      case object NoResults extends CompletionResult {
+        override def results: List[compiler.Member] = Nil
+      }
+    }
+    def completionsOf(buf: String, cursor: Int): CompletionResult = {
+      val offset = preambleLength
+      val pos1 = unit.source.position(offset + cursor)
+      import compiler._
+      val focus1: Tree = typedTreeAt(pos1)
+      focus1 match {
+        case sel @ Select(qual, name) =>
+          val prefix = if (name == nme.ERROR) "" else name.encoded
+          val allTypeMembers = typeMembers(qual.pos).toList.flatten
+          val completions = allTypeMembers.filter(_.sym.name.startsWith(prefix))
+          def fallback = qual.pos.end + 2
+          val nameStart: Int = (qual.pos.end + 1 until focus1.pos.end).find(p =>
+            unit.source.identifier(unit.source.position(p)).exists(_.length > 0)
+          ).getOrElse(fallback)
+          val position: Int = cursor + nameStart - pos1.start
+          CompletionResult.TypeMembers(position, sel, completions)
+        case Ident(name) =>
+          val allMembers = scopeMembers(pos1)
+          val completions = allMembers.filter(_.sym.name.startsWith(name.encoded))
+          val position: Int = cursor + focus1.pos.start - pos1.start
+          CompletionResult.ScopeMembers(position, completions)
+        case _ =>
+          CompletionResult.NoResults
+      }
+    }
+  }
+
+  object PresentationCompileResult {
+    def apply(request0: Request, compiler0: interactive.Global)(unit0: compiler0.RichCompilationUnit, preambleLength0: Int) = new PresentationCompileResult {
+
+      override def request: Request = request0
+
+      override val compiler = compiler0
+
+      override def unit = unit0.asInstanceOf[compiler.RichCompilationUnit]
+
+      override def preambleLength = preambleLength0
+    }
+  }
+}

--- a/src/repl/scala/tools/nsc/interpreter/PresentationCompilerAPI.scala
+++ b/src/repl/scala/tools/nsc/interpreter/PresentationCompilerAPI.scala
@@ -1,0 +1,22 @@
+/* NSC -- new Scala compiler
+ * Copyright 2005-2015 LAMP/EPFL
+ * @author Martin Odersky
+ */
+package scala.tools.nsc.interpreter
+
+import scala.reflect.internal.util.RangePosition
+import scala.tools.nsc.typechecker.TypeStrings
+
+class PresentationCompilerAPI(interpreter: IMain) {
+
+  def typeAt(code: String, selectionStart: Int, selectionEnd: Int): Option[String] =
+    interpreter.presentationCompile(code) match {
+      case Left(_)       => None
+      case Right(result) =>
+        val start = selectionStart + result.preambleLength
+        val end   = selectionEnd + result.preambleLength
+        val pos   = new RangePosition(result.unit.source, start, start, end)
+        val tree  = result.compiler.typedTreeAt(pos)
+        Some(interpreter.global.exitingTyper(tree.tpe.toString))
+    }
+}

--- a/src/repl/scala/tools/nsc/interpreter/PresentationCompilerCompleter.scala
+++ b/src/repl/scala/tools/nsc/interpreter/PresentationCompilerCompleter.scala
@@ -1,0 +1,66 @@
+/* NSC -- new Scala compiler
+ * Copyright 2005-2013 LAMP/EPFL
+ * @author Martin Odersky
+ */
+package scala.tools.nsc.interpreter
+
+import scala.tools.nsc.interpreter.Completion.{ScalaCompleter, Candidates}
+
+class PresentationCompilerCompletionProvider(intp: IMain) extends Completion {
+  def resetVerbosity(): Unit = ()
+  def completer(): ScalaCompleter = new PresentationCompilerCompleter(intp)
+}
+
+class PresentationCompilerCompleter(intp: IMain) extends ScalaCompleter {
+  private case class Request(line: String, cursor: Int)
+  private var lastRequest = new Request("", -1)
+  private var tabCount = 0
+
+  override def complete(buf: String, cursor: Int): Candidates = {
+    val request = new Request(buf, cursor)
+    if (request == lastRequest) tabCount += 1 else { tabCount = 0; lastRequest = request}
+    val printMode = buf.matches(""".*// *print *$""") && cursor == buf.length
+    val (typeAtMode, start, end) = {
+      val R = """.*// *typeAt *(\d+) *(\d+) *$""".r
+      buf match {
+        case R(s, e) if cursor == buf.length => (true, s.toInt, e.toInt)
+        case _ => (false, -1, -1)
+      }
+    }
+    intp.presentationCompile(buf) match {
+      case Left(_) => Completion.NoCandidates
+      case Right(result) => try {
+        if (printMode) {
+          val offset = result.preambleLength
+          val pos1 = result.unit.source.position(offset).withEnd(offset + buf.length)
+          import result.compiler._
+          val tree = new Locator(pos1) locateIn result.unit.body match {
+            case Template(_, _, constructor :: (rest :+ last)) => if (rest.isEmpty) last else Block(rest, last)
+            case t => t
+          }
+          val printed = showCode(tree)
+          Candidates(cursor, "" :: printed :: Nil)
+        } else if (typeAtMode) {
+          val tp = intp.api.typeAt(buf, start, end)
+          Candidates(cursor, "" :: tp ++: Nil)
+        } else {
+          import result.CompletionResult._
+          result.completionsOf(buf, cursor) match {
+            case TypeMembers(newCursor, result.compiler.Select(qual, name), members) =>
+              if (tabCount > 0 && members.forall(_.sym.name == name)) {
+                val defStrings = members.flatMap(_.sym.alternatives).map(sym => sym.defStringSeenAs(qual.tpe memberType sym))
+                Candidates(cursor, "" :: defStrings)
+              } else {
+                val memberCompletions: List[String] = members.map(_.sym.name.decoded)
+                Candidates(newCursor, memberCompletions)
+              }
+            case ScopeMembers(newCursor, members) =>
+              Candidates(newCursor, members.map(_.sym.name.decoded))
+            case _ =>
+              Completion.NoCandidates
+          }
+        }
+      } finally result.cleanup()
+    }
+  }
+}

--- a/test/files/jvm/interpreter.check
+++ b/test/files/jvm/interpreter.check
@@ -30,7 +30,7 @@ scala> val four: anotherint = 4
 four: anotherint = 4
 
 scala> val bogus: anotherint = "hello"
-<console>:11: error: type mismatch;
+<console>:12: error: type mismatch;
  found   : String("hello")
  required: anotherint
     (which expands to)  Int
@@ -353,7 +353,7 @@ defined class Term
 scala> def f(e: Exp) = e match {  // non-exhaustive warning here
   case _:Fact => 3
 }
-<console>:21: warning: match may not be exhaustive.
+<console>:22: warning: match may not be exhaustive.
 It would fail on the following inputs: Exp(), Term()
        def f(e: Exp) = e match {  // non-exhaustive warning here
                        ^
@@ -363,6 +363,6 @@ scala> :quit
 plusOne: (x: Int)Int
 res0: Int = 6
 res0: String = after reset
-<console>:11: error: not found: value plusOne
+<console>:12: error: not found: value plusOne
        plusOne(5) // should be undefined now
        ^

--- a/test/files/jvm/throws-annot-from-java.check
+++ b/test/files/jvm/throws-annot-from-java.check
@@ -1,10 +1,8 @@
 
 scala> :power
-** Power User mode enabled - BEEP WHIR GYVE **
-** :phase has been set to 'typer'.          **
-** scala.tools.nsc._ has been imported      **
-** global._, definitions._ also imported    **
-** Try  :help, :vals, power.<tab>           **
+Power mode enabled. :phase is at typer.
+import scala.tools.nsc._, intp.global._, definitions._
+Try :help or completions for vals._ and power._
 
 scala> :paste
 // Entering paste mode (ctrl-D to finish)

--- a/test/files/run/class-symbol-contravariant.check
+++ b/test/files/run/class-symbol-contravariant.check
@@ -1,10 +1,8 @@
 
 scala> :power
-** Power User mode enabled - BEEP WHIR GYVE **
-** :phase has been set to 'typer'.          **
-** scala.tools.nsc._ has been imported      **
-** global._, definitions._ also imported    **
-** Try  :help, :vals, power.<tab>           **
+Power mode enabled. :phase is at typer.
+import scala.tools.nsc._, intp.global._, definitions._
+Try :help or completions for vals._ and power._
 
 scala> val u = rootMirror.universe
 u: $r.intp.global.type = <global>

--- a/test/files/run/constant-type.check
+++ b/test/files/run/constant-type.check
@@ -1,10 +1,8 @@
 
 scala> :power
-** Power User mode enabled - BEEP WHIR GYVE **
-** :phase has been set to 'typer'.          **
-** scala.tools.nsc._ has been imported      **
-** global._, definitions._ also imported    **
-** Try  :help, :vals, power.<tab>           **
+Power mode enabled. :phase is at typer.
+import scala.tools.nsc._, intp.global._, definitions._
+Try :help or completions for vals._ and power._
 
 scala> val s = transformedType(StringClass.toType).asInstanceOf[Type]
 s: $r.intp.global.Type = String

--- a/test/files/run/constrained-types.check
+++ b/test/files/run/constrained-types.check
@@ -133,16 +133,16 @@ y: String = hello
 scala> 
 
 scala> val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
-<console>:11: error: not found: value e
+<console>:12: error: not found: value e
        val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
                               ^
-<console>:11: error: not found: value f
+<console>:12: error: not found: value f
        val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
                                 ^
-<console>:11: error: not found: value g
+<console>:12: error: not found: value g
        val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
                                   ^
-<console>:11: error: not found: value h
+<console>:12: error: not found: value h
        val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
                                     ^
 

--- a/test/files/run/kind-repl-command.check
+++ b/test/files/run/kind-repl-command.check
@@ -19,7 +19,7 @@ scala> :k new { def empty = false }
 AnyRef{def empty: Boolean}'s kind is A
 
 scala> :k Nonexisting
-<console>:11: error: not found: value Nonexisting
+<console>:12: error: not found: value Nonexisting
        Nonexisting
        ^
 

--- a/test/files/run/reify-repl-fail-gracefully.check
+++ b/test/files/run/reify-repl-fail-gracefully.check
@@ -8,7 +8,7 @@ import scala.reflect.runtime.universe._
 scala> 
 
 scala> reify
-<console>:15: error: too few argument lists for macro invocation
+<console>:16: error: too few argument lists for macro invocation
        reify
        ^
 

--- a/test/files/run/reify_newimpl_22.check
+++ b/test/files/run/reify_newimpl_22.check
@@ -15,7 +15,7 @@ scala> {
   }
   println(code.eval)
 }
-<console>:18: free term: Ident(TermName("x")) defined by res0  in <console>:17:14
+<console>:19: free term: Ident(TermName("x")) defined by res0  in <console>:18:14
          val code = reify {
                           ^
 2

--- a/test/files/run/reify_newimpl_23.check
+++ b/test/files/run/reify_newimpl_23.check
@@ -14,7 +14,7 @@ scala> def foo[T]{
   }
   println(code.eval)
 }
-<console>:16: free type: Ident(TypeName("T")) defined by foo in <console>:15:16
+<console>:17: free type: Ident(TypeName("T")) defined by foo in <console>:16:16
          val code = reify {
                           ^
 foo: [T]=> Unit

--- a/test/files/run/reify_newimpl_25.check
+++ b/test/files/run/reify_newimpl_25.check
@@ -5,7 +5,7 @@ scala> {
   val tt = implicitly[TypeTag[x.type]]
   println(tt)
 }
-<console>:14: free term: Ident(TermName("x")) defined by res0  in <console>:13:14
+<console>:15: free term: Ident(TermName("x")) defined by res0  in <console>:14:14
          val tt = implicitly[TypeTag[x.type]]
                             ^
 TypeTag[x.type]

--- a/test/files/run/reify_newimpl_26.check
+++ b/test/files/run/reify_newimpl_26.check
@@ -4,7 +4,7 @@ scala> def foo[T]{
   val tt = implicitly[WeakTypeTag[List[T]]]
   println(tt)
 }
-<console>:12: free type: Ident(TypeName("T")) defined by foo in <console>:10:16
+<console>:13: free type: Ident(TypeName("T")) defined by foo in <console>:11:16
          val tt = implicitly[WeakTypeTag[List[T]]]
                             ^
 foo: [T]=> Unit

--- a/test/files/run/repl-bare-expr.check
+++ b/test/files/run/repl-bare-expr.check
@@ -1,12 +1,12 @@
 
 scala> 2 ; 3
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        2 ;;
        ^
 res0: Int = 3
 
 scala> { 2 ; 3 }
-<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:12: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        { 2 ; 3 }
          ^
 res1: Int = 3
@@ -15,16 +15,16 @@ scala> 5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Mooo
   1 +
   2 +
   3 } ; bippy+88+11
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
        ^
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
            ^
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
                                   ^
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
                                                                                          ^
 defined object Cow

--- a/test/files/run/repl-parens.check
+++ b/test/files/run/repl-parens.check
@@ -18,10 +18,10 @@ scala>   (  (2 + 2 )  )
 res5: Int = 4
 
 scala> 5 ;   (  (2 + 2 )  ) ; ((5))
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        5 ;   (  (2 + 2 )  ) ;;
        ^
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        5 ;   (  (2 + 2 )  ) ;;
                    ^
 res6: Int = 5
@@ -38,16 +38,16 @@ res9: String = 4423
 scala> 
 
 scala> 55 ; ((2 + 2)) ; (1, 2, 3)
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        55 ; ((2 + 2)) ;;
        ^
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        55 ; ((2 + 2)) ;;
                 ^
 res10: (Int, Int, Int) = (1,2,3)
 
 scala> 55 ; (x: Int) => x + 1 ; () => ((5))
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        55 ; (x: Int) => x + 1 ;;
        ^
 res11: () => Int = <function0>
@@ -58,7 +58,7 @@ scala> () => 5
 res12: () => Int = <function0>
 
 scala> 55 ; () => 5
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        55 ;;
        ^
 res13: () => Int = <function0>

--- a/test/files/run/repl-paste-2.check
+++ b/test/files/run/repl-paste-2.check
@@ -1,7 +1,7 @@
 
 scala> scala> 999l
 
-// Detected repl transcript paste: ctrl-D to finish.
+// Detected repl transcript. Paste more, or ctrl-D to finish.
 
 res4: Int = 0123
 

--- a/test/files/run/repl-paste-2.check
+++ b/test/files/run/repl-paste-2.check
@@ -42,7 +42,7 @@ scala> res5 + res6
 res1: Int = 690
 
 scala> val x = dingus
-<console>:10: error: not found: value dingus
+<console>:11: error: not found: value dingus
        val x = dingus
                ^
 

--- a/test/files/run/repl-power.check
+++ b/test/files/run/repl-power.check
@@ -1,10 +1,8 @@
 
 scala> :power
-** Power User mode enabled - BEEP WHIR GYVE **
-** :phase has been set to 'typer'.          **
-** scala.tools.nsc._ has been imported      **
-** global._, definitions._ also imported    **
-** Try  :help, :vals, power.<tab>           **
+Power mode enabled. :phase is at typer.
+import scala.tools.nsc._, intp.global._, definitions._
+Try :help or completions for vals._ and power._
 
 scala> // guarding against "error: reference to global is ambiguous"
 

--- a/test/files/run/repl-reset.check
+++ b/test/files/run/repl-reset.check
@@ -28,13 +28,13 @@ Forgetting all expression results and named terms: $intp, BippyBungus, x1, x2, x
 Forgetting defined types: BippyBungus
 
 scala> x1 + x2 + x3
-<console>:11: error: not found: value x1
+<console>:12: error: not found: value x1
        x1 + x2 + x3
        ^
-<console>:11: error: not found: value x2
+<console>:12: error: not found: value x2
        x1 + x2 + x3
             ^
-<console>:11: error: not found: value x3
+<console>:12: error: not found: value x3
        x1 + x2 + x3
                  ^
 
@@ -42,7 +42,7 @@ scala> val x1 = 4
 x1: Int = 4
 
 scala> new BippyBungus
-<console>:11: error: not found: type BippyBungus
+<console>:12: error: not found: type BippyBungus
        new BippyBungus
            ^
 

--- a/test/files/run/repl-transcript.check
+++ b/test/files/run/repl-transcript.check
@@ -1,7 +1,7 @@
 
 scala> scala> class Bippity
 
-// Detected repl transcript paste: ctrl-D to finish.
+// Detected repl transcript. Paste more, or ctrl-D to finish.
 
 defined class Bippity
 

--- a/test/files/run/repl-trim-stack-trace.scala
+++ b/test/files/run/repl-trim-stack-trace.scala
@@ -12,7 +12,7 @@ f: Nothing
 
 scala> f
 java.lang.Exception: Uh-oh
-  at .f(<console>:10)
+  at .f(<console>:11)
   ... 69 elided
 
 scala> def f = throw new Exception("")
@@ -20,7 +20,7 @@ f: Nothing
 
 scala> f
 java.lang.Exception:
-  at .f(<console>:10)
+  at .f(<console>:11)
   ... 69 elided
 
 scala> def f = throw new Exception
@@ -28,7 +28,7 @@ f: Nothing
 
 scala> f
 java.lang.Exception
-  at .f(<console>:10)
+  at .f(<console>:11)
   ... 69 elided
 
 scala> :quit"""

--- a/test/files/run/t1931.scala
+++ b/test/files/run/t1931.scala
@@ -1,0 +1,43 @@
+
+import scala.tools.partest.SessionTest
+
+object Test extends SessionTest {
+
+  def session =
+"""
+scala> val x: Any = 42
+x: Any = 42
+
+scala> x + " works"
+res0: String = 42 works
+
+scala> import Predef.{ any2stringadd => _, _ }
+import Predef.{any2stringadd=>_, _}
+
+scala> x + " works"
+<console>:14: error: value + is not a member of Any
+       x + " works"
+         ^
+
+scala> import Predef._
+import Predef._
+
+scala> x + " works"
+res2: String = 42 works
+
+scala> object Predef { def f = 42 }
+defined object Predef
+
+scala> import Predef._
+import Predef._
+
+scala> f
+<console>:14: error: not found: value f
+       f
+       ^
+
+scala> Predef.f
+res4: Int = 42
+
+scala> :quit"""
+}

--- a/test/files/run/t4438.scala
+++ b/test/files/run/t4438.scala
@@ -1,0 +1,38 @@
+
+
+import scala.tools.nsc.Settings
+import scala.tools.nsc.interpreter.{ IMain, PresentationCompilerCompleter }
+
+import java.io.{ PrintWriter, StringWriter }
+
+
+object Test extends App {
+  // completion hangs off of JLine, which we lack in Testland. Note the trailing tab.
+  def session =
+    s"""|
+        |scala> Array(1, 2, 3) rev\u0009
+        | reverseIterator   reverse   reverseMap   reversed
+        |
+        |scala> :quit"""
+
+  val settings = new Settings()
+  settings.Xnojline.value = true
+  settings.usejavacp.value = true
+
+  val writer = new StringWriter
+  val out = new PrintWriter(writer)
+
+  val intp = new IMain(settings, out)
+
+  val completer = new PresentationCompilerCompleter(intp)
+
+  def `pcc handles extension methods of primitive arrays`() = {
+    val code = "Array(1, 2, 3) rev"
+    val candidates = completer.complete(code, code.length)
+
+    assert(candidates.candidates.size == 5)
+    assert((candidates.candidates.distinct.sorted mkString ", ") == "reverse, reverseIterator, reverseMap, reversed")
+  }
+
+  `pcc handles extension methods of primitive arrays`()
+}

--- a/test/files/run/t4542.check
+++ b/test/files/run/t4542.check
@@ -5,7 +5,7 @@ scala> @deprecated("foooo", "ReplTest version 1.0-FINAL") class Foo() {
 defined class Foo
 
 scala> val f = new Foo
-<console>:11: warning: class Foo is deprecated: foooo
+<console>:12: warning: class Foo is deprecated: foooo
        val f = new Foo
                    ^
 f: Foo = Bippy

--- a/test/files/run/t4594-repl-settings.scala
+++ b/test/files/run/t4594-repl-settings.scala
@@ -15,7 +15,7 @@ object Test extends SessionTest {
    |scala> :settings -deprecation
    |
    |scala> def b = depp
-   |<console>:11: warning: method depp is deprecated: Please don't do that.
+   |<console>:12: warning: method depp is deprecated: Please don't do that.
    |       def b = depp
    |               ^
    |b: String

--- a/test/files/run/t5655.check
+++ b/test/files/run/t5655.check
@@ -6,7 +6,7 @@ scala> import x._
 import x._
 
 scala> x
-<console>:15: error: reference to x is ambiguous;
+<console>:16: error: reference to x is ambiguous;
 it is imported twice in the same scope by
 import x._
 and import x
@@ -14,7 +14,7 @@ and import x
        ^
 
 scala> x
-<console>:15: error: reference to x is ambiguous;
+<console>:16: error: reference to x is ambiguous;
 it is imported twice in the same scope by
 import x._
 and import x

--- a/test/files/run/t6146b.check
+++ b/test/files/run/t6146b.check
@@ -4,11 +4,9 @@ It would fail on the following inputs: S2(), S3()
                        ^
 
 scala> :power
-** Power User mode enabled - BEEP WHIR GYVE **
-** :phase has been set to 'typer'.          **
-** scala.tools.nsc._ has been imported      **
-** global._, definitions._ also imported    **
-** Try  :help, :vals, power.<tab>           **
+Power mode enabled. :phase is at typer.
+import scala.tools.nsc._, intp.global._, definitions._
+Try :help or completions for vals._ and power._
 
 scala> val u = rootMirror.universe; import u._, language._
 u: $r.intp.global.type = <global>

--- a/test/files/run/t6439.check
+++ b/test/files/run/t6439.check
@@ -48,11 +48,9 @@ scala> type F = Int // no warn
 defined type alias F
 
 scala> :power
-** Power User mode enabled - BEEP WHIR GYVE **
-** :phase has been set to 'typer'.          **
-** scala.tools.nsc._ has been imported      **
-** global._, definitions._ also imported    **
-** Try  :help, :vals, power.<tab>           **
+Power mode enabled. :phase is at typer.
+import scala.tools.nsc._, intp.global._, definitions._
+Try :help or completions for vals._ and power._
 
 scala> object lookup {
   import intp._

--- a/test/files/run/t7319.check
+++ b/test/files/run/t7319.check
@@ -15,21 +15,21 @@ warning: there was one feature warning; re-run with -feature for details
 convert: [F[X <: F[X]]](builder: F[_ <: F[_]])Int
 
 scala> convert(Some[Int](0))
-<console>:15: error: no type parameters for method convert: (builder: F[_ <: F[_]])Int exist so that it can be applied to arguments (Some[Int])
+<console>:16: error: no type parameters for method convert: (builder: F[_ <: F[_]])Int exist so that it can be applied to arguments (Some[Int])
  --- because ---
 argument expression's type is not compatible with formal parameter type;
  found   : Some[Int]
  required: ?F[_$1] forSome { type _$1 <: ?F[_$2] forSome { type _$2 } }
        convert(Some[Int](0))
        ^
-<console>:15: error: type mismatch;
+<console>:16: error: type mismatch;
  found   : Some[Int]
  required: F[_ <: F[_]]
        convert(Some[Int](0))
                         ^
 
 scala> Range(1,2).toArray: Seq[_]
-<console>:14: error: polymorphic expression cannot be instantiated to expected type;
+<console>:15: error: polymorphic expression cannot be instantiated to expected type;
  found   : [B >: Int]Array[B]
  required: Seq[_]
        Range(1,2).toArray: Seq[_]

--- a/test/files/run/t7747-repl.check
+++ b/test/files/run/t7747-repl.check
@@ -295,11 +295,9 @@ scala> b(a)
 res4: String = Found Sum
 
 scala> :power
-** Power User mode enabled - BEEP WHIR GYVE **
-** :phase has been set to 'typer'.          **
-** scala.tools.nsc._ has been imported      **
-** global._, definitions._ also imported    **
-** Try  :help, :vals, power.<tab>           **
+Power mode enabled. :phase is at typer.
+import scala.tools.nsc._, intp.global._, definitions._
+Try :help or completions for vals._ and power._
 
 scala> intp.lastRequest
 res5: $r.intp.Request = Request(line=def $ires3 = intp.global, 1 trees)

--- a/test/files/run/t7747-repl.check
+++ b/test/files/run/t7747-repl.check
@@ -15,13 +15,13 @@ scala> val z = x * y
 z: Int = 156
 
 scala> 2 ; 3
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        2 ;;
        ^
 res0: Int = 3
 
 scala> { 2 ; 3 }
-<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:12: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        { 2 ; 3 }
          ^
 res1: Int = 3
@@ -30,16 +30,16 @@ scala> 5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Mooo
   1 +
   2 +
   3 } ; bippy+88+11
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
        ^
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
            ^
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
                                   ^
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
                                                                                          ^
 defined object Cow
@@ -81,10 +81,10 @@ scala>   (  (2 + 2 )  )
 res10: Int = 4
 
 scala> 5 ;   (  (2 + 2 )  ) ; ((5))
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        5 ;   (  (2 + 2 )  ) ;;
        ^
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        5 ;   (  (2 + 2 )  ) ;;
                    ^
 res11: Int = 5
@@ -101,16 +101,16 @@ res14: String = 4423
 scala> 
 
 scala> 55 ; ((2 + 2)) ; (1, 2, 3)
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        55 ; ((2 + 2)) ;;
        ^
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        55 ; ((2 + 2)) ;;
                 ^
 res15: (Int, Int, Int) = (1,2,3)
 
 scala> 55 ; (x: Int) => x + 1 ; () => ((5))
-<console>:12: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:13: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        55 ; (x: Int) => x + 1 ;;
        ^
 res16: () => Int = <function0>
@@ -121,7 +121,7 @@ scala> () => 5
 res17: () => Int = <function0>
 
 scala> 55 ; () => 5
-<console>:10: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
        55 ;;
        ^
 res18: () => Int = <function0>
@@ -209,13 +209,13 @@ Forgetting all expression results and named terms: $intp, BippyBungus, Bovine, C
 Forgetting defined types: BippyBungus, Moo, Ruminant
 
 scala> x1 + x2 + x3
-<console>:11: error: not found: value x1
+<console>:12: error: not found: value x1
        x1 + x2 + x3
        ^
-<console>:11: error: not found: value x2
+<console>:12: error: not found: value x2
        x1 + x2 + x3
             ^
-<console>:11: error: not found: value x3
+<console>:12: error: not found: value x3
        x1 + x2 + x3
                  ^
 
@@ -223,7 +223,7 @@ scala> val x1 = 4
 x1: Int = 4
 
 scala> new BippyBungus
-<console>:11: error: not found: type BippyBungus
+<console>:12: error: not found: type BippyBungus
        new BippyBungus
            ^
 

--- a/test/files/run/t9170.scala
+++ b/test/files/run/t9170.scala
@@ -8,17 +8,17 @@ object Test extends SessionTest {
   def session =
 """
 scala> object Y { def f[A](a: => A) = 1 ; def f[A](a: => Either[Exception, A]) = 2 }
-<console>:10: error: double definition:
-def f[A](a: => A): Int at line 10 and
-def f[A](a: => Either[Exception,A]): Int at line 10
+<console>:11: error: double definition:
+def f[A](a: => A): Int at line 11 and
+def f[A](a: => Either[Exception,A]): Int at line 11
 have same type after erasure: (a: Function0)Int
        object Y { def f[A](a: => A) = 1 ; def f[A](a: => Either[Exception, A]) = 2 }
                                               ^
 
 scala> object Y { def f[A](a: => A) = 1 ; def f[A](a: => Either[Exception, A]) = 2 }
-<console>:10: error: double definition:
-def f[A](a: => A): Int at line 10 and
-def f[A](a: => Either[Exception,A]): Int at line 10
+<console>:11: error: double definition:
+def f[A](a: => A): Int at line 11 and
+def f[A](a: => Either[Exception,A]): Int at line 11
 have same type after erasure: (a: Function0)Int
        object Y { def f[A](a: => A) = 1 ; def f[A](a: => Either[Exception, A]) = 2 }
                                               ^
@@ -27,9 +27,9 @@ scala> object Y {
      |   def f[A](a: =>  A) = 1
      |   def f[A](a: => Either[Exception, A]) = 2
      | }
-<console>:12: error: double definition:
-def f[A](a: => A): Int at line 11 and
-def f[A](a: => Either[Exception,A]): Int at line 12
+<console>:13: error: double definition:
+def f[A](a: => A): Int at line 12 and
+def f[A](a: => Either[Exception,A]): Int at line 13
 have same type after erasure: (a: Function0)Int
          def f[A](a: => Either[Exception, A]) = 2
              ^
@@ -44,9 +44,9 @@ object Y {
 
 // Exiting paste mode, now interpreting.
 
-<console>:12: error: double definition:
-def f[A](a: => A): Int at line 11 and
-def f[A](a: => Either[Exception,A]): Int at line 12
+<console>:13: error: double definition:
+def f[A](a: => A): Int at line 12 and
+def f[A](a: => Either[Exception,A]): Int at line 13
 have same type after erasure: (a: Function0)Int
          def f[A](a: => Either[Exception, A]) = 2
              ^

--- a/test/files/run/t9206.scala
+++ b/test/files/run/t9206.scala
@@ -7,14 +7,14 @@ object Test extends SessionTest {
   def session =
     s"""|
         |scala> val i: Int = "foo"
-        |<console>:10: error: type mismatch;
+        |<console>:11: error: type mismatch;
         | found   : String("foo")
         | required: Int
         |       val i: Int = "foo"
         |                    ^
         |
         |scala> { val j = 42 ; val i: Int = "foo" + j }
-        |<console>:11: error: type mismatch;
+        |<console>:12: error: type mismatch;
         | found   : String
         | required: Int
         |       { val j = 42 ; val i: Int = "foo" + j }

--- a/test/files/run/tpeCache-tyconCache.check
+++ b/test/files/run/tpeCache-tyconCache.check
@@ -1,10 +1,8 @@
 
 scala> :power
-** Power User mode enabled - BEEP WHIR GYVE **
-** :phase has been set to 'typer'.          **
-** scala.tools.nsc._ has been imported      **
-** global._, definitions._ also imported    **
-** Try  :help, :vals, power.<tab>           **
+Power mode enabled. :phase is at typer.
+import scala.tools.nsc._, intp.global._, definitions._
+Try :help or completions for vals._ and power._
 
 scala> 
 

--- a/test/files/run/xMigration.check
+++ b/test/files/run/xMigration.check
@@ -10,7 +10,7 @@ res1: Iterable[String] = MapLike(eis)
 scala> :setting -Xmigration:any
 
 scala> Map(1 -> "eis").values    // warn
-<console>:11: warning: method values in trait MapLike has changed semantics in version 2.8.0:
+<console>:12: warning: method values in trait MapLike has changed semantics in version 2.8.0:
 `values` returns `Iterable[B]` rather than `Iterator[B]`.
        Map(1 -> "eis").values    // warn
                        ^
@@ -24,7 +24,7 @@ res3: Iterable[String] = MapLike(eis)
 scala> :setting -Xmigration:2.7
 
 scala> Map(1 -> "eis").values    // warn
-<console>:11: warning: method values in trait MapLike has changed semantics in version 2.8.0:
+<console>:12: warning: method values in trait MapLike has changed semantics in version 2.8.0:
 `values` returns `Iterable[B]` rather than `Iterator[B]`.
        Map(1 -> "eis").values    // warn
                        ^
@@ -38,7 +38,7 @@ res5: Iterable[String] = MapLike(eis)
 scala> :setting -Xmigration      // same as :any
 
 scala> Map(1 -> "eis").values    // warn
-<console>:11: warning: method values in trait MapLike has changed semantics in version 2.8.0:
+<console>:12: warning: method values in trait MapLike has changed semantics in version 2.8.0:
 `values` returns `Iterable[B]` rather than `Iterator[B]`.
        Map(1 -> "eis").values    // warn
                        ^


### PR DESCRIPTION
The presentation compiler completer is the result of a weekend retreat on which they had nothing better to do. The completion strategy can be selected with `-Ycompletion:pc,adhoc,none`.

The usual trick for hiding `any2stradd` works in REPL.

After pasting a partial transcript in REPL, it will return you to the prompt to finish the code, e.g., if you want to modify a function def.

The merge conflicts over jline refactors and repl imports are surmounted.
