### PR TITLE
SI-9546 Fix regression in rewrite of case apply to constructor call

### DIFF
--- a/test/files/run/t9546.scala
+++ b/test/files/run/t9546.scala
@@ -1,0 +1,13 @@
+package foo {
+  case class Opt[A] private[foo](val get: A) extends AnyVal
+  object Opt {
+    def mkOpt = Opt("")
+  }
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    foo.Opt.mkOpt
+  }
+}
+

--- a/test/files/run/t9546b.scala
+++ b/test/files/run/t9546b.scala
@@ -1,0 +1,13 @@
+package foo {
+  case class Opt[A](val get: A) extends AnyVal {
+  }
+  object Opt {
+    def mkOpt = Opt("")
+  }
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    foo.Opt.mkOpt
+  }
+}

--- a/test/files/run/t9546c.scala
+++ b/test/files/run/t9546c.scala
@@ -1,0 +1,13 @@
+package foo {
+  case class Opt[A] private[foo](val get: A)
+  object Opt {
+    def mkOpt = Opt("")
+  }
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    foo.Opt.mkOpt
+  }
+}
+

--- a/test/files/run/t9546d.scala
+++ b/test/files/run/t9546d.scala
@@ -1,0 +1,16 @@
+class X {
+  def test: Any = {
+    object Opt {
+      def mkOpt = Opt("")
+    }
+    case class Opt[A] private[X](val get: A)
+    Opt.mkOpt
+  }
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    new X().test
+  }
+}
+

--- a/test/files/run/t9546e.scala
+++ b/test/files/run/t9546e.scala
@@ -1,0 +1,15 @@
+case class A private (x: Int)
+case class B private (x: Int)(y: Int)
+
+class C {
+  def f = A(1)
+  def g = B(1)(2) // was: constructor B in class B cannot be accessed in class C
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    new C().f
+    new C().g
+  }
+
+}


### PR DESCRIPTION
In SI-9425, I disabled the rewrite of `CaseClass.apply(x)` to
`new CaseClass(x)` if the constructor was was less accessible
than the apply method. This solved a problem with spurious
"constructor cannot be accessed" errors during refchecks for
case classes with non-public constructors.

However, for polymorphic case classes, refchecks was persistent,
and even after refusing to transform the `TypeApply` within:

```
CaseClass.apply[String]("")
```

It _would_ try again to transform the enclosing `Select`, a
code path only intended for monomorphic case classes. The tree has
a `PolyType`, which foiled the newly added accessibility check.

I've modified the guard to specifically exclude `PolyType` typed
trees (which only reach that code after we decline to transform
an enclosing `TypeApply`). I've also rewritten the check to use
`finalResultType` rather than `resultType`, which would have also
avoided the problem.

```
scala> case class CaseClass[A](a: A)
defined class CaseClass

scala> typeOf[CaseClass.type].decl(TermName("apply")).info
res0: $r.intp.global.Type = [A](a: A)CaseClass[A]

scala> res0.resultType
res1: $r.intp.global.Type = (a: A)CaseClass[A]

scala> res0.resultType.typeSymbol
res2: $r.intp.global.Symbol = <none>

scala> res0.finalResultType
res3: $r.intp.global.Type = CaseClass[A]

scala> res0.finalResultType.typeSymbol
res4: $r.intp.global.Symbol = class CaseClass
```

I've manually checked that the rewrite is still applied for a
generic case class with a public constructor.

```
% ./build-sbt/pack/bin/scalac -Xprint:refchecks test/files/run/t9546.scala 2>&1 | grep "def mkOpt"
      def mkOpt: foo.Opt[String] = Opt.apply[String]("");
/code/scala2 on ticket/9546*
% ./build-sbt/pack/bin/scalac -Xprint:refchecks test/files/run/t9546b.scala 2>&1 | grep "def mkOpt"
      def mkOpt: foo.Opt[String] = new foo.Opt[String]("");
```

If the case class was not also a value class, the bug still existed,
but never manifest as a crash. In `run/t9546c.scala`, the following
nonsensical tree was created in refchecks, but the problem was washed
away during erasure.

```
def mkOpt = new foo.Opt[A][String]("");
```

If `Opt` is a value class, `posterasure` needs to inspect and transform
this tree, and the crash ensued.
