### PR TITLE
SI-9264 Disable JIT for a method failure [no-merge] [:pray:]

### DIFF
--- a/scripts/common
+++ b/scripts/common
@@ -21,6 +21,10 @@ rm -rf $IVY_CACHE/cache/org.scala-lang
 SBT_CMD=${sbtCmd-sbt}
 SBT_CMD="$SBT_CMD -sbt-version 0.13.12"
 
+# Possible workaround for SI-9264, an intermittent failure compiling quick on 2.11.x.
+JIT_OPTION="-J-XX:UnlockDiagnosticVMOptions -XX:CompileCommand=exclude,scala.tools.nsc.transform.patmat.MatchTreeMaking$TreeMakers$TypeTestTreeMaker.renderCondition"
+SBT_CMD="$SBT_CMD $JIT_OPTION"
+
 # temp dir where all 'non-build' operation are performed
 TMP_ROOT_DIR=$(mktemp -d -t pr-scala.XXXX)
 TMP_DIR="${TMP_ROOT_DIR}/tmp"


### PR DESCRIPTION
I found that after disabling JIT for this method the "genLoadIdent"
crash went away. It was intermittend beforehand, so I don't know for
sure if this will work, but let's try this out for a while.