### PR TITLE
Avoid function chaining with reverse method

### DIFF
--- a/src/library/scala/collection/mutable/PriorityQueue.scala
+++ b/src/library/scala/collection/mutable/PriorityQueue.scala
@@ -200,9 +200,7 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
    *  @return   A reversed priority queue.
    */
   def reverse = {
-    val revq = new PriorityQueue[A]()(new scala.math.Ordering[A] {
-      def compare(x: A, y: A) = ord.compare(y, x)
-    })
+    val revq = new PriorityQueue[A]()(ord.reverse)
     for (i <- 1 until resarr.length) revq += resarr(i)
     revq
   }

--- a/test/junit/scala/collection/mutable/PriorityQueueTest.scala
+++ b/test/junit/scala/collection/mutable/PriorityQueueTest.scala
@@ -14,6 +14,12 @@ class PriorityQueueTest {
   priorityQueue.enqueue(elements :_*)
 
   @Test
+  def orderingReverseReverse() {
+    val pq = new mutable.PriorityQueue[Nothing]()((_,_)=>42)
+    assert(pq.ord eq pq.reverse.reverse.ord)
+  }
+  
+  @Test
   def canSerialize() {
     val outputStream = new ByteArrayOutputStream()
     new ObjectOutputStream(outputStream).writeObject(priorityQueue)
@@ -27,6 +33,7 @@ class PriorityQueueTest {
 
     val objectInputStream = new ObjectInputStream(new ByteArrayInputStream(bytes))
     val deserializedPriorityQueue = objectInputStream.readObject().asInstanceOf[PriorityQueue[Int]]
+    //correct sequencing is also tested here:
     assert(deserializedPriorityQueue.dequeueAll == elements.sorted.reverse)
   }
 }


### PR DESCRIPTION
`pq.reverse.reverse.reverse.reverse.reverse` could possibly occur in a loop.

(no similar cases found searching rest of the standard library)
