### PR TITLE
Keep line numbers when inlining from the same compilation unit

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
@@ -98,7 +98,7 @@ class BackendUtils[BT <: BTypes](val btypes: BT) {
    * a boolean indicating if the instruction list contains an instantiation of a serializable SAM
    * type.
    */
-  def cloneInstructions(methodNode: MethodNode, labelMap: Map[LabelNode, LabelNode]): (InsnList, Map[AbstractInsnNode, AbstractInsnNode], Boolean) = {
+  def cloneInstructions(methodNode: MethodNode, labelMap: Map[LabelNode, LabelNode], keepLineNumbers: Boolean): (InsnList, Map[AbstractInsnNode, AbstractInsnNode], Boolean) = {
     val javaLabelMap = labelMap.asJava
     val result = new InsnList
     var map = Map.empty[AbstractInsnNode, AbstractInsnNode]
@@ -112,9 +112,11 @@ class BackendUtils[BT <: BTypes](val btypes: BT) {
         }
         case _ =>
       }
-      val cloned = ins.clone(javaLabelMap)
-      result add cloned
-      map += ((ins, cloned))
+      if (keepLineNumbers || !ins.isInstanceOf[LineNumberNode]) {
+        val cloned = ins.clone(javaLabelMap)
+        result add cloned
+        map += ((ins, cloned))
+      }
     }
     (result, map, hasSerializableClosureInstantiation)
   }

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/ClosureOptimizer.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/ClosureOptimizer.scala
@@ -17,7 +17,6 @@ import scala.tools.nsc.backend.jvm.BTypes.InternalName
 import BytecodeUtils._
 import BackendReporting._
 import Opcodes._
