### PR TITLE
Improve performance of immutable Map.contains

### DIFF
--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -49,7 +49,10 @@ sealed class HashMap[A, +B] extends AbstractMap[A, B]
 
   override def foreach[U](f: ((A, B)) => U): Unit = ()
 
-  def get(key: A): Option[B] =
+  override def contains(key: A): Boolean =
+    contains0(key, computeHash(key), 0)
+
+  override def get(key: A): Option[B] =
     get0(key, computeHash(key), 0)
 
   override def updated [B1 >: B] (key: A, value: B1): HashMap[A, B1] =
@@ -90,6 +93,8 @@ sealed class HashMap[A, +B] extends AbstractMap[A, B]
   private[collection] def computeHash(key: A) = improve(elemHashCode(key))
 
   import HashMap.{Merger, MergeFunction, liftMerger}
+
+  private[collection] def contains0(key: A, hash: Int, level: Int): Boolean = false
 
   private[collection] def get0(key: A, hash: Int, level: Int): Option[B] = None
 
@@ -192,6 +197,9 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
     private[collection] def getHash = hash
     private[collection] def computeHashFor(k: A) = computeHash(k)
 
+    override def contains0(key: A, hash: Int, level: Int): Boolean =
+      hash == this.hash && key == this.key
+
     override def get0(key: A, hash: Int, level: Int): Option[B] =
       if (hash == this.hash && key == this.key) Some(value) else None
 
@@ -235,6 +243,9 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
     // assert(kvs.size > 1)
 
     override def size = kvs.size
+
+    override def contains0(key: A, hash: Int, level: Int): Boolean =
+      hash == this.hash && kvs.contains(key)
 
     override def get0(key: A, hash: Int, level: Int): Option[B] =
       if (hash == this.hash) kvs.get(key) else None
@@ -304,6 +315,18 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
     // assert(elems.length > 1 || (elems.length == 1 && elems(0).isInstanceOf[HashTrieMap[_,_]]))
 
     override def size = size0
+
+    override def contains0(key: A, hash: Int, level: Int): Boolean = {
+      val index = (hash >>> level) & 0x1f
+      val mask = 1 << index
+      if (bitmap == - 1) {
+        elems(index & 0x1f).contains0(key, hash, level + 5)
+      } else if ((bitmap & mask) != 0) {
+        val offset = Integer.bitCount(bitmap & (mask-1))
+        elems(offset).contains0(key, hash, level + 5)
+      } else
+        false
+    }
 
     override def get0(key: A, hash: Int, level: Int): Option[B] = {
       val index = (hash >>> level) & 0x1f

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/MapBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/MapBenchmark.scala
@@ -1,0 +1,37 @@
+package scala.collection.immutable
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+object MapBenchmark {
+  case class Content(value: Int)
+}
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class MapBenchmark {
+  import MapBenchmark._
+  @Param(Array("1", "10", "100", "1000"))
+  var size: Int = _
+
+  var values: List[Content] = _
+  var map: Map[Content,Content] = _
+
+
+  @Setup(Level.Trial) def initKeys(): Unit = {
+    values = (1 until size).map { Content(_) }.toList
+    map = values.filter(_.value % 2 == 0).map( v => (v,v)).toMap
+  }
+
+  @Benchmark def contains: Any = {
+    values.foreach { v =>
+      map.contains(v)
+    }
+  }
+}


### PR DESCRIPTION
Map.contains defaults to ``` get(key).isDefined ``` generating an extra Option wrapper on each use (which is immediately discarded).    Override the base implementation to reduce memory churn.

Performance benchmark.
```
before 
[info] Benchmark              (size)  Mode  Cnt      Score      Error  Units
[info] MapBenchmark.contains       1  avgt   20      2.610 ±    0.138  ns/op
[info] MapBenchmark.contains      10  avgt   20     30.473 ±    1.233  ns/op
[info] MapBenchmark.contains     100  avgt   20   1549.097 ±   65.146  ns/op
[info] MapBenchmark.contains    1000  avgt   20  21638.244 ± 1021.994  ns/op

after
[info] Benchmark              (size)  Mode  Cnt      Score     Error  Units
[info] MapBenchmark.contains       1  avgt   20      2.682 ±   0.116  ns/op
[info] MapBenchmark.contains      10  avgt   20     31.703 ±   1.563  ns/op
[info] MapBenchmark.contains     100  avgt   20   1068.583 ±  53.095  ns/op
[info] MapBenchmark.contains    1000  avgt   20  14310.988 ± 758.181  ns/op
```