### PR TITLE
WIP: constant folding preserves tree, tracks constant in type

### DIFF
--- a/src/compiler/scala/reflect/reify/codegen/GenTrees.scala
+++ b/src/compiler/scala/reflect/reify/codegen/GenTrees.scala
@@ -67,7 +67,7 @@ trait GenTrees {
     case global.EmptyTree             => reifyMirrorObject(EmptyTree)
     case global.noSelfType            => mirrorSelect(nme.noSelfType)
     case global.pendingSuperCall      => mirrorSelect(nme.pendingSuperCall)
-    case Literal(const @ Constant(_)) => mirrorCall(nme.Literal, reifyProduct(const))
+    case treeInfo.LiteralLike(const @ Constant(_)) => mirrorCall(nme.Literal, reifyProduct(const))
     case Import(expr, selectors)      => mirrorCall(nme.Import, reify(expr), mkList(selectors map reifyProduct))
     case _                            => reifyProduct(tree)
   }

--- a/src/compiler/scala/reflect/reify/codegen/GenTrees.scala
+++ b/src/compiler/scala/reflect/reify/codegen/GenTrees.scala
@@ -67,7 +67,7 @@ trait GenTrees {
     case global.EmptyTree             => reifyMirrorObject(EmptyTree)
     case global.noSelfType            => mirrorSelect(nme.noSelfType)
     case global.pendingSuperCall      => mirrorSelect(nme.pendingSuperCall)
-    case treeInfo.LiteralLike(const @ Constant(_)) => mirrorCall(nme.Literal, reifyProduct(const))
+    case Literal(const @ Constant(_)) => mirrorCall(nme.Literal, reifyProduct(const))
     case Import(expr, selectors)      => mirrorCall(nme.Import, reify(expr), mkList(selectors map reifyProduct))
     case _                            => reifyProduct(tree)
   }

--- a/src/compiler/scala/tools/nsc/transform/TypeAdaptingTransformer.scala
+++ b/src/compiler/scala/tools/nsc/transform/TypeAdaptingTransformer.scala
@@ -129,29 +129,33 @@ trait TypeAdaptingTransformer {
     }
 
     /** Generate a synthetic cast operation from tree.tpe to pt.
-     *  @pre pt eq pt.normalize
+      *
+      *  @pre pt eq pt.normalize
      */
     def cast(tree: Tree, pt: Type): Tree = {
-      if ((tree.tpe ne null) && !(tree.tpe =:= ObjectTpe)) {
+      val treeTp = tree.tpe
+      if ((treeTp ne null) && !(treeTp =:= ObjectTpe)) {
         def word = (
-          if (tree.tpe <:< pt) "upcast"
-          else if (pt <:< tree.tpe) "downcast"
-          else if (pt weak_<:< tree.tpe) "coerce"
-          else if (tree.tpe weak_<:< pt) "widen"
+          if (treeTp <:< pt) "upcast"
+          else if (pt <:< treeTp) "downcast"
+          else if (pt weak_<:< treeTp) "coerce"
+          else if (treeTp weak_<:< pt) "widen"
           else "cast"
         )
-        log(s"erasure ${word}s from ${tree.tpe} to $pt")
+        log(s"erasure ${word}s from ${treeTp} to $pt")
       }
       if (pt =:= UnitTpe) {
         // See SI-4731 for one example of how this occurs.
         log("Attempted to cast to Unit: " + tree)
         tree.duplicate setType pt
-      } else if (tree.tpe != null && tree.tpe.typeSymbol == ArrayClass && pt.typeSymbol == ArrayClass) {
+      } else {
         // See SI-2386 for one example of when this might be necessary.
-        val needsExtraCast = isPrimitiveValueType(tree.tpe.typeArgs.head) && !isPrimitiveValueType(pt.typeArgs.head)
-        val tree1 = if (needsExtraCast) gen.mkRuntimeCall(nme.toObjectArray, List(tree)) else tree
-        gen.mkAttributedCast(tree1, pt)
-      } else gen.mkAttributedCast(tree, pt)
+        val needsToObjArray =
+          (treeTp ne null) && pt.typeSymbol == ArrayClass && treeTp.typeSymbol == ArrayClass &&
+          isPrimitiveValueType(treeTp.typeArgs.head) && !isPrimitiveValueType(pt.typeArgs.head)
+
+        gen.mkAttributedCast(if (needsToObjArray) gen.mkRuntimeCall(nme.toObjectArray, List(tree)) else tree, pt)
+      }
     }
 
     /** Adapt `tree` to expected type `pt`.

--- a/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
@@ -764,7 +764,7 @@ trait ScalaLogic extends Interface with Logic with TreeAndTypeAnalysis {
           val wideTp = widenToClass(tp)
 
           val narrowTp =
-            if (tp.isInstanceOf[SingletonType]) tp
+            if (tp.isInstanceOf[SingletonType] || tp.isInstanceOf[ConstantType]) tp
             else p match {
               case Literal(c) =>
                 if (c.tpe =:= UnitTpe) c.tpe

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1041,7 +1041,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             case TypeRef(_, UnitClass, _) => // (12)
               if (!isPastTyper && settings.warnValueDiscard)
                 context.warning(tree.pos, "discarded non-Unit value")
-              return typedPos(tree.pos, mode, pt)(Block(List(tree), Literal(Constant(()))))
+              return typedPos(tree.pos, mode, pt)(gen.singleStatementBlock(tree))
             case TypeRef(_, sym, _) if isNumericValueClass(sym) && isNumericSubType(tree.tpe, pt) =>
               if (!isPastTyper && settings.warnNumericWiden)
                 context.warning(tree.pos, "implicit numeric widening")
@@ -1185,7 +1185,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       val savedUndetparams = context.undetparams
       silent(_.instantiate(tree, mode, UnitTpe)) orElse { _ =>
         context.undetparams = savedUndetparams
-        val valueDiscard = atPos(tree.pos)(Block(List(instantiate(tree, mode, WildcardType)), Literal(Constant(()))))
+        val valueDiscard = atPos(tree.pos)(gen.singleStatementBlock(instantiate(tree, mode, WildcardType)))
         typed(valueDiscard, mode, UnitTpe)
       }
     }

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2421,7 +2421,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       }
 
 //    body1 = checkNoEscaping.locals(context.scope, pt, body1)
-      treeCopy.CaseDef(cdef, pat1, guard1, body1) setType body1.tpe
+      treeCopy.CaseDef(cdef, pat1, guard1, body1) setType body1.tpe.deconst
     }
 
     def typedCases(cases: List[CaseDef], pattp: Type, pt: Type): List[CaseDef] =

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -124,7 +124,6 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     }
 
     /** Overridden to false in scaladoc and/or interactive. */
