### PR TITLE
SI-9114 Fix crasher in pattern matcher with type aliases

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3891,7 +3891,7 @@ trait Types
    *        any corresponding non-variant type arguments of bt1 and bt2 are the same
    */
   def isPopulated(tp1: Type, tp2: Type): Boolean = {
-    def isConsistent(tp1: Type, tp2: Type): Boolean = (tp1, tp2) match {
+    def isConsistent(tp1: Type, tp2: Type): Boolean = (tp1.dealias, tp2.dealias) match {
       case (TypeRef(pre1, sym1, args1), TypeRef(pre2, sym2, args2)) =>
         assert(sym1 == sym2, (sym1, sym2))
         (    pre1 =:= pre2

--- a/test/files/run/t9114.scala
+++ b/test/files/run/t9114.scala
@@ -1,0 +1,31 @@
+import annotation.unchecked
+
+class Test {
+  trait Two[A, B]
+  type One[A] = Two[A,A]
+  class View extends One[Any]
+
+  def checkAny(x: Some[One[Any]]) = x match { // okay
+    case Some(_: View) => true
+    case _ => false
+  }
+  def checkAbstract[A](x: Some[One[A]]) = x match { // okay
+    case Some(_: View) => true
+    case _ => false
+  }
+
+  def checkExistential(x: Some[One[_]]) = x match {
+    case Some(_: View) => true // compiler crash
+    case _ => false
+  }
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val t1 = new Test
+    val t2 = new Test
+    assert(t1.checkAny(Some(new t1.View)))
+    assert(t1.checkAbstract(Some(new t1.View)))
+    assert(t1.checkExistential(Some(new t1.View)))
+  }
+}


### PR DESCRIPTION
When determining whether or not a pattern match requires an equality
check of the outer instance of a type in addition to a type test,
`needsOuterTest` determines if the intersection of the selector and
the pattern types could be populated. Both type arrive at
`isPopulated` dealised.

However, `isPopulated` recurs when it encounters an existential,
and, as seen in thest case, a failure to dealias the quantified
type can lead to an assertion failure as we try to relate a
typeref to an alias and a typeref to a class.

See also SI-7214, which added deliasing of the pattern type
before calling `isPopulated`.

JIRA: https://issues.scala-lang.org/browse/SI-9114 https://issues.scala-lang.org/browse/SI-7214