### PR TITLE
SI-9656 Distinguish Numeric with step type

### DIFF
--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -161,6 +161,12 @@ extends AbstractSeq[T] with IndexedSeq[T] with Serializable {
       override def isEmpty = underlyingRange.isEmpty
       override def apply(idx: Int): A = fm(underlyingRange(idx))
       override def containsTyped(el: A) = underlyingRange exists (x => fm(x) == el)
+
+      override def toString = {
+        def simpleOf(x: Any): String = x.getClass.getName.split("\\.").last
+        val stepped = simpleOf(underlyingRange.step)
+        s"${super.toString} (using $underlyingRange of $stepped)"
+      }
     }
   }
 
@@ -250,9 +256,11 @@ extends AbstractSeq[T] with IndexedSeq[T] with Serializable {
       super.equals(other)
   }
 
-  override def toString() = {
-    val endStr = if (length > Range.MAX_PRINT) ", ... )" else ")"
-    take(Range.MAX_PRINT).mkString("NumericRange(", ", ", endStr)
+  override def toString = {
+    val empty = if (isEmpty) "empty " else ""
+    val preposition = if (isInclusive) "to" else "until"
+    val stepped = if (step == 1) "" else s" by $step"
+    s"${empty}NumericRange $start $preposition $end$stepped"
   }
 }
 

--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -396,22 +396,20 @@ extends scala.collection.AbstractSeq[Int]
     case _ =>
       super.equals(other)
   }
-  /** Note: hashCode can't be overridden without breaking Seq's
-   *  equals contract.
-   */
 
