### PR TITLE
Bump sbt-jmh version to 0.2.16

### DIFF
--- a/test/benchmarks/project/plugins.sbt
+++ b/test/benchmarks/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "4.0.0")
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.6")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.16")


### PR DESCRIPTION
It'd be good to use the latest version( with the latest JMH version `1.14.1`). From sbt-jmh version `0.2.10`, Flight Recorder / Java Mission Control is available[1], which would be nice.

[1] https://github.com/ktoso/sbt-jmh#using-oracle-flight-recorder
