### PR TITLE
Reduce boxing of scala.reflect.internal.Depth

### DIFF
--- a/src/reflect/scala/reflect/internal/Depth.scala
+++ b/src/reflect/scala/reflect/internal/Depth.scala
@@ -5,7 +5,7 @@ package internal
 import Depth._
 
 final class Depth private (val depth: Int) extends AnyVal with Ordered[Depth] {
-  def max(that: Depth): Depth   = if (this < that) that else this
+  def max(that: Depth): Depth   = if (this.depth < that.depth) that else this
   def decr(n: Int): Depth       = if (isAnyDepth) this else Depth(depth - n)
   def incr(n: Int): Depth       = if (isAnyDepth) this else Depth(depth + n)
   def decr: Depth               = decr(1)


### PR DESCRIPTION
A fairly trivial change to Depth to remove the boxing generated during the max function.
