### PR TITLE
fix tests which failed on Windows because \r\n vs \n

### DIFF
--- a/src/reflect/scala/reflect/internal/util/StripMarginInterpolator.scala
+++ b/src/reflect/scala/reflect/internal/util/StripMarginInterpolator.scala
@@ -16,6 +16,10 @@ trait StripMarginInterpolator {
    * String escape sequences are '''not''' processed; this interpolator is designed to
    * be used with triple quoted Strings.
    *
+   * Triple quotes preserve platform-specific line endings (see SI-3101), which is
+   * a frequent source of test failures on Windows, so we also normalize to Unix
+   * line endings.
+   *
    * {{{
    * scala> val foo = "f|o|o"
    * foo: String = f|o|o
@@ -37,5 +41,6 @@ trait StripMarginInterpolator {
       case Nil => Nil
     }
     new StringContext(stripped: _*).raw(args: _*)
+      .replaceAll("\r\n", "\n")
   }
 }

--- a/test/junit/scala/io/SourceTest.scala
+++ b/test/junit/scala/io/SourceTest.scala
@@ -1,4 +1,3 @@
-
 package scala.io
 
 import org.junit.Test
@@ -21,7 +20,7 @@ class SourceTest {
     |readily interchangeable in general, because the
     |laws of arithmetic send signals leftward from
     |the bits that are "least significant."
-    |""".stripMargin.trim
+    |""".stripMargin.trim.replaceAll("\r\n", "\n")  // SI-3101
 
   private def in = new ByteArrayInputStream(sampler.getBytes)
 

--- a/test/junit/scala/reflect/internal/PrintersTest.scala
+++ b/test/junit/scala/reflect/internal/PrintersTest.scala
@@ -3,6 +3,7 @@ package scala.reflect.internal
 import org.junit.Test
 import org.junit.Assert._
 import scala.tools.reflect._
+import scala.reflect.internal.util.StringContextStripMarginOps
 import scala.reflect.runtime.universe._
 import scala.reflect.runtime.{currentMirror=>cm}
 import org.junit.runner.RunWith
@@ -68,7 +69,6 @@ object PrinterHelper {
     else assertResultCode(source)(parsedCode = source, wrap = wrapCode)
   }
 
-  implicit class StrContextStripMarginOps(val stringContext: StringContext) extends util.StripMarginInterpolator
 }
 
 import PrinterHelper._

--- a/test/junit/scala/tools/nsc/backend/jvm/analysis/NullnessAnalyzerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/analysis/NullnessAnalyzerTest.scala
@@ -71,12 +71,12 @@ class NullnessAnalyzerTest extends ClearAfterClass {
     // So in the frame for `ALOAD 0`, the stack is still empty.
 
     val res =
-      """                                                          L0: 0:  NotNull
-        |                                             LINENUMBER 1 L0: 0:  NotNull
-        |                                                     ALOAD 0: 0:  NotNull
-        |INVOKEVIRTUAL java/lang/Object.toString ()Ljava/lang/String;: 0:  NotNull, 1:  NotNull
-        |                                                     ARETURN: 0:  NotNull, 1: Unknown1
-        |                                                          L0: null""".stripMargin
+      sm"""                                                          L0: 0:  NotNull
+          |                                             LINENUMBER 1 L0: 0:  NotNull
+          |                                                     ALOAD 0: 0:  NotNull
+          |INVOKEVIRTUAL java/lang/Object.toString ()Ljava/lang/String;: 0:  NotNull, 1:  NotNull
+          |                                                     ARETURN: 0:  NotNull, 1: Unknown1
+          |                                                          L0: null"""
     assertEquals(showAllNullnessFrames(newNullnessAnalyzer(m), m), res)
   }
 
@@ -217,4 +217,7 @@ class NullnessAnalyzerTest extends ClearAfterClass {
       (trim, 3, NotNull)  // receiver at `trim`
     )) testNullness(a, m, insn, index, nullness)
   }
+
+  // add "sm" interpolator
+  implicit class StrContextStripMarginOps(val stringContext: StringContext) extends scala.reflect.internal.util.StripMarginInterpolator
 }

--- a/test/junit/scala/tools/nsc/backend/jvm/analysis/NullnessAnalyzerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/analysis/NullnessAnalyzerTest.scala
@@ -16,6 +16,7 @@ import ASMConverters._
 import scala.tools.testing.ClearAfterClass
 import scala.tools.nsc.backend.jvm.opt.BytecodeUtils._
 import AsmUtils._
+import scala.reflect.internal.util.StringContextStripMarginOps
 
 import scala.collection.convert.decorateAsScala._
 
@@ -218,6 +219,4 @@ class NullnessAnalyzerTest extends ClearAfterClass {
     )) testNullness(a, m, insn, index, nullness)
   }
 
