### PR TITLE
SI-9885 Don't return offset past EOF

### DIFF
--- a/src/reflect/scala/reflect/internal/util/SourceFile.scala
+++ b/src/reflect/scala/reflect/internal/util/SourceFile.scala
@@ -154,18 +154,23 @@ class BatchSourceFile(val file : AbstractFile, content0: Array[Char]) extends So
     case _       => false
   }
 
-  def calculateLineIndices(cs: Array[Char]) = {
-    val buf = new ArrayBuffer[Int]
-    buf += 0
-    for (i <- 0 until cs.length) if (isAtEndOfLine(i)) buf += i + 1
-    buf += cs.length // sentinel, so that findLine below works smoother
-    buf.toArray
+  private lazy val lineIndices: Array[Int] = {
+    def calculateLineIndices(cs: Array[Char]) = {
+      val buf = new ArrayBuffer[Int]
+      buf += 0
+      for (i <- 0 until cs.length) if (isAtEndOfLine(i)) buf += i + 1
+      buf += cs.length // sentinel, so that findLine below works smoother
+      buf.toArray
+    }
+    calculateLineIndices(content)
   }
-  private lazy val lineIndices: Array[Int] = calculateLineIndices(content)
 
-  def lineToOffset(index : Int): Int = lineIndices(index)
+  def lineToOffset(index: Int): Int = {
+    val offset = lineIndices(index)
+    if (offset < length) offset else throw new IndexOutOfBoundsException(index.toString)
+  }
 
-  private var lastLine = 0
+  private[this] var lastLine = 0
 
   /** Convert offset to line in this source file.
    *  Lines are numbered from 0.

--- a/test/junit/scala/reflect/internal/util/SourceFileTest.scala
+++ b/test/junit/scala/reflect/internal/util/SourceFileTest.scala
@@ -5,6 +5,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
+import scala.tools.testing.AssertUtil._
+
 @RunWith(classOf[JUnit4])
 class SourceFileTest {
   def lineContentOf(code: String, offset: Int) =
@@ -56,5 +58,22 @@ class SourceFileTest {
     assertEquals("def", lineContentOf("abc\r\ndef", 7))
     assertEquals("def", lineContentOf("abc\r\ndef", 8))
     assertEquals("def", lineContentOf("abc\r\ndef\r\n", 9))
+  }
+
+  @Test def si9885_lineToOffset(): Unit = {
+    val text = "a\nb\nc\n"
+    val f = new BatchSourceFile("batch", text)
+    assertThrows[IndexOutOfBoundsException] {
+      f.lineToOffset(3)
+    }
+    assertEquals(4, f.lineToOffset(2))
+
+    val p = Position.offset(f, text.length - 1)
+    val q = Position.offset(f, f.lineToOffset(p.line - 1))
+    assertEquals(p.line, q.line)
+    assertEquals(p.column, q.column + 1)
+    assertThrows[IndexOutOfBoundsException] {
+      Position.offset(f, f.lineToOffset(p.line))
+    }
   }
 }


### PR DESCRIPTION
On bad line number, `lineToOffset` should not return
an offset past EOF (which was sentinel, internally).

JIRA: https://issues.scala-lang.org/browse/SI-9885
