### PR TITLE
Remove unnecessary methods in TraversableOnce

### DIFF
--- a/src/library/scala/collection/TraversableOnce.scala
+++ b/src/library/scala/collection/TraversableOnce.scala
@@ -62,12 +62,6 @@ import scala.reflect.ClassTag
 trait TraversableOnce[+A] extends Any with GenTraversableOnce[A] {
   self =>
 
-  //TODO 2.12: Remove these methods. They are already defined in GenTraversableOnce
-  /* Self-documenting abstract methods. */
-  def foreach[U](f: A => U): Unit
-  def isEmpty: Boolean
-  def hasDefiniteSize: Boolean
-
   // Note: We could redefine this in TraversableLike to always return `repr`
   // of type `Repr`, only if `Repr` had type bounds, which it doesn't, because
   // not all `Repr` are a subtype `TraversableOnce[A]`.

--- a/test/files/neg/abstract-report.check
+++ b/test/files/neg/abstract-report.check
@@ -4,6 +4,9 @@ it has 12 unimplemented members.
  *  For convenience, these are usable as stub implementations.
  */
   // Members declared in scala.collection.GenTraversableOnce
+  def foreach[U](f: String => U): Unit = ???
+  def hasDefiniteSize: Boolean = ???
+  def isEmpty: Boolean = ???
   def isTraversableAgain: Boolean = ???
   def toIterator: Iterator[String] = ???
   def toStream: Stream[String] = ???
@@ -13,9 +16,6 @@ it has 12 unimplemented members.
   def exists(p: String => Boolean): Boolean = ???
   def find(p: String => Boolean): Option[String] = ???
   def forall(p: String => Boolean): Boolean = ???
-  def foreach[U](f: String => U): Unit = ???
-  def hasDefiniteSize: Boolean = ???
-  def isEmpty: Boolean = ???
   def seq: scala.collection.TraversableOnce[String] = ???
   def toTraversable: Traversable[String] = ???
 

--- a/test/files/neg/abstract-report2.check
+++ b/test/files/neg/abstract-report2.check
@@ -80,6 +80,9 @@ it has 24 unimplemented members.
   def toArray(): Array[Object] = ???
 
   // Members declared in scala.collection.GenTraversableOnce
+  def foreach[U](f: ((Set[Int], String)) => U): Unit = ???
+  def hasDefiniteSize: Boolean = ???
+  def isEmpty: Boolean = ???
   def isTraversableAgain: Boolean = ???
   def toIterator: Iterator[(Set[Int], String)] = ???
   def toStream: Stream[(Set[Int], String)] = ???
@@ -89,9 +92,6 @@ it has 24 unimplemented members.
   def exists(p: ((Set[Int], String)) => Boolean): Boolean = ???
   def find(p: ((Set[Int], String)) => Boolean): Option[(Set[Int], String)] = ???
   def forall(p: ((Set[Int], String)) => Boolean): Boolean = ???
-  def foreach[U](f: ((Set[Int], String)) => U): Unit = ???
-  def hasDefiniteSize: Boolean = ???
-  def isEmpty: Boolean = ???
   def seq: scala.collection.TraversableOnce[(Set[Int], String)] = ???
   def toTraversable: Traversable[(Set[Int], String)] = ???
 


### PR DESCRIPTION
As the commit(#4939)[1] says, we can remove the following unnecessary methods defined in GenTraversableOnce[2,3,4].
    
* foreach
* isEmpty
* hasDefiniteSize
    
[1] https://github.com/scala/scala/commit/f8d6814bb4fb0248d6121335e67eee8fde7ce455
[2] https://github.com/scala/scala/blob/v2.12.1/src/library/scala/collection/GenTraversableOnce.scala#L68
[3] https://github.com/scala/scala/blob/v2.12.1/src/library/scala/collection/GenTraversableOnce.scala#L87
[4] https://github.com/scala/scala/blob/v2.12.1/src/library/scala/collection/GenTraversableOnce.scala#L112
