### PR TITLE
[WIP] add exception filtering capability to scala.util.Try

### DIFF
--- a/src/library/scala/util/Try.scala
+++ b/src/library/scala/util/Try.scala
@@ -202,13 +202,40 @@ sealed abstract class Try[+T] extends Product with Serializable {
 }
 
 object Try {
+  type ExceptionFilter = PartialFunction[Throwable, Boolean]
+
+  val includeNonFatal: ExceptionFilter = { case NonFatal(_) => true }
+  val defaultFilter = includeNonFatal
+
+
   /** Constructs a `Try` using the by-name parameter.  This
    * method will ensure any non-fatal exception is caught and a
    * `Failure` object is returned.
    */
-  def apply[T](r: => T): Try[T] =
+  def apply[T](r: => T): Try[T] = apply(defaultFilter)(r)
+
+  /** Constructs a `Try` using the by-name parameter with a customised ExceptionFilter.
+   * This method will ensure any filtered exception is caught and a
+   * `Failure` object is returned. The filter parameter can be used to
+   * specify which exceptions should be caught and returned as a `Failure` object
+   * and which should be bubbled up.
+   * Filters are composable:
+   * @example {{{
+   * class MyException extends RuntimeError
+   * val includeNonFatal: ExceptionFilter = { case NonFatal(_) => true }
+   * vak excludeMyException: ExceptionFilter = { case _: MyException => false }
+   * val includeUnsatisfiedLinkError: ExceptionFilter = { case _: UnsatisfiedLinkError => true }
+   *
+   * Try(excludeMyException orElse includeNonFatal orElse includeUnsatisfiedLinkError) { ... }
+   * }}}
+   *
+   * This will catch any NonFatalExceptions, EXCEPT MyException, and also catch UnsatisfiedLinkErrors.
+   * Please note that the ordering of the composition is important when mixing exclusion and inclusion filters.
+   * Usually best practice is to provide exclusions first and inclusions last.
+   */
+  def apply[T](filter: ExceptionFilter)(r: => T): Try[T] =
     try Success(r) catch {
-      case NonFatal(e) => Failure(e)
+      case ex if filter(ex) => Failure(ex)
     }
 }
 

