### PR TITLE
SI-8576 Minimal changes for `-Xcheckinit` compatibility

### DIFF
--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -59,6 +59,7 @@ object Vector extends IndexedSeqFactory[Vector] {
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  */
+@SerialVersionUID(-1334388273712300479L)
 final class Vector[+A] private[immutable] (private[collection] val startIndex: Int, private[collection] val endIndex: Int, focus: Int)
 extends AbstractSeq[A]
    with IndexedSeq[A]

--- a/src/repl/scala/tools/nsc/interpreter/PresentationCompilation.scala
+++ b/src/repl/scala/tools/nsc/interpreter/PresentationCompilation.scala
@@ -69,7 +69,7 @@ trait PresentationCompilation {
     val interactiveGlobal = new interactive.Global(copySettings, storeReporter) { self =>
       override lazy val platform: ThisPlatform = {
         new JavaPlatform {
-          val global: self.type = self
+          lazy val global: self.type = self
           override private[nsc] lazy val classPath: ClassPath = mergedFlatClasspath
         }
       }


### PR DESCRIPTION
As explained in https://issues.scala-lang.org/browse/SI-8576, I expect
serialization compatibility between builds with and without
`-Xcheckinit` to be unattainable. This commit contains some minor fixes
for issues discovered while running builds with `-Xcheckinit`:
- Add `@SerialVersionUID` to `scala.collection.immutable.Vector`, as
  requested in SI-8576. Note that this does not make `Vector`
  serialization compatible.
- Use lazy initialization for `global` in `PresentationCompilation`. It
  used to access the uninitialized `self` variable (which seems to be
  inconsequential in practice and only fails under `-Xcheckinit`).

We should consider using `Externalizable` instead of `Serializable` for
collections in 2.13 to make collection classes serialization compatible.
