### PR TITLE
SI-9806 Fix incorrect codegen with optimizer, constants, try/catch

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/opt/ConstantOptimization.scala
+++ b/src/compiler/scala/tools/nsc/backend/opt/ConstantOptimization.scala
@@ -539,14 +539,14 @@ abstract class ConstantOptimization extends SubComponent {
       // number of instructions excluding the last one
       val normalCount = block.size - 1
 
-      val exceptionState = in.cleanStack
+      var exceptionState = in.cleanStack
       var normalExitState = in
       var idx = 0
       while (idx < normalCount) {
         val inst = block(idx)
         normalExitState = interpretInst(normalExitState, inst)
         if (normalExitState.locals ne exceptionState.locals)
-          exceptionState.copy(locals = exceptionState mergeLocals normalExitState.locals)
+          exceptionState = exceptionState.copy(locals = exceptionState mergeLocals normalExitState.locals)
         idx += 1
       }
 

--- a/test/files/run/t9806.scala
+++ b/test/files/run/t9806.scala
@@ -1,0 +1,18 @@
+object Ex extends Exception
+object Test {
+  def main(args: Array[String]) {
+    try foo catch { case Ex => }
+  }
+
+  def isTrue(b: Boolean) = b
+  def foo = {
+    var streamErrors1 = true
+    try {
+      streamErrors1 = false
+      throw Ex
+    } catch {
+      case ex if streamErrors1 =>
+        assert(isTrue(streamErrors1))
+    }
+  }
+}


### PR DESCRIPTION
The constant optimizer phase performs abstract interpretation of the
icode representation of the progam in order to eliminate dead
code.

For each basic block, the possible and impossible states of each local
variable is computed for both a normal and an exceptional exit.

A bug in this code incorrectly tracked state for exception exits.
This appears to have been an oversight: the new state was computed
at each instruction, but it was discarded rather than folded through
the intepreter.
