### PR TITLE
SI-9442 Fix the uncurry-erasure types

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -691,9 +691,46 @@ abstract class UnCurry extends InfoTransform
               // declared type and assign this to a synthetic val. Later, we'll patch
               // the method body to refer to this, rather than the parameter.
               val tempVal: ValDef = {
+                // SI-9442: using the "uncurry-erased" type (the one after the uncurry phase) can lead to incorrect 
+                // tree transformations. For example, compiling:
+                // ```
+                //   def foo(c: Ctx)(l: c.Tree): Unit = {
+                //     val l2: c.Tree = l
+                //   }
+                // ```
+                // Results in the following AST:
+                // ```
+                //   def foo(c: Ctx, l: Ctx#Tree): Unit = {
+                //     val l$1: Ctx#Tree = l.asInstanceOf[Ctx#Tree]
+                //     val l2: c.Tree = l$1 // no, not really, it's not.
+                //   }
+                // ```
+                // Of course, this is incorrect, since `l$1` has type `Ctx#Tree`, which is not a subtype of `c.Tree`.
+                //
+                // So what we need to do is to use the pre-uncurry type when creating `l$1`, which is `c.Tree` and is
+                // correct. Now, there are two additional problems:
+                // 1. when varargs and byname params are involved, the uncurry transformation desugares these special
+                //    cases to actual typerefs, eg:
+                //    ```
+                //           T*  ~> Seq[T] (Scala-defined varargs)
+                //           T*  ~> Array[T] (Java-defined varargs)
+                //           =>T ~> Function0[T] (by name params)
+                //    ```
+                //    we use the DesugaredParameterType object (defined in scala.reflect.internal.transform.UnCurry)
+                //    to redo this desugaring manually here
+                // 2. the type needs to be normalized, since `gen.mkCast` checks this (no HK here, just aliases have
+                //    to be expanded before handing the type to `gen.mkAttributedCast`, which calls `gen.mkCast`)
+                val info0 = 
+                  enteringUncurry(p.symbol.info) match {
+                    case DesugaredParameterType(desugaredTpe) =>
+                      desugaredTpe
+                    case tpe =>
+                      tpe
+                  }
+                val info = info0.normalize
                 val tempValName = unit freshTermName (p.name + "$")
-                val newSym = dd.symbol.newTermSymbol(tempValName, p.pos, SYNTHETIC).setInfo(p.symbol.info)
-                atPos(p.pos)(ValDef(newSym, gen.mkAttributedCast(Ident(p.symbol), p.symbol.info)))
+                val newSym = dd.symbol.newTermSymbol(tempValName, p.pos, SYNTHETIC).setInfo(info)
+                atPos(p.pos)(ValDef(newSym, gen.mkAttributedCast(Ident(p.symbol), info)))
               }
               Packed(newParam, tempVal)
             }

--- a/src/reflect/scala/reflect/internal/transform/UnCurry.scala
+++ b/src/reflect/scala/reflect/internal/transform/UnCurry.scala
@@ -40,17 +40,25 @@ trait UnCurry {
           apply(MethodType(h.cloneSymbol.resetFlag(IMPLICIT) :: t, restpe))
         case NullaryMethodType(restpe) =>
           apply(MethodType(List(), restpe))
-        case TypeRef(pre, ByNameParamClass, arg :: Nil) =>
-          apply(functionType(List(), arg))
-        case TypeRef(pre, RepeatedParamClass, arg :: Nil) =>
-          apply(seqType(arg))
-        case TypeRef(pre, JavaRepeatedParamClass, arg :: Nil) =>
-          apply(arrayType(
-            if (isUnboundedGeneric(arg)) ObjectTpe else arg))
+        case DesugaredParameterType(desugaredTpe) =>
+          apply(desugaredTpe)
         case _ =>
           expandAlias(mapOver(tp))
       }
     }
+  }
+
+  object DesugaredParameterType {
+    def unapply(tpe: Type): Option[Type] = tpe match {
+      case TypeRef(pre, ByNameParamClass, arg :: Nil) =>
+        Some(functionType(List(), arg))
+      case TypeRef(pre, RepeatedParamClass, arg :: Nil) =>
+        Some(seqType(arg))
+      case TypeRef(pre, JavaRepeatedParamClass, arg :: Nil) =>
+        Some(arrayType(if (isUnboundedGeneric(arg)) ObjectTpe else arg))
+      case _ =>
+        None
+      }
   }
 
   private val uncurryType = new TypeMap {

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -444,7 +444,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.ScalaValueClassesNoUnit
     definitions.ScalaValueClasses
 
-
+    uncurry.DesugaredParameterType
     erasure.GenericArray
     erasure.scalaErasure
     erasure.specialScalaErasure

--- a/test/files/pos/t9442.scala
+++ b/test/files/pos/t9442.scala
@@ -1,0 +1,14 @@
+trait Ctx {
+  trait Tree
+}
+trait Lst[+A] {
+  def zip[A1 >: A, B](that: Lst[B]): Nothing
+}
+class C[@specialized(Int) T] {
+  def moo(t: T) = {
+    def foo1(c: Ctx)(l: Lst[c.Tree]) = l zip l
+    def foo2(c: Ctx)(l: Lst[c.Tree]*) = l(0) zip l(1)
+    def foo3(c: Ctx)(l: => Lst[c.Tree]) = l zip l
+    ???
+  }
+}


### PR DESCRIPTION
Using the "uncurry-erased" type (the one after the uncurry phase) can lead to incorrect tree transformations. For example, compiling:

```
  def foo(c: Ctx)(l: c.Tree): Unit = {
    val l2: c.Tree = l
  }
```

Results in the following AST:

```
  def foo(c: Ctx, l: Ctx#Tree): Unit = {
    val l$1: Ctx#Tree = l.asInstanceOf[Ctx#Tree]
    val l2: c.Tree = l$1 // no, not really, it's not.
  }
```

Of course, this is incorrect, since `l$1` has type `Ctx#Tree`, which is not a subtype of `c.Tree`.

So what we need to do is to use the pre-uncurry type when creating `l$1`, which is `c.Tree` and is correct. Now, there are two additional problems:
1. when varargs and byname params are involved, the uncurry transformation desugares these special cases to actual typerefs, eg:

```
          T*  ~> Seq[T] (Scala-defined varargs)
          T*  ~> Array[T] (Java-defined varargs)
          =>T ~> Function0[T] (by name params)
```

   we use the DesugaredParameterType object (defined in scala.reflect.internal.transform.UnCurry) to redo this desugaring manually here
2. the type needs to be normalized, since `gen.mkCast` checks this (no HK here, just aliases have to be expanded before handing the type to `gen.mkAttributedCast`, which calls `gen.mkCast`)
