### PR TITLE
Add clarification on preservation of order

### DIFF
--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -494,7 +494,7 @@ object Future {
   def apply[T](body: =>T)(implicit @deprecatedName('execctx) executor: ExecutionContext): Future[T] = impl.Future(body)
 
   /** Simple version of `Future.traverse`. Transforms a `TraversableOnce[Future[A]]` into a `Future[TraversableOnce[A]]`.
-   *  Useful for reducing many `Future`s into a single `Future`.
+   *  Useful for reducing many `Future`s into a single `Future`. Does not preserve order.
    */
   def sequence[A, M[X] <: TraversableOnce[X]](in: M[Future[A]])(implicit cbf: CanBuildFrom[M[Future[A]], A, M[A]], executor: ExecutionContext): Future[M[A]] = {
     in.foldLeft(successful(cbf(in))) {


### PR DESCRIPTION
Future.sequence does not preserve order of the original collection. The
current implementation creates a function that adds the results to the
final collection via a builder, but that function does not get called
until the Future is resolved.

So if the futures do not resolve in the
same order in which they are passed, the final collection will not have
the same order as the original.
