### PR TITLE
SI-9564 Make reusing of ArrayBuilder after clear() safe

### DIFF
--- a/src/library/scala/collection/mutable/ArrayBuilder.scala
+++ b/src/library/scala/collection/mutable/ArrayBuilder.scala
@@ -100,6 +100,7 @@ object ArrayBuilder {
 
     def clear() {
       size = 0
+      resize(0)
     }
 
     def result() = {
@@ -165,6 +166,7 @@ object ArrayBuilder {
 
     def clear() {
       size = 0
+      resize(0)
     }
 
     def result() = {
@@ -230,6 +232,7 @@ object ArrayBuilder {
 
     def clear() {
       size = 0
+      resize(0)
     }
 
     def result() = {
@@ -295,6 +298,7 @@ object ArrayBuilder {
 
     def clear() {
       size = 0
+      resize(0)
     }
 
     def result() = {
@@ -360,6 +364,7 @@ object ArrayBuilder {
 
     def clear() {
       size = 0
+      resize(0)
     }
 
     def result() = {
@@ -425,6 +430,7 @@ object ArrayBuilder {
 
     def clear() {
       size = 0
+      resize(0)
     }
 
     def result() = {
@@ -490,6 +496,7 @@ object ArrayBuilder {
 
     def clear() {
       size = 0
+      resize(0)
     }
 
     def result() = {
@@ -555,6 +562,7 @@ object ArrayBuilder {
 
     def clear() {
       size = 0
+      resize(0)
     }
 
     def result() = {
@@ -619,6 +627,7 @@ object ArrayBuilder {
 
     def clear() {
       size = 0
+      resize(0)
     }
 
     def result() = {
@@ -684,6 +693,7 @@ object ArrayBuilder {
 
     def clear() {
       size = 0
+      resize(0)
     }
 
     def result() = {

--- a/test/junit/scala/collection/mutable/ArrayBuilderTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBuilderTest.scala
@@ -1,0 +1,44 @@
+package scala.collection.mutable
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Test
+
+import scala.tools.testing.AssertUtil
+
+@RunWith(classOf[JUnit4])
+class ArrayBuilderTest {
+
+  @Test
+  def reusingAfterClearIsSafe: Unit = {
+    // Test for SI-9564:
+    //Reusing ArrayBuilder after clear() overwrites its previous result
+
+    def buildClearReuse[T](
+        builder: ArrayBuilder[T],
+        elements: scala.collection.immutable.Iterable[T],
+        newElement: T): Unit = {
+
+      builder ++= elements
+      val array = builder.result
+
+      builder.clear()
+
+      builder += newElement // reuse the builder
+
+      AssertUtil.assertSameElements(elements, array) 
+    }
+
+    val sixteen = 1 to 16
+
+    buildClearReuse(new ArrayBuilder.ofByte, sixteen.map(_.toByte), 99.toByte)
+    buildClearReuse(new ArrayBuilder.ofChar, sixteen.map(c => ('a' + c - 1).toChar), 'X')
+    buildClearReuse(new ArrayBuilder.ofShort, sixteen.map(_.toShort), 99.toShort)
+    buildClearReuse(new ArrayBuilder.ofInt, sixteen, 99)
+    buildClearReuse(new ArrayBuilder.ofLong, sixteen.map(_.toLong), 99L)
+    buildClearReuse(new ArrayBuilder.ofFloat, sixteen.map(_.toFloat), 99f)
+    buildClearReuse(new ArrayBuilder.ofDouble, sixteen.map(_.toDouble), 99d)
+    buildClearReuse(new ArrayBuilder.ofBoolean, sixteen.map(_ => true), false)
+    buildClearReuse(new ArrayBuilder.ofRef[String], sixteen.map(_.toString), "X")
+  }
+}


### PR DESCRIPTION
In some cases ArrayBuilder.elems was still pointing to the previously created array after a call to ArrayBuilder.clear(). As a result, reusing such ArrayBuilder would overwrite the contents of previously created array.
