### PR TITLE
make Predef.*CharSequence implicits public again

### DIFF
--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -314,19 +314,19 @@ object Predef extends LowPriorityImplicits {
     def +(other: String): String = String.valueOf(self) + other
   }
 
-  private[scala] implicit final class SeqCharSequence(val __sequenceOfChars: scala.collection.IndexedSeq[Char]) extends CharSequence {
-    def length: Int                                     = __sequenceOfChars.length
-    def charAt(index: Int): Char                        = __sequenceOfChars(index)
-    def subSequence(start: Int, end: Int): CharSequence = new SeqCharSequence(__sequenceOfChars.slice(start, end))
-    override def toString                               = __sequenceOfChars mkString ""
+  implicit final class SeqCharSequence(sequenceOfChars: scala.collection.IndexedSeq[Char]) extends CharSequence {
+    def length: Int                                     = sequenceOfChars.length
+    def charAt(index: Int): Char                        = sequenceOfChars(index)
+    def subSequence(start: Int, end: Int): CharSequence = new SeqCharSequence(sequenceOfChars.slice(start, end))
+    override def toString                               = sequenceOfChars mkString ""
   }
 
   /** @group implicit-classes-char */
-  private[scala] implicit final class ArrayCharSequence(val __arrayOfChars: Array[Char]) extends CharSequence {
-    def length: Int                                     = __arrayOfChars.length
-    def charAt(index: Int): Char                        = __arrayOfChars(index)
-    def subSequence(start: Int, end: Int): CharSequence = new runtime.ArrayCharSequence(__arrayOfChars, start, end)
-    override def toString                               = __arrayOfChars mkString ""
+  implicit final class ArrayCharSequence(arrayOfChars: Array[Char]) extends CharSequence {
+    def length: Int                                     = arrayOfChars.length
+    def charAt(index: Int): Char                        = arrayOfChars(index)
+    def subSequence(start: Int, end: Int): CharSequence = new runtime.ArrayCharSequence(arrayOfChars, start, end)
+    override def toString                               = arrayOfChars mkString ""
   }
 
   implicit val StringCanBuildFrom: CanBuildFrom[String, Char, String] = new CanBuildFrom[String, Char, String] {

--- a/test/junit/scala/CharSequenceImplicitsTests.scala
+++ b/test/junit/scala/CharSequenceImplicitsTests.scala
@@ -1,0 +1,16 @@
+package scala
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+// these two implicit conversions come from Predef
+
+@RunWith(classOf[JUnit4])
+class CharSequenceImplicitsTests {
+  @Test def arrayAsCharSequence(): Unit =
+    assertEquals("ab", (Array     ('a', 'b'): CharSequence).toString)
+  @Test def indexedSeqAsCharSequence(): Unit =
+    assertEquals("ab", (IndexedSeq('a', 'b'): CharSequence).toString)
+}


### PR DESCRIPTION
fixing a recent regression in 2.13

when I was removing deprecated stuff in #5683,
I was going too fast and misunderstood these deprecations.
only the names of the class parameters were supposed to become
private, not the entire class.

note that now that the parameters aren't even vals anymore, they don't
need to have funny `__` names anymore, either.

this was caught by the Scala community build.