### PR TITLE
Add an empty sentinel value to avoid `Future[Unit]`

### DIFF
--- a/src/library/scala/util/Try.scala
+++ b/src/library/scala/util/Try.scala
@@ -266,3 +266,7 @@ final case class Success[+T](value: T) extends Try[T] {
   override def fold[U](fa: Throwable => U, fb: T => U): U =
     try { fb(value) } catch { case NonFatal(e) => fa(e) }
 }
+
+object Success {
+  val empty: Success = Success(())
+}


### PR DESCRIPTION
Taken from `akka.Done` and enriched with an example of a value discarding pitfall.
