### PR TITLE
SD-275 Further harden against refs to absentee classes

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -488,7 +488,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
      *  often to the point of never.
      */
     def newStubSymbol(name: Name, missingMessage: String, isPackage: Boolean = false): Symbol = name match {
-      case n: TypeName  => if (isPackage) new StubPackageClassSymbol(this, n, missingMessage) else new StubClassSymbol(this, n, missingMessage)
+      case n: TypeName  => new StubClassSymbol(this, n, missingMessage)
       case _            => new StubTermSymbol(this, name.toTermName, missingMessage)
     }
 
@@ -3423,7 +3423,6 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     override def companionSymbol = fail(NoSymbol)
   }
   class StubClassSymbol(owner0: Symbol, name0: TypeName, val missingMessage: String) extends ClassSymbol(owner0, owner0.pos, name0) with StubSymbol
-  class StubPackageClassSymbol(owner0: Symbol, name0: TypeName, val missingMessage: String) extends PackageClassSymbol(owner0, owner0.pos, name0) with StubSymbol
   class StubTermSymbol(owner0: Symbol, name0: TermName, val missingMessage: String) extends TermSymbol(owner0, owner0.pos, name0) with StubSymbol
 
   trait FreeSymbol extends Symbol {

--- a/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
+++ b/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
@@ -216,18 +216,6 @@ abstract class UnPickler {
             }
             adjust(decl)
         }
