### PR TITLE
WIP: Add prototype improving default args encoding

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1388,14 +1388,24 @@ trait Namers extends MethodSynthesis {
       var ownerNamer: Option[Namer] = None
       var moduleNamer: Option[(ClassDef, Namer)] = None
       var posCounter = 1
+      var previousParamsCounter = 0
 
       // For each value parameter, create the getter method if it has a
       // default argument. previous denotes the parameter lists which
       // are on the left side of the current one. These get added to the
       // default getter. Example:
       //
-      //   def foo(a: Int)(b: Int = a)      becomes
-      //   foo$default$1(a: Int) = a
+      //   def foo(a: Int, b: Int = a)(c: Int = a + b)      becomes
+      //   foo$default$1(a: Int) = a // for b
+      //   foo$default$2(a: Int, b: Int) = a + b // for c
+      //
+      // This scheme allows a default argument on the right to depend
+      // on every argument on its left and applies for arguments both
+      // in the same parameter list and in previous curried parameter lists.
+      // Note that even if the parameters on the left are not used in the
+      // implementation of a default arg, the parameters are encoded in
+      // the signature of the synthetic method so that future changes
+      // in the implementation of default args does not break binary compat.
       //
       vparamss.foldLeft(Nil: List[List[ValDef]]) { (previous, vparams) =>
         assert(!overrides || vparams.length == baseParamss.head.length, ""+ meth.fullName + ", "+ overridden.fullName)
@@ -1427,7 +1437,8 @@ trait Namers extends MethodSynthesis {
             val name = nme.defaultGetterName(meth.name, posCounter)
 
             var defTparams = rtparams
-            val defVparamss = mmap(rvparamss.take(previous.length)){ rvp =>
+            val leftRvparams = rvparams.take(posCounter - previousParamsCounter - 1)
+            val leftRvparamss = mmap(rvparamss.take(previous.length) ++ List(leftRvparams)){ rvp =>
               copyValDef(rvp)(mods = rvp.mods &~ DEFAULTPARAM, rhs = EmptyTree)
             }
 
@@ -1485,7 +1496,7 @@ trait Namers extends MethodSynthesis {
             val defRhs = rvparam.rhs
 
             val defaultTree = atPos(vparam.pos.focus) {
-              DefDef(Modifiers(paramFlagsToDefaultGetter(meth.flags), ddef.mods.privateWithin) | oflag, name, defTparams, defVparamss, defTpt, defRhs)
+              DefDef(Modifiers(paramFlagsToDefaultGetter(meth.flags), ddef.mods.privateWithin) | oflag, name, defTparams, leftRvparamss, defTpt, defRhs)
             }
             if (!isConstr)
               methOwner.resetFlag(INTERFACE) // there's a concrete member now
@@ -1502,6 +1513,7 @@ trait Namers extends MethodSynthesis {
           if (overrides) baseParams = baseParams.tail
         })
         if (overrides) baseParamss = baseParamss.tail
+        previousParamsCounter += vparams.length
         previous :+ vparams
       }
     }

--- a/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
@@ -429,6 +429,7 @@ trait NamesDefaults { self: Analyzer =>
     if (givenArgs.length < params.length) {
       val (missing, positional) = missingParams(givenArgs, params, nameOfNamedArg)
       if (missing forall (_.hasDefault)) {
+        val generatedDefaults = mutable.HashMap[Symbol, Tree]()
         val defaultArgs = missing flatMap (p => {
           val defGetter = defaultGetter(p, context)
           // TODO #3649 can create spurious errors when companion object is gone (because it becomes unlinked from scope)
@@ -441,8 +442,23 @@ trait NamesDefaults { self: Analyzer =>
             }
             default1 = if (targs.isEmpty) default1
                        else TypeApply(default1, targs.map(_.duplicate))
-            val default2 = (default1 /: previousArgss)((tree, args) =>
+
+            var valuesArgs = givenArgs
+            val leftArgsInParamList = params.take(params.indexOf(p))
+            val valuesArgsOnLeft = leftArgsInParamList.map { arg =>
+              generatedDefaults.get(arg) match {
+                case Some(default) => default
+                case None =>
+                  val value = valuesArgs.head
+                  valuesArgs = givenArgs.tail
+                  value
+              }
+            }
+            val allLeftArgs: List[List[Tree]] = previousArgss ++ List(valuesArgsOnLeft)
+            val default2 = (default1 /: allLeftArgs)((tree, args) =>
               Apply(tree, args.map(_.duplicate)))
+
+            generatedDefaults += (p-> default2)
             Some(atPos(pos) {
               if (positional) default2
               else AssignOrNamedArg(Ident(p.name), default2)

--- a/test/files/run/default-args-class.scala
+++ b/test/files/run/default-args-class.scala
@@ -1,0 +1,7 @@
+class A(a: Int, val b: Int = a)
+
+object Test extends App {
+  val a = new A(1)
+  val a2 = new A(1, 1)
+  assert(a.b == a2.b)
+}

--- a/test/files/run/default-args-method.scala
+++ b/test/files/run/default-args-method.scala
@@ -1,0 +1,81 @@
+object Foo {
+  // Currently works
+  def substring(s: String, start: Int = 0)(end: Int = s.length) =
+    s.substring(start, end)
+
+  // SIP proposes to make these invocations valid
+  def foo(a: Int, b: Int = a) = (a, b)
+  def foo2(a: Int, b: Int = a, c: Int = a + b) = (a, b, c)
+  def foo3(a: Int, b: Int = a)(c: Int = a + b) = (a, b, c)
+  def foo4(a: Int, b: Int = a, c: Int = a + b) = (a, b, c)
+  def foo5(a: Int = 10, b: Int = a, c: Int = a + b) = (a, b, c)
+  def foo6(a: String, b: Int = a.toInt, c: Int = a.toInt + b) = (a.toInt, b, c)
+
+  def fooHK[T](a: T, b: T = a) = (a, b)
+  def fooHK2[T](a: T, b: T = a)(c: T = a) = (a, b, c)
+  def bind(name: String, boundType: String, value: Any, modifiers: List[String] = Nil): List[String] = modifiers
+}
+
+object Test extends App {
+  Foo.substring("")()
+
+  val call0 = Foo.foo(1)
+  val call02 = Foo.foo(1, 1)
+  assert(call0 == call02)
+
+  val a = 1
+  val call1 = Foo.foo(a)
+  val call12 = Foo.foo(a, 1)
+  assert(call1 == call12)
+
+  val call2 = Foo.foo2(1)
+  val call22 = Foo.foo2(1, 1)
+  val call23 = Foo.foo2(1, 1, 2)
+  assert(call2 == call22)
+  assert(call2 == call23)
+
+  val call3 = Foo.foo2(a)
+  val call32 = Foo.foo2(a, 1)
+  val call33 = Foo.foo2(a, 1, 2)
+  assert(call3 == call32)
+  assert(call3 == call33)
+
+  val call4 = Foo.foo3(1)()
+  val call42 = Foo.foo3(1, 1)()
+  val call43 = Foo.foo3(1, 1)(2)
+  assert(call4 == call42)
+  assert(call4 == call43)
+
+  val call5 = Foo.foo3(a)()
+  val call52 = Foo.foo3(a, 1)()
+  val call53 = Foo.foo3(a, 1)(2)
+  assert(call5 == call52)
+  assert(call5 == call53)
+
+  val bar = 4
+  val call6 = Foo.foo4(a, c = bar)
+  assert(call6 == (a, a, bar), s"$call6 != ($a,$a,$bar)")
+
+  val call7 = Foo.foo4(a, b = bar)
+  assert(call7 == (a, bar, 5), s"$call7 != ($a,$bar,5)")
+
+  val call8 = Foo.foo5()
+  val call82 = Foo.foo5(c = 3)
+  assert(call82 == (10, 10, 3), s"$call82 != (10, 10, 3)")
+
+  val call9 = Foo.foo6("1")
+  assert(call9._1.intValue() == 1, s"${call9._1} != 1")
+  assert(call9._2.intValue() == 1, s"${call9._2} != 1")
+  assert(call9._3.intValue() == 2, s"${call9._3} != 2")
+
+  val asdf = "asdfasdf"
+  val call100 = Foo.fooHK(asdf)
+  assert(call100 == (asdf,asdf), s"$call100 != ($asdf,$asdf)")
+
+  val call110 = Foo.fooHK2(asdf)()
+  assert(call110 == (asdf,asdf,asdf), s"$call110 != ($asdf,$asdf,$asdf)")
+
+  val value = ""
+  val call120 = Foo.bind("", value.asInstanceOf[AnyRef].getClass.getName, value)
+  assert(call120 == Nil, s"$call120 != Nil")
+}


### PR DESCRIPTION
The following changes implement a more flexible encoding of default args
that allows default implementation to depend on parameters defined on
the left (either previous parameters lists or parameters in the same
parameter list defined on the left).

This encoding breaks binary compatibility so it targets 2.13. It
consists of changes in the synthetic method generation of defaults and
the call sites of these methods. The implementation of synthetic
methods now depends on any parameter defined at the left of a default arg,
even if it their body does not use these parameters. This is done so
that changing the body of the default args does not change the signature
and hence break binary compatibility.

More explanation on this implementation can be found in the [SIP
proposal](https://github.com/scala/scala.github.com/pull/653).

WIP: This commit still needs more work. This is what's missing:
1. Reusing the results of default args. Currently, invocations to
default methods are inlined at the call-site and a lot of invocations
can be reused. Declaring more than one default arg considerably
increases bytecode size. My idea to tackle this issue is to save the
results of the invocation in vals before the the call-site invocation.

Example:
```scala
// definition
def foo(a: Int, b: Int = a, c: Int = a + b): Int = a + b + c
// invocation
foo(1)
```

will modify the call-site like:
```scala
foo(1, foo$default$2(1), foo$default$3(1, foo$default$2(1)))
```

As you see, invocations to 1 and `foo$default$2` could be optimized:
```scala
val a$default = 1
val b$default = foo$default$2(a$default)
val c$default = foo$default$3(a$default, b$default)
foo(a$default, b$default, c$default)
```

This generates more bytecode for call-sites omitting default arguments,
but avoids unnecessary calls that could cause bad performance
(especially if more than 2 default args are defined in a method).

2. Generate more tests for the default arguments in class.