### PR TITLE
Improve implicits wildcard imports in the IDE

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -823,7 +823,12 @@ trait Contexts { self: Analyzer =>
         case List() =>
           List()
         case List(ImportSelector(nme.WILDCARD, _, _, _)) =>
-          collectImplicits(pre.implicitMembers, pre, imported = true)
+          // Using pre.implicitMembers seems to exposes a problem with out-dated symbols in the IDE,
+          // see the example in https://www.assembla.com/spaces/scala-ide/tickets/1002552#/activity/ticket
+          // I haven't been able to boil that down the an automated test yet.
+          // Looking up implicit members in the package, rather than package object, here is at least
+          // consistent with what is done just below for named imports.
+          collectImplicits(qual.tpe.implicitMembers, pre, imported = true)
         case ImportSelector(from, _, to, _) :: sels1 =>
           var impls = collect(sels1) filter (info => info.name != from)
           if (to != nme.WILDCARD) {


### PR DESCRIPTION
In 451cab967a, I changed handling of selection of members from
package objects so as to correctly use `somePackage.package.type`
as the prefix, rather than `somePackage`. This fixed generic
substitution for members inherited from superclasses of the
package object.

However, this has subtly changed the scope from which we collect
implicits given a wildcard import. It seems that the IDE gets into
a situation after a scaladoc lookup, which temporarily typechecks
the sources of a package object of a third party library, in which
the members of package object differ from the members of the enclosing
package.

The upshot of this was spurious type errors due to implicit search
discarding an candidate implicit whose symbol is not matched by
typechecking an identifier with the symbol's name at the implicit
usage site (this is how we discard shadowed implicits.)

I'd like to ge to the bottom of this, but in the meantime, I've found
that we can fix the regression by looking up the implicit member
symbols in the package, even while correctly using the package object
as the prefix.
