### PR TITLE
SI-8685 Warn on deprecated case ctor

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1158,6 +1158,7 @@ abstract class RefChecks extends Transform {
         }
       }
       checkUndesiredProperties(rtpe.typeSymbol, tree.pos)
+      checkUndesiredProperties(rtpe.typeSymbol.primaryConstructor, tree.pos)
       tree
     }
 

--- a/test/files/neg/t8685.check
+++ b/test/files/neg/t8685.check
@@ -4,6 +4,9 @@ case class D @deprecated("ctor D is depr", since="now") (i: Int)
 t8685.scala:35: warning: class C is deprecated (since now): class C is depr
   def f = C(42)
           ^
+t8685.scala:36: warning: constructor D in class D is deprecated (since now): ctor D is depr
+  def g = D(42)
+          ^
 t8685.scala:37: warning: object E is deprecated (since now): module E is depr
   def h = E(42)
           ^
@@ -41,5 +44,5 @@ t8685.scala:53: warning: class K in object J is deprecated (since now): Inner K 
   def l = new J.K(42)
                 ^
 error: No warnings can be incurred under -Xfatal-warnings.
-14 warnings found
+15 warnings found
 one error found


### PR DESCRIPTION
The narrow use case in the ticket was just to warn
on `C.apply` when the constructor has been
deprecated. Someone added code to warn after the
apply is rewritten, but it wasn't checking the
constructor (and the tree was checked before but
not after transform).