### PR TITLE
Limit partest concurrency to 8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -633,6 +633,8 @@ lazy val test = project
     testFrameworks += new TestFramework("scala.tools.partest.sbt.Framework"),
     testFrameworks -= new TestFramework("org.scalacheck.ScalaCheckFramework"),
     testOptions in IntegrationTest += Tests.Argument("-Dpartest.java_opts=-Xmx1024M -Xms64M -XX:MaxPermSize=128M"),
+    testOptions in IntegrationTest += Tests.Argument(s"-Dpartest.threads=${java.lang.Runtime.getRuntime.availableProcessors().min(8)}"),
+    // More than 8 seems to overwhelm the 2G heap we allocate to the process that compiles partest test sources in parallel
     testOptions in IntegrationTest += Tests.Argument("-Dpartest.scalac_opts=" + (scalacOptions in Compile).value.mkString(" ")),
     testOptions in IntegrationTest += Tests.Setup { () =>
       val cp = (dependencyClasspath in Test).value

--- a/build.sbt
+++ b/build.sbt
@@ -751,72 +751,24 @@ lazy val root: Project = (project in file("."))
       state
     },
     testAll := {
-      val results = ScriptCommands.sequence[Result[Unit]](List(
-        (Keys.test in Test in junit).result,
-        (testOnly in IntegrationTest in testP).toTask(" -- run").result,
-        (testOnly in IntegrationTest in testP).toTask(" -- pos neg jvm").result,
-        (testOnly in IntegrationTest in testP).toTask(" -- res scalap specialized scalacheck").result,
-        (testOnly in IntegrationTest in testP).toTask(" -- instrumented presentation").result,
-        (testOnly in IntegrationTest in testP).toTask(" -- --srcpath scaladoc").result,
-        (Keys.test in Test in osgiTestFelix).result,
-        (Keys.test in Test in osgiTestEclipse).result,
-        (MiMa.mima in library).result,
-        (MiMa.mima in reflect).result,
+      List(
+        (Keys.test in Test in junit).result.value,
+        (testOnly in IntegrationTest in testP).toTask(" -- run").result.value,
+        (testOnly in IntegrationTest in testP).toTask(" -- pos neg jvm").result.value,
+        (testOnly in IntegrationTest in testP).toTask(" -- res scalap specialized scalacheck").result.value,
+        (testOnly in IntegrationTest in testP).toTask(" -- instrumented presentation").result.value,
+        (testOnly in IntegrationTest in testP).toTask(" -- --srcpath scaladoc").result.value,
+        (Keys.test in Test in osgiTestFelix).result.value,
+        (Keys.test in Test in osgiTestEclipse).result.value,
+        (MiMa.mima in library).result.value,
+        (MiMa.mima in reflect).result.value,
         Def.task(()).dependsOn( // Run these in parallel:
           doc in Compile in library,
           doc in Compile in reflect,
           doc in Compile in compiler,
           doc in Compile in scalap
-        ).result
-      )).value
-      // All attempts to define these together with the actual tasks due to the applicative rewriting of `.value`
-      val descriptions = Vector(
-        "junit/test",
-        "partest run",
-        "partest pos neg jvm",
-        "partest res scalap specialized scalacheck",
-        "partest instrumented presentation",
-        "partest --srcpath scaladoc",
-        "osgiTestFelix/test",
-        "osgiTestEclipse/test",
-        "library/mima",
-        "reflect/mima",
-        "doc"
+        ).result.value
       )
-      val failed = results.map(_.toEither).zip(descriptions).collect { case (Left(i: Incomplete), d) => (i, d) }
-      if(failed.nonEmpty) {
-        val log = streams.value.log
-        def showScopedKey(k: Def.ScopedKey[_]): String =
-          Vector(
-            k.scope.project.toOption.map {
-              case p: ProjectRef => p.project
-              case p => p
-            }.map(_ + "/"),
-            k.scope.config.toOption.map(_.name + ":"),
-            k.scope.task.toOption.map(_.label + "::")
-          ).flatten.mkString + k.key
-        def logIncomplete(i: Incomplete, prefix: String): Unit = {
-          val sk = i.node match {
-            case Some(t: Task[_]) =>
-              t.info.attributes.entries.collect { case e if e.key == Keys.taskDefinitionKey => e.value.asInstanceOf[Def.ScopedKey[_]] }
-                .headOption.map(showScopedKey)
-            case _ => None
-          }
-          val childCount = (if(i.directCause.isDefined) 1 else 0) + i.causes.length
-          val skip = childCount <= 1 && sk.isEmpty
-          if(!skip) log.error(s"$prefix- ${sk.getOrElse("?")}")
-          i.directCause match {
-            case Some(e) => log.error(s"$prefix  - $e")
-            case None => i.causes.foreach(i => logIncomplete(i, prefix + (if(skip) "" else "  ")))
-          }
-        }
-        log.error(s"${failed.size} of ${results.length} test tasks failed:")
-        failed.foreach { case (i, d) =>
-          log.error(s"- $d")
-          logIncomplete(i, "  ")
-        }
-        throw new RuntimeException
-      }
     },
     antStyle := false,
     incOptions := incOptions.value.withNameHashing(!antStyle.value).withAntStyle(antStyle.value)


### PR DESCRIPTION
In an attempt to restore stability to CI builds after
the move to a bigger box with 16 processors.
