### PR TITLE
More predictable performance of SBT build startup, reload

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,3 +20,7 @@ buildInfoKeys := Seq[BuildInfoKey](buildClasspath)
 buildInfoPackage := "scalabuild"
 
 libraryDependencies += "com.typesafe" %% "mima-reporter" % "0.1.13"
+
+concurrentRestrictions in Global := Seq(
+  Tags.limitAll(1) // workaround for https://github.com/sbt/sbt/issues/2970
+)


### PR DESCRIPTION
Disable parallelism to avoid a nasty interaction between the
SBT build info plugin, which internally uses `EvaluateTask`,
and can get into a race condition with other concurrnently
running tasks.

This could be seen as frequent, unnecessary Ivy resolution
during the `reload` command, even when nothing had changed.

Gory details in https://github.com/sbt/sbt/issues/2970