### PR TITLE
explicitly specify insertion-order feature in docs

### DIFF
--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -32,7 +32,7 @@ object ListMap extends ImmutableMapFactory[ListMap] {
   private object EmptyListMap extends ListMap[Any, Nothing] { }
 }
 
-/** This class implements immutable maps using a list-based data structure.
+/** This class implements immutable maps using a list-based data structure, which preserves insertion order.
  *  Instances of `ListMap` represent empty maps; they can be either created by
  *  calling the constructor directly, or by applying the function `ListMap.empty`.
  *


### PR DESCRIPTION
As I can see, many developers see it as insertion-order tolerant collection: http://stackoverflow.com/questions/9313866/immutable-scala-map-implementation-that-preserves-insertion-order

However, some of them not so sure, see comments here: http://stackoverflow.com/a/32872750/1809978,  http://stackoverflow.com/a/32872791/1809978

So, how about making it clear?
