### PR TITLE
SI-8778 Treat annotations as interfaces

### DIFF
--- a/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
@@ -751,7 +751,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
       val (statics, body) = typeBody(AT, name)
       val templ = makeTemplate(annotationParents, body)
       addCompanionObject(statics, atPos(pos) {
-        ClassDef(mods | Flags.JAVA_ANNOTATION, name, List(), templ)
+        ClassDef(mods | Flags.JAVA_ANNOTATION | Flags.INTERFACE, name, List(), templ)
       })
     }
 


### PR DESCRIPTION
This makes subclasses "implement" instead of "extend" annotations in
class files, preventing IncompatibleClassChangeErrors.
