### PR TITLE
Spec.: Add language code for some Markdown code blocks that had none.

### DIFF
--- a/spec/03-types.md
+++ b/spec/03-types.md
@@ -660,7 +660,7 @@ same name, we model
 An overloaded type consisting of type alternatives $T_1 \commadots T_n (n \geq 2)$ is denoted internally $T_1 \overload \ldots \overload T_n$.
 
 ###### Example
-```
+```scala
 def println: Unit
 def println(s: String): Unit = $\ldots$
 def println(x: Float): Unit = $\ldots$
@@ -678,7 +678,7 @@ println:  => Unit $\overload$
 ```
 
 ###### Example
-```
+```scala
 def f(x: T): T = $\ldots$
 val f = 0
 ```

--- a/spec/03-types.md
+++ b/spec/03-types.md
@@ -587,7 +587,7 @@ corresponding function type.
 
 The declarations
 
-```
+```scala
 def a: Int
 def b (x: Int): Boolean
 def c (x: Int) (y: String, z: String): String
@@ -642,7 +642,7 @@ the corresponding type parameter clause.
 
 Consider this fragment of the `Iterable[+X]` class:
 
-```
+```scala
 trait Iterable[+X] {
   def flatMap[newType[+X] <: Iterable[X], S](f: X => newType[S]): newType[S]
 }
@@ -979,7 +979,7 @@ after applying [eta-expansion](06-expressions.html#eta-expansion). If $T$ is a m
 
 Given the definitions
 
-```
+```scala
 def foo(x: Int => String): Unit
 def foo(x: ToString): Unit
 

--- a/spec/04-basic-declarations-and-definitions.md
+++ b/spec/04-basic-declarations-and-definitions.md
@@ -88,7 +88,7 @@ The class definition `case class X(), Y(n: Int) extends Z` expands to
 `case class X extends Z; case class Y(n: Int) extends Z`.
 - The object definition `case object Red, Green, Blue extends Color`~
 expands to
-```
+```scala
 case object Red extends Color
 case object Green extends Color
 case object Blue extends Color .

--- a/spec/05-classes-and-objects.md
+++ b/spec/05-classes-and-objects.md
@@ -725,7 +725,7 @@ Here,
 
   - $t$ is a [template](#templates) of the form
 
-    ```
+    ```scala
     $sc$ with $mt_1$ with $\ldots$ with $mt_m$ { $\mathit{stats}$ } // $m \geq 0$
     ```
 

--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -945,7 +945,7 @@ comprehensions have been eliminated.
     `$e$.foreach { case $p$ => $e'$ }`.
   - A for comprehension
 
-    ```
+    ```scala
     for ($p$ <- $e$; $p'$ <- $e'; \ldots$) yield $e''$
     ```
 
@@ -953,13 +953,13 @@ comprehensions have been eliminated.
     sequence of generators, definitions, or guards,
     is translated to
 
-    ```
+    ```scala
     $e$.flatMap { case $p$ => for ($p'$ <- $e'; \ldots$) yield $e''$ }
     ```
 
   - A for loop
 
-    ```
+    ```scala
     for ($p$ <- $e$; $p'$ <- $e'; \ldots$) $e''$
     ```
 
@@ -967,7 +967,7 @@ comprehensions have been eliminated.
     sequence of generators, definitions, or guards,
     is translated to
 
-    ```
+    ```scala
     $e$.foreach { case $p$ => for ($p'$ <- $e'; \ldots$) $e''$ }
     ```
 
@@ -980,7 +980,7 @@ comprehensions have been eliminated.
     `$p'$ = $e'$` is translated to the following generator of pairs of values, where
     $x$ and $x'$ are fresh names:
 
-    ```
+    ```scala
     ($p$, $p'$) <- for ($x @ p$ <- $e$) yield { val $x' @ p'$ = $e'$; ($x$, $x'$) }
     ```
 

--- a/spec/11-annotations.md
+++ b/spec/11-annotations.md
@@ -56,7 +56,7 @@ Java platform, the following annotations have a standard meaning.
     This is equivalent to a the following field
     definition in Java:
 
-    ```
+    ```java
     private final static SerialVersionUID = <longlit>
     ```
 

--- a/spec/11-annotations.md
+++ b/spec/11-annotations.md
@@ -103,7 +103,7 @@ Java platform, the following annotations have a standard meaning.
     matches which would otherwise be emitted. For instance, no warnings
     would be produced for the method definition below.
 
-    ```
+    ```scala
     def f(x: Option[Int]) = (x: @unchecked) match {
     case Some(y) => y
     }
@@ -117,7 +117,7 @@ Java platform, the following annotations have a standard meaning.
     value to appear in a path, even if its type is [volatile](03-types.html#volatile-types).
     For instance, the following member definitions are legal:
 
-    ```
+    ```scala
     type A { type T }
     type B
     @uncheckedStable val x: A with B // volatile type
@@ -140,7 +140,7 @@ Java platform, the following annotations have a standard meaning.
     For instance, the following code would generate specialized traits for
     `Unit`, `Int` and `Double`
 
-    ```
+    ```scala
     trait Function0[@specialized(Unit, Int, Double) T] {
       def apply: T
     }

--- a/spec/12-the-scala-standard-library.md
+++ b/spec/12-the-scala-standard-library.md
@@ -777,7 +777,7 @@ The available high-priority implicits include definitions falling into the follo
   * An implicit wrapper that adds `ensuring` methods
     with the following overloaded variants to type `Any`.
 
-    ```
+    ```scala
     def ensuring(cond: Boolean): A = { assert(cond); x }
     def ensuring(cond: Boolean, msg: Any): A = { assert(cond, msg); x }
     def ensuring(cond: A => Boolean): A = { assert(cond(x)); x }
@@ -787,7 +787,7 @@ The available high-priority implicits include definitions falling into the follo
   * An implicit wrapper that adds a `->` method with the following implementation
     to type `Any`.
 
-    ```
+    ```scala
     def -> [B](y: B): (A, B) = (x, y)
     ```
 
@@ -801,7 +801,7 @@ The available high-priority implicits include definitions falling into the follo
   * An implicit wrapper that adds `+` and `formatted` method with the following
     implementations to type `Any`.
 
-    ```
+    ```scala
     def +(other: String) = String.valueOf(self) + other
     def formatted(fmtstr: String): String = fmtstr format self
     ```
@@ -835,7 +835,7 @@ The available high-priority implicits include definitions falling into the follo
   * An implicit definition that generates instances of type `T <:< T`, for
     any type `T`. Here, `<:<` is a class defined as follows.
 
-    ```
+    ```scala
     sealed abstract class <:<[-From, +To] extends (From => To)
     ```
 


### PR DESCRIPTION
Some code blocks in the Scala language specification did not have a language code (to enable language-specific code highlighting). Most of those contained Scala (literal Scala or mostly Scala (e.g., with ellipses)) or Java.  (A few were non- or not-quite-Scala representations of mappings.)

This branch/PR adds "scala" and "java" language codes to the starting "```" line for those blocks.