### PR TITLE
SI-9817 immutable queue `forall` and `exists` implementations

### DIFF
--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -84,6 +84,14 @@ sealed class Queue[+A] protected(protected val in: List[A], protected val out: L
     else if (in.nonEmpty) new Queue(Nil, in.reverse.tail)
     else throw new NoSuchElementException("tail on empty queue")
 
+  /* This is made to avoid inefficient implementation of iterator. */
+  override def forall(p: A => Boolean): Boolean =
+    in.forall(p) && out.forall(p)
+
+  /* This is made to avoid inefficient implementation of iterator. */
+  override def exists(p: A => Boolean): Boolean =
+    in.exists(p) || out.exists(p)
+
   /** Returns the length of the queue.
    */
   override def length = in.length + out.length


### PR DESCRIPTION
https://issues.scala-lang.org/browse/SI-9817

@axel22

These are ones that i'm particularly interested in, since they create some GC pressure in my application and not as fast as they could be.
Not sure if it's safe to do so, since ordering is broken in case of side effecting predicates.
