### PR TITLE
SI-10194: Fix abstract type resolution for overloaded HOFs

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3333,15 +3333,15 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           def handleOverloaded = {
             val undetparams = context.undetparams
 
-            def funArgTypes(tps: List[Type]) = tps.map { tp =>
-              val relTp = tp.asSeenFrom(pre, fun.symbol.owner)
+            def funArgTypes(tpAlts: List[(Type, Symbol)]) = tpAlts.map { case (tp, alt) =>
+              val relTp = tp.asSeenFrom(pre, alt.owner)
               val argTps = functionOrSamArgTypes(relTp)
               //println(s"funArgTypes $argTps from $relTp")
               argTps.map(approximateAbstracts)
             }
 
-            def functionProto(argTps: List[Type]): Type =
-              try functionType(funArgTypes(argTps).transpose.map(lub), WildcardType)
+            def functionProto(argTpWithAlt: List[(Type, Symbol)]): Type =
+              try functionType(funArgTypes(argTpWithAlt).transpose.map(lub), WildcardType)
               catch { case _: IllegalArgumentException => WildcardType }
 
             // To propagate as much information as possible to typedFunction, which uses the expected type to
@@ -3355,21 +3355,21 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             // do not receive special treatment: they are typed under WildcardType.)
             val altArgPts =
               if (settings.isScala212 && args.exists(treeInfo.isFunctionMissingParamType))
-                try alts.map(alt => formalTypes(alt.info.paramTypes, argslen)).transpose // do least amount of work up front
+                try alts.map(alt => formalTypes(alt.info.paramTypes, argslen).map(ft => (ft, alt))).transpose // do least amount of work up front
                 catch { case _: IllegalArgumentException => args.map(_ => Nil) } // fail safe in case formalTypes fails to align to argslen
               else args.map(_ => Nil) // will type under argPt == WildcardType
 
             val (args1, argTpes) = context.savingUndeterminedTypeParams() {
               val amode = forArgMode(fun, mode)
 
-              map2(args, altArgPts) { (arg, argPts) =>
+              map2(args, altArgPts) { (arg, argPtAlts) =>
                 def typedArg0(tree: Tree) = {
                   // if we have an overloaded HOF such as `(f: Int => Int)Int <and> (f: Char => Char)Char`,
                   // and we're typing a function like `x => x` for the argument, try to collapse
                   // the overloaded type into a single function type from which `typedFunction`
                   // can derive the argument type for `x` in the function literal above
                   val argPt =
-                    if (argPts.nonEmpty && treeInfo.isFunctionMissingParamType(tree)) functionProto(argPts)
+                    if (argPtAlts.nonEmpty && treeInfo.isFunctionMissingParamType(tree)) functionProto(argPtAlts)
                     else WildcardType
 
                   val argTyped = typedArg(tree, amode, BYVALmode, argPt)

--- a/test/files/pos/overloaded_ho_fun.scala
+++ b/test/files/pos/overloaded_ho_fun.scala
@@ -49,3 +49,18 @@ object sorting {
 //   def andThen[C](g: Bijection[B, C]): Bijection[A, C] = ???
 //   def compose[T](g: Bijection[T, A]) = g andThen this
 // }
+
+object SI10194 {
+  trait X[A] {
+    def map[B](f: A => B): Unit
+  }
+
+  trait Y[A] extends X[A] {
+    def map[B](f: A => B)(implicit ordering: Ordering[B]): Unit
+  }
+
+  trait Z[A] extends Y[A]
+
+  (null: Y[Int]).map(x => x.toString) // compiled
+  (null: Z[Int]).map(x => x.toString) // didn't compile
+}


### PR DESCRIPTION
Types in the applicable overload alternatives need to be seen from
the respective owners of the individual alternative, not from the
target’s owner (which can be a subtype of the types that define the
methods).