### PR TITLE
Add substitute methods to <:< =:= making these Liskov/Leibniz

### DIFF
--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -464,8 +464,27 @@ object Predef extends LowPriorityImplicits {
    * @group type-constraints
    */
   @implicitNotFound(msg = "Cannot prove that ${From} <:< ${To}.")
-  sealed abstract class <:<[-From, +To] extends (From => To) with Serializable
-  private[this] final val singleton_<:< = new <:<[Any,Any] { def apply(x: Any): Any = x }
+  sealed abstract class <:<[-From, +To] extends (From => To) with Serializable {
+    /** substitute the To in the type F[To] to From
+     */
+    def substitute[F[-_]](ft: F[To]): F[From]
+    /** create a new evidence for a covariant type F[_]
+     */
+    def liftCo[F[+_]]: <:<[F[From], F[To]] = {
+      type G[-T] = F[T] <:< F[To]
+      substitute[G](implicitly[F[To] <:< F[To]])
+    }
+    /** create a new evidence for a contravariant type F[_]
+     */
+    def liftContra[F[-_]]: <:<[F[To], F[From]] = {
+      type G[-T] = F[To] <:< F[T]
+      substitute[G](implicitly[F[To] <:< F[To]])
+    }
+  }
+  private[this] final val singleton_<:< = new <:<[Any,Any] {
+    def apply(x: Any): Any = x
+    def substitute[F[-_]](ft: F[Any]): F[Any] = ft
+  }
   // The dollar prefix is to dodge accidental shadowing of this method
   // by a user-defined method of the same name (scala/bug#7788).
   // The collections rely on this method.
@@ -478,8 +497,27 @@ object Predef extends LowPriorityImplicits {
    * @group type-constraints
    */
   @implicitNotFound(msg = "Cannot prove that ${From} =:= ${To}.")
-  sealed abstract class =:=[From, To] extends (From => To) with Serializable
-  private[this] final val singleton_=:= = new =:=[Any,Any] { def apply(x: Any): Any = x }
+  sealed abstract class =:=[From, To] extends (From => To) with Serializable {
+    /** substitute the From in the type F[From] to To
+     */
+    def substitute[F[_]](ff: F[From]): F[To]
+    /** create an instance for a type constructor F[_]
+     */
+    def liftTo[F[_]]: =:=[F[From], F[To]] = {
+      type G[T] = F[From] =:= F[T]
+      substitute[G](implicitly[F[From] =:= F[From]])
+    }
+    /** flip the order of the type paraemeters
+     */
+    def flip: =:=[To, From] = {
+      type G[T] = T =:= From
+      substitute[G](implicitly[From =:= From])
+    }
+  }
+  private[this] final val singleton_=:= = new =:=[Any,Any] {
+    def apply(x: Any): Any = x
+    def substitute[F[_]](ff: F[Any]): F[Any] = ff
+  }
   /** @group type-constraints */
   object =:= {
      implicit def tpEquals[A]: A =:= A = singleton_=:=.asInstanceOf[A =:= A]

--- a/test/files/pos/leibniz_liskov.scala
+++ b/test/files/pos/leibniz_liskov.scala
@@ -1,0 +1,33 @@
+object LeibnizLiskov {
+  val isInt = implicitly[Int =:= Int]
+
+  isInt.substitute(List(1, 2, 3))
+
+  def convertInt1[T, U](l: List[T])(ev: T =:= U): List[U] =
+    ev.substitute(l)
+
+  def convertInt2[T, U](l: List[T])(ev: T =:= U): List[U] =
+    ev.liftTo[List](l)
+
+  val isIntSub = implicitly[Int <:< Int]
+
+  isIntSub.liftCo(List(1, 2, 3))
+
+  def convertIntSub[T, U](l: List[T])(ev: T <:< U): List[U] =
+    ev.liftCo[List](l)
+
+  trait Consumes[-T] {
+    def consume(t: T): Unit = ()
+  }
+
+  isIntSub.liftContra(new Consumes[Int] { }): Consumes[Int]
+  isIntSub.substitute(new Consumes[Int] { }): Consumes[Int]
+
+  def convertConsume1[U, T](c: Consumes[T])(ev: U <:< T): Consumes[U] =
+    ev.substitute(c)
+
+  def convertConsume2[U, T](c: Consumes[T])(ev: U <:< T): Consumes[U] = {
+    val ev2 = ev.liftContra[Consumes]
+    ev2(c)
+  }
+}


### PR DESCRIPTION
the `=:=` and `<:<` classes lack a substitute method which works on `F[A]` to `F[B]`. This is easy to add, but without it, we can't do basic things like:

```
A =:= B => Map[A, V] =:= Map[B, V]
A <:< B => List[A] <:< List[B]
```
without these we can resort to casts, but we shouldn't have to. Scalaz has a solution to this, but can't interop fully with the standard library since the standard library lacks `substitute`. Similarly a PR to cats was proposed to address the issue:

https://github.com/typelevel/cats/pull/1178

Since these classes are abstract, adding a few methods to remedy this seems like a very minimal change to address this (minor) defect.