### PR TITLE
Improved runtime speed for Vector, restoring previous performance.

### DIFF
--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -11,7 +11,6 @@ package scala
 import scala.collection.generic._
 import scala.collection.{ mutable, immutable }
 import mutable.{ ArrayBuilder, ArraySeq }
-import scala.compat.Platform.arraycopy
 import scala.reflect.ClassTag
 import scala.runtime.ScalaRunTime.{ array_apply, array_update }
 
@@ -102,7 +101,7 @@ object Array extends FallbackArrayBuilding {
   def copy(src: AnyRef, srcPos: Int, dest: AnyRef, destPos: Int, length: Int) {
     val srcClass = src.getClass
     if (srcClass.isArray && dest.getClass.isAssignableFrom(srcClass))
-      arraycopy(src, srcPos, dest, destPos, length)
+      java.lang.System.arraycopy(src, srcPos, dest, destPos, length)
     else
       slowcopy(src, srcPos, dest, destPos, length)
   }

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -11,7 +11,6 @@ package collection
 package immutable
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.compat.Platform
 import scala.collection.generic._
 import scala.collection.mutable.{Builder, ReusableBuilder}
 import scala.collection.parallel.immutable.ParVector
@@ -478,12 +477,12 @@ override def companion: GenericCompanion[Vector] = Vector
 //    if (array eq null)
 //      println("OUCH!!! " + right + "/" + depth + "/"+startIndex + "/" + endIndex + "/" + focus)
     val a2 = new Array[AnyRef](array.length)
-    Platform.arraycopy(array, 0, a2, 0, right)
+    java.lang.System.arraycopy(array, 0, a2, 0, right)
     a2
   }
   private def copyRight(array: Array[AnyRef], left: Int): Array[AnyRef] = {
     val a2 = new Array[AnyRef](array.length)
-    Platform.arraycopy(array, left, a2, left, a2.length - left)
+    java.lang.System.arraycopy(array, left, a2, left, a2.length - left)
     a2
   }
 
@@ -955,7 +954,7 @@ private[immutable] trait VectorPointer[T] {
 
     private[immutable] final def copyOf(a: Array[AnyRef]) = {
       val b = new Array[AnyRef](a.length)
-      Platform.arraycopy(a, 0, b, 0, a.length)
+      java.lang.System.arraycopy(a, 0, b, 0, a.length)
       b
     }
 
@@ -1119,7 +1118,7 @@ private[immutable] trait VectorPointer[T] {
 
     private[immutable] final def copyRange(array: Array[AnyRef], oldLeft: Int, newLeft: Int) = {
       val elems = new Array[AnyRef](32)
-      Platform.arraycopy(array, oldLeft, elems, newLeft, 32 - math.max(newLeft,oldLeft))
+      java.lang.System.arraycopy(array, oldLeft, elems, newLeft, 32 - math.max(newLeft,oldLeft))
       elems
     }
 

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -67,7 +67,7 @@ class ArrayBuffer[A](override protected val initialSize: Int)
   override def sizeHint(len: Int) {
     if (len > size && len >= 1) {
       val newarray = new Array[AnyRef](len)
-      scala.compat.Platform.arraycopy(array, 0, newarray, 0, size0)
+      java.lang.System.arraycopy(array, 0, newarray, 0, size0)
       array = newarray
     }
   }

--- a/src/library/scala/collection/mutable/PriorityQueue.scala
+++ b/src/library/scala/collection/mutable/PriorityQueue.scala
@@ -331,8 +331,8 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
     val pq = new PriorityQueue[A]
     val n = resarr.p_size0
     pq.resarr.p_ensureSize(n)
+    java.lang.System.arraycopy(resarr.p_array, 1, pq.resarr.p_array, 1, n-1)
     pq.resarr.p_size0 = n
-    scala.compat.Platform.arraycopy(resarr.p_array, 1, pq.resarr.p_array, 1, n-1)
     pq
   }
 }

--- a/src/library/scala/collection/mutable/ResizableArray.scala
+++ b/src/library/scala/collection/mutable/ResizableArray.scala
@@ -101,7 +101,7 @@ trait ResizableArray[A] extends IndexedSeq[A]
       if (newSize > Int.MaxValue) newSize = Int.MaxValue
 
       val newArray: Array[AnyRef] = new Array(newSize.toInt)
-      scala.compat.Platform.arraycopy(array, 0, newArray, 0, size0)
+      java.lang.System.arraycopy(array, 0, newArray, 0, size0)
       array = newArray
     }
   }

--- a/src/reflect/scala/reflect/internal/BaseTypeSeqs.scala
+++ b/src/reflect/scala/reflect/internal/BaseTypeSeqs.scala
@@ -100,7 +100,7 @@ trait BaseTypeSeqs {
 
     def copy(head: Type, offset: Int): BaseTypeSeq = {
       val arr = new Array[Type](elems.length + offset)
-      scala.compat.Platform.arraycopy(elems, 0, arr, offset, elems.length)
+      java.lang.System.arraycopy(elems, 0, arr, offset, elems.length)
       arr(0) = head
       newBaseTypeSeq(parents, arr)
     }

--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -68,7 +68,7 @@ trait Names extends api.Names {
     while (i < len) {
       if (nc + i == chrs.length) {
         val newchrs = new Array[Char](chrs.length * 2)
-        scala.compat.Platform.arraycopy(chrs, 0, newchrs, 0, chrs.length)
+        java.lang.System.arraycopy(chrs, 0, newchrs, 0, chrs.length)
         chrs = newchrs
       }
       chrs(nc + i) = cs(offset + i)
@@ -220,7 +220,7 @@ trait Names extends api.Names {
 
     /** Copy bytes of this name to buffer cs, starting at position `offset`. */
     final def copyChars(cs: Array[Char], offset: Int) =
-      scala.compat.Platform.arraycopy(chrs, index, cs, offset, len)
+      java.lang.System.arraycopy(chrs, index, cs, offset, len)
 
     /** @return the ascii representation of this name */
     final def toChars: Array[Char] = {  // used by ide


### PR DESCRIPTION
copyOf was redirected to java.util.Arrays.copyOf to reduce the work that the JIT compiler has to do to make this work well.

zeroLeft, zeroRight, copyLeft, and copyRight were made private[this] to improve performance (presumably by encouraging the JIT compiler to try harder despite using the new trait encoding scheme).

Checks of performance were conducted with Thyme to aid iteration speed.
