### PR TITLE
Improve Queue.++ when building another Queue

### DIFF
--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -100,6 +100,15 @@ class Queue[+A] protected(protected val in: List[A], protected val out: List[A])
     case _                               => super.:+(elem)(bf)
   }
 
+  override def ++[B >: A, That](that: GenTraversableOnce[B])(implicit bf: CanBuildFrom[Queue[A], B, That]): That = {
+    if (bf eq Queue.ReusableCBF) {
+      val thatQueue = that.asInstanceOf[Queue[B]]
+      new Queue[B](thatQueue.in ++ (thatQueue.out reverse_::: this.in), this.out).asInstanceOf[That]
+    } else {
+      super.++(that)(bf)
+    }
+  }
+
   /** Creates a new queue with element added at the end
    *  of the old queue.
    *

--- a/test/files/run/iq.scala
+++ b/test/files/run/iq.scala
@@ -25,12 +25,18 @@ object iq {
     assert(q2 == qb)
     val qc = 42 +: q :+ 0
     assert(q2 == qc)
+    assert(q ++ qa == qa)
+    val qdr =  1 +: 2 +: 3 +: 4 +: q
+    val qcon1 = 1 +: 2 +: q
+    val qcon2 = q :+ 3 :+ 4
+    val qd = qcon1 ++ qcon2
+    assert(qd == qdr)
 
     Console.println("q2: " + q2)
     Console.println("qa: " + qa)
     Console.println("qb: " + qb)
     Console.println("qc: " + qc)
-    
+
     /* Test is empty and dequeue.
      * Expected: Head: 42
      */


### PR DESCRIPTION
Adds in the Okasaki `concat` version in case we are constructing a `Queue` from two `Queue`s. You can see the impact of the default implementation (and inheritance hierarchy etc.) here: https://ethercalc.org/kknm1xz3mb5s_naakfyfum4p3/app in all of the concat benchmarks, especially the right-associated tree being concatenated. The performance difference is a few orders of magnitude at my benchmark size. Let me know if this is more appropriate for 2.11.x.