### PR TITLE
[WIP] Turn on SAM by default

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -267,7 +267,7 @@ abstract class BCodeHelpers extends BCodeIdiomatic with BytecodeWriters {
       else {
         // Phase travel necessary. For example, nullary methods (getter of an abstract val) get an
         // empty parameter list in later phases and would therefore be picked as SAM.
-        val samSym = exitingPickler(definitions.findSam(classSym.tpe))
+        val samSym = exitingPickler(definitions.samOf(classSym.tpe))
         if (samSym == NoSymbol) None
         else Some(samSym.javaSimpleName.toString + methodSymToDescriptor(samSym))
       }

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -295,7 +295,7 @@ trait Infer extends Checkable {
         && !isByNameParamType(tp)
         && isCompatible(tp, dropByName(pt))
       )
-      def isCompatibleSam(tp: Type, pt: Type): Boolean = {
+      def isCompatibleSam(tp: Type, pt: Type): Boolean = (definitions.isFunctionType(tp) || tp.isInstanceOf[MethodType] || tp.isInstanceOf[PolyType]) &&  {
         val samFun = typer.samToFunctionType(pt)
         (samFun ne NoType) && isCompatible(tp, samFun)
       }

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -796,9 +796,7 @@ trait Definitions extends api.StandardDefinitions {
      * The class defining the method is a supertype of `tp` that
      * has a public no-arg primary constructor.
      */
-    def samOf(tp: Type): Symbol = if (!settings.Xexperimental) NoSymbol else findSam(tp)
-
-    def findSam(tp: Type): Symbol = {
+    def samOf(tp: Type): Symbol = {
       // if tp has a constructor, it must be public and must not take any arguments
       // (not even an implicit argument list -- to keep it simple for now)
       val tpSym  = tp.typeSymbol

--- a/test/files/neg/sammy_error_exist_no_crash.flags
+++ b/test/files/neg/sammy_error_exist_no_crash.flags
@@ -1,1 +1,0 @@
--Xexperimental

--- a/test/files/neg/sammy_restrictions.flags
+++ b/test/files/neg/sammy_restrictions.flags
@@ -1,1 +1,0 @@
--Xexperimental

--- a/test/files/neg/sammy_wrong_arity.flags
+++ b/test/files/neg/sammy_wrong_arity.flags
@@ -1,1 +1,0 @@
--Xexperimental

--- a/test/files/pos/sammy_exist.flags
+++ b/test/files/pos/sammy_exist.flags
@@ -1,1 +1,0 @@
--Xexperimental

--- a/test/files/pos/sammy_overload.flags
+++ b/test/files/pos/sammy_overload.flags
@@ -1,1 +1,0 @@
--Xexperimental

--- a/test/files/pos/sammy_override.flags
+++ b/test/files/pos/sammy_override.flags
@@ -1,1 +1,0 @@
--Xexperimental

--- a/test/files/pos/sammy_poly.flags
+++ b/test/files/pos/sammy_poly.flags
@@ -1,1 +1,0 @@
--Xexperimental

--- a/test/files/pos/sammy_scope.flags
+++ b/test/files/pos/sammy_scope.flags
@@ -1,1 +1,0 @@
--Xexperimental

--- a/test/files/pos/sammy_single.flags
+++ b/test/files/pos/sammy_single.flags
@@ -1,1 +1,0 @@
--Xexperimental

--- a/test/files/pos/sammy_twice.flags
+++ b/test/files/pos/sammy_twice.flags
@@ -1,1 +1,0 @@
--Xexperimental

--- a/test/files/pos/t8310.flags
+++ b/test/files/pos/t8310.flags
@@ -1,1 +1,0 @@
--Xexperimental

--- a/test/files/run/sammy_java8.flags
+++ b/test/files/run/sammy_java8.flags
@@ -1,1 +1,0 @@
--Xexperimental

--- a/test/files/run/sammy_repeated.flags
+++ b/test/files/run/sammy_repeated.flags
@@ -1,1 +1,0 @@
--Xexperimental


### PR DESCRIPTION
Initial work to change settings and test by
Svyatoslav Ilinskiy ilinskiy.sv@gmail.com (Thanks!)

To avoid cycles during overload resolution (which showed up
during bootstrapping), and to improve performance, I've guarded
the detection of SAM types in `isCompatible` to cases when the
LHS is potentially compatible.

The changes to `isCompatible` might need some discussion and refinement, but I'm publishing this PR so we can we how close we are to flipping this switch.
