### PR TITLE
SI-10034: Regression: Make Future.failed(e).failed turn into a success instead of failure

### DIFF
--- a/src/library/scala/concurrent/impl/Promise.scala
+++ b/src/library/scala/concurrent/impl/Promise.scala
@@ -384,7 +384,7 @@ private[concurrent] object Promise {
       private[this] final def thisAs[S]: Future[S] = future.asInstanceOf[Future[S]]
 
       override def onSuccess[U](pf: PartialFunction[T, U])(implicit executor: ExecutionContext): Unit = ()
-      override def failed: Future[Throwable] = thisAs[Throwable]
+      override def failed: Future[Throwable] = KeptPromise(Success(result.exception)).future
       override def foreach[U](f: T => U)(implicit executor: ExecutionContext): Unit = ()
       override def map[S](f: T => S)(implicit executor: ExecutionContext): Future[S] = thisAs[S]
       override def flatMap[S](f: T => Future[S])(implicit executor: ExecutionContext): Future[S] = thisAs[S]

--- a/test/files/jvm/future-spec/FutureTests.scala
+++ b/test/files/jvm/future-spec/FutureTests.scala
@@ -123,7 +123,7 @@ class FutureTests extends MinimalScalaTest {
       assert(f.mapTo[String] eq f, "Future.mapTo must be the same instance as Future.mapTo")
       assert(f.zip(f) eq f, "Future.zip must be the same instance as Future.zip")
       assert(f.flatten eq f, "Future.flatten must be the same instance as Future.flatten")
-      assert(f.failed eq f, "Future.failed must be the same instance as Future.failed")
+      assert(f.failed.value == Some(Success(e)), "Future.failed.failed must become successful") // SI-10034
 
               ECNotUsed(ec => f.foreach(_ => fail("foreach should not have been called"))(ec))
               ECNotUsed(ec => f.onSuccess({ case _ => fail("onSuccess should not have been called") })(ec))


### PR DESCRIPTION
JIRA: https://issues.scala-lang.org/browse/SI-10034

Massive thanks to the reporter who found this >2 year old lurking regression.

I'm surprised the community build didn't catch this, but then OTOH it is a non-happy-path thing.

Review by @retronym ?

Ping @phaller & @heathermiller 