### PR TITLE
SI-9488 - adds the same default toString format to Scala Futures as 2…

### DIFF
--- a/bincompat-backward.whitelist.conf
+++ b/bincompat-backward.whitelist.conf
@@ -217,6 +217,12 @@ filter {
     {
         matchName="scala.concurrent.impl.Promise$DefaultPromise"
         problemName=MissingTypesProblem
+    },
+    // SI-9488: Due to SI-8362 above, toString was silently changed to the AtomicReference toString implementation,
+    // This is fixed by SI-9488, and this should be safe since the class in question is stdlib internal.
+    {
+        matchName="scala.concurrent.impl.Promise.toString"
+        problemName=MissingMethodProblem
     }
   ]
 }

--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -381,6 +381,12 @@ filter {
     {
         matchName="scala.concurrent.impl.Promise$DefaultPromise"
         problemName=MissingTypesProblem
+    },
+    // SI-9488: Due to SI-8362 above, toString was silently changed to the AtomicReference toString implementation,
+    // This is fixed by SI-9488, and this should be safe since the class in question is stdlib internal.
+    {
+        matchName="scala.concurrent.impl.Promise.toString"
+        problemName=MissingMethodProblem
     }
   ]
 }

--- a/src/library/scala/concurrent/impl/Promise.scala
+++ b/src/library/scala/concurrent/impl/Promise.scala
@@ -19,6 +19,10 @@ import java.util.concurrent.locks.AbstractQueuedSynchronizer
 
 private[concurrent] trait Promise[T] extends scala.concurrent.Promise[T] with scala.concurrent.Future[T] {
   def future: this.type = this
+  override def toString: String = value match {
+    case Some(result) => "Future("+result+")"
+    case None => "Future(<not completed>)"
+  }
 }
 
 /* Precondition: `executor` is prepared, i.e., `executor` has been returned from invocation of `prepare` on some other `ExecutionContext`.


### PR DESCRIPTION
….12.x

Includes tests to verify the toString representations.
