### PR TITLE
SI-8831 Fix mapping case accessor lookup with backticked idents

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Constructors.scala
+++ b/src/compiler/scala/tools/nsc/transform/Constructors.scala
@@ -496,10 +496,9 @@ abstract class Constructors extends Statics with Transform with ast.TreeDSL {
     // The constructor parameter corresponding to an accessor
     def parameter(acc: Symbol): Symbol = parameterNamed(acc.unexpandedName.getterName)
 
-    // The constructor parameter with given name. This means the parameter
-    // has given name, or starts with given name, and continues with a `$` afterwards.
+    // The constructor parameter with given name.
     def parameterNamed(name: Name): Symbol = {
-      def matchesName(param: Symbol) = param.name == name || param.name.startsWith(name + nme.NAME_JOIN_STRING)
+      def matchesName(param: Symbol) = nme.unfreshenedName(param.name) == name
 
       (constrParams filter matchesName) match {
         case Nil    => abort(name + " not in " + constrParams)

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -442,6 +442,26 @@ trait StdNames {
     @deprecated("Use Name#getterName", "2.11.0") def getterName(name: TermName): TermName     = name.getterName
     @deprecated("Use Name#getterName", "2.11.0") def setterToGetter(name: TermName): TermName = name.getterName
 
+    /** If `name` is an of the form r"origName\$\d+" name, the original (unfreshened) name.
+      *  Otherwise `name` itself.
+      */
+    final def unfreshenedName(name: Name): Name = name lastIndexOf "$" match {
+      case 0 | -1 => name
+      case x if x == name.length - 1 => name
+      case idx0   =>
+        var idx = idx0 + 1
+        var onlyDigitsFollow = true
+        val len = name.length
+        while (idx < len) {
+          onlyDigitsFollow &&= name.charAt(idx).isDigit
+          idx += 1
+        }
+        if (onlyDigitsFollow)
+          name drop idx + 1
+        else
+          name
+    }
+
     /**
      * Convert `Tuple2$mcII` to `Tuple2`, or `T1$sp` to `T1`.
      */

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2053,7 +2053,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       val primaryNames = constrParamAccessors map (_.name.dropLocal)
       caseFieldAccessorsUnsorted.sortBy { acc =>
         primaryNames indexWhere { orig =>
-          (acc.name == orig) || (acc.name startsWith (orig append "$"))
+          nme.unfreshenedName(acc.name) == orig
         }
       }
     }

--- a/test/files/run/t8831.scala
+++ b/test/files/run/t8831.scala
@@ -1,0 +1,19 @@
+case class wrong(`a b`: Int, a: Int)
+case class verywrong(`a b`: Int, a: String)
+case class privateCase1(private var `a b`: Int, private var a: String)
+case class privateCase2(private var a: String, private var `a b`: Int)
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val a @ wrong(1, 2) = wrong(1, 2)
+    assert(a.`a b` == 1)
+    assert(a.a == 2)
+
+    val b @ verywrong(1, "2") = verywrong(1, "2")
+    assert(b.`a b` == 1)
+    assert(b.a == "2")
+
+    val privateCase1(1, "2") = privateCase1(1, "2")
+    val privateCase2("1", 2) = privateCase2("1", 2)
+  }
+}


### PR DESCRIPTION
Case class parameters may be declared as non-public. If this is the
case, the case accessor method is still synthesized as public, but
it has a mangled name of the form `origName$N`.

See also SI-8944 / #4125.

The compiler maps from case fields to the corresponding accessors
with this naming convention in mind. However, it is too lenient, and
assumes that only one accessor will be of the form "origName\$.*".

If, however, a regular, public case parameter is named `a b`, it will
have a name `a$u0020b`, which spurously matches that overly permissive
pattern.

This commit changes tightens up the logic to expect "origName\$\d+".