### PR TITLE
SI-9814 Fix synchronized in specialized overrides

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -1049,7 +1049,8 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
             }
           }
           debuglog(s"specialized overload $om for ${overriding.name.decode} in ${pp(env)}: ${om.info}")
-          if (overriding.isAbstractOverride) om.setFlag(ABSOVERRIDE)
+          om.setFlag(overriding.flags & (ABSOVERRIDE | SYNCHRONIZED))
+          om.withAnnotations(overriding.annotations.filter(_.symbol == ScalaStrictFPAttr))
           typeEnv(om) = env
           addConcreteSpecMethod(overriding)
           if (overriding.isDeferred) { // abstract override

--- a/test/files/run/t9814.scala
+++ b/test/files/run/t9814.scala
@@ -1,0 +1,28 @@
+import java.lang.reflect.Modifier
+
+import scala.annotation.strictfp
+
+class Foo extends (() => Unit) {
+  def apply(): Unit = synchronized {
+    // we're in a specialized subclass
+    assert(Thread.currentThread.getStackTrace.apply(1).getMethodName == "apply$mcV$sp")
+    assert(Thread.holdsLock(this))
+  }
+}
+
+class Bar extends (() => Unit) {
+  @strictfp def apply(): Unit = synchronized {
+    // we're in a specialized subclass
+    assert(Thread.currentThread.getStackTrace.apply(1).getMethodName == "apply$mcV$sp")
+    assert(Thread.holdsLock(this))
+  }
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    new Foo().apply()
+    
+    val m = classOf[Bar].getDeclaredMethod("apply$mcV$sp")
+    assert(Modifier.isStrict(m.getModifiers))
+  }
+}


### PR DESCRIPTION
Specialization creates a subclasses of a specializd class for each
type parameter combination. These contains copies of the methods from
the superclass.

However, before this transform, the pattern of self-synchronization
in a method body had been replace by flag Flag.SYNCHRONIZED on the
method symbol. This was not being propagated to the override, and
hence no locking occured.

This commit modifies the transform to copy the SYNCHRONIZED flag.
I've also added tests for some other potentially tricky variations
of synchronization to confirm they are working.