### PR TITLE
Bug fixes for the sbt build and partest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -667,7 +667,7 @@ lazy val dist = (project in file("dist"))
     libraryDependencies ++= Seq(scalaContinuationsLibraryDep, scalaContinuationsPluginDep, scalaSwingDep, jlineDep),
     mkBin := mkBinImpl.value,
     mkQuick <<= Def.task {} dependsOn ((distDependencies.map(products in Runtime in _) :+ mkBin): _*),
-    mkPack <<= Def.task {} dependsOn (packageBin in Compile, mkBin),
+    mkPack <<= Def.task {} dependsOn (packagedArtifact in (Compile, packageBin), mkBin),
     target := (baseDirectory in ThisBuild).value / "target" / thisProject.value.id,
     packageBin in Compile := {
       val extraDeps = Set(scalaContinuationsLibraryDep, scalaContinuationsPluginDep, scalaSwingDep, scalaParserCombinatorsDep, scalaXmlDep)
@@ -684,7 +684,7 @@ lazy val dist = (project in file("dist"))
     },
     cleanFiles += (buildDirectory in ThisBuild).value / "quick",
     cleanFiles += (buildDirectory in ThisBuild).value / "pack",
-    packageBin in Compile <<= (packageBin in Compile).dependsOn(distDependencies.map(packageBin in Compile in _): _*)
+    packagedArtifact in (Compile, packageBin) <<= (packagedArtifact in (Compile, packageBin)).dependsOn(distDependencies.map(packagedArtifact in (Compile, packageBin) in _): _*)
   )
   .dependsOn(distDependencies.map(p => p: ClasspathDep[ProjectReference]): _*)
 

