### PR TITLE
Add check to scala REPL package to improve feedback about implicits

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/package.scala
+++ b/src/repl/scala/tools/nsc/interpreter/package.scala
@@ -88,9 +88,6 @@ package object interpreter extends ReplConfig with ReplStrings {
           }
       }
 
-      if (filtered.isEmpty)
-        return "No implicits have been imported other than those in Predef."
-
       filtered foreach {
         case (source, syms) =>
           p("/* " + syms.size + " implicit members imported from " + source.fullName + " */")
@@ -126,7 +123,14 @@ package object interpreter extends ReplConfig with ReplStrings {
           }
           p("")
       }
-      ""
+      
+      if (filtered.nonEmpty) 
+        "" // side-effects above
+      else if (global.settings.nopredef || global.settings.noimports) 
+        "No implicits have been imported."
+      else
+        "No implicits have been imported other than those in Predef." 
+
     }
 
     def kindCommandInternal(expr: String, verbose: Boolean): Unit = {

--- a/test/files/run/repl-implicits-nopredef.check
+++ b/test/files/run/repl-implicits-nopredef.check
@@ -1,0 +1,5 @@
+
+scala> :implicits
+No implicits have been imported.
+
+scala> :quit

--- a/test/files/run/repl-implicits-nopredef.scala
+++ b/test/files/run/repl-implicits-nopredef.scala
@@ -1,0 +1,10 @@
+import scala.tools.partest.ReplTest
+import scala.tools.nsc.Settings
+
+object Test extends ReplTest {
+  override def transformSettings(settings: Settings): Settings = {
+    settings.nopredef.value = true
+    settings
+  }  
+  def code = ":implicits"
+}

--- a/test/files/run/repl-implicits.check
+++ b/test/files/run/repl-implicits.check
@@ -1,0 +1,5 @@
+
+scala> :implicits
+No implicits have been imported other than those in Predef.
+
+scala> :quit

--- a/test/files/run/repl-implicits.scala
+++ b/test/files/run/repl-implicits.scala
@@ -1,0 +1,5 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  def code = ":implicits"
+}


### PR DESCRIPTION
When the repl is started with additional compiler flags that prevent implicits
being in scope (like -Yno-predef) the default message of implicits in scope
using :implicits stays the same. 
This additional check will return the same message if predef is indeed in
scope. And an adjusted message if Predef is not in scope.

``` console
scala -Yno-predef
scala> :implicits
No implicits have been imported other than those in Predef.
```

In the new situation this will be catched and return a more correct answer about in scope implicits:

``` console
scala -Yno-predef
scala> :implicits
No implicits have been imported.
```
