### PR TITLE
More efficient way to compute maxLocals / maxStack

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/AliasingFrame.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/AliasingFrame.scala
@@ -93,7 +93,7 @@ class AliasingFrame[V <: Value](nLocals: Int, nStack: Int) extends Frame[V](nLoc
     def peekStack(n: Int): V = this.peekStack(n)
 
     // the val pattern `val (p, c) = f` still allocates a tuple (https://github.com/scala-opt/scala/issues/28)
-    val prodCons = InstructionStackEffect(insn, this) // needs to be called before super.execute, see its doc
+    val prodCons = InstructionStackEffect.forAsmAnalysis(insn, this) // needs to be called before super.execute, see its doc
     val consumed = prodCons._1
     val produced = prodCons._2
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/AliasingFrame.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/AliasingFrame.scala
@@ -92,10 +92,9 @@ class AliasingFrame[V <: Value](nLocals: Int, nStack: Int) extends Frame[V](nLoc
     def stackTop: Int = this.stackTop
     def peekStack(n: Int): V = this.peekStack(n)
 
-    // the val pattern `val (p, c) = f` still allocates a tuple (https://github.com/scala-opt/scala/issues/28)
     val prodCons = InstructionStackEffect.forAsmAnalysis(insn, this) // needs to be called before super.execute, see its doc
-    val consumed = prodCons._1
-    val produced = prodCons._2
+    val consumed = InstructionStackEffect.cons(prodCons)
+    val produced = InstructionStackEffect.prod(prodCons)
 
     super.execute(insn, interpreter)
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
@@ -337,8 +337,8 @@ class BackendUtils[BT <: BTypes](val btypes: BT) {
         if (insn.getOpcode == -1) { // frames, labels, line numbers
           enqInsnIndex(insnIndex + 1, initHeight)
         } else {
-          val (cons, prod) = InstructionStackEffect.forAsmAnalysisConservative(insn)
-          val heightAfter = initHeight - cons + prod
+          val stackGrowth = InstructionStackEffect.maxStackGrowth(insn)
+          val heightAfter = initHeight + stackGrowth
           if (heightAfter > maxStack) maxStack = heightAfter
 
           // update maxLocals

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/InstructionStackEffect.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/InstructionStackEffect.scala
@@ -5,35 +5,84 @@ package analysis
 import scala.annotation.switch
 import scala.tools.asm.Opcodes._
 import scala.tools.asm.Type
-import scala.tools.asm.tree.{MultiANewArrayInsnNode, InvokeDynamicInsnNode, MethodInsnNode, AbstractInsnNode}
+import scala.tools.asm.tree._
 import scala.tools.asm.tree.analysis.{Frame, Value}
 import opt.BytecodeUtils._
-import collection.immutable
 
 object InstructionStackEffect {
-  private var cache: immutable.IntMap[(Int, Int)] = immutable.IntMap.empty
+  // x up to 10, which covers most cases and limits the cache. y doesn't go above 6 (see cases).
+  val maxCachedX = 10
+  val maxCachedY = 6
+  val xShift = 3
+  private val cache = new Array[(Int, Int)]((maxCachedX << xShift) + maxCachedY + 1)
   private def t(x: Int, y: Int): (Int, Int) = {
-    // x can go up to 255 (number of parameters of a method, dimensions in multianewarray) we cache
-    // x up to 10, which covers most cases and limits the cache. y doesn't go above 6 (see cases).
-    if (x > 10 || y > 6) (x, y)
+    if (x > maxCachedX || y > maxCachedY) (x, y)
     else {
-      val key = (x << 8) + y // this would work for any x < 256
-      if (cache contains key) {
+      val key = (x << xShift) + y
+      if (cache(key) != null) {
         cache(key)
       } else {
         val r = (x, y)
-        cache += key -> r
+        cache(key) = r
         r
       }
     }
   }
 
   /**
-   * Returns a pair with the number of stack values consumed and produced by `insn`.
-   * This method requires the `frame` to be in the state **before** executing / interpreting
-   * the `insn`.
+   * Returns a pair with the number of stack values consumed and produced by `insn`. The returned
+   * values are correct for use in asm's Analyzer framework. For example, a LLOAD instruction
+   * produces one stack value. See also doc in `analysis` package object.
+   *
+   * This method requires the `frame` to be in the state **before** executing / interpreting the
+   * `insn`.
    */
-  def apply[V <: Value](insn: AbstractInsnNode, frame: Frame[V]): (Int, Int) = {
+  def forAsmAnalysis[V <: Value](insn: AbstractInsnNode, frame: Frame[V]): (Int, Int) = computeConsProd(insn, frame = frame)
+
+  /**
+   * Returns a pair with the number of stack values consumed and produced by `insn`. The returned
+   * values are usually the same as used in asm's Analyzer framework, but they may be larger. For
+   * example, consider a POP2 instruction:
+   *   - if two size-1 values are popped, then the asm Analyzer consumes two values
+   *   - if a size-2 value is popped, the asm Analyzer consumes only one stack slot (see doc in the
+   *     `analysis` package object
+   *
+   * If a precise result is needed, invoke the `forAsmAnalysis` and provide a `frame` value that
+   * allows looking up the sizes of values on the stack.
+   *
+   * When the precise stack effect is unknown, this method returns values that are safe for
+   * computing an upper bound on the stack size for running an Analyzer: (prod - cons) is the
+   * largest possible value for any input sizes.
+   */
+  def forAsmAnalysisConservative(insn: AbstractInsnNode): (Int, Int) = computeConsProd(insn, conservative = true)
+
+  /**
+   * Returns a pair with the number of stack values consumed and produced by `insn`. The returned
+   * values are correct for writing into a classfile (see doc on `analysis` package object).
+   */
+  def forClassfile(insn: AbstractInsnNode): (Int, Int) = computeConsProd(insn, forClassfile = true)
+
+  private def invokeConsProd(methodDesc: String, insn: AbstractInsnNode, forClassfile: Boolean): (Int, Int) = {
+    val consumesReceiver = insn.getOpcode != INVOKESTATIC && insn.getOpcode != INVOKEDYNAMIC
+    if (forClassfile) {
+      val sizes = Type.getArgumentsAndReturnSizes(methodDesc)
+      val cons = (sizes >> 2) - (if (consumesReceiver) 0 else 1)
+      val prod = sizes & 0x03
+      t(cons, prod)
+    } else {
+      val cons = Type.getArgumentTypes(methodDesc).length + (if (consumesReceiver) 1 else 0)
+      val prod = if (Type.getReturnType(methodDesc) == Type.VOID_TYPE) 0 else 1
+      t(cons, prod)
+    }
+  }
+
+  private def fieldInsnIsLongOrDouble(insn: AbstractInsnNode) = {
+    val d = insn.asInstanceOf[FieldInsnNode].desc
+    d == "J" || d == "D"
+  }
+
+  private def computeConsProd[V <: Value](insn: AbstractInsnNode, forClassfile: Boolean = false, conservative: Boolean = false, frame: Frame[V] = null): (Int, Int) = {
+    // not used if `forClassfile || conservative`: in these cases, `frame` is allowed to be `null`
     def peekStack(n: Int): V = frame.peekStack(n)
 
     (insn.getOpcode: @switch) match {
@@ -48,142 +97,176 @@ object InstructionStackEffect {
            ICONST_3 |
            ICONST_4 |
            ICONST_5 |
-           LCONST_0 |
-           LCONST_1 |
            FCONST_0 |
            FCONST_1 |
            FCONST_2 |
-           DCONST_0 |
-           DCONST_1 |
            BIPUSH |
            SIPUSH |
-           LDC |
            ILOAD |
-           LLOAD |
            FLOAD |
-           DLOAD |
            ALOAD => t(0, 1)
 
+      case LDC =>
+        if (forClassfile) insn.asInstanceOf[LdcInsnNode].cst match {
+          case _: java.lang.Long | _: java.lang.Double => t(0, 2)
+          case _ => t(0, 1)
+        } else
+          t(0, 1)
+
+      case LCONST_0 |
+           LCONST_1 |
+           DCONST_0 |
+           DCONST_1 |
+           LLOAD |
+           DLOAD => if (forClassfile) t(0, 2) else t(0, 1)
+
       case IALOAD |
-           LALOAD |
            FALOAD |
-           DALOAD |
            AALOAD |
            BALOAD |
            CALOAD |
            SALOAD => t(2, 1)
 
+      case LALOAD |
+           DALOAD => if (forClassfile) t(2, 2) else t(2, 1)
+
       case ISTORE |
-           LSTORE |
            FSTORE |
-           DSTORE |
            ASTORE => t(1, 0)
 
+      case LSTORE |
+           DSTORE => if (forClassfile) t(2, 0) else t(1, 0)
+
       case IASTORE |
-           LASTORE |
            FASTORE |
-           DASTORE |
            AASTORE |
            BASTORE |
            CASTORE |
            SASTORE => t(3, 0)
 
+      case LASTORE |
+           DASTORE => if (forClassfile) t(4, 0) else t(3, 0)
+
       case POP => t(1, 0)
 
       case POP2 =>
-        val isSize2 = peekStack(0).getSize == 2
-        if (isSize2) t(1, 0) else t(2, 0)
+        if (forClassfile) t(2, 0)
+        else if (conservative) t(1, 0)
+        else {
+          val isSize2 = peekStack(0).getSize == 2
+          if (isSize2) t(1, 0) else t(2, 0)
+        }
 
       case DUP => t(1, 2)
 
       case DUP_X1 => t(2, 3)
 
       case DUP_X2 =>
-        val isSize2 = peekStack(1).getSize == 2
-        if (isSize2) t(2, 3) else t(3, 4)
+        if (forClassfile || conservative) t(3, 4)
+        else {
+          val isSize2 = peekStack(1).getSize == 2
+          if (isSize2) t(2, 3) else t(3, 4)
+        }
 
       case DUP2 =>
-        val isSize2 = peekStack(0).getSize == 2
-        if (isSize2) t(1, 2) else t(2, 4)
+        if (forClassfile || conservative) t(2, 4)
+        else {
+          val isSize2 = peekStack(0).getSize == 2
+          if (isSize2) t(1, 2) else t(2, 4)
+        }
 
       case DUP2_X1 =>
-        val isSize2 = peekStack(0).getSize == 2
-        if (isSize2) t(2, 3) else t(3, 4)
+        if (forClassfile || conservative) t(3, 5)
+        else {
+          val isSize2 = peekStack(0).getSize == 2
+          if (isSize2) t(2, 3) else t(3, 5)
+        }
 
       case DUP2_X2 =>
-        val v1isSize2 = peekStack(0).getSize == 2
-        if (v1isSize2) {
-          val v2isSize2 = peekStack(1).getSize == 2
-          if (v2isSize2) t(2, 3) else t(3, 4)
-        } else {
-          val v3isSize2 = peekStack(2).getSize == 2
-          if (v3isSize2) t(3, 5) else t(4, 6)
+        if (forClassfile || conservative) t(4, 6)
+        else {
+          val v1isSize2 = peekStack(0).getSize == 2
+          if (v1isSize2) {
+            val v2isSize2 = peekStack(1).getSize == 2
+            if (v2isSize2) t(2, 3) else t(3, 4)
+          } else {
+            val v3isSize2 = peekStack(2).getSize == 2
+            if (v3isSize2) t(3, 5) else t(4, 6)
+          }
         }
 
       case SWAP => t(2, 2)
 
       case IADD |
-           LADD |
            FADD |
-           DADD |
            ISUB |
-           LSUB |
            FSUB |
-           DSUB |
            IMUL |
-           LMUL |
            FMUL |
-           DMUL |
            IDIV |
-           LDIV |
            FDIV |
-           DDIV |
            IREM |
+           FREM => t(2, 1)
+
+      case LADD |
+           DADD |
+           LSUB |
+           DSUB |
+           LMUL |
+           DMUL |
+           LDIV |
+           DDIV |
            LREM |
-           FREM |
-           DREM => t(2, 1)
+           DREM => if (forClassfile) t(4, 2) else t(2, 1)
 
       case INEG |
-           LNEG |
-           FNEG |
-           DNEG => t(1, 1)
+           FNEG => t(1, 1)
+
+      case LNEG |
+           DNEG => if (forClassfile) t(2, 2) else t(1, 1)
 
       case ISHL |
-           LSHL |
            ISHR |
-           LSHR |
            IUSHR |
-           LUSHR |
            IAND |
-           LAND |
            IOR |
+           IXOR => t(2, 1)
+
+      case LSHL |
+           LSHR |
+           LUSHR => if (forClassfile) t(3, 2) else t(2, 1)
+
+      case LAND |
            LOR |
-           IXOR |
-           LXOR => t(2, 1)
+           LXOR => if (forClassfile) t(4, 2) else t(2, 1)
 
       case IINC => t(0, 0)
 
-      case I2L |
-           I2F |
-           I2D |
-           L2I |
-           L2F |
-           L2D |
+      case I2F |
            F2I |
-           F2L |
-           F2D |
-           D2I |
-           D2L |
-           D2F |
            I2B |
            I2C |
            I2S => t(1, 1)
 
+      case I2L |
+           I2D |
+           F2L |
+           F2D => if (forClassfile) t(1, 2) else t(1, 1)
+
+      case L2I |
+           L2F |
+           D2I |
+           D2F => if (forClassfile) t(2, 1) else t(1, 1)
+
+      case L2D |
+           D2L => if (forClassfile) t(2, 2) else t(1, 1)
+
+      case FCMPL |
+           FCMPG => t(2, 1)
+
       case LCMP |
-           FCMPL |
-           FCMPG |
            DCMPL |
-           DCMPG => t(2, 1)
+           DCMPG => if (forClassfile) t(4, 1) else t(2, 1)
 
       case IFEQ |
            IFNE |
@@ -211,35 +294,36 @@ object InstructionStackEffect {
            LOOKUPSWITCH => t(1, 0)
 
       case IRETURN |
-           LRETURN |
            FRETURN |
-           DRETURN |
            ARETURN => t(1, 0) // Frame.execute consumes one stack value
+
+      case LRETURN |
+           DRETURN => if (forClassfile) t(2, 0) else t(1, 0)
 
       case RETURN => t(0, 0) // Frame.execute does not change the stack
 
-      case GETSTATIC => t(0, 1)
+      case GETSTATIC =>
+        val prod = if (forClassfile && fieldInsnIsLongOrDouble(insn)) 2 else 1
+        t(0, prod)
 
-      case PUTSTATIC => t(1, 0)
+      case PUTSTATIC =>
+        val cons = if (forClassfile && fieldInsnIsLongOrDouble(insn)) 2 else 1
+        t(cons, 0)
 
-      case GETFIELD => t(1, 1)
+      case GETFIELD =>
+        val prod = if (forClassfile && fieldInsnIsLongOrDouble(insn)) 2 else 1
+        t(1, prod)
 
-      case PUTFIELD => t(2, 0)
+      case PUTFIELD =>
+        val cons = if (forClassfile && fieldInsnIsLongOrDouble(insn)) 3 else 2
+        t(cons, 0)
 
       case INVOKEVIRTUAL |
            INVOKESPECIAL |
            INVOKESTATIC |
-           INVOKEINTERFACE =>
-        val desc = insn.asInstanceOf[MethodInsnNode].desc
-        val cons = Type.getArgumentTypes(desc).length + (if (insn.getOpcode == INVOKESTATIC) 0 else 1)
-        val prod = if (Type.getReturnType(desc) == Type.VOID_TYPE) 0 else 1
-        t(cons, prod)
+           INVOKEINTERFACE => invokeConsProd(insn.asInstanceOf[MethodInsnNode].desc, insn, forClassfile)
 
-      case INVOKEDYNAMIC =>
-        val desc = insn.asInstanceOf[InvokeDynamicInsnNode].desc
-        val cons = Type.getArgumentTypes(desc).length
-        val prod = if (Type.getReturnType(desc) == Type.VOID_TYPE) 0 else 1
-        t(cons, prod)
+      case INVOKEDYNAMIC => invokeConsProd(insn.asInstanceOf[InvokeDynamicInsnNode].desc, insn, forClassfile)
 
       case NEW => t(0, 1)
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/ProdConsAnalyzerImpl.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/ProdConsAnalyzerImpl.scala
@@ -368,9 +368,9 @@ trait ProdConsAnalyzerImpl {
       Seq(insn.asInstanceOf[IincInsnNode].`var`)
     } else {
       val frame = frameAt(insn)
-      val stackEffect = InstructionStackEffect.forAsmAnalysis(insn, frame)
+      val prodCons = InstructionStackEffect.forAsmAnalysis(insn, frame)
       val stackSize = frame.getLocals + frame.getStackSize
-      (stackSize - stackEffect._1) until stackSize
+      (stackSize - InstructionStackEffect.cons(prodCons)) until stackSize
     }
   }
 
@@ -387,10 +387,10 @@ trait ProdConsAnalyzerImpl {
         Seq(insn.asInstanceOf[IincInsnNode].`var`)
       } else {
         val frame = frameAt(insn)
-        val stackEffect = InstructionStackEffect.forAsmAnalysis(insn, frame)
+        val prodCons = InstructionStackEffect.forAsmAnalysis(insn, frame)
         val nextFrame = frameAt(insn.getNext)
         val stackSize = nextFrame.getLocals + nextFrame.getStackSize
-        (stackSize - stackEffect._2) until stackSize
+        (stackSize - InstructionStackEffect.prod(prodCons)) until stackSize
       }
   }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/ProdConsAnalyzerImpl.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/ProdConsAnalyzerImpl.scala
@@ -368,7 +368,7 @@ trait ProdConsAnalyzerImpl {
       Seq(insn.asInstanceOf[IincInsnNode].`var`)
     } else {
       val frame = frameAt(insn)
-      val stackEffect = InstructionStackEffect(insn, frame)
+      val stackEffect = InstructionStackEffect.forAsmAnalysis(insn, frame)
       val stackSize = frame.getLocals + frame.getStackSize
       (stackSize - stackEffect._1) until stackSize
     }
@@ -387,7 +387,7 @@ trait ProdConsAnalyzerImpl {
         Seq(insn.asInstanceOf[IincInsnNode].`var`)
       } else {
         val frame = frameAt(insn)
-        val stackEffect = InstructionStackEffect(insn, frame)
+        val stackEffect = InstructionStackEffect.forAsmAnalysis(insn, frame)
         val nextFrame = frameAt(insn.getNext)
         val stackSize = nextFrame.getLocals + nextFrame.getStackSize
         (stackSize - stackEffect._2) until stackSize

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/CallGraph.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/CallGraph.scala
@@ -91,95 +91,94 @@ class CallGraph[BT <: BTypes](val btypes: BT) {
     if (!callsites.contains(methodNode)) addMethod(methodNode, definingClass)
   }
 
-  /**
-   * Returns a list of callsites in the method, plus a list of closure instantiation indy instructions.
-   */
   def addMethod(methodNode: MethodNode, definingClass: ClassBType): Unit = {
-    // TODO: run dataflow analyses to make the call graph more precise
-    //  - producers to get forwarded parameters (ForwardedParam)
-    //  - typeAnalysis for more precise argument types, more precise callee
+    if (!BytecodeUtils.isAbstractMethod(methodNode) && !BytecodeUtils.isNativeMethod(methodNode)) {
+      // TODO: run dataflow analyses to make the call graph more precise
+      //  - producers to get forwarded parameters (ForwardedParam)
+      //  - typeAnalysis for more precise argument types, more precise callee
 
-    // For now we run a NullnessAnalyzer. It is used to determine if the receiver of an instance
-    // call is known to be not-null, in which case we don't have to emit a null check when inlining.
-    // It is also used to get the stack height at the call site.
+      // For now we run a NullnessAnalyzer. It is used to determine if the receiver of an instance
+      // call is known to be not-null, in which case we don't have to emit a null check when inlining.
+      // It is also used to get the stack height at the call site.
 
-    val analyzer = {
-      if (compilerSettings.YoptNullnessTracking && AsmAnalyzer.sizeOKForNullness(methodNode)) {
-        Some(new AsmAnalyzer(methodNode, definingClass.internalName, new NullnessAnalyzer))
-      } else if (AsmAnalyzer.sizeOKForBasicValue(methodNode)) {
-        Some(new AsmAnalyzer(methodNode, definingClass.internalName))
-      } else None
-    }
-
-    // if the method is too large to run an analyzer, it is not added to the call graph
-    if (analyzer.nonEmpty) {
-      val Some(a) = analyzer
-      def receiverNotNullByAnalysis(call: MethodInsnNode, numArgs: Int) = a.analyzer match {
-        case nullnessAnalyzer: NullnessAnalyzer =>
-          val frame = nullnessAnalyzer.frameAt(call, methodNode)
-          frame.getStack(frame.getStackSize - 1 - numArgs) eq NotNullValue
-        case _ => false
+      val analyzer = {
+        if (compilerSettings.YoptNullnessTracking && AsmAnalyzer.sizeOKForNullness(methodNode)) {
+          Some(new AsmAnalyzer(methodNode, definingClass.internalName, new NullnessAnalyzer))
+        } else if (AsmAnalyzer.sizeOKForBasicValue(methodNode)) {
+          Some(new AsmAnalyzer(methodNode, definingClass.internalName))
+        } else None
       }
 
-      var methodCallsites = Map.empty[MethodInsnNode, Callsite]
-      var methodClosureInstantiations = Map.empty[InvokeDynamicInsnNode, ClosureInstantiation]
+      // if the method is too large to run an analyzer, it is not added to the call graph
+      if (analyzer.nonEmpty) {
+        val Some(a) = analyzer
+        def receiverNotNullByAnalysis(call: MethodInsnNode, numArgs: Int) = a.analyzer match {
+          case nullnessAnalyzer: NullnessAnalyzer =>
+            val frame = nullnessAnalyzer.frameAt(call, methodNode)
+            frame.getStack(frame.getStackSize - 1 - numArgs) eq NotNullValue
+          case _ => false
+        }
 
-      // lazy so it is only computed if actually used by computeArgInfos
-      lazy val prodCons = new ProdConsAnalyzer(methodNode, definingClass.internalName)
+        var methodCallsites = Map.empty[MethodInsnNode, Callsite]
+        var methodClosureInstantiations = Map.empty[InvokeDynamicInsnNode, ClosureInstantiation]
 
-      methodNode.instructions.iterator.asScala foreach {
-        case call: MethodInsnNode if a.frameAt(call) != null => // skips over unreachable code
-          val callee: Either[OptimizerWarning, Callee] = for {
-            (method, declarationClass)     <- byteCodeRepository.methodNode(call.owner, call.name, call.desc): Either[OptimizerWarning, (MethodNode, InternalName)]
-            (declarationClassNode, source) <- byteCodeRepository.classNodeAndSource(declarationClass): Either[OptimizerWarning, (ClassNode, Source)]
-          } yield {
-              val declarationClassBType = classBTypeFromClassNode(declarationClassNode)
-              val CallsiteInfo(safeToInline, safeToRewrite, annotatedInline, annotatedNoInline, samParamTypes, warning) = analyzeCallsite(method, declarationClassBType, call.owner, source)
-              Callee(
-                callee = method,
-                calleeDeclarationClass = declarationClassBType,
-                safeToInline = safeToInline,
-                safeToRewrite = safeToRewrite,
-                annotatedInline = annotatedInline,
-                annotatedNoInline = annotatedNoInline,
-                samParamTypes = samParamTypes,
-                calleeInfoWarning = warning)
+        // lazy so it is only computed if actually used by computeArgInfos
+        lazy val prodCons = new ProdConsAnalyzer(methodNode, definingClass.internalName)
+
+        methodNode.instructions.iterator.asScala foreach {
+          case call: MethodInsnNode if a.frameAt(call) != null => // skips over unreachable code
+            val callee: Either[OptimizerWarning, Callee] = for {
+              (method, declarationClass)     <- byteCodeRepository.methodNode(call.owner, call.name, call.desc): Either[OptimizerWarning, (MethodNode, InternalName)]
+              (declarationClassNode, source) <- byteCodeRepository.classNodeAndSource(declarationClass): Either[OptimizerWarning, (ClassNode, Source)]
+            } yield {
+                val declarationClassBType = classBTypeFromClassNode(declarationClassNode)
+                val CallsiteInfo(safeToInline, safeToRewrite, annotatedInline, annotatedNoInline, samParamTypes, warning) = analyzeCallsite(method, declarationClassBType, call.owner, source)
+                Callee(
+                  callee = method,
+                  calleeDeclarationClass = declarationClassBType,
+                  safeToInline = safeToInline,
+                  safeToRewrite = safeToRewrite,
+                  annotatedInline = annotatedInline,
+                  annotatedNoInline = annotatedNoInline,
+                  samParamTypes = samParamTypes,
+                  calleeInfoWarning = warning)
+              }
+
+            val argInfos = computeArgInfos(callee, call, prodCons)
+
+            val receiverNotNull = call.getOpcode == Opcodes.INVOKESTATIC || {
+              val numArgs = Type.getArgumentTypes(call.desc).length
+              receiverNotNullByAnalysis(call, numArgs)
             }
 
-          val argInfos = computeArgInfos(callee, call, prodCons)
+            methodCallsites += call -> Callsite(
+              callsiteInstruction = call,
+              callsiteMethod = methodNode,
+              callsiteClass = definingClass,
+              callee = callee,
+              argInfos = argInfos,
+              callsiteStackHeight = a.frameAt(call).getStackSize,
+              receiverKnownNotNull = receiverNotNull,
+              callsitePosition = callsitePositions.getOrElse(call, NoPosition),
+              annotatedInline = inlineAnnotatedCallsites(call),
+              annotatedNoInline = noInlineAnnotatedCallsites(call)
+            )
 
-          val receiverNotNull = call.getOpcode == Opcodes.INVOKESTATIC || {
-            val numArgs = Type.getArgumentTypes(call.desc).length
-            receiverNotNullByAnalysis(call, numArgs)
-          }
+          case LambdaMetaFactoryCall(indy, samMethodType, implMethod, instantiatedMethodType) if a.frameAt(indy) != null =>
+            val lmf = LambdaMetaFactoryCall(indy, samMethodType, implMethod, instantiatedMethodType)
+            val capturedArgInfos = computeCapturedArgInfos(lmf, prodCons)
+            methodClosureInstantiations += indy -> ClosureInstantiation(
+              lmf,
+              methodNode,
+              definingClass,
+              capturedArgInfos)
 
-          methodCallsites += call -> Callsite(
-            callsiteInstruction = call,
-            callsiteMethod = methodNode,
-            callsiteClass = definingClass,
-            callee = callee,
-            argInfos = argInfos,
-            callsiteStackHeight = a.frameAt(call).getStackSize,
-            receiverKnownNotNull = receiverNotNull,
-            callsitePosition = callsitePositions.getOrElse(call, NoPosition),
-            annotatedInline = inlineAnnotatedCallsites(call),
-            annotatedNoInline = noInlineAnnotatedCallsites(call)
-          )
+          case _ =>
+        }
 
-        case LambdaMetaFactoryCall(indy, samMethodType, implMethod, instantiatedMethodType) if a.frameAt(indy) != null =>
-          val lmf = LambdaMetaFactoryCall(indy, samMethodType, implMethod, instantiatedMethodType)
-          val capturedArgInfos = computeCapturedArgInfos(lmf, prodCons)
-          methodClosureInstantiations += indy -> ClosureInstantiation(
-            lmf,
-            methodNode,
-            definingClass,
-            capturedArgInfos)
-
-        case _ =>
+        callsites(methodNode) = methodCallsites
+        closureInstantiations(methodNode) = methodClosureInstantiations
       }
-
-      callsites(methodNode) = methodCallsites
-      closureInstantiations(methodNode) = methodClosureInstantiations
     }
   }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/InstructionResultSize.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/InstructionResultSize.scala
@@ -33,14 +33,10 @@ object InstructionResultSize {
 
     case LDC =>
       instruction.asInstanceOf[LdcInsnNode].cst match {
-        case _: java.lang.Integer |
-             _: java.lang.Float |
-             _: String |
-             _: Type |
-             _: Handle => 1
-
         case _: java.lang.Long |
              _: java.lang.Double => 2
+
+        case _ => 1
       }
 
     case ILOAD |


### PR DESCRIPTION
In order to run an asm Analyzer, the maxLocals / maxStack values of
the method need to be computed. Asm doesn't provide an efficient
built-in for this purpose, but it computes these values while
serializing a class.

Previously, we used to serialize the method just to compute the max's,
which is inefficient. This commit implements a separate, efficient
traversal.

The computed values are also smaller, allowing to save space when
running an Analyzer: asm Analyzers only allocate a single stack slot
for long/double values, while the JVM allocates two. The maxStack
computed previously would always use two slots, which is not
necessary.

The new calculation was verified to be correct in the following way:
as a test, i left the old computation in place, ran the new one in
addition (in a special mode where the long/double values take two
slots) and asserted equality. Bootstrapping and test suite passed.
