### PR TITLE
Fix diagrams for `Content Hierarchies` in scaladoc

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/diagrams.css
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/diagrams.css
@@ -33,6 +33,10 @@
   display: none;
 }
 
+.diagram-container > span.toggle {
+  z-index: 9;
+}
+
 .diagram {
   overflow: hidden;
   padding-top:15px;
@@ -73,7 +77,7 @@
   z-index: 2;
 }
 
-#inheritance-diagram-container.full-screen {
+.diagram-container.full-screen {
   position: fixed !important;
   margin: 0;
   border-radius: 0;
@@ -85,11 +89,11 @@
   z-index: 10000;
 }
 
-#inheritance-diagram-container.full-screen > span.toggle {
+.diagram-container.full-screen > span.toggle {
   display: none;
 }
 
-#inheritance-diagram-container.full-screen > div.diagram {
+.diagram-container.full-screen > div.diagram {
   position: absolute;
   top: 0; right: 0; bottom: 0; left: 0;
   margin: auto;

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/diagrams.js
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/diagrams.js
@@ -60,8 +60,8 @@ $(document).ready(function()
 	diagrams.initHighlighting();
 
     $("button#diagram-fs").click(function() {
-        $("#inheritance-diagram-container").toggleClass("full-screen");
-        $("#inheritance-diagram-container > div.diagram").css({
+        $(".diagram-container").toggleClass("full-screen");
+        $(".diagram-container > div.diagram").css({
             height: $("svg").height() + "pt"
         });
 
@@ -155,7 +155,7 @@ diagrams.initHighlighting = function()
  */
 diagrams.resize = function() {
     // available width
-    var availableWidth = $("body").width() - 100;
+    var availableWidth = $(".diagram-container").width();
 
     $(".diagram-container").each(function() {
         // unregister click event on whole div
@@ -163,7 +163,7 @@ diagrams.resize = function() {
         var diagramWidth = $(".diagram", this).data("width");
         var diagramHeight = $(".diagram", this).data("height");
 
-        if(diagramWidth > availableWidth) {
+        if (diagramWidth > availableWidth) {
             // resize diagram
             var height = diagramHeight / diagramWidth * availableWidth;
             $(".diagram svg", this).width(availableWidth);
@@ -204,7 +204,7 @@ diagrams.toggle = function(container, dontAnimate)
 
         $("#diagram-controls", container).show();
 
-        $("#inheritance-diagram-container").on('mousewheel.focal', function(e) {
+        $(".diagram-container").on('mousewheel.focal', function(e) {
             e.preventDefault();
             var delta = e.delta || e.originalEvent.wheelDelta;
             var zoomOut = delta ? delta < 0 : e.originalEvent.deltaY > 0;

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.js
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.js
@@ -4,10 +4,10 @@
 var $panzoom = undefined;
 $(document).ready(function() {
     // Add zoom functionality to type inheritance diagram
-    $panzoom = $("#inheritance-diagram").panzoom({
+    $panzoom = $(".diagram-container > .diagram").panzoom({
         increment: 0.1,
         minScale: 1,
-        maxScale: 3,
+        maxScale: 7,
         transition: true,
         duration: 200,
         contain: 'invert',


### PR DESCRIPTION
Selector (js) was broken and would only select "Inheritance Hierarchy", never content hierarchies. This has been remedied! No behaviour changed otherwise.

preview: https://dl.dropboxusercontent.com/u/358427/scaladoc-hierarchys/index.html
review: @VladUreche
