### PR TITLE
SI-6947 Better type parameter names for Map classes

### DIFF
--- a/src/library/scala/collection/GenMap.scala
+++ b/src/library/scala/collection/GenMap.scala
@@ -18,18 +18,18 @@ import generic._
  *  @author Aleksandar Prokopec
  *  @since 2.9
  */
-trait GenMap[A, +B]
-extends GenMapLike[A, B, GenMap[A, B]]
-   with GenIterable[(A, B)]
+trait GenMap[K, +V]
+extends GenMapLike[K, V, GenMap[K, V]]
+   with GenIterable[(K, V)]
 {
-  def seq: Map[A, B]
+  def seq: Map[K, V]
 
-  def updated [B1 >: B](key: A, value: B1): GenMap[A, B1]
+  def updated [V1 >: V](key: K, value: V1): GenMap[K, V1]
 }
 
 object GenMap extends GenMapFactory[GenMap] {
-  def empty[A, B]: immutable.Map[A, B] = immutable.Map.empty
+  def empty[K, V]: immutable.Map[K, V] = immutable.Map.empty
 
   /** $mapCanBuildFromInfo */
-  implicit def canBuildFrom[A, B]: CanBuildFrom[Coll, (A, B), GenMap[A, B]] = new MapCanBuildFrom[A, B]
+  implicit def canBuildFrom[K, V]: CanBuildFrom[Coll, (K, V), GenMap[K, V]] = new MapCanBuildFrom[K, V]
 }

--- a/src/library/scala/collection/GenMapLike.scala
+++ b/src/library/scala/collection/GenMapLike.scala
@@ -22,13 +22,13 @@ package collection
  *  A map is a collection of bindings from keys to values, where there are
  *  no duplicate keys.
  */
