### PR TITLE
SI-9687 - Fix buggy deserialization of immutable.HashMap.HashMap1

### DIFF
--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -54,7 +54,7 @@ class HashMap[A, +B] extends AbstractMap[A, B]
     get0(key, computeHash(key), 0)
 
   override def updated [B1 >: B] (key: A, value: B1): HashMap[A, B1] =
-    updated0(key, computeHash(key), 0, value, null, null)
+    updated0(key, computeHash(key), 0, value, (key -> value), null)
 
   override def + [B1 >: B] (kv: (A, B1)): HashMap[A, B1] =
     updated0(kv._1, computeHash(kv._1), 0, kv._2, kv, null)

--- a/test/junit/scala/collection/immutable/HashMap1Test.scala
+++ b/test/junit/scala/collection/immutable/HashMap1Test.scala
@@ -1,0 +1,29 @@
+package scala.collection.immutable
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import java.io.{ByteArrayOutputStream, ObjectOutputStream, ByteArrayInputStream, ObjectInputStream}
+
+@RunWith(classOf[JUnit4])
+class HashMap1Test {
+
+  @Test
+  def deserializesCorrectly() {
+  	val kv = (1->1)
+    val map = new HashMap.HashMap1(kv._1,kv._1.hashCode,kv._2,kv)
+
+ 	val baos = new ByteArrayOutputStream()
+    val oos = new ObjectOutputStream(baos)
+    oos.writeObject(map)
+    oos.close()
+    
+    val bais = new ByteArrayInputStream(baos.toByteArray())
+    val ois = new ObjectInputStream(bais)
+    val deserializedMap = ois.readObject().asInstanceOf[HashMap$HashMap1]
+    ois.close()
+    
+    assertEquals(kv, deserializedMap.kv)
+  }
+}


### PR DESCRIPTION
When scala.collection.immutable.HashMap.HashMap1 got deserialized, its 'kv'
field was errorneously left as 'null', which caused NullPointerException
in calls to 'merged' function. This commit changes the deserialization to set
'kv' to its proper value.

PR also contains a regression test for this issue.
