### PR TITLE
SI 9766 - allow ++ on empty ConcatIterator

### DIFF
--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -200,7 +200,8 @@ object Iterator {
       } else Iterator.empty.next()
 
     override def ++[B >: A](that: => GenTraversableOnce[B]): Iterator[B] =
-      new ConcatIterator(current, queue :+ (() => that.toIterator))
+      if(current eq null) new JoinIterator(Iterator.empty, that)
+      else new ConcatIterator(current, queue :+ (() => that.toIterator))
   }
 
   private[scala] final class JoinIterator[+A](lhs: Iterator[A], that: => GenTraversableOnce[A]) extends Iterator[A] {

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -192,4 +192,22 @@ class IteratorTest {
     assertSameElements(exp, res)
     assertEquals(8, counter) // was 14
   }
+
+  // SI-9766
+  @Test def exhaustedConcatIteratorConcat: Unit = {
+    def consume[A](i: Iterator[A]) = {
+      while(i.hasNext) i.next()
+    }
+    val joiniter = Iterator.empty ++ Seq(1, 2, 3)
+    assertTrue(joiniter.hasNext)
+    consume(joiniter)
+    val concatiter = joiniter ++ Seq(4, 5, 6)
+    assertTrue(concatiter.hasNext)
+    consume(concatiter)
+    assertFalse(concatiter.hasNext)
+    val concatFromEmpty = concatiter ++ Seq(7, 8, 9)
+    assertTrue(concatFromEmpty.hasNext)
+    consume(concatFromEmpty)
+    assertFalse(concatFromEmpty.hasNext)
+  }
 }


### PR DESCRIPTION
review by @Ichoran , @szeiger 

This is the simplest way to fix this, but I'm not sure it's the cleanest way. Letting `++` do more work by checking if `current eq null` and calling `advance()` if so may be nicer.
