### PR TITLE
Prohibit @native method in trait

### DIFF
--- a/src/library/scala/native.scala
+++ b/src/library/scala/native.scala
@@ -16,8 +16,11 @@ package scala
   * @native def f(x: Int, y: List[Long]): String = ...
   * }}}
   *
-  * Method body is not generated if method is marked with `@native`,
-  * but it is type checked when present.
+  * A `@native` method is compiled to the platform's native method,
+  * while discarding the method's body (if any). The body will be type checked if present.
   *
-  * @since 2.6 */
+  * A method marked @native must be a member of a class, not a trait (since 2.12).
+  *
+  * @since 2.6
+  */
 class native extends scala.annotation.StaticAnnotation {}

--- a/test/files/neg/trait-no-native.check
+++ b/test/files/neg/trait-no-native.check
@@ -1,0 +1,4 @@
+trait-no-native.scala:3: error: A trait cannot define a native method.
+  @native def foo = ???
+              ^
+one error found

--- a/test/files/neg/trait-no-native.scala
+++ b/test/files/neg/trait-no-native.scala
@@ -1,0 +1,4 @@
+trait T {
+  // should not compile, because it would result in a VerifyError
+  @native def foo = ???
+}


### PR DESCRIPTION
On the JVM, a @native interface method results in a VerifyError.

Other platforms could decide to be more permissive, but it seems
like allowing them in classes is enough.

Follow up for #5138 
