### PR TITLE
Add partest paths to the list of watched sources.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1018,6 +1018,9 @@ commands += Command("partest")(_ => PartestUtil.partestParser((baseDirectory in 
   ("test/it:testOnly -- " + parsed) :: state
 }
 
+// Watch the test files also so ~partest triggers on test case changes
+watchSources ++= PartestUtil.testFilePaths((baseDirectory in ThisBuild).value, (baseDirectory in ThisBuild).value / "test")
+
 // Add tab completion to scalac et al.
 commands ++= {
   val commands =

--- a/project/PartestUtil.scala
+++ b/project/PartestUtil.scala
@@ -26,6 +26,10 @@ object PartestUtil {
       isParentOf(testBase / srcPath, f, 2) || isParentOf(f, testBase / srcPath, Int.MaxValue)
     }
   }
+
+  def testFilePaths(globalBase: File, testBase: File): Seq[java.io.File] =
+    (new TestFiles("files", globalBase, testBase)).allTestCases.map(_._1)
+
   /** A parser for the custom `partest` command */
   def partestParser(globalBase: File, testBase: File): Parser[String] = {
     val knownUnaryOptions = List(


### PR DESCRIPTION
This allows running partest continuously (e.g. ~partest a/b/test)
with it triggering on changes to the test source.