### PR TITLE
intern some doubles when boxing [ci: last-only]

### DIFF
--- a/src/library/scala/runtime/BoxesRunTime.java
+++ b/src/library/scala/runtime/BoxesRunTime.java
@@ -73,10 +73,20 @@ public final class BoxesRunTime
         return java.lang.Float.valueOf(f);
     }
 
+    private static final Double DOUBLE_ZERO = java.lang.Double.valueOf(0.0);
+    private static final Double DOUBLE_NEG_ZERO = java.lang.Double.valueOf(-0.0);
+    private static final Double DOUBLE_UNIT = java.lang.Double.valueOf(1.0);
+    private static final Double DOUBLE_NEG_UNIT = java.lang.Double.valueOf(-1.0);
+
     public static java.lang.Double boxToDouble(double d) {
-        // System.out.println("box " + d);
-        // (new Throwable()).printStackTrace();
-        return java.lang.Double.valueOf(d);
+        // Double can detect negative zeros, but primitive == cannot
+        // also note that Double.NaN.equals(Double.NaN) is true, unlike primitive
+        Double value = java.lang.Double.valueOf(d);
+        if (value.equals(DOUBLE_ZERO)) return DOUBLE_ZERO;
+        else if (value.equals(DOUBLE_NEG_ZERO)) return DOUBLE_NEG_ZERO;
+        else if (value.equals(DOUBLE_UNIT)) return DOUBLE_UNIT;
+        else if (value.equals(DOUBLE_NEG_UNIT)) return DOUBLE_NEG_UNIT;
+        else return value;
     }
 
 /* UNBOXING ... UNBOXING ... UNBOXING ... UNBOXING ... UNBOXING ... UNBOXING ... UNBOXING */

--- a/src/library/scala/runtime/BoxesRunTime.java
+++ b/src/library/scala/runtime/BoxesRunTime.java
@@ -74,19 +74,23 @@ public final class BoxesRunTime
     }
 
     private static final Double DOUBLE_ZERO = java.lang.Double.valueOf(0.0);
+    private static final long DOUBLE_ZERO_BITS = java.lang.Double.doubleToLongBits(0.0);
     private static final Double DOUBLE_NEG_ZERO = java.lang.Double.valueOf(-0.0);
+    private static final long DOUBLE_NEG_ZERO_BITS = java.lang.Double.doubleToLongBits(-0.0);
     private static final Double DOUBLE_UNIT = java.lang.Double.valueOf(1.0);
+    private static final long DOUBLE_UNIT_BITS = java.lang.Double.doubleToLongBits(1.0);
     private static final Double DOUBLE_NEG_UNIT = java.lang.Double.valueOf(-1.0);
+    private static final long DOUBLE_NEG_UNIT_BITS = java.lang.Double.doubleToLongBits(-1.0);
 
     public static java.lang.Double boxToDouble(double d) {
         // Double can detect negative zeros, but primitive == cannot
         // also note that Double.NaN.equals(Double.NaN) is true, unlike primitive
-        Double value = java.lang.Double.valueOf(d);
-        if (value.equals(DOUBLE_ZERO)) return DOUBLE_ZERO;
-        else if (value.equals(DOUBLE_NEG_ZERO)) return DOUBLE_NEG_ZERO;
-        else if (value.equals(DOUBLE_UNIT)) return DOUBLE_UNIT;
-        else if (value.equals(DOUBLE_NEG_UNIT)) return DOUBLE_NEG_UNIT;
-        else return value;
+        long bits = java.lang.Double.doubleToLongBits(d);
+        if (bits == DOUBLE_ZERO_BITS) return DOUBLE_ZERO;
+        else if (bits == DOUBLE_NEG_ZERO_BITS) return DOUBLE_NEG_ZERO;
+        else if (bits == DOUBLE_UNIT_BITS) return DOUBLE_UNIT;
+        else if (bits == DOUBLE_NEG_UNIT_BITS) return DOUBLE_NEG_UNIT;
+        else return java.lang.Double.valueOf(d);
     }
 
 /* UNBOXING ... UNBOXING ... UNBOXING ... UNBOXING ... UNBOXING ... UNBOXING ... UNBOXING */

