### PR TITLE
SI-9650 Refchecks on case apply transform

### DIFF
--- a/test/files/neg/compile-time-only-a.check
+++ b/test/files/neg/compile-time-only-a.check
@@ -13,9 +13,15 @@ compile-time-only-a.scala:36: error: C2
 compile-time-only-a.scala:38: error: C3
   new C3(2)
       ^
+compile-time-only-a.scala:39: error: C3
+  C3(2)
+  ^
 compile-time-only-a.scala:41: error: C4
   new C4(2)
       ^
+compile-time-only-a.scala:42: error: C4
+  C4(2)
+  ^
 compile-time-only-a.scala:45: error: C5
   2.ext
   ^
@@ -73,4 +79,4 @@ compile-time-only-a.scala:75: error: placebo
 compile-time-only-a.scala:75: error: placebo
   @placebo def x = (2: @placebo)
                         ^
-25 errors found
+27 errors found

--- a/test/files/neg/t8685.check
+++ b/test/files/neg/t8685.check
@@ -1,0 +1,45 @@
+t8685.scala:6: warning: constructor D in class D is deprecated: ctor D is depr
+case class D @deprecated("ctor D is depr", since="now") (i: Int)
+           ^
+t8685.scala:35: warning: class C is deprecated: class C is depr
+  def f = C(42)
+          ^
+t8685.scala:37: warning: object E is deprecated: module E is depr
+  def h = E(42)
+          ^
+t8685.scala:37: warning: class E is deprecated: class E is depr
+  def h = E(42)
+          ^
+t8685.scala:38: warning: object F is deprecated: module F is depr
+  def i = F.G(42)
+          ^
+t8685.scala:39: warning: object F in object Extra is deprecated: Extra module F is depr
+  def j = Extra.F.G(42)
+                ^
+t8685.scala:43: warning: value gg in trait Applies is deprecated: member gg
+  def k = this.gg.H(0)
+               ^
+t8685.scala:45: warning: class K in object J is deprecated: Inner K is depr
+  def l = J.K(42)
+            ^
+t8685.scala:48: warning: class C is deprecated: class C is depr
+  def f = new C(42)
+              ^
+t8685.scala:49: warning: constructor D in class D is deprecated: ctor D is depr
+  def g = new D(42)
+          ^
+t8685.scala:50: warning: class E is deprecated: class E is depr
+  def h = new E(42)
+              ^
+t8685.scala:51: warning: object F is deprecated: module F is depr
+  def i = new F.G(42)
+              ^
+t8685.scala:52: warning: object F in object Extra is deprecated: Extra module F is depr
+  def j = new Extra.F.G(42)
+                    ^
+t8685.scala:53: warning: class K in object J is deprecated: Inner K is depr
+  def l = new J.K(42)
+                ^
+error: No warnings can be incurred under -Xfatal-warnings.
+14 warnings found
+one error found

--- a/test/files/neg/t8685.flags
+++ b/test/files/neg/t8685.flags
@@ -1,0 +1,1 @@
+-deprecation -Xfatal-warnings

--- a/test/files/neg/t8685.scala
+++ b/test/files/neg/t8685.scala
@@ -1,0 +1,54 @@
+
+
+@deprecated("class C is depr", since="now")
+case class C(i: Int)
+
+case class D @deprecated("ctor D is depr", since="now") (i: Int)
+
+@deprecated("class E is depr", since="now")
+case class E(i: Int)
+@deprecated("module E is depr", since="now")
+object E
+
+@deprecated("module F is depr", since="now")
+object F {
+  case class G(i: Int)
+}
+
+object G {
+  case class H(i: Int)
+}
+
+object Extra {
+  @deprecated("Extra module F is depr", since="now")
+  object F {
+    case class G(i: Int)
+  }
+}
+
+object J {
+  @deprecated("Inner K is depr", since="now")
+  case class K(i: Int)
+}
+
+trait Applies {
+  def f = C(42)
+  def g = D(42)
+  def h = E(42)
+  def i = F.G(42)
+  def j = Extra.F.G(42)
+
+  @deprecated("member gg", since="now")
+  val gg = G
+  def k = this.gg.H(0)
+
+  def l = J.K(42)
+}
+trait News {
+  def f = new C(42)
+  def g = new D(42)
+  def h = new E(42)
+  def i = new F.G(42)
+  def j = new Extra.F.G(42)
+  def l = new J.K(42)
+}


### PR DESCRIPTION
Apply checks for unsavoriness when transforming
a case apply.

This is narrower in scope than SI-8685. It just makes sure check is applied for case apply, including prefix of qual.
