### PR TITLE
SI-9429 fix filtering in scaladoc after focusing on a package

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.js
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.js
@@ -412,7 +412,17 @@ function textFilter() {
     var query = $("#textfilter input").attr("value") || '';
     var queryRegExp = compilePattern(query);
 
-    if ((typeof textFilter.lastQuery === "undefined") || (textFilter.lastQuery !== query)) {
+    // if we are filtering on types, then we have to display types
+    // ("display packages only" is not possible when filtering)
+    if (query !== "") {
+        kindFilter("all");
+    }
+
+    // Three things trigger a reload of the left pane list:
+    // typeof textFilter.lastQuery === "undefined" <-- first load, there is nothing yet in the left pane
+    // textFilter.lastQuery !== query              <-- the filter text has changed
+    // focusFilterState != null                    <-- a package has been "focused"
+    if ((typeof textFilter.lastQuery === "undefined") || (textFilter.lastQuery !== query) || (focusFilterState != null)) {
 
         textFilter.lastQuery = query;
 


### PR DESCRIPTION
The scaladoc left pane used to be refreshed too often until ce5cfd2
when it was changed to only refresh when the filter changed. This forgot
one important case when it also must be refreshed: when entering the
"focus on a single package" mode (and it has been broken ever since).

This forces a refresh when focusing on a package, and makes sure all
entities are displayed when filtering.
