### PR TITLE
Deprecate scala.Enumeration, add @enum annotation

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -337,8 +337,12 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
             genLoadQualUnlessElidable()
             genLoadModule(tree)
           } else if (sym.isStaticMember) {
-            genLoadQualUnlessElidable()
-            fieldLoad(sym, receiverClass)
+            if (sym.isJavaEnum) {
+              fieldLoad(sym, receiverClass.companionClass)
+            } else {
+              genLoadQualUnlessElidable()
+              fieldLoad(sym, receiverClass)
+            }
           } else {
             genLoadQualifier(tree)
             fieldLoad(sym, receiverClass)

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -385,18 +385,16 @@ abstract class BCodeHelpers extends BCodeIdiomatic with BytecodeWriters {
   /*
    *  must-single-thread
    */
-  def fieldSymbols(cls: Symbol): List[Symbol] = {
+  def fieldSymbols(cls: Symbol): List[Symbol] =
     for (f <- cls.info.decls.toList ;
          if !f.isMethod && f.isTerm && !f.isModule
     ) yield f
-  }
 
   /*
    * can-multi-thread
    */
-  def methodSymbols(cd: ClassDef): List[Symbol] = {
+  def methodSymbols(cd: ClassDef): List[Symbol] =
     cd.impl.body collect { case dd: DefDef => dd.symbol }
-  }
 
   /*
    *  must-single-thread

--- a/src/compiler/scala/tools/nsc/transform/Fields.scala
+++ b/src/compiler/scala/tools/nsc/transform/Fields.scala
@@ -84,7 +84,7 @@ abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransfor
     else synthFieldsAndAccessors(tp)
 
   // TODO: drop PRESUPER support when we implement trait parameters in 2.13
-  private def excludedAccessorOrFieldByFlags(statSym: Symbol): Boolean = statSym hasFlag PRESUPER
+  private def excludedAccessorOrFieldByFlags(statSym: Symbol): Boolean = statSym hasFlag PRESUPER | JAVA_ENUM
 
   // used for internal communication between info and tree transform of this phase -- not pickled, not in initialflags
   // TODO: reuse MIXEDIN for NEEDS_TREES?
@@ -158,7 +158,7 @@ abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransfor
     // Note that a strict unit-typed val does receive a field, because we cannot omit the write to the field
     // (well, we could emit it for non-@volatile ones, if I understand the memory model correctly,
     //  but that seems pretty edge-casey)
-    val constantTyped = tp.isInstanceOf[ConstantType]
+    val constantTyped = tp.isInstanceOf[ConstantType] && tp.asInstanceOf[ConstantType].value.tag != EnumTag
   }
 
   private def fieldTypeForGetterIn(getter: Symbol, pre: Type): Type = getter.info.finalResultType.asSeenFrom(pre, getter.owner)
@@ -351,7 +351,7 @@ abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransfor
           }
         }
 
-        if (newDecls nonEmpty) {
+        if (newDecls.nonEmpty) {
           val allDecls = newScope
           origDecls foreach allDecls.enter
           newDecls  foreach allDecls.enter

--- a/src/compiler/scala/tools/nsc/transform/Flatten.scala
+++ b/src/compiler/scala/tools/nsc/transform/Flatten.scala
@@ -17,8 +17,7 @@ abstract class Flatten extends InfoTransform {
   /** the following two members override abstract members in Transform */
   val phaseName: String = "flatten"
 
-  /** Updates the owning scope with the given symbol, unlinking any others.
-   */
+  /** Updates the owning scope with the given symbol, unlinking any others. */
   private def replaceSymbolInCurrentScope(sym: Symbol): Unit = exitingFlatten {
     removeSymbolInCurrentScope(sym)
     sym.owner.info.decls enter sym

--- a/src/compiler/scala/tools/nsc/transform/InfoTransform.scala
+++ b/src/compiler/scala/tools/nsc/transform/InfoTransform.scala
@@ -33,6 +33,7 @@ trait InfoTransform extends Transform {
     if (infoTransformers.nextFrom(id).pid != id) {
       // this phase is not yet in the infoTransformers
       val infoTransformer = new InfoTransformer {
+        override def toString = InfoTransform.this.getClass.toString
         val pid = id
         val changesBaseClasses = InfoTransform.this.changesBaseClasses
         def transform(sym: Symbol, tpe: Type): Type = transformInfo(sym, tpe)

--- a/src/compiler/scala/tools/nsc/transform/Statics.scala
+++ b/src/compiler/scala/tools/nsc/transform/Statics.scala
@@ -5,8 +5,7 @@ abstract class Statics extends Transform with ast.TreeDSL {
   import global._
 
   trait StaticsTransformer extends Transformer {
-    /** generate a static constructor with symbol fields inits, or an augmented existing static ctor
-      */
+    /** generate a static constructor with symbol fields inits, or an augmented existing static ctor */
     def staticConstructor(body: List[Tree], localTyper: analyzer.Typer, pos: Position)(newStaticInits: List[Tree]): Tree =
       body.collectFirst {
         // If there already was a static ctor - augment existing one

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -436,7 +436,7 @@ trait Contexts { self: Analyzer =>
      * Construct a child context. The parent and child will share the report buffer.
      * Compare with `makeSilent`, in which the child has a fresh report buffer.
      *
-     * If `tree` is an `Import`, that import will be avaiable at the head of
+     * If `tree` is an `Import`, that import will be available at the head of
      * `Context#imports`.
      */
     def make(tree: Tree = tree, owner: Symbol = owner,

--- a/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
@@ -10,16 +10,13 @@ import symtab.Flags._
 import scala.reflect.internal.util.StringOps.ojoin
 import scala.reflect.internal.util.ListOfNil
 
-/** Logic related to method synthesis which involves cooperation between
- *  Namer and Typer.
- */
+/** Logic related to method synthesis which involves cooperation between Namer and Typer. */
 trait MethodSynthesis {
   self: Analyzer =>
 
   import global._
   import definitions._
   import CODE._
-
 
   class ClassMethodSynthesis(val clazz: Symbol, localTyper: Typer) {
     def mkThis = This(clazz) setPos clazz.pos.focus

--- a/src/compiler/scala/tools/nsc/typechecker/StdAttachments.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/StdAttachments.scala
@@ -107,24 +107,6 @@ trait StdAttachments {
       })
     )
 
-  /** After being synthesized by the parser, primary constructors aren't fully baked yet.
-   *  A call to super in such constructors is just a fill-me-in-later dummy resolved later
-   *  by `parentTypes`. This attachment coordinates `parentTypes` and `typedTemplate` and
-   *  allows them to complete the synthesis.
-   */
-  case class SuperArgsAttachment(argss: List[List[Tree]])
-
-  /** Convenience method for `SuperArgsAttachment`.
-   *  Compared with `MacroRuntimeAttachment` this attachment has different a usage pattern,
-   *  so it really benefits from a dedicated extractor.
-   */
-  def superArgs(tree: Tree): Option[List[List[Tree]]] =
-    tree.attachments.get[SuperArgsAttachment] collect { case SuperArgsAttachment(argss) => argss }
-
-  /** Determines whether the given tree has an associated SuperArgsAttachment.
-   */
-  def hasSuperArgs(tree: Tree): Boolean = superArgs(tree).nonEmpty
-
   /** @see markMacroImplRef
    */
   case object MacroImplRefAttachment
@@ -151,6 +133,39 @@ trait StdAttachments {
    *  because someone has put MacroImplRefAttachment on it.
    */
   def isMacroImplRef(tree: Tree): Boolean = tree.hasAttachment[MacroImplRefAttachment.type]
+
+  /** After being synthesized by the parser, primary constructors aren't fully baked yet.
+   *  A call to super in such constructors is just a fill-me-in-later dummy resolved later
+   *  by `parentTypes`. This attachment coordinates `parentTypes` and `typedTemplate` and
+   *  allows them to complete the synthesis.
+   */
+  case class SuperArgsAttachment(argss: List[List[Tree]])
+
+  /** Convenience method for `SuperArgsAttachment`.
+   *  Compared with `MacroRuntimeAttachment` this attachment has different a usage pattern,
+   *  so it really benefits from a dedicated extractor.
+   */
+  def superArgs(tree: Tree): Option[List[List[Tree]]] =
+    tree.attachments.get[SuperArgsAttachment] collect { case SuperArgsAttachment(argss) => argss }
+
+  /** Determines whether the given tree has an associated SuperArgsAttachment.
+   */
+  def hasSuperArgs(tree: Tree): Boolean = superArgs(tree).nonEmpty
+
+
+  /** In the typeCompleter (templateSig) of a case class (resp it's module),
+   *  synthetic `copy` (reps `apply`, `unapply`) methods are added. To compute
+   *  their signatures, the corresponding ClassDef is needed. During naming (in
+   *  `enterClassDef`), the case class ClassDef is added as an attachment to the
+   *  moduleClass symbol of the companion module.
+   */
+  case class ClassForCaseCompanionAttachment(caseClass: ClassDef)
+
+  /** We need to pass the tree of the class to the companion object as the methods there need to know which methods where defined. */
+  case class EnumConstantsAttachment(constants: List[TermName])
+
+  /** We use this to keep track of the right ordinal value in typedStat as we read one enum constant after another. */
+  case class EnumConstantOrdinalAttachment(value: Int)
 
   /** Since mkInvoke, the applyDynamic/selectDynamic/etc desugarer, is disconnected
    *  from typedNamedApply, the applyDynamicNamed argument rewriter, the latter

--- a/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
@@ -24,15 +24,7 @@ trait Unapplies extends ast.TreeDSL {
   private def unapplyParamName = nme.x_0
   private def caseMods         = Modifiers(SYNTHETIC | CASE)
 
-  // In the typeCompleter (templateSig) of a case class (resp it's module),
-  // synthetic `copy` (reps `apply`, `unapply`) methods are added. To compute
-  // their signatures, the corresponding ClassDef is needed. During naming (in
-  // `enterClassDef`), the case class ClassDef is added as an attachment to the
-  // moduleClass symbol of the companion module.
-  class ClassForCaseCompanionAttachment(val caseClass: ClassDef)
-
-  /** Returns unapply or unapplySeq if available, without further checks.
-   */
+  /** Returns unapply or unapplySeq if available, without further checks. */
   def directUnapplyMember(tp: Type): Symbol = (tp member nme.unapply) orElse (tp member nme.unapplySeq)
 
   /** Filters out unapplies with multiple (non-implicit) parameter lists,

--- a/src/library/scala/Enumeration.scala
+++ b/src/library/scala/Enumeration.scala
@@ -50,6 +50,7 @@ import scala.util.matching.Regex
  *                 identifies values at run-time.
  *  @author  Matthias Zenger
  */
+@deprecated("use @enum instead", "2.12.0")
 @SerialVersionUID(8476000850333817230L)
 abstract class Enumeration (initial: Int) extends Serializable {
   thisenum =>

--- a/src/library/scala/enum.scala
+++ b/src/library/scala/enum.scala
@@ -1,0 +1,11 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2002-2016, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala
+
+class enum extends scala.annotation.StaticAnnotation

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -970,7 +970,10 @@ trait Definitions extends api.StandardDefinitions {
       //  - .owner: the ModuleClassSymbol of the enumeration (object E)
       //  - .linkedClassOfClass: the ClassSymbol of the enumeration (class E)
       // SI-6613 Subsequent runs of the resident compiler demand the phase discipline here.
-      enteringPhaseNotLaterThan(picklerPhase)(sym.owner.linkedClassOfClass).tpe
+      if (sym.isJavaDefined)
+        enteringPhaseNotLaterThan(picklerPhase)(sym.owner.linkedClassOfClass).tpe
+      else
+        enteringPhaseNotLaterThan(picklerPhase)(sym.owner).tpe
     }
 
     /** Given a class symbol C with type parameters T1, T2, ... Tn
@@ -1169,6 +1172,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val DeprecatedNameAttr         = requiredClass[scala.deprecatedName]
     lazy val DeprecatedInheritanceAttr  = requiredClass[scala.deprecatedInheritance]
     lazy val DeprecatedOverridingAttr   = requiredClass[scala.deprecatedOverriding]
+    lazy val EnumAttr                   = requiredClass[scala.enum]
     lazy val NativeAttr                 = requiredClass[scala.native]
     lazy val RemoteAttr                 = requiredClass[scala.remote]
     lazy val ScalaInlineClass           = requiredClass[scala.inline]

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -3598,8 +3598,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     creator(syms1, tpe.substSym(syms, syms1))
   }
 
-  /** A deep map on a symbol's paramss.
-   */
+  /** A deep map on a symbol's paramss. */
   def mapParamss[T](sym: Symbol)(f: Symbol => T): List[List[T]] = mmap(sym.info.paramss)(f)
 
   def existingSymbols(syms: List[Symbol]): List[Symbol] =

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -393,6 +393,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.DeprecatedNameAttr
     definitions.DeprecatedInheritanceAttr
     definitions.DeprecatedOverridingAttr
+    definitions.EnumAttr
     definitions.NativeAttr
     definitions.RemoteAttr
     definitions.ScalaInlineClass

--- a/test/files/jvm/serialization-new.check
+++ b/test/files/jvm/serialization-new.check
@@ -1,6 +1,6 @@
 warning: there were two deprecation warnings (since 2.11.0)
-warning: there were three deprecation warnings (since 2.12.0)
-warning: there were 5 deprecation warnings in total; re-run with -deprecation for details
+warning: there were four deprecation warnings (since 2.12.0)
+warning: there were 6 deprecation warnings in total; re-run with -deprecation for details
 a1 = Array[1,2,3]
 _a1 = Array[1,2,3]
 arrayEquals(a1, _a1): true

--- a/test/files/jvm/serialization.check
+++ b/test/files/jvm/serialization.check
@@ -1,6 +1,6 @@
 warning: there were two deprecation warnings (since 2.11.0)
-warning: there was one deprecation warning (since 2.12.0)
-warning: there were three deprecation warnings in total; re-run with -deprecation for details
+warning: there were two deprecation warnings (since 2.12.0)
+warning: there were four deprecation warnings in total; re-run with -deprecation for details
 a1 = Array[1,2,3]
 _a1 = Array[1,2,3]
 arrayEquals(a1, _a1): true

--- a/test/files/jvm/t2214.check
+++ b/test/files/jvm/t2214.check
@@ -1,3 +1,4 @@
+warning: there was one deprecation warning (since 2.12.0); re-run with -deprecation for details
 got DEBT
 got FUTURE
 got EQUITY

--- a/test/files/jvm/t2827.check
+++ b/test/files/jvm/t2827.check
@@ -1,3 +1,4 @@
+warning: there was one deprecation warning (since 2.12.0); re-run with -deprecation for details
 Larry
 Curly
 Moe

--- a/test/files/neg/virtpatmat_unreach_select.check
+++ b/test/files/neg/virtpatmat_unreach_select.check
@@ -1,6 +1,7 @@
 virtpatmat_unreach_select.scala:10: warning: unreachable code
     case WARNING.id => // unreachable
                     ^
+warning: there was one deprecation warning (since 2.12.0); re-run with -deprecation for details
 error: No warnings can be incurred under -Xfatal-warnings.
-one warning found
+two warnings found
 one error found

--- a/test/files/res/t831.check
+++ b/test/files/res/t831.check
@@ -1,4 +1,5 @@
 
-nsc> 
+nsc> warning: there was one deprecation warning (since 2.12.0); re-run with -deprecation for details
+
 nsc> 
 nsc> 

--- a/test/files/run/enumerations.check
+++ b/test/files/run/enumerations.check
@@ -1,0 +1,16 @@
+warning: there were 8 deprecation warnings (since 2.12.0); re-run with -deprecation for details
+test Test1 was successful
+test Test2 was successful
+test Test3 was successful
+test Test4 was successful
+
+D1.ValueSet(North, East)
+D2.ValueSet(North, East)
+D1.ValueSet(North, East, West)
+D2.ValueSet(North, East, West)
+List(101)
+List(101)
+D1.ValueSet(North, East)
+D2.ValueSet(North, East)
+WeekDays.ValueSet(Tue, Wed, Thu, Fri)
+

--- a/test/files/run/enumerations.scala
+++ b/test/files/run/enumerations.scala
@@ -1,0 +1,161 @@
+//############################################################################
+// Enumerations
+//############################################################################
+
+object Test1 {
+
+  object WeekDays extends Enumeration  {
+    val Mon, Tue, Wed, Thu, Fri, Sat, Sun = Value
+  }
+
+  def isWorkingDay(d: WeekDays.Value) =
+    ! (d == WeekDays.Sat || d == WeekDays.Sun);
+
+  def run: Int = {
+    val it = WeekDays.values filter (isWorkingDay);
+    it.toList.length
+  }
+}
+
+object Test2 {
+
+  object ThreadState extends Enumeration {
+    val New          = Value("NEW");
+    val Runnable     = Value("RUNNABLE");
+    val Blocked      = Value("BLOCKED");
+    val Waiting      = Value("WAITING");
+    val TimedWaiting = Value("TIMED_WAITING");
+    val Terminated   = Value("TERMINATED");
+  }
+
+  def run: Int = {
+    val it = for (s <- ThreadState.values; if s.id != 0) yield s;
+    it.toList.length
+  }
+}
+
+object Test3 {
+
+  object Direction extends Enumeration {
+    val North = Value("North")
+    val South = Value("South")
+    val East = Value("East")
+    val West = Value("West")
+  }
+
+  def run: Int = {
+    val it = for (d <- Direction.values; if d.toString() startsWith "N") yield d;
+    it.toList.length
+  }
+}
+
+object Test4 {
+
+  object Direction extends Enumeration {
+    val North = Value("North")
+    val South = Value("South")
+    val East = Value("East")
+    val West = Value("West")
+  }
+
+  def run: Int = {
+    val dir = Direction.withName("North")
+    assert(dir.toString == "North")
+    try {
+      Direction.withName("Nord")
+      assert(false)
+    } catch {
+      case e: Exception => /* do nothing */
+    }
+    0
+  }
+}
+
+object Test5 {
+
+  object D1 extends Enumeration(0) {
+    val North, South, East, West = Value;
+  }
+
+  object D2 extends Enumeration(-2) {
+    val North, South, East, West = Value;
+  }
+
+  object WeekDays extends Enumeration  {
+    val Mon, Tue, Wed, Thu, Fri, Sat, Sun = Value
+  }
+
+  def run {
+    val s1 = D1.ValueSet(D1.North, D1.East)
+    val s2 = D2.North + D2.East
+    println(s1)
+    println(s2)
+    println(s1 + D1.West)
+    println(s2 + D2.West)
+    println(s1.toBitMask.map(_.toBinaryString).toList)
+    println(s2.toBitMask.map(_.toBinaryString).toList)
+    println(D1.ValueSet.fromBitMask(s1.toBitMask))
+    println(D2.ValueSet.fromBitMask(s2.toBitMask))
+    println(WeekDays.values.range(WeekDays.Tue, WeekDays.Sat))
+  }
+}
+
+object SerializationTest {
+  object Types extends Enumeration { val X, Y = Value }
+  class A extends java.io.Serializable { val types = Types.values }
+  class B extends java.io.Serializable { val types = Set(Types.X, Types.Y) }
+
+  def serialize(obj: AnyRef) = {
+    val baos = new java.io.ByteArrayOutputStream()
+    val oos = new java.io.ObjectOutputStream(baos)
+    oos.writeObject(obj)
+    oos.close()
+    val bais = new java.io.ByteArrayInputStream(baos.toByteArray)
+    val ois = new java.io.ObjectInputStream(bais)
+    val prime = ois.readObject()
+    ois.close()
+    prime
+  }
+
+  def run {
+    serialize(new B())
+    serialize(new A())
+  }
+}
+
+//############################################################################
+// Test code
+
+object Test {
+
+  def check_success(name: String, closure: => Int, expected: Int): Unit = {
+    Console.print("test " + name);
+    try {
+      val actual: Int = closure;
+      if (actual == expected) {
+        Console.print(" was successful");
+      } else {
+        Console.print(" failed: expected "+ expected +", found "+ actual);
+      }
+    } catch {
+      case exception: Throwable => {
+        Console.print(" raised exception " + exception);
+        exception.printStackTrace();
+      }
+    }
+    Console.println;
+  }
+
+  def main(args: Array[String]): Unit = {
+    check_success("Test1", Test1.run, 5);
+    check_success("Test2", Test2.run, 5);
+    check_success("Test3", Test3.run, 1);
+    check_success("Test4", Test4.run, 0);
+    Console.println;
+    Test5.run;
+    Console.println;
+    SerializationTest.run;
+  }
+}
+
+//############################################################################

--- a/test/files/run/enums.check
+++ b/test/files/run/enums.check
@@ -1,15 +1,124 @@
-test Test1 was successful
-test Test2 was successful
-test Test3 was successful
-test Test4 was successful
+enums.scala:23: warning: match may not be exhaustive.
+It would fail on the following inputs: ConstructorWeek(), Friday, Monday, Thursday, Tuesday, Wednesday
+  def isWeekendMissing = this match {
+                         ^
+enums.scala:45: warning: match may not be exhaustive.
+It would fail on the following inputs: $anon(), $anon(), $anon(), Friday, MethodWeek(), Monday, Thursday, Tuesday, Wednesday
+  def isWeekendMissing = this match {
+                         ^
+enums.scala:61: warning: match may not be exhaustive.
+It would fail on the following inputs: $anon(), $anon(), $anon(), ArgNamedWeek(), Friday, Monday, Thursday, Tuesday, Wednesday
+  def isWeekendMissing = this match {
+                         ^
+enums.scala:77: warning: match may not be exhaustive.
+It would fail on the following inputs: $anon(), $anon(), $anon(), CaseWeek(_), Friday, Monday, Thursday, Tuesday, Wednesday
+  def isWeekendCase = this match {
+                      ^
+enums.scala:81: warning: match may not be exhaustive.
+It would fail on the following inputs: $anon(), $anon(), $anon(), CaseWeek(_), Friday, Monday, Thursday, Tuesday, Wednesday
+  def isWeekendMissing = this match {
+                         ^
+enums.scala:163: warning: match may not be exhaustive.
+It would fail on the following inputs: Friday, Monday, Thursday, Tuesday, Wednesday, Week()
+  def isWeekendMissing(week: Week) = week match {
+                                     ^
+==== enum Empty ====
+true
+16401
+FINAL PUBLIC
+class java.lang.Enum
+List()
+List(private Empty(java.lang.String,int))
+List(public static Empty Empty.valueOf(java.lang.String), public static Empty[] Empty.values())
+List(private static final Empty[] Empty.$VALUES)
+List()
 
-D1.ValueSet(North, East)
-D2.ValueSet(North, East)
-D1.ValueSet(North, East, West)
-D2.ValueSet(North, East, West)
-List(101)
-List(101)
-D1.ValueSet(North, East)
-D2.ValueSet(North, East)
-WeekDays.ValueSet(Tue, Wed, Thu, Fri)
+==== enum ReallyEmpty ====
+true
+16401
+FINAL PUBLIC
+class java.lang.Enum
+List()
+List(private ReallyEmpty(java.lang.String,int))
+List(public static ReallyEmpty ReallyEmpty.valueOf(java.lang.String), public static ReallyEmpty[] ReallyEmpty.values())
+List(private static final ReallyEmpty[] ReallyEmpty.$VALUES)
+List()
 
+==== enum Week ====
+true
+16401
+FINAL PUBLIC
+class java.lang.Enum
+List()
+List(private Week(java.lang.String,int))
+List(public static Week Week.valueOf(java.lang.String), public static Week[] Week.values())
+List(private static final Week[] Week.$VALUES, public static final Week Week.Friday, public static final Week Week.Monday, public static final Week Week.Saturday, public static final Week Week.Sunday, public static final Week Week.Thursday, public static final Week Week.Tuesday, public static final Week Week.Wednesday)
+true
+List(Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday)
+true
+true
+true
+true
+
+==== enum ConstructorWeek ====
+true
+16401
+FINAL PUBLIC
+class java.lang.Enum
+List()
+List(private ConstructorWeek(java.lang.String,int,boolean))
+List(public boolean ConstructorWeek.isWeekend(), public boolean ConstructorWeek.isWeekendMissing(), public static ConstructorWeek ConstructorWeek.valueOf(java.lang.String), public static ConstructorWeek[] ConstructorWeek.values())
+List(private static final ConstructorWeek[] ConstructorWeek.$VALUES, public static final ConstructorWeek ConstructorWeek.Friday, public static final ConstructorWeek ConstructorWeek.Monday, public static final ConstructorWeek ConstructorWeek.Saturday, public static final ConstructorWeek ConstructorWeek.Sunday, public static final ConstructorWeek ConstructorWeek.Thursday, public static final ConstructorWeek ConstructorWeek.Tuesday, public static final ConstructorWeek ConstructorWeek.Wednesday, private final boolean ConstructorWeek.isWeekend)
+true
+List(Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday)
+true
+true
+(List(Saturday, Sunday),List(Monday, Tuesday, Wednesday, Thursday, Friday))
+
+==== enum MethodWeek ====
+true
+16385
+PUBLIC
+class java.lang.Enum
+List()
+List(public MethodWeek(java.lang.String,int))
+List(public boolean MethodWeek.isGoodDay(), public boolean MethodWeek.isWeekend(), public boolean MethodWeek.isWeekendMissing(), public static MethodWeek MethodWeek.valueOf(java.lang.String), public static MethodWeek[] MethodWeek.values())
+List(private static final MethodWeek[] MethodWeek.$VALUES, public static final MethodWeek MethodWeek.Friday, public static final MethodWeek MethodWeek.Monday, public static final MethodWeek MethodWeek.Saturday, public static final MethodWeek MethodWeek.Sunday, public static final MethodWeek MethodWeek.Thursday, public static final MethodWeek MethodWeek.Tuesday, public static final MethodWeek MethodWeek.Wednesday)
+true
+List(Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday)
+true
+true
+(List(Saturday, Sunday),List(Monday, Tuesday, Wednesday, Thursday, Friday))
+(List(Friday, Saturday, Sunday),List(Monday, Tuesday, Wednesday, Thursday))
+
+==== enum ArgNamedWeek ====
+true
+16385
+PUBLIC
+class java.lang.Enum
+List()
+List(public ArgNamedWeek(java.lang.String,int,boolean))
+List(public boolean ArgNamedWeek.isGoodDay(), public boolean ArgNamedWeek.isWeekend(), public boolean ArgNamedWeek.isWeekendMissing(), public static ArgNamedWeek ArgNamedWeek.valueOf(java.lang.String), public static ArgNamedWeek[] ArgNamedWeek.values())
+List(private static final ArgNamedWeek[] ArgNamedWeek.$VALUES, public static final ArgNamedWeek ArgNamedWeek.Friday, public static final ArgNamedWeek ArgNamedWeek.Monday, public static final ArgNamedWeek ArgNamedWeek.Saturday, public static final ArgNamedWeek ArgNamedWeek.Sunday, public static final ArgNamedWeek ArgNamedWeek.Thursday, public static final ArgNamedWeek ArgNamedWeek.Tuesday, public static final ArgNamedWeek ArgNamedWeek.Wednesday, private final boolean ArgNamedWeek.isWeekend)
+true
+List(Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday)
+true
+true
+(List(Saturday, Sunday),List(Monday, Tuesday, Wednesday, Thursday, Friday))
+(List(Friday, Saturday, Sunday),List(Monday, Tuesday, Wednesday, Thursday))
+
+==== enum CaseWeek ====
+true
+16385
+PUBLIC
+class java.lang.Enum
+List(interface scala.Product, interface scala.Serializable)
+List(public CaseWeek(java.lang.String,int,boolean))
+List(public static CaseWeek CaseWeek.apply(java.lang.String,int,boolean), public boolean CaseWeek.canEqual(java.lang.Object), public CaseWeek CaseWeek.copy(java.lang.String,int,boolean), public java.lang.String CaseWeek.copy$default$1(), public int CaseWeek.copy$default$2(), public boolean CaseWeek.copy$default$3(), public boolean CaseWeek.isGoodDay(), public boolean CaseWeek.isWeekend(), public boolean CaseWeek.isWeekendCase(), public boolean CaseWeek.isWeekendMissing(), public int CaseWeek.productArity(), public java.lang.Object CaseWeek.productElement(int), public scala.collection.Iterator CaseWeek.productIterator(), public java.lang.String CaseWeek.productPrefix(), public static scala.Option CaseWeek.unapply(CaseWeek), public static CaseWeek CaseWeek.valueOf(java.lang.String), public static CaseWeek[] CaseWeek.values())
+List(private static final CaseWeek[] CaseWeek.$VALUES, public static final CaseWeek CaseWeek.Friday, public static final CaseWeek CaseWeek.Monday, public static final CaseWeek CaseWeek.Saturday, public static final CaseWeek CaseWeek.Sunday, public static final CaseWeek CaseWeek.Thursday, public static final CaseWeek CaseWeek.Tuesday, public static final CaseWeek CaseWeek.Wednesday, private final boolean CaseWeek.isWeekend, private final java.lang.String CaseWeek.name, private final int CaseWeek.ordinal)
+true
+List(Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday)
+true
+true
+(List(Saturday, Sunday),List(Monday, Tuesday, Wednesday, Thursday, Friday))
+(List(Friday, Saturday, Sunday),List(Monday, Tuesday, Wednesday, Thursday))

--- a/test/files/run/enums.scala
+++ b/test/files/run/enums.scala
@@ -1,161 +1,232 @@
-//############################################################################
-// Enumerations
-//############################################################################
+@enum class Empty {}
+@enum class ReallyEmpty
 
-object Test1 {
+@enum class Week {
+  Monday
+  Tuesday
+  Wednesday
+  Thursday
+  Friday
+  Saturday
+  Sunday
+}
 
-  object WeekDays extends Enumeration  {
-    val Mon, Tue, Wed, Thu, Fri, Sat, Sun = Value
-  }
+@enum class ConstructorWeek(val isWeekend: Boolean) {
+  Monday(false)
+  Tuesday(false)
+  Wednesday(false)
+  Thursday(false)
+  Friday(false)
+  Saturday(true)
+  Sunday(true)
 
-  def isWorkingDay(d: WeekDays.Value) =
-    ! (d == WeekDays.Sat || d == WeekDays.Sun);
-
-  def run: Int = {
-    val it = WeekDays.values filter (isWorkingDay);
-    it.toList.length
+  def isWeekendMissing = this match {
+    case Saturday
+       | ConstructorWeek.Sunday   => true
   }
 }
 
-object Test2 {
+@enum class MethodWeek {
+  Monday
+  Tuesday
+  Wednesday
+  Thursday
+  Friday   { val isGoodDay = true }
+  Saturday { def isGoodDay = true }
+  Sunday   { def isGoodDay = true }
 
-  object ThreadState extends Enumeration {
-    val New          = Value("NEW");
-    val Runnable     = Value("RUNNABLE");
-    val Blocked      = Value("BLOCKED");
-    val Waiting      = Value("WAITING");
-    val TimedWaiting = Value("TIMED_WAITING");
-    val Terminated   = Value("TERMINATED");
+  def isGoodDay: Boolean = false
+
+  def isWeekend = this match {
+    case Saturday
+       | MethodWeek.Sunday   => true
+    case _                   => false
   }
-
-  def run: Int = {
-    val it = for (s <- ThreadState.values; if s.id != 0) yield s;
-    it.toList.length
-  }
-}
-
-object Test3 {
-
-  object Direction extends Enumeration {
-    val North = Value("North")
-    val South = Value("South")
-    val East = Value("East")
-    val West = Value("West")
-  }
-
-  def run: Int = {
-    val it = for (d <- Direction.values; if d.toString() startsWith "N") yield d;
-    it.toList.length
+  def isWeekendMissing = this match {
+    case Saturday
+       | MethodWeek.Sunday   => true
   }
 }
 
-object Test4 {
+@enum class ArgNamedWeek(val isWeekend: Boolean) {
+  Monday(false)
+  Tuesday(false)
+  Wednesday(false)
+  Thursday(false)
+  Friday(false)            { val isGoodDay = true }
+  Saturday(true)           { def isGoodDay = true }
+  Sunday(isWeekend = true) { def isGoodDay = true }
 
-  object Direction extends Enumeration {
-    val North = Value("North")
-    val South = Value("South")
-    val East = Value("East")
-    val West = Value("West")
-  }
-
-  def run: Int = {
-    val dir = Direction.withName("North")
-    assert(dir.toString == "North")
-    try {
-      Direction.withName("Nord")
-      assert(false)
-    } catch {
-      case e: Exception => /* do nothing */
-    }
-    0
+  def isGoodDay: Boolean = false
+  def isWeekendMissing = this match {
+    case Saturday
+       | ArgNamedWeek.Sunday   => true
   }
 }
 
-object Test5 {
+@enum case class CaseWeek(isWeekend: Boolean) {
+  Monday(false)
+  Tuesday(false)
+  Wednesday(false)
+  Thursday(false)
+  Friday(false)            { val isGoodDay = true }
+  Saturday(true)           { def isGoodDay = true }
+  Sunday(isWeekend = true) { def isGoodDay = true }
 
-  object D1 extends Enumeration(0) {
-    val North, South, East, West = Value;
+  def isGoodDay: Boolean = false
+  def isWeekendCase = this match {
+    case Saturday //(true)
+       | CaseWeek.Sunday   => true
   }
-
-  object D2 extends Enumeration(-2) {
-    val North, South, East, West = Value;
-  }
-
-  object WeekDays extends Enumeration  {
-    val Mon, Tue, Wed, Thu, Fri, Sat, Sun = Value
-  }
-
-  def run {
-    val s1 = D1.ValueSet(D1.North, D1.East)
-    val s2 = D2.North + D2.East
-    println(s1)
-    println(s2)
-    println(s1 + D1.West)
-    println(s2 + D2.West)
-    println(s1.toBitMask.map(_.toBinaryString).toList)
-    println(s2.toBitMask.map(_.toBinaryString).toList)
-    println(D1.ValueSet.fromBitMask(s1.toBitMask))
-    println(D2.ValueSet.fromBitMask(s2.toBitMask))
-    println(WeekDays.values.range(WeekDays.Tue, WeekDays.Sat))
+  def isWeekendMissing = this match {
+    case Saturday
+       | CaseWeek.Sunday   => true
   }
 }
 
-object SerializationTest {
-  object Types extends Enumeration { val X, Y = Value }
-  class A extends java.io.Serializable { val types = Types.values }
-  class B extends java.io.Serializable { val types = Set(Types.X, Types.Y) }
+/*
+@enum class ArgDefaultWeek(isWeekend: Boolean = false) {
+  Monday
+  Tuesday
+  Wednesday
+  Thursday
+  Friday
+  Saturday(true)
+  Sunday(true)
+}
 
-  def serialize(obj: AnyRef) = {
-    val baos = new java.io.ByteArrayOutputStream()
-    val oos = new java.io.ObjectOutputStream(baos)
-    oos.writeObject(obj)
-    oos.close()
-    val bais = new java.io.ByteArrayInputStream(baos.toByteArray)
-    val ois = new java.io.ObjectInputStream(bais)
-    val prime = ois.readObject()
-    ois.close()
-    prime
-  }
-
-  def run {
-    serialize(new B())
-    serialize(new A())
+object Nested {
+  @enum class Week {
+    Monday
+    Tuesday
+    Wednesday
+    Thursday
+    Friday
+    Saturday
+    Sunday
   }
 }
 
-//############################################################################
-// Test code
-
-object Test {
-
-  def check_success(name: String, closure: => Int, expected: Int): Unit = {
-    Console.print("test " + name);
-    try {
-      val actual: Int = closure;
-      if (actual == expected) {
-        Console.print(" was successful");
-      } else {
-        Console.print(" failed: expected "+ expected +", found "+ actual);
-      }
-    } catch {
-      case exception: Throwable => {
-        Console.print(" raised exception " + exception);
-        exception.printStackTrace();
-      }
-    }
-    Console.println;
-  }
-
-  def main(args: Array[String]): Unit = {
-    check_success("Test1", Test1.run, 5);
-    check_success("Test2", Test2.run, 5);
-    check_success("Test3", Test3.run, 1);
-    check_success("Test4", Test4.run, 0);
-    Console.println;
-    Test5.run;
-    Console.println;
-    SerializationTest.run;
+class Nested {
+  @enum class Week {
+    Monday
+    Tuesday
+    Wednesday
+    Thursday
+    Friday
+    Saturday
+    Sunday
   }
 }
+*/
 
-//############################################################################
+/*
+@enum sealed abstract class EmptyADT
+
+@enum sealed abstract class ADT
+object One extends ADT
+
+@enum sealed abstract class CaseADT
+case object One
+
+@enum sealed abstract class NestedADT
+object NestedADT {
+  object One
+}
+
+@enum sealed abstract class NestedCaseADT
+object NestedCaseADT {
+  case object One
+}
+*/
+
+object Test extends App {
+
+  printEnumInfo(classOf[Empty])
+  println(Empty.values.toList)
+  println()
+
+  printEnumInfo(classOf[ReallyEmpty])
+  println(ReallyEmpty.values.toList)
+  println()
+
+  printEnumInfo(classOf[Week])
+  println(Week.Monday.getClass.isEnum)
+  println(Week.values.toList)
+  println(Week.valueOf("Friday") == Week.Friday)
+  println(Week.Saturday.compareTo(Week.Sunday) < 0)
+  println(isWeekendMissing(Week.Sunday))
+  println(!isWeekendComplete(Week.Thursday))
+  println()
+  // warning: match may not be exhaustive.
+  // It would fail on the following inputs: Friday, Monday, Tuesday, Wednesday, Week()
+  def isWeekendMissing(week: Week) = week match {
+    case Week.Saturday
+       | Week.Sunday   => true
+  }
+  def isWeekendComplete(week: Week) = week match {
+    case Week.Saturday
+       | Week.Sunday   => true
+    case _             => false
+  }
+
+  printEnumInfo(classOf[ConstructorWeek])
+  println(ConstructorWeek.Monday.getClass.isEnum)
+  println(ConstructorWeek.values.toList)
+  println(ConstructorWeek.valueOf("Friday") == ConstructorWeek.Friday)
+  println(ConstructorWeek.Saturday.compareTo(ConstructorWeek.Sunday) < 0)
+  println(ConstructorWeek.values.toList.partition(_.isWeekend))
+  println()
+
+  printEnumInfo(classOf[MethodWeek])
+  println(MethodWeek.Monday.getClass.isEnum)
+  println(MethodWeek.values.toList)
+  println(MethodWeek.valueOf("Friday") == MethodWeek.Friday)
+  println(MethodWeek.Saturday.compareTo(MethodWeek.Sunday) < 0)
+  println(MethodWeek.values.toList.partition(_.isWeekend))
+  println(MethodWeek.values.toList.partition(_.isGoodDay))
+  println()
+
+  printEnumInfo(classOf[ArgNamedWeek])
+  println(ArgNamedWeek.Monday.getClass.isEnum)
+  println(ArgNamedWeek.values.toList)
+  println(ArgNamedWeek.valueOf("Friday") == ArgNamedWeek.Friday)
+  println(ArgNamedWeek.Saturday.compareTo(ArgNamedWeek.Sunday) < 0)
+  println(ArgNamedWeek.values.toList.partition(_.isWeekend))
+  println(ArgNamedWeek.values.toList.partition(_.isGoodDay))
+  println()
+
+  printEnumInfo(classOf[CaseWeek])
+  println(CaseWeek.Monday.getClass.isEnum)
+  println(CaseWeek.values.toList)
+  println(CaseWeek.valueOf("Friday") == CaseWeek.Friday)
+  println(CaseWeek.Saturday.compareTo(CaseWeek.Sunday) < 0)
+  println(CaseWeek.values.toList.partition(_.isWeekend))
+  println(CaseWeek.values.toList.partition(_.isGoodDay))
+
+  def modifiersToString(flags: Int): String = {
+    import java.lang.reflect.Modifier
+    var buf = new StringBuilder
+    if (Modifier.isAbstract (flags)) buf ++= "ABSTRACT "
+    if (Modifier.isFinal    (flags)) buf ++= "FINAL "
+    if (Modifier.isInterface(flags)) buf ++= "INTERFACE "
+    if (Modifier.isPrivate  (flags)) buf ++= "PRIVATE "
+    if (Modifier.isProtected(flags)) buf ++= "PROTECTED "
+    if (Modifier.isPublic   (flags)) buf ++= "PUBLIC "
+    if (Modifier.isStatic   (flags)) buf ++= "STATIC "
+    buf = buf.init
+    buf.toString()
+  }
+
+  def printEnumInfo(clazz: Class[_ <: Enum[_]]): Unit = {
+    println(s"==== enum ${clazz.getSimpleName} ====")
+    println(clazz.isEnum)
+    println(clazz.getModifiers)
+    println(modifiersToString(clazz.getModifiers))
+    println(clazz.getSuperclass)
+    println(clazz.getInterfaces.toList)
+    println(clazz.getDeclaredConstructors.toList)
+    println(clazz.getDeclaredMethods.toList.sortBy(_.getName))
+    println(clazz.getDeclaredFields.toList.sortBy(_.getName))
+  }
+}

--- a/test/files/run/iterator-from.check
+++ b/test/files/run/iterator-from.check
@@ -1,3 +1,1 @@
 warning: there was one deprecation warning (since 2.12.0); re-run with -deprecation for details
-t.ValueSet(a, b)
-t.ValueSet(a, b)

--- a/test/files/run/manifests-new.check
+++ b/test/files/run/manifests-new.check
@@ -1,2 +1,1 @@
 warning: there were two deprecation warnings (since 2.12.0); re-run with -deprecation for details
-false

--- a/test/files/run/t1505.check
+++ b/test/files/run/t1505.check
@@ -1,2 +1,1 @@
 warning: there were two deprecation warnings (since 2.12.0); re-run with -deprecation for details
-false

--- a/test/files/run/t2111.check
+++ b/test/files/run/t2111.check
@@ -1,3 +1,4 @@
+warning: there were two deprecation warnings (since 2.12.0); re-run with -deprecation for details
 Red
 Green
 Blue

--- a/test/files/run/t3616.check
+++ b/test/files/run/t3616.check
@@ -1,1 +1,2 @@
+warning: there were two deprecation warnings (since 2.12.0); re-run with -deprecation for details
 Fruit.ValueSet(A, B, C)

--- a/test/files/run/t3719.check
+++ b/test/files/run/t3719.check
@@ -1,3 +1,4 @@
+warning: there was one deprecation warning (since 2.12.0); re-run with -deprecation for details
 List(Mon, Tue, Wed, Thu, Fri, Sat, Sun)
 Mon
 Tue

--- a/test/files/run/t3950.check
+++ b/test/files/run/t3950.check
@@ -1,3 +1,4 @@
+warning: there was one deprecation warning (since 2.12.0); re-run with -deprecation for details
 minus
 zero
 plus

--- a/test/files/run/t4570.check
+++ b/test/files/run/t4570.check
@@ -1,1 +1,2 @@
+warning: there was one deprecation warning (since 2.12.0); re-run with -deprecation for details
 foo

--- a/test/files/run/t5588.check
+++ b/test/files/run/t5588.check
@@ -1,2 +1,3 @@
+warning: there was one deprecation warning (since 2.12.0); re-run with -deprecation for details
 true
 true

--- a/test/files/run/t5612.check
+++ b/test/files/run/t5612.check
@@ -1,3 +1,4 @@
+warning: there was one deprecation warning (since 2.12.0); re-run with -deprecation for details
 START for List(Two, Two, One, Three)
 TWO
 TWO

--- a/test/files/run/t8611b.check
+++ b/test/files/run/t8611b.check
@@ -1,2 +1,1 @@
 warning: there were two deprecation warnings (since 2.12.0); re-run with -deprecation for details
-false

--- a/test/files/run/t8611b.flags
+++ b/test/files/run/t8611b.flags
@@ -1,1 +1,0 @@
--Xfatal-warnings

--- a/test/files/run/t949.check
+++ b/test/files/run/t949.check
@@ -1,3 +1,1 @@
 warning: there was one deprecation warning (since 2.12.0); re-run with -deprecation for details
-t.ValueSet(a, b)
-t.ValueSet(a, b)


### PR DESCRIPTION
Rough draft, some things are necessarily ugly, others temporarily.

The syntax

```
@enum
class Week(val isWeekend: Boolean = false) {
  Monday  (false)
  ...
  ...
  Friday  (false)            { def isGoodDay = true }
  Saturday(true)             { val isGoodDay = true }
  Sunday  (isWeekend = true) { def isGoodDay = true }

  def isGoodDay = false
}
```

is a possible implementation example, intention is to also support ADTs
that conform to certain restrictions (no nesting, recursion or
varying constructor parameters), e. g.:

```
@enum
sealed trait Toggle
case object ON  extends Toggle
case object OFF extends Toggle
```

Deprecates the unmitigated disaster that is scala.Enumeration.
Advantages of @enum over scala.Enumeration:
- Actually works
- Java interop
- No erasure issues
- No confusing mini-DSL to learn when defining enumerations

Disadvantages: None.

This addresses the issue of not being able to have one codebase that
supports Scala-JVM, Scala.js and Scala-Native (Java source code
not supported on Scala.js/Scala-Native, Scala source code not able to
define enums that are accepted by existing APIs on Scala-JVM).
