### PR TITLE
less confusing wording for a dependent method type error

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -1190,7 +1190,7 @@ trait ContextErrors {
 
       def IllegalDependentMethTpeError(sym: Symbol)(context: Context) = {
         val errorAddendum =
-          ": parameter appears in the type of another parameter in the same section or an earlier one"
+          ": parameter may only be referenced in a subsequent parameter section"
         issueSymbolTypeError(sym,  "illegal dependent method type" + errorAddendum)(context)
       }
 

--- a/test/files/neg/depmet_1.check
+++ b/test/files/neg/depmet_1.check
@@ -1,7 +1,7 @@
-depmet_1.scala:2: error: illegal dependent method type: parameter appears in the type of another parameter in the same section or an earlier one
+depmet_1.scala:2: error: illegal dependent method type: parameter may only be referenced in a subsequent parameter section
   def precise0(y: x.type)(x: String): Unit = {}
                           ^
-depmet_1.scala:3: error: illegal dependent method type: parameter appears in the type of another parameter in the same section or an earlier one
+depmet_1.scala:3: error: illegal dependent method type: parameter may only be referenced in a subsequent parameter section
   def precise1(x: String, y: x.type): Unit = {}
                ^
 depmet_1.scala:4: error: not found: value y


### PR DESCRIPTION
note to reviewers: the error messages in this file are over the place
about whether they're called "parameter sections", or "argument
lists", or what, so there's no point in being picky about that here

for context see [SI-823](https://issues.scala-lang.org/browse/SI-823)
