### PR TITLE
don't claim full JSR-223 compliance

### DIFF
--- a/2.11/index.markdown
+++ b/2.11/index.markdown
@@ -271,3 +271,5 @@ scala> e.eval("1 to n.asInstanceOf[Int] foreach println")
 10
 res4: Object = null
 ```
+
+Note that not all JSR-223 features are supported; see for example [SI-7916](https://issues.scala-lang.org/browse/SI-7916), [SI-8422](https://issues.scala-lang.org/browse/SI-8422).


### PR DESCRIPTION
in response to the discussion at [SI-8422](https://issues.scala-lang.org/browse/SI-8422)
