### PR TITLE
SI-9314 Marginal edge case to warn-missing-interp

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5206,7 +5206,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           case MethodType(p :: _, _)   => p.isImplicit            // implicit method requires no args
           case _                       => true                    // catches all others including NullaryMethodType
         }
-        def isPlausible(m: Symbol) = m.alternatives exists (m => requiresNoArgs(m.info))
+        def isPlausible(m: Symbol) = !m.isPackage && m.alternatives.exists(x => requiresNoArgs(x.info))
 
         def maybeWarn(s: String): Unit = {
           def warn(message: String)         = context.warning(lit.pos, s"possible missing interpolator: $message")

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -105,7 +105,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
   // that are turned private by typedBlock
   private final val SYNTHETIC_PRIVATE = TRANS_FLAG
 
-  private final val InterpolatorCodeRegex  = """\$\{.*?\}""".r
+  private final val InterpolatorCodeRegex  = """\$\{(.*?)\}""".r
   private final val InterpolatorIdentRegex = """\$[$\w]+""".r // note that \w doesn't include $
 
   abstract class Typer(context0: Context) extends TyperDiagnostics with Adaptation with Tag with PatternTyper with TyperContextErrors {
@@ -5211,11 +5211,13 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         def maybeWarn(s: String): Unit = {
           def warn(message: String)         = context.warning(lit.pos, s"possible missing interpolator: $message")
           def suspiciousSym(name: TermName) = context.lookupSymbol(name, _ => true).symbol
-          def suspiciousExpr                = InterpolatorCodeRegex findFirstIn s
+          val suspiciousExpr                = InterpolatorCodeRegex findFirstMatchIn s
           def suspiciousIdents              = InterpolatorIdentRegex findAllIn s map (s => suspiciousSym(TermName(s drop 1)))
 
           if (suspiciousExpr.nonEmpty)
-            warn("detected an interpolated expression") // "${...}"
+            suspiciousExpr filter (!_.group(1).trim.isEmpty) foreach (_ =>
+              warn("detected an interpolated expression") // "${...}"
+            )
           else
             suspiciousIdents find isPlausible foreach (sym => warn(s"detected interpolated identifier `$$${sym.name}`")) // "$id"
         }

--- a/test/files/neg/t7848-interp-warn.check
+++ b/test/files/neg/t7848-interp-warn.check
@@ -1,8 +1,8 @@
 t7848-interp-warn.scala:18: warning: possible missing interpolator: detected interpolated identifier `$foo`
-    "An important $foo message!"
+    "An important $foo message!"                              // warn on ident in scope
     ^
 t7848-interp-warn.scala:22: warning: possible missing interpolator: detected an interpolated expression
-    "A doubly important ${foo * 2} message!"
+    "A doubly important ${foo * 2} message!"                  // warn on some expr, see below
     ^
 t7848-interp-warn.scala:25: warning: possible missing interpolator: detected interpolated identifier `$bar`
   def i = s"Try using '${ "$bar" }' instead."                 // was: no warn on space test
@@ -10,6 +10,18 @@ t7848-interp-warn.scala:25: warning: possible missing interpolator: detected int
 t7848-interp-warn.scala:26: warning: possible missing interpolator: detected interpolated identifier `$bar`
   def j = s"Try using '${ "something like $bar" }' instead."  // warn
                           ^
+t7848-interp-warn.scala:32: warning: possible missing interpolator: detected an interpolated expression
+  def v = "${baz}${bar}"                                      // warn on second expr
+          ^
+t7848-interp-warn.scala:33: warning: possible missing interpolator: detected an interpolated expression
+  def w = "${ op_* }"                                         // warn, only cheap ident parsing
+          ^
+t7848-interp-warn.scala:34: warning: possible missing interpolator: detected an interpolated expression
+  def x = "${ bar }"                                          // warn, a cheap ident in scope
+          ^
+t7848-interp-warn.scala:36: warning: possible missing interpolator: detected an interpolated expression
+  def z = "${ baz * 3}"                                       // warn, no expr parsing
+          ^
 error: No warnings can be incurred under -Xfatal-warnings.
-four warnings found
+8 warnings found
 one error found

--- a/test/files/neg/t7848-interp-warn.check
+++ b/test/files/neg/t7848-interp-warn.check
@@ -1,13 +1,13 @@
-t7848-interp-warn.scala:8: warning: possible missing interpolator: detected interpolated identifier `$foo`
+t7848-interp-warn.scala:18: warning: possible missing interpolator: detected interpolated identifier `$foo`
     "An important $foo message!"
     ^
-t7848-interp-warn.scala:12: warning: possible missing interpolator: detected an interpolated expression
+t7848-interp-warn.scala:22: warning: possible missing interpolator: detected an interpolated expression
     "A doubly important ${foo * 2} message!"
     ^
-t7848-interp-warn.scala:15: warning: possible missing interpolator: detected interpolated identifier `$bar`
-  def i = s"Try using '${ "$bar" }' instead."  // was: no warn on space test
+t7848-interp-warn.scala:25: warning: possible missing interpolator: detected interpolated identifier `$bar`
+  def i = s"Try using '${ "$bar" }' instead."                 // was: no warn on space test
                           ^
-t7848-interp-warn.scala:16: warning: possible missing interpolator: detected interpolated identifier `$bar`
+t7848-interp-warn.scala:26: warning: possible missing interpolator: detected interpolated identifier `$bar`
   def j = s"Try using '${ "something like $bar" }' instead."  // warn
                           ^
 error: No warnings can be incurred under -Xfatal-warnings.

--- a/test/files/neg/t7848-interp-warn.scala
+++ b/test/files/neg/t7848-interp-warn.scala
@@ -1,7 +1,17 @@
 
 package test
 
+package pancake { }
+
 object Test {
+  type NonVal = Int
+
+  def ok = "Don't warn on $nosymbol interpolated."
+
+  def pass = "Don't warn on $pancake package names."
+
+  def types = "Or $NonVal type symbols either."
+
   def bar = "bar"
   def f = {
     val foo = "bar"
@@ -11,8 +21,8 @@ object Test {
     val foo = "bar"
     "A doubly important ${foo * 2} message!"
   }
-  def h = s"Try using '$$bar' instead."  // no warn
-  def i = s"Try using '${ "$bar" }' instead."  // was: no warn on space test
+  def h = s"Try using '$$bar' instead."                       // no warn
+  def i = s"Try using '${ "$bar" }' instead."                 // was: no warn on space test
   def j = s"Try using '${ "something like $bar" }' instead."  // warn
-  def k = f"Try using '$bar' instead."  // no warn on other std interps
+  def k = f"Try using '$bar' instead."                        // no warn on other std interps
 }

--- a/test/files/neg/t7848-interp-warn.scala
+++ b/test/files/neg/t7848-interp-warn.scala
@@ -15,16 +15,23 @@ object Test {
   def bar = "bar"
   def f = {
     val foo = "bar"
-    "An important $foo message!"
+    "An important $foo message!"                              // warn on ident in scope
   }
   def g = {
     val foo = "bar"
-    "A doubly important ${foo * 2} message!"
+    "A doubly important ${foo * 2} message!"                  // warn on some expr, see below
   }
   def h = s"Try using '$$bar' instead."                       // no warn
   def i = s"Try using '${ "$bar" }' instead."                 // was: no warn on space test
   def j = s"Try using '${ "something like $bar" }' instead."  // warn
   def k = f"Try using '$bar' instead."                        // no warn on other std interps
   def p = "Template ${} {}"                                   // no warn on unlikely or empty expressions
-  def q = "${}$bar"                                           // disables subsequent checks!
+  def q = "${}$bar"                                           // disables subsequent checks! (a feature)
+  def r = "${}${bar}"                                         // disables subsequent checks! (a feature)
+
+  def v = "${baz}${bar}"                                      // warn on second expr
+  def w = "${ op_* }"                                         // warn, only cheap ident parsing
+  def x = "${ bar }"                                          // warn, a cheap ident in scope
+  def y = "${ baz }"                                          // no warn, cheap ident not in scope
+  def z = "${ baz * 3}"                                       // warn, no expr parsing
 }

--- a/test/files/neg/t7848-interp-warn.scala
+++ b/test/files/neg/t7848-interp-warn.scala
@@ -25,4 +25,6 @@ object Test {
   def i = s"Try using '${ "$bar" }' instead."                 // was: no warn on space test
   def j = s"Try using '${ "something like $bar" }' instead."  // warn
   def k = f"Try using '$bar' instead."                        // no warn on other std interps
+  def p = "Template ${} {}"                                   // no warn on unlikely or empty expressions
+  def q = "${}$bar"                                           // disables subsequent checks!
 }


### PR DESCRIPTION
Don't warn on `"$package_name"` or `"${}"`.  Detecting empty expression also nullifies the test. As in "jury nullification."
