### PR TITLE
Check left side of an assignment expression for errors; fixes SI-9781

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4494,7 +4494,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         val opeqStart = if (Statistics.canEnable) Statistics.startTimer(failedOpEqNanos) else null
 
         def onError(reportError: => Tree): Tree = fun match {
-          case Select(qual, name) if !mode.inPatternMode && nme.isOpAssignmentName(newTermName(name.decode)) =>
+          case Select(qual, name)
+            if !mode.inPatternMode && nme.isOpAssignmentName(newTermName(name.decode)) && !qual.exists(_.isErroneous) =>
+
             val qual1 = typedQualifier(qual)
             if (treeInfo.isVariableOrGetter(qual1)) {
               if (Statistics.canEnable) Statistics.stopTimer(failedOpEqNanos, opeqStart)

--- a/test/files/neg/t9781.check
+++ b/test/files/neg/t9781.check
@@ -1,0 +1,4 @@
+t9781.scala:3: error: not found: value undefinedSymbol
+  c(undefinedSymbol) += 1
+    ^
+one error found

--- a/test/files/neg/t9781.scala
+++ b/test/files/neg/t9781.scala
@@ -1,0 +1,4 @@
+object T9781 {
+  val c: collection.mutable.Map[Int, Int] = ???
+  c(undefinedSymbol) += 1
+}


### PR DESCRIPTION
`convertToAssignment` is triggered on a type error but it doesn't seem to really care what the error is as long as the expression can be converted to an assignment expression.

This patch attempts to fix that by checking whether the left side of the expression contains any errors before deciding to continue with the conversion.
