### PR TITLE
SI-9702 Fix backend crash with classOf[T] annotation argument

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -469,13 +469,10 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
         case NullTag    => emit(asm.Opcodes.ACONST_NULL)
 
         case ClazzTag   =>
-          val toPush: BType = {
-            typeToBType(const.typeValue) match {
-              case kind: PrimitiveBType => boxedClassOfPrimitive(kind)
-              case kind => kind
-            }
-          }
-          mnode.visitLdcInsn(toPush.toASMType)
+          val tp = typeToBType(const.typeValue)
+          // classOf[Int] is transformed to Integer.TYPE by CleanUp
+          assert(!tp.isPrimitive, s"expected class type in classOf[T], found primitive type $tp")
+          mnode.visitLdcInsn(tp.toASMType)
 
         case EnumTag   =>
           val sym       = const.symbolValue

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -1112,7 +1112,7 @@ abstract class Erasure extends AddInterfaces
 
         case Literal(ct) if ct.tag == ClazzTag
                          && ct.typeValue.typeSymbol != definitions.UnitClass =>
-          val erased = ct.typeValue match {
+          val erased = ct.typeValue.dealiasWiden match {
             case tr @ TypeRef(_, clazz, _) if clazz.isDerivedValueClass => scalaErasure.eraseNormalClassRef(tr)
             case tpe => specialScalaErasure(tpe)
           }

--- a/src/reflect/scala/reflect/internal/transform/Erasure.scala
+++ b/src/reflect/scala/reflect/internal/transform/Erasure.scala
@@ -112,8 +112,9 @@ trait Erasure {
     protected def eraseDerivedValueClassRef(tref: TypeRef): Type = erasedValueClassArg(tref)
 
     def apply(tp: Type): Type = tp match {
-      case ConstantType(_) =>
-        tp
+      case ConstantType(ct) =>
+        if (ct.tag == ClazzTag) ConstantType(Constant(apply(ct.typeValue)))
+        else tp
       case st: ThisType if st.sym.isPackageClass =>
         tp
       case st: SubType =>

--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -1161,6 +1161,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
       propagatePackageBoundary(jmeth.javaFlags, meth)
       copyAnnotations(meth, jmeth)
       if (jmeth.javaFlags.isVarargs) meth modifyInfo arrayToRepeated
+      if (jmeth.getDefaultValue != null) meth.addAnnotation(AnnotationDefaultAttr)
       markAllCompleted(meth)
       meth
     }

--- a/test/junit/scala/issues/RunTest.scala
+++ b/test/junit/scala/issues/RunTest.scala
@@ -1,0 +1,143 @@
+package scala.issues
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.{AfterClass, BeforeClass, Test}
+import org.junit.Assert._
+
+import scala.reflect.runtime._
+import scala.tools.reflect.ToolBox
+import scala.tools.testing.ClearAfterClass
+
+object RunTest extends ClearAfterClass.Clearable {
+  var toolBox = universe.runtimeMirror(getClass.getClassLoader).mkToolBox()
+  override def clear(): Unit = { toolBox = null }
+
+  // definitions for individual tests
+
+  class VC(val x: Any) extends AnyVal
+}
+
+@RunWith(classOf[JUnit4])
+class RunTest extends ClearAfterClass {
+  ClearAfterClass.stateToClear = RunTest
+
+  def run[T](code: String): T = {
+    val tb = RunTest.toolBox
+    tb.eval(tb.parse(code)).asInstanceOf[T]
+  }
+
+  @Test
+  def classOfValueClassAlias(): Unit = {
+    val code =
+      """import scala.issues.RunTest.VC
+        |type aVC = VC
+        |type aInt = Int
+        |type aInteger = Integer
+        |classOf[VC] == classOf[aVC] &&
+        |  classOf[aInt] == classOf[Int] &&
+        |  classOf[aInteger] == classOf[Integer] &&
+        |  classOf[aInt] != classOf[aInteger]
+      """.stripMargin
+    assertTrue(run[Boolean](code))
+  }
+
+  @Test
+  def classOfFinalVal(): Unit = {
+    val code =
+      """class C {
+        |  final val a1 = classOf[Int]
+        |  final val b1 = classOf[List[_]]
+        |  final val c1 = classOf[List[String]]
+        |  final val d1 = classOf[Array[Int]]
+        |  final val e1 = classOf[Array[List[_]]]
+        |  final val f1 = classOf[Array[_]]
+        |
+        |  val a2 = classOf[Int]
+        |  val b2 = classOf[List[_]]
+        |  val c2 = classOf[List[String]]
+        |  val d2 = classOf[Array[Int]]
+        |  val e2 = classOf[Array[List[_]]]
+        |  val f2 = classOf[Array[_]]
+        |
+        |  val listC = Class.forName("scala.collection.immutable.List")
+        |
+        |  val compare = List(
+        |    (a1, a2, Integer.TYPE),
+        |    (b1, b2, listC),
+        |    (c1, c2, listC),
+        |    (d1, d2, Array(1).getClass),
+        |    (e1, e2, Array(List()).getClass),
+        |    (f1, f2, new Object().getClass))
+        |}
+        |(new C).compare
+      """.stripMargin
+    type K = Class[_]
+    val cs = run[List[(K, K, K)]](code)
+    for ((x, y, z) <- cs) {
+      assertEquals(x, y)
+      assertEquals(x, z)
+    }
+  }
+
+  @Test
+  def t9702(): Unit = {
+    val code =
+      """import javax.annotation.Resource
+        |import scala.issues.RunTest.VC
+        |class C {
+        |  type aList[K] = List[K]
+        |  type aVC = VC
+        |  type aInt = Int
+        |  type aInteger = Integer
+        |  @Resource(`type` = classOf[List[Int]])      def a = 0
+        |  @Resource(`type` = classOf[List[_]])        def b = 0
+        |  @Resource(`type` = classOf[aList[_]])       def c = 0
+        |  @Resource(`type` = classOf[Int])            def d = 0
+        |  @Resource(`type` = classOf[aInt])           def e = 0
+        |  @Resource(`type` = classOf[Integer])        def f = 0
+        |  @Resource(`type` = classOf[aInteger])       def g = 0
+        |  @Resource(`type` = classOf[VC])             def h = 0
+        |  @Resource(`type` = classOf[aVC])            def i = 0
+        |  @Resource(`type` = classOf[Array[Int]])     def j = 0
+        |  @Resource(`type` = classOf[Array[List[_]]]) def k = 0
+        |}
+        |val c = classOf[C]
+        |def typeArg(meth: String) = c.getDeclaredMethod(meth).getDeclaredAnnotation(classOf[Resource]).`type`
+        |('a' to 'k').toList.map(_.toString).map(typeArg)
+      """.stripMargin
+
+    val l = Class.forName("scala.collection.immutable.List")
+    val i = Integer.TYPE
+    val ig = new Integer(1).getClass
+    val v = new RunTest.VC(1).getClass
+    val ai = Array(1).getClass
+    val al = Array(List()).getClass
+
+    // sanity checks
+    assertEquals(i, classOf[Int])
+    assertNotEquals(i, ig)
+
+    assertEquals(run[List[Class[_]]](code),
+      List(l, l, l, i, i, ig, ig, v, v, ai, al))
+  }
+
+  @Test
+  def annotationInfoNotErased(): Unit = {
+    val code =
+      """import javax.annotation.Resource
+        |import scala.annotation.meta.getter
+        |class C {
+        |  type Rg = Resource @getter
+        |  @(Resource @getter)(`type` = classOf[Int]) def a = 0
+        |  @Rg(`type` = classOf[Int])                 def b = 0
+        |}
+        |val c = classOf[C]
+        |def typeArg(meth: String) = c.getDeclaredMethod(meth).getDeclaredAnnotation(classOf[Resource]).`type`
+        |List("a", "b") map typeArg
+        |""".stripMargin
+
+    val i = Integer.TYPE
+    assertEquals(run[List[Class[_]]](code), List(i, i))
+  }
+}


### PR DESCRIPTION
A `classOf[List[Int]]` annotation argument is translated to a constant
with the `AliasArgsTypeRef` as constant value.

To obtain the corresponding ASM Type to emit as annotation argument, we
now go directly to the class symbol using `typeSymbol`, instead of
calling the generic `typeToBType` method, which expects only
non-parameterized types.
