### PR TITLE
SI-9881 Fix ImportHandler's reporting of importedNames and importedSymbols

### DIFF
--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -296,11 +296,13 @@ trait Names extends api.Names {
      */
     final def pos(s: String, start: Int): Int = {
       var i = pos(s.charAt(0), start)
-      while (i + s.length() <= len) {
+      val sLen = s.length()
+      if (sLen == 1) return i
+      while (i + sLen <= len) {
         var j = 1
         while (s.charAt(j) == chrs(index + i + j)) {
           j += 1
-          if (j == s.length()) return i
+          if (j == sLen) return i
         }
         i = pos(s.charAt(0), i + 1)
       }

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4549,7 +4549,12 @@ trait Types
 
   /** Members which can be imported into other scopes.
    */
-  def importableMembers(pre: Type): Scope = pre.members filter isImportable
+  def importableMembers(pre: Type): Scope = {
+    def isFlattenedSymbol(sym: Symbol) = sym.owner.isPackageClass && sym.name.containsName(nme.NAME_JOIN_STRING) && {
+      sym.owner.info.member(sym.name.take(sym.name.indexOf(nme.NAME_JOIN_STRING))) != NoSymbol
+    }
+    pre.members filter (m => !isFlattenedSymbol(m) && isImportable(m))
+  }
 
   def objToAny(tp: Type): Type =
     if (!phase.erasedTypes && tp.typeSymbol == ObjectClass) AnyTpe

--- a/src/repl/scala/tools/nsc/interpreter/ExprTyper.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ExprTyper.scala
@@ -15,6 +15,12 @@ trait ExprTyper {
   import global.{ reporter => _, Import => _, _ }
   import naming.freshInternalVarName
 
+  private def doInterpret(code: String): IR.Result = {
+    // interpret/interpretSynthetic may change the phase, which would have unintended effects on types.
+    val savedPhase = phase
+    try interpretSynthetic(code) finally phase = savedPhase
+  }
+
   def symbolOfLine(code: String): Symbol = {
     def asExpr(): Symbol = {
       val name  = freshInternalVarName()
@@ -23,7 +29,7 @@ trait ExprTyper {
       // behind a def and strip the NullaryMethodType which wraps the expr.
       val line = "def " + name + " = " + code
 
-      interpretSynthetic(line) match {
+      doInterpret(line) match {
         case IR.Success =>
           val sym0 = symbolOfTerm(name)
           // drop NullaryMethodType
@@ -34,7 +40,7 @@ trait ExprTyper {
     def asDefn(): Symbol = {
       val old = repl.definedSymbolList.toSet
 
-      interpretSynthetic(code) match {
+      doInterpret(code) match {
         case IR.Success =>
           repl.definedSymbolList filterNot old match {
             case Nil        => NoSymbol
@@ -45,7 +51,7 @@ trait ExprTyper {
       }
     }
     def asError(): Symbol = {
-      interpretSynthetic(code)
+      doInterpret(code)
       NoSymbol
     }
     beSilentDuring(asExpr()) orElse beSilentDuring(asDefn()) orElse asError()
@@ -74,7 +80,7 @@ trait ExprTyper {
     def asProperType(): Option[Type] = {
       val name = freshInternalVarName()
       val line = "def %s: %s = ???" format (name, typeString)
-      interpretSynthetic(line) match {
+      doInterpret(line) match {
         case IR.Success =>
           val sym0 = symbolOfTerm(name)
           Some(sym0.asMethod.returnType)

--- a/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
+++ b/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
@@ -214,13 +214,16 @@ trait MemberHandlers {
     val Import(expr, selectors) = imp
     def targetType = intp.global.rootMirror.getModuleIfDefined("" + expr) match {
       case NoSymbol => intp.typeOfExpression("" + expr)
-      case sym      => sym.thisType
+      case sym      => sym.typeOfThis
     }
-    private def importableTargetMembers = importableMembers(targetType).toList
+    private def importableTargetMembers = importableMembers(exitingTyper(targetType)).toList
     // wildcard imports, e.g. import foo._
     private def selectorWild    = selectors filter (_.name == nme.USCOREkw)
-    // renamed imports, e.g. import foo.{ bar => baz }
-    private def selectorRenames = selectors map (_.rename) filterNot (_ == null)
+
+    // non-wildcard imports
+    private def individualSelectors = selectors filter { x =>
+      x.name != nme.USCOREkw && x.name != null && x.rename != nme.USCOREkw & x.rename != null
+    }
 
     /** Whether this import includes a wildcard import */
     val importsWildcard = selectorWild.nonEmpty
@@ -228,13 +231,17 @@ trait MemberHandlers {
     def implicitSymbols = importedSymbols filter (_.isImplicit)
     def importedSymbols = individualSymbols ++ wildcardSymbols
 
-    private val selectorNames = selectorRenames filterNot (_ == nme.USCOREkw) flatMap (_.bothNames) toSet
-    lazy val individualSymbols: List[Symbol] = exitingTyper(importableTargetMembers filter (m => selectorNames(m.name)))
-    lazy val wildcardSymbols: List[Symbol]   = exitingTyper(if (importsWildcard) importableTargetMembers else Nil)
+    lazy val importableSymbolsWithRenames = {
+      val selectorRenameMap = individualSelectors.flatMap(x => x.name.bothNames zip x.rename.bothNames).toMap
+      importableTargetMembers flatMap (m => selectorRenameMap.get(m.name) map (m -> _))
+    }
+
+    lazy val individualSymbols: List[Symbol] = importableSymbolsWithRenames map (_._1)
+    lazy val wildcardSymbols: List[Symbol]   = if (importsWildcard) importableTargetMembers else Nil
 
     /** Complete list of names imported by a wildcard */
     lazy val wildcardNames: List[Name]   = wildcardSymbols map (_.name)
-    lazy val individualNames: List[Name] = individualSymbols map (_.name)
+    lazy val individualNames: List[Name] = importableSymbolsWithRenames map (_._2)
 
     /** The names imported by this statement */
     override lazy val importedNames: List[Name] = wildcardNames ++ individualNames

--- a/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
+++ b/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
@@ -214,7 +214,7 @@ trait MemberHandlers {
     val Import(expr, selectors) = imp
     def targetType = intp.global.rootMirror.getModuleIfDefined("" + expr) match {
       case NoSymbol => intp.typeOfExpression("" + expr)
-      case sym      => sym.typeOfThis
+      case sym      => sym.moduleClass.thisType
     }
     private def importableTargetMembers = importableMembers(exitingTyper(targetType)).toList
     // wildcard imports, e.g. import foo._

--- a/test/files/run/t9880-9881.check
+++ b/test/files/run/t9880-9881.check
@@ -1,0 +1,36 @@
+
+scala> // import in various ways
+
+scala> import java.util.Date
+import java.util.Date
+
+scala> import scala.util._
+import scala.util._
+
+scala> import scala.reflect.runtime.{universe => ru}
+import scala.reflect.runtime.{universe=>ru}
+
+scala> import ru.TypeTag
+import ru.TypeTag
+
+scala> 
+
+scala> // show the imports
+
+scala> :imports
+ 1) import java.lang._             (183 types, 189 terms)
+ 2) import scala._                 (692 types, 728 terms)
+ 3) import scala.Predef._          (127 terms, 62 are implicit)
+ 4) import java.util.Date          (1 types, 1 terms)
+ 5) import scala.util._            (56 types, 60 terms)
+ 6) import scala.reflect.runtime.{universe=>ru} (1 terms)
+ 7) import ru.TypeTag              (1 types, 1 terms)
+
+scala> 
+
+scala> // should be able to define this class with the imports above
+
+scala> class C[T](date: Date, rand: Random, typeTag: TypeTag[T])
+defined class C
+
+scala> :quit

--- a/test/files/run/t9880-9881.check
+++ b/test/files/run/t9880-9881.check
@@ -18,13 +18,13 @@ scala>
 scala> // show the imports
 
 scala> :imports
- 1) import java.lang._             (183 types, 189 terms)
- 2) import scala._                 (692 types, 728 terms)
- 3) import scala.Predef._          (127 terms, 62 are implicit)
- 4) import java.util.Date          (1 types, 1 terms)
- 5) import scala.util._            (56 types, 60 terms)
- 6) import scala.reflect.runtime.{universe=>ru} (1 terms)
- 7) import ru.TypeTag              (1 types, 1 terms)
+ 1) import java.lang._             (...)
+ 2) import scala._                 (...)
+ 3) import scala.Predef._          (...)
+ 4) import java.util.Date          (...)
+ 5) import scala.util._            (...)
+ 6) import scala.reflect.runtime.{universe=>ru} (...)
+ 7) import ru.TypeTag              (...)
 
 scala> 
 

