### PR TITLE
Including Lightbend in `-version` message.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -160,7 +160,7 @@ lazy val commonSettings = clearSourceAndResourceDirectories ++ publishSettings +
         <developers>
           <developer>
             <id>lamp</id>
-            <name>EPFL LAMP</name>
+            <name>LAMP/EPFL</name>
           </developer>
           <developer>
             <id>Lightbend</id>

--- a/project/VersionUtil.scala
+++ b/project/VersionUtil.scala
@@ -18,7 +18,7 @@ object VersionUtil {
   )
 
   lazy val generatePropertiesFileSettings = Seq[Setting[_]](
-    copyrightString := "Copyright 2002-2016, LAMP/EPFL",
+    copyrightString := "Copyright 2002-2016, LAMP/EPFL and Lightbend, Inc.",
     resourceGenerators in Compile += generateVersionPropertiesFile.map(file => Seq(file)).taskValue,
     generateVersionPropertiesFile := generateVersionPropertiesFileImpl.value
   )

--- a/src/library/scala/util/Properties.scala
+++ b/src/library/scala/util/Properties.scala
@@ -105,7 +105,7 @@ private[scala] trait PropertiesTrait {
    *  or "version (unknown)" if it cannot be determined.
    */
   val versionString         = "version " + scalaPropOrElse("version.number", "(unknown)")
-  val copyrightString       = scalaPropOrElse("copyright.string", "Copyright 2002-2016, LAMP/EPFL")
+  val copyrightString       = scalaPropOrElse("copyright.string", "Copyright 2002-2016, LAMP/EPFL and Lightbend, Inc.")
 
   /** This is the encoding to use reading in source files, overridden with -encoding.
    *  Note that it uses "prop" i.e. looks in the scala jar, not the system properties.


### PR DESCRIPTION
Also consistently use "LAMP/EPFL" and not "EPFL LAMP".
