### PR TITLE
SI-10072 cast Function nodes to environment in specialization

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Duplicators.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Duplicators.scala
@@ -240,10 +240,6 @@ abstract class Duplicators extends Analyzer {
             result.symbol.updateAttachment(DelambdafyTarget)
           result
 
-        case fun: Function =>
-          debuglog("Clearing the type and retyping Function: " + fun)
-          super.typed(fun.clearType, mode, pt)
-
         case vdef @ ValDef(mods, name, tpt, rhs) =>
           // log("vdef fixing tpe: " + tree.tpe + " with sym: " + tree.tpe.typeSymbol + " and " + invalidSyms)
           //if (mods.hasFlag(Flags.LAZY)) vdef.symbol.resetFlag(Flags.MUTABLE) // Martin to Iulian: lazy vars can now appear because they are no longer boxed; Please check that deleting this statement is OK.

--- a/test/files/run/t10072.scala
+++ b/test/files/run/t10072.scala
@@ -1,0 +1,18 @@
+trait T[A] {
+  def a: A
+  def foldLeft[B](zero: B, op: (B, A) => B): B = op(zero, a)
+  def sum[B >: A](zero: B): B
+}
+
+class C[@specialized(Int) A](val a: A) extends T[A] {
+  override def sum[@specialized(Int) B >: A](zero: B): B = foldLeft(zero, (x: B, y: B) => x)
+}
+
+object Test extends App {
+  def factory[T](a: T): C[T] = new C[T](a)
+
+  assert(new C[Int](1).sum(2) == 2)
+  assert(new C[String]("ho").sum("hu") == "hu")
+  assert(factory[Int](1).sum(2) == 2)
+  assert(factory[String]("ho").sum("hu") == "hu")
+}


### PR DESCRIPTION
This commit basically make sure the fix for SI-5284 works correctly when
a Function node reaches specialization (`-Ydealmbdafy:method` and
IndyLambda are default in 2.12.x). To understand it, best read the
excellent description in b29c01b.

The code that's removed in this commit was added in 13ea590. It
prevented `castType` from being invoked on the `Function` node, which
is exactly what is needed here. It's also what happens under
`-Ydelambdafy:inline`, the `new anonfun()` tree is being casted from
`(Int, Int) => Int` to `(Int, A) => Int`.