### PR TITLE
Small optimizations around use of Scopes.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
@@ -192,8 +192,7 @@ abstract class ExtensionMethods extends Transform with TypingTransformers {
             extensionDefs(currentOwner.companionModule) = new mutable.ListBuffer[Tree]
             currentOwner.primaryConstructor.makeNotPrivate(NoSymbol)
             // SI-7859 make param accessors accessible so the erasure can generate unbox operations.
-            val paramAccessors = currentOwner.info.decls.filter(sym => sym.isParamAccessor && sym.isMethod)
-            paramAccessors.foreach(_.makeNotPrivate(currentOwner))
+            currentOwner.info.decls.foreach(sym => if (sym.isParamAccessor && sym.isMethod) sym.makeNotPrivate(currentOwner))
             super.transform(tree)
           } else if (currentOwner.isStaticOwner) {
             super.transform(tree)

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -463,7 +463,7 @@ trait Namers extends MethodSynthesis {
         //      opening up the package object on the classpath at all if one exists in source.
         if (m.isPackageObject) {
           val packageScope = m.enclosingPackageClass.rawInfo.decls
-          packageScope.filter(_.owner != m.enclosingPackageClass).toList.foreach(packageScope unlink _)
+          packageScope.foreach(mem => if (mem.owner != m.enclosingPackageClass) packageScope unlink mem)
         }
         updatePosFlags(m, tree.pos, moduleFlags)
         setPrivateWithin(tree, m)

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -172,12 +172,12 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
 
       // This has become noisy with implicit classes.
       if (settings.warnPolyImplicitOverload && settings.developer) {
-        clazz.info.decls filter (x => x.isImplicit && x.typeParams.nonEmpty) foreach { sym =>
+        clazz.info.decls.foreach(sym => if (sym.isImplicit && sym.typeParams.nonEmpty) {
           // implicit classes leave both a module symbol and a method symbol as residue
           val alts = clazz.info.decl(sym.name).alternatives filterNot (_.isModule)
           if (alts.size > 1)
             alts foreach (x => reporter.warning(x.pos, "parameterized overloaded implicit methods are not visible as view bounds"))
-        }
+        })
       }
     }
 

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -863,12 +863,13 @@ trait Definitions extends api.StandardDefinitions {
         //    Scopes()
         // must filter out "universal" members (getClass is deferred for some reason)
         val deferredMembers = (
-          tp membersBasedOnFlags (excludedFlags = BridgeAndPrivateFlags, requiredFlags = METHOD)
-          filter (mem => mem.isDeferredNotJavaDefault && !isUniversalMember(mem)) // TODO: test
+          tp.membersBasedOnFlags(excludedFlags = BridgeAndPrivateFlags, requiredFlags = METHOD).toList.filter(
+            mem => mem.isDeferredNotJavaDefault && !isUniversalMember(mem)
+          ) // TODO: test
         )
 
         // if there is only one, it's monomorphic and has a single argument list
-        if (deferredMembers.size == 1 &&
+        if (deferredMembers.lengthCompare(1) == 0 &&
             deferredMembers.head.typeParams.isEmpty &&
             deferredMembers.head.info.paramSectionCount == 1)
           deferredMembers.head

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2036,11 +2036,9 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
         }
       }
     }
-    private final def caseFieldAccessorsUnsorted: List[Symbol] =
-      (info.decls filter (_.isCaseAccessorMethod)).toList
+    private final def caseFieldAccessorsUnsorted: List[Symbol] = info.decls.toList.filter(_.isCaseAccessorMethod)
 
-    final def constrParamAccessors: List[Symbol] =
-      info.decls.filter(sym => !sym.isMethod && sym.isParamAccessor).toList
+    final def constrParamAccessors: List[Symbol] = info.decls.toList.filter(sym => !sym.isMethod && sym.isParamAccessor)
 
     /** The symbol accessed by this accessor (getter or setter) function. */
     final def accessed: Symbol = {


### PR DESCRIPTION
`Scope`'s `filter` is implemented using `toList`, so may as well start with `toList`ourselves.

Also fused some `filter`/`foreach` combos.
