### PR TITLE
SI-10102 REPL ignores sbt init errors

### DIFF
--- a/src/repl/scala/tools/nsc/InterpreterLoop.scala
+++ b/src/repl/scala/tools/nsc/InterpreterLoop.scala
@@ -3,10 +3,15 @@ package scala.tools.nsc
 import interpreter._
 import java.io._
 
-/** A compatibility stub.
+/** A compatibility stub for sbt.
  */
-@deprecated("Use a class in the scala.tools.nsc.interpreter package.", "2.9.0")
+@deprecated("Use scala.tools.nsc.interpreter.ILoop.", "2.9.0")
 class InterpreterLoop(in0: Option[BufferedReader], out: PrintWriter) extends ILoop(in0, out) {
   def this(in0: BufferedReader, out: PrintWriter) = this(Some(in0), out)
   def this() = this(None, new PrintWriter(scala.Console.out))
+
+  override protected final val isSbt = true
+
+  @deprecated("use `process` instead", "2.9.0")
+  def main(settings: Settings): Unit = process(settings) //used by sbt
 }

--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -41,10 +41,7 @@ import Completion._
  *  @author  Lex Spoon
  *  @version 1.2
  */
-class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
-                extends AnyRef
-                   with LoopCommands
-{
+class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter) extends LoopCommands {
   def this(in0: BufferedReader, out: JPrintWriter) = this(Some(in0), out)
   def this() = this(None, new JPrintWriter(Console.out, true))
 
@@ -56,6 +53,9 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
   var intp: IMain = _
 
   private var globalFuture: Future[Boolean] = _
+
+  // ignore silent sbt errors on init
+  protected def isSbt: Boolean = false
 
   /** Print a welcome message! */
   def printWelcome(): Unit = {
@@ -988,15 +988,15 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
           createInterpreter()
         }
         intp.initializeSynchronous()
-        globalFuture = Future successful true
-        if (intp.reporter.hasErrors) {
+        globalFuture = Future.successful(true)
+        if (intp.reporter.hasErrors && (!isSbt || intp.reporter.hasReportableErrors)) {
           echo("Interpreter encountered errors during initialization!")
           null
         } else {
           loopPostInit()
           val line = splash.line           // what they typed in while they were waiting
           if (line == null) {              // they ^D
-            try out print Properties.shellInterruptedString
+            try out.print(Properties.shellInterruptedString)
             finally closeInterpreter()
           }
           line
@@ -1016,9 +1016,6 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
         true
     }
   }
-
-  @deprecated("use `process` instead", "2.9.0")
-  def main(settings: Settings): Unit = process(settings) //used by sbt
 }
 
 object ILoop {

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -130,7 +130,7 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
     catch AbstractOrMissingHandler()
   }
   private val logScope = scala.sys.props contains "scala.repl.scope"
-  private def scopelog(msg: String) = if (logScope) Console.err.println(msg)
+  private def scopelog(msg: => String) = if (logScope) Console.err.println(msg)
 
   // argument is a thunk to execute after init is done
   def initialize(postInitSignal: => Unit) {
@@ -373,24 +373,25 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
     None
   }
 
-  private def updateReplScope(sym: Symbol, isDefined: Boolean) {
-    def log(what: String) {
+  private def updateReplScope(sym: Symbol, isDefined: Boolean): Unit = {
+    def log(what: String) = scopelog {
       val mark = if (sym.isType) "t " else "v "
       val name = exitingTyper(sym.nameString)
       val info = cleanTypeAfterTyper(sym)
       val defn = sym defStringSeenAs info
 
-      scopelog(f"[$mark$what%6s] $name%-25s $defn%s")
+      f"[$mark$what%6s] $name%-25s $defn%s"
     }
-    if (ObjectClass isSubClass sym.owner) return
-    // unlink previous
-    replScope lookupAll sym.name foreach { sym =>
-      log("unlink")
-      replScope unlink sym
+    if (!ObjectClass.isSubClass(sym.owner)) {
+      // unlink previous
+      replScope.lookupAll(sym.name) foreach { sym =>
+        log("unlink")
+        replScope unlink sym
+      }
+      val what = if (isDefined) "define" else "import"
+      log(what)
+      replScope enter sym
     }
-    val what = if (isDefined) "define" else "import"
-    log(what)
-    replScope enter sym
   }
 
   def recordRequest(req: Request) {


### PR DESCRIPTION
sbt runs user init code early, while creating its
custom `IMain`. Failures in this (arbitrary) code
keep the console from starting, including (silent)
errors due to bugs. Ignore silent errors emitted
on startup when sbt is running.