### PR TITLE
Use invokedynamic for structural calls, symbol literals, lambda ser.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
@@ -1,6 +1,8 @@
 package scala.tools.nsc
 package backend.jvm
 
+import scala.annotation.switch
+import scala.tools.asm
 import scala.tools.nsc.backend.jvm.BTypes.InternalName
 
 /**
@@ -109,8 +111,10 @@ class CoreBTypes[BTFS <: BTypesFromSymbols[_ <: Global]](val bTypes: BTFS) {
   lazy val jliMethodTypeRef          : ClassBType = classBTypeFromSymbol(requiredClass[java.lang.invoke.MethodType])
   lazy val jliCallSiteRef            : ClassBType = classBTypeFromSymbol(requiredClass[java.lang.invoke.CallSite])
   lazy val jliLambdaMetafactoryRef   : ClassBType = classBTypeFromSymbol(requiredClass[java.lang.invoke.LambdaMetafactory])
-  lazy val srLambdaDeserializerRef   : ClassBType = classBTypeFromSymbol(requiredModule[scala.runtime.LambdaDeserializer.type].moduleClass)
   lazy val srBoxesRunTimeRef         : ClassBType = classBTypeFromSymbol(requiredClass[scala.runtime.BoxesRunTime])
+  lazy val srSymbolLiteral           : ClassBType = classBTypeFromSymbol(requiredClass[scala.runtime.SymbolLiteral])
+  lazy val srStructuralCallSite      : ClassBType = classBTypeFromSymbol(requiredClass[scala.runtime.StructuralCallSite])
+  lazy val srLambdaDeserialize       : ClassBType = classBTypeFromSymbol(requiredClass[scala.runtime.LambdaDeserialize])
   lazy val srBoxedUnitRef            : ClassBType = classBTypeFromSymbol(requiredClass[scala.runtime.BoxedUnit])
 
   private def methodNameAndType(cls: Symbol, name: Name, static: Boolean = false, filterOverload: Symbol => Boolean = _ => true): MethodNameAndType = {
@@ -263,6 +267,30 @@ class CoreBTypes[BTFS <: BTypesFromSymbols[_ <: Global]](val bTypes: BTFS) {
       case _        => false
     })
   }
+
+  lazy val lambdaMetaFactoryBootstrapHandle =
+    new asm.Handle(asm.Opcodes.H_INVOKESTATIC,
+      coreBTypes.jliLambdaMetafactoryRef.internalName, sn.AltMetafactory.toString,
+      MethodBType(
+        List(
+          coreBTypes.jliMethodHandlesLookupRef,
+          coreBTypes.StringRef,
+          coreBTypes.jliMethodTypeRef,
+          ArrayBType(ObjectRef)),
+        coreBTypes.jliCallSiteRef
+      ).descriptor)
+
+  lazy val lambdaDeserializeBootstrapHandle =
+    new scala.tools.asm.Handle(scala.tools.asm.Opcodes.H_INVOKESTATIC,
+      coreBTypes.srLambdaDeserialize.internalName, sn.Bootstrap.toString,
+      MethodBType(
+        List(
+          coreBTypes.jliMethodHandlesLookupRef,
+          coreBTypes.StringRef,
+          coreBTypes.jliMethodTypeRef
+        ),
+        coreBTypes.jliCallSiteRef
+      ).descriptor)
 }
 
 /**
@@ -290,10 +318,10 @@ trait CoreBTypesProxyGlobalIndependent[BTS <: BTypes] {
   def jiSerializableRef         : ClassBType
   def juHashMapRef              : ClassBType
   def juMapRef                  : ClassBType
+  def jliCallSiteRef            : ClassBType
+  def jliMethodTypeRef          : ClassBType
   def jliSerializedLambdaRef    : ClassBType
-  def jliMethodHandlesRef       : ClassBType
   def jliMethodHandlesLookupRef : ClassBType
-  def srLambdaDeserializerRef   : ClassBType
   def srBoxesRunTimeRef         : ClassBType
   def srBoxedUnitRef            : ClassBType
 
@@ -314,6 +342,9 @@ trait CoreBTypesProxyGlobalIndependent[BTS <: BTypes] {
   def tupleClassConstructors   : Map[InternalName, MethodNameAndType]
 
   def srJFunctionRefs: Set[InternalName]
+
+  def lambdaMetaFactoryBootstrapHandle  : asm.Handle
+  def lambdaDeserializeBootstrapHandle  : asm.Handle
 }
 
 /**
@@ -356,7 +387,6 @@ final class CoreBTypesProxy[BTFS <: BTypesFromSymbols[_ <: Global]](val bTypes: 
   def jliMethodTypeRef          : ClassBType = _coreBTypes.jliMethodTypeRef
   def jliCallSiteRef            : ClassBType = _coreBTypes.jliCallSiteRef
   def jliLambdaMetafactoryRef   : ClassBType = _coreBTypes.jliLambdaMetafactoryRef
-  def srLambdaDeserializerRef   : ClassBType = _coreBTypes.srLambdaDeserializerRef
   def srBoxesRunTimeRef         : ClassBType = _coreBTypes.srBoxesRunTimeRef
   def srBoxedUnitRef            : ClassBType = _coreBTypes.srBoxedUnitRef
 
@@ -378,6 +408,10 @@ final class CoreBTypesProxy[BTFS <: BTypesFromSymbols[_ <: Global]](val bTypes: 
 
   def srJFunctionRefs: Set[InternalName] = _coreBTypes.srJFunctionRefs
 
+  def srSymbolLiteral           : ClassBType = _coreBTypes.srSymbolLiteral
+  def srStructuralCallSite      : ClassBType = _coreBTypes.srStructuralCallSite
+  def srLambdaDeserialize       : ClassBType = _coreBTypes.srLambdaDeserialize
+
   def typeOfArrayOp: Map[Int, BType] = _coreBTypes.typeOfArrayOp
 
   // Some symbols. These references should probably be moved to Definitions.
@@ -390,4 +424,7 @@ final class CoreBTypesProxy[BTFS <: BTypesFromSymbols[_ <: Global]](val bTypes: 
   def BeanInfoAttr: Symbol = _coreBTypes.BeanInfoAttr
 
   def String_valueOf: Symbol = _coreBTypes.String_valueOf
+
+  def lambdaMetaFactoryBootstrapHandle = _coreBTypes.lambdaMetaFactoryBootstrapHandle
+  def lambdaDeserializeBootstrapHandle = _coreBTypes.lambdaDeserializeBootstrapHandle
 }

--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -87,24 +87,6 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
 
         /* ### CREATING THE METHOD CACHE ### */
 