-        def nestedObjectSymbol: Symbol = {
-          // If the owner is overloaded (i.e. a method), it's not possible to select the
-          // right member, so return NoSymbol. This can only happen when unpickling a tree.
-          // the "case Apply" in readTree() takes care of selecting the correct alternative
-          //  after parsing the arguments.
-          if (owner.isOverloaded)
-            return NoSymbol
-
-          if (tag == EXTMODCLASSref && !owner.isInstanceOf[StubSymbol])
-            owner.info.decl(nme.moduleVarName(name.toTermName))
-          else NoSymbol
-        }
 
         def moduleAdvice(missing: String): String = {
           val module =
@@ -254,21 +242,18 @@ abstract class UnPickler {
           // symbols are read from outside: for instance when checking the children
           // of a class.  See #1722.
           fromName(nme.expandedName(name.toTermName, owner)) orElse {
-            // (3) Try as a nested object symbol.
-            nestedObjectSymbol orElse {
-              // (4) Call the mirror's "missing" hook.
-              adjust(mirrorThatLoaded(owner).missingHook(owner, name)) orElse {
-                // (5) Create a stub symbol to defer hard failure a little longer.
-                val advice = moduleAdvice(s"${owner.fullName}.$name")
-                val missingMessage =
-                  s"""|missing or invalid dependency detected while loading class file '$filename'.
-                      |Could not access ${name.longString} in ${owner.kindString} ${owner.fullName},
-                      |because it (or its dependencies) are missing. Check your build definition for
-                      |missing or conflicting dependencies. (Re-run with `-Ylog-classpath` to see the problematic classpath.)
-                      |A full rebuild may help if '$filename' was compiled against an incompatible version of ${owner.fullName}.$advice""".stripMargin
-                val stubName = if (tag == EXTref) name else name.toTypeName
-                owner.newStubSymbol(stubName, missingMessage)
-              }
+            // (3) Call the mirror's "missing" hook.
+            adjust(mirrorThatLoaded(owner).missingHook(owner, name)) orElse {
+              // (4) Create a stub symbol to defer hard failure a little longer.
+              val advice = moduleAdvice(s"${owner.fullName}.$name")
+              val missingMessage =
+                s"""|missing or invalid dependency detected while loading class file '$filename'.
+                    |Could not access ${name.longString} in ${owner.kindString} ${owner.fullName},
+                    |because it (or its dependencies) are missing. Check your build definition for
+                    |missing or conflicting dependencies. (Re-run with `-Ylog-classpath` to see the problematic classpath.)
+                    |A full rebuild may help if '$filename' was compiled against an incompatible version of ${owner.fullName}.$advice""".stripMargin
+              val stubName = if (tag == EXTref) name else name.toTypeName
+              owner.newStubSymbol(stubName, missingMessage)
             }
           }
         }

--- a/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
+++ b/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
@@ -267,7 +267,8 @@ abstract class UnPickler {
                       |because it (or its dependencies) are missing. Check your build definition for
                       |missing or conflicting dependencies. (Re-run with `-Ylog-classpath` to see the problematic classpath.)
                       |A full rebuild may help if '$filename' was compiled against an incompatible version of ${owner.fullName}.$advice""".stripMargin
-                owner.newStubSymbol(name, missingMessage)
+                val stubName = if (tag == EXTref) name else name.toTypeName
+                owner.newStubSymbol(stubName, missingMessage)
               }
             }
           }
@@ -392,9 +393,7 @@ abstract class UnPickler {
 
       def readThisType(): Type = {
         val sym = readSymbolRef() match {
-          case stub: StubSymbol if !stub.isClass =>
-            // SI-8502 This allows us to create a stub for a unpickled reference to `missingPackage.Foo`.
-            stub.owner.newStubSymbol(stub.name.toTypeName, stub.missingMessage, isPackage = true)
+          case stub: StubSymbol => stub.setFlag(PACKAGE)
           case sym => sym
         }
         ThisType(sym)

--- a/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
+++ b/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
@@ -224,10 +224,9 @@ abstract class UnPickler {
           if (owner.isOverloaded)
             return NoSymbol
 
-          if (tag == EXTMODCLASSref) {
+          if (tag == EXTMODCLASSref && !owner.isInstanceOf[StubSymbol])
             owner.info.decl(nme.moduleVarName(name.toTermName))
-          }
-          NoSymbol
+          else NoSymbol
         }
 
         def moduleAdvice(missing: String): String = {

--- a/test/files/run/sd275-java/A.java
+++ b/test/files/run/sd275-java/A.java
@@ -1,0 +1,5 @@
+package sample;
+public class A {
+    public void irrelevant(p1.p2.p3.DeleteMe arg) {}
+    public static class A_Inner {}
+}

--- a/test/files/run/sd275-java/DeleteMe.java
+++ b/test/files/run/sd275-java/DeleteMe.java
@@ -1,0 +1,4 @@
+package p1.p2.p3;
+
+public class DeleteMe {}
+

--- a/test/files/run/sd275-java/LeaveMe.java
+++ b/test/files/run/sd275-java/LeaveMe.java
@@ -1,0 +1,3 @@
+package p1;
+
+public class LeaveMe {}

--- a/test/files/run/sd275-java/Test.scala
+++ b/test/files/run/sd275-java/Test.scala
@@ -1,0 +1,39 @@
+import scala.tools.partest._
+import java.io.File
+
+object Test extends StoreReporterDirectTest {
+  def code = ???
+
+  def compileCode(code: String) = {
+    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
+    compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(code)
+  }
+
+  def show(): Unit = {
+    deletePackage("p1/p2/p3")
+    deletePackage("p1/p2")
+
+    compileCode("""
+package sample
+
+class Test {
+  final class Inner extends A.A_Inner {
+    def foo = 42
+  }
+
+  def test = new Inner().foo
+}
+    """)
+    assert(storeReporter.infos.isEmpty, storeReporter.infos.mkString("\n"))
+  }
+
+  def deletePackage(name: String) {
+    val directory = new File(testOutput.path, name)
+    for (f <- directory.listFiles()) {
+      assert(f.getName.endsWith(".class"))
+      assert(f.delete())
+    }
+    assert(directory.listFiles().isEmpty)
+    assert(directory.delete())
+  }
+}

--- a/test/files/run/sd275.scala
+++ b/test/files/run/sd275.scala
@@ -1,0 +1,60 @@
+import scala.tools.partest._
+import java.io.File
+
+object Test extends StoreReporterDirectTest {
+  def code = ???
+
+  def compileCode(code: String) = {
+    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
+    compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(code)
+  }
+
+  def show(): Unit = {
+    compileCode("""
+package sample {
+
+  class A1 {
+    def irrelevant: p1.p2.p3.DeleteMe = null
+  }
+  object A1 {
+    class A1_Inner
+  }
+}
+
+package p1 {
+  class LeaveMe
+  package p2 {
+    package p3 {
+      class DeleteMe
+    }
+  }
+}
+      """)
+    assert(filteredInfos.isEmpty, filteredInfos)
+    deletePackage("p1/p2/p3")
+    deletePackage("p1/p2")
+
+    compileCode("""
+package sample
+
+class Test {
+  final class Inner extends A1.A1_Inner {
+    def foo = 42
+  }
+
+  def test = new Inner().foo
+}
+    """)
+    assert(storeReporter.infos.isEmpty, storeReporter.infos.mkString("\n")) // Included a MissingRequirementError before.
+  }
+
+  def deletePackage(name: String) {
+    val directory = new File(testOutput.path, name)
+    for (f <- directory.listFiles()) {
+      assert(f.getName.endsWith(".class"))
+      assert(f.delete())
+    }
+    assert(directory.listFiles().isEmpty)
+    assert(directory.delete())
+  }
+}


### PR DESCRIPTION
  - Rework previous fixes for SI-8502 to move the crea
    a term or type stub symbol during unpickling to the
    point of stub creation, based on the tag.
  - Just set the PACKAGE flag on class stub symbols cre
    unpickling `ThisType`, rather than bothering with a
    subclass of `StubSymbol` for (assumed) packages.
  - Limit the strategy of unpickling an external reference to a
    module class to a lookup of the module var to non-stub owners
    in order to enable fall through to stub symbol creation.

Fixes scala/scala-dev#275

Review by @lrytz 