### PR TITLE
SI-9749 REPL strip lead ws on dot continuation

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/Completion.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Completion.scala
@@ -24,11 +24,11 @@ object Completion {
   case class Candidates(cursor: Int, candidates: List[String]) { }
   val NoCandidates = Candidates(-1, Nil)
 
-  def looksLikeInvocation(code: String) = (
-        (code != null)
-    &&  (code startsWith ".")
-    && !(code == ".")
-    && !(code startsWith "./")
-    && !(code startsWith "..")
-  )
+  // a leading dot plus something, but not ".." or "./", ignoring leading whitespace
+  private val dotlike = """\s*\.[^./].*""".r
+  def looksLikeInvocation(code: String) = code match {
+    case null      => false   // insurance
+    case dotlike() => true
+    case _         => false
+  }
 }

--- a/test/files/run/t9749-repl-dot.check
+++ b/test/files/run/t9749-repl-dot.check
@@ -1,0 +1,8 @@
+
+scala> "3"
+res0: String = 3
+
+scala>   .toInt
+res1: Int = 3
+
+scala> :quit

--- a/test/files/run/t9749-repl-dot.scala
+++ b/test/files/run/t9749-repl-dot.scala
@@ -1,0 +1,10 @@
+
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  def code = 
+    """
+"3"
+  .toInt
+    """
+}


### PR DESCRIPTION
Permit leading whitespace before `.` for continued selection.

This is just to handle pastes, which will typically include
indented text, and not to make dot-continuation especially robust.
