### PR TITLE
SI-5463 Check .jars before using them

### DIFF
--- a/test/files/run/t5463.scala
+++ b/test/files/run/t5463.scala
@@ -1,0 +1,21 @@
+import scala.reflect.internal.FatalError
+import scala.tools.partest.DirectTest
+
+object Test extends DirectTest {
+
+  def code = "class A"
+
+  override def show(): Unit = {
+    // Create a broken JAR file and put it on compiler classpath
+    val jarpath = testOutput.path + "/notajar.jar"
+    scala.reflect.io.File(jarpath).writeAll("This isn't really a JAR file")
+
+    val classpath = List(sys.props("partest.lib"), jarpath, testOutput.path) mkString sys.props("path.separator")
+    try {
+      compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(code)
+      throw new Error("Compilation should have failed");
+    } catch {
+      case ex: FatalError => // this is expected
+    }
+  }
+}


### PR DESCRIPTION
This patch makes compiler ignore broken JAR files on classpath, the same way nonexistent JARs are ignored. When an exception occurs while processing a JAR, we treat it as containing no packages and no classes.
