### PR TITLE
Use full braces style in AnsiColor example

### DIFF
--- a/src/library/scala/io/AnsiColor.scala
+++ b/src/library/scala/io/AnsiColor.scala
@@ -13,7 +13,7 @@ package io
   *
   * object ColorDemo extends App {
   *
-  *   println(s"$REVERSED${BOLD}Hello 1979!$RESET")
+  *   println(s"${REVERSED}${BOLD}Hello 1979!${RESET}")
   * }
   * }}}
   *


### PR DESCRIPTION
This matches the use of ${..} in Console.
