### PR TITLE
Avoid compiler crash with missing transitive dependencies

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -953,10 +953,11 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
        definitions.isDefinitionsInitialized
     && rootMirror.isMirrorInitialized
   )
-  override def isPastTyper = (
+  override def isPastTyper = isPast(currentRun.typerPhase)
+  def isPast(phase: Phase) = (
        (curRun ne null)
     && isGlobalInitialized // defense against init order issues
-    && (globalPhase.id > currentRun.typerPhase.id)
+    && (globalPhase.id > phase.id)
   )
 
   // TODO - trim these to the absolute minimum.

--- a/src/compiler/scala/tools/nsc/backend/ScalaPrimitives.scala
+++ b/src/compiler/scala/tools/nsc/backend/ScalaPrimitives.scala
@@ -446,9 +446,10 @@ abstract class ScalaPrimitives {
       inform(s"Unknown primitive method $cls.$method")
     else alts foreach (s =>
       addPrimitive(s,
-        s.info.paramTypes match {
-          case tp :: _ if code == ADD && tp =:= StringTpe => CONCAT
-          case _                                          => code
+        if (code != ADD) code
+        else exitingTyper(s.info).paramTypes match {
+          case tp :: _ if tp =:= StringTpe => CONCAT
+          case _                           => code
         }
       )
     )

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -809,7 +809,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
 
     final def isDerivedValueClass =
       isClass && !hasFlag(PACKAGE | TRAIT) &&
-      info.firstParent.typeSymbol == AnyValClass && !isPrimitiveValueClass
+      !phase.erasedTypes && info.firstParent.typeSymbol == AnyValClass && !isPrimitiveValueClass
 
     final def isMethodWithExtension =
       isMethod && owner.isDerivedValueClass && !isParamAccessor && !isConstructor && !hasFlag(SUPERACCESSOR) && !isMacro && !isSpecialized

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1197,7 +1197,6 @@ trait Types
       else super.safeToString
     override def narrow: Type = this
     override def kind = "ThisType"
-    override def boundSyms = if (sym.isInstanceOf[StubSymbol]) emptySymbolSet else super.boundSyms
   }
 
   final class UniqueThisType(sym: Symbol) extends ThisType(sym) { }

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1197,6 +1197,7 @@ trait Types
       else super.safeToString
     override def narrow: Type = this
     override def kind = "ThisType"
+    override def boundSyms = if (sym.isInstanceOf[StubSymbol]) emptySymbolSet else super.boundSyms
   }
 
   final class UniqueThisType(sym: Symbol) extends ThisType(sym) { }

--- a/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
+++ b/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
@@ -377,7 +377,7 @@ abstract class UnPickler {
 
       def readThisType(): Type = {
         val sym = readSymbolRef() match {
-          case stub: StubSymbol => stub.setFlag(PACKAGE)
+          case stub: StubSymbol => stub.setFlag(PACKAGE | MODULE)
           case sym => sym
         }
         ThisType(sym)

--- a/test/files/run/t10171/Test.scala
+++ b/test/files/run/t10171/Test.scala
@@ -1,0 +1,59 @@
+import scala.tools.partest._
+import java.io.File
+
+object Test extends StoreReporterDirectTest {
+  def code = ???
+
+  def compileCode(code: String) = {
+    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
+    compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(code)
+  }
+
+  def library = """
+package a {
+  package b {
+    class C { class D }
+  }
+}
+package z {
+  class Base {
+    type S = String
+    def foo(s: S): a.b.C#D = null
+  }
+  class Sub extends Base {
+    def sub = "sub"
+  }
+}
+  """
+
+  def client = """
+    class Client { new z.Sub().sub }
+  """
+
+  def deleteClass(s: String) = {
+    val f = new File(testOutput.path, s + ".class")
+    assert(f.exists)
+    f.delete()
+  }
+
+  def deletePackage(s: String) = {
+    val f = new File(testOutput.path, s)
+    assert(f.exists)
+    f.delete()
+  }
+
+  def assertNoErrors(): Unit = {
+    assert(storeReporter.infos.isEmpty, storeReporter.infos.mkString("\n"))
+    storeReporter.reset()
+  }
+  def show(): Unit = {
+    compileCode(library)
+    assertNoErrors()
+    deleteClass("a/b/C$D")
+    deleteClass("a/b/C")
+    deletePackage("a/b")
+    compileCode(client)
+    assertNoErrors()
+  }
+}
+


### PR DESCRIPTION
When we unpickle a reference to `a.b.C` and we don't have a package symbol for `a.b`, we synthesize a stub symbol. This code was modifed in b47aaf6445a to mutate the flags of a stub symbol rather than trying to create a particular subclass of `StubSymbol` when we figure out that a stub represents a package. However, this neglected to set the `MODULE` flag, which can lead to an assertion error later in the compiler.

This PR includes a direct fix for this flag error.

It also includes a few improvements to avoid forcing symbol info transformers in the compiler backend that I identified during the investigation.
I have a few more changes of this nature in [another branch](https://github.com/scala/scala/compare/2.12.x...retronym:topic/stubby-3?expand=1) that I'll revisit.
