### PR TITLE
Faster compilation of inductive implicits.

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -30,7 +30,7 @@ trait ScalaSettings extends AbsScalaSettings
   protected def defaultClasspath = sys.env.getOrElse("CLASSPATH", ".")
 
   /** Enabled under -Xexperimental. */
-  protected def experimentalSettings = List[BooleanSetting](YpartialUnification)
+  protected def experimentalSettings = List[BooleanSetting](YpartialUnification, YinductionHeuristics)
 
   /** Enabled under -Xfuture. */
   protected def futureSettings = List[BooleanSetting]()
@@ -221,6 +221,7 @@ trait ScalaSettings extends AbsScalaSettings
   val YdisableFlatCpCaching  = BooleanSetting    ("-YdisableFlatCpCaching", "Do not cache flat classpath representation of classpath elements from jars across compiler instances.")
   val YpartialUnification = BooleanSetting ("-Ypartial-unification", "Enable partial unification in type constructor inference")
   val Yvirtpatmat     = BooleanSetting    ("-Yvirtpatmat", "Enable pattern matcher virtualization")
+  val YinductionHeuristics = BooleanSetting ("-Yinduction-heuristics", "Enable induction heuristics in implicit resolution")
 
   val exposeEmptyPackage = BooleanSetting ("-Yexpose-empty-package", "Internal only: expose the empty package.").internalOnly()
   val Ydelambdafy        = ChoiceSetting  ("-Ydelambdafy", "strategy", "Strategy used for translating lambdas into JVM code.", List("inline", "method"), "method")

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -183,6 +183,7 @@ trait Implicits {
     def isFailure          = false
     def isAmbiguousFailure = false
     def isDivergent        = false
+    def isNoninductive     = false
     final def isSuccess    = !isFailure
   }
 
