### PR TITLE
SI-9717 Implicit class parameters in block in super class

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -608,7 +608,7 @@ trait Contexts { self: Analyzer =>
       // -- If the first statement is in the constructor, scopingCtx == (constructor definition)
       // -- Otherwise, scopingCtx == (the class which contains the constructor)
       val scopingCtx =
-        if (owner.isConstructor) nextEnclosing(c => !c.tree.isInstanceOf[Block])
+        if (owner.isConstructor) nextEnclosing(c => true)
         else this
 
       scopingCtx.outer

--- a/test/files/pos/t9717.flags
+++ b/test/files/pos/t9717.flags
@@ -1,0 +1,1 @@
+-Yno-predef

--- a/test/files/pos/t9717.scala
+++ b/test/files/pos/t9717.scala
@@ -1,0 +1,8 @@
+import scala.Predef.implicitly
+
+class A(val a: Int)
+class B(implicit F: Int) extends A( implicitly[Int] )
+class C(implicit F: Int) extends A( {
+  val v = implicitly[Int]
+  v
+})


### PR DESCRIPTION
This is a WIP PR for discussion and advice, which addresses [Scala Issue 9717](https://issues.scala-lang.org/browse/SI-9717). 

The issue was that, when using a _block_ expressions as arguments in the call to the super-class constructor, any `implicit` parameter of the class was not visible within that block expression.
We add a `pos`  test file, that highlights the existing error. Note that, when using the implicit parameter _without_ the block, it was compiling fine. 

We have traced the issue back to the implicit resolution method. Here, there is an auxiliary method `nextOuter`, which is used when climbing up the context hierarchy, to skip some intermediate contexts. We guess that this was done as an optimization of implifit search, which may have unintentionally broken the semantics. Disabling this context filtering fixes the problem, so the compiler can now handle the positive test.

We do not know if this change could have a detrimental impact on compiler performance. Advice on this issues would be welcome.

This was done with the help of @ausmarton,  @flowcont, and @milessabin.
