### PR TITLE
SI-9881 Fix ImportHandler's reporting of importedNames and importedSymbols

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -64,15 +64,18 @@ trait Contexts { self: Analyzer =>
     for (imps <- allImportInfos.remove(unit)) {
       for (imp <- imps.reverse.distinct) {
         val used = allUsedSelectors(imp)
-        def isMask(s: ImportSelector) = s.name != nme.WILDCARD && s.rename == nme.WILDCARD
 
-        imp.tree.selectors filterNot (s => isMask(s) || used(s)) foreach { sel =>
+        imp.tree.selectors filterNot (s => isMaskImport(s) || used(s)) foreach { sel =>
           reporter.warning(imp posOf sel, "Unused import")
         }
       }
       allUsedSelectors --= imps
     }
   }
+
+  def isMaskImport(s: ImportSelector): Boolean = s.name != nme.WILDCARD && s.rename == nme.WILDCARD
+  def isIndividualImport(s: ImportSelector): Boolean = s.name != nme.WILDCARD && s.rename != nme.WILDCARD
+  def isWildcardImport(s: ImportSelector): Boolean = s.name == nme.WILDCARD
 
   var lastAccessCheckDetails: String = ""
 

--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -296,11 +296,13 @@ trait Names extends api.Names {
      */
     final def pos(s: String, start: Int): Int = {
       var i = pos(s.charAt(0), start)
-      while (i + s.length() <= len) {
+      val sLen = s.length()
+      if (sLen == 1) return i
+      while (i + sLen <= len) {
         var j = 1
         while (s.charAt(j) == chrs(index + i + j)) {
           j += 1
-          if (j == s.length()) return i
+          if (j == sLen) return i
         }
         i = pos(s.charAt(0), i + 1)
       }

--- a/test/files/run/t9880-9881.check
+++ b/test/files/run/t9880-9881.check
@@ -1,0 +1,36 @@
+
+scala> // import in various ways
+
+scala> import java.util.Date
+import java.util.Date
+
+scala> import scala.util._
+import scala.util._
+
+scala> import scala.reflect.runtime.{universe => ru}
+import scala.reflect.runtime.{universe=>ru}
+
+scala> import ru.TypeTag
+import ru.TypeTag
+
+scala> 
+
+scala> // show the imports
+
+scala> :imports
+ 1) import java.lang._             (...)
+ 2) import scala._                 (...)
+ 3) import scala.Predef._          (...)
+ 4) import java.util.Date          (...)
+ 5) import scala.util._            (...)
+ 6) import scala.reflect.runtime.{universe=>ru} (...)
+ 7) import ru.TypeTag              (...)
+
+scala> 
+
+scala> // should be able to define this class with the imports above
+
+scala> class C[T](date: Date, rand: Random, typeTag: TypeTag[T])
+defined class C
+
+scala> :quit

--- a/test/files/run/t9880-9881.scala
+++ b/test/files/run/t9880-9881.scala
@@ -1,0 +1,29 @@
+import scala.tools.partest.ReplTest
+import scala.tools.nsc.Settings
+
+object Test extends ReplTest {
+
+  override def transformSettings(s: Settings): Settings = {
+    s.Yreplclassbased.value = true
+    s
+  }
+
+  lazy val normalizeRegex = """(import\s.*)\(.*\)""".r
+
+  override def normalize(s: String): String = normalizeRegex.replaceFirstIn(s, "$1(...)")
+
+  def code =
+    """
+      |// import in various ways
+      |import java.util.Date
+      |import scala.util._
+      |import scala.reflect.runtime.{universe => ru}
+      |import ru.TypeTag
+      |
+      |// show the imports
+      |:imports
+      |
+      |// should be able to define this class with the imports above
+      |class C[T](date: Date, rand: Random, typeTag: TypeTag[T])
+    """.stripMargin
+}

--- a/test/junit/scala/reflect/internal/NamesTest.scala
+++ b/test/junit/scala/reflect/internal/NamesTest.scala
@@ -92,4 +92,29 @@ class NamesTest {
     assert(h1 string_== h2)
     assert(h1 string_== h1y)
   }
+
+  @Test
+  def pos(): Unit = {
+    def check(nameString: String, sub: String) = {
+      val name = TermName(nameString)
+      val javaResult = name.toString.indexOf(sub) match { case -1 => name.length case x => x }
+      val nameResult = name.pos(sub)
+      assertEquals(javaResult, nameResult)
+      if (sub.length == 1) {
+        val nameResultChar = name.pos(sub.head)
+        assertEquals(javaResult, nameResultChar)
+      }
+    }
+
+    check("a", "a") // was "String index out of range: 1
+    check("a", "b")
+    check("a", "ab")
+    check("a", "ba")
+    check("ab", "a")
+    check("ab", "b")
+    check("ab", "ab")
+    check("ab", "ba")
+    check("", "x")
+    check("", "xy")
+  }
 }


### PR DESCRIPTION
[Revived from <https://github.com/scala/scala/pull/5326>]

This PR attempts to fix `importedNames` and `importedSymbols` in `ImportHandler`. Currently they are broken, causing the following issues:
- https://issues.scala-lang.org/browse/SI-9881
- https://issues.scala-lang.org/browse/SI-9880

Changes in this PR:
- Keep track of both selector `names` & `renames`. Use `names` to lookup symbols from owner. Use `renames` to construct `importedNames`.
- `sym.thisType` will never work for module symbols. Change to `sym.tpe`.
- Fix the bug where `typeOfExpression` inadvertently resolves type under `jvm` phase, disregarding requested phase from caller. This is used in `ImportHandler` to find `importableMembers` from objects.
- Cherry-picked @retronym 's change from https://github.com/retronym/scala/tree/review/4698 to fix `StringIndexOutOfBoundsException` and filter out flattened inner symbols from `importableMembers`.
