### PR TITLE
Improve performance of REPL autocompletion

### DIFF
--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -1202,7 +1202,8 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
             case Nil => entered.isEmpty && matchCount > 0
             case head :: tail =>
               val enteredAlternatives = Set(entered, entered.capitalize)
-              head.inits.filter(_.length <= entered.length).exists(init =>
+              val n = (head, entered).zipped.count {case (c, e) => c == e || (c.isUpper && c == e.toUpper)}
+              head.take(n).inits.exists(init =>
                 enteredAlternatives.exists(entered =>
                   lenientMatch(entered.stripPrefix(init), tail, matchCount + (if (init.isEmpty) 0 else 1))
                 )

--- a/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
+++ b/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
@@ -174,6 +174,14 @@ class CompletionTest {
     checkExact(completer, "case class D(a: Int, b: Int) { this.a")("a", "asInstanceOf")
   }
 
+  @Test
+  def performanceOfLenientMatch(): Unit = {
+    val intp = newIMain()
+    val completer = new PresentationCompilerCompleter(intp)
+    val ident: String = "thisIsAReallyLongMethodNameWithManyManyManyManyChunks"
+    checkExact(completer, s"($ident: Int) => tia")(ident)
+  }
+
   def checkExact(completer: PresentationCompilerCompleter, before: String, after: String = "")(expected: String*): Unit = {
     assertEquals(expected.toSet, completer.complete(before, after).candidates.toSet)
   }


### PR DESCRIPTION
The code used to fuzzily match, e.g, `declasses` with `getDeclaredClasses`
was exploring fruitless parts of the search space. The enclosed test
case was hanging the REPL.

This commit improves this by performing a prefix match of the unconsumed input
against the current chunk of the candidate before exploring the `inits`.

Fixes scala/scala-dev#271

Review by @som-snytt. Looks like this was just a dumb bug rather than
something calling for a brilliant algorithm. But there might be pathological
cases lurking that still could be improved.