### PR TITLE
Allow @migration to be used outside of the scala package

### DIFF
--- a/src/library/scala/annotation/migration.scala
+++ b/src/library/scala/annotation/migration.scala
@@ -13,7 +13,7 @@ package scala.annotation
  * between versions.  This is intended for methods which for one
  * reason or another retain the same name and type signature,
  * but some aspect of their behavior is different.  An illustrative
- * examples is Stack.iterator, which reversed from LIFO to FIFO
+ * example is Stack.iterator, which reversed from LIFO to FIFO
  * order between Scala 2.7 and 2.8.
  *
  * @param message A message describing the change, which is emitted
@@ -25,4 +25,4 @@ package scala.annotation
  *
  * @since 2.8
  */
- private[scala] final class migration(message: String, changedIn: String) extends scala.annotation.StaticAnnotation
+ final class migration(message: String, changedIn: String) extends scala.annotation.StaticAnnotation


### PR DESCRIPTION
Various Scaladoc guides list @migration as a useful tag however it only
become of use outside of the Standard Standard Library when public.
