### PR TITLE
SI-9967 External linking in scaladoc [WIP]

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/ScaladocAnalyzer.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/ScaladocAnalyzer.scala
@@ -10,7 +10,7 @@ import scala.tools.nsc.ast.parser.{ SyntaxAnalyzer, BracePatch }
 import typechecker.Analyzer
 import scala.reflect.internal.Chars._
 import scala.reflect.internal.util.{ BatchSourceFile, Position }
-import scala.tools.nsc.doc.base.{ CommentFactoryBase, MemberLookupBase, LinkTo, LinkToExternal }
+import scala.tools.nsc.doc.base.{ CommentFactoryBase, MemberLookupBase, LinkTo }
 
 trait ScaladocAnalyzer extends Analyzer {
   val global : Global // generally, a ScaladocGlobal
@@ -122,7 +122,7 @@ abstract class ScaladocSyntaxAnalyzer[G <: Global](val global: G) extends Syntax
       override def internalLink(sym: Symbol, site: Symbol): Option[LinkTo] = None
       override def chooseLink(links: List[LinkTo]): LinkTo = links.headOption.orNull
       override def toString(link: LinkTo): String = "No link"
-      override def findExternalLink(sym: Symbol, name: String): Option[LinkToExternal] = None
+      override def findExternalLink(sym: Symbol, name: String): Option[LinkTo] = None
       override def warnNoLink: Boolean = false
     }
 

--- a/src/scaladoc/scala/tools/nsc/doc/Settings.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/Settings.scala
@@ -253,7 +253,7 @@ class Settings(error: String => Unit, val printMsg: String => Unit = println(_))
     }
   }
 
