### PR TITLE
increase stack size when running JUnit tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -556,6 +556,7 @@ lazy val junit = project.in(file("test") / "junit")
   .settings(disablePublishing: _*)
   .settings(
     fork in Test := true,
+    javaOptions in Test += "-Xss5M",
     libraryDependencies ++= Seq(junitDep, junitInterfaceDep, jolDep),
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
     testFrameworks -= new TestFramework("org.scalacheck.ScalaCheckFramework"),


### PR DESCRIPTION
`scala.collection.immutable.PagedSeqTest.test_SI6615` was failing
intermittently during PR validation

I verified that this change fixes the problem by:
- changing the PageSize constant in PagedSeq (as shown by
  Jason Zaugg) until the test failed every time locally
- making this build change and seeing the test pass again

5M is just an arbitrary number, considerably over the default (which
varies according to platform & CPU). 5M is a lot of stack, but not so
vastly much that it appreciably eats into the heap
