### PR TITLE
Remove doc-version was too long warning

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -154,19 +154,7 @@ trait EntityPage extends HtmlPage {
 
   def search =
     <div id="search">
-        <span id="doc-title">
-          {universe.settings.doctitle.value}
-          <span id="doc-version">
-          {
-            val version = universe.settings.docversion.value
-
-            if (version.length > "XX.XX.XX-XXX".length) {
-              docletReporter.summaryWarning(s"doc-version ($version) was too long to be displayed in the webview, and will be left out. The max length is: XX.XX.XX-XXX")
-              ""
-            } else version
-          }
-          </span>
-        </span>
+        <span id="doc-title">{universe.settings.doctitle.value}<span id="doc-version">{universe.settings.docversion.value}</span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.css
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.css
@@ -167,6 +167,15 @@ textarea, input { outline: none; }
   color: #c2c2c2;
   font-weight: 100;
   font-size: 0.72em;
+  display: inline-block;
+  width: 12ex;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+#search > span#doc-title > span#doc-version:hover {
+  overflow: visible;
 }
 
 #search > span.toggle-sidebar:hover {


### PR DESCRIPTION
It would trigger 3091 times per test run (adding ca. 568k to the log file).
Use CSS to handle overflow instead.
