### PR TITLE
Add back to search for Scaladoc

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.js
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.js
@@ -21,6 +21,20 @@ var Index = {};
     }
 })(Index);
 
+/** Find query string from URL */
+var QueryString = function(key) {
+    if (QueryString.map === undefined) { // only calc once
+        QueryString.map = {};
+        var keyVals = window.location.search.split("?").pop().split("&");
+        keyVals.forEach(function(elem) {
+            var pair = elem.split("=");
+            if (pair.length == 2) QueryString.map[pair[0]] = pair[1];
+        });
+    }
+
+    return QueryString.map[key];
+};
+
 $(document).ready(function() {
     // Clicking #doc-title returns the user to the root package
     $("#doc-title").click(function() { document.location = toRoot + "index.html" });
@@ -39,6 +53,11 @@ $(document).ready(function() {
         else
             $("#textfilter > .input > .clear").hide();
     });
+
+    if (QueryString("search") !== undefined) {
+        $("#index-input").val(QueryString("search"));
+        searchAll();
+    }
 });
 
 /* Handles all key presses while scrolling around with keyboard shortcuts in search results */
@@ -509,6 +528,11 @@ function searchAll() {
         $("#search > span#doc-title").show();
         return;
     }
+
+    // Replace ?search=X with current search string if not hosted locally on Chrome
+    try {
+        window.history.replaceState({}, "", "?search=" + searchStr);
+    } catch(e) {}
 
     $("div#results-content > span.search-text").remove();
 


### PR DESCRIPTION
Add basic support for navigating back to search results. This should work on web-servers as well as firefox local.

Permalinking to search results works on all browsers both local and on http.

There is one known issue. When doing `window.history.replaceState(...)` (to set the url to `.../Boolean.html?search=X`) on Chrome/Safari local, it will yield a security error. This is the reason as to why it only works on web-servers / firefox. There is an alternative - writing to `window.location.search`, unfortunately this will reload the page. Since most scala  docs will be viewed online, this should only be an issue prevalent to a tiny portion of our users.

An alternative implementation might be to switch out the hash to `#doc-search=X` - unfortunately this would break the permalink navigation. Not sure if there's a better approach to this.

preview: https://dl.dropboxusercontent.com/u/358427/scaladoc-unclutter/index.html?search=bool
review: @heathermiller, @VladUreche 
