### PR TITLE
SI-8417 Check adapts of each param section

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Adaptations.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Adaptations.scala
@@ -80,7 +80,9 @@ trait Adaptations {
           context.deprecationWarning(t.pos, t.symbol, adaptWarningMessage(msg), "2.11.0")
         }
       } else if (settings.warnAdaptedArgs)
-        context.warning(t.pos, adaptWarningMessage(s"Adapting argument list by creating a ${args.size}-tuple: this may not be what you want."))
+        context.warning(t.pos, adaptWarningMessage(
+          s"Adapting argument list by creating a ${args.size}-tuple: this may not be what you want.")
+        )
 
       // return `true` if the adaptation should be kept
       !(settings.noAdaptedArgs || (args.isEmpty && settings.future))

--- a/test/files/neg/t8417.check
+++ b/test/files/neg/t8417.check
@@ -1,0 +1,15 @@
+t8417.scala:5: warning: Adapting argument list by creating a 2-tuple: this may not be what you want.
+        signature: T.f(x: Any)(y: Any): String
+  given arguments: "hello", "world"
+ after adaptation: T.f(("hello", "world"): (String, String))
+  def g = f("hello", "world")("holy", "moly")
+           ^
+t8417.scala:5: warning: Adapting argument list by creating a 2-tuple: this may not be what you want.
+        signature: T.f(x: Any)(y: Any): String
+  given arguments: "holy", "moly"
+ after adaptation: T.f(("holy", "moly"): (String, String))
+  def g = f("hello", "world")("holy", "moly")
+                             ^
+error: No warnings can be incurred under -Xfatal-warnings.
+two warnings found
+one error found

--- a/test/files/neg/t8417.flags
+++ b/test/files/neg/t8417.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -Ywarn-adapted-args

--- a/test/files/neg/t8417.scala
+++ b/test/files/neg/t8417.scala
@@ -1,0 +1,6 @@
+
+
+trait T {
+  def f(x: Any)(y: Any) = "" + x + y
+  def g = f("hello", "world")("holy", "moly")
+}


### PR DESCRIPTION
Previously, adaptations like auto-tupling were checked
only on the last param section of an application.

This commit runs the sanity check always.

JIRA: https://issues.scala-lang.org/browse/SI-8417