### PR TITLE
SI-10164 BitSet.tail zigs where it zagged

### DIFF
--- a/src/library/scala/collection/BitSetLike.scala
+++ b/src/library/scala/collection/BitSetLike.scala
@@ -77,26 +77,26 @@ trait BitSetLike[+This <: BitSetLike[This] with SortedSet[Int]] extends SortedSe
   def rangeImpl(from: Option[Int], until: Option[Int]): This = {
     val a = toBitMask
     val len = a.length
-    if(from.isDefined) {
+    if (from.isDefined) {
       var f = from.get
       var pos = 0
-      while(f >= 64 && pos < len) {
+      while (f >= 64 && pos < len) {
         f -= 64
         a(pos) = 0
         pos += 1
       }
-      if(f > 0 && pos < len) a(pos) &= ~((1L << f)-1)
+      if (f > 0 && pos < len) a(pos) &= ~((1L << f)-1)
     }
-    if(until.isDefined) {
+    if (until.isDefined) {
       val u = until.get
       val w = u / 64
       val b = u % 64
       var clearw = w+1
-      while(clearw < len) {
+      while (clearw < len) {
         a(clearw) = 0
         clearw += 1
       }
-      if(w < len) a(w) &= (1L << b)-1
+      if (w < len) a(w) &= (1L << b)-1
     }
     fromBitMaskNoCopy(a)
   }
@@ -220,7 +220,7 @@ trait BitSetLike[+This <: BitSetLike[This] with SortedSet[Int]] extends SortedSe
     while (i >= 0) {
       val wi = word(i)
       if (wi != 0L) return WordLength*i + 63 - java.lang.Long.numberOfLeadingZeros(wi)
-      i += 1
+      i -= 1
     }
     throw new NoSuchElementException("Empty BitSet")
   }
@@ -230,7 +230,7 @@ trait BitSetLike[+This <: BitSetLike[This] with SortedSet[Int]] extends SortedSe
     var pre = ""
     val max = nwords * WordLength
     var i = 0
-    while(i != max) {
+    while (i != max) {
       if (contains(i)) {
         sb append pre append i
         pre = sep

--- a/test/junit/scala/collection/mutable/BitSetTest.scala
+++ b/test/junit/scala/collection/mutable/BitSetTest.scala
@@ -7,7 +7,7 @@ import org.junit.runners.JUnit4
 @RunWith(classOf[JUnit4])
 class BitSetTest {
   // Test for SI-8910
-  @Test def capacityExpansionTest() {
+  @Test def capacityExpansionTest(): Unit = {
     val bitSet = BitSet.empty
     val size   = bitSet.toBitMask.length
     bitSet ^= bitSet
@@ -20,7 +20,7 @@ class BitSetTest {
     assert(bitSet.toBitMask.length == size, "Capacity of bitset changed after &~=")
   }
   
-  @Test def test_SI8917() {
+  @Test def test_SI8917(): Unit = {
     val bigBitSet = BitSet(1, 100, 10000)
     val littleBitSet = BitSet(100)
     bigBitSet &= littleBitSet
@@ -29,10 +29,16 @@ class BitSetTest {
     assert(littleBitSet.toBitMask.length < bigBitSet.toBitMask.length, "Needlessly extended the size of bitset on &=")
   }
 
-  @Test def test_SI8647() {
+  @Test def test_SI8647(): Unit = {
     val bs = BitSet()
     bs.map(_ + 1)    // Just needs to compile
     val xs = bs: SortedSet[Int]
     xs.map(_ + 1)    // Also should compile (did before)
+  }
+
+  @Test def t10164(): Unit = {
+    val bs = BitSet()
+    val last = (bs ++ (0 to 128)).last  // Just needs not to throw
+    assert(last == 128)
   }
 }


### PR DESCRIPTION
A cut/paste issue, an increment was held over from head,
which scans forward, to tail, which scans backward.

Fix is due to reporter.