### PR TITLE
Make scala.math compile under Dotty

### DIFF
--- a/src/library/scala/math/Fractional.scala
+++ b/src/library/scala/math/Fractional.scala
@@ -17,7 +17,7 @@ import scala.language.implicitConversions
 trait Fractional[T] extends Numeric[T] {
   def div(x: T, y: T): T
 
-  class FractionalOps(lhs: T) extends Ops(lhs) {
+  class FractionalOps(lhs: T) extends NumericOps(lhs) {
     def /(rhs: T) = div(lhs, rhs)
   }
   override implicit def mkNumericOps(lhs: T): FractionalOps =

--- a/src/library/scala/math/Integral.scala
+++ b/src/library/scala/math/Integral.scala
@@ -20,7 +20,7 @@ trait Integral[T] extends Numeric[T] {
   def quot(x: T, y: T): T
   def rem(x: T, y: T): T
 
-  class IntegralOps(lhs: T) extends Ops(lhs) {
+  class IntegralOps(lhs: T) extends NumericOps(lhs) {
     def /(rhs: T) = quot(lhs, rhs)
     def %(rhs: T) = rem(lhs, rhs)
     def /%(rhs: T) = (quot(lhs, rhs), rem(lhs, rhs))

--- a/src/library/scala/math/Numeric.scala
+++ b/src/library/scala/math/Numeric.scala
@@ -23,7 +23,7 @@ object Numeric {
      *  def plus[T: Numeric](x: T, y: T) = x + y
      *  }}}
      */
-    implicit def infixNumericOps[T](x: T)(implicit num: Numeric[T]): Numeric[T]#Ops = new num.Ops(x)
+    implicit def infixNumericOps[T](x: T)(implicit num: Numeric[T]): Numeric[T]#NumericOps = new num.NumericOps(x)
   }
   object Implicits extends ExtraImplicits { }
 
@@ -211,7 +211,7 @@ trait Numeric[T] extends Ordering[T] {
     else if (gt(x, zero)) 1
     else 0
 
-  class Ops(lhs: T) {
+  class NumericOps(lhs: T) {
     def +(rhs: T) = plus(lhs, rhs)
     def -(rhs: T) = minus(lhs, rhs)
     def *(rhs: T) = times(lhs, rhs)
@@ -223,5 +223,5 @@ trait Numeric[T] extends Ordering[T] {
     def toFloat(): Float = Numeric.this.toFloat(lhs)
     def toDouble(): Double = Numeric.this.toDouble(lhs)
   }
-  implicit def mkNumericOps(lhs: T): Ops = new Ops(lhs)
+  implicit def mkNumericOps(lhs: T): NumericOps = new NumericOps(lhs)
 }

--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -123,7 +123,7 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
   }
 
   /** This inner class defines comparison operators available for `T`. */
-  class Ops(lhs: T) {
+  class OrderingOps(lhs: T) {
     def <(rhs: T) = lt(lhs, rhs)
     def <=(rhs: T) = lteq(lhs, rhs)
     def >(rhs: T) = gt(lhs, rhs)
@@ -136,7 +136,7 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
   /** This implicit method augments `T` with the comparison operators defined
     * in `scala.math.Ordering.Ops`.
     */
-  implicit def mkOrderingOps(lhs: T): Ops = new Ops(lhs)
+  implicit def mkOrderingOps(lhs: T): OrderingOps = new OrderingOps(lhs)
 }
 
 trait LowPriorityOrderingImplicits {
@@ -189,7 +189,7 @@ object Ordering extends LowPriorityOrderingImplicits {
       * def lessThan[T: Ordering](x: T, y: T) = x < y
       * }}}
       */
-    implicit def infixOrderingOps[T](x: T)(implicit ord: Ordering[T]): Ordering[T]#Ops = new ord.Ops(x)
+    implicit def infixOrderingOps[T](x: T)(implicit ord: Ordering[T]): Ordering[T]#OrderingOps = new ord.OrderingOps(x)
   }
 
   /** An object containing implicits which are not in the default scope. */


### PR DESCRIPTION
Need to change unrelated inner classes so that they
have different names. Dotty does not allow a type
"not-overriding" a class with same name in a basetype.
