### PR TITLE
SD-33 Consider methods annotated @CallerSensitive not safe to inline

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
@@ -98,6 +98,8 @@ object BytecodeUtils {
 
   def isNativeMethod(methodNode: MethodNode): Boolean = (methodNode.access & Opcodes.ACC_NATIVE) != 0
 
+  def hasCallerSensitiveAnnotation(methodNode: MethodNode) = methodNode.visibleAnnotations != null && methodNode.visibleAnnotations.asScala.exists(_.desc == "Lsun/reflect/CallerSensitive;")
+
   def isFinalClass(classNode: ClassNode): Boolean = (classNode.access & Opcodes.ACC_FINAL) != 0
 
   def isFinalMethod(methodNode: MethodNode): Boolean = (methodNode.access & (Opcodes.ACC_FINAL | Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC)) != 0

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/CallGraph.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/CallGraph.scala
@@ -311,7 +311,8 @@ class CallGraph[BT <: BTypes](val btypes: BT) {
                 isStaticallyResolved &&  // (1)
                 !isAbstract &&
                 !BytecodeUtils.isConstructor(calleeMethodNode) &&
-                !BytecodeUtils.isNativeMethod(calleeMethodNode),
+                !BytecodeUtils.isNativeMethod(calleeMethodNode) &&
+                !BytecodeUtils.hasCallerSensitiveAnnotation(calleeMethodNode),
             safeToRewrite     = canInlineFromSource && isRewritableTraitCall, // (2)
             annotatedInline   = methodInlineInfo.annotatedInline,
             annotatedNoInline = methodInlineInfo.annotatedNoInline,


### PR DESCRIPTION
Fixes https://github.com/scala/scala-dev/issues/33

Methods annotated `sun.reflect.CallerSensitive` should not be inlined,
their implementation may depend on the call stack.
