### PR TITLE
[nomerge] Avoid triple-quoting triple quotes

### DIFF
--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -1050,7 +1050,7 @@ trait Printers extends api.Printers { self: SymbolTable =>
           x match {
             case Constant(v: String) if {
               val strValue = x.stringValue
-              strValue.contains(LF) && strValue.contains("\"\"\"") && strValue.size > 1
+              strValue.contains(LF) && !strValue.contains("\"\"\"") && strValue.size > 1
             } =>
               val splitValue = x.stringValue.split(s"$LF").toList
               val multilineStringValue = if (x.stringValue.endsWith(s"$LF")) splitValue :+ "" else splitValue

--- a/test/junit/scala/reflect/internal/PrintersTest.scala
+++ b/test/junit/scala/reflect/internal/PrintersTest.scala
@@ -86,6 +86,14 @@ trait BasePrintTests {
 
   @Test def testConstantLong = assertTreeCode(Literal(Constant(42l)))("42L")
 
+  @Test def testConstantMultiline = assertTreeCode(Literal(Constant("hello\nworld")))("\"\"\"hello\nworld\"\"\"")
+
+  val sq  = "\""
+  val teq = "\\\"" * 3
+  val tq  = "\"" * 3
+
+  @Test def testConstantEmbeddedTriple = assertTreeCode(Literal(Constant(s"${tq}hello${tq}\nworld")))(s"${sq}${teq}hello${teq}\\nworld${sq}")
+
   @Test def testOpExpr = assertPrintedCode("(5).+(4)", checkTypedTree = false)
 
   @Test def testName1 = assertPrintedCode("class test")


### PR DESCRIPTION
The boolean test for triples was inadvertently flipped.

Adds test for pretty printed multiline strings
