### PR TITLE
SI-9665 Backquoted vbar in extractor pattern

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1966,8 +1966,8 @@ self =>
           case _ => EmptyTree
         }
         def loop(top: Tree): Tree = reducePatternStack(base, top) match {
-          case next if isIdentExcept(raw.BAR) => pushOpInfo(next) ; loop(simplePattern(badPattern3))
-          case next                           => next
+          case next if isIdent && !isRawBar => pushOpInfo(next) ; loop(simplePattern(badPattern3))
+          case next                         => next
         }
         checkWildStar orElse stripParens(loop(top))
       }

--- a/test/files/pos/t9665.scala
+++ b/test/files/pos/t9665.scala
@@ -1,0 +1,7 @@
+
+object | { def unapply(x: (Any, Any)) = Some(x) }
+
+trait Test {
+  def f() = (1,2) match { case 1 `|` 2 => }
+  def g() = 2 match { case 1 | 2 => }
+}


### PR DESCRIPTION
Allow an infix extractor named `|`, when backquoted.

Because why not.

Not sure if `isIdentExcept` and `isIdentOf` see any usages.
