### PR TITLE
SI-9936 LinearSeqOptimized.indexWhere

### DIFF
--- a/src/library/scala/collection/IndexedSeqOptimized.scala
+++ b/src/library/scala/collection/IndexedSeqOptimized.scala
@@ -199,7 +199,7 @@ trait IndexedSeqOptimized[+A, +Repr] extends Any with IndexedSeqLike[A, Repr] { 
 
   override /*SeqLike*/
   def indexWhere(p: A => Boolean, from: Int): Int = {
-    val start = from max 0
+    val start = math.max(from, 0)
     negLength(start + segmentLength(!p(_), start))
   }
 

--- a/src/library/scala/collection/LinearSeqOptimized.scala
+++ b/src/library/scala/collection/LinearSeqOptimized.scala
@@ -291,7 +291,7 @@ trait LinearSeqOptimized[+A, +Repr <: LinearSeqOptimized[A, Repr]] extends Linea
 
   override /*SeqLike*/
   def indexWhere(p: A => Boolean, from: Int): Int = {
-    var i = from
+    var i = math.max(from, 0)
     var these = this drop from
     while (these.nonEmpty) {
       if (p(these.head))

--- a/src/library/scala/collection/SeqLike.scala
+++ b/src/library/scala/collection/SeqLike.scala
@@ -113,13 +113,12 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
   }
 
   def indexWhere(p: A => Boolean, from: Int): Int = {
-    var i = from max 0
+    var i = math.max(from, 0)
     val it = iterator.drop(from)
     while (it.hasNext) {
       if (p(it.next())) return i
       else i += 1
     }
-
     -1
   }
 

--- a/test/junit/scala/collection/LinearSeqOptimizedTest.scala
+++ b/test/junit/scala/collection/LinearSeqOptimizedTest.scala
@@ -1,0 +1,19 @@
+package scala.collection
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Assert._
+import org.junit.Test
+
+@RunWith(classOf[JUnit4])
+class LinearSeqOptimizedTest {
+
+  @Test def `SI-9936 indexWhere`(): Unit = {
+    assertEquals(2, "abcde".indexOf('c', -1))
+    assertEquals(2, "abcde".indexOf('c', -2))
+    assertEquals(2, "abcde".toList.indexOf('c', -1))
+    assertEquals(2, "abcde".toList.indexOf('c', -2))
+    assertEquals(2, "abcde".toList.indexWhere(_ == 'c', -1))
+    assertEquals(2, "abcde".toList.indexWhere(_ == 'c', -2))
+  }
+}


### PR DESCRIPTION
Also suffered from the negative `from` bug.

Prefer `math.max` to avoid `RichInt`.

Follows up https://github.com/scala/scala/pull/5421