-  override def toString() = {
-    val endStr =
-      if (numRangeElements > Range.MAX_PRINT || (!isEmpty && numRangeElements < 0)) ", ... )" else ")"
-    take(Range.MAX_PRINT).mkString("Range(", ", ", endStr)
+  /* Note: hashCode can't be overridden without breaking Seq's equals contract. */
+
+  override def toString = {
+    val preposition = if (isInclusive) "to" else "until"
+    val stepped = if (step == 1) "" else s" by $step"
+    val prefix = if (isEmpty) "empty " else if (!isExact) "inexact " else ""
+    s"${prefix}Range $start $preposition $end$stepped"
   }
 }
 
 /** A companion object for the `Range` class.
  */
 object Range {
-  private[immutable] val MAX_PRINT = 512  // some arbitrary value
-
   /** Counts the number of range elements.
    *  @pre  step != 0
    *  If the size of the range exceeds Int.MaxValue, the
@@ -514,6 +512,7 @@ object Range {
   // we offer a partially constructed object.
   class Partial[T, U](f: T => U) {
     def by(x: T): U = f(x)
+    override def toString = "Range requires step"
   }
 
   // Illustrating genericity with Int Range, which should have the same behavior

--- a/test/files/jvm/serialization-new.check
+++ b/test/files/jvm/serialization-new.check
@@ -97,12 +97,12 @@ x = Queue(a, b, c)
 y = Queue(a, b, c)
 x equals y: true, y equals x: true
 
-x = Range(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
-y = Range(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+x = Range 0 until 10
+y = Range 0 until 10
 x equals y: true, y equals x: true
 
-x = NumericRange(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
-y = NumericRange(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+x = NumericRange 0 until 10
+y = NumericRange 0 until 10
 x equals y: true, y equals x: true
 
 x = Map(1 -> A, 2 -> B, 3 -> C)

--- a/test/files/jvm/serialization.check
+++ b/test/files/jvm/serialization.check
@@ -97,12 +97,12 @@ x = Queue(a, b, c)
 y = Queue(a, b, c)
 x equals y: true, y equals x: true
 
-x = Range(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
-y = Range(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+x = Range 0 until 10
+y = Range 0 until 10
 x equals y: true, y equals x: true
 
-x = NumericRange(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
-y = NumericRange(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+x = NumericRange 0 until 10
+y = NumericRange 0 until 10
 x equals y: true, y equals x: true
 
 x = Map(1 -> A, 2 -> B, 3 -> C)

--- a/test/files/run/t9656.check
+++ b/test/files/run/t9656.check
@@ -1,0 +1,14 @@
+Range 1 to 10
+Range 1 to 10
+inexact Range 1 to 10 by 2
+Range 1 to 10 by 3
+inexact Range 1 until 10 by 2
+Range 100 to 100
+empty Range 100 until 100
+NumericRange 1 to 10
+NumericRange 1 to 10 by 2
+NumericRange 0.1 until 1.0 by 0.1
+NumericRange 0.1 until 1.0 by 0.1
+NumericRange 0.1 until 1.0 by 0.1 (using NumericRange 0.1 until 1.0 by 0.1 of BigDecimal)
+NumericRange 0 days until 10 seconds by 1 second
+empty NumericRange 0 days until 0 days by 1 second

--- a/test/files/run/t9656.scala
+++ b/test/files/run/t9656.scala
@@ -1,0 +1,43 @@
+
+import scala.math.BigDecimal
+
+object Test extends App {
+  println(1 to 10)
+  println(1 to 10 by 1)
+  println(1 to 10 by 2)
+  println(1 to 10 by 3)
+  println(1 until 10 by 2)
+  println(100 to 100)
+  println(100 until 100)
+
+  println(1L to 10L)
+  println(1L to 10L by 2)
+
+  // want to know if this is BigDecimal or Double stepping by BigDecimal
+  println(0.1 until 1.0 by 0.1)
+  println(Range.BigDecimal(BigDecimal("0.1"), BigDecimal("1.0"), BigDecimal("0.1")))
+  println(Range.Double(0.1, 1.0, 0.1))
+
+  import concurrent.duration.{SECONDS => Seconds, _}, collection.immutable.NumericRange
+  implicit val `duration is integerish`: math.Integral[FiniteDuration] = new math.Integral[FiniteDuration] {
+    def quot(x: scala.concurrent.duration.FiniteDuration,y: scala.concurrent.duration.FiniteDuration): scala.concurrent.duration.FiniteDuration = ???
+    def rem(x: scala.concurrent.duration.FiniteDuration,y: scala.concurrent.duration.FiniteDuration): scala.concurrent.duration.FiniteDuration = ???
+
+    // Members declared in scala.math.Numeric
+    def fromInt(x: Int): scala.concurrent.duration.FiniteDuration = Duration(x, Seconds)
+    def minus(x: scala.concurrent.duration.FiniteDuration,y: scala.concurrent.duration.FiniteDuration): scala.concurrent.duration.FiniteDuration = ???
+    def negate(x: scala.concurrent.duration.FiniteDuration): scala.concurrent.duration.FiniteDuration = ???
+    def plus(x: scala.concurrent.duration.FiniteDuration,y: scala.concurrent.duration.FiniteDuration): scala.concurrent.duration.FiniteDuration = ???
+    def times(x: scala.concurrent.duration.FiniteDuration,y: scala.concurrent.duration.FiniteDuration): scala.concurrent.duration.FiniteDuration = ???
+    def toDouble(x: scala.concurrent.duration.FiniteDuration): Double = ???
+    def toFloat(x: scala.concurrent.duration.FiniteDuration): Float = ???
+    def toInt(x: scala.concurrent.duration.FiniteDuration): Int = toLong(x).toInt
+    def toLong(x: scala.concurrent.duration.FiniteDuration): Long = x.length
+
+    // Members declared in scala.math.Ordering
+    def compare(x: scala.concurrent.duration.FiniteDuration,y: scala.concurrent.duration.FiniteDuration): Int =
+      x.compare(y)
+  }
+  println(NumericRange(Duration.Zero, Duration(10, Seconds), Duration(1, Seconds)))
+  println(NumericRange(Duration.Zero, Duration.Zero, Duration(1, Seconds)))
+}


### PR DESCRIPTION
Shorthand `toString` for `Range` and `NumericRange`.

```
scala> 1 to 10 by 2
res0: scala.collection.immutable.Range = inexact Range 1 to 10 by 2

scala> 1 until 1 by 2
res1: scala.collection.immutable.Range = empty Range 1 until 1 by 2

scala> .1 to 1.0 by .1
<console>:1: error: ';' expected but double literal found.
res1.1 to 1.0 by .1
    ^

scala> 0.1 to 1.0 by .1
res2: scala.collection.immutable.NumericRange[Double] = NumericRange 0.1 to 1.0 by 0.1

scala> Range.Double(.1, 1.0, .1)
res3: scala.collection.immutable.NumericRange[Double] = NumericRange 0.1 until 1.0 by 0.1 (using NumericRange 0.1 until 1.0 by 0.1 of BigDecimal)

scala> 0.0 to 1.0
res4: Range.Partial[Double,scala.collection.immutable.NumericRange[Double]] = Range requires step

scala> 0 to 1
res5: scala.collection.immutable.Range.Inclusive = Range 0 to 1
```

No parens because `Range(0 to 1)` looks like a factory but just gives a confusing error message.
