### PR TITLE
Do not build partest-javaagent and partest-extras for `pack`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -510,8 +510,10 @@ lazy val scalap = configureAsSubproject(project)
   )
   .dependsOn(compiler)
 
-lazy val partestExtras = configureAsSubproject(Project("partest-extras", file(".") / "src" / "partest-extras"))
+lazy val partestExtras = Project("partest-extras", file(".") / "src" / "partest-extras")
   .dependsOn(replJlineEmbedded)
+  .settings(commonSettings: _*)
+  .settings(generatePropertiesFileSettings: _*)
   .settings(clearSourceAndResourceDirectories: _*)
   .settings(disableDocs: _*)
   .settings(disablePublishing: _*)
@@ -597,8 +599,6 @@ lazy val partestJavaAgent = Project("partest-javaagent", file(".") / "src" / "pa
     // Setting name to "scala-partest-javaagent" so that the jar file gets that name, which the Runner relies on
     name := "scala-partest-javaagent",
     description := "Scala Compiler Testing Tool (compiler-specific java agent)",
-    // writing jar file to $buildDirectory/pack/lib because that's where it's expected to be found
-    setJarLocation,
     // add required manifest entry - previously included from file
     packageOptions in (Compile, packageBin) +=
       Package.ManifestAttributes( "Premain-Class" -> "scala.tools.partest.javaagent.ProfilingAgent" ),
@@ -829,7 +829,7 @@ lazy val root: Project = (project in file("."))
   )
 
 // The following subprojects' binaries are required for building "pack":
-lazy val distDependencies = Seq(replJline, replJlineEmbedded, compiler, library, partestExtras, partestJavaAgent, reflect, scalap, scaladoc)
+lazy val distDependencies = Seq(replJline, replJlineEmbedded, compiler, library, reflect, scalap, scaladoc)
 
 lazy val dist = (project in file("dist"))
   .settings(commonSettings)


### PR DESCRIPTION
Building them as part of `dist/mkQuick` (and thus, by extension,
`dist/mkPack`) was not necessary in the first place. Partest does not
rely on these tasks for its dependencies.

And when we do build the jars, they now go into their standard location
under `target` instead of `build/pack/lib` so they don’t confuse
sbt (see https://github.com/sbt/sbt/issues/2748).
