### PR TITLE
SI-9535 correct bytecode and generic signatures for @throws[TypeParam]

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3653,7 +3653,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       val annType = annTpt.tpe
 
       finish(
-        if (typedFun.isErroneous)
+        if (typedFun.isErroneous || annType == null)
           ErroneousAnnotation
         else if (annType.typeSymbol isNonBottomSubClass ClassfileAnnotationClass) {
           // annotation to be saved as java classfile annotation

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2964,7 +2964,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       loop(info)
     }
 
-    override def exceptions = annotations flatMap ThrownException.unapply
+    override def exceptions = for (ThrownException(tp) <- annotations) yield tp.typeSymbol
   }
   implicit val MethodSymbolTag = ClassTag[MethodSymbol](classOf[MethodSymbol])
 

--- a/test/files/neg/t9535.check
+++ b/test/files/neg/t9535.check
@@ -1,0 +1,7 @@
+t9535.scala:4: error: not found: type E1
+  @throws[E1] def f[E1 <: Exception] = 1
+          ^
+t9535.scala:6: error: class type required but E found
+  @throws(classOf[E]) def g: E = ??? // neg test: classOf requires class type
+                  ^
+two errors found

--- a/test/files/neg/t9535.scala
+++ b/test/files/neg/t9535.scala
@@ -1,0 +1,7 @@
+class C[E <: Exception] {
+  // cannot be expressed in Scala (it's allowed in Java)
+  // https://issues.scala-lang.org/browse/SI-7066
+  @throws[E1] def f[E1 <: Exception] = 1
+
+  @throws(classOf[E]) def g: E = ??? // neg test: classOf requires class type
+}

--- a/test/files/run/t9535.scala
+++ b/test/files/run/t9535.scala
@@ -1,0 +1,22 @@
+class C[E <: Exception] {
+  @throws[E] def f = 1
+
+  @throws(classOf[Exception]) def g: E = ???
+
+  @throws[E] @throws[Exception] def h = 1
+}
+
+object Test extends App {
+  val c = classOf[C[_]]
+  def sig(method: String) = c.getDeclaredMethod(method).toString
+  def genSig(method: String) = c.getDeclaredMethod(method).toGenericString
+
+  assert(sig("f") == "public int C.f() throws java.lang.Exception")
+  assert(genSig("f") == "public int C.f() throws E")
+
+  assert(sig("g") == "public java.lang.Exception C.g() throws java.lang.Exception")
+  assert(genSig("g") == "public E C.g() throws java.lang.Exception")
+
+  assert(sig("h") == "public int C.h() throws java.lang.Exception,java.lang.Exception")
+  assert(genSig("h") == "public int C.h() throws E,java.lang.Exception")
+}


### PR DESCRIPTION
For @throws[E] where E is not a class type, GenASM incorrectly writes
the non-class type to the classfile. GenBCode used to crash before
this commit. Now GenBCode correctly emits the erased type (like
javac) and adds a generic signature.
