### PR TITLE
Format collection conversions Scaladoc as code blocks instead of bullets

### DIFF
--- a/src/library/scala/collection/JavaConversions.scala
+++ b/src/library/scala/collection/JavaConversions.scala
@@ -16,12 +16,12 @@ import convert._
  *
  *    The following conversions are supported:
  *{{{
- *    scala.collection.Iterable <=> java.lang.Iterable
- *    scala.collection.Iterable <=> java.util.Collection
- *    scala.collection.Iterator <=> java.util.{ Iterator, Enumeration }
+ *    scala.collection.Iterable       <=> java.lang.Iterable
+ *    scala.collection.Iterable       <=> java.util.Collection
+ *    scala.collection.Iterator       <=> java.util.{ Iterator, Enumeration }
  *    scala.collection.mutable.Buffer <=> java.util.List
- *    scala.collection.mutable.Set <=> java.util.Set
- *    scala.collection.mutable.Map <=> java.util.{ Map, Dictionary }
+ *    scala.collection.mutable.Set    <=> java.util.Set
+ *    scala.collection.mutable.Map    <=> java.util.{ Map, Dictionary }
  *    scala.collection.concurrent.Map <=> java.util.concurrent.ConcurrentMap
  *}}}
  *    In all cases, converting from a source type to a target type and back

--- a/src/library/scala/collection/JavaConverters.scala
+++ b/src/library/scala/collection/JavaConverters.scala
@@ -19,14 +19,14 @@ import convert._
  *  Scala and Java collections using `asScala` and `asJava` methods.
  *
  *  The following conversions are supported via `asJava`, `asScala`
