### PR TITLE
SI-10007 sys.process thread sync

### DIFF
--- a/src/library/scala/concurrent/SyncVar.scala
+++ b/src/library/scala/concurrent/SyncVar.scala
@@ -91,7 +91,7 @@ class SyncVar[A] {
   // [Heather] the reason why: it doesn't take into consideration
   // whether or not the SyncVar is already defined. So, set has been
   // deprecated in order to eventually be able to make "setting" private
-  @deprecated("use `put` instead, as `set` is potentially error-prone", "2.10.0")
+  @deprecated("use `put` to ensure a value cannot be overwritten without a corresponding `take`", "2.10.0")
   // NOTE: Used by SBT 0.13.0-M2 and below
   def set(x: A): Unit = setVal(x)
 
@@ -111,7 +111,7 @@ class SyncVar[A] {
   // [Heather] the reason why: it doesn't take into consideration
   // whether or not the SyncVar is already defined. So, unset has been
   // deprecated in order to eventually be able to make "unsetting" private
-  @deprecated("use `take` instead, as `unset` is potentially error-prone", "2.10.0")
+  @deprecated("use `take` to ensure a value is never discarded", "2.10.0")
   // NOTE: Used by SBT 0.13.0-M2 and below
   def unset(): Unit = synchronized {
     isDefined = false

--- a/src/library/scala/sys/process/ProcessBuilderImpl.scala
+++ b/src/library/scala/sys/process/ProcessBuilderImpl.scala
@@ -53,12 +53,14 @@ private[process] trait ProcessBuilderImpl {
 
     override def run(io: ProcessIO): Process = {
       val success = new SyncVar[Boolean]
-      success put false
-      val t = Spawn({
-        runImpl(io)
-        success.put(true)
-      }, io.daemonizeThreads)
-
+      def go(): Unit = {
+        var ok = false
+        try {
+          runImpl(io)
+          ok = true
+        } finally success.put(ok)
+      }
+      val t = Spawn(go(), io.daemonizeThreads)
       new ThreadProcess(t, success)
     }
   }

--- a/test/junit/scala/sys/process/PipedProcessTest.scala
+++ b/test/junit/scala/sys/process/PipedProcessTest.scala
@@ -12,6 +12,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.control.Exception.ignoring
 
 // Each test normally ends in a moment, but for failure cases, waits until one second.
+// SI-7350, SI-8768
 
 @RunWith(classOf[JUnit4])
 class PipedProcessTest {

--- a/test/junit/scala/sys/process/ProcessTest.scala
+++ b/test/junit/scala/sys/process/ProcessTest.scala
@@ -1,0 +1,25 @@
+package scala.sys.process
+
+import java.io.ByteArrayInputStream
+// should test from outside the package to ensure implicits work
+//import scala.sys.process._
+import scala.util.Properties._
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+@RunWith(classOf[JUnit4])
+class ProcessTest {
+  private def testily(body: => Unit) = if (!isWin) body
+  @Test def t10007(): Unit = testily {
+    val res = ("cat" #< new ByteArrayInputStream("lol".getBytes)).!!
+    assertEquals("lol\n", res)
+  }
+  // test non-hanging
+  @Test def t10055(): Unit = testily {
+    val res = ("cat" #< ( () => -1 ) ).!
+    assertEquals(0, res)
+  }
+}


### PR DESCRIPTION
A previous change to replace `SyncVar.set` with `SyncVar.put`
breaks things.

This commit tweaks the thread synchronizing in `sys.process`
to actually use `SyncVar` to sync and pass a var.

Joining the thread about to exit is superfluous.

A result is put exactly once, and consumers use
non-destructive `get`.

Note that as usual, avoid kicking off threads in a static
context, since class loading cycles are somewhat dicier
with 2.12 lambdas. In particular, REPL is a static context
by default.
