### PR TITLE
Simplify TypeRef, `baseType` returns NoType, as needed for isSubtype

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
+++ b/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
@@ -127,9 +127,8 @@ abstract class Delambdafy extends Transform with TypingTransformers with ast.Tre
 
     // turns a lambda into a new class def, a New expression instantiating that class
     private def transformFunction(originalFunction: Function): TransformedFunction = {
-      val functionTpe = originalFunction.tpe
-      val targs = functionTpe.typeArgs
-      val formals :+ restpe = targs
+      val formals  = originalFunction.vparams.map(_.tpe)
+      val restpe   = originalFunction.body.tpe.deconst
       val oldClass = originalFunction.symbol.enclClass
 
       // find which variables are free in the lambda because those are captures that need to be

--- a/test/files/run/delambdafy_t6028.check
+++ b/test/files/run/delambdafy_t6028.check
@@ -11,7 +11,7 @@ package <empty> {
     def foo(methodParam: String): Function0 = {
       val methodLocal: String = "";
       {
-        (() => T.this.$anonfun$1(methodParam, methodLocal)).$asInstanceOf[Function0]()
+        (() => T.this.$anonfun$1(methodParam, methodLocal))
       }
     };
     def bar(barParam: String): Object = {
@@ -21,7 +21,7 @@ package <empty> {
     def tryy(tryyParam: String): Function0 = {
       var tryyLocal: runtime.ObjectRef = scala.runtime.ObjectRef.create("");
       {
-        (() => T.this.$anonfun$2(tryyParam, tryyLocal)).$asInstanceOf[Function0]()
+        (() => T.this.$anonfun$2(tryyParam, tryyLocal))
       }
     };
     final <artifact> private[this] def $anonfun$1(methodParam$1: String, methodLocal$1: String): String = T.this.classParam.+(T.this.field()).+(methodParam$1).+(methodLocal$1);


### PR DESCRIPTION
I started pulling on this thread for the INDY sammy work -- ran into SI-9540, which then led me to the isSubType bug due to substitution returning ErrorType (which makes <:< say yes when it should say no, as the original type from baseType was NoType), which then led to obsessing over the complexities due to OO factoring of TypeRef.

---

TODO: 
[dropped -- not sure how to do this, but we should spend more time unit testing subtyping ] test case to show problem with subtyping that should now be fixed -- it was related to transform's call to `instantiateTypeParams` turning a NoType (because there was no base type at the given symbol) into an ErrorType (due to mismatch between type args and params), which makes subtype go from `false` to `true`...
- [x] compare ASF call counts before and after

I've a lot of stack frames to pop back up to, so I have done various manual testing, but I need to get back to the work that triggered this.
