### PR TITLE
SI-9425 Leave Companion.apply if constructor is less accessible

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1511,7 +1511,8 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
         sym.isSourceMethod &&
         sym.isCase &&
         sym.name == nme.apply &&
-        isClassTypeAccessible(tree)
+        isClassTypeAccessible(tree) &&
+        !tree.tpe.resultType.typeSymbol.primaryConstructor.isLessAccessibleThan(tree.symbol)
 
       if (doTransform) {
         tree foreach {

--- a/test/files/run/t9425.scala
+++ b/test/files/run/t9425.scala
@@ -1,0 +1,8 @@
+class C { case class Foo private (x: Int); Foo.apply(0) }
+
+object Test {
+  def test(c: C) = {import c.Foo; Foo.apply(0)}
+  def main(args: Array[String]): Unit = {
+    test(new C)
+  }  
+}


### PR DESCRIPTION
Calls to synthetic case class apply methods are inlined to the
underlying constructor invocation in refchecks.

However, this can lead to accessibility errors if the constructor
is private.

This commit ensures that the constructor is at least as accessible
as the apply method before performing this tranform.

I've manually checked that other the optimization still works in other
cases:

scala> class CaseApply { Some(42)  }
defined class CaseApply

```
scala> :javap -c CaseApply
Compiled from "<console>"
public class CaseApply {
  public CaseApply();
    Code:
       0: aload_0
       1: invokespecial #9                  // Method java/lang/Object."<init>":()V
       4: new           #11                 // class scala/Some
       7: dup
       8: bipush        42
      10: invokestatic  #17                 // Method scala/runtime/BoxesRunTime.boxToInteger:(I)Ljava/lang/Integer;
      13: invokespecial #20                 // Method scala/Some."<init>":(Ljava/lang/Object;)V
      16: pop
      17: return
}
```
