### PR TITLE
Fix var spelling in WeakHashSet

### DIFF
--- a/src/reflect/scala/reflect/internal/util/WeakHashSet.scala
+++ b/src/reflect/scala/reflect/internal/util/WeakHashSet.scala
@@ -57,9 +57,9 @@ final class WeakHashSet[A <: AnyRef](val initialCapacity: Int, val loadFactor: D
   /**
    * the limit at which we'll increase the size of the hash table
    */
-  var threshhold = computeThreshHold
+  var threshhold = computeThreshold
 
-  private[this] def computeThreshHold: Int = (table.size * loadFactor).ceil.toInt
+  private[this] def computeThreshold: Int = (table.size * loadFactor).ceil.toInt
 
   /**
    * find the bucket associated with an element's hash code
@@ -122,7 +122,7 @@ final class WeakHashSet[A <: AnyRef](val initialCapacity: Int, val loadFactor: D
   private[this] def resize() {
     val oldTable = table
     table = new Array[Entry[A]](oldTable.size * 2)
-    threshhold = computeThreshHold
+    threshhold = computeThreshold
 
     @tailrec
     def tableLoop(oldBucket: Int): Unit = if (oldBucket < oldTable.size) {
@@ -253,7 +253,7 @@ final class WeakHashSet[A <: AnyRef](val initialCapacity: Int, val loadFactor: D
   // empty this set
   override def clear(): Unit = {
     table = new Array[Entry[A]](table.size)
-    threshhold = computeThreshHold
+    threshhold = computeThreshold
     count = 0
 
     // drain the queue - doesn't do anything because we're throwing away all the values anyway


### PR DESCRIPTION
Fixed spelling of private def only.

`var threshhold` remains in need of fix.

FWIW, the project builds `$ ant build` with the var access restricted,

```
  /**
   * the limit at which we'll increase the size of the hash table
   */
  private[this] var threshhold = computeThreshold
```

The package is also internal strongly hinting it should not be depended on,

```
package scala
package reflect.internal.util
```

Would those two facts allow the var to be made private and renamed or just renamed in 2.12?

The alternatives are,
- Leave it as-is
- Deprecate it in 2.12 and make private in 2.13
