### PR TITLE
SI-6734 Synthesize companion near case class

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3140,13 +3140,14 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           // SI-5877 The decls of a package include decls of the package object. But we don't want to add
           //         the corresponding synthetics to the package class, only to the package object class.
           // SI-6734 Locality test below is meaningless if we're not even in the correct tree.
+          //         For modules that are synthetic case companions, check that case class is defined here.
           def shouldAdd(sym: Symbol): Boolean = {
             def shouldAddAsModule: Boolean =
               sym.moduleClass.attachments.get[ClassForCaseCompanionAttachment] match {
                 case Some(att) =>
                   val cdef = att.caseClass
                   stats.exists {
-                    case t @ ClassDef(_, _, _, _) => t.symbol == cdef.symbol
+                    case t @ ClassDef(_, _, _, _) => t.symbol == cdef.symbol   // cdef ne t
                     case _ => false
                   }
                 case _ => true

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3139,10 +3139,24 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           val initElems = scope.elems
           // SI-5877 The decls of a package include decls of the package object. But we don't want to add
           //         the corresponding synthetics to the package class, only to the package object class.
-          def shouldAdd(sym: Symbol) =
-            inBlock || !context.isInPackageObject(sym, context.owner)
+          // SI-6734 Locality test below is meaningless if we're not even in the correct tree.
+          def shouldAdd(sym: Symbol): Boolean = {
+            def shouldAddAsModule: Boolean =
+              sym.moduleClass.attachments.get[ClassForCaseCompanionAttachment] match {
+                case Some(att) =>
+                  val cdef = att.caseClass
+                  stats.exists {
+                    case t @ ClassDef(_, _, _, _) => t.symbol == cdef.symbol
+                    case _ => false
+                  }
+                case _ => true
+              }
+
+            (!sym.isModule || shouldAddAsModule) && (inBlock || !context.isInPackageObject(sym, context.owner))
+          }
           for (sym <- scope)
-            for (tree <- context.unit.synthetics get sym if shouldAdd(sym)) { // OPT: shouldAdd is usually true. Call it here, rather than in the outer loop
+            // OPT: shouldAdd is usually true. Call it here, rather than in the outer loop
+            for (tree <- context.unit.synthetics.get(sym) if shouldAdd(sym)) {
               newStats += typedStat(tree) // might add even more synthetics to the scope
               context.unit.synthetics -= sym
             }

--- a/test/files/pos/t6734.scala
+++ b/test/files/pos/t6734.scala
@@ -1,23 +1,17 @@
 
-//single file badimp.scala
-// adding package object gives not found: type SortedMap
-package object badimp
+// desugars to package p { object `package` }
+// previously, synthetic p.C was incorrectly added to this tree
+// This only matters because synthetics are not hygienic
+package object p
 
-package badimp {
-
-  // move before package object works
-  import scala.collection.immutable.SortedMap
-
-  case class Nodal private[badimp] (value: String, children: SortedMap[String, Int])
-
-  // adding target object restores sanity
-  // but adding it before the import does not
-  //object Nodal
+package p {
+  import scala.concurrent.Future
+  case class C private[p] (value: Future[Int])   // private to avoid rewriting C.apply to new C
 }
 
 package client {
   trait X {
-    import scala.collection.immutable.SortedMap
-    def f = badimp.Nodal("test", SortedMap[String, Int]())   // ensure Nodal.apply was created
+    import scala.concurrent.Future
+    def f = p.C(Future(42)(null))  // ensure synthetics were generated, i.e., p.C.apply
   }
 }

--- a/test/files/pos/t6734.scala
+++ b/test/files/pos/t6734.scala
@@ -1,0 +1,23 @@
+
+//single file badimp.scala
+// adding package object gives not found: type SortedMap
+package object badimp
+
+package badimp {
+
+  // move before package object works
+  import scala.collection.immutable.SortedMap
+
+  case class Nodal private[badimp] (value: String, children: SortedMap[String, Int])
+
+  // adding target object restores sanity
+  // but adding it before the import does not
+  //object Nodal
+}
+
+package client {
+  trait X {
+    import scala.collection.immutable.SortedMap
+    def f = badimp.Nodal("test", SortedMap[String, Int]())   // ensure Nodal.apply was created
+  }
+}


### PR DESCRIPTION
Tweak the "should I synthesize now" test for
case modules, so that the tree is inserted in
the same tree as the case class.

This for the case where there are multiple `package p { }` trees, which happens implicitly when there is a `package object p { }`.

No attempt made in this quick fix to improve locality-based synthesis.
