### PR TITLE
Pattern Matching analysis improvements [Backport] #4919 [ci: last-only]

### DIFF
--- a/src/compiler/scala/reflect/macros/contexts/Parsers.scala
+++ b/src/compiler/scala/reflect/macros/contexts/Parsers.scala
@@ -16,6 +16,7 @@ trait Parsers {
       val tree = gen.mkTreeOrBlock(parser.parseStatsOrPackages())
       sreporter.infos.foreach {
         case sreporter.Info(pos, msg, sreporter.ERROR) => throw ParseException(pos, msg)
+        case _ =>
       }
       tree
     } finally global.reporter = oldReporter

--- a/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
@@ -691,7 +691,7 @@ trait ScalaLogic extends Interface with Logic with TreeAndTypeAnalysis {
           // if X is mutable.
           freshExistentialSubtype(t.tpe)
         }
-        else trees find (a => a.correspondsStructure(t)(sameValue)) match {
+        else trees find (a => equivalentTree(a, t)) match {
           case Some(orig) =>
             debug.patmat("unique tp for tree: " + ((orig, orig.tpe)))
             orig.tpe

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -177,6 +177,8 @@ trait TreeAndTypeAnalysis extends Debugging {
               filterChildren(subclasses)
             })
           }
+        case sym if sym.isCase if settings.isScala212 =>
+          List(List(tp))
 
         case sym =>
           debug.patmat("enum unsealed "+ ((tp, sym, sym.isSealed, isPrimitiveValueClass(sym))))

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -85,11 +85,15 @@ trait TreeAndTypeAnalysis extends Debugging {
     tp <:< tpImpliedNormalizedToAny
   }
 
