### PR TITLE
WIP: fix for regression in 2.12.0-RC1 compiling shapeless tests.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -1179,7 +1179,9 @@ abstract class Erasure extends InfoTransform
           copyDefDef(tree)(tparams = Nil)
         case TypeDef(_, _, _, _) =>
           EmptyTree
-
+        case Ident(_) if isSingleConstantType(tree.tpe) =>
+          val Some(ConstantType(ct)) = asConstantType(tree.tpe)
+          treeCopy.Literal(tree, Constant(ct.value))
         case _ =>
           tree
       }

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4060,6 +4060,18 @@ trait Types
     case _               => false
   }
 
+  def isSingleConstantType(tp: Type): Boolean = tp match {
+    case ConstantType(_) => true
+    case _ if isSingleType(tp) => isSingleConstantType(tp.underlying)
+    case _ => false
+  }
+
+  def asConstantType(tp: Type): Option[ConstantType] = tp match {
+    case tp: ConstantType => Some(tp)
+    case _ if isSingleType(tp) => asConstantType(tp.underlying)
+    case _ => None
+  }
+
   def isExistentialType(tp: Type): Boolean = tp match {
     case _: ExistentialType           => true
     case tp: Type if tp.dealias ne tp => isExistentialType(tp.dealias)

--- a/test/files/pos/shapeless-regression.scala
+++ b/test/files/pos/shapeless-regression.scala
@@ -1,0 +1,16 @@
+class W[T <: AnyRef](val t: T) {
+  val v: T {} = t
+}
+
+object W {
+  def apply[T <: AnyRef](t: T) = new W[t.type](t)
+}
+
+object RightAssoc {
+  def ra_:[T](t: T): Unit = ()
+}
+
+object Boom {
+  W("fooo").v ra_: RightAssoc
+}
+


### PR DESCRIPTION
This change allows the shapeless tests to be compiled with 2.12.0-RC1+. I don't claim that this fix is correct, but it should help see what the issue is.

It appears that the new fields phase is [eliminating constant typed vals](https://github.com/scala/scala/blob/2.12.x/src/compiler/scala/tools/nsc/transform/Fields.scala#L695-L698) but not ensuring that all references to them are replaced with the corresponding literal values. The included test doesn't completely cover the failure in the shapeless tests, but it's close ... if this is along the right lines I should be able to come up with a shapeless-independent test which covers the rest, but I think it will require a macro to do it.

Nb. in this instance the problematic val is the synthetic one introduced by the parser when translating right associative operators. Compiling the test case without this fix and with `-Xprint:all` shows the constant typed synthetic val definition being eliminated in fields, but leaving an untransformed reference to it. This leaks right the way through to code generation and blows up then. The fix here eliminates the dangling reference in erasure.
