### PR TITLE
Scaladoc: change behavior of clear-button on input fields

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.js
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.js
@@ -33,14 +33,11 @@ $(document).ready(function() {
 
     configureTextFilter();
 
-    $("#index-input").on("focus", function(e) {
-        $("#textfilter > .input > .clear").show();
-    });
-
-    $("#index-input").on("blur", function() {
-        setTimeout(function() {
+    $("#index-input").on("input", function(e) {
+        if($(this).val().length > 0)
+            $("#textfilter > .input > .clear").show();
+        else
             $("#textfilter > .input > .clear").hide();
-        }, 10);
     });
 });
 
@@ -229,6 +226,8 @@ function configureTextFilter() {
             $("div#search-results").hide();
             $("#search > span.close-results").hide();
             $("#search > span#doc-title").show();
+
+            $(this).hide();
         });
     });
 

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.js
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.js
@@ -147,10 +147,10 @@ $(document).ready(function() {
     });
     $("#memberfilter > .clear").click(function() {
         $("#memberfilter input").attr("value", "");
+        $(this).hide();
         filter();
     });
     $(document).keydown(function(event) {
-
         if (event.keyCode == 9) { // tab
             $("#index-input", window.parent.document).focus();
             input.attr("value", "");
@@ -162,8 +162,7 @@ $(document).ready(function() {
         if ($(this).hasClass("in")) {
             $(this).removeClass("in");
             $(this).addClass("out");
-        }
-        else if ($(this).hasClass("out")) {
+        } else if ($(this).hasClass("out")) {
             $(this).removeClass("out");
             $(this).addClass("in");
         }
@@ -174,8 +173,7 @@ $(document).ready(function() {
         if ($(this).hasClass("in")) {
             $(this).removeClass("in");
             $(this).addClass("out");
-        }
-        else if ($(this).hasClass("out")) {
+        } else if ($(this).hasClass("out")) {
             $(this).removeClass("out");
             $(this).addClass("in");
         }
@@ -307,14 +305,11 @@ $(document).ready(function() {
             exposeMember(jqElem);
     }
 
-    $("#mbrsel-input").on("focus", function() {
-        $("#memberfilter > .clear").show();
-    });
-
-    $("#mbrsel-input").on("blur", function() {
-        setTimeout(function() {
+    $("#mbrsel-input").on("input", function() {
+        if ($(this).val().length > 0)
+            $("#memberfilter > .clear").show();
+        else
             $("#memberfilter > .clear").hide();
-        }, 10);
     });
 });
 


### PR DESCRIPTION
This commit changes the behavior to only remove the "x" if there is no
input in the input field. The old behavior was to bind the blur event to
be fired later - but this had the drawback of not working properly on
fast hardware as the timeout would actually beat the click event.

preview: https://dl.dropboxusercontent.com/u/358427/scaladoc-x-button/scala/Boolean.html
review: @VladUreche 
