### PR TITLE
Optimize javaBinaryName callers

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -114,7 +114,7 @@ class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
     if (classSym == NothingClass) srNothingRef
     else if (classSym == NullClass) srNullRef
     else {
-      val internalName = classSym.javaBinaryName.toString
+      val internalName = classSym.javaBinaryNameString
       classBTypeFromInternalName.getOrElse(internalName, {
         // The new ClassBType is added to the map in its constructor, before we set its info. This
         // allows initializing cyclic dependencies, see the comment on variable ClassBType._info.
@@ -625,7 +625,7 @@ class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
    */
   def mirrorClassClassBType(moduleClassSym: Symbol): ClassBType = {
     assert(isTopLevelModuleClass(moduleClassSym), s"not a top-level module class: $moduleClassSym")
-    val internalName = moduleClassSym.javaBinaryName.dropModule.toString
+    val internalName = moduleClassSym.javaBinaryNameString.stripSuffix(nme.MODULE_SUFFIX_STRING)
     classBTypeFromInternalName.getOrElse(internalName, {
       val c = ClassBType(internalName)
       // class info consistent with BCodeHelpers.genMirrorClass
@@ -642,7 +642,7 @@ class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
   }
 
   def beanInfoClassClassBType(mainClass: Symbol): ClassBType = {
-    val internalName = mainClass.javaBinaryName.toString + "BeanInfo"
+    val internalName = mainClass.javaBinaryNameString + "BeanInfo"
     classBTypeFromInternalName.getOrElse(internalName, {
       val c = ClassBType(internalName)
       c.info = Right(ClassInfo(

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
@@ -337,7 +337,7 @@ abstract class GenBCode extends BCodeSyncAndTry {
       bTypes.initializeCoreBTypes()
       bTypes.javaDefinedClasses.clear()
       bTypes.javaDefinedClasses ++= currentRun.symSource collect {
-        case (sym, _) if sym.isJavaDefined => sym.javaBinaryName.toString
+        case (sym, _) if sym.isJavaDefined => sym.javaBinaryNameString
       }
       Statistics.stopTimer(BackendStats.bcodeInitTimer, initStart)
 

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -258,7 +258,7 @@ abstract class Erasure extends InfoTransform
     // Anything which could conceivably be a module (i.e. isn't known to be
     // a type parameter or similar) must go through here or the signature is
     // likely to end up with Foo<T>.Empty where it needs Foo<T>.Empty$.
-    def fullNameInSig(sym: Symbol) = "L" + enteringJVM(sym.javaBinaryName)
+    def fullNameInSig(sym: Symbol) = "L" + enteringJVM(sym.javaBinaryNameString)
 
     def jsig(tp0: Type, existentiallyBound: List[Symbol] = Nil, toplevel: Boolean = false, primitiveOK: Boolean = true): String = {
       val tp = tp0.dealias


### PR DESCRIPTION
... by calling javaBinaryNameString, instead.

They all are happy with a throw away String, there is no advantage
to interning this into the name table.

Review by @lrytz
