### PR TITLE
Constructors cleanup in preparation of new trait encoding

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -49,7 +49,9 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
       clearStatics()
       val newBody = transformTrees(body)
       val templ   = deriveTemplate(tree)(_ => transformTrees(newStaticMembers.toList) ::: newBody)
-      try addStaticInits(templ, newStaticInits.toList, localTyper) // postprocess to include static ctors
+      try
+        if (newStaticInits.isEmpty) templ
+        else deriveTemplate(templ)(body => staticConstructor(body, localTyper, templ.pos)(newStaticInits.toList) :: body)
       finally clearStatics()
     }
     private def mkTerm(prefix: String): TermName = unit.freshTermName(prefix)

--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -49,7 +49,7 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
       clearStatics()
       val newBody = transformTrees(body)
       val templ   = deriveTemplate(tree)(_ => transformTrees(newStaticMembers.toList) ::: newBody)
-      try addStaticInits(templ, newStaticInits, localTyper) // postprocess to include static ctors
+      try addStaticInits(templ, newStaticInits.toList, localTyper) // postprocess to include static ctors
       finally clearStatics()
     }
     private def mkTerm(prefix: String): TermName = unit.freshTermName(prefix)

--- a/src/compiler/scala/tools/nsc/transform/Constructors.scala
+++ b/src/compiler/scala/tools/nsc/transform/Constructors.scala
@@ -723,7 +723,11 @@ abstract class Constructors extends Statics with Transform with ast.TreeDSL {
       val prunedStats = (defs filterNot omittableStat) ::: delayedHookDefs ::: constructors
 
       //  Add the static initializers
-      addStaticInits(deriveTemplate(impl)(_ => prunedStats), classInitStats, localTyper)
+      if (classInitStats.isEmpty) deriveTemplate(impl)(_ => prunedStats)
+      else {
+        val staticCtor = staticConstructor(prunedStats, localTyper, impl.pos)(classInitStats)
+        deriveTemplate(impl)(_ => staticCtor :: prunedStats)
+      }
     }
   } // TemplateTransformer
 }

--- a/src/compiler/scala/tools/nsc/transform/Statics.scala
+++ b/src/compiler/scala/tools/nsc/transform/Statics.scala
@@ -18,7 +18,7 @@ abstract class Statics extends Transform with ast.TreeDSL {
     /** changes the template for the class so that it contains a static constructor with symbol fields inits,
       * augments an existing static ctor if one already existed.
       */
-    def addStaticInits(template: Template, newStaticInits: Buffer[Tree], localTyper: analyzer.Typer): Template = {
+    def addStaticInits(template: Template, newStaticInits: List[Tree], localTyper: analyzer.Typer): Template = {
       if (newStaticInits.isEmpty)
         template
       else {
@@ -30,15 +30,15 @@ abstract class Statics extends Transform with ast.TreeDSL {
             deriveDefDef(ctor) {
               case block @ Block(stats, expr) =>
                 // need to add inits to existing block
-                treeCopy.Block(block, newStaticInits.toList ::: stats, expr)
+                treeCopy.Block(block, newStaticInits ::: stats, expr)
               case term: TermTree =>
                 // need to create a new block with inits and the old term
-                treeCopy.Block(term, newStaticInits.toList, term)
+                treeCopy.Block(term, newStaticInits, term)
             }
           case _ =>
             // create new static ctor
             val staticCtorSym  = currentClass.newStaticConstructor(template.pos)
-            val rhs            = Block(newStaticInits.toList, Literal(Constant(())))
+            val rhs            = Block(newStaticInits, Literal(Constant(())))
 
             localTyper.typedPos(template.pos)(DefDef(staticCtorSym, rhs))
         }

--- a/src/compiler/scala/tools/nsc/transform/Statics.scala
+++ b/src/compiler/scala/tools/nsc/transform/Statics.scala
@@ -1,49 +1,33 @@
 package scala.tools.nsc
 package transform
 
-import collection.mutable.Buffer
-
 abstract class Statics extends Transform with ast.TreeDSL {
   import global._
 
   class StaticsTransformer extends Transformer {
-
-    /** finds the static ctor DefDef tree within the template if it exists. */
-    def findStaticCtor(template: Template): Option[Tree] =
-      template.body find {
-        case defdef @ DefDef(_, nme.CONSTRUCTOR, _, _, _, _) => defdef.symbol.hasStaticFlag
-        case _ => false
-      }
-
     /** changes the template for the class so that it contains a static constructor with symbol fields inits,
       * augments an existing static ctor if one already existed.
       */
-    def addStaticInits(template: Template, newStaticInits: List[Tree], localTyper: analyzer.Typer): Template = {
-      if (newStaticInits.isEmpty)
-        template
-      else {
-        val newCtor = findStaticCtor(template) match {
-          // in case there already were static ctors - augment existing ones
-          // currently, however, static ctors aren't being generated anywhere else
-          case Some(ctor @ DefDef(_,_,_,_,_,_)) =>
-            // modify existing static ctor
-            deriveDefDef(ctor) {
-              case block @ Block(stats, expr) =>
-                // need to add inits to existing block
-                treeCopy.Block(block, newStaticInits ::: stats, expr)
-              case term: TermTree =>
-                // need to create a new block with inits and the old term
-                treeCopy.Block(term, newStaticInits, term)
-            }
-          case _ =>
-            // create new static ctor
-            val staticCtorSym  = currentClass.newStaticConstructor(template.pos)
-            val rhs            = Block(newStaticInits, Literal(Constant(())))
+    def staticConstructor(body: List[Tree], localTyper: analyzer.Typer, pos: Position)(newStaticInits: List[Tree]): Tree =
+      body.collectFirst {
+        // If there already was a static ctor - augment existing one
+        // currently, however, static ctors aren't being generated anywhere else (!!!)
+        case ctor@DefDef(_, nme.CONSTRUCTOR, _, _, _, _) if ctor.symbol.hasStaticFlag =>
+          // modify existing static ctor
+          deriveDefDef(ctor) {
+            case block@Block(stats, expr) =>
+              // need to add inits to existing block
+              treeCopy.Block(block, newStaticInits ::: stats, expr)
+            case term: TermTree           =>
+              // need to create a new block with inits and the old term
+              treeCopy.Block(term, newStaticInits, term)
+          }
+      } getOrElse {
+        // create new static ctor
+        val staticCtorSym = currentClass.newStaticConstructor(pos)
+        val rhs = Block(newStaticInits, Literal(Constant(())))
 
-            localTyper.typedPos(template.pos)(DefDef(staticCtorSym, rhs))
-        }
-        deriveTemplate(template)(newCtor :: _)
+        localTyper.typedPos(pos)(DefDef(staticCtorSym, rhs))
       }
-    }
   }
 }


### PR DESCRIPTION
I feel it was high time to clean up a bit here. My changes are informed by the work I'm doing on the new trait encoding (fields).

Review by @retronym, cc @SethTisue & @lrytz.
