### PR TITLE
fix indentation

### DIFF
--- a/src/reflect/scala/reflect/internal/Chars.scala
+++ b/src/reflect/scala/reflect/internal/Chars.scala
@@ -66,7 +66,7 @@ trait Chars {
     '0' <= c && c <= '9' || 'A' <= c && c <= 'Z' || 'a' <= c && c <= 'z'
 
   /** Can character start an alphanumeric Scala identifier? */
-    def isIdentifierStart(c: Char): Boolean =
+  def isIdentifierStart(c: Char): Boolean =
     (c == '_') || (c == '$') || Character.isUnicodeIdentifierStart(c)
 
   /** Can character form part of an alphanumeric Scala identifier? */


### PR DESCRIPTION
this sneaked into 2d025fe2d0c9cd0e01e390055b0531166988f901

apologies for the trivial PR; I'm actually mainly just testing a fix
for https://github.com/scala/scabot/issues/51
