### PR TITLE
Don't exclude super calls to trait methods from inlining

### DIFF
--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
@@ -1738,4 +1738,19 @@ class InlinerTest extends BytecodeTesting {
     val List(a, c, t) = compile(code, allowMessage = _.msg contains warn)
     assertInvoke(getMethod(c, "t"), "T", "m$")
   }
+
+  @Test
+  def sd259d(): Unit = {
+    val code =
+      """trait T {
+        |  @inline final def m = 1
+        |}
+        |class C extends T {
+        |  def t = super.m // inline call to T.m$ here, we're not in the mixin forwarder C.m
+        |}
+      """.stripMargin
+    val List(c, t) = compileClasses(code)
+    assertNoInvoke(getMethod(c, "t"))
+    assertInvoke(getMethod(c, "m"), "T", "m$")
+  }
 }


### PR DESCRIPTION
In 8020cd6, the inliner was changed to make sure trait methods bodies
are not duplicated into the static super accessors, and from there into
mixin forwarders.

The check for mixin forwarders was too wide. In `def t = super.m`, where
`m` is a trait method annotated `@inline`, we want to inline `m`. Note
that `super.m` is translated to an `invokestatic T.m$`. The current
check incorrectly identifies `t` as a mixin forwarder, and skip
inlining.