### PR TITLE
SI-9527 Fix NPE in ambiguous implicit error generation

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -1250,13 +1250,14 @@ trait ContextErrors {
           )
         }
 
-        def treeTypeArgs(annotatedTree: Tree) = annotatedTree match {
+        def treeTypeArgs(annotatedTree: Tree): List[String] = annotatedTree match {
           case TypeApply(_, args) => args.map(_.toString)
+          case Block(_, Function(_, treeInfo.Applied(_, targs, _))) => targs.map(_.toString) // eta expansion, see neg/t9527b.scala
           case _ => Nil
         }
 
         context.issueAmbiguousError(AmbiguousImplicitTypeError(tree,
-          (tree1.symbol, tree2.symbol) match {
+          (info1.sym, info2.sym) match {
             case (ImplicitAmbiguousMsg(msg), _) => msg.format(treeTypeArgs(tree1))
             case (_, ImplicitAmbiguousMsg(msg)) => msg.format(treeTypeArgs(tree2))
             case (_, _) if isView => viewMsg

--- a/test/files/neg/t9527a.check
+++ b/test/files/neg/t9527a.check
@@ -1,0 +1,7 @@
+t9527a.scala:5: error: ambiguous implicit values:
+ both method f in class C of type (x: Int)String
+ and method g in class C of type (x: Int)String
+ match expected type Int => String
+    implicitly[Int => String]
+              ^
+one error found

--- a/test/files/neg/t9527a.scala
+++ b/test/files/neg/t9527a.scala
@@ -1,0 +1,8 @@
+class C {
+  implicit def f(x: Int): String = "f was here"
+  implicit def g(x: Int): String = "f was here"
+  def test: Unit = {
+    implicitly[Int => String]
+  }
+}
+

--- a/test/files/neg/t9527b.check
+++ b/test/files/neg/t9527b.check
@@ -1,0 +1,4 @@
+t9527b.scala:6: error: msg A=Nothing
+    implicitly[Int => String]
+              ^
+one error found

--- a/test/files/neg/t9527b.scala
+++ b/test/files/neg/t9527b.scala
@@ -1,0 +1,9 @@
+class C {
+  @annotation.implicitAmbiguous("msg A=${A}")
+  implicit def f[A](x: Int): String = "f was here"
+  implicit def g(x: Int): String = "f was here"
+  def test: Unit = {
+    implicitly[Int => String]
+  }
+}
+


### PR DESCRIPTION
In #4673, an annotation was added to allow customization of the
compiler error for ambigous implicits. This change had incorrect
assumptions about the shape of trees that would be generated during
implicit search, and failed to account for the results of eta expanded
methods when searching for a function type.

This commit:
- Uses the symbol from `ImpilcitInfo`, rather than calling
  `Tree#symbol` which is fraught with the danger of returning a
  null symbol for something other than an application.
- Adds a test for customized messages for a polymorphic, eta
  expanded method, and generalizes `treeTypeArgs` to handle the
  implicit tree of shape `{ (x: X) => f[A](x)}`.

Review by @adriaanm 
