### PR TITLE
Test case for SI-5183, tagged primitives in case classes

### DIFF
--- a/test/files/pos/t5183.scala
+++ b/test/files/pos/t5183.scala
@@ -1,0 +1,7 @@
+trait Day
+
+object Test {
+  def foo(t: Int with Day) = t == t
+}
+
+class DayOps(val i: Int with Day) extends AnyVal


### PR DESCRIPTION
Context: https://gitter.im/scala/scala?at=5725b095ce9e8bce0fd34632
