### PR TITLE
Include jline on quick.bin tool path

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -842,7 +842,7 @@ TODO:
     </path>
 
     <path id="quick.bin.tool.path">
-      <path refid="quick.repl.build.path"/>
+      <path refid="quick.repl-jline.build.path"/>
       <path refid="quick.actors.build.path"/>
       <pathelement location="${build-quick.dir}/classes/scalap"/>
       <pathelement location="${build-quick.dir}/classes/scaladoc"/>


### PR DESCRIPTION
The quick.bin version of the repl didn't have jline on the classpath. On 2.11, this was only detectable by running build/quick/bin/scala -Ydebug and noticing that the jline_embedded InteractiveReader was used because jline.jar was not on the classpath. On 2.12, the embedding is broken because jarjar doesn't support java 8 (sigh!), so no jline was available at all in quick.bin. The distribution wasn't affected, since that classpath was set up to include jline directly:

```
    <path id="pack.bin.tool.path">
...
      <path refid="repl.deps.classpath"/>
```
