### PR TITLE
fix t9370 so it works on Windows too

### DIFF
--- a/test/files/pos/t9370/sample_2.flags
+++ b/test/files/pos/t9370/sample_2.flags
@@ -1,1 +1,1 @@
--Xplugin:/tmp:. -Xplugin-require:timebomb -Ystop-after:parser
+-Xplugin:/tmp -Xplugin:. -Xplugin-require:timebomb -Ystop-after:parser


### PR DESCRIPTION
partest has custom code for -Xplugin handling (see
DirectCompiler.updatePluginPath for details).  that code has its own
idea of what the syntax of -Xplugin is, different from Scalac's.
partest's idea is that multiple paths should be separated by the
platform classpath separator character, so : on Unix and ; on Windows.
the .flags file here was using a colon, and that confuses partest on
Windows, since partest was expecting a semicolon.

it might be nice to fix partest to accept comma as the separator
instead, which is standard for a scalac MultiStringSetting such
as -Xplugin.  but it turns out we have an out: we can just provide
multiple -Xplugin flags.

what evidence do I have that this is the right change?
- the test still passes on both Windows and Mac OS X (manually
  tested); if Travis likes it, we'll know it passes on Linux too
- I tried reverting Som's fix for SI-9370 (c32ba93) and the test failed,
  as expected, both with and without my change
- I added a bunch of debugging output to
  DirectCompiler.updatePluginPath in partest, built a new partest jar,
  and used it to run the test on Windows with and without my fix, and
  verified by eye that the logic there was operating as expected in
  both cases

and in conclusion, for Som's benefit: <insert cryptic joke here>