--- a/build.sbt
+++ b/build.sbt
@@ -68,7 +68,7 @@ val scalaParserCombinatorsDep = withoutScalaLang("org.scala-lang.modules" %% "sc
 val scalaSwingDep = withoutScalaLang("org.scala-lang.modules" %% "scala-swing" % versionNumber("scala-swing"))
 val scalaXmlDep = withoutScalaLang("org.scala-lang.modules" %% "scala-xml" % versionNumber("scala-xml"))
 val partestDep = withoutScalaLang("org.scala-lang.modules" %% "scala-partest" % versionNumber("partest"))
-val partestInterfaceDep = withoutScalaLang("org.scala-lang.modules" %% "scala-partest-interface" % "0.5.0")
+val partestInterfaceDep = withoutScalaLang("org.scala-lang.modules" %% "scala-partest-interface" % "0.7.0")
 val junitDep = "junit" % "junit" % "4.11"
 val junitIntefaceDep = "com.novocode" % "junit-interface" % "0.11" % "test"
 val asmDep = "org.scala-lang.modules" % "scala-asm" % versionProps("scala-asm.version")
@@ -553,8 +553,8 @@ lazy val test = project
   .settings(
     publishArtifact := false,
     libraryDependencies ++= Seq(asmDep, partestDep, scalaXmlDep, partestInterfaceDep, scalacheckDep),
-    unmanagedBase in Test := baseDirectory.value / "files" / "lib",
-    unmanagedJars in Test <+= (unmanagedBase) (j => Attributed.blank(j)) map(identity),
+    unmanagedBase in IntegrationTest := baseDirectory.value / "files" / "lib",
+    unmanagedJars in IntegrationTest <+= (unmanagedBase) (j => Attributed.blank(j)) map(identity),
     // no main sources
     sources in Compile := Seq.empty,
     // test sources are compiled in partest run, not here
@@ -563,6 +563,7 @@ lazy val test = project
     javaOptions in IntegrationTest += "-Xmx1G",
     testFrameworks += new TestFramework("scala.tools.partest.Framework"),
     testOptions in IntegrationTest += Tests.Setup( () => root.base.getAbsolutePath + "/pull-binary-libs.sh" ! ),
+    testOptions in IntegrationTest += Tests.Argument("-Dpartest.java_opts=-Xmx1024M -Xms64M -XX:MaxPermSize=128M"),
     definedTests in IntegrationTest += (
       new sbt.TestDefinition(
         "partest",

--- a/build.sbt
+++ b/build.sbt
@@ -667,7 +667,13 @@ lazy val dist = (project in file("dist"))
   .settings(
     libraryDependencies ++= Seq(scalaContinuationsLibraryDep, scalaContinuationsPluginDep, scalaSwingDep, jlineDep),
     mkBin := mkBinImpl.value,
-    mkQuick <<= Def.task {} dependsOn ((distDependencies.map(products in Runtime in _) :+ mkBin): _*),
+    mkQuick <<= Def.task {
+      val cp = (fullClasspath in IntegrationTest in LocalProject("test")).value
+      val propsFile = (buildDirectory in ThisBuild).value / "quick" / "partest.properties"
+      val props = new java.util.Properties()
+      props.setProperty("partest.classpath", cp.map(_.data.getAbsolutePath).mkString(sys.props("path.separator")))
+      IO.write(props, null, propsFile)
+    } dependsOn ((distDependencies.map(products in Runtime in _) :+ mkBin): _*),
     mkPack <<= Def.task {} dependsOn (packagedArtifact in (Compile, packageBin), mkBin),
     target := (baseDirectory in ThisBuild).value / "target" / thisProject.value.id,
     packageBin in Compile := {

--- a/project/Osgi.scala
+++ b/project/Osgi.scala
@@ -62,6 +62,7 @@ object Osgi {
     val jar = synchronized { builder.build }
     builder.getWarnings.foreach(s => log.warn(s"bnd: $s"))
     builder.getErrors.foreach(s => log.error(s"bnd: $s"))
+    IO.createDirectory(artifactPath.getParentFile)
     jar.write(artifactPath)
     artifactPath
   }

--- a/test/files/jvm/innerClassEnclMethodJavaReflection.scala
+++ b/test/files/jvm/innerClassEnclMethodJavaReflection.scala
@@ -25,12 +25,13 @@ object Test extends App {
 
   def testClasses(jarOrDirectory: String): Unit = {
     val classPath = AbstractFile.getDirectory(new java.io.File(jarOrDirectory))
+    val basePath = classPath.path + "/"
 
-    def flatten(f: AbstractFile): Iterator[AbstractFile] =
-      if (f.isClassContainer) f.iterator.flatMap(flatten)
-      else Iterator(f)
+    def flatten(f: AbstractFile, s: String): Iterator[(AbstractFile, String)] =
+      if (f.isClassContainer) f.iterator.map(ch => (ch, (if(s.isEmpty) "" else s + "/") + ch.name)).flatMap((flatten _).tupled)
+      else Iterator((f, s))
 
-    val classFullNames = flatten(classPath).filter(_.hasExtension("class")).map(_.path.replace("/", ".").replaceAll(".class$", ""))
+    val classFullNames = flatten(classPath, "").filter(_._1.hasExtension("class")).map(_._2.replace("/", ".").replaceAll(".class$", ""))
 
     // it seems that Class objects can only be GC'd together with their class loader
     //   (http://stackoverflow.com/questions/2433261/when-and-how-are-classes-garbage-collected-in-java)

--- a/versions.properties
+++ b/versions.properties
@@ -36,7 +36,7 @@ jline.version=2.12.1
 scala-asm.version=5.0.4-scala-3
 
 # external modules, used internally (not shipped)
-partest.version.number=1.0.9
+partest.version.number=1.0.11
 scalacheck.version.number=1.11.6
 
 # TODO: modularize the compiler


### PR DESCRIPTION
- Use the latest versions of scala-partest and scala-partest-interface for selective test running and other partest features
- Create partest.properties from sbt. This is required to run the command-line version of partest on the build output.
- Bug fix: The sbt build didn't always ensure that build-sbt/pack existed before trying to write to it
- Bug fix: The sbt build depended on the output of "packageBin" which caused the wrong packaging task to run (built-in instead of OSGi o OSGi-enabled subprojects).

Review by @SethTisue 
