### PR TITLE
Fixes reference to script engine factory in META-INF/services

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -406,7 +406,7 @@ lazy val compiler = configureAsSubproject(project)
     ),
     // Generate the ScriptEngineFactory service definition. The Ant build does this when building
     // the JAR but sbt has no support for it and it is easier to do as a resource generator:
-    generateServiceProviderResources("javax.script.ScriptEngineFactory" -> "scala.tools.nsc.interpreter.IMain$Factory"),
+    generateServiceProviderResources("javax.script.ScriptEngineFactory" -> "scala.tools.nsc.interpreter.Scripted$Factory"),
     managedResourceDirectories in Compile := Seq((resourceManaged in Compile).value),
     fixPom(
       "/project/name" -> <name>Scala Compiler</name>,


### PR DESCRIPTION
This prevents the interpreter to run as a JSR-223 scripting engine (using e.g. jrunscript).