-  // add "sm" interpolator
-  implicit class StrContextStripMarginOps(val stringContext: StringContext) extends scala.reflect.internal.util.StripMarginInterpolator
 }

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineWarningTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineWarningTest.scala
@@ -27,6 +27,7 @@ import BackendReporting._
 
 import scala.collection.convert.decorateAsScala._
 import scala.tools.testing.ClearAfterClass
+import scala.reflect.internal.util.StringContextStripMarginOps
 
 object InlineWarningTest extends ClearAfterClass.Clearable {
   val argsNoWarn = "-Ybackend:GenBCode -Yopt:l:classpath"
@@ -192,7 +193,4 @@ class InlineWarningTest extends ClearAfterClass {
     assert(c == 1, c)
   }
 
-  // add "sm" interpolator
-  implicit class StrContextStripMarginOps(val stringContext: StringContext)
-      extends scala.reflect.internal.util.StripMarginInterpolator
 }

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineWarningTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineWarningTest.scala
@@ -80,9 +80,9 @@ class InlineWarningTest extends ClearAfterClass {
     }
 
     val warn =
-      """T::f()I is annotated @inline but cannot be inlined: the trait method call could not be rewritten to the static implementation method. Possible reason:
-        |The method f(LT;)I could not be found in the class T$class or any of its parents.
-        |Note that the following parent classes could not be found on the classpath: T$class""".stripMargin
+      sm"""T::f()I is annotated @inline but cannot be inlined: the trait method call could not be rewritten to the static implementation method. Possible reason:
+          |The method f(LT;)I could not be found in the class T$$class or any of its parents.
+          |Note that the following parent classes could not be found on the classpath: T$$class"""
 
     var c = 0
     compileSeparately(List(codeA, codeB), extraArgs = InlineWarningTest.args, afterEach = removeImpl, allowMessage = i => {c += 1; i.msg contains warn})
