### PR TITLE
Use equal() instead of identity in read-only TNode

### DIFF
--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -261,7 +261,7 @@ private[collection] final class INode[K, V](bn: MainNode[K, V], g: Gen) extends 
           clean(parent, ct, lev - 5)
           RESTART // used to be throw RestartException
         } else {
-          if (tn.hc == hc && tn.k == k) tn.v.asInstanceOf[AnyRef]
+          if (tn.hc == hc && equal(tn.k, k, ct)) tn.v.asInstanceOf[AnyRef]
           else null
         }
         cleanReadOnly(tn)


### PR DESCRIPTION
Fix consistency of what equality function is used in case
of a tombed node with read-only snapshot, useful only in
the case the equality is customized.