### PR TITLE
Use jarlister in build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -279,6 +279,10 @@ TODO:
         <dependency groupId="com.googlecode.jarjar" artifactId="jarjar" version="1.3"/>
       </artifact:dependencies>
 
+      <artifact:dependencies pathId="jarlister.classpath">
+        <dependency groupId="com.github.rjolly" artifactId="jarlister_2.11" version="1.0"/>
+      </artifact:dependencies>
+
       <!-- JUnit -->
       <property name="junit.version" value="4.11"/>
       <artifact:dependencies pathId="junit.classpath" filesetId="junit.fileset">
@@ -865,6 +869,11 @@ TODO:
       <path refid="aux.libs"/>
     </path>
 
+    <path id="pack.lib.path">
+      <pathelement location="${library.jar}"/>
+      <path refid="jarlister.classpath"/>
+    </path>
+
     <path id="pack.bin.tool.path">
       <pathelement location="${library.jar}"/>
       <pathelement location="${xml.jar}"/>
@@ -1228,7 +1237,10 @@ TODO:
 <!-- ===========================================================================
                                   PACKED QUICK BUILD (PACK)
 ============================================================================ -->
-  <target name="pack.lib"    depends="quick.lib, forkjoin.done"> <staged-pack project="library"/></target>
+  <target name="pack.lib" depends="quick.lib, forkjoin.done"> <staged-pack project="library"/>
+    <taskdef resource="scala/tools/ant/antlib.xml" classpathref="pack.lib.path"/>
+    <jarlister file="${library.jar}"/>
+  </target>
 
   <target name="pack.reflect" depends="quick.reflect"> <staged-pack project="reflect"/> </target>
 

--- a/test/files/run/t7843-jsr223-service.scala
+++ b/test/files/run/t7843-jsr223-service.scala
@@ -1,8 +1,6 @@
-import scala.tools.nsc.interpreter.IMain
-
 object Test extends App {
-  val engine = new IMain.Factory getScriptEngine()
-  engine.asInstanceOf[IMain].settings.usejavacp.value = true
+  val m = new javax.script.ScriptEngineManager()
+  val engine = m.getEngineByName("scala")
   engine put ("n", 10)
   engine eval "1 to n.asInstanceOf[Int] foreach print"
 }

--- a/test/files/run/t7933.scala
+++ b/test/files/run/t7933.scala
@@ -1,8 +1,6 @@
-import scala.tools.nsc.interpreter.IMain
-
 object Test extends App {
-  val engine = new IMain.Factory getScriptEngine()
-  engine.asInstanceOf[IMain].settings.usejavacp.value = true
+  val m = new javax.script.ScriptEngineManager()
+  val engine = m.getEngineByName("scala")
   val res2 = engine.asInstanceOf[javax.script.Compilable]
   res2 compile "8" eval()
   val res5 = res2 compile """println("hello") ; 8"""


### PR DESCRIPTION
The goal of this change is to exercize the "manifest classpath" mechanism,
meant to bring the compiler its needed classes as resources, listed
in jar manifests, as opposed to files, thus enabling to use the compiler
in sandboxed environments (and also the scripting engine for that matter).

This is a follow-up to https://github.com/scala/scala/pull/4456 . For the build to succeed, the jarlister should be added to the bintray under its sha1. It is available from http://repo.maven.apache.org/maven2/com/github/rjolly/jarlister_2.11/1.0/jarlister_2.11-1.0.jar
