### PR TITLE
use latest partest (1.0.9)

### DIFF
--- a/src/eclipse/partest/.classpath
+++ b/src/eclipse/partest/.classpath
@@ -5,7 +5,7 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/repl"/>
 	<classpathentry kind="var" path="M2_REPO/com/googlecode/java-diff-utils/diffutils/1.3.0/diffutils-1.3.0.jar"/>
 	<classpathentry kind="var" path="M2_REPO/org/scala-sbt/test-interface/1.0/test-interface-1.0.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/scala-lang/modules/scala-partest_2.11/1.0.7/scala-partest_2.11-1.0.7.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/scala-lang/modules/scala-partest_2.11/1.0.9/scala-partest_2.11-1.0.9.jar"/>
 	<classpathentry kind="var" path="SCALA_BASEDIR/lib/ant/ant.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scala-compiler"/>

--- a/versions.properties
+++ b/versions.properties
@@ -36,7 +36,7 @@ jline.version=2.12.1
 scala-asm.version=5.0.4-scala-3
 
 # external modules, used internally (not shipped)
-partest.version.number=1.0.7
+partest.version.number=1.0.9
 scalacheck.version.number=1.11.6
 
 # TODO: modularize the compiler


### PR DESCRIPTION
the new version should be no different, from this repo's perspective,
since the changes made between 1.0.7 and 1.0.9 had only to do with
build and packaging.  nonetheless, we should be using the latest
latest to help guard against regressions.

(my other motive is that I'm contemplating fixing a partest issue
that would result in a 1.0.10 release, so I'd like to have the
upgrade to 1.0.9 in place first, so if anything goes wrong there
is less searching to do for the cause)

review by @adriaanm
