### PR TITLE
SI-9632 don't keep JarFile open in ZipArchive (with -Dscala.classpath.closeZip=true)

### DIFF
--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -52,6 +52,18 @@ filter {
       problemName=DirectMissingMethodProblem
     },
     {
+      matchName="scala.reflect.io.FileZipArchive$LazyEntry"
+      problemName=MissingClassProblem
+    },
+    {
+      matchName="scala.reflect.io.ZipArchive.closeZipFile"
+      problemName=DirectMissingMethodProblem
+    },
+    {
+      matchName="scala.reflect.io.FileZipArchive$LeakyEntry"
+      problemName=MissingClassProblem
+    },
+    {
       matchName="scala.collection.immutable.HashMap.contains0"
       problemName=DirectMissingMethodProblem
     },


### PR DESCRIPTION
This is a proposed fix for https://issues.scala-lang.org/browse/SI-9632

- avoids a memory leak on all platforms (both OS level file handlers and JVM-level permgen/metaspace)
- allows windows to delete jars that have been used in previous compiles

It is absolutely essential that this does not introduce a performance regression, so I'd like to hear how we can be sure about that.

Timings of the community build are one way to check, but that's expensive. So I wrote https://github.com/fommil/sbt-scala-monkey as a way to try this out for any sbt project (this file should work for 2.11). I've not noticed any performance slowdown on my projects (my work project is very big).

While working on this I noticed a few things that are worth mentioning here:

1. this doesn't fix the larger problem https://issues.scala-lang.org/browse/SI-9682
1. scalac assumes that jars are immutable, so if a project uses sbt's exportJars then a fresh scalaInstance is needed for each compile, see my workaround in https://github.com/fommil/sbt-big-project/issues/45
1. if jars do mutate between scanning and access, the behaviour after this patch does subtely change... the time/size will (still) incorrectly report stale values, but this patch will load the new entries from the jar instead of the old ones.
1. is it worth investigating aggressively loading the input stream into an `Array[Byte]` and returning it, to be sure that the jar file is closed? I could use BasicIO to `readFully`, but I never trusted that it is performant enough.

PS: I go one further than this patch when working on a very large windows codebase at work, where instead of opening the JarFile to read entries, I use the URL classloader and I apply https://github.com/fommil/class-monkey, which will cache entries and (other than timestamp checks) results in zero IO accesses for the second compile. I'm happy to raise a PR with that approach, to get an idea of the impact it has (when not using class-monkey), see https://gist.github.com/fommil/5709abc1678b346b6d927a13cd30b844#file-ziparchive-scala-L140-L223
