### PR TITLE
SD-233 synchronized blocks are JIT-friendly again

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSyncAndTry.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSyncAndTry.scala
@@ -73,9 +73,11 @@ abstract class BCodeSyncAndTry extends BCodeBodyBuilder {
       /* ------ (4) exception-handler version of monitor-exit code.
        *            Reached upon abrupt termination of (2).
        *            Protected by whatever protects the whole synchronized expression.
+       *            null => "any" exception in bytecode, like we emit for finally.
+       *            Important not to use j/l/Throwable which dooms the method to a life of interpretation! (SD-233)
        * ------
        */
-      protect(startProtected, endProtected, currProgramPoint(), jlThrowableRef)
+      protect(startProtected, endProtected, currProgramPoint(), null)
       locals.load(monitor)
       emit(asm.Opcodes.MONITOREXIT)
       emit(asm.Opcodes.ATHROW)

--- a/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
@@ -187,4 +187,12 @@ class BytecodeTest extends BytecodeTesting {
       List(Label(0), LineNumber(2, Label(0)), VarOp(ALOAD, 0), Invoke(INVOKESPECIAL, "T", "t", "()V", true), Op(RETURN), Label(4))
     )
   }
+
+  @Test
+  def sd233(): Unit = {
+    val code = "def f = { println(1); synchronized(println(2)) }"
+    val m = compileMethod(code)
+    val List(ExceptionHandler(_, _, _, desc)) = m.handlers
+    assert(desc == None, desc)
+  }
 }


### PR DESCRIPTION
GenBCode, the new backend in Scala 2.12, subtly changed
the way that synchronized blocks are emitted.

It used `java/lang/Throwable` as an explicitly named exception
type, rather than implying the same by omitting this in bytecode.

This appears to confuse HotSpot JIT, which reports a error
parsing the bytecode into its IR which leaves the enclosing method
stuck in interpreted mode.

This commit passes a `null` descriptor to restore the old pattern
(the same one used by javac.) I've checked that the JIT warnings
are gone and that the method can be compiled again.

Fixes https://github.com/scala/scala-dev/issues/233
