### PR TITLE
Simplify TraversableLike.isEmpty?

### DIFF
--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -128,14 +128,8 @@ trait TraversableLike[+A, +Repr] extends Any
    *  @return    `true` if the $coll contain no elements, `false` otherwise.
    */
   def isEmpty: Boolean = {
-    var result = true
-    breakable {
-      for (x <- this) {
-        result = false
-        break
-      }
-    }
-    result
+    for (x <- this) return false
+    true
   }
 
   def hasDefiniteSize = true


### PR DESCRIPTION
It looks like several methods (isEmpty, forall, exists, find, head, and copyToArray) in TraversableLike could be greatly simplified by using a `for (x <- this) return Y` style, instead of the `breakable { for(x <- this) { ... break}}` style? 

If there are performance implications of using breakable, one could consider also modifying sliceInternal and takeWhile (though that would require calling b.result from two different points in the method). 

@Ichoran @axel22 (listed as handling collections on https://github.com/scala/scala )
