### PR TITLE
Repl should early-init its phase global

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
@@ -44,8 +44,9 @@ trait ReplGlobal extends Global {
     }
   }
 
-  object replPhase extends SubComponent {
+  object replPhase extends {
     val global: ReplGlobal.this.type = ReplGlobal.this
+  } with SubComponent {
     val phaseName = "repl"
     val runsAfter = List[String]("typer")
     val runsRightAfter = None
@@ -59,8 +60,8 @@ trait ReplGlobal extends Global {
     override val requires = List("typer")  // ensure they didn't -Ystop-after:parser
   }
 
-  override protected def computePhaseDescriptors: List[SubComponent] = {
+  override protected def computeInternalPhases(): Unit = {
     addToPhasesSet(replPhase, "repl")
-    super.computePhaseDescriptors
+    super.computeInternalPhases()
   }
 }

--- a/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
@@ -44,24 +44,8 @@ trait ReplGlobal extends Global {
     }
   }
 
-  object replPhase extends {
-    val global: ReplGlobal.this.type = ReplGlobal.this
-  } with SubComponent {
-    val phaseName = "repl"
-    val runsAfter = List[String]("typer")
-    val runsRightAfter = None
-    def newPhase(_prev: Phase): StdPhase = new StdPhase(_prev) {
-      def apply(unit: CompilationUnit) {
-        repldbg("Running replPhase on " + unit.body)
-        // newNamer(rootContext(unit)).enterSym(unit.body)
-      }
-    }
-    // add to initial or terminal phase to sanity check Run at construction
-    override val requires = List("typer")  // ensure they didn't -Ystop-after:parser
-  }
-
   override protected def computeInternalPhases(): Unit = {
-    addToPhasesSet(replPhase, "repl")
+    //addToPhasesSet(replPhase, "repl")
     super.computeInternalPhases()
   }
 }


### PR DESCRIPTION
They're threatening to throw NPE if your SubComponent doesn't
have an early definition of global, so change it now in REPL.

Also, contribute replPhase as an internal phase.
