### PR TITLE
SI-6806 Add an @implicitAmbiguous annotation

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -1212,7 +1212,8 @@ trait ContextErrors {
 
     import definitions._
 
-    def AmbiguousImplicitError(info1: ImplicitInfo, info2: ImplicitInfo,
+    def AmbiguousImplicitError(info1: ImplicitInfo, tree1: Tree,
+                               info2: ImplicitInfo, tree2: Tree,
                                pre1: String, pre2: String, trailer: String)
                                (isView: Boolean, pt: Type, tree: Tree)(implicit context0: Context) = {
       if (!info1.tpe.isErroneous && !info2.tpe.isErroneous) {
@@ -1248,10 +1249,20 @@ trait ContextErrors {
             if (explanation == "") "" else "\n" + explanation
           )
         }
+
+        def treeTypeArgs(annotatedTree: Tree) = annotatedTree match {
+          case TypeApply(_, args) => args.map(_.toString)
+          case _ => Nil
+        }
+
         context.issueAmbiguousError(AmbiguousImplicitTypeError(tree,
-          if (isView) viewMsg
-          else s"ambiguous implicit values:\n${coreMsg}match expected type $pt")
-        )
+          (tree1.symbol, tree2.symbol) match {
+            case (ImplicitAmbiguousMsg(msg), _) => msg.format(treeTypeArgs(tree1))
+            case (_, ImplicitAmbiguousMsg(msg)) => msg.format(treeTypeArgs(tree2))
+            case (_, _) if isView => viewMsg
+            case (_, _) => s"ambiguous implicit values:\n${coreMsg}match expected type $pt"
+          }
+        ))
       }
     }
 

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1468,10 +1468,13 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
         case m: MemberDef =>
           val sym = m.symbol
           applyChecks(sym.annotations)
