### PR TITLE
SI-8521 ScalaClassLoader.asContext saves context

### DIFF
--- a/src/reflect/scala/reflect/internal/util/ScalaClassLoader.scala
+++ b/src/reflect/scala/reflect/internal/util/ScalaClassLoader.scala
@@ -8,15 +8,14 @@ package reflect.internal.util
 
 import scala.language.implicitConversions
 
-import java.lang.{ ClassLoader => JClassLoader }
+import java.lang.{ClassLoader => JClassLoader}
 import java.lang.reflect.Modifier
-import java.net.{ URLClassLoader => JURLClassLoader }
+import java.net.{URLClassLoader => JURLClassLoader}
 import java.net.URL
 
-import scala.reflect.runtime.ReflectionUtils.{ show, unwrapHandler }
-import ScalaClassLoader._
-import scala.util.control.Exception.{ catching }
-import scala.reflect.{ ClassTag, classTag }
+import scala.reflect.runtime.ReflectionUtils.{show, unwrapHandler}
+import scala.util.control.Exception.catching
+import scala.reflect.{ClassTag, classTag}
 
 trait HasClassPath {
   def classPathURLs: Seq[URL]
@@ -28,11 +27,12 @@ trait HasClassPath {
 trait ScalaClassLoader extends JClassLoader {
   /** Executing an action with this classloader as context classloader */
   def asContext[T](action: => T): T = {
+    import ScalaClassLoader.setContext
+
     val saved = Thread.currentThread.getContextClassLoader
     try { setContext(this) ; action }
     finally setContext(saved)
   }
-  def setAsContext() { setContext(this) }
 
   /** Load and link a class with this classloader */
   def tryToLoadClass[T <: AnyRef](path: String): Option[Class[T]] = tryClass(path, initialize = false)
@@ -118,13 +118,8 @@ object ScalaClassLoader {
   }
   def contextLoader = apply(Thread.currentThread.getContextClassLoader)
   def appLoader     = apply(JClassLoader.getSystemClassLoader)
-  def setContext(cl: JClassLoader) =
-    Thread.currentThread.setContextClassLoader(cl)
-  def savingContextLoader[T](body: => T): T = {
-    val saved = contextLoader
-    try body
-    finally setContext(saved)
-  }
+
+  def setContext(cl: JClassLoader) = Thread.currentThread.setContextClassLoader(cl)
 
   class URLClassLoader(urls: Seq[URL], parent: JClassLoader)
       extends JURLClassLoader(urls.toArray, parent)

--- a/src/reflect/scala/reflect/internal/util/ScalaClassLoader.scala
+++ b/src/reflect/scala/reflect/internal/util/ScalaClassLoader.scala
@@ -28,7 +28,7 @@ trait HasClassPath {
 trait ScalaClassLoader extends JClassLoader {
   /** Executing an action with this classloader as context classloader */
   def asContext[T](action: => T): T = {
-    val saved = contextLoader
+    val saved = Thread.currentThread.getContextClassLoader
     try { setContext(this) ; action }
     finally setContext(saved)
   }

--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -17,7 +17,6 @@ import scala.util.Properties.jdkHome
 import scala.tools.nsc.util.{ClassPath, stringFromStream}
 import scala.reflect.classTag
 import scala.reflect.internal.util.{BatchSourceFile, ScalaClassLoader, NoPosition}
-import ScalaClassLoader._
 import scala.reflect.io.{Directory, File, Path}
 import scala.tools.util._
 import io.AbstractFile
@@ -946,8 +945,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter) extend
   /** Start an interpreter with the given settings.
    *  @return true if successful
    */
-  def process(settings: Settings): Boolean = savingContextLoader {
-
+  def process(settings: Settings): Boolean = {
     // yes this is sad
     val runnerSettings = settings match {
       case generic: GenericRunnerSettings => Some(generic)

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -357,8 +357,7 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
       _runtimeClassLoader
     })
 
-  // Set the current Java "context" class loader to this interpreter's class loader
-  def setContextClassLoader() = classLoader.setAsContext()
+  def setContextClassLoader() = ()
 
   def allDefinedNames: List[Name]  = exitingTyper(replScope.toList.map(_.name).sorted)
   def unqualifiedIds: List[String] = allDefinedNames map (_.decode) sorted

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -156,9 +156,9 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
   }
 
   import global._
-  import definitions.{ ObjectClass, termMember, dropNullaryMethod}
+  import definitions.{ObjectClass, termMember, dropNullaryMethod}
 
-  lazy val runtimeMirror = ru.runtimeMirror(classLoader)
+  def runtimeMirror = ru.runtimeMirror(classLoader)
 
   private def noFatal(body: => Symbol): Symbol = try body catch { case _: FatalError => NoSymbol }
 
@@ -357,7 +357,8 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
       _runtimeClassLoader
     })
 
-  def setContextClassLoader() = ()
+  @deprecated("The thread context classloader is now set and restored around execution of REPL line, this method is now a no-op.", since = "2.12.0")
+  def setContextClassLoader() = () // Called from sbt-interface/0.12.4/src/ConsoleInterface.scala:39
 
   def allDefinedNames: List[Name]  = exitingTyper(replScope.toList.map(_.name).sorted)
   def unqualifiedIds: List[String] = allDefinedNames map (_.decode) sorted
@@ -1037,14 +1038,15 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
   // Given the fullName of the symbol, reflectively drill down the path
   def valueOfTerm(id: String): Option[Any] = {
     def value(fullName: String) = {
-      import runtimeMirror.universe.{Symbol, InstanceMirror, TermName}
+      val mirror = runtimeMirror
+      import mirror.universe.{Symbol, InstanceMirror, TermName}
       val pkg :: rest = (fullName split '.').toList
-      val top = runtimeMirror.staticPackage(pkg)
+      val top = mirror.staticPackage(pkg)
       @annotation.tailrec
       def loop(inst: InstanceMirror, cur: Symbol, path: List[String]): Option[Any] = {
         def mirrored =
           if (inst != null) inst
-          else runtimeMirror.reflect((runtimeMirror reflectModule cur.asModule).instance)
+          else mirror.reflect((mirror reflectModule cur.asModule).instance)
 
         path match {
           case last :: Nil  =>
@@ -1056,10 +1058,10 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
             val i =
               if (s.isModule) {
                 if (inst == null) null
-                else runtimeMirror.reflect((inst reflectModule s.asModule).instance)
+                else mirror.reflect((inst reflectModule s.asModule).instance)
               }
               else if (s.isAccessor) {
-                runtimeMirror.reflect(mirrored.reflectMethod(s.asMethod).apply())
+                mirror.reflect(mirrored.reflectMethod(s.asMethod).apply())
               }
               else {
                 assert(false, originalPath(s))

--- a/test/junit/scala/tools/nsc/interpreter/ScriptedTest.scala
+++ b/test/junit/scala/tools/nsc/interpreter/ScriptedTest.scala
@@ -112,4 +112,17 @@ class ScriptedTest {
       Thread.currentThread.setContextClassLoader(saved0)
     }
   }
+  @Test def `restore classloader script api`(): Unit = {
+    val saved0 = Thread.currentThread.getContextClassLoader
+    try {
+      Thread.currentThread.setContextClassLoader(ClassLoader.getSystemClassLoader)
+      val saved = Thread.currentThread.getContextClassLoader
+      val engine = new ScriptEngineManager().getEngineByName("scala")
+      assertNotNull(engine)
+      val now = Thread.currentThread.getContextClassLoader
+      assert(saved eq now)
+    } finally {
+      Thread.currentThread.setContextClassLoader(saved0)
+    }
+  }
 }

--- a/test/junit/scala/tools/nsc/interpreter/ScriptedTest.scala
+++ b/test/junit/scala/tools/nsc/interpreter/ScriptedTest.scala
@@ -99,4 +99,17 @@ class ScriptedTest {
     val err = "not found: value foo in def f = foo at line number 11 at column number 9"
     assertThrows[ScriptException](engine.compile("def f = foo"), _ == err)
   }
+  @Test def `restore classloader`(): Unit = {
+    val saved0 = Thread.currentThread.getContextClassLoader
+    try {
+      Thread.currentThread.setContextClassLoader(ClassLoader.getSystemClassLoader)
+      val saved = Thread.currentThread.getContextClassLoader
+      val engine = scripted
+      scripted.eval("42")
+      val now = Thread.currentThread.getContextClassLoader
+      assert(saved eq now)
+    } finally {
+      Thread.currentThread.setContextClassLoader(saved0)
+    }
+  }
 }


### PR DESCRIPTION
It saves the actual current thread context loader,
not the loader it might biasedly prefer to have.

REPL uses asContext to preserve context, which broke
if the current loader didn't happen to be a
ScalaClassLoader.