### PR TITLE
Changing deprecation warning to lineStream

### DIFF
--- a/src/library/scala/sys/process/ProcessBuilder.scala
+++ b/src/library/scala/sys/process/ProcessBuilder.scala
@@ -186,7 +186,7 @@ trait ProcessBuilder extends Source with Sink {
   def lineStream(log: ProcessLogger): Stream[String]
 
   /** Deprecated (renamed).  Use `lineStream(log: ProcessLogger)` instead. */
-  @deprecated("use stream instead", "2.11.0")
+  @deprecated("use lineStream instead", "2.11.0")
   def lines(log: ProcessLogger): Stream[String] = lineStream(log)
 
   /** Starts the process represented by this builder.  The output is returned as
@@ -210,7 +210,7 @@ trait ProcessBuilder extends Source with Sink {
   def lineStream_!(log: ProcessLogger): Stream[String]
 
   /** Deprecated (renamed).  Use `lineStream_!(log: ProcessLogger)` instead. */
-  @deprecated("use stream_! instead", "2.11.0")
+  @deprecated("use lineStream_! instead", "2.11.0")
   def lines_!(log: ProcessLogger): Stream[String] = lineStream_!(log)
 
   /** Starts the process represented by this builder, blocks until it exits, and


### PR DESCRIPTION
The deprecation text of `ProcessBuilder.lines(log: ProcessLogger)` and `ProcessBuilder.lines_!(log: ProcessLogger) mentions to use the method `stream` and `stream_!` respectively. These methods do not exists.

The text has been changed to use `lineStream` and `lineStream_!` respectively.