### PR TITLE
Script to compare the current scaladoc with the parent commit's doc

### DIFF
--- a/tools/scaladoc-diff
+++ b/tools/scaladoc-diff
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Script to compare the scaladoc of the current commit with the scaladoc
+# of the parent commit. No arguments.
+#
+
+
+oldsha=$(git log -1 --format="%H" HEAD^)
+oldsha=${oldsha#g}
+oldsha=${oldsha:0:10}
+
+sha=`sh tools/get-scala-commit-sha`
+echo "parent commit sha: $oldsha. current commit sha: $sha"
+
+# create scaladoc for parent commit if not done already
+if [ ! -f "build/scaladoc-output-$oldsha.txt" ]
+then
+  echo "making scaladoc for parent commit ($oldsha)"
+  git checkout HEAD^
+  ant docs.lib -Dscaladoc.raw.output='yes' > build/scaladoc-output-$oldsha.txt
+  cp -r build/scaladoc/ build/scaladoc-${oldsha}
+  git checkout $sha
+fi
+
+# create scaladoc for current commit
+echo "making scaladoc for current commit ($sha)"
+ant docs.lib -Dscaladoc.raw.output='yes' > build/scaladoc-output-$sha.txt
+cp -r build/scaladoc/ build/scaladoc-${sha}
+echo "opendiff build/scaladoc-output-$oldsha.txt build/scaladoc-output-$sha.txt"
+opendiff build/scaladoc-output-$oldsha.txt build/scaladoc-output-$sha.txt
+
+echo "Comparing files..."
+
+difffile=build/scaladoc-diff-${sha}-$oldsha.txt
+sh tools/scaladoc-compare build/scaladoc-${sha}/ build/scaladoc-$oldsha/ &> $difffile
+open $difffile &
+
+# Adapted from tools/scaladoc-compare
+echo "Comparing versions with difftool: build/scaladoc-${sha}/ build/scaladoc-$oldsha/"
+NEW_PATH=build/scaladoc-${sha}/
+OLD_PATH=build/scaladoc-$oldsha/
+
+FILES=`find $NEW_PATH -name '*.html.raw'`
+if [ "$FILES" == "" ]
+then
+  echo "No .html.raw files found in $NEW_PATH!"
+  exit 1
+fi
+
+for NEW_FILE in $FILES
+do
+  OLD_FILE=${NEW_FILE/$NEW_PATH/$OLD_PATH}
+  if [ -f $OLD_FILE ]
+  then
+    DIFF=`diff -q -w $NEW_FILE $OLD_FILE 2>&1`
+    if [ "$DIFF" != "" ]
+    then
+      opendiff $OLD_FILE $NEW_FILE > /dev/null
+      echo "next [y\N]? "
+      read -n 1 -s input
+
+      if [ "$input" == "N" ]
+      then exit 0
+      fi
+    fi
+  else
+    echo -e "$NEW_FILE: No corresponding file (expecting $OLD_FILE)\n\n"
+  fi
+done
+
+echo "Done."

--- a/tools/scaladoc-diff
+++ b/tools/scaladoc-diff
@@ -4,68 +4,114 @@
 # of the parent commit. No arguments.
 #
 
+set -e
 
-oldsha=$(git log -1 --format="%H" HEAD^)
-oldsha=${oldsha#g}
-oldsha=${oldsha:0:10}
+# opendiff for Mac OS X, meld for Ubuntu then default to other commands.
+displaydiff() {
+  case "$(uname -s)" in
 
-sha=`sh tools/get-scala-commit-sha`
-echo "parent commit sha: $oldsha. current commit sha: $sha"
+    Darwin)
+      if hash opendiff 2>/dev/null; then
+        echo opendiff "$@"
+        opendiff "$@"
+      else
+        echo diff "$@"
+        diff -y "$@" | less -N
+      fi
+    ;;
+
+    *)
+      if hash meld 2>/dev/null; then
+        echo meld "$@"
+        meld "$@"
+      elif hash gvimdiff 2>/dev/null; then
+        echo gvimdiff "$@"
+        gvimdiff "$@"
+      else
+        echo diff "$@"
+        diff -y "$@" | less -N
+      fi
+    ;;
+  esac
+}
+
+oldsha=$(git rev-parse --short HEAD^)
+
+# Use branch name defaulting to SHA1 when not available for example when in
+# detached HEAD state.
+sha=$(git symbolic-ref -q --short HEAD || git rev-parse --short HEAD)
+
+echo "parent commit sha  : $oldsha"
+echo "current commit sha : $sha"
 
 # create scaladoc for parent commit if not done already
 if [ ! -f "build/scaladoc-output-$oldsha.txt" ]
 then
   echo "making scaladoc for parent commit ($oldsha)"
