### PR TITLE
SI-10066 Fix crash in erroneous code with implicits, dynamic

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -863,11 +863,24 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                   case _ =>
                 }
                 debuglog(s"fallback on implicits: ${tree}/$resetTree")
-                val tree1 = typed(resetTree, mode)
-                // Q: `typed` already calls `pluginsTyped` and `adapt`. the only difference here is that
-                // we pass `EmptyTree` as the `original`. intended? added in 2009 (53d98e7d42) by martin.
-                tree1 setType pluginsTyped(tree1.tpe, this, tree1, mode, pt)
-                if (tree1.isEmpty) tree1 else adapt(tree1, mode, pt, EmptyTree)
+                // SO-10066 Need to patch the enclosing tree in the context to make translation of Dynamic
+                //          work during fallback typechecking below.
+                val resetContext: Context = {
+                  object substResetForOriginal extends Transformer {
+                    override def transform(tree: Tree): Tree = {
+                      if (tree eq original) resetTree
+                      else super.transform(tree)
+                    }
+                  }
+                  context.make(substResetForOriginal.transform(context.tree))
+                }
+                typerWithLocalContext(resetContext) { typer1 =>
+                  val tree1 = typer1.typed(resetTree, mode)
+                  // Q: `typed` already calls `pluginsTyped` and `adapt`. the only difference here is that
+                  // we pass `EmptyTree` as the `original`. intended? added in 2009 (53d98e7d42) by martin.
+                  tree1 setType pluginsTyped(tree1.tpe, typer1, tree1, mode, pt)
+                  if (tree1.isEmpty) tree1 else typer1.adapt(tree1, mode, pt, EmptyTree)
+                }
               }
             )
             else

--- a/test/files/neg/t10066.check
+++ b/test/files/neg/t10066.check
@@ -1,0 +1,7 @@
+t10066.scala:33: error: could not find implicit value for parameter extractor: dynamicrash.Extractor[String]
+  println(storage.foo[String])
+          ^
+t10066.scala:37: error: could not find implicit value for parameter extractor: dynamicrash.Extractor[A]
+  println(storage.foo)
+          ^
+two errors found

--- a/test/files/neg/t10066.scala
+++ b/test/files/neg/t10066.scala
@@ -1,0 +1,38 @@
+package dynamicrash
+
+import scala.language.dynamics
+
+class Config
+
+trait Extractor[A] {
+  def extract(config: Config, name: String): A
+}
+
+object Extractor {
+  // note missing "implicit"
+  val stringExtractor = new Extractor[String] {
+    override def extract(config: Config, name: String): String = ???
+  }
+}
+
+class Workspace extends Dynamic {
+  val config: Config = new Config
+
+  def selectDynamic[A](name: String)(implicit extractor: Extractor[A]): A =
+    extractor.extract(config, name)
+}
+
+object Main {
+  val storage = new Workspace
+
+  // this line works fine
+  // val a = storage.foo
+
+  // this line crashes the compiler ("head of empty list")
+  // in ContextErrors$InferencerContextErrors$InferErrorGen$.NotWithinBoundsErrorMessage
+  println(storage.foo[String])
+
+  // this line crashes the compiler in different way ("unknown type")
+  // in the backend, warning: an unexpected type representation reached the compiler backend while compiling Test.scala: <error>
+  println(storage.foo)
+}

--- a/test/files/pos/t10066.scala
+++ b/test/files/pos/t10066.scala
@@ -1,0 +1,38 @@
+package dynamicrash
+ 
+import scala.language.dynamics
+ 
+class Config
+ 
+trait Extractor[A] {
+  def extract(config: Config, name: String): A
+}
+ 
+object Extractor {
+  // this has "implicit", unlike the corresponding neg test
+  implicit val stringExtractor = new Extractor[String] {
+    override def extract(config: Config, name: String): String = ???
+  }
+}
+ 
+class Workspace extends Dynamic {
+  val config: Config = new Config
+ 
+  def selectDynamic[A](name: String)(implicit extractor: Extractor[A]): A =
+    extractor.extract(config, name)
+}
+ 
+object Main {
+  val storage = new Workspace
+ 
+  // this line works fine
+  // val a = storage.foo
+ 
+  // this line crashes the compiler ("head of empty list")
+  // in ContextErrors$InferencerContextErrors$InferErrorGen$.NotWithinBoundsErrorMessage
+  println(storage.foo[String])
+ 
+  // this line crashes the compiler in different way ("unknown type")
+  // in the backend, warning: an unexpected type representation reached the compiler backend while compiling Test.scala: <error>
+  println(storage.foo)
+}


### PR DESCRIPTION
The compiler support in the typechecker for `scala.Dynamic` is
very particular about the `Context` in which it is typechecked.
It looks at the `tree` in the enclosing context to find the expression
immediately enclosing the dynamic selection. See the logic in
`dyna::mkInvoke` for the details.

This commit substitutes the result of `resetAttrs` into the tree
of the typer context before continuing with typechecking.