### PR TITLE
Add fallback typefaces for monospaced sections in scaladoc

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -173,7 +173,7 @@ trait EntityPage extends HtmlPage {
     </div>
 
   val valueMembers =
-    tpl.methods ++ tpl.values ++ tpl.templates.filter(x => x.isObject || x.isPackage) sorted
+    tpl.methods ++ tpl.values ++ tpl.templates.filter(x => x.isObject) sorted
 
   val (absValueMembers, nonAbsValueMembers) =
     valueMembers partition (_.isAbstract)
@@ -232,6 +232,7 @@ trait EntityPage extends HtmlPage {
 
       { memberToCommentHtml(tpl, tpl.inTemplate, isSelf = true) }
 
+      { if (valueMembers.filterNot(_.kind == "package").isEmpty) NodeSeq.Empty else
       <div id="mbrsel">
         <div class='toggle'></div>
         <div id='memberfilter'>
@@ -241,25 +242,25 @@ trait EntityPage extends HtmlPage {
           </span>
           <i class="clear material-icons">&#xE14C;</i>
         </div>
-          <div id='filterby'>
-            <div id="order">
-              <span class="filtertype">Ordering</span>
-              <ol>
-                {
-                  if (!universe.settings.docGroups.value || (tpl.members.map(_.group).distinct.length == 1))
-                    NodeSeq.Empty
-                  else
-                    <li class="group out"><span>Grouped</span></li>
-                }
-                <li class="alpha in"><span>Alphabetic</span></li>
-                {
-                  if (tpl.linearizationTemplates.isEmpty && tpl.conversions.isEmpty)
-                    NodeSeq.Empty
-                  else
-                    <li class="inherit out"><span>By Inheritance</span></li>
-                }
-              </ol>
-            </div>
+        <div id='filterby'>
+          <div id="order">
+            <span class="filtertype">Ordering</span>
+            <ol>
+              {
+                if (!universe.settings.docGroups.value || (tpl.members.map(_.group).distinct.length == 1))
+                  NodeSeq.Empty
+                else
+                  <li class="group out"><span>Grouped</span></li>
+              }
+              <li class="alpha in"><span>Alphabetic</span></li>
+              {
+                if (tpl.linearizationTemplates.isEmpty && tpl.conversions.isEmpty)
+                  NodeSeq.Empty
+                else
+                  <li class="inherit out"><span>By Inheritance</span></li>
+              }
+            </ol>
+          </div>
           { if (tpl.linearizationTemplates.isEmpty && tpl.conversions.isEmpty) NodeSeq.Empty else
             {
               if (!tpl.linearizationTemplates.isEmpty)
@@ -303,6 +304,7 @@ trait EntityPage extends HtmlPage {
           }
         </div>
       </div>
+      }
 
       <div id="template">
         <div id="allMembers">
@@ -333,7 +335,6 @@ trait EntityPage extends HtmlPage {
               <ol>
                 {
                   concValueMembers
-                    .filter(_.kind != "package")
                     .map(memberToHtml(_, tpl))
                 }
               </ol>

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.css
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.css
@@ -412,7 +412,7 @@ div#content-container {
 div#content-container > div#content {
   -webkit-overflow-scrolling: touch;
   display: block;
-  overflow-y: auto;
+  overflow-y: hidden;
   max-width: 1140px;
   margin: 4em auto 0;
 }
@@ -488,7 +488,7 @@ div#packages > ul > li > a.abstract.type {
 div#packages > ul > li > a {
   text-decoration: none !important;
   margin-left: 1px;
-  font-family: "Source Code Pro";
+  font-family: "Source Code Pro", "Monaco", "Ubuntu Mono Regular", "Lucida Console", monospace;
   font-size: 0.9em;
 }
 
@@ -678,7 +678,7 @@ div#results-content > div#member-results > ul.entities > li > ul.members > li > 
 div#results-content > div#entity-results > ul.entities > li > ul.members > li > span.kind,
 div#results-content > div#entity-results > ul.entities > li > ul.members > li > span.tail {
   margin-right: 0.6em;
-  font-family: "Source Code Pro";
+  font-family: "Source Code Pro", "Monaco", "Ubuntu Mono Regular", "Lucida Console", monospace;
 }
 
 div#results-content > div#member-results > ul.entities > li > ul.members > li > span.kind {
@@ -688,7 +688,7 @@ div#results-content > div#member-results > ul.entities > li > ul.members > li > 
 div#results-content > div#member-results > ul.entities > li > ul.members > li > a.label,
 div#results-content > div#entity-results > ul.entities > li > ul.members > li > a.label {
   color: #2C3D9B;
-  font-family: "Source Code Pro";
+  font-family: "Source Code Pro", "Monaco", "Ubuntu Mono Regular", "Lucida Console", monospace;
 }
 
 /** Scrollpane settings needed for jquery.scrollpane.min.js */

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.css
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.css
@@ -40,7 +40,7 @@ body {
   text-align: center;
   color: #858484;
   bottom: 0;
-  height: 20px;
+  min-height: 20px;
   margin: 0 1em 0.5em;
 }
 
@@ -367,7 +367,7 @@ div.members > ol > li:last-child {
 }
 
 .signature {
-  font-family: "Source Code Pro";
+  font-family: "Source Code Pro", "Monaco", "Ubuntu Mono Regular", "Lucida Console", monospace;
   font-size: 0.8rem;
   line-height: 18px;
   clear: both;
@@ -375,7 +375,7 @@ div.members > ol > li:last-child {
 }
 
 .modifier_kind {
-  font-family: "Source Code Pro";
+  font-family: "Source Code Pro", "Monaco", "Ubuntu Mono Regular", "Lucida Console", monospace;
   font-size: 0.8rem;
   padding-right: 0.5em;
   text-align: right;
@@ -385,7 +385,7 @@ div.members > ol > li:last-child {
 }
 
 .symbol {
-  font-family: "Source Code Pro";
+  font-family: "Source Code Pro", "Monaco", "Ubuntu Mono Regular", "Lucida Console", monospace;
 }
 
 a > .symbol > .name {
@@ -511,7 +511,7 @@ div#definition > h4#signature > span.modifier_kind > i.unfold-arrow,
 
 #definition .morelinks {
   text-align: right;
-  font-family: 'Source Sans Pro', 'Helvetica Neue', Arial, sans-serif;
+  font-family: "Source Code Pro", "Monaco", "Ubuntu Mono Regular", "Lucida Console", monospace;
 }
 
 #definition .morelinks a {
@@ -593,7 +593,7 @@ div#definition > h4#signature > span.modifier_kind > i.unfold-arrow,
   background-color: #fff;
   margin: 5px 0;
   display: block;
-  font-family: "Source Code Pro";
+  font-family: "Source Code Pro", "Monaco", "Ubuntu Mono Regular", "Lucida Console", monospace;
   border-radius: 0.2em;
   overflow-x: auto;
 }


### PR DESCRIPTION
The PR adds fallback typefaces to all monospaced areas. This should ensure that users with some versions of firefox get a good looking monospaced typeface despite firefox's local filesystem security rules.

This commit will also fix the `Filter All Members` input appearing if
there are no members - please see root for an example.

There's also a small CSS fix that addresses a vertical scrollbar on
smaller viewports (footer was not responsively resized).

preview: https://dl.dropboxusercontent.com/u/358427/scaladoc-monosp/index.html
review: @VladUreche 
