### PR TITLE
[backport] Bump sbt.version to 0.13.12, without breaking

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -136,6 +136,11 @@ lazy val commonSettings = clearSourceAndResourceDirectories ++ publishSettings +
     }
   },
   scalaVersion := (scalaVersion in bootstrap).value,
+  // As of sbt 0.13.12 (sbt/sbt#2634) sbt endeavours to align both scalaOrganization and scalaVersion
+  // in the Scala artefacts, for example scala-library and scala-compiler.
+  // This doesn't work in the scala/scala build because the version of scala-library and the scalaVersion of
+  // scala-library are correct to be different. So disable overriding.
+  ivyScala ~= (_ map (_ copy (overrideScalaVersion = false))),
   // we always assume that Java classes are standalone and do not have any dependency
   // on Scala classes
   compileOrder := CompileOrder.JavaThenScala,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.12

--- a/scripts/common
+++ b/scripts/common
@@ -19,7 +19,7 @@ mkdir -p $IVY_CACHE
 rm -rf $IVY_CACHE/cache/org.scala-lang
 
 SBT_CMD=${sbtCmd-sbt}
-SBT_CMD="$SBT_CMD -sbt-version 0.13.11"
+SBT_CMD="$SBT_CMD -sbt-version 0.13.12"
 
 # temp dir where all 'non-build' operation are performed
 TMP_ROOT_DIR=$(mktemp -d -t pr-scala.XXXX)


### PR DESCRIPTION
Aiming to keep 2.11 and 2.12 SBT builds as common as possible.
