### PR TITLE
Multi output problem with delambdafied compilation

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -35,26 +35,14 @@ abstract class BCodeHelpers extends BCodeIdiomatic with BytecodeWriters {
   /*
    * must-single-thread
    */
-  def getOutFolder(csym: Symbol, cName: String, cunit: CompilationUnit): _root_.scala.tools.nsc.io.AbstractFile = Option {
-      try {
-        outputDirectory(csym)
-      } catch {
-        case ex: Throwable =>
-          reporter.warning(cunit.body.pos, s"Couldn't find output folder for symbol source ${csym.name}. Dropping to compliation unit source.\n${ex.getMessage}")
-          null
-      }
-    }.orElse { Option {
-      try {
-        outputDirectory(cunit.source)
-      } catch {
-        case ex: Throwable =>
-          reporter.warning(cunit.body.pos, s"Couldn't find output folder for compilation unit $cName\n${ex.getMessage}")
-	  null
-      }
-    }}.orElse {
-      reporter.error(cunit.body.pos, s"Couldn't create file for class $cName")
-      None
-    }.orNull
+  def getOutFolder(csym: Symbol, cName: String, cunit: CompilationUnit): _root_.scala.tools.nsc.io.AbstractFile =
+    _root_.scala.util.Try {
+      outputDirectory(csym)
+    }.recover {
+      case ex: Throwable =>
+        reporter.error(cunit.body.pos, s"Couldn't create file for class $cName\n${ex.getMessage}")
+        null
+    }.get
 
   var pickledBytes = 0 // statistics
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -35,15 +35,26 @@ abstract class BCodeHelpers extends BCodeIdiomatic with BytecodeWriters {
   /*
    * must-single-thread
    */
-  def getOutFolder(csym: Symbol, cName: String, cunit: CompilationUnit): _root_.scala.tools.nsc.io.AbstractFile = {
-    try {
-      outputDirectory(csym)
-    } catch {
-      case ex: Throwable =>
-        reporter.error(cunit.body.pos, s"Couldn't create file for class $cName\n${ex.getMessage}")
-        null
-    }
-  }
+  def getOutFolder(csym: Symbol, cName: String, cunit: CompilationUnit): _root_.scala.tools.nsc.io.AbstractFile = Option {
+      try {
+        outputDirectory(csym)
+      } catch {
+        case ex: Throwable =>
+          reporter.warning(cunit.body.pos, s"Couldn't find output folder for symbol source ${csym.name}. Dropping to compliation unit source.\n${ex.getMessage}")
+          null
+      }
+    }.orElse { Option {
+      try {
+        outputDirectory(cunit.source)
+      } catch {
+        case ex: Throwable =>
+          reporter.warning(cunit.body.pos, s"Couldn't find output folder for compilation unit $cName\n${ex.getMessage}")
+	  null
+      }
+    }}.orElse {
+      reporter.error(cunit.body.pos, s"Couldn't create file for class $cName")
+      None
+    }.orNull
 
   var pickledBytes = 0 // statistics
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BytecodeWriters.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BytecodeWriters.scala
@@ -25,9 +25,6 @@ trait BytecodeWriters {
   def outputDirectory(sym: Symbol): AbstractFile =
     settings.outputDirs outputDirFor enteringFlatten(sym.sourceFile)
 
-  def outputDirectory(cunitSource: scala.reflect.internal.util.SourceFile): AbstractFile =
-    settings.outputDirs outputDirFor cunitSource.file
-
   /**
    * @param clsName cls.getName
    */

--- a/src/compiler/scala/tools/nsc/backend/jvm/BytecodeWriters.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BytecodeWriters.scala
@@ -25,6 +25,9 @@ trait BytecodeWriters {
   def outputDirectory(sym: Symbol): AbstractFile =
     settings.outputDirs outputDirFor enteringFlatten(sym.sourceFile)
 
+  def outputDirectory(cunitSource: scala.reflect.internal.util.SourceFile): AbstractFile =
+    settings.outputDirs outputDirFor cunitSource.file
+
   /**
    * @param clsName cls.getName
    */

--- a/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
+++ b/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
@@ -294,6 +294,7 @@ abstract class Delambdafy extends Transform with TypingTransformers with ast.Tre
         val name = unit.freshTypeName(s"$oldClassPart$suffix".replace("$anon", "$nestedInAnon"))
 
         val lambdaClass = pkg newClassSymbol(name, originalFunction.pos, FINAL | SYNTHETIC) addAnnotation SerialVersionUIDAnnotation
+        lambdaClass.associatedFile = unit.source.file
         // make sure currentRun.compiles(lambdaClass) is true (AddInterfaces does the same for trait impl classes)
         currentRun.symSource(lambdaClass) = funOwner.sourceFile
         lambdaClass setInfo ClassInfoType(parents, newScope, lambdaClass)

--- a/test/junit/scala/tools/nsc/transform/delambdafy/DelambdafyTest.scala
+++ b/test/junit/scala/tools/nsc/transform/delambdafy/DelambdafyTest.scala
@@ -1,0 +1,73 @@
+package scala.tools.nsc.transform.delambdafy
+
+import scala.reflect.io.Path.jfile2path
+import scala.tools.nsc.backend.jvm.CodeGenTools.getGeneratedClassfiles
+import scala.tools.nsc.backend.jvm.CodeGenTools.makeSourceFile
+import scala.tools.nsc.backend.jvm.CodeGenTools.newCompilerWithoutVirtualOutdir
+import scala.tools.nsc.io.AbstractFile
+import scala.tools.testing.TempDir
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class DelambdafyTest {
+  def compileToMultipleOutputWithDelamdbafyMethod(): List[(String, Array[Byte])] = {
+    val codeForMultiOutput = """
+object Delambdafy {
+  type -->[D, I] = PartialFunction[D, I]
+
+  def main(args: Array[String]): Unit = {
+    val result = List(1, 2, 4).map { a =>
+      val list = List("1", "2", "3").map { _ + "test" }
+      list.find { _ == a.toString + "test" }
+    }
+    println(result)
+    lazy val _foo = foo(result) {
+      case x :: xs if x isDefined => x.get.length
+      case _ => 0
+    }
+    println(_foo)
+    lazy val bar: Int => Int = {
+      case 2 => 23
+      case _ =>
+        val v = List(1).map { _ + 42 }.head
+        v + 31
+    }
+    bar(3)
+    lazy val _baz = baz {
+      case 1 =>
+        val local = List(1).map(_ + 1)
+        local.head
+    }
+  }
+
+  def baz[T](f: Any --> Any): Any => Any = f
+
+  def foo(b: List[Option[String]])(a: List[Option[String]] => Int): Int = a(b)
+}
+"""
+    val srcFile = makeSourceFile(codeForMultiOutput, "delambdafyTest.scala")
+    val outDir = AbstractFile.getDirectory(TempDir.createTempDir())
+    val outDirPath = outDir.canonicalPath
+    val extraArgs = "-Ybackend:GenBCode -Ydelambdafy:method"
+    val argsWithOutDir = extraArgs + s" -d $outDirPath -cp $outDirPath"
+    val compiler = newCompilerWithoutVirtualOutdir(extraArgs = argsWithOutDir)
+    compiler.settings.outputDirs.add(srcFile.file, outDir)
+
+    new compiler.Run().compileSources(List(srcFile))
+
+    val classfiles = getGeneratedClassfiles(outDir)
+    outDir.delete()
+    classfiles
+  }
+  
+  @Test
+  def shouldFindOutputFoldersForAllPromotedLambdasAsMethod(): Unit = {
+    val actual = compileToMultipleOutputWithDelamdbafyMethod()
+
+    assertTrue(actual.length > 0)
+  }
+}


### PR DESCRIPTION
User code compilation with -Ybackend:GenBCode -Ydelambdafy:method
fails for projects with multiple output directories.
The problem has its root in a fact that some `lambdaClass` symbols
the `associatedFile` field is not set. It can be done in Delambdafy.scala
(`makeAnonymousClass` method) and is working for following lambda
examples:

```
package acme

object Delambdafy {
  type -->[D, I] = PartialFunction[D, I]

  def main(args: Array[String]): Unit = {
    val result = List(1, 2, 4).map { a =>
      val list = List("1", "2", "3").map { _ + "test" }
      list.find { _ == a.toString + "test" }
    }
    lazy val _foo = foo(result) {
      case x::xs if x isDefined => x.get.length
      case _ => 0
    }
    lazy val bar: Int => Int = {
      case 2 => 13
      case _ =>
        val v = List(1).map(_ + 42).head
    v + 1
    }
  }
  def foo(b: List[Option[String]])(a: List[Option[String]] => Int): Int =
  a(b)
}
```

but is NOT working for following lambda:

```
package acme

object Delambdafy {
  type -->[D, I] = PartialFunction[D, I]

  def main(args: Array[String]): Unit = {
    lazy val _baz = baz {
      case 1 =>
        val local = List(1).map(_ + 1)
    local.head
    }
  }
  def baz[T](f: Any --> Any): Any => Any = f
}
```

so that's why source of compilation unit is used to determine output
directory in case when source file is not found for symbol.
