### PR TITLE
Calculate MB instead of MiB

### DIFF
--- a/src/compiler/scala/tools/nsc/CompileServer.scala
+++ b/src/compiler/scala/tools/nsc/CompileServer.scala
@@ -47,7 +47,7 @@ class StandardCompileServer(fixPort: Int = 0) extends SocketServer(fixPort) {
   }
 
   def printMemoryStats() {
-    def mb(bytes: Long) = "%dMB".format(bytes / 1000000)
+    def mb(bytes: Long) = "%10.2fMB".format(bytes / 1048576.0)
     info("New session: total memory = %s, max memory = %s, free memory = %s".format(
       mb(totalMemory), mb(maxMemory), mb(freeMemory)))
   }


### PR DESCRIPTION
This is consistent with same calculation in Compilers.freeMemoryString.