### PR TITLE
Update links to docs, codehaus and citeseer

### DIFF
--- a/src/library/scala/collection/immutable/IntMap.scala
+++ b/src/library/scala/collection/immutable/IntMap.scala
@@ -146,7 +146,7 @@ private[immutable] class IntMapKeyIterator[V](it: IntMap[V]) extends IntMapItera
 import IntMap._
 
 /** Specialised immutable map structure for integer keys, based on
- *  <a href="http://citeseer.ist.psu.edu/okasaki98fast.html">Fast Mergeable Integer Maps</a>
+ *  [[http://ittc.ku.edu/~andygill/papers/IntMap98.pdf Fast Mergeable Integer Maps]]
  *  by Okasaki and Gill. Essentially a trie based on binary digits of the integers.
  *
  *  '''Note:''' This class is as of 2.8 largely superseded by HashMap.

--- a/src/library/scala/collection/mutable/Queue.scala
+++ b/src/library/scala/collection/mutable/Queue.scala
@@ -21,7 +21,7 @@ import generic._
  *  @author  Martin Odersky
  *  @version 2.8
  *  @since   1
- *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#mutable_queues "Scala's Collection Library overview"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#queues "Scala's Collection Library overview"]]
  *  section on `Queues` for more information.
  *
  *  @define Coll `mutable.Queue`

--- a/src/library/scala/collection/package.scala
+++ b/src/library/scala/collection/package.scala
@@ -69,6 +69,9 @@ package scala
  * characteristics which are described
  * in [[http://docs.scala-lang.org/overviews/collections/performance-characteristics.html the guide]].
  *
+ * The concrete parallel collections also have specific performance characteristics which are
+ * described in [[http://docs.scala-lang.org/overviews/parallel-collections/concrete-parallel-collections.html#performance-characteristics the parallel collections guide]]
+ *
  * === Converting between Java Collections ===
  *
  * The `JavaConversions` object provides implicit defs that will allow mostly seamless integration

--- a/src/library/scala/io/Codec.scala
+++ b/src/library/scala/io/Codec.scala
@@ -21,7 +21,7 @@ import scala.language.implicitConversions
 // XML: optional encoding parameter.
 //   <?xml version="1.0" encoding="ISO8859-1" ?>
 //
-// MacRoman vs. UTF-8: see http://jira.codehaus.org/browse/JRUBY-3576
+// MacRoman vs. UTF-8: see http://osdir.com/ml/lang-jruby-devel/2009-04/msg00071.html
 // -Dfile.encoding: see http://bugs.java.com/bugdatabase/view_bug.do?bug_id=4375816
 
 /** A class for character encoding/decoding preferences.

--- a/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
+++ b/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
@@ -244,7 +244,7 @@ abstract class UnPickler {
 
           (module map { case (group, art) =>
             s"""\n(NOTE: It looks like the $art module is missing; try adding a dependency on "$group" : "$art".
-               |       See http://docs.scala-lang.org/overviews/core/scala-2.11.html for more information.)""".stripMargin
+               |       See http://docs.scala-lang.org/overviews/ for more information.)""".stripMargin
            } getOrElse "")
         }
 

--- a/src/reflect/scala/reflect/macros/blackbox/Context.scala
+++ b/src/reflect/scala/reflect/macros/blackbox/Context.scala
@@ -29,7 +29,7 @@ package blackbox
  *  which means that its expansion will be upcast to its return type, enforcing faithfullness of that macro to its
  *  type signature. Whitebox macros, i.e. the ones defined with `whitebox.Context`, aren't bound by this restriction,
  *  which enables a number of important use cases, but they are also going to enjoy less support than blackbox macros,
- *  so choose wisely. See the [[http://docs.scala-lang.org/overviews/macros.html Macros Guide]] for more information.
+ *  so choose wisely. See the [[http://docs.scala-lang.org/overviews/macros/overview.html Macros Guide]] for more information.
  *
  *  @see `scala.reflect.macros.whitebox.Context`
  */

--- a/src/reflect/scala/reflect/macros/package.scala
+++ b/src/reflect/scala/reflect/macros/package.scala
@@ -10,14 +10,14 @@ package reflect
  *  Within these functions the programmer has access to compiler APIs.
  *  For example, it is possible to generate, analyze and typecheck code.
  *
- *  See the [[http://docs.scala-lang.org/overviews/macros.html Macros Guide]] on how to get started with Scala macros.
+ *  See the [[http://docs.scala-lang.org/overviews/macros/overview.html Macros Guide]] on how to get started with Scala macros.
  */
 package object macros {
   /** The Scala macros context.
    *
    *  In Scala 2.11, macros that were once the one are split into blackbox and whitebox macros,
    *  with the former being better supported and the latter being more powerful. You can read about
-   *  the details of the split and the associated trade-offs in the [[http://docs.scala-lang.org/overviews/macros.html Macros Guide]].
+   *  the details of the split and the associated trade-offs in the [[http://docs.scala-lang.org/overviews/macros/overview.html Macros Guide]].
    *
    *  `scala.reflect.macros.Context` follows this tendency and turns into `scala.reflect.macros.blackbox.Context`
    *  and `scala.reflect.macros.whitebox.Context`. The original `Context` is left in place for compatibility reasons,

--- a/src/reflect/scala/reflect/macros/whitebox/Context.scala
+++ b/src/reflect/scala/reflect/macros/whitebox/Context.scala
@@ -29,7 +29,7 @@ package whitebox
  *  gaining the ability to refine the type of its expansion beyond its official return type, which enables a number of important use cases.
  *  Blackbox macros, i.e. the ones defined with `blackbox.Context`, can't do that, so they are less powerful.
  *  However blackbox macros are also going to enjoy better support than whitebox macros, so choose wisely.
- *  See the [[http://docs.scala-lang.org/overviews/macros.html Macros Guide]] for more information.
+ *  See the [[http://docs.scala-lang.org/overviews/macros/overview.html Macros Guide]] for more information.
  *
  *  @see `scala.reflect.macros.blackbox.Context`
  */


### PR DESCRIPTION
docs.scala-lang.org
- Align some links to new layout for docs.scala-lang.org
- Include link to concrete parallel collection performance characteristics

codehaus
- Subsitute a link to a JIRA email for the 404 JRUBY-3576 JIRA link
  in Codec.scala. jira.codehaus.org is not redirecting this.

citeseer
- Replace the citeseer link with a direct link to a PDF which is not
  behind a login challenge.