-import scala.tools.nsc.backend.jvm.opt.ByteCodeRepository.CompilationUnit
 import scala.collection.JavaConverters._
 
 class ClosureOptimizer[BT <: BTypes](val btypes: BT) {
@@ -354,16 +353,15 @@ class ClosureOptimizer[BT <: BTypes](val btypes: BT) {
 
     // the method node is needed for building the call graph entry
     val bodyMethod = byteCodeRepository.methodNode(lambdaBodyHandle.getOwner, lambdaBodyHandle.getName, lambdaBodyHandle.getDesc)
-    def bodyMethodIsBeingCompiled = byteCodeRepository.classNodeAndSource(lambdaBodyHandle.getOwner).map(_._2 == CompilationUnit).getOrElse(false)
+    val sourceFilePath = byteCodeRepository.compilingClasses.get(lambdaBodyHandle.getOwner).map(_._2)
     val callee = bodyMethod.map({
       case (bodyMethodNode, bodyMethodDeclClass) =>
         val bodyDeclClassType = classBTypeFromParsedClassfile(bodyMethodDeclClass)
-        val canInlineFromSource = compilerSettings.optInlineGlobal || bodyMethodIsBeingCompiled
         Callee(
           callee = bodyMethodNode,
           calleeDeclarationClass = bodyDeclClassType,
-          safeToInline = canInlineFromSource,
-          canInlineFromSource = canInlineFromSource,
+          safeToInline = inlinerHeuristics.canInlineFromSource(sourceFilePath),
+          sourceFilePath = sourceFilePath,
           annotatedInline = false,
           annotatedNoInline = false,
           samParamTypes = callGraph.samParamTypes(bodyMethodNode, bodyDeclClassType),

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
@@ -253,7 +253,7 @@ class Inliner[BT <: BTypes](val btypes: BT) {
   def inlineCallsite(callsite: Callsite): Unit = {
     import callsite.{callsiteClass, callsiteMethod, callsiteInstruction, receiverKnownNotNull, callsiteStackHeight}
     val Right(callsiteCallee) = callsite.callee
-    import callsiteCallee.{callee, calleeDeclarationClass}
+    import callsiteCallee.{callee, calleeDeclarationClass, sourceFilePath}
 
     // Inlining requires the callee not to have unreachable code, the analyzer used below should not
     // return any `null` frames. Note that inlining a method can create unreachable code. Example:
@@ -268,7 +268,14 @@ class Inliner[BT <: BTypes](val btypes: BT) {
 
     // New labels for the cloned instructions
     val labelsMap = cloneLabels(callee)
-    val (clonedInstructions, instructionMap, hasSerializableClosureInstantiation) = cloneInstructions(callee, labelsMap, keepLineNumbers = callsiteClass == calleeDeclarationClass)
+    val sameSourceFile = sourceFilePath match {
+      case Some(calleeSource) => byteCodeRepository.compilingClasses.get(callsiteClass.internalName) match {
+        case Some((_, `calleeSource`)) => true
+        case _ => false
+      }
+      case _ => false
+    }
+    val (clonedInstructions, instructionMap, hasSerializableClosureInstantiation) = cloneInstructions(callee, labelsMap, keepLineNumbers = sameSourceFile)
 
     // local vars in the callee are shifted by the number of locals at the callsite
     val localVarShift = callsiteMethod.maxLocals

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
@@ -268,11 +268,7 @@ class Inliner[BT <: BTypes](val btypes: BT) {
 
     // New labels for the cloned instructions
     val labelsMap = cloneLabels(callee)
-    val (clonedInstructions, instructionMap, hasSerializableClosureInstantiation) = cloneInstructions(callee, labelsMap)
-    val keepLineNumbers = callsiteClass == calleeDeclarationClass
-    if (!keepLineNumbers) {
-      removeLineNumberNodes(clonedInstructions)
-    }
+    val (clonedInstructions, instructionMap, hasSerializableClosureInstantiation) = cloneInstructions(callee, labelsMap, keepLineNumbers = callsiteClass == calleeDeclarationClass)
 
     // local vars in the callee are shifted by the number of locals at the callsite
     val localVarShift = callsiteMethod.maxLocals

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -431,6 +431,7 @@ trait Namers extends MethodSynthesis {
         && !(module isCoDefinedWith clazz)
         && module.exists
         && clazz.exists
+        && (currentRun.compiles(clazz) == currentRun.compiles(module))
       )
       if (fails) {
         reporter.error(tree.pos, (

--- a/src/reflect/scala/reflect/internal/Flags.scala
+++ b/src/reflect/scala/reflect/internal/Flags.scala
@@ -235,7 +235,6 @@ class Flags extends ModifierFlags {
   final val AllFlags = -1L
 
   /** These flags can be set when class or module symbol is first created.
-   *  They are the only flags to survive a call to resetFlags().
    */
   final val TopLevelCreationFlags =
     MODULE | PACKAGE | FINAL | JAVA

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -725,7 +725,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
 
     def setFlag(mask: Long): this.type   = { _rawflags |= mask ; this }
     def resetFlag(mask: Long): this.type = { _rawflags &= ~mask ; this }
-    def resetFlags() { rawflags &= TopLevelCreationFlags }
+    def resetFlags() { rawflags = 0 }
 
     /** Default implementation calls the generic string function, which
      *  will print overloaded flags as <flag1/flag2/flag3>.  Subclasses

--- a/test/junit/scala/tools/nsc/backend/jvm/DirectCompileTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/DirectCompileTest.scala
@@ -99,4 +99,16 @@ class DirectCompileTest extends BytecodeTesting {
     compiler.compileToBytes(a)
     compiler.compileToBytes(b)
   }
+
+  @Test
+  def residentMultipleRunsNotCompanions(): Unit = {
+    val compiler = newCompiler()
+    val a = List(("public class A { }", "A.java"))
+    // when checking that a class and its companion are defined in the same compilation unit, the
+    // compiler would also emit a warning if the two symbols are defined in separate runs. this
+    // would lead to an error message when compiling the scala class A.
+    val b = "class A"
+    compiler.compileToBytes("", a)
+    compiler.compileToBytes(b)
+  }
 }

--- a/test/junit/scala/tools/nsc/backend/jvm/DirectCompileTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/DirectCompileTest.scala
@@ -88,4 +88,15 @@ class DirectCompileTest extends BytecodeTesting {
   def compileErroneous(): Unit = {
     compileToBytes("class C { def f: String = 1 }", allowMessage = _.msg contains "type mismatch")
   }
+
+  @Test
+  def residentRedefineFinalFlag(): Unit = {
+    val compiler = newCompiler()
+    val a = "final class C { def c1 = 0 }"
+    // for re-defined class symbols (C), the compiler did not clear the `final` flag.
+    // so compiling `D` would give an error `illegal inheritance from final class C`.
+    val b = "class C; class D extends C"
+    compiler.compileToBytes(a)
+    compiler.compileToBytes(b)
+  }
 }

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineWarningTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineWarningTest.scala
@@ -97,7 +97,7 @@ class InlineWarningTest extends BytecodeTesting {
   @Test
   def cannotInlinePrivateCallIntoDifferentClass(): Unit = {
     val code =
-      """class M {
+      """class A {
         |  @inline final def f = {
         |    @noinline def nested = 0
         |    nested
@@ -106,15 +106,15 @@ class InlineWarningTest extends BytecodeTesting {
         |  def t = f // ok
         |}
         |
-        |class N {
-        |  def t(a: M) = a.f // not possible
+        |class B {
+        |  def t(a: A) = a.f // not possible
         |}
       """.stripMargin
 
     val warn =
-      """M::f()I is annotated @inline but could not be inlined:
-        |The callee M::f()I contains the instruction INVOKESTATIC M.nested$1 ()I
-        |that would cause an IllegalAccessError when inlined into class N""".stripMargin
+      """A::f()I is annotated @inline but could not be inlined:
+        |The callee A::f()I contains the instruction INVOKESTATIC A.nested$1 ()I
+        |that would cause an IllegalAccessError when inlined into class B""".stripMargin
 
     var c = 0
     compileToBytes(code, allowMessage = i => { c += 1; i.msg contains warn })
@@ -124,7 +124,7 @@ class InlineWarningTest extends BytecodeTesting {
   @Test
   def dontWarnWhenNotIlnineAnnotated(): Unit = {
     val code =
-      """class M {
+      """class A {
         |  final def f(t: Int => Int) = {
         |    @noinline def nested = 0
         |    nested + t(1)
@@ -132,16 +132,16 @@ class InlineWarningTest extends BytecodeTesting {
         |  def t = f(x => x + 1)
         |}
         |
-        |class N {
-        |  def t(a: M) = a.f(x => x + 1)
+        |class B {
+        |  def t(a: A) = a.f(x => x + 1)
         |}
       """.stripMargin
     compileToBytes(code, allowMessage = _ => false) // no warnings allowed
 
     val warn =
-      """M::f(Lscala/Function1;)I could not be inlined:
-        |The callee M::f(Lscala/Function1;)I contains the instruction INVOKESTATIC M.nested$1 ()I
-        |that would cause an IllegalAccessError when inlined into class N""".stripMargin
+      """A::f(Lscala/Function1;)I could not be inlined:
+        |The callee A::f(Lscala/Function1;)I contains the instruction INVOKESTATIC A.nested$1 ()I
+        |that would cause an IllegalAccessError when inlined into class B""".stripMargin
 
     var c = 0
     compilerWarnAll.compileToBytes(code, allowMessage = i => { c += 1; i.msg contains warn })

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerIllegalAccessTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerIllegalAccessTest.scala
@@ -19,7 +19,7 @@ class InlinerIllegalAccessTest extends BytecodeTesting {
   import compiler._
   import global.genBCode.bTypes._
 
-  def addToRepo(cls: List[ClassNode]): Unit = for (c <- cls) byteCodeRepository.add(c, ByteCodeRepository.Classfile)
+  def addToRepo(cls: List[ClassNode]): Unit = for (c <- cls) byteCodeRepository.add(c, None)
   def assertEmpty(ins: Option[AbstractInsnNode]) = for (i <- ins)
     throw new AssertionError(textify(i))
 

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
@@ -835,11 +835,11 @@ class InlinerTest extends BytecodeTesting {
   @Test
   def inlineInvokeSpecial(): Unit = {
     val code =
-      """class Aa {
+      """class A {
         |  def f1 = 0
         |}
-        |class B extends Aa {
-        |  @inline final override def f1 = 1 + super.f1 // invokespecial Aa.f1
+        |class B extends A {
+        |  @inline final override def f1 = 1 + super.f1 // invokespecial A.f1
         |
         |  private def f2m = 0                          // public B$$f2m in bytecode
         |  @inline final def f2 = f2m                   // invokevirtual B.B$$f2m
@@ -863,13 +863,13 @@ class InlinerTest extends BytecodeTesting {
 
     val warn =
       """B::f1()I is annotated @inline but could not be inlined:
-        |The callee B::f1()I contains the instruction INVOKESPECIAL Aa.f1 ()I
+        |The callee B::f1()I contains the instruction INVOKESPECIAL A.f1 ()I
         |that would cause an IllegalAccessError when inlined into class T.""".stripMargin
     var c = 0
     val List(a, b, t) = compile(code, allowMessage = i => {c += 1; i.msg contains warn})
     assert(c == 1, c)
 
-    assertInvoke(getMethod(b, "t1"), "Aa", "f1")
+    assertInvoke(getMethod(b, "t1"), "A", "f1")
     assertInvoke(getMethod(b, "t2"), "B", "B$$f2m")
     assertInvoke(getMethod(b, "t3"), "B", "<init>")
     assertInvoke(getMethod(b, "t4"), "B", "<init>")

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
@@ -43,7 +43,7 @@ class InlinerTest extends BytecodeTesting {
     // Use the class nodes stored in the byteCodeRepository. The ones returned by compileClasses are not the same,
     // these are created new from the classfile byte array. They are completely separate instances which cannot
     // be used to look up methods / callsites in the callGraph hash maps for example.
-    byteCodeRepository.compilingClasses.valuesIterator.toList.sortBy(_.name)
+    byteCodeRepository.compilingClasses.valuesIterator.map(_._1).toList.sortBy(_.name)
   }
 
   def checkCallsite(callsite: callGraph.Callsite, callee: MethodNode) = {

--- a/test/junit/scala/tools/testing/BytecodeTesting.scala
+++ b/test/junit/scala/tools/testing/BytecodeTesting.scala
@@ -29,7 +29,7 @@ class Compiler(val global: Global) {
     global.settings.outputDirs.setSingleOutput(new VirtualDirectory("(memory)", None))
   }
 
-  private def newRun: global.Run = {
+  def newRun: global.Run = {
     global.reporter.reset()
     resetOutput()
     new global.Run()


### PR DESCRIPTION
So far, line numbers were kept only when inlining from the same class. We
can also keep them when inlining from a different class defined in the same
compilation unit.

Longer-term we should support JSR-45, see SI-7518 and scala-dev#3.

Rebase of #5202
