### PR TITLE
Fix List Scaladoc time & space formatting

### DIFF
--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -25,6 +25,19 @@ import java.io._
  *  This class is optimal for last-in-first-out (LIFO), stack-like access patterns. If you need another access
  *  pattern, for example, random access or FIFO, consider using a collection more suited to this than `List`.
  *
+ *  ==Performance==
+ *  '''Time:''' `List` has `O(1)` prepend and head/tail access. Most other operations are `O(n)` on the number of elements in the list.
+ *  This includes the index-based lookup of elements, `length`, `append` and `reverse`.
+ *
+ *  '''Space:''' `List` implements '''structural sharing''' of the tail list. This means that many operations are either
+ *  zero- or constant-memory cost.
+ *  {{{
+ *  val mainList = List(3, 2, 1)
+ *  val with4 =    4 :: mainList  // re-uses mainList, costs one :: instance
+ *  val with42 =   42 :: mainList // also re-uses mainList, cost one :: instance
+ *  val shorter =  mainList.tail  // costs nothing as it uses the same 2::1::Nil instances as mainList
+ *  }}}
+ *
  *  @example {{{
  *  // Make a list via the companion object factory
  *  val days = List("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday")
@@ -39,19 +52,6 @@ import java.io._
  *    case List() =>
  *      println("There don't seem to be any week days.")
  *  }
- *  }}}
- *
- *  ==Performance==
- *  '''Time:''' `List` has `O(1)` prepend and head/tail access. Most other operations are `O(n)` on the number of elements in the list.
- *  This includes the index-based lookup of elements, `length`, `append` and `reverse`.
- *
- *  '''Space:''' `List` implements '''structural sharing''' of the tail list. This means that many operations are either
- *  zero- or constant-memory cost.
- *  {{{
- *  val mainList = List(3, 2, 1)
- *  val with4 =    4 :: mainList  // re-uses mainList, costs one :: instance
- *  val with42 =   42 :: mainList // also re-uses mainList, cost one :: instance
- *  val shorter =  mainList.tail  // costs nothing as it uses the same 2::1::Nil instances as mainList
  *  }}}
  *
  *  @note The functional list is characterized by persistence and structural sharing, thus offering considerable


### PR DESCRIPTION
The Performance section got sucked into a wormhole and popped up in the
example tag. The laws of physics differ in the attributes block resulting
in the loss of the line break between the Time and Space paragraphs.

Fixed by moving the section out of the example tag.
