### PR TITLE
Update sbt version to most recent that includes the compiler interface

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -461,7 +461,7 @@ TODO:
     </fail>
 
     <!-- Allow this to be overridden simply -->
-    <property name="sbt.latest.version"    value="0.12.4"/>
+    <property name="sbt.latest.version"    value="0.13.9"/>
 
     <property name="sbt.src.dir"           value="${build-sbt.dir}/${sbt.latest.version}/src"/>
     <property name="sbt.lib.dir"           value="${build-sbt.dir}/${sbt.latest.version}/lib"/>


### PR DESCRIPTION
compiler-interface-src.jar was available for 0.13.9 but not 0.13.10 or 0.13.11
at the time this commit was tested.

This in preparation for removing Predef#error which was deprecated in 2.9.0.
