### PR TITLE
SD-186 Fix positions in trait method bytecode

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/TreeGen.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeGen.scala
@@ -350,7 +350,7 @@ abstract class TreeGen extends scala.reflect.internal.TreeGen with TreeDSL {
       case mt @ MethodType(params, res) => copyMethodType(mt, selfParamSym :: params, res)
     })
     val selfParam = ValDef(selfParamSym)
-    val rhs = orig.rhs.substituteThis(newSym.owner, atPos(newSym.pos)(gen.mkAttributedIdent(selfParamSym)))
+    val rhs = orig.rhs.substituteThis(newSym.owner, gen.mkAttributedIdent(selfParamSym)) // SD-186 intentionally leaving Ident($this) is unpositioned
       .substituteSymbols(origParams, newSym.info.params.drop(1)).changeOwner(origSym -> newSym)
     treeCopy.DefDef(orig, orig.mods, orig.name, orig.tparams, (selfParam :: orig.vparamss.head) :: Nil, orig.tpt, rhs).setSymbol(newSym)
   }


### PR DESCRIPTION
Concrete, non private methods in traits are translated into a static
method with an explicit `$this` parameter. After this translation,
the references to `$this` (subistuted for `this` in user written code)
where being positioned at the position of the method, which makes
debugging unpleasant.

This commit leaves the `Ident($this)` trees unpositioned. This is
analagous to what we do in the body of extension methods, which
is the other user of `ThisSubstitutor`.

It would be more correct to copy the position of each `This`
tree over to the substituted tree. That would let us set a breakpoint
on a line that _only_ contained `this`. But in 99% of cases users
won't be able to spot the difference, so I've opted for the tried
and tested approach here.

Review by @lrytz
