### PR TITLE
SI-9913 Lead span iterator finishes at state -1

### DIFF
--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -648,15 +648,15 @@ trait Iterator[+A] extends TraversableOnce[A] {
      * handling of structural calls. It's not what's intended here.
      */
     class Leading extends AbstractIterator[A] {
-      var lookahead: mutable.Queue[A] = null
-      var hd: A = _
+      private[this] var lookahead: mutable.Queue[A] = null
+      private[this] var hd: A = _
       /* Status is kept with magic numbers
        *   1 means next element is in hd and we're still reading into this iterator
        *   0 means we're still reading but haven't found a next element
        *   -1 means we are done reading into the iterator, so we must rely on lookahead
        *   -2 means we are done but have saved hd for the other iterator to use as its first element
        */
-      var status = 0
+      private[this] var status = 0
       private def store(a: A) {
         if (lookahead == null) lookahead = new mutable.Queue[A]
         lookahead += a
@@ -680,14 +680,11 @@ trait Iterator[+A] extends TraversableOnce[A] {
         }
         else empty.next()
       }
-      def finish(): Boolean = {
-        if (status == -1) false
-        else if (status == -2) {
-          status = -1
-          true
-        }
-        else {
-          if (status == 1) store(hd)
+      def finish(): Boolean = status match {
+        case -2 => status = -1 ; true
+        case -1 => false
+        case  1 => store(hd) ; status = 0 ; finish()
+        case  0 => 
           status = -1
           while (self.hasNext) {
             val a = self.next()
@@ -698,8 +695,8 @@ trait Iterator[+A] extends TraversableOnce[A] {
             }
           }
           false
-        }
       }
+      def trailer: A = hd
     }
     
     val leading = new Leading
@@ -732,7 +729,7 @@ trait Iterator[+A] extends TraversableOnce[A] {
           if (status > 0) self.next()
           else {
             status = 1
-            val ans = myLeading.hd
+            val ans = myLeading.trailer
             myLeading = null
             ans
           }

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -688,12 +688,12 @@ trait Iterator[+A] extends TraversableOnce[A] {
         }
         else {
           if (status == 1) store(hd)
+          status = -1
           while (self.hasNext) {
             val a = self.next()
             if (p(a)) store(a)
             else {
               hd = a
-              status = -1
               return true
             }
           }

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -164,6 +164,12 @@ class IteratorTest {
     assertEquals(1, y.next)
     assertFalse(x.hasNext)   // was true, after advancing underlying iterator
   }
+  // SI-9913
+  @Test def `span leading iterator finishes at state -1`(): Unit = {
+    val (yes, no) = Iterator(1, 2, 3).span(_ => true)
+    assertFalse(no.hasNext)
+    assertTrue(yes.hasNext)
+  }
   // SI-9623
   @Test def noExcessiveHasNextInJoinIterator: Unit = {
     var counter = 0


### PR DESCRIPTION
Even if no elements fail the predicate (so that the trailing
iterator is empty).

Review by @Ichoran 

JIRA: https://issues.scala-lang.org/browse/SI-9913
