### PR TITLE
Scaladoc: fix stray number in codeblocks for firefox

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.css
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.css
@@ -769,6 +769,10 @@ div#footer {
   box-shadow: none;
 }
 
+#comment > dl > div > ol {
+  list-style-type: none;
+}
+
 div.fullcomment div.block ol li p,
 div.fullcomment div.block ol li {
   display:inline


### PR DESCRIPTION
Fix the stray number in firefox

review: @VladUreche 

doc example with patch: https://dl.dropboxusercontent.com/u/358427/stray-number-test/index.html#scala.collection.immutable.List