-  git checkout HEAD^
+  git checkout -q $oldsha
   ant docs.lib -Dscaladoc.raw.output='yes' > build/scaladoc-output-$oldsha.txt
-  cp -r build/scaladoc/ build/scaladoc-${oldsha}
-  git checkout $sha
+  rm -rf build/scaladoc-${oldsha}
+  mv build/scaladoc build/scaladoc-${oldsha}
+  git checkout -q $sha
 fi
 
 # create scaladoc for current commit
 echo "making scaladoc for current commit ($sha)"
 ant docs.lib -Dscaladoc.raw.output='yes' > build/scaladoc-output-$sha.txt
-cp -r build/scaladoc/ build/scaladoc-${sha}
-echo "opendiff build/scaladoc-output-$oldsha.txt build/scaladoc-output-$sha.txt"
-opendiff build/scaladoc-output-$oldsha.txt build/scaladoc-output-$sha.txt
+rm -rf build/scaladoc-${sha}
+mv build/scaladoc build/scaladoc-${sha}
 
-echo "Comparing files..."
+# Allow script to continue when diff results in -1
+set +e
 
-difffile=build/scaladoc-diff-${sha}-$oldsha.txt
-sh tools/scaladoc-compare build/scaladoc-${sha}/ build/scaladoc-$oldsha/ &> $difffile
-open $difffile &
+displaydiff build/scaladoc-output-$oldsha.txt build/scaladoc-output-$sha.txt
 
 # Adapted from tools/scaladoc-compare
-echo "Comparing versions with difftool: build/scaladoc-${sha}/ build/scaladoc-$oldsha/"
+echo "Comparing versions with diff: build/scaladoc-${sha}/ build/scaladoc-$oldsha/"
 NEW_PATH=build/scaladoc-${sha}/
 OLD_PATH=build/scaladoc-$oldsha/
 
-FILES=`find $NEW_PATH -name '*.html.raw'`
-if [ "$FILES" == "" ]
+
+NEWFILES=$(find $NEW_PATH -name '*.html.raw')
+if [ "$NEWFILES" == "" ]
 then
   echo "No .html.raw files found in $NEW_PATH!"
   exit 1
 fi
 
-for NEW_FILE in $FILES
+for NEW_FILE in $NEWFILES
 do
   OLD_FILE=${NEW_FILE/$NEW_PATH/$OLD_PATH}
   if [ -f $OLD_FILE ]
   then
-    DIFF=`diff -q -w $NEW_FILE $OLD_FILE 2>&1`
+    DIFF=$(diff -q -w $NEW_FILE $OLD_FILE 2>&1)
     if [ "$DIFF" != "" ]
     then
-      opendiff $OLD_FILE $NEW_FILE > /dev/null
+      displaydiff $OLD_FILE $NEW_FILE > /dev/null
+
       echo "next [y\N]? "
       read -n 1 -s input
-
-      if [ "$input" == "N" ]
-      then exit 0
-      fi
+      if [ "$input" == "N" ]; then exit 0; fi
     fi
   else
-    echo -e "$NEW_FILE: No corresponding file (expecting $OLD_FILE)\n\n"
+    echo
+    echo "New file:                 : $NEW_FILE"
+    echo "No corresponding old file : $OLD_FILE"
+
+    echo "next [y\N]? "
+    read -n 1 -s input
+    if [ "$input" == "N" ]; then exit 0; fi
   fi
 done
 
