### PR TITLE
Fixes an inconsistency between BoxesRunTime and Predef's autoboxing

### DIFF
--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -352,23 +352,23 @@ object Predef extends LowPriorityImplicits with DeprecatedPredef {
 
   // "Autoboxing" and "Autounboxing" ---------------------------------------------------
 
-  implicit def byte2Byte(x: Byte)           = java.lang.Byte.valueOf(x)
-  implicit def short2Short(x: Short)        = java.lang.Short.valueOf(x)
-  implicit def char2Character(x: Char)      = java.lang.Character.valueOf(x)
-  implicit def int2Integer(x: Int)          = java.lang.Integer.valueOf(x)
-  implicit def long2Long(x: Long)           = java.lang.Long.valueOf(x)
-  implicit def float2Float(x: Float)        = java.lang.Float.valueOf(x)
-  implicit def double2Double(x: Double)     = java.lang.Double.valueOf(x)
-  implicit def boolean2Boolean(x: Boolean)  = java.lang.Boolean.valueOf(x)
+  implicit def byte2Byte(x: Byte): java.lang.Byte             = x.asInstanceOf[java.lang.Byte]
+  implicit def short2Short(x: Short): java.lang.Short         = x.asInstanceOf[java.lang.Short]
+  implicit def char2Character(x: Char): java.lang.Character   = x.asInstanceOf[java.lang.Character]
+  implicit def int2Integer(x: Int): java.lang.Integer         = x.asInstanceOf[java.lang.Integer]
+  implicit def long2Long(x: Long): java.lang.Long             = x.asInstanceOf[java.lang.Long]
+  implicit def float2Float(x: Float): java.lang.Float         = x.asInstanceOf[java.lang.Float]
+  implicit def double2Double(x: Double): java.lang.Double     = x.asInstanceOf[java.lang.Double]
+  implicit def boolean2Boolean(x: Boolean): java.lang.Boolean = x.asInstanceOf[java.lang.Boolean]
 
-  implicit def Byte2byte(x: java.lang.Byte): Byte             = x.byteValue
-  implicit def Short2short(x: java.lang.Short): Short         = x.shortValue
-  implicit def Character2char(x: java.lang.Character): Char   = x.charValue
-  implicit def Integer2int(x: java.lang.Integer): Int         = x.intValue
-  implicit def Long2long(x: java.lang.Long): Long             = x.longValue
-  implicit def Float2float(x: java.lang.Float): Float         = x.floatValue
-  implicit def Double2double(x: java.lang.Double): Double     = x.doubleValue
-  implicit def Boolean2boolean(x: java.lang.Boolean): Boolean = x.booleanValue
+  implicit def Byte2byte(x: java.lang.Byte): Byte             = x.asInstanceOf[Byte]
+  implicit def Short2short(x: java.lang.Short): Short         = x.asInstanceOf[Short]
+  implicit def Character2char(x: java.lang.Character): Char   = x.asInstanceOf[Char]
+  implicit def Integer2int(x: java.lang.Integer): Int         = x.asInstanceOf[Int]
+  implicit def Long2long(x: java.lang.Long): Long             = x.asInstanceOf[Long]
+  implicit def Float2float(x: java.lang.Float): Float         = x.asInstanceOf[Float]
+  implicit def Double2double(x: java.lang.Double): Double     = x.asInstanceOf[Double]
+  implicit def Boolean2boolean(x: java.lang.Boolean): Boolean = x.asInstanceOf[Boolean]
 
   // Type Constraints --------------------------------------------------------------
 

--- a/test/junit/scala/PredefAutoboxingTest.scala
+++ b/test/junit/scala/PredefAutoboxingTest.scala
@@ -1,0 +1,35 @@
+package scala
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.tools.testing.AssertUtil._
+
+@RunWith(classOf[JUnit4])
+class PredefAutoboxingTest {
+  @Test def unboxNullByte() =
+    assertEquals(Predef.Byte2byte(null), 0.toByte)
+
+  @Test def unboxNullShort() =
+    assertEquals(Predef.Short2short(null), 0.toShort)
+
+  @Test def unboxNullCharacter() =
+    assertEquals(Predef.Character2char(null), 0.toChar)
+
+  @Test def unboxNullInteger() =
+    assertEquals(Predef.Integer2int(null), 0)
+
+  @Test def unboxNullLong() =
+    assertEquals(Predef.Long2long(null), 0L)
+
+  @Test def unboxNullFloat() =
+    assertEquals(Predef.Float2float(null), 0F, 0F)
+
+  @Test def unboxNullDouble() =
+    assertEquals(Predef.Double2double(null), 0D, 0D)
+
+  @Test def unboxNullBoolean() =
+    assertEquals(Predef.Boolean2boolean(null), false)
+}


### PR DESCRIPTION
Previously autoboxing implicits in Predef were inconsistent with
BoxesRunTime box/unbox due to different treatment of unboxing of
nulls. Implicits didn't check for null and would crash with NPE
unlike the BoxesRunTime which correctly returned zero value of
given type.

The fix is trivial: lets just use asInstanceOfs to implement
implicits in Predef. This would ensure that both have the same
behaviour and that the two would not diverge again in the future.

review @retronym , @sjrd 
