### PR TITLE
EOL is System.lineSeparator

### DIFF
--- a/src/compiler/scala/tools/nsc/reporters/ConsoleReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/ConsoleReporter.scala
@@ -7,9 +7,10 @@ package scala
 package tools.nsc
 package reporters
 
-import java.io.{ BufferedReader, PrintWriter }
-import scala.reflect.internal.util._
-import StringOps._
+import java.io.{BufferedReader, PrintWriter}
+import scala.reflect.internal.util.{Position, StringOps}
+import Position.formatMessage
+import StringOps.{countElementsAsString => countAs, trimAllTrailingSpace => trimTrailing}
 
 /** This class implements a Reporter that displays messages on a text console.
  */
@@ -26,47 +27,35 @@ class ConsoleReporter(val settings: Settings, reader: BufferedReader, writer: Pr
   private def label(severity: Severity): String = severity match {
     case ERROR   => "error"
     case WARNING => "warning"
-    case INFO    => null
+    case INFO    => ""
   }
 
-  protected def clabel(severity: Severity): String = {
-    val label0 = label(severity)
-    if (label0 eq null) "" else label0 + ": "
+  protected def clabel(severity: Severity): String = label(severity) match {
+    case "" => ""
+    case s  => s"$s: "
   }
-
-  /** Returns the number of errors issued totally as a string.
-   */
-  private def getCountString(severity: Severity): String =
-    StringOps.countElementsAsString((severity).count, label(severity))
 
   /** Prints the message. */
-  def printMessage(msg: String) {
-    writer print trimAllTrailingSpace(msg) + "\n"
+  def printMessage(msg: String): Unit = {
+    writer.println(trimTrailing(msg))
     writer.flush()
   }
 
   /** Prints the message with the given position indication. */
-  def printMessage(posIn: Position, msg: String) {
-    printMessage(Position.formatMessage(posIn, msg, shortname))
-  }
-  def print(pos: Position, msg: String, severity: Severity) {
-    printMessage(pos, clabel(severity) + msg)
-  }
+  def printMessage(posIn: Position, msg: String): Unit = printMessage(formatMessage(posIn, msg, shortname))
 
-  /** Prints the column marker of the given position.
-   */
-  def printColumnMarker(pos: Position) =
-    if (pos.isDefined) { printMessage(" " * (pos.column - 1) + "^") }
+  def print(pos: Position, msg: String, severity: Severity): Unit = printMessage(pos, s"${clabel(severity)}${msg}")
 
-  /** Prints the number of errors and warnings if their are non-zero. */
-  def printSummary() {
-    if (WARNING.count > 0) printMessage(getCountString(WARNING) + " found")
-    if (  ERROR.count > 0) printMessage(getCountString(ERROR  ) + " found")
-  }
+  /** Prints the column marker of the given position. */
+  def printColumnMarker(pos: Position): Unit = if (pos.isDefined) printMessage(" " * (pos.column - 1) + "^")
+
+  /** Prints the number of warnings and errors if there are any. */
+  def printSummary(): Unit =
+    for (k <- List(WARNING, ERROR) if k.count > 0) printMessage(s"${countAs(k.count, label(k))} found")
 
   def display(pos: Position, msg: String, severity: Severity): Unit = {
     val ok = severity match {
-      case ERROR   => ERROR.count <= settings.maxerrs.value
+      case ERROR   => ERROR.count   <= settings.maxerrs.value
       case WARNING => WARNING.count <= settings.maxwarns.value
       case _     => true
     }
@@ -74,17 +63,19 @@ class ConsoleReporter(val settings: Settings, reader: BufferedReader, writer: Pr
   }
 
   def displayPrompt(): Unit = {
-    writer.print("\na)bort, s)tack, r)esume: ")
+    writer.println()
+    writer.print("a)bort, s)tack, r)esume: ")
     writer.flush()
     if (reader != null) {
-      val response = reader.read().asInstanceOf[Char].toLower
-      if (response == 'a' || response == 's') {
-        (new Exception).printStackTrace()
-        if (response == 'a')
-          sys exit 1
-
-        writer.print("\n")
-        writer.flush()
+      reader.read match {
+        case 'a' | 'A' =>
+          new Throwable().printStackTrace()
+          System.exit(1)
+        case 's' | 'S' =>
+          new Throwable().printStackTrace()
+          writer.println()
+          writer.flush()
+        case _ =>
       }
     }
   }

--- a/src/reflect/scala/reflect/internal/util/StringOps.scala
+++ b/src/reflect/scala/reflect/internal/util/StringOps.scala
@@ -11,7 +11,7 @@ package reflect
 package internal
 package util
 
-import scala.compat.Platform.EOL
+import java.lang.System.{lineSeparator => EOL}
 
 /** This object provides utility methods to extract elements
  *  from Strings.
@@ -45,7 +45,7 @@ trait StringOps {
     else s.substring(0, end)
   }
   /** Breaks the string into lines and strips each line before reassembling. */
-  def trimAllTrailingSpace(s: String): String = s.lines map trimTrailingSpace mkString EOL
+  def trimAllTrailingSpace(s: String): String = s.lines.map(trimTrailingSpace).mkString(EOL)
 
   def decompose(str: String, sep: Char): List[String] = {
     def ws(start: Int): List[String] =
@@ -69,18 +69,17 @@ trait StringOps {
     else Some((str take idx, str drop (if (doDropIndex) idx + 1 else idx)))
 
   /** Returns a string meaning "n elements".
+   *  Don't try an element such as "index" with irregular plural.
    */
-  def countElementsAsString(n: Int, elements: String): String =
+  def countElementsAsString(n: Int, element: String): String =
     n match {
-      case 0 => s"no ${elements}s"
-      case 1 => "one "   + elements
-      case 2 => "two "   + elements + "s"
-      case 3 => "three " + elements + "s"
-      case 4 => "four "  + elements + "s"
-      case _ => s"$n ${elements}s"
+      case 0 => s"no ${element}s"
+      case 1 => s"one ${element}"
+      case _ => s"${countAsString(n)} ${element}s"
     }
 
   /** Turns a count into a friendly English description if n<=4.
+   *  Otherwise, a scary math representation.
    */
   def countAsString(n: Int): String =
     n match {
@@ -89,8 +88,8 @@ trait StringOps {
       case 2 => "two"
       case 3 => "three"
       case 4 => "four"
-      case _ => "" + n
+      case _ => n.toString
     }
 }
 
-object StringOps extends StringOps { }
+object StringOps extends StringOps

--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -1029,6 +1029,7 @@ object ILoop {
   // like if you'd just typed it into the repl.
   def runForTranscript(code: String, settings: Settings, inSession: Boolean = false): String = {
     import java.io.{ BufferedReader, StringReader, OutputStreamWriter }
+    import java.lang.System.{lineSeparator => EOL}
 
     stringFromStream { ostream =>
       Console.withOut(ostream) {
@@ -1036,10 +1037,9 @@ object ILoop {
           // skip margin prefix for continuation lines, unless preserving session text for test
           // should test for repl.paste.ContinueString or replProps.continueText.contains(ch)
           override def write(str: String) =
-            if (!inSession && (str forall (ch => ch.isWhitespace || ch == '|'))) ()
-            else super.write(str)
+            if (inSession || (str.exists(ch => ch != ' ' && ch != '|'))) super.write(str)
         }
-        val input = new BufferedReader(new StringReader(code.trim + "\n")) {
+        val input = new BufferedReader(new StringReader(s"${code.trim}${EOL}")) {
           override def readLine(): String = {
             mark(1)    // default buffer is 8k
             val c = read()


### PR DESCRIPTION
The old EOL is EOL. Use `println()` when feasible and obvious.

Minor cleanup of surrounding code.