### PR TITLE
SI-9944 Scan after interp expr keeps CR

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -246,6 +246,14 @@ trait Scanners extends ScannersCommon {
     private def inMultiLineInterpolation =
       inStringInterpolation && sepRegions.tail.nonEmpty && sepRegions.tail.head == STRINGPART
 
+    /** Are we in a `${ }` block? such that RBRACE exits back into multiline string. */
+    private def inMultiLineInterpolatedExpression = {
+      sepRegions match {
+        case RBRACE :: STRINGLIT :: STRINGPART :: rest => true
+        case _ => false
+      }
+    }
+
     /** read next token and return last offset
      */
     def skipToken(): Offset = {
@@ -312,7 +320,7 @@ trait Scanners extends ScannersCommon {
           lastOffset -= 1
         }
         if (inStringInterpolation) fetchStringPart() else fetchToken()
-        if(token == ERROR) {
+        if (token == ERROR) {
           if (inMultiLineInterpolation)
             sepRegions = sepRegions.tail.tail
           else if (inStringInterpolation)
@@ -547,7 +555,8 @@ trait Scanners extends ScannersCommon {
         case ')' =>
           nextChar(); token = RPAREN
         case '}' =>
-          nextChar(); token = RBRACE
+          if (inMultiLineInterpolatedExpression) nextRawChar() else nextChar()
+          token = RBRACE
         case '[' =>
           nextChar(); token = LBRACKET
         case ']' =>

--- a/test/files/run/t9944.check
+++ b/test/files/run/t9944.check
@@ -1,0 +1,12 @@
+[[syntax trees at end of                    parser]] // newSource1.scala
+package <empty> {
+  class C extends scala.AnyRef {
+    def <init>() = {
+      super.<init>();
+      ()
+    };
+    def g = 42;
+    def f = StringContext("123\r\n", "\r\n123\r\n").s(g)
+  }
+}
+

--- a/test/files/run/t9944.scala
+++ b/test/files/run/t9944.scala
@@ -1,0 +1,7 @@
+
+import scala.tools.partest.ParserTest
+
+object Test extends ParserTest {
+
+  def code = s"""class C { def g = 42 ; def f = s""\"123\r\n$${ g }\r\n123\r\n""\"}"""
+}


### PR DESCRIPTION
In an interpolated expression `s"""${ e }"""`, the scanner
advances input past the RBRACE. If a multiline string as
shown, get the next raw char, because CR is significant.
