### PR TITLE
Upgrade to jline2 2.14.3

### DIFF
--- a/src/intellij/scala.ipr.SAMPLE
+++ b/src/intellij/scala.ipr.SAMPLE
@@ -77,7 +77,7 @@
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-5.0.4-scala-3.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-xml_2.11/bundles/scala-xml_2.11-1.0.4.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.11/bundles/scala-parser-combinators_2.11-1.0.4.jar!/" />
-        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.12.1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.3.jar!/" />
       </CLASSES>
       <JAVADOC />
       <SOURCES />
@@ -100,7 +100,7 @@
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-5.0.4-scala-3.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-xml_2.11/bundles/scala-xml_2.11-1.0.4.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.11/bundles/scala-parser-combinators_2.11-1.0.4.jar!/" />
-        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.12.1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.3.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-partest_2.11/jars/scala-partest_2.11-1.0.13.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/com.googlecode.java-diff-utils/diffutils/jars/diffutils-1.3.0.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/test-interface/jars/test-interface-1.0.jar!/" />
@@ -126,7 +126,7 @@
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-5.0.4-scala-3.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-xml_2.11/bundles/scala-xml_2.11-1.0.4.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.11/bundles/scala-parser-combinators_2.11-1.0.4.jar!/" />
-        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.12.1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.3.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-partest_2.11/jars/scala-partest_2.11-1.0.13.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/com.googlecode.java-diff-utils/diffutils/jars/diffutils-1.3.0.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/test-interface/jars/test-interface-1.0.jar!/" />
@@ -159,7 +159,7 @@
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-5.0.4-scala-3.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-xml_2.11/bundles/scala-xml_2.11-1.0.4.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.11/bundles/scala-parser-combinators_2.11-1.0.4.jar!/" />
-        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.12.1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.3.jar!/" />
       </CLASSES>
       <JAVADOC />
       <SOURCES />
@@ -303,7 +303,7 @@
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-5.0.4-scala-3.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-xml_2.11/bundles/scala-xml_2.11-1.0.4.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.11/bundles/scala-parser-combinators_2.11-1.0.4.jar!/" />
-        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.12.1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.3.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-partest_2.11/jars/scala-partest_2.11-1.0.13.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/com.googlecode.java-diff-utils/diffutils/jars/diffutils-1.3.0.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/test-interface/jars/test-interface-1.0.jar!/" />

--- a/src/repl-jline/scala/tools/nsc/interpreter/jline/JLineReader.scala
+++ b/src/repl-jline/scala/tools/nsc/interpreter/jline/JLineReader.scala
@@ -149,26 +149,6 @@ private class JLineConsoleReader extends jconsole.ConsoleReader with interpreter
       case _                  => this addCompleter completer
     }
 
-    // This is a workaround for https://github.com/jline/jline2/issues/208
-    // and should not be necessary once we upgrade to JLine 2.13.1
-    ///
-    // Test by:
-    // scala> {" ".char}<LEFT><TAB>
-    //
-    // And checking we don't get an extra } on the line.
-    ///
-    val handler = getCompletionHandler
-    setCompletionHandler(new CompletionHandler {
-      override def complete(consoleReader: ConsoleReader, list: JList[CharSequence], i: Int): Boolean = {
-        try {
-          handler.complete(consoleReader, list, i)
-        } finally if (getCursorBuffer.cursor != getCursorBuffer.length()) {
-          print(" ")
-          getCursorBuffer.write(' ')
-          backspace()
-        }
-      }
-    })
     setAutoprintThreshold(400) // max completion candidates without warning
   }
 }

--- a/src/repl-jline/scala/tools/nsc/interpreter/jline/JLineReader.scala
+++ b/src/repl-jline/scala/tools/nsc/interpreter/jline/JLineReader.scala
@@ -11,9 +11,8 @@ import java.util.{Collection => JCollection, List => JList}
 
 import _root_.jline.{console => jconsole}
 import jline.console.ConsoleReader
-import jline.console.completer.{CompletionHandler, Completer, ArgumentCompleter}
+import jline.console.completer.{CandidateListCompletionHandler, CompletionHandler, Completer, ArgumentCompleter}
 import jconsole.history.{History => JHistory}
-
 
 import scala.tools.nsc.interpreter
 import scala.tools.nsc.interpreter.{Completion, JLineCompletion, NoCompletion}
@@ -136,6 +135,9 @@ private class JLineConsoleReader extends jconsole.ConsoleReader with interpreter
           newCursor
         }
       }
+    getCompletionHandler match {
+      case clch: CandidateListCompletionHandler => clch.setPrintSpaceAfterFullCompletion(false)
+    }
 
     // a last bit of nastiness: parsing help depending on the flavor of completer (fixme)
     completion match {

--- a/versions.properties
+++ b/versions.properties
@@ -32,7 +32,7 @@ scala-continuations-library.version.number=1.0.2
 scala-swing.version.number=1.0.2
 akka-actor.version.number=2.3.16
 actors-migration.version.number=1.1.0
-jline.version=2.12.1
+jline.version=2.14.3
 scala-asm.version=5.0.4-scala-3
 
 # external modules, used internally (not shipped)


### PR DESCRIPTION
Verified to fix SI-8308 (when `-Djline.sigcont` is passed as a REPL option...)

Seems like the end of the line for jline2 -- fitting companion for 2.11.9.

Bump to 2.14.3 from 2.14.1 (as in original commit) motivated by several relevant fixes in:
https://github.com/jline/jline2/compare/jline-2.14.1...jline-2.14.3
   - jline/jline2#270 fix issue jline/jline2#127: support Ctrl+C on Windows
   - https://github.com/jline/jline2/commit/01969b5 Fix regression in public ConsoleReader#print() api (jline/jline2#243, jline/jline2#205) -- our workaround was #5450