### PR TITLE
SI-10148 Accept verbose zero

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -983,6 +983,8 @@ trait Scanners extends ScannersCommon {
 
     def intVal: Long = intVal(negated = false)
 
+    private val zeroFloat = raw"[0.]+(?:[eE][+-]?[0-9]+)?[fFdD]?".r
+
     /** Convert current strVal, base to float value.
      */
     def floatVal(negated: Boolean): Float = {
@@ -990,8 +992,7 @@ trait Scanners extends ScannersCommon {
         val value: Float = java.lang.Float.parseFloat(strVal)
         if (value > Float.MaxValue)
           syntaxError("floating point number too large")
-        val zeroly = "0.fF"
-        if (value == 0.0f && strVal.exists(c => !zeroly.contains(c)))
+        if (value == 0.0f && !zeroFloat.pattern.matcher(strVal).matches)
           syntaxError("floating point number too small")
         if (negated) -value else value
       } catch {
@@ -1010,8 +1011,7 @@ trait Scanners extends ScannersCommon {
         val value: Double = java.lang.Double.parseDouble(strVal)
         if (value > Double.MaxValue)
           syntaxError("double precision floating point number too large")
-        val zeroly = "0.dD"
-        if (value == 0.0d && strVal.exists(c => !zeroly.contains(c)))
+        if (value == 0.0d && !zeroFloat.pattern.matcher(strVal).matches)
           syntaxError("double precision floating point number too small")
         if (negated) -value else value
       } catch {

--- a/test/files/run/literals.scala
+++ b/test/files/run/literals.scala
@@ -6,7 +6,7 @@
 
 object Test {
 
-  /* I add a couple of Unicode identifier tests here temporarily */
+  /* I add a couple of Unicode identifier tests here "temporarily" */
 
   def \u03b1\u03c1\u03b5\u03c4\u03b7 = "alpha rho epsilon tau eta"
 
@@ -80,6 +80,9 @@ object Test {
     check_success("1e1f == 10.0f", 1e1f, 10.0f)
     check_success(".3f == 0.3f", .3f, 0.3f)
     check_success("0f == 0.0f", 0f, 0.0f)
+    check_success("0f == -0.000000000000000000e+00f", 0f, -0.000000000000000000e+00f)
+    check_success("0f == -0.000000000000000000e+00F", 0f, -0.000000000000000000e+00F)
+    check_success("0f == -0.0000000000000000e14f", 0f, -0.0000000000000000e14f)
     check_success("01.23f == 1.23f", 01.23f, 1.23f)
     check_success("3.14f == 3.14f", 3.14f, 3.14f)
     check_success("6.022e23f == 6.022e23f", 6.022e23f, 6.022e23f)
@@ -96,6 +99,11 @@ object Test {
     check_success(".3 == 0.3", .3, 0.3)
     check_success("0.0 == 0.0", 0.0, 0.0)
     check_success("0d == 0.0", 0d, 0.0)
+    check_success("0d == 0.000000000000000000e+00d", 0d, 0.000000000000000000e+00d)
+    check_success("0d == -0.000000000000000000e+00d", 0d, -0.000000000000000000e+00d)
+    check_success("0d == -0.000000000000000000e+00D", 0d, -0.000000000000000000e+00D)
+    check_success("0.0 == 0.000000000000000000e+00", 0.0, 0.000000000000000000e+00)
+    check_success("0.0 == -0.000000000000000000e+00", 0.0, -0.000000000000000000e+00)
     check_success("01.23 == 1.23", 01.23, 1.23)
     check_success("01.23d == 1.23d", 01.23d, 1.23d)
     check_success("3.14 == 3.14", 3.14, 3.14)


### PR DESCRIPTION
The test for non-zero must recognize `-0e+00f` and variants.

This is a follow-up to https://github.com/scala/scala/pull/5648

Community build, I think I love you.

You too, @SethTisue 
