### PR TITLE
Improve drifted URLs

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
@@ -38,7 +38,7 @@ trait Logic extends Debugging  {
     padded.transpose.map(alignedColumns).transpose map (_.mkString(sep)) mkString(lineSep)
   }
 
-  // http://www.cis.upenn.edu/~cis510/tcl/chap3.pdf
+  // ftp://ftp.cis.upenn.edu/pub/cis511/public_html/Spring04/chap3.pdf
   // http://users.encs.concordia.ca/~ta_ahmed/ms_thesis.pdf
   // propositional logic with constants and equality
   trait PropositionalLogic {

--- a/src/library-aux/scala/Any.scala
+++ b/src/library-aux/scala/Any.scala
@@ -27,7 +27,7 @@ package scala
  *     w.print()
  * }}}
  *
- * See the [[http://docs.scala-lang.org/sips/completed/value-classes.html value classes guide]] for more
+ * See the [[http://docs.scala-lang.org/overviews/core/value-classes.html Value Classes and Universal Traits]] for more
  * details on the interplay of universal traits and value classes.
  */
 abstract class Any {

--- a/src/library/scala/AnyVal.scala
+++ b/src/library/scala/AnyVal.scala
@@ -48,9 +48,7 @@ package scala
  *
  * It's important to note that user-defined value classes are limited, and in some circumstances,
  * still must allocate a value class instance at runtime. These limitations and circumstances are
- * explained in greater detail in the [[http://docs.scala-lang.org/overviews/core/value-classes.html Value Classes Guide]]
- * as well as in [[http://docs.scala-lang.org/sips/completed/value-classes.html SIP-15: Value Classes]],
- * the Scala Improvement Proposal.
+ * explained in greater detail in the [[http://docs.scala-lang.org/overviews/core/value-classes.html Value Classes and Universal Traits]].
  */
 abstract class AnyVal extends Any {
   def getClass(): Class[_ <: AnyVal] = null

--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -168,7 +168,8 @@ object RedBlackTree {
   }
 
   /* Based on Stefan Kahrs' Haskell version of Okasaki's Red&Black Trees
-   * http://www.cse.unsw.edu.au/~dons/data/RedBlackTree.html */
+   * Constructing Red-Black Trees, Ralf Hinze: http://www.cs.ox.ac.uk/ralf.hinze/publications/WAAAPL99b.ps.gz
+   * Red-Black Trees in a Functional Setting, Chris Okasaki: https://wiki.rice.edu/confluence/download/attachments/2761212/Okasaki-Red-Black.pdf */
   private[this] def del[A, B](tree: Tree[A, B], k: A)(implicit ordering: Ordering[A]): Tree[A, B] = if (tree eq null) null else {
     def balance(x: A, xv: B, tl: Tree[A, B], tr: Tree[A, B]) = if (isRedTree(tl)) {
       if (isRedTree(tr)) {

--- a/src/library/scala/sys/process/Process.scala
+++ b/src/library/scala/sys/process/Process.scala
@@ -155,8 +155,8 @@ trait ProcessCreation {
     * import java.net.URL
     * import java.io.File
     *
-    * val spde = new URL("http://technically.us/spde/About")
-    * val dispatch = new URL("http://databinder.net/dispatch/About")
+    * val spde = new URL("http://technically.us/spde.html")
+    * val dispatch = new URL("http://dispatch.databinder.net/Dispatch.html")
     * val build = new File("project/build.properties")
     * cat(spde, dispatch, build) #| "grep -i scala" !
     * }}}

--- a/src/manual/scala/man1/Command.scala
+++ b/src/manual/scala/man1/Command.scala
@@ -42,7 +42,7 @@ trait Command {
   def authors = Section("AUTHOR",
 
     "Written by Martin Odersky and other members of the " &
-    Link("Scala team", "http://www.scala-lang.org/node/89") & ".")
+    Link("Scala team", "http://www.scala-lang.org/news/2014/01/22/10-years-of-scala.html") & ".")
 
   def copyright = Section("COPYRIGHT",
 

--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -343,7 +343,7 @@ private[internal] trait TypeMaps {
     object rawToExistentialInJava extends TypeMap {
       def apply(tp: Type): Type = tp match {
         // any symbol that occurs in a java sig, not just java symbols
-        // see http://lampsvn.epfl.ch/trac/scala/ticket/2454#comment:14
+        // see https://issues.scala-lang.org/browse/SI-2454?focusedCommentId=46618
         case TypeRef(pre, sym, List()) if !sym.typeParams.isEmpty =>
           val eparams = typeParamsToExistentials(sym, sym.typeParams)
           existentialAbstraction(eparams, TypeRef(pre, sym, eparams map (_.tpe)))


### PR DESCRIPTION
:star: Any.scala: Link to the guide instead of the SIP.
:star: AnyVal.scala: Remove SIP link and align guide link to Any.scala.
:star: Commands.scala: Use a less out of date team link.
:star: Logic.scala: Link was broken. Substitute found.
:star: Process.scala: Links were 403 & 404. Fixed as this is a code sample.
:star: TypeMaps.scala: Move old EPFL Trac to JIRA.
:star: RedBlackTree.scala: Replaced broken link with substitutes based on site maintainer input :one:.

:one: When asked where `Data-Set-RBTree.html` had gone Don@UNSW advised

```
 "I think it's on the Haskell wiki now. It was Chris Okazaki's version".
```

The closest I could find to what this document probably was is this paper by Hinze edited by Okasaki,

```
  http://www.cs.ox.ac.uk/ralf.hinze/publications/WAAAPL99b.ps.gz
```

The paper cites the Okasaki document so I included a link to that as well.

The Haskell Wiki does have a link to a RB document but that's broken too,

```
  404: https://wiki.haskell.org/Research_papers/Data_structures > Constructing red-black trees
```

:v:
