### PR TITLE
SI-9794 Error advice uses decoded method name

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -632,7 +632,7 @@ trait ContextErrors {
 
       //adapt
       def MissingArgsForMethodTpeError(tree: Tree, meth: Symbol) = {
-        val f = meth.name
+        val f = meth.name.decoded
         val paf = s"$f(${ meth.asMethod.paramLists map (_ map (_ => "_") mkString ",") mkString ")(" })"
         val advice = s"""
           |Unapplied methods are only converted to functions when a function type is expected.

--- a/test/files/neg/missing-arg-list.check
+++ b/test/files/neg/missing-arg-list.check
@@ -18,4 +18,9 @@ Unapplied methods are only converted to functions when a function type is expect
 You can make this conversion explicit by writing `h _` or `h(_,_,_)(_)` instead of `h`.
   val z = h
           ^
-four errors found
+missing-arg-list.scala:15: error: missing argument list for method + in trait T
+Unapplied methods are only converted to functions when a function type is expected.
+You can make this conversion explicit by writing `+ _` or `+(_)` instead of `+`.
+  val p = +
+          ^
+5 errors found

--- a/test/files/neg/missing-arg-list.scala
+++ b/test/files/neg/missing-arg-list.scala
@@ -10,4 +10,7 @@ trait T {
   val x = f
   val y = g
   val z = h
+
+  def +(i: Int) = i + 42
+  val p = +
 }


### PR DESCRIPTION
So much work went into polishing this error message,
it's worth buffing the method name when it's an operator.
The message now says `+` instead of `$plus`.
