### PR TITLE
String.replaceAllLiterally is literally String.replace

### DIFF
--- a/src/library/scala/collection/immutable/StringLike.scala
+++ b/src/library/scala/collection/immutable/StringLike.scala
@@ -165,20 +165,14 @@ self =>
     if (toString.endsWith(suffix)) toString.substring(0, toString.length() - suffix.length)
     else toString
 
-  /** Replace all literal occurrences of `literal` with the string `replacement`.
-   *  This is equivalent to [[java.lang.String#replaceAll]] except that both arguments
-   *  are appropriately quoted to avoid being interpreted as metacharacters.
+  /** Replace all literal occurrences of `literal` with the literal string `replacement`.
+   *  This method is equivalent to [[java.lang.String#replace]].
    *
    *  @param    literal     the string which should be replaced everywhere it occurs
    *  @param    replacement the replacement string
    *  @return               the resulting string
    */
-  def replaceAllLiterally(literal: String, replacement: String): String = {
-    val arg1 = Regex.quote(literal)
-    val arg2 = Regex.quoteReplacement(replacement)
-
-    toString.replaceAll(arg1, arg2)
-  }
+  def replaceAllLiterally(literal: String, replacement: String): String = toString.replace(literal, replacement)
 
   /** For every line in this string:
    *


### PR DESCRIPTION
The method is not deprecated outright because it avoids
the overloaded equivalent.

`replaceAllLiterally` literally just replaces `replace`. Arguably its name is more expressive.

A really useful extension would be `replaceAllAlliteratively`.