### PR TITLE
SI-9729 -Xmaxerrs to limit messages

### DIFF
--- a/src/compiler/scala/tools/nsc/reporters/ConsoleReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/ConsoleReporter.scala
@@ -20,6 +20,7 @@ class ConsoleReporter(val settings: Settings, reader: BufferedReader, writer: Pr
   var shortname: Boolean = false
 
   /** maximal number of error messages to be printed */
+  @deprecated("configured by settings.maxerrs", since="2.12.2")
   final val ERROR_LIMIT = 100
 
   private def label(severity: Severity): String = severity match {
@@ -63,9 +64,13 @@ class ConsoleReporter(val settings: Settings, reader: BufferedReader, writer: Pr
     if (  ERROR.count > 0) printMessage(getCountString(ERROR  ) + " found")
   }
 
-  def display(pos: Position, msg: String, severity: Severity) {
-    if (severity != ERROR || severity.count <= ERROR_LIMIT)
-      print(pos, msg, severity)
+  def display(pos: Position, msg: String, severity: Severity): Unit = {
+    val ok = severity match {
+      case ERROR   => ERROR.count <= settings.maxerrs.value
+      case WARNING => WARNING.count <= settings.maxwarns.value
+      case _     => true
+    }
+    if (ok) print(pos, msg, severity)
   }
 
   def displayPrompt(): Unit = {

--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -416,9 +416,9 @@ class MutableSettings(val errorFn: String => Unit)
     // Helper to generate a textual explanation of valid inputs
     private def getValidText: String = (min, max) match {
       case (IntMin, IntMax)   => "can be any integer"
-      case (IntMin, x)        => "must be less than or equal to "+x
-      case (x, IntMax)        => "must be greater than or equal to "+x
-      case _                  => "must be between %d and %d".format(min, max)
+      case (IntMin, x)        => f"must be less than or equal to $x%d"
+      case (x, IntMax)        => f"must be greater than or equal to $x%d"
+      case _                  => f"must be between $min%d and $max%d"
     }
 
     // Ensure that the default value is actually valid
@@ -431,7 +431,7 @@ class MutableSettings(val errorFn: String => Unit)
       }
     }
 
-    def errorMsg() = errorFn("invalid setting for -"+name+" "+getValidText)
+    def errorMsg() = errorFn(s"invalid setting for $name $getValidText")
 
     def tryToSet(args: List[String]) =
       if (args.isEmpty) errorAndValue("missing argument", None)
@@ -444,7 +444,7 @@ class MutableSettings(val errorFn: String => Unit)
       if (value == default) Nil
       else List(name, value.toString)
 
-    withHelpSyntax(name + " <n>")
+    withHelpSyntax(s"$name <n>")
   }
 
   /** A setting represented by a boolean flag (false, unless set) */

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -107,6 +107,8 @@ trait ScalaSettings extends AbsScalaSettings
   val logFreeTerms       = BooleanSetting      ("-Xlog-free-terms", "Print a message when reification creates a free term.")
   val logFreeTypes       = BooleanSetting      ("-Xlog-free-types", "Print a message when reification resorts to generating a free type.")
   val maxClassfileName   = IntSetting          ("-Xmax-classfile-name", "Maximum filename length for generated classes", 255, Some((72, 255)), _ => None)
+  val maxerrs            = IntSetting          ("-Xmaxerrs", "Maximum errors to print", 100, None, _ => None)
+  val maxwarns           = IntSetting          ("-Xmaxwarns", "Maximum warnings to print", 100, None, _ => None)
   val Xmigration         = ScalaVersionSetting ("-Xmigration", "version", "Warn about constructs whose behavior may have changed since version.", initial = NoScalaVersion, default = Some(AnyScalaVersion))
   val nouescape          = BooleanSetting      ("-Xno-uescape", "Disable handling of \\u unicode escapes.")
   val Xnojline           = BooleanSetting      ("-Xnojline", "Do not use JLine for editing.")

--- a/test/files/neg/maxerrs.check
+++ b/test/files/neg/maxerrs.check
@@ -1,0 +1,16 @@
+maxerrs.scala:22: error: type mismatch;
+ found   : String("")
+ required: Int
+  def F = f("")
+            ^
+maxerrs.scala:24: error: type mismatch;
+ found   : String("")
+ required: Int
+  def g = f("")
+            ^
+maxerrs.scala:26: error: type mismatch;
+ found   : String("")
+ required: Int
+  def h = f("")
+            ^
+5 errors found

--- a/test/files/neg/maxerrs.flags
+++ b/test/files/neg/maxerrs.flags
@@ -1,0 +1,1 @@
+-Xmaxerrs 3 -Xfatal-warnings -deprecation

--- a/test/files/neg/maxerrs.scala
+++ b/test/files/neg/maxerrs.scala
@@ -1,0 +1,32 @@
+
+object X {
+  @deprecated("just to annoy people", since="forever")
+  def x = 42
+
+  def f(i: Int) = i
+}
+
+trait T {
+  import X._
+
+  def a = x
+
+  def b = x
+
+  def c = x
+
+  def d = x
+
+  def e = x
+
+  def F = f("")
+
+  def g = f("")
+
+  def h = f("")
+
+  def i = f("")
+
+  def j = f("")
+}
+

--- a/test/files/neg/maxwarns.check
+++ b/test/files/neg/maxwarns.check
@@ -1,0 +1,12 @@
+maxwarns.scala:12: warning: method x in object X is deprecated (since forever): just to annoy people
+  def a = x
+          ^
+maxwarns.scala:14: warning: method x in object X is deprecated (since forever): just to annoy people
+  def b = x
+          ^
+maxwarns.scala:16: warning: method x in object X is deprecated (since forever): just to annoy people
+  def c = x
+          ^
+error: No warnings can be incurred under -Xfatal-warnings.
+5 warnings found
+one error found

--- a/test/files/neg/maxwarns.flags
+++ b/test/files/neg/maxwarns.flags
@@ -1,0 +1,1 @@
+-Xmaxwarns 3 -Xfatal-warnings -deprecation

--- a/test/files/neg/maxwarns.scala
+++ b/test/files/neg/maxwarns.scala
@@ -1,0 +1,32 @@
+
+object X {
+  @deprecated("just to annoy people", since="forever")
+  def x = 42
+
+  def f(i: String) = i
+}
+
+trait T {
+  import X._
+
+  def a = x
+
+  def b = x
+
+  def c = x
+
+  def d = x
+
+  def e = x
+
+  def F = f("")
+
+  def g = f("")
+
+  def h = f("")
+
+  def i = f("")
+
+  def j = f("")
+}
+


### PR DESCRIPTION
Since 2.7.2, console reporter has limited error messages to
a fixed 100. Use `-Xmaxerrs -Xmaxwarns` as from `javac` to configure.