### PR TITLE
SI-9379  Added toString to .zipped to allow Stream etc to short-circuit

### DIFF
--- a/src/library/scala/runtime/Tuple2Zipped.scala
+++ b/src/library/scala/runtime/Tuple2Zipped.scala
@@ -110,6 +110,8 @@ final class Tuple2Zipped[El1, Repr1, El2, Repr2](val colls: (TraversableLike[El1
         return
     }
   }
+
+  override def toString = "(%s, %s).zipped".format(colls._1.toString, colls._2.toString)
 }
 
 object Tuple2Zipped {

--- a/src/library/scala/runtime/Tuple3Zipped.scala
+++ b/src/library/scala/runtime/Tuple3Zipped.scala
@@ -118,6 +118,8 @@ final class Tuple3Zipped[El1, Repr1, El2, Repr2, El3, Repr3](val colls: (Travers
         return
     }
   }
+
+  override def toString: String = "(%s, %s, %s).zipped".format(colls._1.toString, colls._2.toString, colls._3.toString)
 }
 
 object Tuple3Zipped {

--- a/test/junit/scala/collection/immutable/StreamTest.scala
+++ b/test/junit/scala/collection/immutable/StreamTest.scala
@@ -107,4 +107,20 @@ class StreamTest {
   def withFilter_map_properly_lazy_in_tail: Unit = {
     assertStreamOpLazyInTail(_.withFilter(_ % 2 == 0).map(identity), List(1, 2))
   }
+
+  @Test
+  def test_si9379() {
+    class Boom {
+      private var i = -1
+      def inc = {
+        i += 1
+        if (i > 1000) throw new NoSuchElementException("Boom! Too many elements!")
+        i
+      }
+    }
+    val b = new Boom
+    val s = Stream.continually(b.inc)
+    // zipped.toString must allow s to short-circuit evaluation
+    assertTrue((s, s).zipped.toString contains s.toString)
+  }
 }


### PR DESCRIPTION
Tuple2Zipped and Tuple3Zipped would try to compute a hash code when .toString was called on them.  This overrides toString to print (collection1, collection2).zipped instead, using the collection's own toString method.  This allows collections that have a toString but not a hashCode (such as Iterator.from(0) and s = 1 #:: s) to print out as they usually do.

JUnit test to verify the deferral to collections' .toString.
