### PR TITLE
SI-9666: Use inline group names in Regex

### DIFF
--- a/test/files/run/reify_printf.scala
+++ b/test/files/run/reify_printf.scala
@@ -6,7 +6,6 @@ import scala.tools.reflect.ToolBox
 import scala.reflect.api._
 import scala.reflect.api.Trees
 import scala.reflect.internal.Types
-import scala.util.matching.Regex
 
 object Test extends App {
   //val output = new ByteArrayOutputStream()


### PR DESCRIPTION
Delegate `Match group name` to the underlying `matcher`.

If that fails, try explicit group names as a fall back.

Because no attempt is made to correlate inline and explicit
names, explicit names are deprecated.

In the following case, either name is accepted:

```
new Regex("a(?<Bar>b*)c", "Bee")
```

But if names are reversed, the error is undetected:

```
new Regex("a(?<Bee>b*)(?<Bar>c)", "Bar", "Bee")
```
