### PR TITLE
Improve sbt-based IntelliJ integration in case of Windows

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -936,7 +936,7 @@ intellij := {
 
   val modules: List[(String, Seq[File])] = {
     // for the sbt build module, the dependencies are fetched from the project's build using sbt-buildinfo
-    val buildModule = ("scala-build", scalabuild.BuildInfo.buildClasspath.split(":").toSeq.map(new File(_)))
+    val buildModule = ("scala-build", scalabuild.BuildInfo.buildClasspath.split(java.io.File.pathSeparator).toSeq.map(new File(_)))
     // `sbt projects` lists all modules in the build
     buildModule :: List(
       moduleDeps(compilerP).value,
@@ -1015,12 +1015,14 @@ intellij := {
   var continue = false
   if (!ipr.exists) {
     scala.Console.print(s"Could not find src/intellij/scala.ipr. Create new project files from src/intellij/*.SAMPLE (y/N)? ")
+    scala.Console.flush()
     if (scala.Console.readLine() == "y") {
       intellijCreateFromSample((baseDirectory in ThisBuild).value)
       continue = true
     }
   } else {
     scala.Console.print("Update library classpaths in the current src/intellij/scala.ipr (y/N)? ")
+    scala.Console.flush()
     continue = scala.Console.readLine() == "y"
   }
   if (continue) {
@@ -1045,6 +1047,7 @@ lazy val intellijFromSample = taskKey[Unit]("Create fresh IntelliJ project files
 intellijFromSample := {
   val s = streams.value
   scala.Console.print(s"Create new project files from src/intellij/*.SAMPLE (y/N)? ")
+  scala.Console.flush()
   if (scala.Console.readLine() == "y")
     intellijCreateFromSample((baseDirectory in ThisBuild).value)
   else
@@ -1062,6 +1065,7 @@ lazy val intellijToSample = taskKey[Unit]("Update src/intellij/*.SAMPLE using th
 intellijToSample := {
   val s = streams.value
   scala.Console.print(s"Update src/intellij/*.SAMPLE using the current IntelliJ project files (y/N)? ")
+  scala.Console.flush()
   if (scala.Console.readLine() == "y") {
     val basedir = (baseDirectory in ThisBuild).value
     val existing = basedir / "src/intellij" * "*.SAMPLE"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,9 +11,9 @@ enablePlugins(BuildInfoPlugin)
 
 // configure sbt-buildinfo to send the externalDependencyClasspath to the main build, which allows using it for the IntelliJ project config
 
-lazy val buildClasspath = taskKey[String]("Colon-separated list of entries on the sbt build classpath.")
+lazy val buildClasspath = taskKey[String]("Colon-separated (or semicolon-separated in case of Windows) list of entries on the sbt build classpath.")
 
-buildClasspath := (externalDependencyClasspath in Compile).value.map(_.data).mkString(":")
+buildClasspath := (externalDependencyClasspath in Compile).value.map(_.data).mkString(java.io.File.pathSeparator)
 
 buildInfoKeys := Seq[BuildInfoKey](buildClasspath)
 

--- a/src/intellij/README.md
+++ b/src/intellij/README.md
@@ -17,7 +17,7 @@ are ignored.
 
 ## Dependencies
 
-For every module in the IntelliJ project there is a corresponding `-deps` library, for exmaple `compiler-deps` provides `ant.jar` for the compiler codebase.
+For every module in the IntelliJ project there is a corresponding `-deps` library, for example `compiler-deps` provides `ant.jar` for the compiler codebase.
 The `.jar` files in these `-deps` libraries can be easily kept up-to-date by running `sbt intellij` again.
 This is necessary whenever the dependencies in the sbt build change, for example when the `starr` version is updated.
 


### PR DESCRIPTION
Use File.pathSeparator when processing classpath instead of just : to don't end up with classpath like "C:\sth\a.jar:C:\sth\b.jar", what was causing problems after split(":").

Display questions first and then wait for user input. I tested on 3 computes and without flush the printed  questions were always displayed just after user replied - never before.
