### PR TITLE
SI-9599 Multiple @todo formatted with comma on separate line

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
@@ -624,7 +624,7 @@ class Template(universe: doc.Universe, generator: DiagramGenerator, tpl: DocTemp
             <dt>To do</dt>
             <dd>{
               val todoXml: List[NodeSeq] = (for(todo <- comment.todo ) yield <span class="cmt">{bodyToHtml(todo)}</span> )
-              todoXml.reduceLeft(_ ++ Text(", ") ++ _)
+              todoXml.reduceLeft(_ ++ _)
             }</dd>
           }
 

--- a/test/scaladoc/resources/SI-9599.scala
+++ b/test/scaladoc/resources/SI-9599.scala
@@ -1,0 +1,6 @@
+/**
+  * @todo todo1
+  * @todo todo2
+  * @todo todo3
+  */
+class X

--- a/test/scaladoc/scalacheck/HtmlFactoryTest.scala
+++ b/test/scaladoc/scalacheck/HtmlFactoryTest.scala
@@ -819,4 +819,11 @@ object Test extends Properties("HtmlFactory") {
     }
 
   }
+
+  property("SI-9599 Multiple @todo formatted with comma on separate line") = {
+    createTemplates("SI-9599.scala")("X.html") match {
+      case node: scala.xml.Node => node.text.contains("todo3todo2todo1")
+      case _ => false
+    }
+  }
 }


### PR DESCRIPTION
Hi!

[This is my first Scala fix, so please forgive any mistakes]

From `bodyTags` definition at CommentFactoryBase.scala:318 and WikiParser.document(), it seems we only generate block-like structures for "@todo", so the comma joiner can be removed as unneeded.

I don't think this fix deserves a test so I didn't write one, or should I?

Thanks!
