### PR TITLE
SI-7953 Import handler uses typeSignature

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
+++ b/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
@@ -205,7 +205,7 @@ trait MemberHandlers {
     val Import(expr, selectors) = imp
     def targetType = intp.global.rootMirror.getModuleIfDefined("" + expr) match {
       case NoSymbol => intp.typeOfExpression("" + expr)
-      case sym      => sym.thisType
+      case sym      => sym.typeSignature
     }
     private def importableTargetMembers = importableMembers(targetType).toList
     // wildcard imports, e.g. import foo._

--- a/test/files/run/repl-imports.check
+++ b/test/files/run/repl-imports.check
@@ -1,0 +1,11 @@
+
+scala> import scala.reflect.io.File
+import scala.reflect.io.File
+
+scala> :imports
+ 1) import java.lang._             (...)
+ 2) import scala._                 (...)
+ 3) import scala.Predef._          (...)
+ 4) import scala.reflect.io.File   (...)
+
+scala> :quit

--- a/test/files/run/repl-imports.scala
+++ b/test/files/run/repl-imports.scala
@@ -1,0 +1,14 @@
+
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  def code = """
+import scala.reflect.io.File
+:imports
+  """
+
+  // 4) import scala.reflect.io.File   (1 types, 1 terms)
+  lazy val stats = """\(.*\)""".r
+
+  override def normalize(s: String) = stats.replaceFirstIn(s, "(...)")
+}


### PR DESCRIPTION
Because `thisType` is for class symbols.

Now repl sees members of packages for selections,
for purposes of reporting.
