### PR TITLE
Add link to online version of Programming in Scala

### DIFF
--- a/src/library/scala/Equals.scala
+++ b/src/library/scala/Equals.scala
@@ -13,8 +13,9 @@ package scala
  */
 trait Equals extends Any {
   /** A method that should be called from every well-designed equals method
-   *  that is open to be overridden in a subclass. See Programming in Scala,
-   *  Chapter 28 for discussion and design.
+   *  that is open to be overridden in a subclass. See
+   *  [[http://www.artima.com/pins1ed/object-equality.html Programming in Scala,
+   *  Chapter 28]] for discussion and design.
    *
    *  @param    that    the value being probed for possible equality
    *  @return   true if this instance can possibly equal `that`, otherwise false


### PR DESCRIPTION
This just adds a link to the online version of Programming in Scala which is already referenced in the documentation of `Equals.canEqual`.