-        def addStaticVariableToClass(forName: TermName, forType: Type, forInit: Tree, isFinal: Boolean): Symbol = {
-          val flags = PRIVATE | STATIC | SYNTHETIC | (
-            if (isFinal) FINAL else 0
-          )
-
-          val varSym = currentClass.newVariable(mkTerm("" + forName), ad.pos, flags.toLong) setInfoAndEnter forType
-          if (!isFinal)
-            varSym.addAnnotation(VolatileAttr)
-
-          val varDef = typedPos(ValDef(varSym, forInit))
-          newStaticMembers append transform(varDef)
-
-          val varInit = typedPos( REF(varSym) === forInit )
-          newStaticInits append transform(varInit)
-
-          varSym
-        }
-
         def addStaticMethodToClass(forBody: (Symbol, Symbol) => Tree): Symbol = {
           val methSym = currentClass.newMethod(mkTerm(nme.reflMethodName.toString), ad.pos, STATIC | SYNTHETIC)
           val params  = methSym.newSyntheticValueParams(List(ClassClass.tpe))
@@ -114,9 +96,6 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
           newStaticMembers append transform(methDef)
           methSym
         }
-
-        def fromTypesToClassArrayLiteral(paramTypes: List[Type]): Tree =
-          ArrayValue(TypeTree(ClassClass.tpe), paramTypes map LIT)
 
         def reflectiveMethodCache(method: String, paramTypes: List[Type]): Symbol = {
           /* Implementation of the cache is as follows for method "def xyz(a: A, b: B)"
@@ -128,7 +107,7 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
             var reflPoly$Cache: SoftReference[scala.runtime.MethodCache] = new SoftReference(new EmptyMethodCache())
 
             def reflMethod$Method(forReceiver: JClass[_]): JMethod = {
-              var methodCache: MethodCache = reflPoly$Cache.find(forReceiver)
+              var methodCache: StructuralCallSite = indy[StructuralCallSite.bootstrap, "(LA;LB;)Ljava/lang/Object;]
               if (methodCache eq null) {
                 methodCache = new EmptyMethodCache
                 reflPoly$Cache = new SoftReference(methodCache)
@@ -137,41 +116,32 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
               if (method ne null)
                 return method
               else {
-                method = ScalaRunTime.ensureAccessible(forReceiver.getMethod("xyz", reflParams$Cache))
-                reflPoly$Cache = new SoftReference(methodCache.add(forReceiver, method))
+                method = ScalaRunTime.ensureAccessible(forReceiver.getMethod("xyz", methodCache.parameterTypes()))
+                methodCache.add(forReceiver, method)
                 return method
               }
             }
+
+            invokedynamic is used rather than a static field for the cache to support emitting bodies of methods
+            in Java 8 interfaces, which don't support private static fields.
           */
 
-          val reflParamsCacheSym: Symbol =
-            addStaticVariableToClass(nme.reflParamsCacheName, arrayType(ClassClass.tpe), fromTypesToClassArrayLiteral(paramTypes), true)
-
-          def mkNewPolyCache = gen.mkSoftRef(NEW(TypeTree(EmptyMethodCacheClass.tpe)))
-          val reflPolyCacheSym: Symbol = addStaticVariableToClass(nme.reflPolyCacheName, SoftReferenceClass.tpe, mkNewPolyCache, false)
-
-          def getPolyCache = gen.mkCast(fn(REF(reflPolyCacheSym), nme.get), MethodCacheClass.tpe)
-
           addStaticMethodToClass((reflMethodSym, forReceiverSym) => {
-            val methodCache = reflMethodSym.newVariable(mkTerm("methodCache"), ad.pos) setInfo MethodCacheClass.tpe
+            val methodCache = reflMethodSym.newVariable(mkTerm("methodCache"), ad.pos) setInfo StructuralCallSite.tpe
             val methodSym = reflMethodSym.newVariable(mkTerm("method"), ad.pos) setInfo MethodClass.tpe
 
+            val dummyMethodType = MethodType(NoSymbol.newSyntheticValueParams(paramTypes), AnyTpe)
             BLOCK(
-              ValDef(methodCache, getPolyCache),
-              IF (REF(methodCache) OBJ_EQ NULL) THEN BLOCK(
-                REF(methodCache) === NEW(TypeTree(EmptyMethodCacheClass.tpe)),
-                REF(reflPolyCacheSym) === gen.mkSoftRef(REF(methodCache))
-              ) ENDIF,
-
-              ValDef(methodSym, (REF(methodCache) DOT methodCache_find)(REF(forReceiverSym))),
+              ValDef(methodCache, ApplyDynamic(gen.mkAttributedIdent(StructuralCallSite_dummy), LIT(StructuralCallSite_bootstrap) :: LIT(dummyMethodType) :: Nil).setType(StructuralCallSite.tpe)),
+              ValDef(methodSym, (REF(methodCache) DOT StructuralCallSite_find)(REF(forReceiverSym))),
               IF (REF(methodSym) OBJ_NE NULL) .
                 THEN (Return(REF(methodSym)))
               ELSE {
-                def methodSymRHS  = ((REF(forReceiverSym) DOT Class_getMethod)(LIT(method), REF(reflParamsCacheSym)))
-                def cacheRHS      = ((REF(methodCache) DOT methodCache_add)(REF(forReceiverSym), REF(methodSym)))
+                def methodSymRHS  = ((REF(forReceiverSym) DOT Class_getMethod)(LIT(method), (REF(methodCache) DOT StructuralCallSite_getParameterTypes)()))
+                def cacheAdd      = ((REF(methodCache) DOT StructuralCallSite_add)(REF(forReceiverSym), REF(methodSym)))
                 BLOCK(
                   REF(methodSym)        === (REF(currentRun.runDefinitions.ensureAccessibleMethod) APPLY (methodSymRHS)),
-                  REF(reflPolyCacheSym) === gen.mkSoftRef(cacheRHS),
+                  cacheAdd,
                   Return(REF(methodSym))
                 )
               }
@@ -371,6 +341,8 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
                   reporter.error(ad.pos, "Cannot resolve overload.")
                   (Nil, NoType)
               }
+            case NoType =>
+              abort(ad.symbol.toString)
           }
           typedPos {
             val sym = currentOwner.newValue(mkTerm("qual"), ad.pos) setInfo qual0.tpe
@@ -448,7 +420,7 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
        *   refinement, where the refinement defines a parameter based on a
        *   type variable. */
 
-      case tree: ApplyDynamic =>
+      case tree: ApplyDynamic if tree.symbol.owner.isRefinementClass =>
         transformApplyDynamic(tree)
 
       /* Some cleanup transformations add members to templates (classes, traits, etc).
@@ -478,46 +450,15 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
 
      /*
       * This transformation should identify Scala symbol invocations in the tree and replace them
-      * with references to a static member. Also, whenever a class has at least a single symbol invocation
-      * somewhere in its methods, a new static member should be created and initialized for that symbol.
-      * For instance, say we have a Scala class:
-      *
-      * class Cls {
-      *   def someSymbol1 = 'Symbolic1
-      *   def someSymbol2 = 'Symbolic2
-      *   def sameSymbol1 = 'Symbolic1
-      *   val someSymbol3 = 'Symbolic3
-      * }
-      *
-      * After transformation, this class looks like this:
-      *
-      * class Cls {
-      *   private <static> var symbol$1: scala.Symbol
-      *   private <static> var symbol$2: scala.Symbol
-      *   private <static> var symbol$3: scala.Symbol
-      *   private          val someSymbol3: scala.Symbol
-      *
-      *   private <static> def <clinit> = {
-      *     symbol$1 = Symbol.apply("Symbolic1")
-      *     symbol$2 = Symbol.apply("Symbolic2")
-      *   }
-      *
-      *   private def <init> = {
-      *     someSymbol3 = symbol$3
-      *   }
-      *
-      *   def someSymbol1 = symbol$1
-      *   def someSymbol2 = symbol$2
-      *   def sameSymbol1 = symbol$1
-      *   val someSymbol3 = someSymbol3
-      * }
+      * with references to a statically cached instance.
       *
       * The reasoning behind this transformation is the following. Symbols get interned - they are stored
       * in a global map which is protected with a lock. The reason for this is making equality checks
       * quicker. But calling Symbol.apply, although it does return a unique symbol, accesses a locked object,
       * making symbol access slow. To solve this, the unique symbol from the global symbol map in Symbol
-      * is accessed only once during class loading, and after that, the unique symbol is in the static
-      * member. Hence, it is cheap to both reach the unique symbol and do equality checks on it.
+      * is accessed only once during class loading, and after that, the unique symbol is in the statically
+      * initialized call site returned by invokedynamic. Hence, it is cheap to both reach the unique symbol
+      * and do equality checks on it.
       *
       * And, finally, be advised - Scala's Symbol literal (scala.Symbol) and the Symbol class of the compiler
       * have little in common.
@@ -525,15 +466,7 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
       case Apply(fn @ Select(qual, _), (arg @ Literal(Constant(symname: String))) :: Nil)
         if treeInfo.isQualifierSafeToElide(qual) && fn.symbol == Symbol_apply && !currentClass.isTrait =>
 
-        def transformApply = {
-          // add the symbol name to a map if it's not there already
-          val rhs = gen.mkMethodCall(Symbol_apply, arg :: Nil)
-          val staticFieldSym = getSymbolStaticField(tree.pos, symname, rhs, tree)
-          // create a reference to a static field
-          val ntree = typedWithPos(tree.pos)(REF(staticFieldSym))
-          super.transform(ntree)
-        }
-        transformApply
+        super.transform(treeCopy.ApplyDynamic(tree, atPos(fn.pos)(Ident(SymbolLiteral_dummy).setType(SymbolLiteral_dummy.info)), LIT(SymbolLiteral_bootstrap) :: arg :: Nil))
 
       // Replaces `Array(Predef.wrapArray(ArrayValue(...).$asInstanceOf[...]), <tag>)`
       // with just `ArrayValue(...).$asInstanceOf[...]`
@@ -548,32 +481,6 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
 
       case _ =>
         super.transform(tree)
-    }
-
-    /* Returns the symbol and the tree for the symbol field interning a reference to a symbol 'synmname'.
-     * If it doesn't exist, i.e. the symbol is encountered the first time,
-     * it creates a new static field definition and initialization and returns it.
-     */
-    private def getSymbolStaticField(pos: Position, symname: String, rhs: Tree, tree: Tree): Symbol = {
-      symbolsStoredAsStatic.getOrElseUpdate(symname, {
-        val theTyper = typer.atOwner(tree, currentClass)
-
-        // create a symbol for the static field
-        val stfieldSym = (
-          currentClass.newVariable(mkTerm("symbol$"), pos, PRIVATE | STATIC | SYNTHETIC | FINAL)
-            setInfoAndEnter SymbolClass.tpe
-        )
-
-        // create field definition and initialization
-        val stfieldDef  = theTyper.typedPos(pos)(ValDef(stfieldSym, rhs))
-        val stfieldInit = theTyper.typedPos(pos)(REF(stfieldSym) === rhs)
-
-        // add field definition to new defs
-        newStaticMembers append stfieldDef
-        newStaticInits append stfieldInit
-
-        stfieldSym
-      })
     }
 
   } // CleanUpTransformer

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -1150,6 +1150,8 @@ abstract class Erasure extends AddInterfaces
             case DefDef(_, _, _, _, tpt, _) =>
               try super.transform(tree1).clearType()
               finally tpt setType specialErasure(tree1.symbol)(tree1.symbol.tpe).resultType
+            case ApplyDynamic(qual, Literal(Constant(boostrapMethodRef: Symbol)) :: _) =>
+              tree
             case _ =>
               super.transform(tree1).clearType()
           }

--- a/src/library/scala/runtime/LambdaDeserialize.java
+++ b/src/library/scala/runtime/LambdaDeserialize.java
@@ -1,0 +1,29 @@
+package scala.runtime;
+
+
+import java.lang.invoke.*;
+import java.util.Arrays;
+import java.util.HashMap;
+
+public final class LambdaDeserialize {
+
+    private MethodHandles.Lookup lookup;
+    private final HashMap<String, MethodHandle> cache = new HashMap<>();
+    private final LambdaDeserializer$ l = LambdaDeserializer$.MODULE$;
+
+    private LambdaDeserialize(MethodHandles.Lookup lookup) {
+        this.lookup = lookup;
+    }
+
+    public Object deserializeLambda(SerializedLambda serialized) {
+        return l.deserializeLambda(lookup, cache, serialized);
+    }
+
+    public static CallSite bootstrap(MethodHandles.Lookup lookup, String invokedName,
+                                     MethodType invokedType) throws Throwable {
+        MethodType type = MethodType.fromMethodDescriptorString("(Ljava/lang/invoke/SerializedLambda;)Ljava/lang/Object;", lookup.getClass().getClassLoader());
+        MethodHandle deserializeLambda = lookup.findVirtual(LambdaDeserialize.class, "deserializeLambda", type);
+        MethodHandle exact = deserializeLambda.bindTo(new LambdaDeserialize(lookup)).asType(invokedType);
+        return new ConstantCallSite(exact);
+    }
+}

--- a/src/library/scala/runtime/StructuralCallSite.java
+++ b/src/library/scala/runtime/StructuralCallSite.java
@@ -1,0 +1,43 @@
+package scala.runtime;
+
+
+import java.lang.invoke.*;
+import java.lang.ref.SoftReference;
+import java.lang.reflect.Method;
+
+public final class StructuralCallSite {
+
+    private Class<?>[] parameterTypes;
+    private SoftReference<MethodCache> cache = new SoftReference<>(new EmptyMethodCache());
+
+    private StructuralCallSite(MethodType callType) {
+        parameterTypes = callType.parameterArray();
+    }
+
+    public MethodCache get() {
+        MethodCache cache = this.cache.get();
+        if (cache == null) {
+            cache = new EmptyMethodCache();
+            this.cache = new SoftReference<>(cache);
+        }
+        return cache;
+    }
+
+    public Method find(Class<?> receiver) {
+        return get().find(receiver);
+    }
+
+    public Method add(Class<?> receiver, Method m) {
+        cache = new SoftReference<MethodCache>(get().add(receiver, m));
+        return m;
+    }
+    public Class<?>[] parameterTypes() {
+        return parameterTypes;
+    }
+
+    public static CallSite bootstrap(MethodHandles.Lookup lookup, String invokedName,
+                                     MethodType invokedType, MethodType reflectiveCallType) throws Throwable {
+        StructuralCallSite structuralCallSite = new StructuralCallSite(reflectiveCallType);
+        return new ConstantCallSite(MethodHandles.constant(StructuralCallSite.class, structuralCallSite));
+    }
+}

--- a/src/library/scala/runtime/SymbolLiteral.java
+++ b/src/library/scala/runtime/SymbolLiteral.java
@@ -1,0 +1,20 @@
+package scala.runtime;
+
+import java.lang.invoke.*;
+import java.util.regex.Pattern;
+
+public final class SymbolLiteral {
+    private SymbolLiteral() {
+    }
+
+    public static CallSite bootstrap(MethodHandles.Lookup lookup, String invokedName,
+                                     MethodType invokedType,
+                                     String value) throws Throwable {
+        ClassLoader classLoader = lookup.lookupClass().getClassLoader();
+        MethodType type = MethodType.fromMethodDescriptorString("(Ljava/lang/Object;)Ljava/lang/Object;", classLoader);
+        Class<?> symbolClass = Class.forName("scala.Symbol", false, classLoader);
+        MethodHandle factoryMethod = lookup.findStatic(symbolClass, "apply", type);
+        Object symbolValue = factoryMethod.invokeWithArguments(value);
+        return new ConstantCallSite(MethodHandles.constant(symbolClass, symbolValue));
+    }
+}

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -459,6 +459,16 @@ trait Definitions extends api.StandardDefinitions {
     lazy val MethodCacheClass       = requiredClass[scala.runtime.MethodCache]
       def methodCache_find          = getMemberMethod(MethodCacheClass, nme.find_)
       def methodCache_add           = getMemberMethod(MethodCacheClass, nme.add_)
+    lazy val StructuralCallSite     = getClassIfDefined("scala.runtime.StructuralCallSite")
+      def StructuralCallSite_bootstrap = getMemberMethod(StructuralCallSite.linkedClassOfClass, sn.Bootstrap)
+    // Marker for invokedynamic runtime.StructuralCall.bootstrap
+    lazy val StructuralCallSite_dummy = NoSymbol.newMethodSymbol(nme.apply).setInfo(NullaryMethodType(StructuralCallSite.tpe))
+      def StructuralCallSite_find              = getMemberIfDefined(StructuralCallSite, nme.find_)
+      def StructuralCallSite_add               = getMemberIfDefined(StructuralCallSite, nme.add_)
+      def StructuralCallSite_getParameterTypes = getMemberIfDefined(StructuralCallSite, nme.parameterTypes)
+    lazy val SymbolLiteral        = getClassIfDefined("scala.runtime.SymbolLiteral")
+      def SymbolLiteral_bootstrap = getMemberIfDefined(SymbolLiteral.linkedClassOfClass, sn.Bootstrap)
+      def SymbolLiteral_dummy     = NoSymbol.newMethodSymbol(nme.apply).setInfo(NullaryMethodType(SymbolModule.companionClass.tpe))
 
     // XML
     lazy val ScalaXmlTopScope = getModuleIfDefined("scala.xml.TopScope")

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -696,6 +696,7 @@ trait StdNames {
     val freshTermName: NameType        = "freshTermName"
     val freshTypeName: NameType        = "freshTypeName"
     val get: NameType                  = "get"
+    val parameterTypes: NameType       = "parameterTypes"
     val hashCode_ : NameType           = "hashCode"
     val hash_ : NameType               = "hash"
     val head : NameType                = "head"
@@ -1170,6 +1171,7 @@ trait StdNames {
     final val InvokeExact: TermName      = newTermName("invokeExact")
 
     final val AltMetafactory: TermName      = newTermName("altMetafactory")
+    final val Bootstrap: TermName           = newTermName("bootstrap")
 
     val Boxed = immutable.Map[TypeName, TypeName](
       tpnme.Boolean -> BoxedBoolean,

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -282,6 +282,9 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.MethodClass
     definitions.EmptyMethodCacheClass
     definitions.MethodCacheClass
+    definitions.StructuralCallSite
+    definitions.StructuralCallSite_dummy
+    definitions.SymbolLiteral
     definitions.ScalaXmlTopScope
     definitions.ScalaXmlPackage
     definitions.ReflectPackage

--- a/test/files/instrumented/indy-symbol-literal.scala
+++ b/test/files/instrumented/indy-symbol-literal.scala
@@ -1,0 +1,19 @@
+import scala.tools.partest.instrumented._
+import scala.tools.partest.instrumented.Instrumentation._
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    'warmup
+    startProfiling()
+    var i = 0;
+    while (i < 2) {
+      'foo.name
+      i += 1
+    }
+    stopProfiling()
+    // Only expect a single call to lookup the interned Symbol at each call site the defines
+    // a single literal.
+    val Symbol_apply = MethodCallTrace("scala/Symbol$", "apply", "(Ljava/lang/String;)Lscala/Symbol;")
+    assert(getStatistics.get(Symbol_apply) == Some(1), getStatistics);
+  }
+}

--- a/test/files/run/indy-via-macro-with-dynamic-args/Bootstrap.java
+++ b/test/files/run/indy-via-macro-with-dynamic-args/Bootstrap.java
@@ -1,0 +1,17 @@
+package test;
+
+import java.lang.invoke.*;
+import java.util.regex.Pattern;
+
+public final class Bootstrap {
+    private Bootstrap() {
+    }
+
+    /** Pre-compile a regex */
+    public static CallSite bootstrap(MethodHandles.Lookup lookup, String invokedName,
+                                     MethodType invokedType,
+                                     String value) throws Throwable {
+    	MethodHandle Pattern_matcher = MethodHandles.lookup().findVirtual(java.util.regex.Pattern.class, "matcher", MethodType.fromMethodDescriptorString("(Ljava/lang/CharSequence;)Ljava/util/regex/Matcher;", lookup.lookupClass().getClassLoader()));
+        return new ConstantCallSite(Pattern_matcher.bindTo(Pattern.compile(value)));
+    }
+}

--- a/test/files/run/indy-via-macro-with-dynamic-args/Test_2.scala
+++ b/test/files/run/indy-via-macro-with-dynamic-args/Test_2.scala
@@ -1,0 +1,6 @@
+object Test {
+  def main(args: Array[String]) {
+    val s = "foo!bar"
+    assert(Macro.matcher("foo.bar", s).matches == true)
+  }
+}

--- a/test/files/run/indy-via-macro-with-dynamic-args/macro_1.scala
+++ b/test/files/run/indy-via-macro-with-dynamic-args/macro_1.scala
@@ -1,0 +1,33 @@
+import java.util.regex._
+
+import scala.reflect.internal.SymbolTable
+import scala.reflect.macros.blackbox._
+import language.experimental.macros
+
+object Macro {
+  /**
+    * Equivalent to Pattern.compile(pat).matcher(text), but caches the compiled regex (using invokedynamic) if
+    * `pat` is a literal.
+    */
+  def matcher(pat: String, text: CharSequence): Matcher = macro Macro.impl
+  def impl(c: Context)(pat: c.Tree, text: c.Tree): c.Tree = {
+    def Indy(bootstrapMethod: c.Symbol, bootstrapArgs: List[c.universe.Literal], dynArgs: List[c.Tree]): c.Tree = {
+      val symtab = c.universe.asInstanceOf[SymbolTable]
+      import symtab._
+      val paramSym = NoSymbol.newTermSymbol(TermName("x")).setInfo(typeOf[CharSequence])
+      val dummySymbol = NoSymbol.newTermSymbol(TermName("matcher")).setInfo(internal.methodType(paramSym :: Nil, typeOf[java.util.regex.Matcher]))
+      val bootstrapArgTrees: List[Tree] = Literal(Constant(bootstrapMethod)).setType(NoType) :: bootstrapArgs.asInstanceOf[List[Tree]]
+      val result = ApplyDynamic(Ident(dummySymbol).setType(dummySymbol.info), bootstrapArgTrees ::: dynArgs.asInstanceOf[List[Tree]])
+      result.setType(dummySymbol.info.resultType)
+      result.asInstanceOf[c.Tree]
+    }
+    import c.universe._
+    pat match {
+      case l @ Literal(Constant(pat: String)) =>
+        val boostrapSym = typeOf[test.Bootstrap].companion.member(TermName("bootstrap"))
+        Indy(boostrapSym, l :: Nil, text :: Nil)
+      case _ =>
+        q"_root_.java.util.regex.Pattern.compile($pat).matcher($text)"
+    }
+  }
+}

--- a/test/files/run/indy-via-macro/Bootstrap.java
+++ b/test/files/run/indy-via-macro/Bootstrap.java
@@ -1,0 +1,16 @@
+package test;
+
+import java.lang.invoke.*;
+import java.util.regex.Pattern;
+
+public final class Bootstrap {
+    private Bootstrap() {
+    }
+
+    /** Pre-compile a regex */
+    public static CallSite bootstrap(MethodHandles.Lookup lookup, String invokedName,
+                                     MethodType invokedType,
+                                     String value) throws Throwable {
+        return new ConstantCallSite(MethodHandles.constant(Pattern.class, Pattern.compile(value)));
+    }
+}

--- a/test/files/run/indy-via-macro/Test_2.scala
+++ b/test/files/run/indy-via-macro/Test_2.scala
@@ -1,0 +1,5 @@
+object Test {
+  def main(args: Array[String]) {
+    assert(Macro.compilePattern("foo.bar").matcher("foo!bar").matches)
+  }
+}

--- a/test/files/run/indy-via-macro/macro_1.scala
+++ b/test/files/run/indy-via-macro/macro_1.scala
@@ -1,0 +1,32 @@
+import java.util.regex.Pattern
+
+import scala.reflect.internal.SymbolTable
+import scala.reflect.macros.blackbox._
+import language.experimental.macros
+
+object Macro {
+  /**
+    * Equivalent to Pattern.compile(s), but caches the compiled regex (using invokedynamic) if
+    * `s` is a literal.
+    */
+  def compilePattern(s: String): Pattern = macro Macro.impl
+  def impl(c: Context)(s: c.Tree): c.Tree = {
+    def Indy(bootstrapMethod: c.Symbol, bootstrapArgs: List[c.universe.Literal]): c.Tree = {
+      val symtab = c.universe.asInstanceOf[SymbolTable]
+      import symtab._
+      val dummySymbol = NoSymbol.newTermSymbol(TermName("compile")).setInfo(NullaryMethodType(typeOf[Pattern]))
+      val args: List[Tree] = Literal(Constant(bootstrapMethod)).setType(NoType) :: bootstrapArgs.asInstanceOf[List[Tree]]
+      val result = ApplyDynamic(Ident(dummySymbol).setType(dummySymbol.info), args)
+      result.setType(dummySymbol.info.resultType)
+      result.asInstanceOf[c.Tree]
+    }
+    import c.universe._
+    s match {
+      case l @ Literal(Constant(s: String)) =>
+        val boostrapSym = typeOf[test.Bootstrap].companion.member(TermName("bootstrap"))
+        Indy(boostrapSym, l :: Nil)
+      case _ =>
+        q"_root_.java.util.regex.Pattern.compile($s)"
+    }
+  }
+}

--- a/test/files/run/t7974.check
+++ b/test/files/run/t7974.check
@@ -1,26 +1,12 @@
 
-  // access flags 0x9
-  public static <clinit>()V
-    GETSTATIC scala/Symbol$.MODULE$ : Lscala/Symbol$;
-    LDC "Symbolic1"
-    INVOKEVIRTUAL scala/Symbol$.apply (Ljava/lang/String;)Lscala/Symbol;
-    PUTSTATIC Symbols.symbol$1 : Lscala/Symbol;
-    GETSTATIC scala/Symbol$.MODULE$ : Lscala/Symbol$;
-    LDC "Symbolic2"
-    INVOKEVIRTUAL scala/Symbol$.apply (Ljava/lang/String;)Lscala/Symbol;
-    PUTSTATIC Symbols.symbol$2 : Lscala/Symbol;
-    GETSTATIC scala/Symbol$.MODULE$ : Lscala/Symbol$;
-    LDC "Symbolic3"
-    INVOKEVIRTUAL scala/Symbol$.apply (Ljava/lang/String;)Lscala/Symbol;
-    PUTSTATIC Symbols.symbol$3 : Lscala/Symbol;
-    RETURN
-    MAXSTACK = 2
-    MAXLOCALS = 0
-
-
   // access flags 0x1
   public someSymbol1()Lscala/Symbol;
-    GETSTATIC Symbols.symbol$1 : Lscala/Symbol;
+    INVOKEDYNAMIC apply()Lscala/Symbol; [
+      // handle kind 0x6 : INVOKESTATIC
+      scala/runtime/SymbolLiteral.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;)Ljava/lang/invoke/CallSite;
+      // arguments:
+      "Symbolic1"
+    ]
     ARETURN
     MAXSTACK = 1
     MAXLOCALS = 1
@@ -28,7 +14,12 @@
 
   // access flags 0x1
   public someSymbol2()Lscala/Symbol;
-    GETSTATIC Symbols.symbol$2 : Lscala/Symbol;
+    INVOKEDYNAMIC apply()Lscala/Symbol; [
+      // handle kind 0x6 : INVOKESTATIC
+      scala/runtime/SymbolLiteral.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;)Ljava/lang/invoke/CallSite;
+      // arguments:
+      "Symbolic2"
+    ]
     ARETURN
     MAXSTACK = 1
     MAXLOCALS = 1
@@ -36,7 +27,12 @@
 
   // access flags 0x1
   public sameSymbol1()Lscala/Symbol;
-    GETSTATIC Symbols.symbol$1 : Lscala/Symbol;
+    INVOKEDYNAMIC apply()Lscala/Symbol; [
+      // handle kind 0x6 : INVOKESTATIC
+      scala/runtime/SymbolLiteral.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;)Ljava/lang/invoke/CallSite;
+      // arguments:
+      "Symbolic1"
+    ]
     ARETURN
     MAXSTACK = 1
     MAXLOCALS = 1