--- a/src/library/scala/util/Try.scala
+++ b/src/library/scala/util/Try.scala
@@ -212,7 +212,7 @@ object Try {
    * method will ensure any non-fatal exception is caught and a
    * `Failure` object is returned.
    */
-  def apply[T](r: => T): Try[T] = apply(defaultFilter)(r)
+  def apply[T](r: => T): Try[T] = withFilter(defaultFilter)(r)
 
   /** Constructs a `Try` using the by-name parameter with a customised ExceptionFilter.
    * This method will ensure any filtered exception is caught and a
@@ -233,7 +233,7 @@ object Try {
    * Please note that the ordering of the composition is important when mixing exclusion and inclusion filters.
    * Usually best practice is to provide exclusions first and inclusions last.
    */
-  def apply[T](filter: ExceptionFilter)(r: => T): Try[T] =
+  def withFilter[T](filter: ExceptionFilter)(r: => T): Try[T] =
     try Success(r) catch {
       case ex if filter(ex) => Failure(ex)
     }

--- a/test/files/jvm/future-spec/TryTests.scala
+++ b/test/files/jvm/future-spec/TryTests.scala
@@ -6,45 +6,67 @@
 import scala.util.{Try,Success,Failure}
 
 class TryTests extends MinimalScalaTest {
-  class MyException extends Exception
-  val e = new Exception("this is an exception")
+  class MyException extends Exception("this is an exception")
+  class MyError extends Error("this is a fatal error")
+
+  val ex = new MyException
+  val er = new MyError
 
   "Try()" should {
     "catch exceptions and lift into the Try type" in {
       Try[Int](1) mustEqual Success(1)
-      Try[Int] { throw e } mustEqual Failure(e)
+      Try[Int] { throw ex } mustEqual Failure(ex)
+    }
+
+    "not catch errors with the default filter" in {
+      intercept[Error] {
+        Try[Int] { throw er }
+      }
+    }
+
+    "catch errors if the filter includes them" in {
+      val catchMyError: Try.ExceptionFilter = { case _: MyError => true }
+
+      Try[Int] { throw er}(Try.catchNonFatal) mustEqual Failure(er)
+    }
+
+    "not catch errors if the filter excludes them" in {
+      val dontCatchMyException: Try.ExceptionFilter = { case _: MyException => false }
+
+      intercept[MyException] {
+        Try[Int] { throw new MyException }(dontCatchMyException orElse Try.defaultFilter)
+      }
     }
   }
 
   "Try" should {
     "recoverWith" in {
-      val myException = new MyException
       Success(1) recoverWith { case _ => Success(2) } mustEqual Success(1)
-      Failure(e) recoverWith { case _ => Success(2) } mustEqual Success(2)
-      Failure(e) recoverWith { case _ => Failure(e) } mustEqual Failure(e)
+      Failure(ex) recoverWith { case _ => Success(2) } mustEqual Success(2)
+      Failure(ex) recoverWith { case _ => Failure(ex) } mustEqual Failure(ex)
     }
 
     "getOrElse" in {
       Success(1) getOrElse 2 mustEqual 1
-      Failure(e) getOrElse 2 mustEqual 2
+      Failure(ex) getOrElse 2 mustEqual 2
     }
 
     "orElse" in {
       Success(1) orElse Success(2) mustEqual Success(1)
-      Failure(e) orElse Success(2) mustEqual Success(2)
+      Failure(ex) orElse Success(2) mustEqual Success(2)
     }
 
     "map" in {
       "when there is no exception" in {
         Success(1) map(1+) mustEqual Success(2)
-        Failure[Int](e) map(1+) mustEqual Failure(e)
+        Failure[Int](ex) map(1+) mustEqual Failure(ex)
       }
 
       "when there is an exception" in {
-        Success(1) map(_ => throw e) mustEqual Failure(e)
+        Success(1) map(_ => throw ex) mustEqual Failure(ex)
 
         val e2 = new Exception
-        Failure[Int](e) map(_ => throw e2) mustEqual Failure(e)
+        Failure[Int](ex) map(_ => throw e2) mustEqual Failure(ex)
       }
       "when there is a fatal exception" in {
         val e3 = new ThreadDeath
@@ -57,14 +79,14 @@ class TryTests extends MinimalScalaTest {
     "flatMap" in {
       "when there is no exception" in {
         Success(1) flatMap(x => Success(1 + x)) mustEqual Success(2)
-        Failure[Int](e) flatMap(x => Success(1 + x)) mustEqual Failure(e)
+        Failure[Int](ex) flatMap(x => Success(1 + x)) mustEqual Failure(ex)
       }
 
       "when there is an exception" in {
-        Success(1).flatMap[Int](_ => throw e) mustEqual Failure(e)
+        Success(1).flatMap[Int](_ => throw ex) mustEqual Failure(ex)
 
         val e2 = new Exception
-        Failure[Int](e).flatMap[Int](_ => throw e2) mustEqual Failure(e)
+        Failure[Int](ex).flatMap[Int](_ => throw e2) mustEqual Failure(ex)
       }
       "when there is a fatal exception" in {
         val e3 = new ThreadDeath
@@ -102,27 +124,27 @@ class TryTests extends MinimalScalaTest {
       "with Failure values" in {
         "throws before" in {
           val result = for {
-            i <- Failure[Int](e)
+            i <- Failure[Int](ex)
             j <- Success(1)
           } yield (i + j)
-          result mustEqual Failure(e)
+          result mustEqual Failure(ex)
         }
 
         "throws after" in {
           val result = for {
             i <- Success(1)
-            j <- Failure[Int](e)
+            j <- Failure[Int](ex)
           } yield (i + j)
-          result mustEqual Failure(e)
+          result mustEqual Failure(ex)
         }
 
         "returns the FIRST Failure" in {
           val e2 = new Exception
           val result = for {
-            i <- Failure[Int](e)
+            i <- Failure[Int](ex)
             j <- Failure[Int](e2)
           } yield (i + j)
-          result mustEqual Failure(e)
+          result mustEqual Failure(ex)
         }
       }
     }

--- a/test/files/jvm/future-spec/TryTests.scala
+++ b/test/files/jvm/future-spec/TryTests.scala
@@ -25,16 +25,16 @@ class TryTests extends MinimalScalaTest {
     }
 
     "catch errors if the filter includes them" in {
-      val catchMyError: Try.ExceptionFilter = { case _: MyError => true }
+      val includeMyError: Try.ExceptionFilter = { case _: MyError => true }
 
-      Try[Int] { throw er}(Try.catchNonFatal) mustEqual Failure(er)
+      Try.withFilter(includeMyError) { throw er } mustEqual Failure(er)
     }
 
-    "not catch errors if the filter excludes them" in {
-      val dontCatchMyException: Try.ExceptionFilter = { case _: MyException => false }
+    "not catch exceptions if the filter excludes them" in {
+      val excludeMyException: Try.ExceptionFilter = { case _: MyException => false }
 
       intercept[MyException] {
-        Try[Int] { throw new MyException }(dontCatchMyException orElse Try.defaultFilter)
+        Try.withFilter[Int](excludeMyException orElse Try.defaultFilter) { throw new MyException }
       }
     }
   }


### PR DESCRIPTION
This PR adds the ability to specify which throwables should or should not be catched and turned into a Failure. This enables us to catch Errors (which have been statically considered fatal previously, and always bubbled up), and handle them in the same monadic way as we could handle NonFatal exceptions previously.

Please review the PR, keepeng an eye out for performance considerations.
