### PR TITLE
Remove deprecated Predef.error

### DIFF
--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -188,13 +188,7 @@ object Predef extends LowPriorityImplicits with DeprecatedPredef {
   /** @group utilities */
   @inline def locally[T](x: T): T  = x    // to communicate intent and avoid unmoored statements
 
-  // errors and asserts -------------------------------------------------
-
-  // !!! Remove this when possible - ideally for 2.11.
-  // We are stuck with it a while longer because sbt's compiler interface
-  // still calls it as of 0.12.2.
-  @deprecated("Use `sys.error(message)` instead", "2.9.0")
-  def error(message: String): Nothing = sys.error(message)
+  // assertions ---------------------------------------------------------
 
   /** Tests an expression, throwing an `AssertionError` if false.
    *  Calls to this method will not be generated if `-Xelide-below`

--- a/test/files/pos/t4365/a_1.scala
+++ b/test/files/pos/t4365/a_1.scala
@@ -9,7 +9,7 @@ trait SeqViewLike[+A,
   trait Transformed[+B] extends super[GenSeqViewLike].Transformed[B]
 
   abstract class AbstractTransformed[+B] extends Seq[B] with Transformed[B] {
-    def underlying: Coll = error("")
+    def underlying: Coll = sys.error("")
   }
 
   trait Reversed extends Transformed[A] with super[GenSeqViewLike].Reversed

--- a/test/files/pos/t4365/b_1.scala
+++ b/test/files/pos/t4365/b_1.scala
@@ -10,7 +10,7 @@ self =>
 
   trait Transformed[+B] {
     def length: Int = 0
-    def apply(idx: Int): B = error("")
+    def apply(idx: Int): B = sys.error("")
   }
 
   trait Reversed extends Transformed[A] {


### PR DESCRIPTION
This was deprecated in 2.9.0.

I posted a question about the impact of this on `sbt` here: https://groups.google.com/forum/#!topic/sbt-dev/BNA692wX7Sk. Probably worth checking that thread in a few days - no objections so far but that could be because the post just hasn't be viewed widely enough yet.
## TODO
- [x] Wait for #5009 to be merged
- [x] Wait for #5049 to be merged
