### PR TITLE
SI-8641 Fix right shift docs for integer types

### DIFF
--- a/src/library/scala/Byte.scala
+++ b/src/library/scala/Byte.scala
@@ -79,8 +79,8 @@ final abstract class Byte private extends AnyVal {
   */
   def >>>(x: Long): Int
   /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the right bits with the same value as the left-most bit of this.
+  * Returns this value bit-shifted right by the specified number of bits,
+  *         filling in the left bits with the same value as the left-most bit of this.
   *         The effect of this is to retain the sign of the value.
   * @example {{{
   * -21 >> 3 == -3
@@ -90,8 +90,8 @@ final abstract class Byte private extends AnyVal {
   */
   def >>(x: Int): Int
   /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the right bits with the same value as the left-most bit of this.
+  * Returns this value bit-shifted right by the specified number of bits,
+  *         filling in the left bits with the same value as the left-most bit of this.
   *         The effect of this is to retain the sign of the value.
   * @example {{{
   * -21 >> 3 == -3

--- a/src/library/scala/Char.scala
+++ b/src/library/scala/Char.scala
@@ -79,8 +79,8 @@ final abstract class Char private extends AnyVal {
   */
   def >>>(x: Long): Int
   /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the right bits with the same value as the left-most bit of this.
+  * Returns this value bit-shifted right by the specified number of bits,
+  *         filling in the left bits with the same value as the left-most bit of this.
   *         The effect of this is to retain the sign of the value.
   * @example {{{
   * -21 >> 3 == -3
@@ -90,8 +90,8 @@ final abstract class Char private extends AnyVal {
   */
   def >>(x: Int): Int
   /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the right bits with the same value as the left-most bit of this.
+  * Returns this value bit-shifted right by the specified number of bits,
+  *         filling in the left bits with the same value as the left-most bit of this.
   *         The effect of this is to retain the sign of the value.
   * @example {{{
   * -21 >> 3 == -3

--- a/src/library/scala/Int.scala
+++ b/src/library/scala/Int.scala
@@ -79,8 +79,8 @@ final abstract class Int private extends AnyVal {
   */
   def >>>(x: Long): Int
   /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the right bits with the same value as the left-most bit of this.
+  * Returns this value bit-shifted right by the specified number of bits,
+  *         filling in the left bits with the same value as the left-most bit of this.
   *         The effect of this is to retain the sign of the value.
   * @example {{{
   * -21 >> 3 == -3
@@ -90,8 +90,8 @@ final abstract class Int private extends AnyVal {
   */
   def >>(x: Int): Int
   /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the right bits with the same value as the left-most bit of this.
+  * Returns this value bit-shifted right by the specified number of bits,
+  *         filling in the left bits with the same value as the left-most bit of this.
   *         The effect of this is to retain the sign of the value.
   * @example {{{
   * -21 >> 3 == -3

--- a/src/library/scala/Long.scala
+++ b/src/library/scala/Long.scala
@@ -79,8 +79,8 @@ final abstract class Long private extends AnyVal {
   */
   def >>>(x: Long): Long
   /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the right bits with the same value as the left-most bit of this.
+  * Returns this value bit-shifted right by the specified number of bits,
+  *         filling in the left bits with the same value as the left-most bit of this.
   *         The effect of this is to retain the sign of the value.
   * @example {{{
   * -21 >> 3 == -3
@@ -90,8 +90,8 @@ final abstract class Long private extends AnyVal {
   */
   def >>(x: Int): Long
   /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the right bits with the same value as the left-most bit of this.
+  * Returns this value bit-shifted right by the specified number of bits,
+  *         filling in the left bits with the same value as the left-most bit of this.
   *         The effect of this is to retain the sign of the value.
   * @example {{{
   * -21 >> 3 == -3

--- a/src/library/scala/Short.scala
+++ b/src/library/scala/Short.scala
@@ -79,8 +79,8 @@ final abstract class Short private extends AnyVal {
   */
   def >>>(x: Long): Int
   /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the right bits with the same value as the left-most bit of this.
+  * Returns this value bit-shifted right by the specified number of bits,
+  *         filling in the left bits with the same value as the left-most bit of this.
   *         The effect of this is to retain the sign of the value.
   * @example {{{
   * -21 >> 3 == -3
@@ -90,8 +90,8 @@ final abstract class Short private extends AnyVal {
   */
   def >>(x: Int): Int
   /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the right bits with the same value as the left-most bit of this.
+  * Returns this value bit-shifted right by the specified number of bits,
+  *         filling in the left bits with the same value as the left-most bit of this.
   *         The effect of this is to retain the sign of the value.
   * @example {{{
   * -21 >> 3 == -3


### PR DESCRIPTION
Docs for >> operation of integer types (from Byte to Long) had a wrong
direction saying that it is bit-shift left.
