### PR TITLE
Providing minimalistic & controlled kind-polymorphism [ci: last-only]

### DIFF
--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -42,6 +42,10 @@ filter {
     {
       matchName="scala.util.hashing.MurmurHash3.wrappedArrayHash"
       problemName=DirectMissingMethodProblem
+    },
+    {
+      matchName="scala.reflect.runtime.Settings.YkindPolymorphism"
+      problemName=DirectMissingMethodProblem
     }
   ]
 }

--- a/src/compiler/scala/reflect/reify/Reifier.scala
+++ b/src/compiler/scala/reflect/reify/Reifier.scala
@@ -110,7 +110,7 @@ abstract class Reifier extends States
       // needs to be solved some day
       // upd. a new hope: https://groups.google.com/forum/#!topic/scala-internals/TtCTPlj_qcQ
       var importantSymbols = Set[Symbol](
-        NothingClass, AnyClass, SingletonClass, PredefModule, ScalaRunTimeModule, TypeCreatorClass, TreeCreatorClass, MirrorClass,
+        NothingClass, AnyClass, SingletonClass, AnyKindClass, PredefModule, ScalaRunTimeModule, TypeCreatorClass, TreeCreatorClass, MirrorClass,
         ApiUniverseClass, JavaUniverseClass, ReflectRuntimePackage, runDefinitions.ReflectRuntimeCurrentMirror)
       importantSymbols ++= importantSymbols map (_.companionSymbol)
       importantSymbols ++= importantSymbols map (_.moduleClass)

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -30,7 +30,7 @@ trait ScalaSettings extends AbsScalaSettings
   protected def defaultClasspath = sys.env.getOrElse("CLASSPATH", ".")
 
   /** Enabled under -Xexperimental. */
-  protected def experimentalSettings = List[BooleanSetting](YpartialUnification)
+  protected def experimentalSettings = List[BooleanSetting](YpartialUnification, YkindPolymorphism)
 
   /** Enabled under -Xfuture. */
   protected def futureSettings = List[BooleanSetting]()
@@ -217,6 +217,7 @@ trait ScalaSettings extends AbsScalaSettings
   val YdisableFlatCpCaching  = BooleanSetting    ("-YdisableFlatCpCaching", "Do not cache flat classpath representation of classpath elements from jars across compiler instances.")
   val YpartialUnification = BooleanSetting ("-Ypartial-unification", "Enable partial unification in type constructor inference")
   val Yvirtpatmat     = BooleanSetting    ("-Yvirtpatmat", "Enable pattern matcher virtualization")
+  val YkindPolymorphism = BooleanSetting ("-Ykind-polymorphism", "Enable kind polymorphism")
 
   val exposeEmptyPackage = BooleanSetting ("-Yexpose-empty-package", "Internal only: expose the empty package.").internalOnly()
   val Ydelambdafy        = ChoiceSetting  ("-Ydelambdafy", "strategy", "Strategy used for translating lambdas into JVM code.", List("inline", "method"), "method")

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -146,7 +146,7 @@ abstract class Erasure extends InfoTransform
         if (sym == ArrayClass && args.nonEmpty)
           if (unboundedGenericArrayLevel(tp1) == 1) ObjectTpe
           else mapOver(tp1)
-        else if (sym == AnyClass || sym == AnyValClass || sym == SingletonClass)
+        else if (sym == AnyClass || sym == AnyValClass || sym == SingletonClass || sym == AnyKindClass)
           ObjectTpe
         else if (sym == UnitClass)
           BoxedUnitTpe
@@ -308,7 +308,7 @@ abstract class Erasure extends InfoTransform
             assert(!sym.isAliasType, "Unexpected alias type: " + sym)
             "" + TVAR_TAG + sym.name + ";"
           }
