### PR TITLE
SI-9336 Enable paste detect in jline

### DIFF
--- a/src/repl-jline/scala/tools/nsc/interpreter/jline/JLineReader.scala
+++ b/src/repl-jline/scala/tools/nsc/interpreter/jline/JLineReader.scala
@@ -33,10 +33,13 @@ class InteractiveReader(completer: () => Completion) extends interpreter.Interac
   private val consoleReader = {
     val reader = new JLineConsoleReader()
 
-    reader setPaginationEnabled interpreter.`package`.isPaged
+    reader setPaginationEnabled interpreter.isPaged
 
-    // ASAP
+    // turn off magic !
     reader setExpandEvents false
+
+    // enable detecting pasted tab char (when next char is immediately available) which is taken raw, not completion
+    reader setCopyPasteDetection true
 
     reader setHistory history.asInstanceOf[JHistory]
 


### PR DESCRIPTION
When the next char is available immediately after a tab,
the tab is taken raw instead of invoking completion.
