### PR TITLE
Fix off-by-one documentation error in Product<N>

### DIFF
--- a/src/build/genprod.scala
+++ b/src/build/genprod.scala
@@ -15,7 +15,6 @@ import scala.language.postfixOps
  *      where the argument is the desired output directory
  *
  *  @author  Burak Emir, Stephane Micheloud, Geoffrey Washburn, Paul Phillips
- *  @version 1.1
  */
 object genprod extends App {
   val MAX_ARITY = 22
@@ -353,7 +352,7 @@ object ProductTwo extends Product(2)
 
 class Product(val i: Int) extends Group("Product") with Arity {
   val productElementComment = """
-  /** Returns the n-th projection of this product if 0 < n <= productArity,
+  /** Returns the n-th projection of this product if 0 <= n < productArity,
    *  otherwise throws an `IndexOutOfBoundsException`.
    *
    *  @param n number of the projection to be returned

--- a/src/library/scala/Product1.scala
+++ b/src/library/scala/Product1.scala
@@ -24,7 +24,7 @@ trait Product1[@specialized(Int, Long, Double) +T1] extends Any with Product {
   override def productArity = 1
 
   
-  /** Returns the n-th projection of this product if 0 < n <= productArity,
+  /** Returns the n-th projection of this product if 0 <= n < productArity,
    *  otherwise throws an `IndexOutOfBoundsException`.
    *
    *  @param n number of the projection to be returned

--- a/src/library/scala/Product10.scala
+++ b/src/library/scala/Product10.scala
@@ -24,7 +24,7 @@ trait Product10[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10] extends Any w
   override def productArity = 10
 
   
-  /** Returns the n-th projection of this product if 0 < n <= productArity,
+  /** Returns the n-th projection of this product if 0 <= n < productArity,
    *  otherwise throws an `IndexOutOfBoundsException`.
    *
    *  @param n number of the projection to be returned

--- a/src/library/scala/Product11.scala
+++ b/src/library/scala/Product11.scala
@@ -24,7 +24,7 @@ trait Product11[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11] extends
   override def productArity = 11
 
   
-  /** Returns the n-th projection of this product if 0 < n <= productArity,
+  /** Returns the n-th projection of this product if 0 <= n < productArity,
    *  otherwise throws an `IndexOutOfBoundsException`.
    *
    *  @param n number of the projection to be returned

--- a/src/library/scala/Product12.scala
+++ b/src/library/scala/Product12.scala
@@ -24,7 +24,7 @@ trait Product12[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12] e
   override def productArity = 12
 
   
-  /** Returns the n-th projection of this product if 0 < n <= productArity,
+  /** Returns the n-th projection of this product if 0 <= n < productArity,
    *  otherwise throws an `IndexOutOfBoundsException`.
    *
    *  @param n number of the projection to be returned

--- a/src/library/scala/Product13.scala
+++ b/src/library/scala/Product13.scala
@@ -24,7 +24,7 @@ trait Product13[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +
   override def productArity = 13
 
   
-  /** Returns the n-th projection of this product if 0 < n <= productArity,
+  /** Returns the n-th projection of this product if 0 <= n < productArity,
    *  otherwise throws an `IndexOutOfBoundsException`.
    *
    *  @param n number of the projection to be returned

--- a/src/library/scala/Product14.scala
+++ b/src/library/scala/Product14.scala
@@ -24,7 +24,7 @@ trait Product14[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +
   override def productArity = 14
 
   
-  /** Returns the n-th projection of this product if 0 < n <= productArity,
+  /** Returns the n-th projection of this product if 0 <= n < productArity,
    *  otherwise throws an `IndexOutOfBoundsException`.
    *
    *  @param n number of the projection to be returned

--- a/src/library/scala/Product15.scala
+++ b/src/library/scala/Product15.scala
@@ -24,7 +24,7 @@ trait Product15[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +
   override def productArity = 15
 
   
-  /** Returns the n-th projection of this product if 0 < n <= productArity,
+  /** Returns the n-th projection of this product if 0 <= n < productArity,
    *  otherwise throws an `IndexOutOfBoundsException`.
    *
    *  @param n number of the projection to be returned

--- a/src/library/scala/Product16.scala
+++ b/src/library/scala/Product16.scala
@@ -24,7 +24,7 @@ trait Product16[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +
   override def productArity = 16
 
   
-  /** Returns the n-th projection of this product if 0 < n <= productArity,
+  /** Returns the n-th projection of this product if 0 <= n < productArity,
    *  otherwise throws an `IndexOutOfBoundsException`.
    *
    *  @param n number of the projection to be returned

--- a/src/library/scala/Product17.scala
+++ b/src/library/scala/Product17.scala
@@ -24,7 +24,7 @@ trait Product17[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +
   override def productArity = 17
 
   
-  /** Returns the n-th projection of this product if 0 < n <= productArity,
+  /** Returns the n-th projection of this product if 0 <= n < productArity,
    *  otherwise throws an `IndexOutOfBoundsException`.
    *
    *  @param n number of the projection to be returned

--- a/src/library/scala/Product18.scala
+++ b/src/library/scala/Product18.scala
@@ -24,7 +24,7 @@ trait Product18[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +
   override def productArity = 18
 
   
-  /** Returns the n-th projection of this product if 0 < n <= productArity,
+  /** Returns the n-th projection of this product if 0 <= n < productArity,
    *  otherwise throws an `IndexOutOfBoundsException`.
    *
    *  @param n number of the projection to be returned

--- a/src/library/scala/Product19.scala
+++ b/src/library/scala/Product19.scala
@@ -24,7 +24,7 @@ trait Product19[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +
   override def productArity = 19
 
   
-  /** Returns the n-th projection of this product if 0 < n <= productArity,
+  /** Returns the n-th projection of this product if 0 <= n < productArity,
    *  otherwise throws an `IndexOutOfBoundsException`.
    *
    *  @param n number of the projection to be returned

--- a/src/library/scala/Product2.scala
+++ b/src/library/scala/Product2.scala
@@ -24,7 +24,7 @@ trait Product2[@specialized(Int, Long, Double) +T1, @specialized(Int, Long, Doub
   override def productArity = 2
 
   
-  /** Returns the n-th projection of this product if 0 < n <= productArity,
+  /** Returns the n-th projection of this product if 0 <= n < productArity,
    *  otherwise throws an `IndexOutOfBoundsException`.
    *
    *  @param n number of the projection to be returned

--- a/src/library/scala/Product20.scala
+++ b/src/library/scala/Product20.scala
@@ -24,7 +24,7 @@ trait Product20[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +
   override def productArity = 20
 
   
-  /** Returns the n-th projection of this product if 0 < n <= productArity,
+  /** Returns the n-th projection of this product if 0 <= n < productArity,
    *  otherwise throws an `IndexOutOfBoundsException`.
    *
    *  @param n number of the projection to be returned

--- a/src/library/scala/Product21.scala
+++ b/src/library/scala/Product21.scala
@@ -24,7 +24,7 @@ trait Product21[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +
   override def productArity = 21
 
   
-  /** Returns the n-th projection of this product if 0 < n <= productArity,
+  /** Returns the n-th projection of this product if 0 <= n < productArity,
    *  otherwise throws an `IndexOutOfBoundsException`.
    *
    *  @param n number of the projection to be returned

--- a/src/library/scala/Product22.scala
+++ b/src/library/scala/Product22.scala
@@ -24,7 +24,7 @@ trait Product22[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +
   override def productArity = 22
 
   
-  /** Returns the n-th projection of this product if 0 < n <= productArity,
+  /** Returns the n-th projection of this product if 0 <= n < productArity,
    *  otherwise throws an `IndexOutOfBoundsException`.
    *
    *  @param n number of the projection to be returned

--- a/src/library/scala/Product3.scala
+++ b/src/library/scala/Product3.scala
@@ -24,7 +24,7 @@ trait Product3[+T1, +T2, +T3] extends Any with Product {
   override def productArity = 3
 
   
-  /** Returns the n-th projection of this product if 0 < n <= productArity,
+  /** Returns the n-th projection of this product if 0 <= n < productArity,
    *  otherwise throws an `IndexOutOfBoundsException`.
    *
    *  @param n number of the projection to be returned

--- a/src/library/scala/Product4.scala
+++ b/src/library/scala/Product4.scala
@@ -24,7 +24,7 @@ trait Product4[+T1, +T2, +T3, +T4] extends Any with Product {
   override def productArity = 4
 
   
-  /** Returns the n-th projection of this product if 0 < n <= productArity,
+  /** Returns the n-th projection of this product if 0 <= n < productArity,
    *  otherwise throws an `IndexOutOfBoundsException`.
    *
    *  @param n number of the projection to be returned

--- a/src/library/scala/Product5.scala
+++ b/src/library/scala/Product5.scala
@@ -24,7 +24,7 @@ trait Product5[+T1, +T2, +T3, +T4, +T5] extends Any with Product {
   override def productArity = 5
 
   
-  /** Returns the n-th projection of this product if 0 < n <= productArity,
+  /** Returns the n-th projection of this product if 0 <= n < productArity,
    *  otherwise throws an `IndexOutOfBoundsException`.
    *
    *  @param n number of the projection to be returned

--- a/src/library/scala/Product6.scala
+++ b/src/library/scala/Product6.scala
@@ -24,7 +24,7 @@ trait Product6[+T1, +T2, +T3, +T4, +T5, +T6] extends Any with Product {
   override def productArity = 6
 
   
-  /** Returns the n-th projection of this product if 0 < n <= productArity,
+  /** Returns the n-th projection of this product if 0 <= n < productArity,
    *  otherwise throws an `IndexOutOfBoundsException`.
    *
    *  @param n number of the projection to be returned

--- a/src/library/scala/Product7.scala
+++ b/src/library/scala/Product7.scala
@@ -24,7 +24,7 @@ trait Product7[+T1, +T2, +T3, +T4, +T5, +T6, +T7] extends Any with Product {
   override def productArity = 7
 
   
-  /** Returns the n-th projection of this product if 0 < n <= productArity,
+  /** Returns the n-th projection of this product if 0 <= n < productArity,
    *  otherwise throws an `IndexOutOfBoundsException`.
    *
    *  @param n number of the projection to be returned

--- a/src/library/scala/Product8.scala
+++ b/src/library/scala/Product8.scala
@@ -24,7 +24,7 @@ trait Product8[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8] extends Any with Product 
   override def productArity = 8
 
   
-  /** Returns the n-th projection of this product if 0 < n <= productArity,
+  /** Returns the n-th projection of this product if 0 <= n < productArity,
    *  otherwise throws an `IndexOutOfBoundsException`.
    *
    *  @param n number of the projection to be returned

--- a/src/library/scala/Product9.scala
+++ b/src/library/scala/Product9.scala
@@ -24,7 +24,7 @@ trait Product9[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9] extends Any with Pro
   override def productArity = 9
 
   
-  /** Returns the n-th projection of this product if 0 < n <= productArity,
+  /** Returns the n-th projection of this product if 0 <= n < productArity,
    *  otherwise throws an `IndexOutOfBoundsException`.
    *
    *  @param n number of the projection to be returned


### PR DESCRIPTION
Sanity check:

```
scala> case class P2(i: Int, j: Int)
defined class P2

val p2 = P2(1, 3)

p2.productElement(0)
res0: Any = 1

p2.productElement(1)
res1: Any = 3

p2.productElement(2)
java.lang.IndexOutOfBoundsException: 2
  at P2.productElement(<console>:10)
```
