### PR TITLE
SI-9752 never ignore blank lines when parsing code blocks

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
@@ -295,7 +295,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
       }
 
       case line :: ls if (lastTagKey.isDefined) => {
-        val newtags = if (!line.isEmpty) {
+        val newtags = if (!line.isEmpty || inCodeBlock) {
           val key = lastTagKey.get
           val value =
             ((tags get key): @unchecked) match {

--- a/test/scaladoc/run/t9752.check
+++ b/test/scaladoc/run/t9752.check
@@ -1,0 +1,5 @@
+List(Body(List(Paragraph(Chain(List(Summary(Text())))), Code(class A
+
+
+class B))))
+Done.

--- a/test/scaladoc/run/t9752.scala
+++ b/test/scaladoc/run/t9752.scala
@@ -1,0 +1,28 @@
+import scala.tools.nsc.doc.model._
+import scala.tools.partest.ScaladocModelTest
+
+object Test extends ScaladocModelTest {
+
+  override def code = s"""
+  /**
+    * Foo
+    *
+    * @example
+    * {{{
+    * class A
+    *
+    *
+    * class B
+    * }}}
+    */
+    object Foo
+  """
+
+  def scaladocSettings = ""
+
+  def testModel(root: Package) = {
+    import access._
+    val obj = root._object("Foo")
+    println(obj.comment.get.example)
+  }
+}


### PR DESCRIPTION
The default behavior when parsing the content of a tag text (like after
`@example`) was to ignore empty lines. That's fine, except when we are
in the middle of a code block, where preserving formatting matters.
