### PR TITLE
SD-193 Lock down lambda deserialization

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -14,6 +14,7 @@ import scala.reflect.internal.Flags
 import scala.tools.asm
 import GenBCode._
 import BackendReporting._
+import scala.collection.mutable
 import scala.tools.asm.Opcodes
 import scala.tools.asm.tree.{MethodInsnNode, MethodNode}
 import scala.tools.nsc.backend.jvm.BCodeHelpers.{InvokeStyle, TestOp}
@@ -1349,7 +1350,7 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
       val markers = if (addScalaSerializableMarker) classBTypeFromSymbol(definitions.SerializableClass).toASMType :: Nil else Nil
       visitInvokeDynamicInsnLMF(bc.jmethod, sam.name.toString, invokedType, samMethodType, implMethodHandle, constrainedType, isSerializable, markers)
       if (isSerializable)
-        indyLambdaHosts += cnode.name
+        addIndyLambdaImplMethod(cnode.name, implMethodHandle :: Nil)
     }
   }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -112,14 +112,6 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
 
       gen(cd.impl)
 
-      val shouldAddLambdaDeserialize = (
-        settings.target.value == "jvm-1.8"
-          && settings.Ydelambdafy.value == "method"
-          && indyLambdaHosts.contains(cnode.name))
-
-      if (shouldAddLambdaDeserialize)
-        backendUtils.addLambdaDeserialize(cnode)
-
       cnode.visitAttribute(thisBType.inlineInfoAttribute.get)
 
       if (AsmUtils.traceClassEnabled && cnode.name.contains(AsmUtils.traceClassPattern))

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -124,12 +124,13 @@ abstract class BTypes {
    */
   val indyLambdaImplMethods: mutable.AnyRefMap[InternalName, mutable.LinkedHashSet[asm.Handle]] = recordPerRunCache(mutable.AnyRefMap())
   def addIndyLambdaImplMethod(hostClass: InternalName, handle: Seq[asm.Handle]): Unit = {
-    indyLambdaImplMethods.getOrElseUpdate(hostClass, mutable.LinkedHashSet()) ++= handle
+    if (handle.nonEmpty)
+      indyLambdaImplMethods.getOrElseUpdate(hostClass, mutable.LinkedHashSet()) ++= handle
   }
-  def getIndyLambdaImplMethods(hostClass: InternalName): List[asm.Handle] = {
+  def getIndyLambdaImplMethods(hostClass: InternalName): Iterable[asm.Handle] = {
     indyLambdaImplMethods.getOrNull(hostClass) match {
       case null => Nil
-      case xs => xs.toList.distinct
+      case xs => xs
     }
   }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -122,7 +122,16 @@ abstract class BTypes {
    * inlining: when inlining an indyLambda instruction into a class, we need to make sure the class
    * has the method.
    */
-  val indyLambdaHosts: mutable.Set[InternalName] = recordPerRunCache(mutable.Set.empty)
+  val indyLambdaImplMethods: mutable.AnyRefMap[InternalName, mutable.LinkedHashSet[asm.Handle]] = recordPerRunCache(mutable.AnyRefMap())
+  def addIndyLambdaImplMethod(hostClass: InternalName, handle: Seq[asm.Handle]): Unit = {
+    indyLambdaImplMethods.getOrElseUpdate(hostClass, mutable.LinkedHashSet()) ++= handle
+  }
+  def getIndyLambdaImplMethods(hostClass: InternalName): List[asm.Handle] = {
+    indyLambdaImplMethods.getOrNull(hostClass) match {
+      case null => Nil
+      case xs => xs.toList.distinct
+    }
+  }
 
   /**
    * Obtain the BType for a type descriptor or internal name. For class descriptors, the ClassBType

--- a/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
@@ -289,19 +289,6 @@ class CoreBTypes[BTFS <: BTypesFromSymbols[_ <: Global]](val bTypes: BTFS) {
         coreBTypes.jliCallSiteRef
       ).descriptor,
       /* itf = */ coreBTypes.srLambdaDeserialize.isInterface.get)
-  lazy val lambdaDeserializeAddTargets =
-    new scala.tools.asm.Handle(scala.tools.asm.Opcodes.H_INVOKESTATIC,
-      coreBTypes.srLambdaDeserialize.internalName, "bootstrapAddTargets",
-      MethodBType(
-        List(
-          coreBTypes.jliMethodHandlesLookupRef,
-          coreBTypes.StringRef,
-          coreBTypes.jliMethodTypeRef,
-          ArrayBType(coreBTypes.jliMethodHandleRef)
-        ),
-        coreBTypes.jliCallSiteRef
-      ).descriptor,
-      /* itf = */ coreBTypes.srLambdaDeserialize.isInterface.get)
 }
 
 /**

--- a/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
@@ -283,7 +283,21 @@ class CoreBTypes[BTFS <: BTypesFromSymbols[_ <: Global]](val bTypes: BTFS) {
         List(
           coreBTypes.jliMethodHandlesLookupRef,
           coreBTypes.StringRef,
-          coreBTypes.jliMethodTypeRef
+          coreBTypes.jliMethodTypeRef,
+          ArrayBType(jliMethodHandleRef)
+        ),
+        coreBTypes.jliCallSiteRef
+      ).descriptor,
+      /* itf = */ coreBTypes.srLambdaDeserialize.isInterface.get)
+  lazy val lambdaDeserializeAddTargets =
+    new scala.tools.asm.Handle(scala.tools.asm.Opcodes.H_INVOKESTATIC,
+      coreBTypes.srLambdaDeserialize.internalName, "bootstrapAddTargets",
+      MethodBType(
+        List(
+          coreBTypes.jliMethodHandlesLookupRef,
+          coreBTypes.StringRef,
+          coreBTypes.jliMethodTypeRef,
+          ArrayBType(coreBTypes.jliMethodHandleRef)
         ),
         coreBTypes.jliCallSiteRef
       ).descriptor,

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
@@ -266,6 +266,9 @@ abstract class GenBCode extends BCodeSyncAndTry {
             try {
               localOptimizations(item.plain)
               setInnerClasses(item.plain)
+              val lambdaImplMethods = getIndyLambdaImplMethods(item.plain.name)
+              if (lambdaImplMethods.nonEmpty)
+                backendUtils.addLambdaDeserialize(item.plain, lambdaImplMethods)
               setInnerClasses(item.mirror)
               setInnerClasses(item.bean)
               addToQ3(item)

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
@@ -277,7 +277,7 @@ class Inliner[BT <: BTypes](val btypes: BT) {
       }
       case _ => false
     }
-    val (clonedInstructions, instructionMap, hasSerializableClosureInstantiation) = cloneInstructions(callee, labelsMap, keepLineNumbers = sameSourceFile)
+    val (clonedInstructions, instructionMap, targetHandles) = cloneInstructions(callee, labelsMap, keepLineNumbers = sameSourceFile)
 
     // local vars in the callee are shifted by the number of locals at the callsite
     val localVarShift = callsiteMethod.maxLocals
@@ -405,10 +405,7 @@ class Inliner[BT <: BTypes](val btypes: BT) {
 
     callsiteMethod.maxStack = math.max(callsiteMethod.maxStack, math.max(stackHeightAtNullCheck, maxStackOfInlinedCode))
 
-    if (hasSerializableClosureInstantiation && !indyLambdaHosts(callsiteClass.internalName)) {
-      indyLambdaHosts += callsiteClass.internalName
-      addLambdaDeserialize(byteCodeRepository.classNode(callsiteClass.internalName).get)
-    }
+    addIndyLambdaImplMethod(callsiteClass.internalName, targetHandles)
 
     callGraph.addIfMissing(callee, calleeDeclarationClass)
 

--- a/src/library/scala/runtime/LambdaDeserialize.java
+++ b/src/library/scala/runtime/LambdaDeserialize.java
@@ -2,14 +2,10 @@ package scala.runtime;
 
 
 import java.lang.invoke.*;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 
 public final class LambdaDeserialize {
     public static final MethodType DESERIALIZE_LAMBDA_MT = MethodType.fromMethodDescriptorString("(Ljava/lang/invoke/SerializedLambda;)Ljava/lang/Object;", LambdaDeserialize.class.getClassLoader());
-    public static final MethodType ADD_TARGET_METHODS_MT = MethodType.fromMethodDescriptorString("([Ljava/lang/invoke/MethodHandle;)V", LambdaDeserialize.class.getClassLoader());
 
     private MethodHandles.Lookup lookup;
     private final HashMap<String, MethodHandle> cache = new HashMap<>();
@@ -37,6 +33,6 @@ public final class LambdaDeserialize {
         return new ConstantCallSite(exact);
     }
     public static String nameAndDescriptorKey(String name, String descriptor) {
-        return name + " " + descriptor;
+        return name + descriptor;
     }
 }

--- a/src/library/scala/runtime/LambdaDeserialize.java
+++ b/src/library/scala/runtime/LambdaDeserialize.java
@@ -2,28 +2,41 @@ package scala.runtime;
 
 
 import java.lang.invoke.*;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 
 public final class LambdaDeserialize {
+    public static final MethodType DESERIALIZE_LAMBDA_MT = MethodType.fromMethodDescriptorString("(Ljava/lang/invoke/SerializedLambda;)Ljava/lang/Object;", LambdaDeserialize.class.getClassLoader());
+    public static final MethodType ADD_TARGET_METHODS_MT = MethodType.fromMethodDescriptorString("([Ljava/lang/invoke/MethodHandle;)V", LambdaDeserialize.class.getClassLoader());
 
     private MethodHandles.Lookup lookup;
     private final HashMap<String, MethodHandle> cache = new HashMap<>();
     private final LambdaDeserializer$ l = LambdaDeserializer$.MODULE$;
+    private final HashMap<String, MethodHandle> targetMethodMap;
 
-    private LambdaDeserialize(MethodHandles.Lookup lookup) {
+    private LambdaDeserialize(MethodHandles.Lookup lookup, MethodHandle[] targetMethods) {
         this.lookup = lookup;
+        targetMethodMap = new HashMap<>(targetMethods.length);
+        for (MethodHandle targetMethod : targetMethods) {
+            MethodHandleInfo info = lookup.revealDirect(targetMethod);
+            String key = nameAndDescriptorKey(info.getName(), info.getMethodType().toMethodDescriptorString());
+            targetMethodMap.put(key, targetMethod);
+        }
     }
 
     public Object deserializeLambda(SerializedLambda serialized) {
-        return l.deserializeLambda(lookup, cache, serialized);
+        return l.deserializeLambda(lookup, cache, targetMethodMap, serialized);
     }
 
     public static CallSite bootstrap(MethodHandles.Lookup lookup, String invokedName,
-                                     MethodType invokedType) throws Throwable {
-        MethodType type = MethodType.fromMethodDescriptorString("(Ljava/lang/invoke/SerializedLambda;)Ljava/lang/Object;", lookup.getClass().getClassLoader());
-        MethodHandle deserializeLambda = lookup.findVirtual(LambdaDeserialize.class, "deserializeLambda", type);
-        MethodHandle exact = deserializeLambda.bindTo(new LambdaDeserialize(lookup)).asType(invokedType);
+                                     MethodType invokedType, MethodHandle... targetMethods) throws Throwable {
+        MethodHandle deserializeLambda = lookup.findVirtual(LambdaDeserialize.class, "deserializeLambda", DESERIALIZE_LAMBDA_MT);
+        MethodHandle exact = deserializeLambda.bindTo(new LambdaDeserialize(lookup, targetMethods)).asType(invokedType);
         return new ConstantCallSite(exact);
+    }
+    public static String nameAndDescriptorKey(String name, String descriptor) {
+        return name + " " + descriptor;
     }
 }

--- a/test/files/run/lambda-serialization-security.scala
+++ b/test/files/run/lambda-serialization-security.scala
@@ -1,0 +1,47 @@
+import java.io.{ByteArrayInputStream, ObjectInputStream, ObjectOutputStream, ByteArrayOutputStream}
+
+trait IntToString extends java.io.Serializable { def apply(i: Int): String }
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    roundTrip()
+    roundTripIndySam()
+  }
+
+  def roundTrip(): Unit = {
+    val c = new Capture("Capture")
+    val lambda = (p: Param) => ("a", p, c)
+    val reconstituted1 = serializeDeserialize(lambda).asInstanceOf[Object => Any]
+    val p = new Param
+    assert(reconstituted1.apply(p) == ("a", p, c))
+    val reconstituted2 = serializeDeserialize(lambda).asInstanceOf[Object => Any]
+    assert(reconstituted1.getClass == reconstituted2.getClass)
+
+    val reconstituted3 = serializeDeserialize(reconstituted1)
+    assert(reconstituted3.apply(p) == ("a", p, c))
+
+    val specializedLambda = (p: Int) => List(p, c).length
+    assert(serializeDeserialize(specializedLambda).apply(42) == 2)
+    assert(serializeDeserialize(serializeDeserialize(specializedLambda)).apply(42) == 2)
+  }
+
+  // lambda targeting a SAM, not a FunctionN (should behave the same way)
+  def roundTripIndySam(): Unit = {
+    val lambda: IntToString = (x: Int) => "yo!" * x
+    val reconstituted1 = serializeDeserialize(lambda).asInstanceOf[IntToString]
+    val reconstituted2 = serializeDeserialize(reconstituted1).asInstanceOf[IntToString]
+    assert(reconstituted1.apply(2) == "yo!yo!")
+    assert(reconstituted1.getClass == reconstituted2.getClass)
+  }
+
+  def serializeDeserialize[T <: AnyRef](obj: T) = {
+    val buffer = new ByteArrayOutputStream
+    val out = new ObjectOutputStream(buffer)
+    out.writeObject(obj)
+    val in = new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray))
+    in.readObject.asInstanceOf[T]
+  }
+}
+
+case class Capture(s: String) extends Serializable
+class Param

