### PR TITLE
WIP SI-10081 avoid divergence in implicit scope search with f-bounds, annotated types

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1064,9 +1064,10 @@ trait Implicits {
        *                 in order to cache them in infoMapCache
        */
       def getParts(tp: Type)(implicit infoMap: InfoMap, seen: mutable.Set[Type], pending: Set[Symbol]) {
-        if (seen(tp))
+        val tpWithoutAnnotations = tp.map(_.withoutAnnotations)
+        if (seen(tpWithoutAnnotations))
           return
-        seen += tp
+        seen += tpWithoutAnnotations
         tp match {
           case TypeRef(pre, sym, args) =>
             if (sym.isClass) {

--- a/test/files/pos/t10081.scala
+++ b/test/files/pos/t10081.scala
@@ -1,0 +1,2 @@
+trait A[_]
+trait B[X] extends A[B[X @unchecked]] { this.x }


### PR DESCRIPTION
Fix by @retronym. LGTM. Let's run this through PR validation and get it merged. We keep running into this bug again and again in collections-strawman.