### PR TITLE
Fix scaladoc scroll and auto-expand on permalinks

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/scheduler.js
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/scheduler.js
@@ -5,7 +5,7 @@ function Scheduler() {
     var scheduler = this;
     var resolution = 0;
     this.timeout = undefined;
-    this.queues = new Array(0); // an array of work pacakges indexed by index in the labels table.
+    this.queues = new Array(0); // an array of work packages indexed by index in the labels table.
     this.labels = new Array(0); // an indexed array of labels indexed by priority. This should be short.
 
     this.label = function(name, priority) {


### PR DESCRIPTION
Small chances that fix [anchor links scroll](https://github.com/scala/scala/pull/5018#issuecomment-195020665) and auto-expand member description if an anchor link is used.

Suggested review by @VladUreche, @heathermiller
