### PR TITLE
Explicit set diff

### DIFF
--- a/src/library/scala/collection/GenSetLike.scala
+++ b/src/library/scala/collection/GenSetLike.scala
@@ -83,7 +83,7 @@ extends GenIterableLike[A, Repr]
    *  @return     a set containing those elements of this
    *              set that are not also contained in the given set `that`.
    */
-  def diff(that: GenSet[A]): Repr
+  def diff(that: GenSet[A]): Repr = this filterNot that
 
   /** The difference of this set and another set.
    *

--- a/src/library/scala/collection/SetLike.scala
+++ b/src/library/scala/collection/SetLike.scala
@@ -171,14 +171,6 @@ self =>
    */
   def union(that: GenSet[A]): This = this ++ that
 
-  /** Computes the difference of this set and another set.
-   *
-   *  @param that the set of elements to exclude.
-   *  @return     a set containing those elements of this
-   *              set that are not also contained in the given set `that`.
-   */
-  def diff(that: GenSet[A]): This = this -- that
-
   /** An iterator over all subsets of this set of the given size.
    *  If the requested size is impossible, an empty iterator is returned.
    *

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -65,6 +65,7 @@ object Set extends ImmutableSetFactory[Set] {
   implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Set[A]] = setCanBuildFrom[A]
 
   /** An optimized representation for immutable empty sets */
+  @SerialVersionUID(-2443710944435909512L)
   private object EmptySet extends AbstractSet[Any] with Set[Any] with Serializable {
     override def size: Int = 0
     def contains(elem: Any): Boolean = false

--- a/src/library/scala/collection/parallel/ParSetLike.scala
+++ b/src/library/scala/collection/parallel/ParSetLike.scala
@@ -41,7 +41,4 @@ extends GenSetLike[T, Repr]
     _ union that
   }
 
-  def diff(that: GenSet[T]): Repr = sequentially {
-    _ diff that
-  }
 }

