### PR TITLE
SI-10130 Ignore extra parse warnings

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -1105,7 +1105,7 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
 
     def apply(line: String): Result = debugging(s"""parse("$line")""") {
       var isIncomplete = false
-      def parse = {
+      def parse = withoutWarnings {
         reporter.reset()
         val trees = newUnitParser(line, label).parseStats()
         if (reporter.hasErrors) Error(trees)


### PR DESCRIPTION
Don't emit warnings when parsing to test for
complete input. The warnings will show up
in the templated code.

```
$ scala
Welcome to Scala 2.12.1 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_111).
Type in expressions for evaluation. Or try :help.

scala> '\060'
<console>:1: warning: Octal escape literals are deprecated, use \u0030 instead.
'\060'
 ^
<console>:2: warning: Octal escape literals are deprecated, use \u0030 instead.
'\060'
 ^
<console>:12: warning: Octal escape literals are deprecated, use \u0030 instead.
       '\060'
        ^
res0: Char = 0

scala> val then = 0
<console>:1: warning: then is a reserved word (since 2.10.0); usage as an identifier is deprecated
val then = 0
    ^
<console>:11: warning: then is a reserved word (since 2.10.0); usage as an identifier is deprecated
       val then = 0
           ^
then: Int = 0

scala> 'abc'
<console>:1: error: unclosed character literal
'abc'
    ^

scala> :quit
apm@mara:~/projects/scala$ ./build/pack/bin/scala -deprecation
Welcome to Scala 2.12.2-20170110-140852-827d69d (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_111).
Type in expressions for evaluation. Or try :help.

scala> '\060'
<console>:12: warning: Octal escape literals are deprecated, use \u0030 instead.
       '\060'
        ^
res0: Char = 0

scala> val then = 0
<console>:11: warning: then is a reserved word (since 2.10.0); usage as an identifier is deprecated
       val then = 0
           ^
then: Int = 0

scala> 'abc'
<console>:1: error: unclosed character literal
'abc'
    ^

scala> 
```