### PR TITLE
Override `.slice` in ArrayOps to use arraycopy.

### DIFF
--- a/src/library/scala/collection/mutable/ArrayOps.scala
+++ b/src/library/scala/collection/mutable/ArrayOps.scala
@@ -44,9 +44,9 @@ sealed trait ArrayOps[T] extends Any with ArrayLike[T, Array[T]] with CustomPara
   override def slice(from: Int, until: Int): Array[T] = {
      val lo = math.max(from, 0)
      val hi = math.min(math.max(until, 0), repr.length)
-     val size = math.max(hi-lo, 0)
+     val size = math.max(hi - lo, 0)
      val result = java.lang.reflect.Array.newInstance(elementClass, size)
-     if(size > 0) {
+     if (size > 0) {
       Array.copy(repr, lo, result, 0, size)
      }
      result.asInstanceOf[Array[T]]

--- a/src/library/scala/collection/mutable/ArrayOps.scala
+++ b/src/library/scala/collection/mutable/ArrayOps.scala
@@ -41,6 +41,17 @@ sealed trait ArrayOps[T] extends Any with ArrayLike[T, Array[T]] with CustomPara
     if (l > 0) Array.copy(repr, 0, xs, start, l)
   }
 
+  override def slice(from: Int, until: Int): Array[T] = {
+     val lo = math.max(from, 0)
+     val hi = math.min(math.max(until, 0), repr.length)
+     val size = math.max(hi-lo, 0)
+     val result = java.lang.reflect.Array.newInstance(elementClass, size)
+     if(size > 0) {
+      Array.copy(repr, lo, result, 0, size)
+     }
+     result.asInstanceOf[Array[T]]
+  }
+
   override def toArray[U >: T : ClassTag]: Array[U] = {
     val thatElementClass = implicitly[ClassTag[U]].runtimeClass
     if (elementClass eq thatElementClass)


### PR DESCRIPTION
This makes it ~10x faster when copying large chunks arround.
My benchmark:

```
def bm(duration: Long)(f: => Unit): Int = {
   val end = System.currentTimeMillis + duration
   var count = 0
   while(System.currentTimeMillis < end) {
     f
     count += 1
   }
  count
}

def measure(seconds: Int)(f: => Unit) = (1 to seconds).map { _ => bm(1000)(f) }.sum / seconds

val array = scala.util.Random.alphanumeric.take(1000).toArray

measure(20) { array.slice(100, 500) }
// ~5 million
measure(20) { scala.collection.WrappedArray(array).slice(100, 500) }
// ~300K
```
