### PR TITLE
SI-9823 Rephrase builders for cache friendliness

### DIFF
--- a/src/library/scala/collection/GenTraversableLike.scala
+++ b/src/library/scala/collection/GenTraversableLike.scala
@@ -399,4 +399,6 @@ trait GenTraversableLike[+A, +Repr] extends Any with GenTraversableOnce[A] with 
    */
   def stringPrefix: String
 
+  protected def sizeHintTo(b: mutable.Builder[_, _], delta: Int): Unit = {}
+
 }

--- a/src/library/scala/collection/IndexedSeqLike.scala
+++ b/src/library/scala/collection/IndexedSeqLike.scala
@@ -92,4 +92,6 @@ trait IndexedSeqLike[+A, +Repr] extends Any with SeqLike[A, Repr] {
     copyToBuffer(result)
     result
   }
+
+  override protected def sizeHintTo(b: mutable.Builder[_, _], delta: Int): Unit = { b.sizeHint(size + delta) }
 }

--- a/src/library/scala/collection/IterableLike.scala
+++ b/src/library/scala/collection/IterableLike.scala
@@ -141,7 +141,7 @@ self =>
   override /*TraversableLike*/ def drop(n: Int): Repr = {
     val b = newBuilder
     val lo = math.max(0, n)
-    b.sizeHint(this, -lo)
+    sizeHintTo(b, -lo)
     var i = 0
     val it = iterator
     while (i < n && it.hasNext) {
@@ -235,7 +235,7 @@ self =>
    */
   def dropRight(n: Int): Repr = {
     val b = newBuilder
-    if (n >= 0) b.sizeHint(this, -n)
+    if (n >= 0) sizeHintTo(b, -n)
     val lead = iterator drop n
     val it = iterator
     while (lead.hasNext) {

--- a/src/library/scala/collection/SeqLike.scala
+++ b/src/library/scala/collection/SeqLike.scala
@@ -272,7 +272,7 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
     for (x <- this)
       xs = x :: xs
     val b = newBuilder
-    b.sizeHint(this)
+    sizeHintTo(b, 0)
     for (x <- xs)
       b += x
     b.result()


### PR DESCRIPTION
The HotSpot VM contains a one element cache in the metadata
of each class to record the most recent successful test for
a secondary interface.

For example:

```
classOf[Serializable].isAssignableFrom(classOf[Some[_]])
```

Would, in addition to returning `true`, set:

```
classOf[Some[_]]._secondary_super_cache = classOf[Serializable]
```

This is done to hide the fact that interface tests are O(N),
where N is the number of inherited interfaces.

This scheme is discussed in "Fast Subtype Checking for the
HotSpot JVM" (Click, Rose) [1]

However, if this cache repeatedly misses, not only are we
exposed to the linear search of the secondary super type array,
but we are also required to write back to the cache. If other
cores are operating on the same cache line, this can lead to
a significant slowdown ("cache thrashing"). This effect will
by most (or only?) visible on multi socket machines.

The pathological case is:

```
scala> Iterator.continually(List(classOf[Product], classOf[Serializable])).flatten.take(100).map(intf => intf.isAssignableFrom(classOf[Some[_]])).count(x => x)
res19: Int = 100
```

Which, if run on a multi-socket machine, should be much slower
than:

```
scala> (Iterator.continually(classOf[Product]).take(50) ++ Iterator.continually(classOf[Serializable]).take(50)).map(intf => intf.isAssignableFrom(classOf[Some[_]])).count(x => x)
res20: Int = 100
```

This commit avoids a interface test in a hot path in the collections
by instead using virtual dispatch to differentiate between
IndexedSeqLike and other collections. HotSpot will use some
shared bookkeeping ("inline cache" [2]) at the callsites of
this method, but these aren't prone to need to write to
memory frequently.

[1] https://www.researchgate.net/publication/221552851_Fast_subtype_checking_in_the_HotSpot_JVM
[2] https://wiki.openjdk.java.net/display/HotSpot/PerformanceTechniques
