### PR TITLE
SI-9915 Utf8_info are modified UTF8

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -8,7 +8,7 @@ package tools.nsc
 package symtab
 package classfile
 
-import java.io.{File, IOException}
+import java.io.{ByteArrayInputStream, DataInputStream, File, IOException}
 import java.lang.Integer.toHexString
 import scala.collection.{immutable, mutable}
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
@@ -206,9 +206,13 @@ abstract class ClassfileParser {
         case name: Name => name
         case _          =>
           val start = firstExpecting(index, CONSTANT_UTF8)
-          recordAtIndex(newTermName(in.buf, start + 2, in.getChar(start).toInt), index)
+          val len   = in.getChar(start).toInt
+          recordAtIndex(TermName(fromMUTF8(in.buf, start, len + 2)), index)
       }
     )
+
+    private def fromMUTF8(bytes: Array[Byte], offset: Int, len: Int): String =
+      new DataInputStream(new ByteArrayInputStream(bytes, offset, len)).readUTF
 
     /** Return the name found at given index in the constant pool, with '/' replaced by '.'. */
     def getExternalName(index: Int): Name = {

--- a/test/files/run/t9915/C_1.java
+++ b/test/files/run/t9915/C_1.java
@@ -1,0 +1,18 @@
+
+public class C_1 {
+    public static final String NULLED = "X\000ABC";
+    public static final String SUPPED = "𐒈𐒝𐒑𐒛𐒐𐒘𐒕𐒖";
+
+    public String nulled() {
+        return C_1.NULLED;
+    }
+    public String supped() {
+        return C_1.SUPPED;
+    }
+    public int nulledSize() {
+        return C_1.NULLED.length();
+    }
+    public int suppedSize() {
+        return C_1.SUPPED.length();
+    }
+}

--- a/test/files/run/t9915/Test_2.scala
+++ b/test/files/run/t9915/Test_2.scala
@@ -1,0 +1,12 @@
+
+object Test extends App {
+  val c = new C_1
+  assert(c.nulled == "X\u0000ABC")    // "X\000ABC"
+  assert(c.supped == "𐒈𐒝𐒑𐒛𐒐𐒘𐒕𐒖")
+
+  assert(C_1.NULLED == "X\u0000ABC")  // "X\000ABC"
+  assert(C_1.SUPPED == "𐒈𐒝𐒑𐒛𐒐𐒘𐒕𐒖")
+
+  assert(C_1.NULLED.size == "XYABC".size)
+  assert(C_1.SUPPED.codePointCount(0, C_1.SUPPED.length) == 8)
+}


### PR DESCRIPTION
Use DataInputStream.readUTF to read CONSTANT_Utf8_info.

This fixes reading embedded null char and supplementary chars.

JIRA: https://issues.scala-lang.org/browse/SI-9915
