### PR TITLE
SAM for subtypes of FunctionN

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -773,7 +773,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         else FunctionClass(numVparams)
       }
 
-      if (samSym.exists && samSym.owner != correspondingFunctionSymbol) // don't treat Functions as SAMs
+      if (samSym.exists && tp.typeSymbol != correspondingFunctionSymbol) // don't treat Functions as SAMs
         wildcardExtrapolation(normalize(tp memberInfo samSym))
       else NoType
     }

--- a/test/files/pos/sammy_extends_function.scala
+++ b/test/files/pos/sammy_extends_function.scala
@@ -1,0 +1,4 @@
+// https://github.com/scala/scala-dev/issues/206
+
+trait T extends Function1[String, String]
+object O { (x => x): T }


### PR DESCRIPTION
only exclude FunctionN types themselves from SAM, don't exclude their
subtypes; we want e.g.

```
trait B extends Function1[String, String]
(x => x) : B
```

to compile

reference: https://github.com/scala/scala-dev/issues/206
