### PR TITLE
SI-9855 Fix regression in extractor pattern translation

### DIFF
--- a/test/files/pos/t9855.scala
+++ b/test/files/pos/t9855.scala
@@ -1,0 +1,10 @@
+class C {
+	def xx(verb: String, a: Array[Int]) {
+	  val reYYYY = """(\d\d\d\d)""".r
+	  verb match {
+	    case "time" if a.isEmpty =>
+	    case "time"              =>
+	    case reYYYY(y)           =>
+	  }
+	}
+}

--- a/test/files/pos/t9855b.scala
+++ b/test/files/pos/t9855b.scala
@@ -1,0 +1,16 @@
+object Test {
+  var FALSE = false
+  def main(args: Array[String]): Unit = {
+    val SomeB = new B
+    new B() match {
+      case SomeB if FALSE =>
+      case SomeB =>
+      case Ext(_) =>
+    }
+  }
+}
+object Ext {
+  def unapply(s: A) = Some(())
+}
+class A
+class B extends A

--- a/test/files/run/t6288.check
+++ b/test/files/run/t6288.check
@@ -7,7 +7,7 @@
     };
     [21]def unapply([29]z: [32]<type: [32]scala.Any>): [21]Option[Int] = [56][52][52]scala.Some.apply[[52]Int]([58]-1);
     [64]{
-      [64]case <synthetic> val x1: [64]Any = [64]"";
+      [64]case <synthetic> val x1: [64]String = [64]"";
       [64]case5()[84]{
         [84]<synthetic> val o7: [84]Option[Int] = [84][84]Case3.unapply([84]x1);
         [84]if ([84]o7.isEmpty.unary_!)
@@ -30,7 +30,7 @@
     };
     [127]def unapplySeq([138]z: [141]<type: [141]scala.Any>): [127]Option[List[Int]] = [167]scala.None;
     [175]{
-      [175]case <synthetic> val x1: [175]Any = [175]"";
+      [175]case <synthetic> val x1: [175]String = [175]"";
       [175]case5()[195]{
         [195]<synthetic> val o7: [195]Option[List[Int]] = [195][195]Case4.unapplySeq([195]x1);
         [195]if ([195][195]o7.isEmpty.unary_!.&&([195][195][195][195]o7.get.!=([195]null).&&([195][195][195][195]o7.get.lengthCompare([195]1).==([195]0))))
@@ -53,7 +53,7 @@
     };
     [238]def unapply([246]z: [249]<type: [249]scala.Any>): [238]Boolean = [265]true;
     [273]{
-      [273]case <synthetic> val x1: [273]Any = [273]"";
+      [273]case <synthetic> val x1: [273]String = [273]"";
       [273]case5()[293]{
         [293]<synthetic> val o7: [293]Option[List[Int]] = [293][293]Case4.unapplySeq([293]x1);
         [293]if ([293][293]o7.isEmpty.unary_!.&&([293][293][293][293]o7.get.!=([293]null).&&([293][293][293][293]o7.get.lengthCompare([293]0).==([293]0))))


### PR DESCRIPTION
In faa5ae6, I changed the pattern matchers code generator to
use stable references (`Ident`-s with the singleton type, rather
than the widened type) to the synthetic vals used to store
intermediate results ("binders").

In the case where the scrutinee matched the unapply parameter
type of some extractor pattern, but the pattern subsequently
failed, this led to an regression.

It turns out that this was due to the way that the type of
the binder was mutated to upcast to the exact type of a subsequent
pattern in `ensureConformsTo`:

   https://github.com/scala/scala/blob/953559988/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala#L165-L174

This was added in 32c57329a as a workaround for the problem caused
in t6664.scala, when the binder type was `KList with KCons`, and
the code generator wasn't able to find the case field accessors
for `KCons` in the decls.

The change to use stable references meant that this mutation was
now observed in another part of the tree, as opposed to the 2.11.8
situation, where we had used the original, sharper type of the binder
eagerly to assign to the `Ident` that referred to it. This led to
a tree:

```
Assign(Ident(x3), Ident(x1).setType(x1.tpe)
```

Now that we instead refer generate:

```
Assign(Ident(x3), Ident(x1).setType(stableTypeFor(x1))
```

and we don't typecheck this until after the mutation of `x1.symbol.info`,
we can get a type error.

This commit removes this mutation of the binder type altogether, and
instead uses `aligner.wholeType`, which is based on the result type of
the `Apply(TypeTree(MethodType(params, resultType))` that encodes a
typechecked constructor pattern. In `t6624.scala`, this is `KCons`,
the case class that has the extractors as its decls.
