### PR TITLE
SI-9915 Fix test on windows

### DIFF
--- a/test/files/run/t9915/C_1.java
+++ b/test/files/run/t9915/C_1.java
@@ -1,4 +1,6 @@
-
+/*
+ * javac: -encoding UTF-8
+ */
 public class C_1 {
     public static final String NULLED = "X\000ABC";
     public static final String SUPPED = "𐒈𐒝𐒑𐒛𐒐𐒘𐒕𐒖";


### PR DESCRIPTION
Use `javac: -encoding UTF-8` tool args comment
so javac uses correct source encoding.

Review by @SethTisue 