### PR TITLE
Add a new flag to support importing an extra user defined predef

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -174,6 +174,7 @@ trait ScalaSettings extends AbsScalaSettings
   val Ynogenericsig   = BooleanSetting    ("-Yno-generic-signatures", "Suppress generation of generic signatures for Java.")
   val noimports       = BooleanSetting    ("-Yno-imports", "Compile without importing scala.*, java.lang.*, or Predef.")
   val nopredef        = BooleanSetting    ("-Yno-predef", "Compile without importing Predef.")
+  val extraPredef     = StringSetting     ("-Yextra-predef", "object", "Supply an extra 'predef' style import for all files", "none")
   val noAdaptedArgs   = BooleanSetting    ("-Yno-adapted-args", "Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.")
   val Yrecursion      = IntSetting        ("-Yrecursion", "Set recursion depth used when locking symbols.", 0, Some((0, Int.MaxValue)), (_: String) => None)
   val Xshowtrees      = BooleanSetting    ("-Yshow-trees", "(Requires -Xprint:) Print detailed ASTs in formatted form.")

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -17,7 +17,7 @@ import scala.tools.nsc.reporters.Reporter
  */
 trait Contexts { self: Analyzer =>
   import global._
-  import definitions.{ JavaLangPackage, ScalaPackage, PredefModule, ScalaXmlTopScope, ScalaXmlPackage }
+  import definitions.{ JavaLangPackage, OptionalExtraPredefPackage, ScalaPackage, PredefModule, ScalaXmlTopScope, ScalaXmlPackage }
   import ContextMode._
 
   protected def onTreeCheckerError(pos: Position, msg: String): Unit = ()
@@ -38,10 +38,15 @@ trait Contexts { self: Analyzer =>
     override def toString = "NoContext"
   }
   private object RootImports {
+    // OptionalExtraPredefPackage, configured via -Yextra-predef, always gets
+    // added to scala compilations regardless of -Yno-preef and -Yno-imports
+    private val extraPredefOrNil = OptionalExtraPredefPackage.toList
+
     // Possible lists of root imports
+    val noImportsList    = extraPredefOrNil
     val javaList         = JavaLangPackage :: Nil
-    val javaAndScalaList = JavaLangPackage :: ScalaPackage :: Nil
-    val completeList     = JavaLangPackage :: ScalaPackage :: PredefModule :: Nil
+    val javaAndScalaList = JavaLangPackage :: ScalaPackage :: extraPredefOrNil
+    val completeList     = JavaLangPackage :: ScalaPackage :: PredefModule :: extraPredefOrNil
   }
 
   def ambiguousImports(imp1: ImportInfo, imp2: ImportInfo) =
@@ -87,7 +92,7 @@ trait Contexts { self: Analyzer =>
   protected def rootImports(unit: CompilationUnit): List[Symbol] = {
     assert(definitions.isDefinitionsInitialized, "definitions uninitialized")
 
-    if (settings.noimports) Nil
+    if (settings.noimports) RootImports.noImportsList
     else if (unit.isJava) RootImports.javaList
     else if (settings.nopredef || treeInfo.noPredefImportForUnit(unit.body)) {
       // SI-8258 Needed for the presentation compiler using -sourcepath, otherwise cycles can occur. See the commit

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -340,7 +340,7 @@ trait Definitions extends api.StandardDefinitions {
     // SI-5941: ScalaPackage and JavaLangPackage are never ever shared between mirrors
     // as a result, `Int` becomes `scala.Int` and `String` becomes `java.lang.String`
     // I could just change `isOmittablePrefix`, but there's more to it, so I'm leaving this as a todo for now
-    lazy val UnqualifiedModules = List(PredefModule, ScalaPackage, JavaLangPackage)
+    lazy val UnqualifiedModules = List(Some(PredefModule), Some(ScalaPackage), Some(JavaLangPackage), OptionalExtraPredefPackage).flatten
     // Those modules and their module classes
     lazy val UnqualifiedOwners  = UnqualifiedModules.toSet ++ UnqualifiedModules.map(_.moduleClass)
 
@@ -350,6 +350,9 @@ trait Definitions extends api.StandardDefinitions {
     def isPredefMemberNamed(sym: Symbol, name: Name) = (
       (sym.name == name) && (sym.owner == PredefModule.moduleClass)
     )
+
+    lazy val OptionalExtraPredefPackage =
+      settings.extraPredef.valueSetByUser.map(value => getPackage(TermName(value)))
 
     /** Specialization.
      */

--- a/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
+++ b/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
@@ -15,6 +15,7 @@ abstract class MutableSettings extends AbsSettings {
   type Setting <: SettingValue
   type BooleanSetting <: Setting { type T = Boolean }
   type IntSetting <: Setting { type T = Int }
+  type StringSetting <: Setting { type T = String }
   type MultiStringSetting <: Setting { type T = List[String] }
 
   // basically this is a value which remembers if it's been modified
@@ -47,6 +48,7 @@ abstract class MutableSettings extends AbsSettings {
   def Yshowsymkinds: BooleanSetting
   def breakCycles: BooleanSetting
   def debug: BooleanSetting
+  def extraPredef: StringSetting
   def developer: BooleanSetting
   def explaintypes: BooleanSetting
   def overrideObjects: BooleanSetting

--- a/src/reflect/scala/reflect/runtime/Settings.scala
+++ b/src/reflect/scala/reflect/runtime/Settings.scala
@@ -24,6 +24,12 @@ private[reflect] class Settings extends MutableSettings {
     override def value: Int = v
   }
 
+  class StringSetting(x: String) extends Setting {
+    type T = String
+    protected var v: String = x
+    override def value: String = v
+  }
+
   class MultiStringSetting(xs: List[String]) extends Setting {
     type T = List[String]
     protected var v: List[String] = xs
@@ -41,6 +47,7 @@ private[reflect] class Settings extends MutableSettings {
   val Yshowsymkinds     = new BooleanSetting(false)
   val breakCycles       = new BooleanSetting(false)
   val debug             = new BooleanSetting(false)
+  val extraPredef       = new StringSetting("none")
   val developer         = new BooleanSetting(false)
   val explaintypes      = new BooleanSetting(false)
   val overrideObjects   = new BooleanSetting(false)

--- a/src/repl/scala/tools/nsc/interpreter/package.scala
+++ b/src/repl/scala/tools/nsc/interpreter/package.scala
@@ -123,13 +123,20 @@ package object interpreter extends ReplConfig with ReplStrings {
           }
           p("")
       }
-      
-      if (filtered.nonEmpty) 
+
+      if (filtered.nonEmpty)
         "" // side-effects above
-      else if (global.settings.nopredef || global.settings.noimports) 
-        "No implicits have been imported."
-      else
-        "No implicits have been imported other than those in Predef." 
+      else if (global.settings.nopredef || global.settings.noimports) {
+        if (global.settings.extraPredef.isSetByUser)
+          "No implicits have been imported other than those due to flag -Yextra-predef"
+        else
+          "No implicits have been imported."
+      } else {
+        if (global.settings.extraPredef.isSetByUser)
+          "No implicits have been imported other than those in Predef and those due to flag -Yextra-predef"
+        else
+          "No implicits have been imported other than those in Predef."
+      }
 
     }
 

--- a/test/files/neg/extra-predef-bad.check
+++ b/test/files/neg/extra-predef-bad.check
@@ -1,0 +1,1 @@
+error: object doesNotExit in compiler mirror not found.

--- a/test/files/neg/extra-predef-bad.flags
+++ b/test/files/neg/extra-predef-bad.flags
@@ -1,0 +1,1 @@
+-Yextra-predef doesNotExit

--- a/test/files/neg/extra-predef-bad.scala
+++ b/test/files/neg/extra-predef-bad.scala
@@ -1,0 +1,1 @@
+class ExtraPredef

--- a/test/files/neg/extra-predef-no-imports.check
+++ b/test/files/neg/extra-predef-no-imports.check
@@ -1,0 +1,7 @@
+C_2.scala:3: error: not found: type Int
+  val b: Int = 5678
+         ^
+C_2.scala:4: error: not found: value println
+  println("fail")
+  ^
+two errors found

--- a/test/files/neg/extra-predef-no-imports/C_2.flags
+++ b/test/files/neg/extra-predef-no-imports/C_2.flags
@@ -1,0 +1,2 @@
+-Yno-imports
+-Yextra-predef hello.minidef

--- a/test/files/neg/extra-predef-no-imports/C_2.scala
+++ b/test/files/neg/extra-predef-no-imports/C_2.scala
@@ -1,0 +1,5 @@
+object Test {
+  val a: INT = 1234
+  val b: Int = 5678
+  println("fail")
+}

--- a/test/files/neg/extra-predef-no-imports/minidef_1.scala
+++ b/test/files/neg/extra-predef-no-imports/minidef_1.scala
@@ -1,0 +1,5 @@
+package hello
+
+object minidef {
+  type INT = scala.Int
+}

--- a/test/files/neg/extra-predef-no-predef.check
+++ b/test/files/neg/extra-predef-no-predef.check
@@ -1,0 +1,4 @@
+C_2.scala:4: error: not found: value println
+  println("fail")
+  ^
+one error found

--- a/test/files/neg/extra-predef-no-predef/C_2.flags
+++ b/test/files/neg/extra-predef-no-predef/C_2.flags
@@ -1,0 +1,2 @@
+-Yno-predef
+-Yextra-predef hello.minidef

--- a/test/files/neg/extra-predef-no-predef/C_2.scala
+++ b/test/files/neg/extra-predef-no-predef/C_2.scala
@@ -1,0 +1,5 @@
+object Test {
+  val a: INT = 1234
+  val b: Int = 5678
+  println("fail")
+}

--- a/test/files/neg/extra-predef-no-predef/minidef_1.scala
+++ b/test/files/neg/extra-predef-no-predef/minidef_1.scala
@@ -1,0 +1,5 @@
+package hello
+
+object minidef {
+  type INT = scala.Int
+}

--- a/test/files/pos/extra-predef/C_2.flags
+++ b/test/files/pos/extra-predef/C_2.flags
@@ -1,0 +1,1 @@
+-Yextra-predef hello.minidef

--- a/test/files/pos/extra-predef/C_2.scala
+++ b/test/files/pos/extra-predef/C_2.scala
@@ -1,0 +1,3 @@
+object Test {
+  val a: INT = 1234
+}

--- a/test/files/pos/extra-predef/minidef_1.scala
+++ b/test/files/pos/extra-predef/minidef_1.scala
@@ -1,0 +1,5 @@
+package hello
+
+object minidef {
+  type INT = scala.Int
+}


### PR DESCRIPTION
This is an attempt to add a flag to support an "extra" user defined predef. The extra predef is always added when the flag is set, regardless of the `-Yno-predef` and `-Yno-imports` flags.

From my initial local testing, all tests pass. I've added one positive test for the new flag and two negative tests for behavior interplay with `-Yno-predef` and `-Yno-imports`.
