### PR TITLE
SD-110 Emit self-synchronized trait methods with ACC_SYNCHRONIZED

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -341,7 +341,8 @@ abstract class UnCurry extends InfoTransform
 
     private def isSelfSynchronized(ddef: DefDef) = ddef.rhs match {
       case Apply(fn @ TypeApply(Select(sel, _), _), _) =>
-        fn.symbol == Object_synchronized && sel.symbol == ddef.symbol.enclClass && !ddef.symbol.enclClass.isTrait
+        val result = fn.symbol == Object_synchronized && sel.symbol == ddef.symbol.enclClass
+        result
       case _ => false
     }
 


### PR DESCRIPTION
Avoids the bloat of spelling out the details in the method body.

If we elect to emit trait methods in static methods with an explicit self
parameter (which is under consideration to avoid headaches with using
invokespecial to methods in non-direct parent interfaces), we would
need to revert this change.

Fixes https://github.com/scala/scala-dev/issues/110

Review by @lrytz
