### PR TITLE
SI-9492 REPL paste here doc

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/ReplProps.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplProps.scala
@@ -64,6 +64,8 @@ class ReplProps {
     if (p.isSet) p.get else shellWelcomeString
   }
 
+  val pasteDelimiter = Prop[String]("scala.repl.here")
+
   /** CSV of paged,across to enable pagination or `-x` style
    *  columns, "across" instead of down the column.  Since
    *  pagination turns off columnar output, these flags are

--- a/test/files/run/repl-paste-5.check
+++ b/test/files/run/repl-paste-5.check
@@ -1,0 +1,28 @@
+
+scala> :paste < EOF
+// Entering paste mode (EOF to finish)
+
+class C { def c = 42 }
+EOF
+
+// Exiting paste mode, now interpreting.
+
+defined class C
+
+scala> new C().c
+res0: Int = 42
+
+scala> :paste <| EOF
+// Entering paste mode (EOF to finish)
+
+  |class D { def d = 42 }
+EOF
+
+// Exiting paste mode, now interpreting.
+
+defined class D
+
+scala> new D().d
+res1: Int = 42
+
+scala> :quit

--- a/test/files/run/repl-paste-5.scala
+++ b/test/files/run/repl-paste-5.scala
@@ -1,0 +1,18 @@
+
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  //def code = ":paste < EOF\n" + (
+  def code = 
+    """
+:paste < EOF
+class C { def c = 42 }
+EOF
+new C().c
+:paste <| EOF
+  |class D { def d = 42 }
+EOF
+new D().d
+    """
+  //)
+}


### PR DESCRIPTION
Simple here documentish syntax for REPL paste.

This makes it easier to paste a block of script
(as opposed to transcript).

It also means you won't accidentally ctl-D out
of the REPL and then out of SBT and then out of
the terminal window.

```
scala> :paste < EOF
// Entering paste mode (EOF to finish)

class C { def c = 42 }
EOF

// Exiting paste mode, now interpreting.

defined class C

scala> new C().c
res0: Int = 42

scala> :paste <| EOF
// Entering paste mode (EOF to finish)

  |class D { def d = 42 }
EOF

// Exiting paste mode, now interpreting.

defined class D

scala> new D().d
res1: Int = 42

scala> :quit
```
