### PR TITLE
Topic/copyrighter

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -379,11 +379,15 @@ self =>
           case DefDef(_, nme.main, Nil, List(_), _, _)  => true
           case _                                        => false
         }
+        def isApp(t: Tree) = t match {
+          case Template(ps, _, _) => ps.exists { case Ident(x) if x.decoded == "App" => true ; case _ => false }
+          case _ => false
+        }
         /* For now we require there only be one top level object. */
         var seenModule = false
         val newStmts = stmts collect {
           case t @ Import(_, _) => t
-          case md @ ModuleDef(mods, name, template) if !seenModule && (md exists isMainMethod) =>
+          case md @ ModuleDef(mods, name, template) if !seenModule && (isApp(template) || md.exists(isMainMethod)) =>
             seenModule = true
             /* This slightly hacky situation arises because we have no way to communicate
              * back to the scriptrunner what the name of the program is.  Even if we were

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -364,12 +364,15 @@ self =>
       val stmts = parseStats()
 
       def mainModuleName = newTermName(settings.script.value)
+
       /* If there is only a single object template in the file and it has a
        * suitable main method, we will use it rather than building another object
        * around it.  Since objects are loaded lazily the whole script would have
        * been a no-op, so we're not taking much liberty.
        */
       def searchForMain(): Option[Tree] = {
+        import PartialFunction.cond
+
         /* Have to be fairly liberal about what constitutes a main method since
          * nothing has been typed yet - for instance we can't assume the parameter
          * type will look exactly like "Array[String]" as it could have been renamed
@@ -380,7 +383,7 @@ self =>
           case _                                        => false
         }
         def isApp(t: Tree) = t match {
-          case Template(ps, _, _) => ps.exists { case Ident(x) if x.decoded == "App" => true ; case _ => false }
+          case Template(ps, _, _) => ps.exists(cond(_) { case Ident(tpnme.App) => true })
           case _ => false
         }
         /* For now we require there only be one top level object. */

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -383,7 +383,7 @@ self =>
           case _                                        => false
         }
         def isApp(t: Tree) = t match {
-          case Template(ps, _, _) => ps.exists(cond(_) { case Ident(tpnme.App) => true })
+          case Template(parents, _, _) => parents.exists(cond(_) { case Ident(tpnme.App) => true })
           case _ => false
         }
         /* For now we require there only be one top level object. */
@@ -401,6 +401,8 @@ self =>
              */
             if (name == mainModuleName) md
             else treeCopy.ModuleDef(md, mods, mainModuleName, template)
+          case md @ ModuleDef(_, _, _)   => md
+          case cd @ ClassDef(_, _, _, _) => cd
           case _ =>
             /* If we see anything but the above, fail. */
             return None

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -240,6 +240,7 @@ trait StdNames {
 
     final val Any: NameType             = "Any"
     final val AnyVal: NameType          = "AnyVal"
+    final val App: NameType             = "App"
     final val FlagSet: NameType         = "FlagSet"
     final val Mirror: NameType          = "Mirror"
     final val Modifiers: NameType       = "Modifiers"

--- a/test/files/run/t4625.check
+++ b/test/files/run/t4625.check
@@ -1,0 +1,1 @@
+Test ran.

--- a/test/files/run/t4625.scala
+++ b/test/files/run/t4625.scala
@@ -1,0 +1,7 @@
+
+import scala.tools.partest.ScriptTest
+
+object Test extends ScriptTest {
+  // must be called Main to get probing treatment in parser
+  override def testmain = "Main"
+}

--- a/test/files/run/t4625.script
+++ b/test/files/run/t4625.script
@@ -1,0 +1,5 @@
+
+object Main extends Runnable with App {
+  def run() = println("Test ran.")
+  run()
+}

--- a/test/files/run/t4625b.check
+++ b/test/files/run/t4625b.check
@@ -1,0 +1,1 @@
+Misc top-level detritus

--- a/test/files/run/t4625b.scala
+++ b/test/files/run/t4625b.scala
@@ -1,0 +1,7 @@
+
+import scala.tools.partest.ScriptTest
+
+object Test extends ScriptTest {
+  // must be called Main to get probing treatment in parser
+  override def testmain = "Main"
+}

--- a/test/files/run/t4625b.script
+++ b/test/files/run/t4625b.script
@@ -1,0 +1,8 @@
+
+trait X { def x = "Misc top-level detritus" }
+
+object Bumpkus
+
+object Main extends X with App {
+  println(x)
+}

--- a/tools/Copyrighter.scala
+++ b/tools/Copyrighter.scala
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2016 We don't need no stinkin' copyright notices.
+ */
+import java.nio.file._
+import java.time._
+
+import scala.collection.mutable
+
+object Copyrighter extends App {
+
+  val usage = "Usage: scala -nc tools/Copyrighter.scala [--follow|--update|--verbose|--help]"
+
+  val config = args.foldLeft(Set.empty[String])((flags, arg) => arg match {
+    case "--update" | "--follow" | "--verbose" => flags + arg
+    case "--help" | _ => Console.err.println(usage) ; sys.exit(1)
+  })
+
+  val app = new Copyrighter(config.contains("--verbose"))
+  if (config.contains("--follow"))
+    app.follow(config.contains("--update"))
+  else
+    app.verify(config.contains("--update"))
+}
+
+class Copyrighter(verbose: Boolean) {
+  import EasyOut._
+
+  // string regex for what looks like a copyright
+  val copyrightish = raw"(\(c\)|Copyright) 20[0-9]{2}(-(20[0-9]{2}))?"
+
+  // regex for copyright dates, with capturing groups for start and end year
+  val copyregex = raw"(\(c\)|Copyright) (20[0-9]{2})(?:-(20[0-9]{2}))?".r.unanchored
+
+  case class Copyright(path: Path, lineno: Int, text: String)
+
+  case class Dated(path: Path, from: Year, to: Option[Year])
+
+  /** Sources that seem to bear a copyright, as (Path, line number, text) */
+  def copyrighted: List[Copyright] = {
+    val gitted = xs"git grep -n -E -e $copyrightish -- *.scala"
+    val parted = gitted.map { line =>
+      val parts = line.split(":", 3)
+      Copyright(Paths.get(parts(0)), parts(1).toInt, parts(2))
+    }
+    parted.toList
+  }
+  def copyrightedS: Stream[(Path, Int, String)] = {
+    val gitted = xs"git grep -n -E -e $copyrightish -- *.scala"
+    gitted.map { line =>
+      val parts = line.split(":", 3)
+      (Paths.get(parts(0)), parts(1).toInt, parts(2))
+    }
+  }
+
+  /*
+   * Log all the paths.
+   *
+   * Fast method can't follow, so won't correctly detect earliest commit of code
+   * through moves. For example, `scala.App` should have the same start year as
+   * `scala.Application` from which it is derived.
+   *
+   * "usage: git logs can only follow renames on one pathname at a time"
+   */
+  def verify(update: Boolean): Unit = {
+    def rangify(info: Iterator[String]): Map[Path, Dated] = {
+      val res = mutable.Map.empty[Path, Dated]
+      val lines = info
+      var lastYear: Year = Year.of(Year.MIN_VALUE)
+      while (lines.hasNext) {
+        var yearly = lines.next()
+        while (yearly.isEmpty && lines.hasNext) yearly = lines.next()
+        if (lines.hasNext) {
+          val year = Year.parse(yearly.substring(0, 4))
+          if (verbose && year != lastYear) {
+            pe"Year $year"
+            lastYear = year
+          }
+          var line = lines.next()
+          assert(line.isEmpty)
+          do {
+            line = lines.next()
+            if (line.nonEmpty) {
+              val p = Paths.get(line)
+              res.get(p) match {
+                case Some(dated) => res.put(p, dated.copy(from = year))
+                case None        => res.put(p, Dated(p, from = year, to = Some(year)))
+              }
+              //res.put(p, Dated(p, year, y)).foreach(dated => res.update(p, dated.copy(to = y)))
+            }
+          } while (line.nonEmpty && lines.hasNext)
+        }
+      }
+      res.toMap
+    }
+    def logged(candidates: List[Copyright]): Map[Path, Dated] = {
+      val info = xx"git log --no-merges --date=short --format=%n%cd --name-only"(candidates.map(_.path.toString))
+      rangify(info.iterator)
+    }
+    val limit = 10
+    val candidates = copyrighted.filter(_.lineno <= limit)
+    val ranged = logged(candidates)
+
+    for (candidate @ Copyright(path, lineno, text) <- candidates) {
+      text match {
+        case copyregex(_, start, end) =>
+          val notice = Dated(path, Year.parse(start), Option(end).map(Year.parse))
+          val actual = ranged(path)
+          if (!check(notice, actual) && update && !fix(candidate, actual)) ps"$path: Unable to fix. :("
+      }
+    }
+  }
+
+  /** Check whether notice conforms to actual. True for OK.
+   *
+   *  Verify that start in notice is not after first commit,
+   *  and end in notice is not before last commit.
+   */
+  def check(notice: Dated, actual: Dated): Boolean = {
+    val badStart = actual.from isBefore notice.from
+    val badUntil = notice.to.map(_ isBefore actual.to.get).getOrElse(false)
+    val warnUntil = notice.to.map(_ isAfter actual.to.get).getOrElse(false)
+    val failed = badStart || badUntil || warnUntil
+    if (failed) {
+      if (verbose) {
+        val starting = if (badStart) s"Bad from ${notice.from} should be ${actual.from}. " else ""
+        val ending = notice.to match {
+          case Some(to) =>
+            if (badUntil) s"Bad to ${to} should be ${actual.to.get}."
+            else if (warnUntil) s"Warning: to ${to} is after last commit in ${actual.to.get}."
+            else ""
+          case None     => s"Missing to should be ${actual.to.get}"
+        }
+        ps"${notice.path}: $starting$ending"
+      } else {
+        val starting = if (badStart) s"${notice.from}->${actual.from}" else s"${notice.from}"
+        val ending = notice.to match {
+          case Some(to) =>
+            if (badUntil) s"${to}->${actual.to.get}"
+            else if (warnUntil) s"${to}~>${actual.to.get}"
+            else s"${to}"
+          case None     => s"?->${actual.to.get}"
+        }
+        ps"${notice.path}: ($starting, $ending)"
+      }
+    }
+    !failed
+  }
+
+  /** Attempt to update the candidate path with actual years.
+   */
+  def fix(candidate: Copyright, actual: Dated): Boolean = {
+    import scala.collection.JavaConverters._
+    import scala.io.Codec.UTF8.{ charSet => cs }
+    import candidate._, actual.{ from, to }
+    val lines = Files.readAllLines(path, cs).asScala
+    assert(lines(lineno - 1) == text)
+    val before = lines.take(lineno - 1)
+    val after = lines.drop(lineno)
+    val corrected: String = copyregex.replaceAllIn(text, m => s"${m.group(1)} ${from}-${to.get}")
+    val w = Files.newBufferedWriter(path, cs)
+    def outln(s: String) = {
+      w.write(s)
+      w.newLine()
+    }
+    try {
+      before.foreach(outln)
+      outln(corrected)
+      after.foreach(outln)
+      true
+    } catch {
+      case e: java.io.IOException =>
+        e.printStackTrace()
+        false
+    } finally w.close
+  }
+
+  /** Slow version gets history per path, in order to follow moves. */
+  def follow(update: Boolean): Unit = {
+    val limit = 10
+    val candidates = copyrighted.filter(_.lineno <= limit)
+
+    for (candidate @ Copyright(path, lineno, text) <- candidates) {
+      text match {
+        case copyregex(_, start, end) =>
+          def yearOf(log: String) = Year.parse(log.substring(0, 4))
+          val notice = Dated(path, Year.parse(start), Option(end).map(Year.parse))
+          val gitted = xs"""git log --no-merges --follow --date=short --format=%cd $path"""
+          val actual = Dated(path, yearOf(gitted.last), gitted.headOption.map(yearOf))
+          if (!check(notice, actual) && update && !fix(candidate, actual)) ps"$path: Unable to fix. :("
+      }
+    }
+  }
+}
+
+object EasyOut {
+  /*
+  private[this] val inquotes = """(['"])(.*?)\1""".r
+  def unquoted(s: String) = s match { case inquotes(_, w) => w ; case _ => s }
+  def words(s: String) = (s.trim split "\\s+" filterNot (_ == "") map unquoted).toList
+  */
+
+  implicit class `easy println`(val sc: StringContext) extends AnyVal {
+    import StringContext.treatEscapes, scala.runtime.ScalaRunTime.stringOf
+    /** Print stringOf args. */
+    def p(args: Any*): String = {
+      val s = sc.standardInterpolator(treatEscapes, args.map(stringOf))
+      println(s)
+      s
+    }
+    /** out.print args.toString. */
+    def ps(args: Any*): String = {
+      val s = sc.standardInterpolator(treatEscapes, args.map(_.toString))
+      println(s)
+      s
+    }
+    /** err.print args.toString. */
+    def pe(args: Any*): String = {
+      val s = sc.standardInterpolator(treatEscapes, args.map(_.toString))
+      Console.err.println(s)
+      s
+    }
+  }
+  implicit class `easy process`(val sc: StringContext) extends AnyVal {
+    import StringContext._, scala.runtime.ScalaRunTime.stringOf
+    def sh(args: Any*): String = {
+      import StringContext.processEscapes
+      import sys.process._
+      sc.checkLengths(args)
+      val ss = sc.parts.zipAll(args, "", "").flatMap {
+        case (s, a) => processEscapes(s).split("\\s+").toList.filter(_.nonEmpty) :+ a.toString
+      }.init
+      //p"Try: $ss"
+      //ss.!!
+      ???
+    }
+    /** Execute a process.
+     *
+     *  String parts are split on spaces to form elements of the command;
+     *  empty parts are ignored; interpolated args are taken for elements.
+     *
+     *  No quote parsing is performed: use interpolated arg for embedded spaces and empty args.
+     *
+     *  Use `x` for `String` result, `xs` for `Stream[String]` and `xx` for
+     *  a function that takes more args before running the command.
+     *
+     *  val dir = Paths.get("\\Program Files").toFile
+     *  x"ls -ltr $dir" => Process(Seq("ls", "-ltr", dir.toString))
+     *  x"$cmd$option$dir" => Process(Seq(cmd.toString, option.toString, dir.toString))
+     *
+     *  val empty = ""
+     *  x"scalac -cp $empty *.scala" => Process(Seq("scalac", "-cp", "", "*.scala"))
+     */
+    def x(args: Any*): String = {
+      import sys.process._
+      seq(args: _*).!!
+    }
+    def xs(args: Any*): Stream[String] = {
+      import sys.process._
+      seq(args: _*).lineStream
+    }
+    def xx(args: Any*): Seq[String] => Stream[String] = {
+      import sys.process._
+      val ss = seq(args: _*)
+      more => (ss ++ more).lineStream
+    }
+    def seq(args: Any*): Seq[String] = {
+      import StringContext.processEscapes
+      sc.checkLengths(args)
+      sc.parts.zipAll(args, "", "").flatMap {
+        case (s, a) => processEscapes(s).split("\\s+").toList.filter(_.nonEmpty) :+ a.toString
+      }.init
+    }
+  }
+}


### PR DESCRIPTION
yacc, yet another copyright comparator.

The tool shows current (start, end) and recommended replacements, which it applies on `--update`. The squiggly arrow warns that the end date was previously advanced past the last commit.

```
src/compiler/scala/tools/nsc/ast/NodePrinters.scala: (2005, 2013->2015)
src/compiler/scala/tools/nsc/ast/parser/BracePair.scala: (2005, 2013~>2012)
```

With `--follow`, it shows that `App.scala` should bear the earlier date for `Application.scala`, from which it is derived.

```
< src/library/scala/App.scala: (2010, 2013->2014)

---
> src/library/scala/App.scala: (2010->2004, 2013->2014)
```

But `runtime/AbstractPartialFunction` wants to go too far, probably because most of the initial commit was just the copyright banner itself:

```
< src/library/scala/runtime/AbstractPartialFunction.scala: (2013->2011, ?->2015)

---
> src/library/scala/runtime/AbstractPartialFunction.scala: (2013->2005, ?->2015)
```

Notice that its date was incorrectly updated from 2011 to 2013 in a huge "update copyrights" commit.

Cherry-picked the `App` commits which haven't landed from 2.11 yet.
