### PR TITLE
SI-10068 Only permit elidable methods

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -84,7 +84,10 @@ trait ScalaSettings extends AbsScalaSettings
    * though this helper.
    */
   def isScala211: Boolean = source.value >= ScalaVersion("2.11.0")
-  def isScala212: Boolean = source.value >= ScalaVersion("2.12.0")
+  private[this] val version212 = ScalaVersion("2.12.0")
+  def isScala212: Boolean = source.value >= version212
+  private[this] val version213 = ScalaVersion("2.13.0")
+  def isScala213: Boolean = source.value >= version213
 
   /**
    * -X "Advanced" settings

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -410,8 +410,17 @@ abstract class UnCurry extends InfoTransform
       def isLiftedLambdaMethod(funSym: Symbol) =
         funSym.isArtifact && funSym.name.containsName(nme.ANON_FUN_NAME) && funSym.isLocalToBlock
 
+      def checkIsElisible(sym: Symbol): Boolean =
+        (sym ne null) && sym.elisionLevel.exists { level =>
+          if (sym.isMethod) level < settings.elidebelow.value
+          else {
+            if (settings.isScala213) reporter.error(sym.pos, s"${sym.name}: Only methods can be marked @elidable!")
+            false
+          }
+        }
+
       val result =
-        if ((sym ne null) && sym.elisionLevel.exists(_ < settings.elidebelow.value))
+        if (checkIsElisible(sym))
           replaceElidableTree(tree)
         else translateSynchronized(tree) match {
           case dd @ DefDef(mods, name, tparams, _, tpt, rhs) =>

--- a/test/files/neg/t10068.check
+++ b/test/files/neg/t10068.check
@@ -1,0 +1,13 @@
+t10068.scala:5: error: i : Only methods can be marked @elidable.
+  @elidable(INFO) val i: Int = 42
+                      ^
+t10068.scala:6: error: j: Only methods can be marked @elidable.
+  @elidable(INFO) lazy val j: Int = 42
+                           ^
+t10068.scala:7: error: k : Only methods can be marked @elidable.
+  @elidable(INFO) var k: Int = 42
+                      ^
+t10068.scala:9: error: D: Only methods can be marked @elidable.
+@elidable(INFO) class D
+                      ^
+four errors found

--- a/test/files/neg/t10068.flags
+++ b/test/files/neg/t10068.flags
@@ -1,0 +1,1 @@
+-Xelide-below WARNING -Xsource:2.13

--- a/test/files/neg/t10068.scala
+++ b/test/files/neg/t10068.scala
@@ -1,0 +1,9 @@
+
+import annotation._, elidable._
+
+class C {
+  @elidable(INFO) val i: Int = 42
+  @elidable(INFO) lazy val j: Int = 42
+  @elidable(INFO) var k: Int = 42
+}
+@elidable(INFO) class D

--- a/test/files/run/elidable.flags
+++ b/test/files/run/elidable.flags
@@ -1,1 +1,1 @@
--Xelide-below 900
+-Xelide-below WARNING

--- a/test/files/run/elidable.scala
+++ b/test/files/run/elidable.scala
@@ -1,6 +1,8 @@
 import annotation._
 import elidable._
 
+// runs -Xelide-below WARNING or 900
+
 trait T {
   @elidable(FINEST) def f1()
   @elidable(SEVERE) def f2()
@@ -37,6 +39,13 @@ object Test {
   @elidable(FINEST) def fc() = 1.0f
   @elidable(FINEST) def fd() = 1.0
   @elidable(FINEST) def fe() = "s"
+
+  /* variable elisions? see test/files/neg/t10068.scala
+  @elidable(INFO) val goner1: Int      = { assert(false, "Should have been elided.") ; 42 }
+  @elidable(INFO) lazy val goner2: Int = { assert(false, "Should have been elided.") ; 42 }
+  @elidable(INFO) var goner3: Int      = { assert(false, "Should have been elided.") ; 42 }
+  @elidable(INFO) var goner4: Nothing  = _
+  */
 
   def main(args: Array[String]): Unit = {
     f1()
@@ -80,5 +89,17 @@ object Test {
         Class.forName(className).getMethod(methodName)
       }
     }
+
+    // variable elisions?
+    /*
+    assert(goner1 == 0)
+    assert(goner2 == 0)
+    assert(goner3 == 0)
+    try assert(goner4 == null)
+    catch {
+      case _: NullPointerException => println("NPE")
+      case _: NotImplementedError   => println("NIE")
+    }
+    */
   }
 }


### PR DESCRIPTION
In uncurry, check that symbol with `@elidable` is a method.

This fails to notice the annotation on lazy vals, which seems
to be a product of synthesis at namer/typer.

JIRA: https://issues.scala-lang.org/browse/SI-10068