### PR TITLE
Upgrade scala-asm to 5.0.4-scala-3

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -33,7 +33,7 @@ scala-swing.version.number=1.0.2
 akka-actor.version.number=2.3.10
 actors-migration.version.number=1.1.0
 jline.version=2.12.1
-scala-asm.version=5.0.4-scala-2
+scala-asm.version=5.0.4-scala-3
 
 # external modules, used internally (not shipped)
 partest.version.number=1.0.7


### PR DESCRIPTION
Fixes a crash in the backend when the bytecode of a method is too
large (https://github.com/scala/scala-asm/issues/8).
