### PR TITLE
SI-8700 Exhaustiveness warning for enums from Java source

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -671,7 +671,7 @@ class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
     // Primitives are "abstract final" to prohibit instantiation
     // without having to provide any implementations, but that is an
     // illegal combination of modifiers at the bytecode level so
-    // suppress final if abstract if present.
+    // suppress final if abstract is present.
     import asm.Opcodes._
     GenBCode.mkFlags(
       if (privateFlag) ACC_PRIVATE else ACC_PUBLIC,

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -542,7 +542,7 @@ abstract class ClassfileParser {
             devWarning(s"no linked class for java enum $sym in ${sym.owner}. A referencing class file might be missing an InnerClasses entry.")
           case linked =>
             if (!linked.isSealed)
-              // Marking the enum class SEALED | ABSTRACT enables exhaustiveness checking.
+              // Marking the enum class SEALED | ABSTRACT enables exhaustiveness checking. See also JavaParsers.
               // This is a bit of a hack and requires excluding the ABSTRACT flag in the backend, see method javaClassfileFlags.
               linked setFlag (SEALED | ABSTRACT)
             linked addChild sym

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -653,8 +653,10 @@ trait Namers extends MethodSynthesis {
       if (isScala && deriveAccessors(tree)) enterGetterSetter(tree)
       else assignAndEnterFinishedSymbol(tree)
 
-      if (isEnumConstant(tree))
+      if (isEnumConstant(tree)) {
         tree.symbol setInfo ConstantType(Constant(tree.symbol))
+        tree.symbol.owner.linkedClassOfClass addChild tree.symbol
+      }
     }
 
     def enterLazyVal(tree: ValDef, lazyAccessor: Symbol): TermSymbol = {
@@ -1657,7 +1659,8 @@ trait Namers extends MethodSynthesis {
         checkWithDeferred(FINAL)
       }
 
-      checkNoConflict(FINAL, SEALED)
+      if (!sym.isJavaEnum)
+        checkNoConflict(FINAL, SEALED)
       checkNoConflict(PRIVATE, PROTECTED)
       // checkNoConflict(PRIVATE, OVERRIDE) // this one leads to bad error messages like #4174, so catch in refchecks
       // checkNoConflict(PRIVATE, FINAL)    // can't do this because FINAL also means compile-time constant

--- a/test/files/neg/t8700a.check
+++ b/test/files/neg/t8700a.check
@@ -1,0 +1,11 @@
+Bar.scala:2: warning: match may not be exhaustive.
+It would fail on the following input: B
+  def bar1(foo: Foo) = foo match {
+                       ^
+Bar.scala:6: warning: match may not be exhaustive.
+It would fail on the following input: B
+  def bar2(foo: Baz) = foo match {
+                       ^
+error: No warnings can be incurred under -Xfatal-warnings.
+two warnings found
+one error found

--- a/test/files/neg/t8700a.flags
+++ b/test/files/neg/t8700a.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/t8700a/Bar.scala
+++ b/test/files/neg/t8700a/Bar.scala
@@ -1,0 +1,9 @@
+object Bar {
+  def bar1(foo: Foo) = foo match {
+    case Foo.A => 1
+  }
+
+  def bar2(foo: Baz) = foo match {
+    case Baz.A => 1
+    }
+}

--- a/test/files/neg/t8700a/Baz.java
+++ b/test/files/neg/t8700a/Baz.java
@@ -1,0 +1,11 @@
+public enum Baz {
+    A {
+    	public void baz1() {}
+    },
+    B {
+        public void baz1() {}
+    };
+
+    public abstract void baz1();
+    public void baz2() {}
+}

--- a/test/files/neg/t8700a/Foo.java
+++ b/test/files/neg/t8700a/Foo.java
@@ -1,0 +1,4 @@
+public enum Foo {
+    A,
+    B
+}

--- a/test/files/neg/t8700b.check
+++ b/test/files/neg/t8700b.check
@@ -1,0 +1,11 @@
+Bar_2.scala:2: warning: match may not be exhaustive.
+It would fail on the following input: B
+  def bar1(foo: Foo_1) = foo match {
+                         ^
+Bar_2.scala:6: warning: match may not be exhaustive.
+It would fail on the following input: B
+  def bar2(foo: Baz_1) = foo match {
+                         ^
+error: No warnings can be incurred under -Xfatal-warnings.
+two warnings found
+one error found

--- a/test/files/neg/t8700b.flags
+++ b/test/files/neg/t8700b.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/t8700b/Bar_2.scala
+++ b/test/files/neg/t8700b/Bar_2.scala
@@ -1,0 +1,9 @@
+object Bar {
+  def bar1(foo: Foo_1) = foo match {
+    case Foo_1.A => 1
+  }
+
+  def bar2(foo: Baz_1) = foo match {
+    case Baz_1.A => 1
+    }
+}

--- a/test/files/neg/t8700b/Baz_1.java
+++ b/test/files/neg/t8700b/Baz_1.java
@@ -1,0 +1,11 @@
+public enum Baz_1 {
+    A {
+    	public void baz1() {}
+    },
+    B {
+        public void baz1() {}
+    };
+
+    public abstract void baz1();
+    public void baz2() {}
+}

--- a/test/files/neg/t8700b/Foo_1.java
+++ b/test/files/neg/t8700b/Foo_1.java
@@ -1,0 +1,4 @@
+public enum Foo_1 {
+    A,
+    B
+}


### PR DESCRIPTION
Until now, the warning was only emitted for enums from Java class files.

This commit fixes it by
- aligning the flags set in JavaParsers with the flags set in
  ClassfileParser (which are required by the pattern matcher to
  even consider checking exhaustiveness)
- adding the enum members as childs to the class holding the enum
  as done in ClassfileParser so that the pattern matcher sees the enum
  members when looking for the sealed children of a type