- *
- *  - `scala.collection.Iterable` <=> `java.lang.Iterable`
- *  - `scala.collection.Iterator` <=> `java.util.Iterator`
- *  - `scala.collection.mutable.Buffer` <=> `java.util.List`
- *  - `scala.collection.mutable.Set` <=> `java.util.Set`
- *  - `scala.collection.mutable.Map` <=> `java.util.Map`
- *  - `scala.collection.mutable.concurrent.Map` <=> `java.util.concurrent.ConcurrentMap`
- *
+ *{{{
+ *    scala.collection.Iterable               <=> java.lang.Iterable
+ *    scala.collection.Iterator               <=> java.util.Iterator
+ *    scala.collection.mutable.Buffer         <=> java.util.List
+ *    scala.collection.mutable.Set            <=> java.util.Set
+ *    scala.collection.mutable.Map            <=> java.util.Map
+ *    scala.collection.mutable.concurrent.Map <=> java.util.concurrent.ConcurrentMap
+ *}}}
  *  In all cases, converting from a source type to a target type and back
  *  again will return the original source object, e.g.
  *  {{{
@@ -40,22 +40,22 @@ import convert._
  *  The following conversions are also supported, but the
  *  direction from Scala to Java is done by the more specifically named methods:
  *  `asJavaCollection`, `asJavaEnumeration`, `asJavaDictionary`.
- *
- *  - `scala.collection.Iterable` <=> `java.util.Collection`
- *  - `scala.collection.Iterator` <=> `java.util.Enumeration`
- *  - `scala.collection.mutable.Map` <=> `java.util.Dictionary`
- *
+ *{{{
+ *    scala.collection.Iterable    <=> java.util.Collection
+ *    scala.collection.Iterator    <=> java.util.Enumeration
+ *    scala.collection.mutable.Map <=> java.util.Dictionary
+ *}}}
  *  In addition, the following one way conversions are provided via `asJava`:
- *
- *  - `scala.collection.Seq` => `java.util.List`
- *  - `scala.collection.mutable.Seq` => `java.util.List`
- *  - `scala.collection.Set` => `java.util.Set`
- *  - `scala.collection.Map` => `java.util.Map`
- *
+ *{{{
+ *    scala.collection.Seq         => java.util.List
+ *    scala.collection.mutable.Seq => java.util.List
+ *    scala.collection.Set         => java.util.Set
+ *    scala.collection.Map         => java.util.Map
+ *}}}
  *  The following one way conversion is provided via `asScala`:
- *
- *  - `java.util.Properties` => `scala.collection.mutable.Map`
- *
+ *{{{
+ *    java.util.Properties => scala.collection.mutable.Map
+ *}}}
  *  @since  2.8.1
  */
 object JavaConverters extends DecorateAsJava with DecorateAsScala

--- a/src/library/scala/collection/convert/DecorateAsJava.scala
+++ b/src/library/scala/collection/convert/DecorateAsJava.scala
@@ -20,14 +20,14 @@ import scala.language.implicitConversions
  *  Scala and Java collections using `asScala` and `asJava` methods.
  *
  *  The following conversions are supported via `asJava`, `asScala`
- *
- *  - `scala.collection.Iterable` <=> `java.lang.Iterable`
- *  - `scala.collection.Iterator` <=> `java.util.Iterator`
- *  - `scala.collection.mutable.Buffer` <=> `java.util.List`
- *  - `scala.collection.mutable.Set` <=> `java.util.Set`
- *  - `scala.collection.mutable.Map` <=> `java.util.Map`
- *  - `scala.collection.mutable.concurrent.Map` <=> `java.util.concurrent.ConcurrentMap`
- *
+ *{{{
+ *    scala.collection.Iterable               <=> java.lang.Iterable
+ *    scala.collection.Iterator               <=> java.util.Iterator
+ *    scala.collection.mutable.Buffer         <=> java.util.List
+ *    scala.collection.mutable.Set            <=> java.util.Set
+ *    scala.collection.mutable.Map            <=> java.util.Map
+ *    scala.collection.mutable.concurrent.Map <=> java.util.concurrent.ConcurrentMap
+ *}}}
  *  In all cases, converting from a source type to a target type and back
  *  again will return the original source object, e.g.
  *  {{{
@@ -41,22 +41,22 @@ import scala.language.implicitConversions
  *  The following conversions are also supported, but the
  *  direction from Scala to Java is done by the more specifically named methods:
  *  `asJavaCollection`, `asJavaEnumeration`, `asJavaDictionary`.
- *
- *  - `scala.collection.Iterable` <=> `java.util.Collection`
- *  - `scala.collection.Iterator` <=> `java.util.Enumeration`
- *  - `scala.collection.mutable.Map` <=> `java.util.Dictionary`
- *
+ *{{{
+ *    scala.collection.Iterable    <=> java.util.Collection
+ *    scala.collection.Iterator    <=> java.util.Enumeration
+ *    scala.collection.mutable.Map <=> java.util.Dictionary
+ *}}}
  *  In addition, the following one way conversions are provided via `asJava`:
- *
- *  - `scala.collection.Seq` => `java.util.List`
- *  - `scala.collection.mutable.Seq` => `java.util.List`
- *  - `scala.collection.Set` => `java.util.Set`
- *  - `scala.collection.Map` => `java.util.Map`
- *
+ *{{{
+ *    scala.collection.Seq         => java.util.List
+ *    scala.collection.mutable.Seq => java.util.List
+ *    scala.collection.Set         => java.util.Set
+ *    scala.collection.Map         => java.util.Map
+ *}}}
  *  The following one way conversion is provided via `asScala`:
- *
- *  - `java.util.Properties` => `scala.collection.mutable.Map`
- *
+ *{{{
+ *    java.util.Properties => scala.collection.mutable.Map
+ *}}}
  *  @since  2.8.1
  */
 trait DecorateAsJava {


### PR DESCRIPTION
- Makes the list of conversions easier to scan
- Makes main comment formatting internally consistent

This is how the documentations looks with this change,

![scaladoc-2 12-conversions-block-formatted](https://cloud.githubusercontent.com/assets/1123855/13556938/7ac0a26a-e3dd-11e5-8f8a-f048de13c173.png)

Before the change showing the use of bullets.

![scaladoc-2 12-conversions-list-formatted](https://cloud.githubusercontent.com/assets/1123855/13556970/62bf6ce0-e3de-11e5-8798-15fbb1762d33.png)

Ignore the package list discrepancy. I wasn't rebased when taking the first captures.
