### PR TITLE
SI-9475 Dependent PolyTypes are dependent types

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2510,6 +2510,9 @@ trait Types
     override def baseType(clazz: Symbol): Type = resultType.baseType(clazz)
     override def narrow: Type = resultType.narrow
 
+    // SI-9475: PolyTypes with dependent method types are still dependent
+    override def isDependentMethodType = resultType.isDependentMethodType
+
     /** @M: typeDefSig wraps a TypeBounds in a PolyType
      *  to represent a higher-kinded type parameter
      *  wrap lo&hi in polytypes to bind variables

--- a/test/files/pos/t9475.scala
+++ b/test/files/pos/t9475.scala
@@ -1,0 +1,19 @@
+trait Ctx {
+  trait Tree
+}
+
+trait Lst[+A] {
+  def zip[A1 >: A, B](that: Lst[B]): Nothing
+}
+
+object Test {
+
+  // both of these methods should be transformed by uncurry
+  // such that List[c.Tree] becomes List[Ctx#Tree]:
+  def foo1(c: Ctx)(l: Lst[c.Tree]) = l zip l
+  def foo2[@specialized T](c: Ctx)(l: Lst[c.Tree], t: T) = l zip l
+
+  // if this doesn't happen for the 2nd method, the specialization
+  // transformation fails
+}
+


### PR DESCRIPTION
Such that uncurry can correctly un-dependify them.
