### PR TITLE
Fully qualify types in REPL generated code

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -614,7 +614,7 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
     bindRep.compile(s"""
         |object ${bindRep.evalName} {
         |  var value: $boundType = _
-        |  def set(x: Any) = value = x.asInstanceOf[$boundType]
+        |  def set(x: _root_.scala.Any) = value = x.asInstanceOf[$boundType]
         |}
       """.stripMargin
     )
@@ -882,7 +882,7 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
     }
 
     class ClassBasedWrapper extends Wrapper {
-      def preambleHeader = "class %s extends Serializable { "
+      def preambleHeader = "class %s extends _root_.java.io.Serializable { "
 
       /** Adds an object that instantiates the outer wrapping class. */
       def postamble  = s"""
@@ -915,7 +915,7 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
       val preamble = """
       |object %s {
       |  %s
-      |  lazy val %s: String = %s {
+      |  lazy val %s: _root_.java.lang.String = %s {
       |    %s
       |    (""
       """.stripMargin.format(

--- a/src/repl/scala/tools/nsc/interpreter/ReplStrings.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplStrings.scala
@@ -34,7 +34,7 @@ trait ReplStrings {
     "\"" + string2code(str) + "\""
 
   def any2stringOf(x: Any, maxlen: Int) =
-    "scala.runtime.ScalaRunTime.replStringOf(%s, %s)".format(x, maxlen)
+    "_root_.scala.runtime.ScalaRunTime.replStringOf(%s, %s)".format(x, maxlen)
 
   // no escaped or nested quotes
   private[this] val inquotes = """(['"])(.*?)\1""".r

--- a/test/files/run/repl-no-imports-no-predef-classbased.check
+++ b/test/files/run/repl-no-imports-no-predef-classbased.check
@@ -1,0 +1,23 @@
+
+scala> case class K(s: java.lang.String)
+defined class K
+
+scala> class C { implicit val k: K = K("OK?"); override def toString = "C(" + k.toString + ")" }
+defined class C
+
+scala> val c = new C
+c: C = C(K(OK?))
+
+scala> import c.k
+import c.k
+
+scala> scala.Predef.implicitly[K]
+res0: K = K(OK?)
+
+scala> val k = 42
+k: Int = 42
+
+scala> k                 // was K(OK?)
+res1: Int = 42
+
+scala> :quit

--- a/test/files/run/repl-no-imports-no-predef-classbased.scala
+++ b/test/files/run/repl-no-imports-no-predef-classbased.scala
@@ -1,0 +1,19 @@
+object Test extends scala.tools.partest.ReplTest {
+
+  override def transformSettings(settings: scala.tools.nsc.Settings) = {
+    settings.noimports.value = true
+    settings.nopredef.value = true
+    settings.Yreplclassbased.value = true
+    settings
+  }
+
+  def code = """
+case class K(s: java.lang.String)
+class C { implicit val k: K = K("OK?"); override def toString = "C(" + k.toString + ")" }
+val c = new C
+import c.k
+scala.Predef.implicitly[K]
+val k = 42
+k                 // was K(OK?)
+"""
+}

--- a/test/files/run/repl-no-imports-no-predef-power.check
+++ b/test/files/run/repl-no-imports-no-predef-power.check
@@ -1,0 +1,29 @@
+
+scala> :power
+Power mode enabled. :phase is at typer.
+import scala.tools.nsc._, intp.global._, definitions._
+Try :help or completions for vals._ and power._
+
+scala> // guarding against "error: reference to global is ambiguous"
+
+scala> global.emptyValDef  // "it is imported twice in the same scope by ..."
+warning: there was one deprecation warning; re-run with -deprecation for details
+res0: $r.global.noSelfType.type = private val _ = _
+
+scala> val tp = ArrayClass[scala.util.Random]    // magic with tags
+warning: there was one feature warning; re-run with -feature for details
+tp: $r.global.Type = Array[scala.util.Random]
+
+scala> tp.memberType(Array_apply)                // evidence
+res1: $r.global.Type = (i: Int)scala.util.Random
+
+scala> val m = LIT(10)                           // treedsl
+m: $r.treedsl.global.Literal = 10
+
+scala> typed(m).tpe                              // typed is in scope
+res2: $r.treedsl.global.Type = Int(10)
+
+scala> """escaping is hard, m'kah"""
+res3: String = escaping is hard, m'kah
+
+scala> :quit

--- a/test/files/run/repl-no-imports-no-predef-power.scala
+++ b/test/files/run/repl-no-imports-no-predef-power.scala
@@ -1,0 +1,21 @@
+object Test extends scala.tools.partest.ReplTest {
+
+  override def transformSettings(settings: scala.tools.nsc.Settings) = {
+    settings.noimports.value = true
+    settings.nopredef.value = true
+    settings
+  }
+
+  def tripleQuote(s: String) = "\"\"\"" + s + "\"\"\""
+
+  def code = s"""
+:power
+// guarding against "error: reference to global is ambiguous"
+global.emptyValDef  // "it is imported twice in the same scope by ..."
+val tp = ArrayClass[scala.util.Random]    // magic with tags
+tp.memberType(Array_apply)                // evidence
+val m = LIT(10)                           // treedsl
+typed(m).tpe                              // typed is in scope
+${tripleQuote("escaping is hard, m'kah")}
+  """.trim
+}

--- a/test/files/run/repl-no-imports-no-predef.check
+++ b/test/files/run/repl-no-imports-no-predef.check
@@ -1,0 +1,360 @@
+
+scala> 1
+res0: Int = 1
+
+scala> 1.0
+res1: Double = 1.0
+
+scala> ()
+
+scala> "abc"
+res3: String = abc
+
+scala> (1, 2)
+res4: (Int, Int) = (1,2)
+
+scala> 
+
+scala> { import scala.Predef.ArrowAssoc; 1 -> 2 }
+res5: (Int, Int) = (1,2)
+
+scala> { import scala.Predef.ArrowAssoc; 1 → 2 }
+res6: (Int, Int) = (1,2)
+
+scala> 1 -> 2
+<console>:12: error: value -> is not a member of Int
+       1 -> 2
+         ^
+
+scala> 1 → 2
+<console>:12: error: value → is not a member of Int
+       1 → 2
+         ^
+
+scala> 
+
+scala> val answer = 42
+answer: Int = 42
+
+scala> { import scala.StringContext; s"answer: $answer" }
+res9: String = answer: 42
+
+scala> s"answer: $answer"
+<console>:13: error: not found: value StringContext
+       s"answer: $answer"
+       ^
+
+scala> 
+
+scala> "abc" + true
+res11: String = abctrue
+
+scala> 
+
+scala> { import scala.Predef.any2stringadd; true + "abc" }
+res12: String = trueabc
+
+scala> true + "abc"
+<console>:12: error: value + is not a member of Boolean
+       true + "abc"
+            ^
+
+scala> 
+
+scala> var x = 10
+x: Int = 10
+
+scala> var y = 11
+y: Int = 11
+
+scala> x = 12
+x: Int = 12
+
+scala> y = 13
+y: Int = 13
+
+scala> 
+
+scala> 2 ; 3
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+       2 ;;
+       ^
+res14: Int = 3
+
+scala> { 2 ; 3 }
+<console>:12: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+       { 2 ; 3 }
+         ^
+res15: Int = 3
+
+scala> 5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
+bippy = {
+  1 +
+  2 +
+  3 } ; bippy+88+11
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+       5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
+       ^
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+       5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
+           ^
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+       5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
+                                  ^
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+       5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
+                                                                                         ^
+defined object Cow
+defined class Moo
+bippy: Int
+res16: Int = 105
+
+scala> 
+
+scala> object Bovine { var x: scala.List[_] = null } ; case class Ruminant(x: scala.Int) ; bippy * bippy * bippy
+defined object Bovine
+defined class Ruminant
+res17: Int = 216
+
+scala> Bovine.x = scala.List(Ruminant(5), Cow, new Moo)
+Bovine.x: List[Any] = List(Ruminant(5), Cow, Moooooo)
+
+scala> Bovine.x
+res18: List[Any] = List(Ruminant(5), Cow, Moooooo)
+
+scala> 
+
+scala> (2)
+res19: Int = 2
+
+scala> (2 + 2)
+res20: Int = 4
+
+scala> ((2 + 2))
+res21: Int = 4
+
+scala>   ((2 + 2))
+res22: Int = 4
+
+scala>   (  (2 + 2))
+res23: Int = 4
+
+scala>   (  (2 + 2 )  )
+res24: Int = 4
+
+scala> 5 ;   (  (2 + 2 )  ) ; ((5))
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+       5 ;   (  (2 + 2 )  ) ;;
+       ^
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+       5 ;   (  (2 + 2 )  ) ;;
+                   ^
+res25: Int = 5
+
+scala> (((2 + 2)), ((2 + 2)))
+res26: (Int, Int) = (4,4)
+
+scala> (((2 + 2)), ((2 + 2)), 2)
+res27: (Int, Int, Int) = (4,4,2)
+
+scala> (((((2 + 2)), ((2 + 2)), 2).productIterator ++ scala.Iterator(3)).mkString)
+res28: String = 4423
+
+scala> 
+
+scala> 55 ; ((2 + 2)) ; (1, 2, 3)
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+       55 ; ((2 + 2)) ;;
+       ^
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+       55 ; ((2 + 2)) ;;
+                ^
+res29: (Int, Int, Int) = (1,2,3)
+
+scala> 55 ; (x: scala.Int) => x + 1 ; () => ((5))
+<console>:12: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+       55 ; (x: scala.Int) => x + 1 ;;
+       ^
+res30: () => Int = <function0>
+
+scala> 
+
+scala> () => 5
+res31: () => Int = <function0>
+
+scala> 55 ; () => 5
+<console>:11: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
+       55 ;;
+       ^
+res32: () => Int = <function0>
+
+scala> () => { class X ; new X }
+res33: () => AnyRef = <function0>
+
+scala> 
+
+scala> def foo(x: scala.Int)(y: scala.Int)(z: scala.Int) = x+y+z
+foo: (x: Int)(y: Int)(z: Int)Int
+
+scala> foo(5)(10)(15)+foo(5)(10)(15)
+res34: Int = 60
+
+scala> 
+
+scala> scala.List(1) ++ scala.List('a')
+res35: List[AnyVal] = List(1, a)
+
+scala> 
+
+scala> :paste < EOF
+// Entering paste mode (EOF to finish)
+
+class C { def c = 42 }
+EOF
+
+// Exiting paste mode, now interpreting.
+
+defined class C
+
+scala> new C().c
+res36: Int = 42
+
+scala> :paste <| EOF
+// Entering paste mode (EOF to finish)
+
+class D { def d = 42 }
+EOF
+
+// Exiting paste mode, now interpreting.
+
+defined class D
+
+scala> new D().d
+res37: Int = 42
+
+scala> 
+
+scala> :paste < EOF
+// Entering paste mode (EOF to finish)
+
+class Dingus
+{
+  private val x = 5
+  def y = Dingus.x * 2
+}
+object Dingus
+{
+  private val x = 55
+}
+EOF
+
+// Exiting paste mode, now interpreting.
+
+defined class Dingus
+defined object Dingus
+
+scala> val x = (new Dingus).y
+x: Int = 110
+
+scala> 
+
+scala> val x1 = 1
+x1: Int = 1
+
+scala> val x2 = 2
+x2: Int = 2
+
+scala> val x3 = 3
+x3: Int = 3
+
+scala> case class BippyBungus()
+defined class BippyBungus
+
+scala> x1 + x2 + x3
+res38: Int = 6
+
+scala> :reset
+Resetting interpreter state.
+Forgetting this session history:
+
+1
+1.0
+()
+"abc"
+(1, 2)
+{ import scala.Predef.ArrowAssoc; 1 -> 2 }
+{ import scala.Predef.ArrowAssoc; 1 → 2 }
+val answer = 42
+{ import scala.StringContext; s"answer: $answer" }
+"abc" + true
+{ import scala.Predef.any2stringadd; true + "abc" }
+var x = 10
+var y = 11
+x = 12
+y = 13
+2 ; 3
+{ 2 ; 3 }
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
+bippy = {
+  1 +
+  2 +
+  3 } ; bippy+88+11
+object Bovine { var x: scala.List[_] = null } ; case class Ruminant(x: scala.Int) ; bippy * bippy * bippy
+Bovine.x = scala.List(Ruminant(5), Cow, new Moo)
+Bovine.x
+(2)
+(2 + 2)
+((2 + 2))
+  ((2 + 2))
+  (  (2 + 2))
+  (  (2 + 2 )  )
+5 ;   (  (2 + 2 )  ) ; ((5))
+(((2 + 2)), ((2 + 2)))
+(((2 + 2)), ((2 + 2)), 2)
+(((((2 + 2)), ((2 + 2)), 2).productIterator ++ scala.Iterator(3)).mkString)
+55 ; ((2 + 2)) ; (1, 2, 3)
+55 ; (x: scala.Int) => x + 1 ; () => ((5))
+() => 5
+55 ; () => 5
+() => { class X ; new X }
+def foo(x: scala.Int)(y: scala.Int)(z: scala.Int) = x+y+z
+foo(5)(10)(15)+foo(5)(10)(15)
+scala.List(1) ++ scala.List('a')
+new C().c
+new D().d
+val x = (new Dingus).y
+val x1 = 1
+val x2 = 2
+val x3 = 3
+case class BippyBungus()
+x1 + x2 + x3
+
+Forgetting all expression results and named terms: $intp, BippyBungus, Bovine, Cow, Dingus, Ruminant, answer, bippy, foo, x, x1, x2, x3, y
+Forgetting defined types: BippyBungus, C, D, Dingus, Moo, Ruminant
+
+scala> x1 + x2 + x3
+<console>:12: error: not found: value x1
+       x1 + x2 + x3
+       ^
+<console>:12: error: not found: value x2
+       x1 + x2 + x3
+            ^
+<console>:12: error: not found: value x3
+       x1 + x2 + x3
+                 ^
+
+scala> val x1 = 4
+x1: Int = 4
+
+scala> new BippyBungus
+<console>:12: error: not found: type BippyBungus
+       new BippyBungus
+           ^
+
+scala> class BippyBungus() { def f = 5 }
+defined class BippyBungus
+
+scala> { new BippyBungus ; x1 }
+res2: Int = 4
+
+scala> :quit

--- a/test/files/run/repl-no-imports-no-predef.scala
+++ b/test/files/run/repl-no-imports-no-predef.scala
@@ -1,0 +1,108 @@
+object Test extends scala.tools.partest.ReplTest {
+
+  override def transformSettings(settings: scala.tools.nsc.Settings) = {
+    settings.noimports.value = true
+    settings.nopredef.value = true
+    settings
+  }
+
+  // replace indylambda function names by <function0>
+  override def normalize(s: String) = """\$\$Lambda.*""".r.replaceAllIn(s, "<function0>")
+
+  def code = """
+1
+1.0
+()
+"abc"
+(1, 2)
+
+{ import scala.Predef.ArrowAssoc; 1 -> 2 }
+{ import scala.Predef.ArrowAssoc; 1 → 2 }
+1 -> 2
+1 → 2
+
+val answer = 42
+{ import scala.StringContext; s"answer: $answer" }
+s"answer: $answer"
+
+"abc" + true
+
+{ import scala.Predef.any2stringadd; true + "abc" }
+true + "abc"
+
+var x = 10
+var y = 11
+x = 12
+y = 13
+
+2 ; 3
+{ 2 ; 3 }
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
+bippy = {
+  1 +
+  2 +
+  3 } ; bippy+88+11
+
+object Bovine { var x: scala.List[_] = null } ; case class Ruminant(x: scala.Int) ; bippy * bippy * bippy
+Bovine.x = scala.List(Ruminant(5), Cow, new Moo)
+Bovine.x
+
+(2)
+(2 + 2)
+((2 + 2))
+  ((2 + 2))
+  (  (2 + 2))
+  (  (2 + 2 )  )
+5 ;   (  (2 + 2 )  ) ; ((5))
+(((2 + 2)), ((2 + 2)))
+(((2 + 2)), ((2 + 2)), 2)
+(((((2 + 2)), ((2 + 2)), 2).productIterator ++ scala.Iterator(3)).mkString)
+
+55 ; ((2 + 2)) ; (1, 2, 3)
+55 ; (x: scala.Int) => x + 1 ; () => ((5))
+
+() => 5
+55 ; () => 5
+() => { class X ; new X }
+
+def foo(x: scala.Int)(y: scala.Int)(z: scala.Int) = x+y+z
+foo(5)(10)(15)+foo(5)(10)(15)
+
+scala.List(1) ++ scala.List('a')
+
+:paste < EOF
+class C { def c = 42 }
+EOF
+new C().c
+:paste <| EOF
+class D { def d = 42 }
+EOF
+new D().d
+
+:paste < EOF
+class Dingus
+{
+  private val x = 5
+  def y = Dingus.x * 2
+}
+object Dingus
+{
+  private val x = 55
+}
+EOF
+val x = (new Dingus).y
+
+val x1 = 1
+val x2 = 2
+val x3 = 3
+case class BippyBungus()
+x1 + x2 + x3
+:reset
+x1 + x2 + x3
+val x1 = 4
+new BippyBungus
+class BippyBungus() { def f = 5 }
+{ new BippyBungus ; x1 }
+
+"""
+}

--- a/test/files/run/repl-parens.scala
+++ b/test/files/run/repl-parens.scala
@@ -1,6 +1,9 @@
 import scala.tools.partest.ReplTest
 
 object Test extends ReplTest {
+  // replace indylambda function names by <function0>
+  override def normalize(s: String) = """\$\$Lambda.*""".r.replaceAllIn(s, "<function0>")
+
   def code = """
 (2)
 (2 + 2)
@@ -26,11 +29,4 @@ foo(5)(10)(15)+foo(5)(10)(15)
 List(1) ++ List('a')
 
   """.trim
-
-  // replace indylambda function names by <function0>
-  override def eval() = {
-    val lines = super.eval
-    val r = """\$\$Lambda.*""".r
-    lines.map(l => r.replaceAllIn(l, "<function0>"))
-  }
 }

--- a/test/files/run/t7747-repl.check
+++ b/test/files/run/t7747-repl.check
@@ -246,12 +246,12 @@ scala> case class Bingo()
 defined class Bingo
 
 scala> List(BippyBups(), PuppyPups(), Bingo()) // show
-class $read extends Serializable {
+class $read extends _root_.java.io.Serializable {
   def <init>() = {
     super.<init>;
     ()
   };
-  class $iw extends Serializable {
+  class $iw extends _root_.java.io.Serializable {
     def <init>() = {
       super.<init>;
       ()
@@ -262,7 +262,7 @@ class $read extends Serializable {
     import $line45.$read.INSTANCE.$iw.$iw.PuppyPups;
     import $line46.$read.INSTANCE.$iw.$iw.Bingo;
     import $line46.$read.INSTANCE.$iw.$iw.Bingo;
-    class $iw extends Serializable {
+    class $iw extends _root_.java.io.Serializable {
       def <init>() = {
         super.<init>;
         ()

--- a/test/files/run/t7747-repl.scala
+++ b/test/files/run/t7747-repl.scala
@@ -9,11 +9,7 @@ object Test extends ReplTest {
   }
 
   // replace indylambda function names by <function0>
-  override def eval() = {
-    val lines = super.eval
-    val r = """\$Lambda.*""".r
-    lines.map(l => r.replaceAllIn(l, "<function0>"))
-  }
+  override def normalize(s: String) = """\$Lambda.*""".r.replaceAllIn(s, "<function0>")
 
   def code = """
     |var x = 10

--- a/test/junit/scala/tools/nsc/interpreter/ScriptedTest.scala
+++ b/test/junit/scala/tools/nsc/interpreter/ScriptedTest.scala
@@ -13,6 +13,14 @@ class ScriptedTest {
     // same as by service discovery
     //new ScriptEngineManager().getEngineByName("scala").asInstanceOf[ScriptEngine with Compilable]
 
+  // scripted, but also -Yno-predef -Yno-imports
+  def scriptedNoNothing: ScriptEngine with Compilable = {
+    val settings = new Settings()
+    settings.noimports.value = true
+    settings.nopredef.value = true
+    Scripted(settings = settings)
+  }
+
   @Test def eval() = {
     val engine = scripted
     engine.put("foo","bar")
@@ -21,6 +29,17 @@ class ScriptedTest {
     bindings.put("foo","baz")
     assert("baz" == engine.eval("foo", bindings))
     val c = engine.compile("def f = foo.asInstanceOf[String] ; f * 2")
+    assert("barbar" == c.eval())
+    assert("bazbaz" == c.eval(bindings))
+  }
+  @Test def evalNoNothing() = {
+    val engine = scriptedNoNothing
+    engine.put("foo","bar")
+    assert("bar" == engine.eval("foo"))
+    val bindings = engine.createBindings()
+    bindings.put("foo","baz")
+    assert("baz" == engine.eval("foo", bindings))
+    val c = engine.compile("import scala.Predef.augmentString ; def f = foo.asInstanceOf[java.lang.String] ; f * 2")
     assert("barbar" == c.eval())
     assert("bazbaz" == c.eval(bindings))
   }


### PR DESCRIPTION
This is so the Scala REPL can work with `-Yno-imports` and `-Yno-predef`.

The partest run case is a bit of a shotgun approach to seeing if I can get it to fall over in any other way, stealing code from existing repl test cases.  If there's a better approach, please let me know.

I'm happy to iterate.

Review by @retronym.
