### PR TITLE
Fix typo in the docs for the ++ method of Stream

### DIFF
--- a/src/library/scala/collection/immutable/Stream.scala
+++ b/src/library/scala/collection/immutable/Stream.scala
@@ -357,7 +357,7 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
    * `List(BigInt(12)) ++ fibs`.
    *
    * @tparam B The element type of the returned collection.'''That'''
-   * @param that The [[scala.collection.GenTraversableOnce]] the be concatenated
+   * @param that The [[scala.collection.GenTraversableOnce]] to be concatenated
    * to this `Stream`.
    * @return A new collection containing the result of concatenating `this` with
    * `that`.


### PR DESCRIPTION
Fixes a typo in the scala docs for `Stream.++`, more precisely in the docs for the param `that`:

> @param that The [[scala.collection.GenTraversableOnce]] **the** be concatenated to this `Stream`.

changed to

> @param that The [[scala.collection.GenTraversableOnce]] **to** be concatenated to this `Stream`.
