### PR TITLE
SI-10023: third iteration using member.keyword and special handling for parameterless methods

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
+++ b/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
@@ -152,8 +152,10 @@ trait MemberHandlers {
     override def definesValue = flattensToEmpty(member.vparamss) // true if 0-arity
     override def resultExtractionCode(req: Request) = {
       val nameString = colorName(name)
-      val typeString = colorType(req typeOf name)
-      if (mods.isPublic) s""" + "$nameString: $typeString\\n"""" else ""
+      val defType = req.typesOfDefinedTerms(name)
+      val typeString = colorType(s"${paramString(defType)}: ${defType.resultType}")
+
+      if (mods.isPublic) s""" + "${member.keyword} $nameString$typeString\\n"""" else ""
     }
   }
 

--- a/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
+++ b/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
@@ -153,7 +153,11 @@ trait MemberHandlers {
     override def resultExtractionCode(req: Request) = {
       val nameString = colorName(name)
       val defType = req.typesOfDefinedTerms(name)
-      val typeString = colorType(s"${paramString(defType)}: ${defType.resultType}")
+      val paramsTypeString =
+        if (!defType.params.isEmpty) paramString(defType)
+        else ""
+
+      val typeString = colorType(s"$paramsTypeString: ${defType.resultType}")
 
       if (mods.isPublic) s""" + "${member.keyword} $nameString$typeString\\n"""" else ""
     }


### PR DESCRIPTION
I guess that the strings _probably_ shouldn't be hard coded. What would be a more appropriate way to do it?