### PR TITLE
SI-9943 sealed class does not yield SAM type

### DIFF
--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -1361,6 +1361,7 @@ Note that a function literal that targets a SAM is not necessarily compiled to t
 
 It follows that:
   - if class `C` defines a constructor, it must be accessible and must define exactly one, empty, argument list;
+  - class `C` cannot be `final` or `sealed` (for simplicity we ignore the possibility of SAM conversion in the same compilation unit as the sealed class);
   - `m` cannot be polymorphic;
   - it must be possible to derive a fully-defined type `U` from `S` by inferring any unknown type parameters of `C`.
 

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -840,14 +840,14 @@ trait Definitions extends api.StandardDefinitions {
      *
      * The method must be monomorphic and have exactly one parameter list.
      * The class defining the method is a supertype of `tp` that
-     * has a public no-arg primary constructor.
+     * has a public no-arg primary constructor and it can be subclassed (not final or sealed).
      */
     def samOf(tp: Type): Symbol = if (!doSam) NoSymbol else if (!isNonRefinementClassType(unwrapToClass(tp))) NoSymbol else {
       // look at erased type because we (only) care about what ends up in bytecode
       // (e.g., an alias type is fine as long as is compiles to a single-abstract-method)
       val tpSym: Symbol = erasure.javaErasure(tp).typeSymbol
 
-      if (tpSym.exists && tpSym.isClass
+      if (tpSym.exists && tpSym.isClass && !(tpSym hasFlag (FINAL | SEALED))
           // if tp has a constructor (its class is not a trait), it must be public and must not take any arguments
           // (implementation restriction: implicit argument lists are excluded to simplify type inference in adaptToSAM)
           && { val ctor = tpSym.primaryConstructor

--- a/test/files/pos/t9943.scala
+++ b/test/files/pos/t9943.scala
@@ -1,0 +1,9 @@
+class Foo[T] {
+  def toMap[K, V](implicit ev: Foo[T] <:< Foo[(K, V)]): Foo[Map[K, V]] = null
+  def toMap[K](keySelector:    T      =>  K): Foo[Map[K, T]] = null
+}
+
+object Foo {
+  (??? : Foo[Int])           toMap (_ % 2)
+  (??? : Foo[(Int, String)]).toMap
+}


### PR DESCRIPTION
Cannot subclass such a class. (Well, we could subclass a sealed
class in the same compilation unit. We ignore this for simplicity.)

This is a bit of a sneaky fix for this bug, but our hand
is pretty much forced by other constraints, in this intersection
of overload resolution involving built-in function types and SAMs,
and type inference for higher-order function literals (#5307).

Luckily, in this particular issue, the overloading clash seems
accidental. The `sealed` `<:<` class is not a SAM type as it
cannot be subclassed outside of `Predef`. For simplicity,
we don't consider where the SAM conversion occurs and exclude
all sealed classes from yielding SAM types.

Thanks to Miles for pointing out that `final` was missing in my
first iteration of this fix.

JIRA: https://issues.scala-lang.org/browse/SI-9943