### PR TITLE
sbt build: fix "unchecked" warnings when compiling Java code

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -133,7 +133,7 @@ lazy val commonSettings = clearSourceAndResourceDirectories ++ publishSettings +
   // we always assume that Java classes are standalone and do not have any dependency
   // on Scala classes
   compileOrder := CompileOrder.JavaThenScala,
-  javacOptions in Compile ++= Seq("-g", "-source", "1.8", "-target", "1.8"),
+  javacOptions in Compile ++= Seq("-g", "-source", "1.8", "-target", "1.8", "-Xlint:unchecked"),
   // we don't want any unmanaged jars; as a reminder: unmanaged jar is a jar stored
   // directly on the file system and it's not resolved through Ivy
   // Ant's build stored unmanaged jars in `lib/` directory

--- a/test/junit/scala/runtime/LambdaDeserializerTest.java
+++ b/test/junit/scala/runtime/LambdaDeserializerTest.java
@@ -136,6 +136,7 @@ public final class LambdaDeserializerTest {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private <A> A deserizalizeLambdaCreatingAllowedMap(A f1, HashMap<String, MethodHandle> cache, MethodHandles.Lookup lookup) {
         SerializedLambda serialized = writeReplace(f1);
         HashMap<String, MethodHandle> allowed = createAllowedMap(lookup, serialized);

--- a/test/junit/scala/tools/testing/ClearAfterClass.java
+++ b/test/junit/scala/tools/testing/ClearAfterClass.java
@@ -45,6 +45,7 @@ public class ClearAfterClass {
         }
     }
 
+    @SuppressWarnings("unchecked")
     public <T> T cached(String key, scala.Function0<T> t) {
         Map<String, Object> perClassCache = cache.get(getClass());
         return (T) perClassCache.computeIfAbsent(key, s -> t.apply());


### PR DESCRIPTION
a small step towards a warning-free build
