### PR TITLE
SI-7898 Preserve reader against subversion

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -966,7 +966,10 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
 
       // while we go fire up the REPL
       try {
-        createInterpreter()
+        // don't allow ancient sbt to hijack the reader
+        savingReader {
+          createInterpreter()
+        }
         intp.initializeSynchronous()
         globalFuture = Future successful true
         if (intp.reporter.hasErrors) {


### PR DESCRIPTION
SBT tries to install its own SimpleReader (for some reason)
if it needs to create its own IMain.

Because Rube Goldberg needs to execute some postinit hooks,
don't let SBT do that.

I tested this on locally built sbt 13.12 and scala 2.12.

```
apm@mara:~/projects/sample$ sbt console
[info] Set current project to Sample (in build file:/home/apm/projects/sample/)
[info] Compiling 1 Scala source to /home/apm/projects/sample/target/scala-2.12.0-M4/classes...
[info] Starting scala interpreter...
[info] 
Welcome to Scala 2.12.0-20160604-133738-e33ff9e (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_60).
Type in expressions for evaluation. Or try :help.

scala> 42
res0: Int = 42

scala> 43
res1: Int = 43

scala> 44
res2: Int = 44

scala> 45
res3: Int = 45

scala> 

scala> 

scala> println("hello")
hello

scala> 
[success] Total time: 379 s, completed Jun 4, 2016 3:07:28 PM
apm@mara:~/projects/sample$ cat build.properties 
sbt.version=0.13.12-SNAPSHOT
```
