### PR TITLE
[Backport] Modify ArrayBuilder and WrappedArrayBuilder to be reusable

### DIFF
--- a/src/library/scala/collection/mutable/ArrayBuilder.scala
+++ b/src/library/scala/collection/mutable/ArrayBuilder.scala
@@ -104,7 +104,10 @@ object ArrayBuilder {
     }
 
     def result() = {
-      if (capacity != 0 && capacity == size) elems
+      if (capacity != 0 && capacity == size) {
+        capacity = 0
+        elems
+      }
       else mkArray(size)
     }
 
@@ -169,7 +172,10 @@ object ArrayBuilder {
     }
 
     def result() = {
-      if (capacity != 0 && capacity == size) elems
+      if (capacity != 0 && capacity == size) {
+        capacity = 0
+        elems
+      }
       else mkArray(size)
     }
 
@@ -234,7 +240,10 @@ object ArrayBuilder {
     }
 
     def result() = {
-      if (capacity != 0 && capacity == size) elems
+      if (capacity != 0 && capacity == size) {
+        capacity = 0
+        elems
+      }
       else mkArray(size)
     }
 
@@ -299,7 +308,10 @@ object ArrayBuilder {
     }
 
     def result() = {
-      if (capacity != 0 && capacity == size) elems
+      if (capacity != 0 && capacity == size) {
+        capacity = 0
+        elems
+      }
       else mkArray(size)
     }
 
@@ -364,7 +376,10 @@ object ArrayBuilder {
     }
 
     def result() = {
-      if (capacity != 0 && capacity == size) elems
+      if (capacity != 0 && capacity == size) {
+        capacity = 0
+        elems
+      }
       else mkArray(size)
     }
 
@@ -429,7 +444,10 @@ object ArrayBuilder {
     }
 
     def result() = {
-      if (capacity != 0 && capacity == size) elems
+      if (capacity != 0 && capacity == size) {
+        capacity = 0
+        elems
+      }
       else mkArray(size)
     }
 
@@ -494,7 +512,10 @@ object ArrayBuilder {
     }
 
     def result() = {
-      if (capacity != 0 && capacity == size) elems
+      if (capacity != 0 && capacity == size) {
+        capacity = 0
+        elems
+      }
       else mkArray(size)
     }
 
@@ -559,7 +580,10 @@ object ArrayBuilder {
     }
 
     def result() = {
-      if (capacity != 0 && capacity == size) elems
+      if (capacity != 0 && capacity == size) {
+        capacity = 0
+        elems
+      }
       else mkArray(size)
     }
 
@@ -623,7 +647,10 @@ object ArrayBuilder {
     }
 
     def result() = {
-      if (capacity != 0 && capacity == size) elems
+      if (capacity != 0 && capacity == size) {
+        capacity = 0
+        elems
+      }
       else mkArray(size)
     }
 
@@ -688,7 +715,10 @@ object ArrayBuilder {
     }
 
     def result() = {
-      if (capacity != 0 && capacity == size) elems
+      if (capacity != 0 && capacity == size) {
+        capacity = 0
+        elems
+      }
       else mkArray(size)
     }
 

--- a/src/library/scala/collection/mutable/WrappedArrayBuilder.scala
+++ b/src/library/scala/collection/mutable/WrappedArrayBuilder.scala
@@ -78,7 +78,10 @@ class WrappedArrayBuilder[A](tag: ClassTag[A]) extends Builder[A, WrappedArray[A
   }
 
   def result() = {
-    if (capacity != 0 && capacity == size) elems
+    if (capacity != 0 && capacity == size) {
+      capacity = 0
+      elems
+    }
     else mkArray(size)
   }
 

--- a/test/junit/scala/collection/mutable/ArrayBuilderTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBuilderTest.scala
@@ -1,0 +1,28 @@
+package scala.collection.mutable
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Test
+import scala.collection.mutable
+
+@RunWith(classOf[JUnit4])
+class ArrayBuilderTest {
+  @Test
+  def reusable() {
+    val builder = new ArrayBuilder.ofInt
+    val vector = Vector.range(1, 17)
+    val expected = Vector.range(1, 17).toArray
+
+    builder ++= vector
+    val actual = builder.result()
+    assert ( actual.deep == expected.deep )
+
+    builder.clear()
+    val expected2 = Array[Int](100)
+    builder += 100
+
+    // Previously created array MUST be immutable even after `result`, `clear` and some operation are called
+    assert( actual.deep == expected.deep )
+    assert( builder.result().deep == expected2.deep )
+  }
+}

--- a/test/junit/scala/collection/mutable/WrappedArrayBuilderTest.scala
+++ b/test/junit/scala/collection/mutable/WrappedArrayBuilderTest.scala
@@ -1,0 +1,30 @@
+package scala.collection.mutable
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Test
+
+import scala.collection.mutable
+import scala.reflect.ClassTag
+
+@RunWith(classOf[JUnit4])
+class WrappedArrayBuilderTest {
+  @Test
+  def reusable() {
+    val builder = new WrappedArrayBuilder(ClassTag.Int)
+    val vector = Vector.range(1, 17)
+    val expected = new WrappedArray.ofInt(Vector.range(1, 17).toArray)
+
+    builder ++= vector
+    val actual = builder.result()
+    assert( actual == expected )
+
+    builder.clear()
+    val expected2 = new WrappedArray.ofInt(Array[Int](100))
+    builder += 100
+
+    // Previously created WrappedArray MUST be immutable even after `result`, `clear` and some operation are called
+    assert( actual == expected )
+    assert( builder.result() == expected2 )
+  }
+}


### PR DESCRIPTION
# Problem
In 2.11.x, ArrayBuilder should be reusable after a call of `result` followed by `clear`, and it MUST not mutate any arrays it has created.

This is not the case under the condition below.
```
scala> import scala.collection.mutable.ArrayBuilder
import scala.collection.mutable.ArrayBuilder

scala> val builder = new ArrayBuilder.ofInt
builder: scala.collection.mutable.ArrayBuilder.ofInt = ArrayBuilder.ofInt

scala> builder ++= Vector.range(1, 17)
res0: builder.type = ArrayBuilder.ofInt

scala> val arr = builder.result()
arr: Array[Int] = Array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)

scala> builder.clear()

scala> builder += 100
res2: builder.type = ArrayBuilder.ofInt

scala> val arr2 = builder.result()
arr2: Array[Int] = Array(100)

scala> arr
res3: Array[Int] = Array(100, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
// arr should be Array(1, .., 16) but was unexpectedly mutated by `+=` operation
```

`arr` was mutated as follows;
1. `result` & `clear`
    - `arr = elems`
    - `size = 0`
2. `+=(100)`
    - `ensureSize(0 + 1)`
     => `capacity < size || capacity == 0` is `false` as `capacity == 16` and `size == 1`
    -  `elems(0) = 100` this is where `arr(0) = 100` was done because we did not reallocate a new array for `elems` when calling `ensureSize`, which should have happened. 
    - `size = 1`
3. `result`
    - `mkArray(1)` gives us `arr2 = Array(100)`

# Solution
We should reset `capacity` to `0` when calling `result` so that `ensureSize(1)` calls `resize(16)`, which satisfies the property of Builder reusability. Besides mutation of previously created arrays does not happen.