### PR TITLE
SI-9426 Rename the argument f of LinearSeqOptimized.foldLeft/foldRight to op

### DIFF
--- a/src/library/scala/collection/LinearSeqOptimized.scala
+++ b/src/library/scala/collection/LinearSeqOptimized.scala
@@ -117,20 +117,20 @@ trait LinearSeqOptimized[+A, +Repr <: LinearSeqOptimized[A, Repr]] extends Linea
   }
 
   override /*TraversableLike*/
-  def foldLeft[B](z: B)(f: (B, A) => B): B = {
+  def foldLeft[B](z: B)(op: (B, A) => B): B = {
     var acc = z
     var these = this
     while (!these.isEmpty) {
-      acc = f(acc, these.head)
+      acc = op(acc, these.head)
       these = these.tail
     }
     acc
   }
 
   override /*IterableLike*/
-  def foldRight[B](z: B)(f: (A, B) => B): B =
+  def foldRight[B](z: B)(op: (A, B) => B): B =
     if (this.isEmpty) z
-    else f(head, tail.foldRight(z)(f))
+    else op(head, tail.foldRight(z)(op))
 
   override /*TraversableLike*/
   def reduceLeft[B >: A](f: (B, A) => B): B =

--- a/src/library/scala/collection/LinearSeqOptimized.scala
+++ b/src/library/scala/collection/LinearSeqOptimized.scala
@@ -133,9 +133,9 @@ trait LinearSeqOptimized[+A, +Repr <: LinearSeqOptimized[A, Repr]] extends Linea
     else op(head, tail.foldRight(z)(op))
 
   override /*TraversableLike*/
-  def reduceLeft[B >: A](f: (B, A) => B): B =
+  def reduceLeft[B >: A](op: (B, A) => B): B =
     if (isEmpty) throw new UnsupportedOperationException("empty.reduceLeft")
-    else tail.foldLeft[B](head)(f)
+    else tail.foldLeft[B](head)(op)
 
   override /*IterableLike*/
   def reduceRight[B >: A](op: (A, B) => B): B =

--- a/src/library/scala/collection/LinearSeqOptimized.scala
+++ b/src/library/scala/collection/LinearSeqOptimized.scala
@@ -117,7 +117,7 @@ trait LinearSeqOptimized[+A, +Repr <: LinearSeqOptimized[A, Repr]] extends Linea
   }
 
   override /*TraversableLike*/
-  def foldLeft[B](z: B)(op: (B, A) => B): B = {
+  def foldLeft[B](z: B)(@deprecatedName('f) op: (B, A) => B): B = {
     var acc = z
     var these = this
     while (!these.isEmpty) {
@@ -128,12 +128,12 @@ trait LinearSeqOptimized[+A, +Repr <: LinearSeqOptimized[A, Repr]] extends Linea
   }
 
   override /*IterableLike*/
-  def foldRight[B](z: B)(op: (A, B) => B): B =
+  def foldRight[B](z: B)(@deprecatedName('f) op: (A, B) => B): B =
     if (this.isEmpty) z
     else op(head, tail.foldRight(z)(op))
 
   override /*TraversableLike*/
-  def reduceLeft[B >: A](op: (B, A) => B): B =
+  def reduceLeft[B >: A](@deprecatedName('f) op: (B, A) => B): B =
     if (isEmpty) throw new UnsupportedOperationException("empty.reduceLeft")
     else tail.foldLeft[B](head)(op)
 


### PR DESCRIPTION
The argument of `LinearSeqOptimized.foldLeft`/`foldRight` which represents binary operator is named `f`:
`def foldLeft[B](z: B)(f: (A, B) ⇒ B): B`.
These methods are overridden in `LinearSeqOptimized` and their original methods are defined as
`def foldLeft[B](z: B)(op: (A, B) ⇒ B): B`
in `GenTraversableOnce`.
The ScalaDoc templates of them are also defined in `GenTraversableOnce` and it says `@param op the binary operator`.
Because of the difference between the `@param op` in doc template and the actual name of argument `f` in `LinearSeqOptimized.foldLeft`/`foldRight`, the description of `f` is missing in ScalaDoc.

In this PR, I renamed `f` to `op` in `LinearSeqOptimized.foldLeft`/`foldRight`.
I also renamed `f` to `op` in `LinearSeqOptimized.reduceLeft` which had a same problem.

Thanks!
