### PR TITLE
SI-9691 BufferedIterator should expose an headOption

### DIFF
--- a/src/library/scala/collection/BufferedIterator.scala
+++ b/src/library/scala/collection/BufferedIterator.scala
@@ -24,10 +24,7 @@ trait BufferedIterator[+A] extends Iterator[A] {
    */
   def head: A
 
-  def headOption : Option[A] = {
-    if (this.nonEmpty) Option(head)
-    else None
-  }
+  def headOption : Option[A] = if (hasNext) Some(head) else None
 
   override def buffered: this.type = this
 }

--- a/src/library/scala/collection/BufferedIterator.scala
+++ b/src/library/scala/collection/BufferedIterator.scala
@@ -24,5 +24,10 @@ trait BufferedIterator[+A] extends Iterator[A] {
    */
   def head: A
 
+  def headOption : Option[A] = {
+    if (hasNext) Option(head)
+    else None
+  }
+
   override def buffered: this.type = this
 }

--- a/src/library/scala/collection/BufferedIterator.scala
+++ b/src/library/scala/collection/BufferedIterator.scala
@@ -24,6 +24,10 @@ trait BufferedIterator[+A] extends Iterator[A] {
    */
   def head: A
 
+  /** Returns an option of the next element of an iterator without advancing beyond it.
+    * @return  the next element of this iterator if it is has a next element
+    *           `None` if it is does not
+    */
   def headOption : Option[A] = if (hasNext) Some(head) else None
 
   override def buffered: this.type = this

--- a/src/library/scala/collection/BufferedIterator.scala
+++ b/src/library/scala/collection/BufferedIterator.scala
@@ -25,7 +25,7 @@ trait BufferedIterator[+A] extends Iterator[A] {
   def head: A
 
   def headOption : Option[A] = {
-    if (hasNext) Option(head)
+    if (this.nonEmpty) Option(head)
     else None
   }
 

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -216,12 +216,16 @@ class IteratorTest {
   }
 
   @Test def bufferedHeadOptionReturnsValueWithHeadOrNone(): Unit = {
-    val i = List(1,2,3).iterator
-    val validHeadOption = i.buffered.headOption
+
+    val validHeadOption = List(1,2,3).iterator.buffered.headOption
     assertEquals(Some(1), validHeadOption)
 
-    val invalidHeadOption = i.drop(10).buffered.headOption
+    val invalidHeadOption = List(1,2,3).iterator.drop(10).buffered.headOption
     assertEquals(None: Option[Int], invalidHeadOption)
+
+    val validHeadOptionAtTail = List(1,2,3).iterator.drop(2).buffered.headOption
+    assertEquals(Some(3), validHeadOptionAtTail)
+
   }
 
 }

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -214,4 +214,14 @@ class IteratorTest {
     assertSameElements(exp, res)
     assertEquals(8, counter) // was 14
   }
+
+  @Test def bufferedHeadOptionReturnsValueWithHeadOrNone(): Unit = {
+    val i = List(1,2,3).iterator
+    val validHeadOption = i.buffered.headOption
+    assertEquals(Some(1), validHeadOption)
+
+    val invalidHeadOption = i.drop(10).buffered.headOption
+    assertEquals(None: Option[Int], invalidHeadOption)
+  }
+
 }

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -226,6 +226,8 @@ class IteratorTest {
     val validHeadOptionAtTail = List(1,2,3).iterator.drop(2).buffered.headOption
     assertEquals(Some(3), validHeadOptionAtTail)
 
+    val nullHandingList = List(null, "yellow").iterator.buffered.headOption
+    assertEquals(Some(null), nullHandingList)
   }
 
 }

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -226,8 +226,21 @@ class IteratorTest {
     val validHeadOptionAtTail = List(1,2,3).iterator.drop(2).buffered.headOption
     assertEquals(Some(3), validHeadOptionAtTail)
 
+    val invalidHeadOptionOnePastTail = List(1,2,3).iterator.drop(3).buffered.headOption
+    assertEquals(None, invalidHeadOptionOnePastTail)
+
     val nullHandingList = List(null, "yellow").iterator.buffered.headOption
     assertEquals(Some(null), nullHandingList)
+
+    val it = List(1,2,3).iterator.buffered
+    val v1 = it.head
+    val v2 = it.headOption
+    val v3 = it.head
+    val v4 = it.headOption
+    assertEquals(v1, v3)
+    assertEquals(v2, v4)
+    assertEquals(Some(v1), v2)
+
   }
 
 }


### PR DESCRIPTION
While I am uncertain if this is the appropriate context. With a simple if block this can be achieved and breaks no tests that I can see. The hasNext feature allows us to be aware whether or not we need to return the value wrapped or whether to return a None object which should allow this trait to proliferate. I was worried about where this coincided with already exists. However it appears that it was using override already where the mix occurs at. As it is implemented in the trait it should not affect current code.

I am not sure if this is even an appropriate feature however I thought I could implement it so I wanted to try. Please let me know if anything needs to be done. 
