### PR TITLE
Consider a val/var to match a nullary method with the same name

### DIFF
--- a/spec/05-classes-and-objects.md
+++ b/spec/05-classes-and-objects.md
@@ -263,6 +263,8 @@ and $M'$ bind the same name, and one of following holds.
    equal number of argument types $\overline T$, $\overline T'$
    and equal numbers of type parameters
    $\overline t$, $\overline t'$, say, and  $\overline T' = [\overline t'/\overline t]\overline T$.
+5. $M$ is not a method definition and $M'$ defines a parameterless method or a method
+   with an empty parameter list `()` or _vice versa_.
 
 <!--
 every argument type


### PR DESCRIPTION
The current definition of “matching” in the spec does not take the case
into account where a method matches a non-method member. I believe this
is necessary to make 5.1.4 (Overriding) correctly explain the case of
a val or var implementing an abstract method or overriding a concrete
method, both of which are allowed.