### PR TITLE
SI-9684 Deprecate JavaConversions

### DIFF
--- a/project/Osgi.scala
+++ b/project/Osgi.scala
@@ -3,7 +3,7 @@ import aQute.bnd.osgi.Constants._
 import java.util.Properties
 import sbt._
 import sbt.Keys._
-import scala.collection.JavaConversions._
+import collection.JavaConverters._
 import VersionUtil.versionProperties
 
 /** OSGi packaging for the Scala build, distilled from sbt-osgi. We do not use sbt-osgi because it
@@ -57,12 +57,12 @@ object Osgi {
     headers foreach { case (k, v) => builder.setProperty(k, v) }
     val includeRes = resourceDirectories.filter(_.exists).map(_.getAbsolutePath).mkString(",")
     if(!includeRes.isEmpty) builder.setProperty(INCLUDERESOURCE, includeRes)
-    builder.getProperties.foreach { case (k, v) => log.debug(s"bnd: $k: $v") }
+    builder.getProperties.asScala.foreach { case (k, v) => log.debug(s"bnd: $k: $v") }
     // builder.build is not thread-safe because it uses a static SimpleDateFormat.  This ensures
     // that all calls to builder.build are serialized.
     val jar = synchronized { builder.build }
-    builder.getWarnings.foreach(s => log.warn(s"bnd: $s"))
-    builder.getErrors.foreach(s => log.error(s"bnd: $s"))
+    builder.getWarnings.asScala.foreach(s => log.warn(s"bnd: $s"))
+    builder.getErrors.asScala.foreach(s => log.error(s"bnd: $s"))
     IO.createDirectory(artifactPath.getParentFile)
     jar.write(artifactPath)
     artifactPath

--- a/src/compiler/scala/tools/cmd/Property.scala
+++ b/src/compiler/scala/tools/cmd/Property.scala
@@ -65,8 +65,8 @@ trait Property extends Reference {
     propertiesToOptions(loadProperties(file))
 
   def propertiesToOptions(props: java.util.Properties): List[String] = {
-    import scala.collection.JavaConversions._
-    propertiesToOptions(props.toList)
+    import scala.collection.JavaConverters._
+    propertiesToOptions(props.asScala.toList)
   }
   def propertiesToOptions(props: List[(String, String)]) = props flatMap propMapper
 }

--- a/src/compiler/scala/tools/nsc/backend/jvm/AsmUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/AsmUtils.scala
@@ -9,8 +9,7 @@ import scala.tools.asm.tree.{InsnList, AbstractInsnNode, ClassNode, MethodNode}
 import java.io.{StringWriter, PrintWriter}
 import scala.tools.asm.util.{CheckClassAdapter, TraceClassVisitor, TraceMethodVisitor, Textifier}
 import scala.tools.asm.{ClassReader, ClassWriter, Attribute}
-import scala.collection.convert.decorateAsScala._
-import scala.collection.convert.decorateAsJava._
+import scala.collection.JavaConverters._
 import scala.tools.nsc.backend.jvm.analysis.InitialProducer
 import scala.tools.nsc.backend.jvm.opt.InlineInfoAttributePrototype
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -17,7 +17,7 @@ import scala.tools.nsc.backend.jvm.BTypes.{InlineInfo, MethodInlineInfo}
 import scala.tools.nsc.backend.jvm.BackendReporting._
 import scala.tools.nsc.backend.jvm.analysis.BackendUtils
 import scala.tools.nsc.backend.jvm.opt._
-import scala.collection.convert.decorateAsScala._
+import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 import scala.tools.nsc.settings.ScalaSettings
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
@@ -221,7 +221,7 @@ abstract class GenBCode extends BCodeSyncAndTry {
      */
     class Worker2 {
       def runGlobalOptimizations(): Unit = {
-        import scala.collection.convert.decorateAsScala._
+        import scala.collection.JavaConverters._
 
         // add classes to the bytecode repo before building the call graph: the latter needs to
         // look up classes and methods in the code repo.

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
@@ -12,8 +12,7 @@ import scala.tools.nsc.backend.jvm.BTypes._
 import scala.tools.nsc.backend.jvm.opt.BytecodeUtils._
 import java.lang.invoke.LambdaMetafactory
 import scala.collection.mutable
-import scala.collection.convert.decorateAsJava._
-import scala.collection.convert.decorateAsScala._
+import scala.collection.JavaConverters._
 
 /**
  * This component hosts tools and utilities used in the backend that require access to a `BTypes`

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/ProdConsAnalyzerImpl.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/ProdConsAnalyzerImpl.scala
@@ -18,7 +18,7 @@ import scala.tools.asm.tree.analysis._
 
 import opt.BytecodeUtils._
 
-import scala.collection.convert.decorateAsScala._
+import scala.collection.JavaConverters._
 
 /**
  * This class provides additional queries over ASM's built-in `SourceValue` analysis.

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/BoxUnbox.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/BoxUnbox.scala
@@ -12,7 +12,7 @@ import scala.tools.asm.Type
 import scala.tools.asm.Opcodes._
 import scala.tools.asm.tree._
 import scala.collection.mutable
-import scala.collection.convert.decorateAsScala._
+import scala.collection.JavaConverters._
 import scala.tools.nsc.backend.jvm.BTypes.InternalName
 import scala.tools.nsc.backend.jvm.opt.BytecodeUtils._
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/ByteCodeRepository.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/ByteCodeRepository.scala
@@ -9,7 +9,7 @@ package opt
 
 import scala.tools.asm
 import asm.tree._
-import scala.collection.convert.decorateAsScala._
+import scala.collection.JavaConverters._
 import scala.collection.concurrent
 import scala.tools.asm.Attribute
 import scala.tools.nsc.backend.jvm.BackendReporting._

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
@@ -17,7 +17,7 @@ import scala.tools.asm.{Label, Type}
 import scala.tools.asm.Opcodes._
 import scala.tools.asm.tree._
 import GenBCode._
-import scala.collection.convert.decorateAsScala._
+import scala.collection.JavaConverters._
 import scala.tools.nsc.backend.jvm.analysis.InstructionStackEffect
 
 object BytecodeUtils {

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/CallGraph.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/CallGraph.scala
@@ -12,7 +12,7 @@ import scala.reflect.internal.util.{NoPosition, Position}
 import scala.tools.asm.{Opcodes, Type, Handle}
 import scala.tools.asm.tree._
 import scala.collection.{concurrent, mutable}
-import scala.collection.convert.decorateAsScala._
+import scala.collection.JavaConverters._
 import scala.tools.nsc.backend.jvm.BTypes.InternalName
 import scala.tools.nsc.backend.jvm.BackendReporting._
 import scala.tools.nsc.backend.jvm.analysis._

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/ClosureOptimizer.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/ClosureOptimizer.scala
@@ -18,7 +18,7 @@ import BytecodeUtils._
 import BackendReporting._
 import Opcodes._
 import scala.tools.nsc.backend.jvm.opt.ByteCodeRepository.CompilationUnit
-import scala.collection.convert.decorateAsScala._
+import scala.collection.JavaConverters._
 
 class ClosureOptimizer[BT <: BTypes](val btypes: BT) {
   import btypes._

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/CopyProp.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/CopyProp.scala
@@ -13,7 +13,7 @@ import scala.tools.asm.Type
 import scala.tools.asm.Opcodes._
 import scala.tools.asm.tree._
 import scala.collection.mutable
-import scala.collection.convert.decorateAsScala._
+import scala.collection.JavaConverters._
 import scala.tools.nsc.backend.jvm.BTypes.InternalName
 import scala.tools.nsc.backend.jvm.analysis._
 import scala.tools.nsc.backend.jvm.opt.BytecodeUtils._

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
@@ -11,8 +11,7 @@ import scala.annotation.tailrec
 import scala.tools.asm
 import asm.Opcodes._
 import asm.tree._
-import scala.collection.convert.decorateAsScala._
-import scala.collection.convert.decorateAsJava._
+import scala.collection.JavaConverters._
 import AsmUtils._
 import BytecodeUtils._
 import collection.mutable

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/InlinerHeuristics.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/InlinerHeuristics.scala
@@ -9,7 +9,7 @@ package opt
 
 import scala.tools.asm.tree.MethodNode
 import scala.tools.nsc.backend.jvm.BTypes.InternalName
-import scala.collection.convert.decorateAsScala._
+import scala.collection.JavaConverters._
 import scala.tools.nsc.backend.jvm.BackendReporting.OptimizerWarning
 
 class InlinerHeuristics[BT <: BTypes](val bTypes: BT) {

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/LocalOpt.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/LocalOpt.scala
@@ -14,7 +14,7 @@ import scala.tools.asm.tree.analysis.Frame
 import scala.tools.asm.Opcodes._
 import scala.tools.asm.tree._
 import scala.collection.mutable
-import scala.collection.convert.decorateAsScala._
+import scala.collection.JavaConverters._
 import scala.tools.nsc.backend.jvm.BTypes.InternalName
 import scala.tools.nsc.backend.jvm.analysis._
 import scala.tools.nsc.backend.jvm.opt.BytecodeUtils._

--- a/src/compiler/scala/tools/nsc/util/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/util/ClassPath.scala
@@ -113,10 +113,9 @@ object ClassPath {
   }
 
   def manifests: List[java.net.URL] = {
-    import scala.collection.convert.WrapAsScala.enumerationAsScalaIterator
-    Thread.currentThread().getContextClassLoader()
-      .getResources("META-INF/MANIFEST.MF")
-      .filter(_.getProtocol == "jar").toList
+    import scala.collection.JavaConverters._
+    val resources = Thread.currentThread().getContextClassLoader().getResources("META-INF/MANIFEST.MF")
+    resources.asScala.filter(_.getProtocol == "jar").toList
   }
 
   class JavaContext extends ClassPathContext[AbstractFile] {

--- a/src/library/scala/collection/JavaConversions.scala
+++ b/src/library/scala/collection/JavaConversions.scala
@@ -1,6 +1,6 @@
 /*                     __                                               *\
 **     ________ ___   / /  ___     Scala API                            **
-**    / __/ __// _ | / /  / _ |    (c) 2006-2013, LAMP/EPFL             **
+**    / __/ __// _ | / /  / _ |    (c) 2006-2016, LAMP/EPFL             **
 **  __\ \/ /__/ __ |/ /__/ __ |    http://www.scala-lang.org/           **
 ** /____/\___/_/ |_/____/_/ | |                                         **
 **                          |/                                          **
@@ -11,10 +11,10 @@ package collection
 
 import convert._
 
-/**   A collection of implicit conversions supporting interoperability between
- *    Scala and Java collections.
+/** A collection of implicit conversions supporting interoperability between
+ *  Scala and Java collections.
  *
- *    The following conversions are supported:
+ *  The following conversions are supported:
  *{{{
  *    scala.collection.Iterable       <=> java.lang.Iterable
  *    scala.collection.Iterable       <=> java.util.Collection
@@ -24,8 +24,8 @@ import convert._
  *    scala.collection.mutable.Map    <=> java.util.{ Map, Dictionary }
  *    scala.collection.concurrent.Map <=> java.util.concurrent.ConcurrentMap
  *}}}
- *    In all cases, converting from a source type to a target type and back
- *    again will return the original source object, eg.
+ *  In all cases, converting from a source type to a target type and back
+ *  again will return the original source object:
  *
  *{{{
  *    import scala.collection.JavaConversions._
@@ -45,8 +45,16 @@ import convert._
  *    java.util.Properties         => scala.collection.mutable.Map[String, String]
  *}}}
  *
+ *  The transparent conversions provided here are considered
+ *  fragile because they can result in unexpected behavior and performance.
+ *
+ *  Therefore, this API has been deprecated and `JavaConverters` should be
+ *  used instead. `JavaConverters` provides the same conversions, but through
+ *  extension methods.
+ *
  *  @author Miles Sabin
  *  @author Martin Odersky
  *  @since  2.8
  */
+@deprecated("Use JavaConverters", since="2.12")
 object JavaConversions extends WrapAsScala with WrapAsJava

--- a/src/library/scala/collection/JavaConversions.scala
+++ b/src/library/scala/collection/JavaConversions.scala
@@ -11,7 +11,7 @@ package collection
 
 import convert._
 
-/** A collection of implicit conversions supporting interoperability between
+/** A variety of implicit conversions supporting interoperability between
  *  Scala and Java collections.
  *
  *  The following conversions are supported:

--- a/src/library/scala/collection/JavaConverters.scala
+++ b/src/library/scala/collection/JavaConverters.scala
@@ -1,6 +1,6 @@
 /*                     __                                               *\
 **     ________ ___   / /  ___     Scala API                            **
-**    / __/ __// _ | / /  / _ |    (c) 2006-2013, LAMP/EPFL             **
+**    / __/ __// _ | / /  / _ |    (c) 2006-2016, LAMP/EPFL             **
 **  __\ \/ /__/ __ |/ /__/ __ |    http://www.scala-lang.org/           **
 ** /____/\___/_/ |_/____/_/ | |                                         **
 **                          |/                                          **
@@ -11,14 +11,12 @@ package collection
 
 import convert._
 
-// TODO: I cleaned all this documentation up in JavaConversions, but the
-// documentation in here is basically the pre-cleaned-up version with minor
-// additions.  Would be nice to have in one place.
-
-/** A collection of decorators that allow converting between
- *  Scala and Java collections using `asScala` and `asJava` methods.
+/** A variety of decorators that enable converting between
+ *  Scala and Java collections using extension methods, `asScala` and `asJava`.
  *
- *  The following conversions are supported via `asJava`, `asScala`
+ *  The extension methods return adapters for the corresponding API.
+ *
+ *  The following conversions are supported via `asScala` and `asJava`:
  *{{{
  *    scala.collection.Iterable               <=> java.lang.Iterable
  *    scala.collection.Iterator               <=> java.util.Iterator
@@ -27,25 +25,14 @@ import convert._
  *    scala.collection.mutable.Map            <=> java.util.Map
  *    scala.collection.mutable.concurrent.Map <=> java.util.concurrent.ConcurrentMap
  *}}}
- *  In all cases, converting from a source type to a target type and back
- *  again will return the original source object, e.g.
- *  {{{
- *    import scala.collection.JavaConverters._
- *
- *    val sl = new scala.collection.mutable.ListBuffer[Int]
- *    val jl : java.util.List[Int] = sl.asJava
- *    val sl2 : scala.collection.mutable.Buffer[Int] = jl.asScala
- *    assert(sl eq sl2)
- *  }}}
- *  The following conversions are also supported, but the
- *  direction from Scala to Java is done by the more specifically named methods:
- *  `asJavaCollection`, `asJavaEnumeration`, `asJavaDictionary`.
+ *  The following conversions are supported via `asScala` and through
+ *  specially-named extension methods to convert to Java collections, as shown:
  *{{{
- *    scala.collection.Iterable    <=> java.util.Collection
- *    scala.collection.Iterator    <=> java.util.Enumeration
- *    scala.collection.mutable.Map <=> java.util.Dictionary
+ *    scala.collection.Iterable    <=> java.util.Collection   (via asJavaCollection)
+ *    scala.collection.Iterator    <=> java.util.Enumeration  (via asJavaEnumeration)
+ *    scala.collection.mutable.Map <=> java.util.Dictionary   (via asJavaDictionary)
  *}}}
- *  In addition, the following one way conversions are provided via `asJava`:
+ *  In addition, the following one-way conversions are provided via `asJava`:
  *{{{
  *    scala.collection.Seq         => java.util.List
  *    scala.collection.mutable.Seq => java.util.List
@@ -56,6 +43,31 @@ import convert._
  *{{{
  *    java.util.Properties => scala.collection.mutable.Map
  *}}}
+ *  In all cases, converting from a source type to a target type and back
+ *  again will return the original source object. For example:
+ *  {{{
+ *    import scala.collection.JavaConverters._
+ *
+ *    val source = new scala.collection.mutable.ListBuffer[Int]
+ *    val target: java.util.List[Int] = source.asJava
+ *    val other: scala.collection.mutable.Buffer[Int] = target.asScala
+ *    assert(source eq other)
+ *  }}}
+ *  Alternatively, the conversion methods have descriptive names and can be invoked explicitly.
+ *  {{{
+ *    scala> val vs = java.util.Arrays.asList("hi", "bye")
+ *    vs: java.util.List[String] = [hi, bye]
+ *
+ *    scala> val ss = asScalaIterator(vs.iterator)
+ *    ss: Iterator[String] = non-empty iterator
+ *
+ *    scala> .toList
+ *    res0: List[String] = List(hi, bye)
+ *
+ *    scala> val ss = asScalaBuffer(vs)
+ *    ss: scala.collection.mutable.Buffer[String] = Buffer(hi, bye)
+ *  }}}
+ *
  *  @since  2.8.1
  */
 object JavaConverters extends DecorateAsJava with DecorateAsScala

--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -1106,14 +1106,14 @@ private[concurrent] case object TrieMapSerializationEnd
 
 
 private[concurrent] object Debug {
-  import scala.collection._
+  import JavaConverters._
 
   lazy val logbuffer = new java.util.concurrent.ConcurrentLinkedQueue[AnyRef]
 
   def log(s: AnyRef) = logbuffer.add(s)
 
   def flush() {
-    for (s <- JavaConversions.asScalaIterator(logbuffer.iterator())) Console.out.println(s.toString)
+    for (s <- logbuffer.iterator().asScala) Console.out.println(s.toString)
     logbuffer.clear()
   }
 

--- a/src/library/scala/collection/convert/AsJavaConverters.scala
+++ b/src/library/scala/collection/convert/AsJavaConverters.scala
@@ -1,6 +1,6 @@
 /*                     __                                               *\
 **     ________ ___   / /  ___     Scala API                            **
-**    / __/ __// _ | / /  / _ |    (c) 2006-2013, LAMP/EPFL             **
+**    / __/ __// _ | / /  / _ |    (c) 2006-2016, LAMP/EPFL             **
 **  __\ \/ /__/ __ |/ /__/ __ |    http://www.scala-lang.org/           **
 ** /____/\___/_/ |_/____/_/ | |                                         **
 **                          |/                                          **
@@ -17,58 +17,55 @@ trait AsJavaConverters {
   import Wrappers._
 
   /**
-   * Converts a Scala Iterator to a Java Iterator.
+   * Converts a Scala `Iterator` to a Java `Iterator`.
    *
-   * The returned Java Iterator is backed by the provided Scala
-   * Iterator and any side-effects of using it via the Java interface will
-   * be visible via the Scala interface and vice versa.
+   * The returned Java `Iterator` is backed by the provided Scala `Iterator` and any side-effects of
+   * using it via the Java interface will be visible via the Scala interface and vice versa.
    *
-   * If the Scala Iterator was previously obtained from an implicit or
-   * explicit call of `asScalaIterator(java.util.Iterator)` then the original
-   * Java Iterator will be returned.
+   * If the Scala `Iterator` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.asScalaIterator]](java.util.Iterator)` then the original Java `Iterator` will
+   * be returned.
    *
-   * @param  it The Iterator to be converted.
-   * @return    A Java Iterator view of the argument.
+   * @param i The Scala `Iterator` to be converted.
+   * @return  A Java `Iterator` view of the argument.
    */
-  def asJavaIterator[A](it: Iterator[A]): ju.Iterator[A] = it match {
+  def asJavaIterator[A](i: Iterator[A]): ju.Iterator[A] = i match {
     case null                       => null
     case JIteratorWrapper(wrapped)  => wrapped.asInstanceOf[ju.Iterator[A]]
-    case _                          => IteratorWrapper(it)
+    case _                          => IteratorWrapper(i)
   }
 
   /**
-   * Converts a Scala Iterator to a Java Enumeration.
+   * Converts a Scala `Iterator` to a Java `Enumeration`.
    *
-   * The returned Java Enumeration is backed by the provided Scala
-   * Iterator and any side-effects of using it via the Java interface will
-   * be visible via the Scala interface and vice versa.
+   * The returned Java `Enumeration` is backed by the provided Scala `Iterator` and any side-effects
+   * of using it via the Java interface will be visible via the Scala interface and vice versa.
    *
-   * If the Scala Iterator was previously obtained from an implicit or
-   * explicit call of `enumerationAsScalaIterator(java.util.Enumeration)` then the
-   * original Java Enumeration will be returned.
+   * If the Scala `Iterator` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.enumerationAsScalaIterator]](java.util.Enumeration)` then the original Java
+   * `Enumeration` will be returned.
    *
-   * @param it The Iterator to be converted.
-   * @return   A Java Enumeration view of the argument.
+   * @param i The Scala `Iterator` to be converted.
+   * @return  A Java `Enumeration` view of the argument.
    */
-  def asJavaEnumeration[A](it: Iterator[A]): ju.Enumeration[A] = it match {
+  def asJavaEnumeration[A](i: Iterator[A]): ju.Enumeration[A] = i match {
     case null                         => null
     case JEnumerationWrapper(wrapped) => wrapped.asInstanceOf[ju.Enumeration[A]]
-    case _                            => IteratorWrapper(it)
+    case _                            => IteratorWrapper(i)
   }
 
   /**
-   * Converts a Scala Iterable to a Java Iterable.
+   * Converts a Scala `Iterable` to a Java `Iterable`.
    *
-   * The returned Java Iterable is backed by the provided Scala
-   * Iterable and any side-effects of using it via the Java interface will
-   * be visible via the Scala interface and vice versa.
+   * The returned Java `Iterable` is backed by the provided Scala `Iterable` and any side-effects of
+   * using it via the Java interface will be visible via the Scala interface and vice versa.
    *
-   * If the Scala Iterable was previously obtained from an implicit or
-   * explicit call of `iterableasScalaIterable(java.lang.Iterable)` then the original
-   * Java Iterable will be returned.
+   * If the Scala `Iterable` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.iterableAsScalaIterable]](java.lang.Iterable)` then the original Java
+   * `Iterable` will be returned.
    *
-   * @param i The Iterable to be converted.
-   * @return A Java Iterable view of the argument.
+   * @param i The Scala `Iterable` to be converted.
+   * @return  A Java `Iterable` view of the argument.
    */
   def asJavaIterable[A](i: Iterable[A]): jl.Iterable[A] = i match {
     case null                       => null
@@ -77,34 +74,33 @@ trait AsJavaConverters {
   }
 
   /**
-   * Converts a Scala Iterable to an immutable Java Collection.
+   * Converts a Scala `Iterable` to an immutable Java `Collection`.
    *
-   * If the Scala Iterable was previously obtained from an implicit or
-   * explicit call of `collectionAsScalaIterable(java.util.Collection)` then the original
-   * Java Collection will be returned.
+   * If the Scala `Iterable` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.collectionAsScalaIterable]](java.util.Collection)` then the original Java
+   * `Collection` will be returned.
    *
-   * @param it The SizedIterable to be converted.
-   * @return   A Java Collection view of the argument.
+   * @param i The Scala `Iterable` to be converted.
+   * @return  A Java `Collection` view of the argument.
    */
-  def asJavaCollection[A](it: Iterable[A]): ju.Collection[A] = it match {
+  def asJavaCollection[A](i: Iterable[A]): ju.Collection[A] = i match {
     case null                         => null
     case JCollectionWrapper(wrapped)  => wrapped.asInstanceOf[ju.Collection[A]]
-    case _                            => new IterableWrapper(it)
+    case _                            => new IterableWrapper(i)
   }
 
   /**
-   * Converts a Scala mutable Buffer to a Java List.
+   * Converts a Scala mutable `Buffer` to a Java List.
    *
-   * The returned Java List is backed by the provided Scala
-   * Buffer and any side-effects of using it via the Java interface will
-   * be visible via the Scala interface and vice versa.
+   * The returned Java List is backed by the provided Scala `Buffer` and any side-effects of using
+   * it via the Java interface will be visible via the Scala interface and vice versa.
    *
-   * If the Scala Buffer was previously obtained from an implicit or
-   * explicit call of `asScalaBuffer(java.util.List)` then the original
-   * Java List will be returned.
+   * If the Scala `Buffer` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.asScalaBuffer]](java.util.List)` then the original Java `List` will be
+   * returned.
    *
-   * @param b The Buffer to be converted.
-   * @return A Java List view of the argument.
+   * @param b The Scala `Buffer` to be converted.
+   * @return A Java `List` view of the argument.
    */
   def bufferAsJavaList[A](b: mutable.Buffer[A]): ju.List[A] = b match {
     case null                   => null
@@ -113,58 +109,54 @@ trait AsJavaConverters {
   }
 
   /**
-   * Converts a Scala mutable Seq to a Java List.
+   * Converts a Scala mutable `Seq` to a Java `List`.
    *
-   * The returned Java List is backed by the provided Scala
-   * Seq and any side-effects of using it via the Java interface will
-   * be visible via the Scala interface and vice versa.
+   * The returned Java `List` is backed by the provided Scala `Seq` and any side-effects of using it
+   * via the Java interface will be visible via the Scala interface and vice versa.
    *
-   * If the Scala Seq was previously obtained from an implicit or
-   * explicit call of `asScalaBuffer(java.util.List)` then the original
-   * Java List will be returned.
+   * If the Scala `Seq` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.asScalaBuffer]](java.util.List)` then the original Java `List` will be
+   * returned.
    *
-   * @param seq The Seq to be converted.
-   * @return    A Java List view of the argument.
+   * @param s The Scala `Seq` to be converted.
+   * @return  A Java `List` view of the argument.
    */
-  def mutableSeqAsJavaList[A](seq: mutable.Seq[A]): ju.List[A] = seq match {
+  def mutableSeqAsJavaList[A](s: mutable.Seq[A]): ju.List[A] = s match {
     case null                   => null
     case JListWrapper(wrapped)  => wrapped
-    case _                      => new MutableSeqWrapper(seq)
+    case _                      => new MutableSeqWrapper(s)
   }
 
   /**
-   * Converts a Scala Seq to a Java List.
+   * Converts a Scala `Seq` to a Java `List`.
    *
-   * The returned Java List is backed by the provided Scala
-   * Seq and any side-effects of using it via the Java interface will
-   * be visible via the Scala interface and vice versa.
+   * The returned Java `List` is backed by the provided Scala `Seq` and any side-effects of using it
+   * via the Java interface will be visible via the Scala interface and vice versa.
    *
-   * If the Scala Seq was previously obtained from an implicit or
-   * explicit call of `asScalaBuffer(java.util.List)` then the original
-   * Java List will be returned.
+   * If the Scala `Seq` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.asScalaBuffer]](java.util.List)` then the original Java `List` will be
+   * returned.
    *
-   * @param seq The Seq to be converted.
-   * @return    A Java List view of the argument.
+   * @param s The Scala `Seq` to be converted.
+   * @return  A Java `List` view of the argument.
    */
-  def seqAsJavaList[A](seq: Seq[A]): ju.List[A] = seq match {
+  def seqAsJavaList[A](s: Seq[A]): ju.List[A] = s match {
     case null                   => null
     case JListWrapper(wrapped)  => wrapped.asInstanceOf[ju.List[A]]
-    case _                      => new SeqWrapper(seq)
+    case _                      => new SeqWrapper(s)
   }
 
   /**
-   * Converts a Scala mutable Set to a Java Set.
+   * Converts a Scala mutable `Set` to a Java `Set`.
    *
-   * The returned Java Set is backed by the provided Scala
-   * Set and any side-effects of using it via the Java interface will
-   * be visible via the Scala interface and vice versa.
+   * The returned Java `Set` is backed by the provided Scala `Set` and any side-effects of using it
+   * via the Java interface will be visible via the Scala interface and vice versa.
    *
-   * If the Scala Set was previously obtained from an implicit or
-   * explicit call of `asSet(java.util.Set)` then the original
-   * Java Set will be returned.
+   * If the Scala `Set` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.asScalaSet]](java.util.Set)` then the original Java `Set` will be returned.
    *
-   * @param s The Set to be converted.
-   * @return A Java Set view of the argument.
+   * @param s The Scala mutable `Set` to be converted.
+   * @return  A Java `Set` view of the argument.
    */
   def mutableSetAsJavaSet[A](s: mutable.Set[A]): ju.Set[A] = s match {
     case null                 => null
@@ -173,18 +165,16 @@ trait AsJavaConverters {
   }
 
   /**
-   * Converts a Scala Set to a Java Set.
+   * Converts a Scala `Set` to a Java `Set`.
    *
-   * The returned Java Set is backed by the provided Scala
-   * Set and any side-effects of using it via the Java interface will
-   * be visible via the Scala interface and vice versa.
+   * The returned Java `Set` is backed by the provided Scala `Set` and any side-effects of using it
+   * via the Java interface will be visible via the Scala interface and vice versa.
    *
-   * If the Scala Set was previously obtained from an implicit or
-   * explicit call of `asScalaSet(java.util.Set)` then the original
-   * Java Set will be returned.
+   * If the Scala `Set` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.asScalaSet]](java.util.Set)` then the original Java `Set` will be returned.
    *
-   * @param s The Set to be converted.
-   * @return A Java Set view of the argument.
+   * @param s The Scala `Set` to be converted.
+   * @return  A Java `Set` view of the argument.
    */
   def setAsJavaSet[A](s: Set[A]): ju.Set[A] = s match {
     case null                 => null
@@ -193,18 +183,17 @@ trait AsJavaConverters {
   }
 
   /**
-   * Converts a Scala mutable Map to a Java Map.
+   * Converts a Scala mutable `Map` to a Java `Map`.
    *
-   * The returned Java Map is backed by the provided Scala
-   * Map and any side-effects of using it via the Java interface will
-   * be visible via the Scala interface and vice versa.
+   * The returned Java `Map` is backed by the provided Scala `Map` and any side-effects of using it
+   * via the Java interface will be visible via the Scala interface and vice versa.
    *
-   * If the Scala Map was previously obtained from an implicit or
-   * explicit call of `mapAsScalaMap(java.util.Map)` then the original
-   * Java Map will be returned.
+   * If the Scala `Map` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.mapAsScalaMap]](java.util.Map)` then the original Java `Map` will be
+   * returned.
    *
-   * @param m The Map to be converted.
-   * @return A Java Map view of the argument.
+   * @param m The Scala mutable `Map` to be converted.
+   * @return  A Java `Map` view of the argument.
    */
   def mutableMapAsJavaMap[A, B](m: mutable.Map[A, B]): ju.Map[A, B] = m match {
     case null                 => null
@@ -215,16 +204,16 @@ trait AsJavaConverters {
   /**
    * Converts a Scala mutable `Map` to a Java `Dictionary`.
    *
-   * The returned Java `Dictionary` is backed by the provided Scala
-   * `Dictionary` and any side-effects of using it via the Java interface
-   * will be visible via the Scala interface and vice versa.
+   * The returned Java `Dictionary` is backed by the provided Scala `Dictionary` and any
+   * side-effects of using it via the Java interface will be visible via the Scala interface and
+   * vice versa.
    *
-   * If the Scala `Dictionary` was previously obtained from an implicit or
-   * explicit call of `dictionaryAsScalaMap(java.util.Dictionary)` then the original
-   * Java Dictionary will be returned.
+   * If the Scala `Dictionary` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.dictionaryAsScalaMap]](java.util.Dictionary)` then the original Java
+   * `Dictionary` will be returned.
    *
-   * @param m The `Map` to be converted.
-   * @return A Java `Dictionary` view of the argument.
+   * @param m The Scala `Map` to be converted.
+   * @return  A Java `Dictionary` view of the argument.
    */
   def asJavaDictionary[A, B](m: mutable.Map[A, B]): ju.Dictionary[A, B] = m match {
     case null                         => null
@@ -235,16 +224,15 @@ trait AsJavaConverters {
   /**
    * Converts a Scala `Map` to a Java `Map`.
    *
-   * The returned Java `Map` is backed by the provided Scala `Map` and
-   * any side-effects of using it via the Java interface will be visible
-   * via the Scala interface and vice versa.
+   * The returned Java `Map` is backed by the provided Scala `Map` and any side-effects of using it
+   * via the Java interface will be visible via the Scala interface and vice versa.
    *
-   * If the Scala `Map` was previously obtained from an implicit or
-   * explicit call of `mapAsScalaMap(java.util.Map)` then the original
-   * Java `Map` will be returned.
+   * If the Scala `Map` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.mapAsScalaMap]](java.util.Map)` then the original Java `Map` will be
+   * returned.
    *
-   * @param m The `Map` to be converted.
-   * @return A Java `Map` view of the argument.
+   * @param m The Scala `Map` to be converted.
+   * @return  A Java `Map` view of the argument.
    */
   def mapAsJavaMap[A, B](m: Map[A, B]): ju.Map[A, B] = m match {
     case null                 => null
@@ -255,16 +243,16 @@ trait AsJavaConverters {
   /**
    * Converts a Scala mutable `concurrent.Map` to a Java `ConcurrentMap`.
    *
-   * The returned Java `ConcurrentMap` is backed by the provided Scala
-   * `concurrent.Map` and any side-effects of using it via the Java interface
-   * will be visible via the Scala interface and vice versa.
+   * The returned Java `ConcurrentMap` is backed by the provided Scala `concurrent.Map` and any
+   * side-effects of using it via the Java interface will be visible via the Scala interface and
+   * vice versa.
    *
-   * If the Scala `concurrent.Map` was previously obtained from an implicit or
-   * explicit call of `mapAsScalaConcurrentMap(java.util.concurrent.ConcurrentMap)`
-   * then the original Java ConcurrentMap will be returned.
+   * If the Scala `concurrent.Map` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.mapAsScalaConcurrentMap]](java.util.concurrent.ConcurrentMap)` then the
+   * original Java `ConcurrentMap` will be returned.
    *
    * @param m The Scala `concurrent.Map` to be converted.
-   * @return A Java `ConcurrentMap` view of the argument.
+   * @return  A Java `ConcurrentMap` view of the argument.
    */
   def mapAsJavaConcurrentMap[A, B](m: concurrent.Map[A, B]): juc.ConcurrentMap[A, B] = m match {
     case null                           => null

--- a/src/library/scala/collection/convert/AsJavaConverters.scala
+++ b/src/library/scala/collection/convert/AsJavaConverters.scala
@@ -11,145 +11,150 @@ package collection
 package convert
 
 import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
-import scala.language.implicitConversions
 
-@deprecated("Use JavaConverters or consider ToJavaImplicits", since="2.12")
-trait WrapAsJava {
+/** Defines converter methods from Scala to Java collections. */
+trait AsJavaConverters {
   import Wrappers._
 
   /**
-   * Implicitly converts a Scala Iterator to a Java Iterator.
+   * Converts a Scala Iterator to a Java Iterator.
+   *
    * The returned Java Iterator is backed by the provided Scala
    * Iterator and any side-effects of using it via the Java interface will
    * be visible via the Scala interface and vice versa.
    *
    * If the Scala Iterator was previously obtained from an implicit or
-   * explicit call of `asIterator(java.util.Iterator)` then the original
+   * explicit call of `asScalaIterator(java.util.Iterator)` then the original
    * Java Iterator will be returned.
    *
    * @param  it The Iterator to be converted.
    * @return    A Java Iterator view of the argument.
    */
-  implicit def asJavaIterator[A](it: Iterator[A]): ju.Iterator[A] = it match {
+  def asJavaIterator[A](it: Iterator[A]): ju.Iterator[A] = it match {
     case null                       => null
     case JIteratorWrapper(wrapped)  => wrapped.asInstanceOf[ju.Iterator[A]]
     case _                          => IteratorWrapper(it)
   }
 
   /**
-   * Implicitly converts a Scala Iterator to a Java Enumeration.
+   * Converts a Scala Iterator to a Java Enumeration.
+   *
    * The returned Java Enumeration is backed by the provided Scala
    * Iterator and any side-effects of using it via the Java interface will
    * be visible via the Scala interface and vice versa.
    *
    * If the Scala Iterator was previously obtained from an implicit or
-   * explicit call of `asIterator(java.util.Enumeration)` then the
+   * explicit call of `enumerationAsScalaIterator(java.util.Enumeration)` then the
    * original Java Enumeration will be returned.
    *
    * @param it The Iterator to be converted.
    * @return   A Java Enumeration view of the argument.
    */
-  implicit def asJavaEnumeration[A](it: Iterator[A]): ju.Enumeration[A] = it match {
+  def asJavaEnumeration[A](it: Iterator[A]): ju.Enumeration[A] = it match {
     case null                         => null
     case JEnumerationWrapper(wrapped) => wrapped.asInstanceOf[ju.Enumeration[A]]
     case _                            => IteratorWrapper(it)
   }
 
   /**
-   * Implicitly converts a Scala Iterable to a Java Iterable.
+   * Converts a Scala Iterable to a Java Iterable.
+   *
    * The returned Java Iterable is backed by the provided Scala
    * Iterable and any side-effects of using it via the Java interface will
    * be visible via the Scala interface and vice versa.
    *
    * If the Scala Iterable was previously obtained from an implicit or
-   * explicit call of `asIterable(java.lang.Iterable)` then the original
+   * explicit call of `iterableasScalaIterable(java.lang.Iterable)` then the original
    * Java Iterable will be returned.
    *
    * @param i The Iterable to be converted.
    * @return A Java Iterable view of the argument.
    */
-  implicit def asJavaIterable[A](i: Iterable[A]): jl.Iterable[A] = i match {
+  def asJavaIterable[A](i: Iterable[A]): jl.Iterable[A] = i match {
     case null                       => null
     case JIterableWrapper(wrapped)  => wrapped.asInstanceOf[jl.Iterable[A]]
     case _                          => IterableWrapper(i)
   }
 
   /**
-   * Implicitly converts a Scala Iterable to an immutable Java
-   * Collection.
+   * Converts a Scala Iterable to an immutable Java Collection.
    *
    * If the Scala Iterable was previously obtained from an implicit or
-   * explicit call of `asSizedIterable(java.util.Collection)` then the original
+   * explicit call of `collectionAsScalaIterable(java.util.Collection)` then the original
    * Java Collection will be returned.
    *
    * @param it The SizedIterable to be converted.
    * @return   A Java Collection view of the argument.
    */
-  implicit def asJavaCollection[A](it: Iterable[A]): ju.Collection[A] = it match {
+  def asJavaCollection[A](it: Iterable[A]): ju.Collection[A] = it match {
     case null                         => null
     case JCollectionWrapper(wrapped)  => wrapped.asInstanceOf[ju.Collection[A]]
     case _                            => new IterableWrapper(it)
   }
 
   /**
-   * Implicitly converts a Scala mutable Buffer to a Java List.
+   * Converts a Scala mutable Buffer to a Java List.
+   *
    * The returned Java List is backed by the provided Scala
    * Buffer and any side-effects of using it via the Java interface will
    * be visible via the Scala interface and vice versa.
    *
    * If the Scala Buffer was previously obtained from an implicit or
-   * explicit call of `asBuffer(java.util.List)` then the original
+   * explicit call of `asScalaBuffer(java.util.List)` then the original
    * Java List will be returned.
    *
    * @param b The Buffer to be converted.
    * @return A Java List view of the argument.
    */
-  implicit def bufferAsJavaList[A](b: mutable.Buffer[A]): ju.List[A] = b match {
+  def bufferAsJavaList[A](b: mutable.Buffer[A]): ju.List[A] = b match {
     case null                   => null
     case JListWrapper(wrapped)  => wrapped
     case _                      => new MutableBufferWrapper(b)
   }
 
   /**
-   * Implicitly converts a Scala mutable Seq to a Java List.
+   * Converts a Scala mutable Seq to a Java List.
+   *
    * The returned Java List is backed by the provided Scala
    * Seq and any side-effects of using it via the Java interface will
    * be visible via the Scala interface and vice versa.
    *
    * If the Scala Seq was previously obtained from an implicit or
-   * explicit call of `asSeq(java.util.List)` then the original
+   * explicit call of `asScalaBuffer(java.util.List)` then the original
    * Java List will be returned.
    *
    * @param seq The Seq to be converted.
    * @return    A Java List view of the argument.
    */
-  implicit def mutableSeqAsJavaList[A](seq: mutable.Seq[A]): ju.List[A] = seq match {
+  def mutableSeqAsJavaList[A](seq: mutable.Seq[A]): ju.List[A] = seq match {
     case null                   => null
     case JListWrapper(wrapped)  => wrapped
     case _                      => new MutableSeqWrapper(seq)
   }
 
   /**
-   * Implicitly converts a Scala Seq to a Java List.
+   * Converts a Scala Seq to a Java List.
+   *
    * The returned Java List is backed by the provided Scala
    * Seq and any side-effects of using it via the Java interface will
    * be visible via the Scala interface and vice versa.
    *
    * If the Scala Seq was previously obtained from an implicit or
-   * explicit call of `asSeq(java.util.List)` then the original
+   * explicit call of `asScalaBuffer(java.util.List)` then the original
    * Java List will be returned.
    *
    * @param seq The Seq to be converted.
    * @return    A Java List view of the argument.
    */
-  implicit def seqAsJavaList[A](seq: Seq[A]): ju.List[A] = seq match {
+  def seqAsJavaList[A](seq: Seq[A]): ju.List[A] = seq match {
     case null                   => null
     case JListWrapper(wrapped)  => wrapped.asInstanceOf[ju.List[A]]
     case _                      => new SeqWrapper(seq)
   }
 
   /**
-   * Implicitly converts a Scala mutable Set to a Java Set.
+   * Converts a Scala mutable Set to a Java Set.
+   *
    * The returned Java Set is backed by the provided Scala
    * Set and any side-effects of using it via the Java interface will
    * be visible via the Scala interface and vice versa.
@@ -161,93 +166,94 @@ trait WrapAsJava {
    * @param s The Set to be converted.
    * @return A Java Set view of the argument.
    */
-  implicit def mutableSetAsJavaSet[A](s: mutable.Set[A]): ju.Set[A] = s match {
+  def mutableSetAsJavaSet[A](s: mutable.Set[A]): ju.Set[A] = s match {
     case null                 => null
     case JSetWrapper(wrapped) => wrapped
     case _                    => new MutableSetWrapper(s)
   }
 
   /**
-   * Implicitly converts a Scala Set to a Java Set.
+   * Converts a Scala Set to a Java Set.
+   *
    * The returned Java Set is backed by the provided Scala
    * Set and any side-effects of using it via the Java interface will
    * be visible via the Scala interface and vice versa.
    *
    * If the Scala Set was previously obtained from an implicit or
-   * explicit call of asSet(java.util.Set) then the original
+   * explicit call of `asScalaSet(java.util.Set)` then the original
    * Java Set will be returned.
    *
    * @param s The Set to be converted.
    * @return A Java Set view of the argument.
    */
-  implicit def setAsJavaSet[A](s: Set[A]): ju.Set[A] = s match {
+  def setAsJavaSet[A](s: Set[A]): ju.Set[A] = s match {
     case null                 => null
     case JSetWrapper(wrapped) => wrapped
     case _                    => new SetWrapper(s)
   }
 
   /**
-   * Implicitly converts a Scala mutable Map to a Java Map.
+   * Converts a Scala mutable Map to a Java Map.
+   *
    * The returned Java Map is backed by the provided Scala
    * Map and any side-effects of using it via the Java interface will
    * be visible via the Scala interface and vice versa.
    *
    * If the Scala Map was previously obtained from an implicit or
-   * explicit call of `asMap(java.util.Map)` then the original
+   * explicit call of `mapAsScalaMap(java.util.Map)` then the original
    * Java Map will be returned.
    *
    * @param m The Map to be converted.
    * @return A Java Map view of the argument.
    */
-  implicit def mutableMapAsJavaMap[A, B](m: mutable.Map[A, B]): ju.Map[A, B] = m match {
+  def mutableMapAsJavaMap[A, B](m: mutable.Map[A, B]): ju.Map[A, B] = m match {
     case null                 => null
     case JMapWrapper(wrapped) => wrapped
     case _                    => new MutableMapWrapper(m)
   }
 
   /**
-   * Implicitly converts a Scala mutable `Map` to a Java `Dictionary`.
+   * Converts a Scala mutable `Map` to a Java `Dictionary`.
    *
    * The returned Java `Dictionary` is backed by the provided Scala
    * `Dictionary` and any side-effects of using it via the Java interface
    * will be visible via the Scala interface and vice versa.
    *
    * If the Scala `Dictionary` was previously obtained from an implicit or
-   * explicit call of `asMap(java.util.Dictionary)` then the original
+   * explicit call of `dictionaryAsScalaMap(java.util.Dictionary)` then the original
    * Java Dictionary will be returned.
    *
    * @param m The `Map` to be converted.
    * @return A Java `Dictionary` view of the argument.
    */
-  implicit def asJavaDictionary[A, B](m: mutable.Map[A, B]): ju.Dictionary[A, B] = m match {
+  def asJavaDictionary[A, B](m: mutable.Map[A, B]): ju.Dictionary[A, B] = m match {
     case null                         => null
     case JDictionaryWrapper(wrapped)  => wrapped
     case _                            => new DictionaryWrapper(m)
   }
 
   /**
-   * Implicitly converts a Scala `Map` to a Java `Map`.
+   * Converts a Scala `Map` to a Java `Map`.
    *
    * The returned Java `Map` is backed by the provided Scala `Map` and
    * any side-effects of using it via the Java interface will be visible
    * via the Scala interface and vice versa.
    *
    * If the Scala `Map` was previously obtained from an implicit or
-   * explicit call of `asMap(java.util.Map)` then the original
+   * explicit call of `mapAsScalaMap(java.util.Map)` then the original
    * Java `Map` will be returned.
    *
    * @param m The `Map` to be converted.
    * @return A Java `Map` view of the argument.
    */
-  implicit def mapAsJavaMap[A, B](m: Map[A, B]): ju.Map[A, B] = m match {
+  def mapAsJavaMap[A, B](m: Map[A, B]): ju.Map[A, B] = m match {
     case null                 => null
     case JMapWrapper(wrapped) => wrapped.asInstanceOf[ju.Map[A, B]]
     case _                    => new MapWrapper(m)
   }
 
   /**
-   * Implicitly converts a Scala mutable `concurrent.Map` to a Java
-   * `ConcurrentMap`.
+   * Converts a Scala mutable `concurrent.Map` to a Java `ConcurrentMap`.
    *
    * The returned Java `ConcurrentMap` is backed by the provided Scala
    * `concurrent.Map` and any side-effects of using it via the Java interface
@@ -260,12 +266,9 @@ trait WrapAsJava {
    * @param m The Scala `concurrent.Map` to be converted.
    * @return A Java `ConcurrentMap` view of the argument.
    */
-  implicit def mapAsJavaConcurrentMap[A, B](m: concurrent.Map[A, B]): juc.ConcurrentMap[A, B] = m match {
+  def mapAsJavaConcurrentMap[A, B](m: concurrent.Map[A, B]): juc.ConcurrentMap[A, B] = m match {
     case null                           => null
     case JConcurrentMapWrapper(wrapped) => wrapped
     case _                              => new ConcurrentMapWrapper(m)
   }
 }
-
-@deprecated("Use JavaConverters or consider ImplicitConversionsToJava", since="2.12")
-object WrapAsJava extends WrapAsJava

--- a/src/library/scala/collection/convert/AsScalaConverters.scala
+++ b/src/library/scala/collection/convert/AsScalaConverters.scala
@@ -1,6 +1,6 @@
 /*                     __                                               *\
 **     ________ ___   / /  ___     Scala API                            **
-**    / __/ __// _ | / /  / _ |    (c) 2006-2013, LAMP/EPFL             **
+**    / __/ __// _ | / /  / _ |    (c) 2006-2016, LAMP/EPFL             **
 **  __\ \/ /__/ __ |/ /__/ __ |    http://www.scala-lang.org/           **
 ** /____/\___/_/ |_/____/_/ | |                                         **
 **                          |/                                          **
@@ -19,36 +19,34 @@ trait AsScalaConverters {
   /**
    * Converts a Java `Iterator` to a Scala `Iterator`.
    *
-   * The returned Scala `Iterator` is backed by the provided Java `Iterator`
-   * and any side-effects of using it via the Scala interface will be visible
-   * via the Java interface and vice versa.
+   * The returned Scala `Iterator` is backed by the provided Java `Iterator` and any side-effects of
+   * using it via the Scala interface will be visible via the Java interface and vice versa.
    *
-   * If the Java `Iterator` was previously obtained from an implicit or
-   * explicit call of `asJavaIterator(scala.collection.Iterator)` then the
-   * original Scala `Iterator` will be returned.
+   * If the Java `Iterator` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.asJavaIterator]](scala.collection.Iterator)` then the original Scala
+   * `Iterator` will be returned.
    *
-   * @param it The `Iterator` to be converted.
-   * @return   A Scala `Iterator` view of the argument.
+   * @param i The Java `Iterator` to be converted.
+   * @return  A Scala `Iterator` view of the argument.
    */
-  def asScalaIterator[A](it: ju.Iterator[A]): Iterator[A] = it match {
+  def asScalaIterator[A](i: ju.Iterator[A]): Iterator[A] = i match {
     case null                     => null
     case IteratorWrapper(wrapped) => wrapped
-    case _                        => JIteratorWrapper(it)
+    case _                        => JIteratorWrapper(i)
   }
 
   /**
-   * Converts a Java Enumeration to a Scala Iterator.
+   * Converts a Java `Enumeration` to a Scala `Iterator`.
    *
-   * The returned Scala Iterator is backed by the provided Java
-   * Enumeration and any side-effects of using it via the Scala interface will
-   * be visible via the Java interface and vice versa.
+   * The returned Scala `Iterator` is backed by the provided Java `Enumeration` and any side-effects
+   * of using it via the Scala interface will be visible via the Java interface and vice versa.
    *
-   * If the Java Enumeration was previously obtained from an implicit or
-   * explicit call of `asJavaEnumeration(scala.collection.Iterator)`
-   * then the original Scala Iterator will be returned.
+   * If the Java `Enumeration` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.asJavaEnumeration]](scala.collection.Iterator)` then the original Scala
+   * `Iterator` will be returned.
    *
-   * @param i The Enumeration to be converted.
-   * @return A Scala Iterator view of the argument.
+   * @param i The Java `Enumeration` to be converted.
+   * @return  A Scala `Iterator` view of the argument.
    */
   def enumerationAsScalaIterator[A](i: ju.Enumeration[A]): Iterator[A] = i match {
     case null                     => null
@@ -59,16 +57,15 @@ trait AsScalaConverters {
   /**
    * Converts a Java `Iterable` to a Scala `Iterable`.
    *
-   * The returned Scala `Iterable` is backed by the provided Java `Iterable`
-   * and any side-effects of using it via the Scala interface will be visible
-   * via the Java interface and vice versa.
+   * The returned Scala `Iterable` is backed by the provided Java `Iterable` and any side-effects of
+   * using it via the Scala interface will be visible via the Java interface and vice versa.
    *
-   * If the Java `Iterable` was previously obtained from an implicit or
-   * explicit call of `asJavaIterable(scala.collection.Iterable)`
-   * then the original Scala Iterable will be returned.
+   * If the Java `Iterable` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.asJavaIterable]](scala.collection.Iterable) then the original Scala
+   * `Iterable` will be returned.
    *
-   * @param i The Iterable to be converted.
-   * @return A Scala Iterable view of the argument.
+   * @param i The Java `Iterable` to be converted.
+   * @return  A Scala `Iterable` view of the argument.
    */
   def iterableAsScalaIterable[A](i: jl.Iterable[A]): Iterable[A] = i match {
     case null                     => null
@@ -79,12 +76,12 @@ trait AsScalaConverters {
   /**
    * Converts a Java `Collection` to an Scala `Iterable`.
    *
-   * If the Java `Collection` was previously obtained from an implicit or
-   * explicit call of `asJavaCollection(scala.collection.Iterable)`
-   * then the original Scala `Iterable` will be returned.
+   * If the Java `Collection` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.asJavaCollection]](scala.collection.Iterable)` then the original Scala
+   * `Iterable` will be returned.
    *
-   * @param i The Collection to be converted.
-   * @return A Scala Iterable view of the argument.
+   * @param i The Java `Collection` to be converted.
+   * @return  A Scala `Iterable` view of the argument.
    */
   def collectionAsScalaIterable[A](i: ju.Collection[A]): Iterable[A] = i match {
     case null                     => null
@@ -95,15 +92,14 @@ trait AsScalaConverters {
   /**
    * Converts a Java `List` to a Scala mutable `Buffer`.
    *
-   * The returned Scala `Buffer` is backed by the provided Java `List`
-   * and any side-effects of using it via the Scala interface will
-   * be visible via the Java interface and vice versa.
+   * The returned Scala `Buffer` is backed by the provided Java `List` and any side-effects of using
+   * it via the Scala interface will be visible via the Java interface and vice versa.
    *
-   * If the Java `List` was previously obtained from an implicit or
-   * explicit call of `bufferAsJavaList(scala.collection.mutable.Buffer)`
-   * then the original Scala `Buffer` will be returned.
+   * If the Java `List` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.bufferAsJavaList]](scala.collection.mutable.Buffer)` then the original Scala
+   * `Buffer` will be returned.
    *
-   * @param l The `List` to be converted.
+   * @param l The Java `List` to be converted.
    * @return A Scala mutable `Buffer` view of the argument.
    */
   def asScalaBuffer[A](l: ju.List[A]): mutable.Buffer[A] = l match {
@@ -113,18 +109,17 @@ trait AsScalaConverters {
   }
 
   /**
-   * Converts a Java Set to a Scala mutable Set.
+   * Converts a Java `Set` to a Scala mutable `Set`.
    *
-   * The returned Scala Set is backed by the provided Java
-   * Set and any side-effects of using it via the Scala interface will
-   * be visible via the Java interface and vice versa.
+   * The returned Scala `Set` is backed by the provided Java `Set` and any side-effects of using it
+   * via the Scala interface will be visible via the Java interface and vice versa.
    *
-   * If the Java Set was previously obtained from an implicit or
-   * explicit call of `mutableSetAsJavaSet(scala.collection.mutable.Set)` then
-   * the original Scala Set will be returned.
+   * If the Java `Set` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.mutableSetAsJavaSet]](scala.collection.mutable.Set)` then the original Scala
+   * `Set` will be returned.
    *
-   * @param s The Set to be converted.
-   * @return A Scala mutable Set view of the argument.
+   * @param s The Java `Set` to be converted.
+   * @return  A Scala mutable `Set` view of the argument.
    */
   def asScalaSet[A](s: ju.Set[A]): mutable.Set[A] = s match {
     case null                       => null
@@ -135,22 +130,20 @@ trait AsScalaConverters {
   /**
    * Converts a Java `Map` to a Scala mutable `Map`.
    *
-   * The returned Scala `Map` is backed by the provided Java `Map` and any
-   * side-effects of using it via the Scala interface will be visible via
-   * the Java interface and vice versa.
+   * The returned Scala `Map` is backed by the provided Java `Map` and any side-effects of using it
+   * via the Scala interface will be visible via the Java interface and vice versa.
    *
-   * If the Java `Map` was previously obtained from an implicit or
-   * explicit call of `mutableMapAsJavaMap(scala.collection.mutable.Map)` then
-   * the original Scala Map will be returned.
+   * If the Java `Map` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.mutableMapAsJavaMap]](scala.collection.mutable.Map)` then the original Scala
+   * `Map` will be returned.
    *
-   * If the wrapped map is synchronized (e.g. from `java.util.Collections.synchronizedMap`),
-   * it is your responsibility to wrap all
-   * non-atomic operations with `underlying.synchronized`.
-   * This includes `get`, as `java.util.Map`'s API does not allow for an
-   * atomic `get` when `null` values may be present.
+   * If the wrapped map is synchronized (e.g. from `java.util.Collections.synchronizedMap`), it is
+   * your responsibility to wrap all non-atomic operations with `underlying.synchronized`.
+   * This includes `get`, as `java.util.Map`'s API does not allow for an atomic `get` when `null`
+   * values may be present.
    *
-   * @param m The Map to be converted.
-   * @return A Scala mutable Map view of the argument.
+   * @param m The Java `Map` to be converted.
+   * @return  A Scala mutable `Map` view of the argument.
    */
   def mapAsScalaMap[A, B](m: ju.Map[A, B]): mutable.Map[A, B] = m match {
     case null                       => null
@@ -159,18 +152,18 @@ trait AsScalaConverters {
   }
 
   /**
-   * Converts a Java ConcurrentMap to a Scala mutable ConcurrentMap.
+   * Converts a Java `ConcurrentMap` to a Scala mutable `ConcurrentMap`.
    *
-   * The returned Scala ConcurrentMap is backed by the provided Java
-   * ConcurrentMap and any side-effects of using it via the Scala interface will
-   * be visible via the Java interface and vice versa.
+   * The returned Scala `ConcurrentMap` is backed by the provided Java `ConcurrentMap` and any
+   * side-effects of using it via the Scala interface will be visible via the Java interface and
+   * vice versa.
    *
-   * If the Java ConcurrentMap was previously obtained from an implicit or
-   * explicit call of `mapAsJavaConcurrentMap(scala.collection.mutable.ConcurrentMap)`
-   * then the original Scala ConcurrentMap will be returned.
+   * If the Java `ConcurrentMap` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.mapAsJavaConcurrentMap]](scala.collection.mutable.ConcurrentMap)`
+   * then the original Scala `ConcurrentMap` will be returned.
    *
-   * @param m The ConcurrentMap to be converted.
-   * @return A Scala mutable ConcurrentMap view of the argument.
+   * @param m The Java `ConcurrentMap` to be converted.
+   * @return  A Scala mutable `ConcurrentMap` view of the argument.
    */
   def mapAsScalaConcurrentMap[A, B](m: juc.ConcurrentMap[A, B]): concurrent.Map[A, B] = m match {
     case null                             => null
@@ -181,16 +174,15 @@ trait AsScalaConverters {
   /**
    * Converts a Java `Dictionary` to a Scala mutable `Map`.
    *
-   * The returned Scala `Map` is backed by the provided Java
-   * `Dictionary` and any side-effects of using it via the Scala interface
-   * will be visible via the Java interface and vice versa.
+   * The returned Scala `Map` is backed by the provided Java `Dictionary` and any side-effects of
+   * using it via the Scala interface will be visible via the Java interface and vice versa.
    *
-   * If the Java `Dictionary` was previously obtained from an implicit or
-   * explicit call of `asJavaDictionary(scala.collection.mutable.Map)` then the original
-   * Scala Map will be returned.
+   * If the Java `Dictionary` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.asJavaDictionary]](scala.collection.mutable.Map)` then the original
+   * Scala `Map` will be returned.
    *
-   * @param p The Dictionary to be converted.
-   * @return  A Scala mutable Map view of the argument.
+   * @param p The Java `Dictionary` to be converted.
+   * @return  A Scala mutable `Map` view of the argument.
    */
   def dictionaryAsScalaMap[A, B](p: ju.Dictionary[A, B]): mutable.Map[A, B] = p match {
     case null                       => null
@@ -199,14 +191,14 @@ trait AsScalaConverters {
   }
 
   /**
-   * Converts a Java `Properties` to a Scala `mutable Map[String, String]`.
+   * Converts a Java `Properties` to a Scala mutable `Map[String, String]`.
    *
-   * The returned Scala `Map[String, String]` is backed by the provided Java
-   * `Properties` and any side-effects of using it via the Scala interface
-   * will be visible via the Java interface and vice versa.
+   * The returned Scala `Map[String, String]` is backed by the provided Java `Properties` and any
+   * side-effects of using it via the Scala interface will be visible via the Java interface and
+   * vice versa.
    *
-   * @param p The Properties to be converted.
-   * @return  A Scala mutable Map[String, String] view of the argument.
+   * @param p The Java `Properties` to be converted.
+   * @return  A Scala mutable `Map[String, String]` view of the argument.
    */
   def propertiesAsScalaMap(p: ju.Properties): mutable.Map[String, String] = p match {
     case null => null

--- a/src/library/scala/collection/convert/AsScalaConverters.scala
+++ b/src/library/scala/collection/convert/AsScalaConverters.scala
@@ -11,134 +11,136 @@ package collection
 package convert
 
 import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
-import scala.language.implicitConversions
 
-@deprecated("Use JavaConverters or consider ToScalaImplicits", since="2.12")
-trait WrapAsScala {
+/** Defines converter methods from Java to Scala collections. */
+trait AsScalaConverters {
   import Wrappers._
+
   /**
-   * Implicitly converts a Java `Iterator` to a Scala `Iterator`.
+   * Converts a Java `Iterator` to a Scala `Iterator`.
    *
    * The returned Scala `Iterator` is backed by the provided Java `Iterator`
    * and any side-effects of using it via the Scala interface will be visible
    * via the Java interface and vice versa.
    *
    * If the Java `Iterator` was previously obtained from an implicit or
-   * explicit call of `asIterator(scala.collection.Iterator)` then the
+   * explicit call of `asJavaIterator(scala.collection.Iterator)` then the
    * original Scala `Iterator` will be returned.
    *
    * @param it The `Iterator` to be converted.
    * @return   A Scala `Iterator` view of the argument.
    */
-  implicit def asScalaIterator[A](it: ju.Iterator[A]): Iterator[A] = it match {
+  def asScalaIterator[A](it: ju.Iterator[A]): Iterator[A] = it match {
     case null                     => null
     case IteratorWrapper(wrapped) => wrapped
     case _                        => JIteratorWrapper(it)
   }
 
   /**
-   * Implicitly converts a Java Enumeration to a Scala Iterator.
+   * Converts a Java Enumeration to a Scala Iterator.
+   *
    * The returned Scala Iterator is backed by the provided Java
    * Enumeration and any side-effects of using it via the Scala interface will
    * be visible via the Java interface and vice versa.
    *
    * If the Java Enumeration was previously obtained from an implicit or
-   * explicit call of `enumerationAsScalaIterator(scala.collection.Iterator)`
+   * explicit call of `asJavaEnumeration(scala.collection.Iterator)`
    * then the original Scala Iterator will be returned.
    *
    * @param i The Enumeration to be converted.
    * @return A Scala Iterator view of the argument.
    */
-  implicit def enumerationAsScalaIterator[A](i: ju.Enumeration[A]): Iterator[A] = i match {
+  def enumerationAsScalaIterator[A](i: ju.Enumeration[A]): Iterator[A] = i match {
     case null                     => null
     case IteratorWrapper(wrapped) => wrapped
     case _                        => JEnumerationWrapper(i)
   }
 
   /**
-   * Implicitly converts a Java `Iterable` to a Scala `Iterable`.
+   * Converts a Java `Iterable` to a Scala `Iterable`.
    *
    * The returned Scala `Iterable` is backed by the provided Java `Iterable`
    * and any side-effects of using it via the Scala interface will be visible
    * via the Java interface and vice versa.
    *
    * If the Java `Iterable` was previously obtained from an implicit or
-   * explicit call of `iterableAsScalaIterable(scala.collection.Iterable)`
+   * explicit call of `asJavaIterable(scala.collection.Iterable)`
    * then the original Scala Iterable will be returned.
    *
    * @param i The Iterable to be converted.
    * @return A Scala Iterable view of the argument.
    */
-  implicit def iterableAsScalaIterable[A](i: jl.Iterable[A]): Iterable[A] = i match {
+  def iterableAsScalaIterable[A](i: jl.Iterable[A]): Iterable[A] = i match {
     case null                     => null
     case IterableWrapper(wrapped) => wrapped
     case _                        => JIterableWrapper(i)
   }
 
   /**
-   * Implicitly converts a Java `Collection` to an Scala `Iterable`.
+   * Converts a Java `Collection` to an Scala `Iterable`.
    *
    * If the Java `Collection` was previously obtained from an implicit or
-   * explicit call of `collectionAsScalaIterable(scala.collection.SizedIterable)`
+   * explicit call of `asJavaCollection(scala.collection.Iterable)`
    * then the original Scala `Iterable` will be returned.
    *
    * @param i The Collection to be converted.
    * @return A Scala Iterable view of the argument.
    */
-  implicit def collectionAsScalaIterable[A](i: ju.Collection[A]): Iterable[A] = i match {
+  def collectionAsScalaIterable[A](i: ju.Collection[A]): Iterable[A] = i match {
     case null                     => null
     case IterableWrapper(wrapped) => wrapped
     case _                        => JCollectionWrapper(i)
   }
 
   /**
-   * Implicitly converts a Java `List` to a Scala mutable `Buffer`.
+   * Converts a Java `List` to a Scala mutable `Buffer`.
    *
    * The returned Scala `Buffer` is backed by the provided Java `List`
    * and any side-effects of using it via the Scala interface will
    * be visible via the Java interface and vice versa.
    *
    * If the Java `List` was previously obtained from an implicit or
-   * explicit call of `asScalaBuffer(scala.collection.mutable.Buffer)`
+   * explicit call of `bufferAsJavaList(scala.collection.mutable.Buffer)`
    * then the original Scala `Buffer` will be returned.
    *
    * @param l The `List` to be converted.
    * @return A Scala mutable `Buffer` view of the argument.
    */
-  implicit def asScalaBuffer[A](l: ju.List[A]): mutable.Buffer[A] = l match {
+  def asScalaBuffer[A](l: ju.List[A]): mutable.Buffer[A] = l match {
     case null                           => null
     case MutableBufferWrapper(wrapped)  => wrapped
     case _                              => new JListWrapper(l)
   }
 
   /**
-   * Implicitly converts a Java Set to a Scala mutable Set.
+   * Converts a Java Set to a Scala mutable Set.
+   *
    * The returned Scala Set is backed by the provided Java
    * Set and any side-effects of using it via the Scala interface will
    * be visible via the Java interface and vice versa.
    *
    * If the Java Set was previously obtained from an implicit or
-   * explicit call of `asScalaSet(scala.collection.mutable.Set)` then
+   * explicit call of `mutableSetAsJavaSet(scala.collection.mutable.Set)` then
    * the original Scala Set will be returned.
    *
    * @param s The Set to be converted.
    * @return A Scala mutable Set view of the argument.
    */
-  implicit def asScalaSet[A](s: ju.Set[A]): mutable.Set[A] = s match {
+  def asScalaSet[A](s: ju.Set[A]): mutable.Set[A] = s match {
     case null                       => null
     case MutableSetWrapper(wrapped) => wrapped
     case _                          => new JSetWrapper(s)
   }
 
   /**
-   * Implicitly converts a Java `Map` to a Scala mutable `Map`.
+   * Converts a Java `Map` to a Scala mutable `Map`.
    *
    * The returned Scala `Map` is backed by the provided Java `Map` and any
    * side-effects of using it via the Scala interface will be visible via
    * the Java interface and vice versa.
    *
    * If the Java `Map` was previously obtained from an implicit or
-   * explicit call of `mapAsScalaMap(scala.collection.mutable.Map)` then
+   * explicit call of `mutableMapAsJavaMap(scala.collection.mutable.Map)` then
    * the original Scala Map will be returned.
    *
    * If the wrapped map is synchronized (e.g. from `java.util.Collections.synchronizedMap`),
@@ -150,50 +152,54 @@ trait WrapAsScala {
    * @param m The Map to be converted.
    * @return A Scala mutable Map view of the argument.
    */
-  implicit def mapAsScalaMap[A, B](m: ju.Map[A, B]): mutable.Map[A, B] = m match {
+  def mapAsScalaMap[A, B](m: ju.Map[A, B]): mutable.Map[A, B] = m match {
     case null                       => null
     case MutableMapWrapper(wrapped) => wrapped
     case _                          => new JMapWrapper(m)
   }
 
   /**
-   * Implicitly converts a Java ConcurrentMap to a Scala mutable ConcurrentMap.
+   * Converts a Java ConcurrentMap to a Scala mutable ConcurrentMap.
+   *
    * The returned Scala ConcurrentMap is backed by the provided Java
    * ConcurrentMap and any side-effects of using it via the Scala interface will
    * be visible via the Java interface and vice versa.
    *
    * If the Java ConcurrentMap was previously obtained from an implicit or
-   * explicit call of `asConcurrentMap(scala.collection.mutable.ConcurrentMap)`
+   * explicit call of `mapAsJavaConcurrentMap(scala.collection.mutable.ConcurrentMap)`
    * then the original Scala ConcurrentMap will be returned.
    *
    * @param m The ConcurrentMap to be converted.
    * @return A Scala mutable ConcurrentMap view of the argument.
    */
-  implicit def mapAsScalaConcurrentMap[A, B](m: juc.ConcurrentMap[A, B]): concurrent.Map[A, B] = m match {
+  def mapAsScalaConcurrentMap[A, B](m: juc.ConcurrentMap[A, B]): concurrent.Map[A, B] = m match {
     case null                             => null
     case cmw: ConcurrentMapWrapper[_, _]  => cmw.underlying
     case _                                => new JConcurrentMapWrapper(m)
   }
 
   /**
-   * Implicitly converts a Java `Dictionary` to a Scala mutable
-   * `Map`.
+   * Converts a Java `Dictionary` to a Scala mutable `Map`.
    *
    * The returned Scala `Map` is backed by the provided Java
    * `Dictionary` and any side-effects of using it via the Scala interface
    * will be visible via the Java interface and vice versa.
    *
+   * If the Java `Dictionary` was previously obtained from an implicit or
+   * explicit call of `asJavaDictionary(scala.collection.mutable.Map)` then the original
+   * Scala Map will be returned.
+   *
    * @param p The Dictionary to be converted.
    * @return  A Scala mutable Map view of the argument.
    */
-  implicit def dictionaryAsScalaMap[A, B](p: ju.Dictionary[A, B]): mutable.Map[A, B] = p match {
+  def dictionaryAsScalaMap[A, B](p: ju.Dictionary[A, B]): mutable.Map[A, B] = p match {
     case null                       => null
     case DictionaryWrapper(wrapped) => wrapped
     case _                          => new JDictionaryWrapper(p)
   }
 
   /**
-   * Implicitly converts a Java `Properties` to a Scala `mutable Map[String, String]`.
+   * Converts a Java `Properties` to a Scala `mutable Map[String, String]`.
    *
    * The returned Scala `Map[String, String]` is backed by the provided Java
    * `Properties` and any side-effects of using it via the Scala interface
@@ -202,11 +208,8 @@ trait WrapAsScala {
    * @param p The Properties to be converted.
    * @return  A Scala mutable Map[String, String] view of the argument.
    */
-  implicit def propertiesAsScalaMap(p: ju.Properties): mutable.Map[String, String] = p match {
+  def propertiesAsScalaMap(p: ju.Properties): mutable.Map[String, String] = p match {
     case null => null
     case _    => new JPropertiesWrapper(p)
   }
 }
-
-@deprecated("Use JavaConverters or consider ImplicitConversionsToScala", since="2.12")
-object WrapAsScala extends WrapAsScala

--- a/src/library/scala/collection/convert/DecorateAsJava.scala
+++ b/src/library/scala/collection/convert/DecorateAsJava.scala
@@ -1,6 +1,6 @@
 /*                     __                                               *\
 **     ________ ___   / /  ___     Scala API                            **
-**    / __/ __// _ | / /  / _ |    (c) 2006-2013, LAMP/EPFL             **
+**    / __/ __// _ | / /  / _ |    (c) 2006-2016, LAMP/EPFL             **
 **  __\ \/ /__/ __ |/ /__/ __ |    http://www.scala-lang.org/           **
 ** /____/\___/_/ |_/____/_/ | |                                         **
 **                          |/                                          **
@@ -14,286 +14,95 @@ import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
 import Decorators._
 import scala.language.implicitConversions
 
-/** A collection of decorators that allow converting between
- *  Scala and Java collections using `asScala` and `asJava` methods.
- *
- *  The following conversions are supported via `asJava`, `asScala`
- *{{{
- *    scala.collection.Iterable               <=> java.lang.Iterable
- *    scala.collection.Iterator               <=> java.util.Iterator
- *    scala.collection.mutable.Buffer         <=> java.util.List
- *    scala.collection.mutable.Set            <=> java.util.Set
- *    scala.collection.mutable.Map            <=> java.util.Map
- *    scala.collection.mutable.concurrent.Map <=> java.util.concurrent.ConcurrentMap
- *}}}
- *  In all cases, converting from a source type to a target type and back
- *  again will return the original source object, e.g.
- *  {{{
- *    import scala.collection.JavaConverters._
- *
- *    val sl = new scala.collection.mutable.ListBuffer[Int]
- *    val jl : java.util.List[Int] = sl.asJava
- *    val sl2 : scala.collection.mutable.Buffer[Int] = jl.asScala
- *    assert(sl eq sl2)
- *  }}}
- *  The following conversions are also supported, but the
- *  direction from Scala to Java is done by the more specifically named methods:
- *  `asJavaCollection`, `asJavaEnumeration`, `asJavaDictionary`.
- *{{{
- *    scala.collection.Iterable    <=> java.util.Collection
- *    scala.collection.Iterator    <=> java.util.Enumeration
- *    scala.collection.mutable.Map <=> java.util.Dictionary
- *}}}
- *  In addition, the following one way conversions are provided via `asJava`:
- *{{{
- *    scala.collection.Seq         => java.util.List
- *    scala.collection.mutable.Seq => java.util.List
- *    scala.collection.Set         => java.util.Set
- *    scala.collection.Map         => java.util.Map
- *}}}
- *  The following one way conversion is provided via `asScala`:
- *{{{
- *    java.util.Properties => scala.collection.mutable.Map
- *}}}
- *
- *  @since  2.8.1
- */
+/** Defines `asJava` extension methods for [[JavaConverters]]. */
 trait DecorateAsJava extends AsJavaConverters {
   /**
-   * Adds an `asJava` method that implicitly converts a Scala `Iterator` to a
-   * Java `Iterator`. The returned Java `Iterator` is backed by the provided Scala
-   * `Iterator` and any side-effects of using it via the Java interface will
-   * be visible via the Scala interface and vice versa.
-   *
-   * If the Scala `Iterator` was previously obtained from an implicit or explicit
-   * call of `asIterator(java.util.Iterator)` then the original Java `Iterator`
-   * will be returned by the `asJava` method.
-   *
-   * @param i The `Iterator` to be converted.
-   * @return An object with an `asJava` method that returns a Java `Iterator` view of the argument.
+   * Adds an `asJava` method that implicitly converts a Scala `Iterator` to a Java `Iterator`.
+   * See [[asJavaIterator]].
    */
   implicit def asJavaIteratorConverter[A](i : Iterator[A]): AsJava[ju.Iterator[A]] =
     new AsJava(asJavaIterator(i))
 
   /**
-   * Adds an `asJavaEnumeration` method that implicitly converts a Scala
-   * `Iterator` to a Java `Enumeration`. The returned Java `Enumeration` is
-   * backed by the provided Scala `Iterator` and any side-effects of using
-   * it via the Java interface will be visible via the Scala interface and
-   * vice versa.
-   *
-   * If the Scala `Iterator` was previously obtained from an implicit or
-   * explicit call of `asIterator(java.util.Enumeration)` then the
-   * original Java `Enumeration` will be returned.
-   *
-   * @param i The `Iterator` to be converted.
-   * @return An object with an `asJavaEnumeration` method that returns a Java
-   *         `Enumeration` view of the argument.
+   * Adds an `asJavaEnumeration` method that implicitly converts a Scala `Iterator` to a Java
+   * `Enumeration`. See [[asJavaEnumeration]].
    */
   implicit def asJavaEnumerationConverter[A](i : Iterator[A]): AsJavaEnumeration[A] =
     new AsJavaEnumeration(i)
 
   /**
-   * Adds an `asJava` method that implicitly converts a Scala `Iterable` to
-   * a Java `Iterable`.
-   *
-   * The returned Java `Iterable` is backed by the provided Scala `Iterable`
-   * and any side-effects of using it via the Java interface will be visible
-   * via the Scala interface and vice versa.
-   *
-   * If the Scala `Iterable` was previously obtained from an implicit or
-   * explicit call of `asIterable(java.lang.Iterable)` then the original
-   * Java `Iterable` will be returned.
-   *
-   * @param i The `Iterable` to be converted.
-   * @return An object with an `asJavaCollection` method that returns a Java
-   *         `Iterable` view of the argument.
+   * Adds an `asJava` method that implicitly converts a Scala `Iterable` to a Java `Iterable`.
+   * See [[asJavaIterable]].
    */
   implicit def asJavaIterableConverter[A](i : Iterable[A]): AsJava[jl.Iterable[A]] =
     new AsJava(asJavaIterable(i))
 
   /**
-   * Adds an `asJavaCollection` method that implicitly converts a Scala
-   * `Iterable` to an immutable Java `Collection`.
-   *
-   * If the Scala `Iterable` was previously obtained from an implicit or
-   * explicit call of `asSizedIterable(java.util.Collection)` then the
-   * original Java `Collection` will be returned.
-   *
-   * @param i The `SizedIterable` to be converted.
-   * @return An object with an `asJava` method that returns a Java
-   *         `Collection` view of the argument.
+   * Adds an `asJavaCollection` method that implicitly converts a Scala `Iterable` to an immutable
+   * Java `Collection`. See [[asJavaCollection]].
    */
   implicit def asJavaCollectionConverter[A](i : Iterable[A]): AsJavaCollection[A] =
     new AsJavaCollection(i)
 
   /**
-   * Adds an `asJava` method that implicitly converts a Scala mutable `Buffer`
-   * to a Java `List`.
-   *
-   * The returned Java `List` is backed by the provided Scala `Buffer` and any
-   * side-effects of using it via the Java interface will be visible via the
-   * Scala interface and vice versa.
-   *
-   * If the Scala `Buffer` was previously obtained from an implicit or explicit
-   * call of `asBuffer(java.util.List)` then the original Java `List` will be
-   * returned.
-   *
-   * @param b The `Buffer` to be converted.
-   * @return An object with an `asJava` method that returns a Java `List` view
-   *         of the argument.
+   * Adds an `asJava` method that implicitly converts a Scala mutable `Buffer` to a Java `List`.
+   * See [[bufferAsJavaList]].
    */
   implicit def bufferAsJavaListConverter[A](b : mutable.Buffer[A]): AsJava[ju.List[A]] =
     new AsJava(bufferAsJavaList(b))
 
   /**
-   * Adds an `asJava` method that implicitly converts a Scala mutable `Seq`
-   * to a Java `List`.
-   *
-   * The returned Java `List` is backed by the provided Scala `Seq` and any
-   * side-effects of using it via the Java interface will be visible via the
-   * Scala interface and vice versa.
-   *
-   * If the Scala `Seq` was previously obtained from an implicit or explicit
-   * call of `asSeq(java.util.List)` then the original Java `List` will be
-   * returned.
-   *
-   * @param b The `Seq` to be converted.
-   * @return An object with an `asJava` method that returns a Java `List`
-   *         view of the argument.
+   * Adds an `asJava` method that implicitly converts a Scala mutable `Seq` to a Java `List`.
+   * See [[mutableSeqAsJavaList]].
    */
   implicit def mutableSeqAsJavaListConverter[A](b : mutable.Seq[A]): AsJava[ju.List[A]] =
     new AsJava(mutableSeqAsJavaList(b))
 
   /**
-   * Adds an `asJava` method that implicitly converts a Scala `Seq` to a
-   * Java `List`.
-   *
-   * The returned Java `List` is backed by the provided Scala `Seq` and any
-   * side-effects of using it via the Java interface will be visible via the
-   * Scala interface and vice versa.
-   *
-   * If the Scala `Seq` was previously obtained from an implicit or explicit
-   * call of `asSeq(java.util.List)` then the original Java `List` will be
-   * returned.
-   *
-   * @param b The `Seq` to be converted.
-   * @return An object with an `asJava` method that returns a Java `List`
-   *         view of the argument.
+   * Adds an `asJava` method that implicitly converts a Scala `Seq` to a Java `List`.
+   * See [[seqAsJavaList]].
    */
   implicit def seqAsJavaListConverter[A](b : Seq[A]): AsJava[ju.List[A]] =
     new AsJava(seqAsJavaList(b))
 
   /**
-   * Adds an `asJava` method that implicitly converts a Scala mutable `Set`>
-   * to a Java `Set`.
-   *
-   * The returned Java `Set` is backed by the provided Scala `Set` and any
-   * side-effects of using it via the Java interface will be visible via
-   * the Scala interface and vice versa.
-   *
-   * If the Scala `Set` was previously obtained from an implicit or explicit
-   * call of `asSet(java.util.Set)` then the original Java `Set` will be
-   * returned.
-   *
-   * @param s The `Set` to be converted.
-   * @return An object with an `asJava` method that returns a Java `Set` view
-   *         of the argument.
+   * Adds an `asJava` method that implicitly converts a Scala mutable `Set` to a Java `Set`.
+   * See [[mutableSetAsJavaSet]].
    */
   implicit def mutableSetAsJavaSetConverter[A](s : mutable.Set[A]): AsJava[ju.Set[A]] =
     new AsJava(mutableSetAsJavaSet(s))
 
   /**
-   * Adds an `asJava` method that implicitly converts a Scala `Set` to a
-   * Java `Set`.
-   *
-   * The returned Java `Set` is backed by the provided Scala `Set` and any
-   * side-effects of using it via the Java interface will be visible via
-   * the Scala interface and vice versa.
-   *
-   * If the Scala `Set` was previously obtained from an implicit or explicit
-   * call of `asSet(java.util.Set)` then the original Java `Set` will be
-   * returned.
-   *
-   * @param s The `Set` to be converted.
-   * @return An object with an `asJava` method that returns a Java `Set` view
-   *         of the argument.
+   * Adds an `asJava` method that implicitly converts a Scala `Set` to a Java `Set`.
+   * See [[setAsJavaSet]].
    */
   implicit def setAsJavaSetConverter[A](s : Set[A]): AsJava[ju.Set[A]] =
     new AsJava(setAsJavaSet(s))
 
   /**
-   * Adds an `asJava` method that implicitly converts a Scala mutable `Map`
-   * to a Java `Map`.
-   *
-   * The returned Java `Map` is backed by the provided Scala `Map` and any
-   * side-effects of using it via the Java interface will be visible via the
-   * Scala interface and vice versa.
-   *
-   * If the Scala `Map` was previously obtained from an implicit or explicit
-   * call of `asMap(java.util.Map)` then the original Java `Map` will be
-   * returned.
-   *
-   * @param m The `Map` to be converted.
-   * @return An object with an `asJava` method that returns a Java `Map` view
-   *         of the argument.
+   * Adds an `asJava` method that implicitly converts a Scala mutable `Map` to a Java `Map`.
+   * See [[mutableMapAsJavaMap]].
    */
   implicit def mutableMapAsJavaMapConverter[A, B](m : mutable.Map[A, B]): AsJava[ju.Map[A, B]] =
     new AsJava(mutableMapAsJavaMap(m))
 
   /**
-   * Adds an `asJavaDictionary` method that implicitly converts a Scala
-   * mutable `Map` to a Java `Dictionary`.
-   *
-   * The returned Java `Dictionary` is backed by the provided Scala
-   * `Dictionary` and any side-effects of using it via the Java interface
-   * will be visible via the Scala interface and vice versa.
-   *
-   * If the Scala `Dictionary` was previously obtained from an implicit or
-   * explicit call of `asMap(java.util.Dictionary)` then the original
-   * Java `Dictionary` will be returned.
-   *
-   * @param m The `Map` to be converted.
-   * @return An object with an `asJavaDictionary` method that returns a
-   *         Java `Dictionary` view of the argument.
+   * Adds an `asJavaDictionary` method that implicitly converts a Scala mutable `Map` to a Java
+   * `Dictionary`. See [[asJavaDictionary]].
    */
   implicit def asJavaDictionaryConverter[A, B](m : mutable.Map[A, B]): AsJavaDictionary[A, B] =
     new AsJavaDictionary(m)
 
   /**
-   * Adds an `asJava` method that implicitly converts a Scala `Map` to
-   * a Java `Map`.
-   *
-   * The returned Java `Map` is backed by the provided Scala `Map` and any
-   * side-effects of using it via the Java interface will be visible via
-   * the Scala interface and vice versa.
-   *
-   * If the Scala `Map` was previously obtained from an implicit or explicit
-   * call of `asMap(java.util.Map)` then the original Java `Map` will be
-   * returned.
-   *
-   * @param m The `Map` to be converted.
-   * @return An object with an `asJava` method that returns a Java `Map` view
-   *         of the argument.
+   * Adds an `asJava` method that implicitly converts a Scala `Map` to a Java `Map`.
+   * See [[mapAsJavaMap]].
    */
   implicit def mapAsJavaMapConverter[A, B](m : Map[A, B]): AsJava[ju.Map[A, B]] =
     new AsJava(mapAsJavaMap(m))
 
   /**
-   * Adds an `asJava` method that implicitly converts a Scala mutable
-   * `concurrent.Map` to a Java `ConcurrentMap`.
-   *
-   * The returned Java `ConcurrentMap` is backed by the provided Scala
-   * `concurrent.Map` and any side-effects of using it via the Java interface
-   * will be visible via the Scala interface and vice versa.
-   *
-   * If the Scala `concurrent.Map` was previously obtained from an implicit or
-   * explicit call of `asConcurrentMap(java.util.concurrent.ConcurrentMap)`
-   * then the original Java `ConcurrentMap` will be returned.
-   *
-   * @param m The Scala `concurrent.Map` to be converted.
-   * @return An object with an `asJava` method that returns a Java
-   *         `ConcurrentMap` view of the argument.
+   * Adds an `asJava` method that implicitly converts a Scala mutable `concurrent.Map` to a Java
+   * `ConcurrentMap`. See [[mapAsJavaConcurrentMap]].
    */
   implicit def mapAsJavaConcurrentMapConverter[A, B](m: concurrent.Map[A, B]): AsJava[juc.ConcurrentMap[A, B]] =
     new AsJava(mapAsJavaConcurrentMap(m))

--- a/src/library/scala/collection/convert/DecorateAsJava.scala
+++ b/src/library/scala/collection/convert/DecorateAsJava.scala
@@ -12,9 +12,7 @@ package convert
 
 import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
 import Decorators._
-import WrapAsJava._
 import scala.language.implicitConversions
-
 
 /** A collection of decorators that allow converting between
  *  Scala and Java collections using `asScala` and `asJava` methods.
@@ -57,9 +55,10 @@ import scala.language.implicitConversions
  *{{{
  *    java.util.Properties => scala.collection.mutable.Map
  *}}}
+ *
  *  @since  2.8.1
  */
-trait DecorateAsJava {
+trait DecorateAsJava extends AsJavaConverters {
   /**
    * Adds an `asJava` method that implicitly converts a Scala `Iterator` to a
    * Java `Iterator`. The returned Java `Iterator` is backed by the provided Scala

--- a/src/library/scala/collection/convert/DecorateAsScala.scala
+++ b/src/library/scala/collection/convert/DecorateAsScala.scala
@@ -1,6 +1,6 @@
 /*                     __                                               *\
 **     ________ ___   / /  ___     Scala API                            **
-**    / __/ __// _ | / /  / _ |    (c) 2006-2013, LAMP/EPFL             **
+**    / __/ __// _ | / /  / _ |    (c) 2006-2016, LAMP/EPFL             **
 **  __\ \/ /__/ __ |/ /__/ __ |    http://www.scala-lang.org/           **
 ** /____/\___/_/ |_/____/_/ | |                                         **
 **                          |/                                          **
@@ -14,182 +14,74 @@ import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
 import Decorators._
 import scala.language.implicitConversions
 
+/** Defines `asScala` extension methods for [[JavaConverters]]. */
 trait DecorateAsScala extends AsScalaConverters {
   /**
-   * Adds an `asScala` method that implicitly converts a Java `Iterator` to
-   * a Scala `Iterator`.
-   *
-   * The returned Scala `Iterator` is backed by the provided Java `Iterator`
-   * and any side-effects of using it via the Scala interface will be visible
-   * via the Java interface and vice versa.
-   *
-   * If the Java `Iterator` was previously obtained from an implicit or
-   * explicit call of `asIterator(scala.collection.Iterator)` then the
-   * original Scala `Iterator` will be returned.
-   *
-   * @param i The `Iterator` to be converted.
-   * @return An object with an `asScala` method that returns a Scala
-   *         `Iterator` view of the argument.
+   * Adds an `asScala` method that implicitly converts a Java `Iterator` to a Scala `Iterator`.
+   * See [[asScalaIterator]].
    */
   implicit def asScalaIteratorConverter[A](i : ju.Iterator[A]): AsScala[Iterator[A]] =
     new AsScala(asScalaIterator(i))
 
   /**
-   * Adds an `asScala` method that implicitly converts a Java `Enumeration`
-   * to a Scala `Iterator`.
-   *
-   * The returned Scala `Iterator` is backed by the provided Java
-   * `Enumeration` and any side-effects of using it via the Scala interface
-   * will be visible via the Java interface and vice versa.
-   *
-   * If the Java `Enumeration` was previously obtained from an implicit or
-   * explicit call of `asEnumeration(scala.collection.Iterator)` then the
-   * original Scala `Iterator` will be returned.
-   *
-   * @param i The `Enumeration` to be converted.
-   * @return An object with an `asScala` method that returns a Scala
-   *         `Iterator` view of the argument.
+   * Adds an `asScala` method that implicitly converts a Java `Enumeration` to a Scala `Iterator`.
+   * See [[enumerationAsScalaIterator]].
    */
   implicit def enumerationAsScalaIteratorConverter[A](i : ju.Enumeration[A]): AsScala[Iterator[A]] =
     new AsScala(enumerationAsScalaIterator(i))
 
   /**
-   * Adds an `asScala` method that implicitly converts a Java `Iterable` to
-   * a Scala `Iterable`.
-   *
-   * The returned Scala `Iterable` is backed by the provided Java `Iterable`
-   * and any side-effects of using it via the Scala interface will be visible
-   * via the Java interface and vice versa.
-   *
-   * If the Java `Iterable` was previously obtained from an implicit or
-   * explicit call of `asIterable(scala.collection.Iterable)` then the original
-   * Scala `Iterable` will be returned.
-   *
-   * @param i The `Iterable` to be converted.
-   * @return An object with an `asScala` method that returns a Scala `Iterable`
-   *         view of the argument.
+   * Adds an `asScala` method that implicitly converts a Java `Iterable` to a Scala `Iterable`.
+   * See [[iterableAsScalaIterable]].
    */
   implicit def iterableAsScalaIterableConverter[A](i : jl.Iterable[A]): AsScala[Iterable[A]] =
     new AsScala(iterableAsScalaIterable(i))
 
   /**
-   * Adds an `asScala` method that implicitly converts a Java `Collection` to
-   * an Scala `Iterable`.
-   *
-   * If the Java `Collection` was previously obtained from an implicit or
-   * explicit call of `asCollection(scala.collection.SizedIterable)` then
-   * the original Scala `SizedIterable` will be returned.
-   *
-   * @param i The `Collection` to be converted.
-   * @return An object with an `asScala` method that returns a Scala
-   *        `SizedIterable` view of the argument.
+   * Adds an `asScala` method that implicitly converts a Java `Collection` to an Scala `Iterable`.
+   * See [[collectionAsScalaIterable]].
    */
   implicit def collectionAsScalaIterableConverter[A](i : ju.Collection[A]): AsScala[Iterable[A]] =
     new AsScala(collectionAsScalaIterable(i))
 
   /**
-   * Adds an `asScala` method that implicitly converts a Java `List` to a
-   * Scala mutable `Buffer`.
-   *
-   * The returned Scala `Buffer` is backed by the provided Java `List` and
-   * any side-effects of using it via the Scala interface will be visible via
-   * the Java interface and vice versa.
-   *
-   * If the Java `List` was previously obtained from an implicit or explicit
-   * call of `asList(scala.collection.mutable.Buffer)` then the original
-   * Scala `Buffer` will be returned.
-   *
-   * @param l The `List` to be converted.
-   * @return An object with an `asScala` method that returns a Scala mutable
-   *        `Buffer` view of the argument.
+   * Adds an `asScala` method that implicitly converts a Java `List` to a Scala mutable `Buffer`.
+   * See [[asScalaBuffer]].
    */
   implicit def asScalaBufferConverter[A](l : ju.List[A]): AsScala[mutable.Buffer[A]] =
     new AsScala(asScalaBuffer(l))
 
   /**
-   * Adds an `asScala` method that implicitly converts a Java `Set` to a
-   * Scala mutable `Set`.
-   *
-   * The returned Scala `Set` is backed by the provided Java `Set` and any
-   * side-effects of using it via the Scala interface will be visible via
-   * the Java interface and vice versa.
-   *
-   * If the Java `Set` was previously obtained from an implicit or explicit
-   * call of `asSet(scala.collection.mutable.Set)` then the original
-   * Scala `Set` will be returned.
-   *
-   * @param s The `Set` to be converted.
-   * @return An object with an `asScala` method that returns a Scala mutable
-   *         `Set` view of the argument.
+   * Adds an `asScala` method that implicitly converts a Java `Set` to a Scala mutable `Set`.
+   * See [[asScalaSet]].
    */
   implicit def asScalaSetConverter[A](s : ju.Set[A]): AsScala[mutable.Set[A]] =
     new AsScala(asScalaSet(s))
 
   /**
-   * Adds an `asScala` method that implicitly converts a Java `Map` to a Scala
-   * mutable `Map`. The returned Scala `Map` is backed by the provided Java
-   * `Map` and any side-effects of using it via the Scala interface will
-   * be visible via the Java interface and vice versa.
-   *
-   * If the Java `Map` was previously obtained from an implicit or explicit
-   * call of `asMap(scala.collection.mutable.Map)` then the original
-   * Scala `Map` will be returned.
-   * 
-   * If the wrapped map is synchronized (e.g. from `java.util.Collections.synchronizedMap`),
-   * it is your responsibility to wrap all 
-   * non-atomic operations with `underlying.synchronized`.
-   * This includes `get`, as `java.util.Map`'s API does not allow for an
-   * atomic `get` when `null` values may be present.
-   *
-   * @param m The `Map` to be converted.
-   * @return An object with an `asScala` method that returns a Scala mutable
-   *         `Map` view of the argument.
+   * Adds an `asScala` method that implicitly converts a Java `Map` to a Scala mutable `Map`.
+   * See [[mapAsScalaMap]].
    */
   implicit def mapAsScalaMapConverter[A, B](m : ju.Map[A, B]): AsScala[mutable.Map[A, B]] =
     new AsScala(mapAsScalaMap(m))
 
   /**
-   * Adds an `asScala` method that implicitly converts a Java `ConcurrentMap`
-   * to a Scala mutable `concurrent.Map`. The returned Scala `concurrent.Map` is
-   * backed by the provided Java `ConcurrentMap` and any side-effects of using
-   * it via the Scala interface will be visible via the Java interface and
-   * vice versa.
-   *
-   * If the Java `ConcurrentMap` was previously obtained from an implicit or
-   * explicit call of `mapAsScalaConcurrentMap(scala.collection.mutable.ConcurrentMap)`
-   * then the original Scala `concurrent.Map` will be returned.
-   *
-   * @param m The `ConcurrentMap` to be converted.
-   * @return An object with an `asScala` method that returns a Scala mutable
-   *         `concurrent.Map` view of the argument.
+   * Adds an `asScala` method that implicitly converts a Java `ConcurrentMap` to a Scala mutable
+   * `concurrent.Map`. See [[mapAsScalaConcurrentMap]].
    */
   implicit def mapAsScalaConcurrentMapConverter[A, B](m: juc.ConcurrentMap[A, B]): AsScala[concurrent.Map[A, B]] =
     new AsScala(mapAsScalaConcurrentMap(m))
 
   /**
-   * Adds an `asScala` method that implicitly converts a Java `Dictionary`
-   * to a Scala mutable `Map[String, String]`. The returned Scala
-   * `Map[String, String]` is backed by the provided Java `Dictionary` and
-   * any side-effects of using it via the Scala interface will be visible via
-   * the Java interface and vice versa.
-   *
-   * @param p The `Dictionary` to be converted.
-   * @return  An object with an `asScala` method that returns a Scala mutable
-   *          `Map[String, String]` view of the argument.
+   * Adds an `asScala` method that implicitly converts a Java `Dictionary` to a Scala mutable `Map`.
+   * See [[dictionaryAsScalaMap]].
    */
   implicit def dictionaryAsScalaMapConverter[A, B](p: ju.Dictionary[A, B]): AsScala[mutable.Map[A, B]] =
     new AsScala(dictionaryAsScalaMap(p))
 
   /**
-   * Adds an `asScala` method that implicitly converts a Java `Properties`
-   * to a Scala mutable `Map[String, String]`. The returned Scala
-   * `Map[String, String]` is backed by the provided Java `Properties` and
-   * any side-effects of using it via the Scala interface will be visible via
-   * the Java interface and vice versa.
-   *
-   * @param p The `Properties` to be converted.
-   * @return  An object with an `asScala` method that returns a Scala mutable
-   *          `Map[String, String]` view of the argument.
+   * Adds an `asScala` method that implicitly converts a Java `Properties` to a Scala mutable
+   * `Map[String, String]`. See [[propertiesAsScalaMap]].
    */
   implicit def propertiesAsScalaMapConverter(p: ju.Properties): AsScala[mutable.Map[String, String]] =
     new AsScala(propertiesAsScalaMap(p))

--- a/src/library/scala/collection/convert/DecorateAsScala.scala
+++ b/src/library/scala/collection/convert/DecorateAsScala.scala
@@ -12,10 +12,9 @@ package convert
 
 import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
 import Decorators._
-import WrapAsScala._
 import scala.language.implicitConversions
 
-trait DecorateAsScala {
+trait DecorateAsScala extends AsScalaConverters {
   /**
    * Adds an `asScala` method that implicitly converts a Java `Iterator` to
    * a Scala `Iterator`.

--- a/src/library/scala/collection/convert/Decorators.scala
+++ b/src/library/scala/collection/convert/Decorators.scala
@@ -12,7 +12,7 @@ package convert
 
 import java.{ util => ju }
 
-private[collection] trait Decorators {
+private[collection] object Decorators {
   /** Generic class containing the `asJava` converter method */
   class AsJava[A](op: => A) {
     /** Converts a Scala collection to the corresponding Java collection */
@@ -28,20 +28,18 @@ private[collection] trait Decorators {
   /** Generic class containing the `asJavaCollection` converter method */
   class AsJavaCollection[A](i: Iterable[A]) {
     /** Converts a Scala `Iterable` to a Java `Collection` */
-    def asJavaCollection: ju.Collection[A] = JavaConversions.asJavaCollection(i)
+    def asJavaCollection: ju.Collection[A] = JavaConverters.asJavaCollection(i)
   }
 
   /** Generic class containing the `asJavaEnumeration` converter method */
   class AsJavaEnumeration[A](i: Iterator[A]) {
     /** Converts a Scala `Iterator` to a Java `Enumeration` */
-    def asJavaEnumeration: ju.Enumeration[A] = JavaConversions.asJavaEnumeration(i)
+    def asJavaEnumeration: ju.Enumeration[A] = JavaConverters.asJavaEnumeration(i)
   }
 
   /** Generic class containing the `asJavaDictionary` converter method */
   class AsJavaDictionary[A, B](m : mutable.Map[A, B]) {
     /** Converts a Scala `Map` to a Java `Dictionary` */
-    def asJavaDictionary: ju.Dictionary[A, B] = JavaConversions.asJavaDictionary(m)
+    def asJavaDictionary: ju.Dictionary[A, B] = JavaConverters.asJavaDictionary(m)
   }
 }
-
-private[collection] object Decorators extends Decorators

--- a/src/library/scala/collection/convert/ImplicitConversions.scala
+++ b/src/library/scala/collection/convert/ImplicitConversions.scala
@@ -17,358 +17,76 @@ import JavaConverters._
 
 /** Defines implicit converter methods from Java to Scala collections. */
 trait ToScalaImplicits {
-
-  /**
-   * Implicitly converts a Java `Iterator` to a Scala `Iterator`.
-   *
-   * The returned Scala `Iterator` is backed by the provided Java `Iterator`
-   * and any side-effects of using it via the Scala interface will be visible
-   * via the Java interface and vice versa.
-   *
-   * If the Java `Iterator` was previously obtained from an implicit or
-   * explicit call of `asIterator(scala.collection.Iterator)` then the
-   * original Scala `Iterator` will be returned.
-   *
-   * @param it The `Iterator` to be converted.
-   * @return   A Scala `Iterator` view of the argument.
-   */
+  /** Implicitly converts a Java `Iterator` to a Scala `Iterator`. See [[asScalaIterator]]. */
   implicit def `iterator asScala`[A](it: ju.Iterator[A]): Iterator[A] = asScalaIterator(it)
 
-  /**
-   * Implicitly converts a Java Enumeration to a Scala Iterator.
-   * The returned Scala Iterator is backed by the provided Java
-   * Enumeration and any side-effects of using it via the Scala interface will
-   * be visible via the Java interface and vice versa.
-   *
-   * If the Java Enumeration was previously obtained from an implicit or
-   * explicit call of `enumerationAsScalaIterator(scala.collection.Iterator)`
-   * then the original Scala Iterator will be returned.
-   *
-   * @param i The Enumeration to be converted.
-   * @return A Scala Iterator view of the argument.
-   */
+  /** Implicitly converts a Java `Enumeration` to a Scala `Iterator`. See [[enumerationAsScalaIterator]]. */
   implicit def `enumeration AsScalaIterator`[A](i: ju.Enumeration[A]): Iterator[A] = enumerationAsScalaIterator(i)
 
-  /**
-   * Implicitly converts a Java `Iterable` to a Scala `Iterable`.
-   *
-   * The returned Scala `Iterable` is backed by the provided Java `Iterable`
-   * and any side-effects of using it via the Scala interface will be visible
-   * via the Java interface and vice versa.
-   *
-   * If the Java `Iterable` was previously obtained from an implicit or
-   * explicit call of `iterableAsScalaIterable(scala.collection.Iterable)`
-   * then the original Scala Iterable will be returned.
-   *
-   * @param i The Iterable to be converted.
-   * @return A Scala Iterable view of the argument.
-   */
+  /** Implicitly converts a Java `Iterable` to a Scala `Iterable`. See [[iterableAsScalaIterable]]. */
   implicit def `iterable AsScalaIterable`[A](i: jl.Iterable[A]): Iterable[A] = iterableAsScalaIterable(i)
 
-  /**
-   * Implicitly converts a Java `Collection` to an Scala `Iterable`.
-   *
-   * If the Java `Collection` was previously obtained from an implicit or
-   * explicit call of `collectionAsScalaIterable(scala.collection.SizedIterable)`
-   * then the original Scala `Iterable` will be returned.
-   *
-   * @param i The Collection to be converted.
-   * @return A Scala Iterable view of the argument.
-   */
+  /** Implicitly converts a Java `Collection` to an Scala `Iterable`. See [[collectionAsScalaIterable]]. */
   implicit def `collection AsScalaIterable`[A](i: ju.Collection[A]): Iterable[A] = collectionAsScalaIterable(i)
 
-  /**
-   * Implicitly converts a Java `List` to a Scala mutable `Buffer`.
-   *
-   * The returned Scala `Buffer` is backed by the provided Java `List`
-   * and any side-effects of using it via the Scala interface will
-   * be visible via the Java interface and vice versa.
-   *
-   * If the Java `List` was previously obtained from an implicit or
-   * explicit call of `asScalaBuffer(scala.collection.mutable.Buffer)`
-   * then the original Scala `Buffer` will be returned.
-   *
-   * @param l The `List` to be converted.
-   * @return A Scala mutable `Buffer` view of the argument.
-   */
+  /** Implicitly converts a Java `List` to a Scala mutable `Buffer`. See [[asScalaBuffer]]. */
   implicit def `list asScalaBuffer`[A](l: ju.List[A]): mutable.Buffer[A] = asScalaBuffer(l)
 
-  /**
-   * Implicitly converts a Java Set to a Scala mutable Set.
-   * The returned Scala Set is backed by the provided Java
-   * Set and any side-effects of using it via the Scala interface will
-   * be visible via the Java interface and vice versa.
-   *
-   * If the Java Set was previously obtained from an implicit or
-   * explicit call of `asScalaSet(scala.collection.mutable.Set)` then
-   * the original Scala Set will be returned.
-   *
-   * @param s The Set to be converted.
-   * @return A Scala mutable Set view of the argument.
-   */
+  /** Implicitly converts a Java `Set` to a Scala mutable `Set`. See [[asScalaSet]]. */
   implicit def `set asScala`[A](s: ju.Set[A]): mutable.Set[A] = asScalaSet(s)
 
-  /**
-   * Implicitly converts a Java `Map` to a Scala mutable `Map`.
-   *
-   * The returned Scala `Map` is backed by the provided Java `Map` and any
-   * side-effects of using it via the Scala interface will be visible via
-   * the Java interface and vice versa.
-   *
-   * If the Java `Map` was previously obtained from an implicit or
-   * explicit call of `mapAsScalaMap(scala.collection.mutable.Map)` then
-   * the original Scala Map will be returned.
-   *
-   * If the wrapped map is synchronized (e.g. from `java.util.Collections.synchronizedMap`),
-   * it is your responsibility to wrap all
-   * non-atomic operations with `underlying.synchronized`.
-   * This includes `get`, as `java.util.Map`'s API does not allow for an
-   * atomic `get` when `null` values may be present.
-   *
-   * @param m The Map to be converted.
-   * @return A Scala mutable Map view of the argument.
-   */
+  /** Implicitly converts a Java `Map` to a Scala mutable `Map`. See [[mapAsScalaMap]]. */
   implicit def `map AsScala`[A, B](m: ju.Map[A, B]): mutable.Map[A, B] = mapAsScalaMap(m)
 
-  /**
-   * Implicitly converts a Java ConcurrentMap to a Scala mutable ConcurrentMap.
-   * The returned Scala ConcurrentMap is backed by the provided Java
-   * ConcurrentMap and any side-effects of using it via the Scala interface will
-   * be visible via the Java interface and vice versa.
-   *
-   * If the Java ConcurrentMap was previously obtained from an implicit or
-   * explicit call of `asConcurrentMap(scala.collection.mutable.ConcurrentMap)`
-   * then the original Scala ConcurrentMap will be returned.
-   *
-   * @param m The ConcurrentMap to be converted.
-   * @return A Scala mutable ConcurrentMap view of the argument.
-   */
+  /** Implicitly converts a Java `ConcurrentMap` to a Scala mutable `ConcurrentMap`. See [[mapAsScalaConcurrentMap]]. */
   implicit def `map AsScalaConcurrentMap`[A, B](m: juc.ConcurrentMap[A, B]): concurrent.Map[A, B] = mapAsScalaConcurrentMap(m)
 
-  /**
-   * Implicitly converts a Java `Dictionary` to a Scala mutable
-   * `Map`.
-   *
-   * The returned Scala `Map` is backed by the provided Java
-   * `Dictionary` and any side-effects of using it via the Scala interface
-   * will be visible via the Java interface and vice versa.
-   *
-   * @param p The Dictionary to be converted.
-   * @return  A Scala mutable Map view of the argument.
-   */
+  /** Implicitly converts a Java `Dictionary` to a Scala mutable `Map`. See [[dictionaryAsScalaMap]]. */
   implicit def `dictionary AsScalaMap`[A, B](p: ju.Dictionary[A, B]): mutable.Map[A, B] = dictionaryAsScalaMap(p)
 
-  /**
-   * Implicitly converts a Java `Properties` to a Scala `mutable Map[String, String]`.
-   *
-   * The returned Scala `Map[String, String]` is backed by the provided Java
-   * `Properties` and any side-effects of using it via the Scala interface
-   * will be visible via the Java interface and vice versa.
-   *
-   * @param p The Properties to be converted.
-   * @return  A Scala mutable Map[String, String] view of the argument.
-   */
+  /** Implicitly converts a Java `Properties` to a Scala `mutable Map[String, String]`. See [[propertiesAsScalaMap]]. */
   implicit def `properties AsScalaMap`(p: ju.Properties): mutable.Map[String, String] = propertiesAsScalaMap(p)
 }
 
 /** Defines implicit conversions from Scala to Java collections. */
 trait ToJavaImplicits {
-
-  /**
-   * Implicitly converts a Scala Iterator to a Java Iterator.
-   * The returned Java Iterator is backed by the provided Scala
-   * Iterator and any side-effects of using it via the Java interface will
-   * be visible via the Scala interface and vice versa.
-   *
-   * If the Scala Iterator was previously obtained from an implicit or
-   * explicit call of `asIterator(java.util.Iterator)` then the original
-   * Java Iterator will be returned.
-   *
-   * @param  it The Iterator to be converted.
-   * @return    A Java Iterator view of the argument.
-   */
+  /** Implicitly converts a Scala `Iterator` to a Java `Iterator`. See [[asJavaIterator]]. */
   implicit def `iterator asJava`[A](it: Iterator[A]): ju.Iterator[A] = asJavaIterator(it)
 
-  /**
-   * Implicitly converts a Scala Iterator to a Java Enumeration.
-   * The returned Java Enumeration is backed by the provided Scala
-   * Iterator and any side-effects of using it via the Java interface will
-   * be visible via the Scala interface and vice versa.
-   *
-   * If the Scala Iterator was previously obtained from an implicit or
-   * explicit call of `asIterator(java.util.Enumeration)` then the
-   * original Java Enumeration will be returned.
-   *
-   * @param it The Iterator to be converted.
-   * @return   A Java Enumeration view of the argument.
-   */
+  /** Implicitly converts a Scala `Iterator` to a Java `Enumeration`. See [[asJavaEnumeration]]. */
   implicit def `enumeration asJava`[A](it: Iterator[A]): ju.Enumeration[A] = asJavaEnumeration(it)
 
-  /**
-   * Implicitly converts a Scala Iterable to a Java Iterable.
-   * The returned Java Iterable is backed by the provided Scala
-   * Iterable and any side-effects of using it via the Java interface will
-   * be visible via the Scala interface and vice versa.
-   *
-   * If the Scala Iterable was previously obtained from an implicit or
-   * explicit call of `asIterable(java.lang.Iterable)` then the original
-   * Java Iterable will be returned.
-   *
-   * @param i The Iterable to be converted.
-   * @return A Java Iterable view of the argument.
-   */
+  /** Implicitly converts a Scala `Iterable` to a Java `Iterable`. See [[asJavaIterable]]. */
   implicit def `iterable asJava`[A](i: Iterable[A]): jl.Iterable[A] = asJavaIterable(i)
 
-  /**
-   * Implicitly converts a Scala Iterable to an immutable Java
-   * Collection.
-   *
-   * If the Scala Iterable was previously obtained from an implicit or
-   * explicit call of `asSizedIterable(java.util.Collection)` then the original
-   * Java Collection will be returned.
-   *
-   * @param it The SizedIterable to be converted.
-   * @return   A Java Collection view of the argument.
-   */
+  /** Implicitly converts a Scala `Iterable` to an immutable Java `Collection`. See [[asJavaCollection]]. */
   implicit def `collection asJava`[A](it: Iterable[A]): ju.Collection[A] = asJavaCollection(it)
 
-  /**
-   * Implicitly converts a Scala mutable Buffer to a Java List.
-   * The returned Java List is backed by the provided Scala
-   * Buffer and any side-effects of using it via the Java interface will
-   * be visible via the Scala interface and vice versa.
-   *
-   * If the Scala Buffer was previously obtained from an implicit or
-   * explicit call of `asBuffer(java.util.List)` then the original
-   * Java List will be returned.
-   *
-   * @param b The Buffer to be converted.
-   * @return A Java List view of the argument.
-   */
+  /** Implicitly converts a Scala mutable `Buffer` to a Java `List`. See [[bufferAsJavaList]]. */
   implicit def `buffer AsJavaList`[A](b: mutable.Buffer[A]): ju.List[A] = bufferAsJavaList(b)
 
-  /**
-   * Implicitly converts a Scala mutable Seq to a Java List.
-   * The returned Java List is backed by the provided Scala
-   * Seq and any side-effects of using it via the Java interface will
-   * be visible via the Scala interface and vice versa.
-   *
-   * If the Scala Seq was previously obtained from an implicit or
-   * explicit call of `asSeq(java.util.List)` then the original
-   * Java List will be returned.
-   *
-   * @param seq The Seq to be converted.
-   * @return    A Java List view of the argument.
-   */
+  /** Implicitly converts a Scala mutable `Seq` to a Java `List`. See [[mutableSeqAsJavaList]]. */
   implicit def `mutableSeq AsJavaList`[A](seq: mutable.Seq[A]): ju.List[A] = mutableSeqAsJavaList(seq)
 
-  /**
-   * Implicitly converts a Scala Seq to a Java List.
-   * The returned Java List is backed by the provided Scala
-   * Seq and any side-effects of using it via the Java interface will
-   * be visible via the Scala interface and vice versa.
-   *
-   * If the Scala Seq was previously obtained from an implicit or
-   * explicit call of `asSeq(java.util.List)` then the original
-   * Java List will be returned.
-   *
-   * @param seq The Seq to be converted.
-   * @return    A Java List view of the argument.
-   */
+  /** Implicitly converts a Scala `Seq` to a Java `List`. See [[seqAsJavaList]]. */
   implicit def `seq AsJavaList`[A](seq: Seq[A]): ju.List[A] = seqAsJavaList(seq)
 
-  /**
-   * Implicitly converts a Scala mutable Set to a Java Set.
-   * The returned Java Set is backed by the provided Scala
-   * Set and any side-effects of using it via the Java interface will
-   * be visible via the Scala interface and vice versa.
-   *
-   * If the Scala Set was previously obtained from an implicit or
-   * explicit call of `asSet(java.util.Set)` then the original
-   * Java Set will be returned.
-   *
-   * @param s The Set to be converted.
-   * @return A Java Set view of the argument.
-   */
+  /** Implicitly converts a Scala mutable `Set` to a Java `Set`. See [[mutableSetAsJavaSet]]. */
   implicit def `mutableSet AsJavaSet`[A](s: mutable.Set[A]): ju.Set[A] = mutableSetAsJavaSet(s)
 
-  /**
-   * Implicitly converts a Scala Set to a Java Set.
-   * The returned Java Set is backed by the provided Scala
-   * Set and any side-effects of using it via the Java interface will
-   * be visible via the Scala interface and vice versa.
-   *
-   * If the Scala Set was previously obtained from an implicit or
-   * explicit call of asSet(java.util.Set) then the original
-   * Java Set will be returned.
-   *
-   * @param s The Set to be converted.
-   * @return A Java Set view of the argument.
-   */
+  /** Implicitly converts a Scala `Set` to a Java `Set`. See [[setAsJavaSet]]. */
   implicit def `set AsJavaSet`[A](s: Set[A]): ju.Set[A] = setAsJavaSet(s)
 
-  /**
-   * Implicitly converts a Scala mutable Map to a Java Map.
-   * The returned Java Map is backed by the provided Scala
-   * Map and any side-effects of using it via the Java interface will
-   * be visible via the Scala interface and vice versa.
-   *
-   * If the Scala Map was previously obtained from an implicit or
-   * explicit call of `asMap(java.util.Map)` then the original
-   * Java Map will be returned.
-   *
-   * @param m The Map to be converted.
-   * @return A Java Map view of the argument.
-   */
+  /** Implicitly converts a Scala mutable `Map` to a Java `Map`. See [[mutableMapAsJavaMap]]. */
   implicit def `mutableMap AsJavaMap`[A, B](m: mutable.Map[A, B]): ju.Map[A, B] = mutableMapAsJavaMap(m)
 
-  /**
-   * Implicitly converts a Scala mutable `Map` to a Java `Dictionary`.
-   *
-   * The returned Java `Dictionary` is backed by the provided Scala
-   * `Dictionary` and any side-effects of using it via the Java interface
-   * will be visible via the Scala interface and vice versa.
-   *
-   * If the Scala `Dictionary` was previously obtained from an implicit or
-   * explicit call of `asMap(java.util.Dictionary)` then the original
-   * Java Dictionary will be returned.
-   *
-   * @param m The `Map` to be converted.
-   * @return A Java `Dictionary` view of the argument.
-   */
+  /** Implicitly converts a Scala mutable `Map` to a Java `Dictionary`. See [[asJavaDictionary]]. */
   implicit def `dictionary asJava`[A, B](m: mutable.Map[A, B]): ju.Dictionary[A, B] = asJavaDictionary(m)
 
-  /**
-   * Implicitly converts a Scala `Map` to a Java `Map`.
-   *
-   * The returned Java `Map` is backed by the provided Scala `Map` and
-   * any side-effects of using it via the Java interface will be visible
-   * via the Scala interface and vice versa.
-   *
-   * If the Scala `Map` was previously obtained from an implicit or
-   * explicit call of `asMap(java.util.Map)` then the original
-   * Java `Map` will be returned.
-   *
-   * @param m The `Map` to be converted.
-   * @return A Java `Map` view of the argument.
-   */
+  /** Implicitly converts a Scala `Map` to a Java `Map`. See [[mapAsJavaMap]]. */
   implicit def `map AsJavaMap`[A, B](m: Map[A, B]): ju.Map[A, B] = mapAsJavaMap(m)
 
-  /**
-   * Implicitly converts a Scala mutable `concurrent.Map` to a Java
-   * `ConcurrentMap`.
-   *
-   * The returned Java `ConcurrentMap` is backed by the provided Scala
-   * `concurrent.Map` and any side-effects of using it via the Java interface
-   * will be visible via the Scala interface and vice versa.
-   *
-   * If the Scala `concurrent.Map` was previously obtained from an implicit or
-   * explicit call of `mapAsScalaConcurrentMap(java.util.concurrent.ConcurrentMap)`
-   * then the original Java ConcurrentMap will be returned.
-   *
-   * @param m The Scala `concurrent.Map` to be converted.
-   * @return A Java `ConcurrentMap` view of the argument.
-   */
+  /** Implicitly converts a Scala mutable `concurrent.Map` to a Java `ConcurrentMap`. See [[mapAsJavaConcurrentMap]]. */
   implicit def `map AsJavaConcurrentMap`[A, B](m: concurrent.Map[A, B]): juc.ConcurrentMap[A, B] = mapAsJavaConcurrentMap(m)
 }
 

--- a/src/library/scala/collection/convert/ImplicitConversions.scala
+++ b/src/library/scala/collection/convert/ImplicitConversions.scala
@@ -1,0 +1,407 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2006-2016, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://www.scala-lang.org/           **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala
+package collection
+package convert
+
+import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
+import scala.language.implicitConversions
+
+import JavaConverters._
+
+/** Defines implicit converter methods from Java to Scala collections. */
+trait ToScalaImplicits {
+
+  /**
+   * Implicitly converts a Java `Iterator` to a Scala `Iterator`.
+   *
+   * The returned Scala `Iterator` is backed by the provided Java `Iterator`
+   * and any side-effects of using it via the Scala interface will be visible
+   * via the Java interface and vice versa.
+   *
+   * If the Java `Iterator` was previously obtained from an implicit or
+   * explicit call of `asIterator(scala.collection.Iterator)` then the
+   * original Scala `Iterator` will be returned.
+   *
+   * @param it The `Iterator` to be converted.
+   * @return   A Scala `Iterator` view of the argument.
+   */
+  implicit def `iterator asScala`[A](it: ju.Iterator[A]): Iterator[A] = asScalaIterator(it)
+
+  /**
+   * Implicitly converts a Java Enumeration to a Scala Iterator.
+   * The returned Scala Iterator is backed by the provided Java
+   * Enumeration and any side-effects of using it via the Scala interface will
+   * be visible via the Java interface and vice versa.
+   *
+   * If the Java Enumeration was previously obtained from an implicit or
+   * explicit call of `enumerationAsScalaIterator(scala.collection.Iterator)`
+   * then the original Scala Iterator will be returned.
+   *
+   * @param i The Enumeration to be converted.
+   * @return A Scala Iterator view of the argument.
+   */
+  implicit def `enumeration AsScalaIterator`[A](i: ju.Enumeration[A]): Iterator[A] = enumerationAsScalaIterator(i)
+
+  /**
+   * Implicitly converts a Java `Iterable` to a Scala `Iterable`.
+   *
+   * The returned Scala `Iterable` is backed by the provided Java `Iterable`
+   * and any side-effects of using it via the Scala interface will be visible
+   * via the Java interface and vice versa.
+   *
+   * If the Java `Iterable` was previously obtained from an implicit or
+   * explicit call of `iterableAsScalaIterable(scala.collection.Iterable)`
+   * then the original Scala Iterable will be returned.
+   *
+   * @param i The Iterable to be converted.
+   * @return A Scala Iterable view of the argument.
+   */
+  implicit def `iterable AsScalaIterable`[A](i: jl.Iterable[A]): Iterable[A] = iterableAsScalaIterable(i)
+
+  /**
+   * Implicitly converts a Java `Collection` to an Scala `Iterable`.
+   *
+   * If the Java `Collection` was previously obtained from an implicit or
+   * explicit call of `collectionAsScalaIterable(scala.collection.SizedIterable)`
+   * then the original Scala `Iterable` will be returned.
+   *
+   * @param i The Collection to be converted.
+   * @return A Scala Iterable view of the argument.
+   */
+  implicit def `collection AsScalaIterable`[A](i: ju.Collection[A]): Iterable[A] = collectionAsScalaIterable(i)
+
+  /**
+   * Implicitly converts a Java `List` to a Scala mutable `Buffer`.
+   *
+   * The returned Scala `Buffer` is backed by the provided Java `List`
+   * and any side-effects of using it via the Scala interface will
+   * be visible via the Java interface and vice versa.
+   *
+   * If the Java `List` was previously obtained from an implicit or
+   * explicit call of `asScalaBuffer(scala.collection.mutable.Buffer)`
+   * then the original Scala `Buffer` will be returned.
+   *
+   * @param l The `List` to be converted.
+   * @return A Scala mutable `Buffer` view of the argument.
+   */
+  implicit def `list asScalaBuffer`[A](l: ju.List[A]): mutable.Buffer[A] = asScalaBuffer(l)
+
+  /**
+   * Implicitly converts a Java Set to a Scala mutable Set.
+   * The returned Scala Set is backed by the provided Java
+   * Set and any side-effects of using it via the Scala interface will
+   * be visible via the Java interface and vice versa.
+   *
+   * If the Java Set was previously obtained from an implicit or
+   * explicit call of `asScalaSet(scala.collection.mutable.Set)` then
+   * the original Scala Set will be returned.
+   *
+   * @param s The Set to be converted.
+   * @return A Scala mutable Set view of the argument.
+   */
+  implicit def `set asScala`[A](s: ju.Set[A]): mutable.Set[A] = asScalaSet(s)
+
+  /**
+   * Implicitly converts a Java `Map` to a Scala mutable `Map`.
+   *
+   * The returned Scala `Map` is backed by the provided Java `Map` and any
+   * side-effects of using it via the Scala interface will be visible via
+   * the Java interface and vice versa.
+   *
+   * If the Java `Map` was previously obtained from an implicit or
+   * explicit call of `mapAsScalaMap(scala.collection.mutable.Map)` then
+   * the original Scala Map will be returned.
+   *
+   * If the wrapped map is synchronized (e.g. from `java.util.Collections.synchronizedMap`),
+   * it is your responsibility to wrap all
+   * non-atomic operations with `underlying.synchronized`.
+   * This includes `get`, as `java.util.Map`'s API does not allow for an
+   * atomic `get` when `null` values may be present.
+   *
+   * @param m The Map to be converted.
+   * @return A Scala mutable Map view of the argument.
+   */
+  implicit def `map AsScala`[A, B](m: ju.Map[A, B]): mutable.Map[A, B] = mapAsScalaMap(m)
+
+  /**
+   * Implicitly converts a Java ConcurrentMap to a Scala mutable ConcurrentMap.
+   * The returned Scala ConcurrentMap is backed by the provided Java
+   * ConcurrentMap and any side-effects of using it via the Scala interface will
+   * be visible via the Java interface and vice versa.
+   *
+   * If the Java ConcurrentMap was previously obtained from an implicit or
+   * explicit call of `asConcurrentMap(scala.collection.mutable.ConcurrentMap)`
+   * then the original Scala ConcurrentMap will be returned.
+   *
+   * @param m The ConcurrentMap to be converted.
+   * @return A Scala mutable ConcurrentMap view of the argument.
+   */
+  implicit def `map AsScalaConcurrentMap`[A, B](m: juc.ConcurrentMap[A, B]): concurrent.Map[A, B] = mapAsScalaConcurrentMap(m)
+
+  /**
+   * Implicitly converts a Java `Dictionary` to a Scala mutable
+   * `Map`.
+   *
+   * The returned Scala `Map` is backed by the provided Java
+   * `Dictionary` and any side-effects of using it via the Scala interface
+   * will be visible via the Java interface and vice versa.
+   *
+   * @param p The Dictionary to be converted.
+   * @return  A Scala mutable Map view of the argument.
+   */
+  implicit def `dictionary AsScalaMap`[A, B](p: ju.Dictionary[A, B]): mutable.Map[A, B] = dictionaryAsScalaMap(p)
+
+  /**
+   * Implicitly converts a Java `Properties` to a Scala `mutable Map[String, String]`.
+   *
+   * The returned Scala `Map[String, String]` is backed by the provided Java
+   * `Properties` and any side-effects of using it via the Scala interface
+   * will be visible via the Java interface and vice versa.
+   *
+   * @param p The Properties to be converted.
+   * @return  A Scala mutable Map[String, String] view of the argument.
+   */
+  implicit def `properties AsScalaMap`(p: ju.Properties): mutable.Map[String, String] = propertiesAsScalaMap(p)
+}
+
+/** Defines implicit conversions from Scala to Java collections. */
+trait ToJavaImplicits {
+
+  /**
+   * Implicitly converts a Scala Iterator to a Java Iterator.
+   * The returned Java Iterator is backed by the provided Scala
+   * Iterator and any side-effects of using it via the Java interface will
+   * be visible via the Scala interface and vice versa.
+   *
+   * If the Scala Iterator was previously obtained from an implicit or
+   * explicit call of `asIterator(java.util.Iterator)` then the original
+   * Java Iterator will be returned.
+   *
+   * @param  it The Iterator to be converted.
+   * @return    A Java Iterator view of the argument.
+   */
+  implicit def `iterator asJava`[A](it: Iterator[A]): ju.Iterator[A] = asJavaIterator(it)
+
+  /**
+   * Implicitly converts a Scala Iterator to a Java Enumeration.
+   * The returned Java Enumeration is backed by the provided Scala
+   * Iterator and any side-effects of using it via the Java interface will
+   * be visible via the Scala interface and vice versa.
+   *
+   * If the Scala Iterator was previously obtained from an implicit or
+   * explicit call of `asIterator(java.util.Enumeration)` then the
+   * original Java Enumeration will be returned.
+   *
+   * @param it The Iterator to be converted.
+   * @return   A Java Enumeration view of the argument.
+   */
+  implicit def `enumeration asJava`[A](it: Iterator[A]): ju.Enumeration[A] = asJavaEnumeration(it)
+
+  /**
+   * Implicitly converts a Scala Iterable to a Java Iterable.
+   * The returned Java Iterable is backed by the provided Scala
+   * Iterable and any side-effects of using it via the Java interface will
+   * be visible via the Scala interface and vice versa.
+   *
+   * If the Scala Iterable was previously obtained from an implicit or
+   * explicit call of `asIterable(java.lang.Iterable)` then the original
+   * Java Iterable will be returned.
+   *
+   * @param i The Iterable to be converted.
+   * @return A Java Iterable view of the argument.
+   */
+  implicit def `iterable asJava`[A](i: Iterable[A]): jl.Iterable[A] = asJavaIterable(i)
+
+  /**
+   * Implicitly converts a Scala Iterable to an immutable Java
+   * Collection.
+   *
+   * If the Scala Iterable was previously obtained from an implicit or
+   * explicit call of `asSizedIterable(java.util.Collection)` then the original
+   * Java Collection will be returned.
+   *
+   * @param it The SizedIterable to be converted.
+   * @return   A Java Collection view of the argument.
+   */
+  implicit def `collection asJava`[A](it: Iterable[A]): ju.Collection[A] = asJavaCollection(it)
+
+  /**
+   * Implicitly converts a Scala mutable Buffer to a Java List.
+   * The returned Java List is backed by the provided Scala
+   * Buffer and any side-effects of using it via the Java interface will
+   * be visible via the Scala interface and vice versa.
+   *
+   * If the Scala Buffer was previously obtained from an implicit or
+   * explicit call of `asBuffer(java.util.List)` then the original
+   * Java List will be returned.
+   *
+   * @param b The Buffer to be converted.
+   * @return A Java List view of the argument.
+   */
+  implicit def `buffer AsJavaList`[A](b: mutable.Buffer[A]): ju.List[A] = bufferAsJavaList(b)
+
+  /**
+   * Implicitly converts a Scala mutable Seq to a Java List.
+   * The returned Java List is backed by the provided Scala
+   * Seq and any side-effects of using it via the Java interface will
+   * be visible via the Scala interface and vice versa.
+   *
+   * If the Scala Seq was previously obtained from an implicit or
+   * explicit call of `asSeq(java.util.List)` then the original
+   * Java List will be returned.
+   *
+   * @param seq The Seq to be converted.
+   * @return    A Java List view of the argument.
+   */
+  implicit def `mutableSeq AsJavaList`[A](seq: mutable.Seq[A]): ju.List[A] = mutableSeqAsJavaList(seq)
+
+  /**
+   * Implicitly converts a Scala Seq to a Java List.
+   * The returned Java List is backed by the provided Scala
+   * Seq and any side-effects of using it via the Java interface will
+   * be visible via the Scala interface and vice versa.
+   *
+   * If the Scala Seq was previously obtained from an implicit or
+   * explicit call of `asSeq(java.util.List)` then the original
+   * Java List will be returned.
+   *
+   * @param seq The Seq to be converted.
+   * @return    A Java List view of the argument.
+   */
+  implicit def `seq AsJavaList`[A](seq: Seq[A]): ju.List[A] = seqAsJavaList(seq)
+
+  /**
+   * Implicitly converts a Scala mutable Set to a Java Set.
+   * The returned Java Set is backed by the provided Scala
+   * Set and any side-effects of using it via the Java interface will
+   * be visible via the Scala interface and vice versa.
+   *
+   * If the Scala Set was previously obtained from an implicit or
+   * explicit call of `asSet(java.util.Set)` then the original
+   * Java Set will be returned.
+   *
+   * @param s The Set to be converted.
+   * @return A Java Set view of the argument.
+   */
+  implicit def `mutableSet AsJavaSet`[A](s: mutable.Set[A]): ju.Set[A] = mutableSetAsJavaSet(s)
+
+  /**
+   * Implicitly converts a Scala Set to a Java Set.
+   * The returned Java Set is backed by the provided Scala
+   * Set and any side-effects of using it via the Java interface will
+   * be visible via the Scala interface and vice versa.
+   *
+   * If the Scala Set was previously obtained from an implicit or
+   * explicit call of asSet(java.util.Set) then the original
+   * Java Set will be returned.
+   *
+   * @param s The Set to be converted.
+   * @return A Java Set view of the argument.
+   */
+  implicit def `set AsJavaSet`[A](s: Set[A]): ju.Set[A] = setAsJavaSet(s)
+
+  /**
+   * Implicitly converts a Scala mutable Map to a Java Map.
+   * The returned Java Map is backed by the provided Scala
+   * Map and any side-effects of using it via the Java interface will
+   * be visible via the Scala interface and vice versa.
+   *
+   * If the Scala Map was previously obtained from an implicit or
+   * explicit call of `asMap(java.util.Map)` then the original
+   * Java Map will be returned.
+   *
+   * @param m The Map to be converted.
+   * @return A Java Map view of the argument.
+   */
+  implicit def `mutableMap AsJavaMap`[A, B](m: mutable.Map[A, B]): ju.Map[A, B] = mutableMapAsJavaMap(m)
+
+  /**
+   * Implicitly converts a Scala mutable `Map` to a Java `Dictionary`.
+   *
+   * The returned Java `Dictionary` is backed by the provided Scala
+   * `Dictionary` and any side-effects of using it via the Java interface
+   * will be visible via the Scala interface and vice versa.
+   *
+   * If the Scala `Dictionary` was previously obtained from an implicit or
+   * explicit call of `asMap(java.util.Dictionary)` then the original
+   * Java Dictionary will be returned.
+   *
+   * @param m The `Map` to be converted.
+   * @return A Java `Dictionary` view of the argument.
+   */
+  implicit def `dictionary asJava`[A, B](m: mutable.Map[A, B]): ju.Dictionary[A, B] = asJavaDictionary(m)
+
+  /**
+   * Implicitly converts a Scala `Map` to a Java `Map`.
+   *
+   * The returned Java `Map` is backed by the provided Scala `Map` and
+   * any side-effects of using it via the Java interface will be visible
+   * via the Scala interface and vice versa.
+   *
+   * If the Scala `Map` was previously obtained from an implicit or
+   * explicit call of `asMap(java.util.Map)` then the original
+   * Java `Map` will be returned.
+   *
+   * @param m The `Map` to be converted.
+   * @return A Java `Map` view of the argument.
+   */
+  implicit def `map AsJavaMap`[A, B](m: Map[A, B]): ju.Map[A, B] = mapAsJavaMap(m)
+
+  /**
+   * Implicitly converts a Scala mutable `concurrent.Map` to a Java
+   * `ConcurrentMap`.
+   *
+   * The returned Java `ConcurrentMap` is backed by the provided Scala
+   * `concurrent.Map` and any side-effects of using it via the Java interface
+   * will be visible via the Scala interface and vice versa.
+   *
+   * If the Scala `concurrent.Map` was previously obtained from an implicit or
+   * explicit call of `mapAsScalaConcurrentMap(java.util.concurrent.ConcurrentMap)`
+   * then the original Java ConcurrentMap will be returned.
+   *
+   * @param m The Scala `concurrent.Map` to be converted.
+   * @return A Java `ConcurrentMap` view of the argument.
+   */
+  implicit def `map AsJavaConcurrentMap`[A, B](m: concurrent.Map[A, B]): juc.ConcurrentMap[A, B] = mapAsJavaConcurrentMap(m)
+}
+
+/**
+ * Convenience for miscellaneous implicit conversions from Scala to Java collections API.
+ *
+ * It is recommended to use explicit conversions provided by [[collection.JavaConverters]] instead.
+ * Implicit conversions may cause unexpected issues, see [[ImplicitConversions]].
+ */
+object ImplicitConversionsToJava extends ToJavaImplicits
+
+/**
+ * Convenience for miscellaneous implicit conversions from Java to Scala collections API.
+ *
+ * It is recommended to use explicit conversions provided by [[collection.JavaConverters]] instead.
+ * Implicit conversions may cause unexpected issues, see [[ImplicitConversions]].
+ */
+object ImplicitConversionsToScala extends ToScalaImplicits
+
+/**
+ * Convenience for miscellaneous implicit conversions between Java and Scala collections API.
+ *
+ * It is recommended to use explicit conversions provided by [[collection.JavaConverters]] instead.
+ * Implicit conversions may cause unexpected issues. Example:
+ *
+ * {{{
+ *   import collection.convert.ImplicitConversions._
+ *   case class StringBox(s: String)
+ *   val m = Map(StringBox("one") -> "uno")
+ *   m.get("one")
+ * }}}
+ *
+ * The above example returns `null` instead of producing a type error at compile-time. The map is
+ * implicitly converted to a `java.util.Map` which provides a method `get(x: AnyRef)`.
+ */
+object ImplicitConversions extends ToScalaImplicits with ToJavaImplicits

--- a/src/library/scala/collection/convert/WrapAsJava.scala
+++ b/src/library/scala/collection/convert/WrapAsJava.scala
@@ -14,7 +14,26 @@ import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
 import scala.language.implicitConversions
 
 @deprecated("Use JavaConverters or consider ToJavaImplicits", since="2.12")
-trait WrapAsJava {
+trait WrapAsJava extends LowPriorityWrapAsJava {
+  // provide higher-priority implicits with names that don't exist in JavaConverters for the case
+  // when importing both JavaConverters._ and JavaConversions._. otherwise implicit conversions
+  // would not apply, see https://github.com/scala/scala/pull/5109#issuecomment-212417789
+  implicit def `deprecated asJavaIterator`[A](it: Iterator[A]): ju.Iterator[A] = asJavaIterator(it)
+  implicit def `deprecated asJavaEnumeration`[A](it: Iterator[A]): ju.Enumeration[A] = asJavaEnumeration(it)
+  implicit def `deprecated asJavaIterable`[A](i: Iterable[A]): jl.Iterable[A] = asJavaIterable(i)
+  implicit def `deprecated asJavaCollection`[A](it: Iterable[A]): ju.Collection[A] = asJavaCollection(it)
+  implicit def `deprecated bufferAsJavaList`[A](b: mutable.Buffer[A]): ju.List[A] = bufferAsJavaList(b)
+  implicit def `deprecated mutableSeqAsJavaList`[A](seq: mutable.Seq[A]): ju.List[A] = mutableSeqAsJavaList(seq)
+  implicit def `deprecated seqAsJavaList`[A](seq: Seq[A]): ju.List[A] = seqAsJavaList(seq)
+  implicit def `deprecated mutableSetAsJavaSet`[A](s: mutable.Set[A]): ju.Set[A] = mutableSetAsJavaSet(s)
+  implicit def `deprecated setAsJavaSet`[A](s: Set[A]): ju.Set[A] = setAsJavaSet(s)
+  implicit def `deprecated mutableMapAsJavaMap`[A, B](m: mutable.Map[A, B]): ju.Map[A, B] = mutableMapAsJavaMap(m)
+  implicit def `deprecated asJavaDictionary`[A, B](m: mutable.Map[A, B]): ju.Dictionary[A, B] = asJavaDictionary(m)
+  implicit def `deprecated mapAsJavaMap`[A, B](m: Map[A, B]): ju.Map[A, B] = mapAsJavaMap(m)
+  implicit def `deprecated mapAsJavaConcurrentMap`[A, B](m: concurrent.Map[A, B]): juc.ConcurrentMap[A, B] = mapAsJavaConcurrentMap(m)
+}
+
+private[convert] trait LowPriorityWrapAsJava {
   import Wrappers._
 
   /**

--- a/src/library/scala/collection/convert/WrapAsScala.scala
+++ b/src/library/scala/collection/convert/WrapAsScala.scala
@@ -14,8 +14,25 @@ import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
 import scala.language.implicitConversions
 
 @deprecated("Use JavaConverters or consider ToScalaImplicits", since="2.12")
-trait WrapAsScala {
+trait WrapAsScala extends LowPriorityWrapAsScala {
+  // provide higher-priority implicits with names that don't exist in JavaConverters for the case
+  // when importing both JavaConverters._ and JavaConversions._. otherwise implicit conversions
+  // would not apply, see https://github.com/scala/scala/pull/5109#issuecomment-212417789
+  implicit def `deprecated asScalaIterator`[A](it: ju.Iterator[A]): Iterator[A] = asScalaIterator(it)
+  implicit def `deprecated enumerationAsScalaIterator`[A](i: ju.Enumeration[A]): Iterator[A] = enumerationAsScalaIterator(i)
+  implicit def `deprecated iterableAsScalaIterable`[A](i: jl.Iterable[A]): Iterable[A] = iterableAsScalaIterable(i)
+  implicit def `deprecated collectionAsScalaIterable`[A](i: ju.Collection[A]): Iterable[A] = collectionAsScalaIterable(i)
+  implicit def `deprecated asScalaBuffer`[A](l: ju.List[A]): mutable.Buffer[A] = asScalaBuffer(l)
+  implicit def `deprecated asScalaSet`[A](s: ju.Set[A]): mutable.Set[A] = asScalaSet(s)
+  implicit def `deprecated mapAsScalaMap`[A, B](m: ju.Map[A, B]): mutable.Map[A, B] = mapAsScalaMap(m)
+  implicit def `deprecated mapAsScalaConcurrentMap`[A, B](m: juc.ConcurrentMap[A, B]): concurrent.Map[A, B] = mapAsScalaConcurrentMap(m)
+  implicit def `deprecated dictionaryAsScalaMap`[A, B](p: ju.Dictionary[A, B]): mutable.Map[A, B] = dictionaryAsScalaMap(p)
+  implicit def `deprecated propertiesAsScalaMap`(p: ju.Properties): mutable.Map[String, String] = propertiesAsScalaMap(p)
+}
+
+private[convert] trait LowPriorityWrapAsScala {
   import Wrappers._
+
   /**
    * Implicitly converts a Java `Iterator` to a Scala `Iterator`.
    *

--- a/src/library/scala/collection/convert/Wrappers.scala
+++ b/src/library/scala/collection/convert/Wrappers.scala
@@ -14,17 +14,7 @@ import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
 import WrapAsScala._
 import WrapAsJava._
 
-/** Adapters for Java/Scala collections API.
- *  
- *  The implicit scope of these wrappers includes the current
- *  lexical scope as well as enclosing package scopes, so the
- *  implicit conversions provided by `AsScalaImplicits` and
- *  `AsJavaImplicits` must not be installed in those enclosing
- *  scopes.
- *  
- *  In particular, the implicit scope of classes extending these
- *  wrappers also includes those contexts. See SI-5580.
- */
+/** Adapters for Java/Scala collections API. */
 private[collection] trait Wrappers {
   trait IterableWrapperTrait[A] extends ju.AbstractCollection[A] {
     val underlying: Iterable[A]

--- a/src/library/scala/collection/convert/Wrappers.scala
+++ b/src/library/scala/collection/convert/Wrappers.scala
@@ -14,9 +14,16 @@ import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
 import WrapAsScala._
 import WrapAsJava._
 
-/** Don't put the implementations in the same scope as the implicits
- *  which utilize them, or they will stow away into every scope which
- *  extends one of those implementations.  See SI-5580.
+/** Adapters for Java/Scala collections API.
+ *  
+ *  The implicit scope of these wrappers includes the current
+ *  lexical scope as well as enclosing package scopes, so the
+ *  implicit conversions provided by `AsScalaImplicits` and
+ *  `AsJavaImplicits` must not be installed in those enclosing
+ *  scopes.
+ *  
+ *  In particular, the implicit scope of classes extending these
+ *  wrappers also includes those contexts. See SI-5580.
  */
 private[collection] trait Wrappers {
   trait IterableWrapperTrait[A] extends ju.AbstractCollection[A] {

--- a/src/library/scala/collection/convert/package.scala
+++ b/src/library/scala/collection/convert/package.scala
@@ -10,10 +10,17 @@ package scala
 package collection
 
 package object convert {
+  @deprecated("Use JavaConverters", since="2.12")
   val decorateAsJava  = new DecorateAsJava { }
+  @deprecated("Use JavaConverters", since="2.12")
   val decorateAsScala = new DecorateAsScala { }
-  val decorateAll     = new DecorateAsJava with DecorateAsScala { }
+  @deprecated("Use JavaConverters", since="2.12")
+  val decorateAll     = JavaConverters
+
+  @deprecated("Use JavaConverters or consider ImplicitConversionsToJava", since="2.12")
   val wrapAsJava      = new WrapAsJava { }
+  @deprecated("Use JavaConverters or consider ImplicitConversionsToScala", since="2.12")
   val wrapAsScala     = new WrapAsScala { }
+  @deprecated("Use JavaConverters or consider ImplicitConversions", since="2.12")
   val wrapAll         = new WrapAsJava with WrapAsScala { }
 }

--- a/src/library/scala/collection/package.scala
+++ b/src/library/scala/collection/package.scala
@@ -76,13 +76,9 @@ package scala
  * The concrete parallel collections also have specific performance characteristics which are
  * described in [[http://docs.scala-lang.org/overviews/parallel-collections/concrete-parallel-collections.html#performance-characteristics the parallel collections guide]]
  *
- * === Converting between Java Collections ===
+ * === Converting to and from Java Collections ===
  *
- * The [[scala.collection.JavaConversions]] object provides implicit defs that
- * will allow mostly seamless integration between APIs using Java Collections
- * and the Scala collections library.
- *
- * Alternatively the [[scala.collection.JavaConverters]] object provides a collection
+ * The [[scala.collection.JavaConverters]] object provides a collection
  * of decorators that allow converting between Scala and Java collections using `asScala`
  * and `asJava` methods.
  */

--- a/src/library/scala/sys/process/package.scala
+++ b/src/library/scala/sys/process/package.scala
@@ -203,9 +203,9 @@ package scala.sys {
   package object process extends ProcessImplicits {
     /** The arguments passed to `java` when creating this process */
     def javaVmArguments: List[String] = {
-      import scala.collection.JavaConversions._
+      import scala.collection.JavaConverters._
 
-      java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments().toList
+      java.lang.management.ManagementFactory.getRuntimeMXBean.getInputArguments.asScala.toList
     }
     /** The input stream of this process */
     def stdin  = java.lang.System.in

--- a/src/reflect/scala/reflect/io/ZipArchive.scala
+++ b/src/reflect/scala/reflect/io/ZipArchive.scala
@@ -13,7 +13,7 @@ import java.io.{ File => JFile }
 import java.util.zip.{ ZipEntry, ZipFile, ZipInputStream }
 import java.util.jar.Manifest
 import scala.collection.mutable
-import scala.collection.convert.WrapAsScala.asScalaIterator
+import scala.collection.JavaConverters._
 import scala.annotation.tailrec
 
 /** An abstraction for zip files and streams.  Everything is written the way
@@ -238,7 +238,7 @@ final class ManifestResources(val url: URL) extends ZipArchive(null) {
     val root     = new DirEntry("/")
     val dirs     = mutable.HashMap[String, DirEntry]("/" -> root)
     val manifest = new Manifest(input)
-    val iter     = manifest.getEntries().keySet().iterator().filter(_.endsWith(".class")).map(new ZipEntry(_))
+    val iter     = manifest.getEntries().keySet().iterator().asScala.filter(_.endsWith(".class")).map(new ZipEntry(_))
 
     for (zipEntry <- iter) {
       val dir = getDir(dirs, zipEntry)

--- a/test/disabled/presentation/akka/src/akka/actor/ActorRegistry.scala
+++ b/test/disabled/presentation/akka/src/akka/actor/ActorRegistry.scala
@@ -342,7 +342,7 @@ class Index[K <: AnyRef, V <: AnyRef: ArrayTag] {
    * if no matches it returns None
    */
   def findValue(key: K)(f: (V) => Boolean): Option[V] = {
-    import scala.collection.JavaConversions._
+    import scala.collection.convert.wrapAsScala._
     val set = container get key
     if (set ne null) set.iterator.find(f)
     else None
@@ -352,7 +352,7 @@ class Index[K <: AnyRef, V <: AnyRef: ArrayTag] {
    * Applies the supplied function to all keys and their values
    */
   def foreach(fun: (K, V) => Unit) {
-    import scala.collection.JavaConversions._
+    import scala.collection.convert.wrapAsScala._
     container.entrySet foreach { (e) =>
       e.getValue.foreach(fun(e.getKey, _))
     }

--- a/test/disabled/presentation/akka/src/akka/actor/Scheduler.scala
+++ b/test/disabled/presentation/akka/src/akka/actor/Scheduler.scala
@@ -15,8 +15,6 @@
  */
 package akka.actor
 
-import scala.collection.JavaConversions
-
 import java.util.concurrent._
 
 import akka.event.EventHandler

--- a/test/disabled/presentation/akka/src/akka/japi/JavaAPI.scala
+++ b/test/disabled/presentation/akka/src/akka/japi/JavaAPI.scala
@@ -58,7 +58,7 @@ trait Creator[T] {
  * Java API
  */
 sealed abstract class Option[A] extends java.lang.Iterable[A] {
-  import scala.collection.JavaConversions._
+  import scala.collection.convert.wrapAsScala._
 
   def get: A
   def isEmpty: Boolean

--- a/test/disabled/presentation/akka/src/akka/routing/Iterators.scala
+++ b/test/disabled/presentation/akka/src/akka/routing/Iterators.scala
@@ -5,7 +5,7 @@
 package akka.routing
 
 import akka.actor.ActorRef
-import scala.collection.JavaConversions._
+import scala.collection.convert.wrapAsScala._
 import scala.collection.immutable.Seq
 
 /**

--- a/test/disabled/presentation/akka/src/akka/routing/Listeners.scala
+++ b/test/disabled/presentation/akka/src/akka/routing/Listeners.scala
@@ -6,7 +6,7 @@ package akka.routing
 
 import akka.actor.{ Actor, ActorRef }
 import java.util.concurrent.ConcurrentSkipListSet
-import scala.collection.JavaConversions._
+import scala.collection.convert.wrapAsScala._
 
 sealed trait ListenerMessage
 case class Listen(listener: ActorRef) extends ListenerMessage

--- a/test/files/neg/saferJavaConversions.scala
+++ b/test/files/neg/saferJavaConversions.scala
@@ -3,17 +3,17 @@ case class Foo(s: String)
 
 object Test {
   def f1 = {
-    import scala.collection.JavaConversions._
+    import scala.collection.convert.ImplicitConversions._
     val map: Map[Foo, String] = Map(Foo("a") -> "a", Foo("b") -> "b")
     val v = map.get("a")  // should be a type error, actually returns null
   }
   def f2 = {
-    import scala.collection.convert.wrapAsScala._
+    import scala.collection.convert.ImplicitConversionsToScala._
     val map: Map[Foo, String] = Map(Foo("a") -> "a", Foo("b") -> "b")
     val v = map.get("a")  // now this is a type error
   }
   def f3 = {
-    import scala.collection.convert.wrapAsJava._
+    import scala.collection.convert.ImplicitConversionsToJava._
     val map: Map[Foo, String] = Map(Foo("a") -> "a", Foo("b") -> "b")
     val v = map.get("a")
   }

--- a/test/files/neg/t5580b.scala
+++ b/test/files/neg/t5580b.scala
@@ -1,5 +1,5 @@
 import scala.collection.mutable.WeakHashMap
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 class bar { }
 

--- a/test/files/neg/t9684.check
+++ b/test/files/neg/t9684.check
@@ -1,0 +1,9 @@
+t9684.scala:6: warning: object JavaConversions in package collection is deprecated: Use JavaConverters
+  null.asInstanceOf[java.util.List[Int]] : Buffer[Int]
+                   ^
+t9684.scala:8: warning: object JavaConversions in package collection is deprecated: Use JavaConverters
+  null.asInstanceOf[Iterable[Int]] : java.util.Collection[Int]
+                   ^
+error: No warnings can be incurred under -Xfatal-warnings.
+two warnings found
+one error found

--- a/test/files/neg/t9684.flags
+++ b/test/files/neg/t9684.flags
@@ -1,0 +1,1 @@
+-deprecation -Xfatal-warnings

--- a/test/files/neg/t9684.scala
+++ b/test/files/neg/t9684.scala
@@ -1,0 +1,9 @@
+
+import scala.collection.JavaConversions._
+import scala.collection.mutable.Buffer
+
+trait Test {
+  null.asInstanceOf[java.util.List[Int]] : Buffer[Int]
+
+  null.asInstanceOf[Iterable[Int]] : java.util.Collection[Int]
+}

--- a/test/files/neg/t9684b.check
+++ b/test/files/neg/t9684b.check
@@ -1,0 +1,7 @@
+t9684b.scala:6: error: reference to asScalaIterator is ambiguous;
+it is imported twice in the same scope by
+import scala.collection.JavaConversions._
+and import scala.collection.JavaConverters._
+  asScalaIterator(null)                                           // fails: asScalaIterator is imported twice.
+  ^
+one error found

--- a/test/files/neg/t9684b.scala
+++ b/test/files/neg/t9684b.scala
@@ -1,0 +1,14 @@
+trait T1 {
+  import scala.collection.JavaConverters._
+  import scala.collection.JavaConversions._
+
+  null.asInstanceOf[java.util.Iterator[String]]: Iterator[String] // works
+  asScalaIterator(null)                                           // fails: asScalaIterator is imported twice.
+}
+
+trait T2 {
+  import scala.collection.JavaConversions.asScalaIterator
+
+  null.asInstanceOf[java.util.Iterator[String]]: Iterator[String] // works
+  asScalaIterator(null)                                           // works
+}

--- a/test/files/pos/arrays2.scala
+++ b/test/files/pos/arrays2.scala
@@ -17,7 +17,7 @@ object arrays4 {
 
 // #2461
 object arrays3 {
-  import scala.collection.JavaConversions._
+  import collection.convert.ImplicitConversions._
   def apply[X](xs : X*) : java.util.List[X] = java.util.Arrays.asList(xs: _*)
 }
 

--- a/test/files/pos/javaConversions-2.10-ambiguity.scala
+++ b/test/files/pos/javaConversions-2.10-ambiguity.scala
@@ -1,5 +1,5 @@
-import collection.{JavaConversions, mutable, concurrent}
-import JavaConversions._
+import collection.{mutable, concurrent}
+import collection.convert.ImplicitConversionsToScala._
 import java.util.concurrent.{ConcurrentHashMap => CHM}
 
 object Bar {

--- a/test/files/pos/javaConversions-2.10-regression.scala
+++ b/test/files/pos/javaConversions-2.10-regression.scala
@@ -1,10 +1,10 @@
-import collection.{JavaConversions, mutable, concurrent}
-import JavaConversions._
+import collection.{convert, mutable, concurrent, JavaConverters}
+import convert.ImplicitConversionsToScala._
 import java.util.concurrent.{ConcurrentHashMap => CHM}
 
 object Foo {
   def buildCache2_9_simple[K <: AnyRef, V <: AnyRef]: concurrent.Map[K, V] =
-    mapAsScalaConcurrentMap(new CHM())
+    JavaConverters.mapAsScalaConcurrentMap(new CHM())
 
   def buildCache2_9_implicit[K <: AnyRef, V <: AnyRef]: concurrent.Map[K, V] =
     new CHM[K, V]()

--- a/test/files/pos/t2293.scala
+++ b/test/files/pos/t2293.scala
@@ -1,4 +1,4 @@
-import scala.collection.JavaConversions._
+import scala.collection.convert.ImplicitConversionsToJava._
 
 object Test {
   val m: java.util.Map[String,String] = collection.mutable.Map("1"->"2")

--- a/test/files/pos/t2956/t2956.scala
+++ b/test/files/pos/t2956/t2956.scala
@@ -1,4 +1,4 @@
-import scala.collection.JavaConversions._
+import scala.collection.convert.ImplicitConversionsToScala._
 
 class Outer {
   protected class Inner extends BeanDefinitionVisitor {

--- a/test/files/pos/t3688.scala
+++ b/test/files/pos/t3688.scala
@@ -1,5 +1,5 @@
 import collection.mutable
-import collection.JavaConversions._
+import collection.convert.ImplicitConversionsToJava._
 import java.{util => ju}
 
 object Test {

--- a/test/files/presentation/ide-bug-1000531/src/CrashOnLoad.scala
+++ b/test/files/presentation/ide-bug-1000531/src/CrashOnLoad.scala
@@ -1,6 +1,6 @@
 /** When this files is opened within the IDE, a typing error is reported. */
 class A[B] extends TestIterable[B] {
-  import scala.collection.JavaConversions._
+  import collection.convert.ImplicitConversionsToScala._
   def iterator: other.TestIterator[Nothing] = ???
 
   iterator./*!*/

--- a/test/files/run/concurrent-map-conversions.scala
+++ b/test/files/run/concurrent-map-conversions.scala
@@ -1,14 +1,5 @@
 
-
-
-
-
-object Test {
-
-  def main(args: Array[String]) {
-    testConversions()
-    testConverters()
-  }
+object Test extends App {
 
   def needPackageConcurrentMap(map: collection.concurrent.Map[Int, Int]) {
   }
@@ -16,7 +7,7 @@ object Test {
   }
 
   def testConversions() {
-    import collection.JavaConversions._
+    import collection.convert.ImplicitConversions._
     val skiplist = new java.util.concurrent.ConcurrentSkipListMap[Int, Int]
     val ctrie = new collection.concurrent.TrieMap[Int, Int]
 
@@ -33,4 +24,6 @@ object Test {
     needJavaConcurrent(ctrie.asJava)
   }
 
+  testConversions()
+  testConverters()
 }

--- a/test/files/run/map_java_conversions.scala
+++ b/test/files/run/map_java_conversions.scala
@@ -1,20 +1,16 @@
-
-
-
-
+import collection.convert.ImplicitConversionsToScala._
+import collection.JavaConverters._
 
 object Test {
 
   def main(args: Array[String]) {
-    import collection.JavaConversions._
-
     test(new java.util.HashMap[String, String])
     test(new java.util.Properties)
     testConcMap
   }
 
   def testConcMap {
-    import collection.JavaConversions._
+    import collection.convert.ImplicitConversionsToScala._
 
     val concMap = new java.util.concurrent.ConcurrentHashMap[String, String]
 
@@ -50,7 +46,6 @@ object Test {
     for (i <- 0 until 10) m += (("key" + i, "value" + i))
     for ((k, v) <- m) assert(k.startsWith("key"))
   }
-
 }
 
 

--- a/test/files/run/noInlineUnknownIndy/Test.scala
+++ b/test/files/run/noInlineUnknownIndy/Test.scala
@@ -1,6 +1,6 @@
 import java.io.File
 
-import scala.collection.convert.decorateAsScala._
+import scala.collection.JavaConverters._
 import scala.tools.asm.tree.{ClassNode, InvokeDynamicInsnNode}
 import scala.tools.asm.{Handle, Opcodes}
 import scala.tools.partest.BytecodeTest.modifyClassFile

--- a/test/files/run/t2250.scala
+++ b/test/files/run/t2250.scala
@@ -6,7 +6,7 @@ object Test {
 
     // we'll say rather unlikely a.sameElements(b) unless
     // they are pointing to the same array
-    import scala.collection.JavaConversions._
+    import scala.collection.convert.ImplicitConversionsToScala._
     assert(a sameElements b)
   }
 }

--- a/test/files/run/t2813.2.scala
+++ b/test/files/run/t2813.2.scala
@@ -1,5 +1,5 @@
 import java.util.LinkedList
-import collection.JavaConversions._
+import collection.convert.ImplicitConversions._
 
 object Test extends App {
   def assertListEquals[A](expected: List[A], actual: Seq[A]) {

--- a/test/files/run/t5880.scala
+++ b/test/files/run/t5880.scala
@@ -1,8 +1,5 @@
 
-
-import scala.collection.JavaConversions._
-
-
+import scala.collection.convert.ImplicitConversionsToJava._
 
 object Test {
 

--- a/test/files/run/t7269.scala
+++ b/test/files/run/t7269.scala
@@ -1,4 +1,4 @@
-import scala.collection.JavaConversions._
+import scala.collection.convert.ImplicitConversionsToScala._
 import scala.collection.mutable
 
 object Test extends App {

--- a/test/files/run/t7974/Test.scala
+++ b/test/files/run/t7974/Test.scala
@@ -4,7 +4,7 @@ import scala.tools.partest.BytecodeTest
 import scala.tools.nsc.backend.jvm.AsmUtils
 import scala.tools.asm.util._
 import scala.tools.nsc.util.stringFromWriter
-import scala.collection.convert.decorateAsScala._
+import scala.collection.JavaConverters._
 
 object Test extends BytecodeTest {
   def show {

--- a/test/junit/scala/collection/convert/NullSafetyTest.scala
+++ b/test/junit/scala/collection/convert/NullSafetyTest.scala
@@ -7,7 +7,7 @@ import org.junit.Test
 import org.junit.experimental.runners.Enclosed
 import org.junit.runner.RunWith
 
-import scala.collection.JavaConversions._
+import collection.convert.ImplicitConversions._
 import scala.collection.JavaConverters._
 import scala.collection.{mutable, concurrent}
 

--- a/test/junit/scala/tools/nsc/backend/jvm/analysis/NullnessAnalyzerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/analysis/NullnessAnalyzerTest.scala
@@ -17,7 +17,7 @@ import scala.tools.testing.ClearAfterClass
 import scala.tools.nsc.backend.jvm.opt.BytecodeUtils._
 import AsmUtils._
 
-import scala.collection.convert.decorateAsScala._
+import scala.collection.JavaConverters._
 
 object NullnessAnalyzerTest extends ClearAfterClass.Clearable {
   var noOptCompiler = newCompiler(extraArgs = "-Yopt:l:none")

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/AnalyzerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/AnalyzerTest.scala
@@ -18,7 +18,7 @@ import AsmUtils._
 import BackendReporting._
 import BytecodeUtils._
 
-import scala.collection.convert.decorateAsScala._
+import scala.collection.JavaConverters._
 import scala.tools.testing.ClearAfterClass
 
 object AnalyzerTest extends ClearAfterClass.Clearable {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/BTypesFromClassfileTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/BTypesFromClassfileTest.scala
@@ -17,7 +17,7 @@ import ASMConverters._
 
 import BackendReporting._
 
-import scala.collection.convert.decorateAsScala._
+import scala.collection.JavaConverters._
 
 @RunWith(classOf[JUnit4])
 class BTypesFromClassfileTest {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/CallGraphTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/CallGraphTest.scala
@@ -21,7 +21,7 @@ import ASMConverters._
 import AsmUtils._
 import BackendReporting._
 
-import scala.collection.convert.decorateAsScala._
+import scala.collection.JavaConverters._
 import scala.tools.testing.ClearAfterClass
 
 object CallGraphTest extends ClearAfterClass.Clearable {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/ClosureOptimizerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/ClosureOptimizerTest.scala
@@ -24,7 +24,7 @@ import AsmUtils._
 
 import BackendReporting._
 
-import scala.collection.convert.decorateAsScala._
+import scala.collection.JavaConverters._
 import scala.tools.testing.ClearAfterClass
 
 object ClosureOptimizerTest extends ClearAfterClass.Clearable {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineInfoTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineInfoTest.scala
@@ -16,7 +16,7 @@ import scala.tools.testing.ClearAfterClass
 
 import BackendReporting._
 
-import scala.collection.convert.decorateAsScala._
+import scala.collection.JavaConverters._
 
 object InlineInfoTest extends ClearAfterClass.Clearable {
   var compiler = newCompiler(extraArgs = "-Yopt:l:classpath")

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineWarningTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineWarningTest.scala
@@ -24,7 +24,7 @@ import AsmUtils._
 
 import BackendReporting._
 
-import scala.collection.convert.decorateAsScala._
+import scala.collection.JavaConverters._
 import scala.tools.testing.ClearAfterClass
 
 object InlineWarningTest extends ClearAfterClass.Clearable {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerIllegalAccessTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerIllegalAccessTest.scala
@@ -16,7 +16,7 @@ import scala.tools.partest.ASMConverters
 import ASMConverters._
 import AsmUtils._
 
-import scala.collection.convert.decorateAsScala._
+import scala.collection.JavaConverters._
 import scala.tools.testing.ClearAfterClass
 
 object InlinerIllegalAccessTest extends ClearAfterClass.Clearable {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerSeparateCompilationTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerSeparateCompilationTest.scala
@@ -13,7 +13,7 @@ import scala.tools.partest.ASMConverters
 import ASMConverters._
 import AsmUtils._
 
-import scala.collection.convert.decorateAsScala._
+import scala.collection.JavaConverters._
 
 object InlinerSeparateCompilationTest {
   val args = "-Yopt:l:classpath"

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
@@ -19,7 +19,7 @@ import AsmUtils._
 
 import BackendReporting._
 
-import scala.collection.convert.decorateAsScala._
+import scala.collection.JavaConverters._
 import scala.tools.testing.ClearAfterClass
 
 object InlinerTest extends ClearAfterClass.Clearable {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/MethodLevelOptsTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/MethodLevelOptsTest.scala
@@ -16,7 +16,7 @@ import CodeGenTools._
 import scala.tools.partest.ASMConverters
 import ASMConverters._
 import scala.tools.testing.ClearAfterClass
-import scala.collection.convert.decorateAsScala._
+import scala.collection.JavaConverters._
 
 object MethodLevelOptsTest extends ClearAfterClass.Clearable {
   var methodOptCompiler = newCompiler(extraArgs = "-Yopt:l:method")

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/ScalaInlineInfoTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/ScalaInlineInfoTest.scala
@@ -13,7 +13,7 @@ import scala.tools.asm.tree.ClassNode
 import scala.tools.nsc.backend.jvm.BTypes.{MethodInlineInfo, InlineInfo}
 import scala.tools.partest.ASMConverters
 import ASMConverters._
-import scala.collection.convert.decorateAsScala._
+import scala.collection.JavaConverters._
 import scala.tools.testing.ClearAfterClass
 
 object ScalaInlineInfoTest extends ClearAfterClass.Clearable {


### PR DESCRIPTION
Implicit conversions are now in package convert as ImplicitConversions,
ImplicitConversionsToScala and ImplicitConversionsToJava.

Deprecated WrapAsJava, WrapAsScala and the values in package object.

Improve documentation.
