### PR TITLE
use Any instead of type-bound to clarify unboundedness

### DIFF
--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -227,7 +227,7 @@ sealed abstract class Option[+A] extends Product with Serializable {
    *  @return `true` if the option has an element that is equal (as
    *  determined by `==`) to `elem`, `false` otherwise.
    */
-  final def contains[A1 >: A](elem: A1): Boolean =
+  final def contains(elem: Any): Boolean =
     !isEmpty && this.get == elem
 
   /** Returns true if this option is nonempty '''and''' the predicate

--- a/src/library/scala/collection/LinearSeqOptimized.scala
+++ b/src/library/scala/collection/LinearSeqOptimized.scala
@@ -95,7 +95,7 @@ trait LinearSeqOptimized[+A, +Repr <: LinearSeqOptimized[A, Repr]] extends Linea
   }
 
   override /*SeqLike*/
-  def contains[A1 >: A](elem: A1): Boolean = {
+  def contains(elem: Any): Boolean = {
     var these = this
     while (!these.isEmpty) {
       if (these.head == elem) return true

--- a/src/library/scala/collection/SeqLike.scala
+++ b/src/library/scala/collection/SeqLike.scala
@@ -397,7 +397,7 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
    *  @return     `true` if this $coll has an element that is equal (as
    *              determined by `==`) to `elem`, `false` otherwise.
    */
-  def contains[A1 >: A](elem: A1): Boolean = exists (_ == elem)
+  def contains(elem: Any): Boolean = exists (_ == elem)
 
   /** Produces a new sequence which contains all elements of this $coll and also all elements of
    *  a given sequence. `xs union ys`  is equivalent to `xs ++ ys`.

--- a/src/library/scala/collection/SeqProxyLike.scala
+++ b/src/library/scala/collection/SeqProxyLike.scala
@@ -52,7 +52,7 @@ trait SeqProxyLike[+A, +Repr <: SeqLike[A, Repr] with Seq[A]] extends SeqLike[A,
   override def lastIndexOfSlice[B >: A](that: GenSeq[B]): Int = self.lastIndexOfSlice(that)
   override def lastIndexOfSlice[B >: A](that: GenSeq[B], end: Int): Int = self.lastIndexOfSlice(that, end)
   override def containsSlice[B](that: GenSeq[B]): Boolean = self.indexOfSlice(that) != -1
-  override def contains[A1 >: A](elem: A1): Boolean = self.contains(elem)
+  override def contains(elem: Any): Boolean = self.contains(elem)
   override def union[B >: A, That](that: GenSeq[B])(implicit bf: CanBuildFrom[Repr, B, That]): That = self.union(that)(bf)
   override def diff[B >: A](that: GenSeq[B]): Repr = self.diff(that)
   override def intersect[B >: A](that: GenSeq[B]): Repr = self.intersect(that)

--- a/src/library/scala/collection/generic/SeqForwarder.scala
+++ b/src/library/scala/collection/generic/SeqForwarder.scala
@@ -53,7 +53,7 @@ trait SeqForwarder[+A] extends Seq[A] with IterableForwarder[A] {
   override def lastIndexOfSlice[B >: A](that: GenSeq[B]): Int = underlying lastIndexOfSlice that
   override def lastIndexOfSlice[B >: A](that: GenSeq[B], end: Int): Int = underlying.lastIndexOfSlice(that, end)
   override def containsSlice[B](that: GenSeq[B]): Boolean = underlying containsSlice that
-  override def contains[A1 >: A](elem: A1): Boolean = underlying contains elem
+  override def contains(elem: Any): Boolean = underlying contains elem
   override def corresponds[B](that: GenSeq[B])(p: (A,B) => Boolean): Boolean = underlying.corresponds(that)(p)
   override def indices: Range = underlying.indices
 }

--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -174,7 +174,7 @@ extends AbstractSeq[T] with IndexedSeq[T] with Serializable {
   def containsTyped(x: T): Boolean =
     isWithinBoundaries(x) && (((x - start) % step) == zero)
 
-  override def contains[A1 >: T](x: A1): Boolean =
+  override def contains(x: Any): Boolean =
     try containsTyped(x.asInstanceOf[T])
     catch { case _: ClassCastException => false }
 


### PR DESCRIPTION
.contains accepts anything in these cases. While the previous code worked fine,
this signature is simpler and makes it slightly more obvious (especially to beginners)
that there is no type-safety here.

Do others agree with this judgement? Not married to this, but seems like a minor improvement to me to scare away type-system newbies a little bit less.
