### PR TITLE
2.11.x collection documentation fixes

### DIFF
--- a/src/library/scala/collection/GenTraversableLike.scala
+++ b/src/library/scala/collection/GenTraversableLike.scala
@@ -158,18 +158,6 @@ trait GenTraversableLike[+A, +Repr] extends Any with GenTraversableOnce[A] with 
   @migration("The behavior of `scanRight` has changed. The previous behavior can be reproduced with scanRight.reverse.", "2.9.0")
   def scanRight[B, That](z: B)(op: (A, B) => B)(implicit bf: CanBuildFrom[Repr, B, That]): That
 
-  /** Applies a function `f` to all elements of this $coll.
-   *
-   *  @param  f   the function that is applied for its side-effect to every element.
-   *              The result of function `f` is discarded.
-   *
-   *  @tparam  U  the type parameter describing the result of function `f`.
-   *              This result will always be ignored. Typically `U` is `Unit`,
-   *              but this is not necessary.
-   *
-   *  @usecase def foreach(f: A => Unit): Unit
-   *    @inheritdoc
-   */
   def foreach[U](f: A => U): Unit
 
   /** Builds a new collection by applying a function to all elements of this $coll.

--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -340,14 +340,6 @@ trait TraversableLike[+A, +Repr] extends Any
     b.result
   }
 
-  /** Tests whether a predicate holds for all elements of this $coll.
-   *
-   *  $mayNotTerminateInf
-   *
-   *  @param   p     the predicate used to test elements.
-   *  @return        `true`  if this $coll is empty, otherwise `true` if the given predicate `p`
-    *                holds for all elements of this $coll, otherwise `false`.
-   */
   def forall(p: A => Boolean): Boolean = {
     var result = true
     breakable {
@@ -374,15 +366,6 @@ trait TraversableLike[+A, +Repr] extends Any
     result
   }
 
-  /** Finds the first element of the $coll satisfying a predicate, if any.
-   *
-   *  $mayNotTerminateInf
-   *  $orderDependent
-   *
-   *  @param p    the predicate used to test elements.
-   *  @return     an option value containing the first element in the $coll
-   *              that satisfies `p`, or `None` if none exists.
-   */
   def find(p: A => Boolean): Option[A] = {
     var result: Option[A] = None
     breakable {
@@ -594,23 +577,6 @@ trait TraversableLike[+A, +Repr] extends Any
    */
   def inits: Iterator[Repr] = iterateUntilEmpty(_.init)
 
-  /** Copies elements of this $coll to an array.
-   *  Fills the given array `xs` with at most `len` elements of
-   *  this $coll, starting at position `start`.
-   *  Copying will stop once either the end of the current $coll is reached,
-   *  or the end of the array is reached, or `len` elements have been copied.
-   *
-   *  @param  xs     the array to fill.
-   *  @param  start  the starting index.
-   *  @param  len    the maximal number of elements to copy.
-   *  @tparam B      the type of the elements of the array.
-   *
-   *
-   *  @usecase def copyToArray(xs: Array[A], start: Int, len: Int): Unit
-   *    @inheritdoc
-   *
-   *    $willNotTerminateInf
-   */
   def copyToArray[B >: A](xs: Array[B], start: Int, len: Int) {
     var i = start
     val end = (start + len) min xs.length
@@ -625,7 +591,7 @@ trait TraversableLike[+A, +Repr] extends Any
 
   @deprecatedOverriding("Enforce contract of toTraversable that if it is Traversable it returns itself.", "2.11.0")
   def toTraversable: Traversable[A] = thisCollection
-  
+
   def toIterator: Iterator[A] = toStream.iterator
   def toStream: Stream[A] = toBuffer.toStream
   // Override to provide size hint.

--- a/src/library/scala/collection/package.scala
+++ b/src/library/scala/collection/package.scala
@@ -13,8 +13,11 @@ package scala
  *
  * == Guide ==
  *
- * A detailed guide for the collections library is available
+ * A detailed guide for using the collections library is available
  * at [[http://docs.scala-lang.org/overviews/collections/introduction.html]].
+ * Developers looking to extend the collections library can find a description
+ * of its architecture at
+ * [[http://docs.scala-lang.org/overviews/core/architecture-of-scala-collections.html]].
  *
  * == Using Collections ==
  *
@@ -31,24 +34,25 @@ package scala
  * array: Array[Int] = Array(1, 2, 3, 4, 5, 6)
  *
  * scala> array map { _.toString }
- * res0: Array[java.lang.String] = Array(1, 2, 3, 4, 5, 6)
+ * res0: Array[String] = Array(1, 2, 3, 4, 5, 6)
  *
  * scala> val list = List(1,2,3,4,5,6)
  * list: List[Int] = List(1, 2, 3, 4, 5, 6)
  *
  * scala> list map { _.toString }
- * res1: List[java.lang.String] = List(1, 2, 3, 4, 5, 6)
+ * res1: List[String] = List(1, 2, 3, 4, 5, 6)
  *
  * }}}
  *
  * == Creating Collections ==
  *
- * The most common way to create a collection is to use the companion objects as factories.
- * Of these, the three most common
- * are [[scala.collection.Seq]], [[scala.collection.immutable.Set]], and [[scala.collection.immutable.Map]].  Their
- * companion objects are all available
- * as type aliases the either the [[scala]] package or in `scala.Predef`, and can be used
- * like so:
+ * The most common way to create a collection is to use its companion object as
+ * a factory. The three most commonly used collections are
+ * [[scala.collection.Seq]], [[scala.collection.immutable.Set]], and
+ * [[scala.collection.immutable.Map]].
+ * They can be used directly as shown below since their companion objects are
+ * all available as type aliases in either the [[scala]] package or in
+ * `scala.Predef`. New collections are created like this:
  * {{{
  * scala> val seq = Seq(1,2,3,4,1)
  * seq: Seq[Int] = List(1, 2, 3, 4, 1)
@@ -56,12 +60,12 @@ package scala
  * scala> val set = Set(1,2,3,4,1)
  * set: scala.collection.immutable.Set[Int] = Set(1, 2, 3, 4)
  *
- * scala> val map = Map(1 -> "one",2 -> "two", 3 -> "three",2 -> "too")
- * map: scala.collection.immutable.Map[Int,java.lang.String] = Map((1,one), (2,too), (3,three))
+ * scala> val map = Map(1 -> "one", 2 -> "two", 3 -> "three", 2 -> "too")
+ * map: scala.collection.immutable.Map[Int,String] = Map(1 -> one, 2 -> too, 3 -> three)
  * }}}
  *
- * It is also typical to use the [[scala.collection.immutable]] collections over those
- * in [[scala.collection.mutable]]; The types aliased in
+ * It is also typical to prefer the [[scala.collection.immutable]] collections
+ * over those in [[scala.collection.mutable]]; the types aliased in
  * the `scala.Predef` object are the immutable versions.
  *
  * Also note that the collections library was carefully designed to include several implementations of
@@ -74,9 +78,13 @@ package scala
  *
  * === Converting between Java Collections ===
  *
- * The `JavaConversions` object provides implicit defs that will allow mostly seamless integration
- * between Java Collections-based APIs and the Scala collections library.
+ * The [[scala.collection.JavaConversions]] object provides implicit defs that
+ * will allow mostly seamless integration between APIs using Java Collections
+ * and the Scala collections library.
  *
+ * Alternatively the [[scala.collection.JavaConverters]] object provides a collection
+ * of decorators that allow converting between Scala and Java collections using `asScala`
+ * and `asJava` methods.
  */
 package object collection {
   import scala.collection.generic.CanBuildFrom

--- a/src/library/scala/collection/parallel/ParIterableLike.scala
+++ b/src/library/scala/collection/parallel/ParIterableLike.scala
@@ -1499,5 +1499,4 @@ self: ParIterableLike[T, Repr, Sequential] =>
       append(s)
     }
   })
-
 }


### PR DESCRIPTION
This PR started life as #4651.

The bulk of it was separated out into more focused PRs,
#4765 - ScalaDoc comparison script
#4789 - Parameter and type renaming
#4803 - tparam naming consistency

Original PR comment

<pre>
Some doc fixes for GenTraversableOnce, methods from aggregate to foreach in alphabetical order.

This covers a-f so far. The rest of the alphabet is pending.

Types of corrections:

 * Rewordings, (hopefully) better explanations
 * Fixing type params and parameter names so doc gets inherited properly
 * Adjusting REPL output to what I get with 2.11
 * Moving documentation up to GenTraversableOnce (e.g. copyToArray
   was defined in GTO, but had no documentation there, only in TraversableLike)
 * Squashing some horizontal whitespace
</pre>
## TODO
- [x] Confirm build green and spot check changes
- [x] Take off `on-hold`
## DONE
- [x] Clone PR locally
- [x] Create initial as-is PR based on #4651 
- [x] Rebase onto current 2.11.x branch
- [x] Add `@deprecatedName('previousName)` where parameter names have changed
- [x] Confirm build passing
- [x] Modify parameter names for other `find`, `exists`, `forall` locating offenders with `def forall\([^p]` etc 
- [x] Split Out: Copy ScalaDoc comparison script to new PR (#4765)
- [x] Remove diff script (5cf459c2f55373cee38a6f637297f2276909efec)
- [x] Split Out: Move parameter and type renaming to new PR (#4789)
- [x] Rebase following merge of #4789
- [x] Remove commits that added a single new line :one:
- [x] Migrate tparam name change from `Doc fix for GenTraversableOnce.aggregate` to `Doc fixes for GenTraversableOnce.foreach` where all the other tparam name change are to be found.
- [x] Add de-double-spacing for `TreeMap`, `Iterator`, `IntMap` & `LongMap` to _Doc fixes for GenTraversableOnce.foreach_
- [x] Prefer _satisfies_ in _Doc fixes for GenTraversableOnce.find_
- [x] Rename _Doc fixes for GenTraversableOnce.foreach_ to _Conform tparam..._
- [x] Move _Conform tparam..._ to first commit
- [x] Restrict _Conform tparam..._ to `tparam` changes (and some whitespace edits)
- [x] Apply { } to () change to tparam commit
- [x] Create new PR restricted to `tparam` changes
- [x] Wait for merge of _Conform tparam..._ (#4803)
- [x] Rebase following merge of _Conform tparam..._ (#4803)
- [x] Fix build failure: method foreach is defined twice:`GenTraversableOnce.scala': def foreach[U](f: A => U): Unit` by editing _Doc fixes for collection/package_
- [x] Rename _Doc fixes for GenTraversableOnce.find_ to _Doc fixes for TraversableLike_
- [x] Squash _Doc fixes for GenTraversableOnce.forall_ into _Doc fixes for TraversableLike_
- [x] Squash `Doc fixes for GenTraversableOnce.fold, foldLeft and foldRight` & `Doc fixes for copyToArray in TraversableLike and GenTraversableOnce` to `Improve collections documentation`
- [x] Squash `Doc fixes for TraversableLike` into `Improve collections documentation`
- [x] Squash `Doc fix for GenTraversableOnce.aggregate` into `Improve collections documentation`
- [x] Do not delete `foreach` in `Doc fixes for collection/package`
- [x] Squash `Doc fixes for collection/package` into `Improve collections documentation`
- [x] Review current changes (continue from `AnyRefMap.scala`)
- [x] Address review comments including "So".

:one: This was temporarily added to get past a `git rebase --continue` problem.
