### PR TITLE
Fix how "sbt" is written

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,7 @@
 # Standard symbolic link to build/quick/bin
 /qbin
 
-# Sbt's target directories
+# sbt's target directories
 /target/
 /project/target/
 /project/project/target/

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ bootstrap build locally.
 For history on how the current scheme was arrived at, see
 https://groups.google.com/d/topic/scala-internals/gp5JsM1E0Fo/discussion.
 
-### Using the Sbt Build
+### Using the sbt Build
 
 Core commands:
 

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -49,7 +49,7 @@ object MiMa {
       "--curr", curr.getAbsolutePath,
       "--filters", filter.getAbsolutePath,
       "--generate-filters",
-      // !!! Command line MiMa (which we call rathan the SBT Plugin for reasons alluded to in f2d0f1e85) incorrectly
+      // !!! Command line MiMa (which we call rathan the sbt Plugin for reasons alluded to in f2d0f1e85) incorrectly
       //     defaults to no checking (!) if this isn't specified. Fixed in https://github.com/typesafehub/migration-manager/pull/138
       //     TODO: Try out the new "--direction both" mode of MiMa
       "--direction", "backwards"

--- a/project/PartestUtil.scala
+++ b/project/PartestUtil.scala
@@ -35,7 +35,7 @@ object PartestUtil {
 
     // HACK: if we parse `--srcpath scaladoc`, we overwrite this var. The parser for test file paths
     // then lazily creates the examples based on the current value.
-    // TODO is there a cleaner way to do this with SBT's parser infrastructure?
+    // TODO is there a cleaner way to do this with sbt's parser infrastructure?
     var srcPath = "files"
     var _testFiles: TestFiles = null
     def testFiles = {

--- a/project/Quiet.scala
+++ b/project/Quiet.scala
@@ -2,7 +2,7 @@ import sbt._
 import Keys._
 
 object Quiet {
-  // Workaround SBT issue described:
+  // Workaround sbt issue described:
   //
   //   https://github.com/scala/scala-dev/issues/100
   def silenceScalaBinaryVersionWarning = ivyConfiguration := {

--- a/project/ScalaOptionParser.scala
+++ b/project/ScalaOptionParser.scala
@@ -5,7 +5,7 @@ import sbt.complete.Parsers._
 import sbt.complete._
 
 object ScalaOptionParser {
-  /** A SBT parser for the Scala command line runners (scala, scalac, etc) */
+  /** An sbt parser for the Scala command line runners (scala, scalac, etc) */
   def scalaParser(entryPoint: String, globalBase: File): Parser[String] = {
     def BooleanSetting(name: String): Parser[String] =
       token(name)

--- a/src/compiler/scala/tools/nsc/CompilationUnits.scala
+++ b/src/compiler/scala/tools/nsc/CompilationUnits.scala
@@ -52,7 +52,7 @@ trait CompilationUnits { global: Global =>
      *  To get their sourcefiles, you need to dereference with .sourcefile
      */
     private[this] val _depends = mutable.HashSet[Symbol]()
-    // SBT compatibility (SI-6875)
+    // sbt compatibility (SI-6875)
     //
     // imagine we have a file named A.scala, which defines a trait named Foo and a module named Main
     // Main contains a call to a macro, which calls compileLate to define a mock for Foo
@@ -63,12 +63,12 @@ trait CompilationUnits { global: Global =>
     // * Virt35af32 depends on A (because it extends Foo from A)
     // * A depends on Virt35af32 (because it contains a macro expansion referring to FooMock from Virt35af32)
     //
-    // after compiling A.scala, SBT will notice that it has a new source file named Virt35af32.
+    // after compiling A.scala, sbt will notice that it has a new source file named Virt35af32.
     // it will also think that this file hasn't yet been compiled and since A depends on it
     // it will think that A needs to be recompiled.
     //
     // recompilation will lead to another macro expansion. that another macro expansion might choose to create a fresh mock,
-    // producing another virtual file, say, Virtee509a, which will again trick SBT into thinking that A needs a recompile,
+    // producing another virtual file, say, Virtee509a, which will again trick sbt into thinking that A needs a recompile,
     // which will lead to another macro expansion, which will produce another virtual file and so on
     def depends = if (exists && !source.file.isVirtual) _depends else mutable.HashSet[Symbol]()
 

--- a/src/compiler/scala/tools/util/VerifyClass.scala
+++ b/src/compiler/scala/tools/util/VerifyClass.scala
@@ -31,7 +31,7 @@ object VerifyClass {
     if (name endsWith ".jar")  checkClassesInJar(name, cl)
     else checkClassesInDir(name, cl)
 
-  /** Attempts to load all classes on the classpath defined in the args string array.  This method is meant to be used via reflection from tools like SBT or Ant. */
+  /** Attempts to load all classes on the classpath defined in the args string array.  This method is meant to be used via reflection from tools like sbt or Ant. */
   def run(args: Array[String]): java.util.Map[String, String] = {
     val urls = args.map(Path.apply).map(_.toFile.toURI.toURL).toArray
     println("As urls: " + urls.mkString(","))

--- a/src/library/scala/concurrent/SyncVar.scala
+++ b/src/library/scala/concurrent/SyncVar.scala
@@ -92,7 +92,7 @@ class SyncVar[A] {
   // whether or not the SyncVar is already defined. So, set has been
   // deprecated in order to eventually be able to make "setting" private
   @deprecated("use `put` to ensure a value cannot be overwritten without a corresponding `take`", "2.10.0")
-  // NOTE: Used by SBT 0.13.0-M2 and below
+  // NOTE: Used by sbt 0.13.0-M2 and below
   def set(x: A): Unit = setVal(x)
 
   /** Place a value in the SyncVar. If the SyncVar already has a stored value,
@@ -112,7 +112,7 @@ class SyncVar[A] {
   // whether or not the SyncVar is already defined. So, unset has been
   // deprecated in order to eventually be able to make "unsetting" private
   @deprecated("use `take` to ensure a value is never discarded", "2.10.0")
-  // NOTE: Used by SBT 0.13.0-M2 and below
+  // NOTE: Used by sbt 0.13.0-M2 and below
   def unset(): Unit = synchronized {
     isDefined = false
     value = null.asInstanceOf[A]

--- a/src/library/scala/util/MurmurHash.scala
+++ b/src/library/scala/util/MurmurHash.scala
@@ -82,7 +82,7 @@ class MurmurHash[@specialized(Int,Long,Float,Double) T](seed: Int) extends (T =>
  *  needs to be called to finalize the hash.
  */
 @deprecated("use the object MurmurHash3 instead", "2.10.0")
-// NOTE: Used by SBT 0.13.0-M2 and below
+// NOTE: Used by sbt 0.13.0-M2 and below
 object MurmurHash {
   // Magic values used for MurmurHash's 32 bit hash.
   // Don't change these without consulting a hashing expert!

--- a/src/reflect/scala/reflect/internal/Scopes.scala
+++ b/src/reflect/scala/reflect/internal/Scopes.scala
@@ -408,7 +408,7 @@ trait Scopes extends api.Scopes { self: SymbolTable =>
       if (toList forall p) this
       else newScopeWith(toList filter p: _*)
     )
-    @deprecated("use `toList.reverse` instead", "2.10.0") // Used in SBT 0.12.4
+    @deprecated("use `toList.reverse` instead", "2.10.0") // Used in sbt 0.12.4
     def reverse: List[Symbol] = toList.reverse
 
     override def mkString(start: String, sep: String, end: String) =

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -416,7 +416,7 @@ abstract class SymbolTable extends macros.Universe
    */
   def isCompilerUniverse = false
 
-  @deprecated("use enteringPhase", "2.10.0") // Used in SBT 0.12.4
+  @deprecated("use enteringPhase", "2.10.0") // Used in sbt 0.12.4
   @inline final def atPhase[T](ph: Phase)(op: => T): T = enteringPhase(ph)(op)
 
 

--- a/src/reflect/scala/reflect/internal/util/Position.scala
+++ b/src/reflect/scala/reflect/internal/util/Position.scala
@@ -222,7 +222,7 @@ private[util] trait InternalPositionImpl {
 private[util] trait DeprecatedPosition {
   self: Position =>
 
-  @deprecated("use `point`", "2.9.0") // Used in SBT 0.12.4
+  @deprecated("use `point`", "2.9.0") // Used in sbt 0.12.4
   def offset: Option[Int] = if (isDefined) Some(point) else None
 
   @deprecated("use `focus`", "2.11.0")

--- a/test/benchmarks/README.md
+++ b/test/benchmarks/README.md
@@ -1,7 +1,7 @@
 # Scala library benchmarks
 
-This directory is a standalone SBT project, within the Scala project,
-that makes use of the [SBT plugin](https://github.com/ktoso/sbt-jmh) for [JMH](http://openjdk.java.net/projects/code-tools/jmh/).
+This directory is a standalone sbt project, within the Scala project,
+that makes use of the [sbt plugin](https://github.com/ktoso/sbt-jmh) for [JMH](http://openjdk.java.net/projects/code-tools/jmh/).
 
 ## Running a benchmark
 
@@ -16,10 +16,10 @@ Using this example, one would simply run
 
     jmh:runMain scala.collection.mutable.OpenHashMapRunner
 
-in SBT, run _from this directory_ (`test/benchmarks`).
+in sbt, run _from this directory_ (`test/benchmarks`).
 
 The JMH results can be found under `target/jmh-results/`.
-`target` gets deleted on an SBT `clean`,
+`target` gets deleted on an sbt `clean`,
 so you should copy these files out of `target` if you wish to preserve them.
 
 ## Creating a benchmark and runner

--- a/test/files/pos/t5120.scala
+++ b/test/files/pos/t5120.scala
@@ -1,4 +1,4 @@
-// An example extracted from SBT by Iulian
+// An example extracted from sbt by Iulian
 // that showed that the previous fix to t5120
 // was too strict.
 class Test {

--- a/test/files/pos/t8947/Macro_1.scala
+++ b/test/files/pos/t8947/Macro_1.scala
@@ -36,6 +36,6 @@ object X {
   //      }
   //
   //   To make this visible to the macro implementation, it will need to be compiled in an earlier stage,
-  //   e.g a separate SBT sub-project.
+  //   e.g a separate sbt sub-project.
 
 }


### PR DESCRIPTION
"sbt" is not an acronym (it used to be, but it isn't any longer).
It's a proper name, like "iPhone" or "eBay".

So, just like you wouldn't write "Get Started With EBay" or
"How To Reset Your IPhone", we don't write "Using the Sbt Build".