### PR TITLE
Hash table getOrElseUpdate and indexing 2.12 backport [ci: last-only]

### DIFF
--- a/src/library/scala/collection/mutable/FlatHashTable.scala
+++ b/src/library/scala/collection/mutable/FlatHashTable.scala
@@ -10,6 +10,9 @@ package scala
 package collection
 package mutable
 
+import java.lang.Integer.rotateRight
+import scala.util.hashing.byteswap32
+
 /** An implementation class backing a `HashSet`.
  *
  *  This trait is used internally. It can be mixed in with various collections relying on
@@ -415,20 +418,7 @@ private[collection] object FlatHashTable {
     // so that:
     protected final def sizeMapBucketSize = 1 << sizeMapBucketBitSize
 
-    protected final def improve(hcode: Int, seed: Int) = {
-      //var h: Int = hcode + ~(hcode << 9)
-      //h = h ^ (h >>> 14)
-      //h = h + (h << 4)
-      //h ^ (h >>> 10)
-
-      val improved= scala.util.hashing.byteswap32(hcode)
-
-      // for the remainder, see SI-5293
-      // to ensure that different bits are used for different hash tables, we have to rotate based on the seed
-      val rotation = seed % 32
-      val rotated = (improved >>> rotation) | (improved << (32 - rotation))
-      rotated
-    }
+    protected final def improve(hcode: Int, seed: Int) = rotateRight(byteswap32(hcode), seed)
 
     /**
      * Elems have type A, but we store AnyRef in the table. Plus we need to deal with

--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -72,6 +72,37 @@ extends AbstractMap[A, B]
     else Some(e.value)
   }
 
+  override def getOrElseUpdate(key: A, defaultValue: => B): B = {
+    val i = index(elemHashCode(key))
+    val entry = findEntry(key, i)
+    if (entry != null) entry.value
+    else addEntry(createNewEntry(key, defaultValue), i)
+  }
+
+  /* inlined HashTable.findEntry0 to preserve its visibility */
+  private[this] def findEntry(key: A, h: Int): Entry = {
+    var e = table(h).asInstanceOf[Entry]
+    while (notFound(key, e))
+      e = e.next
+    e
+  }
+  private[this] def notFound(key: A, e: Entry): Boolean = (e != null) && !elemEquals(e.key, key)
+
+  /* inlined HashTable.addEntry0 to preserve its visibility */
+  private[this] def addEntry(e: Entry, h: Int): B = {
+    if (tableSize >= threshold) addEntry(e)
+    else addEntry0(e, h)
+    e.value
+  }
+
+  /* extracted to make addEntry inlinable */
+  private[this] def addEntry0(e: Entry, h: Int) {
+    e.next = table(h).asInstanceOf[Entry]
+    table(h) = e
+    tableSize += 1
+    nnSizeMapAdd(h)
+  }
+
   override def put(key: A, value: B): Option[B] = {
     val e = findOrAddEntry(key, value)
     if (e eq null) None

--- a/src/library/scala/collection/mutable/HashTable.scala
+++ b/src/library/scala/collection/mutable/HashTable.scala
@@ -183,6 +183,7 @@ trait HashTable[A, Entry >: Null <: HashEntry[A, Entry]] extends HashTable.HashU
         table(h) = e.next
         tableSize = tableSize - 1
         nnSizeMapRemove(h)
+        e.next = null
         return e
       } else {
         var e1 = e.next
@@ -194,6 +195,7 @@ trait HashTable[A, Entry >: Null <: HashEntry[A, Entry]] extends HashTable.HashU
           e.next = e1.next
           tableSize = tableSize - 1
           nnSizeMapRemove(h)
+          e1.next = null
           return e1
         }
       }
