### PR TITLE
Apply some static code analysis recommendations

### DIFF
--- a/src/library/scala/reflect/ScalaLongSignature.java
+++ b/src/library/scala/reflect/ScalaLongSignature.java
@@ -8,5 +8,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface ScalaLongSignature {
-    public String[] bytes();
+    String[] bytes();
 }

--- a/src/library/scala/reflect/ScalaSignature.java
+++ b/src/library/scala/reflect/ScalaSignature.java
@@ -8,5 +8,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface ScalaSignature {
-    public String bytes();
+    String bytes();
 }

--- a/src/reflect/scala/reflect/internal/util/WeakHashSet.scala
+++ b/src/reflect/scala/reflect/internal/util/WeakHashSet.scala
@@ -41,7 +41,7 @@ final class WeakHashSet[A <: AnyRef](val initialCapacity: Int, val loadFactor: D
    * power of two equal to or greater than the specified initial capacity
    */
   private def computeCapacity = {
-    if (initialCapacity < 0) throw new IllegalArgumentException("initial capacity cannot be less than 0");
+    if (initialCapacity < 0) throw new IllegalArgumentException("initial capacity cannot be less than 0")
     var candidate = 1
     while (candidate < initialCapacity) {
       candidate  *= 2
@@ -372,13 +372,13 @@ final class WeakHashSet[A <: AnyRef](val initialCapacity: Int, val loadFactor: D
      * Number of buckets that hold collisions. Useful for diagnosing performance issues.
      */
     def collisionBucketsCount: Int =
-      (table filter (entry => entry != null && entry.tail != null)).size
+      (table count (entry => entry != null && entry.tail != null))
 
     /**
      * Number of buckets that are occupied in this hash table.
      */
     def fullBucketsCount: Int =
-      (table filter (entry => entry != null)).size
+      (table count (entry => entry != null))
 
     /**
      *  Number of buckets in the table

--- a/src/reflect/scala/reflect/macros/Attachments.scala
+++ b/src/reflect/scala/reflect/macros/Attachments.scala
@@ -39,7 +39,7 @@ abstract class Attachments { self =>
 
   /** An underlying payload of the given class type `T`. */
   def get[T: ClassTag]: Option[T] =
-    (all filter matchesTag[T]).headOption.asInstanceOf[Option[T]]
+    (all find matchesTag[T]).asInstanceOf[Option[T]]
 
   /** Check underlying payload contains an instance of type `T`. */
   def contains[T: ClassTag]: Boolean =

--- a/src/reflect/scala/reflect/runtime/ReflectionUtils.scala
+++ b/src/reflect/scala/reflect/runtime/ReflectionUtils.scala
@@ -72,7 +72,7 @@ object ReflectionUtils {
     def singletonAccessor(clazz: Class[_]): Option[Method] =
       if (clazz == null) None
       else {
-        val declaredAccessor = clazz.getDeclaredMethods.filter(_.getName == accessorName).headOption
+        val declaredAccessor = clazz.getDeclaredMethods.find(_.getName == accessorName)
         declaredAccessor orElse singletonAccessor(clazz.getSuperclass)
       }
 
@@ -92,7 +92,7 @@ object ReflectionUtils {
   }
 
   class EnclosedIn[T](enclosure: jClass[_] => T) {
-    def unapply(jclazz: jClass[_]): Option[T] = if (enclosure(jclazz) != null) Some(enclosure(jclazz)) else None
+    def unapply(jclazz: jClass[_]): Option[T] = Option(enclosure(jclazz))
   }
 
   object EnclosedInMethod extends EnclosedIn(_.getEnclosingMethod)

--- a/src/reflect/scala/reflect/runtime/SynchronizedOps.scala
+++ b/src/reflect/scala/reflect/runtime/SynchronizedOps.scala
@@ -15,7 +15,7 @@ private[reflect] trait SynchronizedOps extends internal.SymbolTable
 
   override protected def newBaseTypeSeq(parents: List[Type], elems: Array[Type]) =
     // only need to synchronize BaseTypeSeqs if they contain refined types
-    if (elems.filter(_.isInstanceOf[RefinedType]).nonEmpty) new BaseTypeSeq(parents, elems) with SynchronizedBaseTypeSeq
+    if (elems.exists(_.isInstanceOf[RefinedType])) new BaseTypeSeq(parents, elems) with SynchronizedBaseTypeSeq
     else new BaseTypeSeq(parents, elems)
 
   trait SynchronizedBaseTypeSeq extends BaseTypeSeq {
@@ -31,7 +31,7 @@ private[reflect] trait SynchronizedOps extends internal.SymbolTable
 
     override def lateMap(f: Type => Type): BaseTypeSeq =
       // only need to synchronize BaseTypeSeqs if they contain refined types
-      if (map(f).toList.filter(_.isInstanceOf[RefinedType]).nonEmpty) new MappedBaseTypeSeq(this, f) with SynchronizedBaseTypeSeq
+      if (map(f).toList.exists(_.isInstanceOf[RefinedType])) new MappedBaseTypeSeq(this, f) with SynchronizedBaseTypeSeq
       else new MappedBaseTypeSeq(this, f)
   }
 

--- a/src/repl/scala/tools/nsc/interpreter/JLineCompletion.scala
+++ b/src/repl/scala/tools/nsc/interpreter/JLineCompletion.scala
@@ -175,7 +175,7 @@ class JLineCompletion(val intp: IMain) extends Completion with CompletionOutput 
         case Some((clazz, runtimeType)) =>
           val sym = intp.symbolOfTerm(id)
           if (sym.isStable) {
-            val param = new NamedParam.Untyped(id, intp valueOfTerm id getOrElse null)
+            val param = new NamedParam.Untyped(id, intp valueOfTerm id orNull)
             Some(TypeMemberCompletion(tpe, runtimeType, param))
           }
           else default

--- a/src/repl/scala/tools/nsc/interpreter/JavapClass.scala
+++ b/src/repl/scala/tools/nsc/interpreter/JavapClass.scala
@@ -600,11 +600,11 @@ object JavapClass {
     def parents: List[ClassLoader] = parentsOf(loader)
     /* all file locations */
     def locations = {
-      def alldirs = parents flatMap (_ match {
+      def alldirs = parents flatMap {
         case ucl: ScalaClassLoader.URLClassLoader => ucl.classPathURLs
         case jcl: java.net.URLClassLoader         => jcl.getURLs
         case _ => Nil
-      })
+      }
       val dirs = for (d <- alldirs; if d.getProtocol == "file") yield Path(new JFile(d.toURI))
       dirs
     }

--- a/src/scalap/scala/tools/scalap/CodeWriter.scala
+++ b/src/scalap/scala/tools/scalap/CodeWriter.scala
@@ -35,7 +35,7 @@ class CodeWriter(writer: Writer) {
   def setIndentWidth(width: Int): CodeWriter =
     setIndentString(List.fill(width)(' ').mkString)
 
-  def getIndentString = step;
+  def getIndentString = step
 
   def setIndentString(step: String): CodeWriter = {
     this.step = step

--- a/src/scalap/scala/tools/scalap/Decode.scala
+++ b/src/scalap/scala/tools/scalap/Decode.scala
@@ -49,7 +49,7 @@ object Decode {
     import classFile._
 
     classFile annotation SCALA_SIG_ANNOTATION map { case Annotation(_, els) =>
-      val bytesElem = els find (x => constant(x.elementNameIndex) == BYTES_VALUE) getOrElse null
+      val bytesElem = els find (x => constant(x.elementNameIndex) == BYTES_VALUE) orNull
       val _bytes    = bytesElem.elementValue match { case ConstValueIndex(x) => constantWrapped(x) }
       val bytes     = _bytes.asInstanceOf[StringBytesPair].bytes
       val length    = ByteCodecs.decode(bytes)

--- a/src/scalap/scala/tools/scalap/JavaWriter.scala
+++ b/src/scalap/scala/tools/scalap/JavaWriter.scala
@@ -164,7 +164,7 @@ class JavaWriter(classfile: Classfile, writer: Writer) extends CodeWriter(writer
   }
 
   def printClass() {
-    val pck = getPackage(cf.classname);
+    val pck = getPackage(cf.classname)
     if (pck.length() > 0)
       println("package " + pck + ";")
     print(flagsToStr(true, cf.flags))
@@ -175,14 +175,14 @@ class JavaWriter(classfile: Classfile, writer: Writer) extends CodeWriter(writer
         printClassHeader;
       case Some(cf.Attribute(_, data)) =>
         val mp = new MetaParser(getName(
-          ((data(0) & 0xff) << 8) + (data(1) & 0xff)).trim());
+          ((data(0) & 0xff) << 8) + (data(1) & 0xff)).trim())
         mp.parse match {
           case None => printClassHeader;
           case Some(str) =>
             if (isInterface(cf.flags))
-              print("trait " + getSimpleClassName(cf.classname) + str);
+              print("trait " + getSimpleClassName(cf.classname) + str)
             else
-              print("class " + getSimpleClassName(cf.classname) + str);
+              print("class " + getSimpleClassName(cf.classname) + str)
         }
     }
     var statics: List[cf.Member] = Nil

--- a/src/scalap/scala/tools/scalap/MetaParser.scala
+++ b/src/scalap/scala/tools/scalap/MetaParser.scala
@@ -64,7 +64,7 @@ class MetaParser(meta: String) {
         case _: Exception => None
       }
     } else
-      None;
+      None
 
   protected def parseMetaClass: String = {
     nextToken
@@ -100,7 +100,7 @@ class MetaParser(meta: String) {
         parseType
       } while (token == "with")
     }
-    res.toString();
+    res.toString()
   }
 
   protected def parseMetaMethod: String = {
@@ -113,10 +113,10 @@ class MetaParser(meta: String) {
         var loop = true
         res.append("[")
         while (loop) {
-          res.append(token.substring(1));
-          nextToken;
+          res.append(token.substring(1))
+          nextToken
           if (token == "<") {
-            nextToken;
+            nextToken
             res.append(" <: ")
             parseType
           }
@@ -133,16 +133,16 @@ class MetaParser(meta: String) {
     if (token == "(") {
       do {
         if (token == ",") {
-          nextToken;
+          nextToken
           if (token != ")")
             res.append(", ")
         } else {
-          nextToken;
+          nextToken
           res.append("(")
         }
         if (token != ")") {
           if (token == "def") {
-            nextToken;
+            nextToken
             res.append("def ")
           }
           parseType

--- a/src/scalap/scala/tools/scalap/scalax/rules/Result.scala
+++ b/src/scalap/scala/tools/scalap/scalax/rules/Result.scala
@@ -12,7 +12,7 @@
 
 package scala.tools.scalap
 package scalax
-package rules;
+package rules
 
 /** Represents the combined value of two rules applied in sequence.
  *

--- a/src/scalap/scala/tools/scalap/scalax/rules/scalasig/ScalaSigPrinter.scala
+++ b/src/scalap/scala/tools/scalap/scalax/rules/scalasig/ScalaSigPrinter.scala
@@ -91,7 +91,7 @@ class ScalaSigPrinter(stream: PrintStream, printPrivates: Boolean) {
 
   def printWithIndent(level: Int, s: String) {
     def indent() {for (i <- 1 to level) print("  ")}
-    indent;
+    indent
     print(s)
   }
 
@@ -208,7 +208,7 @@ class ScalaSigPrinter(stream: PrintStream, printPrivates: Boolean) {
       mt.resultType match {
         case mt: MethodType => printMethodType(mt, printResult)({})
         case x => if (printResult) {
-          print(": ");
+          print(": ")
           printType(x)
         }
       }
@@ -374,7 +374,7 @@ class ScalaSigPrinter(stream: PrintStream, printPrivates: Boolean) {
       }
       case AnnotatedWithSelfType(typeRef, symbol, attribTreeRefs) => toString(typeRef, sep)
       case ExistentialType(typeRef, symbols) => {
-        val refs = symbols.map(toString _).filter(!_.startsWith("_")).map("type " + _)
+        val refs = symbols.map(toString).filter(!_.startsWith("_")).map("type " + _)
         toString(typeRef, sep) + (if (refs.size > 0) refs.mkString(" forSome {", "; ", "}") else "")
       }
       case _ => sep + t.toString


### PR DESCRIPTION
Fix a batch of code inspection recommendations generated by IntelliJ 14.1.5.

Categories of fix,
- Unnecessary public modifier in interface
- Replace filter+size with count
- Replace filter+nonEmpty with exists
- Replace filter+headOption with find
- Replace `if (x != null) Some(x) else None` with `Option(x)`
- Replace `getOrElse null` with `orNull`
- Drop redundant semicolons
- Replace anon fun with PF
- Replace anon fun with method
