### PR TITLE
SI-6407 Default to UTF-8 for text encoding

### DIFF
--- a/src/compiler/scala/tools/nsc/ClassPathMemoryConsumptionTester.scala
+++ b/src/compiler/scala/tools/nsc/ClassPathMemoryConsumptionTester.scala
@@ -48,7 +48,7 @@ object ClassPathMemoryConsumptionTester {
     println("Memory consumption can be now measured")
 
     var textFromStdIn = ""
-    while (textFromStdIn.toLowerCase != "exit")
+    while (textFromStdIn.toLowerCase(java.util.Locale.ENGLISH) != "exit")
       textFromStdIn = readLine("Type 'exit' to close application: ")
   }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
@@ -158,7 +158,7 @@ class CoreBTypes[BTFS <: BTypesFromSymbols[_ <: Global]](val bTypes: BTFS) {
   lazy val javaUnboxMethods: Map[InternalName, MethodNameAndType] = {
     ScalaValueClassesNoUnit.map(primitive => {
       val boxed = boxedClass(primitive)
-      val name = primitive.name.toString.toLowerCase + "Value"
+      val name = primitive.name.toString.toLowerCase(java.util.Locale.ENGLISH) + "Value"
       (classBTypeFromSymbol(boxed).internalName, methodNameAndType(boxed, newTermName(name)))
     })(collection.breakOut)
   }
@@ -172,10 +172,10 @@ class CoreBTypes[BTFS <: BTypesFromSymbols[_ <: Global]](val bTypes: BTFS) {
   }
 
   // boolean2Boolean -> (Z)Ljava/lang/Boolean;
-  lazy val predefAutoBoxMethods: Map[String, MethodBType] = predefBoxingMethods((primitive, boxed) => primitive.toLowerCase + "2" + boxed)
+  lazy val predefAutoBoxMethods: Map[String, MethodBType] = predefBoxingMethods((primitive, boxed) => primitive.toLowerCase(java.util.Locale.ENGLISH) + "2" + boxed)
 
   // Boolean2boolean -> (Ljava/lang/Boolean;)Z
-  lazy val predefAutoUnboxMethods: Map[String, MethodBType] = predefBoxingMethods((primitive, boxed) => boxed + "2" + primitive.toLowerCase)
+  lazy val predefAutoUnboxMethods: Map[String, MethodBType] = predefBoxingMethods((primitive, boxed) => boxed + "2" + primitive.toLowerCase(java.util.Locale.ENGLISH))
 
   private def staticRefMethods(name: Name): Map[InternalName, MethodNameAndType] = {
     allRefClasses.map(refClass =>

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
@@ -157,7 +157,7 @@ abstract class GenBCode extends BCodeSyncAndTry {
         val claszSymbol = cd.symbol
 
         // GenASM checks this before classfiles are emitted, https://github.com/scala/scala/commit/e4d1d930693ac75d8eb64c2c3c69f2fc22bec739
-        val lowercaseJavaClassName = claszSymbol.javaClassName.toLowerCase
+        val lowercaseJavaClassName = claszSymbol.javaClassName.toLowerCase(java.util.Locale.ENGLISH)
         caseInsensitively.get(lowercaseJavaClassName) match {
           case None =>
             caseInsensitively.put(lowercaseJavaClassName, claszSymbol)

--- a/src/library/scala/compat/Platform.scala
+++ b/src/library/scala/compat/Platform.scala
@@ -129,5 +129,5 @@ object Platform {
 
   /** The name of the default character set encoding as a string */
   @inline
-  def defaultCharsetName: String = java.nio.charset.Charset.defaultCharset.name
+  def defaultCharsetName: String = "UTF-8"
 }

--- a/src/library/scala/io/Source.scala
+++ b/src/library/scala/io/Source.scala
@@ -11,6 +11,7 @@ package io
 
 import scala.collection.AbstractIterator
 import java.io.{ FileInputStream, InputStream, PrintStream, File => JFile, Closeable }
+import java.nio.charset.StandardCharsets
 import java.net.{ URI, URL }
 
 /** This object provides convenience methods to create an iterable
@@ -109,34 +110,28 @@ object Source {
   def fromBytes(bytes: Array[Byte], enc: String): Source =
     fromBytes(bytes)(Codec(enc))
 
-  /** Create a `Source` from array of bytes, assuming
-   *  one byte per character (ISO-8859-1 encoding.)
-   */
+  /** Create a `Source` from array of bytes, assuming one byte per character (ISO-8859-1 encoding.) */
+  @deprecated("Use `fromBytes` and specify encoding explicitly.", "2.12.0")
   def fromRawBytes(bytes: Array[Byte]): Source =
-    fromString(new String(bytes, Codec.ISO8859.name))
+    fromString(new String(bytes, StandardCharsets.ISO_8859_1))
 
-  /** creates `Source` from file with given file: URI
-   */
+  /** creates `Source` from file with given file: URI */
   def fromURI(uri: URI)(implicit codec: Codec): BufferedSource =
     fromFile(new JFile(uri))(codec)
 
-  /** same as fromURL(new URL(s))(Codec(enc))
-   */
+  /** same as fromURL(new URL(s))(Codec(enc)) */
   def fromURL(s: String, enc: String): BufferedSource =
     fromURL(s)(Codec(enc))
 
-  /** same as fromURL(new URL(s))
-   */
+  /** same as fromURL(new URL(s)) */
   def fromURL(s: String)(implicit codec: Codec): BufferedSource =
     fromURL(new URL(s))(codec)
 
-  /** same as fromInputStream(url.openStream())(Codec(enc))
-   */
+  /** same as fromInputStream(url.openStream())(Codec(enc)) */
   def fromURL(url: URL, enc: String): BufferedSource =
     fromURL(url)(Codec(enc))
 
-  /** same as fromInputStream(url.openStream())(codec)
-   */
+  /** same as fromInputStream(url.openStream())(codec) */
   def fromURL(url: URL)(implicit codec: Codec): BufferedSource =
     fromInputStream(url.openStream())(codec)
 

--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -1341,7 +1341,7 @@ trait Printers extends api.Printers { self: SymbolTable =>
       val s_flags = new scala.collection.mutable.ListBuffer[String]
       def hasFlag(left: Long, right: Long): Boolean = (left & right) != 0
       for (i <- 0 to 63 if hasFlag(flags, 1L << i))
-        s_flags += flagToString(1L << i).replace("<", "").replace(">", "").toUpperCase
+        s_flags += flagToString(1L << i).replace("<", "").replace(">", "").toUpperCase(java.util.Locale.ENGLISH)
       s_flags mkString " | "
     }
   }

--- a/src/reflect/scala/reflect/io/AbstractFile.scala
+++ b/src/reflect/scala/reflect/io/AbstractFile.scala
@@ -99,7 +99,7 @@ abstract class AbstractFile extends Iterable[AbstractFile] {
   def canonicalPath: String = if (file == null) path else file.getCanonicalPath
 
   /** Checks extension case insensitively. */
-  def hasExtension(other: String) = extension == other.toLowerCase
+  def hasExtension(other: String) = extension == other.toLowerCase(java.util.Locale.ENGLISH)
   private lazy val extension: String = Path.extension(name)
 
   /** The absolute file, if this is a relative file. */

--- a/src/reflect/scala/reflect/io/Path.scala
+++ b/src/reflect/scala/reflect/io/Path.scala
@@ -42,7 +42,7 @@ object Path {
       i -= 1
 
     if (i < 0) ""
-    else name.substring(i + 1).toLowerCase
+    else name.substring(i + 1).toLowerCase(java.util.Locale.ENGLISH)
   }
 
   // not certain these won't be problematic, but looks good so far
@@ -176,8 +176,8 @@ class Path private[io] (val jfile: JFile) {
   }
   // compares against extensions in a CASE INSENSITIVE way.
   def hasExtension(ext: String, exts: String*) = {
-    val lower = extension.toLowerCase
-    ext.toLowerCase == lower || exts.exists(_.toLowerCase == lower)
+    val lower = extension.toLowerCase(java.util.Locale.ENGLISH)
+    ext.toLowerCase(java.util.Locale.ENGLISH) == lower || exts.exists(_.toLowerCase(java.util.Locale.ENGLISH) == lower)
   }
   // returns the filename without the extension.
   def stripExtension: String = name stripSuffix ("." + extension)

--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -190,10 +190,10 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
 
   /** Search the history */
   def searchHistory(_cmdline: String) {
-    val cmdline = _cmdline.toLowerCase
+    val cmdline = _cmdline.toLowerCase(java.util.Locale.ENGLISH)
     val offset  = history.index - history.size + 1
 
-    for ((line, index) <- history.asStrings.zipWithIndex ; if line.toLowerCase contains cmdline)
+    for ((line, index) <- history.asStrings.zipWithIndex ; if line.toLowerCase(java.util.Locale.ENGLISH) contains cmdline)
       echo("%d %s".format(index + offset, line))
   }
 

--- a/src/repl/scala/tools/nsc/interpreter/Phased.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Phased.scala
@@ -52,7 +52,7 @@ trait Phased {
     if (str == "") NoPhaseName
     else if (str forall (_.isDigit)) PhaseName(str.toInt)
     else {
-      val (name, rest) = str.toLowerCase span (_.isLetter)
+      val (name, rest) = str.toLowerCase(java.util.Locale.ENGLISH) span (_.isLetter)
       val start        = PhaseName(name)
       val change       = parsePhaseChange(rest)
 
@@ -99,7 +99,7 @@ trait Phased {
   }
   sealed abstract class PhaseName {
     lazy val id   = phase.id
-    lazy val name = toString.toLowerCase
+    lazy val name = toString.toLowerCase(java.util.Locale.ENGLISH)
     def phase     = currentRun.phaseNamed(name)
     def isEmpty   = this eq NoPhaseName
   }

--- a/src/scaladoc/scala/tools/nsc/doc/Settings.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/Settings.scala
@@ -240,10 +240,10 @@ class Settings(error: String => Unit, val printMsg: String => Unit = println(_))
     if (docSkipPackages.value == "")
       Set[String]()
     else
-      docSkipPackages.value.toLowerCase.split(':').toSet
+      docSkipPackages.value.toLowerCase(java.util.Locale.ENGLISH).split(':').toSet
 
   def skipPackage(qname: String) =
-    skipPackageNames(qname.toLowerCase)
+    skipPackageNames(qname.toLowerCase(java.util.Locale.ENGLISH))
 
   lazy val hiddenImplicits: Set[String] = {
     if (docImplicitsHide.value.isEmpty) hardcoded.commonConversionTargets
@@ -333,7 +333,7 @@ class Settings(error: String => Unit, val printMsg: String => Unit = println(_))
      *  but showing priority in scaladoc would make no sense -- so we have to manually remove the conversions that we
      *  know will never get a chance to kick in. Anyway, DIRTY DIRTY DIRTY! */
     def valueClassFilter(value: String, conversionName: String): Boolean = {
-      val valueName = value.toLowerCase
+      val valueName = value.toLowerCase(java.util.Locale.ENGLISH)
       val otherValues = valueClassList.filterNot(_ == valueName)
 
       for (prefix <- valueClassFilterPrefixes)

--- a/src/scaladoc/scala/tools/nsc/doc/base/comment/Body.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/comment/Body.scala
@@ -76,7 +76,7 @@ final case class HtmlTag(data: String) extends Inline {
   private val Pattern = """(?ms)\A<(/?)(.*?)[\s>].*\z""".r
   private val (isEnd, tagName) = data match {
     case Pattern(s1, s2) =>
-      (! s1.isEmpty, Some(s2.toLowerCase))
+      (!s1.isEmpty, Some(s2.toLowerCase(java.util.Locale.ENGLISH)))
     case _ =>
       (false, None)
   }

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -1124,5 +1124,5 @@ object EntityPage {
 
   /* Vlad: Lesson learned the hard way: don't put any stateful code that references the model here,
    * it won't be garbage collected and you'll end up filling the heap with garbage */
-  def lowerFirstLetter(s: String) = if (s.length >= 1) s.substring(0,1).toLowerCase() + s.substring(1) else s
+  def lowerFirstLetter(s: String) = if (s.length >= 1) s.substring(0,1).toLowerCase(java.util.Locale.ENGLISH) + s.substring(1) else s
 }

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/IndexScript.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/IndexScript.scala
@@ -29,7 +29,7 @@ class IndexScript(universe: doc.Universe) extends Page {
       case (pack, templates) => {
         val merged = mergeByQualifiedName(templates)
 
-        val ary = merged.keys.toVector.sortBy(_.toLowerCase).map { key =>
+        val ary = merged.keys.toVector.sortBy(_.toLowerCase(java.util.Locale.ENGLISH)).map { key =>
           /** One pair is generated for the class/trait and one for the
            *  companion object, both will have the same {"name": key}
            *


### PR DESCRIPTION
Traditionally there were two ways of getting a “default” text encoding:
- Use UTF-8
- Use the underlying platform's encoding

We shouldn't invent an additional, third way to do that.

Instead we use UTF-8 by default, and encourage people to be explicit.
Most of the code written out there is never designed with arbitrary
encoding changes via `-Dfile.encoding` or other means in mind, and only
causes pain, suffering and a larger testing surface for developers.

Deprecates the `Codec.ISO8859` constant, because the number is NOT
optional. "ISO-8859" is like "UTF" ... it's not meaningful and doesn't
denote a specific encoding.

Also fixes code that used `toLowerCase` or `toUpperCase` without a
locale. This is dangerous as code and scalac itself will behave
differently under some locales, namely azeri, lithuanian and turkish.
