### PR TITLE
SD-142 Avoid noisy log output in backend

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -394,15 +394,18 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
 
       if (settings.debug && (settings.verbose || currentRun.size < 5))
         inform("[running phase " + name + " on " + unit + "]")
+      if (!cancelled(unit)) {
+        currentRun.informUnitStarting(this, unit)
+        try withCurrentUnitNoLog(unit)(task)
+        finally currentRun.advanceUnit()
+      }
+    }
 
+    final def withCurrentUnitNoLog(unit: CompilationUnit)(task: => Unit) {
       val unit0 = currentUnit
       try {
         currentRun.currentUnit = unit
-        if (!cancelled(unit)) {
-          currentRun.informUnitStarting(this, unit)
-          task
-        }
-        currentRun.advanceUnit()
+        task
       } finally {
         //assert(currentUnit == unit)
         currentRun.currentUnit = unit0

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
@@ -135,7 +135,7 @@ abstract class GenBCode extends BCodeSyncAndTry {
             return
           }
           else {
-            try   { withCurrentUnit(item.cunit)(visit(item)) }
+            try   { withCurrentUnitNoLog(item.cunit)(visit(item)) }
             catch {
               case ex: Throwable =>
                 ex.printStackTrace()


### PR DESCRIPTION
`withCurrentUnit` is designed to be called once per
compilation unit as it side effects by logging and updating
progress counters.

`GenBCode` was calling it more frequently (once per `ClassDef`.)
This is due to the somewhat convoluted internal architecture
of that phase, which is designed to support paralellism in
the future.

This commit factors out the internal part of `withCompilationUnit`
that modifies `currentUnit`, and calls that instead in the loop
over classes.

After this change:

```
% qscala -Ydebug
...
[running phase jvm on <console>] // only once
```

Review by @lrytz 
