### PR TITLE
SI-9585 hide auto-implicit conversions from scaladoc

### DIFF
--- a/test/scaladoc/run/t9585.check
+++ b/test/scaladoc/run/t9585.check
@@ -1,0 +1,6 @@
+warning: there was one feature warning; re-run with -feature for details
+any2stringadd[Box[T]]
+StringFormat[Box[T]]
+Ensuring[Box[T]]
+ArrowAssoc[Box[T]]
+Done.

--- a/test/scaladoc/run/t9585.scala
+++ b/test/scaladoc/run/t9585.scala
@@ -1,0 +1,25 @@
+import scala.tools.nsc.doc.model._
+import scala.tools.partest.ScaladocModelTest
+
+object Test extends ScaladocModelTest {
+  override def code = """
+  object Box {
+
+    implicit def anyToBox[T](t: T): Box[T] = new Box(t)
+
+  }
+
+  class Box[T](val t: T)
+  """
+
+  def scaladocSettings = "-implicits"
+
+  def testModel(root: Package) = {
+    import access._
+
+    // this used to contain the conversion to Box[Box[T]],
+    // but not anymore.
+    val conversions = root._class("Box").conversions
+    println(conversions.map(_.targetType).mkString("\n"))
+  }
+}


### PR DESCRIPTION
This hides implicits conversions (and potential members obtained through
it) that converts a type into itself, because these conversions are
usually non-sensical. They are not completely removed, just placed behind
`-doc-implicits-show-all`, like other implicits deemed probably useless.

---

Consider the scaladoc for the following class:

```
object Box {
  implicit def anyToBox[T](t: T): Box[T] = new Box(t)
}
class Box[T](val t: T)
```

When looking for implicits members to add to class `Box`, it finds the
implicit conversion `anyToBox`, and applies it to itself to have an
implicit conversion to `Box[Box[T]]`, which brings a useless implicit
member `t: Box[T]`.

This commit makes scaladoc ignore any conversion from a type to itself
(even if type parameters differ) by default.

Using the (very useful) `tools/scaladoc-diff` script, I found that this
change removes the following conversion from the library doc:

```
Ensuring[A] to Ensuring[Ensuring[A]]
anytostringadd[A] to any2stringadd[anytostringadd[A]]
ArrowAssoc[A] to ArrowAssoc[ArrowAssoc[A]]
=:=[From,To] to =:=[From,To]
SearchImpl[A,Repr] to SearchImpl[A,SearchImpl[A,Repr]]
CollectionsHaveToParArray[C, T]  to CollectionsHaveToParArray[CollectionsHaveToParArray[C, T], T]
Ordered[A] to Ordered[Ordered[A]]
StringFormat[A] to StringFormat[StringFormat[A]]
```
