### PR TITLE
Fix more compiler crashes with fields, refinement types

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/AccessorSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/transform/AccessorSynthesis.scala
@@ -332,7 +332,7 @@ trait AccessorSynthesis extends Transform with ast.TreeDSL {
 
         val isUnit    = isUnitGetter(lazyAccessor)
         val selectVar = if (isUnit) UNIT         else Select(thisRef, lazyVar)
-        val storeRes  = if (isUnit) rhsAtSlowDef else Assign(selectVar, rhsAtSlowDef)
+        val storeRes  = if (isUnit) rhsAtSlowDef else Assign(selectVar, fields.castHack(rhsAtSlowDef, lazyVar.info))
 
         def needsInit = mkTest(lazyAccessor)
         val doInit = Block(List(storeRes), mkSetFlag(lazyAccessor))

--- a/test/files/pos/sd268.scala
+++ b/test/files/pos/sd268.scala
@@ -1,0 +1,17 @@
+class Context(val v : AnyRef)
+
+trait AbidePlugin {
+  val someVal = ""
+
+       val x = null.asInstanceOf[Context { val v : someVal.type }] // CRASH
+  lazy val y = null.asInstanceOf[Context { val v : someVal.type }] // CRASH
+       var z = null.asInstanceOf[Context { val v : someVal.type }] // CRASH
+}
+
+class C {
+  val someVal = ""
+
+       val x = null.asInstanceOf[Context { val v : someVal.type }]
+  lazy val y = null.asInstanceOf[Context { val v : someVal.type }] // CRASH
+       var z = null.asInstanceOf[Context { val v : someVal.type }]
+}


### PR DESCRIPTION
In the same manner as scala/scala-dev#219, the placement of the fields
phase after uncurry is presenting some challenges in keeping our trees
type correct.

This commit whacks a few more moles by adding a casts in the body of
synthetic methods.

Fixes scala/scala-dev#268