### PR TITLE
Move dealiasing from Uncurry to Erasure

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/TreeGen.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeGen.scala
@@ -146,9 +146,8 @@ abstract class TreeGen extends scala.reflect.internal.TreeGen with TreeDSL {
     debuglog("casting " + tree + ":" + tree.tpe + " to " + pt + " at phase: " + phase)
     assert(!tree.tpe.isInstanceOf[MethodType], tree)
     assert(!pt.isInstanceOf[MethodType], tree)
-    assert(pt eq pt.normalize, tree +" : "+ debugString(pt) +" ~>"+ debugString(pt.normalize))
     atPos(tree.pos) {
-      mkAsInstanceOf(tree, pt, any = !phase.next.erasedTypes, wrapInApply = isAtPhaseAfter(currentRun.uncurryPhase))
+      mkAsInstanceOf(tree, pt.normalize, any = !phase.next.erasedTypes, wrapInApply = isAtPhaseAfter(currentRun.uncurryPhase))
     }
   }
 

--- a/test/files/run/delambdafy_t6555.check
+++ b/test/files/run/delambdafy_t6555.check
@@ -1,6 +1,6 @@
 [[syntax trees at end of                specialize]] // newSource1.scala
 package <empty> {
-  class Foo extends Object {
+  class Foo extends AnyRef {
     def <init>(): Foo = {
       Foo.super.<init>();
       ()

--- a/test/files/run/delambdafy_uncurry_byname_inline.check
+++ b/test/files/run/delambdafy_uncurry_byname_inline.check
@@ -1,6 +1,6 @@
 [[syntax trees at end of                   uncurry]] // newSource1.scala
 package <empty> {
-  class Foo extends Object {
+  class Foo extends AnyRef {
     def <init>(): Foo = {
       Foo.super.<init>();
       ()

--- a/test/files/run/delambdafy_uncurry_byname_method.check
+++ b/test/files/run/delambdafy_uncurry_byname_method.check
@@ -1,6 +1,6 @@
 [[syntax trees at end of                   uncurry]] // newSource1.scala
 package <empty> {
-  class Foo extends Object {
+  class Foo extends AnyRef {
     def <init>(): Foo = {
       Foo.super.<init>();
       ()

--- a/test/files/run/delambdafy_uncurry_inline.check
+++ b/test/files/run/delambdafy_uncurry_inline.check
@@ -1,6 +1,6 @@
 [[syntax trees at end of                   uncurry]] // newSource1.scala
 package <empty> {
-  class Foo extends Object {
+  class Foo extends AnyRef {
     def <init>(): Foo = {
       Foo.super.<init>();
       ()

--- a/test/files/run/delambdafy_uncurry_method.check
+++ b/test/files/run/delambdafy_uncurry_method.check
@@ -1,6 +1,6 @@
 [[syntax trees at end of                   uncurry]] // newSource1.scala
 package <empty> {
-  class Foo extends Object {
+  class Foo extends AnyRef {
     def <init>(): Foo = {
       Foo.super.<init>();
       ()

--- a/test/files/run/t6308.check
+++ b/test/files/run/t6308.check
@@ -10,7 +10,6 @@ f5 f5$mIc$sp
 f4(Boolean) f4
 f4(String)  f4
 
-// Ideally these would be specialized
-todo1 todo1
-todo2 todo2
-todo3 todo3
+aliasF1 aliasF1$mIc$sp
+aliasF2 aliasF2$mIc$sp
+aliasF3 aliasF3$mIc$sp

--- a/test/files/run/t6308.scala
+++ b/test/files/run/t6308.scala
@@ -13,13 +13,10 @@ object Test {
 
   def f5[@sp(Int) A, B <: Object](a: A, b: B)  = { val c = caller; print(""); c }
 
-  // `uncurryTreeType` calls a TypeMap on the call to this method and we end up with new
-  // type parameter symbols, which are not found in `TypeEnv.includes(typeEnv(member), env)`
-  // in `specSym`. (One of `uncurry`'s tasks is to expand type aliases in signatures.)
   type T = Object
-  def todo1[@sp(Int) A, B <: T](a: A, b: String)           = { val c = caller; print(""); c }
-  def todo2[@sp(Int) A, B <: AnyRef](a: A, b: String)      = { val c = caller; print(""); c }
-  def todo3[B <: List[A], @specialized(Int) A](a: A, b: B) = { val c = caller; print(""); c }
+  def aliasF1[@sp(Int) A, B <: T](a: A, b: String)           = { val c = caller; print(""); c }
+  def aliasF2[@sp(Int) A, B <: AnyRef](a: A, b: String)      = { val c = caller; print(""); c }
+  def aliasF3[B <: List[A], @specialized(Int) A](a: A, b: B) = { val c = caller; print(""); c }
 
   def main(args: Array[String]) {
     val s = ""
@@ -36,10 +33,9 @@ object Test {
           |f4(Boolean) ${f4(Boolean,Nil)}
           |f4(String)  ${f4("",Nil)}
           |
-          |// Ideally these would be specialized
-          |todo1 ${todo1(1,s)}
-          |todo2 ${todo2(1,s)}
-          |todo3 ${todo3(1,List(0))}""".stripMargin
+          |aliasF1 ${aliasF1(1,s)}
+          |aliasF2 ${aliasF2(1,s)}
+          |aliasF3 ${aliasF3(1,List(0))}""".stripMargin
     println(result)
   }
 }

--- a/test/files/run/t6555.check
+++ b/test/files/run/t6555.check
@@ -1,6 +1,6 @@
 [[syntax trees at end of                specialize]] // newSource1.scala
 package <empty> {
-  class Foo extends Object {
+  class Foo extends AnyRef {
     def <init>(): Foo = {
       Foo.super.<init>();
       ()

--- a/test/junit/scala/tools/nsc/backend/jvm/GenericSignaturesTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/GenericSignaturesTest.scala
@@ -60,4 +60,23 @@ class GenericSignaturesTest extends BytecodeTesting {
     assertEquals(List(("MODULE$", null), ("key", null)),
       cM.fields.asScala.toList.map(f => (f.name, f.signature)).sorted)
   }
+
+  @Test
+  def alias(): Unit = {
+    val code =
+      """
+        |import scala.language._
+        |class T[M[_]]
+        |class C {
+        |  type A = String => String
+        |  type B[X] = List[X]
+        |  private[this] val a: A = null
+        |  private[this] val b: T[B] = null
+        |}
+      """.stripMargin
+    val List(c, t) = compileClasses(code)
+    assertEquals(List(("a", "Lscala/Function1<Ljava/lang/String;Ljava/lang/String;>;"), ("b", "LT<Lscala/collection/immutable/List;>;")),
+      c.fields.asScala.toList.map(f => (f.name, f.signature)).sorted)
+
+  }
 }


### PR DESCRIPTION
The motivation is to make the uncurry info tranform an identity
for more method signatures.

A few spots in erasure needed to be updated to account for
the possibility of aliases, by callng normalize and/or using
baseType rather than just assuming that the type args and class
type params line up.

Fixes scala/scala-dev#297