### PR TITLE
SI-10180 Scan generic signatures when populating InnerClass attribute

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
@@ -275,7 +275,7 @@ class BackendUtils[BT <: BTypes](val btypes: BT) {
         visitInternalName(internalName.toString)
       }
       override def raiseError(msg: String): Unit = {
-        // don't crash on invalid generic signatures
+        throw new FatalError(msg)
       }
     }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
@@ -263,7 +263,10 @@ class BackendUtils[BT <: BTypes](val btypes: BT) {
 
     def visitInternalName(internalName: InternalName): Unit = if (internalName != null) {
       val t = classBTypeFromParsedClassfile(internalName)
-      if (t.isNestedClass.get) innerClasses += t
+      t.isNestedClass match {
+        case Right(true) => innerClasses += t
+        case _ => // ignores absent classes
+      }
     }
 
     // either an internal/Name or [[Linternal/Name; -- there are certain references in classfiles

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -686,7 +686,7 @@ abstract class ClassfileParser {
           accept(';')
           tpe
         case ARRAY_TAG =>
-          while ('0' <= sig.charAt(index) && sig.charAt(index) <= '9') index += 1
+          while ('0' <= sig.charAt(index) && sig.charAt(index) <= '9') index += 1 // TODO this line doesn't seem to correspond to the spec, remove?
           var elemtp = sig2type(tparams, skiptvs)
           // make unbounded Array[T] where T is a type variable into Array[T with Object]
           // (this is necessary because such arrays have a representation which is incompatible
@@ -767,7 +767,7 @@ abstract class ClassfileParser {
         ClassInfoType(parents.toList, instanceScope, sym)
       }
     GenPolyType(ownTypeParams, tpe)
-  } // sigToType
+  }
 
   def parseAttributes(sym: Symbol, symtype: Type) {
     def convertTo(c: Constant, pt: Type): Constant = {

--- a/src/compiler/scala/tools/nsc/symtab/classfile/JavaSignatureWalker.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/JavaSignatureWalker.scala
@@ -1,0 +1,113 @@
+package scala.tools.nsc.symtab.classfile
+
+import scala.reflect.internal.ClassfileConstants._
+
+abstract class JavaSignatureWalker {
+  def visitName(internalName: CharSequence): Unit
+  def raiseError(msg: String): Unit
+
+  def walk(sig: CharSequence): Unit = {
+    def raiseError(msg: String): Unit = {
+      this.raiseError(s"$msg (while parsing $sig)")
+    }
+    val EOF: Char = '\0'
+    var index = 0
+    val end = sig.length
+    def accept(ch: Char) {
+      if (current() != ch)
+        raiseError(s"Invalid signature. Expected $ch, but found ${current()} at position $index of $sig")
+      index += 1
+    }
+    def skipSubName(isDelimiter: Char => Boolean): Unit = {
+      val start = index
+      while (!{val ch = current(); ch == EOF || isDelimiter(ch)}) { index += 1 }
+    }
+    def appendSubName(builder: java.lang.StringBuilder, isDelimiter: Char => Boolean): CharSequence = {
+      val start = index
+      skipSubName(isDelimiter)
+      builder.append(sig, start, index)
+    }
+    def current(): Char = {
+      if (index < end)
+        sig.charAt(index)
+      else EOF
+    }
+
+    def parseMethodOrFieldType(): Unit = {
+      val tag = current(); index += 1
+      tag match {
+        case OBJECT_TAG =>
+          def parseTypeArgs(): Unit = {
+            if (current() == '<') {
+              accept('<')
+              while (current() != '>') {
+                current() match {
+                  case '+' | '-' =>
+                    index += 1
+                    parseMethodOrFieldType()
+                  case  '*' =>
+                    index += 1
+                  case _ =>
+                    parseMethodOrFieldType()
+                }
+              }
+              accept('>')
+            }
+          }
+
+          val internalName = new java.lang.StringBuilder
+          appendSubName(internalName, c => c == ';' || c == '<')
+          parseTypeArgs()
+          while (current() == '.') {
+            accept('.')
+            internalName.append('$')
+            appendSubName(internalName, c => c == ';' || c == '<' || c == '.')
+            parseTypeArgs()
+          }
+          accept(';')
+          visitName(internalName.toString)
+        case ARRAY_TAG =>
+          parseMethodOrFieldType()
+        case '(' =>
+          while (current() != ')') {
+            parseMethodOrFieldType()
+          }
+          accept(')')
+          parseMethodOrFieldType()
+          while (current() == '^') {
+            accept('^')
+            parseMethodOrFieldType()
+          }
+        case TVAR_TAG =>
+          skipSubName(';'.==)
+          index += 1
+        case BYTE_TAG | CHAR_TAG | DOUBLE_TAG | FLOAT_TAG | INT_TAG | LONG_TAG | SHORT_TAG | BOOL_TAG =>
+        case VOID_TAG =>
+        case _ =>
+          raiseError("Unexpected tag: " + tag)
+      }
+    }
+
+    def parseBounds(): Unit = {
+      while (current() == ':') {
+        index += 1
+        if (current() != ':') // guard against empty class bound
+          parseMethodOrFieldType()
+      }
+    }
+
+    if (current() == '<') {
+      index += 1
+      val start = index
+      while (current() != '>') {
+        skipSubName(':'.==)
+        parseBounds()
+      }
+      accept('>')
+    }
+    while (index < end) {
+      parseMethodOrFieldType()
+    }
+  }
+
+}

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -286,7 +286,18 @@ abstract class Erasure extends InfoTransform
               (
                 if (needsJavaSig(preRebound, Nil)) {
                   val s = jsig(preRebound, existentiallyBound)
-                  if (s.charAt(0) == 'L') s.substring(0, s.length - 1) + "." + sym.javaSimpleName
+                  if (s.charAt(0) == 'L') {
+                    val withoutSemicolon = s.substring(0, s.length - 1)
+                    val withoutOwningModuleDollar =
+                      if (preRebound.typeSymbolDirect.isModuleClass && sym.isModuleOrModuleClass)
+                        // mimic the (questionable) choice of `ModuleSymbol#name` to use the owning module's
+                        // Scala name, rather than the javaSimpleName (which includes the $ suffix)
+                        // as the basis for the flat name of a nested module.
+                        withoutSemicolon.stripSuffix(nme.MODULE_SUFFIX_STRING)
+                      else withoutSemicolon
+
+                    withoutOwningModuleDollar + "." + sym.javaSimpleName
+                  }
                   else fullNameInSig(sym)
                 }
                 else fullNameInSig(sym)

--- a/test/files/run/t10180.scala
+++ b/test/files/run/t10180.scala
@@ -1,0 +1,22 @@
+trait T[A] {
+  class X[A] {
+    object U {
+      object V
+    }
+  }
+}
+
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val U = Class.forName("T$X$U$")
+    val V = Class.forName("T$X$U$V$")
+
+    // Was: java.lang.TypeNotPresentException: Type T$X$U$$V$ not present
+    assert(V.getEnclosingClass == U, V.getEnclosingClass)
+    val tp = U.getMethod("V").getGenericReturnType.asInstanceOf[java.lang.reflect.ParameterizedType]
+    val cls = Class.forName(tp.getRawType.getTypeName)
+    assert(cls == V, cls)
+  }
+}
+


### PR DESCRIPTION
Generic signatures, like descriptors, include class names directly into the
grammar, rather than referring to class constants in the constant pool.

For the benefit of other compilers and tools consuming generic signatures,
we should record the metadata for inner classes that the reference.

This commit includers a parser for generic signatures that is designed for
performance with the simplifying assumption that it need only read
internal names. I started with the existing parser in ClassfileParser
that builds up symbols/types based on generic signatures. I don't see
an easy way to share more code between the two parsers without compromising
performance.

The new parser is used in the backend to trawl for referenced names in
the signatures of class definitions, field types, and method types.

Review by @lrytz. This is an old bug, so I'm happy to defer it to 2.12.3 if we don't have time to review it for 2.12.2