### PR TITLE
SI-9497 Fix SetLike#clear() default implementation

### DIFF
--- a/src/library/scala/collection/mutable/SetLike.scala
+++ b/src/library/scala/collection/mutable/SetLike.scala
@@ -129,7 +129,9 @@ trait SetLike[A, +This <: SetLike[A, This] with Set[A]]
   /** Removes all elements from the set. After this operation is completed,
    *  the set will be empty.
    */
-  def clear() { foreach(-=) }
+  def clear(): Unit =
+    for (elem <- this.toList)
+      this -= elem
 
   override def clone(): This = empty ++= repr.seq
 

--- a/test/junit/scala/collection/mutable/SetLikeTest.scala
+++ b/test/junit/scala/collection/mutable/SetLikeTest.scala
@@ -1,0 +1,26 @@
+package scala.collection.mutable
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class SetLikeTest {
+
+  class MySet(self: Set[String]) extends Set[String] with SetLike[String, MySet] {
+    override def -=(elem: String) = { self -= elem; this }
+    override def +=(elem: String) = { self += elem; this }
+
+    override def empty = new MySet(self.empty)
+    override def iterator = self.iterator
+    override def contains(elem: String) = self.contains(elem)
+  }
+
+  @Test
+  def hasCorrectClear() {
+    val s = new MySet(Set("EXPOSEDNODE", "CONNECTABLE"))
+    s.clear()
+    assertEquals(new MySet(Set()), s)
+  }
+}


### PR DESCRIPTION
When dealing with mutable collections, it is not safe to assume iterators will remain consistent when the collection is modified mid-traversal. The bug reported in [SI-9497](https://issues.scala-lang.org/browse/SI-9497) is very similar to [SI-7269](https://issues.scala-lang.org/browse/SI-7269), "ConcurrentModificationException when filtering converted Java HashMap". Then, only the `retain` method was fixed. This commit fixes `clear`, which had the same problem.
