### PR TITLE
Remove notes about -doc-title and -doc-version not being used

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/Settings.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/Settings.scala
@@ -25,7 +25,7 @@ class Settings(error: String => Unit, val printMsg: String => Unit = println(_))
   )
 
   /** A setting that defines the overall title of the documentation, typically the name of the library being
-    * documented. ''Note:'' This setting is currently not used. */
+    * documented. */
   val doctitle = StringSetting (
     "-doc-title",
     "title",
@@ -34,7 +34,7 @@ class Settings(error: String => Unit, val printMsg: String => Unit = println(_))
   )
 
   /** A setting that defines the overall version number of the documentation, typically the version of the library being
-    * documented. ''Note:'' This setting is currently not used. */
+    * documented. */
   val docversion = StringSetting (
     "-doc-version",
     "version",


### PR DESCRIPTION
Confirmed these options are used by editing build-ant-macros.xml and viewing
the output,

```
               <scaladoc docRootContent="${src.dir}/@{project}/${@{project}.docroot}"
                 destdir="${build-docs.dir}/@{project}"
-                doctitle="${@{project}.description}"
+                doctitle="${@{project}.description} - test-title"
                 docfooter="epfl"
-                docversion="${version.number}"
+                docversion="${version.number} - test-version"

```
