### PR TITLE
SI-9671, SI-7397 fix null.asInstanceOf[Int] when pt erases to Object

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -606,10 +606,8 @@ abstract class Erasure extends AddInterfaces
           // !!! Make pending/run/t5866b.scala work. The fix might be here and/or in unbox1.
           if (isPrimitiveValueType(targ.tpe) || isErasedValueType(targ.tpe)) {
             val noNullCheckNeeded = targ.tpe match {
-              case ErasedValueType(_, underlying) =>
-                isPrimitiveValueClass(underlying.typeSymbol)
-              case _ =>
-                true
+              case ErasedValueType(_, underlying) => isPrimitiveValueType(underlying)
+              case _ => true
             }
             if (noNullCheckNeeded) unbox(qual1, targ.tpe)
             else {

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -1141,6 +1141,10 @@ abstract class Erasure extends AddInterfaces
         else {
           val tree1 = preErase(tree)
           tree1 match {
+            case TypeApply(fun, targs @ List(targ)) if fun.symbol == Any_asInstanceOf && targ.tpe == UnitTpe =>
+              // SI-9066 prevent transforming `o.asInstanceOf[Unit]` to `o.asInstanceOf[BoxedUnit]`.
+              // adaptMember will then replace the call by a reference to BoxedUnit.UNIT.
+              treeCopy.TypeApply(tree1, transform(fun), targs).clearType()
             case EmptyTree | TypeTree() =>
               tree1 setType specialScalaErasure(tree1.tpe)
             case ArrayValue(elemtpt, trees) =>

--- a/test/junit/scala/BoxUnboxTest.scala
+++ b/test/junit/scala/BoxUnboxTest.scala
@@ -106,14 +106,14 @@ class BoxUnboxTest {
     Unit.unbox({eff(); null}); chk()
     assertThrows[ClassCastException](Unit.unbox({eff(); ""})); chk()
 
-    val n1 = null.asInstanceOf[Unit]              // SI-9066: should be UNIT, but currently null
-    assertThrows[AssertionError](assert(n1 == b)) // should not throw
+    val n1 = null.asInstanceOf[Unit]
+    assert(n1 == b)
 
-    val n2 = null.asInstanceOf[Unit] == b    // SI-9066: should be true, but currently false
-    assertThrows[AssertionError](assert(n2)) // should not throw
+    val n2 = null.asInstanceOf[Unit] == b
+    assert(n2)
 
     def f(a: Any) = "" + a
-    val n3 = f(null.asInstanceOf[Unit])                  // "null", should be "()". probably same cause as SI-602.
-    assertThrows[AssertionError](assertEquals(n3, "()")) // should not throw
+    val n3 = f(null.asInstanceOf[Unit])
+    assertEquals(n3, "()")
   }
 }

--- a/test/junit/scala/BoxUnboxTest.scala
+++ b/test/junit/scala/BoxUnboxTest.scala
@@ -48,22 +48,22 @@ class BoxUnboxTest {
     assertEquals(n4, 0)
     val n5 = null.asInstanceOf[Int] == 0
     assertTrue(n5)
-    val n6 = null.asInstanceOf[Int] == null       // SI-9671 -- should be false, but is true
-    assertThrows[AssertionError](assertFalse(n6)) // should not throw
+    val n6 = null.asInstanceOf[Int] == null
+    assertFalse(n6)
     val n7 = null.asInstanceOf[Int] != 0
     assertFalse(n7)
-    val n8 = null.asInstanceOf[Int] != null      // SI-9671 -- should be true, but is false
-    assertThrows[AssertionError](assertTrue(n8)) // should not throw
+    val n8 = null.asInstanceOf[Int] != null
+    assertTrue(n8)
 
     val mp = new java.util.HashMap[Int, Int]
     val n9 = mp.get(0)
     assertEquals(n9, 0)
-    val n10 = mp.get(0) == null                    // SI-602 -- maybe related to SI-9671 (test above)?
+    val n10 = mp.get(0) == null                    // SI-602
     assertThrows[AssertionError](assertFalse(n10)) // should not throw
 
     def f(a: Any) = "" + a
-    val n11 = f(null.asInstanceOf[Int])                  // "null", should be "0". probably same cause as SI-602.
-    assertThrows[AssertionError](assertEquals(n11, "0")) // should not throw
+    val n11 = f(null.asInstanceOf[Int])
+    assertEquals(n11, "0")
 
     def n12 = genericNull[Int]
     assertEquals(n12, 0)
@@ -81,8 +81,8 @@ class BoxUnboxTest {
 
   @Test
   def boxUnboxBoolean(): Unit = {
-    val n1 = Option(null.asInstanceOf[Boolean])                 // SI-7397 -- should be Some(false), but is None
-    assertThrows[AssertionError](assertEquals(n1, Some(false))) // should not throw
+    val n1 = Option(null.asInstanceOf[Boolean])
+    assertEquals(n1, Some(false))
   }
 
   @Test

--- a/test/junit/scala/issues/BytecodeTest.scala
+++ b/test/junit/scala/issues/BytecodeTest.scala
@@ -419,6 +419,16 @@ class BytecodeTest extends ClearAfterClass {
     assertInvoke(getSingleMethod(c, "f3"), "java/lang/Object", "hashCode")
     assertInvoke(getSingleMethod(c, "f4"), "java/lang/Object", "toString")
   }
+
+  @Test
+  def superConstructorArgumentInSpecializedClass(): Unit = {
+    // see comment in SpecializeTypes.forwardCtorCall
+    val code = "case class C[@specialized(Int) T](_1: T)"
+    val List(c, cMod, cSpec) = compileClasses(compiler)(code)
+    assertSameSummary(getSingleMethod(cSpec, "<init>"),
+      // pass `null` to super constructor, no box-unbox, no Integer created
+      List(ALOAD, ILOAD, PUTFIELD, ALOAD, ACONST_NULL, "<init>", RETURN))
+  }
 }
 
 object invocationReceiversTestCode {

--- a/test/junit/scala/issues/RunTest.scala
+++ b/test/junit/scala/issues/RunTest.scala
@@ -10,8 +10,8 @@ import scala.tools.reflect.ToolBox
 import scala.tools.testing.ClearAfterClass
 
 object RunTest {
-
   class VC(val x: Any) extends AnyVal
+  class VCI(val x: Int) extends AnyVal { override def toString = "" + x }
 }
 
 @RunWith(classOf[JUnit4])
@@ -153,5 +153,101 @@ class RunTest extends ClearAfterClass {
       """.stripMargin
     val u = Void.TYPE
     assertEquals(run[(Class[_], Class[_])](code), (u, u))
+  }
+
+  @Test
+  def t9671(): Unit = {
+    val code =
+      """import scala.issues.RunTest.VCI
+        |
+        |def f1(a: Any) = "" + a
+        |def f2(a: AnyVal) = "" + a
+        |def f3[T](a: T) = "" + a
+        |def f4(a: Int) = "" + a
+        |def f5(a: VCI) = "" + a
+        |def f6(u: Unit) = "" + u
+        |
+        |def n1: AnyRef = null
+        |def n2: Null = null
+        |def n3: Any = null
+        |def n4[T]: T = null.asInstanceOf[T]
+        |
+        |def npe(s: => String) = try { s; throw new Error() } catch { case _: NullPointerException => "npe" }
+        |
+        |    f1(null.asInstanceOf[Int])  +
+        |    f1(  n1.asInstanceOf[Int])  +
+        |    f1(  n2.asInstanceOf[Int])  +
+        |    f1(  n3.asInstanceOf[Int])  +
+        |    f1(               n4[Int])  + // "null"
+        |"-"                             +
+        |    f1(null.asInstanceOf[VCI])  +
+        |npe(f1(  n1.asInstanceOf[VCI])) + // SI-8097
+        |    f1(  n2.asInstanceOf[VCI])  +
+        |npe(f1(  n3.asInstanceOf[VCI])) + // SI-8097
+        |    f1(               n4[VCI])  + // "null"
+        |"-"                             +
+        |    f1(null.asInstanceOf[Unit]) + // "null", SI-9066
+        |    f1(  n1.asInstanceOf[Unit]) + // "null", SI-9066
+        |    f1(  n2.asInstanceOf[Unit]) + // "null", SI-9066
+        |    f1(  n3.asInstanceOf[Unit]) + // "null", SI-9066
+        |    f1(               n4[Unit]) + // "null"
+        |"-"                             +
+        |    f2(null.asInstanceOf[Int])  +
+        |    f2(  n1.asInstanceOf[Int])  +
+        |    f2(  n2.asInstanceOf[Int])  +
+        |    f2(  n3.asInstanceOf[Int])  +
+        |    f2(               n4[Int])  + // "null"
+        |"-"                             +
+        |    f2(null.asInstanceOf[VCI])  +
+        |npe(f2(  n1.asInstanceOf[VCI])) + // SI-8097
+        |    f2(  n2.asInstanceOf[VCI])  +
+        |npe(f2(  n3.asInstanceOf[VCI])) + // SI-8097
+        |    f2(               n4[VCI])  + // "null"
+        |"-"                             +
+        |    f2(null.asInstanceOf[Unit]) + // "null", SI-9066
+        |    f2(  n1.asInstanceOf[Unit]) + // "null", SI-9066
+        |    f2(  n2.asInstanceOf[Unit]) + // "null", SI-9066
+        |    f2(  n3.asInstanceOf[Unit]) + // "null", SI-9066
+        |    f2(               n4[Unit]) + // "null"
+        |"-"                             +
+        |    f3(null.asInstanceOf[Int])  +
+        |    f3(  n1.asInstanceOf[Int])  +
+        |    f3(  n2.asInstanceOf[Int])  +
+        |    f3(  n3.asInstanceOf[Int])  +
+        |    f3(               n4[Int])  + // "null"
+        |"-"                             +
+        |    f3(null.asInstanceOf[VCI])  +
+        |npe(f3(  n1.asInstanceOf[VCI])) + // SI-8097
+        |    f3(  n2.asInstanceOf[VCI])  +
+        |npe(f3(  n3.asInstanceOf[VCI])) + // SI-8097
+        |    f3(               n4[VCI])  + // "null"
+        |"-"                             +
+        |    f3(null.asInstanceOf[Unit]) + // "null", SI-9066
+        |    f3(  n1.asInstanceOf[Unit]) + // "null", SI-9066
+        |    f3(  n2.asInstanceOf[Unit]) + // "null", SI-9066
+        |    f3(  n3.asInstanceOf[Unit]) + // "null", SI-9066
+        |    f3(               n4[Unit]) + // "null"
+        |"-"                             +
+        |    f4(null.asInstanceOf[Int])  +
+        |    f4(  n1.asInstanceOf[Int])  +
+        |    f4(  n2.asInstanceOf[Int])  +
+        |    f4(  n3.asInstanceOf[Int])  +
+        |    f4(               n4[Int])  +
+        |"-"                             +
+        |    f5(null.asInstanceOf[VCI])  +
+        |npe(f5(  n1.asInstanceOf[VCI])) + // SI-8097
+        |    f5(  n2.asInstanceOf[VCI])  +
+        |npe(f5(  n3.asInstanceOf[VCI])) + // SI-8097
+        |npe(f5(               n4[VCI])) + // SI-8097
+        |"-"                             +
+        |    f6(null.asInstanceOf[Unit]) + // "null", SI-9066
+        |    f6(  n1.asInstanceOf[Unit]) + // "null", SI-9066
+        |    f6(  n2.asInstanceOf[Unit]) + // "null", SI-9066
+        |    f6(  n3.asInstanceOf[Unit]) + // "null", SI-9066
+        |    f6(               n4[Unit])   // "null"
+      """.stripMargin
+
+    assertEquals(run[String](code),
+      "0000null-0npe0npenull-nullnullnullnullnull-0000null-0npe0npenull-nullnullnullnullnull-0000null-0npe0npenull-nullnullnullnullnull-00000-0npe0npenpe-nullnullnullnullnull")
   }
 }

--- a/test/junit/scala/issues/RunTest.scala
+++ b/test/junit/scala/issues/RunTest.scala
@@ -186,10 +186,10 @@ class RunTest extends ClearAfterClass {
         |npe(f1(  n3.asInstanceOf[VCI])) + // SI-8097
         |    f1(               n4[VCI])  + // "null"
         |"-"                             +
-        |    f1(null.asInstanceOf[Unit]) + // "null", SI-9066
-        |    f1(  n1.asInstanceOf[Unit]) + // "null", SI-9066
-        |    f1(  n2.asInstanceOf[Unit]) + // "null", SI-9066
-        |    f1(  n3.asInstanceOf[Unit]) + // "null", SI-9066
+        |    f1(null.asInstanceOf[Unit]) +
+        |    f1(  n1.asInstanceOf[Unit]) +
+        |    f1(  n2.asInstanceOf[Unit]) +
+        |    f1(  n3.asInstanceOf[Unit]) +
         |    f1(               n4[Unit]) + // "null"
         |"-"                             +
         |    f2(null.asInstanceOf[Int])  +
@@ -204,10 +204,10 @@ class RunTest extends ClearAfterClass {
         |npe(f2(  n3.asInstanceOf[VCI])) + // SI-8097
         |    f2(               n4[VCI])  + // "null"
         |"-"                             +
-        |    f2(null.asInstanceOf[Unit]) + // "null", SI-9066
-        |    f2(  n1.asInstanceOf[Unit]) + // "null", SI-9066
-        |    f2(  n2.asInstanceOf[Unit]) + // "null", SI-9066
-        |    f2(  n3.asInstanceOf[Unit]) + // "null", SI-9066
+        |    f2(null.asInstanceOf[Unit]) +
+        |    f2(  n1.asInstanceOf[Unit]) +
+        |    f2(  n2.asInstanceOf[Unit]) +
+        |    f2(  n3.asInstanceOf[Unit]) +
         |    f2(               n4[Unit]) + // "null"
         |"-"                             +
         |    f3(null.asInstanceOf[Int])  +
@@ -222,10 +222,10 @@ class RunTest extends ClearAfterClass {
         |npe(f3(  n3.asInstanceOf[VCI])) + // SI-8097
         |    f3(               n4[VCI])  + // "null"
         |"-"                             +
-        |    f3(null.asInstanceOf[Unit]) + // "null", SI-9066
-        |    f3(  n1.asInstanceOf[Unit]) + // "null", SI-9066
-        |    f3(  n2.asInstanceOf[Unit]) + // "null", SI-9066
-        |    f3(  n3.asInstanceOf[Unit]) + // "null", SI-9066
+        |    f3(null.asInstanceOf[Unit]) +
+        |    f3(  n1.asInstanceOf[Unit]) +
+        |    f3(  n2.asInstanceOf[Unit]) +
+        |    f3(  n3.asInstanceOf[Unit]) +
         |    f3(               n4[Unit]) + // "null"
         |"-"                             +
         |    f4(null.asInstanceOf[Int])  +
@@ -240,14 +240,14 @@ class RunTest extends ClearAfterClass {
         |npe(f5(  n3.asInstanceOf[VCI])) + // SI-8097
         |npe(f5(               n4[VCI])) + // SI-8097
         |"-"                             +
-        |    f6(null.asInstanceOf[Unit]) + // "null", SI-9066
-        |    f6(  n1.asInstanceOf[Unit]) + // "null", SI-9066
-        |    f6(  n2.asInstanceOf[Unit]) + // "null", SI-9066
-        |    f6(  n3.asInstanceOf[Unit]) + // "null", SI-9066
+        |    f6(null.asInstanceOf[Unit]) +
+        |    f6(  n1.asInstanceOf[Unit]) +
+        |    f6(  n2.asInstanceOf[Unit]) +
+        |    f6(  n3.asInstanceOf[Unit]) +
         |    f6(               n4[Unit])   // "null"
       """.stripMargin
 
     assertEquals(run[String](code),
-      "0000null-0npe0npenull-nullnullnullnullnull-0000null-0npe0npenull-nullnullnullnullnull-0000null-0npe0npenull-nullnullnullnullnull-00000-0npe0npenpe-nullnullnullnullnull")
+      "0000null-0npe0npenull-()()()()null-0000null-0npe0npenull-()()()()null-0000null-0npe0npenull-()()()()null-00000-0npe0npenpe-()()()()null")
   }
 }


### PR DESCRIPTION
Erasure first replaces null.asInstanceOf[Int] by unbox(null). If the
expected type erases to object, erasure then introduces a box operation,
yielding box(unbox(null)). Note that this value is a box of zero, not
null.

Erasure has an optimization to replace box(unbox(x)) in case x is
of primitive type. 60f1b4b extended this to the case when x is null,
which is incorrect in general. The reason was to prevent creating a
primitive box to be stored in the unused generic field when creating
an instance of a specialized class. A special case ensures that this
optimization is still performed.
