### PR TITLE
SI-6967 Primitive ClassTag.unapply is removed

### DIFF
--- a/src/library/scala/reflect/ClassTag.scala
+++ b/src/library/scala/reflect/ClassTag.scala
@@ -83,21 +83,6 @@ trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serial
        ) Some(x.asInstanceOf[T])
     else None
 
-  // TODO: deprecate overloads in 2.12.0, remove in 2.13.0
-  def unapply(x: Byte)    : Option[T] = unapplyImpl(x, classOf[Byte])
-  def unapply(x: Short)   : Option[T] = unapplyImpl(x, classOf[Short])
-  def unapply(x: Char)    : Option[T] = unapplyImpl(x, classOf[Char])
-  def unapply(x: Int)     : Option[T] = unapplyImpl(x, classOf[Int])
-  def unapply(x: Long)    : Option[T] = unapplyImpl(x, classOf[Long])
-  def unapply(x: Float)   : Option[T] = unapplyImpl(x, classOf[Float])
-  def unapply(x: Double)  : Option[T] = unapplyImpl(x, classOf[Double])
-  def unapply(x: Boolean) : Option[T] = unapplyImpl(x, classOf[Boolean])
-  def unapply(x: Unit)    : Option[T] = unapplyImpl(x, classOf[Unit])
-
-  private[this] def unapplyImpl(x: Any, primitiveCls: java.lang.Class[_]): Option[T] =
-    if (runtimeClass.isInstance(x) || runtimeClass.isAssignableFrom(primitiveCls)) Some(x.asInstanceOf[T])
-    else None
-
   // case class accessories
   override def canEqual(x: Any) = x.isInstanceOf[ClassTag[_]]
   override def equals(x: Any) = x.isInstanceOf[ClassTag[_]] && this.runtimeClass == x.asInstanceOf[ClassTag[_]].runtimeClass


### PR DESCRIPTION
Follow-up to remove the overloads, which is source
compatible, in favor of unapply(Any).

There ought to be a `@removed(since = "2.12", signature = "")` annotation for folks who go looking for removed API.

Removal approval at https://github.com/scala/scala/pull/5347#issuecomment-243129126
