### PR TITLE
SD-225 Use a "lzycompute" method for module initialization

### DIFF
--- a/test/files/run/delambdafy_t6028.check
+++ b/test/files/run/delambdafy_t6028.check
@@ -42,10 +42,11 @@ package <empty> {
       <synthetic> <stable> <artifact> def $outer(): T = MethodLocalObject$2.this.$outer;
       <synthetic> <stable> <artifact> def $outer(): T = MethodLocalObject$2.this.$outer
     };
+    final private[this] def MethodLocalObject$lzycompute$1(barParam$1: String, MethodLocalObject$module$1: runtime.VolatileObjectRef): Unit = T.this.synchronized[Unit](if (MethodLocalObject$module$1.elem.$asInstanceOf[T#MethodLocalObject$2.type]().eq(null))
+      MethodLocalObject$module$1.elem = new T#MethodLocalObject$2.type(T.this, barParam$1));
     final <stable> private[this] def MethodLocalObject$1(barParam$1: String, MethodLocalObject$module$1: runtime.VolatileObjectRef): T#MethodLocalObject$2.type = {
       if (MethodLocalObject$module$1.elem.$asInstanceOf[T#MethodLocalObject$2.type]().eq(null))
-        T.this.synchronized[Unit](if (MethodLocalObject$module$1.elem.$asInstanceOf[T#MethodLocalObject$2.type]().eq(null))
-          MethodLocalObject$module$1.elem = new T#MethodLocalObject$2.type(T.this, barParam$1));
+        T.this.MethodLocalObject$lzycompute$1(barParam$1, MethodLocalObject$module$1);
       MethodLocalObject$module$1.elem.$asInstanceOf[T#MethodLocalObject$2.type]()
     };
     final <artifact> private[this] def $anonfun$tryy$1(tryyParam$1: String, tryyLocal$1: runtime.ObjectRef): Unit = try {

--- a/test/files/run/t6028.check
+++ b/test/files/run/t6028.check
@@ -54,10 +54,11 @@ package <empty> {
       <synthetic> <stable> <artifact> def $outer(): T = MethodLocalObject$2.this.$outer;
       <synthetic> <stable> <artifact> def $outer(): T = MethodLocalObject$2.this.$outer
     };
+    final private[this] def MethodLocalObject$lzycompute$1(barParam$1: Int, MethodLocalObject$module$1: runtime.VolatileObjectRef): Unit = T.this.synchronized[Unit](if (MethodLocalObject$module$1.elem.$asInstanceOf[T#MethodLocalObject$2.type]().eq(null))
+      MethodLocalObject$module$1.elem = new T#MethodLocalObject$2.type(T.this, barParam$1));
     final <stable> private[this] def MethodLocalObject$1(barParam$1: Int, MethodLocalObject$module$1: runtime.VolatileObjectRef): T#MethodLocalObject$2.type = {
       if (MethodLocalObject$module$1.elem.$asInstanceOf[T#MethodLocalObject$2.type]().eq(null))
-        T.this.synchronized[Unit](if (MethodLocalObject$module$1.elem.$asInstanceOf[T#MethodLocalObject$2.type]().eq(null))
-          MethodLocalObject$module$1.elem = new T#MethodLocalObject$2.type(T.this, barParam$1));
+        T.this.MethodLocalObject$lzycompute$1(barParam$1, MethodLocalObject$module$1);
       MethodLocalObject$module$1.elem.$asInstanceOf[T#MethodLocalObject$2.type]()
     };
     @SerialVersionUID(value = 0) final <synthetic> class $anonfun$tryy$1 extends scala.runtime.AbstractFunction0$mcV$sp with Serializable {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineWarningTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineWarningTest.scala
@@ -198,7 +198,9 @@ class InlineWarningTest extends BytecodeTesting {
         |Note that class A is defined in a Java source (mixed compilation), no bytecode is available.""".stripMargin
     )
     var c = 0
-    compileClasses(sCode, javaCode = List((jCode, "A.java")), allowMessage = i => { c += 1; warns.exists(i.msg.contains)})
+    compileClasses(sCode, javaCode = List((jCode, "A.java")), allowMessage = i => { c += 1;
+      warns.exists(i.msg.contains)
+    })
     assert(c == 2)
   }
 }

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/ScalaInlineInfoTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/ScalaInlineInfoTest.scala
@@ -107,7 +107,9 @@ class ScalaInlineInfoTest extends BytecodeTesting {
         ("x5$(LT;)I",                                                  MethodInlineInfo(true ,false,false)),
         ("L$1(Lscala/runtime/VolatileObjectRef;)LT$L$2$;",            MethodInlineInfo(true, false,false)),
         ("nest$1()I",                                                 MethodInlineInfo(true, false,false)),
-        ("$init$(LT;)V",                                              MethodInlineInfo(true,false,false))),
+        ("$init$(LT;)V",                                              MethodInlineInfo(true,false,false)),
+        ("L$lzycompute$1(Lscala/runtime/VolatileObjectRef;)V",        MethodInlineInfo(true,false,false))
+      ),
       None // warning
     )
 
@@ -128,7 +130,9 @@ class ScalaInlineInfoTest extends BytecodeTesting {
       "x4()I"                                 -> MethodInlineInfo(false,false,false),
 //      "x5()I"                                 -> MethodInlineInfo(true ,false,false), -- there is no x5 in the class as it's implemented fully in the interface
       "T$$super$toString()Ljava/lang/String;" -> MethodInlineInfo(true ,false,false),
-      "<init>()V"                             -> MethodInlineInfo(false,false,false)),
+      "<init>()V"                             -> MethodInlineInfo(false,false,false),
+      "O$lzycompute$1()V"                     -> MethodInlineInfo(true,false,false)
+    ),
       None)
 
     assert(infoC == expectC, mapDiff(expectC.methodInfos, infoC.methodInfos) + infoC)
@@ -179,6 +183,7 @@ class ScalaInlineInfoTest extends BytecodeTesting {
     val infoC = inlineInfo(c)
     val expected = Map(
       "<init>()V"            -> MethodInlineInfo(false,false,false),
+      "O$lzycompute$1()V"    -> MethodInlineInfo(true,false,false),
       "O()LC$O$;"            -> MethodInlineInfo(true,false,false))
     assert(infoC.methodInfos == expected, mapDiff(infoC.methodInfos, expected))
     assertSameMethods(c, expected.keySet)


### PR DESCRIPTION
The monitors and module instantation were inliuned into the module accessor
method in b2e0911. However, this seems to have had a detrimental impact on
performance. This might be because the module accessors are now above the
"always inline" HotSpot threshold of 35 bytes, or perhaps because they
contain monitor-entry/exit and exception handlers.

This commit returns to the the 2.11.8 appraoch of factoring
the the second check of the doublecheck locking into a method.
I've done this by declaring a nested method within the accessor;
this will be lifted out to the class level by lambdalift.

This represents a slight deviation from the implementation strategy used
for lazy accessors, which create a symbol for the slowpath method in
the info transform and generate the corresponding DefDef as a class
member. I don't believe this deviation is particular worrisome, though.

I have bootstrapped the compiler through this commit and found that
the drastic regression in compiling the shapeless test suite is solved.

Fixes https://github.com/scala/scala-dev/issues/225
