### PR TITLE
Add support for args file to scala command

### DIFF
--- a/src/compiler/scala/tools/nsc/GenericRunnerCommand.scala
+++ b/src/compiler/scala/tools/nsc/GenericRunnerCommand.scala
@@ -28,7 +28,12 @@ extends CompilerCommand(args, settings) {
   // change CompilerCommand behavior
   override def shouldProcessArguments: Boolean = false
 
-  private lazy val (_ok, targetAndArguments) = settings.processArguments(args, processAll = false)
+  private lazy val (_ok, targetAndArguments) = {
+    val (ok1, args1) = settings.processArguments(args, processAll = false)
+    if (ok1) {
+      new CompilerCommand(args, settings).processArguments
+    } else (ok1, args1)
+  }
   override def ok = _ok
   private def guessHowToRun(target: String): GenericRunnerCommand.HowToRun = {
     if (!ok) Error


### PR DESCRIPTION
Like javac, scalac supports use of an "args file" to contain
command line arguments. The motivating use case is to avoid limitations
on the length of the command line, in particular on Windows.

The help of `scala` command claims to accept all options that
`scalac` accepts, but it doesn't expand args files.

This commit adds support for args files, by reusing the exiting logic
in `CompilerCommand`.

Manual testing:

No args file, warnings issued in `-e` mode, REPL mode, and in script mode:

```
% qscala -e 42; printf '{42;()}\n' | qscala; printf 'object Test { def main(args: Array[String]): Unit = {42; ()}}' > /tmp/test.scala; qscala /tmp/test.scala
/var/folders/s2/g6fgtpk52hl8njjvx8vyzr9r0000gn/T/scalacmd2244828122836059261.scala:1: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
42
^
Welcome to Scala 2.12.0-20161021-132114-01b76a2 (OpenJDK 64-Bit Server VM, Java 1.8.0_112-release).
Type in expressions for evaluation. Or try :help.

scala> {42;()}
<console>:12: warning: a pure expression does nothing in statement position
       {42;()}
        ^

scala> :quit
/tmp/test.scala:1: warning: a pure expression does nothing in statement position
object Test { def main(args: Array[String]): Unit = {42; ()}}
                                                     ^

%
```

Adding `-nowarn` to an `/tmp/args.txt`, we can silence these warnings in all modes:

```
% qscala @/tmp/args.txt -e 42; printf '{42;()}\n' | qscala @/tmp/args.txt; printf 'object Test { def main(args: Array[String]): Unit = {42; ()}}' > /tmp/test.scala; qscala @/tmp/args.txt /tmp/test.scala
Welcome to Scala 2.12.0-20161021-132114-01b76a2 (OpenJDK 64-Bit Server VM, Java 1.8.0_112-release).
Type in expressions for evaluation. Or try :help.

scala> {42;()}

scala> :quit

%
```

The args file can also appear a different position in the command line:

```
% qscala -e 42 @/tmp/args.txt;  printf 'object Test { def main(args: Array[String]): Unit = {42; ()}}' > /tmp/test.scala; qscala /tmp/test.scala @/tmp/args.txt

%
```
