### PR TITLE
SD-192 Change scheme for trait super accessors

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -52,7 +52,7 @@ abstract class BCodeHelpers extends BCodeIdiomatic with BytecodeWriters {
 
   def needsStaticImplMethod(sym: Symbol) = sym.hasAttachment[global.mixer.NeedStaticImpl.type]
 
-  final def traitImplMethodName(sym: Symbol): Name = {
+  final def traitSuperAccessorName(sym: Symbol): Name = {
     val name = sym.javaSimpleName
     if (sym.isMixinConstructor) name
     else name.append(nme.NAME_JOIN_STRING)

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -596,7 +596,7 @@ class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
             annotatedNoInline = methodSym.hasAnnotation(ScalaNoInlineClass))
 
           if (needsStaticImplMethod(methodSym)) {
-            val staticName = traitImplMethodName(methodSym).toString
+            val staticName = traitSuperAccessorName(methodSym).toString
             val selfParam = methodSym.newSyntheticValueParam(methodSym.owner.typeConstructor, nme.SELF)
             val staticMethodType = methodSym.info match {
               case mt @ MethodType(params, res) => copyMethodType(mt, selfParam :: params, res)

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -76,4 +76,6 @@ trait StdAttachments {
     * in place of the outer parameter, can help callers to avoid capturing the outer instance.
     */
   case object OuterArgCanBeElided extends PlainAttachment
+
+  case object UseInvokeSpecial extends PlainAttachment
 }

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -46,6 +46,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.NoInlineCallsiteAttachment
     this.InlineCallsiteAttachment
     this.OuterArgCanBeElided
+    this.UseInvokeSpecial
     this.noPrint
     this.typeDebug
     this.Range

--- a/test/junit/scala/collection/mutable/OpenHashMapTest.scala
+++ b/test/junit/scala/collection/mutable/OpenHashMapTest.scala
@@ -1,6 +1,6 @@
 package scala.collection.mutable
 
-import org.junit.Test
+import org.junit.{Ignore, Test}
 import org.junit.Assert._
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4

--- a/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
@@ -169,7 +169,7 @@ class BytecodeTest extends BytecodeTesting {
     assertEquals(x.end, labels(7))
   }
 
-  @Test // wrong line numbers for rewritten `this` references in trait static methods
+  @Test
   def sd186_traitLineNumber(): Unit = {
     val code =
       """trait T {
@@ -182,9 +182,9 @@ class BytecodeTest extends BytecodeTesting {
     val t = compileClass(code)
     val tMethod = getMethod(t, "t$")
     val invoke = Invoke(INVOKEVIRTUAL, "java/lang/Object", "toString", "()Ljava/lang/String;", false)
+    // ths static accessor is positioned at the line number of the accessed method.
     assertSameCode(tMethod.instructions,
-      List(Label(0), LineNumber(3, Label(0)), VarOp(ALOAD, 0), invoke, Op(POP),
-        Label(5), LineNumber(4, Label(5)), VarOp(ALOAD, 0), invoke, Op(POP), Op(RETURN), Label(11))
+      List(Label(0), LineNumber(2, Label(0)), VarOp(ALOAD, 0), Invoke(INVOKESPECIAL, "T", "t", "()V", true), Op(RETURN), Label(4))
     )
   }
 }

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerSeparateCompilationTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerSeparateCompilationTest.scala
@@ -97,7 +97,7 @@ class InlinerSeparateCompilationTest {
       """.stripMargin
 
     val List(a, t) = compileClassesSeparately(List(codeA, assembly), args)
-    assertNoInvoke(getMethod(t, "f$"))
-    assertNoInvoke(getMethod(a, "n$"))
+    assertNoInvoke(getMethod(t, "f"))
+    assertNoInvoke(getMethod(a, "n"))
   }
 }

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
@@ -518,7 +518,7 @@ class InlinerTest extends BytecodeTesting {
     val List(c, oMirror, oModule, t) = compile(code, allowMessage = i => {count += 1; i.msg contains warn})
     assert(count == 1, count)
 
-    assertNoInvoke(getMethod(t, "f$"))
+    assertNoInvoke(getMethod(t, "f"))
 
     assertNoInvoke(getMethod(c, "t1"))
     assertNoInvoke(getMethod(c, "t2"))
@@ -544,9 +544,9 @@ class InlinerTest extends BytecodeTesting {
 
     val List(assembly, c, t) = compile(code)
 
-    assertNoInvoke(getMethod(t, "f$"))
+    assertNoInvoke(getMethod(t, "f"))
 
-    assertNoInvoke(getMethod(assembly, "n$"))
+    assertNoInvoke(getMethod(assembly, "n"))
 
     assertNoInvoke(getMethod(c, "t1"))
     assertNoInvoke(getMethod(c, "t2"))
@@ -622,8 +622,8 @@ class InlinerTest extends BytecodeTesting {
     val List(ca, cb, t1, t2a, t2b) = compile(code, allowMessage = i => {count += 1; i.msg contains warning})
     assert(count == 4, count) // see comments, f is not inlined 4 times
 
-    assertNoInvoke(getMethod(t2a, "g2a$"))
-    assertInvoke(getMethod(t2b, "g2b$"), "T1", "f")
+    assertNoInvoke(getMethod(t2a, "g2a"))
+    assertInvoke(getMethod(t2b, "g2b"), "T1", "f")
 
     assertInvoke(getMethod(ca, "m1a"), "T1", "f")
     assertNoInvoke(getMethod(ca, "m2a"))            // no invoke, see comment on def g2a
@@ -682,8 +682,8 @@ class InlinerTest extends BytecodeTesting {
         |}
       """.stripMargin
     val List(c, t) = compile(code)
-    val t1 = getMethod(t, "t1$")
-    val t2 = getMethod(t, "t2$")
+    val t1 = getMethod(t, "t1")
+    val t2 = getMethod(t, "t2")
     val cast = TypeOp(CHECKCAST, "C")
     Set(t1, t2).foreach(m => assert(m.instructions.contains(cast), m.instructions))
   }


### PR DESCRIPTION
Rather than putting the code of a trait method
body into a static method, leave it in the default
method. The static method (needed as the target
of the super calls) now uses `invokespecial`
to exactly call that method.

The [JVM spec](https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokespecial) is slightly ambiguous for this case. "If all of the following are true, let C be the direct superclass of the current class" should apply, all of the conditions in the list are true. But there's no superclass, as T is an interface.

Relevant implementation in HotSpot:

http://hg.openjdk.java.net/jdk/jdk/file/c30c35118303/src/hotspot/share/interpreter/linkResolver.cpp#l1126
http://hg.openjdk.java.net/jdk/jdk/file/c30c35118303/src/hotspot/share/interpreter/linkResolver.cpp#l867

Here's the inclusion of the check for `is_same_or_direct_interface`

http://hg.openjdk.java.net/jdk/jdk/annotate/b7dba4cde1c6/hotspot/src/share/vm/interpreter/linkResolver.cpp#l924

Implementing part of [JSR-335 Lambda Expressions](https://jcp.org/aboutJava/communityprocess/final/jsr335/index.html)

![image](https://user-images.githubusercontent.com/119636/42257561-53a5a0fa-7f57-11e8-96e5-07ca57153d87.png)

Even thought the discussion is all about the use case of naming a super-interface method, its explicitly says its okay for invokespecial to name a method in the current interface, which is what we're doing.