--- a/test/files/run/boxesRunTime-boxToDouble.scala
+++ b/test/files/run/boxesRunTime-boxToDouble.scala
@@ -1,18 +1,17 @@
 // partest test/files/run/boxesRunTime-boxToDouble.scala
 object Test {
   def main(args: Array[String]): Unit = {
-    assert(!(-0.0.asInstanceOf[java.lang.Double] eq 0.0.asInstanceOf[java.lang.Double]), "negative zero was positive")
-
     assert(0.0.asInstanceOf[java.lang.Double] eq 0.0.asInstanceOf[java.lang.Double], "zero was not interned")
     assert(-0.0.asInstanceOf[java.lang.Double] eq -0.0.asInstanceOf[java.lang.Double], "negative zero was not interned")
     assert(1.0.asInstanceOf[java.lang.Double] eq 1.0.asInstanceOf[java.lang.Double], "one was not interned")
     assert(-1.0.asInstanceOf[java.lang.Double] eq -1.0.asInstanceOf[java.lang.Double], "negative one was not interned")
 
-    // a reminder of the java.land.Double API vs Scala/Java primitives
+    // a reminder of the java.lang.Double vs primitive equality exceptions
     assert(java.lang.Double.NaN.equals(java.lang.Double.NaN))
     assert(Double.NaN != Double.NaN)
 
-    // canary, the JVM may start to cache these...
-    assert(!(100.0.asInstanceOf[java.lang.Double] eq 100.0.asInstanceOf[java.lang.Double]), "100 was interned")
+    assert(!(java.lang.Double.valueOf(0.0).equals(java.lang.Double.valueOf(-0.0))))
+    assert(0.0 == -0.0)
+    assert(!(-0.0.asInstanceOf[java.lang.Double] eq 0.0.asInstanceOf[java.lang.Double]), "negative zero was positive")
   }
 }

--- a/test/files/run/boxesRunTime-boxToDouble.scala
+++ b/test/files/run/boxesRunTime-boxToDouble.scala
@@ -1,0 +1,18 @@
+// partest test/files/run/boxesRunTime-boxToDouble.scala
+object Test {
+  def main(args: Array[String]): Unit = {
+    assert(!(-0.0.asInstanceOf[java.lang.Double] eq 0.0.asInstanceOf[java.lang.Double]), "negative zero was positive")
+
+    assert(0.0.asInstanceOf[java.lang.Double] eq 0.0.asInstanceOf[java.lang.Double], "zero was not interned")
+    assert(-0.0.asInstanceOf[java.lang.Double] eq -0.0.asInstanceOf[java.lang.Double], "negative zero was not interned")
+    assert(1.0.asInstanceOf[java.lang.Double] eq 1.0.asInstanceOf[java.lang.Double], "one was not interned")
+    assert(-1.0.asInstanceOf[java.lang.Double] eq -1.0.asInstanceOf[java.lang.Double], "negative one was not interned")
+
+    // a reminder of the java.land.Double API vs Scala/Java primitives
+    assert(java.lang.Double.NaN.equals(java.lang.Double.NaN))
+    assert(Double.NaN != Double.NaN)
+
+    // canary, the JVM may start to cache these...
+    assert(!(100.0.asInstanceOf[java.lang.Double] eq 100.0.asInstanceOf[java.lang.Double]), "100 was interned")
+  }
+}


### PR DESCRIPTION
In applications that are number heavy, the number of boxings can contribute significantly to the heap size. This becomes a major GC problem when the `java.lang.Double` instances are strongly referenced.

In contrast, the JVM feels it is worth the effort to intern byte, int and long, but not double.

This PR works around the lack of interning in the JVM by manually caching a very small subset of `Double` instances that are generally the largest contributors to the heap in the typical application.
