### PR TITLE
add comonadic comprehensions (keyword 'cofor')

### DIFF
--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -388,6 +388,10 @@ filter {
         problemName=DirectMissingMethodProblem
     },
     {
+        matchName="scala.reflect.runtime.Settings.YcoforExtension"
+        problemName=MissingMethodProblem
+    },
+    {
         matchName="scala.collection.mutable.ArrayOps$ofFloat"
         problemName=MissingTypesProblem
     },

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1516,6 +1516,24 @@ self =>
             tree setPos tree.pos.withStart(start)
           else tree
         adjustStart(parseFor)
+      case COFOR if settings.YcoforExtension =>
+        val start = in.skipToken()
+        def parseCoFor = atPos(start) {
+          
+          val inputPattern = inParens(gen.patvarTransformer.transform(noSeq.pattern1()))
+          val enums =
+            inBraces(cofor_enumerators())
+          newLinesOpt()
+          accept(YIELD)
+ 
+          gen.mkCoFor(inputPattern, enums, expr())
+
+        }
+        def adjustStart(tree: Tree) =
+          if (tree.pos.isRange && start < tree.pos.start)
+            tree setPos tree.pos.withStart(start)
+          else tree
+        adjustStart(parseCoFor)
       case RETURN =>
         def parseReturn =
           atPos(in.skipToken()) {
@@ -1822,7 +1840,39 @@ self =>
       }
       enums.toList
     }
