### PR TITLE
bump required Ant version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ scala/
 
 ## Requirements
 
-You'll need a Java SDK (6 or newer), Apache Ant (version 1.8.0 or above), and curl (for `./pull-binary-libs.sh`).
+You'll need a Java SDK (6 or newer), Apache Ant (version 1.9.0 or above), and curl (for `./pull-binary-libs.sh`).
 
 ## Git Hygiene
 


### PR DESCRIPTION
(a little missing piece of https://github.com/scala/scala/pull/4746
we missed at review time)
