### PR TITLE
Warn, drop @native annotation in traits

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -552,7 +552,15 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
         return
       }
 
-      val isNative         = methSymbol.hasAnnotation(definitions.NativeAttr)
+      val isNative =
+        (methSymbol.hasAnnotation(definitions.NativeAttr)) && {
+          if (methSymbol.owner.isTrait) {
+            reporter.warning(methSymbol.pos, "Native methods are not supprted in traits, ignoring")
+            false
+          } else true
+        }
+
+
       val isAbstractMethod = rhs == EmptyTree
       val flags = GenBCode.mkFlags(
         javaFlags(methSymbol),

--- a/test/files/run/trait-native.check
+++ b/test/files/run/trait-native.check
@@ -1,0 +1,3 @@
+trait-native.scala:2: warning: Native methods are not supprted in traits, ignoring
+  @native def foo = ???
+              ^

--- a/test/files/run/trait-native.scala
+++ b/test/files/run/trait-native.scala
@@ -1,0 +1,8 @@
+trait T {
+  @native def foo = ???
+}
+object Test extends T {
+  def main(args: Array[String]): Unit = {
+     // was VerifyError
+  }
+}


### PR DESCRIPTION
This avoids a potential VerifyError.
