### PR TITLE
Privatize the deprecated members of `immutable.Range`.

### DIFF
--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -81,8 +81,7 @@ extends scala.collection.AbstractSeq[Int]
     || (start == end && !isInclusive)
   )
 
-  @deprecated("this method will be made private, use `length` instead", "2.11.0")
-  final val numRangeElements: Int = {
+  private val numRangeElements: Int = {
     if (step == 0) throw new IllegalArgumentException("step cannot be 0.")
     else if (isEmpty) 0
     else {
@@ -92,8 +91,7 @@ extends scala.collection.AbstractSeq[Int]
     }
   }
 
-  @deprecated("this method will be made private, use `last` instead", "2.11.0")
-  final val lastElement =
+  private val lastElement =
     if (isEmpty) start - step
     else step match {
       case 1  => if (isInclusive) end else end-1
@@ -104,9 +102,6 @@ extends scala.collection.AbstractSeq[Int]
         else if (isInclusive) end
         else end - step
     }
-
-  @deprecated("this method will be made private", "2.11.0")
-  final val terminalElement = lastElement + step
 
   /** The last element of this range.  This method will return the correct value
    *  even if there are too many elements to iterate over.

--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -91,17 +91,16 @@ extends scala.collection.AbstractSeq[Int]
     }
   }
 
-  private val lastElement =
-    if (isEmpty) start - step
-    else step match {
-      case 1  => if (isInclusive) end else end-1
-      case -1 => if (isInclusive) end else end+1
-      case _  =>
-        val remainder = (gap % step).toInt
-        if (remainder != 0) end - remainder
-        else if (isInclusive) end
-        else end - step
-    }
+  // This field has a sensible value only for non-empty ranges
+  private val lastElement = step match {
+    case 1  => if (isInclusive) end else end-1
+    case -1 => if (isInclusive) end else end+1
+    case _  =>
+      val remainder = (gap % step).toInt
+      if (remainder != 0) end - remainder
+      else if (isInclusive) end
+      else end - step
+  }
 
   /** The last element of this range.  This method will return the correct value
    *  even if there are too many elements to iterate over.


### PR DESCRIPTION
The implementation of these obscure members of `Range` are uselessly complicated for the purposes of `Range` itself. Making them private will allow to relax their semantics to the specific needs of `Range`, making them simpler, together with the initialization code of `Range`.

`terminalElement` becomes dead code and is removed.

Subsequently, we relax the initialization of `lastElement` not to care about the empty case, since it is only used in code paths where the range is non-empty.

About compatibility with 2.11: this is not the first breaking change of deprecated parts of `Range` in 2.12. `Range` was sealed in https://github.com/scala/scala/commit/cb1a4524d2b34605232afa083dd43f0b7d39b7a7, according to a deprecated inheritance that was added in 2.11. The present PR is arguably a less damaging break than that.
