### PR TITLE
SI-9793 Hard exit scaladoc if bad CLI arguments are given

### DIFF
--- a/src/scaladoc/scala/tools/nsc/ScalaDoc.scala
+++ b/src/scaladoc/scala/tools/nsc/ScalaDoc.scala
@@ -19,13 +19,15 @@ class ScalaDoc {
 
   def process(args: Array[String]): Boolean = {
     var reporter: ScalaDocReporter = null
-    val docSettings = new doc.Settings(msg => reporter.error(FakePos("scaladoc"), msg + "\n  scaladoc -help  gives more information"),
+    val docSettings = new doc.Settings(msg => reporter.error(FakePos("scaladoc"), msg),
                                        msg => reporter.printMessage(msg))
     reporter = new ScalaDocReporter(docSettings)
     val command = new ScalaDoc.Command(args.toList, docSettings)
     def hasFiles = command.files.nonEmpty || docSettings.uncompilableFiles.nonEmpty
 
-    if (docSettings.version.value)
+    if (reporter.reallyHasErrors)
+      reporter.echo("Usage: scaladoc <options> <source files>\nscaladoc -help gives more information")
+    else if (docSettings.version.value)
       reporter.echo(versionMsg)
     else if (docSettings.Xhelp.value)
       reporter.echo(command.xusageMsg)


### PR DESCRIPTION
Scaladoc should exit immediately when given bad arguments. Scaladoc currently interprets bad arguments as filenames.

Before:

```
chase@chase-kubuntu:~/projects/scala$ ./build/quick/bin/scaladoc -h
scaladoc error: bad option: '-h'
  scaladoc -help  gives more information
error: source file '-h' could not be found
model contains 1 documentable templates
two errors found
```

After:

```
chase@chase-kubuntu:~/projects/scala$ ./build/quick/bin/scaladoc -h
scaladoc error: bad option: '-h'
  scaladoc -help gives more information
```

This PR also fixes a typo in the error message printed to the console when a bad argument is encountered.

review by @janekdb
