### PR TITLE
Unix script template: get java version through java command

### DIFF
--- a/src/compiler/scala/tools/ant/templates/tool-unix.tmpl
+++ b/src/compiler/scala/tools/ant/templates/tool-unix.tmpl
@@ -198,8 +198,8 @@ fi
 if [[ "$usebootcp" == "true" ]]; then
   classpath_args=("-Xbootclasspath/a:$TOOL_CLASSPATH" -classpath "\"\"")
   # Note that the version numbers go 1.7, 1.8, 9, 10, ...
-  java_release="$(cat $JAVA_HOME/release | grep JAVA_VERSION)"
-  if [[ ! "$java_release" =~ JAVA_VERSION=\"1\. ]]; then
+  java_release="$($JAVACMD -version 2>&1 | head -n 1 | sed 's/.* version \"\(.*\)\"/\1/g')"
+  if [[ ! "$java_release" =~ 1\. ]]; then
     # Java 9 removed sun.boot.class.path, and the supposed replacement to at least see
     # the appended boot classpath (jdk.boot.class.path.append) is not visible.
     # So we have to pass a custom system property that PathResolver will find.


### PR DESCRIPTION
The `release` file does not exist in every java distribution (at least not in OpenJDK for Debian Stretch).
This change parses the output `java -version` to determine the version instead.

cc @retronym