### PR TITLE
Update spec build to Jekyll 3.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # To build the spec on Travis CI
 source "https://rubygems.org"
 
-gem "jekyll", "2.5.3"
+gem "jekyll", "3.3.0"
 gem "rouge"
 # gem 's3_website'
 gem "redcarpet", "3.3.2"


### PR DESCRIPTION
Seth Tisue suggested updating the Jekyll dependency for the Scala spec in scala/scala-lang#559 so that is consistent with the scala-lang.org and docs.scala-lang.org Web sites.

Upgrading Jekll from 2.5.3 to 3.3.0 produces slight differences in the HTML output.  The differences in the HTML are isolated to the markup for source code highlighting.  In the spec, those are Scala code listings and the blocks of extended-BNF. From what I saw looking at all the pages, they render exactly the same, pixel-for-pixel, as before.  I hit print preview and also didn't notice any anomalies.

I tested in Ruby 2.2.5 using rbenv 0.4.0, gem 2.4.5.1 and Bundler 1.13.6.  This is compared to the Travis build that uses Ruby 2.2.0p0 using rvm 1.26.10, gem 2.4.5 and Bundler 1.7.9.