### PR TITLE
SD-79 don't issue spurious inliner warnings under l:project

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/ClosureOptimizer.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/ClosureOptimizer.scala
@@ -358,11 +358,13 @@ class ClosureOptimizer[BT <: BTypes](val btypes: BT) {
     val callee = bodyMethod.map({
       case (bodyMethodNode, bodyMethodDeclClass) =>
         val bodyDeclClassType = classBTypeFromParsedClassfile(bodyMethodDeclClass)
+        val canInlineFromSource = compilerSettings.YoptInlineGlobal || bodyMethodIsBeingCompiled
         Callee(
           callee = bodyMethodNode,
           calleeDeclarationClass = bodyDeclClassType,
-          safeToInline = compilerSettings.YoptInlineGlobal || bodyMethodIsBeingCompiled,
+          safeToInline = canInlineFromSource,
           safeToRewrite = false, // the lambda body method is not a trait interface method
+          canInlineFromSource = canInlineFromSource,
           annotatedInline = false,
           annotatedNoInline = false,
           samParamTypes = callGraph.samParamTypes(bodyMethodNode, bodyDeclClassType),

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
@@ -83,7 +83,7 @@ class Inliner[BT <: BTypes](val btypes: BT) {
    * True for statically resolved trait callsites that should be rewritten to the static implementation method.
    */
   def doRewriteTraitCallsite(callsite: Callsite) = callsite.callee match {
-    case Right(Callee(_, _, _, safeToRewrite, _, _, _, _)) => safeToRewrite
+    case Right(callee) => callee.safeToRewrite
     case _ => false
   }
 
@@ -101,7 +101,7 @@ class Inliner[BT <: BTypes](val btypes: BT) {
     // If the callsite was eliminated by DCE, do nothing.
     if (!callGraph.containsCallsite(callsite)) return
 
-    val Right(Callee(callee, calleeDeclarationClass, _, _, annotatedInline, annotatedNoInline, samParamTypes, infoWarning)) = callsite.callee
+    val Right(Callee(callee, calleeDeclarationClass, _, _, canInlineFromSource, annotatedInline, annotatedNoInline, samParamTypes, infoWarning)) = callsite.callee
 
     val traitMethodArgumentTypes = asm.Type.getArgumentTypes(callee.desc)
 
@@ -159,6 +159,7 @@ class Inliner[BT <: BTypes](val btypes: BT) {
           calleeDeclarationClass = implClassBType,
           safeToInline           = true,
           safeToRewrite          = false,
+          canInlineFromSource    = canInlineFromSource,
           annotatedInline        = annotatedInline,
           annotatedNoInline      = annotatedNoInline,
           samParamTypes          = staticCallSamParamTypes,

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/InlinerHeuristics.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/InlinerHeuristics.scala
@@ -41,7 +41,7 @@ class InlinerHeuristics[BT <: BTypes](val bTypes: BT) {
     compilingMethods.map(methodNode => {
       var requests = Set.empty[InlineRequest]
       callGraph.callsites(methodNode).valuesIterator foreach {
-        case callsite @ Callsite(_, _, _, Right(Callee(callee, calleeDeclClass, safeToInline, _, calleeAnnotatedInline, _, _, callsiteWarning)), _, _, _, pos, _, _) =>
+        case callsite @ Callsite(_, _, _, Right(Callee(callee, calleeDeclClass, safeToInline, _, canInlineFromSource, calleeAnnotatedInline, _, _, callsiteWarning)), _, _, _, pos, _, _) =>
           inlineRequest(callsite) match {
             case Some(Right(req)) => requests += req
             case Some(Left(w))    =>
@@ -52,7 +52,7 @@ class InlinerHeuristics[BT <: BTypes](val bTypes: BT) {
               }
 
             case None =>
-              if (calleeAnnotatedInline && !callsite.annotatedNoInline && bTypes.compilerSettings.YoptWarningEmitAtInlineFailed) {
+              if (canInlineFromSource && calleeAnnotatedInline && !callsite.annotatedNoInline && bTypes.compilerSettings.YoptWarningEmitAtInlineFailed) {
                 // if the callsite is annotated @inline, we report an inline warning even if the underlying
                 // reason is, for example, mixed compilation (which has a separate -Yopt-warning flag).
                 def initMsg = s"${BackendReporting.methodSignature(calleeDeclClass.internalName, callee)} is annotated @inline but cannot be inlined"

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
@@ -1515,4 +1515,13 @@ class InlinerTest extends ClearAfterClass {
         "C$$$anonfun$2", IRETURN,
         -1 /*A*/, "C$$$anonfun$3", IRETURN))
   }
+
+  @Test
+  def inlineProject(): Unit = {
+    val codeA = "final class A { @inline def f = 1 }"
+    val codeB = "class B { def t(a: A) = a.f }"
+    // tests that no warning is emitted
+    val List(a, b) = compileClassesSeparately(List(codeA, codeB), extraArgs = "-Yopt:l:project -Yopt-warnings")
+    assertInvoke(getSingleMethod(b, "t"), "A", "f")
+  }
 }


### PR DESCRIPTION
When enabling `-Yopt:inline-project` (or `-Yopt:l:project`), the inliner
would spuriously warn about callsites to methods marked `@inline` that
are read from the classpath (not being compiled currently).

This patch introduces yet another field to the `Callsite` class, which
is growing a bit too large. But the call graph representation will get
an overhaul when implementing the new inliner heuristics (2.12.0-M5), so
this is just a temporary fix that would be nice to have in M4.
