### PR TITLE
Improve support for enum trees

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -337,8 +337,12 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
             genLoadQualUnlessElidable()
             genLoadModule(tree)
           } else if (sym.isStaticMember) {
-            genLoadQualUnlessElidable()
-            fieldLoad(sym, receiverClass)
+            if (sym.isJavaEnum) {
+              fieldLoad(sym, receiverClass.companionClass)
+            } else {
+              genLoadQualUnlessElidable()
+              fieldLoad(sym, receiverClass)
+            }
           } else {
             genLoadQualifier(tree)
             fieldLoad(sym, receiverClass)

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -385,18 +385,16 @@ abstract class BCodeHelpers extends BCodeIdiomatic with BytecodeWriters {
   /*
    *  must-single-thread
    */
-  def fieldSymbols(cls: Symbol): List[Symbol] = {
+  def fieldSymbols(cls: Symbol): List[Symbol] =
     for (f <- cls.info.decls.toList ;
          if !f.isMethod && f.isTerm && !f.isModule
     ) yield f
-  }
 
   /*
    * can-multi-thread
    */
-  def methodSymbols(cd: ClassDef): List[Symbol] = {
+  def methodSymbols(cd: ClassDef): List[Symbol] =
     cd.impl.body collect { case dd: DefDef => dd.symbol }
-  }
 
   /*
    *  must-single-thread

--- a/src/compiler/scala/tools/nsc/transform/Fields.scala
+++ b/src/compiler/scala/tools/nsc/transform/Fields.scala
@@ -84,7 +84,7 @@ abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransfor
     else synthFieldsAndAccessors(tp)
 
   // TODO: drop PRESUPER support when we implement trait parameters in 2.13
-  private def excludedAccessorOrFieldByFlags(statSym: Symbol): Boolean = statSym hasFlag PRESUPER
+  private def excludedAccessorOrFieldByFlags(statSym: Symbol): Boolean = statSym hasFlag PRESUPER | JAVA_ENUM
 
   // used for internal communication between info and tree transform of this phase -- not pickled, not in initialflags
   // TODO: reuse MIXEDIN for NEEDS_TREES?
@@ -158,7 +158,7 @@ abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransfor
     // Note that a strict unit-typed val does receive a field, because we cannot omit the write to the field
     // (well, we could emit it for non-@volatile ones, if I understand the memory model correctly,
     //  but that seems pretty edge-casey)
-    val constantTyped = tp.isInstanceOf[ConstantType]
+    val constantTyped = tp.isInstanceOf[ConstantType] && tp.asInstanceOf[ConstantType].value.tag != EnumTag
   }
 
   private def fieldTypeForGetterIn(getter: Symbol, pre: Type): Type = getter.info.finalResultType.asSeenFrom(pre, getter.owner)
@@ -343,7 +343,7 @@ abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransfor
           }
         }
 
-        if (newDecls nonEmpty) {
+        if (newDecls.nonEmpty) {
           val allDecls = newScope
           origDecls foreach allDecls.enter
           newDecls  foreach allDecls.enter

--- a/src/compiler/scala/tools/nsc/transform/Flatten.scala
+++ b/src/compiler/scala/tools/nsc/transform/Flatten.scala
@@ -17,8 +17,7 @@ abstract class Flatten extends InfoTransform {
   /** the following two members override abstract members in Transform */
   val phaseName: String = "flatten"
 
-  /** Updates the owning scope with the given symbol, unlinking any others.
-   */
+  /** Updates the owning scope with the given symbol, unlinking any others. */
   private def replaceSymbolInCurrentScope(sym: Symbol): Unit = exitingFlatten {
     removeSymbolInCurrentScope(sym)
     sym.owner.info.decls enter sym

--- a/src/compiler/scala/tools/nsc/transform/InfoTransform.scala
+++ b/src/compiler/scala/tools/nsc/transform/InfoTransform.scala
@@ -36,9 +36,9 @@ trait InfoTransform extends Transform {
         val pid = id
         val changesBaseClasses = InfoTransform.this.changesBaseClasses
         def transform(sym: Symbol, tpe: Type): Type = transformInfo(sym, tpe)
+        override def toString = InfoTransform.this.getClass.toString
       }
       infoTransformers insert infoTransformer
     }
   }
 }
