### PR TITLE
scala-xml dependency should be provided

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -423,7 +423,7 @@ lazy val compiler = configureAsSubproject(project)
     description := "Scala Compiler",
     libraryDependencies ++= Seq(antDep, asmDep),
     // These are only needed for the POM:
-    libraryDependencies ++= Seq(scalaXmlDep, scalaParserCombinatorsDep, jlineDep % "optional"),
+    libraryDependencies ++= Seq(scalaXmlDep % "provided", scalaParserCombinatorsDep, jlineDep % "optional"),
     // this a way to make sure that classes from interactive and scaladoc projects
     // end up in compiler jar (that's what Ant build does)
     // we need to use LocalProject references (with strings) to deal with mutual recursion


### PR DESCRIPTION
Nothing should transitively depend on the scala-xml module except for
scaladoc and library-all.

Compiler needs scala-xml as a build dependency, but not at runtime.
The user is supposed to provide scala-xml as a dependency at runtime.
This fixes an issue where the classpath in SBT shadows the scala-xml
module, see scala/scala-module-dependency-sample#14.  The only
consequence of dropping the dependency at runtime is that scala-xml
always needs to be binary compatible.  That's the point of MiMa and
dbuild, no?