### PR TITLE
Report per-phase JVM statistics (e.g cpu time, user time, allocated bytes)

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1405,11 +1405,14 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
       reporter.reset()
       warnDeprecatedAndConflictingSettings(unitbuf.head)
       globalPhase = fromPhase
+      val profiler = profile.Profiler(settings)
 
       while (globalPhase.hasNext && !reporter.hasErrors) {
         val startTime = currentTime
         phase = globalPhase
+        val profileBefore=profiler.before(phase)
         globalPhase.run()
+        profiler.after(phase, profileBefore)
 
         // progress update
         informTime(globalPhase.description, startTime)
@@ -1444,6 +1447,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
 
         advancePhase()
       }
+      profiler.finished()
 
       reporting.summarizeErrors()
 

--- a/src/compiler/scala/tools/nsc/profile/ExtendedThreadMxBean.java
+++ b/src/compiler/scala/tools/nsc/profile/ExtendedThreadMxBean.java
@@ -1,0 +1,304 @@
+package scala.tools.nsc.profile;
+
+import javax.management.ObjectName;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.reflect.Method;
+
+@SuppressWarnings("unused")
+public abstract class ExtendedThreadMxBean implements ThreadMXBean {
+    static final ExtendedThreadMxBean proxy;
+
+    static {
+        ExtendedThreadMxBean local;
+        ThreadMXBean threadMx = ManagementFactory.getThreadMXBean();
+        try {
+            Class cls = Class.forName("com.sun.management.ThreadMXBean");
+            if (cls.isInstance(threadMx)) {
+                local = new SunThreadMxBean(threadMx);
+            } else {
+                local = new OtherThreadMxBean(threadMx);
+            }
+        } catch (ClassNotFoundException e) {
+            local = new OtherThreadMxBean(threadMx);
+        }
+        proxy = local;
+    }
+
+    protected final ThreadMXBean underlying;
+
+    protected ExtendedThreadMxBean(ThreadMXBean underlying) {
+        this.underlying = underlying;
+    }
+
+    public abstract long[] getThreadUserTime(long[] longs) throws Exception;
+
+    public abstract boolean isThreadAllocatedMemoryEnabled() throws Exception;
+
+    public abstract void setThreadAllocatedMemoryEnabled(boolean b) throws Exception;
+
+    public abstract long getThreadAllocatedBytes(long l) throws Exception;
+
+    public abstract long[] getThreadAllocatedBytes(long[] longs) throws Exception;
+
+    public abstract boolean isThreadAllocatedMemorySupported() throws Exception;
+
+    public abstract long[] getThreadCpuTime(long[] longs) throws Exception;
+    //common features from java.lang.management.ThreadMXBean
+
+    @Override
+    public int getThreadCount() {
+        return underlying.getThreadCount();
+    }
+
+    @Override
+    public int getPeakThreadCount() {
+        return underlying.getPeakThreadCount();
+    }
+
+    @Override
+    public long getTotalStartedThreadCount() {
+        return underlying.getTotalStartedThreadCount();
+    }
+
+    @Override
+    public int getDaemonThreadCount() {
+        return underlying.getDaemonThreadCount();
+    }
+
+    @Override
+    public long[] getAllThreadIds() {
+        return underlying.getAllThreadIds();
+    }
+
+    @Override
+    public ThreadInfo getThreadInfo(long id) {
+        return underlying.getThreadInfo(id);
+    }
+
+    @Override
+    public ThreadInfo[] getThreadInfo(long[] ids) {
+        return underlying.getThreadInfo(ids);
+    }
+
+    @Override
+    public ThreadInfo getThreadInfo(long id, int maxDepth) {
+        return underlying.getThreadInfo(id, maxDepth);
+    }
+
+    @Override
+    public ThreadInfo[] getThreadInfo(long[] ids, int maxDepth) {
+        return underlying.getThreadInfo(ids, maxDepth);
+    }
+
+    @Override
+    public boolean isThreadContentionMonitoringSupported() {
+        return underlying.isThreadContentionMonitoringSupported();
+    }
+
+    @Override
+    public boolean isThreadContentionMonitoringEnabled() {
+        return underlying.isThreadContentionMonitoringEnabled();
+    }
+
+    @Override
+    public void setThreadContentionMonitoringEnabled(boolean enable) {
+        underlying.setThreadContentionMonitoringEnabled(enable);
+    }
+
+    @Override
+    public long getCurrentThreadCpuTime() {
+        return underlying.getCurrentThreadCpuTime();
+    }
+
+    @Override
+    public long getCurrentThreadUserTime() {
+        return underlying.getCurrentThreadUserTime();
+    }
+
+    @Override
+    public long getThreadCpuTime(long id) {
+        return underlying.getThreadCpuTime(id);
+    }
+
+    @Override
+    public long getThreadUserTime(long id) {
+        return underlying.getThreadUserTime(id);
+    }
+
+    @Override
+    public boolean isThreadCpuTimeSupported() {
+        return underlying.isThreadCpuTimeSupported();
+    }
+
+    @Override
+    public boolean isCurrentThreadCpuTimeSupported() {
+        return underlying.isCurrentThreadCpuTimeSupported();
+    }
+
+    @Override
+    public boolean isThreadCpuTimeEnabled() {
+        return underlying.isThreadCpuTimeEnabled();
+    }
+
+    @Override
+    public void setThreadCpuTimeEnabled(boolean enable) {
+        underlying.setThreadCpuTimeEnabled(enable);
+    }
+
+    @Override
+    public long[] findMonitorDeadlockedThreads() {
+        return underlying.findMonitorDeadlockedThreads();
+    }
+
+    @Override
+    public void resetPeakThreadCount() {
+        underlying.resetPeakThreadCount();
+    }
+
+    @Override
+    public long[] findDeadlockedThreads() {
+        return underlying.findDeadlockedThreads();
+    }
+
+    @Override
+    public boolean isObjectMonitorUsageSupported() {
+        return underlying.isObjectMonitorUsageSupported();
+    }
+
+    @Override
+    public boolean isSynchronizerUsageSupported() {
+        return underlying.isSynchronizerUsageSupported();
+    }
+
+    @Override
+    public ThreadInfo[] getThreadInfo(long[] ids, boolean lockedMonitors, boolean lockedSynchronizers) {
+        return underlying.getThreadInfo(ids, lockedMonitors, lockedSynchronizers);
+    }
+
+    @Override
+    public ThreadInfo[] dumpAllThreads(boolean lockedMonitors, boolean lockedSynchronizers) {
+        return underlying.dumpAllThreads(lockedMonitors, lockedSynchronizers);
+    }
+
+    @Override
+    public ObjectName getObjectName() {
+        return underlying.getObjectName();
+    }
+}
+
+class OtherThreadMxBean extends ExtendedThreadMxBean {
+    OtherThreadMxBean(ThreadMXBean underlying) {
+        super(underlying);
+    }
+
+    @Override
+    public long[] getThreadUserTime(long[] longs) throws Exception {
+        return new long[0];
+    }
+
+    @Override
+    public boolean isThreadAllocatedMemoryEnabled() throws Exception {
+        return false;
+    }
+
+    @Override
+    public void setThreadAllocatedMemoryEnabled(boolean b) throws Exception {
+
+    }
+
+    @Override
+    public long getThreadAllocatedBytes(long l) throws Exception {
+        return -1;
+    }
+
+    @Override
+    public long[] getThreadAllocatedBytes(long[] longs) throws Exception {
+        return new long[0];
+    }
+
+    @Override
+    public boolean isThreadAllocatedMemorySupported() throws Exception {
+        return false;
+    }
+
+    @Override
+    public long[] getThreadCpuTime(long[] longs) throws Exception {
+        return new long[0];
+    }
+
+}
+
+
+class SunThreadMxBean extends ExtendedThreadMxBean {
+
+    private final ThreadMXBean real;
+
+    private final Method getThreadUserTimeMethod;
+    private final Method isThreadAllocatedMemoryEnabledMethod;
+    private final Method setThreadAllocatedMemoryEnabledMethod;
+    private final Method getThreadAllocatedBytesMethod1;
+    private final Method getThreadAllocatedBytesMethod2;
+    private final Method isThreadAllocatedMemorySupportedMethod;
+    private final Method getThreadCpuTimeMethod;
+
+
+    public SunThreadMxBean(ThreadMXBean underlying) {
+        super(underlying);
+        this.real = underlying;
+        try {
+            getThreadUserTimeMethod = real.getClass().getMethod("getThreadUserTime", long[].class);
+            isThreadAllocatedMemoryEnabledMethod = real.getClass().getMethod("isThreadAllocatedMemoryEnabled");
+            setThreadAllocatedMemoryEnabledMethod = real.getClass().getMethod("setThreadAllocatedMemoryEnabled", Boolean.TYPE);
+            getThreadAllocatedBytesMethod1 = real.getClass().getMethod("getThreadAllocatedBytes", Long.TYPE);
+            getThreadAllocatedBytesMethod2 = real.getClass().getMethod("getThreadAllocatedBytes", long[].class);
+            isThreadAllocatedMemorySupportedMethod = real.getClass().getMethod("isThreadAllocatedMemorySupported");
+            getThreadCpuTimeMethod = real.getClass().getMethod("getThreadCpuTime", long[].class);
+
+            getThreadUserTimeMethod.setAccessible(true);
+            isThreadAllocatedMemoryEnabledMethod.setAccessible(true);
+            setThreadAllocatedMemoryEnabledMethod.setAccessible(true);
+            getThreadAllocatedBytesMethod1.setAccessible(true);
+            getThreadAllocatedBytesMethod2.setAccessible(true);
+            isThreadAllocatedMemorySupportedMethod.setAccessible(true);
+            getThreadCpuTimeMethod.setAccessible(true);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+
+    public boolean isExtended() {
+        return true;
+    }
+
+    public long[] getThreadUserTime(long[] longs) throws Exception {
+        return (long[]) getThreadUserTimeMethod.invoke(real, longs);
+    }
+
+    public boolean isThreadAllocatedMemoryEnabled() throws Exception {
+        return (boolean) isThreadAllocatedMemoryEnabledMethod.invoke(real);
+    }
+
+    public void setThreadAllocatedMemoryEnabled(boolean b) throws Exception {
+        setThreadAllocatedMemoryEnabledMethod.invoke(real, b);
+    }
+
+    public long getThreadAllocatedBytes(long l) throws Exception {
+        return (long) getThreadAllocatedBytesMethod1.invoke(real,l);
+    }
+
+    public long[] getThreadAllocatedBytes(long[] longs) throws Exception {
+        return (long[]) getThreadAllocatedBytesMethod2.invoke(real, longs);
+    }
+
+    public boolean isThreadAllocatedMemorySupported() throws Exception {
+        return (boolean) isThreadAllocatedMemorySupportedMethod.invoke(real);
+    }
+
+    public long[] getThreadCpuTime(long[] longs) throws Exception {
+        return (long[]) getThreadCpuTimeMethod.invoke(real, longs);
+
+    }
+}

--- a/src/compiler/scala/tools/nsc/profile/ExternalToolHook.java
+++ b/src/compiler/scala/tools/nsc/profile/ExternalToolHook.java
@@ -1,0 +1,17 @@
+package scala.tools.nsc.profile;
+
+/**
+ * this is an external tool hook
+ * it allows an external tool such as YourKit or JProfiler to instrument a particular phase of the compiler
+ *
+ * the use case is like this
+ * other profiling has indicated that a particular phase of the compiler requires some deep analysis via an external tool
+ *
+ * confilerure the tool to start and stop profiling base on execution of these methods
+ * then add the -YProfile-external-tool to call these methods for the pahse that you are interested in
+ */
+public class ExternalToolHook {
+    private ExternalToolHook() {}
+    public static void before() {}
+    public static void after() {}
+}

--- a/src/compiler/scala/tools/nsc/profile/Profiler.scala
+++ b/src/compiler/scala/tools/nsc/profile/Profiler.scala
@@ -125,7 +125,7 @@ sealed trait ProfileReporter {
 
 object ConsoleProfileReporter extends ProfileReporter {
   override def report(profiler: RealProfiler, phase: Phase, diff: ProfileCounters): Unit =
-    println(f"Profiler compile ${profiler.id} after phase ${phase.id}:(${phase.name}) wallClockTime: ${diff.wallClockTimeMillis}%6.4fms, cpuTime ${diff.cpuTimeMillis}%6.4fms, userTime ${diff.userTimeMillis}%6.4fms, allocatedBytes ${diff.allocatedMB}%6.4fMB, retainedHeapBytes ${diff.retainedHeapMB}%6.4fMB, gcTime ${diff.gcTimeMillis}%6.0fms")
+    println(f"Profiler compile ${profiler.id} after phase ${phase.id}%2d:${phase.name}%20s wallClockTime: ${diff.wallClockTimeMillis}%12.4fms, cpuTime ${diff.cpuTimeMillis}%12.4fms, userTime ${diff.userTimeMillis}%12.4fms, allocatedBytes ${diff.allocatedMB}%12.4fMB, retainedHeapBytes ${diff.retainedHeapMB}%12.4fMB, gcTime ${diff.gcTimeMillis}%6.0fms")
 
   override def close(profiler: RealProfiler): Unit = ()
 

--- a/src/compiler/scala/tools/nsc/profile/Profiler.scala
+++ b/src/compiler/scala/tools/nsc/profile/Profiler.scala
@@ -1,6 +1,6 @@
 package scala.tools.nsc.profile
 
-import java.io.{FileWriter, Writer}
+import java.io.{FileWriter, PrintWriter}
 import java.lang.management.ManagementFactory
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -11,21 +11,35 @@ object Profiler {
     if (!settings.YprofileEnabled) NoOpProfiler
     else {
       val reporter = if(settings.YprofileDestination.isSetByUser)
-        new StreamProfileReporter(new FileWriter(settings.YprofileDestination.value, true))
+        new StreamProfileReporter(new PrintWriter(new FileWriter(settings.YprofileDestination.value, true)))
       else ConsoleProfileReporter
-      new RealProfiler(reporter, settings.outdir.value)
+      new RealProfiler(reporter, settings)
     }
 }
 
 
-case class ProfileCounters(wallClockTimeNs : Long, cpuTimeNs: Long, userTimeNs: Long, allocatedBytes:Long ) {
+case class ProfileCounters(wallClockTimeNanos : Long, cpuTimeNanos: Long, userTimeNanos: Long, allocatedBytes:Long, retainedHeapBytes:Long, gcTimeMillis:Long) {
   def - (that :ProfileCounters) = {
     ProfileCounters(
-      this.wallClockTimeNs - that.wallClockTimeNs,
-      this.cpuTimeNs - that.cpuTimeNs,
-      this.userTimeNs - that.userTimeNs,
-      this.allocatedBytes - that.allocatedBytes)
+      this.wallClockTimeNanos - that.wallClockTimeNanos,
+      this.cpuTimeNanos - that.cpuTimeNanos,
+      this.userTimeNanos - that.userTimeNanos,
+      this.allocatedBytes - that.allocatedBytes,
+      this.retainedHeapBytes - that.retainedHeapBytes,
+      this.gcTimeMillis - that.gcTimeMillis)
   }
+  def updateHeap(heapDetails:ProfileCounters) = {
+    copy(retainedHeapBytes = heapDetails.retainedHeapBytes)
+  }
+  private def toMillis(ns: Long) = ns/1000000.0D
+  private def toMegaBytes(bytes: Long) = bytes/1000000.0D
+
+  def wallClockTimeMillis = toMillis(wallClockTimeNanos)
+  def cpuTimeMillis = toMillis(cpuTimeNanos)
+  def userTimeMillis = toMillis(userTimeNanos)
+  def allocatedMB = toMegaBytes(allocatedBytes)
+  def retainedHeapMB = toMegaBytes(retainedHeapBytes)
+
 }
 
 sealed trait Profiler {
@@ -37,7 +51,7 @@ sealed trait Profiler {
 
 }
 private [profile] object NoOpProfiler extends Profiler {
-  val noSnap = ProfileCounters(0,0,0,0)
+  val noSnap = ProfileCounters(0,0,0,0,0,0)
 
   override def before(phase: Phase): ProfileCounters = noSnap
 
@@ -46,37 +60,61 @@ private [profile] object NoOpProfiler extends Profiler {
   override def finished(): Unit = ()
 }
 private [profile] object RealProfiler {
+  import scala.collection.JavaConverters._
   val runtimeMx = ManagementFactory.getRuntimeMXBean
   val memoryMx = ManagementFactory.getMemoryMXBean
+  val gcMx = ManagementFactory.getGarbageCollectorMXBeans.asScala.toList
   val threadMx = ExtendedThreadMxBean.proxy
   if (threadMx.isThreadCpuTimeSupported) threadMx.setThreadCpuTimeEnabled(true)
   private val idGen = new AtomicInteger()
 }
 
-private [profile] class RealProfiler(reporter : ProfileReporter, val outDir:String) extends Profiler {
-
+private [profile] class RealProfiler(reporter : ProfileReporter, val settings: Settings) extends Profiler {
+  def outDir = settings.outdir.value
   val id = RealProfiler.idGen.incrementAndGet()
 
   private def snap :ProfileCounters = {
     import RealProfiler._
     ProfileCounters(System.nanoTime(), threadMx.getCurrentThreadCpuTime, threadMx.getCurrentThreadUserTime,
-      threadMx.getThreadAllocatedBytes(Thread.currentThread().getId))
+      threadMx.getThreadAllocatedBytes(Thread.currentThread().getId), memoryMx.getHeapMemoryUsage.getUsed,
+      gcMx.foldLeft(0L){case (sum,bean) => bean.getCollectionTime + sum})
   }
   private val overhead = {
     val s1 = snap
     val s2 = snap
     s2 - s1
   }
+  private def doGC: Unit = {
+    System.gc()
+    System.runFinalization()
+  }
   reporter.header(this)
 
   override def finished(): Unit = reporter.close(this)
 
-  override def after(phase: Phase, profileBefore: ProfileCounters): Unit =
-    reporter.report(this, phase, snap - profileBefore - overhead)
+  override def after(phase: Phase, profileBefore: ProfileCounters): Unit = {
+    val initialSnap= snap
+    if (settings.YprofileExternalTool.containsPhase(phase)) {
+      println("Profile hook stop")
+      ExternalToolHook.after()
+    }
+    val finalSnap = if (settings.YprofileRunGcBetweenPhases.containsPhase(phase)) {
+      doGC
+      initialSnap.updateHeap(snap)
+    } else initialSnap
+    reporter.report(this, phase, finalSnap - profileBefore - overhead)
+  }
+  override def before(phase: Phase): ProfileCounters = {
+    if (settings.YprofileRunGcBetweenPhases.containsPhase(phase))
+      doGC
+    if (settings.YprofileExternalTool.containsPhase(phase)) {
+      println("Profile hook start")
+      ExternalToolHook.before()
+    }
 
-  override def before(phase: Phase): ProfileCounters = snap
+    snap
+  }
 }
-
 
 sealed trait ProfileReporter {
   def report(profiler: RealProfiler, phase: Phase, diff: ProfileCounters) : Unit
@@ -87,21 +125,22 @@ sealed trait ProfileReporter {
 
 object ConsoleProfileReporter extends ProfileReporter {
   override def report(profiler: RealProfiler, phase: Phase, diff: ProfileCounters): Unit =
-    println(s"Profiler compile ${profiler.id} after phase ${phase.id}:(${phase.name}) wallClockTime: ${diff.wallClockTimeNs}ns, cpuTime ${diff.cpuTimeNs}, userTime ${diff.userTimeNs}, allocatedBytes ${diff.allocatedBytes}")
+    println(f"Profiler compile ${profiler.id} after phase ${phase.id}:(${phase.name}) wallClockTime: ${diff.wallClockTimeMillis}%6.4fms, cpuTime ${diff.cpuTimeMillis}%6.4fms, userTime ${diff.userTimeMillis}%6.4fms, allocatedBytes ${diff.allocatedMB}%6.4fMB, retainedHeapBytes ${diff.retainedHeapMB}%6.4fMB, gcTime ${diff.gcTimeMillis}%6.0fms")
 
   override def close(profiler: RealProfiler): Unit = ()
-  override def header(profiler: RealProfiler): Unit = ()
+
+  override def header(profiler: RealProfiler): Unit = {
+    println(s"Profiler start (${profiler.id}) ${profiler.outDir}")
+  }
 }
 
-class StreamProfileReporter(out:Writer) extends ProfileReporter {
+class StreamProfileReporter(out:PrintWriter) extends ProfileReporter {
   override def header(profiler: RealProfiler): Unit = {
-    out.write(s"info, ${profiler.id}, ${profiler.outDir}\n")
-    out.write(s"header, id, phase, wallClockTimeNs, cpuTimeNs, userTimeNs, allocatedBytes\n")
-
+    out.println(s"info, ${profiler.id}, ${profiler.outDir}")
+    out.println(s"header,id,phaseId,phaseName,wallClockTimeMs,cpuTimeMs,userTimeMs,allocatedMB,retainedHeapMB,gcTimeMs")
   }
   override def report(profiler: RealProfiler, phase: Phase, diff: ProfileCounters): Unit = {
-    out.write(s"data,${phase.id},${diff.wallClockTimeNs},${diff.cpuTimeNs},${diff.userTimeNs},${diff.allocatedBytes}\n")
-
+    out.println(s"data,${profiler.id},${phase.id},${phase.name},${diff.wallClockTimeMillis},${diff.cpuTimeMillis},${diff.userTimeMillis},${diff.allocatedMB},${diff.retainedHeapMB},${diff.gcTimeMillis}")
   }
 
   override def close(profiler: RealProfiler): Unit = {

--- a/src/compiler/scala/tools/nsc/profile/Profiler.scala
+++ b/src/compiler/scala/tools/nsc/profile/Profiler.scala
@@ -1,0 +1,112 @@
+package scala.tools.nsc.profile
+
+import java.io.{FileWriter, Writer}
+import java.lang.management.ManagementFactory
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.tools.nsc.{Phase, Settings}
+
+object Profiler {
+  def apply(settings: Settings):Profiler =
+    if (!settings.YprofileEnabled) NoOpProfiler
+    else {
+      val reporter = if(settings.YprofileDestination.isSetByUser)
+        new StreamProfileReporter(new FileWriter(settings.YprofileDestination.value, true))
+      else ConsoleProfileReporter
+      new RealProfiler(reporter, settings.outdir.value)
+    }
+}
+
+
+case class ProfileCounters(wallClockTimeNs : Long, cpuTimeNs: Long, userTimeNs: Long, allocatedBytes:Long ) {
+  def - (that :ProfileCounters) = {
+    ProfileCounters(
+      this.wallClockTimeNs - that.wallClockTimeNs,
+      this.cpuTimeNs - that.cpuTimeNs,
+      this.userTimeNs - that.userTimeNs,
+      this.allocatedBytes - that.allocatedBytes)
+  }
+}
+
+sealed trait Profiler {
+  def finished() :Unit
+
+  def after(phase: Phase, profileBefore: ProfileCounters) : Unit
+
+  def before(phase: Phase) : ProfileCounters
+
+}
+private [profile] object NoOpProfiler extends Profiler {
+  val noSnap = ProfileCounters(0,0,0,0)
+
+  override def before(phase: Phase): ProfileCounters = noSnap
+
+  override def after(phase: Phase, profileBefore: ProfileCounters): Unit = ()
+
+  override def finished(): Unit = ()
+}
+private [profile] object RealProfiler {
+  val runtimeMx = ManagementFactory.getRuntimeMXBean
+  val memoryMx = ManagementFactory.getMemoryMXBean
+  val threadMx = ExtendedThreadMxBean.proxy
+  if (threadMx.isThreadCpuTimeSupported) threadMx.setThreadCpuTimeEnabled(true)
+  private val idGen = new AtomicInteger()
+}
+
+private [profile] class RealProfiler(reporter : ProfileReporter, val outDir:String) extends Profiler {
+
+  val id = RealProfiler.idGen.incrementAndGet()
+
+  private def snap :ProfileCounters = {
+    import RealProfiler._
+    ProfileCounters(System.nanoTime(), threadMx.getCurrentThreadCpuTime, threadMx.getCurrentThreadUserTime,
+      threadMx.getThreadAllocatedBytes(Thread.currentThread().getId))
+  }
+  private val overhead = {
+    val s1 = snap
+    val s2 = snap
+    s2 - s1
+  }
+  reporter.header(this)
+
+  override def finished(): Unit = reporter.close(this)
+
+  override def after(phase: Phase, profileBefore: ProfileCounters): Unit =
+    reporter.report(this, phase, snap - profileBefore - overhead)
+
+  override def before(phase: Phase): ProfileCounters = snap
+}
+
+
+sealed trait ProfileReporter {
+  def report(profiler: RealProfiler, phase: Phase, diff: ProfileCounters) : Unit
+
+  def header(profiler: RealProfiler) :Unit
+  def close(profiler: RealProfiler) :Unit
+}
+
+object ConsoleProfileReporter extends ProfileReporter {
+  override def report(profiler: RealProfiler, phase: Phase, diff: ProfileCounters): Unit =
+    println(s"Profiler compile ${profiler.id} after phase ${phase.id}:(${phase.name}) wallClockTime: ${diff.wallClockTimeNs}ns, cpuTime ${diff.cpuTimeNs}, userTime ${diff.userTimeNs}, allocatedBytes ${diff.allocatedBytes}")
+
+  override def close(profiler: RealProfiler): Unit = ()
+  override def header(profiler: RealProfiler): Unit = ()
+}
+
+class StreamProfileReporter(out:Writer) extends ProfileReporter {
+  override def header(profiler: RealProfiler): Unit = {
+    out.write(s"info, ${profiler.id}, ${profiler.outDir}\n")
+    out.write(s"header, id, phase, wallClockTimeNs, cpuTimeNs, userTimeNs, allocatedBytes\n")
+
+  }
+  override def report(profiler: RealProfiler, phase: Phase, diff: ProfileCounters): Unit = {
+    out.write(s"data,${phase.id},${diff.wallClockTimeNs},${diff.cpuTimeNs},${diff.userTimeNs},${diff.allocatedBytes}\n")
+
+  }
+
+  override def close(profiler: RealProfiler): Unit = {
+    out.flush
+    out.close
+  }
+}
+

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -339,6 +339,11 @@ trait ScalaSettings extends AbsScalaSettings
   val YprofileEnabled = BooleanSetting("-Yprofile-enabled", "Enable profiling.")
   val YprofileDestination = StringSetting("-Yprofile-destination", "file", "where to send profiling output - specify a file, default is to the console.", "").
     withPostSetHook( _ => YprofileEnabled.value = true )
+  val YprofileExternalTool = PhasesSetting("-Yprofile-external-tool", "Enable profiling for a phase using an external tool hook. Generally only useful for a single phase", "typer").
+    withPostSetHook( _ => YprofileEnabled.value = true )
+  val YprofileRunGcBetweenPhases = PhasesSetting("-Yprofile-run-gc", "Run a GC between phases - this allows heap size to be accurate at the expense of more time. Specify a list of phases, or *", "_").
+    withPostSetHook( _ => YprofileEnabled.value = true )
+
 
 
   /** Area-specific debug output.

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -336,6 +336,11 @@ trait ScalaSettings extends AbsScalaSettings
 
   def YstatisticsEnabled = Ystatistics.value.nonEmpty
 
+  val YprofileEnabled = BooleanSetting("-Yprofile-enabled", "Enable profiling.")
+  val YprofileDestination = StringSetting("-Yprofile-destination", "file", "where to send profiling output - specify a file, default is to the console.", "").
+    withPostSetHook( _ => YprofileEnabled.value = true )
+
+
   /** Area-specific debug output.
    */
   val Ydocdebug               = BooleanSetting("-Ydoc-debug", "Trace all scaladoc activity.")


### PR DESCRIPTION
add some profiling support to scalac

This adds  a few -Yprofile... options that assist in profiling scalac

This has proved useful so far in https://github.com/rorygraves/scalac_perf for identification of opportunities for optimisation

The output can be generated to a console, or a CSV.
This could enable the generation of CI tasks that error if some indicator goes out of bounds, but that is outside the scope of this PR.

console output is in the form 
```
Profiler compile 1 after phase  4:               typer wallClockTime:   13088.2065ms, cpuTime   12609.3750ms, userTime   12500.0000ms, allocatedBytes     651.6394MB, retainedHeapBytes     681.0260MB, gcTime      0ms
Profiler compile 1 after phase  5:              patmat wallClockTime:    2128.9528ms, cpuTime    2062.5000ms, userTime    2062.5000ms, allocatedBytes     132.4393MB, retainedHeapBytes     153.0780MB, gcTime      0ms
Profiler compile 1 after phase  6:      superaccessors wallClockTime:     349.0044ms, cpuTime     328.1250ms, userTime     328.1250ms, allocatedBytes      27.4235MB, retainedHeapBytes      43.8591MB, gcTime      0ms
Profiler compile 1 after phase  7:          extmethods wallClockTime:     130.9848ms, cpuTime      93.7500ms, userTime      93.7500ms, allocatedBytes       5.7003MB, retainedHeapBytes       0.0000MB, gcTime      0ms
Profiler compile 1 after phase  8:             pickler wallClockTime:     371.8387ms, cpuTime     375.0000ms, userTime     375.0000ms, allocatedBytes      23.6769MB, retainedHeapBytes      21.9295MB, gcTime      0ms
Profiler compile 1 after phase  9:            xsbt-api wallClockTime:    2040.5242ms, cpuTime    2031.2500ms, userTime    2031.2500ms, allocatedBytes     314.7573MB, retainedHeapBytes     307.0130MB, gcTime      0ms
Profiler compile 1 after phase 10:     xsbt-dependency wallClockTime:    1410.9184ms, cpuTime    1406.2500ms, userTime    1078.1250ms, allocatedBytes     436.6854MB, retainedHeapBytes     438.5903MB, gcTime      0ms
```
