### PR TITLE
Avoid unnecessary implicit view on String

### DIFF
--- a/src/library/scala/collection/immutable/StringLike.scala
+++ b/src/library/scala/collection/immutable/StringLike.scala
@@ -217,8 +217,8 @@ self =>
         pos = thisString.indexOf(separator, prev)
       } while (pos != -1)
 
-      if (prev != thisString.size)
-        res += thisString.substring(prev, thisString.size)
+      if (prev != thisString.length)
+        res += thisString.substring(prev, thisString.length)
 
       val initialResult = res.result()
       pos = initialResult.length


### PR DESCRIPTION
Using length instead of size on String to avoid a conversion call.

This dump confirms there is a conversion to StringOps when using size.

```
object StringSize {
  val s = "hi"
  println(s.size)
}

$ scalac -Xprint:typer StringSize.scala
[[syntax trees at end of                     typer]] // StringSize.scala
package <empty> {
  object StringSize extends scala.AnyRef {
    def <init>(): StringSize.type = {
      StringSize.super.<init>();
      ()
    };
    private[this] val s: String = "hi";
    <stable> <accessor> def s: String = StringSize.this.s;
    scala.this.Predef.println(scala.this.Predef.augmentString(StringSize.this.s).size)
  }
}
```