-  def appendIndex(url: String): String = url.stripSuffix("index.html").stripSuffix("/") + "/index.html"
+  def appendIndex(url: String): String = url.stripSuffix("index.html").stripSuffix("/") + "/"
 
   lazy val extUrlMapping: Map[String, String] = docExternalDoc.value flatMap { s =>
     val idx = s.indexOf("#")

--- a/src/scaladoc/scala/tools/nsc/doc/base/LinkTo.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/LinkTo.scala
@@ -9,5 +9,5 @@ package base
 sealed trait LinkTo
 final case class LinkToMember[Mbr, Tpl](mbr: Mbr, tpl: Tpl) extends LinkTo
 final case class LinkToTpl[Tpl](tpl: Tpl) extends LinkTo
-final case class LinkToExternal(name: String, url: String) extends LinkTo
+final case class LinkToExternalTpl[Tpl](name: String, baseUrl: String, tpl: Tpl) extends LinkTo
 final case class Tooltip(name: String) extends LinkTo

--- a/src/scaladoc/scala/tools/nsc/doc/base/MemberLookupBase.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/MemberLookupBase.scala
@@ -15,7 +15,7 @@ trait MemberLookupBase {
   def internalLink(sym: Symbol, site: Symbol): Option[LinkTo]
   def chooseLink(links: List[LinkTo]): LinkTo
   def toString(link: LinkTo): String
-  def findExternalLink(sym: Symbol, name: String): Option[LinkToExternal]
+  def findExternalLink(sym: Symbol, name: String): Option[LinkTo]
   def warnNoLink: Boolean
 
   import global._

--- a/src/scaladoc/scala/tools/nsc/doc/html/HtmlPage.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/HtmlPage.scala
@@ -145,8 +145,12 @@ abstract class HtmlPage extends Page { thisPage =>
         <span class="extmbr" name={ mbr.qualifiedName }>{ inlineToHtml(text) }</span>
     case Tooltip(tooltip) =>
       <span class="extype" name={ tooltip }>{ inlineToHtml(text) }</span>
-    case LinkToExternal(name, url) =>
-      <a href={ url } class="extype" target="_top">{ inlineToHtml(text) }</a>
+    case LinkToExternalTpl(name, baseUrl, dtpl: TemplateEntity) =>
+      def url = Page.makeUrl(baseUrl, Page.templateToPath(dtpl))
+      if (hasLinks)
+        <a href={ url } class="extype" name={ dtpl.qualifiedName }>{ inlineToHtml(text) }</a>
+      else
+        <span class="extype" name={ dtpl.qualifiedName }>{ inlineToHtml(text) }</span>
     case _ =>
       inlineToHtml(text)
   }

--- a/src/scaladoc/scala/tools/nsc/doc/html/Page.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/Page.scala
@@ -13,6 +13,44 @@ import scala.reflect.NameTransformer
 import java.nio.channels.Channels
 import java.io.Writer
 
+object Page {
+
+  def templateToPath(tpl: TemplateEntity): List[String] = {
+    def doName(tpl: TemplateEntity): String =
+      (if (tpl.inPackageObject) "package$$" else "") + NameTransformer.encode(tpl.name) + (if (tpl.isObject) "$" else "")
+    def downPacks(pack: TemplateEntity): List[String] =
+      if (pack.isRootPackage) Nil else (doName(pack) :: downPacks(pack.inTemplate))
+    def downInner(nme: String, tpl: TemplateEntity): (String, TemplateEntity) = {
+      if(tpl.inTemplate.isPackage) {
+        (nme + ".html", tpl.inTemplate)
+      } else {
+        downInner(doName(tpl.inTemplate) + "$" + nme, tpl.inTemplate)
+      }
+    }
+    val (file, pack) =
+      if(tpl.isPackage) {
+        ("index.html", tpl)
+      } else {
+        downInner(doName(tpl), tpl)
+      }
+    file :: downPacks(pack)
+  }
+
+  def makeUrl(baseUrl : String, path : List[String]) : String = baseUrl.stripSuffix("/") + "/" + path.reverse.mkString("/")
+
+  /** A relative link from a page's path to some destination path.
+    * @param destPath The path that the link will point to. */
+  def relativeLinkTo(thisPagePath: List[String], destPath: List[String]): String = {
+    def relativize(from: List[String], to: List[String]): List[String] = (from, to) match {
+      case (f :: fs, t :: ts) if (f == t) => // both paths are identical to that point
+        relativize(fs, ts)
+      case (fss, tss) =>
+        List.fill(fss.length - 1)("..") ::: tss
+    }
+    relativize(thisPagePath.reverse, destPath.reverse).mkString("/")
+  }
+}
+
 abstract class Page {
   thisPage =>
 
@@ -66,41 +104,17 @@ abstract class Page {
       case _ => sys.error("Cannot create kind for: " + mbr + " of class " + mbr.getClass)
     }
 
-  def templateToPath(tpl: TemplateEntity): List[String] = {
-    def doName(tpl: TemplateEntity): String =
-      (if (tpl.inPackageObject) "package$$" else "") + NameTransformer.encode(tpl.name) + (if (tpl.isObject) "$" else "")
-    def downPacks(pack: Package): List[String] =
-      if (pack.isRootPackage) Nil else (doName(pack) :: downPacks(pack.inTemplate))
-    def downInner(nme: String, tpl: TemplateEntity): (String, Package) = {
-      tpl.inTemplate match {
-        case inPkg: Package => (nme + ".html", inPkg)
-        case inTpl => downInner(doName(inTpl) + "$" + nme, inTpl)
-      }
-    }
-    val (file, pack) =
-      tpl match {
-        case p: Package => ("index.html", p)
-        case _ => downInner(doName(tpl), tpl)
-      }
-    file :: downPacks(pack)
-  }
+  def templateToPath(tpl: TemplateEntity): List[String] = Page.templateToPath(tpl)
 
   /** A relative link from this page to some destination class entity.
     * @param destClass The class or object entity that the link will point to. */
   def relativeLinkTo(destClass: TemplateEntity): String =
-    relativeLinkTo(templateToPath(destClass))
+    Page.relativeLinkTo(thisPage.path, templateToPath(destClass))
 
-  /** A relative link from this page to some destination path.
+  /** A relative link from a page's path to some destination path.
     * @param destPath The path that the link will point to. */
-  def relativeLinkTo(destPath: List[String]): String = {
-    def relativize(from: List[String], to: List[String]): List[String] = (from, to) match {
-      case (f :: fs, t :: ts) if (f == t) => // both paths are identical to that point
-        relativize(fs, ts)
-      case (fss, tss) =>
-        List.fill(fss.length - 1)("..") ::: tss
-    }
-    relativize(thisPage.path.reverse, destPath.reverse).mkString("/")
-  }
+  def relativeLinkTo(destPath: List[String]): String =
+    Page.relativeLinkTo(thisPage.path, destPath)
 
   def hasCompanion(mbr: TemplateEntity): Boolean = mbr match {
     case dtpl: DocTemplateEntity => dtpl.companion.isDefined

--- a/src/scaladoc/scala/tools/nsc/doc/model/MemberLookup.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/MemberLookup.scala
@@ -37,7 +37,7 @@ trait MemberLookup extends base.MemberLookupBase {
     case _ => link.toString
   }
 
-  override def findExternalLink(sym: Symbol, name: String): Option[LinkToExternal] = {
+  override def findExternalLink(sym: Symbol, name: String): Option[LinkTo] = {
     val sym1 =
       if (sym == AnyClass || sym == AnyRefClass || sym == AnyValClass || sym == NothingClass) ListClass
       else if (sym.hasPackageFlag)
@@ -60,8 +60,9 @@ trait MemberLookup extends base.MemberLookupBase {
       }
     }
     classpathEntryFor(sym1) flatMap { path =>
-      settings.extUrlMapping get path map { url =>
-        LinkToExternal(name, url + "#" + name)
+      settings.extUrlMapping get path map { url => {
+         LinkToExternalTpl(name, url, makeTemplate(sym1))
+        }
       }
     }
   }

--- a/test/scaladoc/run/SI-191.scala
+++ b/test/scaladoc/run/SI-191.scala
@@ -1,6 +1,7 @@
 import scala.tools.nsc.doc.model._
 import scala.tools.nsc.doc.base._
 import scala.tools.nsc.doc.base.comment._
+import scala.tools.nsc.doc.html.Page
 import scala.tools.partest.ScaladocModelTest
 import java.net.{URI, URL}
 import java.io.File
@@ -49,7 +50,7 @@ object Test extends ScaladocModelTest {
 
     def check(memberDef: Def, expected: Int) {
       val externals = memberDef.valueParams(0)(0).resultType.refEntity collect {
-        case (_, (LinkToExternal(name, url), _)) => assert(url.contains(scalaURL)); name
+        case (_, (LinkToExternalTpl(name, url, _), _)) => assert(url.contains(scalaURL)); name
       }
       assert(externals.size == expected)
     }
@@ -60,18 +61,24 @@ object Test extends ScaladocModelTest {
     check(test._method("baz"), 0)
 
     val expectedUrls = collection.mutable.Set[String](
-                         "scala.collection.Map",
-                         "scala.collection.immutable.::",
-                         "scala.Int",
-                         "scala.Predef$",
-                         "scala.Int@toLong:Long",
-                         "scala.package",
-                         "scala.package@AbstractMethodError=AbstractMethodError",
-                         "scala.Predef$@String=String"
-                       ).map(scalaURL + "/index.html#" + _)
+                         "scala/collection/Map",
+                         "scala/collection/immutable/$colon$colon",
+                         "scala/Int",
+                         "scala/Predef$",
+                         "scala/Int#toLong:Long",
+                         "scala/index",
+                         "scala/index#AbstractMethodError=AbstractMethodError",
+                         "scala/Predef$String"
+                      ).map( _.split("#").toSeq ).map({
+                        case Seq(one)      => scalaURL + "/" + one + ".html"
+                        case Seq(one, two) => scalaURL + "/" + one + ".html#" + two
+                      })
 
     def isExpectedExternalLink(l: EntityLink) = l.link match {
-      case LinkToExternal(name, url) => assert(expectedUrls contains url, url); true
+      case LinkToExternalTpl(name, baseUrl, tpl: TemplateEntity) =>
+        val url = Page.makeUrl(baseUrl, Page.templateToPath(tpl))
+        assert(expectedUrls contains url, url + " " + expectedUrls)
+        true
       case _ => false
     }
 

--- a/test/scaladoc/run/t8557.scala
+++ b/test/scaladoc/run/t8557.scala
@@ -40,7 +40,7 @@ object Test extends ScaladocModelTest {
 
     val a = rootPackage._package("scala")._package("test")._package("scaladoc")._package("T8857")._class("A")
 
-    val links = countLinks(a.comment.get, _.link.isInstanceOf[LinkToExternal])
+    val links = countLinks(a.comment.get, _.link.isInstanceOf[LinkToExternalTpl])
     assert(links == 1, links + " ==  1 (the links to external in class A)")
   }
 }


### PR DESCRIPTION
https://issues.scala-lang.org/browse/SI-9967

```
On 2.12.0-RC2, scaladoc appears to be generating fragment identifiers
Ex: index.html#com.foo.Bar
Instead of the new directory structure based urls. Ex: http://bog.us/com/foo/Bar.html
Example link generated when referencing a Long primitive as a return value:
<a href="http://www.scala-lang.org/api/2.12.0-RC2/index.html#scala.Long" class="extype" target="_top">Long</a>
Expected result:
http://www.scala-lang.org/api/2.12.0-RC2/scala/Long.html
```

I've signed the scala CLA

I don't know who would be good to review this, and I can't figure out how to run test/SI-191, hoping the continuous integration will pick it up and inform me.
