### PR TITLE
SI-10207 Error before update conversion

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4666,19 +4666,20 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             val qual1 = typedQualifier(qual)
             if (treeInfo.isVariableOrGetter(qual1)) {
               if (Statistics.canEnable) Statistics.stopTimer(failedOpEqNanos, opeqStart)
-              val erred = qual1.isErroneous || args.exists(_.isErroneous)
+              val erred = qual1.exists(_.isErroneous) || args.exists(_.isErroneous)
               if (erred) reportError(error) else {
                 val convo = convertToAssignment(fun, qual1, name, args)
                 silent(op = _.typed1(convo, mode, pt)) match {
                   case SilentResultValue(t) => t
-                  case err: SilentTypeError => reportError(SilentTypeError(advice1(convo, error.errors, err), error.warnings))
+                  case err: SilentTypeError => reportError(
+                    SilentTypeError(advice1(convo, error.errors, err), error.warnings)
+                  )
                 }
               }
-            }
-            else {
+            } else {
               if (Statistics.canEnable) Statistics.stopTimer(failedApplyNanos, appStart)
               val Apply(Select(qual2, _), args2) = tree
-              val erred = qual2.isErroneous || args2.exists(_.isErroneous)
+              val erred = qual2.exists(_.isErroneous) || args2.exists(_.isErroneous)
               reportError {
                 if (erred) error else SilentTypeError(advice2(error.errors), error.warnings)
               }

--- a/test/files/neg/t10207.check
+++ b/test/files/neg/t10207.check
@@ -1,0 +1,4 @@
+t10207.scala:14: error: too many arguments (2) for method apply: (key: Int)scala.collection.mutable.ArrayBuffer[String] in trait MapLike
+  m(1, (_ => empty)) ++= AB("eins", "uno")
+          ^
+one error found

--- a/test/files/neg/t10207.scala
+++ b/test/files/neg/t10207.scala
@@ -1,0 +1,16 @@
+
+// Was:
+// warning: an unexpected type representation reached the compiler backend
+// Now:
+// error: too many arguments (2) for method apply: (key: Int)scala.collection.mutable.ArrayBuffer[String] in trait MapLike
+
+trait Test {
+  import collection.mutable.{Map=>MMap, ArrayBuffer=>AB}
+
+  val m = MMap((1 -> AB("one")))
+
+  val empty = AB[String]()
+
+  m(1, (_ => empty)) ++= AB("eins", "uno")
+}
+


### PR DESCRIPTION
Gaze deeper for errors before committing to conversion
of assignment to update. The error buried in the transformed
tree escapes notice of retypechecking and leaks to backend.