### PR TITLE
 Add $deserializeLambda$ when inlining an indyLambda into a class

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -11,6 +11,7 @@ package jvm
 
 import scala.annotation.switch
 import scala.reflect.internal.Flags
+import java.lang.invoke.LambdaMetafactory
 
 import scala.tools.asm
 import GenBCode._
@@ -1303,7 +1304,7 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
       val samName = sam.name.toString
       val samMethodType = asmMethodType(sam).toASMType
 
-      val flags = 3 // TODO 2.12.x Replace with LambdaMetafactory.FLAG_SERIALIZABLE | LambdaMetafactory.FLAG_MARKERS
+      val flags = LambdaMetafactory.FLAG_SERIALIZABLE | LambdaMetafactory.FLAG_MARKERS
 
       val ScalaSerializable = classBTypeFromSymbol(definitions.SerializableClass).toASMType
       bc.jmethod.visitInvokeDynamicInsn(samName, invokedType, lambdaMetaFactoryBootstrapHandle,

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -1316,7 +1316,7 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
         /* markerInterfaces[0]    = */ ScalaSerializable,
         /* bridgeCount            = */ 0.asInstanceOf[AnyRef]
       )
-      indyLambdaHosts += this.claszSymbol
+      indyLambdaHosts += cnode.name
     }
   }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -67,8 +67,6 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
     var isCZStaticModule           = false
     var isCZRemote                 = false
 
-    protected val indyLambdaHosts = collection.mutable.Set[Symbol]()
-
     /* ---------------- idiomatic way to ask questions to typer ---------------- */
 
     def paramTKs(app: Apply): List[BType] = {
@@ -127,7 +125,7 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
       val shouldAddLambdaDeserialize = (
         settings.target.value == "jvm-1.8"
           && settings.Ydelambdafy.value == "method"
-          && indyLambdaHosts.contains(claszSymbol))
+          && indyLambdaHosts.contains(cnode.name))
 
       if (shouldAddLambdaDeserialize)
         backendUtils.addLambdaDeserialize(cnode)

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -130,7 +130,7 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
           && indyLambdaHosts.contains(claszSymbol))
 
       if (shouldAddLambdaDeserialize)
-        addLambdaDeserialize(claszSymbol, cnode)
+        backendUtils.addLambdaDeserialize(cnode)
 
       addInnerClassesASM(cnode, innerClassBufferASM.toList)
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -14,7 +14,7 @@ import asm.Opcodes
 import scala.tools.asm.tree._
 import scala.tools.nsc.backend.jvm.BTypes.{InlineInfo, MethodInlineInfo}
 import scala.tools.nsc.backend.jvm.BackendReporting._
-import scala.tools.nsc.backend.jvm.analysis.Analyzers
+import scala.tools.nsc.backend.jvm.analysis.BackendUtils
 import scala.tools.nsc.backend.jvm.opt._
 import scala.collection.convert.decorateAsScala._
 import scala.tools.nsc.settings.ScalaSettings
