### PR TITLE
SI-8289 Scaladoc: Make the order of subclasses deterministic

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
@@ -13,11 +13,9 @@ package page
 import base._
 import base.comment._
 
-import model._
-import model.diagram._
+import scala.collection.mutable
 import scala.xml.{NodeSeq, Text, UnprefixedAttribute}
 import scala.language.postfixOps
-import scala.collection.mutable. { Set, HashSet }
 
 import model._
 import model.diagram._
@@ -659,7 +657,7 @@ class Template(universe: doc.Universe, generator: DiagramGenerator, tpl: DocTemp
 
     val subclasses = mbr match {
       case dtpl: DocTemplateEntity if isSelf && !isReduced =>
-        val subs: Set[DocTemplateEntity] = HashSet.empty
+        val subs = mutable.HashSet.empty[DocTemplateEntity]
         def transitive(dtpl: DocTemplateEntity) {
           for (sub <- dtpl.directSubClasses if !(subs contains sub)) {
             subs add sub
@@ -671,7 +669,7 @@ class Template(universe: doc.Universe, generator: DiagramGenerator, tpl: DocTemp
           <div class="toggleContainer block">
             <span class="toggle">Known Subclasses</span>
             <div class="subClasses hiddenContent">{
-              templatesToHtml(subs.toList.sortBy(_.name), scala.xml.Text(", "))
+              templatesToHtml(subs.toList.sorted(Entity.EntityOrdering), scala.xml.Text(", "))
             }</div>
           </div>
         else NodeSeq.Empty

--- a/src/scaladoc/scala/tools/nsc/doc/model/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/Entity.scala
@@ -62,9 +62,15 @@ object Entity {
     case x: MemberEntity  => x.deprecation.isDefined
     case _                => false
   }
+
+  private def isObject(x: Entity) = x match {
+    case x: TemplateEntity  => x.isObject
+    case _                  => false
+  }
+
   /** Ordering deprecated things last. */
   implicit lazy val EntityOrdering: Ordering[Entity] =
-    Ordering[(Boolean, String)] on (x => (isDeprecated(x), x.name))
+    Ordering[(Boolean, String, Boolean)] on (x => (isDeprecated(x), x.qualifiedName, isObject(x)))
 }
 
 /** A template, which is either a class, trait, object or package. Depending on whether documentation is available


### PR DESCRIPTION
I intentionally used 2.12.x as a base branch since there is a huge improvement on Scaladoc in the branch :)
