### PR TITLE
SI-8774 Null link fields in mutable LinkedHashMap (and friends) on remove

### DIFF
--- a/src/library/scala/collection/mutable/HashTable.scala
+++ b/src/library/scala/collection/mutable/HashTable.scala
@@ -183,6 +183,7 @@ trait HashTable[A, Entry >: Null <: HashEntry[A, Entry]] extends HashTable.HashU
         table(h) = e.next
         tableSize = tableSize - 1
         nnSizeMapRemove(h)
+        e.next = null
         return e
       } else {
         var e1 = e.next
@@ -194,6 +195,7 @@ trait HashTable[A, Entry >: Null <: HashEntry[A, Entry]] extends HashTable.HashU
           e.next = e1.next
           tableSize = tableSize - 1
           nnSizeMapRemove(h)
+          e1.next = null
           return e1
         }
       }
@@ -227,8 +229,9 @@ trait HashTable[A, Entry >: Null <: HashEntry[A, Entry]] extends HashTable.HashU
     var es        = iterTable(idx)
 
     while (es != null) {
+      val next = es.next // Cache next in case f removes es.
       f(es.asInstanceOf[Entry])
-      es = es.next
+      es = next
 
       while (es == null && idx > 0) {
         idx -= 1

--- a/src/library/scala/collection/mutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/mutable/LinkedHashMap.scala
@@ -81,6 +81,8 @@ class LinkedHashMap[A, B] extends AbstractMap[A, B]
       else e.earlier.later = e.later
       if (e.later eq null) lastEntry = e.earlier
       else e.later.earlier = e.earlier
+      e.earlier = null // Null references to prevent nepotism
+      e.later = null
       Some(e.value)
     }
   }

--- a/src/library/scala/collection/mutable/LinkedHashSet.scala
+++ b/src/library/scala/collection/mutable/LinkedHashSet.scala
@@ -73,6 +73,8 @@ class LinkedHashSet[A] extends AbstractSet[A]
       else e.earlier.later = e.later
       if (e.later eq null) lastEntry = e.earlier
       else e.later.earlier = e.earlier
+      e.earlier = null // Null references to prevent nepotism
+      e.later = null
       true
     }
   }


### PR DESCRIPTION
It is about time to close SI-8774.

I bootstrapped the compiler to verify that my solution does not hit the bug mentioned in SI-8774.