-  // TODO: improve, e.g., for constants
-  def sameValue(a: Tree, b: Tree): Boolean = (a eq b) || ((a, b) match {
-    case (_ : Ident, _ : Ident) => a.symbol eq b.symbol
-    case _                      => false
-  })
+  def equivalentTree(a: Tree, b: Tree): Boolean = (a, b) match {
+    case (Select(qual1, _), Select(qual2, _)) => equivalentTree(qual1, qual2) && a.symbol == b.symbol
+    case (Ident(_), Ident(_)) => a.symbol == b.symbol
+    case (Literal(c1), Literal(c2)) => c1 == c2
+    case (This(_), This(_)) => a.symbol == b.symbol
+    case (Apply(fun1, args1), Apply(fun2, args2)) => equivalentTree(fun1, fun2) && args1.corresponds(args2)(equivalentTree)
+    // Those are the only cases we need to handle in the pattern matcher
+    case _ => false
+  }
 
   trait CheckableTreeAndTypeAnalysis {
     val typer: Typer
@@ -277,7 +281,7 @@ trait MatchApproximation extends TreeAndTypeAnalysis with ScalaLogic with MatchT
 
       // hashconsing trees (modulo value-equality)
       def unique(t: Tree, tpOverride: Type = NoType): Tree =
-        trees find (a => a.correspondsStructure(t)(sameValue)) match {
+        trees find (a => equivalentTree(a, t)) match {
           case Some(orig) =>
             // debug.patmat("unique: "+ (t eq orig, orig))
             orig

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1859,7 +1859,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       clazz.annotations.map(_.completeInfo())
       if (templ.symbol == NoSymbol)
         templ setSymbol clazz.newLocalDummy(templ.pos)
-      val self1 = templ.self match {
+      val self1 = (templ.self: @unchecked) match {
         case vd @ ValDef(_, _, tpt, EmptyTree) =>
           val tpt1 = checkNoEscaping.privates(
             clazz.thisSym,

--- a/test/files/jvm/future-spec/FutureTests.scala
+++ b/test/files/jvm/future-spec/FutureTests.scala
@@ -128,7 +128,7 @@ class FutureTests extends MinimalScalaTest {
     "support pattern matching within a for-comprehension" in {
       case class Req[T](req: T)
       case class Res[T](res: T)
-      def async[T](req: Req[T]) = req match {
+      def async[T](req: Req[T]) = (req: @unchecked) match {
         case Req(s: String) => Future { Res(s.length) }
         case Req(i: Int)    => Future { Res((i * 2).toString) }
       }

--- a/test/files/jvm/patmat_opt_ignore_underscore/Analyzed_1.scala
+++ b/test/files/jvm/patmat_opt_ignore_underscore/Analyzed_1.scala
@@ -7,7 +7,7 @@ class SameBytecode {
   case class Foo(x: Any, y: String)
 
   def a =
-    Foo(1, "a") match {
+    (Foo(1, "a"): @unchecked) match {
       case Foo(_: String, y) => y
     }
 

--- a/test/files/neg/t9398.check
+++ b/test/files/neg/t9398.check
@@ -1,0 +1,7 @@
+match.scala:3: warning: match may not be exhaustive.
+It would fail on the following input: CC(B2)
+  def test(c: CC): Unit = c match {
+                          ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/t9398.flags
+++ b/test/files/neg/t9398.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -Xsource:2.12

--- a/test/files/neg/t9398/data.scala
+++ b/test/files/neg/t9398/data.scala
@@ -1,0 +1,5 @@
+sealed abstract class TB
+case object B extends TB
+case object B2 extends TB
+
+case class CC(tb: TB)

--- a/test/files/neg/t9398/match.scala
+++ b/test/files/neg/t9398/match.scala
@@ -1,0 +1,6 @@
+class Test {
+  // Should warn that CC(B2) isn't matched
+  def test(c: CC): Unit = c match {
+    case CC(B) => ()
+  }
+}

--- a/test/files/pos/t5899.scala
+++ b/test/files/pos/t5899.scala
@@ -14,6 +14,7 @@ trait Foo {
     Bippy(Stable) match {
       case Bippy(nme.WILDCARD) => 1
       case Bippy(Stable) => 2 // should not be considered unreachable
+      case Bippy(_) => 3
     }
   }
 }

--- a/test/files/pos/t9399.flags
+++ b/test/files/pos/t9399.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t9399.scala
+++ b/test/files/pos/t9399.scala
@@ -1,0 +1,16 @@
+sealed abstract class TA
+sealed abstract class TB extends TA
+case object A extends TA
+case object B extends TB
+
+sealed trait C
+case class CTA(id: Int, da: TA) extends C
+case class CTB(id: Int, da: TB) extends C
+
+class Test {
+  def test(c: C): Unit = c match {
+    case CTA(_, A) =>
+    case CTA(_, B) =>
+    case CTB(_, B) =>
+  }
+}

--- a/test/files/pos/t9411a.flags
+++ b/test/files/pos/t9411a.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t9411a.scala
+++ b/test/files/pos/t9411a.scala
@@ -1,0 +1,27 @@
+object OhNoes {
+
+  sealed trait F
+  sealed abstract class FA extends F
+  sealed abstract class FB extends F
+
+  case object FA1 extends FA
+  case object FB1 extends FB
+  case object FB2 extends FB
+
+  sealed trait G
+  case object G1 extends G
+  case object G2 extends G
+
+  sealed trait H
+  case class H1(a: FB, b: G) extends H
+  case class H2(a: F)        extends H
+
+  val demo: H => Unit = {
+    case H1(FB1, G1) =>
+    case H1(FB2, G2) =>
+    case H2(_: FB) =>
+    case H2(_: FA) =>
+    case H1(FB1, G2) =>
+    case H1(FB2, G1) =>
+  }
+}

--- a/test/files/pos/t9411b.flags
+++ b/test/files/pos/t9411b.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t9411b.scala
+++ b/test/files/pos/t9411b.scala
@@ -1,0 +1,36 @@
+object OhNoes {
+
+  sealed trait F
+  sealed abstract class FA extends F
+  sealed abstract class FB extends F
+
+  case object FA1 extends FA
+  case object FB1 extends FB
+  case object FB2 extends FB
+
+  sealed trait G
+  case object G1 extends G
+  case object G2 extends G
+
+  sealed trait H
+  case class H1(a: FB, b: G) extends H
+  case class H2(b: F)        extends H
+
+  val demo: H => Unit = {
+    case H1(FB1, G1) =>
+    case H1(FB2, G2) =>
+    case H2(_: FB) =>
+    case H2(_: FA) =>
+    case H1(FB1, G2) =>
+    case H1(FB2, G1) =>
+  }
+
+  val demo2: H => Unit = {
+    case H2(_: FA) =>
+    case H2(_: FB) =>
+    case H1(FB1, G1) =>
+    case H1(FB2, G1) =>
+    case H1(FB1, G2) =>
+    case H1(FB2, G2) =>
+  }
+}

--- a/test/files/pos/t9630.flags
+++ b/test/files/pos/t9630.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t9630/t9630a.scala
+++ b/test/files/pos/t9630/t9630a.scala
@@ -1,0 +1,8 @@
+
+sealed trait Base
+final case class Base_1(sameName: Some[Any]) extends Base
+final case class Base_2(sameName: Nested) extends Base
+
+sealed trait Nested
+final case class Nested_1(x: Any) extends Nested
+final case class Nested_2(y: Any) extends Nested

--- a/test/files/pos/t9630/t9630b.scala
+++ b/test/files/pos/t9630/t9630b.scala
@@ -1,0 +1,8 @@
+
+class Test {
+  def test(b: Base): Unit = b match {
+    case Base_1(Some(_)) =>
+    case Base_2(Nested_1(_)) =>
+    case Base_2(Nested_2(_)) =>
+  }
+}

--- a/test/files/run/Course-2002-07.scala
+++ b/test/files/run/Course-2002-07.scala
@@ -485,7 +485,7 @@ object MB {
   import Utils._;
 
 
-  trait Expr {
+  sealed trait Expr {
 
     private def count: Int = this match {
       case Lit(n)        => n

--- a/test/files/run/caseclasses.scala
+++ b/test/files/run/caseclasses.scala
@@ -18,7 +18,7 @@ object M {
 object Test extends App {
 
   def Abs(x: Int) = new Abs(x * 2){}
-  Abs(2) match {
+  (Abs(2): @unchecked) match {
     case Abs(4) => ;
   }
 

--- a/test/files/run/infix.scala
+++ b/test/files/run/infix.scala
@@ -7,5 +7,6 @@ object Test extends App {
   Console.println(xs)
   xs match {
     case null op (0, 0) op (1, 1) op (2, 2) => Console.println("OK")
+    case _ =>
   }
 }

--- a/test/files/run/patmatnew.scala
+++ b/test/files/run/patmatnew.scala
@@ -539,7 +539,7 @@ object Test {
     case class Operator(x: Int);
     val EQ = new Operator(2);
 
-    def analyze(x: Tuple2[Operator, Int]) = x match {
+    def analyze(x: Tuple2[Operator, Int]) = (x: @unchecked) match {
       case (EQ, 0) => "0"
       case (EQ, 1) => "1"
       case (EQ, 2) => "2"
@@ -603,7 +603,7 @@ object Test {
 
   object Bug1093 {
     def run() {
-      assert(Some(3) match {
+      assert((Some(3): @unchecked) match {
         case Some(1 | 2) => false
         case Some(3) => true
       })

--- a/test/files/run/t3126.scala
+++ b/test/files/run/t3126.scala
@@ -4,6 +4,6 @@ object Test {
 
   def main(args: Array[String]): Unit = {
     try C.unapply(null) catch { case _: MatchError => }
-    try v match { case Some(1) => } catch { case _: MatchError => }
+    try ((v: @unchecked) match { case Some(1) => }) catch { case _: MatchError => }
   }
 }

--- a/test/files/run/t4124.scala
+++ b/test/files/run/t4124.scala
@@ -2,22 +2,22 @@ import xml.Node
 
 object Test extends App {
   val body: Node = <elem>hi</elem>	
-  println ((body: AnyRef, "foo") match {
+  println (((body: AnyRef, "foo"): @unchecked) match {
     case (node: Node, "bar")        => "bye"
     case (ser: Serializable, "foo") => "hi"
   })
 
-  println ((body, "foo") match {
+  println (((body, "foo"): @unchecked) match {
     case (node: Node, "bar")        => "bye"
     case (ser: Serializable, "foo") => "hi"
   })
 
-  println ((body: AnyRef, "foo") match {
+  println (((body: AnyRef, "foo"): @unchecked) match {
     case (node: Node, "foo")        => "bye"
     case (ser: Serializable, "foo") => "hi"
   })
 
-  println ((body: AnyRef, "foo") match {
+  println (((body: AnyRef, "foo"): @unchecked) match {
     case (node: Node, "foo")        => "bye"
     case (ser: Serializable, "foo") => "hi"
   })

--- a/test/files/run/t6089.scala
+++ b/test/files/run/t6089.scala
@@ -3,7 +3,7 @@ case class Foo(x: Int)
 object Test {
   def bippo(result: Boolean): Boolean = result
   def bungus(m: Foo): Boolean         =
-    bippo(m match { case Foo(2) => bungus(m) })
+    bippo((m: @unchecked) match { case Foo(2) => bungus(m) })
 
   def main(args: Array[String]): Unit = try {
     bungus(Foo(0))

--- a/test/files/run/t7459f.scala
+++ b/test/files/run/t7459f.scala
@@ -3,7 +3,7 @@ object Test extends App {
 
   case class FooSeq(x: Int, y: String, z: C*)
 
-  FooSeq(1, "a", new C()) match {
+  (FooSeq(1, "a", new C()): @unchecked) match {
     case FooSeq(1, "a", x@_* ) =>
       //println(x.toList)
       x.asInstanceOf[x.type]


### PR DESCRIPTION
Backport #4919, review by @retronym 

Straightforward rebase, dropping `test/junit/scala/tools/nsc/transform/patmat/PatmatBytecodeTest.scala`
