### PR TITLE
Improve hash code of Names

### DIFF
--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -47,17 +47,15 @@ trait Names extends api.Names {
   /** Hashtable for finding type names quickly. */
   private val typeHashtable = new Array[TypeName](HASH_SIZE)
 
-  /**
-   * The hashcode of a name depends on the first, the last and the middle character,
-   * and the length of the name.
-   */
-  private def hashValue(cs: Array[Char], offset: Int, len: Int): Int =
-    if (len > 0)
-      (len * (41 * 41 * 41) +
-       cs(offset) * (41 * 41) +
-       cs(offset + len - 1) * 41 +
-       cs(offset + (len >> 1)))
-    else 0
+  private def hashValue(cs: Array[Char], offset: Int, len: Int): Int = {
+    var h = 0
+    var i = 0
+    while (i < len) {
+      h = 31 * h + cs(i + offset)
+      i += 1
+    }
+    h
+  }
 
   /** Is (the ASCII representation of) name at given index equal to
    *  cs[offset..offset+len-1]?


### PR DESCRIPTION
The old approach of using the first, last, and middle characters
only lays a trap for generate names that have little or no entropy
at these locations. Fresh existential names generated in "as seen
from" operations are one such case, and when compiling large
batches of files the name table can become imbalanced.

I found such an example in ScalaTest:

   https://github.com/scala/scala-dev/issues/246#issuecomment-255338925

This commit uses all characters to compute the hashCode.

Review by @adriaanm @lrytz

I expect that this change will be beneficial on large code bases
that regularly exercise `AsSeenFrom#captureThis`, and neutral on
most smaller code bases. I'll perform some benchmarks to make sure
of that "neutral" claim and post the results here.
