### PR TITLE
SI-4950 Test reduction

### DIFF
--- a/test/files/run/t4950.check
+++ b/test/files/run/t4950.check
@@ -1,7 +1,0 @@
-
-scala> val 1 = 2
-scala.MatchError: 2 (of class java.lang.Integer)
-
-scala> val List(1) = List(1)
-
-scala> :quit

--- a/test/files/run/t4950.scala
+++ b/test/files/run/t4950.scala
@@ -1,12 +1,24 @@
-import scala.tools.partest.ReplTest
+import scala.tools.partest.SessionTest
+import scala.PartialFunction.{ cond => when }
 
-object Test extends ReplTest {
+object Elision {
+  val elideMsg = """  ... \d+ elided""".r
+}
+
+object Test extends SessionTest {
+  import Elision._
+
   // Filter out the abbreviated stacktrace "... X elided" 
   // because the number seems to differ between versions/platforms/...
-  override def show = eval() filterNot (_ contains "elided") foreach println
-  def code =
+  def elided(s: String) = when(s) { case elideMsg() => true }
+  override def eval() = super.eval() filterNot elided
+  def session =
 """
-val 1 = 2
-val List(1) = List(1)
+scala> val 1 = 2
+scala.MatchError: 2 (of class java.lang.Integer)
+
+scala> val List(1) = List(1)
+
+scala> :quit
 """
 }


### PR DESCRIPTION
A session test with filtering best expresses the intentions.

No check file is required.