@@ -198,6 +199,11 @@ trait Implicits {
   lazy val AmbiguousSearchFailure = new SearchResult(EmptyTree, EmptyTreeTypeSubstituter, Nil) {
     override def isFailure          = true
     override def isAmbiguousFailure = true
+  }
+
+  lazy val NoninductiveSearchFailure = new SearchResult(EmptyTree, EmptyTreeTypeSubstituter, Nil) {
+    override def isFailure      = true
+    override def isNoninductive = true
   }
 
   /** A class that records an available implicit
@@ -220,7 +226,7 @@ trait Implicits {
       isCyclicOrErroneousCache.booleanValue
     }
 
-    private[this] final def computeIsCyclicOrErroneous =
+    def computeIsCyclicOrErroneous =
       try sym.hasFlag(LOCKED) || containsError(tpe)
       catch { case _: CyclicReference => true }
 
@@ -825,12 +831,70 @@ trait Implicits {
      *                             shadowing. The head of the list `iss` must represent implicits from the closest
      *                             enclosing scope, and so on.
      */
-    class ImplicitComputation(iss: Infoss, isLocalToCallsite: Boolean) {
+    class ImplicitComputation(iss: Infoss, isLocalToCallsite: Boolean) extends AbstractImplicitComputation(iss, isLocalToCallsite) {
+      /** Sorted list of eligible implicits.
+       */
+      val eligible: List[ImplicitInfo]  = {
+        val matches = iss flatMap { is =>
+          val result = is filter (info => checkValid(info.sym) && survives(info))
+          shadower addInfos is
+          result
+        }
+
+        // most frequent one first
+        matches sortBy (x => if (isView) -x.useCountView else -x.useCountArg)
+      }
+      if (eligible.nonEmpty)
+        printTyping(tree, eligible.size + s" eligible for pt=$pt at ${fullSiteString(context)}")
+    }
+
+    // MS: The split between the original and the new inductive computation could be more
+    // cleanly factored, but deferred to make it easier to see the difference between the
+    // cases.
+    class InductiveImplicitComputation(iss: Infoss, isLocalToCallsite: Boolean) extends AbstractImplicitComputation(iss, isLocalToCallsite) {
+      def inductionType(tpe: Type): Type = {
+        tpe.dealias match {
+          case TypeRef(pre, sym, args) => typeRef(pre, sym, args.map(_ => WildcardType))
+          case RefinedType(List(t), _) => inductionType(t)
+          case RefinedType(List(a, t), _) if a =:= AnyRefClass.tpe => inductionType(t)
+          case t => t
+        }
+      }
+
+      val inductionPt = inductionType(pt)
+
+      def matchesInductionPt(info: ImplicitInfo): Boolean = (
+        info.isStablePrefix && matchesPt(depoly(info.tpe), inductionPt, Nil)
+      )
+
+      def isIneligibleForInduction(info: ImplicitInfo) = (
+           info.computeIsCyclicOrErroneous // avoid side effects
+        || isView && (info.sym eq Predef_conforms) // as an implicit conversion, Predef.$conforms is a no-op, so exclude it
+        || (!context.macrosEnabled && info.sym.isTermMacro)
+      )
+
+      def survivesForInduction(info: ImplicitInfo) = (
+           !isIneligibleForInduction(info)               // cyclic, erroneous, shadowed, or specially excluded
+        && isPlausiblyCompatible(info.tpe, inductionPt)  // optimization to avoid matchesPt
+        && !shadower.isShadowed(info.name)          // OPT rare, only check for plausible candidates
+        && matchesInductionPt(info)                          // stable and matches expected type
+      )
+
+      val eligible: List[ImplicitInfo] = {
+        iss flatMap { is =>
+          val result = is filter (info => checkValid(info.sym) && survivesForInduction(info))
+          shadower addInfos is
+          result
+        }
+      }
+    }
+
+    abstract class AbstractImplicitComputation(iss: Infoss, isLocalToCallsite: Boolean) {
       abstract class Shadower {
         def addInfos(infos: Infos)
         def isShadowed(name: Name): Boolean
       }
-      private val shadower: Shadower = {
+      val shadower: Shadower = {
         /** Used for exclude implicits from outer scopes that are shadowed by same-named implicits */
         final class LocalShadower extends Shadower {
           val shadowed = util.HashSet[Name](512)
@@ -870,7 +934,7 @@ trait Implicits {
 
       /** Tests for validity and updates invalidImplicits by side effect when false.
        */
-      private def checkValid(sym: Symbol) = isValid(sym) || { invalidImplicits += sym ; false }
+      def checkValid(sym: Symbol) = isValid(sym) || { invalidImplicits += sym ; false }
 
       /** Preventing a divergent implicit from terminating implicit search,
        *  so that if there is a best candidate it can still be selected.
@@ -911,20 +975,7 @@ trait Implicits {
         }
       }
 
-      /** Sorted list of eligible implicits.
-       */
-      val eligible = {
-        val matches = iss flatMap { is =>
-          val result = is filter (info => checkValid(info.sym) && survives(info))
-          shadower addInfos is
-          result
-        }
-
-        // most frequent one first
-        matches sortBy (x => if (isView) -x.useCountView else -x.useCountArg)
-      }
-      if (eligible.nonEmpty)
-        printTyping(tree, eligible.size + s" eligible for pt=$pt at ${fullSiteString(context)}")
+      def eligible: List[ImplicitInfo]
 
       /** Faster implicit search.  Overall idea:
        *   - prune aggressively
@@ -1030,6 +1081,307 @@ trait Implicits {
     def searchImplicit(implicitInfoss: Infoss, isLocalToCallsite: Boolean): SearchResult =
       if (implicitInfoss.forall(_.isEmpty)) SearchFailure
       else new ImplicitComputation(implicitInfoss, isLocalToCallsite) findBest()
+
+    def dealiasUnrefine(tpe: Type): Type = {
+      tpe.dealias match {
+        case RefinedType(List(t), _) => dealiasUnrefine(t)
+        case RefinedType(List(a, t), _) if a =:= AnyRefClass.tpe => dealiasUnrefine(t)
+        case t => t
+      }
+    }
+
+    def convergent(argTpe: Type, resTpe: Type): Boolean = {
+      recursive(argTpe, resTpe) &&
+        (dealiasUnrefine(argTpe).typeArgs zip dealiasUnrefine(resTpe).typeArgs).exists {
+          case (arg, res) => !(res =:= arg) && res.contains(arg.typeSymbol) && !res.typeConstructor.typeSymbol.isParameter
+        }
+    }
+
+    sealed trait Convergence
+    case object Convergent extends Convergence
+    case object Neutral extends Convergence
+    case object Divergent extends Convergence
+
+    def divergenceMap(info: ImplicitInfo): List[Convergence] = {
+      val PolyType(args, mt) = info.tpe
+      val resTpe = mt.finalResultType
+      val List(params) = info.tpe.paramLists
+      val List(rec) = params.filter(param => recursive(param.info, resTpe))
+      val argTpe = rec.info
+
+      (dealiasUnrefine(argTpe).typeArgs zip dealiasUnrefine(resTpe).typeArgs) map {
+        case (arg, res) =>
+          if (res =:= arg) Neutral
+          else if (res.contains(arg.typeSymbol)) Convergent
+          else Divergent
+      }
+    }
+
+    def recursive(argTpe: Type, resTpe: Type): Boolean =
+      dealiasUnrefine(argTpe).typeConstructor =:= dealiasUnrefine(resTpe).typeConstructor
+
+    def isBase(i: ImplicitInfo): Boolean =
+      i.tpe match {
+        case PolyType(args, mt) =>
+          val tp = mt.finalResultType
+          i.tpe.paramLists match {
+            case List(params) if params.head.isImplicit => !params.exists(param => recursive(param.info, tp))
+            case Nil => true
+            case _ => false
+          }
+
+        case NullaryMethodType(_) => true
+        case other => false
+      }
+
+    def isInduction(i: ImplicitInfo): Boolean =
+      i.tpe match {
+        case PolyType(args, mt) =>
+          val tp = mt.finalResultType
+          i.tpe.paramLists match {
+            case List(params) if params.head.isImplicit =>
+              params.filter(param => recursive(param.info, tp)) match {
+                case List(rec) => convergent(rec.info, tp)
+                case _ => false
+              }
+            case _ => false
+          }
+        case _ => false
+      }
+
+    def inductive(local: List[ImplicitInfo], scope: List[ImplicitInfo]): Boolean = {
+      val exhaustive =
+        (local.exists(isBase) || scope.exists(isBase)) &&
+        (local.exists(isInduction) || scope.exists(isInduction)) &&
+        local.forall(i => !i.sym.isMacro && (isBase(i) || isInduction(i))) &&
+        scope.forall(i => !i.sym.isMacro && (isBase(i) || isInduction(i)))
+
+      if (exhaustive) {
+        val inductions = local.filter(isInduction) ++ scope.filter(isInduction)
+        inductions.map(divergenceMap).transpose.forall { convergences =>
+          !(convergences.exists(_ == Convergent) && convergences.exists(_ == Divergent))
+        }
+      } else false
+    }
+
+    def solve(pt: Type, tp: Type): SearchResult = {
+      val wildPt = deriveTypeWithWildcards(context.outer.undetparams ++ context.undetparams)(pt)
+      val (tp0, tparams) = tp match {
+        case PolyType(tparams, restpe) => (ApproximateDependentMap(restpe).finalResultType, tparams)
+        case _ => (ApproximateDependentMap(tp).finalResultType, Nil)
+      }
+
+      val allUndetparams = (context.outer.undetparams ++ context.undetparams ++ tparams).distinct
+      val tvars = allUndetparams map freshVar
+      val tpInstantiated = tp0.instantiateTypeParams(allUndetparams, tvars)
+
+      if (!matchesPt(tpInstantiated, wildPt, allUndetparams)) SearchFailure
+      else {
+        val targs = solvedTypes(tvars, allUndetparams, allUndetparams map varianceInType(pt), upper = false, lubDepth(wildPt :: tp :: Nil))
+        if (!checkBounds(EmptyTree, NoPrefix, NoSymbol, allUndetparams, targs, "inferred ")) SearchFailure
+        else {
+          val AdjustedTypeArgs(okParams, okArgs) = adjustTypeArgs(allUndetparams, tvars, targs)
+          val undetparams = allUndetparams diff okParams
+          val tpSubst = tp0.instantiateTypeParams(okParams, okArgs)
+          if (!matchesPt(tpSubst, wildPt, undetparams)) SearchFailure
+          else {
+            val subst: TreeTypeSubstituter =
+              if (okParams.isEmpty) EmptyTreeTypeSubstituter
+              else new TreeTypeSubstituter(okParams, okArgs)
+            new SearchResult(EmptyTree, subst, undetparams)
+          }
+        }
+      }
+    }
+
+    def tryInduction(iss: Infoss): SearchResult = {
+      val local = new InductiveImplicitComputation(context.implicitss, true).eligible
+      val scope = new InductiveImplicitComputation(iss, false).eligible
+
+      lazy val markedInductive = dealiasUnrefine(pt).typeConstructor.typeSymbol.hasAnnotation(InductiveClass)
+      val nonInductive: SearchResult =
+        if (markedInductive) NoninductiveSearchFailure
+        else SearchFailure
+
+      val inductionResult =
+        if (scope.isEmpty || !inductive(local, scope)) nonInductive
+        else {
+          def improves0(info1: ImplicitInfo, info2: ImplicitInfo): Boolean = improves(info1, info2) || !improves(info2, info1)
+
+          val ranked = local.sortWith(improves0) ++ scope.sortWith(improves0)
+
+          // MS: Mutual recursion between loop and applyImplicitArgs means that this isn't stack safe. I'm deferring
+          // changing this for now so that the common logic between typedImplicit1 and Typers#applyImplicitArgs is
+          // easily visible.
+          def loop(pt: Type, reportAmbiguous: Boolean): SearchResult = {
+            def tryInfo(info: ImplicitInfo): SearchResult = {
+              val solvedContext = solve(pt, info.tpe) // Is there duplication between solve and the subsequent type
+                                                      // checking which could be eliminated?
+              if (solvedContext.isFailure) SearchFailure
+              else {
+                val allUndetparams = (context.undetparams ++ context.outer.undetparams ++ solvedContext.undetparams).distinct
+                context.undetparams = (context.undetparams ++ solvedContext.undetparams).distinct
+
+                val wildPt = deriveTypeWithWildcards(allUndetparams)(pt)
+
+                val fun0 = atPos(pos.focus) { Select(gen.mkAttributedQualifier(info.pre), info.sym.name) }
+                val fun = if (isBlackbox(info.sym)) suppressMacroExpansion(fun0) else fun0
+
+                val fun2 = typed1(fun, EXPRmode, wildPt)
+                val (mt, fun3) =
+                  fun2.tpe match {
+                    case PolyType(tparams, mt) =>
+                      (mt, TypeApply(fun2, tparams map (tparam => TypeTree(tparam.tpeHK) setPos fun2.pos.focus)) setPos fun2.pos)
+                    case other =>
+                      (other, fun2)
+                  }
+
+                val tree1 =
+                  if (isImplicitMethodType(mt)) {
+                    applyImplicitArgs(fun3, mt, solvedContext, pt)
+                  } else {
+                    solvedContext.subst traverse fun3
+                    fun3
+                  }
+
+                val tree2 = typed(tree1, EXPRmode, wildPt)
+                if (tree2.isErroneous || context.reporter.hasErrors) SearchFailure
+                else {
+                  val tvars = allUndetparams map freshVar
+                  def ptInstantiated = pt.instantiateTypeParams(allUndetparams, tvars)
+                  if (!matchesPt(tree2.tpe, ptInstantiated, allUndetparams)) SearchFailure
+                  else {
+                    val targs = solvedTypes(tvars, allUndetparams, allUndetparams map varianceInType(pt), upper = false, lubDepth(tree2.tpe :: pt :: Nil))
+                    checkBounds(tree2, NoPrefix, NoSymbol, allUndetparams, targs, "inferred ")
+                    context.reporter.firstError match {
+                      case Some(err) => SearchFailure
+                      case None =>
+                        val AdjustedTypeArgs(okParams, okArgs) = adjustTypeArgs(allUndetparams, tvars, targs)
+                        val subst: TreeTypeSubstituter =
+                          if (okParams.isEmpty) EmptyTreeTypeSubstituter
+                          else {
+                            val subst = new TreeTypeSubstituter(okParams, okArgs)
+                            subst traverse tree2
+                            notifyUndetparamsInferred(okParams, okArgs)
+                            subst
+                          }
+
+                        context.undetparams = allUndetparams diff okParams
+                        new SearchResult(unsuppressMacroExpansion(tree2), subst, context.undetparams)
+                    }
+                  }
+                }
+              }
+            }
+
+            ranked.foldLeft((nonInductive: SearchResult, None: Option[ImplicitInfo])) {
+              case (acc@(prevResult, None), info) if prevResult.isFailure && !prevResult.isAmbiguousFailure =>
+                val savedUndetparams = context.undetparams
+                val previousErrs = context.reporter.errors
+                context.reporter.clearAllErrors
+
+                val result = tryInfo(info)
+
+                if (result.isFailure) {
+                  context.reporter ++= previousErrs
+                  context.undetparams = savedUndetparams
+                  acc
+                } else
+                  (result, Some(info))
+
+              case (acc@(prevResult, Some(prevInfo)), info) if prevResult.isSuccess && prevInfo != info && !improves(prevInfo, info) =>
+                val savedUndetparams = context.undetparams
+                val previousErrs = context.reporter.errors
+                context.reporter.clearAllErrors
+
+                val ambigResult = tryInfo(info)
+
+                context.reporter.clearAllErrors
+                context.reporter ++= previousErrs
+                context.undetparams = savedUndetparams
+
+                if(ambigResult.isFailure)
+                  acc
+                else {
+                  if(reportAmbiguous)
+                    AmbiguousImplicitError(prevInfo, prevResult.tree, info, ambigResult.tree, "both", "and", "")(false, pt, tree)(context)
+                  (AmbiguousSearchFailure, None)
+                }
+
+              case (acc, _) => acc
+            }._1
+          }
+
+          // Adapted from Typers#applyImplicitArgs
+          def applyImplicitArgs(fun: Tree, ftpe: Type, init: SearchResult, prevTp: Type): Tree = ftpe match {
+            case MethodType(params, mt) =>
+              val argResultsBuff = ListBuffer(init)
+              val argBuff = new ListBuffer[Tree]()
+              // paramFailed cannot be initialized with params.exists(_.tpe.isError) because that would
+              // hide some valid errors for params preceding the erroneous one.
+              var paramFailed = false
+              var mkArg: (Name, Tree) => Tree = (_, tree) => tree
+
+              // DEPMETTODO: instantiate type vars that depend on earlier implicit args (see adapt (4.1))
+              //
+              // apply the substitutions (undet type param -> type) that were determined
+              // by implicit resolution of implicit arguments on the left of this argument
+              for(param <- params) {
+                var paramTp = param.tpe
+                for(ar <- argResultsBuff)
+                  paramTp = paramTp.subst(ar.subst.from, ar.subst.to)
+
+                val paramRecursive = recursive(paramTp, mt.finalResultType)
+
+                val res =
+                  if (paramFailed || (paramTp.isErroneous && {paramFailed = true; true}) || paramTp =:= prevTp) SearchFailure
+                  else if (paramRecursive && samePlausibleImplicits(pt, paramTp)) loop(paramTp, false)
+                  else inferImplicitFor(paramTp, fun, context, reportAmbiguous = false)
+
+                argResultsBuff += res
+
+                if (res.isSuccess) {
+                  argBuff += mkArg(param.name, res.tree)
+                } else {
+                  mkArg = gen.mkNamedArg // don't pass the default argument (if any) here, but start emitting named arguments for the following args
+                  if (!param.hasDefault && !paramFailed) {
+                    if (paramRecursive || !markedInductive)
+                      context.reporter.reportFirstDivergentError(fun, param, paramTp)(context)
+                    else
+                      IncompleteInductionImplicitExpansionError(fun, pt, paramTp)(context)
+
+                    paramFailed = true
+                  }
+                  /* else {
+                   TODO: alternative (to expose implicit search failure more) -->
+                   resolve argument, do type inference, keep emitting positional args, infer type params based on default value for arg
+                   for (ar <- argResultsBuff) ar.subst traverse defaultVal
+                   val targs = exprTypeArgs(context.undetparams, defaultVal.tpe, paramTp)
+                   substExpr(tree, tparams, targs, pt)
+                  }*/
+                }
+              }
+
+              val args = argBuff.toList
+              for (ar <- argResultsBuff) {
+                ar.subst traverse fun
+                for (arg <- args) ar.subst traverse arg
+              }
+
+              new ApplyToImplicitArgs(fun, args) setPos fun.pos
+
+            case ErrorType =>
+              fun
+          }
+
+          loop(pt, true)
+        }
+
+      if (inductionResult.isNoninductive && inductionResult.tree.isEmpty)
+        NoninductiveImplicitExpansionError(tree, pt)(context)
+
+      inductionResult
+    }
 
     /** Produce an implicit info map, i.e. a map from the class symbols C of all parts of this type to
      *  the implicit infos in the companion objects of these class symbols C.
@@ -1142,7 +1494,7 @@ trait Implicits {
      *  These are all implicits found in companion objects of classes C
      *  such that some part of `tp` has C as one of its superclasses.
      */
-    private def implicitsOfExpectedType: Infoss = {
+    private def implicitsOfExpectedType(pt: Type): Infoss = {
       if (Statistics.canEnable) Statistics.incCounter(implicitCacheAccs)
       implicitsCache get pt match {
         case Some(implicitInfoss) =>
@@ -1164,6 +1516,16 @@ trait Implicits {
             implicitsCache -= implicitsCache.keysIterator.next
           implicitInfoss1
       }
+    }
+
+    private def implicitsOfExpectedType: Infoss = implicitsOfExpectedType(pt)
+
+    def samePlausibleImplicits(tp0: Type, tp1: Type): Boolean = {
+      def check(tp: Type)(info: ImplicitInfo): Boolean = isValid(info.sym) && isPlausiblyCompatible(info.tpe, tp)
+
+      val i0 = implicitsOfExpectedType(tp0).flatten.filter(check(tp0))
+      val i1 = implicitsOfExpectedType(tp1).flatten.filter(check(tp1))
+      i0.sameElements(i1)
     }
 
     /** Creates a tree will produce a tag of the requested flavor.
@@ -1414,8 +1776,17 @@ trait Implicits {
 
         // `materializeImplicit` does some preprocessing for `pt`
         // is it only meant for manifests/tags or we need to do the same for `implicitsOfExpectedType`?
-        if (result.isFailure && !wasAmbiguous)
-          result = searchImplicit(implicitsOfExpectedType, isLocalToCallsite = false)
+        if (settings.YinductionHeuristics) {
+          if (result.isFailure && !wasAmbiguous) {
+            result = tryInduction(implicitsOfExpectedType)
+
+            if (result.isFailure && !result.isNoninductive && !result.isAmbiguousFailure)
+              result = searchImplicit(implicitsOfExpectedType, isLocalToCallsite = false)
+          }
+        } else {
+          if (result.isFailure && !wasAmbiguous)
+            result = searchImplicit(implicitsOfExpectedType, isLocalToCallsite = false)
+        }
 
         if (result.isFailure)
           context.reporter ++= previousErrs

--- a/src/library/mima-filters/2.12.0.forwards.excludes
+++ b/src/library/mima-filters/2.12.0.forwards.excludes
@@ -16,3 +16,5 @@ ProblemFilters.exclude[MissingClassProblem]("scala.annotation.showAsInfix")
 
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.util.PropertiesTrait.coloredOutputEnabled")
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.util.Properties.coloredOutputEnabled")
+
+ProblemFilters.exclude[MissingClassProblem]("scala.annotation.inductive")

--- a/src/library/scala/annotation/inductive.scala
+++ b/src/library/scala/annotation/inductive.scala
@@ -1,0 +1,19 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2002-2016, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala.annotation
+
+/** A type annotation which verifies that the implicit values of the
+ *  annotated type will be resolved inductively.
+ *
+ *  If it is present, the compiler will issue an error if implicit values
+ *  cannot be resolved inductively.
+ *
+ *  @since 2.12.0
+ */
+final class inductive extends scala.annotation.StaticAnnotation

--- a/src/reflect/mima-filters/2.12.0.forwards.excludes
+++ b/src/reflect/mima-filters/2.12.0.forwards.excludes
@@ -14,3 +14,5 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.ZipArchive.
 ProblemFilters.exclude[MissingClassProblem]("scala.reflect.io.FileZipArchive$LeakyEntry")
 
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.SynchronizedSymbols#SynchronizedSymbol.exists")
+
+ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.Settings.YinductionHeuristics")

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1156,6 +1156,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val ScalaStrictFPAttr          = requiredClass[scala.annotation.strictfp]
     lazy val SwitchClass                = requiredClass[scala.annotation.switch]
     lazy val TailrecClass               = requiredClass[scala.annotation.tailrec]
+    lazy val InductiveClass             = requiredClass[scala.annotation.inductive]
     lazy val VarargsClass               = requiredClass[scala.annotation.varargs]
     lazy val uncheckedStableClass       = requiredClass[scala.annotation.unchecked.uncheckedStable]
     lazy val uncheckedVarianceClass     = requiredClass[scala.annotation.unchecked.uncheckedVariance]

--- a/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
+++ b/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
@@ -55,6 +55,7 @@ abstract class MutableSettings extends AbsSettings {
   def verbose: BooleanSetting
   def YpartialUnification: BooleanSetting
   def Yvirtpatmat: BooleanSetting
+  def YinductionHeuristics: BooleanSetting
 
   def Yrecursion: IntSetting
   def maxClassfileName: IntSetting

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -388,6 +388,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.ScalaStrictFPAttr
     definitions.SwitchClass
     definitions.TailrecClass
+    definitions.InductiveClass
     definitions.VarargsClass
     definitions.uncheckedStableClass
     definitions.uncheckedVarianceClass

--- a/src/reflect/scala/reflect/runtime/Settings.scala
+++ b/src/reflect/scala/reflect/runtime/Settings.scala
@@ -49,6 +49,7 @@ private[reflect] class Settings extends MutableSettings {
   val verbose           = new BooleanSetting(false)
   val YpartialUnification = new BooleanSetting(false)
   val Yvirtpatmat       = new BooleanSetting(false)
+  val YinductionHeuristics = new BooleanSetting(false)
 
   val Yrecursion        = new IntSetting(0)
   val maxClassfileName  = new IntSetting(255)

--- a/test/files/neg/inductive-implicits11.check
+++ b/test/files/neg/inductive-implicits11.check
@@ -1,0 +1,5 @@
+inductive-implicits11.scala:9: error: diverging implicit expansion for type Foo[Option[Int],Int]
+starting with method tick in object Foo
+  implicitly[Foo[Option[Int], Int]]
+            ^
+one error found

--- a/test/files/neg/inductive-implicits11.flags
+++ b/test/files/neg/inductive-implicits11.flags
@@ -1,0 +1,1 @@
+-Yinduction-heuristics

--- a/test/files/neg/inductive-implicits11.scala
+++ b/test/files/neg/inductive-implicits11.scala
@@ -1,0 +1,10 @@
+trait Foo[T, U]
+object Foo {
+  implicit def tick[T, U](implicit f: Foo[Option[T], U]): Foo[T, Option[U]] = ???
+  implicit def tock[T, U](implicit f: Foo[T, Option[U]]): Foo[Option[T], U] = ???
+  implicit val stop: Foo[Int, Int] = ???
+}
+
+object Test {
+  implicitly[Foo[Option[Int], Int]]
+}

--- a/test/files/neg/inductive-implicits12.check
+++ b/test/files/neg/inductive-implicits12.check
@@ -1,0 +1,23 @@
+inductive-implicits12.scala:17: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+  h0: TC[Int]
+    ^
+inductive-implicits12.scala:19: error: ambiguous implicit values:
+ both value intTC in object TC of type => TC[Int]
+ and method fooTC in object TC of type [A](implicit ev: TC[A])TC[Foo[A]]
+ match expected type TC[A]
+  val h1 = handler(Bar(23))
+                  ^
+inductive-implicits12.scala:25: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+  h3: TC[Foo[Int]]
+    ^
+inductive-implicits12.scala:28: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+  h4: TC[Int]
+    ^
+inductive-implicits12.scala:31: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+  h5: TC[Foo[Int]]
+    ^
+inductive-implicits12.scala:34: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+  h6: TC[Foo[Foo[Int]]]
+    ^
+5 warnings found
+one error found

--- a/test/files/neg/inductive-implicits12.flags
+++ b/test/files/neg/inductive-implicits12.flags
@@ -1,0 +1,1 @@
+-Yinduction-heuristics

--- a/test/files/neg/inductive-implicits12.scala
+++ b/test/files/neg/inductive-implicits12.scala
@@ -1,0 +1,35 @@
+sealed trait Foo[+A]
+
+final case class Bar(x: Int) extends Foo[Nothing]
+final case class Baz[A](x: A) extends Foo[A]
+
+sealed trait TC[A]
+
+object TC {
+  implicit val intTC: TC[Int] = new TC[Int] {}
+  implicit def fooTC[A](implicit ev: TC[A]): TC[Foo[A]] = new TC[Foo[A]] {}
+}
+
+object Test {
+  def handler[A](foo: Foo[A])(implicit ev: TC[A]): TC[A] = ev
+
+  val h0 = handler(Baz(23))
+  h0: TC[Int]
+
+  val h1 = handler(Bar(23))
+  h1: TC[Foo[Int]]
+
+  val h2: TC[Int] = handler(Bar(23))
+
+  val h3 = handler(Bar(23))(TC.fooTC(TC.intTC))
+  h3: TC[Foo[Int]]
+
+  val h4 = handler[Int](Bar(23))
+  h4: TC[Int]
+
+  val h5 = handler[Foo[Int]](Bar(23))
+  h5: TC[Foo[Int]]
+
+  val h6 = handler[Foo[Foo[Int]]](Bar(23))
+  h6: TC[Foo[Foo[Int]]]
+}

--- a/test/files/neg/inductive-implicits14.check
+++ b/test/files/neg/inductive-implicits14.check
@@ -1,0 +1,40 @@
+inductive-implicits14.scala:21: error: ambiguous implicit values:
+ both value intTC in trait TC0 of type => TC[Int]
+ and method ambig0 in object TC of type [A]=> TC[A]
+ match expected type TC[Int]
+  val h0 = handler(Baz(23))
+                  ^
+inductive-implicits14.scala:24: error: type mismatch;
+ found   : TC[Nothing]
+ required: TC[A]
+Note: Nothing <: A, but trait TC is invariant in type A.
+You may wish to define A as +A instead. (SLS 4.5)
+  val h1 = handler(Bar(23))
+                  ^
+inductive-implicits14.scala:25: error: type mismatch;
+ found   : TC[Nothing]
+ required: TC[Foo[Int]]
+Note: Nothing <: Foo[Int], but trait TC is invariant in type A.
+You may wish to define A as +A instead. (SLS 4.5)
+  h1: TC[Foo[Int]]
+  ^
+inductive-implicits14.scala:27: error: type mismatch;
+ found   : TC[Nothing]
+ required: TC[A]
+Note: Nothing <: A, but trait TC is invariant in type A.
+You may wish to define A as +A instead. (SLS 4.5)
+  val h2: TC[Int] = handler(Bar(23))
+                           ^
+inductive-implicits14.scala:29: error: ambiguous implicit values:
+ both value intTC in trait TC0 of type => TC[Int]
+ and method ambig0 in object TC of type [A]=> TC[A]
+ match expected type TC[Int]
+  val h4 = handler[Int](Bar(23))
+                       ^
+inductive-implicits14.scala:32: error: ambiguous implicit values:
+ both method fooTC in trait TC0 of type [A](implicit ev: TC[A])TC[Foo[A]]
+ and method ambig1 in object TC of type [A <: AnyRef]=> TC[A]
+ match expected type TC[Foo[Foo[Int]]]
+  val h6 = handler[Foo[Foo[Int]]](Bar(23))
+                                 ^
+6 errors found

--- a/test/files/neg/inductive-implicits14.flags
+++ b/test/files/neg/inductive-implicits14.flags
@@ -1,0 +1,1 @@
+-Yinduction-heuristics

--- a/test/files/neg/inductive-implicits14.scala
+++ b/test/files/neg/inductive-implicits14.scala
@@ -1,0 +1,34 @@
+sealed trait Foo[+A]
+
+final case class Bar(x: Int) extends Foo[Nothing]
+final case class Baz[A](x: A) extends Foo[A]
+
+sealed trait TC[A]
+
+object TC extends TC0 {
+  implicit def ambig0[A]: TC[A] = new TC[A] {}
+  implicit def ambig1[A <: AnyRef]: TC[A] = new TC[A] {}
+}
+
+trait TC0 {
+  implicit def fooTC[A](implicit ev: TC[A]): TC[Foo[A]] = new TC[Foo[A]] {}
+  implicit val intTC: TC[Int] = new TC[Int] {}
+}
+
+object Test {
+  def handler[A](foo: Foo[A])(implicit ev: TC[A]): TC[A] = ev
+
+  val h0 = handler(Baz(23))
+  h0: TC[Int]
+
+  val h1 = handler(Bar(23))
+  h1: TC[Foo[Int]]
+
+  val h2: TC[Int] = handler(Bar(23))
+
+  val h4 = handler[Int](Bar(23))
+  h4: TC[Int]
+
+  val h6 = handler[Foo[Foo[Int]]](Bar(23))
+  h6: TC[Foo[Foo[Int]]]
+}

--- a/test/files/neg/inductive-implicits3.check
+++ b/test/files/neg/inductive-implicits3.check
@@ -1,0 +1,4 @@
+inductive-implicits3.scala:192: error: could not find implicit value for parameter e: shapeless.Union.Aux[Int :: shapeless.HNil,Int :: shapeless.HNil,Int :: String :: shapeless.HNil]
+  implicitly[Union.Aux[Int :: HNil, Int :: HNil, Int :: String :: HNil]]
+            ^
+one error found

--- a/test/files/neg/inductive-implicits3.flags
+++ b/test/files/neg/inductive-implicits3.flags
@@ -1,0 +1,1 @@
+-Yinduction-heuristics

--- a/test/files/neg/inductive-implicits3.scala
+++ b/test/files/neg/inductive-implicits3.scala
@@ -1,0 +1,196 @@
+object shapeless {
+  sealed trait HList extends Product with Serializable
+
+  final case class ::[+H, +T <: HList](head : H, tail : T) extends HList {
+    def ::[HH](h : HH) : HH :: H :: T = shapeless.::(h, this)
+
+    override def toString = head match {
+      case _: ::[_, _] => "("+head.toString+") :: "+tail.toString
+      case _ => head.toString+" :: "+tail.toString
+    }
+  }
+
+  sealed trait HNil extends HList {
+    def ::[H](h : H) = shapeless.::(h, this)
+    override def toString = "HNil"
+  }
+
+  case object HNil extends HNil
+
+  final class HListOps[L <: HList](l : L) {
+    def ::[H](h : H) : H :: L = shapeless.::(h, l)
+  }
+
+  object HList {
+    implicit def hlistOps[L <: HList](l: L): HListOps[L] = new HListOps(l)
+  }
+
+  trait FilterNot[L <: HList, U] {
+    type Out <: HList
+    def apply(l: L): Out
+  }
+
+  object FilterNot {
+    def apply[L <: HList, U](implicit filter: FilterNot[L, U]): Aux[L, U, filter.Out] = filter
+
+    type Aux[L <: HList, U, Out0 <: HList] = FilterNot[L, U] { type Out = Out0 }
+
+    implicit def hlistFilterNot[L <: HList, U, LPrefix <: HList, LSuffix <: HList](
+      implicit partition: Partition.Aux[L, U, LPrefix, LSuffix]
+    ): Aux[L, U, LSuffix] = new FilterNot[L, U] {
+      type Out = LSuffix
+
+      def apply(l: L): Out = partition.filterNot(l)
+    }
+  }
+
+  trait Remove[L <: HList, E] {
+    type Out
+    def apply(l: L): Out
+    def reinsert(out: Out): L
+  }
+
+  trait LowPriorityRemove {
+    type Aux[L <: HList, E, Out0] = Remove[L, E] { type Out = Out0 }
+
+    implicit def recurse[H, T <: HList, E, OutT <: HList](implicit r : Aux[T, E, (E, OutT)]): Aux[H :: T, E, (E, H :: OutT)] =
+      new Remove[H :: T, E] {
+        type Out = (E, H :: OutT)
+        def apply(l : H :: T): Out = {
+          val (e, tail) = r(l.tail)
+          (e, l.head :: tail)
+        }
+
+        def reinsert(out: (E, H :: OutT)): H :: T = out._2.head :: r.reinsert((out._1, out._2.tail))
+      }
+  }
+
+  object Remove extends LowPriorityRemove {
+    def apply[L <: HList, E](implicit remove: Remove[L, E]): Aux[L, E, remove.Out] = remove
+
+    implicit def remove[H, T <: HList]: Aux[H :: T, H, (H, T)] =
+      new Remove[H :: T, H] {
+        type Out = (H, T)
+        def apply(l : H :: T): Out = (l.head, l.tail)
+
+        def reinsert(out: (H, T)): H :: T = out._1 :: out._2
+      }
+  }
+
+  object typeops {
+    trait =:!=[A, B] extends Serializable
+
+    implicit def neq[A, B] : A =:!= B = new =:!=[A, B] {}
+    implicit def neqAmbig1[A] : A =:!= A = ???
+    implicit def neqAmbig2[A] : A =:!= A = ???
+  }
+
+  trait Partition[L <: HList, U] {
+    type Prefix <: HList
+    type Suffix <: HList
+    type Out = (Prefix, Suffix)
+
+    def apply(l: L): Out = toTuple2(product(l))
+    def product(l: L): Prefix :: Suffix :: HNil = filter(l) :: filterNot(l) :: HNil
+    def filter(l: L): Prefix
+    def filterNot(l: L): Suffix
+
+    def toTuple2[Prefix, Suffix](l: Prefix :: Suffix :: HNil): (Prefix, Suffix) = (l.head, l.tail.head)
+  }
+
+  object Partition {
+    import typeops._
+
+    def apply[L <: HList, U]
+      (implicit partition: Partition[L, U]): Aux[L, U, partition.Prefix, partition.Suffix] = partition
+
+    type Aux[L <: HList, U, Prefix0 <: HList, Suffix0 <: HList] = Partition[L, U] {
+      type Prefix = Prefix0
+      type Suffix = Suffix0
+    }
+
+    implicit def hlistPartitionNil[U]: Aux[HNil, U, HNil, HNil] = new Partition[HNil, U] {
+      type Prefix = HNil
+      type Suffix = HNil
+
+      def filter(l: HNil): HNil = HNil
+      def filterNot(l: HNil): HNil = HNil
+    }
+
+    implicit def hlistPartition1[H, L <: HList, LPrefix <: HList, LSuffix <: HList](
+      implicit p: Aux[L, H, LPrefix, LSuffix]
+    ): Aux[H :: L, H, H :: LPrefix, LSuffix] = new Partition[H :: L, H] {
+      type Prefix = H :: LPrefix
+      type Suffix = LSuffix
+
+      def filter(l: H :: L): Prefix    = l.head :: p.filter(l.tail)
+      def filterNot(l: H :: L): Suffix = p.filterNot(l.tail)
+    }
+
+    implicit def hlistPartition2[H, L <: HList, U, LPrefix <: HList, LSuffix <: HList](
+      implicit p: Aux[L, U, LPrefix, LSuffix], e: U =:!= H
+    ): Aux[H :: L, U, LPrefix, H :: LSuffix] = new Partition[H :: L, U] {
+      type Prefix = LPrefix
+      type Suffix = H :: LSuffix
+
+      def filter(l: H :: L): Prefix    = p.filter(l.tail)
+      def filterNot(l: H :: L): Suffix = l.head :: p.filterNot(l.tail)
+    }
+  }
+
+  trait Union[L <: HList, M <: HList] {
+    type Out <: HList
+    def apply(l: L, m: M): Out
+  }
+
+  trait LowPriorityUnion {
+    type Aux[L <: HList, M <: HList, Out0 <: HList] = Union[L, M] { type Out = Out0 }
+
+    // buggy version; let (H :: T) ∪ M  =  H :: (T ∪ M)
+    @deprecated("Incorrectly witnesses that {x} ∪ {x} = {x, x}", "2.3.1")
+    def hlistUnion1[H, T <: HList, M <: HList]
+      (implicit u: Union[T, M]): Aux[H :: T, M, H :: u.Out] =
+        new Union[H :: T, M] {
+          type Out = H :: u.Out
+          def apply(l: H :: T, m: M): Out = l.head :: u(l.tail, m)
+        }
+  }
+
+  object Union extends LowPriorityUnion {
+    def apply[L <: HList, M <: HList](implicit union: Union[L, M]): Aux[L, M, union.Out] = union
+
+    // let ∅ ∪ M = M
+    implicit def hlistUnion[M <: HList]: Aux[HNil, M, M] =
+      new Union[HNil, M] {
+        type Out = M
+        def apply(l: HNil, m: M): Out = m
+      }
+
+    // let (H :: T) ∪ M  =  H :: (T ∪ M) when H ∉ M
+    implicit def hlistUnion1[H, T <: HList, M <: HList]
+      (implicit
+       u: Union[T, M],
+       f: FilterNot.Aux[M, H, M]
+      ): Aux[H :: T, M, H :: u.Out] =
+        new Union[H :: T, M] {
+          type Out = H :: u.Out
+          def apply(l: H :: T, m: M): Out = l.head :: u(l.tail, m)
+        }
+
+    // let (H :: T) ∪ M  =  H :: (T ∪ (M - H)) when H ∈ M
+    implicit def hlistUnion2[H, T <: HList, M <: HList, MR <: HList]
+      (implicit
+        r: Remove.Aux[M, H, (H, MR)],
+        u: Union[T, MR]
+      ): Aux[H :: T, M, H :: u.Out] =
+        new Union[H :: T, M] {
+          type Out = H :: u.Out
+          def apply(l: H :: T, m: M): Out = l.head :: u(l.tail, r(m)._2)
+        }
+  }
+
+  implicitly[Union.Aux[Int :: HNil, Int :: HNil, Int :: String :: HNil]]
+
+  //val u = Union[Int :: HNil, Int :: HNil]
+  //val v: Union.Aux[Int :: HNil, Int :: HNil, Int :: HNil] = u
+}

--- a/test/files/neg/inductive-implicits7.check
+++ b/test/files/neg/inductive-implicits7.check
@@ -1,0 +1,4 @@
+inductive-implicits7.scala:74: error: Inductive implicit expansion for type shapeless.Mapper[Test.Fn.type,Test.L] failed due to missing auxiliary implicit shapeless.Case1[Test.Fn.type,String]
+  val map = Mapper[Fn.type, L]
+                  ^
+one error found

--- a/test/files/neg/inductive-implicits7.flags
+++ b/test/files/neg/inductive-implicits7.flags
@@ -1,0 +1,1 @@
+-Yinduction-heuristics

--- a/test/files/neg/inductive-implicits7.scala
+++ b/test/files/neg/inductive-implicits7.scala
@@ -1,0 +1,76 @@
+package shapeless {
+  sealed trait HList extends Product with Serializable
+
+  final case class ::[+H, +T <: HList](head : H, tail : T) extends HList {
+    def ::[HH](h : HH) : HH :: H :: T = shapeless.::(h, this)
+
+    override def toString = head match {
+      case _: ::[_, _] => "("+head.toString+") :: "+tail.toString
+      case _ => head.toString+" :: "+tail.toString
+    }
+  }
+
+  sealed trait HNil extends HList {
+    def ::[H](h : H) = shapeless.::(h, this)
+    override def toString = "HNil"
+  }
+
+  case object HNil extends HNil
+
+  final class HListOps[L <: HList](l : L) {
+    def ::[H](h : H) : H :: L = shapeless.::(h, l)
+  }
+
+  object HList {
+    implicit def hlistOps[L <: HList](l: L): HListOps[L] = new HListOps(l)
+  }
+
+  trait Case1[HF, In] {
+    type Result
+    def apply(t: In): Result
+  }
+
+  object Case1 {
+    type Aux[HF, In, Result0] = Case1[HF, In] { type Result = Result0 }
+  }
+
+  @annotation.inductive
+  trait Mapper[HF, In <: HList] {
+    type Out <: HList
+    def apply(in: In): Out
+  }
+
+  object Mapper {
+    def apply[F, L <: HList](implicit mapper: Mapper[F, L]): Aux[F, L, mapper.Out] = mapper
+
+    type Aux[HF, In <: HList, Out0 <: HList] = Mapper[HF, In] { type Out = Out0 }
+
+    implicit def hnilMapper1[HF]: Aux[HF, HNil, HNil] =
+      new Mapper[HF, HNil] {
+        type Out = HNil
+        def apply(l : HNil): Out = HNil
+      }
+
+    implicit def hlistMapper1[HF, InH, InT <: HList]
+      (implicit hc : Case1[HF, InH], mt : Mapper[HF, InT]): Aux[HF, InH :: InT, hc.Result :: mt.Out] =
+        new Mapper[HF, InH :: InT] {
+          type Out = hc.Result :: mt.Out
+          def apply(l : InH :: InT): Out = hc(l.head) :: mt(l.tail)
+        }
+  }
+}
+
+import shapeless._
+
+object Test extends App {
+  type L = Int :: String :: Boolean :: HNil
+
+  object Fn {
+    implicit val caseInt: Case1.Aux[Fn.type, Int, Int] = new Case1[Fn.type, Int] { type Result = Int ; def apply(t: Int): Int = t }
+    //implicit val caseString: Case1.Aux[Fn.type, String, String] = new Case1[Fn.type, String] { type Result = String ; def apply(t: String): String = t }
+    implicit val caseBoolean: Case1.Aux[Fn.type, Boolean, Boolean] = new Case1[Fn.type, Boolean] { type Result = Boolean ; def apply(t: Boolean): Boolean = t }
+  }
+
+  val map = Mapper[Fn.type, L]
+  map: Mapper.Aux[Fn.type, L, L]
+}

--- a/test/files/neg/inductive-implicits8.check
+++ b/test/files/neg/inductive-implicits8.check
@@ -1,0 +1,4 @@
+inductive-implicits8.scala:8: error: Noninductive implicit expansion for type Foo[Int]
+  implicitly[Foo[Int]]
+            ^
+one error found

--- a/test/files/neg/inductive-implicits8.flags
+++ b/test/files/neg/inductive-implicits8.flags
@@ -1,0 +1,1 @@
+-Yinduction-heuristics

--- a/test/files/neg/inductive-implicits8.scala
+++ b/test/files/neg/inductive-implicits8.scala
@@ -1,0 +1,9 @@
+@annotation.inductive
+trait Foo[T]
+object Foo {
+  implicit def fooInt: Foo[Int] = ???
+}
+
+object Test {
+  implicitly[Foo[Int]]
+}

--- a/test/files/neg/inductive-implicits9.check
+++ b/test/files/neg/inductive-implicits9.check
@@ -1,0 +1,7 @@
+inductive-implicits9.scala:10: error: ambiguous implicit values:
+ both value b of type Foo[String]
+ and value a of type Foo[String]
+ match expected type Foo[String]
+    implicitly[Foo[String]]
+              ^
+one error found

--- a/test/files/neg/inductive-implicits9.flags
+++ b/test/files/neg/inductive-implicits9.flags
@@ -1,0 +1,1 @@
+-Yinduction-heuristics

--- a/test/files/neg/inductive-implicits9.scala
+++ b/test/files/neg/inductive-implicits9.scala
@@ -1,0 +1,12 @@
+trait Foo[A]
+object Foo {
+  implicit def materialize[A]: Foo[A] = new Foo[A] {}
+}
+
+object Test {
+  def test {
+    implicit val a = new Foo[String] { }
+    implicit val b = new Foo[String] { }
+    implicitly[Foo[String]]
+  }
+}

--- a/test/files/pos/inductive-implicits.flags
+++ b/test/files/pos/inductive-implicits.flags
@@ -1,0 +1,1 @@
+-Yinduction-heuristics

--- a/test/files/pos/inductive-implicits.scala
+++ b/test/files/pos/inductive-implicits.scala
@@ -1,0 +1,633 @@
+package shapeless {
+  sealed trait HList extends Product with Serializable
+
+  final case class ::[+H, +T <: HList](head : H, tail : T) extends HList {
+    def ::[HH](h : HH) : HH :: H :: T = shapeless.::(h, this)
+
+    override def toString = head match {
+      case _: ::[_, _] => "("+head.toString+") :: "+tail.toString
+      case _ => head.toString+" :: "+tail.toString
+    }
+  }
+
+  sealed trait HNil extends HList {
+    def ::[H](h : H) = shapeless.::(h, this)
+    override def toString = "HNil"
+  }
+
+  case object HNil extends HNil
+
+  final class HListOps[L <: HList](l : L) {
+    def ::[H](h : H) : H :: L = shapeless.::(h, l)
+  }
+
+  object HList {
+    implicit def hlistOps[L <: HList](l: L): HListOps[L] = new HListOps(l)
+  }
+
+  @annotation.inductive
+  trait Selector[L <: HList, U] {
+    def apply(l: L): U
+  }
+
+  object Selector {
+    def apply[L <: HList, U](implicit selector: Selector[L, U]): Selector[L, U] = selector
+
+    implicit def inHead[H, T <: HList]: Selector[H :: T, H] =
+      new Selector[H :: T, H] {
+        def apply(l : H :: T) = l.head
+      }
+
+    implicit def inTail[H, T <: HList, U]
+      (implicit st : Selector[T, U]): Selector[H :: T, U] =
+        new Selector[H :: T, U] {
+          def apply(l : H :: T) = st(l.tail)
+        }
+  }
+
+  trait Reverse[L <: HList] {
+    type Out <: HList
+    def apply(l: L): Out
+  }
+
+  object Reverse {
+    def apply[L <: HList](implicit reverse: Reverse[L]): Aux[L, reverse.Out] = reverse
+
+    type Aux[L <: HList, Out0 <: HList] = Reverse[L] { type Out = Out0 }
+
+    implicit def reverse[L <: HList, Out0 <: HList](implicit reverse : Reverse0[HNil, L, Out0]): Aux[L, Out0] =
+      new Reverse[L] {
+        type Out = Out0
+        def apply(l : L) : Out = reverse(HNil, l)
+      }
+
+    @annotation.inductive
+    trait Reverse0[Acc <: HList, L <: HList, Out <: HList] {
+      def apply(acc : Acc, l : L) : Out
+    }
+
+    object Reverse0 {
+      implicit def hnilReverse[Out <: HList]: Reverse0[Out, HNil, Out] =
+        new Reverse0[Out, HNil, Out] {
+          def apply(acc : Out, l : HNil) : Out = acc
+        }
+
+      implicit def hlistReverse[Acc <: HList, InH, InT <: HList, Out <: HList]
+        (implicit rt : Reverse0[InH :: Acc, InT, Out]): Reverse0[Acc, InH :: InT, Out] =
+          new Reverse0[Acc, InH :: InT, Out] {
+            def apply(acc : Acc, l : InH :: InT) : Out = rt(l.head :: acc, l.tail)
+          }
+    }
+  }
+
+  trait Case1[HF, In] {
+    type Result
+    def apply(t: In): Result
+  }
+
+  object Case1 {
+    type Aux[HF, In, Result0] = Case1[HF, In] { type Result = Result0 }
+  }
+
+  @annotation.inductive
+  trait Mapper[HF, In <: HList] {
+    type Out <: HList
+    def apply(in: In): Out
+  }
+
+  object Mapper {
+    def apply[F, L <: HList](implicit mapper: Mapper[F, L]): Aux[F, L, mapper.Out] = mapper
+
+    type Aux[HF, In <: HList, Out0 <: HList] = Mapper[HF, In] { type Out = Out0 }
+
+    implicit def hnilMapper1[HF]: Aux[HF, HNil, HNil] =
+      new Mapper[HF, HNil] {
+        type Out = HNil
+        def apply(l : HNil): Out = HNil
+      }
+
+    implicit def hlistMapper1[HF, InH, InT <: HList]
+      (implicit hc : Case1[HF, InH], mt : Mapper[HF, InT]): Aux[HF, InH :: InT, hc.Result :: mt.Out] =
+        new Mapper[HF, InH :: InT] {
+          type Out = hc.Result :: mt.Out
+          def apply(l : InH :: InT): Out = hc(l.head) :: mt(l.tail)
+        }
+  }
+
+  trait Nat {
+    type N <: Nat
+  }
+
+  case class Succ[P <: Nat]() extends Nat {
+    type N = Succ[P]
+  }
+
+  class _0 extends Nat with Serializable {
+    type N = _0
+  }
+
+  object nats {
+    type _1 = Succ[_0]
+    val _1: _1 = new _1
+
+    type _2 = Succ[_1]
+    val _2: _2 = new _2
+
+    type _3 = Succ[_2]
+    val _3: _3 = new _3
+
+    type _4 = Succ[_3]
+    val _4: _4 = new _4
+
+    type _5 = Succ[_4]
+    val _5: _5 = new _5
+
+    type _6 = Succ[_5]
+    val _6: _6 = new _6
+
+    type _7 = Succ[_6]
+    val _7: _7 = new _7
+
+    type _8 = Succ[_7]
+    val _8: _8 = new _8
+
+    type _9 = Succ[_8]
+    val _9: _9 = new _9
+
+    type _10 = Succ[_9]
+    val _10: _10 = new _10
+
+    type _11 = Succ[_10]
+    val _11: _11 = new _11
+
+    type _12 = Succ[_11]
+    val _12: _12 = new _12
+
+    type _13 = Succ[_12]
+    val _13: _13 = new _13
+
+    type _14 = Succ[_13]
+    val _14: _14 = new _14
+
+    type _15 = Succ[_14]
+    val _15: _15 = new _15
+
+    type _16 = Succ[_15]
+    val _16: _16 = new _16
+
+    type _17 = Succ[_16]
+    val _17: _17 = new _17
+
+    type _18 = Succ[_17]
+    val _18: _18 = new _18
+
+    type _19 = Succ[_18]
+    val _19: _19 = new _19
+
+    type _20 = Succ[_19]
+    val _20: _20 = new _20
+
+    type _21 = Succ[_20]
+    val _21: _21 = new _21
+
+    type _22 = Succ[_21]
+    val _22: _22 = new _22
+  }
+
+  @annotation.inductive
+  trait LT[A <: Nat, B <: Nat] extends Serializable
+
+  object LT extends LT0 {
+    def apply[A <: Nat, B <: Nat](implicit lt: A < B): LT[A, B] = lt
+
+    implicit def lt1[B <: Nat] = new <[_0, Succ[B]] {}
+    implicit def lt2[A <: Nat, B <: Nat](implicit lt : A < B) = new <[Succ[A], Succ[B]] {}
+  }
+
+  trait LT0 {
+    type <[A <: Nat, B <: Nat] = LT[A, B]
+
+    implicit def lt3[A <: Nat] = new <[A, Succ[A]] {}
+  }
+
+  @annotation.inductive
+  trait Sum[A <: Nat, B <: Nat] extends Serializable { type Out <: Nat }
+
+  object Sum {
+    def apply[A <: Nat, B <: Nat](implicit sum: Sum[A, B]): Aux[A, B, sum.Out] = sum
+
+    type Aux[A <: Nat, B <: Nat, C <: Nat] = Sum[A, B] { type Out = C }
+
+    implicit def sum1[B <: Nat]: Aux[_0, B, B] = new Sum[_0, B] { type Out = B }
+    implicit def sum2[A <: Nat, B <: Nat]
+      (implicit sum : Sum[A, Succ[B]]): Aux[Succ[A], B, sum.Out] = new Sum[Succ[A], B] { type Out = sum.Out }
+  }
+
+  @annotation.inductive
+  trait Diff[A <: Nat, B <: Nat] extends Serializable { type Out <: Nat }
+
+  object Diff {
+    def apply[A <: Nat, B <: Nat](implicit diff: Diff[A, B]): Aux[A, B, diff.Out] = diff
+
+    type Aux[A <: Nat, B <: Nat, C <: Nat] = Diff[A, B] { type Out = C }
+
+    implicit def diff1[A <: Nat]: Aux[A, _0, A] = new Diff[A, _0] { type Out = A }
+    implicit def diff2[A <: Nat, B <: Nat]
+      (implicit diff : Diff[A, B]): Aux[Succ[A], Succ[B], diff.Out] = new Diff[Succ[A], Succ[B]] { type Out = diff.Out }
+  }
+
+  @annotation.inductive
+  trait Prod[A <: Nat, B <: Nat] extends Serializable { type Out <: Nat }
+
+  object Prod {
+    def apply[A <: Nat, B <: Nat](implicit prod: Prod[A, B]): Aux[A, B, prod.Out] = prod
+
+    type Aux[A <: Nat, B <: Nat, C <: Nat] = Prod[A, B] { type Out = C }
+
+    implicit def prod1[B <: Nat]: Aux[_0, B, _0] = new Prod[_0, B] { type Out = _0 }
+    implicit def prod2[A <: Nat, B <: Nat, C <: Nat]
+      (implicit prod: Prod.Aux[A, B, C], sum: Sum[B, C]): Aux[Succ[A], B, sum.Out] = new Prod[Succ[A], B] { type Out = sum.Out }
+  }
+
+  //@annotation.inductive
+  trait Div[A <: Nat, B <: Nat] extends Serializable { type Out <: Nat }
+
+  object Div {
+    def apply[A <: Nat, B <: Nat](implicit div: Div[A, B]): Aux[A, B, div.Out] = div
+
+    import LT._
+
+    type Aux[A <: Nat, B <: Nat, C <: Nat] = Div[A, B] { type Out = C }
+
+    implicit def div1[A <: Nat]: Aux[_0, A, _0] = new Div[_0, A] { type Out = _0 }
+
+    implicit def div2[A <: Nat, B <: Nat](implicit lt: A < B): Aux[A, B, _0] =
+      new Div[A, B] { type Out = _0 }
+
+    implicit def div3[A <: Nat, B <: Nat, C <: Nat, D <: Nat]
+      (implicit diff: Diff.Aux[Succ[A], B, C], div: Div.Aux[C, B, D]): Aux[Succ[A], B, Succ[D]] =
+        new Div[Succ[A], B] { type Out = Succ[D] }
+  }
+
+  @annotation.inductive
+  trait Pow[N <: Nat, X <: Nat] extends Serializable { type Out <: Nat }
+
+  object Pow {
+    def apply[A <: Nat, B <: Nat](implicit pow: Pow[A, B]): Aux[A, B, pow.Out] = pow
+
+    import nats._1
+
+    type Aux[N <: Nat, X <: Nat, Z <: Nat] = Pow[N, X] { type Out = Z }
+
+    implicit def pow1[A <: Nat]: Aux[Succ[A], _0, _0] = new Pow[Succ[A], _0] { type Out = _0 }
+    implicit def pow2[A <: Nat]: Aux[_0, Succ[A], _1] = new Pow[_0, Succ[A]] { type Out = _1 }
+    implicit def pow3[N <: Nat, X <: Nat, Z <: Nat, Y <: Nat]
+      (implicit ev : Pow.Aux[N, X, Z], ev2 : Prod.Aux[Z, X, Y]): Aux[Succ[N], X, Y] = new Pow[Succ[N], X] { type Out = Y }
+  }
+
+  trait Foo[T, P]
+  object Foo {
+    implicit def foo[T]: Foo[T, T] = ???
+  }
+
+  @annotation.inductive
+  trait Bar[T]
+  object Bar {
+    implicit val barBase: Bar[Unit] = ???
+    implicit def barStep[T, U, P](implicit ft: Foo[T, P], bu: Bar[U]): Bar[(T, U)] = ???
+  }
+
+  @annotation.inductive
+  trait Baz[T] {
+    type U
+  }
+  object Baz extends Baz0 {
+    def apply[T](implicit bt: Baz[T]): Aux[T, bt.U] = bt
+
+    implicit def bazStep[T, U](implicit btu: Aux[T, U], qu: Quux[U]): Aux[Option[T], T] = ???
+  }
+  trait Baz0 {
+    type Aux[T, U0] = Baz[T] { type U = U0 }
+    implicit def bazBase[T]: Aux[T, T] = ???
+  }
+
+  trait Quux[T]
+  object Quux {
+    implicit def quux[T]: Quux[T] = ???
+  }
+
+  trait Wobble[T] {
+    type U
+  }
+  object Wobble {
+    type Aux[T, U0] = Wobble[T] { type U = U0 }
+    implicit def wobble[T]: Aux[T, T] = ???
+  }
+
+  @annotation.inductive
+  trait Wibble[T, U]
+  object Wibble extends Wibble0 {
+    def apply[T, U](implicit wtu: Wibble[T, U]): Wibble[T, U] = wtu
+
+    implicit def wibbleStep[T, U, V](implicit wtu: Wobble.Aux[T, U], wu: Wibble[T, U]): Wibble[Option[T], V] = ???
+  }
+  trait Wibble0 {
+    implicit def wibbleBase[T]: Wibble[T, T] = ???
+  }
+
+  @annotation.inductive
+  trait Wiggle[T] {
+    type I
+  }
+  object Wiggle extends Wiggle0 {
+    implicit def wiggleStep[T, U](implicit btu: Aux[T, U]): Aux[Option[T], U] = ???
+
+  }
+  trait Wiggle0 {
+    type Aux[T, I0] = Wiggle[T] { type I = I0 }
+    implicit def wiggleBase[T]: Aux[T, T] = ???
+  }
+
+  trait Waggle[T] {
+    type A
+  }
+  object Waggle {
+    type Aux[T, A0] = Waggle[T] { type A = A0 }
+    def apply[T](implicit wa: Waggle[T]): Aux[T, wa.A] = wa
+    implicit def waggle[T, U](implicit wi: Wiggle.Aux[T, U]): Waggle.Aux[T, U] = ???
+  }
+
+  object typeops {
+    trait =:!=[A, B] extends Serializable
+
+    implicit def neq[A, B] : A =:!= B = new =:!=[A, B] {}
+    implicit def neqAmbig1[A] : A =:!= A = ???
+    implicit def neqAmbig2[A] : A =:!= A = ???
+  }
+
+  trait Partition[L <: HList, U] {
+    type Prefix <: HList
+    type Suffix <: HList
+    type Out = (Prefix, Suffix)
+
+    def apply(l: L): Out = toTuple2(product(l))
+    def product(l: L): Prefix :: Suffix :: HNil = filter(l) :: filterNot(l) :: HNil
+    def filter(l: L): Prefix
+    def filterNot(l: L): Suffix
+
+    def toTuple2[Prefix, Suffix](l: Prefix :: Suffix :: HNil): (Prefix, Suffix) = (l.head, l.tail.head)
+  }
+
+  object Partition {
+    import typeops._
+
+    def apply[L <: HList, U]
+      (implicit partition: Partition[L, U]): Aux[L, U, partition.Prefix, partition.Suffix] = partition
+
+    type Aux[L <: HList, U, Prefix0 <: HList, Suffix0 <: HList] = Partition[L, U] {
+      type Prefix = Prefix0
+      type Suffix = Suffix0
+    }
+
+    implicit def hlistPartitionNil[U]: Aux[HNil, U, HNil, HNil] = new Partition[HNil, U] {
+      type Prefix = HNil
+      type Suffix = HNil
+
+      def filter(l: HNil): HNil = HNil
+      def filterNot(l: HNil): HNil = HNil
+    }
+
+    implicit def hlistPartition1[H, L <: HList, LPrefix <: HList, LSuffix <: HList](
+      implicit p: Aux[L, H, LPrefix, LSuffix]
+    ): Aux[H :: L, H, H :: LPrefix, LSuffix] = new Partition[H :: L, H] {
+      type Prefix = H :: LPrefix
+      type Suffix = LSuffix
+
+      def filter(l: H :: L): Prefix    = l.head :: p.filter(l.tail)
+      def filterNot(l: H :: L): Suffix = p.filterNot(l.tail)
+    }
+
+    implicit def hlistPartition2[H, L <: HList, U, LPrefix <: HList, LSuffix <: HList](
+      implicit p: Aux[L, U, LPrefix, LSuffix], e: U =:!= H
+    ): Aux[H :: L, U, LPrefix, H :: LSuffix] = new Partition[H :: L, U] {
+      type Prefix = LPrefix
+      type Suffix = H :: LSuffix
+
+      def filter(l: H :: L): Prefix    = p.filter(l.tail)
+      def filterNot(l: H :: L): Suffix = l.head :: p.filterNot(l.tail)
+    }
+  }
+
+  trait Lub[-A, -B, Out] extends Serializable {
+    def left(a : A): Out
+    def right(b : B): Out
+  }
+
+  object Lub {
+    implicit def lub[T] = new Lub[T, T, T] {
+      def left(a : T): T = a
+      def right(b : T): T = b
+    }
+  }
+
+  @annotation.inductive
+  trait ToTraversable[L <: HList, M[_]] {
+    type Lub
+    def builder(): collection.mutable.Builder[Lub, M[Lub]]
+    def append[LLub](l: L, b: collection.mutable.Builder[LLub, M[LLub]], f: Lub => LLub): Unit
+
+    type Out = M[Lub]
+    def apply(l: L): Out = {
+      val b = builder()
+      append(l, b, identity)
+      b.result()
+    }
+  }
+
+  object ToTraversable {
+    def apply[L <: HList, M[_]]
+      (implicit toTraversable: ToTraversable[L, M]): Aux[L, M, toTraversable.Lub] = toTraversable
+
+    type Aux[L <: HList, M[_], Lub0] = ToTraversable[L, M] { type Lub = Lub0 }
+
+    implicit def hnilToTraversable[L <: HNil, M[_], T]
+      (implicit cbf : collection.generic.CanBuildFrom[M[T], T, M[T]]) : Aux[L, M, T] =
+        new ToTraversable[L, M] {
+          type Lub = T
+          def builder() = cbf()
+          def append[LLub](l : L, b : collection.mutable.Builder[LLub, M[LLub]], f : Lub => LLub) = {}
+        }
+
+    implicit def hnilToTraversableNothing[L <: HNil, M[_]]
+      (implicit cbf : collection.generic.CanBuildFrom[M[Nothing], Nothing, M[Nothing]]) : Aux[L, M, Nothing] =
+        hnilToTraversable[L, M, Nothing]
+
+    implicit def hsingleToTraversable[T, M[_], Lub0]
+      (implicit ev : T <:< Lub0, cbf : collection.generic.CanBuildFrom[Nothing, Lub0, M[Lub0]]) : Aux[T :: HNil, M, Lub0] =
+        new ToTraversable[T :: HNil, M] {
+          type Lub = Lub0
+          def builder() = cbf()
+          def append[LLub](l : T :: HNil, b : collection.mutable.Builder[LLub, M[LLub]], f : Lub0 => LLub) = {
+            b += f(l.head)
+          }
+        }
+
+    implicit def hlistToTraversable[H1, H2, T <: HList, LubT, Lub0, M[_]]
+      (implicit
+       tttvs  : Aux[H2 :: T, M, LubT],
+       u      : Lub[H1, LubT, Lub0],
+       cbf    : collection.generic.CanBuildFrom[M[Lub0], Lub0, M[Lub0]]) : Aux[H1 :: H2 :: T, M, Lub0] =
+        new ToTraversable[H1 :: H2 :: T, M] {
+          type Lub = Lub0
+          def builder() = cbf()
+          def append[LLub](l : H1 :: H2 :: T, b : collection.mutable.Builder[LLub, M[LLub]], f : Lub0 => LLub): Unit = {
+            b += f(u.left(l.head)); tttvs.append[LLub](l.tail, b, f compose u.right)
+          }
+        }
+  }
+}
+
+import shapeless._, nats._
+
+object Test extends App {
+  type L = Int :: Boolean :: HNil
+  val sel = Selector[L, Boolean]
+  val rev = Reverse[L]
+  rev: Reverse[L] { type Out = Boolean :: Int :: HNil }
+  object Fn {
+    implicit val caseInt: Case1.Aux[Fn.type, Int, Int] = new Case1[Fn.type, Int] { type Result = Int ; def apply(t: Int): Int = t }
+    implicit val caseBoolean: Case1.Aux[Fn.type, Boolean, Boolean] = new Case1[Fn.type, Boolean] { type Result = Boolean ; def apply(t: Boolean): Boolean = t }
+  }
+
+  val map = Mapper[Fn.type, L]
+  map: Mapper.Aux[Fn.type, L, L]
+
+  implicitly[Partition[L, Boolean]]
+
+  implicitly[Sum.Aux[_2, _3, _5]]
+  val sum23 = Sum[_2, _3]
+  sum23: Sum.Aux[_2, _3, _5]
+
+  implicitly[Prod.Aux[_0, _1, _0]]
+  implicitly[Prod.Aux[_1, _0, _0]]
+  implicitly[Prod.Aux[_1, _1, _1]]
+  implicitly[Prod.Aux[_2, _1, _2]]
+  implicitly[Prod.Aux[_2, _3, _6]]
+  implicitly[Prod.Aux[_4, _5, _20]]
+
+  val prod212 = Prod[_2, _1]
+  prod212: Prod.Aux[_2, _1, _2]
+
+  val prod236 = Prod[_2, _3]
+  prod236: Prod.Aux[_2, _3, _6]
+
+  implicitly[Bar[(Unit, Unit)]]
+
+  val res2 = Wibble[Option[Int], String]
+  res2: Wibble[Option[Int], String]
+  val res3 = Wibble[Option[Option[Int]], String]
+  res3: Wibble[Option[Option[Int]], String]
+
+  val res0 = Baz[Option[Int]]
+  res0: Baz.Aux[Option[Int], Int]
+  val res1 = Baz[Option[Option[Int]]]
+  res1: Baz.Aux[Option[Option[Int]], Option[Int]]
+
+  trait Check[N <: Nat]
+  def check(expected: Nat)(actually : => Check[expected.N]) {}
+
+  def prod(a: Nat, b: Nat)(implicit prod : Prod[a.N, b.N]) = new Check[prod.Out] {}
+  val p1 = prod(_2, _3)
+  check(_6)(p1)
+  val p2 = prod(_4, _5)
+  check(_20)(p2)
+
+  implicitly[Diff.Aux[_5, _1, _4]]
+
+  def diff(a: Nat, b: Nat)(implicit diff : Diff[a.N, b.N]) = new Check[diff.Out] {}
+  val diff1 = diff(_5, _1)
+  check(_4)(diff1)
+
+  implicitly[LT[_3, _5]]
+
+  implicitly[Div.Aux[_7, _2, _3]]
+  implicitly[Div.Aux[_7, _2, _3]]
+  implicitly[Div.Aux[_22, _11, _2]]
+  implicitly[Div.Aux[_15, _3, _5]]
+
+  def div(a: Nat, b: Nat)(implicit div : Div[a.N, b.N]) = new Check[div.Out] {}
+  val d1 = div(_7, _2)
+  check(_3)(d1)
+  val d2 = div(_22, _11)
+  check(_2)(d2)
+  val d3 = div(_15, _3)
+  check(_5)(d3)
+
+  implicitly[Pow.Aux[_0, _8, _1]]
+  implicitly[Pow.Aux[_9, _0, _0]]
+  implicitly[Pow.Aux[_3, _2, _8]]
+
+  def pow(a: Nat, b: Nat)(implicit pow : Pow[a.N, b.N]) = new Check[pow.Out] {}
+  val e1 = pow(_3, _1)
+  check(_1)(e1)
+  val e2 = pow(_2, _3)
+  check(_9)(e2)
+  val e3 = pow(_2, _4)
+  check(_16)(e3)
+
+  val res4 = Waggle[Option[Option[Int]]]
+  res4: Waggle.Aux[Option[Option[Int]], Int]
+
+  val res5 = Div[_1, _1]
+  res5: Div.Aux[_1, _1, _1]
+
+  trait Poly { outer =>
+    trait Case[P, A] {
+      type R
+      val f: A => R
+    }
+    object Case {
+      type Aux[A, R0] = Case[outer.type, A] { type R = R0 }
+    }
+
+    def at[A] = new {
+      def apply[R0](f0: A => R0): Case.Aux[A, R0] = new Case[outer.type, A] { type R = R0 ; val f = f0 }
+    }
+  }
+
+  object Poly {
+    implicit def inst1[A](p: Poly)(implicit cse: p.Case[p.type, A]): (A) => cse.R = (a: A) => cse.f(a)
+  }
+
+  object Rec extends Poly {
+    implicit def default[T] = at[T](_ => 13)
+    implicit def opt[T](implicit rt: Case.Aux[T, Int]) = at[Option[T]](ot => ot.map(Rec).getOrElse(0))
+  }
+
+  trait Fruit
+  class Apple extends Fruit
+  class Pear extends Fruit
+
+  val ttnil = ToTraversable[HNil, List]
+  ttnil: ToTraversable.Aux[HNil, List, Nothing]
+
+  implicitly[ToTraversable.Aux[HNil, List, Int]]
+
+  val tti = ToTraversable[Int :: HNil, List]
+  tti: ToTraversable.Aux[Int:: HNil, List, Int]
+
+  val ttap = ToTraversable[Apple :: Pear :: HNil, List]
+  //ttap: ToTraversable.Aux[Apple :: Pear :: HNil, List, Fruit]
+
+  trait C[P, T]
+  object P1 {
+    implicit val p1: C[P1.type, Int] = ???
+  }
+
+  object P2 {
+    implicit val p2a: C[P2.type, Unit] = ???
+    implicit def p2b[T](implicit p1: C[P1.type, T]): C[P2.type, Option[T]] = ???
+  }
+
+  implicitly[C[P2.type, Option[Int]]]
+}

--- a/test/files/pos/inductive-implicits10.flags
+++ b/test/files/pos/inductive-implicits10.flags
@@ -1,0 +1,1 @@
+-Yinduction-heuristics

--- a/test/files/pos/inductive-implicits10.scala
+++ b/test/files/pos/inductive-implicits10.scala
@@ -1,0 +1,87 @@
+object shapeless {
+  sealed trait HList extends Product with Serializable
+
+  final case class ::[+H, +T <: HList](head : H, tail : T) extends HList {
+    def ::[HH](h : HH) : HH :: H :: T = shapeless.::(h, this)
+
+    override def toString = head match {
+      case _: ::[_, _] => "("+head.toString+") :: "+tail.toString
+      case _ => head.toString+" :: "+tail.toString
+    }
+  }
+
+  sealed trait HNil extends HList {
+    def ::[H](h : H) = shapeless.::(h, this)
+    override def toString = "HNil"
+  }
+
+  case object HNil extends HNil
+
+  sealed trait Coproduct extends Product with Serializable
+
+  /** Like Either, the :+: type defines a new type that can contain either H or T.
+    */
+  sealed trait :+:[+H, +T <: Coproduct] extends Coproduct {
+    /**
+     * Non-recursive fold (like Either#fold)
+     */
+    def eliminate[A](l: H => A, r: T => A): A
+  }
+
+  /** `H :+: T` can either be `H` or `T`.
+    * In this case it is `H`.
+    */
+  final case class Inl[+H, +T <: Coproduct](head : H) extends :+:[H, T] {
+    override def eliminate[A](l: H => A, r: T => A) = l(head)
+  }
+
+  /** `H :+: T` can either be `H` or `T`.
+    * In this case it is `T`.
+    */
+  final case class Inr[+H, +T <: Coproduct](tail : T) extends :+:[H, T] {
+    override def eliminate[A](l: H => A, r: T => A) = r(tail)
+  }
+
+  sealed trait CNil extends Coproduct {
+    def impossible: Nothing
+  }
+
+  trait Inject[C <: Coproduct, I] extends Serializable {
+    def apply(i: I): C
+  }
+
+  object Inject {
+    def apply[C <: Coproduct, I](implicit inject: Inject[C, I]): Inject[C, I] = inject
+
+    implicit def tlInject[H, T <: Coproduct, I](implicit tlInj : Inject[T, I]): Inject[H :+: T, I] = new Inject[H :+: T, I] {
+      def apply(i: I): H :+: T = Inr(tlInj(i))
+    }
+
+    implicit def hdInject[H, T <: Coproduct]: Inject[H :+: T, H] = new Inject[H :+: T, H] {
+      def apply(i: H): H :+: T = Inl(i)
+    }
+  }
+}
+
+import shapeless._
+
+sealed trait ToCoproductCodecs[C <: Coproduct, L <: HList]
+
+object ToCoproductCodecs {
+  implicit val base: ToCoproductCodecs[CNil, HNil] = new ToCoproductCodecs[CNil, HNil] {}
+
+  implicit def step[A, CT <: Coproduct, LT <: HList](
+    implicit tailAux: ToCoproductCodecs[CT, LT],
+    inj: Inject[A :+: CT, A]
+  ): ToCoproductCodecs[A :+: CT, A :: LT] = new ToCoproductCodecs[A :+: CT, A :: LT] {}
+}
+
+final class CoproductCodecBuilder[C <: Coproduct, L <: HList, R](codecs: L)(implicit aux: ToCoproductCodecs[C, L]) {
+  def :+:[A](left: A): CoproductCodecBuilder[A :+: C, A :: L, A :+: C] =
+    CoproductCodecBuilder(::(left, codecs))
+}
+
+object CoproductCodecBuilder {
+  def apply[C <: Coproduct, L <: HList](l: L)(implicit aux: ToCoproductCodecs[C, L]): CoproductCodecBuilder[C, L, C] =
+    new CoproductCodecBuilder[C, L, C](l)
+}

--- a/test/files/pos/inductive-implicits13.flags
+++ b/test/files/pos/inductive-implicits13.flags
@@ -1,0 +1,1 @@
+-Yinduction-heuristics

--- a/test/files/pos/inductive-implicits13.scala
+++ b/test/files/pos/inductive-implicits13.scala
@@ -1,0 +1,26 @@
+sealed trait Foo[+A]
+final case class Bar(x: Int) extends Foo[Nothing]
+final case class Baz[A](x: A) extends Foo[A]
+
+sealed trait TC[A]
+
+trait TCImplicits extends TCLowerImplicits {
+  implicit def fooTC[A](implicit tca: TC[A]): TC[Foo[A]] = new TC[Foo[A]] {}
+}
+
+trait TCLowerImplicits {
+  implicit val intTC: TC[Int] = new TC[Int] {}
+}
+
+object test extends TCImplicits {
+  def handler[A](foo: Foo[A])(implicit ev: TC[A]): TC[A] = ev
+
+  val h0a = handler(Bar(23))(fooTC[Int](intTC))
+  h0a: TC[Foo[Int]]
+
+  val h0 = handler(Bar(23))
+  h0: TC[Foo[Int]]
+
+  val h1 = handler(Baz(23))
+  h1: TC[Int]
+}

--- a/test/files/pos/inductive-implicits15.flags
+++ b/test/files/pos/inductive-implicits15.flags
@@ -1,0 +1,1 @@
+-Yinduction-heuristics

--- a/test/files/pos/inductive-implicits15.scala
+++ b/test/files/pos/inductive-implicits15.scala
@@ -1,0 +1,25 @@
+sealed trait Foo[+A]
+
+final case class Bar(x: Int) extends Foo[Nothing]
+
+sealed trait TC[A]
+
+object TC extends TC0 {
+  implicit def ambig0[A]: TC[A] = new TC[A] {}
+  implicit def ambig1[A <: AnyRef]: TC[A] = new TC[A] {}
+}
+
+trait TC0 {
+  implicit def fooTC[A](implicit ev: TC[A]): TC[Foo[A]] = new TC[Foo[A]] {}
+  implicit val intTC: TC[Int] = new TC[Int] {}
+}
+
+object Test {
+  def handler[A](foo: Foo[A])(implicit ev: TC[A]): TC[A] = ev
+
+  //val h3 = handler(Bar(23))(TC.fooTC(TC.intTC))
+  //h3: TC[Foo[Int]]
+
+  val h5 = handler[Foo[Int]](Bar(23))
+  //h5: TC[Foo[Int]]
+}

--- a/test/files/pos/inductive-implicits2.flags
+++ b/test/files/pos/inductive-implicits2.flags
@@ -1,0 +1,1 @@
+-Yinduction-heuristics

--- a/test/files/pos/inductive-implicits2.scala
+++ b/test/files/pos/inductive-implicits2.scala
@@ -1,0 +1,189 @@
+object shapeless {
+  sealed trait HList extends Product with Serializable
+
+  final case class ::[+H, +T <: HList](head : H, tail : T) extends HList {
+    def ::[HH](h : HH) : HH :: H :: T = shapeless.::(h, this)
+
+    override def toString = head match {
+      case _: ::[_, _] => "("+head.toString+") :: "+tail.toString
+      case _ => head.toString+" :: "+tail.toString
+    }
+  }
+
+  sealed trait HNil extends HList {
+    def ::[H](h : H) = shapeless.::(h, this)
+    override def toString = "HNil"
+  }
+
+  case object HNil extends HNil
+
+  final class HListOps[L <: HList](l : L) {
+    def ::[H](h : H) : H :: L = shapeless.::(h, l)
+  }
+
+  object HList {
+    implicit def hlistOps[L <: HList](l: L): HListOps[L] = new HListOps(l)
+  }
+
+  abstract class Case[P, L <: HList] extends Serializable {
+    type Result
+    val value : L => Result
+
+    def apply(t : L) = value(t)
+    def apply()(implicit ev: HNil =:= L) = value(HNil)
+    def apply[T](t: T)(implicit ev: (T :: HNil) =:= L) = value(t :: HNil)
+    def apply[T, U](t: T, u: U)(implicit ev: (T :: U :: HNil) =:= L) = value(t :: u :: HNil)
+  }
+
+  trait FnToProduct[-F] extends Serializable {
+    type Out
+    def apply(f: F): Out
+  }
+
+  trait FnToProductInstances {
+    type Aux[F, Out0] = FnToProduct[F] { type Out = Out0 }
+
+    implicit def fnToProduct1
+      [A, Res]
+    : Aux[
+      ((A) => Res),
+      (A::HNil) => Res
+    ] =
+      new FnToProduct[(A) => Res] {
+        type Out = (A::HNil) => Res
+        def apply(fn: (A) => Res): Out
+          = (l : A::HNil)
+            => l match { case a::HNil => fn(a) }
+      }
+
+    implicit def fnToProduct2
+      [A, B, Res]
+    : Aux[
+      ((A, B) => Res),
+      (A::B::HNil) => Res
+    ] =
+      new FnToProduct[(A, B) => Res] {
+        type Out = (A::B::HNil) => Res
+        def apply(fn: (A, B) => Res): Out
+          = (l : A::B::HNil)
+            => l match { case a::b::HNil => fn(a, b) }
+      }
+  }
+
+  object FnToProduct extends FnToProductInstances {
+    def apply[F <: AnyRef](implicit fntop: FnToProduct[F]): Aux[F, fntop.Out] = fntop
+  }
+
+  trait CaseInst {
+    implicit def inst1
+      [Fn <: Poly, A, Res]
+      (cse : Case[Fn, A::HNil] { type Result = Res })
+    : (A) => Res =
+      (a:A)
+        => cse.value(a::HNil)
+
+    implicit def inst2
+      [Fn <: Poly, A, B, Res]
+      (cse : Case[Fn, A::B::HNil] { type Result = Res })
+    : (A, B) => Res =
+      (a:A, b:B)
+        => cse.value(a::b::HNil)
+  }
+
+  object Case extends CaseInst {
+    type Aux[P, L <: HList, Result0] = Case[P, L] { type Result = Result0 }
+    type Hom[P, T] = Aux[P, T :: HNil, T]
+
+    def apply[P, L <: HList, R](v : L => R): Aux[P, L, R] = new Case[P, L] {
+      type Result = R
+      val value = v
+    }
+  }
+
+  trait PolyInst {
+    implicit def inst1
+      [A]
+      (fn : Poly)(implicit cse : fn.ProductCase[A::HNil])
+    : (A) => cse.Result =
+      (a:A)
+        => cse(a::HNil)
+
+    implicit def inst2
+      [A, B]
+      (fn : Poly)(implicit cse : fn.ProductCase[A::B::HNil])
+    : (A, B) => cse.Result =
+      (a:A, b:B)
+        => cse(a::b::HNil)
+  }
+
+  object Poly extends PolyInst {
+    implicit def inst0(p: Poly)(implicit cse : p.ProductCase[HNil]) : cse.Result = cse()
+  }
+
+  trait PolyApply {
+    def apply
+      [A]
+      (a:A)
+      (implicit cse : Case[this.type, A::HNil])
+    : cse.Result =
+      cse(a::HNil)
+
+    def apply
+      [A, B]
+      (a:A, b:B)
+      (implicit cse : Case[this.type, A::B::HNil])
+    : cse.Result =
+      cse(a::b::HNil)
+  }
+
+  trait Poly extends PolyApply with Serializable {
+    /** The type of the case representing this polymorphic function at argument types `L`. */
+    type ProductCase[L <: HList] = Case[this.type, L]
+    object ProductCase extends Serializable {
+      /** The type of a case of this polymorphic function of the form `L => R` */
+      type Aux[L <: HList, Result0] = ProductCase[L] { type Result = Result0 }
+
+      /** The type of a case of this polymorphic function of the form `T => T` */
+      type Hom[T] = Aux[T :: HNil, T]
+
+      def apply[L <: HList, R](v : L => R) = new ProductCase[L] {
+        type Result = R
+        val value = v
+      }
+    }
+
+    def use[T, L <: HList, R](t : T)(implicit cb: CaseBuilder[T, L, R]) = cb(t)
+
+    trait CaseBuilder[T, L <: HList, R] extends Serializable {
+      def apply(t: T): ProductCase.Aux[L, R]
+    }
+
+    trait LowPriorityCaseBuilder {
+      implicit def valueCaseBuilder[T]: CaseBuilder[T, HNil, T] =
+        new CaseBuilder[T, HNil, T] {
+          def apply(t: T) = ProductCase((_: HNil) => t)
+        }
+    }
+
+    object CaseBuilder extends LowPriorityCaseBuilder {
+      implicit def fnCaseBuilder[F, H, T <: HList, Result]
+        (implicit fntp: FnToProduct.Aux[F, ((H :: T) => Result)]): CaseBuilder[F, H :: T, Result] =
+          new CaseBuilder[F, H :: T, Result] {
+            def apply(f: F) = ProductCase((l : H :: T) => fntp(f)(l))
+          }
+    }
+
+    def caseAt[L <: HList](implicit c: ProductCase[L]) = c
+
+    def apply[R](implicit c : ProductCase.Aux[HNil, R]) : R = c()
+  }
+
+  object smear extends Poly {
+    implicit val caseIntInt    = use((x: Int) => x)
+    //implicit val caseIntInt    = use((x: Int) => x)
+    //implicit val caseStringInt = use((x: String, y: Int) => x.toInt + y)
+    //implicit val caseIntString = use((x: Int, y: String) => x + y.toInt)
+  }
+
+  smear(13)
+}

--- a/test/files/pos/inductive-implicits3.flags
+++ b/test/files/pos/inductive-implicits3.flags
@@ -1,0 +1,1 @@
+-Yinduction-heuristics

--- a/test/files/pos/inductive-implicits3.scala
+++ b/test/files/pos/inductive-implicits3.scala
@@ -1,0 +1,209 @@
+object shapeless {
+  sealed trait HList extends Product with Serializable
+
+  final case class ::[+H, +T <: HList](head : H, tail : T) extends HList {
+    def ::[HH](h : HH) : HH :: H :: T = shapeless.::(h, this)
+
+    override def toString = head match {
+      case _: ::[_, _] => "("+head.toString+") :: "+tail.toString
+      case _ => head.toString+" :: "+tail.toString
+    }
+  }
+
+  sealed trait HNil extends HList {
+    def ::[H](h : H) = shapeless.::(h, this)
+    override def toString = "HNil"
+  }
+
+  case object HNil extends HNil
+
+  final class HListOps[L <: HList](l : L) {
+    def ::[H](h : H) : H :: L = shapeless.::(h, l)
+    def union[M <: HList](s: M)(implicit union: Union[L, M]): union.Out = union(l, s)
+  }
+
+  object HList {
+    implicit def hlistOps[L <: HList](l: L): HListOps[L] = new HListOps(l)
+  }
+
+  trait FilterNot[L <: HList, U] {
+    type Out <: HList
+    def apply(l: L): Out
+  }
+
+  object FilterNot {
+    def apply[L <: HList, U](implicit filter: FilterNot[L, U]): Aux[L, U, filter.Out] = filter
+
+    type Aux[L <: HList, U, Out0 <: HList] = FilterNot[L, U] { type Out = Out0 }
+
+    implicit def hlistFilterNot[L <: HList, U, LPrefix <: HList, LSuffix <: HList](
+      implicit partition: Partition.Aux[L, U, LPrefix, LSuffix]
+    ): Aux[L, U, LSuffix] = new FilterNot[L, U] {
+      type Out = LSuffix
+
+      def apply(l: L): Out = partition.filterNot(l)
+    }
+  }
+
+  trait Remove[L <: HList, E] {
+    type Out
+    def apply(l: L): Out
+    def reinsert(out: Out): L
+  }
+
+  trait LowPriorityRemove {
+    type Aux[L <: HList, E, Out0] = Remove[L, E] { type Out = Out0 }
+
+    implicit def recurse[H, T <: HList, E, OutT <: HList](implicit r : Aux[T, E, (E, OutT)]): Aux[H :: T, E, (E, H :: OutT)] =
+      new Remove[H :: T, E] {
+        type Out = (E, H :: OutT)
+        def apply(l : H :: T): Out = {
+          val (e, tail) = r(l.tail)
+          (e, l.head :: tail)
+        }
+
+        def reinsert(out: (E, H :: OutT)): H :: T = out._2.head :: r.reinsert((out._1, out._2.tail))
+      }
+  }
+
+  object Remove extends LowPriorityRemove {
+    def apply[L <: HList, E](implicit remove: Remove[L, E]): Aux[L, E, remove.Out] = remove
+
+    implicit def remove[H, T <: HList]: Aux[H :: T, H, (H, T)] =
+      new Remove[H :: T, H] {
+        type Out = (H, T)
+        def apply(l : H :: T): Out = (l.head, l.tail)
+
+        def reinsert(out: (H, T)): H :: T = out._1 :: out._2
+      }
+  }
+
+  object typeops {
+    trait =:!=[A, B] extends Serializable
+
+    implicit def neq[A, B] : A =:!= B = new =:!=[A, B] {}
+    implicit def neqAmbig1[A] : A =:!= A = ???
+    implicit def neqAmbig2[A] : A =:!= A = ???
+  }
+
+  trait Partition[L <: HList, U] {
+    type Prefix <: HList
+    type Suffix <: HList
+    type Out = (Prefix, Suffix)
+
+    def apply(l: L): Out = toTuple2(product(l))
+    def product(l: L): Prefix :: Suffix :: HNil = filter(l) :: filterNot(l) :: HNil
+    def filter(l: L): Prefix
+    def filterNot(l: L): Suffix
+
+    def toTuple2[Prefix, Suffix](l: Prefix :: Suffix :: HNil): (Prefix, Suffix) = (l.head, l.tail.head)
+  }
+
+  object Partition {
+    import typeops._
+
+    def apply[L <: HList, U]
+      (implicit partition: Partition[L, U]): Aux[L, U, partition.Prefix, partition.Suffix] = partition
+
+    type Aux[L <: HList, U, Prefix0 <: HList, Suffix0 <: HList] = Partition[L, U] {
+      type Prefix = Prefix0
+      type Suffix = Suffix0
+    }
+
+    implicit def hlistPartitionNil[U]: Aux[HNil, U, HNil, HNil] = new Partition[HNil, U] {
+      type Prefix = HNil
+      type Suffix = HNil
+
+      def filter(l: HNil): HNil = HNil
+      def filterNot(l: HNil): HNil = HNil
+    }
+
+    implicit def hlistPartition1[H, L <: HList, LPrefix <: HList, LSuffix <: HList](
+      implicit p: Aux[L, H, LPrefix, LSuffix]
+    ): Aux[H :: L, H, H :: LPrefix, LSuffix] = new Partition[H :: L, H] {
+      type Prefix = H :: LPrefix
+      type Suffix = LSuffix
+
+      def filter(l: H :: L): Prefix    = l.head :: p.filter(l.tail)
+      def filterNot(l: H :: L): Suffix = p.filterNot(l.tail)
+    }
+
+    implicit def hlistPartition2[H, L <: HList, U, LPrefix <: HList, LSuffix <: HList](
+      implicit p: Aux[L, U, LPrefix, LSuffix], e: U =:!= H
+    ): Aux[H :: L, U, LPrefix, H :: LSuffix] = new Partition[H :: L, U] {
+      type Prefix = LPrefix
+      type Suffix = H :: LSuffix
+
+      def filter(l: H :: L): Prefix    = p.filter(l.tail)
+      def filterNot(l: H :: L): Suffix = l.head :: p.filterNot(l.tail)
+    }
+  }
+
+  trait Union[L <: HList, M <: HList] {
+    type Out <: HList
+    def apply(l: L, m: M): Out
+  }
+
+  trait LowPriorityUnion {
+    type Aux[L <: HList, M <: HList, Out0 <: HList] = Union[L, M] { type Out = Out0 }
+
+    // buggy version; let (H :: T) ∪ M  =  H :: (T ∪ M)
+    @deprecated("Incorrectly witnesses that {x} ∪ {x} = {x, x}", "2.3.1")
+    def hlistUnion1[H, T <: HList, M <: HList]
+      (implicit u: Union[T, M]): Aux[H :: T, M, H :: u.Out] =
+        new Union[H :: T, M] {
+          type Out = H :: u.Out
+          def apply(l: H :: T, m: M): Out = l.head :: u(l.tail, m)
+        }
+  }
+
+  object Union extends LowPriorityUnion {
+    def apply[L <: HList, M <: HList](implicit union: Union[L, M]): Aux[L, M, union.Out] = union
+
+    // let ∅ ∪ M = M
+    implicit def hlistUnion[M <: HList]: Aux[HNil, M, M] =
+      new Union[HNil, M] {
+        type Out = M
+        def apply(l: HNil, m: M): Out = m
+      }
+
+    // let (H :: T) ∪ M  =  H :: (T ∪ M) when H ∉ M
+    implicit def hlistUnion1[H, T <: HList, M <: HList]
+      (implicit
+       u: Union[T, M],
+       f: FilterNot.Aux[M, H, M]
+      ): Aux[H :: T, M, H :: u.Out] =
+        new Union[H :: T, M] {
+          type Out = H :: u.Out
+          def apply(l: H :: T, m: M): Out = l.head :: u(l.tail, m)
+        }
+
+    // let (H :: T) ∪ M  =  H :: (T ∪ (M - H)) when H ∈ M
+    implicit def hlistUnion2[H, T <: HList, M <: HList, MR <: HList]
+      (implicit
+        r: Remove.Aux[M, H, (H, MR)],
+        u: Union[T, MR]
+      ): Aux[H :: T, M, H :: u.Out] =
+        new Union[H :: T, M] {
+          type Out = H :: u.Out
+          def apply(l: H :: T, m: M): Out = l.head :: u(l.tail, r(m)._2)
+        }
+  }
+
+  // should be in neg
+  //implicitly[Union.Aux[Int :: HNil, Int :: HNil, Int :: String :: HNil]]
+
+  val u = Union[Int :: HNil, Int :: HNil]
+  val v: Union.Aux[Int :: HNil, Int :: HNil, Int :: HNil] = u
+
+  val u1 = Union[String :: Long :: HNil, Int :: String :: Boolean :: HNil]
+  val v1: Union.Aux[String :: Long :: HNil, Int :: String :: Boolean :: HNil, String :: Long :: Int :: Boolean :: HNil] = u1
+
+  type L1 = String :: Long :: HNil
+  val l1: L1 = "foo" :: 3L :: HNil
+
+  type L2 = Int :: String :: Boolean :: HNil
+  val l2: L2 = 2 :: "bar" :: true :: HNil
+
+  val l12 = l1.union(l2)
+}

--- a/test/files/pos/inductive-implicits5.flags
+++ b/test/files/pos/inductive-implicits5.flags
@@ -1,0 +1,1 @@
+-Yinduction-heuristics

--- a/test/files/pos/inductive-implicits5.scala
+++ b/test/files/pos/inductive-implicits5.scala
@@ -1,0 +1,222 @@
+object shapeless {
+  sealed trait HList extends Product with Serializable
+
+  final case class ::[+H, +T <: HList](head : H, tail : T) extends HList {
+    def ::[HH](h : HH) : HH :: H :: T = shapeless.::(h, this)
+
+    override def toString = head match {
+      case _: ::[_, _] => "("+head.toString+") :: "+tail.toString
+      case _ => head.toString+" :: "+tail.toString
+    }
+  }
+
+  sealed trait HNil extends HList {
+    def ::[H](h : H) = shapeless.::(h, this)
+    override def toString = "HNil"
+  }
+
+  case object HNil extends HNil
+
+  final class HListOps[L <: HList](l : L) {
+    def ::[H](h : H) : H :: L = shapeless.::(h, l)
+  }
+
+  object HList {
+    implicit def hlistOps[L <: HList](l: L): HListOps[L] = new HListOps(l)
+  }
+
+  trait Prepend[P <: HList, S <: HList] {
+    type Out <: HList
+    def apply(p: P, s: S): Out
+  }
+
+  trait LowestPriorityPrepend {
+    type Aux[P <: HList, S <: HList, Out0 <: HList] = Prepend[P, S] { type Out = Out0 }
+
+    implicit def hlistPrepend[PH, PT <: HList, S <: HList]
+     (implicit pt : Prepend[PT, S]): Prepend.Aux[PH :: PT, S, PH :: pt.Out] =
+      new Prepend[PH :: PT, S] {
+        type Out = PH :: pt.Out
+        def apply(prefix : PH :: PT, suffix : S): Out = prefix.head :: pt(prefix.tail, suffix)
+      }
+  }
+
+  trait LowPriorityPrepend extends LowestPriorityPrepend {
+    /**
+     * Binary compatibility stub
+     * This one is for https://github.com/milessabin/shapeless/issues/406
+     */
+    override type Aux[P <: HList, S <: HList, Out0 <: HList] = Prepend[P, S] { type Out = Out0 }
+
+    implicit def hnilPrepend0[P <: HList, S <: HNil]: Aux[P, S, P] =
+      new Prepend[P, S] {
+        type Out = P
+        def apply(prefix : P, suffix : S): P = prefix
+      }
+  }
+
+  object Prepend extends LowPriorityPrepend {
+    def apply[P <: HList, S <: HList](implicit prepend: Prepend[P, S]): Aux[P, S, prepend.Out] = prepend
+
+    implicit def hnilPrepend1[P <: HNil, S <: HList]: Aux[P, S, S] =
+      new Prepend[P, S] {
+        type Out = S
+        def apply(prefix : P, suffix : S): S = suffix
+      }
+  }
+
+  abstract class Case[P, L <: HList] extends Serializable {
+    type Result
+    val value : L => Result
+
+    def apply(t : L) = value(t)
+    def apply()(implicit ev: HNil =:= L) = value(HNil)
+    def apply[T](t: T)(implicit ev: (T :: HNil) =:= L) = value(t :: HNil)
+    def apply[T, U](t: T, u: U)(implicit ev: (T :: U :: HNil) =:= L) = value(t :: u :: HNil)
+  }
+
+  trait CaseInst {
+    implicit def inst1
+      [Fn <: Poly, A, Res]
+      (cse : Case[Fn, A::HNil] { type Result = Res })
+    : (A) => Res =
+      (a:A)
+        => cse.value(a::HNil)
+  }
+
+  object Case extends CaseInst {
+    type Aux[P, L <: HList, Result0] = Case[P, L] { type Result = Result0 }
+    type Hom[P, T] = Aux[P, T :: HNil, T]
+
+    def apply[P, L <: HList, R](v : L => R): Aux[P, L, R] = new Case[P, L] {
+      type Result = R
+      val value = v
+    }
+  }
+
+  type Case1[Fn, A]
+    = Case[Fn, A::HNil]
+
+  object Case1 {
+    type Aux[Fn, A, Result0]
+      = Case[Fn, A::HNil] { type Result = Result0 }
+
+    def apply
+      [Fn, A, Result0]
+      (fn: (A) => Result0)
+    : Aux[Fn, A, Result0] =
+      new Case[Fn, A::HNil] {
+        type Result = Result0
+        val value = (l: A::HNil)
+          => l match {
+            case a::HNil =>
+              fn(a)
+          }
+      }
+  }
+
+  trait PolyInst {
+    implicit def inst1
+      [A]
+      (fn : Poly)(implicit cse : fn.ProductCase[A::HNil])
+    : (A) => cse.Result =
+      (a:A)
+        => cse(a::HNil)
+  }
+
+  object Poly extends PolyInst {
+    implicit def inst0(p: Poly)(implicit cse : p.ProductCase[HNil]) : cse.Result = cse()
+  }
+
+  trait PolyApply {
+    def apply
+      [A]
+      (a:A)
+      (implicit cse : Case[this.type, A::HNil])
+    : cse.Result =
+      cse(a::HNil)
+  }
+
+  trait Poly extends PolyApply with Serializable {
+    /** The type of the case representing this polymorphic function at argument types `L`. */
+    type ProductCase[L <: HList] = Case[this.type, L]
+    object ProductCase extends Serializable {
+      /** The type of a case of this polymorphic function of the form `L => R` */
+      type Aux[L <: HList, Result0] = ProductCase[L] { type Result = Result0 }
+
+      /** The type of a case of this polymorphic function of the form `T => T` */
+      type Hom[T] = Aux[T :: HNil, T]
+
+      def apply[L <: HList, R](v : L => R) = new ProductCase[L] {
+        type Result = R
+        val value = v
+      }
+    }
+  }
+
+  trait Poly1 extends Poly { outer =>
+    type Case[A]
+      = shapeless.Case[this.type, A::HNil]
+
+    object Case {
+      type Aux[A, Result0]
+        = shapeless.Case[outer.type, A::HNil] { type Result = Result0 }
+    }
+
+    class CaseBuilder[A] {
+      def apply[Res]
+        (fn: (A) => Res) = new Case[A] {
+        type Result = Res
+        val value = (l: A::HNil)
+          => l match { case a::HNil => fn(a) }
+      }
+    }
+
+    def at[A]
+      = new CaseBuilder[A]
+  }
+
+  trait FlatMapper[HF, In <: HList] {
+    type Out <: HList
+    def apply(l: In): Out
+  }
+
+  object FlatMapper {
+    def apply[F, L <: HList](implicit mapper: FlatMapper[F, L]): Aux[F, L, mapper.Out] = mapper
+
+    type Aux[HF, In <: HList, Out0 <: HList] = FlatMapper[HF, In] { type Out = Out0 }
+
+    implicit def hnilFlatMapper1[HF]: Aux[HF, HNil, HNil] =
+      new FlatMapper[HF, HNil] {
+        type Out = HNil
+        def apply(l : HNil): Out = HNil
+      }
+
+    implicit def hlistFlatMapper1[HF, InH, OutH <: HList, InT <: HList, OutT <: HList, Out0 <: HList]
+      (implicit
+        hc : Case1.Aux[HF, InH, OutH],
+        mt : FlatMapper.Aux[HF, InT, OutT],
+        prepend : Prepend.Aux[OutH, OutT, Out0]
+      ): Aux[HF, InH :: InT, Out0] =
+        new FlatMapper[HF, InH :: InT] {
+          type Out = Out0
+          def apply(l : InH :: InT): Out = prepend(hc(l.head), mt(l.tail))
+        }
+  }
+}
+
+object FlattenExample {
+  import shapeless._
+
+  trait LowPriorityFlatten extends Poly1 {
+    implicit def default = at[Int](_ :: HNil)
+  }
+  object flatten extends LowPriorityFlatten {
+    implicit def caseTuple[L <: HList](implicit lfm: FlatMapper[flatten.type, L]) =
+      at[L](lfm(_))
+  }
+
+  val t1 = (2 :: HNil) :: 4 :: HNil
+  val f1 = flatten(t1)
+  val f2: Int :: Int :: HNil = f1
+}

--- a/test/files/pos/inductive-implicits6.flags
+++ b/test/files/pos/inductive-implicits6.flags
@@ -1,0 +1,1 @@
+-Yinduction-heuristics

--- a/test/files/pos/inductive-implicits6.scala
+++ b/test/files/pos/inductive-implicits6.scala
@@ -1,0 +1,49 @@
+object shapeless {
+  sealed trait HList extends Product with Serializable
+
+  final case class ::[+H, +T <: HList](head : H, tail : T) extends HList {
+    def ::[HH](h : HH) : HH :: H :: T = shapeless.::(h, this)
+
+    override def toString = head match {
+      case _: ::[_, _] => "("+head.toString+") :: "+tail.toString
+      case _ => head.toString+" :: "+tail.toString
+    }
+  }
+
+  sealed trait HNil extends HList {
+    def ::[H](h : H) = shapeless.::(h, this)
+    override def toString = "HNil"
+  }
+
+  case object HNil extends HNil
+
+  final class HListOps[L <: HList](l : L) {
+    def ::[H](h : H) : H :: L = shapeless.::(h, l)
+  }
+
+  object HList {
+    implicit def hlistOps[L <: HList](l: L): HListOps[L] = new HListOps(l)
+  }
+
+  trait ~>[F[_], G[_]]
+
+  trait NatTRel[L1 <: HList, F1[_], L2 <: HList, F2[_]] extends Serializable {
+    def map(nt: F1 ~> F2, fa: L1): L2
+  }
+
+  object NatTRel {
+    def apply[L1 <: HList, F1[_], L2 <: HList, F2[_]](implicit natTRel: NatTRel[L1, F1, L2, F2]) = natTRel
+
+    implicit def hnilNatTRel1[F1[_], F2[_]] = new NatTRel[HNil, F1, HNil, F2] {
+      def map(f: F1 ~> F2, fa: HNil): HNil = HNil
+    }
+
+    implicit def hlistNatTRel1[H, F1[_], F2[_], T1 <: HList, T2 <: HList](implicit nt : NatTRel[T1, F1, T2, F2]) =
+      new NatTRel[F1[H] :: T1, F1, F2[H] :: T2, F2] {
+        def map(f: F1 ~> F2, fa: F1[H] :: T1): F2[H] :: T2 = ???
+      }
+  }
+
+  type N = Nothing
+  implicitly[NatTRel[Option[N] :: HNil, Option, List[N] :: HNil, List]]
+}

--- a/test/files/run/inductive-implicits4/Macros_1.scala
+++ b/test/files/run/inductive-implicits4/Macros_1.scala
@@ -1,0 +1,67 @@
+import scala.language.experimental.macros
+import scala.reflect.macros.whitebox
+
+package object shapeless {
+  def cachedImplicit[T]: T = macro CachedImplicitMacros.cachedImplicitImpl[T]
+}
+
+package shapeless {
+  class CachedImplicitMacros(val c: whitebox.Context) {
+    import c.universe._
+
+    def cachedImplicitImpl[T](implicit tTag: WeakTypeTag[T]): Tree = {
+      val casted = c.asInstanceOf[reflect.macros.runtime.Context]
+      val typer = casted.callsiteTyper
+      val global: casted.universe.type = casted.universe
+      val analyzer: global.analyzer.type = global.analyzer
+      val tCtx = typer.context
+      val owner = tCtx.owner
+      if(!owner.isVal && !owner.isLazy)
+        c.abort(c.enclosingPosition, "cachedImplicit should only be used to initialize vals and lazy vals")
+      val tTpe = weakTypeOf[T]
+      val application = casted.macroApplication
+      val tpe = {
+        val tpe0 =
+          if (tTpe.typeSymbol.isParameter) owner.tpe.asInstanceOf[Type]
+          else tTpe
+        tpe0.finalResultType
+      }.asInstanceOf[global.Type]
+
+      // Run our own custom implicit search that isn't allowed to find
+      // the thing we are enclosed in
+      val sCtx = tCtx.makeImplicit(false)
+      val is = new analyzer.ImplicitSearch(
+        tree = application,
+        pt = tpe,
+        isView = false,
+        context0 = sCtx,
+        pos0 = c.enclosingPosition.asInstanceOf[global.Position]
+      ) {
+        override def searchImplicit(
+          implicitInfoss: List[List[analyzer.ImplicitInfo]],
+          isLocalToCallsite: Boolean
+        ): analyzer.SearchResult = {
+          val filteredInput = implicitInfoss.map { infos =>
+            infos.filter { info =>
+              val sym = if(info.sym.isLazy) info.sym else info.sym.accessedOrSelf
+              sym.owner != owner.owner || (!sym.isVal && !sym.isLazy)
+            }
+          }
+          super.searchImplicit(filteredInput, isLocalToCallsite)
+        }
+      }
+      val best = is.bestImplicit
+      if (best.isFailure) {
+        val errorMsg = tpe.typeSymbolDirect match {
+          case analyzer.ImplicitNotFoundMsg(msg) =>
+            msg.format(TermName("evidence").asInstanceOf[global.TermName], tpe)
+          case _ =>
+            s"Could not find an implicit value of type $tpe to cache"
+        }
+        c.abort(c.enclosingPosition, errorMsg)
+      } else {
+        best.tree.asInstanceOf[Tree]
+      }
+    }
+  }
+}

--- a/test/files/run/inductive-implicits4/Test_2.flags
+++ b/test/files/run/inductive-implicits4/Test_2.flags
@@ -1,0 +1,1 @@
+-Yinduction-heuristics

--- a/test/files/run/inductive-implicits4/Test_2.scala
+++ b/test/files/run/inductive-implicits4/Test_2.scala
@@ -1,0 +1,38 @@
+package shapeless {
+
+class Defns {
+  trait G[T] { type Repr }
+  object G {
+    type Aux[T, R] = G[T] { type Repr = R }
+    def apply[T](implicit gen: G[T]): Aux[T, gen.Repr] = gen
+    implicit def g[T]: Aux[T, Int] = new G[T] { type Repr = Int }
+  }
+
+  trait LG[T] { type Repr }
+  object LG {
+    type Aux[T, R] = LG[T] { type Repr = R }
+    implicit def lg[T]: Aux[T, Int] = new LG[T] { type Repr = Int }
+  }
+
+  case class Quux2(i: Int, s: String)
+  object Quux2 {
+    val gen0 = cachedImplicit[G[Quux2]]
+    implicit val gen: G.Aux[Quux2, gen0.Repr] = gen0
+
+    val lgen0 = cachedImplicit[LG[Quux2]]
+    implicit val lgen: LG.Aux[Quux2, lgen0.Repr] = lgen0
+  }
+
+  def testRefined2 {
+    assert(Quux2.gen != null)
+    assert(Quux2.gen eq Quux2.gen0)
+
+    val gen = G[Quux2]
+    assert(gen eq Quux2.gen0)
+  }
+}
+}
+
+object Test extends App {
+  (new shapeless.Defns).testRefined2
+}

--- a/test/induction/inductive-implicits-bench.scala
+++ b/test/induction/inductive-implicits-bench.scala
@@ -1,0 +1,619 @@
+// Compiled with ./build/pack/bin/scalac -J-Xss4M -J-Xmx2G test/files/pos/inductive-implicits.scala
+//
+// 1: baseline - scalac 2.12.x
+// 2: + -Yinduction-heuristics
+//
+//              (1)   (2)
+// HList Size
+//  50           4     3
+// 100          10     3
+// 150          19     4
+// 200          38     5
+// 250          66     5
+// 300          98     6
+// 350         155     7
+// 400         218     8
+// 450         238     9
+// 500         438    12
+//
+//            Compile time in seconds
+
+package shapeless {
+  sealed trait HList extends Product with Serializable
+
+  final case class ::[+H, +T <: HList](head : H, tail : T) extends HList {
+    def ::[HH](h : HH) : HH :: H :: T = shapeless.::(h, this)
+
+    override def toString = head match {
+      case _: ::[_, _] => "("+head.toString+") :: "+tail.toString
+      case _ => head.toString+" :: "+tail.toString
+    }
+  }
+
+  sealed trait HNil extends HList {
+    def ::[H](h : H) = shapeless.::(h, this)
+    override def toString = "HNil"
+  }
+
+  case object HNil extends HNil
+
+  @annotation.inductive
+  trait Selector[L <: HList, U] {
+    def apply(l: L): U
+  }
+
+  object Selector {
+    def apply[L <: HList, U](implicit selector: Selector[L, U]): Selector[L, U] = selector
+
+    implicit def inHead[H, T <: HList]: Selector[H :: T, H] =
+      new Selector[H :: T, H] {
+        def apply(l : H :: T) = l.head
+      }
+
+    implicit def inTail[H, T <: HList, U]
+      (implicit st : Selector[T, U]): Selector[H :: T, U] =
+        new Selector[H :: T, U] {
+          def apply(l : H :: T) = st(l.tail)
+        }
+  }
+}
+
+import shapeless._
+
+object Test extends App {
+  val sel = Selector[L, Boolean]
+
+  type L =
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+    Int ::
+//
+    Boolean ::
+    HNil
+}

--- a/test/induction/inductive.sh
+++ b/test/induction/inductive.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mkdir -p target/induction
+time build/pack/bin/scalac -Yinduction-heuristics -J-Xss4M -J-Xmx2G -d target/induction test/induction/inductive-implicits-bench.scala

--- a/test/induction/vanilla.sh
+++ b/test/induction/vanilla.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mkdir -p target/induction
+time build/pack/bin/scalac -J-Xss4M -J-Xmx2G -d target/induction test/induction/inductive-implicits-bench.scala


### PR DESCRIPTION
This PR provides much faster (35 x in the provided benchmark case) compilation of the kind of inductive implicit resolution that is found in shapeless and its uses for type class derivation in libraries such as Circe, Doobie and Scodec. I will follow up with a PR for a backport of this to 2.11.x later today.

The method is to spot patterns in the set of eligible implicit definitions for an implicit argument of the form `F[A, B, C ...]` corresponding to a singly recursive, convergent (to either success or failure) induction. When these hold the induction is solved for directly by unfolding the recursive steps until one of the base cases is reached. The patterns are a little conservative (in the sense that some inductions might be missed), but they cover many important cases, in particular most of the interesting inductions in shapeless are handled.

The strategy is enabled by the `-Yinduction-heuristics` scalac flag. If it isn't enabled then normal implicit resolution is always performed. If it is enabled, then the inductive strategy is applied where possible. If it cannot be applied implicit resolution falls back to the normal mechanism. In all cases it is intended that the semantics are identical to normal implicit resolution: the only effect of enabling this option should be a reduction in compile times for applicable implicit resolutions.

An `@inductive` annotation for types is provided with a similar intent to `@tailrec`. It asserts that implicit instances of types with the annotation are expected to be solved for by the new induction mechanism. It is an error if they are not and they are instead solved by the normal mechanism. Note that the annotation does not change semantics in the success case (it does change semantics in the failure case because an error is reported). Nor does it affect which algorithm is used to resolve implicits: it is simply a post hoc check that the expected solver was used successfully, in the same way that `@tailrec` is a post hoc check that an expected tail call optimization was performed.

The use of `@inductive` allows more informative error messages to be generated for inductions which fail due to missing implicit instances of types which are auxiliary to the main induction. For example, in the case of shapeless's `Mapper` type class (which recurses through an `HList` applying an auxiliary type class instance specific to the type of each element as it goes), with normal implicit search if any instance of the auxiliary type class is missing the error reported will be just that the overall `Mapper` instance can't be resolved. With this algorithm, and in the presence of the `@inductive` annotation, the compiler knows that an induction is being performed and is able to report that an induction has failed due to the absence of the specific auxiliary type class instance. This is a much requested feature by the authors and users of libraries based on shapeless type class derivation. See `test/files/neg/inductive-implicts.{scala,flags,check}` for an example.

One limitation that people using inductive implicits now where the induction step is wrapped in shapeless's `Lazy` will notice is that these will not take advantage of this algorithm. In some cases it may be possible to drop the use of `Lazy`, though not all. I intend to follow this PR with another which provides an interpretation of byname implicit arguments which is equivalent to shapeless's `Lazy` and which will get along nicely with this induction heuristic.

All (par)tests pass with this option forcibly enabled. In addition shapeless, Circe, Doobie and Scodec, which make extensive use of these forms of induction, all compile and test successfully. A benchmark is provided in `test/files/induction` which validates my performance claims.