### PR TITLE
SI-4331 Fix memory leaks across REPL :reset command

### DIFF
--- a/src/reflect/scala/reflect/internal/util/ScalaClassLoader.scala
+++ b/src/reflect/scala/reflect/internal/util/ScalaClassLoader.scala
@@ -32,7 +32,6 @@ trait ScalaClassLoader extends JClassLoader {
     try { setContext(this) ; action }
     finally setContext(saved)
   }
-  def setAsContext() { setContext(this) }
 
   /** Load and link a class with this classloader */
   def tryToLoadClass[T <: AnyRef](path: String): Option[Class[T]] = tryClass(path, initialize = false)

--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -888,8 +888,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
         flatMap (f => io.File(f).safeSlurp())
         foreach (intp quietRun _)
     )
-    // classloader and power mode setup
-    intp.setContextClassLoader()
+    // power mode setup
     if (isReplPower) {
       replProps.power setValue true
       unleashAndSetPhase()

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -165,7 +165,7 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
   import global._
   import definitions.{ ObjectClass, termMember, dropNullaryMethod}
 
-  lazy val runtimeMirror = ru.runtimeMirror(classLoader)
+  def runtimeMirror = ru.runtimeMirror(classLoader)
 
   private def noFatal(body: => Symbol): Symbol = try body catch { case _: FatalError => NoSymbol }
 
@@ -363,7 +363,9 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
     })
 
   // Set the current Java "context" class loader to this interpreter's class loader
-  def setContextClassLoader() = classLoader.setAsContext()
+  @deprecated("The thread context classloader is now set and restored around execution of REPL line, this method is now a no-op.", since = "2.12.0")
+  // Called from sbt-interface/0.12.4/src/ConsoleInterface.scala:39
+  def setContextClassLoader() = ()
 
   def allDefinedNames: List[Name]  = exitingTyper(replScope.toList.map(_.name).sorted)
   def unqualifiedIds: List[String] = allDefinedNames map (_.decode) sorted


### PR DESCRIPTION
When replacing the classloader, which retains all values created
in the prior REPL lines, we must be careful not to keep around
references to the previous classloader.

We were doing this in two places: the thread context classloader and
in an runtime reflection mirror.

Both of those references to the old classloader would have been
correctness problems, and would likely have meant some degraded
functionality for a post :reset REPL. Furthermore, they served to
retain memory allocated up to the first :reset forever.

I changed handling of the thread context classlaoder to only set and
restore it around execution of code. This avoids leaking the
classloader to whatever thread happend to initialize the REPL.
We actually call the initialization code from within in a background
thread that allows the user to start typing the first command sooner.

I trawled the git logs to understand the history of how and when
we set the context classloader. It was originally added in
7e617efa8f. A more recent change to
add support for JSR-223 (Scripting) also wrapped this around the
execution 3a30af154e62. I believe the second commit is the correct
approach, and that it safe to remove the old code.

While this commit makes :reset perform its advertised function,
it doesn't go further to making it a particulary useful command.
Ideally we'd offer a mechanism to transport some data across a :reset
boundary. The user could do something like this manually by stashing
data in a `java.util.Map` hosted in some class in the same classloader
as IMain. They would also have to restrict this to sending "pure data"
rather than instances of data types defined in the REPL session
itself.

I located the leaks with YourKit, and have tested manually by
repeatedly running:

```
 qscala -J-XX:+HeapDumpOnOutOfMemoryError -J-Xmx512M
Welcome to Scala 2.12.0-20151110-111920-44ae563d37 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_51).
Type in expressions for evaluation. Or try :help.

scala> {val b = new Array[Byte](256 * 1024* 1024); () => b}
res0: () => Array[Byte] = $$Lambda$1781/1479140596@4218500f

scala> :reset
Resetting interpreter state.
Forgetting this session history:

{val b = new Array[Byte](256 * 1024* 1024); () => b}

Forgetting all expression results and named terms: $intp

scala> {val b = new Array[Byte](256 * 1024* 1024); () => b}
res0: () => Array[Byte] = $$Lambda$1828/1370495328@6831d8fd

scala> :reset
Resetting interpreter state.
Forgetting this session history:

{val b = new Array[Byte](256 * 1024* 1024); () => b}

scala> {val b = new Array[Byte](256 * 1024* 1024); () => b}
res0: () => Array[Byte] = $$Lambda$1829/79706679@2e140e59

scala> :reset
Resetting interpreter state.
Forgetting this session history:

{val b = new Array[Byte](256 * 1024* 1024); () => b}

scala> {val b = new Array[Byte](256 * 1024* 1024); () => b}
res0: () => Array[Byte] = $$Lambda$1830/1649884294@2418ba04

scala> {val b = new Array[Byte](256 * 1024* 1024); () => b}
java.lang.OutOfMemoryError: Java heap space
Dumping heap to java_pid21760.hprof ...
Heap dump file created [346682068 bytes in 0.870 secs]
java.lang.OutOfMemoryError: Java heap space
  ... 32 elided

scala> :reset
Resetting interpreter state.
Forgetting this session history:

{val b = new Array[Byte](256 * 1024* 1024); () => b}

scala> {val b = new Array[Byte](256 * 1024* 1024); () => b}
res0: () => Array[Byte] = $$Lambda$1839/174999703@32f5ecc4
```

Review by @SethTisue 
