### PR TITLE
SI-8829 Defaultly scala -feature -deprecation

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -43,19 +43,19 @@ trait Reporting extends scala.reflect.internal.Reporting { self: ast.Positions w
             else sinceAndAmount += ((since, 1))
           }
           val deprecationSummary = sinceAndAmount.size > 1
-          sinceAndAmount.foreach { case (since, amount) =>
-            val numWarnings   = amount
+          sinceAndAmount.foreach { case (since, numWarnings) =>
             val warningsSince = if (since.nonEmpty) s" (since $since)" else ""
             val warningVerb   = if (numWarnings == 1) "was" else "were"
             val warningCount  = countElementsAsString(numWarnings, s"$what warning")
-            val rerun         = if (deprecationSummary) "" else s"; re-run with ${setting.name} for details"
-            reporter.warning(NoPosition, s"there $warningVerb $warningCount$warningsSince$rerun")
+            val rerun         = if (deprecationSummary) "" else reporter.rerunWithDetails(setting, setting.name)
+            reporter.warning(NoPosition, s"there ${warningVerb} ${warningCount}${warningsSince}${rerun}")
           }
           if (deprecationSummary) {
             val numWarnings   = warnings.size
             val warningVerb   = if (numWarnings == 1) "was" else "were"
             val warningCount  = countElementsAsString(numWarnings, s"$what warning")
-            reporter.warning(NoPosition, s"there $warningVerb $warningCount in total; re-run with ${setting.name} for details")
+            val rerun         = reporter.rerunWithDetails(setting, setting.name)
+            reporter.warning(NoPosition, s"there ${warningVerb} ${warningCount} in total${rerun}")
           }
         }
     }

--- a/src/reflect/scala/reflect/internal/Reporting.scala
+++ b/src/reflect/scala/reflect/internal/Reporting.scala
@@ -7,6 +7,8 @@ package scala
 package reflect
 package internal
 
+import settings.MutableSettings
+
 /** Provides delegates to the reporter doing the actual work.
  *  All forwarding methods should be marked final,
  *  but some subclasses out of our reach still override them.
@@ -105,6 +107,13 @@ abstract class Reporter {
 
   /** Finish reporting: print summaries, release resources. */
   def finish(): Unit = ()
+
+  /** After reporting, offer advice on getting more details. */
+  def rerunWithDetails(setting: MutableSettings#Setting, name: String): String =
+    setting.value match {
+      case b: Boolean if !b => s"; re-run with ${name} for details"
+      case _ => s"; re-run enabling ${name} for details, or try -help"
+    }
 }
 
 // TODO: move into superclass once partest cuts tie on Severity

--- a/src/repl/scala/tools/nsc/MainGenericRunner.scala
+++ b/src/repl/scala/tools/nsc/MainGenericRunner.scala
@@ -71,6 +71,11 @@ class MainGenericRunner {
           Right(false)
         case _  =>
           // We start the repl when no arguments are given.
+          // If user is agnostic about both -feature and -deprecation, turn them on.
+          if (settings.deprecation.isDefault && settings.feature.isDefault) {
+            settings.deprecation.value = true
+            settings.feature.value = true
+          }
           Right(new interpreter.ILoop process settings)
       }
 

--- a/src/repl/scala/tools/nsc/interpreter/ReplReporter.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplReporter.scala
@@ -68,4 +68,7 @@ class ReplReporter(intp: IMain) extends ConsoleReporter(intp.settings, Console.i
     else super.displayPrompt()
   }
 
+  override def rerunWithDetails(setting: reflect.internal.settings.MutableSettings#Setting, name: String) =
+    s"; for details, enable `:setting $name' or `:replay $name'"
+
 }

--- a/test/files/jvm/interpreter.check
+++ b/test/files/jvm/interpreter.check
@@ -93,7 +93,7 @@ scala> case class Bar(n: Int)
 defined class Bar
 
 scala> implicit def foo2bar(foo: Foo) = Bar(foo.n)
-warning: there was one feature warning; re-run with -feature for details
+warning: there was one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 foo2bar: (foo: Foo)Bar
 
 scala> val bar: Bar = Foo(3)
@@ -267,7 +267,7 @@ scala> xs map (x => x)
 res6: Array[_] = Array(1, 2)
 
 scala> xs map (x => (x, x))
-warning: there was one feature warning; re-run with -feature for details
+warning: there was one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 res7: Array[(_$1, _$1)] forSome { type _$1 } = Array((1,1), (2,2))
 
 scala> 

--- a/test/files/run/constrained-types.check
+++ b/test/files/run/constrained-types.check
@@ -69,11 +69,11 @@ scala> var four = "four"
 four: String = four
 
 scala> val four2 = m(four) // should have an existential bound
