### PR TITLE
SI-10059 reset the `DEFERRED` flag for Java varargs forwarders

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -747,7 +747,7 @@ abstract class UnCurry extends InfoTransform
       if (!dd.symbol.hasAnnotation(VarargsClass) || !enteringUncurry(mexists(dd.symbol.paramss)(sym => definitions.isRepeatedParamType(sym.tpe))))
         return flatdd
 
-      val forwSym = currentClass.newMethod(dd.name.toTermName, dd.pos, VARARGS | SYNTHETIC | flatdd.symbol.flags)
+      val forwSym = currentClass.newMethod(dd.name.toTermName, dd.pos, VARARGS | SYNTHETIC | flatdd.symbol.flags & ~DEFERRED)
 
       val isRepeated = enteringUncurry(dd.symbol.info.paramss.flatten.map(sym => definitions.isRepeatedParamType(sym.tpe)))
 

--- a/test/files/run/t10059/A.java
+++ b/test/files/run/t10059/A.java
@@ -1,0 +1,3 @@
+public class A {
+  public static int foo(T t) { return t.m(1, 2, 3); }
+}

--- a/test/files/run/t10059/Test.scala
+++ b/test/files/run/t10059/Test.scala
@@ -1,0 +1,9 @@
+abstract class T {
+  @annotation.varargs def m(l: Int*): Int
+}
+class C extends T {
+  override def m(l: Int*): Int = 1
+}
+object Test extends App {
+  assert(A.foo(new C) == 1)
+}


### PR DESCRIPTION
When an abstract method is annotated `@varargs`, make sure that the
generated synthetic Java varargs method does not have the `DEFERRED`
flag (`ACC_ABSTRACT` in bytecode).

The flag lead to an NPE in the code generator, because the ASM framework
leaves certain fields `null` for abstract methods (`localVariables` in
this case).

Interestingly this did not crash in 2.11.x: the reason is that the test
whether to emit a method body or not has changed in the 2.12 backend
(in c8e6050).

    val isAbstractMethod = [..] methSymbol.isDeferred [..] // 2.11
    val isAbstractMethod = rhs == EmptyTree                // 2.12

So in 2.11, the varargs forwarder method was actually left abstract in
bytecode, leading to an `AbstractMethodError: T.m([I)I` at run-time.