### PR TITLE
[SI-9638] Size aware flatMap

### DIFF
--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -419,7 +419,7 @@ trait Iterator[+A] extends TraversableOnce[A] {
    */
   def ++[B >: A](that: => GenTraversableOnce[B]): Iterator[B] = new Iterator.JoinIterator(self, that)
 
-  private[this] class flatMapIterator[B](f: (A, Option[Int]) => GenTraversableOnce[B]) extends AbstractIterator[B] {
+  private[this] class FlatMapIterator[B](f: (A, Option[Int]) => GenTraversableOnce[B]) extends AbstractIterator[B] {
     private var l = 0
     private var cur: Iterator[B] = empty
     private def nextCur() { cur = f(self.next(), Some(l)).toIterator; l += 1 }
@@ -443,10 +443,10 @@ trait Iterator[+A] extends TraversableOnce[A] {
    *           `f` to each value produced by this iterator and concatenating the results.
    *  @note    Reuse: $consumesAndProducesIterator
    */
-  def flatMap[B](f: A => GenTraversableOnce[B]): Iterator[B] = new flatMapIterator[B]((x, _) => f(x))
+  def flatMap[B](f: A => GenTraversableOnce[B]): Iterator[B] = new FlatMapIterator[B]((x, _) => f(x))
 
   //TODO pfperez: Add documentation
-  def sizedFlatMap[B](f: (A, Option[Int]) => GenTraversableOnce[B]): Iterator[B] = new flatMapIterator[B](f)
+  def sizedFlatMap[B](f: (A, Option[Int]) => GenTraversableOnce[B]): Iterator[B] = new FlatMapIterator[B](f)
 
   /** Returns an iterator over all the elements of this iterator that satisfy the predicate `p`.
    *  The order of the elements is preserved.

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -419,17 +419,10 @@ trait Iterator[+A] extends TraversableOnce[A] {
    */
   def ++[B >: A](that: => GenTraversableOnce[B]): Iterator[B] = new Iterator.JoinIterator(self, that)
 
-  /** Creates a new iterator by applying a function to all values produced by this iterator
-   *  and concatenating the results.
-   *
-   *  @param f the function to apply on each element.
-   *  @return  the iterator resulting from applying the given iterator-valued function
-   *           `f` to each value produced by this iterator and concatenating the results.
-   *  @note    Reuse: $consumesAndProducesIterator
-   */
-  def flatMap[B](f: A => GenTraversableOnce[B]): Iterator[B] = new AbstractIterator[B] {
+  private[this] class flatMapIterator[B](f: (A, Option[Int]) => GenTraversableOnce[B]) extends AbstractIterator[B] {
+    private var l = 0
     private var cur: Iterator[B] = empty
-    private def nextCur() { cur = f(self.next()).toIterator }
+    private def nextCur() { cur = f(self.next(), Some(l)).toIterator; l += 1 }
     def hasNext: Boolean = {
       // Equivalent to cur.hasNext || self.hasNext && { nextCur(); hasNext }
       // but slightly shorter bytecode (better JVM inlining!)
@@ -441,6 +434,19 @@ trait Iterator[+A] extends TraversableOnce[A] {
     }
     def next(): B = (if (hasNext) cur else empty).next()
   }
+
+  /** Creates a new iterator by applying a function to all values produced by this iterator
+   *  and concatenating the results.
+   *
+   *  @param f the function to apply on each element.
+   *  @return  the iterator resulting from applying the given iterator-valued function
+   *           `f` to each value produced by this iterator and concatenating the results.
+   *  @note    Reuse: $consumesAndProducesIterator
+   */
+  def flatMap[B](f: A => GenTraversableOnce[B]): Iterator[B] = new flatMapIterator[B]((x, _) => f(x))
+
+  //TODO pfperez: Add documentation
+  def sizedFlatMap[B](f: (A, Option[Int]) => GenTraversableOnce[B]): Iterator[B] = new flatMapIterator[B](f)
 
   /** Returns an iterator over all the elements of this iterator that satisfy the predicate `p`.
    *  The order of the elements is preserved.

--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -253,6 +253,17 @@ trait TraversableLike[+A, +Repr] extends Any
     b.result
   }
 
+  def sizedFlatMap[B, That](f: (A, Option[Int]) => GenTraversableOnce[B])(implicit bf: CanBuildFrom[Repr, B, That]): That = {
+    def builder : mutable.Builder[B, That] = bf(repr)
+    val b = builder
+    val builderAsBufferLike = b match {
+      case bl: mutable.BufferLike[_, _] => Some(bl)
+      case _ => None
+    }
+    for (x <- this) b ++= f(x, builderAsBufferLike.map(_.length)).seq
+    b.result
+  }
+
   private[scala] def filterImpl(p: A => Boolean, isFlipped: Boolean): Repr = {
     val b = newBuilder
     for (x <- this)
@@ -723,6 +734,17 @@ trait TraversableLike[+A, +Repr] extends Any
       val b = bf(repr)
       for (x <- self)
         if (p(x)) b ++= f(x).seq
+      b.result
+    }
+
+    def sizedFlatMap[B, That](f: (A, Option[Int]) => GenTraversableOnce[B])(implicit bf: CanBuildFrom[Repr, B, That]): That = {
+      val b = bf(repr)
+      val builderAsBufferLike = b match {
+        case bl: mutable.BufferLike[_, _] => Some(bl)
+        case _ => None
+      }
+      for (x <- this)
+        if (p(x)) b ++= f(x, builderAsBufferLike.map(_.length)).seq
       b.result
     }
 

--- a/src/library/scala/collection/TraversableProxyLike.scala
+++ b/src/library/scala/collection/TraversableProxyLike.scala
@@ -36,6 +36,7 @@ trait TraversableProxyLike[+A, +Repr <: TraversableLike[A, Repr] with Traversabl
   override def ++[B >: A, That](xs: GenTraversableOnce[B])(implicit bf: CanBuildFrom[Repr, B, That]): That = self.++(xs)(bf)
   override def map[B, That](f: A => B)(implicit bf: CanBuildFrom[Repr, B, That]): That = self.map(f)(bf)
   override def flatMap[B, That](f: A => GenTraversableOnce[B])(implicit bf: CanBuildFrom[Repr, B, That]): That = self.flatMap(f)(bf)
+  override def sizedFlatMap[B, That](f: (A, Option[Int]) => GenTraversableOnce[B])(implicit bf: CanBuildFrom[Repr, B, That]): That = self.sizedFlatMap(f)(bf)
   override def filter(p: A => Boolean): Repr = self.filter(p)
   override def filterNot(p: A => Boolean): Repr = self.filterNot(p)
   override def collect[B, That](pf: PartialFunction[A, B])(implicit bf: CanBuildFrom[Repr, B, That]): That = self.collect(pf)(bf)


### PR DESCRIPTION
Added `sizedFlatMap` to `TraversableLike` and `Iterator` which provides an implementation for a `flatMap` operation which receives a  `f: (A, Option[Int]) ⇒ GenTraversableOnce[B]` or `f: (A, Int) ⇒ GenTraversableOnce[B]` instead of just ``f: (A) ⇒ GenTraversableOnce[B]`. Where the second `f` parameter were the accumulated result size so far.

Issue: https://issues.scala-lang.org/browse/SI-9638
