### PR TITLE
Compiler classpath : add file entries of URLClassLoader if available

### DIFF
--- a/src/compiler/scala/tools/nsc/classpath/ClassPathFactory.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ClassPathFactory.scala
@@ -42,6 +42,10 @@ trait ClassPathFactory[T] {
 
   def classesInPath(path: String) = classesInPathImpl(path, expand = false)
 
+  def classesInURLs(useURLClassPath: Boolean) =
+    if (useURLClassPath) ClassPath.urls.map(url => newClassPath(AbstractFile.getDirectory(url.getPath)))
+    else Nil
+
   def classesInManifest(useManifestClassPath: Boolean) =
     if (useManifestClassPath) ClassPath.manifests.map(url => newClassPath(AbstractFile getResources url))
     else Nil

--- a/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
@@ -44,6 +44,7 @@ trait StandardScalaSettings {
   val uniqid =         BooleanSetting ("-uniqid", "Uniquely tag all identifiers in debugging output.")
   val usejavacp =      BooleanSetting ("-usejavacp", "Utilize the java.class.path in classpath resolution.")
   val usemanifestcp =  BooleanSetting ("-usemanifestcp", "Utilize the manifest in classpath resolution.")
+  val useurlcp =       BooleanSetting ("-useurlcp", "Utilize URLClassLoader in classpath resolution.")
   val verbose =        BooleanSetting ("-verbose", "Output messages about what the compiler is doing.")
   val version =        BooleanSetting ("-version", "Print product version and exit.")
 }

--- a/src/compiler/scala/tools/nsc/util/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/util/ClassPath.scala
@@ -121,7 +121,7 @@ object ClassPath {
       if (cl == null) acc.reverse else getClassPath(cl.getParent, cp :: acc)
     }
 
-    val classPath = getClassPath(this.getClass.getClassLoader)
+    val classPath = getClassPath(Thread.currentThread().getContextClassLoader)
     val currentClassPath = classPath.head
 
     currentClassPath ::: (if (currentClassPath.size == 1 && currentClassPath(0).getPath.endsWith(".jar")) {

--- a/src/compiler/scala/tools/nsc/util/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/util/ClassPath.scala
@@ -9,7 +9,7 @@ package util
 
 import io.{ AbstractFile, Directory, File, Jar }
 import java.net.MalformedURLException
-import java.net.URL
+import java.net.{URL, URLClassLoader}
 import java.util.regex.PatternSyntaxException
 import scala.collection.{ mutable, immutable }
 import scala.reflect.internal.util.StringOps.splitWhere
@@ -112,7 +112,26 @@ object ClassPath {
         new SourcePath[T](dir, this)
   }
 
-  def manifests: List[java.net.URL] = {
+  def urls: List[URL] = {
+    def getClassPath(cl: ClassLoader, acc: List[List[URL]] = List.empty): List[List[URL]] = {
+      val cp = cl match {
+        case urlClassLoader: URLClassLoader => urlClassLoader.getURLs.filter(_.getProtocol == "file").toList
+        case _ => Nil
+      }
+      if (cl == null) acc.reverse else getClassPath(cl.getParent, cp :: acc)
+    }
+
+    val classPath = getClassPath(this.getClass.getClassLoader)
+    val currentClassPath = classPath.head
+
+    currentClassPath ::: (if (currentClassPath.size == 1 && currentClassPath(0).getPath.endsWith(".jar")) {
+      expandManifestPath(currentClassPath(0).getPath)
+    } else {
+      Nil
+    }) ::: classPath.tail.flatten
+  }
+
+  def manifests: List[URL] = {
     import scala.collection.convert.WrapAsScala.enumerationAsScalaIterator
     Thread.currentThread().getContextClassLoader()
       .getResources("META-INF/MANIFEST.MF")

--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -67,6 +67,7 @@ object PathResolver {
     /** The java classpath and whether to use it. */
     def javaUserClassPath   = propOrElse("java.class.path", "")
     def useJavaClassPath    = propOrFalse("scala.usejavacp")
+    def useURLClassPath     = propOrFalse("scala.useurlcp")
 
     override def toString = s"""
       |object Environment {
@@ -87,6 +88,7 @@ object PathResolver {
     def javaUserClassPath = Environment.javaUserClassPath
     def javaExtDirs       = Environment.javaExtDirs
     def useJavaClassPath  = Environment.useJavaClassPath
+    def useURLClassPath   = Environment.useURLClassPath
 
     def scalaHome         = Environment.scalaHome
     def scalaHomeDir      = Directory(scalaHome)
@@ -238,6 +240,7 @@ abstract class PathResolverBase[BaseClassPathType <: ClassFileLookup[AbstractFil
     def scalaHome           = Defaults.scalaHome
     def useJavaClassPath    = settings.usejavacp.value || Defaults.useJavaClassPath
     def useManifestClassPath= settings.usemanifestcp.value
+    def useURLClassPath     = settings.useurlcp.value || Defaults.useURLClassPath
     def javaBootClassPath   = cmdLineOrElse("javabootclasspath", Defaults.javaBootClassPath)
     def javaExtDirs         = cmdLineOrElse("javaextdirs", Defaults.javaExtDirs)
     def javaUserClassPath   = if (useJavaClassPath) Defaults.javaUserClassPath else ""
@@ -276,6 +279,7 @@ abstract class PathResolverBase[BaseClassPathType <: ClassFileLookup[AbstractFil
       classesInPath(scalaBootClassPath),            // 4. The Scala boot class path.
       contentsOfDirsInPath(scalaExtDirs),           // 5. The Scala extension class path.
       classesInExpandedPath(userClassPath),         // 6. The Scala application class path.
+      classesInURLs(useURLClassPath),               // 9. The URL class path.
       classesInManifest(useManifestClassPath),      // 8. The Manifest class path.
       sourcesInPath(sourcePath)                     // 7. The Scala source path.
     )

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -1305,6 +1305,7 @@ object IMain {
     def getScriptEngine: ScriptEngine = {
       val settings = new Settings()
       settings.usemanifestcp.value = true
+      settings.embeddedDefaults(Thread.currentThread().getContextClassLoader)
       new IMain(this, settings)
     }
   }

--- a/test/files/run/t6393/A.scala
+++ b/test/files/run/t6393/A.scala
@@ -1,0 +1,6 @@
+package p1 {
+  package p2 {
+    class A
+    object A
+  }
+}

--- a/test/files/run/t6393/Test.scala
+++ b/test/files/run/t6393/Test.scala
@@ -1,0 +1,13 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    import scala.tools.reflect.ToolBox
+    val m = scala.reflect.runtime.currentMirror
+    val u = m.universe
+    import u._
+    val tb = m.mkToolBox(options = "-useurlcp")
+
+    { import p1.p2; new p2.A }
+    tb.eval(q"import p1.p2; new p2.A")
+    tb.eval(q"List(1, 2, 3)")
+  }
+}


### PR DESCRIPTION
This is a follow-up to https://github.com/scala/scala/pull/4456 . In order to inform the classpath of the compiler, when run from an application such as a script engine or a reflection toolbox, we look for URLClassLoaderS in the classloader hierarchy. Then we collect all "file" entries of said classloaders and we add them to the compiler's classpath. Both a system property and a command line parameter are provided to enable the mechanism.
