### PR TITLE
SI-9773 linesWithSeparators is like split

### DIFF
--- a/src/library/scala/collection/immutable/StringLike.scala
+++ b/src/library/scala/collection/immutable/StringLike.scala
@@ -100,19 +100,23 @@ self =>
   /** Return all lines in this string in an iterator, including trailing
    *  line end characters.
    *
-   *  The number of strings returned is one greater than the number of line
-   *  end characters in this string. For an empty string, a single empty
-   *  line is returned. A line end character is one of
-   *  - `LF` - line feed   (`0x0A` hex)
-   *  - `FF` - form feed   (`0x0C` hex)
+   *  This method is analogous to `s.split(EOL).toIterator`,
+   *  except that any existing line endings are preserved in the result strings.
+   *
+   *  The empty string yields an iterator with one element, the empty string.
+   *
+   *  A line end character is one of
+   *  - `LF` - line feed   (`0x0A`)
+   *  - `FF` - form feed   (`0x0C`)
    */
   def linesWithSeparators: Iterator[String] = new AbstractIterator[String] {
     val str = self.toString
     private val len = str.length
-    private var index = 0
+    private var index = -1
     def hasNext: Boolean = index < len
     def next(): String = {
       if (index >= len) throw new NoSuchElementException("next on empty iterator")
+      index = index max 0
       val start = index
       while (index < len && !isLineBreak(apply(index))) index += 1
       index += 1
@@ -121,7 +125,7 @@ self =>
   }
 
   /** Return all lines in this string in an iterator, excluding trailing line
-   *  end characters, i.e., apply `.stripLineEnd` to all lines
+   *  end characters; i.e., apply `.stripLineEnd` to all lines
    *  returned by `linesWithSeparators`.
    */
   def lines: Iterator[String] =

--- a/test/junit/scala/collection/immutable/StringLikeTest.scala
+++ b/test/junit/scala/collection/immutable/StringLikeTest.scala
@@ -1,15 +1,16 @@
 package scala.collection.immutable
 
 import org.junit.Test
+import org.junit.Assert._
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.AssertUtil
+import scala.tools.testing.AssertUtil._
 import scala.util.Random
 
-/* Test for SI-8988 */
 @RunWith(classOf[JUnit4])
 class StringLikeTest {
+  /* Test for SI-8988 */
   @Test
   def testStringSplitWithChar: Unit = {
     val chars = (0 to 255).map(_.toChar)
@@ -22,7 +23,7 @@ class StringLikeTest {
       // make sure we can match a literal character done by Java's split
       val jSplit = jString.split("\\Q" + c.toString + "\\E")
       val sSplit = s.split(c)
-      AssertUtil.assertSameElements(jSplit, sSplit, s"Not same result as Java split for char $c in string $s")
+      assertSameElements(jSplit, sSplit, s"Not same result as Java split for char $c in string $s")
     }
   }
 
@@ -33,11 +34,21 @@ class StringLikeTest {
     val surrogatepair = List(high, low).mkString
     val twopairs = surrogatepair + "_" + surrogatepair
     
-    AssertUtil.assertSameElements("abcd".split('d'), Array("abc")) // not Array("abc", "")
-    AssertUtil.assertSameElements("abccc".split('c'), Array("ab")) // not Array("ab", "", "", "")
-    AssertUtil.assertSameElements("xxx".split('x'), Array[String]()) // not Array("", "", "", "")
-    AssertUtil.assertSameElements("".split('x'), Array("")) // not Array()
-    AssertUtil.assertSameElements("--ch--omp--".split("-"), Array("", "", "ch", "", "omp")) // All the cases!
-    AssertUtil.assertSameElements(twopairs.split(high), Array(twopairs)) //don't split on characters that are half a surrogate pair
+    assertSameElements("abcd".split('d'), Array("abc")) // not Array("abc", "")
+    assertSameElements("abccc".split('c'), Array("ab")) // not Array("ab", "", "", "")
+    assertSameElements("xxx".split('x'), Array[String]()) // not Array("", "", "", "")
+    assertSameElements("".split('x'), Array("")) // not Array()
+    assertSameElements("--ch--omp--".split("-"), Array("", "", "ch", "", "omp")) // All the cases!
+    assertSameElements(twopairs.split(high), Array(twopairs)) //don't split on characters that are half a surrogate pair
+  }
+
+  @Test def `linesWithSeparators is like split.iterator`(): Unit = {
+    assertEquals(1, "".linesWithSeparators.size)
+    assertEquals("", "".linesWithSeparators.next)
+    assertSameElements(List("a\n", "b"), "a\nb".linesWithSeparators.toList)
+    assertSameElements(List("a\n", "b\n"), "a\nb\n".linesWithSeparators.toList)
+    assertSameElements(List("\n", "a\n", "b\n"), "\na\nb\n".linesWithSeparators.toList)
+    assertSameElements(List("a\r\n", "b"), "a\r\nb".linesWithSeparators.toList)
+    assertSameElements(List("a\f", "b"), "a\fb".linesWithSeparators.toList)
   }
 }


### PR DESCRIPTION
StringLike.linesWithSeparators is like split but
preserves the separators.

Change the doc and implementation to align.

In particular, an empty string should yield one element.