-          else if (sym == AnyClass || sym == AnyValClass || sym == SingletonClass)
+          else if (sym == AnyClass || sym == AnyValClass || sym == SingletonClass || sym == AnyKindClass)
             jsig(ObjectTpe)
           else if (sym == UnitClass)
             jsig(BoxedUnitTpe)

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -468,7 +468,10 @@ abstract class RefChecks extends Transform {
             overrideError("cannot be used here - term macros cannot override abstract methods")
           } else if (other.isTermMacro && !member.isTermMacro) { // (1.10)
             overrideError("cannot be used here - only term macros can override term macros")
-          } else {
+          } else if (other.tpe.isComplete && other.tpe.typeSymbol.isNonBottomSubClass(definitions.AnyKindClass)) {
+            // a AnyKind bounded type can be overriden by a type not bounded by AnyKind (this is the purpose of it)
+          }
+            else {
             checkOverrideTypes()
             checkOverrideDeprecated()
             if (settings.warnNullaryOverride) {

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -170,7 +170,10 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
           val res =
             if (paramFailed || (paramTp.isErroneous && {paramFailed = true; true})) SearchFailure
-            else inferImplicitFor(paramTp, fun, context, reportAmbiguous = context.reportErrors)
+            else {
+              inferImplicitFor(paramTp, fun, context, reportAmbiguous = context.reportErrors)
+            }
+          
           argResultsBuff += res
 
           if (res.isSuccess) {
@@ -590,7 +593,6 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
      *  4. Give getClass calls a more precise type based on the type of the target of the call.
      */
     protected def stabilize(tree: Tree, pre: Type, mode: Mode, pt: Type): Tree = {
-
       // Side effect time! Don't be an idiot like me and think you
       // can move "val sym = tree.symbol" before this line, because
       // inferExprAlternative side-effects the tree's symbol.
@@ -828,7 +830,6 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     protected def adapt(tree: Tree, mode: Mode, pt: Type, original: Tree = EmptyTree): Tree = {
       def hasUndets           = context.undetparams.nonEmpty
       def hasUndetsInMonoMode = hasUndets && !mode.inPolyMode
-
       def adaptToImplicitMethod(mt: MethodType): Tree = {
         if (hasUndets) { // (9) -- should revisit dropped condition `hasUndetsInMonoMode`
           // dropped so that type args of implicit method are inferred even if polymorphic expressions are allowed
@@ -952,6 +953,15 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           case _                       => pt == WildcardType
         }
 
+        // should be recursive for checking kind of all subtypes
+        def kpBadKindArityMatches(tparams: List[Symbol], targs: List[Type]): List[(Symbol, Type)] = {
+          tparams.zip(targs).flatMap { case (tparam, targ) =>
+            if (isAnyKind(tparam.tpe)) List()
+            else if (!sameLength(targ.typeParams, tparam.typeParams)) List(tparam -> targ)
+            else kpBadKindArityMatches(tparam.typeParams, targ.typeParams.map(_.tpe))
+          }
+        }
+
         // todo. It would make sense when mode.inFunMode to instead use
         //    tree setType tree.tpe.normalize
         // when typechecking, say, TypeApply(Ident(`some abstract type symbol`), List(...))
@@ -959,13 +969,35 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         // but this needs additional investigation, because it crashes t5228, gadts1 and maybe something else
         if (mode.inFunMode)
           tree
-        else if (properTypeRequired && tree.symbol.typeParams.nonEmpty)  // (7)
+        else if (properTypeRequired && tree.symbol.typeParams.nonEmpty)  // (7) 
           MissingTypeParametersError(tree)
-        else if (kindArityMismatch && !kindArityMismatchOk)  // (7.1) @M: check kind-arity
+        else if (kindArityMismatch && !kindArityMismatchOk) // (7.1) @M: check kind-arity                       
           KindArityMismatchError(tree, pt)
         else tree match { // (6)
           case TypeTree() => tree
-          case _          => TypeTree(tree.tpe) setOriginal tree
+          case _          =>
+            if(settings.YkindPolymorphism) {
+              // we exclude RefinedClasses because in kind-polymorphic cases, it can happen
+              // type Kinder.Aux[H, M, HL0] = Kinder[H]{type M = M; type Args = HL0} gives
+              // isRefinementClass:true tree.tpe.typeSymbol:<refinement of Test.Kinder[H]>
+              // tree.tpe.typeSymbol.typeParams:List()
+              // tree.tpe.typeArgs:List(H, M, HL0)
+              // 
+              if(!tree.tpe.typeSymbol.isRefinementClass && tree.tpe.typeSymbol.typeParams.length == 0 && tree.tpe.typeArgs.length > 0) {
+                KindPolymorphicKindArityMismatchError(original, tree.tpe, tree.tpe.typeArgs, List(), tree.tpe.typeSymbol.tpe)
+              }
+              else if(tree.tpe.typeSymbol.typeParams.length > tree.tpe.typeArgs.length && tree.tpe.typeArgs.length > 0) {
+                // List() to have a nicer error msg
+                KindPolymorphicKindArityMismatchError(original, tree.tpe, tree.tpe.typeArgs, List(), tree.tpe.typeSymbol.tpe)
+              }
+              else {
+                val badKinds = kpBadKindArityMatches(tree.tpe.typeSymbol.typeParams, tree.tpe.typeArgs)
+                if(badKinds.nonEmpty) {
+                  KindPolymorphicKindArityMismatchError(original, tree.tpe, tree.tpe.typeArgs, badKinds, tree.tpe.typeSymbol.tpe)
+                } else TypeTree(tree.tpe) setOriginal tree
+              }
+            }
+            else TypeTree(tree.tpe) setOriginal tree
         }
       }
 
@@ -1090,11 +1122,13 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                 // all in one fell swoop at the end of typedFunction?
                 val samAttach = inferSamType(tree, pt, mode)
 
+
                 if (samAttach.samTp ne NoType) tree.setType(samAttach.samTp).updateAttachment(samAttach)
                 else {  // (15) implicit view application
                   val coercion =
                     if (context.implicitsEnabled) inferView(tree, tree.tpe, pt)
                     else EmptyTree
+
                   if (coercion ne EmptyTree) {
                     def msg = s"inferred view from ${tree.tpe} to $pt via $coercion: ${coercion.tpe}"
                     if (settings.logImplicitConv) context.echo(tree.pos, msg)
@@ -2257,6 +2291,11 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       val tpt1 = checkNoEscaping.privates(meth, typedType(ddef.tpt))
       checkNonCyclic(ddef, tpt1)
       ddef.tpt.setType(tpt1.tpe)
+
+      // AnyKind shouldn't be usable as a real type
+      if(ddef.tpt.tpe eq definitions.AnyKindClass.tpe) {
+        AnyKindTypeError(ddef.tpt)
+      }
       val typedMods = typedModifiers(ddef.mods)
       var rhs1 =
         if (ddef.name == nme.CONSTRUCTOR && !ddef.symbol.hasStaticFlag) { // need this to make it possible to generate static ctors
@@ -4038,6 +4077,12 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               checkCheckable(tree, targs.head, scrutineeType, inPattern = false)
             }
             val resultpe = restpe.instantiateTypeParams(tparams, targs)
+
+            // when using YkindPolymorphism, in case resulType has been inferred to a Type Contructor or AnyKind,
+            // let's inform with a nice error
+            if(settings.YkindPolymorphism && (resultpe.resultType.typeParams.nonEmpty || (resultpe.resultType eq definitions.AnyKindClass))) {
+              InferredReturnTypeError(fun, resultpe)
+            } else
             //@M substitution in instantiateParams needs to be careful!
             //@M example: class Foo[a] { def foo[m[x]]: m[a] = error("") } (new Foo[Int]).foo[List] : List[Int]
             //@M    --> first, m[a] gets changed to m[Int], then m gets substituted for List,
@@ -5088,17 +5133,24 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           if (sameLength(tparams, args)) {
             // @M: kind-arity checking is done here and in adapt, full kind-checking is in checkKindBounds (in Infer)
             val args1 = map2Conserve(args, tparams) { (arg, tparam) =>
-              def ptParams = Kind.FromParams(tparam.typeParams)
-
-              // if symbol hasn't been fully loaded, can't check kind-arity except when we're in a pattern,
-              // where we can (we can't take part in F-Bounds) and must (SI-8023)
-              val pt = if (mode.typingPatternOrTypePat) {
-                tparam.initialize; ptParams
+              // if in KindPolymorphism, let's check type is complete, that it is AnyKind and use the inTypeConstructorAllowed mode
+              // in order to avoid ProperTypeRequired and let inference happen later
+              if(settings.YkindPolymorphism && tparam.rawInfo.isComplete && isAnyKind(tparam.tpe)) {
+                typedHigherKindedType(arg, mode)
               }
-              else if (isComplete) ptParams
-              else Kind.Wildcard
+              else {
+                  def ptParams = Kind.FromParams(tparam.typeParams)
 
-              typedHigherKindedType(arg, mode, pt)
+                  // if symbol hasn't been fully loaded, can't check kind-arity except when we're in a pattern,
+                  // where we can (we can't take part in F-Bounds) and must (SI-8023)
+                  val pt = if (mode.typingPatternOrTypePat) {
+                    tparam.initialize; ptParams
+                  }
+                  else if (isComplete) ptParams
+                  else Kind.Wildcard
+
+                  typedHigherKindedType(arg, mode, pt)
+              }
             }
             val argtypes = mapList(args1)(treeTpe)
 
@@ -5279,7 +5331,13 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
         // @M maybe the well-kindedness check should be done when checking the type arguments conform to the type parameters' bounds?
         val args1 = if (sameLength(args, tparams)) map2Conserve(args, tparams) {
-          (arg, tparam) => typedHigherKindedType(arg, mode, Kind.FromParams(tparam.typeParams))
+          (arg, tparam) =>            
+            // if in KindPolymorphism, let's check type is complete, that it is AnyKind and use the inTypeConstructorAllowed mode
+            // in order to avoid ProperTypeRequired and let inference happen later
+            if(settings.YkindPolymorphism && tparam.rawInfo.isComplete && isAnyKind(tparam.tpe)) {
+              typedHigherKindedType(arg, mode)
+            }
+            else typedHigherKindedType(arg, mode, Kind.FromParams(tparam.typeParams))
         }
         else {
           //@M  this branch is correctly hit for an overloaded polymorphic type. It also has to handle erroneous cases.

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -385,6 +385,9 @@ trait Definitions extends api.StandardDefinitions {
     lazy val JavaRepeatedParamClass = specialPolyClass(tpnme.JAVA_REPEATED_PARAM_CLASS_NAME, COVARIANT)(tparam => arrayType(tparam.tpe))
     lazy val RepeatedParamClass     = specialPolyClass(tpnme.REPEATED_PARAM_CLASS_NAME, COVARIANT)(tparam => seqType(tparam.tpe))
 
+    // TODO : requires ABSTRACT | TRAIT | FINAL ????
+    lazy val AnyKindClass   = enterNewClass(ScalaPackageClass, tpnme.AnyKind, AnyTpe :: Nil, ABSTRACT | TRAIT) markAllCompleted
+
     def isByNameParamType(tp: Type)        = tp.typeSymbol == ByNameParamClass
     def isScalaRepeatedParamType(tp: Type) = tp.typeSymbol == RepeatedParamClass
     def isJavaRepeatedParamType(tp: Type)  = tp.typeSymbol == JavaRepeatedParamClass
@@ -756,7 +759,7 @@ trait Definitions extends api.StandardDefinitions {
     def isStable(tp: Type): Boolean = tp match {
       case _: SingletonType                             => true
       case NoPrefix                                     => true
-      case TypeRef(_, NothingClass | SingletonClass, _) => true
+      case TypeRef(_, NothingClass | SingletonClass | AnyKindClass, _) => true
       case TypeRef(_, sym, _) if sym.isAbstractType     => tp.bounds.hi.typeSymbol isSubClass SingletonClass
       case TypeRef(pre, sym, _) if sym.isModuleClass    => isStable(pre)
       case TypeRef(_, _, _) if tp ne tp.dealias         => isStable(tp.dealias)
@@ -1360,7 +1363,8 @@ trait Definitions extends api.StandardDefinitions {
       AnyValClass,
       NullClass,
       NothingClass,
-      SingletonClass
+      SingletonClass,
+      AnyKindClass
     )
     /** Lists core methods that don't have underlying bytecode, but are synthesized on-the-fly in every reflection universe */
     lazy val syntheticCoreMethods = List(

--- a/src/reflect/scala/reflect/internal/Kinds.scala
+++ b/src/reflect/scala/reflect/internal/Kinds.scala
@@ -151,7 +151,10 @@ trait Kinds {
         log("checkKindBoundsHK under params: "+ underHKParams +" with args "+ withHKArgs)
       }
 
-      if (!sameLength(hkargs, hkparams)) {
+      def isAnyKind = settings.YkindPolymorphism && param.tpe.typeSymbol.isNonBottomSubClass(definitions.AnyKindClass)
+
+      // if using Kind Polymorphism, let it pass now and let inference happen a bit later
+      if (!sameLength(hkargs, hkparams) && !isAnyKind) {
         // Any and Nothing are kind-overloaded
         if (arg == AnyClass || arg == NothingClass) NoKindErrors
         // shortcut: always set error, whether explainTypesOrNot

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -256,6 +256,7 @@ trait StdNames {
     final val Singleton: NameType       = "Singleton"
     final val Throwable: NameType       = "Throwable"
     final val unchecked: NameType       = "unchecked"
+    final val AnyKind: NameType         = "AnyKind"
 
     final val api: NameType                 = "api"
     final val Annotation: NameType          = "Annotation"

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -676,7 +676,6 @@ trait Types
           val m     = new AsSeenFromMap(pre.normalize, clazz)
           val tp    = m(this)
           val tp1   = existentialAbstraction(m.capturedParams, tp)
-
           if (m.capturedSkolems.isEmpty) tp1
           else deriveType(m.capturedSkolems, _.cloneSymbol setFlag CAPTURED)(tp1)
         }
@@ -4365,13 +4364,22 @@ trait Types
       }
   }
 
+  // if using Kind Polymorphism, we check those flags to avoid CyclicError & TypeError
+  // if there is any better way to do it, it would be cool to replace those
+  def isAnyKind(tpe: Type): Boolean =
+    !tpe.typeSymbol.rawInfo.bounds.hi.typeSymbol.hasFlag(LOCKED) &&
+    !tpe.typeSymbol.hasFlag(LOCKED) &&
+    tpe.typeSymbol.isNonBottomSubClass(definitions.AnyKindClass)
+
   /** Do type arguments `targs` conform to formal parameters `tparams`?
    */
   def isWithinBounds(pre: Type, owner: Symbol, tparams: List[Symbol], targs: List[Type]): Boolean = {
     var bounds = instantiatedBounds(pre, owner, tparams, targs)
     if (targs exists typeHasAnnotations)
       bounds = adaptBoundsToAnnotations(bounds, tparams, targs)
-    (bounds corresponds targs)(boundsContainType)
+    (bounds corresponds targs) { (bounds: TypeBounds, tp: Type) => 
+      boundsContainType(bounds, tp)
+    }
   }
 
   def instantiatedBounds(pre: Type, owner: Symbol, tparams: List[Symbol], targs: List[Type]): List[TypeBounds] =

--- a/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
+++ b/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
@@ -55,6 +55,7 @@ abstract class MutableSettings extends AbsSettings {
   def verbose: BooleanSetting
   def YpartialUnification: BooleanSetting
   def Yvirtpatmat: BooleanSetting
+  def YkindPolymorphism: BooleanSetting
 
   def Yrecursion: IntSetting
   def maxClassfileName: IntSetting

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -266,6 +266,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.ByNameParamClass
     definitions.JavaRepeatedParamClass
     definitions.RepeatedParamClass
+    definitions.AnyKindClass
     definitions.ConsClass
     definitions.IteratorClass
     definitions.IterableClass

--- a/src/reflect/scala/reflect/runtime/Settings.scala
+++ b/src/reflect/scala/reflect/runtime/Settings.scala
@@ -49,6 +49,7 @@ private[reflect] class Settings extends MutableSettings {
   val verbose           = new BooleanSetting(false)
   val YpartialUnification = new BooleanSetting(false)
   val Yvirtpatmat       = new BooleanSetting(false)
+  val YkindPolymorphism   = new BooleanSetting(false)
 
   val Yrecursion        = new IntSetting(0)
   val maxClassfileName  = new IntSetting(255)

--- a/test/files/neg/kind-poly-noflag.check
+++ b/test/files/neg/kind-poly-noflag.check
@@ -1,0 +1,7 @@
+kind-poly-noflag.scala:3: error: AnyKind can't be used as a real type
+  def foo: AnyKind = ???
+           ^
+kind-poly-noflag.scala:4: error: AnyKind can't be used as a real type
+  val foo2: AnyKind = ???
+            ^
+two errors found

--- a/test/files/neg/kind-poly-noflag.scala
+++ b/test/files/neg/kind-poly-noflag.scala
@@ -1,0 +1,6 @@
+object Test {
+  // AnyKind shouldn't be usable as a type
+  def foo: AnyKind = ???
+  val foo2: AnyKind = ???
+
+}

--- a/test/files/neg/kind-poly.check
+++ b/test/files/neg/kind-poly.check
@@ -1,0 +1,13 @@
+kind-poly.scala:21: error: inferred result type (=> List) takes type parameters
+  foo0[List]                // KO -> neg
+  ^
+kind-poly.scala:22: error: inferred result type (=> List) takes type parameters
+  val l = foo0[List]        // KO -> neg
+          ^
+kind-poly.scala:24: error: F does not take type parameters
+  def foo1[F <: AnyKind, A <: AnyKind]: F[A] = ??? // KO
+                                        ^
+kind-poly.scala:26: error: AnyKind can't be used as a real type
+  def foo3: AnyKind = ??? // KO
+            ^
+four errors found

--- a/test/files/neg/kind-poly.flags
+++ b/test/files/neg/kind-poly.flags
@@ -1,0 +1,1 @@
+-Ykind-polymorphism

--- a/test/files/neg/kind-poly.scala
+++ b/test/files/neg/kind-poly.scala
@@ -1,0 +1,28 @@
+object Test {
+
+  ////////////////////////////////////////////////
+  // PoC of controlled KindPolymorphism in Scala
+  //
+  // The idea is NOT to provide universal kind-polymorphism that would be a bad idea anyway
+  // but to bring a "controlled" kind-polymorphism relying on accepted kinds defined by typeclass implicits
+  // Thus, kind-polymorphism is strictly scoped to your domain and is what you expect to be, nothing else.
+  //
+  // `Ykind-polymorphism` flag aims at deferring just a bit Scalac type inference when encountering AnyKind higher bounds
+  // without losing any strictness in the final typing.
+  // `<: AnyKind` type-bound is purely technicaland totally eliminated after erasure. There is not type associated to it.
+  // 
+  // Here are code-samples that work now:
+  //    - basic kind polymorphism controlled by implicits
+  //    - Kindness proofs based on typeclasses (specially SameKind)
+  //    - Kind-Polymorphic list (on type & value) (2 different implementations)
+  //    - Some weird cases we don't want the compiler to authorize
+
+  def foo0[F <: AnyKind]: F = null.asInstanceOf[F]
+  foo0[List]                // KO -> neg
+  val l = foo0[List]        // KO -> neg
+
+  def foo1[F <: AnyKind, A <: AnyKind]: F[A] = ??? // KO
+
+  def foo3: AnyKind = ??? // KO
+
+}

--- a/test/files/neg/kind-poly2.check
+++ b/test/files/neg/kind-poly2.check
@@ -1,0 +1,16 @@
+kind-poly2.scala:6: error: type arguments [Int] do not conform to trait X's type parameter bounds [F[_] <: AnyKind]
+  new X[Int] { }   // compiles and runs
+      ^
+kind-poly2.scala:7: error: type arguments [Int] do not conform to trait X's type parameter bounds [F[_] <: AnyKind]
+  new X[Int] { }.a // the compiler dies
+      ^
+kind-poly2.scala:8: error: type arguments [Either] do not conform to trait X's type parameter bounds [F[_] <: AnyKind]
+  new X[Either] { } // compiles and runs
+      ^
+kind-poly2.scala:9: error: type arguments [Either] do not conform to trait X's type parameter bounds [F[_] <: AnyKind]
+  new X[Either] { }.a // doesn't compile (error: erroneous or inaccessible type)
+      ^
+kind-poly2.scala:11: error: type arguments [[X, Y]X] do not conform to trait X's type parameter bounds [F[_] <: AnyKind]
+  new X[({ type l[X, Y] = X })#l] { }
+      ^
+5 errors found

--- a/test/files/neg/kind-poly2.flags
+++ b/test/files/neg/kind-poly2.flags
@@ -1,0 +1,1 @@
+-Ykind-polymorphism

--- a/test/files/neg/kind-poly2.scala
+++ b/test/files/neg/kind-poly2.scala
@@ -1,0 +1,13 @@
+object Test {
+
+  // Checking edge cases that should not compile with kind-polymorphism
+
+  trait X[F[_] <: AnyKind] { type L = F[Int]; def a: L = ??? }
+  new X[Int] { }   // compiles and runs
+  new X[Int] { }.a // the compiler dies
+  new X[Either] { } // compiles and runs
+  new X[Either] { }.a // doesn't compile (error: erroneous or inaccessible type)
+  // dies with an assertion (different error than in the second case):
+  new X[({ type l[X, Y] = X })#l] { }
+
+}

--- a/test/files/neg/kind-poly3.check
+++ b/test/files/neg/kind-poly3.check
@@ -1,0 +1,43 @@
+kind-poly3.scala:59: error: Foo is already defined as trait Foo
+  trait Foo[A]
+        ^
+kind-poly3.scala:8: error: Double takes no type parameters, expected: one
+  val i0: X[Option, Double]#B = Some(5)
+                    ^
+kind-poly3.scala:11: error: [Kind-Polymorphic Error] X[Option, List]#B inferred to type List[Option] with illegally kinded type arguments Option applied to type List[A] (kind errors: type A[*]<=>Option[(*->*)])
+  val i1: X[Option, List]#B = Some(5)
+                          ^
+kind-poly3.scala:14: error: type mismatch;
+ found   : Some[Int]
+ required: List[Option[Double]]
+  val i2: X[Option[Double], List]#B = Some(5)
+                                          ^
+kind-poly3.scala:20: error: [Kind-Polymorphic Error] X[Double, scala.AnyRef {
+  type l[X[_] >: [_]Nothing <: [_]Any] = X[Int]
+}#l]#B inferred to type Double[Int] with illegally kinded type arguments Int applied to type Double
+  val i4: X[Double, ({ type l[X[_]] = X[Int] })#l]#B = 5.0
+                                                   ^
+kind-poly3.scala:26: error: [Kind-Polymorphic Error] X[Either, List]#B inferred to type List[[+A, +B]scala.util.Either[A,B]] with illegally kinded type arguments [+A, +B]scala.util.Either[A,B] applied to type List[A] (kind errors: type A[*]<=>[+A, +B]scala.util.Either[A,B][(*->*->*)])
+  val i7: X[Either, List]#B = Some(5)
+                          ^
+kind-poly3.scala:30: error: type mismatch;
+ found   : Some[Int]
+ required: Test.Foo[Int]
+  val i8: X[Foo, ({ type l[X[_]] = X[Int] })#l]#B = Some(5)
+                                                        ^
+kind-poly3.scala:37: error: [Kind-Polymorphism Error] Illegally trying to substitute type F by [X[_]]X[Int][type X] in F[Option[Double]] with kind-mismatching arguments (type X<(*->*)>!=Option[Double]<*>)
+      .asInstanceOf[X2[List, Option[Double]]].run[({ type l[X[_]] = X[Int] })#l]
+                                                 ^
+kind-poly3.scala:42: error: [Kind-Polymorphism Error] Illegally trying to substitute type F by List[type A] in F[List] with kind-mismatching arguments (type A<*>!=List<(*->*)>)
+      .asInstanceOf[X2[List, Option[Double]]].run[List]
+                                                 ^
+kind-poly3.scala:49: error: [Kind-Polymorphism Error] Illegally trying to substitute type F by Map[type A, type B] in F[List,String] with kind-mismatching arguments (type A<*>!=List<(*->*)>)
+      .asInstanceOf[X3[Option[Double], List, String]].run[Map]
+                                                         ^
+kind-poly3.scala:53: error: [Kind-Polymorphism Error] Illegally trying to substitute type F by Map[type A, type B] in F[List,String] with kind-mismatching arguments (type A<*>!=List<(*->*)>)
+      .asInstanceOf[X3[List, Option[Double], String]].run[Map]
+                                                         ^
+kind-poly3.scala:67: error: [Kind-Polymorphism Error] Illegally trying to substitute type F by Test.Bar2[type A, type B] in F[Test.Bar,Int] with kind-mismatching arguments (type A<*>!=Test.Bar<(*->*)>)
+      .asInstanceOf[X3[Bar, Bar, Int]].run[Bar2]
+                                          ^
+12 errors found

--- a/test/files/neg/kind-poly3.flags
+++ b/test/files/neg/kind-poly3.flags
@@ -1,0 +1,1 @@
+-Ykind-polymorphism

--- a/test/files/neg/kind-poly3.scala
+++ b/test/files/neg/kind-poly3.scala
@@ -1,0 +1,69 @@
+object Test {
+
+  // Checking edge cases that should not compile with kind-polymorphism
+
+  trait X[A <: AnyKind, F[_ <: AnyKind]] { type B = F[A] }
+  
+  // KO
+  val i0: X[Option, Double]#B = Some(5)  
+
+  // KO
+  val i1: X[Option, List]#B = Some(5)  
+  
+  // KO
+  val i2: X[Option[Double], List]#B = Some(5)  
+
+  // KO
+  val i3: X[Option[Double], ({ type l[X[_]] = X[Int] })#l]#B = Some(5)
+
+  // KO
+  val i4: X[Double, ({ type l[X[_]] = X[Int] })#l]#B = 5.0
+
+  // KO
+  val i6: X[Either, ({ type l[X[_]] = X[Int] })#l]#B = Some(5)
+
+  // KO
+  val i7: X[Either, List]#B = Some(5)
+
+  // KO
+  trait Foo[A[_[_]]]
+  val i8: X[Foo, ({ type l[X[_]] = X[Int] })#l]#B = Some(5)
+
+
+  trait X2[A <: AnyKind, B <: AnyKind] { def run[F[_ <: AnyKind]]: F[A] => F[B] }
+
+  val x21 = {
+    new X2[Int, Int] { def run[F[_]]: F[Int] => F[Int] = identity[F[Int]] }
+      .asInstanceOf[X2[List, Option[Double]]].run[({ type l[X[_]] = X[Int] })#l]
+  }
+
+  val x22 = {
+    new X2[Int, Int] { def run[F[_]]: F[Int] => F[Int] = identity[F[Int]] }
+      .asInstanceOf[X2[List, Option[Double]]].run[List]
+  }
+
+  trait X3[A <: AnyKind, B <: AnyKind, C <: AnyKind] { def run[F[_ <: AnyKind, _ <: AnyKind]]: F[A, C] => F[B, C] }
+
+  val x31 = {
+    new X3[Int, Int, String] { def run[F[_, _]]: F[Int, String] => F[Int, String] = identity[F[Int, String]] }
+      .asInstanceOf[X3[Option[Double], List, String]].run[Map]
+  }  
+  val x32 = {
+    new X3[Int, Int, String] { def run[F[_, _]]: F[Int, String] => F[Int, String] = identity[F[Int, String]] }
+      .asInstanceOf[X3[List, Option[Double], String]].run[Map]
+  }
+
+
+  trait X4[A <: AnyKind, B <: AnyKind, C] { def run[F[_ <: AnyKind, _]]: F[A, C] => F[B, C] }
+
+  trait Foo[A]
+  trait Bar[A]
+  trait Bar2[A, B]
+
+  trait Toto[F[_], A]
+
+  val x41 = {
+    new X3[Foo, Foo, Int] { def run[F[_[_], A]]: F[Foo, Int] => F[Foo, Int] = identity[F[Foo, Int]] }
+      .asInstanceOf[X3[Bar, Bar, Int]].run[Bar2]
+  }  
+}

--- a/test/files/pos/kind-poly.flags
+++ b/test/files/pos/kind-poly.flags
@@ -1,0 +1,1 @@
+-Ykind-polymorphism

--- a/test/files/pos/kind-poly.scala
+++ b/test/files/pos/kind-poly.scala
@@ -1,0 +1,217 @@
+object Test {
+
+  case class Bar[A](a: A)
+  trait Toto[A, B]
+
+  ////////////////////////////////////////////////
+  // PoC of controlled KindPolymorphism in Scala
+  //
+  // The idea is NOT to provide universal kind-polymorphism that would be a bad idea anyway
+  // but to bring a "controlled" kind-polymorphism relying on accepted kinds defined by typeclass implicits
+  // Thus, kind-polymorphism is strictly scoped to your domain and is what you expect to be, nothing else.
+  //
+  // `Ykind-polymorphism` flag aims at deferring just a bit Scalac type inference when encountering AnyKind higher bounds
+  // without losing any strictness in the final typing.
+  // `<: AnyKind` type-bound is purely technicaland totally eliminated after erasure. There is not type associated to it.
+  // 
+  // Here are code-samples that work now:
+  //    - basic kind polymorphism controlled by implicits
+  //    - Kindness proofs based on typeclasses (specially SameKind)
+  //    - Kind-Polymorphic list (on type & value) (2 different implementations)
+  //    - Some weird cases we don't want the compiler to authorize
+
+  ////////////////////////////////////////////////
+  // Basic Kind polymorphism sample
+  trait Foo[T <: AnyKind] { type Out ; def id(t: Out): Out = t }
+
+  object Foo {
+    implicit def foo0[T] = new Foo[T] { type Out = T }
+    implicit def foo1[T[_]] = new Foo[T] { type Out = T[Any] }
+    implicit def foo2[T[_, _]] = new Foo[T] { type Out = T[Any, Any] }
+  }
+
+  def foo[T <: AnyKind](implicit f: Foo[T]): f.type = f
+  foo[Int].id(23)
+  foo[List].id(List[Any](1, 2, 3))
+  foo[Map].id(Map[Any, Any](1 -> "toto", 2 -> "tata", 3 -> "tutu"))
+
+  ////////////////////////////////////////////////
+  // Is a type M Kinded as you want ?
+  trait Kinded[M <: AnyKind] { type Out <: AnyKind }
+  object Kinded {
+    type Aux[M <: AnyKind, Out0 <: AnyKind] = Kinded[M] { type Out = Out0 }
+
+    implicit def kinded0[M]: Aux[M, M] = new Kinded[M] { type Out = M }
+    implicit def kinded1[M[_]]: Aux[M, M] = new Kinded[M] { type Out[t] = M[t] }
+    implicit def kinded2[M[_, _]]: Aux[M, M] = new Kinded[M] { type Out[t, u] = M[t, u] }
+  }
+
+  implicitly[Kinded.Aux[Int, Int]]
+  implicitly[Kinded.Aux[List, List]]
+  implicitly[Kinded.Aux[Map, Map]]
+
+  ////////////////////////////////////////////////
+  // Extract Kind from a type
+  trait Kinder[MA] { type M <: AnyKind; type Args <: HList }
+  object Kinder extends KinderLowerImplicits {
+    type Aux[MA, M0 <: AnyKind, Args0 <: HList] = Kinder[MA] { type M = M0; type Args = Args0 }
+
+    implicit def kinder2[M0[_, _], A0, B0]: Kinder.Aux[M0[A0, B0], M0, A0 :: B0 :: HNil] = new Kinder[M0[A0, B0]] { type M[t, u] = M0[t, u]; type Args = A0 :: B0 :: HNil }
+    implicit def kinder1[M0[_], A0]: Kinder.Aux[M0[A0], M0, A0 :: HNil] = new Kinder[M0[A0]] { type M[t] = M0[t]; type Args = A0 :: HNil }
+  }
+
+  trait KinderLowerImplicits {
+    implicit def kinder0[A]: Kinder.Aux[A, A, HNil] = new Kinder[A] { type M = A; type Args = HNil }    
+  }
+
+  ////////////////////////////////////////////////
+  //IsoKindness Test
+  trait SameKind[M <: AnyKind, M2 <: AnyKind]
+  object SameKind {
+
+    implicit def sameKind0[A, B] = new SameKind[A, B] {}
+    implicit def sameKind01[M1[_], M2[_]] = new SameKind[M1, M2] {}
+    implicit def sameKind02[M1[_, _], M2[_, _]] = new SameKind[M1, M2] {}
+  }
+
+  def sameKind[M1 <: AnyKind, M2 <: AnyKind](implicit sameKind: SameKind[M1, M2]) = sameKind
+
+  sameKind[Int, String]     // OK
+  sameKind[List, Bar]       // OK
+  sameKind[Map, Toto]       // OK
+
+  // sameKind[List, String] // KO
+  // sameKind[Map, List]    // KO
+  // sameKind[Map, Boolean] // KO
+
+
+
+  ////////////////////////////////////////////////
+  // Kind-Polymorphic List style
+
+  // Classic Heterogenous List used in KindPolymorphic List
+  sealed trait HList
+  final case class ::[+H, +T <: HList](head : H, tail : T) extends HList
+  sealed trait HNil extends HList
+  final case object HNil extends HNil
+
+  object New {
+    // The Kind Polymorphic List
+    sealed trait KPList
+
+    sealed trait KPNil extends KPList
+    case object KPNil extends KPNil {
+      def :::[H, M <: AnyKind, HL <: HList](h:H)(implicit kinder: Kinder.Aux[H, M, HL]) =
+        New.:::(h, KPNil)
+    }
+    
+    sealed case class :::[H, T <: KPList, M <: AnyKind, HL0 <: HList](
+      head: H
+    , tail: T
+    )(implicit val kinder: Kinder.Aux[H, M, HL0]) extends KPList
+
+    final case class KPListOps[L <: KPList](l : L) {
+      def :::[H, M <: AnyKind, HL <: HList](h:H)(implicit kinder: Kinder.Aux[H, M, HL]) =
+        New.:::(h, l)
+    }
+
+    implicit def kplistOps[L <: KPList](l: L): KPListOps[L] = new KPListOps(l)
+
+    val kl = Bar(5) ::: "toto" ::: List(1, 2, 3) ::: Map("toto" -> 1L, "tata" -> 2L) ::: KPNil
+
+    val h: Bar[Int] = kl.head
+    val h2: String = kl.tail.head
+    val h3: List[Int] = kl.tail.tail.head
+    val h4: Map[String, Long] = kl.tail.tail.tail.head
+
+  }
+
+
+  ////////////////////////////////////////////////
+  // SPECIAL CASES
+  def foo0[F <: AnyKind]: F = null.asInstanceOf[F]
+  val i = foo0[Int]             // OK
+  val li = foo0[List[Int]]      // OK
+  // foo0[List]                // KO -> neg
+  // val l = foo0[List]        // KO -> neg
+
+  // def foo1[F <: AnyKind, A <: AnyKind]: F[A] = ??? // KO
+
+  // def foo2: AnyKind = ??? // KO
+
+
+  // Older implementation Kind-Polymorphic List but I prefer the one above
+  object Old {
+
+    // The Kind Polymorphic List
+    sealed trait KPList
+
+    sealed trait KPNil extends KPList
+    case object KPNil extends KPNil
+    
+    sealed trait :::[H <: AnyKind, T <: KPList] extends KPList
+    trait KPCons[M <: AnyKind, T <: KPList] extends :::[M, T]  {
+      type HL <: HList
+      type H
+      def head: H
+      def tail: T
+    }
+
+    object KPCons {
+      type Aux[M <: AnyKind, T <: KPList, H0, HL0 <: HList] = KPCons[M, T] { type H = H0; type HL = HL0 }
+      // Polymorphic 
+      trait Apply[M <: AnyKind, A <: HList] { type Out }
+      object Apply {
+        type Aux[M <: AnyKind, A <: HList, Out0] = Apply[M, A] { type Out = Out0 }
+        implicit def apply0[M]: Aux[M, HNil, M] = new Apply[M, HNil] { type Out = M }
+        implicit def apply1[M[_], A]: Aux[M, A :: HNil, M[A]] = new Apply[M, A :: HNil] { type Out = M[A] }
+        implicit def apply2[M[_, _], A, B]: Aux[M, A :: B :: HNil, M[A, B]] = new Apply[M, A :: B :: HNil] { type Out = M[A, B] }
+      }
+
+      trait Unapply[M <: AnyKind, O] { type Out <: HList }
+      object Unapply {
+        type Aux[M <: AnyKind, O, Out0 <: HList] = Unapply[M, O] { type Out = Out0 }
+
+        implicit def unapply0[M]: Aux[M, M, HNil] = new Unapply[M, M] { type Out = HNil }
+        implicit def unapply1[M[_], A0]: Unapply.Aux[M, M[A0], A0 :: HNil] = new Unapply[M, M[A0]] { type Out = A0 :: HNil }
+        implicit def unapply2[M[_, _], A0, B0]: Aux[M, M[A0, B0], A0 :: B0 :: HNil] = new Unapply[M, M[A0, B0]] { type Out = A0 :: B0 :: HNil }
+      }
+
+      // the list builder
+      trait KPConsBuilder[M <: AnyKind] {
+        def apply[H0, HL0 <: HList, T <: KPList](head0: H0, tail0: T)(implicit unap: Unapply.Aux[M, H0, HL0]): KPCons.Aux[M, T, H0, HL0] = new KPCons[M, T] {
+          type HL = HL0
+          type H = H0
+          val head: H = head0
+          val tail: T = tail0
+        }
+      }
+
+      def apply[M <: AnyKind] = new KPConsBuilder[M] {}
+    }
+
+
+    // Let's create some kind-polymorphic list
+    val kl = 
+      KPCons[Bar](
+        Bar(5)
+      , KPCons[String](
+          "toto"
+        , KPCons[List](
+            List(1, 2, 3)
+          , KPCons[Map](
+              Map("toto" -> 1L, "tata" -> 2L)
+            , KPNil
+            )
+          )
+        )
+      )
+
+    val h: Bar[Int] = kl.head
+    val h2: String = kl.tail.head
+    val h3: List[Int] = kl.tail.tail.head
+    val h4: Map[String, Long] = kl.tail.tail.tail.head
+
+  }
+
+}

--- a/test/files/pos/kind-poly2.flags
+++ b/test/files/pos/kind-poly2.flags
@@ -1,0 +1,1 @@
+-Ykind-polymorphism

--- a/test/files/pos/kind-poly2.scala
+++ b/test/files/pos/kind-poly2.scala
@@ -1,0 +1,78 @@
+object Test {
+  case class Bar[A](a: A)
+  trait Toto[A, B]
+
+  //////
+  ////////////////////////////////////////////////
+  // Extract Kind from a type
+  trait Kinder[MA] { type M <: AnyKind }
+  object Kinder extends KinderLowerImplicits {
+    type Aux[MA, M0 <: AnyKind] = Kinder[MA] { type M = M0 }
+
+    implicit def kinder1[M0[_], A0]: Kinder.Aux[M0[A0], M0] = new Kinder[M0[A0]] { type M[t] = M0[t] }
+    implicit def kinder2[M0[_, _], A0, B0]: Kinder.Aux[M0[A0, B0], M0] = new Kinder[M0[A0, B0]] { type M[t, u] = M0[t, u]; type Args = A0 :: B0 :: HNil }
+  }
+  trait KinderLowerImplicits {
+    implicit def kinder0[A]: Kinder.Aux[A, A] = new Kinder[A] { type M = A; type Args = HNil }    
+  }
+
+  // Classic Heterogenous List used in KindPolymorphic List
+  sealed trait HList
+  final case class ::[+H, +T <: HList](head : H, tail : T) extends HList
+  sealed trait HNil extends HList {
+    def ::[H](h : H) = Test.::(h, this)
+  }
+  final case object HNil extends HNil
+
+  trait SemiGroup[M <: AnyKind] {
+    // Just a mirror type of itself to ensure the owning of AppendFunction...
+    type Self
+    def append[MA](m1: MA, m2: MA)(implicit appender: SemiGroup.AppendFunction[Self, MA, M]) = appender(m1, m2)
+  }
+
+  object SemiGroup {
+    type Aux[M <: AnyKind, Self0] = SemiGroup[M] { type Self = Self0 }
+
+    trait AppendFunction[P, FA, F <: AnyKind] {
+      def apply(m1: FA, m2: FA): FA
+    }
+  }
+
+  implicit object SemiGroupInt extends SemiGroup[Int] {
+    type Self = this.type
+    implicit val appender = new SemiGroup.AppendFunction[Self, Int, Int] {
+      def apply(m1: Int, m2: Int) = m1 + m2
+    }
+  }
+
+  implicit object SemiGroupList extends SemiGroup[List] {
+    type Self = this.type
+    implicit def appender[A] = new SemiGroup.AppendFunction[Self, List[A], List] {
+      def apply(m1: List[A], m2: List[A]) = m1 ++ m2
+    }
+  }
+
+  implicit object SemiGroupMap extends SemiGroup[Map] {
+    type Self = this.type
+    implicit def appender[A, B] = new SemiGroup.AppendFunction[Self, Map[A, B], Map] {
+      def apply(m1: Map[A, B], m2: Map[A, B]) = m1 ++ m2
+    }
+  }
+
+  // Searching a semigroup and using it
+  def semiGroup[M <: AnyKind](implicit sg: SemiGroup[M]): SemiGroup.Aux[M, sg.Self] = sg
+
+  semiGroup[Int].append(5, 8)
+  semiGroup[List].append(List(1), List(3))
+  semiGroup[Map].append(Map("toto" -> 1L), Map("tata" -> 3L))
+
+  // higher level append function
+  def append[MA, M <: AnyKind, Self](m1: MA, m2: MA)(
+    implicit kinder: Kinder.Aux[MA, M], semiGroup: SemiGroup.Aux[M, Self], appender: SemiGroup.AppendFunction[Self, MA, M]
+  ): MA = semiGroup.append(m1, m2)
+
+  val r1: Int = append(5, 8)   // OK
+  val r2: List[Int] = append(List(1), List(3))    // KO -> certainly a bug in propagating an implicit with an AnyKind type
+  val r3: Map[String, Long] = append(Map("toto" -> 1L), Map("tata" -> 3L))
+
+}

--- a/test/files/pos/kind-poly3.flags
+++ b/test/files/pos/kind-poly3.flags
@@ -1,0 +1,1 @@
+-Ykind-polymorphism

--- a/test/files/pos/kind-poly3.scala
+++ b/test/files/pos/kind-poly3.scala
@@ -1,0 +1,49 @@
+object Test {
+  abstract class Recursive[T <: AnyKind, Base <: AnyKind, ~~>[_ <: AnyKind, _ <: AnyKind]] {
+    def project: T ~~> Base
+  }
+
+  object Recursive {
+    type Aux[T <: AnyKind, Base <: AnyKind, ~~>[_ <: AnyKind, _ <: AnyKind]] = Recursive[T, Base, ~~>]
+  }
+
+  trait ~>[F[_], G[_]] {
+    def apply[A](fa: F[A]): G[A]
+  }
+
+  // single-sorted recursion
+  final case class Fix[F[_]](unFix: F[Fix[F]])
+
+  object Fix {
+    implicit def recursive[F[_]]: Recursive.Aux[Fix[F], F[Fix[F]], Function1] =
+      new Recursive[Fix[F], F[Fix[F]], Function1] {
+        def project: Fix[F] => F[Fix[F]] = _.unFix
+      }
+  }
+
+  // multi-sorted recursion (comments have kind-projected version)
+  final case class FixH[F[_[_], _], A](hunFix: F[({ type λ[α] = FixH[F, α] })#λ, A])
+
+  object FixH {
+    //       def recursive[F[_[_], _]]: Recursive.Aux[FixH[F, ?], F, ~>] =
+    implicit def recursive[F[_[_], _]]: Recursive.Aux[
+      ({ type λ[α] = FixH[F, α] })#λ
+    , ({type λ[α] = F[({ type λ[α] = FixH[F, α] })#λ, α] })#λ
+    , ~>] = {
+
+      type In[A] = FixH[F, A]
+      type Out[A] = F[In, A]
+
+      new Recursive[In, Out, ~>] {
+        def project: In ~> Out = new (In ~> Out) {
+          def apply[A](fa: In[A]): Out[A] = fa.hunFix
+        }
+      }
+    }
+  }
+
+  trait Foo[F[_], A]
+  type FixHFoo[A] = FixH[Foo, A]
+  FixH.recursive[Foo].project(FixH[Foo, Int](new Foo[FixHFoo, Int] {}))
+
+}

--- a/test/files/pos/kind-poly4.flags
+++ b/test/files/pos/kind-poly4.flags
@@ -1,0 +1,1 @@
+-Ykind-polymorphism

--- a/test/files/pos/kind-poly4.scala
+++ b/test/files/pos/kind-poly4.scala
@@ -1,0 +1,156 @@
+object Test {
+  case class Bar[A](a: A)
+  trait Toto[A, B]
+
+  /** A Typeclass indexed by a kind of morphism and able to:
+    * 1/ extract a F[_*] from FA
+    * 2/ apply M on it
+    * 3/ return a GA which is a G[_*]
+    */
+  trait UnapplyApply[FA, F <: AnyKind, G <: AnyKind, GA, M <: Morphism[F, G]] {
+    def apply(m: M)(g: FA): GA
+  }
+
+  /** a kind-polymorphic morphism */
+  sealed trait Morphism[F <: AnyKind, G <: AnyKind] {
+    def apply[FApp, GApp](v: FApp)(implicit unapplyApply: UnapplyApply[FApp, F, G, GApp, this.type]): GApp = unapplyApply(this)(v)
+  }
+
+  /** order-1 morphism AKA function */
+  class Morphism1[A, B](val f: A => B) extends Morphism[A, B]
+
+  object Morphism1 {
+    /** the unapplyApply for morphism1 */
+    implicit def unapplyApply1[A, B, M <: Morphism1[A, B]] = new UnapplyApply[A, A, B, B, M] {
+      def apply(m: M)(a: A): B = m.f(a)
+    }
+  }
+
+  /** order-2 morphism AKA FunctionK */
+  trait Morphism2[F[_], G[_]] extends Morphism[F, G] {
+    def apply[A](fa: F[A]): G[A]
+  }
+
+  object Morphism2 {
+    /** the unapplyApply for morphism2 */
+    implicit def unapplyApply2[F[_], G[_], A, M <: Morphism2[F, G]] = new UnapplyApply[F[A], F, G, G[A], M] {
+      def apply(m: M)(fa: F[A]): G[A] = m.apply(fa)
+    }
+  }
+
+  // Morphism sample
+  val m1 = new Morphism1( (i:Int) => i.toString )
+  m1(1)
+
+  val m2 = new Morphism2[Bar, List] {
+    def apply[A](fa: Bar[A]): List[A] = List(fa.a)
+  }
+  m2(Bar(5))
+
+  /** A simple Product (X1, X2) indexed by the type of morphism and respecting the categorical product representation
+    * described on Wikipedia https://en.wikipedia.org/wiki/Product_(category_theory):
+    * "Let C be a category with some objects X1 and X2. A product of X1 and X2 is an object X (often denoted X1 × X2)
+    *  together with a pair of morphisms π1 : X → X1, π2 : X → X2 that satisfy the following universal property:
+    *     -for every object Y and pair of morphisms f1 : Y → X1, f2 : Y → X2 there exists a unique morphism f : Y → X
+    * "
+    * In this model:
+    * - A Product[Morphism1] is a simple tuple
+    * - A Product[Morphism2] is a order-2 product [A] => (F[A], G[A])
+    * - etc...
+    */
+  trait Prod[M[a<:AnyKind, b<:AnyKind] <: Morphism[a , b]] {
+    // synthetic poly-kinded representation of own type for be used in π1 & π2 morphisms
+    type Self <: AnyKind
+
+    // the types in the product
+    type X1 <: AnyKind
+    type X2 <: AnyKind
+
+    // the projection morphism
+    def π1 : M[Self, X1]
+    def π2 : M[Self, X2]
+  }
+
+  /** the Product[Morphism1] AKA a simple tuple */
+  case class Prod1[A, B](a: A, b: B) extends Prod[Morphism1] {
+    type Self = Prod1[A, B]
+    type X1 = A
+    type X2 = B
+
+    val π1 = new Morphism1[Self, A](_ => a)
+    val π2 = new Morphism1[Self, B](_ => b)
+
+    val prj1: A = π1(this)
+    val prj2: B = π2(this)
+  }
+
+  /** The Builder represents the unique morphism from categorical representation:
+    * "for every object Y and pair of morphisms f1 : Y → X1, f2 : Y → X2 there exists a unique morphism f : Y → X"
+    */
+  class ProdBuilder1[Y, A, B](f1: Morphism1[Y, A], f2: Morphism1[Y, B]) extends Morphism1[Y, Prod1[A, B]](
+    (y:Y) => new Prod1(f1(y), f2(y))
+  )
+
+  /** the Product[Morphism2] AKA a [A] => (F[A], G[A]) */
+  case class Prod2[F[_], G[_], A](fa: F[A], ga: G[A]) extends Prod[Morphism2] {
+    type Self[A] = Prod2[F, G, A]
+    type X1[A] = F[A]
+    type X2[A] = G[A]
+    val π1 = new Morphism2[Self, F] {
+      def apply[A](x: Self[A]): F[A] = x.fa
+    }
+    val π2 = new Morphism2[Self, G] {
+      def apply[A](x: Self[A]): G[A] = x.ga
+    }
+
+    val prj1: F[A] = π1(this)
+    val prj2: G[A] = π2(this)
+  }
+
+  /** The Builder represents the unique morphism from categorical representation:
+    * "for every object Y and pair of morphisms f1 : Y → X1, f2 : Y → X2 there exists a unique morphism f : Y → X"
+    */
+  class ProdBuilder2[Y[_], F[_], G[_]](f1: Morphism2[Y, F], f2: Morphism2[Y, G])
+    extends Morphism2[Y, ({ type l[t] = Prod2[F, G, t] })#l] {
+    def apply[A](ya: Y[A]): Prod2[F, G, A] = new Prod2(f1(ya), f2(ya))
+  }
+
+
+
+  // Prod1 Sample (ok it's a bit less simple to write :D)
+  // Y is here Unit for convenience but it could be anything
+  val prodb1 = new ProdBuilder1(
+    new Morphism1((y:Unit) => 5)
+  , new Morphism1((y:Unit) => "toto")
+  )
+  val prod1 = prodb1()
+  val i: Int = prod1.π1(prod1)
+  val s: String = prod1.π2(prod1)
+
+
+  // Prod2 Sample (ok it's a bit less simple to write :D)
+  // ID is used for having a Y in order-2
+  type Id[A] = A
+  val prodb2 = new ProdBuilder2(
+    new Morphism2[Id, List] {
+      def apply[A](x: Id[A]): List[A] = List(x)
+    }
+  , new Morphism2[Id, Option] {
+      def apply[A](x: Id[A]): Option[A] = Option(x)
+    }
+  )
+
+  val prod2Int = prodb2(5)
+  val l1: List[Int] = prod2Int.π1(prod2Int)
+  val l11: List[Int] = prod2Int.prj1
+  val o1: Option[Int] = prod2Int.π2(prod2Int)
+  val o11: Option[Int] = prod2Int.prj2
+
+  val prod2String = prodb2("toto")
+  val l2: List[String] = prod2String.π1(prod2String)
+  val l21: List[String] = prod2String.prj1
+  val o2: Option[String] = prod2String.π2(prod2String)
+  val o21: Option[String] = prod2String.prj2
+
+
+}

--- a/test/files/pos/kind-poly5.flags
+++ b/test/files/pos/kind-poly5.flags
@@ -1,0 +1,1 @@
+-Ykind-polymorphism

--- a/test/files/pos/kind-poly5.scala
+++ b/test/files/pos/kind-poly5.scala
@@ -1,0 +1,159 @@
+object Test {
+
+  // PKList or the Any-Order heterogenous list
+  sealed trait PKList[Args <: AnyKind]
+
+  trait PKNil[Args <: AnyKind] extends PKList[Args]
+
+  sealed trait PKCons[Args <: AnyKind, HA, TA <: PKList[Args]] extends PKList[Args] {
+    def head: HA
+    def tail: TA
+  }
+
+  object PKList {
+
+    trait PKConsBuilder[Args <: AnyKind, HA, UL <: PKList[Args]] {
+      type OutA
+      def ::(l: UL)(ha: HA): OutA
+    }
+
+    implicit class PKListOps[
+      Args <: AnyKind
+    ](l: PKNil[Args]) {
+      def ::[HA0](ha: HA0)(implicit unap: PKConsBuilder[Args, HA0, PKNil[Args]]): unap.OutA = unap.::(l)(ha)
+    }
+
+    implicit class PKListOps2[
+      Args <: AnyKind
+    , HA
+    , T <: PKList[Args]
+    ](l: PKCons[Args, HA, T]) {
+      def ::[HA0](ha: HA0)(implicit unap: PKConsBuilder[Args, HA0, PKCons[Args, HA, T]]): unap.OutA = unap.::(l)(ha)
+    }
+
+  }
+
+
+  object PKConsBuilder1 {
+    import PKList._
+
+    sealed trait HNil extends PKNil[Nothing] {
+      def ::[H](h : H) = PKConsBuilder1.::(h, this)
+    }
+    final case object HNil extends HNil
+    final case class ::[H, T <: PKList[Nothing]](head : H, tail : T) extends PKCons[Nothing, H, T] {
+      def ::[H2](h : H2) = PKConsBuilder1.::(h, this)
+    }
+
+    // implicit def build0cons[H0, A, T <: PKList[Nothing]] =
+    //   new PKConsBuilder[Nothing, H0, T] {
+    //     type OutA = PKCons[Nothing, H0, T]
+
+    //     def ::(l: T)(h: H0): OutA = new PKCons[Nothing, H0, T] {
+    //       val head = h
+    //       val tail = l
+    //     }
+    //   }
+
+    implicit def build1cons[H0, A, T <: PKList[HNil]] =
+      new PKConsBuilder[HNil, H0, T] {
+        type OutA = PKCons[HNil, H0, T]
+
+        def ::(l: T)(h: H0): OutA = new PKCons[HNil, H0, T] {
+          val head = h
+          val tail = l
+        }
+      }
+
+    implicit def build2cons[H0[_], A, T <: PKList[A :: HNil]] =
+      new PKConsBuilder[A :: HNil, H0[A], T] {
+        type OutA = PKCons[A :: HNil, H0[A], T]
+
+        def ::(l: T)(h: H0[A]): OutA = new PKCons[A :: HNil, H0[A], T] {
+          val head = h
+          val tail = l
+        }
+      }
+
+    implicit def build3cons[H0[_, _], A, B, T <: PKList[A :: B :: HNil]] =
+      new PKConsBuilder[A :: B :: HNil, H0[A, B], T] {
+        type OutA = PKCons[A :: B :: HNil, H0[A, B], T]
+
+        def ::(l: T)(h: H0[A, B]): OutA = new PKCons[A :: B :: HNil, H0[A, B], T] {
+          val head = h
+          val tail = l
+        }
+      }
+
+    implicit def buildMCons[M[_[_]], F[_], T <: PKList[F]] =
+      new PKConsBuilder[F, M[F], T] {
+        type OutA = PKCons[F, M[F], T]
+
+        def ::(l: T)(h: M[F]): OutA = new PKCons[F, M[F], T] {
+          val head = h
+          val tail = l
+        }
+      }
+
+
+    case class Bar[A](a: A)
+    class Toto[A, B]
+
+
+    val l0 : Int :: String :: HNil = 5 :: "toto" :: HNil
+
+
+    // List of *
+    case object HNil1 extends PKNil[HNil]
+
+    val l1 = 5 :: "toto" :: HNil1
+    val i1: Int = l1.head
+    val s1: String = l1.tail.head
+    val t: PKNil[HNil] = l1.tail.tail
+
+    // List of * -> *
+    case class HNil2[A]() extends PKNil[A :: HNil]
+
+    val l2 = List("tutu") :: Bar("tata") :: HNil2[String]()
+    val h21: List[String] = l2.head
+    val h22: Bar[String] = l2.tail.head
+    val t2: PKNil[String :: HNil] = l2.tail.tail
+
+    // val l21 = List(5) :: Bar("tata") :: HNil2() // KO
+
+    // List of * -> * -> *
+    case class HNil3[A, B]() extends PKNil[A :: B :: HNil]
+
+    val l3 = Map("tutu" -> 42L) :: (new Toto[String, Long]) :: HNil3[String, Long]()
+    val h31: Map[String, Long] = l3.head
+    val h32: Toto[String, Long] = l3.tail.head
+    val t3: PKNil[String :: Long :: HNil] = l3.tail.tail
+
+    // val l31 = Map("tutu" -> 42L) :: HNil3[String, Int]() // KO 
+    // val l32 = Map("tutu" -> 42L) :: (new Toto[String, Int]) :: HNil3() // KO
+
+
+    // List of (* -> *) -> *
+    case class HNilM[F[_]]() extends PKNil[F]
+
+    trait Functor[F[_]]
+    trait Traverse[F[_]]
+    trait Foldable[F[_]]
+    
+    trait Foo[A]
+    implicit val functor: Functor[Foo] = ???
+    implicit val traverse: Traverse[Foo] = ???
+    implicit val foldable: Foldable[Foo] = ???
+
+    val m = functor :: traverse :: foldable :: HNilM[Foo]()
+
+    val f: Functor[Foo] = m.head
+
+    def build[F[_] : Functor : Traverse : Foldable] =
+      implicitly[Functor[F]] :: implicitly[Traverse[F]] :: implicitly[Foldable[F]] :: HNilM[F]()
+
+    build[Foo]
+  }
+
+
+}

--- a/test/files/pos/kind-poly6.flags
+++ b/test/files/pos/kind-poly6.flags
@@ -1,0 +1,1 @@
+-Ykind-polymorphism

--- a/test/files/pos/kind-poly6.scala
+++ b/test/files/pos/kind-poly6.scala
@@ -1,0 +1,34 @@
+object Test {
+
+  trait Foo
+  class Foo1 extends Foo
+  class Bar[T] extends Foo
+  class Baz[T, U] extends Foo
+
+  def fooFoo[T <: Foo with AnyKind]: Unit = ()
+  fooFoo[Bar] // OK
+  fooFoo[Baz] // OK
+  // fooFoo[List] // Not OK
+  // fooFoo[Int] // Not OK
+
+  trait Toto1[A]
+  class Toto11[A] extends Toto1[A]
+  class Toto12[A, B] extends Toto1[A]
+
+  def fooToto[T <: Toto1[_] with AnyKind]: Unit = ()
+  fooToto[Toto11]
+  fooToto[Toto12]
+  // fooToto[List] // Not OK
+  // fooToto[Int]   // Not OK
+
+  def foo[T <: AnyKind]: Unit = ()
+  foo[String]
+  foo[Foo]
+  foo[Bar]
+  foo[Baz]
+  foo[List]
+  foo[Map]
+  foo[List[Int]]
+  foo[Map[Int, Long]]
+
+}

--- a/test/files/run/kind-poly10.flags
+++ b/test/files/run/kind-poly10.flags
@@ -1,0 +1,1 @@
+-Ykind-polymorphism

--- a/test/files/run/kind-poly10.scala
+++ b/test/files/run/kind-poly10.scala
@@ -1,0 +1,191 @@
+import scala.language.higherKinds
+import scala.reflect.ClassTag
+import scala.collection.{ GenMap, GenTraversable }
+
+/** Draft implmementation of Polykinded Safe Type Representation & Cast */
+object Test extends App {
+
+  /** Representation of the type of a value
+    * T is the type constructor of the type of the value (For example Int => T = Int, List[Int] => T = List)
+    * TAbs (for T abstracted) is a well-formed monomorphic type derived from T (For example List => TAbs = List[Any])
+    * To think about: variance could be taken into account there
+    */
+  trait TypeRepr[T <: AnyKind, TAbs] {
+    // the value associated to this type representation
+    def value: TAbs
+
+    // cast local value to the monomorphic type TT
+    def cast[TT](implicit typeable: Typeable[TT]): Option[typeable.TAbs] = typeable.repr(value).map(_.value)
+
+    def describe: String
+    override def toString = s"TypeRepr[$describe]"
+  }
+
+  /** Kind-Polymorphic Typeable typeclass
+    */
+  trait Typeable[T <: AnyKind] extends Serializable {
+    type TAbs
+
+    // returns an eventual type representation associated the given value
+    def repr(t: Any): Option[TypeRepr[T, TAbs]]
+
+    def describe: String
+    override def toString = s"Typeable[$describe]"
+  }
+
+  object Typeable {
+    import java.{ lang => jl }
+
+    def apply[T <: AnyKind](implicit st: Typeable[T]): st.type = st
+    
+    case class ValueTypeable[T, B](cB: Class[B], describe: String) extends Typeable[T] {
+      self =>
+      type TAbs = T
+      def repr(t: Any): Option[TypeRepr[T, T]] = {
+        if(t != null && cB.isInstance(t))
+          Some(new TypeRepr[T, T] {
+            val value = t.asInstanceOf[T]
+            val describe = self.describe
+          })
+        else None
+      }
+    }
+
+    /** Typeable instance for `String`. */
+    implicit val stringTypeable: Typeable[String] = ValueTypeable[String, String](classOf[String], "String")
+    /** Typeable instance for `Byte`. */
+    implicit val byteTypeable: Typeable[Byte] = ValueTypeable[Byte, jl.Byte](classOf[jl.Byte], "Byte")
+    /** Typeable instance for `Short`. */
+    implicit val shortTypeable: Typeable[Short] = ValueTypeable[Short, jl.Short](classOf[jl.Short], "Short")
+    /** Typeable instance for `Char`. */
+    implicit val charTypeable: Typeable[Char] = ValueTypeable[Char, jl.Character](classOf[jl.Character], "Char")
+    /** Typeable instance for `Int`. */
+    implicit val intTypeable: Typeable[Int] = ValueTypeable[Int, jl.Integer](classOf[jl.Integer], "Int")
+    /** Typeable instance for `Long`. */
+    implicit val longTypeable: Typeable[Long] = ValueTypeable[Long, jl.Long](classOf[jl.Long], "Long")
+    /** Typeable instance for `Float`. */
+    implicit val floatTypeable: Typeable[Float] = ValueTypeable[Float, jl.Float](classOf[jl.Float], "Float")
+    /** Typeable instance for `Double`. */
+    implicit val doubleTypeable: Typeable[Double] = ValueTypeable[Double, jl.Double](classOf[jl.Double], "Double")
+    /** Typeable instance for `Boolean`. */
+    implicit val booleanTypeable: Typeable[Boolean] = ValueTypeable[Boolean, jl.Boolean](classOf[jl.Boolean], "Boolean")
+    /** Typeable instance for `Unit`. */
+    implicit val unitTypeable: Typeable[Unit] = ValueTypeable[Unit, runtime.BoxedUnit](classOf[runtime.BoxedUnit], "Unit")
+
+    /** Typeable instance for `Any`. */
+    implicit val anyTypeable: Typeable[Any] =
+      new Typeable[Any] {
+        type TAbs = Any
+        def repr(t: Any): Option[TypeRepr[Any, Any]] = Some(new TypeRepr[Any, Any] {
+          val value = t
+          val describe = "Any"
+        })
+        val describe = "Any"
+      }
+
+    // We coulld take variance into to use Any or Nothing in TAbs
+    implicit def typeable1A[F[_]](implicit mF: ClassTag[F[_]]) =
+      new Typeable[F] {
+        type TAbs = F[Any]
+        def repr(t: Any): Option[TypeRepr[F, F[Any]]] =
+          if(t == null) None
+          else if(mF.runtimeClass isAssignableFrom t.getClass) {
+            Some(new TypeRepr[F, F[Any]] {
+              val value = t.asInstanceOf[F[Any]]
+              val describe = s"${mF.runtimeClass.getSimpleName}"
+            })
+          } else None
+
+        val describe = s"${mF.runtimeClass.getSimpleName}"
+      }
+
+    implicit def typeable2AB[F[_, _]](implicit mF: ClassTag[F[_, _]]) =
+      new Typeable[F] {
+        type TAbs = F[Any, Any]
+        def repr(t: Any): Option[TypeRepr[F, F[Any, Any]]] =
+          if(t == null) None
+          else if(mF.runtimeClass isAssignableFrom t.getClass) {
+            Some(new TypeRepr[F, F[Any, Any]] {
+              val value = t.asInstanceOf[F[Any, Any]]
+              val describe = s"${mF.runtimeClass.getSimpleName}"
+            })
+          } else None
+
+        val describe = s"${mF.runtimeClass.getSimpleName}"
+      }
+
+    implicit def genTraversableTypeable[CC[X] <: GenTraversable[X], T]
+      (implicit mCC: ClassTag[CC[_]], castT: Typeable[T]): Typeable[CC[T] with GenTraversable[T]] =
+        new Typeable[CC[T]] {
+          type TAbs = CC[T]
+          def repr(t: Any): Option[TypeRepr[CC[T], CC[T]]] =
+            if(t == null) None
+            else if(mCC.runtimeClass isAssignableFrom t.getClass) {
+              val cc = t.asInstanceOf[CC[Any]]
+              if(cc.forall(x => castT.repr(x).isDefined)) Some(new TypeRepr[CC[T], CC[T]] {
+                val value = t.asInstanceOf[CC[T]]
+                val describe = s"${mCC.runtimeClass.getSimpleName}[${castT.describe}]"
+              })
+              else None
+            } else None
+          val describe = s"${mCC.runtimeClass.getSimpleName}[${castT.describe}]"
+        }
+
+    /** Typeable instance for `Map`. Note that the contents will be tested for conformance to the key/value types. */
+    implicit def genMapTypeable[M[X, Y], K, V]
+      (implicit ev: M[K, V] <:< GenMap[K, V], mM: ClassTag[M[_, _]], castK: Typeable[K], castV: Typeable[V]): Typeable[M[K, V]] =
+      new Typeable[M[K, V]] {
+        type TAbs = M[K, V]
+        def repr(t: Any): Option[TypeRepr[M[K, V], M[K, V]]] =
+          if(t == null) None
+          else if(mM.runtimeClass isAssignableFrom t.getClass) {
+            val m = t.asInstanceOf[GenMap[Any, Any]]
+            if(m.forall(x => castK.repr(x._1).isDefined && castV.repr(x._2).isDefined)) Some(new TypeRepr[M[K, V], M[K, V]] {
+              val value = t.asInstanceOf[M[K, V]]
+              val describe = s"${mM.runtimeClass.getSimpleName}[${castK.describe}, ${castV.describe}]"
+            })
+            else None
+          } else None
+        val describe = s"${mM.runtimeClass.getSimpleName}[${castK.describe}, ${castV.describe}]"
+      }
+
+  }
+
+  /** Builds eventual type representation of a value
+    * For ex:
+    * repr[Int](5) => Some(TypeRepr[Int])
+    * repr[List](List(1, 2, 3) => Some(TypeRepr[List])
+    * repr[String](5) => None    
+    */
+  def repr[T <: AnyKind](t: Any)(implicit typeable: Typeable[T]): Option[TypeRepr[T, typeable.TAbs]] = typeable.repr(t)
+  
+  /** Safe-casts a monomorphic-typed value using implicit typeable
+    * cast[Int](5) => Some(5)
+    * cast[String](5) => None
+    */
+  def cast[T](t: Any)(implicit typeable: Typeable[T]): Option[typeable.TAbs] = typeable.repr(t).flatMap(_.cast[T])
+
+  assert(repr[Int](5).isDefined)
+  assert(cast[Int](5) == Some(5))
+
+  assert(repr[String](5) == None)
+  assert(repr[String]("5").isDefined)
+  assert(cast[String]("5") == Some("5"))
+
+  // List
+  assert(repr[List](List(1, 2, 3)).isDefined)
+  assert(cast[List[Int]](List(1, 2, 3)) == Some(List(1, 2, 3)))
+  assert(repr[List[String]](List(1, 2, 3)) == None)
+  assert(repr[List](List(1, "tutu", 3L)).flatMap(_.cast[List[Any]]) == Some(List(1, "tutu", 3L)))
+  assert(cast[List[Any]](List(1, "tutu", 3L)) == Some(List(1, "tutu", 3L)))
+
+  // Map
+  assert(repr[Map](Map(1 -> "toto", 2 -> "tata", 3 -> "tutu")).isDefined)  
+  assert(repr[Map](Map(1 -> "toto", 2 -> "tata", 3 -> "tutu")).flatMap(_.cast[Map[Int, String]]) == Some(Map(1 -> "toto", 2 -> "tata", 3 -> "tutu")))
+  assert(repr[List](Map(1 -> "toto", 2 -> "tata", 3 -> "tutu")) == None)
+  assert(cast[Map[Int, String]](Map(1 -> "toto", 2 -> "tata", 3 -> "tutu")) == Some(Map(1 -> "toto", 2 -> "tata", 3 -> "tutu")))
+}
+
+
+
+

--- a/test/files/run/kind-poly11.flags
+++ b/test/files/run/kind-poly11.flags
@@ -1,0 +1,2 @@
+-Ykind-polymorphism
+-opt-warnings

--- a/test/files/run/kind-poly12.flags
+++ b/test/files/run/kind-poly12.flags
@@ -1,0 +1,1 @@
+-Ykind-polymorphism

--- a/test/files/run/kind-poly12.scala
+++ b/test/files/run/kind-poly12.scala
@@ -1,0 +1,357 @@
+import scala.language.higherKinds
+// import scala.reflect.ClassTag
+// import scala.collection.{ GenMap, GenTraversable }
+
+object Test extends App {
+
+  // Scala Conversion of haskell code in http://blog.functorial.com/posts/2012-02-02-Polykinded-Folds.html
+  // to study more samples of kind polymorphism in Scala
+  // 
+  // It provides the implementation of Kind-Polymorphism Category, Functor & Rec for generic folding
+
+  // HASKELL CODE
+  // class Category hom where
+  //   ident :: hom a a
+  //   compose :: hom a b -> hom b c -> hom a c
+  trait Category[->[_<:AnyKind, _<:AnyKind]] {
+    def ident[A <: AnyKind] : A -> A
+    def compose[A <: AnyKind, B <: AnyKind, C <: AnyKind] : (A -> B) => (B -> C) => (A -> C)
+  }
+
+  object Category {
+    def apply[->[_<:AnyKind, _<:AnyKind]](implicit cat: Category[->]): cat.type = cat
+  }
+
+  /** Category for => */
+  implicit val Function1Category = new Category[Function1] {
+    def ident[A] : A => A = identity
+    def compose[A, B, C] = (f: A => B) => (g: B => C) => g.compose(f)
+  }
+
+  // Test
+
+  /** Category for ~> Natural Transformation */
+  trait ~>[F[_], G[_]] {
+    def apply[A](fa: F[A]): G[A]
+  }
+
+  implicit val NatCategory = new Category[~>] {
+    def ident[A[_]] : A ~> A = new (A ~> A) {
+      def apply[T](a: A[T]) = a
+    }
+    
+    def compose[A[_], B[_], C[_]] = (f: A ~> B) => (g: B ~> C) => new (A ~> C) {
+      def apply[T](a: A[T]): C[T] = g(f(a))
+    }
+  }
+
+  // Test
+  // assert(implicitly[Category[~>]].ident[List](List(5)) == List(5))
+  
+  val list2Option = new (List ~> Option) {
+    def apply[A](l: List[A]) = l.headOption
+  }
+  val option2List = new (Option ~> List) {
+    def apply[A](l: Option[A]) = l.toList
+  }
+  // assert(Category[~>].compose(list2Option)(option2List)(List(5, 6)) == List(5))
+/*
+  // class HFunctor hom f where
+  //   hmap :: hom a b -> hom (f a) (f b)  
+  /**
+    * HFunctor is a higher-kind functor transforming a morphism A -> B into (F[A] -> F[B])
+    * where F[A] is A applied to polykinded type F (considered as curried type function)
+    * for example: if F is TC[?[_], ?] and we apply A[_] to F, it gives F[A] = TC[A, ?]
+    */
+  trait HFunctor[F <: AnyKind, ->[_<:AnyKind, _<:AnyKind]] {
+    /** In Scala, types are not naturally currified type function so we need to help scalac with this HMorph structure
+      * that transform the morphism A -> B into morphism F[A] -> F[B] where F[A] means A applied to F 
+      */ 
+    def hmap[A <: AnyKind, B <: AnyKind](f: => A -> B)(implicit hmorph: HMorph[F, ->, A, B]): hmorph.Out = hmorph(f)
+  }
+
+  object HFunctor {
+    def apply[F <: AnyKind, ->[_<:AnyKind, _<:AnyKind]](implicit hf: HFunctor[F, ->]): hf.type = hf
+  }
+
+
+  /** Transform a morphism A -> B into another morphism (F[A] -> F[B]) where F[A] means type A applied to type function F
+    *
+    * For example, for TC[M[_], A] and Natural Transformation ~>, 
+    * it could transform (F ~> G) into (TC[F, ?] ~> TC[G, ?]) applying F and G on TC
+    */
+  trait HMorph[F <: AnyKind, ->[_<:AnyKind, _<:AnyKind], A <: AnyKind, B <: AnyKind] {
+    type OutA <: AnyKind
+    type OutB <: AnyKind
+    type Out = OutA -> OutB
+    def apply(f: => A -> B): Out
+  }
+
+  // class Rec hom f t where
+  //   _in :: hom (f t) t
+  //   out :: hom t (f t)
+  /** A Generic Recursion structure used in classic (un)folding techniques (like cata/ana)... cf matryoschka */
+  trait Rec[F <: AnyKind, ->[_<:AnyKind, _<:AnyKind], T <: AnyKind, FT <: AnyKind] {
+    def in: FT -> T
+    def out: T -> FT
+  }
+
+  // SAMPLE with Tree
+  // data FCTree f a = FCLeaf a | FCBranch (f (a, a))
+  sealed trait FCTree[F[_], A]
+  case class FCLeaf[F[_], A](a: A) extends FCTree[F, A]
+  case class FCBranch[F[_], A](fa: F[(A, A)]) extends FCTree[F, A]
+  
+  // data CTree a = CLeaf a | CBranch (CTree (a, a))
+  sealed trait CTree[A]
+  case class CLeaf[A](a: A) extends CTree[A]
+  case class CBranch[A](fa: CTree[(A, A)]) extends CTree[A]
+
+  object FCTree {
+    /** the Morphism from A ~> Bto FCTree[A, ?] ~> FCTree[B, ?] */
+    implicit def hmorph[A[_], B[_]] = new HMorph[FCTree, ~>, A, B] {
+      type OutA[t] = FCTree[A, t]
+      type OutB[t] = FCTree[B, t]
+      def apply(f: => A ~> B): (OutA ~> OutB) = new (OutA ~> OutB) {
+        def apply[T](fa: OutA[T]) = fa match {
+          case FCLeaf(a) => FCLeaf(a)
+          case FCBranch(fa) => FCBranch(f(fa))
+        }
+      }
+    }
+
+    /** Functor is trivial as HMorph does the job */
+    implicit val hfunctor = new HFunctor[FCTree, ~>] {}
+
+    /** Rec */
+    implicit val rec = new Rec[FCTree, ~>, CTree, ({ type l[t] = FCTree[CTree, t] })#l] {
+      type FT[t] = FCTree[CTree, t]
+      val in = new (FT ~> CTree) {
+        def apply[A](ft: FT[A]): CTree[A] = ft match {
+          case FCLeaf(a)    => CLeaf(a)
+          case FCBranch(aa) => CBranch(aa)
+        }
+      }
+      val out = new (CTree ~> FT) {
+        def apply[A](ct: CTree[A]): FT[A] = ct match {
+          case CLeaf(a)    => FCLeaf(a)
+          case CBranch(aa) => FCBranch(aa)
+        }
+      }
+    }
+  }
+
+  val mapper = HFunctor[FCTree, ~>].hmap(list2Option)
+  assert(mapper(FCLeaf[List, Int](5)) == FCLeaf[Option, Int](5))
+  assert(mapper(FCBranch(List((5, 6)))) == FCBranch(Some((5, 6))))
+
+  /** Generic fold function (like cata) */
+  // fold :: (Category hom, HFunctor hom f, Rec hom f rec) => hom (f t) t -> hom rec t
+  // fold phi = compose out (compose (hmap (fold phi)) phi)
+  def fold[F <: AnyKind, ->[_<:AnyKind, _<:AnyKind], T <: AnyKind, R <: AnyKind, FT <: AnyKind, FR <: AnyKind](phi: FT -> T)(
+    implicit  category: Category[->]
+            , hfunctor: HFunctor[F, ->]
+            , rec: Rec[F, ->, R, FR]
+            , hmorph: HMorph[F, ->, FT, T]
+  ): R -> T = category.compose(rec.out)(category.compose(hfunctor.hmap(fold(phi)))(phi))
+
+  /** Generic unfold function (like cata) */
+  // unfold :: (Category hom, HFunctor hom f, Rec hom f rec) => hom t (f t) -> hom t rec
+  // unfold phi = compose phi (compose (hmap (unfold phi)) _in)
+  def unfold[F <: AnyKind, ->[_<:AnyKind, _<:AnyKind], T <: AnyKind, R <: AnyKind, FT <: AnyKind, FR <: AnyKind](phi: T -> FT)(
+    implicit  category: Category[->]
+            , hfunctor: HFunctor[F, ->]
+            , rec: Rec[F, ->, R, FR]
+            , hmorph: HMorph[F, ->, FT, T]
+  ): T -> R = category.compose(phi)(category.compose(hfunctor.hmap(unfold(phi)))(rec.in))
+
+
+  // cdepth :: CTree a -> Int
+  // cdepth c = let (K d) = nu (fold (Nat phi)) c in d where
+  //   phi :: FCTree (K Int) a -> K Int a
+  //   phi (FCLeaf a) = K 1
+  //   phi (FCBranch (K n)) = K (n + 1)
+
+  case class K[A, B](a: A)
+  def cdepth[A](c: CTree[A]): Int = {
+    type KInt[A] = K[Int, A]
+    type FK[A] = FCTree[KInt, A]
+    type FC[A] = FCTree[CTree, A]
+
+    val phi = new (FK ~> KInt) {
+      def apply[A](f: FCTree[KInt, A]): KInt[A] = f match {
+        case FCLeaf(a) => K(1)
+        case FCBranch(K(n)) => K(n + 1)
+      }
+    }
+
+    fold[FCTree, ~>, KInt, CTree, FK, FC](phi).apply(c).a
+  }
+
+  assert(cdepth(CBranch(CBranch(CLeaf((5, 6),(7, 8))))) == 3)
+*/
+
+  /** Monoid forms a Category
+    * FYI, for convenience of the sample, that Monoid representation can't represent Monads
+    * as "mult" can't be used to represent Functor Composition M[M[?]]
+    */
+  trait Monoid[M <: AnyKind] {
+    type ->[_<:AnyKind, _<:AnyKind]
+    type I <: AnyKind
+
+    def unit: ->[I, M]
+    def mult(a: I -> M, b: I -> M): I -> M
+  }
+
+  object Monoid {
+    type Aux[M <: AnyKind, M0[_<:AnyKind, _<:AnyKind], I0 <: AnyKind] = Monoid[M] { type ->[a <: AnyKind, b <: AnyKind] = M0[a, b]; type I = I0 }
+
+    def apply[M <: AnyKind](implicit monoid: Monoid[M]): monoid.type = monoid
+  }
+
+  /** Sample with Int & integer multiplication */
+  implicit val MonoidIntMul: Monoid.Aux[Int, Function1, Unit] = new Monoid[Int] {
+    type ->[a, b] = Function1[a, b]
+    type I = Unit
+
+    val unit: Unit => Int = _ => 1
+    def mult(a: Unit => Int, b: Unit => Int): Unit => Int = _ => a(()) * b(())
+  }
+
+  assert(Monoid[Int].unit(()) == 1)
+  assert(Monoid[Int].mult(_ => 5, _ => 10)(()) == 50)
+
+  type Id[A] = A
+  implicit val MonoidList: Monoid.Aux[List, ~>, Id] = new Monoid[List] {
+    type ->[a[_], b[_]] = ~>[a, b]
+    type I[a] = Id[a]
+
+    val unit: Id ~> List = new (Id ~> List) {
+      def apply[A](id: Id[A]): List[A] = List()
+    }
+    def mult(a: Id ~> List, b: Id ~> List): Id ~> List = new (Id ~> List) {
+      def apply[A](id: Id[A]): List[A] = a(id) ++ b(id)
+    }
+  }
+
+  assert(Monoid[List].unit(0:Id[Int]) == List[Int]())
+  val l = new (Id ~> List) {
+    def apply[A](id: Id[A]): List[A] = List(id)
+  }
+  assert(Monoid[List].mult(l, l)(5: Id[Int]) == List(5, 5))
+
+  def MonoidCategory[M <: AnyKind](implicit monoid: Monoid[M]) = {
+    import monoid._
+    new Category[({ type l[A <: AnyKind, B <: AnyKind] = I -> M })#l] {
+      def ident[A <: AnyKind]: I -> M = monoid.unit
+      def compose[A <: AnyKind, B <: AnyKind, C <: AnyKind] =
+        (f: I -> M) => (g: I -> M) => monoid.mult(f, g)
+    }
+  }
+
+  assert(MonoidCategory[List].ident(0) == List())
+  assert(MonoidCategory[List].compose(l)(l)(5: Id[Int]) == List(5, 5))
+
+
+/*
+  // The rest of the code is far better in Haskell and in Scala we wouldn't write it as in the article
+  // showing once again that it's useless to try to write Haskell in Scala as both have different pros/cons
+  // It's better to use the right techniques in the context of its language and not try to imitate
+  // Yet it's clear that naturally curried types in Haskell makes syntax much cleaner...
+
+  // data Choice = Fst | Snd
+  sealed trait Choice
+  case object Fst extends Choice
+  case object Snd extends Choice
+
+  trait Applied[F <: AnyKind, A <: AnyKind] {
+    type Out <: AnyKind
+  }
+
+  // newtype PHom h1 h2 p1 p2 = PHom { runPHom :: forall r. (h1 (p1 Fst) (p2 Fst) -> h2 (p1 Snd) (p2 Snd) -> r) -> r }
+  trait PHom[H1[_ <: AnyKind, _ <: AnyKind], H2[_ <: AnyKind, _ <: AnyKind], P1<:AnyKind, P2<:AnyKind] {
+    def apply[R](h: H1[Applied[P1, Fst.type], Applied[P2, Fst.type]] => H2[Applied[P1, Snd.type], Applied[P2, Snd.type]] => R): R
+  }
+
+  // instance (Category h1, Category h2) => Category (PHom h1 h2) where
+  //  ident = mkPHom ident ident
+  //  compose p1 p2 = mkPHom (compose (fstPHom p1) (fstPHom p2)) (compose (sndPHom p1) (sndPHom p2))
+  object PHom {
+    implicit def category[H1[_ <: AnyKind, _ <: AnyKind], H2[_ <: AnyKind, _ <: AnyKind]](
+      implicit  cat1: Category[H1], cat2: Category[H2]
+    ) = new Category[({ type l[p1<:AnyKind, p2<:AnyKind] = PHom[H1, H2, p1, p2] })#l] {
+      def ident[A <: AnyKind] : PHom[H1, H2, A, A] = new PHom[H1, H2, A, A] {
+        def apply[R](h: H1[Applied[A, Fst.type], Applied[A, Fst.type]] => H2[Applied[A, Snd.type], Applied[A, Snd.type]] => R): R =
+          h(cat1.ident[A])(cat2.ident[A])
+      }
+
+      def compose[A <: AnyKind, B <: AnyKind, C <: AnyKind] : PHom[H1, H2, A, B] => PHom[H1, H2, B, C] => PHom[H1, H2, A, C] =
+        p1 => p2 => {
+          val fst1 = p1( (fst: H1[Applied[A, Fst.type], Applied[B, Fst.type]]) => (snd: H2[Applied[A, Snd.type], Applied[B, Snd.type]]) => fst )
+          val snd1 = p1( (fst: H1[Applied[A, Fst.type], Applied[B, Fst.type]]) => (snd: H2[Applied[A, Snd.type], Applied[B, Snd.type]]) => snd )
+          val fst2 = p2( (fst: H1[Applied[B, Fst.type], Applied[C, Fst.type]]) => (snd: H2[Applied[B, Snd.type], Applied[C, Snd.type]]) => fst )
+          val snd2 = p2( (fst: H1[Applied[B, Fst.type], Applied[C, Fst.type]]) => (snd: H2[Applied[B, Snd.type], Applied[C, Snd.type]]) => snd )
+          
+          new PHom[H1, H2, A, C] {
+            def apply[R](h: H1[Applied[A, Fst.type], Applied[C, Fst.type]] => H2[Applied[A, Snd.type], Applied[C, Snd.type]] => R): R =
+              h(cat1.compose(fst1)(fst2))(cat2.compose(snd1)(snd2))
+          }
+        }
+    }
+  }
+
+
+  // data FAlt :: * -> (Choice -> *) -> Choice -> * where
+  //   FZero :: FAlt a p Fst
+  //   FSucc1 :: a -> (p Snd) -> FAlt a p Fst
+  //   FSucc2 :: a -> (p Fst) -> FAlt a p Snd
+  sealed trait FAlt[A, P[C <: Choice], C <: Choice]
+  case class FZero[A, P[C <: Choice]]() extends FAlt[A, P, Fst.type]
+  case class FSucc1[A, P[C <: Choice]](h: A, t: P[Snd.type]) extends FAlt[A, P, Fst.type]
+  case class FSucc2[A, P[C <: Choice]](h: A, t: P[Fst.type]) extends FAlt[A, P, Snd.type]
+
+  // data Alt :: * -> Choice -> * where
+  //   Zero :: Alt a Fst
+  //   Succ1 :: a -> Alt a Snd -> Alt a Fst
+  //   Succ2 :: a -> Alt a Fst -> Alt a Snd
+  sealed trait Alt[A, C <: Choice]
+  case class Zero[A]() extends Alt[A, Fst.type]
+  case class Succ1[A](h: A, t: Alt[A, Snd.type]) extends Alt[A, Fst.type]
+  case class Succ2[A](h: A, t: Alt[A, Fst.type]) extends Alt[A, Snd.type]
+
+
+  // instance Rec (PHom (->) (->)) (FAlt a) (Alt a) where
+  //   _in = mkPHom f g where
+  //     f FZero = Zero
+  //     f (FSucc1 a b) = Succ1 a b
+  //     g (FSucc2 a b) = Succ2 a b
+  //   out = mkPHom f g where
+  //     f Zero = FZero
+  //     f (Succ1 a b) = FSucc1 a b
+  //     g (Succ2 a b) = FSucc2 a b
+
+  // instance HFunctor (PHom (->) (->)) (FAlt a) where
+  //   hmap p = mkPHom hf hg where
+  //     hf FZero = FZero
+  //     hf (FSucc1 a x) = FSucc1 a (sndPHom p x)
+  //     hg (FSucc2 a x) = FSucc2 a (fstPHom p x)
+
+  // object FAlt {
+  //   implicit def hmorph[A] = new HMorph[FAlt, ({ type l[p1<:AnyKind, p2<:AnyKind] = PHom[Function1, Function1, p1, p2] })#l, A, B] {
+  //     type OutA[P[C <: Choice], C <: Choice] = FAlt[A, P, C]
+  //     type OutB[P[C <: Choice], C <: Choice] = FAlt[A, P, t]
+  //     def apply(f: => PHom[Function1, Function1, A, B]): PHom[->, ->, FAlt[A, P, C], FAlt[A, P, C]] = {
+  //       def hf(fa: FAlt[A, P1, C]) = fa match {
+  //         case FZero() => FZero[A, P2, C]
+  //         case FSucc1(a, t) => FSucc1(a, f((fst: Applied[P1, Fst.type] => Applied[P2, Fst.type]]) => (snd: H2[Applied[A, Snd.type], Applied[B, Snd.type]]) => fst )))
+  //       }
+  //     }
+  //   }
+
+  //   implicit def hfunctor[A] = new HFunctor[({ type l[P[C <: Choice], C <: Choice] = FAlt[A, P, C] })#l, ({ type l[p1<:AnyKind, p2<:AnyKind] = PHom[->, ->, p1, p2] })#l] {}
+  // }
+*/
+}
+
+
+

--- a/test/files/run/kind-poly13.flags
+++ b/test/files/run/kind-poly13.flags
@@ -1,0 +1,1 @@
+-Ykind-polymorphism

--- a/test/files/run/kind-poly13.scala
+++ b/test/files/run/kind-poly13.scala
@@ -1,0 +1,35 @@
+import scala.language.higherKinds
+
+object Test extends App {
+
+  trait Bar[A[_]]
+  trait Foo {
+    type L[_ <: AnyKind]
+  }
+  type Aux[L0[_ <: AnyKind]] = Foo { type L[a <: AnyKind] = L0[a] }
+
+  val l: Aux[Bar] = new Foo { type L[a[_]] = Bar[a] }
+
+
+  trait Foo2 {
+    type L <: AnyKind
+  }
+  type Aux2[L0 <: AnyKind] = Foo2 { type L = L0 }
+  val l2: Aux2[List] = new Foo2 { type L[a] = List[a] }
+
+  trait Foo3[M <: AnyKind] {
+    type L <: AnyKind
+  }
+  type Aux3[M <: AnyKind, L0 <: AnyKind] = Foo3[M] { type L = L0 }
+
+  val l3: Aux3[List, Int] = new Foo3[List] { type L = Int }
+
+
+  trait ~>[F[_], G[_]] {
+    def apply[A](fa: F[A]): G[A]
+  }
+
+}
+
+
+

--- a/test/files/run/kind-poly14.flags
+++ b/test/files/run/kind-poly14.flags
@@ -1,0 +1,1 @@
+-Ykind-polymorphism

--- a/test/files/run/kind-poly14.scala
+++ b/test/files/run/kind-poly14.scala
@@ -1,0 +1,131 @@
+import scala.language.higherKinds
+
+object Test extends App {
+
+
+  trait X[F[_] <: AnyKind] { type L = F[Int]; def a: L = ??? }
+  new X[List] { }
+
+  trait X2[A <: AnyKind, B <: AnyKind] { def run[F[_ <: AnyKind]]: F[A] => F[B] }
+
+  val x21 = {
+    new X2[Int, Int] { def run[F[_]]: F[Int] => F[Int] = identity[F[Int]] }.run[List]
+  }
+
+
+  trait X3[A <: AnyKind, B <: AnyKind, C <: AnyKind] { def run[F[_ <: AnyKind, _ <: AnyKind]]: F[A, C] => F[B, C] }
+
+  val x31 = {
+    new X3[Int, Int, String] { def run[F[_, _]]: F[Int, String] => F[Int, String] = identity[F[Int, String]] }.run[Map]
+  }
+
+
+  trait X4[A <: AnyKind, B <: AnyKind, C] { def run[F[_ <: AnyKind, _]]: F[A, C] => F[B, C] }
+
+  trait Foo4[A]
+  trait Bar4[A]
+
+  trait Toto4[F[_], A]
+
+  val x41 = {
+    new X4[Foo4, Foo4, Int] { def run[F[_[_], A]]: F[Foo4, Int] => F[Foo4, Int] = identity[F[Foo4, Int]] }
+      .asInstanceOf[X4[Bar4, Bar4, Int]].run[Toto4]
+  }
+
+  trait X5[A[_ <: AnyKind], B[_ <: AnyKind]] { def run[F[_[_ <: AnyKind]]]: F[A] => F[B] }
+
+  trait Foo5[A[_]]
+  trait Bar5[A[_]]
+
+  trait Toto[F[_[_]]]
+
+  val x51 = {
+    new X5[Foo5, Foo5] { def run[F[_[_ <: AnyKind]]]: F[Foo5] => F[Foo5] = identity[F[Foo5]] }
+      .asInstanceOf[X5[Bar5, Bar5]].run[Toto]
+  }
+
+  x51(new Toto[Bar5] {})
+
+
+}
+
+
+
+
+
+
+/*
+class Functor (p :: k1 -> k2) (r :: k1 -> k1 -> *) (s :: k2 -> k2 -> *) where
+  fmap :: a `r` b -> (p a) `s` (p b)
+type Nat (cat :: k1 -> k1 -> *) (f :: k2 -> k1) (g :: k2 -> k1) = forall (a :: k2). (f a) `cat` (g a)
+newtype HFreeK (cat :: k -> k -> *) (c :: (k -> *) -> Constraint) (f :: k -> *) a =
+  HFree { runHFree :: forall (g :: k -> *). (c g, Functor g cat (->)) => Nat (->) f g -> g a }
+*/
+
+// sealed trait Functor[K1<:AnyKind, K2[_<:K1]<:AnyKind, ->[_<:K1, _<:K1], ~>[_<:K2, _<:K2]] {
+//   def fmap[A <: K1, B <: K1]: A -> B => K2[A] ~> K2[B]
+// }
+
+/*
+  data HFree t m a where
+    Lift :: m a -> HFree t m a
+    Gen :: t m a -> HFree t m a
+    Hoist :: (forall x . n x -> m x) -> HFree t n a -> HFree t m a
+    Embed :: (forall x . n x -> HFree t m x) -> HFree t n a -> HFree t m a
+*/
+
+// trait UnapplyApply[FA, F <: AnyKind, G <: AnyKind, GA, M <: Morphism[F, G]] {
+//   def apply(m: M)(g: FA): GA
+// }
+
+// /** a kind-polymorphic morphism */
+// sealed trait Morphism[F <: AnyKind, G <: AnyKind] {
+//   def apply[FApp, GApp](v: FApp)(implicit unapplyApply: UnapplyApply[FApp, F, G, GApp, this.type]): GApp = unapplyApply(this)(v)
+// }
+
+// sealed trait HFree[M <: AnyKind, ->[_<:AnyKind, _<:AnyKind]] {
+//   type MA
+//   type A
+// }
+
+// case class Lift[M <: AnyKind, ->[_<:AnyKind, _<:AnyKind], MA0, A0](value: A0) extends HFree[M, ->] {
+//   type MA = MA0
+//   type A = A0
+// }
+
+// case class Gen[M <: AnyKind, ->[_<:AnyKind, _<:AnyKind], MA0, A0](value: MA0) extends HFree[M, ->] {
+//   type MA = MA0
+//   type A = A0
+// }
+
+// case class Hoist[N <: AnyKind, ->[_<:AnyKind, _<:AnyKind], NA, A, M <: AnyKind, MA](
+//   nat: N -> M
+// , free: HFree[N, ->]
+// ) extends HFree[M, ->] {
+//   type MA = 
+// }
+
+// case class Embed[M <: AnyKind](
+//   nat: N -> HFree[M, ->]
+// , free: HFree[N, ->]
+// ) extends HFree[M, ->]
+
+// trait Lifter[->[_<:AnyKind, _<:AnyKind], M <: AnyKind, T <: AnyKind] {
+//   type TM
+//   def lift: M -> TM
+// }
+
+// new Lifter[~>, M[_], T[_[_]]] {
+//   type TM = TM[M]
+// }
+
+// def foldMap[M <: AnyKind, N <: AnyKind, -> <: Morphism[M, N]](nat: M -> N): HFree[M, ->] -> MA = free match {
+//   case Lift(a) => Lift()
+// }
+
+// trait ~>[F[_], G[_]] {
+//   def apply[A](fa: F[A]): G[A]
+// }
+
+// type Free[F[_], A] = HFree[F, ~>, F[A], A]
+

--- a/test/files/run/kind-poly7.flags
+++ b/test/files/run/kind-poly7.flags
@@ -1,0 +1,1 @@
+-Ykind-polymorphism

--- a/test/files/run/kind-poly7.scala
+++ b/test/files/run/kind-poly7.scala
@@ -1,0 +1,170 @@
+import scala.language.higherKinds
+
+object Test extends App {
+  /** An poly-kinded representation of morphism
+    * UnapplyApply is used to recollect kinds and their order-1  derived types
+    */
+  trait UnapplyApply[FA, F <: AnyKind, G <: AnyKind, GA, M] {
+    def apply(m: M)(g: FA): GA
+  }
+
+  /** a kind-polymorphic morphism */
+  sealed trait Morphism[F <: AnyKind, G <: AnyKind] {
+    def apply[FApp, GApp](v: FApp)(implicit unapplyApply: UnapplyApply[FApp, F, G, GApp, this.type]): GApp = unapplyApply(this)(v)
+  }
+
+  /** order-1 morphism AKA function */
+  class Morphism1[A, B](val f: A => B) extends Morphism[A, B]
+
+  object Morphism1 {
+    /** the unapplyApply for morphism1 */
+    implicit def unapplyApply1[A, B, M <: Morphism1[A, B]] = new UnapplyApply[A, A, B, B, M] {
+      def apply(m: M)(a: A): B = m.f(a)
+    }
+  }
+
+  /** order-2 morphism AKA FunctionK */
+  trait Morphism2[F[_], G[_]] extends Morphism[F, G] {
+    def apply[A](fa: F[A]): G[A]
+  }
+
+  object Morphism2 {
+    /** the unapplyApply for morphism2 */
+    implicit def unapplyApply2[F[_], G[_], A, M <: Morphism2[F, G]] = new UnapplyApply[F[A], F, G, G[A], M] {
+      def apply(m: M)(fa: F[A]): G[A] = m.apply(fa)
+    }
+  }
+
+  /** The PolyKinded representation of Functor */
+  trait Functor[F <: AnyKind] extends {
+    /** the functor domain morphism (A => B for simple Functor) */
+    type M <: AnyKind
+    /** the functor co-domain morphism (F[A] => F[B] for simple Functor) */
+    type MK <: AnyKind
+
+    /** the Functor Morphism of Morphism (A => B) => (F[A] => F[B]) */
+    def mapper[MA, MKA](ma: MA)(implicit unap: UnapplyApply[MA, M, MK, MKA, this.type]): MKA = unap.apply(this)(ma)
+  }
+
+  object Functor {
+    type Aux[F <: AnyKind, M0 <: AnyKind, MK0 <: AnyKind] = Functor[F] { type M = M0; type MK = MK0 }
+    
+    def apply[F <: AnyKind](implicit functor: Functor[F]): functor.type = functor
+  }
+
+  type Morphism1F[F[_], A, B] = Morphism1[F[A], F[B]]
+
+  /** Just a helper to make it simpler to write Functor of F[_] (like Functor[List]) */
+  abstract class Functor1[F[_]] extends Functor[F] {
+    type M[A, B] = Morphism1[A, B]
+    type MK[A, B] = Morphism1F[F, A, B]
+
+    def map[A, B](fa: F[A])(f: A => B): F[B]
+  }
+
+  object Functor1 {
+    def apply[F[_]](implicit functor: Functor1[F]): functor.type = functor
+
+    implicit def unap1[F[_], A, B, F1 <: Functor1[F]] =
+      new UnapplyApply[Morphism1[A, B], Morphism1, ({ type l[a, b] = Morphism1F[F, a, b] })#l, Morphism1F[F, A, B], F1] {
+        def apply(m: F1)(ma: Morphism1[A, B]): Morphism1F[F, A, B] = new Morphism1[F[A], F[B]](
+          (fa: F[A]) => m.map(fa)(a => ma.f(a))
+        )
+      }   
+  }
+
+  /** Just a helper to make it simpler to write Functor of TC[_[_], _] (like Functor[TC[_[_], _]]) */
+  abstract class Functor21[TC[_[_], _]] extends Functor[TC] {
+    type M[F[_], G[_]] = Morphism2[F, G]
+    type MK[F[_], G[_]] = Morphism2[({ type l[t] = TC[F, t] })#l, ({ type l[t] = TC[G, t] })#l]
+
+    def map[F[_], G[_], A](fa: TC[F, A])(f: Morphism2[F, G]): TC[G, A]
+  }
+
+  type Morphism2F[TC[_[_], _], F[_], G[_]] = Morphism2[({ type l[t] = TC[F, t] })#l, ({ type l[t] = TC[G, t] })#l]
+
+  object Functor21 {
+    implicit def unap21[TC[_[_], _], F[_], G[_], FU <: Functor21[TC]] = {
+      new UnapplyApply[Morphism2[F, G], Morphism2, ({ type l[f[_], g[_]] = Morphism2F[TC, f, g] })#l, Morphism2F[TC, F, G], FU] {
+        def apply(fu: FU)(ma: Morphism2[F, G]): Morphism2F[TC, F, G] =
+          new Morphism2[({ type l[t] = TC[F, t] })#l, ({ type l[t] = TC[G, t] })#l] {
+            def apply[A](tca: TC[F, A]) : TC[G, A] = fu.map(tca)(ma)
+          }
+      }
+    }
+  }
+
+  /** Just a helper to make it simpler to write Functor of TC[_[_], _] restricted by Functor (like Functor[Free]) */
+  abstract class Functor21Functor[TC[_[_], _]] extends Functor[TC] {
+    type M[F[_], G[_]] = Morphism2[F, G]
+    type MK[F[_], G[_]] = Morphism2[({ type l[t] = TC[F, t] })#l, ({ type l[t] = TC[G, t] })#l]
+
+    def map[F[_]:Functor1, G[_]:Functor1, A](fa: TC[F, A])(f: Morphism2[F, G]): TC[G, A]
+  }
+
+  object Functor21Functor {
+    implicit def unap21Functor[TC[_[_], _], F[_]: Functor1, G[_]: Functor1, FU <: Functor21Functor[TC]] = {
+      new UnapplyApply[Morphism2[F, G], Morphism2, ({ type l[f[_], g[_]] = Morphism2F[TC, f, g] })#l, Morphism2F[TC, F, G], FU] {
+        def apply(fu: FU)(ma: Morphism2[F, G]): Morphism2F[TC, F, G] =
+          new Morphism2[({ type l[t] = TC[F, t] })#l, ({ type l[t] = TC[G, t] })#l] {
+            def apply[A](tca: TC[F, A]) : TC[G, A] = fu.map(tca)(ma)
+          }
+      }
+    }
+  }
+
+  // Sample1: List/Option Functor
+  implicit val listFunctor = new Functor1[List] {
+    def map[A, B](fa: List[A])(f: A => B): List[B] = fa.map(f)
+  }
+
+  val l: List[String] = Functor[List].mapper(new Morphism1((i:Int) => i.toString)).apply(List(5))
+  assert(l == List("5"))
+
+  implicit val optionFunctor = new Functor1[Option] {
+    def map[A, B](fa: Option[A])(f: A => B): Option[B ]= fa.map(f)
+  }
+
+  val l2: Option[String] = Functor[Option].mapper(new Morphism1((i:Int) => i.toString)).apply(Some(5):Option[Int])
+  assert(l2 == Some("5"))
+
+  // Sample2: TC[_[_], _] Functor
+  case class TC[F[_], A](fa: F[A])
+    
+  object TC {
+    implicit val tcFunctor = new Functor21[TC] {
+      def map[F[_], G[_], A](tca: TC[F, A])(m: Morphism2[F, G]): TC[G, A] = new TC[G, A](m.apply(tca.fa))
+    }
+  }
+
+  case class Foo[A](a: A)
+  case class Bar[A](a: A)
+  val tc: TC[Bar, Int] = Functor[TC].mapper(new Morphism2[Foo, Bar] {
+    def apply[A](foo: Foo[A]): Bar[A] = Bar(foo.a)
+  }).apply(TC(Foo(15)))
+
+  assert(tc == TC(Bar(15)))
+
+
+  // Sample3: Free[_[_], _] Functor
+  sealed abstract class Free[F[_]: Functor1, A]
+  case class Pure[F[_]: Functor1, A](a: A) extends Free[F, A]
+  case class Suspend[F[_]: Functor1, A](a: F[Free[F, A]]) extends Free[F, A]
+
+  object Free {
+    implicit val freeFunctor = new Functor21Functor[Free] {
+      self =>
+      def map[F[_]:Functor1, G[_]:Functor1, A](free: Free[F, A])(m2: Morphism2[F, G]): Free[G, A] = free match {
+        case Pure(a)      => Pure[G, A](a)
+        case Suspend(fa)  => Suspend(m2.apply(Functor[F].map(fa){ (free: Free[F, A]) => self.map(free)(m2) }))
+      }
+    }
+  }
+
+  val free: Free[Option, Int] = Functor[Free].mapper(new Morphism2[List, Option] {
+    def apply[A](l: List[A]): Option[A] = l.headOption
+  }).apply(Pure[List, Int](15))
+
+  assert(free == Pure[Option, Int](15))
+}
+

--- a/test/files/run/kind-poly8.flags
+++ b/test/files/run/kind-poly8.flags
@@ -1,0 +1,1 @@
+-Ykind-polymorphism

--- a/test/files/run/kind-poly8.scala
+++ b/test/files/run/kind-poly8.scala
@@ -1,0 +1,64 @@
+import scala.language.higherKinds
+
+object Test extends App {
+
+
+  trait ShowType[T <: AnyKind] {
+    def show: String
+  }
+
+  object ShowType {
+
+    def apply[T <: AnyKind](implicit st: ShowType[T]): st.type = st
+    
+    implicit def show1A[F[_], A](implicit stf: ShowType[F], sta: ShowType[A]) =
+      new ShowType[F[A]] { def show = s"${stf.show}[${sta.show}]" }
+
+    implicit def show2AB[F[_, _], A, B](implicit stf: ShowType[F], sta: ShowType[A], stb: ShowType[B]) =
+      new ShowType[F[A, B]] { def show = s"${stf.show}[${sta.show}, ${stb.show}]" }
+
+    implicit def showInt = new ShowType[Int] { def show = s"Int" }
+    implicit def showString = new ShowType[String] { def show = s"String" }
+
+    implicit def showList = new ShowType[List] { def show = s"List" }
+    implicit def showMap = new ShowType[Map] { def show = s"Map" }
+    
+  }
+
+
+  assert(ShowType[Int].show == "Int")
+  assert(ShowType[List].show == "List")
+  assert(ShowType[List[Int]].show == "List[Int]")
+
+  assert(ShowType[Map].show == "Map")
+  assert(ShowType[Map[Int, String]].show == "Map[Int, String]")
+
+  trait HeadOption[T <: AnyKind] {
+    import HeadOption._
+    def headOption[TA, A](ta: TA)(implicit unap: UnapplyApply[TA, T, A, this.type]): Option[A] = unap.apply(ta)
+  }
+
+  object HeadOption {
+    def apply[T <: AnyKind](implicit ho: HeadOption[T]): ho.type = ho
+
+    trait UnapplyApply[TA, T <: AnyKind, A, M <: HeadOption[T]] {
+      def apply(ta: TA): Option[A]
+    }
+
+    implicit def listUnap[A, M <: HeadOption[List]] = new HeadOption.UnapplyApply[List[A], List, A, M] {
+      def apply(ta: List[A]): Option[A] = ta.headOption
+    }
+    implicit def listHO = new HeadOption[List] {}
+
+    implicit def mapUnap[A, B, M <: HeadOption[Map]] = new HeadOption.UnapplyApply[Map[A, B], Map, (A, B), M] {
+      def apply(ta: Map[A, B]): Option[(A, B)] = ta.headOption
+    }
+
+    implicit def mapHO = new HeadOption[Map] {}
+  }
+
+  assert(HeadOption[List].headOption(List(5, 6, 7)) == Some(5))
+  assert(HeadOption[Map].headOption(Map("toto" -> 5L, "tata" -> 10L)) == Some("toto" -> 5L))
+}
+
+

--- a/test/files/run/kind-poly9.flags
+++ b/test/files/run/kind-poly9.flags
@@ -1,0 +1,1 @@
+-Ykind-polymorphism

--- a/test/files/run/kind-poly9.scala
+++ b/test/files/run/kind-poly9.scala
@@ -1,0 +1,205 @@
+import scala.language.higherKinds
+
+object Test extends App {
+
+  // PKList or the Any-Order heterogenous list
+  sealed trait PKList[Args <: AnyKind]
+
+  trait PKNil[Args <: AnyKind] extends PKList[Args]
+
+  sealed trait PKCons[Args <: AnyKind, HA, TA <: PKList[Args]] extends PKList[Args] {
+    def head: HA
+    def tail: TA
+  }
+
+  object PKList {
+
+    trait PKConsBuilder[Args <: AnyKind, HA, UL <: PKList[Args]] {
+      type OutA <: PKList[Args]
+      def ::(l: UL)(ha: HA): OutA
+    }
+
+    implicit class PKListOps[
+      Args <: AnyKind
+    ](l: PKNil[Args]) {
+      def ::[HA0](ha: HA0)(implicit unap: PKConsBuilder[Args, HA0, PKNil[Args]]): unap.OutA = unap.::(l)(ha)
+    }
+
+
+    implicit class PKListOps2[
+      Args <: AnyKind
+    , HA
+    , T <: PKList[Args]
+    ](l: PKCons[Args, HA, T]) {
+      def ::[HA0](ha: HA0)(implicit unap: PKConsBuilder[Args, HA0, PKCons[Args, HA, T]]): unap.OutA = unap.::(l)(ha)
+    }
+
+    trait Contains[Args <: AnyKind, H, L <: PKList[Args]] {
+      def apply(l: L): H
+    }
+
+    object Contains {
+      def apply[Args <: AnyKind, H, L2 <: PKList[Args]](implicit is: Contains[Args, H, L2]) = is
+
+      implicit def head[Args <: AnyKind, H, L2 <: PKList[Args]] = new Contains[Args, H, PKCons[Args, H, L2]] {
+        def apply(l: PKCons[Args, H, L2]): H = l.head
+      }
+
+      implicit def corec[Args <: AnyKind, H, H2, L2 <: PKList[Args]] (
+        implicit next: Contains[Args, H, L2]
+      ) = new Contains[Args, H, PKCons[Args, H2, L2]]  {
+        def apply(l: PKCons[Args, H2, L2]): H = next(l.tail)
+      }
+    }
+
+    trait IsSubPKList[Args <: AnyKind, L1 <: PKList[Args], L2 <: PKList[Args]] {
+      def sub(l2: L2): L1
+    }
+
+    object IsSubPKList {
+      def apply[Args <: AnyKind, L1 <: PKList[Args], L2 <: PKList[Args]](implicit is: IsSubPKList[Args, L1, L2]) = is
+
+      implicit def nil[Args <: AnyKind, L2 <: PKList[Args]] = new IsSubPKList[Args, PKNil[Args], L2] {
+        def sub(l2: L2): PKNil[Args] = new PKNil[Args] {}
+      }
+
+      implicit def head[Args <: AnyKind, H, L1 <: PKList[Args], L2 <: PKList[Args]](
+        implicit c: Contains[Args, H, L2], next: IsSubPKList[Args, L1, L2]
+      ) = new IsSubPKList[Args, PKCons[Args, H, L1], L2]  {
+        def sub(l2: L2): PKCons[Args, H, L1] = new PKCons[Args, H, L1] {
+          val head = c(l2)
+          val tail = next.sub(l2)
+        }
+      }
+    }
+
+  }
+
+  object Lawful {
+    import PKList._
+
+    case class HNilF[F <: AnyKind]() extends PKNil[F]
+
+    implicit def buildMCons[M[_ <: AnyKind], F <: AnyKind, T <: PKList[F]] =
+      new PKConsBuilder[F, M[F], T] {
+        type OutA = PKCons[F, M[F], T]
+
+        def ::(l: T)(h: M[F]): OutA =
+          new PKCons[F, M[F], T] {
+            val head = h
+            val tail = l
+          }
+      }
+
+    trait Laws[Scope, F <: AnyKind, L <: PKList[F]] {
+      def laws: L
+    }
+
+    object Laws {
+      // type Aux[F <: AnyKind, L0 <: PKList[F]] = Laws[F] { type L = L0 }
+
+      class Builder[Scope, F] {
+        def apply[L0 <: PKList[F]](l0: L0): Laws[Scope, F, L0] = new Laws[Scope, F, L0] {
+          val laws = l0
+        }
+      }
+
+      def apply[Scope, F <: AnyKind] = new Builder[Scope, F]
+
+    }
+
+    trait HasLaws[Scope, Args <: AnyKind, LS <: PKList[Args]] {
+      def laws: LS
+      def apply[HA](implicit c: Contains[Args, HA, LS]): HA = c(laws)
+    }
+
+    object HasLaws {
+      def apply[Scope, Args <: AnyKind, LS <: PKList[Args]](implicit hl: HasLaws[Scope, Args, LS]): HasLaws[Scope, Args, LS] = hl
+
+      implicit def hasLaws[Scope, Args <: AnyKind, LS <: PKList[Args], LS2 <: PKList[Args]](
+        implicit la: Laws[Scope, Args, LS], issub: IsSubPKList[Args, LS2, LS]
+      ): HasLaws[Scope, Args, LS2] = new HasLaws[Scope, Args, LS2] {
+        val laws = issub.sub(la.laws)
+      }
+    }
+
+    trait HasLaw[Scope, Args <: AnyKind, L] {
+      def law: L
+    }
+
+    object HasLaw {
+      def apply[Scope, Args <: AnyKind, L](implicit hasLaws: HasLaws[Scope, Args, PKCons[Args, L, PKNil[Args]]]) =
+        new HasLaw[Scope, Args, L] {
+          val law = hasLaws.laws.head
+        }
+
+      implicit def hasLaw[Scope, Args <: AnyKind, L](implicit hasLaws: HasLaws[Scope, Args, PKCons[Args, L, PKNil[Args]]]) =
+        new HasLaw[Scope, Args, L] {
+          val law = hasLaws.laws.head
+        }
+
+    }
+
+    case class Scope[S](s: S)
+    case class WithScope[S](s: S) {
+      val scope = Scope(s)
+      def apply[A](f: Scope[S] => A): A = f(scope)
+    }
+  }
+  
+  import PKList._
+  import Lawful._
+
+  // simple-order monoid typeclass
+  trait Monoid[F] {
+    def append(a: F, b: F): F
+  }
+
+  // append depending on a scope (could be made more idiomatic with some macro/annoation/scalameta)
+  def append[F, S](a: F, b: F)(implicit scope: Scope[S], hasMonoid: HasLaw[S, F, Monoid[F]]): F = hasMonoid.law.append(a, b)
+
+  // Scope for Numeric Sum monoid
+  object SumScope { self =>
+    def monoid[T](implicit numeric: Numeric[T]): Monoid[T] = new Monoid[T] {
+      def append(a: T, b: T): T = numeric.plus(a, b)
+    }
+
+    implicit def laws[T](implicit numeric: Numeric[T]) = Laws[self.type, T](monoid[T] :: HNilF[T]())
+  }
+
+  // Scope for Numeric Product monoid
+  object ProdScope { self =>
+    def monoid[T](implicit numeric: Numeric[T]): Monoid[T] = new Monoid[T] {
+      def append(a: T, b: T): T = numeric.times(a, b)
+    }
+
+    implicit def laws[T](implicit numeric: Numeric[T]) = Laws[self.type, T](monoid[T] :: HNilF[T]())
+  }
+
+
+  WithScope(SumScope)  { implicit s => 
+    assert(append(5, 3) == 8)
+    assert(append(5.234, 9.876) == 15.11)
+  }
+  
+  WithScope(ProdScope) { implicit s =>
+    assert(append(5, 3) == 15)
+    assert(append(5.234, 9.876) == 51.690984)
+  }
+  
+  class NumericField[N](
+    implicit
+        N : Numeric[N]
+      , Sum: HasLaw[SumScope.type, N, Monoid[N]]
+      , Product: HasLaw[ProdScope.type, N, Monoid[N]]
+  ) {
+    def sum(lhs: N, rhs: N) = Sum.law.append(lhs, rhs)
+    def product(lhs: N, rhs: N) = Product.law.append(lhs, rhs)
+  }
+
+  val intField = new NumericField[Int]
+
+  assert(intField.sum(3, 5) == 8)
+  assert(intField.product(3, 5) == 15)
+
+}


### PR DESCRIPTION
> This is a PoC for supporting minimalistic & very controlled KindPolymorphism in Scala based on original work by @milessabin.

## Motivations
The idea is NOT to provide universal kind-polymorphism for all possible kinds which would be impossible and a bad idea.
We want to provide a limited kind-polymorphism controlled through typeclass implicits defining the accepted level of kind-polymorphism in a determined scope.

Our first motivations is to be able to manipulate kind of types (comparing, extracting etc...) and naturally to build structures that can abstract on the kind. This is meant to build higher-level tooling "à la shapeless".

## Example

A basic example is:

```scala
trait Foo[T <: AnyKind] { type Out ; def id(t: Out): Out = t }

  object Foo {
    implicit def foo0[T] = new Foo[T] { type Out = T }
    implicit def foo1[T[_]] = new Foo[T] { type Out = T[Any] }
    implicit def foo2[T[_, _]] = new Foo[T] { type Out = T[Any, Any] }
  }

  def foo[T <: AnyKind](implicit f: Foo[T]): f.type = f
  foo[Int].id(23)
  foo[List].id(List[Any](1, 2, 3))
  foo[Map].id(Map[Any, Any](1 -> "toto", 2 -> "tata", 3 -> "tutu"))
```

## Requirements

To make it possible, we need to provide:
- A flag `-Ykind-polymorphism` to activate the feature in the compiler
- A new technical type bound `<: AnyKind` to indicate a type is _kind polymorphic_

With some conditions:
- When `-Ykind-polymorphism` isn't activated, it shouldn't bother other features of scala at all.
- `AnyKind` shouldn't be used as a real type.

## Use cases

### `AnyKind` for type parameter

```scala
// T is <: AnyKind here because this is a kind-polymorphic structure
trait Foo[T <: AnyKind] { ... }
object Foo {
    // T and T[_] here aren't <: AnyKind but just types used to build a specific kinded instance of
    // a kind-polymorphic structure.
    implicit def foo0[T] = new Foo[T] { ... }
    implicit def foo1[T[_]] = new Foo[T] { ... }
}
// T is <: AnyKind because this is a kind-polymorphic function
def foo[T <: AnyKind](implicit f: Foo[T]) = ???
```

### `AnyKind` for path-dependent types

```scala
trait Kinder[MA] { type M <: AnyKind }
  object Kinder extends KinderLowerImplicits {
    type Aux[MA, M0 <: AnyKind] = Kinder[MA] { type M = M0 }

    implicit def kinder2[M0[_, _], A0, B0]: Kinder.Aux[M0[A0, B0], M0] = new Kinder[M0[A0, B0]] {  
        // M becomes a M[_, _] here
        type M[t, u] = M0[t, u]
    }

    implicit def kinder1[M0[_], A0]: Kinder.Aux[M0[A0], M0] = new Kinder[M0[A0]] {
        // M becomes a M[_] here
        type M[t] = M0[t]
    }
  }

  trait KinderLowerImplicits {
    // defines in a lower implicit priority to prevent implicit collisions
    implicit def kinder0[A]: Kinder.Aux[A, A] = new Kinder[A] {
        type M = A
    }    
  }
```

## Implementation details

### global mechanism

When (and only when) `Ykind-polymorphism` is activated, if the typer encounters a type with `<: AnyKind`, it doesn't compare type parameters length as strictly as default Scala behavior but defers a bit the strictness checking.
The idea is to lose NO strictness in typing but to delay this strictness a bit later in the compiling chain.

Naturally, the `<: Anykind` is purely technical and is completely eliminated at erasure.

### the `isAnyKind` condition
We have added a condition to be checked in a very few places  of the coed: https://github.com/mandubian/scala/blob/topic/kind-poly-v1/src/reflect/scala/reflect/internal/Types.scala#L4379-L4382.

The main difficulty was to check that our type is subclassing `AnyKind`. But it appears that the call to `isNonBottomSubClass` on an _incomplete_ type can trigger `CyclicError` or `TypeError`.

> in `isAnyKind`, we have added checks only meant to prevent those exceptions to happen. If a better solution is possible, don't hesitate to propose it.

### Forbid using AnyKind as a type

We want the following cases to be forbidden:
https://github.com/mandubian/scala/blob/topic/kind-poly-v1/test/files/neg/kind-poly.scala#L20-L26

To strictly forbid those cases and provide user-friendly error messages, 2 new error cases have been added.

> If you have better ways to check that, don't hesitate to propose once again.


### More samples

Check this test file : https://github.com/mandubian/scala/blob/topic/kind-poly-v1/test/files/pos/kind-poly.scala
(with a kind-polymorphic list implementation)

### Next steps

- Explore what can be done & not with this feature as it is quite promising and already working so well.
- Check more edge-cases
- Study potentially `typeOf` taking into account kind polymorphism.
- More ideas


