### PR TITLE
SI-6162 Make @deprecated{Inheritance,Overriding} public

### DIFF
--- a/src/library/scala/deprecatedInheritance.scala
+++ b/src/library/scala/deprecatedInheritance.scala
@@ -19,5 +19,4 @@ package scala
  *  @since  2.10
  *  @see    [[scala.deprecatedOverriding]]
  */
-private[scala] // for now, this needs to be generalized to communicate other modifier deltas
 class deprecatedInheritance(message: String = "", since: String = "") extends scala.annotation.StaticAnnotation

--- a/src/library/scala/deprecatedOverriding.scala
+++ b/src/library/scala/deprecatedOverriding.scala
@@ -17,5 +17,4 @@ package scala
  *  @since  2.10
  *  @see    [[scala.deprecatedInheritance]]
  */
-private[scala] // for the same reasons as deprecatedInheritance
 class deprecatedOverriding(message: String = "", since: String = "") extends scala.annotation.StaticAnnotation


### PR DESCRIPTION
It was kept private first with the expectation that further modifier
changes might warrant a more extensible design.

Until now, there doesn't seem to have appeared other interesting
use-cases that warranted a design overhaul.

This commit makes the existing annotations public to allow all Scala
developers to benefit from it.
