### PR TITLE
Simplify and correctify calculation of the InnerClass attribute

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -96,12 +96,12 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
       val thrownKind = tpeTK(expr)
       // `throw null` is valid although scala.Null (as defined in src/library-aux) isn't a subtype of Throwable.
       // Similarly for scala.Nothing (again, as defined in src/library-aux).
-      assert(thrownKind.isNullType || thrownKind.isNothingType || thrownKind.asClassBType.isSubtypeOf(ThrowableReference).get)
+      assert(thrownKind.isNullType || thrownKind.isNothingType || thrownKind.asClassBType.isSubtypeOf(jlThrowableRef).get)
       genLoad(expr, thrownKind)
       lineNumber(expr)
       emit(asm.Opcodes.ATHROW) // ICode enters here into enterIgnoreMode, we'll rely instead on DCE at ClassNode level.
 
-      RT_NOTHING // always returns the same, the invoker should know :)
+      srNothingRef // always returns the same, the invoker should know :)
     }
 
     /* Generate code for primitive arithmetic operations. */
@@ -325,7 +325,7 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
           else {
             mnode.visitVarInsn(asm.Opcodes.ALOAD, 0)
             generatedType =
-              if (tree.symbol == ArrayClass) ObjectReference
+              if (tree.symbol == ArrayClass) ObjectRef
               else classBTypeFromSymbol(claszSymbol)
           }
 
@@ -368,7 +368,7 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
           if (value.tag != UnitTag) (value.tag, expectedType) match {
             case (IntTag,   LONG  ) => bc.lconst(value.longValue);       generatedType = LONG
             case (FloatTag, DOUBLE) => bc.dconst(value.doubleValue);     generatedType = DOUBLE
-            case (NullTag,  _     ) => bc.emit(asm.Opcodes.ACONST_NULL); generatedType = RT_NULL
+            case (NullTag,  _     ) => bc.emit(asm.Opcodes.ACONST_NULL); generatedType = srNullRef
             case _                  => genConstant(value);               generatedType = tpeTK(tree)
           }
 
