### PR TITLE
Add SeqLike.get

### DIFF
--- a/src/library/scala/collection/SeqLike.scala
+++ b/src/library/scala/collection/SeqLike.scala
@@ -68,6 +68,12 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
 
   def apply(idx: Int): A
 
+  def get(idx: Int): Option[A] =
+    if (idx >= 0 && idx < length)
+      Some(apply(idx))
+    else
+      None
+
   protected[this] override def parCombiner = ParSeq.newCombiner[A]
 
   /** Compares the length of this $coll to a test value.

--- a/src/library/scala/collection/mutable/LinkedListLike.scala
+++ b/src/library/scala/collection/mutable/LinkedListLike.scala
@@ -156,7 +156,7 @@ trait LinkedListLike[A, This <: Seq[A] with LinkedListLike[A, This]] extends Seq
   override def apply(n: Int): A   = atLocation(n)(_.elem)
   def update(n: Int, x: A): Unit  = atLocation(n)(_.elem = x)
 
-  def get(n: Int): Option[A] = {
+  override def get(n: Int): Option[A] = {
     val loc = drop(n)
     if (loc.nonEmpty) Some(loc.elem)
     else None

--- a/src/library/scala/collection/mutable/MutableList.scala
+++ b/src/library/scala/collection/mutable/MutableList.scala
@@ -92,7 +92,7 @@ extends AbstractSeq[A]
   /** Returns the `n`-th element of this list or `None`
    *  if index does not exist.
    */
-  def get(n: Int): Option[A] = first0.get(n)
+  override def get(n: Int): Option[A] = first0.get(n)
 
   protected def prependElem(elem: A) {
     first0 = new LinkedList[A](elem, first0)


### PR DESCRIPTION
This adds `get` as a safe alternative to the unsafe `apply`, just like
the get/apply in Map.

I originally just wanted this in `Vector` but `SeqLike` seems like the right place for this.
