### PR TITLE
Merge 2.11 to 2.12 apr 22

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Here, `<milestone>` is the milestone targeted by the PR (e.g., 2.11.6), and `<sh
 
 ## IDE Setup
 ### Eclipse
-See `src/eclipse/README.md`.
+See [src/eclipse/README.md](src/eclipse/README.md).
 
 ### IntelliJ 15
 See [src/intellij/README.md](src/intellij/README.md).

--- a/scripts/jobs/integrate/windows
+++ b/scripts/jobs/integrate/windows
@@ -8,6 +8,9 @@ export ANT_OPTS="-Dfile.encoding=UTF-8 -server -XX:+AggressiveOpts -XX:+UseParNe
 # ant manually installed on jenkins-worker-windows-publish.
 PATH=/cygdrive/c/apache-ant-1.9.6/bin:$PATH
 
+export JAVA_HOME='C:/java/jdk-1.6'
+export PATH="$JAVA_HOME/bin:$PATH"
+
 ant \
   -Dstarr.version=2.11.8 \
   -Dscalac.args.optimise=-optimise \

--- a/scripts/jobs/integrate/windows
+++ b/scripts/jobs/integrate/windows
@@ -4,12 +4,13 @@
 
 export ANT_OPTS="-Dfile.encoding=UTF-8 -server -XX:+AggressiveOpts -XX:+UseParNewGC -Xmx2G -Xss1M -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=128M"
 
-# TODO: don't hardcode this path, which is just where we currently have
-# ant manually installed on jenkins-worker-windows-publish.
-PATH=/cygdrive/c/apache-ant-1.9.6/bin:$PATH
-
+# TODO: don't hardcode this path -- should be in scala/scala-jenkins-infra
+export PATH='/cygdrive/c/java/jdk-1.6/bin:/cygdrive/c/apache-ant-1.9.6/bin:/cygdrive/c/Program Files (x86)/Git-2.5.3/Cmd:/bin:/usr/bin:'
 export JAVA_HOME='C:/java/jdk-1.6'
-export PATH="$JAVA_HOME/bin:$PATH"
+
+java -version
+javac -version
+ant -version
 
 ant \
   -Dstarr.version=2.11.8 \

--- a/src/eclipse/README.md
+++ b/src/eclipse/README.md
@@ -7,21 +7,20 @@ The following points describe how to build Scala using Eclipse.
 
 0. Download the [Scala IDE bundle](http://scala-ide.org/download/sdk.html). It comes preconfigured for optimal performance.
 
-0. Run `ant init` to download some necessary jars.
+0. Run `ant build` to download some necessary jars and see a successful build.
 
-0. Import the project (in `src/eclipse`) via `File` → `Import Existing Projects` and navigate to `scala/src/eclipse`. Check all projects and click ok.
-
-0. You need to define a `path variable` inside Eclipse. Define `SCALA_BASEDIR` in
-`Preferences/General/Workspace/Linked Resources`. The value should be the absolute
-path to your Scala checkout. All paths in the project files are relative to this one,
-so nothing will work before you do so.
-
-  The same `SCALA_BASEDIR` variable needs to be defined as a `classpath variable` in
+0. You need to define a `path variable` and a `classpath variable` inside Eclipse, both pointing to the Scala checkout directory:
+  - (experimental): run `./update-workspace.sh scala_checkout_dir [workspace_dir]`. This should update your workspace settings
+ (restart Eclipse if it was running). For example:
+ ```
+ ./update-workspace.sh $HOME/git/scala ~/Documents/workspace-scalac
+ ```
+  - If the above didn't work, you can perform these steps manually: Define `SCALA_BASEDIR` in `Preferences/General/Workspace/Linked Resources`. The value should be the absolute
+path to your Scala checkout. All paths in the project files are relative to this one, so nothing will work before you do so.
+The same `SCALA_BASEDIR` variable needs to be defined **also** as a `classpath variable` in
 `Java/Build Path/Classpath Variables`.
 
-  Additionally, we start using Maven dependencies (e.g. `JUnit`) so you need to define another
-`classpath variable` inside Eclipse. Define `M2_REPO` in `Java/Build Path/Classpath Variables`
-to point to your local Maven repository (e.g. `$HOME/.m2/repository`).
+0. Import the project (in `src/eclipse`) via `File` → `Import Existing Projects` and navigate to `scala/src/eclipse`. Check all projects and click ok.
 
   Lastly, the JRE used by Eclipse needs to know the path to the `JLine` library, which is used by the REPL.
 To set the JAR file, navigate to `Java/Installed JREs`, select the default JRE, press `Edit/Add External JARs...`

--- a/src/eclipse/interactive/.classpath
+++ b/src/eclipse/interactive/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="interactive"/>
-	<classpathentry kind="var" path="M2_REPO/org/scala-lang/modules/scala-asm/5.0.4-scala-3/scala-asm-5.0.4-scala-3.jar"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/asm/scala-asm-5.0.4-scala-3.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scaladoc"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scala-compiler"/>

--- a/src/eclipse/partest/.classpath
+++ b/src/eclipse/partest/.classpath
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="partest-extras"/>
-	<classpathentry kind="var" path="M2_REPO/org/scala-lang/modules/scala-asm/5.0.4-scala-3/scala-asm-5.0.4-scala-3.jar"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/asm/scala-asm-5.0.4-scala-3.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/repl"/>
-	<classpathentry kind="var" path="M2_REPO/com/googlecode/java-diff-utils/diffutils/1.3.0/diffutils-1.3.0.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/scala-sbt/test-interface/1.0/test-interface-1.0.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/scala-lang/modules/scala-partest_2.11/1.0.9/scala-partest_2.11-1.0.9.jar"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/partest/diffutils-1.3.0.jar"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/partest/test-interface-1.0.jar"/>
 	<classpathentry kind="var" path="SCALA_BASEDIR/lib/ant/ant.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scala-compiler"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scala-library"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/partest/scala-partest_2.11-1.0.13.jar"/>
 	<classpathentry kind="output" path="build-quick-partest-extras"/>
 </classpath>

--- a/src/eclipse/reflect/.classpath
+++ b/src/eclipse/reflect/.classpath
@@ -3,5 +3,6 @@
 	<classpathentry kind="src" path="reflect"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scala-library"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
 	<classpathentry kind="output" path="build-quick-reflect"/>
 </classpath>

--- a/src/eclipse/repl/.classpath
+++ b/src/eclipse/repl/.classpath
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="repl"/>
-	<classpathentry kind="var" path="M2_REPO/org/scala-lang/modules/scala-asm/5.0.4-scala-3/scala-asm-5.0.4-scala-3.jar"/>
-	<classpathentry kind="var" path="M2_REPO/jline/jline/2.12.1/jline-2.12.1.jar"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/asm/scala-asm-5.0.4-scala-3.jar"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/repl/jline-2.12.1.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scala-compiler"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scala-library"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/interactive"/>
 	<classpathentry kind="output" path="build-quick-repl"/>
 </classpath>

--- a/src/eclipse/scala-compiler/.classpath
+++ b/src/eclipse/scala-compiler/.classpath
@@ -4,7 +4,8 @@
 	<classpathentry combineaccessrules="false" exported="true" kind="src" path="/reflect"/>
 	<classpathentry combineaccessrules="false" exported="true" kind="src" path="/scala-library"/>
 	<classpathentry kind="var" path="SCALA_BASEDIR/lib/ant/ant.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/scala-lang/modules/scala-asm/5.0.4-scala-3/scala-asm-5.0.4-scala-3.jar"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/asm/scala-asm-5.0.4-scala-3.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
 	<classpathentry kind="output" path="build-quick-compiler"/>
 </classpath>

--- a/src/eclipse/scaladoc/.classpath
+++ b/src/eclipse/scaladoc/.classpath
@@ -2,12 +2,12 @@
 <classpath>
 	<classpathentry kind="src" path="scaladoc"/>
 	<classpathentry kind="var" path="SCALA_BASEDIR/lib/ant/ant.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/scala-lang/modules/scala-asm/5.0.4-scala-3/scala-asm-5.0.4-scala-3.jar"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/asm/scala-asm-5.0.4-scala-3.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scala-compiler"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scala-library"/>
-	<classpathentry kind="var" path="M2_REPO/org/scala-lang/modules/scala-xml_2.11/1.0.4/scala-xml_2.11-1.0.4.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/scala-lang/modules/scala-parser-combinators_2.11/1.0.4/scala-parser-combinators_2.11-1.0.4.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/scala-lang/modules/scala-partest_2.11/1.0.9/scala-partest_2.11-1.0.9.jar"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/scaladoc/scala-xml_2.11-1.0.5.jar"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/scaladoc/scala-parser-combinators_2.11-1.0.4.jar"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/partest/scala-partest_2.11-1.0.13.jar"/>
 	<classpathentry kind="output" path="build-quick-scaladoc"/>
 </classpath>

--- a/src/eclipse/test-junit/.classpath
+++ b/src/eclipse/test-junit/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="test-junit"/>
-	<classpathentry kind="var" path="M2_REPO/org/scala-lang/modules/scala-asm/5.0.4-scala-3/scala-asm-5.0.4-scala-3.jar"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/asm/scala-asm-5.0.4-scala-3.jar"/>
 	<classpathentry kind="var" path="SCALA_BASEDIR/lib/ant/ant.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/reflect"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scala-library"/>
@@ -10,7 +10,7 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/repl"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/partest-extras"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/scaladoc"/>
-	<classpathentry kind="var" path="M2_REPO/org/scala-lang/modules/scala-xml_2.11/1.0.4/scala-xml_2.11-1.0.4.jar"/>
+	<classpathentry kind="var" path="SCALA_BASEDIR/build/deps/scaladoc/scala-xml_2.11-1.0.5.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="output" path="build-test-junit"/>
 </classpath>

--- a/src/eclipse/update-workspace.sh
+++ b/src/eclipse/update-workspace.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+function usage() {
+    echo "$0 scala_checkout_dir [workspace_dir]"
+    echo "\n Add necessary path variables to Eclipse workspace settings for Scalac to build"
+}
+
+METADATA_DIR=`pwd`/.metadata
+
+if [ $# -lt 1 ]; then
+    echo "Need the Scala directory checkout as argument"
+    exit 1
+fi
+
+SCALA_DIR=$1
+
+if [ ! -z $2 ]; then
+    METADATA_DIR=$2/.metadata
+fi
+
+if [ ! -d $METADATA_DIR ]; then
+    echo "$METADATA_DIR is not a directory"
+    exit 1
+fi
+
+echo "Using metadata directory $METADATA_DIR and Scala checkout $SCALA_DIR" 
+
+CORE_PREFS=$METADATA_DIR/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.core.resources.prefs
+if [ ! -f $CORE_PREFS ]; then
+    echo "Couldn't find $CORE_PREFS. Is $METADATA_DIR an Eclipse workspace?"
+    exit 1
+fi
+echo -e "Workspace preferences:\t$CORE_PREFS"
+
+JDT_PREFS=$METADATA_DIR/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.jdt.core.prefs
+if [ ! -f $JDT_PREFS ]; then
+    echo "Couldn't find $JDT_PREFS. Creating fresh file."
+    touch $JDT_PREFS
+fi
+echo -e "JDT preferences:\t$JDT_PREFS" 
+
+# $1 - preference file (will be backed-up before writing)
+# $2 - preference key
+# $3 - preference value
+function updatePref() {
+    mv $1 ${1}_backup
+      
+    awk -v key=$2 -v value=$3 '
+    BEGIN { 
+        FS="="; 
+        OFS="=";
+        prev=""
+    }
+    { 
+        if ($1 == key) {
+            prev=$2
+            $2=value
+        }
+        print
+    }
+    END { 
+        if (prev) {
+            printf "Updated existing value from %s to %s\n", prev, value > "/dev/stderr"
+        } else {
+            print key,value
+        }
+    }
+    ' ${1}_backup >$1
+}
+
+updatePref $CORE_PREFS "pathvariable.SCALA_BASEDIR" $SCALA_DIR
+updatePref $JDT_PREFS "org.eclipse.jdt.core.classpathVariable.SCALA_BASEDIR" $SCALA_DIR

--- a/src/repl/scala/tools/nsc/interpreter/Imports.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Imports.scala
@@ -183,7 +183,7 @@ trait Imports {
                   case _ =>
                     val valName = req.lineRep.packageName + req.lineRep.readName
                     if (!tempValLines.contains(req.lineRep.lineId)) {
-                      code.append(s"val $valName = $objName\n")
+                      code.append(s"val $valName: ${objName}.type = $objName\n")
                       tempValLines += req.lineRep.lineId
                     }
                     code.append(s"import $valName${req.accessPath}.`$imv`;\n")

--- a/src/repl/scala/tools/nsc/interpreter/ReplStrings.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplStrings.scala
@@ -11,13 +11,21 @@ import scala.reflect.internal.Chars
 trait ReplStrings {
   /** Convert a string into code that can recreate the string.
    *  This requires replacing all special characters by escape
-   *  codes. It does not add the surrounding " marks.  */
+   *  codes. It does not add the surrounding " marks.
+   */
   def string2code(str: String): String = {
     val res = new StringBuilder
     for (c <- str) c match {
-      case '"' | '\'' | '\\'  => res += '\\' ; res += c
-      case _ if c.isControl   => res ++= Chars.char2uescape(c)
-      case _                  => res += c
+      case '"'  => res ++= """\""""
+      case '\'' => res ++= """\'"""
+      case '\\' => res ++= """\\"""
+      case '\b' => res ++= """\b"""
+      case '\t' => res ++= """\t"""
+      case '\n' => res ++= """\n"""
+      case '\f' => res ++= """\f"""
+      case '\r' => res ++= """\r"""
+      case _ if c.isControl => res ++= Chars.char2uescape(c)
+      case _    => res += c
     }
     res.toString
   }

--- a/test/files/run/repl-no-uescape.check
+++ b/test/files/run/repl-no-uescape.check
@@ -1,0 +1,5 @@
+
+scala> object A
+defined object A
+
+scala> :quit

--- a/test/files/run/repl-no-uescape.scala
+++ b/test/files/run/repl-no-uescape.scala
@@ -1,0 +1,31 @@
+import scala.tools.partest.ReplTest
+import scala.tools.nsc.Settings
+
+/*
+scala> object A
+<console>:10: error: invalid escape character
++ "defined object " + "A" + "\u000A"
+
+Under -Dscala.color=true control chars are common
+  $eval.this.$print = {
+    $line2.$read.$iw.$iw;
+    "\033[1m\033[34mres1\033[0m: \033[1m\033[32mInt\033[0m = ".+(scala.runtime.ScalaRunTime.replStringOf($line2.$read.$iw.$iw.res1, 1000))
+  };
+
+$ skala -Dscala.color=true -Xno-uescape
+Welcome to Scala 2.11.9-20160323-163638-1fcfdd8c8b (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_60).
+Type in expressions for evaluation. Or try :help.
+
+scala> 42
+<console>:10: error: invalid escape character
+ + "\u001B[1m\u001B[34mres0\u001B[0m: \u001B[1m\u001B[32mInt\u001B[0m = " + scala.runtime.ScalaRunTime.replStringOf(res0, 1000)
+ */
+object Test extends ReplTest {
+  override def transformSettings(settings: Settings): Settings = {
+    settings.nouescape.value = true
+    settings
+  }
+  def code = """
+object A
+  """
+}

--- a/test/files/run/repl-paste-6.check
+++ b/test/files/run/repl-paste-6.check
@@ -1,0 +1,17 @@
+
+scala> :paste < EOF
+// Entering paste mode (EOF to finish)
+
+case class C(i: Int)
+val c = C(42)
+EOF
+
+// Exiting paste mode, now interpreting.
+
+defined class C
+c: C = C(42)
+
+scala> val d: C = c // shew
+d: C = C(42)
+
+scala> :quit

--- a/test/files/run/repl-paste-6.scala
+++ b/test/files/run/repl-paste-6.scala
@@ -1,0 +1,23 @@
+
+import scala.tools.partest.ReplTest
+import scala.tools.nsc.Settings
+
+
+/*
+ * Add // show to witness:
+ *     val $line3$read: $line3.$read.INSTANCE.type = $line3.$read.INSTANCE;
+ */
+object Test extends ReplTest {
+  override def transformSettings(settings: Settings): Settings = {
+    settings.Yreplclassbased.value = true
+    settings
+  }
+  def code = 
+    """
+:paste < EOF
+case class C(i: Int)
+val c = C(42)
+EOF
+val d: C = c // shew
+    """
+}


### PR DESCRIPTION
```
$ git log --decorate --oneline -1 2.11.x | cat
2dd311f (upstream/2.11.x, origin/2.11.x, 2.11.x) CI: hardcode java path in integrate/windows script
$ git log --decorate --oneline -1 2.12.x | cat
f55dd20 (HEAD -> 2.12.x, upstream/2.12.x, origin/2.12.x) CI: hardcode java path in integrate/windows script

