### PR TITLE
[Do not merge] Testing building with Java 9 in our CI environment.

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.4-b646662

--- a/scripts/common
+++ b/scripts/common
@@ -19,7 +19,7 @@ mkdir -p $IVY_CACHE
 rm -rf $IVY_CACHE/cache/org.scala-lang
 
 SBT_CMD=${sbtCmd-sbt}
-SBT_CMD="$SBT_CMD -sbt-version 0.13.13"
+SBT_CMD="$SBT_CMD -sbt-version 0.13.14-b646662"
 
 # temp dir where all 'non-build' operation are performed
 TMP_ROOT_DIR=$(mktemp -d -t pr-scala.XXXX)

--- a/scripts/common
+++ b/scripts/common
@@ -19,7 +19,7 @@ mkdir -p $IVY_CACHE
 rm -rf $IVY_CACHE/cache/org.scala-lang
 
 SBT_CMD=${sbtCmd-sbt}
-SBT_CMD="$SBT_CMD -sbt-version 0.13.14-b646662"
+SBT_CMD="$SBT_CMD -sbt-version 0.13.14-b646662 -Dscala.ext.dirs=$JAVA_HOME/scala-ext"
 
 # temp dir where all 'non-build' operation are performed
 TMP_ROOT_DIR=$(mktemp -d -t pr-scala.XXXX)


### PR DESCRIPTION
I've run `sbt publishLocal` on the CI server to make SBT 0.13.4-b646662
available. This includes changes to be compatible with Java 9.

I've also installed JDK9-ea on the CI server, and made it selectable
with `jvmSelect oracle 9`:

  https://github.com/scala/scala-jenkins-infra/pull/221

Finally, I've used:

  https://github.com/retronym/java9-rt-export

to export a Java 8-style rt.jar to make scalac work without
needing native support for reading the jrt:// virtual filesystem
containing the standard library classes. Scala 2.12.1 and higher
support this, but SBT itself still uses Scala 2.10.6, so the shim
JAR is required.

This commit uses 0.13.4-b646662 for this build, and sets an system
property to instruct scalac to add the rt.jar shim to the compilation
classpath.