### PR TITLE
Silence SBT logging about macros and incremental compilation.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -358,6 +358,8 @@ lazy val library = configureAsSubproject(project)
         "-doc-root-content", (sourceDirectory in Compile).value + "/rootdoc.txt"
       )
     },
+    // macros in library+reflect are hard-wired to implementations with `FastTrack`.
+    incOptions := incOptions.value.withRecompileOnMacroDef(false),
     includeFilter in unmanagedResources in Compile := "*.tmpl" | "*.xml" | "*.js" | "*.css" | "rootdoc.txt",
     // Include *.txt files in source JAR:
     mappings in Compile in packageSrc ++= {
@@ -389,6 +391,8 @@ lazy val reflect = configureAsSubproject(project)
   .settings(
     name := "scala-reflect",
     description := "Scala Reflection Library",
+    // macros in library+reflect are hard-wired to implementations with `FastTrack`.
+    incOptions := incOptions.value.withRecompileOnMacroDef(false),
     Osgi.bundleName := "Scala Reflect",
     scalacOptions in Compile in doc ++= Seq(
       "-skip-packages", "scala.reflect.macros.internal:scala.reflect.internal:scala.reflect.io"


### PR DESCRIPTION
Since upgrading to SBT 0.13.12, clean builds have incurred warnings like:

    Because JavaMirrors.scala contains a macro definition, the following
    dependencies are invalidated unconditionally: ....

This commit disables this behaviour of the SBT incremental compiler in
the library and reflect projects, as these aren't regular macros (the
macro implementations are hard coded in the compiler in `FastTrack`)
so the new behaviour isn't actually improving correctness of inc.
compilation.