### PR TITLE
Automate Eclipse settings and update project files:

### DIFF
--- a/src/eclipse/README.md
+++ b/src/eclipse/README.md
@@ -7,21 +7,20 @@ The following points describe how to build Scala using Eclipse.
 
 0. Download the [Scala IDE bundle](http://scala-ide.org/download/sdk.html). It comes preconfigured for optimal performance.
 
-0. Run `ant init` to download some necessary jars.
+0. Run `ant build` to download some necessary jars and see a successful build.
 
-0. Import the project (in `src/eclipse`) via `File` → `Import Existing Projects` and navigate to `scala/src/eclipse`. Check all projects and click ok.
-
-0. You need to define a `path variable` inside Eclipse. Define `SCALA_BASEDIR` in
-`Preferences/General/Workspace/Linked Resources`. The value should be the absolute
-path to your Scala checkout. All paths in the project files are relative to this one,
-so nothing will work before you do so.
-
-  The same `SCALA_BASEDIR` variable needs to be defined as a `classpath variable` in
+0. You need to define a `path variable` and a `classpath variable` inside Eclipse, both pointing to the Scala checkout directory:
+  - (experimental): run `./update-workspace.sh scala_checkout_dir [workspace_dir]`. This should update your workspace settings
+ (restart Eclipse if it was running). For example:
+ ```
+ ./update-workspace.sh $HOME/git/scala ~/Documents/workspace-scalac
+ ```
+  - If the above didn't work, you can perform these steps manually: Define `SCALA_BASEDIR` in `Preferences/General/Workspace/Linked Resources`. The value should be the absolute
+path to your Scala checkout. All paths in the project files are relative to this one, so nothing will work before you do so.
+The same `SCALA_BASEDIR` variable needs to be defined **also** as a `classpath variable` in
 `Java/Build Path/Classpath Variables`.
 
-  Additionally, we start using Maven dependencies (e.g. `JUnit`) so you need to define another
-`classpath variable` inside Eclipse. Define `M2_REPO` in `Java/Build Path/Classpath Variables`
-to point to your local Maven repository (e.g. `$HOME/.m2/repository`).
+0. Import the project (in `src/eclipse`) via `File` → `Import Existing Projects` and navigate to `scala/src/eclipse`. Check all projects and click ok.
 
   Lastly, the JRE used by Eclipse needs to know the path to the `JLine` library, which is used by the REPL.
 To set the JAR file, navigate to `Java/Installed JREs`, select the default JRE, press `Edit/Add External JARs...`

--- a/src/eclipse/interactive/.classpath
+++ b/src/eclipse/interactive/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="interactive"/>
-	<classpathentry kind="var" path="M2_REPO/org/scala-lang/modules/scala-asm/5.0.4-scala-3/scala-asm-5.0.4-scala-3.jar"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/asm/scala-asm-5.0.4-scala-3.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scaladoc"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scala-compiler"/>

--- a/src/eclipse/partest/.classpath
+++ b/src/eclipse/partest/.classpath
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="partest-extras"/>
-	<classpathentry kind="var" path="M2_REPO/org/scala-lang/modules/scala-asm/5.0.4-scala-3/scala-asm-5.0.4-scala-3.jar"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/asm/scala-asm-5.0.4-scala-3.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/repl"/>
-	<classpathentry kind="var" path="M2_REPO/com/googlecode/java-diff-utils/diffutils/1.3.0/diffutils-1.3.0.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/scala-sbt/test-interface/1.0/test-interface-1.0.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/scala-lang/modules/scala-partest_2.11/1.0.9/scala-partest_2.11-1.0.9.jar"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/partest/diffutils-1.3.0.jar"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/partest/test-interface-1.0.jar"/>
 	<classpathentry kind="var" path="SCALA_BASEDIR/lib/ant/ant.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scala-compiler"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scala-library"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/partest/scala-partest_2.11-1.0.13.jar"/>
 	<classpathentry kind="output" path="build-quick-partest-extras"/>
 </classpath>

--- a/src/eclipse/reflect/.classpath
+++ b/src/eclipse/reflect/.classpath
@@ -3,5 +3,6 @@
 	<classpathentry kind="src" path="reflect"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scala-library"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
 	<classpathentry kind="output" path="build-quick-reflect"/>
 </classpath>

--- a/src/eclipse/repl/.classpath
+++ b/src/eclipse/repl/.classpath
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="repl"/>
-	<classpathentry kind="var" path="M2_REPO/org/scala-lang/modules/scala-asm/5.0.4-scala-3/scala-asm-5.0.4-scala-3.jar"/>
-	<classpathentry kind="var" path="M2_REPO/jline/jline/2.12.1/jline-2.12.1.jar"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/asm/scala-asm-5.0.4-scala-3.jar"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/repl/jline-2.12.1.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scala-compiler"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scala-library"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/interactive"/>
 	<classpathentry kind="output" path="build-quick-repl"/>
 </classpath>

--- a/src/eclipse/scala-compiler/.classpath
+++ b/src/eclipse/scala-compiler/.classpath
@@ -4,7 +4,8 @@
 	<classpathentry combineaccessrules="false" exported="true" kind="src" path="/reflect"/>
 	<classpathentry combineaccessrules="false" exported="true" kind="src" path="/scala-library"/>
 	<classpathentry kind="var" path="SCALA_BASEDIR/lib/ant/ant.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/scala-lang/modules/scala-asm/5.0.4-scala-3/scala-asm-5.0.4-scala-3.jar"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/asm/scala-asm-5.0.4-scala-3.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
 	<classpathentry kind="output" path="build-quick-compiler"/>
 </classpath>

--- a/src/eclipse/scaladoc/.classpath
+++ b/src/eclipse/scaladoc/.classpath
@@ -2,12 +2,12 @@
 <classpath>
 	<classpathentry kind="src" path="scaladoc"/>
 	<classpathentry kind="var" path="SCALA_BASEDIR/lib/ant/ant.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/scala-lang/modules/scala-asm/5.0.4-scala-3/scala-asm-5.0.4-scala-3.jar"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/asm/scala-asm-5.0.4-scala-3.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scala-compiler"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scala-library"/>
-	<classpathentry kind="var" path="M2_REPO/org/scala-lang/modules/scala-xml_2.11/1.0.4/scala-xml_2.11-1.0.4.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/scala-lang/modules/scala-parser-combinators_2.11/1.0.4/scala-parser-combinators_2.11-1.0.4.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/scala-lang/modules/scala-partest_2.11/1.0.9/scala-partest_2.11-1.0.9.jar"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/scaladoc/scala-xml_2.11-1.0.5.jar"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/scaladoc/scala-parser-combinators_2.11-1.0.4.jar"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/partest/scala-partest_2.11-1.0.13.jar"/>
 	<classpathentry kind="output" path="build-quick-scaladoc"/>
 </classpath>

--- a/src/eclipse/test-junit/.classpath
+++ b/src/eclipse/test-junit/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="test-junit"/>
-	<classpathentry kind="var" path="M2_REPO/org/scala-lang/modules/scala-asm/5.0.4-scala-3/scala-asm-5.0.4-scala-3.jar"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/asm/scala-asm-5.0.4-scala-3.jar"/>
 	<classpathentry kind="var" path="SCALA_BASEDIR/lib/ant/ant.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/reflect"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scala-library"/>
@@ -10,7 +10,7 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/repl"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/partest-extras"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scaladoc"/>
-	<classpathentry kind="var" path="M2_REPO/org/scala-lang/modules/scala-xml_2.11/1.0.4/scala-xml_2.11-1.0.4.jar"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/scaladoc/scala-xml_2.11-1.0.5.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="output" path="build-test-junit"/>
 </classpath>

--- a/src/eclipse/update-workspace.sh
+++ b/src/eclipse/update-workspace.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+function usage() {
+    echo "$0 scala_checkout_dir [workspace_dir]"
+    echo "\n Add necessary path variables to Eclipse workspace settings for Scalac to build"
+}
+
+METADATA_DIR=`pwd`/.metadata
+
+if [ $# -lt 1 ]; then
+    echo "Need the Scala directory checkout as argument"
+    exit 1
+fi
+
+SCALA_DIR=$1
+
+if [ ! -z $2 ]; then
+    METADATA_DIR=$2/.metadata
+fi
+
+if [ ! -d $METADATA_DIR ]; then
+    echo "$METADATA_DIR is not a directory"
+    exit 1
+fi
+
+echo "Using metadata directory $METADATA_DIR and Scala checkout $SCALA_DIR" 
+
+CORE_PREFS=$METADATA_DIR/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.core.resources.prefs
+if [ ! -f $CORE_PREFS ]; then
+    echo "Couldn't find $CORE_PREFS. Is $METADATA_DIR an Eclipse workspace?"
+    exit 1
+fi
+echo -e "Workspace preferences:\t$CORE_PREFS"
+
+JDT_PREFS=$METADATA_DIR/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.jdt.core.prefs
+if [ ! -f $JDT_PREFS ]; then
+    echo "Couldn't find $JDT_PREFS. Creating fresh file."
+    touch $JDT_PREFS
+fi
+echo -e "JDT preferences:\t$JDT_PREFS" 
+
+# $1 - preference file (will be backed-up before writing)
+# $2 - preference key
+# $3 - preference value
+function updatePref() {
+    mv $1 ${1}_backup
+      
+    awk -v key=$2 -v value=$3 '
+    BEGIN { 
+        FS="="; 
+        OFS="=";
+        prev=""
+    }
+    { 
+        if ($1 == key) {
+            prev=$2
+            $2=value
+        }
+        print
+    }
+    END { 
+        if (prev) {
+            printf "Updated existing value from %s to %s\n", prev, value > "/dev/stderr"
+        } else {
+            print key,value
+        }
+    }
+    ' ${1}_backup >$1
+}
+
+updatePref $CORE_PREFS "pathvariable.SCALA_BASEDIR" $SCALA_DIR
+updatePref $JDT_PREFS "org.eclipse.jdt.core.classpathVariable.SCALA_BASEDIR" $SCALA_DIR


### PR DESCRIPTION
- remove `M2_REPO`. All dependencies are picked up from `build/deps`
- add script to update an existing workspace directory with the required path variables
- add the default Scala library to several projects for better out-of-the-box experience. This means
  that changes in the scale-library project may not be visible in the other projects, but makes it
  way easier to get a working config. If you really need that, you probably know what you’re doing
  anyway.
