### PR TITLE
language.future.{noStringPlus,syntax}

### DIFF
--- a/project/ScalaOptionParser.scala
+++ b/project/ScalaOptionParser.scala
@@ -107,7 +107,7 @@ object ScalaOptionParser {
     "-target" -> List("jvm-1.5", "jvm-1.6", "jvm-1.7", "jvm-1.8"))
   private def multiChoiceSettingNames = Map[String, List[String]](
     "-Xlint" -> List("adapted-args", "nullary-unit", "inaccessible", "nullary-override", "infer-any", "missing-interpolator", "doc-detached", "private-shadow", "type-parameter-shadow", "poly-implicit-overload", "option-implicit", "delayedinit-select", "by-name-right-associative", "package-object-classes", "unsound-match", "stars-align"),
-    "-language" -> List("help", "_", "dynamics", "postfixOps", "reflectiveCalls", "implicitConversions", "higherKinds", "existentials", "experimental.macros"),
+    "-language" -> List("help", "_", "dynamics", "postfixOps", "reflectiveCalls", "implicitConversions", "higherKinds", "existentials", "experimental.macros", "future.noStringPlus"),
     "-opt" -> List("l:none", "l:default", "l:method", "l:project", "l:classpath", "unreachable-code", "simplify-jumps", "empty-line-numbers", "empty-labels", "compact-locals", "nullness-tracking", "closure-elimination", "inline-project", "inline-global"),
     "-Ystatistics" -> List("parser", "typer", "patmat", "erasure", "cleanup", "jvm")
   )

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -821,6 +821,7 @@ trait Scanners extends ScannersCommon {
           }
           val alt = if (oct == LF) "\\n" else "\\u%04x" format oct
           def msg(what: String) = s"Octal escape literals are $what, use $alt instead."
+          //if (settings.language containsChoice settings.languageFeatures.syntax)
           if (settings.future)
             syntaxError(start, msg("unsupported"))
           else

--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -639,19 +639,29 @@ class MutableSettings(val errorFn: String => Unit)
     }
 
     type T = domain.ValueSet
-    protected var v: T = domain.ValueSet.empty
+    protected var v: T = emptyChoices
+
+    private def emptyChoices = domain.ValueSet.empty
 
     // Explicitly enabled or disabled. Yeas may contain expanding options, nays may not.
-    private var yeas = domain.ValueSet.empty
-    private var nays = domain.ValueSet.empty
+    private var yeas = emptyChoices
+    private var nays = emptyChoices
 
     // Asked for help
     private var sawHelp = false
     // Wildcard _ encountered
     private var sawAll  = false
+    private val wildPrefixes = collection.mutable.Set.empty[String]
+
+    // A wildcard has an optional prefix: "_", "experimental._"
+    private val wild = raw"([^.]*\.)?_".r
 
     private def badChoice(s: String) = errorFn(s"'$s' is not a valid choice for '$name'")
-    private def isChoice(s: String) = (s == "_") || (choices contains pos(s))
+    private def isChoice(s: String) = s match {
+      case wild(null)   => true
+      case wild(prefix) => choices exists (_.startsWith(prefix))
+      case _            => choices contains pos(s)
+    }
 
     private def pos(s: String) = s stripPrefix "-"
     private def isPos(s: String) = !(s startsWith "-")
