### PR TITLE
SI-10081 Avoid diverging implicit scope search

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1042,8 +1042,7 @@ trait Implicits {
                   if (sym.isPackageClass) sym.packageObject.typeOfThis
                   else singleType(pre, companionSymbolOf(sym, context))
                 val infos = pre1.implicitMembers.iterator.map(mem => new ImplicitInfo(mem.name, pre1, mem)).toList
-                if (infos.nonEmpty)
-                  infoMap += (sym -> infos)
+                infoMap += (sym -> infos)
               }
               val bts = tp.baseTypeSeq
               var i = 1

--- a/test/files/neg/t10081.check
+++ b/test/files/neg/t10081.check
@@ -1,0 +1,4 @@
+t10081.scala:2: error: value x is not a member of B[X]
+trait B[X] extends A[B[X @unchecked]] { this.x }
+                                             ^
+one error found

--- a/test/files/neg/t10081.scala
+++ b/test/files/neg/t10081.scala
@@ -1,0 +1,2 @@
+trait A[_]
+trait B[X] extends A[B[X @unchecked]] { this.x }


### PR DESCRIPTION
Storing empty infos into the infoMap (thus avoiding recomputation)
prevents the endless recursion.

This is an alternative to https://github.com/scala/scala/pull/5734 that
avoids the expensive annotation removal and the regression in
pos/t1203a.scala.