### PR TITLE
Detect clash of mixedin val and existing member.

### DIFF
--- a/test/files/neg/t1960.check
+++ b/test/files/neg/t1960.check
@@ -1,4 +1,7 @@
-t1960.scala:5: error: parameter 'p' requires field but conflicts with variable p in trait TBase
-class Aclass (p: Int) extends TBase { def g() { f(p) } }
-              ^
-one error found
+t1960.scala:2: error: parameter 'vr' requires field but conflicts with variable vr in trait T
+class C(vr: Int, vl: Int) extends T { def ref = vr + vl }
+        ^
+t1960.scala:2: error: parameter 'vl' requires field but conflicts with value vl in trait T
+class C(vr: Int, vl: Int) extends T { def ref = vr + vl }
+                 ^
+two errors found

--- a/test/files/neg/t1960.scala
+++ b/test/files/neg/t1960.scala
@@ -1,5 +1,2 @@
-object ClassFormatErrorExample extends App { new Aclass(1) }
-
-trait TBase { var p:Int = 0; def f(p1: Int) {} }
-
-class Aclass (p: Int) extends TBase { def g() { f(p) } }
+trait T { var vr: Int = 0 ; val vl: Int = 0 }
+class C(vr: Int, vl: Int) extends T { def ref = vr + vl }

--- a/test/files/pos/issue244.scala
+++ b/test/files/pos/issue244.scala
@@ -1,0 +1,2 @@
+trait T { lazy val overloaded: String = "a" }
+class C extends T { def overloaded(a: String): String = "b" }


### PR DESCRIPTION
Before, we looked only at the result type, which was silly.
This was originally motivated by a hack to get to the error
about conflicting paramaccessors. The error detection for that
can now be formulated more directly.

Fixes scala/scala-dev#244
