### PR TITLE
SD-226 Be lazier in Fields info transform for better performance

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Fields.scala
+++ b/src/compiler/scala/tools/nsc/transform/Fields.scala
@@ -305,7 +305,7 @@ abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransfor
       lazyCallingSuper setInfo tp
     }
 
-    private def needsMixin(cls: Symbol): Boolean = {
+    private def classNeedsInfoTransform(cls: Symbol): Boolean = {
       !(cls.isPackageClass || cls.isJavaDefined) && (currentRun.compiles(cls) || refChecks.isSeparatelyCompiledScalaSuperclass(cls))
     }
 
@@ -365,7 +365,7 @@ abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransfor
         } else tp
 
 
-      case tp@ClassInfoType(parents, oldDecls, clazz) if !needsMixin(clazz) => tp
+      case tp@ClassInfoType(parents, oldDecls, clazz) if !classNeedsInfoTransform(clazz) => tp
 
       // mix in fields & accessors for all mixed in traits
       case tp@ClassInfoType(parents, oldDecls, clazz) =>

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -95,6 +95,9 @@ abstract class RefChecks extends Transform {
       )
   }
 
+  private val separatelyCompiledScalaSuperclass = perRunCaches.newAnyRefMap[Symbol, Unit]()
+  final def isSeparatelyCompiledScalaSuperclass(sym: Symbol) = separatelyCompiledScalaSuperclass.contains(sym)
+
   class RefCheckTransformer(unit: CompilationUnit) extends Transformer {
 
     var localTyper: analyzer.Typer = typer
@@ -854,6 +857,8 @@ abstract class RefChecks extends Transform {
 //            println("validate base type "+tp)
         val baseClass = tp.typeSymbol
         if (baseClass.isClass) {
+          if (!baseClass.isTrait && !baseClass.isJavaDefined && !currentRun.compiles(baseClass) && !separatelyCompiledScalaSuperclass.contains(baseClass))
+            separatelyCompiledScalaSuperclass.update(baseClass, ())
           val index = clazz.info.baseTypeIndex(baseClass)
           if (index >= 0) {
             if (seenTypes(index) forall (tp1 => !(tp1 <:< tp)))

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -96,7 +96,13 @@ abstract class RefChecks extends Transform {
   }
 
   private val separatelyCompiledScalaSuperclass = perRunCaches.newAnyRefMap[Symbol, Unit]()
-  final def isSeparatelyCompiledScalaSuperclass(sym: Symbol) = separatelyCompiledScalaSuperclass.contains(sym)
+  final def isSeparatelyCompiledScalaSuperclass(sym: Symbol) = if (globalPhase.refChecked){
+    separatelyCompiledScalaSuperclass.contains(sym)
+  } else {
+    // conservative approximation in case someone in pre-refchecks phase asks for `exitingFields(someClass.info)`
+    // and we haven't run the refchecks tree transform which populates `separatelyCompiledScalaSuperclass`
+    false
+  }
 
   class RefCheckTransformer(unit: CompilationUnit) extends Transformer {
 


### PR DESCRIPTION
Only mixin fields + accessors into class infos of classes that are
either in the current run, or appear in a superclass chain of a class
in the current run.

This is analagous to what happens in the mixin phase.

Review by @adriaanm 

I'll post some benchmark results below.
