### PR TITLE
SI-4625 Recognize App in script

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -380,11 +380,15 @@ self =>
           case DefDef(_, nme.main, Nil, List(_), _, _)  => true
           case _                                        => false
         }
+        def isApp(t: Tree) = t match {
+          case Template(ps, _, _) => ps.exists { case Ident(x) if x.decoded == "App" => true ; case _ => false }
+          case _ => false
+        }
         /* For now we require there only be one top level object. */
         var seenModule = false
         val newStmts = stmts collect {
           case t @ Import(_, _) => t
-          case md @ ModuleDef(mods, name, template) if !seenModule && (md exists isMainMethod) =>
+          case md @ ModuleDef(mods, name, template) if !seenModule && (isApp(template) || md.exists(isMainMethod)) =>
             seenModule = true
             /* This slightly hacky situation arises because we have no way to communicate
              * back to the scriptrunner what the name of the program is.  Even if we were

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -384,7 +384,7 @@ self =>
           case _                                        => false
         }
         def isApp(t: Tree) = t match {
-          case Template(ps, _, _) => ps.exists(cond(_) { case Ident(tpnme.App) => true })
+          case Template(parents, _, _) => parents.exists(cond(_) { case Ident(tpnme.App) => true })
           case _ => false
         }
         /* For now we require there only be one top level object. */
@@ -402,6 +402,8 @@ self =>
              */
             if (name == mainModuleName) md
             else treeCopy.ModuleDef(md, mods, mainModuleName, template)
+          case md @ ModuleDef(_, _, _)   => md
+          case cd @ ClassDef(_, _, _, _) => cd
           case _ =>
             /* If we see anything but the above, fail. */
             return None

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -365,12 +365,15 @@ self =>
       val stmts = parseStats()
 
       def mainModuleName = newTermName(settings.script.value)
+
       /* If there is only a single object template in the file and it has a
        * suitable main method, we will use it rather than building another object
        * around it.  Since objects are loaded lazily the whole script would have
        * been a no-op, so we're not taking much liberty.
        */
       def searchForMain(): Option[Tree] = {
+        import PartialFunction.cond
+
         /* Have to be fairly liberal about what constitutes a main method since
          * nothing has been typed yet - for instance we can't assume the parameter
          * type will look exactly like "Array[String]" as it could have been renamed
@@ -381,7 +384,7 @@ self =>
           case _                                        => false
         }
         def isApp(t: Tree) = t match {
-          case Template(ps, _, _) => ps.exists { case Ident(x) if x.decoded == "App" => true ; case _ => false }
+          case Template(ps, _, _) => ps.exists(cond(_) { case Ident(tpnme.App) => true })
           case _ => false
         }
         /* For now we require there only be one top level object. */

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -371,7 +371,7 @@ self =>
        * around it.  Since objects are loaded lazily the whole script would have
        * been a no-op, so we're not taking much liberty.
        */
-      def searchForMain(): Option[Tree] = {
+      def searchForMain(): Tree = {
         import PartialFunction.cond
 
         /* Have to be fairly liberal about what constitutes a main method since
@@ -387,10 +387,10 @@ self =>
           case Template(parents, _, _) => parents.exists(cond(_) { case Ident(tpnme.App) => true })
           case _ => false
         }
-        /* For now we require there only be one top level object. */
+        /* We allow only one main module. */
         var seenModule = false
         var disallowed = EmptyTree: Tree
-        val newStmts = stmts collect {
+        val newStmts = stmts.map {
           case md @ ModuleDef(mods, name, template) if !seenModule && (isApp(template) || md.exists(isMainMethod)) =>
             seenModule = true
             /* This slightly hacky situation arises because we have no way to communicate
@@ -407,54 +407,58 @@ self =>
           case t  @ Import(_, _)         => t
           case t =>
             /* If we see anything but the above, fail. */
-            disallowed = t
+            if (disallowed.isEmpty) disallowed = t
             EmptyTree
         }
-        if (disallowed.isEmpty) Some(makeEmptyPackage(0, newStmts))
+        if (disallowed.isEmpty) makeEmptyPackage(0, newStmts)
         else {
           if (seenModule)
             warning(disallowed.pos.point, "Script has a main object but statement is disallowed")
-          None
+          EmptyTree
         }
       }
 
-      if (mainModuleName == newTermName(ScriptRunner.defaultScriptMain))
-        searchForMain() foreach { return _ }
+      def mainModule: Tree =
+        if (mainModuleName == newTermName(ScriptRunner.defaultScriptMain)) searchForMain() else EmptyTree
 
-      /*  Here we are building an AST representing the following source fiction,
-       *  where `moduleName` is from -Xscript (defaults to "Main") and <stmts> are
-       *  the result of parsing the script file.
-       *
-       *  {{{
-       *  object moduleName {
-       *    def main(args: Array[String]): Unit =
-       *      new AnyRef {
-       *        stmts
-       *      }
-       *  }
-       *  }}}
-       */
-      def emptyInit   = DefDef(
-        NoMods,
-        nme.CONSTRUCTOR,
-        Nil,
-        ListOfNil,
-        TypeTree(),
-        Block(List(Apply(gen.mkSuperInitCall, Nil)), literalUnit)
-      )
+      def repackaged: Tree = {
+        /*  Here we are building an AST representing the following source fiction,
+         *  where `moduleName` is from -Xscript (defaults to "Main") and <stmts> are
+         *  the result of parsing the script file.
+         *
+         *  {{{
+         *  object moduleName {
+         *    def main(args: Array[String]): Unit =
+         *      new AnyRef {
+         *        stmts
+         *      }
+         *  }
+         *  }}}
+         */
+        def emptyInit   = DefDef(
+          NoMods,
+          nme.CONSTRUCTOR,
+          Nil,
+          ListOfNil,
+          TypeTree(),
+          Block(List(Apply(gen.mkSuperInitCall, Nil)), literalUnit)
+        )
 
-      // def main
-      def mainParamType = AppliedTypeTree(Ident(tpnme.Array), List(Ident(tpnme.String)))
-      def mainParameter = List(ValDef(Modifiers(Flags.PARAM), nme.args, mainParamType, EmptyTree))
-      def mainDef       = DefDef(NoMods, nme.main, Nil, List(mainParameter), scalaDot(tpnme.Unit), gen.mkAnonymousNew(stmts))
+        // def main
+        def mainParamType = AppliedTypeTree(Ident(tpnme.Array), List(Ident(tpnme.String)))
+        def mainParameter = List(ValDef(Modifiers(Flags.PARAM), nme.args, mainParamType, EmptyTree))
+        def mainDef       = DefDef(NoMods, nme.main, Nil, List(mainParameter), scalaDot(tpnme.Unit), gen.mkAnonymousNew(stmts))
 
-      // object Main
-      def moduleName  = newTermName(ScriptRunner scriptMain settings)
-      def moduleBody  = Template(atInPos(scalaAnyRefConstr) :: Nil, noSelfType, List(emptyInit, mainDef))
-      def moduleDef   = ModuleDef(NoMods, moduleName, moduleBody)
+        // object Main
+        def moduleName  = newTermName(ScriptRunner scriptMain settings)
+        def moduleBody  = Template(atInPos(scalaAnyRefConstr) :: Nil, noSelfType, List(emptyInit, mainDef))
+        def moduleDef   = ModuleDef(NoMods, moduleName, moduleBody)
 
-      // package <empty> { ... }
-      makeEmptyPackage(0, moduleDef :: Nil)
+        // package <empty> { ... }
+        makeEmptyPackage(0, moduleDef :: Nil)
+      }
+
+      mainModule orElse repackaged
     }
 
 /* --------------- PLACEHOLDERS ------------------------------------------- */

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -240,6 +240,7 @@ trait StdNames {
 
     final val Any: NameType             = "Any"
     final val AnyVal: NameType          = "AnyVal"
+    final val App: NameType             = "App"
     final val FlagSet: NameType         = "FlagSet"
     final val Mirror: NameType          = "Mirror"
     final val Modifiers: NameType       = "Modifiers"

--- a/test/files/run/t4625.check
+++ b/test/files/run/t4625.check
@@ -1,0 +1,1 @@
+Test ran.

--- a/test/files/run/t4625.scala
+++ b/test/files/run/t4625.scala
@@ -1,0 +1,7 @@
+
+import scala.tools.partest.ScriptTest
+
+object Test extends ScriptTest {
+  // must be called Main to get probing treatment in parser
+  override def testmain = "Main"
+}

--- a/test/files/run/t4625.script
+++ b/test/files/run/t4625.script
@@ -1,0 +1,5 @@
+
+object Main extends Runnable with App {
+  def run() = println("Test ran.")
+  run()
+}

--- a/test/files/run/t4625b.check
+++ b/test/files/run/t4625b.check
@@ -1,0 +1,1 @@
+Misc top-level detritus

--- a/test/files/run/t4625b.scala
+++ b/test/files/run/t4625b.scala
@@ -1,0 +1,7 @@
+
+import scala.tools.partest.ScriptTest
+
+object Test extends ScriptTest {
+  // must be called Main to get probing treatment in parser
+  override def testmain = "Main"
+}

--- a/test/files/run/t4625b.script
+++ b/test/files/run/t4625b.script
@@ -1,0 +1,8 @@
+
+trait X { def x = "Misc top-level detritus" }
+
+object Bumpkus
+
+object Main extends X with App {
+  println(x)
+}

--- a/test/files/run/t4625c.check
+++ b/test/files/run/t4625c.check
@@ -1,0 +1,3 @@
+newSource1.scala:2: warning: Script has a main object but statement is disallowed
+val x = "value x"
+    ^

--- a/test/files/run/t4625c.scala
+++ b/test/files/run/t4625c.scala
@@ -1,0 +1,7 @@
+
+import scala.tools.partest.ScriptTest
+
+object Test extends ScriptTest {
+  // must be called Main to get probing treatment in parser
+  override def testmain = "Main"
+}

--- a/test/files/run/t4625c.script
+++ b/test/files/run/t4625c.script
@@ -1,0 +1,6 @@
+
+val x = "value x"
+
+object Main extends App {
+  println(s"Test ran with $x.")
+}

--- a/test/files/run/t4625c.script
+++ b/test/files/run/t4625c.script
@@ -1,5 +1,6 @@
 
 val x = "value x"
+val y = "value y"
 
 object Main extends App {
   println(s"Test ran with $x.")


### PR DESCRIPTION
Cheap name test: if the script object extends "App",
take it for a main-bearing parent.

Note that if `-Xscript` is not `Main`, the default,
then the source is taken as a snippet and there is
no attempt to locate an existing `main` method.
