### PR TITLE
Improve Future documentation (+ minor code cleanups)

### DIFF
--- a/test/files/jvm/scala-concurrent-tck.check
+++ b/test/files/jvm/scala-concurrent-tck.check
@@ -1,1 +1,1 @@
-warning: there were 73 deprecation warnings; re-run with -deprecation for details
+warning: there were 75 deprecation warnings; re-run with -deprecation for details


### PR DESCRIPTION
Primarily improves the documentation but also makes some minor adjustments to implementation, without semantical difference.

Also adds a "missing" test case to ensure that it is possible to add numerous callbacks in a chain and still have the correct number of invocations. (this is an important test esp. if the representation of the callbacks for the standard implementation changes down the line)
