### PR TITLE
Ensure trait var accessor type is widened

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -952,7 +952,8 @@ trait Namers extends MethodSynthesis {
            !tpe.typeSymbolDirect.isModuleClass // Infer Foo.type instead of "object Foo"
         && (tpe.widen <:< pt)                  // Don't widen our way out of conforming to pt
         && (   sym.isVariable
-            || sym.isMethod && !sym.hasAccessorFlag
+            || sym.hasFlag(ACCESSOR) && !sym.hasFlag(STABLE)
+            || sym.isMethod && !sym.hasFlag(ACCESSOR)
             || isHidden(tpe)
            )
       )

--- a/test/files/pos/fields_widen_trait_var.scala
+++ b/test/files/pos/fields_widen_trait_var.scala
@@ -1,0 +1,4 @@
+// check that the `var x` below is assigned the type `Int`, and not `Constant(0)`,
+// and that we can assign to it (if it gets a constant type, the `x` in `x = 42`
+// is constant-folded to `0` and we can't find a setter..
+trait C { protected final var x = 0; x = 42 }


### PR DESCRIPTION
If we don't widen, we'll fail to find the setter when
typing `x = 42`, because `x` is constant-folded to `0`,
as its type is `=> Int(0)`. After widening, `x` is
type checked to `x` and its symbol is the getter in the
trait, which can then be rewritten to the setter.

Regression spotted and test case by @szeiger.
