### PR TITLE
SD-256 enable colored output by default on unix

### DIFF
--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -423,6 +423,14 @@ filter {
     {
       matchName="scala.annotation.showAsInfix"
       problemName=MissingClassProblem
+    },
+    {
+      matchName="scala.util.PropertiesTrait.coloredOutputEnabled"
+      problemName=DirectMissingMethodProblem
+    },
+    {
+      matchName="scala.util.Properties.coloredOutputEnabled"
+      problemName=DirectMissingMethodProblem
     }
   ]
 }

--- a/src/library/scala/util/Properties.scala
+++ b/src/library/scala/util/Properties.scala
@@ -154,6 +154,12 @@ private[scala] trait PropertiesTrait {
   /* Some runtime values. */
   private[scala] def isAvian = javaVmName contains "Avian"
 
+  private[scala] def coloredOutputEnabled: Boolean = propOrElse("scala.color", "auto") match {
+    case "auto" => System.console() != null && !isWin
+    case a if a.toLowerCase() == "true" => true
+    case _ => false
+  }
+
   // This is looking for javac, tools.jar, etc.
   // Tries JDK_HOME first, then the more common but likely jre JAVA_HOME,
   // and finally the system property based javaHome.

--- a/src/reflect/scala/reflect/internal/TypeDebugging.scala
+++ b/src/reflect/scala/reflect/internal/TypeDebugging.scala
@@ -59,7 +59,7 @@ trait TypeDebugging {
   object typeDebug {
     import scala.Console._
 
-    private val colorsOk = sys.props contains "scala.color"
+    private val colorsOk = scala.util.Properties.coloredOutputEnabled
     private def inColor(s: String, color: String) = if (colorsOk && s != "") color +        s + RESET else s
     private def inBold(s: String, color: String)  = if (colorsOk && s != "") color + BOLD + s + RESET else s
 

--- a/src/repl/scala/tools/nsc/interpreter/ReplProps.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplProps.scala
@@ -17,7 +17,7 @@ class ReplProps {
   private def int(name: String)  = Prop[Int](name)
 
   // This property is used in TypeDebugging. Let's recycle it.
-  val colorOk = bool("scala.color")
+  val colorOk = Properties.coloredOutputEnabled
 
   val info  = bool("scala.repl.info")
   val debug = bool("scala.repl.debug")


### PR DESCRIPTION
This enables `-Dscala.color` by default when running via the shell
script and when stdout is a terminal.

Can be overriden on the CLI or via `JAVA_OPTS`:

```sh
$ qbin/scala -nc -e 'println(util.Properties.propOrFalse("scala.color"))'
true
$ qbin/scala -nc -e 'println(util.Properties.propOrFalse("scala.color"))' | cat
false
$ qbin/scala -nc -Dscala.color=false -e 'println(util.Properties.propOrFalse("scala.color"))'
false
$ JAVA_OPTS="-Dscala.color=false" qbin/scala -nc -e 'println(util.Properties.propOrFalse("scala.color"))'
false
```