### PR TITLE
SI-8779 Enable inlining of code within a REPL session

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -95,6 +95,9 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
 
   type ThisPlatform = JavaPlatform { val global: Global.this.type }
   lazy val platform: ThisPlatform  = new GlobalPlatform
+  /* A hook for the REPL to add a classpath entry containing products of previous runs to inliner's bytecode repository*/
+  // Fixes SI-8779
+  def optimizerClassPath(base: ClassPath): ClassPath = base
 
   def classPath: ClassPath = platform.classPath
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -37,7 +37,7 @@ class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
   val coreBTypes = new CoreBTypesProxy[this.type](this)
   import coreBTypes._
 
-  val byteCodeRepository: ByteCodeRepository[this.type] = new ByteCodeRepository(global.classPath, this)
+  val byteCodeRepository: ByteCodeRepository[this.type] = new ByteCodeRepository(global.optimizerClassPath(global.classPath), this)
 
   val localOpt: LocalOpt[this.type] = new LocalOpt(this)
 

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -889,7 +889,7 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
     }
 
     class ClassBasedWrapper extends Wrapper {
-      def preambleHeader = "class %s extends _root_.java.io.Serializable { "
+      def preambleHeader = "sealed class %s extends _root_.java.io.Serializable { "
 
       /** Adds an object that instantiates the outer wrapping class. */
       def postamble  = s"""

--- a/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
@@ -6,6 +6,9 @@
 package scala.tools.nsc
 package interpreter
 
+import scala.tools.nsc.backend.JavaPlatform
+import scala.tools.nsc.classpath.{AggregateClassPath, ClassPathFactory}
+import scala.tools.nsc.util.ClassPath
 import typechecker.Analyzer
 
 /** A layer on top of Global so I can guarantee some extra
@@ -29,6 +32,16 @@ trait ReplGlobal extends Global {
       macroLogVerbose("macro classloader: initializing from a REPL classloader: %s".format(global.classPath.asURLs))
       val virtualDirectory = globalSettings.outputDirs.getSingleOutput.get
       new util.AbstractFileClassLoader(virtualDirectory, loader) {}
+    }
+  }
+
+  override def optimizerClassPath(base: ClassPath): ClassPath = {
+    settings.outputDirs.getSingleOutput match {
+      case None => base
+      case Some(out) =>
+        // Make bytecode of previous lines available to the inliner
+        val replOutClasspath = ClassPathFactory.newClassPath(settings.outputDirs.getSingleOutput.get, settings)
+        AggregateClassPath.createAggregate(platform.classPath, replOutClasspath)
     }
   }
 }

--- a/test/files/run/repl-inline.check
+++ b/test/files/run/repl-inline.check
@@ -4,3 +4,8 @@ g: String
 h: String
 g: String
 h: String
+callerOfCaller: String
+g: String
+h: String
+g: String
+h: String

--- a/test/files/run/repl-inline.check
+++ b/test/files/run/repl-inline.check
@@ -1,0 +1,6 @@
+warning: there was one deprecation warning (since 2.11.0); re-run with -deprecation for details
+callerOfCaller: String
+g: String
+h: String
+g: String
+h: String

--- a/test/files/run/repl-inline.scala
+++ b/test/files/run/repl-inline.scala
@@ -1,0 +1,21 @@
+import scala.tools.nsc._
+
+object Test {
+  val testCode = """
+def callerOfCaller = Thread.currentThread.getStackTrace.drop(2).head.getMethodName
+def g = callerOfCaller
+def h = g
+assert(h == "g", h)
+@inline def g = callerOfCaller
+def h = g
+assert(h == "h", h)
+  """
+
+  def main(args: Array[String]) {
+    val settings = new Settings()
+    settings.processArgumentString("-opt:l:classpath")
+    settings.usejavacp.value = true
+    val repl = new interpreter.IMain(settings)
+    testCode.linesIterator.foreach(repl.interpret(_))
+  }
+}

--- a/test/files/run/repl-inline.scala
+++ b/test/files/run/repl-inline.scala
@@ -1,7 +1,8 @@
 import scala.tools.nsc._
 
 object Test {
-  val testCode = """
+  val testCode =
+    """
 def callerOfCaller = Thread.currentThread.getStackTrace.drop(2).head.getMethodName
 def g = callerOfCaller
 def h = g
@@ -12,10 +13,15 @@ assert(h == "h", h)
   """
 
   def main(args: Array[String]) {
-    val settings = new Settings()
-    settings.processArgumentString("-opt:l:classpath")
-    settings.usejavacp.value = true
-    val repl = new interpreter.IMain(settings)
-    testCode.linesIterator.foreach(repl.interpret(_))
+    def test(f: Settings => Unit): Unit = {
+      val settings = new Settings()
+      settings.processArgumentString("-opt:l:classpath")
+      f(settings)
+      settings.usejavacp.value = true
+      val repl = new interpreter.IMain(settings)
+      testCode.linesIterator.foreach(repl.interpret(_))
+    }
+    test(_ => ())
+    test(_.Yreplclassbased.value = true)
   }
 }

