### PR TITLE
Fix race condition in lambda deserialization

### DIFF
--- a/src/library/scala/runtime/LambdaDeserializer.scala
+++ b/src/library/scala/runtime/LambdaDeserializer.scala
@@ -94,13 +94,15 @@ object LambdaDeserializer {
     val key = serialized.getImplMethodName + " : " + serialized.getImplMethodSignature
     val factory: MethodHandle = if (cache == null) {
       makeCallSite.getTarget
-    } else cache.get(key) match {
-      case null =>
-        val callSite = makeCallSite
-        val temp = callSite.getTarget
-        cache.put(key, temp)
-        temp
-      case target => target
+    } else cache.synchronized{
+      cache.get(key) match {
+        case null =>
+          val callSite = makeCallSite
+          val temp = callSite.getTarget
+          cache.put(key, temp)
+          temp
+        case target => target
+      }
     }
 
     val captures = Array.tabulate(serialized.getCapturedArgCount)(n => serialized.getCapturedArg(n))


### PR DESCRIPTION
Review of the code made me aware that concurrent calls to `$deserializeLambda$` for some lambda hosting class could result in concurrent calls to operations on `j.u.HashMap`.

I've added a synchronized block to avoid this problem. I don't think this is likely to be a bottleneck in practical use cases, but if so we could come up with a lock-free scheme in the future.
