### PR TITLE
SI-9534 Use BoxedUnit in all cases for creating Array[Unit]

### DIFF
--- a/src/library/scala/reflect/Manifest.scala
+++ b/src/library/scala/reflect/Manifest.scala
@@ -157,6 +157,9 @@ object ManifestFactory {
     override def newArray(len: Int): Array[Unit] = new Array[Unit](len)
     override def newWrappedArray(len: Int): WrappedArray[Unit] = new WrappedArray.ofUnit(new Array[Unit](len))
     override def newArrayBuilder(): ArrayBuilder[Unit] = new ArrayBuilder.ofUnit()
+    override protected def arrayClass[T](tp: Class[_]): Class[Array[T]] =
+      if (tp eq runtimeClass) classOf[Array[scala.runtime.BoxedUnit]].asInstanceOf[Class[Array[T]]]
+      else super.arrayClass(tp)
     private def readResolve(): Any = Manifest.Unit
   }
 

--- a/test/junit/scala/reflect/ClassTag.scala
+++ b/test/junit/scala/reflect/ClassTag.scala
@@ -26,4 +26,14 @@ class ClassTagTest {
   @Test def checkDouble  = assertTrue(checkNotInt[Double] (0.toDouble))
   @Test def checkBoolean = assertTrue(checkNotInt[Boolean](false))
   @Test def checkUnit    = assertTrue(checkNotInt[Unit]   ({}))
+
+  @Test def t9534: Unit = {
+    val ct = implicitly[scala.reflect.ClassTag[Unit]]
+    val a1 = ct.newArray(1)
+    a1(0) = ()
+    val a2 = ct.wrap.newArray(1)
+    a2(0) = a1
+    val a3 = ct.newArray2(1)
+    a3(0) = a1
+  }
 }


### PR DESCRIPTION
Calling `wrap` or one of the higher-dimension Array factory methods on
the `Manifest` for `Unit` led to an exception because it tried to use
`void` as a primitive type. Unlike all other primitive Scala types,
`Unit` needs to be boxed. The basic `newArray` method was not affected
by this bug because it was already special-cased. The fix is to also
special-case `arrayClass`.
