### PR TITLE
SI-3809 Avoid cycles during classfile parsing

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/AbstractFileReader.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/AbstractFileReader.scala
@@ -19,11 +19,9 @@ import scala.tools.nsc.io.AbstractFile
  * @author Philippe Altherr
  * @version 1.0, 23/03/2004
  */
-class AbstractFileReader(val file: AbstractFile) {
+class AbstractFileReader(val file: AbstractFile, var buf: Array[Byte]) {
 
-  /** the buffer containing the file
-   */
-  val buf: Array[Byte] = file.toByteArray
+  def this(file: AbstractFile) = this(file, file.toByteArray)
 
   /** the current input pointer
    */

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -461,7 +461,7 @@ abstract class ClassfileParser {
       staticModule setFlag JAVA
       staticModule.moduleClass setFlag JAVA
       // attributes now depend on having infos set already
-      parseAttributes(clazz, classInfo)
+      parseAttributes(clazz, isVarargs = false)
 
       def queueLoad() {
         in.bp = curbp
@@ -486,7 +486,7 @@ abstract class ClassfileParser {
         }
       }
     } else
-      parseAttributes(clazz, classInfo)
+      parseAttributes(clazz, isVarargs = false)
   }
 
   /** Add type parameters of enclosing classes */
@@ -518,7 +518,7 @@ abstract class ClassfileParser {
         else info
       }
       propagatePackageBoundary(jflags, sym)
-      parseAttributes(sym, info)
+      parseAttributes(sym, isVarargs = false)
       getScope(jflags) enter sym
 
       // sealed java enums
@@ -552,43 +552,10 @@ abstract class ClassfileParser {
       } else {
         val name = readName()
         val sym = ownerForFlags(jflags).newMethod(name.toTermName, NoPosition, sflags)
-        var info = pool.getType(sym, u2)
-        if (name == nme.CONSTRUCTOR)
-          info match {
-            case MethodType(params, restpe) =>
-              // if this is a non-static inner class, remove the explicit outer parameter
-              val paramsNoOuter = innerClasses getEntry currentClass match {
-                case Some(entry) if !isScalaRaw && !entry.jflags.isStatic =>
-                  /* About `clazz.owner.hasPackageFlag` below: SI-5957
-                   * For every nested java class A$B, there are two symbols in the scala compiler.
-                   *  1. created by SymbolLoader, because of the existence of the A$B.class file, owner: package
-                   *  2. created by ClassfileParser of A when reading the inner classes, owner: A
-                   * If symbol 1 gets completed (e.g. because the compiled source mentions `A$B`, not `A#B`), the
-                   * ClassfileParser for 1 executes, and clazz.owner is the package.
-                   */
-                  assert(params.head.tpe.typeSymbol == clazz.owner || clazz.owner.hasPackageFlag, params.head.tpe.typeSymbol + ": " + clazz.owner)
-                  params.tail
-                case _ =>
-                  params
-              }
-              val newParams = paramsNoOuter match {
-                case (init :+ tail) if jflags.isSynthetic =>
-                  // SI-7455 strip trailing dummy argument ("access constructor tag") from synthetic constructors which
-                  // are added when an inner class needs to access a private constructor.
-                  init
-                case _ =>
-                  paramsNoOuter
-              }
-
-              info = MethodType(newParams, clazz.tpe)
-          }
-        // Note: the info may be overwritten later with a generic signature
-        // parsed from SignatureATTR
-        sym setInfo info
+        val lazyInfo = new JavaSignatureTypeCompleter(name, jflags, index = u2)
+        sym.info = lazyInfo
         propagatePackageBoundary(jflags, sym)
-        parseAttributes(sym, info)
-        if (jflags.isVarargs)
-          sym modifyInfo arrayToRepeated
+        parseAttributes(sym, jflags.isVarargs)
 
         getScope(jflags) enter sym
       }
@@ -770,7 +737,7 @@ abstract class ClassfileParser {
     GenPolyType(ownTypeParams, tpe)
   } // sigToType
 
-  def parseAttributes(sym: Symbol, symtype: Type) {
+  def parseAttributes(sym: Symbol, isVarargs: Boolean) {
     def convertTo(c: Constant, pt: Type): Constant = {
       if (pt.typeSymbol == BooleanClass && c.tag == IntTag)
         Constant(c.value != 0)
@@ -784,8 +751,12 @@ abstract class ClassfileParser {
         case tpnme.SignatureATTR =>
           if (!isScala && !isScalaRaw) {
             val sig = pool.getExternalName(u2)
-            val newType = sigToType(sym, sig)
-            sym.setInfo(newType)
+            if (sym.isClass) {
+              sym.setInfo(sigToType(sym, sig))
+            } else {
+              val lazyType = new JavaGenericSignatureTypeCompleter(sig, isVarargs)
+              sym.setInfo(lazyType)
+            }
           }
           else in.skip(attrLen)
         case tpnme.SyntheticATTR =>
@@ -800,9 +771,9 @@ abstract class ClassfileParser {
           in.skip(attrLen)
         case tpnme.ConstantValueATTR =>
           val c = pool.getConstant(u2)
-          val c1 = convertTo(c, symtype)
+          val c1 = convertTo(c, sym.initialize.info.resultType)
           if (c1 ne null) sym.setInfo(ConstantType(c1))
-          else devWarning(s"failure to convert $c to $symtype")
+          else devWarning(s"failure to convert $c to ${sym.initialize.info.resultType}")
         case tpnme.MethodParametersATTR =>
           def readParamNames(): Unit = {
             import tools.asm.Opcodes.ACC_SYNTHETIC
@@ -1186,6 +1157,49 @@ abstract class ClassfileParser {
   class LazyAliasType(alias: Symbol) extends LazyType with FlagAgnosticCompleter {
     override def complete(sym: Symbol) {
       sym setInfo createFromClonedSymbols(alias.initialize.typeParams, alias.tpe)(typeFun)
+    }
+  }
+  final class JavaSignatureTypeCompleter(name: Name, jflags: JavaAccFlags, index: Int) extends LazyType {
+    override def complete(sym: symbolTable.Symbol): Unit = {
+      var info = pool.getType(sym, index)
+      if (name == nme.CONSTRUCTOR)
+        info match {
+          case MethodType(params, restpe) =>
+            // if this is a non-static inner class, remove the explicit outer parameter
+            val paramsNoOuter = innerClasses getEntry currentClass match {
+              case Some(entry) if !isScalaRaw && !entry.jflags.isStatic =>
+                /* About `clazz.owner.hasPackageFlag` below: SI-5957
+                 * For every nested java class A$B, there are two symbols in the scala compiler.
+                 *  1. created by SymbolLoader, because of the existence of the A$B.class file, owner: package
+                 *  2. created by ClassfileParser of A when reading the inner classes, owner: A
+                 * If symbol 1 gets completed (e.g. because the compiled source mentions `A$B`, not `A#B`), the
+                 * ClassfileParser for 1 executes, and clazz.owner is the package.
+                 */
+                assert(params.head.tpe.typeSymbol == clazz.owner || clazz.owner.hasPackageFlag, params.head.tpe.typeSymbol + ": " + clazz.owner)
+                params.tail
+              case _ =>
+                params
+            }
+            val newParams = paramsNoOuter match {
+              case (init :+ tail) if jflags.isSynthetic =>
+                // SI-7455 strip trailing dummy argument ("access constructor tag") from synthetic constructors which
+                // are added when an inner class needs to access a private constructor.
+                init
+              case _ =>
+                paramsNoOuter
+            }
+
+            info = MethodType(newParams, clazz.tpe)
+        }
+      // Note: the info may be overwritten later with a generic signature
+      // parsed from SignatureATTR
+      sym.setInfo(if (jflags.isVarargs) arrayToRepeated(info) else info)
+    }
+  }
+  final class JavaGenericSignatureTypeCompleter(sig: Name, isVarargs: Boolean) extends LazyType {
+    override def complete(sym: symbolTable.Symbol): Unit = {
+      var info = sigToType(sym, sig)
+      sym.setInfo(if (isVarargs) arrayToRepeated(info) else info)
     }
   }
 

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1524,53 +1524,9 @@ trait Types
       throw new TypeError("illegal cyclic inheritance involving " + tpe.typeSymbol)
   }
 
-  object baseClassesCycleMonitor {
-    private var open: List[Symbol] = Nil
-    @inline private def cycleLog(msg: => String) {
-      if (settings.debug)
-        Console.err.println(msg)
-    }
-    def size = open.size
-    def push(clazz: Symbol) {
-      cycleLog("+ " + ("  " * size) + clazz.fullNameString)
-      open ::= clazz
-    }
-    def pop(clazz: Symbol) {
-      assert(open.head eq clazz, (clazz, open))
-      open = open.tail
-    }
-    def isOpen(clazz: Symbol) = open contains clazz
-  }
-
   protected def defineBaseClassesOfCompoundType(tpe: CompoundType) {
-    def define() = defineBaseClassesOfCompoundType(tpe, force = false)
-    if (!breakCycles || isPastTyper) define()
-    else tpe match {
-      // non-empty parents helpfully excludes all package classes
-      case tpe @ ClassInfoType(_ :: _, _, clazz) if !clazz.isAnonOrRefinementClass =>
-        // Cycle: force update
-        if (baseClassesCycleMonitor isOpen clazz)
-          defineBaseClassesOfCompoundType(tpe, force = true)
-        else {
-          baseClassesCycleMonitor push clazz
-          try define()
-          finally baseClassesCycleMonitor pop clazz
-        }
-      case _ =>
-        define()
-    }
-  }
-  private def defineBaseClassesOfCompoundType(tpe: CompoundType, force: Boolean) {
     val period = tpe.baseClassesPeriod
-    if (period == currentPeriod) {
-      if (force && breakCycles) {
-        def what = tpe.typeSymbol + " in " + tpe.typeSymbol.owner.fullNameString
-        val bcs  = computeBaseClasses(tpe)
-        tpe.baseClassesCache = bcs
-        warning(s"Breaking cycle in base class computation of $what ($bcs)")
-      }
-    }
-    else {
+    if (period != currentPeriod) {
       tpe.baseClassesPeriod = currentPeriod
       if (!isValidForBaseClasses(period)) {
         val start = if (Statistics.canEnable) Statistics.pushTimer(typeOpsStack, baseClassesNanos) else null

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -146,7 +146,6 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.SuperType
     this.TypeBounds
     this.CompoundType
-    this.baseClassesCycleMonitor
     this.RefinedType
     this.ClassInfoType
     this.ConstantType

--- a/test/files/pos/cycle-jsoup.flags
+++ b/test/files/pos/cycle-jsoup.flags
@@ -1,1 +1,0 @@
--Ybreak-cycles

--- a/test/files/pos/cycle.flags
+++ b/test/files/pos/cycle.flags
@@ -1,1 +1,0 @@
--Ybreak-cycles

--- a/test/files/run/t7455/Test.scala
+++ b/test/files/run/t7455/Test.scala
@@ -23,8 +23,8 @@ object Test extends DirectTest {
       clazz = compiler.rootMirror.staticClass(name)
       constr <- clazz.info.member(termNames.CONSTRUCTOR).alternatives
     } {
-      println(constr.defString)
       fullyInitializeSymbol(constr)
+      println(constr.defString)
     }
   }
 }

--- a/test/junit/scala/tools/nsc/symtab/ClassfileParserTest.scala
+++ b/test/junit/scala/tools/nsc/symtab/ClassfileParserTest.scala
@@ -1,0 +1,32 @@
+package scala.tools.nsc
+package symtab
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.openjdk.jol.info.{GraphLayout, GraphPathRecord, GraphVisitor, GraphWalker}
+
+import scala.tools.testing.AssertUtil.assertThrows
+import scala.reflect.internal.util.OffsetPosition
+import scala.tools.nsc.symtab.classfile.AbstractFileReader
+
+@RunWith(classOf[JUnit4])
+class ClassfileParserTest {
+  object symbolTable extends SymbolTableForUnitTesting
+  import symbolTable._
+
+  @Test def retention(): Unit = {
+    definitions.StringClass
+    System.gc()
+    System.gc()
+    System.gc()
+    val before: GraphLayout = GraphLayout.parseInstance(symbolTable)
+    definitions.StringClass.info
+    System.gc()
+    System.gc()
+    System.gc()
+    val after: GraphLayout = GraphLayout.parseInstance(symbolTable)
+    println(after.subtract(before).toFootprint)
+  }
+}


### PR DESCRIPTION
Manually tested with:

```
scalaHome := Some(file("/code/scala/build/pack"))
libraryDependencies += "com.datastax.cassandra" % "dse-driver" % "1.0.0"
```

```
class Test {
  new com.datastax.driver.dse.DseCluster.Builder()
}
```

I was also able to compile `pos/cycle{-jsoup,}` without the experimental
`-Ybreak-cycles`. I've removed the entire `-Ybreak-cycles` option and
supporting code in favour of the approach in this patch.

What's changed? I've used lazy types for methods infos, which is analagous
to what we do in `Unpickler` for scala originated types.