### PR TITLE
Decrease stack size for JUnit tests to 1M (same as the old ant build)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -556,7 +556,7 @@ lazy val junit = project.in(file("test") / "junit")
   .settings(disablePublishing: _*)
   .settings(
     fork in Test := true,
-    javaOptions in Test += "-Xss5M",
+    javaOptions in Test += "-Xss1M",
     libraryDependencies ++= Seq(junitDep, junitInterfaceDep, jolDep),
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
     testFrameworks -= new TestFramework("org.scalacheck.ScalaCheckFramework"),


### PR DESCRIPTION
Follow-up to #5362 (see discussion there). I'll kick off some bootstrap builds to see how well it behaves with 1M.
