### PR TITLE
SI-9245 Fresher name in Try and test

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
@@ -105,7 +105,7 @@ abstract class TreeBuilder {
   def makeCatchFromExpr(catchExpr: Tree): CaseDef = {
     val binder   = freshTermName()
     val pat      = Bind(binder, Typed(Ident(nme.WILDCARD), Ident(tpnme.Throwable)))
-    val catchDef = ValDef(Modifiers(ARTIFACT), freshTermName("catchExpr"), TypeTree(), catchExpr)
+    val catchDef = ValDef(Modifiers(ARTIFACT), freshTermName("catchExpr$"), TypeTree(), catchExpr)
     val catchFn  = Ident(catchDef.name)
     val body     = atPos(catchExpr.pos.makeTransparent)(Block(
       List(catchDef),

--- a/test/files/pos/t9245.scala
+++ b/test/files/pos/t9245.scala
@@ -1,0 +1,27 @@
+
+/*
+Was:
+test/files/pos/t9245.scala:5: error: recursive value catchExpr1 needs type
+    try {} catch catchExpr1
+                 ^
+
+Now:
+    def catchExpr1: PartialFunction[Throwable,Any] = scala.this.Predef.???;
+    def test: Any = try {
+      ()
+    } catch {
+      case (x$1 @ (_: Throwable)) => {
+        <artifact> val catchExpr$1: PartialFunction[Throwable,Any] = Test.this.catchExpr1;
+        if (catchExpr$1.isDefinedAt(x$1))
+          catchExpr$1.apply(x$1)
+        else
+          throw x$1
+      }
+    }
+*/
+trait Test {
+  def catchExpr1: PartialFunction[Throwable, Any] = ???
+  def test = {
+    try {} catch catchExpr1
+  }
+}


### PR DESCRIPTION
Fresh name for catcher gets a dollar. "Here, have a dollar."
Test due to retronym demonstrates possible conflict.

Over the lifetime of the universe, surely at least one code
monkey would type in that identifier to catch a banana.
