### PR TITLE
Escape triple quotes when printing multiline strings

### DIFF
--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -1055,7 +1055,16 @@ trait Printers extends api.Printers { self: SymbolTable =>
               val splitValue = x.stringValue.split(s"$LF").toList
               val multilineStringValue = if (x.stringValue.endsWith(s"$LF")) splitValue :+ "" else splitValue
               val trQuotes = "\"\"\""
-              print(trQuotes); printSeq(multilineStringValue) { print(_) } { print(LF) }; print(trQuotes)
+
+              def escapeSegment(value: String) {
+                printSeq(value.split(trQuotes, -1).toList) { print(_) } {
+                  print(trQuotes)
+                  print(" + \"\\\"\\\"\\\"\" + ")
+                  print(trQuotes)
+                }
+              }
+
+              print(trQuotes); printSeq(multilineStringValue)(escapeSegment) { print(LF) }; print(trQuotes)
             case _ =>
               // processing Float constants
               val printValue = x.escapedStringValue + (if (x.value.isInstanceOf[Float]) "F" else "")

--- a/test/junit/scala/reflect/internal/PrintersTest.scala
+++ b/test/junit/scala/reflect/internal/PrintersTest.scala
@@ -86,6 +86,10 @@ trait BasePrintTests {
 
   @Test def testConstantLong = assertTreeCode(Literal(Constant(42l)))("42L")
 
+  @Test def testConstantStringWithTripleQuotes = assertTreeCode(
+    tree = Literal(Constant("hello\n\"\"\"world")))(
+    code = "\"\"\"hello\n\"\"\" + \"\\\"\\\"\\\"\" + \"\"\"world\"\"\"")
+
   @Test def testOpExpr = assertPrintedCode("(5).+(4)", checkTypedTree = false)
 
   @Test def testName1 = assertPrintedCode("class test")


### PR DESCRIPTION
When printing multiline literals containing triple quotes, the triple quotes are currently left intact and invalid code is emitted.

This addresses this issue by using string concatenation to insert escaped triple quotes.

Originally discovered in scala-exercises/scala-exercises#350.
