### PR TITLE
SD-220 building without being in a git repository

### DIFF
--- a/tools/get-scala-commit-date
+++ b/tools/get-scala-commit-date
@@ -10,8 +10,13 @@
 
 [[ $# -eq 0 ]] || cd "$1"
 
-lastcommitdate=$(git log --format="%ci" HEAD | head -n 1 | cut -d ' ' -f 1)
-lastcommithours=$(git log --format="%ci" HEAD | head -n 1 | cut -d ' ' -f 2)
+if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+	lastcommitdate=$(git log --format="%ci" HEAD | head -n 1 | cut -d ' ' -f 1)
+	lastcommithours=$(git log --format="%ci" HEAD | head -n 1 | cut -d ' ' -f 2)
+else
+	lastcommitdate=$(date +%Y-%m-%d)
+	lastcommithours=$(date +%H:%M:%S)
+fi
 
 # 20120324
 echo "${lastcommitdate//-/}-${lastcommithours//:/}"

--- a/tools/get-scala-commit-sha
+++ b/tools/get-scala-commit-sha
@@ -10,9 +10,13 @@
 
 [[ $# -eq 0 ]] || cd "$1"
 
-# printf %016s is not portable for 0-padding, has to be a digit.
-# so we're stuck disassembling it.
-hash=$(git log -1 --format="%H" HEAD)
-hash=${hash#g}
-hash=${hash:0:10}
+if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+	# printf %016s is not portable for 0-padding, has to be a digit.
+	# so we're stuck disassembling it.
+	hash=$(git log -1 --format="%H" HEAD)
+	hash=${hash#g}
+	hash=${hash:0:10}
+else
+	hash="unknown"
+fi
 echo "$hash"


### PR DESCRIPTION
This allows building from the scala source tarball or similar
situations where there is no local git repository:
- the git commit date becomes the local date
- the short git sha1 becomes "unknown"

```
Welcome to Scala 2.12.0-20160920-155429-unknown (OpenJDK 64-Bit Server VM, Java 1.8.0_102).
```
