### PR TITLE
SI-9658 Fix crosstalk between partial fun. and GADT match

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2584,8 +2584,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
         // the default uses applyOrElse's first parameter since the scrut's type has been widened
         val match_ = {
-          val defaultCase = methodBodyTyper.typedCase(
-            mkDefaultCase(methodBodyTyper.typed1(REF(default) APPLY (REF(x)), mode, B1.tpe).setType(B1.tpe)), argTp, B1.tpe)
+          val cdef = mkDefaultCase(methodBodyTyper.typed1(REF(default) APPLY (REF(x)), mode, B1.tpe).setType(B1.tpe))
+          val List(defaultCase) = methodBodyTyper.typedCases(List(cdef), argTp, B1.tpe)
           treeCopy.Match(match0, match0.selector, match0.cases :+ defaultCase)
         }
         match_ setType B1.tpe

--- a/test/files/pos/t9658.scala
+++ b/test/files/pos/t9658.scala
@@ -1,0 +1,10 @@
+sealed trait G[T]
+case object GI extends G[Int]
+
+class C {
+  def typerFail[T](rt: G[T]): T = rt match {
+    case GI =>
+      { case x => x } : PartialFunction[Any, Any] // comment this line, compiles.
+      0 // found Int, required T
+  }
+}


### PR DESCRIPTION
When typechecking the synthetic default case of a pattern matching
anonymous partial function, we failed to create a new `Context`.
This led to crosstalk with the management of the saved type bounds
of an enclosing GADT pattern match.

This commit avoids the direct call to `typeCase` and instead
indirects through `typedCases`, which spawns a new nested typer
context, and hence avoids the crosstalk when `restoreSavedTypeBounds`
runs.
