### PR TITLE
Address SI-9675 Add warning about non-sensible equals in anonymous functions

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1130,7 +1130,7 @@ abstract class RefChecks extends Transform {
     }
     /** Sensibility check examines flavors of equals. */
     def checkSensible(pos: Position, fn: Tree, args: List[Tree]) = fn match {
-      case Select(qual, name @ (nme.EQ | nme.NE | nme.eq | nme.ne)) if args.length == 1 && isObjectOrAnyComparisonMethod(fn.symbol) && !currentOwner.isSynthetic =>
+      case Select(qual, name @ (nme.EQ | nme.NE | nme.eq | nme.ne)) if args.length == 1 && isObjectOrAnyComparisonMethod(fn.symbol) && (!currentOwner.isSynthetic || currentOwner.isAnonymousFunction) =>
         checkSensibleEquals(pos, qual, name, fn.symbol, args.head)
       case _ =>
     }

--- a/test/files/neg/t9675.check
+++ b/test/files/neg/t9675.check
@@ -1,0 +1,27 @@
+t9675.scala:4: warning: comparing values of types Test.A and String using `!=' will always yield true
+  val func1 = (x: A) => { x != "x" }
+                            ^
+t9675.scala:6: warning: comparing values of types Test.A and String using `!=' will always yield true
+  val func2  = (x: A) => { x != "x" }: Boolean
+                             ^
+t9675.scala:8: warning: comparing values of types Test.A and String using `!=' will always yield true
+  val func3: Function1[A, Boolean] = (x) => { x != "x" }
+                                                ^
+t9675.scala:11: warning: comparing values of types Test.A and String using `!=' will always yield true
+    def apply(x: A): Boolean = { x != "x" }
+                                   ^
+t9675.scala:14: warning: comparing values of types Test.A and String using `!=' will always yield true
+  def method(x: A): Boolean = { x != "x" }
+                                  ^
+t9675.scala:18: warning: comparing values of types Test.A and String using `!=' will always yield true
+    A("x") != "x"
+           ^
+t9675.scala:20: warning: comparing values of types Test.A and String using `!=' will always yield true
+    val func5: Function1[A, Boolean] = (x) => { x != "x" }
+                                                  ^
+t9675.scala:22: warning: comparing values of types Test.A and String using `!=' will always yield true
+    List(A("x")).foreach((item: A) => item != "x")
+                                           ^
+error: No warnings can be incurred under -Xfatal-warnings.
+8 warnings found
+one error found

--- a/test/files/neg/t9675.flags
+++ b/test/files/neg/t9675.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/t9675.scala
+++ b/test/files/neg/t9675.scala
@@ -1,0 +1,24 @@
+object Test {
+  case class A(x: String)
+
+  val func1 = (x: A) => { x != "x" }
+
+  val func2  = (x: A) => { x != "x" }: Boolean
+
+  val func3: Function1[A, Boolean] = (x) => { x != "x" }
+
+  val func4 = new Function1[A, Boolean] {
+    def apply(x: A): Boolean = { x != "x" }
+  }
+
+  def method(x: A): Boolean = { x != "x" }
+  case class PersonInfo(rankPayEtc: Unit)
+
+  def main(args: Array[String]) {
+    A("x") != "x"
+
+    val func5: Function1[A, Boolean] = (x) => { x != "x" }
+
+    List(A("x")).foreach((item: A) => item != "x")
+  }
+}


### PR DESCRIPTION
The problem was that in an attempt to address an issue with #4473, warnings about non-sensible equals were removed for synthetic entities. But an anonymous function is also a synthetic entity, so warnings were removed for these too by mistake.