### PR TITLE
Avoid mismatched symbols in fields phase

### DIFF
--- a/test/files/pos/sd219.scala
+++ b/test/files/pos/sd219.scala
@@ -1,0 +1,11 @@
+class Global { class Name }
+
+trait CommonPrintUtils {
+  val global: Global 
+  
+  lazy val precedence: global.Name => Int = ???
+}
+
+trait CompilerProvider {  val global: Global = ??? }
+    
+class AbstractPrinter extends CommonPrintUtils with CompilerProvider 

--- a/test/files/run/delambdafy_t6028.check
+++ b/test/files/run/delambdafy_t6028.check
@@ -47,7 +47,7 @@ package <empty> {
     final <stable> private[this] def MethodLocalObject$1(barParam$1: String, MethodLocalObject$module$1: runtime.VolatileObjectRef): T#MethodLocalObject$2.type = {
       if (MethodLocalObject$module$1.elem.$asInstanceOf[T#MethodLocalObject$2.type]().eq(null))
         T.this.MethodLocalObject$lzycompute$1(barParam$1, MethodLocalObject$module$1);
-      MethodLocalObject$module$1.elem.$asInstanceOf[T#MethodLocalObject$2.type]()
+      (MethodLocalObject$module$1.elem.$asInstanceOf[T#MethodLocalObject$2.type](): T#MethodLocalObject$2.type)
     };
     final <artifact> private[this] def $anonfun$tryy$1(tryyParam$1: String, tryyLocal$1: runtime.ObjectRef): Unit = try {
       tryyLocal$1.elem = tryyParam$1

--- a/test/files/run/t6028.check
+++ b/test/files/run/t6028.check
@@ -59,7 +59,7 @@ package <empty> {
     final <stable> private[this] def MethodLocalObject$1(barParam$1: Int, MethodLocalObject$module$1: runtime.VolatileObjectRef): T#MethodLocalObject$2.type = {
       if (MethodLocalObject$module$1.elem.$asInstanceOf[T#MethodLocalObject$2.type]().eq(null))
         T.this.MethodLocalObject$lzycompute$1(barParam$1, MethodLocalObject$module$1);
-      MethodLocalObject$module$1.elem.$asInstanceOf[T#MethodLocalObject$2.type]()
+      (MethodLocalObject$module$1.elem.$asInstanceOf[T#MethodLocalObject$2.type](): T#MethodLocalObject$2.type)
     };
     @SerialVersionUID(value = 0) final <synthetic> class $anonfun$tryy$1 extends scala.runtime.AbstractFunction0$mcV$sp with Serializable {
       def <init>($outer: T, tryyParam$1: Int, tryyLocal$1: runtime.IntRef): <$anon: Function0> = {


### PR DESCRIPTION
The info of the var that stores a trait's lazy val's computed value
is expressed in terms of symbols that exist before the fields phase.
When we're implementing the lazy val in a subclass of that trait,
we now see symbols created by the fields phase, which results
in mismatches between the types of the lhs and rhs in the assignment
of `lazyVar = super.lazyImpl`.

So, type check the super-call to the trait's lazy accessor before our
own phase. If the lazy var's info depends on a val that is now
implemented by an accessor synthesize by our info transformer,
we'll get a mismatch when assigning `rhs` to `lazyVarOf(getter)`,
unless we also run before our own phase (like when we were
creating the info for the lazy var).

This was revealed by Hanns Holger Rutz's efforts in compiling 
scala-refactoring's test suite ([reported on scala-internals](https://groups.google.com/d/msg/scala-internals/lQT4RxTiiiw/K_C1XjNBFAAJ)).

Fixes scala/scala-dev#219
