### PR TITLE
Ensure ordering for args to `choose` in DurationTest

### DIFF
--- a/test/scalacheck/duration.scala
+++ b/test/scalacheck/duration.scala
@@ -32,7 +32,10 @@ object DurationTest extends Properties("Division of Duration by Long") {
   val genClose = for {
     a <- weightedLong
     if a != 0
-    b <- choose(Long.MaxValue / a - 10, Long.MaxValue / a + 10)
+    val center = Long.MaxValue / a
+    b <-
+      if (center - 10 < center + 10) choose(center - 10,  center + 10)
+      else choose(center + 10,  center - 10) // deal with overflow if abs(a) == 1
   } yield (a, b)
 
   val genBorderline =


### PR DESCRIPTION
Fix scala/scala-dev#296