### PR TITLE
upgrade to sbt 0.13.13

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.13

--- a/scripts/common
+++ b/scripts/common
@@ -19,7 +19,7 @@ mkdir -p $IVY_CACHE
 rm -rf $IVY_CACHE/cache/org.scala-lang
 
 SBT_CMD=${sbtCmd-sbt}
-SBT_CMD="$SBT_CMD -sbt-version 0.13.12"
+SBT_CMD="$SBT_CMD -sbt-version 0.13.13"
 
 # temp dir where all 'non-build' operation are performed
 TMP_ROOT_DIR=$(mktemp -d -t pr-scala.XXXX)


### PR DESCRIPTION
we already know from https://github.com/scala/scala/pull/5409 that 0.13.13-RC3 passes CI, presumably this one will as well
