### PR TITLE
CI validation: run test:compile before testAll

### DIFF
--- a/scripts/jobs/validate/test
+++ b/scripts/jobs/validate/test
@@ -23,6 +23,7 @@ case $prDryRun in
        --warn \
        "setupValidateTest $prRepoUrl" \
        $testExtraArgs \
+       test:compile \
        testAll
 
     ;;


### PR DESCRIPTION
Seeks to fail fast and in an normal manner for bootstrapping errors,
rather than the enourmous diagnostic error seen in:

https://scala-ci.typesafe.com/job/scala-2.12.x-validate-test/3175/consoleText

Review by @szeiger
