### PR TITLE
Fix typos in spec, docs and comments

### DIFF
--- a/docs/TODO
+++ b/docs/TODO
@@ -53,7 +53,7 @@
 
   The process is about the same for symbols in PolyTypes. The main
   difference is that type parameters may be referenced and thus we
-  need something like De Bruijn indicies to represent these
+  need something like De Bruijn indices to represent these
   references.
 
 

--- a/spec/01-lexical-syntax.md
+++ b/spec/01-lexical-syntax.md
@@ -443,7 +443,7 @@ multiLineChars  ::=  {[‘"’] [‘"’] charNoDoubleQuote} {‘"’}
 
 A multi-line string literal is a sequence of characters enclosed in
 triple quotes `""" ... """`. The sequence of characters is
-arbitrary, except that it may contain three or more consuctive quote characters
+arbitrary, except that it may contain three or more consecutive quote characters
 only at the very end. Characters
 must not necessarily be printable; newlines or other
 control characters are also permitted.  Unicode escapes work as everywhere else, but none

--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -1736,7 +1736,7 @@ so `scala.Any` is the type inferred for `a`.
 _Eta-expansion_ converts an expression of method type to an
 equivalent expression of function type. It proceeds in two steps.
 
-First, one identifes the maximal sub-expressions of $e$; let's
+First, one identifies the maximal sub-expressions of $e$; let's
 say these are $e_1 , \ldots , e_m$. For each of these, one creates a
 fresh name $x_i$. Let $e'$ be the expression resulting from
 replacing every maximal subexpression $e_i$ in $e$ by the

--- a/spec/07-implicits.md
+++ b/spec/07-implicits.md
@@ -84,7 +84,7 @@ The _parts_ of a type $T$ are:
 - if $T$ is an abstract type, the parts of its upper bound;
 - if $T$ denotes an implicit conversion to a type with a method with argument types $T_1 , \ldots , T_n$ and result type $U$,
   the union of the parts of $T_1 , \ldots , T_n$ and $U$;
-- the parts of quantified (existential or univeral) and annotated types are defined as the parts of the underlying types (e.g., the parts of `T forSome { ... }` are the parts of `T`);
+- the parts of quantified (existential or universal) and annotated types are defined as the parts of the underlying types (e.g., the parts of `T forSome { ... }` are the parts of `T`);
 - in all other cases, just $T$ itself.
 
 Note that packages are internally represented as classes with companion modules to hold the package members.

--- a/spec/12-the-scala-standard-library.md
+++ b/spec/12-the-scala-standard-library.md
@@ -171,7 +171,7 @@ Any numeric value type $T$ supports the following methods.
     evaluated by converting the receiver and its argument to their
     operation type and performing the given arithmetic operation of that
     type.
-  * Parameterless arithmethic methods identity (`+`) and negation
+  * Parameterless arithmetic methods identity (`+`) and negation
     (`-`), with result type $T$.  The first of these returns the
     receiver unchanged, whereas the second returns its negation.
   * Conversion methods `toByte`, `toShort`, `toChar`,
@@ -194,7 +194,7 @@ Integer numeric value types support in addition the following operations:
     operation of that type.
 
   * A parameterless bit-negation method (`~`). Its result type is
-    the reciver type $T$ or `Int`, whichever is larger.
+    the receiver type $T$ or `Int`, whichever is larger.
     The operation is evaluated by converting the receiver to the result
     type and negating every bit in its value.
   * Bit-shift methods left-shift (`<<`), arithmetic right-shift
@@ -745,7 +745,7 @@ object Predef {
   def readf2(format: String) = Console.readf2(format)
   def readf3(format: String) = Console.readf3(format)
 
-  // Implict conversions ------------------------------------------------
+  // Implicit conversions ------------------------------------------------
 
   ...
 }

--- a/spec/15-changelog.md
+++ b/spec/15-changelog.md
@@ -31,7 +31,7 @@ formal parameter types. Added section on
 [numeric widening](06-expressions.html#numeric-widening) to support
 weak conformance.
 
-Tightened rules to avoid accidential [overrides](05-classes-and-objects.html#overriding).
+Tightened rules to avoid accidental [overrides](05-classes-and-objects.html#overriding).
 
 Removed class literals.
 
@@ -53,7 +53,7 @@ has been brought in line with. From now on `+=`, has the same precedence as `=`.
 
 #### Wildcards as function parameters
 
-A formal parameter to an anonymous fucntion may now be a
+A formal parameter to an anonymous function may now be a
 [wildcard represented by an underscore](06-expressions.html#placeholder-syntax-for-anonymous-functions).
 
 >      _ => 7   // The function that ignores its argument

--- a/src/actors/scala/actors/Future.scala
+++ b/src/actors/scala/actors/Future.scala
@@ -12,7 +12,7 @@ package scala.actors
 import scala.actors.scheduler.DaemonScheduler
 import scala.concurrent.SyncVar
 
-/** A function of arity 0, returing a value of type `T` that,
+/** A function of arity 0, returning a value of type `T` that,
  *  when applied, blocks the current actor (`Actor.self`)
  *  until the future's value is available.
  *

--- a/src/compiler/scala/tools/nsc/ast/TreeGen.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeGen.scala
@@ -261,7 +261,7 @@ abstract class TreeGen extends scala.reflect.internal.TreeGen with TreeDSL {
    * Create a method based on a Function
    *
    * Used both to under `-Ydelambdafy:method` create a lifted function and
-   * under `-Ydelamdafy:inline` to create the apply method on the anonymous
+   * under `-Ydelambdafy:inline` to create the apply method on the anonymous
    * class.
    *
    * It creates a method definition with value params cloned from the

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2031,11 +2031,11 @@ self =>
     /** Drop `private` modifier when followed by a qualifier.
      *  Contract `abstract` and `override` to ABSOVERRIDE
      */
-    private def normalizeModifers(mods: Modifiers): Modifiers =
+    private def normalizeModifiers(mods: Modifiers): Modifiers =
       if (mods.isPrivate && mods.hasAccessBoundary)
-        normalizeModifers(mods &~ Flags.PRIVATE)
+        normalizeModifiers(mods &~ Flags.PRIVATE)
       else if (mods hasAllFlags (Flags.ABSTRACT | Flags.OVERRIDE))
-        normalizeModifers(mods &~ (Flags.ABSTRACT | Flags.OVERRIDE) | Flags.ABSOVERRIDE)
+        normalizeModifiers(mods &~ (Flags.ABSTRACT | Flags.OVERRIDE) | Flags.ABSOVERRIDE)
       else
         mods
 
@@ -2080,7 +2080,7 @@ self =>
      *  AccessModifier ::= (private | protected) [AccessQualifier]
      *  }}}
      */
-    def accessModifierOpt(): Modifiers = normalizeModifers {
+    def accessModifierOpt(): Modifiers = normalizeModifiers {
       in.token match {
         case m @ (PRIVATE | PROTECTED)  => in.nextToken() ; accessQualifierOpt(Modifiers(flagTokens(m)))
         case _                          => NoMods
@@ -2094,7 +2094,7 @@ self =>
      *              |  override
      *  }}}
      */
-    def modifiers(): Modifiers = normalizeModifers {
+    def modifiers(): Modifiers = normalizeModifiers {
       def loop(mods: Modifiers): Modifiers = in.token match {
         case PRIVATE | PROTECTED =>
           loop(accessQualifierOpt(addMod(mods, flagTokens(in.token), tokenRange(in))))

--- a/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/GenICode.scala
@@ -2016,7 +2016,7 @@ abstract class GenICode extends SubComponent {
        *
        *  This could result in unreachable code which has to be cleaned up later, e.g. if the try and all the exception
        *  handlers always end in RETURN then there will be no "normal" flow out of the try/catch/finally.
-       *  Later reachability analysis will remove unreacahble code.
+       *  Later reachability analysis will remove unreachable code.
        */
       def Try(body: Context => Context,
               handlers: List[(Symbol, TypeKind, Context => Context)],
@@ -2060,7 +2060,7 @@ abstract class GenICode extends SubComponent {
         if (settings.YdisableUnreachablePrevention || !outerCtx.bb.ignore) {
           if (finalizer != EmptyTree) {
             val exh = outerCtx.newExceptionHandler(NoSymbol, finalizer.pos) // finalizer covers exception handlers
-            this.addActiveHandler(exh)  // .. and body aswell
+            this.addActiveHandler(exh)  // .. and body as well
             val exhStartCtx = finalizerCtx.enterExceptionHandler(exh)
             exhStartCtx.bb killIf outerCtx.bb.ignore
             val exception = exhStartCtx.makeLocal(finalizer.pos, ThrowableTpe, "exc")

--- a/src/compiler/scala/tools/nsc/backend/icode/ICodeCheckers.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/ICodeCheckers.scala
@@ -20,7 +20,7 @@ abstract class ICodeCheckers {
    *  </p>
    *  <ul>
    *    <li>
-   *      for primitive operations: the type and numer of operands match
+   *      for primitive operations: the type and number of operands match
    *      the type of the operation
    *    </li>
    *    <li>

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -92,8 +92,8 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
 
     def genThrow(expr: Tree): BType = {
       val thrownKind = tpeTK(expr)
-      // `throw null` is valid although scala.Null (as defined in src/libray-aux) isn't a subtype of Throwable.
-      // Similarly for scala.Nothing (again, as defined in src/libray-aux).
+      // `throw null` is valid although scala.Null (as defined in src/library-aux) isn't a subtype of Throwable.
+      // Similarly for scala.Nothing (again, as defined in src/library-aux).
       assert(thrownKind.isNullType || thrownKind.isNothingType || thrownKind.asClassBType.isSubtypeOf(ThrowableReference).get)
       genLoad(expr, thrownKind)
       lineNumber(expr)

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -1126,7 +1126,7 @@ object BTypes {
    *                               The map is indexed by the string s"$name$descriptor" (to
    *                               disambiguate overloads).
    *
-   * @param warning                Contains an warning message if an error occured when building this
+   * @param warning                Contains an warning message if an error occurred when building this
    *                               InlineInfo, for example if some classfile could not be found on
    *                               the classpath. This warning can be reported later by the inliner.
    */

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/NullnessAnalyzer.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/NullnessAnalyzer.scala
@@ -12,7 +12,7 @@ import scala.tools.nsc.backend.jvm.opt.BytecodeUtils
 import BytecodeUtils._
 
 /**
- * Some notes on the ASM ananlyzer framework.
+ * Some notes on the ASM analyzer framework.
  *
  * Value
  *  - Abstract, needs to be implemented for each analysis.

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/ClosureOptimizer.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/ClosureOptimizer.scala
@@ -359,7 +359,7 @@ class ClosureOptimizer[BT <: BTypes](val btypes: BT) {
   }
 
   /**
-   * Stores a local varaible index the opcode offset required for operating on that variable.
+   * Stores a local variable index the opcode offset required for operating on that variable.
    *
    * The xLOAD / xSTORE opcodes are in the following sequence: I, L, F, D, A, so the offset for
    * a local variable holding a reference (`A`) is 4. See also method `getOpcode` in [[scala.tools.asm.Type]].

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
@@ -366,7 +366,7 @@ class Inliner[BT <: BTypes](val btypes: BT) {
 
       clonedInstructions.insert(argStores)
 
-      // label for the exit of the inlined functions. xRETURNs are rplaced by GOTOs to this label.
+      // label for the exit of the inlined functions. xRETURNs are replaced by GOTOs to this label.
       val postCallLabel = newLabelNode
       clonedInstructions.add(postCallLabel)
 

--- a/src/compiler/scala/tools/nsc/transform/Constructors.scala
+++ b/src/compiler/scala/tools/nsc/transform/Constructors.scala
@@ -137,7 +137,7 @@ abstract class Constructors extends Statics with Transform with ast.TreeDSL {
    *       and thus may only be accessed from value or method definitions owned by the current class
    *       (ie there's no point drilling down into nested classes).
    *
-   *   (d) regarding candidates in (b), they are accesible from all places listed in (c) and in addition
+   *   (d) regarding candidates in (b), they are accessible from all places listed in (c) and in addition
    *       from nested classes (nested at any number of levels).
    *
    * In all cases, we're done with traversing as soon as all candidates have been ruled out.

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -658,7 +658,7 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
       //
       // Situation #2 requires measures to be taken. If we're in it, then noone's going to help us infer
       // the undetermined type params. Therefore we need to do something ourselves or otherwise this
-      // expandee will forever remaing not expanded (see SI-5692). A traditional way out of this conundrum
+      // expandee will forever remain not expanded (see SI-5692). A traditional way out of this conundrum
       // is to call `instantiate` and let the inferencer try to find the way out. It works for simple cases,
       // but sometimes, if the inferencer lacks information, it will be forced to approximate.
       //

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3305,7 +3305,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           // https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.12.3
           //
           // One can think of these methods as being infinitely overloaded. We create
-          // a ficticious new cloned method symbol for each call site that takes on a signature
+          // a fictitious new cloned method symbol for each call site that takes on a signature
           // governed by a) the argument types and b) the expected type
           val args1 = typedArgs(args, forArgMode(fun, mode))
           val pts = args1.map(_.tpe.deconst)
@@ -4106,7 +4106,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
         def resultingTypeTree(tpe: Type) = {
           // we need symbol-ful originals for reification
-          // hence we go the extra mile to hand-craft tis guy
+          // hence we go the extra mile to hand-craft this guy
           val original = arg1 match {
             case tt @ TypeTree() if tt.original != null => Annotated(ann, tt.original)
             // this clause is needed to correctly compile stuff like "new C @D" or "@(inline @getter)"
@@ -4258,7 +4258,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         // in the special (though common) case where the types are equal, it pays to pack before comparing
         // especially virtpatmat needs more aggressive unification of skolemized types
         // this breaks src/library/scala/collection/immutable/TrieIterator.scala
-        // annotated types need to be lubbed regardless (at least, continations break if you by pass them like this)
+        // annotated types need to be lubbed regardless (at least, continuations break if you bypass them like this)
         def samePackedTypes = (
              !isPastTyper
           && thenp1.tpe.annotations.isEmpty

--- a/src/forkjoin/scala/concurrent/forkjoin/ThreadLocalRandom.java
+++ b/src/forkjoin/scala/concurrent/forkjoin/ThreadLocalRandom.java
@@ -24,7 +24,7 @@ import java.util.Random;
  * {@code ThreadLocalRandom.current().nextX(...)} (where
  * {@code X} is {@code Int}, {@code Long}, etc).
  * When all usages are of this form, it is never possible to
- * accidently share a {@code ThreadLocalRandom} across multiple threads.
+ * accidentally share a {@code ThreadLocalRandom} across multiple threads.
  *
  * <p>This class also provides additional commonly used bounded random
  * generation methods.

--- a/src/library/scala/util/Sorting.scala
+++ b/src/library/scala/util/Sorting.scala
@@ -88,7 +88,7 @@ object Sorting {
               a(pL - 1) = current
               pL -= 1
             case x if x < 0 =>
-              // Already in place.  Just update indicies.
+              // Already in place.  Just update indices.
               iA += 1
             case _ if iB > pR =>
               // Wrong side.  There's room on the other side, so swap

--- a/src/reflect/scala/reflect/api/Types.scala
+++ b/src/reflect/scala/reflect/api/Types.scala
@@ -588,7 +588,7 @@ trait Types {
   /** An extractor class to create and pattern match with syntax `TypeRef(pre, sym, args)`
    *  Here, `pre` is the prefix of the type reference, `sym` is the symbol
    *  referred to by the type reference, and `args` is a possible empty list of
-   *  type argumenrts.
+   *  type arguments.
    *  @group Extractors
    */
   abstract class TypeRefExtractor {

--- a/src/reflect/scala/reflect/internal/Kinds.scala
+++ b/src/reflect/scala/reflect/internal/Kinds.scala
@@ -237,7 +237,7 @@ trait Kinds {
    *
    * Proper types are represented using ProperTypeKind.
    *
-   * Type constructors are reprented using TypeConKind.
+   * Type constructors are represented using TypeConKind.
    */
   abstract class Kind {
     import Kind.StringState

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2113,7 +2113,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     /** The package class containing this symbol, or NoSymbol if there
      *  is not one.
      *  TODO: formulate as enclosingSuchThat, after making sure
-     *        we can start with current symbol rather than onwner.
+     *        we can start with current symbol rather than owner.
      *  TODO: Also harmonize with enclClass, enclMethod etc.
      */
     def enclosingPackageClass: Symbol = {

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -1601,7 +1601,7 @@ trait Trees extends api.Trees {
           case _          =>
             // no special handling is required for Function or Import nodes here.
             // as they don't have interesting infos attached to their symbols.
-            // Subsitution of the referenced symbol of Return nodes is handled
+            // Substitution of the referenced symbol of Return nodes is handled
             // in .ChangeOwnerTraverser
         }
         tree match {

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
@@ -781,7 +781,7 @@ class Template(universe: doc.Universe, generator: DiagramGenerator, tpl: DocTemp
           if (isReduced) NodeSeq.Empty else {
             def paramsToHtml(vlsss: List[List[ValueParam]]): NodeSeq = {
               def param0(vl: ValueParam): NodeSeq =
-                // notice the }{ in the next lines, they are necessary to avoid an undesired withspace in output
+                // notice the }{ in the next lines, they are necessary to avoid an undesired whitespace in output
                 <span name={ vl.name }>{
                   Text(vl.name)
                 }{ Text(": ") ++ typeToHtml(vl.resultType, hasLinks) }{

--- a/test/files/neg/name-lookup-stable.check
+++ b/test/files/neg/name-lookup-stable.check
@@ -6,6 +6,6 @@ import ColumnOption._
 name-lookup-stable.scala:17: error: reference to PrimaryKey is ambiguous;
 it is both defined in class A and imported subsequently by
 import ColumnOption._
-    PrimaryKey // was already ambigious in 2.10.3
+    PrimaryKey // was already ambiguous in 2.10.3
     ^
 two errors found

--- a/test/files/neg/name-lookup-stable.scala
+++ b/test/files/neg/name-lookup-stable.scala
@@ -14,7 +14,7 @@ class A {
 
     (null: Any) match { case PrimaryKey => }
 
-    PrimaryKey // was already ambigious in 2.10.3
+    PrimaryKey // was already ambiguous in 2.10.3
   }
 }
 

--- a/test/files/neg/t5376.scala
+++ b/test/files/neg/t5376.scala
@@ -12,7 +12,7 @@ object Test {
     "a": Int
   }
 
-  // Import one implict and one non-implicit method with the
+  // Import one implicit and one non-implicit method with the
   // same name in the same scope.
   def m2 = {
     import O1._

--- a/test/files/neg/t8597b.scala
+++ b/test/files/neg/t8597b.scala
@@ -4,7 +4,7 @@ object Unchecked {
 
       // t is a fresh pattern type variable, despite our attempts to
       // backtick our way to the enclosing `t`. Under this interpretation,
-      // the absense of an unchecked warning is expected.
+      // the absence of an unchecked warning is expected.
       (null: Any) match {
         case _: Some[t] => // no warn
       }

--- a/test/files/neg/t8675b.scala
+++ b/test/files/neg/t8675b.scala
@@ -9,7 +9,7 @@ object Test {
   }
   trait Reportable1[Params, R]
 
-  // "missing paramater type" error was swallowed in 2.11.0 leading to a crash
+  // "missing parameter type" error was swallowed in 2.11.0 leading to a crash
   // in the backend.
   //
   // This error is itself a regression (or at least a change) in 2.11.0-M7,

--- a/test/files/neg/virtpatmat_exhaust_compound.scala
+++ b/test/files/neg/virtpatmat_exhaust_compound.scala
@@ -10,7 +10,7 @@ case object O3 extends Base2
 case object O4 extends Base with Base2
 
 object Test {
-  val a /*: Product with Serialiable with Base */ = if (true) O1 else O2
+  val a /*: Product with Serializable with Base */ = if (true) O1 else O2
   a match {
     case null =>
   }

--- a/test/files/pos/t2405.scala
+++ b/test/files/pos/t2405.scala
@@ -6,14 +6,14 @@ object Test1 {
 	implicitly[Int]
 }
 
-// Testing for the absense of shadowing #1.
+// Testing for the absence of shadowing #1.
 object Test2 {
 	import A.{x => y}
 	val x = 2
 	implicitly[Int]
 }
 
-// Testing for the absense of shadowing #2.
+// Testing for the absence of shadowing #2.
 object Test3 {
 	{
 		import A.{x => y}

--- a/test/files/pos/t8002-nested-scope.scala
+++ b/test/files/pos/t8002-nested-scope.scala
@@ -1,5 +1,5 @@
 //  This test serves to capture the status quo, but should really
-// emit an accessibiltiy error.
+// emit an accessibility error.
 
 // `Namers#companionSymbolOf` seems too lenient, and currently doesn't
 // implement the same-scope checks mentioned:

--- a/test/files/run/dead-code-elimination.scala
+++ b/test/files/run/dead-code-elimination.scala
@@ -10,7 +10,7 @@
 // the stack after code elimination.
 //
 // Originally, this did not compile, but I included it in the run
-// tests because this was ASM-dependand and did not happen for GenJVM.
+// tests because this was ASM-dependent and did not happen for GenJVM.
 //
 // Thus, we run the code and force the loading of class B -- if the
 // bytecode is incorrect, it will fail the test.

--- a/test/files/run/names-defaults.scala
+++ b/test/files/run/names-defaults.scala
@@ -192,7 +192,7 @@ object Test extends App {
   println(argName) // should be 4
   test5 { argName = 5 }
   println(argName) // should be 5
-  val a: Unit = test1(a = 10, b = "2") // local values a and b exist, but not ambiuous since they're val's
+  val a: Unit = test1(a = 10, b = "2") // local values a and b exist, but it's not ambiguous since they're vals
 
 
   // dependent types and copy method

--- a/test/files/run/nothingTypeNoOpt.scala
+++ b/test/files/run/nothingTypeNoOpt.scala
@@ -26,7 +26,7 @@ class C {
   }
 
   def f5(x: Boolean) = {
-    // stack heights need to be the smae. ??? looks to the jvm like returning a value of
+    // stack heights need to be the same. ??? looks to the jvm like returning a value of
     // type Nothing$, need to drop or throw it.
     println(
       if (x) { ???; 10 }

--- a/test/files/run/t8047.scala
+++ b/test/files/run/t8047.scala
@@ -1,7 +1,7 @@
 object Test extends App {
   import scala.reflect.runtime.universe._
   //
-  // x's owner is outer Test scope. Previosly the quasiquote expansion
+  // x's owner is outer Test scope. Previously the quasiquote expansion
   // looked like:
   //
   //     object Test {

--- a/test/junit/scala/tools/nsc/backend/jvm/analysis/ProdConsAnalyzerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/analysis/ProdConsAnalyzerTest.scala
@@ -204,7 +204,7 @@ class ProdConsAnalyzerTest extends ClearAfterClass {
   def iincProdCons(): Unit = {
     import Opcodes._
     val m = genMethod(descriptor = "(I)I")(
-      Incr(IINC, 1, 1), // producer and cosumer of local variable 1
+      Incr(IINC, 1, 1), // producer and consumer of local variable 1
       VarOp(ILOAD, 1),
       Op(IRETURN)
     )

--- a/versions.properties
+++ b/versions.properties
@@ -5,7 +5,7 @@
 # also add them to the update.versions mechanism in build.xml,
 # which is used by the release script scripts/jobs/integrate/bootstrap
 
-# The scala version used for boostrapping. This has no impact on the final classfiles:
+# The scala version used for bootstrapping. This has no impact on the final classfiles:
 # there are two stages (locker and quick), so compiler and library are always built
 # with themselves. Stability is ensured by building a third stage (strap).
 starr.version=2.11.7


### PR DESCRIPTION
I corrected also the name of a private method (there's a separate commit with this change).
