### PR TITLE
SI-9555 Refactor SystemProperties to avoid mutable map

### DIFF
--- a/src/library/scala/sys/SystemProperties.scala
+++ b/src/library/scala/sys/SystemProperties.scala
@@ -69,24 +69,24 @@ object SystemProperties {
   def exclusively[T](body: => T) = this synchronized body
 
   implicit def systemPropertiesToCompanion(p: SystemProperties): SystemProperties.type = this
-  private lazy val propertyHelp = mutable.Map[String, String]()
-  private def addHelp[P <: Prop[_]](p: P, helpText: String): P = {
-    propertyHelp(p.key) = helpText
-    p
-  }
-  private def bool(key: String, helpText: String): BooleanProp = addHelp[BooleanProp](
-    if (key startsWith "java.") BooleanProp.valueIsTrue(key) else BooleanProp.keyExists(key),
-    helpText
-  )
-  def help(key: String) = propertyHelp.getOrElse(key, "")
 
-  // Todo: bring some sanity to the intersection of system properties aka "mutable
-  // state shared by everyone and everything" and the reality that there is no other
-  // mechanism for accomplishing some things on the jvm.
-  lazy val headless            = bool("java.awt.headless", "system should not utilize a display device")
-  lazy val preferIPv4Stack     = bool("java.net.preferIPv4Stack", "system should prefer IPv4 sockets")
-  lazy val preferIPv6Addresses = bool("java.net.preferIPv6Addresses", "system should prefer IPv6 addresses")
-  lazy val noTraceSuppression  = bool("scala.control.noTraceSuppression", "scala should not suppress any stack trace creation")
+  private final val HeadlessKey            = "java.awt.headless"
+  private final val PreferIPv4StackKey     = "java.net.preferIPv4Stack"
+  private final val PreferIPv6AddressesKey = "java.net.preferIPv6Addresses"
+  private final val NoTraceSuppressionKey  = "scala.control.noTraceSuppression"
+
+  def help(key: String): String = key match {
+    case HeadlessKey            => "system should not utilize a display device"
+    case PreferIPv4StackKey     => "system should prefer IPv4 sockets"
+    case PreferIPv6AddressesKey => "system should prefer IPv6 addresses"
+    case NoTraceSuppressionKey  => "scala should not suppress any stack trace creation"
+    case _                      => ""
+  }
+
+  lazy val headless: BooleanProp            = BooleanProp.keyExists(HeadlessKey)
+  lazy val preferIPv4Stack: BooleanProp     = BooleanProp.keyExists(PreferIPv4StackKey)
+  lazy val preferIPv6Addresses: BooleanProp = BooleanProp.keyExists(PreferIPv6AddressesKey)
+  lazy val noTraceSuppression: BooleanProp  = BooleanProp.valueIsTrue(NoTraceSuppressionKey)
   @deprecated("Use noTraceSuppression", "2.12.0")
   def noTraceSupression        = noTraceSuppression
 }


### PR DESCRIPTION
A mutable map with help text was lazy populated if and when
lazy vals containing `BooleanProp` for a particular system was
initialized.

Reviewing this code, I noticed two problems: the class doesn't appear
to be designed for multithreaded access (e.g. someone could call
`help` while the map is being updated.), and the help method
won't return anything until the vals below are accessed for
the first time.

We don't use the help method anywhere else, but I kept it around
in the unlikely event it was being used by some other tool.

I've done away with the mutable map by just moving the help messages
into a match in the help method itself.

Review by @adriaanm 
