### PR TITLE
Update Java and Sun URLs to replacement Java and Oracle URLs

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
@@ -2700,7 +2700,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters { self =>
               case CMPG =>
                 (kind: @unchecked) match {
                   case FLOAT  => emit(Opcodes.FCMPG)
-                  case DOUBLE => emit(Opcodes.DCMPL) // TODO bug? why not DCMPG? http://docs.oracle.com/javase/specs/jvms/se5.0/html/Instructions2.doc3.html
+                  case DOUBLE => emit(Opcodes.DCMPL) // TODO bug? why not DCMPG? http://docs.oracle.com/javase/specs/jvms/se6/html/Instructions2.doc3.html
 
                 }
             }

--- a/src/compiler/scala/tools/nsc/io/Jar.scala
+++ b/src/compiler/scala/tools/nsc/io/Jar.scala
@@ -154,7 +154,7 @@ object Jar {
     def update(key: Attributes.Name, value: String) = attrs.put(key, value)
   }
 
-  // See http://download.java.net/jdk7/docs/api/java/nio/file/Path.html
+  // See http://docs.oracle.com/javase/7/docs/api/java/nio/file/Path.html
   // for some ideas.
   private val ZipMagicNumber = List[Byte](80, 75, 3, 4)
   private def magicNumberIsZip(f: Path) = f.isFile && (f.toFile.bytes().take(4).toList == ZipMagicNumber)

--- a/src/compiler/scala/tools/nsc/util/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/util/ClassPath.scala
@@ -22,7 +22,7 @@ import Jar.isJarOrZip
 
 /** <p>
  *    This module provides star expansion of '-classpath' option arguments, behaves the same as
- *    java, see [http://java.sun.com/javase/6/docs/technotes/tools/windows/classpath.html]
+ *    java, see [[http://docs.oracle.com/javase/6/docs/technotes/tools/windows/classpath.html]]
  *  </p>
  *
  *  @author Stepan Koltsov

--- a/src/library/scala/concurrent/SyncVar.scala
+++ b/src/library/scala/concurrent/SyncVar.scala
@@ -40,7 +40,7 @@ class SyncVar[A] {
     wait(timeout)
     val elapsed = System.nanoTime() - start
     // nanoTime should be monotonic, but it's not possible to rely on that.
-    // See http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6458294.
+    // See http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6458294.
     if (elapsed < 0) 0 else TimeUnit.NANOSECONDS.toMillis(elapsed)
   }
 

--- a/src/library/scala/io/Codec.scala
+++ b/src/library/scala/io/Codec.scala
@@ -22,7 +22,7 @@ import scala.language.implicitConversions
 //   <?xml version="1.0" encoding="ISO8859-1" ?>
 //
 // MacRoman vs. UTF-8: see http://jira.codehaus.org/browse/JRUBY-3576
-// -Dfile.encoding: see http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4375816
+// -Dfile.encoding: see http://bugs.java.com/bugdatabase/view_bug.do?bug_id=4375816
 
 /** A class for character encoding/decoding preferences.
  *

--- a/src/library/scala/runtime/ScalaRunTime.scala
+++ b/src/library/scala/runtime/ScalaRunTime.scala
@@ -155,7 +155,7 @@ object ScalaRunTime {
     arr
   }
 
-  // Java bug: http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4071957
+  // Java bug: http://bugs.java.com/bugdatabase/view_bug.do?bug_id=4071957
   // More background at ticket #2318.
   def ensureAccessible(m: JMethod): JMethod = scala.reflect.ensureAccessible(m)
 

--- a/src/reflect/scala/reflect/internal/ClassfileConstants.scala
+++ b/src/reflect/scala/reflect/internal/ClassfileConstants.scala
@@ -14,7 +14,7 @@ object ClassfileConstants {
   final val JAVA_MAJOR_VERSION = 45
   final val JAVA_MINOR_VERSION = 3
 
-  /** (see http://java.sun.com/docs/books/jvms/second_edition/jvms-clarify.html)
+  /** (see http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.1)
    *
    *  If the `ACC_INTERFACE` flag is set, the `ACC_ABSTRACT` flag must also
    *  be set (ch. 2.13.1).


### PR DESCRIPTION
For each URL
- Where it redirected the target of the redirection was used
- Where is no longer existed a replacement was selected
