### PR TITLE
SI-9629 Emit missing 'pattern must be a value' error

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5421,6 +5421,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         if (!isPastTyper)
           signalDone(context.asInstanceOf[analyzer.Context], tree, result)
 
+        if (mode.inPatternMode && !mode.inPolyMode && result.isType)
+          PatternMustBeValue(result, pt)
+
         result
       }
 
@@ -5510,10 +5513,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       // as a compromise, context.enrichmentEnabled tells adaptToMember to go ahead and enrich,
       // but arbitrary conversions (in adapt) are disabled
       // TODO: can we achieve the pattern matching bit of the string interpolation SIP without this?
-      typingInPattern(context.withImplicitsDisabledAllowEnrichment(typed(tree, PATTERNmode, pt))) match {
-        case tpt if tpt.isType => PatternMustBeValue(tpt, pt); tpt
-        case pat               => pat
-      }
+      typingInPattern(context.withImplicitsDisabledAllowEnrichment(typed(tree, PATTERNmode, pt)))
     }
 
     /** Types a (fully parameterized) type tree */

--- a/test/files/neg/t9629.check
+++ b/test/files/neg/t9629.check
@@ -1,0 +1,17 @@
+t9629.scala:4: error: pattern must be a value: Option[Int]
+Note: if you intended to match against the class, try `case _: Option[_]`
+      case Option[Int] => // error was issued before
+                 ^
+t9629.scala:5: error: pattern must be a value: Option[Int]
+Note: if you intended to match against the class, try `case _: Option[_]`
+      case Some(Option[Int]) => // error was skipped, patmat issued an internal error
+                      ^
+t9629.scala:8: error: pattern must be a value: Option[Int]
+Note: if you intended to match against the class, try `case _: Option[_]`
+      case (_, Option[Int]) =>
+                     ^
+t9629.scala:9: error: pattern must be a value: Option[Int]
+Note: if you intended to match against the class, try `case _: Option[_]`
+      case x @ (y @ Option[Int]) =>
+                          ^
+four errors found

--- a/test/files/neg/t9629.scala
+++ b/test/files/neg/t9629.scala
@@ -1,0 +1,12 @@
+class Test {
+  def foo(a: Any) {
+    a match {
+      case Option[Int] => // error was issued before
+      case Some(Option[Int]) => // error was skipped, patmat issued an internal error
+
+      // variations
+      case (_, Option[Int]) =>
+      case x @ (y @ Option[Int]) =>
+    }
+  }
+}


### PR DESCRIPTION
The error used to only be emitted for top-level patterns.

This commit moves it into `typedInternal` so it works
for nested patterns. It uses the typer mode to know
when to fire.
