### PR TITLE
More groundwork for JDK 9 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,7 @@
  *   - to modularize the Scala compiler or library further
  */
 
+import scala.build._
 import VersionUtil._
 
 // Scala dependencies:

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -1,3 +1,5 @@
+package scala.build
+
 import sbt._
 
 /** This object defines keys that should be visible with an unqualified name in all .sbt files and the command line */

--- a/project/GenerateAnyVals.scala
+++ b/project/GenerateAnyVals.scala
@@ -1,3 +1,5 @@
+package scala.build
+
 /** Code generation of the AnyVal types and their companions. */
 trait GenerateAnyValReps {
   self: GenerateAnyVals =>

--- a/project/JarJar.scala
+++ b/project/JarJar.scala
@@ -1,3 +1,5 @@
+package scala.build
+
 import org.pantsbuild.jarjar
 import org.pantsbuild.jarjar._
 import org.pantsbuild.jarjar.util._

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -1,3 +1,5 @@
+package scala.build
+
 // It would be nice to use sbt-mima-plugin here, but the plugin is missing
 // at least two features we need:
 // * ability to run MiMa twice, swapping `curr` and `prev`, to detect

--- a/project/Osgi.scala
+++ b/project/Osgi.scala
@@ -1,3 +1,5 @@
+package scala.build
+
 import aQute.bnd.osgi.Builder
 import aQute.bnd.osgi.Constants._
 import java.util.Properties

--- a/project/ParserUtil.scala
+++ b/project/ParserUtil.scala
@@ -1,3 +1,5 @@
+package scala.build
+
 import sbt._
 import sbt.complete.Parser._
 import sbt.complete.Parsers._

--- a/project/PartestUtil.scala
+++ b/project/PartestUtil.scala
@@ -1,3 +1,5 @@
+package scala.build
+
 import sbt._
 import sbt.complete._, Parser._, Parsers._
 

--- a/project/Quiet.scala
+++ b/project/Quiet.scala
@@ -1,3 +1,5 @@
+package scala.build
+
 import sbt._
 import Keys._
 

--- a/project/ScalaOptionParser.scala
+++ b/project/ScalaOptionParser.scala
@@ -1,3 +1,5 @@
+package scala.build
+
 import ParserUtil._
 import sbt._
 import sbt.complete.Parser._

--- a/project/ScalaTool.scala
+++ b/project/ScalaTool.scala
@@ -1,3 +1,5 @@
+package scala.build
+
 import sbt._
 import org.apache.commons.lang3.SystemUtils
 import org.apache.commons.lang3.StringUtils.replaceEach

--- a/project/ScriptCommands.scala
+++ b/project/ScriptCommands.scala
@@ -1,3 +1,5 @@
+package scala.build
+
 import sbt._
 import Keys._
 import BuildSettings.autoImport._

--- a/project/VersionUtil.scala
+++ b/project/VersionUtil.scala
@@ -1,3 +1,5 @@
+package scala.build
+
 import sbt._
 import Keys._
 import java.util.Properties

--- a/src/reflect/scala/reflect/internal/util/AbstractFileClassLoader.scala
+++ b/src/reflect/scala/reflect/internal/util/AbstractFileClassLoader.scala
@@ -92,7 +92,7 @@ class AbstractFileClassLoader(val root: AbstractFile, parent: ClassLoader)
     }
   }
 
-  private val packages = mutable.Map[String, Package]()
+  private[this] val packages = mutable.Map[String, Package]()
 
   override def definePackage(name: String, specTitle: String, specVersion: String, specVendor: String, implTitle: String, implVersion: String, implVendor: String, sealBase: URL): Package = {
     throw new UnsupportedOperationException()

--- a/src/repl/scala/tools/nsc/interpreter/Scripted.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Scripted.scala
@@ -331,7 +331,7 @@ class WriterOutputStream(writer: Writer) extends OutputStream {
     byteBuffer.flip()
     val result = decoder.decode(byteBuffer, charBuffer, /*eoi=*/ false)
     if (byteBuffer.remaining == 0) byteBuffer.clear()
-    if (charBuffer.position > 0) {
+    if (charBuffer.position() > 0) {
       charBuffer.flip()
       writer write charBuffer.toString
       charBuffer.clear()

--- a/versions.properties
+++ b/versions.properties
@@ -21,7 +21,7 @@ scala-swing.version.number=2.0.0
 scala-swing.version.osgi=2.0.0
 jline.version=2.14.3
 # this one is shaded and embedded in scala-compiler.jar
-scala-asm.version=5.1.0-scala-1
+scala-asm.version=5.1.0-scala-2
 
 # external modules, used internally (not shipped)
 partest.version.number=1.1.0


### PR DESCRIPTION
Workaround an as-yet-unsolved problem in SBT+runtime reflection;
make some small changes to our code to compile against the Java 9
standard library.

With this, I can build using Java 9

    % java_use 8
    % sbt 'setupPublishCore' publishLocal
    % java_use 9
    % sbt -sbt-version 0.13.14-b646662 -Dstarr.version=2.12.2-96e8e97-SNAPSHOT \
     -Dscala.ext.dirs=/Library/Java/JavaVirtualMachines/jdk-9.jdk/Contents/Home/scala-ext \
      dist/mkQuick

This will all get a little easier once
  - we restarr
  - SBT 0.13.14 is released,
  - SBT launcher absorbs my utility to export rt.jar from JDK9
    https://github.com/sbt/sbt-launcher-package/pull/143

I also need to fix a performance problem in our new classpath implementation
based on the jrt:// filesystem.