### PR TITLE
SI-9574 Prevent illegal overrides of members with module types

### DIFF
--- a/test/files/neg/override-object-no.check
+++ b/test/files/neg/override-object-no.check
@@ -20,4 +20,12 @@ an overriding object must conform to the overridden object's class bound;
  required: case2.Bar[Traversable[String]]
     override object A extends Bar[List[String]]  // err
                     ^
-four errors found
+override-object-no.scala:52: error: overriding method x in trait A of type => SI9574.Foo.type;
+ method x has incompatible type
+  trait B extends A { def x: Bar.type } // should not compile (SI-9574)
+                          ^
+override-object-no.scala:53: error: overriding method x in trait A of type => SI9574.Foo.type;
+ object x has incompatible type
+  trait C extends A { override object x }
+                                      ^
+6 errors found

--- a/test/files/neg/override-object-no.scala
+++ b/test/files/neg/override-object-no.scala
@@ -43,3 +43,14 @@ package case2 {
     override object A extends Bar[List[String]]  // err
   }
 }
+
+// Both overridden and overriding members must be objects, not vals with a module type
+object SI9574 {
+  object Foo
+  object Bar
+  trait A { def x: Foo.type }
+  trait B extends A { def x: Bar.type } // should not compile (SI-9574)
+  trait C extends A { override object x }
+  trait D { object x; def y = x }
+  trait E extends D { override val x: super.x.type = y } // OK but doesn't need object subtyping exception
+}


### PR DESCRIPTION
Commit f32a32b1b33c9d7ccd62467e3e10cb69930023c8 introduced the ability
to override objects with other objects. The exception that allows
these overrides (where the usual subtyping check fails) was applied to
all members whose type is a module class. This is too broad, however,
because it not only applies to members of the form `object foo` but
also `def foo: bar.type` (where `bar` is an `object`).

The fix is to restrict the exception to those cases where both
definitions actually are objects.

Review by @adriaanm 
