### PR TITLE
SI-9369 Fix pattern matcher warnings for diamond shaped inheritance.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -150,7 +150,11 @@ trait TreeAndTypeAnalysis extends Debugging {
                               acc: List[List[Type]]): List[List[Type]] = wl match {
               case hd :: tl =>
                 val children = enumerateChildren(hd)
-                groupChildren(tl ++ children, acc :+ filterChildren(children))
+                // put each trait in a new group, since traits could belong to the same
+                // group as a derived class
+                val (traits, nonTraits) = children.partition(_.isTrait)
+                val filtered = (traits.map(List(_)) ++ List(nonTraits)).map(filterChildren)
+                groupChildren(tl ++ children, acc ++ filtered)
               case Nil      => acc
             }
 

--- a/test/files/pos/t9369.flags
+++ b/test/files/pos/t9369.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -unchecked

--- a/test/files/pos/t9369.scala
+++ b/test/files/pos/t9369.scala
@@ -1,0 +1,24 @@
+object Test {
+
+  trait Tree
+
+  sealed abstract class Prop
+
+  trait Simple extends Prop
+
+  case class Atom(tree: Tree) extends Prop with Simple
+
+  case class Not(prop: Prop) extends Prop with Simple
+
+  def simplify1(prop: Prop): Prop = prop match {
+    case Atom(tree) => ???
+    case Not(prop)  => ???
+    case _          => ???
+  }
+
+  def simplify2(prop: Prop): Prop = prop match {
+    case Not(Atom(tree)) => ???
+    case Not(Not(prop))  => ???
+    case _               => ???
+  }
+}


### PR DESCRIPTION
A previous optimization (d44a86f432a7f9ca250b014acdeab02ac9f2c304) for
pattern matcher exhaustivity checks used a smarter encoding to ensure
that the scrutinee can be equal to one child only.
However, in case of traits between the root and leave type, a child can
be of several types and these types should not be in a mutually exclusive
group.

I realized that my previous approach was just too complicated, a simple
solution that was suggested by @retronym is good enough.
I wouldn't expect users to write big class hierarchies with many traits in it -
usually there are a few traits and potentially many classes involved, so
simply putting each trait in a new group ensures that no class can be in the
same group as a base trait.

Review by @retronym  
