### PR TITLE
SI-10032 Fix code gen with returns in nested try-finally blocks

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -488,16 +488,11 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
           bc emitRETURN returnType
         case nextCleanup :: rest =>
           if (saveReturnValue) {
-            if (insideCleanupBlock) {
-              reporter.warning(r.pos, "Return statement found in finally-clause, discarding its return-value in favor of that of a more deeply nested return.")
-              bc drop returnType
-            } else {
-              // regarding return value, the protocol is: in place of a `return-stmt`, a sequence of `adapt, store, jump` are inserted.
-              if (earlyReturnVar == null) {
-                earlyReturnVar = locals.makeLocal(returnType, "earlyReturnVar")
-              }
-              locals.store(earlyReturnVar)
+            // regarding return value, the protocol is: in place of a `return-stmt`, a sequence of `adapt, store, jump` are inserted.
+            if (earlyReturnVar == null) {
+              earlyReturnVar = locals.makeLocal(returnType, "earlyReturnVar")
             }
+            locals.store(earlyReturnVar)
           }
           bc goTo nextCleanup
           shouldEmitCleanup = true

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -255,7 +255,6 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
     // used by genLoadTry() and genSynchronized()
     var earlyReturnVar: Symbol     = null
     var shouldEmitCleanup          = false
-    var insideCleanupBlock         = false
     // line numbers
     var lastEmittedLineNr          = -1
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSyncAndTry.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSyncAndTry.scala
@@ -36,7 +36,7 @@ abstract class BCodeSyncAndTry extends BCodeBodyBuilder {
       // if the synchronized block returns a result, store it in a local variable.
       // Just leaving it on the stack is not valid in MSIL (stack is cleaned when leaving try-blocks).
       val hasResult = (expectedType != UNIT)
-      val monitorResult: Symbol = if (hasResult) locals.makeLocal(tpeTK(args.head), "monitorResult") else null;
+      val monitorResult: Symbol = if (hasResult) locals.makeLocal(tpeTK(args.head), "monitorResult") else null
 
       /* ------ (1) pushing and entering the monitor, also keeping a reference to it in a local var. ------ */
       genLoadQualifier(fun)
@@ -215,7 +215,7 @@ abstract class BCodeSyncAndTry extends BCodeBodyBuilder {
        * please notice `tmp` has type tree.tpe, while `earlyReturnVar` has the method return type.
        * Because those two types can be different, dedicated vars are needed.
        */
-      val tmp          = if (guardResult) locals.makeLocal(tpeTK(tree), "tmp") else null;
+      val tmp          = if (guardResult) locals.makeLocal(tpeTK(tree), "tmp") else null
 
       /*
        * upon early return from the try-body or one of its EHs (but not the EH-version of the finally-clause)
@@ -238,6 +238,34 @@ abstract class BCodeSyncAndTry extends BCodeBodyBuilder {
       val endTryBody = currProgramPoint()
       bc goTo postHandlers
 
+      /**
+       * A return within a `try` or `catch` block where a `finally` is present ("early return")
+       * emits a store of the result to a local, jump to a "cleanup" version of the `finally` block,
+       * and sets `shouldEmitCleanup = true` (see [[PlainBodyBuilder.genReturn]]).
+       *
+       * If the try-catch is nested, outer `finally` blocks need to be emitted in a cleanup version
+       * as well, so the `shouldEmitCleanup` variable remains `true` until the outermost `finally`.
+       * Nested cleanup `finally` blocks jump to the next enclosing one. For the outermost, we emit
+       * a read of the local variable, a return, and we set `shouldEmitCleanup = false` (see
+       * [[pendingCleanups]]).
+       *
+       * Now, assume we have
+       *
+       *     try { return 1 } finally {
+       *       try { println() } finally { println() }
+       *     }
+       *
+       * Here, the outer `finally` needs a cleanup version, but the inner one does not. The method
+       * here makes sure that `shouldEmitCleanup` is only propagated outwards, not inwards to
+       * nested `finally` blocks.
+       */
+      def withFreshCleanupScope(body: => Unit) = {
+        val savedShouldEmitCleanup = shouldEmitCleanup
+        shouldEmitCleanup = false
+        body
+        shouldEmitCleanup = savedShouldEmitCleanup || shouldEmitCleanup
+      }
+
       /* ------ (2) One EH for each case-clause (this does not include the EH-version of the finally-clause)
        *            An EH in (2) is reached upon abrupt termination of (1).
        *            An EH in (2) is protected by:
@@ -246,8 +274,7 @@ abstract class BCodeSyncAndTry extends BCodeBodyBuilder {
        * ------
        */
 
-      for (ch <- caseHandlers) {
-
+      for (ch <- caseHandlers) withFreshCleanupScope {
         // (2.a) emit case clause proper
         val startHandler = currProgramPoint()
         var endHandler: asm.Label = null
@@ -277,8 +304,12 @@ abstract class BCodeSyncAndTry extends BCodeBodyBuilder {
         protect(startTryBody, endTryBody, startHandler, excType)
         // (2.c) emit jump to the program point where the finally-clause-for-normal-exit starts, or in effect `after` if no finally-clause was given.
         bc goTo postHandlers
-
       }
+
+      // Need to save the state of `shouldEmitCleanup` at this point: while emitting the first
+      // version of the `finally` block below, the variable may become true. But this does not mean
+      // that we need a cleanup version for the current block, only for the enclosing ones.
+      val currentFinallyBlockNeedsCleanup = shouldEmitCleanup
 
       /* ------ (3.A) The exception-handler-version of the finally-clause.
        *              Reached upon abrupt termination of (1) or one of the EHs in (2).
@@ -288,7 +319,7 @@ abstract class BCodeSyncAndTry extends BCodeBodyBuilder {
 
       // a note on terminology: this is not "postHandlers", despite appearances.
       // "postHandlers" as in the source-code view. And from that perspective, both (3.A) and (3.B) are invisible implementation artifacts.
-      if (hasFinally) {
+      if (hasFinally) withFreshCleanupScope {
         nopIfNeeded(startTryBody)
         val finalHandler = currProgramPoint() // version of the finally-clause reached via unhandled exception.
         protect(startTryBody, finalHandler, finalHandler, null)
@@ -316,7 +347,7 @@ abstract class BCodeSyncAndTry extends BCodeBodyBuilder {
       // this is not "postHandlers" either.
       // `shouldEmitCleanup` can be set, and at the same time this try expression may lack a finally-clause.
       // In other words, all combinations of (hasFinally, shouldEmitCleanup) are valid.
-      if (hasFinally && shouldEmitCleanup) {
+      if (hasFinally && currentFinallyBlockNeedsCleanup) {
         val savedInsideCleanup = insideCleanupBlock
         insideCleanupBlock = true
         markProgramPoint(finCleanup)

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSyncAndTry.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSyncAndTry.scala
@@ -348,13 +348,10 @@ abstract class BCodeSyncAndTry extends BCodeBodyBuilder {
       // `shouldEmitCleanup` can be set, and at the same time this try expression may lack a finally-clause.
       // In other words, all combinations of (hasFinally, shouldEmitCleanup) are valid.
       if (hasFinally && currentFinallyBlockNeedsCleanup) {
-        val savedInsideCleanup = insideCleanupBlock
-        insideCleanupBlock = true
         markProgramPoint(finCleanup)
         // regarding return value, the protocol is: in place of a `return-stmt`, a sequence of `adapt, store, jump` are inserted.
         emitFinalizer(finalizer, null, isDuplicate = true)
         pendingCleanups()
-        insideCleanupBlock = savedInsideCleanup
       }
 
       /* ------ (4) finally-clause-for-normal-nonEarlyReturn-exit

--- a/test/files/run/t10032.check
+++ b/test/files/run/t10032.check
@@ -1,0 +1,49 @@
+t10032.scala:72: warning: Return statement found in finally-clause, discarding its return-value in favor of that of a more deeply nested return.
+      finally { return i2 }
+                ^
+t1
+ i1
+ a1
+t2
+ i1
+ a1
+ a2
+ a3
+t3
+ i1
+ a1
+ a3
+t3
+ e1
+ a1
+ i2
+ a2
+ a3
+t4
+ i1
+ i2
+t5
+ i1
+ a1
+ a3
+t5
+ e1
+ a1
+ i2
+ a3
+t6
+ i1
+ i2
+ i3
+t7
+ i1
+ a1
+t7
+ e1
+ i2
+ a1
+t8
+ i1
+ i2
+ a1
+ a2

--- a/test/files/run/t10032.check
+++ b/test/files/run/t10032.check
@@ -1,6 +1,3 @@
-t10032.scala:72: warning: Return statement found in finally-clause, discarding its return-value in favor of that of a more deeply nested return.
-      finally { return i2 }
-                ^
 t1
  i1
  a1
@@ -22,6 +19,9 @@ t3
 t4
  i1
  i2
+t4
+ e1
+ i2
 t5
  i1
  a1
@@ -33,6 +33,10 @@ t5
  a3
 t6
  i1
+ i2
+ i3
+t6
+ e1
  i2
  i3
 t7
@@ -47,3 +51,32 @@ t8
  i2
  a1
  a2
+t8
+ e1
+ i2
+ a1
+ a2
+t9
+ i1
+ i2
+ a1
+t9
+ e1
+ i2
+ a1
+t10
+ i1
+ i2
+ i3
+t10
+ e1
+ i2
+ i3
+t11
+ i1
+ i2
+ a1
+t11
+ e1
+ i2
+ a1

--- a/test/files/run/t10032.scala
+++ b/test/files/run/t10032.scala
@@ -1,0 +1,113 @@
+object Test extends App {
+  def a1(): Unit = println(" a1")
+  def a2(): Unit = println(" a2")
+  def a3(): Unit = println(" a3")
+
+  def i1: Int = { println(" i1"); 1 }
+  def i2: Int = { println(" i2"); 2 }
+  def i3: Int = { println(" i3"); 3 }
+
+  def e1: Int = { println(" e1"); throw new Exception() }
+
+  def t1: Int = {
+    println("t1")
+    try {
+      synchronized { return i1 }
+    } finally {
+      synchronized { a1() }
+    }
+  }
+
+  def t2: Int = {
+    println("t2")
+    try {
+      try { return i1 }
+      finally { a1() }
+    } finally {
+      try { a2() } finally { a3() }
+    }
+  }
+
+  def t3(i: => Int): Int = {
+    println("t3")
+    try {
+      try { return i }
+      finally { a1() }
+    } catch {
+      case _: Throwable =>
+        try { i2 }
+        finally { a2() } // no cleanup version
+    } finally {
+      a3()
+    }
+  }
+
+  def t4: Int = {
+    println("t4")
+    try {
+      return i1
+    } finally {
+      return i2
+    }
+  }
+
+  def t5(i: => Int): Int = {
+    println("t5")
+    try {
+      try {
+        try { return i }
+        finally { a1() }
+      } catch {
+        case _: Throwable => i2
+      }
+    } finally {
+      a3()
+    }
+  }
+
+  def t6: Int = {
+    println("t6")
+    try {
+      try { return i1 }
+      finally { return i2 }
+    } finally {
+      return i3
+    }
+  }
+
+  def t7(i: => Int): Int = {
+    println("t7")
+    try { i }
+    catch {
+      case _: Throwable =>
+        return i2
+    } finally {
+      a1() // cleanup required, early return in handler
+    }
+  }
+
+  def t8(): Int = {
+    println("t8")
+    try {
+      try { i1 }
+      finally {           // no cleanup version
+        try { return i2 }
+        finally { a1() }  // cleanup version required
+      }
+    } finally {           // cleanup version required
+      a2()
+    }
+  }
+
+  assert(t1 == 1)
+  assert(t2 == 1)
+  assert(t3(i1) == 1)
+  assert(t3(e1) == 2)
+  assert(t4 == 2)
+  assert(t5(i1) == 1)
+  assert(t5(e1) == 2)
+  assert(t6 == 3)
+  assert(t7(i1) == 1)
+  assert(t7(e1) == 2)
+  assert(t8 == 2)
+}

--- a/test/files/run/t10032.scala
+++ b/test/files/run/t10032.scala
@@ -24,7 +24,8 @@ object Test extends App {
       try { return i1 }
       finally { a1() }
     } finally {
-      try { a2() } finally { a3() }
+      try { a2() }
+      finally { a3() }
     }
   }
 
@@ -42,10 +43,10 @@ object Test extends App {
     }
   }
 
-  def t4: Int = {
+  def t4(i: => Int): Int = {
     println("t4")
     try {
-      return i1
+      return i
     } finally {
       return i2
     }
@@ -65,10 +66,10 @@ object Test extends App {
     }
   }
 
-  def t6: Int = {
+  def t6(i: => Int): Int = {
     println("t6")
     try {
-      try { return i1 }
+      try { return i }
       finally { return i2 }
     } finally {
       return i3
@@ -86,10 +87,10 @@ object Test extends App {
     }
   }
 
-  def t8(): Int = {
+  def t8(i: => Int): Int = {
     println("t8")
     try {
-      try { i1 }
+      try { i }
       finally {           // no cleanup version
         try { return i2 }
         finally { a1() }  // cleanup version required
@@ -99,15 +100,65 @@ object Test extends App {
     }
   }
 
+  def t9(i: => Int): Int = {
+    println("t9")
+    try {
+      return i
+    } finally {
+      try { return i2 }
+      finally { a1() }
+    }
+  }
+
+  def t10(i: => Int): Int = {
+    println("t10")
+    try {
+      return i
+    } finally {
+      try { return i2 }
+      finally { return i3 }
+    }
+  }
+
+  // this changed semantics between 2.12.0 and 2.12.1, see https://github.com/scala/scala/pull/5509#issuecomment-259291609
+  def t11(i: => Int): Int = {
+    println("t11")
+    try {
+      try { return i }
+      finally { return i2 }
+    } finally {
+      a1()
+    }
+  }
+
   assert(t1 == 1)
+
   assert(t2 == 1)
+
   assert(t3(i1) == 1)
   assert(t3(e1) == 2)
-  assert(t4 == 2)
+
+  assert(t4(i1) == 2)
+  assert(t4(e1) == 2)
+
   assert(t5(i1) == 1)
   assert(t5(e1) == 2)
-  assert(t6 == 3)
+
+  assert(t6(i1) == 3)
+  assert(t6(e1) == 3)
+
   assert(t7(i1) == 1)
   assert(t7(e1) == 2)
-  assert(t8 == 2)
+
+  assert(t8(i1) == 2)
+  assert(t8(e1) == 2)
+
+  assert(t9(i1) == 2)
+  assert(t9(e1) == 2)
+
+  assert(t10(i1) == 3)
+  assert(t10(e1) == 3)
+
+  assert(t11(i1) == 2)
+  assert(t11(e1) == 2)
 }


### PR DESCRIPTION
Return statements within `try` or `catch` blocks need special treatement
if there's also a `finally`

    try { return 1 } finally { println() }

For the return, the code generator emits a store to a local and a jump
to a "cleanup" version of the finally block. There will be 3 versions
of the finally block:

  - One reached through a handler, if the code in the try block
    throws; re-throws at the end
  - A "cleanup" version reached from returns within the try; reads the
    local and returns the value at the end
  - One reached for ordinary control flow, if there's no return and no
    exception within the try

If there are multiple enclosing finally blocks, a "cleanup" version is
emitted for each of them. The nested ones jump to the enclosing ones,
the outermost one reads the local and returns.

A global variable `shouldEmitCleanup` stores whether cleanup versions
are required for the curren finally blocks. By mistake, this variable
was not reset to `false` when emitting a `try-finally` nested within a
`finally`:

    try {
      try { return 1 }
      finally { println() } // need cleanup version
    } finally {             // need cleanup version
      try { println() }
      finally { println() } // no cleanup version needed!
    }

In this commit we ensure that the variable is reset when emitting
nested `try-finally` blocks.