### PR TITLE
Fixing signatures of universal methods on `Any` and `AnyRef`.

### DIFF
--- a/src/library-aux/scala/Any.scala
+++ b/src/library-aux/scala/Any.scala
@@ -77,7 +77,7 @@ abstract class Any {
    *
    *  @return a class object corresponding to the runtime type of the receiver.
    */
-  def getClass(): Class[_]
+  final def getClass(): Class[_] = sys.error("getClass")
 
   /** Test two objects for equality.
    *  The expression `x == that` is equivalent to `if (x eq null) that eq null else x.equals(that)`.
@@ -116,7 +116,7 @@ abstract class Any {
    *
    *  @return `true` if the receiver object is an instance of erasure of type `T0`; `false` otherwise.
    */
-  def isInstanceOf[T0]: Boolean = sys.error("isInstanceOf")
+  final def isInstanceOf[T0]: Boolean = sys.error("isInstanceOf")
 
   /** Cast the receiver object to be of type `T0`.
    *
@@ -129,5 +129,5 @@ abstract class Any {
    *  @throws ClassCastException if the receiver object is not an instance of the erasure of type `T0`.
    *  @return the receiver object.
    */
-  def asInstanceOf[T0]: T0 = sys.error("asInstanceOf")
+  final def asInstanceOf[T0]: T0 = sys.error("asInstanceOf")
 }

--- a/src/library-aux/scala/AnyRef.scala
+++ b/src/library-aux/scala/AnyRef.scala
@@ -100,33 +100,24 @@ trait AnyRef extends Any {
    */
   protected def finalize(): Unit
 
-  /** A representation that corresponds to the dynamic class of the receiver object.
-   *
-   *  The nature of the representation is platform dependent.
-   *
-   *  @note   not specified by SLS as a member of AnyRef
-   *  @return a representation that corresponds to the dynamic class of the receiver object.
-   */
-  def getClass(): Class[_]
-
   /** Wakes up a single thread that is waiting on the receiver object's monitor.
    *
    *  @note   not specified by SLS as a member of AnyRef
    */
-  def notify(): Unit
+  final def notify(): Unit
 
   /** Wakes up all threads that are waiting on the receiver object's monitor.
    *
    *  @note   not specified by SLS as a member of AnyRef
    */
-  def notifyAll(): Unit
+  final def notifyAll(): Unit
 
   /** Causes the current Thread to wait until another Thread invokes
    *  the notify() or notifyAll() methods.
    *
    *  @note   not specified by SLS as a member of AnyRef
    */
-  def wait (): Unit
-  def wait (timeout: Long, nanos: Int): Unit
-  def wait (timeout: Long): Unit
+  final def wait (): Unit
+  final def wait (timeout: Long, nanos: Int): Unit
+  final def wait (timeout: Long): Unit
 }


### PR DESCRIPTION
Methods `getClass`, `isInstanceOf`, `asInstanceOf`, `notify`, `notifyAll`, and `wait` should be final.
Method `getClass` should exist only on Any.

I am considering this a documentation change as this file is not linked. Review by @heathermiller 
