### PR TITLE
SI-10016 preserve annotation on existential

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -167,19 +167,7 @@ trait Types
    *  forwarded here. Some operations are rewrapped again.
    */
   trait RewrappingTypeProxy extends SimpleTypeProxy {
-    protected def maybeRewrap(newtp: Type) = (
-      if (newtp eq underlying) this
-      else {
-        // - BoundedWildcardTypes reach here during erroneous compilation: neg/t6258
-        // - Higher-kinded exclusion is because [x]CC[x] compares =:= to CC: pos/t3800
-        // - Avoid reusing the existing Wrapped(RefinedType) when we've be asked to wrap an =:= RefinementTypeRef, the
-        //   distinction is important in base type sequences. See TypesTest.testExistentialRefinement
-        // - Otherwise, if newtp =:= underlying, don't rewrap it.
-        val hasSpecialMeaningBeyond_=:= = newtp.isWildcard || newtp.isHigherKinded || newtp.isInstanceOf[RefinementTypeRef]
-        if (!hasSpecialMeaningBeyond_=:= && (newtp =:= underlying)) this
-        else rewrap(newtp)
-      }
-    )
+    protected def maybeRewrap(newtp: Type) = if (newtp eq underlying) this else rewrap(newtp)
     protected def rewrap(newtp: Type): Type
 
     // the following are all operations in class Type that are overridden in some subclass

--- a/test/files/run/t10016.check
+++ b/test/files/run/t10016.check
@@ -1,0 +1,8 @@
+
+scala> def existWith(x: (List[T] forSome {type T}) with Int {def xxx: Int}) = ???
+existWith: (x: List[_] with Int{def xxx: Int})Nothing
+
+scala> def existKeepsAnnot(x: (List[T] forSome {type T})@SerialVersionUID(1L) with Int {def xxx: Int}) = ???
+existKeepsAnnot: (x: List[Any] @SerialVersionUID(value = 1L) with Int{def xxx: Int})Nothing
+
+scala> :quit

--- a/test/files/run/t10016.scala
+++ b/test/files/run/t10016.scala
@@ -1,0 +1,11 @@
+import scala.tools.partest.ReplTest
+
+// check that we don't lose the annotation on the existential type nested in an intersection type
+// it's okay that List[_] is represented as List[Any] -- they are equivalent due to variance (existential extrapolation)
+// (The above comment should not be construed as an endorsement of rewrapping as a great way to implement a bunch of different type "proxies")
+object Test extends ReplTest {
+  def code = """
+    |def existWith(x: (List[T] forSome {type T}) with Int {def xxx: Int}) = ???
+    |def existKeepsAnnot(x: (List[T] forSome {type T})@SerialVersionUID(1L) with Int {def xxx: Int}) = ???
+  """.stripMargin
+}

--- a/test/files/run/t6329_repl.check
+++ b/test/files/run/t6329_repl.check
@@ -4,7 +4,7 @@ import scala.reflect.classTag
 
 scala> classManifest[scala.List[_]]
 warning: there was one deprecation warning (since 2.10.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
-res0: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List[<?>]
+res0: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List[Any]
 
 scala> classTag[scala.List[_]]
 res1: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List

--- a/test/files/run/t6329_vanilla.check
+++ b/test/files/run/t6329_vanilla.check
@@ -1,4 +1,4 @@
-scala.collection.immutable.List[<?>]
+scala.collection.immutable.List[Any]
 scala.collection.immutable.List
 scala.collection.immutable.List[<?>]
 scala.collection.immutable.List


### PR DESCRIPTION
We'll just have to live with manifests not being
able to resolve the difference between `scala.List[_]` and `scala.List[Any]`
(dealiasing causes rewrapping causes existential extrapolation).
They are equivalent types after all (and manifests are deprecated).

A type tag will be more precise.

This commit reverts #1900, which caused this regression.
Recently, #5263 improved the situation a bit, but showed that
the original tweak was not a good idea (too many exceptions).
Also, I doubt using `=:=` will improve performance, even if it
reduces allocation a bit, as it's far more expensive than `eq`...