### PR TITLE
Make partest --grep glob paths, not just filenames

### DIFF
--- a/project/PartestUtil.scala
+++ b/project/PartestUtil.scala
@@ -64,9 +64,9 @@ object PartestUtil {
         }
         val matchingFileName = try {
           val filter = GlobFilter("*" + x + "*")
-          testFiles.allTestCases.filter(x => filter.accept(x._1.name))
+          testFiles.allTestCases.filter(x => filter.accept(x._1.asFile.getPath))
         } catch {
-          case t: Throwable => Nil
+          case _: Throwable => Nil
         }
         (matchingFileContent ++ matchingFileName).map(_._2).distinct.sorted
       }


### PR DESCRIPTION
Allows for "partest --grep run/t365*" to work, while previous it returned:

    > partest --grep run\/t365*
    [error] no tests match pattern / glob
    [error] partest --grep run\/t365*
    [error]                          ^