### PR TITLE
Document that `scala -e` starts/uses a compilation daemon

### DIFF
--- a/src/compiler/scala/tools/nsc/GenericRunnerCommand.scala
+++ b/src/compiler/scala/tools/nsc/GenericRunnerCommand.scala
@@ -87,7 +87,11 @@ A file argument will be run as a scala script unless it contains only
 self-contained compilation units (classes and objects) and exactly one
 runnable main method.  In that case the file will be compiled and the
 main method invoked.  This provides a bridge between scripts and standard
-scala source.%n"""
+scala source.
+
+When running a script or using -e, an already running compilation daemon
+(fsc) is used, or a new one started on demand.  The -nc option can be
+used to prevent this.%n"""
 }
 
 object GenericRunnerCommand {

--- a/src/manual/scala/man1/scala.scala
+++ b/src/manual/scala/man1/scala.scala
@@ -65,6 +65,10 @@ object scala extends Command {
         "Do not use the " & MBold("fsc") & " offline compiler."),
 
       Definition(
+        CmdOption("nc"),
+        "Same as " & Mono("-nocompdaemon") & "."),
+
+      Definition(
         CmdOptionBound("D", "property=value"),
         "Set a Java system property.  If no value is specified, " &
         "then the property is set to the empty string."),
@@ -134,6 +138,11 @@ object scala extends Command {
     "Such a header must have each header boundary start at the beginning of a " &
     "line.  Headers can be used to make stand-alone script files, as shown " &
     "in the examples below.",
+
+    "When running a script or using " & Mono("-e") & ", an already running " &
+    "compilation daemon (fsc) is used, or a new one started on demand.  The " &
+    Mono("-nocompdaemon") & " or " & Mono("-nc") & " option can be used to " &
+    "prevent this.",
 
     "If " & Mono("scala") & " is run from an sbaz(1) directory, " &
     "then it will add to its classpath any jars installed in the " &


### PR DESCRIPTION
We should consider changing the default in the long term. For now, make it explicit that `-e` starts and uses fsc.
