### PR TITLE
SI-8790 test case

### DIFF
--- a/test/junit/scala/tools/nsc/backend/jvm/opt/MethodLevelOptsTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/MethodLevelOptsTest.scala
@@ -756,4 +756,24 @@ class MethodLevelOptsTest extends ClearAfterClass {
     val List(c) = compileClasses(methodOptCompiler)(code)
     assertNoInvoke(getSingleMethod(c, "compare"))
   }
+
+  @Test
+  def t8790(): Unit = {
+    val code =
+      """class C {
+        |  def t(x: Int, y: Int): String = (x, y) match {
+        |    case (7, 8) => "a"
+        |    case _ => "b"
+        |  }
+        |}
+      """.stripMargin
+    val List(c) = compileClasses(methodOptCompiler)(code)
+
+    assertEquals(getSingleMethod(c, "t").instructions.summary, List(
+      BIPUSH, ILOAD, IF_ICMPNE,
+      BIPUSH, ILOAD, IF_ICMPNE,
+      LDC, ASTORE, GOTO,
+      -1, LDC, ASTORE,
+      -1, ALOAD, ARETURN))
+  }
 }


### PR DESCRIPTION
Tuples created for pattern matching are eliminated since
https://github.com/scala/scala/pull/4858
