### PR TITLE
Fix comparisons involving NaN

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/ScalaPrimitives.scala
+++ b/src/compiler/scala/tools/nsc/backend/ScalaPrimitives.scala
@@ -61,8 +61,8 @@ abstract class ScalaPrimitives {
   final val NE = 43                            // x != y
   final val LT = 44                            // x < y
   final val LE = 45                            // x <= y
-  final val GE = 46                            // x > y
-  final val GT = 47                            // x >= y
+  final val GT = 46                            // x > y
+  final val GE = 47                            // x >= y
 
   // Boolean unary operations
   final val ZNOT = 50                          // !x

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -1336,6 +1336,7 @@ object BCodeHelpers {
   }
 
   object TestOp {
+    // the order here / op numbers are important to get the correct result when calling opcodeIF
     val EQ = new TestOp(0)
     val NE = new TestOp(1)
     val LT = new TestOp(2)

--- a/test/junit/scala/lang/primitives/NaNTest.scala
+++ b/test/junit/scala/lang/primitives/NaNTest.scala
@@ -1,0 +1,38 @@
+package scala.lang.primitives
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.tools.testing.RunTesting
+
+@RunWith(classOf[JUnit4])
+class NaNTest extends RunTesting {
+
+  @Test
+  def compNaNFalse(): Unit = {
+    def code(tp: String) =
+      s"""val n = $tp.NaN
+          |def ne(x: $tp, y: $tp) = x != y
+          |val fs: List[($tp, $tp) => Boolean] = List(_ < _, _ <= _, _ > _, _ >= _,  _ == _, (x, y) => !ne(x, y))
+          |val vs = List[$tp](n, 1, -1, 0)
+          |for (f <- fs; v <- vs; (x, y) <- List((n, v), (v, n))) yield f(x, y)
+      """.stripMargin
+
+    runner.run[List[Boolean]](code("Double")).foreach(assertFalse)
+    runner.run[List[Boolean]](code("Float")).foreach(assertFalse)
+  }
+
+  @Test
+  def genericEqNe(): Unit = {
+    def code(tp: String) =
+      s"""def a[T](x: T, y: T) = x == y
+         |def b[T](x: T, y: T) = x != y
+         |val n = $tp.NaN
+         |a(n, n) :: a(n, 0) :: a (0, n) :: !b(n, n) :: !b(n, 0) :: !b(0, n) :: Nil
+      """.stripMargin
+    runner.run[List[Boolean]](code("Double")).foreach(assertFalse)
+    runner.run[List[Boolean]](code("Float")).foreach(assertFalse)
+  }
+}


### PR DESCRIPTION
Floating point comparisons involving NaN should always return false,
except for !=. Fixes a regression introduced by #4963.
