### PR TITLE
Add message about contributing to scaladoc footer

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -396,7 +396,7 @@ trait EntityPage extends HtmlPage {
 
       {
         if (Set("epfl", "EPFL").contains(tpl.universe.settings.docfooter.value))
-          <div id="footer">Scala programming documentation. Copyright (c) 2003-2016 <a href="http://www.epfl.ch" target="_top">EPFL</a>, with contributions from <a href="http://www.lightbend.com" target="_top">Lightbend</a>.</div>
+          <div id="footer">Scala programming documentation. Copyright (c) 2003-2016 <a href="http://www.epfl.ch" target="_top">EPFL</a>, with contributions from <a href="http://www.lightbend.com" target="_top">Lightbend</a>. Get involved on <a href="https://github.com/scala/scala" target="_top">GitHub</a>.</div>
         else
           <div id="footer"> { tpl.universe.settings.docfooter.value } </div>
       }


### PR DESCRIPTION
A shameless plug encouraging involvement in the footer of the documentation:

![image](https://cloud.githubusercontent.com/assets/965439/21559818/12742048-ce19-11e6-9fef-16189d5ecd91.png)
