### PR TITLE
GH-644: Remove static html styling of spec code blocks

### DIFF
--- a/spec/_config.yml
+++ b/spec/_config.yml
@@ -1,7 +1,7 @@
 baseurl: /files/archive/spec/2.12
 safe: true
 lsi: false
-highlighter: null
+highlighter: false
 markdown: redcarpet
 encoding: utf-8
 redcarpet:


### PR DESCRIPTION
Prior to this Jekyll configuration change code blocks were being marked up
in a ways that disrupted MathJax styling.

Tested as far a possible locally. Confidence mainly drawn from html comparison
to working 2.11.x version.

My efforts to test locally have been frustrated by an inability to see the known good branch (2.11.x) working locally.

The key differences between the working 2.11.x html source and this is shown here: https://github.com/scala/scala.github.com/issues/644 (Search for _These are examples of the two types of differences_)

On the basis of the source html inspection I'm suggesting a merge as the next step in testing! If there's is an alternative please suggest.