### PR TITLE
Correct the AbstractVar error message to be more correct

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -1211,7 +1211,7 @@ trait ContextErrors {
             "pass-by-name arguments not allowed for case class parameters"
 
           case AbstractVar =>
-            "only classes can have declared but undefined members" + abstractVarMessage(sym)
+            "only traits and abstract classes can have declared but undefined members" + abstractVarMessage(sym)
 
         }
         issueSymbolTypeError(sym, msg)

--- a/test/files/neg/nested-fn-print.check
+++ b/test/files/neg/nested-fn-print.check
@@ -1,4 +1,4 @@
-nested-fn-print.scala:4: error: only classes can have declared but undefined members
+nested-fn-print.scala:4: error: only traits and abstract classes can have declared but undefined members
 (Note that variables need to be initialized to be defined)
   var x3: Int => Double
       ^

--- a/test/files/neg/t565.check
+++ b/test/files/neg/t565.check
@@ -1,4 +1,4 @@
-t565.scala:2: error: only classes can have declared but undefined members
+t565.scala:2: error: only traits and abstract classes can have declared but undefined members
 (Note that variables need to be initialized to be defined)
   var s0: String
       ^

--- a/test/files/neg/t8217-local-alias-requires-rhs.check
+++ b/test/files/neg/t8217-local-alias-requires-rhs.check
@@ -1,10 +1,10 @@
-t8217-local-alias-requires-rhs.scala:3: error: only classes can have declared but undefined members
+t8217-local-alias-requires-rhs.scala:3: error: only traits and abstract classes can have declared but undefined members
     type A
          ^
-t8217-local-alias-requires-rhs.scala:6: error: only classes can have declared but undefined members
+t8217-local-alias-requires-rhs.scala:6: error: only traits and abstract classes can have declared but undefined members
     type B
          ^
-t8217-local-alias-requires-rhs.scala:14: error: only classes can have declared but undefined members
+t8217-local-alias-requires-rhs.scala:14: error: only traits and abstract classes can have declared but undefined members
   def this(a: Any) = { this(); type C }
                                     ^
 three errors found


### PR DESCRIPTION
The error currently reads "only classes can have declared but undefined
members", which isn't true on two counts: traits can have them, and
concrete classes cannot. This corrects the error message to read "only
traits and abstract classes can have declared but undefined members".