### PR TITLE
SI-9760 Fix for higher-kinded GADT refinement

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1254,7 +1254,6 @@ trait Infer extends Checkable {
       def isFreeTypeParamOfTerm(sym: Symbol) = (
         sym.isAbstractType
           && sym.owner.isTerm
-          && !sym.info.bounds.exists(_.typeParams.nonEmpty)
         )
 
       // Intentionally *not* using `Type#typeSymbol` here, which would normalize `tp`

--- a/test/files/pos/hkgadt.scala
+++ b/test/files/pos/hkgadt.scala
@@ -1,0 +1,18 @@
+package test
+
+object HKGADT {
+  sealed trait Foo[F[_]]
+  final case class Bar() extends Foo[List]
+
+  def frob[F[_]](foo: Foo[F]): F[Int] =
+    foo match {
+      case Bar() =>
+         List(1)
+    }
+
+  sealed trait Foo1[F]
+  final case class Bar1() extends Foo1[Int]
+  def frob1[A](foo: Foo1[A]) = foo match {
+    case Bar1() => 1
+  }
+}


### PR DESCRIPTION
This is a backport of #5106 to 2.11.x for 2.11.9.
