### PR TITLE
Trim complexity in CommentFactoryBase

### DIFF
--- a/test/scaladoc/run/tag-requirements.check
+++ b/test/scaladoc/run/tag-requirements.check
@@ -1,0 +1,16 @@
+newSource:3: warning: Only one '@version' tag is allowed
+        /**
+        ^
+newSource:9: warning: Tag '@param' must be followed by a symbol name
+          /**
+          ^
+newSource:9: warning: Tag '@param' is not recognised
+          /**
+          ^
+newSource:14: warning: Only one '@param' tag for symbol b is allowed
+          /**
+          ^
+newSource:20: warning: Tag '@unrecognised' is not recognised
+          /**
+          ^
+Done.

--- a/test/scaladoc/run/tag-requirements.scala
+++ b/test/scaladoc/run/tag-requirements.scala
@@ -1,0 +1,53 @@
+import scala.tools.nsc.doc.base._
+import scala.tools.nsc.doc.model._
+import scala.tools.partest.ScaladocModelTest
+
+object Test extends ScaladocModelTest {
+
+  override def code =
+    """
+      package scala.test.scaladoc.tagrequirements
+        /**
+         * object comment
+         * @version 1.0
+         * @version 2.0
+         */
+        object Test {
+          /**
+           * foo comment
+           * @param
+           */
+          def foo(b: Any) = ???
+          /**
+           * bar comment
+           * @param b A value
+           * @param b A value
+           */
+          def bar(b: Any) = ???
+          /**
+           * baz comment
+           * @unrecognised
+           */
+          def baz() = ???
+        }
+    """
+
+  def scaladocSettings = ""
+
+  def testModel(root: Package) = {
+    // get the quick access implicit defs in scope (_package(s), _class(es), _trait(s), object(s) _method(s), _value(s))
+    import access._
+
+    val base = root._package("scala")._package("test")._package("scaladoc")._package("tagrequirements")
+
+    val test = base._object("Test")
+    /*
+     * We only care about the warnings which are side effects but we assert on the comment to
+     * avoid static code analysis noise about unused values.
+     */
+    assert(extractCommentText(test.comment.get) == "object comment")
+    assert(extractCommentText(test._method("foo").comment.get) == "foo comment")
+    assert(extractCommentText(test._method("bar").comment.get) == "bar comment")
+    assert(extractCommentText(test._method("baz").comment.get) == "baz comment")
+  }
+}


### PR DESCRIPTION
1. Replace option handling with library call
2. Remove NumberFormatException catch presumed to be copy/paste legacy
3. It's Scaladoc
4. Parse trailing whitespace regex once instead of per line
5. Use string interpolation where it improves readability
6. Add missed alternative to block grammar production rule
7. Add regression test for tag requirement warnings