--- a/test/files/run/t9880-9881.scala
+++ b/test/files/run/t9880-9881.scala
@@ -1,0 +1,25 @@
+import scala.tools.partest.ReplTest
+import scala.tools.nsc.Settings
+
+object Test extends ReplTest {
+
+  override def transformSettings(s: Settings): Settings = {
+    s.Yreplclassbased.value = true
+    s
+  }
+
+  def code =
+    """
+      |// import in various ways
+      |import java.util.Date
+      |import scala.util._
+      |import scala.reflect.runtime.{universe => ru}
+      |import ru.TypeTag
+      |
+      |// show the imports
+      |:imports
+      |
+      |// should be able to define this class with the imports above
+      |class C[T](date: Date, rand: Random, typeTag: TypeTag[T])
+    """.stripMargin
+}

--- a/test/files/run/t9880-9881.scala
+++ b/test/files/run/t9880-9881.scala
@@ -8,6 +8,10 @@ object Test extends ReplTest {
     s
   }
 
+  lazy val normalizeRegex = """(import\s.*)\(.*\)""".r
+
+  override def normalize(s: String): String = normalizeRegex.replaceFirstIn(s, "$1(...)")
+
   def code =
     """
       |// import in various ways

--- a/test/junit/scala/reflect/internal/NamesTest.scala
+++ b/test/junit/scala/reflect/internal/NamesTest.scala
@@ -92,4 +92,29 @@ class NamesTest {
     assert(h1 string_== h2)
     assert(h1 string_== h1y)
   }
+
+  @Test
+  def pos(): Unit = {
+    def check(name: Name, sub: String) = {
+      val javaResult = name.toString.indexOf(sub)
+      val nameResult = name.pos(sub)
+      assertEquals(javaResult, nameResult)
+      if (sub.length == 1) {
+        val nameResultChar = name.pos(sub.head)
+        assertEquals(javaResult, nameResultChar)
+      }
+    }
+    check(nme.EMPTY, "")
+    check(nme.EMPTY, "x")
+    check(nme.EMPTY, "xy")
+    check(TermName("a"), "")
+    check(TermName("a"), "a")
+    check(TermName("a"), "b")
+    check(TermName("a"), "ab")
+    check(TermName("a"), "ba")
+    check(TermName("ab"), "a")
+    check(TermName("ab"), "b")
+    check(TermName("ab"), "ab")
+    check(TermName("ab"), "ba")
+  }
 }

--- a/test/junit/scala/reflect/internal/NamesTest.scala
+++ b/test/junit/scala/reflect/internal/NamesTest.scala
@@ -95,8 +95,9 @@ class NamesTest {
 
   @Test
   def pos(): Unit = {
-    def check(name: Name, sub: String) = {
-      val javaResult = name.toString.indexOf(sub)
+    def check(nameString: String, sub: String) = {
+      val name = TermName(nameString)
+      val javaResult = name.toString.indexOf(sub) match { case -1 => name.length case x => x }
       val nameResult = name.pos(sub)
       assertEquals(javaResult, nameResult)
       if (sub.length == 1) {
@@ -104,17 +105,18 @@ class NamesTest {
         assertEquals(javaResult, nameResultChar)
       }
     }
-    check(nme.EMPTY, "")
-    check(nme.EMPTY, "x")
-    check(nme.EMPTY, "xy")
-    check(TermName("a"), "")
-    check(TermName("a"), "a")
-    check(TermName("a"), "b")
-    check(TermName("a"), "ab")
-    check(TermName("a"), "ba")
-    check(TermName("ab"), "a")
-    check(TermName("ab"), "b")
-    check(TermName("ab"), "ab")
-    check(TermName("ab"), "ba")
+    // check(nme.EMPTY, "") `pos` requires a non-empty string argument
+    //    check("a", "")
+
+    check("a", "a") // was "String index out of range: 1
+    check("a", "b")
+    check("a", "ab")
+    check("a", "ba")
+    check("ab", "a")
+    check("ab", "b")
+    check("ab", "ab")
+    check("ab", "ba")
+    check("", "x")
+    check("", "xy")
   }
 }


### PR DESCRIPTION
This PR attempts to fix `importedNames` and `importedSymbols` in `ImportHandler`. Currently they are broken, causing the following issues:
- https://issues.scala-lang.org/browse/SI-9881
- https://issues.scala-lang.org/browse/SI-9880

Changes in this PR:
- Keep track of both selector `names` & `renames`. Use `names` to lookup symbols from owner. Use `renames` to construct `importedNames`.
- `sym.thisType` will never work for module symbols. Change to ~~`sym.typeOfThis`~~ `sym.moduleClass.thisType`.
- Fix the bug where `typeOfExpression` inadvertently resolves type under `jvm` phase, disregarding requested phase from caller. This is used in `ImportHandler` to find `importableMembers` from objects.
- Cherry-picked @retronym 's change from https://github.com/retronym/scala/tree/review/4698 to filter out flattened inner symbols from `importableMembers`.
