### PR TITLE
SI-8647 Used immutable scheme for mutable.BitSet to resolve canBuildFrom

### DIFF
--- a/src/library/scala/collection/mutable/SortedSet.scala
+++ b/src/library/scala/collection/mutable/SortedSet.scala
@@ -43,10 +43,12 @@ trait SortedSet[A] extends scala.collection.SortedSet[A] with scala.collection.S
  *
  */
 object SortedSet extends MutableSortedSetFactory[SortedSet] {
-  implicit def canBuildFrom[A](implicit ord: Ordering[A]): CanBuildFrom[Coll, A, SortedSet[A]] = new SortedSetCanBuildFrom[A]
+  def canBuildFrom[A](implicit ord: Ordering[A]): CanBuildFrom[Coll, A, SortedSet[A]] = new SortedSetCanBuildFrom[A]
 
   def empty[A](implicit ord: Ordering[A]): SortedSet[A] = TreeSet.empty[A]
 
+  // Force a declaration here so that BitSet (which does not inherit from SortedSetFactory) can be more specific
+  override implicit def newCanBuildFrom[A](implicit ord : Ordering[A]): CanBuildFrom[Coll, A, SortedSet[A]] = super.newCanBuildFrom
 }
 
 /** Explicit instantiation of the `SortedSet` trait to reduce class file size in subclasses. */

--- a/test/junit/scala/collection/mutable/BitSetTest.scala
+++ b/test/junit/scala/collection/mutable/BitSetTest.scala
@@ -28,4 +28,11 @@ class BitSetTest {
     littleBitSet &= bigBitSet
     assert(littleBitSet.toBitMask.length < bigBitSet.toBitMask.length, "Needlessly extended the size of bitset on &=")
   }
+
+  @Test def test_SI8647() {
+    val bs = BitSet()
+    bs.map(_ + 1)    // Just needs to compile
+    val xs = bs: SortedSet[Int]
+    xs.map(_ + 1)    // Also should compile (did before)
+  }
 }


### PR DESCRIPTION
mutable.BitSet had a conflict between its own implicit canBuildFrom and the one inherited from SortedSetFactory in mutable.SortedSet.

The immutable hierarchy already had a workaround; this just copies it on the mutable side.

Test written to verify compilation.
