### PR TITLE
Abort Ant build if Ant version is <1.9

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -506,6 +506,11 @@ TODO:
     </condition>
 
     <fail if="has.unsupported.jdk" message="JDK ${ant.java.version} is not supported by this build!"/>
+    <fail message="Ant 1.9+ required">
+      <condition>
+        <not><antversion atleast="1.9" /></not>
+      </condition>
+    </fail>
 
     <!-- Allow this to be overridden simply -->
     <property name="sbt.latest.version"    value="0.12.4"/>


### PR DESCRIPTION
Older Ant versions are not able to compiler Java8 sources

Review by @lrytz 
