### PR TITLE
Scaladoc: Add progress bar for search

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -63,6 +63,9 @@ trait EntityPage extends HtmlPage {
     <body>
       { search }
       <div id="search-results">
+        <div id="search-progress">
+          <div id="progress-fill"></div>
+        </div>
         <div id="results-content">
           <div id="entity-results"></div>
           <div id="member-results"></div>

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.css
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.css
@@ -316,6 +316,20 @@ textarea, input { outline: none; }
   z-index: 1;
 }
 
+div#search-progress {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 0.25em;
+}
+
+div#search-progress > div#progress-fill {
+  width: 0%;
+  background-color: #f16665;
+  transition: 0.1s;
+}
+
 #focusfilter .focuscoll {
   font-weight: bold;
 }

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/scheduler.js
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/scheduler.js
@@ -98,4 +98,11 @@ function Scheduler() {
             });
         }
     }
+
+    this.numberOfJobs = function(label) {
+        var index = scheduler.indexOf(label);
+        if (index == -1) throw("queue for label '" + label + "' non-existent");
+
+        return scheduler.queues[index].length;
+    }
 };


### PR DESCRIPTION
As suggested by @jrudolph, here's a simple implementation of the progress bar. It the `setProgress` function is run each time a package has been searched and the results added to the DOM. It seems to be accurate enough to not warrant a more advanced implementation.

Preview: https://dl.dropboxusercontent.com/u/358427/scaladoc-progress/index.html
Review: @heathermiller 
