### PR TITLE
SI-7838 Mark tail var in `::` as volatile

### DIFF
--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -431,7 +431,7 @@ case object Nil extends List[Nothing] {
  *  @since   2.8
  */
 @SerialVersionUID(509929039250432923L) // value computed by serialver for 2.11.2, annotation added in 2.11.4
-final case class ::[B](override val head: B, private[scala] var tl: List[B]) extends List[B] {
+final case class ::[B](override val head: B, @volatile private[scala] var tl: List[B]) extends List[B] {
   override def tail : List[B] = tl
   override def isEmpty: Boolean = false
 }

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -431,9 +431,10 @@ case object Nil extends List[Nothing] {
  *  @since   2.8
  */
 @SerialVersionUID(509929039250432923L) // value computed by serialver for 2.11.2, annotation added in 2.11.4
-final case class ::[B](override val head: B, @volatile private[scala] var tl: List[B]) extends List[B] {
+sealed case class ::[B](override val head: B, private[scala] var tl: List[B]) extends List[B] {
   override def tail : List[B] = tl
-  override def isEmpty: Boolean = false
+  final override def isEmpty: Boolean = false
+  private[collection] final def freeze: ::[B] = new SafeCons(head, tl)
 }
 
 /** $factoryInfo

--- a/src/library/scala/collection/immutable/SafeCons.java
+++ b/src/library/scala/collection/immutable/SafeCons.java
@@ -1,0 +1,25 @@
+package scala.collection.immutable;
+
+import scala.collection.mutable.Builder;
+
+/** A subclass of `::` which routes access to the usually mutable `tl` var through a final val.
+ * This ensures thread-safe publishing of the tail (cf. SI-7838).
+ */
+final class SafeCons extends $colon$colon {
+  private final List tl2;
+
+  public SafeCons(Object _head, List<?> _tail) {
+    super(_head, _tail);
+    this.tl2 = _tail;
+    // freeze action for `tl2` happens here
+  }
+
+  // Scala generates two identical accessor methods which read the `tl` field directly.
+  // We have to override both of them. All other generated methods go through one of
+  // these accessors:
+  @Override public List tl$access$1() { return tl2; }
+  @Override public List tl() { return tl2; }
+
+  // Disambiguate `newBuilder`, which is inherited twice
+  @Override public Builder newBuilder() { return super.newBuilder(); }
+}

--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -308,7 +308,10 @@ final class ListBuffer[A]
    */
   override def toList: List[A] = {
     exported = !isEmpty
-    start
+    start match {
+      case cons: ::[A] => cons.freeze
+      case _ => start
+    }
   }
 
 // New methods in ListBuffer

--- a/test/benchmarks/README.md
+++ b/test/benchmarks/README.md
@@ -5,9 +5,7 @@ that makes use of the [SBT plugin](https://github.com/ktoso/sbt-jmh) for [JMH](h
 
 ## Running a benchmark
 
-The benchmarks require first building Scala into `../../build/pack` with `ant`.
-If you want to build with `sbt dist/mkPack` instead,
-you'll need to change `scalaHome` in this project.
+The benchmarks require first building Scala into `../../build/pack`.
 
 You'll then need to know the fully-qualified name of the benchmark runner class.
 The benchmarking classes are organized under `src/main/scala`,

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/VolatileListBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/VolatileListBenchmark.scala
@@ -1,0 +1,51 @@
+package scala.collection.immutable;
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import scala.collection.mutable.ListBuffer
+
+/** Benchmark some list operations to check the impact of making `::.tl` volatile. */
+class VolatileListBenchmark {
+
+  @Benchmark
+  def buildSum10: Int = {
+    val l = new ListBuffer[Int]
+    var i = 0
+    while(i < 10) {
+      l += i
+      i += 1
+    }
+    l.result.sum
+  }
+
+  @Benchmark
+  def buildSum1000: Int = {
+    val l = new ListBuffer[Int]
+    var i = 0
+    while(i < 1000) {
+      l += i
+      i += 1
+    }
+    l.result.sum
+  }
+
+  @Benchmark
+  def buildImmutableSum1000: Int = {
+    var l1: List[Int] = Nil
+    var i = 0
+    while(i < 1000) {
+      l1 = i :: l1
+      i += 1
+    }
+    l1.reverse.sum
+  }
+
+  @Benchmark
+  def sum1000: Int = VolatileListBenchmark.l1000.sum
+}
+
+object VolatileListBenchmark {
+  val l1000 = (0 to 1000).toList
+}


### PR DESCRIPTION
As recommended in SI-7838. I did some benchmarking by building Scala (`sbt clean dist/mkQuick`) with both, this version and the previous commit as STARR. Since scalac uses `List` heavily in its internal data structures, this should make a good real-life test case.

Before: 315 305 300 313 292 302 299 302 301 300 300
After: 314 318 302 301 299 298 297 316 303 301 302

All build times in seconds. Running on an otherwise idle machine, there's still more variation than I'd like but it doesn't look like the new version is substantially slower.
