### PR TITLE
Optimize VectorBuilder#++=(xs: TraversableOnce)

### DIFF
--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -655,7 +655,10 @@ final class VectorBuilder[A]() extends ReusableBuilder[A, Vector[A]] with Vector
     this
   }
 
-  override def ++=(xs: TraversableOnce[A]): this.type = super.++=(xs)
+  override def ++=(xs: TraversableOnce[A]): this.type = {
+    xs.foreach(+=(_))
+    this
+  }
 
   def result: Vector[A] = {
     val size = blockIndex + lo

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/VectorBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/VectorBenchmark.scala
@@ -1,0 +1,42 @@
+package scala.collection.immutable
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra._
+import org.openjdk.jmh.runner.IterationType
+import benchmark._
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class VectorBenchmark {
+  @Param(Array("1", "10", "100", "1000", "10000"))
+  var size: Int = _
+
+  var values: Vector[Any] = _
+
+  @Setup(Level.Trial) def initKeys(): Unit = {
+    values = (0 to size).map(i => (i % 4) match {
+      case 0 => i.toString
+      case 1 => i.toChar
+      case 2 => i.toDouble
+      case 3 => i.toInt
+    }).toVector
+  }
+
+  @Benchmark
+  def builderConcat() = {
+    val builder = Vector.newBuilder[Any]
+    val loopSize = 1000
+    var i = 0
+    while (i < loopSize) {
+      builder ++= values
+      i += 1
+    }
+    builder.result()
+  }
+}

--- a/test/junit/scala/collection/immutable/VectorTest.scala
+++ b/test/junit/scala/collection/immutable/VectorTest.scala
@@ -27,4 +27,21 @@ class VectorTest {
     assertEquals(v, v drop Int.MinValue)
     assertEquals(v, v dropRight Int.MinValue)
   }
+
+  @Test
+  def builderConcat() = {
+    val builder = Vector.newBuilder[Int]
+
+    builder ++= Vector()
+    assertEquals(builder.result(), Vector.empty[Int])
+
+    builder ++= Vector(0)
+    assertEquals(builder.result(), Vector(0))
+
+    builder ++= Vector(1, 2, 3)
+    assertEquals(builder.result(), Vector(0, 1, 2, 3))
+
+    builder ++= Vector()
+    assertEquals(builder.result(), Vector(0, 1, 2, 3))
+  }
 }


### PR DESCRIPTION
We can improve the performance by using `xs.foreach(+=(_))` instead of using `super.++=(xs)`

Benchmark results are as follows:

before
```
[info] Benchmark                      (size)  Mode  Cnt          Score        Error  Units
[info] VectorBenchmark.builderConcat       1  avgt   20      61304.834 ±   5649.373  ns/op
[info] VectorBenchmark.builderConcat      10  avgt   20     143109.259 ±  22050.573  ns/op
[info] VectorBenchmark.builderConcat     100  avgt   20    1087507.944 ±  15564.617  ns/op
[info] VectorBenchmark.builderConcat    1000  avgt   20    9975918.443 ±  52197.275  ns/op
[info] VectorBenchmark.builderConcat   10000  avgt   20  101155017.712 ± 988804.970  ns/op
```

after
```
[info] Benchmark                      (size)  Mode  Cnt         Score         Error  Units
[info] VectorBenchmark.builderConcat       1  avgt   20     38958.564 ±    1012.915  ns/op
[info] VectorBenchmark.builderConcat      10  avgt   20    116479.188 ±     916.548  ns/op
[info] VectorBenchmark.builderConcat     100  avgt   20    789017.215 ±    4176.121  ns/op
[info] VectorBenchmark.builderConcat    1000  avgt   20   7428021.120 ±   41471.026  ns/op
[info] VectorBenchmark.builderConcat   10000  avgt   20  74379030.621 ± 1083102.872  ns/op
```
