### PR TITLE
SI-9450 Fix triple quoted strings in REPL :power mode

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -133,7 +133,6 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
     }
     catch AbstractOrMissingHandler()
   }
-  private def tquoted(s: String) = "\"\"\"" + s + "\"\"\""
   private val logScope = scala.sys.props contains "scala.repl.scope"
   private def scopelog(msg: String) = if (logScope) Console.err.println(msg)
 
@@ -905,7 +904,10 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
       def path = originalPath("$intp")
       def envLines = {
         if (!isReplPower) Nil // power mode only for now
-        else List("def %s = %s".format("$line", tquoted(originalLine)), "def %s = Nil".format("$trees"))
+        else {
+          val escapedLine = Constant(originalLine).escapedStringValue
+          List(s"""def $$line = $escapedLine """, """def $trees = _root_.scala.Nil""")
+        }
       }
       def preamble = s"""
         |$headerPreamble

--- a/test/files/run/repl-power.check
+++ b/test/files/run/repl-power.check
@@ -25,4 +25,7 @@ m: $r.treedsl.global.Literal = 10
 scala> typed(m).tpe                              // typed is in scope
 res2: $r.treedsl.global.Type = Int(10)
 
+scala> """escaping is hard, m'kah"""
+res3: String = escaping is hard, m'kah
+
 scala> :quit

--- a/test/files/run/repl-power.scala
+++ b/test/files/run/repl-power.scala
@@ -1,7 +1,9 @@
 import scala.tools.partest.ReplTest
 
 object Test extends ReplTest {
-  def code = """
+  def tripleQuote(s: String) = "\"\"\"" + s + "\"\"\""
+
+  def code = s"""
 :power
 // guarding against "error: reference to global is ambiguous"
 global.emptyValDef  // "it is imported twice in the same scope by ..."
@@ -9,5 +11,6 @@ val tp = ArrayClass[scala.util.Random]    // magic with tags
 tp.memberType(Array_apply)                // evidence
 val m = LIT(10)                           // treedsl
 typed(m).tpe                              // typed is in scope
+${tripleQuote("escaping is hard, m'kah")}
   """.trim
 }


### PR DESCRIPTION
Some extra synthetic code generated under this mode failed to escape
input before adding it to a literal string. It used to get away with
this most of the time by triple quoting the literal.

This commit reuses Scala string escaping logic buried in `Constant`
to do this properly. Actually, the proper approach would be to build
the synthetic code with trees and quasiquotes, and avoid the mess
of stringly-genererated code.

I threw in some defensive hygiene for the reference to `Nil` while
I was in the neighbourhood.

Review by @SethTisue 