@@ -29,6 +29,8 @@ import scala.tools.nsc.settings.ScalaSettings
  */
 abstract class BTypes {
   import BTypes.InternalName
+
+  val backendUtils: BackendUtils[this.type]
 
   // Some core BTypes are required here, in class BType, where no Global instance is available.
   // The Global is only available in the subclass BTypesFromSymbols. We cannot depend on the actual
@@ -50,8 +52,6 @@ abstract class BTypes {
   val closureOptimizer: ClosureOptimizer[this.type]
 
   val callGraph: CallGraph[this.type]
-
-  val analyzers: Analyzers[this.type]
 
   val backendReporting: BackendReporting
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -7,7 +7,7 @@ package scala.tools.nsc
 package backend.jvm
 
 import scala.tools.asm
-import scala.tools.nsc.backend.jvm.analysis.Analyzers
+import scala.tools.nsc.backend.jvm.analysis.BackendUtils
 import scala.tools.nsc.backend.jvm.opt._
 import scala.tools.nsc.backend.jvm.BTypes._
 import BackendReporting._
@@ -33,6 +33,8 @@ class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
   val bCodeAsmCommon: BCodeAsmCommon[global.type] = new BCodeAsmCommon(global)
   import bCodeAsmCommon._
 
+  val backendUtils: BackendUtils[this.type] = new BackendUtils(this)
+
   // Why the proxy, see documentation of class [[CoreBTypes]].
   val coreBTypes = new CoreBTypesProxy[this.type](this)
   import coreBTypes._
@@ -48,8 +50,6 @@ class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
   val closureOptimizer: ClosureOptimizer[this.type] = new ClosureOptimizer(this)
 
   val callGraph: CallGraph[this.type] = new CallGraph(this)
-
-  val analyzers: Analyzers[this.type] = new Analyzers(this)
 
   val backendReporting: BackendReporting = new BackendReportingImpl(global)
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
@@ -206,12 +206,14 @@ trait CoreBTypesProxyGlobalIndependent[BTS <: BTypes] {
 
   def boxedClasses: Set[ClassBType]
 
-  def RT_NOTHING : ClassBType
-  def RT_NULL    : ClassBType
+  def RT_NOTHING: ClassBType
+  def RT_NULL   : ClassBType
 
-  def ObjectReference          : ClassBType
-  def jlCloneableReference     : ClassBType
-  def jioSerializableReference : ClassBType
+  def ObjectReference         : ClassBType
+  def jlCloneableReference    : ClassBType
+  def jioSerializableReference: ClassBType
+  def javaUtilHashMapReference: ClassBType
+  def javaUtilMapReference    : ClassBType
 }
 
 /**

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
@@ -8,12 +8,14 @@ import scala.tools.nsc.backend.jvm.BTypes._
 import scala.tools.nsc.backend.jvm.opt.BytecodeUtils._
 
 /**
- * This component hosts tools for running ASM analyzers that require access to a `BTypes` instance.
- * In particular, the AsmAnalyzer class runs `computeMaxLocalsMaxStack` on the methodNode to be
- * analyzed. This method in turn lives inside the BTypes assembly because it queries the per-run
+ * This component hosts tools and utilities used in the backend that require access to a `BTypes`
+ * instance.
+ *
+ * One example is the AsmAnalyzer class, which runs `computeMaxLocalsMaxStack` on the methodNode to
+ * be analyzed. This method in turn lives inside the BTypes assembly because it queries the per-run
  * cache `maxLocalsMaxStackComputed` defined in there.
  */
-class Analyzers[BT <: BTypes](val btypes: BT) {
+class BackendUtils[BT <: BTypes](val btypes: BT) {
   import btypes._
 
   /**

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
@@ -16,8 +16,6 @@ import scala.tools.asm.{MethodWriter, ClassWriter, Label, Opcodes, Type}
 import scala.tools.asm.tree._
 import GenBCode._
 import scala.collection.convert.decorateAsScala._
-import scala.collection.convert.decorateAsJava._
-import scala.tools.nsc.backend.jvm.BTypes._
 
 object BytecodeUtils {
 
@@ -268,22 +266,6 @@ object BytecodeUtils {
     val labelNode = new LabelNode(label)
     label.info = labelNode
     labelNode
-  }
-
-  /**
-   * Clone the instructions in `methodNode` into a new [[InsnList]], mapping labels according to
-   * the `labelMap`. Returns the new instruction list and a map from old to new instructions.
-   */
-  def cloneInstructions(methodNode: MethodNode, labelMap: Map[LabelNode, LabelNode]): (InsnList, Map[AbstractInsnNode, AbstractInsnNode]) = {
-    val javaLabelMap = labelMap.asJava
-    val result = new InsnList
-    var map = Map.empty[AbstractInsnNode, AbstractInsnNode]
-    for (ins <- methodNode.instructions.iterator.asScala) {
-      val cloned = ins.clone(javaLabelMap)
-      result add cloned
-      map += ((ins, cloned))
-    }
-    (result, map)
   }
 
   /**

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/CallGraph.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/CallGraph.scala
@@ -21,7 +21,7 @@ import BytecodeUtils._
 
 class CallGraph[BT <: BTypes](val btypes: BT) {
   import btypes._
-  import analyzers._
+  import backendUtils._
 
   /**
    * The call graph contains the callsites in the program being compiled.

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/ClosureOptimizer.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/ClosureOptimizer.scala
@@ -23,7 +23,7 @@ import scala.collection.convert.decorateAsScala._
 class ClosureOptimizer[BT <: BTypes](val btypes: BT) {
   import btypes._
   import callGraph._
-  import analyzers._
+  import backendUtils._
 
   /**
    * If a closure is allocated and invoked within the same method, re-write the invocation to the

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
@@ -299,7 +299,7 @@ class Inliner[BT <: BTypes](val btypes: BT) {
 
     // New labels for the cloned instructions
     val labelsMap = cloneLabels(callee)
-    val (clonedInstructions, instructionMap) = cloneInstructions(callee, labelsMap)
+    val (clonedInstructions, instructionMap, hasSerializableClosureInstantiation) = cloneInstructions(callee, labelsMap)
     val keepLineNumbers = callsiteClass == calleeDeclarationClass
     if (!keepLineNumbers) {
       removeLineNumberNodes(clonedInstructions)
@@ -430,6 +430,11 @@ class Inliner[BT <: BTypes](val btypes: BT) {
     }
 
     callsiteMethod.maxStack = math.max(callsiteMethod.maxStack, math.max(stackHeightAtNullCheck, maxStackOfInlinedCode))
+
+    if (hasSerializableClosureInstantiation && !indyLambdaHosts(callsiteClass.internalName)) {
+      indyLambdaHosts += callsiteClass.internalName
+      addLambdaDeserialize(byteCodeRepository.classNode(callsiteClass.internalName).get)
+    }
 
     callGraph.addIfMissing(callee, calleeDeclarationClass)
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
@@ -24,7 +24,7 @@ class Inliner[BT <: BTypes](val btypes: BT) {
   import btypes._
   import callGraph._
   import inlinerHeuristics._
-  import analyzers._
+  import backendUtils._
 
   def eliminateUnreachableCodeAndUpdateCallGraph(methodNode: MethodNode, definingClass: InternalName): Unit = {
     localOpt.minimalRemoveUnreachableCode(methodNode, definingClass) foreach {

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/LocalOpt.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/LocalOpt.scala
@@ -48,7 +48,7 @@ import scala.tools.nsc.backend.jvm.opt.BytecodeUtils._
 class LocalOpt[BT <: BTypes](val btypes: BT) {
   import LocalOptImpls._
   import btypes._
-  import analyzers._
+  import backendUtils._
 
   /**
    * In order to run an Analyzer, the maxLocals / maxStack fields need to be available. The ASM

--- a/test/files/run/inlineAddDeserializeLambda.scala
+++ b/test/files/run/inlineAddDeserializeLambda.scala
@@ -1,0 +1,20 @@
+class C { @inline final def f: Int => Int = (x: Int) => x + 1 }
+
+object Test extends App {
+  import java.io._
+
+  def serialize(obj: AnyRef): Array[Byte] = {
+    val buffer = new ByteArrayOutputStream
+    val out = new ObjectOutputStream(buffer)
+    out.writeObject(obj)
+    buffer.toByteArray
+  }
+  def deserialize(a: Array[Byte]): AnyRef = {
+    val in = new ObjectInputStream(new ByteArrayInputStream(a))
+    in.readObject
+  }
+
+  def serializeDeserialize[T <: AnyRef](obj: T) = deserialize(serialize(obj)).asInstanceOf[T]
+
+  assert(serializeDeserialize((new C).f).isInstanceOf[Function1[_, _]])
+}

--- a/test/junit/scala/tools/nsc/backend/jvm/analysis/NullnessAnalyzerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/analysis/NullnessAnalyzerTest.scala
@@ -31,7 +31,7 @@ object NullnessAnalyzerTest extends ClearAfterClass.Clearable {
 class NullnessAnalyzerTest extends ClearAfterClass {
   ClearAfterClass.stateToClear = NullnessAnalyzerTest
   val noOptCompiler = NullnessAnalyzerTest.noOptCompiler
-  import noOptCompiler.genBCode.bTypes.analyzers._
+  import noOptCompiler.genBCode.bTypes.backendUtils._
 
   def newNullnessAnalyzer(methodNode: MethodNode, classInternalName: InternalName = "C") = new AsmAnalyzer(methodNode, classInternalName, new NullnessAnalyzer)
 

--- a/test/junit/scala/tools/nsc/backend/jvm/analysis/ProdConsAnalyzerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/analysis/ProdConsAnalyzerTest.scala
@@ -26,7 +26,7 @@ object ProdConsAnalyzerTest extends ClearAfterClass.Clearable {
 class ProdConsAnalyzerTest extends ClearAfterClass {
   ClearAfterClass.stateToClear = ProdConsAnalyzerTest
   val noOptCompiler = ProdConsAnalyzerTest.noOptCompiler
-  import noOptCompiler.genBCode.bTypes.analyzers._
+  import noOptCompiler.genBCode.bTypes.backendUtils._
 
   def prodToString(producer: AbstractInsnNode) = producer match {
     case p: InitialProducer => p.toString

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
@@ -68,7 +68,7 @@ class InlinerTest extends ClearAfterClass {
 
   val compiler = InlinerTest.compiler
   import compiler.genBCode.bTypes._
-  import compiler.genBCode.bTypes.analyzers._
+  import compiler.genBCode.bTypes.backendUtils._
 
   def compile(scalaCode: String, javaCode: List[(String, String)] = Nil, allowMessage: StoreReporter#Info => Boolean = _ => false): List[ClassNode] = {
     InlinerTest.notPerRun.foreach(_.clear())


### PR DESCRIPTION
Fixes scala/scala-dev#39

When inlining an indyLambda closure instantiation into a class, and
the closure type is serializable, make sure that the target class has
the synthetic `$deserializeLambda$` method.
