### PR TITLE
Restore missing element type to List class documentation

### DIFF
--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -16,7 +16,7 @@ import scala.annotation.tailrec
 import java.io._
 
 /** A class for immutable linked lists representing ordered collections
- *  of elements of type.
+ *  of elements of type `A`.
  *
  *  This class comes with two implementing case classes `scala.Nil`
  *  and `scala.::` that implement the abstract members `isEmpty`,


### PR DESCRIPTION
See line 18,

```
 git show cb1c0c src/library/scala/collection/immutable/List.scala|head -20|cat -n
```

This shows the type reference prior to removal.
