### PR TITLE
Add Extractor and apply Method for SoftReference

### DIFF
--- a/src/library/scala/ref/SoftReference.scala
+++ b/src/library/scala/ref/SoftReference.scala
@@ -20,6 +20,19 @@ class SoftReference[+T <: AnyRef](value : T, queue : ReferenceQueue[T]) extends 
 }
 
 /**
+ *  A companion object that implements an extractor for `SoftReference` values
+ *  @author Rebecca Claire Murphy
+ */
+object SoftReference {
+
+  /** Creates a `SoftReference` pointing to `value` */
+  def apply[T <: AnyRef](value: T) = new SoftReference(value)
+
+  /** Optionally returns the referenced value, or `None` if that value no longer exists */
+  def unapply[T <: AnyRef](sr: SoftReference[T]): Option[T] = Option(sr.underlying.get)
+}
+
+/**
  *  @author Philipp Haller
  */
 private class SoftReferenceWithWrapper[T <: AnyRef](value: T, queue: ReferenceQueue[T], val wrapper: SoftReference[T])


### PR DESCRIPTION
`scala.ref.WeakReference` has two features which are lacking in `scala.ref.SoftReference`, an extractor and a `.apply` method, that greatly enhance the usability of that class.  This commit simply replicates that functionality for `SoftReference`.

This is #4812 reopened against `2.12.x`
