### PR TITLE
SI-9068 Deprecate scala.collection.mutable.Stack

### DIFF
--- a/src/library/scala/collection/mutable/Stack.scala
+++ b/src/library/scala/collection/mutable/Stack.scala
@@ -54,6 +54,7 @@ object Stack extends SeqFactory[Stack] {
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  */
+@deprecated("Stack is an inelegant and potentially poorly-performing wrapper around List. Use a List assigned to a var instead.", "2.12.0")
 class Stack[A] private (var elems: List[A])
 extends AbstractSeq[A]
    with Seq[A]

--- a/test/files/jvm/serialization-new.check
+++ b/test/files/jvm/serialization-new.check
@@ -1,6 +1,6 @@
 warning: there were two deprecation warnings (since 2.11.0)
-warning: there was one deprecation warning (since 2.12.0)
-warning: there were three deprecation warnings in total; re-run with -deprecation for details
+warning: there were three deprecation warnings (since 2.12.0)
+warning: there were 5 deprecation warnings in total; re-run with -deprecation for details
 a1 = Array[1,2,3]
 _a1 = Array[1,2,3]
 arrayEquals(a1, _a1): true

--- a/test/files/run/collection-stacks.check
+++ b/test/files/run/collection-stacks.check
@@ -1,4 +1,6 @@
-warning: there was one deprecation warning (since 2.11.0); re-run with -deprecation for details
+warning: there was one deprecation warning (since 2.11.0)
+warning: there were two deprecation warnings (since 2.12.0)
+warning: there were three deprecation warnings in total; re-run with -deprecation for details
 3-2-1: true
 3-2-1: true
 apply


### PR DESCRIPTION
JIRA: [SI-9068](https://issues.scala-lang.org/browse/SI-9068)
