### PR TITLE
SI-5712 Support dependent argument types for constructor parameter lists

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -182,10 +182,7 @@ trait Namers extends MethodSynthesis {
       sym
     }
     def namerOf(sym: Symbol): Namer = {
-      val usePrimary = sym.isTerm && (
-           (sym.isParamAccessor)
-        || (sym.isParameter && sym.owner.isPrimaryConstructor)
-      )
+      val usePrimary = sym.isTerm && (sym.isParameter && sym.owner.isPrimaryConstructor)
 
       if (usePrimary) createPrimaryConstructorParameterNamer
       else innerNamer

--- a/test/files/pos/t5712.scala
+++ b/test/files/pos/t5712.scala
@@ -1,0 +1,9 @@
+class Global {
+  class Typer[T]
+}
+
+class Reifier[T](global: Global)(typer: global.Typer[T])
+
+object Test {
+  def mkReifier[T](global: Global)(typer: global.Typer[T]) = typer
+}


### PR DESCRIPTION
Issue details can be found at https://issues.scala-lang.org/browse/SI-5712

Implementation as per @adriaanm 's comment in the ticket. From reading the comments and the surrounding code, this looks like the correct solution to me (unless I've misunderstood something)
