### PR TITLE
WIP^2: Remove repl import wrappers

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1195,7 +1195,8 @@ trait Contexts { self: Analyzer =>
     }
     override final def imports      = impInfo :: super.imports
     override final def firstImport  = Some(impInfo)
-    override final def isRootImport = !tree.pos.isDefined
+    override final val isRootImport = !tree.pos.isDefined || (
+      tree.symbol != NoSymbol && tree.symbol == definitions.Interpreter_iw)
     override final def toString     = super.toString + " with " + s"ImportContext { $impInfo; outer.owner = ${outer.owner} }"
   }
 

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1195,7 +1195,8 @@ trait Contexts { self: Analyzer =>
     }
     override final def imports      = impInfo :: super.imports
     override final def firstImport  = Some(impInfo)
-    override final val isRootImport = !tree.pos.isDefined || (
+    // must be a def for bootstrapping -- TODO: why?
+    override final def isRootImport = !tree.pos.isDefined || (
       tree.symbol != NoSymbol && tree.symbol == definitions.Interpreter_iw)
     override final def toString     = super.toString + " with " + s"ImportContext { $impInfo; outer.owner = ${outer.owner} }"
   }

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -550,7 +550,7 @@ trait Namers extends MethodSynthesis {
             defSym andAlso (typer.permanentlyHiddenWarning(pos, to0, _))
           }
         }
