### PR TITLE
SI-5365 Enable exhaustivity analysis of matches with guards

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -136,6 +136,8 @@ trait ScalaSettings extends AbsScalaSettings
   val XnoPatmatAnalysis = BooleanSetting ("-Xno-patmat-analysis", "Don't perform exhaustivity/unreachability analysis. Also, ignore @switch annotation.")
   val XfullLubs         = BooleanSetting ("-Xfull-lubs", "Retains pre 2.10 behavior of less aggressive truncation of least upper bounds.")
 
+  val XstrictPatmatAnalysis = BooleanSetting ("-Xstrict-patmat-analysis", "Assume pattern guards are false for the purposes of exhaustivity analysis")
+
   // XML parsing options
   object XxmlSettings extends MultiChoiceEnumeration {
     val coalescing   = Choice("coalescing", "Convert PCData to Text and coalesce sibling nodes")

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -516,11 +516,15 @@ trait MatchAnalysis extends MatchApproximation {
       //    - there are extractor calls (that we can't secretly/soundly) rewrite
       val start = if (Statistics.canEnable) Statistics.startTimer(patmatAnaExhaust) else null
       var backoff = false
+      val strict = settings.XstrictPatmatAnalysis.value
 
       val approx = new TreeMakersToPropsIgnoreNullChecks(prevBinder)
       val symbolicCases = approx.approximateMatch(cases, approx.onUnknown { tm =>
         approx.fullRewrite.applyOrElse[TreeMaker, Prop](tm, {
           case BodyTreeMaker(_, _) => True // irrelevant -- will be discarded by symbolCase later
+          case GuardTreeMaker(_) => if (strict) False else True
+          case ExtractorTreeMaker(extractor, _, _) if extractor.symbol.name != nme.unapplySeq =>
+            if (strict) False else True
           case _ => // debug.patmat("backing off due to "+ tm)
             backoff = true
             False
@@ -761,6 +765,7 @@ trait MatchAnalysis extends MatchApproximation {
       def chop(path: Tree): List[Symbol] = path match {
         case Ident(_) => List(path.symbol)
         case Select(pre, name) => chop(pre) :+ path.symbol
+        case Apply(fun, args) => chop(fun) :+ path.symbol
         case _ =>
           // debug.patmat("don't know how to chop "+ path)
           Nil

--- a/test/files/neg/t5365.check
+++ b/test/files/neg/t5365.check
@@ -1,0 +1,15 @@
+t5365.scala:2: warning: match may not be exhaustive.
+It would fail on the following input: None
+  def nonExhautiveIfWeAssumeGuardsTrueOrFalse(x: Option[Int]): Int = x match {
+                                                                     ^
+t5365.scala:17: warning: match may not be exhaustive.
+It would fail on the following input: None
+  def extractor(x: Option[Int]) = x match {
+                                  ^
+t5365.scala:20: warning: match may not be exhaustive.
+It would fail on the following input: None
+  def repeatedExtractor(x: Option[Int]) = x match {
+                                          ^
+error: No warnings can be incurred under -Xfatal-warnings.
+three warnings found
+one error found

--- a/test/files/neg/t5365.flags
+++ b/test/files/neg/t5365.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/t5365.scala
+++ b/test/files/neg/t5365.scala
@@ -1,0 +1,39 @@
+class C {
+  def nonExhautiveIfWeAssumeGuardsTrueOrFalse(x: Option[Int]): Int = x match {
+    case Some(n) if n % 2 == 0 => n
+  }
+
+  def nonExhautiveIfWeAssumeGuardsFalse(x: Option[Int]): Int = x match {
+    case Some(n) if n % 2 == 0 => n
+    case None => 0
+  }
+
+  def inverseGuards(x: Option[Int]): Int = x match {
+    case Some(n) if n > 0 => n
+    case Some(n) if n <= 0 => ???
+    case None => 0
+  }
+
+  def extractor(x: Option[Int]) = x match {
+    case Some(Extractor(_)) =>
+  }
+  def repeatedExtractor(x: Option[Int]) = x match {
+    case Some(RepeatedExtractor(_)) =>
+  }
+  def extractorStrict(x: Option[Int]) = x match {
+    case Some(Extractor(_)) =>
+    case None =>
+  }
+  def repeatedExtractorStrict(x: Option[Int]) = x match {
+    case Some(RepeatedExtractor(_)) =>
+    case None =>
+  }
+}
+
+object Extractor {
+  def unapply(a: Any): Option[Any] = None
+}
+
+object RepeatedExtractor {
+  def unapplySeq(a: Any): Option[Seq[Any]] = None
+}

--- a/test/files/neg/t5365b.check
+++ b/test/files/neg/t5365b.check
@@ -1,0 +1,31 @@
+t5365b.scala:2: warning: match may not be exhaustive.
+It would fail on the following inputs: None, Some(_)
+  def nonExhautiveIfWeAssumeGuardsTrueOrFalse(x: Option[Int]): Int = x match {
+                                                                     ^
+t5365b.scala:6: warning: match may not be exhaustive.
+It would fail on the following input: Some(_)
+  def nonExhautiveIfWeAssumeGuardsFalse(x: Option[Int]): Int = x match {
+                                                               ^
+t5365b.scala:11: warning: match may not be exhaustive.
+It would fail on the following input: Some(_)
+  def inverseGuards(x: Option[Int]): Int = x match {
+                                           ^
+t5365b.scala:17: warning: match may not be exhaustive.
+It would fail on the following inputs: None, Some(_)
+  def extractor(x: Option[Int]) = x match {
+                                  ^
+t5365b.scala:20: warning: match may not be exhaustive.
+It would fail on the following inputs: None, Some(_)
+  def repeatedExtractor(x: Option[Int]) = x match {
+                                          ^
+t5365b.scala:23: warning: match may not be exhaustive.
+It would fail on the following input: Some(_)
+  def extractorStrict(x: Option[Int]) = x match {
+                                        ^
+t5365b.scala:27: warning: match may not be exhaustive.
+It would fail on the following input: Some(_)
+  def repeatedExtractorStrict(x: Option[Int]) = x match {
+                                                ^
+error: No warnings can be incurred under -Xfatal-warnings.
+7 warnings found
+one error found

--- a/test/files/neg/t5365b.flags
+++ b/test/files/neg/t5365b.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -Xstrict-patmat-analysis

--- a/test/files/neg/t5365b.scala
+++ b/test/files/neg/t5365b.scala
@@ -1,0 +1,39 @@
+class C {
+  def nonExhautiveIfWeAssumeGuardsTrueOrFalse(x: Option[Int]): Int = x match {
+    case Some(n) if n % 2 == 0 => n
+  }
+
+  def nonExhautiveIfWeAssumeGuardsFalse(x: Option[Int]): Int = x match {
+    case Some(n) if n % 2 == 0 => n
+    case None => 0
+  }
+
+  def inverseGuards(x: Option[Int]): Int = x match {
+    case Some(n) if n > 0 => n
+    case Some(n) if n <= 0 => ???
+    case None => 0
+  }
+
+  def extractor(x: Option[Int]) = x match {
+    case Some(Extractor(_)) =>
+  }
+  def repeatedExtractor(x: Option[Int]) = x match {
+    case Some(RepeatedExtractor(_)) =>
+  }
+  def extractorStrict(x: Option[Int]) = x match {
+    case Some(Extractor(_)) =>
+    case None =>
+  }
+  def repeatedExtractorStrict(x: Option[Int]) = x match {
+    case Some(RepeatedExtractor(_)) =>
+    case None =>
+  }
+}
+
+object Extractor {
+  def unapply(a: Any): Option[Any] = None
+}
+
+object RepeatedExtractor {
+  def unapplySeq(a: Any): Option[Seq[Any]] = None
+}

--- a/test/files/run/virtpatmat_apply.scala
+++ b/test/files/run/virtpatmat_apply.scala
@@ -1,5 +1,5 @@
 object Test extends App {
- List(1, 2, 3) match {
+ (List(1, 2, 3): @unchecked) match {
    case Nil => println("FAIL")
    case x :: y :: xs if xs.length == 2 => println("FAIL")
    case x :: y :: xs if xs.length == 1 => println("OK "+ y)


### PR DESCRIPTION
Rather than disabling the analysis altogether, rewrite
guard to `true` (by default) or to `false` under a new
compiler option.

The default option errs on the side of avoiding spurious
warnings where the guard writer knows better. However,
there was a convincing argument made in the ticket that
in these cases it would not be to onerous to require
the code to be rewritten from

```
case P if g1 =>
case P if g2 =>
```

to:

```
case P if g1 =>
case P       =>
```

Or to:

```
(scrut: @unchecked) match {
  case P if g1 =>
  case P if g2 =>
```

So perhaps we can turn on the strict version by
default, after running against the community build
as a sanity check.

Extractor patterns had the same limitation as guards.
This commit also enables the analysis for them.
