### PR TITLE
Change synchronization method in TwoWayCache for more parallelism

### DIFF
--- a/src/reflect/scala/reflect/runtime/TwoWayCache.scala
+++ b/src/reflect/scala/reflect/runtime/TwoWayCache.scala
@@ -67,9 +67,7 @@ private[runtime] class TwoWayCache[J, S] {
       case SomeRef(v) =>
         v
       case _ =>
-        val result = body
-        enter(result, key)
-        result
+        syncToJava(key)(body)
     }
   }
 }

--- a/src/reflect/scala/reflect/runtime/TwoWayCache.scala
+++ b/src/reflect/scala/reflect/runtime/TwoWayCache.scala
@@ -2,9 +2,10 @@ package scala
 package reflect
 package runtime
 
-import scala.collection.mutable.WeakHashMap
 import java.lang.ref.WeakReference
+import java.util.{Collections, WeakHashMap}
 
+import scala.collection.convert.decorateAsScala._
 /** A cache that maintains a bijection between Java reflection type `J`
  *  and Scala reflection type `S`.
  *
@@ -14,13 +15,13 @@ import java.lang.ref.WeakReference
  */
 private[runtime] class TwoWayCache[J, S] {
 
-  private val toScalaMap = new WeakHashMap[J, WeakReference[S]]
-  private val toJavaMap = new WeakHashMap[S, WeakReference[J]]
+  private val toScalaMap = Collections.synchronizedMap(new WeakHashMap[J, WeakReference[S]]()).asScala
+  private val toJavaMap = Collections.synchronizedMap(new WeakHashMap[S, WeakReference[J]]()).asScala
 
-  def enter(j: J, s: S) = synchronized {
+  def enter(j: J, s: S) = {
     // debugInfo("cached: "+j+"/"+s)
-    toScalaMap(j) = new WeakReference(s)
-    toJavaMap(s) = new WeakReference(j)
+    toScalaMap.put(j, new WeakReference(s))
+    toJavaMap.put(s, new WeakReference(j))
   }
 
   private object SomeRef {
@@ -30,8 +31,8 @@ private[runtime] class TwoWayCache[J, S] {
       } else None
   }
 
-  def toScala(key: J)(body: => S): S = synchronized {
-    toScalaMap get key match {
+  def toScala(key: J)(body: => S): S = {
+    toScalaMap.get(key) match {
       case SomeRef(v) =>
         v
       case _ =>
@@ -41,8 +42,8 @@ private[runtime] class TwoWayCache[J, S] {
     }
   }
 
-  def toJava(key: S)(body: => J): J = synchronized {
-    toJavaMap get key match {
+  def toJava(key: S)(body: => J): J = {
+    toJavaMap.get(key) match {
       case SomeRef(v) =>
         v
       case _ =>
@@ -52,3 +53,4 @@ private[runtime] class TwoWayCache[J, S] {
     }
   }
 }
+


### PR DESCRIPTION
Remove full synchronization of TwoWayCache methods and synchronize only cache maps. Because in multithreading app full synchronization cache operations implies performance degradation. Altough synchronized need only for two maps: toJava and toScala and only for write operations.

I'm replace they from WeakHashMap to synchronyzed wraper on WeakHashMap, because there are not exsists true concurrent WeakHashMap modification.

Before changes in my performance tests number of reflections operations decrease when I was add new threads. And in threads dump can see what most time thread try attempt lock. After changes number operations have linear dependensy of threads count.
