### PR TITLE
Minor fixes to Scaladoc

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/HtmlFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/HtmlFactory.scala
@@ -33,6 +33,7 @@ class HtmlFactory(val universe: doc.Universe, val reporter: ScalaDocReporter) {
     "class_comp.svg",
     "object_comp.svg",
     "trait_comp.svg",
+    "object_comp_trait.svg",
     "abstract_type.svg",
     "lato-v11-latin-100.eot",
     "lato-v11-latin-100.ttf",

--- a/src/scaladoc/scala/tools/nsc/doc/html/HtmlPage.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/HtmlPage.scala
@@ -216,40 +216,15 @@ abstract class HtmlPage extends Page { thisPage =>
     val Trait, Class, Type, Object, Package = Value
   }
 
-  /** Returns the _big image name and the alt attribute
-   *  corresponding to the DocTemplate Entity (upper left icon) */
-  def docEntityKindToBigImage(ety: DocTemplateEntity) = {
-    def entityToImage(e: DocTemplateEntity) =
-      if (e.isTrait)                              Image.Trait
-      else if (e.isClass)                         Image.Class
-      else if (e.isAbstractType || e.isAliasType) Image.Type
-      else if (e.isObject)                        Image.Object
-      else if (e.isPackage)                       Image.Package
-      else {
-        // FIXME: an entity *should* fall into one of the above categories,
-        // but AnyRef is somehow not
-        Image.Class
-      }
-
-    val image = entityToImage(ety)
-    val companionImage = ety.companion filter {
-      e => e.visibility.isPublic && ! e.inSource.isEmpty
-    } map { entityToImage }
-
-    (image, companionImage) match {
-      case (from, Some(to)) =>
-        ((from + "_to_" + to + "_big.png").toLowerCase, from + "/" + to)
-      case (from, None) =>
-        ((from + "_big.png").toLowerCase, from.toString)
-    }
-  }
-
   def permalink(template: Entity, isSelf: Boolean = true): Elem =
     <span class="permalink">
       <a href={ memberToUrl(template, isSelf) } title="Permalink">
         <i class="material-icons">&#xE157;</i>
       </a>
     </span>
+
+  def docEntityImageClass(tpl: DocTemplateEntity): String =
+    tpl.kind + tpl.companion.fold("")("-companion-" + _.kind)
 
   def docEntityKindToCompanionTitle(ety: DocTemplateEntity, baseString: String = "See companion") =
     ety.companion match{

--- a/src/scaladoc/scala/tools/nsc/doc/html/Page.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/Page.scala
@@ -102,6 +102,11 @@ abstract class Page {
     relativize(thisPage.path.reverse, destPath.reverse).mkString("/")
   }
 
+  def hasCompanion(mbr: TemplateEntity): Boolean = mbr match {
+    case dtpl: DocTemplateEntity => dtpl.companion.isDefined
+    case _ => false
+  }
+
   protected def inlineToStr(inl: comment.Inline): String = inl match {
     case comment.Chain(items) => items flatMap (inlineToStr(_)) mkString ""
     case comment.Italic(in) => inlineToStr(in)

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -216,14 +216,13 @@ trait EntityPage extends HtmlPage {
     <body class={ tpl.kind + (if (tpl.isType) " type" else " value") }>
       <div id="definition">
         {
-          val (src, alt) = docEntityKindToBigImage(tpl)
-          val identifier = alt.toString.substring(0,2).toLowerCase
+          val imageClass = docEntityImageClass(tpl)
 
           tpl.companion match {
             case Some(companion) if (companion.visibility.isPublic && companion.inSource != None) =>
-              <a href={relativeLinkTo(companion)} title={docEntityKindToCompanionTitle(tpl)}><div class={s"big-circle companion $identifier"}>{ identifier.substring(0,1) }</div></a>
+              <a href={relativeLinkTo(companion)} title={docEntityKindToCompanionTitle(tpl)}><div class={s"big-circle $imageClass"}>{ imageClass.substring(0,1) }</div></a>
             case _ =>
-              <div class={ "big-circle " + alt.toString.toLowerCase }>{ identifier.substring(0,1) }</div>
+              <div class={s"big-circle $imageClass"}>{ imageClass.substring(0,1) }</div>
           }
         }
         { owner }

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -79,21 +79,24 @@ trait EntityPage extends HtmlPage {
               <ul>
                 {
                   def entityToUl(mbr: TemplateEntity with MemberEntity, indentation: Int): NodeSeq =
-                    <li class={"current-entities indented" + indentation}>
-                      {
-                        mbr match {
-                          case dtpl: DocTemplateEntity =>
-                            dtpl.companion.fold(<span class="separator"></span>) { c: DocTemplateEntity =>
-                              <a class="object" href={relativeLinkTo(c)} title={c.comment.fold("")(com => inlineToStr(com.short))}></a>
-                            }
-                          case _ => <span class="separator"></span>
+                    if (mbr.isObject && hasCompanion(mbr))
+                      NodeSeq.Empty
+                    else
+                      <li class={"current-entities indented" + indentation}>
+                        {
+                          mbr match {
+                            case dtpl: DocTemplateEntity =>
+                              dtpl.companion.fold(<span class="separator"></span>) { c: DocTemplateEntity =>
+                                <a class="object" href={relativeLinkTo(c)} title={c.comment.fold("")(com => inlineToStr(com.short))}></a>
+                              }
+                            case _ => <span class="separator"></span>
+                          }
                         }
-                      }
-                      <a class={mbr.kind} href={relativeLinkTo(mbr)} title={mbr.comment.fold("")(com => inlineToStr(com.short))}></a>
-                      <a href={relativeLinkTo(mbr)} title={mbr.comment.fold("")(com => inlineToStr(com.short))}>
-                        {mbr.name}
-                      </a>
-                    </li>
+                        <a class={mbr.kind} href={relativeLinkTo(mbr)} title={mbr.comment.fold("")(com => inlineToStr(com.short))}></a>
+                        <a href={relativeLinkTo(mbr)} title={mbr.comment.fold("")(com => inlineToStr(com.short))}>
+                          {mbr.name}
+                        </a>
+                      </li>
 
                   // Get path from root
                   val rootToParentLis = tpl.toRoot
@@ -123,7 +126,7 @@ trait EntityPage extends HtmlPage {
                   val subsToTplLis    = subsToTpl.map(memberToHtml(_, tpl, indentation = rootToParentLis.length))
                   val subsAfterTplLis = subsAfterTpl.map(memberToHtml(_, tpl, indentation = rootToParentLis.length))
                   val currEntityLis   = currentPackageTpls
-                    .filter(x => !x.isPackage && (x.isTrait || x.isClass || x.isAbstractType))
+                    .filter(x => !x.isPackage && (x.isTrait || x.isClass || x.isAbstractType || x.isObject))
                     .sortBy(_.name)
                     .map(entityToUl(_, (if (tpl.isPackage) 0 else -1) + rootToParentLis.length))
                   val currSubLis = tpl.templates

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.js
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.js
@@ -506,7 +506,7 @@ function listItem(entity, regExp) {
     } else {
         var spacer = document.createElement("div");
         spacer.className = "icon spacer";
-        li.appendChild(spacer);
+        li.insertBefore(spacer, iconElem);
     }
 
     var ul = document.createElement("ul");

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/object_comp_trait.svg
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/object_comp_trait.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="72px" height="72px" viewBox="0 0 72 72" version="1.1">
+  <defs>
+    <filter x="-50%" y="-50%" width="200%" height="200%" filterUnits="objectBoundingBox" id="filter-1">
+      <feOffset dx="0" dy="4" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feGaussianBlur stdDeviation="2" in="shadowOffsetOuter1" result="shadowBlurOuter1"/>
+      <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.14 0" in="shadowBlurOuter1" type="matrix" result="shadowMatrixOuter1"/>
+      <feMerge>
+        <feMergeNode in="shadowMatrixOuter1"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <circle id="path-2" cx="32" cy="32" r="32"/>
+    <filter x="-50%" y="-50%" width="200%" height="200%" filterUnits="objectBoundingBox" id="filter-4">
+      <feOffset dx="0" dy="4" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feGaussianBlur stdDeviation="2" in="shadowOffsetOuter1" result="shadowBlurOuter1"/>
+      <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.14 0" in="shadowBlurOuter1" type="matrix" result="shadowMatrixOuter1"/>
+      <feOffset dx="0" dy="1" in="SourceAlpha" result="shadowOffsetInner1"/>
+      <feGaussianBlur stdDeviation="0" in="shadowOffsetInner1" result="shadowBlurInner1"/>
+      <feComposite in="shadowBlurInner1" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner1"/>
+      <feColorMatrix values="0 0 0 0 1   0 0 0 0 1   0 0 0 0 1  0 0 0 0.14 0" in="shadowInnerInner1" type="matrix" result="shadowMatrixInner1"/>
+      <feOffset dx="0" dy="-1" in="SourceAlpha" result="shadowOffsetInner2"/>
+      <feGaussianBlur stdDeviation="0" in="shadowOffsetInner2" result="shadowBlurInner2"/>
+      <feComposite in="shadowBlurInner2" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner2"/>
+      <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.14 0" in="shadowInnerInner2" type="matrix" result="shadowMatrixInner2"/>
+      <feMerge>
+        <feMergeNode in="shadowMatrixOuter1"/>
+        <feMergeNode in="SourceGraphic"/>
+        <feMergeNode in="shadowMatrixInner1"/>
+        <feMergeNode in="shadowMatrixInner2"/>
+      </feMerge>
+    </filter>
+    <path id="path-5" d="M32 61C49.673112 61 64 48.0162577 64 32 64 15.9837423 49.673112 3 32 3 14.326888 3 0 15.9837423 0 32 0 48.0162577 14.326888 61 32 61Z"/>
+  </defs>
+  <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g id="Artboard-1" transform="translate(-298.000000, -91.000000)">
+      <g id="BG" transform="translate(302.000000, 91.000000)">
+        <g id="Icon">
+          <mask id="mask-3" fill="white">
+            <use xlink:href="#path-2"/>
+          </mask>
+          <use id="Mask" fill="#19AACF" filter="url(#filter-1)" xlink:href="#path-2"/>
+          <rect id="Rectangle-2" opacity="0.3" fill="#000000" mask="url(#mask-3)" x="-8" y="33" width="80" height="31"/>
+          <mask id="mask-6" fill="white">
+            <use xlink:href="#path-5"/>
+          </mask>
+          <use id="Mask" fill="#2C6C8D" filter="url(#filter-4)" xlink:href="#path-5"/>
+          <text id="t" mask="url(#mask-6)" font-family="Open Sans, Helvetica Neueu, Sans-serif" font-size="40" font-weight="normal" fill="#FFFFFF">
+            <tspan x="17" y="47">
+              O
+            </tspan>
+          </text>
+          <rect id="Rectangle-2" opacity="0.190065299" fill="#000000" mask="url(#mask-6)" x="-8" y="2" width="80" height="31"/>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.css
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.css
@@ -216,16 +216,20 @@ span.symbol > a {
   background: url("class.svg") no-repeat center;
 }
 
-.big-circle.cl.companion {
+.big-circle.class-companion-object {
   background: url("class_comp.svg") no-repeat center;
 }
 
-.big-circle.ob.companion {
+.big-circle.object-companion-class {
   background: url("object_comp.svg") no-repeat center;
 }
 
-.big-circle.tr.companion {
+.big-circle.trait-companion-object {
   background: url("trait_comp.svg") no-repeat center;
+}
+
+.big-circle.object-companion-trait {
+  background: url("object_comp_trait.svg") no-repeat center;
 }
 
 .big-circle.object {

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.js
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.js
@@ -275,8 +275,13 @@ $(document).ready(function() {
       }
     };
 
-    $(".toggleContainer:not(.diagram-container)").click(function() {
+    $(".toggleContainer:not(.diagram-container):not(.full-signature-block)").click(function() {
       toggleShowContentFct($(this));
+    });
+
+    $(".toggleContainer.full-signature-block").click(function() {
+      toggleShowContentFct($(this));
+      return false;
     });
 
     if ($("#order > ol > li.group").length == 1) { orderGroup(); };


### PR DESCRIPTION
This PR contain small fixes for some minor annoyances listed in https://github.com/scala/scala-dev/issues/84. Including:
- Fix sidebar not displaying objects which are without companion trait/class
- Fix inconsistencies in icon elements in search (see: http://imgur.com/a/c1uyX)
- Fix incorrect icon being displayed for objects with companion traits (they were being shown as objects with companion classes)

preview: https://dl.dropboxusercontent.com/u/358427/scaladoc-minor-fixes/index.html
review: @VladUreche 

Since github now allows squashing by the merging party - I'm not going to squash the history. All branches should build anyhow. See: https://github.com/blog/2141-squash-your-commits for details

PS: my uplink is incredibly slow here in the apt, ~~dropbox says 20 minutes until all files are in the cloud~~ done :)
