### PR TITLE
Scaladoc: Add better hover-text in search results

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/base/comment/Comment.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/comment/Comment.scala
@@ -21,7 +21,7 @@ abstract class Comment {
   /** The main body of the comment that describes what the entity does and is.  */
   def body: Body
 
-  private def closeHtmlTags(inline: Inline) = {
+  private def closeHtmlTags(inline: Inline): Inline = {
     val stack = mutable.ListBuffer.empty[HtmlTag]
     def scan(i: Inline) {
       i match {

--- a/src/scaladoc/scala/tools/nsc/doc/html/Page.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/Page.scala
@@ -7,6 +7,7 @@ package scala
 package tools.nsc.doc.html
 
 import scala.tools.nsc.doc.model._
+import scala.tools.nsc.doc.base.comment
 import java.io.{FileOutputStream, File}
 import scala.reflect.NameTransformer
 import java.nio.channels.Channels
@@ -99,5 +100,17 @@ abstract class Page {
         List.fill(fss.length - 1)("..") ::: tss
     }
     relativize(thisPage.path.reverse, destPath.reverse).mkString("/")
+  }
+
+  protected def inlineToStr(inl: comment.Inline): String = inl match {
+    case comment.Chain(items) => items flatMap (inlineToStr(_)) mkString ""
+    case comment.Italic(in) => inlineToStr(in)
+    case comment.Bold(in) => inlineToStr(in)
+    case comment.Underline(in) => inlineToStr(in)
+    case comment.Monospace(in) => inlineToStr(in)
+    case comment.Text(text) => text
+    case comment.Summary(in) => inlineToStr(in)
+    case comment.EntityLink(comment.Text(text), _) => text
+    case _ => inl.toString
   }
 }

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -995,17 +995,6 @@ trait EntityPage extends HtmlPage {
     case _ => block.toString
   }
 
-  private def inlineToStr(inl: comment.Inline): String = inl match {
-    case comment.Chain(items) => items flatMap (inlineToStr(_)) mkString ""
-    case comment.Italic(in) => inlineToStr(in)
-    case comment.Bold(in) => inlineToStr(in)
-    case comment.Underline(in) => inlineToStr(in)
-    case comment.Monospace(in) => inlineToStr(in)
-    case comment.Text(text) => text
-    case comment.Summary(in) => inlineToStr(in)
-    case _ => inl.toString
-  }
-
   private def typeToHtmlWithStupidTypes(tpl: TemplateEntity, superTpl: TemplateEntity, superType: TypeEntity): NodeSeq =
     if (tpl.universe.settings.useStupidTypes.value)
       superTpl match {

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/IndexScript.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/IndexScript.scala
@@ -31,11 +31,12 @@ class IndexScript(universe: doc.Universe, index: doc.Index) extends Page {
         val merged = mergeByQualifiedName(templates)
 
         val ary = merged.keys.toList.sortBy(_.toLowerCase).map(key => {
-          val pairs = merged(key).flatMap { t =>
+          val pairs = merged(key).flatMap { t: DocTemplateEntity =>
             Seq(
               kindToString(t) -> relativeLinkTo(t),
               "kind" -> kindToString(t),
-              "members" -> membersToJSON(t.members.filter(!_.isShadowedOrAmbiguousImplicit)))
+              "members" -> membersToJSON(t.members.filter(!_.isShadowedOrAmbiguousImplicit)),
+              "shortDescription" -> shortDesc(t))
           }
 
           JSONObject(Map(pairs : _*) + ("name" -> key))
@@ -74,6 +75,11 @@ class IndexScript(universe: doc.Universe, index: doc.Index) extends Page {
         case t: DocTemplateEntity if !t.isPackage && !universe.settings.hardcoded.isExcluded(t.qualifiedName) => t
       }
     }) : _*)
+  }
+
+  /** Gets the short description i.e. the first sentence of the docstring */
+  def shortDesc(mbr: MemberEntity): String = mbr.comment.fold("") { c =>
+    inlineToStr(c.short).replaceAll("\n", "")
   }
 
   /** Returns the json representation of the supplied members */

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala
@@ -939,17 +939,6 @@ class Template(universe: doc.Universe, generator: DiagramGenerator, tpl: DocTemp
     case _ => block.toString
   }
 
-  private def inlineToStr(inl: comment.Inline): String = inl match {
-    case comment.Chain(items) => items flatMap (inlineToStr(_)) mkString ""
-    case comment.Italic(in) => inlineToStr(in)
-    case comment.Bold(in) => inlineToStr(in)
-    case comment.Underline(in) => inlineToStr(in)
-    case comment.Monospace(in) => inlineToStr(in)
-    case comment.Text(text) => text
-    case comment.Summary(in) => inlineToStr(in)
-    case _ => inl.toString
-  }
-
   private def typeToHtmlWithStupidTypes(tpl: TemplateEntity, superTpl: TemplateEntity, superType: TypeEntity): NodeSeq =
     if (tpl.universe.settings.useStupidTypes.value)
       superTpl match {

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.js
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.js
@@ -352,7 +352,7 @@ function searchMembers(entities, regExp, pack) {
         nameElem.className = "entity";
 
         var entityUrl = document.createElement("a");
-        entityUrl.title = name;
+        entityUrl.title = entity.shortDescription ? entity.shortDescription : name;
         entityUrl.href = toRoot + entity[entity.kind];
         entityUrl.appendChild(document.createTextNode(name));
 
@@ -484,7 +484,7 @@ function listItem(entity, regExp) {
     nameElem.className = "entity";
 
     var entityUrl = document.createElement("a");
-    entityUrl.title = name;
+    entityUrl.title = entity.shortDescription ? entity.shortDescription : name;
     entityUrl.href = toRoot + entity[entity.kind];
 
     entityUrl.appendChild(document.createTextNode(name));


### PR DESCRIPTION
This commit adds hover text to entities in the search results. It does this by taking the `comment.short` and turning it into a `String` which is then placed in the JSON blob generated by `IndexScript.scala`.

Generated docs: https://dl.dropboxusercontent.com/u/358427/scaladoc-hover/index.html

Review: @VladUreche 
