### PR TITLE
Propagate overloaded function type to expected arg type

### DIFF
--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -1426,9 +1426,14 @@ Let $\mathscr{B}$ be the set of alternatives in $\mathscr{A}$ that are [_applica
 to expressions $(e_1 , \ldots , e_n)$ of types $(\mathit{shape}(e_1) , \ldots , \mathit{shape}(e_n))$.
 If there is precisely one alternative in $\mathscr{B}$, that alternative is chosen.
 
-Otherwise, let $S_1 , \ldots , S_m$ be the vector of types obtained by
-typing each argument with an undefined expected type.  For every
-member $m$ in $\mathscr{B}$ one determines whether it is applicable
+Otherwise, let $S_1 , \ldots , S_m$ be the list of types obtained by typing each argument as follows.
+An argument `$e_i$` of the shape `($p_1$: $T_1 , \ldots , p_n$: $T_n$) => $b$` where one of the `$T_i$` is missing,
+i.e., a function literal with a missing parameter type, is typed with an expected function type that
+propagates the least upper bound of the fully defined types of the corresponding parameters of
+the ([SAM-converted](#sam-conversion)) function types specified by the `$i$`th argument type found in each alternative.
+All other arguments are typed with an undefined expected type.
+
+For every member $m$ in $\mathscr{B}$ one determines whether it is applicable
 to expressions ($e_1 , \ldots , e_m$) of types $S_1, \ldots , S_m$.
 
 It is an error if none of the members in $\mathscr{B}$ is applicable. If there is one

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -731,7 +731,7 @@ trait Infer extends Checkable {
       // If args eq the incoming arg types, fail; otherwise recurse with these args.
       def tryWithArgs(args: List[Type]) = (
            (args ne argtpes0)
-        && isApplicable(undetparams, mt, args, pt)
+        && isApplicableToMethod(undetparams, mt, args, pt) // used to be isApplicable(undetparams, mt, args, pt), knowing mt: MethodType
       )
       def tryInstantiating(args: List[Type]) = falseIfNoInstance {
         val restpe = mt resultType args

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -687,6 +687,17 @@ trait Definitions extends api.StandardDefinitions {
       }
     }
 
+    // the argument types expected by the function described by `tp` (a FunctionN or SAM type),
+    // or `Nil` if `tp` does not represent a function type or SAM (or if it happens to be Function0...)
+    def functionOrSamArgTypes(tp: Type): List[Type] = {
+      val dealiased = tp.dealiasWiden
+      if (isFunctionTypeDirect(dealiased)) dealiased.typeArgs.init
+      else samOf(tp) match {
+        case samSym if samSym.exists => tp.memberInfo(samSym).paramTypes
+        case _ => Nil
+      }
+    }
+
     // the SAM's parameters and the Function's formals must have the same length
     // (varargs etc don't come into play, as we're comparing signatures, not checking an application)
     def samMatchesFunctionBasedOnArity(sam: Symbol, formals: List[Any]): Boolean =

--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -263,6 +263,12 @@ abstract class TreeInfo {
     true
   }
 
+  def isFunctionMissingParamType(tree: Tree): Boolean = tree match {
+    case Function(vparams, _) => vparams.exists(_.tpt.isEmpty)
+    case _ => false
+  }
+
+
   /** Is symbol potentially a getter of a variable?
    */
   def mayBeVarGetter(sym: Symbol): Boolean = sym.info match {

--- a/test/files/neg/sammy_overload.check
+++ b/test/files/neg/sammy_overload.check
@@ -1,7 +1,7 @@
-sammy_overload.scala:11: error: missing parameter type for expanded function ((x$1: <error>) => x$1.toString)
-  O.m(_.toString) // error expected: eta-conversion breaks down due to overloading
-      ^
-sammy_overload.scala:12: error: missing parameter type
-  O.m(x => x) // error expected: needs param type
-      ^
-two errors found
+sammy_overload.scala:14: error: overloaded method value m with alternatives:
+  (x: ToString)Int <and>
+  (x: Int => String)Int
+ cannot be applied to (Int => Int)
+  O.m(x => x) // error expected: m cannot be applied to Int => Int
+    ^
+one error found

--- a/test/files/neg/sammy_overload.scala
+++ b/test/files/neg/sammy_overload.scala
@@ -2,12 +2,14 @@ trait ToString { def convert(x: Int): String }
 
 class ExplicitSamType {
   object O {
-    def m(x: Int => String): Int = 0
-    def m(x: ToString): Int = 1
+    def m(x: Int => String): Int = 0 // (1)
+    def m(x: ToString): Int = 1      // (2)
   }
 
-  O.m((x: Int) => x.toString) // ok, function type takes precedence
+  O.m((x: Int) => x.toString) // ok, function type takes precedence, because (1) is more specific than (2),
+  // because (1) is as specific as (2): (2) can be applied to a value of type Int => String (well, assuming it's a function literal)
+  // but (2) is not as specific as (1): (1) cannot be applied to a value of type ToString
 
-  O.m(_.toString) // error expected: eta-conversion breaks down due to overloading
-  O.m(x => x) // error expected: needs param type
+  O.m(_.toString) // ok: overloading resolution pushes through `Int` as the argument type, so this type checks
+  O.m(x => x) // error expected: m cannot be applied to Int => Int
 }

--- a/test/files/neg/t6214.check
+++ b/test/files/neg/t6214.check
@@ -1,4 +1,7 @@
-t6214.scala:5: error: missing parameter type
+t6214.scala:5: error: ambiguous reference to overloaded definition,
+both method m in object Test of type (f: Int => Unit)Int
+and  method m in object Test of type (f: String => Unit)Int
+match argument types (Any => Unit)
   	m { s => case class Foo() }
-            ^
+        ^
 one error found

--- a/test/files/pos/overloaded_ho_fun.scala
+++ b/test/files/pos/overloaded_ho_fun.scala
@@ -1,0 +1,51 @@
+import scala.math.Ordering
+import scala.reflect.ClassTag
+
+trait Sam { def apply(x: Int): String }
+trait SamP[U] { def apply(x: Int): U }
+
+class OverloadedFun[T](x: T) {
+  def foo(f: T => String): String = f(x)
+  def foo(f: Any => T): T = f("a")
+
+  def poly[U](f: Int => String): String = f(1)
+  def poly[U](f: Int => U): U = f(1)
+
+  def polySam[U](f: Sam): String = f(1)
+  def polySam[U](f: SamP[U]): U = f(1)
+
+  // check that we properly instantiate java.util.function.Function's type param to String
+  def polyJavaSam(f: String => String) = 1
+  def polyJavaSam(f: java.util.function.Function[String, String]) = 2
+}
+
+class StringLike(xs: String) {
+  def map[A](f: Char => A): Array[A] = ???
+  def map(f: Char => Char): String = ???
+}
+
+object Test {
+  val of = new OverloadedFun[Int](1)
+
+  of.foo(_.toString)
+
+  of.poly(x => x / 2 )
+  of.polySam(x => x / 2 )
+  of.polyJavaSam(x => x)
+
+  val sl = new StringLike("a")
+  sl.map(_ == 'a')  // : Array[Boolean]
+  sl.map(x => 'a')  // : String
+}
+
+object sorting {
+  def stableSort[K: ClassTag](a: Seq[K], f: (K, K) => Boolean): Array[K] = ???
+  def stableSort[L: ClassTag](a: Array[L], f: (L, L) => Boolean): Unit = ???
+
+  stableSort(??? : Seq[Boolean], (x: Boolean, y: Boolean) => x && !y)
+}
+
+// trait Bijection[A, B] extends (A => B) {
+//   def andThen[C](g: Bijection[B, C]): Bijection[A, C] = ???
+//   def compose[T](g: Bijection[T, A]) = g andThen this
+// }


### PR DESCRIPTION
Infer missing parameter types for function literals passed
to higher-order overloaded methods by deriving the
expected argument type from the function types in the
overloaded method type's argument types.

This eases the pain caused by methods becoming overloaded
because SAM types and function types are compatible,
which used to disable parameter type inference because
for overload resolution arguments are typed without
expected type, while typedFunction needs the expected
type to infer missing parameter types for function literals.

It also aligns us with dotty. The special case for
function literals seems reasonable, as it has precedent,
and it just enables the special case in typing function
literals (derive the param types from the expected type).

Since this does change type inference, you can opt out
using the Scala 2.11 source level.

Fix scala/scala-dev#157
