### PR TITLE
Whitelist the remaining changes since 2.12.0 that break all builds

### DIFF
--- a/bincompat-backward.whitelist.conf
+++ b/bincompat-backward.whitelist.conf
@@ -12,7 +12,10 @@ filter {
     {
       matchName="scala.reflect.runtime.SymbolLoaders#TopClassCompleter.this"
       problemName=IncompatibleMethTypeProblem
+    },
+    {
+      matchName="scala.sys.process.ProcessImpl#CompoundProcess.getExitValue"
+      problemName=DirectMissingMethodProblem
     }
-
   ]
 }

--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -12,6 +12,14 @@ filter {
     {
       matchName="scala.reflect.runtime.SymbolLoaders#TopClassCompleter.this"
       problemName=IncompatibleMethTypeProblem
+    },
+    {
+      matchName="scala.sys.process.ProcessImpl#CompoundProcess.futureValue"
+      problemName=DirectMissingMethodProblem
+    },
+    {
+      matchName="scala.sys.process.ProcessImpl#CompoundProcess.futureThread"
+      problemName=DirectMissingMethodProblem
     }
   ]
 }


### PR DESCRIPTION
The changes were made in https://github.com/scala/scala/pull/5481,
subsequently breaking binary compatibility checks after
https://github.com/scala/scala/pull/5532 was merged, too. The affected
methods are part of an internal implementation class. Whitelisting
should be safe.