### PR TITLE
SI-10178 Route reporter.echo to stdout

### DIFF
--- a/src/compiler/scala/tools/nsc/reporters/ConsoleReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/ConsoleReporter.scala
@@ -14,8 +14,10 @@ import StringOps.{countElementsAsString => countAs, trimAllTrailingSpace => trim
 
 /** This class implements a Reporter that displays messages on a text console.
  */
-class ConsoleReporter(val settings: Settings, reader: BufferedReader, writer: PrintWriter) extends AbstractReporter {
-  def this(settings: Settings) = this(settings, Console.in, new PrintWriter(Console.err, true))
+class ConsoleReporter(val settings: Settings, reader: BufferedReader, writer: PrintWriter, echoWriter: PrintWriter) extends AbstractReporter {
+  def this(settings: Settings) = this(settings, Console.in, new PrintWriter(Console.err, true), new PrintWriter(Console.out, true))
+  def this(settings: Settings, reader: BufferedReader, writer: PrintWriter) =
+    this(settings, reader, writer, writer)
 
   /** Whether a short file name should be displayed before errors */
   var shortname: Boolean = false
@@ -39,6 +41,12 @@ class ConsoleReporter(val settings: Settings, reader: BufferedReader, writer: Pr
   def printMessage(msg: String): Unit = {
     writer.println(trimTrailing(msg))
     writer.flush()
+  }
+
+  /** Prints the message to the echoWriter, which is usually stdout. */
+  override def echo(msg: String): Unit = {
+    echoWriter.println(trimTrailing(msg))
+    echoWriter.flush()
   }
 
   /** Prints the message with the given position indication. */


### PR DESCRIPTION
`echo` is currently used only for usage information, and that makes a lot more sense to 
go to stdout instead of stderr. This allows grepping through the extensive list of
compiler options.

```
$ build/quick/bin/scalac -Y | grep macro
  -Ymacro-debug-lite                       Trace essential macro-related activities.
  -Ymacro-debug-verbose                    Trace all macro-related activities: compilation, generation of synthetics, classloading, expansion, exceptions.
  -Ymacro-expand:<policy>                  Control expansion of macros, useful for scaladoc and presentation compiler. Choices: (normal,none,discard), default: normal.
  -Ymacro-no-expand                        Don't expand macros. Might be useful for scaladoc and presentation compiler, but will crash anything which uses macros and gets past typer.
                                             deprecated: Use -Ymacro-expand:none
```