### PR TITLE
SD-20 Include static methods in the InlineInfo in mixed compilation

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -1145,8 +1145,7 @@ object BTypes {
   final case class InlineInfo(isEffectivelyFinal: Boolean,
                               sam: Option[String],
                               methodInfos: Map[String, MethodInlineInfo],
-                              warning: Option[ClassInlineInfoWarning]) {
-  }
+                              warning: Option[ClassInlineInfoWarning])
 
   val EmptyInlineInfo = InlineInfo(false, None, Map.empty, None)
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -557,9 +557,16 @@ class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
 
     var warning = Option.empty[ClassSymbolInfoFailureSI9111]
 
+    def keepMember(sym: Symbol) = sym.isMethod && !scalaPrimitives.isPrimitive(sym)
+    val classMethods = classSym.info.decls.iterator.filter(keepMember)
+    val methods = if (!classSym.isJavaDefined) classMethods else {
+      val staticMethods = classSym.companionModule.info.decls.iterator.filter(m => !m.isConstructor && keepMember(m))
+      staticMethods ++ classMethods
+    }
+
     // Primitive methods cannot be inlined, so there's no point in building a MethodInlineInfo. Also, some
     // primitive methods (e.g., `isInstanceOf`) have non-erased types, which confuses [[typeToBType]].
-    val methodInlineInfos = classSym.info.decls.iterator.filter(m => m.isMethod && !scalaPrimitives.isPrimitive(m)).flatMap({
+    val methodInlineInfos = methods.flatMap({
       case methodSym =>
         if (completeSilentlyAndCheckErroneous(methodSym)) {
           // Happens due to SI-9111. Just don't provide any MethodInlineInfo for that method, we don't need fail the compiler.

--- a/src/compiler/scala/tools/nsc/backend/jvm/BackendReporting.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BackendReporting.scala
@@ -96,8 +96,8 @@ object BackendReporting {
         val missingClassWarning = missingClass match {
           case None => ""
           case Some(c) =>
-            if (c.definedInJavaSource) s"\nNote that the parent class ${c.internalName} is defined in a Java source (mixed compilation), no bytecode is available."
-            else s"\nNote that the parent class ${c.internalName} could not be found on the classpath."
+            if (c.definedInJavaSource) s"\nNote that class ${c.internalName} is defined in a Java source (mixed compilation), no bytecode is available."
+            else s"\nNote that class ${c.internalName} could not be found on the classpath."
         }
         s"The method $name$descriptor could not be found in the class $ownerInternalName or any of its parents." + missingClassWarning
 

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
@@ -416,7 +416,7 @@ class InlinerTest extends BytecodeTesting {
       """B::flop()I is annotated @inline but could not be inlined:
         |Failed to check if B::flop()I can be safely inlined to B without causing an IllegalAccessError. Checking instruction INVOKESTATIC A.bar ()I failed:
         |The method bar()I could not be found in the class A or any of its parents.
-        |Note that the parent class A is defined in a Java source (mixed compilation), no bytecode is available.""".stripMargin
+        |Note that class A is defined in a Java source (mixed compilation), no bytecode is available.""".stripMargin
 
     var c = 0
     val List(b) = compile(scalaCode, List((javaCode, "A.java")), allowMessage = i => {c += 1; i.msg contains warn})
@@ -819,7 +819,7 @@ class InlinerTest extends BytecodeTesting {
     val warn =
       """failed to determine if <init> should be inlined:
         |The method <init>()V could not be found in the class A$Inner or any of its parents.
-        |Note that the parent class A$Inner could not be found on the classpath.""".stripMargin
+        |Note that class A$Inner could not be found on the classpath.""".stripMargin
 
     var c = 0
 


### PR DESCRIPTION
In mixed compilation, the InlineInfo for a Java-defined class is created
using the class symbol (vs in separate compilation, where the info is
created by looking at the classfile and its methods). The scala compiler
puts static java methods into the companion symbol, and we forgot to
include them in the list of methods in the InlineInfo.
