### PR TITLE
SI-9479 Fix regression w. inherited overloads in package object

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -957,7 +957,7 @@ trait Contexts { self: Analyzer =>
     private def importedAccessibleSymbol(imp: ImportInfo, name: Name, requireExplicit: Boolean, record: Boolean): Symbol =
       imp.importedSymbol(name, requireExplicit, record) filter (s => isAccessible(s, imp.qual.tpe, superAccess = false))
 
-    private def requiresQualifier(s: Symbol) = (
+    private def requiresQualifier(s: Symbol): Boolean = (
          s.owner.isClass
       && !s.owner.isPackageClass
       && !s.isTypeParameterOrSkolem
@@ -967,8 +967,10 @@ trait Contexts { self: Analyzer =>
     /** Must `sym` defined in package object of package `pkg`, if
      *  it selected from a prefix with `pkg` as its type symbol?
      */
-    def isInPackageObject(sym: Symbol, pkg: Symbol): Boolean =
-      pkg.isPackage && sym.owner != pkg && requiresQualifier(sym)
+    def isInPackageObject(sym: Symbol, pkg: Symbol): Boolean = {
+      if (sym.isOverloaded) sym.alternatives.exists(alt => isInPackageObject(alt, pkg))
+      else pkg.isPackage && sym.owner != pkg && requiresQualifier(sym)
+    }
 
     def isNameInScope(name: Name) = lookupSymbol(name, _ => true).isSuccess
 

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -544,7 +544,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           tree match {
             case Ident(_) =>
               val packageObject =
-                if (sym.owner.isModuleClass) sym.owner.sourceModule // historical optimization, perhaps no longer needed
+                if (!sym.isOverloaded && sym.owner.isModuleClass) sym.owner.sourceModule // historical optimization, perhaps no longer needed
                 else pre.typeSymbol.packageObject
               Ident(packageObject)
             case Select(qual, _) => Select(qual, nme.PACKAGEkw)

--- a/test/files/pos/t9479.scala
+++ b/test/files/pos/t9479.scala
@@ -1,0 +1,15 @@
+trait Predefs {
+  def bridge(p: String): Unit = ???
+  def bridge(p: Any): Unit = ???
+}
+
+package object molecule extends Predefs
+
+package molecule {
+  package process {
+    class Test {
+      def main(): Unit = bridge(null, null)
+    }
+  }
+}
+

--- a/test/files/pos/t9479b.scala
+++ b/test/files/pos/t9479b.scala
@@ -1,0 +1,15 @@
+trait Predefs {
+  def bridge(p: String): Unit = ???
+  def bridge(p: Any): Unit = ???
+}
+
+package object molecule extends Predefs
+
+package molecule {
+  package process {
+    class Test {
+      def main(): Unit = molecule.bridge(null, null)
+    }
+  }
+}
+


### PR DESCRIPTION
One shouldn't base any decisions of the owner of an overloaded
symbol. Instead, the owner of each of the alternatives should
be considered.

This gotcha is super easy to forget, as I did with my change to
simplify the way we detect whether we need to add the `.package`
prefix to a tree.

Review by @lrytz 