-warning: there was one feature warning; re-run with -feature for details
+warning: there was one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 four2: String @Annot(x) forSome { val x: String } = four
 
 scala> val four3 = four2   // should have the same type as four2
-warning: there was one feature warning; re-run with -feature for details
+warning: there was one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 four3: String @Annot(x) forSome { val x: String } = four
 
 scala> val stuff = m("stuff") // should not crash
@@ -96,7 +96,7 @@ scala> def m = {
   val y : String @Annot(x) = x
   y
 } // x should not escape the local scope with a narrow type
-warning: there was one feature warning; re-run with -feature for details
+warning: there was one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 m: String @Annot(x) forSome { val x: String }
 
 scala> 
@@ -110,7 +110,7 @@ scala> def n(y: String) = {
   }
   m("stuff".stripMargin)
 } // x should be existentially bound
-warning: there was one feature warning; re-run with -feature for details
+warning: there was one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 n: (y: String)String @Annot(x) forSome { val x: String }
 
 scala> 

--- a/test/files/run/iterator-from.scala
+++ b/test/files/run/iterator-from.scala
@@ -1,5 +1,5 @@
 /* This file tests iteratorFrom, keysIteratorFrom, and valueIteratorFrom on various sorted sets and maps
- * filter: inliner warnings; re-run with
+ * filter: inliner warnings
  */
 
 import scala.util.{Random => R}

--- a/test/files/run/reflection-magicsymbols-repl.check
+++ b/test/files/run/reflection-magicsymbols-repl.check
@@ -19,7 +19,7 @@ scala> def test(n: Int): Unit = {
   val x = sig.asInstanceOf[MethodType].params.head
   println(x.info)
 }
-warning: there was one feature warning; re-run with -feature for details
+warning: there was one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 test: (n: Int)Unit
 
 scala> for (i <- 1 to 8) test(i)

--- a/test/files/run/repl-no-imports-no-predef-power.check
+++ b/test/files/run/repl-no-imports-no-predef-power.check
@@ -7,11 +7,11 @@ Try :help or completions for vals._ and power._
 scala> // guarding against "error: reference to global is ambiguous"
 
 scala> global.emptyValDef  // "it is imported twice in the same scope by ..."
