### PR TITLE
bump version (now 2.12.2) + and STARR (now 2.12.1)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,7 @@ lazy val publishSettings : Seq[Setting[_]] = Seq(
 // should not be set directly. It is the same as the Maven version and derived automatically from `baseVersion` and
 // `baseVersionSuffix`.
 globalVersionSettings
-baseVersion in Global := "2.12.1"
+baseVersion in Global := "2.12.2"
 baseVersionSuffix in Global := "SNAPSHOT"
 mimaReferenceVersion in Global := Some("2.12.0")
 

--- a/versions.properties
+++ b/versions.properties
@@ -1,7 +1,7 @@
 # Scala version used for bootstrapping. (This has no impact on the
 # final classfiles, since compiler and library are built first using
 # starr, then rebuilt using themselves.)
-starr.version=2.12.0
+starr.version=2.12.1
 
 # These are the versions of the modules that go with this release.
 # These properties are used during PR validation and in dbuild builds.


### PR DESCRIPTION
as we normally do post-release