### PR TITLE
SI-9397 Add "_root_" to "GenUtils.scalaFactoryCall" to avoid the scala package name conflits

### DIFF
--- a/src/compiler/scala/reflect/reify/codegen/GenUtils.scala
+++ b/src/compiler/scala/reflect/reify/codegen/GenUtils.scala
@@ -55,7 +55,7 @@ trait GenUtils {
     mirrorCall(TermName("" + prefix), args: _*)
 
   def scalaFactoryCall(name: TermName, args: Tree*): Tree =
-    call(s"scala.$name.apply", args: _*)
+    call(s"_root_.scala.$name.apply", args: _*)
 
   def scalaFactoryCall(name: String, args: Tree*): Tree =
     scalaFactoryCall(TermName(name), args: _*)

--- a/src/compiler/scala/reflect/reify/utils/NodePrinters.scala
+++ b/src/compiler/scala/reflect/reify/utils/NodePrinters.scala
@@ -28,7 +28,7 @@ trait NodePrinters {
         var s = line substring 2
         s = s.replace(nme.UNIVERSE_PREFIX.toString, "")
         s = s.replace(".apply", "")
-        s = "([^\"])scala\\.collection\\.immutable\\.".r.replaceAllIn(s, "$1")
+        s = "([^\"])(_root_\\.)?scala\\.collection\\.immutable\\.".r.replaceAllIn(s, "$1")
         s = "List\\[List\\[.*?\\].*?\\]".r.replaceAllIn(s, "List")
         s = "List\\[.*?\\]".r.replaceAllIn(s, "List")
         s = s.replace("immutable.this.Nil", "List()")

--- a/test/files/pos/t9397.scala
+++ b/test/files/pos/t9397.scala
@@ -1,0 +1,12 @@
+package foo.scala
+
+import scala.reflect.runtime.universe._
+
+object Foo {
+
+  def bar[T: TypeTag]() {
+  }
+
+  import foo._
+  bar[String]()
+}


### PR DESCRIPTION
When a user imports some package ending with `scala`, the macro expansion of TypeTag may not work because it uses `scala.collection.immutable.List` but it's overrided (see the example in [SI-9397](https://issues.scala-lang.org/browse/SI-9397)). This patch adds the `_root_` prefix to avoid the scala package name conflits. Of cause, after this fix, importing a package ending with `_root_` has the same issue. However, people rarely do that.