@@ -227,8 +229,9 @@ trait HashTable[A, Entry >: Null <: HashEntry[A, Entry]] extends HashTable.HashU
     var es        = iterTable(idx)
 
     while (es != null) {
+      val next = es.next // Cache next in case f removes es.
       f(es.asInstanceOf[Entry])
-      es = es.next
+      es = next
 
       while (es == null && idx > 0) {
         idx -= 1

--- a/src/library/scala/collection/mutable/HashTable.scala
+++ b/src/library/scala/collection/mutable/HashTable.scala
@@ -12,7 +12,7 @@ package scala
 package collection
 package mutable
 
-import java.lang.Integer.rotateRight
+import java.lang.Integer.{numberOfLeadingZeros, rotateRight}
 import scala.util.hashing.byteswap32
 
 /** This class can be used to construct data structures that are based
@@ -367,11 +367,7 @@ trait HashTable[A, Entry >: Null <: HashEntry[A, Entry]] extends HashTable.HashU
     * Note: we take the most significant bits of the hashcode, not the lower ones
     * this is of crucial importance when populating the table in parallel
     */
-  protected final def index(hcode: Int): Int = {
-    val ones = table.length - 1
-    val exponent = Integer.numberOfLeadingZeros(ones)
-    (improve(hcode, seedvalue) >>> exponent) & ones
-  }
+  protected final def index(hcode: Int): Int = if (table.length == 1) 0 else improve(hcode, seedvalue) >>> numberOfLeadingZeros(table.length - 1)
 
   protected def initWithContents(c: HashTable.Contents[A, Entry]) = {
     if (c != null) {

--- a/src/library/scala/collection/mutable/HashTable.scala
+++ b/src/library/scala/collection/mutable/HashTable.scala
@@ -411,58 +411,23 @@ private[collection] object HashTable {
 
     protected def elemHashCode(key: KeyType) = key.##
 
-    protected final def improve(hcode: Int, seed: Int) = {
-      /* Murmur hash
-       *  m = 0x5bd1e995
-       *  r = 24
-       *  note: h = seed = 0 in mmix
-       *  mmix(h,k) = k *= m; k ^= k >> r; k *= m; h *= m; h ^= k; */
-      // var k = hcode * 0x5bd1e995
-      // k ^= k >> 24
-      // k *= 0x5bd1e995
-      // k
-
-      /* Another fast multiplicative hash
-       * by Phil Bagwell
-       *
-       * Comment:
-       * Multiplication doesn't affect all the bits in the same way, so we want to
-       * multiply twice, "once from each side".
-       * It would be ideal to reverse all the bits after the first multiplication,
-       * however, this is more costly. We therefore restrict ourselves only to
-       * reversing the bytes before final multiplication. This yields a slightly
-       * worse entropy in the lower 8 bits, but that can be improved by adding:
-       *
-       * `i ^= i >> 6`
-       *
-       * For performance reasons, we avoid this improvement.
-       * */
-      val i= scala.util.hashing.byteswap32(hcode)
-
-      /* Jenkins hash
-       * for range 0-10000, output has the msb set to zero */
-      // var h = hcode + (hcode << 12)
-      // h ^= (h >> 22)
-      // h += (h << 4)
-      // h ^= (h >> 9)
-      // h += (h << 10)
-      // h ^= (h >> 2)
-      // h += (h << 7)
-      // h ^= (h >> 12)
-      // h
-
-      /* OLD VERSION
-       * quick, but bad for sequence 0-10000 - little entropy in higher bits
-       * since 2003 */
-      // var h: Int = hcode + ~(hcode << 9)
-      // h = h ^ (h >>> 14)
-      // h = h + (h << 4)
-      // h ^ (h >>> 10)
-
-      // the rest of the computation is due to SI-5293
-      val rotation = seed % 32
-      val rotated = (i >>> rotation) | (i << (32 - rotation))
-      rotated
+    /**
+      * Defer to a high-quality hash in [[scala.util.hashing]].
+      * The goal is to distribute across bins as well as possible even if a hash code has low entropy at some bits.
+      * <p/>
+      * OLD VERSION - quick, but bad for sequence 0-10000 - little entropy in higher bits - since 2003
+      * {{{
+      * var h: Int = hcode + ~(hcode << 9)
+      * h = h ^ (h >>> 14)
+      * h = h + (h << 4)
+      * h ^ (h >>> 10)
+      * }}}
+      * the rest of the computation is due to SI-5293
+      */
+    protected final def improve(hcode: Int, seed: Int): Int = {
+      val hash = scala.util.hashing.byteswap32(hcode)
+      val shift = seed & ((1 << 5) - 1)
+      (hash >>> shift) | (hash << (32 - shift))
     }
   }
 

--- a/src/library/scala/collection/mutable/HashTable.scala
+++ b/src/library/scala/collection/mutable/HashTable.scala
@@ -360,14 +360,14 @@ trait HashTable[A, Entry >: Null <: HashEntry[A, Entry]] extends HashTable.HashU
 
   protected def elemEquals(key1: A, key2: A): Boolean = (key1 == key2)
 
-  // Note:
-  // we take the most significant bits of the hashcode, not the lower ones
-  // this is of crucial importance when populating the table in parallel
-  protected final def index(hcode: Int) = {
+  /**
+    * Note: we take the most significant bits of the hashcode, not the lower ones
+    * this is of crucial importance when populating the table in parallel
+    */
+  protected final def index(hcode: Int): Int = {
     val ones = table.length - 1
-    val improved = improve(hcode, seedvalue)
-    val shifted = (improved >> (32 - java.lang.Integer.bitCount(ones))) & ones
-    shifted
+    val exponent = Integer.numberOfLeadingZeros(ones)
+    (improve(hcode, seedvalue) >>> exponent) & ones
   }
 
   protected def initWithContents(c: HashTable.Contents[A, Entry]) = {

--- a/src/library/scala/collection/mutable/HashTable.scala
+++ b/src/library/scala/collection/mutable/HashTable.scala
@@ -12,6 +12,9 @@ package scala
 package collection
 package mutable
 
+import java.lang.Integer.rotateRight
+import scala.util.hashing.byteswap32
+
 /** This class can be used to construct data structures that are based
  *  on hashtables. Class `HashTable[A]` implements a hashtable
  *  that maps keys of type `A` to values of the fully abstract
@@ -424,11 +427,7 @@ private[collection] object HashTable {
       * }}}
       * the rest of the computation is due to SI-5293
       */
-    protected final def improve(hcode: Int, seed: Int): Int = {
-      val hash = scala.util.hashing.byteswap32(hcode)
-      val shift = seed & ((1 << 5) - 1)
-      (hash >>> shift) | (hash << (32 - shift))
-    }
+    protected final def improve(hcode: Int, seed: Int): Int = rotateRight(byteswap32(hcode), seed)
   }
 
   /**

--- a/src/library/scala/collection/mutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/mutable/LinkedHashMap.scala
@@ -81,6 +81,8 @@ class LinkedHashMap[A, B] extends AbstractMap[A, B]
       else e.earlier.later = e.later
       if (e.later eq null) lastEntry = e.earlier
       else e.later.earlier = e.earlier
+      e.earlier = null // Null references to prevent nepotism
+      e.later = null
       Some(e.value)
     }
   }

--- a/src/library/scala/collection/mutable/LinkedHashSet.scala
+++ b/src/library/scala/collection/mutable/LinkedHashSet.scala
@@ -73,6 +73,8 @@ class LinkedHashSet[A] extends AbstractSet[A]
       else e.earlier.later = e.later
       if (e.later eq null) lastEntry = e.earlier
       else e.later.earlier = e.earlier
+      e.earlier = null // Null references to prevent nepotism
+      e.later = null
       true
     }
   }


### PR DESCRIPTION
Backported by recommendation from @Ichoran and @retronym: https://github.com/scala/scala/pull/5528#issuecomment-260799361