### PR TITLE
SI-10093 don't move member traits to constructor body in constructors

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Constructors.scala
+++ b/src/compiler/scala/tools/nsc/transform/Constructors.scala
@@ -462,7 +462,7 @@ abstract class Constructors extends Statics with Transform with TypingTransforme
 
     // find and dissect primary constructor
     private val (primaryConstr, _primaryConstrParams, primaryConstrBody) = stats collectFirst {
-      case dd@DefDef(_, _, _, vps :: Nil, _, rhs: Block) if dd.symbol.isPrimaryConstructor || dd.symbol.isMixinConstructor => (dd, vps map (_.symbol), rhs)
+      case dd@DefDef(_, _, _, vps :: Nil, _, rhs: Block) if dd.symbol.isPrimaryConstructor => (dd, vps map (_.symbol), rhs)
     } getOrElse {
       abort("no constructor in template: impl = " + impl)
     }
@@ -646,14 +646,14 @@ abstract class Constructors extends Statics with Transform with TypingTransforme
 
           stat match {
             // recurse on class definition, store in defBuf
-            case _: ClassDef if !statSym.isInterface =>
-              defBuf += new ConstructorTransformer(unit).transform(stat)
+            case _: ClassDef =>
+              if (statSym.isInterface) defBuf += stat
+              else defBuf += new ConstructorTransformer(unit).transform(stat)
 
             // primary constructor is already tracked as `primaryConstr`
             // non-primary constructors go to auxConstructorBuf
-            // mixin constructors are suppressed (!?!?)
             case _: DefDef if statSym.isConstructor =>
-              if ((statSym ne primaryConstrSym) && !statSym.isMixinConstructor) auxConstructorBuf += stat
+              if (statSym ne primaryConstrSym) auxConstructorBuf += stat
 
             // If a val needs a field, an empty valdef goes into the template.
             // Except for lazy and ConstantTyped vals, the field is initialized by an assignment in:

--- a/src/reflect/scala/reflect/internal/Flags.scala
+++ b/src/reflect/scala/reflect/internal/Flags.scala
@@ -92,7 +92,9 @@ class ModifierFlags {
   final val ABSTRACT      = 1 << 3        // abstract class, or used in conjunction with abstract override.
                                           // Note difference to DEFERRED!
   final val DEFERRED      = 1 << 4        // was `abstract' for members | trait is virtual
-  final val INTERFACE     = 1 << 7        // symbol is an interface (i.e. a trait which defines only abstract methods)
+  final val INTERFACE     = 1 << 7        // symbol is an interface. the flag is set for:
+                                          //  - scala-defined traits with only abstract methods or fields
+                                          //  - any java-defined interface (even if it has default methods)
   final val MUTABLE       = 1 << 12       // symbol is a mutable variable.
   final val PARAM         = 1 << 13       // symbol is a (value or type) parameter to a method
   final val MACRO         = 1 << 15       // symbol is a macro definition

--- a/test/files/pos/t10093.flags
+++ b/test/files/pos/t10093.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t10093.scala
+++ b/test/files/pos/t10093.scala
@@ -1,0 +1,5 @@
+class A[@specialized(Int) T](val value: T) {
+  trait B
+  def useValue(x:T): Unit = ()
+  useValue(value)
+}

--- a/test/junit/scala/tools/nsc/symtab/FlagsTest.scala
+++ b/test/junit/scala/tools/nsc/symtab/FlagsTest.scala
@@ -2,15 +2,17 @@ package scala.tools.nsc
 package symtab
 
 import org.junit.Assert._
-import scala.tools.testing.AssertUtil._
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
+import scala.tools.testing.BytecodeTesting
+
 @RunWith(classOf[JUnit4])
-class FlagsTest {
+class FlagsTest extends BytecodeTesting {
   object symbolTable extends SymbolTableForUnitTesting
   import symbolTable._
+
   import Flags._
 
   def sym = NoSymbol.newTermSymbol(nme.EMPTY)
@@ -86,5 +88,39 @@ class FlagsTest {
     import scala.reflect.runtime.universe._
     val dep = typeOf[java.lang.Deprecated].typeSymbol
     assertTrue(dep.isJavaAnnotation && dep.isJava)
+  }
+
+  @Test
+  def interfaceFlag(): Unit = {
+    // scala traits are `isInterface` if they have only type defs and abstract methods / fields.
+    // java interfaces are always `isInterface`.
+    val scalaCode =
+      """package p
+        |trait T1 {
+        |  import scala.collection
+        |  def m: Int
+        |  val f: Int
+        |  type T <: AnyRef
+        |}
+        |trait T2 {
+        |  def m = 1
+        |}
+        |trait T3 {
+        |  val f = 1
+        |}
+        |trait T4 {
+        |  println()
+        |}
+      """.stripMargin
+    val javaI1 = "package p; interface I1 { int m(); }"
+    val javaI2 = "package p; interface I2 { default int m() { return 1; } }"
+    compiler.compileClasses(code = scalaCode, javaCode = (javaI1, "I1.java") :: (javaI2, "I2.java") :: Nil)
+    import compiler.global.rootMirror._
+    assert( getRequiredClass("p.T1").isInterface)
+    assert(!getRequiredClass("p.T2").isInterface)
+    assert(!getRequiredClass("p.T3").isInterface)
+    assert(!getRequiredClass("p.T4").isInterface)
+    assert( getRequiredClass("p.I1").isInterface)
+    assert( getRequiredClass("p.I2").isInterface)
   }
 }


### PR DESCRIPTION
Fixes a regression introduced in c8e6050. Member traits with only
abstract definitions (`isInterface`) were moved into the primary
constructor by mistake. (Flatten moved the classes back.)

The member trait was duplicated into the constructor of specialized
subclasses, causing it to be generated multiple times.

Also removes some unnecessary `isMixinConstructor` checks: the mixin
constructor is always the primary constructor.

This commit also clarifies (and tests) what `isInterface` means: for
scala-defined traits, it means there are only abstract members. For
java-defined interfaces, it is always true.