### PR TITLE
Remove the error recovery mechanism in RedBlackTree.TreeIterator.

### DIFF
--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -486,23 +486,8 @@ object RedBlackTree {
       else findLeftMostOrPopOnEmpty(goLeft(tree))
 
     private[this] def pushNext(tree: Tree[A, B]) {
-      try {
-        stackOfNexts(index) = tree
-        index += 1
-      } catch {
-        case _: ArrayIndexOutOfBoundsException =>
-          /*
-           * Either the tree became unbalanced or we calculated the maximum height incorrectly.
-           * To avoid crashing the iterator we expand the path array. Obviously this should never
-           * happen...
-           *
-           * An exception handler is used instead of an if-condition to optimize the normal path.
-           * This makes a large difference in iteration speed!
-           */
-          assert(index >= stackOfNexts.length)
-          stackOfNexts :+= null
-          pushNext(tree)
-      }
+      stackOfNexts(index) = tree
+      index += 1
     }
     private[this] def popNext(): Tree[A, B] = if (index == 0) null else {
       index -= 1


### PR DESCRIPTION
After fixing the stack size computation in 648eba62b0054d7a0442de3f5a79eb75d38e7602, this commit removes the error recovery mechanism which hid the internal bug. As the comment in `pushNext` says, "Obviously this should never happen".

This commit is potentially risky, if we still do wrongly compute the maximum stack size, but further problems are not caught by the test suite. But at least we would now know when we fail to compute the stack size correctly, instead of letting it go unnoticed for years.

This change also ensures that Scala/JVM does not silently succeed where Scala.js would fail.

This is follow up of https://github.com/scala/scala/pull/5645, now that its content has reached the 2.13.x branch. Since @szeiger reviewed #5645, I assign this one to him as well.