### PR TITLE
SI-9636 More precise error pos on apply inference

### DIFF
--- a/test/files/neg/t9636.check
+++ b/test/files/neg/t9636.check
@@ -1,0 +1,6 @@
+t9636.scala:11: warning: a type was inferred to be `AnyVal`; this may indicate a programming error.
+    if (signature.sameElements(Array(0x1F, 0x8B))) {
+                  ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/t9636.flags
+++ b/test/files/neg/t9636.flags
@@ -1,0 +1,1 @@
+-Xlint -Xfatal-warnings

--- a/test/files/neg/t9636.scala
+++ b/test/files/neg/t9636.scala
@@ -1,0 +1,17 @@
+
+import java.io._
+import java.util.zip._
+
+class C {
+  def isWrapper(is: FileInputStream): InputStream = {
+    val pb = new PushbackInputStream(is, 2)
+    val signature = new Array[Byte](2)
+    pb.read(signature)
+    pb.unread(signature)
+    if (signature.sameElements(Array(0x1F, 0x8B))) {
+      new GZIPInputStream(new BufferedInputStream(pb))
+    } else {
+      pb
+    }
+  }
+}

--- a/test/files/neg/warn-inferred-any.check
+++ b/test/files/neg/warn-inferred-any.check
@@ -9,7 +9,7 @@ warn-inferred-any.scala:17: warning: a type was inferred to be `AnyVal`; this ma
              ^
 warn-inferred-any.scala:25: warning: a type was inferred to be `Any`; this may indicate a programming error.
   def za = f(1, "one")
-             ^
+           ^
 error: No warnings can be incurred under -Xfatal-warnings.
 four warnings found
 one error found


### PR DESCRIPTION
If a method type arg is inferred Any, warn about the
function and not the innocent arg.

The arg-specific code still backs up the `isApplicable` path.

As suggested by retronym on jira.