### PR TITLE
Streamline logic related to accessor derivation in MethodSynthesis & Namers

### DIFF
--- a/src/compiler/scala/reflect/reify/phases/Reshape.scala
+++ b/src/compiler/scala/reflect/reify/phases/Reshape.scala
@@ -325,8 +325,7 @@ trait Reshape {
           if (reifyDebug) println(s"reconstructed lazy val is $vdef1")
           vdef1::Nil
         case ddef: DefDef if ddef.symbol.isLazy =>
-          def hasUnitType(sym: Symbol) = (sym.tpe.typeSymbol == UnitClass) && sym.tpe.annotations.isEmpty
-          if (hasUnitType(ddef.symbol)) {
+          if (isUnitType(ddef.symbol.info)) {
             // since lazy values of type Unit don't have val's
             // we need to create them from scratch
             toPreTyperLazyVal(ddef) :: Nil

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -1105,7 +1105,7 @@ trait ContextErrors {
       def GetterDefinedTwiceError(getter: Symbol) =
         issueSymbolTypeError(getter, getter+" is defined twice")
 
-      def ValOrValWithSetterSuffixError(tree: Tree) =
+      def ValOrVarWithSetterSuffixError(tree: Tree) =
         issueNormalTypeError(tree, "Names of vals or vars may not end in `_='")
 
       def PrivateThisCaseClassParameterError(tree: Tree) =

--- a/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
@@ -338,10 +338,11 @@ trait MethodSynthesis {
         case _                => NoSymbol
       }
 
-      // TODO: when is `derivedSym.isOverloaded`??? is it always an error?
-      private def setterRhs =
+      private def setterRhs = {
+        assert(!derivedSym.isOverloaded, s"Unexpected overloaded setter $derivedSym for $basisSym in $enclClass")
         if (Field.noFieldFor(tree) || derivedSym.isOverloaded) EmptyTree
         else Assign(fieldSelection, Ident(setterParam))
+      }
 
       private def setterDef = DefDef(derivedSym, setterRhs)
       override def derivedTree: Tree = if (setterParam == NoSymbol) EmptyTree else setterDef

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -118,7 +118,7 @@ trait Namers extends MethodSynthesis {
     // PRIVATE | LOCAL are fields generated for primary constructor arguments
     // @PP: ...or fields declared as private[this].  PARAMACCESSOR marks constructor arguments.
     // Neither gets accessors so the code is as far as I know still correct.
-    def noEnterGetterSetter(vd: ValDef) = !vd.mods.isLazy && (
+    def deriveAccessors(vd: ValDef) = vd.mods.isLazy || !(
          !owner.isClass
       || (vd.mods.isPrivateLocal && !vd.mods.isCaseAccessor)
       || (vd.name startsWith nme.OUTER)
@@ -126,7 +126,7 @@ trait Namers extends MethodSynthesis {
       || isEnumConstant(vd)
     )
 
-    def noFinishGetterSetter(vd: ValDef) = (
+    def deriveAccessorTrees(vd: ValDef) = !(
          (vd.mods.isPrivateLocal && !vd.mods.isLazy) // all lazy vals need accessors, even private[this]
       || vd.symbol.isModuleVar
       || isEnumConstant(vd))
@@ -656,10 +656,8 @@ trait Namers extends MethodSynthesis {
     }
 
     def enterValDef(tree: ValDef) {
-      if (noEnterGetterSetter(tree))
-        assignAndEnterFinishedSymbol(tree)
-      else
-        enterGetterSetter(tree)
+      if (deriveAccessors(tree)) enterGetterSetter(tree)
+      else assignAndEnterFinishedSymbol(tree)
 
       if (isEnumConstant(tree))
         tree.symbol setInfo ConstantType(Constant(tree.symbol))

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -233,6 +233,8 @@ trait Definitions extends api.StandardDefinitions {
       || tp =:= AnyRefTpe
     )
 
+    def isUnitType(tp: Type) = tp.typeSymbol == UnitClass && tp.annotations.isEmpty
+
     def hasMultipleNonImplicitParamLists(member: Symbol): Boolean = hasMultipleNonImplicitParamLists(member.info)
     def hasMultipleNonImplicitParamLists(info: Type): Boolean = info match {
       case PolyType(_, restpe)                                   => hasMultipleNonImplicitParamLists(restpe)


### PR DESCRIPTION
Distinguish abstract ValDef from ValDef that needs a setter. 
(Later, all trait vals will also need a setter -- right now, it's only mutable ones.)

Similarly, make explicit whether a field is needed. (Later, fields will not be emitted for traits.)

Simplify decision whether to derive accessors. Comments in the original code below (modulo renaming & reduction of double negation in previous commit) explain why I believe my changes make sense:

```
def deriveAccessors(vd: ValDef) = vd.mods.isLazy || !(
     !owner.isClass
  || (vd.mods.isPrivateLocal && !vd.mods.isCaseAccessor) // this is an error -- now checking first
  || (vd.name startsWith nme.OUTER)
  || (context.unit.isJava) // pulled out to caller
  || isEnumConstant(vd)
)

def deriveAccessorTrees(vd: ValDef) = !(
     (vd.mods.isPrivateLocal && !vd.mods.isLazy) // lazy was pulled out to outer disjunction
  || vd.symbol.isModuleVar // pulled out to caller
  || isEnumConstant(vd))
```

These conditions are now captured by one method.

Review by @lrytz, @retronym & @SethTisue. I'll check bytecode diffs (should be empty) later tonight.
