### PR TITLE
don't mass-delete old nightlies at release time

### DIFF
--- a/scripts/jobs/integrate/bootstrap
+++ b/scripts/jobs/integrate/bootstrap
@@ -476,7 +476,7 @@ removeExistingBuilds() {
   local scalaLangModules=`curl -s $storageApiUrl/org/scala-lang | jq -r '.children | .[] | "org/scala-lang" + .uri'`
 
   for module in "org/scalacheck" $scalaLangModules; do
-    local artifacts=`curl -s $storageApiUrl/$module | jq -r ".children | .[] | select(.uri | contains(\"$SCALA_VER\")) | .uri"`
+    local artifacts=`curl -s $storageApiUrl/$module | jq -r ".children | .[] | select(.uri | endswith(\"$SCALA_VER\")) | .uri"`
     for artifact in $artifacts; do
       echo "Deleting $releaseTempRepoUrl$module$artifact"
       curl -s --netrc-file $netrcFile -X DELETE $releaseTempRepoUrl$module$artifact


### PR DESCRIPTION
as happened with 2.12.0, for gory details see
https://github.com/scala/scala-dev/issues/257

fix suggested by Stefan Zeiger