### PR TITLE
Avoid double-compiling junit sources

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -558,6 +558,7 @@ lazy val junit = project.in(file("test") / "junit")
     libraryDependencies ++= Seq(junitDep, junitInterfaceDep, jolDep),
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
     // testFrameworks -= new TestFramework("org.scalacheck.ScalaCheckFramework"),
+    unmanagedSourceDirectories in Compile := Nil,
     unmanagedSourceDirectories in Test := List(baseDirectory.value)
   )
 


### PR DESCRIPTION
Fixes scala/scala-dev#266