### PR TITLE
Spec:  Fix 2 pairs of quotes in text.

### DIFF
--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -655,7 +655,7 @@ precedence, with characters on the same line having the same precedence.
 ```
 
 That is, operators starting with a letter have lowest precedence,
-followed by operators starting with ``|`', etc.
+followed by operators starting with ‘`|`’, etc.
 
 There's one exception to this rule, which concerns
 [_assignment operators_](#assignment-operators).
@@ -664,7 +664,7 @@ of simple assignment `(=)`. That is, it is lower than the
 precedence of any other operator.
 
 The _associativity_ of an operator is determined by the operator's
-last character.  Operators ending in a colon ``:`' are
+last character.  Operators ending in a colon ‘`:`’ are
 right-associative. All other operators are left-associative.
 
 Precedence and associativity of operators determine the grouping of

--- a/spec/README.md
+++ b/spec/README.md
@@ -36,5 +36,5 @@ and open http://0.0.0.0:4000/. Jekyll will rebuild as you edit the markdown, but
 
 ### Unicode Character replacements
 
-- The unicode  left and right single  quotation marks (‘ and  ’) have been used in  place of ` and  ', where the quotation marks  are intended to  be paired. These can  be typed on  a mac using  Option+] for a left  quote and Option+Shift+] for the right quote.
-- Similarly for left and right double quotation marks (“ and ”) in place of ". These can be typed on a mac using Option+[ and Option+Shift+].
+- The unicode  left and right single  quotation marks (‘ and ’ (U+2018 and U+2019, respectively)) have been used in  place of ` and ', where the quotation marks  are intended to  be paired. These can  be typed on  a mac using  Option+] for a left  quote and Option+Shift+] for the right quote.
+- Similarly for left and right double quotation marks (“ and ” (U+201C and U+201D, respectively)) in place of ". These can be typed on a mac using Option+[ and Option+Shift+].


### PR DESCRIPTION
This change fixes two pairs of quotes that were still ASCII ` and ' (instead of the intended left and right single quotes (U+2018 and U+2019)).

(It also clarifies specification of quote characters in the spec's read-me file.)