### PR TITLE
SI-9684 Deprecate JavaConversions

### DIFF
--- a/project/Osgi.scala
+++ b/project/Osgi.scala
@@ -3,7 +3,8 @@ import aQute.bnd.osgi.Constants._
 import java.util.Properties
 import sbt._
 import sbt.Keys._
-import scala.collection.JavaConversions._
+import collection.convert.wrapAsScala._
+import collection.convert.wrapAsJava._
 import VersionUtil.versionProperties
 
 /** OSGi packaging for the Scala build, distilled from sbt-osgi. We do not use sbt-osgi because it

--- a/src/compiler/scala/tools/cmd/Property.scala
+++ b/src/compiler/scala/tools/cmd/Property.scala
@@ -65,8 +65,8 @@ trait Property extends Reference {
     propertiesToOptions(loadProperties(file))
 
   def propertiesToOptions(props: java.util.Properties): List[String] = {
-    import scala.collection.JavaConversions._
-    propertiesToOptions(props.toList)
+    import scala.collection.convert.decorateAsScala._
+    propertiesToOptions(props.asScala.toList)
   }
   def propertiesToOptions(props: List[(String, String)]) = props flatMap propMapper
 }

--- a/src/compiler/scala/tools/cmd/Property.scala
+++ b/src/compiler/scala/tools/cmd/Property.scala
@@ -65,7 +65,7 @@ trait Property extends Reference {
     propertiesToOptions(loadProperties(file))
 
   def propertiesToOptions(props: java.util.Properties): List[String] = {
-    import scala.collection.convert.decorateAsScala._
+    import scala.collection.JavaConverters._
     propertiesToOptions(props.asScala.toList)
   }
   def propertiesToOptions(props: List[(String, String)]) = props flatMap propMapper

--- a/src/library/scala/collection/JavaConversions.scala
+++ b/src/library/scala/collection/JavaConversions.scala
@@ -11,10 +11,10 @@ package collection
 
 import convert._
 
-/**   A collection of implicit conversions supporting interoperability between
- *    Scala and Java collections.
+/** A collection of implicit conversions supporting interoperability between
+ *  Scala and Java collections.
  *
- *    The following conversions are supported:
+ *  The following conversions are supported:
  *{{{
  *    scala.collection.Iterable       <=> java.lang.Iterable
  *    scala.collection.Iterable       <=> java.util.Collection
@@ -24,8 +24,8 @@ import convert._
  *    scala.collection.mutable.Map    <=> java.util.{ Map, Dictionary }
  *    scala.collection.concurrent.Map <=> java.util.concurrent.ConcurrentMap
  *}}}
- *    In all cases, converting from a source type to a target type and back
- *    again will return the original source object, eg.
+ *  In all cases, converting from a source type to a target type and back
+ *  again will return the original source object:
  *
  *{{{
  *    import scala.collection.JavaConversions._
@@ -45,8 +45,18 @@ import convert._
  *    java.util.Properties         => scala.collection.mutable.Map[String, String]
  *}}}
  *
+ *  The transparent conversions provided here are considered
+ *  fragile because they can result in unexpected behavior and performance.
+ *
+ *  Consider using `JavaConverters` instead, which provides an `asScala` member
+ *  (respectively `asJava`) to signal that a conversion is required.
+ *
+ *  The current functionality is also provided by `convert.wrapAsScala` and
+ *  `convert.wrapAsJava`.
+ *
  *  @author Miles Sabin
  *  @author Martin Odersky
  *  @since  2.8
  */
+@deprecated("Use JavaConverters or convert.{wrapAsScala,wrapAsJava}.", since="2.12")
 object JavaConversions extends WrapAsScala with WrapAsJava

--- a/src/library/scala/collection/JavaConversions.scala
+++ b/src/library/scala/collection/JavaConversions.scala
@@ -1,6 +1,6 @@
 /*                     __                                               *\
 **     ________ ___   / /  ___     Scala API                            **
-**    / __/ __// _ | / /  / _ |    (c) 2006-2013, LAMP/EPFL             **
+**    / __/ __// _ | / /  / _ |    (c) 2006-2016, LAMP/EPFL             **
 **  __\ \/ /__/ __ |/ /__/ __ |    http://www.scala-lang.org/           **
 ** /____/\___/_/ |_/____/_/ | |                                         **
 **                          |/                                          **
@@ -48,15 +48,13 @@ import convert._
  *  The transparent conversions provided here are considered
  *  fragile because they can result in unexpected behavior and performance.
  *
- *  Consider using `JavaConverters` instead, which provides an `asScala` member
- *  (respectively `asJava`) to signal that a conversion is required.
- *
- *  The current functionality is also provided by `convert.wrapAsScala` and
- *  `convert.wrapAsJava`.
+ *  Therefore, this API has been deprecated and `JavaConverters` should be
+ *  used instead. `JavaConverters` provides the same conversions, but through
+ *  extension methods.
  *
  *  @author Miles Sabin
  *  @author Martin Odersky
  *  @since  2.8
  */
-@deprecated("Use JavaConverters or convert.{wrapAsScala,wrapAsJava}.", since="2.12")
+@deprecated("Use JavaConverters", since="2.12")
 object JavaConversions extends WrapAsScala with WrapAsJava

--- a/src/library/scala/collection/JavaConverters.scala
+++ b/src/library/scala/collection/JavaConverters.scala
@@ -26,7 +26,7 @@ import convert._
  *    scala.collection.mutable.concurrent.Map <=> java.util.concurrent.ConcurrentMap
  *}}}
  *  The following conversions are supported via `asScala` and through
- *  specially-named methods to convert to Java collections, as shown:
+ *  specially-named extension methods to convert to Java collections, as shown:
  *{{{
  *    scala.collection.Iterable    <=> java.util.Collection   (via asJavaCollection)
  *    scala.collection.Iterator    <=> java.util.Enumeration  (via asJavaEnumeration)
@@ -53,6 +53,21 @@ import convert._
  *    val other: scala.collection.mutable.Buffer[Int] = target.asScala
  *    assert(source eq other)
  *  }}}
+ *  Alternatively, the conversion methods have descriptive names and can be invoked explicitly.
+ *  {{{
+ *    scala> val vs = java.util.Arrays.asList("hi", "bye")
+ *    vs: java.util.List[String] = [hi, bye]
+ *
+ *    scala> val ss = asScalaIterator(vs.iterator)
+ *    ss: Iterator[String] = non-empty iterator
+ *
+ *    scala> .toList
+ *    res0: List[String] = List(hi, bye)
+ *
+ *    scala> val ss = asScalaBuffer(vs)
+ *    ss: scala.collection.mutable.Buffer[String] = Buffer(hi, bye)
+ *  }}}
+ *
  *  @since  2.8.1
  */
 object JavaConverters extends DecorateAsJava with DecorateAsScala

--- a/src/library/scala/collection/JavaConverters.scala
+++ b/src/library/scala/collection/JavaConverters.scala
@@ -1,6 +1,6 @@
 /*                     __                                               *\
 **     ________ ___   / /  ___     Scala API                            **
-**    / __/ __// _ | / /  / _ |    (c) 2006-2013, LAMP/EPFL             **
+**    / __/ __// _ | / /  / _ |    (c) 2006-2016, LAMP/EPFL             **
 **  __\ \/ /__/ __ |/ /__/ __ |    http://www.scala-lang.org/           **
 ** /____/\___/_/ |_/____/_/ | |                                         **
 **                          |/                                          **
@@ -11,14 +11,12 @@ package collection
 
 import convert._
 
-// TODO: I cleaned all this documentation up in deprecated JxxxConversions, but the
-// documentation in here is basically the pre-cleaned-up version with minor
-// additions.  Would be nice to have in one place.
-
-/** A collection of decorators that allow converting between
- *  Scala and Java collections using `asScala` and `asJava` methods.
+/** A variety of decorators that enable converting between
+ *  Scala and Java collections using extension methods, `asScala` and `asJava`.
  *
- *  The following conversions are supported via `asJava`, `asScala`
+ *  The extension methods return adapters for the corresponding API.
+ *
+ *  The following conversions are supported via `asScala` and `asJava`:
  *{{{
  *    scala.collection.Iterable               <=> java.lang.Iterable
  *    scala.collection.Iterator               <=> java.util.Iterator
@@ -27,25 +25,14 @@ import convert._
  *    scala.collection.mutable.Map            <=> java.util.Map
  *    scala.collection.mutable.concurrent.Map <=> java.util.concurrent.ConcurrentMap
  *}}}
- *  In all cases, converting from a source type to a target type and back
- *  again will return the original source object, e.g.
- *  {{{
- *    import scala.collection.JavaConverters._
- *
- *    val sl = new scala.collection.mutable.ListBuffer[Int]
- *    val jl : java.util.List[Int] = sl.asJava
- *    val sl2 : scala.collection.mutable.Buffer[Int] = jl.asScala
- *    assert(sl eq sl2)
- *  }}}
- *  The following conversions are also supported, but the
- *  direction from Scala to Java is done by the more specifically named methods:
- *  `asJavaCollection`, `asJavaEnumeration`, `asJavaDictionary`.
+ *  The following conversions are supported via `asScala` and through
+ *  specially-named methods to convert to Java collections, as shown:
  *{{{
- *    scala.collection.Iterable    <=> java.util.Collection
- *    scala.collection.Iterator    <=> java.util.Enumeration
- *    scala.collection.mutable.Map <=> java.util.Dictionary
+ *    scala.collection.Iterable    <=> java.util.Collection   (via asJavaCollection)
+ *    scala.collection.Iterator    <=> java.util.Enumeration  (via asJavaEnumeration)
+ *    scala.collection.mutable.Map <=> java.util.Dictionary   (via asJavaDictionary)
  *}}}
- *  In addition, the following one way conversions are provided via `asJava`:
+ *  In addition, the following one-way conversions are provided via `asJava`:
  *{{{
  *    scala.collection.Seq         => java.util.List
  *    scala.collection.mutable.Seq => java.util.List
@@ -56,6 +43,16 @@ import convert._
  *{{{
  *    java.util.Properties => scala.collection.mutable.Map
  *}}}
+ *  In all cases, converting from a source type to a target type and back
+ *  again will return the original source object. For example:
+ *  {{{
+ *    import scala.collection.JavaConverters._
+ *
+ *    val source = new scala.collection.mutable.ListBuffer[Int]
+ *    val target: java.util.List[Int] = source.asJava
+ *    val other: scala.collection.mutable.Buffer[Int] = target.asScala
+ *    assert(source eq other)
+ *  }}}
  *  @since  2.8.1
  */
 object JavaConverters extends DecorateAsJava with DecorateAsScala

