### PR TITLE
SI-9936 SeqLike.indexWhere starts at zero

### DIFF
--- a/src/library/scala/collection/SeqLike.scala
+++ b/src/library/scala/collection/SeqLike.scala
@@ -113,7 +113,7 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
   }
 
   def indexWhere(p: A => Boolean, from: Int): Int = {
-    var i = from
+    var i = from max 0
     val it = iterator.drop(from)
     while (it.hasNext) {
       if (p(it.next())) return i

--- a/test/junit/scala/collection/SeqLikeTest.scala
+++ b/test/junit/scala/collection/SeqLikeTest.scala
@@ -1,0 +1,19 @@
+package scala.collection
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Assert._
+import org.junit.Test
+
+@RunWith(classOf[JUnit4])
+class SeqLikeTest {
+
+  @Test def `SI-9936 indexWhere`(): Unit = {
+    assertEquals(2, "abcde".indexOf('c', -1))
+    assertEquals(2, "abcde".indexOf('c', -2))
+    assertEquals(2, "abcde".toVector.indexOf('c', -1))
+    assertEquals(2, "abcde".toVector.indexOf('c', -2))
+    assertEquals(2, "abcde".toVector.indexWhere(_ == 'c', -1))
+    assertEquals(2, "abcde".toVector.indexWhere(_ == 'c', -2))
+  }
+}


### PR DESCRIPTION
This follows the Scaladoc, and makes

```
"abcdef".indexOf('c', -1)
```

work like

```
"abcdef".toVector.indexOf('c', -1)
```
