### PR TITLE
SI-8873: Annotations on case class constructor parameters

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
@@ -128,7 +128,7 @@ trait Unapplies extends ast.TreeDSL {
    */
   def factoryMeth(mods: Modifiers, name: TermName, cdef: ClassDef): DefDef = {
     val tparams   = constrTparamsInvariant(cdef)
-    val cparamss  = constrParamss(cdef)
+    val cparamss  = mmap(constrParamss(cdef))(param => param.copy(mods = param.mods.copy(annotations = Nil)))
     def classtpe = classType(cdef, tparams)
     atPos(cdef.pos.focus)(
       DefDef(mods, name, tparams, cparamss, classtpe,

--- a/test/files/pos/t8873/t1.scala
+++ b/test/files/pos/t8873/t1.scala
@@ -1,0 +1,3 @@
+object Test {
+  case class A(@volatile var a: Int)
+}


### PR DESCRIPTION
Fixes SI-8873, allowing annotations on case class constructor parameters by stripping them from the generated apply method's parameter list and keeping them on the generated fields. Not sure if this is exactly the approach to take, but I'm not sure which annotations should be removed exactly if not all of them.