--- a/src/library/scala/collection/JavaConverters.scala
+++ b/src/library/scala/collection/JavaConverters.scala
@@ -11,7 +11,7 @@ package collection
 
 import convert._
 
-// TODO: I cleaned all this documentation up in JavaConversions, but the
+// TODO: I cleaned all this documentation up in deprecated JxxxConversions, but the
 // documentation in here is basically the pre-cleaned-up version with minor
 // additions.  Would be nice to have in one place.
 

--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -1113,7 +1113,7 @@ private[concurrent] object Debug {
   def log(s: AnyRef) = logbuffer.add(s)
 
   def flush() {
-    for (s <- JavaConversions.asScalaIterator(logbuffer.iterator())) Console.out.println(s.toString)
+    for (s <- convert.wrapAsScala.asScalaIterator(logbuffer.iterator())) Console.out.println(s.toString)
     logbuffer.clear()
   }
 

--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -1106,14 +1106,14 @@ private[concurrent] case object TrieMapSerializationEnd
 
 
 private[concurrent] object Debug {
-  import scala.collection._
+  import JavaConverters._
 
   lazy val logbuffer = new java.util.concurrent.ConcurrentLinkedQueue[AnyRef]
 
   def log(s: AnyRef) = logbuffer.add(s)
 
   def flush() {
-    for (s <- convert.wrapAsScala.asScalaIterator(logbuffer.iterator())) Console.out.println(s.toString)
+    for (s <- logbuffer.iterator().asScala) Console.out.println(s.toString)
     logbuffer.clear()
   }
 

--- a/src/library/scala/collection/convert/AsJavaConverters.scala
+++ b/src/library/scala/collection/convert/AsJavaConverters.scala
@@ -11,145 +11,150 @@ package collection
 package convert
 
 import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
-import scala.language.implicitConversions
 
-@deprecatedInheritance("Use JavaConverters or consider ImplicitConversions", since="2.12")
-trait WrapAsJava {
+/** Defines converter methods from Scala to Java collections. */
+trait AsJavaConverters {
   import Wrappers._
 
   /**
-   * Implicitly converts a Scala Iterator to a Java Iterator.
+   * Converts a Scala Iterator to a Java Iterator.
+   *
    * The returned Java Iterator is backed by the provided Scala
    * Iterator and any side-effects of using it via the Java interface will
    * be visible via the Scala interface and vice versa.
    *
    * If the Scala Iterator was previously obtained from an implicit or
-   * explicit call of `asIterator(java.util.Iterator)` then the original
+   * explicit call of `asScalaIterator(java.util.Iterator)` then the original
    * Java Iterator will be returned.
    *
    * @param  it The Iterator to be converted.
    * @return    A Java Iterator view of the argument.
    */
-  implicit def asJavaIterator[A](it: Iterator[A]): ju.Iterator[A] = it match {
+  def asJavaIterator[A](it: Iterator[A]): ju.Iterator[A] = it match {
     case null                       => null
     case JIteratorWrapper(wrapped)  => wrapped.asInstanceOf[ju.Iterator[A]]
     case _                          => IteratorWrapper(it)
   }
 
   /**
-   * Implicitly converts a Scala Iterator to a Java Enumeration.
+   * Converts a Scala Iterator to a Java Enumeration.
+   *
    * The returned Java Enumeration is backed by the provided Scala
    * Iterator and any side-effects of using it via the Java interface will
    * be visible via the Scala interface and vice versa.
    *
    * If the Scala Iterator was previously obtained from an implicit or
-   * explicit call of `asIterator(java.util.Enumeration)` then the
+   * explicit call of `enumerationAsScalaIterator(java.util.Enumeration)` then the
    * original Java Enumeration will be returned.
    *
    * @param it The Iterator to be converted.
    * @return   A Java Enumeration view of the argument.
    */
-  implicit def asJavaEnumeration[A](it: Iterator[A]): ju.Enumeration[A] = it match {
+  def asJavaEnumeration[A](it: Iterator[A]): ju.Enumeration[A] = it match {
     case null                         => null
     case JEnumerationWrapper(wrapped) => wrapped.asInstanceOf[ju.Enumeration[A]]
     case _                            => IteratorWrapper(it)
   }
 
   /**
-   * Implicitly converts a Scala Iterable to a Java Iterable.
+   * Converts a Scala Iterable to a Java Iterable.
+   *
    * The returned Java Iterable is backed by the provided Scala
    * Iterable and any side-effects of using it via the Java interface will
    * be visible via the Scala interface and vice versa.
    *
    * If the Scala Iterable was previously obtained from an implicit or
-   * explicit call of `asIterable(java.lang.Iterable)` then the original
+   * explicit call of `iterableasScalaIterable(java.lang.Iterable)` then the original
    * Java Iterable will be returned.
    *
    * @param i The Iterable to be converted.
    * @return A Java Iterable view of the argument.
    */
-  implicit def asJavaIterable[A](i: Iterable[A]): jl.Iterable[A] = i match {
+  def asJavaIterable[A](i: Iterable[A]): jl.Iterable[A] = i match {
     case null                       => null
     case JIterableWrapper(wrapped)  => wrapped.asInstanceOf[jl.Iterable[A]]
     case _                          => IterableWrapper(i)
   }
 
   /**
-   * Implicitly converts a Scala Iterable to an immutable Java
-   * Collection.
+   * Converts a Scala Iterable to an immutable Java Collection.
    *
    * If the Scala Iterable was previously obtained from an implicit or
-   * explicit call of `asSizedIterable(java.util.Collection)` then the original
+   * explicit call of `collectionAsScalaIterable(java.util.Collection)` then the original
    * Java Collection will be returned.
    *
    * @param it The SizedIterable to be converted.
    * @return   A Java Collection view of the argument.
    */
-  implicit def asJavaCollection[A](it: Iterable[A]): ju.Collection[A] = it match {
+  def asJavaCollection[A](it: Iterable[A]): ju.Collection[A] = it match {
     case null                         => null
     case JCollectionWrapper(wrapped)  => wrapped.asInstanceOf[ju.Collection[A]]
     case _                            => new IterableWrapper(it)
   }
 
   /**
-   * Implicitly converts a Scala mutable Buffer to a Java List.
+   * Converts a Scala mutable Buffer to a Java List.
+   *
    * The returned Java List is backed by the provided Scala
    * Buffer and any side-effects of using it via the Java interface will
    * be visible via the Scala interface and vice versa.
    *
    * If the Scala Buffer was previously obtained from an implicit or
-   * explicit call of `asBuffer(java.util.List)` then the original
+   * explicit call of `asScalaBuffer(java.util.List)` then the original
    * Java List will be returned.
    *
    * @param b The Buffer to be converted.
    * @return A Java List view of the argument.
    */
-  implicit def bufferAsJavaList[A](b: mutable.Buffer[A]): ju.List[A] = b match {
+  def bufferAsJavaList[A](b: mutable.Buffer[A]): ju.List[A] = b match {
     case null                   => null
     case JListWrapper(wrapped)  => wrapped
     case _                      => new MutableBufferWrapper(b)
   }
 
   /**
-   * Implicitly converts a Scala mutable Seq to a Java List.
+   * Converts a Scala mutable Seq to a Java List.
+   *
    * The returned Java List is backed by the provided Scala
    * Seq and any side-effects of using it via the Java interface will
    * be visible via the Scala interface and vice versa.
    *
    * If the Scala Seq was previously obtained from an implicit or
-   * explicit call of `asSeq(java.util.List)` then the original
+   * explicit call of `asScalaBuffer(java.util.List)` then the original
    * Java List will be returned.
    *
    * @param seq The Seq to be converted.
    * @return    A Java List view of the argument.
    */
-  implicit def mutableSeqAsJavaList[A](seq: mutable.Seq[A]): ju.List[A] = seq match {
+  def mutableSeqAsJavaList[A](seq: mutable.Seq[A]): ju.List[A] = seq match {
     case null                   => null
     case JListWrapper(wrapped)  => wrapped
     case _                      => new MutableSeqWrapper(seq)
   }
 
   /**
-   * Implicitly converts a Scala Seq to a Java List.
+   * Converts a Scala Seq to a Java List.
+   *
    * The returned Java List is backed by the provided Scala
    * Seq and any side-effects of using it via the Java interface will
    * be visible via the Scala interface and vice versa.
    *
    * If the Scala Seq was previously obtained from an implicit or
-   * explicit call of `asSeq(java.util.List)` then the original
+   * explicit call of `asScalaBuffer(java.util.List)` then the original
    * Java List will be returned.
    *
    * @param seq The Seq to be converted.
    * @return    A Java List view of the argument.
    */
-  implicit def seqAsJavaList[A](seq: Seq[A]): ju.List[A] = seq match {
+  def seqAsJavaList[A](seq: Seq[A]): ju.List[A] = seq match {
     case null                   => null
     case JListWrapper(wrapped)  => wrapped.asInstanceOf[ju.List[A]]
     case _                      => new SeqWrapper(seq)
   }
 
   /**
-   * Implicitly converts a Scala mutable Set to a Java Set.
+   * Converts a Scala mutable Set to a Java Set.
+   *
    * The returned Java Set is backed by the provided Scala
    * Set and any side-effects of using it via the Java interface will
    * be visible via the Scala interface and vice versa.
@@ -161,93 +166,94 @@ trait WrapAsJava {
    * @param s The Set to be converted.
    * @return A Java Set view of the argument.
    */
-  implicit def mutableSetAsJavaSet[A](s: mutable.Set[A]): ju.Set[A] = s match {
+  def mutableSetAsJavaSet[A](s: mutable.Set[A]): ju.Set[A] = s match {
     case null                 => null
     case JSetWrapper(wrapped) => wrapped
     case _                    => new MutableSetWrapper(s)
   }
 
   /**
-   * Implicitly converts a Scala Set to a Java Set.
+   * Converts a Scala Set to a Java Set.
+   *
    * The returned Java Set is backed by the provided Scala
    * Set and any side-effects of using it via the Java interface will
    * be visible via the Scala interface and vice versa.
    *
    * If the Scala Set was previously obtained from an implicit or
-   * explicit call of asSet(java.util.Set) then the original
+   * explicit call of `asScalaSet(java.util.Set)` then the original
    * Java Set will be returned.
    *
    * @param s The Set to be converted.
    * @return A Java Set view of the argument.
    */
-  implicit def setAsJavaSet[A](s: Set[A]): ju.Set[A] = s match {
+  def setAsJavaSet[A](s: Set[A]): ju.Set[A] = s match {
     case null                 => null
     case JSetWrapper(wrapped) => wrapped
     case _                    => new SetWrapper(s)
   }
 
   /**
-   * Implicitly converts a Scala mutable Map to a Java Map.
+   * Converts a Scala mutable Map to a Java Map.
+   *
    * The returned Java Map is backed by the provided Scala
    * Map and any side-effects of using it via the Java interface will
    * be visible via the Scala interface and vice versa.
    *
    * If the Scala Map was previously obtained from an implicit or
-   * explicit call of `asMap(java.util.Map)` then the original
+   * explicit call of `mapAsScalaMap(java.util.Map)` then the original
    * Java Map will be returned.
    *
    * @param m The Map to be converted.
    * @return A Java Map view of the argument.
    */
-  implicit def mutableMapAsJavaMap[A, B](m: mutable.Map[A, B]): ju.Map[A, B] = m match {
+  def mutableMapAsJavaMap[A, B](m: mutable.Map[A, B]): ju.Map[A, B] = m match {
     case null                 => null
     case JMapWrapper(wrapped) => wrapped
     case _                    => new MutableMapWrapper(m)
   }
 
   /**
-   * Implicitly converts a Scala mutable `Map` to a Java `Dictionary`.
+   * Converts a Scala mutable `Map` to a Java `Dictionary`.
    *
    * The returned Java `Dictionary` is backed by the provided Scala
    * `Dictionary` and any side-effects of using it via the Java interface
    * will be visible via the Scala interface and vice versa.
    *
    * If the Scala `Dictionary` was previously obtained from an implicit or
-   * explicit call of `asMap(java.util.Dictionary)` then the original
+   * explicit call of `dictionaryAsScalaMap(java.util.Dictionary)` then the original
    * Java Dictionary will be returned.
    *
    * @param m The `Map` to be converted.
    * @return A Java `Dictionary` view of the argument.
    */
-  implicit def asJavaDictionary[A, B](m: mutable.Map[A, B]): ju.Dictionary[A, B] = m match {
+  def asJavaDictionary[A, B](m: mutable.Map[A, B]): ju.Dictionary[A, B] = m match {
     case null                         => null
     case JDictionaryWrapper(wrapped)  => wrapped
     case _                            => new DictionaryWrapper(m)
   }
 
   /**
-   * Implicitly converts a Scala `Map` to a Java `Map`.
+   * Converts a Scala `Map` to a Java `Map`.
    *
    * The returned Java `Map` is backed by the provided Scala `Map` and
    * any side-effects of using it via the Java interface will be visible
    * via the Scala interface and vice versa.
    *
    * If the Scala `Map` was previously obtained from an implicit or
-   * explicit call of `asMap(java.util.Map)` then the original
+   * explicit call of `mapAsScalaMap(java.util.Map)` then the original
    * Java `Map` will be returned.
    *
    * @param m The `Map` to be converted.
    * @return A Java `Map` view of the argument.
    */
-  implicit def mapAsJavaMap[A, B](m: Map[A, B]): ju.Map[A, B] = m match {
+  def mapAsJavaMap[A, B](m: Map[A, B]): ju.Map[A, B] = m match {
     case null                 => null
     case JMapWrapper(wrapped) => wrapped.asInstanceOf[ju.Map[A, B]]
     case _                    => new MapWrapper(m)
   }
 
   /**
-   * Implicitly converts a Scala mutable `concurrent.Map` to a Java
-   * `ConcurrentMap`.
+   * Converts a Scala mutable `concurrent.Map` to a Java `ConcurrentMap`.
    *
    * The returned Java `ConcurrentMap` is backed by the provided Scala
    * `concurrent.Map` and any side-effects of using it via the Java interface
@@ -260,11 +266,9 @@ trait WrapAsJava {
    * @param m The Scala `concurrent.Map` to be converted.
    * @return A Java `ConcurrentMap` view of the argument.
    */
-  implicit def mapAsJavaConcurrentMap[A, B](m: concurrent.Map[A, B]): juc.ConcurrentMap[A, B] = m match {
+  def mapAsJavaConcurrentMap[A, B](m: concurrent.Map[A, B]): juc.ConcurrentMap[A, B] = m match {
     case null                           => null
     case JConcurrentMapWrapper(wrapped) => wrapped
     case _                              => new ConcurrentMapWrapper(m)
   }
 }
-
-object WrapAsJava extends WrapAsJava

--- a/src/library/scala/collection/convert/AsScalaConverters.scala
+++ b/src/library/scala/collection/convert/AsScalaConverters.scala
@@ -11,134 +11,136 @@ package collection
 package convert
 
 import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
-import scala.language.implicitConversions
 
-@deprecatedInheritance("Use JavaConverters or consider ImplicitConversions", since="2.12")
-trait WrapAsScala {
+/** Defines converter methods from Java to Scala collections. */
+trait AsScalaConverters {
   import Wrappers._
+
   /**
-   * Implicitly converts a Java `Iterator` to a Scala `Iterator`.
+   * Converts a Java `Iterator` to a Scala `Iterator`.
    *
    * The returned Scala `Iterator` is backed by the provided Java `Iterator`
    * and any side-effects of using it via the Scala interface will be visible
    * via the Java interface and vice versa.
    *
    * If the Java `Iterator` was previously obtained from an implicit or
-   * explicit call of `asIterator(scala.collection.Iterator)` then the
+   * explicit call of `asJavaIterator(scala.collection.Iterator)` then the
    * original Scala `Iterator` will be returned.
    *
    * @param it The `Iterator` to be converted.
    * @return   A Scala `Iterator` view of the argument.
    */
-  implicit def asScalaIterator[A](it: ju.Iterator[A]): Iterator[A] = it match {
+  def asScalaIterator[A](it: ju.Iterator[A]): Iterator[A] = it match {
     case null                     => null
     case IteratorWrapper(wrapped) => wrapped
     case _                        => JIteratorWrapper(it)
   }
 
   /**
-   * Implicitly converts a Java Enumeration to a Scala Iterator.
+   * Converts a Java Enumeration to a Scala Iterator.
+   *
    * The returned Scala Iterator is backed by the provided Java
    * Enumeration and any side-effects of using it via the Scala interface will
    * be visible via the Java interface and vice versa.
    *
    * If the Java Enumeration was previously obtained from an implicit or
-   * explicit call of `enumerationAsScalaIterator(scala.collection.Iterator)`
+   * explicit call of `asJavaEnumeration(scala.collection.Iterator)`
    * then the original Scala Iterator will be returned.
    *
    * @param i The Enumeration to be converted.
    * @return A Scala Iterator view of the argument.
    */
-  implicit def enumerationAsScalaIterator[A](i: ju.Enumeration[A]): Iterator[A] = i match {
+  def enumerationAsScalaIterator[A](i: ju.Enumeration[A]): Iterator[A] = i match {
     case null                     => null
     case IteratorWrapper(wrapped) => wrapped
     case _                        => JEnumerationWrapper(i)
   }
 
   /**
-   * Implicitly converts a Java `Iterable` to a Scala `Iterable`.
+   * Converts a Java `Iterable` to a Scala `Iterable`.
    *
    * The returned Scala `Iterable` is backed by the provided Java `Iterable`
    * and any side-effects of using it via the Scala interface will be visible
    * via the Java interface and vice versa.
    *
    * If the Java `Iterable` was previously obtained from an implicit or
-   * explicit call of `iterableAsScalaIterable(scala.collection.Iterable)`
+   * explicit call of `asJavaIterable(scala.collection.Iterable)`
    * then the original Scala Iterable will be returned.
    *
    * @param i The Iterable to be converted.
    * @return A Scala Iterable view of the argument.
    */
-  implicit def iterableAsScalaIterable[A](i: jl.Iterable[A]): Iterable[A] = i match {
+  def iterableAsScalaIterable[A](i: jl.Iterable[A]): Iterable[A] = i match {
     case null                     => null
     case IterableWrapper(wrapped) => wrapped
     case _                        => JIterableWrapper(i)
   }
 
   /**
-   * Implicitly converts a Java `Collection` to an Scala `Iterable`.
+   * Converts a Java `Collection` to an Scala `Iterable`.
    *
    * If the Java `Collection` was previously obtained from an implicit or
-   * explicit call of `collectionAsScalaIterable(scala.collection.SizedIterable)`
+   * explicit call of `asJavaCollection(scala.collection.Iterable)`
    * then the original Scala `Iterable` will be returned.
    *
    * @param i The Collection to be converted.
    * @return A Scala Iterable view of the argument.
    */
-  implicit def collectionAsScalaIterable[A](i: ju.Collection[A]): Iterable[A] = i match {
+  def collectionAsScalaIterable[A](i: ju.Collection[A]): Iterable[A] = i match {
     case null                     => null
     case IterableWrapper(wrapped) => wrapped
     case _                        => JCollectionWrapper(i)
   }
 
   /**
-   * Implicitly converts a Java `List` to a Scala mutable `Buffer`.
+   * Converts a Java `List` to a Scala mutable `Buffer`.
    *
    * The returned Scala `Buffer` is backed by the provided Java `List`
    * and any side-effects of using it via the Scala interface will
    * be visible via the Java interface and vice versa.
    *
    * If the Java `List` was previously obtained from an implicit or
-   * explicit call of `asScalaBuffer(scala.collection.mutable.Buffer)`
+   * explicit call of `bufferAsJavaList(scala.collection.mutable.Buffer)`
    * then the original Scala `Buffer` will be returned.
    *
    * @param l The `List` to be converted.
    * @return A Scala mutable `Buffer` view of the argument.
    */
-  implicit def asScalaBuffer[A](l: ju.List[A]): mutable.Buffer[A] = l match {
+  def asScalaBuffer[A](l: ju.List[A]): mutable.Buffer[A] = l match {
     case null                           => null
     case MutableBufferWrapper(wrapped)  => wrapped
     case _                              => new JListWrapper(l)
   }
 
   /**
-   * Implicitly converts a Java Set to a Scala mutable Set.
+   * Converts a Java Set to a Scala mutable Set.
+   *
    * The returned Scala Set is backed by the provided Java
    * Set and any side-effects of using it via the Scala interface will
    * be visible via the Java interface and vice versa.
    *
    * If the Java Set was previously obtained from an implicit or
-   * explicit call of `asScalaSet(scala.collection.mutable.Set)` then
+   * explicit call of `mutableSetAsJavaSet(scala.collection.mutable.Set)` then
    * the original Scala Set will be returned.
    *
    * @param s The Set to be converted.
    * @return A Scala mutable Set view of the argument.
    */
-  implicit def asScalaSet[A](s: ju.Set[A]): mutable.Set[A] = s match {
+  def asScalaSet[A](s: ju.Set[A]): mutable.Set[A] = s match {
     case null                       => null
     case MutableSetWrapper(wrapped) => wrapped
     case _                          => new JSetWrapper(s)
   }
 
   /**
-   * Implicitly converts a Java `Map` to a Scala mutable `Map`.
+   * Converts a Java `Map` to a Scala mutable `Map`.
    *
    * The returned Scala `Map` is backed by the provided Java `Map` and any
    * side-effects of using it via the Scala interface will be visible via
    * the Java interface and vice versa.
    *
    * If the Java `Map` was previously obtained from an implicit or
-   * explicit call of `mapAsScalaMap(scala.collection.mutable.Map)` then
+   * explicit call of `mutableMapAsJavaMap(scala.collection.mutable.Map)` then
    * the original Scala Map will be returned.
    *
    * If the wrapped map is synchronized (e.g. from `java.util.Collections.synchronizedMap`),
@@ -150,50 +152,54 @@ trait WrapAsScala {
    * @param m The Map to be converted.
    * @return A Scala mutable Map view of the argument.
    */
-  implicit def mapAsScalaMap[A, B](m: ju.Map[A, B]): mutable.Map[A, B] = m match {
+  def mapAsScalaMap[A, B](m: ju.Map[A, B]): mutable.Map[A, B] = m match {
     case null                       => null
     case MutableMapWrapper(wrapped) => wrapped
     case _                          => new JMapWrapper(m)
   }
 
   /**
-   * Implicitly converts a Java ConcurrentMap to a Scala mutable ConcurrentMap.
+   * Converts a Java ConcurrentMap to a Scala mutable ConcurrentMap.
+   *
    * The returned Scala ConcurrentMap is backed by the provided Java
    * ConcurrentMap and any side-effects of using it via the Scala interface will
    * be visible via the Java interface and vice versa.
    *
    * If the Java ConcurrentMap was previously obtained from an implicit or
-   * explicit call of `asConcurrentMap(scala.collection.mutable.ConcurrentMap)`
+   * explicit call of `mapAsJavaConcurrentMap(scala.collection.mutable.ConcurrentMap)`
    * then the original Scala ConcurrentMap will be returned.
    *
    * @param m The ConcurrentMap to be converted.
    * @return A Scala mutable ConcurrentMap view of the argument.
    */
-  implicit def mapAsScalaConcurrentMap[A, B](m: juc.ConcurrentMap[A, B]): concurrent.Map[A, B] = m match {
+  def mapAsScalaConcurrentMap[A, B](m: juc.ConcurrentMap[A, B]): concurrent.Map[A, B] = m match {
     case null                             => null
     case cmw: ConcurrentMapWrapper[_, _]  => cmw.underlying
     case _                                => new JConcurrentMapWrapper(m)
   }
 
   /**
-   * Implicitly converts a Java `Dictionary` to a Scala mutable
-   * `Map`.
+   * Converts a Java `Dictionary` to a Scala mutable `Map`.
    *
    * The returned Scala `Map` is backed by the provided Java
    * `Dictionary` and any side-effects of using it via the Scala interface
    * will be visible via the Java interface and vice versa.
    *
+   * If the Java `Dictionary` was previously obtained from an implicit or
+   * explicit call of `asJavaDictionary(scala.collection.mutable.Map)` then the original
+   * Scala Map will be returned.
+   *
    * @param p The Dictionary to be converted.
    * @return  A Scala mutable Map view of the argument.
    */
-  implicit def dictionaryAsScalaMap[A, B](p: ju.Dictionary[A, B]): mutable.Map[A, B] = p match {
+  def dictionaryAsScalaMap[A, B](p: ju.Dictionary[A, B]): mutable.Map[A, B] = p match {
     case null                       => null
     case DictionaryWrapper(wrapped) => wrapped
     case _                          => new JDictionaryWrapper(p)
   }
 
   /**
-   * Implicitly converts a Java `Properties` to a Scala `mutable Map[String, String]`.
+   * Converts a Java `Properties` to a Scala `mutable Map[String, String]`.
    *
    * The returned Scala `Map[String, String]` is backed by the provided Java
    * `Properties` and any side-effects of using it via the Scala interface
@@ -202,10 +208,8 @@ trait WrapAsScala {
    * @param p The Properties to be converted.
    * @return  A Scala mutable Map[String, String] view of the argument.
    */
-  implicit def propertiesAsScalaMap(p: ju.Properties): mutable.Map[String, String] = p match {
+  def propertiesAsScalaMap(p: ju.Properties): mutable.Map[String, String] = p match {
     case null => null
     case _    => new JPropertiesWrapper(p)
   }
 }
-
-object WrapAsScala extends WrapAsScala

--- a/src/library/scala/collection/convert/DecorateAsJava.scala
+++ b/src/library/scala/collection/convert/DecorateAsJava.scala
@@ -12,9 +12,7 @@ package convert
 
 import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
 import Decorators._
-import WrapAsJava._
 import scala.language.implicitConversions
-
 
 /** A collection of decorators that allow converting between
  *  Scala and Java collections using `asScala` and `asJava` methods.
@@ -59,7 +57,7 @@ import scala.language.implicitConversions
  *}}}
  *  @since  2.8.1
  */
-trait DecorateAsJava {
+trait DecorateAsJava extends AsJavaConverters {
   /**
    * Adds an `asJava` method that implicitly converts a Scala `Iterator` to a
    * Java `Iterator`. The returned Java `Iterator` is backed by the provided Scala

--- a/src/library/scala/collection/convert/DecorateAsScala.scala
+++ b/src/library/scala/collection/convert/DecorateAsScala.scala
@@ -12,10 +12,9 @@ package convert
 
 import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
 import Decorators._
-import WrapAsScala._
 import scala.language.implicitConversions
 
-trait DecorateAsScala {
+trait DecorateAsScala extends AsScalaConverters {
   /**
    * Adds an `asScala` method that implicitly converts a Java `Iterator` to
    * a Scala `Iterator`.

--- a/src/library/scala/collection/convert/Decorators.scala
+++ b/src/library/scala/collection/convert/Decorators.scala
@@ -28,19 +28,19 @@ private[collection] trait Decorators {
   /** Generic class containing the `asJavaCollection` converter method */
   class AsJavaCollection[A](i: Iterable[A]) {
     /** Converts a Scala `Iterable` to a Java `Collection` */
-    def asJavaCollection: ju.Collection[A] = JavaConversions.asJavaCollection(i)
+    def asJavaCollection: ju.Collection[A] = wrapAsJava.asJavaCollection(i)
   }
 
   /** Generic class containing the `asJavaEnumeration` converter method */
   class AsJavaEnumeration[A](i: Iterator[A]) {
     /** Converts a Scala `Iterator` to a Java `Enumeration` */
-    def asJavaEnumeration: ju.Enumeration[A] = JavaConversions.asJavaEnumeration(i)
+    def asJavaEnumeration: ju.Enumeration[A] = wrapAsJava.asJavaEnumeration(i)
   }
 
   /** Generic class containing the `asJavaDictionary` converter method */
   class AsJavaDictionary[A, B](m : mutable.Map[A, B]) {
     /** Converts a Scala `Map` to a Java `Dictionary` */
-    def asJavaDictionary: ju.Dictionary[A, B] = JavaConversions.asJavaDictionary(m)
+    def asJavaDictionary: ju.Dictionary[A, B] = wrapAsJava.asJavaDictionary(m)
   }
 }
 

--- a/src/library/scala/collection/convert/ImplicitConversions.scala
+++ b/src/library/scala/collection/convert/ImplicitConversions.scala
@@ -1,0 +1,377 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2006-2016, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://www.scala-lang.org/           **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala
+package collection
+package convert
+
+import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
+import scala.language.implicitConversions
+
+import JavaConverters._
+
+/** Defines implicit converter methods from Java to Scala collections. */
+trait AsScalaImplicits {
+
+  /**
+   * Implicitly converts a Java `Iterator` to a Scala `Iterator`.
+   *
+   * The returned Scala `Iterator` is backed by the provided Java `Iterator`
+   * and any side-effects of using it via the Scala interface will be visible
+   * via the Java interface and vice versa.
+   *
+   * If the Java `Iterator` was previously obtained from an implicit or
+   * explicit call of `asIterator(scala.collection.Iterator)` then the
+   * original Scala `Iterator` will be returned.
+   *
+   * @param it The `Iterator` to be converted.
+   * @return   A Scala `Iterator` view of the argument.
+   */
+  implicit def `iterator asScala`[A](it: ju.Iterator[A]): Iterator[A] = asScalaIterator(it)
+
+  /**
+   * Implicitly converts a Java Enumeration to a Scala Iterator.
+   * The returned Scala Iterator is backed by the provided Java
+   * Enumeration and any side-effects of using it via the Scala interface will
+   * be visible via the Java interface and vice versa.
+   *
+   * If the Java Enumeration was previously obtained from an implicit or
+   * explicit call of `enumerationAsScalaIterator(scala.collection.Iterator)`
+   * then the original Scala Iterator will be returned.
+   *
+   * @param i The Enumeration to be converted.
+   * @return A Scala Iterator view of the argument.
+   */
+  implicit def `enumeration AsScalaIterator`[A](i: ju.Enumeration[A]): Iterator[A] = enumerationAsScalaIterator(i)
+
+  /**
+   * Implicitly converts a Java `Iterable` to a Scala `Iterable`.
+   *
+   * The returned Scala `Iterable` is backed by the provided Java `Iterable`
+   * and any side-effects of using it via the Scala interface will be visible
+   * via the Java interface and vice versa.
+   *
+   * If the Java `Iterable` was previously obtained from an implicit or
+   * explicit call of `iterableAsScalaIterable(scala.collection.Iterable)`
+   * then the original Scala Iterable will be returned.
+   *
+   * @param i The Iterable to be converted.
+   * @return A Scala Iterable view of the argument.
+   */
+  implicit def `iterable AsScalaIterable`[A](i: jl.Iterable[A]): Iterable[A] = iterableAsScalaIterable(i)
+
+  /**
+   * Implicitly converts a Java `Collection` to an Scala `Iterable`.
+   *
+   * If the Java `Collection` was previously obtained from an implicit or
+   * explicit call of `collectionAsScalaIterable(scala.collection.SizedIterable)`
+   * then the original Scala `Iterable` will be returned.
+   *
+   * @param i The Collection to be converted.
+   * @return A Scala Iterable view of the argument.
+   */
+  implicit def `collection AsScalaIterable`[A](i: ju.Collection[A]): Iterable[A] = collectionAsScalaIterable(i)
+
+  /**
+   * Implicitly converts a Java `List` to a Scala mutable `Buffer`.
+   *
+   * The returned Scala `Buffer` is backed by the provided Java `List`
+   * and any side-effects of using it via the Scala interface will
+   * be visible via the Java interface and vice versa.
+   *
+   * If the Java `List` was previously obtained from an implicit or
+   * explicit call of `asScalaBuffer(scala.collection.mutable.Buffer)`
+   * then the original Scala `Buffer` will be returned.
+   *
+   * @param l The `List` to be converted.
+   * @return A Scala mutable `Buffer` view of the argument.
+   */
+  implicit def `list asScalaBuffer`[A](l: ju.List[A]): mutable.Buffer[A] = asScalaBuffer(l)
+
+  /**
+   * Implicitly converts a Java Set to a Scala mutable Set.
+   * The returned Scala Set is backed by the provided Java
+   * Set and any side-effects of using it via the Scala interface will
+   * be visible via the Java interface and vice versa.
+   *
+   * If the Java Set was previously obtained from an implicit or
+   * explicit call of `asScalaSet(scala.collection.mutable.Set)` then
+   * the original Scala Set will be returned.
+   *
+   * @param s The Set to be converted.
+   * @return A Scala mutable Set view of the argument.
+   */
+  implicit def `set asScala`[A](s: ju.Set[A]): mutable.Set[A] = asScalaSet(s)
+
+  /**
+   * Implicitly converts a Java `Map` to a Scala mutable `Map`.
+   *
+   * The returned Scala `Map` is backed by the provided Java `Map` and any
+   * side-effects of using it via the Scala interface will be visible via
+   * the Java interface and vice versa.
+   *
+   * If the Java `Map` was previously obtained from an implicit or
+   * explicit call of `mapAsScalaMap(scala.collection.mutable.Map)` then
+   * the original Scala Map will be returned.
+   *
+   * If the wrapped map is synchronized (e.g. from `java.util.Collections.synchronizedMap`),
+   * it is your responsibility to wrap all
+   * non-atomic operations with `underlying.synchronized`.
+   * This includes `get`, as `java.util.Map`'s API does not allow for an
+   * atomic `get` when `null` values may be present.
+   *
+   * @param m The Map to be converted.
+   * @return A Scala mutable Map view of the argument.
+   */
+  implicit def `map AsScala`[A, B](m: ju.Map[A, B]): mutable.Map[A, B] = mapAsScalaMap(m)
+
+  /**
+   * Implicitly converts a Java ConcurrentMap to a Scala mutable ConcurrentMap.
+   * The returned Scala ConcurrentMap is backed by the provided Java
+   * ConcurrentMap and any side-effects of using it via the Scala interface will
+   * be visible via the Java interface and vice versa.
+   *
+   * If the Java ConcurrentMap was previously obtained from an implicit or
+   * explicit call of `asConcurrentMap(scala.collection.mutable.ConcurrentMap)`
+   * then the original Scala ConcurrentMap will be returned.
+   *
+   * @param m The ConcurrentMap to be converted.
+   * @return A Scala mutable ConcurrentMap view of the argument.
+   */
+  implicit def `map AsScalaConcurrentMap`[A, B](m: juc.ConcurrentMap[A, B]): concurrent.Map[A, B] = mapAsScalaConcurrentMap(m)
+
+  /**
+   * Implicitly converts a Java `Dictionary` to a Scala mutable
+   * `Map`.
+   *
+   * The returned Scala `Map` is backed by the provided Java
+   * `Dictionary` and any side-effects of using it via the Scala interface
+   * will be visible via the Java interface and vice versa.
+   *
+   * @param p The Dictionary to be converted.
+   * @return  A Scala mutable Map view of the argument.
+   */
+  implicit def `dictionary AsScalaMap`[A, B](p: ju.Dictionary[A, B]): mutable.Map[A, B] = dictionaryAsScalaMap(p)
+
+  /**
+   * Implicitly converts a Java `Properties` to a Scala `mutable Map[String, String]`.
+   *
+   * The returned Scala `Map[String, String]` is backed by the provided Java
+   * `Properties` and any side-effects of using it via the Scala interface
+   * will be visible via the Java interface and vice versa.
+   *
+   * @param p The Properties to be converted.
+   * @return  A Scala mutable Map[String, String] view of the argument.
+   */
+  implicit def `properties AsScalaMap`(p: ju.Properties): mutable.Map[String, String] = propertiesAsScalaMap(p)
+}
+
+/** Defines implicit conversions from Scala to Java collections. */
+trait AsJavaImplicits {
+
+  /**
+   * Implicitly converts a Scala Iterator to a Java Iterator.
+   * The returned Java Iterator is backed by the provided Scala
+   * Iterator and any side-effects of using it via the Java interface will
+   * be visible via the Scala interface and vice versa.
+   *
+   * If the Scala Iterator was previously obtained from an implicit or
+   * explicit call of `asIterator(java.util.Iterator)` then the original
+   * Java Iterator will be returned.
+   *
+   * @param  it The Iterator to be converted.
+   * @return    A Java Iterator view of the argument.
+   */
+  implicit def `iterator asJava`[A](it: Iterator[A]): ju.Iterator[A] = asJavaIterator(it)
+
+  /**
+   * Implicitly converts a Scala Iterator to a Java Enumeration.
+   * The returned Java Enumeration is backed by the provided Scala
+   * Iterator and any side-effects of using it via the Java interface will
+   * be visible via the Scala interface and vice versa.
+   *
+   * If the Scala Iterator was previously obtained from an implicit or
+   * explicit call of `asIterator(java.util.Enumeration)` then the
+   * original Java Enumeration will be returned.
+   *
+   * @param it The Iterator to be converted.
+   * @return   A Java Enumeration view of the argument.
+   */
+  implicit def `enumeration asJava`[A](it: Iterator[A]): ju.Enumeration[A] = asJavaEnumeration(it)
+
+  /**
+   * Implicitly converts a Scala Iterable to a Java Iterable.
+   * The returned Java Iterable is backed by the provided Scala
+   * Iterable and any side-effects of using it via the Java interface will
+   * be visible via the Scala interface and vice versa.
+   *
+   * If the Scala Iterable was previously obtained from an implicit or
+   * explicit call of `asIterable(java.lang.Iterable)` then the original
+   * Java Iterable will be returned.
+   *
+   * @param i The Iterable to be converted.
+   * @return A Java Iterable view of the argument.
+   */
+  implicit def `iterable asJava`[A](i: Iterable[A]): jl.Iterable[A] = asJavaIterable(i)
+
+  /**
+   * Implicitly converts a Scala Iterable to an immutable Java
+   * Collection.
+   *
+   * If the Scala Iterable was previously obtained from an implicit or
+   * explicit call of `asSizedIterable(java.util.Collection)` then the original
+   * Java Collection will be returned.
+   *
+   * @param it The SizedIterable to be converted.
+   * @return   A Java Collection view of the argument.
+   */
+  implicit def `collection asJava`[A](it: Iterable[A]): ju.Collection[A] = asJavaCollection(it)
+
+  /**
+   * Implicitly converts a Scala mutable Buffer to a Java List.
+   * The returned Java List is backed by the provided Scala
+   * Buffer and any side-effects of using it via the Java interface will
+   * be visible via the Scala interface and vice versa.
+   *
+   * If the Scala Buffer was previously obtained from an implicit or
+   * explicit call of `asBuffer(java.util.List)` then the original
+   * Java List will be returned.
+   *
+   * @param b The Buffer to be converted.
+   * @return A Java List view of the argument.
+   */
+  implicit def `buffer AsJavaList`[A](b: mutable.Buffer[A]): ju.List[A] = bufferAsJavaList(b)
+
+  /**
+   * Implicitly converts a Scala mutable Seq to a Java List.
+   * The returned Java List is backed by the provided Scala
+   * Seq and any side-effects of using it via the Java interface will
+   * be visible via the Scala interface and vice versa.
+   *
+   * If the Scala Seq was previously obtained from an implicit or
+   * explicit call of `asSeq(java.util.List)` then the original
+   * Java List will be returned.
+   *
+   * @param seq The Seq to be converted.
+   * @return    A Java List view of the argument.
+   */
+  implicit def `mutableSeq AsJavaList`[A](seq: mutable.Seq[A]): ju.List[A] = mutableSeqAsJavaList(seq)
+
+  /**
+   * Implicitly converts a Scala Seq to a Java List.
+   * The returned Java List is backed by the provided Scala
+   * Seq and any side-effects of using it via the Java interface will
+   * be visible via the Scala interface and vice versa.
+   *
+   * If the Scala Seq was previously obtained from an implicit or
+   * explicit call of `asSeq(java.util.List)` then the original
+   * Java List will be returned.
+   *
+   * @param seq The Seq to be converted.
+   * @return    A Java List view of the argument.
+   */
+  implicit def `seq AsJavaList`[A](seq: Seq[A]): ju.List[A] = seqAsJavaList(seq)
+
+  /**
+   * Implicitly converts a Scala mutable Set to a Java Set.
+   * The returned Java Set is backed by the provided Scala
+   * Set and any side-effects of using it via the Java interface will
+   * be visible via the Scala interface and vice versa.
+   *
+   * If the Scala Set was previously obtained from an implicit or
+   * explicit call of `asSet(java.util.Set)` then the original
+   * Java Set will be returned.
+   *
+   * @param s The Set to be converted.
+   * @return A Java Set view of the argument.
+   */
+  implicit def `mutableSet AsJavaSet`[A](s: mutable.Set[A]): ju.Set[A] = mutableSetAsJavaSet(s)
+
+  /**
+   * Implicitly converts a Scala Set to a Java Set.
+   * The returned Java Set is backed by the provided Scala
+   * Set and any side-effects of using it via the Java interface will
+   * be visible via the Scala interface and vice versa.
+   *
+   * If the Scala Set was previously obtained from an implicit or
+   * explicit call of asSet(java.util.Set) then the original
+   * Java Set will be returned.
+   *
+   * @param s The Set to be converted.
+   * @return A Java Set view of the argument.
+   */
+  implicit def `set AsJavaSet`[A](s: Set[A]): ju.Set[A] = setAsJavaSet(s)
+
+  /**
+   * Implicitly converts a Scala mutable Map to a Java Map.
+   * The returned Java Map is backed by the provided Scala
+   * Map and any side-effects of using it via the Java interface will
+   * be visible via the Scala interface and vice versa.
+   *
+   * If the Scala Map was previously obtained from an implicit or
+   * explicit call of `asMap(java.util.Map)` then the original
+   * Java Map will be returned.
+   *
+   * @param m The Map to be converted.
+   * @return A Java Map view of the argument.
+   */
+  implicit def `mutableMap AsJavaMap`[A, B](m: mutable.Map[A, B]): ju.Map[A, B] = mutableMapAsJavaMap(m)
+
+  /**
+   * Implicitly converts a Scala mutable `Map` to a Java `Dictionary`.
+   *
+   * The returned Java `Dictionary` is backed by the provided Scala
+   * `Dictionary` and any side-effects of using it via the Java interface
+   * will be visible via the Scala interface and vice versa.
+   *
+   * If the Scala `Dictionary` was previously obtained from an implicit or
+   * explicit call of `asMap(java.util.Dictionary)` then the original
+   * Java Dictionary will be returned.
+   *
+   * @param m The `Map` to be converted.
+   * @return A Java `Dictionary` view of the argument.
+   */
+  implicit def `dictionary asJava`[A, B](m: mutable.Map[A, B]): ju.Dictionary[A, B] = asJavaDictionary(m)
+
+  /**
+   * Implicitly converts a Scala `Map` to a Java `Map`.
+   *
+   * The returned Java `Map` is backed by the provided Scala `Map` and
+   * any side-effects of using it via the Java interface will be visible
+   * via the Scala interface and vice versa.
+   *
+   * If the Scala `Map` was previously obtained from an implicit or
+   * explicit call of `asMap(java.util.Map)` then the original
+   * Java `Map` will be returned.
+   *
+   * @param m The `Map` to be converted.
+   * @return A Java `Map` view of the argument.
+   */
+  implicit def `map AsJavaMap`[A, B](m: Map[A, B]): ju.Map[A, B] = mapAsJavaMap(m)
+
+  /**
+   * Implicitly converts a Scala mutable `concurrent.Map` to a Java
+   * `ConcurrentMap`.
+   *
+   * The returned Java `ConcurrentMap` is backed by the provided Scala
+   * `concurrent.Map` and any side-effects of using it via the Java interface
+   * will be visible via the Scala interface and vice versa.
+   *
+   * If the Scala `concurrent.Map` was previously obtained from an implicit or
+   * explicit call of `mapAsScalaConcurrentMap(java.util.concurrent.ConcurrentMap)`
+   * then the original Java ConcurrentMap will be returned.
+   *
+   * @param m The Scala `concurrent.Map` to be converted.
+   * @return A Java `ConcurrentMap` view of the argument.
+   */
+  implicit def `map AsJavaConcurrentMap`[A, B](m: concurrent.Map[A, B]): juc.ConcurrentMap[A, B] = mapAsJavaConcurrentMap(m)
+}
+
+/** Convenience for miscellaneous implicit conversions between Java and Scala collections API.
+ */
+object ImplicitConversions extends AsScalaImplicits with AsJavaImplicits

--- a/src/library/scala/collection/convert/WrapAsJava.scala
+++ b/src/library/scala/collection/convert/WrapAsJava.scala
@@ -13,6 +13,7 @@ package convert
 import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
 import scala.language.implicitConversions
 
+@deprecatedInheritance("Use JavaConverters", since="2.12")
 trait WrapAsJava {
   import Wrappers._
 

--- a/src/library/scala/collection/convert/WrapAsScala.scala
+++ b/src/library/scala/collection/convert/WrapAsScala.scala
@@ -13,6 +13,7 @@ package convert
 import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
 import scala.language.implicitConversions
 
+@deprecatedInheritance("Use JavaConverters", since="2.12")
 trait WrapAsScala {
   import Wrappers._
   /**

--- a/src/library/scala/collection/convert/package.scala
+++ b/src/library/scala/collection/convert/package.scala
@@ -10,10 +10,16 @@ package scala
 package collection
 
 package object convert {
+  @deprecated("Use JavaConverters", since="2.12")
   val decorateAsJava  = new DecorateAsJava { }
+  @deprecated("Use JavaConverters", since="2.12")
   val decorateAsScala = new DecorateAsScala { }
+  @deprecated("Use JavaConverters", since="2.12")
   val decorateAll     = new DecorateAsJava with DecorateAsScala { }
+  @deprecated("Use JavaConverters", since="2.12")
   val wrapAsJava      = new WrapAsJava { }
+  @deprecated("Use JavaConverters", since="2.12")
   val wrapAsScala     = new WrapAsScala { }
+  @deprecated("Use JavaConverters", since="2.12")
   val wrapAll         = new WrapAsJava with WrapAsScala { }
 }

--- a/src/library/scala/collection/package.scala
+++ b/src/library/scala/collection/package.scala
@@ -76,13 +76,9 @@ package scala
  * The concrete parallel collections also have specific performance characteristics which are
  * described in [[http://docs.scala-lang.org/overviews/parallel-collections/concrete-parallel-collections.html#performance-characteristics the parallel collections guide]]
  *
- * === Converting between Java Collections ===
+ * === Converting to and from Java Collections ===
  *
- * The [[scala.collection.JavaConversions]] object provides implicit defs that
- * will allow mostly seamless integration between APIs using Java Collections
- * and the Scala collections library.
- *
- * Alternatively the [[scala.collection.JavaConverters]] object provides a collection
+ * The [[scala.collection.JavaConverters]] object provides a collection
  * of decorators that allow converting between Scala and Java collections using `asScala`
  * and `asJava` methods.
  */

--- a/src/library/scala/sys/process/package.scala
+++ b/src/library/scala/sys/process/package.scala
@@ -203,7 +203,7 @@ package scala.sys {
   package object process extends ProcessImplicits {
     /** The arguments passed to `java` when creating this process */
     def javaVmArguments: List[String] = {
-      import scala.collection.convert.decorateAsScala._
+      import scala.collection.JavaConverters._
 
       java.lang.management.ManagementFactory.getRuntimeMXBean.getInputArguments.asScala.toList
     }

--- a/src/library/scala/sys/process/package.scala
+++ b/src/library/scala/sys/process/package.scala
@@ -203,9 +203,9 @@ package scala.sys {
   package object process extends ProcessImplicits {
     /** The arguments passed to `java` when creating this process */
     def javaVmArguments: List[String] = {
-      import scala.collection.JavaConversions._
+      import scala.collection.convert.decorateAsScala._
 
-      java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments().toList
+      java.lang.management.ManagementFactory.getRuntimeMXBean.getInputArguments.asScala.toList
     }
     /** The input stream of this process */
     def stdin  = java.lang.System.in

--- a/test/disabled/presentation/akka/src/akka/actor/ActorRegistry.scala
+++ b/test/disabled/presentation/akka/src/akka/actor/ActorRegistry.scala
@@ -342,7 +342,7 @@ class Index[K <: AnyRef, V <: AnyRef: ArrayTag] {
    * if no matches it returns None
    */
   def findValue(key: K)(f: (V) => Boolean): Option[V] = {
-    import scala.collection.JavaConversions._
+    import scala.collection.convert.wrapAsScala._
     val set = container get key
     if (set ne null) set.iterator.find(f)
     else None
@@ -352,7 +352,7 @@ class Index[K <: AnyRef, V <: AnyRef: ArrayTag] {
    * Applies the supplied function to all keys and their values
    */
   def foreach(fun: (K, V) => Unit) {
-    import scala.collection.JavaConversions._
+    import scala.collection.convert.wrapAsScala._
     container.entrySet foreach { (e) =>
       e.getValue.foreach(fun(e.getKey, _))
     }

--- a/test/disabled/presentation/akka/src/akka/actor/Scheduler.scala
+++ b/test/disabled/presentation/akka/src/akka/actor/Scheduler.scala
@@ -15,8 +15,6 @@
  */
 package akka.actor
 
-import scala.collection.JavaConversions
-
 import java.util.concurrent._
 
 import akka.event.EventHandler

--- a/test/disabled/presentation/akka/src/akka/japi/JavaAPI.scala
+++ b/test/disabled/presentation/akka/src/akka/japi/JavaAPI.scala
@@ -58,7 +58,7 @@ trait Creator[T] {
  * Java API
  */
 sealed abstract class Option[A] extends java.lang.Iterable[A] {
-  import scala.collection.JavaConversions._
+  import scala.collection.convert.wrapAsScala._
 
   def get: A
   def isEmpty: Boolean

--- a/test/disabled/presentation/akka/src/akka/routing/Iterators.scala
+++ b/test/disabled/presentation/akka/src/akka/routing/Iterators.scala
@@ -5,7 +5,7 @@
 package akka.routing
 
 import akka.actor.ActorRef
-import scala.collection.JavaConversions._
+import scala.collection.convert.wrapAsScala._
 import scala.collection.immutable.Seq
 
 /**

--- a/test/disabled/presentation/akka/src/akka/routing/Listeners.scala
+++ b/test/disabled/presentation/akka/src/akka/routing/Listeners.scala
@@ -6,7 +6,7 @@ package akka.routing
 
 import akka.actor.{ Actor, ActorRef }
 import java.util.concurrent.ConcurrentSkipListSet
-import scala.collection.JavaConversions._
+import scala.collection.convert.wrapAsScala._
 
 sealed trait ListenerMessage
 case class Listen(listener: ActorRef) extends ListenerMessage

--- a/test/files/neg/saferJavaConversions.check
+++ b/test/files/neg/saferJavaConversions.check
@@ -1,4 +1,4 @@
-saferJavaConversions.scala:13: error: type mismatch;
+saferJavaConversions.scala:14: error: type mismatch;
  found   : String("a")
  required: Foo
     val v = map.get("a")  // now this is a type error

--- a/test/files/neg/saferJavaConversions.scala
+++ b/test/files/neg/saferJavaConversions.scala
@@ -3,7 +3,8 @@ case class Foo(s: String)
 
 object Test {
   def f1 = {
-    import scala.collection.JavaConversions._
+    import scala.collection.convert.wrapAsScala._
+    import scala.collection.convert.wrapAsJava._
     val map: Map[Foo, String] = Map(Foo("a") -> "a", Foo("b") -> "b")
     val v = map.get("a")  // should be a type error, actually returns null
   }

--- a/test/files/neg/t5580b.scala
+++ b/test/files/neg/t5580b.scala
@@ -1,5 +1,5 @@
 import scala.collection.mutable.WeakHashMap
-import collection.convert.wrapAsScala._
+import scala.collection.JavaConverters._
 
 class bar { }
 

--- a/test/files/neg/t5580b.scala
+++ b/test/files/neg/t5580b.scala
@@ -1,5 +1,5 @@
 import scala.collection.mutable.WeakHashMap
-import scala.collection.JavaConversions._
+import collection.convert.wrapAsScala._
 
 class bar { }
 

--- a/test/files/neg/t9684.check
+++ b/test/files/neg/t9684.check
@@ -1,0 +1,9 @@
+t9684.scala:6: warning: object JavaConversions in package collection is deprecated: Use JavaConverters or convert.{wrapAsScala,wrapAsJava}.
+  null.asInstanceOf[java.util.List[Int]] : Buffer[Int]
+                   ^
+t9684.scala:8: warning: object JavaConversions in package collection is deprecated: Use JavaConverters or convert.{wrapAsScala,wrapAsJava}.
+  null.asInstanceOf[Iterable[Int]] : java.util.Collection[Int]
+                   ^
+error: No warnings can be incurred under -Xfatal-warnings.
+two warnings found
+one error found

--- a/test/files/neg/t9684.flags
+++ b/test/files/neg/t9684.flags
@@ -1,0 +1,1 @@
+-deprecation -Xfatal-warnings

--- a/test/files/neg/t9684.scala
+++ b/test/files/neg/t9684.scala
@@ -1,0 +1,9 @@
+
+import scala.collection.JavaConversions._
+import scala.collection.mutable.Buffer
+
+trait Test {
+  null.asInstanceOf[java.util.List[Int]] : Buffer[Int]
+
+  null.asInstanceOf[Iterable[Int]] : java.util.Collection[Int]
+}

--- a/test/files/pos/arrays2.scala
+++ b/test/files/pos/arrays2.scala
@@ -17,7 +17,7 @@ object arrays4 {
 
 // #2461
 object arrays3 {
-  import scala.collection.JavaConversions._
+  import collection.convert.wrapAsScala._
   def apply[X](xs : X*) : java.util.List[X] = java.util.Arrays.asList(xs: _*)
 }
 

--- a/test/files/pos/javaConversions-2.10-ambiguity.scala
+++ b/test/files/pos/javaConversions-2.10-ambiguity.scala
@@ -1,5 +1,5 @@
-import collection.{JavaConversions, mutable, concurrent}
-import JavaConversions._
+import collection.{mutable, concurrent}
+import collection.convert.wrapAsScala._
 import java.util.concurrent.{ConcurrentHashMap => CHM}
 
 object Bar {

--- a/test/files/pos/javaConversions-2.10-regression.scala
+++ b/test/files/pos/javaConversions-2.10-regression.scala
@@ -1,5 +1,5 @@
-import collection.{JavaConversions, mutable, concurrent}
-import JavaConversions._
+import collection.{convert, mutable, concurrent}
+import convert.wrapAsScala._
 import java.util.concurrent.{ConcurrentHashMap => CHM}
 
 object Foo {

--- a/test/files/pos/t2293.scala
+++ b/test/files/pos/t2293.scala
@@ -1,4 +1,4 @@
-import scala.collection.JavaConversions._
+import scala.collection.convert.wrapAsJava._
 
 object Test {
   val m: java.util.Map[String,String] = collection.mutable.Map("1"->"2")

--- a/test/files/pos/t2956/t2956.scala
+++ b/test/files/pos/t2956/t2956.scala
@@ -1,4 +1,4 @@
-import scala.collection.JavaConversions._
+import scala.collection.convert.wrapAsScala._
 
 class Outer {
   protected class Inner extends BeanDefinitionVisitor {

--- a/test/files/pos/t3688.scala
+++ b/test/files/pos/t3688.scala
@@ -1,5 +1,5 @@
 import collection.mutable
-import collection.JavaConversions._
+import collection.convert.wrapAsJava._
 import java.{util => ju}
 
 object Test {

--- a/test/files/presentation/ide-bug-1000531/src/CrashOnLoad.scala
+++ b/test/files/presentation/ide-bug-1000531/src/CrashOnLoad.scala
@@ -1,6 +1,6 @@
 /** When this files is opened within the IDE, a typing error is reported. */
 class A[B] extends TestIterable[B] {
-  import scala.collection.JavaConversions._
+  import collection.convert.wrapAsScala._
   def iterator: other.TestIterator[Nothing] = ???
 
   iterator./*!*/

--- a/test/files/run/concurrent-map-conversions.scala
+++ b/test/files/run/concurrent-map-conversions.scala
@@ -1,14 +1,5 @@
 
-
-
-
-
-object Test {
-
-  def main(args: Array[String]) {
-    testConversions()
-    testConverters()
-  }
+object Test extends App {
 
   def needPackageConcurrentMap(map: collection.concurrent.Map[Int, Int]) {
   }
@@ -16,7 +7,8 @@ object Test {
   }
 
   def testConversions() {
-    import collection.JavaConversions._
+    import collection.convert.wrapAsScala._
+    import collection.convert.wrapAsJava._
     val skiplist = new java.util.concurrent.ConcurrentSkipListMap[Int, Int]
     val ctrie = new collection.concurrent.TrieMap[Int, Int]
 
@@ -33,4 +25,6 @@ object Test {
     needJavaConcurrent(ctrie.asJava)
   }
 
+  testConversions()
+  testConverters()
 }

--- a/test/files/run/map_java_conversions.scala
+++ b/test/files/run/map_java_conversions.scala
@@ -1,12 +1,8 @@
 
-
-
-
-
 object Test {
 
   def main(args: Array[String]) {
-    import collection.JavaConversions._
+    import collection.convert.wrapAsScala._
 
     test(new java.util.HashMap[String, String])
     test(new java.util.Properties)
@@ -14,7 +10,7 @@ object Test {
   }
 
   def testConcMap {
-    import collection.JavaConversions._
+    import collection.convert.wrapAsScala._
 
     val concMap = new java.util.concurrent.ConcurrentHashMap[String, String]
 

--- a/test/files/run/t2250.scala
+++ b/test/files/run/t2250.scala
@@ -6,7 +6,7 @@ object Test {
 
     // we'll say rather unlikely a.sameElements(b) unless
     // they are pointing to the same array
-    import scala.collection.JavaConversions._
+    import scala.collection.convert.wrapAsScala._
     assert(a sameElements b)
   }
 }

--- a/test/files/run/t2813.2.scala
+++ b/test/files/run/t2813.2.scala
@@ -1,5 +1,6 @@
 import java.util.LinkedList
-import collection.JavaConversions._
+import collection.convert.wrapAsScala._
+import collection.convert.wrapAsJava._
 
 object Test extends App {
   def assertListEquals[A](expected: List[A], actual: Seq[A]) {

--- a/test/files/run/t5880.scala
+++ b/test/files/run/t5880.scala
@@ -1,8 +1,5 @@
 
-
-import scala.collection.JavaConversions._
-
-
+import scala.collection.convert.wrapAsJava._
 
 object Test {
 

--- a/test/files/run/t7269.scala
+++ b/test/files/run/t7269.scala
@@ -1,4 +1,4 @@
-import scala.collection.JavaConversions._
+import scala.collection.convert.wrapAsScala._
 import scala.collection.mutable
 
 object Test extends App {

--- a/test/junit/scala/collection/convert/NullSafetyTest.scala
+++ b/test/junit/scala/collection/convert/NullSafetyTest.scala
@@ -7,7 +7,8 @@ import org.junit.Test
 import org.junit.experimental.runners.Enclosed
 import org.junit.runner.RunWith
 
-import scala.collection.JavaConversions._
+import collection.convert.wrapAsScala._
+import collection.convert.wrapAsJava._
 import scala.collection.JavaConverters._
 import scala.collection.{mutable, concurrent}
 


### PR DESCRIPTION
Recommend JavaConverters and migrate usages to `wrapAsJava`
and `wrapAsScala`.
