### PR TITLE
Inline super calls, as they are statically resolved

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
@@ -88,6 +88,11 @@ object BytecodeUtils {
 
   def isLoadOrStore(instruction: AbstractInsnNode): Boolean = isLoad(instruction) || isStore(instruction)
 
+  def isNonVirtualCall(instruction: AbstractInsnNode): Boolean = {
+    val op = instruction.getOpcode
+    op == INVOKESPECIAL || op == INVOKESTATIC
+  }
+
   def isExecutable(instruction: AbstractInsnNode): Boolean = instruction.getOpcode >= 0
 
   def isConstructor(methodNode: MethodNode): Boolean = {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/BTypesFromClassfileTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/BTypesFromClassfileTest.scala
@@ -67,14 +67,17 @@ class BTypesFromClassfileTest {
     // there's a separate InlineInfoTest.
 
     val chk1 = sameBTypes(fromSym.superClass, fromClassfile.superClass, checked)
+    
+    // was:
+    // val chk2 = sameBTypes(fromSym.interfaces, fromClassfile.interfaces, chk1)
 
+    // TODO: The new trait encoding emits redundant parents in the backend to avoid linkage errors in invokespecial
+    // Need to give this some more thought, maybe do it earlier so it is reflected in the Symbol's info, too.
     val fromSymInterfaces = fromSym.interfaces
     val fromClassFileInterfaces = fromClassfile.interfaces
     val (matching, other) = fromClassFileInterfaces.partition(x => fromSymInterfaces.exists(_.internalName == x.internalName))
     val chk2 = sameBTypes(fromSym.interfaces, matching, chk1)
     for (redundant <- other) {
-      // TODO SD-86 The new trait encoding emits redundant parents in the backend to avoid linkage errors in invokespecial
-      //            Need to give this some more thought, maybe do it earlier so it is reflected in the Symbol's info, too.
       assert(matching.exists(x => x.isSubtypeOf(redundant).orThrow), redundant)
     }
 

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineInfoTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineInfoTest.scala
@@ -59,9 +59,7 @@ class InlineInfoTest extends ClearAfterClass {
         |}
         |class C extends T with U
       """.stripMargin
-//    val classes = compile(code) // SD-86
-    InlineInfoTest.notPerRun.foreach(_.clear())
-    val classes = compileClasses(compiler)(code, allowMessage = _ => true) // SD-86 inline warnings
+    val classes = compile(code)
 
     val fromSyms = classes.map(c => compiler.genBCode.bTypes.classBTypeFromInternalName(c.name).info.get.inlineInfo)
 

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineWarningTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineWarningTest.scala
@@ -67,10 +67,10 @@ class InlineWarningTest extends ClearAfterClass {
       "T::m2()I is annotated @inline but cannot be inlined: the method is not final and may be overridden",
       "D::m2()I is annotated @inline but cannot be inlined: the method is not final and may be overridden")
     compile(code, allowMessage = i => {count += 1; warns.exists(i.msg contains _)})
-    assert(count == 5, count) // TODO SD-85: 5th warning
+    assert(count == 4, count)
   }
 
-  // TODO SD-85: no more impl classes. this test (and the warning it tests!) can be removed
+  // TODO SD-86: no more impl classes. this test (and the warning it tests!) can be removed
   @org.junit.Ignore @Test
   def traitMissingImplClass(): Unit = {
     val codeA = "trait T { @inline final def f = 1 }"

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerSeparateCompilationTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerSeparateCompilationTest.scala
@@ -42,15 +42,10 @@ class InlinerSeparateCompilationTest {
         |}
       """.stripMargin
 
-    val warns = Set(
-      "T::f()I is annotated @inline but cannot be inlined: the method is not final and may be overridden",
-      // TODO SD-85
-      """O$::f()I is annotated @inline but could not be inlined:
-        |The callee O$::f()I contains the instruction INVOKESPECIAL T.f ()I
-        |that would cause an IllegalAccessError when inlined into class C""".stripMargin)
-    val List(c, o, oMod, t) = compileClassesSeparately(List(codeA, codeB), args + " -Yopt-warnings", i => warns.exists(i.msg contains _))
+    val warn = "T::f()I is annotated @inline but cannot be inlined: the method is not final and may be overridden"
+    val List(c, o, oMod, t) = compileClassesSeparately(List(codeA, codeB), args + " -Yopt-warnings", _.msg contains warn)
     assertInvoke(getSingleMethod(c, "t1"), "T", "f")
-//    assertNoInvoke(getSingleMethod(c, "t2")) // SD-85
+    assertNoInvoke(getSingleMethod(c, "t2"))
     assertNoInvoke(getSingleMethod(c, "t3"))
   }
 


### PR DESCRIPTION
Ensures that mixin methods of `@inline` annotated concrete trait methods
inline the trait method.

Fixes https://github.com/scala/scala-dev/issues/86
