### PR TITLE
[Build] Include missing web assets in scaladoc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -507,7 +507,7 @@ lazy val scaladoc = configureAsSubproject(project)
     name := "scala-compiler-doc",
     description := "Scala Documentation Generator",
     libraryDependencies ++= Seq(scalaXmlDep, scalaParserCombinatorsDep, partestDep),
-    includeFilter in unmanagedResources in Compile := "*.html" | "*.css" | "*.gif" | "*.png" | "*.js" | "*.txt"
+    includeFilter in unmanagedResources in Compile := "*.html" | "*.css" | "*.gif" | "*.png" | "*.js" | "*.txt" | "*.svg" | "*.eot" | "*.woff" | "*.ttf"
   )
   .dependsOn(compiler)
 


### PR DESCRIPTION
Running a Scala version that is built with sbt will fail when generating docs, since some required assets are not included in the packaged Scala artifacts. This PR adds the missing assets to the sbt build definition.

cc @SethTisue, the changes are related to the sbt build 
