### PR TITLE
SI-9567 Fix pattern match on 23+ param, method local case class

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/PatternTypers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternTypers.scala
@@ -79,7 +79,7 @@ trait PatternTypers {
       // do not update the symbol if the tree's symbol's type does not define an unapply member
       // (e.g. since it's some method that returns an object with an unapply member)
       val fun         = inPlaceAdHocOverloadingResolution(fun0)(hasUnapplyMember)
-      val caseClass   = fun.tpe.typeSymbol.linkedClassOfClass
+      val caseClass   = companionSymbolOf(fun.tpe.typeSymbol.sourceModule, context)
       val member      = unapplyMember(fun.tpe)
       def resultType  = (fun.tpe memberType member).finalResultType
       def isEmptyType = resultOfMatchingMethod(resultType, nme.isEmpty)()

--- a/test/files/run/t9567.scala
+++ b/test/files/run/t9567.scala
@@ -1,0 +1,18 @@
+object Test {
+  def testMethodLocalCaseClass {
+    case class MethodLocalWide(
+                                f01: Int, f02: Int, f03: Int, f04: Int, f05: Int, f06: Int, f07: Int, f08: Int, f09: Int, f10: Int,
+                                f11: Int, f12: Int, f13: Int, f14: Int, f15: Int, f16: Int, f17: Int, f18: Int, f19: Int, f20: Int,
+                                f21: Int, f22: Int, f23: Int)
+
+    val instance = MethodLocalWide(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    val result = instance match {
+      case MethodLocalWide(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) => true
+      case _ => false
+    }
+    assert(result)
+  }
+  def main(args: Array[String]) {
+    testMethodLocalCaseClass
+  }
+}

--- a/test/files/run/t9567b.scala
+++ b/test/files/run/t9567b.scala
@@ -1,0 +1,19 @@
+object Test {
+  def testMethodLocalCaseClass {
+    object MethodLocalWide
+    case class MethodLocalWide(
+                                f01: Int, f02: Int, f03: Int, f04: Int, f05: Int, f06: Int, f07: Int, f08: Int, f09: Int, f10: Int,
+                                f11: Int, f12: Int, f13: Int, f14: Int, f15: Int, f16: Int, f17: Int, f18: Int, f19: Int, f20: Int,
+                                f21: Int, f22: Int, f23: Int)
+
+    val instance = MethodLocalWide(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    val result = instance match {
+      case MethodLocalWide(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) => true
+      case _ => false
+    }
+    assert(result)
+  }
+  def main(args: Array[String]) {
+    testMethodLocalCaseClass
+  }
+}

--- a/test/files/run/t9567c.scala
+++ b/test/files/run/t9567c.scala
@@ -1,0 +1,29 @@
+case class CaseSequenceTopLevel(as: Int*)
+
+object Test {
+   def main(args: Array[String]): Unit = {
+
+    val buffer1 = collection.mutable.Buffer(0, 0)
+    CaseSequenceTopLevel(buffer1: _*) match {
+      case CaseSequenceTopLevel(_, i) =>
+        buffer1(1) = 1
+        assert(i == 0, i) // fails in 2.11.7 -optimize
+    }
+
+    case class CaseSequence(as: Int*)
+    val buffer2 = collection.mutable.Buffer(0, 0)
+    CaseSequence(buffer2: _*) match {
+      case CaseSequence(_, i) =>
+        buffer2(1) = 1
+        assert(i == 0, i)
+    }
+
+    case class CaseSequenceWithVar(var x: Any, as: Int*)
+    val buffer3 = collection.mutable.Buffer(0, 0)
+    CaseSequenceWithVar("", buffer3: _*) match {
+      case CaseSequenceWithVar(_, _, i) => // crashes in 2.11.7
+        buffer2(1) = 1
+        assert(i == 0, i)
+    }
+  }
+}


### PR DESCRIPTION
Typechecking constructor patterns of method local case classes
was only working because of the existence of the unapply method
in the companion, which is used if navigation to the case class
companion object fails.

We now support defintion of, and pattern matching on, case classes
with more than 22 parameters. These have no `unapply` method
in the companion, as we don't have a large enough tuple type to
return. So for such case classes, the fallback that we inadvertently
relied on would no longer save us, and we'd end up with a compile
error advising that the identifier in the constructor pattern was
neither a case class nor an extractor.

This is due to the propensity of `Symbol#companionXxx` to return
`NoSymbol` when in the midst of typechecking. That method should
only be relied upon after typechecking. During typechecking,
`Namers#companionSymbolOf` should be used instead, which looks in the
scopes of enclosing contexts for symbol companionship. That's
what I've done in this commit.
