### PR TITLE
Added Properties.isLinux to compliment the isWin and isMac methods

### DIFF
--- a/src/library/scala/util/Properties.scala
+++ b/src/library/scala/util/Properties.scala
@@ -148,6 +148,8 @@ private[scala] trait PropertiesTrait {
   // the reason why we don't follow developer.apple.com/library/mac/#technotes/tn2002/tn2110.
   /** Returns `true` iff the underlying operating system is a version of Apple Mac OSX.  */
   def isMac                 = osName startsWith "Mac OS X"
+  /** Returns `true` iff the underlying operating system is a Linux distribution. */
+  def isLinux               = osName startsWith "Linux"
 
   /* Some runtime values. */
   private[scala] def isAvian = javaVmName contains "Avian"


### PR DESCRIPTION
Noticed that there was a missing isLinux (or isNix?) method in scala.util.Properties to go with Mac and Linux. The added one checks for `os.name startsWith "Linux"`, which was the case on my Arch Linux system. I ran `ant opt-test` (after opt-build) but it failed with an OutOfMemoryError, which didn't seem like it could even be related to this, so I assumed that it was a problem from elsewhere.

This is my first-ever pull request, so please go easy :D
