### PR TITLE
avoid boxing

### DIFF
--- a/src/library/scala/concurrent/duration/Duration.scala
+++ b/src/library/scala/concurrent/duration/Duration.scala
@@ -120,7 +120,7 @@ object Duration {
   def fromNanos(nanos: Double): Duration = {
     if (nanos.isInfinite)
       if (nanos > 0) Inf else MinusInf
-    else if (nanos.isNaN)
+    else if (JDouble.isNaN(nanos))
       Undefined
     else if (nanos > Long.MaxValue || nanos < Long.MinValue)
       throw new IllegalArgumentException("trying to construct too large duration with " + nanos + "ns")
@@ -196,11 +196,11 @@ object Duration {
     }
 
     def *(factor: Double): Duration =
-      if (factor == 0d || factor.isNaN) Undefined
+      if (factor == 0d || JDouble.isNaN(factor)) Undefined
       else if (factor < 0d) -this
       else this
     def /(divisor: Double): Duration =
-      if (divisor.isNaN || divisor.isInfinite) Undefined
+      if (JDouble.isNaN(divisor) || divisor.isInfinite) Undefined
       else if ((divisor compare 0d) < 0) -this
       else this
     def /(divisor: Duration): Double = divisor match {
@@ -627,13 +627,13 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
 
   def *(factor: Double) =
     if (!factor.isInfinite) fromNanos(toNanos * factor)
-    else if (factor.isNaN) Undefined
+    else if (JDouble.isNaN(factor)) Undefined
     else if ((factor > 0) ^ (this < Zero)) Inf
     else MinusInf
 
   def /(divisor: Double) =
     if (!divisor.isInfinite) fromNanos(toNanos / divisor)
-    else if (divisor.isNaN) Undefined
+    else if (JDouble.isNaN(divisor)) Undefined
     else Zero
 
   // if this is made a constant, then scalac will elide the conditional and always return +0.0, SI-6331

--- a/src/reflect/scala/reflect/internal/Constants.scala
+++ b/src/reflect/scala/reflect/internal/Constants.scala
@@ -87,8 +87,8 @@ trait Constants extends api.Constants {
     }
 
     def isNaN = value match {
-      case f: Float  => f.isNaN
-      case d: Double => d.isNaN
+      case f: Float  => java.lang.Float.isNaN(f)
+      case d: Double => java.lang.Double.isNaN(d)
       case _ => false
     }
 


### PR DESCRIPTION
scala.runtime.Rich{Double, Float} has `isNaN` and these are value class.
Also java.lang.{Double, Float} has `isNaN`.
- https://docs.oracle.com/javase/8/docs/api/java/lang/Double.html#isNaN--
- https://docs.oracle.com/javase/8/docs/api/java/lang/Float.html#isNaN--

We can't call `RichDouble#isNaN` because
`implicit def double2Double(x: Double): java.lang.Double`
is higher priority than
`implicit def doubleWrapper(x: Double): RichDouble`

```
$ scala -version
Scala code runner version 2.11.8 -- Copyright 2002-2016, LAMP/EPFL

$ scala -Xprint:jvm -e "1.0.isNaN"
[[syntax trees at end of                       jvm]] // scalacmd616162202928036892.scala
package <empty> {
  object Main extends Object {
    def main(args: Array[String]): Unit = {
      new <$anon: Object>();
      ()
    };
    def <init>(): Main.type = {
      Main.super.<init>();
      ()
    }
  };
  final class anon$1 extends Object {
    def <init>(): <$anon: Object> = {
      anon$1.super.<init>();
      scala.this.Predef.double2Double(1.0).isNaN();
      ()
    }
  }
}
```
