### PR TITLE
fixed broken references after move from 'model' to 'base'

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/base/comment/Body.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/comment/Body.scala
@@ -11,8 +11,9 @@ package comment
 import scala.collection._
 
 /** A body of text. A comment has a single body, which is composed of
-  * at least one block. Inside every body is exactly one summary (see
-  * [[scala.tools.nsc.doc.model.comment.Summary]]). */
+  * at least one block. Inside every body is exactly one summary.
+  * @see [[Summary]]
+  */
 final case class Body(blocks: Seq[Block]) {
 
   /** The summary text of the comment body. */

--- a/src/scaladoc/scala/tools/nsc/doc/base/comment/Comment.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/comment/Comment.scala
@@ -12,7 +12,7 @@ import scala.collection._
 
 /** A Scaladoc comment and all its tags.
   *
-  * '''Note:''' the only instantiation site of this class is in [[CommentFactory]].
+  * '''Note:''' the only instantiation site of this class is in [[model.CommentFactory]].
   *
   * @author Manohar Jonnalagedda
   * @author Gilles Dubochet */


### PR DESCRIPTION
broken since https://github.com/scala/scala/pull/1722