### PR TITLE
SI-10060 Fixes NumericRange.max bug on empty ranges

### DIFF
--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -115,14 +115,14 @@ extends AbstractSeq[T] with IndexedSeq[T] with Serializable {
 
   override def min[T1 >: T](implicit ord: Ordering[T1]): T =
     if (ord eq defaultOrdering(num)) {
-      if (num.signum(step) > 0) start
+      if (num.signum(step) > 0) head
       else last
     } else super.min(ord)
 
   override def max[T1 >: T](implicit ord: Ordering[T1]): T =
     if (ord eq defaultOrdering(num)) {
       if (num.signum(step) > 0) last
-      else start
+      else head
     } else super.max(ord)
 
   // Motivated by the desire for Double ranges with BigDecimal precision,

--- a/test/junit/scala/collection/immutable/RangeTest.scala
+++ b/test/junit/scala/collection/immutable/RangeTest.scala
@@ -11,17 +11,29 @@ class RangeTest {
   import AssertUtil._
 
   @Test
-  def test_SI10060_long_max(): Unit = {
+  def test_SI10060_numeric_range_min_max(): Unit = {
+    assertEquals(Range.Long.inclusive(1, 9, 1).min, 1)
+    assertEquals(Range.Long.inclusive(1, 9, 1).max, 9)
+    assertEquals(Range.Long.inclusive(9, 1, -1).min, 1)
+    assertEquals(Range.Long.inclusive(9, 1, -1).max, 9)
+    assertThrows[java.util.NoSuchElementException](Range.Long.inclusive(1, 9, -1).min)
+    assertThrows[java.util.NoSuchElementException](Range.Long.inclusive(1, 9, -1).max)
+    assertThrows[java.util.NoSuchElementException](Range.Long.inclusive(9, 1, 1).min)
+    assertThrows[java.util.NoSuchElementException](Range.Long.inclusive(9, 1, 1).max)
+
     assertEquals(Range.Int.inclusive(1, 9, 1).min, 1)
     assertEquals(Range.Int.inclusive(1, 9, 1).max, 9)
+    assertEquals(Range.Int.inclusive(9, 1, -1).min, 1)
+    assertEquals(Range.Int.inclusive(9, 1, -1).max, 9)
     assertThrows[java.util.NoSuchElementException](Range.Int.inclusive(1, 9, -1).min)
     assertThrows[java.util.NoSuchElementException](Range.Int.inclusive(1, 9, -1).max)
     assertThrows[java.util.NoSuchElementException](Range.Int.inclusive(9, 1, 1).min)
     assertThrows[java.util.NoSuchElementException](Range.Int.inclusive(9, 1, 1).max)
 
-
     assertEquals(Range.inclusive(1, 9, 1).min, 1)
     assertEquals(Range.inclusive(1, 9, 1).max, 9)
+    assertEquals(Range.inclusive(9, 1, -1).min, 1)
+    assertEquals(Range.inclusive(9, 1, -1).max, 9)
     assertThrows[java.util.NoSuchElementException](Range.inclusive(1, 9, -1).min)
     assertThrows[java.util.NoSuchElementException](Range.inclusive(1, 9, -1).max)
     assertThrows[java.util.NoSuchElementException](Range.inclusive(9, 1, 1).min)

--- a/test/junit/scala/collection/immutable/RangeTest.scala
+++ b/test/junit/scala/collection/immutable/RangeTest.scala
@@ -1,0 +1,30 @@
+package scala.collection.immutable
+
+import org.junit.{Assert, Test}
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import scala.tools.testing.AssertUtil
+
+@RunWith(classOf[JUnit4])
+class RangeTest {
+  import Assert._
+  import AssertUtil._
+
+  @Test
+  def test_SI10060_long_max(): Unit = {
+    assertEquals(Range.Int.inclusive(1, 9, 1).min, 1)
+    assertEquals(Range.Int.inclusive(1, 9, 1).max, 9)
+    assertThrows[java.util.NoSuchElementException](Range.Int.inclusive(1, 9, -1).min)
+    assertThrows[java.util.NoSuchElementException](Range.Int.inclusive(1, 9, -1).max)
+    assertThrows[java.util.NoSuchElementException](Range.Int.inclusive(9, 1, 1).min)
+    assertThrows[java.util.NoSuchElementException](Range.Int.inclusive(9, 1, 1).max)
+
+
+    assertEquals(Range.inclusive(1, 9, 1).min, 1)
+    assertEquals(Range.inclusive(1, 9, 1).max, 9)
+    assertThrows[java.util.NoSuchElementException](Range.inclusive(1, 9, -1).min)
+    assertThrows[java.util.NoSuchElementException](Range.inclusive(1, 9, -1).max)
+    assertThrows[java.util.NoSuchElementException](Range.inclusive(9, 1, 1).min)
+    assertThrows[java.util.NoSuchElementException](Range.inclusive(9, 1, 1).max)
+  }
+}


### PR DESCRIPTION
As described in [SI-10060](https://issues.scala-lang.org/browse/SI-10060)
`Range.Int.inclusive(1, 9, -1).max` returns `1` instead of throwing an exception.