### PR TITLE
SI-9542 Fix regression in value classes (served two ways)

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
@@ -244,7 +244,10 @@ abstract class ExtensionMethods extends Transform with TypingTransformers {
 
           // These three lines are assembling Foo.bar$extension[T1, T2, ...]($this)
           // which leaves the actual argument application for extensionCall.
-          val sel        = Select(gen.mkAttributedRef(companion), extensionMeth)
+          // SI-9542 We form the selection here from the thisType of the companion's owner. This is motivated
+          //         by the test case, and is a valid way to construct the reference because we know that this
+          //         method is also enclosed by that owner.
+          val sel        = Select(gen.mkAttributedRef(companion.owner.thisType, companion), extensionMeth)
           val targs      = origTpeParams map (_.tpeHK)
           val callPrefix = gen.mkMethodCall(sel, targs, This(origThis) :: Nil)
 

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3970,14 +3970,15 @@ trait Types
     }
   }
 
-  def normalizePlus(tp: Type) = (
+  def normalizePlus(tp: Type): Type = {
     if (isRawType(tp)) rawToExistential(tp)
     else tp.normalize match {
-      // Unify the two representations of module classes
-      case st @ SingleType(_, sym) if sym.isModule => st.underlying.normalize
-      case _                                       => tp.normalize
+      // Unify the representations of module classes
+      case st@SingleType(_, sym) if sym.isModule => st.underlying.normalize
+      case st@ThisType(sym) if sym.isModuleClass => normalizePlus(st.underlying)
+      case _ => tp.normalize
     }
-  )
+  }
 
   /*
   todo: change to:

--- a/test/files/pos/t9542.scala
+++ b/test/files/pos/t9542.scala
@@ -1,0 +1,8 @@
+object O {
+  trait T
+
+  class VC(val self: Any) extends AnyVal {
+    def extMethod(f: F1[T, Any]) = ()
+  }
+}
+trait F1[A, B]

--- a/test/junit/scala/reflect/internal/TypesTest.scala
+++ b/test/junit/scala/reflect/internal/TypesTest.scala
@@ -1,9 +1,10 @@
 package scala.reflect.internal
 
 import org.junit.Assert._
-import org.junit.Test
+import org.junit.{Assert, Test}
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import scala.collection.mutable
 import scala.tools.nsc.symtab.SymbolTableForUnitTesting
 
 @RunWith(classOf[JUnit4])
@@ -31,5 +32,30 @@ class TypesTest {
     val uniquelyNarrowed1 = refinedType(boolWithString1narrow1 :: Nil, NoSymbol)
     val uniquelyNarrowed2 = refinedType(boolWithString1narrow2 :: Nil, NoSymbol)
     assert(uniquelyNarrowed1 =:= uniquelyNarrowed2)
+  }
+
+  @Test
+  def testTransitivityWithModuleTypeRef(): Unit = {
+    import rootMirror.EmptyPackageClass
+    val (module, moduleClass) = EmptyPackageClass.newModuleAndClassSymbol(TermName("O"), NoPosition, 0L)
+    val minfo = ClassInfoType(List(ObjectTpe), newScope, moduleClass)
+    module.moduleClass setInfo minfo
+    module setInfo module.moduleClass.tpe
+    val tp1 = TypeRef(ThisType(EmptyPackageClass), moduleClass, Nil)
+    val tp2 = SingleType(ThisType(EmptyPackageClass), module)
+    val tp3 = ThisType(moduleClass)
+    val tps = List(tp1, tp2, tp3)
+    val results = mutable.Buffer[String]()
+    tps.permutations.foreach {
+      case ts @ List(a, b, c) =>
+        def tsShownRaw = ts.map(t => showRaw(t)).mkString(", ")
+        if (a <:< b && b <:< c && !(a <:< c)) results += s"<:< intransitive: $tsShownRaw"
+        if (a =:= b && b =:= c && !(a =:= c)) results += s"=:= intransitive: $tsShownRaw"
+    }
+    results.toList match {
+      case Nil => // okay
+      case xs =>
+        Assert.fail(xs.mkString("\n"))
+    }
   }
 }


### PR DESCRIPTION
```
% git log -3 --oneline --graph
*   b1c522a Merge branch 'ticket/9542' into ticket/9542-combo
|\
| * d09f024 SI-9542 Fix regression in value classes with enclosing refs
* | e7980e4 SI-9542 Unify different reprs. of module type refs
|/
```
