### PR TITLE
Remove GIJ memory configuration advice from man pages.

### DIFF
--- a/src/manual/scala/man1/fsc.scala
+++ b/src/manual/scala/man1/fsc.scala
@@ -126,11 +126,7 @@ object fsc extends Command {
 
           "With Java 1.5 (or newer) one may for example configure the " &
           "memory usage of the JVM as follows: " &
-          Mono("JAVA_OPTS=\"-Xmx512M -Xms16M -Xss16M\""),
-
-          "With " & Link("GNU Java", "http://gcc.gnu.org/java/") & " one " &
-          "may configure the memory usage of the GIJ as follows: " &
-          Mono("JAVA_OPTS=\"--mx512m --ms16m\"")
+          Mono("JAVA_OPTS=\"-Xmx512M -Xms16M -Xss16M\"")
         ))))
 
   val exitStatus = Section("EXIT STATUS",

--- a/src/manual/scala/man1/scala.scala
+++ b/src/manual/scala/man1/scala.scala
@@ -184,11 +184,7 @@ object scala extends Command {
 
           "With Java 1.5 (or newer) one may for example configure the " &
           "memory usage of the JVM as follows: " &
-          Mono("JAVA_OPTS=\"-Xmx512M -Xms16M -Xss16M\""),
-
-          "With " & Link("GNU Java", "http://gcc.gnu.org/java/") & " one " &
-          "may configure the memory usage of the GIJ as follows: " &
-          Mono("JAVA_OPTS=\"--mx512m --ms16m\"")
+          Mono("JAVA_OPTS=\"-Xmx512M -Xms16M -Xss16M\"")
         ))))
 
   val examples = Section("EXAMPLES",

--- a/src/manual/scala/man1/scalac.scala
+++ b/src/manual/scala/man1/scalac.scala
@@ -450,11 +450,7 @@ object scalac extends Command {
 
           "With Java 1.5 (or newer) one may for example configure the " &
           "memory usage of the JVM as follows: " &
-          Mono("JAVA_OPTS=\"-Xmx512M -Xms16M -Xss16M\""),
-
-          "With " & Link("GNU Java", "http://gcc.gnu.org/java/") & " one " &
-          "may configure the memory usage of the GIJ as follows: " &
-          Mono("JAVA_OPTS=\"--mx512m --ms16m\"")
+          Mono("JAVA_OPTS=\"-Xmx512M -Xms16M -Xss16M\"")
         ))))
 
   val examples = Section("EXAMPLES",


### PR DESCRIPTION
GIJ is uncommonly used so general guidance on setting memory configuration
in the fsc, scala and scalac man pages would only be of use to a highly
select group of individuals. For 99.99999999999999% of users this info
would be an historical curio at best and random noise at worst.
