### PR TITLE
Modules w. serializable type alias "companions" are not serializable

### DIFF
--- a/src/library/scala/concurrent/forkjoin/package.scala
+++ b/src/library/scala/concurrent/forkjoin/package.scala
@@ -25,7 +25,7 @@ package object forkjoin {
   @deprecated("use java.util.concurrent.ForkJoinTask directly, instead of this alias",         "2.12.0")
   type ForkJoinTask[T] = juc.ForkJoinTask[T]
   @deprecated("use java.util.concurrent.ForkJoinTask directly, instead of this alias",         "2.12.0")
-  object ForkJoinTask {
+  object ForkJoinTask extends scala.Serializable {
     def adapt(runnable: Runnable): ForkJoinTask[_]                           = juc.ForkJoinTask.adapt(runnable)
     def adapt[T](callable: juc.Callable[_ <: T]): ForkJoinTask[T]            = juc.ForkJoinTask.adapt(callable)
     def adapt[T](runnable: Runnable, result: T): ForkJoinTask[T]             = juc.ForkJoinTask.adapt(runnable, result)
@@ -51,7 +51,7 @@ package object forkjoin {
   @deprecated("use java.util.concurrent.ThreadLocalRandom directly, instead of this alias",    "2.12.0")
   type ThreadLocalRandom      = juc.ThreadLocalRandom
   @deprecated("use java.util.concurrent.ThreadLocalRandom directly, instead of this alias",    "2.12.0")
-  object ThreadLocalRandom {
+  object ThreadLocalRandom extends scala.Serializable {
     // For source compatibility, current must declare the empty argument list.
     // Having no argument list makes more sense since it doesn't have any side effects,
     // but existing callers will break if they invoked it as `current()`.

--- a/test/files/run/SD-290.scala
+++ b/test/files/run/SD-290.scala
@@ -1,0 +1,39 @@
+object p1 {
+  class B
+  object B
+
+  class C extends java.io.Serializable
+  object C
+
+  type D = DD
+  object D
+}
+package object p2 {
+  class B
+  object B
+
+  class C extends java.io.Serializable
+  object C
+
+  type D = DD
+  object D
+
+}
+class DD extends java.io.Serializable
+
+object Test {
+  def main(args: Array[String]): Unit = {
+
+    // This is the behaviour that was intended and was unchanged by this commmit.
+    assert(!(p1.B : Object).isInstanceOf[scala.Serializable])
+    assert(p1.C.isInstanceOf[scala.Serializable])
+    assert(!(p1.D: Object).isInstanceOf[scala.Serializable])
+
+    assert(!(p2.B : Object).isInstanceOf[scala.Serializable])
+    assert(p2.C.isInstanceOf[scala.Serializable])
+
+    // this behaviour was different in 2.12.1 and earlier due to a bug
+    // in companionSymbolOf
+    assert(!(p2.D: Object).isInstanceOf[scala.Serializable])
+  }
+}


### PR DESCRIPTION
MiMa alerted us to a change in the parentage of two objects in the forkjoin
package object.

In Scala 2.12.0/1, they implemented `scala.Serializable`. Recently, this
(synthetically added) parent was absent. This appears to be due to a bug
fix in `companionSymbolOf`, which no longer treats objects and same-named
type aliases to be companions.

This commit manually adds the formerly-synthetic parents to these objects,
and documents the change in compiler behaviour with a test.

## Compatibility Note

Library authors with code like:

```scala
package object p1 {
  type A = SomeSerializableType
  object A
}
```

Will need to change this to:

```scala
package object p1 {
  type A = SomeSerializableType
  object A extends scala.Serializable
}
```

To remain technically binary compatible with the version compiled with Scala 2.12.0 or 2.12.1.