### PR TITLE
it's Scaladoc, not ScalaDoc

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -231,7 +231,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
   /** Called from parser, which signals hereby that a method definition has been parsed. */
   def signalParseProgress(pos: Position) {}
 
-  /** Called by ScalaDocAnalyzer when a doc comment has been parsed. */
+  /** Called by ScaladocAnalyzer when a doc comment has been parsed. */
   def signalParsedDocComment(comment: String, pos: Position) = {
     // TODO: this is all very broken (only works for scaladoc comments, not regular ones)
     //       --> add hooks to parser and refactor Interactive global to handle comments directly

--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -78,7 +78,7 @@ trait Reporting extends scala.reflect.internal.Reporting { self: ast.Positions w
         s"""|
             |This can be achieved by adding the import clause 'import $fqname'
             |or by setting the compiler option -language:$featureName.
-            |See the Scala docs for value $fqname for a discussion
+            |See the Scaladoc for value $fqname for a discussion
             |why the feature $req be explicitly enabled.""".stripMargin
       )
       reportedFeature += featureTrait

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -49,7 +49,7 @@ trait Warnings {
     val NullaryOverride        = LintWarning("nullary-override",          "Warn when non-nullary `def f()' overrides nullary `def f'.",                true)
     val InferAny               = LintWarning("infer-any",                 "Warn when a type argument is inferred to be `Any`.",                        true)
     val MissingInterpolator    = LintWarning("missing-interpolator",      "A string literal appears to be missing an interpolator id.")
-    val DocDetached            = LintWarning("doc-detached",              "A ScalaDoc comment appears to be detached from its element.")
+    val DocDetached            = LintWarning("doc-detached",              "A Scaladoc comment appears to be detached from its element.")
     val PrivateShadow          = LintWarning("private-shadow",            "A private field (or class parameter) shadows a superclass field.")
     val TypeParameterShadow    = LintWarning("type-parameter-shadow",     "A local type parameter shadows a type already in scope.")
     val PolyImplicitOverload   = LintWarning("poly-implicit-overload",    "Parameterized overloaded implicit methods are not visible as view bounds.")

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -588,10 +588,10 @@ trait Implicits {
       if (Statistics.canEnable) Statistics.incCounter(matchingImplicits)
 
       // workaround for deficient context provided by ModelFactoryImplicitSupport#makeImplicitConstraints
-      val isScalaDoc = context.tree == EmptyTree
+      val isScaladoc = context.tree == EmptyTree
 
       val itree0 = atPos(pos.focus) {
-        if (isLocalToCallsite && !isScalaDoc) {
+        if (isLocalToCallsite && !isScaladoc) {
           // SI-4270 SI-5376 Always use an unattributed Ident for implicits in the local scope,
           // rather than an attributed Select, to detect shadowing.
           Ident(info.name)
@@ -628,7 +628,7 @@ trait Implicits {
               // for instance, if we have `class C[T]` and `implicit def conv[T: Numeric](c: C[T]) = ???`
               // then Scaladoc will give us something of type `C[T]`, and it would like to know
               // that `conv` is potentially available under such and such conditions
-              case tree if isImplicitMethodType(tree.tpe) && !isScalaDoc =>
+              case tree if isImplicitMethodType(tree.tpe) && !isScaladoc =>
                 applyImplicitArgs(tree)
               case tree => tree
             }

--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -80,7 +80,7 @@ trait InteractiveAnalyzer extends Analyzer {
         val existingDerivedSym = owningInfo.decl(sym.name.toTermName).filter(sym => sym.isSynthetic && sym.isMethod)
         existingDerivedSym.alternatives foreach (owningInfo.decls.unlink)
         val defTree = tree match {
-          case dd: DocDef => dd.definition // See SI-9011, Scala IDE's presentation compiler incorporates ScalaDocGlobal with InterativeGlobal, so we have to unwrap DocDefs.
+          case dd: DocDef => dd.definition // See SI-9011, Scala IDE's presentation compiler incorporates ScaladocGlobal with InteractiveGlobal, so we have to unwrap DocDefs.
           case _ => tree
         }
         enterImplicitWrapper(defTree.asInstanceOf[ClassDef])

--- a/src/scaladoc/scala/tools/nsc/doc/ScaladocAnalyzer.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/ScaladocAnalyzer.scala
@@ -125,9 +125,9 @@ abstract class ScaladocSyntaxAnalyzer[G <: Global](val global: G) extends Syntax
       } else if (in.ch == '*') {
         docBuffer = null
         in.next
-        val scalaDoc = ("/**", "*/")
+        val scaladoc = ("/**", "*/")
         if (in.ch == '*')
-          docBuffer = new StringBuilder(scalaDoc._1)
+          docBuffer = new StringBuilder(scaladoc._1)
         do {
           do {
             if (in.ch != '*' && in.ch != SU) {

--- a/src/scaladoc/scala/tools/nsc/doc/Settings.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/Settings.scala
@@ -45,7 +45,7 @@ class Settings(error: String => Unit, val printMsg: String => Unit = println(_))
   val docfooter = StringSetting (
     "-doc-footer",
     "footer",
-    "A footer on every ScalaDoc page, by default the EPFL/Typesafe copyright notice. Can be overridden with a custom footer.",
+    "A footer on every Scaladoc page, by default the EPFL/Typesafe copyright notice. Can be overridden with a custom footer.",
     ""
   )
 

--- a/test/disabled/presentation/akka/src/akka/actor/Supervisor.scala
+++ b/test/disabled/presentation/akka/src/akka/actor/Supervisor.scala
@@ -95,7 +95,7 @@ case class SupervisorFactory(val config: SupervisorConfig) {
  * wire the children together using 'link', 'spawnLink' etc. and set the 'trapExit' flag in the
  * children that should trap error signals and trigger restart.
  * <p/>
- * See the ScalaDoc for the SupervisorFactory for an example on how to declaratively wire up children.
+ * See the Scaladoc for the SupervisorFactory for an example on how to declaratively wire up children.
  *
  * @author <a href="http://jonasboner.com">Jonas Bon&#233;r</a>
  */

--- a/test/files/neg/macro-without-xmacros-a.check
+++ b/test/files/neg/macro-without-xmacros-a.check
@@ -2,7 +2,7 @@ Macros_2.scala:5: error: macro definition needs to be enabled
 by making the implicit value scala.language.experimental.macros visible.
 This can be achieved by adding the import clause 'import scala.language.experimental.macros'
 or by setting the compiler option -language:experimental.macros.
-See the Scala docs for value scala.language.experimental.macros for a discussion
+See the Scaladoc for value scala.language.experimental.macros for a discussion
 why the feature needs to be explicitly enabled.
     def foo(x: Int): Int = macro foo_impl
         ^

--- a/test/files/neg/macro-without-xmacros-b.check
+++ b/test/files/neg/macro-without-xmacros-b.check
@@ -2,7 +2,7 @@ Macros_2.scala:3: error: macro definition needs to be enabled
 by making the implicit value scala.language.experimental.macros visible.
 This can be achieved by adding the import clause 'import scala.language.experimental.macros'
 or by setting the compiler option -language:experimental.macros.
-See the Scala docs for value scala.language.experimental.macros for a discussion
+See the Scaladoc for value scala.language.experimental.macros for a discussion
 why the feature needs to be explicitly enabled.
     def foo(x: Int): Int = macro Impls.foo_impl
         ^

--- a/test/files/neg/t6040.check
+++ b/test/files/neg/t6040.check
@@ -2,7 +2,7 @@ t6040.scala:1: error: extension of type scala.Dynamic needs to be enabled
 by making the implicit value scala.language.dynamics visible.
 This can be achieved by adding the import clause 'import scala.language.dynamics'
 or by setting the compiler option -language:dynamics.
-See the Scala docs for value scala.language.dynamics for a discussion
+See the Scaladoc for value scala.language.dynamics for a discussion
 why the feature needs to be explicitly enabled.
 class X extends Dynamic
                 ^

--- a/test/files/neg/t6120.check
+++ b/test/files/neg/t6120.check
@@ -2,7 +2,7 @@ t6120.scala:5: warning: postfix operator bippy should be enabled
 by making the implicit value scala.language.postfixOps visible.
 This can be achieved by adding the import clause 'import scala.language.postfixOps'
 or by setting the compiler option -language:postfixOps.
-See the Scala docs for value scala.language.postfixOps for a discussion
+See the Scaladoc for value scala.language.postfixOps for a discussion
 why the feature should be explicitly enabled.
   def f = null == null bippy
                        ^

--- a/test/files/neg/t6952.check
+++ b/test/files/neg/t6952.check
@@ -2,7 +2,7 @@ t6952.scala:2: error: extension of type scala.Dynamic needs to be enabled
 by making the implicit value scala.language.dynamics visible.
 This can be achieved by adding the import clause 'import scala.language.dynamics'
 or by setting the compiler option -language:dynamics.
-See the Scala docs for value scala.language.dynamics for a discussion
+See the Scaladoc for value scala.language.dynamics for a discussion
 why the feature needs to be explicitly enabled.
 trait B extends Dynamic
                 ^

--- a/test/files/neg/t8736-c.check
+++ b/test/files/neg/t8736-c.check
@@ -2,7 +2,7 @@ t8736-c.scala:4: warning: higher-kinded type should be enabled
 by making the implicit value scala.language.higherKinds visible.
 This can be achieved by adding the import clause 'import scala.language.higherKinds'
 or by setting the compiler option -language:higherKinds.
-See the Scala docs for value scala.language.higherKinds for a discussion
+See the Scaladoc for value scala.language.higherKinds for a discussion
 why the feature should be explicitly enabled.
   def hk[M[_]] = ???
          ^

--- a/test/scaladoc/resources/links.scala
+++ b/test/scaladoc/resources/links.scala
@@ -1,6 +1,6 @@
 // that would be:
 // SI-5079 "Scaladoc can't link to an object (only a class or trait)"
-// SI-4497 "Links in ScalaDoc - Spec and implementation unsufficient"
+// SI-4497 "Links in Scaladoc - Spec and implementation unsufficient"
 // SI-4224 "Wiki-links should support method targets"
 // SI-3695 "support non-fully-qualified type links in scaladoc comments"
 // SI-6487 "Scaladoc can't link to inner classes"

--- a/test/scaladoc/run/links.scala
+++ b/test/scaladoc/run/links.scala
@@ -3,7 +3,7 @@ import scala.tools.nsc.doc.model._
 import scala.tools.partest.ScaladocModelTest
 
 // SI-5079 "Scaladoc can't link to an object (only a class or trait)"
-// SI-4497 "Links in ScalaDoc - Spec and implementation unsufficient"
+// SI-4497 "Links in Scaladoc - Spec and implementation unsufficient"
 // SI-4224 "Wiki-links should support method targets"
 // SI-3695 "support non-fully-qualified type links in scaladoc comments"
 // SI-6487 "Scaladoc can't link to inner classes"


### PR DESCRIPTION
renaming the existing ScalaDoc and ScalaDocReporter classes might
break stuff, sadly, but at least we can expunge these other remaining
uses of the big D

review by @janekdb
