### PR TITLE
SI-9507 Make Stream #:: and #::: allow type widening

### DIFF
--- a/src/library/scala/collection/immutable/Stream.scala
+++ b/src/library/scala/collection/immutable/Stream.scala
@@ -1119,11 +1119,11 @@ object Stream extends SeqFactory[Stream] {
     /** Construct a stream consisting of a given first element followed by elements
      *  from a lazily evaluated Stream.
      */
-    def #::(hd: A): Stream[A] = cons(hd, tl)
+    def #::[B >: A](hd: B): Stream[B] = cons(hd, tl)
     /** Construct a stream consisting of the concatenation of the given stream and
      *  a lazily evaluated Stream.
      */
-    def #:::(prefix: Stream[A]): Stream[A] = prefix append tl
+    def #:::[B >: A](prefix: Stream[B]): Stream[B] = prefix append tl
   }
 
   /** A wrapper method that adds `#::` for cons and `#:::` for concat as operations

--- a/test/junit/scala/collection/immutable/StreamTest.scala
+++ b/test/junit/scala/collection/immutable/StreamTest.scala
@@ -117,4 +117,10 @@ class StreamTest {
     assert((0 #:: 1 #:: s) == (0 #:: 1 #:: s), "Cons of referentially identical streams should be equal (==)")
     assert((0 #:: 1 #:: s) equals (0 #:: 1 #:: s), "Cons of referentially identical streams should be equal (equals)")
   }
+
+  @Test
+  def t9886: Unit = {
+    assertEquals(Stream(None, Some(1)), None #:: Stream(Some(1)))
+    assertEquals(Stream(None, Some(1)), Stream(None) #::: Stream(Some(1)))
+  }
 }


### PR DESCRIPTION
Self explanatory; simply adds a `[B >: A]` type parameter to `#::` and `#:::`, as suggested in [SI-9886](https://issues.scala-lang.org/browse/SI-9886).

This PR targets 2.13 as I'm not 100% sure if this change leads to binary or source incompatibility. If you think this change can be included in Scala 2.12, please tell me and I'll rebase this.