-          // validate implicitNotFoundMessage
-          analyzer.ImplicitNotFoundMsg.check(sym) foreach { warn =>
-            reporter.warning(tree.pos, f"Invalid implicitNotFound message for ${sym}%s${sym.locationString}%s:%n$warn")
-          }
+
+          def messageWarning(name: String)(warn: String) =
+            reporter.warning(tree.pos, f"Invalid $name message for ${sym}%s${sym.locationString}%s:%n$warn")
+
+          // validate implicitNotFoundMessage and implicitAmbiguousMessage
+          analyzer.ImplicitNotFoundMsg.check(sym) foreach messageWarning("implicitNotFound")
+          analyzer.ImplicitAmbiguousMsg.check(sym) foreach messageWarning("implicitAmbiguous")
 
         case tpt@TypeTree() =>
           if(tpt.original != null) {

--- a/src/library/scala/annotation/implicitAmbiguous.scala
+++ b/src/library/scala/annotation/implicitAmbiguous.scala
@@ -1,0 +1,34 @@
+package scala.annotation
+
+import scala.annotation.meta._
+
+/**
+  * To customize the error message that's emitted when an implicit of type
+  * C[T1,..., TN] is found more than once, annotate the class C
+  * with @implicitAmbiguous. Assuming C has type parameters X1,..., XN, the
+  * error message will be the result of replacing all occurrences of ${Xi} in
+  * the string msg with the string representation of the corresponding type
+  * argument Ti. *
+  *
+  * If more than one @implicitAmbiguous annotation is collected, the compiler is
+  * free to pick any of them to display.
+  *
+  * Nice errors can direct users to fix imports or even tell them why code
+  * intentionally doesn't compile.
+  *
+  * {{{
+  * trait =!=[C, D]
+  *
+  * implicit def neq[E, F] : E =!= F = null
+  *
+  * @annotation.implicitAmbiguous("Could not prove ${J} =!= ${J}")
+  * implicit def neqAmbig1[G, H, J] : J =!= J = null
+  * implicit def neqAmbig2[I] : I =!= I = null
+  *
+  * implicitly[Int =!= Int]
+  * }}}
+  *
+  * @author Brian McKenna
+  * @since 2.12.0
+  */
+final class implicitAmbiguous(msg: String) extends scala.annotation.StaticAnnotation {}

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1103,6 +1103,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val BridgeClass                = requiredClass[scala.annotation.bridge]
     lazy val ElidableMethodClass        = requiredClass[scala.annotation.elidable]
     lazy val ImplicitNotFoundClass      = requiredClass[scala.annotation.implicitNotFound]
+    lazy val ImplicitAmbiguousClass     = getClassIfDefined("scala.annotation.implicitAmbiguous")
     lazy val MigrationAnnotationClass   = requiredClass[scala.annotation.migration]
     lazy val ScalaStrictFPAttr          = requiredClass[scala.annotation.strictfp]
     lazy val SwitchClass                = requiredClass[scala.annotation.switch]

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -884,10 +884,11 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     // string.  So this needs attention.  For now the fact that migration is
     // private[scala] ought to provide enough protection.
     def hasMigrationAnnotation = hasAnnotation(MigrationAnnotationClass)
-    def migrationMessage    = getAnnotation(MigrationAnnotationClass) flatMap { _.stringArg(0) }
-    def migrationVersion    = getAnnotation(MigrationAnnotationClass) flatMap { _.stringArg(1) }
-    def elisionLevel        = getAnnotation(ElidableMethodClass) flatMap { _.intArg(0) }
-    def implicitNotFoundMsg = getAnnotation(ImplicitNotFoundClass) flatMap { _.stringArg(0) }
+    def migrationMessage     = getAnnotation(MigrationAnnotationClass) flatMap { _.stringArg(0) }
+    def migrationVersion     = getAnnotation(MigrationAnnotationClass) flatMap { _.stringArg(1) }
+    def elisionLevel         = getAnnotation(ElidableMethodClass) flatMap { _.intArg(0) }
+    def implicitNotFoundMsg  = getAnnotation(ImplicitNotFoundClass) flatMap { _.stringArg(0) }
+    def implicitAmbiguousMsg = getAnnotation(ImplicitAmbiguousClass) flatMap { _.stringArg(0) }
 
     def isCompileTimeOnly       = hasAnnotation(CompileTimeOnlyAttr)
     def compileTimeOnlyMessage  = getAnnotation(CompileTimeOnlyAttr) flatMap (_ stringArg 0)

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -370,6 +370,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.BridgeClass
     definitions.ElidableMethodClass
     definitions.ImplicitNotFoundClass
+    definitions.ImplicitAmbiguousClass
     definitions.MigrationAnnotationClass
     definitions.ScalaStrictFPAttr
     definitions.SwitchClass

--- a/test/files/neg/implicit-ambiguous-2.check
+++ b/test/files/neg/implicit-ambiguous-2.check
@@ -1,0 +1,4 @@
+implicit-ambiguous-2.scala:10: error: Could not prove Int =!= Int
+  implicitly[Int =!= Int]
+            ^
+one error found

--- a/test/files/neg/implicit-ambiguous-2.scala
+++ b/test/files/neg/implicit-ambiguous-2.scala
@@ -1,0 +1,11 @@
+object Test {
+  trait =!=[C, D]
+
+  implicit def neq[E, F] : E =!= F = null
+
+  implicit def neqAmbig1[G, H, J] : J =!= J = null
+  @annotation.implicitAmbiguous("Could not prove ${I} =!= ${I}")
+  implicit def neqAmbig2[I] : I =!= I = null
+
+  implicitly[Int =!= Int]
+}

--- a/test/files/neg/implicit-ambiguous-invalid.check
+++ b/test/files/neg/implicit-ambiguous-invalid.check
@@ -1,0 +1,7 @@
+implicit-ambiguous-invalid.scala:5: warning: Invalid implicitAmbiguous message for method neqAmbig1 in object Test:
+The type parameter B referenced in the message of the @implicitAmbiguous annotation is not defined by method neqAmbig1.
+  implicit def neqAmbig1[A] : A =!= A = null
+               ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/implicit-ambiguous-invalid.flags
+++ b/test/files/neg/implicit-ambiguous-invalid.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/implicit-ambiguous-invalid.scala
+++ b/test/files/neg/implicit-ambiguous-invalid.scala
@@ -1,0 +1,6 @@
+object Test {
+  trait =!=[C, D]
+
+  @annotation.implicitAmbiguous("Could not prove ${A} =!= ${B}")
+  implicit def neqAmbig1[A] : A =!= A = null
+}

--- a/test/files/neg/implicit-ambiguous.check
+++ b/test/files/neg/implicit-ambiguous.check
@@ -1,0 +1,4 @@
+implicit-ambiguous.scala:10: error: Could not prove Int =!= Int
+  implicitly[Int =!= Int]
+            ^
+one error found

--- a/test/files/neg/implicit-ambiguous.scala
+++ b/test/files/neg/implicit-ambiguous.scala
@@ -1,0 +1,11 @@
+object Test {
+  trait =!=[C, D]
+
+  implicit def neq[E, F] : E =!= F = null
+
+  @annotation.implicitAmbiguous("Could not prove ${J} =!= ${J}")
+  implicit def neqAmbig1[G, H, J] : J =!= J = null
+  implicit def neqAmbig2[I] : I =!= I = null
+
+  implicitly[Int =!= Int]
+}


### PR DESCRIPTION
Resolves SI-6806

Example usage:

``` scala
trait =!=[C, D]

implicit def neq[E, F] : E =!= F = null

@annotation.implicitAmbiguous("Could not prove ${J} =!= ${J}")
implicit def neqAmbig1[G, H, J] : J =!= J = null
implicit def neqAmbig2[I] : I =!= I = null

implicitly[Int =!= Int]
```

Which gives the following error:

```
implicit-ambiguous.scala:9: error: Could not prove Int =!= Int
  implicitly[Int =!= Int]
            ^
```

Better than what was previously given:

```
implicit-ambiguous.scala:9: error: ambiguous implicit values:
 both method neqAmbig1 in object Test of type [G, H, J]=> Main.$anon.Test.=!=[J,J]
 and method neqAmbig2 in object Test of type [I]=> Main.$anon.Test.=!=[I,I]
 match expected type Main.$anon.Test.=!=[Int,Int]
  implicitly[Int =!= Int]
            ^
```
