### PR TITLE
SI-9834 Improve error on failed op=

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4501,20 +4501,54 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         val appStart = if (Statistics.canEnable) Statistics.startTimer(failedApplyNanos) else null
         val opeqStart = if (Statistics.canEnable) Statistics.startTimer(failedOpEqNanos) else null
 
-        def onError(reportError: => Tree): Tree = fun match {
-          case Select(qual, name) if !mode.inPatternMode && nme.isOpAssignmentName(newTermName(name.decode)) =>
+        def isConversionCandidate(qual: Tree, name: Name): Boolean =
+          !mode.inPatternMode && nme.isOpAssignmentName(TermName(name.decode)) && !qual.exists(_.isErroneous)
+
+        def reportError(error: SilentTypeError): Tree = {
+          error.reportableErrors foreach context.issue
+          error.warnings foreach { case (p, m) => context.warning(p, m) }
+          args foreach (arg => typed(arg, mode, ErrorType))
+          setError(tree)
+        }
+        def advice1(errors: List[AbsTypeError], err: SilentTypeError): List[AbsTypeError] =
+          errors.map { e =>
+            if (e.errPos == tree.pos) {
+              val header = f"${e.errMsg}%n  Expression does not convert to assignment because:%n    "
+              NormalTypeError(tree, err.errors.flatMap(_.errMsg.lines.toList).mkString(header, f"%n    ", ""))
+            } else e
+          }
+        def advice2(errors: List[AbsTypeError]): List[AbsTypeError] =
+          errors.map { e =>
+            if (e.errPos == tree.pos) {
+              val msg = f"${e.errMsg}%n  Expression does not convert to assignment because receiver is not assignable."
+              NormalTypeError(tree, msg)
+            } else e
+          }
+        def onError(error: SilentTypeError): Tree = fun match {
+          case Select(qual, name) if isConversionCandidate(qual, name) =>
             val qual1 = typedQualifier(qual)
             if (treeInfo.isVariableOrGetter(qual1)) {
               if (Statistics.canEnable) Statistics.stopTimer(failedOpEqNanos, opeqStart)
-              convertToAssignment(fun, qual1, name, args)
+              val erred = qual1.isErroneous || args.exists(_.isErroneous)
+              if (erred) reportError(error) else {
+                val convo = convertToAssignment(fun, qual1, name, args)
+                silent(op = _.typed1(convo, mode, pt)) match {
+                  case SilentResultValue(t) => t
+                  case err: SilentTypeError => reportError(SilentTypeError(advice1(error.errors, err), error.warnings))
+                }
+              }
             }
             else {
               if (Statistics.canEnable) Statistics.stopTimer(failedApplyNanos, appStart)
-                reportError
+              val Apply(Select(qual2, _), args2) = tree
+              val erred = qual2.isErroneous || args2.exists(_.isErroneous)
+              reportError {
+                if (erred) error else SilentTypeError(advice2(error.errors), error.warnings)
+              }
             }
           case _ =>
             if (Statistics.canEnable) Statistics.stopTimer(failedApplyNanos, appStart)
-            reportError
+            reportError(error)
         }
         val silentResult = silent(
           op                    = _.typed(fun, mode.forFunMode, funpt),
@@ -4539,13 +4573,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               tryTypedApply(fun2, args)
             else
               doTypedApply(tree, fun2, args, mode, pt)
-          case err: SilentTypeError =>
-            onError({
-              err.reportableErrors foreach context.issue
-              err.warnings foreach { case (p, m) => context.warning(p, m) }
-              args foreach (arg => typed(arg, mode, ErrorType))
-              setError(tree)
-            })
+          case err: SilentTypeError => onError(err)
         }
       }
 
@@ -4588,7 +4616,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               Select(vble.duplicate, prefix) setPos fun.pos.focus, args) setPos tree.pos.makeTransparent
           ) setPos tree.pos
 
-        def mkUpdate(table: Tree, indices: List[Tree]) = {
+        def mkUpdate(table: Tree, indices: List[Tree]) =
           gen.evalOnceAll(table :: indices, context.owner, context.unit) {
             case tab :: is =>
               def mkCall(name: Name, extraArgs: Tree*) = (
@@ -4603,9 +4631,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               )
             case _ => EmptyTree
           }
-        }
 
