### PR TITLE
Add two missed scaladoc commands into scaladoc specific help section

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/Settings.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/Settings.scala
@@ -212,9 +212,10 @@ class Settings(error: String => Unit, val printMsg: String => Unit = println(_))
   // For improved help output.
   def scaladocSpecific = Set[Settings#Setting](
     docformat, doctitle, docfooter, docversion, docUncompilable, docsourceurl, docgenerator, docRootContent, useStupidTypes,
+    docExternalDoc,
     docAuthor, docDiagrams, docDiagramsDebug, docDiagramsDotPath,
     docDiagramsDotTimeout, docDiagramsDotRestart,
-    docImplicits, docImplicitsDebug, docImplicitsShowAll, docImplicitsHide,
+    docImplicits, docImplicitsDebug, docImplicitsShowAll, docImplicitsHide, docImplicitsSoundShadowing,
     docDiagramsMaxNormalClasses, docDiagramsMaxImplicitClasses,
     docNoPrefixes, docNoLinkWarnings, docRawOutput, docSkipPackages,
     docExpandAllTypes, docGroups


### PR DESCRIPTION
Prior to this change these scaladoc options were buried in the scalac section
of the help text,

```
-doc-external-doc
-implicits-sound-shadowing
```

With this change the options are listed in the scaladoc section.

This will make the commands easier to discover.
