### PR TITLE
Fix spec links to `07-implicits.html`

### DIFF
--- a/spec/04-basic-declarations-and-definitions.md
+++ b/spec/04-basic-declarations-and-definitions.md
@@ -404,7 +404,7 @@ function definitions.  In this section we consider only type parameter
 definitions with lower bounds `>: $L$` and upper bounds
 `<: $U$` whereas a discussion of context bounds
 `: $U$` and view bounds `<% $U$`
-is deferred to [here](07-implicit-parameters-and-views.html#context-bounds-and-view-bounds).
+is deferred to [here](07-implicits.html#context-bounds-and-view-bounds).
 
 The most general form of a first-order type parameter is
 `$@a_1 \ldots @a_n$ $\pm$ $t$ >: $L$ <: $U$`.
@@ -686,7 +686,7 @@ The by-name modifier is disallowed for parameters of classes that
 carry a `val` or `var` prefix, including parameters of case
 classes for which a `val` prefix is implicitly generated. The
 by-name modifier is also disallowed for
-[implicit parameters](07-implicit-parameters-and-views.html#implicit-parameters).
+[implicit parameters](07-implicits.html#implicit-parameters).
 
 ###### Example
 The declaration

--- a/spec/12-the-scala-standard-library.md
+++ b/spec/12-the-scala-standard-library.md
@@ -141,7 +141,7 @@ Byte - Short
 whereas `Double` is the highest-ranked.  Ranking does _not_
 imply a [conformance relationship](03-types.html#conformance); for
 instance `Int` is not a subtype of `Long`.  However, object
-[`Predef`](#the-predef-object) defines [views](07-implicit-parameters-and-views.html#views)
+[`Predef`](#the-predef-object) defines [views](07-implicits.html#views)
 from every numeric value type to all higher-ranked numeric value types.
 Therefore, lower-ranked types are implicitly converted to higher-ranked types
 when required by the [context](06-expressions.html#implicit-conversions).
@@ -467,7 +467,7 @@ val ys: Array[Object] = xs.asInstanceOf[Array[Object]] // OK
 
 The instantiation of an array with a polymorphic element type $T$ requires
 information about type $T$ at runtime.
-This information is synthesized by adding a [context bound](07-implicit-parameters-and-views.html#context-bounds-and-view-bounds)
+This information is synthesized by adding a [context bound](07-implicits.html#context-bounds-and-view-bounds)
 of `scala.reflect.ClassTag` to type $T$.
 An example is the
 following implementation of method `mkArray`, which creates


### PR DESCRIPTION
The file referenced by the current links actually exists under
http://www.scala-lang.org/files/archive/spec/2.11/ but with a different
design than the rest. It seems to be left over from an older version.