-warning: there was one deprecation warning (since 2.11.0); re-run with -deprecation for details
+warning: there was one deprecation warning (since 2.11.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res0: $r.global.noSelfType.type = private val _ = _
 
 scala> val tp = ArrayClass[scala.util.Random]    // magic with tags
-warning: there was one feature warning; re-run with -feature for details
+warning: there was one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 tp: $r.global.Type = Array[scala.util.Random]
 
 scala> tp.memberType(Array_apply)                // evidence

--- a/test/files/run/repl-power.check
+++ b/test/files/run/repl-power.check
@@ -7,11 +7,11 @@ Try :help or completions for vals._ and power._
 scala> // guarding against "error: reference to global is ambiguous"
 
 scala> global.emptyValDef  // "it is imported twice in the same scope by ..."
-warning: there was one deprecation warning (since 2.11.0); re-run with -deprecation for details
+warning: there was one deprecation warning (since 2.11.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res0: $r.global.noSelfType.type = private val _ = _
 
 scala> val tp = ArrayClass[scala.util.Random]    // magic with tags
-warning: there was one feature warning; re-run with -feature for details
+warning: there was one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 tp: $r.global.Type = Array[scala.util.Random]
 
 scala> tp.memberType(Array_apply)                // evidence

--- a/test/files/run/synchronized.scala
+++ b/test/files/run/synchronized.scala
@@ -1,5 +1,5 @@
 /*
- * filter: inliner warnings; re-run with
+ * filter: inliner warnings;
  */
 import java.lang.Thread.holdsLock
 import scala.collection.mutable.StringBuilder

--- a/test/files/run/t4172.check
+++ b/test/files/run/t4172.check
@@ -1,6 +1,6 @@
 
 scala> val c = { class C { override def toString = "C" }; ((new C, new C { def f = 2 })) }
-warning: there was one feature warning; re-run with -feature for details
+warning: there was one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 c: (C, C{def f: Int}) forSome { type C <: AnyRef } = (C,C)
 
 scala> :quit

--- a/test/files/run/t4594-repl-settings.scala
+++ b/test/files/run/t4594-repl-settings.scala
@@ -9,7 +9,7 @@ object Test extends SessionTest {
    |depp: String
    |
    |scala> def a = depp
-   |warning: there was one deprecation warning (since Time began.); re-run with -deprecation for details
+   |warning: there was one deprecation warning (since Time began.); for details, enable `:setting -deprecation' or `:replay -deprecation'
    |a: String
    |
    |scala> :settings -deprecation

--- a/test/files/run/t4710.check
+++ b/test/files/run/t4710.check
@@ -1,6 +1,6 @@
 
 scala> def method : String = { implicit def f(s: Symbol) = "" ; 'symbol }
-warning: there was one feature warning; re-run with -feature for details
+warning: there was one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 method: String
 
 scala> :quit

--- a/test/files/run/t6329_repl.check
+++ b/test/files/run/t6329_repl.check
@@ -3,28 +3,28 @@ scala> import scala.reflect.classTag
 import scala.reflect.classTag
 
 scala> classManifest[scala.List[_]]
-warning: there was one deprecation warning (since 2.10.0); re-run with -deprecation for details
+warning: there was one deprecation warning (since 2.10.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res0: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List[<?>]
 
 scala> classTag[scala.List[_]]
 res1: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List
 
 scala> classManifest[scala.collection.immutable.List[_]]
-warning: there was one deprecation warning (since 2.10.0); re-run with -deprecation for details
+warning: there was one deprecation warning (since 2.10.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res2: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List[<?>]
 
 scala> classTag[scala.collection.immutable.List[_]]
 res3: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List
 
 scala> classManifest[Predef.Set[_]]
-warning: there was one deprecation warning (since 2.10.0); re-run with -deprecation for details
+warning: there was one deprecation warning (since 2.10.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res4: scala.reflect.ClassTag[scala.collection.immutable.Set[_]] = scala.collection.immutable.Set[<?>]
 
 scala> classTag[Predef.Set[_]]
 res5: scala.reflect.ClassTag[scala.collection.immutable.Set[_]] = scala.collection.immutable.Set
 
 scala> classManifest[scala.collection.immutable.Set[_]]
-warning: there was one deprecation warning (since 2.10.0); re-run with -deprecation for details
+warning: there was one deprecation warning (since 2.10.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res6: scala.reflect.ClassTag[scala.collection.immutable.Set[_]] = scala.collection.immutable.Set[<?>]
 
 scala> classTag[scala.collection.immutable.Set[_]]

--- a/test/files/run/t6329_repl_bug.check
+++ b/test/files/run/t6329_repl_bug.check
@@ -6,7 +6,7 @@ scala> import scala.reflect.runtime._
 import scala.reflect.runtime._
 
 scala> classManifest[List[_]]
-warning: there was one deprecation warning (since 2.10.0); re-run with -deprecation for details
+warning: there was one deprecation warning (since 2.10.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res0: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List[<?>]
 
 scala> scala.reflect.classTag[List[_]]

--- a/test/files/run/t7319.check
+++ b/test/files/run/t7319.check
@@ -3,15 +3,15 @@ scala> class M[A]
 defined class M
 
 scala> implicit def ma0[A](a: A): M[A] = null
-warning: there was one feature warning; re-run with -feature for details
+warning: there was one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 ma0: [A](a: A)M[A]
 
 scala> implicit def ma1[A](a: A): M[A] = null
-warning: there was one feature warning; re-run with -feature for details
+warning: there was one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 ma1: [A](a: A)M[A]
 
 scala> def convert[F[X <: F[X]]](builder: F[_ <: F[_]]) = 0
-warning: there was one feature warning; re-run with -feature for details
+warning: there was one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 convert: [F[X <: F[X]]](builder: F[_ <: F[_]])Int
 
 scala> convert(Some[Int](0))


### PR DESCRIPTION
Turn on `-feature -deprecation` in REPL if neither option
is selected.

```
$ ./build/pack/bin/scala
Welcome to Scala 2.12.0-20160707-105953-4e564ef (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_92).
Type in expressions for evaluation. Or try :help.

scala> @deprecated("","") def f = 42
f: Int

scala> f toDouble
<console>:13: warning: postfix operator toDouble should be enabled
by making the implicit value scala.language.postfixOps visible.
This can be achieved by adding the import clause 'import scala.language.postfixOps'
or by setting the compiler option -language:postfixOps.
See the Scaladoc for value scala.language.postfixOps for a discussion
why the feature should be explicitly enabled.
       f toDouble
         ^
<console>:13: warning: method f is deprecated:
       f toDouble
       ^
res1: Double = 42.0

scala> :quit
$ scala
Welcome to Scala 2.11.8 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_92).
Type in expressions for evaluation. Or try :help.

scala> @deprecated("","") def f = 42
f: Int

scala> f toDouble
warning: there was one deprecation warning; re-run with -deprecation for details
warning: there was one feature warning; re-run with -feature for details
res1: Double = 42.0

```
