### PR TITLE
SI-6276 Exclude var from trivial recursion warning

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1127,7 +1127,7 @@ abstract class RefChecks extends Transform {
     // SI-6276 warn for trivial recursion, such as `def foo = foo` or `val bar: X = bar`, which come up more frequently than you might think.
     // TODO: Move to abide rule. Also, this does not check that the def is final or not overridden, for example
     def checkInfiniteLoop(sym: Symbol, rhs: Tree): Unit =
-      if (!sym.isValueParameter && sym.paramss.isEmpty) {
+      if (!sym.isValueParameter && !sym.isVariable && sym.paramss.isEmpty) {
         rhs match {
           case t@(Ident(_) | Select(This(_), _)) if t hasSymbolWhich (_.accessedOrSelf == sym) =>
             reporter.warning(rhs.pos, s"${sym.fullLocationString} does nothing other than call itself recursively")

--- a/test/files/neg/t6276.scala
+++ b/test/files/neg/t6276.scala
@@ -41,4 +41,10 @@ object Test {
       }
     }
   }
+
+  class F {
+    g()
+    var f: String = f
+    def g() = this.f = "hi"
+  }
 }


### PR DESCRIPTION
`var x: X = x` is the new `var x: X = _`.

Unlike explicitly setting a default, it preserves any value
that was set earlier during initialization.