+    /** {{{
+     *  Enumerators ::= Generator {semi Enumerator}
+     *  Enumerator  ::=  Generator
+     *  }}}
+     */
+    def cofor_enumerators(): List[Tree] = {
+      val enums = new ListBuffer[Tree]
+      enums ++= cofor_generator
+      while (isStatSep) {
+        in.nextToken()
+        enums ++= cofor_generator
+      }
+      enums.toList
+    }
+    
+    /** {{{
+     *  Generator ::= Pattern1 (`<-') Expr 
+     *  }}}
+     */
+    def cofor_generator: List[Tree] = {
+      val start = in.offset
 
+      val pat = noSeq.pattern1()
+      val point = in.offset
+
+      accept(LARROW)
+      val rhs = expr()
+      // why max? IDE stress tests have shown that lastOffset could be less than start,
+      // I guess this happens if instead if a for-expression we sit on a closing paren.
+      val genPos = r2p(start, point, in.lastOffset max start)
+      gen.mkCoForGenerator(genPos, pat, rhs) +: Nil
+    }
+	
     def enumerator(isFirst: Boolean, allowNestedIf: Boolean = true): List[Tree] =
       if (in.token == IF && !isFirst) makeFilter(in.offset, guard()) :: Nil
       else generator(!isFirst, allowNestedIf)

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -1166,7 +1166,11 @@ trait Scanners extends ScannersCommon {
 
   // ------------- keyword configuration -----------------------------------
 
-  private val allKeywords = List[(Name, Token)](
+  private[this] val addKeywords: List[(Name, Token)] => List[(Name, Token)] =
+    if (settings.YcoforExtension) ((nme.COFORkw -> COFOR) +: _)  else ( identity)
+  private val allKeywords = 
+		  addKeywords(
+    List[(Name, Token)](
     nme.ABSTRACTkw  -> ABSTRACT,
     nme.CASEkw      -> CASE,
     nme.CATCHkw     -> CATCH,
@@ -1219,7 +1223,7 @@ trait Scanners extends ScannersCommon {
     nme.ATkw        -> AT,
     nme.MACROkw     -> IDENTIFIER,
     nme.THENkw      -> IDENTIFIER)
-
+    )
   private var kwOffset: Offset = -1
   private val kwArray: Array[Token] = {
     val (offset, arr) = createKeywordArray(allKeywords, IDENTIFIER)

--- a/src/compiler/scala/tools/nsc/ast/parser/Tokens.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Tokens.scala
@@ -42,6 +42,8 @@ object Tokens extends CommonTokens {
   final val YIELD = 86
   final val MATCH = 95
 
+  final val COFOR = 126
+  
   /** special symbols */
   final val HASH = 130
   final val USCORE = 131

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -222,7 +222,9 @@ trait ScalaSettings extends AbsScalaSettings
 
   val exposeEmptyPackage = BooleanSetting ("-Yexpose-empty-package", "Internal only: expose the empty package.").internalOnly()
   val Ydelambdafy        = ChoiceSetting  ("-Ydelambdafy", "strategy", "Strategy used for translating lambdas into JVM code.", List("inline", "method"), "method")
-
+  val YcoforExtension   = BooleanSetting ("-Ycofor-extension", "Enable cofor keyword")
+  
+  
   object optChoices extends MultiChoiceEnumeration {
     val unreachableCode         = Choice("unreachable-code",          "Eliminate unreachable code, exception handlers guarding no instructions, redundant metadata (debug information, line numbers).")
     val simplifyJumps           = Choice("simplify-jumps",            "Simplify branching instructions, eliminate unnecessary ones.")

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -61,6 +61,8 @@ trait StdAttachments {
    */
   case object ForAttachment extends PlainAttachment
 
+  case object CoforAttachment extends PlainAttachment
+  
   /** Identifies unit constants which were inserted by the compiler (e.g. gen.mkBlock)
    */
   case object SyntheticUnitAttachment extends PlainAttachment

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -172,6 +172,7 @@ trait StdNames {
     final val CASEkw: TermName      = kw("case")
     final val CLASSkw: TermName     = kw("class")
     final val CATCHkw: TermName     = kw("catch")
+	final val COFORkw: TermName     = kw("cofor")
     final val DEFkw: TermName       = kw("def")
     final val DOkw: TermName        = kw("do")
     final val ELSEkw: TermName      = kw("else")
@@ -667,6 +668,7 @@ trait StdNames {
     val canEqual_ : NameType           = "canEqual"
     val classOf: NameType              = "classOf"
     val clone_ : NameType              = "clone"
+	val coflatMap : NameType           = "coflatMap"
     val collection: NameType           = "collection"
     val conforms: NameType             = "$conforms" // dollar prefix to avoid accidental shadowing
     val copy: NameType                 = "copy"
@@ -688,6 +690,7 @@ trait StdNames {
     val error: NameType                = "error"
     val ex: NameType                   = "ex"
     val experimental: NameType         = "experimental"
+	val extract: NameType              = "extract"
     val f: NameType                    = "f"
     val false_ : NameType              = "false"
     val filter: NameType               = "filter"

--- a/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
+++ b/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
@@ -55,6 +55,7 @@ abstract class MutableSettings extends AbsSettings {
   def verbose: BooleanSetting
   def YpartialUnification: BooleanSetting
   def Yvirtpatmat: BooleanSetting
+  def YcoforExtension: BooleanSetting
 
   def Yrecursion: IntSetting
   def maxClassfileName: IntSetting

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -41,6 +41,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.DelambdafyTarget
     this.BackquotedIdentifierAttachment
     this.ForAttachment
+    this.CoforAttachment
     this.SyntheticUnitAttachment
     this.SubpatternsAttachment
     this.NoInlineCallsiteAttachment

--- a/src/reflect/scala/reflect/runtime/Settings.scala
+++ b/src/reflect/scala/reflect/runtime/Settings.scala
@@ -49,7 +49,8 @@ private[reflect] class Settings extends MutableSettings {
   val verbose           = new BooleanSetting(false)
   val YpartialUnification = new BooleanSetting(false)
   val Yvirtpatmat       = new BooleanSetting(false)
-
+  val YcoforExtension   = new BooleanSetting(false)
+  
   val Yrecursion        = new IntSetting(0)
   val maxClassfileName  = new IntSetting(255)
   def isScala211        = true

--- a/test/files/neg/cofor.check
+++ b/test/files/neg/cofor.check
@@ -1,0 +1,7 @@
+cofor.scala:54: error: ')' expected but '@' found.
+  val result : StreamZipper[Person] => (Person, Boolean, Int) = cofor (p @ Person(_, age)) {
+                                                                         ^
+cofor.scala:54: error: ';' expected but ')' found.
+  val result : StreamZipper[Person] => (Person, Boolean, Int) = cofor (p @ Person(_, age)) {
+                                                                                         ^
+two errors found

--- a/test/files/neg/cofor.scala
+++ b/test/files/neg/cofor.scala
@@ -1,0 +1,70 @@
+object Test {
+
+  def unfold[A, B](a: A)(f: A => Option[(B, A)]): Stream[B] = f(a) match {
+    case Some((b, a)) => b #:: unfold(a)(f)
+    case None         => Stream.empty
+  }
+
+  case class StreamZipper[A](left: Stream[A], focus: A, right: Stream[A]) {
+    def next = right match {
+      case h +: rest => Some(StreamZipper(focus +: left, h, rest))
+      case _         => None
+
+    }
+    def previous = left match {
+      case h +: rest => Some(StreamZipper(rest, h, focus +: right))
+      case _         => None
+
+    }
+    def map[B](f: A => B) = StreamZipper(left map f, f(focus), right map f)
+    def extract = focus
+    def duplicate: StreamZipper[StreamZipper[A]] = {
+      val r = unfold(this)(z => z.next.map(x => (x, x)))
+      val l = unfold(this)(z => z.previous.map(x => (x, x)))
+      StreamZipper(l, this, r)
+    }
+    def coflatMap[B](f: StreamZipper[A] => B): StreamZipper[B] = duplicate map f
+
+    def toStream = left.reverse ++ (focus +: right)
+    
+  }
+  
+  def stream2zipper[A](sa: Stream[A]) = sa match {
+    case h +: rest => Some(StreamZipper(Stream.empty, h, rest))
+    case _ => None
+  }
+  
+  
+  case class Person(name: String, age: Int)
+  
+  
+  val people = Stream(Person("john", 40),Person("alice", 45),Person("jones", 50),Person("bob", 60),Person("jane", 50))
+  
+  
+  val Some(zi) = stream2zipper(people)
+  def isSandwitch(z : StreamZipper[Int]) = z match {
+    case StreamZipper(pi +: _, i, ni +: _) if (pi < i && i < ni) => true
+    case _ => false
+  }
+  
+  def fff(z : StreamZipper[Person]) = z.extract
+  def numberOfTruth(z: StreamZipper[Boolean]) : Int  = 
+    if (z.focus) 1 + z.right.takeWhile(true ==).size else 0
+  
+  val result : StreamZipper[Person] => (Person, Boolean, Int) = cofor (p @ Person(_, age)) {
+    tag <- isSandwitch(age)
+    count <- numberOfTruth(tag)
+  } yield (p.extract, tag.extract, count.extract)
+  
+  
+  zi.coflatMap(result).toStream
+  
+  val result2 : StreamZipper[Person] => (Person, Boolean, Int) = cofor (p) {
+    Person(_, age) <- fff(p)
+    tag <- isSandwitch(age)
+    count <- numberOfTruth(tag)
+  } yield (p.extract, tag.extract, count.extract)
+  
+  
+  zi.coflatMap(result2).toStream
+}

--- a/test/files/pos/cofor.flags
+++ b/test/files/pos/cofor.flags
@@ -1,0 +1,1 @@
+-Ycofor-extension

--- a/test/files/pos/cofor.scala
+++ b/test/files/pos/cofor.scala
@@ -1,0 +1,70 @@
+object Test {
+
+  def unfold[A, B](a: A)(f: A => Option[(B, A)]): Stream[B] = f(a) match {
+    case Some((b, a)) => b #:: unfold(a)(f)
+    case None         => Stream.empty
+  }
+
+  case class StreamZipper[A](left: Stream[A], focus: A, right: Stream[A]) {
+    def next = right match {
+      case h +: rest => Some(StreamZipper(focus +: left, h, rest))
+      case _         => None
+
+    }
+    def previous = left match {
+      case h +: rest => Some(StreamZipper(rest, h, focus +: right))
+      case _         => None
+
+    }
+    def map[B](f: A => B) = StreamZipper(left map f, f(focus), right map f)
+    def extract = focus
+    def duplicate: StreamZipper[StreamZipper[A]] = {
+      val r = unfold(this)(z => z.next.map(x => (x, x)))
+      val l = unfold(this)(z => z.previous.map(x => (x, x)))
+      StreamZipper(l, this, r)
+    }
+    def coflatMap[B](f: StreamZipper[A] => B): StreamZipper[B] = duplicate map f
+
+    def toStream = left.reverse ++ (focus +: right)
+    
+  }
+  
+  def stream2zipper[A](sa: Stream[A]) = sa match {
+    case h +: rest => Some(StreamZipper(Stream.empty, h, rest))
+    case _ => None
+  }
+  
+  
+  case class Person(name: String, age: Int)
+  
+  
+  val people = Stream(Person("john", 40),Person("alice", 45),Person("jones", 50),Person("bob", 60),Person("jane", 50))
+  
+  
+  val Some(zi) = stream2zipper(people)
+  def isSandwitch(z : StreamZipper[Int]) = z match {
+    case StreamZipper(pi +: _, i, ni +: _) if (pi < i && i < ni) => true
+    case _ => false
+  }
+  
+  def fff(z : StreamZipper[Person]) = z.extract
+  def numberOfTruth(z: StreamZipper[Boolean]) : Int  = 
+    if (z.focus) 1 + z.right.takeWhile(true ==).size else 0
+  
+  val result : StreamZipper[Person] => (Person, Boolean, Int) = cofor (p @ Person(_, age)) {
+    tag <- isSandwitch(age)
+    count <- numberOfTruth(tag)
+  } yield (p.extract, tag.extract, count.extract)
+  
+  
+  zi.coflatMap(result).toStream
+  
+  val result2 : StreamZipper[Person] => (Person, Boolean, Int) = cofor (p) {
+    Person(_, age) <- fff(p)
+    tag <- isSandwitch(age)
+    count <- numberOfTruth(tag)
+  } yield (p.extract, tag.extract, count.extract)
+  
+  
+  zi.coflatMap(result2).toStream
+}


### PR DESCRIPTION
This is a proposal (POC) to provide a new keyword (cofor) for co-monadic comprehensions in Scala.
The work is based over Dominic Orchard and Alan Mycroft paper: https://www.cl.cam.ac.uk/~dao29/publ/codo-notation-orchard-ifl12.pdf

If you find the implementation flawed, it is me to blame and not them!

the 'cofor' expression returns a function: (T[A] => B).
The function's type MUST be stated explicitly in the call-site. e.g.:
val result: Zipper[Person] => Boolean = cofor...

the syntax:
cofor(inputpatten) {
pattern1 <- gen1
pattern2 <- gen2
...
} yield body

the 'cofor' and generator must use types that provide:
def map(A => B)
def extract: A
def coflatMap(T[A] => B)

implementation is much more complex than 'for' desugaring as stated in the paper.

current implementation supports full Scala patterns in the input and generator patterns.
missing:

desugared tree positioning validation (should not affect surrounding code)
quasiquotes/macros/reification -- this is the next phase in the implementation.
the flag to control the keyword: -Ycofor-extension
if the flag is not enabled, current Scala code should not be affected.

compatibility: adding a new keyword breaks existing use of 'cofor' identifier and it should be back-quoted.

Plz let me know your thoughts on this.