### PR TITLE
[ci: last-only] bump versions on 2.12.x branch for eventual 2.12.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,7 @@ lazy val publishSettings : Seq[Setting[_]] = Seq(
 // should not be set directly. It is the same as the Maven version and derived automatically from `baseVersion` and
 // `baseVersionSuffix`.
 globalVersionSettings
-baseVersion in Global := "2.12.0"
+baseVersion in Global := "2.12.1"
 baseVersionSuffix in Global := "SNAPSHOT"
 mimaReferenceVersion in Global := Some("2.12.0-RC1")
 

--- a/scripts/jobs/integrate/bootstrap
+++ b/scripts/jobs/integrate/bootstrap
@@ -317,8 +317,6 @@ scalaVerToBinary() {
 determineScalaVersion() {
   cd $WORKSPACE
   parseScalaProperties "versions.properties"
-  echo "repo_ref=2.12.x" >> $baseDir/jenkins.properties # for the -dist downstream jobs that build the actual archives
-
 
   # each of the branches below defines the following vars: SCALA_VER_BASE, SCALA_VER_SUFFIX, SCALADOC_SOURCE_LINKS_VER, publishToSonatype
   if [ -z "$SCALA_VER_BASE" ]; then

--- a/versions.properties
+++ b/versions.properties
@@ -9,7 +9,7 @@ starr.version=2.12.0-RC1-1e81a09
 #    So the value is the full version (e.g. 2.12.0-M2).
 # Also determines how modules are resolved. For example, it determines which
 # partest artifact is being used for running the tests.
-scala.binary.version=2.12.0-RC1
+scala.binary.version=2.12
 
 # external modules shipped with distribution, as specified by scala-library-all's pom
 scala-xml.version.number=1.0.6

--- a/versions.properties
+++ b/versions.properties
@@ -8,7 +8,7 @@
 # The scala version used for bootstrapping. This has no impact on the final classfiles:
 # there are two stages (locker and quick), so compiler and library are always built
 # with themselves. Stability is ensured by building a third stage (strap).
-starr.version=2.12.0-RC1-1e81a09
+starr.version=2.12.0-RC2
 
 # These are the versions of the modules that go with this release.
 # These properties are used during PR validation and in dbuild builds.
@@ -19,7 +19,7 @@ starr.version=2.12.0-RC1-1e81a09
 #  - After 2.x.0 is released, the binary version is 2.x.
 #  - During milestones and RCs, modules are cross-built against the full version.
 #    So the value is the full version (e.g. 2.12.0-M2).
-scala.binary.version=2.12.0-RC1
+scala.binary.version=2.12.0-RC2
 
 # external modules shipped with distribution, as specified by scala-library-all's pom
 scala-xml.version.number=1.0.5


### PR DESCRIPTION
not mergeable until 2.12.0 final is published, with modules
