### PR TITLE
SI-9464 Clarify spec on no final trait

### DIFF
--- a/spec/05-classes-and-objects.md
+++ b/spec/05-classes-and-objects.md
@@ -597,10 +597,12 @@ overridden in subclasses. A `final` class may not be inherited by
 a template. `final` is redundant for object definitions.  Members
 of final classes or objects are implicitly also final, so the
 `final` modifier is generally redundant for them, too. Note, however, that
-[constant value definitions](04-basic-declarations-and-definitions.html#value-declarations-and-definitions) do require
-an explicit `final` modifier, even if they are defined in a final class or
-object. `final` may not be applied to incomplete members, and it may not be
-combined in one modifier list with `sealed`.
+[constant value definitions](04-basic-declarations-and-definitions.html#value-declarations-and-definitions)
+do require an explicit `final` modifier,
+even if they are defined in a final class or object.
+`final` is permitted for abstract classes
+but it may not be applied to traits or incomplete members,
+and it may not be combined in one modifier list with `sealed`.
 
 ### `sealed`
 The `sealed` modifier applies to class definitions. A


### PR DESCRIPTION
Without being too finicky with syntax,
say that `final abstract class` is OK
(even as a nested class, where it would
be an incomplete member) but not `final trait`.

Such a class might be a standard lib primitive,
or might be an implicit value that is only a
ludicrous marker and, if present, need only
have the null value.

JIRA: https://issues.scala-lang.org/browse/SI-9464