### PR TITLE
Make sure sbt's exit code is seen as script exit code

### DIFF
--- a/scripts/jobs/integrate/bootstrap
+++ b/scripts/jobs/integrate/bootstrap
@@ -523,7 +523,7 @@ bootstrap() {
       $clean \
       $sbtBuildTask \
       dist/mkQuick \
-      publish | grep -v "was too long to be displayed in the webview, and will be left out"
+      publish
 
   # clear ivy cache (and to be sure, local as well), so the next round of sbt builds sees the fresh scala
   rm -rf $baseDir/ivy2
@@ -559,7 +559,7 @@ publishSonatype() {
       -Dstarr.version=$SCALA_VER \
       ${updatedModuleVersions[@]} \
       "setupBootstrapPublish $releaseTempRepoUrl $SCALA_VER" \
-      $publishSonatypeTaskCore | grep -v "was too long to be displayed in the webview, and will be left out"
+      $publishSonatypeTaskCore
 
   echo "### Publishing modules to sonatype"
   # build/test/publish scala core modules to sonatype (this will start a new staging repo)

--- a/scripts/jobs/integrate/windows
+++ b/scripts/jobs/integrate/windows
@@ -16,4 +16,4 @@ $SBT --warn "setupPublishCore" generateBuildCharacterPropertiesFile publishLocal
 
 # Build quick and run the tests
 parseScalaProperties buildcharacter.properties
-$SBT -Dstarr.version=$maven_version_number --warn "setupValidateTest" testAll | grep -v "was too long to be displayed in the webview, and will be left out"
+$SBT -Dstarr.version=$maven_version_number --warn "setupValidateTest" testAll

--- a/scripts/jobs/validate/test
+++ b/scripts/jobs/validate/test
@@ -23,7 +23,7 @@ case $prDryRun in
        --warn \
        "setupValidateTest $prRepoUrl" \
        $testExtraArgs \
-       testAll | grep -v "was too long to be displayed in the webview, and will be left out"
+       testAll
 
     ;;
 


### PR DESCRIPTION
... and not grep's exit code, which would mean the test suite's
result is determined by whether grep fails or not,
instead of partest/junit's hard work
