### PR TITLE
Improve constant factor performance in AliasedFrame merge

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/AliasingFrame.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/AliasingFrame.scala
@@ -38,7 +38,17 @@ class AliasingFrame[V <: Value](nLocals: Int, nStack: Int) extends Frame[V](nLoc
   /**
    * Returns the indices of the values array which are aliases of the object `id`.
    */
-  def valuesWithAliasId(id: Long): Set[Int] = immutable.BitSet.empty ++ aliasIds.indices.iterator.filter(i => aliasId(i) == id)
+  def valuesWithAliasId(id: Long): Set[Int] = {
+    // performance sensitive method
+    var result = immutable.BitSet.empty
+    var i = 0
+    while (i < aliasIds.length) {
+      if (aliasId(i) == id)
+        result = result + i
+      i += 1
+    }
+    result
+  }
 
   /**
    * The set of aliased values for a given entry in the `values` array.

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/AliasingFrame.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/AliasingFrame.scala
@@ -233,12 +233,15 @@ class AliasingFrame[V <: Value](nLocals: Int, nStack: Int) extends Frame[V](nLoc
     val valuesChanged = super.merge(other, interpreter)
     var aliasesChanged = false
     val aliasingOther = other.asInstanceOf[AliasingFrame[_]]
-    for (i <- aliasIds.indices) {
-      val thisAliases = aliasesOf(i)
-      val thisNotOther = thisAliases diff (thisAliases intersect aliasingOther.aliasesOf(i))
-      if (thisNotOther.nonEmpty) {
-        aliasesChanged = true
-        thisNotOther foreach removeAlias
+    val Threshold = 64
+    if (aliasIds.length < 64) {
+      for (i <- aliasIds.indices) {
+        val thisAliases = aliasesOf(i)
+        val thisNotOther = thisAliases diff (thisAliases intersect aliasingOther.aliasesOf(i))
+        if (thisNotOther.nonEmpty) {
+          aliasesChanged = true
+          thisNotOther foreach removeAlias
+        }
       }
     }
     valuesChanged || aliasesChanged


### PR DESCRIPTION
Before:

```
% time qscalac -J-Xmx2G -Yopt:l:classpath -d /tmp test/files/run/patmat-exprs.scala
^C
real    11m6.461s
user    11m39.127s
sys 0m2.779s
```

After:

```
⚡ time qscalac -J-Xmx2G -Yopt:l:classpath -d /tmp test/files/run/patmat-exprs.scala

real    2m4.458s
user    2m33.159s
sys 0m1.451s
```

Albeit still far slower than:

```
% time scalac-hash v2.11.7 -J-Xmx2G -Yopt:l:classpath -d /tmp test/files/run/patmat-exprs.scala

real    0m7.088s
user    0m25.526s
sys 0m1.005s
```
