### PR TITLE
upgrade to MiMa 0.1.8

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1642,7 +1642,7 @@ TODO:
     <mkdir dir="${bc-build.dir}"/>
     <!-- Pull down MIMA -->
     <artifact:dependencies pathId="mima.classpath">
-      <dependency groupId="com.typesafe" artifactId="mima-reporter_2.10" version="0.1.6"/>
+      <dependency groupId="com.typesafe" artifactId="mima-reporter_2.10" version="0.1.8"/>
     </artifact:dependencies>
     <artifact:dependencies pathId="old.bc.classpath">
       <dependency groupId="org.scala-lang" artifactId="scala-library" version="${bc-reference-version}"/>


### PR DESCRIPTION
just for general dogfooding purposes.  also because the new version
understands 2.12 bytecode better, and this commit will get merged onto
2.12
