### PR TITLE
SI-9799 Keep ImportHandlers that imports implicit symbols for -Yrepl-class-based

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/Imports.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Imports.scala
@@ -115,8 +115,9 @@ trait Imports {
         // Single symbol imports might be implicits! See bug #1752.  Rather than
         // try to finesse this, we will mimic all imports for now.
         def keepHandler(handler: MemberHandler) = handler match {
-          // While defining classes in class based mode - implicits are not needed.
-          case h: ImportHandler if isClassBased && definesClass => h.importedNames.exists(x => wanted.contains(x))
+          case h: ImportHandler if isClassBased && definesClass =>
+            // While defining classes in class based mode, keep implicits and wanted imports.
+            h.implicitSymbols.nonEmpty || h.importedNames.exists(x => wanted.contains(x))
           case _: ImportHandler     => true
           case x if generousImports => x.definesImplicit || (x.definedNames exists (d => wanted.exists(w => d.startsWith(w))))
           case x                    => x.definesImplicit || (x.definedNames exists wanted)

--- a/test/files/run/t9799-repl.check
+++ b/test/files/run/t9799-repl.check
@@ -1,0 +1,33 @@
+
+scala> :paste < EOF
+// Entering paste mode (EOF to finish)
+
+object X {
+  import scala.language.implicitConversions
+  implicit def bar(a: Array[String]) = new Foo(a)
+  class Foo(a: Array[String]) {
+    def toX: Seq[String] = a.toSeq
+  }
+}
+EOF
+
+// Exiting paste mode, now interpreting.
+
+defined object X
+
+scala> import X._
+import X._
+
+scala> :paste < EOF
+// Entering paste mode (EOF to finish)
+
+class Bar(s: String) {
+  val x = Array(s).toX
+}
+EOF
+
+// Exiting paste mode, now interpreting.
+
+defined class Bar
+
+scala> :quit

--- a/test/files/run/t9799-repl.scala
+++ b/test/files/run/t9799-repl.scala
@@ -1,0 +1,27 @@
+import scala.tools.partest.ReplTest
+import scala.tools.nsc.Settings
+
+object Test extends ReplTest {
+
+  override def transformSettings(s: Settings): Settings = {
+    s.Yreplclassbased.value = true
+    s
+  }
+
+  def code = """:paste < EOF
+    |object X {
+    |  import scala.language.implicitConversions
+    |  implicit def bar(a: Array[String]) = new Foo(a)
+    |  class Foo(a: Array[String]) {
+    |    def toX: Seq[String] = a.toSeq
+    |  }
+    |}
+    |EOF
+    |import X._
+    |:paste < EOF
+    |class Bar(s: String) {
+    |  val x = Array(s).toX
+    |}
+    |EOF
+    | """.stripMargin
+}


### PR DESCRIPTION
Since we don't know whether the implicit imports are necessary, they should be always kept.
