### PR TITLE
Fix the interface flag when re-writing a closure call to the body method

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/ClosureOptimizer.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/ClosureOptimizer.scala
@@ -325,8 +325,7 @@ class ClosureOptimizer[BT <: BTypes](val btypes: BT) {
         insns.insertBefore(invocation, new InsnNode(DUP))
         INVOKESPECIAL
     }
-    val isInterface = bodyOpcode == INVOKEINTERFACE
-    val bodyInvocation = new MethodInsnNode(bodyOpcode, lambdaBodyHandle.getOwner, lambdaBodyHandle.getName, lambdaBodyHandle.getDesc, isInterface)
+    val bodyInvocation = new MethodInsnNode(bodyOpcode, lambdaBodyHandle.getOwner, lambdaBodyHandle.getName, lambdaBodyHandle.getDesc, lambdaBodyHandle.isInterface)
     ownerMethod.instructions.insertBefore(invocation, bodyInvocation)
 
     val bodyReturnType = Type.getReturnType(lambdaBodyHandle.getDesc)

--- a/test/files/run/sd242.scala
+++ b/test/files/run/sd242.scala
@@ -1,0 +1,13 @@
+trait T {
+  def test: Unit = {
+    byName("".toString)
+    ()
+  }
+
+  @inline
+  final def byName(action: => Unit) = action
+}
+
+object Test extends App {
+  (new T {}).test
+}


### PR DESCRIPTION
When re-writing a closure invocation to the body method, the `itf` flag
of the invocation instruction was incorrect: it needs to be true if
the method is defined in an interface (including static methdos), not
if the method is invoked through `INVOKEINTERFACE`.

JDK 8 doesn't flag this inconsistency and executes the bytecode, but the
verifier in JDK 9 throws an `IncompatibleClassChangeError`.

Similar fixes went into e619b03.

Fixes https://github.com/scala/scala-dev/issues/242
