### PR TITLE
Emit a warning when a constant expression evaluates to an error

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -59,6 +59,7 @@ trait Warnings {
     val PackageObjectClasses   = LintWarning("package-object-classes",    "Class or object defined in package object.")
     val UnsoundMatch           = LintWarning("unsound-match",             "Pattern match may not be typesafe.")
     val StarsAlign             = LintWarning("stars-align",               "Pattern sequence wildcard must align with sequence component.")
+    val Constant               = LintWarning("constant",                  "Evaluation of a constant arithmetic expression results in an error.")
 
     def allLintWarnings = values.toSeq.asInstanceOf[Seq[LintWarning]]
   }
@@ -80,6 +81,7 @@ trait Warnings {
   def warnPackageObjectClasses   = lint contains PackageObjectClasses
   def warnUnsoundMatch           = lint contains UnsoundMatch
   def warnStarsAlign             = lint contains StarsAlign
+  def warnConstant               = lint contains Constant
 
   // Lint warnings that are currently -Y, but deprecated in that usage
   @deprecated("Use warnAdaptedArgs", since="2.11.2")

--- a/src/compiler/scala/tools/nsc/typechecker/ConstantFolder.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ConstantFolder.scala
@@ -40,9 +40,10 @@ abstract class ConstantFolder {
       if ((x ne null) && x.tag != UnitTag) tree setType ConstantType(x)
       else tree
     } catch {
-      case _: ArithmeticException => tree   // the code will crash at runtime,
-                                           // but that is better than the
-                                           // compiler itself crashing
+      case e: ArithmeticException =>
+        if (settings.warnConstant)
+          warning(tree.pos, s"Evaluation of a constant expression results in an arithmetic error: ${e.getMessage}")
+        tree
     }
 
   private def foldUnop(op: Name, x: Constant): Constant = (op, x.tag) match {
@@ -158,7 +159,7 @@ abstract class ConstantFolder {
       else if (x.isNumeric && y.isNumeric) math.max(x.tag, y.tag)
       else NoTag
 
-    try optag match {
+    optag match {
       case BooleanTag                               => foldBooleanOp(op, x, y)
       case ByteTag | ShortTag | CharTag | IntTag    => foldSubrangeOp(op, x, y)
       case LongTag                                  => foldLongOp(op, x, y)
@@ -166,9 +167,6 @@ abstract class ConstantFolder {
       case DoubleTag                                => foldDoubleOp(op, x, y)
       case StringTag if op == nme.ADD               => Constant(x.stringValue + y.stringValue)
       case _                                        => null
-    }
-    catch {
-      case _: ArithmeticException => null
     }
   }
 }

--- a/test/files/pos/constant-warning.check
+++ b/test/files/pos/constant-warning.check
@@ -1,0 +1,4 @@
+constant-warning.scala:2: warning: Evaluation of a constant expression results in an arithmetic error: / by zero
+  val fails = 1 + 2 / (3 - 2 - 1)
+                    ^
+one warning found

--- a/test/files/pos/constant-warning.flags
+++ b/test/files/pos/constant-warning.flags
@@ -1,0 +1,1 @@
+-Xlint:constant

--- a/test/files/pos/constant-warning.scala
+++ b/test/files/pos/constant-warning.scala
@@ -1,0 +1,3 @@
+object Test {
+  val fails = 1 + 2 / (3 - 2 - 1)
+}


### PR DESCRIPTION
Emit a warning from the constant folder when evaluation of a constant expression results in an `ArithmeticException`, e.g. division by zero.

There are linters that can detect this but it doesn't seem to add any expense to just have the compiler warn about it.
