### PR TITLE
SI-10009 Fields survive untypecheck/retypecheck

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
@@ -132,7 +132,11 @@ trait MethodSynthesis {
 
       // only one symbol can have `tree.pos`, the others must focus their position
       // normally the field gets the range position, but if there is none, give it to the getter
+      //
+      // SI-10009 the tree's modifiers can be temporarily out of sync with the new symbol's flags.
+      //          typedValDef corrects this later on.
       tree.symbol = fieldSym orElse (getterSym setPos tree.pos)
+
       val namer = namerOf(tree.symbol)
 
       // the valdef gets the accessor symbol for a lazy val (too much going on in its RHS)

--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -480,7 +480,8 @@ abstract class TreeInfo {
         } map { dd =>
           val DefDef(dmods, dname, _, _, _, drhs) = dd
           // get access flags from DefDef
-          val vdMods = (vmods &~ Flags.AccessFlags) | (dmods & Flags.AccessFlags).flags
+          val defDefMask = Flags.AccessFlags | OVERRIDE | IMPLICIT | DEFERRED
+          val vdMods = (vmods &~ defDefMask) | (dmods & defDefMask).flags
           // for most cases lazy body should be taken from accessor DefDef
           val vdRhs = if (vmods.isLazy) lazyValDefRhs(drhs) else vrhs
           copyValDef(vd)(mods = vdMods, name = dname, rhs = vdRhs)

--- a/test/files/pos/t10009.scala
+++ b/test/files/pos/t10009.scala
@@ -1,0 +1,6 @@
+class C {
+  def c(a: Any, b: Any*) = a
+}
+object Test {
+  new C().c(b = new { val x = 42 }, a = 0)
+}

--- a/test/files/run/t10009.scala
+++ b/test/files/run/t10009.scala
@@ -1,0 +1,28 @@
+import scala.reflect.runtime.currentMirror
+import scala.reflect.runtime.universe._
+import scala.tools.reflect.ToolBox
+
+object Test {
+  def test(code: String, log: Boolean = false) {
+    val tb = currentMirror.mkToolBox()
+    val tree = tb.parse(code)
+    val typed = tb.typecheck(tree)
+    if (log) {
+      println("=" * 80)
+      println(typed)
+    }
+    val untyped = tb.untypecheck(typed)
+    if (log) println(untyped)
+    val retyped = tb.typecheck(untyped)
+    if (log) println(retyped)
+  }
+  def main(args: Array[String]): Unit = {
+    test("{ class a { val x = 42 }; new a }") // failed
+    test("{ trait a { val x = 42 }; new a {} }") // worked
+    test("{ abstract class a { val x: Int } }") // worked
+    test("{ abstract class a { val x: Int }; new a { val x = 42 } }") // failed
+    test("{ class a { private val x = 42 }; new a }") // failed
+    test("{ class a { protected val x = 42 }; new a { x } }") // failed
+    test("{ class a { protected[a] val x = 42 }; new a }") // failed
+  }
+}


### PR DESCRIPTION
Some places in the compiler, and many places in macros, use
`untypecheck` (aka `resetAttrs`) to strip types and local symbols
from a tree before retypechecking it under some different context.

The refactoring of the desugaring of vals and vars in Scala 2.12.0
broke an assumption in this facility.

When a ValDef must be split into multiple members (e.g. a field and
a getter, or a perhaps also a setter), the ValDef that was parsed
assumes the role of the `field`, and the trees for other members are
stached by `Namer` to the `synthetics` map of the compilation unit,
in order to spliced into the right statement list by typechecking.
See `enterGetterSetter` for more details.

However, the parsed ValDef is now used verbatim, carrying the meaning
(ie, the symbol) of the `private[this]` field. This tree now had
an inconsistency between the flags in `tree.mods.flags` and
`tree.symbol.flags`. `tree.name` also differed from `tree.symbol.name`
(the latter was renamed to be a local name, ie one with a trailing space.)

When `ResetAttrs` stripped off the symbol and we retypechecked, we'd
end up with two symbols in scope with the same name.

In the first from the `run` test:

```
================================================================================
{
  class a extends scala.AnyRef {
    def <init>(): a = {
      a.super.<init>();
      ()
    };
    private[this] val x: Int = 42;
    <stable> <accessor> def x: Int = a.this.x
  };
  new a()
}

{
  class a extends scala.AnyRef {
    def <init>() = {
      super.<init>();
      ()
    };
    val x = 42; // oops, the name is "x" rather than "x " and we've missing `private[this]`!
    <stable> <accessor> def x: Int = a.this.x
  };
  new a()
}

scala.tools.reflect.ToolBoxError: reflective typecheck has failed: x is already defined as value x
```

This commit uses the flags and name of the symbol in `typedValDef`.
I've also had to modify the internals of `CodePrinter` to use the
implicit, override, and deferred flags from the modifiers of an
accessor when recovering pre-typer tree for a ValDef.

