### PR TITLE
Avoid omitting constant typed vals in constructors

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Fields.scala
+++ b/src/compiler/scala/tools/nsc/transform/Fields.scala
@@ -694,7 +694,7 @@ abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransfor
 
         // drop the val for (a) constant (pure & not-stored) and (b) not-stored (but still effectful) fields
         case ValDef(mods, _, _, rhs) if (rhs ne EmptyTree) && !excludedAccessorOrFieldByFlags(statSym)
-                                        && fieldMemoizationIn(statSym, currOwner).constantTyped =>
+                                        && currOwner.isClass && fieldMemoizationIn(statSym, currOwner).constantTyped =>
           EmptyThicket
 
         case ModuleDef(_, _, impl) =>

--- a/test/files/pos/shapeless-regression.scala
+++ b/test/files/pos/shapeless-regression.scala
@@ -1,0 +1,16 @@
+class W[T <: AnyRef](val t: T) {
+  val v: T {} = t
+}
+
+object W {
+  def apply[T <: AnyRef](t: T) = new W[t.type](t)
+}
+
+object RightAssoc {
+  def ra_:[T](t: T): Unit = ()
+}
+
+object Boom {
+  W("fooo").v ra_: RightAssoc
+}
+


### PR DESCRIPTION
Fix for regression in 2.12.0-RC1 compiling shapeless tests.

They were given the same treatment as vals that are
members of classes on the definition side without the
requisite transformation of references to the val to
fold the constant into references.

This commit limits the transform to members of classes.
