### PR TITLE
SI-9920 Avoid linkage errors with captured local objects + self types

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -8,7 +8,7 @@ package tools.nsc
 package transform
 
 import symtab._
-import Flags.{ CASE => _, _ }
+import Flags.{CASE => _, _}
 import scala.collection.mutable.ListBuffer
 
 /** This class ...
@@ -263,7 +263,10 @@ abstract class ExplicitOuter extends InfoTransform
      */
     protected def outerPath(base: Tree, from: Symbol, to: Symbol): Tree = {
       //Console.println("outerPath from "+from+" to "+to+" at "+base+":"+base.tpe)
-      if (from == to) base
+      if (from == to) {
+        if (base.tpe.typeSymbol.isNonBottomSubClass(to)) base
+        else atPos(base.pos)(gen.mkAttributedCast(base, to.tpe_*))
+      }
       else outerPath(outerSelect(base), from.outerClass, to)
     }
 

--- a/test/files/run/t9220.scala
+++ b/test/files/run/t9220.scala
@@ -1,0 +1,17 @@
+class C0
+trait T { self: C0 =>
+  def test = {
+    object Local
+
+    class C1 {
+      Local
+    }
+    new C1()
+  }
+}
+
+object Test extends C0 with T {
+  def main(args: Array[String]): Unit = {
+    test
+  }
+}

--- a/test/files/run/t9220b.scala
+++ b/test/files/run/t9220b.scala
@@ -1,0 +1,17 @@
+class C0
+trait T {
+  def test = {
+    object Local
+
+    class C1 {
+      Local
+    }
+    new C1()
+  }
+}
+
+object Test extends C0 with T {
+  def main(args: Array[String]): Unit = {
+    test
+  }
+}

--- a/test/files/run/t9220c.scala
+++ b/test/files/run/t9220c.scala
@@ -1,0 +1,21 @@
+class C0
+trait T { self: C0 =>
+  def test = {
+    object Local
+
+    class C2 {
+      class C1 {
+        Local
+      }
+      T.this.toString
+      new C1
+    }
+    new C2()
+  }
+}
+
+object Test extends C0 with T {
+  def main(args: Array[String]): Unit = {
+    test
+  }
+}


### PR DESCRIPTION
An outer parameter of a nested class is typed with the self type
of the enclosing class:

```
class C; trait T { _: C => def x = 42; class D { x } }
```

leads to:

```
    class D extends Object {
      def <init>($outer: C): T.this.D = {
        D.super.<init>();
        ()
      };
      D.this.$outer().$asInstanceOf[T]().x();
```

Note that a cast is inserted before the call to `x`.

If we modify that a little, to instead capture a local module:

```
class C; trait T { _: C => def y { object O; class D { O } } }
```

Scala 2.11 used to generate (after lambdalift):

```
    class D$1 extends Object {
      def <init>($outer: C, O$module$1: runtime.VolatileObjectRef): C#D$1 = {
        D$1.super.<init>();
        ()
      };
      D$1.this.$outer().O$1(O$module$1);
```

That isn't type correct, `D$1.this.$outer() : C` does not
have a member `O$1`.

However, the old trait encoding would rewrite this in mixin to:

```
T$class.O$1($outer, O$module$1);
```

Trait implementation methods also used to accept the self type:

```
trait T$class {
   final <stable> def O$1($this: C, O$module$1: runtime.VolatileObjectRef): T$O$2.type
}
```

So the problem was hidden.

This commit changes `outerPath` (used in both explicitouter and in lambdalift to
insert a cast if required.)
