### PR TITLE
Fix Scaladoc overloaded method link to Duration companion object

### DIFF
--- a/src/library/scala/concurrent/duration/Duration.scala
+++ b/src/library/scala/concurrent/duration/Duration.scala
@@ -94,7 +94,7 @@ object Duration {
     timeUnitLabels flatMap { case (unit, names) => expandLabels(names) map (_ -> unit) } toMap
 
   /**
-   * Extract length and time unit out of a string, where the format must match the description for [[Duration$.apply(String):Duration apply(String)]].
+   * Extract length and time unit out of a string, where the format must match the description for [[Duration$.apply(s:String)* apply(String)]].
    * The extractor will not match for malformed strings or non-finite durations.
    */
   def unapply(s: String): Option[(Long, TimeUnit)] =
@@ -355,7 +355,7 @@ object Duration {
  *  - isomorphic to `java.lang.Double` when it comes to infinite or undefined values
  *
  * The conversion between Duration and Double is done using [[Duration.toUnit]] (with unit NANOSECONDS)
- * and [[Duration$.fromNanos(Double):Duration Duration.fromNanos(Double)]].
+ * and [[Duration$.fromNanos(nanos:Double)* Duration.fromNanos(Double)]]
  *
  * <h2>Ordering</h2>
  *


### PR DESCRIPTION
The links were being skipped with a warning before this commit.

The key change was to remove the result type and add an asterisk.
