### PR TITLE
Spec: match SI-2066 fix in chapter 3

### DIFF
--- a/spec/03-types.md
+++ b/spec/03-types.md
@@ -886,11 +886,14 @@ transitive relation that satisfies the following conditions.
   that:
     - The bounds on $a_i$ must be weaker than the corresponding bounds declared
       for $a'_i$.
-    - The variance of $a_i$ must match the variance of $a'_i$, where covariance
-      matches covariance, contravariance matches contravariance and any variance
-      matches invariance.
-    - Recursively, these restrictions apply to the corresponding higher-order
-      type parameter clauses of $a_i$ and $a'_i$.
+    - The variance of $a_i$ must match the variance of $a'_i$, where
+      covariance matches covariance, contravariance matches
+      contravariance and any variance matches invariance.  (This is
+      not symmetric; only invariant $a'_i$ matches any variance of
+      $a_i$.)
+    - Recursively, these restrictions apply to the corresponding
+      higher-order type parameter clauses of $a'_i$ and $a_i$.  (Note
+      that the direction of consideration of conformance is reversed.)
 
 A declaration or definition in some compound type of class type $C$
 _subsumes_ another declaration of the same name in some compound type or class


### PR DESCRIPTION
Broadly, this updates the spec to match the discussions and implementation of #3184.

This first clarifies the meaning of "matches" in the description of how variances are compared.  Because, like conformance itself, this relation is not symmetric.

Secondly, it specifies the "flipping" subsumption of variance described in #3184, along with the requisite "flipping" of expected bounds-weakening, by specifying the "contravariant" nature of the recursive descent into type constructor parameters.
