### PR TITLE
Remove unnecessary dependency on parallel collections in ScalaRunTime.

### DIFF
--- a/src/library/scala/runtime/ScalaRunTime.scala
+++ b/src/library/scala/runtime/ScalaRunTime.scala
@@ -9,11 +9,10 @@
 package scala
 package runtime
 
-import scala.collection.{ Seq, IndexedSeq, TraversableView, AbstractIterator }
+import scala.collection.{ Seq, IndexedSeq, TraversableView, AbstractIterator, GenIterable }
 import scala.collection.mutable.WrappedArray
 import scala.collection.immutable.{ StringLike, NumericRange, List, Stream, Nil, :: }
 import scala.collection.generic.{ Sorted, IsTraversableLike }
-import scala.collection.parallel.ParIterable
 import scala.reflect.{ ClassTag, classTag }
 import scala.util.control.ControlThrowable
 import java.lang.{ Class => jClass }
@@ -326,8 +325,7 @@ object ScalaRunTime {
       case x if useOwnToString(x)       => x.toString
       case x: AnyRef if isArray(x)      => arrayToString(x)
       case x: scala.collection.Map[_, _]      => x.iterator take maxElements map mapInner mkString (x.stringPrefix + "(", ", ", ")")
-      case x: Iterable[_]               => x.iterator take maxElements map inner mkString (x.stringPrefix + "(", ", ", ")")
-      case x: ParIterable[_]            => x.iterator take maxElements map inner mkString (x.stringPrefix + "(", ", ", ")")
+      case x: GenIterable[_]            => x.iterator take maxElements map inner mkString (x.stringPrefix + "(", ", ", ")")
       case x: Traversable[_]            => x take maxElements map inner mkString (x.stringPrefix + "(", ", ", ")")
       case x: Product1[_] if isTuple(x) => "(" + inner(x._1) + ",)" // that special trailing comma
       case x: Product if isTuple(x)     => x.productIterator map inner mkString ("(", ",", ")")

--- a/test/junit/scala/runtime/ScalaRunTimeTest.scala
+++ b/test/junit/scala/runtime/ScalaRunTimeTest.scala
@@ -67,4 +67,61 @@ class ScalaRunTimeTest {
     val c = new C()
     assertFalse(c.toString, isTuple(c))
   }
+
+  @Test
+  def testStingOf() {
+    import ScalaRunTime.stringOf
+    import scala.collection._
+    import parallel.ParIterable
+
+    assertEquals("null", stringOf(null))
+    assertEquals( "\"\"", stringOf(""))
+
+    assertEquals("abc", stringOf("abc"))
+    assertEquals("\" abc\"", stringOf(" abc"))
+    assertEquals("\"abc \"", stringOf("abc "))
+
+    assertEquals("""Array()""", stringOf(Array.empty[AnyRef]))
+    assertEquals("""Array()""", stringOf(Array.empty[Int]))
+    assertEquals("""Array(1, 2, 3)""", stringOf(Array(1, 2, 3)))
+    assertEquals("""Array(a, "", " c", null)""", stringOf(Array("a", "", " c", null)))
+    assertEquals("""Array(Array("", 1, Array(5)), Array(1))""",
+        stringOf(Array(Array("", 1, Array(5)), Array(1))))
+
+    val map = Map(1->"", 2->"a", 3->" a", 4->null)
+    assertEquals(s"""${map.stringPrefix}(1 -> "", 2 -> a, 3 -> " a", 4 -> null)""", stringOf(map))
+    assertEquals(s"""${map.stringPrefix}(1 -> "", 2 -> a)""", stringOf(map, 2))
+
+    val iterable = Iterable("a", "", " c", null)
+    assertEquals(s"""${iterable.stringPrefix}(a, "", " c", null)""", stringOf(iterable))
+    assertEquals(s"""${iterable.stringPrefix}(a, "")""", stringOf(iterable, 2))
+
+    val parIterable = ParIterable("a", "", " c", null)
+    assertEquals(s"""${parIterable.stringPrefix}(a, "", " c", null)""", stringOf(parIterable))
+    assertEquals(s"""${parIterable.stringPrefix}(a, "")""", stringOf(parIterable, 2))
+
+    val traversable = new Traversable[Int] {
+       def foreach[U](f: Int => U): Unit = (0 to 3).foreach(f)
+    }
+    assertEquals(s"${traversable.stringPrefix}(0, 1, 2, 3)", stringOf(traversable))
+    assertEquals(s"${traversable.stringPrefix}(0, 1)", stringOf(traversable, 2))
+
+    val tuple1 = Tuple1(0)
+    assertEquals("(0,)", stringOf(tuple1))
+    assertEquals("(0,)", stringOf(tuple1, 0))
+
+    val tuple2 = Tuple2(0, 1)
+    assertEquals("(0,1)", stringOf(tuple2))
+    assertEquals("(0,1)", stringOf(tuple2, 0))
+
+    val tuple3 = Tuple3(0, 1, 2)
+    assertEquals("(0,1,2)", stringOf(tuple3))
+    assertEquals("(0,1,2)", stringOf(tuple3, 0))
+
+    val x = new Object {
+        override def toString(): String = "this is the stringOf string"
+    }
+    assertEquals(stringOf(x), "this is the stringOf string")
+    assertEquals(stringOf(x, 2), "this is the stringOf string")
+  }
 }


### PR DESCRIPTION
This change is required for Scala.js compatibility.
