### PR TITLE
Warn on unused entries on classpath

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1445,6 +1445,23 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
         advancePhase()
       }
 
+      if (settings.YwarnOnUnusedJars.value) {
+        settings.outputDirs.outputs.foreach { case (_, abstractFile) =>
+          abstractFile.file match {
+            case dir: File if dir.isDirectory =>
+              Option(dir.getParentFile).foreach { parent =>
+                val jars = classpathUsage.diff(settings.classpath.value)
+                classpathUsage.store(parent, dir.getName, jars)
+                val count = jars.diff.size
+                if (count != 0) {
+                  warning(s"$count unused jars were detected, see '$parent' for the log files with the details.")
+                }
+              }
+            case _ =>
+          }
+        }
+      }
+
       reporting.summarizeErrors()
 
       if (traceSymbolActivity)

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -219,6 +219,8 @@ trait ScalaSettings extends AbsScalaSettings
   val YdisableFlatCpCaching  = BooleanSetting    ("-YdisableFlatCpCaching", "Do not cache flat classpath representation of classpath elements from jars across compiler instances.")
   val YpartialUnification = BooleanSetting ("-Ypartial-unification", "Enable partial unification in type constructor inference")
   val Yvirtpatmat     = BooleanSetting    ("-Yvirtpatmat", "Enable pattern matcher virtualization")
+  val YwarnOnUnusedJars
+                      = BooleanSetting    ("-Ywarn-on-unused-jars", "Collect data about which classpath entries are used during compilation. If any is not used, then issue a warning.")
 
   val exposeEmptyPackage = BooleanSetting ("-Yexpose-empty-package", "Internal only: expose the empty package.").internalOnly()
   val Ydelambdafy        = ChoiceSetting  ("-Ydelambdafy", "strategy", "Strategy used for translating lambdas into JVM code.", List("inline", "method"), "method")

--- a/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
@@ -308,6 +308,7 @@ abstract class SymbolLoaders {
 
     protected def doComplete(root: Symbol) {
       val start = if (Statistics.canEnable) Statistics.startTimer(classReadNanos) else null
+      if (settings.YwarnOnUnusedJars.value) classpathUsage.register(classfile)
       classfileParser.parse(classfile, clazz, module)
       if (root.associatedFile eq NoAbstractFile) {
         root match {

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -49,6 +49,8 @@ abstract class SymbolTable extends macros.Universe
                               with Reporting
 {
 
+  object classpathUsage extends ClasspathUsage()
+
   val gen = new InternalTreeGen { val global: SymbolTable.this.type = SymbolTable.this }
 
   def log(msg: => AnyRef): Unit

--- a/src/reflect/scala/reflect/internal/util/ClasspathUsage.scala
+++ b/src/reflect/scala/reflect/internal/util/ClasspathUsage.scala
@@ -1,0 +1,51 @@
+package scala.reflect.internal.util
+
+import java.io.{File, FileWriter}
+
+import scala.collection.immutable
+import scala.collection.mutable
+import scala.reflect.io.AbstractFile
+
+/**
+  * Records usage of jars during the compilation.
+  *
+  * Stores used jars in `deps-scope.txt` file, full classpath in `classpath-scope.txt` and diff in `diff-scope.txt`,
+  * all placed in output dir.
+  */
+class ClasspathUsage() {
+
+  private val usedJars = mutable.Set.empty[String]
+
+  private def isJarPath(path: String) = path.endsWith(".jar")
+
+  def register(classfile: AbstractFile): Unit = {
+    classfile.underlyingSource match {
+      case Some(file) if isJarPath(file.path) => usedJars += file.path
+      case _ =>
+    }
+  }
+
+  def diff(classpath: String): ClasspathUsage.Jars = {
+    val declaredJars = classpath.split(File.pathSeparator).toSet.filter(isJarPath)
+    ClasspathUsage.Jars(usedJars.toSet, declaredJars.toSet)
+  }
+
+  def store(parent: File, scope: String, jars: ClasspathUsage.Jars): Unit = {
+    def store(fileName: String, body: Iterable[String]) = {
+      val file = new File(parent, fileName + "-" + scope + ".txt")
+      val fw = new FileWriter(file)
+      try fw.append(body.toList.sorted.mkString("\n")) finally fw.close()
+    }
+
+    store("jars-used", jars.used)
+    store("jars-path", jars.declared)
+    store("jars-diff", jars.diff)
+  }
+
+}
+
+object ClasspathUsage {
+  case class Jars(used: immutable.Set[String], declared: immutable.Set[String]) {
+    def diff: immutable.Set[String] = declared -- used
+  }
+}

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -29,6 +29,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.internal
     this.treeInfo
     this.rootMirror
+    this.classpathUsage
     this.traceSymbols
     this.perRunCaches
     this.compat


### PR DESCRIPTION
This commits introduces new flag, '-Ywarn-on-unused-jars'. When enabled,
all jars on classpath wil be logged in the output directory, together with
all jars that were accessed during compilation.

If there were any jars present on a classpath but not used, a warning will
be issued.

Disclaimer required by the lawyers:

THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE:
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
ONLY THE SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE, IF ANY, THAT ARE ATTACHED TO (OR OTHERWISE ACCOMPANY) THIS SUBMISSION (AND ORDINARY COURSE CONTRIBUTIONS OF FUTURES PATCHES THERETO) ARE TO BE CONSIDERED A CONTRIBUTION. NO OTHER SOFTWARE CODE OR MATERIALS ARE A CONTRIBUTION.