-        if (!tree.symbol.isSynthetic && expr.symbol != null && !expr.symbol.isInterpreterWrapper) {
+        if (!tree.symbol.isSynthetic && expr.symbol != null) {
           if (base.member(from) != NoSymbol)
             check(to0)
           if (base.member(from.toTypeName) != NoSymbol)

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -523,6 +523,8 @@ trait Definitions extends api.StandardDefinitions {
          def MacroContextTreeType         = BlackboxContextClass.map(sym => getTypeMember(sym, tpnme.Tree))
     lazy val MacroImplAnnotation          = requiredClass[scala.reflect.macros.internal.macroImpl]
 
+    lazy val Interpreter_iw               = getClassIfDefined("scala.tools.nsc.interpreter.$iw")
+
     lazy val StringContextClass           = requiredClass[scala.StringContext]
 
     // SI-8392 a reflection universe on classpath may not have

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -319,7 +319,6 @@ trait StdNames {
     val EXCEPTION_RESULT_PREFIX        = "exceptionResult"
     val EXPAND_SEPARATOR_STRING        = "$$"
     val FRESH_TERM_NAME_PREFIX         = "x$"
-    val INTERPRETER_IMPORT_WRAPPER     = "$iw"
     val LOCALDUMMY_PREFIX              = "<local "       // owner of local blocks
     val PROTECTED_PREFIX               = "protected$"
     val PROTECTED_SET_PREFIX           = PROTECTED_PREFIX + "set"
@@ -379,7 +378,6 @@ trait StdNames {
     def isLocalName(name: Name)             = name endsWith LOCAL_SUFFIX_STRING
     def isLoopHeaderLabel(name: Name)       = (name startsWith WHILE_PREFIX) || (name startsWith DO_WHILE_PREFIX)
     def isProtectedAccessorName(name: Name) = name startsWith PROTECTED_PREFIX
-    def isReplWrapperName(name: Name)       = name containsName INTERPRETER_IMPORT_WRAPPER
     def isSetterName(name: Name)            = name endsWith SETTER_SUFFIX
     def isTraitSetterName(name: Name)       = isSetterName(name) && (name containsName TRAIT_SETTER_SEPARATOR_STRING)
     def isSingletonName(name: Name)         = name endsWith SINGLETON_SUFFIX

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -665,12 +665,6 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     final def isLazyAccessor       = isLazy && lazyAccessor != NoSymbol
     final def isOverridableMember  = !(isClass || isEffectivelyFinal) && safeOwner.isClass
 
-    /** Does this symbol denote a wrapper created by the repl? */
-    final def isInterpreterWrapper = (
-         (this hasFlag MODULE)
-      && isTopLevel
-      && nme.isReplWrapperName(name)
-    )
 
     /** In our current architecture, symbols for top-level classes and modules
      *  are created as dummies. Package symbols just call newClass(name) or newModule(name) and
@@ -852,7 +846,6 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def isEmptyPrefix = (
          isEffectiveRoot                      // has no prefix for real, <empty> or <root>
       || isAnonOrRefinementClass              // has uninteresting <anon> or <refinement> prefix
-      || nme.isReplWrapperName(name)          // has ugly $iw. prefix (doesn't call isInterpreterWrapper due to nesting)
     )
     def isFBounded = info match {
       case TypeBounds(_, _) => info.baseTypeSeq exists (_ contains this)

--- a/src/repl/scala/tools/nsc/interpreter/$iw.scala
+++ b/src/repl/scala/tools/nsc/interpreter/$iw.scala
@@ -1,0 +1,9 @@
+package scala.tools.nsc.interpreter
+
+// The REPL adds a magic import of "import scala.tools.nsc.interpreter.$iw"
+// to increase the effective nesting level of the typechecker.
+//
+// `foo` will bind to `baz.foo` in this example:
+//
+// { import bar.foo; import interpreseter.$iw; import baz.foo; foo }
+class $iw

--- a/src/repl/scala/tools/nsc/interpreter/Imports.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Imports.scala
@@ -27,34 +27,12 @@ trait Imports {
   }
 
   /** Symbols whose contents are language-defined to be imported. */
-  def languageWildcardSyms: List[Symbol] = List(JavaLangPackage, ScalaPackage, PredefModule)
+  private def languageWildcardSyms: List[Symbol] = List(JavaLangPackage, ScalaPackage, PredefModule)
   def languageWildcardHandlers = languageWildcardSyms map makeWildcardImportHandler
-
-  def allImportedNames = importHandlers flatMap (_.importedNames)
-
-  /** Types which have been wildcard imported, such as:
-   *    val x = "abc" ; import x._  // type java.lang.String
-   *    import java.lang.String._   // object java.lang.String
-   *
-   *  Used by tab completion.
-   *
-   *  XXX right now this gets import x._ and import java.lang.String._,
-   *  but doesn't figure out import String._.  There's a lot of ad hoc
-   *  scope twiddling which should be swept away in favor of digging
-   *  into the compiler scopes.
-   */
-  def sessionWildcards: List[Type] = {
-    importHandlers filter (_.importsWildcard) map (_.targetType) distinct
-  }
-
-  def languageSymbols        = languageWildcardSyms flatMap membersAtPickler
-  def sessionImportedSymbols = importHandlers flatMap (_.importedSymbols)
-  def importedSymbols        = languageSymbols ++ sessionImportedSymbols
-  def importedTermSymbols    = importedSymbols collect { case x: TermSymbol => x }
 
   /** Tuples of (source, imported symbols) in the order they were imported.
    */
-  def importedSymbolsBySource: List[(Symbol, List[Symbol])] = {
+  private def importedSymbolsBySource: List[(Symbol, List[Symbol])] = {
     val lang    = languageWildcardSyms map (sym => (sym, membersAtPickler(sym)))
     val session = importHandlers filter (_.targetType != NoType) map { mh =>
       (mh.targetType.typeSymbol, mh.importedSymbols)

--- a/src/repl/scala/tools/nsc/interpreter/PresentationCompilerCompleter.scala
+++ b/src/repl/scala/tools/nsc/interpreter/PresentationCompilerCompleter.scala
@@ -76,8 +76,7 @@ class PresentationCompilerCompleter(intp: IMain) extends Completion {
               case _ => false
             }
             (
-                 isUniversal && nme.isReplWrapperName(m.prefix.typeSymbol.name)
-              || isUniversal && tabCount == 0 && r.name.isEmpty
+              isUniversal && tabCount == 0 && r.name.isEmpty
               || viaUniversalExtensionMethod && tabCount == 0 && r.name.isEmpty
             )
           }


### PR DESCRIPTION
@retronym figured out a much nicer way to enforce proper scoping in the repl, which removes some of the wrapping we need to do.

This would be nice to have for M5, but no show stopper.

I'm throwing this PR out there because I don't have time to work on this right now, but I think this would make for a nice improvement. Would be grateful if someone could pick this up.
