### PR TITLE
SI-10154 Fix implicit search regression for term-owned objects

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1194,7 +1194,8 @@ trait Contexts { self: Analyzer =>
     }
 
     final def lookupCompanionOf(original: Symbol): Symbol = {
-      lookupScopeEntry(original) match {
+      if (original.isModuleClass) original.sourceModule
+      else lookupScopeEntry(original) match {
         case null => NoSymbol
         case entry => entry.owner.lookupCompanion(original)
       }

--- a/test/files/pos/t10154.scala
+++ b/test/files/pos/t10154.scala
@@ -1,0 +1,11 @@
+trait Bar2[T]
+
+object Test2 {
+  def wrap {
+    object Foo {
+      implicit def fooBar: Bar2[Foo.type] = ???
+    }
+
+    implicitly[Bar2[Foo.type]]
+  }
+}

--- a/test/files/pos/t10154b.scala
+++ b/test/files/pos/t10154b.scala
@@ -1,0 +1,16 @@
+ import scala.language.existentials
+
+ class Bar[T]
+ class Test {
+  def method = {
+    object Foo {
+      implicit def x: Bar[Foo.type] = new Bar[Foo.type]
+    }
+    type T = Foo.type
+
+    {
+      object Foo
+      implicitly[Bar[T]]
+    }
+  }
+}


### PR DESCRIPTION
A recent change  to fix lookup of companion implicits of term-owned
classes (#5550) caused a regression in the enclosed test case. The
previous approach of calling `Scope#lookup(companionName)` was
replaced by a lookup of the scope entry of the original name followed
by a narrower search lookup for the companion name, to ensure
that it was a true companion, and not just a same-named module
from defined at a different nested scope.

However, module class symbols are not themselves entered into
scopes, so the first part of the new scheme fails. We need to
add a special case modules here.

I've chosen to just call `.sourceModule` on module classes.
For module classes in the current run (all term owned symbols
will fall into this category), this amounts to using the value
of the field `ModuleClassSymbol#module`.

JIRA: https://issues.scala-lang.org/browse/SI-10154