--- a/test/benchmarks/src/main/scala/benchmark/TwoSetInRatioProvider.scala
+++ b/test/benchmarks/src/main/scala/benchmark/TwoSetInRatioProvider.scala
@@ -1,0 +1,32 @@
+package benchmark
+
+/** Provider of pair [[Set[T], Set[T]]
+  * 
+  * @tparam T the type of the keys
+  */
+trait TwoSetInRatioProvider[T] {
+  /** Return new instance of T base on int index. */
+  def instance(idx: Int): T
+
+  /**
+    * |---s1--|---s1-&-s2--|-------s2-------| ; |s1|+|s2| = size; |s1|/|s2| = ratio; |s1 & s2|/n = intersection
+    * Return a pair of Sets having size, ratio and intersection. */
+  def build(size: Int, ratio: Float, intersection: Float): (scala.collection.immutable.Set[T], scala.collection.immutable.Set[T]) = {
+    val keys = (0 until size).map(instance).toList
+    val s2Start = Math.round(size * (1 - intersection) * ratio / (1 + ratio))
+    val s1End = Math.round(s2Start + size * intersection * ratio)
+
+    val set1 = keys.take(s1End).toSet
+    val set2 = keys.drop(s2Start).toSet
+
+    (set1, set2)
+  }
+}
+
+object TwoSetInRatioProvider {
+
+  implicit object TwoSetInRatioIntProviÅder extends TwoSetInRatioProvider[Int] {
+    override def instance(idx: Int): Int = idx
+  }
+
+}

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/SetBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/SetBenchmark.scala
@@ -1,0 +1,82 @@
+package scala.collection.immutable
+
+import java.util.concurrent.TimeUnit
+
+import benchmark._
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra._
+
+private object SetBenchmark {
+
+  @State(Scope.Thread)
+  private[this] abstract class DiffByFilterBulk[T](implicit keyBuilder: TwoSetInRatioProvider[T]) {
+
+    /** Total number of values in both sets. */
+    private[this] var size: Int = _
+
+    /** Target proportion of sizes of both sets. */
+    private[this] var ratio: Float = _
+
+    /** Target share of values that are in both sets. */
+    private[this] var intersection: Float = _
+
+    /** The set from which we want to subtract another set */
+    private[this] var _set1: Set[T] = _
+    def set1 = _set1
+
+    /** The set values of which we do not desire in set1 */
+    private[this] var _set2: Set[T] = _
+    def set2 = _set2
+
+    /** Build both sets. */
+    @Setup
+    def threadSetup(params: BenchmarkParams) {
+      size = params.getParam("size").toInt
+      ratio = params.getParam("ratio").toFloat
+      intersection = params.getParam("intersection").toFloat
+
+      val generatedSets: (Predef.Set[T], Predef.Set[T]) = keyBuilder.build(size, ratio, intersection)
+      _set1 = generatedSets._1.toSet
+      _set2 = generatedSets._2.toSet
+      System.gc()
+    }
+  }
+
+  private class IntDiffByFilterBulk extends DiffByFilterBulk[Int]
+
+}
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(1)
+@Threads(1)
+@Warmup(iterations = 2)
+@Measurement(iterations = 2)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+class SetBenchmark {
+
+  import SetBenchmark._
+
+  @Param(Array("100", "1000", "100000", "10000000"))
+  var size: Int = _
+
+  @Param(Array("0.0", "0.1", "0.25", "0.5", "0.75", "0.9", "1.0"))
+  var ratio: Float = _
+
+  @Param(Array("0.0", "0.33", "0.66", "1.0"))
+  var intersection: Float = _
+
+  // Tests with Int values
+
+  @Benchmark
+  def int_set_diff_by_filtering(state: IntDiffByFilterBulk) = state.set1 filterNot state.set2
+
+  /** Be sure You run this benchmark with a version of scala where &~ (diff) is implemented as -- **/
+  @Benchmark
+  def int_set_diff_by_removing(state: IntDiffByFilterBulk) = state.set1 -- state.set2
+
+  @Benchmark
+  def int_set_diff_by_diff(state: IntDiffByFilterBulk) = state.set1 &~ state.set2
+
+}
+

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/SetRunner.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/SetRunner.scala
@@ -1,0 +1,60 @@
+package scala.collection.immutable
+
+import java.io.{File, PrintWriter}
+
+import benchmark.JmhRunner
+import org.openjdk.jmh.results.{Result, RunResult}
+import org.openjdk.jmh.runner.Runner
+import org.openjdk.jmh.runner.options.{CommandLineOptions, OptionsBuilder, VerboseMode}
+
+import scala.language.existentials
+
+/** Replacement JMH application that runs the [[Set]] benchmark.
+  *
+  * Outputs the results in a form consumable by a Gnuplot script.
+  */
+object SetRunner extends JmhRunner {
+  /** File that will be created for the output data set. */
+  private[this] val outputFile = new File(outputDirectory, "SetDiffComaparsion.dat")
+
+  /** Adapter to the JMH result class that simplifies our method calls. */
+  private[this] implicit class MyRunResult(r: RunResult) {
+    /** Return the dataset label. */
+    def label = r.getPrimaryResult.getLabel
+
+    /** Return the number of values. */
+    def size = r.getParams.getParam("size")
+
+    /** Return the ratio counts. */
+    def ratio = r.getParams.getParam("ratio")
+
+    /** Return the intersection. */
+    def intersection = r.getParams.getParam("intersection")
+
+  }
+
+  /** Return the statistics of the given result as a string. */
+  private[this] def stats(r: Result[_]) = r.getScore + " " + r.getStatistics.getStandardDeviation
+
+  def main(args: Array[String]) {
+
+    val opts = new CommandLineOptions(args: _*)
+    var builder = new OptionsBuilder().parent(opts).jvmArgsPrepend("-Xmx6000m")
+    if (!opts.verbosity.hasValue) builder = builder.verbosity(VerboseMode.SILENT)
+
+    val results = new Runner(builder.build).run()
+
+    val f = new PrintWriter(outputFile, "UTF-8")
+    try {
+      results.forEach(result => outputDataset(f, result.label, result))
+    } finally {
+      f.close()
+    }
+  }
+
+  private[this] def outputDataset(f: PrintWriter, label: String, r: RunResult) {
+    f.println(s"# [$label]")
+    f.println(r.size + "\t" + r.ratio + "\t" + r.intersection + "\t" + r.getPrimaryResult.getScore)
+    f.println("\n")
+  }
+}


### PR DESCRIPTION
When dealing with sets, I run into troubles. Suppose we want to do operations on two sets **S1**, **S2**. Why is **&** implemented as **S1 filter S2** but **&~** is evidently implemented as **r=S1; S2.foreach(x => r = r - x); r**
The **-** operation creates a new instance of **S1**-like large set each time element is removed. 

Take into consideration the following:
We want to do **S1** diff **S2**.

(1)  |S1| = n, |S2| = M, |S1 intersect S2| = k, **k <= n << M**, 

The current version has to go through M values and creates k-times new Instance of a collection.
Whereas the proposed version has to do just n times a query to S2 and it creates just one final instance of Set (filter uses SetBuilder).

(2)  |S1| = N, |S2| = m, **N >> m >= k**

Although the current version goes through just m values, it creates k-times a massive collection.
The proposed version goes through a lot of (N) values, however it does create an output of just k items.

Complexity summary:
(1) - current - memory O(n \* k), **time O(M)**
(1) - proposed - memory k, time n*C, where C is time of evaluating whether element is in a large set

(2) - current - **memory O(N \* k)**, time O(m)
(2) - proposed - memory k, time M \* c, where c is time of evaluating whether element is in a small set

...Besides who would have thought that & and &~ behave so differently?
If **&** can do it by filtering so can **&~**
