### PR TITLE
Eliminate non-matching overloads early for partial function literals

### DIFF
--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -1422,6 +1422,7 @@ The *shape* of an argument expression $e$, written  $\mathit{shape}(e)$, is
 a type that is defined as follows:
   - For a function expression `($p_1$: $T_1 , \ldots , p_n$: $T_n$) => $b$: (Any $, \ldots ,$ Any) => $\mathit{shape}(b)$`,
     where `Any` occurs $n$ times in the argument type.
+  - For a pattern-matching anonymous function definition `{ case ... }`: `PartialFunction[Any, Nothing]`.
   - For a named argument `$n$ = $e$`: $\mathit{shape}(e)$.
   - For all other expressions: `Nothing`.
 

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3291,6 +3291,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               // overloading resolution happens during type checking.
               // During erasure, the condition above (fun.symbol.isOverloaded) is false.
               functionType(vparams map (_ => AnyTpe), shapeType(body))
+            case Match(EmptyTree, _) => // A partial function literal
+              appliedType(PartialFunctionClass, AnyTpe :: NothingTpe :: Nil)
             case AssignOrNamedArg(Ident(name), rhs) =>
               NamedType(name, shapeType(rhs))
             case _ =>

--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -265,6 +265,7 @@ abstract class TreeInfo {
 
   def isFunctionMissingParamType(tree: Tree): Boolean = tree match {
     case Function(vparams, _) => vparams.exists(_.tpt.isEmpty)
+    case Match(EmptyTree, _) => true
     case _ => false
   }
 

--- a/test/files/run/InferOverloadedPartialFunction.scala
+++ b/test/files/run/InferOverloadedPartialFunction.scala
@@ -1,0 +1,47 @@
+class MySeq[T](val i: Int) {
+  def map1[U](f: T => U): MySeq[U] = new MySeq[U](10)
+  def map2[U](f: T => U): MySeq[U] = new MySeq[U](20)
+}
+
+class MyMap[A, B](i: Int) extends MySeq[(A, B)](i) {
+  def map1[C](f: (A, B) => C): MySeq[C] = new MySeq[C](11)
+  def map1[C, D](f: (A, B) => (C, D)): MyMap[C, D] = new MyMap[C, D](12)
+  def map1[C, D](f: ((A, B)) => (C, D)): MyMap[C, D] = new MyMap[C, D](13)
+  def map3[U](f: PartialFunction[(A, B), U]): MySeq[U] = new MySeq[U](30)
+
+  def foo(f: Function2[Int, Int, Int]): Unit = ()
+  def foo[R](pf: PartialFunction[(A, B), R]): MySeq[R] = new MySeq[R](100)
+}
+
+object Test extends App {
+  val m = new MyMap[Int, String](0)
+
+  // These ones already worked because they are not overloaded:
+  m.map2 { case (k, v) => k - 1 }
+  m.map3 { case (k, v) => k - 1 }
+
+  // These already worked because preSelectOverloaded eliminated the non-applicable overload:
+  // (The still pick the same overload; no previously legal code changes semantics)
+  assert(m.map1(t => t._1).i == 10)
+  assert(m.map1((kInFunction, vInFunction) => kInFunction - 1).i == 11)
+  val r1 = m.map1(t => (t._1, 42.0))
+  val r1t: MyMap[Int, Double] = r1
+  assert(r1.i == 13)
+
+  // These worked because they are not case literals (and the argument types are known for overload resolution):
+  assert(m.map1({ case (k, v) => k - 1 }: PartialFunction[(Int, String), Int]).i == 10)
+  assert(m.map2({ case (k, v) => k - 1 }: PartialFunction[(Int, String), Int]).i == 20)
+
+  // These ones did not work before, now always picks tupled version over Function2 version:
+  assert(m.map1 { case (k, v) => k }.i == 10)
+  val r2 = m.map1 { case (k, v) => (k, k*10) }
+  val r2t: MyMap[Int, Int] = r2
+  assert(r2.i == 13)
+  val r3 = m.foo { case (k, v) => k - 1 }
+  val r3t: MySeq[Int] = r3
+
+  // Used to be ambiguous but overload resolution now favors PartialFunction
+  def h[R](pf: Function2[Int, String, R]): Int = 1
+  def h[R](pf: PartialFunction[(Double, Double), R]): Int = 2
+  assert(h { case (a: Double, b: Double) => 42: Int } == 2)
+}


### PR DESCRIPTION
This was already done for function literals. It is important in cases
where only one overload of a method takes a `Function1` or
`PartialFunction`, for example:

    def map[U](f: T => U): R[U]
    def map[U](f: (A, B) => U): R[C]

By recognizing that a partial function literal always conforms to
`PartialFunction[Any, Nothing]`, in a call such as

    m.map { case (a, b) => a }

the non-matching overload (which takes a `Function2`) can be eliminated
early, thus allowing the known types `A` and `B` to be used during
type-checking of the partial function (which would otherwise fail).