### PR TITLE
SI-7898 Read user input during REPL warmup

### DIFF
--- a/src/compiler/scala/tools/nsc/GenericRunnerCommand.scala
+++ b/src/compiler/scala/tools/nsc/GenericRunnerCommand.scala
@@ -79,6 +79,7 @@ Other startup options:
 
  -howtorun    what to run <script|object|jar|guess> (default: guess)
  -i <file>    preload <file> before starting the repl
+ -I <file>    preload <file>, enforcing line-by-line interpretation
  -e <string>  execute <string> as if entered in the repl
  -save        save the compiled script in a jar for future use
  -nc          no compilation daemon: do not use the fsc offline compiler

--- a/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
+++ b/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
@@ -21,9 +21,15 @@ class GenericRunnerSettings(error: String => Unit) extends Settings(error) {
 
   val loadfiles =
     MultiStringSetting(
+      "-I",
+      "file",
+      "load a file line-by-line")
+
+  val pastefiles =
+    MultiStringSetting(
       "-i",
       "file",
-      "load a file (assumes the code is given interactively)")
+      "paste a file")
 
   val execute =
     StringSetting(

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -1191,7 +1191,7 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
       var isIncomplete = false
       def parse = {
         reporter.reset()
-        val trees = newUnitParser(line).parseStats()
+        val trees = newUnitParser(line, label).parseStats()
         if (reporter.hasErrors) Error(trees)
         else if (isIncomplete) Incomplete(trees)
         else Success(trees)

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -1,5 +1,5 @@
 /* NSC -- new Scala compiler
- * Copyright 2005-2013 LAMP/EPFL
+ * Copyright 2005-2016 LAMP/EPFL
  * @author  Martin Odersky
  */
 
@@ -74,13 +74,14 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
 
   lazy val isClassBased: Boolean = settings.Yreplclassbased.value
 
-  private[nsc] var printResults               = true      // whether to print result lines
-  private[nsc] var totalSilence               = false     // whether to print anything
-  private var _initializeComplete             = false     // compiler is initialized
-  private var _isInitialized: Future[Boolean] = null      // set up initialization future
-  private var bindExceptions                  = true      // whether to bind the lastException variable
-  private var _executionWrapper               = ""        // code to be wrapped around all lines
-  var partialInput: String = ""                           // code accumulated in multi-line REPL input
+  private[nsc] var printResults               = true        // whether to print result lines
+  private[nsc] var totalSilence               = false       // whether to print anything
+  private var _initializeComplete             = false       // compiler is initialized
+  private var _isInitialized: Future[Boolean] = null        // set up initialization future
+  private var bindExceptions                  = true        // whether to bind the lastException variable
+  private var _executionWrapper               = ""          // code to be wrapped around all lines
+  var partialInput: String                    = ""          // code accumulated in multi-line REPL input
+  private var label                           = "<console>" // compilation unit name for reporting
 
   /** We're going to go to some trouble to initialize the compiler asynchronously.
    *  It's critical that nothing call into it until it's been initialized or we will
@@ -107,6 +108,12 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
 
     try body
     finally if (!saved) settings.nowarn.value = false
+  }
+  // Apply a temporary label for compilation (for example, script name)
+  def withLabel[A](temp: String)(body: => A): A = {
+    val saved = label
+    label = temp
+    try body finally label = saved
   }
 
   /** construct an interpreter that reports to Console */
@@ -810,7 +817,7 @@ class IMain(@BeanProperty val factory: ScriptEngineFactory, initialSettings: Set
       case Right(result) => Right(result)
     }
 
-    def compile(source: String): Boolean = compileAndSaveRun("<console>", source)
+    def compile(source: String): Boolean = compileAndSaveRun(label, source)
 
     /** The innermost object inside the wrapper, found by
       * following accessPath into the outer one.

--- a/src/repl/scala/tools/nsc/interpreter/InteractiveReader.scala
+++ b/src/repl/scala/tools/nsc/interpreter/InteractiveReader.scala
@@ -50,3 +50,98 @@ object InteractiveReader {
   def createDefault(): InteractiveReader = apply() // used by sbt
 }
 
+/** Collect one line of user input from the supplied reader.
+ *  Runs on a new thread while the REPL is initializing on the main thread.
+ *
+ *  The user can enter text or a `:paste` command.
+ */
+class SplashLoop(reader: InteractiveReader, prompt: String) extends Runnable {
+  import java.util.concurrent.SynchronousQueue
+  import scala.compat.Platform.EOL
+
+  private val result = new SynchronousQueue[Option[String]]
+  @volatile private var running: Boolean = _
+  private var thread: Thread = _
+
+  /** Read one line of input which can be retrieved with `line`. */
+  def run(): Unit = {
+    var line = ""
+    try
+      do {
+        line = reader.readLine(prompt)
+        if (line != null) {
+          line = process(line.trim)
+        }
+      } while (line != null && line.isEmpty && running)
+    finally {
+      result.put(Option(line))
+    }
+  }
+
+  /** Check for `:paste` command. */
+  private def process(line: String): String = {
+    def isPrefix(s: String, p: String, n: Int) = (
+      //s != null && p.inits.takeWhile(_.length >= n).exists(s == _)
+      s != null && s.length >= n && s.length <= p.length && s == p.take(s.length)
+    )
+    if (isPrefix(line, ":paste", 3)) {
+      // while collecting lines, check running flag
+      var help = f"// Entering paste mode (ctrl-D to finish)%n%n"
+      def readWhile(cond: String => Boolean) = {
+        Iterator continually reader.readLine(help) takeWhile { x =>
+          help = ""
+          x != null && cond(x)
+        }
+      }
+      val text = (readWhile(_ => running) mkString EOL).trim
+      val next =
+        if (text.isEmpty) "// Nothing pasted, nothing gained."
+        else "// Exiting paste mode, now interpreting."
+      Console println f"%n${next}%n"
+      text
+    } else {
+      line
+    }
+  }
+
+  def start(): Unit = result.synchronized {
+    require(thread == null, "Already started")
+    thread = new Thread(this)
+    running = true
+    thread.start()
+  }
+
+  def stop(): Unit = result.synchronized {
+    running = false
+    if (thread != null) thread.interrupt()
+    thread = null
+  }
+
+  /** Block for the result line, or null on ctl-D. */
+  def line: String = result.take getOrElse null
+}
+object SplashLoop {
+  def apply(reader: SplashReader, prompt: String): SplashLoop = new SplashLoop(reader, prompt)
+}
+
+/** Reader during splash. Handles splash-completion with a stub, otherwise delegates. */
+class SplashReader(reader: InteractiveReader, postIniter: InteractiveReader => Unit) extends InteractiveReader {
+  /** Invoke the postInit action with the underlying reader. */
+  override def postInit(): Unit = postIniter(reader)
+
+  override val interactive: Boolean = reader.interactive
+
+  override def reset(): Unit = reader.reset()
+  override def history: History = reader.history
+  override val completion: Completion = NoCompletion
+  override def redrawLine(): Unit = reader.redrawLine()
+
+  override protected[interpreter] def readOneLine(prompt: String): String = ???   // unused
+  override protected[interpreter] def readOneKey(prompt: String): Int     = ???   // unused
+
+  override def readLine(prompt: String): String = reader.readLine(prompt)
+}
+object SplashReader {
+  def apply(reader: InteractiveReader)(postIniter: InteractiveReader => Unit) =
+    new SplashReader(reader, postIniter)
+}

--- a/test/files/run/repl-paste-parse.check
+++ b/test/files/run/repl-paste-parse.check
@@ -1,0 +1,6 @@
+Type in expressions for evaluation. Or try :help.
+
+scala> repl-paste-parse.script:1: error: illegal start of simple pattern
+val case = 9
+    ^
+:quit

--- a/test/files/run/repl-paste-parse.scala
+++ b/test/files/run/repl-paste-parse.scala
@@ -1,0 +1,27 @@
+
+import java.io.{ BufferedReader, StringReader, StringWriter, PrintWriter }
+
+import scala.tools.partest.DirectTest
+import scala.tools.nsc.interpreter.ILoop
+import scala.tools.nsc.GenericRunnerSettings
+
+object Test extends DirectTest {
+  override def extraSettings = s"-usejavacp -i $scriptPath"
+  def scriptPath = testPath.changeExtension("script")
+  override def newSettings(args: List[String]) = {
+    val ss = new GenericRunnerSettings(Console.println)
+    ss.processArguments(args, true)
+    ss
+  }
+  def code = ""
+  def show() = {
+    val r = new BufferedReader(new StringReader(""))
+    val w = new StringWriter
+    val p = new PrintWriter(w, true)
+    new ILoop(r, p).process(settings)
+    w.toString.lines foreach { s =>
+      if (!s.startsWith("Welcome to Scala")) println(s)
+    }
+  }
+}
+

--- a/test/files/run/repl-paste-parse.script
+++ b/test/files/run/repl-paste-parse.script
@@ -1,0 +1,1 @@
+val case = 9

--- a/test/files/run/t7805-repl-i.check
+++ b/test/files/run/t7805-repl-i.check
@@ -1,6 +1,3 @@
-Loading t7805-repl-i.script...
-import util._
-
 Welcome to Scala
 Type in expressions for evaluation. Or try :help.
 

--- a/test/files/run/t9170.scala
+++ b/test/files/run/t9170.scala
@@ -44,7 +44,7 @@ object Y {
 
 // Exiting paste mode, now interpreting.
 
-<console>:13: error: double definition:
+<pastie>:13: error: double definition:
 def f[A](a: => A): Int at line 12 and
 def f[A](a: => Either[Exception,A]): Int at line 13
 have same type after erasure: (a: Function0)Int


### PR DESCRIPTION
The compiler is created on main thread and user input is read
on an aux thread (opposite to currently).

Fixes completion when `-i` is supplied.

Adds an `-I` option to paste init files.

The temporary reader uses postInit to swap in the underlying
reader.

Completion is disabled for the temporary reader, rather than
blocking while it waits for a compiler. But manically hitting
tab is one way of knowing exactly when completion is live.
