### PR TITLE
explicitly specify insertion-order feature in docs

### DIFF
--- a/src/library/scala/collection/mutable/ListMap.scala
+++ b/src/library/scala/collection/mutable/ListMap.scala
@@ -15,7 +15,7 @@ package mutable
 import generic._
 import annotation.tailrec
 
-/** A simple mutable map backed by a list.
+/** A simple mutable map backed by a list, so it preserves insertion order.
  *
  *  @tparam A    the type of the keys contained in this list map.
  *  @tparam B    the type of the values assigned to keys in this list map.


### PR DESCRIPTION
It's based on this very minor pull request: https://github.com/scala/scala/pull/4788

Just added similar details for mutable version of `ListMap`.

P.S. Next time I'll try to not split that kind of minor changes into different PRs.
