### PR TITLE
SD-120 Non FunctionN lambdas should not be universally serializable

### DIFF
--- a/test/files/run/lambda-serialization.scala
+++ b/test/files/run/lambda-serialization.scala
@@ -1,6 +1,6 @@
 import java.io.{ByteArrayInputStream, ObjectInputStream, ObjectOutputStream, ByteArrayOutputStream}
 
-trait IntToString { def apply(i: Int): String }
+trait IntToString extends java.io.Serializable { def apply(i: Int): String }
 
 object Test {
   def main(args: Array[String]): Unit = {

--- a/test/files/run/sammy_seriazable.scala
+++ b/test/files/run/sammy_seriazable.scala
@@ -1,0 +1,47 @@
+import java.io._
+
+trait NotSerializableInterface { def apply(a: Any): Any }
+abstract class NotSerializableClass { def apply(a: Any): Any }
+// SAM type that supports lambdas-as-invoke-dynamic
+trait IsSerializableInterface extends java.io.Serializable { def apply(a: Any): Any }
+// SAM type that still requires lambdas-as-anonhmous-classes
+abstract class IsSerializableClass extends java.io.Serializable { def apply(a: Any): Any }
+
+object Test {
+  def main(args: Array[String]) {
+    val nsi: NotSerializableInterface = x => x
+    val nsc: NotSerializableClass = x => x
+
+    import SerDes._
+    assertNotSerializable(nsi)
+    assertNotSerializable(nsc)
+    assert(serializeDeserialize[IsSerializableInterface](x => x).apply("foo") == "foo")
+    assert(serializeDeserialize[IsSerializableClass](x => x).apply("foo") == "foo")
+    assert(ObjectStreamClass.lookup(((x => x): IsSerializableClass).getClass).getSerialVersionUID == 0)
+  }
+}
+
+object SerDes {
+  def assertNotSerializable(a: AnyRef): Unit = {
+    try {
+      serialize(a)
+      assert(false)
+    } catch {
+      case _: NotSerializableException => // okay
+    }
+  }
+
+  def serialize(obj: AnyRef): Array[Byte] = {
+    val buffer = new ByteArrayOutputStream
+    val out = new ObjectOutputStream(buffer)
+    out.writeObject(obj)
+    buffer.toByteArray
+  }
+
+  def deserialize(a: Array[Byte]): AnyRef = {
+    val in = new ObjectInputStream(new ByteArrayInputStream(a))
+    in.readObject
+  }
+
+  def serializeDeserialize[T <: AnyRef](obj: T) = deserialize(serialize(obj)).asInstanceOf[T]
+}


### PR DESCRIPTION
Instead, we follow the example set by javac, and predicate serializability
of bot anon-class and invokedynamic-based lambdas on whether or not the
SAM type extends java.io.Serializable.

Fixes https://github.com/scala/scala-dev/issues/120
