### PR TITLE
Re-enable tree checkers

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
@@ -262,7 +262,14 @@ abstract class TreeCheckers extends Analyzer {
         checkedTyped(tree, mode, pt)
     )
     private def checkedTyped(tree: Tree, mode: Mode, pt: Type): Tree = {
-      val typed = wrap(tree)(super.typed(tree, mode, pt))
+      val typed = wrap(tree)(super.typed(tree.clearType(), mode, pt))
+
+      // Vlad: super.typed returns null for package defs, why is that?
+      if (typed eq null)
+        return tree
+
+      if (typed.tpe ne null)
+        assert(!typed.tpe.isErroneous, "Tree has erroneous type: " + typed)
 
       if (tree ne typed)
         treesDiffer(tree, typed)


### PR DESCRIPTION
My expectation is that tree checkers are re-typechecking the trees and making sure they are consistent. Unfortunately, following patch aced32d05c97651534f468bc9a475ea5f6ae75b8, the call to clearType() was removed, thus the typer no longer recursed inside the trees, rendering the type checkers framework useless.

This is an attempt to make the tree checkers run again, by resetting the type of a tree before the call to super.typed, thus allowing the typer to actually visit the entire tree (not just the outer package
definition).

The work was prompted by SI-9442, where the type checkers would gladly validate the inconsistent trees.
