### PR TITLE
SI-9019  TraversableLike stringPrefix broken for inner classes

### DIFF
--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -606,12 +606,21 @@ trait TraversableLike[+A, +Repr] extends Any
    *           simple name of the collection class $coll.
    */
   def stringPrefix : String = {
-    var string = repr.getClass.getName
-    val idx1 = string.lastIndexOf('.' : Int)
-    if (idx1 != -1) string = string.substring(idx1 + 1)
-    val idx2 = string.indexOf('$')
-    if (idx2 != -1) string = string.substring(0, idx2)
-    string
+    val fqn = repr.getClass.getName
+    val cls = {
+      val idx1 = fqn.lastIndexOf('.' : Int)
+      if (idx1 != -1) fqn.substring(idx1 + 1) else fqn
+    }
+    val parts = cls.split('$')
+    val last = parts.length - 1
+    parts.zipWithIndex.foldLeft("") { case (z, (s, i)) =>
+      if (s.isEmpty) z
+      else if (i != last && s.forall(java.lang.Character.isDigit)) "" // drop prefix in method-local classes
+      else if (i == 0 || java.lang.Character.isUpperCase(s.charAt(0))) {
+        if (z.isEmpty) s else z + '.' + s
+      }
+      else z
+    }
   }
 
   /** Creates a non-strict view of this $coll.

--- a/test/files/run/xMigration.check
+++ b/test/files/run/xMigration.check
@@ -1,11 +1,11 @@
 
 scala> Map(1 -> "eis").values    // no warn
-res0: Iterable[String] = MapLike(eis)
+res0: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 
 scala> :setting -Xmigration:none
 
 scala> Map(1 -> "eis").values    // no warn
-res1: Iterable[String] = MapLike(eis)
+res1: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 
 scala> :setting -Xmigration:any
 
@@ -14,12 +14,12 @@ scala> Map(1 -> "eis").values    // warn
 `values` returns `Iterable[B]` rather than `Iterator[B]`.
        Map(1 -> "eis").values    // warn
                        ^
-res2: Iterable[String] = MapLike(eis)
+res2: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 
 scala> :setting -Xmigration:2.8
 
 scala> Map(1 -> "eis").values    // no warn
-res3: Iterable[String] = MapLike(eis)
+res3: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 
 scala> :setting -Xmigration:2.7
 
@@ -28,12 +28,12 @@ scala> Map(1 -> "eis").values    // warn
 `values` returns `Iterable[B]` rather than `Iterator[B]`.
        Map(1 -> "eis").values    // warn
                        ^
-res4: Iterable[String] = MapLike(eis)
+res4: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 
 scala> :setting -Xmigration:2.11
 
 scala> Map(1 -> "eis").values    // no warn
-res5: Iterable[String] = MapLike(eis)
+res5: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 
 scala> :setting -Xmigration      // same as :any
 
@@ -42,6 +42,6 @@ scala> Map(1 -> "eis").values    // warn
 `values` returns `Iterable[B]` rather than `Iterator[B]`.
        Map(1 -> "eis").values    // warn
                        ^
-res6: Iterable[String] = MapLike(eis)
+res6: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 
 scala> :quit

--- a/test/junit/scala/collection/TraversableLikeTest.scala
+++ b/test/junit/scala/collection/TraversableLikeTest.scala
@@ -1,0 +1,33 @@
+package scala.collection
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class TraversableLikeTest {
+  // For test_SI9019; out here because as of test writing, putting this in a method would crash compiler
+  class Baz[@specialized(Int) A]() extends IndexedSeq[A] {
+    def apply(i: Int) = ???
+    def length: Int = 0
+  }
+  
+  @Test
+  def test_SI9019 {
+    object Foo {
+      def mkBar = () => {
+        class Bar extends IndexedSeq[Int] {
+          def apply(i: Int) = ???
+          def length: Int = 0
+        }
+        new Bar
+      }
+    }
+    val bar = Foo.mkBar()
+    assertEquals("Bar", bar.stringPrefix)  // Previously would have been outermost class, TraversableLikeTest
+
+    val baz = new Baz[Int]()
+    assertEquals("TraversableLikeTest.Baz", baz.stringPrefix)  // Make sure we don't see specialization $mcI$sp stuff
+  }
+}


### PR DESCRIPTION
Resurrecting https://github.com/scala/scala/pull/4421 for 2.12.x

JIRA: https://issues.scala-lang.org/browse/SI-9019