-trait GenMapLike[A, +B, +Repr] extends GenIterableLike[(A, B), Repr] with Equals with Parallelizable[(A, B), parallel.ParMap[A, B]] {
-  def default(key: A): B
-  def get(key: A): Option[B]
-  def apply(key: A): B
-  def seq: Map[A, B]
-  def +[B1 >: B](kv: (A, B1)): GenMap[A, B1]
-  def - (key: A): Repr
+trait GenMapLike[K, +V, +Repr] extends GenIterableLike[(K, V), Repr] with Equals with Parallelizable[(K, V), parallel.ParMap[K, V]] {
+  def default(key: K): V
+  def get(key: K): Option[V]
+  def apply(key: K): V
+  def seq: Map[K, V]
+  def +[V1 >: V](kv: (K, V1)): GenMap[K, V1]
+  def - (key: K): Repr
 
   // This hash code must be symmetric in the contents but ought not
   // collide trivially.
@@ -41,17 +41,17 @@ trait GenMapLike[A, +B, +Repr] extends GenIterableLike[(A, B), Repr] with Equals
    *   @tparam  B1       the result type of the default computation.
    *   @return  the value associated with `key` if it exists,
    *            otherwise the result of the `default` computation.
-   *   @usecase def getOrElse(key: A, default: => B): B
+   *   @usecase def getOrElse(key: K, default: => V): V
    *     @inheritdoc
    */
-  def getOrElse[B1 >: B](key: A, default: => B1): B1
+  def getOrElse[V1 >: V](key: K, default: => V1): V1
 
   /** Tests whether this map contains a binding for a key.
    *
    *  @param key the key
    *  @return    `true` if there is a binding for `key` in this map, `false` otherwise.
    */
-  def contains(key: A): Boolean
+  def contains(key: K): Boolean
 
   /** Tests whether this map contains a binding for a key. This method,
    *  which implements an abstract method of trait `PartialFunction`,
@@ -60,47 +60,47 @@ trait GenMapLike[A, +B, +Repr] extends GenIterableLike[(A, B), Repr] with Equals
    *  @param key the key
    *  @return    `true` if there is a binding for `key` in this map, `false` otherwise.
    */
-  def isDefinedAt(key: A): Boolean
+  def isDefinedAt(key: K): Boolean
 
-  def keySet: GenSet[A]
+  def keySet: GenSet[K]
 
   /** Collects all keys of this map in an iterable collection.
    *
    *  @return the keys of this map as an iterable.
    */
-  def keys: GenIterable[A]
+  def keys: GenIterable[K]
 
   /** Collects all values of this map in an iterable collection.
    *
    *  @return the values of this map as an iterable.
    */
-  def values: GenIterable[B]
+  def values: GenIterable[V]
 
   /** Creates an iterator for all keys.
    *
    *  @return an iterator over all keys.
    */
-  def keysIterator: Iterator[A]
+  def keysIterator: Iterator[K]
 
   /** Creates an iterator for all values in this map.
    *
    *  @return an iterator over all values that are associated with some key in this map.
    */
-  def valuesIterator: Iterator[B]
+  def valuesIterator: Iterator[V]
 
   /** Filters this map by retaining only keys satisfying a predicate.
    *  @param  p   the predicate used to test keys
    *  @return an immutable map consisting only of those key value pairs of this map where the key satisfies
    *          the predicate `p`. The resulting map wraps the original map without copying any elements.
    */
-  def filterKeys(p: A => Boolean): GenMap[A, B]
+  def filterKeys(p: K => Boolean): GenMap[K, V]
 
   /** Transforms this map by applying a function to every retrieved value.
    *  @param  f   the function used to transform values of this map.
    *  @return a map view which maps every key of this map
    *          to `f(this(key))`. The resulting map wraps the original map without copying any elements.
    */
-  def mapValues[C](f: B => C): GenMap[A, C]
+  def mapValues[W](f: V => W): GenMap[K, W]
 
   /** Compares two maps structurally; i.e., checks if all mappings
    *  contained in this map are also contained in the other map,

--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -12,7 +12,7 @@ package collection
 import generic._
 
 /**
- *  A map from keys of type `A` to values of type `B`.
+ *  A map from keys of type `K` to values of type `V`.
  *
  *  $mapNote
  *
@@ -22,15 +22,15 @@ import generic._
  *  '''Note:''' If your additions and mutations return the same kind of map as the map
  *        you are defining, you should inherit from `MapLike` as well.
  *
- *  @tparam A     the type of the keys in this map.
- *  @tparam B     the type of the values associated with keys.
+ *  @tparam K     the type of the keys in this map.
+ *  @tparam V     the type of the values associated with keys.
  *
  *  @since 1.0
  */
-trait Map[A, +B] extends Iterable[(A, B)] with GenMap[A, B] with MapLike[A, B, Map[A, B]] {
-  def empty: Map[A, B] = Map.empty
+trait Map[K, +V] extends Iterable[(K, V)] with GenMap[K, V] with MapLike[K, V, Map[K, V]] {
+  def empty: Map[K, V] = Map.empty
 
-  override def seq: Map[A, B] = this
+  override def seq: Map[K, V] = this
 }
 
 /** $factoryInfo
@@ -38,22 +38,22 @@ trait Map[A, +B] extends Iterable[(A, B)] with GenMap[A, B] with MapLike[A, B, M
  *  @define coll map
  */
 object Map extends MapFactory[Map] {
-  def empty[A, B]: immutable.Map[A, B] = immutable.Map.empty
+  def empty[K, V]: immutable.Map[K, V] = immutable.Map.empty
 
   /** $mapCanBuildFromInfo */
-  implicit def canBuildFrom[A, B]: CanBuildFrom[Coll, (A, B), Map[A, B]] = new MapCanBuildFrom[A, B]
+  implicit def canBuildFrom[K, V]: CanBuildFrom[Coll, (K, V), Map[K, V]] = new MapCanBuildFrom[K, V]
 
   /** An abstract shell used by { mutable, immutable }.Map but not by collection.Map
    *  because of variance issues.
    */
-  abstract class WithDefault[A, +B](underlying: Map[A, B], d: A => B) extends AbstractMap[A, B] with Map[A, B] with Serializable {
+  abstract class WithDefault[K, +V](underlying: Map[K, V], d: K => V) extends AbstractMap[K, V] with Map[K, V] with Serializable {
     override def size               = underlying.size
-    def get(key: A)                 = underlying.get(key) // removed in 2.9: orElse Some(default(key))
+    def get(key: K)                 = underlying.get(key) // removed in 2.9: orElse Some(default(key))
     def iterator                    = underlying.iterator
-    override def default(key: A): B = d(key)
+    override def default(key: K): V = d(key)
   }
 
 }
 
 /** Explicit instantiation of the `Map` trait to reduce class file size in subclasses. */
-abstract class AbstractMap[A, +B] extends AbstractIterable[(A, B)] with Map[A, B]
+abstract class AbstractMap[K, +V] extends AbstractIterable[(K, V)] with Map[K, V]

--- a/src/library/scala/collection/MapLike.scala
+++ b/src/library/scala/collection/MapLike.scala
@@ -28,10 +28,10 @@ import parallel.ParMap
  *    To implement a concrete map, you need to provide implementations of the
  *    following methods:
  *    {{{
- *       def get(key: A): Option[B]
- *       def iterator: Iterator[(A, B)]
- *       def + [B1 >: B](kv: (A, B1)): This
- *       def -(key: A): This
+ *       def get(key: K): Option[V]
+ *       def iterator: Iterator[(K, V)]
+ *       def + [V1 >: V](kv: (K, V1)): This
+ *       def -(key: K): This
  *    }}}
  *    If you wish that methods like `take`, `drop`, `filter` also return the same kind of map
  *    you should also override:
@@ -42,8 +42,8 @@ import parallel.ParMap
  *    `size` for efficiency.
  *
  *  @define mapTags
- *  @tparam A    the type of the keys.
- *  @tparam B    the type of associated values.
+ *  @tparam K    the type of the keys.
+ *  @tparam V    the type of associated values.
  *  @tparam This the type of the map itself.
  *
  *  @author  Martin Odersky
@@ -54,12 +54,12 @@ import parallel.ParMap
  *  @define willNotTerminateInf
  *  @define mayNotTerminateInf
  */
-trait MapLike[A, +B, +This <: MapLike[A, B, This] with Map[A, B]]
-  extends PartialFunction[A, B]
-     with IterableLike[(A, B), This]
-     with GenMapLike[A, B, This]
-     with Subtractable[A, This]
-     with Parallelizable[(A, B), ParMap[A, B]]
+trait MapLike[K, +V, +This <: MapLike[K, V, This] with Map[K, V]]
+  extends PartialFunction[K, V]
+     with IterableLike[(K, V), This]
+     with GenMapLike[K, V, This]
+     with Subtractable[K, This]
+     with Parallelizable[(K, V), ParMap[K, V]]
 {
 self =>
 
@@ -71,7 +71,7 @@ self =>
   /** A common implementation of `newBuilder` for all maps in terms of `empty`.
    *  Overridden for mutable maps in `mutable.MapLike`.
    */
-  override protected[this] def newBuilder: Builder[(A, B), This] = new MapBuilder[A, B, This](empty)
+  override protected[this] def newBuilder: Builder[(K, V), This] = new MapBuilder[K, V, This](empty)
 
   /** Optionally returns the value associated with a key.
    *
@@ -79,32 +79,32 @@ self =>
    *  @return an option value containing the value associated with `key` in this map,
    *          or `None` if none exists.
    */
-  def get(key: A): Option[B]
+  def get(key: K): Option[V]
 
   /** Creates a new iterator over all key/value pairs of this map
    *
    *  @return the new iterator
    */
-  def iterator: Iterator[(A, B)]
+  def iterator: Iterator[(K, V)]
 
   /** Adds a key/value pair to this map, returning a new map.
    *  @param    kv the key/value pair
-   *  @tparam   B1 the type of the value in the key/value pair.
+   *  @tparam   V1 the type of the value in the key/value pair.
    *  @return   a new map with the new binding added to this map
    *
-   *  @usecase  def + (kv: (A, B)): Map[A, B]
+   *  @usecase  def + (kv: (K, V)): Map[K, V]
    *    @inheritdoc
    */
-  def + [B1 >: B] (kv: (A, B1)): Map[A, B1]
+  def + [V1 >: V] (kv: (K, V1)): Map[K, V1]
 
   /** Removes a key from this map, returning a new map.
    *  @param    key the key to be removed
    *  @return   a new map without a binding for `key`
    *
-   *  @usecase  def - (key: A): Map[A, B]
+   *  @usecase  def - (key: K): Map[K, V]
    *    @inheritdoc
    */
-  def - (key: A): This
+  def - (key: K): This
 
   /** Tests whether the map is empty.
    *
@@ -116,14 +116,14 @@ self =>
    *   @param   key      the key.
    *   @param   default  a computation that yields a default value in case no binding for `key` is
    *                     found in the map.
-   *   @tparam  B1       the result type of the default computation.
+   *   @tparam  V1       the result type of the default computation.
    *   @return  the value associated with `key` if it exists,
    *            otherwise the result of the `default` computation.
    *
-   *   @usecase def getOrElse(key: A, default: => B): B
+   *   @usecase def getOrElse(key: K, default: => V): V
    *     @inheritdoc
    */
-  def getOrElse[B1 >: B](key: A, default: => B1): B1 = get(key) match {
+  def getOrElse[V1 >: V](key: K, default: => V1): V1 = get(key) match {
     case Some(v) => v
     case None => default
   }
@@ -137,7 +137,7 @@ self =>
    *  @return     the value associated with the given key, or the result of the
    *              map's `default` method, if none exists.
    */
-  def apply(key: A): B = get(key) match {
+  def apply(key: K): V = get(key) match {
     case None => default(key)
     case Some(value) => value
   }
@@ -147,7 +147,7 @@ self =>
    *  @param key the key
    *  @return    `true` if there is a binding for `key` in this map, `false` otherwise.
    */
-  def contains(key: A): Boolean = get(key).isDefined
+  def contains(key: K): Boolean = get(key).isDefined
 
   /** Tests whether this map contains a binding for a key. This method,
    *  which implements an abstract method of trait `PartialFunction`,
@@ -156,33 +156,33 @@ self =>
    *  @param key the key
    *  @return    `true` if there is a binding for `key` in this map, `false` otherwise.
    */
-  def isDefinedAt(key: A) = contains(key)
+  def isDefinedAt(key: K) = contains(key)
 
   override /*PartialFunction*/
-  def applyOrElse[A1 <: A, B1 >: B](x: A1, default: A1 => B1): B1 =
+  def applyOrElse[K1 <: K, V1 >: V](x: K1, default: K1 => V1): V1 =
     getOrElse(x, default(x))
 
   /** Collects all keys of this map in a set.
    * @return  a set containing all keys of this map.
    */
-  def keySet: Set[A] = new DefaultKeySet
+  def keySet: Set[K] = new DefaultKeySet
 
   /** The implementation class of the set returned by `keySet`.
    */
-  protected class DefaultKeySet extends AbstractSet[A] with Set[A] with Serializable {
-    def contains(key : A) = self.contains(key)
+  protected class DefaultKeySet extends AbstractSet[K] with Set[K] with Serializable {
+    def contains(key : K) = self.contains(key)
     def iterator = keysIterator
-    def + (elem: A): Set[A] = (Set[A]() ++ this + elem).asInstanceOf[Set[A]] // !!! concrete overrides abstract problem
-    def - (elem: A): Set[A] = (Set[A]() ++ this - elem).asInstanceOf[Set[A]] // !!! concrete overrides abstract problem
+    def + (elem: K): Set[K] = (Set[K]() ++ this + elem).asInstanceOf[Set[K]] // !!! concrete overrides abstract problem
+    def - (elem: K): Set[K] = (Set[K]() ++ this - elem).asInstanceOf[Set[K]] // !!! concrete overrides abstract problem
     override def size = self.size
-    override def foreach[U](f: A => U) = self.keysIterator foreach f
+    override def foreach[U](f: K => U) = self.keysIterator foreach f
   }
 
   /** Creates an iterator for all keys.
    *
    *  @return an iterator over all keys.
    */
-  def keysIterator: Iterator[A] = new AbstractIterator[A] {
+  def keysIterator: Iterator[K] = new AbstractIterator[K] {
     val iter = self.iterator
     def hasNext = iter.hasNext
     def next() = iter.next()._1
@@ -192,29 +192,29 @@ self =>
    *
    *  @return the keys of this map as an iterable.
    */
-  @migration("`keys` returns `Iterable[A]` rather than `Iterator[A]`.", "2.8.0")
-  def keys: Iterable[A] = keySet
+  @migration("`keys` returns `Iterable[K]` rather than `Iterator[K]`.", "2.8.0")
+  def keys: Iterable[K] = keySet
 
   /** Collects all values of this map in an iterable collection.
    *
    *  @return the values of this map as an iterable.
    */
-  @migration("`values` returns `Iterable[B]` rather than `Iterator[B]`.", "2.8.0")
-  def values: Iterable[B] = new DefaultValuesIterable
+  @migration("`values` returns `Iterable[V]` rather than `Iterator[V]`.", "2.8.0")
+  def values: Iterable[V] = new DefaultValuesIterable
 
   /** The implementation class of the iterable returned by `values`.
    */
-  protected class DefaultValuesIterable extends AbstractIterable[B] with Iterable[B] with Serializable {
+  protected class DefaultValuesIterable extends AbstractIterable[V] with Iterable[V] with Serializable {
     def iterator = valuesIterator
     override def size = self.size
-    override def foreach[U](f: B => U) = self.valuesIterator foreach f
+    override def foreach[U](f: V => U) = self.valuesIterator foreach f
   }
 
   /** Creates an iterator for all values in this map.
    *
    *  @return an iterator over all values that are associated with some key in this map.
    */
-  def valuesIterator: Iterator[B] = new AbstractIterator[B] {
+  def valuesIterator: Iterator[V] = new AbstractIterator[V] {
     val iter = self.iterator
     def hasNext = iter.hasNext
     def next() = iter.next()._2
@@ -228,33 +228,33 @@ self =>
    *  @param key the given key value for which a binding is missing.
    *  @throws NoSuchElementException
    */
-  def default(key: A): B =
+  def default(key: K): V =
     throw new NoSuchElementException("key not found: " + key)
 
-  protected class FilteredKeys(p: A => Boolean) extends AbstractMap[A, B] with DefaultMap[A, B] {
-    override def foreach[U](f: ((A, B)) => U): Unit = for (kv <- self) if (p(kv._1)) f(kv)
+  protected class FilteredKeys(p: K => Boolean) extends AbstractMap[K, V] with DefaultMap[K, V] {
+    override def foreach[U](f: ((K, V)) => U): Unit = for (kv <- self) if (p(kv._1)) f(kv)
     def iterator = self.iterator.filter(kv => p(kv._1))
-    override def contains(key: A) = p(key) && self.contains(key)
-    def get(key: A) = if (!p(key)) None else self.get(key)
+    override def contains(key: K) = p(key) && self.contains(key)
+    def get(key: K) = if (!p(key)) None else self.get(key)
   }
 
   /** Filters this map by retaining only keys satisfying a predicate.
    *
-   *  '''Note''': the predicate must accept any key of type `A`, not just those already
+   *  '''Note''': the predicate must accept any key of type `K`, not just those already
    *  present in the map, as the predicate is tested before the underlying map is queried.
    *
    *  @param  p   the predicate used to test keys
    *  @return an immutable map consisting only of those key value pairs of this map where the key satisfies
    *          the predicate `p`. The resulting map wraps the original map without copying any elements.
    */
-  def filterKeys(p: A => Boolean): Map[A, B] = new FilteredKeys(p)
+  def filterKeys(p: K => Boolean): Map[K, V] = new FilteredKeys(p)
 
-  protected class MappedValues[C](f: B => C) extends AbstractMap[A, C] with DefaultMap[A, C] {
-    override def foreach[U](g: ((A, C)) => U): Unit = for ((k, v) <- self) g((k, f(v)))
+  protected class MappedValues[W](f: V => W) extends AbstractMap[K, W] with DefaultMap[K, W] {
+    override def foreach[U](g: ((K, W)) => U): Unit = for ((k, v) <- self) g((k, f(v)))
     def iterator = for ((k, v) <- self.iterator) yield (k, f(v))
     override def size = self.size
-    override def contains(key: A) = self.contains(key)
-    def get(key: A) = self.get(key).map(f)
+    override def contains(key: K) = self.contains(key)
+    def get(key: K) = self.get(key).map(f)
   }
 
   /** Transforms this map by applying a function to every retrieved value.
@@ -262,22 +262,22 @@ self =>
    *  @return a map view which maps every key of this map
    *          to `f(this(key))`. The resulting map wraps the original map without copying any elements.
    */
-  def mapValues[C](f: B => C): Map[A, C] = new MappedValues(f)
+  def mapValues[W](f: V => W): Map[K, W] = new MappedValues(f)
 
   // The following 5 operations (updated, two times +, two times ++) should really be
-  // generic, returning This[B]. We need better covariance support to express that though.
+  // generic, returning This[V]. We need better covariance support to express that though.
   // So right now we do the brute force approach of code duplication.
 
   /** Creates a new map obtained by updating this map with a given key/value pair.
    *  @param    key the key
    *  @param    value the value
-   *  @tparam   B1 the type of the added value
+   *  @tparam   V1 the type of the added value
    *  @return   A new map with the new key/value mapping added to this map.
    *
-   *  @usecase  def updated(key: A, value: B): Map[A, B]
+   *  @usecase  def updated(key: K, value: V): Map[K, V]
    *    @inheritdoc
    */
-  def updated [B1 >: B](key: A, value: B1): Map[A, B1] = this + ((key, value))
+  def updated [V1 >: V](key: K, value: V1): Map[K, V1] = this + ((key, value))
 
   /** Adds key/value pairs to this map, returning a new map.
    *
@@ -287,27 +287,27 @@ self =>
    *  @param    kv1 the first key/value pair
    *  @param    kv2 the second key/value pair
    *  @param    kvs the remaining key/value pairs
-   *  @tparam   B1  the type of the added values
+   *  @tparam   V1  the type of the added values
    *  @return   a new map with the given bindings added to this map
    *
-   *  @usecase  def + (kvs: (A, B)*): Map[A, B]
+   *  @usecase  def + (kvs: (K, V)*): Map[K, V]
    *    @inheritdoc
    *    @param    kvs the key/value pairs
    */
-  def + [B1 >: B] (kv1: (A, B1), kv2: (A, B1), kvs: (A, B1) *): Map[A, B1] =
+  def + [V1 >: V] (kv1: (K, V1), kv2: (K, V1), kvs: (K, V1) *): Map[K, V1] =
     this + kv1 + kv2 ++ kvs
 
   /** Adds all key/value pairs in a traversable collection to this map, returning a new map.
    *
    *  @param    xs  the collection containing the added key/value pairs
-   *  @tparam   B1  the type of the added values
+   *  @tparam   V1  the type of the added values
    *  @return   a new map with the given bindings added to this map
    *
-   *  @usecase  def ++ (xs: Traversable[(A, B)]): Map[A, B]
+   *  @usecase  def ++ (xs: Traversable[(K, V)]): Map[K, V]
    *    @inheritdoc
    */
-  def ++[B1 >: B](xs: GenTraversableOnce[(A, B1)]): Map[A, B1] =
-    ((repr: Map[A, B1]) /: xs.seq) (_ + _)
+  def ++[V1 >: V](xs: GenTraversableOnce[(K, V1)]): Map[K, V1] =
+    ((repr: Map[K, V1]) /: xs.seq) (_ + _)
 
   /** Returns a new map obtained by removing all key/value pairs for which the predicate
    *  `p` returns `true`.
@@ -320,31 +320,31 @@ self =>
    *  @param p    A predicate over key-value pairs
    *  @return     A new map containing elements not satisfying the predicate.
    */
-  override def filterNot(p: ((A, B)) => Boolean): This = {
+  override def filterNot(p: ((K, V)) => Boolean): This = {
     var res: This = repr
     for (kv <- this)
       if (p(kv)) res = (res - kv._1).asInstanceOf[This] // !!! concrete overrides abstract problem
     res
   }
 
-  override def toSeq: Seq[(A, B)] = {
-    if (isEmpty) Vector.empty[(A, B)]
+  override def toSeq: Seq[(K, V)] = {
+    if (isEmpty) Vector.empty[(K, V)]
     else {
       // Default appropriate for immutable collections; mutable collections override this
-      val vb = Vector.newBuilder[(A, B)]
+      val vb = Vector.newBuilder[(K, V)]
       foreach(vb += _)
       vb.result
     }
   }
 
-  override def toBuffer[C >: (A, B)]: mutable.Buffer[C] = {
-    val result = new mutable.ArrayBuffer[C](size)
+  override def toBuffer[E >: (K, V)]: mutable.Buffer[E] = {
+    val result = new mutable.ArrayBuffer[E](size)
     // Faster to let the map iterate itself than to defer through copyToBuffer
     foreach(result += _)
     result
   }
 
-  protected[this] override def parCombiner = ParMap.newCombiner[A, B]
+  protected[this] override def parCombiner = ParMap.newCombiner[K, V]
 
   /** Appends all bindings of this map to a string builder using start, end, and separator strings.
    *  The written text begins with the string `start` and ends with the string

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -18,30 +18,30 @@ import generic._
  * functionality for the abstract methods in `Map`:
  *
  * {{{
- *    def get(key: A): Option[B]
- *    def iterator: Iterator[(A, B)]
- *    def + [B1 >: B](kv: (A, B1)): Map[A, B1]
- *    def -(key: A): Map[A, B]
+ *    def get(key: K): Option[V]
+ *    def iterator: Iterator[(K, V)]
+ *    def + [V1 >: V](kv: (K, V1)): Map[K, V1]
+ *    def -(key: K): Map[K, V]
  * }}}
  *
  * @since 1
  */
-trait Map[A, +B] extends Iterable[(A, B)]
-//                    with GenMap[A, B]
-                    with scala.collection.Map[A, B]
-                    with MapLike[A, B, Map[A, B]] { self =>
+trait Map[K, +V] extends Iterable[(K, V)]
+//                    with GenMap[K, V]
+                    with scala.collection.Map[K, V]
+                    with MapLike[K, V, Map[K, V]] { self =>
 
-  override def empty: Map[A, B] = Map.empty
+  override def empty: Map[K, V] = Map.empty
 
   /** Returns this $coll as an immutable map.
    *
    *  A new map will not be built; lazy collections will stay lazy.
    */
   @deprecatedOverriding("Immutable maps should do nothing on toMap except return themselves cast as a map.",  "2.11.0")
-  override def toMap[T, U](implicit ev: (A, B) <:< (T, U)): immutable.Map[T, U] =
+  override def toMap[T, U](implicit ev: (K, V) <:< (T, U)): immutable.Map[T, U] =
     self.asInstanceOf[immutable.Map[T, U]]
 
-  override def seq: Map[A, B] = this
+  override def seq: Map[K, V] = this
 
   /** The same map with a given default function.
    *  Note: `get`, `contains`, `iterator`, `keys`, etc are not affected by `withDefault`.
@@ -51,7 +51,7 @@ trait Map[A, +B] extends Iterable[(A, B)]
    *  @param d     the function mapping keys to values, used for non-present keys
    *  @return      a wrapper of the map with a default value
    */
-  def withDefault[B1 >: B](d: A => B1): immutable.Map[A, B1] = new Map.WithDefault[A, B1](this, d)
+  def withDefault[V1 >: V](d: K => V1): immutable.Map[K, V1] = new Map.WithDefault[K, V1](this, d)
 
   /** The same map with a given default value.
    *  Note: `get`, `contains`, `iterator`, `keys`, etc are not affected by `withDefaultValue`.
@@ -61,15 +61,15 @@ trait Map[A, +B] extends Iterable[(A, B)]
    *  @param d     default value used for non-present keys
    *  @return      a wrapper of the map with a default value
    */
-  def withDefaultValue[B1 >: B](d: B1): immutable.Map[A, B1] = new Map.WithDefault[A, B1](this, x => d)
+  def withDefaultValue[V1 >: V](d: V1): immutable.Map[K, V1] = new Map.WithDefault[K, V1](this, x => d)
 
   /** Add a key/value pair to this map.
    *  @param    key the key
    *  @param    value the value
    *  @return   A new map with the new binding added to this map
    */
-  override def updated [B1 >: B](key: A, value: B1): Map[A, B1]
-  def + [B1 >: B](kv: (A, B1)): Map[A, B1]
+  override def updated [V1 >: V](key: K, value: V1): Map[K, V1]
+  def + [V1 >: V](kv: (K, V1)): Map[K, V1]
 }
 
 /** $factoryInfo
@@ -79,17 +79,17 @@ trait Map[A, +B] extends Iterable[(A, B)]
 object Map extends ImmutableMapFactory[Map] {
 
   /** $mapCanBuildFromInfo */
-  implicit def canBuildFrom[A, B]: CanBuildFrom[Coll, (A, B), Map[A, B]] = new MapCanBuildFrom[A, B]
+  implicit def canBuildFrom[K, V]: CanBuildFrom[Coll, (K, V), Map[K, V]] = new MapCanBuildFrom[K, V]
 
-  def empty[A, B]: Map[A, B] = EmptyMap.asInstanceOf[Map[A, B]]
+  def empty[K, V]: Map[K, V] = EmptyMap.asInstanceOf[Map[K, V]]
 
-  class WithDefault[A, +B](underlying: Map[A, B], d: A => B) extends scala.collection.Map.WithDefault[A, B](underlying, d) with Map[A, B] {
+  class WithDefault[K, +V](underlying: Map[K, V], d: K => V) extends scala.collection.Map.WithDefault[K, V](underlying, d) with Map[K, V] {
     override def empty = new WithDefault(underlying.empty, d)
-    override def updated[B1 >: B](key: A, value: B1): WithDefault[A, B1] = new WithDefault[A, B1](underlying.updated[B1](key, value), d)
-    override def + [B1 >: B](kv: (A, B1)): WithDefault[A, B1] = updated(kv._1, kv._2)
-    override def - (key: A): WithDefault[A, B] = new WithDefault(underlying - key, d)
-    override def withDefault[B1 >: B](d: A => B1): immutable.Map[A, B1] = new WithDefault[A, B1](underlying, d)
-    override def withDefaultValue[B1 >: B](d: B1): immutable.Map[A, B1] = new WithDefault[A, B1](underlying, x => d)
+    override def updated[V1 >: V](key: K, value: V1): WithDefault[K, V1] = new WithDefault[K, V1](underlying.updated[V1](key, value), d)
+    override def + [V1 >: V](kv: (K, V1)): WithDefault[K, V1] = updated(kv._1, kv._2)
+    override def - (key: K): WithDefault[K, V] = new WithDefault(underlying - key, d)
+    override def withDefault[V1 >: V](d: K => V1): immutable.Map[K, V1] = new WithDefault[K, V1](underlying, d)
+    override def withDefaultValue[V1 >: V](d: V1): immutable.Map[K, V1] = new WithDefault[K, V1](underlying, x => d)
   }
 
   private object EmptyMap extends AbstractMap[Any, Nothing] with Map[Any, Nothing] with Serializable {
@@ -98,119 +98,119 @@ object Map extends ImmutableMapFactory[Map] {
     override def contains(key: Any) = false
     def get(key: Any): Option[Nothing] = None
     def iterator: Iterator[(Any, Nothing)] = Iterator.empty
-    override def updated [B1] (key: Any, value: B1): Map[Any, B1] = new Map1(key, value)
-    def + [B1](kv: (Any, B1)): Map[Any, B1] = updated(kv._1, kv._2)
+    override def updated [V1] (key: Any, value: V1): Map[Any, V1] = new Map1(key, value)
+    def + [V1](kv: (Any, V1)): Map[Any, V1] = updated(kv._1, kv._2)
     def - (key: Any): Map[Any, Nothing] = this
   }
 
-  class Map1[A, +B](key1: A, value1: B) extends AbstractMap[A, B] with Map[A, B] with Serializable {
+  class Map1[K, +V](key1: K, value1: V) extends AbstractMap[K, V] with Map[K, V] with Serializable {
     override def size = 1
-    override def apply(key: A) = if (key == key1) value1 else throw new NoSuchElementException("key not found: " + key)
-    override def contains(key: A) = key == key1
-    def get(key: A): Option[B] =
+    override def apply(key: K) = if (key == key1) value1 else throw new NoSuchElementException("key not found: " + key)
+    override def contains(key: K) = key == key1
+    def get(key: K): Option[V] =
       if (key == key1) Some(value1) else None
     def iterator = Iterator((key1, value1))
-    override def updated [B1 >: B] (key: A, value: B1): Map[A, B1] =
+    override def updated [V1 >: V] (key: K, value: V1): Map[K, V1] =
       if (key == key1) new Map1(key1, value)
       else new Map2(key1, value1, key, value)
-    def + [B1 >: B](kv: (A, B1)): Map[A, B1] = updated(kv._1, kv._2)
-    def - (key: A): Map[A, B] =
+    def + [V1 >: V](kv: (K, V1)): Map[K, V1] = updated(kv._1, kv._2)
+    def - (key: K): Map[K, V] =
       if (key == key1) Map.empty else this
-    override def foreach[U](f: ((A, B)) => U): Unit = {
+    override def foreach[U](f: ((K, V)) => U): Unit = {
       f((key1, value1))
     }
   }
 
-  class Map2[A, +B](key1: A, value1: B, key2: A, value2: B) extends AbstractMap[A, B] with Map[A, B] with Serializable {
+  class Map2[K, +V](key1: K, value1: V, key2: K, value2: V) extends AbstractMap[K, V] with Map[K, V] with Serializable {
     override def size = 2
-    override def apply(key: A) =
+    override def apply(key: K) =
       if (key == key1) value1
       else if (key == key2) value2
       else throw new NoSuchElementException("key not found: " + key)
-    override def contains(key: A) = (key == key1) || (key == key2)
-    def get(key: A): Option[B] =
+    override def contains(key: K) = (key == key1) || (key == key2)
+    def get(key: K): Option[V] =
       if (key == key1) Some(value1)
       else if (key == key2) Some(value2)
       else None
     def iterator = Iterator((key1, value1), (key2, value2))
-    override def updated [B1 >: B] (key: A, value: B1): Map[A, B1] =
+    override def updated [V1 >: V] (key: K, value: V1): Map[K, V1] =
       if (key == key1) new Map2(key1, value, key2, value2)
       else if (key == key2) new Map2(key1, value1, key2, value)
       else new Map3(key1, value1, key2, value2, key, value)
-    def + [B1 >: B](kv: (A, B1)): Map[A, B1] = updated(kv._1, kv._2)
-    def - (key: A): Map[A, B] =
+    def + [V1 >: V](kv: (K, V1)): Map[K, V1] = updated(kv._1, kv._2)
+    def - (key: K): Map[K, V] =
       if (key == key1) new Map1(key2, value2)
       else if (key == key2) new Map1(key1, value1)
       else this
-    override def foreach[U](f: ((A, B)) => U): Unit = {
+    override def foreach[U](f: ((K, V)) => U): Unit = {
       f((key1, value1)); f((key2, value2))
     }
   }
 
-  class Map3[A, +B](key1: A, value1: B, key2: A, value2: B, key3: A, value3: B) extends AbstractMap[A, B] with Map[A, B] with Serializable {
+  class Map3[K, +V](key1: K, value1: V, key2: K, value2: V, key3: K, value3: V) extends AbstractMap[K, V] with Map[K, V] with Serializable {
     override def size = 3
-    override def apply(key: A) =
+    override def apply(key: K) =
       if (key == key1) value1
       else if (key == key2) value2
       else if (key == key3) value3
       else throw new NoSuchElementException("key not found: " + key)
-    override def contains(key: A) = (key == key1) || (key == key2) || (key == key3)
-    def get(key: A): Option[B] =
+    override def contains(key: K) = (key == key1) || (key == key2) || (key == key3)
+    def get(key: K): Option[V] =
       if (key == key1) Some(value1)
       else if (key == key2) Some(value2)
       else if (key == key3) Some(value3)
       else None
     def iterator = Iterator((key1, value1), (key2, value2), (key3, value3))
-    override def updated [B1 >: B] (key: A, value: B1): Map[A, B1] =
+    override def updated [V1 >: V] (key: K, value: V1): Map[K, V1] =
       if (key == key1)      new Map3(key1, value, key2, value2, key3, value3)
       else if (key == key2) new Map3(key1, value1, key2, value, key3, value3)
       else if (key == key3) new Map3(key1, value1, key2, value2, key3, value)
       else new Map4(key1, value1, key2, value2, key3, value3, key, value)
-    def + [B1 >: B](kv: (A, B1)): Map[A, B1] = updated(kv._1, kv._2)
-    def - (key: A): Map[A, B] =
+    def + [V1 >: V](kv: (K, V1)): Map[K, V1] = updated(kv._1, kv._2)
+    def - (key: K): Map[K, V] =
       if (key == key1)      new Map2(key2, value2, key3, value3)
       else if (key == key2) new Map2(key1, value1, key3, value3)
       else if (key == key3) new Map2(key1, value1, key2, value2)
       else this
-    override def foreach[U](f: ((A, B)) => U): Unit = {
+    override def foreach[U](f: ((K, V)) => U): Unit = {
       f((key1, value1)); f((key2, value2)); f((key3, value3))
     }
   }
 
-  class Map4[A, +B](key1: A, value1: B, key2: A, value2: B, key3: A, value3: B, key4: A, value4: B) extends AbstractMap[A, B] with Map[A, B] with Serializable {
+  class Map4[K, +V](key1: K, value1: V, key2: K, value2: V, key3: K, value3: V, key4: K, value4: V) extends AbstractMap[K, V] with Map[K, V] with Serializable {
     override def size = 4
-    override def apply(key: A) =
+    override def apply(key: K) =
       if (key == key1) value1
       else if (key == key2) value2
       else if (key == key3) value3
       else if (key == key4) value4
       else throw new NoSuchElementException("key not found: " + key)
-    override def contains(key: A) = (key == key1) || (key == key2) || (key == key3) || (key == key4)
-    def get(key: A): Option[B] =
+    override def contains(key: K) = (key == key1) || (key == key2) || (key == key3) || (key == key4)
+    def get(key: K): Option[V] =
       if (key == key1) Some(value1)
       else if (key == key2) Some(value2)
       else if (key == key3) Some(value3)
       else if (key == key4) Some(value4)
       else None
     def iterator = Iterator((key1, value1), (key2, value2), (key3, value3), (key4, value4))
-    override def updated [B1 >: B] (key: A, value: B1): Map[A, B1] =
+    override def updated [V1 >: V] (key: K, value: V1): Map[K, V1] =
       if (key == key1)      new Map4(key1, value, key2, value2, key3, value3, key4, value4)
       else if (key == key2) new Map4(key1, value1, key2, value, key3, value3, key4, value4)
       else if (key == key3) new Map4(key1, value1, key2, value2, key3, value, key4, value4)
       else if (key == key4) new Map4(key1, value1, key2, value2, key3, value3, key4, value)
       else new HashMap + ((key1, value1), (key2, value2), (key3, value3), (key4, value4), (key, value))
-    def + [B1 >: B](kv: (A, B1)): Map[A, B1] = updated(kv._1, kv._2)
-    def - (key: A): Map[A, B] =
+    def + [V1 >: V](kv: (K, V1)): Map[K, V1] = updated(kv._1, kv._2)
+    def - (key: K): Map[K, V] =
       if (key == key1)      new Map3(key2, value2, key3, value3, key4, value4)
       else if (key == key2) new Map3(key1, value1, key3, value3, key4, value4)
       else if (key == key3) new Map3(key1, value1, key2, value2, key4, value4)
       else if (key == key4) new Map3(key1, value1, key2, value2, key3, value3)
       else this
-    override def foreach[U](f: ((A, B)) => U): Unit = {
+    override def foreach[U](f: ((K, V)) => U): Unit = {
       f((key1, value1)); f((key2, value2)); f((key3, value3)); f((key4, value4))
     }
   }
 }
 
 /** Explicit instantiation of the `Map` trait to reduce class file size in subclasses. */
-abstract class AbstractMap[A, +B] extends scala.collection.AbstractMap[A, B] with Map[A, B]
+abstract class AbstractMap[K, +V] extends scala.collection.AbstractMap[K, V] with Map[K, V]

--- a/src/library/scala/collection/immutable/MapLike.scala
+++ b/src/library/scala/collection/immutable/MapLike.scala
@@ -14,16 +14,16 @@ import generic._
 import parallel.immutable.ParMap
 
 /**
- *  A generic template for immutable maps from keys of type `A`
- *  to values of type `B`.
+ *  A generic template for immutable maps from keys of type `K`
+ *  to values of type `V`.
  *  To implement a concrete map, you need to provide implementations of the
  *  following methods (where `This` is the type of the actual map implementation):
  *
  *  {{{
- *    def get(key: A): Option[B]
- *    def iterator: Iterator[(A, B)]
- *    def + [B1 >: B](kv: (A, B)): Map[A, B1]
- *    def - (key: A): This
+ *    def get(key: K): Option[V]
+ *    def iterator: Iterator[(K, V)]
+ *    def + [V1 >: V](kv: (K, V)): Map[K, V1]
+ *    def - (key: K): This
  *  }}}
  *
  *  If you wish that transformer methods like `take`, `drop`, `filter` return the
@@ -36,8 +36,8 @@ import parallel.immutable.ParMap
  *  It is also good idea to override methods `foreach` and
  *  `size` for efficiency.
  *
- *  @tparam A     the type of the keys contained in this collection.
- *  @tparam B     the type of the values associated with the keys.
+ *  @tparam K     the type of the keys contained in this collection.
+ *  @tparam V     the type of the values associated with the keys.
  *  @tparam This  The type of the actual map implementation.
  *
  *  @author  Martin Odersky
@@ -46,26 +46,26 @@ import parallel.immutable.ParMap
  *  @define Coll immutable.Map
  *  @define coll immutable map
  */
-trait MapLike[A, +B, +This <: MapLike[A, B, This] with Map[A, B]]
-  extends scala.collection.MapLike[A, B, This]
-     with Parallelizable[(A, B), ParMap[A, B]]
+trait MapLike[K, +V, +This <: MapLike[K, V, This] with Map[K, V]]
+  extends scala.collection.MapLike[K, V, This]
+     with Parallelizable[(K, V), ParMap[K, V]]
 {
 self =>
 
-  protected[this] override def parCombiner = ParMap.newCombiner[A, B]
+  protected[this] override def parCombiner = ParMap.newCombiner[K, V]
 
   /** A new immutable map containing updating this map with a given key/value mapping.
    *  @param    key the key
    *  @param    value the value
    *  @return   A new map with the new key/value mapping
    */
-  override def updated [B1 >: B](key: A, value: B1): immutable.Map[A, B1] = this + ((key, value))
+  override def updated [V1 >: V](key: K, value: V1): immutable.Map[K, V1] = this + ((key, value))
 
   /** Add a key/value pair to this map, returning a new map.
    *  @param    kv the key/value pair.
    *  @return   A new map with the new binding added to this map.
    */
-  def + [B1 >: B] (kv: (A, B1)): immutable.Map[A, B1]
+  def + [V1 >: V] (kv: (K, V1)): immutable.Map[K, V1]
 
   /** Adds two or more elements to this collection and returns
    *  a new collection.
@@ -75,7 +75,7 @@ self =>
    *  @param elems the remaining elements to add.
    *  @return A new map with the new bindings added to this map.
    */
-  override def + [B1 >: B] (elem1: (A, B1), elem2: (A, B1), elems: (A, B1) *): immutable.Map[A, B1] =
+  override def + [V1 >: V] (elem1: (K, V1), elem2: (K, V1), elems: (K, V1) *): immutable.Map[K, V1] =
     this + elem1 + elem2 ++ elems
 
   /** Adds a number of elements provided by a traversable object
@@ -84,40 +84,40 @@ self =>
    *  @param xs      the traversable object consisting of key-value pairs.
    *  @return        a new immutable map with the bindings of this map and those from `xs`.
    */
-  override def ++[B1 >: B](xs: GenTraversableOnce[(A, B1)]): immutable.Map[A, B1] =
-    ((repr: immutable.Map[A, B1]) /: xs.seq) (_ + _)
+  override def ++[V1 >: V](xs: GenTraversableOnce[(K, V1)]): immutable.Map[K, V1] =
+    ((repr: immutable.Map[K, V1]) /: xs.seq) (_ + _)
 
   /** Filters this map by retaining only keys satisfying a predicate.
    *  @param  p   the predicate used to test keys
    *  @return an immutable map consisting only of those key value pairs of this map where the key satisfies
    *          the predicate `p`. The resulting map wraps the original map without copying any elements.
    */
-  override def filterKeys(p: A => Boolean): Map[A, B] = new FilteredKeys(p) with DefaultMap[A, B]
+  override def filterKeys(p: K => Boolean): Map[K, V] = new FilteredKeys(p) with DefaultMap[K, V]
 
   /** Transforms this map by applying a function to every retrieved value.
    *  @param  f   the function used to transform values of this map.
    *  @return a map view which maps every key of this map
    *          to `f(this(key))`. The resulting map wraps the original map without copying any elements.
    */
-  override def mapValues[C](f: B => C): Map[A, C] = new MappedValues(f) with DefaultMap[A, C]
+  override def mapValues[W](f: V => W): Map[K, W] = new MappedValues(f) with DefaultMap[K, W]
 
   /** Collects all keys of this map in a set.
    *  @return  a set containing all keys of this map.
    */
-  override def keySet: immutable.Set[A] = new ImmutableDefaultKeySet
+  override def keySet: immutable.Set[K] = new ImmutableDefaultKeySet
 
-  protected class ImmutableDefaultKeySet extends super.DefaultKeySet with immutable.Set[A] {
-    override def + (elem: A): immutable.Set[A] =
+  protected class ImmutableDefaultKeySet extends super.DefaultKeySet with immutable.Set[K] {
+    override def + (elem: K): immutable.Set[K] =
       if (this(elem)) this
-      else immutable.Set[A]() ++ this + elem
-    override def - (elem: A): immutable.Set[A] =
-      if (this(elem)) immutable.Set[A]() ++ this - elem
+      else immutable.Set[K]() ++ this + elem
+    override def - (elem: K): immutable.Set[K] =
+      if (this(elem)) immutable.Set[K]() ++ this - elem
       else this
       
     // ImmutableDefaultKeySet is only protected, so we won't warn on override.
     // Someone could override in a way that makes widening not okay
     // (e.g. by overriding +, though the version in this class is fine)
-    override def toSet[B >: A]: Set[B] = this.asInstanceOf[Set[B]]
+    override def toSet[B >: K]: Set[B] = this.asInstanceOf[Set[B]]
   }
 
   /** This function transforms all the values of mappings contained
@@ -126,10 +126,9 @@ self =>
    *  @param f A function over keys and values
    *  @return  the updated map
    */
-  def transform[C, That](f: (A, B) => C)(implicit bf: CanBuildFrom[This, (A, C), That]): That = {
+  def transform[W, That](f: (K, V) => W)(implicit bf: CanBuildFrom[This, (K, W), That]): That = {
     val b = bf(repr)
     for ((key, value) <- this) b += ((key, f(key, value)))
     b.result()
   }
 }
-

--- a/src/library/scala/collection/mutable/Map.scala
+++ b/src/library/scala/collection/mutable/Map.scala
@@ -20,15 +20,15 @@ import generic._
  *  @since 1.0
  *  @author  Matthias Zenger
  */
-trait Map[A, B]
-  extends Iterable[(A, B)]
-//     with GenMap[A, B]
-     with scala.collection.Map[A, B]
-     with MapLike[A, B, Map[A, B]] {
+trait Map[K, V]
+  extends Iterable[(K, V)]
+//     with GenMap[K, V]
+     with scala.collection.Map[K, V]
+     with MapLike[K, V, Map[K, V]] {
 
-  override def empty: Map[A, B] = Map.empty
+  override def empty: Map[K, V] = Map.empty
 
-  override def seq: Map[A, B] = this
+  override def seq: Map[K, V] = this
 
   /** The same map with a given default function.
    *
@@ -37,7 +37,7 @@ trait Map[A, B]
    *  @param d     the function mapping keys to values, used for non-present keys
    *  @return      a wrapper of the map with a default value
    */
-  def withDefault(d: A => B): mutable.Map[A, B] = new Map.WithDefault[A, B](this, d)
+  def withDefault(d: K => V): mutable.Map[K, V] = new Map.WithDefault[K, V](this, d)
 
   /** The same map with a given default value.
    *
@@ -46,7 +46,7 @@ trait Map[A, B]
    *  @param d     default value used for non-present keys
    *  @return      a wrapper of the map with a default value
    */
-  def withDefaultValue(d: B): mutable.Map[A, B] = new Map.WithDefault[A, B](this, x => d)
+  def withDefaultValue(d: V): mutable.Map[K, V] = new Map.WithDefault[K, V](this, x => d)
 }
 
 /** $factoryInfo
@@ -56,25 +56,25 @@ trait Map[A, B]
  */
 object Map extends MutableMapFactory[Map] {
   /** $canBuildFromInfo */
-  implicit def canBuildFrom[A, B]: CanBuildFrom[Coll, (A, B), Map[A, B]] = new MapCanBuildFrom[A, B]
+  implicit def canBuildFrom[K, V]: CanBuildFrom[Coll, (K, V), Map[K, V]] = new MapCanBuildFrom[K, V]
 
-  def empty[A, B]: Map[A, B] = new HashMap[A, B]
+  def empty[K, V]: Map[K, V] = new HashMap[K, V]
 
-  class WithDefault[A, B](underlying: Map[A, B], d: A => B) extends scala.collection.Map.WithDefault(underlying, d) with Map[A, B] {
-    override def += (kv: (A, B)) = {underlying += kv; this}
-    def -= (key: A) = {underlying -= key; this}
+  class WithDefault[K, V](underlying: Map[K, V], d: K => V) extends scala.collection.Map.WithDefault(underlying, d) with Map[K, V] {
+    override def += (kv: (K, V)) = {underlying += kv; this}
+    def -= (key: K) = {underlying -= key; this}
     override def empty = new WithDefault(underlying.empty, d)
-    override def updated[B1 >: B](key: A, value: B1): WithDefault[A, B1] = new WithDefault[A, B1](underlying.updated[B1](key, value), d)
-    override def + [B1 >: B](kv: (A, B1)): WithDefault[A, B1] = updated(kv._1, kv._2)
-    override def - (key: A): WithDefault[A, B] = new WithDefault(underlying - key, d)
+    override def updated[V1 >: V](key: K, value: V1): WithDefault[K, V1] = new WithDefault[K, V1](underlying.updated[V1](key, value), d)
+    override def + [V1 >: V](kv: (K, V1)): WithDefault[K, V1] = updated(kv._1, kv._2)
+    override def - (key: K): WithDefault[K, V] = new WithDefault(underlying - key, d)
 
     /** If these methods aren't overridden to thread through the underlying map,
      *  successive calls to withDefault* have no effect.
      */
-    override def withDefault(d: A => B): mutable.Map[A, B] = new WithDefault[A, B](underlying, d)
-    override def withDefaultValue(d: B): mutable.Map[A, B] = new WithDefault[A, B](underlying, x => d)
+    override def withDefault(d: K => V): mutable.Map[K, V] = new WithDefault[K, V](underlying, d)
+    override def withDefaultValue(d: V): mutable.Map[K, V] = new WithDefault[K, V](underlying, x => d)
   }
 }
 
 /** Explicit instantiation of the `Map` trait to reduce class file size in subclasses. */
-abstract class AbstractMap[A, B] extends scala.collection.AbstractMap[A, B] with Map[A, B]
+abstract class AbstractMap[K, V] extends scala.collection.AbstractMap[K, V] with Map[K, V]

--- a/test/files/run/xMigration.check
+++ b/test/files/run/xMigration.check
@@ -11,7 +11,7 @@ scala> :setting -Xmigration:any
 
 scala> Map(1 -> "eis").values    // warn
 <console>:12: warning: method values in trait MapLike has changed semantics in version 2.8.0:
-`values` returns `Iterable[B]` rather than `Iterator[B]`.
+`values` returns `Iterable[V]` rather than `Iterator[V]`.
        Map(1 -> "eis").values    // warn
                        ^
 res2: Iterable[String] = MapLike(eis)
@@ -25,7 +25,7 @@ scala> :setting -Xmigration:2.7
 
 scala> Map(1 -> "eis").values    // warn
 <console>:12: warning: method values in trait MapLike has changed semantics in version 2.8.0:
-`values` returns `Iterable[B]` rather than `Iterator[B]`.
+`values` returns `Iterable[V]` rather than `Iterator[V]`.
        Map(1 -> "eis").values    // warn
                        ^
 res4: Iterable[String] = MapLike(eis)
@@ -39,7 +39,7 @@ scala> :setting -Xmigration      // same as :any
 
 scala> Map(1 -> "eis").values    // warn
 <console>:12: warning: method values in trait MapLike has changed semantics in version 2.8.0:
-`values` returns `Iterable[B]` rather than `Iterator[B]`.
+`values` returns `Iterable[V]` rather than `Iterator[V]`.
        Map(1 -> "eis").values    // warn
                        ^
 res6: Iterable[String] = MapLike(eis)


### PR DESCRIPTION
Type parameter names are currently assigned pretty much alphabetically
without any meaning. This change renames all key parameters in Map
classes from `A` to `K` and all value parameters from `B` to `V` to
make them more meaningful. Derived names are renamed accordingly (e.g.
`V1` instead of `B1` for an upper bound on `V`, `W` instead of `C` for
a new value type).

As a side-effect this solves the documentation problem in SI-6947. Due
to using `B` both as a type parameter for `foldLeft[B]` in
`GenTraversableOnce[A]` and in `Map[A, B]` which extends
`GenTraversableOnce[(A, B)]`, the signature of `Map.foldLeft` was
rendered in scaladoc as

```
def foldLeft[B](z: B)(op: (B, (A, B)) ⇒ B): B 
```

Now you get an unambiguous version:

```
def foldLeft[B](z: B)(op: (B, (K, V)) ⇒ B): B
```
