### PR TITLE
Align DotRunner dot restart count with command option description

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/page/diagram/DotRunner.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/diagram/DotRunner.scala
@@ -18,16 +18,16 @@ import model._
 /** This class takes care of running the graphviz dot utility */
 class DotRunner(settings: doc.Settings) {
 
-  private[this] var dotRestarts = 0
+  private[this] var dotAttempts = 0
   private[this] var dotProcess: DotProcess  = null
 
   def feedToDot(dotInput: String, template: DocTemplateEntity): String = {
 
     if (dotProcess == null) {
-      if (dotRestarts < settings.docDiagramsDotRestart.value) {
-        if (dotRestarts != 0)
+      if (dotAttempts < settings.docDiagramsDotRestart.value + 1) {
+        if (dotAttempts > 0)
           settings.printMsg("Graphviz will be restarted...\n")
-        dotRestarts += 1
+        dotAttempts += 1
         dotProcess = new DotProcess(settings)
       } else
         return null
@@ -41,7 +41,7 @@ class DotRunner(settings: doc.Settings) {
     if (result == null) {
       dotProcess.cleanup()
       dotProcess = null
-      if (dotRestarts == settings.docDiagramsDotRestart.value) {
+      if (dotAttempts == 1 + settings.docDiagramsDotRestart.value) {
         settings.printMsg("\n")
         settings.printMsg("**********************************************************************")
         settings.printMsg("Diagrams will be disabled for this run because the graphviz dot tool")


### PR DESCRIPTION
This is the command option description,

```
val docDiagramsDotRestart = IntSetting(
  "-diagrams-dot-restart",
  "The number of times to restart a malfunctioning dot process before
      disabling diagrams (default: 5)",
  5,
  None,
  _ => None
)
```

Prior to this change dot was restarted four times instead of five. Maybe the
intention of the option was to allow a total number of attempts to be specified
but with 5 restarts we need 6 attempts. The local var was renamed to reflect this.
