### PR TITLE
SI-6978 No linting of Java parens

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -472,7 +472,7 @@ abstract class RefChecks extends Transform {
             checkOverrideTypes()
             checkOverrideDeprecated()
             if (settings.warnNullaryOverride) {
-              if (other.paramss.isEmpty && !member.paramss.isEmpty) {
+              if (other.paramss.isEmpty && !member.paramss.isEmpty && !member.isJavaDefined) {
                 reporter.warning(member.pos, "non-nullary method overrides nullary method")
               }
             }

--- a/test/files/pos/t6978.flags
+++ b/test/files/pos/t6978.flags
@@ -1,0 +1,1 @@
+-Xlint -Xfatal-warnings

--- a/test/files/pos/t6978/J.java
+++ b/test/files/pos/t6978/J.java
@@ -1,0 +1,5 @@
+
+public class J {
+    public int f() { return 42; }
+}
+

--- a/test/files/pos/t6978/S.scala
+++ b/test/files/pos/t6978/S.scala
@@ -1,0 +1,7 @@
+
+trait X { def f: Int }
+
+object Test extends J with X with App {
+  println(f)
+}
+


### PR DESCRIPTION
Don't lint overriding of nullary by non-nullary
when non-nullary is Java-defined. They can't help it.

Review by @SethTisue 

JIRA: https://issues.scala-lang.org/browse/SI-6978