### PR TITLE
fix IndexedSeqTest to work in both Ant and sbt

### DIFF
--- a/test/junit/scala/collection/IndexedSeqTest.scala
+++ b/test/junit/scala/collection/IndexedSeqTest.scala
@@ -1,9 +1,14 @@
 package scala.collection
 
 import org.junit.Test
+import org.junit.Ignore
 import org.junit.Assert.{assertEquals, _}
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+
+// with the Ant JUnit runner, it's necessary to @Ignore the abstract
+// classes here, or JUnit tries to instantiate them.  the annotations
+// can be removed when this is merged forward (TODO 2.12.x)
 
 /**
   * base class for testing common methods on a various implementations
@@ -12,6 +17,7 @@ import org.junit.runners.JUnit4
   * @tparam E the element type
   */
 @RunWith(classOf[JUnit4])
+@Ignore
 abstract class IndexedTest[T, E] {
 
   protected def size = 10
@@ -311,8 +317,9 @@ package IndexedTestImpl {
     def toType(n: Int)= if ((n & 0) == 0) null else BoxedUnit.UNIT
   }
 
+  @Ignore
   abstract class ArrayTest[E] (
-                               //the object or primative type of the array
+                               //the object or primitive type of the array
                                val TYPE: Class[_]) extends IndexedTest[Array[E], E]{
     override final def length(underTest: Array[E]) = underTest.length
 
@@ -342,8 +349,9 @@ package IndexedTestImpl {
   }
 
 
+  @Ignore
   abstract class WrappedArrayTest[E](
-                                      //the object or primative type of the array
+                                      //the object or primitive type of the array
                                       val TYPE: Class[_]) extends IndexedTest[mutable.WrappedArray[E], E]  with DataProvider[E]{
     import mutable.WrappedArray
     override final def length(underTest: WrappedArray[E]) = underTest.length
@@ -375,6 +383,7 @@ package IndexedTestImpl {
 
   //construct the data using java as much as possible to avoid invalidating the test
 
+  @Ignore
   abstract class MutableIndexedSeqTest[T <: mutable.Seq[E], E] extends IndexedTest[T, E]   with DataProvider[E]{
     override final def length(underTest: T) = underTest.length
 
@@ -404,6 +413,7 @@ package IndexedTestImpl {
     }
 
   }
+  @Ignore
   abstract class ImmutableIndexedSeqTest[T <: SeqLike[E, T], E] extends IndexedTest[T, E]   with DataProvider[E] {
     override final def length(underTest: T) = underTest.length
 
@@ -424,6 +434,7 @@ package IndexedTestImpl {
     }
 
   }
+  @Ignore
   abstract class StringOpsBaseTest extends IndexedTest[StringOps, Char] with DataProvider[Char]  {
     override final def length(underTest: StringOps) = underTest.length
 


### PR DESCRIPTION
follows up on https://github.com/scala/scala/pull/5664;
fixes https://github.com/scala/scala-dev/issues/301