### PR TITLE
SI-9762 Update the REPL to use JLine 2.14.1

### DIFF
--- a/src/intellij/scala.ipr.SAMPLE
+++ b/src/intellij/scala.ipr.SAMPLE
@@ -77,7 +77,7 @@
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-5.0.4-scala-3.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-xml_2.12.0-M3-dc9effe/bundles/scala-xml_2.12.0-M3-dc9effe-1.0.5.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.12.0-M3-dc9effe/bundles/scala-parser-combinators_2.12.0-M3-dc9effe-1.0.4.jar!/" />
-        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.12.1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.1.jar!/" />
       </CLASSES>
       <JAVADOC />
       <SOURCES />
@@ -100,7 +100,7 @@
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-5.0.4-scala-3.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-xml_2.12.0-M3-dc9effe/bundles/scala-xml_2.12.0-M3-dc9effe-1.0.5.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.12.0-M3-dc9effe/bundles/scala-parser-combinators_2.12.0-M3-dc9effe-1.0.4.jar!/" />
-        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.12.1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.1.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-partest_2.12.0-M3-dc9effe/jars/scala-partest_2.12.0-M3-dc9effe-1.0.13.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/com.googlecode.java-diff-utils/diffutils/jars/diffutils-1.3.0.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/test-interface/jars/test-interface-1.0.jar!/" />
@@ -126,7 +126,7 @@
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-5.0.4-scala-3.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-xml_2.12.0-M3-dc9effe/bundles/scala-xml_2.12.0-M3-dc9effe-1.0.5.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.12.0-M3-dc9effe/bundles/scala-parser-combinators_2.12.0-M3-dc9effe-1.0.4.jar!/" />
-        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.12.1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.1.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-partest_2.12.0-M3-dc9effe/jars/scala-partest_2.12.0-M3-dc9effe-1.0.13.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/com.googlecode.java-diff-utils/diffutils/jars/diffutils-1.3.0.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/test-interface/jars/test-interface-1.0.jar!/" />
@@ -159,7 +159,7 @@
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-5.0.4-scala-3.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-xml_2.12.0-M3-dc9effe/bundles/scala-xml_2.12.0-M3-dc9effe-1.0.5.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.12.0-M3-dc9effe/bundles/scala-parser-combinators_2.12.0-M3-dc9effe-1.0.4.jar!/" />
-        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.12.1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.1.jar!/" />
       </CLASSES>
       <JAVADOC />
       <SOURCES />
@@ -303,7 +303,7 @@
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-5.0.4-scala-3.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-xml_2.12.0-M3-dc9effe/bundles/scala-xml_2.12.0-M3-dc9effe-1.0.5.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.12.0-M3-dc9effe/bundles/scala-parser-combinators_2.12.0-M3-dc9effe-1.0.4.jar!/" />
-        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.12.1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.1.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-partest_2.12.0-M3-dc9effe/jars/scala-partest_2.12.0-M3-dc9effe-1.0.13.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/com.googlecode.java-diff-utils/diffutils/jars/diffutils-1.3.0.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/test-interface/jars/test-interface-1.0.jar!/" />

--- a/src/repl-jline/scala/tools/nsc/interpreter/jline/JLineReader.scala
+++ b/src/repl-jline/scala/tools/nsc/interpreter/jline/JLineReader.scala
@@ -141,26 +141,6 @@ private class JLineConsoleReader extends jconsole.ConsoleReader with interpreter
       case _                  => this addCompleter completer
     }
 
-    // This is a workaround for https://github.com/jline/jline2/issues/208
-    // and should not be necessary once we upgrade to JLine 2.13.1
-    ///
-    // Test by:
-    // scala> {" ".char}<LEFT><TAB>
-    //
-    // And checking we don't get an extra } on the line.
-    ///
-    val handler = getCompletionHandler
-    setCompletionHandler(new CompletionHandler {
-      override def complete(consoleReader: ConsoleReader, list: JList[CharSequence], i: Int): Boolean = {
-        try {
-          handler.complete(consoleReader, list, i)
-        } finally if (getCursorBuffer.cursor != getCursorBuffer.length()) {
-          print(" ")
-          getCursorBuffer.write(' ')
-          backspace()
-        }
-      }
-    })
     setAutoprintThreshold(400) // max completion candidates without warning
   }
 }

--- a/src/repl-jline/scala/tools/nsc/interpreter/jline/JLineReader.scala
+++ b/src/repl-jline/scala/tools/nsc/interpreter/jline/JLineReader.scala
@@ -11,9 +11,8 @@ import java.util.{Collection => JCollection, List => JList}
 
 import _root_.jline.{console => jconsole}
 import jline.console.ConsoleReader
-import jline.console.completer.{CompletionHandler, Completer}
+import jline.console.completer.{CandidateListCompletionHandler, Completer, CompletionHandler}
 import jconsole.history.{History => JHistory}
-
 
 import scala.tools.nsc.interpreter
 import scala.tools.nsc.interpreter.{Completion, NoCompletion}
@@ -133,6 +132,9 @@ private class JLineConsoleReader extends jconsole.ConsoleReader with interpreter
           newCursor
         }
       }
+    getCompletionHandler match {
+      case clch: CandidateListCompletionHandler => clch.setPrintSpaceAfterFullCompletion(false)
+    }
 
     completion match {
       case NoCompletion       => ()

--- a/versions.properties
+++ b/versions.properties
@@ -26,7 +26,7 @@ scala-xml.version.number=1.0.5
 scala-parser-combinators.version.number=1.0.4
 scala-swing.version.number=2.0.0-M2
 scala-swing.version.osgi=2.0.0.M2
-jline.version=2.12.1
+jline.version=2.14.1
 scala-asm.version=5.0.4-scala-3
 
 # external modules, used internally (not shipped)


### PR DESCRIPTION
Highlights:
- Adds opt-in support for suspend / resume. Enable with `jline.sigcont=true` in `$HOME/.jlinerc`, or with `scala -Djline.code`
- Fixes handling of completion with multibyte characters: https://github.com/jline/jline2/issues/135

Full changelog in JLine since the 2.12.1: https://github.com/jline/jline2/compare/jline-2.12.1...jline-2.14.1

Users with `keymap = vi` in `.inputrc` should be aware that this now will start the REPL in insert mode, rather than edit mode. This behaviour might be a bug, and is being discussed in https://github.com/jline/jline2/issues/113

Review, tyre kicking, by @som-snytt
