### PR TITLE
SI-9735 REPL prefer standard escapes for code text

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/ReplStrings.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplStrings.scala
@@ -11,13 +11,21 @@ import scala.reflect.internal.Chars
 trait ReplStrings {
   /** Convert a string into code that can recreate the string.
    *  This requires replacing all special characters by escape
-   *  codes. It does not add the surrounding " marks.  */
+   *  codes. It does not add the surrounding " marks.
+   */
   def string2code(str: String): String = {
     val res = new StringBuilder
     for (c <- str) c match {
-      case '"' | '\'' | '\\'  => res += '\\' ; res += c
-      case _ if c.isControl   => res ++= Chars.char2uescape(c)
-      case _                  => res += c
+      case '"'  => res ++= """\""""
+      case '\'' => res ++= """\'"""
+      case '\\' => res ++= """\\"""
+      case '\b' => res ++= """\b"""
+      case '\t' => res ++= """\t"""
+      case '\n' => res ++= """\n"""
+      case '\f' => res ++= """\f"""
+      case '\r' => res ++= """\r"""
+      case _ if c.isControl => res ++= Chars.char2uescape(c)
+      case _    => res += c
     }
     res.toString
   }

--- a/test/files/run/repl-no-uescape.check
+++ b/test/files/run/repl-no-uescape.check
@@ -1,0 +1,5 @@
+
+scala> object A
+defined object A
+
+scala> :quit

--- a/test/files/run/repl-no-uescape.scala
+++ b/test/files/run/repl-no-uescape.scala
@@ -1,0 +1,31 @@
+import scala.tools.partest.ReplTest
+import scala.tools.nsc.Settings
+
+/*
+scala> object A
+<console>:10: error: invalid escape character
++ "defined object " + "A" + "\u000A"
+
+Under -Dscala.color=true control chars are common
+  $eval.this.$print = {
+    $line2.$read.$iw.$iw;
+    "\033[1m\033[34mres1\033[0m: \033[1m\033[32mInt\033[0m = ".+(scala.runtime.ScalaRunTime.replStringOf($line2.$read.$iw.$iw.res1, 1000))
+  };
+
+$ skala -Dscala.color=true -Xno-uescape
+Welcome to Scala 2.11.9-20160323-163638-1fcfdd8c8b (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_60).
+Type in expressions for evaluation. Or try :help.
+
+scala> 42
+<console>:10: error: invalid escape character
+ + "\u001B[1m\u001B[34mres0\u001B[0m: \u001B[1m\u001B[32mInt\u001B[0m = " + scala.runtime.ScalaRunTime.replStringOf(res0, 1000)
+ */
+object Test extends ReplTest {
+  override def transformSettings(settings: Settings): Settings = {
+    settings.nouescape.value = true
+    settings
+  }
+  def code = """
+object A
+  """
+}


### PR DESCRIPTION
When constructing code text for compilation, the REPL
should prefer standard escape sequences, in case unicode
escapes are disabled.
