### PR TITLE
SI-9896 Join operations at `MapLike`

### DIFF
--- a/src/library/scala/collection/MapLike.scala
+++ b/src/library/scala/collection/MapLike.scala
@@ -369,4 +369,36 @@ self =>
   override /*PartialFunction*/
   def toString = super[IterableLike].toString
 
+  /**
+    * Joins this map with a given one, keeping just entries with keys present at both maps and returning a new map
+    * with their combined values.
+    *
+    * @param that map to join with.
+    * @tparam VT the type of the other map values.
+    * @return a new map of tuple values with each map value for those keys present at both this map and the other.
+    */
+  def joinInner[VT](that: Map[K, VT]): Map[K, (V,VT)] =
+    for((k,va) <- this; vb <- that.get(k)) yield k -> (va, vb)
+
+  /**
+    * Joins this map with a given one, keeping entries with keys present at both maps or just `this` and returning a
+    * new map with the values at `this` and, optionally, their values at the right map.
+    *
+    * @param that map to join with.
+    * @tparam VT the type of the other map values.
+    * @return a new map of tuples of values from `this` and `None` or some values from the right map.
+    */
+  def joinOuterLeft[VT](that: Map[K, VT]): Map[K, (V,Option[VT])] =
+    for((k,va) <- this) yield k -> (va, that.get(k))
+
+  /**
+    * Joins this map with a given one, keeping entries with keys present at both or just the joined map and returning a
+    * new map with the values at `that` and, optinonally, their values at `this`
+    * @param that map to join with.
+    * @tparam VT the type of the other map values.
+    * @return a new map of tuples of `None` or some values from `this` and values from the right map.
+    */
+  def joinOuterRight[VT](that: Map[K, VT]): Map[K, (Option[V],VT)] =
+    for((k,vb) <- that) yield k -> (get(k), vb)
+
 }

--- a/test/junit/scala/collection/MapLikeTest.scala
+++ b/test/junit/scala/collection/MapLikeTest.scala
@@ -1,0 +1,47 @@
+package scala.collection
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class MapLikeTest {
+
+  val ma = Map(0 -> " ", 1 -> "a", 2 -> "b")
+  val mb = Map(1 -> "A", 2 -> "B", 3 -> "C")
+
+  @Test
+  def joinInnerRightValues(): Unit = {
+
+    assertEquals(Map(1 -> ("a", "A"), 2 -> ("b", "B")), ma joinInner mb)
+
+  }
+
+  @Test
+  def joinOuterLeftRightValues(): Unit = {
+
+    val expected = Map(
+      0 -> (" ", None     ),
+      1 -> ("a", Some("A")),
+      2 -> ("b", Some("B"))
+    )
+
+    assertEquals(expected, ma joinOuterLeft mb)
+
+  }
+
+  @Test
+  def joinOuterRightRightValues(): Unit = {
+
+    val expected = Map(
+      1 -> (Some("a"), "A"),
+      2 -> (Some("b"), "B"),
+      3 -> (None     , "C")
+    )
+
+    assertEquals(expected, ma joinOuterRight mb)
+
+  }
+
+}


### PR DESCRIPTION
This PR adds `innerJoin`, `leftJoin` and `rightJoin` methods to `MapLike` interface thus providing functionality analogous to Spark's `PairRDD' [join, leftOuterJoin, ...](http://spark.apache.org/docs/latest/api/scala/#org.apache.spark.rdd.PairRDDFunctions).

It isn't difficult to find Scala users needing to join maps in Scala ([e.g.](http://stackoverflow.com/questions/39031928/finding-the-totalspent-for-each-customer-in-scala/39032738#39032738)).

Besides, these operations could be easily used along side `TraversableLike`'s [groupBy](http://www.scala-lang.org/api/2.11.8/index.html#scala.collection.TraversableLike@groupBy[K]%28f:A=>K%29:scala.collection.immutable.Map[K,Repr]) to build powerful and concise algorithms.
