### PR TITLE
Improved error message for "filename too long" build errors

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
@@ -532,6 +532,10 @@ abstract class GenASM extends SubComponent with BytecodeWriters { self =>
         case e: java.lang.RuntimeException if e.getMessage != null && (e.getMessage contains "too large!") =>
           reporter.error(sym.pos,
             s"Could not write class $jclassName because it exceeds JVM code size limits. ${e.getMessage}")
+        case e: java.io.IOException if e.getMessage != null && (e.getMessage contains "File name too long")  =>
+          reporter.error(sym.pos, e.getMessage + "\n" +
+            "This can happen on some encrypted or legacy file systems.  Please see SI-3623 for more details.")
+
       }
     }
 


### PR DESCRIPTION
When building on ecryptfs filenames can be limited to ~142 characters.
This limit doesn't take long to hit and can leave the the user with a
hard to diagnosis error message.  This just adds a hint that it might
be related to the fs encryption.
