### PR TITLE
Desugar module var and accessor in refchecks/lazyvals

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/TreeGen.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeGen.scala
@@ -242,11 +242,14 @@ abstract class TreeGen extends scala.reflect.internal.TreeGen with TreeDSL {
   def mkSynchronizedCheck(clazz: Symbol, cond: Tree, syncBody: List[Tree], stats: List[Tree]): Tree =
     mkSynchronizedCheck(mkAttributedThis(clazz), cond, syncBody, stats)
 
-  def mkSynchronizedCheck(attrThis: Tree, cond: Tree, syncBody: List[Tree], stats: List[Tree]): Tree =
-    Block(mkSynchronized(
-      attrThis,
-      If(cond, Block(syncBody: _*), EmptyTree)) ::
-      stats: _*)
+  def mkSynchronizedCheck(attrThis: Tree, cond: Tree, syncBody: List[Tree], stats: List[Tree]): Tree = {
+    def blockOrStat(stats: List[Tree]): Tree = stats match {
+      case head :: Nil => head
+      case _ => Block(stats : _*)
+    }
+    val sync = mkSynchronized(attrThis, If(cond, blockOrStat(syncBody), EmptyTree))
+    blockOrStat(sync :: stats)
+  }
 
   /** Creates a tree representing new Object { stats }.
    *  To make sure an anonymous subclass of Object is created,

--- a/src/compiler/scala/tools/nsc/transform/LazyVals.scala
+++ b/src/compiler/scala/tools/nsc/transform/LazyVals.scala
@@ -54,14 +54,35 @@ abstract class LazyVals extends Transform with TypingTransformers with ast.TreeD
     private val lazyVals = perRunCaches.newMap[Symbol, Int]() withDefaultValue 0
 
     import symtab.Flags._
+    private def flattenThickets(stats: List[Tree]): List[Tree] = stats.flatMap(_ match {
+      case b @ Block(List(d1@DefDef(_, n1, _, _, _, _)), d2@DefDef(_, n2, _, _, _, _)) if b.tpe == null && n1.endsWith(nme.LAZY_SLOW_SUFFIX) =>
+        List(d1, d2)
+      case stat =>
+        List(stat)
+    })
 
     /** Perform the following transformations:
      *  - for a lazy accessor inside a method, make it check the initialization bitmap
+     *  - implement double checked locking of member modules for non-trait owners (trait just have the abstract accessor)
+     *     ```
+     *     // typer
+     *     class C { object x }
+     *     // refchecks
+     *     class C { var x$module; def x() = { x$module = new x; x$module }
+     *     // lazyvals
+     *     class C {
+     *       var x$module                                                                               // module var
+     *       def x() = { if (x$module == null) x$lzycompute() else x$module                             // fast path
+     *       def x$lzycompute() = { synchronized { if (x$module == null) x$module = new x }; x$module } // slow path
+     *     }
+     *     ```
      *  - for all methods, add enough int vars to allow one flag per lazy local value
      *  - blocks in template bodies behave almost like methods. A single bitmaps section is
      *      added in the first block, for all lazy values defined in such blocks.
      *  - remove ACCESSOR flags: accessors in traits are not statically implemented,
      *    but moved to the host class. local lazy values should be statically implemented.
+     *
+     * The general pattern is
      */
     override def transform(tree: Tree): Tree = {
       val sym = tree.symbol
@@ -72,20 +93,14 @@ abstract class LazyVals extends Transform with TypingTransformers with ast.TreeD
         case Block(_, _) =>
           val block1 = super.transform(tree)
           val Block(stats, expr) = block1
-          val stats1 = stats.flatMap(_ match {
-            case Block(List(d1@DefDef(_, n1, _, _, _, _)), d2@DefDef(_, n2, _, _, _, _)) if (nme.newLazyValSlowComputeName(n2) == n1) =>
-              List(d1, d2)
-            case stat =>
-              List(stat)
-          })
-          treeCopy.Block(block1, stats1, expr)
+          treeCopy.Block(block1, flattenThickets(stats), expr)
 
         case DefDef(_, _, _, _, _, rhs) => atOwner(tree.symbol) {
           val (res, slowPathDef) = if (!sym.owner.isClass && sym.isLazy) {
             val enclosingClassOrDummyOrMethod = {
               val enclMethod = sym.enclMethod
 
-              if (enclMethod != NoSymbol ) {
+              if (enclMethod != NoSymbol) {
                 val enclClass = sym.enclClass
                 if (enclClass != NoSymbol && enclMethod == enclClass.enclMethod)
                   enclClass
@@ -100,11 +115,26 @@ abstract class LazyVals extends Transform with TypingTransformers with ast.TreeD
             val (rhs1, sDef) = mkLazyDef(enclosingClassOrDummyOrMethod, transform(rhs), idx, sym)
             sym.resetFlag((if (lazyUnit(sym)) 0 else LAZY) | ACCESSOR)
             (rhs1, sDef)
-          } else
+          } else if (sym.hasAllFlags(MODULE | METHOD) && !sym.owner.isTrait) {
+            rhs match {
+              case b @ Block((assign @ Assign(moduleRef, _)) :: Nil, expr) =>
+                val cond = Apply(Select(moduleRef, Object_eq), List(Literal(Constant(null))))
+                val (fastPath, slowPath) = mkFastPathBody(sym.owner.enclClass, moduleRef.symbol, cond, transform(assign) :: Nil, Nil, transform(expr))
+                (localTyper.typedPos(tree.pos)(fastPath), localTyper.typedPos(tree.pos)(slowPath))
+              case rhs =>
+                global.reporter.error(tree.pos, "Unexpected tree on the RHS of a module accessor: " + rhs)
+                (rhs, EmptyTree)
+            }
+          } else {
             (transform(rhs), EmptyTree)
+          }
 
           val ddef1 = deriveDefDef(tree)(_ => if (LocalLazyValFinder.find(res)) typed(addBitmapDefs(sym, res)) else res)
-          if (slowPathDef != EmptyTree) Block(slowPathDef, ddef1) else ddef1
+          if (slowPathDef != EmptyTree) {
+            // The contents of this block are flattened into the enclosing statement sequence, see flattenThickets
+            // This is a poor man's version of dotty's Thicket: https://github.com/lampepfl/dotty/blob/d5280358d1/src/dotty/tools/dotc/ast/Trees.scala#L707
+            Block(slowPathDef, ddef1)
+          } else ddef1
         }
 
         case Template(_, _, body) => atOwner(currentOwner) {
@@ -135,7 +165,7 @@ abstract class LazyVals extends Transform with TypingTransformers with ast.TreeD
                 })
                 toAdd0
             } else List()
-          deriveTemplate(tree)(_ => innerClassBitmaps ++ stats)
+          deriveTemplate(tree)(_ => innerClassBitmaps ++ flattenThickets(stats))
         }
 
         case ValDef(_, _, _, _) if !sym.owner.isModule && !sym.owner.isClass =>

--- a/src/compiler/scala/tools/nsc/transform/Mixin.scala
+++ b/src/compiler/scala/tools/nsc/transform/Mixin.scala
@@ -784,12 +784,12 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL {
         defSym
       }
 
-      def mkFastPathLazyBody(clazz: Symbol, lzyVal: Symbol, cond: Tree, syncBody: List[Tree],
+      def mkFastPathLazyBody(clazz: Symbol, lzyVal: Symbol, cond: => Tree, syncBody: List[Tree],
                              stats: List[Tree], retVal: Tree): Tree = {
         mkFastPathBody(clazz, lzyVal, cond, syncBody, stats, retVal, gen.mkAttributedThis(clazz), List())
       }
 
-      def mkFastPathBody(clazz: Symbol, lzyVal: Symbol, cond: Tree, syncBody: List[Tree],
+      def mkFastPathBody(clazz: Symbol, lzyVal: Symbol, cond: => Tree, syncBody: List[Tree],
                         stats: List[Tree], retVal: Tree, attrThis: Tree, args: List[Tree]): Tree = {
         val slowPathSym: Symbol = mkSlowPathDef(clazz, lzyVal, cond, syncBody, stats, retVal, attrThis, args)
         If(cond, fn (This(clazz), slowPathSym, args.map(arg => Ident(arg.symbol)): _*), retVal)

--- a/src/compiler/scala/tools/nsc/transform/TypingTransformers.scala
+++ b/src/compiler/scala/tools/nsc/transform/TypingTransformers.scala
@@ -26,7 +26,7 @@ trait TypingTransformers {
 
     def atOwner[A](tree: Tree, owner: Symbol)(trans: => A): A = {
       val savedLocalTyper = localTyper
-      localTyper = localTyper.atOwner(tree, if (owner.isModule) owner.moduleClass else owner)
+      localTyper = localTyper.atOwner(tree, if (owner.isModuleNotMethod) owner.moduleClass else owner)
       val result = super.atOwner(owner)(trans)
       localTyper = savedLocalTyper
       result

--- a/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
@@ -387,7 +387,7 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
       val savedValid = validCurrentOwner
       if (owner.isClass) validCurrentOwner = true
       val savedLocalTyper = localTyper
-      localTyper = localTyper.atOwner(tree, if (owner.isModule) owner.moduleClass else owner)
+      localTyper = localTyper.atOwner(tree, if (owner.isModuleNotMethod) owner.moduleClass else owner)
       typers = typers updated (owner, localTyper)
       val result = super.atOwner(tree, owner)(trans)
       localTyper = savedLocalTyper

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -876,7 +876,7 @@ trait StdNames {
     val toCharacter: NameType = "toCharacter"
     val toInteger: NameType   = "toInteger"
 
-    def newLazyValSlowComputeName(lzyValName: Name) = lzyValName append LAZY_SLOW_SUFFIX
+    def newLazyValSlowComputeName(lzyValName: Name) = (lzyValName stripSuffix MODULE_VAR_SUFFIX append LAZY_SLOW_SUFFIX).toTermName
 
     // ASCII names for operators
     val ADD       = encode("+")

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -323,7 +323,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def newModuleVarSymbol(accessor: Symbol): TermSymbol = {
       val newName  = nme.moduleVarName(accessor.name.toTermName)
       val newFlags = MODULEVAR | ( if (this.isClass) PrivateLocal | SYNTHETIC else 0 )
-      val newInfo  = accessor.tpe.finalResultType
+      val newInfo  = thisType.memberType(accessor).finalResultType
       val mval     = newVariable(newName, accessor.pos.focus, newFlags.toLong) addAnnotation VolatileAttr
 
       if (this.isClass)

--- a/src/reflect/scala/reflect/internal/transform/Erasure.scala
+++ b/src/reflect/scala/reflect/internal/transform/Erasure.scala
@@ -123,7 +123,7 @@ trait Erasure {
       case tref @ TypeRef(pre, sym, args) =>
         if (sym == ArrayClass)
           if (unboundedGenericArrayLevel(tp) == 1) ObjectTpe
-          else if (args.head.typeSymbol.isBottomClass) arrayType(ObjectTpe)
+          else if (args.head.typeSymbol.isBottomClass)  arrayType(ObjectTpe)
           else typeRef(apply(pre), sym, args map applyInArray)
         else if (sym == AnyClass || sym == AnyValClass || sym == SingletonClass) ObjectTpe
         else if (sym == UnitClass) BoxedUnitTpe

--- a/test/files/run/delambdafy_t6028.check
+++ b/test/files/run/delambdafy_t6028.check
@@ -38,10 +38,18 @@ package <empty> {
       <synthetic> <stable> <artifact> def $outer(): T = MethodLocalObject$2.this.$outer;
       <synthetic> <stable> <artifact> def $outer(): T = MethodLocalObject$2.this.$outer
     };
-    final <stable> private[this] def MethodLocalObject$1(barParam$1: String, MethodLocalObject$module$1: runtime.VolatileObjectRef): T#MethodLocalObject$2.type = {
-      MethodLocalObject$module$1.elem = new T#MethodLocalObject$2.type(T.this, barParam$1);
+    final <stable> private[this] def MethodLocalObject$lzycompute$1(barParam$1: String, MethodLocalObject$module$1: runtime.VolatileObjectRef): T#MethodLocalObject$2.type = {
+      T.this.synchronized({
+        if (MethodLocalObject$module$1.elem.$asInstanceOf[T#MethodLocalObject$2.type]().eq(null))
+          MethodLocalObject$module$1.elem = new T#MethodLocalObject$2.type(T.this, barParam$1);
+        scala.runtime.BoxedUnit.UNIT
+      });
       MethodLocalObject$module$1.elem.$asInstanceOf[T#MethodLocalObject$2.type]()
     };
+    final <stable> private[this] def MethodLocalObject$1(barParam$1: String, MethodLocalObject$module$1: runtime.VolatileObjectRef): T#MethodLocalObject$2.type = if (MethodLocalObject$module$1.elem.$asInstanceOf[T#MethodLocalObject$2.type]().eq(null))
+      T.this.MethodLocalObject$lzycompute$1(barParam$1, MethodLocalObject$module$1)
+    else
+      MethodLocalObject$module$1.elem.$asInstanceOf[T#MethodLocalObject$2.type]();
     abstract trait MethodLocalTrait$1$class extends Object with T#MethodLocalTrait$1 {
       def /*MethodLocalTrait$1$class*/$init$(barParam$1: String): Unit = {
         ()

--- a/test/files/run/t6028.check
+++ b/test/files/run/t6028.check
@@ -50,10 +50,18 @@ package <empty> {
       <synthetic> <stable> <artifact> def $outer(): T = MethodLocalObject$2.this.$outer;
       <synthetic> <stable> <artifact> def $outer(): T = MethodLocalObject$2.this.$outer
     };
-    final <stable> private[this] def MethodLocalObject$1(barParam$1: Int, MethodLocalObject$module$1: runtime.VolatileObjectRef): T#MethodLocalObject$2.type = {
-      MethodLocalObject$module$1.elem = new T#MethodLocalObject$2.type(T.this, barParam$1);
+    final <stable> private[this] def MethodLocalObject$lzycompute$1(barParam$1: Int, MethodLocalObject$module$1: runtime.VolatileObjectRef): T#MethodLocalObject$2.type = {
+      T.this.synchronized({
+        if (MethodLocalObject$module$1.elem.$asInstanceOf[T#MethodLocalObject$2.type]().eq(null))
+          MethodLocalObject$module$1.elem = new T#MethodLocalObject$2.type(T.this, barParam$1);
+        scala.runtime.BoxedUnit.UNIT
+      });
       MethodLocalObject$module$1.elem.$asInstanceOf[T#MethodLocalObject$2.type]()
     };
+    final <stable> private[this] def MethodLocalObject$1(barParam$1: Int, MethodLocalObject$module$1: runtime.VolatileObjectRef): T#MethodLocalObject$2.type = if (MethodLocalObject$module$1.elem.$asInstanceOf[T#MethodLocalObject$2.type]().eq(null))
+      T.this.MethodLocalObject$lzycompute$1(barParam$1, MethodLocalObject$module$1)
+    else
+      MethodLocalObject$module$1.elem.$asInstanceOf[T#MethodLocalObject$2.type]();
     abstract trait MethodLocalTrait$1$class extends Object with T#MethodLocalTrait$1 {
       def /*MethodLocalTrait$1$class*/$init$(barParam$1: Int): Unit = {
         ()

--- a/test/files/run/trait-defaults-modules.scala
+++ b/test/files/run/trait-defaults-modules.scala
@@ -1,0 +1,20 @@
+trait T1 { def a: Any }
+
+trait T2 extends T1 { object a; object b; private object c; def usec: Any = c}
+trait T3 extends T2
+
+class C1 extends T1 { object a; object b }
+class C2 extends C1
+class C3 extends T2
+class C4 extends T3
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val (c1, c2, c3, c4) = (new C1, new C2, new C3, new C4)
+    c1.a; c1.b; (c1: T1).a
+    c2.a; c2.b; (c2: T1).a
+    c3.a; c3.b; (c3: T1).a; c3.usec
+    c4.a; c4.b; (c4: T1).a; c4.usec
+  }
+
+}

--- a/test/files/run/trait-defaults-modules2/T_1.scala
+++ b/test/files/run/trait-defaults-modules2/T_1.scala
@@ -1,0 +1,4 @@
+trait T {
+  private object O
+  def useO: Any = O
+}

--- a/test/files/run/trait-defaults-modules2/Test_2.scala
+++ b/test/files/run/trait-defaults-modules2/Test_2.scala
@@ -1,0 +1,5 @@
+object Test extends T {
+  def main(args: Array[String]): Unit = {
+    useO
+  }
+}

--- a/test/files/run/trait-defaults-modules3.scala
+++ b/test/files/run/trait-defaults-modules3.scala
@@ -1,0 +1,8 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    object O
+    val x = O
+    val y = O
+    assert(x eq y)
+  }
+}


### PR DESCRIPTION
Rather than leaving it until mixin.

The broader motivation is to simplify the mixin phase of the
compiler before we get rid of implementatation classes in
favour of using JDK8 default interface methods.

The current code in mixin is used for both lazy val and modules,
and puts the "slow path" code that uses the monitor into a
dedicated method (`moduleName$lzyCompute`). I tracked this
back to a3d4d17b77. I can't tell from that commit whether the
performance sensititivity was related to modules or lazy vals,
from the commit message I'd say the latter.

As the initialization code for a module is just a constructor call,
rather than an arbitraryly large chunk of code for a lazy initializer,
this commit opts to inline the `lzycompute` method.

During refchecks, mixin module accessors are added to classes, so
that mixed in and defined modules are translated uniformly.

Defer synthesis of the double checked locking idiom to the lazyvals
phase, which gets us a step closer to a unified translation of
modules and lazy vals.

I had to change the `atOwner` methods to to avoid using the
non-existent module class of a module accessor method as the
current owner. This fixes a latent bug. Without this change,
retypechecking of the module accessor method during erasure crashes
with an accessibility error selecting the module var.

Review by @adriaanm 

I'll add a results of bytecode diffing to the comments here in a day or so. I need to rig up your ASM utilities to do this cleanly. There will be changes to the names of some synthetic private methods because we used to lambda lift the module and the create the accessor in mixin, whereas now we create the "$lzycompute" method before lambda lift (in lazy vals).

Here's a preview of the changes in trees I'm looking at: https://gist.github.com/retronym/855857c1c1bf9452f1b8
