### PR TITLE
SI-8044 Allow binding backquoted varid in patterns

### DIFF
--- a/spec/01-lexical-syntax.md
+++ b/spec/01-lexical-syntax.md
@@ -49,6 +49,8 @@ classes (Unicode general category given in parentheses):
 ```ebnf
 op       ::=  opchar {opchar}
 varid    ::=  lower idrest
+boundvarid ::=  varid
+             | ‘`’ varid ‘`’
 plainid  ::=  upper idrest
            |  varid
            |  op

--- a/spec/08-pattern-matching.md
+++ b/spec/08-pattern-matching.md
@@ -10,10 +10,10 @@ chapter: 8
 
 ```ebnf
   Pattern         ::=  Pattern1 { ‘|’ Pattern1 }
-  Pattern1        ::=  varid ‘:’ TypePat
+  Pattern1        ::=  boundvarid ‘:’ TypePat
                     |  ‘_’ ‘:’ TypePat
                     |  Pattern2
-  Pattern2        ::=  varid [‘@’ Pattern3]
+  Pattern2        ::=  boundvarid [‘@’ Pattern3]
                     |  Pattern3
   Pattern3        ::=  SimplePattern
                     |  SimplePattern {id [nl] SimplePattern}

--- a/spec/08-pattern-matching.md
+++ b/spec/08-pattern-matching.md
@@ -13,7 +13,7 @@ chapter: 8
   Pattern1        ::=  boundvarid ‘:’ TypePat
                     |  ‘_’ ‘:’ TypePat
                     |  Pattern2
-  Pattern2        ::=  boundvarid [‘@’ Pattern3]
+  Pattern2        ::=  id [‘@’ Pattern3]
                     |  Pattern3
   Pattern3        ::=  SimplePattern
                     |  SimplePattern {id [nl] SimplePattern}
@@ -22,7 +22,7 @@ chapter: 8
                     |  Literal
                     |  StableId
                     |  StableId ‘(’ [Patterns] ‘)’
-                    |  StableId ‘(’ [Patterns ‘,’] [varid ‘@’] ‘_’ ‘*’ ‘)’
+                    |  StableId ‘(’ [Patterns ‘,’] [id ‘@’] ‘_’ ‘*’ ‘)’
                     |  ‘(’ [Patterns] ‘)’
                     |  XmlPattern
   Patterns        ::=  Pattern {‘,’ Patterns}

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1901,19 +1901,20 @@ self =>
       }
 
       /** {{{
-       *  Pattern1    ::= varid `:' TypePat
+       *  Pattern1    ::= boundvarid `:' TypePat
        *                |  `_' `:' TypePat
        *                |  Pattern2
-       *  SeqPattern1 ::= varid `:' TypePat
+       *  SeqPattern1 ::= boundvarid `:' TypePat
        *                |  `_' `:' TypePat
        *                |  [SeqPattern2]
        *  }}}
        */
       def pattern1(): Tree = pattern2() match {
         case p @ Ident(name) if in.token == COLON =>
-          if (treeInfo.isVarPattern(p))
+          if (nme.isVariableName(name)) {
+            p.removeAttachment[BackquotedIdentifierAttachment.type]
             atPos(p.pos.start, in.skipToken())(Typed(p, compoundType()))
-          else {
+          } else {
             syntaxError(in.offset, "Pattern variables must start with a lower-case letter. (SLS 8.1.1.)")
             p
           }
@@ -1921,9 +1922,9 @@ self =>
       }
 
       /** {{{
-       *  Pattern2    ::=  varid [ @ Pattern3 ]
+       *  Pattern2    ::=  boundvarid [ @ Pattern3 ]
        *                |   Pattern3
-       *  SeqPattern2 ::=  varid [ @ SeqPattern3 ]
+       *  SeqPattern2 ::=  boundvarid [ @ SeqPattern3 ]
        *                |   SeqPattern3
        *  }}}
        */
@@ -1935,7 +1936,7 @@ self =>
           case Ident(nme.WILDCARD) =>
             in.nextToken()
             pattern3()
-          case Ident(name) if treeInfo.isVarPattern(p) =>
+          case Ident(name) if nme.isVariableName(name) =>
             in.nextToken()
             atPos(p.pos.start) { Bind(name, pattern3()) }
           case _ => p

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1922,10 +1922,9 @@ self =>
       }
 
       /** {{{
-       *  Pattern2    ::=  boundvarid [ @ Pattern3 ]
+       *  Pattern2    ::=  id  @ Pattern3
+       *                |  `_' @ Pattern3
        *                |   Pattern3
-       *  SeqPattern2 ::=  boundvarid [ @ SeqPattern3 ]
-       *                |   SeqPattern3
        *  }}}
        */
       def pattern2(): Tree = {
@@ -1936,7 +1935,7 @@ self =>
           case Ident(nme.WILDCARD) =>
             in.nextToken()
             pattern3()
-          case Ident(name) if nme.isVariableName(name) =>
+          case Ident(name) =>
             in.nextToken()
             atPos(p.pos.start) { Bind(name, pattern3()) }
           case _ => p

--- a/test/files/neg/t8044-b.check
+++ b/test/files/neg/t8044-b.check
@@ -1,0 +1,4 @@
+t8044-b.scala:3: error: Pattern variables must start with a lower-case letter. (SLS 8.1.1.)
+  def g = 42 match { case `Oops` : Int => }  // must be varish
+                                 ^
+one error found

--- a/test/files/neg/t8044-b.scala
+++ b/test/files/neg/t8044-b.scala
@@ -1,0 +1,4 @@
+
+trait T {
+  def g = 42 match { case `Oops` : Int => }  // must be varish
+}

--- a/test/files/neg/t8044.check
+++ b/test/files/neg/t8044.check
@@ -1,0 +1,4 @@
+t8044.scala:3: error: not found: value _
+  def f = 42 match { case `_` : Int => `_` }   // doesn't leak quoted underscore
+                                       ^
+one error found

--- a/test/files/neg/t8044.scala
+++ b/test/files/neg/t8044.scala
@@ -1,0 +1,4 @@
+
+trait T {
+  def f = 42 match { case `_` : Int => `_` }   // doesn't leak quoted underscore
+}

--- a/test/files/pos/t8044.scala
+++ b/test/files/pos/t8044.scala
@@ -1,0 +1,7 @@
+
+trait T {
+  def f = 42 match { case `x` @ _ => x }
+  def g = 42 match { case `type` @ _ => `type` }
+  def h = 42 match { case `type` : Int => `type` }
+  def i = (null: Any) match { case _: Int | _: String => 17 }
+}

--- a/test/files/pos/t8044.scala
+++ b/test/files/pos/t8044.scala
@@ -4,4 +4,12 @@ trait T {
   def g = 42 match { case `type` @ _ => `type` }
   def h = 42 match { case `type` : Int => `type` }
   def i = (null: Any) match { case _: Int | _: String => 17 }
+
+  // arbitrary idents allowed in @ syntax
+  def j = "Fred" match { case Name @ (_: String) => Name }
+  def k = "Fred" match { case * @ (_: String) => * }
+
+  // also in sequence pattern
+  def m = List(1,2,3,4,5) match { case List(1, `Rest of them` @ _*) => `Rest of them` }
+
 }


### PR DESCRIPTION
Previously, a varid could not be backquoted, so that it was not
possible to introduce variables with names such as `type` in a
match expression.

This commit allows backquoted varids in `case x @ _` and
`case x: Int`. In neither position is a stable id accepted,
that is, an id with leading uppercase.

Therefore, this commit merely relaxes the backquoted varid to
be taken as a normal varid in these contexts.
