### PR TITLE
Use jarlister in build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -351,6 +351,7 @@ lazy val library = configureAsSubproject(project)
     products in Compile in packageBin ++=
       (products in Compile in packageBin in forkjoin).value,
     Osgi.headers += "Import-Package" -> "sun.misc;resolution:=optional, *",
+    Osgi.jarlist := true,
     fixPom(
       "/project/name" -> <name>Scala Library</name>,
       "/project/description" -> <description>Standard library for the Scala Programming Language</description>,
@@ -420,13 +421,15 @@ lazy val compiler = configureAsSubproject(project)
     scalacOptions in Compile in doc ++= Seq(
       "-doc-root-content", (sourceDirectory in Compile).value + "/rootdoc.txt"
     ),
-    Osgi.headers +=
+    Osgi.headers ++= Seq(
       "Import-Package" -> ("jline.*;resolution:=optional," +
                            "org.apache.tools.ant.*;resolution:=optional," +
                            "scala.util.parsing.*;version=\"${range;[====,====];"+versionNumber("scala-parser-combinators")+"}\";resolution:=optional," +
                            "scala.xml.*;version=\"${range;[====,====];"+versionNumber("scala-xml")+"}\";resolution:=optional," +
                            "scala.*;version=\"${range;[==,=+);${ver}}\"," +
                            "*"),
+      "Class-Path" -> "scala-reflect.jar scala-library.jar"
+    ),
     // Generate the ScriptEngineFactory service definition. The ant build does this when building
     // the JAR but sbt has no support for it and it is easier to do as a resource generator:
     generateServiceProviderResources("javax.script.ScriptEngineFactory" -> "scala.tools.nsc.interpreter.IMain$Factory"),

--- a/build.xml
+++ b/build.xml
@@ -279,6 +279,10 @@ TODO:
         <dependency groupId="com.googlecode.jarjar" artifactId="jarjar" version="1.3"/>
       </artifact:dependencies>
 
+      <artifact:dependencies pathId="jarlister.classpath">
+        <dependency groupId="com.github.rjolly" artifactId="jarlister_2.11" version="1.0"/>
+      </artifact:dependencies>
+
       <!-- JUnit -->
       <property name="junit.version" value="4.11"/>
       <artifact:dependencies pathId="junit.classpath" filesetId="junit.fileset">
@@ -867,6 +871,11 @@ TODO:
       <path refid="aux.libs"/>
     </path>
 
+    <path id="pack.lib.path">
+      <pathelement location="${library.jar}"/>
+      <path refid="jarlister.classpath"/>
+    </path>
+
     <path id="pack.bin.tool.path">
       <pathelement location="${library.jar}"/>
       <pathelement location="${xml.jar}"/>
@@ -1230,7 +1239,10 @@ TODO:
 <!-- ===========================================================================
                                   PACKED QUICK BUILD (PACK)
 ============================================================================ -->
-  <target name="pack.lib"    depends="quick.lib, forkjoin.done"> <staged-pack project="library"/></target>
+  <target name="pack.lib" depends="quick.lib, forkjoin.done"> <staged-pack project="library"/>
+    <taskdef resource="scala/tools/ant/antlib.xml" classpathref="pack.lib.path"/>
+    <jarlister file="${library.jar}"/>
+  </target>
 
   <target name="pack.reflect" depends="quick.reflect"> <staged-pack project="reflect"/> </target>
 

--- a/project/Osgi.scala
+++ b/project/Osgi.scala
@@ -1,6 +1,7 @@
 import aQute.lib.osgi.Builder
 import aQute.lib.osgi.Constants._
 import java.util.Properties
+import java.util.jar.Attributes
 import sbt._
 import sbt.Keys._
 import scala.collection.JavaConversions._
@@ -16,6 +17,7 @@ object Osgi {
   val bundleName = SettingKey[String]("osgiBundleName", "The Bundle-Name for the manifest.")
   val bundleSymbolicName = SettingKey[String]("osgiBundleSymbolicName", "The Bundle-SymbolicName for the manifest.")
   val headers = SettingKey[Seq[(String, String)]]("osgiHeaders", "Headers and processing instructions for BND.")
+  val jarlist = SettingKey[Boolean]("osgiJarlist", "List classes in manifest.")
 
   def settings: Seq[Setting[_]] = Seq(
     bundleName := description.value,
@@ -33,8 +35,9 @@ object Osgi {
         "-eclipse" -> "false"
       )
     },
+    jarlist := false,
     bundle <<= Def.task {
-      bundleTask(headers.value.toMap, (products in Compile in packageBin).value,
+      bundleTask(headers.value.toMap, jarlist.value, (products in Compile in packageBin).value,
         (artifactPath in (Compile, packageBin)).value, Nil, streams.value)
     },
     packagedArtifact in (Compile, packageBin) <<= (artifact in (Compile, packageBin), bundle).identityMap,
@@ -47,7 +50,7 @@ object Osgi {
     )
   )
 
-  def bundleTask(headers: Map[String, String], fullClasspath: Seq[File], artifactPath: File,
+  def bundleTask(headers: Map[String, String], jarlist: Boolean, fullClasspath: Seq[File], artifactPath: File,
                  resourceDirectories: Seq[File], streams: TaskStreams): File = {
     val log = streams.log
     val builder = new Builder
@@ -62,6 +65,12 @@ object Osgi {
     builder.getWarnings.foreach(s => log.warn(s"bnd: $s"))
     builder.getErrors.foreach(s => log.error(s"bnd: $s"))
     IO.createDirectory(artifactPath.getParentFile)
+    if (jarlist) {
+      val entries = jar.getManifest.getEntries
+      for ((name, resource) <- jar.getResources if name.endsWith(".class")) {
+        entries.put(name, new Attributes)
+      }
+    }
     jar.write(artifactPath)
     artifactPath
   }

--- a/test/files/run/t7843-jsr223-service.scala
+++ b/test/files/run/t7843-jsr223-service.scala
@@ -1,8 +1,6 @@
-import scala.tools.nsc.interpreter.IMain
-
 object Test extends App {
-  val engine = new IMain.Factory getScriptEngine()
-  engine.asInstanceOf[IMain].settings.usejavacp.value = true
+  val m = new javax.script.ScriptEngineManager()
+  val engine = m.getEngineByName("scala")
   engine put ("n", 10)
   engine eval "1 to n.asInstanceOf[Int] foreach print"
 }

--- a/test/files/run/t7933.scala
+++ b/test/files/run/t7933.scala
@@ -1,8 +1,6 @@
-import scala.tools.nsc.interpreter.IMain
-
 object Test extends App {
-  val engine = new IMain.Factory getScriptEngine()
-  engine.asInstanceOf[IMain].settings.usejavacp.value = true
+  val m = new javax.script.ScriptEngineManager()
+  val engine = m.getEngineByName("scala")
   val res2 = engine.asInstanceOf[javax.script.Compilable]
   res2 compile "8" eval()
   val res5 = res2 compile """println("hello") ; 8"""


### PR DESCRIPTION
The goal of this change is to exercize the "manifest classpath" mechanism,
meant to bring the compiler its needed classes as resources, listed
in jar manifests, as opposed to files, thus enabling to use the compiler
in sandboxed environments (and also the scripting engine for that matter).

This is a follow-up to #4799 which was closed prematurely.
