### PR TITLE
Fix bold text in reflect API for 2.11.x

### DIFF
--- a/src/reflect/scala/reflect/api/Internals.scala
+++ b/src/reflect/scala/reflect/api/Internals.scala
@@ -939,7 +939,7 @@ trait Internals { self: Universe =>
 
   /** Marks underlying reference to id as boxed.
    *
-   *  <b>Precondition:<\b> id must refer to a captured variable
+   *  <b>Precondition:</b> id must refer to a captured variable
    *  A reference such marked will refer to the boxed entity, no dereferencing
    *  with `.elem` is done on it.
    *  This tree node can be emitted by macros such as reify that call referenceCapturedVariable.


### PR DESCRIPTION
Same as #4999 

Edit by Vlad: For the record, this patch addresses the [runaway bold affecting the `*Universe` scaladoc](http://www.scala-lang.org/api/2.11.7/scala-reflect/#scala.reflect.api.Universe) all the way [since 2.10.0](http://www.scala-lang.org/api/2.10.0/#scala.reflect.runtime.JavaUniverse):

![1](https://cloud.githubusercontent.com/assets/428706/13372518/b9157e52-dd46-11e5-9eea-592ee05c9717.png)

review: @VladUreche 
