### PR TITLE
Disable stub warning by default.

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -366,7 +366,7 @@ abstract class ClassfileParser {
       //   - better owner than `NoSymbol`
       //   - remove eager warning
       val msg = s"Class $name not found - continuing with a stub."
-      if (!settings.isScaladoc) warning(msg)
+      if ((!settings.isScaladoc) && (settings.verbose || settings.developer)) warning(msg)
       return NoSymbol.newStubSymbol(name.toTypeName, msg)
     }
     val completer     = new loaders.ClassfileLoader(file)

--- a/test/files/run/t7439.check
+++ b/test/files/run/t7439.check
@@ -1,2 +1,2 @@
 Recompiling after deleting t7439-run.obj/A_1.class
-pos: NoPosition Class A_1 not found - continuing with a stub. WARNING
+

--- a/test/files/run/t8442.check
+++ b/test/files/run/t8442.check
@@ -1,1 +1,1 @@
-pos: NoPosition Class A_1 not found - continuing with a stub. WARNING
+

--- a/test/files/run/t9268.check
+++ b/test/files/run/t9268.check
@@ -1,5 +1,4 @@
 Compiling Client1
-pos: NoPosition Class Waiter not found - continuing with a stub. WARNING
+
 Compiling Client2
-pos: NoPosition Class Waiter not found - continuing with a stub. WARNING
 pos: NoPosition Unable to locate class corresponding to inner class entry for Predicate in owner Waiter ERROR


### PR DESCRIPTION
When we create a class symbols from a classpath elements, references
to other classes that are absent from the classpath are represented
as references to "stub symbols". This is not a fatal error; for instance
if these references are from the signature of a method that isn't called
from the program being compiled, we don't need to know anything about them.
A subsequent attempt to look at the type of a stub symbols will trigger a
compile error.

Currently, the creation of a stub symbol incurs a warning. This commit
removes that warning on the basis that it isn't something users need
to worry about. javac doesn't emit a comparable warning.

The warning is still issued under any of `-verbose` / `-Xdev` / `-Ydebug`.

Rebase  of #5268, both to squash and expand the commit message, and to step away from the transient build failures that seemed to plague that PR 🙏 
