### PR TITLE
Optimizations in immutable.Map.{get, contains}

### DIFF
--- a/bincompat-backward.whitelist.conf
+++ b/bincompat-backward.whitelist.conf
@@ -32,6 +32,22 @@ filter {
     {
       matchName="scala.sys.process.ProcessImpl#CompoundProcess.getExitValue"
       problemName=DirectMissingMethodProblem
+    },
+    {
+      matchName="scala.collection.immutable.HashMap.contains0"
+      problemName=DirectMissingMethodProblem
+    },
+    {
+      matchName="scala.collection.immutable.HashMap#HashTrieMap.contains0"
+      problemName=DirectMissingMethodProblem
+    },
+    {
+      matchName="scala.collection.immutable.HashMap#HashMap1.contains0"
+      problemName=DirectMissingMethodProblem
+    },
+    {
+      matchName="scala.collection.immutable.HashMap#HashMapCollision1.contains0"
+      problemName=DirectMissingMethodProblem
     }
   ]
 }

--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -42,6 +42,22 @@ filter {
     {
       matchName="scala.util.hashing.MurmurHash3.wrappedArrayHash"
       problemName=DirectMissingMethodProblem
+    },
+    {
+      matchName="scala.collection.immutable.HashMap.contains0"
+      problemName=DirectMissingMethodProblem
+    },
+    {
+      matchName="scala.collection.immutable.HashMap#HashTrieMap.contains0"
+      problemName=DirectMissingMethodProblem
+    },
+    {
+      matchName="scala.collection.immutable.HashMap#HashMap1.contains0"
+      problemName=DirectMissingMethodProblem
+    },
+    {
+      matchName="scala.collection.immutable.HashMap#HashMapCollision1.contains0"
+      problemName=DirectMissingMethodProblem
     }
   ]
 }

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/HashMapBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/HashMapBenchmark.scala
@@ -6,8 +6,6 @@ import org.openjdk.jmh.runner.IterationType
 import benchmark._
 import java.util.concurrent.TimeUnit
 
-import scala.collection.mutable
-
 @BenchmarkMode(Array(Mode.AverageTime))
 @Fork(2)
 @Threads(1)
@@ -34,7 +32,7 @@ class HashMapBenchmark {
 
   var map: collection.immutable.HashMap[Any, Any] = null
 
-  @Setup(Level.Trial) def initializeMutable = {
+  @Setup(Level.Trial) def initialize = {
     map = collection.immutable.HashMap(existingKeys.map(x => (x, x)) : _*)
   }
 

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/HashMapBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/HashMapBenchmark.scala
@@ -1,0 +1,58 @@
+package scala.collection.immutable
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra._
+import org.openjdk.jmh.runner.IterationType
+import benchmark._
+import java.util.concurrent.TimeUnit
+
+import scala.collection.mutable
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class HashMapBenchmark {
+  @Param(Array("10", "100", "1000"))
+  var size: Int = _
+
+  var existingKeys: Array[Any] = _
+  var missingKeys: Array[Any] = _
+
+  @Setup(Level.Trial) def initKeys(): Unit = {
+    existingKeys = (0 to size).map(i => (i % 4) match {
+      case 0 => i.toString
+      case 1 => i.toChar
+      case 2 => i.toDouble
+      case 3 => i.toInt
+    }).toArray
+    missingKeys = (size to 2 * size).toArray
+  }
+
+  var map: collection.immutable.HashMap[Any, Any] = null
+
+  @Setup(Level.Trial) def initializeMutable = {
+    map = collection.immutable.HashMap(existingKeys.map(x => (x, x)) : _*)
+  }
+
+  @Benchmark def contains(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < size) {
+      bh.consume(map.contains(existingKeys(i)))
+      bh.consume(map.contains(missingKeys(i)))
+      i += 1
+    }
+  }
+
+  @Benchmark def get(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < size) {
+      bh.consume(map.get(existingKeys(i)))
+      bh.consume(map.get(missingKeys(i)))
+      i += 1
+    }
+  }
+}


### PR DESCRIPTION
  - Avoid allocation of Some in get
  - defer integer left shift until needed
  - avoid redundantly masking an integer

before:

    Benchmark                  (size)  Mode  Cnt      Score      Error  Units
    HashMapBenchmark.contains      10  avgt   20    284.624 ±   18.985  ns/op
    HashMapBenchmark.contains     100  avgt   20   3190.580 ±   33.622  ns/op
    HashMapBenchmark.contains    1000  avgt   20  52967.171 ± 1524.834  ns/op
    HashMapBenchmark.get           10  avgt   20    248.168 ±    2.612  ns/op
    HashMapBenchmark.get          100  avgt   20   2795.469 ±   54.458  ns/op
    HashMapBenchmark.get         1000  avgt   20  52238.773 ± 1268.764  ns/op

after:

    Benchmark                  (size)  Mode  Cnt      Score     Error  Units
    HashMapBenchmark.contains      10  avgt   20    195.107 ±   2.442  ns/op
    HashMapBenchmark.contains     100  avgt   20   2454.151 ±  24.392  ns/op
    HashMapBenchmark.contains    1000  avgt   20  40722.993 ± 520.473  ns/op
    HashMapBenchmark.get           10  avgt   20    245.282 ±   3.547  ns/op
    HashMapBenchmark.get          100  avgt   20   2729.669 ±  32.767  ns/op
    HashMapBenchmark.get         1000  avgt   20  49568.410 ± 794.565  ns/op