-    def canAdaptConstantTypeToLiteral = true
     def canTranslateEmptyListToNil    = true
     def missingSelectErrorTree(tree: Tree, qual: Tree, name: Name): Tree = tree
 

--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -41,7 +41,6 @@ trait InteractiveAnalyzer extends Analyzer {
   override def newNamer(context: Context): InteractiveNamer = new Namer(context) with InteractiveNamer
 
   trait InteractiveTyper extends Typer {
-    override def canAdaptConstantTypeToLiteral = false
     override def canTranslateEmptyListToNil    = false
     override def missingSelectErrorTree(tree: Tree, qual: Tree, name: Name): Tree = tree match {
       case Select(_, _)             => treeCopy.Select(tree, qual, name)

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -445,9 +445,11 @@ abstract class TreeGen {
     AppliedTypeTree(rootScalaDot(newTypeName("Function" + argtpes.length)), argtpes ::: List(restpe))
 
   /** Create a literal unit tree that is inserted by the compiler but not
-   *  written by end user. It's important to distinguish the two so that
-   *  quasiquotes can strip synthetic ones away.
-   */
+    * written by end user. It's important to distinguish the two so that
+    * quasiquotes can strip synthetic ones away.
+    *
+    * TODO: there are plenty of `Literal(Constant(()))` left that should probably be replace by a call to this method?
+    */
   def mkSyntheticUnit() = Literal(Constant(())).updateAttachment(SyntheticUnitAttachment)
 
   /** Create block of statements `stats`  */
@@ -456,6 +458,8 @@ abstract class TreeGen {
     else if (!stats.last.isTerm) Block(stats, mkSyntheticUnit())
     else if (stats.length == 1 && doFlatten) stats.head
     else Block(stats.init, stats.last)
+
+  def singleStatementBlock(stat: Tree) = Block(List(stat), mkSyntheticUnit())
 
   /** Create a block that wraps multiple statements but don't
    *  do any wrapping if there is just one statement. Used by

--- a/src/scaladoc/scala/tools/nsc/doc/ScaladocAnalyzer.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/ScaladocAnalyzer.scala
@@ -21,8 +21,6 @@ trait ScaladocAnalyzer extends Analyzer {
   trait ScaladocTyper extends Typer {
     private def unit = context.unit
 
-    override def canAdaptConstantTypeToLiteral = false
-
     override protected def macroImplementationNotFoundMessage(name: Name): String = (
         super.macroImplementationNotFoundMessage(name)
       + "\nWhen generating scaladocs for multiple projects at once, consider using -Ymacro-no-expand to disable macro expansions altogether."

--- a/test/files/neg/logImplicits.check
+++ b/test/files/neg/logImplicits.check
@@ -4,7 +4,7 @@ logImplicits.scala:2: applied implicit conversion from xs.type to ?{def size: ?}
 logImplicits.scala:7: applied implicit conversion from String("abc") to ?{def map: ?} = implicit def augmentString(x: String): scala.collection.immutable.StringOps
   def f = "abc" map (_ + 1)
           ^
-logImplicits.scala:15: inferred view from String("abc") to Int = C.this.convert:(p: String("abc"))Int
+logImplicits.scala:15: inferred view from String("abc") to Int = C.this.convert:(p: String)Int
   math.max(122, x: Int)
                 ^
 logImplicits.scala:19: applied implicit conversion from Int(1) to ?{def ->: ?} = implicit def ArrowAssoc[A](self: A): ArrowAssoc[A]

--- a/test/files/presentation/infix-completion.check
+++ b/test/files/presentation/infix-completion.check
@@ -3,7 +3,7 @@ reload: Snippet.scala
 askTypeCompletion at Snippet.scala(1,34)
 ================================================================================
 [response] askTypeCompletion at (1,34)
-retrieved 192 members
+retrieved 211 members
 [inaccessible] protected def integralNum: math.Numeric.DoubleAsIfIntegral.type
 [inaccessible] protected def num: math.Numeric.DoubleIsFractional.type
 [inaccessible] protected def ord: math.Ordering.Double.type
@@ -109,10 +109,16 @@ def ^(x: Short): Int
 def byteValue(): Byte
 def ceil: Double
 def compare(y: Double): Int
+def compare(y: Float): Int
+def compare(y: Int): Int
 def compare(y: Long): Int
 def compareTo(that: Double): Int
+def compareTo(that: Float): Int
+def compareTo(that: Int): Int
 def compareTo(that: Long): Int
 def compareTo(x$1: Double): Int
+def compareTo(x$1: Float): Int
+def compareTo(x$1: Integer): Int
 def compareTo(x$1: Long): Int
 def doubleValue(): Double
 def ensuring(cond: Boolean): Int
@@ -136,6 +142,10 @@ def round: Long
 def shortValue(): Short
 def to(end: Double): Range.Partial[Double,scala.collection.immutable.NumericRange[Double]]
 def to(end: Double,step: Double): scala.collection.immutable.NumericRange.Inclusive[Double]
+def to(end: Float): Range.Partial[Float,scala.collection.immutable.NumericRange[Float]]
+def to(end: Float,step: Float): scala.collection.immutable.NumericRange.Inclusive[Float]
+def to(end: Int): scala.collection.immutable.Range.Inclusive
+def to(end: Int,step: Int): scala.collection.immutable.Range.Inclusive
 def to(end: Long): scala.collection.immutable.NumericRange.Inclusive[Long]
 def to(end: Long,step: Long): scala.collection.immutable.NumericRange.Inclusive[Long]
 def toBinaryString: String
@@ -157,6 +167,10 @@ def unary_~: Int
 def underlying(): AnyRef
 def until(end: Double): Range.Partial[Double,scala.collection.immutable.NumericRange[Double]]
 def until(end: Double,step: Double): scala.collection.immutable.NumericRange.Exclusive[Double]
+def until(end: Float): Range.Partial[Float,scala.collection.immutable.NumericRange[Float]]
+def until(end: Float,step: Float): scala.collection.immutable.NumericRange.Exclusive[Float]
+def until(end: Int): scala.collection.immutable.Range
+def until(end: Int,step: Int): scala.collection.immutable.Range
 def until(end: Long): scala.collection.immutable.NumericRange.Exclusive[Long]
 def until(end: Long,step: Long): scala.collection.immutable.NumericRange.Exclusive[Long]
 def |(x: Byte): Int
@@ -185,8 +199,12 @@ override def isValidInt: Boolean
 override def isValidShort: Boolean
 override def isWhole(): Boolean
 override def max(that: Double): Double
+override def max(that: Float): Float
+override def max(that: Int): Int
 override def max(that: Long): Long
 override def min(that: Double): Double
+override def min(that: Float): Float
+override def min(that: Int): Int
 override def min(that: Long): Long
 override def signum: Int
 private[this] val self: Double

--- a/test/files/presentation/memory-leaks/MemoryLeaksTest.scala
+++ b/test/files/presentation/memory-leaks/MemoryLeaksTest.scala
@@ -29,9 +29,7 @@ object Test extends InteractiveTest {
   import interactive.Global
   trait InteractiveScaladocAnalyzer extends interactive.InteractiveAnalyzer with doc.ScaladocAnalyzer {
     val global : Global
-    override def newTyper(context: Context) = new Typer(context) with InteractiveTyper with ScaladocTyper {
-      override def canAdaptConstantTypeToLiteral = false
-    }
+    override def newTyper(context: Context) = new Typer(context) with InteractiveTyper with ScaladocTyper
   }
 
   private class ScaladocEnabledGlobal extends Global(settings, compilerReporter) {


### PR DESCRIPTION
This is motivated by scaladoc, presentation & incremental compilers all needing the original tree. There's no reason for the type checker to replace the tree -- this can wait until erasure. 

NOTE: this is a WIP to see what breaks and start the discusion --  no decision has been made about whether this can go into 2.11.x. It has to be a smooth, low-risk, transition.
