### PR TITLE
Apply title case to Scaladoc buttons: By Inheritance & Show All

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
@@ -139,7 +139,7 @@ class Template(universe: doc.Universe, generator: DiagramGenerator, tpl: DocTemp
                   if (tpl.linearizationTemplates.isEmpty && tpl.conversions.isEmpty)
                     NodeSeq.Empty
                   else
-                    <li class="inherit out"><span>By inheritance</span></li>
+                    <li class="inherit out"><span>By Inheritance</span></li>
                 }
               </ol>
             </div>
@@ -175,7 +175,7 @@ class Template(universe: doc.Universe, generator: DiagramGenerator, tpl: DocTemp
             <span class="filtertype"></span>
             <ol>
               <li class="hideall out"><span>Hide All</span></li>
-              <li class="showall in"><span>Show all</span></li>
+              <li class="showall in"><span>Show All</span></li>
             </ol>
           </div>
         }


### PR DESCRIPTION
The alternative choice was to change "Hide All" to "Hide all" to match the majority capitalization but title case fits for this UI.

![image](https://cloud.githubusercontent.com/assets/1123855/11826813/735b750c-a37f-11e5-9122-98a1e5f4049d.png)
