### PR TITLE
SI-9178 Don't eta expand to an Function0-like SAM expected type

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -862,7 +862,14 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           case Block(_, tree1) => tree1.symbol
           case _               => tree.symbol
         }
-        if (!meth.isConstructor && (isFunctionType(pt) || samOf(pt).exists)) { // (4.2)
+        def shouldEtaExpandToSam: Boolean = {
+          // SI-9536 don't adapt parameterless method types to a to SAM's, fall through to empty application
+          // instead for backwards compatiblity with 2.11. See comments of that ticket and SI-7187
+          // for analogous trouble with non-SAM eta expansion. Suggestions there are: a) deprecate eta expansion to Function0,
+          // or b) switch the order of eta-expansion and empty application in this adaptation.
+          !mt.params.isEmpty && samOf(pt).exists
+        }
+        if (!meth.isConstructor && (isFunctionType(pt) || shouldEtaExpandToSam)) { // (4.2)
           debuglog(s"eta-expanding $tree: ${tree.tpe} to $pt")
           checkParamsConvertible(tree, tree.tpe)
           val tree0 = etaExpand(context.unit, tree, this)

--- a/test/files/pos/t9178.flags
+++ b/test/files/pos/t9178.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -deprecation

--- a/test/files/pos/t9178.scala
+++ b/test/files/pos/t9178.scala
@@ -1,0 +1,13 @@
+// eta expansion to Function0 is problematic (as shown here).
+// Perhaps we should we deprecate it? See discussion in the comments of
+// on SI-9178.
+//
+// This test encodes the status quo: no deprecation.
+object Test {
+  def foo(): () => String = () => ""
+  val f: () => Any = foo
+
+  def main(args: Array[String]): Unit = {
+    println(f()) // <function0>
+  }
+}

--- a/test/files/pos/t9178b.flags
+++ b/test/files/pos/t9178b.flags
@@ -1,0 +1,1 @@
+-Xexperimental

--- a/test/files/pos/t9178b.scala
+++ b/test/files/pos/t9178b.scala
@@ -1,0 +1,7 @@
+abstract class Test{
+  val writeInput: java.io.OutputStream => Unit
+  def getOutputStream(): java.io.OutputStream
+
+  writeInput(getOutputStream)
+}
+

--- a/test/files/run/t9178a.flags
+++ b/test/files/run/t9178a.flags
@@ -1,0 +1,1 @@
+-Xexperimental

--- a/test/files/run/t9178a.scala
+++ b/test/files/run/t9178a.scala
@@ -1,0 +1,15 @@
+trait Sam { def apply(): Unit }
+abstract class Test {
+  def foo(): Sam
+  // no parens, instantiateToMethodType would wrap in a `new Sam { def apply = foo }`
+  // rather than applying to an empty param list() */
+  val f: Sam = foo
+}
+
+object Test extends Test {
+  lazy val samIAm = new Sam { def apply() {} }
+  def foo() = samIAm
+  def main(args: Array[String]): Unit = {
+    assert(f eq samIAm, f)
+  }
+}

--- a/test/files/run/t9489.flags
+++ b/test/files/run/t9489.flags
@@ -1,0 +1,1 @@
+-Xexperimental

--- a/test/files/run/t9489/A.java
+++ b/test/files/run/t9489/A.java
@@ -1,0 +1,3 @@
+public class A {
+  public B b() { return null; }
+}

--- a/test/files/run/t9489/B.java
+++ b/test/files/run/t9489/B.java
@@ -1,0 +1,3 @@
+public abstract class B {
+  public abstract int m();
+}

--- a/test/files/run/t9489/test.scala
+++ b/test/files/run/t9489/test.scala
@@ -1,0 +1,10 @@
+class T {
+  def f(a: A) = g(a.b) // was: "found Int, required B"
+  def g(b: => B) = null
+}
+
+object Test extends T {
+  def main(args: Array[String]): Unit = {
+    f(new A)
+  }
+}


### PR DESCRIPTION
Otherwise, we can end up with a subtle source incompatibility with
the pre-SAM regime. Arguably we should phase out eta expansion to
Function0 as well, but I'll leave that for another day.

Review by @adriaanm 
