### PR TITLE
Avoid using ExecutionContext for Future.sequence of empty collection

### DIFF
--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -610,7 +610,7 @@ object Future {
   def sequence[A, M[X] <: TraversableOnce[X]](in: M[Future[A]])(implicit cbf: CanBuildFrom[M[Future[A]], A, M[A]], executor: ExecutionContext): Future[M[A]] = {
     in.foldLeft(successful(cbf(in))) {
       (fr, fa) => for (r <- fr; a <- fa) yield (r += a)
-    } map (_.result())
+    }.map(_.result())(InternalCallbackExecutor)
   }
 
   /** Asynchronously and non-blockingly returns a new `Future` to the result of the first future


### PR DESCRIPTION
Previously _.result() was invoked in the ExecutionContext, but this is an unnecessary use of the context (and thus less performant) if there are no futures.

---

I happened to come across this when observing deadlock due to thread exhaustion when Await was used. (Of course, that's not entirely unexpected if Await is used....this was not ideal code.)

In this particular case, it could have been prevented if `Future.sequence(Seq[Future[Nothing]]())` didn't require running something on an `ExecutionContext`.