@@ -56,7 +52,12 @@
     ALOAD 0
     INVOKESPECIAL java/lang/Object.<init> ()V
     ALOAD 0
-    GETSTATIC Symbols.symbol$3 : Lscala/Symbol;
+    INVOKEDYNAMIC apply()Lscala/Symbol; [
+      // handle kind 0x6 : INVOKESTATIC
+      scala/runtime/SymbolLiteral.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;)Ljava/lang/invoke/CallSite;
+      // arguments:
+      "Symbolic3"
+    ]
     PUTFIELD Symbols.someSymbol3 : Lscala/Symbol;
     RETURN
     MAXSTACK = 2


### PR DESCRIPTION
The previous encodings created static fields in the enclosing class
to host caches. However, this isn't an option once emit code in default
methods of interfaces, as Java interfaces don't allow static fields.

Luckily, we can emulate a static field by using invokedynamic: when
the call site is linked, our bootstrap methid can perform one-time
computation, and we can capture the result in the CallSite.

Review by @lrytz. 

I can't remember why I needed to change `visitHandle`, but I know that the ugliness there is a symptom of a somewhat ad-hoc representation of indy calls in our trees. Ideally, we'd be able to come up with something general purpose, so that a macro author could emit an arbitrary indy call, without needing special cases in the backend for each bootstrap method.
