### PR TITLE
Update to partest 1.0.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,7 +68,6 @@ val scalaParserCombinatorsDep = withoutScalaLang("org.scala-lang.modules" %% "sc
 val scalaSwingDep = withoutScalaLang("org.scala-lang.modules" %% "scala-swing" % versionNumber("scala-swing"))
 val scalaXmlDep = withoutScalaLang("org.scala-lang.modules" %% "scala-xml" % versionNumber("scala-xml"))
 val partestDep = withoutScalaLang("org.scala-lang.modules" %% "scala-partest" % versionNumber("partest"))
-val partestInterfaceDep = withoutScalaLang("org.scala-lang.modules" %% "scala-partest-interface" % "0.7.0")
 val junitDep = "junit" % "junit" % "4.11"
 val junitIntefaceDep = "com.novocode" % "junit-interface" % "0.11" % "test"
 val asmDep = "org.scala-lang.modules" % "scala-asm" % versionProps("scala-asm.version")
@@ -577,7 +576,7 @@ lazy val test = project
   .settings(Defaults.itSettings: _*)
   .settings(
     publishArtifact := false,
-    libraryDependencies ++= Seq(asmDep, partestDep, scalaXmlDep, partestInterfaceDep, scalacheckDep),
+    libraryDependencies ++= Seq(asmDep, partestDep, scalaXmlDep, scalacheckDep),
     unmanagedBase in IntegrationTest := baseDirectory.value / "files" / "lib",
     unmanagedJars in IntegrationTest <+= (unmanagedBase) (j => Attributed.blank(j)) map(identity),
     // no main sources
@@ -586,7 +585,7 @@ lazy val test = project
     sources in IntegrationTest := Seq.empty,
     fork in IntegrationTest := true,
     javaOptions in IntegrationTest += "-Xmx1G",
-    testFrameworks += new TestFramework("scala.tools.partest.Framework"),
+    testFrameworks += new TestFramework("scala.tools.partest.sbt.Framework"),
     testOptions in IntegrationTest += Tests.Setup( () => root.base.getAbsolutePath + "/pull-binary-libs.sh" ! ),
     testOptions in IntegrationTest += Tests.Argument("-Dpartest.java_opts=-Xmx1024M -Xms64M -XX:MaxPermSize=128M"),
     definedTests in IntegrationTest += (

--- a/scripts/jobs/integrate/bootstrap
+++ b/scripts/jobs/integrate/bootstrap
@@ -238,15 +238,6 @@ buildPartest() {
   fi
 }
 
-# buildPartestIface() {
-#   if [ "$forceRebuild" != "yes" ] && ( sbtResolve "org.scala-lang.modules"  "scala-partest-interface" $PARTEST_IFACE_VER )
-#   then echo "Found scala-partest-interface $PARTEST_IFACE_VER; not building."
-#   else
-#     update scala scala-partest-interface "$PARTEST_IFACE_REF" && gfxd
-#     sbtBuild 'set version :="'$PARTEST_IFACE_VER'"' $clean "${buildTasks[@]}"
-#   fi
-# }
-
 buildContinuations() {
   if [ "$CONT_PLUG_BUILT" != "yes" ] && [ "$forceRebuild" != "yes" ] && ( sbtResolve "org.scala-lang.plugins"  "scala-continuations-plugin" $CONTINUATIONS_VER full )
   then echo "Found scala-continuations-plugin $CONTINUATIONS_VER; not building."
@@ -312,7 +303,6 @@ buildModules() {
   buildActorsMigration
   buildScalacheck
   buildPartest
-  # buildPartestIface
 }
 
 buildPublishedModules() {
@@ -324,7 +314,6 @@ buildPublishedModules() {
   buildSwing
   buildActorsMigration
   buildPartest
-  # buildPartestIface
 }
 
 
@@ -441,7 +430,6 @@ deriveModuleVersions() {
                 SWING_REF="v$SWING_VER"
      ACTORS_MIGRATION_REF="v$ACTORS_MIGRATION_VER"
               PARTEST_REF="v$PARTEST_VER"
-      # PARTEST_IFACE_REF="v$PARTEST_IFACE_VER"
            SCALACHECK_REF="$SCALACHECK_VER" # no `v` in their tags
    else
     # use HEAD as default when no revision is specified on the command line
@@ -451,7 +439,6 @@ deriveModuleVersions() {
                SWING_REF=${SWING_REF-"HEAD"}
     ACTORS_MIGRATION_REF=${ACTORS_MIGRATION_REF-"HEAD"}
              PARTEST_REF=${PARTEST_REF-"HEAD"}
-     # PARTEST_IFACE_REF=${PARTEST_IFACE_REF-"HEAD"}
           SCALACHECK_REF=${SCALACHECK_REF-"HEAD"}
 
                  XML_VER=$(deriveVersion scala scala-xml "$XML_REF")
@@ -472,7 +459,6 @@ deriveModuleVersions() {
   echo "SWING            = $SWING_VER at $SWING_REF"
   echo "XML              = $XML_VER at $XML_REF"
 
-  # PARTEST_IFACE_VER=${PARTEST_IFACE_VER-$(deriveVersion scala scala-partest-interface "$PARTEST_IFACE_REF")}
 }
 
 createNetrcFile() {

--- a/versions.properties
+++ b/versions.properties
@@ -36,7 +36,7 @@ jline.version=2.12.1
 scala-asm.version=5.0.4-scala-3
 
 # external modules, used internally (not shipped)
-partest.version.number=1.0.11
+partest.version.number=1.0.13
 scalacheck.version.number=1.11.6
 
 # TODO: modularize the compiler


### PR DESCRIPTION
Which lets us remove the dependency on sbt-partest-interface,
as this has been incorporated into scala-partest itself.

The new version of partest is still in transit between Sonatype and Maven Central.

I've tested this locally by explicitly adding Sonatype releases as a resolver.

``` scala
resolvers in ThisBuild += sbt.Opts.resolver.sonatypeReleases
```

```
> partest --srcpath scaladoc --run --terse
[info] Packaging /Users/jason/code/scala2/build-sbt/pack/lib/scala-partest-javaagent.jar ...
[info] Done packaging.
Selected 57 tests drawn from 1 named test categories

# starting 57 tests in run
```

Review by @szeiger 
