### PR TITLE
improve top-level compiler/reflect doc text

### DIFF
--- a/src/compiler/rootdoc.txt
+++ b/src/compiler/rootdoc.txt
@@ -1,6 +1,1 @@
-The Scala compiler API. 
-
-The following resources are useful for Scala plugin/compiler development:
-  - [[http://www.scala-lang.org/node/215 Scala development tutorials]] on [[http://www.scala-lang.org www.scala-lang.org]] 
-  - [[https://wiki.scala-lang.org/display/SIW/ Scala Internals wiki]] 
-  - [[http://lampwww.epfl.ch/~magarcia/ScalaCompilerCornerReloaded/ Scala compiler corner]], maintained by Miguel 
+The Scala compiler and reflection APIs.


### PR DESCRIPTION
this shows up at http://www.scala-lang.org/api/2.12.0/scala-compiler/

ideally there'd be something better here, but we should at least not
link to egregiously outdated stuff