### PR TITLE
SI-9270 Default xml coalescing off in 2.12

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -140,7 +140,7 @@ trait ScalaSettings extends AbsScalaSettings
   // XML parsing options
   object XxmlSettings extends MultiChoiceEnumeration {
     val coalescing   = Choice("coalescing", "Convert PCData to Text and coalesce sibling nodes")
-    def isCoalescing = (Xxml contains coalescing) || (!isScala212 && !Xxml.isSetByUser)
+    def isCoalescing = Xxml contains coalescing
   }
   val Xxml = MultiChoiceSetting(
     name    = "-Xxml",


### PR DESCRIPTION
By default, `-Xxml:-coalescing` as of 2.12.

This commit corrects the default for future versions.

Proposing this bookkeeping change before I forget. And while the wounds are fresh.
