### PR TITLE
Change the signature of WrappedArray.newBuilder[T] to return WrappedArrayBuilder[T]

### DIFF
--- a/src/library/scala/collection/mutable/WrappedArray.scala
+++ b/src/library/scala/collection/mutable/WrappedArray.scala
@@ -132,7 +132,7 @@ object WrappedArray {
         ArrayBuilder.make[T]()(m) mapResult WrappedArray.make[T]
   }
 
-  def newBuilder[A]: Builder[A, IndexedSeq[A]] = new ArrayBuffer
+  def newBuilder[T](implicit t: ClassTag[T]): Builder[T, WrappedArray[T]] = new WrappedArrayBuilder[T](t)
 
   private val emptyWrappedByte = new ofByte(new Array[Byte](0))
   private val emptyWrappedShort = new ofShort(new Array[Short](0))


### PR DESCRIPTION
(I'm not quite sure if this is a good idea but) As we have already defined [WrappedArrayBuilder](https://github.com/scala/scala/blob/v2.12.1/src/library/scala/collection/mutable/WrappedArrayBuilder.scala), we can return `WrappedArrayBuilder` instead of `ArrayBuffer`.

The return type has not been changed since it was first added to `WrappedArray` in this commit.[1]

[1] https://github.com/scala/scala/commit/d5b02c8652d7edbdfb0b5a02570d370d3bad299f#diff-5999d408677554483bfed5cdce592b1fR73