-echo "Done."
+OLDFILES=$(find $OLD_PATH -name '*.html.raw')
+for OLD_FILE in $OLDFILES
+do
+  NEW_FILE=${OLD_FILE/$OLD_PATH/$NEW_PATH}
+  if [ ! -f $NEW_FILE ]
+  then
+    echo
+    echo "Old file:                 : $OLD_FILE"
+    echo "No corresponding new file : $NEW_FILE"
+  fi
+done


### PR DESCRIPTION
This commit was extracted from #4760 to make that PR less diverse.

:ok_hand: LGTM on Ubuntu.
## Activity Log

This script does not work for me yet. Ideally this would also be tested by others on different UNIXes.

Please pull, test locally and provide comments or patches.
## :hotsprings: TODO
- [x] Fix `issue 1`. (46f717fef07086d8acc3ba3ed3b468979a55ee2a)
- [x] Fix `issue 2`. (8380096da92fe276aaeb98702cc28acad18924ea)
- [x] Fix `issue 3`.
- [x] Fix `issue 4`. (fafa2995ea19f93bfc2b1542f79ebd2e564cea95)
- [x] Ensure running the script twice copies the scaladoc to the same location. (9373058467c8205c25ac7900aded62a74b946074)
- [x] Consider `issue 5`. (0315e78816d03619ac01c747671f9d0b68efbfe9)
- [x] Fix `issue 6.
- [x] Check missing new files are detected.
- [x] Check missing old files are detected.
- [x] Test on `Ubuntu 14.04.3 LTS`.
- [x] Test on `OSX` - Help welcomed! :beer: :beer: :beer: :beer:
- [x] Squash commits down to two.
- [x] Extend any tooling overview documentation that already exists. Outcome: No update required.
- [x] Take off hold.
- [x] Add reviewers.
- [ ] Test with `git diff` instead of `displaydiff`
## :mount_fuji: Deferred
- [ ] Add optional param to allow using any ref as the oldsha (HEAD~6 for example)
## Known Issues

_none_
## Fixed Issues
### :white_check_mark: Issue 1

OS: Ubuntu 14.04.3 LTS

`not found` & `Bad substitution` errors,

```
21:58 $ ./tools/scaladoc-diff 
tools/get-scala-commit-sha: 11: tools/get-scala-commit-sha: [[: not found
tools/get-scala-commit-sha: 17: tools/get-scala-commit-sha: Bad substitution
parent commit sha: a6c1687aa7. current commit sha: 
making scaladoc for parent commit (a6c1687aa7)
Note: checking out 'HEAD^'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at a6c1687... Merge pull request #4757 from lrytz/t9375-2.11
```
### :white_check_mark: Issue 2

OS: Ubuntu 14.04.3 LTS

The script uses `opendiff` which is not present by default on this OS. At the very least the script should preflight the existence of all required commands if there is any reasonable chance they will not be present.

Solution: Check for these commands in order and use the first found,
- opendiff
- meld
- gvimdiff
- diff -y old new | less
### :white_check_mark: Issue 3

OS: Ubuntu 14.04.3 LTS

ScalaDoc `$ ant docs` & `$ ant docs.lib` does not build for @janekdb. Discussion on https://groups.google.com/forum/#!topic/scala-internals/VMzPo_tHL00

Solution: `ant clean build`
### :white_check_mark: Issue 4

OS: Ubuntu 14.04.3 LTS

The script uses `open` which is specific to Mac OS X.

Solution: Check for these commands in order and use the first found,
- open
- gedit
- less

open: https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/open.1.html
### :white_check_mark: Issue 5

When the working directory is restored with `git checkout $sha` the repo ends in a detached head state. Look for a way to restore the starting branch if possible.
- Determine initial branch
- If start state was a branch checkout the branch instead of the initial sha when restoring the working directory.

This can be used

```
git symbolic-ref -q --short HEAD
```

When on a branch it exits normally with the branch name, if on a detached head there is an error status code and then the short `SHA1` can be captured instead.
### :white_check_mark: Issue 6

OS: Ubuntu 14.04.3 LTS

Invoke `scaladoc-compare` with `bash` instead of `sh` to avoid _bad substitution_ error,

```
sh tools/scaladoc-compare build/scaladoc-${sha}/ build/scaladoc-$oldsha/ &> $difffile
```
