### PR TITLE
Updating README.md Eclipse version reference.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Here, `<milestone>` is the milestone targeted by the PR (e.g., 2.11.6), and `<sh
 
 ## IDE Setup
 ### Eclipse
-See `src/eclipse/README.md`.
+See [src/eclipse/README.md](src/eclipse/README.md).
 
 ### IntelliJ 15
 See [src/intellij/README.md](src/intellij/README.md).


### PR DESCRIPTION
Related: https://github.com/scala/scala/pull/4984

Added link to eclipse readme doc.

Where is the <3 for Eclipse?
