### PR TITLE
SI-9388  Fix Range behavior around Int.MaxValue

### DIFF
--- a/test/files/run/t4658.check
+++ b/test/files/run/t4658.check
@@ -1,5 +1,5 @@
 Ranges:
-1073741824
+-1073741824
 1073741824
 0
 0
@@ -20,7 +20,7 @@ Ranges:
 -10
 IntRanges:
 -1073741824
--1073741824
+1073741824
 0
 0
 55
@@ -78,3 +78,6 @@ BigIntRanges:
 -24
 -30
 -10
+BigInt agrees with Long: true
+Long agrees with Int when rounded: true
+Numeric Int agrees with Range: true

--- a/test/files/run/t4658.scala
+++ b/test/files/run/t4658.scala
@@ -2,6 +2,7 @@ import scala.collection.immutable.NumericRange
 //#4658
 object Test {
 
+  // Only works for Int values!  Need to rethink explicit otherwise.
   case class R(start: Int, end: Int, step: Int = 1, inclusive: Boolean = true)
 
   val rangeData = Array(
@@ -28,6 +29,14 @@ object Test {
     numericLongRanges.foreach{range => println(range.sum)}
     println("BigIntRanges:")
     numericBigIntRanges.foreach{range => println(range.sum)}
+    println("BigInt agrees with Long: " + 
+      (numericLongRanges zip numericBigIntRanges).forall{ case (lr, bir) => lr.sum == bir.sum }
+    )
+    println("Long agrees with Int when rounded: " + 
+      (numericLongRanges zip numericIntRanges).forall{ case (lr, ir) => lr.sum.toInt == ir.sum }
+    )
+    println("Numeric Int agrees with Range: " +
+      (numericIntRanges zip ranges).forall{ case (ir, r) => ir.sum == r.sum }
+    )
   }
-
 }

--- a/test/files/scalacheck/range.scala
+++ b/test/files/scalacheck/range.scala
@@ -134,7 +134,22 @@ abstract class RangeTest(kind: String) extends Properties("Range "+kind) {
     val expected = r.length match {
       case 0 => 0
       case 1 => r.head
-      case _ => ((r.head + r.last).toLong * r.length  / 2).toInt
+      case x if x < 1000 => 
+        // Explicit sum, to guard against having the same mistake in both the
+        // range implementation and test implementation of sum formula.
+        // (Yes, this happened before.)
+        var i = r.head
+        var s = 0L
+        var n = x
+        while (n > 0) {
+          s += i
+          i += r.step
+          n -= 1
+        }
+        s.toInt
+      case _ =>
+        // Make sure head + last doesn't overflow!
+        ((r.head.toLong + r.last) * r.length  / 2).toInt
     }
 //   println("size: " + r.length)
 //   println("expected: " + expected)

--- a/test/junit/scala/collection/immutable/RangeConsistencyTest.scala
+++ b/test/junit/scala/collection/immutable/RangeConsistencyTest.scala
@@ -148,4 +148,28 @@ class RangeConsistencyTest {
     val bdRange = bd(-10.0) until bd(0.0) by bd(4.5)
     assert( bdRange sameElements List(bd(-10.0), bd(-5.5), bd(-1.0)) )
   }
+
+  @Test
+  def test_SI9388()  {
+    val possiblyNotDefaultNumeric = new scala.math.Numeric[Int] {
+      def fromInt(x: Int) = x
+      def minus(x: Int, y: Int): Int = x - y
+      def negate(x: Int): Int = -x
+      def plus(x: Int, y: Int): Int = x + y
+      def times(x: Int, y: Int): Int = x*y
+      def toDouble(x: Int): Double = x.toDouble
+      def toFloat(x: Int): Float = x.toFloat
+      def toInt(x: Int): Int = x
+      def toLong(x: Int): Long = x.toLong
+      def compare(x: Int, y: Int) = x compare y
+    }
+    val r = (Int.MinValue to Int.MaxValue by (1<<23))
+    val nr = NumericRange(Int.MinValue, Int.MaxValue, 1 << 23)
+    assert({ var i = 0; r.foreach(_ => i += 1); i } == 512)
+    assert({ var i = 0; nr.foreach(_ => i += 1); i } == 512)
+    assert(r.sum == Int.MinValue)
+    assert(nr.sum == Int.MinValue)
+    assert(r.sum(possiblyNotDefaultNumeric) == Int.MinValue)
+    assert(nr.sum(possiblyNotDefaultNumeric) == Int.MinValue)
+  }
 }


### PR DESCRIPTION
terminalElement (the element _after_ the last one!) was used to terminate foreach loops and sums of non-standard instances of Numeric.  Unfortunately, this could result in the end wrapping around and hitting the beginning again, making the first element bad.

This patch fixes the behavior by altering the loop to end after the last element is encountered.  The particular flavor was chosen out of a few possibilities because it gave the best microbenchmarks on both large and small ranges.

Test written.  While testing, a bug was also uncovered in NumericRange (improperly placed parentheses), and was also fixed.
