### PR TITLE
Improve documentation of `GenSeqLike#length`

### DIFF
--- a/src/library/scala/collection/GenSeqLike.scala
+++ b/src/library/scala/collection/GenSeqLike.scala
@@ -58,6 +58,7 @@ trait GenSeqLike[+A, +Repr] extends Any with GenIterableLike[A, Repr] with Equal
    *  Note: `xs.length` and `xs.size` yield the same result.
    *
    *  @return     the number of elements in this $coll.
+   *  @throws     IllegalArgumentException if the length of the sequence cannot be represented in an `Int`, for example, `(-1 to Int.MaxValue).length`.
    */
   def length: Int
 


### PR DESCRIPTION
- [Range#length](https://github.com/scala/scala/blob/2.12.x/src/library/scala/collection/immutable/Range.scala#L140) throws Exception in the case when [Range#longLength](https://github.com/scala/scala/blob/2.12.x/src/library/scala/collection/immutable/Range.scala#L72) returns a Long greater than `Int.MaxValue`