@@ -668,13 +678,14 @@ class MutableSettings(val errorFn: String => Unit)
 
     /** (Re)compute from current yeas, nays, wildcard status. */
     def compute() = {
+      /** Is non-expanding. */
       def simple(v: domain.Value) = v match {
         case ChoiceOrVal(_, _, Nil) => true
         case _ => false
       }
 
       /**
-       * Expand an expanding option, if necessary recursively. Expanding options are not included in
+       * Recursively expand an expanding option, if necessary. Expanding options are not included in
        * the result (consistent with "_", which is not in `value` either).
        *
        * Note: by precondition, options in nays are not expanding, they can only be leaves.
@@ -685,7 +696,13 @@ class MutableSettings(val errorFn: String => Unit)
       }
 
       // yeas from _ or expansions are weak: an explicit nay will disable them
-      val weakYeas = if (sawAll) domain.values filter simple else expand(yeas filterNot simple)
+      val weakYeas = {
+        val wild     = if (sawAll) domain.values.filter(v => simple(v) && !v.toString.contains('.')) else emptyChoices
+        val prefixed = domain.values.filter(v => simple(v) && wildPrefixes.exists(v.toString.startsWith))
+        val expanded = expand(yeas.filterNot(simple))
+        (wild | prefixed | expanded)
+      }
+
       value = (yeas filter simple) | (weakYeas &~ nays)
     }
 
@@ -693,8 +710,11 @@ class MutableSettings(val errorFn: String => Unit)
     def add(arg: String) = arg match {
       case _ if !isChoice(arg) =>
         badChoice(arg)
-      case "_" =>
+      case wild(null) =>
         sawAll = true
+        compute()
+      case wild(prefix) =>
+        wildPrefixes += prefix
         compute()
       case _ if isPos(arg) =>
         yeas += domain withName arg

--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -748,6 +748,8 @@ class MutableSettings(val errorFn: String => Unit)
 
     def contains(choice: domain.Value): Boolean = value contains choice
 
+    def isChoiceSetByUser(choice: domain.Value): Boolean = yeas(choice) || nays(choice)
+
     override def isHelping: Boolean = sawHelp
 
     override def help: String = {

--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -768,6 +768,9 @@ class MutableSettings(val errorFn: String => Unit)
 
     def contains(choice: domain.Value): Boolean = value contains choice
 
+    // avoid overloading
+    def containsChoice(choice: domain.Value): Boolean = contains(choice)
+
     def isChoiceSetByUser(choice: domain.Value): Boolean = yeas(choice) || nays(choice)
 
     override def isHelping: Boolean = sawHelp

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -220,6 +220,12 @@ trait ScalaSettings extends AbsScalaSettings
   val YdisableFlatCpCaching  = BooleanSetting    ("-YdisableFlatCpCaching", "Do not cache flat classpath representation of classpath elements from jars across compiler instances.")
   val YpartialUnification = BooleanSetting ("-Ypartial-unification", "Enable partial unification in type constructor inference")
 
+  // a dependent setting to drill through the reflect layer, not available directly to user
+  val YnoStringPlus   = (new BooleanSetting("-Yno-string-plus", "Compile without synthetic String.+(Any) method") {
+    override def value: Boolean = language.isChoiceSetByUser(languageFeatures.noStringPlus)
+    //override def value: Boolean = language contains languageFeatures.noStringPlus
+  }).internalOnly
+
   val exposeEmptyPackage = BooleanSetting ("-Yexpose-empty-package", "Internal only: expose the empty package.").internalOnly()
   val Ydelambdafy        = ChoiceSetting  ("-Ydelambdafy", "strategy", "Strategy used for translating lambdas into JVM code.", List("inline", "method"), "method")
 

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -72,6 +72,7 @@ trait ScalaSettings extends AbsScalaSettings
     val existentials        = Choice("existentials",        "Existential types (besides wildcard types) can be written and inferred")
     val macros              = Choice("experimental.macros", "Allow macro definition (besides implementation and application)")
     val noStringPlus        = Choice("future.noStringPlus", "Disables String.+(Any)")
+    val syntax              = Choice("future.syntax",       "No octal literals")
   }
   val language      = {
     val description = "Enable or disable language features"

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -71,6 +71,7 @@ trait ScalaSettings extends AbsScalaSettings
     val higherKinds         = Choice("higherKinds",         "Allow higher-kinded types")
     val existentials        = Choice("existentials",        "Existential types (besides wildcard types) can be written and inferred")
     val macros              = Choice("experimental.macros", "Allow macro definition (besides implementation and application)")
+    val noStringPlus        = Choice("future.noStringPlus", "Disables String.+(Any)")
   }
   val language      = {
     val description = "Enable or disable language features"

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -726,13 +726,14 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       }
     }
 
-    /** Check whether feature given by `featureTrait` is enabled.
+    /** Check whether feature identified by `featureTrait` is enabled.
      *  If it is not, issue an error or a warning depending on whether the feature is required.
      *  @param  construct  A string expression that is substituted for "#" in the feature description string
      *  @param  immediate  When set, feature check is run immediately, otherwise it is run
      *                     at the end of the typechecking run for the enclosing unit. This
      *                     is done to avoid potential cyclic reference errors by implicits
      *                     that are forced too early.
+     *  @param  isAnOptInFeature  Indicates if the feature is opt-in or not
      *  @return if feature check is run immediately: true if feature is enabled, false otherwise
      *          if feature check is delayed or suppressed because we are past typer: true
      */
@@ -745,13 +746,13 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         def action(): Boolean = {
           def hasImport = inferImplicitByType(featureTrait.tpe, context).isSuccess
           def hasOption = settings.language contains featureName
-          val OK = hasImport || hasOption
-          if (!OK) {
+          val featureIsEnabled = hasImport || hasOption
+          if (!featureIsEnabled) {
             val Some(AnnotationInfo(_, List(Literal(Constant(featureDesc: String)), Literal(Constant(required: Boolean))), _)) =
               featureTrait getAnnotation LanguageFeatureAnnot
             context.featureWarning(pos, featureName, featureDesc, featureTrait, construct, required)
           }
-          OK
+          featureIsEnabled
         }
         if (immediate) {
           action()

--- a/src/compiler/scala/tools/reflect/FormatInterpolator.scala
+++ b/src/compiler/scala/tools/reflect/FormatInterpolator.scala
@@ -113,7 +113,9 @@ abstract class FormatInterpolator {
           }
           def badOctal = {
             def msg(what: String) = s"Octal escape literals are $what$alt."
-            if (settings.future) {
+            //if (settings.language contains settings.languageFeatures.syntax)
+            //if (settings.language containsChoice settings.language.domain.syntax) {
+            if (settings.future) {  // checkFeature
               c.error(errPoint, msg("unsupported"))
               s0
             } else {

--- a/src/library/scala/language.scala
+++ b/src/library/scala/language.scala
@@ -32,6 +32,7 @@ package scala
  *  @groupname production   Language Features
  *  @groupname experimental Experimental Language Features
  *  @groupprio experimental 10
+ *  @groupname future Future Language Features
  */
 object language {
 
@@ -181,11 +182,40 @@ object language {
     implicit lazy val macros: macros = languageFeature.experimental.macros
   }
 
+  /** The future object contains features that will be added to the Scala language
+   *  in an unspecified future release.
+   *
+   *  Future features are expected to enter the language in the form and
+   *  implementation enabled here. These features broadly conform to
+   *  the `-Xfuture` compiler option, which allows programmers to future-proof
+   *  their code.
+   *
+   *  @group future
+   */
   object future {
 
     import languageFeature.future._
 
-    implicit lazy val noStringPlus: noStringPlus = languageFeature.future.noStringPlus
+    /** Language syntax evolves slowly after long deprecation cycles.
+     *  This language control enables checks against future syntax.
+     *
+     *  '''Why enable the feature?''' This feature allows programmers to embrace
+     *  future language changes without negotiating deprecation warnings.
+     *
+     *  '''Why control it?''' In the absence of code rewriting and migration tools,
+     *  language changes must be introduced slowly to accommodate existing codebases.
+     *  The implicit control enables local migration of code.
+     */
+    implicit lazy val syntax: syntax = languageFeature.future.syntax
 
+    /** Disable the `+` operator for concatenating to `String` objects.
+     *
+     *  '''Why enable the feature?''' There are better uses for `+`.
+     *
+     *  '''Why control it?''' The conventional `+` for String concatentation has
+     *  a history on various platforms. But string interpolation is preferred
+     *  for new code.
+     */
+    implicit lazy val noStringPlus: noStringPlus = languageFeature.future.noStringPlus
   }
 }

--- a/src/library/scala/language.scala
+++ b/src/library/scala/language.scala
@@ -180,4 +180,12 @@ object language {
      */
     implicit lazy val macros: macros = languageFeature.experimental.macros
   }
+
+  object future {
+
+    import languageFeature.future._
+
+    implicit lazy val noStringPlus: noStringPlus = languageFeature.future.noStringPlus
+
+  }
 }

--- a/src/library/scala/languageFeature.scala
+++ b/src/library/scala/languageFeature.scala
@@ -45,6 +45,10 @@ object languageFeature {
   }
 
   object future {
+    @meta.languageFeature("future language syntax", enableRequired = true)
+    sealed trait syntax
+    object syntax extends syntax
+
     @meta.languageFeature("no string plus", enableRequired = true)
     sealed trait noStringPlus
     object noStringPlus extends noStringPlus

--- a/src/library/scala/languageFeature.scala
+++ b/src/library/scala/languageFeature.scala
@@ -43,5 +43,10 @@ object languageFeature {
     sealed trait macros
     object macros extends macros
   }
-}
 
+  object future {
+    @meta.languageFeature("no string plus", enableRequired = true)
+    sealed trait noStringPlus
+    object noStringPlus extends noStringPlus
+  }
+}

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1108,7 +1108,11 @@ trait Definitions extends api.StandardDefinitions {
     lazy val Object_synchronized = newPolyMethod(1, ObjectClass, nme.synchronized_, FINAL)(tps =>
       (Some(List(tps.head.typeConstructor)), tps.head.typeConstructor)
     )
-    lazy val String_+ = enterNewMethod(StringClass, nme.raw.PLUS, AnyTpe :: Nil, StringTpe, FINAL)
+    lazy val String_+ = {
+      // YnoStringPlus checks (settings.language.isChoiceSetByUser(settings.languageFeatures.noStringPlus))
+      val opname = if (settings.YnoStringPlus) nme.concat else nme.raw.PLUS
+      enterNewMethod(StringClass, opname, AnyTpe :: Nil, StringTpe, FINAL)
+    }
 
     def Object_getClass  = getMemberMethod(ObjectClass, nme.getClass_)
     def Object_clone     = getMemberMethod(ObjectClass, nme.clone_)

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1546,7 +1546,9 @@ trait Definitions extends api.StandardDefinitions {
       lazy val materializeTypeTag     = ReflectApiPackage.map(sym => getMemberMethod(sym, nme.materializeTypeTag))
 
       lazy val experimentalModule         = getMemberModule(languageFeatureModule, nme.experimental)
+      lazy val futureModule               = getMemberModule(languageFeatureModule, nme.future)
       lazy val MacrosFeature              = getLanguageFeature("macros", experimentalModule)
+      lazy val NoStringPlusFeature        = getLanguageFeature("noStringPlus", futureModule)
       lazy val DynamicsFeature            = getLanguageFeature("dynamics")
       lazy val PostfixOpsFeature          = getLanguageFeature("postfixOps")
       lazy val ReflectiveCallsFeature     = getLanguageFeature("reflectiveCalls")

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -698,6 +698,7 @@ trait StdNames {
     val foreach: NameType              = "foreach"
     val freshTermName: NameType        = "freshTermName"
     val freshTypeName: NameType        = "freshTypeName"
+    val future: NameType               = "future"
     val get: NameType                  = "get"
     val parameterTypes: NameType       = "parameterTypes"
     val hashCode_ : NameType           = "hashCode"

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -886,6 +886,9 @@ trait StdNames {
 
     def newLazyValSlowComputeName(lzyValName: Name) = (lzyValName stripSuffix MODULE_VAR_SUFFIX append LAZY_SLOW_SUFFIX).toTermName
 
+    // string concat
+    val concat: NameType = "$concat"
+
     // ASCII names for operators
     val ADD       = encode("+")
     val AND       = encode("&")

--- a/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
+++ b/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
@@ -54,6 +54,7 @@ abstract class MutableSettings extends AbsSettings {
   def uniqid: BooleanSetting
   def verbose: BooleanSetting
   def YpartialUnification: BooleanSetting
+  def YnoStringPlus: BooleanSetting
 
   def Yrecursion: IntSetting
   def maxClassfileName: IntSetting

--- a/src/reflect/scala/reflect/runtime/Settings.scala
+++ b/src/reflect/scala/reflect/runtime/Settings.scala
@@ -48,6 +48,7 @@ private[reflect] class Settings extends MutableSettings {
   val uniqid            = new BooleanSetting(false)
   val verbose           = new BooleanSetting(false)
   val YpartialUnification = new BooleanSetting(false)
+  val YnoStringPlus     = new BooleanSetting(false)
 
   val Yrecursion        = new IntSetting(0)
   val maxClassfileName  = new IntSetting(255)

--- a/test/files/neg/no-string-plus-1.flags
+++ b/test/files/neg/no-string-plus-1.flags
@@ -1,0 +1,1 @@
+-language:-future.noStringPlus

--- a/test/files/neg/no-string-plus-2.flags
+++ b/test/files/neg/no-string-plus-2.flags
@@ -1,0 +1,1 @@
+-language:-future.noStringPlus

--- a/test/files/neg/no-string-plus-3.check
+++ b/test/files/neg/no-string-plus-3.check
@@ -1,0 +1,4 @@
+no-string-plus-3.scala:3: error: value + is not a member of String
+  def f(s1: String, s2: String) = s1 + s2
+                                     ^
+one error found

--- a/test/files/neg/no-string-plus-3.flags
+++ b/test/files/neg/no-string-plus-3.flags
@@ -1,0 +1,1 @@
+-Yno-predef -language:future.noStringPlus

--- a/test/files/neg/no-string-plus-3.scala
+++ b/test/files/neg/no-string-plus-3.scala
@@ -1,0 +1,4 @@
+
+object Test {
+  def f(s1: String, s2: String) = s1 + s2
+}

--- a/test/files/pos/no-string-plus-2.flags
+++ b/test/files/pos/no-string-plus-2.flags
@@ -1,0 +1,1 @@
+-language:-future.noStringPlus

--- a/test/files/pos/no-string-plus-3.flags
+++ b/test/files/pos/no-string-plus-3.flags
@@ -1,0 +1,1 @@
+-language:-future.noStringPlus

--- a/test/files/run/no-string-plus.check
+++ b/test/files/run/no-string-plus.check
@@ -1,0 +1,2 @@
+falsetrue
+true

--- a/test/files/run/no-string-plus.flags
+++ b/test/files/run/no-string-plus.flags
@@ -1,0 +1,1 @@
+-language:-future.noStringPlus

--- a/test/files/run/no-string-plus.scala
+++ b/test/files/run/no-string-plus.scala
@@ -1,0 +1,25 @@
+
+object Test extends App {
+  locally {
+    import Stringly._
+    val b = "false" + true
+    Console println b
+  }
+  locally {
+    import language.future.noStringPlus
+    import Truly._
+
+    val b = "false" + true
+    Console println b
+  }
+}
+object Truly {
+  implicit class `sum of truths`(private val s: String) extends AnyVal {
+    def +(b: Boolean) = s.toBoolean | b
+  }
+}
+object Stringly {
+  implicit class `sum of truths`(private val s: String) extends AnyVal {
+    def +(other: Any) = s"$s$other"
+  }
+}


### PR DESCRIPTION
Something like that.

This has `-language:-future.noStringPlus` enable local implicit, where `String.+` is not installed but is tacked on when typecheck fails, on the conservative theory that extra implicit searches for string concat would hurt compilation time for status quo. But that theory is not tested, so maybe there's no reason to be conservative.
