### PR TITLE
SI-9634: Avoiding NullPointerException's when making Options from java.lang values

### DIFF
--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -24,6 +24,22 @@ object Option {
    */
   def apply[A](x: A): Option[A] = if (x == null) None else Some(x)
 
+  /** Option factories for values received from some Java API. Without this,
+    * nulls can trigger NullPointerException, in some scenarios. Also, convert
+    * to appropriate Scala AnyVals that guarantee the inner value won't be null.
+    *
+    *  @param  x the value (java.lang.xxx)
+    *  @return   Some(value) if value != null, None if value == null    # value is converted to a Scala AnyVal
+    */
+  def apply(x: java.lang.Boolean): Option[Boolean] = if (x == null) None else Some(x)
+  def apply(x: java.lang.Character): Option[Char] = if (x == null) None else Some(x)
+  def apply(x: java.lang.Byte): Option[Byte] =      if (x == null) None else Some(x)
+  def apply(x: java.lang.Short): Option[Short] =    if (x == null) None else Some(x)
+  def apply(x: java.lang.Integer): Option[Int] =    if (x == null) None else Some(x)
+  def apply(x: java.lang.Long): Option[Long] =      if (x == null) None else Some(x)
+  def apply(x: java.lang.Float): Option[Float] =    if (x == null) None else Some(x)
+  def apply(x: java.lang.Double): Option[Double] =  if (x == null) None else Some(x)
+
   /** An Option factory which returns `None` in a manner consistent with
    *  the collections hierarchy.
    */
@@ -335,6 +351,20 @@ final case class Some[+A](x: A) extends Option[A] {
   def get = x
 }
 
+/** Ensure that applying `Some` to `java.lang` values creates the same type as applying `Option`.
+  *
+  * Note: this DOES NOT WORK - try (sbt) 'testOnly *OptionsWithJavaValues'.
+ */
+object Some {
+  def apply(x: java.lang.Boolean): Option[Boolean] = Some(x: Boolean)
+  def apply(x: java.lang.Character): Option[Char] = Some(x: Char)
+  def apply(x: java.lang.Byte): Option[Byte] = Some(x: Byte)
+  def apply(x: java.lang.Short): Option[Short] = Some(x: Short)
+  def apply(x: java.lang.Integer): Option[Int] = Some(x: Int)
+  def apply(x: java.lang.Long): Option[Long] = Some(x: Long)
+  def apply(x: java.lang.Float): Option[Float] = Some(x: Float)
+  def apply(x: java.lang.Double): Option[Double] = Some(x: Double)
+}
 
 /** This case object represents non-existent values.
  *

--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -352,8 +352,6 @@ final case class Some[+A](x: A) extends Option[A] {
 }
 
 /** Ensure that applying `Some` to `java.lang` values creates the same type as applying `Option`.
-  *
-  * Note: this DOES NOT WORK - try (sbt) 'testOnly *OptionsWithJavaValues'.
  */
 object Some {
   def apply(x: java.lang.Boolean): Option[Boolean] = Some(x: Boolean)

--- a/test/junit/scala/issues/OptionsWithJavaValues.scala
+++ b/test/junit/scala/issues/OptionsWithJavaValues.scala
@@ -1,0 +1,83 @@
+package scala.issues
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class OptionsWithJavaValuesTests {
+  import OptionsWithJavaValues._
+
+  // See -> https://issues.scala-lang.org/browse/SI-9634
+
+  @Test
+  def t9634(): Unit = {
+    // These compile but give NullPointerException in Scala 2.11.7 and 2.12.0-M3
+    //
+    // Note: SI-9634 does not try to fix this. Instead, it makes giving the type parameter explicitly
+    //      unnecessary, since the conversion to a Scala AnyVal is done automatically.
+    /*
+    assert( Option[Boolean](null.asInstanceOf[java.lang.Boolean]) == None )
+    assert( Option[Char](null.asInstanceOf[java.lang.Character]) == None )
+    assert( Option[Byte](null.asInstanceOf[java.lang.Byte]) == None )
+    assert( Option[Short](null.asInstanceOf[java.lang.Short]) == None )
+    assert( Option[Int](null.asInstanceOf[java.lang.Integer]) == None )
+    assert( Option[Long](null.asInstanceOf[java.lang.Long]) == None )
+    assert( Option[Float](null.asInstanceOf[java.lang.Float]) == None )
+    assert( Option[Double](null.asInstanceOf[java.lang.Double]) == None )
+    */
+
+    // Check that proper values get through, and they are converted to Scala AnyVals
+    //
+    def check[A](javaVal: A, scalaVal: AnyVal ): Unit = {
+      val v = Option(javaVal).get
+      assert( v == scalaVal )
+      assert( v.getClass.getName == scalaVal.getClass.getName )
+    }
+
+    check(jBoolean, true)     // not "java.lang.Boolean"
+    check(jCharacter, 'b')    // not "java.lang.Character"
+    check(jByte, 1.toByte)    // not "java.lang.Byte"
+    check(jShort, 1.toShort)  // not "java.lang.Short"
+    check(jInteger, 1)        // not "java.lang.Integer"
+    check(jLong, 1L)          // not "java.lang.Long"
+    check(jFloat, 0.0f)       // not "java.lang.Float"
+    check(jDouble, 0.0)       // not "java.lang.Double"
+
+    // Using 'Some' on java.lang.* should convert to Scala AnyVals
+    //
+    assert( Some(jBoolean).get.getClass.getName == "boolean" )
+    assert( Some(jCharacter).get.getClass.getName == "char" )
+    assert( Some(jByte).get.getClass.getName == "byte" )
+    assert( Some(jShort).get.getClass.getName == "short" )
+    assert( Some(jInteger).get.getClass.getName == "int" )
+    assert( Some(jLong).get.getClass.getName == "long" )
+    assert( Some(jFloat).get.getClass.getName == "float" )
+    assert( Some(jDouble).get.getClass.getName == "double" )
+
+    // Creating Option with java.lang.* shouldn't be possible, even explicitly
+    //
+    // It still is, not sure how it could be blocked without burdening normal use of 'Option' (i.e.
+    // adding to compile times, complexity etc.)
+    //
+    Option[java.lang.Boolean](jBoolean)
+    Option[java.lang.Character](jCharacter)
+    Option[java.lang.Byte](jByte)
+    Option[java.lang.Short](jShort)
+    Option[java.lang.Integer](jInteger)
+    Option[java.lang.Long](jLong)
+    Option[java.lang.Float](jFloat)
+    Option[java.lang.Double](jDouble)
+  }
+}
+
+object OptionsWithJavaValues {
+  val jBoolean = new java.lang.Boolean(true)
+  val jCharacter = new java.lang.Character('b')
+  val jByte = (1.toByte).asInstanceOf[java.lang.Byte]
+  val jShort = (1.toShort).asInstanceOf[java.lang.Short]
+  val jInteger = new java.lang.Integer(1)
+  val jLong = new java.lang.Long(1L)
+  val jFloat = new java.lang.Float(0.0)
+  val jDouble = new java.lang.Double(0.0)
+}

--- a/test/junit/scala/issues/OptionsWithJavaValues.scala
+++ b/test/junit/scala/issues/OptionsWithJavaValues.scala
@@ -59,7 +59,7 @@ class OptionsWithJavaValuesTests {
     //
     // It still is, not sure how it could be blocked without burdening normal use of 'Option' (i.e.
     // adding to compile times, complexity etc.)
-    //
+    /*
     Option[java.lang.Boolean](jBoolean)
     Option[java.lang.Character](jCharacter)
     Option[java.lang.Byte](jByte)
@@ -68,6 +68,7 @@ class OptionsWithJavaValuesTests {
     Option[java.lang.Long](jLong)
     Option[java.lang.Float](jFloat)
     Option[java.lang.Double](jDouble)
+    */
   }
 }
 


### PR DESCRIPTION
Introducing `AnyVal` seems to have caused a problem in the use of `java.lang` values, together with `Option`s. The current behaviour is somewhat surprising, and there is really no need for having Options of java basic values. 

This PR handles the normal `Option` and `Some` use cases, converting non-null `java.lang` values to an `Option` of corresponding `AnyVal`. This should be what the user wants, though they might not know it. :)

A further idea could be to ban `Option[java.lang.Long]` and others from existing, at all, but my type programming skills were not up to suggesting how that could be done, without adding complexities.

The bigger explanation of this is naturally in the [SI-9634](https://issues.scala-lang.org/browse/SI-9634) ticket. I hope to get feedback on this - even if the PR were not accepted, for some reason.
