### PR TITLE
SI-9422 Fix incorrect constant propagation

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/opt/ConstantOptimization.scala
+++ b/src/compiler/scala/tools/nsc/backend/opt/ConstantOptimization.scala
@@ -170,9 +170,11 @@ abstract class ConstantOptimization extends SubComponent {
         // out all the possibilities
         case Impossible(possible2) => (possible -- possible2).nonEmpty
       })
-      def mightNotEqual(other: Contents): Boolean = (this ne other) && (other match {
-        // two Possibles might not be equal if either has possible members that the other doesn't
-        case Possible(possible2) => (possible -- possible2).nonEmpty || (possible2 -- possible).nonEmpty
+      def mightNotEqual(other: Contents): Boolean = (other match {
+        case Possible(possible2) =>
+          // two Possibles must equal if each is known to be of the same, single value
+          val mustEqual = possible.size == 1 && possible == possible2
+          !mustEqual
         case Impossible(_) => true
       })
     }

--- a/test/files/run/t9422.scala
+++ b/test/files/run/t9422.scala
@@ -1,0 +1,11 @@
+class Test(val x: Long) {
+  def sameDirection(y: Long): Boolean =
+    (y == 0 || x == 0 || ((y > 0) == (x > 0)))
+}
+ 
+object Test {
+  def main(args: Array[String]) {
+    val b = new Test(1L)
+    assert(!b.sameDirection(-1L))
+  }
+}


### PR DESCRIPTION
The ConstantOptimization phase uses abstract interpretation
to track what is known about values, and then to use this information
to optimize away tests with a statically known result.

Constant propagation was added under -optimize in Scala 2.11.0-M3, in
PR #2214.

For example, we might know that a variable must hold one of a set
of values (`Possible`). Or, we could track that it must _not_
be of of a set of value (`Impossible`).

The test case in the bug report was enough to create comparison:

```
v1 == v2 // where V1 = Possible(Set(true, false))
         //       V2 = Possible(Set(true, false))
```

This test was considered to be always true, due to a bug in
`Possible#mightNotEqual`. The only time we can be sure that
`Possible(p1) mightNotEquals Possible(p2)` is if
`p1` and `p2` are the same singleton set. This commit changes
this method to implement this logic.

The starting assumption for all values is currently
`Impossible(Set())`, although it would also be reasonable to represent
an unknown boolean variable as `Possible(Set(true, false))`, given
the finite and small domain.

I tried to change the starting assumption for boolean locals in
exactly this manner, and that brings the bug into sharp focus.

Under this patch:

```
https://github.com/retronym/scala/commit/e564fe522d
```

This code:

   def test(a: Boolean, b: Boolean) = a == b

Compiles to:

  public boolean test(boolean, boolean);
    Code:
       0: iconst_1
       1: ireturn

Note: the enclosed test case does not list `-optimize` in a `.flags`
file, I'm relying on that being passed in by the validation build.
I've tested locally with that option, though.

Review by @lrytz
