### PR TITLE
Generalize `Future.traverse` and `Future.sequence`

### DIFF
--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -496,7 +496,7 @@ object Future {
   /** Simple version of `Future.traverse`. Transforms a `TraversableOnce[Future[A]]` into a `Future[TraversableOnce[A]]`.
    *  Useful for reducing many `Future`s into a single `Future`.
    */
-  def sequence[A, M[X] <: TraversableOnce[X]](in: M[Future[A]])(implicit cbf: CanBuildFrom[M[Future[A]], A, M[A]], executor: ExecutionContext): Future[M[A]] = {
+  def sequence[A, M[X] <: TraversableOnce[X], That](in: M[Future[A]])(implicit cbf: CanBuildFrom[M[Future[A]], A, That], executor: ExecutionContext): Future[That] = {
     in.foldLeft(successful(cbf(in))) {
       (fr, fa) => for (r <- fr; a <- fa) yield (r += a)
     }.map(_.result())(InternalCallbackExecutor)
@@ -571,7 +571,7 @@ object Future {
    *    val myFutureList = Future.traverse(myList)(x => Future(myFunc(x)))
    *  }}}
    */
-  def traverse[A, B, M[X] <: TraversableOnce[X]](in: M[A])(fn: A => Future[B])(implicit cbf: CanBuildFrom[M[A], B, M[B]], executor: ExecutionContext): Future[M[B]] =
+  def traverse[A, B, M[X] <: TraversableOnce[X], That](in: M[A])(fn: A => Future[B])(implicit cbf: CanBuildFrom[M[A], B, That], executor: ExecutionContext): Future[That] =
     in.foldLeft(successful(cbf(in))) { (fr, a) =>
       val fb = fn(a)
       for (r <- fr; b <- fb) yield (r += b)

--- a/test/files/jvm/future-spec/FutureTests.scala
+++ b/test/files/jvm/future-spec/FutureTests.scala
@@ -414,6 +414,22 @@ class FutureTests extends MinimalScalaTest {
       Await.result(traversedIterator, defaultTimeout).sum mustBe (10000)
     }
 
+    "shouldTraverseAndChangeCollections" in {
+      import scala.collection.breakOut
+
+      val input = Map(1 -> "one", 2 -> "two")
+
+      val traversed: Future[Map[Int,String]] =
+        Future.traverse(input){Future.successful}(breakOut, implicitly)
+
+      Await.result(traversed, defaultTimeout) mustBe input
+
+      val sequenced: Future[Map[Int,String]] =
+        Future.sequence(input.map(Future.successful))(breakOut, implicitly)
+
+      Await.result(sequenced, defaultTimeout) mustBe input
+    }
+
     "shouldBlockUntilResult" in {
       val latch = new TestLatch
 


### PR DESCRIPTION
Allow `CanBuildFrom` to determine the resulting collection type, instead
of forcing it to be the same as the input.  This allows to do a
`Future.traverse` on a `Map[A,B]` and using `collection.breakOut` get
back a Future[Map[A,B]] again.
