### PR TITLE
Changed hashing bit rotation to use Integer.rotateRight

### DIFF
--- a/src/library/scala/collection/mutable/FlatHashTable.scala
+++ b/src/library/scala/collection/mutable/FlatHashTable.scala
@@ -10,6 +10,9 @@ package scala
 package collection
 package mutable
 
+import java.lang.Integer.rotateRight
+import scala.util.hashing.byteswap32
+
 /** An implementation class backing a `HashSet`.
  *
  *  This trait is used internally. It can be mixed in with various collections relying on
@@ -415,20 +418,7 @@ private[collection] object FlatHashTable {
     // so that:
     protected final def sizeMapBucketSize = 1 << sizeMapBucketBitSize
 
-    protected final def improve(hcode: Int, seed: Int) = {
-      //var h: Int = hcode + ~(hcode << 9)
-      //h = h ^ (h >>> 14)
-      //h = h + (h << 4)
-      //h ^ (h >>> 10)
-
-      val improved= scala.util.hashing.byteswap32(hcode)
-
-      // for the remainder, see SI-5293
-      // to ensure that different bits are used for different hash tables, we have to rotate based on the seed
-      val rotation = seed % 32
-      val rotated = (improved >>> rotation) | (improved << (32 - rotation))
-      rotated
-    }
+    protected final def improve(hcode: Int, seed: Int) = rotateRight(byteswap32(hcode), seed)
 
     /**
      * Elems have type A, but we store AnyRef in the table. Plus we need to deal with

--- a/src/library/scala/collection/mutable/HashTable.scala
+++ b/src/library/scala/collection/mutable/HashTable.scala
@@ -12,6 +12,9 @@ package scala
 package collection
 package mutable
 
+import java.lang.Integer.rotateRight
+import scala.util.hashing.byteswap32
+
 /** This class can be used to construct data structures that are based
  *  on hashtables. Class `HashTable[A]` implements a hashtable
  *  that maps keys of type `A` to values of the fully abstract
@@ -424,11 +427,7 @@ private[collection] object HashTable {
       * }}}
       * the rest of the computation is due to SI-5293
       */
-    protected final def improve(hcode: Int, seed: Int): Int = {
-      val hash = scala.util.hashing.byteswap32(hcode)
-      val shift = seed & ((1 << 5) - 1)
-      (hash >>> shift) | (hash << (32 - shift))
-    }
+    protected final def improve(hcode: Int, seed: Int): Int = rotateRight(byteswap32(hcode), seed)
   }
 
   /**


### PR DESCRIPTION
Related to https://issues.scala-lang.org/browse/SI-10049 and https://issues.scala-lang.org/browse/SI-10084

The benchmarks show the following (`ns/op`, lower is better)

`Before:`
```scala
Benchmark                                     (size)  Mode  Cnt      Score      Error  Units
s.c.immutable.VectorMapBenchmark.groupBy          10  avgt   20    616.164 ±    4.712  ns/op
s.c.immutable.VectorMapBenchmark.groupBy         100  avgt   20   2034.447 ±   14.495  ns/op
s.c.immutable.VectorMapBenchmark.groupBy        1000  avgt   20  14712.164 ±  119.983  ns/op
s.c.mutable.HashMapBenchmark.get                  10  avgt   20    679.046 ±    6.872  ns/op
s.c.mutable.HashMapBenchmark.get                 100  avgt   20   7242.097 ±   41.244  ns/op
s.c.mutable.HashMapBenchmark.get                1000  avgt   20  95342.919 ± 1521.328  ns/op
s.c.mutable.HashMapBenchmark.getOrElseUpdate      10  avgt   20    488.034 ±    4.554  ns/op
s.c.mutable.HashMapBenchmark.getOrElseUpdate     100  avgt   20   4883.123 ±   59.268  ns/op
s.c.mutable.HashMapBenchmark.getOrElseUpdate    1000  avgt   20  65174.034 ±  496.759  ns/op
s.c.mutable.HashMapBenchmark.put                  10  avgt   20    267.983 ±    1.797  ns/op
s.c.mutable.HashMapBenchmark.put                 100  avgt   20   5097.351 ±  104.538  ns/op
s.c.mutable.HashMapBenchmark.put                1000  avgt   20  78772.540 ±  543.935  ns/op
```
`After:`
```scala
Benchmark                                     (size)  Mode  Cnt      Score      Error  Units
s.c.immutable.VectorMapBenchmark.groupBy          10  avgt   20    600.785 ±    1.639  ns/op
s.c.immutable.VectorMapBenchmark.groupBy         100  avgt   20   1927.722 ±   10.543  ns/op
s.c.immutable.VectorMapBenchmark.groupBy        1000  avgt   20  14450.596 ±   86.490  ns/op
s.c.mutable.HashMapBenchmark.get                  10  avgt   20    654.584 ±    3.316  ns/op
s.c.mutable.HashMapBenchmark.get                 100  avgt   20   7212.925 ±   43.364  ns/op
s.c.mutable.HashMapBenchmark.get                1000  avgt   20  94023.279 ± 1618.070  ns/op
s.c.mutable.HashMapBenchmark.getOrElseUpdate      10  avgt   20    485.574 ±    3.803  ns/op
s.c.mutable.HashMapBenchmark.getOrElseUpdate     100  avgt   20   4920.506 ±   25.781  ns/op
s.c.mutable.HashMapBenchmark.getOrElseUpdate    1000  avgt   20  63444.007 ±  289.288  ns/op
s.c.mutable.HashMapBenchmark.put                  10  avgt   20    241.557 ±    1.778  ns/op
s.c.mutable.HashMapBenchmark.put                 100  avgt   20   5125.638 ±   30.796  ns/op
s.c.mutable.HashMapBenchmark.put                1000  avgt   20  77419.913 ±  548.382  ns/op
```