### PR TITLE
SBT build tweaks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -150,6 +150,7 @@ lazy val commonSettings = clearSourceAndResourceDirectories ++ publishSettings +
   cleanFiles += (classDirectory in Compile).value,
   cleanFiles += (target in Compile in doc).value,
   fork in run := true,
+  skipDoc := false,
   scalacOptions in Compile in doc ++= Seq(
     "-doc-footer", "epfl",
     "-diagrams",
@@ -196,6 +197,8 @@ lazy val commonSettings = clearSourceAndResourceDirectories ++ publishSettings +
   // Remove auto-generated manifest attributes
   packageOptions in Compile in packageBin := Seq.empty,
   packageOptions in Compile in packageSrc := Seq.empty,
+
+  publishArtifact in packageDoc := !skipDoc.value,
 
   // Lets us CTRL-C partest without exiting SBT entirely
   cancelable in Global := true,
@@ -714,6 +717,7 @@ def configureAsSubproject(project: Project): Project = {
     .settings(generatePropertiesFileSettings: _*)
 }
 
+lazy val skipDoc = settingKey[Boolean]("Skip Scaladoc generation.")
 lazy val buildDirectory = settingKey[File]("The directory where all build products go. By default ./build")
 lazy val mkBin = taskKey[Seq[File]]("Generate shell script (bash or Windows batch).")
 lazy val mkQuick = taskKey[Unit]("Generate a full build, including scripts, in build-sbt/quick")

--- a/project/VersionUtil.scala
+++ b/project/VersionUtil.scala
@@ -115,7 +115,9 @@ object VersionUtil {
     val in = new FileInputStream(file("versions.properties"))
     try props.load(in)
     finally in.close()
-    props.asScala.toMap
+    props.asScala.toMap.map {
+      case (k, v) => (k, sys.props.getOrElse(k, v)) // allow system properties to override versions.properties
+    }
   }
 
   /** Get a subproject version number from `versionProps` */


### PR DESCRIPTION
I accumulated these changes while seeing if the SBT build could be used in place of Ant in the bootstrap script. These changes aren't sufficient, but I thought I'd get the ball rolling with this PR.

The motivation for a custom setting for `skipDoc` setting key is that `set every publishArtifact in packageDoc` seemed not to work for me. (`set every` has some limitations in SBT).

Future work:
- Add a task equivalent to `publishCoreNoDocs` in the Ant build
- Figure out how to get SBT to pull a Scala version from the local Ivy version (I tried `sbt publishLocal` / `sbt 'set scalaVersion = ...' update`), but ran into problems.

Review by @szeiger 
