### PR TITLE
SD-129 Mark JFunctionN as serializable

### DIFF
--- a/src/library/scala/runtime/java8/JFunction0.java
+++ b/src/library/scala/runtime/java8/JFunction0.java
@@ -6,7 +6,7 @@
 package scala.runtime.java8;
 
 @FunctionalInterface
-public interface JFunction0<R> extends scala.Function0<R> {
+public interface JFunction0<R> extends scala.Function0<R>, java.io.Serializable {
     default void $init$() {
     };
     default void apply$mcV$sp() {

--- a/src/library/scala/runtime/java8/JFunction1.java
+++ b/src/library/scala/runtime/java8/JFunction1.java
@@ -6,7 +6,7 @@
 package scala.runtime.java8;
 
 @FunctionalInterface
-public interface JFunction1<T1, R> extends scala.Function1<T1, R> {
+public interface JFunction1<T1, R> extends scala.Function1<T1, R>, java.io.Serializable {
     default void apply$mcVI$sp(int v1) {
         apply((T1) scala.runtime.BoxesRunTime.boxToInteger(v1));
     }

--- a/src/library/scala/runtime/java8/JFunction10.java
+++ b/src/library/scala/runtime/java8/JFunction10.java
@@ -6,5 +6,5 @@
 package scala.runtime.java8;
 
 @FunctionalInterface
-public interface JFunction10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R> extends scala.Function10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R> {
+public interface JFunction10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R> extends scala.Function10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R>, java.io.Serializable {
 }

--- a/src/library/scala/runtime/java8/JFunction11.java
+++ b/src/library/scala/runtime/java8/JFunction11.java
@@ -6,5 +6,5 @@
 package scala.runtime.java8;
 
 @FunctionalInterface
-public interface JFunction11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R> extends scala.Function11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R> {
+public interface JFunction11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R> extends scala.Function11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R>, java.io.Serializable {
 }

--- a/src/library/scala/runtime/java8/JFunction12.java
+++ b/src/library/scala/runtime/java8/JFunction12.java
@@ -6,5 +6,5 @@
 package scala.runtime.java8;
 
 @FunctionalInterface
-public interface JFunction12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R> extends scala.Function12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R> {
+public interface JFunction12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R> extends scala.Function12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R>, java.io.Serializable {
 }

--- a/src/library/scala/runtime/java8/JFunction13.java
+++ b/src/library/scala/runtime/java8/JFunction13.java
@@ -6,5 +6,5 @@
 package scala.runtime.java8;
 
 @FunctionalInterface
-public interface JFunction13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R> extends scala.Function13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R> {
+public interface JFunction13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R> extends scala.Function13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R>, java.io.Serializable {
 }

--- a/src/library/scala/runtime/java8/JFunction14.java
+++ b/src/library/scala/runtime/java8/JFunction14.java
@@ -6,5 +6,5 @@
 package scala.runtime.java8;
 
 @FunctionalInterface
-public interface JFunction14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R> extends scala.Function14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R> {
+public interface JFunction14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R> extends scala.Function14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R>, java.io.Serializable {
 }

--- a/src/library/scala/runtime/java8/JFunction15.java
+++ b/src/library/scala/runtime/java8/JFunction15.java
@@ -6,5 +6,5 @@
 package scala.runtime.java8;
 
 @FunctionalInterface
-public interface JFunction15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R> extends scala.Function15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R> {
+public interface JFunction15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R> extends scala.Function15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R>, java.io.Serializable {
 }

--- a/src/library/scala/runtime/java8/JFunction16.java
+++ b/src/library/scala/runtime/java8/JFunction16.java
@@ -6,5 +6,5 @@
 package scala.runtime.java8;
 
 @FunctionalInterface
-public interface JFunction16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R> extends scala.Function16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R> {
+public interface JFunction16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R> extends scala.Function16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R>, java.io.Serializable {
 }

--- a/src/library/scala/runtime/java8/JFunction17.java
+++ b/src/library/scala/runtime/java8/JFunction17.java
@@ -6,5 +6,5 @@
 package scala.runtime.java8;
 
 @FunctionalInterface
-public interface JFunction17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R> extends scala.Function17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R> {
+public interface JFunction17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R> extends scala.Function17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R>, java.io.Serializable {
 }

--- a/src/library/scala/runtime/java8/JFunction18.java
+++ b/src/library/scala/runtime/java8/JFunction18.java
@@ -6,5 +6,5 @@
 package scala.runtime.java8;
 
 @FunctionalInterface
-public interface JFunction18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R> extends scala.Function18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R> {
+public interface JFunction18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R> extends scala.Function18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R>, java.io.Serializable {
 }

--- a/src/library/scala/runtime/java8/JFunction19.java
+++ b/src/library/scala/runtime/java8/JFunction19.java
@@ -6,5 +6,5 @@
 package scala.runtime.java8;
 
 @FunctionalInterface
-public interface JFunction19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R> extends scala.Function19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R> {
+public interface JFunction19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R> extends scala.Function19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R>, java.io.Serializable {
 }

--- a/src/library/scala/runtime/java8/JFunction2.java
+++ b/src/library/scala/runtime/java8/JFunction2.java
@@ -6,7 +6,7 @@
 package scala.runtime.java8;
 
 @FunctionalInterface
-public interface JFunction2<T1, T2, R> extends scala.Function2<T1, T2, R> {
+public interface JFunction2<T1, T2, R> extends scala.Function2<T1, T2, R>, java.io.Serializable {
     default void apply$mcVII$sp(int v1, int v2) {
         apply((T1) scala.runtime.BoxesRunTime.boxToInteger(v1), (T2) scala.runtime.BoxesRunTime.boxToInteger(v2));
     }

--- a/src/library/scala/runtime/java8/JFunction20.java
+++ b/src/library/scala/runtime/java8/JFunction20.java
@@ -6,5 +6,5 @@
 package scala.runtime.java8;
 
 @FunctionalInterface
-public interface JFunction20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R> extends scala.Function20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R> {
+public interface JFunction20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R> extends scala.Function20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R>, java.io.Serializable {
 }

--- a/src/library/scala/runtime/java8/JFunction21.java
+++ b/src/library/scala/runtime/java8/JFunction21.java
@@ -6,5 +6,5 @@
 package scala.runtime.java8;
 
 @FunctionalInterface
-public interface JFunction21<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R> extends scala.Function21<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R> {
+public interface JFunction21<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R> extends scala.Function21<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R>, java.io.Serializable {
 }

--- a/src/library/scala/runtime/java8/JFunction22.java
+++ b/src/library/scala/runtime/java8/JFunction22.java
@@ -6,5 +6,5 @@
 package scala.runtime.java8;
 
 @FunctionalInterface
-public interface JFunction22<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R> extends scala.Function22<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R> {
+public interface JFunction22<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R> extends scala.Function22<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R>, java.io.Serializable {
 }

--- a/src/library/scala/runtime/java8/JFunction3.java
+++ b/src/library/scala/runtime/java8/JFunction3.java
@@ -6,5 +6,5 @@
 package scala.runtime.java8;
 
 @FunctionalInterface
-public interface JFunction3<T1, T2, T3, R> extends scala.Function3<T1, T2, T3, R> {
+public interface JFunction3<T1, T2, T3, R> extends scala.Function3<T1, T2, T3, R>, java.io.Serializable {
 }

--- a/src/library/scala/runtime/java8/JFunction4.java
+++ b/src/library/scala/runtime/java8/JFunction4.java
@@ -6,5 +6,5 @@
 package scala.runtime.java8;
 
 @FunctionalInterface
-public interface JFunction4<T1, T2, T3, T4, R> extends scala.Function4<T1, T2, T3, T4, R> {
+public interface JFunction4<T1, T2, T3, T4, R> extends scala.Function4<T1, T2, T3, T4, R>, java.io.Serializable {
 }

--- a/src/library/scala/runtime/java8/JFunction5.java
+++ b/src/library/scala/runtime/java8/JFunction5.java
@@ -6,5 +6,5 @@
 package scala.runtime.java8;
 
 @FunctionalInterface
-public interface JFunction5<T1, T2, T3, T4, T5, R> extends scala.Function5<T1, T2, T3, T4, T5, R> {
+public interface JFunction5<T1, T2, T3, T4, T5, R> extends scala.Function5<T1, T2, T3, T4, T5, R>, java.io.Serializable {
 }

--- a/src/library/scala/runtime/java8/JFunction6.java
+++ b/src/library/scala/runtime/java8/JFunction6.java
@@ -6,5 +6,5 @@
 package scala.runtime.java8;
 
 @FunctionalInterface
-public interface JFunction6<T1, T2, T3, T4, T5, T6, R> extends scala.Function6<T1, T2, T3, T4, T5, T6, R> {
+public interface JFunction6<T1, T2, T3, T4, T5, T6, R> extends scala.Function6<T1, T2, T3, T4, T5, T6, R>, java.io.Serializable {
 }

--- a/src/library/scala/runtime/java8/JFunction7.java
+++ b/src/library/scala/runtime/java8/JFunction7.java
@@ -6,5 +6,5 @@
 package scala.runtime.java8;
 
 @FunctionalInterface
-public interface JFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends scala.Function7<T1, T2, T3, T4, T5, T6, T7, R> {
+public interface JFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends scala.Function7<T1, T2, T3, T4, T5, T6, T7, R>, java.io.Serializable {
 }

--- a/src/library/scala/runtime/java8/JFunction8.java
+++ b/src/library/scala/runtime/java8/JFunction8.java
@@ -6,5 +6,5 @@
 package scala.runtime.java8;
 
 @FunctionalInterface
-public interface JFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends scala.Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> {
+public interface JFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends scala.Function8<T1, T2, T3, T4, T5, T6, T7, T8, R>, java.io.Serializable {
 }

--- a/src/library/scala/runtime/java8/JFunction9.java
+++ b/src/library/scala/runtime/java8/JFunction9.java
@@ -6,5 +6,5 @@
 package scala.runtime.java8;
 
 @FunctionalInterface
-public interface JFunction9<T1, T2, T3, T4, T5, T6, T7, T8, T9, R> extends scala.Function9<T1, T2, T3, T4, T5, T6, T7, T8, T9, R> {
+public interface JFunction9<T1, T2, T3, T4, T5, T6, T7, T8, T9, R> extends scala.Function9<T1, T2, T3, T4, T5, T6, T7, T8, T9, R>, java.io.Serializable {
 }


### PR DESCRIPTION
Before this change, if these were used as the target type of a lambda
in Java source code, the lambda would not be serializable. This is
somewhat suprising when contrasted with the way that Scala lambdas
work in Scala source.

Since we copied these classes over from scala-java8-compat, that
project has opted to add Serializable as a parent to solve this issue.
This commit brings our copy of these interfaces into line with that
change.

Review by @szeiger

Fixes scala/scala-dev#129
