### PR TITLE
Remove duplicate words across the code base.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/package.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/package.scala
@@ -191,7 +191,7 @@ package scala.tools.nsc.backend.jvm
  * I measured nullness analysis (which tracks aliases) and a SimpleValue analysis. Nullness runs
  * roughly 5x slower (because of alias tracking) at every problem size - this factor doesn't change.
  *
- * The numbers below are for nullness. Note that the the last column is constant, i.e., the running
+ * The numbers below are for nullness. Note that the last column is constant, i.e., the running
  * time is proportional to #ins * #loc^2. Therefore we use this factor when limiting the maximal
  * method size for running an analysis.
  *

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
@@ -114,7 +114,7 @@ object BytecodeUtils {
   }
 
   def sameTargetExecutableInstruction(a: JumpInsnNode, b: JumpInsnNode): Boolean = {
-    // Compare next executable instead of the the labels. Identifies a, b as the same target:
+    // Compare next executable instead of the labels. Identifies a, b as the same target:
     //   LabelNode(a)
     //   LabelNode(b)
     //   Instr

--- a/src/compiler/scala/tools/nsc/transform/Constructors.scala
+++ b/src/compiler/scala/tools/nsc/transform/Constructors.scala
@@ -305,7 +305,7 @@ abstract class Constructors extends Statics with Transform with ast.TreeDSL {
       val delayedHook     = delayedEndpointDef(remainingConstrStats)
       val delayedHookSym  = delayedHook.symbol.asInstanceOf[MethodSymbol]
 
-      // transform to make the closure-class' default constructor assign the the outer instance to its param-accessor field.
+      // transform to make the closure-class' default constructor assign the outer instance to its param-accessor field.
       val hookCallerClass = (new ConstructorTransformer(unit)) transform delayedInitClosure(delayedHookSym)
       val delayedInitCall = localTyper.typedPos(impl.pos) {
         gen.mkMethodCall(This(clazz), delayedInitMethod, Nil, List(New(hookCallerClass.symbol.tpe, This(clazz))))

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -651,7 +651,7 @@ abstract class UnCurry extends InfoTransform
      * This transformation erases the dependent method types by:
      *   - Widening the formal parameter type to existentially abstract
      *     over the prior parameters (using `packSymbols`). This transformation
-     *     is performed in the the `InfoTransform`er [[scala.reflect.internal.transform.UnCurry]].
+     *     is performed in the `InfoTransform`er [[scala.reflect.internal.transform.UnCurry]].
      *   - Inserting casts in the method body to cast to the original,
      *     precise type.
      *

--- a/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
@@ -542,7 +542,7 @@ trait ScalaLogic extends Interface with Logic with TreeAndTypeAnalysis {
          *
          * (0) A or B must be in the domain to draw any conclusions.
          *
-         *     For example, knowing the the scrutinee is *not* true does not
+         *     For example, knowing the scrutinee is *not* true does not
          *     statically exclude it from being `X`, because that is an opaque
          *     Boolean.
          *

--- a/src/compiler/scala/tools/nsc/typechecker/AnalyzerPlugins.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/AnalyzerPlugins.scala
@@ -65,7 +65,7 @@ trait AnalyzerPlugins { self: Analyzer =>
      * The hooks into `typeSig` allow analyzer plugins to add annotations to (or change the types
      * of) definition symbols. This cannot not be achieved by using `pluginsTyped`: this method
      * is only called during type checking, so changing the type of a symbol at this point is too
-     * late: references to the symbol might already be typed and therefore obtain the the original
+     * late: references to the symbol might already be typed and therefore obtain the original
      * type assigned during naming.
      *
      * @param defTree is the definition for which the type was computed. The different cases are

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -56,7 +56,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     new FreeTypeSymbol(name, origin) initFlags flags
 
   /**
-   * This map stores the original owner the the first time the owner of a symbol is re-assigned.
+   * This map stores the original owner the first time the owner of a symbol is re-assigned.
    * The original owner of a symbol is needed in some places in the backend. Ideally, owners should
    * be versioned like the type history.
    */

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/jquery.layout.js
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/jquery.layout.js
@@ -752,7 +752,7 @@ $.layout.defaults = {
  *	PANE-SPECIFIC SETTINGS
  *	- options listed below MUST be specified per-pane - they CANNOT be set under 'panes'
  *	- all options under the 'panes' key can also be set specifically for any pane
- *	- most options under the 'panes' key apply only to 'border-panes' - NOT the the center-pane
+ *	- most options under the 'panes' key apply only to 'border-panes' - NOT the center-pane
  */
 ,	north: {
 		paneSelector:			".ui-layout-north"
@@ -921,7 +921,7 @@ $.layout.backwardCompatibility = {
 			$.extend(true, opts.panes, opts.defaults);
 			delete opts.defaults;
 		}
-		// rename options in the the options.panes key
+		// rename options in the options.panes key
 		if (opts.panes) ren( opts.panes );
 		// rename options inside *each pane key*, eg: options.west
 		$.each($.layout.config.allPanes, function (i, pane) {


### PR DESCRIPTION
This fixes a few minor duplicate words.

This is my first contribution and a test to make sure I get the process correct.
