### PR TITLE
SI-9480 Fix NPE in PagedSeq.slice at end of seq

### DIFF
--- a/src/library/scala/collection/immutable/PagedSeq.scala
+++ b/src/library/scala/collection/immutable/PagedSeq.scala
@@ -190,8 +190,8 @@ extends scala.collection.AbstractSeq[T]
     val e = if (_end == UndeterminedEnd) _end else start + _end
     var f = first1
     while (f.end <= s && !f.isLast) {
-      if (f.next eq null) f.addMore(more)
-      f = f.next
+      if (f.next eq null) f = f.addMore(more)
+      else f = f.next
     }
     // Warning -- not refining `more` means that slices can freely request and obtain
     // data outside of their slice.  This is part of the design of PagedSeq

--- a/test/junit/scala/collection/immutable/PagedSeqTest.scala
+++ b/test/junit/scala/collection/immutable/PagedSeqTest.scala
@@ -13,6 +13,12 @@ class PagedSeqTest {
     assertEquals(Seq('a'), PagedSeq.fromStrings(List.fill(5000)("a")).slice(4096, 4097))
   }
 
+  // should not NPE, and should be empty
+  @Test
+  def test_SI9480(): Unit = {
+    assertEquals(Seq(), PagedSeq.fromStrings(List("a")).slice(1))
+  }
+
   // Slices shouldn't read outside where they belong
   @Test
   def test_SI6519 {


### PR DESCRIPTION
Basically the same thing as SI-6615, including the fact everything works okay 
if the PagedSeq is printed before calling slice.

It might seem strange that this allows taking slices that start beyond the 
end, but
- this was possible anyway if one forced the entire sequence, and
- it is reasonable to be able to take a slice at the very end (not beyond it)
  and get an empty sequence, which is exactly what StreamReader in
  scala-parser-combinators does and gets an NPE.
