### PR TITLE
bump versions after 2.11.8 release

### DIFF
--- a/build.number
+++ b/build.number
@@ -4,7 +4,7 @@
 
 version.major=2
 version.minor=11
-version.patch=8
+version.patch=9
 
 # This is the -N part of a version (2.9.1-1). If it's 0, it's dropped from maven versions. It should not be used again.
 version.bnum=0

--- a/build.sbt
+++ b/build.sbt
@@ -113,7 +113,7 @@ lazy val publishSettings : Seq[Setting[_]] = Seq(
 // VersionUtil.versionPropertiesImpl for details. The standard sbt `version` setting should not be set directly. It
 // is the same as the Maven version and derived automatically from `baseVersion` and `baseVersionSuffix`.
 globalVersionSettings
-baseVersion in Global := "2.11.8"
+baseVersion in Global := "2.11.9"
 baseVersionSuffix in Global := "SNAPSHOT"
 
 lazy val commonSettings = clearSourceAndResourceDirectories ++ publishSettings ++ Seq[Setting[_]](

--- a/scripts/jobs/integrate/windows
+++ b/scripts/jobs/integrate/windows
@@ -9,7 +9,7 @@ export ANT_OPTS="-Dfile.encoding=UTF-8 -server -XX:+AggressiveOpts -XX:+UseParNe
 PATH=/cygdrive/c/apache-ant-1.9.6/bin:$PATH
 
 ant \
-  -Dstarr.version=2.11.7 \
+  -Dstarr.version=2.11.8 \
   -Dscalac.args.optimise=-optimise \
   -Dlocker.skip=1 \
   test

--- a/versions.properties
+++ b/versions.properties
@@ -8,7 +8,7 @@
 # The scala version used for bootstrapping. This has no impact on the final classfiles:
 # there are two stages (locker and quick), so compiler and library are always built
 # with themselves. Stability is ensured by building a third stage (strap).
-starr.version=2.11.7
+starr.version=2.11.8
 
 # These are the versions of the modules that go with this release.
 # These properties are used during PR validation and in dbuild builds.
@@ -22,7 +22,7 @@ starr.version=2.11.7
 scala.binary.version=2.11
 # e.g. 2.11.0-RC1, 2.11.0, 2.11.1-RC1, 2.11.1
 # this defines the dependency on scala-continuations-plugin in scala-dist's pom
-scala.full.version=2.11.7
+scala.full.version=2.11.8
 
 # external modules shipped with distribution, as specified by scala-library-all's pom
 scala-xml.version.number=1.0.4


### PR DESCRIPTION
based on earlier example of fbc49a655ba672d453e2b60ce13f133921488448

review by @adriaanm
