### PR TITLE
SI-9745 Ensure assignment transformation gets re-run in typedFunction

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2907,7 +2907,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               // We're looking for a method (as indicated by FUNmode in the silent typed below),
               // so let's make sure our expected type is a MethodType
               val methArgs = NoSymbol.newSyntheticValueParams(argpts map { case NoType => WildcardType case tp => tp })
-              silent(_.typed(meth, mode.forFunMode, MethodType(methArgs, respt))) filter (isMonoContext) map { methTyped =>
+              silent(_.typed(duplicateAndKeepPositions(meth), mode.forFunMode, MethodType(methArgs, respt))) filter (isMonoContext) map { methTyped =>
                 // if context.undetparams is not empty, the method was polymorphic,
                 // so we need the missing arguments to infer its type. See #871
                 val funPt = normalize(methTyped.tpe) baseType FunctionClass(numVparams)

--- a/test/files/pos/t9745.scala
+++ b/test/files/pos/t9745.scala
@@ -1,0 +1,5 @@
+object T9745 {
+  var i = 0
+  def f(i: Unit)(j: Int): Int = ???
+  val g = x => f(i += 1)(x)
+}


### PR DESCRIPTION
See comment on [SI-9745](https://issues.scala-lang.org/browse/SI-9745).

We try to solve the problem by duplicating the function tree so that the erroneous remains of the assignment transformation do not prevent a second from happening.

This seems like it could be expensive if there are a lot of large function expressions?
