### PR TITLE
Fix documentation of immutable.Queue

### DIFF
--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -110,7 +110,7 @@ class Queue[+A] protected(protected val in: List[A], protected val out: List[A])
   /** Returns a new queue with all elements provided by an `Iterable` object
    *  added at the end of the queue.
    *
-   *  The elements are prepended in the order they are given out by the
+   *  The elements are appended in the order they are given out by the
    *  iterator.
    *
    *  @param  iter        an iterable object


### PR DESCRIPTION
`enqueue` appends elements to the `Queue`, it doesn't prepend them.