### PR TITLE
Eliminate major sources of daily noise in SBT build.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,8 @@
  * What you see below is very much work-in-progress. The following features are implemented:
  *   - Compiling all classses for the compiler and library ("compile" in the respective subprojects)
  *   - Running JUnit tests ("test") and partest ("test/it:test")
- *   - Creating build-sbt/quick with all compiled classes and launcher scripts ("dist/mkQuick")
- *   - Creating build-sbt/pack with all JARs and launcher scripts ("dist/mkPack")
+ *   - Creating build/quick with all compiled classes and launcher scripts ("dist/mkQuick")
+ *   - Creating build/pack with all JARs and launcher scripts ("dist/mkPack")
  *   - Building all scaladoc sets ("doc")
  *   - Publishing ("publishDists" and standard sbt tasks like "publish" and "publishLocal")
  *
@@ -771,8 +771,8 @@ def configureAsForkOfJavaProject(project: Project): Project = {
 
 lazy val buildDirectory = settingKey[File]("The directory where all build products go. By default ./build")
 lazy val mkBin = taskKey[Seq[File]]("Generate shell script (bash or Windows batch).")
-lazy val mkQuick = taskKey[Unit]("Generate a full build, including scripts, in build-sbt/quick")
-lazy val mkPack = taskKey[Unit]("Generate a full build, including scripts, in build-sbt/pack")
+lazy val mkQuick = taskKey[Unit]("Generate a full build, including scripts, in build/quick")
+lazy val mkPack = taskKey[Unit]("Generate a full build, including scripts, in build/pack")
 
 // Defining these settings is somewhat redundant as we also redefine settings that depend on them.
 // However, IntelliJ's project import works better when these are set correctly.
@@ -831,7 +831,7 @@ def generateServiceProviderResources(services: (String, String)*): Setting[_] =
     }
   }.taskValue
 
-buildDirectory in ThisBuild := (baseDirectory in ThisBuild).value / "build-sbt"
+buildDirectory in ThisBuild := (baseDirectory in ThisBuild).value / "build"
 
 // Add tab completion to partest
 commands += Command("partest")(_ => PartestUtil.partestParser((baseDirectory in ThisBuild).value, (baseDirectory in ThisBuild).value / "test")) { (state, parsed) =>

--- a/build.sbt
+++ b/build.sbt
@@ -210,7 +210,9 @@ lazy val commonSettings = clearSourceAndResourceDirectories ++ publishSettings +
 
   // Don't log process output (e.g. of forked `compiler/runMain ...Main`), just pass it
   // directly to stdout
-  outputStrategy in run := Some(StdoutOutput)
+  outputStrategy in run := Some(StdoutOutput),
+  Quiet.silenceScalaBinaryVersionWarning,
+  Quiet.silenceIvyUpdateInfoLogging
 )
 
 /** Extra post-processing for the published POM files. These are needed to create POMs that
@@ -475,6 +477,7 @@ lazy val replJlineEmbedded = Project("repl-jline-embedded", file(".") / "target"
     }),
     publishArtifact := false,
     connectInput in run := true
+
   )
   .dependsOn(replJline)
 
@@ -677,8 +680,9 @@ lazy val root = (project in file("."))
     publishArtifact := false,
     publish := {},
     publishLocal := {},
-    commands ++= ScriptCommands.all
-  )
+    commands ++= ScriptCommands.all,
+    Quiet.silenceIvyUpdateInfoLogging
+)
   .aggregate(library, forkjoin, reflect, compiler, interactive, repl, replJline, replJlineEmbedded,
     scaladoc, scalap, actors, partestExtras, junit, libraryAll, scalaDist).settings(
     sources in Compile := Seq.empty,

--- a/project/Quiet.scala
+++ b/project/Quiet.scala
@@ -1,0 +1,33 @@
+import sbt._
+import Keys._
+
+object Quiet {
+  // Workaround SBT issue described:
+  //
+  //   https://github.com/scala/scala-dev/issues/100
+  def silenceScalaBinaryVersionWarning = ivyConfiguration := {
+    ivyConfiguration.value match {
+      case c: InlineIvyConfiguration =>
+        val delegate = c.log
+        val logger = new Logger {
+          override def trace(t: => Throwable): Unit = delegate.trace(t)
+          override def log(level: sbt.Level.Value, message: => String): Unit = {
+            level match {
+              case sbt.Level.Warn =>
+                val message0 = message
+                val newLevel = if (message.contains("differs from Scala binary version in project"))
+                  delegate.log(sbt.Level.Debug, message)
+                else
+                  delegate.log(level, message)
+              case _ => delegate.log(level, message)
+            }
+          }
+          override def success(message: => String): Unit = delegate.success(message)
+        }
+        new InlineIvyConfiguration(c.paths, c.resolvers, c.otherResolvers, c.moduleConfigurations, c.localOnly, c.lock, c.checksums, c.resolutionCacheDir, c.updateOptions, logger)
+      case x => x
+    }
+  }
+
+  def silenceIvyUpdateInfoLogging = logLevel in update := Level.Warn
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 libraryDependencies += "org.apache.commons" % "commons-lang3" % "3.3.2"
 
-libraryDependencies += "org.pantsbuild" % "jarjar" % "1.6.0"
+libraryDependencies += "org.pantsbuild" % "jarjar" % "1.6.3"
 
 libraryDependencies += "biz.aQute" % "bndlib" % "1.50.0"
 


### PR DESCRIPTION
Eliminate major sources of daily noise in SBT build.
- Intercept incorrect "binary conflict" warning issued by SBT.
  Fixes https://github.com/scala/scala-dev/issues/100
- Bump to a new version of pantsbuild/jarjar to fix an
  incompatibility with Java 8 parameter names in class
  files, which we run into on the 2.12.x branch. See:
  https://github.com/pantsbuild/jarjar/pull/19
- Disable info level logging for dependency resolve/download.

Review by @szeiger or @lrytz 
