### PR TITLE
Unfinalize the class DefaultPromise

### DIFF
--- a/src/library/scala/concurrent/impl/Promise.scala
+++ b/src/library/scala/concurrent/impl/Promise.scala
@@ -178,7 +178,9 @@ private[concurrent] object Promise {
    * DefaultPromises, and `linkedRootOf` is currently only designed to be called
    * by Future.flatMap.
    */
-  final class DefaultPromise[T] extends AtomicReference[AnyRef](Nil) with Promise[T] {
+  // Left non-final to enable addition of extra fields by Java/Scala converters
+  // in scala-java8-compat.
+  class DefaultPromise[T] extends AtomicReference[AnyRef](Nil) with Promise[T] {
 
     /** Get the root promise for this promise, compressing the link chain to that
      *  promise if necessary.
@@ -248,12 +250,12 @@ private[concurrent] object Promise {
 
     @throws(classOf[TimeoutException])
     @throws(classOf[InterruptedException])
-    def ready(atMost: Duration)(implicit permit: CanAwait): this.type =
+    final def ready(atMost: Duration)(implicit permit: CanAwait): this.type =
       if (tryAwait(atMost)) this
       else throw new TimeoutException("Futures timed out after [" + atMost + "]")
 
     @throws(classOf[Exception])
-    def result(atMost: Duration)(implicit permit: CanAwait): T =
+    final def result(atMost: Duration)(implicit permit: CanAwait): T =
       ready(atMost).value.get.get // ready throws TimeoutException if timeout so value.get is safe here
 
     def value: Option[Try[T]] = value0
@@ -265,7 +267,7 @@ private[concurrent] object Promise {
       case _ => None
     }
 
-    override def isCompleted: Boolean = isCompleted0
+    override final def isCompleted: Boolean = isCompleted0
 
     @tailrec
     private def isCompleted0: Boolean = get() match {
@@ -274,7 +276,7 @@ private[concurrent] object Promise {
       case _ => false
     }
 
-    def tryComplete(value: Try[T]): Boolean = {
+    final def tryComplete(value: Try[T]): Boolean = {
       val resolved = resolveTry(value)
       tryCompleteAndGetListeners(resolved) match {
         case null             => false
@@ -297,7 +299,7 @@ private[concurrent] object Promise {
       }
     }
 
-    def onComplete[U](func: Try[T] => U)(implicit executor: ExecutionContext): Unit =
+    final def onComplete[U](func: Try[T] => U)(implicit executor: ExecutionContext): Unit =
       dispatchOrAddCallback(new CallbackRunnable[T](executor.prepare(), func))
 
     /** Tries to add the callback, if already completed, it dispatches the callback to be executed.


### PR DESCRIPTION
It was non-final in Scala 2.11.x, and made final as part
of fa0743c32.

Removing the final modifier seems like the cleanest way to enable
conversions like `javaFuture.toScala.toJava` to return the original
`javaFuture` in scala-java8-compat.

I have made the methods defined in this class final as an
alternative lockdown.

Discussion, Motivation:

  https://github.com/scala/scala-java8-compat/pull/46
  https://github.com/scala/scala-java8-compat/pull/50

Review by @viktorklang 