--- a/test/junit/scala/runtime/LambdaDeserializerTest.java
+++ b/test/junit/scala/runtime/LambdaDeserializerTest.java
@@ -4,9 +4,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.Serializable;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.SerializedLambda;
+import java.lang.invoke.*;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -85,19 +83,20 @@ public final class LambdaDeserializerTest {
     public void implMethodNameChanged() {
         F1<Boolean, String> f1 = lambdaHost.lambdaBackedByStaticImplMethod();
         SerializedLambda sl = writeReplace(f1);
-        checkIllegalAccess(copySerializedLambda(sl, sl.getImplMethodName() + "___", sl.getImplMethodSignature()));
+        checkIllegalAccess(sl, copySerializedLambda(sl, sl.getImplMethodName() + "___", sl.getImplMethodSignature()));
     }
 
     @Test
     public void implMethodSignatureChanged() {
         F1<Boolean, String> f1 = lambdaHost.lambdaBackedByStaticImplMethod();
         SerializedLambda sl = writeReplace(f1);
-        checkIllegalAccess(copySerializedLambda(sl, sl.getImplMethodName(), sl.getImplMethodSignature().replace("Boolean", "Integer")));
+        checkIllegalAccess(sl, copySerializedLambda(sl, sl.getImplMethodName(), sl.getImplMethodSignature().replace("Boolean", "Integer")));
     }
 
-    private void checkIllegalAccess(SerializedLambda serialized) {
+    private void checkIllegalAccess(SerializedLambda allowed, SerializedLambda requested) {
         try {
-            LambdaDeserializer.deserializeLambda(MethodHandles.lookup(), null, null, serialized);
+            HashMap<String, MethodHandle> allowedMap = createAllowedMap(LambdaHost.lookup(), allowed);
+            LambdaDeserializer.deserializeLambda(MethodHandles.lookup(), null, allowedMap, requested);
             throw new AssertionError();
         } catch (IllegalArgumentException iae) {
             if (!iae.getMessage().contains("Illegal lambda deserialization")) {
@@ -123,6 +122,7 @@ public final class LambdaDeserializerTest {
             throw new RuntimeException(e);
         }
     }
+
     private <A, B> A reconstitute(A f1) {
         return reconstitute(f1, null);
     }
@@ -130,11 +130,55 @@ public final class LambdaDeserializerTest {
     @SuppressWarnings("unchecked")
     private <A, B> A reconstitute(A f1, java.util.HashMap<String, MethodHandle> cache) {
         try {
-            return (A) LambdaDeserializer.deserializeLambda(LambdaHost.lookup(), cache, null, writeReplace(f1));
+            return deserizalizeLambdaCreatingAllowedMap(f1, cache, LambdaHost.lookup());
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
+
+    private <A> A deserizalizeLambdaCreatingAllowedMap(A f1, HashMap<String, MethodHandle> cache, MethodHandles.Lookup lookup) {
+        SerializedLambda serialized = writeReplace(f1);
+        HashMap<String, MethodHandle> allowed = createAllowedMap(lookup, serialized);
+        return (A) LambdaDeserializer.deserializeLambda(lookup, cache, allowed, serialized);
+    }
+
+    private HashMap<String, MethodHandle> createAllowedMap(MethodHandles.Lookup lookup, SerializedLambda serialized) {
+        Class<?> implClass = classForName(serialized.getImplClass().replace("/", "."), lookup.lookupClass().getClassLoader());
+        MethodHandle implMethod = findMember(lookup, serialized.getImplMethodKind(), implClass, serialized.getImplMethodName(), MethodType.fromMethodDescriptorString(serialized.getImplMethodSignature(), lookup.lookupClass().getClassLoader()));
+        HashMap<String, MethodHandle> allowed = new HashMap<>();
+        allowed.put(LambdaDeserialize.nameAndDescriptorKey(serialized.getImplMethodName(), serialized.getImplMethodSignature()), implMethod);
+        return allowed;
+    }
+
+    private Class<?> classForName(String className, ClassLoader classLoader) {
+        try {
+            return Class.forName(className, true, classLoader);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private MethodHandle findMember(MethodHandles.Lookup lookup, int kind, Class<?> owner,
+                                    String name, MethodType signature) {
+        try {
+            switch (kind) {
+                case MethodHandleInfo.REF_invokeStatic:
+                    return lookup.findStatic(owner, name, signature);
+                case MethodHandleInfo.REF_newInvokeSpecial:
+                    return lookup.findConstructor(owner, signature);
+                case MethodHandleInfo.REF_invokeVirtual:
+                case MethodHandleInfo.REF_invokeInterface:
+                    return lookup.findVirtual(owner, name, signature);
+                case MethodHandleInfo.REF_invokeSpecial:
+                    return lookup.findSpecial(owner, name, signature, owner);
+                default:
+                    throw new IllegalArgumentException();
+            }
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
 
     private <A> SerializedLambda writeReplace(A f1) {
         try {
@@ -189,5 +233,7 @@ class LambdaHost {
 }
 
 interface I {
-    default String i() { return "i"; };
+    default String i() {
+        return "i";
+    }
 }

--- a/test/junit/scala/runtime/LambdaDeserializerTest.java
+++ b/test/junit/scala/runtime/LambdaDeserializerTest.java
@@ -97,7 +97,7 @@ public final class LambdaDeserializerTest {
 
     private void checkIllegalAccess(SerializedLambda serialized) {
         try {
-            LambdaDeserializer.deserializeLambda(MethodHandles.lookup(), null, serialized);
+            LambdaDeserializer.deserializeLambda(MethodHandles.lookup(), null, null, serialized);
             throw new AssertionError();
         } catch (IllegalArgumentException iae) {
             if (!iae.getMessage().contains("Illegal lambda deserialization")) {
@@ -130,7 +130,7 @@ public final class LambdaDeserializerTest {
     @SuppressWarnings("unchecked")
     private <A, B> A reconstitute(A f1, java.util.HashMap<String, MethodHandle> cache) {
         try {
-            return (A) LambdaDeserializer.deserializeLambda(LambdaHost.lookup(), cache, writeReplace(f1));
+            return (A) LambdaDeserializer.deserializeLambda(LambdaHost.lookup(), cache, null, writeReplace(f1));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
The old design allowed a forged `SerializedLambda` to be
deserialized into a lambda that could call any private method
in the host class.

This commit passes through the list of all lambda impl methods
to the bootstrap method and verifies that you are deserializing
one of these.

The new test case shows that a forged lambda can no longer call
the private method, and that the new encoding is okay with a large
number of lambdas in a file.

We already have method handle constants in the constant pool
to support the invokedynamic through LambdaMetafactory, so
the only additional cost will be referring to these in
the boostrap args for `LambdaDeserialize`, 2 bytes per lambda.

I checked this with an example:

  https://gist.github.com/retronym/e343d211f7536d06f1fef4b499a0a177

fixes scala/scala-dev#193
