### PR TITLE
Update to partest 1.0.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,6 @@ val scalaParserCombinatorsDep = withoutScalaLang("org.scala-lang.modules" %% "sc
 val scalaSwingDep = withoutScalaLang("org.scala-lang.modules" %% "scala-swing" % versionNumber("scala-swing"))
 val scalaXmlDep = withoutScalaLang("org.scala-lang.modules" %% "scala-xml" % versionNumber("scala-xml"))
 val partestDep = withoutScalaLang("org.scala-lang.modules" %% "scala-partest" % versionNumber("partest"))
-val partestInterfaceDep = withoutScalaLang("org.scala-lang.modules" %% "scala-partest-interface" % "0.7.0")
 val junitDep = "junit" % "junit" % "4.11"
 val junitIntefaceDep = "com.novocode" % "junit-interface" % "0.11" % "test"
 val asmDep = "org.scala-lang.modules" % "scala-asm" % versionProps("scala-asm.version")
@@ -548,7 +547,7 @@ lazy val test = project
   .settings(Defaults.itSettings: _*)
   .settings(
     publishArtifact := false,
-    libraryDependencies ++= Seq(asmDep, partestDep, scalaXmlDep, partestInterfaceDep, scalacheckDep),
+    libraryDependencies ++= Seq(asmDep, partestDep, scalaXmlDep, scalacheckDep),
     unmanagedBase in IntegrationTest := baseDirectory.value / "files" / "lib",
     unmanagedJars in IntegrationTest <+= (unmanagedBase) (j => Attributed.blank(j)) map(identity),
     // no main sources
@@ -557,7 +556,7 @@ lazy val test = project
     sources in IntegrationTest := Seq.empty,
     fork in IntegrationTest := true,
     javaOptions in IntegrationTest += "-Xmx1G",
-    testFrameworks += new TestFramework("scala.tools.partest.Framework"),
+    testFrameworks += new TestFramework("scala.tools.partest.sbt.Framework"),
     testOptions in IntegrationTest += Tests.Setup( () => root.base.getAbsolutePath + "/pull-binary-libs.sh" ! ),
     testOptions in IntegrationTest += Tests.Argument("-Dpartest.java_opts=-Xmx1024M -Xms64M -XX:MaxPermSize=128M"),
     definedTests in IntegrationTest += (

--- a/scripts/jobs/integrate/bootstrap
+++ b/scripts/jobs/integrate/bootstrap
@@ -238,15 +238,6 @@ buildPartest() {
   fi
 }
 
-# buildPartestIface() {
-#   if [ "$forceRebuild" != "yes" ] && ( sbtResolve "org.scala-lang.modules"  "scala-partest-interface" $PARTEST_IFACE_VER )
-#   then echo "Found scala-partest-interface $PARTEST_IFACE_VER; not building."
-#   else
-#     update scala scala-partest-interface "$PARTEST_IFACE_REF" && gfxd
-#     sbtBuild 'set version :="'$PARTEST_IFACE_VER'"' $clean "${buildTasks[@]}"
-#   fi
-# }
-
 buildSwing() {
   if [ "$SWING_BUILT" != "yes" ] && [ "$forceRebuild" != "yes" ] && ( sbtResolve "org.scala-lang.modules"  "scala-swing" $SWING_VER )
   then echo "Found scala-swing $SWING_VER; not building."
@@ -277,7 +268,6 @@ buildModules() {
   buildSwing
   buildScalacheck
   buildPartest
-  # buildPartestIface
 }
 
 buildPublishedModules() {
@@ -287,7 +277,6 @@ buildPublishedModules() {
   buildParsers
   buildSwing
   buildPartest
-  # buildPartestIface
 }
 
 
@@ -400,7 +389,6 @@ deriveModuleVersions() {
               PARSERS_REF="v$PARSERS_VER"
                 SWING_REF="v$SWING_VER"
               PARTEST_REF="v$PARTEST_VER"
-      # PARTEST_IFACE_REF="v$PARTEST_IFACE_VER"
            SCALACHECK_REF="$SCALACHECK_VER" # no `v` in their tags
    else
     # use HEAD as default when no revision is specified on the command line
@@ -408,7 +396,6 @@ deriveModuleVersions() {
              PARSERS_REF=${PARSERS_REF-"HEAD"}
                SWING_REF=${SWING_REF-"HEAD"}
              PARTEST_REF=${PARTEST_REF-"HEAD"}
-     # PARTEST_IFACE_REF=${PARTEST_IFACE_REF-"HEAD"}
           SCALACHECK_REF=${SCALACHECK_REF-"HEAD"}
 
                  XML_VER=$(deriveVersion scala scala-xml "$XML_REF")
@@ -425,7 +412,6 @@ deriveModuleVersions() {
   echo "SWING            = $SWING_VER at $SWING_REF"
   echo "XML              = $XML_VER at $XML_REF"
 
-  # PARTEST_IFACE_VER=${PARTEST_IFACE_VER-$(deriveVersion scala scala-partest-interface "$PARTEST_IFACE_REF")}
 }
 
 createNetrcFile() {

--- a/versions.properties
+++ b/versions.properties
@@ -30,7 +30,7 @@ jline.version=2.12.1
 scala-asm.version=5.0.4-scala-3
 
 # external modules, used internally (not shipped)
-partest.version.number=1.0.12
+partest.version.number=1.0.13
 scalacheck.version.number=1.11.6
 
 # TODO: modularize the compiler


### PR DESCRIPTION
Which lets us remove the dependency on sbt-partest-interface,
as this has been incorporated into scala-partest itself.

Review by @szeiger 
