### PR TITLE
SI-9734 Narrow type when import REPL history

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/Imports.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Imports.scala
@@ -183,7 +183,7 @@ trait Imports {
                   case _ =>
                     val valName = req.lineRep.packageName + req.lineRep.readName
                     if (!tempValLines.contains(req.lineRep.lineId)) {
-                      code.append(s"val $valName = $objName\n")
+                      code.append(s"val $valName: ${objName}.type = $objName\n")
                       tempValLines += req.lineRep.lineId
                     }
                     code.append(s"import $valName${req.accessPath}.`$imv`;\n")

--- a/test/files/run/repl-paste-6.check
+++ b/test/files/run/repl-paste-6.check
@@ -1,0 +1,17 @@
+
+scala> :paste < EOF
+// Entering paste mode (EOF to finish)
+
+case class C(i: Int)
+val c = C(42)
+EOF
+
+// Exiting paste mode, now interpreting.
+
+defined class C
+c: C = C(42)
+
+scala> val d: C = c // shew
+d: C = C(42)
+
+scala> :quit

--- a/test/files/run/repl-paste-6.scala
+++ b/test/files/run/repl-paste-6.scala
@@ -1,0 +1,23 @@
+
+import scala.tools.partest.ReplTest
+import scala.tools.nsc.Settings
+
+
+/*
+ * Add // show to witness:
+ *     val $line3$read: $line3.$read.INSTANCE.type = $line3.$read.INSTANCE;
+ */
+object Test extends ReplTest {
+  override def transformSettings(settings: Settings): Settings = {
+    settings.Yreplclassbased.value = true
+    settings
+  }
+  def code = 
+    """
+:paste < EOF
+case class C(i: Int)
+val c = C(42)
+EOF
+val d: C = c // shew
+    """
+}


### PR DESCRIPTION
Under `-Yrepl-class-based`, imports from historical `$read`
instances must be singleton-typed so that path-dependent types
remain so.