--- a/test/files/run/t7747-repl.check
+++ b/test/files/run/t7747-repl.check
@@ -246,12 +246,12 @@ scala> case class Bingo()
 defined class Bingo
 
 scala> List(BippyBups(), PuppyPups(), Bingo()) // show
-class $read extends _root_.java.io.Serializable {
+sealed class $read extends _root_.java.io.Serializable {
   def <init>() = {
     super.<init>;
     ()
   };
-  class $iw extends _root_.java.io.Serializable {
+  sealed class $iw extends _root_.java.io.Serializable {
     def <init>() = {
       super.<init>;
       ()
@@ -262,7 +262,7 @@ class $read extends _root_.java.io.Serializable {
     import $line45.$read.INSTANCE.$iw.$iw.PuppyPups;
     import $line46.$read.INSTANCE.$iw.$iw.Bingo;
     import $line46.$read.INSTANCE.$iw.$iw.Bingo;
-    class $iw extends _root_.java.io.Serializable {
+    sealed class $iw extends _root_.java.io.Serializable {
       def <init>() = {
         super.<init>;
         ()

--- a/test/junit/scala/tools/nsc/classpath/VirtualDirectoryClassPathTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/VirtualDirectoryClassPathTest.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2014 Contributor. All rights reserved.
+ */
+package scala.tools.nsc.classpath
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.reflect.io.VirtualDirectory
+
+
+@RunWith(classOf[JUnit4])
+class VirtualDirectoryClassPathTest {
+
+  @Test
+  def virtualDirectoryClassPath_findClassFile(): Unit = {
+    val base = new VirtualDirectory("base", None)
+    val p1 = base subdirectoryNamed "p1"
+    val p1_Test_class = p1.fileNamed("Test.class")
+    val p2 = base subdirectoryNamed "p2"
+    val p3 = p2 subdirectoryNamed "p3"
+    val p4 = p3 subdirectoryNamed "p4"
+    val p4_Test1_class = p4.fileNamed("Test.class")
+    val classPath = VirtualDirectoryClassPath(base)
+
+    assertEquals(Some(p1_Test_class), classPath.findClassFile("p1/Test"))
+
+    assertEquals(None, classPath.findClassFile("p1/DoesNotExist"))
+    assertEquals(None, classPath.findClassFile("DoesNotExist"))
+    assertEquals(None, classPath.findClassFile("p2"))
+    assertEquals(None, classPath.findClassFile("p2/DoesNotExist"))
+    assertEquals(None, classPath.findClassFile("p4/DoesNotExist"))
+
+    assertEquals(List("p1", "p2"), classPath.packages("").toList.map(_.name).sorted)
+    assertEquals(List(), classPath.packages("p1").toList.map(_.name).sorted)
+    assertEquals(List("p2.p3"), classPath.packages("p2").toList.map(_.name).sorted)
+    assertEquals(List("p2.p3.p4"), classPath.packages("p2.p3").toList.map(_.name).sorted)
+  }
+}

--- a/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
+++ b/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
@@ -1,10 +1,11 @@
 package scala.tools.nsc.interpreter
 
-import java.io.{StringWriter, PrintWriter}
+import java.io.{PrintWriter, StringWriter}
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
+import scala.reflect.internal.util.BatchSourceFile
 import scala.tools.nsc.Settings
 
 class CompletionTest {
@@ -172,6 +173,16 @@ class CompletionTest {
     checkExact(completer, "class C(val a: Int, val b: Int) { this.")("a", "b")
     assert(Set("asInstanceOf", "==").diff(completer.complete("class C(val a: Int, val b: Int) { this.").candidates.toSet).isEmpty)
     checkExact(completer, "case class D(a: Int, b: Int) { this.a")("a", "asInstanceOf")
+  }
+
+  @Test
+  def replGeneratedCodeDeepPackages(): Unit = {
+    val intp = newIMain()
+    val completer = new PresentationCompilerCompleter(intp)
+    intp.compileSources(new BatchSourceFile("<paste>", "package p1.p2.p3; object Ping { object Pong }"))
+    checkExact(completer, "p1.p2.p")("p3")
+    checkExact(completer, "p1.p2.p3.P")("Ping")
+    checkExact(completer, "p1.p2.p3.Ping.Po")("Pong")
   }
 
   def checkExact(completer: PresentationCompilerCompleter, before: String, after: String = "")(expected: String*): Unit = {


### PR DESCRIPTION
The REPL has a long running instance of Global which outputs
classfiles by default to a VirtualDirectory. The inliner did not find
any of these class files when compiling calls to methods defined in
previous runs (ie, previous lines of input.)

This commit:

  - Adds a hook to augment the classpath that the optimizer searches,
    and uses this in the REPL to add the output directory
  - Fixes the implementation of `findClassFile` in VirtualDirectory,
    which doesn't seem to have been used in anger before. I've factored out
    some common code into a new method on `AbstractFile`.
  - Fixes a similar problem getSubDir reported by Li Haoyi
  - Adds missing unit test coverage.

This also fixes a bug in REPL autocompletion for types defined
in packages >= 2 level deep (with the `:paste -raw` command).
I've added a test for this case.

Review by @lrytz