### PR TITLE
"macro" is a reserved word since Scala 2.11

### DIFF
--- a/spec/01-lexical-syntax.md
+++ b/spec/01-lexical-syntax.md
@@ -90,11 +90,11 @@ syntactic class `id` of lexical identifiers.
 abstract    case        catch       class       def
 do          else        extends     false       final
 finally     for         forSome     if          implicit
-import      lazy        match       new         null
-object      override    package     private     protected
-return      sealed      super       this        throw
-trait       try         true        type        val
-var         while       with        yield
+import      lazy        macro       match       new
+null        object      override    package     private
+protected   return      sealed      super       this
+throw       trait       try         true        type
+val         var         while       with        yield
 _    :    =    =>    <-    <:    <%     >:    #    @
 ```
 


### PR DESCRIPTION
https://github.com/scala/scala/commit/ea8ae48c18eb558ac9
