### PR TITLE
Doc: capitalize doesn't handle non-BMP characters

### DIFF
--- a/src/library/scala/collection/immutable/StringLike.scala
+++ b/src/library/scala/collection/immutable/StringLike.scala
@@ -137,6 +137,7 @@ self =>
 
   /** Returns this string with first character converted to upper case.
    * If the first character of the string is capitalized, it is returned unchanged.
+   * This method does not convert characters outside the Basic Multilingual Plane (BMP).
    */
   def capitalize: String =
     if (toString == null) null


### PR DESCRIPTION
After a brief discussion on Gitter with @Ichoran, documenting the behaviour is preferable over changing it.