-

--- a/src/compiler/scala/tools/nsc/transform/Statics.scala
+++ b/src/compiler/scala/tools/nsc/transform/Statics.scala
@@ -5,8 +5,7 @@ abstract class Statics extends Transform with ast.TreeDSL {
   import global._
 
   trait StaticsTransformer extends Transformer {
-    /** generate a static constructor with symbol fields inits, or an augmented existing static ctor
-      */
+    /** generate a static constructor with symbol fields inits, or an augmented existing static ctor */
     def staticConstructor(body: List[Tree], localTyper: analyzer.Typer, pos: Position)(newStaticInits: List[Tree]): Tree =
       body.collectFirst {
         // If there already was a static ctor - augment existing one

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -436,7 +436,7 @@ trait Contexts { self: Analyzer =>
      * Construct a child context. The parent and child will share the report buffer.
      * Compare with `makeSilent`, in which the child has a fresh report buffer.
      *
-     * If `tree` is an `Import`, that import will be avaiable at the head of
+     * If `tree` is an `Import`, that import will be available at the head of
      * `Context#imports`.
      */
     def make(tree: Tree = tree, owner: Symbol = owner,

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -665,9 +665,14 @@ trait Namers extends MethodSynthesis {
       if (isScala && deriveAccessors(tree)) enterGetterSetter(tree)
       else assignAndEnterFinishedSymbol(tree)
 
+      val sym = tree.symbol
+
       if (isEnumConstant(tree)) {
-        tree.symbol setInfo ConstantType(Constant(tree.symbol))
-        tree.symbol.owner.linkedClassOfClass addChild tree.symbol
+        sym setInfo ConstantType(Constant(sym))
+        if (sym.isJavaDefined)
+          sym.owner.linkedClassOfClass addChild sym
+        else
+          sym.owner addChild sym
       }
     }
 

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -519,7 +519,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
     /** Does the context of tree `tree` require a stable type?
      */
-    private def isStableContext(tree: Tree, mode: Mode, pt: Type) = {
+    private def isStableContext(tree: Tree, mode: Mode, pt: Type): Boolean = {
       def ptSym = pt.typeSymbol
       def expectsStable = (
            pt.isStable
@@ -1165,7 +1165,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         case atp @ AnnotatedType(_, _) if canAdaptAnnotations(tree, this, mode, pt) => // (-1)
           adaptAnnotations(tree, this, mode, pt)
         case ct @ ConstantType(value) if mode.inNone(TYPEmode | FUNmode) && (ct <:< pt) && canAdaptConstantTypeToLiteral => // (0)
-          adaptConstant(value)
+          if (value.tag == EnumTag) tree
+          else adaptConstant(value)
         case OverloadedType(pre, alts) if !mode.inFunMode => // (1)
           inferExprAlternative(tree, pt)
           adaptAfterOverloadResolution(tree, mode, pt, original)
@@ -1797,11 +1798,12 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
     def typedClassDef(cdef: ClassDef): Tree = {
       val clazz = cdef.symbol
+      val templ = cdef.impl
       val typedMods = typedModifiers(cdef.mods)
       assert(clazz != NoSymbol, cdef)
       reenterTypeParams(cdef.tparams)
       val tparams1 = cdef.tparams mapConserve (typedTypeDef)
-      val impl1 = newTyper(context.make(cdef.impl, clazz, newScope)).typedTemplate(cdef.impl, typedParentTypes(cdef.impl))
+      val impl1 = newTyper(context.make(templ, clazz, newScope)).typedTemplate(templ, typedParentTypes(templ))
       val impl2 = finishMethodSynthesis(impl1, clazz, context)
       if (clazz.isTrait && clazz.info.parents.nonEmpty && clazz.info.firstParent.typeSymbol == AnyClass)
         checkEphemeral(clazz, impl2.body)
@@ -4781,11 +4783,14 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             if (isStableContext(tree, mode, pt)) tree setType clazz.thisType else tree
         }
 
+      def isEligibleForJavaStatic(cls: Symbol): Boolean =
+        ((context.unit.isJava && cls.isClass) || (cls != null && cls.companionClass.isJavaEnum && cls.isModule)) && !cls.isModuleClass
+
 
       // For Java, instance and static members are in the same scope, but we put the static ones in the companion object
       // so, when we can't find a member in the class scope, check the companion
       def inCompanionForJavaStatic(pre: Type, cls: Symbol, name: Name): Symbol =
-        if (!(context.unit.isJava && cls.isClass && !cls.isModuleClass)) NoSymbol else {
+        if (!isEligibleForJavaStatic(cls)) NoSymbol else {
           val companion = companionSymbolOf(cls, context)
           if (!companion.exists) NoSymbol
           else member(gen.mkAttributedRef(pre, companion), name) // assert(res.isStatic, s"inCompanionJavaStatic($pre, $cls, $name) = $res ${res.debugFlagString}")
@@ -4983,14 +4988,13 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                 }
           case LookupSucceeded(qual, sym)   =>
             (// this -> Foo.this
-            if (sym.isThisSym)
+            if (sym.isThisSym) {
               typed1(This(sym.owner) setPos tree.pos, mode, pt)
-            else if (isPredefClassOf(sym) && pt.typeSymbol == ClassClass && pt.typeArgs.nonEmpty) {
+            } else if (isPredefClassOf(sym) && pt.typeSymbol == ClassClass && pt.typeArgs.nonEmpty) {
               // Inferring classOf type parameter from expected type.  Otherwise an
               // actual call to the stubbed classOf method is generated, returning null.
               typedClassOf(tree, TypeTree(pt.typeArgs.head).setPos(tree.pos.focus))
-            }
-          else {
+            } else {
               val pre1  = if (sym.isTopLevel) sym.owner.thisType else if (qual == EmptyTree) NoPrefix else qual.tpe
               val tree1 = if (qual == EmptyTree) tree else atPos(tree.pos)(Select(atPos(tree.pos.focusStart)(qual), name))
               val (tree2, pre2) = makeAccessible(tree1, sym, pre1, qual)
@@ -5554,12 +5558,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     def atOwner(tree: Tree, owner: Symbol): Typer =
       newTyper(context.make(tree, owner))
 
-    /** Types expression or definition `tree`.
-     */
-    def typed(tree: Tree): Tree = {
-      val ret = typed(tree, context.defaultModeForTyped, WildcardType)
-      ret
-    }
+    /** Types expression or definition `tree`. */
+    def typed(tree: Tree): Tree =
+      typed(tree, context.defaultModeForTyped, WildcardType)
 
     def typedByValueExpr(tree: Tree, pt: Type = WildcardType): Tree = typed(tree, EXPRmode | BYVALmode, pt)
 

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -970,7 +970,10 @@ trait Definitions extends api.StandardDefinitions {
       //  - .owner: the ModuleClassSymbol of the enumeration (object E)
       //  - .linkedClassOfClass: the ClassSymbol of the enumeration (class E)
       // SI-6613 Subsequent runs of the resident compiler demand the phase discipline here.
-      enteringPhaseNotLaterThan(picklerPhase)(sym.owner.linkedClassOfClass).tpe
+      if (sym.isJavaDefined)
+        enteringPhaseNotLaterThan(picklerPhase)(sym.owner.linkedClassOfClass).tpe
+      else
+        enteringPhaseNotLaterThan(picklerPhase)(sym.owner).tpe
     }
 
     /** Given a class symbol C with type parameters T1, T2, ... Tn


### PR DESCRIPTION
These are the minimal changes required to allow macro authors to emit
trees that end up as valid JVM enums in the backend.