-        val tree1 = qual match {
+        val assignment = qual match {
           case Ident(_) =>
             mkAssign(qual)
 
@@ -4621,7 +4648,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               case _  => UnexpectedTreeAssignmentConversionError(qual)
             }
         }
-        typed1(tree1, mode, pt)
+        assignment
       }
 
       def typedSuper(tree: Super) = {

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4510,11 +4510,12 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           args foreach (arg => typed(arg, mode, ErrorType))
           setError(tree)
         }
-        def advice1(errors: List[AbsTypeError], err: SilentTypeError): List[AbsTypeError] =
+        def advice1(convo: Tree, errors: List[AbsTypeError], err: SilentTypeError): List[AbsTypeError] =
           errors.map { e =>
             if (e.errPos == tree.pos) {
               val header = f"${e.errMsg}%n  Expression does not convert to assignment because:%n    "
-              NormalTypeError(tree, err.errors.flatMap(_.errMsg.lines.toList).mkString(header, f"%n    ", ""))
+              val expansion = f"%n    expansion: ${show(convo)}"
+              NormalTypeError(tree, err.errors.flatMap(_.errMsg.lines.toList).mkString(header, f"%n    ", expansion))
             } else e
           }
         def advice2(errors: List[AbsTypeError]): List[AbsTypeError] =
@@ -4534,7 +4535,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                 val convo = convertToAssignment(fun, qual1, name, args)
                 silent(op = _.typed1(convo, mode, pt)) match {
                   case SilentResultValue(t) => t
-                  case err: SilentTypeError => reportError(SilentTypeError(advice1(error.errors, err), error.warnings))
+                  case err: SilentTypeError => reportError(SilentTypeError(advice1(convo, error.errors, err), error.warnings))
                 }
               }
             }

--- a/test/files/neg/t0903.check
+++ b/test/files/neg/t0903.check
@@ -1,4 +1,5 @@
 t0903.scala:3: error: value += is not a member of Int
+  Expression does not convert to assignment because receiver is not assignable.
   x += 1
     ^
 t0903.scala:4: error: reassignment to val

--- a/test/files/neg/t1215.check
+++ b/test/files/neg/t1215.check
@@ -1,4 +1,5 @@
 t1215.scala:2: error: value += is not a member of Int
+  Expression does not convert to assignment because receiver is not assignable.
   val x = 1 += 1
             ^
 one error found

--- a/test/files/neg/t8763.check
+++ b/test/files/neg/t8763.check
@@ -1,0 +1,6 @@
+t8763.scala:9: error: type mismatch;
+ found   : Char
+ required: String
+    names_times(fields(0)) += fields(1).toLong
+                      ^
+one error found

--- a/test/files/neg/t8763.scala
+++ b/test/files/neg/t8763.scala
@@ -1,0 +1,11 @@
+
+import collection.mutable
+
+object Foo {
+  def bar() {
+    val names_times = mutable.Map[String, mutable.Set[Long]]()
+    val line = ""
+    val Array(fields) = line.split("\t")
+    names_times(fields(0)) += fields(1).toLong
+  }
+}

--- a/test/files/neg/t9834.check
+++ b/test/files/neg/t9834.check
@@ -1,0 +1,8 @@
+t9834.scala:5: error: value += is not a member of Int
+  Expression does not convert to assignment because:
+    type mismatch;
+     found   : String
+     required: Int
+  x() += "42"
+      ^
+one error found

--- a/test/files/neg/t9834.check
+++ b/test/files/neg/t9834.check
@@ -3,6 +3,7 @@ t9834.scala:5: error: value += is not a member of Int
     type mismatch;
      found   : String
      required: Int
+    expansion: x.update(x.apply().+("42"))
   x() += "42"
       ^
 one error found

--- a/test/files/neg/t9834.scala
+++ b/test/files/neg/t9834.scala
@@ -1,0 +1,6 @@
+
+object x { def apply() = 42 ; def update(i: Int) = () }
+
+trait Test {
+  x() += "42"
+}


### PR DESCRIPTION
If rewriting x += y fails to typecheck, emit error messages
for both the original tree and the assignment.

If rewrite is not attempted because x is a val, then say so.

Supersedes https://github.com/scala/scala/pull/5254 from last June. I must've forgotten it was against 2.11. What fashions did we wear and what music did we listen to back then? Who was president?