$ export MB=$(git merge-base 2.12.x 2.11.x)

$ git checkout 2.12.x
$ git checkout -b merge-2.11-to-2.12-apr-22
Switched to a new branch 'merge-2.11-to-2.12-apr-22'

$ git log --graph --oneline --decorate $MB...2.11.x | cat
* 2dd311f (upstream/2.11.x, origin/2.11.x, 2.11.x) CI: hardcode java path in integrate/windows script
*   932162a Merge pull request #5113 from adriaanm/ci-win-java6
|\
| * 04904be CI: use java 6 for windows integration
|/
* 684c314 SI-9734 Narrow type when import REPL history (#5084)
* 956923a SI-9735 REPL prefer standard escapes for code text (#5086)
* 65a7dfe Updating README.md Eclipse version reference. (#5092)
* 23159d2 Automate Eclipse settings and update project files: (#5091)


$ git merge 23159d2 -X theirs

  manually fixed .classpath files to look exactly like in 2.11.x, except for versioned dependencies.
  see diff of src/eclipse 2.11 vs 2.12 here: https://gist.github.com/lrytz/0d325780428396bd1455f1f2ac9dcb2b


$ git merge 684c314

  no conflicts here

$ git merge 2dd311f -s ours

  the last two changes (04904be, 2dd311f) are 2.11-specific and should not go in 2.12
```
