### PR TITLE
Workaround in backend for linkedClassOfClass returning a type alias

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -477,8 +477,9 @@ class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
         if ((innerClassSym.isJavaDefined && innerClassSym.rawowner.isModuleClass) ||                      // (1)
             (!isAnonymousOrLocalClass(innerClassSym) && isTopLevelModuleClass(innerClassSym.rawowner))) { // (2)
           // phase travel for linkedCoC - does not always work in late phases
+          // (*) `!sym.isClass` is a workaround for scala-dev#248, linkedCoC can return a type alias
           exitingPickler(innerClassSym.rawowner.linkedClassOfClass) match {
-            case NoSymbol =>
+            case sym if sym == NoSymbol || !sym.isClass => // (*)
               // For top-level modules without a companion class, see doc of mirrorClassClassBType.
               mirrorClassClassBType(exitingPickler(innerClassSym.rawowner))
 

--- a/test/files/pos/sd248/Prop_1.scala
+++ b/test/files/pos/sd248/Prop_1.scala
@@ -1,0 +1,2 @@
+package p
+object Prop { class Whitelist }

--- a/test/files/pos/sd248/Test_2.scala
+++ b/test/files/pos/sd248/Test_2.scala
@@ -1,0 +1,5 @@
+package p
+
+object PropTest {
+  def t = new Prop.Whitelist
+}

--- a/test/files/pos/sd248/package_1.scala
+++ b/test/files/pos/sd248/package_1.scala
@@ -1,0 +1,3 @@
+package object p {
+  type Prop = String
+}


### PR DESCRIPTION
Fixes scala/scala-dev/issues/248

This fix is the a workaround and does not fix the underlying issue.
The change propsed here is minimal and safe.

In principle, linkedClassOfClass should not return a type alias. This
could be easily achieved by adding an additional filter to
Symbol.companionClass, as proposed in a comment on the ticket. However,
I observed some further complex interactions in the classfile parser /
unpickler when having type aliases shadowing companions. This behavior
might be cause by the proposed fix. In any case, a change to
companionClass seems rather fundamental and needs to be carefully
investigated.
