### PR TITLE
No warn when discarding r.f(): r.type

### DIFF
--- a/src/compiler/scala/tools/nsc/CompilerCommand.scala
+++ b/src/compiler/scala/tools/nsc/CompilerCommand.scala
@@ -103,15 +103,7 @@ class CompilerCommand(arguments: List[String], val settings: Settings) {
       val components = global.phaseNames  // global.phaseDescriptors // one initializes
       s"Phase graph of ${components.size} components output to ${genPhaseGraph.value}*.dot."
     }
-    // would be nicer if we could ask all the options for their helpful messages
-    else {
-      val sb = new StringBuilder
-      allSettings foreach {
-        case s if s.isHelping => sb append s.help
-        case _ =>
-      }
-      sb.toString
-    }
+    else allSettings.filter(_.isHelping).map(_.help).mkString("\n\n")
   }
 
   /**

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -38,11 +38,8 @@ trait ScalaSettings extends AbsScalaSettings
   /** If any of these settings is enabled, the compiler should print a message and exit.  */
   def infoSettings = List[Setting](version, help, Xhelp, Yhelp, showPlugins, showPhases, genPhaseGraph)
 
-  /** Any -option:help? */
-  private def multihelp = allSettings exists { case s => s.isHelping case _ => false }
-
-  /** Is an info setting set? */
-  def isInfo = (infoSettings exists (_.isSetByUser)) || multihelp
+  /** Is an info setting set? Any -option:help? */
+  def isInfo = infoSettings.exists(_.isSetByUser) || allSettings.exists(_.isHelping)
 
   /** Disable a setting */
   def disable(s: Setting) = allSettings -= s

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1060,8 +1060,13 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           @inline def tpdPos(transformed: Tree) = typedPos(tree.pos, mode, pt)(transformed)
           @inline def tpd(transformed: Tree)    = typed(transformed, mode, pt)
 
-          @inline def warnValueDiscard(): Unit =
-            if (!isPastTyper && settings.warnValueDiscard) context.warning(tree.pos, "discarded non-Unit value")
+          @inline def warnValueDiscard(): Unit = if (!isPastTyper && settings.warnValueDiscard) {
+            def isThisTypeResult = (tree, tree.tpe) match {
+              case (Apply(Select(receiver, _), _), SingleType(_, sym)) => sym == receiver.symbol
+              case _ => false
+            }
+            if (!isThisTypeResult) context.warning(tree.pos, "discarded non-Unit value")
+          }
           @inline def warnNumericWiden(): Unit =
             if (!isPastTyper && settings.warnNumericWiden) context.warning(tree.pos, "implicit numeric widening")
 

--- a/src/repl/scala/tools/nsc/MainGenericRunner.scala
+++ b/src/repl/scala/tools/nsc/MainGenericRunner.scala
@@ -49,10 +49,6 @@ class MainGenericRunner {
       def isI   = !settings.loadfiles.isDefault
       def dashi = settings.loadfiles.value
 
-      // Deadlocks on startup under -i unless we disable async.
-      if (isI)
-        settings.Yreplsync.value = true
-
       def combinedCode  = {
         val files   = if (isI) dashi map (file => File(file).slurp()) else Nil
         val str     = if (isE) List(dashe) else Nil
@@ -98,7 +94,7 @@ class MainGenericRunner {
     if (!command.ok)
       errorFn(f"%n$shortUsageMsg")
     else if (shouldStopWithInfo)
-      errorFn(command getInfoMessage sampleCompiler, isFailure = false)
+      errorFn(command.getInfoMessage(sampleCompiler), isFailure = false)
     else
       run()
   }

--- a/test/files/pos/t9020.scala
+++ b/test/files/pos/t9020.scala
@@ -8,3 +8,9 @@ test/files/pos/t9020.scala:2: warning: discarded non-Unit value
       ^
 one warning found
 */
+
+trait DiscardThis {
+  import collection.mutable.ListBuffer
+  val b = ListBuffer.empty[String]
+  def add(s: String): Unit = b += s
+}


### PR DESCRIPTION
The paradigm is `def add(x: X): Unit = listBuffer += x`.

The value that is discarded is not new information.

Also cleans up the recent tweaks to help messaging.

Adds newlines in case they ask for multiple helps.

This commit is also a test whether warnings and help
fall under documentation tweaks which don't require
a tracking issue. That doesn't mean the tweak can't
crash the compiler.
