### PR TITLE
SI-9349 Fix use of patmat binder as prefix for new x.Inner

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
@@ -101,7 +101,7 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
     case class SubstOnlyTreeMaker(prevBinder: Symbol, nextBinder: Symbol) extends TreeMaker {
       val pos = NoPosition
 
-      val localSubstitution = Substitution(prevBinder, CODE.REF(nextBinder))
+      val localSubstitution = Substitution(prevBinder, gen.mkAttributedStableRef(nextBinder))
       def chainBefore(next: Tree)(casegen: Casegen): Tree = substitution(next)
       override def toString = "S"+ localSubstitution
     }
@@ -118,7 +118,7 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
       val res: Tree
 
       lazy val nextBinder = freshSym(pos, nextBinderTp)
-      lazy val localSubstitution = Substitution(List(prevBinder), List(CODE.REF(nextBinder)))
+      lazy val localSubstitution = Substitution(List(prevBinder), List(gen.mkAttributedStableRef(nextBinder)))
 
       def chainBefore(next: Tree)(casegen: Casegen): Tree =
         atPos(pos)(casegen.flatMapCond(cond, res, nextBinder, substitution(next)))
@@ -485,7 +485,7 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
       // NOTE: generate `patTree == patBinder`, since the extractor must be in control of the equals method (also, patBinder may be null)
       // equals need not be well-behaved, so don't intersect with pattern's (stabilized) type (unlike MaybeBoundTyped's accumType, where it's required)
       val cond = codegen._equals(patTree, prevBinder)
-      val res  = CODE.REF(prevBinder)
+      val res  = gen.mkAttributedStableRef(prevBinder)
       override def toString = "ET"+((prevBinder.name, patTree))
     }
 

--- a/test/files/run/t9349/data.scala
+++ b/test/files/run/t9349/data.scala
@@ -1,0 +1,1 @@
+case class Outer(i: Int) { class Inner }

--- a/test/files/run/t9349/test.scala
+++ b/test/files/run/t9349/test.scala
@@ -1,0 +1,21 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    val o1 = Outer(5)
+    o1 match {
+      case o @ Outer(_) =>
+        val i = new o.Inner
+    }
+    o1 match {
+      case o : Outer =>
+        val i = new o.Inner
+
+    }
+    object Extractor {
+      def unapply(a: Any): Option[Outer] = Some(o1)
+    }
+    null match {
+      case Extractor(o2) =>
+        val i = new o2.Inner
+    }
+  }
+}


### PR DESCRIPTION
When substituting in references to the synthetic values
representing pattern binders, we were replacing:

```
Select(Ident(o).setType(o.type), TypeName("Inner"))
```

with:

```
Select(Ident(x2).setType(typeOf[Outer]), TypeName("Inner"))
```

The post transform in uncurry would then run:

```
 else if (tree.isType)
    TypeTree(tree.tpe) setPos tree.pos
```

Which would loses track of the outer term `o` and crashes the
compiler in ExplicitOuter.

This commit generates stable references to the binders.
I made this change in the substitutions for all `TreeMakers`,
however only one of seems like it triggers a crash in the
test variations I tried.

Here's how the trees for the first pattern in the test case
change after this patch:

```
@@ -1,30 +1,30 @@
 [[syntax trees at end of                    patmat]] // test.scala
 package <empty>{<empty>.type} {
   object Test extends scala.AnyRef {
     def <init>(): Test.type = {
       Test.super{Test.type}.<init>{()Object}(){Object};
       (){Unit}
     }{Unit};
     def main(args: Array[String]): Unit = {
       val o1: Outer = Outer.apply{(i: Int)Outer}(5{Int(5)}){Outer};
       {
         case <synthetic> val x1: Outer = o1{Outer};
         case5(){
           if (x1.ne{(x$1: AnyRef)Boolean}(null{Null(null)}){Boolean})
             matchEnd4{(x: Unit)Unit}({
-              val i: Outer#Inner = new x1.Inner{Outer#Inner}{()Outer#Inner}(){Outer#Inner};
+              val i: x1.Inner = new x1.Inner{x1.Inner}{()x1.Inner}(){x1.Inner};
               (){Unit}
             }{Unit}){Unit}
           else
             case6{()Unit}(){Unit}{Unit}
         }{Unit};
         case6(){
           matchEnd4{(x: Unit)Unit}(throw new MatchError{MatchError}{(obj: Any)MatchError}(x1{Outer}){MatchError}{Nothing}){Unit}
         }{Unit};
         matchEnd4(x: Unit){
           x{Unit}
         }{Unit}
       }{Unit}
     }{Unit}
   }
```

Review by @adriaanm 