@@ -123,14 +123,14 @@ class InlineWarningTest extends ClearAfterClass {
       """.stripMargin
 
     val warns = List(
-      """failed to determine if bar should be inlined:
-        |The method bar()I could not be found in the class A or any of its parents.
-        |Note that the following parent classes are defined in Java sources (mixed compilation), no bytecode is available: A""".stripMargin,
+      sm"""failed to determine if bar should be inlined:
+          |The method bar()I could not be found in the class A or any of its parents.
+          |Note that the following parent classes are defined in Java sources (mixed compilation), no bytecode is available: A""",
 
-      """B::flop()I is annotated @inline but could not be inlined:
-        |Failed to check if B::flop()I can be safely inlined to B without causing an IllegalAccessError. Checking instruction INVOKESTATIC A.bar ()I failed:
-        |The method bar()I could not be found in the class A or any of its parents.
-        |Note that the following parent classes are defined in Java sources (mixed compilation), no bytecode is available: A""".stripMargin)
+      sm"""B::flop()I is annotated @inline but could not be inlined:
+          |Failed to check if B::flop()I can be safely inlined to B without causing an IllegalAccessError. Checking instruction INVOKESTATIC A.bar ()I failed:
+          |The method bar()I could not be found in the class A or any of its parents.
+          |Note that the following parent classes are defined in Java sources (mixed compilation), no bytecode is available: A""")
 
     var c = 0
     val List(b) = compile(scalaCode, List((javaCode, "A.java")), allowMessage = i => {c += 1; warns.tail.exists(i.msg contains _)})
@@ -162,9 +162,9 @@ class InlineWarningTest extends ClearAfterClass {
       """.stripMargin
 
     val warn =
-      """M::f()I is annotated @inline but could not be inlined:
-        |The callee M::f()I contains the instruction INVOKESPECIAL M.nested$1 ()I
-        |that would cause an IllegalAccessError when inlined into class N""".stripMargin
+      sm"""M::f()I is annotated @inline but could not be inlined:
+          |The callee M::f()I contains the instruction INVOKESPECIAL M.nested$$1 ()I
+          |that would cause an IllegalAccessError when inlined into class N"""
 
     var c = 0
     compile(code, allowMessage = i => { c += 1; i.msg contains warn })
@@ -183,12 +183,16 @@ class InlineWarningTest extends ClearAfterClass {
       """.stripMargin
 
     val warn =
-      """C::f()I is annotated @inline but could not be inlined:
-        |The callsite method C::t2()I
-        |does not have the same strictfp mode as the callee C::f()I.""".stripMargin
+      sm"""C::f()I is annotated @inline but could not be inlined:
+          |The callsite method C::t2()I
+          |does not have the same strictfp mode as the callee C::f()I."""
 
     var c = 0
     compile(code, allowMessage = i => { c += 1; i.msg contains warn })
     assert(c == 1, c)
   }
+
+  // add "sm" interpolator
+  implicit class StrContextStripMarginOps(val stringContext: StringContext)
+      extends scala.reflect.internal.util.StripMarginInterpolator
 }

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
@@ -29,6 +29,7 @@ import scala.collection.convert.decorateAsScala._
 import scala.tools.testing.ClearAfterClass
 
 object InlinerTest extends ClearAfterClass.Clearable {
+
   val args = "-Ybackend:GenBCode -Yopt:l:classpath -Yopt-warnings"
   var compiler = newCompiler(extraArgs = args)
 
@@ -462,10 +463,10 @@ class InlinerTest extends ClearAfterClass {
       """.stripMargin
 
     val warn =
-      """B::flop()I is annotated @inline but could not be inlined:
-        |Failed to check if B::flop()I can be safely inlined to B without causing an IllegalAccessError. Checking instruction INVOKESTATIC A.bar ()I failed:
-        |The method bar()I could not be found in the class A or any of its parents.
-        |Note that the following parent classes are defined in Java sources (mixed compilation), no bytecode is available: A""".stripMargin
+      sm"""B::flop()I is annotated @inline but could not be inlined:
+          |Failed to check if B::flop()I can be safely inlined to B without causing an IllegalAccessError. Checking instruction INVOKESTATIC A.bar ()I failed:
+          |The method bar()I could not be found in the class A or any of its parents.
+          |Note that the following parent classes are defined in Java sources (mixed compilation), no bytecode is available: A"""
 
     var c = 0
     val List(b) = compile(scalaCode, List((javaCode, "A.java")), allowMessage = i => {c += 1; i.msg contains warn})
@@ -890,9 +891,9 @@ class InlinerTest extends ClearAfterClass {
     // is still necessary, otherwise this test crashes.
     // The warning below is the typical warning we get in mixed compilation.
     val warn =
-      """failed to determine if <init> should be inlined:
-        |The method <init>()V could not be found in the class A$Inner or any of its parents.
-        |Note that the following parent classes could not be found on the classpath: A$Inner""".stripMargin
+      sm"""failed to determine if <init> should be inlined:
+          |The method <init>()V could not be found in the class A$$Inner or any of its parents.
+          |Note that the following parent classes could not be found on the classpath: A$$Inner"""
 
     var c = 0
 
@@ -933,9 +934,9 @@ class InlinerTest extends ClearAfterClass {
       """.stripMargin
 
     val warn =
-      """B::f1()I is annotated @inline but could not be inlined:
-        |The callee B::f1()I contains the instruction INVOKESPECIAL Aa.f1 ()I
-        |that would cause an IllegalAccessError when inlined into class T.""".stripMargin
+      sm"""B::f1()I is annotated @inline but could not be inlined:
+          |The callee B::f1()I contains the instruction INVOKESPECIAL Aa.f1 ()I
+          |that would cause an IllegalAccessError when inlined into class T."""
     var c = 0
     val List(a, b, t) = compile(code, allowMessage = i => {c += 1; i.msg contains warn})
     assert(c == 1, c)
@@ -977,7 +978,7 @@ class InlinerTest extends ClearAfterClass {
   }
 
   @Test
-  def noRedunantNullChecks(): Unit = {
+  def noRedundantNullChecks(): Unit = {
     val code =
       """class C {
         |  @inline final def f: String = "hai!"
@@ -991,4 +992,8 @@ class InlinerTest extends ClearAfterClass {
     assert(2 == t.collect({case Ldc(_, "hai!") => }).size)     // twice the body of f
     assert(1 == t.collect({case Jump(IFNONNULL, _) => }).size) // one single null check
   }
+
+  // add "sm" interpolator
+  implicit class StrContextStripMarginOps(val stringContext: StringContext)
+      extends scala.reflect.internal.util.StripMarginInterpolator
 }

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
@@ -27,6 +27,7 @@ import BackendReporting._
 
 import scala.collection.convert.decorateAsScala._
 import scala.tools.testing.ClearAfterClass
+import scala.reflect.internal.util.StringContextStripMarginOps
 
 object InlinerTest extends ClearAfterClass.Clearable {
 
@@ -993,7 +994,4 @@ class InlinerTest extends ClearAfterClass {
     assert(1 == t.collect({case Jump(IFNONNULL, _) => }).size) // one single null check
   }
 
-  // add "sm" interpolator
-  implicit class StrContextStripMarginOps(val stringContext: StringContext)
-      extends scala.reflect.internal.util.StripMarginInterpolator
 }


### PR DESCRIPTION
with these changes, all of our JUnit tests are passing again on Windows.
(I'll deal with partest failures, if there any, in a separate PR.)

review by @retronym (thx for the string interpolator!)
