### PR TITLE
Optimizations around setting lookups

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -245,7 +245,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
       body
   }
 
-  override protected def isDeveloper = settings.developer || super.isDeveloper
+  override protected def isDeveloper = settings.developer.boolValue || super.isDeveloper
 
   /** This is for WARNINGS which should reach the ears of scala developers
    *  whenever they occur, but are not useful for normal users. They should
@@ -274,7 +274,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
   }
 
   @inline final override def debuglog(msg: => String) {
-    if (settings.debug)
+    if (settings.debug.boolValue)
       log(msg)
   }
 

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1052,7 +1052,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
 
   /** A Run is a single execution of the compiler on a set of units.
    */
-  class Run extends RunContextApi with RunReporting with RunParsing {
+  class Run extends RunContextApi with RunReporting with RunParsing with RunSettings {
     /** Have been running into too many init order issues with Run
      *  during erroneous conditions.  Moved all these vals up to the
      *  top of the file so at least they're not trivially null.
@@ -1517,6 +1517,12 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
     }
   } // class Run
 
+
+  class PerRunSettings extends PerRunSettingsBase {
+    override val isScala211: Boolean = settings.isScala211
+    override val isScala212: Boolean = settings.isScala212
+  }
+  override protected def PerRunSettings: PerRunSettings = new PerRunSettings
   def printAllUnits() {
     print("[[syntax trees at end of %25s]]".format(phase))
     exitingPhase(phase)(currentRun.units foreach { unit =>

--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -455,6 +455,7 @@ class MutableSettings(val errorFn: String => Unit)
     type T = Boolean
     protected var v: Boolean = false
     override def value: Boolean = v
+    def boolValue: Boolean = v
 
     def tryToSet(args: List[String]) = { value = true ; Some(args) }
     def unparse: List[String] = if (value) List(name) else Nil

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -804,7 +804,7 @@ trait Contexts { self: Analyzer =>
       isAccessible(sym, pre) &&
       !(imported && {
         val e = scope.lookupEntry(name)
-        (e ne null) && (e.owner == scope) && (!settings.isScala212 || e.sym.exists)
+        (e ne null) && (e.owner == scope) && (!currentRun.runSettings.isScala212 || e.sym.exists)
       })
 
     /** Do something with the symbols with name `name` imported via the import in `imp`,

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -61,11 +61,6 @@ trait Namers extends MethodSynthesis {
     private lazy val innerNamer =
       if (isTemplateContext(context)) createInnerNamer() else this
 
-    // Cached as a val because `settings.isScala212` parses the Scala version each time...
-    // Not in Namers because then we need to go to outer first to check this.
-    // I do think it's ok to check every time we create a Namer instance (so, not a lazy val).
-    private[this] val isScala212 = settings.isScala212
-
     def createNamer(tree: Tree): Namer = {
       val sym = tree match {
         case ModuleDef(_, _, _) => tree.symbol.moduleClass
@@ -1495,7 +1490,7 @@ trait Namers extends MethodSynthesis {
               val valOwner = owner.owner
               // there's no overriding outside of classes, and we didn't use to do this in 2.11, so provide opt-out
 
-              if (!isScala212 || !valOwner.isClass) WildcardType
+              if (!currentRun.runSettings.isScala212 || !valOwner.isClass) WildcardType
               else {
                 // normalize to getter so that we correctly consider a val overriding a def
                 // (a val's name ends in a " ", so can't compare to def)

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -513,7 +513,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val TypeCreatorClass      = getClassIfDefined("scala.reflect.api.TypeCreator") // defined in scala-reflect.jar, so we need to be careful
     lazy val TreeCreatorClass      = getClassIfDefined("scala.reflect.api.TreeCreator") // defined in scala-reflect.jar, so we need to be careful
 
-    private def Context_210               = if (settings.isScala211) NoSymbol else getClassIfDefined("scala.reflect.macros.Context") // needed under -Xsource:2.10
+    private def Context_210               = if (currentRun.runSettings.isScala211) NoSymbol else getClassIfDefined("scala.reflect.macros.Context") // needed under -Xsource:2.10
     lazy val BlackboxContextClass         = getClassIfDefined("scala.reflect.macros.blackbox.Context").orElse(Context_210) // defined in scala-reflect.jar, so we need to be careful
 
     lazy val WhiteboxContextClass         = getClassIfDefined("scala.reflect.macros.whitebox.Context").orElse(Context_210) // defined in scala-reflect.jar, so we need to be careful
@@ -834,7 +834,7 @@ trait Definitions extends api.StandardDefinitions {
       (sym eq PartialFunctionClass) || (sym eq AbstractPartialFunctionClass)
     }
 
-    private[this] val doSam = settings.isScala212 || (settings.isScala211 && settings.Xexperimental)
+    private[this] val doSam = currentRun.runSettings.isScala212 || (currentRun.runSettings.isScala211 && settings.Xexperimental)
 
     /** The single abstract method declared by type `tp` (or `NoSymbol` if it cannot be found).
      *

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -210,6 +210,18 @@ abstract class SymbolTable extends macros.Universe
   /** The run identifier of the given period. */
   final def runId(period: Period): RunId = period >> 8
 
+  trait RunSettings {
+    val runSettings: PerRunSettings = PerRunSettings
+  }
+
+  type PerRunSettings <: PerRunSettingsBase
+  protected def PerRunSettings: PerRunSettings
+  abstract class PerRunSettingsBase {
+    def isScala211: Boolean
+    def isScala212: Boolean
+  }
+  def currentRun: RunSettings with RunReporting
+
   /** The phase identifier of the given period. */
   final def phaseId(period: Period): Phase#Id = period & 0xFF
 

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -61,7 +61,7 @@ abstract class SymbolTable extends macros.Universe
 
   def shouldLogAtThisPhase = false
   def isPastTyper = false
-  protected def isDeveloper: Boolean = settings.debug
+  protected def isDeveloper: Boolean = settings.debug.boolValue
 
   @deprecated("use devWarning if this is really a warning; otherwise use log", "2.11.0")
   def debugwarn(msg: => String): Unit = devWarning(msg)

--- a/src/reflect/scala/reflect/internal/Variances.scala
+++ b/src/reflect/scala/reflect/internal/Variances.scala
@@ -75,7 +75,7 @@ trait Variances {
           else if (isExemptFromVariance(sym)) Bivariant
           else if (sym.isAliasType) (
             // Unsound pre-2.11 behavior preserved under -Xsource:2.10
-            if (settings.isScala211 || sym.isOverridingSymbol) Invariant
+            if (currentRun.runSettings.isScala211 || sym.isOverridingSymbol) Invariant
             else {
               currentRun.reporting.deprecationWarning(sym.pos, "Construct depends on unsound variance analysis and will not compile in scala 2.11 and beyond", "2.11.0")
               Bivariant

--- a/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
+++ b/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
@@ -13,7 +13,7 @@ package settings
 abstract class MutableSettings extends AbsSettings {
 
   type Setting <: SettingValue
-  type BooleanSetting <: Setting { type T = Boolean }
+  type BooleanSetting <: Setting { type T = Boolean; def boolValue: Boolean }
   type IntSetting <: Setting { type T = Int }
   type MultiStringSetting <: Setting { type T = List[String] }
 

--- a/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
@@ -173,11 +173,11 @@ trait TypeComparers {
   // SI-2066 This prevents overrides with incompatible variance in higher order type parameters.
   private def methodHigherOrderTypeParamsSameVariance(sym1: Symbol, sym2: Symbol) = {
     def ignoreVariance(sym: Symbol) = !(sym.isHigherOrderTypeParameter && sym.logicallyEnclosingMember.isMethod)
-    !settings.isScala211 || ignoreVariance(sym1) || ignoreVariance(sym2) || sym1.variance == sym2.variance
+    !currentRun.runSettings.isScala211 || ignoreVariance(sym1) || ignoreVariance(sym2) || sym1.variance == sym2.variance
   }
 
   private def methodHigherOrderTypeParamsSubVariance(low: Symbol, high: Symbol) =
-    !settings.isScala211 || methodHigherOrderTypeParamsSameVariance(low, high) || low.variance.isInvariant
+    !currentRun.runSettings.isScala211 || methodHigherOrderTypeParamsSameVariance(low, high) || low.variance.isInvariant
 
   def isSameType2(tp1: Type, tp2: Type): Boolean = {
     def retry(lhs: Type, rhs: Type) = ((lhs ne tp1) || (rhs ne tp2)) && isSameType(lhs, rhs)

--- a/src/reflect/scala/reflect/runtime/JavaUniverse.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverse.scala
@@ -28,11 +28,16 @@ class JavaUniverse extends InternalSymbolTable with JavaUniverseForce with Refle
   }
 
   // minimal Run to get Reporting wired
-  def currentRun = new RunReporting {}
+  def currentRun = new RunReporting with RunSettings{}
   class PerRunReporting extends PerRunReportingBase {
     def deprecationWarning(pos: Position, msg: String, since: String): Unit = reporter.warning(pos, msg)
   }
   protected def PerRunReporting = new PerRunReporting
+  class PerRunSettings extends PerRunSettingsBase {
+    override def isScala211: Boolean = settings.isScala211
+    override def isScala212: Boolean = settings.isScala212
+  }
+  protected def PerRunSettings = new PerRunSettings
 
 
   type TreeCopier = InternalTreeCopierOps

--- a/src/reflect/scala/reflect/runtime/Settings.scala
+++ b/src/reflect/scala/reflect/runtime/Settings.scala
@@ -14,6 +14,7 @@ private[reflect] class Settings extends MutableSettings {
 
   class BooleanSetting(x: Boolean) extends Setting {
     type T = Boolean
+    def boolValue = x
     protected var v: Boolean = x
     override def value: Boolean = v
   }

--- a/test/junit/scala/tools/nsc/symtab/SymbolTableForUnitTesting.scala
+++ b/test/junit/scala/tools/nsc/symtab/SymbolTableForUnitTesting.scala
@@ -82,8 +82,14 @@ class SymbolTableForUnitTesting extends SymbolTable {
     protected def info0(pos: Position, msg: String, severity: Severity, force: Boolean): Unit = println(msg)
   }
 
+  class PerRunSettings extends PerRunSettingsBase {
+    def isScala211: Boolean = true
+    def isScala212: Boolean = true
+  }
+  protected def PerRunSettings: PerRunSettings = new PerRunSettings
+
   // minimal Run to get Reporting wired
-  def currentRun = new RunReporting {}
+  def currentRun = new RunReporting with RunSettings {}
   class PerRunReporting extends PerRunReportingBase {
     def deprecationWarning(pos: Position, msg: String, since: String): Unit = reporter.warning(pos, msg)
   }


### PR DESCRIPTION
Generalize the optimization used in Namers to cache `isScala2xx`
to all callers of these expensive, settings derived values.

Also avoids boxy, generic code paths for simple lookups of boolean
settings.
