### PR TITLE
SI-9380 Remove Regex.unapplySeq(Any)

### DIFF
--- a/src/library/scala/util/matching/Regex.scala
+++ b/src/library/scala/util/matching/Regex.scala
@@ -319,20 +319,6 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
     else if (m.matcher.pattern == this.pattern) Some((1 to m.groupCount).toList map m.group)
     else unapplySeq(m.matched)
 
-  /** Tries to match target.
-   *  @param target The string to match
-   *  @return       The matches
-   */
-  @deprecated("extracting a match result from anything but a CharSequence or Match is deprecated", "2.11.0")
-  def unapplySeq(target: Any): Option[List[String]] = target match {
-    case s: CharSequence =>
-      val m = pattern matcher s
-      if (runMatcher(m)) Some((1 to m.groupCount).toList map m.group)
-      else None
-    case m: Match => unapplySeq(m.matched)
-    case _ => None
-  }
-
   //  @see UnanchoredRegex
   protected def runMatcher(m: Matcher) = m.matches()
 

--- a/test/files/neg/t6406-regextract.check
+++ b/test/files/neg/t6406-regextract.check
@@ -1,6 +1,4 @@
-t6406-regextract.scala:4: warning: method unapplySeq in class Regex is deprecated (since 2.11.0): extracting a match result from anything but a CharSequence or Match is deprecated
+t6406-regextract.scala:4: error: cannot resolve overloaded unapply
   List(1) collect { case r(i) => i }
                          ^
-error: No warnings can be incurred under -Xfatal-warnings.
-one warning found
 one error found

--- a/test/files/neg/t6406-regextract.flags
+++ b/test/files/neg/t6406-regextract.flags
@@ -1,1 +1,0 @@
--Xfatal-warnings -deprecation

--- a/test/junit/scala/util/matching/RegexTest.scala
+++ b/test/junit/scala/util/matching/RegexTest.scala
@@ -14,9 +14,7 @@ class RegexTest {
     val full = """.*: (.)$""".r
     val text = "   When I use this operator: *"
     // Testing 2.10.x compatibility of the return types of unapplySeq
-    val x :: Nil = full.unapplySeq(text: Any).get
     val y :: Nil = full.unapplySeq(text: CharSequence).get
-    assertEquals("*", x)
     assertEquals("*", y)
   }
 
@@ -24,9 +22,7 @@ class RegexTest {
     val R = """(\d)""".r
     val matchh = R.findFirstMatchIn("a1").get
     // Testing 2.10.x compatibility of the return types of unapplySeq
-    val x :: Nil = R.unapplySeq(matchh: Any).get
     val y :: Nil = R.unapplySeq(matchh).get
-    assertEquals("1", x)
     assertEquals("1", y)
   }
 


### PR DESCRIPTION
Long deprecation cycle and annoying deprecation message.

Changes deprecation to: "error: cannot resolve overloaded unapply".

Maybe "on-hold" until 2.13.
