### PR TITLE
SI-9959: Change `...' to ‘...’ (Unicode quotes) in ENBF (per intent per README.md).

### DIFF
--- a/spec/05-classes-and-objects.md
+++ b/spec/05-classes-and-objects.md
@@ -7,9 +7,9 @@ chapter: 5
 # Classes and Objects
 
 ```ebnf
-TmplDef          ::= [`case'] `class' ClassDef
-                  |  [`case'] `object' ObjectDef
-                  |  `trait' TraitDef
+TmplDef          ::= [‘case’] ‘class’ ClassDef
+                  |  [‘case’] ‘object’ ObjectDef
+                  |  ‘trait’ TraitDef
 ```
 
 [Classes](#class-definitions) and [objects](#object-definitions)
@@ -20,11 +20,11 @@ are both defined in terms of _templates_.
 ```ebnf
 ClassTemplate   ::=  [EarlyDefs] ClassParents [TemplateBody]
 TraitTemplate   ::=  [EarlyDefs] TraitParents [TemplateBody]
-ClassParents    ::=  Constr {`with' AnnotType}
-TraitParents    ::=  AnnotType {`with' AnnotType}
-TemplateBody    ::=  [nl] `{' [SelfType] TemplateStat {semi TemplateStat} `}'
-SelfType        ::=  id [`:' Type] `=>'
-                 |   this `:' Type `=>'
+ClassParents    ::=  Constr {‘with’ AnnotType}
+TraitParents    ::=  AnnotType {‘with’ AnnotType}
+TemplateBody    ::=  [nl] ‘{’ [SelfType] TemplateStat {semi TemplateStat} ‘}’
+SelfType        ::=  id [‘:’ Type] ‘=>’
+                 |   this ‘:’ Type ‘=>’
 ```
 
 A _template_ defines the type signature, behavior and initial state of a
@@ -145,7 +145,7 @@ def delayedInit(body: => Unit)
 ### Constructor Invocations
 
 ```ebnf
-Constr  ::=  AnnotType {`(' [Exprs] `)'}
+Constr  ::=  AnnotType {‘(’ [Exprs] ‘)’}
 ```
 
 Constructor invocations define the type, members, and initial state of
@@ -410,7 +410,7 @@ necessary to make subtyping decidable[^kennedy]).
 ### Early Definitions
 
 ```ebnf
-EarlyDefs         ::= `{' [EarlyDef {semi EarlyDef}] `}' `with'
+EarlyDefs         ::= ‘{’ [EarlyDef {semi EarlyDef}] ‘}’ ‘with’
 EarlyDef          ::=  {Annotation} {Modifier} PatVarDef
 ```
 
@@ -478,14 +478,14 @@ body, it would be initialized after the constructor of
 ```ebnf
 Modifier          ::=  LocalModifier
                     |  AccessModifier
-                    |  `override'
-LocalModifier     ::=  `abstract'
-                    |  `final'
-                    |  `sealed'
-                    |  `implicit'
-                    |  `lazy'
-AccessModifier    ::=  (`private' | `protected') [AccessQualifier]
-AccessQualifier   ::=  `[' (id | `this') `]'
+                    |  ‘override’
+LocalModifier     ::=  ‘abstract’
+                    |  ‘final’
+                    |  ‘sealed’
+                    |  ‘implicit’
+                    |  ‘lazy’
+AccessModifier    ::=  (‘private’ | ‘protected’) [AccessQualifier]
+AccessQualifier   ::=  ‘[’ (id | ‘this’) ‘]’
 ```
 
 Member definitions may be preceded by modifiers which affect the
@@ -668,16 +668,16 @@ constructor `private` ([example](#example-private-constructor)).
 ## Class Definitions
 
 ```ebnf
-TmplDef           ::=  `class' ClassDef
+TmplDef           ::=  ‘class’ ClassDef
 ClassDef          ::=  id [TypeParamClause] {Annotation}
                        [AccessModifier] ClassParamClauses ClassTemplateOpt
 ClassParamClauses ::=  {ClassParamClause}
-                       [[nl] `(' implicit ClassParams `)']
-ClassParamClause  ::=  [nl] `(' [ClassParams] ')'
-ClassParams       ::=  ClassParam {`,' ClassParam}
-ClassParam        ::=  {Annotation} {Modifier} [(`val' | `var')]
-                       id [`:' ParamType] [`=' Expr]
-ClassTemplateOpt  ::=  `extends' ClassTemplate | [[`extends'] TemplateBody]
+                       [[nl] ‘(’ implicit ClassParams ‘)’]
+ClassParamClause  ::=  [nl] ‘(’ [ClassParams] ‘)’
+ClassParams       ::=  ClassParam {‘,’ ClassParam}
+ClassParam        ::=  {Annotation} {Modifier} [(‘val’ | ‘var’)]
+                       id [‘:’ ParamType] [‘=’ Expr]
+ClassTemplateOpt  ::=  ‘extends’ ClassTemplate | [[‘extends’] TemplateBody]
 ```
 
 The most general form of class definition is
@@ -768,12 +768,12 @@ class Sensitive private () {
 ### Constructor Definitions
 
 ```ebnf
-FunDef         ::= `this' ParamClause ParamClauses
-                   (`=' ConstrExpr | [nl] ConstrBlock)
+FunDef         ::= ‘this’ ParamClause ParamClauses
+                   (‘=’ ConstrExpr | [nl] ConstrBlock)
 ConstrExpr     ::= SelfInvocation
                 |  ConstrBlock
-ConstrBlock    ::= `{' SelfInvocation {semi BlockStat} `}'
-SelfInvocation ::= `this' ArgumentExprs {ArgumentExprs}
+ConstrBlock    ::= ‘{’ SelfInvocation {semi BlockStat} ‘}’
+SelfInvocation ::= ‘this’ ArgumentExprs {ArgumentExprs}
 ```
 
 A class may have additional constructors besides the primary
@@ -836,7 +836,7 @@ third one constructs a list with a given head and tail.
 ### Case Classes
 
 ```ebnf
-TmplDef  ::=  `case' `class' ClassDef
+TmplDef  ::=  ‘case’ ‘class’ ClassDef
 ```
 
 If a class definition is prefixed with `case`, the class is said
@@ -967,9 +967,9 @@ directly extend `Expr` must be in the same source file as
 ## Traits
 
 ```ebnf
-TmplDef          ::=  `trait' TraitDef
+TmplDef          ::=  ‘trait’ TraitDef
 TraitDef         ::=  id [TypeParamClause] TraitTemplateOpt
-TraitTemplateOpt ::=  `extends' TraitTemplate | [[`extends'] TemplateBody]
+TraitTemplateOpt ::=  ‘extends’ TraitTemplate | [[‘extends’] TemplateBody]
 ```
 
 A _trait_ is a class that is meant to be added to some other class

--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -7,44 +7,44 @@ chapter: 6
 # Expressions
 
 ```ebnf
-Expr         ::=  (Bindings | id | `_') `=>' Expr
+Expr         ::=  (Bindings | id | ‘_’) ‘=>’ Expr
                |  Expr1
-Expr1        ::=  `if' `(' Expr `)' {nl} Expr [[semi] `else' Expr]
-               |  `while' `(' Expr `)' {nl} Expr
-               |  `try' (`{' Block `}' | Expr) [`catch' `{' CaseClauses `}'] [`finally' Expr]
-               |  `do' Expr [semi] `while' `(' Expr ')'
-               |  `for' (`(' Enumerators `)' | `{' Enumerators `}') {nl} [`yield'] Expr
-               |  `throw' Expr
-               |  `return' [Expr]
-               |  [SimpleExpr `.'] id `=' Expr
-               |  SimpleExpr1 ArgumentExprs `=' Expr
+Expr1        ::=  ‘if’ ‘(’ Expr ‘)’ {nl} Expr [[semi] ‘else’ Expr]
+               |  ‘while’ ‘(’ Expr ‘)’ {nl} Expr
+               |  ‘try’ (‘{’ Block ‘}’ | Expr) [‘catch’ ‘{’ CaseClauses ‘}’] [‘finally’ Expr]
+               |  ‘do’ Expr [semi] ‘while’ ‘(’ Expr ‘)’
+               |  ‘for’ (‘(’ Enumerators ‘)’ | ‘{’ Enumerators ‘}’) {nl} [‘yield’] Expr
+               |  ‘throw’ Expr
+               |  ‘return’ [Expr]
+               |  [SimpleExpr ‘.’] id ‘=’ Expr
+               |  SimpleExpr1 ArgumentExprs ‘=’ Expr
                |  PostfixExpr
                |  PostfixExpr Ascription
-               |  PostfixExpr `match' `{' CaseClauses `}'
+               |  PostfixExpr ‘match’ ‘{’ CaseClauses ‘}’
 PostfixExpr  ::=  InfixExpr [id [nl]]
 InfixExpr    ::=  PrefixExpr
                |  InfixExpr id [nl] InfixExpr
-PrefixExpr   ::=  [`-' | `+' | `~' | `!'] SimpleExpr
-SimpleExpr   ::=  `new' (ClassTemplate | TemplateBody)
+PrefixExpr   ::=  [‘-’ | ‘+’ | ‘~’ | ‘!’] SimpleExpr
+SimpleExpr   ::=  ‘new’ (ClassTemplate | TemplateBody)
                |  BlockExpr
-               |  SimpleExpr1 [`_']
+               |  SimpleExpr1 [‘_’]
 SimpleExpr1  ::=  Literal
                |  Path
-               |  `_'
-               |  `(' [Exprs] `)'
-               |  SimpleExpr `.' id s
+               |  ‘_’
+               |  ‘(’ [Exprs] ‘)’
+               |  SimpleExpr ‘.’ id s
                |  SimpleExpr TypeArgs
                |  SimpleExpr1 ArgumentExprs
                |  XmlExpr
-Exprs        ::=  Expr {`,' Expr}
+Exprs        ::=  Expr {‘,’ Expr}
 BlockExpr    ::=  ‘{’ CaseClauses ‘}’
                |  ‘{’ Block ‘}’
 Block        ::=  BlockStat {semi BlockStat} [ResultExpr]
 ResultExpr   ::=  Expr1
-               |  (Bindings | ([`implicit'] id | `_') `:' CompoundType) `=>' Block
-Ascription   ::=  `:' InfixType
-               |  `:' Annotation {Annotation}
-               |  `:' `_' `*'
+               |  (Bindings | ([‘implicit’] id | ‘_’) ‘:’ CompoundType) ‘=>’ Block
+Ascription   ::=  ‘:’ InfixType
+               |  ‘:’ Annotation {Annotation}
+               |  ‘:’ ‘_’ ‘*’
 ```
 
 Expressions are composed of operators and operands. Expression forms are
@@ -100,7 +100,7 @@ A reference to any other member of the "null" object causes a
 
 ```ebnf
 SimpleExpr  ::=  Path
-              |  SimpleExpr `.' id
+              |  SimpleExpr ‘.’ id
 ```
 
 A designator refers to a named term. It can be a _simple name_ or
@@ -151,8 +151,8 @@ by a definition overriding $m$.
 ## This and Super
 
 ```ebnf
-SimpleExpr  ::=  [id `.'] `this'
-              |  [id '.'] `super' [ClassQualifier] `.' id
+SimpleExpr  ::=  [id ‘.’] ‘this’
+              |  [id ‘.’] ‘super’ [ClassQualifier] ‘.’ id
 ```
 
 The expression `this` can appear in the statement part of a
@@ -234,10 +234,10 @@ depending on whether `B` is mixed in with class `Root` or `A`.
 
 ```ebnf
 SimpleExpr    ::=  SimpleExpr1 ArgumentExprs
-ArgumentExprs ::=  `(' [Exprs] `)'
-                |  `(' [Exprs `,'] PostfixExpr `:' `_' `*' ')'
+ArgumentExprs ::=  ‘(’ [Exprs] ‘)’
+                |  ‘(’ [Exprs ‘,’] PostfixExpr ‘:’ ‘_’ ‘*’ ‘)’
                 |  [nl] BlockExpr
-Exprs         ::=  Expr {`,' Expr}
+Exprs         ::=  Expr {‘,’ Expr}
 ```
 
 An application `$f(e_1 , \ldots , e_m)$` applies the function `$f$` to the argument expressions `$e_1, \ldots , e_m$`. For this expression to be well-typed, the function must be *applicable* to its arguments, which is defined next by case analysis on $f$'s type.
@@ -406,7 +406,7 @@ On the Java platform version 7 and later, the methods `invoke` and `invokeExact`
 ## Method Values
 
 ```ebnf
-SimpleExpr    ::=  SimpleExpr1 `_'
+SimpleExpr    ::=  SimpleExpr1 ‘_’
 ```
 
 The expression `$e$ _` is well-formed if $e$ is of method
@@ -461,7 +461,7 @@ and the expected result type.
 ## Tuples
 
 ```ebnf
-SimpleExpr   ::=  `(' [Exprs] `)'
+SimpleExpr   ::=  ‘(’ [Exprs] ‘)’
 ```
 
 A _tuple expression_ `($e_1 , \ldots , e_n$)` is an alias
@@ -473,7 +473,7 @@ The empty tuple
 ## Instance Creation Expressions
 
 ```ebnf
-SimpleExpr     ::=  `new' (ClassTemplate | TemplateBody)
+SimpleExpr     ::=  ‘new’ (ClassTemplate | TemplateBody)
 ```
 
 A _simple instance creation expression_ is of the form
@@ -605,7 +605,7 @@ the existentially quantified type
 PostfixExpr     ::=  InfixExpr [id [nl]]
 InfixExpr       ::=  PrefixExpr
                   |  InfixExpr id [nl] InfixExpr
-PrefixExpr      ::=  [`-' | `+' | `!' | `~'] SimpleExpr
+PrefixExpr      ::=  [‘-’ | ‘+’ | ‘!’ | ‘~’] SimpleExpr
 ```
 
 Expressions can be constructed from operands and operators.
@@ -735,7 +735,7 @@ The re-interpretation occurs if the following two conditions are fulfilled.
 ## Typed Expressions
 
 ```ebnf
-Expr1              ::=  PostfixExpr `:' CompoundType
+Expr1              ::=  PostfixExpr ‘:’ CompoundType
 ```
 
 The _typed expression_ $e: T$ has type $T$. The type of
@@ -754,7 +754,7 @@ Here are examples of well-typed and ill-typed expressions.
 ## Annotated Expressions
 
 ```ebnf
-Expr1              ::=  PostfixExpr `:' Annotation {Annotation}
+Expr1              ::=  PostfixExpr ‘:’ Annotation {Annotation}
 ```
 
 An _annotated expression_ `$e$: @$a_1$ $\ldots$ @$a_n$`
@@ -764,8 +764,8 @@ expression $e$.
 ## Assignments
 
 ```ebnf
-Expr1        ::=  [SimpleExpr `.'] id `=' Expr
-               |  SimpleExpr1 ArgumentExprs `=' Expr
+Expr1        ::=  [SimpleExpr ‘.’] id ‘=’ Expr
+               |  SimpleExpr1 ArgumentExprs ‘=’ Expr
 ```
 
 The interpretation of an assignment to a simple variable `$x$ = $e$`
@@ -849,7 +849,7 @@ def matmul(xss: Array[Array[Double]], yss: Array[Array[Double]]) = {
 ## Conditional Expressions
 
 ```ebnf
-Expr1          ::=  `if' `(' Expr `)' {nl} Expr [[semi] `else' Expr]
+Expr1          ::=  ‘if’ ‘(’ Expr ‘)’ {nl} Expr [[semi] ‘else’ Expr]
 ```
 
 The _conditional expression_ `if ($e_1$) $e_2$ else $e_3$` chooses
@@ -875,7 +875,7 @@ evaluated as if it was `if ($e_1$) $e_2$ else ()`.
 ## While Loop Expressions
 
 ```ebnf
-Expr1          ::=  `while' `(' Expr ')' {nl} Expr
+Expr1          ::=  ‘while’ ‘(’ Expr ‘)’ {nl} Expr
 ```
 
 The _while loop expression_ `while ($e_1$) $e_2$` is typed and
@@ -890,7 +890,7 @@ def whileLoop(cond: => Boolean)(body: => Unit): Unit  =
 ## Do Loop Expressions
 
 ```ebnf
-Expr1          ::=  `do' Expr [semi] `while' `(' Expr ')'
+Expr1          ::=  ‘do’ Expr [semi] ‘while’ ‘(’ Expr ‘)’
 ```
 
 The _do loop expression_ `do $e_1$ while ($e_2$)` is typed and
@@ -900,11 +900,11 @@ A semicolon preceding the `while` symbol of a do loop expression is ignored.
 ## For Comprehensions and For Loops
 
 ```ebnf
-Expr1          ::=  `for' (`(' Enumerators `)' | `{' Enumerators `}')
-                       {nl} [`yield'] Expr
+Expr1          ::=  ‘for’ (‘(’ Enumerators ‘)’ | ‘{’ Enumerators ‘}’)
+                       {nl} [‘yield’] Expr
 Enumerators    ::=  Generator {semi Generator}
-Generator      ::=  Pattern1 `<-' Expr {[semi] Guard | semi Pattern1 `=' Expr}
-Guard          ::=  `if' PostfixExpr
+Generator      ::=  Pattern1 ‘<-’ Expr {[semi] Guard | semi Pattern1 ‘=’ Expr}
+Guard          ::=  ‘if’ PostfixExpr
 ```
 
 A _for loop_ `for ($\mathit{enums}\,$) $e$` executes expression $e$
@@ -1048,7 +1048,7 @@ The code above makes use of the fact that `map`, `flatMap`,
 ## Return Expressions
 
 ```ebnf
-Expr1      ::=  `return' [Expr]
+Expr1      ::=  ‘return’ [Expr]
 ```
 
 A _return expression_ `return $e$` must occur inside the body of some
@@ -1085,7 +1085,7 @@ and will propagate up the call stack.
 ## Throw Expressions
 
 ```ebnf
-Expr1      ::=  `throw' Expr
+Expr1      ::=  ‘throw’ Expr
 ```
 
 A _throw expression_ `throw $e$` evaluates the expression
@@ -1102,8 +1102,8 @@ is `scala.Nothing`.
 ## Try Expressions
 
 ```ebnf
-Expr1 ::=  `try' (`{' Block `}' | Expr) [`catch' `{' CaseClauses `}']
-           [`finally' Expr]
+Expr1 ::=  ‘try’ (‘{’ Block ‘}’ | Expr) [‘catch’ ‘{’ CaseClauses ‘}’]
+           [‘finally’ Expr]
 ```
 
 A _try expression_ is of the form `try { $b$ } catch $h$`
@@ -1154,10 +1154,10 @@ for  `try { try { $b$ } catch $e_1$ } finally $e_2$`.
 ## Anonymous Functions
 
 ```ebnf
-Expr            ::=  (Bindings | [`implicit'] id | `_') `=>' Expr
-ResultExpr      ::=  (Bindings | ([`implicit'] id | `_') `:' CompoundType) `=>' Block
-Bindings        ::=  `(' Binding {`,' Binding} `)'
-Binding         ::=  (id | `_') [`:' Type]
+Expr            ::=  (Bindings | [‘implicit’] id | ‘_’) ‘=>’ Expr
+ResultExpr      ::=  (Bindings | ([‘implicit’] id | ‘_’) ‘:’ CompoundType) ‘=>’ Block
+Bindings        ::=  ‘(’ Binding {‘,’ Binding} ‘)’
+Binding         ::=  (id | ‘_’) [‘:’ Type]
 ```
 
 The anonymous function of arity $n$, `($x_1$: $T_1 , \ldots , x_n$: $T_n$) => e` maps parameters $x_i$ of types $T_i$ to a result given by expression $e$. The scope of each formal parameter $x_i$ is $e$. Formal parameters must have pairwise distinct names.
@@ -1215,7 +1215,7 @@ _ => 5                             // The function that ignores its argument
 ### Placeholder Syntax for Anonymous Functions
 
 ```ebnf
-SimpleExpr1  ::=  `_'
+SimpleExpr1  ::=  ‘_’
 ```
 
 An expression (of syntactic category `Expr`)

--- a/spec/08-pattern-matching.md
+++ b/spec/08-pattern-matching.md
@@ -56,7 +56,7 @@ patterns.
 ### Variable Patterns
 
 ```ebnf
-  SimplePattern   ::=  `_'
+  SimplePattern   ::=  ‘_’
                     |  varid
 ```
 
@@ -69,8 +69,8 @@ which is treated as if it was a fresh variable on each occurrence.
 ### Typed Patterns
 
 ```ebnf
-  Pattern1        ::=  varid `:' TypePat
-                    |  `_' `:' TypePat
+  Pattern1        ::=  varid ‘:’ TypePat
+                    |  ‘_’ ‘:’ TypePat
 ```
 
 A _typed pattern_ $x: T$ consists of a pattern variable $x$ and a
@@ -83,7 +83,7 @@ that value.
 ### Pattern Binders
 
 ```ebnf
-  Pattern2        ::=  varid `@' Pattern3
+  Pattern2        ::=  varid ‘@’ Pattern3
 ```
 
 A _pattern binder_ `$x$@$p$` consists of a pattern variable $x$ and a
@@ -144,7 +144,7 @@ argument of `f` are equal.
 ### Constructor Patterns
 
 ```ebnf
-SimplePattern   ::=  StableId `(' [Patterns] `)
+SimplePattern   ::=  StableId ‘(’ [Patterns] ‘)’
 ```
 
 A _constructor pattern_ is of the form $c(p_1 , \ldots , p_n)$ where $n
@@ -170,7 +170,7 @@ repeated parameter. This is further discussed [here](#pattern-sequences).
 ### Tuple Patterns
 
 ```ebnf
-  SimplePattern   ::=  `(' [Patterns] `)'
+  SimplePattern   ::=  ‘(’ [Patterns] ‘)’
 ```
 
 A _tuple pattern_ `($p_1 , \ldots , p_n$)` is an alias
@@ -181,7 +181,7 @@ where $n \geq 2$. The empty tuple
 ### Extractor Patterns
 
 ```ebnf
-  SimplePattern   ::=  StableId `(' [Patterns] `)'
+  SimplePattern   ::=  StableId ‘(’ [Patterns] ‘)’
 ```
 
 An _extractor pattern_ $x(p_1 , \ldots , p_n)$ where $n \geq 0$ is of
@@ -241,7 +241,7 @@ val y = x match {
 ### Pattern Sequences
 
 ```ebnf
-SimplePattern ::= StableId `(' [Patterns `,'] [varid `@'] `_' `*' `)'
+SimplePattern ::= StableId ‘(’ [Patterns ‘,’] [varid ‘@’] ‘_’ ‘*’ ‘)’
 ```
 
 A _pattern sequence_ $p_1 , \ldots , p_n$ appears in two contexts.
@@ -277,7 +277,7 @@ shorthand for the constructor or extractor pattern $\mathit{op}(p, q_1
 ### Pattern Alternatives
 
 ```ebnf
-  Pattern   ::=  Pattern1 { `|' Pattern1 }
+  Pattern   ::=  Pattern1 { ‘|’ Pattern1 }
 ```
 
 A _pattern alternative_ `$p_1$ | $\ldots$ | $p_n$`
@@ -521,9 +521,9 @@ function's declared result type, `Number`.
 ## Pattern Matching Expressions
 
 ```ebnf
-  Expr            ::=  PostfixExpr `match' `{' CaseClauses `}'
+  Expr            ::=  PostfixExpr ‘match’ ‘{’ CaseClauses ‘}’
   CaseClauses     ::=  CaseClause {CaseClause}
-  CaseClause      ::=  `case' Pattern [Guard] `=>' Block
+  CaseClause      ::=  ‘case’ Pattern [Guard] ‘=>’ Block
 ```
 
 A _pattern matching expression_
@@ -638,7 +638,7 @@ conforms to its expected type, `T`.
 ## Pattern Matching Anonymous Functions
 
 ```ebnf
-  BlockExpr ::= `{' CaseClauses `}'
+  BlockExpr ::= ‘{’ CaseClauses ‘}’
 ```
 
 An anonymous function can be defined by a sequence of cases

--- a/spec/10-xml-expressions-and-patterns.md
+++ b/spec/10-xml-expressions-and-patterns.md
@@ -76,8 +76,8 @@ AttValue      ::=    ‘"’ {CharQ | CharRef} ‘"’
 
 ScalaExpr     ::=    Block
 
-CharData      ::=   { CharNoRef } $\textit{ without}$ {CharNoRef}`{'CharB {CharNoRef}
-                                  $\textit{ and without}$ {CharNoRef}`]]>'{CharNoRef}
+CharData      ::=   { CharNoRef } $\textit{ without}$ {CharNoRef}‘{’CharB {CharNoRef}
+                                  $\textit{ and without}$ {CharNoRef}‘]]>’{CharNoRef}
 ```
 
 <!-- {% raw  %} stupid liquid borks on the double brace below; brace yourself, liquid! -->

--- a/spec/13-syntax-summary.md
+++ b/spec/13-syntax-summary.md
@@ -11,7 +11,7 @@ The following descriptions of Scala tokens uses literal characters `‘c’` whe
 _Unicode escapes_ are used to represent the Unicode character with the given hexadecimal code:
 
 ```ebnf
-UnicodeEscape ::= ‘\‘ ‘u‘ {‘u‘} hexDigit hexDigit hexDigit hexDigit
+UnicodeEscape ::= ‘\’ ‘u’ {‘u’} hexDigit hexDigit hexDigit hexDigit
 hexDigit      ::= ‘0’ | … | ‘9’ | ‘A’ | … | ‘F’ | ‘a’ | … | ‘f’
 ```
 
@@ -30,7 +30,7 @@ delim            ::=  ‘`’ | ‘'’ | ‘"’ | ‘.’ | ‘;’ | ‘,’
 opchar           ::= // printableChar not matched by (whiteSpace | upper | lower |
                      // letter | digit | paren | delim | opchar | Unicode_Sm | Unicode_So)
 printableChar    ::= // all characters in [\u0020, \u007F] inclusive
-charEscapeSeq    ::= ‘\‘ (‘b‘ | ‘t‘ | ‘n‘ | ‘f‘ | ‘r‘ | ‘"‘ | ‘'‘ | ‘\‘)
+charEscapeSeq    ::= ‘\’ (‘b’ | ‘t’ | ‘n’ | ‘f’ | ‘r’ | ‘"’ | ‘'’ | ‘\’)
 
 op               ::=  opchar {opchar}
 varid            ::=  lower idrest

--- a/spec/13-syntax-summary.md
+++ b/spec/13-syntax-summary.md
@@ -129,18 +129,18 @@ grammar:
 
   Expr              ::=  (Bindings | [‘implicit’] id | ‘_’) ‘=>’ Expr
                       |  Expr1
-  Expr1             ::=  `if' `(' Expr `)' {nl} Expr [[semi] `else' Expr]
-                      |  `while' `(' Expr `)' {nl} Expr
-                      |  `try' (`{' Block `}' | Expr) [`catch' `{' CaseClauses `}'] [`finally' Expr]
-                      |  `do' Expr [semi] `while' `(' Expr `)'
-                      |  `for' (`(' Enumerators `)' | `{' Enumerators `}') {nl} [`yield'] Expr
-                      |  `throw' Expr
-                      |  `return' [Expr]
-                      |  [SimpleExpr `.'] id `=' Expr
-                      |  SimpleExpr1 ArgumentExprs `=' Expr
+  Expr1             ::=  ‘if’ ‘(’ Expr ‘)’ {nl} Expr [[semi] ‘else’ Expr]
+                      |  ‘while’ ‘(’ Expr ‘)’ {nl} Expr
+                      |  ‘try’ (‘{’ Block ‘}’ | Expr) [‘catch’ ‘{’ CaseClauses ‘}’] [‘finally’ Expr]
+                      |  ‘do’ Expr [semi] ‘while’ ‘(’ Expr ‘)’
+                      |  ‘for’ (‘(’ Enumerators ‘)’ | ‘{’ Enumerators ‘}’) {nl} [‘yield’] Expr
+                      |  ‘throw’ Expr
+                      |  ‘return’ [Expr]
+                      |  [SimpleExpr ‘.’] id ‘=’ Expr
+                      |  SimpleExpr1 ArgumentExprs ‘=’ Expr
                       |  PostfixExpr
                       |  PostfixExpr Ascription
-                      |  PostfixExpr `match' `{' CaseClauses `}'
+                      |  PostfixExpr ‘match’ ‘{’ CaseClauses ‘}’
   PostfixExpr       ::=  InfixExpr [id [nl]]
   InfixExpr         ::=  PrefixExpr
                       |  InfixExpr id [nl] InfixExpr
@@ -213,7 +213,7 @@ grammar:
                          [[nl] ‘(’ ‘implicit’ ClassParams ‘)’]
   ClassParamClause  ::=  [nl] ‘(’ [ClassParams] ‘)’
   ClassParams       ::=  ClassParam {‘,’ ClassParam}
-  ClassParam        ::=  {Annotation} {Modifier} [(`val' | `var')]
+  ClassParam        ::=  {Annotation} {Modifier} [(‘val’ | ‘var’)]
                          id ‘:’ ParamType [‘=’ Expr]
   Bindings          ::=  ‘(’ Binding {‘,’ Binding} ‘)’
   Binding           ::=  (id | ‘_’) [‘:’ Type]


### PR DESCRIPTION
Changed occurrences of `...' (with ASCII grave accent and apostrophe) to ‘...’ (with Unicode single quotes) in ENBF (per the intent described in spec/README.md).

Also added a missing closing quote in the SimplePattern production involving StableId.
