### PR TITLE
DRY-er trees in pattern matcher code gen.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchCodeGen.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchCodeGen.scala
@@ -55,7 +55,15 @@ trait MatchCodeGen extends Interface {
       def flatMap(prev: Tree, b: Symbol, next: Tree): Tree
       def flatMapCond(cond: Tree, res: Tree, nextBinder: Symbol, next: Tree): Tree
       def flatMapGuard(cond: Tree, next: Tree): Tree
-      def ifThenElseZero(c: Tree, thenp: Tree): Tree = IF (c) THEN thenp ELSE zero
+      def ifThenElseZero(c: Tree, thenp: Tree): Tree = {
+        val z = zero
+        thenp match {
+          case If(c1, thenp1, elsep1) if z equalsStructure elsep1 =>
+            If(c AND c1, thenp1, elsep1) // cleaner, leaner trees
+          case _ =>
+            If(c, thenp, zero)
+        }
+      }
       protected def zero: Tree
     }
 

--- a/test/files/run/t6288.check
+++ b/test/files/run/t6288.check
@@ -33,11 +33,8 @@
       [175]case <synthetic> val x1: [175]Any = [175]"";
       [175]case5()[195]{
         [195]<synthetic> val o7: [195]Option[List[Int]] = [195][195]Case4.unapplySeq([195]x1);
-        [195]if ([195]o7.isEmpty.unary_!)
-          [195]if ([195][195][195][195]o7.get.!=([195]null).&&([195][195][195][195]o7.get.lengthCompare([195]1).==([195]0)))
-            [208][208]matchEnd4([208]())
-          else
-            [195][195]case6()
+        [195]if ([195][195]o7.isEmpty.unary_!.&&([195][195][195][195]o7.get.!=([195]null).&&([195][195][195][195]o7.get.lengthCompare([195]1).==([195]0))))
+          [208][208]matchEnd4([208]())
         else
           [195][195]case6()
       };
@@ -59,11 +56,8 @@
       [273]case <synthetic> val x1: [273]Any = [273]"";
       [273]case5()[293]{
         [293]<synthetic> val o7: [293]Option[List[Int]] = [293][293]Case4.unapplySeq([293]x1);
-        [293]if ([293]o7.isEmpty.unary_!)
-          [293]if ([293][293][293][293]o7.get.!=([293]null).&&([293][293][293][293]o7.get.lengthCompare([293]0).==([293]0)))
-            [304][304]matchEnd4([304]())
-          else
-            [293][293]case6()
+        [293]if ([293][293]o7.isEmpty.unary_!.&&([293][293][293][293]o7.get.!=([293]null).&&([293][293][293][293]o7.get.lengthCompare([293]0).==([293]0))))
+          [304][304]matchEnd4([304]())
         else
           [293][293]case6()
       };


### PR DESCRIPTION
Rather than building a cascade of if/elses, push additional conditions
into a conjunction in the condition of a single if/else. This is
possible when emitting conditions for the list of arguments of a
pattern.

Here's an example of the improvement to post-pattern matcher trees:

  https://gist.github.com/retronym/0d8f7126157061d72b81

While we could try to rely on the optimizer to coalesce the repeated
else clauses, it seems wasteful to emit the code in that way in
the first place.

Review by @lrytz && @adriaanm 
