### PR TITLE
upgrade to scala-xml 1.0.6

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -22,7 +22,7 @@ starr.version=2.12.0-RC1
 scala.binary.version=2.12.0-RC1
 
 # external modules shipped with distribution, as specified by scala-library-all's pom
-scala-xml.version.number=1.0.5
+scala-xml.version.number=1.0.6
 scala-parser-combinators.version.number=1.0.4
 scala-swing.version.number=2.0.0-M2
 scala-swing.version.osgi=2.0.0.M2


### PR DESCRIPTION
just because in general we want to ship the latest versions of the
modules, and some desirable-looking fixes went into 1.0.6

let's at least see if Jenkins passes

1.0.6 release notes: https://github.com/scala/scala-xml/releases/tag/v1.0.6
