### PR TITLE
SI-9953 Any Any aborts warn on equals

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1103,7 +1103,7 @@ abstract class RefChecks extends Transform {
         // better to have lubbed and lost
         def warnIfLubless(): Unit = {
           val common = global.lub(List(actual.tpe, receiver.tpe))
-          if (ObjectTpe <:< common && !(ObjectTpe <:< actual.tpe && ObjectTpe <:< receiver.tpe))
+          if (ObjectTpe <:< common && !(ObjectTpe <:< actual.tpe) && !(ObjectTpe <:< receiver.tpe))
             unrelatedTypes()
         }
         // warn if actual has a case parent that is not same as receiver's;

--- a/test/files/neg/t9953.check
+++ b/test/files/neg/t9953.check
@@ -1,0 +1,6 @@
+t9953.scala:10: warning: Object and X are unrelated: they will never compare equal
+  def b = y == x   // warn
+            ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/t9953.flags
+++ b/test/files/neg/t9953.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/t9953.scala
+++ b/test/files/neg/t9953.scala
@@ -1,0 +1,13 @@
+
+class X(val v: Int) extends AnyVal
+trait T extends Any
+object Y extends T
+
+class C {
+  val x = new X(42)
+  val y = new Object
+  val a: T = null
+  def b = y == x   // warn
+  def c = y == a   // no warn
+  def d = Y == a   // no warn
+}


### PR DESCRIPTION
Don't warn about equals if any `Any` is involved. cf SI-8965

The condition for warning is that both types lub to a supertype
of Object.

JIRA: https://issues.scala-lang.org/browse/SI-9953