### PR TITLE
don't use Console.setOut: was deprecated, now deleted

### DIFF
--- a/src/manual/scala/tools/docutil/EmitHtml.scala
+++ b/src/manual/scala/tools/docutil/EmitHtml.scala
@@ -208,19 +208,19 @@ object EmitHtml {
     case _                          => sys.exit(1)
   }
 
-  def emitHtml(classname: String, outStream: java.io.OutputStream = out.out) {
-    if(outStream != out.out) out setOut outStream
-    try {
-      val cl = this.getClass.getClassLoader()
-      val clasz = cl loadClass classname
-      val meth = clasz getDeclaredMethod "manpage"
-      val doc = meth.invoke(null).asInstanceOf[Document]
-      emitDocument(doc)
-    } catch {
-      case ex: Exception =>
-        ex.printStackTrace()
-        System.err println "Error in EmitManPage"
-        sys.exit(1)
+  def emitHtml(classname: String, outStream: java.io.OutputStream = out.out): Unit =
+    Console.withOut(outStream) {
+      try {
+        val cl = this.getClass.getClassLoader()
+        val clasz = cl loadClass classname
+        val meth = clasz getDeclaredMethod "manpage"
+        val doc = meth.invoke(null).asInstanceOf[Document]
+        emitDocument(doc)
+      } catch {
+        case ex: Exception =>
+          ex.printStackTrace()
+          System.err println "Error in EmitManPage"
+          sys.exit(1)
+      }
     }
-  }
 }

--- a/src/manual/scala/tools/docutil/EmitManPage.scala
+++ b/src/manual/scala/tools/docutil/EmitManPage.scala
@@ -169,19 +169,19 @@ object EmitManPage {
     case _                          => sys.exit(1)
   }
 
-  def emitManPage(classname: String, outStream: java.io.OutputStream = out.out) {
-    if(outStream != out.out) out setOut outStream
-    try {
-      val cl = this.getClass.getClassLoader()
-      val clasz = cl loadClass classname
-      val meth = clasz getDeclaredMethod "manpage"
-      val doc = meth.invoke(null).asInstanceOf[Document]
-      emitDocument(doc)
-    } catch {
-      case ex: Exception =>
-        ex.printStackTrace()
-        System.err println "Error in EmitManPage"
-        sys.exit(1)
+  def emitManPage(classname: String, outStream: java.io.OutputStream = out.out): Unit =
+    Console.withOut(outStream) {
+      try {
+        val cl = this.getClass.getClassLoader()
+        val clasz = cl loadClass classname
+        val meth = clasz getDeclaredMethod "manpage"
+        val doc = meth.invoke(null).asInstanceOf[Document]
+        emitDocument(doc)
+      } catch {
+        case ex: Exception =>
+          ex.printStackTrace()
+          System.err println "Error in EmitManPage"
+          sys.exit(1)
+      }
     }
-  }
 }


### PR DESCRIPTION
which was causing integrate-bootstrap to fail

fixes https://github.com/scala/scala-dev/issues/315