### PR TITLE
SD-317 Fix package & compiler/package

### DIFF
--- a/project/Osgi.scala
+++ b/project/Osgi.scala
@@ -50,7 +50,8 @@ object Osgi {
       "Bundle-SymbolicName" -> (bundleSymbolicName.value + ".source"),
       "Bundle-Version" -> versionProperties.value.osgiVersion,
       "Eclipse-SourceBundle" -> (bundleSymbolicName.value + ";version=\"" + versionProperties.value.osgiVersion + "\";roots:=\".\"")
-    )
+    ),
+    Keys.`package` := bundle.value
   )
 
   def bundleTask(headers: Map[String, String], jarlist: Boolean, fullClasspath: Seq[File], artifactPath: File,


### PR DESCRIPTION
repl-jline-embedded contains everything that repl-jline contains, except
for scala.tools.nsc.interactive.jline being rewritten to jline_embedded,
which is what we want.

Defining both sets leads to the following mapping error:

    [error] (compiler/compile:packageBin) java.util.zip.ZipException: duplicate entry: repl-jline.properties

Fixes scala/scala-dev#317.