### PR TITLE
SI-9688 Make merge in immutable HashMap1 work with null kv.

### DIFF
--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -197,7 +197,7 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
           if (this.value.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef]) this
           else new HashMap1(key, hash, value, kv)
         } else {
-          val nkv = merger(this.ensurePair, if(kv != null) kv else (key->value))
+          val nkv = merger(this.ensurePair, if(kv != null) kv else (key, value))
           new HashMap1(nkv._1, hash, nkv._2, nkv)
         }
       } else {

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -197,7 +197,7 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
           if (this.value.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef]) this
           else new HashMap1(key, hash, value, kv)
         } else {
-          val nkv = merger(this.kv, kv)
+          val nkv = merger(this.ensurePair, if(kv != null) kv else (key->value))
           new HashMap1(nkv._1, hash, nkv._2, nkv)
         }
       } else {

--- a/test/junit/scala/collection/immutable/HashMapTest.scala
+++ b/test/junit/scala/collection/immutable/HashMapTest.scala
@@ -1,0 +1,48 @@
+package scala.collection.immutable
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class HashMapTest {
+
+  private val computeHashF = {
+    HashMap.empty.computeHash _
+  }
+
+  @Test
+  def canMergeIdenticalHashMap1sWithNullKvs() {
+    def m = new HashMap.HashMap1(1, computeHashF(1), 1, null)
+    val merged = m.merged(m)(null)
+    assertEquals(m, merged)
+  }
+
+  @Test
+  def canMergeIdenticalHashMap1sWithNullKvsCustomMerge() {
+    def m = new HashMap.HashMap1(1, computeHashF(1), 1, null)
+    val merged = m.merged(m) {
+      case ((k1, v1), (k2, v2)) =>
+        (k1, v1 + v2)
+    }
+    assertEquals(new HashMap.HashMap1(1, computeHashF(1), 2, null), merged)
+  }
+
+  @Test
+  def canMergeHashMap1sWithNullKvsHashCollision() {
+    val key1 = 1000L * 1000 * 1000 * 10
+    val key2 = key1.##.toLong
+    assert(key1.## == key2.##)
+
+    val m1 = new HashMap.HashMap1(key1, computeHashF(key1.##), 1, null)
+    val m2 = new HashMap.HashMap1(key2, computeHashF(key2.##), 1, null)
+    val expected = HashMap(key1 -> 1, key2 -> 1)
+    val merged = m1.merged(m2)(null)
+    assertEquals(expected, merged)
+    val mergedWithMergeFunction = m1.merged(m2) { (kv1, kv2) =>
+      throw new RuntimeException("Should not be reached.")
+    }
+    assertEquals(expected, mergedWithMergeFunction)
+  }
+}


### PR DESCRIPTION
The kv field of scala.collection.immutable.HashMap.HashMap1 can be null. This
commit corrects the behavior of updated0 (which is on call path for merged) to
work in such cases, instead of throwing NPE.

Commit contains regression test.