@@ -553,8 +553,8 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
             else if (l.isPrimitive) {
               bc drop l
               if (cast) {
-                mnode.visitTypeInsn(asm.Opcodes.NEW, classCastExceptionReference.internalName)
-                bc dup ObjectReference
+                mnode.visitTypeInsn(asm.Opcodes.NEW, jlClassCastExceptionRef.internalName)
+                bc dup ObjectRef
                 emit(asm.Opcodes.ATHROW)
               } else {
                 bc boolconst false
@@ -644,7 +644,7 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
           val nativeKind = tpeTK(expr)
           genLoad(expr, nativeKind)
           val MethodNameAndType(mname, methodType) = asmBoxTo(nativeKind)
-          bc.invokestatic(BoxesRunTime.internalName, mname, methodType.descriptor, app.pos)
+          bc.invokestatic(srBoxesRunTimeRef.internalName, mname, methodType.descriptor, app.pos)
           generatedType = boxResultType(fun.symbol) // was typeToBType(fun.symbol.tpe.resultType)
 
         case Apply(fun @ _, List(expr)) if currentRun.runDefinitions.isUnbox(fun.symbol) =>
@@ -652,7 +652,7 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
           val boxType = unboxResultType(fun.symbol) // was typeToBType(fun.symbol.owner.linkedClassOfClass.tpe)
           generatedType = boxType
           val MethodNameAndType(mname, methodType) = asmUnboxTo(boxType)
-          bc.invokestatic(BoxesRunTime.internalName, mname, methodType.descriptor, app.pos)
+          bc.invokestatic(srBoxesRunTimeRef.internalName, mname, methodType.descriptor, app.pos)
 
         case app @ Apply(fun, args) =>
           val sym = fun.symbol
@@ -997,7 +997,7 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
 
         // Optimization for expressions of the form "" + x.  We can avoid the StringBuilder.
         case List(Literal(Constant("")), arg) =>
-          genLoad(arg, ObjectReference)
+          genLoad(arg, ObjectRef)
           genCallMethod(String_valueOf, icodes.opcodes.Static(onInstance = false), arg.pos)
 
         case concatenations =>
@@ -1011,7 +1011,7 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
 
       }
 
-      StringReference
+      StringRef
     }
 
     def genCallMethod(method: Symbol, style: InvokeStyle, pos: Position, hostClass0: Symbol = null) {
@@ -1076,7 +1076,7 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
     /* Generate the scala ## method. */
     def genScalaHash(tree: Tree, applyPos: Position): BType = {
       genLoadModule(ScalaRunTimeModule) // TODO why load ScalaRunTimeModule if ## has InvokeStyle of Static(false) ?
-      genLoad(tree, ObjectReference)
+      genLoad(tree, ObjectRef)
       genCallMethod(hashMethodSym, icodes.opcodes.Static(onInstance = false), applyPos)
 
       INT
@@ -1164,8 +1164,8 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
         if (scalaPrimitives.isReferenceEqualityOp(code) &&
             { nonNullSide = ifOneIsNull(l, r); nonNullSide != null }
         ) {
-          genLoad(nonNullSide, ObjectReference)
-          genCZJUMP(success, failure, op, ObjectReference)
+          genLoad(nonNullSide, ObjectRef)
+          genCZJUMP(success, failure, op, ObjectRef)
         }
         else {
           val tk = tpeTK(l).maxType(tpeTK(r))
@@ -1252,42 +1252,42 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
             else platform.externalEqualsNumObject
           } else platform.externalEquals
         }
-        genLoad(l, ObjectReference)
-        genLoad(r, ObjectReference)
+        genLoad(l, ObjectRef)
+        genLoad(r, ObjectRef)
         genCallMethod(equalsMethod, icodes.opcodes.Static(onInstance = false), pos)
         genCZJUMP(success, failure, icodes.NE, BOOL)
       }
       else {
         if (isNull(l)) {
           // null == expr -> expr eq null
-          genLoad(r, ObjectReference)
-          genCZJUMP(success, failure, icodes.EQ, ObjectReference)
+          genLoad(r, ObjectRef)
+          genCZJUMP(success, failure, icodes.EQ, ObjectRef)
         } else if (isNull(r)) {
           // expr == null -> expr eq null
-          genLoad(l, ObjectReference)
-          genCZJUMP(success, failure, icodes.EQ, ObjectReference)
+          genLoad(l, ObjectRef)
+          genCZJUMP(success, failure, icodes.EQ, ObjectRef)
         } else if (isNonNullExpr(l)) {
           // SI-7852 Avoid null check if L is statically non-null.
-          genLoad(l, ObjectReference)
-          genLoad(r, ObjectReference)
+          genLoad(l, ObjectRef)
+          genLoad(r, ObjectRef)
           genCallMethod(Object_equals, icodes.opcodes.Dynamic, pos)
           genCZJUMP(success, failure, icodes.NE, BOOL)
         } else {
           // l == r -> if (l eq null) r eq null else l.equals(r)
-          val eqEqTempLocal = locals.makeLocal(ObjectReference, nme.EQEQ_LOCAL_VAR.toString)
+          val eqEqTempLocal = locals.makeLocal(ObjectRef, nme.EQEQ_LOCAL_VAR.toString)
           val lNull    = new asm.Label
           val lNonNull = new asm.Label
 
-          genLoad(l, ObjectReference)
-          genLoad(r, ObjectReference)
+          genLoad(l, ObjectRef)
+          genLoad(r, ObjectRef)
           locals.store(eqEqTempLocal)
-          bc dup ObjectReference
-          genCZJUMP(lNull, lNonNull, icodes.EQ, ObjectReference)
+          bc dup ObjectRef
+          genCZJUMP(lNull, lNonNull, icodes.EQ, ObjectRef)
 
           markProgramPoint(lNull)
-          bc drop ObjectReference
+          bc drop ObjectRef
           locals.load(eqEqTempLocal)
-          genCZJUMP(success, failure, icodes.EQ, ObjectReference)
+          genCZJUMP(success, failure, icodes.EQ, ObjectRef)
 
           markProgramPoint(lNonNull)
           locals.load(eqEqTempLocal)

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -666,7 +666,7 @@ abstract class BCodeHelpers extends BCodeIdiomatic with BytecodeWriters {
         bType.info.get.flags,
         bType.internalName,
         null /* no java-generic-signature */,
-        ObjectReference.internalName,
+        ObjectRef.internalName,
         EMPTY_STRING_ARRAY
       )
 
@@ -710,7 +710,7 @@ abstract class BCodeHelpers extends BCodeIdiomatic with BytecodeWriters {
         beanInfoType.info.get.flags,
         beanInfoType.internalName,
         null, // no java-generic-signature
-        ScalaBeanInfoReference.internalName,
+        sbScalaBeanInfoRef.internalName,
         EMPTY_STRING_ARRAY
       )
 
@@ -747,7 +747,7 @@ abstract class BCodeHelpers extends BCodeIdiomatic with BytecodeWriters {
         EMPTY_STRING_ARRAY // no throwable exceptions
       )
 
-      val stringArrayJType: BType = ArrayBType(StringReference)
+      val stringArrayJType: BType = ArrayBType(StringRef)
       val conJType: BType = MethodBType(
         classBTypeFromSymbol(definitions.ClassClass) :: stringArrayJType :: stringArrayJType :: Nil,
         UNIT
@@ -760,7 +760,7 @@ abstract class BCodeHelpers extends BCodeIdiomatic with BytecodeWriters {
           constructor.visitLdcInsn(new java.lang.Integer(fi))
           if (f == null) { constructor.visitInsn(asm.Opcodes.ACONST_NULL) }
           else           { constructor.visitLdcInsn(f) }
-          constructor.visitInsn(StringReference.typedOpcode(asm.Opcodes.IASTORE))
+          constructor.visitInsn(StringRef.typedOpcode(asm.Opcodes.IASTORE))
           fi += 1
         }
       }
@@ -773,12 +773,12 @@ abstract class BCodeHelpers extends BCodeIdiomatic with BytecodeWriters {
 
       // push the string array of field information
       constructor.visitLdcInsn(new java.lang.Integer(fieldList.length))
-      constructor.visitTypeInsn(asm.Opcodes.ANEWARRAY, StringReference.internalName)
+      constructor.visitTypeInsn(asm.Opcodes.ANEWARRAY, StringRef.internalName)
       push(fieldList)
 
       // push the string array of method information
       constructor.visitLdcInsn(new java.lang.Integer(methodList.length))
-      constructor.visitTypeInsn(asm.Opcodes.ANEWARRAY, StringReference.internalName)
+      constructor.visitTypeInsn(asm.Opcodes.ANEWARRAY, StringRef.internalName)
       push(methodList)
 
       // invoke the superclass constructor, which will do the

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeIdiomatic.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeIdiomatic.scala
@@ -220,10 +220,10 @@ abstract class BCodeIdiomatic extends SubComponent {
     final def genStringConcat(el: BType, pos: Position): Unit = {
 
       val jtype =
-        if (el.isArray || el.isClass) ObjectReference
+        if (el.isArray || el.isClass) ObjectRef
         else el
 
-      val bt = MethodBType(List(jtype), StringBuilderReference)
+      val bt = MethodBType(List(jtype), jlStringBuilderRef)
 
       invokevirtual(StringBuilderClassName, "append", bt.descriptor, pos)
     }

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -140,7 +140,7 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
     private def initJClass(jclass: asm.ClassVisitor) {
 
       val bType = classBTypeFromSymbol(claszSymbol)
-      val superClass = bType.info.get.superClass.getOrElse(ObjectReference).internalName
+      val superClass = bType.info.get.superClass.getOrElse(ObjectRef).internalName
       val interfaceNames = bType.info.get.interfaces.map(_.internalName)
 
       val flags = javaFlags(claszSymbol)

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -157,7 +157,7 @@ abstract class BTypes {
       val res = ClassBType(internalName)
       byteCodeRepository.classNode(internalName) match {
         case Left(msg) => res.info = Left(NoClassBTypeInfoMissingBytecode(msg)); res
-        case Right(c)  => setClassInfoFromParsedClassfile(c, res)
+        case Right(c)  => setClassInfoFromClassNode(c, res)
       }
     })
   }
@@ -167,11 +167,11 @@ abstract class BTypes {
    */
   def classBTypeFromClassNode(classNode: ClassNode): ClassBType = {
     classBTypeFromInternalName.getOrElse(classNode.name, {
-      setClassInfoFromParsedClassfile(classNode, ClassBType(classNode.name))
+      setClassInfoFromClassNode(classNode, ClassBType(classNode.name))
     })
   }
 
-  private def setClassInfoFromParsedClassfile(classNode: ClassNode, classBType: ClassBType): ClassBType = {
+  private def setClassInfoFromClassNode(classNode: ClassNode, classBType: ClassBType): ClassBType = {
     val superClass = classNode.superName match {
       case null =>
         assert(classNode.name == ObjectReference.internalName, s"class with missing super type: ${classNode.name}")

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -174,7 +174,7 @@ abstract class BTypes {
   private def setClassInfoFromClassNode(classNode: ClassNode, classBType: ClassBType): ClassBType = {
     val superClass = classNode.superName match {
       case null =>
-        assert(classNode.name == ObjectReference.internalName, s"class with missing super type: ${classNode.name}")
+        assert(classNode.name == ObjectRef.internalName, s"class with missing super type: ${classNode.name}")
         None
       case superName =>
         Some(classBTypeFromParsedClassfile(superName))
@@ -321,8 +321,8 @@ abstract class BTypes {
 
     final def isNonVoidPrimitiveType = isPrimitive && this != UNIT
 
-    final def isNullType             = this == RT_NULL
-    final def isNothingType          = this == RT_NOTHING
+    final def isNullType             = this == srNullRef
+    final def isNothingType          = this == srNothingRef
 
     final def isBoxed = this.isClass && boxedClasses(this.asClassBType)
 
@@ -345,7 +345,7 @@ abstract class BTypes {
 
       this match {
         case ArrayBType(component) =>
-          if (other == ObjectReference || other == jlCloneableReference || other == jioSerializableReference) true
+          if (other == ObjectRef || other == jlCloneableRef || other == jiSerializableRef) true
           else other match {
             case ArrayBType(otherComponent) => component.conformsTo(otherComponent).orThrow
             case _ => false
@@ -354,7 +354,7 @@ abstract class BTypes {
         case classType: ClassBType =>
           if (isBoxed) {
             if (other.isBoxed) this == other
-            else if (other == ObjectReference) true
+            else if (other == ObjectRef) true
             else other match {
               case otherClassType: ClassBType => classType.isSubtypeOf(otherClassType).orThrow // e.g., java/lang/Double conforms to java/lang/Number
               case _ => false
@@ -397,7 +397,7 @@ abstract class BTypes {
 
         assert(other.isRef, s"Cannot compute maxType: $this, $other")
         // Approximate `lub`. The common type of two references is always ObjectReference.
-        ObjectReference
+        ObjectRef
 
       case _: MethodBType =>
         assertionError(s"unexpected method type when computing maxType: $this")
@@ -869,7 +869,7 @@ abstract class BTypes {
       // best-effort verification. also we don't report an error if the info is a Left.
       def ifInit(c: ClassBType)(p: ClassBType => Boolean): Boolean = c._info == null || c.info.isLeft || p(c)
 
-      def isJLO(t: ClassBType) = t.internalName == ObjectReference.internalName
+      def isJLO(t: ClassBType) = t.internalName == ObjectRef.internalName
 
       assert(!ClassBType.isInternalPhantomType(internalName), s"Cannot create ClassBType for phantom type $this")
 
@@ -949,7 +949,7 @@ abstract class BTypes {
     def isSubtypeOf(other: ClassBType): Either[NoClassBTypeInfo, Boolean] = try {
       if (this == other) return Right(true)
       if (isInterface.orThrow) {
-        if (other == ObjectReference) return Right(true) // interfaces conform to Object
+        if (other == ObjectRef) return Right(true) // interfaces conform to Object
         if (!other.isInterface.orThrow) return Right(false)   // this is an interface, the other is some class other than object. interfaces cannot extend classes, so the result is false.
         // else: this and other are both interfaces. continue to (*)
       } else {
@@ -982,13 +982,13 @@ abstract class BTypes {
             // exercised by test/files/run/t4761.scala
             if (other.isSubtypeOf(this).orThrow) this
             else if (this.isSubtypeOf(other).orThrow) other
-            else ObjectReference
+            else ObjectRef
 
           case (true, false) =>
-            if (other.isSubtypeOf(this).orThrow) this else ObjectReference
+            if (other.isSubtypeOf(this).orThrow) this else ObjectRef
 
           case (false, true) =>
-            if (this.isSubtypeOf(other).orThrow) other else ObjectReference
+            if (this.isSubtypeOf(other).orThrow) other else ObjectRef
 
           case _ =>
             // TODO @lry I don't really understand the reasoning here.

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -110,8 +110,8 @@ class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
     assert(classSym.isClass, s"Cannot create ClassBType from non-class symbol $classSym")
     assertClassNotArrayNotPrimitive(classSym)
     assert(!primitiveTypeMap.contains(classSym) || isCompilingPrimitive, s"Cannot create ClassBType for primitive class symbol $classSym")
-    if (classSym == NothingClass) RT_NOTHING
-    else if (classSym == NullClass) RT_NULL
+    if (classSym == NothingClass) srNothingRef
+    else if (classSym == NullClass) srNullRef
     else {
       val internalName = classSym.javaBinaryName.toString
       classBTypeFromInternalName.getOrElse(internalName, {
@@ -164,7 +164,7 @@ class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
      */
     def nonClassTypeRefToBType(sym: Symbol): ClassBType = {
       assert(sym.isType && isCompilingArray, sym)
-      ObjectReference
+      ObjectRef
     }
 
     t.dealiasWiden match {
@@ -201,7 +201,7 @@ class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
             "If possible, please file a bug on issues.scala-lang.org.")
 
         tp match {
-          case ThisType(ArrayClass)               => ObjectReference // was introduced in 9b17332f11 to fix SI-999, but this code is not reached in its test, or any other test
+          case ThisType(ArrayClass)               => ObjectRef // was introduced in 9b17332f11 to fix SI-999, but this code is not reached in its test, or any other test
           case ThisType(sym)                      => classBTypeFromSymbol(sym)
           case SingleType(_, sym)                 => primitiveOrClassToBType(sym)
           case ConstantType(_)                    => typeToBType(t.underlying)
@@ -460,7 +460,7 @@ class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
       // class info consistent with BCodeHelpers.genMirrorClass
       val nested = exitingPickler(memberClassesForInnerClassTable(moduleClassSym)) map classBTypeFromSymbol
       c.info = Right(ClassInfo(
-        superClass = Some(ObjectReference),
+        superClass = Some(ObjectRef),
         interfaces = Nil,
         flags = asm.Opcodes.ACC_SUPER | asm.Opcodes.ACC_PUBLIC | asm.Opcodes.ACC_FINAL,
         nestedClasses = nested,
@@ -475,7 +475,7 @@ class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
     classBTypeFromInternalName.getOrElse(internalName, {
       val c = ClassBType(internalName)
       c.info = Right(ClassInfo(
-        superClass = Some(ScalaBeanInfoReference),
+        superClass = Some(sbScalaBeanInfoRef),
         interfaces = Nil,
         flags = javaFlags(mainClass),
         nestedClasses = Nil,

--- a/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
@@ -29,7 +29,7 @@ import scala.annotation.switch
 class CoreBTypes[BTFS <: BTypesFromSymbols[_ <: Global]](val bTypes: BTFS) {
   import bTypes._
   import global._
-  import rootMirror.{requiredClass, getClassIfDefined}
+  import rootMirror.{requiredClass, requiredModule, getClassIfDefined}
   import definitions._
 
   /**
@@ -116,6 +116,11 @@ class CoreBTypes[BTFS <: BTypesFromSymbols[_ <: Global]](val bTypes: BTFS) {
   lazy val classCastExceptionReference : ClassBType = classBTypeFromSymbol(ClassCastExceptionClass)   // java/lang/ClassCastException
   lazy val javaUtilMapReference        : ClassBType = classBTypeFromSymbol(JavaUtilMap)               // java/util/Map
   lazy val javaUtilHashMapReference    : ClassBType = classBTypeFromSymbol(JavaUtilHashMap)           // java/util/HashMap
+  lazy val ScalaBeanInfoReference      : ClassBType = classBTypeFromSymbol(requiredClass[scala.beans.ScalaBeanInfo])
+  lazy val jliSerializedLambda         : ClassBType = classBTypeFromSymbol(requiredClass[java.lang.invoke.SerializedLambda])
+  lazy val jliMethodHandles            : ClassBType = classBTypeFromSymbol(requiredClass[java.lang.invoke.MethodHandles])
+  lazy val jliMethodHandlesLookup      : ClassBType = classBTypeFromSymbol(exitingPickler(rootMirror.getRequiredClass("java.lang.invoke.MethodHandles.Lookup")))
+  lazy val srLambdaDeserializer        : ClassBType = classBTypeFromSymbol(requiredModule[scala.runtime.LambdaDeserializer.type].moduleClass)
 
   lazy val srBooleanRef : ClassBType = classBTypeFromSymbol(requiredClass[scala.runtime.BooleanRef])
   lazy val srByteRef    : ClassBType = classBTypeFromSymbol(requiredClass[scala.runtime.ByteRef])
@@ -214,6 +219,11 @@ trait CoreBTypesProxyGlobalIndependent[BTS <: BTypes] {
   def jioSerializableReference: ClassBType
   def javaUtilHashMapReference: ClassBType
   def javaUtilMapReference    : ClassBType
+
+  def jliSerializedLambda     : ClassBType
+  def jliMethodHandles        : ClassBType
+  def jliMethodHandlesLookup  : ClassBType
+  def srLambdaDeserializer    : ClassBType
 }
 
 /**
@@ -264,6 +274,11 @@ final class CoreBTypesProxy[BTFS <: BTypesFromSymbols[_ <: Global]](val bTypes: 
   def classCastExceptionReference : ClassBType = _coreBTypes.classCastExceptionReference
   def javaUtilMapReference        : ClassBType = _coreBTypes.javaUtilMapReference
   def javaUtilHashMapReference    : ClassBType = _coreBTypes.javaUtilHashMapReference
+  def ScalaBeanInfoReference      : ClassBType = _coreBTypes.ScalaBeanInfoReference
+  def jliSerializedLambda         : ClassBType = _coreBTypes.jliSerializedLambda
+  def jliMethodHandles            : ClassBType = _coreBTypes.jliMethodHandles
+  def jliMethodHandlesLookup      : ClassBType = _coreBTypes.jliMethodHandlesLookup
+  def srLambdaDeserializer        : ClassBType = _coreBTypes.srLambdaDeserializer
 
   def srBooleanRef : ClassBType = _coreBTypes.srBooleanRef
   def srByteRef    : ClassBType = _coreBTypes.srByteRef

--- a/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
@@ -48,15 +48,15 @@ class CoreBTypes[BTFS <: BTypesFromSymbols[_ <: Global]](val bTypes: BTFS) {
     DoubleClass  -> DOUBLE
   )
 
-  lazy val BOXED_UNIT    : ClassBType = classBTypeFromSymbol(requiredClass[java.lang.Void])
-  lazy val BOXED_BOOLEAN : ClassBType = classBTypeFromSymbol(BoxedBooleanClass)
-  lazy val BOXED_BYTE    : ClassBType = classBTypeFromSymbol(BoxedByteClass)
-  lazy val BOXED_SHORT   : ClassBType = classBTypeFromSymbol(BoxedShortClass)
-  lazy val BOXED_CHAR    : ClassBType = classBTypeFromSymbol(BoxedCharacterClass)
-  lazy val BOXED_INT     : ClassBType = classBTypeFromSymbol(BoxedIntClass)
-  lazy val BOXED_LONG    : ClassBType = classBTypeFromSymbol(BoxedLongClass)
-  lazy val BOXED_FLOAT   : ClassBType = classBTypeFromSymbol(BoxedFloatClass)
-  lazy val BOXED_DOUBLE  : ClassBType = classBTypeFromSymbol(BoxedDoubleClass)
+  private lazy val BOXED_UNIT    : ClassBType = classBTypeFromSymbol(requiredClass[java.lang.Void])
+  private lazy val BOXED_BOOLEAN : ClassBType = classBTypeFromSymbol(BoxedBooleanClass)
+  private lazy val BOXED_BYTE    : ClassBType = classBTypeFromSymbol(BoxedByteClass)
+  private lazy val BOXED_SHORT   : ClassBType = classBTypeFromSymbol(BoxedShortClass)
+  private lazy val BOXED_CHAR    : ClassBType = classBTypeFromSymbol(BoxedCharacterClass)
+  private lazy val BOXED_INT     : ClassBType = classBTypeFromSymbol(BoxedIntClass)
+  private lazy val BOXED_LONG    : ClassBType = classBTypeFromSymbol(BoxedLongClass)
+  private lazy val BOXED_FLOAT   : ClassBType = classBTypeFromSymbol(BoxedFloatClass)
+  private lazy val BOXED_DOUBLE  : ClassBType = classBTypeFromSymbol(BoxedDoubleClass)
 
   /**
    * Map from primitive types to their boxed class type. Useful when pushing class literals onto the
@@ -95,40 +95,30 @@ class CoreBTypes[BTFS <: BTypesFromSymbols[_ <: Global]](val bTypes: BTFS) {
 
   /*
    * RT_NOTHING and RT_NULL exist at run-time only. They are the bytecode-level manifestation (in
-   * method signatures only) of what shows up as NothingClass resp. NullClass in Scala ASTs.
+   * method signatures only) of what shows up as NothingClass (scala.Nothing) resp. NullClass
+   * (scala.Null) in Scala ASTs.
    *
    * Therefore, when RT_NOTHING or RT_NULL are to be emitted, a mapping is needed: the internal
    * names of NothingClass and NullClass can't be emitted as-is.
    */
-  lazy val RT_NOTHING : ClassBType = classBTypeFromSymbol(requiredClass[scala.runtime.Nothing$])
-  lazy val RT_NULL    : ClassBType = classBTypeFromSymbol(requiredClass[scala.runtime.Null$])
+  lazy val srNothingRef : ClassBType = classBTypeFromSymbol(requiredClass[scala.runtime.Nothing$])
+  lazy val srNullRef    : ClassBType = classBTypeFromSymbol(requiredClass[scala.runtime.Null$])
 
-  lazy val ObjectReference   : ClassBType = classBTypeFromSymbol(ObjectClass)
-  lazy val objArrayReference : ArrayBType = ArrayBType(ObjectReference)
-
-  lazy val StringReference             : ClassBType = classBTypeFromSymbol(StringClass)
-  lazy val StringBuilderReference      : ClassBType = classBTypeFromSymbol(StringBuilderClass)
-  lazy val ThrowableReference          : ClassBType = classBTypeFromSymbol(ThrowableClass)
-  lazy val jlCloneableReference        : ClassBType = classBTypeFromSymbol(JavaCloneableClass)        // java/lang/Cloneable
-  lazy val jlNPEReference              : ClassBType = classBTypeFromSymbol(NullPointerExceptionClass) // java/lang/NullPointerException
-  lazy val jioSerializableReference    : ClassBType = classBTypeFromSymbol(JavaSerializableClass)     // java/io/Serializable
-  lazy val scalaSerializableReference  : ClassBType = classBTypeFromSymbol(SerializableClass)         // scala/Serializable
-  lazy val classCastExceptionReference : ClassBType = classBTypeFromSymbol(ClassCastExceptionClass)   // java/lang/ClassCastException
-  lazy val javaUtilMapReference        : ClassBType = classBTypeFromSymbol(JavaUtilMap)               // java/util/Map
-  lazy val javaUtilHashMapReference    : ClassBType = classBTypeFromSymbol(JavaUtilHashMap)           // java/util/HashMap
-  lazy val ScalaBeanInfoReference      : ClassBType = classBTypeFromSymbol(requiredClass[scala.beans.ScalaBeanInfo])
-  lazy val jliSerializedLambda         : ClassBType = classBTypeFromSymbol(requiredClass[java.lang.invoke.SerializedLambda])
-  lazy val jliMethodHandles            : ClassBType = classBTypeFromSymbol(requiredClass[java.lang.invoke.MethodHandles])
-  lazy val jliMethodHandlesLookup      : ClassBType = classBTypeFromSymbol(exitingPickler(rootMirror.getRequiredClass("java.lang.invoke.MethodHandles.Lookup")))
-  lazy val srLambdaDeserializer        : ClassBType = classBTypeFromSymbol(requiredModule[scala.runtime.LambdaDeserializer.type].moduleClass)
-
-  lazy val srBooleanRef : ClassBType = classBTypeFromSymbol(requiredClass[scala.runtime.BooleanRef])
-  lazy val srByteRef    : ClassBType = classBTypeFromSymbol(requiredClass[scala.runtime.ByteRef])
-  lazy val srCharRef    : ClassBType = classBTypeFromSymbol(requiredClass[scala.runtime.CharRef])
-  lazy val srIntRef     : ClassBType = classBTypeFromSymbol(requiredClass[scala.runtime.IntRef])
-  lazy val srLongRef    : ClassBType = classBTypeFromSymbol(requiredClass[scala.runtime.LongRef])
-  lazy val srFloatRef   : ClassBType = classBTypeFromSymbol(requiredClass[scala.runtime.FloatRef])
-  lazy val srDoubleRef  : ClassBType = classBTypeFromSymbol(requiredClass[scala.runtime.DoubleRef])
+  lazy val ObjectRef                 : ClassBType = classBTypeFromSymbol(ObjectClass)
+  lazy val StringRef                 : ClassBType = classBTypeFromSymbol(StringClass)
+  lazy val jlStringBuilderRef        : ClassBType = classBTypeFromSymbol(StringBuilderClass)
+  lazy val jlThrowableRef            : ClassBType = classBTypeFromSymbol(ThrowableClass)
+  lazy val jlCloneableRef            : ClassBType = classBTypeFromSymbol(JavaCloneableClass)        // java/lang/Cloneable
+  lazy val jiSerializableRef         : ClassBType = classBTypeFromSymbol(JavaSerializableClass)     // java/io/Serializable
+  lazy val jlClassCastExceptionRef   : ClassBType = classBTypeFromSymbol(ClassCastExceptionClass)   // java/lang/ClassCastException
+  lazy val juMapRef                  : ClassBType = classBTypeFromSymbol(JavaUtilMap)               // java/util/Map
+  lazy val juHashMapRef              : ClassBType = classBTypeFromSymbol(JavaUtilHashMap)           // java/util/HashMap
+  lazy val sbScalaBeanInfoRef        : ClassBType = classBTypeFromSymbol(requiredClass[scala.beans.ScalaBeanInfo])
+  lazy val jliSerializedLambdaRef    : ClassBType = classBTypeFromSymbol(requiredClass[java.lang.invoke.SerializedLambda])
+  lazy val jliMethodHandlesRef       : ClassBType = classBTypeFromSymbol(requiredClass[java.lang.invoke.MethodHandles])
+  lazy val jliMethodHandlesLookupRef : ClassBType = classBTypeFromSymbol(exitingPickler(rootMirror.getRequiredClass("java.lang.invoke.MethodHandles.Lookup"))) // didn't find a reliable non-stringly-typed way that works for inner classes in the backend
+  lazy val srLambdaDeserializerRef   : ClassBType = classBTypeFromSymbol(requiredModule[scala.runtime.LambdaDeserializer.type].moduleClass)
+  lazy val srBoxesRunTimeRef         : ClassBType = classBTypeFromSymbol(requiredClass[scala.runtime.BoxesRunTime])
 
   lazy val hashMethodSym: Symbol = getMember(ScalaRunTimeModule, nme.hash_)
 
@@ -146,16 +136,6 @@ class CoreBTypes[BTFS <: BTypesFromSymbols[_ <: Global]](val bTypes: BTFS) {
     })
   }
 
-  // scala.FunctionX and scala.runtim.AbstractFunctionX
-  lazy val FunctionReference         : Vector[ClassBType]   = (0 to MaxFunctionArity).map(i => classBTypeFromSymbol(FunctionClass(i)))(collection.breakOut)
-  lazy val AbstractFunctionReference : Vector[ClassBType]   = (0 to MaxFunctionArity).map(i => classBTypeFromSymbol(AbstractFunctionClass(i)))(collection.breakOut)
-  lazy val AbstractFunctionArityMap  : Map[ClassBType, Int] = AbstractFunctionReference.zipWithIndex.toMap
-
-  lazy val PartialFunctionReference         : ClassBType = classBTypeFromSymbol(PartialFunctionClass)
-  lazy val AbstractPartialFunctionReference : ClassBType = classBTypeFromSymbol(AbstractPartialFunctionClass)
-
-  lazy val BoxesRunTime: ClassBType = classBTypeFromSymbol(requiredClass[scala.runtime.BoxesRunTime])
-
   /**
    * Methods in scala.runtime.BoxesRuntime
    */
@@ -171,14 +151,14 @@ class CoreBTypes[BTFS <: BTypesFromSymbols[_ <: Global]](val bTypes: BTFS) {
   )
 
   lazy val asmUnboxTo: Map[BType, MethodNameAndType] = Map(
-    BOOL   -> MethodNameAndType("unboxToBoolean", MethodBType(List(ObjectReference), BOOL)),
-    BYTE   -> MethodNameAndType("unboxToByte",    MethodBType(List(ObjectReference), BYTE)),
-    CHAR   -> MethodNameAndType("unboxToChar",    MethodBType(List(ObjectReference), CHAR)),
-    SHORT  -> MethodNameAndType("unboxToShort",   MethodBType(List(ObjectReference), SHORT)),
-    INT    -> MethodNameAndType("unboxToInt",     MethodBType(List(ObjectReference), INT)),
-    LONG   -> MethodNameAndType("unboxToLong",    MethodBType(List(ObjectReference), LONG)),
-    FLOAT  -> MethodNameAndType("unboxToFloat",   MethodBType(List(ObjectReference), FLOAT)),
-    DOUBLE -> MethodNameAndType("unboxToDouble",  MethodBType(List(ObjectReference), DOUBLE))
+    BOOL   -> MethodNameAndType("unboxToBoolean", MethodBType(List(ObjectRef), BOOL)),
+    BYTE   -> MethodNameAndType("unboxToByte",    MethodBType(List(ObjectRef), BYTE)),
+    CHAR   -> MethodNameAndType("unboxToChar",    MethodBType(List(ObjectRef), CHAR)),
+    SHORT  -> MethodNameAndType("unboxToShort",   MethodBType(List(ObjectRef), SHORT)),
+    INT    -> MethodNameAndType("unboxToInt",     MethodBType(List(ObjectRef), INT)),
+    LONG   -> MethodNameAndType("unboxToLong",    MethodBType(List(ObjectRef), LONG)),
+    FLOAT  -> MethodNameAndType("unboxToFloat",   MethodBType(List(ObjectRef), FLOAT)),
+    DOUBLE -> MethodNameAndType("unboxToDouble",  MethodBType(List(ObjectRef), DOUBLE))
   )
 
   lazy val typeOfArrayOp: Map[Int, BType] = {
@@ -192,7 +172,7 @@ class CoreBTypes[BTFS <: BTypesFromSymbols[_ <: Global]](val bTypes: BTFS) {
         (List(LARRAY_LENGTH, LARRAY_GET, LARRAY_SET) map (_ -> LONG))   ++
         (List(FARRAY_LENGTH, FARRAY_GET, FARRAY_SET) map (_ -> FLOAT))  ++
         (List(DARRAY_LENGTH, DARRAY_GET, DARRAY_SET) map (_ -> DOUBLE)) ++
-        (List(OARRAY_LENGTH, OARRAY_GET, OARRAY_SET) map (_ -> ObjectReference)) : _*
+        (List(OARRAY_LENGTH, OARRAY_GET, OARRAY_SET) map (_ -> ObjectRef)) : _*
     )
   }
 }
@@ -211,19 +191,17 @@ trait CoreBTypesProxyGlobalIndependent[BTS <: BTypes] {
 
   def boxedClasses: Set[ClassBType]
 
-  def RT_NOTHING: ClassBType
-  def RT_NULL   : ClassBType
-
-  def ObjectReference         : ClassBType
-  def jlCloneableReference    : ClassBType
-  def jioSerializableReference: ClassBType
-  def javaUtilHashMapReference: ClassBType
-  def javaUtilMapReference    : ClassBType
-
-  def jliSerializedLambda     : ClassBType
-  def jliMethodHandles        : ClassBType
-  def jliMethodHandlesLookup  : ClassBType
-  def srLambdaDeserializer    : ClassBType
+  def ObjectRef                 : ClassBType
+  def srNothingRef              : ClassBType
+  def srNullRef                 : ClassBType
+  def jlCloneableRef            : ClassBType
+  def jiSerializableRef         : ClassBType
+  def juHashMapRef              : ClassBType
+  def juMapRef                  : ClassBType
+  def jliSerializedLambdaRef    : ClassBType
+  def jliMethodHandlesRef       : ClassBType
+  def jliMethodHandlesLookupRef : ClassBType
+  def srLambdaDeserializerRef   : ClassBType
 }
 
 /**
@@ -240,53 +218,30 @@ final class CoreBTypesProxy[BTFS <: BTypesFromSymbols[_ <: Global]](val bTypes: 
 
   def primitiveTypeMap: Map[Symbol, PrimitiveBType] = _coreBTypes.primitiveTypeMap
 
-  def BOXED_UNIT    : ClassBType = _coreBTypes.BOXED_UNIT
-  def BOXED_BOOLEAN : ClassBType = _coreBTypes.BOXED_BOOLEAN
-  def BOXED_BYTE    : ClassBType = _coreBTypes.BOXED_BYTE
-  def BOXED_SHORT   : ClassBType = _coreBTypes.BOXED_SHORT
-  def BOXED_CHAR    : ClassBType = _coreBTypes.BOXED_CHAR
-  def BOXED_INT     : ClassBType = _coreBTypes.BOXED_INT
-  def BOXED_LONG    : ClassBType = _coreBTypes.BOXED_LONG
-  def BOXED_FLOAT   : ClassBType = _coreBTypes.BOXED_FLOAT
-  def BOXED_DOUBLE  : ClassBType = _coreBTypes.BOXED_DOUBLE
-
   def boxedClasses: Set[ClassBType] = _coreBTypes.boxedClasses
 
   def boxedClassOfPrimitive: Map[PrimitiveBType, ClassBType] = _coreBTypes.boxedClassOfPrimitive
 
   def boxResultType: Map[Symbol, ClassBType] = _coreBTypes.boxResultType
-
   def unboxResultType: Map[Symbol, PrimitiveBType] = _coreBTypes.unboxResultType
 
-  def RT_NOTHING : ClassBType = _coreBTypes.RT_NOTHING
-  def RT_NULL    : ClassBType = _coreBTypes.RT_NULL
-
-  def ObjectReference   : ClassBType = _coreBTypes.ObjectReference
-  def objArrayReference : ArrayBType = _coreBTypes.objArrayReference
-
-  def StringReference             : ClassBType = _coreBTypes.StringReference
-  def StringBuilderReference      : ClassBType = _coreBTypes.StringBuilderReference
-  def ThrowableReference          : ClassBType = _coreBTypes.ThrowableReference
-  def jlCloneableReference        : ClassBType = _coreBTypes.jlCloneableReference
-  def jlNPEReference              : ClassBType = _coreBTypes.jlNPEReference
-  def jioSerializableReference    : ClassBType = _coreBTypes.jioSerializableReference
-  def scalaSerializableReference  : ClassBType = _coreBTypes.scalaSerializableReference
-  def classCastExceptionReference : ClassBType = _coreBTypes.classCastExceptionReference
-  def javaUtilMapReference        : ClassBType = _coreBTypes.javaUtilMapReference
-  def javaUtilHashMapReference    : ClassBType = _coreBTypes.javaUtilHashMapReference
-  def ScalaBeanInfoReference      : ClassBType = _coreBTypes.ScalaBeanInfoReference
-  def jliSerializedLambda         : ClassBType = _coreBTypes.jliSerializedLambda
-  def jliMethodHandles            : ClassBType = _coreBTypes.jliMethodHandles
-  def jliMethodHandlesLookup      : ClassBType = _coreBTypes.jliMethodHandlesLookup
-  def srLambdaDeserializer        : ClassBType = _coreBTypes.srLambdaDeserializer
-
-  def srBooleanRef : ClassBType = _coreBTypes.srBooleanRef
-  def srByteRef    : ClassBType = _coreBTypes.srByteRef
-  def srCharRef    : ClassBType = _coreBTypes.srCharRef
-  def srIntRef     : ClassBType = _coreBTypes.srIntRef
-  def srLongRef    : ClassBType = _coreBTypes.srLongRef
-  def srFloatRef   : ClassBType = _coreBTypes.srFloatRef
-  def srDoubleRef  : ClassBType = _coreBTypes.srDoubleRef
+  def ObjectRef                 : ClassBType = _coreBTypes.ObjectRef
+  def StringRef                 : ClassBType = _coreBTypes.StringRef
+  def jlStringBuilderRef        : ClassBType = _coreBTypes.jlStringBuilderRef
+  def srNothingRef              : ClassBType = _coreBTypes.srNothingRef
+  def srNullRef                 : ClassBType = _coreBTypes.srNullRef
+  def jlThrowableRef            : ClassBType = _coreBTypes.jlThrowableRef
+  def jlCloneableRef            : ClassBType = _coreBTypes.jlCloneableRef
+  def jiSerializableRef         : ClassBType = _coreBTypes.jiSerializableRef
+  def jlClassCastExceptionRef   : ClassBType = _coreBTypes.jlClassCastExceptionRef
+  def juMapRef                  : ClassBType = _coreBTypes.juMapRef
+  def juHashMapRef              : ClassBType = _coreBTypes.juHashMapRef
+  def sbScalaBeanInfoRef        : ClassBType = _coreBTypes.sbScalaBeanInfoRef
+  def jliSerializedLambdaRef    : ClassBType = _coreBTypes.jliSerializedLambdaRef
+  def jliMethodHandlesRef       : ClassBType = _coreBTypes.jliMethodHandlesRef
+  def jliMethodHandlesLookupRef : ClassBType = _coreBTypes.jliMethodHandlesLookupRef
+  def srLambdaDeserializerRef   : ClassBType = _coreBTypes.srLambdaDeserializerRef
+  def srBoxesRunTimeRef         : ClassBType = _coreBTypes.srBoxesRunTimeRef
 
   def hashMethodSym: Symbol = _coreBTypes.hashMethodSym
 
@@ -296,15 +251,6 @@ final class CoreBTypesProxy[BTFS <: BTypesFromSymbols[_ <: Global]](val bTypes: 
   def BeanInfoAttr: Symbol = _coreBTypes.BeanInfoAttr
 
   def String_valueOf: Symbol = _coreBTypes.String_valueOf
-
-  def FunctionReference         : Vector[ClassBType]   = _coreBTypes.FunctionReference
-  def AbstractFunctionReference : Vector[ClassBType]   = _coreBTypes.AbstractFunctionReference
-  def AbstractFunctionArityMap  : Map[ClassBType, Int] = _coreBTypes.AbstractFunctionArityMap
-
-  def PartialFunctionReference         : ClassBType = _coreBTypes.PartialFunctionReference
-  def AbstractPartialFunctionReference : ClassBType = _coreBTypes.AbstractPartialFunctionReference
-
-  def BoxesRunTime: ClassBType = _coreBTypes.BoxesRunTime
 
   def asmBoxTo  : Map[BType, MethodNameAndType] = _coreBTypes.asmBoxTo
   def asmUnboxTo: Map[BType, MethodNameAndType] = _coreBTypes.asmUnboxTo

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
@@ -245,6 +245,11 @@ abstract class GenBCode extends BCodeSyncAndTry {
         BackendStats.timed(BackendStats.methodOptTimer)(localOpt.methodOptimizations(classNode))
       }
 
+      def setInnerClasses(classNode: ClassNode): Unit = if (classNode != null) {
+        classNode.innerClasses.clear()
+        addInnerClasses(classNode, bTypes.backendUtils.collectNestedClasses(classNode))
+      }
+
       def run() {
         runGlobalOptimizations()
 
@@ -257,6 +262,9 @@ abstract class GenBCode extends BCodeSyncAndTry {
           else {
             try {
               localOptimizations(item.plain)
+              setInnerClasses(item.plain)
+              setInnerClasses(item.mirror)
+              setInnerClasses(item.bean)
               addToQ3(item)
           } catch {
               case e: java.lang.RuntimeException if e.getMessage != null && (e.getMessage contains "too large!") =>

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
@@ -77,10 +77,10 @@ class BackendUtils[BT <: BTypes](val btypes: BT) {
     // stack map frames and invokes the `getCommonSuperClass` method. This method expects all
     // ClassBTypes mentioned in the source code to exist in the map.
 
-    val mapDesc = javaUtilMapReference.descriptor
-    val nilLookupDesc = MethodBType(Nil, jliMethodHandlesLookup).descriptor
-    val serlamObjDesc = MethodBType(jliSerializedLambda :: Nil, ObjectReference).descriptor
-    val lookupMapSerlamObjDesc = MethodBType(jliMethodHandlesLookup :: javaUtilMapReference :: jliSerializedLambda :: Nil, ObjectReference).descriptor
+    val mapDesc = juMapRef.descriptor
+    val nilLookupDesc = MethodBType(Nil, jliMethodHandlesLookupRef).descriptor
+    val serlamObjDesc = MethodBType(jliSerializedLambdaRef :: Nil, ObjectRef).descriptor
+    val lookupMapSerlamObjDesc = MethodBType(jliMethodHandlesLookupRef :: juMapRef :: jliSerializedLambdaRef :: Nil, ObjectRef).descriptor
 
     {
       val fv = cw.visitField(ACC_PRIVATE + ACC_STATIC + ACC_SYNTHETIC, "$deserializeLambdaCache$", mapDesc, null, null)
@@ -96,18 +96,18 @@ class BackendUtils[BT <: BTypes](val btypes: BT) {
       mv.visitVarInsn(ALOAD, 1)
       val l0 = new Label()
       mv.visitJumpInsn(IFNONNULL, l0)
-      mv.visitTypeInsn(NEW, javaUtilHashMapReference.internalName)
+      mv.visitTypeInsn(NEW, juHashMapRef.internalName)
       mv.visitInsn(DUP)
-      mv.visitMethodInsn(INVOKESPECIAL, javaUtilHashMapReference.internalName, "<init>", "()V", false)
+      mv.visitMethodInsn(INVOKESPECIAL, juHashMapRef.internalName, "<init>", "()V", false)
       mv.visitVarInsn(ASTORE, 1)
       mv.visitVarInsn(ALOAD, 1)
       mv.visitFieldInsn(PUTSTATIC, classNode.name, "$deserializeLambdaCache$", mapDesc)
       mv.visitLabel(l0)
-      mv.visitFieldInsn(GETSTATIC, srLambdaDeserializer.internalName, "MODULE$", srLambdaDeserializer.descriptor)
-      mv.visitMethodInsn(INVOKESTATIC, jliMethodHandles.internalName, "lookup", nilLookupDesc, false)
+      mv.visitFieldInsn(GETSTATIC, srLambdaDeserializerRef.internalName, "MODULE$", srLambdaDeserializerRef.descriptor)
+      mv.visitMethodInsn(INVOKESTATIC, jliMethodHandlesRef.internalName, "lookup", nilLookupDesc, false)
       mv.visitVarInsn(ALOAD, 1)
       mv.visitVarInsn(ALOAD, 0)
-      mv.visitMethodInsn(INVOKEVIRTUAL, srLambdaDeserializer.internalName, "deserializeLambda", lookupMapSerlamObjDesc, false)
+      mv.visitMethodInsn(INVOKEVIRTUAL, srLambdaDeserializerRef.internalName, "deserializeLambda", lookupMapSerlamObjDesc, false)
       mv.visitInsn(ARETURN)
       mv.visitEnd()
     }

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
@@ -2,12 +2,14 @@ package scala.tools.nsc
 package backend.jvm
 package analysis
 
-import scala.tools.asm.Label
+import scala.annotation.switch
+import scala.tools.asm.{Handle, Type, Label}
 import scala.tools.asm.tree._
 import scala.tools.asm.tree.analysis.{Frame, BasicInterpreter, Analyzer, Value}
 import scala.tools.nsc.backend.jvm.BTypes._
 import scala.tools.nsc.backend.jvm.opt.BytecodeUtils._
 import java.lang.invoke.LambdaMetafactory
+import scala.collection.mutable
 import scala.collection.convert.decorateAsJava._
 import scala.collection.convert.decorateAsScala._
 
@@ -67,41 +69,45 @@ class BackendUtils[BT <: BTypes](val btypes: BT) {
   def addLambdaDeserialize(classNode: ClassNode): Unit = {
     val cw = classNode
     import scala.tools.asm.Opcodes._
+    import btypes.coreBTypes._
 
-    // Need to force creation of BTypes for these as `getCommonSuperClass` is called on
-    // automatically computing the max stack size (`visitMaxs`) during method writing.
-    btypes.coreBTypes.javaUtilHashMapReference
-    btypes.coreBTypes.javaUtilMapReference
+    // Make sure to reference the ClassBTypes of all types that are used in the code generated
+    // here (e.g. java/util/Map) are initialized. Initializing a ClassBType adds it to the
+    // `classBTypeFromInternalName` map. When writing the classfile, the asm ClassWriter computes
+    // stack map frames and invokes the `getCommonSuperClass` method. This method expects all
+    // ClassBTypes mentioned in the source code to exist in the map.
 
-    // This is fine, even if `visitInnerClass` was called before for MethodHandles.Lookup: duplicates are not emitted.
-    cw.visitInnerClass("java/lang/invoke/MethodHandles$Lookup", "java/lang/invoke/MethodHandles", "Lookup", ACC_PUBLIC + ACC_FINAL + ACC_STATIC)
+    val mapDesc = javaUtilMapReference.descriptor
+    val nilLookupDesc = MethodBType(Nil, jliMethodHandlesLookup).descriptor
+    val serlamObjDesc = MethodBType(jliSerializedLambda :: Nil, ObjectReference).descriptor
+    val lookupMapSerlamObjDesc = MethodBType(jliMethodHandlesLookup :: javaUtilMapReference :: jliSerializedLambda :: Nil, ObjectReference).descriptor
 
     {
-      val fv = cw.visitField(ACC_PRIVATE + ACC_STATIC + ACC_SYNTHETIC, "$deserializeLambdaCache$", "Ljava/util/Map;", null, null)
+      val fv = cw.visitField(ACC_PRIVATE + ACC_STATIC + ACC_SYNTHETIC, "$deserializeLambdaCache$", mapDesc, null, null)
       fv.visitEnd()
     }
 
     {
-      val mv = cw.visitMethod(ACC_PRIVATE + ACC_STATIC + ACC_SYNTHETIC, "$deserializeLambda$", "(Ljava/lang/invoke/SerializedLambda;)Ljava/lang/Object;", null, null)
+      val mv = cw.visitMethod(ACC_PRIVATE + ACC_STATIC + ACC_SYNTHETIC, "$deserializeLambda$", serlamObjDesc, null, null)
       mv.visitCode()
       // javaBinaryName returns the internal name of a class. Also used in BTypesFromsymbols.classBTypeFromSymbol.
-      mv.visitFieldInsn(GETSTATIC, classNode.name, "$deserializeLambdaCache$", "Ljava/util/Map;")
+      mv.visitFieldInsn(GETSTATIC, classNode.name, "$deserializeLambdaCache$", mapDesc)
       mv.visitVarInsn(ASTORE, 1)
       mv.visitVarInsn(ALOAD, 1)
       val l0 = new Label()
       mv.visitJumpInsn(IFNONNULL, l0)
-      mv.visitTypeInsn(NEW, "java/util/HashMap")
+      mv.visitTypeInsn(NEW, javaUtilHashMapReference.internalName)
       mv.visitInsn(DUP)
-      mv.visitMethodInsn(INVOKESPECIAL, "java/util/HashMap", "<init>", "()V", false)
+      mv.visitMethodInsn(INVOKESPECIAL, javaUtilHashMapReference.internalName, "<init>", "()V", false)
       mv.visitVarInsn(ASTORE, 1)
       mv.visitVarInsn(ALOAD, 1)
-      mv.visitFieldInsn(PUTSTATIC, classNode.name, "$deserializeLambdaCache$", "Ljava/util/Map;")
+      mv.visitFieldInsn(PUTSTATIC, classNode.name, "$deserializeLambdaCache$", mapDesc)
       mv.visitLabel(l0)
-      mv.visitFieldInsn(GETSTATIC, "scala/runtime/LambdaDeserializer$", "MODULE$", "Lscala/runtime/LambdaDeserializer$;")
-      mv.visitMethodInsn(INVOKESTATIC, "java/lang/invoke/MethodHandles", "lookup", "()Ljava/lang/invoke/MethodHandles$Lookup;", false)
+      mv.visitFieldInsn(GETSTATIC, srLambdaDeserializer.internalName, "MODULE$", srLambdaDeserializer.descriptor)
+      mv.visitMethodInsn(INVOKESTATIC, jliMethodHandles.internalName, "lookup", nilLookupDesc, false)
       mv.visitVarInsn(ALOAD, 1)
       mv.visitVarInsn(ALOAD, 0)
-      mv.visitMethodInsn(INVOKEVIRTUAL, "scala/runtime/LambdaDeserializer$", "deserializeLambda", "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/util/Map;Ljava/lang/invoke/SerializedLambda;)Ljava/lang/Object;", false)
+      mv.visitMethodInsn(INVOKEVIRTUAL, srLambdaDeserializer.internalName, "deserializeLambda", lookupMapSerlamObjDesc, false)
       mv.visitInsn(ARETURN)
       mv.visitEnd()
     }
@@ -132,5 +138,122 @@ class BackendUtils[BT <: BTypes](val btypes: BT) {
       map += ((ins, cloned))
     }
     (result, map, hasSerializableClosureInstantiation)
+  }
+
+  /**
+   * Visit the class node and collect all referenced nested classes.
+   */
+  def collectNestedClasses(classNode: ClassNode): List[ClassBType] = {
+    val innerClasses = mutable.Set.empty[ClassBType]
+
+    def visitInternalName(internalName: InternalName): Unit = if (internalName != null) {
+      val t = classBTypeFromParsedClassfile(internalName)
+      if (t.isNestedClass.get) innerClasses += t
+    }
+
+    // either an internal/Name or [[Linternal/Name; -- there are certain references in classfiles
+    // that are either an internal name (without the surrounding `L;`) or an array descriptor
+    // `[Linternal/Name;`.
+    def visitInternalNameOrArrayReference(ref: String): Unit = if (ref != null) {
+      val bracket = ref.lastIndexOf('[')
+      if (bracket == -1) visitInternalName(ref)
+      else if (ref.charAt(bracket + 1) == 'L') visitInternalName(ref.substring(bracket + 2, ref.length - 1))
+    }
+
+    // we are only interested in the class references in the descriptor, so we can skip over
+    // primitves and the brackets of array descriptors
+    def visitDescriptor(desc: String): Unit = (desc.charAt(0): @switch) match {
+      case '(' =>
+        val internalNames = mutable.ListBuffer.empty[String]
+        var i = 1
+        while (i < desc.length) {
+          if (desc.charAt(i) == 'L') {
+            val start = i + 1 // skip the L
+            while (desc.charAt(i) != ';') i += 1
+            internalNames append desc.substring(start, i)
+          }
+          // skips over '[', ')', primitives
+          i += 1
+        }
+        internalNames foreach visitInternalName
+
+      case 'L' =>
+        visitInternalName(desc.substring(1, desc.length - 1))
+
+      case '[' =>
+        visitInternalNameOrArrayReference(desc)
+
+      case _ => // skip over primitive types
+    }
+
+    def visitConstant(const: AnyRef): Unit = const match {
+      case t: Type => visitDescriptor(t.getDescriptor)
+      case _ =>
+    }
+
+    // in principle we could references to annotation types, as they only end up as strings in the
+    // constant pool, not as class references. however, the java compiler still includes nested
+    // annotation classes in the innerClass table, so we do the same. explained in detail in the
+    // large comment in class BTypes.
+    def visitAnnotation(annot: AnnotationNode): Unit = {
+      visitDescriptor(annot.desc)
+      if (annot.values != null) annot.values.asScala foreach visitConstant
+    }
+
+    def visitAnnotations(annots: java.util.List[_ <: AnnotationNode]) = if (annots != null) annots.asScala foreach visitAnnotation
+    def visitAnnotationss(annotss: Array[java.util.List[AnnotationNode]]) = if (annotss != null) annotss foreach visitAnnotations
+
+    def visitHandle(handle: Handle): Unit = {
+      visitInternalNameOrArrayReference(handle.getOwner)
+      visitDescriptor(handle.getDesc)
+    }
+
+    visitInternalName(classNode.name)
+    innerClasses ++= classBTypeFromParsedClassfile(classNode.name).info.get.nestedClasses
+
+    visitInternalName(classNode.superName)
+    classNode.interfaces.asScala foreach visitInternalName
+    visitInternalName(classNode.outerClass)
+
+    visitAnnotations(classNode.visibleAnnotations)
+    visitAnnotations(classNode.visibleTypeAnnotations)
+    visitAnnotations(classNode.invisibleAnnotations)
+    visitAnnotations(classNode.invisibleTypeAnnotations)
+
+    for (f <- classNode.fields.asScala) {
+      visitDescriptor(f.desc)
+      visitAnnotations(f.visibleAnnotations)
+      visitAnnotations(f.visibleTypeAnnotations)
+      visitAnnotations(f.invisibleAnnotations)
+      visitAnnotations(f.invisibleTypeAnnotations)
+    }
+
+    for (m <- classNode.methods.asScala) {
+      visitDescriptor(m.desc)
+
+      visitAnnotations(m.visibleAnnotations)
+      visitAnnotations(m.visibleTypeAnnotations)
+      visitAnnotations(m.invisibleAnnotations)
+      visitAnnotations(m.invisibleTypeAnnotations)
+      visitAnnotationss(m.visibleParameterAnnotations)
+      visitAnnotationss(m.invisibleParameterAnnotations)
+      visitAnnotations(m.visibleLocalVariableAnnotations)
+      visitAnnotations(m.invisibleLocalVariableAnnotations)
+
+      m.exceptions.asScala foreach visitInternalName
+      for (tcb <- m.tryCatchBlocks.asScala) visitInternalName(tcb.`type`)
+
+      val iter = m.instructions.iterator()
+      while (iter.hasNext) iter.next() match {
+        case ti: TypeInsnNode           => visitInternalNameOrArrayReference(ti.desc)
+        case fi: FieldInsnNode          => visitInternalNameOrArrayReference(fi.owner); visitDescriptor(fi.desc)
+        case mi: MethodInsnNode         => visitInternalNameOrArrayReference(mi.owner); visitDescriptor(mi.desc)
+        case id: InvokeDynamicInsnNode  => visitDescriptor(id.desc); visitHandle(id.bsm); id.bsmArgs foreach visitConstant
+        case ci: LdcInsnNode            => visitConstant(ci.cst)
+        case ma: MultiANewArrayInsnNode => visitDescriptor(ma.desc)
+        case _ =>
+      }
+    }
+    innerClasses.toList
   }
 }

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
@@ -310,9 +310,9 @@ object BytecodeUtils {
    * method which explains the issue with such phantom values.
    */
   def fixLoadedNothingOrNullValue(loadedType: Type, loadInstr: AbstractInsnNode, methodNode: MethodNode, bTypes: BTypes): Unit = {
-    if (loadedType == bTypes.coreBTypes.RT_NOTHING.toASMType) {
+    if (loadedType == bTypes.coreBTypes.srNothingRef.toASMType) {
       methodNode.instructions.insert(loadInstr, new InsnNode(Opcodes.ATHROW))
-    } else if (loadedType == bTypes.coreBTypes.RT_NULL.toASMType) {
+    } else if (loadedType == bTypes.coreBTypes.srNullRef.toASMType) {
       methodNode.instructions.insert(loadInstr, new InsnNode(Opcodes.ACONST_NULL))
       methodNode.instructions.insert(loadInstr, new InsnNode(Opcodes.POP))
     }

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
@@ -20,7 +20,7 @@ import scala.collection.convert.decorateAsScala._
 object BytecodeUtils {
 
   // http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.9.1
-  final val maxJVMMethodSize         = 65535
+  final val maxJVMMethodSize = 65535
 
   // 5% margin, more than enough for the instructions added by the inliner (store / load args, null check for instance methods)
   final val maxMethodSizeAfterInline = maxJVMMethodSize - (maxJVMMethodSize / 20)

--- a/test/files/jvm/innerClassAttribute/Classes_1.scala
+++ b/test/files/jvm/innerClassAttribute/Classes_1.scala
@@ -13,7 +13,7 @@ object A3 {
 
 class A4 {
   def f(l: List[String]): List[String] = {
-    l map (_ + "1")
+    l map (_ + "1") : @noinline // inlining adds a reference to the nested class scala/collection/generic/GenTraversableFactory$GenericCanBuildFrom
   }
 }
 
@@ -274,8 +274,8 @@ object NestedInValueClass {
   class A(val arg: String) extends AnyVal {
     // A has InnerClass entries for the two closures (and for A and A$). not for B / C
     def f = {
-      def g = List().map(x => ((s: String) => x)) // outer class A, no outer method (g is moved to the companion, doesn't exist in A)
-      g.map(x => ((s: String) => x))              // outer class A, outer method f
+      def g = List().map(x => ((s: String) => x)): @noinline // outer class A, no outer method (g is moved to the companion, doesn't exist in A)
+      g.map(x => ((s: String) => x)): @noinline              // outer class A, outer method f
     }
     // statements and field declarations are not allowed in value classes
   }

--- a/test/files/jvm/innerClassAttribute/Test.scala
+++ b/test/files/jvm/innerClassAttribute/Test.scala
@@ -23,7 +23,7 @@ object Test extends BytecodeTest {
 
   def testInner(cls: String, fs: (InnerClassNode => Unit)*) = {
     val ns = innerClassNodes(cls)
-    assert(ns.length == fs.length, ns)
+    assert(ns.length == fs.length, ns.map(_.name))
     (ns zip fs.toList) foreach { case (n, f) => f(n) }
   }
 


### PR DESCRIPTION
The InnerClass attribute needs to contain an entry for every nested
class that is defined or referenced in a class. Details are in a
doc comment in BTypes.scala.

Instead of collecting ClassBTypes of nested classes into a hash map
during code generation, traverse the class before writing it out to
disk. The previous approach was incorrect as soon as the generated
bytecode was modified by the optimzier (DCE, inlining).

Fixes https://github.com/scala/scala-dev/issues/21.

The second commit contains cleanups in CoreBTypes
