### PR TITLE
SI-9516 Fix the behavior of Int shift Long operations.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -117,15 +117,16 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
 
         // binary operation
         case rarg :: Nil =>
-          resKind = tpeTK(larg).maxType(tpeTK(rarg))
-          if (scalaPrimitives.isShiftOp(code) || scalaPrimitives.isBitwiseOp(code)) {
+          val isShiftOp = scalaPrimitives.isShiftOp(code)
+          resKind = tpeTK(larg).maxType(if (isShiftOp) INT else tpeTK(rarg))
+
+          if (isShiftOp || scalaPrimitives.isBitwiseOp(code)) {
             assert(resKind.isIntegralType || (resKind == BOOL),
                    s"$resKind incompatible with arithmetic modulo operation.")
           }
 
           genLoad(larg, resKind)
-          genLoad(rarg, // check .NET size of shift arguments!
-                  if (scalaPrimitives.isShiftOp(code)) INT else resKind)
+          genLoad(rarg, if (isShiftOp) INT else resKind)
 
           (code: @switch) match {
             case ADD => bc add resKind

--- a/src/compiler/scala/tools/nsc/typechecker/ConstantFolder.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ConstantFolder.scala
@@ -102,13 +102,13 @@ abstract class ConstantFolder {
     case nme.XOR => Constant(x.longValue ^ y.longValue)
     case nme.AND => Constant(x.longValue & y.longValue)
     case nme.LSL if x.tag <= IntTag
-                 => Constant(x.intValue << y.longValue)
+                 => Constant(x.intValue << y.longValue.toInt) // TODO: remove .toInt once starr includes the fix for SI-9516 (2.12.0-M5)
     case nme.LSL => Constant(x.longValue <<  y.longValue)
     case nme.LSR if x.tag <= IntTag
-                 => Constant(x.intValue >>> y.longValue)
+                 => Constant(x.intValue >>> y.longValue.toInt) // TODO: remove .toInt once starr includes the fix for SI-9516 (2.12.0-M5)
     case nme.LSR => Constant(x.longValue >>> y.longValue)
     case nme.ASR if x.tag <= IntTag
-                 => Constant(x.intValue >> y.longValue)
+                 => Constant(x.intValue >> y.longValue.toInt) // TODO: remove .toInt once starr includes the fix for SI-9516 (2.12.0-M5)
     case nme.ASR => Constant(x.longValue >> y.longValue)
     case nme.EQ  => Constant(x.longValue == y.longValue)
     case nme.NE  => Constant(x.longValue != y.longValue)

--- a/test/files/run/t9516.scala
+++ b/test/files/run/t9516.scala
@@ -1,0 +1,52 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    intShiftLeftLongConstantFolded()
+    intShiftLeftLongAtRuntime()
+    intShiftLogicalRightLongConstantFolded()
+    intShiftLogicalRightLongAtRuntime()
+    intShiftArithmeticRightLongConstantFolded()
+    intShiftArithmeticRightLongAtRuntime()
+  }
+
+  def intShiftLeftLongConstantFolded(): Unit = {
+    assert(0x01030507 << 36L == 271601776)
+    val r = 0x01030507 << 36L
+    assert(r == 271601776)
+  }
+
+  def intShiftLeftLongAtRuntime(): Unit = {
+    var x: Int = 0x01030507
+    var y: Long = 36L
+    assert(x << y == 271601776)
+    val r = x << y
+    assert(r == 271601776)
+  }
+
+  def intShiftLogicalRightLongConstantFolded(): Unit = {
+    assert(0x90503010 >>> 36L == 151323393)
+    val r = 0x90503010 >>> 36L
+    assert(r == 151323393)
+  }
+
+  def intShiftLogicalRightLongAtRuntime(): Unit = {
+    var x: Int = 0x90503010
+    var y: Long = 36L
+    assert(x >>> y == 151323393)
+    val r = x >>> y
+    assert(r == 151323393)
+  }
+
+  def intShiftArithmeticRightLongConstantFolded(): Unit = {
+    assert(0x90503010 >> 36L == -117112063)
+    val r = 0x90503010 >> 36L
+    assert(r == -117112063)
+  }
+
+  def intShiftArithmeticRightLongAtRuntime(): Unit = {
+    var x: Int = 0x90503010
+    var y: Long = 36L
+    assert(x >> y == -117112063)
+    val r = x >> y
+    assert(r == -117112063)
+  }
+}


### PR DESCRIPTION
In any shift operation where the lhs is an Int (or smaller) and
the rhs is a Long, the result kind must be Int, and not Long.
This is important because the lhs must _not_ be promoted to a
Long, as that causes an opcode for long shift to be emitted.
This uses an rhs modulo 64, instead of int shifts which use an
rhs module 32. Instead, the rhs must be downgraded to an Int.

The new behavior is consistent with the same operations in the
Java programming language.

Link to SI-9516: https://issues.scala-lang.org/browse/SI-9516
