### PR TITLE
Don't pass -opt to starr / locker build in the bootstrap script

### DIFF
--- a/scripts/jobs/integrate/bootstrap
+++ b/scripts/jobs/integrate/bootstrap
@@ -494,7 +494,6 @@ bootstrap() {
             -Dremote.snapshot.repository=NOPE\
             -Dremote.release.repository=$releaseTempRepoUrl\
             -Drepository.credentials.id=$releaseTempRepoCred\
-            -Dscalac.args.optimise=-opt:l:classpath\
             -Ddocs.skip=1\
             -Dlocker.skip=1\
             $publishStarrPrivateTask >> $baseDir/logs/builds 2>&1
@@ -516,7 +515,6 @@ bootstrap() {
       $SET_STARR\
       -Dremote.release.repository=$releaseTempRepoUrl\
       -Drepository.credentials.id=$releaseTempRepoCred\
-      -Dscalac.args.optimise=-opt:l:classpath\
       -Ddocs.skip=1\
       -Dlocker.skip=1\
       $publishLockerPrivateTask >> $baseDir/logs/builds 2>&1


### PR DESCRIPTION
Renaming -Yopt to -opt revealed that we're passing the flag when
building the locker (and optionally the starr) version. This is not
necessary: when building the next stage with the flag enabled, the same
optimizations are performed no matter if the current stage was built
with the flag or not.
