### PR TITLE
Use https links to JS and CSS in the spec when serving from https

### DIFF
--- a/spec/_layouts/default.yml
+++ b/spec/_layouts/default.yml
@@ -15,9 +15,9 @@
     }
   });
   </script>
-  <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/2.3-latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+  <script type="text/javascript" src="//cdn.mathjax.org/mathjax/2.3-latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
   <script src="//code.jquery.com/jquery-2.1.3.min.js"></script>
-  <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.2/styles/default.min.css">
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.2/styles/default.min.css">
   <!-- need to use include to see value of page.chapter variable -->
   <style type="text/css">
     {% include numbering.css %}


### PR DESCRIPTION
The spec is published on a server that supports https
(https://www.scala-lang.org/files/archive/spec/2.11/) and this comes up
as the default in search results (as it should) but the link to
MathJAX is hardcoded to http, which prevents any web browser that cares
about security from loading it.

This commit changes the links to MathJAX and to the Highlight.js
stylesheet to be scheme-relative (like the link to JQuery already was).