### PR TITLE
Rename forall, exists and find predicate and operator params.

### DIFF
--- a/src/library/scala/collection/GenTraversableOnce.scala
+++ b/src/library/scala/collection/GenTraversableOnce.scala
@@ -393,20 +393,35 @@ trait GenTraversableOnce[+A] extends Any {
    */
   def minBy[B](f: A => B)(implicit cmp: Ordering[B]): A
 
-  def forall(pred: A => Boolean): Boolean
+  /** Tests whether a predicate holds for all elements of this $coll.
+   *
+   *  $mayNotTerminateInf
+   *
+   *  @param   p     the predicate used to test elements.
+   *  @return        `true` if this $coll is empty or the given predicate `p`
+   *                 holds for all elements of this $coll, otherwise `false`.
+   */
+  def forall(@deprecatedName('pred) p: A => Boolean): Boolean
 
-  def exists(pred: A => Boolean): Boolean
+  /** Tests whether a predicate holds for at least one element of this $coll.
+   *
+   *  $mayNotTerminateInf
+   *
+   *  @param   p     the predicate used to test elements.
+   *  @return        `true` if the given predicate `p` is satisfied by at least one element of this $coll, otherwise `false`
+   */
+  def exists(@deprecatedName('pred) p: A => Boolean): Boolean
 
   /** Finds the first element of the $coll satisfying a predicate, if any.
    *
    *  $mayNotTerminateInf
    *  $orderDependent
    *
-   *  @param pred    the predicate used to test elements.
+   *  @param p       the predicate used to test elements.
    *  @return        an option value containing the first element in the $coll
    *                 that satisfies `p`, or `None` if none exists.
    */
-  def find(pred: A => Boolean): Option[A]
+  def find(@deprecatedName('pred) p: A => Boolean): Option[A]
 
   /** Copies values of this $coll to an array.
    *  Fills the given array `xs` with values of this $coll.

--- a/src/library/scala/collection/LinearSeqOptimized.scala
+++ b/src/library/scala/collection/LinearSeqOptimized.scala
@@ -117,20 +117,20 @@ trait LinearSeqOptimized[+A, +Repr <: LinearSeqOptimized[A, Repr]] extends Linea
   }
 
   override /*TraversableLike*/
-  def foldLeft[B](z: B)(f: (B, A) => B): B = {
+  def foldLeft[B](z: B)(@deprecatedName('f) op: (B, A) => B): B = {
     var acc = z
     var these = this
     while (!these.isEmpty) {
-      acc = f(acc, these.head)
+      acc = op(acc, these.head)
       these = these.tail
     }
     acc
   }
 
   override /*IterableLike*/
-  def foldRight[B](z: B)(f: (A, B) => B): B =
+  def foldRight[B](z: B)(@deprecatedName('f) op: (A, B) => B): B =
     if (this.isEmpty) z
-    else f(head, tail.foldRight(z)(f))
+    else op(head, tail.foldRight(z)(op))
 
   override /*TraversableLike*/
   def reduceLeft[B >: A](f: (B, A) => B): B =

--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -357,7 +357,7 @@ trait TraversableLike[+A, +Repr] extends Any
     result
   }
 
-  /** Tests whether a predicate holds for some of the elements of this $coll.
+  /** Tests whether a predicate holds for at least one element of this $coll.
    *
    *  $mayNotTerminateInf
    *

--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -409,11 +409,11 @@ object RedBlackTree {
 
     def cons[B](x: B, xs: NList[B]): NList[B] = new NList(x, xs)
 
-    def foldLeft[A, B](xs: NList[A], z: B)(f: (B, A) => B): B = {
+    def foldLeft[A, B](xs: NList[A], z: B)(op: (B, A) => B): B = {
       var acc = z
       var these = xs
       while (these ne null) {
-        acc = f(acc, these.head)
+        acc = op(acc, these.head)
         these = these.tail
       }
       acc

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -33,7 +33,7 @@ trait Set[A] extends Iterable[A]
                 with Parallelizable[A, ParSet[A]]
 {
   override def companion: GenericCompanion[Set] = Set
-  
+
   
   /** Returns this $coll as an immutable set, perhaps accepting a
    *  wider range of elements.  Since it already is an
@@ -63,7 +63,7 @@ trait Set[A] extends Iterable[A]
 object Set extends ImmutableSetFactory[Set] {
   /** $setCanBuildFromInfo */
   implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Set[A]] = setCanBuildFrom[A]
-  
+
   /** An optimized representation for immutable empty sets */
   private object EmptySet extends AbstractSet[Any] with Set[Any] with Serializable {
     override def size: Int = 0
@@ -71,7 +71,7 @@ object Set extends ImmutableSetFactory[Set] {
     def + (elem: Any): Set[Any] = new Set1(elem)
     def - (elem: Any): Set[Any] = this
     def iterator: Iterator[Any] = Iterator.empty
-    override def foreach[U](f: Any =>  U): Unit = {}
+    override def foreach[U](f: Any => U): Unit = ()
     override def toSet[B >: Any]: Set[B] = this.asInstanceOf[Set[B]]
   }
   private[collection] def emptyInstance: Set[Any] = EmptySet
@@ -90,17 +90,17 @@ object Set extends ImmutableSetFactory[Set] {
       else this
     def iterator: Iterator[A] =
       Iterator(elem1)
-    override def foreach[U](f: A =>  U): Unit = {
+    override def foreach[U](f: A => U): Unit = {
       f(elem1)
     }
-    override def exists(f: A => Boolean): Boolean = {
-      f(elem1)
+    override def exists(@deprecatedName('f) p: A => Boolean): Boolean = {
+      p(elem1)
     }
-    override def forall(f: A => Boolean): Boolean = {
-      f(elem1)
+    override def forall(@deprecatedName('f) p: A => Boolean): Boolean = {
+      p(elem1)
     }
-    override def find(f: A => Boolean): Option[A] = {
-      if (f(elem1)) Some(elem1)
+    override def find(@deprecatedName('f) p: A => Boolean): Option[A] = {
+      if (p(elem1)) Some(elem1)
       else None
     }
     // Why is Set1 non-final?  Need to fix that!
@@ -124,18 +124,18 @@ object Set extends ImmutableSetFactory[Set] {
       else this
     def iterator: Iterator[A] =
       Iterator(elem1, elem2)
-    override def foreach[U](f: A =>  U): Unit = {
+    override def foreach[U](f: A => U): Unit = {
       f(elem1); f(elem2)
     }
-    override def exists(f: A => Boolean): Boolean = {
-      f(elem1) || f(elem2)
+    override def exists(@deprecatedName('f) p: A => Boolean): Boolean = {
+      p(elem1) || p(elem2)
     }
-    override def forall(f: A => Boolean): Boolean = {
-      f(elem1) && f(elem2)
+    override def forall(@deprecatedName('f) p: A => Boolean): Boolean = {
+      p(elem1) && p(elem2)
     }
-    override def find(f: A => Boolean): Option[A] = {
-      if (f(elem1)) Some(elem1)
-      else if (f(elem2)) Some(elem2)
+    override def find(@deprecatedName('f) p: A => Boolean): Option[A] = {
+      if (p(elem1)) Some(elem1)
+      else if (p(elem2)) Some(elem2)
       else None
     }
     // Why is Set2 non-final?  Need to fix that!
@@ -159,19 +159,19 @@ object Set extends ImmutableSetFactory[Set] {
       else this
     def iterator: Iterator[A] =
       Iterator(elem1, elem2, elem3)
-    override def foreach[U](f: A =>  U): Unit = {
+    override def foreach[U](f: A => U): Unit = {
       f(elem1); f(elem2); f(elem3)
     }
-    override def exists(f: A => Boolean): Boolean = {
-      f(elem1) || f(elem2) || f(elem3)
+    override def exists(@deprecatedName('f) p: A => Boolean): Boolean = {
+      p(elem1) || p(elem2) || p(elem3)
     }
-    override def forall(f: A => Boolean): Boolean = {
-      f(elem1) && f(elem2) && f(elem3)
+    override def forall(@deprecatedName('f) p: A => Boolean): Boolean = {
+      p(elem1) && p(elem2) && p(elem3)
     }
-    override def find(f: A => Boolean): Option[A] = {
-      if (f(elem1)) Some(elem1)
-      else if (f(elem2)) Some(elem2)
-      else if (f(elem3)) Some(elem3)
+    override def find(@deprecatedName('f) p: A => Boolean): Option[A] = {
+      if (p(elem1)) Some(elem1)
+      else if (p(elem2)) Some(elem2)
+      else if (p(elem3)) Some(elem3)
       else None
     }
     // Why is Set3 non-final?  Need to fix that!
@@ -196,20 +196,20 @@ object Set extends ImmutableSetFactory[Set] {
       else this
     def iterator: Iterator[A] =
       Iterator(elem1, elem2, elem3, elem4)
-    override def foreach[U](f: A =>  U): Unit = {
+    override def foreach[U](f: A => U): Unit = {
       f(elem1); f(elem2); f(elem3); f(elem4)
     }
-    override def exists(f: A => Boolean): Boolean = {
-      f(elem1) || f(elem2) || f(elem3) || f(elem4)
+    override def exists(@deprecatedName('f) p: A => Boolean): Boolean = {
+      p(elem1) || p(elem2) || p(elem3) || p(elem4)
     }
-    override def forall(f: A => Boolean): Boolean = {
-      f(elem1) && f(elem2) && f(elem3) && f(elem4)
+    override def forall(@deprecatedName('f) p: A => Boolean): Boolean = {
+      p(elem1) && p(elem2) && p(elem3) && p(elem4)
     }
-    override def find(f: A => Boolean): Option[A] = {
-      if (f(elem1)) Some(elem1)
-      else if (f(elem2)) Some(elem2)
-      else if (f(elem3)) Some(elem3)
-      else if (f(elem4)) Some(elem4)
+    override def find(@deprecatedName('f) p: A => Boolean): Option[A] = {
+      if (p(elem1)) Some(elem1)
+      else if (p(elem2)) Some(elem2)
+      else if (p(elem3)) Some(elem3)
+      else if (p(elem4)) Some(elem4)
       else None
     }
     // Why is Set4 non-final?  Need to fix that!

--- a/src/library/scala/collection/parallel/ParIterableLike.scala
+++ b/src/library/scala/collection/parallel/ParIterableLike.scala
@@ -520,22 +520,22 @@ self: ParIterableLike[T, Repr, Sequential] =>
    *
    *  $abortsignalling
    *
-   *  @param pred    a predicate used to test elements
+   *  @param p       a predicate used to test elements
    *  @return        true if `p` holds for all elements, false otherwise
    */
-  def forall(pred: T => Boolean): Boolean = {
-    tasksupport.executeAndWaitResult(new Forall(pred, splitter assign new DefaultSignalling with VolatileAbort))
+  def forall(@deprecatedName('pred) p: T => Boolean): Boolean = {
+    tasksupport.executeAndWaitResult(new Forall(p, splitter assign new DefaultSignalling with VolatileAbort))
   }
 
   /** Tests whether a predicate holds for some element of this $coll.
    *
    *  $abortsignalling
    *
-   *  @param pred    a predicate used to test elements
+   *  @param p       a predicate used to test elements
    *  @return        true if `p` holds for some element, false otherwise
    */
-  def exists(pred: T => Boolean): Boolean = {
-    tasksupport.executeAndWaitResult(new Exists(pred, splitter assign new DefaultSignalling with VolatileAbort))
+  def exists(@deprecatedName('pred) p: T => Boolean): Boolean = {
+    tasksupport.executeAndWaitResult(new Exists(p, splitter assign new DefaultSignalling with VolatileAbort))
   }
 
   /** Finds some element in the collection for which the predicate holds, if such
@@ -546,11 +546,11 @@ self: ParIterableLike[T, Repr, Sequential] =>
    *
    *  $abortsignalling
    *
-   *  @param pred     predicate used to test the elements
+   *  @param p        predicate used to test the elements
    *  @return         an option value with the element if such an element exists, or `None` otherwise
    */
-  def find(pred: T => Boolean): Option[T] = {
-    tasksupport.executeAndWaitResult(new Find(pred, splitter assign new DefaultSignalling with VolatileAbort))
+  def find(@deprecatedName('pred) p: T => Boolean): Option[T] = {
+    tasksupport.executeAndWaitResult(new Find(p, splitter assign new DefaultSignalling with VolatileAbort))
   }
 
   /** Creates a combiner factory. Each combiner factory instance is used

--- a/src/library/scala/runtime/Tuple2Zipped.scala
+++ b/src/library/scala/runtime/Tuple2Zipped.scala
@@ -84,12 +84,12 @@ final class Tuple2Zipped[El1, Repr1, El2, Repr2](val colls: (TraversableLike[El1
     (b1.result(), b2.result())
   }
 
-  def exists(f: (El1, El2) => Boolean): Boolean = {
+  def exists(@deprecatedName('f) p: (El1, El2) => Boolean): Boolean = {
     val elems2 = colls._2.iterator
 
     for (el1 <- colls._1) {
       if (elems2.hasNext) {
-        if (f(el1, elems2.next()))
+        if (p(el1, elems2.next()))
           return true
       }
       else return false
@@ -97,8 +97,8 @@ final class Tuple2Zipped[El1, Repr1, El2, Repr2](val colls: (TraversableLike[El1
     false
   }
 
-  def forall(f: (El1, El2) => Boolean): Boolean =
-    !exists((x, y) => !f(x, y))
+  def forall(@deprecatedName('f) p: (El1, El2) => Boolean): Boolean =
+    !exists((x, y) => !p(x, y))
 
   def foreach[U](f: (El1, El2) => U): Unit = {
     val elems2 = colls._2.iterator

--- a/src/library/scala/runtime/Tuple3Zipped.scala
+++ b/src/library/scala/runtime/Tuple3Zipped.scala
@@ -90,13 +90,13 @@ final class Tuple3Zipped[El1, Repr1, El2, Repr2, El3, Repr3](val colls: (Travers
     result
   }
 
-  def exists(f: (El1, El2, El3) => Boolean): Boolean = {
+  def exists(@deprecatedName('f) p: (El1, El2, El3) => Boolean): Boolean = {
     val elems2 = colls._2.iterator
     val elems3 = colls._3.iterator
 
     for (el1 <- colls._1) {
       if (elems2.hasNext && elems3.hasNext) {
-        if (f(el1, elems2.next(), elems3.next()))
+        if (p(el1, elems2.next(), elems3.next()))
           return true
       }
       else return false
@@ -104,8 +104,8 @@ final class Tuple3Zipped[El1, Repr1, El2, Repr2, El3, Repr3](val colls: (Travers
     false
   }
 
-  def forall(f: (El1, El2, El3) => Boolean): Boolean =
-    !exists((x, y, z) => !f(x, y, z))
+  def forall(@deprecatedName('f) p: (El1, El2, El3) => Boolean): Boolean =
+    !exists((x, y, z) => !p(x, y, z))
 
   def foreach[U](f: (El1, El2, El3) => U): Unit = {
     val elems2 = colls._2.iterator

--- a/src/library/scala/util/Either.scala
+++ b/src/library/scala/util/Either.scala
@@ -329,8 +329,8 @@ object Either {
      * }}}
      *
      */
-    def forall(f: A => Boolean) = e match {
-      case Left(a) => f(a)
+    def forall(@deprecatedName('f) p: A => Boolean) = e match {
+      case Left(a) => p(a)
       case Right(_) => true
     }
 
@@ -345,8 +345,8 @@ object Either {
      * }}}
      *
      */
-    def exists(f: A => Boolean) = e match {
-      case Left(a) => f(a)
+    def exists(@deprecatedName('f) p: A => Boolean) = e match {
+      case Left(a) => p(a)
       case Right(_) => false
     }
 
@@ -507,9 +507,9 @@ object Either {
      * Left(12).right.exists(_ > 10)   // false
      * }}}
      */
-    def exists(f: B => Boolean) = e match {
+    def exists(@deprecatedName('f) p: B => Boolean) = e match {
       case Left(_) => false
-      case Right(b) => f(b)
+      case Right(b) => p(b)
     }
 
     /**


### PR DESCRIPTION
Align parameters names to use p for predicates and op for combining operations.

Based on #4760. Extended to include,
- Tuple2Zipped
- Tuple3Zipped
- Either

The original author was vsalvis.

The scope for this commit is code changes with some closely related documentation moved over.
