### PR TITLE
Conform foreach tparam to majority naming convention

### DIFF
--- a/src/library/scala/collection/BitSetLike.scala
+++ b/src/library/scala/collection/BitSetLike.scala
@@ -115,7 +115,7 @@ trait BitSetLike[+This <: BitSetLike[This] with SortedSet[Int]] extends SortedSe
       else Iterator.empty.next()
   }
 
-  override def foreach[B](f: Int => B) {
+  override def foreach[U](f: Int => U) {
     /* NOTE: while loops are significantly faster as of 2.11 and
        one major use case of bitsets is performance. Also, there
        is nothing to do when all bits are clear, so use that as

--- a/src/library/scala/collection/GenTraversableLike.scala
+++ b/src/library/scala/collection/GenTraversableLike.scala
@@ -269,16 +269,16 @@ trait GenTraversableLike[+A, +Repr] extends Any with GenTraversableOnce[A] with 
    *    {{{
    *      scala> val a = List(1)
    *      a: List[Int] = List(1)
-   *      
+   *
    *      scala> val b = List(2)
    *      b: List[Int] = List(2)
-   *      
+   *
    *      scala> val c = a ++ b
    *      c: List[Int] = List(1, 2)
-   *      
+   *
    *      scala> val d = List('a')
    *      d: List[Char] = List(a)
-   *      
+   *
    *      scala> val e = c ++ d
    *      e: List[AnyVal] = List(1, 2, a)
    *    }}}

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -851,7 +851,7 @@ trait Iterator[+A] extends TraversableOnce[A] {
    *  @usecase def foreach(f: A => Unit): Unit
    *    @inheritdoc
    */
-  def foreach[U](f: A =>  U) { while (hasNext) f(next()) }
+  def foreach[U](f: A => U) { while (hasNext) f(next()) }
 
   /** Tests whether a predicate holds for all values produced by this iterator.
    *  $mayNotTerminateInf

--- a/src/library/scala/collection/LinearSeqOptimized.scala
+++ b/src/library/scala/collection/LinearSeqOptimized.scala
@@ -67,7 +67,7 @@ trait LinearSeqOptimized[+A, +Repr <: LinearSeqOptimized[A, Repr]] extends Linea
   }
 
   override /*IterableLike*/
-  def foreach[B](f: A => B) {
+  def foreach[U](f: A => U) {
     var these = this
     while (!these.isEmpty) {
       f(these.head)

--- a/src/library/scala/collection/MapLike.scala
+++ b/src/library/scala/collection/MapLike.scala
@@ -171,7 +171,7 @@ self =>
     def + (elem: A): Set[A] = (Set[A]() ++ this + elem).asInstanceOf[Set[A]] // !!! concrete overrides abstract problem
     def - (elem: A): Set[A] = (Set[A]() ++ this - elem).asInstanceOf[Set[A]] // !!! concrete overrides abstract problem
     override def size = self.size
-    override def foreach[C](f: A => C) = self.keysIterator foreach f
+    override def foreach[U](f: A => U) = self.keysIterator foreach f
   }
 
   /** Creates an iterator for all keys.
@@ -203,7 +203,7 @@ self =>
   protected class DefaultValuesIterable extends AbstractIterable[B] with Iterable[B] with Serializable {
     def iterator = valuesIterator
     override def size = self.size
-    override def foreach[C](f: B => C) = self.valuesIterator foreach f
+    override def foreach[U](f: B => U) = self.valuesIterator foreach f
   }
 
   /** Creates an iterator for all values in this map.
@@ -228,7 +228,7 @@ self =>
     throw new NoSuchElementException("key not found: " + key)
 
   protected class FilteredKeys(p: A => Boolean) extends AbstractMap[A, B] with DefaultMap[A, B] {
-    override def foreach[C](f: ((A, B)) => C): Unit = for (kv <- self) if (p(kv._1)) f(kv)
+    override def foreach[U](f: ((A, B)) => U): Unit = for (kv <- self) if (p(kv._1)) f(kv)
     def iterator = self.iterator.filter(kv => p(kv._1))
     override def contains(key: A) = self.contains(key) && p(key)
     def get(key: A) = if (!p(key)) None else self.get(key)
@@ -242,7 +242,7 @@ self =>
   def filterKeys(p: A => Boolean): Map[A, B] = new FilteredKeys(p)
 
   protected class MappedValues[C](f: B => C) extends AbstractMap[A, C] with DefaultMap[A, C] {
-    override def foreach[D](g: ((A, C)) => D): Unit = for ((k, v) <- self) g((k, f(v)))
+    override def foreach[U](g: ((A, C)) => U): Unit = for ((k, v) <- self) g((k, f(v)))
     def iterator = for ((k, v) <- self.iterator) yield (k, f(v))
     override def size = self.size
     override def contains(key: A) = self.contains(key)

--- a/src/library/scala/collection/Traversable.scala
+++ b/src/library/scala/collection/Traversable.scala
@@ -38,7 +38,7 @@ trait Traversable[+A] extends TraversableLike[A, Traversable[A]]
   override def remove(p: A => Boolean): Traversable[A]
   override def partition(p: A => Boolean): (Traversable[A], Traversable[A])
   override def groupBy[K](f: A => K): Map[K, Traversable[A]]
-  override def foreach[U](f: A =>  U): Unit
+  override def foreach[U](f: A => U): Unit
   override def forall(p: A => Boolean): Boolean
   override def exists(p: A => Boolean): Boolean
   override def count(p: A => Boolean): Int

--- a/src/library/scala/collection/TraversableOnce.scala
+++ b/src/library/scala/collection/TraversableOnce.scala
@@ -61,7 +61,8 @@ import scala.reflect.ClassTag
 trait TraversableOnce[+A] extends Any with GenTraversableOnce[A] {
   self =>
 
-  /** Self-documenting abstract methods. */
+  /* Self-documenting abstract methods. */
+
   def foreach[U](f: A => U): Unit
   def isEmpty: Boolean
   def hasDefiniteSize: Boolean
@@ -334,10 +335,10 @@ trait TraversableOnce[+A] extends Any with GenTraversableOnce[A] {
    * {{{
    *      scala> val a = List(1,2,3,4)
    *      a: List[Int] = List(1, 2, 3, 4)
-   *      
+   *
    *      scala> val b = new StringBuilder()
-   *      b: StringBuilder = 
-   *      
+   *      b: StringBuilder =
+   *
    *      scala> a.addString(b , "List(" , ", " , ")")
    *      res5: StringBuilder = List(1, 2, 3, 4)
    * }}}
@@ -376,7 +377,7 @@ trait TraversableOnce[+A] extends Any with GenTraversableOnce[A] {
    * {{{
    *      scala> val a = List(1,2,3,4)
    *      a: List[Int] = List(1, 2, 3, 4)
-   *      
+   *
    *      scala> val b = new StringBuilder()
    *      b: StringBuilder =
    *
@@ -399,7 +400,7 @@ trait TraversableOnce[+A] extends Any with GenTraversableOnce[A] {
    * {{{
    *      scala> val a = List(1,2,3,4)
    *      a: List[Int] = List(1, 2, 3, 4)
-   *      
+   *
    *      scala> val b = new StringBuilder()
    *      b: StringBuilder =
    *

--- a/src/library/scala/collection/TraversableProxyLike.scala
+++ b/src/library/scala/collection/TraversableProxyLike.scala
@@ -28,7 +28,7 @@ import scala.reflect.ClassTag
 trait TraversableProxyLike[+A, +Repr <: TraversableLike[A, Repr] with Traversable[A]] extends TraversableLike[A, Repr] with Proxy {
   def self: Repr
 
-  override def foreach[B](f: A => B): Unit = self.foreach(f)
+  override def foreach[U](f: A => U): Unit = self.foreach(f)
   override def isEmpty: Boolean = self.isEmpty
   override def nonEmpty: Boolean = self.nonEmpty
   override def size: Int = self.size

--- a/src/library/scala/collection/generic/TraversableForwarder.scala
+++ b/src/library/scala/collection/generic/TraversableForwarder.scala
@@ -32,7 +32,7 @@ trait TraversableForwarder[+A] extends Traversable[A] {
   /** The traversable object to which calls are forwarded. */
   protected def underlying: Traversable[A]
 
-  override def foreach[B](f: A => B): Unit = underlying foreach f
+  override def foreach[U](f: A => U): Unit = underlying foreach f
   override def isEmpty: Boolean = underlying.isEmpty
   override def nonEmpty: Boolean = underlying.nonEmpty
   override def size: Int = underlying.size

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -48,7 +48,7 @@ class HashMap[A, +B] extends AbstractMap[A, B]
 
   def iterator: Iterator[(A,B)] = Iterator.empty
 
-  override def foreach[U](f: ((A, B)) =>  U): Unit = { }
+  override def foreach[U](f: ((A, B)) => U): Unit = ()
 
   def get(key: A): Option[B] =
     get0(key, computeHash(key), 0)
@@ -422,7 +422,7 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
       final override def getElem(cc: AnyRef): (A, B) = cc.asInstanceOf[HashMap1[A, B]].ensurePair
     }
 
-    override def foreach[U](f: ((A, B)) =>  U): Unit = {
+    override def foreach[U](f: ((A, B)) => U): Unit = {
       var i = 0
       while (i < elems.length) {
         elems(i).foreach(f)

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -53,7 +53,7 @@ class HashSet[A] extends AbstractSet[A]
 
   def iterator: Iterator[A] = Iterator.empty
 
-  override def foreach[U](f: A =>  U): Unit = { }
+  override def foreach[U](f: A => U): Unit = ()
 
   def contains(e: A): Boolean = get0(e, computeHash(e), 0)
 
@@ -215,7 +215,7 @@ object HashSet extends ImmutableSetFactory[HashSet] {
 
   private object EmptyHashSet extends HashSet[Any] { }
   private[collection] def emptyInstance: HashSet[Any] = EmptyHashSet
-  
+
   // utility method to create a HashTrieSet from two leaf HashSets (HashSet1 or HashSetCollision1) with non-colliding hash code)
   private def makeHashTrieSet[A](hash0:Int, elem0:HashSet[A], hash1:Int, elem1:HashSet[A], level:Int) : HashTrieSet[A] = {
     val index0 = (hash0 >>> level) & 0x1f
@@ -966,7 +966,7 @@ object HashSet extends ImmutableSetFactory[HashSet] {
       final override def getElem(cc: AnyRef): A = cc.asInstanceOf[HashSet1[A]].key
     }
 
-    override def foreach[U](f: A =>  U): Unit = {
+    override def foreach[U](f: A => U): Unit = {
       var i = 0
       while (i < elems.length) {
         elems(i).foreach(f)

--- a/src/library/scala/collection/immutable/IntMap.scala
+++ b/src/library/scala/collection/immutable/IntMap.scala
@@ -184,7 +184,7 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
   /**
    * Loops over the key, value pairs of the map in unsigned order of the keys.
    */
-  override final def foreach[U](f: ((Int, T)) =>  U): Unit = this match {
+  override final def foreach[U](f: ((Int, T)) => U): Unit = this match {
     case IntMap.Bin(_, _, left, right) => { left.foreach(f); right.foreach(f) }
     case IntMap.Tip(key, value) => f((key, value))
     case IntMap.Nil =>

--- a/src/library/scala/collection/immutable/LongMap.scala
+++ b/src/library/scala/collection/immutable/LongMap.scala
@@ -176,7 +176,7 @@ extends AbstractMap[Long, T]
   /**
    * Loops over the key, value pairs of the map in unsigned order of the keys.
    */
-  override final def foreach[U](f: ((Long, T)) =>  U): Unit = this match {
+  override final def foreach[U](f: ((Long, T)) => U): Unit = this match {
     case LongMap.Bin(_, _, left, right) => { left.foreach(f); right.foreach(f) }
     case LongMap.Tip(key, value) => f((key, value))
     case LongMap.Nil =>

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -112,7 +112,7 @@ object Map extends ImmutableMapFactory[Map] {
     def + [B1 >: B](kv: (A, B1)): Map[A, B1] = updated(kv._1, kv._2)
     def - (key: A): Map[A, B] =
       if (key == key1) Map.empty else this
-    override def foreach[U](f: ((A, B)) =>  U): Unit = {
+    override def foreach[U](f: ((A, B)) => U): Unit = {
       f((key1, value1))
     }
   }
@@ -133,7 +133,7 @@ object Map extends ImmutableMapFactory[Map] {
       if (key == key1) new Map1(key2, value2)
       else if (key == key2) new Map1(key1, value1)
       else this
-    override def foreach[U](f: ((A, B)) =>  U): Unit = {
+    override def foreach[U](f: ((A, B)) => U): Unit = {
       f((key1, value1)); f((key2, value2))
     }
   }
@@ -157,7 +157,7 @@ object Map extends ImmutableMapFactory[Map] {
       else if (key == key2) new Map2(key1, value1, key3, value3)
       else if (key == key3) new Map2(key1, value1, key2, value2)
       else this
-    override def foreach[U](f: ((A, B)) =>  U): Unit = {
+    override def foreach[U](f: ((A, B)) => U): Unit = {
       f((key1, value1)); f((key2, value2)); f((key3, value3))
     }
   }
@@ -184,7 +184,7 @@ object Map extends ImmutableMapFactory[Map] {
       else if (key == key3) new Map3(key1, value1, key2, value2, key4, value4)
       else if (key == key4) new Map3(key1, value1, key2, value2, key3, value3)
       else this
-    override def foreach[U](f: ((A, B)) =>  U): Unit = {
+    override def foreach[U](f: ((A, B)) => U): Unit = {
       f((key1, value1)); f((key2, value2)); f((key3, value3)); f((key4, value4))
     }
   }

--- a/src/library/scala/collection/immutable/Stream.scala
+++ b/src/library/scala/collection/immutable/Stream.scala
@@ -176,9 +176,9 @@ import scala.language.implicitConversions
  *    loop(1, 1)
  *  }
  *  }}}
- * 
+ *
  *  Note that `mkString` forces evaluation of a `Stream`, but `addString` does
- *  not.  In both cases, a `Stream` that is or ends in a cycle 
+ *  not.  In both cases, a `Stream` that is or ends in a cycle
  *  (e.g. `lazy val s: Stream[Int] = 0 #:: s`) will convert additional trips
  *  through the cycle to `...`.  Additionally, `addString` will display an
  *  un-memoized tail as `?`.
@@ -566,7 +566,7 @@ self =>
       else super.flatMap(f)(bf)
     }
 
-    override def foreach[B](f: A => B) =
+    override def foreach[U](f: A => U) =
       for (x <- self)
         if (p(x)) f(x)
 
@@ -589,7 +589,7 @@ self =>
    *  unless the `f` throws an exception.
    */
   @tailrec
-  override final def foreach[B](f: A => B) {
+  override final def foreach[U](f: A => U) {
     if (!this.isEmpty) {
       f(head)
       tail.foreach(f)

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -200,5 +200,5 @@ class TreeMap[A, +B] private (tree: RB.Tree[A, B])(implicit val ordering: Orderi
   override def contains(key: A): Boolean = RB.contains(tree, key)
   override def isDefinedAt(key: A): Boolean = RB.contains(tree, key)
 
-  override def foreach[U](f : ((A,B)) =>  U) = RB.foreach(tree, f)
+  override def foreach[U](f : ((A,B)) => U) = RB.foreach(tree, f)
 }

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -151,7 +151,7 @@ class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: Orderin
   def iterator: Iterator[A] = RB.keysIterator(tree)
   override def keysIteratorFrom(start: A): Iterator[A] = RB.keysIterator(tree, Some(start))
 
-  override def foreach[U](f: A =>  U) = RB.foreachKey(tree, f)
+  override def foreach[U](f: A => U) = RB.foreachKey(tree, f)
 
   override def rangeImpl(from: Option[A], until: Option[A]): TreeSet[A] = newSet(RB.rangeImpl(tree, from, until))
   override def range(from: A, until: A): TreeSet[A] = newSet(RB.range(tree, from, until))

--- a/src/library/scala/collection/mutable/AnyRefMap.scala
+++ b/src/library/scala/collection/mutable/AnyRefMap.scala
@@ -5,23 +5,23 @@ package mutable
 import generic.CanBuildFrom
 
 /** This class implements mutable maps with `AnyRef` keys based on a hash table with open addressing.
- * 
- *  Basic map operations on single entries, including `contains` and `get`, 
+ *
+ *  Basic map operations on single entries, including `contains` and `get`,
  *  are typically significantly faster with `AnyRefMap` than [[HashMap]].
  *  Note that numbers and characters are not handled specially in AnyRefMap;
  *  only plain `equals` and `hashCode` are used in comparisons.
- * 
+ *
  *  Methods that traverse or regenerate the map, including `foreach` and `map`,
  *  are not in general faster than with `HashMap`.  The methods `foreachKey`,
  *  `foreachValue`, `mapValuesNow`, and `transformValues` are, however, faster
  *  than alternative ways to achieve the same functionality.
- * 
+ *
  *  Maps with open addressing may become less efficient at lookup after
  *  repeated addition/removal of elements.  Although `AnyRefMap` makes a
  *  decent attempt to remain efficient regardless,  calling `repack`
  *  on a map that will no longer have elements removed but will be
  *  used heavily may save both time and storage space.
- * 
+ *
  *  This map is not intended to contain more than 2^29^ entries (approximately
  *  500 million).  The maximum capacity is 2^30^, but performance will degrade
  *  rapidly as 2^30^ is approached.
@@ -34,50 +34,50 @@ extends AbstractMap[K, V]
 {
   import AnyRefMap._
   def this() = this(AnyRefMap.exceptionDefault, 16, true)
-  
+
   /** Creates a new `AnyRefMap` that returns default values according to a supplied key-value mapping. */
   def this(defaultEntry: K => V) = this(defaultEntry, 16, true)
 
   /** Creates a new `AnyRefMap` with an initial buffer of specified size.
-   * 
+   *
    *  An `AnyRefMap` can typically contain half as many elements as its buffer size
    *  before it requires resizing.
    */
   def this(initialBufferSize: Int) = this(AnyRefMap.exceptionDefault, initialBufferSize, true)
-  
+
   /** Creates a new `AnyRefMap` with specified default values and initial buffer size. */
   def this(defaultEntry: K => V, initialBufferSize: Int) = this(defaultEntry, initialBufferSize, true)
-  
+
   private[this] var mask = 0
   private[this] var _size = 0
   private[this] var _vacant = 0
   private[this] var _hashes: Array[Int] = null
   private[this] var _keys: Array[AnyRef] = null
   private[this] var _values: Array[AnyRef] = null
-    
+
   if (initBlank) defaultInitialize(initialBufferSize)
-  
+
   private[this] def defaultInitialize(n: Int) {
-    mask = 
+    mask =
       if (n<0) 0x7
       else (((1 << (32 - java.lang.Integer.numberOfLeadingZeros(n-1))) - 1) & 0x3FFFFFFF) | 0x7
     _hashes = new Array[Int](mask+1)
     _keys = new Array[AnyRef](mask+1)
     _values = new Array[AnyRef](mask+1)
   }
-  
+
   private[collection] def initializeTo(
     m: Int, sz: Int, vc: Int, hz: Array[Int], kz: Array[AnyRef], vz: Array[AnyRef]
   ) {
     mask = m; _size = sz; _vacant = vc; _hashes = hz; _keys = kz; _values = vz
   }
-  
+
   override def size: Int = _size
   override def empty: AnyRefMap[K,V] = new AnyRefMap(defaultEntry)
-  
-  private def imbalanced: Boolean = 
+
+  private def imbalanced: Boolean =
     (_size + _vacant) > 0.5*mask || _vacant > _size
-  
+
   private def hashOf(key: K): Int = {
     if (key eq null) 0x41081989
     else {
@@ -88,7 +88,7 @@ extends AbstractMap[K, V]
       if (j==0) 0x41081989 else j & 0x7FFFFFFF
     }
   }
-  
+
   private def seekEntry(h: Int, k: AnyRef): Int = {
     var e = h & mask
     var x = 0
@@ -100,7 +100,7 @@ extends AbstractMap[K, V]
     }
     e | MissingBit
   }
-  
+
   private def seekEntryOrOpen(h: Int, k: AnyRef): Int = {
     var e = h & mask
     var x = 0
@@ -114,19 +114,19 @@ extends AbstractMap[K, V]
     }
     if (o >= 0) o | MissVacant else e | MissingBit
   }
-  
+
   override def contains(key: K): Boolean = seekEntry(hashOf(key), key) >= 0
-  
+
   override def get(key: K): Option[V] = {
     val i = seekEntry(hashOf(key), key)
     if (i < 0) None else Some(_values(i).asInstanceOf[V])
   }
-  
+
   override def getOrElse[V1 >: V](key: K, default: => V1): V1 = {
     val i = seekEntry(hashOf(key), key)
     if (i < 0) default else _values(i).asInstanceOf[V]
   }
-  
+
   override def getOrElseUpdate(key: K, defaultValue: => V): V = {
     val h = hashOf(key)
     var i = seekEntryOrOpen(h, key)
@@ -154,10 +154,10 @@ extends AbstractMap[K, V]
     }
     else _values(i).asInstanceOf[V]
   }
-  
+
   /** Retrieves the value associated with a key, or the default for that type if none exists
    *  (null for AnyRef, 0 for floats and integers).
-   * 
+   *
    *  Note: this is the fastest way to retrieve a value that may or
    *  may not exist, if the default null/zero is acceptable.  For key/value
    *  pairs that do exist, `apply` (i.e. `map(key)`) is equally fast.
@@ -166,22 +166,22 @@ extends AbstractMap[K, V]
     val i = seekEntry(hashOf(key), key)
     (if (i < 0) null else _values(i)).asInstanceOf[V]
   }
-  
-  /** Retrieves the value associated with a key. 
+
+  /** Retrieves the value associated with a key.
    *  If the key does not exist in the map, the `defaultEntry` for that key
-   *  will be returned instead; an exception will be thrown if no 
+   *  will be returned instead; an exception will be thrown if no
    *  `defaultEntry` was supplied.
    */
   override def apply(key: K): V = {
     val i = seekEntry(hashOf(key), key)
     if (i < 0) defaultEntry(key) else _values(i).asInstanceOf[V]
   }
-  
+
   /** Defers to defaultEntry to find a default value for the key.  Throws an
    *  exception if no other default behavior was specified.
    */
   override def default(key: K) = defaultEntry(key)
-  
+
   private def repack(newMask: Int) {
     val oh = _hashes
     val ok = _keys
@@ -205,9 +205,9 @@ extends AbstractMap[K, V]
       i += 1
     }
   }
-  
+
   /** Repacks the contents of this `AnyRefMap` for maximum efficiency of lookup.
-   * 
+   *
    *  For maps that undergo a complex creation process with both addition and
    *  removal of keys, and then are used heavily with no further removal of
    *  elements, calling `repack` after the end of the creation can result in
@@ -220,7 +220,7 @@ extends AbstractMap[K, V]
     while (m > 8 && 8*_size < m) m = m >>> 1
     repack(m)
   }
-  
+
   override def put(key: K, value: V): Option[V] = {
     val h = hashOf(key)
     val k = key
@@ -243,9 +243,9 @@ extends AbstractMap[K, V]
       ans
     }
   }
-  
+
   /** Updates the map to include a new key-value pair.
-   * 
+   *
    *  This is the fastest way to add an entry to an `AnyRefMap`.
    */
   override def update(key: K, value: V): Unit = {
@@ -267,12 +267,12 @@ extends AbstractMap[K, V]
       _values(i) = value.asInstanceOf[AnyRef]
     }
   }
-  
+
   /** Adds a new key/value pair to this map and returns the map. */
   def +=(key: K, value: V): this.type = { update(key, value); this }
 
   def +=(kv: (K, V)): this.type = { update(kv._1, kv._2); this }
-  
+
   def -=(key: K): this.type = {
     val i = seekEntry(hashOf(key), key)
     if (i >= 0) {
@@ -284,14 +284,14 @@ extends AbstractMap[K, V]
     }
     this
   }
-  
+
   def iterator: Iterator[(K, V)] = new Iterator[(K, V)] {
     private[this] val hz = _hashes
     private[this] val kz = _keys
     private[this] val vz = _values
-    
+
     private[this] var index = 0
-    
+
     def hasNext: Boolean = index<hz.length && {
       var h = hz(index)
       while (h+h == 0) {
@@ -301,7 +301,7 @@ extends AbstractMap[K, V]
       }
       true
     }
-    
+
     def next: (K, V) = {
       if (hasNext) {
         val ans = (kz(index).asInstanceOf[K], vz(index).asInstanceOf[V])
@@ -311,8 +311,8 @@ extends AbstractMap[K, V]
       else throw new NoSuchElementException("next")
     }
   }
-  
-  override def foreach[A](f: ((K,V)) => A) {
+
+  override def foreach[U](f: ((K,V)) => U) {
     var i = 0
     var e = _size
     while (e > 0) {
@@ -325,7 +325,7 @@ extends AbstractMap[K, V]
       else return
     }
   }
-    
+
   override def clone(): AnyRefMap[K, V] = {
     val hz = java.util.Arrays.copyOf(_hashes, _hashes.length)
     val kz = java.util.Arrays.copyOf(_keys, _keys.length)
@@ -334,7 +334,7 @@ extends AbstractMap[K, V]
     arm.initializeTo(mask, _size, _vacant, hz, kz,  vz)
     arm
   }
-  
+
   private[this] def foreachElement[A,B](elems: Array[AnyRef], f: A => B) {
     var i,j = 0
     while (i < _hashes.length & j < _size) {
@@ -346,13 +346,13 @@ extends AbstractMap[K, V]
       i += 1
     }
   }
-  
+
   /** Applies a function to all keys of this map. */
   def foreachKey[A](f: K => A) { foreachElement[K,A](_keys, f) }
 
   /** Applies a function to all values of this map. */
   def foreachValue[A](f: V => A) { foreachElement[V,A](_values, f) }
-  
+
   /** Creates a new `AnyRefMap` with different values.
    *  Unlike `mapValues`, this method generates a new
    *  collection immediately.
@@ -374,8 +374,8 @@ extends AbstractMap[K, V]
     arm.initializeTo(mask, _size, _vacant, hz, kz, vz)
     arm
   }
-  
-  /** Applies a transformation function to all values stored in this map. 
+
+  /** Applies a transformation function to all values stored in this map.
    *  Note: the default, if any,  is not transformed.
    */
   def transformValues(f: V => V): this.type = {
@@ -398,15 +398,15 @@ object AnyRefMap {
   private final val MissingBit = 0x80000000
   private final val VacantBit  = 0x40000000
   private final val MissVacant = 0xC0000000
-  
+
   private val exceptionDefault = (k: Any) => throw new NoSuchElementException(if (k == null) "(null)" else k.toString)
-  
+
   implicit def canBuildFrom[K <: AnyRef, V, J <: AnyRef, U]: CanBuildFrom[AnyRefMap[K,V], (J, U), AnyRefMap[J,U]] =
     new CanBuildFrom[AnyRefMap[K,V], (J, U), AnyRefMap[J,U]] {
       def apply(from: AnyRefMap[K,V]): AnyRefMapBuilder[J, U] = apply()
       def apply(): AnyRefMapBuilder[J, U] = new AnyRefMapBuilder[J, U]
     }
-  
+
   final class AnyRefMapBuilder[K <: AnyRef, V] extends Builder[(K, V), AnyRefMap[K, V]] {
     private[collection] var elems: AnyRefMap[K, V] = new AnyRefMap[K, V]
     def +=(entry: (K, V)): this.type = {
@@ -425,14 +425,14 @@ object AnyRefMap {
     if (arm.size < (sz>>3)) arm.repack()
     arm
   }
-  
+
   /** Creates a new empty `AnyRefMap`. */
   def empty[K <: AnyRef, V]: AnyRefMap[K, V] = new AnyRefMap[K, V]
-  
+
   /** Creates a new empty `AnyRefMap` with the supplied default */
   def withDefault[K <: AnyRef, V](default: K => V): AnyRefMap[K, V] = new AnyRefMap[K, V](default)
-  
-  /** Creates a new `AnyRefMap` from arrays of keys and values. 
+
+  /** Creates a new `AnyRefMap` from arrays of keys and values.
    *  Equivalent to but more efficient than `AnyRefMap((keys zip values): _*)`.
    */
   def fromZip[K <: AnyRef, V](keys: Array[K], values: Array[V]): AnyRefMap[K, V] = {
@@ -443,8 +443,8 @@ object AnyRefMap {
     if (arm.size < (sz>>3)) arm.repack()
     arm
   }
-  
-  /** Creates a new `AnyRefMap` from keys and values. 
+
+  /** Creates a new `AnyRefMap` from keys and values.
    *  Equivalent to but more efficient than `AnyRefMap((keys zip values): _*)`.
    */
   def fromZip[K <: AnyRef, V](keys: Iterable[K], values: Iterable[V]): AnyRefMap[K, V] = {

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -68,7 +68,7 @@ extends AbstractSeq[A]
     array(idx) = elem.asInstanceOf[AnyRef]
   }
 
-  override def foreach[U](f: A =>  U) {
+  override def foreach[U](f: A => U) {
     var i = 0
     while (i < length) {
       f(array(i).asInstanceOf[A])

--- a/src/library/scala/collection/mutable/ArrayStack.scala
+++ b/src/library/scala/collection/mutable/ArrayStack.scala
@@ -233,7 +233,7 @@ extends AbstractSeq[T]
     }
   }
 
-  override def foreach[U](f: T =>  U) {
+  override def foreach[U](f: T => U) {
     var currentIndex = index
     while (currentIndex > 0) {
       currentIndex -= 1

--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -96,16 +96,16 @@ extends AbstractMap[A, B]
 
   def iterator = entriesIterator map (e => ((e.key, e.value)))
 
-  override def foreach[C](f: ((A, B)) => C): Unit = foreachEntry(e => f((e.key, e.value)))
+  override def foreach[U](f: ((A, B)) => U): Unit = foreachEntry(e => f((e.key, e.value)))
 
   /* Override to avoid tuple allocation in foreach */
   override def keySet: scala.collection.Set[A] = new DefaultKeySet {
-    override def foreach[C](f: A => C) = foreachEntry(e => f(e.key))
+    override def foreach[U](f: A => U) = foreachEntry(e => f(e.key))
   }
 
   /* Override to avoid tuple allocation in foreach */
   override def values: scala.collection.Iterable[B] = new DefaultValuesIterable {
-    override def foreach[C](f: B => C) = foreachEntry(e => f(e.value))
+    override def foreach[U](f: B => U) = foreachEntry(e => f(e.value))
   }
 
   /* Override to avoid tuple allocation */

--- a/src/library/scala/collection/mutable/HashSet.scala
+++ b/src/library/scala/collection/mutable/HashSet.scala
@@ -70,7 +70,7 @@ extends AbstractSet[A]
 
   override def iterator: Iterator[A] = super[FlatHashTable].iterator
 
-  override def foreach[U](f: A =>  U) {
+  override def foreach[U](f: A => U) {
     var i = 0
     val len = table.length
     while (i < len) {

--- a/src/library/scala/collection/mutable/ImmutableSetAdaptor.scala
+++ b/src/library/scala/collection/mutable/ImmutableSetAdaptor.scala
@@ -32,7 +32,7 @@ extends AbstractSet[A]
 
   def contains(elem: A): Boolean = set.contains(elem)
 
-  override def foreach[U](f: A =>  U): Unit = set.foreach(f)
+  override def foreach[U](f: A => U): Unit = set.foreach(f)
 
   override def exists(p: A => Boolean): Boolean = set.exists(p)
 

--- a/src/library/scala/collection/mutable/LinkedListLike.scala
+++ b/src/library/scala/collection/mutable/LinkedListLike.scala
@@ -172,7 +172,7 @@ trait LinkedListLike[A, This <: Seq[A] with LinkedListLike[A, This]] extends Seq
     }
   }
 
-  override def foreach[B](f: A => B) {
+  override def foreach[U](f: A => U) {
     var these = this
     while (these.nonEmpty) {
       f(these.elem)

--- a/src/library/scala/collection/mutable/SynchronizedSet.scala
+++ b/src/library/scala/collection/mutable/SynchronizedSet.scala
@@ -78,7 +78,7 @@ trait SynchronizedSet[A] extends Set[A] {
     super.subsetOf(that)
   }
 
-  override def foreach[U](f: A =>  U) = synchronized {
+  override def foreach[U](f: A => U) = synchronized {
     super.foreach(f)
   }
 

--- a/src/library/scala/collection/parallel/ParMapLike.scala
+++ b/src/library/scala/collection/parallel/ParMapLike.scala
@@ -99,14 +99,14 @@ self =>
     def - (elem: K): ParSet[K] =
       (ParSet[K]() ++ this - elem).asInstanceOf[ParSet[K]] // !!! concrete overrides abstract problem
     override def size = self.size
-    override def foreach[S](f: K => S) = for ((k, v) <- self) f(k)
+    override def foreach[U](f: K => U) = for ((k, v) <- self) f(k)
     override def seq = self.seq.keySet
   }
 
   protected class DefaultValuesIterable extends ParIterable[V] {
     def splitter = valuesIterator(self.splitter)
     override def size = self.size
-    override def foreach[S](f: V => S) = for ((k, v) <- self) f(v)
+    override def foreach[U](f: V => U) = for ((k, v) <- self) f(v)
     def seq = self.seq.values
   }
 
@@ -118,7 +118,7 @@ self =>
 
   def filterKeys(p: K => Boolean): ParMap[K, V] = new ParMap[K, V] {
     lazy val filtered = self.filter(kv => p(kv._1))
-    override def foreach[S](f: ((K, V)) => S): Unit = for (kv <- self) if (p(kv._1)) f(kv)
+    override def foreach[U](f: ((K, V)) => U): Unit = for (kv <- self) if (p(kv._1)) f(kv)
     def splitter = filtered.splitter
     override def contains(key: K) = self.contains(key) && p(key)
     def get(key: K) = if (!p(key)) None else self.get(key)
@@ -129,7 +129,7 @@ self =>
   }
 
   def mapValues[S](f: V => S): ParMap[K, S] = new ParMap[K, S] {
-    override def foreach[Q](g: ((K, S)) => Q): Unit = for ((k, v) <- self) g((k, f(v)))
+    override def foreach[U](g: ((K, S)) => U): Unit = for ((k, v) <- self) g((k, f(v)))
     def splitter = self.splitter.map(kv => (kv._1, f(kv._2)))
     override def size = self.size
     override def contains(key: K) = self.contains(key)


### PR DESCRIPTION
'U' is the common choice for the foreach function result tparam.

This command summarises the naming diversity before and after this change.

$ fgrep -r 'def foreach[' *|cut -f2 -d:|cut -f1 -d'('|tr -s ' '|sed 's/override //g'|sort|uniq -c|sort -nr

Before,

```
 80  def foreach[U]
  6  def foreach[C]
  6  def foreach[B]
  4  final def foreach[U]
  3  def foreach[S]
  2  inline final def foreach[U]
  2  def foreach[A]
  1  inline final def foreach[specialized
  1  final def foreach[B]
  1  * def foreach[U]
  1  def foreach[Q]
  1  def foreach[D]
  1  def foreach[A,B,U]
```

After,

```
 98  def foreach[U]
  5  final def foreach[U]
  2  inline final def foreach[U]
  1  inline final def foreach[specialized
  1  * def foreach[U]
  1  def foreach[A,B,U]
```

(@ symbols removed.)
