### PR TITLE
add ClassTag context bounds to OpenHashMap type params

### DIFF
--- a/src/library/scala/collection/mutable/OpenHashMap.scala
+++ b/src/library/scala/collection/mutable/OpenHashMap.scala
@@ -10,6 +10,8 @@ package scala
 package collection
 package mutable
 
+import scala.reflect.ClassTag
+
 /**
  *  @define Coll `OpenHashMap`
  *  @define coll open hash map
@@ -18,8 +20,8 @@ package mutable
  */
 object OpenHashMap {
 
-  def apply[K, V](elems : (K, V)*) = new OpenHashMap[K, V] ++= elems
-  def empty[K, V] = new OpenHashMap[K, V]
+  def apply[K : ClassTag, V : ClassTag](elems : (K, V)*) = new OpenHashMap[K, V] ++= elems
+  def empty[K : ClassTag, V : ClassTag] = new OpenHashMap[K, V]
 
   final private class OpenEntry[Key, Value](val key: Key,
                                             val hash: Int,
@@ -47,7 +49,7 @@ object OpenHashMap {
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  */
-class OpenHashMap[Key, Value](initialSize : Int)
+class OpenHashMap[Key : ClassTag, Value : ClassTag](initialSize : Int)
 extends AbstractMap[Key, Value]
    with Map[Key, Value]
    with MapLike[Key, Value, OpenHashMap[Key, Value]] {

--- a/test/junit/scala/collection/SetMapConsistencyTest.scala
+++ b/test/junit/scala/collection/SetMapConsistencyTest.scala
@@ -9,6 +9,7 @@ import scala.collection.JavaConverters._
 /* Tests various maps by making sure they all agree on the same answers. */
 @RunWith(classOf[JUnit4])
 class SetMapConsistencyTest {
+  import scala.reflect.ClassTag
   
   trait MapBox[A] {
     protected def oor(s: String, n: Int) = throw new IllegalArgumentException(s"Out of range for $s: $n")
@@ -65,7 +66,7 @@ class SetMapConsistencyTest {
   
   def boxMhm[A] = new BoxMutableMap[A, cm.HashMap[A, Int]](new cm.HashMap[A, Int], "mutable.HashMap")
   
-  def boxMohm[A] = new BoxMutableMap[A, cm.OpenHashMap[A, Int]](new cm.OpenHashMap[A, Int], "mutable.OpenHashMap")
+  def boxMohm[A : ClassTag] = new BoxMutableMap[A, cm.OpenHashMap[A, Int]](new cm.OpenHashMap[A, Int], "mutable.OpenHashMap")
 
   def boxMtm[A: Ordering] = new BoxMutableMap[A, cm.TreeMap[A, Int]](new cm.TreeMap[A, Int], "mutable.TreeMap")
   


### PR DESCRIPTION
I'm creating this PR now so that this API-breaking change makes it into 2.12.
