### PR TITLE
SI-9924: Fix: Spec. refers to U+007F (DELETE) as printable character

### DIFF
--- a/spec/01-lexical-syntax.md
+++ b/spec/01-lexical-syntax.md
@@ -41,7 +41,7 @@ classes (Unicode general category given in parentheses):
 1. Parentheses `‘(’ | ‘)’ | ‘[’ | ‘]’ | ‘{’ | ‘}’ `.
 1. Delimiter characters ``‘`’ | ‘'’ | ‘"’ | ‘.’ | ‘;’ | ‘,’ ``.
 1. Operator characters. These consist of all printable ASCII characters
-   `\u0020` - `\u007F` which are in none of the sets above, mathematical
+   (`\u0020` - `\u007E`) that are in none of the sets above, mathematical
    symbols (`Sm`) and other symbols (`So`).
 
 ## Identifiers


### PR DESCRIPTION
Fixed "\u0020 - \u007F" to "\u0020 - \u007E".
(Also fixed/clarified punctuation and grammar.)
